### PR TITLE
Adding support for D-link DAP-1620-A2

### DIFF
--- a/target/linux/ramips/dts/mt7620a_dlink_dap-1620-a2.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dap-1620-a2.dts
@@ -1,0 +1,171 @@
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "dlink,dap-1620-a2", "ralink,mt7620a-soc";
+	model = "D-Link DAP-1620 A2";
+
+	aliases {
+		led-boot = &power_red;
+		led-running = &wifi_low;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_red: power {
+			label = "power:red";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_red: signal_red {
+			label = "wifi:red";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_low: signal_low {
+			label = "wifi:low";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_med: signal_med {
+			label = "wifi:med";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi_high: signal_high {
+			label = "wifi:high";
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "nvram";
+				reg = <0x30000 0x10000>;
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			firmware: partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf", "nd_sd";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &rgmii2_pins &mdio_pins>;
+
+	nvmem-cells = <&macaddr_factory_ffe8>;
+	nvmem-cell-names = "mac-address";
+
+	mediatek,portmap = "wllll";
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy0: ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+		};
+
+		phy1: ethernet-phy@1 {
+			reg = <1>;
+			phy-mode = "rgmii";
+		};
+
+		phy1f: ethernet-phy@1f {
+			reg = <0x1f>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&gsw {
+	mediatek,ephy-base = /bits/ 8 <12>;
+};
+
+&wmac {
+	ralink,mtd-eeprom = <&factory 0x0>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x8000>;
+		mediatek,2ghz = <0>;
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_ffe8: macaddr@ffe8 {
+		reg = <0xffe8 0x11>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -207,6 +207,16 @@ define Device/comfast_cf-wr800n
 endef
 TARGET_DEVICES += comfast_cf-wr800n
 
+define Device/dlink_dap-1620-a2
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DAP-1620
+  IMAGE_SIZE := 7872k
+  DEVICE_VARIANT := A2
+  SOC := mt7620a
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-mt76x2
+endef
+TARGET_DEVICES += dlink_dap-1620-a2
+
 define Device/dlink_dch-m225
   $(Device/seama)
   SOC := mt7620a

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -42,6 +42,7 @@ ramips_setup_interfaces()
 	alfa-network,tube-e4g|\
 	ampedwireless,b1200ex|\
 	buffalo,wmr-300|\
+	dlink,dap-1620-a2|\
 	dlink,dch-m225|\
 	edimax,ew-7476rpc|\
 	edimax,ew-7478ac|\


### PR DESCRIPTION
Hello,

Adding support for D-Link DAP-1620-A2 device. A bit older device, but nevertheless has a decent hardware (64/8 and both 2.4 & 5). The firmware package needs to be pushed to device through U-Boot serial port and can't be done through Web UI, since the recovery occupies the second part of NAND. Can add the details to the wiki page once the code is merged and compiled. 

Waiting for OpenWrt based compile of image. Anyways added the OpenWrt boot log to the wiki already. Available here:
https://openwrt.org/inbox/toh/d-link/d-link_dap-1620

Any questions, please let me know.

Thanks

