### PR TITLE
ath79: meraki-mr18: fix initramfs build

### DIFF
--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -313,10 +313,9 @@ define Device/meraki_mr18
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   LOADER_TYPE := bin
+  LZMA_TEXT_START := 0x82800000
   KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | meraki-header MR18
-# Initramfs-build fails due to size issues
-# KERNEL_INITRAMFS := $$(KERNEL)
-  KERNEL_INITRAMFS :=
+  KERNEL_INITRAMFS := $$(KERNEL)
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   SUPPORTED_DEVICES += mr18
 endef


### PR DESCRIPTION
Now, that initramfs images built for ZTE devices work, by moving LZMA_TEXT_START further up the available RAM - same fix works successfully for Meraki MR18 too. Apply it and reenable initramfs generation again.