### PR TITLE
mediatek: add support for Mercusys MR80X v3

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -340,6 +340,18 @@ define U-Boot/mt7981_openwrt_one-nor
   DEPENDS:=+trusted-firmware-a-mt7981-nor-ddr4
 endef
 
+define U-Boot/mt7981_mercusys_mr80x-v3
+  NAME:=mercusys mr80x-v3
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=mercusys_mr80x-v3
+  UBOOT_CONFIG:=mt7981_mercusys_mr80xv3
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr3
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr3
+endef
+
 define U-Boot/mt7981_rfb-spim-nand
   NAME:=MT7981 Reference Board
   BUILD_SUBTARGET:=filogic
@@ -842,6 +854,7 @@ UBOOT_TARGETS := \
 	mt7981_nokia_ea0326gmp \
 	mt7981_openwrt_one-snand \
 	mt7981_openwrt_one-nor \
+	mt7981_mercusys_mr80x-v3 \
 	mt7981_rfb-spim-nand \
 	mt7981_rfb-emmc \
 	mt7981_rfb-nor \

--- a/package/boot/uboot-mediatek/patches/445_add_mercusys_mr80xv3_dts_and_target.patch
+++ b/package/boot/uboot-mediatek/patches/445_add_mercusys_mr80xv3_dts_and_target.patch
@@ -1,0 +1,326 @@
+--- /dev/null
++++ b/configs/mt7981_mercusys_mr80xv3_defconfig
+@@ -0,0 +1,187 @@
++CONFIG_ARM=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TARGET_MT7981=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981-spim-nand-rfb"
++CONFIG_BOOTCMD="bootm 0x46000000"
++CONFIG_DEFAULT_FDT_FILE="mt7981-spim-nand-rfb"
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_FIT=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++CONFIG_LOGLEVEL=7
++CONFIG_LOG=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_BOOTP=y
++CONFIG_CMD_BUTTON=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_CPU=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_ECHO=y
++CONFIG_CMD_ENV_READMEM=y
++# CONFIG_CMD_EXT4 is not set
++# CONFIG_CMD_FAT is not set
++CONFIG_CMD_FDT=y
++# CONFIG_CMD_FS_GENERIC is not set
++# CONFIG_CMD_FS_UUID is not set
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_ITEST=y
++CONFIG_CMD_LED=y
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_LINK_LOCAL=y
++# CONFIG_CMD_MBR is not set
++CONFIG_CMD_MTD=y
++# CONFIG_CMD_PCI is not set
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++# CONFIG_CMD_PWM is not set
++CONFIG_CMD_SMC=y
++CONFIG_CMD_TFTPBOOT=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_CMD_UBIFS=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_SETEXPR=y
++CONFIG_CMD_SLEEP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_SOURCE=y
++# CONFIG_CMD_USB is not set
++# CONFIG_CMD_FLASH is not set
++CONFIG_DISPLAY_CPUINFO=y
++CONFIG_DM_MTD=y
++# CONFIG_DM_USB is not set
++CONFIG_DM_PWM=y
++CONFIG_PWM_MTK=y
++CONFIG_PARTITION_UUIDS=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_CLK=y
++CONFIG_DM_GPIO=y
++# CONFIG_DM_SCSI is not set
++# CONFIG_AHCI is not set
++CONFIG_PHY=y
++# CONFIG_PHY_MTK_TPHY is not set
++CONFIG_PHY_FIXED=y
++CONFIG_MTK_AHCI=y
++CONFIG_DM_ETH=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PCI=y
++CONFIG_MMC=y
++CONFIG_DM_MMC=y
++CONFIG_MTD=y
++# CONFIG_DM_PCI is not set
++CONFIG_PCIE_MEDIATEK=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_RAM=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPI_NAND=y
++CONFIG_MTK_SPI_NAND_MTD=y
++CONFIG_SYSRESET_WATCHDOG=y
++CONFIG_WDT_MTK=y
++CONFIG_LZO=y
++# CONFIG_ZSTD is not set
++CONFIG_HEXDUMP=y
++# CONFIG_RANDOM_UUID is not set
++CONFIG_REGEX=y
++# CONFIG_USB is not set
++# CONFIG_USB_HOST is not set
++# CONFIG_USB_XHCI_HCD is not set
++# CONFIG_USB_XHCI_MTK is not set
++# CONFIG_USB_STORAGE is not set
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++# CONFIG_ENV_IS_IN_UBI is not set
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_SIZE=0x20000
++CONFIG_ENV_MTD_NAME="u-boot-env"
++CONFIG_ENV_SIZE_REDUND=0x80000
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_NET_RANDOM_ETHADDR=y
++# CONFIG_USE_DEFAULT_ENV_FILE is not set
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTK_SPIM=y
++CONFIG_CMD_NAND=y
++CONFIG_CMD_NAND_TRIMFFS=y
++CONFIG_LMB_MAX_REGIONS=8
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_ARM64_SUPPORT_AARCH32=y
++CONFIG_SYS_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_LEN=0x400000
++CONFIG_SYS_MEMTEST_START=0x40000000
++CONFIG_SYS_MEMTEST_END=0x41000000
++CONFIG_ENV_OFFSET=0x0
++CONFIG_MULTI_DTB_FIT_UNCOMPRESS_SZ=0x8000
++CONFIG_MTK_BROM_HEADER_INFO="media=snand;nandinfo=2k+64"
++# CONFIG_ENABLE_NAND_NMBM is not set
++CONFIG_MEDIATEK_BOOTMENU=y
++CONFIG_MEDIATEK_BOOTMENU_COUNTDOWN=y
++CONFIG_MEDIATEK_BOOTMENU_DELAY=1
++CONFIG_MT7981_BOOTMENU_UBI=y
++CONFIG_BOOTSTAGE_STASH_ADDR=0
++CONFIG_IDENT_STRING=""
++CONFIG_SYS_CLK_FREQ=0
++CONFIG_PSCI_RESET=y
++CONFIG_STACK_SIZE=0x1000000
++CONFIG_FIT_EXTERNAL_OFFSET=0x0
++CONFIG_ARCH_FIXUP_FDT_MEMORY=y
++CONFIG_BOOTSTAGE_STASH_SIZE=0x1000
++CONFIG_USE_BOOTARGS=y
++CONFIG_BOOTARGS="ubi.mtd=ubi0 console=ttyS0,115200n1 loglevel=8 earlycon=uart8250,mmio32,0x11002000 init=/etc/preinit"
++CONFIG_MENU=y
++CONFIG_LOG_DEFAULT_LEVEL=6
++CONFIG_CMDLINE=y
++CONFIG_CMDLINE_EDITING=y
++CONFIG_CMD_BOOTM=y
++CONFIG_CMD_MEMTEST=y
++CONFIG_CMD_TFTPBOOT=y
++CONFIG_NET_TFTP_VARS=y
++CONFIG_CMD_BLOCK_CACHE=y
++CONFIG_CMD_SLEEP=y
++CONFIG_MTDIDS_DEFAULT="spi-nand0=spi-nand0"
++CONFIG_MTDPARTS_DEFAULT="spi-nand0:2M(boot),1M(u-boot-env),50M(ubi0),50M(ubi1),8M(userconfig),8M(tp_data)"
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBIFS=y
++CONFIG_PARTITIONS=y
++CONFIG_ENV_IS_IN_MTD=y
++CONFIG_ARP_TIMEOUT=5000
++CONFIG_NET_RETRY_COUNT=5
++CONFIG_BOOTDEV_ETH=y
++CONFIG_MTD=y
++CONFIG_MTD_NAND_CORE=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_FLASH=y
++CONFIG_MTD_UBI_WL_THRESHOLD=4096
++CONFIG_MTD_UBI_BEB_LIMIT=20
++CONFIG_POWER=y
++CONFIG_RESET_MEDIATEK=y
++CONFIG_LMB=y
++CONFIG_LMB_USE_MAX_REGIONS=y
++CONFIG_SUPPORT_SECOND_UBOOT=y
+--- /dev/null
++++ b/arch/arm/dts/mt7981-spim-nand-rfb.dts
+@@ -0,0 +1,133 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) 2022 MediaTek Inc.
++ * Author: Sam Shih <sam.shih@mediatek.com>
++ */
++
++/dts-v1/;
++#include "mt7981.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/linux-event-codes.h>
++
++/ {
++	#address-cells = <1>;
++	#size-cells = <1>;
++	model = "mediatek mt7981";
++	compatible = "mediatek,mt7981", "mediatek,mt7981-rfb";
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x20000000>;
++	};
++};
++
++&uart0 {
++	status = "okay";
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <0>;
++	phy-mode = "sgmii";
++	mediatek,switch = "mt7531";
++	reset-gpios = <&gpio 39 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <1000>;
++		full-duplex;
++	};
++};
++
++&pinctrl {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
++		};
++
++		conf-pd {
++			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
++		};
++	};
++
++	spic_pins: spi1-pins-func-1 {
++		mux {
++			function = "spi";
++			groups = "spi1_1";
++		};
++	};
++
++	uart1_pins: spi1-pins-func-3 {
++		mux {
++			function = "uart";
++			groups = "uart1_2";
++		};
++	};
++
++	/* pin15 as pwm0 */
++	one_pwm_pins: one-pwm-pins {
++		mux {
++			function = "pwm";
++			groups = "pwm0_1";
++		};
++	};
++
++	/* pin15 as pwm0 and pin14 as pwm1 */
++	two_pwm_pins: two-pwm-pins {
++		mux {
++			function = "pwm";
++			groups = "pwm0_1", "pwm1_0";
++		};
++	};
++
++	/* pin15 as pwm0, pin14 as pwm1, pin7 as pwm2 */
++	three_pwm_pins: three-pwm-pins {
++		mux {
++			function = "pwm";
++			groups = "pwm0_1", "pwm1_0", "pwm2";
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++	};
++};
++
++&pwm {
++	pinctrl-names = "default";
++	pinctrl-0 = <&two_pwm_pins>;
++	status = "okay";
++};
++
++&watchdog {
++	status = "disabled";
++};

