### PR TITLE
[WIP] base-files: add support for LED pattern trigger

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -423,23 +423,25 @@ generate_led() {
 			EOF
 		;;
 
-		usb)
-			local device
-			json_get_vars device
+		pattern)
+			local pattern patternon patternoff repeat brightness
+			json_get_vars pattern patternon patternoff repeat brightness
 			uci -q batch <<-EOF
-				set system.$cfg.trigger='usbdev'
-				set system.$cfg.interval='50'
-				set system.$cfg.dev='$device'
+				set system.$cfg.trigger='$type'
+				set system.$cfg.pattern='$pattern'
+				set system.$cfg.patternon='$patternon'
+				set system.$cfg.patternoff='$patternoff'
+				set system.$cfg.repeat='$repeat'
+				set system.$cfg.brightness='$brightness'
 			EOF
 		;;
 
-		usbport)
-			local ports port
-			json_get_values ports ports
-			uci set system.$cfg.trigger='usbport'
-			for port in $ports; do
-				uci add_list system.$cfg.port=$port
-			done
+		portstate)
+			local port_state
+			json_get_vars port_state
+			uci -q batch <<-EOF
+				set system.$cfg.port_state='$port_state'
+			EOF
 		;;
 
 		rssi)
@@ -465,27 +467,6 @@ generate_led() {
 			EOF
 		;;
 
-		pattern)
-			local pattern patternon patternoff repeat brightness
-			json_get_vars pattern patternon patternoff repeat brightness
-			uci -q batch <<-EOF
-				set system.$cfg.trigger='$type'
-				set system.$cfg.pattern='$pattern'
-				set system.$cfg.patternon='$patternon'
-				set system.$cfg.patternoff='$patternoff'
-				set system.$cfg.repeat='$repeat'
-				set system.$cfg.brightness='$brightness'
-			EOF
-		;;
-
-		portstate)
-			local port_state
-			json_get_vars port_state
-			uci -q batch <<-EOF
-				set system.$cfg.port_state='$port_state'
-			EOF
-		;;
-
 		timer|oneshot)
 			local delayon delayoff
 			json_get_vars delayon delayoff
@@ -494,6 +475,25 @@ generate_led() {
 				set system.$cfg.delayon='$delayon'
 				set system.$cfg.delayoff='$delayoff'
 			EOF
+		;;
+
+		usb)
+			local device
+			json_get_vars device
+			uci -q batch <<-EOF
+				set system.$cfg.trigger='usbdev'
+				set system.$cfg.interval='50'
+				set system.$cfg.dev='$device'
+			EOF
+		;;
+
+		usbport)
+			local ports port
+			json_get_values ports ports
+			uci set system.$cfg.trigger='usbport'
+			for port in $ports; do
+				uci add_list system.$cfg.port=$port
+			done
 		;;
 	esac
 

--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -465,6 +465,19 @@ generate_led() {
 			EOF
 		;;
 
+		pattern)
+			local pattern patternon patternoff repeat brightness
+			json_get_vars pattern patternon patternoff repeat brightness
+			uci -q batch <<-EOF
+				set system.$cfg.trigger='$type'
+				set system.$cfg.pattern='$pattern'
+				set system.$cfg.patternon='$patternon'
+				set system.$cfg.patternoff='$patternoff'
+				set system.$cfg.repeat='$repeat'
+				set system.$cfg.brightness='$brightness'
+			EOF
+		;;
+
 		portstate)
 			local port_state
 			json_get_vars port_state

--- a/package/base-files/files/etc/init.d/led
+++ b/package/base-files/files/etc/init.d/led
@@ -128,6 +128,11 @@ load_led() {
 			return 1
 		}
 		case "$trigger" in
+		"gpio")
+			echo $gpio > /sys/class/leds/${sysfs}/gpio
+			echo $inverted > /sys/class/leds/${sysfs}/inverted
+			;;
+
 		"heartbeat")
 			echo "${inverted}" > "/sys/class/leds/${sysfs}/invert"
 			;;
@@ -141,21 +146,6 @@ load_led() {
 				done
 				echo $interval > /sys/class/leds/${sysfs}/interval 2>/dev/null
 			}
-			;;
-
-		"timer"|"oneshot")
-			[ -n "$delayon" ] && \
-				echo $delayon > /sys/class/leds/${sysfs}/delay_on
-			[ -n "$delayoff" ] && \
-				echo $delayoff > /sys/class/leds/${sysfs}/delay_off
-			;;
-
-		"usbport")
-			local p
-
-			for p in $ports; do
-				echo 1 > /sys/class/leds/${sysfs}/ports/$p
-			done
 			;;
 
 		"pattern")
@@ -179,11 +169,6 @@ load_led() {
 				echo $port_state > /sys/class/leds/${sysfs}/port_state
 			;;
 
-		"gpio")
-			echo $gpio > /sys/class/leds/${sysfs}/gpio
-			echo $inverted > /sys/class/leds/${sysfs}/inverted
-			;;
-
 		switch[0-9]*)
 			local port_mask speed_mask
 
