### PR TITLE
realtek: add support for HPE 1920-24G PoE-370W (JG926A)

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -36,6 +36,7 @@ hpe,1920-8g-poe-65w|\
 hpe,1920-8g-poe-180w|\
 hpe,1920-16g|\
 hpe,1920-24g|\
+hpe,1920-24g-poe-370w|\)
 hpe,1920-48g|\
 hpe,1920-48g-poe)
 	label_mac=$(mtd_get_mac_binary factory 0x68)
@@ -94,6 +95,9 @@ hpe,1920-8g-poe-65w)
 	;;
 hpe,1920-8g-poe-180w)
 	ucidef_set_poe 180 "$(filter_port_list_reverse "$lan_list" "lan9 lan10")"
+	;;
+hpe,1920-24g-poe-370w)
+	ucidef_set_poe 370 "$(filter_port_list_reverse "$lan_list" "lan25 lan26 lan27 lan28")"
 	;;
 hpe,1920-48g-poe)
 	ucidef_set_poe 370 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23

--- a/target/linux/realtek/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/realtek/base-files/etc/board.d/03_gpio_switches
@@ -6,7 +6,8 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
-hpe,1920-8g-poe-180w)
+hpe,1920-8g-poe-180w|\
+hpe,1920-24g-poe-370w)
 	ucidef_add_gpio_switch "fan_ctrl" "Fan control" "456" "0"
 	;;
 esac

--- a/target/linux/realtek/dts/rtl8382_hpe_1920-24g-poe-370w.dts
+++ b/target/linux/realtek/dts/rtl8382_hpe_1920-24g-poe-370w.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl8382_hpe_1920-24g.dtsi"
+
+/ {
+	compatible = "hpe,1920-24g-poe-370w", "realtek,rtl838x-soc";
+	model = "HPE 1920-24G-PoE+ 370W (JG926A)";
+};
+
+&uart1 {
+        status = "okay";
+};

--- a/target/linux/realtek/dts/rtl8382_hpe_1920-24g.dts
+++ b/target/linux/realtek/dts/rtl8382_hpe_1920-24g.dts
@@ -1,68 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "rtl8382_hpe_1920.dtsi"
+#include "rtl8382_hpe_1920-24g.dtsi"
 
 / {
 	compatible = "hpe,1920-24g", "realtek,rtl838x-soc";
 	model = "HPE 1920-24G (JG924A)";
-};
-
-&mdio {
-	EXTERNAL_PHY(0)
-	EXTERNAL_PHY(1)
-	EXTERNAL_PHY(2)
-	EXTERNAL_PHY(3)
-	EXTERNAL_PHY(4)
-	EXTERNAL_PHY(5)
-	EXTERNAL_PHY(6)
-	EXTERNAL_PHY(7)
-};
-
-&switch0 {
-	ports {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		SWITCH_PORT(0, 1, qsgmii)
-		SWITCH_PORT(1, 2, qsgmii)
-		SWITCH_PORT(2, 3, qsgmii)
-		SWITCH_PORT(3, 4, qsgmii)
-		SWITCH_PORT(4, 5, qsgmii)
-		SWITCH_PORT(5, 6, qsgmii)
-		SWITCH_PORT(6, 7, qsgmii)
-		SWITCH_PORT(7, 8, qsgmii)
-
-		SWITCH_PORT(8, 9, internal)
-		SWITCH_PORT(9, 10, internal)
-		SWITCH_PORT(10, 11, internal)
-		SWITCH_PORT(11, 12, internal)
-		SWITCH_PORT(12, 13, internal)
-		SWITCH_PORT(13, 14, internal)
-		SWITCH_PORT(14, 15, internal)
-		SWITCH_PORT(15, 16, internal)
-
-		SWITCH_PORT(16, 17, qsgmii)
-		SWITCH_PORT(17, 18, qsgmii)
-		SWITCH_PORT(18, 19, qsgmii)
-		SWITCH_PORT(19, 20, qsgmii)
-		SWITCH_PORT(20, 21, qsgmii)
-		SWITCH_PORT(21, 22, qsgmii)
-		SWITCH_PORT(22, 23, qsgmii)
-		SWITCH_PORT(23, 24, qsgmii)
-
-		SWITCH_PORT(24, 25, qsgmii)
-		SWITCH_PORT(25, 26, qsgmii)
-		SWITCH_PORT(26, 27, qsgmii)
-		SWITCH_PORT(27, 28, qsgmii)
-
-		port@28 {
-			ethernet = <&ethernet0>;
-			reg = <28>;
-			phy-mode = "internal";
-			fixed-link {
-				speed = <1000>;
-				full-duplex;
-			};
-		};
-	};
 };

--- a/target/linux/realtek/dts/rtl8382_hpe_1920-24g.dtsi
+++ b/target/linux/realtek/dts/rtl8382_hpe_1920-24g.dtsi
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl8382_hpe_1920.dtsi"
+
+/ {
+	compatible = "hpe,1920-24g", "realtek,rtl838x-soc";
+	model = "HPE 1920-24G (JG924A)";
+};
+
+&mdio {
+	EXTERNAL_PHY(0)
+	EXTERNAL_PHY(1)
+	EXTERNAL_PHY(2)
+	EXTERNAL_PHY(3)
+	EXTERNAL_PHY(4)
+	EXTERNAL_PHY(5)
+	EXTERNAL_PHY(6)
+	EXTERNAL_PHY(7)
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+
+		SWITCH_PORT(24, 25, qsgmii)
+		SWITCH_PORT(25, 26, qsgmii)
+		SWITCH_PORT(26, 27, qsgmii)
+		SWITCH_PORT(27, 28, qsgmii)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -144,6 +144,15 @@ define Device/hpe_1920-24g
 endef
 TARGET_DEVICES += hpe_1920-24g
 
+define Device/hpe_1920-24g-poe-370w
+  $(Device/hpe_1920)
+  SOC := rtl8382
+  DEVICE_MODEL := 1920-24G-PoE+ 370W (JG926A)
+  DEVICE_PACKAGES += realtek-poe
+  H3C_DEVICE_ID := 0x00010029
+endef
+TARGET_DEVICES += hpe_1920-24g-poe-370w
+
 define Device/inaba_aml2-17gp
   SOC := rtl8382
   IMAGE_SIZE := 13504k


### PR DESCRIPTION
Submitting this PR because I'm using this device (23.05.5 and 24.10.0-rc4) with the patches from below.  Would be great to have it included in the final 24.10 release.  It's just another variant in the HPE 1920 series.

https://forum.openwrt.org/t/add-support-for-hpe-jg926a-1920-24g-poe-370w/210387

https://lists.openwrt.org/pipermail/openwrt-devel/2024-September/043163.html
https://lists.openwrt.org/pipermail/openwrt-devel/2024-September/043164.html

