### PR TITLE
ath79: add Cisco Meraki Z1

### DIFF
--- a/target/linux/ath79/dts/ar9344_meraki_z1.dts
+++ b/target/linux/ath79/dts/ar9344_meraki_z1.dts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include "ar9344.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "meraki,z1", "qca,ar9344";
+	model = "Cisco Meraki Z1";
+
+	aliases {
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_orange;
+		led-upgrade = &led_power_orange;
+		label-mac-device = &eth0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: led-0 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+			panic-indicator;
+		};
+	};
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&gpio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&jtag_disable_pins>;
+
+	gpio_ext_lna0 {
+		gpio-hog;
+		gpios = <18 GPIO_ACTIVE_HIGH>;
+		output-low;
+		line-name = "z1:ext:lna0";
+	};
+
+	gpio_ext_lna1 {
+		gpio-hog;
+		gpios = <19 GPIO_ACTIVE_HIGH>;
+		output-low;
+		line-name = "z1:ext:lna1";
+	};
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,002a";
+		reg = <0x0000 0 0 0 0>;
+		qca,no-eeprom;
+		nvmem-cells = <&macaddr_board_66 3>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&wmac {
+	status = "okay";
+	qca,no-eeprom;
+
+	nvmem-cells = <&macaddr_board_66 2>;
+	nvmem-cell-names = "mac-address";
+};
+
+&nand {
+	status = "okay";
+
+	nand-ecc-mode = "soft";
+	nand-ecc-algo = "bch";
+	nand-ecc-strength = <4>;
+	nand-ecc-step-size = <512>;
+	nand-is-boot-medium;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "loader1";
+			reg = <0x0 0x20000>;
+			read-only;
+		};
+
+		partition@20000 {
+			label = "kernel";
+			reg = <0x20000 0x7e0000>;
+		};
+
+		partition@800000 {
+			label = "loader2";
+			reg = <0x800000 0x20000>;
+			read-only;
+		};
+
+		partition@820000 {
+			label = "recovery";
+			reg = <0x820000 0x7e0000>;
+		};
+
+		partition@1000000 {
+			label = "ubi";
+			reg = <0x1000000 0x6fe0000>;
+
+			volumes {
+				ubi-volume-board-config {
+					volname = "board-config";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						macaddr_board_66: macaddr@66 {
+							compatible = "mac-base";
+							reg = <0x66 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+			};
+		};
+
+		partition@7fe0000 {
+			label = "origcaldata";
+			reg = <0x7fe0000 0x20000>;
+			read-only;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "rgmii";
+
+		qca,ar8327-initvals = <
+			0x04 0x07600000 /* PORT0 PAD MODE CTRL */
+			0x7c 0x0000007e /* PORT0_STATUS */
+			>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	pll-data = <0x06000000 0x00000101 0x00001313>;
+	phy-mode = "rgmii-id";
+	nvmem-cells = <&macaddr_board_66 0>;
+	nvmem-cell-names = "mac-address";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-gmac0 = <1>;
+		switch-only-mode = <1>;
+	};
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -19,6 +19,14 @@ define Build/meraki-header
         @mv $@.new $@
 endef
 
+define Build/meraki-old-nand
+	-$(STAGING_DIR_HOST)/bin/mkmerakifw-old \
+		-B $(1) -s \
+		-i $@ \
+		-o $@.new
+	@mv $@.new $@
+endef
+
 # attention: only zlib compression is allowed for the boot fs
 define Build/zyxel-buildkerneljffs
 	mkdir -p $@.tmp/boot
@@ -320,6 +328,25 @@ define Device/meraki_mr18
   SUPPORTED_DEVICES += mr18
 endef
 TARGET_DEVICES += meraki_mr18
+
+define Device/meraki_z1
+  SOC = ar9344
+  DEVICE_VENDOR := Meraki
+  DEVICE_MODEL := Z1
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-owl-loader \
+	kmod-leds-uleds kmod-spi-gpio nu801 -uboot-envtools
+  KERNEL_SIZE := 8064k
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  LOADER_TYPE := bin
+  LZMA_TEXT_START := 0x82800000
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | \
+	    pad-to $$(BLOCKSIZE) | meraki-old-nand z1
+  KERNEL_INITRAMFS := $$(KERNEL)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  SUPPORTED_DEVICES += z1
+endef
+TARGET_DEVICES += meraki_z1
 
 # fake rootfs is mandatory, pad-offset 129 equals (2 * uimage_header + '\0')
 define Device/netgear_ath79_nand

--- a/target/linux/ath79/nand/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/nand/base-files/etc/board.d/01_leds
@@ -30,6 +30,9 @@ netgear,pgzng1)
 netgear,r6100)
 	ucidef_set_led_netdev "wan-green" "WAN (green)" "green:wan" "eth1"
 	;;
