### PR TITLE
treewide: fix coccinelle checks

### DIFF
--- a/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
+++ b/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
@@ -1286,8 +1286,7 @@ IFX_MEI_RunAdslModem (DSL_DEV_Device_t *pDev)
 //	DSL_DEV_WinHost_Message_t m;
 
 	if (mei_arc_swap_buff == NULL) {
-		mei_arc_swap_buff =
-			(u32 *) kmalloc (MAXSWAPSIZE * 4, GFP_KERNEL);
+		mei_arc_swap_buff = kmalloc (MAXSWAPSIZE * 4, GFP_KERNEL);
 		if (mei_arc_swap_buff == NULL) {
 			IFX_MEI_EMSG (">>> malloc fail for codeswap buff!!! <<<\n");
 			return DSL_DEV_MEI_ERR_FAILURE;

--- a/package/kernel/lantiq/ltq-adsl-mei/src/ifxmips_mei_interface.h
+++ b/package/kernel/lantiq/ltq-adsl-mei/src/ifxmips_mei_interface.h
@@ -418,7 +418,7 @@ typedef struct _arc_img_hdr {
 	u32 size;		//      Size of binary image in bytes
 	u32 checksum;		//      Checksum for image
 	u32 count;		//      Count of swp pages in image
-	ARC_SWP_PAGE_HDR page[1];	//      Should be "count" pages - '1' to make compiler happy
+	ARC_SWP_PAGE_HDR page[];	//      Should be "count" pages - '1' to make compiler happy
 } ARC_IMG_HDR;
 
 typedef struct smmu_mem_info {

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_amazon_se.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_amazon_se.c
@@ -224,8 +224,8 @@ static inline int pp32_download_code(u32 *code_src, unsigned int code_dword_len,
 {
     volatile u32 *dest;
 
-    if ( code_src == 0 || ((unsigned long)code_src & 0x03) != 0
-        || data_src == 0 || ((unsigned long)data_src & 0x03) != 0 )
+    if (!code_src || ((unsigned long)code_src & 0x03) != 0
+        || !data_src || ((unsigned long)data_src & 0x03) != 0 )
         return -1;
 
     if ( code_dword_len <= CDM_CODE_MEMORYn_DWLEN(0) )

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_ar9.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_ar9.c
@@ -163,8 +163,8 @@ static inline int pp32_download_code(u32 *code_src, unsigned int code_dword_len,
 {
     volatile u32 *dest;
 
-    if ( code_src == 0 || ((unsigned long)code_src & 0x03) != 0
-        || data_src == 0 || ((unsigned long)data_src & 0x03) != 0 )
+    if (!code_src || ((unsigned long)code_src & 0x03) != 0
+        || !data_src || ((unsigned long)data_src & 0x03) != 0 )
         return -1;
 
     if ( code_dword_len <= CDM_CODE_MEMORYn_DWLEN(0) )

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_danube.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_danube.c
@@ -110,8 +110,8 @@ static inline int danube_pp32_download_code(u32 *code_src, unsigned int code_dwo
 {
 	volatile u32 *dest;
 
-	if ( code_src == 0 || ((unsigned long)code_src & 0x03) != 0
-			|| data_src == 0 || ((unsigned long)data_src & 0x03) != 0 )
+	if (!code_src || ((unsigned long)code_src & 0x03) != 0
+			|| !data_src || ((unsigned long)data_src & 0x03) != 0 )
 		return -1;
 
 	if ( code_dword_len <= CDM_CODE_MEMORYn_DWLEN(0) )

--- a/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_vr9.c
+++ b/package/kernel/lantiq/ltq-atm/src/ifxmips_atm_vr9.c
@@ -96,8 +96,8 @@ static inline int vr9_pp32_download_code(int pp32, u32 *code_src, unsigned int c
 	unsigned int clr, set;
 	volatile u32 *dest;
 
-	if ( code_src == 0 || ((unsigned long)code_src & 0x03) != 0
-			|| data_src == 0 || ((unsigned long)data_src & 0x03) != 0 )
+	if (!code_src || ((unsigned long)code_src & 0x03) != 0
+			|| !data_src || ((unsigned long)data_src & 0x03) != 0 )
 		return -1;
 
 	clr = pp32 ? 0xF0 : 0x0F;

--- a/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
+++ b/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
@@ -1501,17 +1501,10 @@ static inline void clear_priv_data(void)
 		}
 	}
 
-	if ( g_atm_priv_data.tx_skb_base != NULL )
-		kfree(g_atm_priv_data.tx_skb_base);
-
-	if ( g_atm_priv_data.tx_desc_base != NULL )
-		kfree(g_atm_priv_data.tx_desc_base);
-
-	if ( g_atm_priv_data.oam_buf_base != NULL )
-		kfree(g_atm_priv_data.oam_buf_base);
-
-	if ( g_atm_priv_data.oam_desc_base != NULL )
-		kfree(g_atm_priv_data.oam_desc_base);
+	kfree(g_atm_priv_data.tx_skb_base);
+	kfree(g_atm_priv_data.tx_desc_base);
+	kfree(g_atm_priv_data.oam_buf_base);
+	kfree(g_atm_priv_data.oam_desc_base);
 
 	if ( g_atm_priv_data.aal_desc_base != NULL ) {
 		for ( i = 0; i < dma_rx_descriptor_length; i++ ) {
@@ -1520,8 +1513,9 @@ static inline void clear_priv_data(void)
 				dev_kfree_skb_any(skb);
 			}
 		}
-		kfree(g_atm_priv_data.aal_desc_base);
 	}
+
+	kfree(g_atm_priv_data.aal_desc_base);
 }
 
 static inline void init_rx_tables(void)

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_aes.c
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_aes.c
@@ -276,7 +276,7 @@ void ifx_deu_aes (void *ctx_arg, u8 *out_arg, const u8 *in_arg,
         aes->IV2R = DEU_ENDIAN_SWAP(*((u32 *) iv_arg + 1));
         aes->IV1R = DEU_ENDIAN_SWAP(*((u32 *) iv_arg + 2));
         aes->IV0R = DEU_ENDIAN_SWAP(*((u32 *) iv_arg + 3));
-    };
+    }
 
 
     i = 0;
@@ -1529,7 +1529,7 @@ static int aes_cbcmac_init_tfm(struct crypto_tfm *tfm)
 {
     struct aes_ctx *mctx = crypto_tfm_ctx(tfm);
     mctx->temp = kzalloc(AES_BLOCK_SIZE * AES_CBCMAC_DBN_TEMP_SIZE, GFP_KERNEL);
-    if (IS_ERR(mctx->temp)) return PTR_ERR(mctx->temp);
+    if (!mctx->temp) return -ENOMEM;
 
     return 0;
 }

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_async_aes.c
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_async_aes.c
@@ -234,7 +234,7 @@ static int lq_deu_aes_core (void *ctx_arg, u8 *out_arg, const u8 *in_arg,
         aes->IV2R = DEU_ENDIAN_SWAP(*((u32 *) iv_arg + 1));
         aes->IV1R = DEU_ENDIAN_SWAP(*((u32 *) iv_arg + 2));
         aes->IV0R = DEU_ENDIAN_SWAP(*((u32 *) iv_arg + 3));
-    };
+    }
 
 
     /* Prepare Rx buf length used in dma psuedo interrupt */
@@ -251,7 +251,7 @@ static int lq_deu_aes_core (void *ctx_arg, u8 *out_arg, const u8 *in_arg,
 
     while (aes->controlr.BUS) {
          // wait for AES to be ready
-    };
+    }
 
     deu_priv->outcopy = (u32 *) DEU_DWORD_REORDERING(out_arg, aes_buff_out, BUFFER_OUT, nbytes);
     deu_priv->event_src = AES_ASYNC_EVENT;
@@ -577,9 +577,7 @@ static int lq_aes_queue_mgr(struct aes_ctx *ctx, struct ablkcipher_request *areq
     u32 chunk_bytes = src->length;
     
  
-    aes_con = (struct aes_container *)kmalloc(sizeof(struct aes_container),
-    	                                       GFP_KERNEL);
-
+    aes_con = kmalloc(sizeof(struct aes_container), GFP_KERNEL);
     if (!(aes_con)) {
         printk("Cannot allocate memory for AES container, fn %s, ln %d\n",
 		__func__, __LINE__);

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_async_des.c
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_async_des.c
@@ -254,7 +254,7 @@ static int lq_deu_des_core (void *ctx_arg, u8 *out_arg, const u8 *in_arg,
         if (mode > 0) {
                 des->IVHR = DEU_ENDIAN_SWAP(*(u32 *) iv_arg);
                 des->IVLR = DEU_ENDIAN_SWAP(*((u32 *) iv_arg + 1));
-        };
+        }
 
     /* memory alignment issue */
     dword_mem_aligned_in = (u32 *) DEU_DWORD_REORDERING(in_arg, des_buff_in, BUFFER_IN, nbytes);
@@ -268,7 +268,7 @@ static int lq_deu_des_core (void *ctx_arg, u8 *out_arg, const u8 *in_arg,
     dma->controlr.EN = 1;
 
     while (des->controlr.BUS) {
-    };
+    }
 
     wlen = dma_device_write (dma_device, (u8 *) dword_mem_aligned_in, nbytes, NULL);
     if (wlen != nbytes) {
@@ -287,7 +287,7 @@ static int lq_deu_des_core (void *ctx_arg, u8 *out_arg, const u8 *in_arg,
     if (mode > 0) {
         *(u32 *) iv_arg = DEU_ENDIAN_SWAP(des->IVHR);
         *((u32 *) iv_arg + 1) = DEU_ENDIAN_SWAP(des->IVLR);
-    };
+    }
 
     CRTCL_SECT_END; 
 
@@ -578,9 +578,7 @@ static int lq_queue_mgr(struct des_ctx *ctx, struct ablkcipher_request *areq,
     u32 remain, inc, nbytes = areq->nbytes;
     u32 chunk_bytes = src->length;
    
-    des_con = (struct des_container *)kmalloc(sizeof(struct des_container), 
-                                       GFP_KERNEL);
-
+    des_con = kmalloc(sizeof(struct des_container), GFP_KERNEL);
     if (!(des_con)) {
         printk("Cannot allocate memory for AES container, fn %s, ln %d\n",
                 __func__, __LINE__);

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_des.c
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_des.c
@@ -229,7 +229,7 @@ void ifx_deu_des (void *ctx_arg, u8 *out_arg, const u8 *in_arg,
         if (mode > 0) {
                 des->IVHR = DEU_ENDIAN_SWAP(*(u32 *) iv_arg);
                 des->IVLR = DEU_ENDIAN_SWAP(*((u32 *) iv_arg + 1));
-        };
+        }
 
         nblocks = nbytes / 4;
 
@@ -260,7 +260,7 @@ void ifx_deu_des (void *ctx_arg, u8 *out_arg, const u8 *in_arg,
     if (mode > 0) {
         *(u32 *) iv_arg = DEU_ENDIAN_SWAP(des->IVHR);
         *((u32 *) iv_arg + 1) = DEU_ENDIAN_SWAP(des->IVLR);
-    };
+    }
 
     CRTCL_SECT_END;
 }

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_deu_ar9.h
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_deu_ar9.h
@@ -87,8 +87,8 @@
         volatile struct aes_t *aes = (volatile struct aes_t *) AES_START; \
         for (i = 0; i < 10; i++)      \
 	    udelay(DELAY_PERIOD);     \
-        while (dma->controlr.BSY) {}; \
-        while (aes->controlr.BUS) {}; \
+        while (dma->controlr.BSY) {}  \
+        while (aes->controlr.BUS) {}  \
     } while (0)
 
 #define WAIT_DES_DMA_READY()          \
@@ -98,8 +98,8 @@
         volatile struct des_t *des = (struct des_t *) DES_3DES_START; \
         for (i = 0; i < 10; i++)      \
             udelay(DELAY_PERIOD);     \
-        while (dma->controlr.BSY) {}; \
-        while (des->controlr.BUS) {}; \
+        while (dma->controlr.BSY) {}  \
+        while (des->controlr.BUS) {}  \
     } while (0)
 
 #define AES_DMA_MISC_CONFIG()        \

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_deu_danube.h
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_deu_danube.h
@@ -81,8 +81,8 @@
         volatile struct aes_t *aes = (volatile struct aes_t *) AES_START; \
         for (i = 0; i < 10; i++)      \
             udelay(DELAY_PERIOD);     \
-        while (dma->controlr.BSY) {}; \
-        while (aes->controlr.BUS) {}; \
+        while (dma->controlr.BSY) {}  \
+        while (aes->controlr.BUS) {}  \
     } while (0)
 
 #define WAIT_DES_DMA_READY()          \
@@ -92,8 +92,8 @@
         volatile struct des_t *des = (struct des_t *) DES_3DES_START; \
         for (i = 0; i < 10; i++)      \
             udelay(DELAY_PERIOD);     \
-        while (dma->controlr.BSY) {}; \
-        while (des->controlr.BUS) {}; \
+        while (dma->controlr.BSY) {}  \
+        while (des->controlr.BUS) {}  \
     } while (0)     
 
 #define SHA_HASH_INIT                  \

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_deu_vr9.h
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_deu_vr9.h
@@ -102,8 +102,8 @@
         volatile struct aes_t *aes = (volatile struct aes_t *) AES_START; \
         for (i = 0; i < 10; i++)      \
             udelay(DELAY_PERIOD);     \
-        while (dma->controlr.BSY) {}; \
-        while (aes->controlr.BUS) {}; \
+        while (dma->controlr.BSY) {}  \
+        while (aes->controlr.BUS) {}  \
     } while (0)
 
 #define WAIT_DES_DMA_READY()          \
@@ -113,8 +113,8 @@
         volatile struct des_t *des = (struct des_t *) DES_3DES_START; \
         for (i = 0; i < 10; i++)      \
             udelay(DELAY_PERIOD);     \
-        while (dma->controlr.BSY) {}; \
-        while (des->controlr.BUS) {}; \
+        while (dma->controlr.BSY) {}  \
+        while (des->controlr.BUS) {}  \
     } while (0)
 
 #define AES_DMA_MISC_CONFIG()        \

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_md5.c
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_md5.c
@@ -107,7 +107,7 @@ static void md5_transform(struct md5_ctx *mctx, u32 *hash, u32 const *in)
     for (i = 0; i < 16; i++) {
         hashs->MR = in[i];
 //      printk("in[%d]: %08x\n", i, in[i]);
-    };
+    }
 
     //wait for processing
     while (hashs->controlr.BSY) {

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_md5_hmac.c
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_md5_hmac.c
@@ -308,7 +308,7 @@ static int md5_hmac_final_impl(struct shash_desc *desc, u8 *out, bool hash_final
     {
         for (i = 0; i < 16; i++) {
             hashs->MR = in[i];
-        };
+        }
 
         hashs->controlr.GO = 1;
         asm("sync");
@@ -355,9 +355,9 @@ static int md5_hmac_init_tfm(struct crypto_tfm *tfm)
 {
     struct md5_hmac_ctx *mctx = crypto_tfm_ctx(tfm);
     mctx->temp = kzalloc(4 * MD5_HMAC_DBN_TEMP_SIZE, GFP_KERNEL);
-    if (IS_ERR(mctx->temp)) return PTR_ERR(mctx->temp);
+    if (!mctx->temp) return -ENOMEM;
     mctx->desc = kzalloc(sizeof(struct shash_desc), GFP_KERNEL);
-    if (IS_ERR(mctx->desc)) return PTR_ERR(mctx->desc);
+    if (!mctx->desc) return -ENOMEM;
 
     return 0;
 }

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_sha1.c
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_sha1.c
@@ -119,7 +119,7 @@ static void sha1_transform1 (struct sha1_ctx *sctx, u32 *state, const u32 *in)
 
     for (i = 0; i < 16; i++) {
         hashs->MR = in[i];
-    };
+    }
 
     //wait for processing
     while (hashs->controlr.BSY) {

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_sha1_hmac.c
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_sha1_hmac.c
@@ -325,7 +325,7 @@ static int sha1_hmac_final_impl(struct shash_desc *desc, u8 *out, bool hash_fina
     {
         for (i = 0; i < 16; i++) {
             hashs->MR = in[i];
-        };
+        }
 
         hashs->controlr.GO = 1;
         asm("sync");
@@ -376,9 +376,9 @@ static int sha1_hmac_init_tfm(struct crypto_tfm *tfm)
 {
     struct sha1_hmac_ctx *sctx = crypto_tfm_ctx(tfm);
     sctx->temp = kzalloc(4 * SHA1_HMAC_DBN_TEMP_SIZE, GFP_KERNEL);
-    if (IS_ERR(sctx->temp)) return PTR_ERR(sctx->temp);
+    if (!sctx->temp) return -ENOMEM;
     sctx->desc = kzalloc(sizeof(struct shash_desc), GFP_KERNEL);
-    if (IS_ERR(sctx->desc)) return PTR_ERR(sctx->desc);
+    if (!sctx->desc) return -ENOMEM;
 
     return 0;
 }

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
@@ -1320,14 +1320,9 @@ static INLINE void clear_priv_data(void)
         }
     }
 
-    if ( g_ptm_priv_data.rx_desc_base != NULL )
-        kfree(g_ptm_priv_data.rx_desc_base);
-
-    if ( g_ptm_priv_data.tx_desc_base != NULL )
-        kfree(g_ptm_priv_data.tx_desc_base);
-
-    if ( g_ptm_priv_data.tx_skb_base != NULL )
-        kfree(g_ptm_priv_data.tx_skb_base);
+    kfree(g_ptm_priv_data.rx_desc_base);
+    kfree(g_ptm_priv_data.tx_desc_base);
+    kfree(g_ptm_priv_data.tx_skb_base);
 }
 
 static INLINE void init_tables(void)

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_amazon_se.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_amazon_se.c
@@ -223,8 +223,8 @@ static inline int pp32_download_code(u32 *code_src, unsigned int code_dword_len,
 {
     volatile u32 *dest;
 
-    if ( code_src == 0 || ((unsigned long)code_src & 0x03) != 0
-        || data_src == 0 || ((unsigned long)data_src & 0x03) != 0 )
+    if (!code_src || ((unsigned long)code_src & 0x03) != 0
+        || !data_src || ((unsigned long)data_src & 0x03) != 0 )
         return -1;
 
     if ( code_dword_len <= CDM_CODE_MEMORYn_DWLEN(0) )

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_ar9.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_ar9.c
@@ -246,8 +246,8 @@ static inline int pp32_download_code(u32 *code_src, unsigned int code_dword_len,
 {
     volatile u32 *dest;
 
-    if ( code_src == 0 || ((unsigned long)code_src & 0x03) != 0
-        || data_src == 0 || ((unsigned long)data_src & 0x03) != 0 )
+    if (!code_src || ((unsigned long)code_src & 0x03) != 0
+        || !data_src || ((unsigned long)data_src & 0x03) != 0 )
         return -1;
 
     if ( code_dword_len <= CDM_CODE_MEMORYn_DWLEN(0) )

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_danube.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_danube.c
@@ -218,8 +218,8 @@ static inline int pp32_download_code(u32 *code_src, unsigned int code_dword_len,
 {
     volatile u32 *dest;
 
-    if ( code_src == 0 || ((unsigned long)code_src & 0x03) != 0
-        || data_src == 0 || ((unsigned long)data_src & 0x03) != 0 )
+    if (!code_src || ((unsigned long)code_src & 0x03) != 0
+        || !data_src || ((unsigned long)data_src & 0x03) != 0 )
         return -1;
 
     if ( code_dword_len <= CDM_CODE_MEMORYn_DWLEN(0) )

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
@@ -408,7 +408,7 @@ static int ptm_ioctl(struct net_device *dev, struct ifreq *ifr, void __user *dat
 	//  use bear channel 0 preemption gamma interface settings
         ((IFX_PTM_CFG_T *)data)->RxEthCrcPresent = 1;
         ((IFX_PTM_CFG_T *)data)->RxEthCrcCheck   = RX_GAMMA_ITF_CFG(0)->rx_eth_fcs_ver_dis == 0 ? 1 : 0;
-        ((IFX_PTM_CFG_T *)data)->RxTcCrcCheck    = RX_GAMMA_ITF_CFG(0)->rx_tc_crc_ver_dis == 0 ? 1 : 0;;
+        ((IFX_PTM_CFG_T *)data)->RxTcCrcCheck    = RX_GAMMA_ITF_CFG(0)->rx_tc_crc_ver_dis == 0 ? 1 : 0;
         ((IFX_PTM_CFG_T *)data)->RxTcCrcLen      = RX_GAMMA_ITF_CFG(0)->rx_tc_crc_size == 0 ? 0 : (RX_GAMMA_ITF_CFG(0)->rx_tc_crc_size * 16);
         ((IFX_PTM_CFG_T *)data)->TxEthCrcGen     = TX_GAMMA_ITF_CFG(0)->tx_eth_fcs_gen_dis == 0 ? 1 : 0;
         ((IFX_PTM_CFG_T *)data)->TxTcCrcGen      = TX_GAMMA_ITF_CFG(0)->tx_tc_crc_size == 0 ? 0 : 1;

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vr9.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vr9.c
@@ -207,8 +207,8 @@ static inline int pp32_download_code(int pp32, u32 *code_src, unsigned int code_
     unsigned int clr, set;
     volatile u32 *dest;
 
-    if ( code_src == 0 || ((unsigned long)code_src & 0x03) != 0
-        || data_src == 0 || ((unsigned long)data_src & 0x03) != 0 )
+    if (!code_src || ((unsigned long)code_src & 0x03) != 0
+        || !data_src || ((unsigned long)data_src & 0x03) != 0 )
         return -1;
 
     clr = pp32 ? 0xF0 : 0x0F;

--- a/package/kernel/rtc-rv5c386a/src/rtc.c
+++ b/package/kernel/rtc-rv5c386a/src/rtc.c
@@ -174,13 +174,13 @@ static int i2c_outb(int c)
 		if (sclhi() < 0) { /* timed out */
 			sdahi(); /* we don't want to block the net */
 			return -ETIMEDOUT;
-		};
+		}
 		scllo();
 	}
 	sdahi();
 	if (sclhi() < 0) {
 		return -ETIMEDOUT;
-	};
+	}
 	/* read ack: SDA should be pulled down by slave */
 	ack = getsda() == 0;	/* ack: sda is pulled low ->success.	 */
 	scllo();
@@ -204,7 +204,7 @@ static int i2c_inb(int ack)
 	for (i = 0; i < 8; i++) {
 		if (sclhi() < 0) {
 			return -ETIMEDOUT;
-		};
+		}
 		indata *= 2;
 		if (getsda())
 			indata |= 0x01;

--- a/target/linux/at91/image/dfboot/src/com.c
+++ b/target/linux/at91/image/dfboot/src/com.c
@@ -273,7 +273,7 @@ static int number(int num, int base, int size,
     putc(tmp[i]);
 
   while (size-- > 0)
-    putc(' ');;
+    putc(' ');
 
   return 1;
 }

--- a/target/linux/at91/image/dfboot/src/dataflash.c
+++ b/target/linux/at91/image/dfboot/src/dataflash.c
@@ -166,7 +166,7 @@ int read_dataflash(unsigned long addr, unsigned long size, char *result)
 	AT91PS_DataFlash pFlash = &DataFlashInst;
 
 	pFlash = AT91F_DataflashSelect (pFlash, &AddrToRead);
-	if (pFlash == 0)
+	if (!pFlash)
 		return -1;
 
 	return (AT91F_DataFlashRead(pFlash, AddrToRead, size, result));

--- a/target/linux/ath79/files/drivers/mtd/nand/raw/ar934x_nand.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/ar934x_nand.c
@@ -1379,10 +1379,8 @@ static int ar934x_nfc_probe(struct platform_device *pdev)
 	}
 
 	nfc->irq = platform_get_irq(pdev, 0);
-	if (nfc->irq < 0) {
-		dev_err(&pdev->dev, "no IRQ resource specified\n");
+	if (nfc->irq < 0)
 		return -EINVAL;
-	}
 
 	init_waitqueue_head(&nfc->irq_waitq);
 	ret = devm_request_irq(&pdev->dev, nfc->irq, ar934x_nfc_irq_handler,

--- a/target/linux/bcm47xx/image/lzma-loader/src/LzmaDecode.c
+++ b/target/linux/bcm47xx/image/lzma-loader/src/LzmaDecode.c
@@ -185,7 +185,6 @@ int RangeDecoderReverseBitTreeDecode(CProb *probs, int numLevels, CRangeDecoder 
 {
   int mi = 1;
   int i;
-  int symbol = 0;
   #ifdef _LZMA_LOC_OPT
   RC_INIT_VAR
   #endif
@@ -203,7 +202,7 @@ int RangeDecoderReverseBitTreeDecode(CProb *probs, int numLevels, CRangeDecoder 
   #ifdef _LZMA_LOC_OPT
   RC_FLUSH_VAR
   #endif
-  return symbol;
+  return 0;
 }
 
 Byte LzmaLiteralDecode(CProb *probs, CRangeDecoder *rd)

--- a/target/linux/generic/files/drivers/mtd/nand/mtk_bmt.c
+++ b/target/linux/generic/files/drivers/mtd/nand/mtk_bmt.c
@@ -385,8 +385,7 @@ void mtk_bmt_detach(struct mtd_info *mtd)
 	if (bmtd.mtd != mtd)
 		return;
 
-	if (bmtd.debugfs_dir)
-		debugfs_remove_recursive(bmtd.debugfs_dir);
+	debugfs_remove_recursive(bmtd.debugfs_dir);
 	bmtd.debugfs_dir = NULL;
 
 	kfree(bmtd.bbt_buf);

--- a/target/linux/generic/files/drivers/mtd/nand/mtk_bmt_nmbm.c
+++ b/target/linux/generic/files/drivers/mtd/nand/mtk_bmt_nmbm.c
@@ -810,7 +810,7 @@ static bool nmbm_write_signature(struct nmbm_instance *ni, uint32_t limit,
 
 	next_block:
 		ba--;
-	};
+	}
 
 	return false;
 }
@@ -2069,7 +2069,7 @@ static bool nmbm_find_signature(struct nmbm_instance *ni,
 				return true;
 			}
 		}
-	};
+	}
 
 	return false;
 }

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
@@ -551,9 +551,11 @@ static int b53_configure_ports_of(struct b53_device *dev)
 				    mode == PHY_INTERFACE_MODE_REVMII) {
 					b53_read8(dev, B53_CTRL_PAGE,
 						  B53_PORT_OVERRIDE_CTRL, &po);
-					if (!(po & PORT_OVERRIDE_RV_MII_25))
-					pr_err("Failed to enable reverse MII mode\n");
-					return -EINVAL;
+					if (!(po & PORT_OVERRIDE_RV_MII_25)) {
+						pr_err("Failed to enable reverse MII mode\n");
+						of_node_put(dn);
+						return -EINVAL;
+					}
 				}
 			} else {
 				po |= GMII_PO_EN;
@@ -845,7 +847,7 @@ static int b53_vlan_set_ports(struct switch_dev *dev, struct switch_val *val)
 		if (!(port->flags & BIT(SWITCH_PORT_FLAG_TAGGED))) {
 			vlan->untag |= BIT(port->id);
 			priv->ports[port->id].pvid = val->port_vlan;
-		};
+		}
 	}
 
 	/* ignore disabled ports */

