### PR TITLE
apk: Make new config files suffix defineable and set it to -apk-new

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git
@@ -67,6 +67,8 @@ MESON_HOST_ARGS += \
 MESON_ARGS += \
 	$(MESON_COMMON_ARGS) \
 	-Dcrypto_backend=$(BUILD_VARIANT)
+
+TARGET_CFLAGS += -DCFGNEW_SUFFIX=\"-apk-new\"
 
 define Package/apk/conffiles
 /etc/apk/repositories.d/customfeeds.list

--- a/package/system/apk/patches/0020-new-config-file-suffix-define.patch
+++ b/package/system/apk/patches/0020-new-config-file-suffix-define.patch
@@ -1,0 +1,55 @@
+--- a/src/apk_package.h
++++ b/src/apk_package.h
+@@ -122,6 +122,10 @@
+ 				APK_BLOB_IS_NULL(*(dep)->version) ? "" : apk_version_op_string((dep)->op), \
+ 				BLOB_PRINTF(*(dep)->version)
+ 
++#ifndef CFGNEW_SUFFIX
++#define CFGNEW_SUFFIX		".apk-new"
++#endif
++
+ extern const char *apk_script_types[];
+ 
+ static inline int apk_dep_conflict(const struct apk_dependency *dep) { return !!(dep->op & APK_VERSION_CONFLICT); }
+--- a/src/app_audit.c
++++ b/src/app_audit.c
+@@ -359,7 +359,7 @@
+ 				break;
+ 			}
+ 			if ((!dbf || reason == 'A') &&
+-			    apk_blob_ends_with(bent, APK_BLOB_STR(".apk-new")))
++			    apk_blob_ends_with(bent, APK_BLOB_STR(CFGNEW_SUFFIX)))
+ 				goto done;
+ 			break;
+ 		case MODE_SYSTEM:
+--- a/src/database.c
++++ b/src/database.c
+@@ -2924,7 +2924,7 @@
+ 					} else {
+ 						// All files differ. Use the package's file as .apk-new.
+ 						ctrl = APK_FS_CTRL_APKNEW;
+-						apk_msg(out, PKG_VER_FMT ": installing file to " DIR_FILE_FMT ".apk-new",
++						apk_msg(out, PKG_VER_FMT ": installing file to " DIR_FILE_FMT CFGNEW_SUFFIX,
+ 						    PKG_VER_PRINTF(ipkg->pkg),
+ 						    DIR_FILE_PRINTF(diri->dir, file));
+ 					}
+--- a/src/fs_fsys.c
++++ b/src/fs_fsys.c
+@@ -203,7 +203,7 @@
+ 		break;
+ 	case APK_FS_CTRL_APKNEW:
+ 		// rename tmpname -> realname.apk-new
+-		rc = apk_fmt(apknewname, sizeof apknewname, "%s%s", fn, ".apk-new");
++		rc = apk_fmt(apknewname, sizeof apknewname, "%s%s", fn, CFGNEW_SUFFIX);
+ 		if (rc < 0) break;
+ 		if (renameat(atfd, format_tmpname(&ac->dctx, d->pkgctx, dirname, apk_pathbuilder_get(&d->pb), tmpname),
+ 			     atfd, apknewname) < 0)
+@@ -221,7 +221,7 @@
+ 		break;
+ 	case APK_FS_CTRL_DELETE_APKNEW:
+ 		// remove apknew (which may or may not exist)
+-		rc = apk_fmt(apknewname, sizeof apknewname, "%s%s", fn, ".apk-new");
++		rc = apk_fmt(apknewname, sizeof apknewname, "%s%s", fn, CFGNEW_SUFFIX);
+ 		if (rc < 0) break;
+ 		unlinkat(atfd, apknewname, 0);
+ 		break;


### PR DESCRIPTION
This PR fixes the uci incompatibility with the new config file's suffix ".apk-new" that is used when installing a package that already has a config file.

VERSION 2: 

**One upstreamable patch that just changes the 4 separate literals to one definition**
 
`apk: Add configuration for the suffix of a new config file`

Add configuration possibility to the suffix of a new config file that is installed along a package, when there already exists a config file that should not get overwritten, and the new config file need to get added with a suffix.

Define the option as a preprocessor define, so that it can be also set via compiler command line.

The default value stays ".apk-new".

**Makefile change**

Set "-apk-new" as the new default suffix in OpenWrt.
Apk's default is ".apk-new" that chokes uci.



The first commit could be upstreamed to apk-tools.

<del>In place of the second commit there could maybe be a compile-time configuratin options from Makefile that sets the suffix, and that would be used instead, as  the definition in .h might be inside `#if !defined`</del>

Now just a Makefile change is needed, no permanent patch  (if the the first gets upstreamed)

This should fix #17033

-----
Proof:
```
root@router5:~# ls /etc/config/us*
/etc/config/usteer    /etc/config/usteer-opkg

root@router5:~# apk del usteer
OK: 69 MiB in 312 packages
root@router5:~# apk add usteer
(1/1) Installing usteer (2022.08.18~7d2b17c9-r1)
usteer-2022.08.18~7d2b17c9-r1: installing file to etc/config/usteer-apk-new
Executing usteer-2022.08.18~7d2b17c9-r1.post-install
OK: 70 MiB in 313 packages

root@router5:~# ls /etc/config/us*
/etc/config/usteer     /etc/config/usteer-apk-new  /etc/config/usteer-opkg
```