### PR TITLE
ipq807x: add support for TP-Link EAP620 HD v1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "git.alwaysSignOff": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "git.alwaysSignOff": true
+}

--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -39,6 +39,7 @@ linksys,mx8500)
 	;;
 netgear,sxr80|\
 netgear,sxs80|\
+tplink,eap620hd-v1|\
 tplink,eap660hd-v1)
 	idx="$(find_mtd_index 0:appsblenv)"
 	[ -n "$idx" ] && \

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -55,6 +55,7 @@ ALLWIFIBOARDS:= \
 	redmi_ax6 \
 	skspruce_wia3300-20 \
 	spectrum_sax1v1k \
+	tplink_eap620hd-v1 \
 	tplink_eap660hd-v1 \
 	wallys_dr40x9 \
 	xiaomi_ax3600 \
@@ -184,6 +185,7 @@ $(eval $(call generate-ipq-wifi-package,prpl_haze,prpl Haze))
 $(eval $(call generate-ipq-wifi-package,redmi_ax6,Redmi AX6))
 $(eval $(call generate-ipq-wifi-package,skspruce_wia3300-20,SKSpruce WIA3300-20))
 $(eval $(call generate-ipq-wifi-package,spectrum_sax1v1k,Spectrum SAX1V1K))
+$(eval $(call generate-ipq-wifi-package,tplink_eap620hd-v1,TP-Link EAP620 HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap660hd-v1,TP-Link EAP660 HD v1))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8070-eap620hd-v1.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8070-eap620hd-v1.dts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR BSD-2-Clause
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	model = "TP-Link EAP620 HD v1";
+	compatible = "tplink,eap620hd-v1", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+		ethernet0 = &dp6;
+		label-mac-device = &dp6;
+	};
+
+	chosen {
+		stdout-path = "serial0,115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status-blue {
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 42 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+	
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "qcom,qca8075-package";
+		reg = <0>;
+
+		qca8075_4: ethernet-phy@4 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <4>;
+		};
+	};
+};
+
+&dp6 {
+	status = "okay";
+	phy-handle = <&qca8075_4>;
+	label = "lan";
+};
+
+&switch {
+	status = "okay";
+	switch_lan_bmp = <ESS_PORT6>;
+	switch_mac_mode0 = <MAC_MODE_PSGMII>;
+	switch_mac_mode1 = <MAC_MODE_SGMII_CHANNEL0>;
+	switch_mac_mode2 = <MAC_MODE_SGMII_CHANNEL0>;
+
+	qcom,port_phyinfo {
+		port@6 {
+			phy_address = <4>;
+			port_id = <6>;
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+	qcom,ath11k-calibration-variant = "TP-Link-EAP620-HD-v1";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -346,6 +346,20 @@ define Device/spectrum_sax1v1k
 endef
 TARGET_DEVICES += spectrum_sax1v1k
 
+define Device/tplink_eap620hd-v1
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := TP-Link
+	DEVICE_MODEL := EAP620 HD
+	DEVICE_VARIANT := v1
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq8070
+	DEVICE_PACKAGES := ipq-wifi-tplink_eap620hd-v1
+	TPLINK_SUPPORT_STRING := SupportList:\r\nEAP620 HD(TP-Link|UN|AX1800-D):1.0\r\n
+endef
+TARGET_DEVICES += tplink_eap620hd-v1
+
 define Device/tplink_eap660hd-v1
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -60,6 +60,7 @@ ipq807x_setup_interfaces()
 	qnap,301w)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 10g-2" "10g-1"
 		;;
+	tplink,eap620hd-v1|\
 	tplink,eap660hd-v1)
 		ucidef_set_interface_lan "lan" "dhcp"
 		;;
@@ -92,6 +93,7 @@ ipq807x_setup_macs()
 			lan_mac=$(macaddr_add $label_mac 1)
 			wan_mac=$label_mac
 		;;
+		tplink,eap620hd-v1|\
 		tplink,eap660hd-v1)
 			label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
 			lan_mac=$label_mac

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -80,6 +80,7 @@ case "$FIRMWARE" in
 	spectrum,sax1v1k)
 		caldata_extract_mmc "0:ART" 0x1000 0x20000
 		;;
+	tplink,eap620hd-v1|\
 	tplink,eap660hd-v1)
 		caldata_from_file "/tmp/factory_data/radio" 0 0x20000
 		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)

--- a/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
@@ -7,6 +7,7 @@ preinit_mount_factory_data() {
 	. /lib/functions/system.sh
 
 	case $(board_name) in
+	tplink,eap620hd-v1|\
 	tplink,eap660hd-v1)
 		mtd_path=$(find_mtd_chardev "factory_data")
 		ubiattach --dev-path="$mtd_path" --devn=1

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -214,6 +214,7 @@ platform_do_upgrade() {
 		CI_DATAPART="rootfs_data"
 		emmc_do_upgrade "$1"
 		;;
+	tplink,eap620hd-v1|\
 	tplink,eap660hd-v1)
 		tplink_do_upgrade "$1"
 		;;


### PR DESCRIPTION
Specifications:
* SoC: Qualcomm IPQ8070A (64-bit Quad-core Arm Cortex-A53 @ 1.4 GHz)
* Memory: 2x ESMT M15T4G16256A-DEBG2G (1 GiB DDR3-1866 13-13-13)
* Serial Port: 3v3 TTL 115200n8
* Wi-Fi: QCA5054 (4x4 5 GHz 802.11ax)
* Wi-Fi: QCN5024 (2x4 2.4 GHz 802.11b/g/n/ax)
* Ethernet: QCA8072 (10/100/1000BASE-T)
* Flash: Winbond W29N01HZSINF (128 MiB)
* LEDs: 1x Blue Status (GPIO 42 Active High)
* Buttons: 1x Reset (GPIO 50 Active Low)

Installation Instructions (Serial+TFTP):
1. Solder 4 pin header to JP1 and bridge pads of R58 and R62.
2. Connect 3V3 TTL port to TX, RX, and GND, which are positions 1, 2, and 3 respectively. Be sure to crossover TX and RX.
3. Copy RAM firmware
`openwrt-qualcommax-ipq807x-tplink_eap620hd-v1-initramfs-uImage.itb` 
to a TFTP server's root that is in the same subnet as your AP.
5. Power up the AP hold `Ctrl+B` in the serial console (115200n8) until autoboot is halted.
6. Run the following commands in the U-boot prompt: 
`# setenv serverip <TFTP server addr>`
`# setenv ipaddr <addr of AP>` 
`# tftpboot 0x44000000 openwrt-qualcommax-ipq807x-tplink_eap620hd-v1-initramfs-uImage.itb`
`# bootm` 
You may need to type `Ctrl+C` and Enter before running these commands to clear invisible characters from the buffer.
8. Run the following command in a terminal to copy the sysupgrade image to be installed (check IP address): 
`$ scp -O openwrt-qualcommax-ipq807x-tplink_eap620hd-v1-squashfs-sysupgrade.bin root@192.168.1.1:/tmp/`
10. Activate the OpenWrt serial console and run the following commands: 
`# cd /tmp # sysupgrade -n openwrt-qualcommax-ipq807x-tplink_eap620hd-v1-squashfs-sysupgrade.bin`
12. The AP will reboot and OpenWrt will be successfully installed.
