### PR TITLE
ramips: mt7620: various minor wireless issue fixes for some devices

### DIFF
--- a/package/base-files/files/lib/functions/caldata.sh
+++ b/package/base-files/files/lib/functions/caldata.sh
@@ -125,8 +125,8 @@ caldata_valid() {
 caldata_patch_data() {
 	local data=$1
 	local data_count=$((${#1} / 2))
-	local data_offset=$(($2))
-	local chksum_offset=$(($3))
+	[ -n "$2" ] && local data_offset=$(($2))
+	[ -n "$3" ] && local chksum_offset=$(($3))
 	local target=$4
 	local fw_data
 	local fw_chksum

--- a/package/kernel/mac80211/patches/rt2x00/602-01-wifi-rt2x00-Add-support-for-loading-EEPROM-from-user.patch
+++ b/package/kernel/mac80211/patches/rt2x00/602-01-wifi-rt2x00-Add-support-for-loading-EEPROM-from-user.patch
@@ -151,7 +151,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 +	}
 +
 +	if (!ee_name)
-+		return 0;
++		return -ENOENT;
 +
 +	rt2x00_info(rt2x00dev, "Loading EEPROM data from '%s'.\n", ee_name);
 +

--- a/target/linux/ramips/dts/mt7620a_linksys_e1700.dts
+++ b/target/linux/ramips/dts/mt7620a_linksys_e1700.dts
@@ -167,6 +167,10 @@
 };
 
 &wmac {
+	pinctrl-names = "default", "pa_gpio";
+	pinctrl-0 = <&pa_pins>;
+	pinctrl-1 = <&pa_gpio_pins>;
+
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
+++ b/target/linux/ramips/mt7620/base-files/etc/hotplug.d/firmware/10-rt2x00-eeprom
@@ -34,12 +34,12 @@ case "$FIRMWARE" in
 		wan_mac=$(jboot_config_read -m -i $(find_mtd_part "config") -o 0xE000)
 		wifi_mac=$(macaddr_add "$wan_mac" 1)
 		jboot_eeprom_extract "config" 0xE000
-		caldata_patch_mac $wifi_mac 0x4
+		caldata_patch_data "${wifi_mac//:/}" 0x4
 		;;
 	dovado,tiny-ac)
 		wifi_mac=$(mtd_get_mac_ascii u-boot-env INIC_MAC_ADDR)
 		caldata_extract "factory" 0x0 0x200
-		caldata_patch_mac $wifi_mac 0x4
+		caldata_patch_data "${wifi_mac//:/}" 0x4
 		;;
 	*)
 		caldata_die "Please define mtd-eeprom in $board DTS file!"


### PR DESCRIPTION
This patch series fixes some minor wireless issue for mt7620:

ramips: mt7620: add missing PA/LNA pinctrl for Linksys E1700
Fixes: https://github.com/openwrt/openwrt/issues/7959

mac80211: rt2x00: fix eeprom load from PCI eFuse 
Fixes: https://github.com/openwrt/openwrt/issues/17854

base-files: fix offset conversion on caldata_patch_data()
Revert "Revert "ramips: mt7620: fix patching mac address in caldata"" 
Fixes: https://github.com/openwrt/openwrt/issues/17818