### PR TITLE
Fix/network start

### DIFF
--- a/package/network/config/netifd/files/etc/init.d/network
+++ b/package/network/config/netifd/files/etc/init.d/network
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-START=20
+START=15
 STOP=90
 
 USE_PROCD=1


### PR DESCRIPTION
See comment. Probably, not bad idea to slow id for both odhcp and dnsmasq to, say, 17 so consumers might work against already connected clients (if any)  

