### PR TITLE
ramips: use USB PHY regulators

### DIFF
--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
@@ -67,16 +67,17 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <0>;
-			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &gpio1 {

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
@@ -64,16 +64,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &gpio1 {

--- a/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
+++ b/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
@@ -35,16 +35,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usbpower {
-			gpio-export,name = "usbpower";
-			gpio-export,output = <1>;
-			gpios = <&gpio2 5 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio2 5 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &gpio2 {

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
@@ -62,15 +62,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-		usb-power {
-			gpio-export,name="usb-power";
-			gpio-export,output=<1>;
-			gpios = <&gpio2 5 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio2 5 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &gpio2 {

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5761.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5761.dts
@@ -37,16 +37,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usbpower {
-			gpio-export,name = "usbpower";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &ehci {

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
@@ -42,16 +42,17 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usbpower {
-			gpio-export,name = "usbpower";
-			gpio-export,output = <0>;
-			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &ehci {

--- a/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
+++ b/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
@@ -54,16 +54,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usbpower {
-			gpio-export,name = "usbpower";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
+++ b/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
@@ -60,16 +60,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb-power {
-			gpio-export,name = "usb-power";
-			gpio-export,output = <1>;
-			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &gpio1 {

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
@@ -95,16 +95,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		power_usb {
-			gpio-export,name = "power_usb1";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &gpio1 {

--- a/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
+++ b/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
@@ -72,15 +72,13 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb_power {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
 
 	rtl8367rb {
@@ -88,6 +86,10 @@
 		realtek,extif = <7 1 0 1 1 1 1 1 1 2>;
 		mii-bus = <&mdio0>;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
@@ -66,16 +66,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb_power {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &gpio1 {

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
@@ -66,16 +66,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb_power {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &gpio1 {

--- a/target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_tr1200-v1.dts
@@ -56,15 +56,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
@@ -65,16 +65,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
+++ b/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
@@ -45,16 +45,18 @@
 		};
 	};
 
-	gpio-export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb-power {
-			gpio-export,name = "usb-power";
-			gpio-export,output = <1>;
-			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &sdhci {

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5761a.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5761a.dts
@@ -32,16 +32,17 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb_power {
-			gpio-export,name = "usb_power";
-			gpio-export,output = <0>;
-			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7628an_kroks_kndrt31r16.dts
+++ b/target/linux/ramips/dts/mt7628an_kroks_kndrt31r16.dts
@@ -20,16 +20,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb1power {
-			gpio-export,name = "usb1power";
-			gpio-export,output = <1>;
-			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &esw {

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
@@ -81,16 +81,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usbpower {
-			gpio-export,name = "usbpower";
-			gpio-export,output = <1>;
-			gpios = <&gpio 39 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 39 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -69,15 +69,13 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usbpower {
-			gpio-export,name = "usbpower";
-			gpio-export,output = <1>;
-			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
 
 	virtual_flash {
@@ -96,6 +94,10 @@
 			};
 		};
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/rt3052_accton_wr6202.dts
+++ b/target/linux/ramips/dts/rt3052_accton_wr6202.dts
@@ -94,16 +94,17 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <0>;
-			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &state_default {

--- a/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
+++ b/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
@@ -53,16 +53,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &gpio1 {

--- a/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
+++ b/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
@@ -129,23 +129,24 @@
 		realtek,extif = <9 1 0 1 1 1 1 1 1 2>;
 	};
 
-	/*
-	 * Unclear if this is the correct gpio setup; the USB ports are
-	 * unpopulated on a stock BR-6475nD, even though the hardware exists
-	 * and the headers are there.
-	 */
-	/*
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb {
-			gpio-export,name="usb";
-			gpio-export,output=<0>;
-			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		/*
+		 * Unclear if this is the correct gpio setup; the USB ports are
+		 * unpopulated on a stock BR-6475nD, even though the hardware exists
+		 * and the headers are there.
+		 */
+		 status = "disabled";
 	};
-	*/
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &state_default {

--- a/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
+++ b/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
@@ -44,16 +44,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &gpio1 {

--- a/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
+++ b/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
@@ -40,16 +40,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &gpio1 {

--- a/target/linux/ramips/dts/rt5350_dlink_dir-320-b1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-320-b1.dts
@@ -57,18 +57,25 @@
 		compatible = "gpio-export";
 		#size-cells = <0>;
 
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
-		};
-
 		root_hub {
 			gpio-export,name = "root_hub";
 			gpio-export,output = <1>;
 			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/rt5350_hame_mpr-a1.dts
+++ b/target/linux/ramips/dts/rt5350_hame_mpr-a1.dts
@@ -44,18 +44,25 @@
 		compatible = "gpio-export";
 		#size-cells = <0>;
 
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
-		};
-
 		root_hub {
 			gpio-export,name = "root_hub";
 			gpio-export,output = <1>;
 			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/rt5350_hame_mpr-a2.dts
+++ b/target/linux/ramips/dts/rt5350_hame_mpr-a2.dts
@@ -44,18 +44,25 @@
 		compatible = "gpio-export";
 		#size-cells = <0>;
 
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
-		};
-
 		root_hub {
 			gpio-export,name = "root_hub";
 			gpio-export,output = <1>;
 			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/rt5350_tenda_3g150b.dts
+++ b/target/linux/ramips/dts/rt5350_tenda_3g150b.dts
@@ -40,16 +40,18 @@
 		};
 	};
 
-	gpio_export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
-		};
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &spi0 {

--- a/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
+++ b/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
@@ -45,18 +45,25 @@
 		compatible = "gpio-export";
 		#size-cells = <0>;
 
-		usb {
-			gpio-export,name = "usb";
-			gpio-export,output = <1>;
-			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
-		};
-
 		root_hub {
 			gpio-export,name = "root_hub";
 			gpio-export,output = <1>;
 			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
+	reg_usb_power: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+};
+
+&usbphy {
+	phy-supply = <&reg_usb_power>;
 };
 
 &spi0 {


### PR DESCRIPTION
While the generic E/OHCI drivers do not support regulators, the phy does. This means something like uhubctl can disable the PHY and hence the GPIO.

ping @DragonBluep @blogic 