### PR TITLE
mvebu: update 309-linksys-status-led.patch

### DIFF
--- a/target/linux/mvebu/patches-6.6/309-linksys-status-led.patch
+++ b/target/linux/mvebu/patches-6.6/309-linksys-status-led.patch
@@ -19,7 +19,7 @@
  		pinctrl-names = "default";
  
 -		led-power {
-+		led_power: power {
++		led_power: led-power {
  			gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
  			default-state = "on";
  		};
@@ -44,7 +44,7 @@
  		pinctrl-names = "default";
  
 -		led-power {
-+		led_power: power {
++		led_power: led-power {
  			label = "mamba:white:power";
  			gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
  			default-state = "on";


### PR DESCRIPTION
Fix power led status, by using correct naming scheme.

Kernel 6.6 requires name to be in form led-<<name>>
