### PR TITLE
treewide: remove THIS_MODULE assignment

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -693,7 +693,6 @@ static struct platform_driver gpio_keys_driver = {
 	.remove	= gpio_keys_remove,
 	.driver	= {
 		.name	= "gpio-keys",
-		.owner	= THIS_MODULE,
 		.of_match_table = of_match_ptr(gpio_keys_of_match),
 	},
 };
@@ -703,7 +702,6 @@ static struct platform_driver gpio_keys_polled_driver = {
 	.remove	= gpio_keys_remove,
 	.driver	= {
 		.name	= "gpio-keys-polled",
-		.owner	= THIS_MODULE,
 		.of_match_table = of_match_ptr(gpio_keys_polled_of_match),
 	},
 };

--- a/package/kernel/gpio-nct5104d/src/gpio-nct5104d.c
+++ b/package/kernel/gpio-nct5104d/src/gpio-nct5104d.c
@@ -366,7 +366,6 @@ err:
 
 static struct platform_driver nct5104d_gpio_driver = {
 	.driver = {
-		.owner	= THIS_MODULE,
 		.name	= DRVNAME,
 	},
 	.probe		= nct5104d_gpio_probe,

--- a/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
+++ b/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
@@ -2807,7 +2807,6 @@ static struct platform_driver ltq_mei_driver = {
 	.remove = ltq_mei_remove,
 	.driver = {
 		.name = "lantiq,mei-xway",
-		.owner = THIS_MODULE,
 		.of_match_table = ltq_mei_match,
 	},
 };

--- a/package/kernel/lantiq/ltq-adsl/patches/120-platform.patch
+++ b/package/kernel/lantiq/ltq-adsl/patches/120-platform.patch
@@ -36,7 +36,7 @@
  }
  
  #ifndef _lint
-@@ -1159,8 +1159,30 @@ module_param(debug_level, byte, 0);
+@@ -1159,8 +1159,29 @@ module_param(debug_level, byte, 0);
  MODULE_PARM_DESC(debug_level, "set to get more (1) or fewer (4) debug outputs");
  #endif /* #ifndef DSL_DEBUG_DISABLE*/
  
@@ -59,7 +59,6 @@
 +	.remove = __devexit_p(ltq_adsl_remove),
 +	.driver = {
 +		.name = "adsl",
-+		.owner = THIS_MODULE,
 +		.of_match_table = ltq_adsl_match,
 +	},
 +};

--- a/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
+++ b/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
@@ -1894,7 +1894,6 @@ static struct platform_driver ltq_atm_driver = {
 	.remove = ltq_atm_remove,
 	.driver = {
 		.name = "atm",
-		.owner = THIS_MODULE,
 		.of_match_table = ltq_atm_match,
 	},
 };

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_deu.c
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_deu.c
@@ -196,7 +196,6 @@ static struct platform_driver ltq_deu_driver = {
 	.remove = ltq_deu_remove,
 	.driver = {
 		.name = "deu",
-		.owner = THIS_MODULE,
 		.of_match_table = ltq_deu_match,
 	},
 };

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
@@ -1600,7 +1600,6 @@ static struct platform_driver ltq_ptm_driver = {
        .remove = ltq_ptm_remove,
        .driver = {
                .name = "ptm",
-               .owner = THIS_MODULE,
                .of_match_table = ltq_ptm_match,
        },
 };

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
@@ -1138,7 +1138,6 @@ static struct platform_driver ltq_ptm_driver = {
 	.remove = ltq_ptm_remove,
 	.driver = {
 		.name = "ptm",
-		.owner = THIS_MODULE,
 		.of_match_table = ltq_ptm_match,
 	},
 };

--- a/package/kernel/ubootenv-nvram/src/ubootenv-nvram.c
+++ b/package/kernel/ubootenv-nvram/src/ubootenv-nvram.c
@@ -146,7 +146,6 @@ static struct platform_driver ubootenv_driver = {
 	.remove = ubootenv_remove,
 	.driver = {
 		.name           = NAME,
-		.owner          = THIS_MODULE,
 		.of_match_table = of_ubootenv_match,
 	},
 };

