### PR TITLE
qualcommax: add missing WAN LED support to Spectrum SAX1V1K routers

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-sax1v1k.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-sax1v1k.dts
@@ -137,6 +137,27 @@
 		reg = <28>;
 		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
 		reset-deassert-us = <10000>;
+		
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_YELLOW>;
+				function = LED_FUNCTION_WAN;
+				default-state = "keep";
+				active-low;
+			};
+
+			led@2 {
+				reg = <2>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+				default-state = "keep";
+				active-low;
+			};
+		};
 	};
 };
 

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -16,7 +16,8 @@ asus,rt-ax89x)
 	ucidef_set_led_netdev "sfp" "SFP" "white:sfp" "10g-sfp"
 	ucidef_set_led_netdev "wan" "WAN" "white:wan" "wan"
 	;;
-dynalink,dl-wrx36)
+dynalink,dl-wrx36|\
+spectrum,sax1v1k)
 	ucidef_set_led_netdev "wan-port-link-green" "WAN-PORT-LINK-GREEN" "90000.mdio-1:1c:green:wan" "wan" "link_2500"
 	ucidef_set_led_netdev "wan-port-link-yellow" "WAN-PORT-LINK-YELLOW" "90000.mdio-1:1c:yellow:wan" "wan" "tx rx link_10 link_100 link_1000"
 	;;


### PR DESCRIPTION
Fixed an issue where both WAN LEDs light up before plugging in the ethernet cable and no blinking regardless of WAN network activity. Updated the LED configuration to reflect proper status:
- Green indicates connection speed.
- Yellow indicates traffic activity.

This resolves inconsistent WAN LED behavior on Spectrum SAX1V1K routers.

Signed-off-by:  Ivan Deng <hongba@rocketmail.com>
