### PR TITLE
lantiq: grow kernel partition Zyxel P-2812HNU-F1

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f1.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f1.dts
@@ -47,11 +47,11 @@
 			};
 			partition@60000 {
 				label = "kernel";
-				reg = <0x60000 0x300000>;
+				reg = <0x60000 0x500000>;
 			};
-			partition@360000 {
+			partition@560000 {
 				label = "ubi";
-				reg = <0x360000 0x7ca0000>;
+				reg = <0x560000 0x7aa0000>;
 			};
 		};
 	};

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -368,16 +368,17 @@ endef
 TARGET_DEVICES += netgear_dm200
 
 define Device/zyxel_p-2812hnu-f1
-  $(Device/dsa-migration)
   $(Device/NAND)
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := kernel and ubi partitions had to be resized. \
+  Upgrade manually using initramfs, and change u-boot environment to load 5MiB for uImage.
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := P-2812HNU
   DEVICE_VARIANT := F1
   BOARD_NAME := P2812HNUF1
   DEVICE_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls kmod-usb-dwc2 kmod-usb-ledtrig-usbport
-  KERNEL_SIZE := 3072k
+  KERNEL_SIZE := 5120k
   SUPPORTED_DEVICES += P2812HNUF1
-  DEFAULT := n
 endef
 TARGET_DEVICES += zyxel_p-2812hnu-f1
 

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/05_compat-version
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/05_compat-version
@@ -8,6 +8,10 @@
 board_config_update
 
 case "$(board_name)" in
+	zyxel,p-2812hnu-f1)
+		ucidef_set_compat_version "2.0"
+		;;
+
 	*)
 		ucidef_set_compat_version "1.1"
 		;;


### PR DESCRIPTION
Change partition table in dts file.
Change DEVICE_COMPAT_VERSION
Enable automatic build.

To take advantage of the bigger kernel partition,
the uboot environment has to be changed:
setenv nboot 'nand read 0x81000000 0x60000 0x500000; bootm 0x81000000' setenv bootcmd 'run nboot'
saveenv

Of course you need a u-boot capable of handling this. The u-boot discussed in this forum thread:
https://forum.openwrt.org/t/zyxel-p2812hnu-f1-u-boot/100281 should be able to handle kernels up to an uncompressed size of 16MiB.

When this patch is accepted, it would be be nice if it could also be applied to the 24.10 branch. At the moment there is no P2812HNU-F1 build in the rc's.