### PR TITLE
ramips: mt7621: add missing regulator-boot-on

### DIFF
--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -87,6 +87,7 @@
 		regulator-max-microvolt = <5000000>;
 		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
+		regulator-boot-on;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_humax_e10.dts
+++ b/target/linux/ramips/dts/mt7621_humax_e10.dts
@@ -63,6 +63,7 @@
 		regulator-max-microvolt = <5000000>;
 		gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
+		regulator-boot-on;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
@@ -22,6 +22,7 @@
 		regulator-max-microvolt = <5000000>;
 		gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
+		regulator-boot-on;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
@@ -103,6 +103,7 @@
 		regulator-max-microvolt = <5000000>;
 		gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
+		regulator-boot-on;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
@@ -101,6 +101,7 @@
 		regulator-max-microvolt = <5000000>;
 		gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
+		regulator-boot-on;
 	};
 };
 


### PR DESCRIPTION
What seems to be happening is that the kernel requests an ACTIVE_LOW gpio initially and sets it to high later based on gpios in dts.

This seems to break some devices where the bootloader sets it to high.

Fixes: e612900ae0 ("ramips: mt7621: convert usb power to regulators")

ping @DragonBluep @mkrle