### PR TITLE
Added support for Rockhip FriendlyElec NanoPC T6 LTS

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -256,7 +256,8 @@ define U-Boot/nanopc-t6-rk3588
   $(U-Boot/rk3588/Default)
   NAME:=NanoPC T6
   BUILD_DEVICES:= \
-    friendlyarm_nanopc-t6
+    friendlyarm_nanopc-t6 \
+    friendlyarm_nanopc-t6-lts
 endef
 
 define U-Boot/rock5b-rk3588

--- a/package/boot/uboot-rockchip/patches/106-rockchip-add-friendlyelec-nanopc-t6-lts.patch
+++ b/package/boot/uboot-rockchip/patches/106-rockchip-add-friendlyelec-nanopc-t6-lts.patch
@@ -1,0 +1,150 @@
+From 7cec3e701940064b2cfc0cf8b80ff24c391c55ec Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Thu, 17 Oct 2024 20:00:27 +0000
+Subject: [PATCH] rockchip: rk3588-nanopc-t6: Add support for NanoPC-T6 LTS
+
+Update defconfig to enable features included in pending upstream DT and
+implement board_fit_config_name_match() to load correct DT for LTS and
+non-LTS version of the NanoPC-T6.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Reviewed-by: Kever Yang <kever.yang@rock-chips.com>
+---
+ arch/arm/dts/rk3588-nanopc-t6-u-boot.dtsi     |  5 ++
+ board/friendlyelec/nanopc-t6-rk3588/Makefile  |  3 +
+ .../nanopc-t6-rk3588/nanopc-t6-rk3588.c       | 59 +++++++++++++++++++
+ configs/nanopc-t6-rk3588_defconfig            | 12 ++++
+ 4 files changed, 79 insertions(+)
+ create mode 100644 board/friendlyelec/nanopc-t6-rk3588/Makefile
+ create mode 100644 board/friendlyelec/nanopc-t6-rk3588/nanopc-t6-rk3588.c
+
+--- a/arch/arm/dts/rk3588-nanopc-t6-u-boot.dtsi
++++ b/arch/arm/dts/rk3588-nanopc-t6-u-boot.dtsi
+@@ -11,6 +11,11 @@
+ 	bootph-some-ram;
+ };
+ 
++&saradc {
++	bootph-pre-ram;
++	vdd-microvolts = <1800000>;
++};
++
+ &sfc {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&fspim1_pins>;
+--- /dev/null
++++ b/board/friendlyelec/nanopc-t6-rk3588/Makefile
+@@ -0,0 +1,3 @@
++# SPDX-License-Identifier: GPL-2.0+
++
++obj-y += nanopc-t6-rk3588.o
+--- /dev/null
++++ b/board/friendlyelec/nanopc-t6-rk3588/nanopc-t6-rk3588.c
+@@ -0,0 +1,59 @@
++// SPDX-License-Identifier: GPL-2.0+
++
++#include <adc.h>
++#include <env.h>
++#include <linux/errno.h>
++#include <linux/kernel.h>
++
++#define HW_ID_CHANNEL	5
++
++struct board_model {
++	unsigned int low;
++	unsigned int high;
++	const char *fdtfile;
++};
++
++static const struct board_model board_models[] = {
++	{  348,  528, "rockchip/rk3588-nanopc-t6.dtb" },
++	{ 1957, 2137, "rockchip/rk3588-nanopc-t6-lts.dtb" },
++};
++
++static const struct board_model *get_board_model(void)
++{
++	unsigned int val;
++	int i, ret;
++
++	ret = adc_channel_single_shot("adc@fec10000", HW_ID_CHANNEL, &val);
++	if (ret)
++		return NULL;
++
++	for (i = 0; i < ARRAY_SIZE(board_models); i++) {
++		unsigned int min = board_models[i].low;
++		unsigned int max = board_models[i].high;
++
++		if (min <= val && val <= max)
++			return &board_models[i];
++	}
++
++	return NULL;
++}
++
++int rk_board_late_init(void)
++{
++	const struct board_model *model = get_board_model();
++
++	if (model)
++		env_set("fdtfile", model->fdtfile);
++
++	return 0;
++}
++
++int board_fit_config_name_match(const char *name)
++{
++	const struct board_model *model = get_board_model();
++
++	if (model && !strcmp(name, model->fdtfile))
++		return 0;
++
++	return -EINVAL;
++}
+--- a/configs/nanopc-t6-rk3588_defconfig
++++ b/configs/nanopc-t6-rk3588_defconfig
+@@ -31,6 +31,7 @@ CONFIG_SPL_PAD_TO=0x7f8000
+ CONFIG_SPL_SPI_LOAD=y
+ CONFIG_SYS_SPI_U_BOOT_OFFS=0x60000
+ CONFIG_SPL_ATF=y
++CONFIG_CMD_ADC=y
+ CONFIG_CMD_GPIO=y
+ CONFIG_CMD_GPT=y
+ CONFIG_CMD_I2C=y
+@@ -42,13 +43,20 @@ CONFIG_CMD_REGULATOR=y
+ # CONFIG_SPL_DOS_PARTITION is not set
+ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_OF_LIVE=y
++CONFIG_OF_LIST="rockchip/rk3588-nanopc-t6 rockchip/rk3588-nanopc-t6-lts"
+ CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_SPL_DM_SEQ_ALIAS=y
+ CONFIG_SPL_REGMAP=y
+ CONFIG_SPL_SYSCON=y
++CONFIG_SPL_ADC=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_ADC=y
+ CONFIG_SPL_CLK=y
+ CONFIG_ROCKCHIP_GPIO=y
+ CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_LED=y
++CONFIG_LED_GPIO=y
+ CONFIG_MISC=y
+ CONFIG_SUPPORT_EMMC_RPMB=y
+ CONFIG_MMC_DW=y
+@@ -69,12 +77,16 @@ CONFIG_PHY_ROCKCHIP_INNO_USB2=y
+ CONFIG_PHY_ROCKCHIP_NANENG_COMBOPHY=y
+ CONFIG_PHY_ROCKCHIP_USBDP=y
+ CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_RK8XX=y
+ CONFIG_PWM_ROCKCHIP=y
+ CONFIG_SPL_RAM=y
+ CONFIG_BAUDRATE=1500000
+ CONFIG_DEBUG_UART_SHIFT=2
+ CONFIG_SYS_NS16550_MEM32=y
+ CONFIG_ROCKCHIP_SFC=y
++CONFIG_ROCKCHIP_SPI=y
+ CONFIG_SYSRESET=y
+ CONFIG_USB=y
+ CONFIG_USB_XHCI_HCD=y

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -21,6 +21,7 @@ rockchip_setup_interfaces()
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 		;;
 	friendlyarm,nanopc-t6|\
+	friendlyarm,nanopc-t6-lts|\
 	friendlyarm,nanopi-r5c|\
 	radxa,e25|\
 	radxa,rock-3b)
