### PR TITLE
ramips: mt7620: add support for THA-103AC (Version v1.0R)

### DIFF
--- a/target/linux/ramips/dts/mt7620a_trendnet_tha103ac.dts
+++ b/target/linux/ramips/dts/mt7620a_trendnet_tha103ac.dts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "trendnet,tha103ac", "ralink,mt7620a-soc";
+	model = "TRENDNET THA-103AC (EU)";
+
+	aliases {
+		label-mac-device = &ethernet;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys: keys {
+		compatible = "gpio-keys";
+
+		button_reset {
+			label = "reset";
+			gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		/* wps button reassigned to rfkill */
+		button_rfkill {
+			label = "wifi on/off";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_BLUE>;
+			/* LED_FUNCTION_RSSILOW isn't implemented yet */
+			function = "rssilow";
+			gpios = <&gpio2 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			color = <LED_COLOR_ID_BLUE>;
+			/* LED_FUNCTION_RSSIMEDLOW isn't implemented yet */
+			function = "rssimedlow";
+			gpios = <&gpio2 17 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			color = <LED_COLOR_ID_BLUE>;
+			/* LED_FUNCTION_RSSIMEDIUM isn't implemented yet */
+			function = "rssimedium";
+			gpios = <&gpio2 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led-6 {
+			color = <LED_COLOR_ID_BLUE>;
+			/* LED_FUNCTION_RSSIHIGH isn't implemented yet */
+			function = "rssihigh";
+			gpios = <&gpio2 19 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						compatible = "mac-base";
+						reg = <0x28 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_8004: macaddr@8004 {
+						compatible = "mac-base";
+						reg = <0x8004 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uartf", "ephy";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28 0>;
+	nvmem-cell-names = "mac-address";
+
+	mediatek,portmap = "wl";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_8004 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1322,6 +1322,16 @@ define Device/trendnet_tew-810dr
 endef
 TARGET_DEVICES += trendnet_tew-810dr
 
+define Device/trendnet_tha103ac
+  SOC := mt7620a
+  DEVICE_PACKAGES := kmod-mt76x0e rssileds
+  DEVICE_VENDOR := TRENDnet
+  DEVICE_MODEL := THA-103AC
+  IMAGE_SIZE := 7872k
+  SUPPORTED_DEVICES += mt7620a_mt7610e
+endef
+TARGET_DEVICES += trendnet_tha103ac
+
 define Device/vonets_var11n-300
   SOC := mt7620n
   IMAGE_SIZE := 3776k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -249,6 +249,13 @@ tplink,ec220-g5-v2)
 tplink,re200-v1)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
+trendnet,tha103ac)
+	ucidef_set_rssimon "wlan0" "200000" "1"
+	ucidef_set_led_rssi "led_rssilow" "RSSILOW" "blue:rssilow" "wlan0" "31" "100"
+	ucidef_set_led_rssi "led_rssimedlow" "RSSIMEDIUMLOW" "blue:rssimedlow" "wlan0" "41" "100"
+	ucidef_set_led_rssi "led_rssimedium" "RSSIMEDIUM" "blue:rssimedium" "wlan0" "51" "100"
+	ucidef_set_led_rssi "led_rssihigh" "RSSIHIGH" "blue:rssihigh" "wlan0" "71" "100"
+	;;
 wavlink,wl-wn535k1)
 	ucidef_set_led_switch "lan1" "lan1" "green:lan1" "switch0" "0x20"
 	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x04"

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -65,6 +65,7 @@ ramips_setup_interfaces()
 	sercomm,na930|\
 	tplink,re200-v1|\
 	tplink,re210-v1|\
+	trendnet,tha103ac|\
 	yukai,bocco|\
 	zbtlink,zbt-cpe102|\
 	zte,q7)
@@ -340,7 +341,8 @@ ramips_setup_macs()
 	asus,rt-ac54u)
 		lan_mac=$(mtd_get_mac_binary factory 0x22)
 		;;
-	dlink,dch-m225)
+	dlink,dch-m225|\
+	trendnet,tha103ac)
 		lan_mac=$(mtd_get_mac_ascii factory lanmac)
 		;;
 	dlink,dir-510l|\


### PR DESCRIPTION
**Hardware**
Mediatek MT7620A + Mediatek MT7610EN 
64MB RAM
8MB NAND (Winbond 25064FVSIG )

