### PR TITLE
ath79: pqi-air-pen: adjust mac addresses

### DIFF
--- a/target/linux/ath79/dts/ar9330_pqi_air-pen.dts
+++ b/target/linux/ath79/dts/ar9330_pqi_air-pen.dts
@@ -95,10 +95,6 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
-					macaddr_art_2: macaddr@2 {
-						reg = <0x2 0x6>;
-					};
-
 					cal_art_1000: calibration@1000 {
 						reg = <0x1000 0x440>;
 					};
@@ -153,6 +149,6 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&macaddr_art_2>, <&cal_art_1000>;
-	nvmem-cell-names = "mac-address", "calibration";
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -46,9 +46,6 @@ case "$FIRMWARE" in
 	ubnt,picostation-m)
 		caldata_extract "art" 0x1000 0x1000
 		;;
-	pqi,air-pen)
-		caldata_extract "art" 0x1000 0x7d2
-		;;
 	*)
 		caldata_die "board $board is not supported yet"
 		;;


### PR DESCRIPTION
The original ar71xx version of this device used 1002 as mac address for both ethernet and wireless. The ath79 version inexplicably changes this to 2, which seems to be done nowhere else in ath79, indicating it's bogus.

Restore previous ar71xx assignment. 1002 is used as an ethernet interface with some other devices as well.

Also remove the bogus caldata userspace extraction. The size is bogus and it's already handled in dts.

ping @srchack @DragonBluep @hauke 

Some important links:
https://github.com/openwrt/openwrt/commit/261415a660c12a5673fe3d48dabaf677e1d5c32c
https://github.com/openwrt/openwrt/commit/27eae6597e5f1570f2f0a8584907b077e724a0e1
https://github.com/openwrt/openwrt/pull/1434#issuecomment-648789094