### PR TITLE
ath79: fix tl-wa eth1 mac

### DIFF
--- a/target/linux/ath79/dts/ar7240_tplink_tl-wa.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wa.dtsi
@@ -17,7 +17,7 @@
 };
 
 &eth1 {
-	nvmem-cells = <&macaddr_uboot_1fc00>;
+	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };
 


### PR DESCRIPTION
This is using mac-base and so a 0 needs to be added.

ping @DragonBluep @hauke @robimarko 

Needs a backport to 24.10