### PR TITLE
x86: add all ports to the Gowin 1U default network config

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -58,7 +58,7 @@ gowin-solution-co-ltd-gw-mb-u01)
 		ucidef_set_network_device_path_port "sfp2" "$sfp_device/$sfp_port" "0"
 	fi
 
-	ucidef_set_interface_lan "eth1 eth2 eth3 eth4"
+	ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 poe" "sfp1 sfp2"
 	;;
 pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"


### PR DESCRIPTION
With commit e52c57bb1b30375e0bcc5523db76a672a4a8b4a4, I renamed all network ports to match the faceplate of the Gowin 1U Rack Mount Server and added the `br-lan` bridge for the `eth*` ports.

However, we decided it's better to have all the device's network ports inside the default network configuration.
This commit adds the PoE port to the `br-lan` bridge and a `br-wan` bridge for the two SFP ports so that all ports are part of the default network configuration.