### PR TITLE
realtek: Add support for ZyXEL XGS1210-12 Switch

### DIFF
--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1210-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1210-12.dts
@@ -354,22 +354,21 @@
                         sfp = <&sfp0>;
                         led-set = <2>;
 
-			managed = "in-band-status";
-			/*
+			//managed = "in-band-status";
+			
                         fixed-link {
-                                speed = <1000>;
+                                speed = <10000>;
                                 full-duplex;
                                 pause;
                         };
-                        */
+                        
 
                 };
 
 		port@27 {
 			reg = <27>;
 			label = "lan12";
-			//phy-mode = "10gbase-r";
-			phy-mode = "usxgmii";
+			phy-mode = "10gbase-r";
 			phy-handle = <&phy27>;
 			sfp = <&sfp1>;
 			led-set = <2>;

--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1210-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1210-12.dts
@@ -1,0 +1,395 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "zyxel,xgs1210-12", "realtek,rtl838x-soc";
+	model = "Zyxel XGS1210-12 Switch";
+
+	aliases {
+		led-boot = &led_pwr_sys;
+		led-failsafe = &led_pwr_sys;
+		led-running = &led_pwr_sys;
+		led-upgrade = &led_pwr_sys;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		mode {
+			label = "reset";
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	/* i2c of the SFP cage: port 12 */
+
+        i2cP: i2c-rtl9300 {
+                compatible = "realtek,rtl9300-i2c";
+                reg = <0x1b00036c 0x3c>;
+                #address-cells = <1>;
+                #size-cells = <0>;
+                sda-pin = <9>;
+                scl-pin = <8>;
+                clock-frequency = <100000>;
+        };
+
+
+	i2cM: i2c-mux-rtl9300 {
+		compatible = "realtek,i2c-mux-rtl9300";
+		i2c-parent = <&i2cP>;
+//		reg = <0x1b00036c 0x3c>;
+//		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+//		sda-pin = <9>;
+//		scl-pin = <8>;
+//		clock-frequency = <100000>;
+	
+
+	i2c0: i2c@0 {
+		reg=<0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		sda-pin = <9>;
+		scl-pin = <8>;
+	};
+
+	i2c1: i2c@1 {
+		reg=<1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		sda-pin = <10>;
+		scl-pin = <8>;
+	};
+
+	};
+
+
+/*
+        i2c1: i2c-rtl9300 {
+                compatible = "realtek,rtl9300-i2c";
+                reg = <0x1b00036c 0x3c>;
+                #address-cells = <1>;
+                #size-cells = <0>;
+                sda-pin = <10>;
+                scl-pin = <8>;
+                clock-frequency = <100000>;
+        };
+*/
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>;
+
+		led_pwr_sys: led-0 {
+			label = "green:power";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	sfp0: sfp-p11 {
+                compatible = "sff,sfp";
+                i2c-bus = <&i2c0>;
+                los-gpio = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+                tx-fault-gpio = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+                mod-def0-gpio = <&gpio0 12 GPIO_ACTIVE_LOW>;
+                tx-disable-gpio = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+        };
+
+	sfp1: sfp-p12 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio0 17 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 15 GPIO_ACTIVE_HIGH>;
+	};
+
+	led_set: led_set@0 {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		led_set0 = <0x0000 0xffff 0x0a20 0x0b80>; // LED set 0: 1000Mbps,  10/100Mbps
+		led_set1 = <0x0a0b 0x0a28 0x0a82 0x0a0b>; // LED set 1: (10G, 5G, 2.5G) (2.5G, 1G)
+							  // (5G, 10/100) (10G, 5G, 2.5G)
+		led_set2 = <0x0000 0xffff 0x0a20 0x0a01>; // LED set 2: 1000MBit, 10GBit
+	};
+};
+
+&spi0 {
+	status = "okay";
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x10000>;
+			};
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0xf0000 0x10000>;
+				read-only;
+			};
+			partition@100000 {
+				label = "jffs";
+				reg = <0x100000 0x100000>;
+			};
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x200000 0x100000>;
+			};
+			partition@b300000 {
+				label = "firmware";
+				reg = <0x300000 0xce0000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x93001210>;
+			};
+			partition@fe0000 {
+				label = "log";
+				reg = <0xfe0000 0x20000>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* External RTL8218D PHY */
+		phy0: ethernet-phy@0 {
+			reg = <0>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 0>;
+			sds = < 2 >;
+			// Disabled because we do not know how to bring up again
+			// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+		};
+		phy1: ethernet-phy@1 {
+			reg = <1>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 1>;
+		};
+		phy2: ethernet-phy@2 {
+			reg = <2>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 2>;
+		};
+		phy3: ethernet-phy@3 {
+			reg = <3>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 3>;
+		};
+		phy4: ethernet-phy@4 {
+			reg = <4>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 4>;
+		};
+		phy5: ethernet-phy@5 {
+			reg = <5>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 5>;
+		};
+		phy6: ethernet-phy@6 {
+			reg = <6>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 6>;
+		};
+		phy7: ethernet-phy@7 {
+			reg = <7>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 7>;
+		};
+
+		/* External Aquantia 113C PHYs */
+		phy24: ethernet-phy@24 {
+			reg = <24>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <1 8>;
+			sds = < 6 >;
+			// Disabled because we do not know how to bring up again
+			// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+		};
+
+		phy25: ethernet-phy@25 {
+			reg = <25>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <2 9>;
+			sds = < 7 >;
+			// Disabled because we do not know how to bring up again
+			// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+		};
+
+		/* SFP0 Ports */
+		phy26: ethernet-phy@26 {
+			reg = <26>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+//			rtl9300,smi-address = <3 10>;
+			sds = < 8 >;
+			// Disabled because we do not know how to bring up again
+			// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+		};
+
+		/* SFP1 Ports */
+		phy27: ethernet-phy@27 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+			reg = <27>;
+//			rtl9300,smi-address = <4 11>;
+			sds = < 9 >;
+		};
+
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			phy-handle = <&phy0>;
+			phy-mode = "xgmii";
+			led-set = <0>;
+		};
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+			phy-handle = <&phy1>;
+			phy-mode = "xgmii";
+			led-set = <0>;
+		};
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+			phy-handle = <&phy2>;
+			phy-mode = "xgmii";
+			led-set = <0>;
+		};
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+			phy-handle = <&phy3>;
+			phy-mode = "xgmii";
+			led-set = <0>;
+		};
+		port@4 {
+			reg = <4>;
+			label = "lan5";
+			phy-handle = <&phy4>;
+			phy-mode = "xgmii";
+			led-set = <0>;
+		};
+		port@5 {
+			reg = <5>;
+			label = "lan6";
+			phy-handle = <&phy5>;
+			phy-mode = "xgmii";
+			led-set = <0>;
+		};
+		port@6 {
+			reg = <6>;
+			label = "lan7";
+			phy-handle = <&phy6>;
+			phy-mode = "xgmii";
+			led-set = <0>;
+		};
+		port@7 {
+			reg = <7>;
+			label = "lan8";
+			phy-handle = <&phy7>;
+			phy-mode = "xgmii";
+			led-set = <0>;
+		};
+
+		port@24 {
+			reg = <24>;
+			label = "lan9";
+			phy-mode = "usxgmii";
+			phy-handle = <&phy24>;
+			led-set = <1>;
+		};
+		port@25 {
+			reg = <25>;
+			label = "lan10";
+			phy-mode = "usxgmii";
+			phy-handle = <&phy25>;
+			led-set = <1>;
+		};
+
+                port@26 {
+                        reg = <26>;
+                        label = "lan11";
+                        phy-mode = "10gbase-r";
+                        phy-handle = <&phy26>;
+                        sfp = <&sfp0>;
+                        led-set = <2>;
+
+			managed = "in-band-status";
+			/*
+                        fixed-link {
+                                speed = <1000>;
+                                full-duplex;
+                                pause;
+                        };
+                        */
+
+                };
+
+		port@27 {
+			reg = <27>;
+			label = "lan12";
+			//phy-mode = "10gbase-r";
+			phy-mode = "usxgmii";
+			phy-handle = <&phy27>;
+			sfp = <&sfp1>;
+			led-set = <2>;
+
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+				pause;
+			};
+
+		};
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1210-12.dts
+++ b/target/linux/realtek/dts-5.15/rtl9302_zyxel_xgs1210-12.dts
@@ -121,8 +121,8 @@
 		active-low;
 
 		led_set0 = <0x0000 0xffff 0x0a20 0x0b80>; // LED set 0: 1000Mbps,  10/100Mbps
