### PR TITLE
mediatek: filogic: fix mt7986a-zyxel-ex5601-t0-stock.dts model name and eth1 wan definition

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
@@ -11,8 +11,8 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	model = "Zyxel EX5601-T0";
-	compatible = "zyxel,ex5601-t0", "mediatek,mt7986a-rfb-snand";
+	model = "Zyxel EX5601-T0 (stock layout)";
+	compatible = "zyxel,ex5601-t0-stock", "mediatek,mt7986a";
 
 	memory@40000000 {
 		device_type = "memory";

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -141,7 +141,7 @@ xiaomi,redmi-router-ax6000-ubootmod)
 zbtlink,zbt-z8103ax)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
-zyxel_ex5601-t0-stock|\
+zyxel,ex5601-t0-stock|\
 zyxel,ex5601-t0-ubootmod)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link tx rx"
 	ucidef_set_led_netdev "wan" "WAN" "green:inet" "eth1" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -166,7 +166,7 @@ case "$board" in
 	routerich,ax3000-ubootmod|\
 	zbtlink,zbt-z8102ax|\
 	zbtlink,zbt-z8103ax|\
-	zyxel,ex5601-t0|\
+	zyxel,ex5601-t0-stock|\
 	zyxel,ex5601-t0-ubootmod)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
Fix the model name to reflect the stock partitioning and the wan eth1 detection in the 02_network script.

