### PR TITLE
[23.05]: mediatek: filogic: Add support for D-Link AQUILA PRO AI M60

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -66,7 +66,8 @@ zbtlink,zbt-z8102ax|\
 zbtlink,zbt-z8103ax)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
-dlink,aquila-pro-ai-m30-a1)
+dlink,aquila-pro-ai-m30-a1|\
+dlink,aquila-pro-ai-m60-a1)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x40000"
 	;;
 h3c,magic-nx30-pro|\

--- a/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
+++ b/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	model = "D-Link AQUILA PRO AI M60 A1";
+	compatible = "dlink,aquila-pro-ai-m60-a1", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_white;
+		led-upgrade = &led_status_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		button-leds-on-off {
+			label = "leds-on-off";
+			linux,code = <KEY_LIGHTS_TOGGLE>;
+			gpios = <&pio 47 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_odm 1>;
+		nvmem-cell-names = "mac-address";
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy6>;
+		nvmem-cells = <&macaddr_odm 0>;
+		nvmem-cell-names = "mac-address";
+		label = "internet";
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <1500000>;
+		reset-post-delay-us = <1000000>;
+
+		phy6: phy@6 {
+			compatible = "maxlinear,gpy211", "ethernet-phy-ieee802.3-c45";
+			reg = <6>;
+			phy-mode = "2500base-x";
+		};
+
+		switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "lan1";
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan2";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan3";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan4";
+				};
+
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <8>;
+			mediatek,pull-down-adv = <0>; /* bias-disable */
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins =
+				"WF0_HB2",
+				"WF0_HB3",
+				"WF0_HB4",
+				"WF0_HB0",
+				"WF0_HB0_B",
+				"WF0_HB5",
+				"WF0_HB6",
+				"WF0_HB7",
+				"WF0_HB8",
+				"WF0_HB9",
+				"WF0_HB10",
+				"WF0_TOP_CLK",
+				"WF0_TOP_DATA",
+				"WF1_HB1",
+				"WF1_HB2",
+				"WF1_HB3",
+				"WF1_HB4",
+				"WF1_HB0",
+				"WF1_HB5",
+				"WF1_HB6",
+				"WF1_HB7",
+				"WF1_HB8",
+				"WF1_TOP_CLK",
+				"WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+
+	i2c_pins_3_4: i2c-pins-3-4 {
+		mux {
+			function = "i2c";
+			groups = "i2c";
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+
+		spi-max-frequency = <20000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x000000 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x3200000>;
+			};
+
+			partition@3780000 {
+				label = "ubi1";
+				reg = <0x3780000 0x3200000>;
+				read-only;
+			};
+
+			partition@6980000 {
+				label = "Odm";
+				reg = <0x6980000 0x40000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_odm: macaddr@81 {
+						compatible = "mac-base";
+						reg = <0x81 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+
+			};
+
+			partition@69c0000 {
+				label = "Config1";
+				reg = <0x69c0000 0x80000>;
+				read-only;
+			};
+
+			partition@6a40000 {
+				label = "Config2";
+				reg = <0x6a40000 0x80000>;
+				read-only;
+			};
+
+			partition@6ac0000 {
+				label = "Storage";
+				reg = <0x6ac0000 0xA00000>;
+				read-only;
+			};
+
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+
+	band@0 {
+		/* 2.4 GHz */
+		reg = <0>;
+		nvmem-cells = <&macaddr_odm 2>;
+		nvmem-cell-names = "mac-address";
+	};
+	band@1 {
+		/* 5 GHz */
+		reg = <1>;
+		nvmem-cells = <&macaddr_odm 5>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&i2c0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c_pins_3_4>;
+
+	gca230718@40 {
+		compatible = "unknown,gca230718";
+		reg = <0x40>;
+
+		led_status_red: led@0 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			reg = <0>;
+		};
+
+		led@1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			reg = <1>;
+		};
+
+		led_status_blue: led@2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			reg = <2>;
+		};
+
+		led_status_white: led@3 {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			reg = <3>;
+		};
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -50,7 +50,8 @@ mediatek_setup_interfaces()
 	glinet,gl-mt3000)
 		ucidef_set_interfaces_lan_wan eth1 eth0
 		;;
-	dlink,aquila-pro-ai-m30-a1)
+	dlink,aquila-pro-ai-m30-a1|\
+	dlink,aquila-pro-ai-m60-a1)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" internet
 		;;
 	glinet,gl-mt6000|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -116,6 +116,10 @@ platform_do_upgrade() {
 	yuncore,ax835)
 		default_do_upgrade "$1"
 		;;
+	dlink,aquila-pro-ai-m60-a1)
+		fw_setenv sw_tryactive 0
+		nand_do_upgrade "$1"
+		;;
 	glinet,gl-mt6000)
 		CI_KERNPART="kernel"
 		CI_ROOTPART="rootfs"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -452,6 +452,20 @@ define Device/dlink_aquila-pro-ai-m30-a1
 endef
 TARGET_DEVICES += dlink_aquila-pro-ai-m30-a1
 
