### PR TITLE
qualcommax: ipq60xx: add NSS reserved memory

### DIFF
--- a/target/linux/qualcommax/patches-6.6/0140-arm64-dts-qcom-ipq6018-add-NSS-reserved-memory.patch
+++ b/target/linux/qualcommax/patches-6.6/0140-arm64-dts-qcom-ipq6018-add-NSS-reserved-memory.patch
@@ -1,0 +1,27 @@
+From 7e102b1eb2ca3eff7a6f33ebeab17825e6f70956 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Mon, 4 Nov 2024 22:01:24 +0100
+Subject: [PATCH] arm64: dts: qcom: ipq6018: add NSS reserved memory
+
+It seems that despite NSS not being supported in OpenWrt the memory it
+usually uses needs to be reserved anyway for stability reasons.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ arch/arm64/boot/dts/qcom/ipq6018.dtsi | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
++++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
+@@ -199,6 +199,11 @@
+ 			no-map;
+ 		};
+ 
++		nss_region: memory@40000000 {
++			reg = <0x0 0x40000000 0x0 0x01000000>;
++			no-map;
++		};
++
+ 		bootloader@4a100000 {
+ 			reg = <0x0 0x4a100000 0x0 0x400000>;
+ 			no-map;

--- a/target/linux/qualcommax/patches-6.6/0906-arm64-dts-qcom-ipq6018-add-wifi-node.patch
+++ b/target/linux/qualcommax/patches-6.6/0906-arm64-dts-qcom-ipq6018-add-wifi-node.patch
@@ -15,7 +15,7 @@ Signed-off-by: Mantas Pucka <mantas@8devices.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
-@@ -809,6 +809,102 @@
+@@ -814,6 +814,102 @@
  			};
  		};
  

--- a/target/linux/qualcommax/patches-6.6/0907-soc-qcom-fix-smp2p-ack-on-ipq6018.patch
+++ b/target/linux/qualcommax/patches-6.6/0907-soc-qcom-fix-smp2p-ack-on-ipq6018.patch
@@ -15,7 +15,7 @@ Signed-off-by: Mantas Pucka <mantas@8devices.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
-@@ -1157,6 +1157,7 @@
+@@ -1162,6 +1162,7 @@
  
  		wcss_smp2p_out: master-kernel {
  			qcom,entry-name = "master-kernel";

--- a/target/linux/qualcommax/patches-6.6/0909-arm64-dts-qcom-ipq6018-assign-QDSS_AT-clock-to-wifi-.patch
+++ b/target/linux/qualcommax/patches-6.6/0909-arm64-dts-qcom-ipq6018-assign-QDSS_AT-clock-to-wifi-.patch
@@ -13,7 +13,7 @@ Signed-off-by: Mantas Pucka <mantas@8devices.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq6018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq6018.dtsi
-@@ -930,8 +930,8 @@
+@@ -935,8 +935,8 @@
  				      "wcss_reset",
  				      "wcss_q6_reset";
  


### PR DESCRIPTION
It seems that despite NSS not being supported in OpenWrt the memory it usually uses needs to be reserved anyway for stability reasons.
