### PR TITLE
kernel: packages: add pstore-blk and mtdpstore modules

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -713,3 +713,29 @@ define KernelPackage/pstore/description
 endef
 
 $(eval $(call KernelPackage,pstore))
+
+
+define KernelPackage/pstore-blk
+  SUBMENU:=$(FS_MENU)
+  TITLE:=Pstore file system for block devices
+  DEFAULT:=m if ALL_KMODS
+  KCONFIG:= \
+  CONFIG_PSTORE_ZONE \
+  CONFIG_PSTORE_BLK \
+  CONFIG_PSTORE_BLK_BLKDEV="pstore" \
+  CONFIG_PSTORE_BLK_KMSG_SIZE=64 \
+  CONFIG_PSTORE_BLK_MAX_REASON=2 \
+  CONFIG_PSTORE_BLK_PMSG_SIZE=64 \
+  CONFIG_PSTORE_BLK_CONSOLE_SIZE=64 \
+  CONFIG_PSTORE_BLK_FTRACE_SIZE=64
+  FILES:= $(LINUX_DIR)/fs/pstore/pstore_blk.ko \
+  $(LINUX_DIR)/fs/pstore/pstore_zone.ko
+  AUTOLOAD:=$(call AutoLoad,30,pstore-blk)
+  DEPENDS:=+kmod-pstore
+endef
+
+define KernelPackage/pstore-blk/description
+ Kernel module for Log panic/oops to a block device labelled pstore
+endef
+
+$(eval $(call KernelPackage,pstore-blk))

--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -622,6 +622,22 @@ endef
 $(eval $(call KernelPackage,mtdoops))
 
 
+define KernelPackage/mtdpstore
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Log panic/oops to an MTD buffer based on pstore
+  KCONFIG:=CONFIG_MTD_PSTORE
+  DEPENDS:=+kmod-pstore-blk
+  FILES:=$(LINUX_DIR)/drivers/mtd/mtdpstore.ko
+  AUTOLOAD:=$(call AutoLoad,30,mtdpstore,1)
+endef
+
+define KernelPackage/mtdpstore/description
+ Kernel modules for Log panic/oops to an MTD buffer based on pstore
+endef
+
+$(eval $(call KernelPackage,mtdpstore))
+
+
 define KernelPackage/mtdram
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Test MTD driver using RAM


### PR DESCRIPTION
pstore-blk offers non-volatile storage for pstore, allowing more flexibility to collect oops or panic messages in situations in which ramoops won't work.

Furthermore, mtdpstore extends that flexibility to devices with mtd storage.

This PR adds those modules so oops/panic logs can be written to an mtd partition labelled as 'pstore' for later retrieval.

These changes have been tested on a real world situation in which I had to troubleshoot a kernel panic triggered by a led driver.

To increase the chances of catching the log during the crash, pstore shouldn't use compression but that module is shared with ramoops which has traditionally used it, although that is possibly not necessary on modern devices, even embedded ones. There is a conversation in this regard that is relevant: https://github.com/openwrt/openwrt/pull/16705

NOTE: this is the same PR as https://github.com/openwrt/openwrt/pull/17397 which I mistakenly opened using the main branch of my fork.