### PR TITLE
include/package-pack: add default 'provider_priority' for APK packages

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -359,7 +359,7 @@ else
 			) \
 		), \
 		$$(prov) )" \
-	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100") \
+	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100",$(if $(PROVIDES),--info "provider-priority:1")) \
 	  --script "post-install:$$(ADIR_$(1))/post-install" \
 	  --script "pre-deinstall:$$(ADIR_$(1))/pre-deinstall" \
 	  --info "depends:$$(foreach depends,$$(subst $$(comma),$$(space),$$(subst $$(space),,$$(subst $$(paren_right),,$$(subst $$(paren_left),,$$(Package/$(1)/DEPENDS))))),$$(depends))" \


### PR DESCRIPTION
Currently, trying to use APK to install a package that has a dependency on a virtual package that needs to be resolved via 'provides' it will fail if package does not have 'DEFAULT_VARIANT:=1' like:
```
apk add usbutils
ERROR: unable to select packages:
  libudev (virtual):
    note: please select one of the 'provided by' packages explicitly
    provided by: libudev-zero
    required by: usbutils-017-r1[libudev]
```

Issue is that we dont set 'provider_priority' that APK uses to break ties when choosing a virtual package to satisfy a dependency and thus despite only one package providing the dependency it will still end up with a tie and just error out.

So, lets simply fix this by providing a default value for 'provider_priority' when 'DEFAULT_VARIANT' is not set and then APK will be able to resolve dependencies.

Fixes: #16976 
