### PR TITLE
ath79: use gpio-beeper instead of gpio-exports

### DIFF
--- a/target/linux/ath79/dts/ar9331_hak5_wifi-pineapple-nano.dts
+++ b/target/linux/ath79/dts/ar9331_hak5_wifi-pineapple-nano.dts
@@ -16,17 +16,17 @@
 		led-upgrade = &led_system;
 	};
 
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+	};
+
 	gpio-export {
 		compatible = "gpio-export";
 
 		microsd-detect {
 			gpio-export,name = "microsd-detect";
 			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-		};
-
-		usb-alarm {
-			gpio-export,name = "usb-alarm";
-			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
 		};
 	};
 

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951g-2hnd.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951g-2hnd.dts
@@ -17,12 +17,11 @@
 			gpio-export,output = <1>;
 			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
 		};
+	};
 
-		buzzer {
-			gpio-export,name = "buzzer";
-			gpio-export,output = <1>;
-			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
-		};
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/ath79/dts/qca9531_wallys_dr531.dts
+++ b/target/linux/ath79/dts/qca9531_wallys_dr531.dts
@@ -17,14 +17,9 @@
 		led-upgrade = &led_sig4;
 	};
 
-	gpio-export {
-		compatible = "gpio-export";
-
-		buzzer {
-			gpio-export,name = "buzzer";
-			gpio-export,output = <0>;
-			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
-		};
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/qca9558_mikrotik_routerboard-96x.dtsi
+++ b/target/linux/ath79/dts/qca9558_mikrotik_routerboard-96x.dtsi
@@ -12,6 +12,12 @@
 		led-upgrade = &led_user;
 	};
 
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		/* Beeper requires PWM for frequency selection */
+	};
+
 	leds {
 		compatible = "gpio-leds";
 
@@ -34,13 +40,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-
-		buzzer {
-			/* Beeper requires PWM for frequency selection */
-			gpio-export,name = "buzzer";
-			gpio-export,output = <0>;
-			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
-		};
 
 		usb_power {
 			gpio-export,name = "usb-power";

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1823,7 +1823,7 @@ define Device/hak5_wifi-pineapple-nano
   DEVICE_MODEL := WiFi Pineapple NANO
   TPLINK_HWID := 0x4e414e4f
   IMAGES := sysupgrade.bin
-  DEVICE_PACKAGES := kmod-ath9k-htc kmod-usb-chipidea2 kmod-usb-storage \
+  DEVICE_PACKAGES := kmod-ath9k-htc kmod-gpio-beeper kmod-usb-chipidea2 kmod-usb-storage \
 	-swconfig -uboot-envtools
   SUPPORTED_DEVICES += wifi-pineapple-nano
 endef
@@ -3212,7 +3212,7 @@ define Device/wallys_dr531
   SOC := qca9531
   DEVICE_VENDOR := Wallys
   DEVICE_MODEL := DR531
-  DEVICE_PACKAGES := kmod-usb2 rssileds
+  DEVICE_PACKAGES := kmod-gpio-beeper kmod-usb2 rssileds
   IMAGE_SIZE := 7808k
   SUPPORTED_DEVICES += dr531
 endef

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -94,7 +94,7 @@ define Device/mikrotik_routerboard-951g-2hnd
   $(Device/mikrotik_nand)
   SOC := ar9344
   DEVICE_MODEL := RouterBOARD 951G-2HnD
-  DEVICE_PACKAGES += kmod-usb-ohci kmod-usb2
+  DEVICE_PACKAGES += kmod-gpio-beeper kmod-usb-ohci kmod-usb2
   SUPPORTED_DEVICES += rb-951g-2hnd
 endef
 TARGET_DEVICES += mikrotik_routerboard-951g-2hnd
@@ -132,7 +132,7 @@ define Device/mikrotik_routerboard-962uigs-5hact2hnt
   SOC := qca9558
   DEVICE_MODEL := RouterBOARD 962UiGS-5HacT2HnT (hAP ac)
   DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2 \
-	kmod-i2c-gpio kmod-sfp
+	kmod-gpio-beeper kmod-i2c-gpio kmod-sfp
   IMAGE_SIZE := 16256k
   SUPPORTED_DEVICES += rb-962uigs-5hact2hnt
 endef


### PR DESCRIPTION
This seems to be the standard way to implement this instead of the local gpio-export solution.