@@ -195,6 +180,21 @@ load_led() {
 				echo $speed_mask > /sys/class/leds/${sysfs}/speed_mask
 			[ -n "$mode" ] && \
 				echo "$mode" > /sys/class/leds/${sysfs}/mode
+			;;
+
+		"timer"|"oneshot")
+			[ -n "$delayon" ] && \
+				echo $delayon > /sys/class/leds/${sysfs}/delay_on
+			[ -n "$delayoff" ] && \
+				echo $delayoff > /sys/class/leds/${sysfs}/delay_off
+			;;
+
+		"usbport")
+			local p
+
+			for p in $ports; do
+				echo 1 > /sys/class/leds/${sysfs}/ports/$p
+			done
 			;;
 		esac
 	}

--- a/package/base-files/files/etc/init.d/led
+++ b/package/base-files/files/etc/init.d/led
@@ -52,6 +52,10 @@ load_led() {
 	local delayoff
 	local interval
 	local brightness
+	local pattern
+	local patternon
+	local patternoff
+	local repeat
 
 	config_get sysfs $1 sysfs
 	config_get name $1 name "$sysfs"
@@ -69,6 +73,10 @@ load_led() {
 	config_get gpio $1 gpio "0"
 	config_get_bool inverted $1 inverted "0"
 	config_get brightness $1 brightness
+	config_get pattern $1 pattern
+	config_get patternon $1 patternon ""
+	config_get patternoff $1 patternoff ""
+	config_get repeat $1 repeat "-1"
 
 	[ "$2" ] && [ "$sysfs" != "$2" ] && return
 
@@ -148,6 +156,22 @@ load_led() {
 			for p in $ports; do
 				echo 1 > /sys/class/leds/${sysfs}/ports/$p
 			done
+			;;
+
+		"pattern")
+			# brightness needs setting again because pattern is echoed to trigger after
+			# brightness is set, which resets it to 0 on the pattern trigger
+			[ -z "$brightness" ] && brightness="$(cat /sys/class/leds/${sysfs}/max_brightness)"
+			echo "$brightness" > /sys/class/leds/${sysfs}/brightness
+			[ -n "$pattern" ] && {
+				[ "$default" = 0 ] && \
+					echo $patternoff > /sys/class/leds/${sysfs}/${pattern}
+				[ "$default" = 1 ] && {
+					echo $patternon > /sys/class/leds/${sysfs}/${pattern}
+					sleep 1s # quick hack to overcome latency/work queue issue under investigation
+					echo $repeat > /sys/class/leds/${sysfs}/repeat
+				}
+			}
 			;;
 
 		"port_state")

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -485,6 +485,29 @@ ucidef_set_led_oneshot() {
 	_ucidef_set_led_timer $1 $2 $3 "oneshot" $4 $5
 }
 
+ucidef_set_led_pattern() {
+	local default="${4:-0}"
+	local pattern="$5"
+	local patternon="$6"
+	local patternoff="$7"
+	local repeat="$8"
+	local brightness="$9"
+
+	_ucidef_set_led_common "$1" "$2" "$3"
+	
+	json_add_string type pattern
+	json_add_string trigger pattern
+	json_add_int default "$default"
+	json_add_string pattern "$pattern"
+	json_add_string patternon "$patternon"
+	json_add_string patternoff "$patternoff"
+	json_add_string repeat "$repeat"
+	json_add_string brightness "$brightness"
+	json_select ..
+
+	json_select ..
+}
+
 ucidef_set_led_portstate() {
 	local port_state="$4"
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-homewrk.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-homewrk.dts
@@ -37,6 +37,35 @@
 	};
 };
 
+&blsp1_i2c2 {
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
 &dp2 {
 	status = "okay";
 	phy-handle = <&qca8075_1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
@@ -11,6 +11,35 @@
 	compatible = "linksys,mx4200v1", "qcom,ipq8074";
 };
 
+&blsp1_i2c2 {
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
 &wifi {
 	status = "okay";
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v2.dts
@@ -10,6 +10,35 @@
 	compatible = "linksys,mx4200v2", "qcom,ipq8074";
 };
 
+&blsp1_i2c2 {
+
+	led-controller@58 {
+		compatible = "st,led1202";
+		reg = <0x58>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		led_system_green: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			linux,default-trigger = "pattern";
+		};
+		led_system_red: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			linux,default-trigger = "pattern";
+		};
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			linux,default-trigger = "pattern";
+		};
+	};
+};
+
 &wifi {
 	status = "okay";
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4300.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4300.dts
@@ -242,6 +242,35 @@
 	};
 };
 
