### PR TITLE
ramips: sync upstream Ralink clock patches

### DIFF
--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -32,13 +32,6 @@
 		compatible = "mti,cpu-interrupt-controller";
 	};
 
-	mmc_clk: mmc-clock {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <48000000>;
-		clock-accuracy = <100>;
-	};
-
 	mmc_reg_1v8: regulator-1v8 {
 		compatible = "regulator-fixed";
 
@@ -80,7 +73,7 @@
 			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
-			clocks = <&sysc 5>;
+			clocks = <&sysc 7>;
 
 			interrupt-parent = <&intc>;
 			interrupts = <1>;
@@ -90,7 +83,7 @@
 			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
-			clocks = <&sysc 6>;
+			clocks = <&sysc 8>;
 
 			resets = <&sysc 8>;
 			reset-names = "wdt";
@@ -122,7 +115,7 @@
 			compatible = "ralink,mt7620a-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0x500 0x100>;
 
-			clocks = <&sysc 7>;
+			clocks = <&sysc 9>;
 
 			resets = <&sysc 12>;
 
@@ -216,7 +209,7 @@
 			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 8>;
+			clocks = <&sysc 10>;
 
 			resets = <&sysc 16>;
 			reset-names = "i2c";
@@ -234,7 +227,7 @@
 			compatible = "mediatek,mt7620-i2s";
 			reg = <0xa00 0x100>;
 
-			clocks = <&sysc 9>;
+			clocks = <&sysc 11>;
 
 			resets = <&sysc 17>;
 			reset-names = "i2s";
@@ -256,7 +249,7 @@
 			compatible = "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
 
-			clocks = <&sysc 10>;
+			clocks = <&sysc 12>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -274,7 +267,7 @@
 			compatible = "ralink,rt2880-spi";
 			reg = <0xb40 0x60>;
 
-			clocks = <&sysc 11>;
+			clocks = <&sysc 13>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -292,7 +285,7 @@
 			compatible = "ralink,mt7620a-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
-			clocks = <&sysc 12>;
+			clocks = <&sysc 14>;
 
 			resets = <&sysc 19>;
 
@@ -539,7 +532,7 @@
 		cap-mmc-highspeed;
 		cap-sd-highspeed;
 
-		clocks = <&mmc_clk>, <&mmc_clk>;
+		clocks = <&sysc 15>, <&sysc 15>;
 		clock-names = "source", "hclk";
 
 		disable-wp;
@@ -645,7 +638,7 @@
 		compatible = "ralink,rt7620-wmac", "ralink,rt2880-wmac";
 		reg = <0x10180000 0x40000>;
 
-		clocks = <&sysc 13>;
+		clocks = <&sysc 16>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/dts/mt7620n.dtsi
+++ b/target/linux/ramips/dts/mt7620n.dtsi
@@ -51,7 +51,7 @@
 			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
-			clocks = <&sysc 5>;
+			clocks = <&sysc 7>;
 
 			interrupt-parent = <&intc>;
 			interrupts = <1>;
@@ -61,7 +61,7 @@
 			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
-			clocks = <&sysc 6>;
+			clocks = <&sysc 8>;
 
 			resets = <&sysc 8>;
 			reset-names = "wdt";
@@ -171,7 +171,7 @@
 			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 8>;
+			clocks = <&sysc 10>;
 
 			resets = <&sysc 16>;
 			reset-names = "i2c";
@@ -189,7 +189,7 @@
 			compatible = "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
 
-			clocks = <&sysc 10>;
+			clocks = <&sysc 12>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -207,7 +207,7 @@
 			compatible = "ralink,rt2880-spi";
 			reg = <0xb40 0x60>;
 
-			clocks = <&sysc 11>;
+			clocks = <&sysc 13>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -225,7 +225,7 @@
 			compatible = "ralink,mt7620a-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
-			clocks = <&sysc 12>;
+			clocks = <&sysc 14>;
 
 			resets = <&sysc 19>;
 
@@ -372,7 +372,7 @@
 		compatible = "ralink,rt7620-wmac", "ralink,rt2880-wmac";
 		reg = <0x10180000 0x40000>;
 
-		clocks = <&sysc 13>;
+		clocks = <&sysc 16>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -30,13 +30,6 @@
 		compatible = "mti,cpu-interrupt-controller";
 	};
 
