### PR TITLE
mediatek: Fixed phy6 DTS settings

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
+++ b/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
@@ -87,9 +87,8 @@
 		reset-post-delay-us = <1000000>;
 
 		phy6: phy@6 {
-			compatible = "maxlinear,gpy211", "ethernet-phy-ieee802.3-c45";
+			compatible = "ethernet-phy-ieee802.3-c45";
 			reg = <6>;
-			phy-mode = "2500base-x";
 		};
 
 		switch@1f {


### PR DESCRIPTION
Settings for phy6 can be simplified in the DTS