### PR TITLE
bcm27xx/bcm2712: add RP1 camera front-end

### DIFF
--- a/target/linux/bcm27xx/modules/video.mk
+++ b/target/linux/bcm27xx/modules/video.mk
@@ -20,6 +20,25 @@ endef
 $(eval $(call KernelPackage,camera-bcm2835))
 
 
+define KernelPackage/rp1-cfe
+  TITLE:=RP1 Camera Front-End
+  SUBMENU:=$(VIDEO_MENU)
+  KCONFIG:= \
+     CONFIG_VIDEO_RP1_CFE \
+     CONFIG_VIDEO_BCM2835
+  FILES:=$(LINUX_DIR)/drivers/media/platform/raspberrypi/rp1_cfe/rp1-cfe.ko
+  AUTOLOAD:=$(call AutoLoad,67,rp1-cfe)
+  DEPENDS:=@TARGET_bcm27xx_bcm2712 +kmod-video-core +kmod-video-fwnode +kmod-video-dma-contig +kmod-video-async
+endef
+
+define KernelPackage/rp1-cfe/description
+  Driver for the Camera Serial Interface (CSI) to capture video
+  streams from connected cameras.
+endef
+
+$(eval $(call KernelPackage,rp1-cfe))
+
+
 define KernelPackage/codec-bcm2835
   TITLE:=BCM2835 Video Codec
   KCONFIG:= \


### PR DESCRIPTION
Add kmod for RP1 camera front-end for RPi5B

Build system: x86/64
Build-tested: bcm2712/RPi5B
Run-tested: bcm2712/RPi5B