### PR TITLE
ipq40xx: Support Meraki MR30H, Z3, Go GX20

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -57,6 +57,7 @@ ALLWIFIBOARDS:= \
 	linksys_mx8500 \
 	linksys_spnmx56 \
 	linksys_whw03 \
+	meraki_mr30h \
 	meraki_z3 \
 	netgear_lbr20 \
 	netgear_rax120v2 \
@@ -231,6 +232,7 @@ $(eval $(call generate-ipq-wifi-package,linksys_mx5500,Linksys MX5500))
 $(eval $(call generate-ipq-wifi-package,linksys_mx8500,Linksys MX8500))
 $(eval $(call generate-ipq-wifi-package,linksys_spnmx56,Linksys SPNMX56))
 $(eval $(call generate-ipq-wifi-package,linksys_whw03,Linksys WHW03))
+$(eval $(call generate-ipq-wifi-package,meraki_mr30h,Meraki MR30H))
 $(eval $(call generate-ipq-wifi-package,meraki_z3,Meraki Z3))
 $(eval $(call generate-ipq-wifi-package,netgear_lbr20,Netgear LBR20))
 $(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -57,6 +57,7 @@ ALLWIFIBOARDS:= \
 	linksys_mx8500 \
 	linksys_spnmx56 \
 	linksys_whw03 \
+	meraki_z3 \
 	netgear_lbr20 \
 	netgear_rax120v2 \
 	netgear_sxk80 \
@@ -230,6 +231,7 @@ $(eval $(call generate-ipq-wifi-package,linksys_mx5500,Linksys MX5500))
 $(eval $(call generate-ipq-wifi-package,linksys_mx8500,Linksys MX8500))
 $(eval $(call generate-ipq-wifi-package,linksys_spnmx56,Linksys SPNMX56))
 $(eval $(call generate-ipq-wifi-package,linksys_whw03,Linksys WHW03))
+$(eval $(call generate-ipq-wifi-package,meraki_z3,Meraki Z3))
 $(eval $(call generate-ipq-wifi-package,netgear_lbr20,Netgear LBR20))
 $(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))
 $(eval $(call generate-ipq-wifi-package,netgear_sxk80,Netgear SXK80))

--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -96,6 +96,18 @@ mobipromo,cm520-79f)
 	ucidef_set_led_netdev "lan1" "LAN1" "blue:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "LAN2" "blue:lan2" "lan2"
 	;;
+meraki,z3)
+	ucidef_set_led_netdev "wan_link" "WAN (link)" "green:wan-0" "wan" "link"
+	ucidef_set_led_netdev "wan_act" "WAN (txrx)" "green:wan-1" "wan" "tx rx"
+	ucidef_set_led_netdev "lan1_link" "LAN2 (link)" "green:lan-2" "lan2" "link"
+	ucidef_set_led_netdev "lan1_act" "LAN2 (txrx)" "green:lan-3" "lan2" "tx rx"
+	ucidef_set_led_netdev "lan2_link" "LAN3 (link)" "green:lan-4" "lan3" "link"
+	ucidef_set_led_netdev "lan2_act" "LAN3 (txrx)" "green:lan-5" "lan3" "tx rx"
+	ucidef_set_led_netdev "lan3_link" "LAN4 (link)" "green:lan-6" "lan4" "link"
+	ucidef_set_led_netdev "lan3_act" "LAN4 (txrx)" "green:lan-7" "lan4" "tx rx"
+	ucidef_set_led_netdev "lan4_link" "LAN5 (link)" "green:lan-8" "lan5" "link"
+	ucidef_set_led_netdev "lan4_act" "LAN5 (txrx)" "green:lan-9" "lan5" "tx rx"
+	;;
 netgear,ex6100v2 |\
 netgear,ex6150v2)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:router" "phy0tpt"

--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -96,6 +96,7 @@ mobipromo,cm520-79f)
 	ucidef_set_led_netdev "lan1" "LAN1" "blue:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "LAN2" "blue:lan2" "lan2"
 	;;
