### PR TITLE
hostapd: fix logging of configuration content

### DIFF
--- a/package/network/services/hostapd/patches/701-reload_config_inline.patch
+++ b/package/network/services/hostapd/patches/701-reload_config_inline.patch
@@ -8,7 +8,7 @@ as adding/removing interfaces.
 
 --- a/hostapd/config_file.c
 +++ b/hostapd/config_file.c
-@@ -4981,7 +4981,12 @@ struct hostapd_config * hostapd_config_r
+@@ -4981,7 +4981,14 @@ struct hostapd_config * hostapd_config_r
  	int errors = 0;
  	size_t i;
  
@@ -19,6 +19,8 @@ as adding/removing interfaces.
 +	} else {
 +		f = fopen(fname, "r");
 +	}
++	wpa_printf(MSG_INFO, "Configuration file: Reading configuration file '%s'",
++	     fname);
  	if (f == NULL) {
  		wpa_printf(MSG_ERROR, "Could not open configuration file '%s' "
  			   "for reading.", fname);
@@ -39,3 +41,36 @@ as adding/removing interfaces.
  	if (f == NULL) {
  		wpa_printf(MSG_ERROR, "Failed to open config file '%s', "
  			   "error: %s", name, strerror(errno));
+--- a/hostapd/main.c
++++ b/hostapd/main.c
+@@ -406,7 +406,11 @@ hostapd_interface_init(struct hapd_inter
+ 	struct hostapd_iface *iface;
+ 	int k;
+ 
+-	wpa_printf(MSG_DEBUG, "Configuration file: %s", config_fname);
++	if (!strncmp(config_fname, "data:", 5)) {
++		wpa_printf(MSG_DEBUG, "Configuration file: %s", "<inline>");
++	} else {
++		wpa_printf(MSG_DEBUG, "Configuration file: %s", config_fname);
++	}
+ 	iface = hostapd_init(interfaces, config_fname);
+ 	if (!iface)
+ 		return NULL;
+--- a/src/ap/hostapd.c
++++ b/src/ap/hostapd.c
+@@ -3380,8 +3380,13 @@ hostapd_interface_init_bss(struct hapd_i
+ 		}
+ 	}
+ 
+-	wpa_printf(MSG_INFO, "Configuration file: %s (phy %s)%s",
+-		   config_fname, phy, iface ? "" : " --> new PHY");
++	if (!strncmp(config_fname, "data:", 5)) {
++		wpa_printf(MSG_INFO, "Configuration file: %s (phy %s)%s",
++		     "<inline>", phy, iface ? "" : " --> new PHY");
++	} else {
++		wpa_printf(MSG_INFO, "Configuration file: %s (phy %s)%s",
++		     config_fname, phy, iface ? "" : " --> new PHY");
++	}
+ 
+ 	conf = interfaces->config_read_cb(config_fname);
+ 	if (!conf)


### PR DESCRIPTION
As discussed in #17517, there are contents of hostapd's configuration file logged in syslog. This includes critical information like passphrase`. To circumvent this condition, this commit logs only "inline" if config_fname is inline data.

Otherwise the upstream logic of hostapd applies.

Fixes: #14049 