### PR TITLE
kernel: modules: appletalk: add for Netatalk (backport 23.05)

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -42,6 +42,24 @@ endef
 $(eval $(call KernelPackage,atmtcp))
 
 
+define KernelPackage/appletalk
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
+  TITLE:=Appletalk protocol support
+  KCONFIG:= \
+        CONFIG_ATALK \
+        CONFIG_DEV_APPLETALK \
+        CONFIG_IPDDP=n
+  FILES:=$(LINUX_DIR)/net/appletalk/appletalk.ko
+  AUTOLOAD:=$(call AutoLoad,40,appletalk)
+endef
+
+define KernelPackage/appletalk/description
+  Kernel module for AppleTalk protocol.
+endef
+
+$(eval $(call KernelPackage,appletalk))
+
+
 define KernelPackage/bonding
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=Ethernet bonding driver


### PR DESCRIPTION
Netatalk v4 reintroduces AppleTalk and this module is required for layer 3 protocol support.

Module was removed in kernel 4.14 for OpenWrt 18.06 (commmit 14a0131, 22/02/2018). At the time nothing used it as Netatalk v3 did not support AppleTalk.

Not building ipddp feature/module like it was in the past, as recommended by upstream Netatalk maintainers.

Cherry pick: 5eb25dddb17fa3cf4958e91dfc9fc868c9eb03ac
Link: https://github.com/openwrt/openwrt/pull/16979

This is related (highly recommended but not mandatory) for PR to backport latest version of netatalk to 23.05 for (probably its last) service release.
Link: https://github.com/openwrt/packages/pull/25262