### PR TITLE
uboot-envtools: ipq60xx: remove number of blocks

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq60xx
@@ -18,12 +18,12 @@ cambiumnetworks,xe3-4)
 linksys,mr7350)
 	idx="$(find_mtd_index u_env)"
 	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000"
 	;;
 netgear,wax214)
 	idx="$(find_mtd_index 0:appsblenv)"
 	[ -n "$idx" ] && \
-		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000" "2"
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000"
 	;;
 yuncore,fap650)
 	idx="$(find_mtd_index 0:appsblenv)"


### PR DESCRIPTION
It is not required to specify the number of blocks as envtools are able to autodetect it.
