### PR TITLE
mediatek: filogic: increase spi flash memory speed on ZyXEL EX5601

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -168,7 +168,7 @@
                 #size-cells = <1>;
                 compatible = "spi-nand";
                 reg = <1>;
-                spi-max-frequency = <10000000>;
+                spi-max-frequency = <20000000>;
                 spi-tx-bus-width = <4>;
                 spi-rx-bus-width = <4>;
 


### PR DESCRIPTION
The factory firmware uses a 20 MHz frequency, so it should be safe. The same frequency is already used by openwrt u-boot.

Before:
10485760 bytes (10 MB, 10 MiB) copied, 2.53096 s, 4.1 MB/s

After:
10485760 bytes (10 MB, 10 MiB) copied, 1.51901 s, 6.9 MB/s

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>