### PR TITLE
lantiq: use regulator for USB GPIO

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zte_h201l.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zte_h201l.dts
@@ -96,16 +96,23 @@
 			gpio-export,output = <1>;
 			gpios = <&gpio 38 GPIO_ACTIVE_HIGH>;
 		};
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio 28 GPIO_ACTIVE_HIGH>;
-		};
 		wifi {
 			gpio-export,name = "wifi";
 			gpio-export,output = <1>;
 			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
 		};
+	};
+
+	usb_phy: regulator-usb-phy {
+		compatible = "regulator-fixed";
+
+		regulator-name = "USB_PHY";
+
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpios = <&gpio 28 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
 
 	usb_vbus: regulator-usb-vbus {
@@ -166,6 +173,7 @@
 
 &usb_phy0 {
 	status = "okay";
+	phy-supply = <&usb_phy>;
 };
 
 


### PR DESCRIPTION
One is already present. The other one can be implemented in terms of the PHY.

ping @hauke @blogic 