### PR TITLE
ramips: mt7621: use regulators for USB GPIO

### DIFF
--- a/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
@@ -60,20 +60,26 @@
 		};
 	};
 
+	reg_usb_vbus: regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
 	gpio_export {
 		compatible = "gpio-export";
-
-		power_usb2 {
-			gpio-export,name = "power_usb2";
-			gpio-export,output = <1>;
-			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
-		};
-
-		power_usb3 {
-			gpio-export,name = "power_usb3";
-			gpio-export,output = <1>;
-			gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
-		};
 
 		power_sata {
 			gpio-export,name = "power_sata";
@@ -100,6 +106,11 @@
 
 &sdhci {
 	status = "okay";
+};
+
+&xhci {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_usb_vbus>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7621_dual-q_h721.dts
+++ b/target/linux/ramips/dts/mt7621_dual-q_h721.dts
@@ -21,22 +21,6 @@
 		bootargs = "console=ttyS0,115200";
 	};
 
-	gpio-export {
-		compatible = "gpio-export";
-
-		usb-30-power {
-			gpio-export,name = "usb-30-power";
-			gpio-export,output = <0>;
-			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
-		};
-
-		usb-20-power {
-			gpio-export,name = "usb-20-power";
-			gpio-export,output = <0>;
-			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
-		};
-	};
-
 	keys {
 		compatible = "gpio-keys";
 
@@ -91,6 +75,27 @@
 			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	reg_usb_vbus: regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&xhci {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_usb_vbus>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -59,25 +59,32 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
+	reg_usb_vbus: regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 
-		usb2power {
-			gpio-export,name = "usb2power";
-			gpio-export,output = <1>;
-			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
-		};
-
-		usb3power {
-			gpio-export,name = "usb3power";
-			gpio-export,output = <1>;
-			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
-		};
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
 };
 
 &sdhci {
 	status = "okay";
+};
+
+&xhci {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_usb_vbus>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
+++ b/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
@@ -67,24 +67,35 @@
 	gpio_export {
 		compatible = "gpio-export";
 
-		power_usb2 {
-			gpio-export,name = "power_usb2";
-			gpio-export,output = <1>;
-			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
-		};
-
-		power_usb3 {
-			gpio-export,name = "power_usb3";
-			gpio-export,output = <1>;
-			gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
-		};
-
 		power_sata {
 			gpio-export,name = "power_sata";
 			gpio-export,output = <1>;
 			gpios = <&gpio 27 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	reg_usb_vbus: regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&xhci {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_usb_vbus>;
 };
 
 &spi0 {


### PR DESCRIPTION
Regulators as implemented by the XHCI driver only accept one GPIO. However, we can abuse the fact that the XHCI driver accepts two regulators, one for 5V and the other for 3.3V, for USB 2 and 3 GPIOs.

ping @DragonBluep 