### PR TITLE
bcm27xx/bcm2712: add rp1 kmods

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -745,3 +745,16 @@ endef
 $(eval $(call KernelPackage,hwmon-adcxx))
 
 
+define KernelPackage/hwmon-rp1-adc
+  TITLE:=RP1 ADC driver
+  KCONFIG:=CONFIG_SENSORS_RP1_ADC
+  FILES:=$(LINUX_DIR)/drivers/hwmon/rp1-adc.ko
+  AUTOLOAD:=$(call AutoLoad,60,rp1_adc)
+  $(call AddDepends/hwmon,)
+endef
+
+define KernelPackage/hwmon-rp1-adc/description
+  RP1 ADC driver
+endef
+
+$(eval $(call KernelPackage,hwmon-rp1-adc))

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -584,6 +584,18 @@ endef
 $(eval $(call KernelPackage,mfd))
 
 
+define KernelPackage/rp1
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=RP1 wrapper
+  HIDDEN:=1
+  KCONFIG:=CONFIG_MFD_RP1
+  FILES:=$(LINUX_DIR)/drivers/mfd/rp1
+  AUTOLOAD:=$(call AutoLoad,10,rp1)
+endef
+
+$(eval $(call KernelPackage,rp1))
+
+
 define KernelPackage/mtdtests
   SUBMENU:=$(OTHER_MENU)
   TITLE:=MTD subsystem tests

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -201,7 +201,8 @@ define Device/rpi-5
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \
 	kmod-brcmfmac wpad-basic-mbedtls \
-	kmod-hwmon-pwmfan kmod-thermal
+	kmod-hwmon-pwmfan kmod-thermal \
+	hwmon-rp1-adc rp1
   IMAGE/sysupgrade.img.gz := boot-common | sdcard-img | gzip | append-metadata
   IMAGE/factory.img.gz := boot-common | sdcard-img | gzip
 endef


### PR DESCRIPTION
Attempt to add the following config options:
CONFIG_SENSORS_RP1_ADC=y
CONFIG_MFD_RP1=y
CONFIG_COMMON_CLK_RP1=y
CONFIG_PWM_RP1=y

And corresponding modules:
rp1
rp1_adc
rp1_pio