--- a/target/linux/generic/files/drivers/net/phy/rtl8367b.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367b.c
@@ -1594,8 +1594,7 @@ static int  rtl8367b_probe(struct platform_device *pdev)
 	platform_set_drvdata(pdev, NULL);
 	rtl8366_smi_cleanup(smi);
  err_free_smi:
-	if (smi->emu_vlanmc)
-		kfree(smi->emu_vlanmc);
+	kfree(smi->emu_vlanmc);
 	kfree(smi);
 	return err;
 }

--- a/target/linux/generic/files/drivers/platform/mikrotik/rb_hardconfig.c
+++ b/target/linux/generic/files/drivers/platform/mikrotik/rb_hardconfig.c
@@ -549,7 +549,7 @@ static int hc_wlan_data_unpack_lzor_lz77(const u16 tag_id, const u8 *inbuf, size
 			ret = -ENODATA;
 			goto fail;
 		}
-	};
+	}
 	templen -= (u8 *)needle - tempbuf;
 
 	/* Past magic. Look for tag node */

--- a/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367c/i2c.c
+++ b/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367c/i2c.c
@@ -215,7 +215,7 @@ rtk_api_ret_t rtk_i2c_data_read(rtk_uint8 deviceAddr, rtk_uint32 slaveRegAddr, r
 {
      rtk_uint32 retVal, counter=0;
      rtk_uint8 controlByte_W, controlByte_R;
-     rtk_uint8 slaveRegAddr_L, slaveRegAddr_H = 0x0, temp;
+     rtk_uint8 slaveRegAddr_L, slaveRegAddr_H = 0x0;
      rtk_uint8 regData_L, regData_H;
 
    /* control byte :deviceAddress + W,  deviceAddress + R   */
@@ -226,11 +226,7 @@ rtk_api_ret_t rtk_i2c_data_read(rtk_uint8 deviceAddr, rtk_uint32 slaveRegAddr, r
     slaveRegAddr_H = (rtk_uint8) (slaveRegAddr >>8) ;
 
     if( rtk_i2c_mode == I2C_70B_LSB_16BIT_MODE)
-    {
-        temp = slaveRegAddr_L ;
-        slaveRegAddr_L = slaveRegAddr_H;
-        slaveRegAddr_H = temp;
-    }
+	swap(slaveRegAddr_L, slaveRegAddr_H);
 
 
   /*check bus state: idle*/
@@ -339,7 +335,7 @@ rtk_api_ret_t rtk_i2c_data_write(rtk_uint8 deviceAddr, rtk_uint32 slaveRegAddr, 
 {
      rtk_uint32 retVal,counter;
      rtk_uint8 controlByte_W;
-     rtk_uint8 slaveRegAddr_L, slaveRegAddr_H = 0x0, temp;
+     rtk_uint8 slaveRegAddr_L, slaveRegAddr_H = 0x0;
      rtk_uint8 regData_L, regData_H;
 
   /* control byte :deviceAddress + W    */
@@ -352,11 +348,7 @@ rtk_api_ret_t rtk_i2c_data_write(rtk_uint8 deviceAddr, rtk_uint32 slaveRegAddr, 
     regData_L   = (rtk_uint8) (regData & 0x00FF);
 
     if( rtk_i2c_mode == I2C_70B_LSB_16BIT_MODE)
-    {
-        temp = slaveRegAddr_L ;
-        slaveRegAddr_L = slaveRegAddr_H;
-        slaveRegAddr_H = temp;
-    }
+        swap(slaveRegAddr_L, slaveRegAddr_H);
 
 
   /*check bus state: idle*/

--- a/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367c/rtl8367c_asicdrv_qos.c
+++ b/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367c/rtl8367c_asicdrv_qos.c
@@ -233,7 +233,7 @@ ret_t rtl8367c_setAsicPriorityDecision(rtk_uint32 index, rtk_uint32 prisrc, rtk_
             break;
         default:
             break;
-    };
+    }
 
     return RT_ERR_OK;
 
@@ -278,7 +278,7 @@ ret_t rtl8367c_getAsicPriorityDecision(rtk_uint32 index, rtk_uint32 prisrc, rtk_
             break;
         default:
             break;
-    };
+    }
 
     return RT_ERR_OK;
 

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
@@ -1459,7 +1459,7 @@ MODULE_DEVICE_TABLE(of, ralink_esw_match);
 int rt3050_esw_init(struct fe_priv *priv)
 {
 	struct device_node *np = priv->switch_np;
-	struct platform_device *pdev = of_find_device_by_node(np);
+	struct platform_device *pdev;
 	struct switch_dev *swdev;
 	struct rt305x_esw *esw;
 	const __be32 *rgmii;
@@ -1471,9 +1471,12 @@ int rt3050_esw_init(struct fe_priv *priv)
 	if (!of_device_is_compatible(np, ralink_esw_match->compatible))
 		return -EINVAL;
 
+	pdev = of_find_device_by_node(np);
 	esw = platform_get_drvdata(pdev);
-	if (!esw)
+	if (!esw) {
+		put_device(&pdev->dev);
 		return -EPROBE_DEFER;
+	}
 
 	priv->soc->swpriv = esw;
 	esw->priv = priv;
@@ -1489,6 +1492,7 @@ int rt3050_esw_init(struct fe_priv *priv)
 		dev_err(&pdev->dev, "RGMII mode, not exporting switch device.\n");
 		unregister_switch(&esw->swdev);
 		platform_set_drvdata(pdev, NULL);
+		put_device(&pdev->dev);
 		return -ENODEV;
 	}
 

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
@@ -205,17 +205,18 @@ int mtk_gsw_init(struct fe_priv *priv)
 	struct device_node *eth_node = priv->dev->of_node;
 	struct device_node *phy_node, *mdiobus_node;
 	struct device_node *np = priv->switch_np;
-	struct platform_device *pdev = of_find_device_by_node(np);
+	struct platform_device *pdev;
 	struct mt7620_gsw *gsw;
 	const __be32 *id;
 	int ret;
 	u8 val;
 
-	if (!pdev)
-		return -ENODEV;
-
 	if (!of_device_is_compatible(np, mediatek_gsw_match->compatible))
 		return -EINVAL;
+
+	pdev = of_find_device_by_node(np);
+	if (!pdev)
+		return -ENODEV;
 
 	gsw = platform_get_drvdata(pdev);
 	priv->soc->swpriv = gsw;
@@ -248,12 +249,14 @@ int mtk_gsw_init(struct fe_priv *priv)
 		ret = devm_request_irq(&pdev->dev, gsw->irq, gsw_interrupt_mt7620, 0,
 				  "gsw", priv);
 		if (ret) {
+			put_device(&pdev->dev);
 			dev_err(&pdev->dev, "Failed to request irq");
 			return ret;
 		}
 		mtk_switch_w32(gsw, ~PORT_IRQ_ST_CHG, GSW_REG_IMR);
 	}
 
+	put_device(&pdev->dev);
 	return 0;
 }
 

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mdio.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mdio.c
@@ -268,6 +268,6 @@ void fe_mdio_cleanup(struct fe_priv *priv)
 		return;
 
 	mdiobus_unregister(priv->mii_bus);
-	of_node_put(priv->mii_bus->dev.of_node);
+	put_device(&priv->mii_bus->dev);
 	kfree(priv->mii_bus);
 }

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -1556,10 +1556,8 @@ static int fe_probe(struct platform_device *pdev)
 	netdev->base_addr = (unsigned long)fe_base;
 
 	netdev->irq = platform_get_irq(pdev, 0);
-	if (netdev->irq < 0) {
-		dev_err(&pdev->dev, "no IRQ resource found\n");
+	if (netdev->irq < 0)
 		return -ENXIO;
-	}
 
 	priv = netdev_priv(netdev);
 	spin_lock_init(&priv->page_lock);

--- a/target/linux/realtek/files-6.6/drivers/clk/realtek/clk-rtl83xx.c
+++ b/target/linux/realtek/files-6.6/drivers/clk/realtek/clk-rtl83xx.c
@@ -492,7 +492,7 @@ static int rtcl_ccu_create(struct device_node *np)
 		return -ENXIO;
 
 	rtcl_ccu = kzalloc(sizeof(*rtcl_ccu), GFP_KERNEL);
-	if (IS_ERR(rtcl_ccu))
+	if (!rtcl_ccu)
 		return -ENOMEM;
 
 	rtcl_ccu->np = np;
@@ -657,6 +657,7 @@ int rtcl_init_sram(void)
 	rtcl_ccu->sram.pmark = (int *)((void *)sram_pbase + (dram_size - 4));
 	rtcl_ccu->sram.vbase = sram_vbase;
 
+	put_device(&pdev->dev);
 	return 0;
 
 err_put_device:

--- a/target/linux/realtek/files-6.6/drivers/i2c/muxes/i2c-mux-rtl9300.c
+++ b/target/linux/realtek/files-6.6/drivers/i2c/muxes/i2c-mux-rtl9300.c
@@ -245,6 +245,7 @@ static int rtl9300_i2c_mux_probe(struct platform_device *pdev)
 		channels[chan].sda_num = pin - mux_data->sda0_pin;
 		if (channels[chan].sda_num < 0 || channels[chan].sda_num >= mux_data->sda_pins) {
 			dev_warn(dev, "SDA pin %d not supported\n", pin);
+			of_node_put(node);
 			return -EINVAL;
 		}
 		pr_info("%s channel %d sda_num %d\n", __func__, chan, channels[chan].sda_num);

--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/common.c
@@ -366,6 +366,7 @@ static int __init rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 			sprintf(led_set_str, "led_set%d", led_set);
 			priv->ports[pn].leds_on_this_port = of_property_count_u32_elems(led_node, led_set_str);
 			if (priv->ports[pn].leds_on_this_port > 4) {
+				of_node_put(dn);
 				dev_err(priv->dev, "led_set %d for port %d configuration is invalid\n", led_set, pn);
 				return -ENODEV;
 			}

--- a/target/linux/realtek/files-6.6/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.6/drivers/net/ethernet/rtl838x_eth.c
@@ -2287,6 +2287,7 @@ static int rtl838x_mdio_init(struct rtl838x_eth_priv *priv)
 			continue;
 
 		if (pn >= MAX_PORTS) {
+			of_node_put(dn);
 			pr_err("%s: illegal port number %d\n", __func__, pn);
 			return -ENODEV;
 		}
@@ -2305,6 +2306,7 @@ static int rtl838x_mdio_init(struct rtl838x_eth_priv *priv)
 		}
 
 		if (priv->smi_bus[pn] >= MAX_SMI_BUSSES) {
+			of_node_put(dn);
 			pr_err("%s: illegal SMI bus number %d\n", __func__, priv->smi_bus[pn]);
 			return -ENODEV;
 		}
