### PR TITLE
ipq40xx: dts: add ethernet0 alias for most devices

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-a42.dts
@@ -52,6 +52,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_status_green;
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap120c-ac.dts
@@ -15,6 +15,8 @@
 		led-failsafe = &status;
 		led-running = &status;
 		led-upgrade = &status;
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		ethernet1 = &swport5;
 	};
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cap-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cap-ac.dts
@@ -21,6 +21,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_user;
 		led-failsafe = &led_user;
 		led-running = &led_user;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cs-w3-wd1200g-eup.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cs-w3-wd1200g-eup.dts
@@ -11,6 +11,8 @@
 	compatible = "ezviz,cs-w3-wd1200g-eup";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_status_green;
 		led-failsafe = &led_status_red;
 		led-running = &led_status_blue;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-dap-2610.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-dap-2610.dts
@@ -11,6 +11,8 @@
 	compatible = "dlink,dap-2610";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_red;
 		led-failsafe = &led_red;
 		led-running = &led_green;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ea6350v3.dts
@@ -11,6 +11,8 @@
 	compatible = "linksys,ea6350v3";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &power;
 		led-failsafe = &power;
 		led-running = &power;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-eap1300.dts
@@ -41,6 +41,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &power;
 		led-failsafe = &power;
 		led-running = &power;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
@@ -46,6 +46,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &power_amber;
 		led-failsafe = &power_amber;
 		led-running = &power_green;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-fritzbox-4040.dts
@@ -11,6 +11,7 @@
 	compatible = "avm,fritzbox-4040";
 
 	aliases {
+		ethernet0 = &gmac;
 		led-boot = &power;
 		led-failsafe = &flash;
 		led-running = &power;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-a1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-a1300.dts
@@ -11,6 +11,8 @@
 	compatible = "glinet,gl-a1300", "qcom,ipq4019";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_run;
 		led-failsafe = &led_run;
 		led-running = &led_run;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-gl-ap1300.dts
@@ -11,6 +11,8 @@
 	compatible = "glinet,gl-ap1300";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
@@ -21,6 +21,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_user;
 		led-failsafe = &led_user;
 		led-running = &led_user;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-jalapeno.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-jalapeno.dtsi
@@ -8,6 +8,8 @@
 
 / {
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		ethernet1 = &swport5;
 	};
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
@@ -9,6 +9,11 @@
 	model = "devolo Magic 2 WiFi next";
 	compatible = "devolo,magic-2-wifi-next";
 
+	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
+	};
+
 	memory {
 		device_type = "memory";
 		reg = <0x80000000 0x10000000>;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287_common.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287_common.dtsi
@@ -11,6 +11,8 @@
 
 / {
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_status;
 		led-failsafe = &led_status;
 		led-running = &led_status;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-pa1200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-pa1200.dts
@@ -52,6 +52,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_status_purple;
 		led-failsafe = &led_status_yellow;
 		led-running = &led_status_cyan;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
@@ -16,6 +16,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx50.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx50.dts
@@ -7,6 +7,8 @@
 	compatible = "teltonika,rutx50";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_rssi0;
 		led-failsafe = &led_rssi0;
 		led-running = &led_rssi0;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
@@ -21,6 +21,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_user;
 		led-failsafe = &led_user;
 		led-running = &led_user;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wac510.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wac510.dts
@@ -16,6 +16,8 @@
 		led-failsafe = &led_power_amber;
 		led-running = &led_power_green;
 		led-upgrade = &led_power_amber;
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		ethernet1 = &swport5;
 	};
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wap-ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wap-ac.dtsi
@@ -18,6 +18,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_user;
 		led-failsafe = &led_user;
 		led-running = &led_user;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-whw01.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-whw01.dts
@@ -10,6 +10,8 @@
 	compatible = "linksys,whw01";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		serial0 = &blsp1_uart1;
 		led-boot = &led_system_blue;
 		led-running = &led_system_blue;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wr-1.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wr-1.dts
@@ -11,6 +11,8 @@
 	compatible = "pakedge,wr-1";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		label-mac-device = &gmac;
 		led-boot = &led_power;
 		led-failsafe = &led_power;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wrtq-329acn.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wrtq-329acn.dts
@@ -9,6 +9,11 @@
 	model = "Luma Home WRTQ-329ACN";
 	compatible = "luma,wrtq-329acn";
 
+	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
+	};
+
 	i2c-gpio {
 		compatible = "i2c-gpio";
 		sda-gpios = <&tlmm 1 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
@@ -52,6 +52,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_status_green;
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-cm520-79f.dts
@@ -11,6 +11,8 @@
 	compatible = "mobipromo,cm520-79f";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_sys;
 		led-failsafe = &led_sys;
 		led-running = &led_sys;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac-c1.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac-c1.dts
@@ -11,6 +11,11 @@
 / {
 	model = "Qxwlan E2600AC c1";
 	compatible = "qxwlan,e2600ac-c1";
+
+	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
+	};
 };
 
 &blsp1_spi1 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac-c2.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-e2600ac-c2.dts