-		led_set1 = <0x0a0b 0x0a28 0x0a82 0x0a0b>; // LED set 1: (10G, 5G, 2.5G) (2.5G, 1G)
-							  // (5G, 10/100) (10G, 5G, 2.5G)
+		//led_set1 = <0x0a0b 0x0a20 0x0b80 0x0a0b>; // LED set 1: (10G, 5G, 2.5G) (2.5G, 1G)
+		led_set1 = <0x0a20 0x0b80 0x0b8b 0x0a0b>;  // (5G, 10/100) (10G, 5G, 2.5G)
 		led_set2 = <0x0000 0xffff 0x0a20 0x0a01>; // LED set 2: 1000MBit, 10GBit
 	};
 };

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -445,6 +445,11 @@ static void rtl93xx_phylink_validate(struct dsa_switch *ds, int port,
 		phylink_set(mask, 10000baseKR_Full);
 		phylink_set(mask, 10000baseSR_Full);
 		phylink_set(mask, 10000baseCR_Full);
+
+		phylink_set(mask, 10000baseLR_Full);
+		phylink_set(mask, 10000baseLRM_Full);
+		phylink_set(mask, 10000baseER_Full);
+
 	}
 	if (state->interface == PHY_INTERFACE_MODE_INTERNAL) {
 		phylink_set(mask, 1000baseX_Full);
@@ -874,6 +879,8 @@ static void rtl93xx_phylink_mac_config(struct dsa_switch *ds, int port,
 
 	if (state->duplex == DUPLEX_FULL)
 		reg |= RTL930X_DUPLEX_MODE;
+	else
+		reg &= ~RTL930X_DUPLEX_MODE; /* Clear duplex bit otherwise */
 
 	if (priv->ports[port].phy_is_integrated)
 		reg &= ~RTL930X_FORCE_EN; /* Clear MAC_FORCE_EN to allow SDS-MAC link */

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/dsa.c
@@ -822,7 +822,7 @@ static void rtl93xx_phylink_mac_config(struct dsa_switch *ds, int port,
 					const struct phylink_link_state *state)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
-	int sds_num, sds_mode;
+	int sds_num;
 	u32 reg;
 
 	pr_info("%s port %d, mode %x, phy-mode: %s, speed %d, link %d\n", __func__,
@@ -837,32 +837,10 @@ static void rtl93xx_phylink_mac_config(struct dsa_switch *ds, int port,
 
 	sds_num = priv->ports[port].sds_num;
 	pr_info("%s SDS is %d\n", __func__, sds_num);
-	if (sds_num >= 0) {
-		switch (state->interface) {
-		case PHY_INTERFACE_MODE_HSGMII:
-			sds_mode = 0x12;
-			break;
-		case PHY_INTERFACE_MODE_1000BASEX:
-			sds_mode = 0x04;
-			break;
-		case PHY_INTERFACE_MODE_XGMII:
-			sds_mode = 0x10;
-			break;
-		case PHY_INTERFACE_MODE_10GBASER:
-		case PHY_INTERFACE_MODE_10GKR:
-			sds_mode = 0x1b; /* 10G 1000X Auto */
-			break;
-		case PHY_INTERFACE_MODE_USXGMII:
-			sds_mode = 0x0d;
-			break;
-		default:
-			pr_err("%s: unknown serdes mode: %s\n",
-			       __func__, phy_modes(state->interface));
-			return;
-		}
-		if (state->interface == PHY_INTERFACE_MODE_10GBASER)
-			rtl9300_serdes_setup(sds_num, state->interface);
-	}
+	if (sds_num >= 0 &&
+	    (state->interface == PHY_INTERFACE_MODE_1000BASEX ||
+	     state->interface == PHY_INTERFACE_MODE_10GBASER))
+		rtl9300_serdes_setup(port, sds_num, state->interface);
 
 	reg = sw_r32(priv->r->mac_force_mode_ctrl(port));
 	reg &= ~(0xf << 3);
@@ -880,8 +858,11 @@ static void rtl93xx_phylink_mac_config(struct dsa_switch *ds, int port,
 	case SPEED_1000:
 		reg |= 2 << 3;
 		break;
+	case SPEED_100:
+		reg |= 1 << 3;
+		break;
 	default:
-		reg |= 2 << 3;
+		/* Also covers 10M */
 		break;
 	}
 

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -121,7 +121,7 @@ irqreturn_t rtl839x_switch_irq(int irq, void *dev_id);
 void rtl930x_vlan_profile_dump(int index);
 int rtl9300_sds_power(int mac, int val);
 void rtl9300_sds_rst(int sds_num, u32 mode);
-int rtl9300_serdes_setup(int sds_num, phy_interface_t phy_mode);
+int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode);
 void rtl930x_print_matrix(void);
 
 /* RTL931x-specific */

--- a/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-5.15/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -249,9 +249,9 @@ static void rtl930x_vlan_fwd_on_inner(int port, bool is_set)
 {
 	/* Always set all tag modes to fwd based on either inner or outer tag */
 	if (is_set)
-		sw_w32_mask(0, 0xf, RTL930X_VLAN_PORT_FWD + (port << 2));
-	else
 		sw_w32_mask(0xf, 0, RTL930X_VLAN_PORT_FWD + (port << 2));
+	else
+		sw_w32_mask(0, 0xf, RTL930X_VLAN_PORT_FWD + (port << 2));
 }
 
 static void rtl930x_vlan_profile_setup(int profile)

--- a/target/linux/realtek/files-5.15/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-5.15/drivers/net/phy/rtl83xx-phy.c
@@ -54,6 +54,23 @@ extern struct mutex smi_lock;
 
 #define RTL9300_PHY_ID_MASK 0xf0ffffff
 
+/* RTL930X SerDes supports the following modes:
+ * 0x02: SGMII		0x04: 1000BX_FIBER	0x05: FIBER100
+ * 0x06: QSGMII		0x09: RSGMII		0x0d: USXGMII
+ * 0x10: XSGMII		0x12: HISGMII		0x16: 2500Base_X
+ * 0x17: RXAUI_LITE	0x19: RXAUI_PLUS	0x1a: 10G Base-R
+ * 0x1b: 10GR1000BX_AUTO			0x1f: OFF
+ */
+#define RTL930X_SDS_MODE_SGMII		0x02
+#define RTL930X_SDS_MODE_1000BASEX	0x04
+#define RTL930X_SDS_MODE_USXGMII	0x0d
+#define RTL930X_SDS_MODE_XGMII		0x10
+#define RTL930X_SDS_MODE_HSGMII		0x12
+#define RTL930X_SDS_MODE_2500BASEX	0x16
+#define RTL930X_SDS_MODE_10GBASER	0x1a
+#define RTL930X_SDS_OFF			0x1f
+#define RTL930X_SDS_MASK		0x1f
+
 /* This lock protects the state of the SoC automatically polling the PHYs over the SMI
  * bus to detect e.g. link and media changes. For operations on the PHYs such as
  * patching or other configuration changes such as EEE, polling needs to be disabled
@@ -2702,6 +2719,7 @@ u32 rtl9300_sds_sym_err_get(int sds_num, phy_interface_t phy_mode)
 	case PHY_INTERFACE_MODE_XGMII:
 		break;
 
+	case PHY_INTERFACE_MODE_1000BASEX:
 	case PHY_INTERFACE_MODE_10GBASER:
 		v = rtl930x_read_sds_phy(sds_num, 5, 1);
 		return v & 0xff;
@@ -2726,6 +2744,7 @@ int rtl9300_sds_check_calibration(int sds_num, phy_interface_t phy_mode)
 	errors2 = rtl9300_sds_sym_err_get(sds_num, phy_mode);
 
 	switch (phy_mode) {
+		case PHY_INTERFACE_MODE_1000BASEX:
 		case PHY_INTERFACE_MODE_XGMII:
 
 			if ((errors2 - errors1 > 100) ||
@@ -2773,51 +2792,81 @@ void rtl9300_phy_enable_10g_1g(int sds_num)
 	pr_info("%s set medium after: %08x\n", __func__, v);
 }
 
+static int rtl9300_sds_10g_idle(int sds_num);
+static void rtl9300_serdes_patch(int sds_num);
+
 #define RTL930X_MAC_FORCE_MODE_CTRL		(0xCA1C)
-/* phy_mode = PHY_INTERFACE_MODE_10GBASER, sds_mode = 0x1a */
-int rtl9300_serdes_setup(int sds_num, phy_interface_t phy_mode)
+int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode)
 {
-	int sds_mode;
 	int calib_tries = 0;
 
-	switch (phy_mode) {
-	case PHY_INTERFACE_MODE_HSGMII:
-		sds_mode = 0x12;
-		break;
-	case PHY_INTERFACE_MODE_1000BASEX:
-		sds_mode = 0x04;
-		break;
-	case PHY_INTERFACE_MODE_XGMII:
-		sds_mode = 0x10;
-		break;
-	case PHY_INTERFACE_MODE_10GBASER:
-		sds_mode = 0x1a;
-		break;
-	case PHY_INTERFACE_MODE_USXGMII:
-		sds_mode = 0x0d;
-		break;
-	default:
-		pr_err("%s: unknown serdes mode: %s\n", __func__, phy_modes(phy_mode));
-		return -EINVAL;
-	}
+	/* Turn Off Serdes */
+	rtl9300_sds_rst(sds_num, RTL930X_SDS_OFF);
+
+	/* Apply serdes patches */
+	rtl9300_serdes_patch(sds_num);
 
 	/* Maybe use dal_longan_sds_init */
 
 	/* dal_longan_construct_serdesConfig_init */ /* Serdes Construct */
 	rtl9300_phy_enable_10g_1g(sds_num);
 
-	/* Set Serdes Mode */
-	rtl9300_sds_set(sds_num, 0x1a); /* 0x1b: RTK_MII_10GR1000BX_AUTO */
+	/* Disable MAC */
+	sw_w32_mask(0, 1, RTL930X_MAC_FORCE_MODE_CTRL + 4 * port);
+	mdelay(20);
 
-	/* Do RX calibration */
+	/* ----> dal_longan_sds_mode_set */
+	pr_info("%s: Configuring RTL9300 SERDES %d\n", __func__, sds_num);
+
+	/* Configure link to MAC */
+	rtl9300_serdes_mac_link_config(sds_num, true, true);	/* MAC Construct */
+
+	/* Re-Enable MAC */
+	sw_w32_mask(1, 0, RTL930X_MAC_FORCE_MODE_CTRL + 4 * port);
+
+	/* Enable SDS in desired mode */
+	rtl9300_force_sds_mode(sds_num, phy_mode);
+
+	/* Enable Fiber RX */
+	rtl9300_sds_field_w(sds_num, 0x20, 2, 12, 12, 0);
+
+	/* Calibrate SerDes receiver in loopback mode */
+	rtl9300_sds_10g_idle(sds_num);
 	do {
 		rtl9300_do_rx_calibration(sds_num, phy_mode);
 		calib_tries++;
 		mdelay(50);
 	} while (rtl9300_sds_check_calibration(sds_num, phy_mode) && calib_tries < 3);
+	if (calib_tries >= 3)
+		pr_warn("%s: SerDes RX calibration failed\n", __func__);
 
+	/* Leave loopback mode */
+	rtl9300_sds_tx_config(sds_num, phy_mode);
 
 	return 0;
+}
+
+static int rtl9300_sds_10g_idle(int sds_num)
+{
+	bool busy;
+	int i = 0;
+
+	do {
+		if (sds_num % 2) {
+			rtl9300_sds_field_w(sds_num - 1, 0x1f, 0x2, 15, 0, 53);
+			busy = !!rtl9300_sds_field_r(sds_num - 1, 0x1f, 0x14, 1, 1);
+		} else {
+			rtl9300_sds_field_w(sds_num, 0x1f, 0x2, 15, 0, 53);
+			busy = !!rtl9300_sds_field_r(sds_num, 0x1f, 0x14, 0, 0);
+		}
+		i++;
+	} while (busy && i < 100);
+
+	if (i < 100)
+		return 0;
+
+	pr_warn("%s WARNING: Waiting for RX idle timed out, SDS %d\n", __func__, sds_num);
+	return -EIO;
 }
 
 typedef struct {
@@ -2916,6 +2965,23 @@ sds_config rtl9300_a_sds_10gr_lane1[] =
 	{0x2F, 0x10, 0x0020}, {0x2F, 0x11, 0x8840}, {0x2B, 0x13, 0x3D87},
 	{0x2B, 0x14, 0x3108}, {0x2D, 0x13, 0x3C87}, {0x2D, 0x14, 0x1808},
 };
+
+static void rtl9300_serdes_patch(int sds_num)
+{
+	if (sds_num % 2) {
+		for (int i = 0; i < sizeof(rtl9300_a_sds_10gr_lane1) / sizeof(sds_config); ++i) {
+			rtl930x_write_sds_phy(sds_num, rtl9300_a_sds_10gr_lane1[i].page,
+					      rtl9300_a_sds_10gr_lane1[i].reg,
+					      rtl9300_a_sds_10gr_lane1[i].data);
+		}
+	} else {
+		for (int i = 0; i < sizeof(rtl9300_a_sds_10gr_lane0) / sizeof(sds_config); ++i) {
+			rtl930x_write_sds_phy(sds_num, rtl9300_a_sds_10gr_lane0[i].page,
+					      rtl9300_a_sds_10gr_lane0[i].reg,
+					      rtl9300_a_sds_10gr_lane0[i].data);
+		}
+	}
+}
 
 int rtl9300_sds_cmu_band_get(int sds)
 {

--- a/target/linux/realtek/files-5.15/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-5.15/drivers/net/phy/rtl83xx-phy.c
@@ -275,6 +275,8 @@ int rtl930x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v)
 	sw_w32(v, RTL930X_SDS_INDACS_DATA);
 	cmd = phy_addr << 2 | page << 7 | phy_reg << 13 | 0x3;
 
+	sw_w32(cmd, RTL930X_SDS_INDACS_CMD);
+
 	for (i = 0; i < 100; i++) {
 		if (!(sw_r32(RTL930X_SDS_INDACS_CMD) & 0x1))
 			break;

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -14,4 +14,22 @@ define Device/zyxel_xgs1250-12
 	zyxel-vers | \
 	uImage gzip
 endef
+
+define Device/zyxel_xgs1210-12
+  SOC := rtl9302
+  UIMAGE_MAGIC := 0x93001210
+  ZYXEL_VERS := ABWE
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := XGS1210-12
+  IMAGE_SIZE := 13312k
+  KERNEL_INITRAMFS := \
+        kernel-bin | \
+        append-dtb | \
+        gzip | \
+        zyxel-vers | \
+        uImage gzip
+endef
+
+
 TARGET_DEVICES += zyxel_xgs1250-12
+TARGET_DEVICES += zyxel_xgs1210-12


### PR DESCRIPTION
The ZyXEL XGS1210-12 Switch is a 10 + 2 port multi-GBit switch with
- 8 x 10/100/1000BaseT Ethernet ports
- 2 x 10/100/1000/2500BaseT Ethernet ports
- 2 SFP+ module slot working with 10G and 1G speed

Hardware:
- RTL9302B SoC
- Macronix MX25L12833F (16MB flash)
- Nanja NT5CC64M16GP-1 (128MB DDR3 SDRAM)
- RTL8231 GPIO extender to control the port LEDs
- RTL8218D 8x Gigabit PHY
- RTL8226 2x 2.5Gigabit PHY
- SFP+ 2x 10GBit slot

At this commit, all ethernet ports work under OpenWRT, including the various NBaseT modes and the SFP+ are working with 10G and 1G module with i2c support for both ports.