### PR TITLE
wifi-scripts: don't fail on unset PSK

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -724,7 +724,7 @@ hostapd_set_bss_options() {
 				append bss_conf "wpa_psk=$key" "$N"
 			elif [ ${#key} -ge 8 ] && [ ${#key} -le 63 ]; then
 				append bss_conf "wpa_passphrase=$key" "$N"
-			elif [ -n "$key" ] || [ -z "$wpa_psk_file" ] || [ -z "$sae_password_file" ]; then
+			elif [ -n "$key" ]; then
 				wireless_setup_vif_failed INVALID_WPA_PSK
 				return 1
 			fi


### PR DESCRIPTION
Don't fail wireless interface bringup on empty PSK set. This is a valid configuration, resulting in a PSK network which can't be connected to. It does not fail the bringup of the hostapd process.

Keep failing the interface setup in case a password with invalid length is used.