### PR TITLE
realtek: rtl83xx: use devm for mutex_init

### DIFF
--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/common.c
@@ -1492,7 +1492,9 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 	priv->ds->needs_standalone_vlan_filtering = true;
 	priv->dev = dev;
 
-	mutex_init(&priv->reg_mutex);
+	err = devm_mutex_init(dev, &priv->reg_mutex);
+	if (err)
+		return err;
 
 	priv->family_id = soc_info.family;
 	priv->id = soc_info.id;


### PR DESCRIPTION
mutex_destroy is missing in remove.

ping @robimarko @svanheule 