### PR TITLE
mediatek: filogic: Add support for OpenWRT One mikroBUS spidev spi1 with device tree overlay

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-openwrt-one-mikrobus-spidev.dtso
+++ b/target/linux/mediatek/dts/mt7981b-openwrt-one-mikrobus-spidev.dtso
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (C) 2025
+ * Author: Mark Birss <mark.birss@gmail.com>
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "openwrt,one", "mediatek,mt7981";
+
+        fragment@0 {
+                target = <&spi1>;
+                __overlay__ {
+                        status = "okay";
+
+                        spidev@0 {
+                                compatible = "silabs,si3210";
+                                reg = <0>;
+                                #address-cells = <1>;
+                                #size-cells = <0>;
+                                spi-max-frequency = <52000000>;
+                        };
+                };
+        };
+};

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1265,6 +1265,7 @@ define Device/openwrt_one
   DEVICE_VENDOR := OpenWrt
   DEVICE_MODEL := One
   DEVICE_DTS := mt7981b-openwrt-one
+  DEVICE_DTS_OVERLAY := mt7981b-openwrt-one-mikrobus-spidev
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTC_FLAGS := --pad 4096
   DEVICE_DTS_LOADADDR := 0x43f00000


### PR DESCRIPTION
This PR is a redo of a previous closed https://github.com/openwrt/openwrt/pull/17244

Use: running Meshtastic (packages are being merged already)

Reason: Change to device-tree overlay

Device: OpenWRT One specifically for the mikroBUS

Purpose: Adds device tree overlay for mikroBUS spidev spi2

Compiled Test: OpenWRT One/master