### PR TITLE
ipq806x: Fix default MAC addresses on MR42 by moving to nvmem-layout

### DIFF
--- a/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr42.dts
+++ b/target/linux/ipq806x/files-5.15/arch/arm/boot/dts/qcom-ipq8068-mr42.dts
@@ -58,7 +58,7 @@
 	phy-mode = "sgmii";
 	phy-handle = <&phy2>;
 
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 0>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -84,11 +84,17 @@
 		pagesize = <32>;
 		reg = <0x56>;
 		read-only;
-		#address-cells = <1>;
-		#size-cells = <1>;
 
-		mac_address: mac-address@66 {
-			reg = <0x66 0x6>;
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			mac_address: mac-address@66 {
+				compatible = "mac-base";
+				reg = <0x66 0x6>;
+				#nvmem-cell-cells = <1>;
+			};
 		};
 	};
 };
@@ -186,21 +192,18 @@
 };
 
 &wifi0 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 1>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <1>;
 };
 
 &wifi1 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 2>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <2>;
 };
 
 &wifi2 {
-	nvmem-cells = <&mac_address>;
+	nvmem-cells = <&mac_address 3>;
 	nvmem-cell-names = "mac-address";
-	mac-address-increment = <3>;
 };
 
 &hs_phy_0 {


### PR DESCRIPTION
Partial, single-target update extracted from https://github.com/openwrt/openwrt/commit/d264d3a6

The previous `mac-address-increment` is deprecated, and in particular on this target means that the kernel is unable to read the MAC address, causing the system to boot with a new random MAC address each time.

Fixes: https://github.com/openwrt/openwrt/issues/13992


[rafal.boni@gmail.com: single-target-specific backport from larger change]