### PR TITLE
mediatek: fix pwn fan settings for sinovoip bpi-r3 (v2)

### DIFF
--- a/target/linux/mediatek/patches-6.12/061-v6.19-arm64-dts-mediatek-mt7986-bpi-r3-Change-fan-PWM-valu.patch
+++ b/target/linux/mediatek/patches-6.12/061-v6.19-arm64-dts-mediatek-mt7986-bpi-r3-Change-fan-PWM-valu.patch
@@ -1,0 +1,72 @@
+From 5f271fe1365b63f67fc384ca8d50d473d09de0d1 Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Tue, 3 Dec 2024 07:33:55 +0300
+Subject: [PATCH] arm64: dts: mediatek: mt7986-bpi-r3: Change fan PWM value for
+ mid speed
+
+Popular cheap PWM fans for this machine, like the ones coming in
+heatsink+fan combos will not work properly at the currently defined
+medium speed. Trying different pwm setting using a command
+
+  echo $value > /sys/devices/platform/pwm-fan/hwmon/hwmon1/pwm1
+
+I found:
+
+  pwm1 value     fan rotation speed   cpu temperature     notes
+  -----------------------------------------------------------------
+    0            maximal              31.5 Celsius        too noisy
+   40            optimal              35.2 Celsius        no noise hearable
+   95            minimal
+   above 95      does not rotate      55.5 Celsius
+  -----------------------------------------------------------------
+
+Thus only cpu-active-high and cpu-active-low modes are usable.
+I think this is wrong.
+
+This patch fixes cpu-active-medium settings for bpi-r3 board.
+
+I know, the patch is not ideal as it can break pwm fan for some users.
+Likely this is the only official mt7986-bpi-r3 heatsink+fan solution
+available on the market.
+
+This patch may not be enough. Users may wants to tweak their thermal_zone0
+trip points, thus tuning fan rotation speed depending on cpu temperature.
+That can be done on the base of the following example:
+
+  === example =========
+  # cpu temperature below 25 Celsius degrees, no rotation
+  echo 25000 > /sys/class/thermal/thermal_zone0/trip_point_4_temp
+  # cpu temperature in [25..32] Celsius degrees, normal rotation speed
+  echo 32000 > /sys/class/thermal/thermal_zone0/trip_point_3_temp
+  # cpu temperature above 50 Celsius degrees, max rotation speed
+  echo 50000 > /sys/class/thermal/thermal_zone0/trip_point_2_temp
+  =====================
+
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Acked-by: Frank Wunderlich <frank-w@public-files.de>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+
+---
+Changes from v1 to v2:
+ * improve patch description
+
+Changes from v2 to v3:
+ * added question to Frank Wunderlich
+
+Changes from v3 to v4:
+ * Acked by Frank Wunderlich
+---
+ arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts
+@@ -42,7 +42,7 @@
+ 		compatible = "pwm-fan";
+ 		#cooling-cells = <2>;
+ 		/* cooling level (0, 1, 2) - pwm inverted */
+-		cooling-levels = <255 96 0>;
++		cooling-levels = <255 40 0>;
+ 		pwms = <&pwm 0 10000>;
+ 		status = "okay";
+ 	};


### PR DESCRIPTION
Popular bpi-r3 pwm fans like this one
<img src="https://m.media-amazon.com/images/I/61yLslTkg0L._AC_UF1000,1000_QL80_.jpg" alt="cooler" width="200"/>
  https://www.amazon.com/youyeetoo-Barebone-Fan-BPI-R3-Integrated/dp/B0CCCTY8PS

will not work properly with current openwrt-23.05/24.10upstream firmwares.

Trying different pwm setting with the following command
`echo $value > /sys/devices/platform/pwm-fan/hwmon/hwmon1/pwm1`
I found:
|pwm1 value | fan rotation speed     | cpu temperature  |   notes                    |
|------------------|--------------------------------|---------------------------|---------------------------|
| 0                   | maximal                       | 31.5 Celsius           | too noisy                |
| 40                 | optimal                        |35.2 Celsius            |no noise hearable  |
| 95                 | minimal                       |                                 |                                   |
| above 95     | fan does not rotates |55.5 Celsius            |                                   |

At the moment we are having following cooling levels configured in _mt7986a-bananapi-bpi-r3.dts_
`cooling-levels = <255 96 0>;`

for _cpu-active-low_, _cpu-active-med_ and _cpu-active-high_ modes correspondingly. Thus only _cpu-active-high_ and _cpu-active-low_ are usable. I think this is wrong.

This patch fixes _cpu-active-med_ settings for bpi-r3 board.

PS: I know, the patch is not ideal as it can break pwm fan for some users. There are some peoples that use handmade cooling solutions, but:
- discussed cooler is the only 'official' pwm cooler for bpi-r3 available on the market.
- most peoples will use passive cooling available on the market or the discussed cooler.
- the pwm-fan dts section was added before the official cooler appears on the market. 

Thus it should not be a lot of harm from this fix.

This patch may not be enough, users may wants to tweak their _thermal_zone0_ trip points, thus tuning fan rotation speed depending on cpu temperature. That can be done by editing _/etc/rc.local_ file like this:
```
# Put your custom commands here that should be executed once
# the system init finished. By default this file does nothing.

# cpu temterature below 25 Celsius degrees, no rotation
echo 25000 > /sys/class/thermal/thermal_zone0/trip_point_4_temp
# cpu temperature in [25..32] Celsius degrees, normal rotation speed
echo 32000 > /sys/class/thermal/thermal_zone0/trip_point_3_temp
# cpu temperature above 50 Celsius degrees, max rotation speed
echo 50000 > /sys/class/thermal/thermal_zone0/trip_point_2_temp

exit 0
```