### PR TITLE
ath79: add support for KuWFi N650 CPE

### DIFF
--- a/target/linux/ath79/dts/qca9563_kuwfi_n650.dts
+++ b/target/linux/ath79/dts/qca9563_kuwfi_n650.dts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	model = "KuWFi N650";
+	compatible = "kuwfi,n650", "qca,qca9563";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_green;
+		led-running = &led_green;
+		led-failsafe = &led_blue;
+		led-upgrade = &led_blue;
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x0>;
+				label = "firmware";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+			};
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_blue: blue {
+			function = LED_FUNCTION_DEBUG;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_green: green {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x030000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x030000 0x010000>;
+			};
+
+			fwconcat0: partition@40000 {
+				label = "fwconcat0";
+				reg = <0x040000 0xd40000>;
+			};
+
+			partition@d80000 {
+				label = "loader";
+				reg = <0xd80000 0x10000>;
+			};
+
+			fwconcat1: partition@d90000 {
+				label = "fwconcat1";
+				reg = <0xd90000 0x160000>;
+			};
+
+			partition@ef0000 {
+				label = "log";
+				reg = <0xef0000 0x0f0000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "nvram";
+				reg = <0xfe0000 0x010000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					precal_art_5000: pre-calibration@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		reset-gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0 0>;
+	nvmem-cell-names = "mac-address";
+	phy-handle = <&phy0>;
+	phy-mode = "sgmii";
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "pci168c,0056";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&precal_art_5000>, <&macaddr_art_0 1>;
+		nvmem-cell-names = "pre-calibration", "mac-address";
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -401,6 +401,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:2" "4:lan:1"
 		;;
+	kuwfi,n650)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:1" "3:lan:2"
+		;;
 	letv,lba-047-ch)
 		ucidef_set_interface_wan "eth0"
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1963,6 +1963,25 @@ define Device/kuwfi_c910
 endef
 TARGET_DEVICES += kuwfi_c910
 
+define Device/kuwfi_n650
+  $(Device/loader-okli-uimage)
+  SOC := qca9563
+  DEVICE_VENDOR := KuWFi
+  DEVICE_MODEL := N650
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  FACTORY_SIZE := 13632k
+  LOADER_FLASH_OFFS := 0x40000
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49
+  IMAGE_SIZE := 15040k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+    append-rootfs | pad-rootfs | check-size | pad-to 13568k | \
+    append-loader-okli-uimage $(1) | pad-to 64k | check-size $$$$(FACTORY_SIZE)
+  ARTIFACTS := loader.bin
+  ARTIFACT/loader.bin := append-loader-okli-uimage $(1) | pad-to 64k
+endef
+TARGET_DEVICES += kuwfi_n650
+
 define Device/letv_lba-047-ch
   $(Device/loader-okli-uimage)
   SOC := qca9531


### PR DESCRIPTION
The KuWFi N650 is a 5GHz outdoor wireless bridge based on QCA9563.

Specs
=====

CPU: QCA9563
RAM: 128MiB
Flash: 16MiB
Wireless: QCA9888 (5GHz only)
Ethernet: 2x GBit (via QCA8337)

Installation
============

From OEM firmware
-----------------

The OEM firmware has telnet enabled by default. If not, it can be enabled from the firmware web interface. You need a TFTP server on your computer and the OpenWrt factory image should be available as "n650factory.bin". It is assumed that your computer has the IP 192.168.1.1 and the N650 192.168.1.20 (default IP address).

1. Connect via Telnet to the device and log in with the default credentials "admin:admin"
2. Exploit the limited interface by typing "ps & /bin/sh"
3. Press <ENTER> to start the shell
4. Enter the following commands:
```
$ cd /tmp
$ tftp -r n650factory.bin -g 192.168.1.1
$ cat << EOF > /tmp/openwrt.sh
#!/bin/sh

IMAGE_NAME="\$1"

if [ ! -e \${IMAGE_NAME} ]; then
  echo "Image file not found: \${IMAGE_NAME}"
  exit 1
fi

. /usr/sbin/common.sh

kill_remaining TERM
sleep 3
kill_remaining KILL

run_ramfs mtd write \${IMAGE_NAME} firmware
sleep 2
reboot -f
EOF

$ chmod +x /tmp/openwrt.sh
$ /tmp/openwrt.sh n650factory.bin
```
Once the device reboots, it should load OpenWrt.

From UART
---------

UART installation is possible since the serial header is already soldered on. The pinout is GND - Tx - Rx - VCC from top to bottom (RJ45 ports are at the bottom). Connect with 115200 8N1.

First, boot OpenWrt from TFTP. Enter the following commands in the U-Boot shell, assuming your computer has the IP address 192.168.1.1 and a TFTP server running where the initramfs image is provided as n650.bin:
```
  setenv ipaddr 192.168.1.20
  setenv serverip 192.168.1.1
  tftpboot 0x84000000 n650.bin
  bootm
```
Once booted, transfer -loader.bin and -sysupgrade.bin images to the device at /tmp. Enter the following commands, replacing the filenames:
```
  mtd write /tmp/loader.bin loader
  sysupgrade /tmp/sysupgrade.bin
```
Reboot and OpenWrt should load from flash.
