### PR TITLE
omnia-eeprom: depend only on subtarget

### DIFF
--- a/package/utils/omnia-eeprom/Makefile
+++ b/package/utils/omnia-eeprom/Makefile
@@ -29,7 +29,7 @@ define Package/omnia-eeprom
   CATEGORY:=Utilities
   URL:=https://gitlab.nic.cz/turris/omnia-eeprom
   TITLE:=CZ.NIC Turris Omnia EEPROM accessing utility
-  DEPENDS:=@TARGET_mvebu_cortexa9_DEVICE_cznic_turris-omnia +kmod-eeprom-at24
+  DEPENDS:=@TARGET_mvebu_cortexa9 +kmod-eeprom-at24
 endef
 
 define Package/omnia-eeprom/description


### PR DESCRIPTION
Now that omnia-eeprom is marked nonshared building the cortex-a9 mvebu subtarget will fail with:
```
ERROR: unable to select packages:
  omnia-eeprom (no such package):
    required by: world[omnia-eeprom]
```

This is because omnia-eeprom depends on TARGET_mvebu_cortexa9_DEVICE_cznic_turris-omnia which will not be satisfied in buildbots since CONFIG_TARGET_ALL_PROFILES and CONFIG_TARGET_PER_DEVICE_ROOTFS are set in which case CONFIG_TARGET_mvebu_cortexa9_DEVICE_cznic_turris-omnia is not set.

So, lets simply depend on the mvebu/cortex-a9 subtarget.

Fixes: 371e7bef4046 ("omnia-eeprom: Mark it nonshared")
