### PR TITLE
ramips: add support for Maginon MC-1200AC

### DIFF
--- a/target/linux/ramips/dts/mt7621_maginon_mc-1200ac.dts
+++ b/target/linux/ramips/dts/mt7621_maginon_mc-1200ac.dts
@@ -1,0 +1,145 @@
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "maginon,mc-1200ac", "mediatek,mt7621-soc";
+	model = "Maginon MC-1200AC";
+    
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8";
+	};
+	
+	aliases {
+		led-running = &top_blue_led;
+		led-boot = &top_red_led;
+		led-failsafe = &top_red_led;
+		led-upgrade = &top_red_led;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		top_blue_led: blue_led {
+			label = "top_blue_led";
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		top_red_led: red_led {
+			label = "top_red_led";
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset Button";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+		touch {
+			label = "Reset Button";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+		pair {
+			label = "Reset Button";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	mt76@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x1e140000 0x40000>;
+		ieee80211-freq-limit = <2400000 2500000>; // 2,4 GHz
+	};
+};
+
+&pcie1 {
+	mt76@0,1  {
+		compatible = "mediatek,mt76";
+		reg = <0x1e150000 0x40000>;
+		ieee80211-freq-limit = <5000000 6000000>; // 5 GHz
+	};
+};
+
+&switch0 {
+	ports {
+
+		port@0 {
+			status = "okay";
+			label = "lan";
+		};
+		port@4 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <0x17d7840>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x00 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+			
+			partition@40000 {
+				label = "Factory";
+				reg = <0x40000 0x10000>;
+			};
+    
+			partition@50000 {
+				label = "firmware";
+				reg = <0x50000 0xf30000>;
+				compatible = "denx,fit";
+			};
+
+			partition@fb0000 {
+				label = "vendor";
+				reg = <0xf80000 0x80000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "i2c", "uart2", "uart3";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1956,6 +1956,20 @@ define Device/linksys_re7000
 endef
 TARGET_DEVICES += linksys_re7000
 
+define Device/maginon_mc-1200ac
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Maginon
+  DEVICE_MODEL := MC-1200AC
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap -uboot-envtools
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | append-metadata
+  IMAGE_SIZE := 15040k
+endef
+TARGET_DEVICES += maginon_mc-1200ac
+
 define Device/mediatek_ap-mt7621a-v60
   $(Device/dsa-migration)
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -72,6 +72,7 @@ ramips_setup_interfaces()
 	humax,e10|\
 	keenetic,kn-3510|\
 	openfi,5pro|\
+	maginon,mc-1200ac|\
 	wavlink,ws-wn572hp3-4g|\
 	winstars,ws-wn583a6)
 		ucidef_set_interfaces_lan_wan "lan" "wan"


### PR DESCRIPTION
This commit adds support for Maginon MC-1200AC.

**Hardware specifications:**
- **SoC:** MediaTek MT7621
- **Flash:** 16 MB SPI Flash
- **RAM:** 128 MB RAM
- **Ethernet:**
  - 2x 1G RJ45 ports
- **WLAN:**
  - 2.4GHz: MediaTek MT7603E
  - 5GHz: MediaTek MT7613BE
- **LEDs:** Red and blue status lights
- **Power:** 12V DC
- **UART:** 3.3V, 115200 baud, 8N1

**Installation:**
- The firmware can be flashed via the U-Boot recovery web interface.  
  - To access it, hold the reset button while powering on the device.  
- Alternatively, the image can be loaded using the U-Boot serial interface and TFTP.

Signed-off-by: Simon Etzlstorfer <etzisim@gmail.com>