### PR TITLE
ath79: document that calibration size is correct

### DIFF
--- a/target/linux/ath79/dts/ar7241_ubnt_unifi-ap.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi-ap.dtsi
@@ -92,6 +92,7 @@
 };
 
 &wifi {
+	compatible = "pci168c,002e";
 	nvmem-cells = <&calibration_art_1000>;
 	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -159,6 +159,7 @@
 	status = "okay";
 
 	ath9k: wifi@0,0 {
+		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
 		#gpio-cells = <2>;
 		gpio-controller;


### PR DESCRIPTION
These use 0x440 as the size, which is unusual for ar72xx