### PR TITLE
netfilter: tune udp ct timeout for http3 and libtorrent

### DIFF
--- a/package/kernel/linux/files/sysctl-nf-conntrack.conf
+++ b/package/kernel/linux/files/sysctl-nf-conntrack.conf
@@ -5,4 +5,4 @@ net.netfilter.nf_conntrack_acct=1
 net.netfilter.nf_conntrack_checksum=0
 net.netfilter.nf_conntrack_tcp_timeout_established=7440
 net.netfilter.nf_conntrack_udp_timeout=60
-net.netfilter.nf_conntrack_udp_timeout_stream=180
+net.netfilter.nf_conntrack_udp_timeout_stream=600


### PR DESCRIPTION
Increase udp replied connection timeout to allow for ~~server pushes~~ normal libtorrent operation
Todays browsers negotiate http3 keepalive of 120..180s with sites like yt ig gmaps
 then ct state gets severed and browser stops receiving server pushed
 updates leading to missed notifications or frozen ui while casually browsing web
Also helps games get past their own splash screens.

Signed-off-by: Andris PE <neandris@gmail.com>

