### PR TITLE
ramips: rt3050: fix wrong compatible

### DIFF
--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -296,12 +296,12 @@
 	};
 
 	usbphy: usbphy {
-		compatible = "ralink,rt3050-usbphy";
+		compatible = "ralink,rt3352-usbphy";
 		#phy-cells = <0>;
 
 		ralink,sysctl = <&sysc>;
-		resets = <&sysc 22>;
-		reset-names = "host";
+		resets = <&sysc 22>, <&sysc 25>;
+		reset-names = "host", "device";
 	};
 
 	ethernet: ethernet@10100000 {


### PR DESCRIPTION
In the process of upstreaming the local phy driver back in 2017, it seems rt3050.dtsi was left out when updating the compatible string.

ping @blogic 