### PR TITLE
apm821xx: fixes WNDAP620 + WNDAP660 sysupgrade failures

### DIFF
--- a/target/linux/apm821xx/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/apm821xx/base-files/etc/uci-defaults/05_fix-compat-version
@@ -2,10 +2,13 @@
 
 case "$(board_name)" in
 meraki,mx60|\
-netgear,wndap620|\
-netgear,wndap660|\
 netgear,wndr4700)
 	uci set system.@system[0].compat_version="3.0"
+	uci commit system
+	;;
+netgear,wndap620|\
+netgear,wndap660)
+	uci set system.@system[0].compat_version="2.0"
 	uci commit system
 	;;
 esac


### PR DESCRIPTION
OpenWRT on the WNDAP6x0 refuses to sysupgrade to itself due to a compat_version imbalance. The Image is generated with version 2.0 set in the image/nand.mk, but the uci-defaults' 05_fix-compat-version sets on the first boot to 3.0. This causes the next sysupgrade to complain and bail out of the upgrade because it detects a "downgrade".

Fix this by downgrading WNDAP6x0 05_fix-compat-version's values back to 2.0 for both devices so the value matches what we currently already use.

People that have upgraded to a broken version, either use sysupgrade -F or edit compat_version through uci in the /etc/config/system back to 2.0 before updating:

 '# uci set system.@system[0].compat_version="2.0"'
 '# uci commit system'

Fixes: 5815884c3a2a ("apm821xx: migrate to DSA")
(needs backport to openwrt-24.10 too... but mainline first.)
