### PR TITLE
mac80211: Fix tracing backport

### DIFF
--- a/package/kernel/mac80211/patches/build/140-trace_backport.patch
+++ b/package/kernel/mac80211/patches/build/140-trace_backport.patch
@@ -1,541 +1,694 @@
 --- a/drivers/bus/mhi/host/trace.h
 +++ b/drivers/bus/mhi/host/trace.h
-@@ -104,7 +104,7 @@ TRACE_EVENT(mhi_gen_tre,
+@@ -104,7 +104,11 @@ TRACE_EVENT(mhi_gen_tre,
  	),
  
  	TP_fast_assign(
--		__assign_str(name);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(name);
++#else
 +		__assign_str(name, mhi_cntrl->mhi_dev->name);
++#endif
  		__entry->ch_num = mhi_chan->chan;
  		__entry->wp = mhi_tre;
  		__entry->tre_ptr = le64_to_cpu(mhi_tre->ptr);
-@@ -132,7 +132,7 @@ TRACE_EVENT(mhi_intvec_states,
+@@ -132,7 +136,11 @@ TRACE_EVENT(mhi_intvec_states,
  	),
  
  	TP_fast_assign(
--		__assign_str(name);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(name);
++#else
 +		__assign_str(name, mhi_cntrl->mhi_dev->name);
++#endif
  		__entry->local_ee = mhi_cntrl->ee;
  		__entry->state = mhi_cntrl->dev_state;
  		__entry->dev_ee = dev_ee;
-@@ -159,7 +159,7 @@ TRACE_EVENT(mhi_tryset_pm_state,
+@@ -159,7 +167,11 @@ TRACE_EVENT(mhi_tryset_pm_state,
  	),
  
  	TP_fast_assign(
--		__assign_str(name);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(name);
++#else
 +		__assign_str(name, mhi_cntrl->mhi_dev->name);
++#endif
  		if (pm_state)
  			pm_state = __fls(pm_state);
  		__entry->pm_state = pm_state;
-@@ -185,7 +185,7 @@ DECLARE_EVENT_CLASS(mhi_process_event_ri
+@@ -185,7 +197,11 @@ DECLARE_EVENT_CLASS(mhi_process_event_ri
  	),
  
  	TP_fast_assign(
--		__assign_str(name);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(name);
++#else
 +		__assign_str(name, mhi_cntrl->mhi_dev->name);
++#endif
  		__entry->rp = rp;
  		__entry->ptr = le64_to_cpu(rp->ptr);
  		__entry->dword0 = le32_to_cpu(rp->dword[0]);
-@@ -227,7 +227,7 @@ DECLARE_EVENT_CLASS(mhi_update_channel_s
+@@ -227,7 +243,11 @@ DECLARE_EVENT_CLASS(mhi_update_channel_s
  	),
  
  	TP_fast_assign(
--		__assign_str(name);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(name);
++#else
 +		__assign_str(name, mhi_cntrl->mhi_dev->name);
++#endif
  		__entry->ch_num = mhi_chan->chan;
  		__entry->state = state;
  		__entry->reason = reason;
-@@ -266,7 +266,7 @@ TRACE_EVENT(mhi_pm_st_transition,
+@@ -266,7 +286,11 @@ TRACE_EVENT(mhi_pm_st_transition,
  	),
  
  	TP_fast_assign(
--		__assign_str(name);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(name);
++#else
 +		__assign_str(name, mhi_cntrl->mhi_dev->name);
++#endif
  		__entry->state = state;
  	),
  
 --- a/drivers/net/wireless/ath/ath10k/trace.h
 +++ b/drivers/net/wireless/ath/ath10k/trace.h
-@@ -55,8 +55,8 @@ DECLARE_EVENT_CLASS(ath10k_log_event,
+@@ -55,8 +55,13 @@ DECLARE_EVENT_CLASS(ath10k_log_event,
  		__vstring(msg, vaf->fmt, vaf->va)
  	),
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__assign_vstr(msg, vaf->fmt, vaf->va);
  	),
  	TP_printk(
-@@ -92,8 +92,8 @@ TRACE_EVENT(ath10k_log_dbg,
+@@ -92,8 +97,13 @@ TRACE_EVENT(ath10k_log_dbg,
  		__vstring(msg, vaf->fmt, vaf->va)
  	),
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->level = level;
  		__assign_vstr(msg, vaf->fmt, vaf->va);
  	),
-@@ -121,10 +121,10 @@ TRACE_EVENT(ath10k_log_dbg_dump,
+@@ -121,10 +131,17 @@ TRACE_EVENT(ath10k_log_dbg_dump,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
--		__assign_str(msg);
--		__assign_str(prefix);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
+ 		__assign_str(msg);
+ 		__assign_str(prefix);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
 +		__assign_str(msg, msg);
 +		__assign_str(prefix, prefix);
++#endif
  		__entry->buf_len = buf_len;
  		memcpy(__get_dynamic_array(buf), buf, buf_len);
  	),
-@@ -152,8 +152,8 @@ TRACE_EVENT(ath10k_wmi_cmd,
+@@ -152,8 +169,13 @@ TRACE_EVENT(ath10k_wmi_cmd,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->id = id;
  		__entry->buf_len = buf_len;
  		memcpy(__get_dynamic_array(buf), buf, buf_len);
-@@ -182,8 +182,8 @@ TRACE_EVENT(ath10k_wmi_event,
+@@ -182,8 +204,13 @@ TRACE_EVENT(ath10k_wmi_event,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->id = id;
  		__entry->buf_len = buf_len;
  		memcpy(__get_dynamic_array(buf), buf, buf_len);
-@@ -211,8 +211,8 @@ TRACE_EVENT(ath10k_htt_stats,
+@@ -211,8 +238,13 @@ TRACE_EVENT(ath10k_htt_stats,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->buf_len = buf_len;
  		memcpy(__get_dynamic_array(buf), buf, buf_len);
  	),
-@@ -239,8 +239,8 @@ TRACE_EVENT(ath10k_wmi_dbglog,
+@@ -239,8 +271,13 @@ TRACE_EVENT(ath10k_wmi_dbglog,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->hw_type = ar->hw_rev;
  		__entry->buf_len = buf_len;
  		memcpy(__get_dynamic_array(buf), buf, buf_len);
-@@ -269,8 +269,8 @@ TRACE_EVENT(ath10k_htt_pktlog,
+@@ -269,8 +306,13 @@ TRACE_EVENT(ath10k_htt_pktlog,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->hw_type = ar->hw_rev;
  		__entry->buf_len = buf_len;
  		memcpy(__get_dynamic_array(pktlog), buf, buf_len);
-@@ -301,8 +301,8 @@ TRACE_EVENT(ath10k_htt_tx,
+@@ -301,8 +343,13 @@ TRACE_EVENT(ath10k_htt_tx,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->msdu_id = msdu_id;
  		__entry->msdu_len = msdu_len;
  		__entry->vdev_id = vdev_id;
-@@ -332,8 +332,8 @@ TRACE_EVENT(ath10k_txrx_tx_unref,
+@@ -332,8 +379,13 @@ TRACE_EVENT(ath10k_txrx_tx_unref,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->msdu_id = msdu_id;
  	),
  
-@@ -358,8 +358,8 @@ DECLARE_EVENT_CLASS(ath10k_hdr_event,
+@@ -358,8 +410,13 @@ DECLARE_EVENT_CLASS(ath10k_hdr_event,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->len = ath10k_frm_hdr_len(data, len);
  		memcpy(__get_dynamic_array(data), data, __entry->len);
  	),
-@@ -386,8 +386,8 @@ DECLARE_EVENT_CLASS(ath10k_payload_event
+@@ -386,8 +443,13 @@ DECLARE_EVENT_CLASS(ath10k_payload_event
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->len = len - ath10k_frm_hdr_len(data, len);
  		memcpy(__get_dynamic_array(payload),
  		       data + ath10k_frm_hdr_len(data, len), __entry->len);
-@@ -435,8 +435,8 @@ TRACE_EVENT(ath10k_htt_rx_desc,
+@@ -435,8 +497,13 @@ TRACE_EVENT(ath10k_htt_rx_desc,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->hw_type = ar->hw_rev;
  		__entry->len = len;
  		memcpy(__get_dynamic_array(rxdesc), data, len);
-@@ -472,8 +472,8 @@ TRACE_EVENT(ath10k_wmi_diag_container,
+@@ -472,8 +539,13 @@ TRACE_EVENT(ath10k_wmi_diag_container,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->type = type;
  		__entry->timestamp = timestamp;
  		__entry->code = code;
-@@ -505,8 +505,8 @@ TRACE_EVENT(ath10k_wmi_diag,
+@@ -505,8 +577,13 @@ TRACE_EVENT(ath10k_wmi_diag,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->dev));
 +		__assign_str(driver, dev_driver_string(ar->dev));
++#endif
  		__entry->len = len;
  		memcpy(__get_dynamic_array(data), data, len);
  	),
 --- a/drivers/net/wireless/ath/ath11k/trace.h
 +++ b/drivers/net/wireless/ath/ath11k/trace.h
-@@ -48,8 +48,8 @@ TRACE_EVENT(ath11k_htt_pktlog,
+@@ -48,8 +48,13 @@ TRACE_EVENT(ath11k_htt_pktlog,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->ab->dev));
 +		__assign_str(driver, dev_driver_string(ar->ab->dev));
++#endif
  		__entry->buf_len = buf_len;
  		__entry->pktlog_checksum = pktlog_checksum;
  		memcpy(__get_dynamic_array(pktlog), buf, buf_len);
-@@ -77,8 +77,8 @@ TRACE_EVENT(ath11k_htt_ppdu_stats,
+@@ -77,8 +82,13 @@ TRACE_EVENT(ath11k_htt_ppdu_stats,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->ab->dev));
 +		__assign_str(driver, dev_driver_string(ar->ab->dev));
++#endif
  		__entry->len = len;
  		memcpy(__get_dynamic_array(ppdu), data, len);
  	),
-@@ -105,8 +105,8 @@ TRACE_EVENT(ath11k_htt_rxdesc,
+@@ -105,8 +115,13 @@ TRACE_EVENT(ath11k_htt_rxdesc,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->ab->dev));
 +		__assign_str(driver, dev_driver_string(ar->ab->dev));
++#endif
  		__entry->len = len;
  		__entry->log_type = log_type;
  		memcpy(__get_dynamic_array(rxdesc), data, len);
-@@ -130,8 +130,8 @@ DECLARE_EVENT_CLASS(ath11k_log_event,
+@@ -130,8 +145,13 @@ DECLARE_EVENT_CLASS(ath11k_log_event,
  		__vstring(msg, vaf->fmt, vaf->va)
  	),
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ab->dev));
 +		__assign_str(driver, dev_driver_string(ab->dev));
++#endif
  		__assign_vstr(msg, vaf->fmt, vaf->va);
  	),
  	TP_printk(
-@@ -171,8 +171,8 @@ TRACE_EVENT(ath11k_wmi_cmd,
+@@ -171,8 +191,13 @@ TRACE_EVENT(ath11k_wmi_cmd,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ab->dev));
 +		__assign_str(driver, dev_driver_string(ab->dev));
++#endif
  		__entry->id = id;
  		__entry->buf_len = buf_len;
  		memcpy(__get_dynamic_array(buf), buf, buf_len);
-@@ -201,8 +201,8 @@ TRACE_EVENT(ath11k_wmi_event,
+@@ -201,8 +226,13 @@ TRACE_EVENT(ath11k_wmi_event,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ab->dev));
 +		__assign_str(driver, dev_driver_string(ab->dev));
++#endif
  		__entry->id = id;
  		__entry->buf_len = buf_len;
  		memcpy(__get_dynamic_array(buf), buf, buf_len);
-@@ -230,8 +230,8 @@ TRACE_EVENT(ath11k_log_dbg,
+@@ -230,8 +260,13 @@ TRACE_EVENT(ath11k_log_dbg,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ab->dev));
 +		__assign_str(driver, dev_driver_string(ab->dev));
++#endif
  		__entry->level = level;
  		WARN_ON_ONCE(vsnprintf(__get_dynamic_array(msg),
  				       ATH11K_MSG_MAX, vaf->fmt,
-@@ -262,10 +262,10 @@ TRACE_EVENT(ath11k_log_dbg_dump,
+@@ -262,10 +297,17 @@ TRACE_EVENT(ath11k_log_dbg_dump,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
--		__assign_str(msg);
--		__assign_str(prefix);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
+ 		__assign_str(msg);
+ 		__assign_str(prefix);
++#else
 +		__assign_str(device, dev_name(ab->dev));
 +		__assign_str(driver, dev_driver_string(ab->dev));
 +		__assign_str(msg, msg);
 +		__assign_str(prefix, prefix);
++#endif
  		__entry->buf_len = buf_len;
  		memcpy(__get_dynamic_array(buf), buf, buf_len);
  	),
-@@ -292,8 +292,8 @@ TRACE_EVENT(ath11k_wmi_diag,
+@@ -292,8 +334,13 @@ TRACE_EVENT(ath11k_wmi_diag,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ab->dev));
 +		__assign_str(driver, dev_driver_string(ab->dev));
++#endif
  		__entry->len = len;
  		memcpy(__get_dynamic_array(data), data, len);
  	),
-@@ -318,8 +318,8 @@ TRACE_EVENT(ath11k_ps_timekeeper,
+@@ -318,8 +365,14 @@ TRACE_EVENT(ath11k_ps_timekeeper,
  			 __field(u32, peer_ps_timestamp)
  	),
  
 -	TP_fast_assign(__assign_str(device);
--		       __assign_str(driver);
-+	TP_fast_assign(__assign_str(device, dev_name(ar->ab->dev));
++	TP_fast_assign(
++#if LINUX_VERSION_IS_GEQ(6,10,0)
++		       __assign_str(device);
+ 		       __assign_str(driver);
++#else
++		       __assign_str(device, dev_name(ar->ab->dev));
 +		       __assign_str(driver, dev_driver_string(ar->ab->dev));
++#endif
  		       memcpy(__get_dynamic_array(peer_addr), peer_addr,
  			      ETH_ALEN);
  		       __entry->peer_ps_state = peer_ps_state;
 --- a/drivers/net/wireless/ath/ath12k/trace.h
 +++ b/drivers/net/wireless/ath/ath12k/trace.h
-@@ -36,8 +36,8 @@ TRACE_EVENT(ath12k_htt_pktlog,
+@@ -36,8 +36,13 @@ TRACE_EVENT(ath12k_htt_pktlog,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->ab->dev));
 +		__assign_str(driver, dev_driver_string(ar->ab->dev));
++#endif
  		__entry->buf_len = buf_len;
  		__entry->pktlog_checksum = pktlog_checksum;
  		memcpy(__get_dynamic_array(pktlog), buf, buf_len);
-@@ -73,8 +73,8 @@ TRACE_EVENT(ath12k_htt_ppdu_stats,
+@@ -73,8 +78,13 @@ TRACE_EVENT(ath12k_htt_ppdu_stats,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->ab->dev));
 +		__assign_str(driver, dev_driver_string(ar->ab->dev));
++#endif
  		__entry->len = len;
  		__entry->info = ar->pdev->timestamp.info;
  		__entry->sync_tstmp_lo_us = ar->pdev->timestamp.sync_timestamp_hi_us;
-@@ -117,8 +117,8 @@ TRACE_EVENT(ath12k_htt_rxdesc,
+@@ -117,8 +127,13 @@ TRACE_EVENT(ath12k_htt_rxdesc,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ar->ab->dev));
 +		__assign_str(driver, dev_driver_string(ar->ab->dev));
++#endif
  		__entry->len = len;
  		__entry->type = type;
  		__entry->info = ar->pdev->timestamp.info;
-@@ -153,8 +153,8 @@ TRACE_EVENT(ath12k_wmi_diag,
+@@ -153,8 +168,13 @@ TRACE_EVENT(ath12k_wmi_diag,
  	),
  
  	TP_fast_assign(
--		__assign_str(device);
--		__assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(device);
+ 		__assign_str(driver);
++#else
 +		__assign_str(device, dev_name(ab->dev));
 +		__assign_str(driver, dev_driver_string(ab->dev));
++#endif
  		__entry->len = len;
  		memcpy(__get_dynamic_array(data), data, len);
  	),
 --- a/drivers/net/wireless/ath/ath6kl/trace.h
 +++ b/drivers/net/wireless/ath/ath6kl/trace.h
-@@ -304,8 +304,8 @@ TRACE_EVENT(ath6kl_log_dbg_dump,
+@@ -304,8 +304,13 @@ TRACE_EVENT(ath6kl_log_dbg_dump,
  	),
  
  	TP_fast_assign(
--		__assign_str(msg);
--		__assign_str(prefix);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(msg);
+ 		__assign_str(prefix);
++#else
 +		__assign_str(msg, msg);
 +		__assign_str(prefix, prefix);
++#endif
  		__entry->buf_len = buf_len;
  		memcpy(__get_dynamic_array(buf), buf, buf_len);
  	),
 --- a/drivers/net/wireless/ath/trace.h
 +++ b/drivers/net/wireless/ath/trace.h
-@@ -44,8 +44,8 @@ TRACE_EVENT(ath_log,
+@@ -44,8 +44,13 @@ TRACE_EVENT(ath_log,
  	    ),
  
  	    TP_fast_assign(
--		    __assign_str(device);
--		    __assign_str(driver);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		    __assign_str(device);
+ 		    __assign_str(driver);
++#else
 +		    __assign_str(device, wiphy_name(wiphy));
 +		    __assign_str(driver, KBUILD_MODNAME);
++#endif
  		    __assign_vstr(msg, vaf->fmt, vaf->va);
  	    ),
  
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/tracepoint.h
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/tracepoint.h
-@@ -41,7 +41,7 @@ TRACE_EVENT(brcmf_err,
+@@ -41,7 +41,11 @@ TRACE_EVENT(brcmf_err,
  		__vstring(msg, vaf->fmt, vaf->va)
  	),
  	TP_fast_assign(
--		__assign_str(func);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(func);
++#else
 +		__assign_str(func, func);
++#endif
  		__assign_vstr(msg, vaf->fmt, vaf->va);
  	),
  	TP_printk("%s: %s", __get_str(func), __get_str(msg))
-@@ -57,7 +57,7 @@ TRACE_EVENT(brcmf_dbg,
+@@ -57,7 +61,11 @@ TRACE_EVENT(brcmf_dbg,
  	),
  	TP_fast_assign(
  		__entry->level = level;
--		__assign_str(func);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(func);
++#else
 +		__assign_str(func, func);
++#endif
  		__assign_vstr(msg, vaf->fmt, vaf->va);
  	),
  	TP_printk("%s: %s", __get_str(func), __get_str(msg))
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmsmac/brcms_trace_brcmsmac.h
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmsmac/brcms_trace_brcmsmac.h
-@@ -81,7 +81,7 @@ TRACE_EVENT(brcms_macintstatus,
+@@ -81,7 +81,11 @@ TRACE_EVENT(brcms_macintstatus,
  		__field(u32, mask)
  	),
  	TP_fast_assign(
--		__assign_str(dev);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(dev);
++#else
 +		__assign_str(dev, dev_name(dev));
++#endif
  		__entry->in_isr = in_isr;
  		__entry->macintstatus = macintstatus;
  		__entry->mask = mask;
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmsmac/brcms_trace_brcmsmac_msg.h
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmsmac/brcms_trace_brcmsmac_msg.h
-@@ -71,7 +71,7 @@ TRACE_EVENT(brcms_dbg,
+@@ -71,7 +71,11 @@ TRACE_EVENT(brcms_dbg,
  	),
  	TP_fast_assign(
  		__entry->level = level;
--		__assign_str(func);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(func);
++#else
 +		__assign_str(func, func);
++#endif
  		__assign_vstr(msg, vaf->fmt, vaf->va);
  	),
  	TP_printk("%s: %s", __get_str(func), __get_str(msg))
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmsmac/brcms_trace_brcmsmac_tx.h
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmsmac/brcms_trace_brcmsmac_tx.h
-@@ -31,7 +31,7 @@ TRACE_EVENT(brcms_txdesc,
+@@ -31,7 +31,11 @@ TRACE_EVENT(brcms_txdesc,
  		__dynamic_array(u8, txh, txh_len)
  	),
  	TP_fast_assign(
--		__assign_str(dev);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(dev);
++#else
 +		__assign_str(dev, dev_name(dev));
++#endif
  		memcpy(__get_dynamic_array(txh), txh, txh_len);
  	),
  	TP_printk("[%s] txdesc", __get_str(dev))
-@@ -54,7 +54,7 @@ TRACE_EVENT(brcms_txstatus,
+@@ -54,7 +58,11 @@ TRACE_EVENT(brcms_txstatus,
  		__field(u16, ackphyrxsh)
  	),
  	TP_fast_assign(
--		__assign_str(dev);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(dev);
++#else
 +		__assign_str(dev, dev_name(dev));
++#endif
  		__entry->framelen = framelen;
  		__entry->frameid = frameid;
  		__entry->status = status;
-@@ -85,7 +85,7 @@ TRACE_EVENT(brcms_ampdu_session,
+@@ -85,7 +93,11 @@ TRACE_EVENT(brcms_ampdu_session,
  		__field(u16, dma_len)
  	),
  	TP_fast_assign(
--		__assign_str(dev);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(dev);
++#else
 +		__assign_str(dev, dev_name(dev));
++#endif
  		__entry->max_ampdu_len = max_ampdu_len;
  		__entry->max_ampdu_frames = max_ampdu_frames;
  		__entry->ampdu_len = ampdu_len;
 --- a/drivers/net/wireless/intel/iwlwifi/iwl-devtrace-msg.h
 +++ b/drivers/net/wireless/intel/iwlwifi/iwl-devtrace-msg.h
-@@ -57,7 +57,7 @@ TRACE_EVENT(iwlwifi_dbg,
+@@ -57,7 +57,11 @@ TRACE_EVENT(iwlwifi_dbg,
  	),
  	TP_fast_assign(
  		__entry->level = level;
--		__assign_str(function);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(function);
++#else
 +		__assign_str(function, function);
++#endif
  		__assign_vstr(msg, vaf->fmt, vaf->va);
  	),
  	TP_printk("%s", __get_str(msg))
 --- a/drivers/net/wireless/intel/iwlwifi/iwl-devtrace.h
 +++ b/drivers/net/wireless/intel/iwlwifi/iwl-devtrace.h
-@@ -87,7 +87,7 @@ static inline void trace_ ## name(proto)
+@@ -87,7 +87,11 @@ static inline void trace_ ## name(proto)
  #endif
  
  #define DEV_ENTRY	__string(dev, dev_name(dev))
--#define DEV_ASSIGN	__assign_str(dev)
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ #define DEV_ASSIGN	__assign_str(dev)
++#else
 +#define DEV_ASSIGN	__assign_str(dev, dev_name(dev))
++#endif
  
  #include "iwl-devtrace-io.h"
  #include "iwl-devtrace-ucode.h"
 --- a/include/trace/events/qrtr.h
 +++ b/include/trace/events/qrtr.h
-@@ -102,7 +102,7 @@ TRACE_EVENT(qrtr_ns_message,
+@@ -102,7 +102,11 @@ TRACE_EVENT(qrtr_ns_message,
  	),
  
  	TP_fast_assign(
--		__assign_str(ctrl_pkt_str);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(ctrl_pkt_str);
++#else
 +		__assign_str(ctrl_pkt_str, ctrl_pkt_str);
++#endif
  		__entry->sq_node = sq_node;
  		__entry->sq_port = sq_port;
  	),
 --- a/net/mac80211/trace.h
 +++ b/net/mac80211/trace.h
-@@ -33,7 +33,7 @@
+@@ -31,9 +31,15 @@
+ #define VIF_ENTRY	__field(enum nl80211_iftype, vif_type) __field(void *, sdata)	\
+ 			__field(bool, p2p)						\
  			__string(vif_name, sdata->name)
++#if LINUX_VERSION_IS_GEQ(6,10,0)
  #define VIF_ASSIGN	__entry->vif_type = sdata->vif.type; __entry->sdata = sdata;	\
  			__entry->p2p = sdata->vif.p2p;					\
--			__assign_str(vif_name)
+ 			__assign_str(vif_name)
++#else
++#define VIF_ASSIGN	__entry->vif_type = sdata->vif.type; __entry->sdata = sdata;	\
++			__entry->p2p = sdata->vif.p2p;					\
 +			__assign_str(vif_name, sdata->name)
++#endif
  #define VIF_PR_FMT	" vif:%s(%d%s)"
  #define VIF_PR_ARG	__get_str(vif_name), __entry->vif_type, __entry->p2p ? "/p2p" : ""
  
 --- a/net/wireless/trace.h
 +++ b/net/wireless/trace.h
-@@ -446,7 +446,7 @@ TRACE_EVENT(rdev_add_virtual_intf,
+@@ -446,7 +446,11 @@ TRACE_EVENT(rdev_add_virtual_intf,
  	),
  	TP_fast_assign(
  		WIPHY_ASSIGN;
--		__assign_str(vir_intf_name);
++#if LINUX_VERSION_IS_GEQ(6,10,0)
+ 		__assign_str(vir_intf_name);
++#else
 +		__assign_str(vir_intf_name, name ? name : "<noname>");
++#endif
  		__entry->type = type;
  	),
  	TP_printk(WIPHY_PR_FMT ", virtual intf name: %s, type: %d",


### PR DESCRIPTION
Update handling of macro `__assign_str()` to also support the one-argument variant when building against kernel 6.10 or later. This is needed for building LTS kernel 6.12 and later.

Fixes: 384d079fd8 ("mac80211: update to version 6.11")

I PR'd another necessary `mac80211` fix at [OpenWrt backports](https://github.com/nbd168/backports/pull/1). Although it's possible to include a similar patch here, I believe the backports repo is the right place for it. Please let me know if otherwise.

CC: @nbd168 @hauke @PolynomialDivision @robimarko 

Happy New Year!