### PR TITLE
kernel: packages: fix building package/devel/perf with -O3

### DIFF
--- a/target/linux/generic/backport-6.6/192-v6.12-fix-libbpf-Wmaybe-uninitialized.patch
+++ b/target/linux/generic/backport-6.6/192-v6.12-fix-libbpf-Wmaybe-uninitialized.patch
@@ -1,0 +1,59 @@
+From fab45b962749184e1a1a57c7c583782b78fad539 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Tue, 13 Aug 2024 20:49:06 +0100
+Subject: [PATCH] libbpf: Workaround -Wmaybe-uninitialized false positive
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In `elf_close`, we get this with GCC 15 -O3 (at least):
+```
+In function ‘elf_close’,
+    inlined from ‘elf_close’ at elf.c:53:6,
+    inlined from ‘elf_find_func_offset_from_file’ at elf.c:384:2:
+elf.c:57:9: warning: ‘elf_fd.elf’ may be used uninitialized [-Wmaybe-uninitialized]
+   57 |         elf_end(elf_fd->elf);
+      |         ^~~~~~~~~~~~~~~~~~~~
+elf.c: In function ‘elf_find_func_offset_from_file’:
+elf.c:377:23: note: ‘elf_fd.elf’ was declared here
+  377 |         struct elf_fd elf_fd;
+      |                       ^~~~~~
+In function ‘elf_close’,
+    inlined from ‘elf_close’ at elf.c:53:6,
+    inlined from ‘elf_find_func_offset_from_file’ at elf.c:384:2:
+elf.c:58:9: warning: ‘elf_fd.fd’ may be used uninitialized [-Wmaybe-uninitialized]
+   58 |         close(elf_fd->fd);
+      |         ^~~~~~~~~~~~~~~~~
+elf.c: In function ‘elf_find_func_offset_from_file’:
+elf.c:377:23: note: ‘elf_fd.fd’ was declared here
+  377 |         struct elf_fd elf_fd;
+      |                       ^~~~~~
+```
+
+In reality, our use is fine, it's just that GCC doesn't model errno
+here (see linked GCC bug). Suppress -Wmaybe-uninitialized accordingly
+by initializing elf_fd.fd to -1 and elf_fd.elf to NULL.
+
+I've done this in two other functions as well given it could easily
+occur there too (same access/use pattern).
+
+Signed-off-by: Sam James <sam@gentoo.org>
+Signed-off-by: Andrii Nakryiko <andrii@kernel.org>
+Link: https://gcc.gnu.org/PR114952
+Link: https://lore.kernel.org/bpf/14ec488a1cac02794c2fa2b83ae0cef1bce2cb36.1723578546.git.sam@gentoo.org
+---
+ tools/lib/bpf/elf.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/tools/lib/bpf/elf.c
++++ b/tools/lib/bpf/elf.c
+@@ -16,6 +16,9 @@ int elf_open(const char *binary_path, st
+ 	int fd, ret;
+ 	Elf *elf;
+ 
++	elf_fd->elf = NULL;
++	elf_fd->fd = -1;
++
+ 	if (elf_version(EV_CURRENT) == EV_NONE) {
+ 		pr_warn("elf: failed to init libelf for %s\n", binary_path);
+ 		return -LIBBPF_ERRNO__LIBELF;


### PR DESCRIPTION
Currently building `package/devel/perf` (`CONFIG_PACKAGE_perf`) fails when `CONFIG_TARGET_OPTIMIZATION` has `-O3` enabled with this error:

```
In function 'elf_close',
    inlined from 'elf_close' at elf.c:41:6,
    inlined from 'elf_find_func_offset_from_file' at elf.c:267:2:
elf.c:45:9: error: 'elf_fd.elf' may be used uninitialized [-Werror=maybe-uninitialized]
   45 |         elf_end(elf_fd->elf);
      |         ^~~~~~~~~~~~~~~~~~~~
elf.c: In function 'elf_find_func_offset_from_file':
elf.c:260:23: note: 'elf_fd.elf' was declared here
  260 |         struct elf_fd elf_fd;
      |                       ^~~~~~
In function 'elf_close',
    inlined from 'elf_close' at elf.c:41:6,
    inlined from 'elf_find_func_offset_from_file' at elf.c:267:2:
elf.c:46:9: error: 'elf_fd.fd' may be used uninitialized [-Werror=maybe-uninitialized]
   46 |         close(elf_fd->fd);
      |         ^~~~~~~~~~~~~~~~~
elf.c: In function 'elf_find_func_offset_from_file':
elf.c:260:23: note: 'elf_fd.fd' was declared here
  260 |         struct elf_fd elf_fd;
      |                       ^~~~~~
```

Minimal config to reproduce the issue:
```
CONFIG_DEVEL=y
CONFIG_TOOLCHAINOPTS=y
CONFIG_KERNEL_PERF_EVENTS=y
CONFIG_PACKAGE_perf=y
CONFIG_TARGET_OPTIMIZATION="-O3 -pipe"
CONFIG_TARGET_OPTIONS=y
```

This happens due to a way on how `kernel/tools/lib/bpf/elf.c` (which are the static dep for perf) initializes elf_fd structure which makes gcc to suspect it might be used uninitialized.

This PR adopts a patch with the upstream accepted fix: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/commit/?id=fab45b962749

Tested to build image with working perf tool on Bananapi BPI-R4 target, also tested to fix building for generic x86_64 target (didn't tested tool itself, but it should work same way as for the BPI-R4 target).