### PR TITLE
mac80211: set basic-rate for mesh interfaces

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -849,6 +849,11 @@ mac80211_setup_mesh() {
 	[ -n "$mcast_rate" ] && wpa_supplicant_add_rate mcval "$mcast_rate"
 	[ -n "$mesh_id" ] && ssid="$mesh_id"
 
+	brstr=
+	for br in $basic_rate_list; do
+		wpa_supplicant_add_rate brstr "$br"
+	done
+
 	local prev
 	json_set_namespace wdev_uc prev
 
@@ -859,6 +864,7 @@ mac80211_setup_mesh() {
 	json_add_string freq "$freq"
 	json_add_string htmode "$iw_htmode"
 	[ -n "$mcval" ] && json_add_string mcast-rate "$mcval"
+	[ -n "$brstr" ] && json_add_string basic-rates "$brstr"
 	json_add_int beacon-interval "$beacon_int"
 	mac80211_add_mesh_params
 

--- a/package/network/config/wifi-scripts/files/usr/share/hostap/wdev.uc
+++ b/package/network/config/wifi-scripts/files/usr/share/hostap/wdev.uc
@@ -45,7 +45,7 @@ function iface_start(wdev)
 		system(cmd);
 	} else if (wdev.mode == "mesh") {
 		let cmd = [ "iw", "dev", ifname, "mesh", "join", wdev.ssid, "freq", wdev.freq, htmode ];
-		for (let key in [ "mcast-rate", "beacon-interval" ])
+		for (let key in [ "basic-rates", "mcast-rate", "beacon-interval" ])
 			if (wdev[key])
 				push(cmd, key, wdev[key]);
 		system(cmd);


### PR DESCRIPTION
Basic rates were not set for mesh-interfaces, resulting in the undesired behavior where 11s frames might be sent with a rate which was not configured.

Depending on the driver, the basic rate might also be used to determine the beacon rate configured to the chip. One such example are MediaTek MT7915 platforms.