### PR TITLE
ramips: Add alternate support for TP-Link FR205

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -915,7 +915,7 @@ define Device/dlink_dir-2150-r1
   KERNEL := $$(KERNEL)
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
-	check-size | sign-dlink-ru e6587b35a6b34e07bedeca23e140322f 
+	check-size | sign-dlink-ru e6587b35a6b34e07bedeca23e140322f
 endef
 TARGET_DEVICES += dlink_dir-2150-r1
 
@@ -2378,7 +2378,7 @@ define Device/openfi_5pro
   $(Device/dsa-migration)
   IMAGE_SIZE := 65216k
   DEVICE_VENDOR := OpenFi
-  DEVICE_MODEL := 5Pro 
+  DEVICE_MODEL := 5Pro
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap kmod-usb3 \
 	kmod-mmc-mtk
 endef
@@ -2763,6 +2763,9 @@ define Device/tplink_er605-v2
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := ER605
   DEVICE_VARIANT := v2
+  DEVICE_ALT0_VENDOR := TP-Link
+  DEVICE_ALT0_MODEL := FR205
+  DEVICE_ALT0_VARIANT := v1
   DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 -uboot-envtools
   KERNEL_IN_UBI := 1
   KERNEL_LOADADDR := 0x82000000


### PR DESCRIPTION
This is a MT7621-based device with 128MB NAND flash, 256MB RAM, and a USB port. It is identical hardware to the already supported TP-Link ER605 v2 right down to the PCB ID.  The only differences are the color of the case and the factory firmware features.

Signed-off-by: Raylynn Knight <rayknight@me.com>