### PR TITLE
Dnsmasq: shared folder dnsmasq.d

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -11,8 +11,8 @@ ADD_LOCAL_HOSTNAME=1
 ADD_WAN_FQDN=0
 ADD_LOCAL_FQDN=""
 
+COMMONCONFDIR="/tmp/dnsmasq.d"
 BASECONFIGFILE="/var/etc/dnsmasq.conf"
-EXTRACONFFILE="extraconfig.conf"
 BASEHOSTFILE="/tmp/hosts/dhcp"
 TRUSTANCHORSFILE="/usr/share/dnsmasq/trust-anchors.conf"
 TIMEVALIDFILE="/var/state/dnsmasqsec"
@@ -1144,21 +1144,42 @@ dnsmasq_start()
 
 	xappend "--dhcp-broadcast=tag:needs-broadcast"
 
+	# Set up daemon config paths
+	[ ! -d "$COMMONCONFDIR" ] && mkdir -p "$COMMONCONFDIR"
 
-	# Create a dnsmasq.d dir for each instance
-	config_get dnsmasqconfdir "$cfg" confdir "/tmp/dnsmasq${cfg:+.$cfg}.d"
-	# Ensure dnsmasqconfdir is an absolute path
-	[ "${dnsmasqconfdir:0:1}" = '/' ] && {
-		xappend "--conf-dir=$dnsmasqconfdir"
-		dnsmasqconfdir="${dnsmasqconfdir%%,*}"
-		[ ! -d "$dnsmasqconfdir" ] && mkdir -p "$dnsmasqconfdir"
+	# Add common/shared --conf-dir (it can be used only once)
+	# ,* signals dnsmasq to glob every file in the path
+	xappend "--conf-dir=$COMMONCONFDIR,*"
+
+	# Per-instance configuration directory
+	config_get _instanceconfdir "$cfg" confdir "/tmp/dnsmasq${cfg:+.$cfg}.d,*"
+
+	# in case mask suffix was also provided
+	[ "$_instanceconfdir" != "${_instanceconfdir%%,*}" ] && {
+		_mask="${_instanceconfdir##*,}"
+		_instanceconfdir="${_instanceconfdir%%,*}"
+	}
+	# Set default file mask to *
+	_mask="${_mask:-*}"
+
+	# Ensure _instanceconfdir is an absolute path
+	[ "${_instanceconfdir:0:1}" = '/' ] && {
+		[ ! -d "$_instanceconfdir" ] && mkdir -p "$_instanceconfdir"
+
 		xappend "--user=dnsmasq"
 		xappend "--group=dnsmasq"
 		echo >> "$CONFIGFILE_TMP"
 
-		# EXTRACONFFILE allows new dnsmasq parameters before they are natively handled in this init file
+		# Instance-specific conf file
+		instance_conf_file="$_instanceconfdir/${cfg}.conf"
 		config_get extraconftext "$cfg" extraconftext
-		[ -n "$extraconftext" ] && echo -e "$extraconftext" > "$dnsmasqconfdir"/"$EXTRACONFFILE"
+		[ -n "$extraconftext" ] && echo -e "$extraconftext" > "$instance_conf_file"
+
+		# Add each instance path file individually (later, jail only the folder)
+		for conf in "$_instanceconfdir"/$_mask ; do
+			[ -f "$conf" ] || continue
+			xappend "--conf-file=$conf"
+		done
 	}
 
 	config_get_bool enable_tftp "$cfg" enable_tftp 0
@@ -1254,7 +1275,8 @@ dnsmasq_start()
 	procd_add_jail dnsmasq ubus log
 	procd_add_jail_mount "$CONFIGFILE" "$DHCPBOGUSHOSTNAMEFILE" "$DHCPSCRIPT" "$DHCPSCRIPT_DEPENDS"
 	procd_add_jail_mount "$EXTRA_MOUNT" "$RFC6761FILE" "$TRUSTANCHORSFILE"
-	procd_add_jail_mount "$dnsmasqconffile" "$dnsmasqinstanceconfdir" "$resolvdir" "$user_dhcpscript"
+	procd_add_jail_mount "$COMMONCONFDIR"
+	procd_add_jail_mount "$dnsmasqconffile" "$_instanceconfdir" "$resolvdir" "$user_dhcpscript"
 	procd_add_jail_mount /etc/passwd /etc/group /etc/TZ /etc/hosts /etc/ethers
 	procd_add_jail_mount_rw /var/run/dnsmasq/ "$leasefile"
 	case "$logfacility" in */*)

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1164,7 +1164,7 @@ dnsmasq_start()
 	config_get_bool enable_tftp "$cfg" enable_tftp 0
 	[ "$enable_tftp" -gt 0 ] && {
 		config_get tftp_root "$cfg" tftp_root
-		append EXTRA_MOUNT $tftp_root
+		append EXTRA_MOUNT "$tftp_root"
 	}
 
 	config_foreach filter_dnsmasq host dhcp_host_add "$cfg"
@@ -1241,8 +1241,8 @@ dnsmasq_start()
 	config_list_foreach "$cfg" addnmount append_extramount
 
 	procd_open_instance $cfg
-	procd_set_param command $PROG -C $CONFIGFILE -k -x /var/run/dnsmasq/dnsmasq."${cfg}".pid
-	procd_set_param file $CONFIGFILE
+	procd_set_param command $PROG -C "$CONFIGFILE" -k -x /var/run/dnsmasq/dnsmasq."${cfg}".pid
+	procd_set_param file "$CONFIGFILE"
 	[ -n "$user_dhcpscript" ] && procd_set_param env USER_DHCPSCRIPT="$user_dhcpscript"
 	procd_set_param respawn
 
@@ -1252,16 +1252,16 @@ dnsmasq_start()
 		[ -n "$instance_netdev" ] && procd_set_param netdev $instance_netdev
 
 	procd_add_jail dnsmasq ubus log
-	procd_add_jail_mount $CONFIGFILE $DHCPBOGUSHOSTNAMEFILE $DHCPSCRIPT $DHCPSCRIPT_DEPENDS
-	procd_add_jail_mount $EXTRA_MOUNT $RFC6761FILE $TRUSTANCHORSFILE
-	procd_add_jail_mount $dnsmasqconffile $dnsmasqconfdir $resolvdir $user_dhcpscript
+	procd_add_jail_mount "$CONFIGFILE" "$DHCPBOGUSHOSTNAMEFILE" "$DHCPSCRIPT" "$DHCPSCRIPT_DEPENDS"
+	procd_add_jail_mount "$EXTRA_MOUNT" "$RFC6761FILE" "$TRUSTANCHORSFILE"
+	procd_add_jail_mount "$dnsmasqconffile" "$dnsmasqinstanceconfdir" "$resolvdir" "$user_dhcpscript"
 	procd_add_jail_mount /etc/passwd /etc/group /etc/TZ /etc/hosts /etc/ethers
-	procd_add_jail_mount_rw /var/run/dnsmasq/ $leasefile
+	procd_add_jail_mount_rw /var/run/dnsmasq/ "$leasefile"
 	case "$logfacility" in */*)
 		[ ! -e "$logfacility" ] && touch "$logfacility"
 		procd_add_jail_mount_rw "$logfacility"
 	esac
-	[ -e "$hostsfile" ] && procd_add_jail_mount $hostsfile
+	[ -e "$hostsfile" ] && procd_add_jail_mount "$hostsfile"
 
 	procd_close_instance
 }


### PR DESCRIPTION
This PR simplifies a common folder between all dnsmasq instances (via a single `--conf-dir`), so common config elements can be applied across all instances. Each instance still gets its own folder, where the init script parses each file found therein for inclusion via `--conf-file`. `--conf-file` can be used multiple times (giving the effect of another `--conf-dir` parameter, which can only be used once by dnsmasq).

Example:

dnsmasq main instance:
```
--conf-dir /tmp/dnsmasq.d
--conf-file /tmp/dnsmasq.cfg0011.d/extraconf.conf
```

dnsmasq named instances:
```
--conf-dir /tmp/dnsmasq.d
--conf-file /tmp/dnsmasq.namedinstance.d/extraconf.conf
```

The glob masks for specifying config files in instance folders are also handled. It also quotes some variables which potentially contain spaces.

Obsoletes / supersedes #16806

@stangri please test

ping @pprindeville for a solid shell review.