--- a/target/linux/ath79/files/drivers/gpio/gpio-latch-mikrotik.c
+++ b/target/linux/ath79/files/drivers/gpio/gpio-latch-mikrotik.c
@@ -168,7 +168,6 @@ static struct platform_driver gpio_latch_driver = {
 	.probe = gpio_latch_probe,
 	.driver = {
 		.name = GPIO_LATCH_DRIVER_NAME,
-		.owner = THIS_MODULE,
 		.of_match_table = gpio_latch_match,
 	},
 };

--- a/target/linux/ath79/files/drivers/gpio/gpio-rb91x-key.c
+++ b/target/linux/ath79/files/drivers/gpio/gpio-rb91x-key.c
@@ -182,7 +182,6 @@ static struct platform_driver gpio_rb91x_key_driver = {
 	.probe = gpio_rb91x_key_probe,
 	.driver = {
 		.name = GPIO_RB91X_KEY_DRIVER_NAME,
-		.owner = THIS_MODULE,
 		.of_match_table = gpio_rb91x_key_match,
 	},
 };

--- a/target/linux/ath79/files/drivers/mtd/nand/raw/ar934x_nand.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/ar934x_nand.c
@@ -1478,7 +1478,6 @@ static struct platform_driver ar934x_nfc_driver = {
 	.remove		= ar934x_nfc_remove,
 	.driver = {
 		.name	= AR934X_NFC_DRIVER_NAME,
-		.owner	= THIS_MODULE,
 		.of_match_table = ar934x_nfc_match,
 	},
 };

--- a/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
@@ -356,7 +356,6 @@ static struct platform_driver rb91x_nand_driver = {
 	.remove	= rb91x_nand_remove,
 	.driver	= {
 		.name	= "rb91x-nand",
-		.owner	= THIS_MODULE,
 		.of_match_table = rb91x_nand_match,
 	},
 };

--- a/target/linux/bcm47xx/patches-6.6/831-old_gpio_wdt.patch
+++ b/target/linux/bcm47xx/patches-6.6/831-old_gpio_wdt.patch
@@ -32,7 +32,7 @@ Signed-off-by: Mathias Adam <m.adam--openwrt@adamis.de>
  obj-$(CONFIG_TXX9_WDT) += txx9wdt.o
 --- /dev/null
 +++ b/drivers/watchdog/old_gpio_wdt.c
