### PR TITLE
mediatek: filogic: prevent faulty mac address assignment

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
@@ -11,7 +11,6 @@
 	compatible = "cudy,wr3000-v1", "mediatek,mt7981";
 
 	aliases {
-		ethernet0 = &gmac0;
 		label-mac-device = &gmac0;
 		led-boot = &led_status;
 		led-failsafe = &led_status;


### PR DESCRIPTION
This extends this fix #15507 also for Cudy WR3000

see also:
#15587
#15515