### PR TITLE
ramips: mt7621: add support for JDCloud RE-SP-01B

### DIFF
--- a/target/linux/ramips/dts/mt7621_jdcloud_re-sp-01b.dts
+++ b/target/linux/ramips/dts/mt7621_jdcloud_re-sp-01b.dts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "jdcloud,re-sp-01b", "mediatek,mt7621-soc";
+	model = "JDCloud RE-SP-01B";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-blue {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1ab0000>;
+			};
+
+			partition@1b00000 {
+				label = "mini";
+				reg = <0x1b00000 0x400000>;
+				read-only;
+			};
+
+			partition@1f00000 {
+				label = "oem";
+				reg = <0x1f00000 0x100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1857,6 +1857,16 @@ define Device/jdcloud_re-cp-02
 endef
 TARGET_DEVICES += jdcloud_re-cp-02
 
+define Device/jdcloud_re-sp-01b
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 27328k
+  DEVICE_VENDOR := JDCloud
+  DEVICE_MODEL := RE-SP-01B
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware \
+	kmod-mmc-mtk kmod-usb3
+endef
+TARGET_DEVICES += jdcloud_re-sp-01b
+
 define Device/keenetic_kn-1910
   $(Device/nand)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -97,6 +97,7 @@ ramips_setup_interfaces()
 	iodata,wn-deax1800gr|\
 	iptime,a3002mesh|\
 	jcg,q20|\
+	jdcloud,re-sp-01b|\
 	lenovo,newifi-d1|\
 	mikrotik,routerboard-m33g|\
 	mts,wg430223|\
@@ -279,6 +280,11 @@ ramips_setup_macs()
 	iptime,t5004)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
+	jdcloud,re-sp-01b)
+		lan_mac=$(mtd_get_mac_ascii config mac)
+		wan_mac=$lan_mac
+		label_mac=$lan_mac
 		;;
 	linksys,e5600|\
 	linksys,ea6350-v4|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -130,6 +130,11 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0x4)" > /sys${DEVPATH}/macaddress
 		;;
+	jdcloud,re-sp-01b)
+		hw_mac_addr=$(mtd_get_mac_ascii config mac)
+		[ "$PHYNBR" = "0" ] && echo $hw_mac_addr > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 0x800000 > /sys${DEVPATH}/macaddress
+		;;
 	keenetic,kn-1910)
 		lan_mac_addr="$(mtd_get_mac_binary RF-EEPROM 0x4)"
 		[ "$PHYNBR" = "1" ] && \


### PR DESCRIPTION
JDCloud RE-SP-01B is a dual-band WiFi 5 router based on the MT7621AT.
  
  Specifications:
  - SoC: MediaTek MT7621AT
  - RAM: 512MB DDR3
  - Flash: 32MB SPI NOR
  - WiFi: MediaTek MT7603EN (2.4GHz), MediaTek MT7615N (5GHz)
  - Ethernet: 1x WAN, 2x LAN (Gigabit Ethernet)
  - LEDs: red, blue, green (GPIO controlled)
  - Button: Reset (GPIO controlled)
  - eMMC: Single onboard (32GB/64GB/128GB)
  - USB: 1x USB 2.0 port
  
  MAC Address Structure:
  The MAC addresses share the structure DC:D8:7C:XX:XX:XX, where:
  - WAN, LAN, and 2.4GHz WiFi: same as the label MAC address.
  - 5GHz WiFi: label MAC address + 0x800000.
  
  The manufacturer writes the label MAC address at different
  offsets depending on the storage version of the device:
  
  e.g.
  128GB version:  &config + 0x442a
  64GB version:   &config + 0x4429
  
  So `get_mac_ascii()` is used here to search for the
  base label MAC address of the device.
  
  Ref:
  https://github.com/openwrt/openwrt/pull/17409#discussion_r1899674262
  https://github.com/immortalwrt/immortalwrt/commit/c0c480d
  
  Flash Instruction:
  A 3rd party bootloader is required to boot the image. You can
  use a SOP16 test clip to burn the image/bootloader to the flash.
  
  The official bootloader does provide a web recovery interface
  which only accepts an official image. To access it, you will
  need to hold the reset button and power on the device, set your
  IP address to 192.168.68.2 and visit http://192.168.68.1.