### PR TITLE
generic: mtk_eth_soc: reduce driver memory usage

### DIFF
--- a/target/linux/generic/pending-6.6/738-01-net-ethernet-mtk_eth_soc-reduce-rx-ring-size-for-older.patch
+++ b/target/linux/generic/pending-6.6/738-01-net-ethernet-mtk_eth_soc-reduce-rx-ring-size-for-older.patch
@@ -1,0 +1,104 @@
+From: Felix Fietkau <nbd@nbd.name>
+Subject: [PATCH net-next 3/4] net: ethernet: mtk_eth_soc: reduce rx ring size for older chipsets
+Date: Tue, 15 Oct 2024 13:09:37 +0200
+
+Commit c57e55819443 ("net: ethernet: mtk_eth_soc: handle dma buffer
+size soc specific") resolved some tx timeout issues by bumping FQ and
+tx ring sizes from 512 to 2048 entries (the value used in the MediaTek
+SDK), however it also changed the rx ring size for all chipsets in the
+same way.
+
+Based on a few tests, it seems that a symmetric rx/tx ring size of 2048
+really only makes sense on MT7988, which is capable of 10G ethernet links.
+
+Older chipsets are typically deployed in systems that are more memory
+constrained and don't actually need the larger rings to handle received
+packets.
+
+In order to reduce wasted memory set the ring size based on the SoC to
+the following values:
+- 2048 on MT7988
+- 1024 on MT7986
+- 512 (previous value) on everything else, except:
+- 256 on RT5350 (the oldest supported chipset)
+
+Fixes: c57e55819443 ("net: ethernet: mtk_eth_soc: handle dma buffer size soc specific")
+Signed-off-by: Felix Fietkau <nbd@nbd.name>
+---
+ drivers/net/ethernet/mediatek/mtk_eth_soc.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
++++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+@@ -5381,7 +5381,7 @@ static const struct mtk_soc_data mt2701_
+ 		.desc_size = sizeof(struct mtk_rx_dma),
+ 		.irq_done_mask = MTK_RX_DONE_INT,
+ 		.dma_l4_valid = RX_DMA_L4_VALID,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(512),
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+ 	},
+@@ -5409,7 +5409,7 @@ static const struct mtk_soc_data mt7621_
+ 		.desc_size = sizeof(struct mtk_rx_dma),
+ 		.irq_done_mask = MTK_RX_DONE_INT,
+ 		.dma_l4_valid = RX_DMA_L4_VALID,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(512),
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+ 	},
+@@ -5439,7 +5439,7 @@ static const struct mtk_soc_data mt7622_
+ 		.desc_size = sizeof(struct mtk_rx_dma),
+ 		.irq_done_mask = MTK_RX_DONE_INT,
+ 		.dma_l4_valid = RX_DMA_L4_VALID,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(512),
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+ 	},
+@@ -5468,7 +5468,7 @@ static const struct mtk_soc_data mt7623_
+ 		.desc_size = sizeof(struct mtk_rx_dma),
+ 		.irq_done_mask = MTK_RX_DONE_INT,
+ 		.dma_l4_valid = RX_DMA_L4_VALID,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(512),
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+ 	},
+@@ -5494,7 +5494,7 @@ static const struct mtk_soc_data mt7629_
+ 		.desc_size = sizeof(struct mtk_rx_dma),
+ 		.irq_done_mask = MTK_RX_DONE_INT,
+ 		.dma_l4_valid = RX_DMA_L4_VALID,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(512),
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+ 	},
+@@ -5526,7 +5526,7 @@ static const struct mtk_soc_data mt7981_
+ 		.dma_l4_valid = RX_DMA_L4_VALID_V2,
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(512),
+ 	},
+ };
+ 
+@@ -5556,7 +5556,7 @@ static const struct mtk_soc_data mt7986_
+ 		.dma_l4_valid = RX_DMA_L4_VALID_V2,
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(1K),
+ 	},
+ };
+ 
+@@ -5609,7 +5609,7 @@ static const struct mtk_soc_data rt5350_
+ 		.dma_l4_valid = RX_DMA_L4_VALID_PDMA,
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(256),
+ 	},
+ };
+ 

--- a/target/linux/generic/pending-6.6/738-02-net-ethernet-mtk_eth_soc-do-not-enable-pp-stats-by-def.patch
+++ b/target/linux/generic/pending-6.6/738-02-net-ethernet-mtk_eth_soc-do-not-enable-pp-stats-by-def.patch
@@ -1,0 +1,40 @@
+Author: Danila Romanov <pervokur@gmail.com>
+Date:   Thu Jan 19 13:55:21 2025 +0300
+
+There is no reason for it to be enabled by default.
+Align mtk_eth_soc driver to mt76 driver.
+
+From the Kconfig file:
+This option incurs additional CPU cost in allocation
+and recycle paths and additional memory cost to store
+the statistics.
+
+Signed-off-by: Danila Romanov <pervokur@gmail.com>
+--- a/drivers/net/ethernet/mediatek/Kconfig
++++ b/drivers/net/ethernet/mediatek/Kconfig
+@@ -18,7 +18,6 @@ config NET_MEDIATEK_SOC
+ 	select PHYLINK
+ 	select DIMLIB
+ 	select PAGE_POOL
+-	select PAGE_POOL_STATS
+ 	select PCS_MTK_LYNXI
+ 	select REGMAP_MMIO
+ 	help
+--- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
++++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+@@ -4552,6 +4552,7 @@ static int mtk_get_sset_count(struct net
+ 
+ static void mtk_ethtool_pp_stats(struct mtk_eth *eth, u64 *data)
+ {
++#ifdef CONFIG_PAGE_POOL_STATS
+ 	struct page_pool_stats stats = {};
+ 	int i;
+ 
+@@ -4564,6 +4565,7 @@ static void mtk_ethtool_pp_stats(struct
+ 		page_pool_get_stats(ring->page_pool, &stats);
+ 	}
+ 	page_pool_ethtool_stats_get(data, &stats);
++#endif
+ }
+ 
+ static void mtk_get_ethtool_stats(struct net_device *dev,


### PR DESCRIPTION
1. Import pending patch to fix ramips/mt7621 64MB devices,
which become broken after https://github.com/torvalds/linux/commit/c57e558194430d10d5e5f4acd8a8655b68dade13

https://lore.kernel.org/all/20241015110940.63702-3-nbd@nbd.name/

Older chipsets are typically deployed in systems that are more memory
constrained and don't actually need the larger rings to handle received
packets.

In order to reduce wasted memory set the ring size based on the SoC
to the following values:
- 2048 on MT7988
- 1024 on MT7986
- 512 (previous value) on everything else, except:
- 256 on RT5350 (the oldest supported chipset)

Fixes https://github.com/openwrt/openwrt/issues/17401
Fixes https://github.com/openwrt/openwrt/issues/16687
Fixes https://github.com/openwrt/openwrt/issues/16688

2. Further reduce memory usage by disabling CONFIG_PAGE_POOL_STATS
by default. Like it should be by default.

Signed-off-by: Danila Romanov <pervokur@gmail.com>