+&blsp1_i2c2 {
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
 &dp2 {
 	status = "okay";
 	phy-handle = <&qca8075_1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4x00.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4x00.dtsi
@@ -94,32 +94,6 @@
 
 &blsp1_i2c2 {
 	status = "okay";
-
-	led-controller@62 {
-		compatible = "nxp,pca9633";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <0x62>;
-		nxp,hw-blink;
-
-		led_system_red: led@0 {
-			reg = <0>;
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led_system_green: led@1 {
-			reg = <1>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led_system_blue: led@2 {
-			reg = <2>;
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_STATUS;
-		};
-	};
 };
 
 &mdio {

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -182,7 +182,6 @@ define Device/linksys_mx
 	SOC := ipq8072
 	IMAGES += factory.bin
 	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=$$$$(DEVICE_MODEL)
-	DEVICE_PACKAGES := kmod-leds-pca963x
 endef
 
 define Device/linksys_mx4x00
@@ -195,13 +194,15 @@ define Device/linksys_mx4200v1
 	$(call Device/linksys_mx4x00)
 	DEVICE_MODEL := MX4200
 	DEVICE_VARIANT := v1
-	DEVICE_PACKAGES += kmod-bluetooth
+	DEVICE_PACKAGES += kmod-bluetooth kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx4200v1
 
 define Device/linksys_mx4200v2
-	$(call Device/linksys_mx4200v1)
+	$(call Device/linksys_mx4x00)
+	DEVICE_MODEL := MX4200
 	DEVICE_VARIANT := v2
+	DEVICE_PACKAGES += kmod-bluetooth kmod-leds-st1202
 endef
 TARGET_DEVICES += linksys_mx4200v2
 
@@ -213,6 +214,7 @@ define Device/linksys_mx4300
 	KERNEL_SIZE := 8192k
 	IMAGE_SIZE := 171264k
 	NAND_SIZE := 1024m
+	DEVICE_PACKAGES += kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx4300
 
@@ -220,7 +222,7 @@ define Device/linksys_mx5300
 	$(call Device/linksys_mx)
 	DEVICE_MODEL := MX5300
 	DEVICE_PACKAGES += kmod-rtc-ds1307 ipq-wifi-linksys_mx5300 \
-		kmod-ath10k-ct ath10k-firmware-qca9984-ct
+		kmod-ath10k-ct ath10k-firmware-qca9984-ct kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx5300
 
@@ -228,7 +230,7 @@ define Device/linksys_mx8500
 	$(call Device/linksys_mx)
 	DEVICE_MODEL := MX8500
 	DEVICE_PACKAGES += ipq-wifi-linksys_mx8500 kmod-ath11k-pci \
-		ath11k-firmware-qcn9074 kmod-bluetooth
+		ath11k-firmware-qcn9074 kmod-bluetooth kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx8500
 

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -23,6 +23,11 @@ dynalink,dl-wrx36)
 edgecore,eap102)
 	ucidef_set_led_netdev "wan" "WAN" "green:wanpoe" "wan"
 	;;
+linksys,mx4200v2)
+	ucidef_set_led_pattern "red" "red" "red:status" 0 "hw_pattern" "225 1000" "" "-1" "255"
+	ucidef_set_led_pattern "green" "green" "green:status" 0 "hw_pattern" "225 1000" "" "-1" "255"
+	ucidef_set_led_pattern "blue" "blue" "blue:status" 1 "hw_pattern" "225 1000" "" "-1" "255"
+	;;
 netgear,rax120v2)
 	ucidef_set_led_netdev "aqr" "AQR" "white:aqr" "lan5"
 	;;


### PR DESCRIPTION
LED pattern triggers are not currently supported by OpenWrt. This PR brings support for those with a view to make adjustments based on real-life use and feedback received from the community.

Please note that while this message is brief, there is a lot more detail in the commit messages. I will update this one once the changes near their final form.

Meanwhile, the wording going to OpenWrt's documentation would be something along these lines:

**Pattern**

The LED changes brightness according to a specified pattern, traversing the series and each brightness value for the
value for the specified duration, either indefinite or a number of times. It is driver-dependant and can produce more sophisticated visuals such a glowing pulse.

| Name    | Type | Required | Default | Description|
| --------    | -------- | -------- | -------- | --------|
| trigger | string | yes | (none) | pattern|
| sysfs | string | yes | (none) | sysfs LED device name |
| default | integer | no | 0 | LED turn action: 0 means OFF and 1 means ON|
| pattern | string | yes | (none) | pattern type (pattern, hr_pattern, hw_pattern) |
| patternon | string | no | empty | pattern to turn ON LED. Depends on trigger and driver. Usually tuple of brightness and duration |
| patternoff | string | no | empty | pattern to turn OFF LED. Depends on trigger and driver. Usually tuple of brightness and duration|
| repeat | integer | yes | -1 | number of times to repeat the pattern. Depends on trigger and driver. -1 is indefinite for all|
| brightness | integer | no | max_brightness | brightness for the LED. pattern brightness is relative to this |