### PR TITLE
mediatek: filogic: set mac addresses correctly for Acer Predator W6/W6d

### DIFF
--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -4,21 +4,29 @@ preinit_set_mac_address() {
 	case $(board_name) in
 	acer,predator-w6|\
 	acer,predator-w6d)
-		$(mmc_get_mac_ascii u-boot-env WANMAC)
-		$(mmc_get_mac_ascii u-boot-env LANMAC)
-		ip link set dev lan1 address "$lan_mac"
-		ip link set dev lan2 address "$lan_mac"
-		ip link set dev lan3 address "$lan_mac"
-		ip link set dev game address "$lan_mac"
-		ip link set dev eth1 address "$wan_mac"
+		wan_mac=$(mmc_get_mac_ascii u-boot-env WANMAC)
+		lan_mac=$(mmc_get_mac_ascii u-boot-env LANMAC)
+		if [ -n "$lan_mac" ] ; then
+			ip link set dev lan1 address "$lan_mac"
+			ip link set dev lan2 address "$lan_mac"
+			ip link set dev lan3 address "$lan_mac"
+			ip link set dev game address "$lan_mac"
+		fi
+		if [ -n "$wan_mac" ] ; then
+			ip link set dev eth1 address "$wan_mac"
+		fi
 		;;
 	acer,vero-w6m)
 		wan_mac=$(mmc_get_mac_ascii u-boot-env WANMAC)
 		lan_mac=$(mmc_get_mac_ascii u-boot-env LANMAC)
-		ip link set dev lan1 address "$lan_mac"
-		ip link set dev lan2 address "$lan_mac"
-		ip link set dev lan3 address "$lan_mac"
-		ip link set dev internet address "$wan_mac"
+		if [ -n "$lan_mac" ] ; then
+			ip link set dev lan1 address "$lan_mac"
+			ip link set dev lan2 address "$lan_mac"
+			ip link set dev lan3 address "$lan_mac"
+		fi
+		if [ -n "$wan_mac" ] ; then
+			ip link set dev internet address "$wan_mac"
+		fi
 		;;
 	asus,tuf-ax4200|\
 	asus,tuf-ax6000)


### PR DESCRIPTION
Add missing variable assignments in lines 7 and 8 of preinit script `/lib/preinit/10_fix_eth_mac.sh` and ensure that the variables are only applied to LAN and WAN ethernet ports if they are not empty (i.e. if the u-boot variables `LANMAC` and `WANMAC` are valid mac addresses) for Acer W6/W6d/W6m devices.