### PR TITLE
mediatek: fix pwn fan settings for sinovoip bpi-r3

### DIFF
--- a/target/linux/mediatek/patches-5.15/196-dts-mt7986a-bpi-r3-pwm-fan-cooling-levels.patch
+++ b/target/linux/mediatek/patches-5.15/196-dts-mt7986a-bpi-r3-pwm-fan-cooling-levels.patch
@@ -1,0 +1,11 @@
+--- a/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts
+@@ -46,7 +46,7 @@
+ 		compatible = "pwm-fan";
+ 		#cooling-cells = <2>;
+ 		/* cooling level (0, 1, 2) - pwm inverted */
+-		cooling-levels = <255 96 0>;
++		cooling-levels = <255 40 0>;
+ 		pwms = <&pwm 0 10000>;
+ 		status = "okay";
+ 	};


### PR DESCRIPTION
Popular bpi-r3 pwm fans like this one
<img src="https://m.media-amazon.com/images/I/61yLslTkg0L._AC_UF1000,1000_QL80_.jpg" alt="cooler" width="200"/>
  https://www.amazon.com/youyeetoo-Barebone-Fan-BPI-R3-Integrated/dp/B0CCCTY8PS

will not work properly with current openwrt-23.05/24.10 firmware.

Trying different pwm setting with the following command
`echo $value > /sys/devices/platform/pwm-fan/hwmon/hwmon1/pwm1`
I found:
|pwm1 value | fan rotation speed     | cpu temperature  |   notes                    |
|------------------|--------------------------------|---------------------------|---------------------------|
| 0                   | maximal                       | 31.5 Celsius           | too noisy                |
| 40                 | optimal                        |35.2 Celsius            |no noise hearable  |
| 95                 | minimal                       |                                 |                                   |
| above 95     | fan does not rotates |55.5 Celsius            |                                   |

At the moment we are having following cooling levels configured in _mt7986a-bananapi-bpi-r3.dts_
`cooling-levels = <255 96 0>;`

for _cpu-active-high_, _cpu-active-med_ and _cpu-active-low_ modes correspondingly. Thus only _cpu-active-high_ and _cpu-active-low_ are usable. I think this is wrong.

This patch fixes _cpu-active-med_ settings for bpi-r3 board.

PS: I know, the patch is not ideal as it can break pwm fan for some users. There are some peoples that use handmade cooling solutions, but:
- discussed cooler is the only 'official' pwm cooler for bpi-r3 available on the market.
- most peoples will use passive cooling available on the market or the discussed cooler.
- the pwm-fan dts section was added before the official cooler appears on the market. 

Thus it should not be a lot of harm from this fix.