### PR TITLE
ath79: gl-x1200: don't override defaults

### DIFF
--- a/target/linux/ath79/dts/ar9331_alfa-network_ap121f.dtsi
+++ b/target/linux/ath79/dts/ar9331_alfa-network_ap121f.dtsi
@@ -116,10 +116,6 @@
 					macaddr_art_0: macaddr@0 {
 						reg = <0x0 0x6>;
 					};
-
-					macaddr_art_1002: macaddr@1002 {
-						reg = <0x1002 0x6>;
-					};
 				};
 			};
 
@@ -143,6 +139,6 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002>;
-	nvmem-cell-names = "calibration", "mac-address";
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
+++ b/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
@@ -154,10 +154,6 @@
 					macaddr_art_6: macaddr@6 {
 						reg = <0x6 0x6>;
 					};
-
-					macaddr_art_1002: macaddr@1002 {
-						reg = <0x1002 0x6>;
-					};
 				};
 			};
 
@@ -173,6 +169,6 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002>;
-	nvmem-cell-names = "calibration", "mac-address";
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/dts/ar9344_embeddedwireless_balin.dts
+++ b/target/linux/ath79/dts/ar9344_embeddedwireless_balin.dts
@@ -122,8 +122,8 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_1002 0>, <&calibration_art_1000>;
-	nvmem-cell-names = "mac-address", "calibration";
+	nvmem-cells = <&calibration_art_1000>;
+	nvmem-cell-names = "calibration";
 };
 
 &pcie {

--- a/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
+++ b/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
@@ -140,10 +140,6 @@
 					macaddr_art_6: macaddr@6 {
 						reg = <0x6 0x6>;
 					};
-
-					macaddr_art_1002: macaddr@1002 {
-						reg = <0x1002 0x6>;
-					};
 				};
 			};
 		};
@@ -174,6 +170,6 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002>;
-	nvmem-cell-names = "calibration", "mac-address";
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
+++ b/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
@@ -124,6 +124,6 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002 0>;
-	nvmem-cell-names = "calibration", "mac-address";
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/dts/qca9563_glinet_gl-x1200.dtsi
+++ b/target/linux/ath79/dts/qca9563_glinet_gl-x1200.dtsi
@@ -111,14 +111,6 @@
 					macaddr_art_0: macaddr@0 {
 						reg = <0x0 0x6>;
 					};
-
-					macaddr_art_1002: macaddr@1002 {
-						reg = <0x1002 0x6>;
-					};
-
-					macaddr_art_5006: macaddr@5006 {
-						reg = <0x5006 0x6>;
-					};
 				};
 			};
 
@@ -182,8 +174,8 @@
 		compatible = "qcom,ath10k";
 		reg = <0 0 0 0 0>;
 
-		nvmem-cells = <&macaddr_art_5006>, <&calibration_ath10k>;
-		nvmem-cell-names = "mac-address", "pre-calibration";
+		nvmem-cells = <&calibration_ath10k>;
+		nvmem-cell-names = "pre-calibration";
 	};
 };
 
@@ -206,6 +198,6 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_1002>, <&calibration_ath9k>;
-	nvmem-cell-names = "mac-address", "calibration";
+	nvmem-cells = <&calibration_ath9k>;
+	nvmem-cell-names = "calibration";
 };


### PR DESCRIPTION
1002 and 5006 are default addresses as part of the calibration data. Don't bother specifying them explicitly.

ping @DragonBluep 