### PR TITLE
 ci: scripts: add tools-smoke-test.sh helper

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -16,4 +16,4 @@ jobs:
       contents: read
       packages: read
       actions: write
-    uses: openwrt/actions-shared-workflows/.github/workflows/coverity.yml@main
+    uses: openwrt/actions-shared-workflows/.github/workflows/coverity.yml@ynezz/buildbot-config

--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -9,4 +9,4 @@ permissions:
 jobs:
   build:
     name: Test Formalities
-    uses: openwrt/actions-shared-workflows/.github/workflows/formal.yml@main
+    uses: openwrt/actions-shared-workflows/.github/workflows/formal.yml@ynezz/buildbot-config

--- a/.github/workflows/issue-labeller.yml
+++ b/.github/workflows/issue-labeller.yml
@@ -8,4 +8,4 @@ jobs:
     name: Validate and Tag Bug Report
     permissions:
       issues: write
-    uses: openwrt/actions-shared-workflows/.github/workflows/issue-labeller.yml@main
+    uses: openwrt/actions-shared-workflows/.github/workflows/issue-labeller.yml@ynezz/buildbot-config

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -39,4 +39,4 @@ jobs:
       ccache_s3_bucket: ${{ secrets.CCACHE_S3_BUCKET }}
       ccache_s3_access_key: ${{ secrets.CCACHE_S3_ACCESS_KEY }}
       ccache_s3_secret_key: ${{ secrets.CCACHE_S3_SECRET_KEY }}
-    uses: openwrt/actions-shared-workflows/.github/workflows/kernel.yml@main
+    uses: openwrt/actions-shared-workflows/.github/workflows/kernel.yml@ynezz/buildbot-config

--- a/.github/workflows/label-kernel.yml
+++ b/.github/workflows/label-kernel.yml
@@ -13,4 +13,4 @@ jobs:
       contents: read
       packages: read
       actions: write
-    uses: openwrt/actions-shared-workflows/.github/workflows/label-kernel.yml@main
+    uses: openwrt/actions-shared-workflows/.github/workflows/label-kernel.yml@ynezz/buildbot-config

--- a/.github/workflows/label-target.yml
+++ b/.github/workflows/label-target.yml
@@ -13,4 +13,4 @@ jobs:
       contents: read
       packages: read
       actions: write
-    uses: openwrt/actions-shared-workflows/.github/workflows/label-target.yml@main
+    uses: openwrt/actions-shared-workflows/.github/workflows/label-target.yml@ynezz/buildbot-config

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -39,4 +39,4 @@ jobs:
       ccache_s3_bucket: ${{ secrets.CCACHE_S3_BUCKET }}
       ccache_s3_access_key: ${{ secrets.CCACHE_S3_ACCESS_KEY }}
       ccache_s3_secret_key: ${{ secrets.CCACHE_S3_SECRET_KEY }}
-    uses: openwrt/actions-shared-workflows/.github/workflows/packages.yml@main
+    uses: openwrt/actions-shared-workflows/.github/workflows/packages.yml@ynezz/buildbot-config

--- a/.github/workflows/push-containers.yml
+++ b/.github/workflows/push-containers.yml
@@ -25,4 +25,4 @@ jobs:
       contents: read
       packages: write
       actions: write
-    uses: openwrt/actions-shared-workflows/.github/workflows/push-containers.yml@main
+    uses: openwrt/actions-shared-workflows/.github/workflows/push-containers.yml@ynezz/buildbot-config

