### PR TITLE
x86:Fix Model shows "Default String" issue in Luci overview page.

### DIFF
--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -15,7 +15,8 @@ do_sysinfo_x86() {
 		case "$vendor" in
 		empty | \
 		System\ manufacturer | \
-		To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\.)
+		To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\. | \
+		Default\ [sS]tring)
 			continue
 			;;
 		esac
@@ -27,7 +28,8 @@ do_sysinfo_x86() {
 		case "$vendor:$product" in
 		?*:empty | \
 		?*:System\ Product\ Name | \
-		?*:To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\.)
+		?*:To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\. | \
+		?*:Default\ [sS]tring)
 			continue
 			;;
 		"PC Engines:APU")


### PR DESCRIPTION
Before:
![56c4cae5-adce-4400-b016-690f2f8de76e](https://github.com/user-attachments/assets/0c88ea2e-6bc7-4719-8282-79674a992a1b)

After:
![03df3117-5867-46dc-a9fd-6be689265f2a](https://github.com/user-attachments/assets/9c3e2dd4-9ebb-4db9-bff5-6d52a0053860)

