### PR TITLE
ramips: mt7621: add support for Keenetic Viva (KN-1910)

### DIFF
--- a/target/linux/ramips/dts/mt7621_keenetic_kn-1910.dts
+++ b/target/linux/ramips/dts/mt7621_keenetic_kn-1910.dts
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "keenetic,kn-1910", "mediatek,mt7621-soc";
+	model = "Keenetic KN-1910";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &gmac0;
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		left_usb_power_on {
+			gpio-export,name = "left-usb:power-on";
+			gpio-export,output = <1>;
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		right_usb_power_on {
+			gpio-export,name = "right-usb:power-on";
+			gpio-export,output = <1>;
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		restart {
+			label = "restart";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		fn1 {
+			label = "fn1";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+
+		fn2 {
+			label = "fn2";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_2>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			label = "green:power";
+			gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		internet {
+			label = "green:internet";
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		fn {
+			label = "green:fn";
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi {
+			label = "green:wifi";
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt","phy1tpt";
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2 &storage_a &storage_b>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7540000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "U-Boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "U-Config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "RF-EEPROM";
+			reg = <0x100000 0x80000>;
+			read-only;
+		};
+
+		firmware1: partition@180000 {
+			label = "Firmware_1";
+			reg = <0x180000 0x1bc0000>;
+		};
+
+		partition@1d40000 {
+			label = "Config_1";
+			reg = <0x1d40000 0x80000>;
+			read-only;
+		};
+
+		partition@1dc0000 {
+			label = "Storage_Legacy";
+			reg = <0x1dc0000 0x200000>;
+			read-only;
+		};
+
+		partition@1fc0000 {
+			label = "Dump";
+			reg = <0x1fc0000 0x40000>;
+			read-only;
+		};
+
+		storage_a: partition@2000000 {
+			label = "Storage_A";
+			reg = <0x2000000 0x1fc0000>;
+		};
+
+		partition@3fc0000 {
+			label = "U-State";
+			reg = <0x3fc0000 0x80000>;
+			read-only;
+		};
+
+		partition@4040000 {
+			label = "U-Config_res";
+			reg = <0x4040000 0x80000>;
+			read-only;
+		};
+
+		partition@40c0000 {
+			label = "RF-EEPROM_res";
+			reg = <0x40c0000 0x80000>;
+			read-only;
+		};
+
+		firmware2: partition@4140000 {
+			label = "Firmware_2";
+			reg = <0x4140000 0x1bc0000>;
+		};
+
+		partition@5d00000 {
+			label = "Config_2";
+			reg = <0x5d00000 0x80000>;
+			read-only;
+		};
+
+		storage_b: partition@5d80000 {
+			label = "Storage_B";
+			reg = <0x5d80000 0x2200000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0>;
+	};
+};
+
+&mdio {
+	ethphy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+		};
+
+		port@2 {
+			status = "okay";
+		};
+
+		port@3 {
+			status = "okay";
+		};
+
+		port@4 {
+			status = "okay";
+		};
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+	};
+
+	macaddr_factory_28: macaddr@28 {
+		reg = <0x28 0x6>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1787,6 +1787,21 @@ define Device/jdcloud_re-cp-02
 endef
 TARGET_DEVICES += jdcloud_re-cp-02
 
+define Device/keenetic_kn-1910
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 24903680
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-1910
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size | zyimage -d 0x801910 -v "KN-1910"
+endef
+TARGET_DEVICES += keenetic_kn-1910
+
 define Device/keenetic_kn-3010
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -125,6 +125,7 @@ gnubee,gb-pc2)
 huasifei,ws1208v2)
 	ucidef_set_led_netdev "wwan0" "wwan0" "green:cellular" "wwan0" "link tx rx"
 	;;
+keenetic,kn-1910|\
 keenetic,kn-3010)
 	ucidef_set_led_netdev "internet" "internet" "green:internet" "wan"
 	;;


### PR DESCRIPTION
Specification:
SoC: MediaTek MT7621A
RAM: 128M DDR3, Winbond W631GG6MB-12 (DDR3-1600) or Winbond W631GG6MB-11 
Flash: 128M, Macronix MX30LF1G18AC-TI (Dual Boot, Parallel-NAND)
Switch: MT7530, 5 ports 1Gbps
WiFi: MT7615DN, 2.4GHz 802.11n and 5GHz 802.11ac
USB: 2 ports USB 2.0
GPIO: 4 buttons (Wi-Fi, Reset, FN1, FN2), 4 LEDs (Power, Internet, FN, Wi-Fi), USB port power controls

LAN: RF-EEPROM + 0x04
WAN: RF-EEPROM + 0x28
2.4 GHz: RF-EEPROM + 0x04
5 GHz: 2.4GHz + 82:00:00:00:00:00

Disassembly:
There are 2 screws at the bottom. After removing the screws, pry the gray plastic part around (it is secured with latches) and remove it.

Serial Interface:
The serial interface can be connected to the 4 pin dots to the left of the radiator. Pins (from LAN ports to LEDs):
3.3V (do not connect)
TX
RX
GND
Settings: 57600, 8N1

Flashing via OEM recovery software:
1. Download the OEM recovery software from the manufacturer's website
2. Download the firmware image (for OpenWRT it is *-squashfs-factory.bin), rename it to KN-1910_recovery.bin
3. Replace the file in the fw folder OEM recovery software with the file from step 2.
4. Run the OEM recovery software and follow the instructions.

Flashing via TFTP:
1. Connect your PC and router to port 1-4, configure PC interface using IP 192.168.1.2, mask 255.255.255.252
2. Serve the firmware image (for OpenWRT it is *-squashfs-factory.bin) renamed to KN-1910_recovery.bin via TFTP
3. Power up the router while pressing Reset button on the back
4. Release Restart button when Power LED starts blinking

To revert back to OEM firmware:
The return to the OEM firmware is carried out by using the methods described above with the help of the appropriate firmware image.

Keenetic's bootloader supports booting a LZMA compressed kernel but seems to fail if the uncompressed data is larger than a fixed buffer therefore it is safer to use a uimage-lzma-loader. When using OEM bootloader, the firmware image size cannot exceed the size of one OEM «Firmware_x» partition or Kernel + rootFS size.

Signed-off-by: Anton Yu. Ivanusev <ivanusevanton@yandex.ru>