### PR TITLE
mediatek: update openembed som7981 support 

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -366,6 +366,26 @@ endef
 $(eval $(call KernelPackage,crypto-hmac))
 
 
+define KernelPackage/crypto-hw-atmel
+  TITLE:=Microchip / Atmel ECC/SHA/RNG hw accelerator
+  DEPENDS:=+kmod-i2c-core +kmod-crypto-ecdh +kmod-crypto-sha1 \
+	+kmod-crypto-sha256 +kmod-lib-crc16 +kmod-random-core
+  KCONFIG:= \
+	CONFIG_CRYPTO_HW=y \
+	CONFIG_CRYPTO_DEV_ATMEL_I2C \
+	CONFIG_CRYPTO_DEV_ATMEL_ECC \
+	CONFIG_CRYPTO_DEV_ATMEL_SHA204A
+  FILES:= \
+	$(LINUX_DIR)/drivers/crypto/atmel-i2c.ko \
+	$(LINUX_DIR)/drivers/crypto/atmel-ecc.ko \
+	$(LINUX_DIR)/drivers/crypto/atmel-sha204a.ko
+  AUTOLOAD:=$(call AutoLoad,09,atmel-i2c atmel-ecc atmel-sha204a)
+  $(call AddDepends/crypto)
+endef
+
+$(eval $(call KernelPackage,crypto-hw-atmel))
+
+
 define KernelPackage/crypto-hw-ccp
   TITLE:=AMD Cryptographic Coprocessor
   DEPENDS:= \

--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -2,7 +2,8 @@ set_preinit_iface() {
 	case $(board_name) in
 	cudy,m3000-v1|\
 	cudy,tr3000-v1|\
-	glinet,gl-mt3000)
+	glinet,gl-mt3000|\
+	openembed,som7981)
 		ip link set eth1 up
 		ifname=eth1
 		;;

--- a/target/linux/mediatek/dts/mt7981b-openembed-som7981.dts
+++ b/target/linux/mediatek/dts/mt7981b-openembed-som7981.dts
@@ -12,9 +12,10 @@
 	compatible = "openembed,som7981", "mediatek,mt7981";
 
 	aliases {
-		led-boot = &wlan2g_led;
-		led-failsafe = &wlan2g_led;
-		led-upgrade = &wlan2g_led;
+		led-boot = &act_led;
+		led-failsafe = &act_led;
+		led-running = &act_led;
+		led-upgrade = &act_led;
 		serial0 = &uart0;
 	};
 
@@ -26,6 +27,11 @@
 		reg = <0 0x40000000 0 0x40000000>;
 	};
 
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+	};
+
 	gpio-keys {
 		compatible = "gpio-keys";
 
@@ -34,12 +40,6 @@
 			linux,code = <KEY_RESTART>;
 			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
 		};
-
-		button-wps {
-			label = "wps";
-			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
-		};
 	};
 
 	gpio-leds {
@@ -47,28 +47,27 @@
 
 		led-0 {
 			function = LED_FUNCTION_LAN;
-			color = <LED_COLOR_ID_AMBER>;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
 		};
 
 		led-1 {
 			function = LED_FUNCTION_LAN;
-			color = <LED_COLOR_ID_GREEN>;
+			color = <LED_COLOR_ID_AMBER>;
 			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
 		};
 
-		wlan2g_led: led-2 {
-			function = LED_FUNCTION_WLAN_2GHZ;
-			color = <LED_COLOR_ID_RED>;
+		led-2 {
+			function = LED_FUNCTION_PANIC;
+			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
+			panic-indicator;
 		};
 
-		led-3 {
-			function = LED_FUNCTION_WLAN_5GHZ;
+		act_led: led-3 {
+			function = LED_FUNCTION_ACTIVITY;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
 		};
 	};
 };
@@ -97,14 +96,38 @@
 	};
 };
 
