### PR TITLE
Revert "ath79: elecom,wab: use nvmem"

### DIFF
--- a/target/linux/ath79/dts/qca955x_elecom_wab.dtsi
+++ b/target/linux/ath79/dts/qca955x_elecom_wab.dtsi
@@ -8,7 +8,6 @@
 
 / {
 	aliases {
-		label-mac-device = &eth0;
 		led-boot = &led_status;
 		led-failsafe = &led_status;
 		led-upgrade = &led_status;
@@ -108,9 +107,6 @@
 	phy-mode = "rgmii-rxid";
 	pll-data = <0xae000000 0x80000101 0x80001313>;
 
-	nvmem-cells = <&macaddr_uboot_ethaddr 0>;
-	nvmem-cell-names = "mac-address";
-
 	gmac-config {
 		device = <&gmac>;
 
@@ -148,8 +144,8 @@
 	wifi@0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&cal_art_5000>, <&macaddr_uboot_ethaddr 1>;
-		nvmem-cell-names = "calibration", "mac-address";
+		nvmem-cells = <&cal_art_5000>;
+		nvmem-cell-names = "calibration";
 	};
 };
 
@@ -173,14 +169,9 @@
 			};
 
 			partition@40000 {
-				compatible = "u-boot,env";
 				label = "u-boot-env";
 				reg = <0x40000 0x10000>;
 				read-only;
-
-				macaddr_uboot_ethaddr: ethaddr {
-					#nvmem-cell-cells = <1>;
-				};
 			};
 
 			partition@50000 {
@@ -261,6 +252,6 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>, <&macaddr_uboot_ethaddr 0>;
-	nvmem-cell-names = "calibration", "mac-address";
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -717,6 +717,9 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii devdata "lanmac")
 		wan_mac=$(mtd_get_mac_ascii devdata "wanmac")
 		;;
+	elecom,wab-i1750-ps|\
+	elecom,wab-s1167-ps|\
+	elecom,wab-s600-ps|\
 	engenius,ecb1200|\
 	engenius,ecb1750)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -42,6 +42,16 @@ case "$board" in
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_ascii bdcfg "wlanmac" > /sys${DEVPATH}/macaddress
 		;;
+	elecom,wab-i1750-ps|\
+	elecom,wab-s1167-ps|\
+	elecom,wab-s600-ps)
+		# set the 5G MAC address (= ethaddr + 1)
+		[ "$PHYNBR" -eq 0 ] && \
+			macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" 1 > /sys${DEVPATH}/macaddress
+		# set the 2.4G MAC address (= ethaddr)
+		[ "$PHYNBR" -eq 1 ] && \
+			mtd_get_mac_ascii u-boot-env "ethaddr" > /sys${DEVPATH}/macaddress
+		;;
 	engenius,ecb1200|\
 	engenius,ecb1750)
 		[ "$PHYNBR" -eq 0 ] && \


### PR DESCRIPTION
This reverts commit 70e41d0205d95386881fa1cdf6ee00f6cca1b3f6.

"ethaddr" is stored into the "u-boot-env" (stock: "Config") partition and it's quoted with double-quotations, but that format is not supported by the current NVMEM u-boot-env driver (and mac_pton() function) and the MAC address won't be parsed to byte array.
This causes random MAC addresses on the adapters, so revert the above commit.
