### PR TITLE
ramips: mt7621: add support for JDCloud RE-SP-01B

### DIFF
--- a/target/linux/ramips/dts/mt7621_jdcloud_re-sp-01b.dts
+++ b/target/linux/ramips/dts/mt7621_jdcloud_re-sp-01b.dts
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/*
+ * Author: aiamadeus <42570690+aiamadeus@users.noreply.github.com>
+ * Modified by: Jin 
+ */
+
+/dts-v1/;
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "jdcloud,re-sp-01b", "mediatek,mt7621-soc";
+	model = "JDCloud RE-SP-01B";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-blue {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			config: partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_4429: macaddr@4429 {
+						compatible = "mac-base";
+						reg = <0x4429 0xC>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			factory: partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1ab0000>;
+			};
+
+			partition@1b00000 {
+				label = "mini";
+				reg = <0x1b00000 0x400000>;
+				read-only;
+			};
+
+			partition@1f00000 {
+				label = "oem";
+				reg = <0x1f00000 0x100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_config_4429 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_config_4429 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_config_4429 0x800000>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1787,6 +1787,16 @@ define Device/jdcloud_re-cp-02
 endef
 TARGET_DEVICES += jdcloud_re-cp-02
 
+define Device/jdcloud_re-sp-01b
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 27328k
+  DEVICE_VENDOR := JDCloud
+  DEVICE_MODEL := RE-SP-01B
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e \
+	kmod-mt7615-firmware kmod-mmc-mtk kmod-usb3
+endef
+TARGET_DEVICES += jdcloud_re-sp-01b
+
 define Device/keenetic_kn-3010
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -85,6 +85,7 @@ ramips_setup_interfaces()
 	iodata,wn-deax1800gr|\
 	iptime,a3002mesh|\
 	jcg,q20|\
+	jdcloud,re-sp-01b|\
 	lenovo,newifi-d1|\
 	mikrotik,routerboard-m33g|\
 	mts,wg430223|\


### PR DESCRIPTION
JDCloud RE-SP-01B is a dual-band WiFi 5 router based on the MT7621AT.

Specifications:
- SoC: MediaTek MT7621AT
- RAM: 512MB DDR3
- Flash: 32MB SPI NOR
- WiFi: MediaTek MT7603EN (2.4GHz), MediaTek MT7615N (5GHz)
- Ethernet: 1x WAN, 2x LAN (Gigabit Ethernet)
- LEDs: red, blue, green (GPIO controlled)
- Button: Reset (GPIO controlled)
- eMMC: Single onboard (32GB/64GB/128GB)
- USB: 1x USB 2.0 port

MAC Address Structure:
The MAC address shares the structure DC:D8:7C:XX:XX:XX, where:
- WAN, LAN, and 2.4GHz WiFi interfaces use the same MAC as the label.
- 5GHz WiFi uses an offset of the label MAC + 0x800000.

(The label MAC address is located in the config partition at offset 0x4429 and it is hexadecimal encoded. Thanks to commit 7db87d7, no additional patch work is needed to support this format)

Flash Instruction:
A third-party bootloader is required to boot the image. (I use a "Clip" tool to flash the image through SPI for testing.)

note:
- The official bootloader does provide a web interface for recovering an official image though. To access it:
  1. Hold the reset button and power on the device.
  2. Set a manual IP address 192.168.68.2 on your computer.
  3. Visit http://192.168.68.1 in a web browser.
  
