### PR TITLE
ipq806x: tr4400v2: revert nesting of MTD partitions that bricks device

### DIFF
--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-tr4400-v2.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-tr4400-v2.dts
@@ -207,15 +207,6 @@
 			stock_partition@1340000 {
 				label = "stock_rootfs";
 				reg = <0x1340000 0x4000000>;
-
-				compatible = "fixed-partitions";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				partition@0 {
-					label = "extra";
-					reg = <0x0 0x4000000>;
-				};
 			};
 			partition@5340000 {
 				label = "0:BOOTCONFIG";
@@ -265,42 +256,6 @@
 			stock_partition@6400000 {
 				label = "stock_rootfs_1";
 				reg = <0x6400000 0x4000000>;
-
-				compatible = "fixed-partitions";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				partition@0 {
-					label = "fw_env";
-					reg = <0x0 0x100000>;
-
-					nvmem-layout {
-						compatible = "fixed-layout";
-						#address-cells = <1>;
-						#size-cells = <1>;
-
-						macaddr_fw_env_0: macaddr@0 {
-							reg = <0x00 0x6>;
-						};
-						macaddr_fw_env_6: macaddr@6 {
-							reg = <0x06 0x6>;
-						};
-						macaddr_fw_env_c: macaddr@c {
-							reg = <0x0c 0x6>;
-						};
-						macaddr_fw_env_12: macaddr@12 {
-							reg = <0x12 0x6>;
-						};
-						macaddr_fw_env_18: macaddr@18 {
-							reg = <0x18 0x6>;
-						};
-					};
-				};
-
-				partition@100000 {
-					label = "ubi";
-					reg = <0x100000 0x9b00000>;
-				};
 			};
 			stock_partition@a400000 {
 				label = "stock_fw_env";
@@ -317,6 +272,41 @@
 			stock_partition@af00000 {
 				label = "stock_scfgmgr";
 				reg = <0xaf00000 0x0100000>;
+			};
+
+			partition@6400000 {
+				label = "fw_env";
+				reg = <0x6400000 0x0100000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_fw_env_0: macaddr@0 {
+						reg = <0x00 0x6>;
+					};
+					macaddr_fw_env_6: macaddr@6 {
+						reg = <0x06 0x6>;
+					};
+					macaddr_fw_env_c: macaddr@c {
+						reg = <0x0c 0x6>;
+					};
+					macaddr_fw_env_12: macaddr@12 {
+						reg = <0x12 0x6>;
+					};
+					macaddr_fw_env_18: macaddr@18 {
+						reg = <0x18 0x6>;
+					};
+				};
+			};
+			partition@6500000 {
+				label = "ubi";
+				reg = <0x6500000 0x9b00000>;
+			};
+			partition@1340000 {
+				label = "extra";
+				reg = <0x1340000 0x4000000>;
 			};
 		};
 	};


### PR DESCRIPTION
@neheb @Ansuel @mans0n 

This reverts commit e1043a746a1030062e73ea027d9a35c58bce6c6a, that attempts to nest partitions that overlap but are not nested. This causes the 'ubi' partition to be truncated, making rootfs inaccessible and bricking the device.

Also, had this commit worked, it would have renumbered MTD partitions in a way that would have broken documented scripts for installation and update of main and recovery OSes, making backups, return to stock, etc, and broken user configurations that put the 'extra' partition to use.

More info [here](https://github.com/openwrt/openwrt/issues/16938).

(I tested this on the device.)