### PR TITLE
mediatek: mt7622: Remove the reserved badblock partition from Totolink A8000RU

### DIFF
--- a/target/linux/mediatek/dts/mt7622-totolink-a8000ru.dts
+++ b/target/linux/mediatek/dts/mt7622-totolink-a8000ru.dts
@@ -245,13 +245,15 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&serial_nand_pins>;
 	status = "okay";
-	flash@0 {
+
+	snand: flash@0 {
 		compatible = "spi-nand";
+		mediatek,bmt-v2;
+		mediatek,bmt-table-size = <0x1000>;
+		nand-ecc-engine = <&snfi>;
 		reg = <0>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
-		nand-ecc-engine = <&snfi>;
-		mediatek,bmt-v2;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -310,12 +312,6 @@
 			partition@6600000 {
 				label = "User_data";
 				reg = <0x6600000 0x100000>;
-			};
-
-			/* size of this partition varies due to BMT & bad blocks. */
-			partition@6700000 {
-				label = "reserved";
-				reg = <0x6700000 0>;
 			};
 		};
 	};


### PR DESCRIPTION
Recent builds on this device cannot reserve enough physical erase block size for bad PEB handling.

```
ubi0 warning: ubi_eba_init: cannot reserve enough PEBs for bad PEB handling, reserved 6, need 19
```

Lets remove the unuseful reserved partition and let the system handle bad block management automatically.

Tested on my device without any issues.

```
ubi0: available PEBs: 0, total reserved PEBs: 800, PEBs reserved for bad PEB handling: 19
```

