### PR TITLE
kernel : Fix setup of flash chips which must be unlocked before use.

### DIFF
--- a/target/linux/generic/pending-6.6/436-mtd-spi-earlier-mtd-setup.patch
+++ b/target/linux/generic/pending-6.6/436-mtd-spi-earlier-mtd-setup.patch
@@ -1,0 +1,20 @@
+--- a/drivers/mtd/spi-nor/core.c
++++ b/drivers/mtd/spi-nor/core.c
+@@ -3540,14 +3540,14 @@
+ 	if (ret)
+ 		return ret;
+ 
++	/* No mtd_info fields should be used up to this point. */
++	spi_nor_set_mtd_info(nor);
++
+ 	/* Send all the required SPI flash commands to initialize device */
+ 	ret = spi_nor_init(nor);
+ 	if (ret)
+ 		return ret;
+ 
+-	/* No mtd_info fields should be used up to this point. */
+-	spi_nor_set_mtd_info(nor);
+-
+ 	dev_info(dev, "%s (%lld Kbytes)\n", info->name,
+ 			(long long)mtd->size >> 10);
+ 

--- a/target/linux/generic/pending-6.6/436-mtd-spi-earlier-mtd-setup.patch
+++ b/target/linux/generic/pending-6.6/436-mtd-spi-earlier-mtd-setup.patch
@@ -1,6 +1,6 @@
 --- a/drivers/mtd/spi-nor/core.c
 +++ b/drivers/mtd/spi-nor/core.c
-@@ -3540,14 +3540,14 @@
+@@ -3532,14 +3532,14 @@ int spi_nor_scan(struct spi_nor *nor, co
  	if (ret)
  		return ret;
  


### PR DESCRIPTION
Setup the mtd information for spi nor flash before calling running the nor setup.

The current code assumes the nor setup doesnt make reference to the mtd information. There's even
a comment to this effect. However, at least when flash chips must be unlocked, this isn't true.
Consequently, the unlock code will fail because it makes reference to uninitialized mtd information. This failure
is silent because the bad mtd information claims the flash is 0 bytes long, and so there is nothing to unlock.

This patch moves the mtd initialization before the nor setup, so the mtd info is available.

This fix has been tested on two different Ubiquiti devices - the Rocket AC Lite and the Rocket M5 XW. These use the mx25l12805d and mx25l6405d Macronix flash chips respectively.  Previously these devices had failed to operate correctly as it was not possible for any persistent changes to be made once the factory build had been installed. With this change these devices behave correctly.

See https://github.com/openwrt/openwrt/issues/17285 for the original issue.

Signed-off-by: Tim Wilkinson <tim.j.wilkinson@gmail.com>