### PR TITLE
config: powerpc64: fix missing seccomp support on qoriq target

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -427,7 +427,7 @@ menu "Global build settings"
 		bool "Enable SECCOMP"
 		select KERNEL_SECCOMP
 		select PACKAGE_procd-seccomp
-		depends on (aarch64 || arm || armeb || mips || mipsel || mips64 || mips64el || i386 || powerpc || x86_64)
+		depends on (aarch64 || arm || armeb || mips || mipsel || mips64 || mips64el || i386 || powerpc || powerpc64 || x86_64)
 		depends on !TARGET_uml
 		default y
 		help


### PR DESCRIPTION
Cc: @stintel 

Changes done in commit 4c65359af49b ("build: fix including busybox, procd and apk/opkg in imagebuilder") exposed missing seccomp support issue:

```shell
 ERROR: unable to select packages:
  procd-seccomp (no such package):
    required by: base-files-1637~efc0c4666b[procd-seccomp]
```

Its happening as `procd-seccomp` depends on `@SECCOMP` config symbol, which is not set. So lets fix it by enabling this feature.

Fixes: 080a769b4da8 ("qoriq: new target")
Fixes: 4c65359af49b ("build: fix including busybox, procd and apk/opkg in imagebuilder")