### PR TITLE
uhttpd: add mDNS advertisement for HTTP service

### DIFF
--- a/package/network/services/uhttpd/files/uhttpd.config
+++ b/package/network/services/uhttpd/files/uhttpd.config
@@ -119,6 +119,9 @@ config uhttpd main
 	# resources.
 #	list httpauth prefix_user
 
+	# Enable or disable mDNS advertisement for uhttpd
+#	option mdns 1
+
 
 # Defaults for automatic certificate and key generation
 config cert defaults

--- a/package/network/services/uhttpd/files/uhttpd.init
+++ b/package/network/services/uhttpd/files/uhttpd.init
@@ -112,7 +112,7 @@ start_instance()
 	local cfg="$1"
 	local realm="$(uci_get system.@system[0].hostname)"
 	local listen http https interpreter indexes path handler httpdconf haveauth
-	local enabled
+	local enabled mdnsport
 
 	config_get_bool enabled "$cfg" 'enabled' 1
 	[ $enabled -gt 0 ] || return
@@ -180,6 +180,12 @@ start_instance()
 	for listen in $http; do
 		 procd_append_param command -p "$listen"
 	done
+	
+	config_get_bool mdns "$cfg" mdns 1
+	if [ "$mdns" -ne 0 ]; then
+		mdnsport="${http##*:}"
+		[ -n "$mdnsport" ] && procd_add_mdns "http" "tcp" "$mdnsport" "daemon=uhttpd"
+	fi
 
 	config_get interpreter "$cfg" interpreter
 	for path in $interpreter; do


### PR DESCRIPTION
If the `mdns` option in the `uhttpd` configuration is not present or
set to 1 `uhttpd` will automatically advertise an HTTP TCP service
via `umdns`. There is a limit of 1 advertisement per `procd` service and so
it will be bound to the last valid port from the `listen_http` config
option. This aligns with IANA service discovery guidelines and is
based on existing Dropbear SSH advertisements and will simplify automated
service discovery.