### PR TITLE
openwrt-keyring: fixes for single release/branch key

### DIFF
--- a/package/system/openwrt-keyring/Makefile
+++ b/package/system/openwrt-keyring/Makefile
@@ -33,7 +33,7 @@ Build/Compile=
 ifneq ($(CONFIG_USE_APK),)
 define Package/openwrt-keyring/install
 	$(INSTALL_DIR) $(1)/etc/apk/keys/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/apk/*.pem $(1)/etc/apk/keys/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/apk/openwrt-snapshots.pem $(1)/etc/apk/keys/
 endef
 else
 define Package/openwrt-keyring/install

--- a/package/system/openwrt-keyring/Makefile
+++ b/package/system/openwrt-keyring/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openwrt-keyring
-PKG_RELEASE:=2
+PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/keyring.git
@@ -40,8 +40,6 @@ define Package/openwrt-keyring/install
 	$(INSTALL_DIR) $(1)/etc/opkg/keys/
 	# Public usign key for unattended snapshot builds
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usign/b5043e70f9a75cde $(1)/etc/opkg/keys/
-	# Public usign key for 24.10 release builds
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/usign/d310c6f2833e97f7 $(1)/etc/opkg/keys/
 endef
 endif
 


### PR DESCRIPTION
### openwrt-keyring: apk: use just snapshot key explicitly

Currently we're going to ship all the apk keys in the keyring, but the
preference is to ship and use single release/branch specific key so lets
use openwrt-snapshots.pem for apk explicitly as well.

Fixes: 2cea05002489 ("openwrt-keyring: add apk public key for signing of package indexes")

### Revert "openwrt-keyring: fix missing 24.10 usign key by installing it"

This reverts commit 37784c48e93c663dafc99454c24bebf4e258556f as the
preference is to have single explicit key for each release/branch.