### PR TITLE
generic: add STMicroelectronics LED1202 LED controller

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -233,6 +233,23 @@ endef
 $(eval $(call KernelPackage,leds-pwm))
 
 
+define KernelPackage/leds-st1202
+  SUBMENU:=LED modules
+  TITLE:=LED support for ST LED1202 I2C chips
+  DEPENDS:=+kmod-i2c-core +kmod-ledtrig-pattern
+  KCONFIG:=CONFIG_LEDS_ST1202
+  FILES:= $(LINUX_DIR)/drivers/leds/leds-st1202.ko
+  AUTOLOAD:=$(call AutoProbe,leds-st1202)
+endef
+
+define KernelPackage/leds-st1202/description
+  This option enables support for LEDs connected to LED1202
+  LED driver chips accessed via the I2C bus.
+endef
+
+$(eval $(call KernelPackage,leds-st1202))
+
+
 define KernelPackage/leds-tlc591xx
   SUBMENU:=$(LEDS_MENU)
   TITLE:=LED driver for TLC59108 and TLC59116 controllers

--- a/target/linux/ath79/patches-6.6/800-leds-add-reset-controller-based-driver.patch
+++ b/target/linux/ath79/patches-6.6/800-leds-add-reset-controller-based-driver.patch
@@ -13,7 +13,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
-@@ -901,6 +901,17 @@ source "drivers/leds/flash/Kconfig"
+@@ -911,6 +911,17 @@ source "drivers/leds/flash/Kconfig"
  comment "RGB LED drivers"
  source "drivers/leds/rgb/Kconfig"
  
@@ -176,7 +176,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +MODULE_ALIAS("platform:leds-reset");
 --- a/drivers/leds/Makefile
 +++ b/drivers/leds/Makefile
-@@ -88,6 +88,7 @@ obj-$(CONFIG_LEDS_TURRIS_OMNIA)		+= leds
+@@ -89,6 +89,7 @@ obj-$(CONFIG_LEDS_TURRIS_OMNIA)		+= leds
  obj-$(CONFIG_LEDS_WM831X_STATUS)	+= leds-wm831x-status.o
  obj-$(CONFIG_LEDS_WM8350)		+= leds-wm8350.o
  obj-$(CONFIG_LEDS_WRAP)			+= leds-wrap.o

--- a/target/linux/bmips/patches-6.6/700-leds-add-support-for-Sercomm-MSP430-LED-controller.patch
+++ b/target/linux/bmips/patches-6.6/700-leds-add-support-for-Sercomm-MSP430-LED-controller.patch
@@ -40,6 +40,6 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  obj-$(CONFIG_LEDS_REGULATOR)		+= leds-regulator.o
  obj-$(CONFIG_LEDS_SC27XX_BLTC)		+= leds-sc27xx-bltc.o
 +obj-$(CONFIG_LEDS_SERCOMM_MSP430)	+= leds-sercomm-msp430.o
+ obj-$(CONFIG_LEDS_ST1202)		+= leds-st1202.o
  obj-$(CONFIG_LEDS_SUNFIRE)		+= leds-sunfire.o
  obj-$(CONFIG_LEDS_SYSCON)		+= leds-syscon.o
- obj-$(CONFIG_LEDS_TCA6507)		+= leds-tca6507.o

