### PR TITLE
ramips: mt76x8: add support for Keenetic KN-3211

### DIFF
--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-3211.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-3211.dts
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "keenetic,kn-3211", "mediatek,mt7628an-soc";
+	model = "Keenetic KN-3211";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status_blue {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: status_green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: status_red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0 0x1ec0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "i2c", "gpio", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&usbphy {
+	status = "disabled";
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <32000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "rf-eeprom";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_400: eeprom@400 {
+						reg = <0x400 0x4da8>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+				};
+			};
+
+			firmware1: partition@50000 {
+				label = "firmware_1";
+				reg = <0x50000 0xf60000>;
+			};
+
+			partition@fb0000 {
+				label = "config_1";
+				reg = <0xfb0000 0x40000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "dump";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+
+			partition@1000000 {
+				label = "u-state";
+				reg = <0x1000000 0x30000>;
+				read-only;
+			};
+
+			partition@1030000 {
+				label = "u-config_res";
+				reg = <0x1030000 0x10000>;
+				read-only;
+			};
+
+			partition@1040000 {
+				label = "rf-eeprom_res";
+				reg = <0x1040000 0x10000>;
+				read-only;
+			};
+
+			firmware2: partition@1050000 {
+				label = "firmware_2";
+				reg = <0x1050000 0xf60000>;
+			};
+
+			partition@1fb0000 {
+				label = "config_2";
+				reg = <0x1fb0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_400>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -365,6 +365,16 @@ define Device/keenetic_kn-1613
 endef
 TARGET_DEVICES += keenetic_kn-1613
 
+define Device/keenetic_kn-3211
+  IMAGE_SIZE := 31488k
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-3211
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to $$$$(BLOCKSIZE) | \
+	check-size | zyimage -d 0x803211 -v "KN-3211"
+endef
+TARGET_DEVICES += keenetic_kn-3211
+
 define Device/kroks_kndrt31r16
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Kroks

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -134,6 +134,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "0:wan" "6@eth0"
 		;;
+	keenetic,kn-3211)
+		ucidef_add_switch "switch0" \
+			"2:lan" "6@eth0"
+		;;
 	kroks,kndrt31r19)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"
@@ -280,6 +284,7 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		;;
 	keenetic,kn-1613|\
+	keenetic,kn-3211|\
 	zyxel,keenetic-extra-ii)
 		wan_mac=$(mtd_get_mac_binary rf-eeprom 0x28)
 		;;


### PR DESCRIPTION
Keenetic KN-3211 is a 2.4 Ghz band 11n (Wi-Fi 4) Wi-Fi repeater, based on MT7628AN.

Specification:
- System-On-Chip: MT7628AN
- CPU/Speed: 575 MHz
- Flash-Chip: Winbond w25q256
- Flash size: 32768 KiB
- RAM: 64 MiB
- 1x 10/100 Mbps Ethernet
- 2x external, non-detachable antennas
- UART (J1) header on PCB (115200 8n1)
- Wireless No1 (2T2R): SoC Built-in 2.4 GHz 802.11bgn
- 3x LED, 1x button, 1x mode switch

Notes:
- The device supports dual boot mode
- The firmware partitions were concatenated into one
- The status button has been reassigned as the WPS button.

Flash instruction:
This device doesn't support sysupgrade, so the only way to flash OpenWrt image is to use tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.1.2/24 and tftp server.
2. Rename "openwrt-ramips-mt76x8-keenetic_kn-3211-squashfs-factory.bin" to "KN-3211_recovery.bin" and place it in tftp server directory.
3. Connect PC with the ethernet port, press the reset button, power up the router and keep button pressed until power led starts blinking.
4. Router will download file from server, write it to flash and reboot.