### PR TITLE
packages: Mark packages nonshared

### DIFF
--- a/package/utils/debugcc/Makefile
+++ b/package/utils/debugcc/Makefile
@@ -11,6 +11,7 @@ PKG_MIRROR_HASH:=4cd7a770a05db28f496a60eb9fe015a4af677bba05053b4d4be21adcf95e52e
 
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
+PKG_FLAGS:=nonshared
 
 PKG_MAINTAINER:=Christian Marangi <ansuelsmth@gmail.com>
 

--- a/package/utils/omnia-eeprom/Makefile
+++ b/package/utils/omnia-eeprom/Makefile
@@ -15,6 +15,7 @@ PKG_SOURCE_SUBDIR:=$(PKG_NAME)-v$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-v$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://gitlab.nic.cz/turris/omnia-eeprom/-/archive/v$(PKG_VERSION)/
 PKG_HASH:=6f949d0b8080adca8bae088774ce615b563ba6ec2807cce97ee6769b4eee7bbf
+PKG_FLAGS:=nonshared
 
 PKG_MAINTAINER:=Marek Behun <kabel@kernel.org>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
 * omnia-eeprom: Mark it nonshared
    
    This tool was build in the phase 2 build, there the
    TARGET_mvebu_cortexa9_DEVICE_cznic_turris-omnia dependecy was probably
    not meat. Mark it as non shared to build it together with the target
    where this option is set.

 * debugcc: Mark it nonshared
    
    This tool was build in the phase 2 build, there the TARGET dependencies
    are probably not meat. Mark it as non shared to build it together with
    the targets where this option is set.