### PR TITLE
scripts: getver.sh: approximate version from date

### DIFF
--- a/scripts/getver.sh
+++ b/scripts/getver.sh
@@ -23,6 +23,9 @@ try_git() {
 		BASE_REV="$(git rev-list ${REBOOT}..HEAD 2>/dev/null | wc -l | awk '{print $1}')"
 		[ $((BASE_REV - GET_REV)) -ge 0 ] && REV="$(git rev-parse HEAD~$((BASE_REV - GET_REV)))"
 		;;
+	*-*-*)  # ISO date format - for approximating when packages were removed or renamed
+		GET_REV="$(git log -n 1 --format="%h" --until "$GET_REV")"
+		;&  # FALLTHROUGH
 	*)
 		BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 		ORIGIN="$(git rev-parse --verify --symbolic-full-name ${BRANCH}@{u} 2>/dev/null)"


### PR DESCRIPTION
When doing package support and management it is often the case that knowing the corresponding openwrt repo's release version is useful.

For example, when adding package changes to the ASU server, the openwrt revision is used as the cutoff for applying those changes. Knowing a package change's hash in its remote feed repo allows us to look up its change date, which we can now use with getver.sh to approximate the revision in openwrt at which it was made.