### PR TITLE
kernel: fallback-sprom: create separate header files

### DIFF
--- a/target/linux/generic/files/drivers/bcma/fallback-sprom.c
+++ b/target/linux/generic/files/drivers/bcma/fallback-sprom.c
@@ -16,6 +16,7 @@
 #include <linux/mtd/mtd.h>
 #include <linux/of_net.h>
 #include <linux/of_platform.h>
+#include "fallback-sprom.h"
 
 #define BCMA_FBS_MAX_SIZE 468
 

--- a/target/linux/generic/files/drivers/bcma/fallback-sprom.h
+++ b/target/linux/generic/files/drivers/bcma/fallback-sprom.h
@@ -1,0 +1,7 @@
+#ifndef _FALLBACK_SPROM_H
+#define _FALLBACK_SPROM_H
+
+int __init bcma_fbs_register(void);
+int bcma_get_fallback_sprom(struct bcma_bus *dev, struct ssb_sprom *out);
+
+#endif /* _FALLBACK_SPROM_H */

--- a/target/linux/generic/files/drivers/ssb/fallback-sprom.c
+++ b/target/linux/generic/files/drivers/ssb/fallback-sprom.c
@@ -16,6 +16,7 @@
 #include <linux/of_net.h>
 #include <linux/of_platform.h>
 #include <linux/ssb/ssb.h>
+#include "fallback-sprom.h"
 
 #define SSB_FBS_MAX_SIZE 440
 

--- a/target/linux/generic/files/drivers/ssb/fallback-sprom.h
+++ b/target/linux/generic/files/drivers/ssb/fallback-sprom.h
@@ -1,0 +1,7 @@
+#ifndef _FALLBACK_SPROM_H
+#define _FALLBACK_SPROM_H
+
+int __init ssb_fbs_register(void);
+int ssb_get_fallback_sprom(struct ssb_bus *dev, struct ssb_sprom *out);
+
+#endif /* _FALLBACK_SPROM_H */

--- a/target/linux/generic/hack-6.6/810-bcma-ssb-fallback-sprom.patch
+++ b/target/linux/generic/hack-6.6/810-bcma-ssb-fallback-sprom.patch
@@ -6,15 +6,15 @@ Subject: [PATCH] ssb_sprom: add generic kernel support for Broadcom  Fallback SP
 ---
  drivers/bcma/Kconfig        |  4 ++++
  drivers/bcma/Makefile       |  1 +
- drivers/bcma/bcma_private.h |  4 ++++
+ drivers/bcma/bcma_private.h |  1 +
  drivers/bcma/main.c         |  8 ++++++++
  drivers/bcma/sprom.c        | 23 ++++++++++++++---------
  drivers/ssb/Kconfig         |  5 +++++
  drivers/ssb/Makefile        |  1 +
  drivers/ssb/main.c          |  8 ++++++++
  drivers/ssb/sprom.c         | 12 +++++++++++-
- drivers/ssb/ssb_private.h   |  4 ++++
- 10 files changed, 60 insertions(+), 10 deletions(-)
+ drivers/ssb/ssb_private.h   |  2 +-
+ 10 files changed, 54 insertions(+), 11 deletions(-)
 
 --- a/drivers/bcma/Kconfig
 +++ b/drivers/bcma/Kconfig
@@ -41,17 +41,14 @@ Subject: [PATCH] ssb_sprom: add generic kernel support for Broadcom  Fallback SP
  obj-$(CONFIG_BCMA)			+= bcma.o
 --- a/drivers/bcma/bcma_private.h
 +++ b/drivers/bcma/bcma_private.h
-@@ -38,6 +38,10 @@ int bcma_bus_resume(struct bcma_bus *bus
- void bcma_detect_chip(struct bcma_bus *bus);
- int bcma_bus_scan(struct bcma_bus *bus);
+@@ -8,6 +8,7 @@
  
-+/* fallback-sprom.c */
-+int __init bcma_fbs_register(void);
-+int bcma_get_fallback_sprom(struct bcma_bus *dev, struct ssb_sprom *out);
-+
- /* sprom.c */
- int bcma_sprom_get(struct bcma_bus *bus);
+ #include <linux/bcma/bcma.h>
+ #include <linux/delay.h>
++#include "fallback-sprom.h"
  
+ #define bcma_err(bus, fmt, ...) \
+ 	dev_err((bus)->dev, "bus%d: " fmt, (bus)->num, ##__VA_ARGS__)
 --- a/drivers/bcma/main.c
 +++ b/drivers/bcma/main.c
 @@ -671,6 +671,14 @@ static int __init bcma_modinit(void)
@@ -174,14 +171,12 @@ Subject: [PATCH] ssb_sprom: add generic kernel support for Broadcom  Fallback SP
  /* https://bcm-v4.sipsolutions.net/802.11/IsSpromAvailable */
 --- a/drivers/ssb/ssb_private.h
 +++ b/drivers/ssb/ssb_private.h
-@@ -143,6 +143,10 @@ extern int ssb_bus_scan(struct ssb_bus *
- extern void ssb_iounmap(struct ssb_bus *ssb);
+@@ -8,7 +8,7 @@
+ #include <linux/ssb/ssb.h>
+ #include <linux/types.h>
+ #include <linux/bcm47xx_wdt.h>
+-
++#include "fallback-sprom.h"
  
- 
-+/* fallback-sprom.c */
-+int __init ssb_fbs_register(void);
-+int ssb_get_fallback_sprom(struct ssb_bus *dev, struct ssb_sprom *out);
-+
- /* sprom.c */
- extern
- ssize_t ssb_attr_sprom_show(struct ssb_bus *bus, char *buf,
+ /* pci.c */
+ #ifdef CONFIG_SSB_PCIHOST


### PR DESCRIPTION
Create a separate header files fallback-sprom.h for BCMA and SSB Fallback SPROM Driver to add function prototypes to fallback-sprom.c as well.
This prevents missing function prototype errors.