### PR TITLE
generic: net: phy: realtek: expose temperature sensors

### DIFF
--- a/target/linux/generic/backport-6.6/781-26-v6.14-net-phy-realtek-HWMON-support-for-standalone-version.patch
+++ b/target/linux/generic/backport-6.6/781-26-v6.14-net-phy-realtek-HWMON-support-for-standalone-version.patch
@@ -1,0 +1,64 @@
+From 64ff63aeefb03139ae27454bd4208244579ae88e Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Fri, 17 Jan 2025 23:24:21 +0100
+Subject: [PATCH] net: phy: realtek: HWMON support for standalone versions of
+ RTL8221B and RTL8251
+
+HWMON support has been added for the RTL8221/8251 PHYs integrated together
+with the MAC inside the RTL8125/8126 chips. This patch extends temperature
+reading support for standalone variants of the mentioned PHYs.
+
+I don't know whether the earlier revisions of the RTL8226 also have a
+built-in temperature sensor, so they have been skipped for now.
+
+Tested on RTL8221B-VB-CG.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/realtek/realtek_main.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -1474,6 +1474,7 @@ static struct phy_driver realtek_drvs[]
+ 	}, {
+ 		.match_phy_device = rtl8221b_vb_cg_c22_match_phy_device,
+ 		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C22)",
++		.probe		= rtl822x_probe,
+ 		.get_features   = rtl822x_get_features,
+ 		.config_aneg    = rtl822x_config_aneg,
+ 		.config_init    = rtl822xb_config_init,
+@@ -1486,6 +1487,7 @@ static struct phy_driver realtek_drvs[]
+ 	}, {
+ 		.match_phy_device = rtl8221b_vb_cg_c45_match_phy_device,
+ 		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C45)",
++		.probe		= rtl822x_probe,
+ 		.config_init    = rtl822xb_config_init,
+ 		.get_rate_matching = rtl822xb_get_rate_matching,
+ 		.get_features   = rtl822x_c45_get_features,
+@@ -1496,6 +1498,7 @@ static struct phy_driver realtek_drvs[]
+ 	}, {
+ 		.match_phy_device = rtl8221b_vn_cg_c22_match_phy_device,
+ 		.name           = "RTL8221B-VM-CG 2.5Gbps PHY (C22)",
++		.probe		= rtl822x_probe,
+ 		.get_features   = rtl822x_get_features,
+ 		.config_aneg    = rtl822x_config_aneg,
+ 		.config_init    = rtl822xb_config_init,
+@@ -1508,6 +1511,7 @@ static struct phy_driver realtek_drvs[]
+ 	}, {
+ 		.match_phy_device = rtl8221b_vn_cg_c45_match_phy_device,
+ 		.name           = "RTL8221B-VN-CG 2.5Gbps PHY (C45)",
++		.probe		= rtl822x_probe,
+ 		.config_init    = rtl822xb_config_init,
+ 		.get_rate_matching = rtl822xb_get_rate_matching,
+ 		.get_features   = rtl822x_c45_get_features,
+@@ -1518,6 +1522,7 @@ static struct phy_driver realtek_drvs[]
+ 	}, {
+ 		.match_phy_device = rtl8251b_c45_match_phy_device,
+ 		.name           = "RTL8251B 5Gbps PHY",
++		.probe		= rtl822x_probe,
+ 		.get_features   = rtl822x_get_features,
+ 		.config_aneg    = rtl822x_config_aneg,
+ 		.read_status    = rtl822x_read_status,

--- a/target/linux/generic/pending-6.6/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
+++ b/target/linux/generic/pending-6.6/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
@@ -52,30 +52,30 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.match_phy_device = rtl8221b_vb_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C22)",
 +		.soft_reset     = genphy_soft_reset,
+ 		.probe		= rtl822x_probe,
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
- 		.config_init    = rtl822xb_config_init,
-@@ -1486,6 +1491,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1487,6 +1492,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vb_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C45)",
 +		.soft_reset     = genphy_soft_reset,
+ 		.probe		= rtl822x_probe,
  		.config_init    = rtl822xb_config_init,
  		.get_rate_matching = rtl822xb_get_rate_matching,
- 		.get_features   = rtl822x_c45_get_features,
-@@ -1496,6 +1502,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1498,6 +1504,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vn_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VM-CG 2.5Gbps PHY (C22)",
 +		.soft_reset     = genphy_soft_reset,
+ 		.probe		= rtl822x_probe,
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
- 		.config_init    = rtl822xb_config_init,
-@@ -1508,6 +1515,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1511,6 +1518,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vn_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VN-CG 2.5Gbps PHY (C45)",
 +		.soft_reset     = genphy_soft_reset,
+ 		.probe		= rtl822x_probe,
  		.config_init    = rtl822xb_config_init,
  		.get_rate_matching = rtl822xb_get_rate_matching,
- 		.get_features   = rtl822x_c45_get_features,

--- a/target/linux/generic/pending-6.6/720-04-net-phy-realtek-introduce-rtl822x_aldps_probe.patch
+++ b/target/linux/generic/pending-6.6/720-04-net-phy-realtek-introduce-rtl822x_aldps_probe.patch
@@ -44,7 +44,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +
 +	phy_write_mmd(phydev, MDIO_MMD_VEND1, RTL8221B_PHYCR1, val);
 +
