### PR TITLE
generic: 6.6: backport upstream r8169 patches

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -970,7 +970,7 @@ $(eval $(call KernelPackage,8139cp))
 define KernelPackage/r8169
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=RealTek RTL-8169 PCI Gigabit Ethernet Adapter kernel support
-  DEPENDS:=@PCI_SUPPORT +kmod-mii +r8169-firmware +kmod-phy-realtek +kmod-mdio-devres
+  DEPENDS:=@PCI_SUPPORT +kmod-mii +r8169-firmware +kmod-phy-realtek +kmod-mdio-devres +kmod-hwmon-core
   KCONFIG:= \
     CONFIG_R8169 \
     CONFIG_R8169_LEDS=y

--- a/target/linux/generic/backport-6.6/780-24-v6.13-r8169-add-support-for-the-temperature-sensor-being-a.patch
+++ b/target/linux/generic/backport-6.6/780-24-v6.13-r8169-add-support-for-the-temperature-sensor-being-a.patch
@@ -1,0 +1,83 @@
+From 1ffcc8d41306fd2e5f140b276820714a26a11cc4 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Mon, 7 Oct 2024 20:34:12 +0200
+Subject: [PATCH] r8169: add support for the temperature sensor being available
+ from RTL8125B
+
+This adds support for the temperature sensor being available from
+RTL8125B. Register information was taken from r8125 vendor driver.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 44 +++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -16,6 +16,7 @@
+ #include <linux/clk.h>
+ #include <linux/delay.h>
+ #include <linux/ethtool.h>
++#include <linux/hwmon.h>
+ #include <linux/phy.h>
+ #include <linux/if_vlan.h>
+ #include <linux/in.h>
+@@ -5373,6 +5374,43 @@ static bool rtl_aspm_is_safe(struct rtl8
+ 	return false;
+ }
+ 
++static umode_t r8169_hwmon_is_visible(const void *drvdata,
++				      enum hwmon_sensor_types type,
++				      u32 attr, int channel)
++{
++	return 0444;
++}
++
++static int r8169_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
++			    u32 attr, int channel, long *val)
++{
++	struct rtl8169_private *tp = dev_get_drvdata(dev);
++	int val_raw;
++
++	val_raw = phy_read_paged(tp->phydev, 0xbd8, 0x12) & 0x3ff;
++	if (val_raw >= 512)
++		val_raw -= 1024;
++
++	*val = 1000 * val_raw / 2;
++
++	return 0;
++}
++
++static const struct hwmon_ops r8169_hwmon_ops = {
++	.is_visible =  r8169_hwmon_is_visible,
++	.read = r8169_hwmon_read,
++};
++
++static const struct hwmon_channel_info * const r8169_hwmon_info[] = {
++	HWMON_CHANNEL_INFO(temp, HWMON_T_INPUT),
++	NULL
++};
++
++static const struct hwmon_chip_info r8169_hwmon_chip_info = {
++	.ops = &r8169_hwmon_ops,
++	.info = r8169_hwmon_info,
++};
++
+ static int rtl_init_one(struct pci_dev *pdev, const struct pci_device_id *ent)
+ {
+ 	struct rtl8169_private *tp;
+@@ -5547,6 +5585,12 @@ static int rtl_init_one(struct pci_dev *
+ 	if (rc)
+ 		return rc;
+ 
++	/* The temperature sensor is available from RTl8125B */
++	if (IS_REACHABLE(CONFIG_HWMON) && tp->mac_version >= RTL_GIGA_MAC_VER_63)
++		/* ignore errors */
++		devm_hwmon_device_register_with_info(&pdev->dev, "nic_temp", tp,
++						     &r8169_hwmon_chip_info,
++						     NULL);
+ 	rc = register_netdev(dev);
+ 	if (rc)
+ 		return rc;

--- a/target/linux/generic/backport-6.6/780-25-v6.13-r8169-remove-original-workaround-for-RTL8125-broken-.patch
+++ b/target/linux/generic/backport-6.6/780-25-v6.13-r8169-remove-original-workaround-for-RTL8125-broken-.patch
@@ -1,0 +1,33 @@
+From 854d71c555dfc3383c1fde7d9989b6046e21093d Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Wed, 9 Oct 2024 07:48:05 +0200
+Subject: [PATCH] r8169: remove original workaround for RTL8125 broken rx issue
+
+Now that we have b9c7ac4fe22c ("r8169: disable ALDPS per default for
+RTL8125"), the first attempt to fix the issue shouldn't be needed
+any longer. So let's effectively revert 621735f59064 ("r8169: fix
+rare issue with broken rx after link-down on RTL8125") and see
+whether anybody complains.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/382d8c88-cbce-400f-ad62-fda0181c7e38@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -4779,11 +4779,7 @@ static void r8169_phylink_handler(struct
+ 	if (netif_carrier_ok(ndev)) {
+ 		rtl_link_chg_patch(tp);
+ 		pm_request_resume(d);
+-		netif_wake_queue(tp->dev);
+ 	} else {
+-		/* In few cases rx is broken after link-down otherwise */
+-		if (rtl_is_8125(tp))
+-			rtl_schedule_task(tp, RTL_FLAG_TASK_RESET_NO_QUEUE_WAKE);
+ 		pm_runtime_idle(d);
+ 	}
+ 

--- a/target/linux/generic/backport-6.6/780-26-v6.13-r8169-enable-SG-TSO-on-selected-chip-versions-per-de.patch
+++ b/target/linux/generic/backport-6.6/780-26-v6.13-r8169-enable-SG-TSO-on-selected-chip-versions-per-de.patch
@@ -1,0 +1,52 @@
+From b8bf38440ba94e8ed8e2ae55c5dfb0276d30e843 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Thu, 10 Oct 2024 12:58:02 +0200
+Subject: [PATCH] r8169: enable SG/TSO on selected chip versions per default
+
+Due to problem reports in the past SG and TSO/TSO6 are disabled per
+default. It's not fully clear which chip versions are affected, so we
+may impact also users of unaffected chip versions, unless they know
+how to use ethtool for enabling SG/TSO/TSO6.
+Vendor drivers r8168/r8125 enable SG/TSO/TSO6 for selected chip
+versions per default, I'd interpret this as confirmation that these
+chip versions are unaffected. So let's do the same here.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 16 +++++++++++-----
+ 1 file changed, 11 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -5529,11 +5529,6 @@ static int rtl_init_one(struct pci_dev *
+ 
+ 	dev->features |= dev->hw_features;
+ 
+-	/* There has been a number of reports that using SG/TSO results in
+-	 * tx timeouts. However for a lot of people SG/TSO works fine.
+-	 * Therefore disable both features by default, but allow users to
+-	 * enable them. Use at own risk!
+-	 */
+ 	if (rtl_chip_supports_csum_v2(tp)) {
+ 		dev->hw_features |= NETIF_F_SG | NETIF_F_TSO | NETIF_F_TSO6;
+ 		netif_set_tso_max_size(dev, RTL_GSO_MAX_SIZE_V2);
+@@ -5544,6 +5539,17 @@ static int rtl_init_one(struct pci_dev *
+ 		netif_set_tso_max_segs(dev, RTL_GSO_MAX_SEGS_V1);
+ 	}
+ 
++	/* There has been a number of reports that using SG/TSO results in
++	 * tx timeouts. However for a lot of people SG/TSO works fine.
++	 * It's not fully clear which chip versions are affected. Vendor
++	 * drivers enable SG/TSO for certain chip versions per default,
++	 * let's mimic this here. On other chip versions users can
++	 * use ethtool to enable SG/TSO, use at own risk!
++	 */
++	if (tp->mac_version >= RTL_GIGA_MAC_VER_46 &&
++	    tp->mac_version != RTL_GIGA_MAC_VER_61)
++		dev->features |= dev->hw_features;
++
+ 	dev->hw_features |= NETIF_F_RXALL;
+ 	dev->hw_features |= NETIF_F_RXFCS;
+ 

--- a/target/linux/generic/backport-6.6/780-27-v6.13-r8169-implement-additional-ethtool-stats-ops.patch
+++ b/target/linux/generic/backport-6.6/780-27-v6.13-r8169-implement-additional-ethtool-stats-ops.patch
@@ -1,0 +1,130 @@
+From e3fc5139bd8ffaa1498adc21be4e8ecbc6aed508 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Sun, 13 Oct 2024 11:17:39 +0200
+Subject: [PATCH] r8169: implement additional ethtool stats ops
+
+This adds support for ethtool standard statistics, and makes use of the
+extended hardware statistics being available from RTl8125.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/58e0da73-a7dd-4be3-82ae-d5b3f9069bde@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 82 +++++++++++++++++++++++
+ 1 file changed, 82 insertions(+)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -2162,6 +2162,19 @@ static void rtl8169_get_ringparam(struct
+ 	data->tx_pending = NUM_TX_DESC;
+ }
+ 
++static void rtl8169_get_pause_stats(struct net_device *dev,
++				    struct ethtool_pause_stats *pause_stats)
++{
++	struct rtl8169_private *tp = netdev_priv(dev);
++
++	if (!rtl_is_8125(tp))
++		return;
++
++	rtl8169_update_counters(tp);
++	pause_stats->tx_pause_frames = le32_to_cpu(tp->counters->tx_pause_on);
++	pause_stats->rx_pause_frames = le32_to_cpu(tp->counters->rx_pause_on);
++}
++
+ static void rtl8169_get_pauseparam(struct net_device *dev,
+ 				   struct ethtool_pauseparam *data)
+ {
+@@ -2188,6 +2201,69 @@ static int rtl8169_set_pauseparam(struct
+ 	return 0;
+ }
+ 
++static void rtl8169_get_eth_mac_stats(struct net_device *dev,
++				      struct ethtool_eth_mac_stats *mac_stats)
++{
++	struct rtl8169_private *tp = netdev_priv(dev);
++
++	rtl8169_update_counters(tp);
++
++	mac_stats->FramesTransmittedOK =
++		le64_to_cpu(tp->counters->tx_packets);
++	mac_stats->SingleCollisionFrames =
++		le32_to_cpu(tp->counters->tx_one_collision);
++	mac_stats->MultipleCollisionFrames =
++		le32_to_cpu(tp->counters->tx_multi_collision);
++	mac_stats->FramesReceivedOK =
++		le64_to_cpu(tp->counters->rx_packets);
++	mac_stats->AlignmentErrors =
++		le16_to_cpu(tp->counters->align_errors);
++	mac_stats->FramesLostDueToIntMACXmitError =
++		le64_to_cpu(tp->counters->tx_errors);
++	mac_stats->BroadcastFramesReceivedOK =
++		le64_to_cpu(tp->counters->rx_broadcast);
++	mac_stats->MulticastFramesReceivedOK =
++		le32_to_cpu(tp->counters->rx_multicast);
++
++	if (!rtl_is_8125(tp))
++		return;
++
++	mac_stats->AlignmentErrors =
++		le32_to_cpu(tp->counters->align_errors32);
++	mac_stats->OctetsTransmittedOK =
++		le64_to_cpu(tp->counters->tx_octets);
++	mac_stats->LateCollisions =
++		le32_to_cpu(tp->counters->tx_late_collision);
++	mac_stats->FramesAbortedDueToXSColls =
++		le32_to_cpu(tp->counters->tx_aborted32);
++	mac_stats->OctetsReceivedOK =
++		le64_to_cpu(tp->counters->rx_octets);
++	mac_stats->FramesLostDueToIntMACRcvError =
++		le32_to_cpu(tp->counters->rx_mac_error);
++	mac_stats->MulticastFramesXmittedOK =
++		le64_to_cpu(tp->counters->tx_multicast64);
++	mac_stats->BroadcastFramesXmittedOK =
++		le64_to_cpu(tp->counters->tx_broadcast64);
++	mac_stats->MulticastFramesReceivedOK =
++		le64_to_cpu(tp->counters->rx_multicast64);
++	 mac_stats->FrameTooLongErrors =
++		le32_to_cpu(tp->counters->rx_frame_too_long);
++}
++
++static void rtl8169_get_eth_ctrl_stats(struct net_device *dev,
++				       struct ethtool_eth_ctrl_stats *ctrl_stats)
++{
++	struct rtl8169_private *tp = netdev_priv(dev);
++
++	if (!rtl_is_8125(tp))
++		return;
++
++	rtl8169_update_counters(tp);
++
++	ctrl_stats->UnsupportedOpcodesReceived =
++		le32_to_cpu(tp->counters->rx_unknown_opcode);
++}
++
+ static const struct ethtool_ops rtl8169_ethtool_ops = {
+ 	.supported_coalesce_params = ETHTOOL_COALESCE_USECS |
+ 				     ETHTOOL_COALESCE_MAX_FRAMES,
+@@ -2209,8 +2285,11 @@ static const struct ethtool_ops rtl8169_
+ 	.get_link_ksettings	= phy_ethtool_get_link_ksettings,
+ 	.set_link_ksettings	= phy_ethtool_set_link_ksettings,
+ 	.get_ringparam		= rtl8169_get_ringparam,
++	.get_pause_stats	= rtl8169_get_pause_stats,
+ 	.get_pauseparam		= rtl8169_get_pauseparam,
+ 	.set_pauseparam		= rtl8169_set_pauseparam,
++	.get_eth_mac_stats	= rtl8169_get_eth_mac_stats,
++	.get_eth_ctrl_stats	= rtl8169_get_eth_ctrl_stats,
+ };
+ 
+ static enum mac_version rtl8169_get_mac_version(u16 xid, bool gmii)
+@@ -3895,6 +3974,9 @@ static void rtl_hw_start_8125(struct rtl
+ 		break;
+ 	}
+ 
++	/* enable extended tally counter */
++	r8168_mac_ocp_modify(tp, 0xea84, 0, BIT(1) | BIT(0));
++
+ 	rtl_hw_config(tp);
+ }
+ 

--- a/target/linux/generic/backport-6.6/780-28-v6.13-r8169-don-t-take-RTNL-lock-in-rtl_task.patch
+++ b/target/linux/generic/backport-6.6/780-28-v6.13-r8169-don-t-take-RTNL-lock-in-rtl_task.patch
@@ -1,0 +1,50 @@
+From ac48430368c1a4f4e6c2fa92243b4b93fd25bee4 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Wed, 16 Oct 2024 22:05:57 +0200
+Subject: [PATCH] r8169: don't take RTNL lock in rtl_task()
+
+There's not really a benefit here in taking the RTNL lock. The task
+handler does exception handling only, so we're in trouble anyway when
+we come here, and there's no need to protect against e.g. a parallel
+ethtool call.
+A benefit of removing the RTNL lock here is that we now can
+synchronously cancel the workqueue from a context holding the RTNL mutex.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Signed-off-by: Andrew Lunn <andrew@lunn.ch>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -4802,10 +4802,8 @@ static void rtl_task(struct work_struct
+ 		container_of(work, struct rtl8169_private, wk.work);
+ 	int ret;
+ 
+-	rtnl_lock();
+-
+ 	if (!test_bit(RTL_FLAG_TASK_ENABLED, tp->wk.flags))
+-		goto out_unlock;
++		return;
+ 
+ 	if (test_and_clear_bit(RTL_FLAG_TASK_TX_TIMEOUT, tp->wk.flags)) {
+ 		/* if chip isn't accessible, reset bus to revive it */
+@@ -4814,7 +4812,7 @@ static void rtl_task(struct work_struct
+ 			if (ret < 0) {
+ 				netdev_err(tp->dev, "Can't reset secondary PCI bus, detach NIC\n");
+ 				netif_device_detach(tp->dev);
+-				goto out_unlock;
++				return;
+ 			}
+ 		}
+ 
+@@ -4833,8 +4831,6 @@ reset:
+ 	} else if (test_and_clear_bit(RTL_FLAG_TASK_RESET_NO_QUEUE_WAKE, tp->wk.flags)) {
+ 		rtl_reset_work(tp);
+ 	}
+-out_unlock:
+-	rtnl_unlock();
+ }
+ 
+ static int rtl8169_poll(struct napi_struct *napi, int budget)

--- a/target/linux/generic/backport-6.6/780-30-v6.13-r8169-avoid-duplicated-messages-if-loading-firmware-.patch
+++ b/target/linux/generic/backport-6.6/780-30-v6.13-r8169-avoid-duplicated-messages-if-loading-firmware-.patch
@@ -1,0 +1,41 @@
+From 1c105bacb160b5918e917ab811552b7be69fc69c Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Wed, 16 Oct 2024 22:29:39 +0200
+Subject: [PATCH] r8169: avoid duplicated messages if loading firmware fails
+ and switch to warn level
+
+In case of a problem with firmware loading we inform at the driver level,
+in addition the firmware load code itself issues warnings. Therefore
+switch to firmware_request_nowarn() to avoid duplicated error messages.
+In addition switch to warn level because the firmware is optional and
+typically just fixes compatibility issues.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Message-ID: <d9c5094c-89a6-40e2-b5fe-8df7df4624ef@gmail.com>
+Signed-off-by: Andrew Lunn <andrew@lunn.ch>
+---
+ drivers/net/ethernet/realtek/r8169_firmware.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_firmware.c
++++ b/drivers/net/ethernet/realtek/r8169_firmware.c
+@@ -215,7 +215,7 @@ int rtl_fw_request_firmware(struct rtl_f
+ {
+ 	int rc;
+ 
+-	rc = request_firmware(&rtl_fw->fw, rtl_fw->fw_name, rtl_fw->dev);
++	rc = firmware_request_nowarn(&rtl_fw->fw, rtl_fw->fw_name, rtl_fw->dev);
+ 	if (rc < 0)
+ 		goto out;
+ 
+@@ -227,7 +227,7 @@ int rtl_fw_request_firmware(struct rtl_f
+ 
+ 	return 0;
+ out:
+-	dev_err(rtl_fw->dev, "Unable to load firmware %s (%d)\n",
+-		rtl_fw->fw_name, rc);
++	dev_warn(rtl_fw->dev, "Unable to load firmware %s (%d)\n",
++		 rtl_fw->fw_name, rc);
+ 	return rc;
+ }

--- a/target/linux/generic/backport-6.6/780-31-v6.13-r8169-remove-rtl_dash_loop_wait_high-low.patch
+++ b/target/linux/generic/backport-6.6/780-31-v6.13-r8169-remove-rtl_dash_loop_wait_high-low.patch
@@ -1,0 +1,82 @@
+From d64113c6bb5ea5a70b7c9c3a6bcadef307638187 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Wed, 16 Oct 2024 22:31:10 +0200
+Subject: [PATCH] r8169: remove rtl_dash_loop_wait_high/low
+
+Remove rtl_dash_loop_wait_high/low to simplify the code.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Message-ID: <fb8c490c-2d92-48f5-8bbf-1fc1f2ee1649@gmail.com>
+Signed-off-by: Andrew Lunn <andrew@lunn.ch>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 35 ++++++-----------------
+ 1 file changed, 8 insertions(+), 27 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -1347,40 +1347,19 @@ static void rtl8168ep_stop_cmac(struct r
+ 	RTL_W8(tp, IBCR0, RTL_R8(tp, IBCR0) & ~0x01);
+ }
+ 
+-static void rtl_dash_loop_wait(struct rtl8169_private *tp,
+-			       const struct rtl_cond *c,
+-			       unsigned long usecs, int n, bool high)
+-{
+-	if (!tp->dash_enabled)
+-		return;
+-	rtl_loop_wait(tp, c, usecs, n, high);
+-}
+-
+-static void rtl_dash_loop_wait_high(struct rtl8169_private *tp,
+-				    const struct rtl_cond *c,
+-				    unsigned long d, int n)
+-{
+-	rtl_dash_loop_wait(tp, c, d, n, true);
+-}
+-
+-static void rtl_dash_loop_wait_low(struct rtl8169_private *tp,
+-				   const struct rtl_cond *c,
+-				   unsigned long d, int n)
+-{
+-	rtl_dash_loop_wait(tp, c, d, n, false);
+-}
+-
+ static void rtl8168dp_driver_start(struct rtl8169_private *tp)
+ {
+ 	r8168dp_oob_notify(tp, OOB_CMD_DRIVER_START);
+-	rtl_dash_loop_wait_high(tp, &rtl_dp_ocp_read_cond, 10000, 10);
++	if (tp->dash_enabled)
++		rtl_loop_wait_high(tp, &rtl_dp_ocp_read_cond, 10000, 10);
+ }
+ 
+ static void rtl8168ep_driver_start(struct rtl8169_private *tp)
+ {
+ 	r8168ep_ocp_write(tp, 0x01, 0x180, OOB_CMD_DRIVER_START);
+ 	r8168ep_ocp_write(tp, 0x01, 0x30, r8168ep_ocp_read(tp, 0x30) | 0x01);
+-	rtl_dash_loop_wait_high(tp, &rtl_ep_ocp_read_cond, 10000, 30);
++	if (tp->dash_enabled)
++		rtl_loop_wait_high(tp, &rtl_ep_ocp_read_cond, 10000, 30);
+ }
+ 
+ static void rtl8168_driver_start(struct rtl8169_private *tp)
+@@ -1394,7 +1373,8 @@ static void rtl8168_driver_start(struct
+ static void rtl8168dp_driver_stop(struct rtl8169_private *tp)
+ {
+ 	r8168dp_oob_notify(tp, OOB_CMD_DRIVER_STOP);
+-	rtl_dash_loop_wait_low(tp, &rtl_dp_ocp_read_cond, 10000, 10);
++	if (tp->dash_enabled)
++		rtl_loop_wait_low(tp, &rtl_dp_ocp_read_cond, 10000, 10);
+ }
+ 
+ static void rtl8168ep_driver_stop(struct rtl8169_private *tp)
+@@ -1402,7 +1382,8 @@ static void rtl8168ep_driver_stop(struct
+ 	rtl8168ep_stop_cmac(tp);
+ 	r8168ep_ocp_write(tp, 0x01, 0x180, OOB_CMD_DRIVER_STOP);
+ 	r8168ep_ocp_write(tp, 0x01, 0x30, r8168ep_ocp_read(tp, 0x30) | 0x01);
+-	rtl_dash_loop_wait_low(tp, &rtl_ep_ocp_read_cond, 10000, 10);
++	if (tp->dash_enabled)
++		rtl_loop_wait_low(tp, &rtl_ep_ocp_read_cond, 10000, 10);
+ }
+ 
+ static void rtl8168_driver_stop(struct rtl8169_private *tp)

--- a/target/linux/generic/backport-6.6/780-32-v6.13-r8169-enable-EEE-at-2.5G-per-default-on-RTL8125B.patch
+++ b/target/linux/generic/backport-6.6/780-32-v6.13-r8169-enable-EEE-at-2.5G-per-default-on-RTL8125B.patch
@@ -1,0 +1,28 @@
+From c4e64095c00cb2de413cd6b90be047c273bcd491 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Thu, 17 Oct 2024 22:27:44 +0200
+Subject: [PATCH] r8169: enable EEE at 2.5G per default on RTL8125B
+
+Register a6d/12 is shadowing register MDIO_AN_EEE_ADV2. So this line
+disables advertisement of EEE at 2.5G. Latest vendor driver r8125
+doesn't do this (any longer?), so this mode seems to be safe.
+EEE saves quite some energy, therefore enable this mode per default.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Message-ID: <95dd5a0c-09ea-4847-94d9-b7aa3063e8ff@gmail.com>
+Signed-off-by: Andrew Lunn <andrew@lunn.ch>
+---
+ drivers/net/ethernet/realtek/r8169_phy_config.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_phy_config.c
++++ b/drivers/net/ethernet/realtek/r8169_phy_config.c
+@@ -99,7 +99,6 @@ static void rtl8125a_config_eee_phy(stru
+ 
+ static void rtl8125b_config_eee_phy(struct phy_device *phydev)
+ {
+-	phy_modify_paged(phydev, 0xa6d, 0x12, 0x0001, 0x0000);
+ 	phy_modify_paged(phydev, 0xa6d, 0x14, 0x0010, 0x0000);
+ 	phy_modify_paged(phydev, 0xa42, 0x14, 0x0080, 0x0000);
+ 	phy_modify_paged(phydev, 0xa4a, 0x11, 0x0200, 0x0000);

--- a/target/linux/generic/backport-6.6/780-33-v6.13-r8169-add-support-for-RTL8125D.patch
+++ b/target/linux/generic/backport-6.6/780-33-v6.13-r8169-add-support-for-RTL8125D.patch
@@ -1,0 +1,143 @@
+From f75d1fbe7809bc5ed134204b920fd9e2fc5db1df Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Thu, 24 Oct 2024 22:42:33 +0200
+Subject: [PATCH] r8169: add support for RTL8125D
+
+This adds support for new chip version RTL8125D, which can be found on
+boards like Gigabyte X870E AORUS ELITE WIFI7. Firmware rtl8125d-1.fw
+for this chip version is available in linux-firmware already.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/d0306912-e88e-4c25-8b5d-545ae8834c0c@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169.h          |  1 +
+ drivers/net/ethernet/realtek/r8169_main.c     | 23 +++++++++++++------
+ .../net/ethernet/realtek/r8169_phy_config.c   | 10 ++++++++
+ 3 files changed, 27 insertions(+), 7 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169.h
++++ b/drivers/net/ethernet/realtek/r8169.h
+@@ -68,6 +68,7 @@ enum mac_version {
+ 	/* support for RTL_GIGA_MAC_VER_60 has been removed */
+ 	RTL_GIGA_MAC_VER_61,
+ 	RTL_GIGA_MAC_VER_63,
++	RTL_GIGA_MAC_VER_64,
+ 	RTL_GIGA_MAC_VER_65,
+ 	RTL_GIGA_MAC_VER_66,
+ 	RTL_GIGA_MAC_NONE
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -56,6 +56,7 @@
+ #define FIRMWARE_8107E_2	"rtl_nic/rtl8107e-2.fw"
+ #define FIRMWARE_8125A_3	"rtl_nic/rtl8125a-3.fw"
+ #define FIRMWARE_8125B_2	"rtl_nic/rtl8125b-2.fw"
++#define FIRMWARE_8125D_1	"rtl_nic/rtl8125d-1.fw"
+ #define FIRMWARE_8126A_2	"rtl_nic/rtl8126a-2.fw"
+ #define FIRMWARE_8126A_3	"rtl_nic/rtl8126a-3.fw"
+ 
+@@ -139,6 +140,7 @@ static const struct {
+ 	[RTL_GIGA_MAC_VER_61] = {"RTL8125A",		FIRMWARE_8125A_3},
+ 	/* reserve 62 for CFG_METHOD_4 in the vendor driver */
+ 	[RTL_GIGA_MAC_VER_63] = {"RTL8125B",		FIRMWARE_8125B_2},
++	[RTL_GIGA_MAC_VER_64] = {"RTL8125D",		FIRMWARE_8125D_1},
+ 	[RTL_GIGA_MAC_VER_65] = {"RTL8126A",		FIRMWARE_8126A_2},
+ 	[RTL_GIGA_MAC_VER_66] = {"RTL8126A",		FIRMWARE_8126A_3},
+ };
+@@ -708,6 +710,7 @@ MODULE_FIRMWARE(FIRMWARE_8168FP_3);
+ MODULE_FIRMWARE(FIRMWARE_8107E_2);
+ MODULE_FIRMWARE(FIRMWARE_8125A_3);
+ MODULE_FIRMWARE(FIRMWARE_8125B_2);
++MODULE_FIRMWARE(FIRMWARE_8125D_1);
+ MODULE_FIRMWARE(FIRMWARE_8126A_2);
+ MODULE_FIRMWARE(FIRMWARE_8126A_3);
+ 
+@@ -2080,10 +2083,7 @@ static void rtl_set_eee_txidle_timer(str
+ 		tp->tx_lpi_timer = timer_val;
+ 		r8168_mac_ocp_write(tp, 0xe048, timer_val);
+ 		break;
+-	case RTL_GIGA_MAC_VER_61:
+-	case RTL_GIGA_MAC_VER_63:
+-	case RTL_GIGA_MAC_VER_65:
+-	case RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_66:
+ 		tp->tx_lpi_timer = timer_val;
+ 		RTL_W16(tp, EEE_TXIDLE_TIMER_8125, timer_val);
+ 		break;
+@@ -2295,6 +2295,9 @@ static enum mac_version rtl8169_get_mac_
+ 		{ 0x7cf, 0x64a,	RTL_GIGA_MAC_VER_66 },
+ 		{ 0x7cf, 0x649,	RTL_GIGA_MAC_VER_65 },
+ 
++		/* 8125D family. */
++		{ 0x7cf, 0x688,	RTL_GIGA_MAC_VER_64 },
++
+ 		/* 8125B family. */
+ 		{ 0x7cf, 0x641,	RTL_GIGA_MAC_VER_63 },
+ 
+@@ -2562,9 +2565,7 @@ static void rtl_init_rxcfg(struct rtl816
+ 	case RTL_GIGA_MAC_VER_61:
+ 		RTL_W32(tp, RxConfig, RX_FETCH_DFLT_8125 | RX_DMA_BURST);
+ 		break;
+-	case RTL_GIGA_MAC_VER_63:
+-	case RTL_GIGA_MAC_VER_65:
+-	case RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_63 ... RTL_GIGA_MAC_VER_66:
+ 		RTL_W32(tp, RxConfig, RX_FETCH_DFLT_8125 | RX_DMA_BURST |
+ 			RX_PAUSE_SLOT_ON);
+ 		break;
+@@ -3876,6 +3877,12 @@ static void rtl_hw_start_8125b(struct rt
+ 	rtl_hw_start_8125_common(tp);
+ }
+ 
++static void rtl_hw_start_8125d(struct rtl8169_private *tp)
++{
++	rtl_set_def_aspm_entry_latency(tp);
++	rtl_hw_start_8125_common(tp);
++}
++
+ static void rtl_hw_start_8126a(struct rtl8169_private *tp)
+ {
+ 	rtl_set_def_aspm_entry_latency(tp);
+@@ -3924,6 +3931,7 @@ static void rtl_hw_config(struct rtl8169
+ 		[RTL_GIGA_MAC_VER_53] = rtl_hw_start_8117,
+ 		[RTL_GIGA_MAC_VER_61] = rtl_hw_start_8125a_2,
+ 		[RTL_GIGA_MAC_VER_63] = rtl_hw_start_8125b,
++		[RTL_GIGA_MAC_VER_64] = rtl_hw_start_8125d,
+ 		[RTL_GIGA_MAC_VER_65] = rtl_hw_start_8126a,
+ 		[RTL_GIGA_MAC_VER_66] = rtl_hw_start_8126a,
+ 	};
+@@ -3941,6 +3949,7 @@ static void rtl_hw_start_8125(struct rtl
+ 	/* disable interrupt coalescing */
+ 	switch (tp->mac_version) {
+ 	case RTL_GIGA_MAC_VER_61:
++	case RTL_GIGA_MAC_VER_64:
+ 		for (i = 0xa00; i < 0xb00; i += 4)
+ 			RTL_W32(tp, i, 0);
+ 		break;
+--- a/drivers/net/ethernet/realtek/r8169_phy_config.c
++++ b/drivers/net/ethernet/realtek/r8169_phy_config.c
+@@ -1103,6 +1103,15 @@ static void rtl8125b_hw_phy_config(struc
+ 	rtl8125b_config_eee_phy(phydev);
+ }
+ 
++static void rtl8125d_hw_phy_config(struct rtl8169_private *tp,
++				   struct phy_device *phydev)
++{
++	r8169_apply_firmware(tp);
++	rtl8125_legacy_force_mode(phydev);
++	rtl8168g_disable_aldps(phydev);
++	rtl8125b_config_eee_phy(phydev);
++}
++
+ static void rtl8126a_hw_phy_config(struct rtl8169_private *tp,
+ 				   struct phy_device *phydev)
+ {
+@@ -1159,6 +1168,7 @@ void r8169_hw_phy_config(struct rtl8169_
+ 		[RTL_GIGA_MAC_VER_53] = rtl8117_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_61] = rtl8125a_2_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_63] = rtl8125b_hw_phy_config,
++		[RTL_GIGA_MAC_VER_64] = rtl8125d_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_65] = rtl8126a_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_66] = rtl8126a_hw_phy_config,
+ 	};

--- a/target/linux/generic/backport-6.6/780-34-v6.13-r8169-fix-inconsistent-indenting-in-rtl8169_get_eth_.patch
+++ b/target/linux/generic/backport-6.6/780-34-v6.13-r8169-fix-inconsistent-indenting-in-rtl8169_get_eth_.patch
@@ -1,0 +1,30 @@
+From b8bd8c44a266c9a7dcb907eab10fbb119e3f6494 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Thu, 24 Oct 2024 22:48:59 +0200
+Subject: [PATCH] r8169: fix inconsistent indenting in
+ rtl8169_get_eth_mac_stats
+
+This fixes an inconsistent indenting introduced with e3fc5139bd8f
+("r8169: implement additional ethtool stats ops").
+
+Reported-by: kernel test robot <lkp@intel.com>
+Closes: https://lore.kernel.org/oe-kbuild-all/202410220413.1gAxIJ4t-lkp@intel.com/
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/20fd6f39-3c1b-4af0-9adc-7d1f49728fad@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -2227,7 +2227,7 @@ static void rtl8169_get_eth_mac_stats(st
+ 		le64_to_cpu(tp->counters->tx_broadcast64);
+ 	mac_stats->MulticastFramesReceivedOK =
+ 		le64_to_cpu(tp->counters->rx_multicast64);
+-	 mac_stats->FrameTooLongErrors =
++	mac_stats->FrameTooLongErrors =
+ 		le32_to_cpu(tp->counters->rx_frame_too_long);
+ }
+ 

--- a/target/linux/generic/backport-6.6/780-35-v6.13-r8169-align-RTL8125-EEE-config-with-vendor-driver.patch
+++ b/target/linux/generic/backport-6.6/780-35-v6.13-r8169-align-RTL8125-EEE-config-with-vendor-driver.patch
@@ -1,0 +1,49 @@
+From eb90f876b7961d702d7fc549e14614860f531e60 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Thu, 31 Oct 2024 22:42:52 +0100
+Subject: [PATCH] r8169: align RTL8125 EEE config with vendor driver
+
+Align the EEE config for RTL8125A/RTL8125B with vendor driver r8125.
+This should help to avoid compatibility issues.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Link: https://patch.msgid.link/044c925e-8669-4b98-87df-95b4056f4f5f@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ .../net/ethernet/realtek/r8169_phy_config.c    | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_phy_config.c
++++ b/drivers/net/ethernet/realtek/r8169_phy_config.c
+@@ -89,19 +89,25 @@ static void rtl8168h_config_eee_phy(stru
+ 	phy_modify_paged(phydev, 0xa42, 0x14, 0x0000, 0x0080);
+ }
+ 
+-static void rtl8125a_config_eee_phy(struct phy_device *phydev)
++static void rtl8125_common_config_eee_phy(struct phy_device *phydev)
+ {
+-	rtl8168h_config_eee_phy(phydev);
++	phy_modify_paged(phydev, 0xa6d, 0x14, 0x0010, 0x0000);
++	phy_modify_paged(phydev, 0xa42, 0x14, 0x0080, 0x0000);
++	phy_modify_paged(phydev, 0xa4a, 0x11, 0x0200, 0x0000);
++}
+ 
++static void rtl8125a_config_eee_phy(struct phy_device *phydev)
++{
++	rtl8168g_config_eee_phy(phydev);
++	/* disable EEE at 2.5Gbps */
+ 	phy_modify_paged(phydev, 0xa6d, 0x12, 0x0001, 0x0000);
+-	phy_modify_paged(phydev, 0xa6d, 0x14, 0x0010, 0x0000);
++	rtl8125_common_config_eee_phy(phydev);
+ }
+ 
+ static void rtl8125b_config_eee_phy(struct phy_device *phydev)
+ {
+-	phy_modify_paged(phydev, 0xa6d, 0x14, 0x0010, 0x0000);
+-	phy_modify_paged(phydev, 0xa42, 0x14, 0x0080, 0x0000);
+-	phy_modify_paged(phydev, 0xa4a, 0x11, 0x0200, 0x0000);
++	rtl8168g_config_eee_phy(phydev);
++	rtl8125_common_config_eee_phy(phydev);
+ }
+ 
+ static void rtl8169s_hw_phy_config(struct rtl8169_private *tp,

--- a/target/linux/generic/backport-6.6/780-36-v6.13-r8169-align-RTL8125-RTL8126-PHY-config-with-vendor-d.patch
+++ b/target/linux/generic/backport-6.6/780-36-v6.13-r8169-align-RTL8125-RTL8126-PHY-config-with-vendor-d.patch
@@ -1,0 +1,46 @@
+From 4af2f60bf7378bd5c92b15a528d8c6c7d02bed6c Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Thu, 31 Oct 2024 22:43:45 +0100
+Subject: [PATCH] r8169: align RTL8125/RTL8126 PHY config with vendor driver
+
+This aligns some parameters with vendor driver r8125/r8126 to avoid
+compatibility issues. Note that for RTL8125B there's no functional
+change, just the open-coded version of the function is replaced.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Link: https://patch.msgid.link/a8a9d896-fbe6-41f2-bf87-666567d3cdb3@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_phy_config.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_phy_config.c
++++ b/drivers/net/ethernet/realtek/r8169_phy_config.c
+@@ -1073,8 +1073,8 @@ static void rtl8125b_hw_phy_config(struc
+ 				   struct phy_device *phydev)
+ {
+ 	r8169_apply_firmware(tp);
++	rtl8168g_enable_gphy_10m(phydev);
+ 
+-	phy_modify_paged(phydev, 0xa44, 0x11, 0x0000, 0x0800);
+ 	phy_modify_paged(phydev, 0xac4, 0x13, 0x00f0, 0x0090);
+ 	phy_modify_paged(phydev, 0xad3, 0x10, 0x0003, 0x0001);
+ 
+@@ -1113,6 +1113,7 @@ static void rtl8125d_hw_phy_config(struc
+ 				   struct phy_device *phydev)
+ {
+ 	r8169_apply_firmware(tp);
++	rtl8168g_enable_gphy_10m(phydev);
+ 	rtl8125_legacy_force_mode(phydev);
+ 	rtl8168g_disable_aldps(phydev);
+ 	rtl8125b_config_eee_phy(phydev);
+@@ -1122,6 +1123,9 @@ static void rtl8126a_hw_phy_config(struc
+ 				   struct phy_device *phydev)
+ {
+ 	r8169_apply_firmware(tp);
++	rtl8168g_enable_gphy_10m(phydev);
++	rtl8125_legacy_force_mode(phydev);
++	rtl8168g_disable_aldps(phydev);
+ }
+ 
+ void r8169_hw_phy_config(struct rtl8169_private *tp, struct phy_device *phydev,

--- a/target/linux/generic/backport-6.6/780-37-v6.13-r8169-align-RTL8126-EEE-config-with-vendor-driver.patch
+++ b/target/linux/generic/backport-6.6/780-37-v6.13-r8169-align-RTL8126-EEE-config-with-vendor-driver.patch
@@ -1,0 +1,25 @@
+From a3d8520e6a19ab018da6c7fc22512c913697a829 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Thu, 31 Oct 2024 22:44:36 +0100
+Subject: [PATCH] r8169: align RTL8126 EEE config with vendor driver
+
+Align the EEE config for RTL8126A with vendor driver r8126 to avoid
+compatibility issues.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Link: https://patch.msgid.link/71e4859e-4cd0-4b6b-b7fa-621d7721992f@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_phy_config.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/ethernet/realtek/r8169_phy_config.c
++++ b/drivers/net/ethernet/realtek/r8169_phy_config.c
+@@ -1126,6 +1126,7 @@ static void rtl8126a_hw_phy_config(struc
+ 	rtl8168g_enable_gphy_10m(phydev);
+ 	rtl8125_legacy_force_mode(phydev);
+ 	rtl8168g_disable_aldps(phydev);
++	rtl8125_common_config_eee_phy(phydev);
+ }
+ 
+ void r8169_hw_phy_config(struct rtl8169_private *tp, struct phy_device *phydev,

--- a/target/linux/generic/backport-6.6/780-38-v6.13-r8169-improve-initialization-of-RSS-registers-on-RTL.patch
+++ b/target/linux/generic/backport-6.6/780-38-v6.13-r8169-improve-initialization-of-RSS-registers-on-RTL.patch
@@ -1,0 +1,38 @@
+From 2cd02f2fdd8a92e5b6b85ff64eab0fc549b30c07 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Sat, 2 Nov 2024 14:49:01 +0100
+Subject: [PATCH] r8169: improve initialization of RSS registers on
+ RTL8125/RTL8126
+
+Replace the register addresses with the names used in r8125/r8126
+vendor driver, and consider that RSS_CTRL_8125 is a 32 bit register.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Link: https://patch.msgid.link/3bf2f340-b369-4174-97bf-fd38d4217492@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -347,6 +347,8 @@ enum rtl8125_registers {
+ 	TxPoll_8125		= 0x90,
+ 	LEDSEL3			= 0x96,
+ 	MAC0_BKP		= 0x19e0,
++	RSS_CTRL_8125		= 0x4500,
++	Q_NUM_CTRL_8125		= 0x4800,
+ 	EEE_TXIDLE_TIMER_8125	= 0x6048,
+ };
+ 
+@@ -3770,8 +3772,8 @@ static void rtl_hw_start_8125_common(str
+ 	rtl_pcie_state_l2l3_disable(tp);
+ 
+ 	RTL_W16(tp, 0x382, 0x221b);
+-	RTL_W8(tp, 0x4500, 0);
+-	RTL_W16(tp, 0x4800, 0);
++	RTL_W32(tp, RSS_CTRL_8125, 0);
++	RTL_W16(tp, Q_NUM_CTRL_8125, 0);
+ 
+ 	/* disable UPS */
+ 	r8168_mac_ocp_modify(tp, 0xd40a, 0x0010, 0x0000);

--- a/target/linux/generic/backport-6.6/780-39-v6.13-r8169-remove-leftover-locks-after-reverted-change.patch
+++ b/target/linux/generic/backport-6.6/780-39-v6.13-r8169-remove-leftover-locks-after-reverted-change.patch
@@ -1,0 +1,113 @@
+From 83cb4b470c66b37b19a347a35cea01e0cbdd258d Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Mon, 4 Nov 2024 23:16:20 +0100
+Subject: [PATCH] r8169: remove leftover locks after reverted change
+
+After e31a9fedc7d8 ("Revert "r8169: disable ASPM during NAPI poll"")
+these locks aren't needed any longer.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Link: https://patch.msgid.link/680f2606-ac7d-4ced-8694-e5033855da9b@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 29 ++---------------------
+ 1 file changed, 2 insertions(+), 27 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -663,13 +663,9 @@ struct rtl8169_private {
+ 		struct work_struct work;
+ 	} wk;
+ 
+-	raw_spinlock_t config25_lock;
+ 	raw_spinlock_t mac_ocp_lock;
+ 	struct mutex led_lock;	/* serialize LED ctrl RMW access */
+ 
+-	raw_spinlock_t cfg9346_usage_lock;
+-	int cfg9346_usage_count;
+-
+ 	unsigned supports_gmii:1;
+ 	unsigned aspm_manageable:1;
+ 	unsigned dash_enabled:1;
+@@ -723,22 +719,12 @@ static inline struct device *tp_to_dev(s
+ 
+ static void rtl_lock_config_regs(struct rtl8169_private *tp)
+ {
+-	unsigned long flags;
+-
+-	raw_spin_lock_irqsave(&tp->cfg9346_usage_lock, flags);
+-	if (!--tp->cfg9346_usage_count)
+-		RTL_W8(tp, Cfg9346, Cfg9346_Lock);
+-	raw_spin_unlock_irqrestore(&tp->cfg9346_usage_lock, flags);
++	RTL_W8(tp, Cfg9346, Cfg9346_Lock);
+ }
+ 
+ static void rtl_unlock_config_regs(struct rtl8169_private *tp)
+ {
+-	unsigned long flags;
+-
+-	raw_spin_lock_irqsave(&tp->cfg9346_usage_lock, flags);
+-	if (!tp->cfg9346_usage_count++)
+-		RTL_W8(tp, Cfg9346, Cfg9346_Unlock);
+-	raw_spin_unlock_irqrestore(&tp->cfg9346_usage_lock, flags);
++	RTL_W8(tp, Cfg9346, Cfg9346_Unlock);
+ }
+ 
+ static void rtl_pci_commit(struct rtl8169_private *tp)
+@@ -749,24 +735,18 @@ static void rtl_pci_commit(struct rtl816
+ 
+ static void rtl_mod_config2(struct rtl8169_private *tp, u8 clear, u8 set)
+ {
+-	unsigned long flags;
+ 	u8 val;
+ 
+-	raw_spin_lock_irqsave(&tp->config25_lock, flags);
+ 	val = RTL_R8(tp, Config2);
+ 	RTL_W8(tp, Config2, (val & ~clear) | set);
+-	raw_spin_unlock_irqrestore(&tp->config25_lock, flags);
+ }
+ 
+ static void rtl_mod_config5(struct rtl8169_private *tp, u8 clear, u8 set)
+ {
+-	unsigned long flags;
+ 	u8 val;
+ 
+-	raw_spin_lock_irqsave(&tp->config25_lock, flags);
+ 	val = RTL_R8(tp, Config5);
+ 	RTL_W8(tp, Config5, (val & ~clear) | set);
+-	raw_spin_unlock_irqrestore(&tp->config25_lock, flags);
+ }
+ 
+ static bool rtl_is_8125(struct rtl8169_private *tp)
+@@ -1572,7 +1552,6 @@ static void __rtl8169_set_wol(struct rtl
+ 		{ WAKE_MAGIC, Config3, MagicPacket }
+ 	};
+ 	unsigned int i, tmp = ARRAY_SIZE(cfg);
+-	unsigned long flags;
+ 	u8 options;
+ 
+ 	rtl_unlock_config_regs(tp);
+@@ -1591,14 +1570,12 @@ static void __rtl8169_set_wol(struct rtl
+ 			r8168_mac_ocp_modify(tp, 0xc0b6, BIT(0), 0);
+ 	}
+ 
+-	raw_spin_lock_irqsave(&tp->config25_lock, flags);
+ 	for (i = 0; i < tmp; i++) {
+ 		options = RTL_R8(tp, cfg[i].reg) & ~cfg[i].mask;
+ 		if (wolopts & cfg[i].opt)
+ 			options |= cfg[i].mask;
+ 		RTL_W8(tp, cfg[i].reg, options);
+ 	}
+-	raw_spin_unlock_irqrestore(&tp->config25_lock, flags);
+ 
+ 	switch (tp->mac_version) {
+ 	case RTL_GIGA_MAC_VER_02 ... RTL_GIGA_MAC_VER_06:
+@@ -5498,8 +5475,6 @@ static int rtl_init_one(struct pci_dev *
+ 	tp->supports_gmii = ent->driver_data == RTL_CFG_NO_GBIT ? 0 : 1;
+ 	tp->ocp_base = OCP_STD_PHY_BASE;
+ 
+-	raw_spin_lock_init(&tp->cfg9346_usage_lock);
+-	raw_spin_lock_init(&tp->config25_lock);
+ 	raw_spin_lock_init(&tp->mac_ocp_lock);
+ 	mutex_init(&tp->led_lock);
+ 

--- a/target/linux/generic/backport-6.6/780-40-v6.13-r8169-improve-__rtl8169_set_wol.patch
+++ b/target/linux/generic/backport-6.6/780-40-v6.13-r8169-improve-__rtl8169_set_wol.patch
@@ -1,0 +1,108 @@
+From c507e96b5763b36b63ad50ad804341f72ea000e4 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Wed, 6 Nov 2024 17:55:45 +0100
+Subject: [PATCH] r8169: improve __rtl8169_set_wol
+
+Add helper r8169_mod_reg8_cond() what allows to significantly simplify
+__rtl8169_set_wol().
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/697b197a-8eac-40c6-8847-27093cacec36@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 55 ++++++++++-------------
+ 1 file changed, 24 insertions(+), 31 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -749,6 +749,20 @@ static void rtl_mod_config5(struct rtl81
+ 	RTL_W8(tp, Config5, (val & ~clear) | set);
+ }
+ 
++static void r8169_mod_reg8_cond(struct rtl8169_private *tp, int reg,
++				u8 bits, bool cond)
++{
++	u8 val, old_val;
++
++	old_val = RTL_R8(tp, reg);
++	if (cond)
++		val = old_val | bits;
++	else
++		val = old_val & ~bits;
++	if (val != old_val)
++		RTL_W8(tp, reg, val);
++}
++
+ static bool rtl_is_8125(struct rtl8169_private *tp)
+ {
+ 	return tp->mac_version >= RTL_GIGA_MAC_VER_61;
+@@ -1539,58 +1553,37 @@ static void rtl8169_get_wol(struct net_d
+ 
+ static void __rtl8169_set_wol(struct rtl8169_private *tp, u32 wolopts)
+ {
+-	static const struct {
+-		u32 opt;
+-		u16 reg;
+-		u8  mask;
+-	} cfg[] = {
+-		{ WAKE_PHY,   Config3, LinkUp },
+-		{ WAKE_UCAST, Config5, UWF },
+-		{ WAKE_BCAST, Config5, BWF },
+-		{ WAKE_MCAST, Config5, MWF },
+-		{ WAKE_ANY,   Config5, LanWake },
+-		{ WAKE_MAGIC, Config3, MagicPacket }
+-	};
+-	unsigned int i, tmp = ARRAY_SIZE(cfg);
+-	u8 options;
+-
+ 	rtl_unlock_config_regs(tp);
+ 
+ 	if (rtl_is_8168evl_up(tp)) {
+-		tmp--;
+ 		if (wolopts & WAKE_MAGIC)
+ 			rtl_eri_set_bits(tp, 0x0dc, MagicPacket_v2);
+ 		else
+ 			rtl_eri_clear_bits(tp, 0x0dc, MagicPacket_v2);
+ 	} else if (rtl_is_8125(tp)) {
+-		tmp--;
+ 		if (wolopts & WAKE_MAGIC)
+ 			r8168_mac_ocp_modify(tp, 0xc0b6, 0, BIT(0));
+ 		else
+ 			r8168_mac_ocp_modify(tp, 0xc0b6, BIT(0), 0);
++	} else {
++		r8169_mod_reg8_cond(tp, Config3, MagicPacket,
++				    wolopts & WAKE_MAGIC);
+ 	}
+ 
+-	for (i = 0; i < tmp; i++) {
+-		options = RTL_R8(tp, cfg[i].reg) & ~cfg[i].mask;
+-		if (wolopts & cfg[i].opt)
+-			options |= cfg[i].mask;
+-		RTL_W8(tp, cfg[i].reg, options);
+-	}
++	r8169_mod_reg8_cond(tp, Config3, LinkUp, wolopts & WAKE_PHY);
++	r8169_mod_reg8_cond(tp, Config5, UWF, wolopts & WAKE_UCAST);
++	r8169_mod_reg8_cond(tp, Config5, BWF, wolopts & WAKE_BCAST);
++	r8169_mod_reg8_cond(tp, Config5, MWF, wolopts & WAKE_MCAST);
++	r8169_mod_reg8_cond(tp, Config5, LanWake, wolopts);
+ 
+ 	switch (tp->mac_version) {
+ 	case RTL_GIGA_MAC_VER_02 ... RTL_GIGA_MAC_VER_06:
+-		options = RTL_R8(tp, Config1) & ~PMEnable;
+-		if (wolopts)
+-			options |= PMEnable;
+-		RTL_W8(tp, Config1, options);
++		r8169_mod_reg8_cond(tp, Config1, PMEnable, wolopts);
+ 		break;
+ 	case RTL_GIGA_MAC_VER_34:
+ 	case RTL_GIGA_MAC_VER_37:
+ 	case RTL_GIGA_MAC_VER_39 ... RTL_GIGA_MAC_VER_66:
+-		if (wolopts)
+-			rtl_mod_config2(tp, 0, PME_SIGNAL);
+-		else
+-			rtl_mod_config2(tp, PME_SIGNAL, 0);
++		r8169_mod_reg8_cond(tp, Config2, PME_SIGNAL, wolopts);
+ 		break;
+ 	default:
+ 		break;

--- a/target/linux/generic/backport-6.6/780-41-v6.13-r8169-improve-rtl_set_d3_pll_down.patch
+++ b/target/linux/generic/backport-6.6/780-41-v6.13-r8169-improve-rtl_set_d3_pll_down.patch
@@ -1,0 +1,44 @@
+From 330dc2297c82953dff402e0b4176a5383a618538 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Wed, 6 Nov 2024 17:56:28 +0100
+Subject: [PATCH] r8169: improve rtl_set_d3_pll_down
+
+Make use of new helper r8169_mod_reg8_cond() and move from a switch()
+to an if() clause. Benefit is that we don't have to touch this piece of
+code each time support for a new chip version is added.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/e1ccdb85-a4ed-4800-89c2-89770ff06452@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 18 +++++-------------
+ 1 file changed, 5 insertions(+), 13 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -1432,19 +1432,11 @@ static enum rtl_dash_type rtl_get_dash_t
+ 
+ static void rtl_set_d3_pll_down(struct rtl8169_private *tp, bool enable)
+ {
+-	switch (tp->mac_version) {
+-	case RTL_GIGA_MAC_VER_25 ... RTL_GIGA_MAC_VER_26:
+-	case RTL_GIGA_MAC_VER_29 ... RTL_GIGA_MAC_VER_30:
+-	case RTL_GIGA_MAC_VER_32 ... RTL_GIGA_MAC_VER_37:
+-	case RTL_GIGA_MAC_VER_39 ... RTL_GIGA_MAC_VER_66:
+-		if (enable)
+-			RTL_W8(tp, PMCH, RTL_R8(tp, PMCH) & ~D3_NO_PLL_DOWN);
+-		else
+-			RTL_W8(tp, PMCH, RTL_R8(tp, PMCH) | D3_NO_PLL_DOWN);
+-		break;
+-	default:
+-		break;
+-	}
++	if (tp->mac_version >= RTL_GIGA_MAC_VER_25 &&
++	    tp->mac_version != RTL_GIGA_MAC_VER_28 &&
++	    tp->mac_version != RTL_GIGA_MAC_VER_31 &&
++	    tp->mac_version != RTL_GIGA_MAC_VER_38)
++		r8169_mod_reg8_cond(tp, PMCH, D3_NO_PLL_DOWN, !enable);
+ }
+ 
+ static void rtl_reset_packet_filter(struct rtl8169_private *tp)

--- a/target/linux/generic/backport-6.6/780-42-v6.13-r8169-align-WAKE_PHY-handling-with-r8125-r8126-vendo.patch
+++ b/target/linux/generic/backport-6.6/780-42-v6.13-r8169-align-WAKE_PHY-handling-with-r8125-r8126-vendo.patch
@@ -1,0 +1,29 @@
+From e3e9e9039fa6ae885c7d5c954d7b9f105fa23e8f Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Wed, 6 Nov 2024 17:57:08 +0100
+Subject: [PATCH] r8169: align WAKE_PHY handling with r8125/r8126 vendor
+ drivers
+
+Vendor drivers r8125/r8126 apply this additional magic setting when
+enabling WAKE_PHY, so do the same here.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/51130715-45be-4db5-abb7-05d87e1f5df9@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -1563,6 +1563,9 @@ static void __rtl8169_set_wol(struct rtl
+ 	}
+ 
+ 	r8169_mod_reg8_cond(tp, Config3, LinkUp, wolopts & WAKE_PHY);
++	if (rtl_is_8125(tp))
++		r8168_mac_ocp_modify(tp, 0xe0c6, 0x3f,
++				     wolopts & WAKE_PHY ? 0x13 : 0);
+ 	r8169_mod_reg8_cond(tp, Config5, UWF, wolopts & WAKE_UCAST);
+ 	r8169_mod_reg8_cond(tp, Config5, BWF, wolopts & WAKE_BCAST);
+ 	r8169_mod_reg8_cond(tp, Config5, MWF, wolopts & WAKE_MCAST);

--- a/target/linux/generic/backport-6.6/780-43-v6.13-r8169-use-helper-r8169_mod_reg8_cond-to-simplify-rtl.patch
+++ b/target/linux/generic/backport-6.6/780-43-v6.13-r8169-use-helper-r8169_mod_reg8_cond-to-simplify-rtl.patch
@@ -1,0 +1,117 @@
+From 7a3bcd39ae1f0e3ab896d9df62339ab4297a0bfd Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Sat, 9 Nov 2024 23:12:12 +0100
+Subject: [PATCH] r8169: use helper r8169_mod_reg8_cond to simplify
+ rtl_jumbo_config
+
+Use recently added helper r8169_mod_reg8_cond() to simplify jumbo
+mode configuration.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/3df1d484-a02e-46e7-8f75-db5b428e422e@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 77 ++++-------------------
+ 1 file changed, 11 insertions(+), 66 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -2547,86 +2547,31 @@ static void rtl8169_init_ring_indexes(st
+ 	tp->dirty_tx = tp->cur_tx = tp->cur_rx = 0;
+ }
+ 
+-static void r8168c_hw_jumbo_enable(struct rtl8169_private *tp)
+-{
+-	RTL_W8(tp, Config3, RTL_R8(tp, Config3) | Jumbo_En0);
+-	RTL_W8(tp, Config4, RTL_R8(tp, Config4) | Jumbo_En1);
+-}
+-
+-static void r8168c_hw_jumbo_disable(struct rtl8169_private *tp)
+-{
+-	RTL_W8(tp, Config3, RTL_R8(tp, Config3) & ~Jumbo_En0);
+-	RTL_W8(tp, Config4, RTL_R8(tp, Config4) & ~Jumbo_En1);
+-}
+-
+-static void r8168dp_hw_jumbo_enable(struct rtl8169_private *tp)
+-{
+-	RTL_W8(tp, Config3, RTL_R8(tp, Config3) | Jumbo_En0);
+-}
+-
+-static void r8168dp_hw_jumbo_disable(struct rtl8169_private *tp)
+-{
+-	RTL_W8(tp, Config3, RTL_R8(tp, Config3) & ~Jumbo_En0);
+-}
+-
+-static void r8168e_hw_jumbo_enable(struct rtl8169_private *tp)
+-{
+-	RTL_W8(tp, MaxTxPacketSize, 0x24);
+-	RTL_W8(tp, Config3, RTL_R8(tp, Config3) | Jumbo_En0);
+-	RTL_W8(tp, Config4, RTL_R8(tp, Config4) | 0x01);
+-}
+-
+-static void r8168e_hw_jumbo_disable(struct rtl8169_private *tp)
+-{
+-	RTL_W8(tp, MaxTxPacketSize, 0x3f);
+-	RTL_W8(tp, Config3, RTL_R8(tp, Config3) & ~Jumbo_En0);
+-	RTL_W8(tp, Config4, RTL_R8(tp, Config4) & ~0x01);
+-}
+-
+-static void r8168b_1_hw_jumbo_enable(struct rtl8169_private *tp)
+-{
+-	RTL_W8(tp, Config4, RTL_R8(tp, Config4) | (1 << 0));
+-}
+-
+-static void r8168b_1_hw_jumbo_disable(struct rtl8169_private *tp)
+-{
+-	RTL_W8(tp, Config4, RTL_R8(tp, Config4) & ~(1 << 0));
+-}
+-
+ static void rtl_jumbo_config(struct rtl8169_private *tp)
+ {
+ 	bool jumbo = tp->dev->mtu > ETH_DATA_LEN;
+ 	int readrq = 4096;
+ 
++	if (jumbo && tp->mac_version >= RTL_GIGA_MAC_VER_17 &&
++	    tp->mac_version <= RTL_GIGA_MAC_VER_26)
++		readrq = 512;
++
+ 	rtl_unlock_config_regs(tp);
+ 	switch (tp->mac_version) {
+ 	case RTL_GIGA_MAC_VER_17:
+-		if (jumbo) {
+-			readrq = 512;
+-			r8168b_1_hw_jumbo_enable(tp);
+-		} else {
+-			r8168b_1_hw_jumbo_disable(tp);
+-		}
++		r8169_mod_reg8_cond(tp, Config4, BIT(0), jumbo);
+ 		break;
+ 	case RTL_GIGA_MAC_VER_18 ... RTL_GIGA_MAC_VER_26:
+-		if (jumbo) {
+-			readrq = 512;
+-			r8168c_hw_jumbo_enable(tp);
+-		} else {
+-			r8168c_hw_jumbo_disable(tp);
+-		}
++		r8169_mod_reg8_cond(tp, Config3, Jumbo_En0, jumbo);
++		r8169_mod_reg8_cond(tp, Config4, Jumbo_En1, jumbo);
+ 		break;
+ 	case RTL_GIGA_MAC_VER_28:
+-		if (jumbo)
+-			r8168dp_hw_jumbo_enable(tp);
+-		else
+-			r8168dp_hw_jumbo_disable(tp);
++		r8169_mod_reg8_cond(tp, Config3, Jumbo_En0, jumbo);
+ 		break;
+ 	case RTL_GIGA_MAC_VER_31 ... RTL_GIGA_MAC_VER_33:
+-		if (jumbo)
+-			r8168e_hw_jumbo_enable(tp);
+-		else
+-			r8168e_hw_jumbo_disable(tp);
++		RTL_W8(tp, MaxTxPacketSize, jumbo ? 0x24 : 0x3f);
++		r8169_mod_reg8_cond(tp, Config3, Jumbo_En0, jumbo);
++		r8169_mod_reg8_cond(tp, Config4, BIT(0), jumbo);
+ 		break;
+ 	default:
+ 		break;


### PR DESCRIPTION
7a3bcd39ae1f r8169: use helper r8169_mod_reg8_cond to simplify rtl_jumbo_config
e3e9e9039fa6 r8169: align WAKE_PHY handling with r8125/r8126 vendor drivers
330dc2297c82 r8169: improve rtl_set_d3_pll_down
c507e96b5763 r8169: improve __rtl8169_set_wol
83cb4b470c66 r8169: remove leftover locks after reverted change
2cd02f2fdd8a r8169: improve initialization of RSS registers on RTL8125/RTL8126
a3d8520e6a19 r8169: align RTL8126 EEE config with vendor driver
4af2f60bf737 r8169: align RTL8125/RTL8126 PHY config with vendor driver
eb90f876b796 r8169: align RTL8125 EEE config with vendor driver
b8bd8c44a266 r8169: fix inconsistent indenting in rtl8169_get_eth_mac_stats
f75d1fbe7809 r8169: add support for RTL8125D
c4e64095c00c r8169: enable EEE at 2.5G per default on RTL8125B
d64113c6bb5e r8169: remove rtl_dash_loop_wait_high/low
1c105bacb160 r8169: avoid duplicated messages if loading firmware fails and switch to warn level
ac48430368c1 r8169: don't take RTNL lock in rtl_task()
e3fc5139bd8f r8169: implement additional ethtool stats ops
b8bf38440ba9 r8169: enable SG/TSO on selected chip versions per default
854d71c555df r8169: remove original workaround for RTL8125 broken rx issue
1ffcc8d41306 r8169: add support for the temperature sensor being available from RTL8125B

The following patches require backporting additional linux patches:
e2015942e90a r8169: replace custom flag with disable_work() et al
e340bff27e63 r8169: copy vendor driver 2.5G/5G EEE advertisement constraints

CC @dangowrt 