--- a/package/boot/uboot-mediatek/patches/446_add_second_uboot_mkimage_command.patch
+++ b/package/boot/uboot-mediatek/patches/446_add_second_uboot_mkimage_command.patch
@@ -1,0 +1,12 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1208,7 +1208,8 @@ u-boot.bin: u-boot-dtb.bin FORCE
+ 
+ else
+ u-boot.bin: u-boot-nodtb.bin FORCE
+-	$(call if_changed,copy)
++	$(call if_changed,copy) &&\
++	./tools/mkimage -A arm -T standalone  -C none -n "seconduboot"  -e 0x41e00000 -d ./u-boot.bin $(TMPDIR)/second-uboot.bin
+ endif
+ 
+ # we call Makefile in arch/arm/mach-imx which

--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -617,6 +617,7 @@ define KernelPackage/mt7981-firmware/install
 		$(PKG_BUILD_DIR)/firmware/mt7981_wa.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7981_wm.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7981_rom_patch.bin \
+		$(PKG_BUILD_DIR)/firmware/mt7981_eeprom_mt7976_dbdc.bin \
 		$(1)/lib/firmware/mediatek
 endef
 

--- a/target/linux/mediatek/dts/mt7981b-mercusys-mr80x-v3.dts
+++ b/target/linux/mediatek/dts/mt7981b-mercusys-mr80x-v3.dts
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7981.dtsi"
+/ {
+	model = "MERCUSYS MR80X v3";
+	compatible = "mercusys,mr80x-v3", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x10000000>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,input-type = <1>;
+		};
+	};
+	leds {
+		compatible = "gpio-leds";
+
+		orange {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+		green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+		led-wan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+		led-lan1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+		led-lan2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+		led-lan3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&afe {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcm_pins>;
+	status = "okay";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c_pins>;
+	status = "disabled";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		nick-index = <4>;
+		phy-handle = <&int_gbe_phy>;
+		phy-link {
+			speed = <1000>;
+			full-duplex;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy5: phy@5 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <5>;
+			reset-gpios = <&pio 14 1>;
+			reset-assert-us = <600>;
+			reset-deassert-us = <20000>;
+			phy-mode = "2500base-x";
+			partner_gmac = <0>;
+		};
+
+		phy6: phy@6 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <6>;
+			phy-mode = "2500base-x";
+			partner_gmac = <1>;
+		};
+
+		switch@0 {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 39 0>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@1 {
+					reg = <1>;
+					label = "lan1";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan2";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan3";
+				};
+
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+	spi_nand: spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+
+		partition@0 {
+			label = "boot";
+			reg = <0x00000 0x0200000>;
+			read-only;
+		};
+
+		partition@200000 {
+			label = "u-boot-env";
+			reg = <0x0200000 0x0100000>;
+		};
+
+		partition@300000 {
+			label = "ubi0";
+			reg = <0x300000 0x3200000>;
+		};
+
+		partition@3500000 {
+			label = "ubi1";
+			reg = <0x3500000 0x3200000>;
+		};
+
+		partition@6700000 {
+			label = "userconfig";
+			reg = <0x6700000 0x800000>;
+		};
+
+		factory:partition@6f00000 {
+			label = "tp_data";
+			reg = <0x6f00000 0x800000>;
+		};
+	};
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spic_pins>;
+	status = "okay";
+
+	proslic_spi: proslic_spi@0 {
+		compatible = "silabs,proslic_spi";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		spi-cpha = <1>;
+		spi-cpol = <1>;
+		channel_count = <1>;
+		debug_level = <4>;
+		reset_gpio = <&pio 15 0>;
+		ig,enable-spi = <1>;
+	};
+};
+
+&pio {
+
+	i2c_pins: i2c-pins-g0 {
+		mux {
+			function = "i2c";
+			groups = "i2c0_0";
+		};
+	};
+
+	pcm_pins: pcm-pins-g0 {
+		mux {
+			function = "pcm";
+			groups = "pcm";
+			};
+	};
+
+	pwm0_pin: pwm0-pin-g0 {
+		mux {
+			function = "pwm";
+			groups = "pwm0_0";
+		};
+	};
+
+	pwm1_pin: pwm1-pin-g0 {
+		mux {
+			function = "pwm";
+			groups = "pwm1_0";
+		};
+	};
+
+	pwm2_pin: pwm2-pin {
+		mux {
+			function = "pwm";
+			groups = "pwm2";
+		};
+	};
+
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+	spic_pins: spi1-pins {
+		mux {
+			function = "spi";
+			groups = "spi1_1";
+		};
+	};
+
+	uart1_pins: uart1-pins-g1 {
+		mux {
+			function = "uart";
+			groups = "uart1_1";
+		};
+	};
+
+	uart2_pins: uart2-pins-g1 {
+		mux {
+			function = "uart";
+			groups = "uart2_1";
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -106,6 +106,9 @@ mediatek_setup_interfaces()
 	mediatek,mt7988a-rfb)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 eth2" eth1
 		;;
+	mercusys,mr80x-v3)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" eth1
+		;;
 	mercusys,mr90x-v1|\
 	mercusys,mr90x-v1-ubi)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2" eth1

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -119,6 +119,13 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary rf-eeprom 0x4)" > /sys${DEVPATH}/macaddress
 		;;
