### PR TITLE
build: rename CC_STACKPROTECTOR_* config variables

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -316,19 +316,19 @@ menu "Global build settings"
 
 	choice
 		prompt "Kernel space Stack-Smashing Protection"
-		default KERNEL_CC_STACKPROTECTOR_REGULAR
+		default KERNEL_STACKPROTECTOR_REGULAR
 		help
 		  Enable GCC Stack-Smashing Protection (SSP) for the kernel
-		config KERNEL_CC_STACKPROTECTOR_NONE
+		config KERNEL_STACKPROTECTOR_NONE
 			bool "None"
 			help
 				No stack smashing protection.
-		config KERNEL_CC_STACKPROTECTOR_REGULAR
+		config KERNEL_STACKPROTECTOR_REGULAR
 			bool "Regular"
 			help
 				Protects functions with vulnerable objects.
 				This includes functions with buffers larger than 8 bytes or calls to alloca.
-		config KERNEL_CC_STACKPROTECTOR_STRONG
+		config KERNEL_STACKPROTECTOR_STRONG
 			bool "Strong"
 			help
 				Like Regular, but also protects functions with
@@ -337,11 +337,11 @@ menu "Global build settings"
 
 	config KERNEL_STACKPROTECTOR
 		bool
-		default KERNEL_CC_STACKPROTECTOR_REGULAR || KERNEL_CC_STACKPROTECTOR_STRONG
+		default KERNEL_STACKPROTECTOR_REGULAR || KERNEL_STACKPROTECTOR_STRONG
 
 	config KERNEL_STACKPROTECTOR_STRONG
 		bool
-		default KERNEL_CC_STACKPROTECTOR_STRONG
+		default KERNEL_STACKPROTECTOR_STRONG
 
 	choice
 		prompt "Enable buffer-overflows detection (FORTIFY_SOURCE)"


### PR DESCRIPTION
Commit message:
```
In OpenWrt, kernel config options are applied by copying all Openwrt config options prefixed with KERNEL_* into the kernel config. This is performed during the `Kernel/Configure` step of include/kernel-defaults.mk.

Since kernel v4.18, the kernel config options for enabling stack-protector mitigations have been renamed from CC_STACKPROTECTOR_* to STACKPROTECTOR_*. (see kernel commit 050e9baa9dc9fbd9ce2b27f0056990fc9e0a08a0)

This breaks the enablement of stack-protector in the kernel as STACKPROTECTOR options prefixed by "CC_" are no longer recognised by the kernel's build process.

This commit fixes this issue by aligning Openwrt config variable names with the kernel once again.
```

Hello, this is my first PR to the OpenWrt project! Although, I've tried to adhere to the patch submission rules as well as I can, I am more than happy to fix any problems. I would like to express my gratitude for the volunteers, developers and maintainers alike who poured innumerable hours of work, to ensuring wireless freedom for all!

Although this is quite a minor change, AFAICT, since OpenWrt 21.02, which updated the kernel >4.18, the kernel stack-protector mitigation has not been compiled in due to this issue.