### PR TITLE
net: phy: broadcom: update dependency condition

### DIFF
--- a/target/linux/generic/pending-6.6/741-net-phy-broadcom-update-dependency-condition.patch
+++ b/target/linux/generic/pending-6.6/741-net-phy-broadcom-update-dependency-condition.patch
@@ -1,0 +1,35 @@
+From 1be3688b3eaa7ea2d9e19bd29ae6a6a51c121a0b Mon Sep 17 00:00:00 2001
+From: David Bauer <mail@david-bauer.net>
+Date: Sat, 16 Nov 2024 22:36:15 +0100
+Subject: [PATCH] net: phy: broadcom: update dependency condition
+
+The broadcom PHY driver only has to depend upon PTP_1588_CLOCK_OPTIONAL
+if NETWORK_PHY_TIMESTAMPING is enabled. The PTP functionality is stubbed
+in this case.
+
+Reflect this circumstance in the dependence condition. This allows to
+build the driver as a built-in module even if PTP is built as a module.
+
+This is required to include the broadcom PHY module regardless of the
+built-setting of the PTP subsystem. On ath79 (and probably more)
+targets with Broadcom PHY, Gigabit operation is currently broken as the
+PHY driver is only built as a module in case all kernel-packages are
+built. Due to this circumstance, affected devices fall back to using the
+generic PHY driver.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+---
+ drivers/net/phy/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/phy/Kconfig
++++ b/drivers/net/phy/Kconfig
+@@ -113,7 +113,7 @@ config BROADCOM_PHY
+ 	tristate "Broadcom 54XX PHYs"
+ 	select BCM_NET_PHYLIB
+ 	select BCM_NET_PHYPTP if NETWORK_PHY_TIMESTAMPING
+-	depends on PTP_1588_CLOCK_OPTIONAL
++	depends on NETWORK_PHY_TIMESTAMPING=n || PTP_1588_CLOCK_OPTIONAL
+ 	help
+ 	  Currently supports the BCM5411, BCM5421, BCM5461, BCM54616S, BCM5464,
+ 	  BCM5481, BCM54810 and BCM5482 PHYs.


### PR DESCRIPTION
The broadcom PHY driver only has to depend upon PTP_1588_CLOCK_OPTIONAL if NETWORK_PHY_TIMESTAMPING is enabled. The PTP functionality is stubbed in this case.

Reflect this circumstance in the dependence condition. This allows to build the driver as a built-in module even if PTP is built as a module.

This is required to include the broadcom PHY module regardless of the built-setting of the PTP subsystem. On ath79 (and probably more) targets with Broadcom PHY, Gigabit operation is currently broken as the PHY driver is only built as a module in case all kernel-packages are built. Due to this circumstance, affected devices fall back to using the generic PHY driver.