### PR TITLE
bmips: b53: enable bcm63268 internal PHYs

### DIFF
--- a/target/linux/bmips/dts/bcm6318.dtsi
+++ b/target/linux/bmips/dts/bcm6318.dtsi
@@ -260,6 +260,12 @@
 					pins = "gpio40";
 				};
 			};
+
+			ephy_rst: reset-controller@3c {
+				compatible = "brcm,bcm6345-reset";
+				reg = <0x3c 0x4>;
+				#reset-cells = <1>;
+			};
 		};
 
 		uart0: serial@10000100 {
@@ -399,6 +405,8 @@
 			reg = <0x10080000 0x8000>;
 			big-endian;
 
+			brcm,gpio-ctrl = <&gpio_cntl>;
+
 			ports {
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -431,21 +439,41 @@
 				phy1: ethernet-phy@1 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <1>;
+
+					resets = <&ephy_rst 0>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy2: ethernet-phy@2 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <2>;
+
+					resets = <&ephy_rst 1>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy3: ethernet-phy@3 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <3>;
+
+					resets = <&ephy_rst 2>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy4: ethernet-phy@4 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <4>;
+
+					resets = <&ephy_rst 3>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 			};
 

--- a/target/linux/bmips/dts/bcm63268.dtsi
+++ b/target/linux/bmips/dts/bcm63268.dtsi
@@ -288,6 +288,12 @@
 					pins = "dsl_gpio9";
 				};
 			};
+
+			ephy_rst: reset-controller@3c {
+				compatible = "brcm,bcm6345-reset";
+				reg = <0x3c 0x4>;
+				#reset-cells = <1>;
+			};
 		};
 
 		uart0: serial@10000180 {
@@ -481,8 +487,7 @@
 				 <&timer_clk BCM63268_TCLK_GPHY1>;
 
 			resets = <&periph_rst BCM63268_RST_ENETSW>,
-				 <&periph_rst BCM63268_RST_EPHY>,
-				 <&periph_rst BCM63268_RST_GPHY>;
+				 <&periph_rst BCM63268_RST_EPHY>;
 
 			power-domains = <&periph_pwr BCM63268_POWER_DOMAIN_ROBOSW>;
 
@@ -532,6 +537,8 @@
 			reg = <0x10700000 0x8000>;
 			big-endian;
 
+			brcm,gpio-ctrl = <&gpio_cntl>;
+
 			ports {
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -564,21 +571,41 @@
 				phy1: ethernet-phy@1 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <1>;
+
+					resets = <&ephy_rst 0>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy2: ethernet-phy@2 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <2>;
+
+					resets = <&ephy_rst 1>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy3: ethernet-phy@3 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <3>;
+
+					resets = <&ephy_rst 2>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy4: ethernet-phy@4 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <4>;
+
+					resets = <&periph_rst BCM63268_RST_GPHY>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 			};
 

--- a/target/linux/bmips/dts/bcm6328.dtsi
+++ b/target/linux/bmips/dts/bcm6328.dtsi
@@ -248,6 +248,12 @@
 					pins = "usb_port1";
 				};
 			};
+
+			ephy_rst: reset-controller@3c {
+				compatible = "brcm,bcm6345-reset";
+				reg = <0x3c 0x4>;
+				#reset-cells = <1>;
+			};
 		};
 
 		uart0: serial@10000100 {
@@ -417,6 +423,8 @@
 			reg = <0x10e00000 0x8000>;
 			big-endian;
 
+			brcm,gpio-ctrl = <&gpio_cntl>;
+
 			ports {
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -449,21 +457,41 @@
 				phy1: ethernet-phy@1 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <1>;
+
+					resets = <&ephy_rst 0>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy2: ethernet-phy@2 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <2>;
+
+					resets = <&ephy_rst 1>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy3: ethernet-phy@3 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <3>;
+
+					resets = <&ephy_rst 2>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy4: ethernet-phy@4 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <4>;
+
+					resets = <&ephy_rst 3>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 			};
 

--- a/target/linux/bmips/dts/bcm6362.dtsi
+++ b/target/linux/bmips/dts/bcm6362.dtsi
@@ -323,6 +323,12 @@
 					pins = "nand_grp";
 				};
 			};
+
+			ephy_rst: reset-controller@3c {
+				compatible = "brcm,bcm6345-reset";
+				reg = <0x3c 0x4>;
+				#reset-cells = <1>;
+			};
 		};
 
 		uart0: serial@10000100 {
@@ -526,6 +532,8 @@
 			reg = <0x10e00000 0x8000>;
 			big-endian;
 
+			brcm,gpio-ctrl = <&gpio_cntl>;
+
 			ports {
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -558,21 +566,41 @@
 				phy1: ethernet-phy@1 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <1>;
+
+					resets = <&ephy_rst 0>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy2: ethernet-phy@2 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <2>;
+
+					resets = <&ephy_rst 1>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy3: ethernet-phy@3 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <3>;
+
+					resets = <&ephy_rst 2>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy4: ethernet-phy@4 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <4>;
+
+					resets = <&ephy_rst 3>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 			};
 

--- a/target/linux/bmips/dts/bcm6368.dtsi
+++ b/target/linux/bmips/dts/bcm6368.dtsi
@@ -337,6 +337,12 @@
 					pins = "uart1_grp";
 				};
 			};
+
+			ephy_rst: reset-controller@3c {
+				compatible = "brcm,bcm6345-reset";
+				reg = <0x3c 0x4>;
+				#reset-cells = <1>;
+			};
 		};
 
 		leds: led-controller@100000d0 {
@@ -528,6 +534,8 @@
 			reg = <0x10f00000 0x8000>;
 			big-endian;
 
+			brcm,gpio-ctrl = <&gpio_cntl>;
+
 			ports {
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -560,21 +568,41 @@
 				phy1: ethernet-phy@1 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <1>;
+
+					resets = <&ephy_rst 6>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy2: ethernet-phy@2 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <2>;
+
+					resets = <&ephy_rst 7>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy3: ethernet-phy@3 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <3>;
+
+					resets = <&ephy_rst 8>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 
 				phy4: ethernet-phy@4 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <4>;
+
+					resets = <&ephy_rst 9>;
+					reset-names = "phy";
+					reset-assert-us = <2000>;
+					reset-deassert-us = <2000>;
 				};
 			};
 


### PR DESCRIPTION
On the smartrg sr505n the bootloader only sets registers to enable the PHYs if it's interrupted. When Linux boots this results in a -EINVAL error when trying to read from the EPHYs and the GPHY doesn't work. This adds a patch to set those registers when probing the b53 driver.

The EPHYs just needs a RST bit toggled briefly. Would it make more sense to treat that register as a reset controller or gpio bank and use the existing phy reset logic?

The GPHY registers look similar to the MDIO ones in bcm_sf2_gphy_enable_set(). If the BCM63268 GPHY has the same registers then it might be possible to do the same config over MDIO and not have to pass the ctrl register to the switch driver. edit: Nevermind, the sf2 registers are in mem. Still need to write the ctrl reg.

I also checked another device with an external switch and it's enabling the EPHYs not in use. Probably not worth the effort, but it would be nice to figure out a way to disable PHYs when they're not needed. 
