### PR TITLE
wifi-scripts: change wifi-station's mac option into list

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-station.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-station.json
@@ -5,9 +5,12 @@
 	"type": "object",
 	"properties": {
 		"mac": {
-			"description": "The stations MAC",
-			"type": "string",
-			"default": "00:00:00:00:00:00"
+			"description": "The station's MAC addresses",
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"default": ["00:00:00:00:00:00"]
 		},
 		"key": {
 			"description": "The passphrase that shall be used",

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -312,10 +312,12 @@ function iface_wpa_stations(config, stas) {
 	let file = fs.open(path, 'w');
 	for (let k, sta in stas)
 		if (sta.config.mac && sta.config.key) {
-			let station = `${sta.config.mac} ${sta.config.key}\n`;
-			if (sta.config.vid)
-				station = `vlanid=${sta.config.vid} ` + station;
-			file.write(station);
+			for (let mac in sta.config.mac) {
+				let station = `${mac} ${sta.config.key}\n`;
+				if (sta.config.vid)
+					station = `vlanid=${sta.config.vid} ` + station;
+				file.write(station);
+			}
 		}
 	file.close();
 
@@ -328,15 +330,16 @@ function iface_sae_stations(config, stas) {
 	let file = fs.open(path, 'w');
 	for (let k, sta in stas)
 		if (sta.config.mac && sta.config.key) {
-			let mac = sta.config.mac;
-			if (mac == '00:00:00:00:00:00')
-				mac = 'ff:ff:ff:ff:ff:ff';
+			for (let mac in sta.config.mac) {
+				if (mac == '00:00:00:00:00:00')
+					mac = 'ff:ff:ff:ff:ff:ff';
 
-			let station = `${sta.config.key}|mac=${mac}`;
-			if (sta.config.vid)
-				station = station + `|vlanid=${sta.config.vid}`;
-			station = station + '\n';
-			file.write(station);
+				let station = `${sta.config.key}|mac=${mac}`;
+				if (sta.config.vid)
+					station = station + `|vlanid=${sta.config.vid}`;
+				station = station + '\n';
+				file.write(station);
+			}
 		}
 	file.close();
 

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -426,10 +426,13 @@ hostapd_set_psk_file() {
 	local vlan="$2"
 	local vlan_id=""
 
-	json_get_vars mac vid key
-	set_default mac "00:00:00:00:00:00"
+	json_get_vars vid key
+	json_get_values mac_list mac
+	set_default mac_list "00:00:00:00:00:00"
 	[ -n "$vid" ] && vlan_id="vlanid=$vid "
-	echo "${vlan_id} ${mac} ${key}" >> /var/run/hostapd-${ifname}.psk
+	for mac in $mac_list; do
+		echo "${vlan_id} ${mac} ${key}" >> /var/run/hostapd-${ifname}.psk
+	done
 }
 
 hostapd_set_psk() {
@@ -448,11 +451,14 @@ hostapd_set_sae_file() {
 	local vlan="$2"
 	local vlan_id=""
 
-	json_get_vars mac vid key
-	set_default mac "ff:ff:ff:ff:ff:ff"
-	[ -n "$mac" ] && mac="|mac=$mac"
+	json_get_vars vid key
+	json_get_values mac_list mac
+	set_default mac_list "ff:ff:ff:ff:ff:ff"
 	[ -n "$vid" ] && vlan_id="|vlanid=$vid"
-	printf '%s%s%s\n' "${key}" "${mac}" "${vlan_id}" >> /var/run/hostapd-${ifname}.sae
+	for mac in $mac_list; do
+		mac="|mac=$mac"
+		printf '%s%s%s\n' "${key}" "${mac}" "${vlan_id}" >> /var/run/hostapd-${ifname}.sae
+	done
 }
 
 hostapd_set_sae() {

--- a/package/network/config/wifi-scripts/files/lib/netifd/netifd-wireless.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/netifd-wireless.sh
@@ -399,7 +399,8 @@ _wdev_common_vlan_config() {
 }
 
 _wdev_common_station_config() {
-	config_add_string mac key vid iface
+	config_add_string key vid iface
+	config_add_array mac
 }
 
 init_wireless_driver() {


### PR DESCRIPTION
In the past PR[1] to add SAE wifi-station support, a commenter[2] requested that the mac option be changed into a list. After trying to migrate my old RADIUS setup I found myself wanting this change as well as it would simplify my config. This patch does precisely that. Old configs that specify `option mac ....` still work without any issues.

This change was done for both PSK and SAE. The schema was updated as well.

[1]: https://github.com/openwrt/openwrt/pull/17145
[2]: https://github.com/openwrt/openwrt/pull/17145#issuecomment-2523507953