### PR TITLE
hostapd: backport upstream patch to fix setting BSS color

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/patches/763-radius-wispr.patch
+++ b/package/network/services/hostapd/patches/763-radius-wispr.patch
@@ -36,7 +36,7 @@
  		sm->eap_if->aaaFail = true;
 --- a/src/ap/sta_info.h
 +++ b/src/ap/sta_info.h
-@@ -95,6 +95,7 @@ struct sta_info {
+@@ -94,6 +94,7 @@ struct sta_info {
  	u8 supported_rates[WLAN_SUPP_RATES_MAX];
  	int supported_rates_len;
  	u8 qosinfo; /* Valid when WLAN_STA_WMM is set */

--- a/package/network/services/hostapd/patches/803-hostapd-fix-80211be-build.patch
+++ b/package/network/services/hostapd/patches/803-hostapd-fix-80211be-build.patch
@@ -25,7 +25,7 @@
 +
 --- a/src/ap/sta_info.h
 +++ b/src/ap/sta_info.h
-@@ -408,23 +408,8 @@ int ap_sta_re_add(struct hostapd_data *h
+@@ -409,23 +409,8 @@ int ap_sta_re_add(struct hostapd_data *h
  
  void ap_free_sta_pasn(struct hostapd_data *hapd, struct sta_info *sta);
  

--- a/package/network/services/hostapd/patches/804-hostapd-Fix-clearing-up-settings-for-color-switch.patch
+++ b/package/network/services/hostapd/patches/804-hostapd-Fix-clearing-up-settings-for-color-switch.patch
@@ -1,0 +1,28 @@
+From 161327f91d956771996c96ea1b6e4e1cb8dc074c Mon Sep 17 00:00:00 2001
+From: Stone Zhang <quic_stonez@quicinc.com>
+Date: Mon, 14 Oct 2024 18:47:32 +0800
+Subject: [PATCH] hostapd: Fix clearing up settings for color switch
+
+Settings for color switch (struct cca_settings settings)
+is used without zero clearing, which causes the member
+settings->ubpr->unsol_bcast_probe_resp_intervalettings
+to be a random value. It is againsts the NLA policy of
+NL80211_UNSOL_BCAST_PROBE_RESP_ATTR_INT and causes
+BSS color switch failure.
+
+Fixes: 654d2395dddf ("BSS coloring: Handling of collision events and triggering CCA")
+Signed-off-by: Stone Zhang <quic_stonez@quicinc.com>
+---
+ src/ap/hostapd.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/src/ap/hostapd.c
++++ b/src/ap/hostapd.c
+@@ -4813,6 +4813,7 @@ static void hostapd_switch_color_timeout
+ 		struct cca_settings settings;
+ 		int ret;
+ 
++		os_memset(&settings, 0, sizeof(settings));
+ 		hostapd_cleanup_cca_params(bss);
+ 		bss->cca_color = r;
+ 		bss->cca_count = 10;


### PR DESCRIPTION
Without this patch, we get the following error:

Mon Dec 23 11:35:44 2024 daemon.err hostapd: nl80211: kernel reports: integer out of range

As updating hostapd would be too complex and requires further testing, we backport this simple upstream fix instead.

Fixes: https://github.com/openwrt/openwrt/issues/16680