### PR TITLE
meson: honor MESON_ARGS and MESON_HOST_ARGS when calling ninja

### DIFF
--- a/include/meson.mk
+++ b/include/meson.mk
@@ -108,7 +108,7 @@ define Host/Configure/Meson
 endef
 
 define Host/Compile/Meson
-	+$(NINJA) -C $(MESON_HOST_BUILD_DIR) $(1)
+	+$(MESON_HOST_VARS) $(NINJA) -C $(MESON_HOST_BUILD_DIR) $(1)
 endef
 
 define Host/Install/Meson
@@ -135,7 +135,7 @@ define Build/Configure/Meson
 endef
 
 define Build/Compile/Meson
-	+$(NINJA) -C $(MESON_BUILD_DIR) $(1)
+	+$(MESON_VARS) $(NINJA) -C $(MESON_BUILD_DIR) $(1)
 endef
 
 define Build/Install/Meson


### PR DESCRIPTION
Set `MESON_ARGS` and `MESON_HOST_ARGS` when calling ninja for building. This is required eg. to be able to set `PYTHONPATH` not just for the Meson (==configure) run but also for the build phase itself.