### PR TITLE
packages: drop DEVICE specific dependency for omnia

### DIFF
--- a/package/firmware/omnia-mcu-firmware/Makefile
+++ b/package/firmware/omnia-mcu-firmware/Makefile
@@ -29,7 +29,6 @@ define Package/omnia-mcu-firmware
   CATEGORY:=Firmware
   URL:=https://gitlab.nic.cz/turris/hw/$(PKG_DISTNAME)/-/releases
   TITLE:=CZ.NIC Turris Omnia MCU firmware
-  DEPENDS:=@TARGET_mvebu_cortexa9_DEVICE_cznic_turris-omnia
 endef
 
 define Package/omnia-mcu-firmware/description

--- a/package/utils/omnia-mcutool/Makefile
+++ b/package/utils/omnia-mcutool/Makefile
@@ -27,7 +27,7 @@ define Package/omnia-mcutool
   CATEGORY:=Utilities
   URL:=https://gitlab.nic.cz/turris/$(PKG_NAME)
   TITLE:=CZ.NIC Turris Omnia MCU utility
-  DEPENDS:=+libopenssl +omnia-mcu-firmware @TARGET_mvebu_cortexa9_DEVICE_cznic_turris-omnia
+  DEPENDS:=+libopenssl +omnia-mcu-firmware
 endef
 
 define Package/omnia-mcutool/description


### PR DESCRIPTION
Both packages `ombnia-mcu-firmware` and `omnia-mcutool` would depend on a specific device. The buildbots however build all devices and therefore the package isn't build at all, due to unmet dependencies.

While this didn't cause issues with OPKG, APK fails actively due to the missing packages. Drop the specific dependency, however wants to install unrelated firmware on any device can do that anyway.