### PR TITLE
mediatek: Fix primary MAC of D-Link M60

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
+++ b/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
@@ -17,6 +17,7 @@
 		led-failsafe = &led_status_red;
 		led-running = &led_status_white;
 		led-upgrade = &led_status_blue;
+		label-mac-device = &gmac0;
 	};
 
 	chosen {


### PR DESCRIPTION
During port to gluon, I saw that the primary mac is not correct. Updated DTS accordingly.