### PR TITLE
ath79: support ZTE MF286C + fix ath10k board files for ZTE MF281, MF286A/R

### DIFF
--- a/package/boot/uboot-envtools/files/ath79
+++ b/package/boot/uboot-envtools/files/ath79
@@ -176,6 +176,7 @@ wallys,dr531)
 	;;
 zte,mf286|\
 zte,mf286a|\
+zte,mf286c|\
 zte,mf286r)
 	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x20000" "0x10000"
 	;;

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -6,9 +6,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2025-02-16
-PKG_SOURCE_VERSION:=331dd0ead646f0d3fe38cb4bf83cce4b448343e8
-PKG_MIRROR_HASH:=f49b3acd56a1cf4a0d52413b060d6adbd65c2754b44cabe096fed69172febbb5
+PKG_SOURCE_DATE:=2025-02-17
+PKG_SOURCE_VERSION:=dd3577ec9f2d9d3ef5e35602d3fe731cb259ff39
+PKG_MIRROR_HASH:=72e749060f53cc1dbe34c56dccded7fc13224701e241c57cff3452cb050f9ce9
 PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/package.mk
@@ -72,6 +72,8 @@ ALLWIFIBOARDS:= \
 	yuncore_fap650 \
 	zbtlink_zbt-z800ax \
 	zte_mf269 \
+	zte_mf286ar\
+	zte_mf286c \
 	zte_mf287 \
 	zte_mf287plus \
 	zyxel_nbg7815
@@ -82,7 +84,7 @@ define Package/ipq-wifi-default
   SUBMENU:=ath10k Board-Specific Overrides
   SECTION:=firmware
   CATEGORY:=Firmware
-  DEPENDS:=@(TARGET_ipq40xx||TARGET_ipq806x||TARGET_qualcommax)
+  DEPENDS:=@(TARGET_ath79||TARGET_ipq40xx||TARGET_ipq806x||TARGET_qualcommax)
   TITLE:=Custom Board
 endef
 
@@ -213,6 +215,8 @@ $(eval $(call generate-ipq-wifi-package,yuncore_ax880,Yuncore AX880))
 $(eval $(call generate-ipq-wifi-package,yuncore_fap650,Yuncore FAP650))
 $(eval $(call generate-ipq-wifi-package,zbtlink_zbt-z800ax,Zbtlink ZBT-Z800AX))
 $(eval $(call generate-ipq-wifi-package,zte_mf269,ZTE MF269))
+$(eval $(call generate-ipq-wifi-package,zte_mf286ar,ZTE MF286A/R))
+$(eval $(call generate-ipq-wifi-package,zte_mf286c,ZTE MF286C))
 $(eval $(call generate-ipq-wifi-package,zte_mf287,ZTE MF287))
 $(eval $(call generate-ipq-wifi-package,zte_mf287plus,ZTE MF287Plus))
 $(eval $(call generate-ipq-wifi-package,zyxel_nbg7815,Zyxel NBG7815))

