### PR TITLE
base-files: optimize sysfixtime

### DIFF
--- a/package/base-files/files/etc/init.d/sysfixtime
+++ b/package/base-files/files/etc/init.d/sysfixtime
@@ -1,5 +1,5 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2013-2014 OpenWrt.org
+# Copyright (C) 2013-2024 OpenWrt.org
 
 START=00
 STOP=90
@@ -9,12 +9,9 @@ HWCLOCK=/sbin/hwclock
 
 boot() {
 	hwclock_load
-	local maxtime="$(find_max_time)"
+	local maxtime="$(find_maxtime)"
 	local curtime="$(date +%s)"
-	if [ $curtime -lt $maxtime ]; then
-		date -s @$maxtime
-		hwclock_save
-	fi
+	[ $maxtime -gt $curtime ] && date -s @$maxtime && hwclock_save
 }
 
 start() {
@@ -26,19 +23,19 @@ stop() {
 }
 
 hwclock_load() {
-	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -s -u -f $RTC_DEV
+	[ -c "$RTC_DEV" -a -x "$HWCLOCK" ] && $HWCLOCK -u -s -f $RTC_DEV
 }
 
 hwclock_save(){
-	[ -e "$RTC_DEV" ] && [ -e "$HWCLOCK" ] && $HWCLOCK -w -u -f $RTC_DEV && \
+	[ -c "$RTC_DEV" -a -x "$HWCLOCK" ] && $HWCLOCK -u -w -f $RTC_DEV && \
 		logger -t sysfixtime "saved '$(date)' to $RTC_DEV"
 }
 
-find_max_time() {
-	local file newest
+find_maxtime() {
+	local file newest IFS=$'\n'
 
-	for file in $( find /etc -type f ) ; do
-		[ -z "$newest" -o "$newest" -ot "$file" ] && newest=$file
+	for file in $(find /etc); do
+		[ -z "$newest" -o "$file" -nt "$newest" ] && newest="$file"
 	done
 	[ "$newest" ] && date -r "$newest" +%s
 }


### PR DESCRIPTION
optimizes /etc/init.d/sysfixtime

boot
```
 *changed find_max_time into find_maxtime (for consistency)
 *changed -lt into -gt and swapped variables (find largest)
 *if date fails there is no need to save to hardware clock
```
hwclock_load&save
```
 *changed -e (file exists) RTC into -c (file is character special)
 *changed -e (file exists) HWCLOCK into -x (file with execute access)
 *merged both tests into one
```
find_maxtime
```
 *changed find_max_time into find_maxtime (for consistency)
 *set local IFS to newline, "luci-uploads" could have files with spaces
 *removed find 'type f' because file-deletion updates directory mtime
 *changed -ot into -nt and swapped variables (find newest)
```