### PR TITLE
armsr: fix serial console regression on device tree systems

### DIFF
--- a/target/linux/armsr/image/Makefile
+++ b/target/linux/armsr/image/Makefile
@@ -12,7 +12,6 @@ GRUB_TERMINAL_CONFIG =
 GRUB_CONSOLE_CMDLINE = earlycon
 
 ifneq ($(CONFIG_GRUB_CONSOLE),)
-  GRUB_CONSOLE_CMDLINE += console=tty1
   GRUB_TERMINALS += console
 endif
 

--- a/target/linux/armsr/patches-6.6/300-printk-always-setup-default-consoles.patch
+++ b/target/linux/armsr/patches-6.6/300-printk-always-setup-default-consoles.patch
@@ -1,0 +1,47 @@
+From 0059efbd0f9c291795078fb4e50722641d525f38 Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Thu, 16 Jan 2025 11:48:44 +1100
+Subject: [PATCH] printk: always setup default (tty0 + stdout / SPCR) consoles
+ when no console= present
+
+(This is a hack specific to OpenWrt's armsr target)
+
+This change resolves a difference in behaviour between arm64 ACPI
+and DT systems.
+Our usecase is to ensure the system console is always present
+regardless of display mode (serial port or screen).
+
+Both ACPI and DT have mechanisms to setup a serial console from
+information passed by firmware (SPCR and stdout-path respectively).
+
+On ACPI systems, the SPCR table is parsed very early on in the kernel
+boot which prevents the screen console (tty0) from appearing if it is
+not explicitly set.
+
+We would like to avoid specifying console= arguments as there are many
+possible configurations on the serial side (like ttyS0, ttyAMA0, ttymxc0
+etc.).
+
+If the kernel does not consume the serial port in SPCR/stdout-path,
+then the 'default' settings from the firmware (baud rate etc.) are lost.
+
+If the system administrator explicitly specifies a console= argument,
+then the old behaviour is returned.
+
+Signed-off-by: Mathew McBride <matt@traverse.com.au>
+Link: https://github.com/openwrt/openwrt/pull/17012#issuecomment-2591751115
+---
+ kernel/printk/printk.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/kernel/printk/printk.c
++++ b/kernel/printk/printk.c
+@@ -3505,7 +3505,7 @@ void register_console(struct console *ne
+ 	 * Note that a console with tty binding will have CON_CONSDEV
+ 	 * flag set and will be first in the list.
+ 	 */
+-	if (preferred_console < 0) {
++	if (!console_set_on_cmdline) {
+ 		if (hlist_empty(&console_list) || !console_first()->device ||
+ 		    console_first()->flags & CON_BOOT) {
+ 			try_enable_default_console(newcon);


### PR DESCRIPTION
~This reverts a portion of #16213 . The addition to inittab for tty1 and change of cmdline on x86 remains.~
**New (January 2025) proposed solution: https://github.com/openwrt/openwrt/pull/17012#issuecomment-2591751115**

This solution makes the kernel always setup the framebuffer (tty0) console, preventing the need to specify any console= on the command line in both serial and screen cases.
The kernel was not setting up tty0 when an ACPI-specified serial port (SPCR) is present, as some system firmwares do not remove the SPCR when a screen is present.

----  


The addition of console=tty1 to the kernel command line will break the default console setup on boards using device tree and without a graphical/framebuffer console, as that will replace any setting supplied by the system firmware.

Instead of forcing the console=tty1 as default on all armsr images, I suggest we do:

1. Add a separate image profile intended for graphical setups (the generic image will work on all machines, but with the kernel boot output not visible on framebuffers)

and/or

**2.** Patch the kernel so the "stdout" console specified in device tree is activated alongside any console= specified on the command line, mirroring existing behavior on ACPI systems (see below) **(current proposed solution)**

and/or

3. Set up some method of persisting custom command lines across sysupgrade (e.g something in /etc/config gets applied by sysupgrade, like `/etc/default/grub` on mainstream distros), so if the user wants to customize the setting for their specific system, it won't be overriden on upgrade.


This is what happens on my LS1088A board:
```
[    0.000000] Linux version 6.6.60 (buildbot@bf03311b041f) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 13.3.0 r27587+508-38bb47c36c) 13.3.0, GNU ld (GNU Binutils) 2.42) #0 SMP Fri Nov 15 03:31:56 2024
[    0.000000] KASLR enabled
[    0.000000] Machine model: Traverse Ten64
...
[    0.008413] Console: colour dummy device 80x25
[    0.012882] printk: console [tty1] enabled
[    0.017000] printk: bootconsole [ns16550a0] disabled
< no further output >
```

The tty on ttyS0 is spawned, but at 9600 instead of the 115200 the board started with.
I have reproduced the issue on another SoC (the Coral 'phanbell' dev board / NXP i.MX8M+). I believe most other boards using device tree and no framebuffer's will also be affected.

When the QEMU virtual machine is used with u-boot and no graphics (`-nographic`) it is also slightly affected, with no kernel output between the serial console being disabled and askfirst:
```
[    0.004485] printk: console [tty1] enabled
[    0.005919] printk: bootconsole [pl11] disabled
Please press Enter to activate this console.
```
The QEMU console will adopt the baud rate that the virtualized OS sets up, meaning the lack of baud rate retention is not a visible issue.

Boards with ACPI firmware do not appear to be affected as the kernel will activate consoles specified by ACPI (in the SPCR table) regardless of the console= supplied.
On DT we have the `stdout-path` attribute under the `chosen` node, but any `console=` settings will override it.
 