+meraki,z1)
+	ucidef_set_led_default "diag" "DIAG" "green:tricolor" "1"
+	;;
 netgear,wndr3700-v4|\
 netgear,wndr4300|\
 netgear,wndr4300sw|\

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -44,6 +44,10 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"6u@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0u@eth0"
 		;;
+	meraki,z1)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan"
+		;;
 	netgear,pgzng1)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
@@ -103,6 +107,10 @@ ath79_setup_macs()
 	glinet,gl-x1200-nor-nand)
 		wan_mac=$(mtd_get_mac_binary art 0x0)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
+		;;
+	meraki,z1)
+		base_mac=$(mtd_get_mac_binary_ubi board-config 102)
+		wan_mac=$(macaddr_add "$base_mac" 1)
 		;;
 	netgear,wndr3700-v4|\
 	netgear,wndr4300|\

--- a/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/nand/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -18,6 +18,16 @@ case "$FIRMWARE" in
 			caldata_extract "odm-caldata" 0x1000 0x440
 		fi
 		;;
+	meraki,z1)
+		. /lib/upgrade/nand.sh
+
+		if [ -n "$(nand_find_volume ubi0 caldata)" ]; then
+			caldata_extract_ubi "caldata" 0x1000 0x800
+		else
+			caldata_extract "origcaldata" 0x1000 0x800
+			ath9k_patch_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 102) 2)
+		fi
+		;;
 	*)
 		caldata_die "board $board is not supported yet"
 		;;
@@ -32,6 +42,16 @@ case "$FIRMWARE" in
 			caldata_extract_ubi "caldata" 0x5000 0x440
 		else
 			caldata_extract "odm-caldata" 0x5000 0x440
+		fi
+		;;
+	meraki,z1)
+		. /lib/upgrade/nand.sh
+
+		if [ -n "$(nand_find_volume ubi0 caldata)" ]; then
+			caldata_extract_ubi "caldata" 0x15000 0x1000
+		else
+			caldata_extract "origcaldata" 0x15000 0x1000
+			ath9k_patch_mac $(macaddr_add $(mtd_get_mac_binary_ubi board-config 102) 3)
 		fi
 		;;
 	*)

--- a/target/linux/ath79/nand/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/nand/base-files/etc/uci-defaults/04_led_migration
@@ -4,6 +4,9 @@
 board=$(board_name)
 
 case "$board" in
+meraki,z1)
+	migrate_leds ":tricolor0=:tricolor"
+	;;
 esac
 
 remove_devicename_leds


### PR DESCRIPTION
Specifications:

