### PR TITLE
[24.10] ramips: Adjust partition layout on Edgerouter-X to allow for kernels up to 6MB

### DIFF
--- a/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dtsi
+++ b/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dtsi
@@ -100,13 +100,8 @@
 		};
 
 		partition@140000 {
-			label = "kernel1";
-			reg = <0x140000 0x300000>;
-		};
-
-		partition@440000 {
-			label = "kernel2";
-			reg = <0x440000 0x300000>;
+			label = "kernel";
+			reg = <0x140000 0x600000>;
 		};
 
 		partition@740000 {

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -229,30 +229,6 @@ define Build/belkin-header
 	mv $@.new $@
 endef
 
-define Build/ubnt-erx-factory-image
-	if [ -e $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) -a "$$(stat -c%s $@)" -lt "$(KERNEL_SIZE)" ]; then \
-		echo '21001:7' > $(1).compat; \
-		$(TAR) -cf $(1) --transform='s/^.*/compat/' $(1).compat; \
-		\
-		$(TAR) -rf $(1) --transform='s/^.*/vmlinux.tmp/' $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE); \
-		$(MKHASH) md5 $(KDIR)/tmp/$(KERNEL_INITRAMFS_IMAGE) > $(1).md5; \
-		$(TAR) -rf $(1) --transform='s/^.*/vmlinux.tmp.md5/' $(1).md5; \
-		\
-		echo "dummy" > $(1).rootfs; \
-		$(TAR) -rf $(1) --transform='s/^.*/squashfs.tmp/' $(1).rootfs; \
-		\
-		$(MKHASH) md5 $(1).rootfs > $(1).md5; \
-		$(TAR) -rf $(1) --transform='s/^.*/squashfs.tmp.md5/' $(1).md5; \
-		\
-		echo '$(BOARD) $(VERSION_CODE) $(VERSION_NUMBER)' > $(1).version; \
-		$(TAR) -rf $(1) --transform='s/^.*/version.tmp/' $(1).version; \
-		\
-		$(CP) $(1) $(BIN_DIR)/; \
-	else \
-		echo "WARNING: initramfs kernel image too big, cannot generate factory image (actual $$(stat -c%s $@); max $(KERNEL_SIZE))" >&2; \
-	fi
-endef
-
 define Build/zytrx-header
 	$(eval board=$(word 1,$(1)))
 	$(eval version=$(word 2,$(1)))
@@ -2861,8 +2837,6 @@ define Device/ubnt_edgerouter_common
   IMAGE_SIZE := 256768k
   FILESYSTEMS := squashfs
   KERNEL_SIZE := 6144k
-  KERNEL_INITRAMFS := $$(KERNEL) | \
-	ubnt-erx-factory-image $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.tar
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   DEVICE_PACKAGES += -wpad-basic-mbedtls -uboot-envtools
   DEVICE_COMPAT_VERSION := 2.0

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2865,6 +2865,10 @@ define Device/ubnt_edgerouter_common
 	ubnt-erx-factory-image $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.tar
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   DEVICE_PACKAGES += -wpad-basic-mbedtls -uboot-envtools
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE :=  Partition table has been changed due to kernel size restrictions. \
+    Refer to the wiki page for instructions to migrate to the new layout: \
+    https://openwrt.org/toh/ubiquiti/edgerouter_x_er-x_ka
   DEFAULT := n
 endef
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2860,7 +2860,7 @@ define Device/ubnt_edgerouter_common
   DEVICE_VENDOR := Ubiquiti
   IMAGE_SIZE := 256768k
   FILESYSTEMS := squashfs
-  KERNEL_SIZE := 3145728
+  KERNEL_SIZE := 6144k
   KERNEL_INITRAMFS := $$(KERNEL) | \
 	ubnt-erx-factory-image $(KDIR)/tmp/$$(KERNEL_INITRAMFS_PREFIX)-factory.tar
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2869,7 +2869,6 @@ define Device/ubnt_edgerouter_common
   DEVICE_COMPAT_MESSAGE :=  Partition table has been changed due to kernel size restrictions. \
     Refer to the wiki page for instructions to migrate to the new layout: \
     https://openwrt.org/toh/ubiquiti/edgerouter_x_er-x_ka
-  DEFAULT := n
 endef
 
 define Device/ubnt_edgerouter-x

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2834,7 +2834,7 @@ define Device/ubnt_edgerouter_common
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := Ubiquiti
-  IMAGE_SIZE := 256768k
+  IMAGE_SIZE := 259840k
   FILESYSTEMS := squashfs
   KERNEL_SIZE := 6144k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
@@ -8,6 +8,8 @@
 board_config_update
 
 case "$(board_name)" in
+	ubnt,edgerouter-x|\
+	ubnt,edgerouter-x-sfp|\
 	iptime,ax2004m)
 		ucidef_set_compat_version "2.0"
 		;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/ubnt.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/ubnt.sh
