### PR TITLE
uboot-mvebu: update to version 2025.04

### DIFF
--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -8,10 +8,10 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
-PKG_VERSION:=2024.10
+PKG_VERSION:=2025.04
 PKG_RELEASE:=1
 
-PKG_HASH:=b28daf4ac17e43156363078bf510297584137f6df50fced9b12df34f61a92fb0
+PKG_HASH:=439d3bef296effd54130be6a731c5b118be7fddd7fcc663ccbc5fb18294d8718
 
 include $(INCLUDE_DIR)/u-boot.mk
 include $(INCLUDE_DIR)/package.mk

--- a/package/boot/uboot-mvebu/patches/102-arm-mvebu-add-support-for-MikroTik-RB5009UG-S-IN.patch
+++ b/package/boot/uboot-mvebu/patches/102-arm-mvebu-add-support-for-MikroTik-RB5009UG-S-IN.patch
@@ -31,7 +31,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -177,6 +177,7 @@ dtb-$(CONFIG_ARCH_MVEBU) +=			\
+@@ -165,6 +165,7 @@ dtb-$(CONFIG_ARCH_MVEBU) +=			\
  	armada-3720-uDPU.dtb			\
  	armada-7040-db-nand.dtb			\
  	armada-7040-db.dtb			\


### PR DESCRIPTION
Update package to the latest stable version. All patches automatically refreshed, just line numbers.

Build-tested for all supported subtargets
Run-tested on _Turris Omnia_ (cortexa9)