### PR TITLE
lantiq: xrx200: add support for lan3 and lan4 on AVM 5490/5491

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz5490.dtsi
@@ -46,6 +46,61 @@
 	phy9: ethernet-phy@9 {
 		reg = <0x09>;
 	};
+
+	switch@0 {
+		compatible = "qca,qca8334";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reset-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		reg = <0>;
+
+		dsa,member = <1 0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				ethernet = <&rgmii0>;
+				phy-mode = "rgmii-txid";
+				tx-internal-delay-ps = <3000>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+				phy-mode = "internal";
+				phy-handle = <&phy_port2>;
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan4";
+				phy-mode = "internal";
+				phy-handle = <&phy_port3>;
+			};
+		};
+
+		mdio {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			phy_port2: phy@1 {
+				reg = <1>;
+			};
+
+			phy_port3: phy@2 {
+				reg = <2>;
+			};
+		};
+	};
 };
 
 &gswip_ports {
@@ -54,6 +109,17 @@
 		label = "wan";
 		phy-mode = "rgmii";
 		phy-handle = <&phy6>;
+	};
+
+	rgmii0: port@1 {
+		reg = <1>;
+		label = "sw0";
+		phy-mode = "rgmii";
+
+		fixed-link {
+			speed = <1000>;
+			full-duplex;
+		};
 	};
 
 	port@2 {

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -177,7 +177,7 @@ define Device/avm_fritz5490
   DEVICE_VARIANT := Other NAND
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-usb3 fritz-tffs \
+  DEVICE_PACKAGES := kmod-dsa-qca8k kmod-phy-qca83xx kmod-usb3 fritz-tffs \
 	-ltq-vdsl-vr9-vectoring-fw-installer -kmod-ltq-vdsl-vr9-mei \
 	-kmod-ltq-vdsl-vr9 -kmod-ltq-atm-vr9 -kmod-ltq-ptm-vr9 \
 	-ltq-vdsl-vr9-app -kmod-owl-loader \
@@ -195,7 +195,7 @@ define Device/avm_fritz5490-micron
   DEVICE_VARIANT := Micron NAND
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-usb3 fritz-tffs \
+  DEVICE_PACKAGES := kmod-dsa-qca8k kmod-phy-qca83xx kmod-usb3 fritz-tffs \
 	-ltq-vdsl-vr9-vectoring-fw-installer -kmod-ltq-vdsl-vr9-mei \
 	-kmod-ltq-vdsl-vr9 -kmod-ltq-atm-vr9 -kmod-ltq-ptm-vr9 \
 	-ltq-vdsl-vr9-app -kmod-owl-loader \

--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -14,15 +14,13 @@ lantiq_setup_interfaces()
 	arcadyan,arv7519rw22)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
 		;;
-	avm,fritz5490|\
-	avm,fritz5490-micron)
-		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
-		;;
 	arcadyan,vgv7510kw22-brn|\
 	arcadyan,vgv7510kw22-nor|\
 	arcadyan,vgv7519-brn|\
 	arcadyan,vgv7519-nor|\
 	arcadyan,vrv9510kwac23|\
+	avm,fritz5490|\
+	avm,fritz5490-micron|\
 	bt,homehub-v5a|\
 	lantiq,easy80920-nand|\
 	lantiq,easy80920-nor|\


### PR DESCRIPTION
On the AVM 5490/5491, lan1, lan2 and wan ports are connected directly to the internal GSWIP switch. The lan3 and lan4 ports are connected via an external QCA8334 switch. This commit adds the missing entries in dts and adds the driver module.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>