### PR TITLE
apk: align feed/repository handling with opkg

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -250,9 +250,9 @@ endif
 		rm -f $(1)/etc/banner.failsafe,)
 
 ifneq ($(CONFIG_USE_APK),)
-	mkdir -p $(1)/etc/apk/
-	$(call FeedSourcesAppendAPK,$(1)/etc/apk/repositories)
-	$(VERSION_SED_SCRIPT) $(1)/etc/apk/repositories
+	mkdir -p $(1)/etc/apk/repositories.d
+	$(call FeedSourcesAppendAPK,$(1)/etc/apk/repositories.d/distfeeds.list)
+	$(VERSION_SED_SCRIPT) $(1)/etc/apk/repositories.d/distfeeds.list
 
 	rm -f $(1)/etc/uci-defaults/13_fix-group-user
 	rm -f $(1)/sbin/pkg_check

--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -14,7 +14,7 @@ PKG_VERSION=3.0.0_pre$(subst -,,$(PKG_SOURCE_DATE))
 PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=LICENSE
-PKG_INSTALL:=1
+PKG_INSTALL:=2
 
 HOST_BUILD_PREFIX:=$(STAGING_DIR_HOST)
 HOST_BUILD_DEPENDS:=lua/host
@@ -68,6 +68,13 @@ MESON_ARGS += \
 	$(MESON_COMMON_ARGS) \
 	-Dcrypto_backend=$(BUILD_VARIANT)
 
+define Package/apk/conffiles
+/etc/apk/repositories.d/customfeeds.list
+endef
+
+Package/apk-mbedtls/conffiles = $(Package/apk/conffiles)
+Package/apk-openssl/conffiles = $(Package/apk/conffiles)
+
 define Package/apk/default/install
 	$(INSTALL_DIR) $(1)/lib/apk/db
 
@@ -76,6 +83,9 @@ define Package/apk/default/install
 
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libapk.so.* $(1)/usr/lib/
+
+	$(INSTALL_DIR) $(1)/etc/apk/repositories.d
+	$(INSTALL_DATA) ./files/customfeeds.list $(1)/etc/apk/repositories.d/customfeeds.list
 endef
 
 Package/apk-mbedtls/install = $(Package/apk/default/install)

--- a/package/system/apk/files/customfeeds.list
+++ b/package/system/apk/files/customfeeds.list
@@ -1,0 +1,3 @@
+# add your custom package feeds here
+#
+# http://www.example.com/path/to/files/packages.adb


### PR DESCRIPTION
With opkg we split up base/distfeeds and custom package feeds into two files, and only the latter is marked as a configuration file. apk currently does not define any configuration files, and uses a toplevel `/etc/apk/repositories`.

Luckily, apk also supports multiple repository lists, so align it to how we have it with opkg:

- `/etc/apk/repositories.d/distfeeds.list` as the base feeds from/for the image
- `/etc/apk/repositories.d/customfeeds.list` for any user feeds, marked as a configuration file.
