### PR TITLE
build: apk: Fix package cleaning

### DIFF
--- a/include/feeds.mk
+++ b/include/feeds.mk
@@ -20,7 +20,7 @@ opkg_package_files = $(wildcard \
 
 apk_package_files = $(wildcard \
 	$(foreach dir,$(PACKAGE_SUBDIRS), \
-	  $(foreach pkg,$(1), $(dir)/$(pkg)_*.apk)))
+	  $(foreach pkg,$(1), $(dir)/$(pkg)-*.apk)))
 
 # 1: package name
 define FeedPackageDir


### PR DESCRIPTION
Fix the regex for removing packages. APK uses a "-" between the package name and the version. opkg used a "_" between them. This fixes removing package in build clean when using apk.

This generates for example this file name:
```
/home/hauke/openwrt/openwrt/bin/packages/mips_24kc/base/libmbedtls21-3.6.2-r1.apk
```

In OPKG we used _ to seperate the package name and the version string. With apk we use a - and can not really say where the package name ends and where the version begins. 
