### PR TITLE
ath79: fix ath9k calibration data size for AR9132

### DIFF
--- a/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
+++ b/target/linux/ath79/dts/ar9132_buffalo_wzr-hp-g300nh.dtsi
@@ -145,7 +145,7 @@
 					#size-cells = <1>;
 
 					cal_art_11000: calibration@11000 {
-						reg = <0x11000 0x440>;
+						reg = <0x11000 0xeb8>;
 					};
 
 					macaddr_art_1120c: macaddr@1120c {

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
@@ -104,7 +104,7 @@
 					#size-cells = <1>;
 
 					cal_art_1000: calibration@1000 {
-						reg = <0x1000 0x440>;
+						reg = <0x1000 0xeb8>;
 					};
 				};
 			};

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
@@ -131,7 +131,7 @@
 					#size-cells = <1>;
 
 					cal_art_1000: calibration@1000 {
-						reg = <0x1000 0x440>;
+						reg = <0x1000 0xeb8>;
 					};
 				};
 			};

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v2.dts
@@ -153,7 +153,7 @@
 					#size-cells = <1>;
 
 					cal_art_1000: calibration@1000 {
-						reg = <0x1000 0x440>;
+						reg = <0x1000 0xeb8>;
 					};
 				};
 			};


### PR DESCRIPTION
For ath9k NICs older than AR9287, The eeprom size is 0xeb8.

Tested-by: @BlueMax. If you want a public `Tested-by:` tag on the commit message, please provide your name and email.

Please cherry-pick it to branch v24.