### PR TITLE
qualcommax: ipq50xx: add support for GL.iNET GL-B3000

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
@@ -8,6 +8,11 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+glinet,gl-b3000)
+	idx="$(find_mtd_index 0:APPSBLENV)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000"
+	;;
 linksys,mr5500|\
 linksys,mx2000|\
 linksys,mx5500|\

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -40,6 +40,7 @@ ALLWIFIBOARDS:= \
 	edimax_cax1800 \
 	glinet_gl-ax1800 \
 	glinet_gl-axt1800 \
+	glinet_gl-b3000 \
 	linksys_homewrk \
 	linksys_mr5500 \
 	linksys_mr7350 \
@@ -189,6 +190,7 @@ $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
 $(eval $(call generate-ipq-wifi-package,glinet_gl-ax1800,GL.iNet GL-AX1800))
 $(eval $(call generate-ipq-wifi-package,glinet_gl-axt1800,GL.iNet GL-AXT1800))
+$(eval $(call generate-ipq-wifi-package,glinet_gl-b3000,GL.iNet GL-B3000))
 $(eval $(call generate-ipq-wifi-package,linksys_homewrk,Linksys HomeWRK))
 $(eval $(call generate-ipq-wifi-package,linksys_mr5500,Linksys MR5500))
 $(eval $(call generate-ipq-wifi-package,linksys_mr7350,Linksys MR7350))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
