### PR TITLE
tools/cmake: update to 3.31.2

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=3.30.5
+PKG_VERSION:=3.31.2
 PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
@@ -15,7 +15,7 @@ PKG_CPE_ID:=cpe:/a:kitware:cmake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
 		https://cmake.org/files/v$(PKG_VERSION_MAJOR)/
-PKG_HASH:=9f55e1a40508f2f29b7e065fa08c29f82c402fa0402da839fffe64a25755a86d
+PKG_HASH:=42abb3f48f37dbd739cdfeb19d3712db0c5935ed5c2aef6c340f9ae9114238a2
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1

--- a/tools/cmake/patches/120-curl-fix-libressl-linking.patch
+++ b/tools/cmake/patches/120-curl-fix-libressl-linking.patch
@@ -20,10 +20,11 @@ Signed-off-by: Jo-Philipp Wich <jo@mein.io>
 ---
 --- a/Utilities/cmcurl/CMakeLists.txt
 +++ b/Utilities/cmcurl/CMakeLists.txt
-@@ -648,6 +648,14 @@ if(CURL_USE_OPENSSL)
+@@ -775,7 +775,14 @@ if(CURL_USE_OPENSSL)
    endif()
-   set(SSL_ENABLED ON)
+   set(_ssl_enabled ON)
    set(USE_OPENSSL ON)
+-
 +  check_library_exists("rt" clock_gettime "" HAVE_LIBRT)
 +  if(HAVE_LIBRT)
 +    list(APPEND OPENSSL_LIBRARIES rt)
@@ -34,4 +35,4 @@ Signed-off-by: Jo-Philipp Wich <jo@mein.io>
 +  endif()
    list(APPEND CURL_LIBS ${OPENSSL_LIBRARIES})
    include_directories(${OPENSSL_INCLUDE_DIR})
- 
+   list(APPEND LIBCURL_PC_REQUIRES_PRIVATE "openssl")

--- a/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
+++ b/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
@@ -1,6 +1,6 @@
 --- a/bootstrap
 +++ b/bootstrap
-@@ -1509,7 +1509,10 @@ int main(){ printf("1%c", (char)0x0a); r
+@@ -1514,7 +1514,10 @@ int main(){ printf("1%c", (char)0x0a); r
  ' > "test.c"
  cmake_original_make_flags="${cmake_make_flags}"
  if test "x${cmake_parallel_make}" != "x"; then

--- a/tools/cmake/patches/150-zstd-libarchive.patch
+++ b/tools/cmake/patches/150-zstd-libarchive.patch
@@ -1,6 +1,6 @@
 --- a/Utilities/cmlibarchive/CMakeLists.txt
 +++ b/Utilities/cmlibarchive/CMakeLists.txt
-@@ -656,7 +656,7 @@ IF(ENABLE_ZSTD)
+@@ -680,7 +680,7 @@ IF(ENABLE_ZSTD)
      SET(ZSTD_FIND_QUIETLY TRUE)
    ENDIF (ZSTD_INCLUDE_DIR)
  

--- a/tools/cmake/patches/160-disable_xcode_generator.patch
+++ b/tools/cmake/patches/160-disable_xcode_generator.patch
@@ -1,6 +1,6 @@
 --- a/Source/CMakeLists.txt
 +++ b/Source/CMakeLists.txt
-@@ -858,7 +858,7 @@ if(CMake_USE_XCOFF_PARSER)
+@@ -888,7 +888,7 @@ if(CMake_USE_XCOFF_PARSER)
  endif()
  
  # Xcode only works on Apple
@@ -11,7 +11,7 @@
      PRIVATE
 --- a/Source/cmake.cxx
 +++ b/Source/cmake.cxx
-@@ -134,7 +134,7 @@
+@@ -133,7 +133,7 @@
  #  include "cmGlobalGhsMultiGenerator.h"
  #endif
  


### PR DESCRIPTION
Release notes: https://cmake.org/cmake/help/latest/release/3.31.html

Refresh patches:
- 120-curl-fix-libressl-linking.patch
- 130-bootstrap_parallel_make_flag.patch
- 150-zstd-libarchive.patch
- 160-disable_xcode_generator.patch