### PR TITLE
build: apk: Remove /run/apk/db.lock

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -101,6 +101,7 @@ ifneq ($(CONFIG_USE_APK),)
 	$(call apk,$(TARGET_DIR)) add --no-cache --initdb --no-scripts --arch $(ARCH_PACKAGES) \
 		--repositories-file /dev/null --repository file://$(PACKAGE_DIR_ALL)/packages.adb \
 		$$(cat $(TMP_DIR)/apk_install_list)
+	rm -rf $(TARGET_DIR)/run
 else
 	$(file >$(TMP_DIR)/opkg_install_list,\
 	  $(call opkg_package_files,\

--- a/package/base-files/files/etc/init.d/boot
+++ b/package/base-files/files/etc/init.d/boot
@@ -24,6 +24,8 @@ boot() {
 	chmod 1777 /var/lock
 	mkdir -p /var/log
 	mkdir -p /var/run
+	ln -s /var/run /run
+	ln -s /var/lock /run/lock
 	mkdir -p /var/state
 	mkdir -p /var/tmp
 	mkdir -p /tmp/.uci


### PR DESCRIPTION
 * build: apk: Remove /run/apk/db.lock
    
    Do not add the file /run/apk/db.lock to the root file system. The /run
    folder should be on a tmpfs.
    
    At runtime we should make /run point to a tmpfs. At build time we should
    just remove the folder.
    
 * base-files: Create /run and /run/lock folder
    
    Create the folder /run and /run/lock using symlinks. Other Linux
    distributions also have these folders and some applications might already
    depend on them. Just create symlinks pointing to the older folder.