### PR TITLE
perf: fix version for APK

### DIFF
--- a/package/devel/perf/Makefile
+++ b/package/devel/perf/Makefile
@@ -30,7 +30,7 @@ define Package/perf
   DEPENDS:= +libelf +libdw +PACKAGE_libunwind:libunwind +libpthread +librt +objdump @!IN_SDK @KERNEL_PERF_EVENTS \
 	    +PACKAGE_libbfd:libbfd +PACKAGE_libopcodes:libopcodes +libtraceevent
   TITLE:=Linux performance monitoring tool
-  VERSION:=$(LINUX_VERSION)-$(PKG_RELEASE)
+  VERSION:=$(LINUX_VERSION)-r$(PKG_RELEASE)
   URL:=http://www.kernel.org
 endef
 


### PR DESCRIPTION
Change the version schema of perf to be compatible with APK as described in this commit: e8725a932e16eaf6ec51add8c084d959cbe32ff2.