### PR TITLE
config: loongarch64,riscv64: fix missing seccomp support

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -427,7 +427,7 @@ menu "Global build settings"
 		bool "Enable SECCOMP"
 		select KERNEL_SECCOMP
 		select PACKAGE_procd-seccomp
-		depends on (aarch64 || arm || armeb || mips || mipsel || mips64 || mips64el || i386 || powerpc || x86_64)
+		depends on (aarch64 || arm || armeb || loongarch64 || mips || mipsel || mips64 || mips64el || i386 || powerpc || powerpc64 || riscv64 || x86_64)
 		depends on !TARGET_uml
 		default y
 		help


### PR DESCRIPTION
### TODO

##### loongarch64/generic

https://github.com/openwrt/openwrt/actions/runs/11887904206/job/33121449154#step:34:400

```shell
CMakeFiles/preload-seccomp.dir/jail/seccomp-oci.c.o -c '/__w/openwrt/openwrt/openwrt/build_dir/target-loongarch64-openwrt-linux-musl_musl/procd-default/procd-2024.11.13~7330fa55/jail/seccomp-oci.c'
In file included from jail/seccomp-oci.c:34:
jail/seccomp-bpf.h:94:3: error: #warning "Platform does not support seccomp filter yet" [-Werror=cpp]
   94 | # warning "Platform does not support seccomp filter yet"
      |   ^~~~~~~
```

##### d1/generic

https://github.com/openwrt/openwrt/actions/runs/11887902877/job/33121444833#step:34:290

```shell
ccache riscv64-openwrt-linux-musl-gcc -L/external-toolchain/openwrt-toolchain-d1-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/usr/lib -L/external-toolchain/openwrt-toolchain-d1-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/lib -fuse-ld=bfd -znow -zrelro  -shared -o extensions/ebtable_nat.so -lc extensions/ebtable_nat.o
mv extensions/ebtable_nat.so extensions/libebtable_nat.so
ccache riscv64-openwrt-linux-musl-gcc -L/external-toolchain/openwrt-toolchain-d1-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/usr/lib -L/external-toolchain/openwrt-toolchain-d1-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/lib -fuse-ld=bfd -znow -zrelro  -shared -o extensions/ebtable_broute.so -lc extensions/ebtable_broute.o
mv extensions/ebtable_broute.so extensions/libebtable_broute.so
ccache riscv64-openwrt-linux-musl-gcc -Os -pipe -mabi=lp64d -march=rv64imafdc -fno-caller-saves -fno-plt -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -fPIC -O3 -DPROGVERSION=\"2.0.10-4\" -DPROGNAME=\"ebtables\" -DPROGDATE=\"December\ 2011\" -D_PATH_ETHERTYPES=\"/etc/ethertypes\" -DEBTD_ARGC_MAX=50 -DEBTD_CMDLINE_MAXLN=2048 -DLOCKFILE=\"/var/lib/ebtables/lock\" -DLOCKDIR=\"/var/lib/ebtables/\" -c ebtables-standalone.c -o ebtables-standalone.o -Iinclude/
ccache riscv64-openwrt-linux-musl-gcc -shared -L/external-toolchain/openwrt-toolchain-d1-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/usr/lib -L/external-toolchain/openwrt-toolchain-d1-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/lib -fuse-ld=bfd -znow -zrelro  -Wl,-soname,libebtc.so -o libebtc.so -lc getethertype.o communication.o libebtc.o useful_functions.o ebtables.o
ccache riscv64-openwrt-linux-musl-gcc -Os -pipe -mabi=lp64d -march=rv64imafdc -fno-caller-saves -fno-plt -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -fPIC -O3 -L/external-toolchain/openwrt-toolchain-d1-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/usr/lib -L/external-toolchain/openwrt-toolchain-d1-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/lib -fuse-ld=bfd -znow -zrelro  -o ebtables ebtables-standalone.o -Iinclude/ -L. -Lextensions -lebtc -L/external-toolchain/openwrt-toolchain-d1-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/lib/ /lib/x86_64-linux-gnu/ /usr/lib/gcc/x86_64-linux-gnu/10/32/ /usr/lib/gcc/x86_64-linux-gnu/10/ /usr/lib/gcc/x86_64-linux-gnu/10/x32/ -lgcc_s  -lebt_802_3  -lebt_nat  -lebt_arp  -lebt_arpreply  -lebt_ip  -lebt_ip6  -lebt_standard  -lebt_log  -lebt_redirect  -lebt_vlan  -lebt_mark_m  -lebt_mark  -lebt_pkttype  -lebt_stp  -lebt_among  -lebt_limit  -lebt_ulog  -lebt_nflog  -lebt_string  -lebtable_filter  -lebtable_nat  -lebtable_broute \
-Wl,-rpath,/usr/lib/ebtables
/external-toolchain/openwrt-toolchain-d1-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/bin/../lib/gcc/riscv64-openwrt-linux-musl/13.3.0/../../../../riscv64-openwrt-linux-musl/bin/ld.bfd: error: /lib/x86_64-linux-gnu/: read: Is a directory
```

##### sifiveu/generic

https://github.com/openwrt/openwrt/actions/runs/11888867981/job/33124290415#step:34:360

Same issue as `d1/generic` above so perhaps something `riscv64` arch specific.

```shell
/external-toolchain/openwrt-toolchain-starfive-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/bin/../lib/gcc/riscv64-openwrt-linux-musl/13.3.0/../../../../riscv64-openwrt-linux-musl/bin/ld.bfd: error: /lib/x86_64-linux-gnu/: read: Is a directory
```

##### starfive/generic

https://github.com/openwrt/openwrt/actions/runs/11888883281/job/33124339408#step:34:352

Same issue as `d1/generic` above so perhaps something `riscv64` arch specific.

```shell
/external-toolchain/openwrt-toolchain-starfive-generic_gcc-13.3.0_musl.Linux-x86_64/toolchain-riscv64_riscv64_gcc-13.3.0_musl/bin/../lib/gcc/riscv64-openwrt-linux-musl/13.3.0/../../../../riscv64-openwrt-linux-musl/bin/ld.bfd: error: /lib/x86_64-linux-gnu/: read: Is a directory
```

-----------
### config: loongarch64,powerpc64,riscv64: fix missing seccomp support

Changes done in commit 4c65359af49b ("build: fix including busybox, procd and apk/opkg in imagebuilder") exposed missing seccomp support issue for `loongarch64`, `d1`, `qoriq`, `sifiveu` and `starfive` targets as builds for targets using those architectures started to fail:

```shell
 ERROR: unable to select packages:
  procd-seccomp (no such package):
    required by: base-files-1637~efc0c4666b[procd-seccomp]
```

Its happening as `procd-seccomp` depends on `@SECCOMP` config symbol, which is not set on those architectures. So lets fix it by enabling this

Fixes: 080a769b4da8 ("qoriq: new target")
Fixes: 99545b4bb1fa ("d1: add new target")
Fixes: 7fcb82665e96 ("loongarch64: new target")
Fixes: a3469a90c47e ("sifiveu: add new target for SiFive U-based boards")
Fixes: 4070e2a64c52 ("starfive: add new target for StarFive JH7100/7110 SoC")
Fixes: 4c65359af49b ("build: fix including busybox, procd and apk/opkg in imagebuilder")