### PR TITLE
busybox: Fix hexdump applet with upstream patch

### DIFF
--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=busybox
 PKG_VERSION:=1.37.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_FLAGS:=essential
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2

--- a/package/utils/busybox/patches/001-fix-non-x86-build.patch
+++ b/package/utils/busybox/patches/001-fix-non-x86-build.patch
@@ -1,7 +1,5 @@
-Index: busybox-1.37.0/libbb/hash_md5_sha.c
-===================================================================
---- busybox-1.37.0.orig/libbb/hash_md5_sha.c
-+++ busybox-1.37.0/libbb/hash_md5_sha.c
+--- a/libbb/hash_md5_sha.c
++++ b/libbb/hash_md5_sha.c
 @@ -1313,7 +1313,9 @@ unsigned FAST_FUNC sha1_end(sha1_ctx_t *
  	hash_size = 8;
  	if (ctx->process_block == sha1_process_block64

--- a/package/utils/busybox/patches/002-upstream-fix-hexdump.patch
+++ b/package/utils/busybox/patches/002-upstream-fix-hexdump.patch
@@ -1,0 +1,49 @@
+From 87e60dcf0f7ef917b73353d8605188a420bd91f9 Mon Sep 17 00:00:00 2001
+From: Natanael Copa <ncopa@alpinelinux.org>
+Date: Mon, 28 Oct 2024 15:26:21 +0100
+Subject: hexdump: fix regression with -n4 -e '"%u"'
+
+Fix bug introduced in busybox 1.37.0 that broke kernel builds.
+
+Fixes commit e2287f99fe6f (od: for !DESKTOP, match output more closely
+to GNU coreutils 9.1, implement -s)
+
+function                                             old     new   delta
+rewrite                                              967     976      +9
+
+Signed-off-by: Natanael Copa <ncopa@alpinelinux.org>
+Signed-off-by: Denys Vlasenko <vda.linux@googlemail.com>
+---
+ libbb/dump.c            | 6 ++++--
+ testsuite/hexdump.tests | 6 ++++++
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+--- a/libbb/dump.c
++++ b/libbb/dump.c
+@@ -198,9 +198,11 @@ static NOINLINE void rewrite(priv_dumper
+ 				if (!e)
+ 					goto DO_BAD_CONV_CHAR;
+ 				pr->flags = F_INT;
+-				if (e > int_convs + 1) /* not d or i? */
+-					pr->flags = F_UINT;
+ 				byte_count_str = "\010\004\002\001";
++				if (e > int_convs + 1) { /* not d or i? */
++					pr->flags = F_UINT;
++					byte_count_str++;
++				}
+ 				goto DO_BYTE_COUNT;
+ 			} else
+ 			if (strchr(int_convs, *p1)) { /* %d etc */
+--- a/testsuite/hexdump.tests
++++ b/testsuite/hexdump.tests
+@@ -82,4 +82,10 @@ testing "hexdump -e /2 %d" \
+ "\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f"\
+ "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff"\
+ 
++testing "hexdump -n4 -e '\"%u\"'" \
++	"hexdump -n4 -e '\"%u\"'" \
++	"12345678" \
++	"" \
++	"\x4e\x61\xbc\x00AAAA"
++
+ exit $FAILCOUNT


### PR DESCRIPTION
cc @hauke 

Fix the hexdump applet's formatting with certain format types by applying the upstream fix for 1.37.0. The fix has been applied to the busybox main branch, but has not yet been backported to the 1.37.0 (that is unchanged since 1.37.0 release)

Also refresh patches.

As busybox 1.37.0 is also in our 24.10 release branch, this should be cherry-picked also for that.

Reference to:

- https://lists.busybox.net/pipermail/busybox/2024-October/date.html

Now they applied a fix, but not yet accepted to 1.37.xxx

- https://git.busybox.net/busybox/commit/?id=87e60dcf0f7ef917b73353d8605188a420bd91f9
- https://lists.busybox.net/pipermail/busybox/2024-December/091044.html

(also https://forum.openwrt.org/t/snapshot-format-failure-in-busybox-hexdump-output/218839 )


Tested with ipq806x/R7800:

```
root@router1:~# apk list -I | grep busy
busybox-1.37.0-r3 arm_cortex-a15_neon-vfpv4 {feeds/base/utils/busybox} (GPL-2.0) [installed]

root@router1:~# echo -n "0123456789" | hexdump -v -e "\"%08x\""
000000300000003400000038

--------

root@router1:~# apk list -I | grep busy
busybox-1.37.0-r4 arm_cortex-a15_neon-vfpv4 {feeds/base/utils/busybox} (GPL-2.0) [installed]

root@router1:~# echo -n "0123456789" | hexdump -v -e "\"%08x\""
333231303736353400003938
```
compared to Ubuntu hexdump:
```
$ echo -n "0123456789" | hexdump -v -e "\"%08x\""
333231303736353400003938
```

