### PR TITLE
ath79: support Mikrotik RouterBOARD 2011-UiAS-2HnD

### DIFF
--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-2011uias-2hnd.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-2011uias-2hnd.dts
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "MikroTik RouterBOARD 2011UiAS-2HnD";
+	compatible = "mikrotik,routerboard-2011uias-2hnd", "qca,ar9344";
+
+	aliases {
+		led-boot = &led_user;
+		led-failsafe = &led_user;
+		led-running = &led_user;
+		led-upgrade = &led_user;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		poe-in {
+			label = "poe-in";
+			linux,input-type = <EV_SW>;
+			linux,code = <BTN_1>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	beeper {
+		compatible = "gpio-beeper";
+		gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp_i2c: i2c-gpio {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		pictrl-names = "default";
+		pinctrl-0 = <&pmx_sfp_i2c>;
+
+		sda-gpios = <&gpio 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+	};
+
+	sfp {
+		/*
+		 * SFP port attached throug AR8327 port 6 isn't functional for now
+		 * The module detects sucessfully, but lacks some GPIO definitions,
+		 * and proper SGMII configuration isn't known yet.
+		 */
+		compatible = "sff,sfp";
+		i2c-bus = <&sfp_i2c>;
+		los-gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <25000000>;
+};
+
+&gpio {
+	nand-nce {
+		gpio-hog;
+		gpios = <14 GPIO_ACTIVE_LOW>;
+		output-high;
+		line-name = "nand-nce";
+	};
+};
+
+&nand {
+	status = "okay";
+
+	nand-ecc-mode = "soft";
+	nand-ecc-step-size = <2048>;
+	qca,nand-swap-dma;
+	qca,nand-scan-fixup;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "booter";
+			reg = <0x0000000 0x0040000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "kernel";
+			reg = <0x0040000 0x03c0000>;
+		};
+
+		partition@400000 {
+			label = "ubi";
+			reg = <0x0400000 0x0>;
+		};
+	};
+};
+
+&pinmux {
+	pmx_sfp_i2c: pinmux_sfp_i2c {
+		pinctrl-single,bits = <0x8 0x00000000 0xff000000>; /* set GPIO11 back as GPIO */
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "mikrotik,routerboot-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "routerboot";
+				reg = <0x0 0x0>;
+				read-only;
+			};
+
+			hard_config {
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_hardconfig_10: macaddr@10 {
+						compatible = "mac-base";
+						reg = <0x10 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			bios {
+				size = <0x1000>;
+				read-only;
+			};
+
+			soft_config {
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+	switch@1f {
+		compatible = "qca,ar8327";
+		reg = <0x1f>;
+
+		qca,ar8327-initvals = <
+			0x04 0x07c00000 /* PORT0 PAD MODE CTRL: Mac0_rgmii_en | Mac0_rgmii_txclk_delay_en | Mac0_rgmii_rxclk_delay_en | Mac0_rgmii_txclk_delay_sel3 | Mac0_rgmii_rxclk_delay_sel0 */
+			0x0c 0x00000080 /* PORT6 PAD MODE CTRL: Mac6_sgmii_en */
+			0x10 0x81000000 /* PWS_REG: POWER_ON_STRAP | LED_OPEN_EN_CSR */
+			0x50 0xc731c731 /* LED_CTRL0 */
+			0x54 0x00000000 /* LED_CTRL1 */
+			0x5c 0x0230c300 /* LED_CTRL3: 5C: enable SFP power */
+			0x7c 0x0000007e /* PORT0_STATUS: DUPLEX_MODE_0 | RX_FLOW_EN_0 | TX_FLOW_EN_0 | RXMAC_EN_0 | TXMAC_EN_0 | SPEED_0 1000M */
+			0x94 0x0000007e /* PORT6_STATUS: DUPLEX_MODE_0 | RX_FLOW_EN_0 | TX_FLOW_EN_0 | RXMAC_EN_0 | TXMAC_EN_0 | SPEED_0 1000M */
+			0xe0 0xc701e7d0 /* SGMII_CTRL */
+			>;
+
+		leds {
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = "eth";
+				function-enumerator = <1>;
+				qca,led-mode = <0>;
+			};
+
+			led@1 {
+				reg = <1>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = "eth";
+				function-enumerator = <6>;
+				qca,led-mode = <1>;
+			};
+
+			lcd_backlight: led@2 {
+				reg = <2>;
+				color = <LED_COLOR_ID_WHITE>;
+				function = LED_FUNCTION_BACKLIGHT;
+				linux,default-trigger = "backlight";
+				active-low;
+				qca,led-mode = <1>;
+			};
+
+			led@3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = "eth";
+				function-enumerator = <2>;
+				qca,led-mode = <0>;
+			};
+
+			led@4 {
+				reg = <4>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = "eth";
+				function-enumerator = <7>;
+				qca,led-mode = <1>;
+			};
+
+			led@6 {
+				reg = <6>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = "eth";
+				function-enumerator = <3>;
+				qca,led-mode = <0>;
+			};
+
+			led@7 {
+				reg = <7>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = "eth";
+				function-enumerator = <8>;
+				qca,led-mode = <1>;
+			};
+
+			led@9 {
+				reg = <9>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = "eth";
+				function-enumerator = <4>;
+				qca,led-mode = <0>;
+			};
+
+			led@10 {
+				reg = <10>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = "eth";
+				function-enumerator = <9>;
+				qca,led-mode = <1>;
+			};
+
+			led@12 {
+				reg = <12>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = "eth";
+				function-enumerator = <5>;
+				qca,led-mode = <0>;
+			};
+
+			led@13 {
+				reg = <13>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = "eth";
+				function-enumerator = <10>;
+				qca,led-mode = <1>;
+			};
+
+			led_user: led@14 {
+				reg = <14>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = "user";
+				qca,led-mode = <1>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	/* default for ar934x, except for 1000M */
+	pll-data = <0x6f000000 0x00000101 0x00001616>;
+
+	phy-mode = "rgmii";
+
+	nvmem-cells = <&macaddr_hardconfig_10 0>;
+	nvmem-cell-names = "mac-address";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+		switch-phy-swap = <0>;
+		switch-only-mode = <1>;
+		rxd-delay = <1>;
+		rxdv-delay = <1>;
+	};
+};
+
+&builtin_switch {
+	/delete-property/ qca,phy4-mii-enable;
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_hardconfig_10 5>;
+	nvmem-cell-names = "mac-address";
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	qca,no-eeprom;
+};

--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -1,5 +1,16 @@
 include ./common-mikrotik.mk
 
+define Device/mikrotik_routerboard-2011uias-2hnd
+  $(Device/mikrotik_nand)
+  SOC := ar9344
+  DEVICE_MODEL := RouterBOARD 2011UiAS-2HnD
+  DEVICE_PACKAGES += kmod-usb2 kmod-i2c-gpio kmod-sfp kmod-gpio-beeper
+  SUPPORTED_DEVICES += rb-2011l rb-2011il rb-2011ils \
+	rb-2011uas rb-2011uas-2hnd rb-2011uias \
+	rb-2011uias-2hnd rb-2011uias-2hnd-r2
+endef
+TARGET_DEVICES += mikrotik_routerboard-2011uias-2hnd
+
 define Device/mikrotik_routerboard-493g
   $(Device/mikrotik_nand)
   SOC := ar7161

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/01_leds
@@ -6,6 +6,13 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+mikrotik,routerboard-2011uias-2hnd)
+	ucidef_set_led_switch "eth6" "eth6" "green:eth-6" "switch1" "0x20"
+	ucidef_set_led_switch "eth7" "eth7" "green:eth-7" "switch1" "0x10"
+	ucidef_set_led_switch "eth8" "eth8" "green:eth-8" "switch1" "0x08"
+	ucidef_set_led_switch "eth9" "eth9" "green:eth-9" "switch1" "0x04"
+	ucidef_set_led_switch "eth10" "eth10" "green:eth-10" "switch1" "0x02"
+	;;
 mikrotik,routerboard-911-lite|\
 mikrotik,routerboard-lhg-5nd)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -7,6 +7,12 @@ ath79_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
+	mikrotik,routerboard-2011uias-2hnd)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan" "3:lan" "4:lan" "5:lan" "6:lan" "1:wan"
+		ucidef_add_switch "switch1" \
+			"0@eth1" "1:lan:5" "2:lan:4" "3:lan:3" "4:lan:2" "5:lan:1"
+		;;
 	mikrotik,routerboard-493g)
 		ucidef_set_interfaces_lan_wan "eth0.1 eth1.1" "eth0.2"
 		ucidef_add_switch "switch0" \
