### PR TITLE
ipq40xx: add ethernet0 alias

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -12,7 +12,6 @@
 		led-failsafe = &led_status_red;
 		led-running = &led_status_green;
 		led-upgrade = &led_status_blue;
-		ethernet0 = &gmac;
 		label-mac-device = &gmac;
 	};
 

--- a/target/linux/ipq40xx/patches-6.6/712-arm-dts-ipq4019-add-ethernet-controller-DT-node.patch
+++ b/target/linux/ipq40xx/patches-6.6/712-arm-dts-ipq4019-add-ethernet-controller-DT-node.patch
@@ -1,0 +1,22 @@
+From: Andre Heider <a.heider@gmail.com>
+Date: Wed, 20 Oct 2021 13:21:45 +0200
+Subject: [PATCH] arm: dts: ipq4019: add ethernet controller DT alias
+
+Add an alias for the IPQESS controller so that the MAC can be set
+properly.
+
+Signed-off-by: Andre Heider <a.heider@gmail.com>
+---
+ arch/arm/boot/dts/qcom-ipq4019.dtsi | 48 +++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+--- a/arch/arm/boot/dts/qcom/qcom-ipq4019.dtsi
++++ b/arch/arm/boot/dts/qcom/qcom-ipq4019.dtsi
+@@ -38,6 +38,7 @@
+ 		spi1 = &blsp1_spi2;
+ 		i2c0 = &blsp1_i2c3;
+ 		i2c1 = &blsp1_i2c4;
++		ethernet0 = &gmac;
+ 	};
+ 
+ 	cpus {


### PR DESCRIPTION
This fixes "ipqess-edma c080000.ethernet: using random MAC address" on each boot after the ethernet0 alias was dropped from the SoC DTSI.

This reverts commit 9ea174c7bf64ec34e96871ce223d7a597ca80d26.

Fixes: cd9c7211241e ("ipq40xx: 6.1: use latest DSA and ethernet patches")