### PR TITLE
realtek: add support for Hasivo S1100W-8XGT-SE switch

### DIFF
--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/thermal/thermal.h>
+
+/ {
+	compatible = "hasivo,s1100w-8xgt-se", "realtek,rtl838x-soc";
+	model = "Hasivo S1100W-8XGT-SE Switch";
+
+	thermal-zones {
+		phy0-thermal {
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy0>;
+
+			trips {
+				phy0_trip0: phy0-trip0 {
+					temperature = <75000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+				phy0_trip1: phy0-trip1 {
+					temperature = <100000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+			cooling-maps {
+				map {
+					trip = <&phy0_trip0>;
+					//cooling-device = <&chasis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x00e0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x00e0000 0x0010000>;
+			};
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0x00f0000 0x0010000>;
+			};
+			partition@100000 {
+				label = "jffs";
+				reg = <0x0100000 0x0100000>;
+				read-only;
+			};
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x0200000 0x0100000>;
+				read-only;
+			};
+			partition@300000 {
+				label = "firmware";
+				reg = <0x0300000 0x0c00000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+			};
+			partition@f00000 {
+				label = "oeminfo";
+				reg = <0x0f00000 0x0100000>;
+				read-only;
+			};
+			
+		};
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: ethernet-phy@0 {
+			reg = <0>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <0 0>;
+			sds = <2>;
+		};
+		phy8: ethernet-phy@8 {
+			reg = <8>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <0 1>;
+			sds = <3>;
+		};
+		phy16: ethernet-phy@16 {
+			reg = <16>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <0 2>;
+			sds = <4>;
+		};
+		phy20: ethernet-phy@20 {
+			reg = <20>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <0 3>;
+			sds = <5>;
+		};
+		phy24: ethernet-phy@24 {
+			reg = <24>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <3 16>;
+			sds = <6>;
+		};
+		phy25: ethernet-phy@25 {
+			reg = <25>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <3 17>;
+			sds = <7>;
+
+		};
+		phy26: ethernet-phy@26 {
+			reg = <26>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <3 18>;
+			sds = <8>;
+		};
+		phy27: ethernet-phy@27 {
+			reg = <27>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <3 19>;
+			sds = <9>;
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			phy-mode = "usxgmii";
+			phy-handle = <&phy0>;
+		};
+		port@8 {
+			reg = <8>;
+			label = "lan2";
+			phy-mode = "usxgmii";
+			phy-handle = <&phy8>;
+		};
+		port@16 {
+			reg = <16>;
+			label = "lan3";
+			phy-mode = "usxgmii";
+			phy-handle = <&phy16>;
+		};
+		port@20 {
+			reg = <20>;
+			label = "lan4";
+			phy-mode = "usxgmii";
+			phy-handle = <&phy20>;
+		};
+		port@24 {
+			reg = <24>;
+			label = "lan5";
+			phy-mode = "usxgmii";
+			phy-handle = <&phy24>;
+		};
+		port@25 {
+			reg = <25>;
+			label = "lan6";
+			phy-mode = "usxgmii";
+			phy-handle = <&phy25>;
+		};
+		port@26 {
+			reg = <26>;
+			label = "lan7";
+			phy-mode = "usxgmii";
+			phy-handle = <&phy26>;
+		};
+		port@27 {
+			reg = <27>;
+			label = "lan8";
+			phy-mode = "usxgmii";
+			phy-handle = <&phy27>;
+		};
+		/* Internal SoC */
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -16,3 +16,17 @@ define Device/zyxel_xgs1250-12
 	uImage gzip
 endef
 TARGET_DEVICES += zyxel_xgs1250-12
+
+define Device/hasivo_s1100w-8xgt-se
+  SOC := rtl9303
+  DEVICE_VENDOR := Hasivo
+  DEVICE_MODEL := S1100W-8XGT-SE
+  DEVICE_PACKAGES := kmod-hwmon-gpiofan kmod-thermal
+  IMAGE_SIZE := 12288k
+  KERNEL_INITRAMFS := \
+	kernel-bin | \
+	append-dtb | \
+	gzip | \
+	uImage gzip
+endef
+TARGET_DEVICES += hasivo_s1100w-8xgt-se


### PR DESCRIPTION
This commit adds support for Hasivo S1100W-8XGT-SE switch.

Device specification
--------------------
SoC Type:	RTL9303
RAM:		Samsung K4B461646E-BYKO (512MB)
Flash:		Fudan FM25Q128A (16 MB)
Ethernet:	8x 10G via 2x RTL8264 PHY
LEDs:		2 LEDs, 1 power green, 1 system green
Button:		Reset
USB ports:	None
Bootloader:	Realtek U-Boot - U-Boot 2011.12.(3.6.6.55087) (Nov 13 2022 - 14:37:31)

Root access via serial
----------------------
1. ctrl+t
2. password: switchrtk
3. press 's' for shell

Root access via SSH
-------------------
1. ctrl+t
2. password: switchrtk
3. sys command sh
4. log in with your username+password
5. ctrl+t
6. password: switchrtk
7. press 's' for shell

Credit to https://forum.openwrt.org/t/hasivo-switches/151758/174 for rooting instructions.