### PR TITLE
ramips: restore full switch performance for USW-Flex

### DIFF
--- a/target/linux/ramips/dts/mt7621_ubnt_usw-flex.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_usw-flex.dts
@@ -64,19 +64,6 @@
 	label = "dsa";
 };
 
-&gmac1 {
-	status = "okay";
-	label = "lan1";
-	phy-handle = <&ethphy4>;
-
-	nvmem-cells = <&macaddr_eeprom>;
-	nvmem-cell-names = "mac-address";
-};
-
-&ethphy4 {
-	/delete-property/ interrupts;
-};
-
 &switch0 {
 	ports {
 		port@0 {
@@ -98,6 +85,11 @@
 			status = "okay";
 			label = "lan2";
 		};
+
+                port@4 {
+                        status = "okay";
+                        label = "lan1";
+                };
 	};
 };
 


### PR DESCRIPTION
I propose reverting #10238 for the USW-Flex where I don't see it making much sense, unlike for a routing device with a WAN port.

The low uplink performance of USW-Flex actually made me buy an inferior replacement switch before I realized that it was merely a configuration issue.

Using a different port for the switch uplink is not possible for me because lan1 is used for PoE-in and thus it must be the uplink.

@arinc9 Building my own firmware has fixed the issue for me, so I am good. This PR is just an attempt to be a good citizen and share my luck. Feel free to shoot it down if it does not fit your vision :)

_Commit message below:_

Since commit f1c9afd80138 ("ramips: mt7621-dts: mux phy0/4 to gmac1") the USW-Flex lan1 port has been attached directly to the CPU. This improves routing performance but hinders switching.

This is a generally accepted trade-off in that commit but for USW-Flex it is a questionable choice. This switch is designed to deliver PoE to remote places and using it as a router is unlikely. Meanwhile, the lan1 port is also PoE-in and will often be the uplink, carrying most of the traffic.

Reverting f1c9afd80138 for USW-Flex restores full 1 Gbps switching performance on all ports.
