### PR TITLE
Switch I-O Data and Apresia devices to new RTL8231 driver

### DIFF
--- a/target/linux/realtek/dts/rtl8382_apresia_aplgs120gtss.dts
+++ b/target/linux/realtek/dts/rtl8382_apresia_aplgs120gtss.dts
@@ -48,6 +48,9 @@
 		compatible = "gpio-keys-polled";
 		poll-interval = <20>;
 
+		pinctrl-names = "default";
+		pinctrl-0 = <&reset_key_debounce>;
+
 		reset {
 			label = "reset";
 			gpios = <&gpio1 33 GPIO_ACTIVE_LOW>;
@@ -141,6 +144,11 @@
 		gpio-controller;
 		#gpio-cells = <2>;
 		gpio-ranges = <&gpio1 0 0 37>;
+
+		reset_key_debounce: reset-key-pins {
+			pins = "gpio33";
+			input-debounce = <100000>;
+		};
 
 		led-controller {
 			compatible = "realtek,rtl8231-leds";


### PR DESCRIPTION
Convert two devices to the new RTL8231 driver, originally submitted by @musashino205 

The Apresia switch can make use of the MDIO infrastructure for the RTL8231's reset line. A HW debounce config is also added for the the reset key.

The I-O DATA switch is a simple conversion and should not result in behavioural changes.