### PR TITLE
ath79: add missing compatible for ath9k

### DIFF
--- a/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
+++ b/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
@@ -141,6 +141,7 @@
 	status = "okay";
 
 	ath9k: wifi@0,0 {
+		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
 		#gpio-cells = <2>;
 		gpio-controller;


### PR DESCRIPTION
The fritz 300e has an AR9382, which is atypical for ar7242 platforms. Document it properly.