### PR TITLE
mediatek: filogic: add support for Tenbay WR3000K

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -139,6 +139,9 @@ zyxel,ex5601-t0)
 zyxel,ex5700-telenor)
 	ubootenv_add_uci_config "/dev/ubootenv" "0x0" "0x4000" "0x4000" "1"
 	;;
+tenbay,wr3000k)
+        ubootenv_add_uci_config "/dev/mtd1" "0" "0x20000" "0x20000" 1
+        ;;
 esac
 
 config_load ubootenv

--- a/target/linux/mediatek/dts/mt7981b-tenbay-wr3000k.dts
+++ b/target/linux/mediatek/dts/mt7981b-tenbay-wr3000k.dts
@@ -1,0 +1,235 @@
+/dts-v1/;
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "WR3000K";
+	compatible = "tenbay,wr3000k", "mediatek,mt7981";
+
+	aliases {
+		ethernet0 = &gmac0;
+		led-boot = &led_run;
+		led-failsafe = &led_blue;
+		led-running = &led_green;
+		led-upgrade = &led_blue;
+		serial0 = &uart0;
+		label-mac-device = &wan;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_run: led-0 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_green: led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_blue: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		nvmem-cells = <&macaddr_factory_4 (-1)>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+};
+
+&mdio_bus {
+	switch0: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		dsa,member = <0 0>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		wan: port@3 {
+			reg = <3>;
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_4 (-2)>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x0200000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x0200000>;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				compatible = "linux,ubi";
+				reg = <0x580000 0x3000000>;
+			};
+
+			partition@3580000 {
+			    label = "ubi1";
+			    reg = <0x3580000 0x3000000>;
+			 };
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+};
+
+&wifi {
+	mediatek,mtd-eeprom = <&factory 0x0>;
+
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -35,7 +35,8 @@ mediatek_setup_interfaces()
 	jcg,q30-pro|\
 	qihoo,360t7|\
 	routerich,ax3000|\
-	routerich,ax3000-ubootmod)
+	routerich,ax3000-ubootmod|\
+	tenbay,wr3000k)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;
 	asus,tuf-ax4200|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1311,6 +1311,28 @@ define Device/ruijie_rg-x60-pro
 endef
 TARGET_DEVICES += ruijie_rg-x60-pro
 
+define Device/tenbay_wr3000k
+  DEVICE_VENDOR := Tenbay
+  DEVICE_MODEL := WR3000K
+  DEVICE_DTS := mt7981b-tenbay-wr3000k
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware uboot-envtools
+  SUPPORTED_DEVICES := tenbay,wr3000k mt7981-spim-nand-gsw-wr3000k
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  KERNEL = kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS = kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+endef
+TARGET_DEVICES += tenbay_wr3000k
+
 define Device/tplink_re6000xd
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := RE6000XD


### PR DESCRIPTION
Tenbay WR3000K is an 802.11ax (Wi-Fi 6) router, based on MediaTek MT7981B.

## Specifications:
●SoC: MetiaTek MT7981B
●RAM: Hynex H5TQ2G863GFR 512MiB
●Flash: Winbond W25N01GVZEIG 128MiB
●Wi-Fi: MediaTek MT7976C (2.4GHz/5GHz, 802.11ax, 2x2 MIMO, AX3000)
●MediaTek MT7915E: 2.4GHz and 5GHz
●Ethernet: 1x 10/100/1000 Mbps WAN + 3x 10/100/1000 Mbps LAN
●Switch: MediaTek MT7531AE
●LEDs: Power
●Buttons: Reset, WPS
●PWR: 12V/1A DC, 5.5×2.1 connector

## MAC Addresses:
| Vendor  | OpenWrt Interface | Address       | Notes                                          |
|---------|-------------------|---------------|------------------------------------------------|
| WAN     | wan            | Label MAC     | Default                                        |
| LAN     | br-lan             | Label MAC+1   |              |
| 2.4GHz  | phy0-ap0          | Label MAC + 2     |  Stored in partition "Factroy" 0x4            |
| 5GHz    | phy1-ap0          | Label MAC + 3     |              |

## MTD Partitions:
●0x000000000000-0x000000100000 : "BL2"
●0x000000100000-0x000000180000 : "u-boot-env"
●0x000000180000-0x000000380000 : "Factory"
●0x000000380000-0x000000580000 : "FIP"
●0x000000580000-0x000003580000 : "ubi"
●0x000006580000-0x0000065a0000 : "Product"

## UBI Partitions (Dynamic):
●id: 0, kernel
●id: 1, rootfs
●id: 2, rootfs_data

## Flash:
### Terminal Flash
scp wr3000k-<build_time>-mediatek-filogic-tenbay_wr3000k-squashfs-sysupgrade.bin to device's /tmp dir and 
flash wr3000k-<build_time>-mediatek-filogic-tenbay_wr3000k-squashfs-sysupgrade.bin
sysupgrade -n /tmp/wr3000k-<build_time>-mediatek-filogic-tenbay_wr3000k-squashfs-sysupgrade.bin
### Web Flash
1.Login to the web browser  via `http://192.168.1.1/`.
2.Select System -> Backup / Flash Firmware -> Flash new firmware image -> Flash image...
3.Select firmware wr3000k-<build_time>-mediatek-filogic-tenbay_wr3000k-squashfs-sysupgrade.bin.
4.Click upload and upgrade.
5.The device will upgrade and reboot.
## Notes
Partition - "Product" is used to store default configurations such as web login passwords and wireless SSID passwords. If the configuration does not exist, use Openwrt's default configuration.
