### PR TITLE
spidev_test: fix version for APK

### DIFF
--- a/package/utils/spidev_test/Makefile
+++ b/package/utils/spidev_test/Makefile
@@ -9,7 +9,8 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=spidev-test
-PKG_RELEASE:=$(LINUX_VERSION)
+PKG_VERSION:=$(LINUX_VERSION)
+PKG_RELEASE:=1
 PKG_BUILD_DIR:=$(LINUX_DIR)/tools/spi-$(TARGET_DIR_NAME)
 PKG_BUILD_PARALLEL:=1
 
@@ -20,7 +21,7 @@ define Package/spidev-test
   CATEGORY:=Utilities
   DEPENDS:=+kmod-spi-dev
   TITLE:=SPI testing utility
-  VERSION:=$(LINUX_VERSION)-$(PKG_RELEASE)
+  VERSION:=$(LINUX_VERSION)-r$(PKG_RELEASE)
   URL:=http://www.kernel.org
 endef
 


### PR DESCRIPTION
Refactor version of spidev_test for APK.

Fixes compilation error:
```
make -f /__w/openwrt/openwrt/openwrt/build_dir/target-mips-openwrt-linux-musl_musl/linux-malta_be/linux-6.6.60/tools/build/Makefile.build dir=. obj=spidev_fdx
  CC      spidev_fdx.o
  LD      spidev_fdx-in.o
  LINK    spidev_test
  LINK    spidev_fdx
rstrip.sh: /__w/openwrt/openwrt/openwrt/build_dir/target-mips-openwrt-linux-musl_musl/linux-malta_be/linux-6.6.60/tools/spi-target-mips-openwrt-linux-musl_musl/ipkg-mips_24kc/spidev-test/sbin/spidev_test: executable
ERROR: info field 'version' has invalid value: package version is invalid
ERROR: failed to create package: /__w/openwrt/openwrt/openwrt/bin/packages/mips_24kc/base/spidev-test-6.6.60-6.6.60.apk: package version is invalid
make[3]: *** [Makefile:87: /__w/openwrt/openwrt/openwrt/bin/packages/mips_24kc/base/spidev-test-6.6.60-6.6.60.apk] Error 99
time: package/utils/spidev_test/compile#0.32#0.26#0.61
Error: Process completed with exit code 2.
```