+meraki,gx20 |\
 meraki,z3)
 	ucidef_set_led_netdev "wan_link" "WAN (link)" "green:wan-0" "wan" "link"
 	ucidef_set_led_netdev "wan_act" "WAN (txrx)" "green:wan-1" "wan" "tx rx"

--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -109,6 +109,16 @@ meraki,z3)
 	ucidef_set_led_netdev "lan4_link" "LAN5 (link)" "green:lan-8" "lan5" "link"
 	ucidef_set_led_netdev "lan4_act" "LAN5 (txrx)" "green:lan-9" "lan5" "tx rx"
 	;;
+meraki,mr30h)
+	ucidef_set_led_netdev "lan1_link" "LAN1 (link)" "green:lan-0" "lan1" "link"
+	ucidef_set_led_netdev "lan1_act" "LAN1 (txrx)" "amber:lan-1" "lan1" "tx rx"
+	ucidef_set_led_netdev "lan2_link" "LAN2 (link)" "green:lan-2" "lan2" "link"
+	ucidef_set_led_netdev "lan2_act" "LAN2 (txrx)" "amber:lan-3" "lan2" "tx rx"
+	ucidef_set_led_netdev "lan3_link" "LAN3 (link)" "green:lan-4" "lan3" "link"
+	ucidef_set_led_netdev "lan3_act" "LAN3 (txrx)" "amber:lan-5" "lan3" "tx rx"
+	ucidef_set_led_netdev "lan4_link" "LAN4 (link)" "green:lan-6" "lan4" "link"
+	ucidef_set_led_netdev "lan4_act" "LAN4 (txrx)" "amber:lan-7" "lan4" "tx rx"
+	;;
 netgear,ex6100v2 |\
 netgear,ex6150v2)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:router" "phy0tpt"

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -29,6 +29,9 @@ ipq40xx_setup_interfaces()
 	zyxel,nbg6617)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;
+	meraki,z3)
+		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
+		;;
 	8dev,jalapeno|\
 	alfa-network,ap120c-ac|\
 	asus,map-ac2200|\

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -29,6 +29,7 @@ ipq40xx_setup_interfaces()
 	zyxel,nbg6617)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;
+	meraki,gx20|\
 	meraki,z3)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
 		;;

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -138,6 +138,9 @@ ipq40xx_setup_interfaces()
 		ucidef_set_interface_lan "lan1 lan2"
 		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
 		;;
+	meraki,mr30h)
+		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
+		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"
 		;;

--- a/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
@@ -21,6 +21,7 @@ cilab,meshpoint-one)
 compex,wpj428)
 	ucidef_add_gpio_switch "sim_card_select" "SIM card select" "3" "0"
 	;;
+meraki,gx20|\
 meraki,z3)
 	ucidef_add_gpio_switch "lan5_poe_disable" "LAN5 PoE disable" "540" "0"
 	;;

--- a/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
@@ -21,6 +21,9 @@ cilab,meshpoint-one)
 compex,wpj428)
 	ucidef_add_gpio_switch "sim_card_select" "SIM card select" "3" "0"
 	;;
+meraki,z3)
+	ucidef_add_gpio_switch "lan5_poe_disable" "LAN5 PoE disable" "540" "0"
+	;;
 mikrotik,cap-ac)
 	ucidef_add_gpio_switch "poe_passtrough" "POE passtrough enable" "514" "0"
 	;;

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -178,6 +178,7 @@ platform_do_upgrade() {
 	linksys,whw03)
 		platform_do_upgrade_linksys_emmc "$1"
 		;;
