### PR TITLE
generic: add pending patches for RealTek Ethernet PHYs

### DIFF
--- a/target/linux/generic/pending-6.6/721-net-phy-realtek-clear-1000Base-T-lpa-bits-if-link-is.patch
+++ b/target/linux/generic/pending-6.6/721-net-phy-realtek-clear-1000Base-T-lpa-bits-if-link-is.patch
@@ -1,0 +1,78 @@
+From patchwork Wed Jan 15 14:43:35 2025
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Daniel Golle <daniel@makrotopia.org>
+X-Patchwork-Id: 13940510
+X-Patchwork-Delegate: kuba@kernel.org
+Date: Wed, 15 Jan 2025 14:43:35 +0000
+From: Daniel Golle <daniel@makrotopia.org>
+To: Andrew Lunn <andrew@lunn.ch>, Heiner Kallweit <hkallweit1@gmail.com>,
+	Russell King <linux@armlinux.org.uk>,
+	"David S. Miller" <davem@davemloft.net>,
+	Eric Dumazet <edumazet@google.com>,
+	Jakub Kicinski <kuba@kernel.org>, Paolo Abeni <pabeni@redhat.com>,
+	Daniel Golle <daniel@makrotopia.org>,
+	"Russell King (Oracle)" <linux@armlinux.org.uk>,
+	netdev@vger.kernel.org, linux-kernel@vger.kernel.org
+Subject: [PATCH net 1/3] net: phy: realtek: clear 1000Base-T lpa if link is
+ down
+Message-ID: 
+ <67e38eee4c46b921938fb33f5bc86c8979b9aa33.1736951652.git.daniel@makrotopia.org>
+References: <cover.1736951652.git.daniel@makrotopia.org>
+Precedence: bulk
+X-Mailing-List: netdev@vger.kernel.org
+List-Id: <netdev.vger.kernel.org>
+List-Subscribe: <mailto:netdev+subscribe@vger.kernel.org>
+List-Unsubscribe: <mailto:netdev+unsubscribe@vger.kernel.org>
+MIME-Version: 1.0
+Content-Disposition: inline
+In-Reply-To: <cover.1736951652.git.daniel@makrotopia.org>
+X-Patchwork-Delegate: kuba@kernel.org
+
+Only read 1000Base-T link partner advertisement if autonegotiation has
+completed and otherwise 1000Base-T link partner advertisement bits.
+
+This fixes bogus 1000Base-T link partner advertisement after link goes
+down (eg. by disconnecting the wire).
+Fixes: 5cb409b3960e ("net: phy: realtek: clear 1000Base-T link partner advertisement")
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Reviewed-by: Michal Swiatkowski <michal.swiatkowski@linux.intel.com>
+---
+ drivers/net/phy/realtek.c | 19 ++++++++-----------
+ 1 file changed, 8 insertions(+), 11 deletions(-)
+
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -1049,23 +1049,20 @@ static int rtl822x_c45_read_status(struc
+ {
+ 	int ret, val;
+ 
+-	ret = genphy_c45_read_status(phydev);
+-	if (ret < 0)
+-		return ret;
+-
+-	if (phydev->autoneg == AUTONEG_DISABLE ||
+-	    !genphy_c45_aneg_done(phydev))
+-		mii_stat1000_mod_linkmode_lpa_t(phydev->lp_advertising, 0);
+-
+ 	/* Vendor register as C45 has no standardized support for 1000BaseT */
+-	if (phydev->autoneg == AUTONEG_ENABLE) {
++	if (phydev->autoneg == AUTONEG_ENABLE && genphy_c45_aneg_done(phydev)) {
+ 		val = phy_read_mmd(phydev, MDIO_MMD_VEND2,
+ 				   RTL822X_VND2_GANLPAR);
+ 		if (val < 0)
+ 			return val;
+-
+-		mii_stat1000_mod_linkmode_lpa_t(phydev->lp_advertising, val);
++	} else {
++		val = 0;
+ 	}
++	mii_stat1000_mod_linkmode_lpa_t(phydev->lp_advertising, val);
++
++	ret = genphy_c45_read_status(phydev);
++	if (ret < 0)
++		return ret;
+ 
+ 	if (!phydev->link)
+ 		return 0;

--- a/target/linux/generic/pending-6.6/722-net-phy-realtek-clear-master_slave_state-if-link-is-.patch
+++ b/target/linux/generic/pending-6.6/722-net-phy-realtek-clear-master_slave_state-if-link-is-.patch
@@ -1,0 +1,61 @@
+From patchwork Wed Jan 15 14:43:43 2025
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Daniel Golle <daniel@makrotopia.org>
+X-Patchwork-Id: 13940511
+X-Patchwork-Delegate: kuba@kernel.org
+Date: Wed, 15 Jan 2025 14:43:43 +0000
+From: Daniel Golle <daniel@makrotopia.org>
+To: Andrew Lunn <andrew@lunn.ch>, Heiner Kallweit <hkallweit1@gmail.com>,
+	Russell King <linux@armlinux.org.uk>,
+	"David S. Miller" <davem@davemloft.net>,
+	Eric Dumazet <edumazet@google.com>,
+	Jakub Kicinski <kuba@kernel.org>, Paolo Abeni <pabeni@redhat.com>,
+	Daniel Golle <daniel@makrotopia.org>,
+	"Russell King (Oracle)" <linux@armlinux.org.uk>,
+	netdev@vger.kernel.org, linux-kernel@vger.kernel.org
+Subject: [PATCH net 2/3] net: phy: realtek: clear master_slave_state if link
+ is down
+Message-ID: 
+ <2155887c3a665e4132a034df1e9cfdeec0ae48c9.1736951652.git.daniel@makrotopia.org>
+References: <cover.1736951652.git.daniel@makrotopia.org>
+Precedence: bulk
+X-Mailing-List: netdev@vger.kernel.org
+List-Id: <netdev.vger.kernel.org>
+List-Subscribe: <mailto:netdev+subscribe@vger.kernel.org>
+List-Unsubscribe: <mailto:netdev+unsubscribe@vger.kernel.org>
+MIME-Version: 1.0
+Content-Disposition: inline
+In-Reply-To: <cover.1736951652.git.daniel@makrotopia.org>
+X-Patchwork-Delegate: kuba@kernel.org
+
+rtlgen_decode_physr() which sets master_slave_state isn't called in case
+the link is down and other than rtlgen_read_status(),
+rtl822x_c45_read_status() doesn't implicitely clear master_slave_state.
+
+Avoid stale master_slave_state by always setting it to
+MASTER_SLAVE_STATE_UNKNOWN in rtl822x_c45_read_status() in case the link
+is down.
+
+Fixes: 081c9c0265c9 ("net: phy: realtek: read duplex and gbit master from PHYSR register")
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Reviewed-by: Michal Swiatkowski <michal.swiatkowski@linux.intel.com>
+---
+ drivers/net/phy/realtek.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -1064,8 +1064,10 @@ static int rtl822x_c45_read_status(struc
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	if (!phydev->link)
++	if (!phydev->link) {
++		phydev->master_slave_state = MASTER_SLAVE_STATE_UNKNOWN;
+ 		return 0;
++	}
+ 
+ 	/* Read actual speed from vendor register. */
+ 	val = phy_read_mmd(phydev, MDIO_MMD_VEND2, RTL_VND2_PHYSR);

--- a/target/linux/generic/pending-6.6/723-net-phy-realtek-always-clear-10gbase-t-link-partner-.patch
+++ b/target/linux/generic/pending-6.6/723-net-phy-realtek-always-clear-10gbase-t-link-partner-.patch
@@ -1,0 +1,67 @@
+From patchwork Wed Jan 15 14:45:00 2025
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Daniel Golle <daniel@makrotopia.org>
+X-Patchwork-Id: 13940519
+X-Patchwork-Delegate: kuba@kernel.org
+Date: Wed, 15 Jan 2025 14:45:00 +0000
+From: Daniel Golle <daniel@makrotopia.org>
+To: Andrew Lunn <andrew@lunn.ch>, Heiner Kallweit <hkallweit1@gmail.com>,
+	Russell King <linux@armlinux.org.uk>,
+	"David S. Miller" <davem@davemloft.net>,
+	Eric Dumazet <edumazet@google.com>,
+	Jakub Kicinski <kuba@kernel.org>, Paolo Abeni <pabeni@redhat.com>,
+	Daniel Golle <daniel@makrotopia.org>,
+	"Russell King (Oracle)" <linux@armlinux.org.uk>,
+	netdev@vger.kernel.org, linux-kernel@vger.kernel.org
+Subject: [PATCH net 3/3] net: phy: realtek: always clear NBase-T lpa
+Message-ID: 
+ <566d4771d68a1e18d2d48860e25891e468e26551.1736951652.git.daniel@makrotopia.org>
+References: <cover.1736951652.git.daniel@makrotopia.org>
+Precedence: bulk
+X-Mailing-List: netdev@vger.kernel.org
+List-Id: <netdev.vger.kernel.org>
+List-Subscribe: <mailto:netdev+subscribe@vger.kernel.org>
+List-Unsubscribe: <mailto:netdev+unsubscribe@vger.kernel.org>
+MIME-Version: 1.0
+Content-Disposition: inline
+In-Reply-To: <cover.1736951652.git.daniel@makrotopia.org>
+X-Patchwork-Delegate: kuba@kernel.org
+
+Clear NBase-T link partner advertisement before calling
+rtlgen_read_status() to avoid phy_resolve_aneg_linkmode() wrongly
+setting speed and duplex.
+
+This fixes bogus 2.5G/5G/10G link partner advertisement and thus
+speed and duplex being set by phy_resolve_aneg_linkmode() due to stale
+NBase-T lpa.
+
+Fixes: 68d5cd09e891 ("net: phy: realtek: change order of calls in C22 read_status()")
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Reviewed-by: Michal Swiatkowski <michal.swiatkowski@linux.intel.com>
+---
+ drivers/net/phy/realtek.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/drivers/net/phy/realtek.c
++++ b/drivers/net/phy/realtek.c
+@@ -978,15 +978,15 @@ static int rtl822x_read_status(struct ph
+ {
+ 	int lpadv, ret;
+ 
++	mii_10gbt_stat_mod_linkmode_lpa_t(phydev->lp_advertising, 0);
++
+ 	ret = rtlgen_read_status(phydev);
+ 	if (ret < 0)
+ 		return ret;
+ 
+ 	if (phydev->autoneg == AUTONEG_DISABLE ||
+-	    !phydev->autoneg_complete) {
+-		mii_10gbt_stat_mod_linkmode_lpa_t(phydev->lp_advertising, 0);
++	    !phydev->autoneg_complete)
+ 		return 0;
+-	}
+ 
+ 	lpadv = phy_read_paged(phydev, 0xa5d, 0x13);
+ 	if (lpadv < 0)


### PR DESCRIPTION
Import patches to fix several issues with status reporting of RealTek 2.5G PHYs.

See also https://patchwork.kernel.org/project/netdevbpf/list/?series=925728