### PR TITLE
d1: Use correct module for devices with wifi

### DIFF
--- a/target/linux/d1/base-files/etc/board.d/02_network
+++ b/target/linux/d1/base-files/etc/board.d/02_network
@@ -8,6 +8,10 @@
 board_config_update
 
 case "$(board_name)" in
+sipeed,lichee-rv-dock |\
+widora,mangopi-mq-pro)
+	ucidef_set_interface_lan "wlan0"
+	;;
 *)
 	ucidef_set_interface_lan 'eth0'
 	;;

--- a/target/linux/d1/image/Makefile
+++ b/target/linux/d1/image/Makefile
@@ -65,7 +65,7 @@ define Device/sipeed_lichee-rv-dock
   DEVICE_MODEL := LicheePi RV (dock)
   DEVICE_DTS := allwinner/sun20i-d1-lichee-rv-dock
   SUPPORTED_DEVICES += lichee_rv_dock
-  DEVICE_PACKAGES += kmod-rtl8723bs
+  DEVICE_PACKAGES += kmod-rtw88-8723ds wpad-basic-mbedtls
   UBOOT := lichee_rv_dock
 endef
 TARGET_DEVICES += sipeed_lichee-rv-dock
@@ -76,7 +76,7 @@ define Device/widora_mangopi-mq-pro
   DEVICE_MODEL := MQ Pro
   DEVICE_DTS := allwinner/sun20i-d1-mangopi-mq-pro
   SUPPORTED_DEVICES += mangopi_mq_pro
-  DEVICE_PACKAGES += kmod-rtl8723bs
+  DEVICE_PACKAGES += kmod-rtw88-8723ds wpad-basic-mbedtls
   UBOOT := mangopi_mq_pro
 endef
 TARGET_DEVICES += widora_mangopi-mq-pro


### PR DESCRIPTION
Devices with wifi (LicheePi RV and MangoPi MQ Pro) were using the wrong module.  Also wpad was missing to enable using the WiFi.

Signed-off-by: Raylynn Knight <rayknight@me.com>

