### PR TITLE
rockchip: configure nanopi R6 system led, reset button, IRQ affinity and load r8169 at boot time.

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -965,7 +965,7 @@ define KernelPackage/r8169
     CONFIG_R8169 \
     CONFIG_R8169_LEDS=y
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/realtek/r8169.ko
-  AUTOLOAD:=$(call AutoProbe,r8169)
+  AUTOLOAD:=$(call AutoProbe,r8169,1)
 endef
 
 define KernelPackage/r8169/description

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -30,10 +30,8 @@ set_interface_core() {
 
 case "$(board_name)" in
 armsom,sige7|\
-friendlyarm,nanopc-t6|\
 friendlyarm,nanopi-r3s|\
 friendlyarm,nanopi-r5c|\
-friendlyarm,nanopi-r6c|\
 radxa,e25|\
 sinovoip,rk3568-bpi-r2pro)
 	set_interface_core 2 "eth0"
@@ -49,15 +47,21 @@ xunlong,orangepi-r1-plus-lts)
 	set_interface_core 4 "eth1" "xhci-hcd:usb[0-9]+"
 	;;
 friendlyarm,nanopi-r4s|\
-friendlyarm,nanopi-r4s-enterprise)
+friendlyarm,nanopi-r4s-enterprise|\
+friendlyarm,nanopi-r6c|\
+friendlyarm,nanopc-t6)
 	set_interface_core 10 "eth0"
 	set_interface_core 20 "eth1"
 	;;
-friendlyarm,nanopi-r5s|\
-friendlyarm,nanopi-r6s)
+friendlyarm,nanopi-r5s)
 	set_interface_core 2 "eth0"
 	set_interface_core 4 "eth1"
 	set_interface_core 8 "eth2"
+	;;
+friendlyarm,nanopi-r6s)
+	set_interface_core 10 "eth0"
+	set_interface_core 20 "eth1"
+	set_interface_core 40 "eth2"
 	;;
 esac
 

--- a/target/linux/rockchip/patches-6.6/401-1-nanopi-r6-show-boot-status-on-system-led
+++ b/target/linux/rockchip/patches-6.6/401-1-nanopi-r6-show-boot-status-on-system-led
@@ -1,0 +1,33 @@
+Nanopi R6: show boot progress on the system LED
+
+Set up openwrt to show boot progress on the nanopi R6S or R6C system LED.
+
+The LED blinking states indicate the boot stage. The led is defined as
+a power LED, but can still be set to heartbeat in /etc/config/system
+after the system is done booting.
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
+@@ -16,6 +16,10 @@
+ 		ethernet0 = &gmac1;
+ 		mmc0 = &sdmmc;
+ 		mmc1 = &sdhci;
++		led-boot = &sys_led;
++		led-failsafe = &sys_led;
++		led-running = &sys_led;
++		led-upgrade = &sys_led;
+ 	};
+ 
+ 	chosen {
+@@ -54,9 +58,9 @@
+ 
+ 		sys_led: led-0 {
+ 			color = <LED_COLOR_ID_RED>;
+-			function = LED_FUNCTION_HEARTBEAT;
++			function = LED_FUNCTION_POWER;
+ 			gpios = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
++			default-state = "on";
+ 			pinctrl-names = "default";
+ 			pinctrl-0 = <&sys_led_pin>;
+ 		};

--- a/target/linux/rockchip/patches-6.6/401-2-nanopi-r6-reset-button
+++ b/target/linux/rockchip/patches-6.6/401-2-nanopi-r6-reset-button
@@ -1,0 +1,18 @@
+Nanopi R6: set up reset button to be handled by openwrt
+
+Set up openwrt to handle the reset button appropriately (so that it
+can trigger the various recovery modes) on the nanopi R6S and R6C models.
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
+@@ -48,8 +48,8 @@
+ 		button-user {
+ 			debounce-interval = <50>;
+ 			gpios = <&gpio1 RK_PC0 GPIO_ACTIVE_LOW>;
+-			label = "User Button";
+-			linux,code = <BTN_1>;
++			label = "reset";
++			linux,code = <KEY_RESTART>;
+ 		};
+ 	};
+ 


### PR DESCRIPTION
These are small configuration changes so that the nanopi R6S and R6C targets will be more in line with expectations out of the box. I am submitting this against main, but I am curious if a backport to 24.10 would also be feasible at this stage. I tested on both R6S and R6C platforms, on both main and 24.10 branches.