### PR TITLE
Mediatek: filogic: add support for XIANGSI HG3000 EMMC version and NAND version

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-xiangsi-hg3000ax-emmc.dts
+++ b/target/linux/mediatek/dts/mt7981b-xiangsi-hg3000ax-emmc.dts
@@ -1,0 +1,239 @@
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "XIANGSI HG3000AX";
+	compatible = "xiangsi,hg3000-emmc", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_lan;
+		led-failsafe = &led_status_lan;
+		led-running = &led_status_lan;
+		led-upgrade = &led_status_lan;
+	};
+
+	memory {
+		reg = <0x00 0x40000000 0x00 0x20000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8  earlycon=uart8250,mmio32,0x11002000 root=/dev/mmcblk0p6 rw rootwait";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: red {
+			label = "amber:5g";
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: green {
+			label = "green:wlan";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: blue {
+			label = "green:5g";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_amber: wlan {
+			label = "amber:wlan";
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_lan: lan {
+			label = "green:lan";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_wan: wan {
+			label = "amber:gbe";
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_default>;
+	pinctrl-1 = <&mmc0_pins_uhs>;
+	bus-width = <8>;
+	max-frequency = <52000000>;
+	cap-mmc-highspeed;
+	vmmc-supply = <&reg_3p3v>;
+	non-removable;
+	status = "okay";
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+			partitions {
+				block-partition-env {
+					partname = "u-boot-env";
+
+					nvmem-layout {
+						compatible = "u-boot,env";
+					};
+				};
+
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x0 0x1000>;
+						};
+
+						macaddr_factory_4: macaddr@4 {
+							compatible = "mac-base";
+							reg = <0x4 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 0>;
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+	};
+};
+
+
+&mdio_bus {
+	switch: switch@0 {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	mmc0_pins_default: mmc0-pins-default {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+	mmc0_pins_uhs: mmc0-pins-uhs {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};

--- a/target/linux/mediatek/dts/mt7981b-xiangsi-hg3000ax-nand.dts
+++ b/target/linux/mediatek/dts/mt7981b-xiangsi-hg3000ax-nand.dts
@@ -1,0 +1,261 @@
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "XIANGSI HG3000AX";
+	compatible = "xiangsi,hg3000-nand", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_lan;
+		led-failsafe = &led_status_lan;
+		led-running = &led_status_lan;
+		led-upgrade = &led_status_lan;
+	};
+
+	memory {
+		reg = <0x00 0x40000000 0x00 0x20000000>;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: red {
+			label = "amber:5g";
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: green {
+			label = "green:wlan";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: blue {
+			label = "green:5g";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_amber: wlan {
+			label = "amber:wlan";
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_lan: lan {
+			label = "green:lan";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_wan: wan {
+			label = "amber:gbe";
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0xe280000>;
+			};
+
+			factory: partition@180000 {
+				label = "factory";
+				reg = <0x180000 0x200000>;
+			};
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00 0x100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	eeprom_factory_0: eeprom@0 {
+		reg = <0x0 0x1000>;
+	};
+
+	macaddr_factory_4: macaddr@004 {
+		compatible = "mac-base";
+		reg = <0x004 0x6>;
+		#nvmem-cell-cells = <1>;
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 0>;
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+	};
+};
+
+&mdio_bus {
+	switch: switch@0 {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -117,6 +117,13 @@ wavlink,wl-wn586x3)
 	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-2" "lan2" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
 	;;
+xiangsi,hg3000-emmc|\
+xiangsi,hg3000-nand)
+	ucidef_set_led_netdev "wanact" "WANACT" "amber:gbe" "eth1"
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "amber:wlan" "phy0-ap0"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan" "phy1-ap0"
+	;;
 xiaomi,mi-router-wr30u-stock|\
 xiaomi,mi-router-wr30u-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -118,6 +118,10 @@ mediatek_setup_interfaces()
 	tplink,re6000xd)
 		ucidef_set_interface_lan "lan1 lan2 eth1"
 		;;
+	xiangsi,hg3000-emmc|\
+	xiangsi,hg3000-nand)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
+		;;
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-ax3000t-ubootmod|\
 	xiaomi,mi-router-wr30u-stock|\

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -32,6 +32,33 @@ preinit_set_mac_address() {
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		ip link set dev eth1 address "$(macaddr_add $addr 1)"
 		;;
+	xiangsi,hg3000-emmc)
+		base_mac=$(mmc_get_mac_binary factory 0x04)
+		lan1_mac=$(macaddr_add $base_mac 1)
+		lan2_mac=$(macaddr_add $base_mac 2)
+		lan3_mac=$(macaddr_add $base_mac 3)
+		lan4_mac=$(macaddr_add $base_mac 4)
+		eth1_mac=$(macaddr_add $base_mac 6)
+		ip link set dev lan1 address "$lan1_mac"
+		ip link set dev lan2 address "$lan2_mac"
+		ip link set dev lan3 address "$lan3_mac"
+		ip link set dev lan4 address "$lan4_mac"
+		ip link set dev eth1 address "$eth1_mac"
+		;;
+	xiangsi,hg3000-nand)
+		# base_mac=$(mtd_get_mac_binary factory 0x04)
+		base_mac=$(get_mac_binary "/proc/device-tree/soc/ethernet@15100000/mac@0/mac-address" 0)
+		lan1_mac=$(macaddr_add $base_mac 1)
+		lan2_mac=$(macaddr_add $base_mac 2)
+		lan3_mac=$(macaddr_add $base_mac 3)
+		lan4_mac=$(macaddr_add $base_mac 4)
+		eth1_mac=$(macaddr_add $base_mac 6)
+		ip link set dev lan1 address "$lan1_mac"
+		ip link set dev lan2 address "$lan2_mac"
+		ip link set dev lan3 address "$lan3_mac"
+		ip link set dev lan4 address "$lan4_mac"
+		ip link set dev eth1 address "$eth1_mac"
+		;;
 	*)
 		;;
 	esac

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -155,6 +155,12 @@ platform_do_upgrade() {
 			;;
 		esac
 		;;
+	xiangsi,hg3000-emmc)
+		emmc_do_upgrade "$1"
+		;;
+	xiangsi,hg3000-nand)
+		nand_do_upgrade "$1"
+		;;
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-wr30u-stock|\
 	xiaomi,redmi-router-ax6000-stock)
@@ -184,6 +190,15 @@ platform_check_image() {
 	cmcc,rax3000m)
 		[ "$magic" != "d00dfeed" ] && {
 			echo "Invalid image type."
+			return 1
+		}
+		return 0
+		;;
+	xiangsi,hg3000-emmc|\
+	xiangsi,hg3000-nand)
+		magic="$(dd if="$1" bs=1 skip=257 count=5 2>/dev/null)"
+		[ "$magic" != "ustar" ] && {
+			log "Invalid image type."
 			return 1
 		}
 		return 0

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1438,6 +1438,42 @@ define Device/wavlink_wl-wn586x3
 endef
 TARGET_DEVICES += wavlink_wl-wn586x3
 
+define Device/xiangsi_hg3000ax-emmc
+  DEVICE_VENDOR := XIANGSI
+  DEVICE_MODEL := HG3000AX-EMMC
+  DEVICE_DTS := mt7981b-xiangsi-hg3000ax-emmc
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES += xiangsi,hg3000-emmc
+  DEVICE_PACKAGES := mkf2fs e2fsprogs blkid blockdev losetup kmod-fs-ext4 \
+    kmod-mmc kmod-fs-f2fs kmod-fs-vfat kmod-nls-cp437 \
+    kmod-nls-iso8859-1 kmod-mt7915e kmod-mt7981-firmware \
+    mt7981-wo-firmware kmod-rtc-pcf8563 kmod-usb3 kmod-nvme kmod-phy-airoha-en8811h
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += xiangsi_hg3000ax-emmc
+
+define Device/xiangsi_hg3000ax-nand
+  DEVICE_VENDOR := XIANGSI
+  DEVICE_MODEL := HG3000AX-NAND
+  DEVICE_DTS := mt7981b-xiangsi-hg3000ax-nand
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES += xiangsi,hg3000-nand
+  DEVICE_PACKAGES := mkf2fs e2fsprogs blkid blockdev losetup kmod-fs-ext4 \
+    kmod-mmc kmod-fs-f2fs kmod-fs-vfat kmod-nls-cp437 \
+    kmod-nls-iso8859-1 kmod-mt7915e kmod-mt7981-firmware kmod-usb2 kmod-usb3\
+    mt7981-wo-firmware kmod-rtc-pcf8563 kmod-nvme kmod-phy-airoha-en8811h
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS := initramfs-factory.ubi
+  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-kernel.bin | ubinize-kernel
+  endif
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += xiangsi_hg3000ax-nand
+
 define Device/xiaomi_mi-router-ax3000t
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router AX3000T


### PR DESCRIPTION
XIANGSI HG3000-EMMC and HG3000-NAND are industry 5G CPEs

Specifications:
- MediaTek MT7981b
- 512MB DDR3
- 256MB SPI-Nand Flash or 120GB EMMC
- Mediatek MT7981b DBDC 802.11ax 2.4/5 GHz
- MediaTek MT7531 Switch, 1WAN+4LAN 1000M adaptive network port 
- FIBOCOM_FM650-CN with 1 nano SIM slot
- 1 USB 3.0
- UART with 3.3V, TX, RX, GND / 115200 8N1

Installation:
1. Keep reset button pressed during power on
2. Open Uboot Web UI at http://192.168.1.1
3. Select the OpenWrt sysupgrade image and upgrade
4. Wait for the CPE to flash new image and reboot

The OEM firmware is also OpenWrt based, therefore
it is feasible to revert to OEM firmware with above method

Signed-off-by: liszhu <zhongcv@yeah.net>
