### PR TITLE
dropbear: configure hostkey auto-generation

### DIFF
--- a/package/network/services/dropbear/files/dropbear.init
+++ b/package/network/services/dropbear/files/dropbear.init
@@ -80,7 +80,20 @@ hk_config()
 # $1 - host key file name
 hk_config__keyfile() { hk_config keyfile "$1" ; }
 
-ktype_all='ed25519 ecdsa rsa'
+hk_enabled_ktypes() {
+	local ktypes ktype values value ret
+
+	ktypes=$($PROG --help 2>&1|awk '/\s+- /{print $2}')
+	values=$(uci get dropbear.@dropbear[-1].HostKeyTypes 2>/dev/null)
+	for ktype in $ktypes ; do
+		for value in $values ; do
+			[ $value = $ktype ] && ret="${ret}${ret:+ }${ktype}"
+		done
+	done
+	echo ${ret:=$ktypes}
+}
+
+ktype_all=$(hk_enabled_ktypes)
 
 hk_generate_as_needed()
 {


### PR DESCRIPTION
Config option "HostKeyTypes" specifies which hostkeys to auto-generate for dropbear.

`uci set dropbear.@dropbear[-1].HostKeyTypes='ed25519'`

HostKeyTypes absent:
```
# rm /etc/dropbear/dropbear_*
# service dropbear restart
# ls /etc/dropbear
authorized_keys            dropbear_ed25519_host_key  dropbear_rsa_host_key
```

HostKeyTypes present:
```
# uci set dropbear.@dropbear[-1].HostKeyTypes='ed25519'
# rm /etc/dropbear/dropbear_*
# service dropbear restart
# ls /etc/dropbear
authorized_keys            dropbear_ed25519_host_key
``` 
