### PR TITLE
network: fix '/sbin/wifi' error on network restart

### DIFF
--- a/package/network/config/netifd/files/etc/init.d/network
+++ b/package/network/config/netifd/files/etc/init.d/network
@@ -30,12 +30,12 @@ reload_service() {
 
 	init_switch
 	ubus call network reload || rv=1
-	/sbin/wifi reload_legacy
+	[ -x /sbin/wifi ] && /sbin/wifi reload_legacy
 	return $rv
 }
 
 stop_service() {
-	/sbin/wifi down
+	[ -x /sbin/wifi ] && /sbin/wifi down
 	ifdown -a
 	sleep 1
 }


### PR DESCRIPTION
This fixes error: `/etc/rc.common: line 38: /sbin/wifi: not found`
on devices that do not have `/sbin/wifi` installed.