-	mmc_clk: mmc-clock {
-		compatible = "fixed-clock";
-		#clock-cells = <0>;
-		clock-frequency = <48000000>;
-		clock-accuracy = <100>;
-	};
-
 	mmc_reg_1v8: regulator-1v8 {
 		compatible = "regulator-fixed";
 
@@ -121,7 +114,7 @@
 			compatible = "mediatek,mt7621-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 7>;
+			clocks = <&sysc 9>;
 			clock-names = "i2c";
 
 			resets = <&sysc 16>;
@@ -140,7 +133,7 @@
 			compatible = "mediatek,mt7628-i2s";
 			reg = <0xa00 0x100>;
 
-			clocks = <&sysc 8>;
+			clocks = <&sysc 10>;
 
 			resets = <&sysc 17>;
 			reset-names = "i2s";
@@ -162,7 +155,7 @@
 			compatible = "ralink,mt7621-spi";
 			reg = <0xb00 0x100>;
 
-			clocks = <&sysc 9>;
+			clocks = <&sysc 11>;
 			clock-names = "spi";
 
 			resets = <&sysc 18>;
@@ -185,7 +178,7 @@
 			reg-io-width = <4>;
 			no-loopback-test;
 
-			clocks = <&sysc 11>;
+			clocks = <&sysc 13>;
 
 			resets = <&sysc 12>;
 
@@ -204,7 +197,7 @@
 			reg-io-width = <4>;
 			no-loopback-test;
 
-			clocks = <&sysc 12>;
+			clocks = <&sysc 14>;
 
 			resets = <&sysc 19>;
 
@@ -225,7 +218,7 @@
 			reg-io-width = <4>;
 			no-loopback-test;
 
-			clocks = <&sysc 13>;
+			clocks = <&sysc 15>;
 
 			resets = <&sysc 20>;
 
@@ -393,7 +386,7 @@
 		cap-mmc-highspeed;
 		cap-sd-highspeed;
 
-		clocks = <&mmc_clk>, <&mmc_clk>;
+		clocks = <&sysc 16>, <&sysc 16>;
 		clock-names = "source", "hclk";
 
 		disable-wp;
@@ -516,7 +509,7 @@
 		compatible = "mediatek,mt7628-wmac";
 		reg = <0x10300000 0x100000>;
 
-		clocks = <&sysc 14>;
+		clocks = <&sysc 17>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/dts/rt3883.dtsi
+++ b/target/linux/ramips/dts/rt3883.dtsi
@@ -51,7 +51,7 @@
 			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
-			clocks = <&sysc 4>;
+			clocks = <&sysc 5>;
 
 			interrupt-parent = <&intc>;
 			interrupts = <1>;
@@ -61,7 +61,7 @@
 			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
-			clocks = <&sysc 5>;
+			clocks = <&sysc 6>;
 
 			resets = <&sysc 8>;
 			reset-names = "wdt";
@@ -93,7 +93,7 @@
 			compatible = "ralink,rt3883-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0x500 0x100>;
 
-			clocks = <&sysc 6>;
+			clocks = <&sysc 7>;
 
 			resets = <&sysc 12>;
 
@@ -187,7 +187,7 @@
 			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 7>;
+			clocks = <&sysc 8>;
 
 			resets = <&sysc 16>;
 			reset-names = "i2c";
@@ -205,7 +205,7 @@
 			compatible = "ralink,rt3883-i2s";
 			reg = <0xa00 0x100>;
 
-			clocks = <&sysc 8>;
+			clocks = <&sysc 9>;
 
 			resets = <&sysc 17>;
 			reset-names = "i2s";
@@ -229,7 +229,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			clocks = <&sysc 9>;
+			clocks = <&sysc 10>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -246,7 +246,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			clocks = <&sysc 10>;
+			clocks = <&sysc 11>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -261,7 +261,7 @@
 			compatible = "ralink,rt3883-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
-			clocks = <&sysc 11>;
+			clocks = <&sysc 12>;
 
 			resets = <&sysc 19>;
 
@@ -343,7 +343,7 @@
 		#size-cells = <0>;
 		reg = <0x10100000 0x10000>;
 
-		clocks = <&sysc 12>;
+		clocks = <&sysc 13>;
 
 		resets = <&sysc 21>;
 		reset-names = "fe";
@@ -463,7 +463,7 @@
 		compatible = "ralink,rt3883-wmac", "ralink,rt2880-wmac";
 		reg = <0x10180000 0x40000>;
 
-		clocks = <&sysc 13>;
+		clocks = <&sysc 14>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/patches-6.6/002-01-v6.13-clk-ralink-mtmips-fix-clock-plan-for-Ralink-SoC-RT38.patch
+++ b/target/linux/ramips/patches-6.6/002-01-v6.13-clk-ralink-mtmips-fix-clock-plan-for-Ralink-SoC-RT38.patch
@@ -1,6 +1,7 @@
-Subject: [PATCH] clk: ralink: mtmips: fix clock plan for Ralink SoC RT3883
-Date: Tue,  6 Aug 2024 16:29:02 +0200
-Message-Id: <20240806142902.224164-1-sergio.paracuellos@gmail.com>
+From 33239152305567b3e9bf052f71fd4baecd626341 Mon Sep 17 00:00:00 2001
+From: Sergio Paracuellos <sergio.paracuellos@gmail.com>
+Date: Tue, 10 Sep 2024 06:40:22 +0200
+Subject: [PATCH 1/3] clk: ralink: mtmips: fix clock plan for Ralink SoC RT3883
 
 Clock plan for Ralink SoC RT3883 needs an extra 'periph' clock to properly
 set some peripherals that has this clock as their parent. When this driver
@@ -14,6 +15,8 @@ properly working clock plan for this SoC.
 
 Fixes: 6f3b15586eef ("clk: ralink: add clock and reset driver for MTMIPS SoCs")
 Signed-off-by: Sergio Paracuellos <sergio.paracuellos@gmail.com>
+Link: https://lore.kernel.org/r/20240910044024.120009-2-sergio.paracuellos@gmail.com
+Signed-off-by: Stephen Boyd <sboyd@kernel.org>
 ---
  drivers/clk/ralink/clk-mtmips.c | 9 +++++++--
  1 file changed, 7 insertions(+), 2 deletions(-)
@@ -24,7 +27,7 @@ Signed-off-by: Sergio Paracuellos <sergio.paracuellos@gmail.com>
  	CLK_FIXED("xtal", NULL, 40000000)
  };
  
