### PR TITLE
bmips: dts: fix pinctrl error

### DIFF
--- a/target/linux/bmips/dts/bcm63268.dtsi
+++ b/target/linux/bmips/dts/bcm63268.dtsi
@@ -245,7 +245,7 @@
 
 				pinctrl_nand: nand-pins {
 					function = "nand";
-					group = "nand_grp";
+					pins = "nand_grp";
 				};
 
 				pinctrl_gpio35_alt: gpio35_alt-pins {
@@ -255,37 +255,37 @@
 
 				pinctrl_dectpd: dectpd-pins {
 					function = "dectpd";
-					group = "dectpd_grp";
+					pins = "dectpd_grp";
 				};
 
 				pinctrl_vdsl_phy_override_0: vdsl_phy_override_0-pins {
 					function = "vdsl_phy_override_0";
-					group = "vdsl_phy_override_0_grp";
+					pins = "vdsl_phy_override_0_grp";
 				};
 
 				pinctrl_vdsl_phy_override_1: vdsl_phy_override_1-pins {
 					function = "vdsl_phy_override_1";
-					group = "vdsl_phy_override_1_grp";
+					pins = "vdsl_phy_override_1_grp";
 				};
 
 				pinctrl_vdsl_phy_override_2: vdsl_phy_override_2-pins {
 					function = "vdsl_phy_override_2";
-					group = "vdsl_phy_override_2_grp";
+					pins = "vdsl_phy_override_2_grp";
 				};
 
 				pinctrl_vdsl_phy_override_3: vdsl_phy_override_3-pins {
 					function = "vdsl_phy_override_3";
-					group = "vdsl_phy_override_3_grp";
+					pins = "vdsl_phy_override_3_grp";
 				};
 
 				pinctrl_dsl_gpio8: dsl_gpio8-pins {
 					function = "dsl_gpio8";
-					group = "dsl_gpio8";
+					pins = "dsl_gpio8";
 				};
 
 				pinctrl_dsl_gpio9: dsl_gpio9-pins {
 					function = "dsl_gpio9";
-					group = "dsl_gpio9";
+					pins = "dsl_gpio9";
 				};
 			};
 		};

--- a/target/linux/bmips/dts/bcm6362.dtsi
+++ b/target/linux/bmips/dts/bcm6362.dtsi
@@ -320,7 +320,7 @@
 
 				pinctrl_nand: nand-pins {
 					function = "nand";
-					group = "nand_grp";
+					pins = "nand_grp";
 				};
 			};
 		};

--- a/target/linux/bmips/dts/bcm6368.dtsi
+++ b/target/linux/bmips/dts/bcm6368.dtsi
@@ -334,7 +334,7 @@
 
 				pinctrl_uart1: uart1-pins {
 					function = "uart1";
-					group = "uart1_grp";
+					pins = "uart1_grp";
 				};
 			};
 		};


### PR DESCRIPTION
The kernel logs the error "bcm6368_nand 10000200.nand: there is not valid maps for state default" on boot and all nand pins show as UNCLAIMED in sysfs pinmux-pins.

bcm63268.dtsi uses the undocumented property group which the driver doesn't understand. This has been documented upstream in commit [caf963efd4b0b9ff42ca12e52b8efe277264d35b](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/Documentation/devicetree/bindings/pinctrl/brcm,bcm63268-pinctrl.yaml?h=v6.12-rc7&id=caf963efd4b0b9ff42ca12e52b8efe277264d35b).

Replacing group with pins allows the nand pins to be properly configured.