### PR TITLE
[24.10] imx venice

### DIFF
--- a/target/linux/generic/backport-6.6/903-v6.12-Bluetooth-btsdio-Do-not-bind-to-non-removable-CYW437.patch
+++ b/target/linux/generic/backport-6.6/903-v6.12-Bluetooth-btsdio-Do-not-bind-to-non-removable-CYW437.patch
@@ -1,0 +1,25 @@
+From 6a9eb32230f33ae273f6ffbabb0aaf560869816e Mon Sep 17 00:00:00 2001
+From: Scott Ehlert <ehlert@battelle.org>
+Date: Mon, 29 Apr 2024 11:23:09 -0700
+Subject: [PATCH] Bluetooth: btsdio: Do not bind to non-removable CYW4373
+
+CYW4373 devices soldered onto the PCB (non-removable),
+use a UART connection for Bluetooth and the advertised btsdio
+support as an SDIO function should be ignored.
+
+Signed-off-by: Scott Ehlert <ehlert@battelle.org>
+Signed-off-by: Tim Harvey <tharvey@gateworks.com>
+---
+ drivers/bluetooth/btsdio.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/bluetooth/btsdio.c
++++ b/drivers/bluetooth/btsdio.c
+@@ -295,6 +295,7 @@ static int btsdio_probe(struct sdio_func
+ 		case SDIO_DEVICE_ID_BROADCOM_4345:
+ 		case SDIO_DEVICE_ID_BROADCOM_43455:
+ 		case SDIO_DEVICE_ID_BROADCOM_4356:
++		case SDIO_DEVICE_ID_BROADCOM_CYPRESS_4373:
+ 			return -ENODEV;
+ 		}
+ 	}

--- a/target/linux/imx/cortexa53/base-files/etc/board.d/02_network
+++ b/target/linux/imx/cortexa53/base-files/etc/board.d/02_network
@@ -9,7 +9,8 @@ gw,imx8mm-gw72xx-0x|\
 gw,imx8mp-gw72xx-2x|\
 gw,imx8mm-gw73xx-0x|\
 gw,imx8mp-gw73xx-2x|\
-gw,imx8mm-gw7902-0x)
+gw,imx8mm-gw7902-0x|\
+gateworks,imx8mp-gw82xx-2x)
 	ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 	;;
 gw,imx8mm-gw7901)

