### PR TITLE
octeon: ubnt-usg: add board name to supported devices

### DIFF
--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -92,6 +92,7 @@ define Device/ubnt_unifi-usg
   DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-leds-gpio
   DEVICE_DTS := cn5020_ubnt_usg
   KERNEL += | append-dtb-to-elf
+  SUPPORTED_DEVICES += ubnt,usg
 endef
 TARGET_DEVICES += ubnt_unifi-usg
 


### PR DESCRIPTION
The on-device board name reported by 'ubus call system board' is not present in the generated profiles.json.  This results in upgrade tools being unable to match the image with the proper device.  Let's add a 'SUPPORTED_DEVICES' entry for the board name to fix this.

Links: https://forum.openwrt.org/t/owut-openwrt-upgrade-tool/200035/441
Links: https://github.com/openwrt/openwrt/commit/2a07270180ed0e295d854d6e9e59c78c40549efc
