### PR TITLE
apk: add dependency on wget provider

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -27,7 +27,7 @@ define Package/apk/default
   SECTION:=base
   CATEGORY:=Base system
   TITLE:=apk package manager
-  DEPENDS:=+zlib
+  DEPENDS:=+zlib +wget
   URL:=$(PKG_SOURCE_URL)
   PROVIDES:=apk
 endef


### PR DESCRIPTION
The apk-* packages contain no declared dependencies on a wget provider, which is required for proper operation.  Let's add it.

Fixes: https://github.com/openwrt/openwrt/issues/17173

Test results (x86/64 1aa2695620):
```
$ apk info --installed --depends apk
apk-mbedtls-3.0.0_pre20241130-r1 depends on:
libc
libmbedtls21
wget
zlib

$ apk info --installed --provides wget
uclient-fetch-2024.10.22~88ae8f20-r1 provides:
wget

$ apk info --installed --rdepends wget
uclient-fetch-2024.10.22~88ae8f20-r1 is required by:
apk-mbedtls-3.0.0_pre20241130-r1

$ apk del uclient-fetch
World updated, but the following packages are not removed due to:
  uclient-fetch: apk-mbedtls
```