### PR TITLE
base-files: fix init.d/sysctl "&>-" bad file descriptor

### DIFF
--- a/package/base-files/files/etc/init.d/sysctl
+++ b/package/base-files/files/etc/init.d/sysctl
@@ -39,6 +39,6 @@ apply_defaults() {
 start() {
 	apply_defaults
 	for CONF in /etc/sysctl.d/*.conf /etc/sysctl.conf; do
-		[ -f "$CONF" ] && sysctl -e -p "$CONF" >&-
+		[ -f "$CONF" ] && sysctl -q -e -p "$CONF"
 	done
 }


### PR DESCRIPTION
Used the `-q` quiet option from sysctl to replace the redirect/close fd.
```
echo bug >&-
sh: write error: Bad file descriptor
```    

