### PR TITLE
image: apk: remove explicit distfeeds handling

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -372,12 +372,10 @@ target-dir-%: FORCE
 ifneq ($(CONFIG_USE_APK),)
 	rm -rf $(mkfs_cur_target_dir)
 	$(CP) $(TARGET_DIR_ORIG) $(mkfs_cur_target_dir)
-	mv $(mkfs_cur_target_dir)/etc/apk/repositories $(mkfs_cur_target_dir).repositories
 	$(if $(mkfs_packages_remove), \
 		$(apk_target) del $(mkfs_packages_remove))
 	$(if $(mkfs_packages_add), \
 		$(apk_target) add $(mkfs_packages_add))
-	mv $(mkfs_cur_target_dir).repositories $(mkfs_cur_target_dir)/etc/apk/repositories
 else
 	rm -rf $(mkfs_cur_target_dir) $(mkfs_cur_target_dir).opkg
 	$(CP) $(TARGET_DIR_ORIG) $(mkfs_cur_target_dir)


### PR DESCRIPTION
Currently the build fails due to the following:

```shell
 mv: cannot stat 'linux-mediatek_filogic/target-dir-7872e783/etc/apk/repositories': No such file or directory
```

as the changes done in the commit e031dab93ec3 ("base-files: move apk
distfeeds into directory") forget to adapt image generation part.

While looking into this, I've realized, that we don't need this explicit
handling in the image generating code since the feeds are solely
configured by `base-files` and `apk` packages, so those should always
provide the correct feeds content, so lets simply drop this unnecessary
code.

Fixes: #16981
Fixes: e031dab93ec3 ("base-files: move apk distfeeds into directory")
Reported-by: @ptpt52 