### PR TITLE
base-files: Remove pkg_check when using apk

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -251,6 +251,7 @@ ifneq ($(CONFIG_USE_APK),)
 	$(VERSION_SED_SCRIPT) $(1)/etc/apk/repositories
 
 	rm -f $(1)/etc/uci-defaults/13_fix-group-user
+	rm -f $(1)/sbin/pkg_check
 else
 	$(if $(CONFIG_CLEAN_IPKG),, \
 		mkdir -p $(1)/etc/opkg; \


### PR DESCRIPTION
/sbin/pkg_check uses opkg and is not even packaged when using the default opkg configuration. remove it when using apk too.
