### PR TITLE
ipq40xx: remove default MAC assignments

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq40x9-dr40x9.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq40x9-dr40x9.dts
@@ -254,16 +254,8 @@
 						reg = <0x1000 0x2f20>;
 					};
 
-					macaddr_art_1006: mac-address@1006 {
-						reg = <0x1006 0x6>;
-					};
-
 					precal_art_5000: precal@5000 {
 						reg = <0x5000 0x2f20>;
-					};
-
-					macaddr_art_5006: mac-address@5006 {
-						reg = <0x5006 0x6>;
 					};
 				};
 			};
@@ -382,15 +374,15 @@
 
 &wifi0 {
 	status = "okay";
-	nvmem-cells = <&precal_art_1000>, <&macaddr_art_1006>;
-	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_1000>;
+	nvmem-cell-names = "pre-calibration";
 	qcom,ath10k-calibration-variant = "Wallys-DR40X9";
 };
 
 &wifi1 {
 	status = "okay";
-	nvmem-cell-names = "pre-calibration", "mac-address";
-	nvmem-cells = <&precal_art_5000>, <&macaddr_art_5006>;
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_art_5000>;
 	qcom,ath10k-calibration-variant = "Wallys-DR40X9";
 };
 


### PR DESCRIPTION
1006 and 5006 are defaults that get set based on the calibration data. There's no need to explicitly specify them.

@hauke it seems I forgot to force push these changes in https://github.com/openwrt/openwrt/pull/17082