### PR TITLE
[24.10] mvebu: Add support for WD Cloud Mirror Gen2

### DIFF
--- a/target/linux/mvebu/cortexa9/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/cortexa9/base-files/etc/board.d/02_network
@@ -13,7 +13,8 @@ mvebu_setup_interfaces()
 
 	case "$board" in
 	ctera,c200-v2|\
-	synology,ds213j)
+	synology,ds213j|\
+	wd,cloud-mirror-gen2)
 		ucidef_set_interface_lan "eth0" "dhcp"
 		;;
 	cznic,turris-omnia)
@@ -93,6 +94,12 @@ mvebu_setup_macs()
 		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		lan_mac=$label_mac
 		wan_mac=$label_mac
+		;;
+	wd,cloud-mirror-gen2)
+		# mac address is on ubi "config" or ubi "reserve2" in text file.
+		# ubi "reserve2" /dev/mtd7 is twice small and only contains basic OEM factory info
+		label_mac=$(macaddr_canonicalize $(strings /dev/mtd7|grep -E '([0-9A-F]{2}[:])'))
+		lan_mac=$label_mac
 		;;
 	esac
 

--- a/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
@@ -31,7 +31,8 @@ platform_do_upgrade() {
 		CI_ROOT_UBIPART=ubi
 		nand_do_upgrade "$1"
 		;;
-	buffalo,ls421de)
+	buffalo,ls421de|\
+	wd,cloud-mirror-gen2)
 		nand_do_upgrade "$1"
 		;;
 	ctera,c200-v2)

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-wd_cloud-mirror-gen2.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-wd_cloud-mirror-gen2.dts
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Device Tree file for Western Digital My Cloud Mirror Gen 2
+ * (BWVZ/Grand Teton)
+ *
+ * Copyright (C) 2020
+ *
+ * Based on the code from:
+ *
+ * Copyright (C) 2019 Evgeny Kolesnikov <evgenyz@gmail.com>
+ * Copyright (C) 2016 Martin Mueller <mm@sig21.net>
+ * Copyright (C) 2013 Gregory CLEMENT <gregory.clement@free-electrons.com>
+ * Copyright (C) 2014 Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+ *
+ */
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include "armada-385.dtsi"
+
+/ {
+	model = "WD MyCloud Mirror Gen 2 (BWVZ/Grand Teton)";
+	compatible = "wd,cloud-mirror-gen2", "marvell,armada385", "marvell,armada380";
+
+	aliases {
+		led-boot = &led_boot;
+		led-failsafe = &led_boot;
+		led-upgrade = &led_boot;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		append-rootblock = "nullparameter="; /* override the bootloader args */
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x00000000 0x20000000>; /* 512 MB */
+	};
+
+	soc {
+		ranges = <MBUS_ID(0xf0, 0x01) 0 0xf1000000 0x100000
+		          MBUS_ID(0x01, 0x1d) 0 0xfff00000 0x100000
+		          MBUS_ID(0x09, 0x19) 0 0xf1100000 0x10000
+		          MBUS_ID(0x09, 0x15) 0 0xf1110000 0x10000
+		          MBUS_ID(0x0c, 0x04) 0 0xf1200000 0x100000>;
+
+		internal-regs {
+			timer@c200 {
+				status = "okay";
+			};
+
+			i2c0: i2c@11000 {
+				status = "okay";
+				clock-frequency = <100000>;
+			};
+
+			i2c1: i2c@11100 {
+				status = "okay";
+				clock-frequency = <100000>;
+			};
+
+			serial@12000 {
+				status = "okay";
+			};
+
+			/* Connected to Welltrend 6703F-OG240WT MCU
+			 * which controls power, fan and other things
+			 */
+			serial@12100 {
+				status = "okay";
+			};
+
+			pinctrl@18000 {
+				/* use only one pin for UART1, as mpp20 is used by sata0 */
+				uart1_pins: uart-pins-1 {
+					marvell,pins = "mpp19";
+					marvell,function = "ua1";
+				};
+
+				xhci0_vbus_pins: xhci0-vbus-pins {
+					marvell,pins = "mpp26";
+					marvell,function = "gpio";
+				};
+
+				xhci1_vbus_pins: xhci1-vbus-pins {
+					marvell,pins = "mpp27";
+					marvell,function = "gpio";
+				};
+
+				sata0_pins: sata-pins-0 {
+					marvell,pins = "mpp55";
+					marvell,function = "sata0";
+				};
+
+				sata1_pins: sata-pins-1 {
+					marvell,pins = "mpp56";
+					marvell,function = "sata1";
+				};
+
+				sata_leds: sata-leds {
+					marvell,pins = "mpp43", "mpp52", "mpp53", "mpp54";
+					marvell,function = "gpio";
+				};
+
+				btn_pins: btn-pins {
+					marvell,pins = "mpp50";
+					marvell,function = "gpio";
+				};
+			};
+
+			usb@58000 {
+				status = "okay";
+			};
+
+			phy: mdio@72004 {
+				phy0: ethernet-phy@0 {
+					/* Init ETH LEDs */
+					marvell,reg-init = <3 16 0 0x101e>;
+					reg = <0>;
+				};
+			};
+
+			sata@a8000 {
+				status = "okay";
+			};
+
+			nand-controller@d0000 {
+				status = "okay";
+
+				nand: nand@0 {
+					reg = <0>;
+					label = "pxa3xx_nand-0";
+					nand-rb = <0>;
+					marvell,nand-keep-config;
+					#marvell,nand-enable-arbiter; //optional
+					nand-on-flash-bbt;
+					nand-ecc-strength = <4>;
+					nand-ecc-step-size = <512>;
+
+					partitions {
+						compatible = "fixed-partitions";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						partition@00000000 {
+							label = "U-Boot";
+							reg = <0x00000000 0x00500000>;    /*   5 MB */
+							read-only;
+						};
+
+						partition@00500000 {
+							label = "kernel";
+							reg = <0x00500000 0x00500000>;    /*   5 MB */
+						};
+
+						partition@00a00000 {
+							label = "uRamdisk";
+							reg = <0x00a00000 0x00500000>;    /*   5 MB */
+							read-only;
+						};
+
+						partition@00f00000 {
+							label = "ubi";
+							reg = <0x00f00000 0x0b900000>;    /* 185 MB */
+						};
+
+						partition@c800000 {
+							label = "rescue fw";
+							reg = <0x0c800000 0x00f00000>;    /*  15 MB */
+							read-only;
+						};
+
+						partition@d70000 {
+							label = "config";
+							reg = <0x0d700000 0x01400000>;    /*  20 MB */
+							read-only;
+						};
+
+						partition@eb00000 {
+							label = "reserve1";
+							reg = <0x0eb00000 0x00a00000>;    /*  10 MB */
+							read-only;
+						};
+
+						partition@f500000 {
+							label = "reserve2";
+							reg = <0x0f500000 0x00a00000>;    /*  10 MB */
+							read-only;
+						};
+					};
+				};
+			};
+
+			usb3@f0000 {
+				usb-phy = <&usb3_0_phy>;
+				status = "okay";
+			};
+
+			usb3@f8000 {
+				usb-phy = <&usb3_1_phy>;
+				status = "okay";
+			};
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&sata_leds>;
+
+		led_boot: s1red {
+			label = "red:hdd1";
+			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		};
+		s2red {
+			label = "red:hdd2";
+			gpios = <&gpio1 20 GPIO_ACTIVE_HIGH>;
+		};
+		s1blue {
+			label = "blue:hdd1";
+			gpios = <&gpio1 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "ata1";
+		};
+		s2blue {
+			label = "blue:hdd2";
+			gpios = <&gpio1 22 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "ata2";
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-names = "default";
+		pinctrl-0 = <&btn_pins>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;  // Restart=0x198, Power=0x116
+			gpios = <&gpio1 18 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+	};
+
+	usb3_0_phy: usb3_0_phy {
+		compatible = "usb-nop-xceiv";
+		vcc-supply = <&reg_usb3_0_vbus>;
+	};
+
+	usb3_1_phy: usb3_1_phy {
+		compatible = "usb-nop-xceiv";
+		vcc-supply = <&reg_usb3_1_vbus>;
+	};
+
+	reg_usb3_0_vbus: usb3-vbus0 {
+		compatible = "regulator-fixed";
+		regulator-name = "usb3-vbus0";
+		pinctrl-names = "default";
+		pinctrl-0 = <&xhci0_vbus_pins>;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+		regulator-always-on;
+		gpio = <&gpio0 26 GPIO_ACTIVE_HIGH>;
+	};
+
+	reg_usb3_1_vbus: usb3-vbus1 {
+		compatible = "regulator-fixed";
+		regulator-name = "usb3-vbus1";
+		pinctrl-names = "default";
+		pinctrl-0 = <&xhci1_vbus_pins>;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+		regulator-always-on;
+		gpio = <&gpio0 27 GPIO_ACTIVE_HIGH>;
+	};
+
+	reg_sata0: pwr-sata0 {
+		compatible = "regulator-fixed";
+		regulator-name = "pwr_en_sata0";
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+		enable-active-high;
+		regulator-boot-on;
+		gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+	};
+
+	reg_5v_sata0: v5-sata0 {
+		compatible = "regulator-fixed";
+		regulator-name = "v5.0-sata0";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		vin-supply = <&reg_sata0>;
+	};
+
+	reg_12v_sata0: v12-sata0 {
+		compatible = "regulator-fixed";
+		regulator-name = "v12.0-sata0";
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+		vin-supply = <&reg_sata0>;
+	};
+
+	reg_sata1: pwr-sata1 {
+		compatible = "regulator-fixed";
+		regulator-name = "pwr_en_sata1";
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+		enable-active-high;
+		regulator-boot-on;
+		gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+	};
+
+	reg_5v_sata1: v5-sata1 {
+		compatible = "regulator-fixed";
+		regulator-name = "v5.0-sata1";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		vin-supply = <&reg_sata1>;
+	};
+
+	reg_12v_sata1: v12-sata1 {
+		compatible = "regulator-fixed";
+		regulator-name = "v12.0-sata1";
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+		vin-supply = <&reg_sata1>;
+	};
+};
+
+&bm {
+	status = "okay";
+};
+
+&bm_bppi {
+	status = "okay";
+};
+
+&eth2 {
+	status = "okay";
+	phy = <&phy0>;
+	phy-mode = "sgmii";
+	buffer-manager = <&bm>;
+	bm,pool-long = <0>;
+	bm,pool-short = <1>;
+};
+
+&ahci0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	sata-port@0 {
+		reg = <0>;
+		target-supply = <&reg_sata0>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sata-port@1 {
+		reg = <1>;
+		target-supply = <&reg_sata1>;
+		#thermal-sensor-cells = <1>;
+	};
+};

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -453,7 +453,7 @@ define Device/wd_cloud-mirror-gen2
   $(Device/NAND-128K)
   DEVICE_VENDOR := Western Digital
   DEVICE_MODEL := MyCloud Mirror Gen 2 (BWVZ/Grand Teton)
-  DEVICE_PACKAGES += -uboot-envtools coreutils-stty mkf2fs e2fsprogs \
+  DEVICE_PACKAGES += -uboot-envtools mkf2fs e2fsprogs \
 	partx-utils kmod-hwmon-drivetemp -ppp -kmod-nft-offload -dnsmasq \
 	-odhcpd-ipv6only 
   DEVICE_DTS := armada-385-wd_cloud-mirror-gen2

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -448,3 +448,20 @@ define Device/synology_ds213j
     -ppp -kmod-nft-offload -dnsmasq -odhcpd-ipv6only
 endef
 TARGET_DEVICES += synology_ds213j
+
+define Device/wd_cloud-mirror-gen2
+  $(Device/NAND-128K)
+  DEVICE_VENDOR := Western Digital
+  DEVICE_MODEL := MyCloud Mirror Gen 2 (BWVZ/Grand Teton)
+  DEVICE_PACKAGES += -uboot-envtools coreutils-stty mkf2fs e2fsprogs \
+	partx-utils kmod-hwmon-drivetemp -ppp -kmod-nft-offload -dnsmasq \
+	-odhcpd-ipv6only 
+  DEVICE_DTS := armada-385-wd_cloud-mirror-gen2
+  KERNEL_SIZE := 5120k
+  KERNEL := kernel-bin | append-dtb | uImage none
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
+  IMAGES += image-cfs-factory.bin uImage-factory.bin
+  IMAGE/image-cfs-factory.bin := append-ubi
+  IMAGE/uImage-factory.bin := append-kernel
+endef
+TARGET_DEVICES += wd_cloud-mirror-gen2


### PR DESCRIPTION
Hardware
--------
Marvell Armada 385 (MV88F6820)
512B RAM
256MB NAND (Hynix H27U2G8F2CTR)
1x 1Gbit
2x USB 3.0
2x SATA-III
UART: 115200 8N1 3.3V
RTC
Weltrend MCU WT6703F connected via UART1 for Power LED / PWM Fan / hw reset / WoL

Installation
------------
Connect UART 3.3V adapter to JP2  pins: 1-RX / 2-GND / 5-TX

Use USB2.0 FAT32 pendrive with openwrt-mvebu-cortexa9-wd_cloud-mirror-gen2-initramfs-kernel.bin
 1. stop boot by pressing 1
 2. usb start
 3. fatload usb 0:1  0x02000000 openwrt-mvebu-cortexa9-wd_cloud-mirror-gen2-initramfs-kernel.bin;bootm 0x02000000 -
 4. do backup mtd1 mtd3
 5. use sysupgrade

Or tftp
 1. stop boot by pressing 1
 2. setenv ethact egiga2;setenv serverip 192.168.11.114;setenv ipaddr 192.168.11.113
 3. tftpboot 0x02000000 openwrt-mvebu-cortexa9-wd_cloud-mirror-gen2-initramfs-kernel.bin; bootm 0x02000000 -
 4. do backup mtd1 mtd3
 5. use sysupgrade

or Evgeny Kolesnikov <evgenyz@gmail.com> method from his failed PR 2040

- Using original firmware's network settings obtain SSH access to the device.
- Put *-image-cfs-factory.bin and *-uImage-factory.bin images into device's /tmp directory.
- Write kernel (uImage) image 'flash_eraseall /dev/mtd1 && nandwrite --markbad -p /dev/mtd1 /tmp/*-uImage-factory.bin'.
- Write rootfs (image-cfs) image 'ubiformat /dev/mtd3 -f /tmp/*-image.cfs-factory.bin -y'.
- Reboot the device.

Installation (upgrade):

Use *-sysupgrade.bin in a usual way.
Weltrend MCU control is done via uart1 19200

stty -F /dev/ttyS1 raw speed 19200
stty -F /dev/ttyS1 raw speed 19200

PWM Fan Control
off: 00
echo -n -e '\xfa\x02\x00\x00\x00\x00\xfb' > /dev/ttyS1 slow: 5F
echo -n -e '\xfa\x02\x00\x5f\x00\x00\xfb' > /dev/ttyS1 max: FF
echo -n -e '\xfa\x02\x00\xff\x00\x00\xfb' > /dev/ttyS1

Power LED Control
Blue
echo -n -e '\xfa\x26\x00\x11\x00\x01\xfb' > /dev/ttyS1 Red
echo -n -e '\xfa\x26\x00\x14\x00\x01\xfb' > /dev/ttyS1 Orange
echo -n -e '\xfa\x26\x00\x12\x00\x01\xfb' > /dev/ttyS1

more here: https://github.com/c-MM/mcm-daemon/blob/master/mcm.h

Signed-off-by: Robert Senderek <robert.senderek@10g.pl>
Link: https://github.com/openwrt/openwrt/pull/17046
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
(cherry picked from commit 8fb805aa1f25b69b7849c8b1ce787ed47b16d123)

