### PR TITLE
ramips: mt76x8: add support for Keenetic Extra (KN-1711)

### DIFF
--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1711.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1711.dts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "keenetic,kn-1711", "mediatek,mt7628an-soc";
+	model = "Keenetic KN-1711";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "USB-power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2 {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi5 {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+
+	keys {
+		compatible = "gpio-keys";
+
+		fn {
+			label = "fn";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		reset {
+			label = "restart";
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0 0x1CC0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "i2c", "gpio", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <104000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "rf-eeprom";
+				reg = <0x40000 0x10000>;
+				read-only;
+				
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_400: eeprom@400 {
+						reg = <0x400 0x4da8>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+				};
+			};
+
+			firmware1: partition@50000 {
+				label = "firmware_1";
+				reg = <0x50000 0xe60000>;
+			};
+
+			partition@eb0000 {
+				label = "config_1";
+				reg = <0xeb0000 0x40000>;
+				read-only;
+			};
+
+			partition@ef0000 {
+				label = "storage";
+				reg = <0xef0000 0x100000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "dump";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+
+			partition@1000000 {
+				label = "u-state";
+				reg = <0x1000000 0x30000>;
+				read-only;
+			};
+
+			partition@1030000 {
+				label = "u-config_res";
+				reg = <0x1030000 0x10000>;
+				read-only;
+			};
+			
+			partition@1040000 {
+				label = "rf-eeprom_res";
+				reg = <0x1040000 0x10000>;
+				read-only;
+			};
+
+			firmware2: partition@1050000 {
+				label = "firmware_2";
+				reg = <0x1050000 0xe60000>;
+			};
+			
+			partition@1EB0000 {
+				label = "Config_2";
+				reg = <0x1eb0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_400>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -366,6 +366,18 @@ define Device/keenetic_kn-1613
 endef
 TARGET_DEVICES += keenetic_kn-1613
 
+define Device/keenetic_kn-1711
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 13434880
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-1711
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap kmod-usb2
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to $$$$(BLOCKSIZE) | \
+	check-size | zyimage -d 0x801711 -v "KN-1711"
+endef
+TARGET_DEVICES += keenetic_kn-1711
+
 define Device/keenetic_kn-1713
   BLOCKSIZE := 64k
   IMAGE_SIZE := 13434880

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -59,8 +59,9 @@ hiwifi,hc5761a)
 	ucidef_set_led_switch "internet" "internet" "blue:internet" "switch0" "0x10"
 	;;
 keenetic,kn-1613|\
+keenetic,kn-1711|\
 keenetic,kn-1713)
-	ucidef_set_led_switch "internet" "internet" "green:internet" "switch0" "0x01"
+	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x01"
 	;;
 mediatek,linkit-smart-7688)
 	ucidef_set_led_wlan "wifi" "wifi" "orange:wifi" "phy0tpt"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -45,6 +45,7 @@ ramips_setup_interfaces()
 	hilink,hlk-7628n|\
 	hilink,hlk-7688a|\
 	hiwifi,hc5861b|\
+	keenetic,kn-1711|\
 	kroks,kndrt31r16|\
 	skylab,skw92a|\
 	tplink,archer-c20-v4|\


### PR DESCRIPTION
Specification:
SoC: MediaTek MT7628AN
RAM: 128 MB, ESMT M14D1G1664A (DDR2)
Flash: 32MB, Winbond 25Q256JVFQ (Dual Boot, SPI)
Switch: MediaTek MT7628AN, 5 ports 100 Mbps
WiFi: MediaTek MT7603 2T2R/2.4GHz 802.11n and MediaTek MT7613AEN 2T2R/5GHz 802.11ac USB: 1 port USB 2.0
GPIO: 3 buttons (Wi-Fi, Reset, FN), 4 LEDs (Power, Internet, FN, Wi-Fi), USB port power controls

Disassembly:
At the bottom there are 4 screws hidden by rubber feet. After removing the screws, pry the gray plastic part around (it is secured with latches) and remove it.

Serial Interface:
The serial interface can be connected to the 4 pin dots to the left of the flash. Pins (from LEDs to LAN ports):
3.3V (do not connect)
TX
RX
GND
Settings: 115200, 8N1

Flashing via OEM recovery software:
1. Download the OEM recovery software from the manufacturer's website
2. Download the firmware image (for OpenWRT it is *-squashfs-factory.bin), rename it to KN-1711_recovery.bin
3. Replace the file in the fw folder OEM recovery software with the file from step 2.
4. Run the OEM recovery software and follow the instructions.

Flashing via TFTP:
1. Connect your PC and router to port 1-4, configure PC interface using IP 192.168.1.2, mask 255.255.255.252
2. Serve the firmware image (for OpenWRT it is *-squashfs-factory.bin) renamed to KN-1711_recovery.bin via TFTP
3. Power up the router while pressing Reset button on the back
4. Release Restart button when Power LED starts blinking

To revert back to OEM firmware:
The return to the OEM firmware is carried out by using the methods described above with the help of the appropriate firmware image.

When using OEM bootloader, the firmware image size cannot exceed the size of one OEM «Firmware_x» partition or Kernel + rootFS size.

Signed-off-by: Anton Yu. Ivanusev <ivanusevanton@yandex.ru>