### PR TITLE
build: apk-index: include all packages in index

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -131,7 +131,7 @@ ifneq ($(CONFIG_USE_APK),)
 			--keys-dir $(TOPDIR) \
 			--sign $(BUILD_KEY_APK_SEC) \
 			--output packages.adb \
-			$$(ls *.apk | grep -vE '^(base-files-|kernel-|libc-)'); \
+			*.apk; \
 		echo -n '{"architecture": "$(ARCH_PACKAGES)", "packages":{' > index.json; \
 		$(STAGING_DIR_HOST)/bin/apk adbdump packages.adb | \
 			awk '/- name: / {pkg = $$NF} ; / version: / {printf "\"%s\": \"%s\", ", pkg, $$NF}' | \


### PR DESCRIPTION
Do not remove any packages from the apk index files upon creation. Doing so breaks certain upgrade tools as they rely on knowing the versions of updated packages from the feeds.

Links: https://github.com/efahl/owut/issues/31#issuecomment-2621087764
Fixes: https://github.com/openwrt/openwrt/issues/17774

Tested on x86/64 build, verified with 
`apk adbdump bin/targets/x86/64/packages/packages.adb`
and examination of generated bin/targets/x86/64/packages/index.json

@aparcar @ynezz @Ansuel @dangowrt
