### PR TITLE
netfilter: add kmod-nfnetlink-ct{helper,timeout}

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1239,6 +1239,13 @@ config KERNEL_MPTCP_IPV6
 	default KERNEL_MPTCP
 endif
 
+config KERNEL_NF_CONNTRACK_TIMEOUT
+	bool "Per-connection connection tracking timeout"
+	default y if !SMALL_FLASH
+	help
+	   Select this option to enable support for per-connection conntrack timeouts.
+	   Increases the (uncompressed) size of nf_conntrack.ko by ~8kB.
+
 #
 # NFS related symbols
 #

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -1048,6 +1048,40 @@ endef
 $(eval $(call KernelPackage,nfnetlink-queue))
 
 
+define KernelPackage/nfnetlink-cthelper
+  TITLE:=Netfilter User space conntrack helpers
+  FILES:=$(LINUX_DIR)/net/netfilter/nfnetlink_cthelper.ko
+  KCONFIG:=CONFIG_NF_CT_NETLINK_HELPER
+  AUTOLOAD:=$(call AutoProbe,nfnetlink_cthelper)
+  $(call AddDepends/nfnetlink,+kmod-nfnetlink-queue +kmod-nf-conntrack-netlink)
+endef
+
+define KernelPackage/nfnetlink-cthelper/description
+ Kernel modules support for a netlink-based connection tracking
+ userspace helpers interface
+endef
+
+$(eval $(call KernelPackage,nfnetlink-cthelper))
+
+
+define KernelPackage/nfnetlink-cttimeout
+  TITLE:=Netfilter conntrack expectation timeout
+  FILES:=$(LINUX_DIR)/net/netfilter/nfnetlink_cttimeout.ko
+  KCONFIG:=CONFIG_NF_CT_NETLINK_TIMEOUT
+  AUTOLOAD:=$(call AutoProbe,nfnetlink_cttimeout)
+  $(call AddDepends/nfnetlink,+kmod-nf-conntrack +kmod-nf-conntrack-timeout @KERNEL_NF_CONNTRACK_TIMEOUT)
+endef
+
+define KernelPackage/nfnetlink-cttimeout/description
+ Kernel modules support for a netlink-based connection tracking
+ userspace timeout interface
+
+ Requires CONFIG_NF_CONNTRACK_TIMEOUT (only enabled for non-small flash devices)
+endef
+
+$(eval $(call KernelPackage,nfnetlink-cttimeout))
+
+
 define KernelPackage/nf-conntrack-netlink
   TITLE:=Connection tracking netlink interface
   FILES:=$(LINUX_DIR)/net/netfilter/nf_conntrack_netlink.ko


### PR DESCRIPTION
Add kmod-nfnetlink-ct{helper,timeout} to allow handling firewall rules in userspace (together with conntrackd). The timeout module allows specifying custom expiration rules.

This is useful for network protocols with esoteric behaviours (like Steam, AirPlay, Chromecast) to allow firewall rules to be made specific by snooping on the discovery and response messages.

Compile Tested: Both on aarch64/mt7622/Linksys E8450
Run Tested: nfnetlink-cthelper on aarch64/mt7622/Linksys E8450