### PR TITLE
[24.10] ath79: linksys_ea4500-v3: take over the space for user data

### DIFF
--- a/target/linux/ath79/dts/qca9558_linksys_ea4500-v3.dts
+++ b/target/linux/ath79/dts/qca9558_linksys_ea4500-v3.dts
@@ -123,7 +123,7 @@
 
 		partition@2c0000 {
 			label = "firmware";
-			reg = <0x2c0000 0x5000000>;
+			reg = <0x2c0000 0x7d40000>;
 
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
@@ -136,7 +136,7 @@
 
 			partition@400000 {
 				label = "ubi";
-				reg = <0x400000 0x4c00000>;
+				reg = <0x400000 0x7940000>;
 			};
 
 			/* Original layout for secondary partitions */
@@ -151,11 +151,11 @@
 			}; */
 		};
 
-		partition@52c0000 {
+		/* Original layout for user data partition */
+		/* partition@52c0000 {
 			label = "syscfg";
 			reg = <0x52c0000 0x2d40000>;
-			read-only;
-		};
+		}; */
 	};
 };
 

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -281,6 +281,12 @@ TARGET_DEVICES += glinet_gl-x1200-nor
 
 define Device/linksys_ea4500-v3
   SOC := qca9558
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Partition table has been changed. Please \
+	install kmod-mtd-rw and erase mtd8 (syscfg) before upgrade \
+	to keep configures, or forcibly flash factory image to mtd5 \
+	(firmware) partition with mtd tool to discard configures but \
+	claim additional space immediately.
   DEVICE_VENDOR := Linksys
   DEVICE_MODEL := EA4500
   DEVICE_VARIANT := v3
@@ -288,7 +294,7 @@ define Device/linksys_ea4500-v3
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   KERNEL_SIZE := 4096k
-  IMAGE_SIZE := 81920k
+  IMAGE_SIZE := 128256k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   LINKSYS_HWNAME := EA4500V3
   IMAGES += factory.img

--- a/target/linux/ath79/nand/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ath79/nand/base-files/etc/board.d/05_compat-version
@@ -4,6 +4,7 @@
 board_config_update
 
 case "$(board_name)" in
+	linksys,ea4500-v3|\
 	netgear,wndr4300-v2|\
 	netgear,wndr4500-v3)
 		ucidef_set_compat_version "1.1"


### PR DESCRIPTION
The last "syscfg" partition of the OEM firmware turns out to be a UBIFS used to store user data, just as the "rootfs_data" of OpenWrt, so it should be reasonable to absorb it into the "ubi" partition.

Factory installations via either OEM firmware or tftp, or by forcibly flashing factory image to mtd5 (firmware) partition with mtd tool are confirmed working, but the UBI remaining inside "syscfg" partition could break upgrade. Fortunately, installing kmod-mtd-rw and erasing "syscfg" partition before upgrade is confirmed working, in which case, "ubi" will automatically expand to the blank space once occupied by the former mtd8 (syscfg), with the total block number increased, but the UBIFS for rootfs_data will not automatically claim the newly available space (since it is created when mtd8 still exists, and sysupgrade does not set "autoresize" flag to rootfs_data). These space will be claimed during the next upgrade, when rootfs_data is removed and created again.

Fixes: 50f727b7737d1 ("ath79: add support for Linksys EA4500 v3")

This is #14791 cherry-picked atop openwrt-24.10.