@@ -76,6 +82,7 @@ ath79_setup_macs()
 		label_mac="$mac_base"
 		lan_mac="$mac_base"
 		;;
+	mikrotik,routerboard-2011uias-2hnd|\
 	mikrotik,routerboard-921gs-5hpacd-15s|\
 	mikrotik,routerboard-922uags-5hpacd)
 		label_mac="$mac_base"

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/03_gpio_switches
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2025 OpenWrt.org
+#
+
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+
+case "$board" in
+mikrotik,routerboard-2011uias-2hnd)
+	ucidef_add_gpio_switch "usb_power_n" "USB host power" "532" "0"
+	ucidef_add_gpio_switch "poe_port10_out_power" "PoE outuput on port 10" "514" "1"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/05_compat-version
@@ -6,6 +6,7 @@
 board_config_update
 
 case "$(board_name)" in
+	mikrotik,routerboard-2011uias-2hnd|\
 	mikrotik,routerboard-493g|\
 	mikrotik,routerboard-911g-5hpacd|\
 	mikrotik,routerboard-911g-xhpnd|\

--- a/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/mikrotik/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -23,6 +23,9 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
+	mikrotik,routerboard-2011uias-2hnd)
+		caldata_mikrotik_ath9k 0x1000 0x440 $(macaddr_add "$mac_base" 11)
+		;;
 	mikrotik,routerboard-911-lite|\
 	mikrotik,routerboard-911g-xhpnd|\
 	mikrotik,routerboard-912uag-2hpnd|\

