### PR TITLE
mac80211: rt2x00: some experimental improvements

### DIFF
--- a/package/kernel/mac80211/patches/rt2x00/620-01-rt2x00-respect-rt2800-hardware-TX-queue-index.patch
+++ b/package/kernel/mac80211/patches/rt2x00/620-01-rt2x00-respect-rt2800-hardware-TX-queue-index.patch
@@ -1,0 +1,257 @@
+From 654653e718f6c55c6f29fd94cc8152a92c8166ac Mon Sep 17 00:00:00 2001
+From: Shiji Yang <yangshiji66@outlook.com>
+Date: Tue, 24 Dec 2024 08:36:32 +0800
+Subject: [PATCH 1/2] rt2x00: respect the rt2800 hardware TX queue index
+
+The Ralink TX queue register index is different from the Linux
+IEEE80211 queue id definition. Their conversion table is as follows:
+
+Queue   IEEE80211   Ralink
+AC_VO      0          3
+AC_VI      1          2
+AC_BE      2          0
+AC_BK      3          1
+
+The TX queues are still functioning properly under the current
+configuration. I don't have evidence, but I believe there should
+be some differences in the internal hardware implementation of
+different TX queues, e.g. interrupt priority. so it's better to
+respect the queue index defined by the Ralink when we construct
+the TX rings and descriptors.
+
+And the more important thing is that we are using the wrong queue
+index to calculate the register offset and mask in .conf_tx(),
+which resulted in writing incorrect AIFSN, CWMAX, CWMIN and TXOP
+values for all TX queues. This patch introduces a index conversion
+table to fix these parameters.
+
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ drivers/net/wireless/ralink/rt2x00/rt2800.h   | 24 ++++++------
+ .../net/wireless/ralink/rt2x00/rt2800lib.c    | 20 +++++++---
+ .../net/wireless/ralink/rt2x00/rt2800mmio.c   | 38 ++++++++++---------
+ .../net/wireless/ralink/rt2x00/rt2x00queue.h  | 20 ++++++++++
+ 4 files changed, 67 insertions(+), 35 deletions(-)
+
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800.h
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800.h
+@@ -379,10 +379,10 @@
+ 
+ /*
+  * WMM_AIFSN_CFG: Aifsn for each EDCA AC
+- * AIFSN0: AC_VO
+- * AIFSN1: AC_VI
+- * AIFSN2: AC_BE
+- * AIFSN3: AC_BK
++ * AIFSN0: AC_BE
++ * AIFSN1: AC_BK
++ * AIFSN2: AC_VI
++ * AIFSN3: AC_VO
+  */
+ #define WMM_AIFSN_CFG			0x0214
+ #define WMM_AIFSN_CFG_AIFSN0		FIELD32(0x0000000f)
+@@ -392,10 +392,10 @@
+ 
+ /*
+  * WMM_CWMIN_CSR: CWmin for each EDCA AC
+- * CWMIN0: AC_VO
+- * CWMIN1: AC_VI
+- * CWMIN2: AC_BE
+- * CWMIN3: AC_BK
++ * CWMIN0: AC_BE
++ * CWMIN1: AC_BK
++ * CWMIN2: AC_VI
++ * CWMIN3: AC_VO
+  */
+ #define WMM_CWMIN_CFG			0x0218
+ #define WMM_CWMIN_CFG_CWMIN0		FIELD32(0x0000000f)
+@@ -405,10 +405,10 @@
+ 
+ /*
+  * WMM_CWMAX_CSR: CWmax for each EDCA AC
+- * CWMAX0: AC_VO
+- * CWMAX1: AC_VI
+- * CWMAX2: AC_BE
+- * CWMAX3: AC_BK
++ * CWMAX0: AC_BE
++ * CWMAX1: AC_BK
++ * CWMAX2: AC_VI
++ * CWMAX3: AC_VO
+  */
+ #define WMM_CWMAX_CFG			0x021c
+ #define WMM_CWMAX_CFG_CWMAX0		FIELD32(0x0000000f)
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+@@ -835,7 +835,8 @@ void rt2800_write_tx_data(struct queue_e
+ 			   txdesc->key_idx : txdesc->u.ht.wcid);
+ 	rt2x00_set_field32(&word, TXWI_W1_MPDU_TOTAL_BYTE_COUNT,
+ 			   txdesc->length);
+-	rt2x00_set_field32(&word, TXWI_W1_PACKETID_QUEUE, entry->queue->qid);
++	rt2x00_set_field32(&word, TXWI_W1_PACKETID_QUEUE,
++			   rt2x00_ac_to_hwq(entry->queue->qid));
+ 	rt2x00_set_field32(&word, TXWI_W1_PACKETID_ENTRY, (entry->entry_idx % 3) + 1);
+ 	rt2x00_desc_write(txwi, 1, word);
+ 
+@@ -1125,6 +1126,12 @@ void rt2800_txdone(struct rt2x00_dev *rt
+ 	u32 reg;
+ 	u8 qid;
+ 	bool match;
++	static const u8 rt2ac[] = {
++		IEEE80211_AC_BE,
++		IEEE80211_AC_BK,
++		IEEE80211_AC_VI,
++		IEEE80211_AC_VO,
++	};
+ 
+ 	while (quota-- > 0 && kfifo_get(&rt2x00dev->txstatus_fifo, &reg)) {
+ 		/*
+@@ -1132,6 +1139,8 @@ void rt2800_txdone(struct rt2x00_dev *rt
+ 		 * guaranteed to be one of the TX QIDs .
+ 		 */
+ 		qid = rt2x00_get_field32(reg, TX_STA_FIFO_PID_QUEUE);
++		/* Convert Ralink hardware queue index to IEEE80211 queue id. */
++		qid = rt2ac[qid];
+ 		queue = rt2x00queue_get_tx_queue(rt2x00dev, qid);
+ 
+ 		if (unlikely(rt2x00queue_empty(queue))) {
+@@ -12188,8 +12197,9 @@ int rt2800_conf_tx(struct ieee80211_hw *
+ 	queue = rt2x00queue_get_tx_queue(rt2x00dev, queue_idx);
+ 
+ 	/* Update WMM TXOP register */
+-	offset = WMM_TXOP0_CFG + (sizeof(u32) * (!!(queue_idx & 2)));
+-	field.bit_offset = (queue_idx & 1) * 16;
++	offset = WMM_TXOP0_CFG +
++		 (sizeof(u32) * (!!(rt2x00_ac_to_hwq(queue_idx) & 2)));
++	field.bit_offset = (rt2x00_ac_to_hwq(queue_idx) & 1) * 16;
+ 	field.bit_mask = 0xffff << field.bit_offset;
+ 
+ 	reg = rt2800_register_read(rt2x00dev, offset);
+@@ -12197,7 +12207,7 @@ int rt2800_conf_tx(struct ieee80211_hw *
+ 	rt2800_register_write(rt2x00dev, offset, reg);
+ 
+ 	/* Update WMM registers */
+-	field.bit_offset = queue_idx * 4;
++	field.bit_offset = rt2x00_ac_to_hwq(queue_idx) * 4;
+ 	field.bit_mask = 0xf << field.bit_offset;
+ 
+ 	reg = rt2800_register_read(rt2x00dev, WMM_AIFSN_CFG);
+@@ -12213,7 +12223,7 @@ int rt2800_conf_tx(struct ieee80211_hw *
+ 	rt2800_register_write(rt2x00dev, WMM_CWMAX_CFG, reg);
+ 
+ 	/* Update EDCA registers */
+-	offset = EDCA_AC0_CFG + (sizeof(u32) * queue_idx);
++	offset = EDCA_AC0_CFG + (sizeof(u32) * rt2x00_ac_to_hwq(queue_idx));
+ 
+ 	reg = rt2800_register_read(rt2x00dev, offset);
+ 	rt2x00_set_field32(&reg, EDCA_AC0_CFG_TX_OP, queue->txop);
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800mmio.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800mmio.c
+@@ -35,7 +35,7 @@ unsigned int rt2800mmio_get_dma_done(str
+ 	case QID_AC_VI:
+ 	case QID_AC_BE:
+ 	case QID_AC_BK:
+-		qid = queue->qid;
++		qid = rt2x00_ac_to_hwq(queue->qid);
+ 		idx = rt2x00mmio_register_read(rt2x00dev, TX_DTX_IDX(qid));
+ 		break;
+ 	case QID_MGMT:
+@@ -456,6 +456,7 @@ void rt2800mmio_kick_queue(struct data_q
+ {
+ 	struct rt2x00_dev *rt2x00dev = queue->rt2x00dev;
+ 	struct queue_entry *entry;
++	u8 qid;
+ 
+ 	switch (queue->qid) {
+ 	case QID_AC_VO:
+@@ -464,7 +465,8 @@ void rt2800mmio_kick_queue(struct data_q
+ 	case QID_AC_BK:
+ 		WARN_ON_ONCE(rt2x00queue_empty(queue));
+ 		entry = rt2x00queue_get_entry(queue, Q_INDEX);
+-		rt2x00mmio_register_write(rt2x00dev, TX_CTX_IDX(queue->qid),
++		qid = rt2x00_ac_to_hwq(queue->qid);
++		rt2x00mmio_register_write(rt2x00dev, TX_CTX_IDX(qid),
+ 					  entry->entry_idx);
+ 		hrtimer_start(&rt2x00dev->txstatus_timer,
+ 			      TXSTATUS_TIMEOUT, HRTIMER_MODE_REL);
+@@ -666,36 +668,36 @@ int rt2800mmio_init_queues(struct rt2x00
+ 	 * Initialize registers.
+ 	 */
+ 	entry_priv = rt2x00dev->tx[0].entries[0].priv_data;
+-	rt2x00mmio_register_write(rt2x00dev, TX_BASE_PTR0,
++	rt2x00mmio_register_write(rt2x00dev, TX_BASE_PTR3,
+ 				  entry_priv->desc_dma);
+-	rt2x00mmio_register_write(rt2x00dev, TX_MAX_CNT0,
++	rt2x00mmio_register_write(rt2x00dev, TX_MAX_CNT3,
+ 				  rt2x00dev->tx[0].limit);
+-	rt2x00mmio_register_write(rt2x00dev, TX_CTX_IDX0, 0);
+-	rt2x00mmio_register_write(rt2x00dev, TX_DTX_IDX0, 0);
++	rt2x00mmio_register_write(rt2x00dev, TX_CTX_IDX3, 0);
++	rt2x00mmio_register_write(rt2x00dev, TX_DTX_IDX3, 0);
+ 
+ 	entry_priv = rt2x00dev->tx[1].entries[0].priv_data;
+-	rt2x00mmio_register_write(rt2x00dev, TX_BASE_PTR1,
++	rt2x00mmio_register_write(rt2x00dev, TX_BASE_PTR2,
+ 				  entry_priv->desc_dma);
+-	rt2x00mmio_register_write(rt2x00dev, TX_MAX_CNT1,
++	rt2x00mmio_register_write(rt2x00dev, TX_MAX_CNT2,
+ 				  rt2x00dev->tx[1].limit);
+-	rt2x00mmio_register_write(rt2x00dev, TX_CTX_IDX1, 0);
+-	rt2x00mmio_register_write(rt2x00dev, TX_DTX_IDX1, 0);
++	rt2x00mmio_register_write(rt2x00dev, TX_CTX_IDX2, 0);
++	rt2x00mmio_register_write(rt2x00dev, TX_DTX_IDX2, 0);
+ 
+ 	entry_priv = rt2x00dev->tx[2].entries[0].priv_data;
+-	rt2x00mmio_register_write(rt2x00dev, TX_BASE_PTR2,
++	rt2x00mmio_register_write(rt2x00dev, TX_BASE_PTR0,
+ 				  entry_priv->desc_dma);
+-	rt2x00mmio_register_write(rt2x00dev, TX_MAX_CNT2,
++	rt2x00mmio_register_write(rt2x00dev, TX_MAX_CNT0,
+ 				  rt2x00dev->tx[2].limit);
+-	rt2x00mmio_register_write(rt2x00dev, TX_CTX_IDX2, 0);
+-	rt2x00mmio_register_write(rt2x00dev, TX_DTX_IDX2, 0);
++	rt2x00mmio_register_write(rt2x00dev, TX_CTX_IDX0, 0);
++	rt2x00mmio_register_write(rt2x00dev, TX_DTX_IDX0, 0);
+ 
+ 	entry_priv = rt2x00dev->tx[3].entries[0].priv_data;
+-	rt2x00mmio_register_write(rt2x00dev, TX_BASE_PTR3,
++	rt2x00mmio_register_write(rt2x00dev, TX_BASE_PTR1,
+ 				  entry_priv->desc_dma);
+-	rt2x00mmio_register_write(rt2x00dev, TX_MAX_CNT3,
++	rt2x00mmio_register_write(rt2x00dev, TX_MAX_CNT1,
+ 				  rt2x00dev->tx[3].limit);
+-	rt2x00mmio_register_write(rt2x00dev, TX_CTX_IDX3, 0);
+-	rt2x00mmio_register_write(rt2x00dev, TX_DTX_IDX3, 0);
++	rt2x00mmio_register_write(rt2x00dev, TX_CTX_IDX1, 0);
++	rt2x00mmio_register_write(rt2x00dev, TX_DTX_IDX1, 0);
+ 
+ 	rt2x00mmio_register_write(rt2x00dev, TX_BASE_PTR4, 0);
+ 	rt2x00mmio_register_write(rt2x00dev, TX_MAX_CNT4, 0);
+--- a/drivers/net/wireless/ralink/rt2x00/rt2x00queue.h
++++ b/drivers/net/wireless/ralink/rt2x00/rt2x00queue.h
+@@ -57,6 +57,26 @@ enum data_queue_qid {
+ };
+ 
+ /**
++ * rt2x00_ac_to_hwq - Convert IEEE80211 queue id to Ralink hardware
++ * queue register index.
++ * @ac: TX queue id.
++ */
++static inline u8 rt2x00_ac_to_hwq(enum data_queue_qid ac)
++{
++	static const u8 ralink_queue_map[] = {
++		[IEEE80211_AC_BE] = 0,
++		[IEEE80211_AC_BK] = 1,
++		[IEEE80211_AC_VI] = 2,
++		[IEEE80211_AC_VO] = 3,
++	};
++
++	if (unlikely(ac >= IEEE80211_NUM_ACS))
++		return ac;
++
++	return ralink_queue_map[ac];
++}
++
++/**
+  * enum skb_frame_desc_flags: Flags for &struct skb_frame_desc
+  *
+  * @SKBDESC_DMA_MAPPED_RX: &skb_dma field has been mapped for RX

--- a/package/kernel/mac80211/patches/rt2x00/620-02-rt2x00-increase-the-watchdog-sampling-frequency.patch
+++ b/package/kernel/mac80211/patches/rt2x00/620-02-rt2x00-increase-the-watchdog-sampling-frequency.patch
@@ -1,0 +1,74 @@
+From aec50d1a30349759de0ac535f54c3441bf7ebef7 Mon Sep 17 00:00:00 2001
+From: Shiji Yang <yangshiji66@outlook.com>
+Date: Sun, 22 Dec 2024 17:06:59 +0800
+Subject: [PATCH 2/2] rt2x00: increase the watchdog sampling frequency
+
+Increase the sampling frequency of the watchdog when the hung
+counter reaches the threshold to avoid some unnecessary resets.
+
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ .../net/wireless/ralink/rt2x00/rt2800lib.c    | 45 +++++++++++++------
+ 1 file changed, 32 insertions(+), 13 deletions(-)
+
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+@@ -1320,26 +1320,45 @@ static bool rt2800_watchdog_hung(struct
+ 	return true;
+ }
+ 
++static inline bool check_dma_busy_rx(u32 reg_cfg, u32 reg_int)
++{
++	return (rt2x00_get_field32(reg_cfg, WPDMA_GLO_CFG_RX_DMA_BUSY) &&
++		rt2x00_get_field32(reg_int, INT_SOURCE_CSR_RX_COHERENT));
++}
++
++static inline bool check_dma_busy_tx(u32 reg_cfg, u32 reg_int)
++{
++	return (rt2x00_get_field32(reg_cfg, WPDMA_GLO_CFG_TX_DMA_BUSY) &&
++		rt2x00_get_field32(reg_int, INT_SOURCE_CSR_TX_COHERENT));
++}
++
+ static bool rt2800_watchdog_dma_busy(struct rt2x00_dev *rt2x00dev)
+ {
+ 	bool busy_rx, busy_tx;
+ 	u32 reg_cfg = rt2800_register_read(rt2x00dev, WPDMA_GLO_CFG);
+ 	u32 reg_int = rt2800_register_read(rt2x00dev, INT_SOURCE_CSR);
+ 
+-	if (rt2x00_get_field32(reg_cfg, WPDMA_GLO_CFG_RX_DMA_BUSY) &&
+-	    rt2x00_get_field32(reg_int, INT_SOURCE_CSR_RX_COHERENT))
+-		rt2x00dev->rxdma_busy++;
+-	else
+-		rt2x00dev->rxdma_busy = 0;
+-
+-	if (rt2x00_get_field32(reg_cfg, WPDMA_GLO_CFG_TX_DMA_BUSY) &&
+-	    rt2x00_get_field32(reg_int, INT_SOURCE_CSR_TX_COHERENT))
+-		rt2x00dev->txdma_busy++;
+-	else
+-		rt2x00dev->txdma_busy = 0;
++	rt2x00dev->rxdma_busy = check_dma_busy_rx(reg_cfg, reg_int) ?
++				rt2x00dev->rxdma_busy + 1 : 0;
++	rt2x00dev->txdma_busy = check_dma_busy_tx(reg_cfg, reg_int) ?
++				rt2x00dev->txdma_busy + 1 : 0;
++
++	if (rt2x00dev->rxdma_busy > 25 || rt2x00dev->txdma_busy > 25) {
++		int cnt;
++		for (cnt = 0; cnt < 10; cnt++) {
++			msleep(5);
++			reg_cfg = rt2800_register_read(rt2x00dev, WPDMA_GLO_CFG);
++			reg_int = rt2800_register_read(rt2x00dev, INT_SOURCE_CSR);
++
++			if (!check_dma_busy_rx(reg_cfg, reg_int))
++				rt2x00dev->rxdma_busy = 0;
++			if (!check_dma_busy_tx(reg_cfg, reg_int))
++				rt2x00dev->txdma_busy = 0;
++		}
++	}
+ 
+-	busy_rx = rt2x00dev->rxdma_busy > 30;
+-	busy_tx = rt2x00dev->txdma_busy > 30;
++	busy_rx = rt2x00dev->rxdma_busy > 40;
++	busy_tx = rt2x00dev->txdma_busy > 40;
+ 
+ 	if (!busy_rx && !busy_tx)
+ 		return false;

--- a/package/kernel/mac80211/patches/rt2x00/621-01-rt2x00-always-calibrate-MT7620-when-switching-channe.patch
+++ b/package/kernel/mac80211/patches/rt2x00/621-01-rt2x00-always-calibrate-MT7620-when-switching-channe.patch
@@ -1,0 +1,77 @@
+From 2c5aad0f9990724cce48e0a53b66bc0438e4603d Mon Sep 17 00:00:00 2001
+From: Shiji Yang <yangshiji66@outlook.com>
+Date: Sun, 22 Dec 2024 17:06:59 +0800
+Subject: [PATCH 1/4] rt2x00: always calibrate MT7620 when switching channel
+
+Perform calibration work after each channel switching operation.
+This should help improve the rx/tx signal strength for MT7620.
+
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ .../net/wireless/ralink/rt2x00/rt2800lib.c    | 24 ++++++++++++++-----
+ 1 file changed, 18 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+@@ -5704,6 +5704,9 @@ static void rt2800_config_ps(struct rt2x
+ 	}
+ }
+ 
++static void rt2800_calibration_rt6352_stage1(struct rt2x00_dev *rt2x00dev);
++static void rt2800_calibration_rt6352_stage2(struct rt2x00_dev *rt2x00dev);
++
+ void rt2800_config(struct rt2x00_dev *rt2x00dev,
+ 		   struct rt2x00lib_conf *libconf,
+ 		   const unsigned int flags)
+@@ -5718,10 +5721,18 @@ void rt2800_config(struct rt2x00_dev *rt
+ 		 */
+ 		rt2800_update_survey(rt2x00dev);
+ 
++		if (rt2x00_rt(rt2x00dev, RT6352) &&
++		    !test_bit(DEVICE_STATE_SCANNING, &rt2x00dev->flags))
++			rt2800_calibration_rt6352_stage1(rt2x00dev);
++
+ 		rt2800_config_channel(rt2x00dev, libconf->conf,
+ 				      &libconf->rf, &libconf->channel);
+ 		rt2800_config_txpower(rt2x00dev, libconf->conf->chandef.chan,
+ 				      libconf->conf->power_level);
++
++		if (rt2x00_rt(rt2x00dev, RT6352) &&
++		    !test_bit(DEVICE_STATE_SCANNING, &rt2x00dev->flags))
++			rt2800_calibration_rt6352_stage2(rt2x00dev);
+ 	}
+ 	if (flags & IEEE80211_CONF_CHANGE_POWER)
+ 		rt2800_config_txpower(rt2x00dev, libconf->conf->chandef.chan,
+@@ -10427,15 +10438,19 @@ static void rt2800_restore_rf_bbp_rt6352
+ 	}
+ }
+ 
+-static void rt2800_calibration_rt6352(struct rt2x00_dev *rt2x00dev)
++static void rt2800_calibration_rt6352_stage1(struct rt2x00_dev *rt2x00dev)
+ {
+-	u32 reg;
+-
+ 	if (rt2x00_has_cap_external_pa(rt2x00dev) ||
+ 	    rt2x00_has_cap_external_lna_bg(rt2x00dev))
+ 		rt2800_restore_rf_bbp_rt6352(rt2x00dev);
+ 
+ 	rt2800_r_calibration(rt2x00dev);
++}
++
++static void rt2800_calibration_rt6352_stage2(struct rt2x00_dev *rt2x00dev)
++{
++	u32 reg;
++
+ 	rt2800_rf_self_txdc_cal(rt2x00dev);
+ 	rt2800_rxdcoc_calibration(rt2x00dev);
+ 	rt2800_bw_filter_calibration(rt2x00dev, true);
+@@ -10766,9 +10781,6 @@ static void rt2800_init_rfcsr_6352(struc
+ 
+ 	rt2800_rfcsr_write_dccal(rt2x00dev, 5, 0x00);
+ 	rt2800_rfcsr_write_dccal(rt2x00dev, 17, 0x7C);
+-
+-	/* Do calibration and init PA/LNA */
+-	rt2800_calibration_rt6352(rt2x00dev);
+ }
+ 
+ static void rt2800_init_rfcsr(struct rt2x00_dev *rt2x00dev)

--- a/package/kernel/mac80211/patches/rt2x00/621-02-rt2x00-rework-link-tuner-for-MT7620.patch
+++ b/package/kernel/mac80211/patches/rt2x00/621-02-rt2x00-rework-link-tuner-for-MT7620.patch
@@ -1,0 +1,48 @@
+From aaa57924324c1ee77afa5e3effc95cc86158ddcc Mon Sep 17 00:00:00 2001
+From: Shiji Yang <yangshiji66@outlook.com>
+Date: Sun, 22 Dec 2024 17:06:59 +0800
+Subject: [PATCH 2/4] rt2x00: rework link tuner for MT7620
+
+Correct the VGC gain value for MT7620 and only do gain calibration
+for supported devices.
+
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ drivers/net/wireless/ralink/rt2x00/rt2800lib.c | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+@@ -5561,6 +5561,9 @@ static void rt2800_config_txpower(struct
+ 
+ void rt2800_gain_calibration(struct rt2x00_dev *rt2x00dev)
+ {
++	if (rt2x00_rt(rt2x00dev, RT6352))
++		return;
++
+ 	rt2800_config_txpower(rt2x00dev, rt2x00dev->hw->conf.chandef.chan,
+ 			      rt2x00dev->tx_power);
+ }
+@@ -5773,9 +5776,10 @@ static u8 rt2800_get_default_vgc(struct
+ 		    rt2x00_rt(rt2x00dev, RT3593) ||
+ 		    rt2x00_rt(rt2x00dev, RT5390) ||
+ 		    rt2x00_rt(rt2x00dev, RT5392) ||
+-		    rt2x00_rt(rt2x00dev, RT5592) ||
+-		    rt2x00_rt(rt2x00dev, RT6352))
++		    rt2x00_rt(rt2x00dev, RT5592))
+ 			vgc = 0x1c + (2 * rt2x00dev->lna_gain);
++		else if(rt2x00_rt(rt2x00dev, RT6352))
++			vgc = 0x04 + (2 * rt2x00dev->lna_gain);
+ 		else
+ 			vgc = 0x2e + rt2x00dev->lna_gain;
+ 	} else { /* 5GHZ band */
+@@ -5828,7 +5832,8 @@ void rt2800_link_tuner(struct rt2x00_dev
+ {
+ 	u8 vgc;
+ 
+-	if (rt2x00_rt_rev(rt2x00dev, RT2860, REV_RT2860C))
++	if (rt2x00_rt_rev(rt2x00dev, RT2860, REV_RT2860C) ||
++	    rt2x00_rt(rt2x00dev, RT6352))
+ 		return;
+ 
+ 	/* When RSSI is better than a certain threshold, increase VGC

--- a/package/kernel/mac80211/patches/rt2x00/621-03-rt2x00-correct-MT7620-SDM-mode-register-value.patch
+++ b/package/kernel/mac80211/patches/rt2x00/621-03-rt2x00-correct-MT7620-SDM-mode-register-value.patch
@@ -1,0 +1,25 @@
+From b672507ca9f06bb17213036b16bc4f5c5bc65357 Mon Sep 17 00:00:00 2001
+From: Shiji Yang <yangshiji66@outlook.com>
+Date: Sun, 22 Dec 2024 17:06:59 +0800
+Subject: [PATCH 3/4] rt2x00: correct MT7620 SDM mode register value
+
+rt2x00_set_field8() is a mask writing function. If we want to set
+the BIT(7) for the SDM mode register here, we only need to fill "4"
+in the mask.
+
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ drivers/net/wireless/ralink/rt2x00/rt2800lib.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+@@ -3848,7 +3848,7 @@ static void rt2800_config_channel_rf7620
+ 
+ 	/* Default: XO=20MHz , SDM mode */
+ 	rfcsr = rt2800_rfcsr_read(rt2x00dev, 16);
+-	rt2x00_set_field8(&rfcsr, RFCSR16_SDM_MODE_MT7620, 0x80);
++	rt2x00_set_field8(&rfcsr, RFCSR16_SDM_MODE_MT7620, 4);
+ 	rt2800_rfcsr_write(rt2x00dev, 16, rfcsr);
+ 
+ 	rfcsr = rt2800_rfcsr_read(rt2x00dev, 21);

--- a/package/kernel/mac80211/patches/rt2x00/621-04-rt2x00-fix-register-operation-on-RXIQ-calibration.patch
+++ b/package/kernel/mac80211/patches/rt2x00/621-04-rt2x00-fix-register-operation-on-RXIQ-calibration.patch
@@ -1,0 +1,60 @@
+From 2585ada646e4dcf152ab813a24d667e6903105f4 Mon Sep 17 00:00:00 2001
+From: Shiji Yang <yangshiji66@outlook.com>
+Date: Sun, 22 Dec 2024 17:06:59 +0800
+Subject: [PATCH 4/4] rt2x00: fix register operation on RXIQ calibration
+
+In rt2800_rxiq_calibration(), some variables are overwritten
+before being used. Based on the values of the relevant registers
+in other functions, I believe the correct operation should be
+bit mask writing.
+
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ drivers/net/wireless/ralink/rt2x00/rt2800lib.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+@@ -8846,7 +8846,7 @@ static void rt2800_rxiq_calibration(stru
+ 		rt2x00_warn(rt2x00dev, "Timeout waiting for MAC status in RXIQ calibration\n");
+ 
+ 	bbpval = bbp4 & (~0x18);
+-	bbpval = bbp4 | 0x00;
++	bbpval = bbpval | 0x00;
+ 	rt2800_bbp_write(rt2x00dev, 4, bbpval);
+ 
+ 	bbpval = rt2800_bbp_read(rt2x00dev, 21);
+@@ -8928,13 +8928,13 @@ static void rt2800_rxiq_calibration(stru
+ 	for (ch_idx = 0; ch_idx < 2; ch_idx = ch_idx + 1) {
+ 		if (ch_idx == 0) {
+ 			rfval = rfb0r1 & (~0x3);
+-			rfval = rfb0r1 | 0x1;
++			rfval = rfval | 0x1;
+ 			rt2800_rfcsr_write_bank(rt2x00dev, 0, 1, rfval);
+ 			rfval = rfb0r2 & (~0x33);
+-			rfval = rfb0r2 | 0x11;
++			rfval = rfval | 0x11;
+ 			rt2800_rfcsr_write_bank(rt2x00dev, 0, 2, rfval);
+ 			rfval = rfb0r42 & (~0x50);
+-			rfval = rfb0r42 | 0x10;
++			rfval = rfval | 0x10;
+ 			rt2800_rfcsr_write_bank(rt2x00dev, 0, 42, rfval);
+ 
+ 			rt2800_register_write(rt2x00dev, RF_CONTROL0, 0x00001006);
+@@ -8947,13 +8947,13 @@ static void rt2800_rxiq_calibration(stru
+ 			rt2800_bbp_dcoc_write(rt2x00dev, 1, 0x00);
+ 		} else {
+ 			rfval = rfb0r1 & (~0x3);
+-			rfval = rfb0r1 | 0x2;
++			rfval = rfval | 0x2;
+ 			rt2800_rfcsr_write_bank(rt2x00dev, 0, 1, rfval);
+ 			rfval = rfb0r2 & (~0x33);
+-			rfval = rfb0r2 | 0x22;
++			rfval = rfval | 0x22;
+ 			rt2800_rfcsr_write_bank(rt2x00dev, 0, 2, rfval);
+ 			rfval = rfb0r42 & (~0x50);
+-			rfval = rfb0r42 | 0x40;
++			rfval = rfval | 0x40;
+ 			rt2800_rfcsr_write_bank(rt2x00dev, 0, 42, rfval);
+ 
+ 			rt2800_register_write(rt2x00dev, RF_CONTROL0, 0x00002006);

--- a/package/kernel/mac80211/patches/rt2x00/622-01-rt2x00-fix-RFCSR-register-init-values-for-RT5592.patch
+++ b/package/kernel/mac80211/patches/rt2x00/622-01-rt2x00-fix-RFCSR-register-init-values-for-RT5592.patch
@@ -1,0 +1,230 @@
+From b48887d5de9921d0ff9e88068e3cd555a383d702 Mon Sep 17 00:00:00 2001
+From: Shiji Yang <yangshiji66@outlook.com>
+Date: Sun, 22 Dec 2024 17:06:59 +0800
+Subject: [PATCH 1/2] rt2x00: fix RFCSR register init values for RT5592
+
+Based on Raink proprietary driver 2.7.1.5, correct the initial
+values of some RFCSR registers for RT5592.
+
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ .../net/wireless/ralink/rt2x00/rt2800lib.c    | 122 ++++++++----------
+ 1 file changed, 53 insertions(+), 69 deletions(-)
+
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+@@ -3576,9 +3576,8 @@ static void rt2800_config_channel_rf55xx
+ 
+ 		/* TODO RF27 <- tssi */
+ 
+-		rfcsr = rf->channel <= 10 ? 0x07 : 0x06;
+-		rt2800_rfcsr_write(rt2x00dev, 23, rfcsr);
+-		rt2800_rfcsr_write(rt2x00dev, 59, rfcsr);
++		rt2800_rfcsr_write(rt2x00dev, 23, rf->channel <= 10 ? 0x08 : 0x07);
++		rt2800_rfcsr_write(rt2x00dev, 59, rf->channel <= 4 ? 0x06 : 0x04);
+ 
+ 		if (is_11b) {
+ 			/* CCK */
+@@ -3599,7 +3598,7 @@ static void rt2800_config_channel_rf55xx
+ 		power_bound = POWER_BOUND;
+ 		ep_reg = 0x2;
+ 	} else {
+-		rt2800_rfcsr_write(rt2x00dev, 10, 0x97);
++		rt2800_rfcsr_write(rt2x00dev, 10, 0x95);
+ 		/* FIMXE: RF11 overwrite */
+ 		rt2800_rfcsr_write(rt2x00dev, 11, 0x40);
+ 		rt2800_rfcsr_write(rt2x00dev, 25, 0xBF);
+@@ -3608,13 +3607,15 @@ static void rt2800_config_channel_rf55xx
+ 		rt2800_rfcsr_write(rt2x00dev, 37, 0x04);
+ 		rt2800_rfcsr_write(rt2x00dev, 38, 0x85);
+ 		rt2800_rfcsr_write(rt2x00dev, 40, 0x42);
+-		rt2800_rfcsr_write(rt2x00dev, 41, 0xBB);
++		rt2800_rfcsr_write(rt2x00dev, 41, 0xAB);
+ 		rt2800_rfcsr_write(rt2x00dev, 42, 0xD7);
+-		rt2800_rfcsr_write(rt2x00dev, 45, 0x41);
++		rt2800_rfcsr_write(rt2x00dev, 45, 0x01);
+ 		rt2800_rfcsr_write(rt2x00dev, 48, 0x00);
+ 		rt2800_rfcsr_write(rt2x00dev, 57, 0x77);
++		rt2800_rfcsr_write(rt2x00dev, 58, 0x19);
+ 		rt2800_rfcsr_write(rt2x00dev, 60, 0x05);
+ 		rt2800_rfcsr_write(rt2x00dev, 61, 0x01);
++		rt2800_rfcsr_write(rt2x00dev, 62, 0x19);
+ 
+ 		/* TODO RF27 <- tssi */
+ 
+@@ -3623,82 +3624,59 @@ static void rt2800_config_channel_rf55xx
+ 			rt2800_rfcsr_write(rt2x00dev, 12, 0x2E);
+ 			rt2800_rfcsr_write(rt2x00dev, 13, 0x22);
+ 			rt2800_rfcsr_write(rt2x00dev, 22, 0x60);
+-			rt2800_rfcsr_write(rt2x00dev, 23, 0x7F);
+-			if (rf->channel <= 50)
+-				rt2800_rfcsr_write(rt2x00dev, 24, 0x09);
+-			else if (rf->channel >= 52)
+-				rt2800_rfcsr_write(rt2x00dev, 24, 0x07);
++			rt2800_rfcsr_write(rt2x00dev, 23, 0x7E);
++			rt2800_rfcsr_write(rt2x00dev, 24, 0x07);
+ 			rt2800_rfcsr_write(rt2x00dev, 39, 0x1C);
+ 			rt2800_rfcsr_write(rt2x00dev, 43, 0x5B);
+-			rt2800_rfcsr_write(rt2x00dev, 44, 0X40);
+ 			rt2800_rfcsr_write(rt2x00dev, 46, 0X00);
+-			rt2800_rfcsr_write(rt2x00dev, 51, 0xFE);
+-			rt2800_rfcsr_write(rt2x00dev, 52, 0x0C);
+-			rt2800_rfcsr_write(rt2x00dev, 54, 0xF8);
++			rt2800_rfcsr_write(rt2x00dev, 51, 0xFD);
++			rt2800_rfcsr_write(rt2x00dev, 52, 0x0E);
++			rt2800_rfcsr_write(rt2x00dev, 55, 0x04);
++			rt2800_rfcsr_write(rt2x00dev, 56, 0xBB);
++			rt2800_rfcsr_write(rt2x00dev, 59, 0x7C);
++
+ 			if (rf->channel <= 50) {
+-				rt2800_rfcsr_write(rt2x00dev, 55, 0x06),
+-				rt2800_rfcsr_write(rt2x00dev, 56, 0xD3);
++				rt2800_rfcsr_write(rt2x00dev, 44, 0X32);
++				rt2800_rfcsr_write(rt2x00dev, 54, 0xF9);
+ 			} else if (rf->channel >= 52) {
+-				rt2800_rfcsr_write(rt2x00dev, 55, 0x04);
+-				rt2800_rfcsr_write(rt2x00dev, 56, 0xBB);
++				rt2800_rfcsr_write(rt2x00dev, 44, 0X2A);
++				rt2800_rfcsr_write(rt2x00dev, 54, 0xF8);
+ 			}
+-
+-			rt2800_rfcsr_write(rt2x00dev, 58, 0x15);
+-			rt2800_rfcsr_write(rt2x00dev, 59, 0x7F);
+-			rt2800_rfcsr_write(rt2x00dev, 62, 0x15);
+-
+ 		} else if (rf->channel >= 100 && rf->channel <= 165) {
+-
+ 			rt2800_rfcsr_write(rt2x00dev, 12, 0x0E);
+ 			rt2800_rfcsr_write(rt2x00dev, 13, 0x42);
+ 			rt2800_rfcsr_write(rt2x00dev, 22, 0x40);
+-			if (rf->channel <= 153) {
+-				rt2800_rfcsr_write(rt2x00dev, 23, 0x3C);
+-				rt2800_rfcsr_write(rt2x00dev, 24, 0x06);
+-			} else if (rf->channel >= 155) {
+-				rt2800_rfcsr_write(rt2x00dev, 23, 0x38);
+-				rt2800_rfcsr_write(rt2x00dev, 24, 0x05);
+-			}
++			rt2800_rfcsr_write(rt2x00dev, 52, 0x06);
++			rt2800_rfcsr_write(rt2x00dev, 55, 0x01);
++
+ 			if (rf->channel <= 138) {
++				rt2800_rfcsr_write(rt2x00dev, 23, 0x7C);
+ 				rt2800_rfcsr_write(rt2x00dev, 39, 0x1A);
+ 				rt2800_rfcsr_write(rt2x00dev, 43, 0x3B);
+-				rt2800_rfcsr_write(rt2x00dev, 44, 0x20);
+ 				rt2800_rfcsr_write(rt2x00dev, 46, 0x18);
+-			} else if (rf->channel >= 140) {
++			} else {
++				rt2800_rfcsr_write(rt2x00dev, 23, 0x78);
+ 				rt2800_rfcsr_write(rt2x00dev, 39, 0x18);
+ 				rt2800_rfcsr_write(rt2x00dev, 43, 0x1B);
+-				rt2800_rfcsr_write(rt2x00dev, 44, 0x10);
+ 				rt2800_rfcsr_write(rt2x00dev, 46, 0X08);
+ 			}
+-			if (rf->channel <= 124)
+-				rt2800_rfcsr_write(rt2x00dev, 51, 0xFC);
+-			else if (rf->channel >= 126)
+-				rt2800_rfcsr_write(rt2x00dev, 51, 0xEC);
+-			if (rf->channel <= 138)
+-				rt2800_rfcsr_write(rt2x00dev, 52, 0x06);
+-			else if (rf->channel >= 140)
+-				rt2800_rfcsr_write(rt2x00dev, 52, 0x06);
+-			rt2800_rfcsr_write(rt2x00dev, 54, 0xEB);
+-			if (rf->channel <= 138)
+-				rt2800_rfcsr_write(rt2x00dev, 55, 0x01);
+-			else if (rf->channel >= 140)
+-				rt2800_rfcsr_write(rt2x00dev, 55, 0x00);
+-			if (rf->channel <= 128)
+-				rt2800_rfcsr_write(rt2x00dev, 56, 0xBB);
+-			else if (rf->channel >= 130)
+-				rt2800_rfcsr_write(rt2x00dev, 56, 0xAB);
+-			if (rf->channel <= 116)
+-				rt2800_rfcsr_write(rt2x00dev, 58, 0x1D);
+-			else if (rf->channel >= 118)
+-				rt2800_rfcsr_write(rt2x00dev, 58, 0x15);
+-			if (rf->channel <= 138)
+-				rt2800_rfcsr_write(rt2x00dev, 59, 0x3F);
+-			else if (rf->channel >= 140)
+-				rt2800_rfcsr_write(rt2x00dev, 59, 0x7C);
+-			if (rf->channel <= 116)
+-				rt2800_rfcsr_write(rt2x00dev, 62, 0x1D);
+-			else if (rf->channel >= 118)
+-				rt2800_rfcsr_write(rt2x00dev, 62, 0x15);
++
++			if (rf->channel <= 114) {
++				rt2800_rfcsr_write(rt2x00dev, 24, 0x02);
++				rt2800_rfcsr_write(rt2x00dev, 44, 0x1A);
++				rt2800_rfcsr_write(rt2x00dev, 54, 0xEA);
++				rt2800_rfcsr_write(rt2x00dev, 56, 0xB3);
++			} else {
++				rt2800_rfcsr_write(rt2x00dev, 24, 0x03);
++				rt2800_rfcsr_write(rt2x00dev, 44, 0x0A);
++				rt2800_rfcsr_write(rt2x00dev, 54, 0xF9);
++				rt2800_rfcsr_write(rt2x00dev, 56, 0x9B);
++			}
++
++			rt2800_rfcsr_write(rt2x00dev, 51, rf->channel <= 124 ? 0xFC : 0xEC);
++			rt2800_rfcsr_write(rt2x00dev, 58, rf->channel <= 116 ? 0x1D : 0x15);
++			rfcsr = (rf->channel >= 116 && rf->channel <= 138) ? 0x7E : 0x7C;
++			rt2800_rfcsr_write(rt2x00dev, 59, rfcsr);
+ 		}
+ 
+ 		power_bound = POWER_BOUND_5G;
+@@ -3710,7 +3688,7 @@ static void rt2800_config_channel_rf55xx
+ 		rt2x00_set_field8(&rfcsr, RFCSR49_TX, power_bound);
+ 	else
+ 		rt2x00_set_field8(&rfcsr, RFCSR49_TX, info->default_power1);
+-	if (is_type_ep)
++	if (!is_type_ep)
+ 		rt2x00_set_field8(&rfcsr, RFCSR49_EP, ep_reg);
+ 	rt2800_rfcsr_write(rt2x00dev, 49, rfcsr);
+ 
+@@ -3719,7 +3697,7 @@ static void rt2800_config_channel_rf55xx
+ 		rt2x00_set_field8(&rfcsr, RFCSR50_TX, power_bound);
+ 	else
+ 		rt2x00_set_field8(&rfcsr, RFCSR50_TX, info->default_power2);
+-	if (is_type_ep)
++	if (!is_type_ep)
+ 		rt2x00_set_field8(&rfcsr, RFCSR50_EP, ep_reg);
+ 	rt2800_rfcsr_write(rt2x00dev, 50, rfcsr);
+ 
+@@ -3740,7 +3718,6 @@ static void rt2800_config_channel_rf55xx
+ 	rt2x00_set_field8(&rfcsr, RFCSR1_RX2_PD, 0);
+ 
+ 	rt2800_rfcsr_write(rt2x00dev, 1, rfcsr);
+-	rt2800_rfcsr_write(rt2x00dev, 6, 0xe4);
+ 
+ 	if (conf_is_ht40(conf))
+ 		rt2800_rfcsr_write(rt2x00dev, 30, 0x16);
+@@ -8505,12 +8482,15 @@ static void rt2800_init_rfcsr_5392(struc
+ 
+ static void rt2800_init_rfcsr_5592(struct rt2x00_dev *rt2x00dev)
+ {
++	u16 eeprom;
++
+ 	rt2800_rf_init_calibration(rt2x00dev, 30);
+ 
+ 	rt2800_rfcsr_write(rt2x00dev, 1, 0x3F);
++	rt2800_rfcsr_write(rt2x00dev, 2, 0x80);
+ 	rt2800_rfcsr_write(rt2x00dev, 3, 0x08);
+ 	rt2800_rfcsr_write(rt2x00dev, 5, 0x10);
+-	rt2800_rfcsr_write(rt2x00dev, 6, 0xE4);
++	rt2800_rfcsr_write(rt2x00dev, 6, 0xE0);
+ 	rt2800_rfcsr_write(rt2x00dev, 7, 0x00);
+ 	rt2800_rfcsr_write(rt2x00dev, 14, 0x00);
+ 	rt2800_rfcsr_write(rt2x00dev, 15, 0x00);
+@@ -8526,9 +8506,13 @@ static void rt2800_init_rfcsr_5592(struc
+ 	rt2800_rfcsr_write(rt2x00dev, 34, 0x07);
+ 	rt2800_rfcsr_write(rt2x00dev, 35, 0x12);
+ 	rt2800_rfcsr_write(rt2x00dev, 47, 0x0C);
+-	rt2800_rfcsr_write(rt2x00dev, 53, 0x22);
++	rt2800_rfcsr_write(rt2x00dev, 53, 0x44);
+ 	rt2800_rfcsr_write(rt2x00dev, 63, 0x07);
+ 
++	eeprom = rt2800_eeprom_read(rt2x00dev, EEPROM_NIC_CONF2);
++	if (!rt2x00_get_field16(eeprom, EEPROM_NIC_CONF2_CRYSTAL))
++		rt2800_rfcsr_write(rt2x00dev, 6, 0xE4);
++
+ 	rt2800_rfcsr_write(rt2x00dev, 2, 0x80);
+ 	msleep(1);
+ 

--- a/package/kernel/mac80211/patches/rt2x00/622-02-rt2x00-fix-BBP-register-init-values-for-RT5592.patch
+++ b/package/kernel/mac80211/patches/rt2x00/622-02-rt2x00-fix-BBP-register-init-values-for-RT5592.patch
@@ -1,0 +1,119 @@
+From 1847d817df5585f9d957d16ed2a56ceb41cf6df7 Mon Sep 17 00:00:00 2001
+From: Shiji Yang <yangshiji66@outlook.com>
+Date: Sun, 22 Dec 2024 17:06:59 +0800
+Subject: [PATCH 2/2] rt2x00: fix BBP register init values for RT5592
+
+Based on Raink proprietary driver 2.7.1.5, correct the initial
+values of some BBP registers for RT5592.
+
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ .../net/wireless/ralink/rt2x00/rt2800lib.c    | 32 +++++++++----------
+ 1 file changed, 15 insertions(+), 17 deletions(-)
+
+--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+@@ -3746,6 +3746,7 @@ static void rt2800_config_channel_rf55xx
+ 	rt2800_bbp_write(rt2x00dev, 80, (rf->channel <= 14) ? 0x0E : 0x08);
+ 	rt2800_bbp_write(rt2x00dev, 81, (rf->channel <= 14) ? 0x3A : 0x38);
+ 	rt2800_bbp_write(rt2x00dev, 82, (rf->channel <= 14) ? 0x62 : 0x92);
++	rt2800_bbp_write(rt2x00dev, 95, (rf->channel <= 14) ? 0x9A : 0x1A);
+ 
+ 	/* GLRT band configuration */
+ 	rt2800_bbp_write(rt2x00dev, 195, 128);
+@@ -3758,7 +3759,7 @@ static void rt2800_config_channel_rf55xx
+ 	rt2800_bbp_write(rt2x00dev, 196, (rf->channel <= 14) ? 0x32 : 0x20);
+ 	rt2800_bbp_write(rt2x00dev, 195, 133);
+ 	rt2800_bbp_write(rt2x00dev, 196, (rf->channel <= 14) ? 0x28 : 0x7F);
+-	rt2800_bbp_write(rt2x00dev, 195, 124);
++	rt2800_bbp_write(rt2x00dev, 195, 134);
+ 	rt2800_bbp_write(rt2x00dev, 196, (rf->channel <= 14) ? 0x19 : 0x7F);
+ }
+ 
+@@ -4304,7 +4305,8 @@ static void rt2800_config_channel(struct
+ 		rt2800_bbp_write(rt2x00dev, 62, 0x37 - rt2x00dev->lna_gain);
+ 		rt2800_bbp_write(rt2x00dev, 63, 0x37 - rt2x00dev->lna_gain);
+ 		rt2800_bbp_write(rt2x00dev, 64, 0x37 - rt2x00dev->lna_gain);
+-		if (rt2x00_rt(rt2x00dev, RT6352))
++		if (rt2x00_rt(rt2x00dev, RT5592) ||
++		    rt2x00_rt(rt2x00dev, RT6352))
+ 			rt2800_bbp_write(rt2x00dev, 86, 0x38);
+ 		else
+ 			rt2800_bbp_write(rt2x00dev, 86, 0);
+@@ -4313,6 +4315,7 @@ static void rt2800_config_channel(struct
+ 	if (rf->channel <= 14) {
+ 		if (!rt2x00_rt(rt2x00dev, RT5390) &&
+ 		    !rt2x00_rt(rt2x00dev, RT5392) &&
++		    !rt2x00_rt(rt2x00dev, RT5592) &&
+ 		    !rt2x00_rt(rt2x00dev, RT6352)) {
+ 			if (rt2x00_has_cap_external_lna_bg(rt2x00dev)) {
+ 				rt2800_bbp_write(rt2x00dev, 82, 0x62);
+@@ -4336,17 +4339,20 @@ static void rt2800_config_channel(struct
+ 		else if (rt2x00_rt(rt2x00dev, RT3593) ||
+ 			 rt2x00_rt(rt2x00dev, RT3883))
+ 			rt2800_bbp_write(rt2x00dev, 82, 0x82);
+-		else if (!rt2x00_rt(rt2x00dev, RT6352))
++		else if (!rt2x00_rt(rt2x00dev, RT5592) &&
++			 !rt2x00_rt(rt2x00dev, RT6352))
+ 			rt2800_bbp_write(rt2x00dev, 82, 0xf2);
+ 
+ 		if (rt2x00_rt(rt2x00dev, RT3593) ||
+ 		    rt2x00_rt(rt2x00dev, RT3883))
+ 			rt2800_bbp_write(rt2x00dev, 83, 0x9a);
+ 
+-		if (rt2x00_has_cap_external_lna_a(rt2x00dev))
+-			rt2800_bbp_write(rt2x00dev, 75, 0x46);
+-		else
+-			rt2800_bbp_write(rt2x00dev, 75, 0x50);
++		if (!rt2x00_rt(rt2x00dev, RT5592)) {
++			if (rt2x00_has_cap_external_lna_a(rt2x00dev))
++				rt2800_bbp_write(rt2x00dev, 75, 0x46);
++			else
++				rt2800_bbp_write(rt2x00dev, 75, 0x50);
++		}
+ 	}
+ 
+ 	reg = rt2800_register_read(rt2x00dev, TX_BAND_CFG);
+@@ -5783,12 +5789,10 @@ static inline void rt2800_set_vgc(struct
+ 		if (rt2x00_rt(rt2x00dev, RT3572) ||
+ 		    rt2x00_rt(rt2x00dev, RT3593) ||
+ 		    rt2x00_rt(rt2x00dev, RT3883) ||
++		    rt2x00_rt(rt2x00dev, RT5592) ||
+ 		    rt2x00_rt(rt2x00dev, RT6352)) {
+ 			rt2800_bbp_write_with_rx_chain(rt2x00dev, 66,
+ 						       vgc_level);
+-		} else if (rt2x00_rt(rt2x00dev, RT5592)) {
+-			rt2800_bbp_write(rt2x00dev, 83, qual->rssi > -65 ? 0x4a : 0x7a);
+-			rt2800_bbp_write_with_rx_chain(rt2x00dev, 66, vgc_level);
+ 		} else {
+ 			rt2800_bbp_write(rt2x00dev, 66, vgc_level);
+ 		}
+@@ -7016,7 +7020,6 @@ static void rt2800_init_bbp_5592(struct
+ 	rt2800_bbp_write(rt2x00dev, 88, 0x90);
+ 	rt2800_bbp_write(rt2x00dev, 91, 0x04);
+ 	rt2800_bbp_write(rt2x00dev, 92, 0x02);
+-	rt2800_bbp_write(rt2x00dev, 95, 0x9a);
+ 	rt2800_bbp_write(rt2x00dev, 98, 0x12);
+ 	rt2800_bbp_write(rt2x00dev, 103, 0xC0);
+ 	rt2800_bbp_write(rt2x00dev, 104, 0x92);
+@@ -7027,6 +7030,7 @@ static void rt2800_init_bbp_5592(struct
+ 	rt2800_bbp_write(rt2x00dev, 134, 0xD0);
+ 	rt2800_bbp_write(rt2x00dev, 135, 0xF6);
+ 	rt2800_bbp_write(rt2x00dev, 137, 0x0F);
++	rt2800_bbp_write(rt2x00dev, 148, 0x84);
+ 
+ 	/* Initialize GLRT (Generalized Likehood Radio Test) */
+ 	rt2800_init_bbp_5592_glrt(rt2x00dev);
+@@ -7051,12 +7055,6 @@ static void rt2800_init_bbp_5592(struct
+ 		rt2x00_set_field8(&value, BBP254_BIT7, 1);
+ 		rt2800_bbp_write(rt2x00dev, 254, value);
+ 	}
+-
+-	rt2800_init_freq_calibration(rt2x00dev);
+-
+-	rt2800_bbp_write(rt2x00dev, 84, 0x19);
+-	if (rt2x00_rt_rev_gte(rt2x00dev, RT5592, REV_RT5592C))
+-		rt2800_bbp_write(rt2x00dev, 103, 0xc0);
+ }
+ 
+ static void rt2800_init_bbp_6352(struct rt2x00_dev *rt2x00dev)

--- a/package/kernel/mac80211/patches/rt2x00/994-rt2x00-import-support-for-external-LNA-on-MT7620.patch
+++ b/package/kernel/mac80211/patches/rt2x00/994-rt2x00-import-support-for-external-LNA-on-MT7620.patch
@@ -52,7 +52,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static const unsigned int rt2800_eeprom_map[EEPROM_WORD_COUNT] = {
  	[EEPROM_CHIP_ID]		= 0x0000,
  	[EEPROM_VERSION]		= 0x0001,
-@@ -10446,8 +10464,10 @@ static void rt2800_restore_rf_bbp_rt6352
+@@ -10428,8 +10446,10 @@ static void rt2800_restore_rf_bbp_rt6352
  static void rt2800_calibration_rt6352_stage1(struct rt2x00_dev *rt2x00dev)
  {
  	if (rt2x00_has_cap_external_pa(rt2x00dev) ||
@@ -64,7 +64,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  	rt2800_r_calibration(rt2x00dev);
  }
-@@ -10471,6 +10491,8 @@ static void rt2800_calibration_rt6352_st
+@@ -10453,6 +10473,8 @@ static void rt2800_calibration_rt6352_st
  	    !rt2x00_has_cap_external_lna_bg(rt2x00dev))
  		return;
  

--- a/package/kernel/mac80211/patches/rt2x00/994-rt2x00-import-support-for-external-LNA-on-MT7620.patch
+++ b/package/kernel/mac80211/patches/rt2x00/994-rt2x00-import-support-for-external-LNA-on-MT7620.patch
@@ -52,7 +52,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static const unsigned int rt2800_eeprom_map[EEPROM_WORD_COUNT] = {
  	[EEPROM_CHIP_ID]		= 0x0000,
  	[EEPROM_VERSION]		= 0x0001,
-@@ -10404,8 +10422,10 @@ static void rt2800_calibration_rt6352(st
+@@ -10432,8 +10450,10 @@ static void rt2800_calibration_rt6352(st
  	u32 reg;
  
  	if (rt2x00_has_cap_external_pa(rt2x00dev) ||
@@ -64,7 +64,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  	rt2800_r_calibration(rt2x00dev);
  	rt2800_rf_self_txdc_cal(rt2x00dev);
-@@ -10423,6 +10443,8 @@ static void rt2800_calibration_rt6352(st
+@@ -10451,6 +10471,8 @@ static void rt2800_calibration_rt6352(st
  	    !rt2x00_has_cap_external_lna_bg(rt2x00dev))
  		return;
  

--- a/package/kernel/mac80211/patches/rt2x00/994-rt2x00-import-support-for-external-LNA-on-MT7620.patch
+++ b/package/kernel/mac80211/patches/rt2x00/994-rt2x00-import-support-for-external-LNA-on-MT7620.patch
@@ -52,9 +52,9 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static const unsigned int rt2800_eeprom_map[EEPROM_WORD_COUNT] = {
  	[EEPROM_CHIP_ID]		= 0x0000,
  	[EEPROM_VERSION]		= 0x0001,
-@@ -10432,8 +10450,10 @@ static void rt2800_calibration_rt6352(st
- 	u32 reg;
- 
+@@ -10446,8 +10464,10 @@ static void rt2800_restore_rf_bbp_rt6352
+ static void rt2800_calibration_rt6352_stage1(struct rt2x00_dev *rt2x00dev)
+ {
  	if (rt2x00_has_cap_external_pa(rt2x00dev) ||
 -	    rt2x00_has_cap_external_lna_bg(rt2x00dev))
 +	    rt2x00_has_cap_external_lna_bg(rt2x00dev)) {
@@ -63,8 +63,8 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	}
  
  	rt2800_r_calibration(rt2x00dev);
- 	rt2800_rf_self_txdc_cal(rt2x00dev);
-@@ -10451,6 +10471,8 @@ static void rt2800_calibration_rt6352(st
+ }
+@@ -10471,6 +10491,8 @@ static void rt2800_calibration_rt6352_st
  	    !rt2x00_has_cap_external_lna_bg(rt2x00dev))
  		return;
  

--- a/package/kernel/mac80211/patches/rt2x00/996-rt2x00-mt7620-differentiate-based-on-SoC-CHIP_VER.patch
+++ b/package/kernel/mac80211/patches/rt2x00/996-rt2x00-mt7620-differentiate-based-on-SoC-CHIP_VER.patch
@@ -14,7 +14,7 @@
   */
 --- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
 +++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
-@@ -3864,14 +3864,16 @@ static void rt2800_config_channel_rf7620
+@@ -3842,14 +3842,16 @@ static void rt2800_config_channel_rf7620
  	rt2x00_set_field8(&rfcsr, RFCSR19_K, rf->rf4);
  	rt2800_rfcsr_write(rt2x00dev, 19, rfcsr);
  
@@ -39,7 +39,7 @@
  
  	rfcsr = rt2800_rfcsr_read(rt2x00dev, 1);
  	rt2x00_set_field8(&rfcsr, RFCSR1_TX2_EN_MT7620,
-@@ -3905,18 +3907,23 @@ static void rt2800_config_channel_rf7620
+@@ -3883,18 +3885,23 @@ static void rt2800_config_channel_rf7620
  		rt2800_rfcsr_write_dccal(rt2x00dev, 59, 0x20);
  	}
  
@@ -73,7 +73,7 @@
  
  	if (!test_bit(DEVICE_STATE_SCANNING, &rt2x00dev->flags)) {
  		if (conf_is_ht40(conf)) {
-@@ -4030,25 +4037,29 @@ static void rt2800_config_alc_rt6352(str
+@@ -4008,25 +4015,29 @@ static void rt2800_config_alc_rt6352(str
  	if (unlikely(rt2800_wait_bbp_rf_ready(rt2x00dev, MAC_STATUS_CFG_BBP_RF_BUSY)))
  		rt2x00_warn(rt2x00dev, "RF busy while configuring ALC\n");
  
@@ -121,7 +121,7 @@
  	rt2800_register_write(rt2x00dev, MAC_SYS_CTRL, mac_sys_ctrl);
  
  	rt2800_vco_calibration(rt2x00dev);
-@@ -4541,7 +4552,8 @@ static void rt2800_config_channel(struct
+@@ -4524,7 +4535,8 @@ static void rt2800_config_channel(struct
  	if (rt2x00_rt(rt2x00dev, RT6352)) {
  		/* BBP for GLRT BW */
  		bbp = conf_is_ht40(conf) ?
@@ -131,7 +131,7 @@
  		      0x15 : 0x1a;
  		rt2800_bbp_glrt_write(rt2x00dev, 141, bbp);
  
-@@ -6061,18 +6073,34 @@ static int rt2800_init_registers(struct
+@@ -6042,18 +6054,34 @@ static int rt2800_init_registers(struct
  	} else if (rt2x00_rt(rt2x00dev, RT5350)) {
  		rt2800_register_write(rt2x00dev, TX_SW_CFG0, 0x00000404);
  	} else if (rt2x00_rt(rt2x00dev, RT6352)) {
@@ -178,7 +178,7 @@
  		reg = rt2800_register_read(rt2x00dev, TX_ALC_CFG_1);
  		rt2x00_set_field32(&reg, TX_ALC_CFG_1_ROS_BUSY_EN, 0);
  		rt2800_register_write(rt2x00dev, TX_ALC_CFG_1, reg);
-@@ -7185,14 +7213,16 @@ static void rt2800_init_bbp_6352(struct
+@@ -7160,14 +7188,16 @@ static void rt2800_init_bbp_6352(struct
  	rt2800_bbp_write(rt2x00dev, 188, 0x00);
  	rt2800_bbp_write(rt2x00dev, 189, 0x00);
  
@@ -203,7 +203,7 @@
  
  	/* BBP for G band GLRT function (BBP_128 ~ BBP_221) */
  	rt2800_bbp_glrt_write(rt2x00dev, 0, 0x00);
-@@ -10422,6 +10452,9 @@ static void rt2800_restore_rf_bbp_rt6352
+@@ -10404,6 +10434,9 @@ static void rt2800_restore_rf_bbp_rt6352
  		rt2800_register_write(rt2x00dev, RF_BYPASS3, 0x0);
  	}
  
@@ -213,7 +213,7 @@
  	if (rt2x00_has_cap_external_lna_bg(rt2x00dev)) {
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 14, 0x16);
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 17, 0x23);
-@@ -10503,6 +10536,9 @@ static void rt2800_calibration_rt6352_st
+@@ -10485,6 +10518,9 @@ static void rt2800_calibration_rt6352_st
  		rt2800_register_write(rt2x00dev, RF_BYPASS3, reg);
  	}
  
@@ -223,7 +223,7 @@
  	if (rt2x00_has_cap_external_lna_bg(rt2x00dev)) {
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 14, 0x66);
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 17, 0x20);
-@@ -10593,31 +10629,36 @@ static void rt2800_init_rfcsr_6352(struc
+@@ -10575,31 +10611,36 @@ static void rt2800_init_rfcsr_6352(struc
  	rt2800_rfcsr_write(rt2x00dev, 42, 0x5B);
  	rt2800_rfcsr_write(rt2x00dev, 43, 0x00);
  
@@ -285,7 +285,7 @@
  
  	/* Initialize RF channel register to default value */
  	rt2800_rfcsr_write_chanreg(rt2x00dev, 0, 0x03);
-@@ -10683,63 +10724,71 @@ static void rt2800_init_rfcsr_6352(struc
+@@ -10665,63 +10706,71 @@ static void rt2800_init_rfcsr_6352(struc
  
  	rt2800_rfcsr_write_bank(rt2x00dev, 6, 45, 0xC5);
  
@@ -412,7 +412,7 @@
  
  	/* Initialize RF DC calibration register to default value */
  	rt2800_rfcsr_write_dccal(rt2x00dev, 0, 0x47);
-@@ -10802,12 +10851,17 @@ static void rt2800_init_rfcsr_6352(struc
+@@ -10784,12 +10833,17 @@ static void rt2800_init_rfcsr_6352(struc
  	rt2800_rfcsr_write_dccal(rt2x00dev, 62, 0x00);
  	rt2800_rfcsr_write_dccal(rt2x00dev, 63, 0x00);
  

--- a/package/kernel/mac80211/patches/rt2x00/996-rt2x00-mt7620-differentiate-based-on-SoC-CHIP_VER.patch
+++ b/package/kernel/mac80211/patches/rt2x00/996-rt2x00-mt7620-differentiate-based-on-SoC-CHIP_VER.patch
@@ -14,7 +14,7 @@
   */
 --- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
 +++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
-@@ -3836,14 +3836,16 @@ static void rt2800_config_channel_rf7620
+@@ -3864,14 +3864,16 @@ static void rt2800_config_channel_rf7620
  	rt2x00_set_field8(&rfcsr, RFCSR19_K, rf->rf4);
  	rt2800_rfcsr_write(rt2x00dev, 19, rfcsr);
  
@@ -39,7 +39,7 @@
  
  	rfcsr = rt2800_rfcsr_read(rt2x00dev, 1);
  	rt2x00_set_field8(&rfcsr, RFCSR1_TX2_EN_MT7620,
-@@ -3877,18 +3879,23 @@ static void rt2800_config_channel_rf7620
+@@ -3905,18 +3907,23 @@ static void rt2800_config_channel_rf7620
  		rt2800_rfcsr_write_dccal(rt2x00dev, 59, 0x20);
  	}
  
@@ -73,7 +73,7 @@
  
  	if (!test_bit(DEVICE_STATE_SCANNING, &rt2x00dev->flags)) {
  		if (conf_is_ht40(conf)) {
-@@ -4002,25 +4009,29 @@ static void rt2800_config_alc_rt6352(str
+@@ -4030,25 +4037,29 @@ static void rt2800_config_alc_rt6352(str
  	if (unlikely(rt2800_wait_bbp_rf_ready(rt2x00dev, MAC_STATUS_CFG_BBP_RF_BUSY)))
  		rt2x00_warn(rt2x00dev, "RF busy while configuring ALC\n");
  
@@ -121,7 +121,7 @@
  	rt2800_register_write(rt2x00dev, MAC_SYS_CTRL, mac_sys_ctrl);
  
  	rt2800_vco_calibration(rt2x00dev);
-@@ -4513,7 +4524,8 @@ static void rt2800_config_channel(struct
+@@ -4541,7 +4552,8 @@ static void rt2800_config_channel(struct
  	if (rt2x00_rt(rt2x00dev, RT6352)) {
  		/* BBP for GLRT BW */
  		bbp = conf_is_ht40(conf) ?
@@ -131,7 +131,7 @@
  		      0x15 : 0x1a;
  		rt2800_bbp_glrt_write(rt2x00dev, 141, bbp);
  
-@@ -6017,18 +6029,33 @@ static int rt2800_init_registers(struct
+@@ -6045,18 +6057,33 @@ static int rt2800_init_registers(struct
  	} else if (rt2x00_rt(rt2x00dev, RT5350)) {
  		rt2800_register_write(rt2x00dev, TX_SW_CFG0, 0x00000404);
  	} else if (rt2x00_rt(rt2x00dev, RT6352)) {
@@ -177,7 +177,7 @@
  		reg = rt2800_register_read(rt2x00dev, TX_ALC_CFG_1);
  		rt2x00_set_field32(&reg, TX_ALC_CFG_1_ROS_BUSY_EN, 0);
  		rt2800_register_write(rt2x00dev, TX_ALC_CFG_1, reg);
-@@ -7141,14 +7168,16 @@ static void rt2800_init_bbp_6352(struct
+@@ -7169,14 +7196,16 @@ static void rt2800_init_bbp_6352(struct
  	rt2800_bbp_write(rt2x00dev, 188, 0x00);
  	rt2800_bbp_write(rt2x00dev, 189, 0x00);
  
@@ -202,7 +202,7 @@
  
  	/* BBP for G band GLRT function (BBP_128 ~ BBP_221) */
  	rt2800_bbp_glrt_write(rt2x00dev, 0, 0x00);
-@@ -10378,6 +10407,9 @@ static void rt2800_restore_rf_bbp_rt6352
+@@ -10406,6 +10435,9 @@ static void rt2800_restore_rf_bbp_rt6352
  		rt2800_register_write(rt2x00dev, RF_BYPASS3, 0x0);
  	}
  
@@ -212,7 +212,7 @@
  	if (rt2x00_has_cap_external_lna_bg(rt2x00dev)) {
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 14, 0x16);
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 17, 0x23);
-@@ -10455,6 +10487,9 @@ static void rt2800_calibration_rt6352(st
+@@ -10483,6 +10515,9 @@ static void rt2800_calibration_rt6352(st
  		rt2800_register_write(rt2x00dev, RF_BYPASS3, reg);
  	}
  
@@ -222,7 +222,7 @@
  	if (rt2x00_has_cap_external_lna_bg(rt2x00dev)) {
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 14, 0x66);
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 17, 0x20);
-@@ -10545,31 +10580,36 @@ static void rt2800_init_rfcsr_6352(struc
+@@ -10573,31 +10608,36 @@ static void rt2800_init_rfcsr_6352(struc
  	rt2800_rfcsr_write(rt2x00dev, 42, 0x5B);
  	rt2800_rfcsr_write(rt2x00dev, 43, 0x00);
  
@@ -284,7 +284,7 @@
  
  	/* Initialize RF channel register to default value */
  	rt2800_rfcsr_write_chanreg(rt2x00dev, 0, 0x03);
-@@ -10635,63 +10675,71 @@ static void rt2800_init_rfcsr_6352(struc
+@@ -10663,63 +10703,71 @@ static void rt2800_init_rfcsr_6352(struc
  
  	rt2800_rfcsr_write_bank(rt2x00dev, 6, 45, 0xC5);
  
@@ -411,7 +411,7 @@
  
  	/* Initialize RF DC calibration register to default value */
  	rt2800_rfcsr_write_dccal(rt2x00dev, 0, 0x47);
-@@ -10754,12 +10802,17 @@ static void rt2800_init_rfcsr_6352(struc
+@@ -10782,12 +10830,17 @@ static void rt2800_init_rfcsr_6352(struc
  	rt2800_rfcsr_write_dccal(rt2x00dev, 62, 0x00);
  	rt2800_rfcsr_write_dccal(rt2x00dev, 63, 0x00);
  

--- a/package/kernel/mac80211/patches/rt2x00/996-rt2x00-mt7620-differentiate-based-on-SoC-CHIP_VER.patch
+++ b/package/kernel/mac80211/patches/rt2x00/996-rt2x00-mt7620-differentiate-based-on-SoC-CHIP_VER.patch
@@ -20,7 +20,7 @@
  
 -	/* Default: XO=20MHz , SDM mode */
 -	rfcsr = rt2800_rfcsr_read(rt2x00dev, 16);
--	rt2x00_set_field8(&rfcsr, RFCSR16_SDM_MODE_MT7620, 0x80);
+-	rt2x00_set_field8(&rfcsr, RFCSR16_SDM_MODE_MT7620, 4);
 -	rt2800_rfcsr_write(rt2x00dev, 16, rfcsr);
 -
 -	rfcsr = rt2800_rfcsr_read(rt2x00dev, 21);
@@ -29,7 +29,7 @@
 +	if (rt2800_hw_get_chipver(rt2x00dev) > 1) {
 +		/* Default: XO=20MHz , SDM mode */
 +		rfcsr = rt2800_rfcsr_read(rt2x00dev, 16);
-+		rt2x00_set_field8(&rfcsr, RFCSR16_SDM_MODE_MT7620, 0x80);
++		rt2x00_set_field8(&rfcsr, RFCSR16_SDM_MODE_MT7620, 4);
 +		rt2800_rfcsr_write(rt2x00dev, 16, rfcsr);
 +
 +		rfcsr = rt2800_rfcsr_read(rt2x00dev, 21);
@@ -131,7 +131,7 @@
  		      0x15 : 0x1a;
  		rt2800_bbp_glrt_write(rt2x00dev, 141, bbp);
  
-@@ -6045,18 +6057,33 @@ static int rt2800_init_registers(struct
+@@ -6061,18 +6073,34 @@ static int rt2800_init_registers(struct
  	} else if (rt2x00_rt(rt2x00dev, RT5350)) {
  		rt2800_register_write(rt2x00dev, TX_SW_CFG0, 0x00000404);
  	} else if (rt2x00_rt(rt2x00dev, RT6352)) {
@@ -162,7 +162,8 @@
 +			rt2800_register_write(rt2x00dev, TX_SW_CFG0, 0x00000401);
 +			rt2800_register_write(rt2x00dev, TX_SW_CFG1, 0x000C0001);
 +			rt2800_register_write(rt2x00dev, TX_SW_CFG2, 0x00000000);
-+			rt2800_register_write(rt2x00dev, TX_ALC_VGA3, 0x00000000);
++			rt2800_register_write(rt2x00dev, TX_PIN_CFG, 0x00150f0f);
++			rt2800_register_write(rt2x00dev, TX_ALC_VGA3, 0x06060606);
 +			rt2800_register_write(rt2x00dev, TX0_BB_GAIN_ATTEN, 0x0);
 +			rt2800_register_write(rt2x00dev, TX1_BB_GAIN_ATTEN, 0x0);
 +			rt2800_register_write(rt2x00dev, TX0_RF_GAIN_ATTEN,
@@ -177,7 +178,7 @@
  		reg = rt2800_register_read(rt2x00dev, TX_ALC_CFG_1);
  		rt2x00_set_field32(&reg, TX_ALC_CFG_1_ROS_BUSY_EN, 0);
  		rt2800_register_write(rt2x00dev, TX_ALC_CFG_1, reg);
-@@ -7169,14 +7196,16 @@ static void rt2800_init_bbp_6352(struct
+@@ -7185,14 +7213,16 @@ static void rt2800_init_bbp_6352(struct
  	rt2800_bbp_write(rt2x00dev, 188, 0x00);
  	rt2800_bbp_write(rt2x00dev, 189, 0x00);
  
@@ -202,7 +203,7 @@
  
  	/* BBP for G band GLRT function (BBP_128 ~ BBP_221) */
  	rt2800_bbp_glrt_write(rt2x00dev, 0, 0x00);
-@@ -10406,6 +10435,9 @@ static void rt2800_restore_rf_bbp_rt6352
+@@ -10422,6 +10452,9 @@ static void rt2800_restore_rf_bbp_rt6352
  		rt2800_register_write(rt2x00dev, RF_BYPASS3, 0x0);
  	}
  
@@ -212,7 +213,7 @@
  	if (rt2x00_has_cap_external_lna_bg(rt2x00dev)) {
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 14, 0x16);
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 17, 0x23);
-@@ -10483,6 +10515,9 @@ static void rt2800_calibration_rt6352(st
+@@ -10503,6 +10536,9 @@ static void rt2800_calibration_rt6352_st
  		rt2800_register_write(rt2x00dev, RF_BYPASS3, reg);
  	}
  
@@ -222,7 +223,7 @@
  	if (rt2x00_has_cap_external_lna_bg(rt2x00dev)) {
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 14, 0x66);
  		rt2800_rfcsr_write_chanreg(rt2x00dev, 17, 0x20);
-@@ -10573,31 +10608,36 @@ static void rt2800_init_rfcsr_6352(struc
+@@ -10593,31 +10629,36 @@ static void rt2800_init_rfcsr_6352(struc
  	rt2800_rfcsr_write(rt2x00dev, 42, 0x5B);
  	rt2800_rfcsr_write(rt2x00dev, 43, 0x00);
  
@@ -284,7 +285,7 @@
  
  	/* Initialize RF channel register to default value */
  	rt2800_rfcsr_write_chanreg(rt2x00dev, 0, 0x03);
-@@ -10663,63 +10703,71 @@ static void rt2800_init_rfcsr_6352(struc
+@@ -10683,63 +10724,71 @@ static void rt2800_init_rfcsr_6352(struc
  
  	rt2800_rfcsr_write_bank(rt2x00dev, 6, 45, 0xC5);
  
@@ -411,7 +412,7 @@
  
  	/* Initialize RF DC calibration register to default value */
  	rt2800_rfcsr_write_dccal(rt2x00dev, 0, 0x47);
-@@ -10782,12 +10830,17 @@ static void rt2800_init_rfcsr_6352(struc
+@@ -10802,12 +10851,17 @@ static void rt2800_init_rfcsr_6352(struc
  	rt2800_rfcsr_write_dccal(rt2x00dev, 62, 0x00);
  	rt2800_rfcsr_write_dccal(rt2x00dev, 63, 0x00);
  
@@ -431,6 +432,6 @@
 +		rt2800_rfcsr_write_dccal(rt2x00dev, 5, 0x00);
 +		rt2800_rfcsr_write_dccal(rt2x00dev, 17, 0x7C);
 +	}
+ }
  
- 	/* Do calibration and init PA/LNA */
- 	rt2800_calibration_rt6352(rt2x00dev);
+ static void rt2800_init_rfcsr(struct rt2x00_dev *rt2x00dev)


### PR DESCRIPTION
1. Increase the sensitivity of the watchdog to avoid some unnecessary resets.
2. Some register value optimization for MT7620.
3. Some register value optimization for RT5592.
4. Fix a serious bug about EDCA parameters.