### PR TITLE
include/trusted-firmware-a.mk: unset CC before compiling

### DIFF
--- a/include/trusted-firmware-a.mk
+++ b/include/trusted-firmware-a.mk
@@ -77,7 +77,8 @@ endef
 DTC=$(wildcard $(LINUX_DIR)/scripts/dtc/dtc)
 
 define Build/Compile/Trusted-Firmware-A
-	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+	+unset CC; \
+	$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
 		CROSS_COMPILE=$(TARGET_CROSS) \
 		OPENSSL_DIR=$(STAGING_DIR_HOST) \
 		$(if $(DTC),DTC="$(DTC)") \


### PR DESCRIPTION
If CC is explicitly set to a non default value, TF-A keeps this value. Otherwise it assigns generic default value.
As the build bot set CC=/usr/bin/gcc-10, TF-A uses it which causes a compile issue.
So unset CC before compiling.

It's a new behavior since v2.12. A part of the explanation is available in this commit [1].

[1] https://github.com/ARM-software/arm-trusted-firmware/commit/e01c71266f9df46ac46dc72669449490d1c94419

Build bot logs: https://buildbot.openwrt.org/images/#/builders/260/builds/30
