### PR TITLE
wifi-scripts: Fix latest 'ucode' uses 'CONFIG_WIFI_SCRIPTS_UCODE' make wireless cannot be started.

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -441,9 +441,9 @@ function device_capabilities(phy) {
 	let phys = nl80211.request(nl80211.const.NL80211_CMD_GET_WIPHY, nl80211.const.NLM_F_DUMP, { wiphy: idx, split_wiphy_dump: true });
 
 	for (let phy in phys) {
-		if (!phy || phy.wiphy != idx)
+		if (!phy || phys.wiphy != idx)
 			continue;
-		for (let band in phy.wiphy_bands) {
+		for (let band in phys.wiphy_bands) {
 			if (!band)
 				continue;
 			phy_capabilities.ht_capa = band.ht_capa ?? 0;
@@ -457,8 +457,8 @@ function device_capabilities(phy) {
 			break;
 		}
 
-		phy_features.ftm_responder = device_extended_features(phy.extended_features, NL80211_EXT_FEATURE_ENABLE_FTM_RESPONDER);
-		phy_features.radar_background = device_extended_features(phy.extended_features, NL80211_EXT_FEATURE_RADAR_BACKGROUND);
+		phy_features.ftm_responder = device_extended_features(phys.extended_features, NL80211_EXT_FEATURE_ENABLE_FTM_RESPONDER);
+		phy_features.radar_background = device_extended_features(phys.extended_features, NL80211_EXT_FEATURE_RADAR_BACKGROUND);
 		break;
 	}
 }


### PR DESCRIPTION

See: https://github.com/jow-/ucode/commit/373df7299c798071bd6e7566b33f807d31c8bf82
````
Sat Dec  7 23:01:18 2024 daemon.notice netifd: radio0 (4422): In device_capabilities(), file /usr/share/ucode/wifi/hostapd.uc, line 444, byte 19:
Sat Dec  7 23:01:18 2024 daemon.notice netifd: radio0 (4422):   called from function generate (/usr/share/ucode/wifi/hostapd.uc:470:32)
Sat Dec  7 23:01:18 2024 daemon.notice netifd: radio0 (4422):   called from function setup (/usr/share/ucode/wifi/hostapd.uc:544:22)
Sat Dec  7 23:01:18 2024 daemon.notice netifd: radio0 (4422):   called from function setup (./mac80211.sh:307:21)
Sat Dec  7 23:01:18 2024 daemon.notice netifd: radio0 (4422):   called from anonymous function (./mac80211.sh:342:14)
Sat Dec  7 23:01:18 2024 daemon.notice netifd: radio0 (4422):
Sat Dec  7 23:01:18 2024 daemon.notice netifd: radio0 (4422):  `        if (!phy || phy.wiphy != idx)`
Sat Dec  7 23:01:18 2024 daemon.notice netifd: radio0 (4422):   Near here --------------^
`````

