### PR TITLE
mediatek: filogic: support openwrt,netdev-name; set labels for sfp ports on bpi-r3 and bpi-r4

### DIFF
--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-poe.dts
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4-poe.dts
@@ -17,6 +17,7 @@
 	phy-connection-type = "internal";
 	phy = <&int_2p5g_phy>;
 	status = "okay";
+	openwrt,netdev-name = "lan4";
 };
 
 &int_2p5g_phy {

--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dts
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dts
@@ -29,6 +29,7 @@
 	managed = "in-band-status";
 	phy-mode = "usxgmii";
 	status = "okay";
+	openwrt,netdev-name = "sfp-lan";
 };
 
 &pca9545 {

--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
@@ -90,6 +90,7 @@
 	managed = "in-band-status";
 	phy-mode = "usxgmii";
 	status = "okay";
+	openwrt,netdev-name = "sfp-wan";
 };
 
 &switch {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -65,9 +65,11 @@ mediatek_setup_interfaces()
 	edgecore,eap111)
 		ucidef_set_interfaces_lan_wan eth0 eth1
 		;;
-	bananapi,bpi-r4|\
+	bananapi,bpi-r4)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 sfp-lan" "wan sfp-wan"
+		;;
 	bananapi,bpi-r4-poe)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 eth1" "wan eth2"
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan sfp-wan"
 		;;
 	comfast,cf-e393ax)
 		ucidef_set_interfaces_lan_wan "lan1" eth1

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -59,7 +59,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" eth1
 		;;
 	bananapi,bpi-r3)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "eth1 wan"
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "sfp1 wan"
 		;;
 	bananapi,bpi-r3-mini|\
 	edgecore,eap111)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
@@ -6,7 +6,7 @@ board_config_update
 
 case "$(board_name)" in
 	bananapi,bpi-r3)
-		ucidef_set_compat_version "1.2"
+		ucidef_set_compat_version "1.3"
 		;;
 	routerich,ax3000)
 		ucidef_set_compat_version "1.1"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
@@ -11,6 +11,10 @@ case "$(board_name)" in
 	routerich,ax3000)
 		ucidef_set_compat_version "1.1"
 		;;
+	bananapi,bpi-r4|\
+	bananapi,bpi-r4-poe)
+		ucidef_set_compat_version "1.1"
+		;;
 esac
 
 board_config_flush

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/04_set_netdev_label
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/04_set_netdev_label
@@ -10,6 +10,14 @@ set_netdev_labels() {
 		[ "$netdev" = "$label" ] && continue
 		ip link set "$netdev" name "$label"
 	done
+
+	for dir in /sys/class/net/*; do
+		[ -r "$dir/of_node/openwrt,netdev-name" ] || continue
+		read -r label < "$dir/of_node/openwrt,netdev-name"
+		netdev="${dir##*/}"
+		[ "$netdev" = "$label" ] && continue
+		ip link set "$netdev" name "$label"
+	done
 }
 
 boot_hook_add preinit_main set_netdev_labels

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -375,8 +375,8 @@ endif
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | pad-rootfs | append-metadata
   DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_COMPAT_VERSION := 1.2
-  DEVICE_COMPAT_MESSAGE := SPI-NAND flash layout changes require bootloader update
+  DEVICE_COMPAT_VERSION := 1.3
+  DEVICE_COMPAT_MESSAGE := First sfp port renamed from eth1 to sfp1
 endef
 TARGET_DEVICES += bananapi_bpi-r3
 

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -433,6 +433,8 @@ define Device/bananapi_bpi-r4-common
   DEVICE_DTC_FLAGS := --pad 4096
   DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-i2c-mux-pca954x kmod-eeprom-at24 kmod-mt7996-firmware kmod-mt7996-233-firmware \
 		     kmod-rtc-pcf8563 kmod-sfp kmod-usb3 e2fsprogs f2fsck mkf2fs mt7988-wo-firmware
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := The non-switch ports were renamed to match the board/case labels
   IMAGES := sysupgrade.itb
   KERNEL_LOADADDR := 0x46000000
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb

--- a/target/linux/mediatek/patches-6.6/955-dts-mt7968a-bpi-r3-add-label-to-gmac-for-sfp1-port.patch
+++ b/target/linux/mediatek/patches-6.6/955-dts-mt7968a-bpi-r3-add-label-to-gmac-for-sfp1-port.patch
@@ -1,0 +1,10 @@
+--- a/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts
+@@ -195,6 +195,7 @@
+ 		phy-mode = "2500base-x";
+ 		sfp = <&sfp1>;
+ 		managed = "in-band-status";
++		openwrt,netdev-name = "sfp1";
+ 	};
+ 
+ 	mdio: mdio-bus {


### PR DESCRIPTION
The LAN and WAN ports, which are connected to the switch chips on Banana Pi R3 and R4, are named properly in the device tree like `wan` and `lanX` (and `sfp2` on R3). However, the other SFP slots are directly connected to the SoC and have their own Ethernet nodes in the device tree. Labelling these is afaik not supported upstream and thus they are automatically named like `eth1` and `eth2` (which is even in bad order on the R4 - `eth2` is first/left SFP port and `eth1` is the second/right).

Thus, set the labels in the `gmac` nodes in the device trees of Banana Pi R3 and R4 with labels that match the labels printed on the PCB/official metal case. The labels are picked up and set by the `04_set_netdev_labels` script/hook in `filogic` subtarget.
On R3, the first SFP port is renamed from `eth1` to `sfp1`. On R4, the first SFP port is renamed from `eth2` to `sfp-wan` and the second is renamed from `eth1` to `sfp-lan`.
Also bump the `compat_version` to indicate that the configuration is incompatible with this change.

This also renames the port of the R4 PoE version, however there is no reference for the name I've chosen since there doesn't seem to be a dedicated label on the board or another faceplate for the metal case (at least I haven't found it).

ping @dangowrt 

EDIT: Due to recent commit 5695267847 I also added another commit which adds support for our own custom dts property `openwrt,netdev-name` for renaming interfaces, as suggested upstream [1].

[1] https://lore.kernel.org/netdev/20240709124503.pubki5nwjfbedhhy@skbuf/