### PR TITLE
mediatek: filogic: fix 2.5G phy compatible for WR3000H

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
@@ -160,7 +160,7 @@
 	};
 
 	phy6: ethernet-phy@6 {
-		compatible = "ethernet-phy-ieee802.3-c22";
+		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <6>;
 		reset-assert-us = <100000>;
 		reset-deassert-us = <100000>;


### PR DESCRIPTION
Following the initial support of the cudy wr3000h with PHY C22 for the
2.5G wan interface, support improvements changes have been made that
affect the initial support,  also changes in probe fix issues with
RealTek RTL8221B PHYs affected the initial support.

This change allows the DTS to be standar with the other cudy
equipment while the wan port is working after the changes with C45
instead of C22.