@@ -8,32 +8,16 @@
 
 UBNT_ERX_KERNEL_INDEX_OFFSET=160
 
-ubnt_get_target_kernel() {
+ubnt_update_kernel_flag() {
 	local factory_mtd=$1
-	local current_kernel_index=$(hexdump -s $UBNT_ERX_KERNEL_INDEX_OFFSET -n 1 -e '/1 "%X "' ${factory_mtd})
+	local kernel_index=$(hexdump -s $UBNT_ERX_KERNEL_INDEX_OFFSET -n 1 -e '/1 "%X "' ${factory_mtd})
 
-	if [ $current_kernel_index == "0" ]; then
-		echo 'kernel2'
-	elif [ $current_kernel_index == "1" ]; then
-		echo 'kernel1'
-	fi
-}
-
-ubnt_update_target_kernel() {
-	local factory_mtd=$1
-	local kernel_part=$2
-
-	local new_kernel_index
-	if [ $kernel_part == "kernel1" ]; then
-		new_kernel_index="\x00"
-	elif [ $kernel_part == "kernel2" ]; then
-		new_kernel_index="\x01"
-	else
-		echo 'Unknown kernel image index' >&2
-		return 1
+	if [ $kernel_index = "0" ]; then
+		echo "Kernel flag already set to kernel slot 1"
+		return 0
 	fi
 
-	if ! (echo -e $new_kernel_index | dd of=${factory_mtd} bs=1 count=1 seek=$UBNT_ERX_KERNEL_INDEX_OFFSET); then
+	if ! (echo -e "\x00" | dd of=${factory_mtd} bs=1 count=1 seek=$UBNT_ERX_KERNEL_INDEX_OFFSET); then
 		echo 'Failed to update kernel bootup index' >&2
 		return 1
 	fi
@@ -45,15 +29,6 @@ platform_upgrade_ubnt_erx() {
 		echo "cannot find factory partition" >&2
 		exit 1
 	fi
-
-	local kernel_part="$(ubnt_get_target_kernel ${factory_mtd})"
-	if [ -z "$kernel_part" ]; then
-		echo "cannot find factory partition" >&2
-		exit 1
-	fi
-
-	# This is a global defined in nand.sh, sets partition kernel will be flashed into
-	CI_KERNPART=${kernel_part}
 
 	#Remove volume possibly left over from stock firmware
 	local ubidev="$( nand_find_ubi "$CI_UBIPART" )"
@@ -72,7 +47,7 @@ platform_upgrade_ubnt_erx() {
 		[ -n "$troot_ubivol" ] && ubirmvol /dev/$ubidev -N troot || true
 	fi
 
-	ubnt_update_target_kernel ${factory_mtd} ${kernel_part} || exit 1
+	ubnt_update_kernel_flag ${factory_mtd} || exit 1
 
 	nand_do_upgrade "$1"
 }


### PR DESCRIPTION
Cherry-picked from `main` for backport to 24.10. From PR #15194.

---

The OEM layout on the Edgerouter X has two kernel slots that are 3MB each. Starting with Linux 6.1 the kernel images no longer fit into this layout. Currently the Edgerouter-X image builds are disabled due to this issue.

This PR will convert the Edgerouter X to use a single kernel slot that is 6MB, this is achieved with the following changes:

Adjust dts to make kernel1 6MB and drop kernel2 slot
Patch ubnt.sh to always flash to kernel1 slot (Likewise set the flag in factory partition to make sure kernel1 slot is active). This file is specific only to Edgerouter X and X-SFP. U-boot will now always boot from kernel1 slot, there is no failover logic within u-boot itself, that could change this boot setting.
Set compat version to 2.0, to ensure the system has the updated ubnt.sh providing support for the new layout.
I have a second https://github.com/openwrt/openwrt/pull/15197 that provides a migration script, that can hopefully be backported to 23.05, allowing users an easy path to migrate to the new layout.

I have also confirmed there is no issue downgrading back to 23.05 from this updated layout, where it will just go back to toggling kernel slots as per normal.

I have tested on Edgerouter X, however same changes also apply to Edgerouter X-SFP which will work the same.

OEM layout:
```
root@OpenWrt:/proc# cat /proc/mtd 
dev:    size   erasesize  name
mtd0: 00080000 00020000 "u-boot"
mtd1: 00060000 00020000 "u-boot-env"
mtd2: 00060000 00020000 "factory"
mtd3: 00300000 00020000 "kernel1"
mtd4: 00300000 00020000 "kernel2"
mtd5: 0f7c0000 00020000 "ubi"
```


New layout:
```
root@OpenWrt:/# cat /proc/mtd
dev:    size   erasesize  name
mtd0: 00080000 00020000 "u-boot"
mtd1: 00060000 00020000 "u-boot-env"
mtd2: 00060000 00020000 "factory"
mtd3: 00600000 00020000 "kernel"
mtd4: 0f7c0000 00020000 "ubi"
```