### PR TITLE
ipq40xx-generic: fix EN WS-AP3915i label-mac and BLOCKSIZE

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -202,6 +202,9 @@ ipq40xx_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;
+	extreme-networks,ws-ap3915i)
+		label_mac="$(mtd_get_mac_ascii CFG1 ethaddr)"
+		;;
 	ezviz,cs-w3-wd1200g-eup)
 		label_mac=$(mtd_get_mac_binary "ART" 0x6)
 		;;

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -542,7 +542,6 @@ define Device/extreme-networks_ws-ap3915i
 	DEVICE_MODEL := WS-AP3915i
 	IMAGE_SIZE := 30080k
 	SOC := qcom-ipq4029
-	BLOCKSIZE := 128k
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 TARGET_DEVICES += extreme-networks_ws-ap3915i


### PR DESCRIPTION
the label-mac on eth0 should be used.
The blocksize is too high, resulting in forgetting the config on sysupgrade
