### PR TITLE
ath79: Add support for Sophos AP15C

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -163,6 +163,7 @@ ruckus,zf7372)
 	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x40000" "0x10000"
 	;;
 sophos,ap15|\
+sophos,ap15c|\
 sophos,ap55|\
 sophos,ap55c|\
 sophos,ap100|\

--- a/target/linux/ath79/dts/qca9557_sophos_ap15c.dts
+++ b/target/linux/ath79/dts/qca9557_sophos_ap15c.dts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "sophos,ap15c", "qca,qca9557";
+	model = "Sophos AP15C";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_yellow;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_yellow;
+		label-mac-device = &eth0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: status_green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_status_yellow: status_yellow {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_YELLOW>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "art";
+				reg = <0x050000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+				};
+			};
+
+			partition@60000 {
+				label = "config";
+				reg = <0x060000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_201a: macaddr@201a {
+						reg = <0x201a 0x6>;
+					};
+				};
+			};
+
+			partition@70000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x070000 0xf90000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy-mask = <0x10>;
+
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+		eee-broken-100tx;
+		eee-broken-1000t;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0xa6000000 0xa0000101 0xa0001313>;
+
+	nvmem-cells = <&macaddr_config_201a>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy4>;
+
+	gmac_config: gmac-config {
+		device = <&gmac>;
+
+		rgmii-enabled = <1>;
+
+		rxdv-delay = <3>;
+		rxd-delay = <3>;
+		txen-delay = <3>;
+		txd-delay = <3>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -76,6 +76,7 @@ ath79_setup_interfaces()
 	ruckus,zf7351|\
 	siemens,ws-ap3610|\
 	sophos,ap15|\
+	sophos,ap15c|\
 	sophos,ap55|\
 	sophos,ap55c|\
 	sophos,ap100|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2972,6 +2972,14 @@ define Device/sophos_ap15
 endef
 TARGET_DEVICES += sophos_ap15
 
+define Device/sophos_ap15c
+  SOC := qca9557
+  DEVICE_VENDOR := Sophos
+  DEVICE_MODEL := AP15C
+  IMAGE_SIZE := 15936k
+endef
+TARGET_DEVICES += sophos_ap15c
+
 define Device/sophos_ap55
   SOC := qca9558
   DEVICE_VENDOR := Sophos


### PR DESCRIPTION
The Sophos AP15C uses the same hardware as the AP15, but has a reset button.

Based on:
commit 6f1efb289837 ("ath79: add support for Sophos AP100/AP55 family")
author    Andrew Powers-Holmes <andrew@omnom.net>
          Fri, 3 Sep 2021 15:53:57 +0200 (23:53 +1000)
committer Hauke Mehrtens <hauke@hauke-m.de>
          Sat, 16 Apr 2022 16:59:29 +0200 (16:59 +0200)

Unique to AP15C:
 - Reset button
 - External RJ45 serial console port

Flashing instructions:

This firmware can be flashed either via a compatible Sophos SG or XG firewall appliance, which does not require disassembling the device, or via the U-Boot console available on the internal UART header.

To flash via XG appliance:
 - Register on Sophos' website for a no-cost Home Use XG firewall license
 - Download and install the XG software on a compatible PC or virtual machine, complete initial appliance setup, and enable SSH console access
 - Connect the target AP device to the XG appliance's LAN interface
 - Approve the AP from the XG Web UI and wait until it shows as Active (this can take 3-5 minutes)
 - Connect to the XG appliance over SSH and access the Advanced Console (Menu option 5, then menu option 3)
 - Run `sudo awetool` and select the menu option to connect to an AP via SSH. When prompted to enable SSH on the target AP, select Yes.
 - Wait 2-3 minutes, then select the AP from the awetool menu again. This will connect you to a root shell on the target AP.
 - Copy the firmware to /tmp/openwrt.bin on the target AP via SCP/TFTP/etc
 - Run `mtd -r write /tmp/openwrt.bin astaro_image`
 - When complete, the access point will reboot to OpenWRT.

To flash via U-Boot serial console:
 - Configure a TFTP server on your PC, and set IP address 192.168.99.8 with netmask 255.255.255.0
 - Copy the firmware .bin to the TFTP server and rename to 'uImage_AP15C'
 - Open the target AP's enclosure and locate the 4-pin 3.3V UART header [4]
 - Connect the AP ethernet to your PC's ethernet port
 - Connect a terminal to the UART at 115200 8/N/1 as usual
 - Power on the AP and press a key to cancel autoboot when prompted
 - Run the following commands at the U-Boot console:
    - `tftpboot`
    - `cp.b $fileaddr 0x9f070000 $filesize`
    - `boot`
 - The access point will boot to OpenWRT.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
