### PR TITLE
ath79: use nvmem for wrong 3e0 cal size

### DIFF
--- a/target/linux/ath79/dts/ar7241_netgear_wnr2200-16m.dts
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2200-16m.dts
@@ -50,6 +50,10 @@
 			macaddr_art_6: macaddr@6 {
 				reg = <0x6 0x6>;
 			};
+
+			cal_art_1000: calibration@1000 {
+				reg = <0x1000 0x3d8>;
+			};
 		};
 	};
 };
@@ -65,6 +69,6 @@
 };
 
 &ath9k {
-	nvmem-cells = <&macaddr_art_0 1>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_art_0 1>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 };

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2200-8m.dts
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2200-8m.dts
@@ -50,6 +50,10 @@
 			macaddr_art_6: macaddr@6 {
 				reg = <0x6 0x6>;
 			};
+
+			cal_art_1000: calibration@1000 {
+				reg = <0x1000 0x3d8>;
+			};
 		};
 	};
 };
@@ -65,6 +69,6 @@
 };
 
 &ath9k {
-	nvmem-cells = <&macaddr_art_0 1>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_art_0 1>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
 };

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2200.dtsi
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2200.dtsi
@@ -173,7 +173,6 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,002e";
 		reg = <0x0000 0 0 0 0>;
-		qca,no-eeprom;
 		#gpio-cells = <2>;
 		gpio-controller;
 

--- a/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
@@ -128,6 +128,16 @@
 				reg = <0x7f0000 0x10000>;
 				label = "art";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x3d8>;
+					};
+				};
 			};
 		};
 	};
@@ -141,9 +151,8 @@
 		reg = <0x0000 0 0 0 0>;
 		#gpio-cells = <2>;
 		gpio-controller;
-		qca,no-eeprom;
-		nvmem-cells = <&macaddr_uboot_1fc00 0>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_uboot_1fc00 0>, <&cal_art_1000>;
+		nvmem-cell-names = "mac-address", "calibration";
 	};
 };
 

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi-ap.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi-ap.dtsi
@@ -83,7 +83,7 @@
 					};
 
 					calibration_art_1000: calibration@1000 {
-						reg = <0x1000 0x440>;
+						reg = <0x1000 0x3d8>;
 					};
 				};
 			};
@@ -92,6 +92,7 @@
 };
 
 &wifi {
+	compatible = "pci168c,002e";
 	nvmem-cells = <&calibration_art_1000>;
 	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -159,6 +159,7 @@
 	status = "okay";
 
 	ath9k: wifi@0,0 {
+		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
 		#gpio-cells = <2>;
 		gpio-controller;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -83,11 +83,6 @@ case "$FIRMWARE" in
 	meraki,mr12)
 		caldata_extract "art" 0x11000 0xeb8
 		;;
-	netgear,wnr2200-8m|\
-	netgear,wnr2200-16m|\
-	tplink,tl-wr842n-v1)
-		caldata_extract "art" 0x1000 0x3e0
-		;;
 	ubnt,powerbridge-m|\
 	ubnt,rocket-m)
 		caldata_extract "art" 0x1000 0x1000

--- a/target/linux/bmips/dts/bcm6328-dlink-dsl-2750b-b1.dts
+++ b/target/linux/bmips/dts/bcm6328-dlink-dsl-2750b-b1.dts
@@ -180,7 +180,7 @@
 					#size-cells = <1>;
 
 					cal_data_1000: calibration@1000 {
-						reg = <0x1000 0x440>;
+						reg = <0x1000 0x3d8>;
 					};
 				};
 			};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7312.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7312.dts
