### PR TITLE
hostapd: fix call to hostapd reload

### DIFF
--- a/package/network/services/hostapd/files/hostapd.uc
+++ b/package/network/services/hostapd/files/hostapd.uc
@@ -899,7 +899,7 @@ let main_obj = {
 			let phy_list = req.args.phy ? [ phy_name(req.args.phy, req.args.radio) ] : keys(hostapd.data.config);
 			for (let phy_name in phy_list) {
 				let phy = hostapd.data.config[phy_name];
-				let config = iface_load_config(phy.phy, radio, phy.orig_file);
+				let config = iface_load_config(phy.phy, phy.radio_idx, phy.orig_file);
 				iface_set_config(phy_name, config);
 			}
 


### PR DESCRIPTION
access to undeclared variable radio In [anonymous function](), file /usr/share/hostap/hostapd.uc, line 830, byte 45

related issue https://github.com/freifunk-gluon/gluon/issues/3391