--- a/target/linux/ath79/dts/qca9563_zte_mf281.dts
+++ b/target/linux/ath79/dts/qca9563_zte_mf281.dts
@@ -158,6 +158,8 @@
 &wifi_ath10k {
 	nvmem-cells = <&macaddr_mac_0 1>, <&cal_caldata_5000>;
 	nvmem-cell-names = "mac-address", "pre-calibration";
+	/* Board file from stock firmware is shared with MF286C */
+	qcom,ath10k-calibration-variant = "ZTE-MF286C";
 };
 
 &pinmux {

--- a/target/linux/ath79/dts/qca9563_zte_mf286.dts
+++ b/target/linux/ath79/dts/qca9563_zte_mf286.dts
@@ -137,6 +137,7 @@
 &wifi_ath10k {
 	nvmem-cells = <&macaddr_mac_0 1>, <&cal_caldata_5000>, <&precal_caldata_5000>;
 	nvmem-cell-names = "mac-address", "calibration", "pre-calibration";
+	qcom,ath10k-calibration-variant = "ZTE-MF286AR";
 };
 
 &wmac {

--- a/target/linux/ath79/dts/qca9563_zte_mf286ar.dtsi
+++ b/target/linux/ath79/dts/qca9563_zte_mf286ar.dtsi
@@ -134,6 +134,7 @@
 &wifi_ath10k {
 	nvmem-cells = <&macaddr_mac_0 0x20000>, <&precal_art_5000>;
 	nvmem-cell-names = "mac-address", "pre-calibration";
+	qcom,ath10k-calibration-variant = "ZTE-MF286AR";
 };
 
 &wmac {

--- a/target/linux/ath79/dts/qca9563_zte_mf286c.dts
+++ b/target/linux/ath79/dts/qca9563_zte_mf286c.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Copyright (c) 2021 Cezary Jackiewicz
+// Copyright (c) 2021, 2022 Lech Perczak
+#include "qca9563_zte_mf286ar.dtsi"
+
+/ {
+	model = "ZTE MF286C";
+	compatible = "zte,mf286c", "qca,qca9563";
+};
+
+&wifi_ath10k {
+	qcom,ath10k-calibration-variant = "ZTE-MF286C";
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -458,6 +458,7 @@ define Device/zte_mf281
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
 	check-size
   DEVICE_PACKAGES += ath10k-firmware-qca9888-ct kmod-usb-net-rndis \
+	-ath10k-board-qca9888 ipq-wifi-zte_mf286c \
 	kmod-usb-acm comgt-ncm
 endef
 TARGET_DEVICES += zte_mf281

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -488,6 +488,15 @@ define Device/zte_mf286a
 endef
 TARGET_DEVICES += zte_mf286a
 
+define Device/zte_mf286c
+  $(Device/zte_mf28x_common)
+  DEVICE_MODEL := MF286C
+  DEVICE_PACKAGES += ath10k-firmware-qca9888-ct kmod-usb-net-qmi-wwan \
+	-ath10k-board-qca9888 ipq-wifi-zte_mf286c \
+	kmod-usb-serial-option uqmi
+endef
+TARGET_DEVICES += zte_mf286c
+
 define Device/zte_mf286r
   $(Device/zte_mf28x_common)
   DEVICE_MODEL := MF286R

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -474,6 +474,7 @@ define Device/zte_mf286
   $(Device/zte_mf28x_common)
   DEVICE_MODEL := MF286
   DEVICE_PACKAGES += ath10k-firmware-qca988x-ct ath10k-firmware-qca9888-ct \
+	-ath10k-board-qca9888 ipq-wifi-zte_mf286ar \
 	kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
 endef
 TARGET_DEVICES += zte_mf286
@@ -482,6 +483,7 @@ define Device/zte_mf286a
   $(Device/zte_mf28x_common)
   DEVICE_MODEL := MF286A
   DEVICE_PACKAGES += ath10k-firmware-qca9888-ct kmod-usb-net-qmi-wwan \
+	-ath10k-board-qca9888 ipq-wifi-zte_mf286ar \
 	kmod-usb-serial-option uqmi
 endef
 TARGET_DEVICES += zte_mf286a

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -73,6 +73,7 @@ ath79_setup_interfaces()
 		;;
 	zte,mf286|\
 	zte,mf286a|\
+	zte,mf286c|\
 	zte,mf286r)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "5:lan:1"

--- a/target/linux/ath79/nand/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/nand/base-files/etc/board.d/03_gpio_switches
@@ -10,6 +10,7 @@ board=$(board_name)
 
 case "$board" in
 zte,mf286a|\
+zte,mf286c|\
 zte,mf286r)
 	ucidef_add_gpio_switch "power_btn_block" "Power button blocker" "532" "0"
 	;;


### PR DESCRIPTION
ZTE MF286C is an indoor LTE category 12 CPE router with simultaneous
dual-band 802.11ac plus 802.11n Wi-Fi radios and quad-port gigabit
Ethernet switch, FXS and external USB 2.0 port.

Software-wise it's compatible with previous MF286A, save for different
5GHz Wi-Fi board definition file, requiring a separate image.

Hardware highlights:
- CPU: QCA9563 SoC at 775MHz,
- RAM: 128MB DDR2,
- NOR Flash: MX25L1606E 2MB SPI Flash, for U-boot only,
- NAND Flash: W25N01GV 128MB SPI NAND-Flash, for all other data,
- Wi-Fi 5GHz: QCA9886 2x2 MIMO 802.11ac Wave2 radio,
- WI-Fi 2.4GHz: QCA9563 3x3 MIMO 802.11n radio,
- Switch: QCA8337v2 4-port gigabit Ethernet, with single SGMII CPU port,
- WWAN: MDM9250-based category 12 internal LTE modem
  in extended  mini-PCIE form factor, with 3 internal antennas and
  2 external antenna connections, single mini-SIM slot.
- FXS: one external ATA port (handled entirely by modem part) with two
  physical connections in parallel,
- USB: Single external USB 2.0 port,
- Switches: power switch, WPS, Wi-Fi and reset buttons,
- LEDs: Wi-Fi, Test (internal). Rest of LEDs (Phone, WWAN, Battery,
  Signal state) handled entirely by modem. 4 link status LEDs handled by
  the switch on the backside.
- Label MAC device: eth0

Internal modem of MF286C is supported via uqmi.

Console connection: connector X2 is the console port, with the following
pinout, starting from pin 1, which is the topmost pin when the board is
upright:
- VCC (3.3V). Do not use unless you need to source power for the
  converer from it.
- TX
- RX
- GND
Default port configuration in U-boot as well as in stock firmware is
115200-8-N-1.

While at that - add board files for ZTE MF286A/R, and to MF281 (which shares it with MF286C). 