### PR TITLE
apk: remove HOST_LDFLAGS hack

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -68,9 +68,6 @@ MESON_ARGS += \
 	$(MESON_COMMON_ARGS) \
 	-Dcrypto_backend=$(BUILD_VARIANT)
 
-HOST_LDFLAGS += \
-	-Wl,-rpath $(STAGING_DIR_HOST)/lib
-
 define Package/apk/default/install
 	$(INSTALL_DIR) $(1)/lib/apk/db
 

--- a/package/system/apk/patches/0001-openwrt-move-layer-db-to-temp-folder.patch
+++ b/package/system/apk/patches/0001-openwrt-move-layer-db-to-temp-folder.patch
@@ -10,7 +10,7 @@ Signed-off-by: Paul Spooren <mail@aparcar.org>
 
 --- a/src/database.c
 +++ b/src/database.c
-@@ -1627,7 +1627,7 @@ const char *apk_db_layer_name(int layer)
+@@ -1631,7 +1631,7 @@ const char *apk_db_layer_name(int layer)
  {
  	switch (layer) {
  	case APK_DB_LAYER_ROOT: return "lib/apk/db";


### PR DESCRIPTION
No longer needed as upstream respects -Ddefault_library now.

Refreshed patches.

ping @ynezz @Ansuel @aparcar 