-@@ -0,0 +1,301 @@
+@@ -0,0 +1,300 @@
 +/*
 + *      Driver for GPIO-controlled Hardware Watchdogs.
 + *
@@ -294,7 +294,6 @@ Signed-off-by: Mathias Adam <m.adam--openwrt@adamis.de>
 +	.probe = gpio_wdt_probe,
 +	.remove = gpio_wdt_remove,
 +	.driver.name = "gpio-wdt",
-+	.driver.owner = THIS_MODULE,
 +};
 +
 +static int __init gpio_wdt_init(void)

--- a/target/linux/generic/files/drivers/net/phy/rtl8366rb.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366rb.c
@@ -1503,7 +1503,6 @@ MODULE_DEVICE_TABLE(of, rtl8366rb_match);
 static struct platform_driver rtl8366rb_driver = {
 	.driver = {
 		.name		= RTL8366RB_DRIVER_NAME,
-		.owner		= THIS_MODULE,
 		.of_match_table = of_match_ptr(rtl8366rb_match),
 	},
 	.probe		= rtl8366rb_probe,

--- a/target/linux/generic/files/drivers/net/phy/rtl8366s.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366s.c
@@ -1291,7 +1291,6 @@ MODULE_DEVICE_TABLE(of, rtl8366s_match);
 static struct platform_driver rtl8366s_driver = {
 	.driver = {
 		.name		= RTL8366S_DRIVER_NAME,
-		.owner		= THIS_MODULE,
 #ifdef CONFIG_OF
 		.of_match_table = of_match_ptr(rtl8366s_match),
 #endif

--- a/target/linux/generic/files/drivers/net/phy/rtl8367.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367.c
@@ -1834,7 +1834,6 @@ MODULE_DEVICE_TABLE(of, rtl8367_match);
 static struct platform_driver rtl8367_driver = {
 	.driver = {
 		.name		= RTL8367_DRIVER_NAME,
-		.owner		= THIS_MODULE,
 #ifdef CONFIG_OF
 		.of_match_table = of_match_ptr(rtl8367_match),
 #endif

--- a/target/linux/generic/files/drivers/net/phy/rtl8367b.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367b.c
@@ -1633,7 +1633,6 @@ MODULE_DEVICE_TABLE(of, rtl8367b_match);
 static struct platform_driver rtl8367b_driver = {
 	.driver = {
 		.name		= RTL8367B_DRIVER_NAME,
-		.owner		= THIS_MODULE,
 #ifdef CONFIG_OF
 		.of_match_table = of_match_ptr(rtl8367b_match),
 #endif

--- a/target/linux/generic/hack-6.6/800-GPIO-add-named-gpio-exports.patch
+++ b/target/linux/generic/hack-6.6/800-GPIO-add-named-gpio-exports.patch
@@ -15,7 +15,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  #include "gpiolib.h"
  #include "gpiolib-of.h"
-@@ -1129,3 +1131,74 @@ void of_gpiochip_remove(struct gpio_chip
+@@ -1129,3 +1131,73 @@ void of_gpiochip_remove(struct gpio_chip
  {
  	of_node_put(dev_of_node(&chip->gpiodev->dev));
  }
@@ -81,7 +81,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static struct platform_driver gpio_export_driver = {
 +	.driver		= {
 +		.name		= "gpio-export",
-+		.owner	= THIS_MODULE,
 +		.of_match_table	= of_match_ptr(gpio_export_ids),
 +	},
 +	.probe		= of_gpio_export_probe,

--- a/target/linux/generic/pending-6.6/510-block-add-uImage.FIT-subimage-block-driver.patch
+++ b/target/linux/generic/pending-6.6/510-block-add-uImage.FIT-subimage-block-driver.patch
@@ -81,7 +81,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  swim_mod-y	:= swim.o swim_asm.o
 --- /dev/null
 +++ b/drivers/block/fitblk.c
-@@ -0,0 +1,659 @@
+@@ -0,0 +1,658 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/*
 + * uImage.FIT virtual block device driver.
@@ -714,7 +714,6 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	.probe		= fitblk_probe,
 +	.driver		= {
 +		.name   = "fitblk",
-+		.owner   = THIS_MODULE,
 +	},
 +};
 +

--- a/target/linux/ipq40xx/patches-6.6/850-soc-add-qualcomm-syscon.patch
+++ b/target/linux/ipq40xx/patches-6.6/850-soc-add-qualcomm-syscon.patch
@@ -23,7 +23,7 @@ Subject: SoC: add qualcomm syscon
 +obj-$(CONFIG_QCOM_TCSR)		+= qcom_tcsr.o
 --- /dev/null
 +++ b/drivers/soc/qcom/qcom_tcsr.c
-@@ -0,0 +1,96 @@
+@@ -0,0 +1,95 @@
 +/*
 + * Copyright (c) 2014, The Linux foundation. All rights reserved.
 + *
@@ -109,7 +109,6 @@ Subject: SoC: add qualcomm syscon
 +static struct platform_driver tcsr_driver = {
 +	.driver = {
 +		.name		= "tcsr",
-+		.owner		= THIS_MODULE,
 +		.of_match_table	= tcsr_dt_match,
 +	},
 +	.probe = tcsr_probe,

--- a/target/linux/ipq806x/patches-6.6/850-soc-add-qualcomm-syscon.patch
+++ b/target/linux/ipq806x/patches-6.6/850-soc-add-qualcomm-syscon.patch
@@ -28,7 +28,7 @@ Subject: SoC: add qualcomm syscon
  	depends on ARCH_QCOM || COMPILE_TEST
 --- /dev/null
 +++ b/drivers/soc/qcom/qcom_tcsr.c
-@@ -0,0 +1,62 @@
+@@ -0,0 +1,61 @@
 +/*
 + * Copyright (c) 2014, The Linux foundation. All rights reserved.
 + *
@@ -80,7 +80,6 @@ Subject: SoC: add qualcomm syscon
 +static struct platform_driver tcsr_driver = {
 +	.driver = {
 +		.name		= "tcsr",
-+		.owner		= THIS_MODULE,
 +		.of_match_table	= tcsr_dt_match,
 +	},
 +	.probe = tcsr_probe,

--- a/target/linux/lantiq/patches-6.6/0008-MIPS-lantiq-backport-old-timer-code.patch
+++ b/target/linux/lantiq/patches-6.6/0008-MIPS-lantiq-backport-old-timer-code.patch
@@ -186,7 +186,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  obj-y += vmmc.o
 --- /dev/null
 +++ b/arch/mips/lantiq/xway/timer.c
-@@ -0,0 +1,887 @@
+@@ -0,0 +1,886 @@
 +#ifndef CONFIG_SOC_AMAZON_SE
 +
 +#include <linux/kernel.h>
@@ -1043,7 +1043,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	.probe = gptu_probe,
 +	.driver = {
 +		.name = "gptu-xway",
-+		.owner = THIS_MODULE,
 +		.of_match_table = gptu_match,
 +	},
 +};

--- a/target/linux/lantiq/patches-6.6/0031-I2C-MIPS-lantiq-add-FALC-ON-i2c-bus-master.patch
+++ b/target/linux/lantiq/patches-6.6/0031-I2C-MIPS-lantiq-add-FALC-ON-i2c-bus-master.patch
@@ -47,7 +47,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  obj-$(CONFIG_I2C_MESON)		+= i2c-meson.o
 --- /dev/null
 +++ b/drivers/i2c/busses/i2c-lantiq.c
-@@ -0,0 +1,746 @@
+@@ -0,0 +1,745 @@
 +
 +/*
 + * Lantiq I2C bus adapter
@@ -782,7 +782,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	.remove	= ltq_i2c_remove,
 +	.driver	= {
 +		.name	= DRV_NAME,
-+		.owner	= THIS_MODULE,
 +		.of_match_table = ltq_i2c_match,
 +	},
 +};

--- a/target/linux/lantiq/patches-6.6/0035-owrt-lantiq-wifi-and-ethernet-eeprom-handling.patch
+++ b/target/linux/lantiq/patches-6.6/0035-owrt-lantiq-wifi-and-ethernet-eeprom-handling.patch
@@ -36,7 +36,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +obj-$(CONFIG_PCI) += ath5k_eep.o
 --- /dev/null
 +++ b/arch/mips/lantiq/xway/ath5k_eep.c
-@@ -0,0 +1,136 @@
+@@ -0,0 +1,135 @@
 +/*
 + *  Copyright (C) 2011 Luca Olivetti <luca@ventoso.org>
 + *  Copyright (C) 2011 John Crispin <blogic@openwrt.org>
@@ -149,7 +149,6 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static struct platform_driver ath5k_eeprom_driver = {
 +	.driver		= {
 +		.name		= "ath5k,eeprom",
-+		.owner	= THIS_MODULE,
 +		.of_match_table	= of_match_ptr(ath5k_eeprom_ids),
 +	},
 +};

--- a/target/linux/lantiq/patches-6.6/0151-lantiq-ifxmips_pcie-use-of.patch
+++ b/target/linux/lantiq/patches-6.6/0151-lantiq-ifxmips_pcie-use-of.patch
@@ -293,7 +293,7 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
  
              register_pci_controller(&ifx_pcie_controller[pcie_port].pcic);
              /* XXX, clear error status */
