### PR TITLE
kernel: f2fs: add option to build with compression

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -333,6 +333,41 @@ if KERNEL_TASKSTATS
 
 endif
 
+
+config KERNEL_F2FS_FS_COMPRESSION
+	bool "F2FS compression feature"
+	depends on PACKAGE_kmod-fs-f2fs
+	help
+	  Enable to build back-end compression for f2fs
+	  Be sure to select at least one of the following back-ends:
+	  LZO, LZO-RLE, LZ4, LZ4HC, or ZSTD.
+
+	config KERNEL_F2FS_FS_LZO
+	bool "LZO compression support"
+	select PACKAGE_kmod-lib-lzo
+	depends on KERNEL_F2FS_FS_COMPRESSION
+
+	config KERNEL_F2FS_FS_LZORLE
+	bool "LZO-RLE compression support"
+	select PACKAGE_kmod-lib-lzorle
+	depends on KERNEL_F2FS_FS_COMPRESSION
+
+	config KERNEL_F2FS_FS_LZ4
+	bool "LZ4 compression support"
+	select PACKAGE_kmod-lib-lz4
+	depends on KERNEL_F2FS_FS_COMPRESSION
+
+	config KERNEL_F2FS_FS_LZ4HC
+	bool "LZ4HC compression support"
+	select PACKAGE_kmod-lib-lz4hc
+	depends on KERNEL_F2FS_FS_COMPRESSION
+
+	config KERNEL_F2FS_FS_ZSTD
+	bool "ZSTD compression support"
+	select PACKAGE_kmod-lib-zstd
+	depends on KERNEL_F2FS_FS_COMPRESSION
+
+
 config KERNEL_PSI
 	bool "Compile the kernel with pressure stall information tracking"
 	help

--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -246,7 +246,12 @@ $(eval $(call KernelPackage,fs-ext4))
 define KernelPackage/fs-f2fs
   SUBMENU:=$(FS_MENU)
   TITLE:=F2FS filesystem support
-  DEPENDS:= +kmod-crypto-hash +kmod-crypto-crc32 +kmod-nls-base
+  DEPENDS:= +kmod-crypto-hash +kmod-crypto-crc32 +kmod-nls-base \
+	    $(if $(CONFIG_F2FS_FS_LZO),+kmod-lib-lzo) \
+	    $(if $(CONFIG_F2FS_FS_LZORLE),+kmod-lib-lzorle) \
+	    $(if $(CONFIG_F2FS_FS_LZ4),+kmod-lib-lz4) \
+	    $(if $(CONFIG_F2FS_FS_LZ4HC),+kmod-lib-lz4hc) \
+	    $(if $(CONFIG_F2FS_FS_ZSTD),+kmod-lib-zstd)
   KCONFIG:=CONFIG_F2FS_FS
   FILES:=$(LINUX_DIR)/fs/f2fs/f2fs.ko
   AUTOLOAD:=$(call AutoLoad,30,f2fs,1)

--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -262,7 +262,11 @@ $(eval $(call KernelPackage,fs-ext4))
 define KernelPackage/fs-f2fs
   SUBMENU:=$(FS_MENU)
   TITLE:=F2FS filesystem support
-  DEPENDS:= +kmod-crypto-hash +kmod-crypto-crc32 +kmod-nls-base
+  DEPENDS:= +kmod-crypto-hash +kmod-crypto-crc32 +kmod-nls-base \
+	+KERNEL_F2FS_FS_LZO:kmod-lib-lzo \
+	+KERNEL_F2FS_FS_LZ4:kmod-lib-lz4 \
+	+KERNEL_F2FS_FS_LZ4HC:kmod-lib-lz4hc \
+	+KERNEL_F2FS_FS_ZSTD:kmod-lib-zstd
   KCONFIG:=CONFIG_F2FS_FS
   FILES:=$(LINUX_DIR)/fs/f2fs/f2fs.ko
   AUTOLOAD:=$(call AutoLoad,30,f2fs,1)
@@ -270,6 +274,37 @@ endef
 
 define KernelPackage/fs-f2fs/description
  Kernel module for F2FS filesystem support
+endef
+
+define KernelPackage/fs-f2fs/config
+  if PACKAGE_kmod-fs-f2fs
+    config KERNEL_F2FS_FS_COMPRESSION
+            bool "F2FS compression feature"
+            help
+              Enable transparent compression for f2fs regular files. Select at
+              least one of the back-ends below, then mount with e.g.
+              compress_algorithm=zstd:3,compress_chksum
+
+    config KERNEL_F2FS_FS_LZO
+            bool "LZO compression support"
+            depends on KERNEL_F2FS_FS_COMPRESSION
+
+    config KERNEL_F2FS_FS_LZORLE
+            bool "LZO-RLE compression support"
+            depends on KERNEL_F2FS_FS_LZO
+
+    config KERNEL_F2FS_FS_LZ4
+            bool "LZ4 compression support"
+            depends on KERNEL_F2FS_FS_COMPRESSION
+
+    config KERNEL_F2FS_FS_LZ4HC
+            bool "LZ4HC compression support"
+            depends on KERNEL_F2FS_FS_LZ4
+
+    config KERNEL_F2FS_FS_ZSTD
+            bool "ZSTD compression support"
+            depends on KERNEL_F2FS_FS_COMPRESSION
+  endif
 endef
 
 $(eval $(call KernelPackage,fs-f2fs))


### PR DESCRIPTION
Transparent compression is a useful feature of f2fs but we currently do not build with support for it. This commit adds the option to build with the supported back-end compression algorithms. These are selectable under: `Global build settings >> Kernel build options >> F2FS compression feature` when the user selects kmod-fs-f2fs.

Once compiled in, users select one via a mount option, e.g.:
`compress_algorithm=zstd:3,compress_chksum`

The default option is to build without any so there is no impact on the kernel image size without user interaction.

Build system: x86/64
Build-tested: bcm27xx/bcm2712, bcm27xx/bcm2711
Run-tested: bcm27xx/bcm2712, bcm27xx/bcm2711