### PR TITLE
realtek: enable fan access for HPE 1920 24 PoE

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/realtek/base-files/etc/board.d/03_gpio_switches
@@ -5,13 +5,8 @@ board_config_update
 
 board=$(board_name)
 
-case "$board" in
-hpe,1920-8g-poe-180w|\
-hpe,1920-24g-poe-180w|\
-hpe,1920-24g-poe-370w)
-	ucidef_add_gpio_switch "fan_ctrl" "Fan control" "456" "0"
-	;;
-esac
+# FIXME: should this entire file be removed, or kept as placeholder for
+#        the future?
 
 board_config_flush
 

--- a/target/linux/realtek/base-files/etc/board.d/05_compat-version
+++ b/target/linux/realtek/base-files/etc/board.d/05_compat-version
@@ -8,6 +8,11 @@
 board_config_update
 
 case "$(board_name)" in
+	hpe,1920-8g-poe-180w | \
+	hpe,1920-24g-poe-180w | \
+	hpe,1920-24g-poe-370w)
+		ucidef_set_compat_version "1.1"
+		;;
 	zyxel,gs1900-8 | \
 	zyxel,gs1900-8hp-v1 | \
 	zyxel,gs1900-8hp-v2 | \

--- a/target/linux/realtek/dts/rtl8380_hpe_1920-8g-poe-180w.dts
+++ b/target/linux/realtek/dts/rtl8380_hpe_1920-8g-poe-180w.dts
@@ -5,6 +5,18 @@
 / {
 	compatible = "hpe,1920-8g-poe-180w", "realtek,rtl838x-soc";
 	model = "HPE 1920-8G-PoE+ 180W (JG922A)";
+
+	gpio_fan_array {
+		compatible = "gpio-fan";
+		target-rpm = <10000>;
+
+		gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		gpio-fan,speed-map =    <5000 0>,
+		                        <8200 1>;
+
+		alarm-gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+		#cooling-cells = <2>;
+	};
 };
 
 &uart1 {

--- a/target/linux/realtek/dts/rtl8382_hpe_1920-24g-poe-180w.dts
+++ b/target/linux/realtek/dts/rtl8382_hpe_1920-24g-poe-180w.dts
@@ -5,6 +5,18 @@
 / {
 	compatible = "hpe,1920-24g-poe-180w", "realtek,rtl838x-soc";
 	model = "HPE 1920-24G-PoE+ 180W (JG925A)";
+
+	gpio_fan_array {
+		compatible = "gpio-fan";
+		target-rpm = <10000>;
+
+		gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		gpio-fan,speed-map =    <5000 0>,
+		                        <8200 1>;
+
+		alarm-gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+		#cooling-cells = <2>;
+	};
 };
 
 &uart1 {

--- a/target/linux/realtek/dts/rtl8382_hpe_1920-24g-poe-370w.dts
+++ b/target/linux/realtek/dts/rtl8382_hpe_1920-24g-poe-370w.dts
@@ -5,6 +5,18 @@
 / {
 	compatible = "hpe,1920-24g-poe-370w", "realtek,rtl838x-soc";
 	model = "HPE 1920-24G-PoE+ 370W (JG926A)";
+
+	gpio_fan_array {
+		compatible = "gpio-fan";
+		target-rpm = <10000>;
+
+		gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		gpio-fan,speed-map =    <5000 0>,
+		                        <8200 1>;
+
+		alarm-gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
+		#cooling-cells = <2>;
+	};
 };
 
 &uart1 {

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -122,7 +122,11 @@ define Device/hpe_1920-8g-poe-180w
   $(Device/hpe_1920)
   SOC := rtl8380
   DEVICE_MODEL := 1920-8G-PoE+ 180W (JG922A)
-  DEVICE_PACKAGES += realtek-poe
+  DEVICE_PACKAGES += realtek-poe kmod-hwmon-gpiofan
+  DEVICE_COMPAT_MESSAGE := \
+      Fan control switched to hwmon. Default fan behaviour fixed. \
+      Your fans will run at max speed unless configured otherwise.
+  DEVICE_COMPAT_VERSION := 1.1
   H3C_DEVICE_ID := 0x00010025
   SUPPORTED_DEVICES += hpe_1920-8g-poe
 endef
@@ -148,7 +152,11 @@ define Device/hpe_1920-24g-poe-180w
   $(Device/hpe_1920)
   SOC := rtl8382
   DEVICE_MODEL := 1920-24G-PoE+ 180W (JG925A)
-  DEVICE_PACKAGES += realtek-poe
+  DEVICE_PACKAGES += realtek-poe kmod-hwmon-gpiofan
+  DEVICE_COMPAT_MESSAGE := \
+      Fan control switched to hwmon. Default fan behaviour fixed. \
+      Your fans will run at max speed unless configured otherwise.
+  DEVICE_COMPAT_VERSION := 1.1
   H3C_DEVICE_ID := 0x00010028
 endef
 TARGET_DEVICES += hpe_1920-24g-poe-180w
@@ -157,7 +165,11 @@ define Device/hpe_1920-24g-poe-370w
   $(Device/hpe_1920)
   SOC := rtl8382
   DEVICE_MODEL := 1920-24G-PoE+ 370W (JG926A)
-  DEVICE_PACKAGES += realtek-poe
+  DEVICE_PACKAGES += realtek-poe kmod-hwmon-gpiofan
+  DEVICE_COMPAT_MESSAGE := \
+      Fan control switched to hwmon. Default fan behaviour fixed. \
+      Your fans will run at max speed unless configured otherwise.
+  DEVICE_COMPAT_VERSION := 1.1
   H3C_DEVICE_ID := 0x00010029
 endef
 TARGET_DEVICES += hpe_1920-24g-poe-370w


### PR DESCRIPTION
Add gpio_fan_array to dts for HPE 1920-24G PoE 180W and 370W variants (JG925A and JG926A).

Drop the fan_ctrl handling from 03_gpio_switches, fan can be controlled via hwmon now.

Add kmod-hwmon-gpiofan to DEFAULT_PACKAGES to make the fan controllable by default.

This is based on the changes posted here:
http://lists.openwrt.org/pipermail/openwrt-devel/2024-October/043296.html by Evan Jobling.