### PR TITLE
tools/automake: bump to 1.17

### DIFF
--- a/tools/automake/Makefile
+++ b/tools/automake/Makefile
@@ -8,12 +8,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=automake
 PKG_CPE_ID:=cpe:/a:gnu:automake
-PKG_VERSION:=1.16.5
+PKG_VERSION:=1.17
 PKG_API_VERSION:=$(word 2,$(subst ., ,$(PKG_VERSION)))
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/automake
-PKG_HASH:=07bd24ad08a64bc17250ce09ec56e921d6343903943e99ccf63bbf0705e34605
+PKG_HASH:=8920c1fc411e13b90bf704ef9db6f29d540e76d232cb3b2c9f4dc4cc599bd990
 
 include $(INCLUDE_DIR)/host-build.mk
 
@@ -21,7 +21,7 @@ HOST_CONFIGURE_ARGS += \
 	--disable-silent-rules
 
 HOST_CONFIGURE_VARS += \
-	PERL="/usr/bin/env perl" \
+	PERL="$(shell command -v perl)" \
 	am_cv_prog_PERL_ithreads=no
 
 define Host/Configure

--- a/tools/automake/patches/000-relocatable.patch
+++ b/tools/automake/patches/000-relocatable.patch
@@ -11,7 +11,7 @@
  # We need at least this version for CLONE support.
 --- a/bin/aclocal.in
 +++ b/bin/aclocal.in
-@@ -23,9 +23,11 @@ use 5.006;
+@@ -23,10 +23,12 @@ use 5.006;
  use strict;
  use warnings FATAL => 'all';
  
@@ -20,21 +20,23 @@
  BEGIN
  {
 -  unshift (@INC, '@datadir@/@PACKAGE@-@APIVERSION@')
+-    unless $ENV{AUTOMAKE_UNINSTALLED};
 +  unshift (@INC, ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/@PACKAGE@-@APIVERSION@' : '@datadir@/@PACKAGE@-@APIVERSION@'))
-     unless $ENV{AUTOMAKE_UNINSTALLED};
++     unless $ENV{AUTOMAKE_UNINSTALLED};
  }
  
+ use File::Basename;
 @@ -65,8 +67,8 @@ $perl_threads = 0;
- # ACLOCAL_PATH environment variable, and reset with the '--system-acdir'
- # option.
+ # --aclocal-path option/ACLOCAL_PATH environment variable, and reset
+ # with the '--system-acdir' option.
  my @user_includes = ();
 -my @automake_includes = ('@datadir@/aclocal-' . $APIVERSION);
 -my @system_includes = ('@datadir@/aclocal');
 +my @automake_includes = ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . "/share/aclocal-$APIVERSION" : "@datadir@/aclocal-$APIVERSION");
 +my @system_includes = ($ENV{'STAGING_DIR_HOST'} ? $ENV{'STAGING_DIR_HOST'} . '/share/aclocal' : '@datadir@/aclocal');
+ my $aclocal_path = '';
  
  # Whether we should copy M4 file in $user_includes[0].
- my $install = 0;
 --- a/bin/automake.in
 +++ b/bin/automake.in
 @@ -26,9 +26,11 @@ use 5.006;

--- a/tools/automake/patches/100-aclocal-skip-not-existing-directories.patch
+++ b/tools/automake/patches/100-aclocal-skip-not-existing-directories.patch
@@ -1,6 +1,6 @@
 --- a/bin/aclocal.in
 +++ b/bin/aclocal.in
-@@ -371,6 +371,12 @@ sub scan_m4_dirs ($$@)
+@@ -372,6 +372,12 @@ sub scan_m4_dirs ($$@)
  
    foreach my $m4dir (@dirlist)
      {

--- a/tools/automake/patches/101-do-not-require-files.patch
+++ b/tools/automake/patches/101-do-not-require-files.patch
@@ -1,6 +1,6 @@
 --- a/bin/automake.in
 +++ b/bin/automake.in
-@@ -4513,7 +4513,7 @@ sub handle_gettext ()
+@@ -4552,7 +4552,7 @@ sub handle_gettext ()
  	    && grep ($_ eq 'intl', @subdirs));
      }
  
@@ -9,7 +9,7 @@
  }
  
  # Emit makefile footer.
-@@ -5641,7 +5641,7 @@ sub check_gnu_standards ()
+@@ -5677,7 +5677,7 @@ sub check_gnu_standards ()
            # otherwise require non-.md.
            my $required
             = (! -f $file && -f "$file.md") ? "$file.md" : $file;
@@ -18,7 +18,7 @@
          }
  
        # Accept one of these three licenses; default to COPYING.
-@@ -5655,7 +5655,7 @@ sub check_gnu_standards ()
+@@ -5691,7 +5691,7 @@ sub check_gnu_standards ()
  	      last;
  	    }
  	}

--- a/tools/automake/patches/200-other-V-values-for-verbosity.patch
+++ b/tools/automake/patches/200-other-V-values-for-verbosity.patch
@@ -9,8 +9,8 @@ Subject: [PATCH] Allow other V values for verbosity
 
 --- a/m4/silent.m4
 +++ b/m4/silent.m4
-@@ -43,7 +43,7 @@ else
- fi])
+@@ -53,7 +53,7 @@ case $enable_silent_rules in @%:@ (((
+ esac
  if test $am_cv_make_support_nested_variables = yes; then
    dnl Using '$V' instead of '$(V)' breaks IRIX make.
 -  AM_V='$(V)'


### PR DESCRIPTION
refresh patch:
000-relocatable.patch
100-aclocal-skip-not-existing-directories.patch
101-do-not-require-files.patch
200-other-V-values-for-verbosity.patch

Announcement:https://lists.gnu.org/archive/html/info-gnu/2021-01/msg00010.html
