### PR TITLE
imagebuilder: package_whatdepends and package_depends fixes

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -349,7 +349,7 @@ ifeq ($(PACKAGE),)
 endif
 	@$(MAKE) -s package_reload
 ifeq ($(CONFIG_USE_APK),)
-	@$(OPKG) list --depends $(PACKAGE)
+	@$(OPKG) whatdepends -A $(PACKAGE)
 else
 	@$(APK) list --depends $(PACKAGE)
 endif

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -363,7 +363,7 @@ endif
 ifeq ($(CONFIG_USE_APK),)
 	@$(OPKG) depends -A $(PACKAGE)
 else
-	@$(OPKG) whatdepends -A $(PACKAGE)
+	@$(APK) info --depends $(PACKAGE)
 endif
 
 .SILENT: help info image manifest package_whatdepends package_depends


### PR DESCRIPTION
It seems that `package_whatdepends` for OPKG got broken when APK was being added and `package_depends` for APK support never worked, so this PR provides fixes for them.

`package_whatdepends` for OPKG is broken in 24.10 as well so I plan to backport it there as well.