### PR TITLE
Fix WWAN IP issue for Redmi AX6

### DIFF
--- a/package/network/config/netifd/files/etc/init.d/network
+++ b/package/network/config/netifd/files/etc/init.d/network
@@ -23,6 +23,8 @@ start_service() {
 		procd_set_param limits core="unlimited"
 	}
 	procd_close_instance
+
+	ifup wwan
 }
 
 reload_service() {
@@ -31,6 +33,7 @@ reload_service() {
 	init_switch
 	ubus call network reload || rv=1
 	/sbin/wifi reload_legacy
+	ifup wwan
 	return $rv
 }
 

--- a/package/network/config/netifd/files/lib/netifd/dhcp.script
+++ b/package/network/config/netifd/files/lib/netifd/dhcp.script
@@ -65,6 +65,7 @@ setup_interface () {
 
 	proto_send_update "$INTERFACE"
 
+	ifup wwan
 
 	if [ "$IFACE6RD" != 0 -a -n "$ip6rd" ]; then
 		local v4mask="${ip6rd%% *}"

--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -71,6 +71,8 @@ proto_dhcp_setup() {
 		${hostname:+-x "hostname:$hostname"} \
 		${vendorid:+-V "$vendorid"} \
 		$clientid $defaultreqopts $broadcast $norelease $dhcpopts
+
+	ifup wwan
 }
 
 proto_dhcp_renew() {


### PR DESCRIPTION
Related to #16369

Add automatic WWAN interface bring-up and DHCP request triggering.

* **package/network/config/netifd/files/etc/init.d/network**
  - Add a call to `ifup` for the WWAN interface in the `start_service` function.
  - Add a call to `ifup` for the WWAN interface in the `reload_service` function.

* **package/network/config/netifd/files/lib/netifd/dhcp.script**
  - Add a call to `ifup` for the WWAN interface in the `setup_interface` function.

* **package/network/config/netifd/files/lib/netifd/proto/dhcp.sh**
  - Add a call to `ifup` for the WWAN interface in the `proto_dhcp_setup` function.

