### PR TITLE
wifi-scripts: Fix parsing of Capabilities

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -208,7 +208,7 @@ mac80211_hostapd_setup_base() {
 				dsss_cck_40:1
 
 			ht_cap_mask=0
-			for cap in $(iw phy "$phy" info | grep 'Capabilities:' | cut -d: -f2); do
+			for cap in $(iw phy "$phy" info | grep -E '^\s*Capabilities:' | cut -d: -f2); do
 				ht_cap_mask="$(($ht_cap_mask | $cap))"
 			done
 


### PR DESCRIPTION
Fixup capabilities parsing in iw output.

In addition to the normal capabilities iw now also outputs HE MAC, HE PHY and EHT MAC and EHT PHY capabilities. Exclude them in the parsing.

The grep returns this with mac80211-hwsim:
```
root@OpenWrt:~# iw phy phy0 info | grep 'Capabilities:'
		Capabilities: 0x107e
			HE PHY Capabilities: (0x02bfce0000000000000000):
			EHT PHY Capabilities: (0x7c0000feffff7f01):
			HE PHY Capabilities: (0x02bfce0000000000000000):
			EHT PHY Capabilities: (0x7c0000feffff7f01):
			HE PHY Capabilities: (0x02bf000000000000000000):
		Capabilities: 0x107e
			HE PHY Capabilities: (0x1cbfce0000000000000000):
			EHT PHY Capabilities: (0xfc1f3ffeffff7f37):
			HE PHY Capabilities: (0x1cbfce0000000000000000):
			EHT PHY Capabilities: (0xfc1f3ffeffff7f37):
			HE PHY Capabilities: (0x1cbf000000000000000000):
			HE PHY Capabilities: (0x1cbfce0000000000000000):
			EHT PHY Capabilities: (0xfefffffeffffff7f):
			HE PHY Capabilities: (0x1cbfce0000000000000000):
			EHT PHY Capabilities: (0xfefffffeffffff7f):
			HE PHY Capabilities: (0x1cbf000000000000000000):
		Capabilities: 0x107e
```

With busybox 1.36.1 the ht_cap_mask variable will be set to -72057598332895361. With busybox 1.37.0 it will be set to -1. Both values are wrong, after this change it will be set to 4222 (0x107E).