### PR TITLE
ramips: add support for Zyxel LTE7490-M904

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -138,6 +138,7 @@ zyxel,lte3301-plus)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x80000"
 	;;
 zyxel,lte5398-m904|\
+zyxel,lte7490-m904|\
 zyxel,nr7101)
 	idx="$(find_mtd_index Config)"
 	[ -n "$idx" ] && \

--- a/target/linux/ramips/dts/mt7621_zyxel_lte7490-m904.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte7490-m904.dts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "zyxel,lte7490-m904", "mediatek,mt7621-soc";
+	model = "Zyxel LTE7490-M904";
+
+	aliases {
+		led-boot = &led_red;
+		led-failsafe = &led_amber;
+		led-running = &led_green;
+		led-upgrade = &led_amber;
+		label-mac-device = &gmac0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_amber: led_amber {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_green: led_green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_red: led_red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wlan";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WLAN>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gpio {
+	lte_pwrkey {
+		gpio-hog;
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "lte-pwrkey";
+	};
+
+	lte_power {
+		gpio-hog;
+		gpios = <18 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "lte-power";
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x80000>;
+		};
+
+		factory: partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+			};
+		};
+
+		partition@140000 {
+			label = "Kernel";
+			reg = <0x140000 0x1ec0000>;
+		};
+
+		partition@540000 {
+			label = "ubi";
+			reg = <0x540000 0x1ac0000>;
+		};
+
+		partition@2140000 {
+			label = "Kernel2";
+			reg = <0x2140000 0x1ec0000>;
+		};
+
+		partition@4000000 {
+			label = "wwan";
+			reg = <0x4000000 0x100000>;
+		};
+
+		partition@4100000 {
+			label = "data";
+			reg = <0x4100000 0x1000000>;
+		};
+
+		partition@5100000 {
+			label = "rom-d";
+			reg = <0x5100000 0x100000>;
+			read-only;
+		};
+
+		partition@5200000 {
+			label = "reserve";
+			reg = <0x5200000 0x80000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@2 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3531,6 +3531,20 @@ define Device/zyxel_lte5398-m904
 endef
 TARGET_DEVICES += zyxel_lte5398-m904
 
+define Device/zyxel_lte7490-m904
+  $(Device/nand)
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := LTE7490-M904
+  KERNEL_SIZE := 31488k
+  DEVICE_PACKAGES := kmod-mt7603 kmod-usb3 kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+  KERNEL := $(KERNEL_DTB) | uImage lzma | \
+	zytrx-header $$(DEVICE_MODEL) $$(VERSION_DIST)-$$(REVISION)
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma | \
+	zytrx-header $$(DEVICE_MODEL) 9.99(ABQY.9)$$(VERSION_DIST)-recovery
+  KERNEL_INITRAMFS_SUFFIX := -recovery.bin
+endef
+TARGET_DEVICES += zyxel_lte7490-m904
+
 define Device/zyxel_nr7101
   $(Device/nand)
   DEVICE_VENDOR := Zyxel

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -81,6 +81,7 @@ ramips_setup_interfaces()
 	wavlink,ws-wn572hp3-4g|\
 	winstars,ws-wn583a6|\
 	yuncore,ax820|\
+        zyxel,lte7490-m904|\
 	zyxel,nr7101)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -34,6 +34,7 @@ zyxel,lte5398-m904)
 	ucidef_add_gpio_switch "usb_power" "Power USB Port" "usb_power" "1"
 	ucidef_add_gpio_switch "lte_power" "Power LTE modem" "lte_power" "1"
 	;;
+zyxel,lte7490-m904|\
 zyxel,nr7101)
 	ucidef_add_gpio_switch "lte_reset" "Reset LTE/5G modem" "515"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -43,6 +43,7 @@ boot() {
 		[ $(printf %d $(fw_printenv -n Image1Try)) -gt 0 ] && fw_setenv Image1Try 0
 		;;
 	zyxel,lte5398-m904|\
+	zyxel,lte7490-m904|\
 	zyxel,nr7101)
 		[ $(printf %d $(fw_printenv -n DebugFlag)) -gt 0 ] || fw_setenv DebugFlag 0x1
 		[ $(printf %d $(fw_printenv -n Image1Stable)) -gt 0 ] || fw_setenv Image1Stable 1

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -196,6 +196,7 @@ platform_do_upgrade() {
 		;;
 	zyxel,lte3301-plus|\
 	zyxel,lte5398-m904|\
+	zyxel,lte7490-m904|\
 	zyxel,nr7101)
 		fw_setenv CheckBypass 0
 		fw_setenv Image1Stable 0


### PR DESCRIPTION
The Zyxel LTE7490-M904 is an 802.3at PoE powered LTE outdoor (IP68) CPE with integrated directional antennas.

### Specifications
 - SoC: MediaTek MT7621AT
 - RAM: 256 MB
 - Flash: 128 MB MB NAND (MX30LF1G18AC)
 - WiFi: MediaTek MT7603E 802.11b/g/n
 - Switch: 1 LAN port (1 Gbps)
 - LTE/3G/2G: Quectel EG18-EA LTE-A Cat. 18 connected by USB3 to SoC
 - SIM: 1 micro-SIM slots under transparent cover
 - Buttons: Reset, WLAN under same cover
 - LEDs: Multicolour green/red/amber under same cover (visible)
 - Power: 802.3at PoE via LAN port

The device is built as an outdoor ethernet to LTE bridge or router. The Wifi interface is intended for installation and/or temporary management purposes only.

### UART Serial
57600N1, located on populated 5 pin header J5:
```
[o] GND
[ ] key - no pin
[o] RX
[o] TX
[o] 3.3V Vcc
```

Remove the SIM/button/LED cover and 12 screws holding the back plate and antenna cover together. Be careful with the cables.

### Installation from OEM web GUI
- Log in as "admin" on OEM web GUI
- Upload OpenWrt initramfs-recovery.bin image on the Maintenance -> Firmware page
- Wait for OpenWrt to boot and ssh to root@192.168.1.1
- Sysupgrade to the OpenWrt sysupgrade image and reboot

For more details about flashing see:
https://github.com/openwrt/openwrt/commit/2449a632084b29632605e5a79ce5d73028eb15dd (ramips: mt7621: Add support for ZyXEL NR7101, 2021-04-19)

Main porting work done by @ErnyTech:
https://github.com/openwrt/openwrt/commit/bf1c12f68b2678647a8e7437cb59907e4677122e (ramips: add support for ZyXEL LTE7490-M904, 2023-12-20)