### PR TITLE
[24.10]: x86: Add kmod-drm-i915 as default package

### DIFF
--- a/target/linux/x86/image/64.mk
+++ b/target/linux/x86/image/64.mk
@@ -4,7 +4,7 @@ define Device/generic
   DEVICE_PACKAGES += \
 	kmod-amazon-ena kmod-amd-xgbe kmod-bnx2 kmod-dwmac-intel kmod-e1000e kmod-e1000 \
 	kmod-forcedeth kmod-fs-vfat kmod-igb kmod-igc kmod-ixgbe kmod-r8169 \
-	kmod-tg3
+	kmod-tg3 kmod-drm-i915
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic

--- a/target/linux/x86/image/generic.mk
+++ b/target/linux/x86/image/generic.mk
@@ -3,7 +3,8 @@ define Device/generic
   DEVICE_MODEL := x86
   DEVICE_PACKAGES += kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 kmod-natsemi \
 	kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 kmod-tg3 \
-	kmod-via-rhine kmod-via-velocity kmod-forcedeth kmod-fs-vfat
+	kmod-via-rhine kmod-via-velocity kmod-forcedeth kmod-fs-vfat \
+	kmod-drm-i915
   GRUB2_VARIANT := generic
 endef
 TARGET_DEVICES += generic

--- a/target/linux/x86/image/legacy.mk
+++ b/target/linux/x86/image/legacy.mk
@@ -3,7 +3,8 @@ define Device/generic
   DEVICE_MODEL := x86/legacy
   DEVICE_PACKAGES += kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 \
 	kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 \
-	kmod-tg3 kmod-via-rhine kmod-via-velocity kmod-forcedeth
+	kmod-tg3 kmod-via-rhine kmod-via-velocity kmod-forcedeth \
+	kmod-drm-i915
   GRUB2_VARIANT := legacy
 endef
 TARGET_DEVICES += generic


### PR DESCRIPTION
Add kmod-drm-i915 to the default packages. It was build into the kernel before and is now build as a kernel module.

Fixes: 77cfe8fd15d3 ("x86: make i915 as a kmod with required firmware")
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
Link: https://github.com/openwrt/openwrt/pull/17781
Signed-off-by: Robert Marko <robimarko@gmail.com>
(cherry picked from commit 8390599c9a29dbb0019447df9086cb8667bfd3d7)