-@@ -1083,6 +1185,30 @@ static int __init ifx_pcie_bios_init(voi
+@@ -1083,6 +1185,29 @@ static int __init ifx_pcie_bios_init(voi
  
      return 0;
  }
@@ -308,7 +308,6 @@ Signed-off-by: Eddi De Pieri <eddi@depieri.net>
 +        .probe = ifx_pcie_bios_probe,
 +        .driver = {
 +                .name = "pcie-xrx200",
-+                .owner = THIS_MODULE,
 +                .of_match_table = ifxmips_pcie_match,
 +        },
 +};

--- a/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s_mdio.c
+++ b/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s_mdio.c
@@ -296,7 +296,6 @@ static struct platform_driver gsw_driver = {
 	.remove = rtk_gsw_remove,
 	.driver = {
 		.name = "rtk-gsw",
-		.owner = THIS_MODULE,
 		.of_match_table = rtk_gsw_match,
 	},
 };

--- a/target/linux/qualcommax/patches-6.6/0900-power-Add-Qualcomm-APM.patch
+++ b/target/linux/qualcommax/patches-6.6/0900-power-Add-Qualcomm-APM.patch
@@ -49,7 +49,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +obj-$(CONFIG_QCOM_APM)		+= apm.o
 --- /dev/null
 +++ b/drivers/power/qcom/apm.c
