### PR TITLE
ipq40xx: orbi: add ethernet0 alias

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -12,6 +12,7 @@
 		led-failsafe = &led_status_red;
 		led-running = &led_status_green;
 		led-upgrade = &led_status_blue;
+		ethernet0 = &gmac;
 		label-mac-device = &gmac;
 	};
 


### PR DESCRIPTION
Netgear Orbi devices rely on ethernet0 alias to be present to U-Boot will populate the MAC.

This fixes the random MAC on each boot after the ethernet0 alias was dropped from the SoC DTSI.

Fixes: cd9c7211241e ("ipq40xx: 6.1: use latest DSA and ethernet patches")
Fixes: #17384 
