### PR TITLE
busybox: libbb/loop: fix existence check for LOOP_CONFIGURE ioctl

### DIFF
--- a/package/utils/busybox/patches/600-libbb-loop-fix-existency-check-for-LOOP_CONFIGURE-io.patch
+++ b/package/utils/busybox/patches/600-libbb-loop-fix-existency-check-for-LOOP_CONFIGURE-io.patch
@@ -1,0 +1,13 @@
+diff --git a/libbb/loop.c b/libbb/loop.c
+index a0c5d0259..b603d0daa 100644
+--- a/libbb/loop.c
++++ b/libbb/loop.c
+@@ -158,7 +158,7 @@ static int set_loopdev_params(int lfd,
+ 		if (rc == 0)
+ 			return rc; /* SUCCESS! */
+ # if ENABLE_TRY_LOOP_CONFIGURE
+-		if (errno != EINVAL)
++		if (errno != EINVAL && errno != ENOTTY)
+ 			return rc; /* error other than old kernel */
+ 		/* Old kernel, fall through into old way to do it: */
+ # endif


### PR DESCRIPTION
The LOOP_CONFIGURE ioctl is supported in 5.8 kernels and up. To have backwards compatibility there is a config option CONFIG_TRY_LOOP_CONFIGURE that will check if the ioctl exists and if not fall back to old way of configuring loop devices.

Normally errno will be set to EINVAL when this ioctl does not exist. However, when kernel config CONFIG_COMPAT is enabled, then compat_ioctl is called. In that case -ENOIOCTLCMD is returned by loop device driver and generic ioctl wrapper will set errno to ENOTTY. Because busybox does not expect this it will fail to mount loop devices in this case.

This patch fixes the check for the existence of the ioctl LOOP_CONFIGURE by checking if errno is one of both: EINVAL or ENOTTY.

This patch was proposed upstream: https://lists.busybox.net/pipermail/busybox/2024-April/090736.html

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
