### PR TITLE
Fix firmware images generated by ASU

### DIFF
--- a/include/default-packages.mk
+++ b/include/default-packages.mk
@@ -1,0 +1,5 @@
+ifneq ($(CONFIG_USE_APK),)
+  DEFAULT_PACKAGES += apk-mbedtls
+else
+  DEFAULT_PACKAGES += opkg
+endif

--- a/include/target.mk
+++ b/include/target.mk
@@ -90,11 +90,6 @@ else
   endif
 endif
 
-# include ujail on systems with enough storage
-ifeq ($(filter small_flash,$(FEATURES)),)
-  DEFAULT_PACKAGES+=procd-ujail
-endif
-
 # Add device specific packages (here below to allow device type set from subtarget)
 DEFAULT_PACKAGES += $(DEFAULT_PACKAGES.$(DEVICE_TYPE))
 

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -43,7 +43,7 @@ define Package/base-files
 	+netifd +libc +jsonfilter +SIGNED_PACKAGES:usign +SIGNED_PACKAGES:openwrt-keyring \
 	+NAND_SUPPORT:ubi-utils +fstools +fwtool \
 	+SELINUX:procd-selinux +!SELINUX:procd +SECCOMP:procd-seccomp \
-	+SELINUX:busybox-selinux +!SELINUX:busybox
+	+SELINUX:busybox-selinux +!SELINUX:busybox +!SMALL_FLASH:procd-ujail
   TITLE:=Base filesystem for OpenWrt
   URL:=http://openwrt.org/
   VERSION:=$(PKG_RELEASE)~$(lastword $(subst -, ,$(REVISION)))

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -26,6 +26,7 @@ include $(INCLUDE_DIR)/debug.mk
 include $(INCLUDE_DIR)/depends.mk
 include $(INCLUDE_DIR)/rootfs.mk
 
+include $(INCLUDE_DIR)/default-packages.mk
 include $(INCLUDE_DIR)/version.mk
 export REVISION
 export SOURCE_DATE_EPOCH

--- a/target/linux/Makefile
+++ b/target/linux/Makefile
@@ -4,6 +4,7 @@
 
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/target.mk
+include $(INCLUDE_DIR)/default-packages.mk
 
 export TARGET_BUILD=1
 


### PR DESCRIPTION
### base-files,imagebuilder: unify handling of apk and opkg

Remove the remaining special handling of `apk` and `opkg` in a same way
as the rest of the packages was handled in the commit 4c65359af49b
("build: fix including busybox, procd and apk/opkg in imagebuilder") and
commit 8a38814b246a ("target,base-files: unify handling of
procd-ujail").

Fixes: #16969
Fixes: openwrt/asu/issues/1084
Fixes: 44598c233dd9 ("build: remove broken dependency of metadata on toplevel .config variables")

### target,base-files: unify handling of procd-ujail

Remove the remaining special handling of procd-ujail in a same way as
the rest of the packages was handled in the commit 4c65359af49b ("build:
fix including busybox, procd and apk/opkg in imagebuilder").

Fixes: 44598c233dd9 ("build: remove broken dependency of metadata on toplevel .config variables")
Signed-off-by: Petr Štetiar <ynezz@true.cz>