-+	return 0;
++	return rtl822x_probe(phydev);
 +}
 +
  static int rtlgen_resume(struct phy_device *phydev)
@@ -66,35 +66,39 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.soft_reset     = genphy_soft_reset,
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
-@@ -1502,6 +1527,7 @@ static struct phy_driver realtek_drvs[]
- 	}, {
+@@ -1503,7 +1528,7 @@ static struct phy_driver realtek_drvs[]
  		.match_phy_device = rtl8221b_vb_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C22)",
-+		.probe          = rtl822x_aldps_probe,
  		.soft_reset     = genphy_soft_reset,
+-		.probe		= rtl822x_probe,
++		.probe          = rtl822x_aldps_probe,
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
-@@ -1515,6 +1541,7 @@ static struct phy_driver realtek_drvs[]
- 	}, {
+ 		.config_init    = rtl822xb_config_init,
+@@ -1517,7 +1542,7 @@ static struct phy_driver realtek_drvs[]
  		.match_phy_device = rtl8221b_vb_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C45)",
-+		.probe          = rtl822x_aldps_probe,
  		.soft_reset     = genphy_soft_reset,
+-		.probe		= rtl822x_probe,
++		.probe          = rtl822x_aldps_probe,
  		.config_init    = rtl822xb_config_init,
  		.get_rate_matching = rtl822xb_get_rate_matching,
-@@ -1526,6 +1553,7 @@ static struct phy_driver realtek_drvs[]
- 	}, {
+ 		.get_features   = rtl822x_c45_get_features,
+@@ -1529,7 +1554,7 @@ static struct phy_driver realtek_drvs[]
  		.match_phy_device = rtl8221b_vn_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VM-CG 2.5Gbps PHY (C22)",
-+		.probe          = rtl822x_aldps_probe,
  		.soft_reset     = genphy_soft_reset,
+-		.probe		= rtl822x_probe,
++		.probe          = rtl822x_aldps_probe,
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
-@@ -1539,6 +1567,7 @@ static struct phy_driver realtek_drvs[]
- 	}, {
+ 		.config_init    = rtl822xb_config_init,
+@@ -1543,7 +1568,7 @@ static struct phy_driver realtek_drvs[]
  		.match_phy_device = rtl8221b_vn_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VN-CG 2.5Gbps PHY (C45)",
-+		.probe          = rtl822x_aldps_probe,
  		.soft_reset     = genphy_soft_reset,
+-		.probe		= rtl822x_probe,
++		.probe          = rtl822x_aldps_probe,
  		.config_init    = rtl822xb_config_init,
  		.get_rate_matching = rtl822xb_get_rate_matching,
+ 		.get_features   = rtl822x_c45_get_features,

--- a/target/linux/generic/pending-6.6/720-06-net-phy-realtek-support-interrupt-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.6/720-06-net-phy-realtek-support-interrupt-of-RTL8221B.patch
@@ -70,8 +70,8 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C22)",
 +		.config_intr	= rtl8221b_config_intr,
 +		.handle_interrupt = rtl8221b_handle_interrupt,
- 		.probe          = rtl822x_aldps_probe,
  		.soft_reset     = genphy_soft_reset,
+ 		.probe          = rtl822x_aldps_probe,
  		.get_features   = rtl822x_get_features,
 @@ -1563,6 +1610,8 @@ static struct phy_driver realtek_drvs[]
  	}, {
@@ -79,8 +79,8 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C45)",
 +		.config_intr	= rtl8221b_config_intr,
 +		.handle_interrupt = rtl8221b_handle_interrupt,
- 		.probe          = rtl822x_aldps_probe,
  		.soft_reset     = genphy_soft_reset,
+ 		.probe          = rtl822x_aldps_probe,
  		.config_init    = rtl822xb_config_init,
 @@ -1575,6 +1624,8 @@ static struct phy_driver realtek_drvs[]
  	}, {
@@ -88,8 +88,8 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.name           = "RTL8221B-VM-CG 2.5Gbps PHY (C22)",
 +		.config_intr	= rtl8221b_config_intr,
 +		.handle_interrupt = rtl8221b_handle_interrupt,
- 		.probe          = rtl822x_aldps_probe,
  		.soft_reset     = genphy_soft_reset,
+ 		.probe          = rtl822x_aldps_probe,
  		.get_features   = rtl822x_get_features,
 @@ -1589,6 +1640,8 @@ static struct phy_driver realtek_drvs[]
  	}, {
@@ -97,6 +97,6 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.name           = "RTL8221B-VN-CG 2.5Gbps PHY (C45)",
 +		.config_intr	= rtl8221b_config_intr,
 +		.handle_interrupt = rtl8221b_handle_interrupt,
- 		.probe          = rtl822x_aldps_probe,
  		.soft_reset     = genphy_soft_reset,
+ 		.probe          = rtl822x_aldps_probe,
  		.config_init    = rtl822xb_config_init,


### PR DESCRIPTION
Expose the temperature sensor built-into RTL822x 2.5G and 5G PHYs.

Tested on GL-MT6000 which shows plausible readings.