### PR TITLE
kernel: Make kmod-usb-chipidea depend on kmod-phy-ath79-usb

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -1737,7 +1737,7 @@ $(eval $(call KernelPackage,usbip-server))
 
 define KernelPackage/usb-chipidea
   TITLE:=Host and device support for Chipidea controllers
-  DEPENDS:=+USB_GADGET_SUPPORT:kmod-usb-gadget @TARGET_ath79 +kmod-usb-ehci +kmod-usb-phy-nop +kmod-usb-roles
+  DEPENDS:=+USB_GADGET_SUPPORT:kmod-usb-gadget @TARGET_ath79 +kmod-usb-ehci +kmod-usb-phy-nop +kmod-usb-roles +kmod-phy-ath79-usb
   KCONFIG:= \
 	CONFIG_EXTCON \
 	CONFIG_USB_CHIPIDEA \


### PR DESCRIPTION
The USB PHY on the ar9330 and similar SoCs needs the PHY driver. In OpenWrt 23.05 it was compiled into the kernel. The kernel 6.6 configuration does not compile it in any more, make the kmod-usb-chipidea driver depend on it to add it to the images.

Fixes: https://github.com/openwrt/openwrt/issues/17710