--- a/.github/workflows/scripts/tools-smoke-test.sh
+++ b/.github/workflows/scripts/tools-smoke-test.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+
+set -e
+
+self="$0"
+
+__errmsg() {
+	echo "$*" >&2
+}
+
+usage() {
+	cat >&2 <<EOF
+Usage: $self [-h|--help]
+       $self <all>|<sdk>|<imagebuilder>|<toolchain>|<bpf> <target> [<subtarget>]
+EOF
+}
+
+cleanup() {
+	local exit_code=$?
+	[ -n "$tmpdir" ] && [ -d "$tmpdir" ] && rm -rf "$tmpdir"
+	exit $exit_code
+}
+
+trap cleanup EXIT INT TERM
+
+tmpdir="$(mktemp -d)"
+[ -d "$tmpdir" ] || {
+	__errmsg "Failed to create temporary directory $tmpdir"
+	exit 1
+}
+
+parse_args() {
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+			--help|-h)
+				usage
+				exit 0
+				;;
+			*)
+				if [ -z "$o_test" ]; then
+					o_test="$1"
+				elif [ -z "$o_target" ]; then
+					o_target="$1"
+				elif [ -z "$o_subtarget" ]; then
+					o_subtarget="$1"
+				else
+					o_extra+=("$1")
+				fi
+
+				shift
+				;;
+		esac
+	done
+
+	[ -n "$o_test" ] || [ -n "$o_target" ] || {
+		usage
+		return 1
+	}
+
+	[ -n "$o_subtarget" ] || o_subtarget="generic"
+
+	eval "$(grep ^CONFIG_BINARY_FOLDER= .config 2>/dev/null)"
+	o_bindir="${CONFIG_BINARY_FOLDER:-bin}"
+	o_targetdir="${o_bindir}/targets/$o_target/$o_subtarget"
+}
+
+test_sdk() {
+	local sdk
+
+	sdk=$(find "$o_targetdir" -name "openwrt-sdk*.Linux-x86_64.tar.zst" -type f)
+	[ -n "$sdk" ] || {
+		__errmsg "SDK file not found in $o_targetdir"
+		return 1
+	}
+
+	tar -C "$tmpdir" -xf "$sdk"
+	pushd "$tmpdir"/openwrt-sdk* > /dev/null
+	make defconfig
+	sed -i 's|git.openwrt.org|github.com|' feeds.conf.default
+	./scripts/feeds update base
+	./scripts/feeds install -p base busybox
+	make -j "$(nproc)" package/busybox/compile V=sc
+	find "bin/packages" -name "busybox*.ipk" -o -name "busybox*.apk"
+
+	echo "[*] sdk test passed"
+	popd > /dev/null
+}
+
+test_imagebuilder() {
+	local ib
+
+	ib=$(find "$o_targetdir" -name "openwrt-imagebuilder*.Linux-x86_64.tar.zst" -type f)
+	[ -n "$ib" ] || {
+		__errmsg "ImageBuilder file not found in $o_targetdir"
+		return 1
+	}
+
+	tar -C "$tmpdir" -xf "$ib"
+	pushd "$tmpdir"/openwrt-imagebuilder* > /dev/null
+	make image PACKAGES="tcpdump"
+	find "bin/targets/$o_target/$o_subtarget" -name "openwrt-*rootfs.tar.gz"
+
+	echo "[*] imagebuilder test passed"
+	popd > /dev/null
+}
+
+test_bpf() {
+	local bpf
+
+	bpf=$(find "$o_targetdir" -name "llvm-bpf-*.Linux-x86_64.tar.zst" -type f)
+	[ -n "$bpf" ] || {
+		__errmsg "BPF toolchain file not found in $o_targetdir"
+		return 1
+	}
+
+	tar -C "$tmpdir" -xf "$bpf"
+	pushd "$tmpdir"/llvm-bpf*Linux-x86_64 > /dev/null
+
+cat > test.c << 'EOF'
+	typedef unsigned int __u32;
+	#define SEC(NAME) __attribute__((section(NAME), used))
+	#define XDP_PASS 2
+	struct xdp_md {
+		__u32 data;
+		__u32 data_end;
+		__u32 data_meta;
+		__u32 ingress_ifindex;
+		__u32 rx_queue_index;
+		__u32 egress_ifindex;
+	};
+
+	SEC("xdp")
+	int xdp_test(struct xdp_md *ctx) {
+		return XDP_PASS;
+	}
+EOF
+
+	./bin/clang -target bpf -c test.c -o test.o
+	./bin/llvm-objdump -S test.o | grep "<xdp_test>:"
+	./bin/llvm-objdump -h test.o | grep "file format elf.*-bpf$"
+	./bin/llvm-objdump -h test.o | grep "xdp .* TEXT"
+
+	echo "[*] bpf test passed"
+	popd > /dev/null
+}
+
+test_toolchain() {
+	local toolchain
+
+	toolchain=$(find "$o_targetdir" -name "openwrt-toolchain*.Linux-x86_64.tar.zst" -type f)
+	[ -n "$toolchain" ] || {
+		__errmsg "Toolchain file not found in $o_targetdir"
+		return 1
+	}
+
+	tar -C "$tmpdir" -xf "$toolchain"
+	pushd "$tmpdir"/openwrt-toolchain*/toolchain* > /dev/null
+
+	compiler=$(find ./bin -name '*-openwrt-linux-gcc' -type l)
+	objdump=$(find ./bin -name '*-openwrt-linux-objdump' -type l)
+
+	[ -n "$compiler" ] || {
+		__errmsg "gcc not found in $tmpdir/openwrt-toolchain*/toolchain*"
+		return 1
+	}
+
+	[ -n "$objdump" ] || {
+		__errmsg "objdump not found in $tmpdir/openwrt-toolchain*/toolchain*"
+		return 1
+	}
+
+cat > test.c << 'EOF'
+	#include <stdio.h>
+
+	int main(void) {
+		printf("Hello world!\n");
+		return 0;
+	}
+EOF
+
+	"$compiler" test.c -o test
+	"$objdump" -S ./test | grep "file format elf"
+	"$objdump" -S ./test | grep "<main>:"
+
+	echo "[*] toolchain test passed"
+	popd > /dev/null
+}
+
+tools_smoke_test() {
+	case "$o_test" in
+		sdk)			test_sdk			;;
+		bpf)			test_bpf			;;
+		imagebuilder)	test_imagebuilder	;;
+		toolchain)		test_toolchain		;;
+		all)
+			test_bpf
+			test_toolchain
+			test_imagebuilder
+			test_sdk
+			echo "[*] all tests passed"
+			;;
+		*)
+			__errmsg "smoke test of $o_test is not supported yet"
+			return 1
+			;;
+	esac
+}
+
+parse_args "$@" && tools_smoke_test

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -26,4 +26,4 @@ jobs:
       contents: read
       packages: read
       actions: write
