### PR TITLE
apk: build static

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git
@@ -53,10 +53,12 @@ MESON_HOST_VARS+=VERSION=$(PKG_VERSION)
 MESON_VARS+=VERSION=$(PKG_VERSION)
 
 MESON_COMMON_ARGS = \
+	-Db_lto=true \
 	-Dcompressed-help=false \
 	-Ddocs=disabled \
 	-Dhelp=enabled \
 	-Dlua_version=5.1 \
+	-Ddefault_library=static \
 	-Durl_backend=wget \
 	-Dzstd=false
 
@@ -80,9 +82,6 @@ define Package/apk/default/install
 
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/apk $(1)/usr/bin/apk
-
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libapk.so.* $(1)/usr/lib/
 
 	$(INSTALL_DIR) $(1)/etc/apk/repositories.d
 	$(INSTALL_DATA) ./files/customfeeds.list $(1)/etc/apk/repositories.d/customfeeds.list


### PR DESCRIPTION
libapk as a library is used nowhere else and makes no sense to link it shared. By linking static, we can take advantage of LTO and get the size reduced further.

Some numbers locally:

Before:

168K staging_dir/target-mips_24kc_musl/root-ath79/usr/bin/apk*
252K staging_dir/target-mips_24kc_musl/root-ath79/usr/lib/libapk.so.2.99.0*

Static:
344K staging_dir/target-mips_24kc_musl/root-ath79/usr/bin/apk*

Static + LTO:
305K staging_dir/target-mips_24kc_musl/root-ath79/usr/bin/apk*