SOC:	Atheros AR9344 @ 560MHz
RAM:	2x Winbond W9751G6KB-25 (128 MiB)
FLASH:	Hynix H27U1G8F2BTR (128 MiB)
WIFI1:	Atheros AR9340 5.0GHz (SoC)
WIFI2:	Atheros AR9280 2.4GHz
SWITCH:	Atheros AR8236 (5x Gigabit (1x WAN, 4x LAN) LED:	1x Power-LED, 1 x RGB Tricolor-LED
INPUT:	One Reset Button
USB:	One USB 2.0 Port
UART:	JP1 on PCB (Labeled UART), 3.3v-Level, 115200n8
        (GND, TX, RX, VCC - GND is next to the UART silk screen)

Flashing Instructions:

If your device still has vulnerable firmware, then existing installation instructions can be used. Devices currently running ar71xx firmware can be upgraded directly.

If your firmware is too new, there are two options
- temporarily adding a SPI-NOR flash to boot initramfs from (recommended)
- patching NAND image with initramfs with external programmer (recommended if and only if you have access to 360-clip, or similar device, that doesn't require desoldering a TSOP48 chip))

Since this device is brought over from an old AR71xx, there's already a wiki-page with detailed instructions:
<https://openwrt.org/toh/meraki/z1>

Installing from SPI-NOR:
- Download pre-built image from <https://github.com/Leo-PL/OpenWrt-Meraki-Z1> or assemble your own by splicing router-u-boot <https://github.com/CodeFetch/router-u-boot> image for TP-Link WDR4300 with Z1 initramfs in uImage format. To build uImage initramfsf from source, remove the "KERNEL_INITRAMFS" variable from target/linux/ath79/image/nand.mk for Z1. Put the U-boot image at offset 0, initramfs at offset 131072.
- Write the image to an 8MB (or greater) SPI flash
- Temporarily bridge - or solder in a 220-ohm resistor between pins 6 and 8 of the SPI-NOR chip to override boot source to SPI
- When the initramfs first boots, write the standard initramfs to NAND, to both 'kernel' and 'recovery' partitions
```
$ mtd write /tmp/openwrt-ath79-nand-meraki_z1-initramfs-kernel.bin kernel
$ mtd write /tmp/openwrt-ath79-nand-meraki_z1-initramfs-kernel.bin recovery
```
  Now you can disconnect the resistor and try to boot the system from NAND. If it works, continue with installation, as described for legacy method using vulnerable stock firmware.
- When done, you can remove SPI-NOR chip and the resistor altogether, it can be reused to perform installation on other devices, or act as a recovery boot source if needed, if the recovery initramfs fails for any reason.

Installing by patching NAND
- If you'd like to desolder NAND to perform this, I highly advise against it, use SPI-NOR method above instead.
- If you have external programmer and a NAND clip, read out the whole chip image, while keeping the device in reset by shorting SRST (pin 11) to ground in JTAG connector, and store a backup in a safe place.
- Patch the chip image with initramfs for raw NAND from <https://github.com/Leo-PL/OpenWrt-Meraki-Z1>, by using a script there, or manually:

```
$ dd if=openwrt-ath79-nand-meraki_z1-initramfs-kernel-rawnand.bin of=z1_dump.img bs=135168 seek=1 conv=notrunc
$ dd if=openwrt-ath79-nand-meraki_z1-initramfs-kernel-rawnand.bin of=z1_dump.img bs=135168 seek=65 conv=notrunc
```

  This will write the initramfs to both kernel and recovery partitions, which is highly recommended, as due to device architecture it is notoriously hard to unbrick.
- Write the image back to the NAND, again, keeping the CPU in the reset.
- When the unit boots to initramfs, proceed as per existing instructions for volnerable firmware.

Legacy installation on vulnerable stock firmware:
The gist:
1. Get a root-shell on the device (see wiki). (needs UART access)
2. make a backup (to a PC/safe location) of the existing Meraki firmware.
3. copy over the OpenWrt initramfs kernel for the Z1. This gets written into the kernel NAND partition. (Verify that written image is complete!)

After the following reboot and successfull boot of the staging OpenWrt initramfs image:

4. Free up space by removing Meraki firmware partitions from UBI volume to free up space for OpenWrt (example given for the latest wired-14 version): $ ubirmvol -N storage /dev/ubi0 $ ubirmvol -N rootfs-wired-14-202005181203-G201ba9ed-rel-gazebo-1 /dev/ubi0 $ ubirmvol -N rootfs-wired-14-202005181203-G201ba9ed-rel-gazebo-2 /dev/ubi0

4. copy over the sysupgrade.bin for the router and use sysupgrade to make the installation permanent.

Notable changes from ar71xx support:
- LED colors are now different, because nu801 userspace driver is used for the RGB LED.

Acknowledgments:
- Hal Martin, for providing additional devices for research, including one modded for SPI boot and with removable NAND
- Christian Lamparter for initial device tree and image configuration