### PR TITLE
x86: rename Mellanox Spectrum network interfaces

### DIFF
--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -771,6 +771,27 @@ ucidef_add_wlan() {
 	ucidef_wlan_idx="$((ucidef_wlan_idx + 1))"
 }
 
+ucidef_set_interface_netdev_range() {
+	local interface="$1"
+	local base_netdev="$2"
+	local start="$3"
+	local stop="$4"
+	local netdevs
+	local i
+
+	if [ "$stop" -ge "$start" ]; then
+		i="$start"
+		netdevs="$base_netdev$i"
+
+		while [ "$i" -lt "$stop" ]; do
+			i=$((i + 1))
+			netdevs="$netdevs $base_netdev$i"
+		done
+
+		ucidef_set_interface "$interface" device "$netdevs"
+	fi
+}
+
 board_config_update() {
 	json_init
 	[ -f ${CFG} ] && json_load "$(cat ${CFG})"

--- a/package/kernel/linux/files/hotplug-mlxsw-spectrum-port-names.sh
+++ b/package/kernel/linux/files/hotplug-mlxsw-spectrum-port-names.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$ACTION" = "add" ]; then
+	read -r board_name < "/tmp/sysinfo/board_name"
+
+	if [[ "$board_name" = "mellanox-technologies-ltd-msn*" ]]; then
+		read -r port_name < "/sys/class/net/$DEVICENAME/phys_port_name"
+		[ -n "$port_name" ] && ip link set "$DEVICENAME" name "sw$port_name"
+	fi
+fi

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1972,6 +1972,13 @@ define KernelPackage/mlxsw-spectrum/description
   Spectrum/Spectrum-2/Spectrum-3/Spectrum-4 Ethernet Switch ASICs.
 endef
 
+define KernelPackage/mlxsw-spectrum/install
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/net
+	$(INSTALL_DATA) \
+		./files/hotplug-mlxsw-spectrum-port-names.sh \
+		$(1)/etc/hotplug.d/net/10-mlxsw-spectrum-port-names
+endef
+
 $(eval $(call KernelPackage,mlxsw-spectrum))
 
 

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1259,7 +1259,7 @@ define KernelPackage/e1000e
   DEPENDS:=@PCIE_SUPPORT +kmod-ptp
   KCONFIG:=CONFIG_E1000E
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/e1000e/e1000e.ko
-  AUTOLOAD:=$(call AutoProbe,e1000e)
+  AUTOLOAD:=$(call AutoProbe,e1000e,1)
   MODPARAMS.e1000e:= \
     IntMode=1 \
     InterruptThrottleRate=4,4,4,4,4,4,4,4

--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -67,6 +67,27 @@ micro-computer-hk-tech-limited-ms-a2)
 	ucidef_set_network_device_path "sfp2" "pci0000:00/0000:00:02.1/0000:05:00.1"
 	ucidef_set_interface_lan "lan1 lan2 sfp1 sfp2"
 	;;
+mellanox-technologies-ltd-msn2100)
+	ucidef_set_network_device_path "mgmt" "pci0000:00/0000:00:14.0"
+	ucidef_set_interface_lan "mgmt "
+	ucidef_set_interface_netdev_range "lan" "swp" "1" "16"
+	;;
+mellanox-technologies-ltd-msn2700)
+	ucidef_set_network_device_path "mgmt0" "pci0000:00/0000:00:19.0"
+	ucidef_set_network_device_path "mgmt1" "pci0000:00/0000:00:1c.6/0000:06:00.0"
+	ucidef_set_interface_lan "mgmt0 mgmt1 "
+	ucidef_set_interface_netdev_range "lan" "swp" "1" "32"
+	;;
+mellanox-technologies-ltd-msn3420)
+	ucidef_set_network_device_path "mgmt" "pci0000:00/0000:00:1c.7/0000:09:00.0"
+	ucidef_set_interface_lan "mgmt "
+	ucidef_set_interface_netdev_range "lan" "swp" "1" "60"
+	;;
+mellanox-technologies-ltd-msn3700)
+	ucidef_set_network_device_path "mgmt" "pci0000:00/0000:00:1c.7/0000:09:00.0"
+	ucidef_set_interface_lan "mgmt "
+	ucidef_set_interface_netdev_range "lan" "swp" "1" "32"
+	;;
 pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;


### PR DESCRIPTION
This PR focuses on correctly labeling the `Mellanox Spectrum SN2100`, `SN2700`, `SN3420`, and `SN3700` Switches. Currently, the interfaces of those switches are all labeled `eth*`. Their order doesn't match the faceplate and is different for each model.

The management port(s) are renamed during boot based on their PCI address.
The boot flag is set for the `e1000e` driver to make this possible for the `SN2700` management ports.

However, this is not enough for the QSFP ports because they support port splitting via breakout cables during runtime. After such ports are split, their port naming begins again with `eth*`, and the same is true after they are unsplit again.
A hotplug script is used here that reads from the sysfs file `phys_port_name`, which contains `p1`, `p2`, `p3`, ... for unsplit ports and `p1s0`, `p1s1`, `p1s2` for split ports.

For the default network config, the management and QSFP ports are put into the `br-lan` bridge.
I added a uci function `ucidef_set_interface_netdev_range` to add all QSFP ports to the bridge more comfortably.