### PR TITLE
ramips: fix image recipe for ASUS RT-N56U

### DIFF
--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -8,7 +8,8 @@ endef
 define Device/asus_rt-n56u
   SOC := rt3662
   IMAGE_SIZE := 7872k
-  IMAGE/sysupgrade.bin += | mkrtn56uimg -s
+  IMAGE/sysupgrade.bin := $$(sysupgrade_bin) | check-size | \
+	mkrtn56uimg -s | append-metadata
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-N56U
   DEVICE_PACKAGES := kmod-usb-ohci kmod-usb2


### PR DESCRIPTION
Backport this fix from the snapshots/24.10.0 release candidates to 23.05.x.

Currently 24.10.0-rc is unusable, it leaves the device unable to boot. Until that is resolved, we can at least make it as easy as possible for users to continue to consume 23.05.x updates by signing the images properly. I have confirmed on my device that this fix does apply cleanly on the 23.05.x branch and produces usable images.

The OpenWrt image metadata includes checksum validation. Therefore, it must be generated at the end.

Fixes: https://github.com/openwrt/openwrt/issues/9045
Fixes: https://github.com/openwrt/openwrt/issues/13674
Link: https://patchwork.ozlabs.org/project/openwrt/patch/TYCP286MB08952FAACDFA234C5E052131BCD82@TYCP286MB0895.JPNP286.PROD.OUTLOOK.COM/