@@ -1,0 +1,436 @@
+/dts-v1/;
+
+#include "ipq5018.dtsi"
+#include "ipq5018-ess.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "GL.iNet GL-B3000";
+	compatible ="glinet,gl-b3000", "qcom,ipq5018";
+
+	aliases {
+		ethernet1 = &dp2;
+		label-mac-device = &dp2;
+		led-boot = &led_system_blue;
+		led-failsafe = &led_status_white;
+		led-running = &led_status_white;
+		led-upgrade = &led_system_blue;
+		serial0 = &blsp1_uart1;
+	};
+
+	chosen {
+		bootargs-append = " root=/dev/ubiblock0_1 swiotlb=1 coherent_pool=2M";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		button_reset {
+			label = "reset";
+			gpios = <&tlmm 27 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&leds_pins>;
+		pinctrl-names = "default";
+
+		led_system_blue: led_system_blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpio = <&tlmm 24 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led_status_white: led_status_white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_POWER;
+			gpio = <&tlmm 23 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+	};
+
+	reserved-memory {
+
+		q6_mem_regions: q6_mem_regions@4b000000 {
+			no-map;
+			reg = <0x0 0x4b000000 0x0 0x3000000>;
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
+
+	qcom,port_phyinfo {
+
+		// MAC0 -> GE Phy -> QCA8337 Phy2
+		port@0 {
+			port_id = <1>;
+			mdiobus = <&mdio0>;
+			phy_address = <7>;
+		};
+
+		// MAC1 ---SGMII---> QCA8337 SerDes
+		port@1 {
+			port_id = <2>;
+			forced-speed = <1000>;
+			forced-duplex = <1>;
+		};
+	};
+};
+
+// MAC1 ---SGMII---> QCA8337 SerDes
+&dp2 {
+	status = "okay";
+	nvmem-cells = <&macaddr_dp2>;
+	nvmem-cell-names = "mac-address";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+&mdio1 {
+	status = "okay";
+	pinctrl-0 = <&mdio1_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 39 GPIO_ACTIVE_LOW>;
+
+	// QCA8337 Phy0 -> WAN
+	qca8337_0: ethernet-phy@0 {
+		reg = <0>;
+	};
+
+	// QCA8337 Phy1 -> LAN1
+	qca8337_1: ethernet-phy@1 {
+		reg = <1>;
+	};
+
+	// QCA8337 Phy3 -> LAN2
+	qca8337_2: ethernet-phy@2 {
+		reg = <2>;
+	};
+
+	// QCA8337 switch
+	switch0: ethernet-switch@17 {
+		compatible = "qca,qca8337";
+		reg = <17>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			switch0cpu: port@0 {
+				reg = <0>;
+				label = "cpu";
+				phy-mode = "sgmii";
+				ethernet = <&dp2>;
+				qca,sgmii-enable-pll;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+
+			// QCA8337 Phy0 -> WAN
+			port@1 {
+				reg = <1>;
+				label = "wan";
+				phy-handle = <&qca8337_0>;
+			};
+
+			// QCA8337 Phy1 -> LAN1
+			port@2 {
+				reg = <2>;
+				label = "lan1";
+				phy-handle = <&qca8337_1>;
+
+				nvmem-cells = <&macaddr_dp2 2>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			// QCA8337 Phy3 -> LAN2
+			port@3 {
+				reg = <3>;
+				label = "lan2";
+				phy-handle = <&qca8337_2>;
+
+				nvmem-cells = <&macaddr_dp2 2>;
+				nvmem-cell-names = "mac-address";
+			};
+		};
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&xo_board_clk {
+	clock-frequency = <24000000>;
+};
+
+&blsp1_uart1 {
+	status = "okay";
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qfprom {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	pinctrl-0 = <&qpic_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		nand-ecc-engine = <&qpic_nand>;
+		nand-ecc-strength = <8>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+
+			partition-0-art {
+				compatible = "fixed-partitions";
+				label = "0:ART";
+				read-only;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_dp2: macaddr@0 {
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+						reg = <0x0 0x6>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&tlmm {
+	mdio1_pins: mdio-state {
+
+		mdc-pins {
+			pins = "gpio36";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio37";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	leds_pins: leds-pins {
+		pins = "gpio23", "gpio24";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	button_pins: button-pins {
+		pins = "gpio27";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+
+	qpic_pins: qpic-state {
+
+		clock-pins {
+			pins = "gpio9";
+			function = "qspi_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		cs-pins {
+			pins = "gpio8";
+			function = "qspi_cs";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		data-pins {
+			pins = "gpio4", "gpio5", "gpio6", "gpio7";
+			function = "qspi_data";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	serial_0_pins: uart0-state {
+		pins =
+			"gpio20", // RX
+			"gpio21"; // TX
+		function = "blsp0_uart0";
+		drive-strength = <8>;
+		bias-disable;
+	};
+};
+
+&tsens {
+	status = "okay ";
+};
+
+&q6v5_wcss {
+	status = "okay";
+
+	memory-region = <&q6_mem_regions>;
+	firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt",
+			"ath11k/IPQ5018/hw1.0/m3_fw.mdt",
+			"ath11k/QCN6122/hw1.0/m3_fw.mdt";
+
+	/* B3000 currently doesn't support passing bootargs */
+	/*boot-args = <					*/
+			/*       type:	0x1  PCIE0	*/
+			/*     length:	4		*/
+			/*      PD id:	3		*/
+			/* reset GPIO:	15		*/
+			/*   reserved:	0 0>;		*/
+
+	// IPQ5018
+	q6_wcss_pd1: pd-1 {
+		firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt";
+
+		resets =
+			<&gcc GCC_WCSSAON_RESET>,
+			<&gcc GCC_WCSS_BCR>,
+			<&gcc GCC_CE_BCR>;
+		reset-names =
+			"wcss_aon_reset",
+			"wcss_reset",
+			"ce_reset";
+
+		clocks =
+			<&gcc GCC_WCSS_AHB_S_CLK>,
+			<&gcc GCC_WCSS_ACMT_CLK>,
+			<&gcc GCC_WCSS_AXI_M_CLK>;
+		clock-names =
+			"gcc_wcss_ahb_s_clk",
+			"gcc_wcss_acmt_clk",
+			"gcc_wcss_axi_m_clk";
+
+		// qcom,halt-regs = <&tcsr_q6_block 0xa000 0xd000 0x0>;
+		interrupts-extended =
+			<&wcss_smp2p_in 8 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 9 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 12 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 11 IRQ_TYPE_NONE>;
+		interrupt-names =
+			"fatal",
+			"ready",
+			"spawn-ack",
+			"stop-ack";
+
+		qcom,smem-states =
+			<&wcss_smp2p_out 8>,
+			<&wcss_smp2p_out 9>,
+			<&wcss_smp2p_out 10>;
+		qcom,smem-state-names =
+			"shutdown",
+			"stop",
+			"spawn";
+	};
+
+	// QCN6102 5G
+	q6_wcss_pd3: pd-3 {
+		firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt";
+
+		interrupts-extended =
+			<&wcss_smp2p_in 24 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 25 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 28 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 27 IRQ_TYPE_NONE>;
+		interrupt-names =
+			"fatal",
+			"ready",
+			"spawn-ack",
+			"stop-ack";
+
+		qcom,smem-states =
+			<&wcss_smp2p_out 24>,
+			<&wcss_smp2p_out 25>,
+			<&wcss_smp2p_out 26>;
+		qcom,smem-state-names =
+			"shutdown",
+			"stop",
+			"spawn";
+	};
+};
+
+&wifi0 {
+	// IPQ5018
+	status = "okay";
+	
+	qcom,rproc = <&q6_wcss_pd1>;
+	qcom,userpd-subsys-name = "q6v5_wcss_userpd1";
+	qcom,ath11k-calibration-variant = "GL-iNet-GL-B3000";
+	qcom,ath11k-fw-memory-mode = <2>;
+	qcom,bdf-addr = <0x4c400000>;
+};
+
+&wifi1 {
+	// QCN6102 5G
+	status = "okay";
+
+	qcom,rproc = <&q6_wcss_pd3>;
+	qcom,userpd-subsys-name = "q6v5_wcss_userpd3";
+	qcom,ath11k-calibration-variant = "GL-iNet-GL-B3000";
+	qcom,ath11k-fw-memory-mode = <2>;
+	qcom,bdf-addr = <0x4d100000>;
+	qcom,m3-dump-addr = <0x4df00000>;
+};

--- a/target/linux/qualcommax/image/glinet_gl-b3000.bootscript
+++ b/target/linux/qualcommax/image/glinet_gl-b3000.bootscript
@@ -1,0 +1,47 @@
+if test "x$verbose" = "x"; then
+    failedmsg=\'[failed]\'
+else
+    failedmsg='######################################## Failed'
+fi
+
+if test -n $soc_hw_version; then
+    if test "$soc_hw_version" = "20180100" || test "$soc_hw_version" = "20180101" ; then
+        echo 'soc_hw_version : Validation success'
+    else
+        echo 'soc_hw_version : did not match, aborting upgrade'
+        exit 1
+    fi
+else
+    echo 'soc_hw_version : unknown, skipping validation'
+fi
+
+if test "$machid" = "8040004" ; then
+    echo 'machid : Validation success'
+else
+    echo 'machid : unknown, aborting upgrade'
+    exit 1
+fi
+
+if test "x$verbose" = "x"; then
+    echo \\c'Flashing ubi:                                          '
+    setenv stdout nulldev
+else
+    echo '######################################## Flashing ubi: Started'
+fi
+
+failreason='error: failed on image extraction'
+imxtract $imgaddr ubi || setenv stdout serial && echo "$failedmsg" && echo "$failreason" && exit 1
+failreason='error: failed on partition erase'
+nand device 0 && nand erase 0x00800000 0x07800000 || setenv stdout serial && echo "$failedmsg" && echo "$failreason" && exit 1
+failreason='error: failed on partition write'
+nand write $fileaddr 0x00800000 rootfs_size || setenv stdout serial && echo "$failedmsg" && echo "$failreason" && exit 1
+if test "x$verbose" = "x"; then
+    setenv stdout serial
+    echo '[ done ]'
+    setenv stdout nulldev
+    setenv stdout serial
+else
+    echo '######################################## Flashing ubi: Done'
+fi
+
+exit 0

--- a/target/linux/qualcommax/image/ipq50xx.mk
+++ b/target/linux/qualcommax/image/ipq50xx.mk
@@ -1,3 +1,27 @@
+DEVICE_VARS += BOOT_SCRIPT
+
+define Device/glinet_gl-b3000
+	$(call Device/FitImage)
+	DEVICE_VENDOR := GL.iNet
+	DEVICE_MODEL := GL-B3000
+	SOC := ipq5018
+	KERNEL_LOADADDR := 0x41080000
+	KERNEL_IN_UBI := 1
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	NAND_SIZE := 128m
+	DEVICE_DTS_CONFIG := config@mp03.5-c1
+	SUPPORTED_DEVICES += b3000
+	BOOT_SCRIPT:= glinet_gl-b3000.bootscript
+	IMAGES := factory.img sysupgrade.bin
+	IMAGE/factory.img := append-ubi | gl-qsdk-factory | append-metadata
+	DEVICE_PACKAGES := \
+		ath11k-firmware-qcn6122 \
+		ipq-wifi-glinet_gl-b3000 \
+		dumpimage
+endef
+TARGET_DEVICES += glinet_gl-b3000
+
 define Device/linksys_ipq50xx_mx_base
 	$(call Device/FitImageLzma)
 	DEVICE_VENDOR := Linksys

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
@@ -7,6 +7,9 @@ ipq50xx_setup_interfaces()
 {
 	local board="$1"
 	case $board in
+	glinet,gl-b3000)
+		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
+		;;
 	linksys,mr5500)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -9,6 +9,11 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath11k/IPQ5018/hw1.0/cal-ahb-c000000.wifi.bin")
 	case "$board" in
+	glinet,gl-b3000)
+		caldata_extract "0:art" 0x1000 0x20000
+		ath11k_patch_mac $(macaddr_add $(get_mac_label_dt) 3) 0
+		ath11k_set_macflag
+		;;
 	linksys,mr5500|\
 	linksys,mx2000|\
 	linksys,mx5500|\
@@ -23,6 +28,11 @@ case "$FIRMWARE" in
 	;;
 "ath11k/QCN6122/hw1.0/cal-ahb-b00a040.wifi1.bin")
 	case "$board" in
+	glinet,gl-b3000)
+		caldata_extract "0:art" 0x26800 0x20000
+		ath11k_patch_mac $(macaddr_add $(get_mac_label_dt) 4) 0
+		ath11k_set_macflag
+		;;
 	linksys,mx2000)
 		caldata_extract "0:ART" 0x26800 0x20000
 		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/glinet-upgrade.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/glinet-upgrade.sh
@@ -1,0 +1,53 @@
+. /lib/upgrade/common.sh
+
+glinet_do_fit_upgrade() {
+	echo -n "fit: Extract [ FIT IMAGE ] -x-x-> [ ubi.bin ] ... "
+	local ubi=/tmp/ubi.bin
+	local part=$(dumpimage -l "$1" | grep -o "Image [0-9] (ubi)" | cut -f2 -d" ")
+
+	local ubibin=$( dumpimage -T flat_dt -p ${part} -o "$ubi"  "$1" )
+	if [ -s "$ubi" ]; then
+		echo "[ OK ]"
+		local ubiMd5=$(md5sum "$ubi" | cut -f1 -d" ")
+		echo -n "fit-copy: [ ubi.bin ] -c-c-> [ firmware.bin ] ... "
+		mv "$ubi" "$1"
+		echo "[ OK ]"
+		local firmMd5=$(md5sum "$1" | cut -f1 -d" ")
+		echo -n "fit-copy: MD5 CHECK: "
+		if [ "$ubiMd5" = "$firmMd5" ]; then
+			echo "[ OK ]"
+			echo "$ubiMd5 <=> $firmMd5"
+			echo "fit: Successfully Extracted UBI from FIT IMAGE"
+			echo "fit: Proceeding with sysupgrade .."
+			nand_do_upgrade "$1"
+			return
+		fi
+		echo "[ FAILED ] !!"
+		echo "ERROR: Failed to Copy UBI into firmware.bin !!"
+		echo "fit: Terminating sysupgrade .."
+		exit 1
+	fi
+	echo "[ FAILED ] !!"
+	echo "ERROR: Failed to Extract UBI from FIT IMAGE !!"
+	echo "fit: Terminating sysupgrade .."
+	exit 1
+}
+
+glinet_do_upgrade() {
+	CI_UBIPART="rootfs"
+	echo -n "Validating GL.iNet Image ... "
+	case "$(identify_magic_long $(get_magic_long "$1"))" in
+	fit)
+		echo "[ OK ]"
+		echo "fit-main: Firmware is Valid: fit"
+		echo "fit-main: Upgrading Firmware via [ FIT IMAGE ]"
+		glinet_do_fit_upgrade "$1"
+		;;
+	*)
+		echo "[ FAILED ] !!"
+		echo "main: GL.iNet Image Validation Failed !!"
+		echo "main: Attempting default sysupgrade"
+		nand_do_upgrade "$1"
+		;;
+	esac
+}

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
@@ -1,7 +1,7 @@
 PART_NAME=firmware
 REQUIRE_IMAGE_METADATA=1
 
-RAMFS_COPY_BIN='fw_printenv fw_setenv head'
+RAMFS_COPY_BIN='dumpimage fw_printenv fw_setenv head'
 RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
 remove_oem_ubi_volume() {
@@ -71,6 +71,9 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
+	glinet,gl-b3000)
+		glinet_do_upgrade "$1"
+		;;
 	linksys,mr5500|\
 	linksys,mx2000|\
 	linksys,mx5500|\


### PR DESCRIPTION
qualcommax: ipq50xx: add support for GL.iNET GL-B3000

Add support for GL.iNET (AX3000) B3000.

Speficiations:
* SoC: Qualcomm IPQ5018 (64-bit dual-core ARM Cortex-A53 @ 1.0Ghz)
* Memory: Winbond W634GU6NQB-11 (512 MiB DDR3-933)
* Serial Port: 3v3 TTL 115200n8
* Wi-Fi: IPQ5018 (2x2 2.4 Ghz 802.11b/g/n/ax)
* Wi-Fi: QCN6102 (2x2:2 5 Ghz 802.11an/ac/ax)
* Ethernet: IPQ5018 integrated virtual switch connected to an external
            QCA8337 switch (3 Ports 10/100/1000 GBASE-T)
* Flash: Winbond W25N01GWZEIG (128 MiB)
* LEDs: 1x single-color blue LED (GPIO 24 Active High)
        1x single-color white LED (GPIO 23 Active High)
* Buttons: 1x Reset (GPIO 27 Active Low)

Flash Instructions:

*** The .img files are now universal ! ***

Openwrt		--> openwrt-qualcommax-ipq50xx-glinet_gl-b3000-squashfs-factory.img

GL.iNet OEM	--> openwrt-b3000-4.5.18-0731-1722397535.img

Either file can be flashed, in any of the available upgrade options, in both Firmwares.

Pick a file .. pick a method .. and SEND IT !!