### PR TITLE
ipq40xx: fix label MAC address for Linksys WHW03 v2

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03.dtsi
@@ -8,12 +8,12 @@
 
 / {
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
 		ethernet0 = &gmac;
 		led-boot = &led_blue;
 		led-failsafe = &led_red;
 		led-running = &led_blue;
 		led-upgrade = &led_red;
+		label-mac-device = &gmac;
 	};
 
 	soc {


### PR DESCRIPTION
The label MAC address is written inside the case of the whw03 v2 at the bottom.

Similar fix as to the 4040 in b22d382ae4eaa1af42930115d91855f402314cac

The ethernet0 alias is required for this device as otherwise the dmesg shows `using random MAC address`.

@robimarko 

