### PR TITLE
lldpd: bump version to 1.0.18

### DIFF
--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lldpd
-PKG_VERSION:=1.0.17
+PKG_VERSION:=1.0.18
 PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lldpd/lldpd/releases/download/$(PKG_VERSION)/
-PKG_HASH:=89ae691a4917ac9e0ec3b8b2c1e634cc402d43b804f98850c73bd1c7df380882
+PKG_HASH:=38cd319aa02ab61d9a2ad130e22f906795ccca9ac73a0a0d9dac19ca99a8a870
 
 PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 PKG_LICENSE:=ISC


### PR DESCRIPTION
Changes (breaking):
- Remove support for building 802.3bt TLVs (broken).

Fix:
- Fix memory leaks in EDP/FDP decoding when receiving some TLVs twice.
- Do not set interface description continuously.
- Use a different Netlink socket for changes and queries.

Signed-off-by: Sebastian Pflieger <sebastian@pflieger.email>