### PR TITLE
ipq40xx: fix label MAC address for FritzBox 7520/7530

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
@@ -19,6 +19,7 @@
 		led-failsafe = &info_red;
 		led-running = &power_green;
 		led-upgrade = &info_red;
+		label-mac-device = &gmac;
 	};
 
 	soc {


### PR DESCRIPTION
The MAC address of the GMAC is contained inside the CWMP-Account number on the label.

Similar fix as to the 4040 in b22d382ae4eaa1af42930115d91855f402314cac

Fixes https://github.com/freifunk-gluon/gluon/issues/3410
Link #13240

This issue still appears with or without the fix in #17442

Should be backported to 24.10 as well :)