### PR TITLE
ath79: usb: upstream friendly changes

### DIFF
--- a/target/linux/ath79/dts/ar7100.dtsi
+++ b/target/linux/ath79/dts/ar7100.dtsi
@@ -54,7 +54,7 @@
 				compatible = "qca,ar7100-usb-phy";
 				reg = <0x18030000 0x10>;
 
-				reset-names = "usb-phy", "usb-host", "usb-ohci-dll";
+				reset-names = "phy", "usb-host", "usb-ohci-dll";
 				resets = <&rst 4>, <&rst 5>, <&rst 6>;
 
 				#phy-cells = <0>;

--- a/target/linux/ath79/dts/ar7100.dtsi
+++ b/target/linux/ath79/dts/ar7100.dtsi
@@ -54,7 +54,7 @@
 				compatible = "qca,ar7100-usb-phy";
 				reg = <0x18030000 0x10>;
 
-				reset-names = "phy", "usb-host", "usb-ohci-dll";
+				reset-names = "phy", "host", "usb-ohci-dll";
 				resets = <&rst 4>, <&rst 5>, <&rst 6>;
 
 				#phy-cells = <0>;

--- a/target/linux/ath79/dts/ar7100.dtsi
+++ b/target/linux/ath79/dts/ar7100.dtsi
@@ -147,7 +147,7 @@
 		interrupt-parent = <&cpuintc>;
 		interrupts = <3>;
 
-		phy-names = "usb-phy";
+		phy-names = "usb";
 		phys = <&usb_phy>;
 
 		has-synopsys-hc-bug;
@@ -170,7 +170,7 @@
 		interrupt-parent = <&miscintc>;
 		interrupts = <6>;
 
-		phy-names = "usb-phy";
+		phy-names = "usb";
 		phys = <&usb_phy>;
 
 		status = "disabled";