--- a/target/linux/imx/patches-6.6/500-6.13-arm64-dts-imx8mm-venice-add-RTC-aliases.patch
+++ b/target/linux/imx/patches-6.6/500-6.13-arm64-dts-imx8mm-venice-add-RTC-aliases.patch
@@ -1,0 +1,189 @@
+From 82b521f4bb8cab09aa016acf2c1b55ffc736eb2e Mon Sep 17 00:00:00 2001
+From: Tim Harvey <tharvey@gateworks.com>
+Date: Mon, 9 Sep 2024 15:15:01 -0700
+Subject: [PATCH] arm64: dts: imx8mm-venice-*: add RTC aliases
+
+Add aliases for the RTCs on the Gateworks Venice boards and on the imx8m
+SoC. This ensures that the primary RTC is always the one on-board
+provided by the Gateworks System Controller (GSC) which is battery
+backed as opposed to the one in the IMX8M.
+
+Signed-off-by: Tim Harvey <tharvey@gateworks.com>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ arch/arm64/boot/dts/freescale/imx8mm-venice-gw700x.dtsi | 7 ++++++-
+ arch/arm64/boot/dts/freescale/imx8mm-venice-gw7901.dts  | 4 +++-
+ arch/arm64/boot/dts/freescale/imx8mm-venice-gw7902.dts  | 4 +++-
+ arch/arm64/boot/dts/freescale/imx8mm-venice-gw7903.dts  | 4 +++-
+ arch/arm64/boot/dts/freescale/imx8mm-venice-gw7904.dts  | 7 ++++++-
+ arch/arm64/boot/dts/freescale/imx8mn-venice-gw7902.dts  | 4 +++-
+ arch/arm64/boot/dts/freescale/imx8mp-venice-gw702x.dtsi | 4 +++-
+ arch/arm64/boot/dts/freescale/imx8mp-venice-gw74xx.dts  | 4 +++-
+ 8 files changed, 30 insertions(+), 8 deletions(-)
+
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw700x.dtsi
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw700x.dtsi
+@@ -8,6 +8,11 @@
+ #include <dt-bindings/net/ti-dp83867.h>
+ 
+ / {
++	aliases {
++		rtc0 = &gsc_rtc;
++		rtc1 = &snvs_rtc;
++	};
++
+ 	memory@40000000 {
+ 		device_type = "memory";
+ 		reg = <0x0 0x40000000 0 0x80000000>;
+@@ -272,7 +277,7 @@
+ 		pagesize = <16>;
+ 	};
+ 
+-	rtc@68 {
++	gsc_rtc: rtc@68 {
+ 		compatible = "dallas,ds1672";
+ 		reg = <0x68>;
+ 	};
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw7901.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw7901.dts
+@@ -22,6 +22,8 @@
+ 		ethernet2 = &lan2;
+ 		ethernet3 = &lan3;
+ 		ethernet4 = &lan4;
++		rtc0 = &gsc_rtc;
++		rtc1 = &snvs_rtc;
+ 		usb0 = &usbotg1;
+ 		usb1 = &usbotg2;
+ 	};
+@@ -495,7 +497,7 @@
+ 		pagesize = <16>;
+ 	};
+ 
+-	rtc@68 {
++	gsc_rtc: rtc@68 {
+ 		compatible = "dallas,ds1672";
+ 		reg = <0x68>;
+ 	};
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw7902.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw7902.dts
+@@ -19,6 +19,8 @@
+ 
+ 	aliases {
+ 		ethernet1 = &eth1;
++		rtc0 = &gsc_rtc;
++		rtc1 = &snvs_rtc;
+ 		usb0 = &usbotg1;
+ 		usb1 = &usbotg2;
+ 	};
+@@ -562,7 +564,7 @@
+ 		pagesize = <16>;
+ 	};
+ 
+-	rtc@68 {
++	gsc_rtc: rtc@68 {
+ 		compatible = "dallas,ds1672";
+ 		reg = <0x68>;
+ 	};
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw7903.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw7903.dts
+@@ -18,6 +18,8 @@
+ 
+ 	aliases {
+ 		ethernet0 = &fec1;
++		rtc0 = &gsc_rtc;
++		rtc1 = &snvs_rtc;
+ 		usb0 = &usbotg1;
+ 	};
+ 
+@@ -392,7 +394,7 @@
+ 		pagesize = <16>;
+ 	};
+ 
+-	rtc@68 {
++	gsc_rtc: rtc@68 {
+ 		compatible = "dallas,ds1672";
+ 		reg = <0x68>;
+ 	};
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw7904.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw7904.dts
+@@ -16,6 +16,11 @@
+ 	model = "Gateworks Venice GW7904 i.MX8MM board";
+ 	compatible = "gateworks,imx8mm-gw7904", "fsl,imx8mm";
+ 
++	aliases {
++		rtc0 = &gsc_rtc;
++		rtc1 = &snvs_rtc;
++	};
++
+ 	chosen {
+ 		stdout-path = &uart2;
+ 	};
+@@ -436,7 +441,7 @@
+ 		pagesize = <16>;
+ 	};
+ 
+-	rtc@68 {
++	gsc_rtc: rtc@68 {
+ 		compatible = "dallas,ds1672";
+ 		reg = <0x68>;
+ 	};
+--- a/arch/arm64/boot/dts/freescale/imx8mn-venice-gw7902.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mn-venice-gw7902.dts
+@@ -17,6 +17,8 @@
+ 	compatible = "gw,imx8mn-gw7902", "fsl,imx8mn";
+ 
+ 	aliases {
++		rtc0 = &gsc_rtc;
++		rtc1 = &snvs_rtc;
+ 		usb0 = &usbotg1;
+ 	};
+ 
+@@ -560,7 +562,7 @@
+ 		pagesize = <16>;
+ 	};
+ 
+-	rtc@68 {
++	gsc_rtc: rtc@68 {
+ 		compatible = "dallas,ds1672";
+ 		reg = <0x68>;
+ 	};
+--- a/arch/arm64/boot/dts/freescale/imx8mp-venice-gw702x.dtsi
++++ b/arch/arm64/boot/dts/freescale/imx8mp-venice-gw702x.dtsi
+@@ -10,6 +10,8 @@
+ / {
+ 	aliases {
+ 		ethernet0 = &eqos;
++		rtc0 = &gsc_rtc;
++		rtc1 = &snvs_rtc;
+ 	};
+ 
+ 	memory@40000000 {
+@@ -260,7 +262,7 @@
+ 		pagesize = <16>;
+ 	};
+ 
+-	rtc@68 {
++	gsc_rtc: rtc@68 {
+ 		compatible = "dallas,ds1672";
+ 		reg = <0x68>;
+ 	};
+--- a/arch/arm64/boot/dts/freescale/imx8mp-venice-gw74xx.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-venice-gw74xx.dts
+@@ -24,6 +24,8 @@
+ 		ethernet4 = &lan3;
+ 		ethernet5 = &lan4;
+ 		ethernet6 = &lan5;
++		rtc0 = &gsc_rtc;
++		rtc1 = &snvs_rtc;
+ 	};
+ 
+ 	chosen {
+@@ -444,7 +446,7 @@
+ 		pagesize = <16>;
+ 	};
+ 
+-	rtc@68 {
++	gsc_rtc: rtc@68 {
+ 		compatible = "dallas,ds1672";
+ 		reg = <0x68>;
+ 	};

--- a/target/linux/imx/patches-6.6/501-6.13-arm64-dts-imx8mp-venice-gw74xx-add-M2SKT_GPIO10-gpio.patch
+++ b/target/linux/imx/patches-6.6/501-6.13-arm64-dts-imx8mp-venice-gw74xx-add-M2SKT_GPIO10-gpio.patch
@@ -1,0 +1,36 @@
+From e6d8fd29bd3d796a00ff9b69f9fae011aec3cb40 Mon Sep 17 00:00:00 2001
+From: Tim Harvey <tharvey@gateworks.com>
+Date: Thu, 5 Sep 2024 11:32:28 -0700
+Subject: [PATCH] arm64: dts: imx8mp-venice-gw74xx: add M2SKT_GPIO10 gpio
+ configuration
+
+The GW74xx D revision has added a M2SKT_GPIO10 GPIO which routes to the
+GPIO10 pin of the M.2 socket for compatibility with certain devices.
+
+Add the iomux and a line name for this.
+
+Signed-off-by: Tim Harvey <tharvey@gateworks.com>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ arch/arm64/boot/dts/freescale/imx8mp-venice-gw74xx.dts | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/freescale/imx8mp-venice-gw74xx.dts
++++ b/arch/arm64/boot/dts/freescale/imx8mp-venice-gw74xx.dts
+@@ -264,7 +264,7 @@
+ &gpio3 {
+ 	gpio-line-names =
+ 		"", "", "", "", "", "", "m2_rst", "",
+-		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "m2_gpio10", "",
+ 		"", "", "", "", "", "", "", "",
+ 		"", "", "", "", "", "", "", "";
+ };
+@@ -786,6 +786,7 @@
+ 			MX8MP_IOMUXC_SD2_CMD__GPIO2_IO14	0x40000150 /* PCIE3_WDIS# */
+ 			MX8MP_IOMUXC_SD2_DATA3__GPIO2_IO18	0x40000150 /* PCIE2_WDIS# */
+ 			MX8MP_IOMUXC_NAND_DATA00__GPIO3_IO06	0x40000040 /* M2SKT_RST# */
++			MX8MP_IOMUXC_NAND_DQS__GPIO3_IO14	0x40000040 /* M2SKT_GPIO10 */
+ 			MX8MP_IOMUXC_SAI3_TXD__GPIO5_IO01	0x40000104 /* UART_TERM */
+ 			MX8MP_IOMUXC_SAI3_TXFS__GPIO4_IO31	0x40000104 /* UART_RS485 */
+ 			MX8MP_IOMUXC_SAI3_TXC__GPIO5_IO00	0x40000104 /* UART_HALF */

--- a/target/linux/imx/patches-6.6/502-6.13-arm64-dts-freescale-rename-gw7905-to-gw75xx.patch
+++ b/target/linux/imx/patches-6.6/502-6.13-arm64-dts-freescale-rename-gw7905-to-gw75xx.patch
@@ -1,0 +1,1426 @@
+From 14c3de96e14b30b1b83016abe607034a5a7e1c6b Mon Sep 17 00:00:00 2001
+From: Tim Harvey <tharvey@gateworks.com>
+Date: Wed, 24 Jan 2024 10:16:03 -0800
+Subject: [PATCH] arm64: dts: freescale: rename gw7905 to gw75xx
+
+The GW7905 was renamed to GW7500 before production release.
+
+Signed-off-by: Tim Harvey <tharvey@gateworks.com>
+---
+ Documentation/devicetree/bindings/arm/fsl.yaml              | 4 ++--
+ arch/arm64/boot/dts/freescale/Makefile                      | 4 ++--
+ ...8mm-venice-gw7905-0x.dts => imx8mm-venice-gw75xx-0x.dts} | 6 +++---
+ ...{imx8mm-venice-gw7905.dtsi => imx8mm-venice-gw75xx.dtsi} | 0
+ ...8mp-venice-gw7905-2x.dts => imx8mp-venice-gw75xx-2x.dts} | 6 +++---
+ ...{imx8mp-venice-gw7905.dtsi => imx8mp-venice-gw75xx.dtsi} | 0
+ 6 files changed, 10 insertions(+), 10 deletions(-)
+ rename arch/arm64/boot/dts/freescale/{imx8mm-venice-gw7905-0x.dts => imx8mm-venice-gw75xx-0x.dts} (67%)
+ rename arch/arm64/boot/dts/freescale/{imx8mm-venice-gw7905.dtsi => imx8mm-venice-gw75xx.dtsi} (100%)
+ rename arch/arm64/boot/dts/freescale/{imx8mp-venice-gw7905-2x.dts => imx8mp-venice-gw75xx-2x.dts} (67%)
+ rename arch/arm64/boot/dts/freescale/{imx8mp-venice-gw7905.dtsi => imx8mp-venice-gw75xx.dtsi} (100%)
+
+--- a/Documentation/devicetree/bindings/arm/fsl.yaml
++++ b/Documentation/devicetree/bindings/arm/fsl.yaml
+@@ -908,8 +908,8 @@ properties:
+               - fsl,imx8mm-ddr4-evk       # i.MX8MM DDR4 EVK Board
+               - fsl,imx8mm-evk            # i.MX8MM EVK Board
+               - fsl,imx8mm-evkb           # i.MX8MM EVKB Board
++              - gateworks,imx8mm-gw75xx-0x # i.MX8MM Gateworks Board
+               - gateworks,imx8mm-gw7904
+-              - gateworks,imx8mm-gw7905-0x # i.MX8MM Gateworks Board
+               - gw,imx8mm-gw71xx-0x       # i.MX8MM Gateworks Development Kit
+               - gw,imx8mm-gw72xx-0x       # i.MX8MM Gateworks Development Kit
+               - gw,imx8mm-gw73xx-0x       # i.MX8MM Gateworks Development Kit
+@@ -1036,7 +1036,7 @@ properties:
+               - gateworks,imx8mp-gw72xx-2x # i.MX8MP Gateworks Board
+               - gateworks,imx8mp-gw73xx-2x # i.MX8MP Gateworks Board
+               - gateworks,imx8mp-gw74xx   # i.MX8MP Gateworks Board
+-              - gateworks,imx8mp-gw7905-2x # i.MX8MP Gateworks Board
++              - gateworks,imx8mp-gw75xx-2x # i.MX8MP Gateworks Board
+               - toradex,verdin-imx8mp     # Verdin iMX8M Plus Modules
+               - toradex,verdin-imx8mp-nonwifi  # Verdin iMX8M Plus Modules without Wi-Fi / BT
+               - toradex,verdin-imx8mp-wifi  # Verdin iMX8M Plus Wi-Fi / BT Modules
+--- a/arch/arm64/boot/dts/freescale/Makefile
++++ b/arch/arm64/boot/dts/freescale/Makefile
+@@ -72,11 +72,11 @@ dtb-$(CONFIG_ARCH_MXC) += imx8mm-var-som
+ dtb-$(CONFIG_ARCH_MXC) += imx8mm-venice-gw71xx-0x.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mm-venice-gw72xx-0x.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mm-venice-gw73xx-0x.dtb
++dtb-$(CONFIG_ARCH_MXC) += imx8mm-venice-gw75xx-0x.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mm-venice-gw7901.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mm-venice-gw7902.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mm-venice-gw7903.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mm-venice-gw7904.dtb
+-dtb-$(CONFIG_ARCH_MXC) += imx8mm-venice-gw7905-0x.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mm-verdin-nonwifi-dahlia.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mm-verdin-nonwifi-dev.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mm-verdin-nonwifi-yavia.dtb
+@@ -107,7 +107,7 @@ dtb-$(CONFIG_ARCH_MXC) += imx8mp-venice-
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-venice-gw72xx-2x.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-venice-gw73xx-2x.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-venice-gw74xx.dtb
+-dtb-$(CONFIG_ARCH_MXC) += imx8mp-venice-gw7905-2x.dtb
++dtb-$(CONFIG_ARCH_MXC) += imx8mp-venice-gw75xx-2x.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-verdin-nonwifi-dahlia.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-verdin-nonwifi-dev.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-verdin-nonwifi-yavia.dtb
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw7905-0x.dts
++++ /dev/null
+@@ -1,28 +0,0 @@
+-// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+-/*
+- * Copyright 2023 Gateworks Corporation
+- */
+-
+-/dts-v1/;
+-
+-#include "imx8mm.dtsi"
+-#include "imx8mm-venice-gw700x.dtsi"
+-#include "imx8mm-venice-gw7905.dtsi"
+-
+-/ {
+-	model = "Gateworks Venice GW7905-0x i.MX8MM Development Kit";
+-	compatible = "gateworks,imx8mm-gw7905-0x", "fsl,imx8mm";
+-
+-	chosen {
+-		stdout-path = &uart2;
+-	};
+-};
+-
+-/* Disable SOM interfaces not used on baseboard */
+-&fec1 {
+-	status = "disabled";
+-};
+-
+-&usdhc1 {
+-	status = "disabled";
+-};
+--- /dev/null
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw75xx-0x.dts
+@@ -0,0 +1,28 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2023 Gateworks Corporation
++ */
++
++/dts-v1/;
++
++#include "imx8mm.dtsi"
++#include "imx8mm-venice-gw700x.dtsi"
++#include "imx8mm-venice-gw75xx.dtsi"
++
++/ {
++	model = "Gateworks Venice GW75xx-0x i.MX8MM Development Kit";
++	compatible = "gateworks,imx8mm-gw75xx-0x", "fsl,imx8mm";
++
++	chosen {
++		stdout-path = &uart2;
++	};
++};
++
++/* Disable SOM interfaces not used on baseboard */
++&fec1 {
++	status = "disabled";
++};
++
++&usdhc1 {
++	status = "disabled";
++};
+--- a/arch/arm64/boot/dts/freescale/imx8mp-venice-gw7905-2x.dts
++++ /dev/null
+@@ -1,28 +0,0 @@
+-// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+-/*
+- * Copyright 2023 Gateworks Corporation
+- */
+-
+-/dts-v1/;
+-
+-#include "imx8mp.dtsi"
+-#include "imx8mp-venice-gw702x.dtsi"
+-#include "imx8mp-venice-gw7905.dtsi"
+-
+-/ {
+-	model = "Gateworks Venice GW7905-2x i.MX8MP Development Kit";
+-	compatible = "gateworks,imx8mp-gw7905-2x", "fsl,imx8mp";
+-
+-	chosen {
+-		stdout-path = &uart2;
+-	};
+-};
+-
+-/* Disable SOM interfaces not used on baseboard */
+-&eqos {
+-	status = "disabled";
+-};
+-
+-&usdhc1 {
+-	status = "disabled";
+-};
+--- /dev/null
++++ b/arch/arm64/boot/dts/freescale/imx8mp-venice-gw75xx-2x.dts
+@@ -0,0 +1,28 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2023 Gateworks Corporation
++ */
++
++/dts-v1/;
++
++#include "imx8mp.dtsi"
++#include "imx8mp-venice-gw702x.dtsi"
++#include "imx8mp-venice-gw75xx.dtsi"
++
++/ {
++	model = "Gateworks Venice GW75xx-2x i.MX8MP Development Kit";
++	compatible = "gateworks,imx8mp-gw75xx-2x", "fsl,imx8mp";
++
++	chosen {
++		stdout-path = &uart2;
++	};
++};
++
++/* Disable SOM interfaces not used on baseboard */
++&eqos {
++	status = "disabled";
++};
++
++&usdhc1 {
++	status = "disabled";
++};
+--- /dev/null
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw75xx.dtsi
+@@ -0,0 +1,303 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2023 Gateworks Corporation
++ */
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/phy/phy-imx8-pcie.h>
++
++/ {
++	led-controller {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_gpio_leds>;
++
++		led-0 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_GREEN>;
++			gpios = <&gpio4 0 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++			linux,default-trigger = "heartbeat";
++		};
++
++		led-1 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_RED>;
++			gpios = <&gpio4 2 GPIO_ACTIVE_HIGH>;
++			default-state = "off";
++		};
++	};
++
++	pcie0_refclk: clock-pcie0 {
++		compatible = "fixed-clock";
++		#clock-cells = <0>;
++		clock-frequency = <100000000>;
++	};
++
++	pps {
++		compatible = "pps-gpio";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_pps>;
++		gpios = <&gpio4 5 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	reg_usb2_vbus: regulator-usb2-vbus {
++		compatible = "regulator-fixed";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usb2_en>;
++		regulator-name = "usb2_vbus";
++		gpio = <&gpio1 8 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	reg_usdhc2_vmmc: regulator-usdhc2 {
++		compatible = "regulator-fixed";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usdhc2_vmmc>;
++		regulator-name = "SD2_3P3V";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio2 19 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++};
++
++/* off-board header */
++&ecspi2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_spi2>;
++	cs-gpios = <&gpio5 13 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
++&gpio1 {
++	gpio-line-names =
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "gpioa", "gpiob", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "";
++};
++
++&gpio4 {
++	gpio-line-names =
++		"", "", "", "pci_usb_sel",
++		"", "", "", "pci_wdis#",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "";
++};
++
++&gpio5 {
++	gpio-line-names =
++		"", "", "", "",
++		"gpioc", "gpiod", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "";
++};
++
++&i2c2 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_i2c2>;
++	status = "okay";
++
++	eeprom@52 {
++		compatible = "atmel,24c32";
++		reg = <0x52>;
++		pagesize = <32>;
++	};
++};
++
++/* off-board header */
++&i2c3 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_i2c3>;
++	status = "okay";
++};
++
++&pcie_phy {
++	fsl,refclk-pad-mode = <IMX8_PCIE_REFCLK_PAD_INPUT>;
++	fsl,clkreq-unsupported;
++	clocks = <&pcie0_refclk>;
++	clock-names = "ref";
++	status = "okay";
++};
++
++&pcie0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pcie0>;
++	reset-gpio = <&gpio4 6 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
++/* GPS */
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart1>;
++	status = "okay";
++};
++
++/* USB1 - Type C front panel SINK port J14 */
++&usbotg1 {
++	dr_mode = "peripheral";
++	status = "okay";
++};
++
++/* USB2 4-port USB3.0 HUB:
++ *  P1 - USBC connector (host only)
++ *  P2 - USB2 test connector
++ *  P3 - miniPCIe full card
++ *  P4 - miniPCIe half card
++ */
++&usbotg2 {
++	dr_mode = "host";
++	vbus-supply = <&reg_usb2_vbus>;
++	status = "okay";
++};
++
++/* microSD */
++&usdhc2 {
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
++	cd-gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&reg_usdhc2_vmmc>;
++	bus-width = <4>;
++	status = "okay";
++};
++
++&iomuxc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_hog>;
++
++	pinctrl_hog: hoggrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO13_GPIO1_IO13	0x40000040 /* GPIOA */
++			MX8MM_IOMUXC_GPIO1_IO14_GPIO1_IO14	0x40000040 /* GPIOB */
++			MX8MM_IOMUXC_SAI1_RXD1_GPIO4_IO3	0x40000106 /* PCI_USBSEL */
++			MX8MM_IOMUXC_SAI1_RXD5_GPIO4_IO7	0x40000106 /* PCIE_WDIS# */
++			MX8MM_IOMUXC_SPDIF_EXT_CLK_GPIO5_IO5	0x40000040 /* GPIOD */
++			MX8MM_IOMUXC_SPDIF_RX_GPIO5_IO4		0x40000040 /* GPIOC */
++		>;
++	};
++
++	pinctrl_gpio_leds: gpioledgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI1_RXFS_GPIO4_IO0	0x6	/* LEDG */
++			MX8MM_IOMUXC_SAI1_RXD0_GPIO4_IO2	0x6	/* LEDR */
++		>;
++	};
++
++	pinctrl_i2c2: i2c2grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_I2C2_SCL_I2C2_SCL		0x400001c2
++			MX8MM_IOMUXC_I2C2_SDA_I2C2_SDA		0x400001c2
++		>;
++	};
++
++	pinctrl_i2c3: i2c3grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_I2C3_SCL_I2C3_SCL		0x400001c2
++			MX8MM_IOMUXC_I2C3_SDA_I2C3_SDA		0x400001c2
++		>;
++	};
++
++	pinctrl_pcie0: pciegrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI1_RXD4_GPIO4_IO6	0x106
++		>;
++	};
++
++	pinctrl_pps: ppsgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI1_RXD3_GPIO4_IO5	0x106
++		>;
++	};
++
++	pinctrl_reg_usb2_en: regusb2grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO08_GPIO1_IO8	0x6	/* USBHUB_RST# (ext p/u) */
++		>;
++	};
++
++	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_RESET_B_GPIO2_IO19	0x40
++		>;
++	};
++
++	pinctrl_spi2: spi2grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_ECSPI2_SCLK_ECSPI2_SCLK	0x140
++			MX8MM_IOMUXC_ECSPI2_MOSI_ECSPI2_MOSI	0x140
++			MX8MM_IOMUXC_ECSPI2_MISO_ECSPI2_MISO	0x140
++			MX8MM_IOMUXC_ECSPI2_SS0_GPIO5_IO13	0x140
++		>;
++	};
++
++	pinctrl_uart1: uart1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_UART1_RXD_UART1_DCE_RX	0x140
++			MX8MM_IOMUXC_UART1_TXD_UART1_DCE_TX	0x140
++		>;
++	};
++
++	pinctrl_usdhc2: usdhc2grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x190
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d0
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d0
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d0
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d0
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d0
++			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0xc0
++		>;
++	};
++
++	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x194
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d4
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d4
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d4
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d4
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d4
++			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0xc0
++		>;
++	};
++
++	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x196
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d6
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d6
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d6
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d6
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d6
++			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0xc0
++		>;
++	};
++
++	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_CD_B_GPIO2_IO12	0x1c4
++		>;
++	};
++};
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw7905.dtsi
++++ /dev/null
+@@ -1,303 +0,0 @@
+-// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+-/*
+- * Copyright 2023 Gateworks Corporation
+- */
+-
+-#include <dt-bindings/gpio/gpio.h>
+-#include <dt-bindings/leds/common.h>
+-#include <dt-bindings/phy/phy-imx8-pcie.h>
+-
+-/ {
+-	led-controller {
+-		compatible = "gpio-leds";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pinctrl_gpio_leds>;
+-
+-		led-0 {
+-			function = LED_FUNCTION_STATUS;
+-			color = <LED_COLOR_ID_GREEN>;
+-			gpios = <&gpio4 0 GPIO_ACTIVE_HIGH>;
+-			default-state = "on";
+-			linux,default-trigger = "heartbeat";
+-		};
+-
+-		led-1 {
+-			function = LED_FUNCTION_STATUS;
+-			color = <LED_COLOR_ID_RED>;
+-			gpios = <&gpio4 2 GPIO_ACTIVE_HIGH>;
+-			default-state = "off";
+-		};
+-	};
+-
+-	pcie0_refclk: clock-pcie0 {
+-		compatible = "fixed-clock";
+-		#clock-cells = <0>;
+-		clock-frequency = <100000000>;
+-	};
+-
+-	pps {
+-		compatible = "pps-gpio";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pinctrl_pps>;
+-		gpios = <&gpio4 5 GPIO_ACTIVE_HIGH>;
+-		status = "okay";
+-	};
+-
+-	reg_usb2_vbus: regulator-usb2-vbus {
+-		compatible = "regulator-fixed";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pinctrl_reg_usb2_en>;
+-		regulator-name = "usb2_vbus";
+-		gpio = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+-		enable-active-high;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-	};
+-
+-	reg_usdhc2_vmmc: regulator-usdhc2 {
+-		compatible = "regulator-fixed";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pinctrl_reg_usdhc2_vmmc>;
+-		regulator-name = "SD2_3P3V";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		gpio = <&gpio2 19 GPIO_ACTIVE_HIGH>;
+-		enable-active-high;
+-	};
+-};
+-
+-/* off-board header */
+-&ecspi2 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_spi2>;
+-	cs-gpios = <&gpio5 13 GPIO_ACTIVE_LOW>;
+-	status = "okay";
+-};
+-
+-&gpio1 {
+-	gpio-line-names =
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "gpioa", "gpiob", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "";
+-};
+-
+-&gpio4 {
+-	gpio-line-names =
+-		"", "", "", "pci_usb_sel",
+-		"", "", "", "pci_wdis#",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "";
+-};
+-
+-&gpio5 {
+-	gpio-line-names =
+-		"", "", "", "",
+-		"gpioc", "gpiod", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "";
+-};
+-
+-&i2c2 {
+-	clock-frequency = <400000>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_i2c2>;
+-	status = "okay";
+-
+-	eeprom@52 {
+-		compatible = "atmel,24c32";
+-		reg = <0x52>;
+-		pagesize = <32>;
+-	};
+-};
+-
+-/* off-board header */
+-&i2c3 {
+-	clock-frequency = <400000>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_i2c3>;
+-	status = "okay";
+-};
+-
+-&pcie_phy {
+-	fsl,refclk-pad-mode = <IMX8_PCIE_REFCLK_PAD_INPUT>;
+-	fsl,clkreq-unsupported;
+-	clocks = <&pcie0_refclk>;
+-	clock-names = "ref";
+-	status = "okay";
+-};
+-
+-&pcie0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_pcie0>;
+-	reset-gpio = <&gpio4 6 GPIO_ACTIVE_LOW>;
+-	status = "okay";
+-};
+-
+-/* GPS */
+-&uart1 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_uart1>;
+-	status = "okay";
+-};
+-
+-/* USB1 - Type C front panel SINK port J14 */
+-&usbotg1 {
+-	dr_mode = "peripheral";
+-	status = "okay";
+-};
+-
+-/* USB2 4-port USB3.0 HUB:
+- *  P1 - USBC connector (host only)
+- *  P2 - USB2 test connector
+- *  P3 - miniPCIe full card
+- *  P4 - miniPCIe half card
+- */
+-&usbotg2 {
+-	dr_mode = "host";
+-	vbus-supply = <&reg_usb2_vbus>;
+-	status = "okay";
+-};
+-
+-/* microSD */
+-&usdhc2 {
+-	pinctrl-names = "default", "state_100mhz", "state_200mhz";
+-	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
+-	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
+-	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
+-	cd-gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
+-	vmmc-supply = <&reg_usdhc2_vmmc>;
+-	bus-width = <4>;
+-	status = "okay";
+-};
+-
+-&iomuxc {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_hog>;
+-
+-	pinctrl_hog: hoggrp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_GPIO1_IO13_GPIO1_IO13	0x40000040 /* GPIOA */
+-			MX8MM_IOMUXC_GPIO1_IO14_GPIO1_IO14	0x40000040 /* GPIOB */
+-			MX8MM_IOMUXC_SAI1_RXD1_GPIO4_IO3	0x40000106 /* PCI_USBSEL */
+-			MX8MM_IOMUXC_SAI1_RXD5_GPIO4_IO7	0x40000106 /* PCIE_WDIS# */
+-			MX8MM_IOMUXC_SPDIF_EXT_CLK_GPIO5_IO5	0x40000040 /* GPIOD */
+-			MX8MM_IOMUXC_SPDIF_RX_GPIO5_IO4		0x40000040 /* GPIOC */
+-		>;
+-	};
+-
+-	pinctrl_gpio_leds: gpioledgrp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SAI1_RXFS_GPIO4_IO0	0x6	/* LEDG */
+-			MX8MM_IOMUXC_SAI1_RXD0_GPIO4_IO2	0x6	/* LEDR */
+-		>;
+-	};
+-
+-	pinctrl_i2c2: i2c2grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_I2C2_SCL_I2C2_SCL		0x400001c2
+-			MX8MM_IOMUXC_I2C2_SDA_I2C2_SDA		0x400001c2
+-		>;
+-	};
+-
+-	pinctrl_i2c3: i2c3grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_I2C3_SCL_I2C3_SCL		0x400001c2
+-			MX8MM_IOMUXC_I2C3_SDA_I2C3_SDA		0x400001c2
+-		>;
+-	};
+-
+-	pinctrl_pcie0: pciegrp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SAI1_RXD4_GPIO4_IO6	0x106
+-		>;
+-	};
+-
+-	pinctrl_pps: ppsgrp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SAI1_RXD3_GPIO4_IO5	0x106
+-		>;
+-	};
+-
+-	pinctrl_reg_usb2_en: regusb2grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_GPIO1_IO08_GPIO1_IO8	0x6	/* USBHUB_RST# (ext p/u) */
+-		>;
+-	};
+-
+-	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SD2_RESET_B_GPIO2_IO19	0x40
+-		>;
+-	};
+-
+-	pinctrl_spi2: spi2grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_ECSPI2_SCLK_ECSPI2_SCLK	0x140
+-			MX8MM_IOMUXC_ECSPI2_MOSI_ECSPI2_MOSI	0x140
+-			MX8MM_IOMUXC_ECSPI2_MISO_ECSPI2_MISO	0x140
+-			MX8MM_IOMUXC_ECSPI2_SS0_GPIO5_IO13	0x140
+-		>;
+-	};
+-
+-	pinctrl_uart1: uart1grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_UART1_RXD_UART1_DCE_RX	0x140
+-			MX8MM_IOMUXC_UART1_TXD_UART1_DCE_TX	0x140
+-		>;
+-	};
+-
+-	pinctrl_usdhc2: usdhc2grp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x190
+-			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d0
+-			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d0
+-			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d0
+-			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d0
+-			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d0
+-			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0xc0
+-		>;
+-	};
+-
+-	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x194
+-			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d4
+-			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d4
+-			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d4
+-			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d4
+-			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d4
+-			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0xc0
+-		>;
+-	};
+-
+-	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x196
+-			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d6
+-			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d6
+-			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d6
+-			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d6
+-			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d6
+-			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0xc0
+-		>;
+-	};
+-
+-	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
+-		fsl,pins = <
+-			MX8MM_IOMUXC_SD2_CD_B_GPIO2_IO12	0x1c4
+-		>;
+-	};
+-};
+--- /dev/null
++++ b/arch/arm64/boot/dts/freescale/imx8mp-venice-gw75xx.dtsi
+@@ -0,0 +1,309 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2023 Gateworks Corporation
++ */
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/phy/phy-imx8-pcie.h>
++
++/ {
++	led-controller {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_gpio_leds>;
++
++		led-0 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_GREEN>;
++			gpios = <&gpio4 22 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++			linux,default-trigger = "heartbeat";
++		};
++
++		led-1 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_RED>;
++			gpios = <&gpio4 27 GPIO_ACTIVE_HIGH>;
++			default-state = "off";
++		};
++	};
++
++	pcie0_refclk: pcie0-refclk {
++		compatible = "fixed-clock";
++		#clock-cells = <0>;
++		clock-frequency = <100000000>;
++	};
++
++	pps {
++		compatible = "pps-gpio";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_pps>;
++		gpios = <&gpio4 21 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	reg_usb2_vbus: regulator-usb2-vbus {
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usb2_en>;
++		compatible = "regulator-fixed";
++		regulator-name = "usb2_vbus";
++		gpio = <&gpio4 12 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	reg_usdhc2_vmmc: regulator-usdhc2 {
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usdhc2_vmmc>;
++		compatible = "regulator-fixed";
++		regulator-name = "SD2_3P3V";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		gpio = <&gpio2 19 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++};
++
++/* off-board header */
++&ecspi2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_spi2>;
++	cs-gpios = <&gpio5 13 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
++&gpio4 {
++	gpio-line-names =
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "gpioa", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "";
++};
++
++&gpio4 {
++	gpio-line-names =
++		"", "gpiod", "", "",
++		"gpiob", "gpioc", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "pci_usb_sel", "",
++		"pci_wdis#", "", "", "";
++};
++
++&i2c2 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_i2c2>;
++	status = "okay";
++
++	eeprom@52 {
++		compatible = "atmel,24c32";
++		reg = <0x52>;
++		pagesize = <32>;
++	};
++};
++
++/* off-board header */
++&i2c3 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_i2c3>;
++	status = "okay";
++};
++
++&pcie_phy {
++	fsl,refclk-pad-mode = <IMX8_PCIE_REFCLK_PAD_INPUT>;
++	fsl,clkreq-unsupported;
++	clocks = <&pcie0_refclk>;
++	clock-names = "ref";
++	status = "okay";
++};
++
++&pcie {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pcie0>;
++	reset-gpio = <&gpio4 29 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
++/* GPS */
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart1>;
++	status = "okay";
++};
++
++/* USB1 - Type C front panel SINK port J14 */
++&usb3_0 {
++	status = "okay";
++};
++
++&usb3_phy0 {
++	status = "okay";
++};
++
++&usb_dwc3_0 {
++	dr_mode = "peripheral";
++	status = "okay";
++};
++
++/* USB2 4-port USB3.0 HUB:
++ *  P1 - USBC connector (host only)
++ *  P2 - USB2 test connector
++ *  P3 - miniPCIe full card
++ *  P4 - miniPCIe half card
++ */
++&usb3_phy1 {
++	vbus-supply = <&reg_usb2_vbus>;
++	status = "okay";
++};
++
++&usb3_1 {
++	fsl,permanently-attached;
++	fsl,disable-port-power-control;
++	status = "okay";
++};
++
++&usb_dwc3_1 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++/* microSD */
++&usdhc2 {
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
++	cd-gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
++	vmmc-supply = <&reg_usdhc2_vmmc>;
++	bus-width = <4>;
++	status = "okay";
++};
++
++&iomuxc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_hog>;
++
++	pinctrl_hog: hoggrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_GPIO1_IO13__GPIO1_IO13	0x40000040 /* GPIOA */
++			MX8MP_IOMUXC_SAI1_RXC__GPIO4_IO01	0x40000040 /* GPIOD */
++			MX8MP_IOMUXC_SAI1_RXD2__GPIO4_IO04	0x40000040 /* GPIOB */
++			MX8MP_IOMUXC_SAI1_RXD3__GPIO4_IO05	0x40000040 /* GPIOC */
++			MX8MP_IOMUXC_SAI2_TXD0__GPIO4_IO26	0x40000106 /* PCI_USBSEL */
++			MX8MP_IOMUXC_SAI3_RXFS__GPIO4_IO28	0x40000106 /* PCI_WDIS# */
++		>;
++	};
++
++	pinctrl_gpio_leds: gpioledgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI2_RXC__GPIO4_IO22	0x6	/* LEDG */
++			MX8MP_IOMUXC_SAI2_MCLK__GPIO4_IO27	0x6	/* LEDR */
++		>;
++	};
++
++	pinctrl_i2c2: i2c2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_I2C2_SCL__I2C2_SCL		0x400001c2
++			MX8MP_IOMUXC_I2C2_SDA__I2C2_SDA		0x400001c2
++		>;
++	};
++
++	pinctrl_i2c3: i2c3grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_I2C3_SCL__I2C3_SCL		0x400001c2
++			MX8MP_IOMUXC_I2C3_SDA__I2C3_SDA		0x400001c2
++		>;
++	};
++
++	pinctrl_pcie0: pciegrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI3_RXC__GPIO4_IO29	0x106
++		>;
++	};
++
++	pinctrl_pps: ppsgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI2_RXFS__GPIO4_IO21	0x106
++		>;
++	};
++
++	pinctrl_reg_usb2_en: regusb2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_TXD0__GPIO4_IO12	0x6 /* USBHUB_RST# (ext p/u) */
++		>;
++	};
++
++	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_RESET_B__GPIO2_IO19	0x40
++		>;
++	};
++
++	pinctrl_spi2: spi2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ECSPI2_SCLK__ECSPI2_SCLK	0x140
++			MX8MP_IOMUXC_ECSPI2_MOSI__ECSPI2_MOSI	0x140
++			MX8MP_IOMUXC_ECSPI2_MISO__ECSPI2_MISO	0x140
++			MX8MP_IOMUXC_ECSPI2_SS0__GPIO5_IO13	0x140
++		>;
++	};
++
++	pinctrl_uart1: uart1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_UART1_RXD__UART1_DCE_RX	0x140
++			MX8MP_IOMUXC_UART1_TXD__UART1_DCE_TX	0x140
++		>;
++	};
++
++	pinctrl_usdhc2: usdhc2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK		0x190
++			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD		0x1d0
++			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0		0x1d0
++			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1		0x1d0
++			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2		0x1d0
++			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3		0x1d0
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0xc0
++		>;
++	};
++
++	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK		0x194
++			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD		0x1d4
++			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0		0x1d4
++			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1		0x1d4
++			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2		0x1d4
++			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3		0x1d4
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0xc0
++		>;
++	};
++
++	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK		0x196
++			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD		0x1d6
++			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0		0x1d6
++			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1		0x1d6
++			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2		0x1d6
++			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3		0x1d6
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0xc0
++		>;
++	};
++
++	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CD_B__GPIO2_IO12		0x1c4
++		>;
++	};
++};
+--- a/arch/arm64/boot/dts/freescale/imx8mp-venice-gw7905.dtsi
++++ /dev/null
+@@ -1,309 +0,0 @@
+-// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+-/*
+- * Copyright 2023 Gateworks Corporation
+- */
+-
+-#include <dt-bindings/gpio/gpio.h>
+-#include <dt-bindings/leds/common.h>
+-#include <dt-bindings/phy/phy-imx8-pcie.h>
+-
+-/ {
+-	led-controller {
+-		compatible = "gpio-leds";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pinctrl_gpio_leds>;
+-
+-		led-0 {
+-			function = LED_FUNCTION_STATUS;
+-			color = <LED_COLOR_ID_GREEN>;
+-			gpios = <&gpio4 22 GPIO_ACTIVE_HIGH>;
+-			default-state = "on";
+-			linux,default-trigger = "heartbeat";
+-		};
+-
+-		led-1 {
+-			function = LED_FUNCTION_STATUS;
+-			color = <LED_COLOR_ID_RED>;
+-			gpios = <&gpio4 27 GPIO_ACTIVE_HIGH>;
+-			default-state = "off";
+-		};
+-	};
+-
+-	pcie0_refclk: pcie0-refclk {
+-		compatible = "fixed-clock";
+-		#clock-cells = <0>;
+-		clock-frequency = <100000000>;
+-	};
+-
+-	pps {
+-		compatible = "pps-gpio";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pinctrl_pps>;
+-		gpios = <&gpio4 21 GPIO_ACTIVE_HIGH>;
+-		status = "okay";
+-	};
+-
+-	reg_usb2_vbus: regulator-usb2-vbus {
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pinctrl_reg_usb2_en>;
+-		compatible = "regulator-fixed";
+-		regulator-name = "usb2_vbus";
+-		gpio = <&gpio4 12 GPIO_ACTIVE_HIGH>;
+-		enable-active-high;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-	};
+-
+-	reg_usdhc2_vmmc: regulator-usdhc2 {
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pinctrl_reg_usdhc2_vmmc>;
+-		compatible = "regulator-fixed";
+-		regulator-name = "SD2_3P3V";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		gpio = <&gpio2 19 GPIO_ACTIVE_HIGH>;
+-		enable-active-high;
+-	};
+-};
+-
+-/* off-board header */
+-&ecspi2 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_spi2>;
+-	cs-gpios = <&gpio5 13 GPIO_ACTIVE_LOW>;
+-	status = "okay";
+-};
+-
+-&gpio4 {
+-	gpio-line-names =
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "gpioa", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "";
+-};
+-
+-&gpio4 {
+-	gpio-line-names =
+-		"", "gpiod", "", "",
+-		"gpiob", "gpioc", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "", "",
+-		"", "", "pci_usb_sel", "",
+-		"pci_wdis#", "", "", "";
+-};
+-
+-&i2c2 {
+-	clock-frequency = <400000>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_i2c2>;
+-	status = "okay";
+-
+-	eeprom@52 {
+-		compatible = "atmel,24c32";
+-		reg = <0x52>;
+-		pagesize = <32>;
+-	};
+-};
+-
+-/* off-board header */
+-&i2c3 {
+-	clock-frequency = <400000>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_i2c3>;
+-	status = "okay";
+-};
+-
+-&pcie_phy {
+-	fsl,refclk-pad-mode = <IMX8_PCIE_REFCLK_PAD_INPUT>;
+-	fsl,clkreq-unsupported;
+-	clocks = <&pcie0_refclk>;
+-	clock-names = "ref";
+-	status = "okay";
+-};
+-
+-&pcie {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_pcie0>;
+-	reset-gpio = <&gpio4 29 GPIO_ACTIVE_LOW>;
+-	status = "okay";
+-};
+-
+-/* GPS */
+-&uart1 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_uart1>;
+-	status = "okay";
+-};
+-
+-/* USB1 - Type C front panel SINK port J14 */
+-&usb3_0 {
+-	status = "okay";
+-};
+-
+-&usb3_phy0 {
+-	status = "okay";
+-};
+-
+-&usb_dwc3_0 {
+-	dr_mode = "peripheral";
+-	status = "okay";
+-};
+-
+-/* USB2 4-port USB3.0 HUB:
+- *  P1 - USBC connector (host only)
+- *  P2 - USB2 test connector
+- *  P3 - miniPCIe full card
+- *  P4 - miniPCIe half card
+- */
+-&usb3_phy1 {
+-	vbus-supply = <&reg_usb2_vbus>;
+-	status = "okay";
+-};
+-
+-&usb3_1 {
+-	fsl,permanently-attached;
+-	fsl,disable-port-power-control;
+-	status = "okay";
+-};
+-
+-&usb_dwc3_1 {
+-	dr_mode = "host";
+-	status = "okay";
+-};
+-
+-/* microSD */
+-&usdhc2 {
+-	pinctrl-names = "default", "state_100mhz", "state_200mhz";
+-	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
+-	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
+-	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
+-	cd-gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
+-	vmmc-supply = <&reg_usdhc2_vmmc>;
+-	bus-width = <4>;
+-	status = "okay";
+-};
+-
+-&iomuxc {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pinctrl_hog>;
+-
+-	pinctrl_hog: hoggrp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_GPIO1_IO13__GPIO1_IO13	0x40000040 /* GPIOA */
+-			MX8MP_IOMUXC_SAI1_RXC__GPIO4_IO01	0x40000040 /* GPIOD */
+-			MX8MP_IOMUXC_SAI1_RXD2__GPIO4_IO04	0x40000040 /* GPIOB */
+-			MX8MP_IOMUXC_SAI1_RXD3__GPIO4_IO05	0x40000040 /* GPIOC */
+-			MX8MP_IOMUXC_SAI2_TXD0__GPIO4_IO26	0x40000106 /* PCI_USBSEL */
+-			MX8MP_IOMUXC_SAI3_RXFS__GPIO4_IO28	0x40000106 /* PCI_WDIS# */
+-		>;
+-	};
+-
+-	pinctrl_gpio_leds: gpioledgrp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_SAI2_RXC__GPIO4_IO22	0x6	/* LEDG */
+-			MX8MP_IOMUXC_SAI2_MCLK__GPIO4_IO27	0x6	/* LEDR */
+-		>;
+-	};
+-
+-	pinctrl_i2c2: i2c2grp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_I2C2_SCL__I2C2_SCL		0x400001c2
+-			MX8MP_IOMUXC_I2C2_SDA__I2C2_SDA		0x400001c2
+-		>;
+-	};
+-
+-	pinctrl_i2c3: i2c3grp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_I2C3_SCL__I2C3_SCL		0x400001c2
+-			MX8MP_IOMUXC_I2C3_SDA__I2C3_SDA		0x400001c2
+-		>;
+-	};
+-
+-	pinctrl_pcie0: pciegrp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_SAI3_RXC__GPIO4_IO29	0x106
+-		>;
+-	};
+-
+-	pinctrl_pps: ppsgrp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_SAI2_RXFS__GPIO4_IO21	0x106
+-		>;
+-	};
+-
+-	pinctrl_reg_usb2_en: regusb2grp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_SAI1_TXD0__GPIO4_IO12	0x6 /* USBHUB_RST# (ext p/u) */
+-		>;
+-	};
+-
+-	pinctrl_reg_usdhc2_vmmc: regusdhc2vmmcgrp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_SD2_RESET_B__GPIO2_IO19	0x40
+-		>;
+-	};
+-
+-	pinctrl_spi2: spi2grp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_ECSPI2_SCLK__ECSPI2_SCLK	0x140
+-			MX8MP_IOMUXC_ECSPI2_MOSI__ECSPI2_MOSI	0x140
+-			MX8MP_IOMUXC_ECSPI2_MISO__ECSPI2_MISO	0x140
+-			MX8MP_IOMUXC_ECSPI2_SS0__GPIO5_IO13	0x140
+-		>;
+-	};
+-
+-	pinctrl_uart1: uart1grp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_UART1_RXD__UART1_DCE_RX	0x140
+-			MX8MP_IOMUXC_UART1_TXD__UART1_DCE_TX	0x140
+-		>;
+-	};
+-
+-	pinctrl_usdhc2: usdhc2grp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK		0x190
+-			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD		0x1d0
+-			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0		0x1d0
+-			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1		0x1d0
+-			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2		0x1d0
+-			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3		0x1d0
+-			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0xc0
+-		>;
+-	};
+-
+-	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK		0x194
+-			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD		0x1d4
+-			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0		0x1d4
+-			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1		0x1d4
+-			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2		0x1d4
+-			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3		0x1d4
+-			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0xc0
+-		>;
+-	};
+-
+-	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK		0x196
+-			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD		0x1d6
+-			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0		0x1d6
+-			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1		0x1d6
+-			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2		0x1d6
+-			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3		0x1d6
+-			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT		0xc0
+-		>;
+-	};
+-
+-	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
+-		fsl,pins = <
+-			MX8MP_IOMUXC_SD2_CD_B__GPIO2_IO12		0x1c4
+-		>;
+-	};
+-};

