### PR TITLE
ath79: tplink,deco-s4-v2: use nvmem for cal

### DIFF
--- a/target/linux/ath79/dts/qca9563_tplink_deco-s4-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_deco-s4-v2.dts
@@ -121,6 +121,10 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
 					precal_art_5000: pre-calibration@5000 {
 						reg = <0x5000 0x2f20>;
 					};
@@ -146,5 +150,6 @@
 &wmac {
 	status = "okay";
 
-	qca,no-eeprom;
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -58,11 +58,6 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env mac_addr)
 		;;
-	tplink,deco-s4-v2)
-		caldata_extract "art" 0x1000 0x440
-		base_mac=$(mtd_get_mac_encrypted_deco $(find_mtd_part config))
-		ath9k_patch_mac $(macaddr_add $base_mac 1)
-		;;
 	*)
 		caldata_die "board $board is not supported yet"
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -110,7 +110,8 @@ case "$board" in
 		base_mac=$(mtd_get_mac_encrypted_deco $(find_mtd_part config))
 		[ "$PHYNBR" -eq 0 ] && \
 			macaddr_add $base_mac 2 > /sys${DEVPATH}/macaddress
-
+		[ "$PHYNBR" -eq 1 ] && \
+			macaddr_add $base_mac 1 > /sys${DEVPATH}/macaddress
 		;;
 	trendnet,tew-823dru)
 		# set the 2.4G interface mac address to LAN MAC


### PR DESCRIPTION
Userspace handling is deprecated. MAC address stuff needs to remain handled in userspace as it's encrypted. Maybe an NVMEM driver can be written in the future...

ping @DragonBluep @robimarko @hauke 