### PR TITLE
mt76: fixes for memory leak and kernels 6.7 and above

### DIFF
--- a/package/kernel/mt76/patches/0001-fix-build-for-linux-6.7.patch
+++ b/package/kernel/mt76/patches/0001-fix-build-for-linux-6.7.patch
@@ -1,0 +1,24 @@
+From: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Date: Sun, 19 Jan 2025 12:35:47 +0100
+Subject: [PATCH] mt76: fix kernel 6.7 compatibility
+
+The PP_FLAG_PAGE_FRAG constant was removed in kernel 6.7,
+so we are removing it from code for kernels 6.7 and above.
+
+Signed-off-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+---
+
+--- a/mac80211.c
++++ b/mac80211.c
+@@ -613,7 +613,11 @@ int mt76_create_page_pool(struct mt76_de
+ {
+ 	struct page_pool_params pp_params = {
+ 		.order = 0,
++#if LINUX_VERSION_IS_LESS(6,7,0)
+ 		.flags = PP_FLAG_PAGE_FRAG,
++#else
++		.flags = 0,
++#endif
+ 		.nid = NUMA_NO_NODE,
+ 		.dev = dev->dma_dev,
+ 	};

--- a/package/kernel/mt76/patches/0002-fix-allocation-check-and-missing-memory-freeing.patch
+++ b/package/kernel/mt76/patches/0002-fix-allocation-check-and-missing-memory-freeing.patch
@@ -1,0 +1,28 @@
+From: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Date: Sun, 19 Jan 2025 12:37:01 +0100
+Subject: [PATCH] mt76: fix allocation check and missing memory freeing
+
+Fixed allocation checking and freeing buffer memory
+inside mt76_eeprom_changes() function.
+
+Signed-off-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+---
+
+--- a/tools/eeprom.c
++++ b/tools/eeprom.c
+@@ -220,10 +220,14 @@ mt76_eeprom_changes(void)
+ 	}
+ 
+ 	buf = malloc(EEPROM_PART_SIZE);
++	if (!buf)
++		return EXIT_FAILURE;
+ 	fseek(f, mtd_offset, SEEK_SET);
+ 	ret = fread(buf, 1, EEPROM_PART_SIZE, f);
+-	if (ret != EEPROM_PART_SIZE)
++	if (ret != EEPROM_PART_SIZE) {
++		free(buf);
+ 		return EXIT_FAILURE;
++	}
+ 	for (i = 0; i < EEPROM_PART_SIZE; i++) {
+ 		if (buf[i] == eeprom_data[i])
+ 			continue;


### PR DESCRIPTION
 - Fix kernel 6.7 compatibility:
The PP_FLAG_PAGE_FRAG constant was removed in kernel 6.7, so we are removing it from code for kernels 6.7 and above.
This is needed for building the openwrt with the next LTS kernel 6.12.


- Fix allocation check and missing memory freeing:
Fixed allocation checking and freeing buffer memory inside mt76_eeprom_changes() function.