--- a/target/linux/imx/patches-6.6/503-6.13-arm64-dts-imx8m-venice-gw75xx-add-Accelerometer-device.patch
+++ b/target/linux/imx/patches-6.6/503-6.13-arm64-dts-imx8m-venice-gw75xx-add-Accelerometer-device.patch
@@ -1,0 +1,79 @@
+From ede044113c0418f11dbee09069ff1dd68f284dfa Mon Sep 17 00:00:00 2001
+From: Tim Harvey <tharvey@gateworks.com>
+Date: Fri, 18 Oct 2024 10:36:08 -0700
+Subject: [PATCH] arm64: dts: imx8m*-venice-gw75xx: add Accelerometer device
+
+The GW75xx has a LIS2DE12TR 3-axis accelerometer on the I2C bus with an
+interrupt pin. Add it to the device-tree.
+
+Signed-off-by: Tim Harvey <tharvey@gateworks.com>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ .../boot/dts/freescale/imx8mm-venice-gw75xx.dtsi | 16 ++++++++++++++++
+ .../boot/dts/freescale/imx8mp-venice-gw75xx.dtsi | 16 ++++++++++++++++
+ 2 files changed, 32 insertions(+)
+
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw75xx.dtsi
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw75xx.dtsi
+@@ -116,6 +116,16 @@
+ 	pinctrl-0 = <&pinctrl_i2c2>;
+ 	status = "okay";
+ 
++	accelerometer@19 {
++		compatible = "st,lis2de12";
++		reg = <0x19>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_accel>;
++		interrupt-parent = <&gpio5>;
++		interrupts = <8 IRQ_TYPE_LEVEL_LOW>;
++		st,drdy-int-pin = <1>;
++	};
++
+ 	eeprom@52 {
+ 		compatible = "atmel,24c32";
+ 		reg = <0x52>;
+@@ -198,6 +208,12 @@
+ 		>;
+ 	};
+ 
++	pinctrl_accel: accelgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_ECSPI1_MISO_GPIO5_IO8	0x159
++		>;
++	};
++
+ 	pinctrl_gpio_leds: gpioledgrp {
+ 		fsl,pins = <
+ 			MX8MM_IOMUXC_SAI1_RXFS_GPIO4_IO0	0x6	/* LEDG */
+--- a/arch/arm64/boot/dts/freescale/imx8mp-venice-gw75xx.dtsi
++++ b/arch/arm64/boot/dts/freescale/imx8mp-venice-gw75xx.dtsi
+@@ -104,6 +104,16 @@
+ 	pinctrl-0 = <&pinctrl_i2c2>;
+ 	status = "okay";
+ 
++	accelerometer@19 {
++		compatible = "st,lis2de12";
++		reg = <0x19>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_accel>;
++		interrupt-parent = <&gpio5>;
++		interrupts = <8 IRQ_TYPE_LEVEL_LOW>;
++		st,drdy-int-pin = <1>;
++	};
++
+ 	eeprom@52 {
+ 		compatible = "atmel,24c32";
+ 		reg = <0x52>;
+@@ -204,6 +214,12 @@
+ 		>;
+ 	};
+ 
++	pinctrl_accel: accelgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ECSPI1_MISO__GPIO5_IO08	0x159
++		>;
++	};
++
+ 	pinctrl_gpio_leds: gpioledgrp {
+ 		fsl,pins = <
+ 			MX8MP_IOMUXC_SAI2_RXC__GPIO4_IO22	0x6	/* LEDG */

--- a/target/linux/imx/patches-6.6/504-6.13-arm64-dts-imx-Add-i.MX8M-Plus-Gateworks-GW82XX-2X-support.patch
+++ b/target/linux/imx/patches-6.6/504-6.13-arm64-dts-imx-Add-i.MX8M-Plus-Gateworks-GW82XX-2X-support.patch
@@ -1,0 +1,1107 @@
+From a79d2638a7150d1605fcadebb6baa36d27cdc48e Mon Sep 17 00:00:00 2001
+From: Tim Harvey <tharvey@gateworks.com>
+Date: Thu, 30 May 2024 10:21:45 -0700
+Subject: [PATCH] arm64: dts: imx: Add i.MX8M Plus Gateworks GW82XX-2X support
+
+The Gateworks GW82XX-2X is an ARM based single board computer (SBC)
+comprised of the i.MX8M Plus based gw702x SoM and the gw82xx
+baseboard featuring:
+ - i.MX8M Plus SoC
+ - LPDDR4 DRAM
+ - eMMC FLASH
+ - Gateworks System Controller (GSC)
+ - microSD (1.8V/3.3V Capable)
+ - panel status bi-color LED
+ - pushbutton switch
+ - fan controller with tachometer
+ - USB Type-C connector
+ - PCIe switch
+ - 2x GbE RJ45 connectors
+ - multi-protocol RS232/RS485/RS422 Serial ports
+ - 2x Flexible Socket Adapters with SDIO/UART/USB/PCIe
+   (for M.2 and miniPCIe expansion)
+ - 2x isolated CAN
+ - GPS
+ - accelerometer
+ - magnetometer
+ - off-board connectors for: SPI, GPIO, I2C, ADC
+ - Wide range DC power input
+ - support for 802.3at PoE (via adapter)
+
+Signed-off-by: Tim Harvey <tharvey@gateworks.com>
+---
+ .../devicetree/bindings/arm/fsl.yaml          |   1 +
+ arch/arm64/boot/dts/freescale/Makefile        |   1 +
+ .../dts/freescale/imx8mm-venice-gw82xx.dtsi   | 460 +++++++++++++++
+ .../boot/dts/freescale/imx8mp-venice-gw82xx-2 |  19 +
+ .../dts/freescale/imx8mp-venice-gw82xx-2x.dts |  19 +
+ .../dts/freescale/imx8mp-venice-gw82xx.dtsi   | 533 ++++++++++++++++++
+ 6 files changed, 1033 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/freescale/imx8mm-venice-gw82xx.dtsi
+ create mode 100644 arch/arm64/boot/dts/freescale/imx8mp-venice-gw82xx-2
+ create mode 100644 arch/arm64/boot/dts/freescale/imx8mp-venice-gw82xx-2x.dts
+ create mode 100644 arch/arm64/boot/dts/freescale/imx8mp-venice-gw82xx.dtsi
+
+--- a/Documentation/devicetree/bindings/arm/fsl.yaml
++++ b/Documentation/devicetree/bindings/arm/fsl.yaml
+@@ -1037,6 +1037,7 @@ properties:
+               - gateworks,imx8mp-gw73xx-2x # i.MX8MP Gateworks Board
+               - gateworks,imx8mp-gw74xx   # i.MX8MP Gateworks Board
+               - gateworks,imx8mp-gw75xx-2x # i.MX8MP Gateworks Board
++              - gateworks,imx8mp-gw82xx-2x # i.MX8MP Gateworks Board
+               - toradex,verdin-imx8mp     # Verdin iMX8M Plus Modules
+               - toradex,verdin-imx8mp-nonwifi  # Verdin iMX8M Plus Modules without Wi-Fi / BT
+               - toradex,verdin-imx8mp-wifi  # Verdin iMX8M Plus Wi-Fi / BT Modules
+--- a/arch/arm64/boot/dts/freescale/Makefile
++++ b/arch/arm64/boot/dts/freescale/Makefile
+@@ -108,6 +108,7 @@ dtb-$(CONFIG_ARCH_MXC) += imx8mp-venice-
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-venice-gw73xx-2x.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-venice-gw74xx.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-venice-gw75xx-2x.dtb
++dtb-$(CONFIG_ARCH_MXC) += imx8mp-venice-gw82xx-2x.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-verdin-nonwifi-dahlia.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-verdin-nonwifi-dev.dtb
+ dtb-$(CONFIG_ARCH_MXC) += imx8mp-verdin-nonwifi-yavia.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw82xx.dtsi
+@@ -0,0 +1,460 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2020 Gateworks Corporation
++ */
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/phy/phy-imx8-pcie.h>
++
++/ {
++	aliases {
++		ethernet1 = &eth1;
++		usb0 = &usbotg1;
++		usb1 = &usbotg2;
++	};
++
++	led-controller {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_gpio_leds>;
++
++		led-0 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_GREEN>;
++			gpios = <&gpio5 5 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++			linux,default-trigger = "heartbeat";
++		};
++
++		led-1 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_RED>;
++			gpios = <&gpio5 4 GPIO_ACTIVE_HIGH>;
++			default-state = "off";
++		};
++	};
++
++	pcie0_refclk: pcie0-refclk {
++		compatible = "fixed-clock";
++		#clock-cells = <0>;
++		clock-frequency = <100000000>;
++	};
++
++	pps {
++		compatible = "pps-gpio";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_pps>;
++		gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
++		status = "okay";
++	};
++
++	reg_1p8v: regulator-1p8v {
++		compatible = "regulator-fixed";
++		regulator-name = "1P8V";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		regulator-always-on;
++	};
++
++	reg_3p3v: regulator-3p3v {
++		compatible = "regulator-fixed";
++		regulator-name = "3P3V";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-always-on;
++	};
++
++	reg_usb_otg1_vbus: regulator-usb-otg1 {
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usb1_en>;
++		compatible = "regulator-fixed";
++		regulator-name = "usb_otg1_vbus";
++		gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	reg_usb_otg2_vbus: regulator-usb-otg2 {
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usb2_en>;
++		compatible = "regulator-fixed";
++		regulator-name = "usb_otg2_vbus";
++		gpio = <&gpio1 8 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	reg_wifi_en: regulator-wifi-en {
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_wl>;
++		compatible = "regulator-fixed";
++		regulator-name = "wl";
++		gpio = <&gpio1 5 GPIO_ACTIVE_HIGH>;
++		startup-delay-us = <100>;
++		enable-active-high;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++	};
++};
++
++/* off-board header */
++&ecspi2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_spi2>;
++	cs-gpios = <&gpio5 13 GPIO_ACTIVE_LOW>,
++		   <&gpio1 10 GPIO_ACTIVE_LOW>;
++	status = "okay";
++
++	tpm@1 {
++		compatible = "atmel,attpm20p", "tcg,tpm_tis-spi";
++		reg = <0x1>;
++		spi-max-frequency = <36000000>;
++	};
++};
++
++&gpio1 {
++	gpio-line-names = "rs485_term", "mipi_gpio4", "", "",
++		"", "", "pci_usb_sel", "dio0",
++		"", "dio1", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "";
++};
++
++&gpio4 {
++	gpio-line-names = "rs485_en", "mipi_gpio3", "rs485_hd", "mipi_gpio2",
++		"mipi_gpio1", "", "", "pci_wdis#",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "",
++		"", "", "", "", "", "", "", "";
++};
++
++&i2c2 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_i2c2>;
++	status = "okay";
++
++	accelerometer@19 {
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_accel>;
++		compatible = "st,lis2de12";
++		reg = <0x19>;
++		st,drdy-int-pin = <1>;
++		interrupt-parent = <&gpio4>;
++		interrupts = <5 IRQ_TYPE_LEVEL_LOW>;
++	};
++
++	// TODO: 0x6f PCIe switch
++};
++
++/* off-board header */
++// TODO: i2c expander
++&i2c3 {
++	clock-frequency = <400000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_i2c3>;
++	status = "okay";
++};
++
++&pcie_phy {
++	fsl,refclk-pad-mode = <IMX8_PCIE_REFCLK_PAD_INPUT>;
++	fsl,clkreq-unsupported;
++	clocks = <&pcie0_refclk>;
++	clock-names = "ref";
++	status = "okay";
++};
++
++&pcie0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pcie0>;
++	reset-gpio = <&gpio4 6 GPIO_ACTIVE_LOW>;
++	clocks = <&clk IMX8MM_CLK_PCIE1_ROOT>, <&pcie0_refclk>,
++		 <&clk IMX8MM_CLK_PCIE1_AUX>;
++	assigned-clocks = <&clk IMX8MM_CLK_PCIE1_AUX>,
++			  <&clk IMX8MM_CLK_PCIE1_CTRL>;
++	assigned-clock-rates = <10000000>, <250000000>;
++	assigned-clock-parents = <&clk IMX8MM_SYS_PLL2_50M>,
++				 <&clk IMX8MM_SYS_PLL2_250M>;
++	status = "okay";
++
++	// TODO: this changes - new switch
++	pcie@0,0 {
++		reg = <0x0000 0 0 0 0>;
++		device_type = "pci";
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++
++		pcie@0,0 {
++			reg = <0x0000 0 0 0 0>;
++			device_type = "pci";
++			#address-cells = <3>;
++			#size-cells = <2>;
++			ranges;
++
++			pcie@4,0 {
++				reg = <0x2000 0 0 0 0>;
++				device_type = "pci";
++				#address-cells = <3>;
++				#size-cells = <2>;
++				ranges;
++
++				eth1: ethernet@0,0 {
++					reg = <0x0000 0 0 0 0>;
++					#address-cells = <3>;
++					#size-cells = <2>;
++					ranges;
++
++					local-mac-address = [00 00 00 00 00 00];
++				};
++			};
++		};
++	};
++};
++
++/* off-board header */
++&sai3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_sai3>;
++	assigned-clocks = <&clk IMX8MM_CLK_SAI3>;
++	assigned-clock-parents = <&clk IMX8MM_AUDIO_PLL1_OUT>;
++	assigned-clock-rates = <24576000>;
++	status = "okay";
++};
++
++/* GPS */
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart1>;
++	status = "okay";
++};
++
++/* bluetooth HCI */
++&uart3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart3>, <&pinctrl_bten>;
++	cts-gpios = <&gpio5 8 GPIO_ACTIVE_LOW>;
++	rts-gpios = <&gpio5 9 GPIO_ACTIVE_LOW>;
++	status = "okay";
++
++	bluetooth {
++		compatible = "brcm,bcm4330-bt";
++		shutdown-gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++/* RS232 */
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart4>;
++	status = "okay";
++};
++
++&usbotg1 {
++	dr_mode = "otg";
++	over-current-active-low;
++	vbus-supply = <&reg_usb_otg1_vbus>;
++	status = "okay";
++};
++
++&usbotg2 {
++	dr_mode = "host";
++	disable-over-current;
++	vbus-supply = <&reg_usb_otg2_vbus>;
++	status = "okay";
++};
++
++/* SDIO WiFi */
++&usdhc1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_usdhc1>;
++	bus-width = <4>;
++	non-removable;
++	vmmc-supply = <&reg_wifi_en>;
++	status = "okay";
++};
++
++/* microSD */
++&usdhc2 {
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
++	cd-gpios = <&gpio2 12 GPIO_ACTIVE_LOW>;
++	bus-width = <4>;
++	vmmc-supply = <&reg_3p3v>;
++	status = "okay";
++};
++
++&iomuxc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_hog>;
++
++	pinctrl_hog: hoggrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SPDIF_TX_GPIO5_IO3		0x40000041 /* PLUG_TEST */
++			MX8MM_IOMUXC_GPIO1_IO06_GPIO1_IO6	0x40000041 /* PCI_USBSEL */
++			MX8MM_IOMUXC_SAI1_RXD5_GPIO4_IO7	0x40000041 /* PCIE_WDIS# */
++			MX8MM_IOMUXC_GPIO1_IO07_GPIO1_IO7	0x40000041 /* DIO0 */
++			MX8MM_IOMUXC_GPIO1_IO09_GPIO1_IO9	0x40000041 /* DIO1 */
++			MX8MM_IOMUXC_GPIO1_IO00_GPIO1_IO0	0x40000104 /* RS485_TERM */
++			MX8MM_IOMUXC_SAI1_RXFS_GPIO4_IO0	0x40000104 /* RS485 */
++			MX8MM_IOMUXC_SAI1_RXD0_GPIO4_IO2	0x40000104 /* RS485_HALF */
++		>;
++	};
++
++	pinctrl_accel: accelgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI1_RXD3_GPIO4_IO5	0x159
++		>;
++	};
++
++	pinctrl_bten: btengrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO03_GPIO1_IO3	0x41
++		>;
++	};
++
++	pinctrl_gpio_leds: gpioledgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SPDIF_EXT_CLK_GPIO5_IO5	0x19
++			MX8MM_IOMUXC_SPDIF_RX_GPIO5_IO4		0x19
++		>;
++	};
++
++	pinctrl_i2c3: i2c3grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_I2C3_SCL_I2C3_SCL		0x400001c3
++			MX8MM_IOMUXC_I2C3_SDA_I2C3_SDA		0x400001c3
++		>;
++	};
++
++	pinctrl_pcie0: pcie0grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI1_RXD4_GPIO4_IO6	0x41
++		>;
++	};
++
++	pinctrl_pps: ppsgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO15_GPIO1_IO15	0x41
++		>;
++	};
++
++	pinctrl_reg_wl: regwlgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO05_GPIO1_IO5	0x41
++		>;
++	};
++
++	pinctrl_reg_usb1_en: regusb1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO12_GPIO1_IO12	0x41
++			MX8MM_IOMUXC_GPIO1_IO13_USB1_OTG_OC	0x41
++		>;
++	};
++
++	pinctrl_reg_usb2_en: regusb2grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_GPIO1_IO08_GPIO1_IO8	0x41
++		>;
++	};
++
++	pinctrl_sai3: sai3grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SAI3_TXFS_SAI3_TX_SYNC     0xd6
++			MX8MM_IOMUXC_SAI3_TXC_SAI3_TX_BCLK      0xd6
++			MX8MM_IOMUXC_SAI3_MCLK_SAI3_MCLK        0xd6
++			MX8MM_IOMUXC_SAI3_TXD_SAI3_TX_DATA0     0xd6
++			MX8MM_IOMUXC_SAI3_RXD_SAI3_RX_DATA0	0xd6
++		>;
++	};
++
++	pinctrl_spi2: spi2grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_ECSPI2_SCLK_ECSPI2_SCLK	0xd6
++			MX8MM_IOMUXC_ECSPI2_MOSI_ECSPI2_MOSI	0xd6
++			MX8MM_IOMUXC_ECSPI2_MISO_ECSPI2_MISO	0xd6
++			MX8MM_IOMUXC_ECSPI2_SS0_GPIO5_IO13	0xd6
++			MX8MM_IOMUXC_GPIO1_IO10_GPIO1_IO10	0xd6
++		>;
++	};
++
++	pinctrl_uart1: uart1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_UART1_RXD_UART1_DCE_RX	0x140
++			MX8MM_IOMUXC_UART1_TXD_UART1_DCE_TX	0x140
++		>;
++	};
++
++	pinctrl_uart3: uart3grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_UART3_RXD_UART3_DCE_RX	0x140
++			MX8MM_IOMUXC_UART3_TXD_UART3_DCE_TX	0x140
++			MX8MM_IOMUXC_ECSPI1_MISO_GPIO5_IO8	0x140
++			MX8MM_IOMUXC_ECSPI1_SS0_GPIO5_IO9	0x140
++		>;
++	};
++
++	pinctrl_uart4: uart4grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_UART4_RXD_UART4_DCE_RX	0x140
++			MX8MM_IOMUXC_UART4_TXD_UART4_DCE_TX	0x140
++		>;
++	};
++
++	pinctrl_usdhc1: usdhc1grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD1_CLK_USDHC1_CLK		0x190
++			MX8MM_IOMUXC_SD1_CMD_USDHC1_CMD		0x1d0
++			MX8MM_IOMUXC_SD1_DATA0_USDHC1_DATA0	0x1d0
++			MX8MM_IOMUXC_SD1_DATA1_USDHC1_DATA1	0x1d0
++			MX8MM_IOMUXC_SD1_DATA2_USDHC1_DATA2	0x1d0
++			MX8MM_IOMUXC_SD1_DATA3_USDHC1_DATA3	0x1d0
++		>;
++	};
++
++	pinctrl_usdhc2: usdhc2grp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x190
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d0
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d0
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d0
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d0
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d0
++		>;
++	};
++
++	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x194
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d4
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d4
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d4
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d4
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d4
++		>;
++	};
++
++	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_CLK_USDHC2_CLK		0x196
++			MX8MM_IOMUXC_SD2_CMD_USDHC2_CMD		0x1d6
++			MX8MM_IOMUXC_SD2_DATA0_USDHC2_DATA0	0x1d6
++			MX8MM_IOMUXC_SD2_DATA1_USDHC2_DATA1	0x1d6
++			MX8MM_IOMUXC_SD2_DATA2_USDHC2_DATA2	0x1d6
++			MX8MM_IOMUXC_SD2_DATA3_USDHC2_DATA3	0x1d6
++		>;
++	};
++
++	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
++		fsl,pins = <
++			MX8MM_IOMUXC_SD2_CD_B_GPIO2_IO12	0x1c4
++			MX8MM_IOMUXC_SD2_RESET_B_USDHC2_RESET_B	0x1d0
++			MX8MM_IOMUXC_GPIO1_IO04_USDHC2_VSELECT	0x1d0
++		>;
++	};
++};
+--- /dev/null
++++ b/arch/arm64/boot/dts/freescale/imx8mp-venice-gw82xx-2
+@@ -0,0 +1,19 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2024 Gateworks Corporation
++ */
++
++/dts-v1/;
++
++#include "imx8mm.dtsi"
++#include "imx8mm-venice-gw700x.dtsi"
++#include "imx8mm-venice-gw82xx.dtsi"
++
++/ {
++	model = "Gateworks Venice GW82xx-0x i.MX8MM Development Kit";
++	compatible = "gw,imx8mm-gw82xx-0x", "fsl,imx8mm";
++
++	chosen {
++		stdout-path = &uart2;
++	};
++};
+--- /dev/null
++++ b/arch/arm64/boot/dts/freescale/imx8mp-venice-gw82xx-2x.dts
+@@ -0,0 +1,19 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2024 Gateworks Corporation
++ */
++
++/dts-v1/;
++
++#include "imx8mp.dtsi"
++#include "imx8mp-venice-gw702x.dtsi"
++#include "imx8mp-venice-gw82xx.dtsi"
++
++/ {
++	model = "Gateworks Venice GW82xx-2x i.MX8MP Development Kit";
++	compatible = "gateworks,imx8mp-gw82xx-2x", "fsl,imx8mp";
++
++	chosen {
++		stdout-path = &uart2;
++	};
++};
+--- /dev/null
++++ b/arch/arm64/boot/dts/freescale/imx8mp-venice-gw82xx.dtsi
+@@ -0,0 +1,533 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright 2024 Gateworks Corporation
++ */
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/phy/phy-imx8-pcie.h>
++
++/ {
++	aliases {
++		ethernet1 = &eth1;
++		fsa1 = &fsa0;
++		fsa2 = &fsa1;
++	};
++
++	led-controller {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_gpio_leds>;
++
++		led-0 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_GREEN>;
++			gpios = <&gpio4 1 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
++			linux,default-trigger = "heartbeat";
++		};
++
++		led-1 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_RED>;
++			gpios = <&gpio4 5 GPIO_ACTIVE_HIGH>;
++			default-state = "off";
++		};
++	};
++
++	pcie0_refclk: clock-pcie0 {
++		compatible = "fixed-clock";
++		#clock-cells = <0>;
++		clock-frequency = <100000000>;
++	};
++
++	pps {
++		compatible = "pps-gpio";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_pps>;
++		gpios = <&gpio4 3 GPIO_ACTIVE_HIGH>;
++	};
++
++	reg_usb2_vbus: regulator-usb2 {
++		compatible = "regulator-fixed";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_reg_usb2_en>;
++		regulator-name = "usb2_vbus";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		gpio = <&gpio4 12 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++	};
++
++	reg_usdhc2_vmmc: regulator-usdhc2-vmmc {
++		compatible = "regulator-fixed";
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_usdhc2_vmmc>;
++		regulator-name = "VDD_3V3_SD";
++		regulator-max-microvolt = <3300000>;
++		regulator-min-microvolt = <3300000>;
++		gpio = <&gpio2 19 GPIO_ACTIVE_HIGH>;
++		enable-active-high;
++		off-on-delay-us = <12000>;
++		startup-delay-us = <100>;
++	};
++};
++
++&ecspi2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_spi2>;
++	cs-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,	/* CS0 onboard TPM */
++		   <&gpio5 13 GPIO_ACTIVE_LOW>, /* CS1 off-board J32 SPI */
++		   <&gpio1 12 GPIO_ACTIVE_LOW>, /* CS3 off-board J52 FSA1 */
++		   <&gpio4 26 GPIO_ACTIVE_LOW>; /* CS2 off-board J51 FSA2 */
++	status = "okay";
++
++	tpm@0 {
++		compatible = "atmel,attpm20p", "tcg,tpm_tis-spi";
++		reg = <0x0>;
++		spi-max-frequency = <10000000>;
++	};
++};
++
++&flexcan1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_can1>;
++	status = "okay";
++};
++
++&flexcan2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_can2>;
++	status = "okay";
++};
++
++&gpio1 {
++	gpio-line-names =
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "fsa2_gpio1", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "", "";
++};
++
++&gpio4 {
++	gpio-line-names =
++		"", "", "", "",
++		"", "", "", "",
++		"dio1", "fsa1_gpio2", "", "dio0",
++		"", "", "", "",
++		"", "", "", "",
++		"", "", "rs485_en", "rs485_term",
++		"fsa2_gpio2", "fsa1_gpio1", "", "rs485_half",
++		"", "", "", "";
++};
++
++&i2c2 {
++	accelerometer@19 {
++		compatible = "st,lis2de12";
++		reg = <0x19>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_accel>;
++		interrupt-parent = <&gpio4>;
++		interrupts = <21 IRQ_TYPE_LEVEL_LOW>;
++		st,drdy-int-pin = <1>;
++	};
++
++	magnetometer@1e {
++		compatible = "st,lis2mdl";
++		reg = <0x1e>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pinctrl_mag>;
++		interrupt-parent = <&gpio4>;
++		interrupts = <28 IRQ_TYPE_LEVEL_LOW>;
++	};
++};
++
++&i2c3 {
++	i2c-mux@70 {
++		compatible = "nxp,pca9548";
++		reg = <0x70>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		/* J30 */
++		fsa1: i2c@0 {
++			reg = <0>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&pinctrl_fsa2i2c>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			gpio@20 {
++				compatible = "nxp,pca9555";
++				reg = <0x20>;
++				interrupt-parent = <&gpio4>;
++				interrupts = <4 IRQ_TYPE_EDGE_FALLING>;
++				interrupt-controller;
++				#interrupt-cells = <2>;
++				gpio-controller;
++				#gpio-cells = <2>;
++			};
++
++			eeprom@54 {
++				compatible = "atmel,24c02";
++				reg = <0x54>;
++				pagesize = <16>;
++			};
++
++			eeprom@55 {
++				compatible = "atmel,24c02";
++				reg = <0x55>;
++				pagesize = <16>;
++			};
++		};
++
++		/* J29 */
++		fsa0: i2c@1 {
++			reg = <1>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&pinctrl_fsa1i2c>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			gpio@20 {
++				compatible = "nxp,pca9555";
++				reg = <0x20>;
++				interrupt-parent = <&gpio4>;
++				interrupts = <14 IRQ_TYPE_EDGE_FALLING>;
++				interrupt-controller;
++				#interrupt-cells = <2>;
++				gpio-controller;
++				#gpio-cells = <2>;
++			};
++
++			eeprom@54 {
++				compatible = "atmel,24c02";
++				reg = <0x54>;
++				pagesize = <16>;
++			};
++
++			eeprom@55 {
++				compatible = "atmel,24c02";
++				reg = <0x55>;
++				pagesize = <16>;
++			};
++		};
++
++		/* J33 */
++		i2c@2 {
++			reg = <2>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++		};
++	};
++};
++
++&pcie_phy {
++	clocks = <&pcie0_refclk>;
++	clock-names = "ref";
++	fsl,refclk-pad-mode = <IMX8_PCIE_REFCLK_PAD_INPUT>;
++	fsl,clkreq-unsupported;
++	status = "okay";
++};
++
++&pcie {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_pcie0>;
++	reset-gpio = <&gpio4 29 GPIO_ACTIVE_LOW>;
++	status = "okay";
++
++	pcie@0,0 {
++		reg = <0x0000 0 0 0 0>;
++		device_type = "pci";
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++
++		pcie@0,0 {
++			reg = <0x0000 0 0 0 0>;
++			device_type = "pci";
++			#address-cells = <3>;
++			#size-cells = <2>;
++			ranges;
++
++			pcie@7,0 {
++				reg = <0x3800 0 0 0 0>;
++				device_type = "pci";
++				#address-cells = <3>;
++				#size-cells = <2>;
++				ranges;
++
++				eth1: ethernet@0,0 {
++					reg = <0x0000 0 0 0 0>;
++					#address-cells = <3>;
++					#size-cells = <2>;
++					ranges;
++					local-mac-address = [00 00 00 00 00 00];
++				};
++			};
++		};
++	};
++};
++
++/* GPS */
++&uart1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart1>;
++	status = "okay";
++};
++
++/* RS232 */
++&uart4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_uart4>;
++	status = "okay";
++};
++
++/* USB1 - FSA1 */
++&usb3_0 {
++	fsl,permanently-attached;
++	fsl,disable-port-power-control;
++	status = "okay";
++};
++
++&usb3_phy0 {
++	status = "okay";
++};
++
++&usb_dwc3_0 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++/* USB2 - USB3.0 Hub */
++&usb3_1 {
++	fsl,permanently-attached;
++	fsl,disable-port-power-control;
++	status = "okay";
++};
++
++&usb3_phy1 {
++	vbus-supply = <&reg_usb2_vbus>;
++	status = "okay";
++};
++
++&usb_dwc3_1 {
++	dr_mode = "host";
++	status = "okay";
++};
++
++/* SDIO 1.8V */
++&usdhc1 {
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc1>;
++	pinctrl-1 = <&pinctrl_usdhc1_100mhz>;
++	pinctrl-2 = <&pinctrl_usdhc1_200mhz>;
++	bus-width = <4>;
++	non-removable;
++	status = "okay";
++};
++
++/* microSD */
++&usdhc2 {
++	pinctrl-names = "default", "state_100mhz", "state_200mhz";
++	pinctrl-0 = <&pinctrl_usdhc2>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-1 = <&pinctrl_usdhc2_100mhz>, <&pinctrl_usdhc2_gpio>;
++	pinctrl-2 = <&pinctrl_usdhc2_200mhz>, <&pinctrl_usdhc2_gpio>;
++	cd-gpios = <&gpio2 12 GPIO_ACTIVE_HIGH>; /* CD is active high */
++	bus-width = <4>;
++	vmmc-supply = <&reg_usdhc2_vmmc>;
++	status = "okay";
++};
++
++&iomuxc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_hog>;
++
++	pinctrl_hog: hoggrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_RXD6__GPIO4_IO08	0x40000146 /* DIO1 */
++			MX8MP_IOMUXC_SAI1_TXC__GPIO4_IO11	0x40000146 /* DIO0 */
++			MX8MP_IOMUXC_SAI2_MCLK__GPIO4_IO27	0x40000106 /* RS485_HALF */
++			MX8MP_IOMUXC_SAI2_RXC__GPIO4_IO22	0x40000106 /* RS485_EN */
++			MX8MP_IOMUXC_SAI2_RXD0__GPIO4_IO23	0x40000106 /* RS485_TERM */
++		>;
++	};
++
++	pinctrl_accel: accelgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI2_RXFS__GPIO4_IO21	0x150	/* IRQ# */
++		>;
++	};
++
++	pinctrl_can1: can1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SPDIF_TX__CAN1_TX		0x154
++			MX8MP_IOMUXC_SPDIF_RX__CAN1_RX		0x154
++		>;
++	};
++
++	pinctrl_can2: can2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI5_RXD3__CAN2_TX		0x154
++			MX8MP_IOMUXC_SAI5_MCLK__CAN2_RX		0x154
++		>;
++	};
++
++	pinctrl_gpio_leds: gpioledgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_RXC__GPIO4_IO01	0x6	/* LEDG */
++			MX8MP_IOMUXC_SAI1_RXD3__GPIO4_IO05	0x6	/* LEDR */
++		>;
++	};
++
++	pinctrl_fsa1i2c: fsa1i2cgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_TXD2__GPIO4_IO14	0x1d0		/* FSA1_ALERT# */
++			MX8MP_IOMUXC_SAI2_TXC__GPIO4_IO25	0x400001d0	/* FSA1_GPIO1 */
++			MX8MP_IOMUXC_SAI1_RXD7__GPIO4_IO09	0x400001d0	/* FSA1_GPIO2 */
++		>;
++	};
++
++	pinctrl_fsa2i2c: fsa2i2cgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_RXD2__GPIO4_IO04	0x1d0		/* FSA2_ALERT# */
++			MX8MP_IOMUXC_GPIO1_IO13__GPIO1_IO13	0x400001d0	/* FSA2_GPIO1 */
++			MX8MP_IOMUXC_SAI2_TXFS__GPIO4_IO24	0x400001d0	/* FSA2_GPIO2 */
++		>;
++	};
++
++	pinctrl_mag: maggrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI3_RXFS__GPIO4_IO28	0x140	/* IRQ# */
++		>;
++	};
++
++	pinctrl_pcie0: pcie0grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI3_RXC__GPIO4_IO29	0x106	/* PERST# */
++		>;
++	};
++
++	pinctrl_pps: ppsgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_RXD1__GPIO4_IO03	0x146
++		>;
++	};
++
++	pinctrl_reg_usb2_en: regusb2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SAI1_TXD0__GPIO4_IO12	0x146	/* USBHUB_RST# */
++		>;
++	};
++
++	pinctrl_spi2: spi2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_ECSPI2_SCLK__ECSPI2_SCLK	0xd0
++			MX8MP_IOMUXC_ECSPI2_MOSI__ECSPI2_MOSI	0xd0
++			MX8MP_IOMUXC_ECSPI2_MISO__ECSPI2_MISO	0xd0
++			MX8MP_IOMUXC_ECSPI2_SS0__GPIO5_IO13	0x140	/* J32_CS */
++			MX8MP_IOMUXC_GPIO1_IO10__GPIO1_IO10	0x140	/* TPM_CS */
++			MX8MP_IOMUXC_GPIO1_IO12__GPIO1_IO12	0x140	/* FSA1_CS */
++			MX8MP_IOMUXC_SAI2_TXD0__GPIO4_IO26	0x140	/* FSA2_CS */
++		>;
++	};
++
++	pinctrl_uart1: uart1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_UART1_RXD__UART1_DCE_RX	0x140
++			MX8MP_IOMUXC_UART1_TXD__UART1_DCE_TX	0x140
++		>;
++	};
++
++	pinctrl_uart4: uart4grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_UART4_RXD__UART4_DCE_RX	0x140
++			MX8MP_IOMUXC_UART4_TXD__UART4_DCE_TX	0x140
++		>;
++	};
++
++	pinctrl_usdhc1: usdhc1grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD1_CLK__USDHC1_CLK	0x190
++			MX8MP_IOMUXC_SD1_CMD__USDHC1_CMD	0x1d0
++			MX8MP_IOMUXC_SD1_DATA0__USDHC1_DATA0	0x1d0
++			MX8MP_IOMUXC_SD1_DATA1__USDHC1_DATA1	0x1d0
++			MX8MP_IOMUXC_SD1_DATA2__USDHC1_DATA2	0x1d0
++			MX8MP_IOMUXC_SD1_DATA3__USDHC1_DATA3	0x1d0
++		>;
++	};
++
++	pinctrl_usdhc1_100mhz: usdhc1-100mhzgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD1_CLK__USDHC1_CLK	0x194
++			MX8MP_IOMUXC_SD1_CMD__USDHC1_CMD	0x1d4
++			MX8MP_IOMUXC_SD1_DATA0__USDHC1_DATA0	0x1d4
++			MX8MP_IOMUXC_SD1_DATA1__USDHC1_DATA1	0x1d4
++			MX8MP_IOMUXC_SD1_DATA2__USDHC1_DATA2	0x1d4
++			MX8MP_IOMUXC_SD1_DATA3__USDHC1_DATA3	0x1d4
++		>;
++	};
++
++	pinctrl_usdhc1_200mhz: usdhc1-200mhzgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD1_CLK__USDHC1_CLK	0x196
++			MX8MP_IOMUXC_SD1_CMD__USDHC1_CMD	0x1d6
++			MX8MP_IOMUXC_SD1_DATA0__USDHC1_DATA0	0x1d6
++			MX8MP_IOMUXC_SD1_DATA1__USDHC1_DATA1	0x1d6
++			MX8MP_IOMUXC_SD1_DATA2__USDHC1_DATA2	0x1d6
++			MX8MP_IOMUXC_SD1_DATA3__USDHC1_DATA3	0x1d6
++		>;
++	};
++
++	pinctrl_usdhc2: usdhc2grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK	0x190
++			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD	0x1d0
++			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0	0x1d0
++			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1	0x1d0
++			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2	0x1d0
++			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3	0x1d0
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc1
++		>;
++	};
++
++	pinctrl_usdhc2_100mhz: usdhc2-100mhzgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK	0x194
++			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD	0x1d4
++			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0	0x1d4
++			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1	0x1d4
++			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2	0x1d4
++			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3	0x1d4
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc1
++		>;
++	};
++
++	pinctrl_usdhc2_200mhz: usdhc2-200mhzgrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CLK__USDHC2_CLK	0x196
++			MX8MP_IOMUXC_SD2_CMD__USDHC2_CMD	0x1d6
++			MX8MP_IOMUXC_SD2_DATA0__USDHC2_DATA0	0x1d6
++			MX8MP_IOMUXC_SD2_DATA1__USDHC2_DATA1	0x1d6
++			MX8MP_IOMUXC_SD2_DATA2__USDHC2_DATA2	0x1d6
++			MX8MP_IOMUXC_SD2_DATA3__USDHC2_DATA3	0x1d6
++			MX8MP_IOMUXC_GPIO1_IO04__USDHC2_VSELECT	0xc1
++		>;
++	};
++
++	pinctrl_usdhc2_vmmc: usdhc2-vmmc-grp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_RESET_B__GPIO2_IO19	0x1d0
++		>;
++	};
++
++	pinctrl_usdhc2_gpio: usdhc2gpiogrp {
++		fsl,pins = <
++			MX8MP_IOMUXC_SD2_CD_B__GPIO2_IO12	0x1c4
++		>;
++	};
++};

