### PR TITLE
base-files: wifi isup if any WiFi radio is up

### DIFF
--- a/package/network/config/wifi-scripts/files/sbin/wifi
+++ b/package/network/config/wifi-scripts/files/sbin/wifi
@@ -30,11 +30,11 @@ wifi_isup() {
 	for device in $devices; do
 		json_select "$device"
 			json_get_var up up
-			[ $up -eq 0 ] && return 1
+			[ $up -eq 1 ] && return 0
 		json_select ..
 	done
 
-	return 0
+	return 1
 }
 
 find_net_config() {(


### PR DESCRIPTION
Currently, the `isup` command of the `wifi` script returns `1` if any WiFi radios aren't up.
Moreover, it returns `0` if no WiFi radios are configured on the system.

I think it makes more sense to return `0` if any WiFi radio of the system is up, and `1` otherwise.

@dhewg 