--- a/target/linux/generic/pending-6.6/891-dt-bindings-leds-Add-LED1202-LED-Controller.patch
+++ b/target/linux/generic/pending-6.6/891-dt-bindings-leds-Add-LED1202-LED-Controller.patch
@@ -1,0 +1,181 @@
+From: Vicentiu Galanopulo <vicentiu.galanopulo@remote-tech.co.uk>
+To: Pavel Machek <pavel@ucw.cz>, Lee Jones <lee@kernel.org>,
+	Rob Herring <robh@kernel.org>,
+	Krzysztof Kozlowski <krzk+dt@kernel.org>,
+	Conor Dooley <conor+dt@kernel.org>,
+	Jonathan Corbet <corbet@lwn.net>,
+	Vicentiu Galanopulo <vicentiu.galanopulo@remote-tech.co.uk>,
+	linux-leds@vger.kernel.org, devicetree@vger.kernel.org,
+	linux-kernel@vger.kernel.org, linux-doc@vger.kernel.org
+Cc: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Subject: [PATCH v11 2/3] dt-bindings: leds: Add LED1202 LED Controller
+Date: Wed, 18 Dec 2024 18:33:58 +0000	[thread overview]
+Message-ID: <20241218183401.41687-3-vicentiu.galanopulo@remote-tech.co.uk> (raw)
+In-Reply-To: <20241218183401.41687-1-vicentiu.galanopulo@remote-tech.co.uk>
+
+The LED1202 is a 12-channel low quiescent current LED driver with:
+  * Supply range from 2.6 V to 5 V
+  * 20 mA current capability per channel
+  * 1.8 V compatible I2C control interface
+  * 8-bit analog dimming individual control
+  * 12-bit local PWM resolution
+  * 8 programmable patterns
+
+If the led node is present in the controller then the channel is
+set to active.
+
+Signed-off-by: Vicentiu Galanopulo <vicentiu.galanopulo@remote-tech.co.uk>
+Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+---
+    v1: https://lore.kernel.org/lkml/ZnCnnQfwuRueCIQ0@admins-Air/T/
+    v2: https://lore.kernel.org/all/ZniNdGgKyUMV-hjq@admins-Air/T/
+    v3: https://lore.kernel.org/all/ZniNdGgKyUMV-hjq@admins-Air/T/
+    
+    Changes in v4:
+      - remove label property, use devm_led_classdev_register_ext instead
+    Changes in v3:
+      - remove active property
+    Changes in v2:
+      - renamed label to remove color from it
+      - add color property for each node
+      - add function and function-enumerator property for each node
+
+ .../devicetree/bindings/leds/st,led1202.yaml  | 132 ++++++++++++++++++
+ 1 file changed, 132 insertions(+)
+ create mode 100644 Documentation/devicetree/bindings/leds/st,led1202.yaml
+
+--- /dev/null
++++ b/Documentation/devicetree/bindings/leds/st,led1202.yaml
+@@ -0,0 +1,132 @@
++# SPDX-License-Identifier: GPL-2.0-only OR BSD-2-Clause
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/leds/st,led1202.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: ST LED1202 LED controllers
++
++maintainers:
++  - Vicentiu Galanopulo <vicentiu.galanopulo@remote-tech.co.uk>
++
++description: |
++  The LED1202 is a 12-channel low quiescent current LED controller
++  programmable via I2C; The output current can be adjusted separately
++  for each channel by 8-bit analog and 12-bit digital dimming control.
++  Datasheet available at
++  https://www.st.com/en/power-management/led1202.html
++
++properties:
++  compatible:
++    const: st,led1202
++
++  reg:
++    maxItems: 1
++
++  "#address-cells":
++    const: 1
++
++  "#size-cells":
++    const: 0
++
++patternProperties:
++  "^led@[0-9a-f]$":
++    type: object
++    $ref: common.yaml#
++    unevaluatedProperties: false
++
++    properties:
++      reg:
++        minimum: 0
++        maximum: 11
++
++    required:
++      - reg
++
++required:
++  - compatible
++  - reg
++  - "#address-cells"
++  - "#size-cells"
++
++additionalProperties: false
++
++examples:
++  - |
++    #include <dt-bindings/leds/common.h>
++
++    i2c {
++        #address-cells = <1>;
++        #size-cells = <0>;
++
++        led-controller@58 {
++            compatible = "st,led1202";
++            reg = <0x58>;
++            #address-cells = <1>;
++            #size-cells = <0>;
++
++            led@0 {
++                reg = <0x0>;
++                function = LED_FUNCTION_STATUS;
++                color = <LED_COLOR_ID_RED>;
++                function-enumerator = <1>;
++            };
++
++            led@1 {
++                reg = <0x1>;
++                function = LED_FUNCTION_STATUS;
++                color = <LED_COLOR_ID_GREEN>;
++                function-enumerator = <2>;
++            };
++
++            led@2 {
++                reg = <0x2>;
++                function = LED_FUNCTION_STATUS;
++                color = <LED_COLOR_ID_BLUE>;
++                function-enumerator = <3>;
++            };
++
++            led@3 {
++                reg = <0x3>;
++                function = LED_FUNCTION_STATUS;
++                color = <LED_COLOR_ID_RED>;
++                function-enumerator = <4>;
++            };
++
++            led@4 {
++                reg = <0x4>;
++                function = LED_FUNCTION_STATUS;
++                color = <LED_COLOR_ID_GREEN>;
++                function-enumerator = <5>;
++            };
++
++            led@5 {
++                reg = <0x5>;
++                function = LED_FUNCTION_STATUS;
++                color = <LED_COLOR_ID_BLUE>;
++                function-enumerator = <6>;
++            };
++
++            led@6 {
++                reg = <0x6>;
++                function = LED_FUNCTION_STATUS;
++                color = <LED_COLOR_ID_RED>;
++                function-enumerator = <7>;
++            };
++
++            led@7 {
++                reg = <0x7>;
++                function = LED_FUNCTION_STATUS;
++                color = <LED_COLOR_ID_GREEN>;
++                function-enumerator = <8>;
++            };
++
++            led@8 {
++                reg = <0x8>;
++                function = LED_FUNCTION_STATUS;
++                color = <LED_COLOR_ID_BLUE>;
++                function-enumerator = <9>;
++            };
++        };
++    };
++...

