### PR TITLE
[octeon/generic] support USB via dwc3-octeon

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -519,6 +519,23 @@ endef
 $(eval $(call KernelPackage,usb-dwc3))
 
 
+define KernelPackage/usb-dwc3-octeon
+  TITLE:=DWC3 Cavium Octeon USB driver
+  DEPENDS:=@TARGET_octeon +kmod-usb-dwc3
+  KCONFIG:= CONFIG_USB_DWC3_OCTEON
+  FILES:= $(LINUX_DIR)/drivers/usb/dwc3/dwc3-octeon.ko
+  AUTOLOAD:=$(call AutoProbe,dwc3-octeon,1)
+  $(call AddDepends/usb)
+endef
+
+define KernelPackage/usb-dwc3-octeon/description
+  This driver adds support for Cavium Octeon platforms with DesignWare
+  Core USB3 IP.
+endef
+
+$(eval $(call KernelPackage,usb-dwc3-octeon))
+
+
 define KernelPackage/usb-dwc3-qcom
   TITLE:=DWC3 Qualcomm USB driver
   DEPENDS:=@(TARGET_ipq40xx||TARGET_ipq806x||TARGET_qualcommax) +kmod-usb-dwc3

--- a/target/linux/octeon/Makefile
+++ b/target/linux/octeon/Makefile
@@ -18,6 +18,6 @@ endef
 
 include $(INCLUDE_DIR)/target.mk
 
-DEFAULT_PACKAGES += mkf2fs e2fsprogs
+DEFAULT_PACKAGES += mkf2fs e2fsprogs kmod-usb-dwc3-octeon
 
 $(eval $(call BuildTarget))


### PR DESCRIPTION
This makes the USB port on the EdgeRouter-4 working again using 24.10.0 and up.  When approved, should be backported to the 24.10.0 branch.