### PR TITLE
qualcommax: ipq807x: add support for Linksys HomeWRK

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -29,6 +29,11 @@ edimax,cax1800)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x20000"
 	;;
+linksys,homewrk)
+	idx="$(find_mtd_index 0:appsblenv)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x40000"
+	;;
 linksys,mx4200v1|\
 linksys,mx4200v2|\
 linksys,mx5300|\

--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -7,79 +7,71 @@ touch /etc/config/ubootenv
 
 board=$(board_name)
 
+ubootenv_add_mtd() {
+	local idx="$(find_mtd_index "${1}")"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "${2}" "${3}" "${4}"
+}
+
+ubootenv_add_sys_mtd() {
+	local idx="$(find_mtd_index "${1}")"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_sys_config "/dev/mtd$idx" "${2}" "${3}" "${4}"
+}
+
+ubootenv_add_mmc() {
+	local mmcpart="$(find_mmc_part "${1}")"
+	[ -n "$mmcpart" ] && \
+		ubootenv_add_uci_config "$mmcpart" "${2}" "${3}" "${4}" "${5}"
+}
+
 case "$board" in
 dynalink,dl-wrx36|\
 netgear,rax120v2|\
+netgear,sxr80|\
+netgear,sxs80|\
 netgear,wax218|\
 netgear,wax620|\
-netgear,wax630)
-	idx="$(find_mtd_index 0:appsblenv)"
-	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"
+netgear,wax630|\
+tplink,eap620hd-v1|\
+tplink,eap660hd-v1)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
 	;;
 compex,wpq873|\
 edgecore,eap102|\
 zyxel,nbg7815)
-	idx="$(find_mtd_index 0:appsblenv)"
-	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000" "1"
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x10000"
 	;;
 edimax,cax1800)
-	idx="$(find_mtd_index 0:appsblenv)"
-	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x20000"
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x20000"
 	;;
 linksys,homewrk)
-	idx="$(find_mtd_index 0:appsblenv)"
-	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x40000"
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x40000"
 	;;
 linksys,mx4200v1|\
 linksys,mx4200v2|\
 linksys,mx5300|\
 linksys,mx8500)
-	idx="$(find_mtd_index u_env)"
-	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"
+	ubootenv_add_mtd "u_env" "0x0" "0x40000" "0x20000"
 	;;
 linksys,mx4300)
-	idx="$(find_mtd_index u_env)"
-	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x40000" "1"
-	;;
-netgear,sxr80|\
-netgear,sxs80|\
-tplink,eap620hd-v1|\
-tplink,eap660hd-v1)
-	idx="$(find_mtd_index 0:appsblenv)"
-	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000"
+	ubootenv_add_mtd "u_env" "0x0" "0x40000" "0x40000"
 	;;
 redmi,ax6|\
 xiaomi,ax3600|\
 xiaomi,ax9000)
-	idx="$(find_mtd_index 0:appsblenv)"
-	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x20000"
-	idx2="$(find_mtd_index bdata)"
-	[ -n "$idx2" ] && \
-		ubootenv_add_uci_sys_config "/dev/mtd$idx2" "0x0" "0x10000" "0x20000"
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x20000"
+	ubootenv_add_sys_mtd "bdata" "0x0" "0x10000" "0x20000"
 	;;
 prpl,haze)
-	mmcpart="$(find_mmc_part 0:APPSBLENV)"
-	[ -n "$mmcpart" ] && \
-		ubootenv_add_uci_config "$mmcpart" "0x0" "0x40000" "0x400" "0x100"
+	ubootenv_add_mmc "0:APPSBLENV" "0x0" "0x40000" "0x400" "0x100"
 	;;
 asus,rt-ax89x|\
 qnap,301w)
-	idx="$(find_mtd_index 0:appsblenv)"
-	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x20000" "0x20000" "1"
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x20000" "0x20000"
 	;;
 spectrum,sax1v1k)
-	mmcpart="$(find_mmc_part 0:APPSBLENV)"
-	[ -n "$mmcpart" ] && \
-		ubootenv_add_uci_config "$mmcpart" "0x0" "0x40000" "0x40000" "1"
+	ubootenv_add_mmc "0:APPSBLENV" "0x0" "0x40000" "0x40000" "1"
 	;;
 esac
 

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -6,9 +6,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2024-12-18
-PKG_SOURCE_VERSION:=4b849214b137b14a903112af3c2016ad9acf48c2
-PKG_MIRROR_HASH:=28162682fe7612460e42398ecc669e245fc0ece873361e3910c2dd8a56111f1c
+PKG_SOURCE_DATE:=2025-01-15
+PKG_SOURCE_VERSION:=6e1801a4992fe72a98a2219f2dcd038194785971
+PKG_MIRROR_HASH:=569cf6894e21712ed6a5553b4fad0bbdeed14e0cc4b9292f5f86343f7897fc7e
 PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/package.mk
@@ -37,6 +37,7 @@ ALLWIFIBOARDS:= \
 	dynalink_dl-wrx36 \
 	edgecore_eap102 \
 	edimax_cax1800 \
+	linksys_homewrk \
 	linksys_mr7350 \
 	linksys_mx4200 \
 	linksys_mx5300 \
@@ -168,6 +169,7 @@ $(eval $(call generate-ipq-wifi-package,compex_wpq873,Compex WPQ-873))
 $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))
 $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
