### PR TITLE
mediatek-mt7622: netgear-wax206 fix wifi leds

### DIFF
--- a/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
+++ b/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
@@ -13,6 +13,7 @@
 
 	aliases {
 		ethernet0 = &gmac0;
+		label-mac-device = &gmac0;
 		led-boot = &led_power_r;
 		led-failsafe = &led_power_r;
 		led-running = &led_power_g;
@@ -84,6 +85,7 @@
 			default-state = "off";
 			gpios = <&pio 85 GPIO_ACTIVE_LOW>;
 			label = "wifin:green";
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wifin_blue {
@@ -96,6 +98,7 @@
 			default-state = "off";
 			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
 			label = "wifia:green";
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wifia_blue {


### PR DESCRIPTION
the wifi leds of the wax206 were not reacting.
This patch enables the green leds to show activity, as the blue ones are very bright.

Also sets the label-mac to the gmac0


Tested and confirmed working