### PR TITLE
build: add comments to makefiles

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -21,6 +21,11 @@ include $(INCLUDE_DIR)/rootfs.mk
 override MAKE:=$(_SINGLE)$(SUBMAKE)
 override NO_TRACE_MAKE:=$(_SINGLE)$(NO_TRACE_MAKE)
 
+##@
+# @brief Convert size with unit postfix to unitless expression in bytes.
+#
+# @param 1: Size with unit. Possible unit postfix are `g`, `m`, `k`.
+##
 exp_units = $(subst k, * 1024,$(subst m, * 1024k,$(subst g, * 1024m,$(1))))
 
 target_params = $(subst +,$(space),$*)
@@ -111,6 +116,12 @@ endef
 
 PROFILE_SANITIZED := $(call tolower,$(subst DEVICE_,,$(subst $(space),-,$(PROFILE))))
 
+##@
+# @brief Call function for each group of arguments.
+#
+# @param 1: List of lists of arguments. Lists are separated by `|`.
+# @param 2: Function to call for list of arguments.
+##
 define split_args
 $(foreach data, \
 	$(subst |,$(space),\
@@ -118,12 +129,24 @@ $(foreach data, \
 	$(call $(2),$(strip $(subst ^,$(space),$(data)))))
 endef
 
+##@
+# @brief Call build function with arguments.
+#
+# @param 1: Function to call. Function name is prepended with `Build/`.
+# @param 2...: Function arguments.
+##
 define build_cmd
 $(if $(Build/$(word 1,$(1))),,$(error Missing Build/$(word 1,$(1))))
 $(call Build/$(word 1,$(1)),$(wordlist 2,$(words $(1)),$(1)))
 
 endef
 
+##@
+# @brief Call build functions from the list.
+#
+# @param 1: List of build functions with arguments, separated by `|`.
+#           First word in each group is a build command without `Build/` prefix.
+##
 define concat_cmd
 $(call split_args,$(1),build_cmd)
 endef
@@ -163,6 +186,12 @@ DTC_WARN_FLAGS := \
 DTC_FLAGS += $(DTC_WARN_FLAGS)
 DTCO_FLAGS += $(DTC_WARN_FLAGS)
 
+##@
+# @brief Pad file to specified size.
+#
+# @param 1: File.
+# @param 2: Padding.
+##
 define Image/pad-to
 	dd if=$(1) of=$(1).new bs=$(2) conv=sync
 	mv $(1).new $(1)
@@ -403,26 +432,53 @@ define Device/InitProfile
   DEVICE_DESCRIPTION = Build firmware images for $$(DEVICE_TITLE)
 endef
 
+##@
+# @brief Image configuration variables.
+#
+# @param 1: Device name.
+##
 define Device/Init
+  ##@ Device name.
   DEVICE_NAME := $(1)
+  ##@ Commands to build kernel.
+  # Commands with arguments are separated by `|`.
+  ##
   KERNEL:=
+  ##@ Commands to build initramfs.
+  # Commands with arguments are separated by `|`.
+  ##
   KERNEL_INITRAMFS = $$(KERNEL)
+  ##@ Kernel command line.
   CMDLINE:=
 
+  ##@ Images to build.
   IMAGES :=
+  ##@ Artifacts to build.
   ARTIFACTS :=
+  ##@ Device image prefix.
   DEVICE_IMG_PREFIX := $(IMG_PREFIX)-$(1)
+  ##@ Device image name.
   DEVICE_IMG_NAME = $$(DEVICE_IMG_PREFIX)-$$(1)-$$(2)
+  ##@ Factory image name.
   FACTORY_IMG_NAME :=
+  ##@ Maximum image size. Optional.
   IMAGE_SIZE :=
+  ##@ Maximum image size. Optional.
   NAND_SIZE :=
+  ##@ Kernel image prefix.
   KERNEL_PREFIX = $$(DEVICE_IMG_PREFIX)
+  ##@ Kernel image suffix.
   KERNEL_SUFFIX := -kernel.bin
+  ##@ Initramfs image suffix.
   KERNEL_INITRAMFS_SUFFIX = $$(KERNEL_SUFFIX)
+  ##@ Kernel image name.
   KERNEL_IMAGE = $$(KERNEL_PREFIX)$$(KERNEL_SUFFIX)
+  ##@ Initramfs image prefix.
   KERNEL_INITRAMFS_PREFIX = $$(DEVICE_IMG_PREFIX)-initramfs
   KERNEL_INITRAMFS_IMAGE = $$(KERNEL_INITRAMFS_PREFIX)$$(KERNEL_INITRAMFS_SUFFIX)
+  ##@ Initramfs image name.
   KERNEL_INITRAMFS_NAME = $$(KERNEL_NAME)-initramfs
+  ##@ Kernel install flag.
   KERNEL_INSTALL :=
   KERNEL_NAME := vmlinux
   KERNEL_DEPENDS :=

--- a/include/target.mk
+++ b/include/target.mk
@@ -7,10 +7,17 @@ ifneq ($(__target_inc),1)
 __target_inc=1
 
 
-# default device type
+##@
+# @brief Default device type ( basic | nas | router ).
+##
 DEVICE_TYPE?=router
 
-# Default packages - the really basic set
+##@
+# @brief Default packages.
+#
+# The really basic set. Additional packages are added based on @DEVICE_TYPE and
+# @CONFIG_* values.
+##
 DEFAULT_PACKAGES:=\
 	base-files \
 	ca-bundle \
@@ -27,15 +34,21 @@ DEFAULT_PACKAGES:=\
 	urandom-seed \
 	urngd
 
-# For the basic set
+##@
+# @brief Default packages for @DEVICE_TYPE basic.
+##
 DEFAULT_PACKAGES.basic:=
-# For nas targets
+##@
+# @brief Default packages for @DEVICE_TYPE nas.
+##
 DEFAULT_PACKAGES.nas:=\
 	block-mount \
 	fdisk \
 	lsblk \
 	mdadm
-# For router targets
+##@
+# @brief Default packages for @DEVICE_TYPE router.
+##
 DEFAULT_PACKAGES.router:=\
 	dnsmasq \
 	firewall4 \
@@ -85,7 +98,18 @@ endif
 # Add device specific packages (here below to allow device type set from subtarget)
 DEFAULT_PACKAGES += $(DEFAULT_PACKAGES.$(DEVICE_TYPE))
 
+##@
+# @brief Filter out packages, prepended with `-`.
+#
+# @param 1: Package list.
+##
 filter_packages = $(filter-out -% $(patsubst -%,%,$(filter -%,$(1))),$(1))
+
+##@
+# @brief Append extra package dependencies.
+#
+# @param 1: Package list.
+##
 extra_packages = $(if $(filter wpad wpad-% nas,$(1)),iwinfo)
 
 define ProfileDefault


### PR DESCRIPTION
Add comments to build system makefile functions and variables to help developers in understanding build system internals and ease the development process.

This patch adds some documentation examples with proposed doxygen-like syntax. Hopefully, this would start the discussion and result in generation of the makefile documentation guidelines.
