### PR TITLE
ath79: gl-e750: use nvmem for mac addresses

### DIFF
--- a/target/linux/ath79/dts/qca9531_glinet_gl-e750.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-e750.dts
@@ -45,6 +45,13 @@
 
 &pcie0 {
 	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&macaddr_art_0 2>;
+		nvmem-cell-names = "mac-address";
+	};
 };
 
 &usb0 {
@@ -90,7 +97,9 @@
 					#size-cells = <1>;
 
 					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
 						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 
 					cal_art_1000: calibration@1000 {
@@ -134,7 +143,7 @@
 
 	phy-handle = <&swphy4>;
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_0 0>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/ieee80211/10-fix-wifi-mac
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/ieee80211/10-fix-wifi-mac
@@ -10,11 +10,6 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case $board in
-	glinet,gl-e750)
-		# Set mac address for 5g device
-		[ "$PHYNBR" -eq 0 ] && \
-			macaddr_add $(mtd_get_mac_binary art 0x0) 2 > /sys${DEVPATH}/macaddress
-		;;
 	zyxel,emg2926-q10a|\
 	zyxel,nbg6716)
 		ethaddr=$(mtd_get_mac_ascii u-boot-env ethaddr)


### PR DESCRIPTION
This is a simple conversion to dts.

https://github.com/openwrt/openwrt/commit/68ac3f2cddab8422d7de0ce1a78d23edf29012e7 states that the 5ghz wifi address is calculated from ART 0 + 2.