### PR TITLE
uboot-envtools: add support for ZyXEL GS-1900-24EP

### DIFF
--- a/package/boot/uboot-envtools/files/realtek
+++ b/package/boot/uboot-envtools/files/realtek
@@ -28,6 +28,7 @@ zyxel,gs1900-10hp|\
 zyxel,gs1900-16|\
 zyxel,gs1900-24-v1|\
 zyxel,gs1900-24e|\
+zyxel,gs1900-24ep|\
 zyxel,gs1900-24hp-v1|\
 zyxel,gs1900-24hp-v2)
 	idx="$(find_mtd_index u-boot-env)"


### PR DESCRIPTION
It seems the that this was forgotten during initial adding of the device in 0688cf5aebe1dc9a2e7f3820861783c2a7a75d44

Thanks to https://forum.openwrt.org/t/zyxel-gs1900-10hp-revision-b1-support-openwrt-firmware/131841/32 for putting me on the right track for this problem

Error that is being fixed - running fw_printenv results in: "Warning: Bad CRC, using default environment"
and not showing boardmodel

Workaround, manually changing /etc/fw_env.config to "/dev/mtd1 0x0 0x400 0x10000 "
