### PR TITLE
[23.05] ipq40xx: make GL.iNet A1300 switch functional

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-gl-a1300.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-gl-a1300.dts
@@ -58,10 +58,11 @@
 			linux,code = <KEY_RESTART>;
 		};
 
-		switch {
-			label = "switch-button";
+		rfkill {
+			label = "WiFi on/off switch";
 			gpios = <&tlmm 0 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_SETUP>;
+			linux,code = <KEY_RFKILL>;
+			linux,input-type = <EV_SW>;
 		};
 	};
 


### PR DESCRIPTION
Set the physical switch to KEY_RFKILL, since its previous value (KEY_SETUP) is unsupported. This should also make the KEY_RESET button functional, by allowing the gpio-button-hotplug kmod to load.

Signed-off-by: Chris Jones <cmsj@tenshu.net>
Link: https://github.com/openwrt/openwrt/pull/16564
Signed-off-by: Robert Marko <robimarko@gmail.com>
Signed-off-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
(cherry picked from commit 83a04cd2b89f3bca2be3a4467b7ea710c7c6ba4f)

Fixes https://github.com/openwrt/openwrt/issues/17160