### PR TITLE
build: ignore chown calls from apk

### DIFF
--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -45,6 +45,7 @@ opkg = \
 
 apk = \
   IPKG_INSTROOT=$(1) \
+  FAKEROOTDONTTRYCHOWN=1 \
   $(FAKEROOT) $(STAGING_DIR_HOST)/bin/apk \
 	--root $(1) \
 	--keys-dir $(if $(APK_KEYS),$(APK_KEYS),$(TOPDIR)) \


### PR DESCRIPTION
Building on NixOS requires emulating the FHS, which involves Bubblewrap.

Bwrap uses namespaces in which UID 0 is unmapped, which causes chown to fail with EINVAL.
There is little point in actually attempting chown because the build is meant to run without privileges anyway.

See: https://github.com/nix-community/nix-environments/blame/master/envs/openwrt/shell.nix
See: https://patchwork.ozlabs.org/project/buildroot/patch/20190403201325.31664-1-peter@korsgaard.com/
See: https://github.com/containers/bubblewrap/issues/395

Possible alternative: drop fakeroot, and run apk with `--usermode` instead, however [that does something weird with permissions](https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/f0e3aa4c139dcf03cec58df16dceb48ea7d4e9a4/src/database.c#L72).