### PR TITLE
kernel: generic: add pending patch

### DIFF
--- a/target/linux/generic/pending-6.6/791-tg3-Fix-DMA-allocations-on-57766-devices.patch
+++ b/target/linux/generic/pending-6.6/791-tg3-Fix-DMA-allocations-on-57766-devices.patch
@@ -1,0 +1,31 @@
+From f992b15965177e2f280fb6f41f292214f9a6f8d5 Mon Sep 17 00:00:00 2001
+From: Pavan Chebbi <pavan.chebbi@broadcom.com>
+Date: Tue, 10 Dec 2024 03:28:31 -0800
+Subject: [PATCH] tg3: Fix DMA allocations on 57766 devices
+
+The coherent DMA mask of 31b may not be accepted if
+the DMA mask is configured to use higher memories of
+64b. Set the DMA mask also to lower 32b for 57766
+devices.
+
+Fixes: 614f4d166eee ("tg3: Set coherent DMA mask bits to 31 for BCM57766 chipsets")
+Reported-By: Rui Salvaterra <rsalvaterra@gmail.com>
+Signed-off-by: Pavan Chebbi <pavan.chebbi@broadcom.com>
+---
+ drivers/net/ethernet/broadcom/tg3.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/broadcom/tg3.c
++++ b/drivers/net/ethernet/broadcom/tg3.c
+@@ -17731,8 +17731,10 @@ static int tg3_init_one(struct pci_dev *
+ 	} else
+ 		persist_dma_mask = dma_mask = DMA_BIT_MASK(64);
+ 
+-	if (tg3_asic_rev(tp) == ASIC_REV_57766)
++	if (tg3_asic_rev(tp) == ASIC_REV_57766) {
++		dma_mask = DMA_BIT_MASK(32);
+ 		persist_dma_mask = DMA_BIT_MASK(31);
++	}
+ 
+ 	/* Configure DMA attributes. */
+ 	if (dma_mask > DMA_BIT_MASK(32)) {


### PR DESCRIPTION
At the request of rsalvaterra, add this patch to fix an issue affecting tg3 ethernet interfaces[1].

1. https://github.com/openwrt/openwrt/pull/17271#issuecomment-2543836518