### PR TITLE
base-files: add migration information for APK

### DIFF
--- a/package/base-files/files/etc/profile
+++ b/package/base-files/files/etc/profile
@@ -38,3 +38,24 @@ in order to prevent unauthorized SSH logins.
 --------------------------------------------------
 EOF
 fi
+
+if [ -x /usr/bin/apk ]; then
+cat << EOF
+
+ OpenWrt recently switched to the "apk" package manger!
+
+ OPKG Command           APK Equivalent      Description
+ ------------------------------------------------------------------
+ opkg install <pkg>     apk add <pkg>       Install a package
+ opkg remove <pkg>      apk del <pkg>       Remove a package
+ opkg upgrade           apk upgrade         Upgrade all packages
+ opkg files <pkg>       apk info -L <pkg>   List package contents
+ opkg list-installed    apk info            List installed packages
+ opkg update            apk update          Update package lists
+ opkg search <pkg>      apk search <pkg>    Search for packages
+ ------------------------------------------------------------------
+
+For more https://openwrt.org/docs/guide-user/additional-software/opkg-to-apk-cheatsheet
+
+EOF
+fi


### PR DESCRIPTION
If the `apk` package manager is installed, show a table of common commands to deal with the system.