### PR TITLE
tools: ccache update to 4.10.2

### DIFF
--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ccache
-PKG_VERSION:=4.10
+PKG_VERSION:=4.10.2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ccache/ccache/releases/download/v$(PKG_VERSION)
-PKG_HASH:=16972ba62c8499045edc3ae7d7b8a0b419a961567f5ff0f01bf5a44194204775
+PKG_HASH:=108100960bb7e64573ea925af2ee7611701241abb36ce0aae3354528403a7d87
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk

--- a/tools/ccache/patches/100-honour-copts.patch
+++ b/tools/ccache/patches/100-honour-copts.patch
@@ -1,6 +1,6 @@
 --- a/src/ccache/ccache.cpp
 +++ b/src/ccache/ccache.cpp
-@@ -1906,6 +1906,7 @@ get_manifest_key(Context& ctx, Hash& has
+@@ -1914,6 +1914,7 @@ get_manifest_key(Context& ctx, Hash& has
      "OBJCPLUS_INCLUDE_PATH",        // Clang
      "CLANG_CONFIG_FILE_SYSTEM_DIR", // Clang
      "CLANG_CONFIG_FILE_USER_DIR",   // Clang


### PR DESCRIPTION
Fixes since 4.10:

 * Fixed detection of Fmt version 11 and newer.
 * Fixed prefix command lookup from PATH.