### PR TITLE
linux-firmware: package MediaTek MT7925 Bluetooth firmware

### DIFF
--- a/package/firmware/linux-firmware/mediatek.mk
+++ b/package/firmware/linux-firmware/mediatek.mk
@@ -69,6 +69,15 @@ define Package/mt7922bt-firmware/install
 endef
 $(eval $(call BuildPackage,mt7922bt-firmware))
 
+Package/mt7925bt-firmware = $(call Package/firmware-default,mt7925bt firmware,,LICENCE.mediatek)
+define Package/mt7925bt-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/mediatek/mt7925
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/mediatek/mt7925/BT_RAM_CODE_MT7925_1_1_hdr.bin \
+		$(1)/lib/firmware/mediatek/mt7925
+endef
+$(eval $(call BuildPackage,mt7925bt-firmware))
+
 Package/mt7981-wo-firmware = $(call Package/firmware-default,MT7981 offload firmware,,LICENCE.mediatek)
 define Package/mt7981-wo-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek


### PR DESCRIPTION
`btusb` fails to start on MT7925 hardware without the appropriate firmware being loaded first:
```
bluetooth hci0: Direct firmware load for mediatek/mt7925/BT_RAM_CODE_MT7925_1_1_hdr.bin failed with error -2
bluetooth hci0: Falling back to sysfs fallback for: mediatek/mt7925/BT_RAM_CODE_MT7925_1_1_hdr.bin
```
Package firmware for MediaTek MT7925 Bluetooth from `linux-firmware`.

(H/T @dangowrt; this commit is heavily inspired by 2510a587a)

Tested on BPi-R3.