### PR TITLE
netifd: handle missing packet_steering option as disabled

### DIFF
--- a/package/network/config/netifd/files/etc/init.d/packet_steering
+++ b/package/network/config/netifd/files/etc/init.d/packet_steering
@@ -20,6 +20,6 @@ reload_service() {
 	if [ -e "/usr/libexec/platform/packet-steering.sh" ]; then
 		/usr/libexec/platform/packet-steering.sh "$packet_steering"
 	else
-		/usr/libexec/network/packet-steering.uc $opts "$packet_steering"
+		/usr/libexec/network/packet-steering.uc $opts "${packet_steering:-0}"
 	fi
 }


### PR DESCRIPTION
By default, and when explicitly disabled via LUCI, the packet_steering option is not present in the network config file; in this case /usr/libexec/network/packet_steering.uc is presented with an empty argument which it treats as "enabled" (i.e. packet_steering='1').

Remedy this by passing a '0' value if the argument is empty.

Fixes: #17611 