### PR TITLE
mac80211: replace qca,led-sources

### DIFF
--- a/package/kernel/mac80211/patches/ath9k/552-ath9k-ahb_of.patch
+++ b/package/kernel/mac80211/patches/ath9k/552-ath9k-ahb_of.patch
@@ -13,7 +13,7 @@
  static const struct platform_device_id ath9k_platform_id_table[] = {
  	{
  		.name = "ath9k",
-@@ -69,22 +73,198 @@ static const struct ath_bus_ops ath_ahb_
+@@ -69,22 +73,207 @@ static const struct ath_bus_ops ath_ahb_
  	.eeprom_read = ath_ahb_eeprom_read,
  };
  
@@ -158,19 +158,28 @@
 +static int of_ath_ahb_probe(struct platform_device *pdev)
 +{
 +	struct ath_hw *ah = platform_get_drvdata(pdev);
-+	const struct of_device_id *match;
++	struct device_node *np = pdev->dev.of_node;
 +	const struct of_ath_ahb_data *data;
-+	u8 led_pin;
++	const struct of_device_id *match;
 +
 +	match = of_match_device(of_ath_ahb_match, &pdev->dev);
 +	data = (const struct of_ath_ahb_data *)match->data;
 +
-+	if (!of_property_read_u8(pdev->dev.of_node, "qca,led-pin", &led_pin))
-+		ah->led_pin = led_pin;
-+	else
-+		ah->led_pin = -1;
++	np = of_get_child_by_name(np, "led");
++	if (np && of_device_is_available(np)) {
++		int led_pin;
 +
-+	if (of_property_read_bool(pdev->dev.of_node, "qca,tx-gain-buffalo"))
++		if (!of_property_read_u32(np, "led-sources", &led_pin))
++			ah->led_pin = led_pin;
++		else
++			ah->led_pin = -1;
++
++		ah->config.led_active_high = !of_property_read_bool(np, "led-active-low");
++
++		of_node_put(np);
++	}
++
++	if (of_property_read_bool(np, "qca,tx-gain-buffalo"))
 +		ah->config.tx_gain_buffalo = true;
 +
 +	if (data->wmac_reset) {
@@ -218,7 +227,7 @@
  
  	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
  	if (res == NULL) {
-@@ -124,7 +304,8 @@ static int ath_ahb_probe(struct platform
+@@ -124,7 +313,8 @@ static int ath_ahb_probe(struct platform
  		goto err_free_hw;
  	}
  
@@ -228,7 +237,7 @@
  	if (ret) {
  		dev_err(&pdev->dev, "failed to initialize device\n");
  		goto err_irq;
-@@ -162,6 +343,7 @@ static struct platform_driver ath_ahb_dr
+@@ -162,6 +352,7 @@ static struct platform_driver ath_ahb_dr
  	.remove_new = ath_ahb_remove,
  	.driver		= {
  		.name	= "ath9k",

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951ui-2hnd.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951ui-2hnd.dts
@@ -70,5 +70,8 @@
 };
 
 &wmac {
-	qca,led-pin = /bits/ 8 <11>;
+	led {
+		led-sources = <11>;
+		led-active-low;
+	};
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
@@ -349,7 +349,6 @@
 				reg = <0x0000 0 0 0 0>;
 				#gpio-cells = <2>;
 				gpio-controller;
-				qca,led-pin = /bits/ 8 <0>;
 				nvmem-cells = <&cal_caldata_1000>, <&macaddr_uboot_4fc00 0>;
 				nvmem-cell-names = "calibration", "mac-address";
 			};
@@ -380,9 +379,13 @@
 				*/
 				device-id = <0x0030>;
 				class-code = <0x028000>;
-				qca,led-pin = /bits/ 8 <0>;
 				nvmem-cells = <&cal_caldata_5000>, <&macaddr_uboot_4fc00 (-1)>;
 				nvmem-cell-names = "calibration", "mac-address";
+
+				led {
+					led-sources = <0>;
+					led-active-low;
+				};
 			};
 		};
 	};
@@ -395,18 +398,25 @@
 		compatible = "gpio-leds";
 
 		led-0 {
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-1 {
 			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WPS;
 		};
 
-		system_green: led-1 {
+		system_green: led-2 {
 			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
 		};
 
-		led-2 {
+		led-3 {
 			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_USB;
@@ -415,7 +425,7 @@
 			trigger-sources = <&hub_port1>;
 		};
 
-		led-3 {
+		led-4 {
 			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_USB;


### PR DESCRIPTION
Upstream seems to be using led-sources instead of custom properties.

Code mostly taken from mt76.

Changed all(few) users of qca,led_pin to use the new format.

ping @DragonBluep @robimarko @kempniu @CHKDSK88 

A big question is whether or not this should be kept. mt76 supports it while being a relatively modern driver.

@CHKDSK88 based on my reading of the code, the presence of gpio-controller makes this whole thing noop. Is this true?