### PR TITLE
qualcommax: dl-wrx36: fix 2.5G port LED-s

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-dl-wrx36.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-dl-wrx36.dts
@@ -178,14 +178,15 @@
 
 			led@0 {
 				reg = <0>;
-				color = <LED_COLOR_ID_GREEN>;
+				color = <LED_COLOR_ID_YELLOW>;
 				function = LED_FUNCTION_WAN;
 				default-state = "keep";
+				active-low;
 			};
 
-			led@1 {
-				reg = <1>;
-				color = <LED_COLOR_ID_YELLOW>;
+			led@2 {
+				reg = <2>;
+				color = <LED_COLOR_ID_GREEN>;
 				function = LED_FUNCTION_WAN;
 				default-state = "keep";
 			};


### PR DESCRIPTION
Currently, 2.5G port LED-s on Dynalink are incorrectly configured and thus they will light up all of the time.

So, lets fix this by:
1. Current green LED is actually yellow, change the color
2. Fix its polarity as its actually active-low
3. The yellow LED that was registered as being connected to LED_1 pin on the PHY is not actually connected at all, so remove it.
4. The actual green LED is connected to LED_2 on the PHY so add it.

Fixes: 75ad5c24142a ("qualcommax: switch to qca8081 upstream PHY driver")
Fixes: #14502 