### PR TITLE
mediatek: filogic: Migrate wifi configuration device paths

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# This must run before 10-wifi-detect
+
+
+[ "${ACTION}" = "add" ] || return
+
+
+. /lib/functions.sh
+
+
+check_radio()
+{
+	local cfg="$1" to="$2"
+
+	config_get path "$cfg" path
+
+	[ "$path" = "$to" ] && PATH_EXISTS=true
+}
+
+do_migrate_radio()
+{
+	local cfg="$1" from="$2" to="$3"
+
+	config_get path "$cfg" path
+
+	[ "$path" = "$from" ] || return
+
+	uci set "wireless.${cfg}.path=${to}"
+	WIRELESS_CHANGED=true
+
+	logger -t wifi-migrate "Updated path of wireless.${cfg} from '${from}' to '${to}'"
+}
+
+migrate_radio()
+{
+	local from="$1" to="$2"
+
+	config_load wireless
+
+	# Check if there is already a section with the target path: In this case, the system
+	# was already upgraded to a version without this migration script before; better bail out,
+	# as we can't be sure we don't break more than we fix.
+	PATH_EXISTS=false
+	config_foreach check_radio wifi-device "$to"
+	$PATH_EXISTS && return
+
+	config_foreach do_migrate_radio wifi-device "$from" "$to"
+}
+
+
+WIRELESS_CHANGED=false
+
+case "$(board_name)" in
+*)
+	migrate_radio 'platform/18000000.wifi' 'platform/soc/18000000.wifi'
+	migrate_radio 'platform/18000000.wifi+1' 'platform/soc/18000000.wifi+1'
+    ;;
+esac
+
+$WIRELESS_CHANGED && uci commit wireless
+
+exit 0


### PR DESCRIPTION
The device path to the devices changed. Migrate the wifi configurations from the old path to the new one. This is needed to migrate Wireless configurations from OpenWrt 23.05 to OpenWrt 24.10.

This script is based on these two files:
target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate

Fixes: 0ef927472148 ("mediatek: filogic: move mt7981 on-SoC blocks to "soc" node in DT")
Fixes: https://github.com/openwrt/openwrt/issues/17174