### PR TITLE
ramips-mt762x: add label-mac-device to ex61x0

### DIFF
--- a/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
@@ -10,6 +10,7 @@
 		led-failsafe = &led_power_amber;
 		led-running = &led_power_green;
 		led-upgrade = &led_power_green;
+		label-mac-device = &ethernet;
 	};
 
 	keys {

--- a/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &power_amber;
 		led-running = &power_green;
 		led-upgrade = &power_amber;
+		label-mac-device = &gmac0;
 	};
 
 	leds {


### PR DESCRIPTION
the label-mac should be set correctly on the netgear ex6150 and netgear ex6120. This is required for gluon support.
See: https://github.com/freifunk-gluon/gluon/pull/3420

I am unsure if the EX6150 requires the mac from gmac0 or from ethernet as well to show the label-mac correctly.