--- a/target/linux/generic/pending-6.6/892-leds-Add-LED1202-I2C-driver.patch
+++ b/target/linux/generic/pending-6.6/892-leds-Add-LED1202-I2C-driver.patch
@@ -1,0 +1,513 @@
+From: Vicentiu Galanopulo <vicentiu.galanopulo@remote-tech.co.uk>
+To: Pavel Machek <pavel@ucw.cz>, Lee Jones <lee@kernel.org>,
+	Rob Herring <robh@kernel.org>,
+	Krzysztof Kozlowski <krzk+dt@kernel.org>,
+	Conor Dooley <conor+dt@kernel.org>,
+	Jonathan Corbet <corbet@lwn.net>,
+	Vicentiu Galanopulo <vicentiu.galanopulo@remote-tech.co.uk>,
+	linux-leds@vger.kernel.org, devicetree@vger.kernel.org,
+	linux-kernel@vger.kernel.org, linux-doc@vger.kernel.org
+Subject: [PATCH v11 3/3] leds: Add LED1202 I2C driver
+Date: Wed, 18 Dec 2024 18:33:59 +0000	[thread overview]
+Message-ID: <20241218183401.41687-4-vicentiu.galanopulo@remote-tech.co.uk> (raw)
+In-Reply-To: <20241218183401.41687-1-vicentiu.galanopulo@remote-tech.co.uk>
+
+The output current can be adjusted separately for each channel by 8-bit
+analog (current sink input) and 12-bit digital (PWM) dimming control. The
+LED1202 implements 12 low-side current generators with independent dimming
+control.
+Internal volatile memory allows the user to store up to 8 different patterns,
+each pattern is a particular output configuration in terms of PWM
+duty-cycle (on 4096 steps). Analog dimming (on 256 steps) is per channel but
+common to all patterns. Each device tree LED node will have a corresponding
+entry in /sys/class/leds with the label name. The brightness property
+corresponds to the per channel analog dimming, while the patterns[1-8] to the
+PWM dimming control.
+
+Signed-off-by: Vicentiu Galanopulo <vicentiu.galanopulo@remote-tech.co.uk>
+---
+    Changes in v10:
+      - update description help in Kconfig
+      - move st1202_led and st1202_chip into one line, declaration and definition
+    Changes in v9:
+      - log errors directly in st1202_write_reg and st1202_read_reg
+      - use mutex guards instead of lock/unlock
+      - remove i2c_set_clientdata
+    Changes in v7:
+      - fix st1202_brightness_get() error: uninitialized symbol 'value'
+    Changes in v6:
+      - fix build error
+    Changes in v5:
+      - remove unused macros
+      - switch to using devm_led_classdev_register_ext (struct st1202_led update)
+      - add prescalar_to_milliseconds (convert [22..5660]ms to [0..255] reg value)
+      - remove register range check in dt_init (range protected by yaml)
+      - address all review comments in v4
+    Changes in v4:
+      - Remove attributes/extended attributes implementation
+      - Use /sys/class/leds/<led>/hw_pattern (Pavel suggestion)
+      - Implement review findings of Christophe JAILLET
+    Changes in v3:
+      - Rename all ll1202 to st1202, including driver file name
+      - Convert all magic numbers to defines
+      - Refactor the show/store callbacks as per Lee's and Thomas's review
+      - Remove ll1202_get_channel and use dev_ext_attributes instead
+      - Log all error values for all the functions
+      - Use sysfs_emit for show callbacks
+    Changes in v2:
+      - Fix build error for device_attribute modes
+
+ drivers/leds/Kconfig       |  10 +
+ drivers/leds/Makefile      |   1 +
+ drivers/leds/leds-st1202.c | 416 +++++++++++++++++++++++++++++++++++++
+ 3 files changed, 427 insertions(+)
+ create mode 100644 drivers/leds/leds-st1202.c
+
+--- a/drivers/leds/Kconfig
++++ b/drivers/leds/Kconfig
+@@ -865,6 +865,16 @@ config LEDS_LM36274
+ 	  Say Y to enable the LM36274 LED driver for TI LMU devices.
+ 	  This supports the LED device LM36274.
+ 
++config LEDS_ST1202
++	tristate "LED Support for STMicroelectronics LED1202 I2C chips"
++	depends on LEDS_CLASS
++	depends on I2C
++	depends on OF
++	select LEDS_TRIGGERS
++	help
++	  Say Y to enable support for LEDs connected to LED1202
++	  LED driver chips accessed via the I2C bus.
++
+ config LEDS_TPS6105X
+ 	tristate "LED support for TI TPS6105X"
+ 	depends on LEDS_CLASS
+--- a/drivers/leds/Makefile
++++ b/drivers/leds/Makefile
+@@ -78,6 +78,7 @@ obj-$(CONFIG_LEDS_POWERNV)		+= leds-powe
+ obj-$(CONFIG_LEDS_PWM)			+= leds-pwm.o
+ obj-$(CONFIG_LEDS_REGULATOR)		+= leds-regulator.o
+ obj-$(CONFIG_LEDS_SC27XX_BLTC)		+= leds-sc27xx-bltc.o
++obj-$(CONFIG_LEDS_ST1202)		+= leds-st1202.o
+ obj-$(CONFIG_LEDS_SUNFIRE)		+= leds-sunfire.o
+ obj-$(CONFIG_LEDS_SYSCON)		+= leds-syscon.o
+ obj-$(CONFIG_LEDS_TCA6507)		+= leds-tca6507.o
+--- /dev/null
++++ b/drivers/leds/leds-st1202.c
+@@ -0,0 +1,416 @@
++// SPDX-License-Identifier: GPL-2.0-only
++/*
++ * LED driver for STMicroelectronics LED1202 chip
++ *
++ * Copyright (C) 2024 Remote-Tech Ltd. UK
++ */
++
++#include <linux/cleanup.h>
++#include <linux/ctype.h>
++#include <linux/delay.h>
++#include <linux/err.h>
++#include <linux/gpio.h>
++#include <linux/i2c.h>
++#include <linux/leds.h>
++#include <linux/module.h>
++#include <linux/slab.h>
++#include <linux/string.h>
++
++#define ST1202_CHAN_DISABLE_ALL            0x00
++#define ST1202_CHAN_ENABLE_HIGH            0x03
++#define ST1202_CHAN_ENABLE_LOW             0x02
++#define ST1202_CONFIG_REG                  0x04
++/* PATS: Pattern sequence feature enable */
++#define ST1202_CONFIG_REG_PATS             BIT(7)
++/* PATSR: Pattern sequence runs (self-clear when sequence is finished) */
++#define ST1202_CONFIG_REG_PATSR            BIT(6)
++#define ST1202_CONFIG_REG_SHFT             BIT(3)
++#define ST1202_DEV_ENABLE                  0x01
++#define ST1202_DEV_ENABLE_ON               BIT(0)
++#define ST1202_DEV_ENABLE_RESET            BIT(7)
++#define ST1202_DEVICE_ID                   0x00
++#define ST1202_ILED_REG0                   0x09
++#define ST1202_MAX_LEDS                    12
++#define ST1202_MAX_PATTERNS                8
++#define ST1202_MILLIS_PATTERN_DUR_MAX      5660
++#define ST1202_MILLIS_PATTERN_DUR_MIN      22
++#define ST1202_PATTERN_DUR                 0x16
++#define ST1202_PATTERN_PWM                 0x1E
++#define ST1202_PATTERN_REP                 0x15
++
++struct st1202_led {
++	struct fwnode_handle *fwnode;
++	struct led_classdev led_cdev;
++	struct st1202_chip *chip;
++	bool is_active;
++	int led_num;
++};
++
++struct st1202_chip {
++	struct i2c_client *client;
++	struct mutex lock;
++	struct st1202_led leds[ST1202_MAX_LEDS];
++};
++
++static struct st1202_led *cdev_to_st1202_led(struct led_classdev *cdev)
++{
++	return container_of(cdev, struct st1202_led, led_cdev);
++}
++
++static int st1202_read_reg(struct st1202_chip *chip, int reg, uint8_t *val)
++{
++	struct device *dev = &chip->client->dev;
++	int ret;
++
++	ret = i2c_smbus_read_byte_data(chip->client, reg);
++	if (ret < 0) {
++		dev_err(dev, "Failed to read register [0x%x]: %d\n", reg, ret);
++		return ret;
++	}
++
++	*val = (uint8_t)ret;
++	return 0;
++}
++
++static int st1202_write_reg(struct st1202_chip *chip, int reg, uint8_t val)
++{
++	struct device *dev = &chip->client->dev;
++	int ret;
++
++	ret = i2c_smbus_write_byte_data(chip->client, reg, val);
++	if (ret != 0)
++		dev_err(dev, "Failed to write %d to register [0x%x]: %d\n", val, reg, ret);
++
++	return ret;
++}
++
++static uint8_t st1202_prescalar_to_miliseconds(unsigned int value)
++{
++	return value / ST1202_MILLIS_PATTERN_DUR_MIN - 1;
++}
++
++static int st1202_pwm_pattern_write(struct st1202_chip *chip, int led_num,
++				int pattern, unsigned int value)
++{
++	u8 value_l, value_h;
++	int ret;
++
++	value_l = (u8)value;
++	value_h = (u8)(value >> 8);
++
++	/*
++	 *  Datasheet: Register address low = 1Eh + 2*(xh) + 18h*(yh),
++	 *  where x is the channel number (led number) in hexadecimal (x = 00h .. 0Bh)
++	 *  and y is the pattern number in hexadecimal (y = 00h .. 07h)
++	 */
++	ret = st1202_write_reg(chip, (ST1202_PATTERN_PWM + (led_num * 2) + 0x18 * pattern),
++				value_l);
++	if (ret != 0)
++		return ret;
++
++	/*
++	 * Datasheet: Register address high = 1Eh + 01h + 2(xh) +18h*(yh),
++	 * where x is the channel number in hexadecimal (x = 00h .. 0Bh)
++	 * and y is the pattern number in hexadecimal (y = 00h .. 07h)
++	 */
++	ret = st1202_write_reg(chip, (ST1202_PATTERN_PWM + 0x1 + (led_num * 2) + 0x18 * pattern),
++				value_h);
++	if (ret != 0)
++		return ret;
++
++	return 0;
++}
++
++static int st1202_duration_pattern_write(struct st1202_chip *chip, int pattern,
++					unsigned int value)
++{
++	return st1202_write_reg(chip, (ST1202_PATTERN_DUR + pattern),
++				st1202_prescalar_to_miliseconds(value));
++}
++
++static void st1202_brightness_set(struct led_classdev *led_cdev,
++				enum led_brightness value)
++{
++	struct st1202_led *led = cdev_to_st1202_led(led_cdev);
++	struct st1202_chip *chip = led->chip;
++
++	guard(mutex)(&chip->lock);
++
++	st1202_write_reg(chip, ST1202_ILED_REG0 + led->led_num, value);
++}
++
++static enum led_brightness st1202_brightness_get(struct led_classdev *led_cdev)
++{
++	struct st1202_led *led = cdev_to_st1202_led(led_cdev);
++	struct st1202_chip *chip = led->chip;
++	u8 value = 0;
++
++	guard(mutex)(&chip->lock);
++
++	st1202_read_reg(chip, ST1202_ILED_REG0 + led->led_num, &value);
++
++	return value;
++}
++
++static int st1202_channel_set(struct st1202_chip *chip, int led_num, bool active)
++{
++	u8 chan_low, chan_high;
++	int ret;
++
++	guard(mutex)(&chip->lock);
++
++	if (led_num <= 7) {
++		ret = st1202_read_reg(chip, ST1202_CHAN_ENABLE_LOW, &chan_low);
++		if (ret < 0)
++			return ret;
++
++		chan_low = active ? chan_low | BIT(led_num) : chan_low & ~BIT(led_num);
++
++		ret = st1202_write_reg(chip, ST1202_CHAN_ENABLE_LOW, chan_low);
++		if (ret < 0)
++			return ret;
++
++	} else {
++		ret = st1202_read_reg(chip, ST1202_CHAN_ENABLE_HIGH, &chan_high);
++		if (ret < 0)
++			return ret;
++
++		chan_high = active ? chan_high | (BIT(led_num) >> 8) :
++					chan_high & ~(BIT(led_num) >> 8);
++
++		ret = st1202_write_reg(chip, ST1202_CHAN_ENABLE_HIGH, chan_high);
++		if (ret < 0)
++			return ret;
++	}
++
++	return 0;
++}
++
++static int st1202_led_set(struct led_classdev *ldev, enum led_brightness value)
++{
++	struct st1202_led *led = cdev_to_st1202_led(ldev);
++	struct st1202_chip *chip = led->chip;
++
++	return st1202_channel_set(chip, led->led_num, value == LED_OFF ? false : true);
++}
++
++static int st1202_led_pattern_clear(struct led_classdev *ldev)
++{
++	struct st1202_led *led = cdev_to_st1202_led(ldev);
++	struct st1202_chip *chip = led->chip;
++	int ret;
++
++	guard(mutex)(&chip->lock);
++
++	for (int patt = 0; patt < ST1202_MAX_PATTERNS; patt++) {
++		ret = st1202_pwm_pattern_write(chip, led->led_num, patt, LED_OFF);
++		if (ret != 0)
++			return ret;
++
++		ret = st1202_duration_pattern_write(chip, patt, ST1202_MILLIS_PATTERN_DUR_MIN);
++		if (ret != 0)
++			return ret;
++	}
++
++	return 0;
++}
++
++static int st1202_led_pattern_set(struct led_classdev *ldev,
++				struct led_pattern *pattern,
++				u32 len, int repeat)
++{
++	struct st1202_led *led = cdev_to_st1202_led(ldev);
++	struct st1202_chip *chip = led->chip;
++	int ret;
++
++	if (len > ST1202_MAX_PATTERNS)
++		return -EINVAL;
++
++	guard(mutex)(&chip->lock);
++
++	for (int patt = 0; patt < len; patt++) {
++		if (pattern[patt].delta_t < ST1202_MILLIS_PATTERN_DUR_MIN ||
++				pattern[patt].delta_t > ST1202_MILLIS_PATTERN_DUR_MAX)
++			return -EINVAL;
++
++		ret = st1202_pwm_pattern_write(chip, led->led_num, patt, pattern[patt].brightness);
++		if (ret != 0)
++			return ret;
++
++		ret = st1202_duration_pattern_write(chip, patt, pattern[patt].delta_t);
++		if (ret != 0)
++			return ret;
++	}
++
++	ret = st1202_write_reg(chip, ST1202_PATTERN_REP, repeat);
++	if (ret != 0)
++		return ret;
++
++	ret = st1202_write_reg(chip, ST1202_CONFIG_REG, (ST1202_CONFIG_REG_PATSR |
++							ST1202_CONFIG_REG_PATS | ST1202_CONFIG_REG_SHFT));
++	if (ret != 0)
++		return ret;
++
++	return 0;
++}
++
++static int st1202_dt_init(struct st1202_chip *chip)
++{
++	struct device *dev = &chip->client->dev;
++	struct st1202_led *led;
++	int err, reg;
++
++	for_each_available_child_of_node_scoped(dev_of_node(dev), child) {
++		struct led_init_data init_data = {};
++
++		err = of_property_read_u32(child, "reg", &reg);
++		if (err)
++			return dev_err_probe(dev, err, "Invalid register\n");
++
++		led = &chip->leds[reg];
++		led->is_active = true;
++		led->fwnode = of_fwnode_handle(child);
++
++		led->led_cdev.max_brightness = U8_MAX;
++		led->led_cdev.brightness_set_blocking = st1202_led_set;
++		led->led_cdev.pattern_set = st1202_led_pattern_set;
++		led->led_cdev.pattern_clear = st1202_led_pattern_clear;
++		led->led_cdev.default_trigger = "pattern";
++
++		init_data.fwnode = led->fwnode;
++		init_data.devicename = "st1202";
++		init_data.default_label = ":";
++
++		err = devm_led_classdev_register_ext(dev, &led->led_cdev, &init_data);
++		if (err < 0)
++			return dev_err_probe(dev, err, "Failed to register LED class device\n");
++
++		led->led_cdev.brightness_set = st1202_brightness_set;
++		led->led_cdev.brightness_get = st1202_brightness_get;
++	}
++
++	return 0;
++}
++
++static int st1202_setup(struct st1202_chip *chip)
++{
++	int ret;
++
++	guard(mutex)(&chip->lock);
++
++	/*
++	 * Once the supply voltage is applied, the LED1202 executes some internal checks,
++	 * afterwords it stops the oscillator and puts the internal LDO in quiescent mode.
++	 * To start the device, EN bit must be set inside the “Device Enable” register at
++	 * address 01h. As soon as EN is set, the LED1202 loads the adjustment parameters
++	 * from the internal non-volatile memory and performs an auto-calibration procedure
++	 * in order to increase the output current precision.
++	 * Such initialization lasts about 6.5 ms.
++	 */
++
++	/* Reset the chip during setup */
++	ret = st1202_write_reg(chip, ST1202_DEV_ENABLE, ST1202_DEV_ENABLE_RESET);
++	if (ret < 0)
++		return ret;
++
++	/* Enable phase-shift delay feature */
++	ret = st1202_write_reg(chip, ST1202_CONFIG_REG, ST1202_CONFIG_REG_SHFT);
++	if (ret < 0)
++		return ret;
++
++	/* Enable the device */
++	ret = st1202_write_reg(chip, ST1202_DEV_ENABLE, ST1202_DEV_ENABLE_ON);
++	if (ret < 0)
++		return ret;
++
++	/* Duration of initialization */
++	usleep_range(6500, 10000);
++
++	/* Deactivate all LEDS (channels) and activate only the ones found in Device Tree */
++	ret = st1202_write_reg(chip, ST1202_CHAN_ENABLE_LOW, ST1202_CHAN_DISABLE_ALL);
++	if (ret < 0)
++		return ret;
++
++	ret = st1202_write_reg(chip, ST1202_CHAN_ENABLE_HIGH, ST1202_CHAN_DISABLE_ALL);
++	if (ret < 0)
++		return ret;
++
++	ret = st1202_write_reg(chip, ST1202_CONFIG_REG,
++				ST1202_CONFIG_REG_PATS | ST1202_CONFIG_REG_PATSR);
++	if (ret < 0)
++		return ret;
++
++	return 0;
++}
++
++static int st1202_probe(struct i2c_client *client)
++{
++	struct st1202_chip *chip;
++	struct st1202_led *led;
++	int ret;
++
++	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA))
++		return dev_err_probe(&client->dev, -EIO, "SMBUS Byte Data not Supported\n");
++
++	chip = devm_kzalloc(&client->dev, sizeof(*chip), GFP_KERNEL);
++	if (!chip)
++		return -ENOMEM;
++
++	devm_mutex_init(&client->dev, &chip->lock);
++	chip->client = client;
++
++	ret = st1202_dt_init(chip);
++	if (ret < 0)
++		return ret;
++
++	ret = st1202_setup(chip);
++	if (ret < 0)
++		return ret;
++
++	for (int i = 0; i < ST1202_MAX_LEDS; i++) {
++		led = &chip->leds[i];
++		led->chip = chip;
++		led->led_num = i;
++
++		if (!led->is_active)
++			continue;
++
++		ret = st1202_channel_set(led->chip, led->led_num, true);
++		if (ret < 0)
++			return dev_err_probe(&client->dev, ret,
++					"Failed to activate LED channel\n");
++
++		ret = st1202_led_pattern_clear(&led->led_cdev);
++		if (ret < 0)
++			return dev_err_probe(&client->dev, ret,
++					"Failed to clear LED pattern\n");
++	}
++
++	return 0;
++}
++
++static const struct i2c_device_id st1202_id[] = {
++	{ "st1202-i2c" },
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(i2c, st1202_id);
++
++static const struct of_device_id st1202_dt_ids[] = {
++	{ .compatible = "st,led1202" },
++	{ /* sentinel */ }
++};
++MODULE_DEVICE_TABLE(of, st1202_dt_ids);
++
++static struct i2c_driver st1202_driver = {
++	.driver = {
++		.name = "leds-st1202",
++		.of_match_table = of_match_ptr(st1202_dt_ids),
++	},
++	.probe = st1202_probe,
++	.id_table = st1202_id,
++};
++module_i2c_driver(st1202_driver);
++
++MODULE_AUTHOR("Remote Tech LTD");
++MODULE_DESCRIPTION("STMicroelectronics LED1202 : 12-channel constant current LED driver");
++MODULE_LICENSE("GPL");

--- a/target/linux/mediatek/patches-6.6/950-smartrg-i2c-led-driver.patch
+++ b/target/linux/mediatek/patches-6.6/950-smartrg-i2c-led-driver.patch
@@ -5,7 +5,7 @@
 
 --- a/drivers/leds/Kconfig
 +++ b/drivers/leds/Kconfig
-@@ -901,6 +901,16 @@ source "drivers/leds/flash/Kconfig"
+@@ -911,6 +911,16 @@ source "drivers/leds/flash/Kconfig"
  comment "RGB LED drivers"
  source "drivers/leds/rgb/Kconfig"
  
@@ -29,6 +29,6 @@
  obj-$(CONFIG_LEDS_REGULATOR)		+= leds-regulator.o
  obj-$(CONFIG_LEDS_SC27XX_BLTC)		+= leds-sc27xx-bltc.o
 +obj-$(CONFIG_LEDS_SMARTRG_LED)		+= leds-smartrg-system.o
+ obj-$(CONFIG_LEDS_ST1202)		+= leds-st1202.o
  obj-$(CONFIG_LEDS_SUNFIRE)		+= leds-sunfire.o
  obj-$(CONFIG_LEDS_SYSCON)		+= leds-syscon.o
- obj-$(CONFIG_LEDS_TCA6507)		+= leds-tca6507.o

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
@@ -11,6 +11,35 @@
 	compatible = "linksys,mx4200v1", "qcom,ipq8074";
 };
 
