### PR TITLE
mediatek: fix nmbm configuration mismatch (Xiaomi AX3000t)

### DIFF
--- a/target/linux/generic/files/drivers/mtd/nand/mtk_bmt.c
+++ b/target/linux/generic/files/drivers/mtd/nand/mtk_bmt.c
@@ -407,6 +407,7 @@ int mtk_bmt_attach(struct mtd_info *mtd)
 {
 	struct device_node *np;
 	int ret = 0;
+	u32 overridden_oobsize = 0;
 
 	if (bmtd.mtd)
 		return -ENOSPC;
@@ -430,6 +431,14 @@ int mtk_bmt_attach(struct mtd_info *mtd)
 
 	bmtd.mtd = mtd;
 	mtk_bmt_replace_ops(mtd);
+
+	if (!of_property_read_u32(np, "mediatek,bmt-mtd-overridden-oobsize",
+				  &overridden_oobsize))
+		if (overridden_oobsize < bmtd.mtd->oobsize) {
+			bmtd.mtd->oobsize = overridden_oobsize;
+			pr_info("NMBM: mtd OOB size has been overridden to %luB\n",
+				(long unsigned int)bmtd.mtd->oobsize);
+		}
 
 	bmtd.blk_size = mtd->erasesize;
 	bmtd.blk_shift = ffs(bmtd.blk_size) - 1;

--- a/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-ax3000t.dts
+++ b/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-ax3000t.dts
@@ -12,6 +12,7 @@
 	mediatek,nmbm;
 	mediatek,bmt-max-ratio = <1>;
 	mediatek,bmt-max-reserved-blocks = <64>;
+	mediatek,bmt-mtd-overridden-oobsize = <64>;
 };
 
 &partitions {


### PR DESCRIPTION
- kernel: nmbm: add mediatek,bmt-mtd-overridden-oobsize property
- mediatek: fix nmbm configuration mismatch (Xiaomi AX3000t)