### PR TITLE
wolfssl: Adjust version for apk

### DIFF
--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -8,12 +8,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wolfssl
-PKG_VERSION:=5.7.2-stable
+PKG_VERSION:=5.7.2
+PKG_REAL_VERSION:=$(PKG_VERSION)-stable
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/wolfSSL/wolfssl/archive/v$(PKG_VERSION)
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_REAL_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/wolfSSL/wolfssl/archive/v$(PKG_REAL_VERSION)
 PKG_HASH:=0f2ed82e345b833242705bbc4b08a2a2037a33f7bf9c610efae6464f6b10e305
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_REAL_VERSION)
 
 PKG_FIXUP:=libtool libtool-abiver
 PKG_INSTALL:=1
@@ -40,7 +43,7 @@ PKG_CONFIG_DEPENDS:=\
 	CONFIG_WOLFSSL_HAS_TLSV13 \
 	CONFIG_WOLFSSL_HAS_WPAS
 
-PKG_ABI_VERSION:=$(patsubst %-stable,%,$(PKG_VERSION)).$(call version_abbrev,$(call confvar,$(PKG_CONFIG_DEPENDS)))
+PKG_ABI_VERSION:=$(PKG_VERSION).$(call version_abbrev,$(call confvar,$(PKG_CONFIG_DEPENDS)))
 
 PKG_CONFIG_DEPENDS+=\
 	CONFIG_PACKAGE_libwolfssl-benchmark \


### PR DESCRIPTION
Adjust wolfssl version for apk by removing the "-stable" from the OpenWrt version, although it is still needed for upstream download archive name.
* Define PKG_BUILD_DIR accordingly.
* Utilize new short version to simplify ABI_VERSION calculation.

wolfssl 

Compile tested for mediatek/mt7622 RT3200

Maintainer: @cotequeiroz 
cc @aparcar  (reference to https://github.com/openwrt/openwrt/pull/16767#issuecomment-2466420984 )

APK error from buildbot:
```
ERROR: info field 'version' has invalid value: package version is invalid
ERROR: failed to create package: /builder/shared-workdir/build/sdk/bin/packages/aarch64_generic/base/libwolfssl5.7.2.e624513f-5.7.2-stable-r1.apk: package version is invalid
make[3]: *** [Makefile:255: /builder/shared-workdir/build/sdk/bin/packages/aarch64_generic/base/libwolfssl5.7.2.e624513f-5.7.2-stable-r1.apk] Error 99
```


