### PR TITLE
mediatek-filogic: fix wax220 wifi leds

### DIFF
--- a/target/linux/mediatek/dts/mt7986b-netgear-wax220.dts
+++ b/target/linux/mediatek/dts/mt7986b-netgear-wax220.dts
@@ -67,6 +67,7 @@
 		wlan2g_blue {
 			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
 			label = "blue:wlan2g";
+			linux,default-trigger = "phy0tpt";
 		};
 
 		lan_green {
@@ -84,6 +85,7 @@
 		wlan5g_blue {
 			gpios = <&pio 2 GPIO_ACTIVE_LOW>;
 			label = "blue:wlan5g";
+			linux,default-trigger = "phy1tpt";
 		};
 	};
 };

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -66,8 +66,6 @@ mercusys,mr90x-v1-ubi)
 	;;
 netgear,wax220)
 	ucidef_set_led_netdev "eth0" "LAN" "green:lan" "eth0"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan2g" "phy0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan5g" "phy1-ap0"
 	;;
 nokia,ea0326gmp)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1" "link"


### PR DESCRIPTION
The WAX220 does have a 2.4GHz and 5GHz wifi led, which was set to trigger on netdev before.
This commit changes this to trigger on activity of the respective radio.