### PR TITLE
ramips: add support for ZyXEL LTE3302

### DIFF
--- a/target/linux/ramips/dts/mt7620n_zyxel_lte3302.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_lte3302.dts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include "mt7620n.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	compatible = "zyxel,lte3302", "ralink,mt7620n-soc";
+	model = "Zyxel LTE3302-M432";
+
+	aliases {
+		led-boot = &led_sstrengthg;
+		led-failsafe = &led_onliney;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN_ONLINE;
+			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_onliney: led-1 {
+			color = <LED_COLOR_ID_YELLOW>;
+			function = LED_FUNCTION_WAN_ONLINE;
+			gpios = <&gpio2 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sstrengthg: led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_MOBILE;
+			gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_MOBILE;
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-5 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+
+		lte_modem_enable {
+			gpio-export,name = "lte_modem_enable";
+			gpio-export,output = <1>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <48000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "jboot";
+				reg = <0x0 0x10000>;
+				read-only;
+			};
+
+			partition@10000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>; 
+				openwrt,offset = <0x10000>;
+				label = "firmware";
+				reg = <0x10000 0xfe0000>;
+			};
+			
+			partition@ff0000 {
+				label = "config";
+				reg = <0xff0000 0x10000>;
+				read-only;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_config: eeprom@e07c {
+						reg = <0xe07c 0x200>;
+					};
+
+					macaddr_config: macaddr@e2cd {
+						compatible = "mac-base";
+						reg = <0xc2cd 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_config>;
+	nvmem-cell-names = "eeprom";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_config 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&state_default {
+	default {
+		groups = "spi refclk", "i2c", "ephy", "wled";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -1632,3 +1632,27 @@ define Device/zyxel_keenetic-viva
   SUPPORTED_DEVICES += kng_rc
 endef
 TARGET_DEVICES += zyxel_keenetic-viva
+
+define Device/zyxel_lte3302
+  $(Device/amit_jboot)
+  SOC := mt7620n
+  IMAGE_SIZE := 16256k
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_MODEL := LTE3302-M432
+  DLINK_ROM_ID := ZXL6E2431001
+  DLINK_FAMILY_MEMBER := 0x6E24
+  DLINK_FIRMWARE_SIZE := 0xFB0000
+  DEVICE_PACKAGES += kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+endef
+TARGET_DEVICES += zyxel_lte3302
+
+define Device/zyxel_lte3302-dt
+  $(Device/zyxel_lte3302)
+  DEVICE_DTS := mt7620n_zyxel_lte3302
+  DEVICE_VENDOR := ZyXEL
+  DEVICE_MODEL := LTE3302-M432
+  DEVICE_VARIANT := Deutsche Telekom
+  DLINK_ROM_ID := ZXL6E2431002
+  SUPPORTED_DEVICES := zyxel,lte3302
+endef
+TARGET_DEVICES += zyxel_lte3302-dt

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -290,6 +290,10 @@ zbtlink,zbt-we1026-h-32m)
 zbtlink,zbt-we2026)
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
 	;;
+zyxel,lte3302)
+	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x03"
+	ucidef_set_led_netdev "online_green" "Online Status Green" "green:wan-online" "wwan0"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -287,6 +287,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch1" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "7t@eth0"
 		;;
+	zyxel,lte3302)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "6@eth0"
+		;;
 	esac
 }
 
@@ -454,6 +458,10 @@ ramips_setup_macs()
 	zyxel,keenetic-omni-ii|\
 	zyxel,keenetic-viva)
 		wan_mac=$(mtd_get_mac_binary factory 0x28)
+		;;
+	zyxel,lte3302)
+		lan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
+		label_mac=$lan_mac
 		;;
 	esac
 

--- a/target/linux/ramips/mt7620/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7620/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -23,4 +23,9 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && [ -n "$label_mac" ] && \
 		macaddr_unsetbit "$label_mac" 6 > /sys${DEVPATH}/macaddress
 		;;
+	zyxel,lte3302)
+		base_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
+		wifi_mac=$(macaddr_add "$base_mac" 1)
+		echo -n "$wifi_mac" > /sys${DEVPATH}/macaddress
+		;;
 esac

