### PR TITLE
ath79: add support for Ruckus R500

### DIFF
--- a/target/linux/ath79/dts/qca9557_ruckus_r500.dts
+++ b/target/linux/ath79/dts/qca9557_ruckus_r500.dts
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	compatible = "ruckus,r500", "qca,qca9557";
+	model = "Ruckus R500";
+
+	aliases {
+		led-boot = &power_green;
+		led-failsafe = &power_red;
+		led-running = &power_green;
+		led-upgrade = &power_red;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins &clks_disable_pins &enable_gpio_4>;
+
+		power_green: led-0 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		power_red: led-1 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+			panic-indicator;
+		};
+
+		// DIR (Zone Director) LED - Indicates Zone director connection status
+		led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "dir";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		// AIR (Signal/Air Quality) LED - Indicates uplink status and the quality of the wireless signal to the uplink AP
+		led-3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "air";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1assoc";
+		};
+
+		led-5 {
+			color = <LED_COLOR_ID_YELLOW>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-6 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0assoc";
+		};
+
+		led-7 {
+			color = <LED_COLOR_ID_YELLOW>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+	};
+
+	beamforming-2g-spi {
+		compatible = "spi-gpio";
+		mosi-gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		sck-gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		beamforming-2g-gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			registers-number = <1>;
+			spi-max-frequency = <24000000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	beamforming-5g-spi {
+		/*
+		 * ath10k driver doesn't expose GPIOs as of now,
+		 * so let's disable it for now. The shift register
+		 * for antenna pattern control is correctly initialized
+		 * for omnidirectional pattern correctly despite that,
+		 * there is just no possibility to control that from OpenWrt yet.
+		 */
+		status = "disabled";
+		compatible = "spi-gpio";
+		mosi-gpios = <&ath10k 15 GPIO_ACTIVE_HIGH>;
+		sck-gpios = <&ath10k 14 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		beamforming-5g-gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			registers-number = <1>;
+			spi-max-frequency = <24000000>;
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	i2c: i2c {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		scl-gpios = <&gpio 19 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio 20 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+
+		tpm@20 {
+			compatible = "infineon,slb9645tt", "tcg,tpm-tis-i2c";
+			reg = <0x20>;
+			crc-checksum;
+		};
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		ruckus-himem@fff0000 {
+			/* Ruckus Himem area used to control
+			 * redundant boot image selection
+			 */
+			compatible = "nvmem-rmem";
+			reg = <0xfff0000 0x10000>;
+			no-map;
+		};
+	};
+};
+
+&pinmux {
+	clks_disable_pins: pinmux_clks_disable_pins {
+		pinctrl-single,bits = <0x40 0x0 0x80>;
+	};
+
+	enable_gpio_4: pinctrl_enable_gpio_4 {
+		pinctrl-single,bits = <0x4 0x0 0xff>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0000000 0x100000>;
+				label = "u-boot";
+				read-only;
+			};
+
+			partition@100000 {
+				compatible = "u-boot,env";
+				reg = <0x0100000 0x40000>;
+				label = "u-boot-env";
+			};
+
+			board_data: partition@140000 {
+				reg = <0x0140000 0x80000>;
+				label = "board-data";
+				read-only;
+			};
+
+			partition@1c0000 {
+				reg = <0x01c0000 0x3e40000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+
+		qca,ar8327-initvals = <
+		    0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+		    0x0c 0x07600000 /* PORT6 PAD MODE CTRL */
+		    0x7c 0x0000007e /* PORT0_STATUS */
+		    0x94 0x0000007e /* PORT6 STATUS */
+		>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_board_data_66>;
+	nvmem-cell-names = "mac-address";
+	pll-data = <0x96000000 0x00000101 0x00001616>;
+
+	phy-handle = <&phy0>;
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_board_data_6c>;
+	nvmem-cell-names = "mac-address";
+	pll-data = <0x03000101 0x00000101 0x00001616>;
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	ath10k: wifi@0,0 {
+		compatible = "pci168c,003c";
+		reg = <0x0000 0 0 0 0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		nvmem-cells = <&macaddr_board_data_76>, <&cal_board_data_45000>;
+		nvmem-cell-names = "mac-address", "calibration";
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_board_data_60>, <&cal_board_data_41000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};
+
+&usb_phy0 {
+	status = "okay";
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy1 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+};
+
+&board_data {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_board_data_60: macaddr@60 {
+			reg = <0x60 0x6>;
+		};
+
+		macaddr_board_data_66: macaddr@66 {
+			reg = <0x66 0x6>;
+		};
+
+		macaddr_board_data_6c: macaddr@6c {
+			reg = <0x6c 0x6>;
+		};
+
+		macaddr_board_data_76: macaddr@76 {
+			reg = <0x76 0x6>;
+		};
+
+		cal_board_data_41000: cal@41000 {
+			reg = <0x41000 0x440>;
+		};
+
+		cal_board_data_45000: cal@45000 {
+			reg = <0x45000 0x844>;
+		};
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -505,6 +505,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0u@eth1" "4:lan:1" "3:lan:2" "2:lan:3" "1:lan:4"
 		;;
+	ruckus,r500)
+		ucidef_add_switch "switch0" \
+			"6u@eth0" "5:lan:1" "3:lan:2" "0@eth1"
+		;;
 	teltonika,rut955|\
 	teltonika,rut955-h7v3c0)
 		ucidef_set_interface_wan "eth1"
@@ -813,6 +817,7 @@ ath79_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 0x0)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
 		;;
+	ruckus,r500|\
 	ruckus,zf7025|\
 	ruckus,zf7321|\
 	ruckus,zf7341|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2941,6 +2941,17 @@ define Device/ruckus_zf7372
 endef
 TARGET_DEVICES += ruckus_zf7372
 
+define Device/ruckus_r500
+  $(Device/ruckus_common)
+  SOC := qca9557
+  DEVICE_MODEL := R500
+  IMAGE_SIZE := 63744k
+  BLOCKSIZE := 256k
+  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct \
+		     kmod-i2c-gpio kmod-tpm-i2c-infineon
+endef
+TARGET_DEVICES += ruckus_r500
+
 define Device/samsung_wam250
   SOC := ar9344
   DEVICE_VENDOR := Samsung


### PR DESCRIPTION
Ruckus R500 datasheet: https://webresources.ruckuswireless.com/datasheets/r500/ds-ruckus-r500.html

Specifications:

SoC: 720Mhz QCA9558
RAM: 256MB
Storage: 64MB of FLASH (SPI NOR - S25FL512S)
1x AR8327 GB switch
Ethernet: 1x1000M port #3 on AR8327,
          1x1000M (802.3at POE), port #5 on AR8327
Wireless: QCA988X HW2.0 802.11ac
AR9550 2.4GHz 802.11b/g/n
5x GPIO LED
1x GPIO Reset Button
1x DC Jack 12v
1x UART, 3.3v, 115200
1x TPM, SLB9645TT12
2x Beamforming antennas configured via 74LV164

MAC addresses:
 1. art 0x807E | Factory bridged | f0:3e:90:XX:XX:80 |
 2. art 0x66   | eth0            | f0:3e:90:XX:XX:83 | (port 5, cpu port 6) - PoE port
 3. art 0x6c   | eth1            | f0:3e:90:XX:XX:84 | (port 3, cpu port 0) - non PoE port

Serial console: 115200-8-N-1 on internal H4 header. Pinout:

```
H1
-----------
|1|x|3|4|5|
-----------
```

Pin 1 is near the "H4" marking.
1 - RX
x - no pin
3 - VCC (3.3V)
4 - GND
5 - TX

JTAG: Connector H2, similar to MIPS eJTAG, standard, unpoulated.

```
H9
----------------------
|2 |4 |6 |8 |10|12|14|
----------------------
|1 |3 |5 |7 |9 |11|13|
----------------------
```

3 - TDI
5 - TDO
7 - TMS
9 - TCK
2,4,6,8,10 - GND
14 - Vref
1,11,12,13 - Not connected

I²C: connector H2, near power LED, unpopulated:

```
------
|1|2|3
------
    H2
```

1 - SCL
2 - SDA
3 - GND

Installation:

Serial Port/TFTP

1. Setup tftp server on the local network
2. Connect to UART with TTL
3. Interupt U-boot process with Ctrl-C
4. Setup appropriate ipaddr and serverip in setenv:
  - setenv ipaddr 192.168.1.1
  - setenv serverip 192.168.1.2
5. On TFTP Server - copy openwrt-ath79-generic-ruckus_r500-initramfs-kernel.bin to /srv/tftp
6. On R500 boot into initrd image
  - tftpboot 0x81000000 openwrt-ath79-generic-ruckus_r500-initramfs-kernel.bin
  - bootm 0x81000000
7. On TFTP server - scp -O openwrt-ath79-generic-ruckus_r500-squashfs-sysupgrade.bin root@192.168.1.1:/tmp
8. Ensure the boot command is set before flashing the image: fw_setenv bootcmd 'bootm 0xbf1c0000'
9. On R500 - sysupgrade /tmp/openwrt-ath79-generic-ruckus_r500-squashfs-sysupgrade.bin
10. If not done in 8; set boot command from U-boot shell itself:
  - setenv bootcmd bootm 0xbf1c0000
  - saveenv
  - reset

This patch adapted from https://github.com/victhor393/openwrt-ruckus-r500/tree/ruckus-r500-master

- Heavily refactored the device tree
- Extended commit message
- Documented onboad connectors
- Refactored MAC and calibration data setups to use nvmem-layout
- Made both network interfaces LAN ports and bridge them, this makes more sense for an access point and is consistent with the rest of Ruckus APs.
- Enable lzma-loader for compressed initramfs
- Enabled the optional internal USB port
- Added missing LEDs and according pinctrl settings
- Added reserved memory region used for bootloader communication
- Added the bit-banged I²C bus and onboard TPM
- Refactored boot scheme and flash layout to match earlier Ruckus devices and maximize usable space for user data.

Quirks:
- H7 is the physical presence switch for the SLB9645TT12 TPM.

TODO:
- Link state reporting on the Ethernet ports doesn't work and both ports report "up" due to limitation of swconfig ar8327 driver. With DSA conversion, this shall be rectified.
- Locate 2nd shift register (U7) controlling beamforming antennas, probably on ath10k GPIOs which are currently unsupported in the driver. For this, there is a device tree node describing that - but explicitly disabled.
- At the moment of adding support, there is an endianness bug in the TPM driver causing it to not detect the TPM module because of ID mismatch.