### PR TITLE
nu801: Mark as nonshared to build in step 1

### DIFF
--- a/package/system/gpio-cdev/nu801/Makefile
+++ b/package/system/gpio-cdev/nu801/Makefile
@@ -3,6 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nu801
+PKG_FLAGS:=nonshared
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git


### PR DESCRIPTION
Mark the package as nonshared to build it in the target specific build step 1 of the build bots instead of the architecture generic build step2. In the build step 2 it may be left out if we build it using a different target.

Fixes: #16857 