### PR TITLE
build: set PATH for post-install scripts

### DIFF
--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -84,7 +84,7 @@ define prepare_rootfs
 			IPKG_POSTINST_PATH=./usr/lib/opkg/info/*.postinst; \
 		fi; \
 		for script in $$IPKG_POSTINST_PATH; do \
-			IPKG_INSTROOT=$(1) $$(command -v bash) $$script; \
+			PATH="$(TARGET_PATH_PKG)" IPKG_INSTROOT=$(1) $$(command -v bash) $$script; \
 			ret=$$?; \
 			if [ $$ret -ne 0 ]; then \
 				echo "postinst script $$script has failed with exit code $$ret" >&2; \


### PR DESCRIPTION
post-install scripts may need to call executables installed to `STAGING_DIR_HOSTPKG` which is not part of the PATH set to `TARGET_PATH` in rules.mk.
Set `PATH` for post-install scripts to `TARGET_PATH_PKG`.