### PR TITLE
lldpd: fix config for build without LLDP-MED

### DIFF
--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lldpd
 PKG_VERSION:=1.0.18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lldpd/lldpd/releases/download/$(PKG_VERSION)/
@@ -90,6 +90,8 @@ endif
 ifneq ($(CONFIG_LLDPD_WITH_LLDPMED),y)
 	sed -i -e 's/CONFIG_LLDPD_WITH_LLDPMED=y/CONFIG_LLDPD_WITH_LLDPMED=n/g' $(1)/etc/init.d/lldpd
 	sed -i -e '/agentxsocket/d' $(1)/etc/config/lldpd
+	sed -i -e '/lldp_class/d' $(1)/etc/config/lldpd
+	sed -i -e '/lldp_location/d' $(1)/etc/config/lldpd
 endif
 endef
 

--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -39,7 +39,6 @@ get_config_restart_hash() {
 
 	config_load 'lldpd'
 
-	config_get      v 'config' 'lldp_class'; append _string "$v" ","
 	if [ "$CONFIG_LLDPD_WITH_SNMP" = "y" ]; then
 		config_get      v 'config' 'agentxsocket'; append _string "$v" ","
 	fi
@@ -49,6 +48,7 @@ get_config_restart_hash() {
 	config_get_bool v 'config' 'lldp_no_version'; append _string "$v" ","
 	if [ "$CONFIG_LLDPD_WITH_LLDPMED" = "y" ]; then
 		config_get_bool v 'config' 'lldpmed_no_inventory'; append _string "$v" ","
+		config_get      v 'config' 'lldp_class'; append _string "$v" ","
 	fi
 	config_get_bool v 'config' 'enable_lldp' 1; append _string "$v" ","
 	config_get_bool v 'config' 'force_lldp'; append _string "$v" ","
@@ -243,10 +243,10 @@ start_service() {
 		config_get_bool enable_edp 'config' 'enable_edp' 0
 		config_get_bool force_edp 'config' 'force_edp' 0
 	fi
-	config_get lldp_class 'config' 'lldp_class'
 	config_get_bool lldp_no_version 'config' 'lldp_no_version' 0
 	if [ "$CONFIG_LLDPD_WITH_LLDPMED" = "y" ]; then
 		config_get_bool lldpmed_no_inventory 'config' 'lldpmed_no_inventory' 0
+		config_get lldp_class 'config' 'lldp_class'
 	fi
 	config_get_bool readonly_mode 'config' 'readonly_mode' 0
 	if [ "$CONFIG_LLDPD_WITH_SNMP" = "y" ]; then


### PR DESCRIPTION
lldpd: fix config for build without LLDP-MED
The lldp_class and lldp_location config option are only valid when
compiled with LLDP-MED support. If not they will cause lldpd not to
start.

Signed-off-by: Sebastian Pflieger <sebastian@pflieger.email>