### PR TITLE
ath79: support Teltonika RUT240

### DIFF
--- a/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
+++ b/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
@@ -83,6 +83,11 @@
 			gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
 		};
 
+		4g {
+			label = "green:4g";
+			gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+		};
+
 		lan {
 			function = LED_FUNCTION_LAN;
 			color = <LED_COLOR_ID_GREEN>;
@@ -96,8 +101,6 @@
 			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
 			/* GPIO 14 - ACTIVE HIGH for hwrev 0 */
 		};
-
-		/* 4G LED - GPIO21 ACTIVE_HIGH for RUT240 */
 	};
 
 	reg_usb_vbus: reg_usb_vbus {

--- a/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
+++ b/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
@@ -68,7 +68,7 @@
 		};
 
 		signal-strength-4 {
-			label = "green:signal-strength4";
+			label = "green:signal-strength-4";
 			gpios = <&gpio 27 GPIO_ACTIVE_HIGH>;
 		};
 

--- a/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
+++ b/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
@@ -191,15 +191,6 @@
 	status = "okay";
 };
 
-&gpio {
-	modem-power {
-		gpio-hog;
-		output-low;
-		gpios = <18 GPIO_ACTIVE_HIGH>;
-		line-name = "modem-power";
-	};
-};
-
 &usb_phy {
 	status = "okay";
 };

--- a/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
+++ b/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
@@ -102,15 +102,6 @@
 			/* GPIO 14 - ACTIVE HIGH for hwrev 0 */
 		};
 	};
-
-	reg_usb_vbus: reg_usb_vbus {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
 };
 
 &eth0 {
@@ -197,7 +188,6 @@
 
 &usb {
 	dr_mode = "host";
-	vbus-supply = <&reg_usb_vbus>;
 	status = "okay";
 };
 

--- a/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
+++ b/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
@@ -36,6 +36,7 @@
 
 		sim-tray {
 			label = "sim-tray";
+			linux,input-type = <EV_SW>;
 			linux,code = <BTN_1>;
 			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;

--- a/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/generic/base-files/etc/board.d/03_gpio_switches
@@ -48,6 +48,11 @@ dlink,dir-835-a1)
 librerouter,librerouter-v1)
 	ucidef_add_gpio_switch "poe_passthrough" "PoE Passthrough" "513" "0"
 	;;
+teltonika,rut230-v1)
+	ucidef_add_gpio_switch "DOUT" "DOUT" "524" "0"
+	ucidef_add_gpio_switch "modem_pwr" "Modem power" "531" "1"
+	ucidef_add_gpio_switch "modem_rst" "Modem reset" "530" "0"
+	;;
 teltonika,rut955)
 	ucidef_add_gpio_switch "sim_sel" "SIM select" "542" "1"
 	ucidef_add_gpio_switch "DOUT1" "DOUT1 (OC)" "543" "0"

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -3064,7 +3064,7 @@ define Device/teltonika_rut230-v1
   DEVICE_MODEL := RUT230
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-chipidea2 kmod-usb-acm \
-	kmod-usb-net-qmi-wwan uqmi -uboot-envtools
+	kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi -uboot-envtools
   IMAGE_SIZE := 15552k
   TPLINK_HWID := 0x32200002
   TPLINK_HWREV := 0x1

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -3063,8 +3063,8 @@ define Device/teltonika_rut230-v1
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT230
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-acm kmod-usb-net-qmi-wwan \
-	uqmi -uboot-envtools
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-chipidea2 kmod-usb-acm \
+	kmod-usb-net-qmi-wwan uqmi -uboot-envtools
   IMAGE_SIZE := 15552k
   TPLINK_HWID := 0x32200002
   TPLINK_HWREV := 0x1

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -3063,6 +3063,9 @@ define Device/teltonika_rut230-v1
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT230
   DEVICE_VARIANT := v1
+  DEVICE_ALT0_VENDOR := Teltonika
+  DEVICE_ALT0_MODEL := RUT240
+  DEVICE_ALT0_VARIANT := v1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-chipidea2 kmod-usb-acm \
 	kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi -uboot-envtools
   IMAGE_SIZE := 15552k


### PR DESCRIPTION
This device is basically the same hardware, as RUT230, except for modems supporting LTE.
This PR includes necessary changes to support that (e.g. additional LED, kmods needed for LTE modems) and bugfixes affecting both devices, and finally adding a device alias - as both RUT230 and RUT240 are supported by same image.