### PR TITLE
base-files: re-run uci-defaults if the first boot after FW-upgrade is…

### DIFF
--- a/package/base-files/files/lib/preinit/80_mount_root
+++ b/package/base-files/files/lib/preinit/80_mount_root
@@ -46,6 +46,8 @@ do_mount_root() {
 		missing_lines /tmp/group /etc/group >> /etc/group
 		missing_lines /tmp/shadow /etc/shadow >> /etc/shadow
 		rm /tmp/passwd /tmp/group /tmp/shadow
+
+		cp /rom/etc/uci-defaults/* /etc/uci-defaults/
 		# Prevent configuration corruption on a power loss
 		sync
 	}


### PR DESCRIPTION
… interrupted by power outage.

When the firmware is updated and the system reboots for the first time, the uci-defaults/* scripts are executed and subsequently removed by S10boot. If a power outage occurs at this point and the system reboots, the /sysupgrade.tgz file remains intact.

As a result,during the pre-init phase (preinit/80_mount_root), the tar xzf /sysupgrade.tgz command runs again. This action inadvertently restores the configurations to their pre-upgrade state, effectively undoing any changes applied by the initial run of uci-defaults/* scripts. This leads to configuration inconsistencies and potential system issues.
