### PR TITLE
mediatek: fix TUF-AX4200 WAN LED

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
@@ -136,8 +136,16 @@
 		reset-assert-us = <10000>;
 		reset-deassert-us = <10000>;
 
-		/* LED0: CONN (WAN white) */
-		mxl,led-config = <0x03f0 0x0 0x0 0x0>;
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_WHITE>;
+				function = LED_FUNCTION_WAN;
+			};
+		};
 	};
 
 	switch: switch@1f {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -11,6 +11,9 @@ abt,asr3000)
 	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan-2ghz" "phy0-ap0"
 	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan-5ghz" "phy1-ap0"
 	;;
+asus,tuf-ax4200)
+	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:white:wan" "eth1" "link tx rx"
+	;;
 confiabits,mt7981)
 	ucidef_set_led_netdev "lan1" "lan1" "blue:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan2" "blue:lan-2" "lan2" "link tx rx"


### PR DESCRIPTION
With the current LED configuration using "mxl,led-config", the WAN LED stops working after the interface is brought down and up again.

Since the driver also properly supports PHY LEDs now, switch to that instead. This makes the LED work properly, but requires configuration from userspace.

Fixes: #17782