### PR TITLE
build: fix filtering of non-upgradable packages

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -131,7 +131,7 @@ ifneq ($(CONFIG_USE_APK),)
 			--keys-dir $(TOPDIR) \
 			--sign $(BUILD_KEY_APK_SEC) \
 			--output packages.adb \
-			$$(ls *.apk | grep -v 'base-files-\|kernel-\|libc-'); \
+			$$(ls *.apk | grep -vE '^(base-files-|kernel-|libc-)'); \
 		echo -n '{"architecture": "$(ARCH_PACKAGES)", "packages":{' > index.json; \
 		$(STAGING_DIR_HOST)/bin/apk adbdump packages.adb | \
 			awk '/- name: / {pkg = $$NF} ; / version: / {printf "\"%s\": \"%s\", ", pkg, $$NF}' | \


### PR DESCRIPTION
Add anchor to name search so that we don't inadvertently filter out packages containing, say, "kernel-" as part of their name.

Fixes: openwrt/packages#25372
