### PR TITLE
ramips: mt76x8: allow larger MTU to support RFC4638

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -1578,6 +1578,8 @@ static int fe_probe(struct platform_device *pdev)
 
 	if (IS_ENABLED(CONFIG_SOC_MT7621))
 		netdev->max_mtu = 2048;
+	if (IS_ENABLED(CONFIG_SOC_MT7620) && IS_ENABLED(CONFIG_NET_RALINK_ESW_RT3050))
+		netdev->max_mtu = 1508;
 
 	/* fake rx vlan filter func. to support tx vlan offload func */
 	if (fe_reg_table[FE_REG_FE_DMA_VID_BASE])


### PR DESCRIPTION
The MT3050_ESW switch incorporated in the MT76x8 SoCs supports upto 1536 byte frames and therefore can accommodate the 1508 byte MTU to support RFC4638 baby jumbo frames for PPPoE connections.

The default maximum MTU of 1500 bytes is set during allocation of the netdev structure (ultimately via a call to ether_setup()) so increase it to 1508 bytes to enable RFC4638 support.

Fixes: #17748