+	meraki,mr30h |\
 	meraki,mr33 |\
 	meraki,mr74)
 		CI_KERNPART="part.safe"

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -183,6 +183,13 @@ platform_do_upgrade() {
 		CI_KERNPART="part.safe"
 		nand_do_upgrade "$1"
 		;;
+	meraki,z3)
+		# DO NOT set CI_KERNPART to part.safe,
+		# that is used for chain-loading an unlocked u-boot
+		# if part.safe is overwritten, then u-boot is lost!
+		CI_KERNPART="part.old"
+		nand_do_upgrade "$1"
+		;;
 	mikrotik,cap-ac|\
 	mikrotik,hap-ac2|\
 	mikrotik,hap-ac3-lte6-kit|\

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -183,6 +183,7 @@ platform_do_upgrade() {
 		CI_KERNPART="part.safe"
 		nand_do_upgrade "$1"
 		;;
+	meraki,gx20|\
 	meraki,z3)
 		# DO NOT set CI_KERNPART to part.safe,
 		# that is used for chain-loading an unlocked u-boot

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-gx20.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-gx20.dts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Device Tree Source for Meraki Go GX20 (Fairyfly)
+
+#include "qcom-ipq4029-wired-qca-common.dtsi"
+
+/ {
+	model = "Meraki Go GX20 Router";
+	compatible = "meraki,gx20";
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_orange: power {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&tlmm 49 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led-1 {
+			/* WAN left */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			function-enumerator = <0>;
+			gpios = <&tlmm 46 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			/* WAN right */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			function-enumerator = <1>;
+			gpios = <&tlmm 30 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			/* port 2 left */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&tlmm 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			/* port 2 right */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			/* port 3 left */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led-6 {
+			/* port 3 right */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <5>;
+			gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led-7 {
+			/* port 4 left */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <6>;
+			gpios = <&tlmm 29 GPIO_ACTIVE_LOW>;
+		};
+
+		led-8 {
+			/* port 4 right */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <7>;
+			gpios = <&tlmm 26 GPIO_ACTIVE_LOW>;
+		};
+
+		led-9 {
+			/* port 5 left */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <8>;
+			gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
+		};
+
+		led-10 {
+			/* port 5 right */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <9>;
+			gpios = <&tlmm 32 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+/* GX20 does not have WiFi radios */
+&wifi0 {
+	status = "disabled";
+};
+
+&wifi1 {
+	status = "disabled";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr30h.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr30h.dts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Device Tree Source for Meraki MR30H (Noisy Cricket)
+
+#include "qcom-ipq4029-wired-qca-common.dtsi"
+
+/ {
+	model = "Meraki MR30H";
+	compatible = "meraki,mr30h";
+
+	soc {
+		/* for USB PHY, device has no USB port */
+		tcsr@194b000 {
+			status = "disabled";
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_orange: power {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&tlmm 49 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led-0 {
+			/* LAN 1 act */
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_ACTIVITY;
+			gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&tlmm 32 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			/* LAN 2 act */
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_ACTIVITY;
+			gpios = <&tlmm 27 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&tlmm 26 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			/* LAN 3 act */
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_ACTIVITY;
+			gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led-6 {
+			/* LAN 4 act */
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_ACTIVITY;
+			gpios = <&tlmm 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led-7 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&usb2_hs_phy {
+	status = "disabled";
+};
+
+&usb2 {
+	status = "disabled";
+};
+
+&usb3_hs_phy {
+	status = "disabled";
+};
+
+&usb3_ss_phy {
+	status = "disabled";
+};
+
+&usb3 {
+	status = "disabled";
+};
+
+&pcie0 {
+	status = "okay";
+	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+};
+
+&pcie_bridge0 {
+	wifi2: wifi@0,0 {
+		compatible = "qcom,ath10k";
+		status = "okay";
+		reg = <0x00010000 0 0 0 0>;
+		nvmem-cells = <&cal_factory_9000>;
+		nvmem-cell-names = "calibration";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "Meraki-MR30H";
+};
+
+&wifi1 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "Meraki-MR30H";
+};
+
+
+&swport1 {
+	label = "lan4";
+	status = "okay";
+};
+
+&swport2 {
+	label = "lan3";
+	status = "okay";
+};
+
+&swport3 {
+	label = "lan2";
+	status = "okay";
+};
+
+&swport4 {
+	label = "lan1";
+	status = "okay";
+};
+
+&swport5 {
+	label = "lan5";
+	status = "okay";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-wired-qca-common.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-wired-qca-common.dtsi
@@ -1,0 +1,411 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Device Tree Source for Meraki "wired-arm-qca" series
+ *
+ * Copyright (C) 2017 Chris Blake <chrisrblake93@gmail.com>
+ * Copyright (C) 2017 Christian Lamparter <chunkeey@googlemail.com>
+ * Copyright (C) 2025 Hal Martin <halmartin@googlemail.com>
+ *
+ */
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &status_green;
+		led-failsafe = &status_red;
+		led-running = &status_green;
+		led-upgrade = &power_orange;
+	};
+
+	soc {
+		/* It is a 56-bit counter that supplies the count to the ARM arch
+		   timers and without upstream driver */
+		counter@4a1000 {
+			compatible = "qcom,qca-gcnt";
+			reg = <0x4a1000 0x4>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			/* select hostmode */
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+			status = "okay";
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_uart1 {
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&blsp1_i2c3 {
+	pinctrl-0 = <&i2c_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	eeprom@50 {
+		compatible = "atmel,24c64";
+		pagesize = <32>;
+		reg = <0x50>;
+		read-only; /* This holds our MAC & Meraki board-data */
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			mac_address: mac-address@66 {
+				compatible = "mac-base";
+				reg = <0x66 0x6>;
+				#nvmem-cell-cells = <1>;
+			};
+		};
+	};
+};
+
+&blsp1_i2c4 {
+	pinctrl-0 = <&i2c_1_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	tricolor: led-controller@30 {
+		compatible = "ti,lp5562";
+		reg = <0x30>;
+		clock-mode = /bits/8 <2>;
+		enable-gpio = <&tlmm 48 GPIO_ACTIVE_HIGH>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* RGB led */
+		status_red: chan@0 {
+			chan-name = "red:status";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+		};
+
+		status_green: chan@1 {
+			chan-name = "green:status";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		chan@2 {
+			chan-name = "blue:status";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+
+		chan@3 {
+			chan-name = "white:status";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			reg = <3>;
+			color = <LED_COLOR_ID_WHITE>;
+		};
+	};
+};
+
+&nand {
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	nand@0 {
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "sbl1";
+				reg = <0x00000000 0x00100000>;
+				read-only;
+			};
+			partition@100000 {
+				label = "mibib";
+				reg = <0x00100000 0x00100000>;
+				read-only;
+			};
+			partition@200000 {
+				label = "bootconfig";
+				reg = <0x00200000 0x00100000>;
+				read-only;
+			};
+			partition@300000 {
+				label = "qsee";
+				reg = <0x00300000 0x00100000>;
+				read-only;
+			};
+			partition@400000 {
+				label = "qsee_alt";
+				reg = <0x00400000 0x00100000>;
+				read-only;
+			};
+			partition@500000 {
+				label = "cdt";
+				reg = <0x00500000 0x00080000>;
+				read-only;
+			};
+			partition@580000 {
+				label = "cdt_alt";
+				reg = <0x00580000 0x00080000>;
+				read-only;
+			};
+			partition@600000 {
+				label = "ddrparams";
+				reg = <0x00600000 0x00080000>;
+				read-only;
+			};
+			partition@700000 {
+				label = "u-boot";
+				reg = <0x00700000 0x00200000>;
+				read-only;
+			};
+			partition@900000 {
+				label = "u-boot-backup";
+				reg = <0x00900000 0x00200000>;
+				read-only;
+			};
+			partition@b00000 {
+				label = "ART";
+				reg = <0x00b00000 0x00080000>;
+				read-only;
+			};
+			partition@c00000 {
+				compatible = "linux,ubi";
+				reg = <0x00c00000 0x07000000>;
+				label = "ubi";
+				/*
+				 * Do not try to allocate the remaining
+				 * 4 MiB to this ubi partition. It will
+				 * confuse the u-boot and it might not
+				 * find the kernel partition anymore.
+				 */
+				volumes {
+					ubi_art: ubi-volume-art {
+						volname = "ART";
+					};
+				};
+			};
+		};
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+};
+
+&tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+		mux_2 {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	serial_0_pins: serial_pinmux {
+		pins = "gpio16", "gpio17";
+		function = "blsp_uart0";
+		bias-disable;
+	};
+
+	serial_1_pins: serial1_pinmux {
+		/* We use the i2c-0 pins for serial_1 */
+		pins = "gpio8", "gpio9";
+		function = "blsp_uart1";
+		bias-disable;
+	};
+
+	i2c_0_pins: i2c_0_pinmux {
+		function = "blsp_i2c0";
+		pins = "gpio20", "gpio21";
+		drive-strength = <16>;
+		bias-disable;
+	};
+
+	i2c_1_pins: i2c_1_pinmux {
+		function = "blsp_i2c1";
+		pins = "gpio34", "gpio35";
+		drive-strength = <16>;
+		bias-disable;
+	};
+
+	nand_pins: nand_pins {
+		/*
+		 * There are 18 pins. 15 pins are common between LCD and NAND.
+		 * The QPIC controller arbitrates between LCD and NAND. Of the
+		 * remaining 4, 2 are for NAND and 2 are for LCD exclusively.
+		 *
+		 * The meraki source hints that the bluetooth module claims
+		 * pin 52 as well. But sadly, there's no data whenever this
+		 * is a NAND or LCD exclusive pin or not.
+		 */
+
+		pullups {
+			pins = "gpio53", "gpio58", "gpio59";
+			function = "qpic";
+			bias-pull-up;
+		};
+
+		pulldowns {
+			pins = "gpio55", "gpio56",
+				"gpio57", "gpio60", "gpio62",
+				"gpio63", "gpio64", "gpio65",
+				"gpio66", "gpio67", "gpio68",
+				"gpio69";
+			function = "qpic";
+			bias-pull-down;
+		};
+	};
+};
+
+&usb2_hs_phy {
+		status = "okay";
+};
+
+&usb2 {
+		status = "okay";
+};
+
+&usb3_hs_phy {
+		status = "okay";
+};
+
+&usb3_ss_phy {
+		status = "okay";
+};
+
+&usb3 {
+		status = "okay";
+};
+
+&ubi_art {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		precal_factory_1000: precal@1000 {
+			reg = <0x1000 0x2f20>;
+		};
+
+		precal_factory_5000: precal@5000 {
+			reg = <0x5000 0x2f20>;
+		};
+
+		cal_factory_9000: cal@9000 {
+			reg = <0x9000 0x844>;
+		};
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	nvmem-cells = <&precal_factory_1000>;
+	nvmem-cell-names = "pre-calibration";
+};
+
+&wifi1 {
+	status = "okay";
+	nvmem-cells = <&precal_factory_5000>;
+	nvmem-cell-names = "pre-calibration";
+};
+
+&gmac {
+	status = "okay";
+	nvmem-cells = <&mac_address 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport1 {
+	label = "wan";
+	status = "okay";
+};
+
+&swport2 {
+	label = "lan2";
+	status = "okay";
+};
+
+&swport3 {
+	label = "lan3";
+	status = "okay";
+};
+
+&swport4 {
+	label = "lan4";
+	status = "okay";
+};
+
+&swport5 {
+	label = "lan5";
+	status = "okay";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-z3.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-z3.dts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Device Tree Source for Meraki Z3 (Fuzzy Cricket)
+
+#include "qcom-ipq4029-wired-qca-common.dtsi"
+
+/ {
+	model = "Meraki Z3 Router";
+	compatible = "meraki,z3";
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_orange: power {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&tlmm 49 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led-1 {
+			/* WAN left */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			function-enumerator = <0>;
+			gpios = <&tlmm 46 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			/* WAN right */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			function-enumerator = <1>;
+			gpios = <&tlmm 30 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			/* port 2 left */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&tlmm 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			/* port 2 right */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			/* port 3 left */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led-6 {
+			/* port 3 right */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <5>;
+			gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led-7 {
+			/* port 4 left */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <6>;
+			gpios = <&tlmm 29 GPIO_ACTIVE_LOW>;
+		};
+
+		led-8 {
+			/* port 4 right */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <7>;
+			gpios = <&tlmm 26 GPIO_ACTIVE_LOW>;
+		};
+
+		led-9 {
+			/* port 5 left */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <8>;
+			gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
+		};
+
+		led-10 {
+			/* port 5 right */
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <9>;
+			gpios = <&tlmm 32 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "Meraki-Z3";
+};
+
+&wifi1 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "Meraki-Z3";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -798,6 +798,7 @@ define Device/meraki_mr30h
 	$(call Device/meraki_common)
 	DEVICE_MODEL := MR30H
 	DEVICE_DTS_CONFIG := config@2
+	DEVICE_PACKAGES += ipq-wifi-meraki_mr30h
 endef
 TARGET_DEVICES += meraki_mr30h
 

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -794,6 +794,13 @@ define Device/meraki_common
 	DEVICE_PACKAGES := ath10k-firmware-qca9887-ct
 endef
 
+define Device/meraki_mr30h
+	$(call Device/meraki_common)
+	DEVICE_MODEL := MR30H
+	DEVICE_DTS_CONFIG := config@2
+endef
+TARGET_DEVICES += meraki_mr30h
+
 define Device/meraki_mr33
 	$(call Device/meraki_common)
 	DEVICE_MODEL := MR33
@@ -806,6 +813,22 @@ define Device/meraki_mr74
 	DEVICE_DTS_CONFIG := config@3
 endef
 TARGET_DEVICES += meraki_mr74
+
+define Device/meraki_z3
+	$(call Device/meraki_common)
+	DEVICE_MODEL := Z3
+	DEVICE_DTS_CONFIG := config@1
+	DEVICE_PACKAGES := -ath10k-firmware-qca9887-ct ipq-wifi-meraki_z3
+endef
+TARGET_DEVICES += meraki_z3
+
+define Device/meraki_gx20
+	$(call Device/meraki_common)
+	DEVICE_MODEL := GX20
+	DEVICE_DTS_CONFIG := config@2
+	DEVICE_PACKAGES := -ath10k-board-qca4019 -ath10k-firmware-qca9887-ct
+endef
+TARGET_DEVICES += meraki_gx20
 
 define Device/mobipromo_cm520-79f
 	$(call Device/FitzImage)


### PR DESCRIPTION
This PR adds support for the following Meraki ipq40xx based devices:

* MR30H

POE powered 802.11ac access point with an integrated 5 port Gigabit switch.

This device is configured with only LAN ports, as there is no "WAN" port by default.

Port 4 has POE output (802.3af) and is the port used for tftp booting in U-Boot.

The device does not have secure boot enabled at this time.

However, the stock U-Boot does not allow interrupting boot to obtain a shell, 
so it is highly recommended to flash a custom U-Boot build. 
An external programmer is required to overwrite the stock U-Boot region of NAND, 
similar to other recent Meraki devices such as the MR33.

Information about flashing and the dumps required can be found in this GitHub repository: https://github.com/halmartin/meraki-openwrt-docs/tree/main/mr30h

* Z3

"Teleworker" device with 802.11ac and an integrated 5 port Gigabit switch.

Port 5 has POE output (802.3af). The WAN port is used for tftp booting in U-Boot.

This device ships with secure boot, and cannot be flashed without an external programmer. 
More details on secure boot can be found at: 
https://watchmysys.com/blog/2024/04/breaking-secure-boot-on-the-meraki-z3-and-meraki-go-gx20/

Information about flashing and the dumps required can be found in this GitHub repository: https://github.com/halmartin/meraki-openwrt-docs/tree/main/z3_gx20

* Go GX20

Wired router with 5 port Gigabit switch. It shares the same PCB as the Z3, but without the WiFi radios.

Port 5 has POE output (802.3af). The WAN port is used for tftp booting in U-Boot.

This device ships with secure boot, and cannot be flashed without an external programmer. 
More details on secure boot can be found at: 
https://watchmysys.com/blog/2024/04/breaking-secure-boot-on-the-meraki-z3-and-meraki-go-gx20/

Information about flashing and the dumps required can be found in this GitHub repository: https://github.com/halmartin/meraki-openwrt-docs/tree/main/z3_gx20
