### PR TITLE
ramips: mt7621: support openwrt,netdev-name for renaming interfaces

### DIFF
--- a/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x-sfp.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x-sfp.dts
@@ -69,11 +69,12 @@
 	ports {
 		port@5 {
 			reg = <5>;
-			label = "eth5";
+			openwrt,netdev-name = "eth5";
 			phy-handle = <&ephy7>;
 			phy-mode = "rgmii-rxid";
 			nvmem-cells = <&macaddr_factory_22 5>;
 			nvmem-cell-names = "mac-address";
+			/delete-property/ label;
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dts
@@ -7,7 +7,7 @@
 
 &gmac1 {
 	status = "okay";
-	label = "eth0";
+	openwrt,netdev-name = "eth0";
 	phy-handle = <&ethphy0>;
 
 	nvmem-cells = <&macaddr_factory_22 0>;

--- a/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dtsi
+++ b/target/linux/ramips/dts/mt7621_ubnt_edgerouter-x.dtsi
@@ -22,42 +22,47 @@
 &gmac0 {
 	nvmem-cells = <&macaddr_factory_22 0>;
 	nvmem-cell-names = "mac-address";
-	label = "dsa";
+	openwrt,netdev-name = "dsa";
 };
 
 &switch0 {
 	ports {
 		port@0 {
 			status = "okay";
-			label = "eth0";
+			openwrt,netdev-name = "eth0";
+			/delete-property/ label;
 		};
 
 		port@1 {
 			status = "okay";
-			label = "eth1";
+			openwrt,netdev-name = "eth1";
 			nvmem-cells = <&macaddr_factory_22 1>;
 			nvmem-cell-names = "mac-address";
+			/delete-property/ label;
 		};
 
 		port@2 {
 			status = "okay";
-			label = "eth2";
+			openwrt,netdev-name = "eth2";
 			nvmem-cells = <&macaddr_factory_22 2>;
 			nvmem-cell-names = "mac-address";
+			/delete-property/ label;
 		};
 
 		port@3 {
 			status = "okay";
-			label = "eth3";
+			openwrt,netdev-name = "eth3";
 			nvmem-cells = <&macaddr_factory_22 3>;
 			nvmem-cell-names = "mac-address";
+			/delete-property/ label;
 		};
 
 		port@4 {
 			status = "okay";
-			label = "eth4";
+			openwrt,netdev-name = "eth4";
 			nvmem-cells = <&macaddr_factory_22 4>;
 			nvmem-cell-names = "mac-address";
+			/delete-property/ label;
 		};
 	};
 };

--- a/target/linux/ramips/mt7621/base-files/lib/preinit/04_set_netdev_label
+++ b/target/linux/ramips/mt7621/base-files/lib/preinit/04_set_netdev_label
@@ -10,6 +10,14 @@ set_netdev_labels() {
 		[ "$netdev" = "$label" ] && continue
 		ip link set "$netdev" name "$label"
 	done
+
+	for dir in /sys/class/net/*; do
+		[ -r "$dir/of_node/openwrt,netdev-name" ] || continue
+		read -r label < "$dir/of_node/openwrt,netdev-name"
+		netdev="${dir##*/}"
+		[ "$netdev" = "$label" ] && continue
+		ip link set "$netdev" name "$label"
+	done
 }
 
 boot_hook_add preinit_main set_netdev_labels


### PR DESCRIPTION
Edgerouter X currently has its eth1 port on the switch missing since there is a naming conflict currently.

So, as the root cause is mixing kernel support for DSA interfaces having predictable names set via "label" property vs others having it assigned dynamically lets avoid the conflict by using our own custom property as suggested upstream [1].

So, add support via "openwrt,netdev-name" property and use it on ERX.

Fixes: 2a25c6ace8d8 ("ramips: get rid of downstream network device label patch")
Fixes: #15643 
