### PR TITLE
build: add git hash field support for package VERSION

### DIFF
--- a/include/package-defaults.mk
+++ b/include/package-defaults.mk
@@ -22,11 +22,7 @@ define Package/Default
   MAINTAINER:=$(PKG_MAINTAINER)
   SOURCE:=$(patsubst $(TOPDIR)/%,%,$(patsubst $(TOPDIR)/package/%,feeds/base/%,$(CURDIR)))
   ifneq ($(PKG_VERSION),)
-    ifneq ($(PKG_RELEASE),)
-      VERSION:=$(PKG_VERSION)-r$(PKG_RELEASE)
-    else
-      VERSION:=$(PKG_VERSION)
-    endif
+    VERSION:=$(PKG_VERSION)$(if $(PKG_RELEASE),-r$(PKG_RELEASE))$(if $(PKG_SOURCE_VERSION),~$(shell echo $(PKG_SOURCE_VERSION) | cut -c1-7))
   else
     VERSION:=$(PKG_RELEASE)
   endif


### PR DESCRIPTION
Append `PKG_SOURCE_VERSION` to package `VERSION`.

In the past, we put the hash field in `PKG_VERSION` or `PKG_RELEASE`:
``` makefile
PKG_VERSION:=0.4.9.13
PKG_RELEASE:=70a40bb
```
or
``` makefile
PKG_VERSION:=0.4.9.13-70a40bb
```
But now we can't do that, must follow the apk format.  
And after the package is delivered, we will not be able to determine the upstream version because the hash field is missing.
