### PR TITLE
mediatek: improve support for cudy devices

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-ap3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-ap3000-v1.dts
@@ -133,8 +133,8 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		spi-cal-enable;
 		spi-cal-mode = "read-data";

--- a/target/linux/mediatek/dts/mt7981b-cudy-ap3000outdoor-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-ap3000outdoor-v1.dts
@@ -8,7 +8,7 @@
 
 / {
 	model = "Cudy AP3000 Outdoor v1";
-	compatible = "cudy,ap3000outdoor-v1", "mediatek,mt7981-spim-snand-rfb";
+	compatible = "cudy,ap3000outdoor-v1", "mediatek,mt7981";
 
 	aliases {
 		label-mac-device = &wifi;
@@ -42,18 +42,19 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_status_green: led@0 {
+		led_status_green: led-0 {
 			function = LED_FUNCTION_STATUS;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 10 GPIO_ACTIVE_HIGH>;
 		};
 
-		led_status_red: led_1 {
+		led_status_red: led-1 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
 		};
 	};
+
 	gpio_export {
 		compatible = "gpio-export";
 		#size-cells = <0>;
@@ -89,7 +90,6 @@
 &eth {
 	pinctrl-names = "default";
 	pinctrl-0 = <&mdio_pins>;
-
 	status = "okay";
 
 	gmac1: mac@1 {

--- a/target/linux/mediatek/dts/mt7981b-cudy-ap3000outdoor-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-ap3000outdoor-v1.dts
@@ -148,6 +148,7 @@
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -163,6 +164,7 @@
 				label = "bdinfo";
 				reg = <0x380000 0x0040000>;
 				read-only;
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -174,24 +176,22 @@
 						#nvmem-cell-cells = <1>;
 					};
 				};
-
 			};
 
-			partition@3C0000 {
+			partition@3c0000 {
 				label = "FIP";
-				reg = <0x3C0000 0x0200000>;
+				reg = <0x3c0000 0x0200000>;
 				read-only;
 			};
 
-			partition@580000 {
+			partition@5c0000 {
 				label = "ubi";
-				reg = <0x5C0000 0x4000000>;
+				reg = <0x5c0000 0x4000000>;
 				compatible = "linux,ubi";
 			};
 		};
 	};
 };
-
 
 &pio {
 	spi0_flash_pins: spi0-pins {

--- a/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
@@ -77,7 +77,6 @@
 &eth {
 	pinctrl-names = "default";
 	pinctrl-0 = <&mdio_pins>;
-
 	status = "okay";
 
 	gmac0: mac@0 {
@@ -105,12 +104,11 @@
 	rtl8221b_phy: ethernet-phy@1 {
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <1>;
-
-		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
-
-		interrupts = <38 IRQ_TYPE_LEVEL_LOW>;
 		reset-assert-us = <100000>;
 		reset-deassert-us = <100000>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		interrupts = <38 IRQ_TYPE_LEVEL_LOW>;
+		interrupt-parent = <&pio>;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
@@ -117,7 +117,6 @@
 &spi0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi0_flash_pins>;
-
 	status = "okay";
 
 	spi_nand: spi_nand@0 {
@@ -127,17 +126,17 @@
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
 
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-
-			mediatek,nmbm;
-			mediatek,bmt-max-ratio = <1>;
-			mediatek,bmt-max-reserved-blocks = <64>;
 
 			partition@0 {
 				label = "BL2";
@@ -177,6 +176,7 @@
 			partition@3c0000 {
 				label = "FIP";
 				reg = <0x03c0000 0x0200000>;
+				read-only;
 			};
 
 			partition@5c0000 {

--- a/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
@@ -6,7 +6,7 @@
 
 / {
 	model = "Cudy M3000 v1";
-	compatible = "cudy,m3000-v1", "mediatek,mt7981-spim-snand-rfb";
+	compatible = "cudy,m3000-v1", "mediatek,mt7981";
 
 	aliases {
 		label-mac-device = &gmac0;

--- a/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
@@ -8,7 +8,7 @@
 
 / {
 	model = "Cudy TR3000 v1";
-	compatible = "cudy,tr3000-v1", "mediatek,mt7981-spim-snand-rfb";
+	compatible = "cudy,tr3000-v1", "mediatek,mt7981";
 
 	aliases {
 		label-mac-device = &gmac1;
@@ -59,11 +59,9 @@
 
 	usb_vbus: regulator-usb {
 		compatible = "regulator-fixed";
-
 		regulator-name = "usb-vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-
 		gpios = <&pio 9 GPIO_ACTIVE_LOW>;
 		regulator-boot-on;
 	};

--- a/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
@@ -81,7 +81,6 @@
 &eth {
 	pinctrl-names = "default";
 	pinctrl-0 = <&mdio_pins>;
-
 	status = "okay";
 
 	gmac0: mac@0 {
@@ -105,13 +104,13 @@
 
 &mdio_bus {
 	phy1: phy@1 {
-		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		phy-mode = "2500base-x";
-		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
-		interrupts = <38 IRQ_TYPE_LEVEL_LOW>;
+		reg = <1>;
 		reset-assert-us = <100000>;
 		reset-deassert-us = <100000>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		interrupts = <38 IRQ_TYPE_LEVEL_LOW>;
+		interrupt-parent = <&pio>;
 		realtek,aldps-enable;
 	};
 };

--- a/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
@@ -162,6 +162,7 @@
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -177,6 +178,7 @@
 				label = "bdinfo";
 				reg = <0x380000 0x0040000>;
 				read-only;
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -188,24 +190,22 @@
 						#nvmem-cell-cells = <1>;
 					};
 				};
-
 			};
 
-			partition@3C0000 {
+			partition@3c0000 {
 				label = "FIP";
-				reg = <0x3C0000 0x0200000>;
+				reg = <0x3c0000 0x0200000>;
 				read-only;
 			};
 
-			partition@580000 {
+			partition@5c0000 {
 				label = "ubi";
-				reg = <0x5C0000 0x4000000>;
+				reg = <0x5c0000 0x4000000>;
 				compatible = "linux,ubi";
 			};
 		};
 	};
 };
-
 
 &pio {
 	spi0_flash_pins: spi0-pins {

--- a/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dts
@@ -12,10 +12,10 @@
 
 	aliases {
 		label-mac-device = &gmac1;
-		led-boot = &led_status;
-		led-failsafe = &led_status;
-		led-running = &led_status;
-		led-upgrade = &led_status;
+		led-boot = &led_sys_red;
+		led-failsafe = &led_sys_red;
+		led-running = &led_sys_white;
+		led-upgrade = &led_sys_white;
 		serial0 = &uart0;
 	};
 
@@ -34,8 +34,8 @@
 
 		mode {
 			label = "mode";
-			linux,input-type = <EV_SW>;
 			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
 			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
 		};
@@ -44,18 +44,17 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_status: led_0 {
+		led_sys_red: led-0 {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
 		};
 
-		led_1 {
+		led_sys_white: led-1 {
 			function = LED_FUNCTION_STATUS;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
 		};
-
 	};
 
 	usb_vbus: regulator-usb {

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
@@ -8,7 +8,7 @@
 
 / {
 	model = "Cudy WR3000H v1";
-	compatible = "cudy,wr3000h-v1", "mediatek,mt7981-spim-snand-rfb";
+	compatible = "cudy,wr3000h-v1", "mediatek,mt7981";
 
 	aliases {
 		label-mac-device = &gmac0;
@@ -53,68 +53,67 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_status: led@0 {
+		led_status: led-status {
 			function = LED_FUNCTION_STATUS;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 		};
 
-
-		led_internet {
+		led-internet {
 			function = LED_FUNCTION_WAN_ONLINE;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
 		};
 
-		led_wps {
+		led-wps {
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
 		};
 
-		led_wlan2g {
+		led-wlan2g {
 			function = LED_FUNCTION_WLAN_2GHZ;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 
-		led_wlan5g {
+		led-wlan5g {
 			function = LED_FUNCTION_WLAN_5GHZ;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy1tpt";
 		};
 
-		led_lan1 {
+		led-lan1 {
 			function = LED_FUNCTION_LAN;
 			function-enumerator = <1>;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
 		};
 
-		led_lan2 {
+		led-lan2 {
 			function = LED_FUNCTION_LAN;
 			function-enumerator = <2>;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
 		};
 
-		led_lan3 {
+		led-lan3 {
 			function = LED_FUNCTION_LAN;
 			function-enumerator = <3>;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
 		};
 
-		led_lan4 {
+		led-lan4 {
 			function = LED_FUNCTION_LAN;
 			function-enumerator = <4>;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
 		};
 
-		led_wan {
+		led-wan {
 			function = LED_FUNCTION_WAN;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 35 GPIO_ACTIVE_LOW>;

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
@@ -39,17 +39,6 @@
 		};
 	};
 
-	gpio-export {
-		compatible = "gpio-export";
-		#size-cells = <0>;
-
-		phyreset {
-			gpio-export,name = "phyreset";
-			gpio-export,output = <1>;
-			gpios = <&pio 3 GPIO_ACTIVE_LOW>;
-		};
-	};
-
 	leds {
 		compatible = "gpio-leds";
 
@@ -132,7 +121,6 @@
 &eth {
 	pinctrl-names = "default";
 	pinctrl-0 = <&mdio_pins>;
-
 	status = "okay";
 
 	gmac0: mac@0 {
@@ -141,7 +129,6 @@
 		phy-mode = "2500base-x";
 		nvmem-cell-names = "mac-address";
 		nvmem-cells = <&macaddr_bdinfo_de00 0>;
-		label = "lan";
 
 		fixed-link {
 			speed = <2500>;
@@ -159,7 +146,6 @@
 		nvmem-cells = <&macaddr_bdinfo_de00 1>;
 		label = "wan";
 	};
-
 };
 
 &mdio_bus {
@@ -172,12 +158,14 @@
 		interrupt-parent = <&pio>;
 		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
 	};
-	phy6: ethernet-phy@6 {
-		compatible = "ethernet-phy-ieee802.3-c22"; // [RTL8221B-VB-CG 2.5Gbps PHY (C22)]
-		reg = <6>;
-		phy-mode = "2500base-x";
-	};
 
+	phy6: ethernet-phy@6 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <6>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+		reset-gpios = <&pio 3 GPIO_ACTIVE_LOW>;
+	};
 };
 
 &spi0 {

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
@@ -227,6 +227,7 @@
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -242,6 +243,7 @@
 				label = "bdinfo";
 				reg = <0x380000 0x0040000>;
 				read-only;
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -255,15 +257,15 @@
 				};
 			};
 
-			partition@3C0000 {
+			partition@3c0000 {
 				label = "FIP";
-				reg = <0x3C0000 0x0200000>;
+				reg = <0x3c0000 0x0200000>;
 				read-only;
 			};
 
-			partition@580000 {
+			partition@5c0000 {
 				label = "ubi";
-				reg = <0x5C0000 0x4000000>;
+				reg = <0x5c0000 0x4000000>;
 				compatible = "linux,ubi";
 			};
 		};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000s-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000s-v1.dts
@@ -8,7 +8,7 @@
 
 / {
 	model = "Cudy WR3000S v1";
-	compatible = "cudy,wr3000s-v1", "mediatek,mt7981-spim-snand-rfb";
+	compatible = "cudy,wr3000s-v1", "mediatek,mt7981";
 
 	aliases {
 		label-mac-device = &gmac0;
@@ -42,33 +42,32 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_status: led@0 {
+		led_status: led-status {
 			function = LED_FUNCTION_STATUS;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
 		};
 
-
-		led_internet {
+		led-internet {
 			function = LED_FUNCTION_WAN_ONLINE;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
 		};
 
-		led_wps {
+		led-wps {
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
 		};
 
-		led_wlan2g {
+		led-wlan2g {
 			function = LED_FUNCTION_WLAN_2GHZ;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 
-		led_wlan5g {
+		led-wlan5g {
 			function = LED_FUNCTION_WLAN_5GHZ;
 			color = <LED_COLOR_ID_WHITE>;
 			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
@@ -88,7 +87,6 @@
 &eth {
 	pinctrl-names = "default";
 	pinctrl-0 = <&mdio_pins>;
-
 	status = "okay";
 
 	gmac0: mac@0 {

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000s-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000s-v1.dts
@@ -165,6 +165,7 @@
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -180,6 +181,7 @@
 				label = "bdinfo";
 				reg = <0x380000 0x0040000>;
 				read-only;
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -193,15 +195,15 @@
 				};
 			};
 
-			partition@3C0000 {
+			partition@3c0000 {
 				label = "FIP";
-				reg = <0x3C0000 0x0200000>;
+				reg = <0x3c0000 0x0200000>;
 				read-only;
 			};
 
-			partition@580000 {
+			partition@5c0000 {
 				label = "ubi";
-				reg = <0x5C0000 0x4000000>;
+				reg = <0x5c0000 0x4000000>;
 				compatible = "linux,ubi";
 			};
 		};


### PR DESCRIPTION
Fixes typo for spi and mtd properties.
Fixes interrupt support for 2.5G PHY.
Delete the unused rfb compatible.
Fixes typo for led properties.