### PR TITLE
rockchip: Add support for Radxa ROCK 4C+/4SE

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -136,6 +136,13 @@ define U-Boot/nanopi-r4s-rk3399
     friendlyarm_nanopi-r4s-enterprise
 endef
 
+define U-Boot/rock-4c-plus-rk3399
+  $(U-Boot/rk3399/Default)
+  NAME:=ROCK 4C+
+  BUILD_DEVICES:= \
+    radxa_rock-4c-plus
+endef
+
 define U-Boot/rock-pi-4-rk3399
   $(U-Boot/rk3399/Default)
   NAME:=ROCK Pi 4
@@ -302,6 +309,7 @@ endef
 UBOOT_TARGETS := \
   nanopc-t4-rk3399 \
   nanopi-r4s-rk3399 \
+  rock-4c-plus-rk3399 \
   rock-pi-4-rk3399 \
   rockpro64-rk3399 \
   rock-pi-s-rk3308 \

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -143,6 +143,13 @@ define U-Boot/rock-4c-plus-rk3399
     radxa_rock-4c-plus
 endef
 
+define U-Boot/rock-4se-rk3399
+  $(U-Boot/rk3399/Default)
+  NAME:=ROCK 4SE
+  BUILD_DEVICES:= \
+    radxa_rock-4se
+endef
+
 define U-Boot/rock-pi-4-rk3399
   $(U-Boot/rk3399/Default)
   NAME:=ROCK Pi 4
@@ -310,6 +317,7 @@ UBOOT_TARGETS := \
   nanopc-t4-rk3399 \
   nanopi-r4s-rk3399 \
   rock-4c-plus-rk3399 \
+  rock-4se-rk3399 \
   rock-pi-4-rk3399 \
   rockpro64-rk3399 \
   rock-pi-s-rk3308 \

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -190,6 +190,13 @@ define Device/radxa_rock-4c-plus
 endef
 TARGET_DEVICES += radxa_rock-4c-plus
 
+define Device/radxa_rock-4se
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := ROCK 4SE
+  SOC := rk3399
+endef
+TARGET_DEVICES += radxa_rock-4se
+
 define Device/radxa_rock-5a
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK 5A

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -183,6 +183,13 @@ define Device/radxa_rock-3c
 endef
 TARGET_DEVICES += radxa_rock-3c
 
+define Device/radxa_rock-4c-plus
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := ROCK 4C+
+  SOC := rk3399
+endef
+TARGET_DEVICES += radxa_rock-4c-plus
+
 define Device/radxa_rock-5a
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK 5A

--- a/target/linux/rockchip/patches-6.6/129-rock-4c-plus-add-led-aliases-and-stop-heartbeat.patch
+++ b/target/linux/rockchip/patches-6.6/129-rock-4c-plus-add-led-aliases-and-stop-heartbeat.patch
@@ -1,0 +1,27 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-4c-plus.dts
+@@ -17,6 +17,10 @@
+ 	aliases {
+ 		mmc0 = &sdhci;
+ 		mmc1 = &sdmmc;
++		led-boot = &led_blue;
++		led-failsafe = &led_blue;
++		led-running = &led_blue;
++		led-upgrade = &led_blue;
+ 	};
+ 
+ 	chosen {
+@@ -44,11 +48,11 @@
+ 		};
+ 
+ 		/* USER_LED2 */
+-		led-1 {
++		led_blue: led-1 {
+ 			function = LED_FUNCTION_STATUS;
+ 			color = <LED_COLOR_ID_BLUE>;
++			default-state = "on";
+ 			gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+ 		};
+ 	};
+ 

--- a/target/linux/rockchip/patches-6.6/130-rock-4se-add-led-aliases-and-stop-heartbeat.patch
+++ b/target/linux/rockchip/patches-6.6/130-rock-4se-add-led-aliases-and-stop-heartbeat.patch
@@ -1,0 +1,27 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+@@ -14,6 +14,10 @@
+ 	aliases {
+ 		mmc0 = &sdhci;
+ 		mmc1 = &sdmmc;
++		led-boot = &led_blue;
++		led-failsafe = &led_blue;
++		led-running = &led_blue;
++		led-upgrade = &led_blue;
+ 	};
+ 
+ 	chosen {
+@@ -33,11 +37,11 @@
+ 		pinctrl-0 = <&user_led2>;
+ 
+ 		/* USER_LED2 */
+-		led-0 {
++		led_blue: led-0 {
+ 			function = LED_FUNCTION_STATUS;
+ 			color = <LED_COLOR_ID_BLUE>;
++			default-state = "on";
+ 			gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+ 		};
+ 	};
+ 


### PR DESCRIPTION
Add support for Radxa ROCK 4C+ and 4SE.

Strangely, the Wi-Fi (AW-CM256SM) doesn't work.

In 4C+, the `brcmfmac` and `brcmfmac_wcc` modules are loaded and a wlan interface is generated, but it doesn't actually work.

In 4SE, only the `brcmfmac` module is loaded and the following error occurs and the wlan interface is not generated.
```
brcmfmac: brcmf_sdio_htclk: HT Avail timeout (1000000): clkctl 0x50
```

In the mainline kernel, the situation is slightly different, but it still doesn't work.