### PR TITLE
rockchip: refresh patch

### DIFF
--- a/target/linux/rockchip/patches-6.6/301-arm64-dts-rockchip-add-DT-entry-for-RNG-to-RK3568.patch
+++ b/target/linux/rockchip/patches-6.6/301-arm64-dts-rockchip-add-DT-entry-for-RNG-to-RK3568.patch
@@ -14,7 +14,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/arch/arm64/boot/dts/rockchip/rk3568.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
-@@ -257,6 +257,13 @@
+@@ -258,6 +258,13 @@
  	};
  };
  


### PR DESCRIPTION
Commit 8a477bafb4637e3499f69f569133039ce060559e backported an upstream patch without refreshing the patches.

CC @robimarko @1715173329