### PR TITLE
include/package-pack: actually call default_postinist/prerm with APK

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -110,6 +110,13 @@ endif
     IDIR_$(1):=$(PKG_BUILD_DIR)/ipkg-$(PKGARCH)/$(1)
     ADIR_$(1):=$(PKG_BUILD_DIR)/apk-$(PKGARCH)/$(1)
     KEEP_$(1):=$(strip $(call Package/$(1)/conffiles))
+    APK_SCRIPTS_$(1):=\
+    --script "post-install:$$(ADIR_$(1))/post-install" \
+    --script "pre-deinstall:$$(ADIR_$(1))/pre-deinstall"
+
+    ifdef Package/$(1)/postrm
+        APK_SCRIPTS_$(1)+=--script "post-deinstall:$$(ADIR_$(1))/postrm"
+    endif
 
     TARGET_VARIANT:=$$(if $(ALL_VARIANTS),$$(if $$(VARIANT),$$(filter-out *,$$(VARIANT)),$(firstword $(ALL_VARIANTS))))
     ifeq ($(BUILD_VARIANT),$$(if $$(TARGET_VARIANT),$$(TARGET_VARIANT),$(BUILD_VARIANT)))
@@ -360,8 +367,7 @@ else
 		), \
 		$$(prov) )" \
 	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100",$(if $(PROVIDES),--info "provider-priority:1")) \
-	  --script "post-install:$$(ADIR_$(1))/post-install" \
-	  --script "pre-deinstall:$$(ADIR_$(1))/pre-deinstall" \
+	  $$(APK_SCRIPTS_$(1)) \
 	  --info "depends:$$(foreach depends,$$(subst $$(comma),$$(space),$$(subst $$(space),,$$(subst $$(paren_right),,$$(subst $$(paren_left),,$$(Package/$(1)/DEPENDS))))),$$(depends))" \
 	  --files "$$(IDIR_$(1))" \
 	  --output "$$(PACK_$(1))" \

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -294,8 +294,8 @@ else
 		echo 'export root="$$$${IPKG_INSTROOT}"'; \
 		echo 'export pkgname="$(1)"'; \
 		echo "add_group_and_user"; \
-		[ ! -f $$(ADIR_$(1))/postinst-pkg ] || cat "$$(ADIR_$(1))/postinst-pkg"; \
 		echo "default_postinst"; \
+		[ ! -f $$(ADIR_$(1))/postinst-pkg ] || cat "$$(ADIR_$(1))/postinst-pkg"; \
 	) > $$(ADIR_$(1))/post-install;
 
 	( \
@@ -304,8 +304,8 @@ else
 		echo ". \$$$${IPKG_INSTROOT}/lib/functions.sh"; \
 		echo 'export root="$$$${IPKG_INSTROOT}"'; \
 		echo 'export pkgname="$(1)"'; \
-		[ ! -f $$(ADIR_$(1))/prerm-pkg ] || cat "$$(ADIR_$(1))/prerm-pkg"; \
 		echo "default_prerm"; \
+		[ ! -f $$(ADIR_$(1))/prerm-pkg ] || cat "$$(ADIR_$(1))/prerm-pkg"; \
 	) > $$(ADIR_$(1))/pre-deinstall;
 
 	if [ -n "$(USERID)" ]; then echo $(USERID) > $$(IDIR_$(1))/lib/apk/packages/$(1).rusers; fi;


### PR DESCRIPTION
Currently, when you install a package that ships uci-defaults scripts they are not getting executed during package installation.

For example, if you install a new LuCI theme it ships a uci-defaults script to add it to the UCI LuCI config so the theme is actually selectable but that does not happen until the device is rebooted so that uci-defaults script is actually executed.

It turns out that the recipe for post-install is the issue since it will include contents of postinst-pkg before the call to default_postinist. This is an issue since postinst-pkg will exit with code 0 before we ever reach the call to default_postinist.

So, lets simply make the call to default_postinist before postinst-pkg inclusion which is what OPKG based installation does.

The same issue affects pre-deinstall script but its not actually being hit since we dont seem to be actually even generating prerm-pkg scripts but lets fix this theoretical issue as well.

Fixes: #16987
Fixes: d788ab376f85 ("build: add APK package build capabilities")
