### PR TITLE
netfilter: fix bogus reference to `kmod-nf-conntrack-timeout`

### DIFF
--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -1069,7 +1069,7 @@ define KernelPackage/nfnetlink-cttimeout
   FILES:=$(LINUX_DIR)/net/netfilter/nfnetlink_cttimeout.ko
   KCONFIG:=CONFIG_NF_CT_NETLINK_TIMEOUT
   AUTOLOAD:=$(call AutoProbe,nfnetlink_cttimeout)
-  $(call AddDepends/nfnetlink,+kmod-nf-conntrack +kmod-nf-conntrack-timeout @KERNEL_NF_CONNTRACK_TIMEOUT)
+  $(call AddDepends/nfnetlink,+kmod-nf-conntrack @KERNEL_NF_CONNTRACK_TIMEOUT)
 endef
 
 define KernelPackage/nfnetlink-cttimeout/description


### PR DESCRIPTION
Fixes error introduced in #17267 (comment: https://github.com/openwrt/openwrt/commit/0e2dcfc4f488ecd7acf31e01bd10624d8a273cde) and #17358.

Please backport this to `openwrt-24.10` also.

Fix bogus reference to `kmod-nf-conntrack-timeout`, fixing the warning `WARNING: Makefile 'package/kernel/linux/Makefile' has a dependency on 'kmod-nf-conntrack-timeout', which does not exist`

Compile Tested: Both on aarch64/mt7622/Linksys E8450
Link: https://github.com/openwrt/openwrt/pull/17388