### PR TITLE
qualcommax: ipq60xx: mr7350: remove leftover commented-out LED-s

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-mr7350.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-mr7350.dts
@@ -46,66 +46,6 @@
 	leds {
 		compatible = "gpio-leds";
 
-		/*lan1-amber {
-			label = "amber:lan1";
-			color = <LED_COLOR_ID_AMBER>;
-			gpios = <&qca8075_0 0 GPIO_ACTIVE_HIGH>;
-		};
-
-		lan1-green {
-			label = "green:lan1";
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&qca8075_0 1 GPIO_ACTIVE_HIGH>;
-		};
-
-		lan2-amber {
-			label = "amber:lan2";
-			color = <LED_COLOR_ID_AMBER>;
-			gpios = <&qca8075_1 0 GPIO_ACTIVE_HIGH>;
-		};
-
-		lan2-green {
-			label = "green:lan2";
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&qca8075_1 1 GPIO_ACTIVE_HIGH>;
-		};
-
-		lan3-amber {
-			label = "amber:lan3";
-			color = <LED_COLOR_ID_AMBER>;
-			gpios = <&qca8075_2 0 GPIO_ACTIVE_HIGH>;
-		};
-
-		lan3-green {
-			label = "green:lan3";
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&qca8075_2 1 GPIO_ACTIVE_HIGH>;
-		};
-
-		lan4-amber {
-			label = "amber:lan4";
-			color = <LED_COLOR_ID_AMBER>;
-			gpios = <&qca8075_3 0 GPIO_ACTIVE_HIGH>;
-		};
-
-		lan4-green {
-			label = "green:lan4";
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&qca8075_3 1 GPIO_ACTIVE_HIGH>;
-		};
-
-		wan-amber {
-			color = <LED_COLOR_ID_AMBER>;
-			function = LED_FUNCTION_WAN;
-			gpios = <&qca8075_4 0 GPIO_ACTIVE_HIGH>;
-		};
-
-		wan-green {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_WAN;
-			gpios = <&qca8075_4 1 GPIO_ACTIVE_HIGH>;
-		};*/
-
 		usb {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_USB;


### PR DESCRIPTION
These PHY LED-s are leftovers from a time when PHY LED offloading did not work like the stock FW, so remove them as they are commented-out anyway.