Both 2.4GHZ and 5GHZ are working, it is enabled by default since there is no physical ethernet port in the device.

All LED's and buttons work.

UART: 57600 8N1 3.3V

**Installation**
Upload the **openwrt-ramips-mt7620-trendnet_tha103ac-initramfs-kernel.bin** via the manufacturer firmware upgrade page on the device.

Upon reboot wait +- 3 mins until the green power LED is not flashing anymore _(do not be tempted to switch the device off while the LED is flashing, unless you are ready for soldering and TTL)_ and then press the WPS button to enable the default OpenWrt Wifi AP, the BLUE wifi LED will start flash.

Then install **openwrt-ramips-mt7620-trendnet_tha103ac-squashfs-sysupgrade.bin** via OpenWrt.

The integrated power monitoring and relay do not work in OpenWrt as the PL7223 chip source/documentation is unavailable.

**Recovery**
Mis-configuration can be dealt with using the RESET button to reset to factory, worst case scenario will require some serious work and soldering, there's pads on the PCB for both the UART and ETH0, and I soldered and tested that it does work.

You will have to power the board using the header pins, 5V and GND, see the 8-pin header socket in the picture below, with layout/white silkscreen on PCB.

![image](https://github.com/user-attachments/assets/abfb3c6a-59d6-4fb0-a2b5-88cfe40567ff)

![image](https://github.com/user-attachments/assets/aad43a94-8d08-4b2b-a582-11f78ee9c718)

Recovery using U-BOOT using  **openwrt-ramips-mt7620-trendnet_tha103ac-squashfs-kernel.bin** renamed to 'test.bin'.

```
Please choose the operation: 
   1: Load system code to SDRAM via TFTP. 
   2: Load system code then write to Flash via TFTP. 
   3: Boot system code via Flash (default).
   4: Entr boot command line interface.
   6: To emergency. 
   7: Load Boot Loader code then write to Flash via Serial. 
   9: Load Boot Loader code then write to Flash via TFTP. 
 
You choosed 1

 
raspi_read: from:40028 len:6 

   
1: System Load Linux to SDRAM via TFTP. 
 Please Input new ones /or Ctrl-C to discard
        Input device IP (10.10.10.123) ==:10.10.10.123
        Input server IP (10.10.10.3) ==:10.10.10.3
        Input Linux Kernel filename (test.bin) ==:test.bin

 netboot_common, argc= 3 

 NetTxPacket = 0x83FE4980 

 KSEG1ADDR(NetTxPacket) = 0xA3FE4980 

 NetLoop,call eth_halt ! 

 NetLoop,call eth_init ! 
Trying Eth0 (10/100-M)

 Waiting for RX_DMA_BUSY status Start... done


 ETH_STATE_ACTIVE!! 
TFTP from server 10.10.10.3; our IP address is 10.10.10.123
Filename 'test.bin'.

 TIMEOUT_COUNT=10,Load address: 0x80a00000
Loading: Got ARP
Got ARP REPLY, set server/gtwy eth addr (f0:76:1c:ba:8f:b1)
Got it
#################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #############################Got ARP
Got ARP REQUEST, return our IP
####################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         #########
done
Bytes transferred = 6034779 (5c155b hex)
NetBootFileXferSize= 005c155b
Automatic boot of image at addr 0x80A00000 ...
## Booting image at 80a00000 ...
   Image Name:   MIPS OpenWrt Linux-6.6.61
   Image Type:   MIPS Linux Kernel Image (lzma compressed)
   Data Size:    6034715 Bytes =  5.8 MB
   Load Address: 80000000
   Entry Point:  80000000
   Verifying Checksum ... OK
   Uncompressing Kernel Image ... OK
No initrd
## Transferring control to Linux (at address 80000000) ...
## Giving linux memsize in MB, 64

Starting kernel ...

[    0.000000] Linux version 6.6.61 (root@OpenWrtBuild) (mipsel-openwrt-linux-musl-gcc (OpenWrt GCC 13.3.0 r28092-487ca61f91) 13.3.0, GNU ld (GNU Binutils) 2.42) #0 Fri Nov 15 23:25:14 2024
[    0.000000] Board has DDR2
```
Tested And
Signed-off-by: Die Peter Pan <diepeterpan@gmail.com>