### PR TITLE
qualcommax: fix usb regulator supply for RT-AX89X

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rt-ax89x.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rt-ax89x.dts
@@ -365,7 +365,7 @@
 &qusb_phy_0 {
 	status = "okay";
 
-	vdda-phy-supply = <&usb0_vbus>;
+	vdd-supply = <&usb0_vbus>;
 };
 
 &ssphy_1 {
@@ -375,7 +375,7 @@
 &qusb_phy_1 {
 	status = "okay";
 
-	vdda-phy-supply = <&usb1_vbus>;
+	vdd-supply = <&usb1_vbus>;
 };
 
 &usb_0 {


### PR DESCRIPTION
The qusb_phy node looks for the following supply:
  "vdd", "vdda-pll", "vdda-phy-dpdm"
And ssphy node looks for the following supply:
  "vdda-phy", "vdda-pll"
So fix the usb regulator supply for RT-AX89X.