### PR TITLE
bcm27xx: remove duplicated kmod-rp1-pio package

### DIFF
--- a/target/linux/bcm27xx/modules/hwmon.mk
+++ b/target/linux/bcm27xx/modules/hwmon.mk
@@ -32,5 +32,3 @@ define KernelPackage/hwmon-raspberrypi/description
 endef
 
 $(eval $(call KernelPackage,hwmon-raspberrypi))
-
-

--- a/target/linux/bcm27xx/modules/other.mk
+++ b/target/linux/bcm27xx/modules/other.mk
@@ -139,20 +139,3 @@ define KernelPackage/rp1-mailbox/description
 endef
 
 $(eval $(call KernelPackage,rp1-mailbox))
-
-
-define KernelPackage/rp1-pio
-  SUBMENU:=$(OTHER_MENU)
-  TITLE:=RP1 PIO driver
-  KCONFIG:=CONFIG_RP1_PIO
-  FILES:=$(LINUX_DIR)/drivers/misc/rp1-pio.ko
-  AUTOLOAD:=$(call AutoLoad,21,rp1-pio)
-  DEPENDS:=@TARGET_bcm27xx_bcm2712 +kmod-rp1
-endef
-
-define KernelPackage/rp1-pio/description
-  Driver for the RP1 PIO.
-endef
-
-$(eval $(call KernelPackage,rp1-pio))
-


### PR DESCRIPTION
Commit f105d1a9a9739267fb25612d039c392a397775bd added a duplicated kmod-rp1-pio package.
Also remove unneeded blank lines added by the same commit.

Fixes: f105d1a9a973 ("bcm27xx/bcm2712: Fix-up RP1 modules")