### PR TITLE
apk: fix long package description handling

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git

--- a/package/system/apk/patches/0020-pkg-truncate-apkv3-description-to-256-bytes.patch
+++ b/package/system/apk/patches/0020-pkg-truncate-apkv3-description-to-256-bytes.patch
@@ -1,0 +1,45 @@
+From 417a93ceae540444fdbd3f76d1dadf0e15621fdc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Timo=20Ter=C3=A4s?= <timo.teras@iki.fi>
+Date: Wed, 13 Nov 2024 09:40:21 +0200
+Subject: [PATCH] pkg: truncate apkv3 description to 256 bytes
+
+The code to read/write installeddb does not really handle long
+description well. Until the database is converted to apkv3 format,
+truncate the apkv3 descriptions to allow existing code to work.
+
+APKv3 index and packages still contain the original long description
+unmodified, so no package rebuild will be needed.
+
+fixes #11038
+
+Upstream-Status: Backport [https://gitlab.alpinelinux.org/alpine/apk-tools/-/commit/417a93ceae540444fdbd3f76d1dadf0e15621fdc]
+---
+ src/apk_blob.h | 5 +++++
+ src/package.c  | 2 +-
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+--- a/src/apk_blob.h
++++ b/src/apk_blob.h
+@@ -48,6 +48,11 @@ static inline apk_blob_t apk_blob_trim(a
+ 	return b;
+ }
+ 
++static inline apk_blob_t apk_blob_truncate(apk_blob_t blob, int maxlen)
++{
++	return APK_BLOB_PTR_LEN(blob.ptr, min(blob.len, maxlen));
++}
++
+ char *apk_blob_cstr(apk_blob_t str);
+ apk_blob_t apk_blob_dup(apk_blob_t blob);
+ int apk_blob_split(apk_blob_t blob, apk_blob_t split, apk_blob_t *l, apk_blob_t *r);
+--- a/src/package.c
++++ b/src/package.c
+@@ -577,7 +577,7 @@ void apk_pkgtmpl_from_adb(struct apk_dat
+ 
+ 	pkg->name = apk_db_get_name(db, adb_ro_blob(pkginfo, ADBI_PI_NAME));
+ 	pkg->version = apk_atomize_dup(&db->atoms, adb_ro_blob(pkginfo, ADBI_PI_VERSION));
+-	pkg->description = apk_atomize_dup0(&db->atoms, adb_ro_blob(pkginfo, ADBI_PI_DESCRIPTION));
++	pkg->description = apk_atomize_dup0(&db->atoms, apk_blob_truncate(adb_ro_blob(pkginfo, ADBI_PI_DESCRIPTION), 512));
+ 	pkg->url = apk_atomize_dup(&db->atoms, adb_ro_blob(pkginfo, ADBI_PI_URL));
+ 	pkg->license = apk_atomize_dup(&db->atoms, adb_ro_blob(pkginfo, ADBI_PI_LICENSE));
+ 	pkg->arch = apk_atomize_dup(&db->atoms, adb_ro_blob(pkginfo, ADBI_PI_ARCH));


### PR DESCRIPTION
### apk: fix long package description handling

Currently its not possible to generate apk package.adb package index if
the package has longer description field, which leads to following
failure:

```shell
 (2352/2353) Installing zoneinfo-all (2024b-r1)
 (2353/2353) Installing zstd (1.5.6-r1)
 ERROR: System state may be inconsistent: failed to write database: No buffer space available
 1 error; 2704 MiB in 2353 packages
```

The code to read/write installeddb does not really handle long
description well. Until the database is converted to apkv3 format,
truncate the apkv3 descriptions to allow existing code to work.

APKv3 index and packages still contain the original long description
unmodified, so no package rebuild will be needed.

Fixing the issue by backporting the single upstream fix as its not
possible to to upstep apk to the latest Git HEAD due to some
regressions, see commit 692052cdc0e7 ("Revert "apk: update to Git
417a93ceae540444fdbd3f76d1dadf0e15621fdc (2024-11-13)"") for more
details.

Fixes: #16929
References: https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/11038
Upstream-Status: `Backport` [[https://gitlab.alpinelinux.org/alpine/apk-tools/-/commit/417a93ceae540444fdbd3f76d1dadf0e15621fdc](https://gitlab.alpinelinux.org/alpine/apk-tools/-/commit/417a93ceae540444fdbd3f76d1dadf0e15621fdc)]