### PR TITLE
mediatek: improve support for Buffalo WSR devices

### DIFF
--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -123,7 +123,7 @@ define Device/buffalo_wsr
 	buffalo-enc $$(DEVICE_MODEL) $$(BUFFALO_TAG_VERSION) -l | \
 	buffalo-tag-dhp $$(DEVICE_MODEL) JP JP | buffalo-enc-tag -l | buffalo-dhp-image
   IMAGE/factory-uboot.bin := append-ubi | \
-	buffalo-trx $$$$(BUFFALO_TRX_MAGIC) $$$$@ $(KDIR)/ubi_mark
+	buffalo-trx $$$$(BUFFALO_TRX_MAGIC) $$$$@ $(KDIR)/ubi_mark | append-metadata
   IMAGE/sysupgrade.bin := \
 	buffalo-trx $$$$(BUFFALO_TRX_MAGIC) $(KDIR)/tmp/$$(DEVICE_NAME).null | \
 	sysupgrade-tar kernel=$$$$@ | append-metadata

--- a/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/09_fix_crc
@@ -1,14 +1,22 @@
 . /lib/functions.sh
 
-kernel_size=$(sed -n 's/mtd[0-9]*: \([0-9a-f]*\).*"\(kernel\|linux\)".*/\1/p' /proc/mtd)
+# don't modify FW data when booting with initramfs image
+fstype="$(/bin/mount | awk '($3 ~ /^\/$/) && ($5 !~ /rootfs/) { print $5 }')"
+[ "$fstype" = "tmpfs" ] && \
+	exit 0
+
+fixup_trx_crc() {
+	local trx_magic="$1"
+	local kernel_size=$(sed -n 's/mtd[0-9]*: \([0-9a-f]*\).*"\(kernel\|linux\)".*/\1/p' /proc/mtd)
+
+	mtd -M $trx_magic ${kernel_size:+-c 0x$kernel_size} fixtrx firmware
+}
 
 case "$(board_name)" in
 buffalo,wsr-2533dhp2)
-	mtd -M 0x44485032 ${kernel_size:+-c 0x$kernel_size} fixtrx firmware && exit 0
-	exit 1
+	fixup_trx_crc 0x44485032
 	;;
 buffalo,wsr-3200ax4s)
-	mtd -M 0x44485033 ${kernel_size:+-c 0x$kernel_size} fixtrx firmware && exit 0
-	exit 1
+	fixup_trx_crc 0x44485033
 	;;
 esac

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -16,16 +16,7 @@ platform_do_upgrade() {
 		;;
 	buffalo,wsr-2533dhp2|\
 	buffalo,wsr-3200ax4s)
-		local magic="$(get_magic_long "$1")"
-
-		# use "mtd write" if the magic is "DHP2 (0x44485032)"
-		# or "DHP3 (0x44485033)"
-		if [ "$magic" = "44485032" -o "$magic" = "44485033" ]; then
-			buffalo_upgrade_ubinized "$1"
-		else
-			CI_KERNPART="firmware"
-			nand_do_upgrade "$1"
-		fi
+		buffalo_do_upgrade "$1"
 		;;
 	dlink,eagle-pro-ai-m32-a1|\
 	dlink,eagle-pro-ai-r32-a1|\


### PR DESCRIPTION
This patch series improves support of Buffalo WSR series devices.
These changes was applied for WSR-2533DHPLx devices in ramips/mt7621 and tested on WSR-2533DHP2.