### PR TITLE
ipq60xx: fix uboot-envtools file syntax error in uci-defaults

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq60xx
@@ -29,6 +29,7 @@ tplink,eap610-outdoor)
 	idx="$(find_mtd_index 0:appsblenv)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000"
+	;;
 yuncore,fap650)
 	idx="$(find_mtd_index 0:appsblenv)"
 	[ -n "$idx" ] && \


### PR DESCRIPTION
The syntax error prevented the correct creation of all ipq60xx U-Boot environment files: /etc/config/ubootenv and /etc/fw_env.config

Signed-off-by: Ivan Deng <hongba@rocketmail.com>