### PR TITLE
netifd: change "wifi reload_legacy" to "wifi reload"

### DIFF
--- a/package/network/config/netifd/files/etc/init.d/network
+++ b/package/network/config/netifd/files/etc/init.d/network
@@ -30,7 +30,7 @@ reload_service() {
 
 	init_switch
 	ubus call network reload || rv=1
-	[ -x /sbin/wifi ] && /sbin/wifi reload_legacy
+	[ -x /sbin/wifi ] && /sbin/wifi reload
 	return $rv
 }
 


### PR DESCRIPTION
In the commit d12753929165 the reload_legacy option has been removed. 
This patch removes the remaining in the code "wifi reload_lagacy",
changing them to "wifi reload".

Fixes: https://github.com/openwrt/openwrt/issues/17738
