### PR TITLE
hostapd: add SAE support for wifi-station and optimize PSK file creation

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -428,7 +428,34 @@ hostapd_set_psk() {
 	local ifname="$1"
 
 	rm -f /var/run/hostapd-${ifname}.psk
+	case "$auth_type" in
+		psk|psk-sae) ;;
+		*) return ;;
+	esac
 	for_each_station hostapd_set_psk_file ${ifname}
+}
+
+hostapd_set_sae_file() {
+	local ifname="$1"
+	local vlan="$2"
+	local vlan_id=""
+
+	json_get_vars mac vid key
+	set_default mac "ff:ff:ff:ff:ff:ff"
+	[ -n "$mac" ] && mac="|mac=$mac"
+	[ -n "$vid" ] && vlan_id="|vlanid=$vid"
+	printf '%s%s%s\n' "${key}" "${mac}" "${vlan_id}" >> /var/run/hostapd-${ifname}.sae
+}
+
+hostapd_set_sae() {
+	local ifname="$1"
+
+	rm -f /var/run/hostapd-${ifname}.sae
+	case "$auth_type" in
+		sae|psk-sae) ;;
+		*) return ;;
+	esac
+	for_each_station hostapd_set_sae_file ${ifname}
 }
 
 append_iw_roaming_consortium() {
@@ -686,7 +713,7 @@ hostapd_set_bss_options() {
 			wps_not_configured=1
 		;;
 		psk|sae|psk-sae)
-			json_get_vars key wpa_psk_file
+			json_get_vars key wpa_psk_file sae_password_file
 			if [ "$ppsk" -ne 0 ]; then
 				json_get_vars auth_secret auth_port
 				set_default auth_port 1812
@@ -697,14 +724,19 @@ hostapd_set_bss_options() {
 				append bss_conf "wpa_psk=$key" "$N"
 			elif [ ${#key} -ge 8 ] && [ ${#key} -le 63 ]; then
 				append bss_conf "wpa_passphrase=$key" "$N"
-			elif [ -n "$key" ] || [ -z "$wpa_psk_file" ]; then
+			elif [ -n "$key" ] || [ -z "$wpa_psk_file" ] || [ -z "$sae_password_file" ]; then
 				wireless_setup_vif_failed INVALID_WPA_PSK
 				return 1
 			fi
 			[ -z "$wpa_psk_file" ] && set_default wpa_psk_file /var/run/hostapd-$ifname.psk
-			[ -n "$wpa_psk_file" ] && {
+			[ -n "$wpa_psk_file" ] && [ "$auth_type" = "psk" -o "$auth_type" = "psk-sae" ] && {
 				[ -e "$wpa_psk_file" ] || touch "$wpa_psk_file"
 				append bss_conf "wpa_psk_file=$wpa_psk_file" "$N"
+			}
+			[ -z "$sae_password_file" ] && set_default sae_password_file /var/run/hostapd-$ifname.sae
+			[ -n "$sae_password_file" ] && [ "$auth_type" = "sae" -o "$auth_type" = "psk-sae" ] && {
+				[ -e "$sae_password_file" ] || touch "$sae_password_file"
+				append bss_conf "sae_password_file=$sae_password_file" "$N"
 			}
 			[ "$eapol_version" -ge "1" -a "$eapol_version" -le "2" ] && append bss_conf "eapol_version=$eapol_version" "$N"
 

--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -668,7 +668,7 @@ mac80211_set_ifname() {
 mac80211_prepare_vif() {
 	json_select config
 
-	json_get_vars ifname mode ssid wds powersave macaddr enable wpa_psk_file vlan_file
+	json_get_vars ifname mode ssid wds powersave macaddr enable wpa_psk_file sae_password_file vlan_file
 
 	[ -n "$ifname" ] || {
 		local prefix;
@@ -701,7 +701,12 @@ mac80211_prepare_vif() {
 
 
 	[ "$mode" == "ap" ] && {
+		json_select config
+		wireless_vif_parse_encryption
+		json_select ..
+
 		[ -z "$wpa_psk_file" ] && hostapd_set_psk "$ifname"
+		[ -z "$sae_password_file" ] && hostapd_set_sae "$ifname"
 		[ -z "$vlan_file" ] && hostapd_set_vlan "$ifname"
 	}
 

--- a/package/network/services/hostapd/files/hostapd.uc
+++ b/package/network/services/hostapd/files/hostapd.uc
@@ -10,6 +10,7 @@ hostapd.data.pending_config = {};
 hostapd.data.file_fields = {
 	vlan_file: true,
 	wpa_psk_file: true,
+	sae_password_file: true,
 	accept_mac_file: true,
 	deny_mac_file: true,
 	eap_user_file: true,
@@ -364,6 +365,7 @@ function bss_remove_file_fields(config)
 	for (let key in config.hash)
 		new_cfg.hash[key] = config.hash[key];
 	delete new_cfg.hash.wpa_psk_file;
+	delete new_cfg.hash.sae_password_file;
 	delete new_cfg.hash.vlan_file;
 
 	return new_cfg;


### PR DESCRIPTION
Regarding SAE support in wifi-station:

Important Note: Unlike PSK wifi-stations, both `mac` and `key` options are required
to make it work. With PSK, hostapd used to perform a brute-force match to find which
PSK entry to use, but with SAE this is infeasible due to SAE's design.

When `mac` is omitted, it will allow any MAC address to use the SAE password if it
didn't have a MAC address assigned to it, but this could only be done once.
The last wildcard entry would be used.

Also, unlike "hostapd: add support for SAE in PPSK option" (commit https://github.com/openwrt/openwrt/commit/913368a223c3818d2b5b60b06820532038be3467),
it is not required to set `sae_pwe` to `0`. This gives it a slight advantage
over using PPSK that goes beyond not needing RADIUS.

Example Configuration:

```
config wifi-vlan
        option iface default_radio0
        option name 999
        option vid 999
        option network management

config wifi-station
        # Allow user with MAC address 00:11:22:33:44:55 and matching
        # key "secretadminpass" to access the management network.
        option iface default_radio0
        option vid 999
        option mac '00:11:22:33:44:55'
        option key secretadminpass

config wifi-vlan
        option iface default_radio0
        option name 100
        option vid 100
        option network guest

config wifi-station
        # With SAE, when 'mac' is omitted it will be the fallback in case no
        # other MAC address matches. It won't be possible for a user that
        # has a matching MAC to use this network (i.e., 00:11:22:33:44:55
        # in this example).
        option iface default_radio0
        option vid 100
        option key guestpass
```

Regarding PSK file creation optimization:

This patch now conditionally runs `hostapd_set_psk_file` depending on `auth_type`.
Previously, `hostapd_set_psk` would always execute `hostapd_set_psk_file`, which
would create a new file if `wifi-station` was in use even if PSK was not enabled.
This change checks the `auth_type` to ensure that it is appropriate to parse the
`wifi-station` entries and create those files.

Furthermore, we now only configure `wpa_psk_file` when it is a supported option
(i.e., psk or psk-sae is used). Previously, we used to configure it when it was
not necessary. While it didn't cause any issues, it would litter `/var/run` with
unnecessary files. This patch fixes that case by configuring it depending on the
`auth_type`.

The new SAE support is aligned with these PSK file changes.