### PR TITLE
trusted-firmware-a.mk: fix release download URL

### DIFF
--- a/include/trusted-firmware-a.mk
+++ b/include/trusted-firmware-a.mk
@@ -3,7 +3,7 @@ PKG_CPE_ID ?= cpe:/a:arm:trusted_firmware-a
 
 ifndef PKG_SOURCE_PROTO
 PKG_SOURCE = trusted-firmware-a-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/snapshot
+PKG_SOURCE_URL:=https://codeload.github.com/TrustedFirmware-A/trusted-firmware-a/tar.gz/v$(PKG_VERSION)?
 endif
 
 PKG_BUILD_DIR = $(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)

--- a/package/boot/arm-trusted-firmware-stm32/Makefile
+++ b/package/boot/arm-trusted-firmware-stm32/Makefile
@@ -10,10 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_VERSION:=2.12
 PKG_RELEASE:=1
 
-PKG_SOURCE_PROTO:=git
-PKG_SOURCE_URL:=https://github.com/ARM-software/arm-trusted-firmware.git
-PKG_SOURCE_VERSION:=v$(PKG_VERSION)
-PKG_MIRROR_HASH:=51b2022baa25df7fd8f2e6d2709c9351c14b17447cda64759a8a1d432f9d1c11
+PKG_HASH:=b4c047493cac1152203e1ba121ae57267e4899b7bf56eb365e22a933342d31c9
 PKG_MAINTAINER:=Thomas Richard <thomas.richard@bootlin.com>
 
 include $(INCLUDE_DIR)/kernel.mk


### PR DESCRIPTION
The URL of trusted-firmware-a is no longer available for downloading release:
```
+ curl -f --connect-timeout 20 --retry 5 --location https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git/snapshot/trusted-firmware-a-2.10.tar.gz
curl: (22) The requested URL returned error: 401 Unauthorized
```

So we switch to the GitHub mirror repository to download.