--- a/target/linux/ath79/dts/ar7240.dtsi
+++ b/target/linux/ath79/dts/ar7240.dtsi
@@ -6,7 +6,7 @@
 	usb_phy: usb-phy {
 		compatible = "qca,ar7200-usb-phy";
 
-		reset-names = "usb-phy", "usb-ohci-dll";
+		reset-names = "phy", "usb-ohci-dll";
 		resets = <&rst 4>, <&rst 3>;
 
 		#phy-cells = <0>;

--- a/target/linux/ath79/dts/ar7240.dtsi
+++ b/target/linux/ath79/dts/ar7240.dtsi
@@ -29,7 +29,7 @@
 		resets = <&rst 5>;
 		reset-names = "usb-host";
 
-		phy-names = "usb-phy";
+		phy-names = "usb";
 		phys = <&usb_phy>;
 
 		status = "disabled";

--- a/target/linux/ath79/dts/ar7240.dtsi
+++ b/target/linux/ath79/dts/ar7240.dtsi
@@ -27,7 +27,6 @@
 		interrupts = <3>;
 
 		resets = <&rst 5>;
-		reset-names = "usb-host";
 
 		phy-names = "usb";
 		phys = <&usb_phy>;

--- a/target/linux/ath79/dts/ar7241.dtsi
+++ b/target/linux/ath79/dts/ar7241.dtsi
@@ -32,7 +32,7 @@
 		has-transaction-translator;
 		caps-offset = <0x100>;
 
-		phy-names = "usb-phy";
+		phy-names = "usb";
 		phys = <&usb_phy>;
 
 		status = "disabled";

--- a/target/linux/ath79/dts/ar7241.dtsi
+++ b/target/linux/ath79/dts/ar7241.dtsi
@@ -6,7 +6,7 @@
 	usb_phy: usb-phy {
 		compatible = "qca,ar7200-usb-phy";
 
-		reset-names = "usb-phy", "usb-suspend-override";
+		reset-names = "phy", "suspend-override";
 		resets = <&rst 4>, <&rst 3>;
 
 		#phy-cells = <0>;

--- a/target/linux/ath79/dts/ar7241.dtsi
+++ b/target/linux/ath79/dts/ar7241.dtsi
@@ -27,7 +27,6 @@
 		interrupts = <3>;
 
 		resets = <&rst 5>;
-		reset-names = "usb-host";
 
 		has-transaction-translator;
 		caps-offset = <0x100>;

--- a/target/linux/ath79/dts/ar7242.dtsi
+++ b/target/linux/ath79/dts/ar7242.dtsi
@@ -32,7 +32,7 @@
 		has-transaction-translator;
 		caps-offset = <0x100>;
 
-		phy-names = "usb-phy";
+		phy-names = "usb";
 		phys = <&usb_phy>;
 
 		status = "disabled";

--- a/target/linux/ath79/dts/ar7242.dtsi
+++ b/target/linux/ath79/dts/ar7242.dtsi
@@ -6,7 +6,7 @@
 	usb_phy: usb-phy {
 		compatible = "qca,ar7200-usb-phy";
 
-		reset-names = "usb-phy", "usb-suspend-override";
+		reset-names = "phy", "suspend-override";
 		resets = <&rst 4>, <&rst 3>;
 
 		#phy-cells = <0>;

--- a/target/linux/ath79/dts/ar7242.dtsi
+++ b/target/linux/ath79/dts/ar7242.dtsi
@@ -27,7 +27,6 @@
 		interrupts = <3>;
 
 		resets = <&rst 5>;
-		reset-names = "usb-host";
 
 		has-transaction-translator;
 		caps-offset = <0x100>;

--- a/target/linux/ath79/dts/ar9132.dtsi
+++ b/target/linux/ath79/dts/ar9132.dtsi
@@ -188,7 +188,7 @@
 	usb_phy: usb-phy {
 		compatible = "qca,ar7200-usb-phy";
 
-		reset-names = "usb-phy", "usb-suspend-override";
+		reset-names = "phy", "suspend-override";
 		resets = <&rst 4>, <&rst 3>;
 
 		#phy-cells = <0>;

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -166,7 +166,7 @@
 	usb_phy: usb-phy {
 		compatible = "qca,ar7200-usb-phy";
 
-		reset-names = "usb-phy", "usb-suspend-override";
+		reset-names = "phy", "suspend-override";
 		resets = <&rst 4>, <&rst 3>;
 
 		#phy-cells = <0>;

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -120,7 +120,6 @@
 
 			interrupts = <3>;
 			resets = <&rst 5>;
-			reset-names = "usb-host";
 
 			phy-names = "usb";
 			phys = <&usb_phy>;

--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -122,7 +122,7 @@
 			resets = <&rst 5>;
 			reset-names = "usb-host";
 
-			phy-names = "usb-phy";
+			phy-names = "usb";
 			phys = <&usb_phy>;
 
 			status = "disabled";

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -166,7 +166,6 @@
 
 			interrupts = <3>;
 			resets = <&rst 5>;
-			reset-names = "usb-host";
 
 			has-transaction-translator;
 			caps-offset = <0x100>;

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -216,7 +216,7 @@
 	usb_phy: usb-phy {
 		compatible = "qca,ar9340-usb-phy", "qca,ar7200-usb-phy";
 
-		reset-names = "usb-phy-analog", "usb-phy", "usb-suspend-override";
+		reset-names = "phy-analog", "phy", "suspend-override";
 		resets = <&rst 11>, <&rst 4>, <&rst 3>;
 
 		#phy-cells = <0>;

--- a/target/linux/ath79/dts/ar934x.dtsi
+++ b/target/linux/ath79/dts/ar934x.dtsi
@@ -171,7 +171,7 @@
 			has-transaction-translator;
 			caps-offset = <0x100>;
 
-			phy-names = "usb-phy";
+			phy-names = "usb";
 			phys = <&usb_phy>;
 
 			status = "disabled";

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -199,7 +199,7 @@
 			has-transaction-translator;
 			caps-offset = <0x100>;
 
-			phy-names = "usb-phy";
+			phy-names = "usb";
 			phys = <&usb_phy>;
 
 			status = "disabled";

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -193,7 +193,6 @@
 
 			interrupts = <3>;
 			resets = <&rst 5>;
-			reset-names = "usb-host";
 			dr_mode = "host";
 
 			has-transaction-translator;

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -60,7 +60,7 @@
 				reg = <0x18030000 0x100>;
 				#phy-cells = <0>;
 
-				reset-names = "usb-phy-analog", "usb-phy", "usb-suspend-override";
+				reset-names = "phy-analog", "phy", "suspend-override";
 				resets = <&rst 11>, <&rst 4>, <&rst 3>;
 
 				status = "disabled";

--- a/target/linux/ath79/dts/qca955x.dtsi
+++ b/target/linux/ath79/dts/qca955x.dtsi
@@ -273,7 +273,6 @@
 			interrupt-parent = <&intc3>;
 			interrupts = <1>;
 			resets = <&rst 5>;
-			reset-names = "usb-host";
 
 			has-transaction-translator;
 			caps-offset = <0x100>;
@@ -299,7 +298,6 @@
 			interrupt-parent = <&intc3>;
 			interrupts = <2>;
 			resets = <&rst2 5>;
-			reset-names = "usb-host";
 
 			has-transaction-translator;
 			caps-offset = <0x100>;

--- a/target/linux/ath79/dts/qca955x.dtsi
+++ b/target/linux/ath79/dts/qca955x.dtsi
@@ -278,7 +278,7 @@
 			has-transaction-translator;
 			caps-offset = <0x100>;
 
-			phy-names = "usb-phy0";
+			phy-names = "usb";
 			phys = <&usb_phy0>;
 
 			status = "disabled";
@@ -304,7 +304,7 @@
 			has-transaction-translator;
 			caps-offset = <0x100>;
 
-			phy-names = "usb-phy1";
+			phy-names = "usb";
 			phys = <&usb_phy1>;
 
 			status = "disabled";

--- a/target/linux/ath79/dts/qca955x.dtsi
+++ b/target/linux/ath79/dts/qca955x.dtsi
@@ -64,7 +64,7 @@
 				compatible ="qca,qca9550-usb-phy", "qca,ar7200-usb-phy";
 				reg = <0x18030000 4>, <0x18030004 4>;
 
-				reset-names = "usb-phy-analog", "usb-phy", "usb-suspend-override";
+				reset-names = "phy-analog", "phy", "suspend-override";
 				resets = <&rst 11>, <&rst 4>, <&rst 3>;
 
 				#phy-cells = <0>;
@@ -76,7 +76,7 @@
 				compatible = "qca,qca9550-usb-phy", "qca,ar7200-usb-phy";
 				reg = <0x18030010 4>, <0x18030014 4>;
 
-				reset-names = "usb-phy-analog", "usb-phy", "usb-suspend-override";
+				reset-names = "phy-analog", "phy", "suspend-override";
 				resets = <&rst2 11>, <&rst2 4>, <&rst2 3>;
 
 				#phy-cells = <0>;

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -192,7 +192,6 @@
 			interrupts = <1>;
 
 			resets = <&rst 5>;
-			reset-names = "usb-host";
 
 			has-transaction-translator;
 			caps-offset = <0x100>;
@@ -219,7 +218,6 @@
 			interrupts = <2>;
 
 			resets = <&rst2 5>;
-			reset-names = "usb-host";
 
 			has-transaction-translator;
 			caps-offset = <0x100>;

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -254,7 +254,7 @@
 	usb_phy0: usb-phy {
 		compatible = "qca,qca9560-usb-phy", "qca,ar7200-usb-phy";
 
-		reset-names = "usb-phy", "usb-suspend-override";
+		reset-names = "phy", "suspend-override";
 		resets = <&rst 4>, <&rst 3>;
 
 		#phy-cells = <0>;
@@ -265,7 +265,7 @@
 	usb_phy1: usb-phy {
 		compatible = "qca,qca9560-usb-phy", "qca,ar7200-usb-phy";
 
-		reset-names = "usb-phy", "usb-suspend-override";
+		reset-names = "phy", "suspend-override";
 		resets = <&rst2 4>, <&rst2 3>;
 
 		#phy-cells = <0>;

--- a/target/linux/ath79/dts/qca956x.dtsi
+++ b/target/linux/ath79/dts/qca956x.dtsi
@@ -197,7 +197,7 @@
 			has-transaction-translator;
 			caps-offset = <0x100>;
 
-			phy-names = "usb-phy0";
+			phy-names = "usb";
 			phys = <&usb_phy0>;
 
 			status = "disabled";
@@ -224,7 +224,7 @@
 			has-transaction-translator;
 			caps-offset = <0x100>;
 
-			phy-names = "usb-phy1";
+			phy-names = "usb";
 			phys = <&usb_phy1>;
 
 			status = "disabled";

--- a/target/linux/ath79/patches-6.6/700-phy-add-ath79-usb-phys.patch
+++ b/target/linux/ath79/patches-6.6/700-phy-add-ath79-usb-phys.patch
@@ -132,7 +132,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	if (IS_ERR(priv->rst_phy))
 +		return dev_err_probe(&pdev->dev, PTR_ERR(priv->rst_phy), "phy reset is missing");
 +
-+	priv->rst_host = devm_reset_control_get(&pdev->dev, "usb-host");
++	priv->rst_host = devm_reset_control_get(&pdev->dev, "host");
 +	if (IS_ERR(priv->rst_host))
 +		return dev_err_probe(&pdev->dev, PTR_ERR(priv->rst_host), "host reset is missing");
 +

--- a/target/linux/ath79/patches-6.6/700-phy-add-ath79-usb-phys.patch
+++ b/target/linux/ath79/patches-6.6/700-phy-add-ath79-usb-phys.patch
@@ -128,7 +128,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	if (IS_ERR(priv->io_base))
 +		return PTR_ERR(priv->io_base);
 +
-+	priv->rst_phy = devm_reset_control_get(&pdev->dev, "usb-phy");
++	priv->rst_phy = devm_reset_control_get(&pdev->dev, "phy");
 +	if (IS_ERR(priv->rst_phy))
 +		return dev_err_probe(&pdev->dev, PTR_ERR(priv->rst_phy), "phy reset is missing");
 +
@@ -250,17 +250,17 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	if (!priv)
 +		return -ENOMEM;
 +
-+	priv->rst_phy = devm_reset_control_get(&pdev->dev, "usb-phy");
++	priv->rst_phy = devm_reset_control_get(&pdev->dev, "phy");
 +	if (IS_ERR(priv->rst_phy))
 +		return dev_err_probe(&pdev->dev, PTR_ERR(priv->rst_phy), "phy reset is missing");
 +
 +	priv->rst_phy_analog = devm_reset_control_get_optional(
-+		&pdev->dev, "usb-phy-analog");
++		&pdev->dev, "phy-analog");
 +	if (IS_ERR(priv->rst_phy_analog))
 +		return PTR_ERR(priv->rst_phy_analog);
 +
 +	priv->suspend_override = devm_reset_control_get_optional(
-+		&pdev->dev, "usb-suspend-override");
++		&pdev->dev, "suspend-override");
 +	if (IS_ERR(priv->suspend_override))
 +		return PTR_ERR(priv->suspend_override);
 +


### PR DESCRIPTION
This PR matches upstream naming with the phy core and USB driver.