### PR TITLE
gdb: Fix for apk by removing backtick from description 

### DIFF
--- a/package/devel/gdb/Makefile
+++ b/package/devel/gdb/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gdb
 PKG_VERSION:=15.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/gdb
@@ -37,7 +37,7 @@ $(call Package/gdb/Default)
 endef
 
 define Package/gdb/description
-GDB, the GNU Project debugger, allows you to see what is going on `inside'
+GDB, the GNU Project debugger, allows you to see what is going on 'inside'
 another program while it executes -- or what another program was doing at the
 moment it crashed.
 endef


### PR DESCRIPTION
@Ansuel @aparcar 

One more core repo package fix case for apk:

Remove backtick from gdb description text, as that seems to be recognized as a shell action by compilation with apk, causing error.

Example from test buildbot:
https://downloads.staging.openwrt.org/snapshots/faillogs/mips_24kc/base/gdb/compile.txt
```
 rstrip.sh: /builder/shared-workdir/build/sdk/build_dir/target-aarch64_generic_musl/gdb-15.2/ipkg-aarch64_generic/gdb/usr/bin/gdb: executable
 bash: -c: line 1: unexpected EOF while looking for matching ``'
 bash: -c: line 2: syntax error: unexpected end of file
 make[3]: *** [Makefile:123: /builder/shared-workdir/build/sdk/bin/packages/aarch64_generic/base/gdb-15.2-r1.apk] Error 2
```

Local compilation:
```
 rstrip.sh: /OpenWrt/aarch64/build_dir/target-aarch64_cortex-a53_musl/gdb-15.2/ipkg-aarch64_cortex-a53/gdb/usr/bin/gdb: executable
 bash: -c: line 1: unexpected EOF while looking for matching ``'
 make[2]: *** [Makefile:123: /OpenWrt/aarch64/bin/packages/aarch64_cortex-a53/base/gdb-15.2-r1.apk] Error 2
```
Fix is compile-tested for mediatek/filogic MT6000. 


Looks like apk is really picky about package description text contents, and the possible shell-action-like contents are more eagerly thought to be for parsing as commands.  E.g. quotes/parenthesis mix, backtick, etc.
