### PR TITLE
Fix: Config menu exit message

### DIFF
--- a/scripts/config/mconf.c
+++ b/scripts/config/mconf.c
@@ -978,7 +978,7 @@ static int handle_exit(void)
 	if (conf_get_changed())
 		res = dialog_yesno(NULL,
 				   "Do you wish to save your new configuration?\n"
-				     "(Press <ESC><ESC> to continue kernel configuration.)",
+				     "(Press <ESC><ESC> to continue your configuration.)",
 				   6, 60);
 	else
 		res = -1;


### PR DESCRIPTION
This message applies to the wholemenu program, fixing it.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
