### PR TITLE
mediatek: filogic: add support for Tenbay WR3000K

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -107,6 +107,7 @@ glinet,gl-mt3000)
 	;;
 mercusys,mr90x-v1|\
 routerich,ax3000|\
+tenbay,wr3000k|\
 tplink,re6000xd)
 	local envdev=/dev/mtd$(find_mtd_index "u-boot-env")
 	ubootenv_add_uci_config "$envdev" "0x0" "0x20000" "0x20000" "1"

--- a/target/linux/mediatek/dts/mt7981b-tenbay-wr3000k.dts
+++ b/target/linux/mediatek/dts/mt7981b-tenbay-wr3000k.dts
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7981.dtsi"
+
+/ {
+	model = "Tenbay WR3000K";
+	compatible = "tenbay,wr3000k", "mediatek,mt7981";
+
+	aliases {
+		led-boot = &led_run;
+		led-failsafe = &led_blue;
+		led-running = &led_green;
+		led-upgrade = &led_blue;
+		serial0 = &uart0;
+		label-mac-device = &wan;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_run: led-0 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_green: led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_blue: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		nvmem-cells = <&macaddr_factory_4 (-1)>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		wan: port@3 {
+			reg = <3>;
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_4 (-2)>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x0200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x0200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				compatible = "linux,ubi";
+				reg = <0x580000 0x3000000>;
+			};
+
+			partition@3580000 {
+			    label = "ubi1";
+			    reg = <0x3580000 0x3000000>;
+			};
+
+			partition@6580000 {
+				label = "Product";
+				reg = <0x6580000 0x0020000>;  // 128 KB
+			};
+
+			partition@65a0000 {
+				label = "Custom";
+				reg = <0x65a0000 0x1000000>;  // 16 MB
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -36,7 +36,8 @@ mediatek_setup_interfaces()
 	keenetic,kn-3811|\
 	qihoo,360t7|\
 	routerich,ax3000|\
-	routerich,ax3000-ubootmod)
+	routerich,ax3000-ubootmod|\
+	tenbay,wr3000k)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;
 	asus,tuf-ax4200|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1368,6 +1368,27 @@ define Device/ruijie_rg-x60-pro
 endef
 TARGET_DEVICES += ruijie_rg-x60-pro
 
+define Device/tenbay_wr3000k
+  DEVICE_VENDOR := Tenbay
+  DEVICE_MODEL := WR3000K
+  DEVICE_DTS := mt7981b-tenbay-wr3000k
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 49152k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  KERNEL = kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS = kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+endef
+TARGET_DEVICES += tenbay_wr3000k
+
 define Device/tplink_re6000xd
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := RE6000XD


### PR DESCRIPTION
Tenbay WR3000K is an 802.11ax (Wi-Fi 6) router, based on MediaTek MT7981B. 

## Specifications:
- SoC: MetiaTek MT7981B
- RAM: Hynex H5TQ2G863GFR 512MiB
- Flash: Winbond W25N01GVZEIG 128MiB
- Wi-Fi: MediaTek MT7976C (2.4GHz/5GHz, 802.11ax, 2x2 MIMO, AX3000)
- MediaTek MT7915E: 2.4GHz and 5GHz
- Ethernet: 1x 10/100/1000 Mbps WAN + 3x 10/100/1000 Mbps LAN
- Switch: MediaTek MT7531AE
- UART: J4 (115200 baud)
- LEDs: Power
- Buttons: Reset, WPS
- PWR: 12V/1A DC, 5.5×2.1 connector

## MAC Addresses:
| Vendor  | OpenWrt Interface | Address       | Notes                                          |
|---------|-------------------|---------------|------------------------------------------------|
| WAN     | wan            | Stored MAC - 2     |  Label MAC |
| LAN     | br-lan             | Stored MAC - 1   |    |
| 2.4GHz  | phy0-ap0          | Stored MAC     |   Stored in  Factory + offset 4        |
| 5GHz    | phy1-ap0          | Stored MAC +1    |              |

## MTD Partitions:
- 0x000000000000-0x000000100000 : "BL2"
- 0x000000100000-0x000000180000 : "u-boot-env"
- 0x000000180000-0x000000380000 : "Factory"
- 0x000000380000-0x000000580000 : "FIP"
- 0x000000580000-0x000003580000 : "ubi"
- 0x000003580000-0x000006580000 : "ubi1"
- 0x000006580000-0x0000065a0000 : "Product"
- 0x0000065a0000-0x000007580000 : "Custom"

#### Note:
- The original partition-Ubi partition-Ubi1 is an AB dual system, and Openwrt only uses Ubi. So flash requires modifying the uboot variable `boot_from=ubi` to ensure that it only starts from Ubi.

- The `Product` and `Custom` partitions are original and only exist to align with the original layout; they are not used by OpenWrt.

## UBI Partitions (Dynamic):
- id: 0, kernel
- id: 1, rootfs
- id: 2, rootfs_data

## Flash instructions:
### Serial Flash
#### 1. Preparation

##### Hardware Requirements
- **USB-to-TTL Serial Adapter** (e.g., CH340 or CP2102).
- **Dupont Wires** (male-to-male, 3 wires).
- **PC/Laptop** with a serial communication tool.
- Screwdriver (to open the router case).

##### Software Requirements
1. **OpenWrt Firmware**:
   - Download the appropriate `wr3000k-<build_time>-mediatek-filogic-tenbay_wr3000k-squashfs-sysupgrade.bin` firmware file for your router from the [OpenWrt website](https://openwrt.org/).
2. **Serial Communication Tool**:
   - Windows: PuTTY, Tera Term.
   - Linux/Mac: Minicom, screen.
3. (Optional) **TFTP Server**:
   - Install a TFTP server like Tftpd64 or tftp-hpa.

---

#### 2. Setup Serial Connection

##### Hardware Connection
1. Open the router casing and locate the **TX, RX, and GND** pins.
2. Connect the router pins to the USB-to-TTL adapter as follows:
   - **TX (router)** → **RX (adapter)**
   - **RX (router)** → **TX (adapter)**
   - **GND (router)** → **GND (adapter)**
3. Do **not** connect the VCC pin to avoid damage.

##### Serial Tool Configuration
- **Baud rate**: 115200
- **Data bits**: 8
- **Stop bits**: 1
- **Parity**: None
- **Flow control**: None

---

#### 3. Modify U-Boot Boot_From Variable
1. Power on the router and observe the serial terminal output.
2. When prompted (e.g., `Hit any key to stop autoboot: 3`), press the '/' key quickly to interrupt the boot process.
3. You will see the U-Boot Boot Menu:
```plaintext
*** U-Boot Boot Menu ***

    1. Factory mode
    2. Startup system (Default)
    3. Upgrade firmware
    4. Upgrade ATF BL2
    5. Upgrade ATF FIP
    6. Upgrade single image
    7. Load image
    0. U-Boot console

Press UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit
```
4. Select Option 0 by typing 0 and pressing Enter.
5. Input into
```plaintext
MT7981> setenv boot_from ubi
MT7981> saveenv
Saving Environment to MTD... Erasing on MTD device 'nmbm0'... OK
Writing to MTD device 'nmbm0'... OK
OK
MT7981> printenv
baudrate=115200
boot_from=ubi
...
```
the above indicates system will start from *ubi*.
and then type
```plaintext
MT7981> reset
```
will boot from *ubi*

#### 4. Enter U-Boot Upgrade Boot Menu

1. Power on the router and observe the serial terminal output.
2. When prompted (e.g., `Hit any key to stop autoboot: 3`), press the '/' key quickly to interrupt the boot process.
3. You will see the U-Boot Boot Menu:
```plaintext
*** U-Boot Boot Menu ***

    1. Factory mode
    2. Startup system (Default)
    3. Upgrade firmware
    4. Upgrade ATF BL2
    5. Upgrade ATF FIP
    6. Upgrade single image
    7. Load image
    0. U-Boot console

Press UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit
```
4. Choose Option 3: Upgrade Firmware Enter Upgrade Mode
Select Option 3 by typing 3 and pressing Enter.
Upgrade Methods
You will be prompted to choose between:
```plaintext
*** Upgrading Firmware ***

Run image after upgrading? (Y/n): y

Available load methods:
    0 - TFTP client (Default)
    1 - Xmodem
    2 - Ymodem
    3 - Kermit
    4 - S-Record
    5 - RAM

Select (enter for default): 0

Input U-Boot's IP address: 192.168.1.1
Input TFTP server's IP address: 192.168.1.10
Input IP netmask: 255.255.255.0
Input file name: wr3000k-<build_time>-mediatek-filogic-tenbay_wr3000k-squashfs-sysupgrade.bin
```
Type Enter to proceed. The router will erase the old firmware and write the new one.

Signed-off-by: Jianyu Zhuang <xzjianyu@gmail.com>