@@ -51,6 +52,7 @@ rockchip_setup_macs()
 	case "$board" in
 	armsom,sige7|\
 	friendlyarm,nanopc-t6|\
+	friendlyarm,nanopc-t6-lts|\
 	friendlyarm,nanopi-r2c|\
 	friendlyarm,nanopi-r2s)
 		wan_mac=$(macaddr_generate_from_mmc_cid mmcblk0)

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -31,6 +31,7 @@ set_interface_core() {
 case "$(board_name)" in
 armsom,sige7|\
 friendlyarm,nanopc-t6|\
+friendlyarm,nanopc-t6-lts|\
 friendlyarm,nanopi-r3s|\
 friendlyarm,nanopi-r5c|\
 friendlyarm,nanopi-r6c|\

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -41,6 +41,14 @@ define Device/friendlyarm_nanopc-t6
 endef
 TARGET_DEVICES += friendlyarm_nanopc-t6
 
+define Device/friendlyarm_nanopc-t6-lts
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPC T6 LTS
+  SOC := rk3588
+  DEVICE_PACKAGES := kmod-r8169
+endef
+TARGET_DEVICES += friendlyarm_nanopc-t6-lts
+
 define Device/friendlyarm_nanopi-r2c
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R2C

--- a/target/linux/rockchip/patches-6.6/129-v6.12-arm64-dts-rockchip-friendlyelec-nanopc-t6-lts-board.patch
+++ b/target/linux/rockchip/patches-6.6/129-v6.12-arm64-dts-rockchip-friendlyelec-nanopc-t6-lts-board.patch
@@ -1,0 +1,103 @@
+From db1dcbe5f752d423421f77d54d246398b196f670 Mon Sep 17 00:00:00 2001
+From: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Date: Thu, 29 Aug 2024 14:26:55 +0200
+Subject: [PATCH] arm64: dts: rockchip: add NanoPC-T6 LTS
+
+In the LTS (2310) version the miniPCIe slot got removed and USB 2.0
+setup has changed. There are two external accessible ports and two ports
+on the internal header.
+
+There is an on-board USB hub which provides:
+- one external connector (bottom one)
+- two internal ports on pin header
+- one port for m.2 E connector
+
+The top USB 2.0 connector comes directly from the SoC.
+
+Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+Link: https://lore.kernel.org/r/20240829-friendlyelec-nanopc-t6-lts-v6-4-edff247e8c02@linaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/Makefile         |  1 +
+ .../dts/rockchip/rk3588-nanopc-t6-lts.dts     | 60 +++++++++++++++++++
+ 2 files changed, 61 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts
+
+diff --git a/arch/arm64/boot/dts/rockchip/Makefile b/arch/arm64/boot/dts/rockchip/Makefile
+index 2a2d0c71280686..60dce56892d0c2 100644
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -134,6 +134,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-evb1-v10.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-friendlyelec-cm3588-nas.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-jaguar.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-nanopc-t6.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-nanopc-t6-lts.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-ok3588-c.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-orangepi-5-plus.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-quartzpro64.dtb
+diff --git a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts
+new file mode 100644
+index 00000000000000..2d92bbb4027d3a
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts
+@@ -0,0 +1,60 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
++ * Copyright (c) 2023 Thomas McKahan
++ * Copyright (c) 2024 Linaro Ltd.
++ *
++ */
++
++/dts-v1/;
++
++#include "rk3588-nanopc-t6.dtsi"
++
++/ {
++	model = "FriendlyElec NanoPC-T6 LTS";
++	compatible = "friendlyarm,nanopc-t6-lts", "rockchip,rk3588";
++
++	/* provide power for on-board USB 2.0 hub */
++	vcc5v0_usb20_host: vcc5v0-usb20-host-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
++		pinctrl-0 = <&usb20_host_pwren>;
++		pinctrl-names = "default";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-max-microvolt = <5000000>;
++		regulator-min-microvolt = <5000000>;
++		regulator-name = "vcc5v0_usb20_host";
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&pinctrl {
++	usb {
++		usb20_host_pwren: usb20-host-pwren {
++			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&u2phy1 {
++	status = "okay";
++};
++
++&u2phy1_otg {
++	status = "okay";
++};
++
++&u2phy2_host {
++	phy-supply = <&vcc5v0_usb20_host>;
++};
++
++&usbdp_phy1 {
++	status = "okay";
++};
++
++&usb_host1_xhci {
++	dr_mode = "host";
++	status = "okay";
++};


### PR DESCRIPTION
FriendlyElec released two versions of their NanoPC T6 board non-LTS (2301) and LTS (2310).
This PR adds support for LTS board.
Non-LTS image works fine with LTS board. This PR just adapt DTS files and provide official support.
The original patch: https://lore.kernel.org/all/20240829-friendlyelec-nanopc-t6-lts-v6-0-edff247e8c02@linaro.org/
was modified and adjusted to mainstream kernel 6.12. The previous version included:
`#include "rk3588-nanopc-t6.dts"`
and a modified one:
`#include "rk3588-nanopc-t6.dtsi`