-@@ -0,0 +1,944 @@
+@@ -0,0 +1,943 @@
 +/*
 + * Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
 + *
@@ -971,7 +971,6 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +	.driver		= {
 +		.name		= MSM_APM_DRIVER_NAME,
 +		.of_match_table	= msm_apm_match_table,
-+		.owner		= THIS_MODULE,
 +	},
 +	.probe		= msm_apm_probe,
 +	.remove		= msm_apm_remove,

--- a/target/linux/qualcommax/patches-6.6/0901-regulator-add-Qualcomm-CPR-regulators.patch
+++ b/target/linux/qualcommax/patches-6.6/0901-regulator-add-Qualcomm-CPR-regulators.patch
@@ -77,7 +77,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  obj-$(CONFIG_REGULATOR_PF8X00) += pf8x00-regulator.o
 --- /dev/null
 +++ b/drivers/regulator/cpr3-npu-regulator.c
-@@ -0,0 +1,695 @@
+@@ -0,0 +1,694 @@
 +/*
 + * Copyright (c) 2017, The Linux Foundation. All rights reserved.
 + *
@@ -752,7 +752,6 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +	.driver		= {
 +		.name		= "qcom,cpr3-npu-regulator",
 +		.of_match_table	= cpr3_regulator_match_table,
-+		.owner		= THIS_MODULE,
 +	},
 +	.probe		= cpr3_npu_regulator_probe,
 +	.remove		= cpr3_npu_regulator_remove,
@@ -9866,7 +9865,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +}
 --- /dev/null
 +++ b/drivers/regulator/cpr4-apss-regulator.c
-@@ -0,0 +1,1819 @@
+@@ -0,0 +1,1818 @@
 +/*
 + * Copyright (c) 2015-2016, The Linux Foundation. All rights reserved.
 + *
@@ -11663,7 +11662,6 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +	.driver		= {
 +		.name		= "qcom,cpr4-apss-regulator",
 +		.of_match_table	= cpr4_regulator_match_table,
-+		.owner		= THIS_MODULE,
 +	},
 +	.probe		= cpr4_apss_regulator_probe,
 +	.remove		= cpr4_apss_regulator_remove,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
@@ -1525,7 +1525,6 @@ static struct platform_driver esw_driver = {
 	.remove = esw_remove,
 	.driver = {
 		.name = "rt3050-esw",
-		.owner = THIS_MODULE,
 		.of_match_table = ralink_esw_match,
 	},
 };

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
@@ -296,7 +296,6 @@ static struct platform_driver gsw_driver = {
 	.remove = mt7620_gsw_remove,
 	.driver = {
 		.name = "mt7620-gsw",
-		.owner = THIS_MODULE,
 		.of_match_table = mediatek_gsw_match,
 	},
 };

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -1657,7 +1657,6 @@ static struct platform_driver fe_driver = {
 	.remove = fe_remove,
 	.driver = {
 		.name = "mtk_soc_eth",
-		.owner = THIS_MODULE,
 		.of_match_table = of_fe_match,
 	},
 };

--- a/target/linux/siflower/files-6.6/drivers/gpio/gpio-siflower.c
+++ b/target/linux/siflower/files-6.6/drivers/gpio/gpio-siflower.c
@@ -333,7 +333,6 @@ static struct platform_driver sf_gpio_driver = {
 	.remove		= sf_gpio_remove,
 	.driver = {
 		.name		= "siflower_gpio",
-		.owner		= THIS_MODULE,
 		.of_match_table	= sf_gpio_ids,
 	},
 };


### PR DESCRIPTION
Matches upstream coccinelle check: api/platform_no_drv_owner.cocci.

ping @hauke @robimarko 