--- a/target/linux/ramips/patches-6.6/861-qmi_wwan_fix_wnc_m18q5_init.patch
+++ b/target/linux/ramips/patches-6.6/861-qmi_wwan_fix_wnc_m18q5_init.patch
@@ -1,0 +1,11 @@
+--- a/drivers/net/usb/qmi_wwan.c
++++ b/drivers/net/usb/qmi_wwan.c
+@@ -1241,7 +1241,7 @@ static const struct usb_device_id produc
+ 	{QMI_FIXED_INTF(0x1435, 0x0918, 3)},	/* Wistron NeWeb D16Q1 */
+ 	{QMI_FIXED_INTF(0x1435, 0x0918, 4)},	/* Wistron NeWeb D16Q1 */
+ 	{QMI_FIXED_INTF(0x1435, 0x0918, 5)},	/* Wistron NeWeb D16Q1 */
+-	{QMI_FIXED_INTF(0x1435, 0x3185, 4)},	/* Wistron NeWeb M18Q5 */
++	{QMI_QUIRK_SET_DTR(0x1435, 0x3185, 4)},	/* Wistron NeWeb M18Q5 */
+ 	{QMI_FIXED_INTF(0x1435, 0xd111, 4)},	/* M9615A DM11-1 D51QC */
+ 	{QMI_FIXED_INTF(0x1435, 0xd181, 3)},	/* Wistron NeWeb D18Q1 */
+ 	{QMI_FIXED_INTF(0x1435, 0xd181, 4)},	/* Wistron NeWeb D18Q1 */

--- a/target/linux/ramips/patches-6.6/862-usb_option_bind_wnc_m18q_interfaces.patch
+++ b/target/linux/ramips/patches-6.6/862-usb_option_bind_wnc_m18q_interfaces.patch
@@ -1,0 +1,10 @@
+--- a/drivers/usb/serial/option.c
++++ b/drivers/usb/serial/option.c
+@@ -2300,6 +2300,7 @@ static const struct usb_device_id option
+ 	{ USB_DEVICE_AND_INTERFACE_INFO(0x07d1, 0x7e11, 0xff, 0xff, 0xff) },	/* D-Link DWM-156/A3 */
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x1435, 0xd191, 0xff),			/* Wistron Neweb D19Q1 */
+ 	  .driver_info = RSVD(1) | RSVD(4) },
++	{ USB_DEVICE_AND_INTERFACE_INFO(0x1435, 0x3185, 0xff, 0x00, 0x00) },    /* Wistron Neweb M18QW */
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x1690, 0x7588, 0xff),			/* ASKEY WWHC050 */
+ 	  .driver_info = RSVD(1) | RSVD(4) },
+ 	{ USB_DEVICE_INTERFACE_CLASS(0x2020, 0x2031, 0xff),			/* Olicard 600 */


### PR DESCRIPTION
ramips: add support for ZyXEL LTE3302

The ZyXEL LTE3302 is an 4G indoor CPE with 2 external LTE antennas. 
There are multiple variants of the device. This patch includes support for the "Deutsche Telekom" as well as the
"genuine ZyXEL" variant*. 
The device is fully functional including the LTE modem.

Specifications:

 - SoC: MediaTek MT7620N
 - RAM: 64 MB
 - Flash: 16 MB MB NOR (W25Q128FV)
 - WiFi: MediaTek MT7620N built in wifi
 - Switch: 2 LAN ports (100M)
 - LTE: WNC M18QW Modem 
 - SIM: 1 micro-SIM slot
 - Buttons: Reset, WPS
 - LEDs: Multicolor LTE signal, multicolor internet, Wifi, LAN, Battery 

The device is built as an indoor ethernet to LTE bridge or router with
Wifi.

UART Serial:

57600 8N1
Located on unpopulated 4 pin header J8:

 [o] GND
 [o] RX
 [o] TX
 [o] 3.3V Vcc

MAC assignment:
lan:  60:31:97:84:5F:EC (base, on the device back)
wlan: 60:31:97:84:5F:ED

Installation:
- Boot bootloader into recovery by pushing and holding the reset key while powering on the device
- Wait until lights start flashing quickly
- Open http://192.168.123.254
- Upload OpenWrt openwrt-ramips-mt7620-zyxel_lte3302-squashfs-factory.bin
- If http doesn't work, it can be done with curl command:
    curl -F FN=@XXXXX.bin http://192.168.123.254/upg
    where XXXXX.bin is name of firmware file.
- Wait for OpenWrt to boot and ssh to root@192.168.1.1


* variants differ by their ROM_ID. You can check the ROM_ID in the bootloader using the info command.
  The ROM_ID is needed for the factory firmware so that the booloader recognizes and accepts the firmware
