### PR TITLE
build: Unconditionally append kmod feed for BuildBot

### DIFF
--- a/include/feeds.mk
+++ b/include/feeds.mk
@@ -37,7 +37,7 @@ define FeedSourcesAppendOPKG
   echo 'src/gz %d_core %U/targets/%S/packages'; \
   $(strip $(if $(CONFIG_PER_FEED_REPO), \
 	echo 'src/gz %d_base %U/packages/%A/base'; \
-	$(if $(filter %SNAPSHOT-y,$(VERSION_NUMBER)-$(CONFIG_BUILDBOT)), \
+	$(if $(CONFIG_BUILDBOT), \
 		echo 'src/gz %d_kmods %U/targets/%S/kmods/$(LINUX_VERSION)-$(LINUX_RELEASE)-$(LINUX_VERMAGIC)';) \
 	$(foreach feed,$(FEEDS_AVAILABLE), \
 		$(if $(CONFIG_FEED_$(feed)), \
@@ -51,7 +51,7 @@ define FeedSourcesAppendAPK
   echo '%U/targets/%S/packages/packages.adb'; \
   $(strip $(if $(CONFIG_PER_FEED_REPO), \
 	echo '%U/packages/%A/base/packages.adb'; \
-	$(if $(filter %SNAPSHOT-y,$(VERSION_NUMBER)-$(CONFIG_BUILDBOT)), \
+	$(if $(CONFIG_BUILDBOT), \
 		echo '%U/targets/%S/kmods/$(LINUX_VERSION)-$(LINUX_RELEASE)-$(LINUX_VERMAGIC)/packages.adb';) \
 	$(foreach feed,$(FEEDS_AVAILABLE), \
 		$(if $(CONFIG_FEED_$(feed)), \


### PR DESCRIPTION
Recent changes to BuildBot config moved the kmods to a dedicated directory and dropped them from the packages dir. This was needed as both OPKG and APK gets confused if both entry are present.

To fix this, unconditionally append the kmod feed line if CONFIG_BUILDBOT is enabled.

Fixes: #17146