### PR TITLE
[24.10] generic: 6.6: backport upstream r8169 patches

### DIFF
--- a/target/linux/generic/backport-6.6/780-44-v6.13-r8169-copy-vendor-driver-2.5G-5G-EEE-advertisement-c.patch
+++ b/target/linux/generic/backport-6.6/780-44-v6.13-r8169-copy-vendor-driver-2.5G-5G-EEE-advertisement-c.patch
@@ -1,0 +1,82 @@
+From e340bff27e63ed61a1e9895bed546107859e48a7 Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Fri, 8 Nov 2024 08:08:24 +0100
+Subject: [PATCH] r8169: copy vendor driver 2.5G/5G EEE advertisement
+ constraints
+
+Vendor driver r8125 doesn't advertise 2.5G EEE on RTL8125A, and r8126
+doesn't advertise 5G EEE. Likely there are compatibility issues,
+therefore do the same in r8169.
+With this change we don't have to disable 2.5G EEE advertisement in
+rtl8125a_config_eee_phy() any longer.
+We use new phylib accessor phy_set_eee_broken() to mark the respective
+EEE modes as broken.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Link: https://patch.msgid.link/ce185e10-8a2f-4cf8-a49b-fd8fb3c3c8a1@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_main.c       |  6 ++++++
+ drivers/net/ethernet/realtek/r8169_phy_config.c | 16 ++++------------
+ 2 files changed, 10 insertions(+), 12 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -5236,6 +5236,11 @@ static int r8169_mdio_register(struct rt
+ 			      tp->phydev->supported_eee);
+ 	phy_support_asym_pause(tp->phydev);
+ 
++	/* mimic behavior of r8125/r8126 vendor drivers */
++	if (tp->mac_version == RTL_GIGA_MAC_VER_61)
++		tp->phydev->eee_broken_modes |= MDIO_EEE_2_5GT;
++	tp->phydev->eee_broken_modes |= MDIO_EEE_5GT;
++
+ 	/* PHY will be woken up in rtl_open() */
+ 	phy_suspend(tp->phydev);
+ 
+--- a/drivers/net/ethernet/realtek/r8169_phy_config.c
++++ b/drivers/net/ethernet/realtek/r8169_phy_config.c
+@@ -96,15 +96,7 @@ static void rtl8125_common_config_eee_ph
+ 	phy_modify_paged(phydev, 0xa4a, 0x11, 0x0200, 0x0000);
+ }
+ 
+-static void rtl8125a_config_eee_phy(struct phy_device *phydev)
+-{
+-	rtl8168g_config_eee_phy(phydev);
+-	/* disable EEE at 2.5Gbps */
+-	phy_modify_paged(phydev, 0xa6d, 0x12, 0x0001, 0x0000);
+-	rtl8125_common_config_eee_phy(phydev);
+-}
+-
+-static void rtl8125b_config_eee_phy(struct phy_device *phydev)
++static void rtl8125_config_eee_phy(struct phy_device *phydev)
+ {
+ 	rtl8168g_config_eee_phy(phydev);
+ 	rtl8125_common_config_eee_phy(phydev);
+@@ -1066,7 +1058,7 @@ static void rtl8125a_2_hw_phy_config(str
+ 	rtl8168g_enable_gphy_10m(phydev);
+ 
+ 	rtl8168g_disable_aldps(phydev);
+-	rtl8125a_config_eee_phy(phydev);
++	rtl8125_config_eee_phy(phydev);
+ }
+ 
+ static void rtl8125b_hw_phy_config(struct rtl8169_private *tp,
+@@ -1106,7 +1098,7 @@ static void rtl8125b_hw_phy_config(struc
+ 
+ 	rtl8125_legacy_force_mode(phydev);
+ 	rtl8168g_disable_aldps(phydev);
+-	rtl8125b_config_eee_phy(phydev);
++	rtl8125_config_eee_phy(phydev);
+ }
+ 
+ static void rtl8125d_hw_phy_config(struct rtl8169_private *tp,
+@@ -1116,7 +1108,7 @@ static void rtl8125d_hw_phy_config(struc
+ 	rtl8168g_enable_gphy_10m(phydev);
+ 	rtl8125_legacy_force_mode(phydev);
+ 	rtl8168g_disable_aldps(phydev);
+-	rtl8125b_config_eee_phy(phydev);
++	rtl8125_config_eee_phy(phydev);
+ }
+ 
+ static void rtl8126a_hw_phy_config(struct rtl8169_private *tp,

--- a/target/linux/generic/backport-6.6/780-45-v6.14-r8169-remove-unused-flag-RTL_FLAG_TASK_RESET_NO_QUEU.patch
+++ b/target/linux/generic/backport-6.6/780-45-v6.14-r8169-remove-unused-flag-RTL_FLAG_TASK_RESET_NO_QUEU.patch
@@ -1,0 +1,35 @@
+From 2e20bf8cc05766dcd0357cdfcada49e1bc45512b Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Mon, 2 Dec 2024 21:14:35 +0100
+Subject: [PATCH] r8169: remove unused flag RTL_FLAG_TASK_RESET_NO_QUEUE_WAKE
+
+After 854d71c555dfc3 ("r8169: remove original workaround for RTL8125
+broken rx issue") this flag isn't used any longer. So remove it.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Michal Swiatkowski <michal.swiatkowski@linux.intel.com>
+Link: https://patch.msgid.link/d9dd214b-3027-4f60-b0e8-6f34a0c76582@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -623,7 +623,6 @@ struct rtl8169_tc_offsets {
+ enum rtl_flag {
+ 	RTL_FLAG_TASK_ENABLED = 0,
+ 	RTL_FLAG_TASK_RESET_PENDING,
+-	RTL_FLAG_TASK_RESET_NO_QUEUE_WAKE,
+ 	RTL_FLAG_TASK_TX_TIMEOUT,
+ 	RTL_FLAG_MAX
+ };
+@@ -4729,8 +4728,6 @@ static void rtl_task(struct work_struct
+ reset:
+ 		rtl_reset_work(tp);
+ 		netif_wake_queue(tp->dev);
+-	} else if (test_and_clear_bit(RTL_FLAG_TASK_RESET_NO_QUEUE_WAKE, tp->wk.flags)) {
+-		rtl_reset_work(tp);
+ 	}
+ }
+ 

--- a/target/linux/generic/backport-6.6/780-46-v6.14-r8169-remove-support-for-chip-version-11.patch
+++ b/target/linux/generic/backport-6.6/780-46-v6.14-r8169-remove-support-for-chip-version-11.patch
@@ -1,0 +1,114 @@
+From bb18265c3aba92b91a1355609769f3e967b65dee Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Mon, 2 Dec 2024 21:20:02 +0100
+Subject: [PATCH] r8169: remove support for chip version 11
+
+This is a follow-up to 982300c115d2 ("r8169: remove detection of chip
+version 11 (early RTL8168b)"). Nobody complained yet, so remove
+support for this chip version.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/b689ab6d-20b5-4b64-bd7e-531a0a972ba3@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169.h            |  2 +-
+ drivers/net/ethernet/realtek/r8169_main.c       | 14 +-------------
+ drivers/net/ethernet/realtek/r8169_phy_config.c | 10 ----------
+ 3 files changed, 2 insertions(+), 24 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169.h
++++ b/drivers/net/ethernet/realtek/r8169.h
+@@ -23,7 +23,7 @@ enum mac_version {
+ 	RTL_GIGA_MAC_VER_08,
+ 	RTL_GIGA_MAC_VER_09,
+ 	RTL_GIGA_MAC_VER_10,
+-	RTL_GIGA_MAC_VER_11,
++	/* support for RTL_GIGA_MAC_VER_11 has been removed */
+ 	/* RTL_GIGA_MAC_VER_12 was handled the same as VER_17 */
+ 	/* RTL_GIGA_MAC_VER_13 was merged with VER_10 */
+ 	RTL_GIGA_MAC_VER_14,
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -103,7 +103,6 @@ static const struct {
+ 	[RTL_GIGA_MAC_VER_08] = {"RTL8102e"				},
+ 	[RTL_GIGA_MAC_VER_09] = {"RTL8102e/RTL8103e"			},
+ 	[RTL_GIGA_MAC_VER_10] = {"RTL8101e/RTL8100e"			},
+-	[RTL_GIGA_MAC_VER_11] = {"RTL8168b/8111b"			},
+ 	[RTL_GIGA_MAC_VER_14] = {"RTL8401"				},
+ 	[RTL_GIGA_MAC_VER_17] = {"RTL8168b/8111b"			},
+ 	[RTL_GIGA_MAC_VER_18] = {"RTL8168cp/8111cp"			},
+@@ -2336,7 +2335,7 @@ static enum mac_version rtl8169_get_mac_
+ 
+ 		/* 8168B family. */
+ 		{ 0x7c8, 0x380,	RTL_GIGA_MAC_VER_17 },
+-		/* This one is very old and rare, let's see if anybody complains.
++		/* This one is very old and rare, support has been removed.
+ 		 * { 0x7c8, 0x300,	RTL_GIGA_MAC_VER_11 },
+ 		 */
+ 
+@@ -3806,7 +3805,6 @@ static void rtl_hw_config(struct rtl8169
+ 		[RTL_GIGA_MAC_VER_08] = rtl_hw_start_8102e_3,
+ 		[RTL_GIGA_MAC_VER_09] = rtl_hw_start_8102e_2,
+ 		[RTL_GIGA_MAC_VER_10] = NULL,
+-		[RTL_GIGA_MAC_VER_11] = rtl_hw_start_8168b,
+ 		[RTL_GIGA_MAC_VER_14] = rtl_hw_start_8401,
+ 		[RTL_GIGA_MAC_VER_17] = rtl_hw_start_8168b,
+ 		[RTL_GIGA_MAC_VER_18] = rtl_hw_start_8168cp_1,
+@@ -4682,12 +4680,6 @@ static irqreturn_t rtl8169_interrupt(int
+ 	if (status & LinkChg)
+ 		phy_mac_interrupt(tp->phydev);
+ 
+-	if (unlikely(status & RxFIFOOver &&
+-	    tp->mac_version == RTL_GIGA_MAC_VER_11)) {
+-		netif_stop_queue(tp->dev);
+-		rtl_schedule_task(tp, RTL_FLAG_TASK_RESET_PENDING);
+-	}
+-
+ 	rtl_irq_disable(tp);
+ 	napi_schedule(&tp->napi);
+ out:
+@@ -5107,9 +5099,6 @@ static void rtl_set_irq_mask(struct rtl8
+ 
+ 	if (tp->mac_version <= RTL_GIGA_MAC_VER_06)
+ 		tp->irq_mask |= SYSErr | RxFIFOOver;
+-	else if (tp->mac_version == RTL_GIGA_MAC_VER_11)
+-		/* special workaround needed */
+-		tp->irq_mask |= RxFIFOOver;
+ }
+ 
+ static int rtl_alloc_irq(struct rtl8169_private *tp)
+@@ -5304,7 +5293,6 @@ static int rtl_jumbo_max(struct rtl8169_
+ 	case RTL_GIGA_MAC_VER_02 ... RTL_GIGA_MAC_VER_06:
+ 		return JUMBO_7K;
+ 	/* RTL8168b */
+-	case RTL_GIGA_MAC_VER_11:
+ 	case RTL_GIGA_MAC_VER_17:
+ 		return JUMBO_4K;
+ 	/* RTL8168c */
+--- a/drivers/net/ethernet/realtek/r8169_phy_config.c
++++ b/drivers/net/ethernet/realtek/r8169_phy_config.c
+@@ -276,15 +276,6 @@ static void rtl8169sce_hw_phy_config(str
+ 	rtl_writephy_batch(phydev, phy_reg_init);
+ }
+ 
+-static void rtl8168bb_hw_phy_config(struct rtl8169_private *tp,
+-				    struct phy_device *phydev)
+-{
+-	phy_write(phydev, 0x1f, 0x0001);
+-	phy_set_bits(phydev, 0x16, BIT(0));
+-	phy_write(phydev, 0x10, 0xf41b);
+-	phy_write(phydev, 0x1f, 0x0000);
+-}
+-
+ static void rtl8168bef_hw_phy_config(struct rtl8169_private *tp,
+ 				     struct phy_device *phydev)
+ {
+@@ -1136,7 +1127,6 @@ void r8169_hw_phy_config(struct rtl8169_
+ 		[RTL_GIGA_MAC_VER_08] = rtl8102e_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_09] = rtl8102e_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_10] = NULL,
+-		[RTL_GIGA_MAC_VER_11] = rtl8168bb_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_14] = rtl8401_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_17] = rtl8168bef_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_18] = rtl8168cp_1_hw_phy_config,

--- a/target/linux/generic/backport-6.6/780-47-v6.14-r8169-adjust-version-numbering-for-RTL8126.patch
+++ b/target/linux/generic/backport-6.6/780-47-v6.14-r8169-adjust-version-numbering-for-RTL8126.patch
@@ -1,0 +1,257 @@
+From b299ea0069284186b0d3d54aebe87f0d195d457a Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Fri, 13 Dec 2024 20:01:41 +0100
+Subject: [PATCH] r8169: adjust version numbering for RTL8126
+
+Adjust version numbering for RTL8126, so that it doesn't overlap with
+new RTL8125 versions.
+
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/6a354364-20e9-48ad-a198-468264288757@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169.h          |  4 +-
+ drivers/net/ethernet/realtek/r8169_main.c     | 62 +++++++++----------
+ .../net/ethernet/realtek/r8169_phy_config.c   |  4 +-
+ 3 files changed, 35 insertions(+), 35 deletions(-)
+
+--- a/drivers/net/ethernet/realtek/r8169.h
++++ b/drivers/net/ethernet/realtek/r8169.h
+@@ -69,8 +69,8 @@ enum mac_version {
+ 	RTL_GIGA_MAC_VER_61,
+ 	RTL_GIGA_MAC_VER_63,
+ 	RTL_GIGA_MAC_VER_64,
+-	RTL_GIGA_MAC_VER_65,
+-	RTL_GIGA_MAC_VER_66,
++	RTL_GIGA_MAC_VER_70,
++	RTL_GIGA_MAC_VER_71,
+ 	RTL_GIGA_MAC_NONE
+ };
+ 
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -139,8 +139,8 @@ static const struct {
+ 	/* reserve 62 for CFG_METHOD_4 in the vendor driver */
+ 	[RTL_GIGA_MAC_VER_63] = {"RTL8125B",		FIRMWARE_8125B_2},
+ 	[RTL_GIGA_MAC_VER_64] = {"RTL8125D",		FIRMWARE_8125D_1},
+-	[RTL_GIGA_MAC_VER_65] = {"RTL8126A",		FIRMWARE_8126A_2},
+-	[RTL_GIGA_MAC_VER_66] = {"RTL8126A",		FIRMWARE_8126A_3},
++	[RTL_GIGA_MAC_VER_70] = {"RTL8126A",		FIRMWARE_8126A_2},
++	[RTL_GIGA_MAC_VER_71] = {"RTL8126A",		FIRMWARE_8126A_3},
+ };
+ 
+ static const struct pci_device_id rtl8169_pci_tbl[] = {
+@@ -1228,7 +1228,7 @@ static void rtl_writephy(struct rtl8169_
+ 	case RTL_GIGA_MAC_VER_31:
+ 		r8168dp_2_mdio_write(tp, location, val);
+ 		break;
+-	case RTL_GIGA_MAC_VER_40 ... RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_40 ... RTL_GIGA_MAC_VER_71:
+ 		r8168g_mdio_write(tp, location, val);
+ 		break;
+ 	default:
+@@ -1243,7 +1243,7 @@ static int rtl_readphy(struct rtl8169_pr
+ 	case RTL_GIGA_MAC_VER_28:
+ 	case RTL_GIGA_MAC_VER_31:
+ 		return r8168dp_2_mdio_read(tp, location);
+-	case RTL_GIGA_MAC_VER_40 ... RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_40 ... RTL_GIGA_MAC_VER_71:
+ 		return r8168g_mdio_read(tp, location);
+ 	default:
+ 		return r8169_mdio_read(tp, location);
+@@ -1574,7 +1574,7 @@ static void __rtl8169_set_wol(struct rtl
+ 		break;
+ 	case RTL_GIGA_MAC_VER_34:
+ 	case RTL_GIGA_MAC_VER_37:
+-	case RTL_GIGA_MAC_VER_39 ... RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_39 ... RTL_GIGA_MAC_VER_71:
+ 		r8169_mod_reg8_cond(tp, Config2, PME_SIGNAL, wolopts);
+ 		break;
+ 	default:
+@@ -2047,7 +2047,7 @@ static void rtl_set_eee_txidle_timer(str
+ 		tp->tx_lpi_timer = timer_val;
+ 		r8168_mac_ocp_write(tp, 0xe048, timer_val);
+ 		break;
+-	case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_71:
+ 		tp->tx_lpi_timer = timer_val;
+ 		RTL_W16(tp, EEE_TXIDLE_TIMER_8125, timer_val);
+ 		break;
+@@ -2256,8 +2256,8 @@ static enum mac_version rtl8169_get_mac_
+ 		enum mac_version ver;
+ 	} mac_info[] = {
+ 		/* 8126A family. */
+-		{ 0x7cf, 0x64a,	RTL_GIGA_MAC_VER_66 },
+-		{ 0x7cf, 0x649,	RTL_GIGA_MAC_VER_65 },
++		{ 0x7cf, 0x64a,	RTL_GIGA_MAC_VER_71 },
++		{ 0x7cf, 0x649,	RTL_GIGA_MAC_VER_70 },
+ 
+ 		/* 8125D family. */
+ 		{ 0x7cf, 0x688,	RTL_GIGA_MAC_VER_64 },
+@@ -2529,7 +2529,7 @@ static void rtl_init_rxcfg(struct rtl816
+ 	case RTL_GIGA_MAC_VER_61:
+ 		RTL_W32(tp, RxConfig, RX_FETCH_DFLT_8125 | RX_DMA_BURST);
+ 		break;
+-	case RTL_GIGA_MAC_VER_63 ... RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_63 ... RTL_GIGA_MAC_VER_71:
+ 		RTL_W32(tp, RxConfig, RX_FETCH_DFLT_8125 | RX_DMA_BURST |
+ 			RX_PAUSE_SLOT_ON);
+ 		break;
+@@ -2661,7 +2661,7 @@ static void rtl_wait_txrx_fifo_empty(str
+ 	case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_61:
+ 		rtl_loop_wait_high(tp, &rtl_rxtx_empty_cond, 100, 42);
+ 		break;
+-	case RTL_GIGA_MAC_VER_63 ... RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_63 ... RTL_GIGA_MAC_VER_71:
+ 		RTL_W8(tp, ChipCmd, RTL_R8(tp, ChipCmd) | StopReq);
+ 		rtl_loop_wait_high(tp, &rtl_rxtx_empty_cond, 100, 42);
+ 		rtl_loop_wait_high(tp, &rtl_rxtx_empty_cond_2, 100, 42);
+@@ -2904,7 +2904,7 @@ static void rtl_enable_exit_l1(struct rt
+ 	case RTL_GIGA_MAC_VER_37 ... RTL_GIGA_MAC_VER_38:
+ 		rtl_eri_set_bits(tp, 0xd4, 0x0c00);
+ 		break;
+-	case RTL_GIGA_MAC_VER_40 ... RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_40 ... RTL_GIGA_MAC_VER_71:
+ 		r8168_mac_ocp_modify(tp, 0xc0ac, 0, 0x1f80);
+ 		break;
+ 	default:
+@@ -2918,7 +2918,7 @@ static void rtl_disable_exit_l1(struct r
+ 	case RTL_GIGA_MAC_VER_34 ... RTL_GIGA_MAC_VER_38:
+ 		rtl_eri_clear_bits(tp, 0xd4, 0x1f00);
+ 		break;
+-	case RTL_GIGA_MAC_VER_40 ... RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_40 ... RTL_GIGA_MAC_VER_71:
+ 		r8168_mac_ocp_modify(tp, 0xc0ac, 0x1f80, 0);
+ 		break;
+ 	default:
+@@ -2944,8 +2944,8 @@ static void rtl_hw_aspm_clkreq_enable(st
+ 
+ 		rtl_mod_config5(tp, 0, ASPM_en);
+ 		switch (tp->mac_version) {
+-		case RTL_GIGA_MAC_VER_65:
+-		case RTL_GIGA_MAC_VER_66:
++		case RTL_GIGA_MAC_VER_70:
++		case RTL_GIGA_MAC_VER_71:
+ 			val8 = RTL_R8(tp, INT_CFG0_8125) | INT_CFG0_CLKREQEN;
+ 			RTL_W8(tp, INT_CFG0_8125, val8);
+ 			break;
+@@ -2956,7 +2956,7 @@ static void rtl_hw_aspm_clkreq_enable(st
+ 
+ 		switch (tp->mac_version) {
+ 		case RTL_GIGA_MAC_VER_46 ... RTL_GIGA_MAC_VER_48:
+-		case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_66:
++		case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_71:
+ 			/* reset ephy tx/rx disable timer */
+ 			r8168_mac_ocp_modify(tp, 0xe094, 0xff00, 0);
+ 			/* chip can trigger L1.2 */
+@@ -2968,7 +2968,7 @@ static void rtl_hw_aspm_clkreq_enable(st
+ 	} else {
+ 		switch (tp->mac_version) {
+ 		case RTL_GIGA_MAC_VER_46 ... RTL_GIGA_MAC_VER_48:
+-		case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_66:
++		case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_71:
+ 			r8168_mac_ocp_modify(tp, 0xe092, 0x00ff, 0);
+ 			break;
+ 		default:
+@@ -2976,8 +2976,8 @@ static void rtl_hw_aspm_clkreq_enable(st
+ 		}
+ 
+ 		switch (tp->mac_version) {
+-		case RTL_GIGA_MAC_VER_65:
+-		case RTL_GIGA_MAC_VER_66:
++		case RTL_GIGA_MAC_VER_70:
++		case RTL_GIGA_MAC_VER_71:
+ 			val8 = RTL_R8(tp, INT_CFG0_8125) & ~INT_CFG0_CLKREQEN;
+ 			RTL_W8(tp, INT_CFG0_8125, val8);
+ 			break;
+@@ -3697,12 +3697,12 @@ static void rtl_hw_start_8125_common(str
+ 	/* disable new tx descriptor format */
+ 	r8168_mac_ocp_modify(tp, 0xeb58, 0x0001, 0x0000);
+ 
+-	if (tp->mac_version == RTL_GIGA_MAC_VER_65 ||
+-	    tp->mac_version == RTL_GIGA_MAC_VER_66)
++	if (tp->mac_version == RTL_GIGA_MAC_VER_70 ||
++	    tp->mac_version == RTL_GIGA_MAC_VER_71)
+ 		RTL_W8(tp, 0xD8, RTL_R8(tp, 0xD8) & ~0x02);
+ 
+-	if (tp->mac_version == RTL_GIGA_MAC_VER_65 ||
+-	    tp->mac_version == RTL_GIGA_MAC_VER_66)
++	if (tp->mac_version == RTL_GIGA_MAC_VER_70 ||
++	    tp->mac_version == RTL_GIGA_MAC_VER_71)
+ 		r8168_mac_ocp_modify(tp, 0xe614, 0x0700, 0x0400);
+ 	else if (tp->mac_version == RTL_GIGA_MAC_VER_63)
+ 		r8168_mac_ocp_modify(tp, 0xe614, 0x0700, 0x0200);
+@@ -3720,8 +3720,8 @@ static void rtl_hw_start_8125_common(str
+ 	r8168_mac_ocp_modify(tp, 0xe056, 0x00f0, 0x0030);
+ 	r8168_mac_ocp_modify(tp, 0xe040, 0x1000, 0x0000);
+ 	r8168_mac_ocp_modify(tp, 0xea1c, 0x0003, 0x0001);
+-	if (tp->mac_version == RTL_GIGA_MAC_VER_65 ||
+-	    tp->mac_version == RTL_GIGA_MAC_VER_66)
++	if (tp->mac_version == RTL_GIGA_MAC_VER_70 ||
++	    tp->mac_version == RTL_GIGA_MAC_VER_71)
+ 		r8168_mac_ocp_modify(tp, 0xea1c, 0x0300, 0x0000);
+ 	else
+ 		r8168_mac_ocp_modify(tp, 0xea1c, 0x0004, 0x0000);
+@@ -3840,8 +3840,8 @@ static void rtl_hw_config(struct rtl8169
+ 		[RTL_GIGA_MAC_VER_61] = rtl_hw_start_8125a_2,
+ 		[RTL_GIGA_MAC_VER_63] = rtl_hw_start_8125b,
+ 		[RTL_GIGA_MAC_VER_64] = rtl_hw_start_8125d,
+-		[RTL_GIGA_MAC_VER_65] = rtl_hw_start_8126a,
+-		[RTL_GIGA_MAC_VER_66] = rtl_hw_start_8126a,
++		[RTL_GIGA_MAC_VER_70] = rtl_hw_start_8126a,
++		[RTL_GIGA_MAC_VER_71] = rtl_hw_start_8126a,
+ 	};
+ 
+ 	if (hw_configs[tp->mac_version])
+@@ -3862,8 +3862,8 @@ static void rtl_hw_start_8125(struct rtl
+ 			RTL_W32(tp, i, 0);
+ 		break;
+ 	case RTL_GIGA_MAC_VER_63:
+-	case RTL_GIGA_MAC_VER_65:
+-	case RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_70:
++	case RTL_GIGA_MAC_VER_71:
+ 		for (i = 0xa00; i < 0xa80; i += 4)
+ 			RTL_W32(tp, i, 0);
+ 		RTL_W16(tp, INT_CFG1_8125, 0x0000);
+@@ -4095,7 +4095,7 @@ static void rtl8169_cleanup(struct rtl81
+ 		RTL_W8(tp, ChipCmd, RTL_R8(tp, ChipCmd) | StopReq);
+ 		rtl_loop_wait_high(tp, &rtl_txcfg_empty_cond, 100, 666);
+ 		break;
+-	case RTL_GIGA_MAC_VER_40 ... RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_40 ... RTL_GIGA_MAC_VER_71:
+ 		rtl_enable_rxdvgate(tp);
+ 		fsleep(2000);
+ 		break;
+@@ -4252,7 +4252,7 @@ static unsigned int rtl_quirk_packet_pad
+ 
+ 	switch (tp->mac_version) {
+ 	case RTL_GIGA_MAC_VER_34:
+-	case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_71:
+ 		padto = max_t(unsigned int, padto, ETH_ZLEN);
+ 		break;
+ 	default:
+@@ -5274,7 +5274,7 @@ static void rtl_hw_initialize(struct rtl
+ 	case RTL_GIGA_MAC_VER_40 ... RTL_GIGA_MAC_VER_48:
+ 		rtl_hw_init_8168g(tp);
+ 		break;
+-	case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_66:
++	case RTL_GIGA_MAC_VER_61 ... RTL_GIGA_MAC_VER_71:
+ 		rtl_hw_init_8125(tp);
+ 		break;
+ 	default:
+--- a/drivers/net/ethernet/realtek/r8169_phy_config.c
++++ b/drivers/net/ethernet/realtek/r8169_phy_config.c
+@@ -1162,8 +1162,8 @@ void r8169_hw_phy_config(struct rtl8169_
+ 		[RTL_GIGA_MAC_VER_61] = rtl8125a_2_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_63] = rtl8125b_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_64] = rtl8125d_hw_phy_config,
+-		[RTL_GIGA_MAC_VER_65] = rtl8126a_hw_phy_config,
+-		[RTL_GIGA_MAC_VER_66] = rtl8126a_hw_phy_config,
++		[RTL_GIGA_MAC_VER_70] = rtl8126a_hw_phy_config,
++		[RTL_GIGA_MAC_VER_71] = rtl8126a_hw_phy_config,
+ 	};
+ 
+ 	if (phy_configs[ver])

--- a/target/linux/generic/backport-6.6/780-48-v6.14-r8169-add-support-for-RTL8125D-rev.b.patch
+++ b/target/linux/generic/backport-6.6/780-48-v6.14-r8169-add-support-for-RTL8125D-rev.b.patch
@@ -1,0 +1,90 @@
+From b3593df26ab19f114d613693fa8a92ab202803d0 Mon Sep 17 00:00:00 2001
+From: ChunHao Lin <hau@realtek.com>
+Date: Fri, 13 Dec 2024 20:02:58 +0100
+Subject: [PATCH] r8169: add support for RTL8125D rev.b
+
+Add support for RTL8125D rev.b. Its XID is 0x689. It is basically
+based on the one with XID 0x688, but with different firmware file.
+
+Signed-off-by: ChunHao Lin <hau@realtek.com>
+[hkallweit1@gmail.com: rebased after adjusted version numbering]
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/75e5e9ec-d01f-43ac-b0f4-e7456baf18d1@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/realtek/r8169.h            | 1 +
+ drivers/net/ethernet/realtek/r8169_main.c       | 6 ++++++
+ drivers/net/ethernet/realtek/r8169_phy_config.c | 1 +
+ 3 files changed, 8 insertions(+)
+
+--- a/drivers/net/ethernet/realtek/r8169.h
++++ b/drivers/net/ethernet/realtek/r8169.h
+@@ -69,6 +69,7 @@ enum mac_version {
+ 	RTL_GIGA_MAC_VER_61,
+ 	RTL_GIGA_MAC_VER_63,
+ 	RTL_GIGA_MAC_VER_64,
++	RTL_GIGA_MAC_VER_65,
+ 	RTL_GIGA_MAC_VER_70,
+ 	RTL_GIGA_MAC_VER_71,
+ 	RTL_GIGA_MAC_NONE
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -56,6 +56,7 @@
+ #define FIRMWARE_8125A_3	"rtl_nic/rtl8125a-3.fw"
+ #define FIRMWARE_8125B_2	"rtl_nic/rtl8125b-2.fw"
+ #define FIRMWARE_8125D_1	"rtl_nic/rtl8125d-1.fw"
++#define FIRMWARE_8125D_2	"rtl_nic/rtl8125d-2.fw"
+ #define FIRMWARE_8126A_2	"rtl_nic/rtl8126a-2.fw"
+ #define FIRMWARE_8126A_3	"rtl_nic/rtl8126a-3.fw"
+ 
+@@ -139,6 +140,7 @@ static const struct {
+ 	/* reserve 62 for CFG_METHOD_4 in the vendor driver */
+ 	[RTL_GIGA_MAC_VER_63] = {"RTL8125B",		FIRMWARE_8125B_2},
+ 	[RTL_GIGA_MAC_VER_64] = {"RTL8125D",		FIRMWARE_8125D_1},
++	[RTL_GIGA_MAC_VER_65] = {"RTL8125D",		FIRMWARE_8125D_2},
+ 	[RTL_GIGA_MAC_VER_70] = {"RTL8126A",		FIRMWARE_8126A_2},
+ 	[RTL_GIGA_MAC_VER_71] = {"RTL8126A",		FIRMWARE_8126A_3},
+ };
+@@ -706,6 +708,7 @@ MODULE_FIRMWARE(FIRMWARE_8107E_2);
+ MODULE_FIRMWARE(FIRMWARE_8125A_3);
+ MODULE_FIRMWARE(FIRMWARE_8125B_2);
+ MODULE_FIRMWARE(FIRMWARE_8125D_1);
++MODULE_FIRMWARE(FIRMWARE_8125D_2);
+ MODULE_FIRMWARE(FIRMWARE_8126A_2);
+ MODULE_FIRMWARE(FIRMWARE_8126A_3);
+ 
+@@ -2260,6 +2263,7 @@ static enum mac_version rtl8169_get_mac_
+ 		{ 0x7cf, 0x649,	RTL_GIGA_MAC_VER_70 },
+ 
+ 		/* 8125D family. */
++		{ 0x7cf, 0x689,	RTL_GIGA_MAC_VER_65 },
+ 		{ 0x7cf, 0x688,	RTL_GIGA_MAC_VER_64 },
+ 
+ 		/* 8125B family. */
+@@ -3840,6 +3844,7 @@ static void rtl_hw_config(struct rtl8169
+ 		[RTL_GIGA_MAC_VER_61] = rtl_hw_start_8125a_2,
+ 		[RTL_GIGA_MAC_VER_63] = rtl_hw_start_8125b,
+ 		[RTL_GIGA_MAC_VER_64] = rtl_hw_start_8125d,
++		[RTL_GIGA_MAC_VER_65] = rtl_hw_start_8125d,
+ 		[RTL_GIGA_MAC_VER_70] = rtl_hw_start_8126a,
+ 		[RTL_GIGA_MAC_VER_71] = rtl_hw_start_8126a,
+ 	};
+@@ -3858,6 +3863,7 @@ static void rtl_hw_start_8125(struct rtl
+ 	switch (tp->mac_version) {
+ 	case RTL_GIGA_MAC_VER_61:
+ 	case RTL_GIGA_MAC_VER_64:
++	case RTL_GIGA_MAC_VER_65:
+ 		for (i = 0xa00; i < 0xb00; i += 4)
+ 			RTL_W32(tp, i, 0);
+ 		break;
+--- a/drivers/net/ethernet/realtek/r8169_phy_config.c
++++ b/drivers/net/ethernet/realtek/r8169_phy_config.c
+@@ -1162,6 +1162,7 @@ void r8169_hw_phy_config(struct rtl8169_
+ 		[RTL_GIGA_MAC_VER_61] = rtl8125a_2_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_63] = rtl8125b_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_64] = rtl8125d_hw_phy_config,
++		[RTL_GIGA_MAC_VER_65] = rtl8125d_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_70] = rtl8126a_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_71] = rtl8126a_hw_phy_config,
+ 	};

--- a/target/linux/generic/backport-6.6/780-49-v6.14-r8169-add-support-for-RTL8125BP-rev.b.patch
+++ b/target/linux/generic/backport-6.6/780-49-v6.14-r8169-add-support-for-RTL8125BP-rev.b.patch
@@ -1,0 +1,184 @@
+From b11bff90f2ad52c5c55c822ecd20326619a73898 Mon Sep 17 00:00:00 2001
+From: ChunHao Lin <hau@realtek.com>
+Date: Tue, 7 Jan 2025 14:43:55 +0800
+Subject: [PATCH] r8169: add support for RTL8125BP rev.b
+
+Add support for RTL8125BP rev.b. Its XID is 0x689. This chip supports
+DASH and its dash type is "RTL_DASH_25_BP".
+
+Signed-off-by: ChunHao Lin <hau@realtek.com>
+Reviewed-by: Heiner Kallweit <hkallweit1@gmail.com>
+Link: https://patch.msgid.link/20250107064355.104711-1-hau@realtek.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/realtek/r8169.h          |  1 +
+ drivers/net/ethernet/realtek/r8169_main.c     | 30 +++++++++++++++++++
+ .../net/ethernet/realtek/r8169_phy_config.c   | 23 ++++++++++++++
+ 3 files changed, 54 insertions(+)
+
+--- a/drivers/net/ethernet/realtek/r8169.h
++++ b/drivers/net/ethernet/realtek/r8169.h
+@@ -70,6 +70,7 @@ enum mac_version {
+ 	RTL_GIGA_MAC_VER_63,
+ 	RTL_GIGA_MAC_VER_64,
+ 	RTL_GIGA_MAC_VER_65,
++	RTL_GIGA_MAC_VER_66,
+ 	RTL_GIGA_MAC_VER_70,
+ 	RTL_GIGA_MAC_VER_71,
+ 	RTL_GIGA_MAC_NONE
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -57,6 +57,7 @@
+ #define FIRMWARE_8125B_2	"rtl_nic/rtl8125b-2.fw"
+ #define FIRMWARE_8125D_1	"rtl_nic/rtl8125d-1.fw"
+ #define FIRMWARE_8125D_2	"rtl_nic/rtl8125d-2.fw"
++#define FIRMWARE_8125BP_2	"rtl_nic/rtl8125bp-2.fw"
+ #define FIRMWARE_8126A_2	"rtl_nic/rtl8126a-2.fw"
+ #define FIRMWARE_8126A_3	"rtl_nic/rtl8126a-3.fw"
+ 
+@@ -141,6 +142,7 @@ static const struct {
+ 	[RTL_GIGA_MAC_VER_63] = {"RTL8125B",		FIRMWARE_8125B_2},
+ 	[RTL_GIGA_MAC_VER_64] = {"RTL8125D",		FIRMWARE_8125D_1},
+ 	[RTL_GIGA_MAC_VER_65] = {"RTL8125D",		FIRMWARE_8125D_2},
++	[RTL_GIGA_MAC_VER_66] = {"RTL8125BP",		FIRMWARE_8125BP_2},
+ 	[RTL_GIGA_MAC_VER_70] = {"RTL8126A",		FIRMWARE_8126A_2},
+ 	[RTL_GIGA_MAC_VER_71] = {"RTL8126A",		FIRMWARE_8126A_3},
+ };
+@@ -632,6 +634,7 @@ enum rtl_dash_type {
+ 	RTL_DASH_NONE,
+ 	RTL_DASH_DP,
+ 	RTL_DASH_EP,
++	RTL_DASH_25_BP,
+ };
+ 
+ struct rtl8169_private {
+@@ -709,6 +712,7 @@ MODULE_FIRMWARE(FIRMWARE_8125A_3);
+ MODULE_FIRMWARE(FIRMWARE_8125B_2);
+ MODULE_FIRMWARE(FIRMWARE_8125D_1);
+ MODULE_FIRMWARE(FIRMWARE_8125D_2);
++MODULE_FIRMWARE(FIRMWARE_8125BP_2);
+ MODULE_FIRMWARE(FIRMWARE_8126A_2);
+ MODULE_FIRMWARE(FIRMWARE_8126A_3);
+ 
+@@ -1361,10 +1365,19 @@ static void rtl8168ep_driver_start(struc
+ 		rtl_loop_wait_high(tp, &rtl_ep_ocp_read_cond, 10000, 30);
+ }
+ 
++static void rtl8125bp_driver_start(struct rtl8169_private *tp)
++{
++	r8168ep_ocp_write(tp, 0x01, 0x14, OOB_CMD_DRIVER_START);
++	r8168ep_ocp_write(tp, 0x01, 0x18, 0x00);
++	r8168ep_ocp_write(tp, 0x01, 0x10, 0x01);
++}
++
+ static void rtl8168_driver_start(struct rtl8169_private *tp)
+ {
+ 	if (tp->dash_type == RTL_DASH_DP)
+ 		rtl8168dp_driver_start(tp);
++	else if (tp->dash_type == RTL_DASH_25_BP)
++		rtl8125bp_driver_start(tp);
+ 	else
+ 		rtl8168ep_driver_start(tp);
+ }
+@@ -1385,10 +1398,19 @@ static void rtl8168ep_driver_stop(struct
+ 		rtl_loop_wait_low(tp, &rtl_ep_ocp_read_cond, 10000, 10);
+ }
+ 
++static void rtl8125bp_driver_stop(struct rtl8169_private *tp)
++{
++	r8168ep_ocp_write(tp, 0x01, 0x14, OOB_CMD_DRIVER_STOP);
++	r8168ep_ocp_write(tp, 0x01, 0x18, 0x00);
++	r8168ep_ocp_write(tp, 0x01, 0x10, 0x01);
++}
++
+ static void rtl8168_driver_stop(struct rtl8169_private *tp)
+ {
+ 	if (tp->dash_type == RTL_DASH_DP)
+ 		rtl8168dp_driver_stop(tp);
++	else if (tp->dash_type == RTL_DASH_25_BP)
++		rtl8125bp_driver_stop(tp);
+ 	else
+ 		rtl8168ep_driver_stop(tp);
+ }
+@@ -1411,6 +1433,7 @@ static bool rtl_dash_is_enabled(struct r
+ 	case RTL_DASH_DP:
+ 		return r8168dp_check_dash(tp);
+ 	case RTL_DASH_EP:
++	case RTL_DASH_25_BP:
+ 		return r8168ep_check_dash(tp);
+ 	default:
+ 		return false;
+@@ -1425,6 +1448,8 @@ static enum rtl_dash_type rtl_get_dash_t
+ 		return RTL_DASH_DP;
+ 	case RTL_GIGA_MAC_VER_51 ... RTL_GIGA_MAC_VER_53:
+ 		return RTL_DASH_EP;
++	case RTL_GIGA_MAC_VER_66:
++		return RTL_DASH_25_BP;
+ 	default:
+ 		return RTL_DASH_NONE;
+ 	}
+@@ -2262,6 +2287,9 @@ static enum mac_version rtl8169_get_mac_
+ 		{ 0x7cf, 0x64a,	RTL_GIGA_MAC_VER_71 },
+ 		{ 0x7cf, 0x649,	RTL_GIGA_MAC_VER_70 },
+ 
++		/* 8125BP family. */
++		{ 0x7cf, 0x681,	RTL_GIGA_MAC_VER_66 },
++
+ 		/* 8125D family. */
+ 		{ 0x7cf, 0x689,	RTL_GIGA_MAC_VER_65 },
+ 		{ 0x7cf, 0x688,	RTL_GIGA_MAC_VER_64 },
+@@ -3845,6 +3873,7 @@ static void rtl_hw_config(struct rtl8169
+ 		[RTL_GIGA_MAC_VER_63] = rtl_hw_start_8125b,
+ 		[RTL_GIGA_MAC_VER_64] = rtl_hw_start_8125d,
+ 		[RTL_GIGA_MAC_VER_65] = rtl_hw_start_8125d,
++		[RTL_GIGA_MAC_VER_66] = rtl_hw_start_8125d,
+ 		[RTL_GIGA_MAC_VER_70] = rtl_hw_start_8126a,
+ 		[RTL_GIGA_MAC_VER_71] = rtl_hw_start_8126a,
+ 	};
+@@ -3864,6 +3893,7 @@ static void rtl_hw_start_8125(struct rtl
+ 	case RTL_GIGA_MAC_VER_61:
+ 	case RTL_GIGA_MAC_VER_64:
+ 	case RTL_GIGA_MAC_VER_65:
++	case RTL_GIGA_MAC_VER_66:
+ 		for (i = 0xa00; i < 0xb00; i += 4)
+ 			RTL_W32(tp, i, 0);
+ 		break;
+--- a/drivers/net/ethernet/realtek/r8169_phy_config.c
++++ b/drivers/net/ethernet/realtek/r8169_phy_config.c
+@@ -1102,6 +1102,28 @@ static void rtl8125d_hw_phy_config(struc
+ 	rtl8125_config_eee_phy(phydev);
+ }
+ 
++static void rtl8125bp_hw_phy_config(struct rtl8169_private *tp,
++				    struct phy_device *phydev)
++{
++	r8169_apply_firmware(tp);
++	rtl8168g_enable_gphy_10m(phydev);
++
++	r8168g_phy_param(phydev, 0x8010, 0x0800, 0x0000);
++
++	phy_write(phydev, 0x1f, 0x0b87);
++	phy_write(phydev, 0x16, 0x8088);
++	phy_modify(phydev, 0x17, 0xff00, 0x9000);
++	phy_write(phydev, 0x16, 0x808f);
++	phy_modify(phydev, 0x17, 0xff00, 0x9000);
++	phy_write(phydev, 0x1f, 0x0000);
++
++	r8168g_phy_param(phydev, 0x8174, 0x2000, 0x1800);
++
++	rtl8125_legacy_force_mode(phydev);
++	rtl8168g_disable_aldps(phydev);
++	rtl8125_config_eee_phy(phydev);
++}
++
+ static void rtl8126a_hw_phy_config(struct rtl8169_private *tp,
+ 				   struct phy_device *phydev)
+ {
+@@ -1163,6 +1185,7 @@ void r8169_hw_phy_config(struct rtl8169_
+ 		[RTL_GIGA_MAC_VER_63] = rtl8125b_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_64] = rtl8125d_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_65] = rtl8125d_hw_phy_config,
++		[RTL_GIGA_MAC_VER_66] = rtl8125bp_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_70] = rtl8126a_hw_phy_config,
+ 		[RTL_GIGA_MAC_VER_71] = rtl8126a_hw_phy_config,
+ 	};


### PR DESCRIPTION
Backport of https://github.com/openwrt/openwrt/pull/17797 https://github.com/openwrt/openwrt/commit/084618f8db7d0e413b47bab3e0ea70804bf84ee2

**WARNING: DO NOT MERGE UNTIL FINAL 24.10 IS RELEASED**