### PR TITLE
ramips: mt7620: add support for Dlink DAP-1620-A2

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -349,7 +349,7 @@ ifeq ($(PACKAGE),)
 endif
 	@$(MAKE) -s package_reload
 ifeq ($(CONFIG_USE_APK),)
-	@$(OPKG) list --depends $(PACKAGE)
+	@$(OPKG) whatdepends -A $(PACKAGE)
 else
 	@$(APK) list --depends $(PACKAGE)
 endif
@@ -363,7 +363,7 @@ endif
 ifeq ($(CONFIG_USE_APK),)
 	@$(OPKG) depends -A $(PACKAGE)
 else
-	@$(OPKG) whatdepends -A $(PACKAGE)
+	@$(APK) info --depends $(PACKAGE)
 endif
 
 .SILENT: help info image manifest package_whatdepends package_depends

--- a/target/linux/ramips/dts/mt7620a_dlink_dap-1620-a2.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dap-1620-a2.dts
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: GPL-2.0-or-later or MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "dlink,dap-1620-a2", "ralink,mt7620a-soc";
+	model = "D-Link DAP-1620 A2";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: status_red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status_green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_low_red {
+			label = "red:rssilow";
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_low_green {
+			label = "green:rssilow";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_med_green {
+			label = "green:rssimed";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_high_green {
+			label = "green:rssihigh";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "nvram";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					macaddr_factory_ffd4: macaddr@ffd4 {
+						compatible = "mac-base";
+						reg = <0xffd4 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_ffe8: macaddr@ffe8 {
+						compatible = "mac-base";
+						reg = <0xffe8 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf", "nd_sd";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &rgmii2_pins &mdio_pins>;
+
+	nvmem-cells = <&macaddr_factory_ffe8 0>;
+	nvmem-cell-names = "mac-address";
+
+	mediatek,portmap = "wllll";
+
+	port@5 {
+		status = "okay";
+		mediatek,fixed-link = <1000 1 1 1>;
+		phy-mode = "rgmii";
+	};
+
+	mdio-bus {
+		status = "okay";
+
+		phy0: ethernet-phy@0 {
+			reg = <0>;
+			phy-mode = "rgmii";
+		};
+
+		phy1: ethernet-phy@1 {
+			reg = <1>;
+			phy-mode = "rgmii";
+		};
+
+		phy1f: ethernet-phy@1f {
+			reg = <0x1f>;
+			phy-mode = "rgmii";
+		};
+	};
+};
+
+&gsw {
+	mediatek,ephy-base = /bits/ 8 <12>;
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_ffd4 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_ffd4 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -207,6 +207,16 @@ define Device/comfast_cf-wr800n
 endef
 TARGET_DEVICES += comfast_cf-wr800n
 
+define Device/dlink_dap-1620-a2
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DAP-1620
+  IMAGE_SIZE := 7872k
+  DEVICE_VARIANT := A2
+  SOC := mt7620a
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-mt76x2 rssileds
+endef
+TARGET_DEVICES += dlink_dap-1620-a2
+
 define Device/dlink_dch-m225
   $(Device/seama)
   SOC := mt7620a

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -49,6 +49,13 @@ comfast,cf-wr800n)
 	ucidef_set_led_netdev "lan" "lan" "white:ethernet" eth0.1
 	ucidef_set_led_netdev "wifi_led" "wifi" "white:wifi" "wlan0"
 	;;
+dlink,dap-1620-a2)
+	ucidef_set_rssimon "wlan1" "200000" "1"
+	ucidef_set_led_rssi "rssilow" "rssilow" "red:rssilow" "wlan1" "1" "40"
+	ucidef_set_led_rssi "rssimediumlow" "rssimediumlow" "green:rssilow" "wlan1" "41" "100"
+	ucidef_set_led_rssi "rssimediumhigh" "rssimediumhigh" "green:rssimed" "wlan1" "61" "100"
+	ucidef_set_led_rssi "rssihigh" "rssihigh" "green:rssihigh" "wlan1" "81" "100"
+	;;
 dlink,dir-806a-b1)
 	ucidef_set_led_netdev "wifi_led" "2.4g" "green:wlan" "phy1-ap0"
 	;;

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -111,6 +111,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan" "6@eth0"
 		;;
+	dlink,dap-1620-a2)
+		ucidef_add_switch "switch0" \
+			"5:lan" "6@eth0"
+		;;
 	dlink,dir-510l)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"


### PR DESCRIPTION
Hello,

Add support for D-Link DAP-1620-A2 device.

A bit older device, but nevertheless has a decent hardware (64/8 and both 2.4 & 5). The firmware package needs to be pushed to device through U-Boot serial port and can't be done through Web UI, since the recovery occupies the second part of NAND. Can add the details to the wiki page once the code is merged and compiled.

Waiting for OpenWrt based compile of image. Anyways added the OpenWrt boot log to the wiki already. Available here:
https://openwrt.org/inbox/toh/d-link/d-link_dap-1620

Made few updates based on previous comment as noted below. Any further questions, please let me know.
https://github.com/openwrt/openwrt/pull/16911
https://github.com/openwrt/openwrt/pull/17002

Thanks