+&i2c0 {
+	clock-frequency = <400000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+
+	eeprom@50 {
+		compatible = "atmel,24c64";
+		reg = <0x50>;
+		page-size = <32>;
+	};
+
+	rtc@51 {
+		compatible = "nxp,pcf8563";
+		reg = <0x51>;
+		#clock-cells = <0>;
+	};
+
+	crypto@60 {
+		compatible = "atmel,atecc508a";
+		reg = <0x60>;
+	};
+};
+
 &mdio_bus {
 	phy0: ethernet-phy@5 {
 		reg = <5>;
 		compatible = "ethernet-phy-ieee802.3-c45";
 		phy-mode = "2500base-x";
 		reset-gpios = <&pio 14 GPIO_ACTIVE_LOW>;
-		reset-assert-us = <10000>;
-		reset-deassert-us = <50000>;
+		reset-assert-us = <15000>;
+		reset-deassert-us = <68000>;
 		realtek,aldps-enable;
 	};
 };
@@ -184,6 +207,13 @@
 };
 
 &pio {
+	i2c0_pins: i2c0-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+
 	spi0_flash_pins: spi0-pins {
 		mux {
 			function = "spi";
@@ -202,9 +232,42 @@
 			mediatek,pull-down-adv = <0>;
 		};
 	};
+
+	uart1_pins: uart1-pins {
+		mux {
+			function = "uart";
+			groups = "uart1_3";
+		};
+	};
+
+	uart2_pins: uart2-pins {
+		mux {
+			function = "uart";
+			groups = "uart2_0_tx_rx";
+		};
+	};
+
+	wwan_rst_h: wwan-rst-h {
+		pins = "GPIO_WPS";
+		drive-strength = <8>;
+		mediatek,pull-down-adv = <0>;
+		output-low;
+	};
 };
 
 &uart0 {
+	status = "okay";
+};
+
+&uart1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart1_pins>;
+	status = "okay";
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart2_pins>;
 	status = "okay";
 };
 
@@ -220,8 +283,16 @@
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 	status = "okay";
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_a 0>;
+		nvmem-cell-names = "mac-address";
+	};
 };
 
 &xhci {
+	pinctrl-names = "default";
+	pinctrl-0 = <&wwan_rst_h>;
 	status = "okay";
 };

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -71,8 +71,8 @@ nradio,c8-668gl)
 	ucidef_set_led_netdev "5g" "5G" "blue:indicator-0" "eth1" "link"
 	;;
 openembed,som7981)
-	ucidef_set_led_netdev "lanact" "LANACT" "green:lan" "eth1" "rx tx"
-	ucidef_set_led_netdev "lanlink" "LANLINK" "amber:lan" "eth1" "link"
+	ucidef_set_led_netdev "lanact" "LANACT" "amber:lan" "eth1" "rx tx"
+	ucidef_set_led_netdev "lanlink" "LANLINK" "green:lan" "eth1" "link"
 	;;
 openwrt,one)
 	ucidef_set_led_netdev "wanact" "WANACT" "mdio-bus:0f:green:wan" "eth0" "rx tx"

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -141,9 +141,6 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo "$hw_mac_addr" > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $hw_mac_addr > /sys${DEVPATH}/macaddress
 		;;
-	openembed,som7981)
-		[ "$PHYNBR" = "1" ] && cat /sys/class/net/eth0/address > /sys${DEVPATH}/macaddress
-		;;
 	qihoo,360t7)
 		addr=$(mtd_get_mac_ascii factory lanMac)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1215,7 +1215,10 @@ define Device/openembed_som7981
   DEVICE_MODEL := SOM7981
   DEVICE_DTS := mt7981b-openembed-som7981
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
+	kmod-crypto-hw-atmel kmod-eeprom-at24 kmod-gpio-beeper kmod-rtc-pcf8563 \
+	kmod-usb-net-cdc-mbim kmod-usb-net-qmi-wwan kmod-usb-serial-option \
+	kmod-usb3 uqmi
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048


### PR DESCRIPTION
The board has been redesigned due to previous hardware bugs
(with other reasons maybe).

Changes in new board:
- Added a gpio beeper
- Added a Atmel i2c eeprom
- Added a Atmel i2c ECC accelerator
- Added a Philips RTC module
- Added two RS485
- Removed WPS button
- Replaced USB3 port with M.2 B-key for LTE modules
- Swapped GbE LEDs gpio

Also assigned wifi mac with nvmem binding, added iface setup for failsafe,
increased phy assert time for rtl8221b, and updated LED labels.

Keeping compatibility for old version is not necessary here as only
few samples were sent to those interested in it.