### PR TITLE
dnsmasq: fix potential lease file cross-contamination

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1041,7 +1041,9 @@ dnsmasq_start()
 	fi
 	config_list_foreach "$cfg" "addnhosts" append_addnhosts
 	config_list_foreach "$cfg" "bogusnxdomain" append_bogusnxdomain
-	append_parm "$cfg" "leasefile" "--dhcp-leasefile" "/tmp/dhcp.leases"
+	append_parm "$cfg" "leasefile" "--dhcp-leasefile" "/tmp/dhcp.$cfg.leases"
+	config_get leasefile $cfg leasefile "/tmp/dhcp.$cfg.leases"
+	[ -n "$leasefile" ] && [ ! -e "$leasefile" ] && touch "$leasefile"
 
 	local serversfile
 	config_get serversfile "$cfg" "serversfile"
@@ -1077,8 +1079,6 @@ dnsmasq_start()
 		xappend "--script-arp"
 	fi
 
-	config_get leasefile $cfg leasefile "/tmp/dhcp.leases"
-	[ -n "$leasefile" ] && [ ! -e "$leasefile" ] && touch "$leasefile"
 	config_get_bool cachelocal "$cfg" cachelocal 1
 
 	config_get_bool noresolv "$cfg" noresolv 0


### PR DESCRIPTION
Fixes potential cross-contamination when multiple dnsmasq instances all use the same lease file.

Tested on 24.snapshot