### PR TITLE
firewall4: allow firewall4 configuration override

### DIFF
--- a/package/network/config/firewall4/Makefile
+++ b/package/network/config/firewall4/Makefile
@@ -42,6 +42,9 @@ endef
 
 define Package/firewall4/install
 	$(CP) -a $(PKG_BUILD_DIR)/root/* $(1)/
+	$(if $(wildcard ./files/firewall.config),
+		$(INSTALL_CONF) ./files/firewall.config $(1)/etc/config/firewall
+	)
 endef
 
 define Build/Compile


### PR DESCRIPTION
Since firewall4 was introduced, in order to make changes to default configuration developers need to edit firewall file hosted in staging_dir. This change allows developers to edit default firewall configuration directly from core repository, preventing editions to file in staging.
