### PR TITLE
sax1v1k: add missing wan LED support

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-sax1v1k.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-sax1v1k.dts
@@ -137,6 +137,27 @@
 		reg = <28>;
 		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
 		reset-deassert-us = <10000>;
+		
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_YELLOW>;
+				function = LED_FUNCTION_WAN;
+				default-state = "keep";
+				active-low;
+			};
+
+			led@1 {
+				reg = <1>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+				default-state = "keep";
+				active-low;
+			};
+		};
 	};
 };
 

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -16,6 +16,9 @@ asus,rt-ax89x)
 	ucidef_set_led_netdev "sfp" "SFP" "white:sfp" "10g-sfp"
 	ucidef_set_led_netdev "wan" "WAN" "white:wan" "wan"
 	;;
+spectrum,sax1v1k)
+	ucidef_set_led_netdev "wan-port-link-yellow" "WAN-PORT-LINK-YELLOW" "90000.mdio-1:1c:yellow:wan" "wan" "tx rx link_10 link_100 link_1000 link_2500"
+	;;
 dynalink,dl-wrx36)
 	ucidef_set_led_netdev "wan-port-link-green" "WAN-PORT-LINK-GREEN" "90000.mdio-1:1c:green:wan" "wan" "link_2500"
 	ucidef_set_led_netdev "wan-port-link-yellow" "WAN-PORT-LINK-YELLOW" "90000.mdio-1:1c:yellow:wan" "wan" "tx rx link_10 link_100 link_1000"


### PR DESCRIPTION
Spectrum SAX1V1K Wan LED both light up before plugging in the ethernet cable and the network activity doesn't make them blink, this commit fixed the problem. The light up status of both LED indicates connection speed and the yellow one indicates traffic activity.

Signed-off-by: Signed-off-by: iv7777 hongba@rocketmail.com