### PR TITLE
Add kmod and firmware for Intel ICE driver (E8xx NICs)

### DIFF
--- a/package/firmware/linux-firmware/intel.mk
+++ b/package/firmware/linux-firmware/intel.mk
@@ -9,6 +9,15 @@ define Package/ibt-firmware/install
 endef
 $(eval $(call BuildPackage,ibt-firmware))
 
+Package/ice-firmware = $(call Package/firmware-default,Intel ICE firmware)
+define Package/ice-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/intel/ice/ddp
+	$(CP) \
+		$(PKG_BUILD_DIR)/intel/ice/ddp/*.pkg \
+		$(1)/lib/firmware/intel/ice/ddp/ice.pkg
+endef
+$(eval $(call BuildPackage,ice-firmware))
+
 Package/iwl3945-firmware = $(call Package/firmware-default,Intel IWL3945 firmware)
 define Package/iwl3945-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1200,6 +1200,24 @@ endef
 $(eval $(call KernelPackage,i40e))
 
 
+define KernelPackage/ice
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Intel(R) Ethernet Controller E810 Series support
+  DEPENDS:=@PCI_SUPPORT +kmod-ptp
+  KCONFIG:=CONFIG_ICE \
+    CONFIG_ICE_HWTS=n \
+    CONFIG_ICE_SWITCHDEV=y
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/ice/ice.ko
+  AUTOLOAD:=$(call AutoProbe,ice)
+endef
+
+define KernelPackage/ice/description
+  Kernel modules for Intel(R) Ethernet Controller E810 Series
+endef
+
+$(eval $(call KernelPackage,ice))
+
+
 define KernelPackage/iavf
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Intel(R) Ethernet Adaptive Virtual Function support


### PR DESCRIPTION
Add support for the Intel ICE firmware (which must be renamed to `ice.pkg` ) and adds the kmod-ice package.

PTM support (`ICE_HWTS`) is disabled as this is does not appear to be used in OpenWRT.
