### PR TITLE
uboot-rockchip: fix build with swig 4.3.0

### DIFF
--- a/package/boot/uboot-rockchip/patches/001-rockchip-board-Increase-rng-seed-size-to-make-it-sufficie.patch
+++ b/package/boot/uboot-rockchip/patches/001-rockchip-board-Increase-rng-seed-size-to-make-it-sufficie.patch
@@ -1,0 +1,96 @@
+From ed4ae7386257aa66455e330234e513d098a36f84 Mon Sep 17 00:00:00 2001
+From: Alex Shumsky <alexthreed@gmail.com>
+Date: Wed, 16 Oct 2024 13:02:03 +0300
+Subject: [PATCH] rockchip: board: Increase rng-seed size to make it sufficient
+ for modern Linux
+
+Increase rng-seed size to make Linux happy and initialize rng pool instantly.
+Linux 5.19+ requires 32 bytes of entropy to initialize random pool, but u-boot
+currently provides only 8 bytes.
+Linux 5.18 and probably some versions before it used to require 64 bytes.
+Bump min value to 64 bytes to be on a safe side.
+
+Boot with 8 byte rng-seed (Linux 6.11):
+    # dmesg | grep crng
+    [   12.089286] random: crng init done
+Boot with 32 byte rng-seed (Linux 6.11):
+    # dmesg | grep crng
+    [    0.000000] random: crng init done
+
+Linux source references:
+https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/char/random.c?h=v5.19#n551
+https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/char/random.c?h=v5.18#n236
+
+Signed-off-by: Alex Shumsky <alexthreed@gmail.com>
+Fixes: d2048bafae40 ("rockchip: board: Add board_rng_seed() for all Rockchip devices")
+Reviewed-by: Dragan Simic <dsimic@manjaro.org>
+Reviewed-by: Marek Vasut <marex@denx.de>
+Reviewed-by: Quentin Schulz <quentin.schulz@cherry.de>
+Reviewed-by: Kever Yang <kever.yang@rock-chips.com>
+---
+ arch/arm/mach-rockchip/board.c | 11 ++++++++++-
+ common/Kconfig                 |  3 +++
+ doc/usage/environment.rst      |  5 +++++
+ include/fdt_support.h          |  3 ++-
+ 4 files changed, 20 insertions(+), 2 deletions(-)
+
+--- a/arch/arm/mach-rockchip/board.c
++++ b/arch/arm/mach-rockchip/board.c
+@@ -480,9 +480,18 @@ __weak int misc_init_r(void)
+ __weak int board_rng_seed(struct abuf *buf)
+ {
+ 	struct udevice *dev;
+-	size_t len = 0x8;
++	ulong len = env_get_ulong("rng_seed_size", 10, 64);
+ 	u64 *data;
+ 
++	if (len < 64) {
++		/*
++		 * rng_seed_size should be at least 32 bytes for Linux 5.19+,
++		 * or 64 for older Linux kernel versions
++		 */
++		log_warning("Value for rng_seed_size (%lu) too low, Linux kernel RNG may fail to initialize early\n",
++			    len);
++	}
++
+ 	data = malloc(len);
+ 	if (!data) {
+ 		printf("Out of memory\n");
+--- a/common/Kconfig
++++ b/common/Kconfig
+@@ -927,6 +927,9 @@ config BOARD_RNG_SEED
+ 	  new seed for use on subsequent boots, and whether or not the
+ 	  kernel should account any entropy from the given seed.
+ 
++	  Default seed size (64 bytes) can be overridden by a decimal
++	  environment variable rng_seed_size.
++
+ endmenu
+ 
+ menu "Update support"
+--- a/doc/usage/environment.rst
++++ b/doc/usage/environment.rst
+@@ -323,6 +323,11 @@ netretry
+     Useful on scripts which control the retry operation
+     themselves.
+ 
++rng_seed_size
++    Size of random value added to device-tree node /chosen/rng-seed.
++    This variable is given as a decimal number.
++    If unset, 64 bytes is used as the default.
++
+ silent_linux
+     If set then Linux will be told to boot silently, by
+     adding 'console=' to its command line. If "yes" it will be
+--- a/include/fdt_support.h
++++ b/include/fdt_support.h
+@@ -202,7 +202,8 @@ int ft_board_setup(void *blob, struct bd
+  *
+  * This function is called if CONFIG_BOARD_RNG_SEED is set, and must
+  * be provided by the board. It should return, via @buf, some suitable
+- * seed value to pass to the kernel.
++ * seed value to pass to the kernel. Seed size could be set in a decimal
++ * environment variable rng_seed_size and it defaults to 64 bytes.
+  *
+  * @param buf         A struct abuf for returning the seed and its size.
+  * @return            0 if ok, negative on error.

--- a/package/boot/uboot-rockchip/patches/002-scripts-dtc-pylibfdt-libfdt-i_shipped-Use-SWIG_AppendOutp.patch
+++ b/package/boot/uboot-rockchip/patches/002-scripts-dtc-pylibfdt-libfdt-i_shipped-Use-SWIG_AppendOutp.patch
@@ -1,0 +1,55 @@
+From a63456b9191fae2fe49f4b121e025792022e3950 Mon Sep 17 00:00:00 2001
+From: Markus Volk <f_l_k@t-online.de>
+Date: Wed, 30 Oct 2024 06:07:16 +0100
+Subject: [PATCH] scripts/dtc/pylibfdt/libfdt.i_shipped: Use SWIG_AppendOutput
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Swig has changed language specific AppendOutput functions. The helper
+macro SWIG_AppendOutput remains unchanged. Use that instead
+of SWIG_Python_AppendOutput, which would require an extra parameter
+since swig 4.3.0.
+
+/home/flk/poky/build-test/tmp/work/qemux86_64-poky-linux/u-boot/2024.10/git/arch/x86/cpu/u-boot-64.lds
+| scripts/dtc/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_next_node’:
+| scripts/dtc/pylibfdt/libfdt_wrap.c:5581:17: error: too few arguments to function ‘SWIG_Python_AppendOutput’
+|  5581 |     resultobj = SWIG_Python_AppendOutput(resultobj, val);
+|       |                 ^~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Markus Volk <f_l_k@t-online.de>
+Reported-by: Rudi Heitbaum <rudi@heitbaum.com>
+Link: https://github.com/dgibson/dtc/pull/154
+---
+ scripts/dtc/pylibfdt/libfdt.i_shipped | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/scripts/dtc/pylibfdt/libfdt.i_shipped
++++ b/scripts/dtc/pylibfdt/libfdt.i_shipped
+@@ -1037,7 +1037,7 @@ typedef uint32_t fdt32_t;
+ 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
+ 		buff = PyByteArray_FromStringAndSize(
+ 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
+-		resultobj = SWIG_Python_AppendOutput(resultobj, buff);
++		resultobj = SWIG_AppendOutput(resultobj, buff);
+ 	}
+ }
+ 
+@@ -1076,7 +1076,7 @@ typedef uint32_t fdt32_t;
+ 
+ %typemap(argout) int *depth {
+         PyObject *val = Py_BuildValue("i", *arg$argnum);
+-        resultobj = SWIG_Python_AppendOutput(resultobj, val);
++        resultobj = SWIG_AppendOutput(resultobj, val);
+ }
+ 
+ %apply int *depth { int *depth };
+@@ -1092,7 +1092,7 @@ typedef uint32_t fdt32_t;
+            if (PyTuple_GET_SIZE(resultobj) == 0)
+               resultobj = val;
+            else
+-              resultobj = SWIG_Python_AppendOutput(resultobj, val);
++              resultobj = SWIG_AppendOutput(resultobj, val);
+         }
+ }
+ 


### PR DESCRIPTION
- increase rng-seed size to speed up booting
- fix build with swig 4.3.0