### PR TITLE
mtd-utils: add ubihealthd to nand-utils

### DIFF
--- a/package/utils/mtd-utils/Makefile
+++ b/package/utils/mtd-utils/Makefile
@@ -65,12 +65,20 @@ CONFIGURE_ARGS += \
 	--without-lzo \
 	--without-zlib
 
+define Package/ubi-utils/conffiles
+/etc/config/ubihealthd
+endef
+
 define Package/ubi-utils/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) \
-		$(PKG_INSTALL_DIR)/usr/sbin/{ubiattach,ubicrc32,ubiblock,ubidetach,ubiformat,ubimkvol} $(1)/usr/sbin/
+		$(PKG_INSTALL_DIR)/usr/sbin/{ubiattach,ubicrc32,ubiblock,ubidetach,ubiformat,ubihealthd} $(1)/usr/sbin/
 	$(INSTALL_BIN) \
-		$(PKG_INSTALL_DIR)/usr/sbin/{ubinfo,ubinize,ubirename,ubirmvol,ubirsvol,ubiupdatevol} $(1)/usr/sbin/
+		$(PKG_INSTALL_DIR)/usr/sbin/{ubimkvol,ubinfo,ubinize,ubirename,ubirmvol,ubirsvol,ubiupdatevol} $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/ubihealthd.init $(1)/etc/init.d/ubihealthd
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DATA) ./files/ubihealthd.defaults $(1)/etc/uci-defaults/ubihealthd
 endef
 
 define Package/nand-utils/install

--- a/package/utils/mtd-utils/files/ubihealthd.defaults
+++ b/package/utils/mtd-utils/files/ubihealthd.defaults
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+[ -e "/etc/config/ubihealthd" ] && exit 0
+[ ! -e "/sys/class/ubi" ] && exit 0
+
+touch  "/etc/config/ubihealthd"
+
+for ubidev in /sys/class/ubi/*/total_eraseblocks; do
+	ubidev="${ubidev%/*}"
+	ubidev="${ubidev##*/}"
+	uci batch <<EOF
+set ubihealthd.$ubidev=ubi-device
+set ubihealthd.$ubidev.device="/dev/$ubidev"
+set ubihealthd.$ubidev.enable=1
+EOF
+done
+
+uci commit ubihealthd

--- a/package/utils/mtd-utils/files/ubihealthd.init
+++ b/package/utils/mtd-utils/files/ubihealthd.init
@@ -1,0 +1,27 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+USE_PROCD=1
+PROG=/usr/sbin/ubihealthd
+
+ubihealthd_instance() {
+	local cfg="$1"
+	local device interval enable
+
+	config_get_bool enable "$cfg" "enable" 1
+	[ "$enable" = "1" ] || return 0
+
+	config_get device "$cfg" "device"
+	config_get interval "$cfg" "interval"
+
+	procd_open_instance
+	procd_set_param command "$PROG" -f -d "$device"
+	[ -n "$interval" ] && procd_append_param command -i "$interval"
+	procd_close_instance
+}
+
+start_service() {
+	config_load ubihealthd
+	config_foreach ubihealthd_instance ubi-device
+}


### PR DESCRIPTION
Add ubihealthd to the nand-utils package, auto-create UCI config for each UBI device and launch the daemon on boot.

The default time interval between scrubbing a random PED is 120 seconds which means that a fully used 128 MiB flash chip gets scrubbed in about a day and a half. The interval can be adjusted in UCI using the 'interval' option.

Suggested-by: @Lanchon

Untested!