### PR TITLE
generic: add leds_st1202 patch to fix NULL pointer access

### DIFF
--- a/target/linux/generic/pending-6.6/893-leds_st1202-Fix-NULL-pointer-access-error.patch
+++ b/target/linux/generic/pending-6.6/893-leds_st1202-Fix-NULL-pointer-access-error.patch
@@ -1,0 +1,70 @@
+From e3da313ebcace17f1227566fe1b0d0c3883061f9 Mon Sep 17 00:00:00 2001
+From: Manuel Fombuena <fombuena@outlook.com>
+Date: Fri, 17 Jan 2025 12:31:49 +0000
+Subject: [PATCH 1/5] leds: leds-st1202: fix NULL pointer access on race
+ condition
+
+st1202_dt_init() calls devm_led_classdev_register_ext() before the
+internal data structures are properly setup, so the leds become visible
+to user space while being partially initialized, leading to a window
+where trying to access them causes a NULL pointer access.
+
+This change moves devm_led_classdev_register_ext() to the last thing to
+happen during initialization to eliminate it.
+
+Signed-off-by: Manuel Fombuena <fombuena@outlook.com>
+---
+ drivers/leds/leds-st1202.c | 21 ++++++++++-----------
+ 1 file changed, 10 insertions(+), 11 deletions(-)
+
+--- a/drivers/leds/leds-st1202.c
++++ b/drivers/leds/leds-st1202.c
+@@ -261,8 +261,6 @@ static int st1202_dt_init(struct st1202_
+ 	int err, reg;
+ 
+ 	for_each_available_child_of_node_scoped(dev_of_node(dev), child) {
+-		struct led_init_data init_data = {};
+-
+ 		err = of_property_read_u32(child, "reg", &reg);
+ 		if (err)
+ 			return dev_err_probe(dev, err, "Invalid register\n");
+@@ -276,15 +274,6 @@ static int st1202_dt_init(struct st1202_
+ 		led->led_cdev.pattern_set = st1202_led_pattern_set;
+ 		led->led_cdev.pattern_clear = st1202_led_pattern_clear;
+ 		led->led_cdev.default_trigger = "pattern";
+-
+-		init_data.fwnode = led->fwnode;
+-		init_data.devicename = "st1202";
+-		init_data.default_label = ":";
+-
+-		err = devm_led_classdev_register_ext(dev, &led->led_cdev, &init_data);
+-		if (err < 0)
+-			return dev_err_probe(dev, err, "Failed to register LED class device\n");
+-
+ 		led->led_cdev.brightness_set = st1202_brightness_set;
+ 		led->led_cdev.brightness_get = st1202_brightness_get;
+ 	}
+@@ -368,6 +357,7 @@ static int st1202_probe(struct i2c_clien
+ 		return ret;
+ 
+ 	for (int i = 0; i < ST1202_MAX_LEDS; i++) {
++		struct led_init_data init_data = {};
+ 		led = &chip->leds[i];
+ 		led->chip = chip;
+ 		led->led_num = i;
+@@ -384,6 +374,15 @@ static int st1202_probe(struct i2c_clien
+ 		if (ret < 0)
+ 			return dev_err_probe(&client->dev, ret,
+ 					"Failed to clear LED pattern\n");
++
++		init_data.fwnode = led->fwnode;
++		init_data.devicename = "st1202";
++		init_data.default_label = ":";
++
++		ret = devm_led_classdev_register_ext(&client->dev, &led->led_cdev, &init_data);
++		if (ret < 0)
++			return dev_err_probe(&client->dev, ret,
++					"Failed to register LED class device\n");
+ 	}
+ 
+ 	return 0;


### PR DESCRIPTION
Merged on https://github.com/openwrt/openwrt/pull/17451, the module has to be loaded before launching preinit to avoid a kernel panic triggered by userspace accessing the controller before it is ready.

It was initially put under modules to minimise the time the LEDs are off, as the driver resets them all, but that surfaced the before-mentioned issue.

So lets use AutoLoad with the boot flag and a relatively low priority as most other LED driver modules.