### PR TITLE
Prevent aligning for DIR-620 to any other size than 64k. It is

### DIFF
--- a/target/linux/ramips/image/rt305x.mk
+++ b/target/linux/ramips/image/rt305x.mk
@@ -457,6 +457,7 @@ endef
 TARGET_DEVICES += dlink_dir-615-h1
 
 define Device/dlink_dir-620-a1
+  BLOCKSIZE := 64k
   SOC := rt3050
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := D-Link


### PR DESCRIPTION
erase size for such device. Not sure about others rt305x's, so applied only for one

Leads to shrunk size of overall sysupgrade image
(about 128kbs in average, depends on lart block number to align) and therefore saves precisious RAM.


=============
to merge to 23th tag as well
