### PR TITLE
ramips: add support for Qding QC202

### DIFF
--- a/target/linux/ramips/dts/mt7628an_qding_qc202.dts
+++ b/target/linux/ramips/dts/mt7628an_qding_qc202.dts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "qding,qc202", "mediatek,mt7628an-soc";
+	model = "Qding QC202";
+
+	leds {
+		compatible = "gpio-leds";
+
+		status_white_1 {
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_WHITE>;
+			function-enumerator = <1>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		status_white_2 {
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_WHITE>;
+			function-enumerator = <2>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		indicator_red {
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_INDICATOR;
+		};
+
+		indicator_green {
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+
+		relay {
+			gpio-export,name = "relay";
+			gpio-export,output = <0>;
+			gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "gpio";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+
+	spidev@1{
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "linux,spidev";
+		reg = <1>;
+		spi-max-frequency = <40000000>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&i2c {
+	status = "okay";
+
+	rfid@28 {
+		compatible = "mfrc522";
+		reg = <0x28>;
+	};
+
+	rtc@68 {
+		compatible = "dallas,ds1339";
+		reg = <0x68>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -522,6 +522,14 @@ define Device/oraybox_x1
 endef
 TARGET_DEVICES += oraybox_x1
 
+define Device/qding_qc202
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Qding
+  DEVICE_MODEL := QC202
+  DEVICE_PACKAGES := kmod-i2c-mt7628 kmod-rtc-ds1307 kmod-gpio-beeper kmod-spi-dev
+endef
+TARGET_DEVICES += qding_qc202
+
 define Device/rakwireless_rak633
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Rakwireless

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -21,6 +21,7 @@ ramips_setup_interfaces()
 	minew,g1-c|\
 	onion,omega2p|\
 	onion,omega2|\
+	qding,qc202|\
 	ravpower,rp-wd009|\
 	tama,w06|\
 	tplink,re200-v2|\

--- a/target/linux/ramips/mt76x8/target.mk
+++ b/target/linux/ramips/mt76x8/target.mk
@@ -4,7 +4,7 @@
 
 SUBTARGET:=mt76x8
 BOARDNAME:=MT76x8 based boards
-FEATURES+=usb ramdisk small_flash
+FEATURES+=usb ramdisk rtc small_flash
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES += kmod-mt7603 wpad-basic-mbedtls swconfig


### PR DESCRIPTION
This is a smart door lock device equipped with OpenWrt 14.07 OEM
modified version Qdwrt

The OEM has closed down, This commit is intended to maximize the
remaining value of these devices. It can flash OpenWrt to become
an AP

Specification:
- SoC: MediaTek MT7628NN
- Flash: 8 MB
- RAM: 64 MB
- Power: DC 5V - 25V
- Ethernet: 1 x RJ45 (10/100 Mbps)
- Wireless radio: 802.11n 2.4g-only
- On-Board LED:
  Status 1: GPIO/43 active-low
  Status 2: GPIO/44 active-low
  Power: AlwaysOn
- Button:
  WPS / RESET: GPIO/14  active-low
- Bluetooth: CC2541 via UART1 (ttyS1) and GPIO/26-29
- RFID: MF RC522 on I2C@28
- RTC: DS1339 on I2C@68
- Shell panel (via CON1 cable)
  - LED (Swipe card area):
        Green  GPIO/3  active-high
        Red     GPIO/11 active-high
  - Matrix keypad: (active-low)
 
|Cols⟍Rows| GPIO/20 | GPIO/21 | GPIO/19 |
|---------|---------|---------|---------|
|GPIO/24|    1     |   2   |      3      |
|GPIO/25|    4     |   5   |      6      |
|GPIO/22|    7     |   8   |      9      |
|GPIO/23| BACK |   0   | ENTER   |

- UART: 1 x UART on PCB - 57600 8N1
- GPIO Relay: GPIO/42 active-high
- GPIO Buzzer: GPIO/15 active-high

Warning:
The original firmware does not use the device tree.
This device tree is written based on the content of /sys/devices/platform
and has been tested

Note:
- On the device, matrix keypad rows actually are columns, and the columns actually are rows
- The key code of the CLEAR key of the matrix keypad is BACK in the original firmware.

Issue:
- No drivers in mainline kernel for RFID and Bluetooth.

Flash Instruction:
Using SSH/Telnet:
1. Connect the board to the computer via RJ45 Ethernet
2. Login 10.10.10.1 with root password "szqdingnet123" (SSH Port 22, Telnet Port 9900)
3. Download openwrt firmware on the computer.
4. Setup a http server on computer. And use wget download openwrt firmware from computer
5. Use command "mtd -r write openwrt-ramips-mt76x8-qding_qc202-squashfs-sysupgrade.bin firmware"
   to flash

Using U-Boot WebUI:
1. Configure PC with a static IP address 10.10.10.2/24.
2. Open http://10.10.10.1/
3. Use "mkqdimg -B qc202 -f openwrt-ramips-mt76x8-qding_qc202-squashfs-sysupgrade.bin" to
   make image.
4. Upload factory.bin via U-Boot WebUI.

Original Firmware Dump / More details:
https://blog.gov.cooking/archives/research-qianding-smart-locker-and-flash.html

Original U-Boot firmware image tools:
https://gitlab.com/CoiaPrant/mkqdimg
