### PR TITLE
ramips: mt762{0,8}: reduce default MMC clock to 24 MHz

### DIFF
--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -540,7 +540,7 @@
 		interrupt-parent = <&intc>;
 		interrupts = <14>;
 
-		max-frequency = <48000000>;
+		max-frequency = <24000000>;
 
 		pinctrl-names = "default", "state_uhs";
 		pinctrl-0 = <&sdhci_pins>;

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
@@ -108,10 +108,6 @@
 	};
 };
 
-&sdhci {
-	max-frequency = <24000000>;
-};
-
 &wmac {
 	pinctrl-names = "default", "pa_gpio";
 	pinctrl-0 = <&pa_pins>;

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -394,7 +394,7 @@
 		interrupt-parent = <&intc>;
 		interrupts = <14>;
 
-		max-frequency = <48000000>;
+		max-frequency = <24000000>;
 
 		pinctrl-names = "default", "state_uhs";
 		pinctrl-0 = <&sdxc_pins>;


### PR DESCRIPTION
This is a known issue. The similar change has already been applied to MT7621 in 04818d5857ae69350ad2e00dc57eade174f64422.
The upstream mtk-sd driver did not perform specific timing optimization for MT762x series SoC, hence the SDHC peripheral of some boards cannot run at too high frequency. Reduce the maximum clock frequency to fix the mmc read/write error.

Closes: https://github.com/openwrt/openwrt/issues/17364
