### PR TITLE
ath79: remove dr_mode and vbus-supply

### DIFF
--- a/target/linux/ath79/dts/ar9344_nec_aterm.dtsi
+++ b/target/linux/ath79/dts/ar9344_nec_aterm.dtsi
@@ -281,8 +281,6 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	dr_mode = "host";
-
 	/delete-node/ port@1;
 
 	/* NEC uPD720114 */

--- a/target/linux/ath79/dts/ar9344_qihoo_c301.dts
+++ b/target/linux/ath79/dts/ar9344_qihoo_c301.dts
@@ -59,8 +59,9 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		enable-active-high;
+		regulator-always-on;
 		gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
 	};
 };
 
@@ -208,7 +209,6 @@
 
 &usb_phy {
 	status = "okay";
-	phy-supply = <&usb_vbus>;
 };
 
 &pcie {

--- a/target/linux/ath79/dts/qca9531_8dev_carambola3.dts
+++ b/target/linux/ath79/dts/qca9531_8dev_carambola3.dts
@@ -35,8 +35,6 @@
 
 &usb0 {
 	status = "okay";
-
-	dr_mode = "host";
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca9531_8dev_lima.dts
+++ b/target/linux/ath79/dts/qca9531_8dev_lima.dts
@@ -26,8 +26,6 @@
 
 &usb0 {
 	status = "okay";
-
-	dr_mode = "host";
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
+++ b/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
@@ -74,8 +74,6 @@
 
 &usb0 {
 	status = "okay";
-
-	dr_mode = "host";
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca9531_tplink_tl-wr810n-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-wr810n-v1.dts
@@ -19,8 +19,6 @@
 
 &usb0 {
 	status = "okay";
-
-	vbus-supply = <&reg_usb_vbus>;
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca953x.dtsi
+++ b/target/linux/ath79/dts/qca953x.dtsi
@@ -193,7 +193,6 @@
 
 			interrupts = <3>;
 			resets = <&rst 5>;
-			dr_mode = "host";
 
 			has-transaction-translator;
 			caps-offset = <0x100>;

--- a/target/linux/ath79/dts/qca9558_aruba_ap-115.dts
+++ b/target/linux/ath79/dts/qca9558_aruba_ap-115.dts
@@ -243,6 +243,5 @@
 };
 
 &usb0 {
-	dr_mode = "host";
 	status = "okay";
 };

--- a/target/linux/ath79/dts/qca9558_nec_aterm.dtsi
+++ b/target/linux/ath79/dts/qca9558_nec_aterm.dtsi
@@ -352,8 +352,6 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 
-	dr_mode = "host";
-
 	/delete-node/ port@1;
 
 	/* NEC uPD720114 */

--- a/target/linux/ath79/dts/qca9558_sophos_ap.dtsi
+++ b/target/linux/ath79/dts/qca9558_sophos_ap.dtsi
@@ -191,7 +191,3 @@
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
 };
-
-&usb0 {
-	vbus-supply = <&reg_usb_vbus>;
-};

--- a/target/linux/ath79/dts/qca9558_sophos_ap100.dts
+++ b/target/linux/ath79/dts/qca9558_sophos_ap100.dts
@@ -17,5 +17,4 @@
 
 &usb0 {
 	status = "okay";
-	dr_mode = "host";
 };

--- a/target/linux/ath79/dts/qca9558_sophos_ap55.dts
+++ b/target/linux/ath79/dts/qca9558_sophos_ap55.dts
@@ -17,5 +17,4 @@
 
 &usb0 {
 	status = "okay";
-	dr_mode = "host";
 };

--- a/target/linux/ath79/dts/qca9558_tplink_archer-d7.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-d7.dtsi
@@ -145,8 +145,6 @@
 };
 
 &usb0 {
-	dr_mode = "host";
-	vbus-supply = <&reg_usb0_vbus>;
 	status = "okay";
 };
 
@@ -155,7 +153,5 @@
 };
 
 &usb1 {
-	dr_mode = "host";
-	vbus-supply = <&reg_usb1_vbus>;
 	status = "okay";
 };

--- a/target/linux/ath79/dts/qca955x_elecom_wab.dtsi
+++ b/target/linux/ath79/dts/qca955x_elecom_wab.dtsi
@@ -34,7 +34,7 @@
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_USB;
-			trigger-sources = <&usb_port1>;
+			trigger-sources = <&hub_port0>;
 			linux,default-trigger = "usbport";
 		};
 	};
@@ -232,17 +232,7 @@
 };
 
 &usb0 {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	status = "okay";
-
-	dr_mode = "host";
-	vbus-supply = <&reg_usb_vbus>;
-
-	usb_port1: port@1 {
-		reg = <1>;
-		#trigger-source-cells = <0>;
-	};
 };
 
 &wdt {


### PR DESCRIPTION
ath79 uses the generic-ehci driver, which does not support regulators using vbus-supply.

dr_mode is also not useful as the driver does not support multiple modes.

ping @DragonBluep 
