### PR TITLE
rampis: rename interfaces on edgerouter-X

### DIFF
--- a/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x-sfp.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x-sfp.dts
@@ -69,7 +69,7 @@
 	ports {
 		port@5 {
 			reg = <5>;
-			label = "eth5";
+			label = "lan5";
 			phy-handle = <&ephy7>;
 			phy-mode = "rgmii-rxid";
 			nvmem-cells = <&macaddr_factory_22 5>;

--- a/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dtsi
+++ b/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dtsi
@@ -29,33 +29,33 @@
 	ports {
 		port@0 {
 			status = "okay";
-			label = "eth0";
+			label = "wan";
 		};
 
 		port@1 {
 			status = "okay";
-			label = "eth1";
+			label = "lan1";
 			nvmem-cells = <&macaddr_factory_22 1>;
 			nvmem-cell-names = "mac-address";
 		};
 
 		port@2 {
 			status = "okay";
-			label = "eth2";
+			label = "lan2";
 			nvmem-cells = <&macaddr_factory_22 2>;
 			nvmem-cell-names = "mac-address";
 		};
 
 		port@3 {
 			status = "okay";
-			label = "eth3";
+			label = "lan3";
 			nvmem-cells = <&macaddr_factory_22 3>;
 			nvmem-cell-names = "mac-address";
 		};
 
 		port@4 {
 			status = "okay";
-			label = "eth4";
+			label = "lan4";
 			nvmem-cells = <&macaddr_factory_22 4>;
 			nvmem-cell-names = "mac-address";
 		};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2840,7 +2840,8 @@ define Device/ubnt_edgerouter_common
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   DEVICE_PACKAGES += -wpad-basic-mbedtls -uboot-envtools
   DEVICE_COMPAT_VERSION := 2.0
-  DEVICE_COMPAT_MESSAGE :=  Partition table has been changed due to kernel size restrictions. \
+  DEVICE_COMPAT_MESSAGE := Network interfaces have been renamed. \
+    Partition table has been changed due to kernel size restrictions. \
     Refer to the wiki page for instructions to migrate to the new layout: \
     https://openwrt.org/toh/ubiquiti/edgerouter_x_er-x_ka
 endef

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -157,11 +157,8 @@ ramips_setup_interfaces()
 	tplink,mr600-v2-eu)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
-	ubnt,edgerouter-x)
-		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4" "eth0"
-		;;
 	ubnt,edgerouter-x-sfp)
-		ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "wan"
 		;;
 	ubnt,usw-flex)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"


### PR DESCRIPTION
With linux-6.6 there is a naming conflict with the eth1 port, when dsa brings up the switch it was already allocated to gmac. As a result eth1 port ends up missing and can't be used.

Rename the ports to lan1-4 and wan, which avoids the name conflict and is more consistent with other ramips targets. Network rules will need to be updated.

I haven't added a compat bump here, as my other PR modifying the Edgerouter-X partition layout bumped to compat 2.0. This was only merged into `main` today.

Fixes: #15643

logs showing error:
```
Thu Jun  6 20:40:48 2024 kern.info kernel: [    3.233498] mt7530-mdio mdio-bus:1f: MT7530 adapts as multi-chip module
Thu Jun  6 20:40:48 2024 kern.info kernel: [    3.273510] mt7530-mdio mdio-bus:1f: configuring for fixed/rgmii link mode
Thu Jun  6 20:40:48 2024 kern.info kernel: [    3.288355] mt7530-mdio mdio-bus:1f: Link is Up - 1Gbps/Full - flow control rx/tx
Thu Jun  6 20:40:48 2024 kern.info kernel: [    3.293786] mt7530-mdio mdio-bus:1f eth1 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7530 PHY] (irq=21)
Thu Jun  6 20:40:48 2024 kern.err kernel: [    3.324660] mtk_soc_eth 1e100000.ethernet eth0: error -17 registering interface eth1
```