+	mercusys,mr80x-v3)
+		prefix_addr=$(cat /tmp/tp_data/default-mac)
+		addr=${prefix_addr#MAC:}
+		formatted_addr=${addr//-/:}
+		[ "$PHYNBR" = "0" ] && macaddr_add $formatted_addr -1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $formatted_addr -2 > /sys${DEVPATH}/macaddress
+		;;
 	mercusys,mr90x-v1|\
 	tplink,re6000xd)
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -12,6 +12,7 @@ mount_ubi_part() {
 
 preinit_mount_cfg_part() {
 	case $(board_name) in
+	mercusys,mr80x-v3|\
 	mercusys,mr90x-v1|\
 	tplink,re6000xd)
 		mount_ubi_part "tp_data"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1692,3 +1692,18 @@ define Device/zyxel_nwa50ax-pro
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += zyxel_nwa50ax-pro
+
+define Device/mercusys_mr80x-v3
+  DEVICE_VENDOR := mercusys
+  DEVICE_MODEL := mr80x-v3
+  DEVICE_DTS := mt7981b-mercusys-mr80x-v3
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7981-firmware
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  KERNEL_IN_UBI := 1
+  UBINIZE_PARTS := uboot=$$(TMPDIR)/second-uboot.bin=1
+  IMAGE/sysupgrade.bin := append-ubi | pad-to 128K | check-size 50m | append-metadata
+endef
+TARGET_DEVICES += mercusys_mr80x-v3


### PR DESCRIPTION
This commit adds support for Mercusys MR80X(EU) v3 router.

Device specification:
 - SoC: Mediatek MT7981b, Cortex-A53, 64-bit
 - RAM: 512MB
 - Flash: SPI NAND GigaDevice GD5F1GQ5UEYIGY (128 MB)
 - Ethernet: 4x 100/1000 Mbps LAN1,LAN2,LAN3 & WAN
 - Wireless: 2.4GHz (802.11 b/g/n/ax)
 - Wireless: 5GHz (802.11 a/n/ac/ax)
 - LEDs: 1 orange and 1 green status LEDs, 4 green gpio-controlled LEDs on ethernet ports
 - Buttons: 1 (Reset)
 - Bootloader: Main U-Boot - U-Boot 2022.01-rc4. Additionally, both UBI slots contain "seconduboot" (also U-Boot 2022.01-rc4)

Installation (UART):
 - Place OpenWrt sysupgrade image on tftp server with IP 192.168.1.2
 - Attach UART, switch on the router and interrupt the boot process by pressing 'Ctrl-C'.
 - Upload the sysupgrade.bin via tftp. setenv serverip 192.168.1.2; setenv ipaddr 192.168.1.1; tftp 0x40001000 sysupgrade.bin
 - Erase "ubi0" part, and write the image. nand erase.spread 0x300000 0x3200000; nand write.spread 0x40001000 0x300000 0x3200000
 - Set the uboot environment for startup. setenv tp_boot_idx 0; setenv bootcmd bootm 0x46000000; saveenv
 - Reboot the router by reconnecting the power.

Recovery:
 - Press Reset button and power on the router.
 - Navigate to U-Boot recovery web server (http://192.168.1.1/) and upload the OEM firmware.

Stock layout:
0x000000000000-0x000000200000 : "boot"
0x000000200000-0x000000300000 : "u-boot-env"
0x000000300000-0x000003500000 : "ubi0"
0x000003500000-0x000006700000 : "ubi1"
0x000006700000-0x000006f00000 : "userconfig"
0x000006f00000-0x000007300000 : "tp_data"

ubi0/ubi1 format:
U-Boot at boot checks that all volumes are in place: +-------------------------------+
| Volume Name: uboot   Vol ID: 0|
| Volume Name: kernel  Vol ID: 1|
| Volume Name: rootfs  Vol ID: 2|
+-------------------------------+

MAC addresses:
+---------+-------------------+-----------+
|         | MAC               | Algorithm |
+---------+-------------------+-----------+
| label   | 94:0C:xx:xx:xx:12 | label     |
| WLAN 2g | 94:0C:xx:xx:xx:11 | label-1   |
| WLAN 5g | 94:0C:xx:xx:xx:10 | label-2   |
+---------+-------------------+-----------+
label MAC address was found in UBI partition "tp_data", file
"default-mac". 

Signed-off-by: Schneider Azima <Schneider-Azima12@protonmail.com>