### PR TITLE
base-files: enable get_mac_ascii() to handle redundant strings

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -66,7 +66,7 @@ get_mac_ascii() {
 	local key="$2"
 	local mac_dirty
 
-	mac_dirty=$(strings "$part" | sed -n 's/^'"$key"'=//p' | head -n 1)
+	mac_dirty=$(strings "$part" | tr -d ' \t' | sed -n 's/^'"$key"'=//p' | head -n 1)
 
 	# "canonicalize" mac
 	[ -n "$mac_dirty" ] && macaddr_canonicalize "$mac_dirty"

--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -66,7 +66,7 @@ get_mac_ascii() {
 	local key="$2"
 	local mac_dirty
 
-	mac_dirty=$(strings "$part" | sed -n 's/^'"$key"'=//p')
+	mac_dirty=$(strings "$part" | sed -n 's/^'"$key"'=//p' | head -n 1)
 
 	# "canonicalize" mac
 	[ -n "$mac_dirty" ] && macaddr_canonicalize "$mac_dirty"


### PR DESCRIPTION
The function get_mac_ascii() will fail when there are two or more same MAC address variable names in the mtd partition. Only retain the first variable to workaround this rare situation.

Tested-by: @huytran123. If you want a public Tested-by: tag on the commit message, please provide your name and email.

Please cherry-pick it to all stable branch.
