### PR TITLE
ramips: mt7620: fix patching mac address in caldata

### DIFF
--- a/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -34,12 +34,12 @@ case "$FIRMWARE" in
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		wifi_mac=$(macaddr_add "$wan_mac" 1)
 		jboot_eeprom_extract "config" 0xE000
-		caldata_patch_mac $wifi_mac 0x4
+		caldata_patch_data "${wifi_mac//:/}" 0x4
 		;;
 	dovado,tiny-ac)
 		wifi_mac=$(mtd_get_mac_ascii u-boot-env INIC_MAC_ADDR)
 		caldata_extract "factory" 0x0 0x200
-		caldata_patch_mac $wifi_mac 0x4
+		caldata_patch_data "${wifi_mac//:/}" 0x4
 		;;
 	*)
 		caldata_die "Please define mtd-eeprom in $board DTS file!"


### PR DESCRIPTION
Fix usage of non-existent 'caldata_patch_mac' function by using the 'caldata_patch_data' function.

Fixes: #17734