### PR TITLE
ipq806x: tr4400v2: fix dtc warnings by deleting stock partitions

### DIFF
--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-tr4400-v2.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-tr4400-v2.dts
@@ -204,8 +204,8 @@
 					};
 				};
 			};
-			stock_partition@1340000 {
-				label = "stock_rootfs";
+			partition@1340000 {
+				label = "extra";
 				reg = <0x1340000 0x4000000>;
 			};
 			partition@5340000 {
@@ -253,30 +253,10 @@
 				reg = <0x5f00000 0x0500000>;
 				read-only;
 			};
-			stock_partition@6400000 {
-				label = "stock_rootfs_1";
-				reg = <0x6400000 0x4000000>;
-			};
-			stock_partition@a400000 {
-				label = "stock_fw_env";
-				reg = <0xa400000 0x0100000>;
-			};
-			stock_partition@a500000 {
-				label = "stock_config";
-				reg = <0xa500000 0x0800000>;
-			};
-			stock_partition@ad00000 {
-				label = "stock_PKI";
-				reg = <0xad00000 0x0200000>;
-			};
-			stock_partition@af00000 {
-				label = "stock_scfgmgr";
-				reg = <0xaf00000 0x0100000>;
-			};
-
 			partition@6400000 {
 				label = "fw_env";
 				reg = <0x6400000 0x0100000>;
+				read-only;
 
 				nvmem-layout {
 					compatible = "fixed-layout";
@@ -303,10 +283,6 @@
 			partition@6500000 {
 				label = "ubi";
 				reg = <0x6500000 0x9b00000>;
-			};
-			partition@1340000 {
-				label = "extra";
-				reg = <0x1340000 0x4000000>;
 			};
 		};
 	};


### PR DESCRIPTION
The original set of stock partitions was kept in the TR4400 v2 port,
with the same partition numbers but their names prefixed with 'stock_'.
This allowed scripts (installation, back to stock, etc) to run on both
stock and OpenWrt firmware. But this triggers warnings in the device
tree compiler, as partitions of the old and new schemes overlap.

This commit fixes the dtc warnings by deleting the stock partitions,
also renumbering some of the remaining MTD partitions in the process.
Additionally, the 'fw_env' partition is set to read-only.

These changes can break existing scripts as well as user configurations
that utilize the 'extra' partition. Users wanting to run old scripts can
do so by reverting to the 23.05 series releases.

----------------

@robimarko 

here it is, tested ok. totally your call whether to merge or not.

(break scripts, but ppl needing back to stock can first install 23.x. very, VERY few people using this device.)

if you merge, please backport to 24.10: we better break now than in the future.

thanks!