### PR TITLE
image: allow creating a zstd-compressed squashfs rootfs

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -87,12 +87,15 @@ SQUASHFSOPT := -b $(SQUASHFS_BLOCKSIZE)
 SQUASHFSOPT += -p '/dev d 755 0 0' -p '/dev/console c 600 0 0 5 1'
 SQUASHFSOPT += $(if $(CONFIG_SELINUX),-xattrs,-no-xattrs)
 SQUASHFSCOMP := gzip
-LZMA_XZ_OPTIONS := -Xpreset 9 -Xe -Xlc 0 -Xlp 2 -Xpb 2
 ifeq ($(CONFIG_SQUASHFS_XZ),y)
   ifneq ($(filter arm x86 powerpc sparc,$(LINUX_KARCH)),)
     BCJ_FILTER:=-Xbcj $(LINUX_KARCH)
   endif
+  LZMA_XZ_OPTIONS := -Xpreset 9 -Xe -Xlc 0 -Xlp 2 -Xpb 2
   SQUASHFSCOMP := xz $(LZMA_XZ_OPTIONS) $(BCJ_FILTER)
+else ifeq ($(CONFIG_SQUASHFS_ZSTD),y)
+  ZSTD_OPTIONS := -Xcompression-level 19
+  SQUASHFSCOMP := zstd $(ZSTD_OPTIONS)
 endif
 
 JFFS2_BLOCKSIZE ?= 64k 128k

--- a/tools/squashfs4/Makefile
+++ b/tools/squashfs4/Makefile
@@ -27,6 +27,7 @@ define Host/Compile
 		XZ_SUPPORT=1 \
 		LZMA_XZ_SUPPORT=1 \
 		XZ_EXTENDED_OPTIONS=1 \
+		ZSTD_SUPPORT=1 \
 		EXTRA_CFLAGS="-I$(STAGING_DIR_HOST)/include" \
 		mksquashfs unsquashfs
 endef


### PR DESCRIPTION
Zstd decompresses much faster than xz, but it also requires large amounts of RAM. This is useful mostly for x86-64-based devices.

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>