### PR TITLE
Revert "target,base-files: unify handling of procd-ujail"

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -90,6 +90,11 @@ else
   endif
 endif
 
+# include ujail on systems with enough storage
+ifeq ($(filter small_flash,$(FEATURES)),)
+  DEFAULT_PACKAGES+=procd-ujail
+endif
+
 # Add device specific packages (here below to allow device type set from subtarget)
 DEFAULT_PACKAGES += $(DEFAULT_PACKAGES.$(DEVICE_TYPE))
 

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -43,7 +43,7 @@ define Package/base-files
 	+netifd +libc +jsonfilter +SIGNED_PACKAGES:usign +SIGNED_PACKAGES:openwrt-keyring \
 	+NAND_SUPPORT:ubi-utils +fstools +fwtool \
 	+SELINUX:procd-selinux +!SELINUX:procd +USE_SECCOMP:procd-seccomp \
-	+SELINUX:busybox-selinux +!SELINUX:busybox +!SMALL_FLASH:procd-ujail
+	+SELINUX:busybox-selinux +!SELINUX:busybox
   TITLE:=Base filesystem for OpenWrt
   URL:=http://openwrt.org/
   VERSION:=$(PKG_RELEASE)~$(lastword $(subst -, ,$(REVISION)))


### PR DESCRIPTION
This reverts commit ac640718aa0ceae55969bb9e7e45d00bb7bc228a as it removes base-files package when KERNEL_NAMESPACES is deselected, asi base-files depends on procd-ujail which needs KERNEL_NAMESPACES.

Fixes: #17075