@@ -2333,6 +2335,8 @@ static int rtl838x_mdio_init(struct rtl838x_eth_priv *priv)
 			priv->interfaces[pn] = PHY_INTERFACE_MODE_NA;
 		pr_debug("%s phy mode of port %d is %s\n", __func__, pn, phy_modes(priv->interfaces[pn]));
 	}
+
+	of_node_put(dn);
 
 	snprintf(priv->mii_bus->id, MII_BUS_ID_SIZE, "%pOFn", mii_np);
 	ret = devm_of_mdiobus_register(&priv->pdev->dev, priv->mii_bus, mii_np);
@@ -2571,10 +2575,8 @@ static int __init rtl838x_eth_probe(struct platform_device *pdev)
 
 	/* Obtain device IRQ number */
 	dev->irq = platform_get_irq(pdev, 0);
-	if (dev->irq < 0) {
-		dev_err(&pdev->dev, "cannot obtain network-device IRQ\n");
-		return err;
-	}
+	if (dev->irq < 0)
+		return -ENODEV;
 
 	err = devm_request_irq(&pdev->dev, dev->irq, priv->r->net_irq,
 			       IRQF_SHARED, dev->name, dev);

--- a/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.c
@@ -529,7 +529,7 @@ static int rtl821x_write_page(struct phy_device *phydev, int page)
 
 static int rtl8226_read_status(struct phy_device *phydev)
 {
-	int ret = 0;
+	int ret;
 	u32 val;
 
 /* TODO: ret = genphy_read_status(phydev);
@@ -579,6 +579,7 @@ static int rtl8226_read_status(struct phy_device *phydev)
 	}
 
 out:
+	ret = 0;
 	return ret;
 }
 
@@ -1103,7 +1104,7 @@ static void rtl8214fc_media_set(struct phy_device *phydev, bool set_fibre)
 
 static int rtl8214fc_set_port(struct phy_device *phydev, int port)
 {
-	bool is_fibre = (port == PORT_FIBRE ? true : false);
+	bool is_fibre = (port == PORT_FIBRE);
 	int addr = phydev->mdio.addr;
 
 	pr_debug("%s port %d to %d\n", __func__, addr, port);
@@ -3035,13 +3036,13 @@ sds_config rtl9300_a_sds_10gr_lane1[] =
 static void rtl9300_serdes_patch(int sds_num)
 {
 	if (sds_num % 2) {
-		for (int i = 0; i < sizeof(rtl9300_a_sds_10gr_lane1) / sizeof(sds_config); ++i) {
+		for (int i = 0; i < ARRAY_SIZE(rtl9300_a_sds_10gr_lane1); ++i) {
 			rtl930x_write_sds_phy(sds_num, rtl9300_a_sds_10gr_lane1[i].page,
 					      rtl9300_a_sds_10gr_lane1[i].reg,
 					      rtl9300_a_sds_10gr_lane1[i].data);
 		}
 	} else {
-		for (int i = 0; i < sizeof(rtl9300_a_sds_10gr_lane0) / sizeof(sds_config); ++i) {
+		for (int i = 0; i < ARRAY_SIZE(rtl9300_a_sds_10gr_lane0); ++i) {
 			rtl930x_write_sds_phy(sds_num, rtl9300_a_sds_10gr_lane0[i].page,
 					      rtl9300_a_sds_10gr_lane0[i].reg,
 					      rtl9300_a_sds_10gr_lane0[i].data);
@@ -3509,13 +3510,13 @@ void rtl931x_sds_init(u32 sds, phy_interface_t mode)
 		if (chiptype) {
 			rtl9310_sds_field_w(asds, 0x6, 0x2, 12, 12, 1);
 
-			for (int i = 0; i < sizeof(sds_config_10p3125g_type1) / sizeof(sds_config); ++i) {
+			for (int i = 0; i < ARRAY_SIZE(sds_config_10p3125g_type1); ++i) {
 				rtl931x_write_sds_phy(asds, sds_config_10p3125g_type1[i].page - 0x4, sds_config_10p3125g_type1[i].reg, sds_config_10p3125g_type1[i].data);
 			}
 
 			evenSds = asds - (asds % 2);
 
-			for (int i = 0; i < sizeof(sds_config_10p3125g_cmu_type1) / sizeof(sds_config); ++i) {
+			for (int i = 0; i < ARRAY_SIZE(sds_config_10p3125g_cmu_type1); ++i) {
 				rtl931x_write_sds_phy(evenSds,
 				                      sds_config_10p3125g_cmu_type1[i].page - 0x4, sds_config_10p3125g_cmu_type1[i].reg, sds_config_10p3125g_cmu_type1[i].data);
 			}


### PR DESCRIPTION
Unneeded semicolon

WARNING comparing pointer to 0

WARNING: NULL check before some freeing functions is not needed.

WARNING: casting value returned by memory allocation function to (u32 *)

ERROR: allocation function on line 378 returns NULL not ERR_PTR on failure
