### PR TITLE
gpio-button-hotplug: use flexible array member

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -302,7 +302,7 @@ struct gpio_keys_button_dev {
 
 	struct device *dev;
 	struct gpio_keys_platform_data *pdata;
-	struct gpio_keys_button_data data[0];
+	struct gpio_keys_button_data data[];
 };
 
 static void gpio_keys_polled_queue_work(struct gpio_keys_button_dev *bdev)


### PR DESCRIPTION
zero length arrays are deprecated.

Fixes coccinelle warning:

WARNING use flexible-array member instead

ping @hauke @robimarko 