### PR TITLE
qualcommax: ipq60xx: remove source-only flag

### DIFF
--- a/target/linux/qualcommax/ipq60xx/target.mk
+++ b/target/linux/qualcommax/ipq60xx/target.mk
@@ -1,5 +1,4 @@
 SUBTARGET:=ipq60xx
-FEATURES += source-only
 BOARDNAME:=Qualcomm Atheros IPQ60xx
 DEFAULT_PACKAGES += ath11k-firmware-ipq6018
 


### PR DESCRIPTION
Its been a while since we added ipq60xx as source-only, it is now quite usable so lets remove the source-only flag to start building official images.

I also plan to merge additional popular boards rather soon.
