### PR TITLE
kernel: disable drm-i915 module for x86/geode

### DIFF
--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -441,7 +441,8 @@ $(eval $(call KernelPackage,drm-amdgpu))
 define KernelPackage/drm-i915
   SUBMENU:=$(VIDEO_MENU)
   TITLE:=Intel i915 DRM support
-  DEPENDS:=@TARGET_x86 @DISPLAY_SUPPORT +kmod-backlight +kmod-drm-ttm \
+  DEPENDS:=@(TARGET_x86_64||TARGET_x86_generic||TARGET_x86_legacy) \
+	@DISPLAY_SUPPORT +kmod-backlight +kmod-drm-ttm \
 	+kmod-drm-ttm-helper +kmod-drm-kms-helper +kmod-i2c-algo-bit +i915-firmware-dmc \
 	+kmod-drm-display-helper +kmod-drm-buddy +kmod-acpi-video \
 	+kmod-drm-exec +kmod-drm-suballoc-helper


### PR DESCRIPTION
Disable drm-i915 module for target x86/geode.

Fixes: 77cfe8fd15d3 ("x86: make i915 as a kmod with required firmware")

Before commit 77cfe8fd15d3 drm-i915 was compiled only for 3 subtargets, 
This PR is going back to that state.

For geode there is an error:
https://github.com/openwrt/openwrt/actions/runs/11864959060/job/33073990007
or for PR https://github.com/openwrt/openwrt/pull/16971
"Package kmod-drm-i915 is missing dependencies for the following libraries: intel-gtt.ko"