-    uses: openwrt/actions-shared-workflows/.github/workflows/toolchain.yml@main
+    uses: openwrt/actions-shared-workflows/.github/workflows/toolchain.yml@ynezz/buildbot-config

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -24,4 +24,4 @@ concurrency:
 jobs:
   build-tools:
     name: Build host tools for linux and macos based systems
-    uses: openwrt/actions-shared-workflows/.github/workflows/tools.yml@main
+    uses: openwrt/actions-shared-workflows/.github/workflows/tools.yml@ynezz/buildbot-config


### PR DESCRIPTION
### TODO

- [ ] review/merge https://github.com/openwrt/actions-shared-workflows/pull/5

### ci: scripts: add tools-smoke-test.sh helper

Currently we're not runtime testing tools like SDK, ImageBuilder,
toolchain or llvm-bpf. So lets add a shell script which would allow
quick smoke testing in GitHub CI, buildbot and during local development
via shared script.

Intended use case is to test the tools after the build in the build
directory.

Example, test all the sdk/imagebuilder/bpf/toolchain tools for x86/64 in one go:

```shell
  ./scripts/tools-smoke-test.sh all x86 64
  ...snip...
  [*] all tests passed

Test just SDK tool for mediatek/filogic:

  ./scripts/tools-smoke-test.sh sdk mediatek filogic
  ...snip...
  [*] sdk test passed
```