### PR TITLE
x86: Add kmod-drm-i915 as default package

### DIFF
--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -4,7 +4,7 @@ define Device/generic
   DEVICE_PACKAGES += \
 	kmod-amazon-ena kmod-amd-xgbe kmod-bnx2 kmod-dwmac-intel kmod-e1000e kmod-e1000 \
 	kmod-forcedeth kmod-fs-vfat kmod-igb kmod-igc kmod-ixgbe kmod-r8169 \
-	kmod-tg3
+	kmod-tg3 kmod-drm-i915
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic

--- a/target/linux/x86/image/generic.mk
+++ b/target/linux/x86/image/generic.mk
@@ -3,7 +3,8 @@ define Device/generic
   DEVICE_MODEL := x86
   DEVICE_PACKAGES += kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 kmod-natsemi \
 	kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 kmod-tg3 \
-	kmod-via-rhine kmod-via-velocity kmod-forcedeth kmod-fs-vfat
+	kmod-via-rhine kmod-via-velocity kmod-forcedeth kmod-fs-vfat \
+	kmod-drm-i915
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic

--- a/target/linux/x86/image/legacy.mk
+++ b/target/linux/x86/image/legacy.mk
@@ -3,7 +3,8 @@ define Device/generic
   DEVICE_MODEL := x86/legacy
   DEVICE_PACKAGES += kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 \
 	kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 \
-	kmod-tg3 kmod-via-rhine kmod-via-velocity kmod-forcedeth
+	kmod-tg3 kmod-via-rhine kmod-via-velocity kmod-forcedeth \
+	kmod-drm-i915
   GRUB2_VARIANT := legacy
 endef
 TARGET_DEVICES += generic


### PR DESCRIPTION
Add kmod-drm-i915 to the default packages. It was build into the kernel before and is now build as a kernel module.

This increases the size of the `openwrt-x86-64-generic-squashfs-combined-efi.img.gz` image by 1,236,766 bytes.

Link: https://forum.openwrt.org/t/openwrt-24-10-0-rc7-seventh-release-candidate/223006/10
Fixes: 77cfe8fd15d3 ("x86: make i915 as a kmod with required firmware")