### PR TITLE
octeon/generic: ubnt,erlite: define profile

### DIFF
--- a/target/linux/octeon/base-files/etc/board.d/01_network
+++ b/target/linux/octeon/base-files/etc/board.d/01_network
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014-2015 OpenWrt.org
+# Copyright (C) 2014-2025 OpenWrt.org
 #
 
 . /lib/functions/uci-defaults.sh
@@ -8,6 +8,7 @@ board_config_update
 
 case "$(board_name)" in
 itus,shield-router|\
+ubnt,erlite|\
 ubnt,usg)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;

--- a/target/linux/octeon/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/octeon/base-files/lib/preinit/01_sysinfo
@@ -14,8 +14,11 @@ do_sysinfo_octeon() {
 	esac
 
 	case "$machine" in
-	"UBNT_E100"*)
-		name="erlite"
+	"UBNT_E100"*|\
+	"UBNT_E300"*|\
+	"UBNT_USG"*)
+		# let generic 02_sysinfo handle it since device has its own device tree
+		return 0
 		;;
 
 	"UBNT_E200"*)
@@ -24,12 +27,6 @@ do_sysinfo_octeon() {
 
 	"UBNT_E220"*)
 		name="erpro"
-		;;
-
-	"UBNT_E300"*|\
-	"UBNT_USG"*)
-		# let generic 02_sysinfo handle it since device has its own device tree
-		return 0
 		;;
 
 	"ITUS_SHIELD"*)

--- a/target/linux/octeon/base-files/lib/preinit/79_move_config
+++ b/target/linux/octeon/base-files/lib/preinit/79_move_config
@@ -25,7 +25,7 @@ octeon_move_config() {
 	. /lib/functions.sh
 
 	case "$(board_name)" in
-		erlite|\
+		ubnt,erlite|\
 		ubnt,usg)
 			move_config "/dev/sda1" "vfat"
 			;;

--- a/target/linux/octeon/base-files/lib/upgrade/platform.sh
+++ b/target/linux/octeon/base-files/lib/upgrade/platform.sh
@@ -47,7 +47,7 @@ platform_copy_config_helper() {
 
 platform_copy_config() {
 	case "$(board_name)" in
-	erlite|\
+	ubnt,erlite|\
 	ubnt,usg)
 		platform_copy_config_helper /dev/sda1 vfat
 		;;
@@ -132,7 +132,7 @@ platform_do_upgrade() {
 	ubnt,edgerouter-6p)
 		kernel=/dev/mmcblk0p1
 		;;
-	erlite|\
+	ubnt,erlite|\
 	ubnt,usg)
 		kernel=/dev/sda1
 		;;
@@ -161,10 +161,10 @@ platform_check_image() {
 
 	case "$board" in
 	er | \
-	erlite | \
 	itus,shield-router | \
 	ubnt,edgerouter-4 | \
 	ubnt,edgerouter-6p | \
+	ubnt,erlite | \
 	ubnt,usg | \
 	cisco,vedge1000)
 		local kernel_length=$(tar xf $tar_file $board_dir/kernel -O | wc -c 2> /dev/null)

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn5020_ubnt_edgerouter-lite.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn5020_ubnt_edgerouter-lite.dts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Device tree source for Ubiquity Edgerouter Lite
+ */
+
+/include/ "ubnt_e100.dts"
+
+/ {
+	compatible = "ubnt,erlite", "cavium,cn5020";
+	model = "Ubiquiti Edgerouter Lite";
+};

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -79,18 +79,21 @@ ERLITE_CMDLINE:=-mtdparts=phys_mapped_flash:512k(boot0)ro,512k(boot1)ro,64k(eepr
 define Device/ubnt_edgerouter-lite
   DEVICE_VENDOR := Ubiquiti
   DEVICE_MODEL := EdgeRouter Lite
-  BOARD_NAME := erlite
+  DEVICE_DTS := cn5020_ubnt_edgerouter-lite
+  KERNEL := kernel-bin | patch-cmdline | append-dtb-to-elf
+  KERNEL_DEPENDS := $$(wildcard $(DTS_DIR)/$(DEVICE_DTS).dts)
   CMDLINE := $(ERLITE_CMDLINE)
-  SUPPORTED_DEVICES += erlite
+  SUPPORTED_DEVICES += erlite ubnt,erlite
 endef
 TARGET_DEVICES += ubnt_edgerouter-lite
 
 define Device/ubnt_unifi-usg
-  $(Device/ubnt_edgerouter-lite)
+  DEVICE_VENDOR := Ubiquiti
   DEVICE_MODEL := UniFi Security Gateway
   BOARD_NAME := ubnt,usg
   DEVICE_PACKAGES += kmod-gpio-button-hotplug kmod-leds-gpio
   DEVICE_DTS := cn5020_ubnt_usg
+  CMDLINE := $(ERLITE_CMDLINE)
   KERNEL += | append-dtb-to-elf
   SUPPORTED_DEVICES += ubnt,usg
 endef


### PR DESCRIPTION
Currently the erlite install shows Model as EBNT_E100, uses eth0 as lan, eth1 as wan, and doesn't use eth2.

- define dts for this device, such that we get a cleaner naming here
- fix handing of this device to inlude eth2
- change eth0 to wan, like er-4/usg/etc as it once was intended

Link: https://github.com/openwrt/openwrt/issues/14946