### PR TITLE
mediatek: Xiaomi AX3000t: fix soft brick for the rd23 model

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount
+++ b/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount
@@ -5,6 +5,24 @@ START=99
 
 boot() {
 	case $(board_name) in
+	xiaomi,mi-router-ax3000t)
+		. /lib/upgrade/common.sh
+		[ "$(rootfs_type)" = "tmpfs" ] && \
+			logger "bootcount: initramfs mode detected, exit" && \
+			return 0
+		[ "$(fw_printenv -n flag_try_sys2_failed 2>&1)" = "8" ] && \
+			logger "bootcount: rd03 model detected, exit" && \
+			return 0
+		fw_setenv -s - <<-EOF
+			flag_boot_rootfs 0
+			flag_boot_success 1
+			flag_last_success 0
+			flag_ota_reboot 0
+			flag_try_sys1_failed 0
+			flag_try_sys2_failed 0
+		EOF
+		logger "bootcount: rd23 model detected, nvram was updated"
+		;;
 	zyxel,ex5700-telenor)
 		fw_setenv uboot_bootcount 0
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -40,13 +40,15 @@ xiaomi_initial_setup()
 		return 0
 	fi
 
-	fw_setenv boot_wait on
-	fw_setenv uart_en 1
-	fw_setenv flag_boot_rootfs 0
-	fw_setenv flag_last_success 1
-	fw_setenv flag_boot_success 1
-	fw_setenv flag_try_sys1_failed 8
-	fw_setenv flag_try_sys2_failed 8
+	fw_setenv -s - <<-EOF
+		boot_wait on
+		uart_en 1
+		flag_boot_rootfs 0
+		flag_last_success 1
+		flag_boot_success 1
+		flag_try_sys1_failed 8
+		flag_try_sys2_failed 8
+	EOF
 
 	local board=$(board_name)
 	case "$board" in


### PR DESCRIPTION
mediatek: replace multiple fw_setenv calls by the bulk one
--------------------------------------------------------------

This commit replaces multiple fw_setenv calls by the bulk one to reduce flash writes.

Thanks @Linaro1985 for the idea.

mediatek: Xiaomi AX3000t: fix soft brick for the rd23 model
--------------------------------------------------------------
This commit fixes Xiaomi AX3000t soft bricks. Issue affects at least rd23 model (Global version) users:
Link: https://forum.openwrt.org/t/openwrt-support-for-xiaomi-ax3000t/180490/452

I also found that these nvram settings are wrong for the rd23 model and U-Boot erase them:
```
flag_try_sys1_failed 8
flag_try_sys2_failed 8
```
As a result, `platform.sh` -> `xiaomi_initial_setup()` function sometimes ends early without applying settings for the rd23 model.

RD03 model strategy:
1. Don't touch values those were set up by `platform.sh` -> `xiaomi_initial_setup()` function

RD23 model strategy:
1. Apply correct nvram settings at every boot
2. Use bulk fw_setenv call

I didn't find opened issue for AX3000t. Similar AX3200 issue:
Link: https://github.com/openwrt/openwrt/issues/16347
So, other Xiaomi devices (e.g. Xiaomi WR30U) may also require fix.

Fixes: https://github.com/csharper2005/openwrt/commit/7dbcc1215a56cc1da68c81bf92d7efa174c5e051 ("mediatek: filogic: add support for Xiaomi AX3000T")
