### PR TITLE
image: apk: dont fail on removing a package that doesnt exist

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -373,7 +373,7 @@ ifneq ($(CONFIG_USE_APK),)
 	rm -rf $(mkfs_cur_target_dir)
 	$(CP) $(TARGET_DIR_ORIG) $(mkfs_cur_target_dir)
 	$(if $(mkfs_packages_remove), \
-		$(apk_target) del $(mkfs_packages_remove))
+		-$(apk_target) del $(mkfs_packages_remove))
 	$(if $(mkfs_packages_add), \
 		$(apk_target) add $(mkfs_packages_add))
 else


### PR DESCRIPTION
Currently, in case when a package in the device package list is marked with the "-" prefix meaning that its supposed to be removed for that device but it was not actually previously built it will cause the APK to error out it and thus image generation will also fail.

So, lets do what OPKG build step does and supress the error with the "-" prefix in make.

Fixes: #17103
Fixes: d788ab376f85 ("build: add APK package build capabilities")