### PR TITLE
tools/libressl: update to 4.0.0

### DIFF
--- a/tools/libressl/Makefile
+++ b/tools/libressl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libressl
-PKG_VERSION:=3.7.3
-PKG_HASH:=7948c856a90c825bd7268b6f85674a8dcd254bae42e221781b24e3f8dc335db3
+PKG_VERSION:=4.0.0
+PKG_HASH:=4d841955f0acc3dfc71d0e3dd35f283af461222350e26843fea9731c0246a1e4
 
 PKG_CPE_ID:=cpe:/a:openbsd:libressl
 

--- a/tools/libressl/patches/010-static.patch
+++ b/tools/libressl/patches/010-static.patch
@@ -1,0 +1,99 @@
+--- a/crypto/ec/ec_kmeth.c
++++ b/crypto/ec/ec_kmeth.c
+@@ -74,12 +74,12 @@ static const EC_KEY_METHOD openssl_ec_ke
+ 	.keygen = ec_key_gen,
+ 	.compute_key = ecdh_compute_key,
+ 
+-	.sign = ecdsa_sign,
+-	.sign_setup = ecdsa_sign_setup,
+-	.sign_sig = ecdsa_sign_sig,
++	.sign = libressl_ecdsa_sign,
++	.sign_setup = libressl_ecdsa_sign_setup,
++	.sign_sig = libressl_ecdsa_sign_sig,
+ 
+-	.verify = ecdsa_verify,
+-	.verify_sig = ecdsa_verify_sig,
++	.verify = libressl_ecdsa_verify,
++	.verify_sig = libressl_ecdsa_verify_sig,
+ };
+ 
+ const EC_KEY_METHOD *default_ec_key_meth = &openssl_ec_key_method;
+--- a/crypto/ec/ec_local.h
++++ b/crypto/ec/ec_local.h
+@@ -342,9 +342,9 @@ struct ec_key_method_st {
+ int ec_key_gen(EC_KEY *eckey);
+ int ecdh_compute_key(unsigned char **out, size_t *out_len,
+     const EC_POINT *pub_key, const EC_KEY *ecdh);
+-int ecdsa_verify(int type, const unsigned char *dgst, int dgst_len,
++int libressl_ecdsa_verify(int type, const unsigned char *dgst, int dgst_len,
+     const unsigned char *sigbuf, int sig_len, EC_KEY *eckey);
+-int ecdsa_verify_sig(const unsigned char *dgst, int dgst_len,
++int libressl_ecdsa_verify_sig(const unsigned char *dgst, int dgst_len,
+     const ECDSA_SIG *sig, EC_KEY *eckey);
+ 
+ /*
+--- a/crypto/ecdsa/ecdsa.c
++++ b/crypto/ecdsa/ecdsa.c
+@@ -217,7 +217,7 @@ ecdsa_prepare_digest(const unsigned char
+ }
+ 
+ int
+-ecdsa_sign(int type, const unsigned char *digest, int digest_len,
++libressl_ecdsa_sign(int type, const unsigned char *digest, int digest_len,
+     unsigned char *signature, unsigned int *signature_len, const BIGNUM *kinv,
+     const BIGNUM *r, EC_KEY *key)
+ {
+@@ -266,7 +266,7 @@ LCRYPTO_ALIAS(ECDSA_sign);
+  */
+ 
+ int
+-ecdsa_sign_setup(EC_KEY *key, BN_CTX *in_ctx, BIGNUM **out_kinv, BIGNUM **out_r)
++libressl_ecdsa_sign_setup(EC_KEY *key, BN_CTX *in_ctx, BIGNUM **out_kinv, BIGNUM **out_r)
+ {
+ 	const EC_GROUP *group;
+ 	EC_POINT *point = NULL;
+@@ -517,7 +517,7 @@ ecdsa_compute_s(BIGNUM **out_s, const BI
+  */
+ 
+ ECDSA_SIG *
+-ecdsa_sign_sig(const unsigned char *digest, int digest_len,
++libressl_ecdsa_sign_sig(const unsigned char *digest, int digest_len,
+     const BIGNUM *in_kinv, const BIGNUM *in_r, EC_KEY *key)
+ {
+ 	BN_CTX *ctx = NULL;
+@@ -600,7 +600,7 @@ ECDSA_do_sign(const unsigned char *diges
+ LCRYPTO_ALIAS(ECDSA_do_sign);
+ 
+ int
+-ecdsa_verify(int type, const unsigned char *digest, int digest_len,
++libressl_ecdsa_verify(int type, const unsigned char *digest, int digest_len,
+     const unsigned char *sigbuf, int sig_len, EC_KEY *key)
+ {
+ 	ECDSA_SIG *s;
+@@ -649,7 +649,7 @@ LCRYPTO_ALIAS(ECDSA_verify);
+  */
+ 
+ int
+-ecdsa_verify_sig(const unsigned char *digest, int digest_len,
++libressl_ecdsa_verify_sig(const unsigned char *digest, int digest_len,
+     const ECDSA_SIG *sig, EC_KEY *key)
+ {
+ 	const EC_GROUP *group;
+--- a/crypto/ecdsa/ecdsa_local.h
++++ b/crypto/ecdsa/ecdsa_local.h
+@@ -68,12 +68,12 @@ struct ECDSA_SIG_st {
+ 	BIGNUM *s;
+ };
+ 
+-int ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *in_ctx, BIGNUM **out_kinv,
++int libressl_ecdsa_sign_setup(EC_KEY *eckey, BN_CTX *in_ctx, BIGNUM **out_kinv,
+     BIGNUM **out_r);
+-int ecdsa_sign(int type, const unsigned char *digest, int digest_len,
++int libressl_ecdsa_sign(int type, const unsigned char *digest, int digest_len,
+     unsigned char *signature, unsigned int *signature_len, const BIGNUM *kinv,
+     const BIGNUM *r, EC_KEY *eckey);
+-ECDSA_SIG *ecdsa_sign_sig(const unsigned char *digest, int digest_len,
++ECDSA_SIG *libressl_ecdsa_sign_sig(const unsigned char *digest, int digest_len,
+     const BIGNUM *in_kinv, const BIGNUM *in_r, EC_KEY *eckey);
+ 
+ __END_HIDDEN_DECLS


### PR DESCRIPTION
Stable version. Odd versions are betas.
