### PR TITLE
config: rename SECCOMP to USE_SECCOMP

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -423,7 +423,7 @@ menu "Global build settings"
 
 	endchoice
 
-	config SECCOMP
+	config USE_SECCOMP
 		bool "Enable SECCOMP"
 		select KERNEL_SECCOMP
 		select PACKAGE_procd-seccomp

--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -426,7 +426,6 @@ menu "Global build settings"
 	config USE_SECCOMP
 		bool "Enable SECCOMP"
 		select KERNEL_SECCOMP
-		select PACKAGE_procd-seccomp
 		depends on (aarch64 || arm || armeb || mips || mipsel || mips64 || mips64el || i386 || powerpc || x86_64)
 		depends on !TARGET_uml
 		default y

--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -78,7 +78,7 @@ _ignore = $(foreach p,$(IGNORE_PACKAGES),--ignore $(p))
 # Config that will invalidate the .targetinfo as they will affect
 # DEFAULT_PACKAGES.
 # Keep DYNAMIC_DEF_PKG_CONF in sync with target.mk to reflect the same configs
-DYNAMIC_DEF_PKG_CONF := CONFIG_USE_APK CONFIG_SELINUX CONFIG_SMALL_FLASH CONFIG_SECCOMP
+DYNAMIC_DEF_PKG_CONF := CONFIG_USE_APK CONFIG_SELINUX CONFIG_SMALL_FLASH CONFIG_USE_SECCOMP
 check-dynamic-def-pkg: FORCE
 	@+DEF_PKG_CONFS=""; \
 	if [ -f $(TOPDIR)/.config ]; then \

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -42,7 +42,7 @@ define Package/base-files
   DEPENDS:= \
 	+netifd +libc +jsonfilter +SIGNED_PACKAGES:usign +SIGNED_PACKAGES:openwrt-keyring \
 	+NAND_SUPPORT:ubi-utils +fstools +fwtool \
-	+SELINUX:procd-selinux +!SELINUX:procd +SECCOMP:procd-seccomp \
+	+SELINUX:procd-selinux +!SELINUX:procd +USE_SECCOMP:procd-seccomp \
 	+SELINUX:busybox-selinux +!SELINUX:busybox +!SMALL_FLASH:procd-ujail
   TITLE:=Base filesystem for OpenWrt
   URL:=http://openwrt.org/

--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -71,7 +71,7 @@ endef
 define Package/procd-seccomp
   SECTION:=base
   CATEGORY:=Base system
-  DEPENDS:=@SECCOMP +libubox +libblobmsg-json
+  DEPENDS:=@USE_SECCOMP +libubox +libblobmsg-json
   TITLE:=OpenWrt process seccomp helper + utrace
 endef
 


### PR DESCRIPTION
It seems that we have some kind of a symbol name conflict which causes
CONFIG_SECCOMP to always be read as y.

Unfortunately, I could not figure out what is causing this, but simply
renaming `SECCOMP` to `USE_SECCOMP` seems to properly work and leaves the
symbol unset unless arch dependencies are satisfied.

This fixes qoriq and others that dont support seccomp from failing due
to procd-seccomp package being selected to get included but it cannot be
built for them:
```
ERROR: unable to select packages:
  procd-seccomp (no such package):
    required by: base-files-1637~52b6c92479[procd-seccomp]
```

Fixes: https://github.com/robimarko/openwrt/commit/4c65359af49b6ccecd98987f842db5eba985f64b ("build: fix including busybox, procd and apk/opkg in imagebuilder")

Second commits just removes the duplicate selection of `procd-seccomp`