### PR TITLE
lantiq-xrx200: fb7430 set correct label-mac

### DIFF
--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -125,6 +125,7 @@ lantiq_setup_macs()
 		tffsdev=$(find_mtd_chardev "nand-tffs")
 		lan_mac=$(/usr/bin/fritz_tffs_nand -d $tffsdev -n maca -o)
 		wan_mac=$(/usr/bin/fritz_tffs_nand -d $tffsdev -n macdsl -o)
+		label_mac=$lan_mac
 		;;
 	bt,homehub-v5a)
 		lan_mac=$(mtd_get_mac_binary_ubi caldata 0x110c)
@@ -142,6 +143,7 @@ lantiq_setup_macs()
 
 	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" "$lan_mac"
 	[ -n "$wan_mac" ] && ucidef_set_interface_macaddr "wan" "$wan_mac"
+	[ -n "$label_mac" ] && ucidef_set_label_macaddr "$label_mac"
 }
 
 board_config_update


### PR DESCRIPTION
After #15501 is merged, the label MAC address of the 7430 still requires a small fix.

The FB7430 has a CWMP-Account written on the back of it which includes the correct MAC-Address.
This is also set on the lan-interface correctly.

This is required for gluon to successfully retrieve the correct mac address