### PR TITLE
[24.10]: generic: fix BCM54612E suspend/resume backport patch

### DIFF
--- a/target/linux/bcm27xx/patches-6.6/950-0260-phy-broadcom-split-out-the-BCM54213PE-from-the-BCM54.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-0260-phy-broadcom-split-out-the-BCM54213PE-from-the-BCM54.patch
@@ -26,7 +26,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
  		return;
  
  	val = bcm_phy_read_shadow(phydev, BCM54XX_SHD_SCR3);
-@@ -1021,7 +1022,7 @@ static struct phy_driver broadcom_driver
+@@ -1019,7 +1020,7 @@ static struct phy_driver broadcom_driver
  	.link_change_notify	= bcm54xx_link_change_notify,
  }, {
  	.phy_id		= PHY_ID_BCM54210E,
@@ -35,7 +35,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.org>
  	.name		= "Broadcom BCM54210E",
  	/* PHY_GBIT_FEATURES */
  	.flags		= PHY_ALWAYS_CALL_SUSPEND,
-@@ -1039,6 +1040,13 @@ static struct phy_driver broadcom_driver
+@@ -1037,6 +1038,13 @@ static struct phy_driver broadcom_driver
  	.set_wol	= bcm54xx_phy_set_wol,
  	.led_brightness_set	= bcm_phy_led_brightness_set,
  }, {

--- a/target/linux/bcm27xx/patches-6.6/950-0382-Populate-phy-driver-block-for-BCM54213PE.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-0382-Populate-phy-driver-block-for-BCM54213PE.patch
@@ -16,7 +16,7 @@ Signed-off-by: Jonathan Lemon <jonathan.lemon@gmail.com>
 
 --- a/drivers/net/phy/broadcom.c
 +++ b/drivers/net/phy/broadcom.c
-@@ -1052,8 +1052,14 @@ static struct phy_driver broadcom_driver
+@@ -1050,8 +1050,14 @@ static struct phy_driver broadcom_driver
  	.phy_id_mask	= 0xffffffff,
  	.name		= "Broadcom BCM54213PE",
  	/* PHY_GBIT_FEATURES */

--- a/target/linux/generic/backport-6.6/734-v6.8-net-phy-bcm54612e-add-suspend-resume.patch
+++ b/target/linux/generic/backport-6.6/734-v6.8-net-phy-bcm54612e-add-suspend-resume.patch
@@ -16,12 +16,12 @@ Signed-off-by: David S. Miller <davem@davemloft.net>
 
 --- a/drivers/net/phy/broadcom.c
 +++ b/drivers/net/phy/broadcom.c
-@@ -1001,6 +1001,8 @@ static struct phy_driver broadcom_driver
- 	.config_intr	= bcm_phy_config_intr,
+@@ -1061,6 +1061,8 @@ static struct phy_driver broadcom_driver
  	.handle_interrupt = bcm_phy_handle_interrupt,
  	.link_change_notify	= bcm54xx_link_change_notify,
+ 	.led_brightness_set	= bcm_phy_led_brightness_set,
 +	.suspend	= bcm54xx_suspend,
 +	.resume		= bcm54xx_resume,
  }, {
- 	.phy_id		= PHY_ID_BCM5421,
+ 	.phy_id		= PHY_ID_BCM54616S,
  	.phy_id_mask	= 0xfffffff0,


### PR DESCRIPTION
This has already been accepted and merged into main in PR #17312. I'd like to also have the fix in the 24.10 releases.

This backport patch inserted suspend/resume callbacks for the wrong PHY driver.
The fixed patch is needed for Huawei AP5030DN
to initialize its second PHY.

Refresh all affected patch with make target/linux/refresh.