### PR TITLE
rockchip: enable USB3 port on NanoPC T6

### DIFF
--- a/target/linux/rockchip/patches-6.6/030-09-v6.12-clk-rockchip-Add-new-pll-type-pll_rk3588_ddr.patch
+++ b/target/linux/rockchip/patches-6.6/030-09-v6.12-clk-rockchip-Add-new-pll-type-pll_rk3588_ddr.patch
@@ -1,0 +1,51 @@
+From e781bffc296766b55dbd048890d558655031e8d1 Mon Sep 17 00:00:00 2001
+From: Elaine Zhang <zhangqing@rock-chips.com>
+Date: Wed, 28 Aug 2024 15:42:52 +0000
+Subject: [PATCH] clk: rockchip: Add new pll type pll_rk3588_ddr
+
+That PLL type is similar to the other rk3588 pll types but the actual
+rate is twice the configured rate.
+Therefore, the returned calculated rate must be multiplied by two.
+
+Signed-off-by: Elaine Zhang <zhangqing@rock-chips.com>
+Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
+Acked-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/0102019199a76ec4-9d5846d4-d76a-4e69-a241-c88c2983d607-000000@eu-west-1.amazonses.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ drivers/clk/rockchip/clk-pll.c | 6 +++++-
+ drivers/clk/rockchip/clk.h     | 1 +
+ 2 files changed, 6 insertions(+), 1 deletion(-)
+
+--- a/drivers/clk/rockchip/clk-pll.c
++++ b/drivers/clk/rockchip/clk-pll.c
+@@ -914,7 +914,10 @@ static unsigned long rockchip_rk3588_pll
+ 	}
+ 	rate64 = rate64 >> cur.s;
+ 
+-	return (unsigned long)rate64;
++	if (pll->type == pll_rk3588_ddr)
++		return (unsigned long)rate64 * 2;
++	else
++		return (unsigned long)rate64;
+ }
+ 
+ static int rockchip_rk3588_pll_set_params(struct rockchip_clk_pll *pll,
+@@ -1167,6 +1170,7 @@ struct clk *rockchip_clk_register_pll(st
+ 		break;
+ 	case pll_rk3588:
+ 	case pll_rk3588_core:
++	case pll_rk3588_ddr:
+ 		if (!pll->rate_table)
+ 			init.ops = &rockchip_rk3588_pll_clk_norate_ops;
+ 		else
+--- a/drivers/clk/rockchip/clk.h
++++ b/drivers/clk/rockchip/clk.h
+@@ -287,6 +287,7 @@ enum rockchip_pll_type {
+ 	pll_rk3399,
+ 	pll_rk3588,
+ 	pll_rk3588_core,
++	pll_rk3588_ddr,
+ };
+ 
+ #define RK3036_PLL_RATE(_rate, _refdiv, _fbdiv, _postdiv1,	\

--- a/target/linux/rockchip/patches-6.6/030-10-v6.12-clk-rockchip-rk3588-drop-unused-code.patch
+++ b/target/linux/rockchip/patches-6.6/030-10-v6.12-clk-rockchip-rk3588-drop-unused-code.patch
@@ -1,0 +1,65 @@
+From 2e7b3daa8cb1ebd17e6a7f417ef5e6553203035c Mon Sep 17 00:00:00 2001
+From: Sebastian Reichel <sebastian.reichel@collabora.com>
+Date: Mon, 25 Mar 2024 20:33:32 +0100
+Subject: [PATCH] clk: rockchip: rk3588: drop unused code
+
+All clocks are registered early using CLK_OF_DECLARE(), which marks
+the DT node as processed. For the processed DT node the probe routine
+is never called. Thus this whole code is never executed. This could
+be "fixed" by using CLK_OF_DECLARE_DRIVER, which avoids marking the
+DT node as processed. But then the probe routine would re-register
+all the clocks by calling rk3588_clk_init() again.
+
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Link: https://lore.kernel.org/r/20240325193609.237182-2-sebastian.reichel@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ drivers/clk/rockchip/clk-rk3588.c | 40 -------------------------------
+ 1 file changed, 40 deletions(-)
+
+--- a/drivers/clk/rockchip/clk-rk3588.c
++++ b/drivers/clk/rockchip/clk-rk3588.c
+@@ -2502,43 +2502,3 @@ static void __init rk3588_clk_init(struc
+ }
+ 
+ CLK_OF_DECLARE(rk3588_cru, "rockchip,rk3588-cru", rk3588_clk_init);
+-
+-struct clk_rk3588_inits {
+-	void (*inits)(struct device_node *np);
+-};
+-
+-static const struct clk_rk3588_inits clk_3588_cru_init = {
+-	.inits = rk3588_clk_init,
+-};
+-
+-static const struct of_device_id clk_rk3588_match_table[] = {
+-	{
+-		.compatible = "rockchip,rk3588-cru",
+-		.data = &clk_3588_cru_init,
+-	},
+-	{ }
+-};
+-
+-static int __init clk_rk3588_probe(struct platform_device *pdev)
+-{
+-	const struct clk_rk3588_inits *init_data;
+-	struct device *dev = &pdev->dev;
+-
+-	init_data = device_get_match_data(dev);
+-	if (!init_data)
+-		return -EINVAL;
+-
+-	if (init_data->inits)
+-		init_data->inits(dev->of_node);
+-
+-	return 0;
+-}
+-
+-static struct platform_driver clk_rk3588_driver = {
+-	.driver		= {
+-		.name	= "clk-rk3588",
+-		.of_match_table = clk_rk3588_match_table,
+-		.suppress_bind_attrs = true,
+-	},
+-};
+-builtin_platform_driver_probe(clk_rk3588_driver, clk_rk3588_probe);

--- a/target/linux/rockchip/patches-6.6/030-11-v6.13-clk-rockchip-fix-finding-of-maximum-clock-ID.patch
+++ b/target/linux/rockchip/patches-6.6/030-11-v6.13-clk-rockchip-fix-finding-of-maximum-clock-ID.patch
@@ -1,0 +1,29 @@
+From ad1081a0da2744141d12e94ff816ac91feb871ca Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Thu, 12 Sep 2024 13:32:05 +0000
+Subject: [PATCH] clk: rockchip: fix finding of maximum clock ID
+
+If an ID of a branch's child is greater than current maximum, we should
+set new maximum to the child's ID, instead of its parent's.
+
+Fixes: 2dc66a5ab2c6 ("clk: rockchip: rk3588: fix CLK_NR_CLKS usage")
+Signed-off-by: Yao Zi <ziyao@disroot.org>
+Link: https://lore.kernel.org/r/20240912133204.29089-2-ziyao@disroot.org
+Reviewed-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Reviewed-by: Heiko Stuebner <heiko@sntech.de>
+Signed-off-by: Stephen Boyd <sboyd@kernel.org>
+---
+ drivers/clk/rockchip/clk.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/clk/rockchip/clk.c
++++ b/drivers/clk/rockchip/clk.c
+@@ -439,7 +439,7 @@ unsigned long rockchip_clk_find_max_clk_
+ 		if (list->id > max)
+ 			max = list->id;
+ 		if (list->child && list->child->id > max)
+-			max = list->id;
++			max = list->child->id;
+ 	}
+ 
+ 	return max;

--- a/target/linux/rockchip/patches-6.6/055-16-v6.13-arm64-dts-rockchip-enable-USB3-on-NanoPC-T6.patch
+++ b/target/linux/rockchip/patches-6.6/055-16-v6.13-arm64-dts-rockchip-enable-USB3-on-NanoPC-T6.patch
@@ -1,0 +1,87 @@
+From a6ae420439dc47a58550a6e61e596e9dd1562caf Mon Sep 17 00:00:00 2001
+From: Rick Wertenbroek <rick.wertenbroek@gmail.com>
+Date: Wed, 6 Nov 2024 14:03:13 +0100
+Subject: [PATCH] arm64: dts: rockchip: enable USB3 on NanoPC-T6
+
+Enable the USB3 port on FriendlyELEC NanoPC-T6.
+
+Signed-off-by: Rick Wertenbroek <rick.wertenbroek@gmail.com>
+Link: https://lore.kernel.org/r/20241106130314.1289055-1-rick.wertenbroek@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ .../boot/dts/rockchip/rk3588-nanopc-t6.dtsi   | 36 +++++++++++++++++++
+ 1 file changed, 36 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -160,6 +160,20 @@
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
++	vbus5v0_usb: vbus5v0-usb-regulator {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb5v_pwren>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-name = "vbus5v0_usb";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
+ 	vcc3v3_pcie2x1l0: vcc3v3-pcie2x1l0-regulator {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+@@ -577,6 +591,10 @@
+ 			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
++		usb5v_pwren: usb5v_pwren {
++			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
+ 		usbc0_int: usbc0-int {
+ 			rockchip,pins = <0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+@@ -976,6 +994,14 @@
+ 	status = "okay";
+ };
+ 
++&u2phy1 {
++	status = "okay";
++};
++
++&u2phy1_otg {
++	status = "okay";
++};
++
+ &u2phy2_host {
+ 	status = "okay";
+ };
+@@ -1015,6 +1041,11 @@
+ 	};
+ };
+ 
++&usbdp_phy1 {
++	phy-supply = <&vbus5v0_usb>;
++	status = "okay";
++};
++
+ &usb_host0_ehci {
+ 	status = "okay";
+ };
+@@ -1035,6 +1066,11 @@
+ 	};
+ };
+ 
++&usb_host1_xhci {
++	dr_mode = "host";
++	status = "okay";
++};
++
+ &usb_host1_ehci {
+ 	status = "okay";
+ };

--- a/target/linux/rockchip/patches-6.6/121-arm64-dts-rockchip-lower-mmc-speed-for-nanopc-t6.patch
+++ b/target/linux/rockchip/patches-6.6/121-arm64-dts-rockchip-lower-mmc-speed-for-nanopc-t6.patch
@@ -1,6 +1,6 @@
 --- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-@@ -616,7 +616,7 @@
+@@ -634,7 +634,7 @@
  	disable-wp;
  	no-mmc;
  	no-sdio;


### PR DESCRIPTION
- backport recent rk3588 clk updates
- enable the USB3 port on FriendlyELEC NanoPC T6