--- a/target/linux/imx/patches-6.6/600-PCI-imx6-Start-link-at-max-gen-first-for-IMX8MM-and-IMX8MP.patch
+++ b/target/linux/imx/patches-6.6/600-PCI-imx6-Start-link-at-max-gen-first-for-IMX8MM-and-IMX8MP.patch
@@ -1,0 +1,119 @@
+From cf983e4a04eecb5be93af7b53cb10805ee448998 Mon Sep 17 00:00:00 2001
+From: Tim Harvey <tharvey@gateworks.com>
+Date: Mon, 21 Aug 2023 09:20:17 -0700
+Subject: [PATCH] PCI: imx6: Start link at max gen first for IMX8MM and IMX8MP
+
+commit fa33a6d87eac ("PCI: imx6: Start link in Gen1 before negotiating
+for Gen2 mode") started link negotiation at Gen1 before attempting
+faster speeds in order to work around an issue with a particular switch
+on an IMX6Q SoC.
+
+This behavior is not the norm for PCI link negotiation and it has been
+found to cause issues in other cases:
+- IMX8MM with PI7C9X2G608GP switch: various endpoints (such as qca988x)
+  will fail to link more than 50% of the time
+- IMX8MP with PI7C9X2G608GP switch: occasionally will fail to link with
+  switch and cause a CPU hang about 30% of the time
+
+Disable this behavior for IMX8MM and IMX8MP.
+
+Signed-off-by: Tim Harvey <tharvey@gateworks.com>
+---
+ drivers/pci/controller/dwc/pci-imx6.c | 53 ++++++++++++++-------------
+ 1 file changed, 27 insertions(+), 26 deletions(-)
+
+--- a/drivers/pci/controller/dwc/pci-imx6.c
++++ b/drivers/pci/controller/dwc/pci-imx6.c
+@@ -60,6 +60,7 @@ enum imx6_pcie_variants {
+ #define IMX6_PCIE_FLAG_IMX6_PHY			BIT(0)
+ #define IMX6_PCIE_FLAG_IMX6_SPEED_CHANGE	BIT(1)
+ #define IMX6_PCIE_FLAG_SUPPORTS_SUSPEND		BIT(2)
++#define IMX6_PCIE_FLAG_GEN1_LAST		BIT(3)
+ 
+ struct imx6_pcie_drvdata {
+ 	enum imx6_pcie_variants variant;
+@@ -876,26 +877,28 @@ static int imx6_pcie_start_link(struct d
+ 	u32 tmp;
+ 	int ret;
+ 
+-	/*
+-	 * Force Gen1 operation when starting the link.  In case the link is
+-	 * started in Gen2 mode, there is a possibility the devices on the
+-	 * bus will not be detected at all.  This happens with PCIe switches.
+-	 */
+-	dw_pcie_dbi_ro_wr_en(pci);
+-	tmp = dw_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCAP);
+-	tmp &= ~PCI_EXP_LNKCAP_SLS;
+-	tmp |= PCI_EXP_LNKCAP_SLS_2_5GB;
+-	dw_pcie_writel_dbi(pci, offset + PCI_EXP_LNKCAP, tmp);
+-	dw_pcie_dbi_ro_wr_dis(pci);
++	if (!(imx6_pcie->drvdata->flags & IMX6_PCIE_FLAG_GEN1_LAST)) {
++		/*
++		 * Force Gen1 operation when starting the link.  In case the link is
++		 * started in Gen2 mode, there is a possibility the devices on the
++		 * bus will not be detected at all.  This happens with PCIe switches.
++		 */
++		dw_pcie_dbi_ro_wr_en(pci);
++		tmp = dw_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCAP);
++		tmp &= ~PCI_EXP_LNKCAP_SLS;
++		tmp |= PCI_EXP_LNKCAP_SLS_2_5GB;
++		dw_pcie_writel_dbi(pci, offset + PCI_EXP_LNKCAP, tmp);
++		dw_pcie_dbi_ro_wr_dis(pci);
++	}
+ 
+ 	/* Start LTSSM. */
+ 	imx6_pcie_ltssm_enable(dev);
+ 
+-	ret = dw_pcie_wait_for_link(pci);
+-	if (ret)
+-		goto err_reset_phy;
++	if ((pci->link_gen > 1) && !(imx6_pcie->drvdata->flags & IMX6_PCIE_FLAG_GEN1_LAST)) {
++		ret = dw_pcie_wait_for_link(pci);
++		if (ret)
++			goto err_reset_phy;
+ 
+-	if (pci->link_gen > 1) {
+ 		/* Allow faster modes after the link is up */
+ 		dw_pcie_dbi_ro_wr_en(pci);
+ 		tmp = dw_pcie_readl_dbi(pci, offset + PCI_EXP_LNKCAP);
+@@ -929,18 +932,14 @@ static int imx6_pcie_start_link(struct d
+ 				goto err_reset_phy;
+ 			}
+ 		}
+-
+-		/* Make sure link training is finished as well! */
+-		ret = dw_pcie_wait_for_link(pci);
+-		if (ret)
+-			goto err_reset_phy;
+-	} else {
+-		dev_info(dev, "Link: Only Gen1 is enabled\n");
+ 	}
+ 
++	ret = dw_pcie_wait_for_link(pci);
++	if (ret)
++		goto err_reset_phy;
++
+ 	imx6_pcie->link_is_up = true;
+-	tmp = dw_pcie_readw_dbi(pci, offset + PCI_EXP_LNKSTA);
+-	dev_info(dev, "Link up, Gen%i\n", tmp & PCI_EXP_LNKSTA_CLS);
++
+ 	return 0;
+ 
+ err_reset_phy:
+@@ -1505,12 +1504,14 @@ static const struct imx6_pcie_drvdata dr
+ 	},
+ 	[IMX8MM] = {
+ 		.variant = IMX8MM,
+-		.flags = IMX6_PCIE_FLAG_SUPPORTS_SUSPEND,
++		.flags = IMX6_PCIE_FLAG_SUPPORTS_SUSPEND |
++			 IMX6_PCIE_FLAG_GEN1_LAST,
+ 		.gpr = "fsl,imx8mm-iomuxc-gpr",
+ 	},
+ 	[IMX8MP] = {
+ 		.variant = IMX8MP,
+-		.flags = IMX6_PCIE_FLAG_SUPPORTS_SUSPEND,
++		.flags = IMX6_PCIE_FLAG_SUPPORTS_SUSPEND |
++			 IMX6_PCIE_FLAG_GEN1_LAST,
+ 		.gpr = "fsl,imx8mp-iomuxc-gpr",
+ 	},
+ 	[IMX8MQ_EP] = {


### PR DESCRIPTION
backport #17717 support recently merged to master: 

Backport some upstream patches to improve Gateworks venice support:

from 6.12: btsdio fixup for an onboard bt controller
from 6.13: updated dt fixups for gpios, accelerometer, adding gw82xx and renaming of gw7905->gw75xx
Added:

network config for new gw82xx
hack to work around PCI init hang on IMX8M{M,P} with bridge chips; links at highest speed first vs lowest speed first