### PR TITLE
mac80211: remove unused variables

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -1004,9 +1004,6 @@ wpa_supplicant_start() {
 }
 
 mac80211_setup_supplicant() {
-	local enable=$1
-	local add_sp=0
-
 	wpa_supplicant_prepare_interface "$ifname" nl80211 || return 1
 
 	if [ "$mode" = "sta" ]; then
@@ -1147,10 +1144,6 @@ drv_mac80211_setup() {
 	}
 
 	set_default ifname_prefix "$phy$vif_phy_suffix-"
-
-	local wdev
-	local cwdev
-	local found
 
 	# convert channel to frequency
 	[ "$auto_channel" -gt 0 ] || freq="$(get_freq "$phy" "$channel" "$band")"


### PR DESCRIPTION
These were leftovers from hostapd ubus support, added in e56c5f7b276a17f4c9b9321e1e6fbef0bf8ca6c6

Changes are shown here:
https://github.com/openwrt/openwrt/commit/e56c5f7b276a17f4c9b9321e1e6fbef0bf8ca6c6#diff-536ed015e7ce65a8888a1943510ecc58d26619becbbec8a7d914e82f8d319162R972

https://github.com/openwrt/openwrt/commit/e56c5f7b276a17f4c9b9321e1e6fbef0bf8ca6c6#diff-536ed015e7ce65a8888a1943510ecc58d26619becbbec8a7d914e82f8d319162

I stumbled across these unused variables, which are not referenced anywhere.
@nbd168 