### PR TITLE
ramips: mt7621: fix typo

### DIFF
--- a/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
@@ -96,7 +96,7 @@
 
 	reg_usb_power: regulator {
 		compatible = "regulator-fixed";
-		reglator-name = "usb_power";
+		regulator-name = "usb_power";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 		gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
Missing u caused the regulator to fail probe.