@@ -11,6 +11,11 @@
 / {
 	model = "Qxwlan E2600AC c2";
 	compatible = "qxwlan,e2600ac-c2";
+
+	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
+	};
 };
 
 &blsp1_spi1 {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
@@ -15,6 +15,7 @@
 	};
 
 	aliases {
+		ethernet0 = &gmac;
 		led-boot = &power_green;
 		led-failsafe = &info_red;
 		led-running = &power_green;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-1200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-1200.dts
@@ -11,6 +11,8 @@
 	compatible = "avm,fritzrepeater-1200";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &power_green;
 		led-failsafe = &power_red;
 		led-running = &power_green;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
@@ -11,6 +11,8 @@
 	compatible = "avm,fritzrepeater-3000";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &power_led;
 		led-failsafe = &power_led;
 		led-running = &power_led;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
@@ -20,6 +20,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		ethernet1 = &swport4;
 	};
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
@@ -12,6 +12,8 @@
 	compatible = "8dev,habanero-dvk";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_status;
 		led-failsafe = &led_status;
 		led-running = &led_status;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3-lte6-kit.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3-lte6-kit.dts
@@ -21,6 +21,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_status_blue;
 		led-failsafe = &led_status_red;
 		led-running = &led_status_blue;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3.dts
@@ -21,6 +21,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_status_blue;
 		led-failsafe = &led_status_red;
 		led-running = &led_status_blue;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
@@ -15,6 +15,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_backlight_white;
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
@@ -35,6 +35,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &user;
 		led-failsafe = &user;
 		led-running = &user;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -14,6 +14,8 @@
 	compatible = "zte,mf18a";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
@@ -13,6 +13,8 @@
 	compatible = "zte,mf282plus";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_internal;
 		led-failsafe = &led_internal;
 		led-running = &led_internal;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
@@ -12,6 +12,8 @@
 	compatible = "zte,mf286d";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_internal;
 		led-failsafe = &led_internal;
 		led-running = &led_internal;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
@@ -13,6 +13,8 @@
 	compatible = "zte,mf289f";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_status;
 		led-failsafe = &led_status;
 		led-running = &led_status;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-ncp-hg100-cellular.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-ncp-hg100-cellular.dts
@@ -12,6 +12,8 @@
 	compatible = "sony,ncp-hg100-cellular";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_cloud_green;
 		led-failsafe = &led_cloud_red;
 		led-running = &led_cloud_green;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
@@ -44,6 +44,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_power_orange;
 		led-failsafe = &led_status_blue;
 		led-running = &led_power_orange;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
@@ -12,6 +12,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_sys;
 		led-failsafe = &led_sys;
 		led-running = &led_sys;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
@@ -14,6 +14,8 @@
 	compatible = "cellc,rtl30vw";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_power_blue;
 		led-failsafe = &led_power_red;
 		led-running = &led_power_blue;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wia3300-20.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wia3300-20.dts
@@ -11,6 +11,8 @@
 	model = "SKSpruce WIA3300-20";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		label-mac-device = &gmac;
 		led-boot = &led_status_red;
 		led-failsafe = &led_status_lime;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wifi.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wifi.dts
@@ -14,6 +14,8 @@
 	compatible = "google,wifi", "google,gale-v2", "qcom,ipq4019";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		label-mac-device = &gmac0;
 		led-boot = &led0_blue;
 		led-failsafe = &led0_red;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
@@ -29,6 +29,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_power_blue;
 		led-failsafe = &led_power_orange;
 		led-running = &led_power_white;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
@@ -26,6 +26,11 @@
 	};
 
 
+	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
+	};
+
 	soc {
 		tcsr@1949000 {
 			compatible = "qcom,tcsr";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4028-wpj428.dts
@@ -73,6 +73,8 @@
 	};
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &status;
 		led-failsafe = &status;
 		led-upgrade = &status;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-ap-303h.dts
@@ -10,6 +10,8 @@
 	compatible = "aruba,ap-303h";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &led_system_green;
 		led-failsafe = &led_system_red;
 		led-running = &led_system_green;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-aruba-glenmorangie.dtsi
@@ -6,6 +6,11 @@
 #include <dt-bindings/soc/qcom,tcsr.h>
 
 / {
+	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
+	};
+
 	memory {
 		device_type = "memory";
 		reg = <0x80000000 0x10000000>;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-gl-b1300.dts
@@ -25,6 +25,8 @@
 	compatible = "glinet,gl-b1300";
 
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &power;
 		led-failsafe = &power;
 		led-running = &power;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -20,6 +20,8 @@
 
 / {
 	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
 		led-boot = &status_green;
 		led-failsafe = &status_red;
 		led-running = &status_green;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq40x9-dr40x9.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq40x9-dr40x9.dts
@@ -9,6 +9,11 @@
 	model = "Wallystech DR40X9";
 	compatible = "wallys,dr40x9";
 
+	aliases {
+		// TODO: Verify if the ethernet0 alias is needed
+		ethernet0 = &gmac;
+	};
+
 	chosen {
 		bootargs-append = " ubi.mtd=ubi root=/dev/ubiblock0_1";
 	};


### PR DESCRIPTION
I don't want to spam this topic, but I would like to get this fixed and backported :)

This excludes the devices listed in `05_set_iface_mac_ipq40xx.sh` as their mac address is not relying on the ethernet0 for sure.

Supersedes #17432
Supersedes #17442

Backport to 24.10 would be very cool.
I hope this is fine @neocturne @robimarko - otherwise just close this as one of the other PRs get merged :)