+&blsp1_i2c2 {
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
 &wifi {
 	status = "okay";
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v2.dts
@@ -10,6 +10,32 @@
 	compatible = "linksys,mx4200v2", "qcom,ipq8074";
 };
 
+&blsp1_i2c2 {
+
+	led-controller@58 {
+		compatible = "st,led1202";
+		reg = <0x58>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		led_system_green: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+		led_system_red: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
 &wifi {
 	status = "okay";
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4300.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4300.dts
@@ -242,6 +242,35 @@
 	};
 };
 
+&blsp1_i2c2 {
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
 &dp2 {
 	status = "okay";
 	phy-handle = <&qca8075_1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4x00.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4x00.dtsi
@@ -94,32 +94,6 @@
 
 &blsp1_i2c2 {
 	status = "okay";
-
-	led-controller@62 {
-		compatible = "nxp,pca9633";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <0x62>;
-		nxp,hw-blink;
-
-		led_system_red: led@0 {
-			reg = <0>;
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led_system_green: led@1 {
-			reg = <1>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led_system_blue: led@2 {
-			reg = <2>;
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_STATUS;
-		};
-	};
 };
 
 &mdio {

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -167,7 +167,6 @@ define Device/linksys_mx
 	SOC := ipq8072
 	IMAGES += factory.bin
 	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=$$$$(DEVICE_MODEL)
-	DEVICE_PACKAGES := kmod-leds-pca963x
 endef
 
 define Device/linksys_mx4x00
@@ -180,13 +179,15 @@ define Device/linksys_mx4200v1
 	$(call Device/linksys_mx4x00)
 	DEVICE_MODEL := MX4200
 	DEVICE_VARIANT := v1
-	DEVICE_PACKAGES += kmod-bluetooth
+	DEVICE_PACKAGES += kmod-bluetooth kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx4200v1
 
 define Device/linksys_mx4200v2
-	$(call Device/linksys_mx4200v1)
+	$(call Device/linksys_mx4x00)
+	DEVICE_MODEL := MX4200
 	DEVICE_VARIANT := v2
+	DEVICE_PACKAGES += kmod-bluetooth kmod-leds-st1202
 endef
 TARGET_DEVICES += linksys_mx4200v2
 
@@ -198,6 +199,7 @@ define Device/linksys_mx4300
 	KERNEL_SIZE := 8192k
 	IMAGE_SIZE := 171264k
 	NAND_SIZE := 1024m
+	DEVICE_PACKAGES += kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx4300
 
@@ -205,7 +207,7 @@ define Device/linksys_mx5300
 	$(call Device/linksys_mx)
 	DEVICE_MODEL := MX5300
 	DEVICE_PACKAGES += kmod-rtc-ds1307 ipq-wifi-linksys_mx5300 \
-		kmod-ath10k-ct ath10k-firmware-qca9984-ct
+		kmod-ath10k-ct ath10k-firmware-qca9984-ct kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx5300
 
@@ -213,7 +215,7 @@ define Device/linksys_mx8500
 	$(call Device/linksys_mx)
 	DEVICE_MODEL := MX8500
 	DEVICE_PACKAGES += ipq-wifi-linksys_mx8500 kmod-ath11k-pci \
-		ath11k-firmware-qcn9074 kmod-bluetooth
+		ath11k-firmware-qcn9074 kmod-bluetooth kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx8500
 


### PR DESCRIPTION
The Linksys MX4200v2 router doesn't have the same LED controller as the MX4200v1 or MX4300.  It comes with the STMicroelectronics LED1202.

This LED controller has a driver under development which is currently being reviewed by the respective kernel maintainers. They are currently on v11 which is included in this PR.

Additionally to the driver patches and kmod configuration, the PR makes the necessary changes to enable the driver on the MX4200v2 and amends the configuration of other devices affected by this change as the LED controller NXP PCA9633 is no common to all of them as it was originally thought.