+$(eval $(call generate-ipq-wifi-package,linksys_homewrk,Linksys HomeWRK))
 $(eval $(call generate-ipq-wifi-package,linksys_mr7350,Linksys MR7350))
 $(eval $(call generate-ipq-wifi-package,linksys_mx4200,Linksys MX4200))
 $(eval $(call generate-ipq-wifi-package,linksys_mx5300,Linksys MX5300))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-homewrk.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-homewrk.dts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq8174-mx4x00.dtsi"
+
+/ {
+	model = "Linksys HomeWRK";
+	compatible = "linksys,homewrk", "qcom,ipq8074";
+
+	aliases {
+		ethernet3 = &dp4;
+		ethernet4 = &dp5;
+	};
+
+	chosen {
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		/*
+		 * Some devices use Micron NAND with with 8 bit ECC 
+		 * other AMD/Spansion NAND with 4 bit ECC
+		 *nand-ecc-strength = <4>;
+		 *nand-ecc-step-size = <512>;
+		 */
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&dp2 {
+	status = "okay";
+	phy-handle = <&qca8075_1>;
+	label = "wan";
+};
+
+&dp3 {
+	status = "okay";
+	phy-handle = <&qca8075_2>;
+	label = "lan3";
+};
+
+&dp4 {
+	status = "okay";
+	phy-handle = <&qca8075_3>;
+	label = "lan2";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8075_4>;
+	label = "lan1";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Linksys-HomeWRK";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -156,6 +156,21 @@ define Device/edimax_cax1800
 endef
 TARGET_DEVICES += edimax_cax1800
 
+define Device/linksys_homewrk
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Linksys
+	DEVICE_MODEL := HomeWRK
+	DEVICE_DTS_CONFIG := config@oak03
+	BLOCKSIZE := 256k
+	PAGESIZE := 4096
+	IMAGE_SIZE := 475m
+	NAND_SIZE := 1024m
+	SOC := ipq8174
+	DEVICE_PACKAGES += kmod-leds-pca963x ipq-wifi-linksys_homewrk
+endef
+TARGET_DEVICES += linksys_homewrk
+
 define Device/linksys_mx
 	$(call Device/FitImage)
 	DEVICE_VENDOR := Linksys

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -27,6 +27,7 @@ ipq807x_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan plc" "wan"
 		;;
 	compex,wpq873|\
+	linksys,homewrk|\
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
 	linksys,mx4300|\

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -30,6 +30,7 @@ case "$FIRMWARE" in
 	zte,mf269)
 		caldata_extract "0:art" 0x1000 0x20000
 		;;
+	linksys,homewrk|\
 	linksys,mx4200v1|\
 	linksys,mx8500)
 		caldata_extract "0:art" 0x1000 0x20000

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -166,6 +166,11 @@ platform_do_upgrade() {
 		fw_setenv upgrade_available 1
 		nand_do_upgrade "$1"
 		;;
+	linksys,homewrk)
+		CI_UBIPART="rootfs"
+		remove_oem_ubi_volume ubi_rootfs
+		nand_do_upgrade "$1"
+		;;
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
 	linksys,mx4300|\


### PR DESCRIPTION
Hardware specification:
========
SoC: Qualcomm IPQ8174
Flash: 1GB (Micron MT29F8G08ABBCAH4 or AMD/Spansion S34MS08G2)
RAM: 2GB (2x Kingston B5116ECMDXGJD or ESMT M15T2G16128A DDR3L)
Ethernet: 4x 10/100/1000Mbps (Qualcomm QCA8075)
WiFi1: 5GHz ax 2x2 (Qualcomm QCN5054 + Skyworks SKY85755-11) - channels 36-64 (low band)
WiFi2: 2.4GHz ax 2x2 (Qualcomm QCN5024 + Skyworks SKY85340-11)
WiFi3: 5GHz ax 4x4 (Qualcomm QCN5054 + Skyworks SKY85755-11) - channels 100-177 (high band)
LED: 1x RGB status (NXP PCA9633)
USB: 1x USB 3.0
Button: WPS, Reset

Flash instructions:
========
1. Installation from initramfs image using USB drive:
    Put the initramfs image on the USB drive:
    - dd bs=1M if=openwrt-qualcommax-ipq807x-linksys_homewrk-initramfs-uImage.itb of=/dev/sdX

    Connect serial console (JST PH 6-pin connector):
    - 1 - GND, 2 - TX, 4 - RX (115200, 8N1, 3.3V)

    Stop u-boot and run:
    - usb start && usbboot 44000000 0 && bootm 44000000

    Write firmware to the flash from initramfs:
    - sysupgrade -n openwrt-qualcommax-ipq807x-linksys_homewrk-squashfs-sysupgrade.bin

    or
    - ubiformat /dev/mtd22 -y -f openwrt-qualcommax-ipq807x-linksys_homewrk-squashfs-factory.ubi

3. USB recovery:
    Put the initramfs image on the USB:
    - dd bs=1M if=openwrt-qualcommax-ipq807x-linksys_homewrk-initramfs-uImage.itb of=/dev/sdX

    Set u-boot env:
    - fw_setenv bootusb 'usb start && usbboot 44000000 0 && bootm 44000000'
    - fw_setenv bootcmd 'run bootusb; bootipq'