### PR TITLE
apm821xx: NETGEAR WNDR4700: Fix compat version

### DIFF
--- a/target/linux/apm821xx/image/nand.mk
+++ b/target/linux/apm821xx/image/nand.mk
@@ -89,9 +89,6 @@ endef
 TARGET_DEVICES += netgear_wndap660
 
 define Device/netgear_wndr4700
-  DEVICE_COMPAT_VERSION := 3.0
-  DEVICE_COMPAT_MESSAGE := Network swconfig configuration cannot be upgraded to DSA. \
-       Upgrade via sysupgrade mechanism is not possible.
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := Centria N900 WNDR4700
   DEVICE_ALT0_VENDOR := NETGEAR
@@ -123,8 +120,9 @@ define Device/netgear_wndr4700
   NETGEAR_HW_ID := 29763875+128+256
   UBINIZE_OPTS := -E 5
   SUPPORTED_DEVICES += wndr4700
-  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_VERSION := 3.0
   DEVICE_COMPAT_MESSAGE := kernel and ubi partitions had to be resized. \
+       Network swconfig configuration cannot be upgraded to DSA. \
        Upgrade via sysupgrade mechanism is not possible.
 endef
 TARGET_DEVICES += netgear_wndr4700


### PR DESCRIPTION
The definition for the netgear_wndr4700 had two different DEVICE_COMPAT_VERSION definitions.
First it was moved to version 3.0 in commit 5815884c3a2 ("apm821xx: migrate to DSA"), the it was later changed to version 2.0 by an additional definition at the end of the board definition in commit 82c8c38a5c23 ("apm821xx: prepare WNDR4700 for 6.6 - add preliminary u-boot-env access").

Move it to version 4.0 now.

Fixes: 82c8c38a5c23 ("apm821xx: prepare WNDR4700 for 6.6 - add preliminary u-boot-env access")

This was reported in the forum: https://forum.openwrt.org/t/openwrt-24-10-0-rc6-sixth-release-candidate/222466/43