-+static struct mtmips_clk_fixed rt3383_fixed_clocks[] = {
++static struct mtmips_clk_fixed rt3883_fixed_clocks[] = {
 +	CLK_FIXED("xtal", NULL, 40000000),
 +	CLK_FIXED("periph", "xtal", 40000000)
 +};
@@ -38,8 +41,8 @@ Signed-off-by: Sergio Paracuellos <sergio.paracuellos@gmail.com>
  	.num_clk_base = ARRAY_SIZE(rt3883_clks_base),
 -	.clk_fixed = rt305x_fixed_clocks,
 -	.num_clk_fixed = ARRAY_SIZE(rt305x_fixed_clocks),
-+	.clk_fixed = rt3383_fixed_clocks,
-+	.num_clk_fixed = ARRAY_SIZE(rt3383_fixed_clocks),
++	.clk_fixed = rt3883_fixed_clocks,
++	.num_clk_fixed = ARRAY_SIZE(rt3883_fixed_clocks),
  	.clk_factor = NULL,
  	.num_clk_factor = 0,
  	.clk_periph = rt5350_pherip_clks,

--- a/target/linux/ramips/patches-6.6/002-02-v6.13-clk-ralink-mtmips-fix-clocks-probe-order-in-oldest-r.patch
+++ b/target/linux/ramips/patches-6.6/002-02-v6.13-clk-ralink-mtmips-fix-clocks-probe-order-in-oldest-r.patch
@@ -1,0 +1,124 @@
+From d34db686a3d74bd564bfce2ada15011c556269fc Mon Sep 17 00:00:00 2001
+From: Sergio Paracuellos <sergio.paracuellos@gmail.com>
+Date: Tue, 10 Sep 2024 06:40:23 +0200
+Subject: [PATCH 2/3] clk: ralink: mtmips: fix clocks probe order in oldest
+ ralink SoCs
+
+Base clocks are the first in being probed and are real dependencies of the
+rest of fixed, factor and peripheral clocks. For old ralink SoCs RT2880,
+RT305x and RT3883 'xtal' must be defined first since in any other case,
+when fixed clocks are probed they are delayed until 'xtal' is probed so the
+following warning appears:
+
+ WARNING: CPU: 0 PID: 0 at drivers/clk/ralink/clk-mtmips.c:499 rt3883_bus_recalc_rate+0x98/0x138
+ Modules linked in:
+ CPU: 0 PID: 0 Comm: swapper Not tainted 6.6.43 #0
+ Stack : 805e58d0 00000000 00000004 8004f950 00000000 00000004 00000000 00000000
+ 80669c54 80830000 80700000 805ae570 80670068 00000001 80669bf8 00000000
+ 00000000 00000000 805ae570 80669b38 00000020 804db7dc 00000000 00000000
+ 203a6d6d 80669b78 80669e48 70617773 00000000 805ae570 00000000 00000009
+ 00000000 00000001 00000004 00000001 00000000 00000000 83fe43b0 00000000
+ ...
+ Call Trace:
+ [<800065d0>] show_stack+0x64/0xf4
+ [<804bca14>] dump_stack_lvl+0x38/0x60
+ [<800218ac>] __warn+0x94/0xe4
+ [<8002195c>] warn_slowpath_fmt+0x60/0x94
+ [<80259ff8>] rt3883_bus_recalc_rate+0x98/0x138
+ [<80254530>] __clk_register+0x568/0x688
+ [<80254838>] of_clk_hw_register+0x18/0x2c
+ [<8070b910>] rt2880_clk_of_clk_init_driver+0x18c/0x594
+ [<8070b628>] of_clk_init+0x1c0/0x23c
+ [<806fc448>] plat_time_init+0x58/0x18c
+ [<806fdaf0>] time_init+0x10/0x6c
+ [<806f9bc4>] start_kernel+0x458/0x67c
+
+ ---[ end trace 0000000000000000 ]---
+
+When this driver was mainlined we could not find any active users of old
+ralink SoCs so we cannot perform any real tests for them. Now, one user
+of a Belkin f9k1109 version 1 device which uses RT3883 SoC appeared and
+reported some issues in openWRT:
+- https://github.com/openwrt/openwrt/issues/16054
+
+Thus, define a 'rt2880_xtal_recalc_rate()' just returning the expected
+frequency 40Mhz and use it along the old ralink SoCs to have a correct
+boot trace with no warnings and a working clock plan from the beggining.
+
+Fixes: 6f3b15586eef ("clk: ralink: add clock and reset driver for MTMIPS SoCs")
+Signed-off-by: Sergio Paracuellos <sergio.paracuellos@gmail.com>
+Link: https://lore.kernel.org/r/20240910044024.120009-3-sergio.paracuellos@gmail.com
+Signed-off-by: Stephen Boyd <sboyd@kernel.org>
+---
+ drivers/clk/ralink/clk-mtmips.c | 21 +++++++++++++--------
+ 1 file changed, 13 insertions(+), 8 deletions(-)
+
+--- a/drivers/clk/ralink/clk-mtmips.c
++++ b/drivers/clk/ralink/clk-mtmips.c
+@@ -263,10 +263,6 @@ err_clk_unreg:
+ 		.rate = _rate		 \
+ 	}
+ 
+-static struct mtmips_clk_fixed rt305x_fixed_clocks[] = {
+-	CLK_FIXED("xtal", NULL, 40000000)
+-};
+-
+ static struct mtmips_clk_fixed rt3883_fixed_clocks[] = {
+ 	CLK_FIXED("xtal", NULL, 40000000),
+ 	CLK_FIXED("periph", "xtal", 40000000)
+@@ -371,6 +367,12 @@ static inline struct mtmips_clk *to_mtmi
+ 	return container_of(hw, struct mtmips_clk, hw);
+ }
+ 
++static unsigned long rt2880_xtal_recalc_rate(struct clk_hw *hw,
++					     unsigned long parent_rate)
++{
++	return 40000000;
++}
++
+ static unsigned long rt5350_xtal_recalc_rate(struct clk_hw *hw,
+ 					     unsigned long parent_rate)
+ {
+@@ -682,10 +684,12 @@ static unsigned long mt76x8_cpu_recalc_r
+ }
+ 
+ static struct mtmips_clk rt2880_clks_base[] = {
++	{ CLK_BASE("xtal", NULL, rt2880_xtal_recalc_rate) },
+ 	{ CLK_BASE("cpu", "xtal", rt2880_cpu_recalc_rate) }
+ };
+ 
+ static struct mtmips_clk rt305x_clks_base[] = {
++	{ CLK_BASE("xtal", NULL, rt2880_xtal_recalc_rate) },
+ 	{ CLK_BASE("cpu", "xtal", rt305x_cpu_recalc_rate) }
+ };
+ 
+@@ -695,6 +699,7 @@ static struct mtmips_clk rt3352_clks_bas
+ };
+ 
+ static struct mtmips_clk rt3883_clks_base[] = {
++	{ CLK_BASE("xtal", NULL, rt2880_xtal_recalc_rate) },
+ 	{ CLK_BASE("cpu", "xtal", rt3883_cpu_recalc_rate) },
+ 	{ CLK_BASE("bus", "cpu", rt3883_bus_recalc_rate) }
+ };
+@@ -751,8 +756,8 @@ err_clk_unreg:
+ static const struct mtmips_clk_data rt2880_clk_data = {
+ 	.clk_base = rt2880_clks_base,
+ 	.num_clk_base = ARRAY_SIZE(rt2880_clks_base),
+-	.clk_fixed = rt305x_fixed_clocks,
+-	.num_clk_fixed = ARRAY_SIZE(rt305x_fixed_clocks),
++	.clk_fixed = NULL,
++	.num_clk_fixed = 0,
+ 	.clk_factor = rt2880_factor_clocks,
+ 	.num_clk_factor = ARRAY_SIZE(rt2880_factor_clocks),
+ 	.clk_periph = rt2880_pherip_clks,
+@@ -762,8 +767,8 @@ static const struct mtmips_clk_data rt28
+ static const struct mtmips_clk_data rt305x_clk_data = {
+ 	.clk_base = rt305x_clks_base,
+ 	.num_clk_base = ARRAY_SIZE(rt305x_clks_base),
+-	.clk_fixed = rt305x_fixed_clocks,
+-	.num_clk_fixed = ARRAY_SIZE(rt305x_fixed_clocks),
++	.clk_fixed = NULL,
++	.num_clk_fixed = 0,
+ 	.clk_factor = rt305x_factor_clocks,
+ 	.num_clk_factor = ARRAY_SIZE(rt305x_factor_clocks),
+ 	.clk_periph = rt305x_pherip_clks,

--- a/target/linux/ramips/patches-6.6/002-03-v6.13-clk-ralink-mtmips-add-mmc-related-clocks-for-SoCs-MT.patch
+++ b/target/linux/ramips/patches-6.6/002-03-v6.13-clk-ralink-mtmips-add-mmc-related-clocks-for-SoCs-MT.patch
@@ -1,0 +1,101 @@
+From 198675bbc03d437fb80a35d781ad13d622d0ff68 Mon Sep 17 00:00:00 2001
+From: Sergio Paracuellos <sergio.paracuellos@gmail.com>
+Date: Tue, 10 Sep 2024 06:40:24 +0200
+Subject: [PATCH 3/3] clk: ralink: mtmips: add mmc related clocks for SoCs
+ MT7620, MT7628 and MT7688
+
+Original architecture clock code from where this driver was derived did not
+include nothing related to mmc clocks. OpenWRT people started to use mtk-sd
+upstream driver recently and they were forced to use a dts 'fixed-clock'
+node with 48 MHz clock:
+- https://github.com/openwrt/openwrt/pull/15896
+The proper thing to do to avoid that is to add the mmc related clocks to the
+driver to avoid a dts with fixed clocks nodes. The minimal documentation in
+the mt7620 programming guide says that there is a BBP_PLL clock of 480 MHz
+derived from the 40 MHz XTAL and from there a clock divider by ten produces
+the desired SDHC clock of 48 MHz for the mmc. Hence add a fixed clock 'bbppll'
+and factor clock 'sdhc' ten divider child to properly set the 'mmc' peripheral
+clock with the desired 48 Mhz rate.
+
+Signed-off-by: Sergio Paracuellos <sergio.paracuellos@gmail.com>
+Link: https://lore.kernel.org/r/20240910044024.120009-4-sergio.paracuellos@gmail.com
+Signed-off-by: Stephen Boyd <sboyd@kernel.org>
+---
+ drivers/clk/ralink/clk-mtmips.c | 30 +++++++++++++++++++++++-------
+ 1 file changed, 23 insertions(+), 7 deletions(-)
+
+--- a/drivers/clk/ralink/clk-mtmips.c
++++ b/drivers/clk/ralink/clk-mtmips.c
+@@ -207,6 +207,7 @@ static struct mtmips_clk mt7620_pherip_c
+ 	{ CLK_PERIPH("10000b00.spi", "bus") },
+ 	{ CLK_PERIPH("10000b40.spi", "bus") },
+ 	{ CLK_PERIPH("10000c00.uartlite", "periph") },
++	{ CLK_PERIPH("10130000.mmc", "sdhc") },
+ 	{ CLK_PERIPH("10180000.wmac", "xtal") }
+ };
+ 
+@@ -220,6 +221,7 @@ static struct mtmips_clk mt76x8_pherip_c
+ 	{ CLK_PERIPH("10000c00.uart0", "periph") },
+ 	{ CLK_PERIPH("10000d00.uart1", "periph") },
+ 	{ CLK_PERIPH("10000e00.uart2", "periph") },
++	{ CLK_PERIPH("10130000.mmc", "sdhc") },
+ 	{ CLK_PERIPH("10300000.wmac", "xtal") }
+ };
+ 
+@@ -272,8 +274,13 @@ static struct mtmips_clk_fixed rt3352_fi
+ 	CLK_FIXED("periph", "xtal", 40000000)
+ };
+ 
++static struct mtmips_clk_fixed mt7620_fixed_clocks[] = {
++	CLK_FIXED("bbppll", "xtal", 480000000)
++};
++
+ static struct mtmips_clk_fixed mt76x8_fixed_clocks[] = {
+-	CLK_FIXED("pcmi2s", "xtal", 480000000),
++	CLK_FIXED("bbppll", "xtal", 480000000),
++	CLK_FIXED("pcmi2s", "bbppll", 480000000),
+ 	CLK_FIXED("periph", "xtal", 40000000)
+ };
+ 
+@@ -328,6 +335,15 @@ static struct mtmips_clk_factor rt305x_f
+ 	CLK_FACTOR("bus", "cpu", 1, 3)
+ };
+ 
++static struct mtmips_clk_factor mt7620_factor_clocks[] = {
++	CLK_FACTOR("sdhc", "bbppll", 1, 10)
++};
++
++static struct mtmips_clk_factor mt76x8_factor_clocks[] = {
++	CLK_FACTOR("bus", "cpu", 1, 3),
++	CLK_FACTOR("sdhc", "bbppll", 1, 10)
++};
++
+ static int mtmips_register_factor_clocks(struct clk_hw_onecell_data *clk_data,
+ 					 struct mtmips_clk_priv *priv)
+ {
+@@ -811,10 +827,10 @@ static const struct mtmips_clk_data rt53
+ static const struct mtmips_clk_data mt7620_clk_data = {
+ 	.clk_base = mt7620_clks_base,
+ 	.num_clk_base = ARRAY_SIZE(mt7620_clks_base),
+-	.clk_fixed = NULL,
+-	.num_clk_fixed = 0,
+-	.clk_factor = NULL,
+-	.num_clk_factor = 0,
++	.clk_fixed = mt7620_fixed_clocks,
++	.num_clk_fixed = ARRAY_SIZE(mt7620_fixed_clocks),
++	.clk_factor = mt7620_factor_clocks,
++	.num_clk_factor = ARRAY_SIZE(mt7620_factor_clocks),
+ 	.clk_periph = mt7620_pherip_clks,
+ 	.num_clk_periph = ARRAY_SIZE(mt7620_pherip_clks),
+ };
+@@ -824,8 +840,8 @@ static const struct mtmips_clk_data mt76
+ 	.num_clk_base = ARRAY_SIZE(mt76x8_clks_base),
+ 	.clk_fixed = mt76x8_fixed_clocks,
+ 	.num_clk_fixed = ARRAY_SIZE(mt76x8_fixed_clocks),
+-	.clk_factor = rt305x_factor_clocks,
+-	.num_clk_factor = ARRAY_SIZE(rt305x_factor_clocks),
++	.clk_factor = mt76x8_factor_clocks,
++	.num_clk_factor = ARRAY_SIZE(mt76x8_factor_clocks),
+ 	.clk_periph = mt76x8_pherip_clks,
+ 	.num_clk_periph = ARRAY_SIZE(mt76x8_pherip_clks),
+ };


### PR DESCRIPTION
1. Add sdhc clock for MT7620 and MT76x8 SoCs.
2. Fix clock driver warning for RT2880, RT305x and RT3883.
