### PR TITLE
ath10k: add channel 177 for 5 GHz range

### DIFF
--- a/package/kernel/mac80211/patches/ath10k/992-ath10k-add-channel-177-for-5-GHz-band.patch
+++ b/package/kernel/mac80211/patches/ath10k/992-ath10k-add-channel-177-for-5-GHz-band.patch
@@ -1,0 +1,38 @@
+From ba693b5c7b25dc0a9451d8909c9b2efe88d9039a Mon Sep 17 00:00:00 2001
+From: Paweł Owoc <frut3k7@gmail.com>
+Date: Thu, 1 Aug 2024 15:16:52 +0200
+Subject: [PATCH v2] wifi: ath10k: add channel 177 for 5 GHz band
+
+Add support for channel 177 (5885 MHz ) for the 5 GHz band.
+
+Tested-on: qca988x hw2.0 firmware ver 10.2.4-1.0-00047
+
+Signed-off-by: Paweł Owoc <frut3k7@gmail.com>
+---
+ drivers/net/wireless/ath/ath10k/core.h | 4 ++--
+ drivers/net/wireless/ath/ath10k/mac.c  | 1 +
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath10k/core.h
++++ b/drivers/net/wireless/ath/ath10k/core.h
+@@ -39,8 +39,8 @@
+ #define WMI_READY_TIMEOUT (5 * HZ)
+ #define ATH10K_FLUSH_TIMEOUT_HZ (5 * HZ)
+ #define ATH10K_CONNECTION_LOSS_HZ (3 * HZ)
+-#define ATH10K_NUM_CHANS 41
+-#define ATH10K_MAX_5G_CHAN 173
++#define ATH10K_NUM_CHANS 42
++#define ATH10K_MAX_5G_CHAN 177
+ 
+ /* Antenna noise floor */
+ #define ATH10K_DEFAULT_NOISE_FLOOR -95
+--- a/drivers/net/wireless/ath/ath10k/mac.c
++++ b/drivers/net/wireless/ath/ath10k/mac.c
+@@ -9646,6 +9646,7 @@ static const struct ieee80211_channel at
+ 	CHAN5G(165, 5825, 0),
+ 	CHAN5G(169, 5845, 0),
+ 	CHAN5G(173, 5865, 0),
++	CHAN5G(177, 5885, 0),
+ 	/* If you add more, you may need to change ATH10K_MAX_5G_CHAN */
+ 	/* And you will definitely need to change ATH10K_NUM_CHANS in core.h */
+ };


### PR DESCRIPTION
Add support for channel 177 (5885 MHz ) for the 5 GHz band.
Running AP on this channel is not possible due to `NO_IR`.