### PR TITLE
include/package-pack: remove leading whitespace from install scripts

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -302,7 +302,7 @@ else
 		echo 'export pkgname="$(1)"'; \
 		echo "add_group_and_user"; \
 		echo "default_postinst"; \
-		[ ! -f $$(ADIR_$(1))/postinst-pkg ] || cat "$$(ADIR_$(1))/postinst-pkg"; \
+		[ ! -f $$(ADIR_$(1))/postinst-pkg ] || sed -z 's/^\s*#!/#!/' "$$(ADIR_$(1))/postinst-pkg"; \
 	) > $$(ADIR_$(1))/post-install;
 
 	( \
@@ -312,8 +312,10 @@ else
 		echo 'export root="$$$${IPKG_INSTROOT}"'; \
 		echo 'export pkgname="$(1)"'; \
 		echo "default_prerm"; \
-		[ ! -f $$(ADIR_$(1))/prerm-pkg ] || cat "$$(ADIR_$(1))/prerm-pkg"; \
+		[ ! -f $$(ADIR_$(1))/prerm-pkg ] || sed -z 's/^\s*#!/#!/' "$$(ADIR_$(1))/prerm-pkg"; \
 	) > $$(ADIR_$(1))/pre-deinstall;
+
+	[ ! -f $$(ADIR_$(1))/postrm ] || sed -zi 's/^\s*#!/#!/' "$$(ADIR_$(1))/postrm";
 
 	if [ -n "$(USERID)" ]; then echo $(USERID) > $$(IDIR_$(1))/lib/apk/packages/$(1).rusers; fi;
 	if [ -n "$(ALTERNATIVES)" ]; then echo $(ALTERNATIVES) > $$(IDIR_$(1))/lib/apk/packages/$(1).alternatives; fi;


### PR DESCRIPTION
Strip off leading blanks and tabs from scripts and script fragments that are supplied by the package's Makefile.  Specifically, the script included in the postrm must be left justified so that the shebang is in the first column.

Fixes: https://github.com/openwrt/openwrt/issues/17439

Verified using @friendly-bits geoip-shell package, as below:
```
$ make package/geoip-shell/compile
...

$ staging_dir/host/bin/apk adbdump ./bin/packages/x86_64/packages/geoip-shell-0.5.2-r1.apk
... trimmed noise ...
scripts:
  post-install: |
    #!/bin/sh
    [ "${IPKG_NO_SCRIPT}" = "1" ] && exit 0
    [ -s ${IPKG_INSTROOT}/lib/functions.sh ] || exit 0
    . ${IPKG_INSTROOT}/lib/functions.sh
    export root="${IPKG_INSTROOT}"
    export pkgname="geoip-shell"
    add_group_and_user
    default_postinst
    #!/bin/sh
    rm "/usr/bin/geoip-shell" 2>/dev/null
    ln -s "/usr/bin/geoip-shell-manage.sh" "/usr/bin/geoip-shell"
    [ -s "/etc/geoip-shell/geoip-shell.conf" ] && /usr/bin/geoip-shell configure -z && exit 0
    logger -s -t "geoip-shell" "Please run 'geoip-shell configure' to complete the setup."
    exit 0
  pre-deinstall: |
    #!/bin/sh
    [ -s ${IPKG_INSTROOT}/lib/functions.sh ] || exit 0
    . ${IPKG_INSTROOT}/lib/functions.sh
    export root="${IPKG_INSTROOT}"
    export pkgname="geoip-shell"
    default_prerm
    #!/bin/sh
    sh /usr/lib/geoip-shell/geoip-shell-owrt-uninstall.sh
    exit 0
  post-deinstall: |
    #!/bin/sh
    sleep 1
    echo "Reloading the firewall..."
    fw4 -q reload
    exit 0
```