+define Device/dlink_aquila-pro-ai-m60-a1
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := AQUILA PRO AI M60
+  DEVICE_VARIANT := A1
+  DEVICE_DTS := mt7986a-dlink-aquila-pro-ai-m60-a1
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-leds-gca230718 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  IMAGES += recovery.bin
+  IMAGE_SIZE := 51200k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/recovery.bin := sysupgrade-tar | pad-to $$(IMAGE_SIZE) | dlink-ai-recovery-header DLK6E8202001 \x30\x6C\x19\x0C \x00\x00\x2C\x00 \x00\x00\x20\x03 \x82\x6E
+endef
+TARGET_DEVICES += dlink_aquila-pro-ai-m60-a1
+
 define Device/glinet_gl-mt3000
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MT3000


### PR DESCRIPTION
Specification:
 - MT7986 CPU using 2.4GHz and 5GHz WiFi (both AX)
 - MT7531 switch
 - 512MB RAM
 - 128MB NAND flash (MX35LF1GE4AB-Z4I) with two UBI partitions with identical size
 - 1 multi color LED (red, green, blue, white) connected via GCA230718 (Same as D-Link M30 A1)
 - 3 buttons (WPS, reset, LED on/off)
 - 1x 2.5 Gbit WAN port with Maxlinear GPY211C
 - 4x 1 Gbit LAN ports

Disassembly:
 - There are five screws at the bottom: 2 under the rubber feet, 3 under the label.
 - After removing the screws, the white plastic part can be shifted out of the blue part.
 - Be careful because the antennas are mounted on the side and the top of the white part.

Serial Interface
 - The serial interface can be connected to the 4 pin holes next to/under the antenna cables.
 - Note that there is another set of 4 pin holes on the side of the board, it's not used.
 - Pins (from front to rear):
   - 3.3V (do not connect)
   - TX
   - RX
   - GND
 - Settings: 115200, 8N1

MAC addresses:
 - MAC address is stored in partition "Odm" at offset 0x81 (for example XX:XX:XX:XX:XX:52)
 - MAC address on the device label is ODM + 1 (for example XX:XX:XX:XX:XX:53)
 - WAN MAC is the one from the ODM partition (for example XX:XX:XX:XX:XX:52)
 - LAN MAC is the one from the ODM partition + 1 (for example XX:XX:XX:XX:XX:53)
 - WLAN MAC (2.4 GHz) is the one from the ODM partition + 2 (for example (XX:XX:XX:XX:XX:54)
 - WLAN MAC (5 GHz) is the one from the ODM partition + 5 (for example (XX:XX:XX:XX:XX:57)

Flashing via OEM web interface:
 - Currently not supported because image crypto is not known

Flashing via recovery web interface:
 - This is only working if the first partition is active because recovery images are always flashed to the active partition and OpenWrt can only be executed from the first partition
 - Use a Chromium based browser, otherwise firmware upgrade might not work
 - Recovery web interface is accessible via 192.168.200.1 after keeping the reset button pressed during start of the device until the LED blinks red
 - Upload the recovery image, this will take some time. LED will continue flashing red during the update process
 - The after flashing, the recovery web interface redirects to http://192.168.0.1. This can be ignored. OpenWrt is accessible via 192.168.1.1 after flashing
 - If the first partition isn't the active partition, OpenWrt will hang during the boot process. In this case:
   - Download the recovery image from https://github.com/RolandoMagico/openwrt/releases/tag/M60-Recovery-UBI-Switch (UBI switch image)
   - Enable recovery web interface again and load the UBI switch image. This image works on the second partition of the M60
   - OpenWrt should boot now as expected. After booting, flash the normal OpenWrt sysupgrade image (for example in the OpenWrt web interface)
   - Flashing a sysupgrade image from the UBI switch image will make the first partition the active partition and from now on, default OpenWrt images can be used

Flashing via Initramfs:
- Before switching to OpenWrt, ensure that both partitions contain OEM firmware.
  - This can be achieved by re-flashing the same OEM firmware version again via the OEM web interface.
  - Flashing via OEM web interface will automatically flash the currently not active partition.
- Open router, connect serial interface
- Start a TFTP server at 192.168.200.2 and provide the initramfs image there
- When starting the router, select "7. Load Image" in U-Boot
- Settings for load address, load method can be kept as they are
- Specify host and router IP address if you use different ones than the default (Router 192.168.200.1, TFTP server 192.168.200.2)
- Enter the file name of the initramfs image
- Confirm "Run loaded data now?" question after loading the image with "Y"
- OpenWrt initramfs will start now
- Before flashing OpenWrt, create a backup of the "ubi" partition. It is required when reverting back to OEM
- Flash sysupgrade image to flash, during flashing the U-Boot variable sw_tryactive will be set to 0
  - During next boot, U-Boot tries to boot from the ubi partition. If it fails, it will switch to the ubi1 partition

Reverting back to OEM:
- Boot the initramfs image as described in "Flashing via Initramfs" above
- Copy the backed up ubi partition to /tmp (e.g. by using SCP)
- Write the backup to the UBI partition: mtd write /tmp/OpenWrt.mtd4.ubi.bin /dev/mtd4
- Reboot the device, OEM firmware will start now

Signed-off-by: Roland Reinl <reinlroland+github@gmail.com>
Link: https://github.com/openwrt/openwrt/pull/17296
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
(cherry picked from commit b3ce08e0b6fa6780bf7ee295a1f176c053b1100b)
