### PR TITLE
apk: disable tests

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git
@@ -60,7 +60,8 @@ MESON_COMMON_ARGS = \
 	-Dlua_version=5.1 \
 	-Ddefault_library=static \
 	-Durl_backend=wget \
-	-Dzstd=false
+	-Dzstd=false \
+	-Dtests=disabled
 
 MESON_HOST_ARGS += \
 	$(MESON_COMMON_ARGS) \

--- a/package/system/apk/patches/0001-openwrt-move-layer-db-to-temp-folder.patch
+++ b/package/system/apk/patches/0001-openwrt-move-layer-db-to-temp-folder.patch
@@ -10,7 +10,7 @@ Signed-off-by: Paul Spooren <mail@aparcar.org>
 
 --- a/src/database.c
 +++ b/src/database.c
-@@ -1631,7 +1631,7 @@ const char *apk_db_layer_name(int layer)
+@@ -1624,7 +1624,7 @@ const char *apk_db_layer_name(int layer)
  {
  	switch (layer) {
  	case APK_DB_LAYER_ROOT: return "lib/apk/db";

--- a/package/system/apk/patches/0002-meson-add-tests-option.patch
+++ b/package/system/apk/patches/0002-meson-add-tests-option.patch
@@ -1,0 +1,52 @@
+From a6180e4cfa1a98d361ffdce9e48857504997fbe9 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 3 Dec 2024 18:12:58 -0800
+Subject: [PATCH] meson: add tests option
+
+Allows disabling tests when not desired.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ meson_options.txt     |  1 +
+ test/meson.build      | 10 +++++++---
+ test/unit/meson.build |  2 +-
+ 3 files changed, 9 insertions(+), 4 deletions(-)
+
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -6,6 +6,7 @@ option('docs', description: 'Build manpa
+ option('help', description: 'Build help into apk binaries, needs lua', type: 'feature', value: 'auto')
+ option('lua', description: 'Build luaapk (lua bindings)', type: 'feature', value: 'auto')
+ option('lua_version', description: 'Lua version to build against', type: 'string', value: '5.3')
++option('tests', description: 'Build tests', type: 'feature', value: 'auto')
+ option('url_backend', description: 'URL backend', type: 'combo', choices: ['libfetch', 'wget'], value: 'libfetch')
+ option('uvol_db_target', description: 'Default target for uvol database layer', type: 'string')
+ option('zstd', description: 'Build with zstd support', type: 'boolean', value: true)
+--- a/test/meson.build
++++ b/test/meson.build
+@@ -1,10 +1,14 @@
++enum_sh = find_program('enum.sh', required: get_option('tests'))
++solver_sh = find_program('solver.sh', required: get_option('tests'))
++
++if not enum_sh.found() or not solver_sh.found()
++	subdir_done()
++endif
++
+ cur_dir = meson.current_source_dir()
+ env = environment()
+ env.set('APK', apk_exe.full_path())
+ 
+-enum_sh = files('enum.sh')
+-solver_sh = files('solver.sh')
+-
+ subdir('unit')
+ 
+ foreach t : run_command(enum_sh, 'shell', check: true).stdout().strip().split(' ')
+--- a/test/unit/meson.build
++++ b/test/unit/meson.build
+@@ -1,4 +1,4 @@
+-cmocka_dep = dependency('cmocka', required: false)
++cmocka_dep = dependency('cmocka', required: get_option('tests'))
+ 
+ if cmocka_dep.found()
+ 


### PR DESCRIPTION
Currently if the host system has cmocka installed it will leak the host path and try to use the host cmocka and build tests.

This will obviously fail, so backport upstream commit allowing disabling of tests and disable building them.

Fixes: openwrt/packages#25456
