### PR TITLE
ramips: fixes for Keenetic KN-1711,1713,1910

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1804,11 +1804,10 @@ define Device/keenetic_kn-1910
   $(Device/uimage-lzma-loader)
   BLOCKSIZE := 128k
   PAGESIZE := 2048
-  IMAGE_SIZE := 24903680
+  IMAGE_SIZE := 20368588
   DEVICE_VENDOR := Keenetic
   DEVICE_MODEL := KN-1910
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
 	append-ubi | check-size | zyimage -d 0x801910 -v "KN-1910"

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -368,7 +368,7 @@ TARGET_DEVICES += keenetic_kn-1613
 
 define Device/keenetic_kn-1711
   BLOCKSIZE := 64k
-  IMAGE_SIZE := 13434880
+  IMAGE_SIZE := 10551296
   DEVICE_VENDOR := Keenetic
   DEVICE_MODEL := KN-1711
   DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap kmod-usb2
@@ -380,7 +380,7 @@ TARGET_DEVICES += keenetic_kn-1711
 
 define Device/keenetic_kn-1713
   BLOCKSIZE := 64k
-  IMAGE_SIZE := 13434880
+  IMAGE_SIZE := 10551296
   DEVICE_VENDOR := Keenetic
   DEVICE_MODEL := KN-1713
   DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap kmod-usb2


### PR DESCRIPTION
The image size has been changed to prevent failures in routers and bootloop when flashing a large image using a stock bootloader. The LED trigger package has been removed for 1910, which is no longer in use.

Signed-off-by: Anton Yu. Ivanusev <ivanusevanton@yandex.ru>