--- a/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
@@ -29,6 +29,7 @@ platform_do_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	mikrotik,routerboard-2011uias-2hnd|\
 	mikrotik,routerboard-493g|\
 	mikrotik,routerboard-911g-5hpacd|\
 	mikrotik,routerboard-911g-xhpnd|\


### PR DESCRIPTION
Mikrotik RouterBOARD 2011 series are AR9344-based wired routers, with
optional 2,4GHz 802.11n 2x2:2 Wi-Fi radio, with desktop or rack-mount
capability, featuring 5 gigabit Ethernet ports and 5 fast Ethernet
ports. Different variants of the board are supported using a single
image.
Bare-bones RouterBOARD 2011LS is supported using the same image.

Specification:
- Power: 10-28V input via 5,5/2,1 DC barrel jack, or terminal block on
  some boards
- CPU: AR9344 at 600 to 750MHz (configurable)
- RAM: 128MB (64MB in budget versions) DDR2
- Flash: 128MB (64MB in budget versions) NAND flash
- Gigabit Ethernet: 5 ports via AR8327 switch (eth1 to eth5)
- Fast Ethernet: 5 ports via AR9344 built-in switch (eth6 to eth10)
- SFP: single port through AR8327 switch (SGMII at port 6) - currently
  unsuppoorted
- PoE in: passive input up to 28V at eth1
- PoE out: passive output up to 28V at eth10
- USB: optional micro-AB host port or type-A host port
- Console: optional Cisco-style RS232 console at the back of the device,
  on budget devices available as 3.3V UART via testpoints
- LCD: 2" touchscreen-equipped LCD (unsupported)

Installation:
- perform TFTP boot of initramfs image as for netinstall procedure
  typical for Mikrotik devices
- when initramfs image boots, use sysupgrade to perform final
  installation.

If upgrading from ar71xx, clean installation should be performed, as the
devices now uses yafut to handle kernel image.

TODO:
- SFP port probes over I²C but neither link status information is
  available, nor data traffic or link establishment occurs.
- Unknown connection to display and touch panel, but some documentation
  is available (seemingly connected via SPI, according to Mikrotik's
  open source code at [1])

[1] https://github.com/robimarko/routeros-GPL

This PR depends on #12487, as all the front panel LEDs are controlled using AR8327 LED outputs.