### PR TITLE
Added support for MERCUSYS MB130-4G v1

### DIFF
--- a/target/linux/ramips/dts/mt7628an_mercusys_mb130-4g-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_mercusys_mb130-4g-v1.dts
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "mercusys,mb130-4g-v1", "mediatek,mt7628an-soc";
+	model = "MERCUSYS MB130-4G v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		signal1 {
+			label = "green:signal1";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			label = "green:signal2";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			label = "green:signal3";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+
+		out_atn {
+			gpio-export,name = "out_atn";
+			gpio-export,output = <0>;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb_power {
+			gpio-export,name = "usb_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 36 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb_boot {
+			gpio-export,name = "usb_boot";
+			gpio-export,output = <0>;
+			gpios = <&gpio 37 GPIO_ACTIVE_HIGH>;
+		};
+
+		usb_reset {
+			gpio-export,name = "usb_reset";
+			gpio-export,output = <0>;
+			gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0xe90000>;
+			};
+
+			partition@eb0000 {
+				label = "ispconfig";
+				reg = <0xeb0000 0x10000>;
+				read-only;
+			};
+
+			partition@ec0000 {
+				label = "romfile";
+				reg = <0xec0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_romfile_f100: macaddr@f100 {
+						compatible = "mac-base";
+						reg = <0xf100 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@ed0000 {
+				label = "config";
+				reg = <0xed0000 0x10000>;
+				read-only;
+			};
+
+			partition@ee0000 {
+				label = "configbak";
+				reg = <0xee0000 0x10000>;
+				read-only;
+			};
+
+			partition@ef0000 {
+				label = "radio";
+				reg = <0xef0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_radio_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+				};
+			};
+
+			partition@f00000 {
+				label = "userdata";
+				reg = <0xf00000 0x100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an", "uart1", "wdt";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_romfile_f100 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	status = "okay";
+};
+
+&esw {
+	mediatek,portmap = <0x37>;
+	mediatek,portdisable = <0x33>;
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_romfile_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_romfile_f100 (-1)>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -488,6 +488,20 @@ define Device/mercury_mac1200r-v2
 endef
 TARGET_DEVICES += mercury_mac1200r-v2
 
+define Device/mercusys_mb130-4g-v1
+$(Device/tplink-v2)
+  IMAGE_SIZE := 14912k
+  DEVICE_VENDOR := MERCUSYS
+  DEVICE_MODEL := MB130-4G
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-mt76x0e kmod-usb2 kmod-mt7663-firmware-ap kmod-mt7615e \
+                     kmod-usb-serial-option kmod-usb-net-cdc-ether
+  TPLINK_FLASHLAYOUT := 16MLmtk
+  IMAGES := sysupgrade.bin tftp-recovery.bin
+  IMAGE/tftp-recovery.bin := pad-extra 128k | $$(IMAGE/factory.bin)
+endef
+TARGET_DEVICES += mercusys_mb130-4g-v1
+
 define Device/minew_g1-c
   IMAGE_SIZE := 15744k
   DEVICE_VENDOR := Minew

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -96,6 +96,7 @@ tplink,archer-mr200-v6)
 	ucidef_set_led_netdev "lan" "lan" "white:lan" "eth0"
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wwan0"
 	;;
+mercusys,mb130-4g-v1|\
 tplink,re200-v2|\
 tplink,re200-v3|\
 tplink,re200-v4|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -156,6 +156,11 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan:1" "1:lan:2" "2:lan:3" "3:lan:4" "4:wan" "6@eth0"
 		;;
+	mercusys,mb130-4g-v1)
+		ucidef_add_switch "switch0" \
+			"2:lan" "3:lan" "6@eth0"
+		ucidef_set_interface_wan "eth1"
+		;;
 	netgear,r6020|\
 	netgear,r6080|\
 	netgear,r6120|\


### PR DESCRIPTION
Dear OpenWRT team,

Please review and accept patch provided in this pull request.
One of them updating firmware-utils package which is required for further adding new platform.

Couple of words about this device - it's widely available in Europe 4G router and its price comparatively small.
On top of that it supports external antennas and very friendly for modifications.

Thank you,
Sergey