### PR TITLE
build: add kernel version information to index.json

### DIFF
--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -47,7 +47,13 @@ for device_id, profile in output.get("profiles", {}).items():
 
 
 if output:
-    default_packages, output["arch_packages"] = run(
+    (
+        default_packages,
+        output["arch_packages"],
+        linux_version,
+        linux_release,
+        linux_vermagic,
+    ) = run(
         [
             "make",
             "--no-print-directory",
@@ -55,6 +61,9 @@ if output:
             "target/linux/",
             "val.DEFAULT_PACKAGES",
             "val.ARCH_PACKAGES",
+            "val.LINUX_VERSION",
+            "val.LINUX_RELEASE",
+            "val.LINUX_VERMAGIC",
             "V=s",
         ],
         stdout=PIPE,
@@ -64,7 +73,11 @@ if output:
     ).stdout.splitlines()
 
     output["default_packages"] = sorted(default_packages.split())
-
+    output["linux_kernel"] = {
+        "version": linux_version,
+        "release": linux_release,
+        "vermagic": linux_vermagic,
+    }
     output_path.write_text(json.dumps(output, sort_keys=True, separators=(",", ":")))
 else:
     print("JSON info file script could not find any JSON files for target")


### PR DESCRIPTION
Construct a variable consisting of the Linux kernel version, revision and vermagic.  The variable construction is restricted to the Makefile's 'index' target, avoiding errors during processing of other targets, where this information may not yet exist (for example, the 'download' target).  Add this as a new field when generating the package index.json files.

```
{
   "architecture" : "x86_64",
   "kernel" : "6.6.61-1-05ac1980a8eb9482b41ad89569bebd8f",
   "packages" : {
      "block-mount" : "2024.07.14~408c2cc4-r1",
      ...
```

This allows direct access to the platform-specific kmods package directory for a specific build, plus allows clients to access the kernel version in a consistent and robust manner.

Fixes: openwrt/openwrt#17036
Fixes: efahl/owut#9