@@ -136,6 +136,10 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					cal_ath9k_cal_985: calibration@985 {
+						reg = <0x985 0x3d8>;
+					};
+
 					macaddr_ath9k_cal_a91: macaddr@a91 {
 						compatible = "mac-base";
 						reg = <0xa91 0x6>;
@@ -180,8 +184,9 @@
 	reset-gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
 
 	wifi@0,0 {
-		compatible = "pci0,0";
+		compatible = "pci168c,002d";
 		reg = <0x7000 0 0 0 0>;
-		qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:00:0e.0.bin */
+		nvmem-cells = <&cal_ath9k_cal_985>;
+		nvmem-cell-names = "calibration";
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7320.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7320.dts
@@ -163,6 +163,10 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					cal_ath9k_cal_985: calibration@985 {
+						reg = <0x985 0x3d8>;
+					};
+
 					macaddr_ath9k_cal_a91: macaddr@a91 {
 						compatible = "mac-base";
 						reg = <0xa91 0x6>;
@@ -206,9 +210,10 @@
 	reset-gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
 
 	wifi@0,0 {
-		compatible = "pci0,0";
+		compatible = "pci168c,002d";
 		reg = <0x7000 0 0 0 0>;
-		qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:00:0e.0.bin */
+		nvmem-cells = <&cal_ath9k_cal_985>;
+		nvmem-cell-names = "calibration";
 	};
 };
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360-v2.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360-v2.dts
@@ -49,7 +49,7 @@
 					#size-cells = <1>;
 
 					cal_urlader_985: cal@985 {
-						reg = <0x985 0x440>;
+						reg = <0x985 0x3d8>;
 					};
 
 					macaddr_urlader_a91: macaddr@a91 {
@@ -94,7 +94,7 @@
 };
 
 &wifi {
-	/delete-property/ qca,no-eeprom;
+	compatible = "pci168c,002e";
 	nvmem-cells = <&cal_urlader_985>;
 	nvmem-cell-names = "calibration";
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360sl.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360sl.dts
@@ -49,6 +49,10 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					cal_urlader_985: cal@985 {
+						reg = <0x985 0x3d8>;
+					};
+
 					macaddr_urlader_a91: macaddr@a91 {
 						compatible = "mac-base";
 						reg = <0xa91 0x6>;
@@ -88,4 +92,10 @@
 
 &phy1 {
 	reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+};
+
+&wifi {
+	compatible = "pci168c,002e";
+	nvmem-cells = <&cal_urlader_985>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
@@ -127,3 +127,8 @@
 &phy1 {
 	reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
 };
+
+&wifi {
+	compatible = "pci168c,0030";
+	qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:01:00.0.bin */
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
@@ -155,10 +155,8 @@
 		#address-cells = <2>;
 		device_type = "pci";
 
-		wifi: wifi@168c,002e {
-			compatible = "pci168c,002e";
+		wifi: wifi@0,0 {
 			reg = <0 0 0 0 0>;
-			qca,no-eeprom; /* load from ath9k-eeprom-pci-0000:01:00.0.bin */
 		};
 	};
 };

--- a/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/xrx200/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -19,9 +19,6 @@ case "$FIRMWARE" in
 			avm,fritz3390)
 				caldata_extract_reverse "urlader" 0x2546 0x440
 				;;
-			avm,fritz7360sl)
-				caldata_extract "urlader" 0x985 0x1000
-				;;
 			avm,fritz7412|\
 			avm,fritz7430)
 				/usr/bin/fritz_cal_extract -i 1 -s 0x1e000 -e 0x207 -l 5120 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader") || \

--- a/target/linux/lantiq/xway/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
+++ b/target/linux/lantiq/xway/base-files/etc/hotplug.d/firmware/12-ath9k-eeprom
@@ -45,9 +45,6 @@ case "$FIRMWARE" in
 				caldata_extract "calibration" 0xf000 0x1000
 				ath9k_patch_mac_crc $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) 2) 0x20c
 				;;
-			avm,fritz7312|avm,fritz7320)
-				caldata_extract "urlader" 0x985 0x1000
-				;;
 			*)
 				caldata_die "board $board is not supported yet"
 				;;


### PR DESCRIPTION
These three devices use AR9287 chips, which have a calibration size of 440.

ping @DragonBluep @robimarko @hauke