### PR TITLE
kirkwood: add support for D-Link DNS-325 A1

### DIFF
--- a/package/boot/uboot-kirkwood/Makefile
+++ b/package/boot/uboot-kirkwood/Makefile
@@ -25,6 +25,11 @@ define U-Boot/dns320l
   BUILD_DEVICES:=dlink_dns320l
 endef
 
+define U-Boot/dns325
+  NAME:=D-Link DNS-325 A1
+  BUILD_DEVICES:=dlink_dns-325-a1
+endef
+
 define U-Boot/dockstar
   NAME:=Seagate DockStar
   BUILD_DEVICES:=seagate_dockstar
@@ -112,6 +117,7 @@ endef
 
 UBOOT_TARGETS := \
 	dns320l \
+	dns325 \
 	dockstar dockstar_second_stage \
 	goflexhome \
 	ib62x0 ib62x0_second_stage \

--- a/package/boot/uboot-kirkwood/patches/011-arm-kirkwood-dns325-Correct-CONFIG_NR_DRAM_BANKS-parameter.patch
+++ b/package/boot/uboot-kirkwood/patches/011-arm-kirkwood-dns325-Correct-CONFIG_NR_DRAM_BANKS-parameter.patch
@@ -1,0 +1,27 @@
+From e7e650e8bdb09ac46da017250394f8c589df10bb Mon Sep 17 00:00:00 2001
+From: Tom Rini <trini@konsulko.com>
+Date: Mon, 14 Sep 2020 15:48:47 -0400
+Subject: [PATCH] arm: kirkwood: dns325: Correct CONFIG_NR_DRAM_BANKS parameter
+
+Testing on a DNS-325 NAS has shown that in order for the device to work
+we need to set CONFIG_NR_DRAM_BANKS to 1 and not 2.
+
+Tested-by: Dmitry N. Kolesnikov <dk.diklab@gmail.com>
+Reported-by: Dmitry N. Kolesnikov <dk.diklab@gmail.com>
+Cc: Stefan Herbrechtsmeier <stefan@herbrechtsmeier.net>
+Signed-off-by: Tom Rini <trini@konsulko.com>
+---
+ configs/dns325_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/configs/dns325_defconfig
++++ b/configs/dns325_defconfig
+@@ -6,7 +6,7 @@ CONFIG_SYS_TEXT_BASE=0x600000
+ CONFIG_TARGET_DNS325=y
+ CONFIG_ENV_SIZE=0x20000
+ CONFIG_ENV_OFFSET=0xE0000
+-CONFIG_NR_DRAM_BANKS=2
++CONFIG_NR_DRAM_BANKS=1
+ CONFIG_IDENT_STRING="\nD-Link DNS-325"
+ # CONFIG_SYS_MALLOC_F is not set
+ CONFIG_BOOTDELAY=3

--- a/package/boot/uboot-kirkwood/patches/100-dns325.patch
+++ b/package/boot/uboot-kirkwood/patches/100-dns325.patch
@@ -1,0 +1,65 @@
+--- a/configs/dns325_defconfig
++++ b/configs/dns325_defconfig
+@@ -27,7 +27,7 @@ CONFIG_CMD_FAT=y
+ CONFIG_CMD_JFFS2=y
+ CONFIG_CMD_MTDPARTS=y
+ CONFIG_MTDIDS_DEFAULT="nand0=orion_nand"
+-CONFIG_MTDPARTS_DEFAULT="mtdparts=orion_nand:896k(u-boot),128k(u-boot-env),5m(kernel),-(rootfs)"
++CONFIG_MTDPARTS_DEFAULT="mtdparts=orion_nand:0xe0000@0x0(u-boot),0x20000@0xe0000(u-boot-env),-@0x100000(ubi)"
+ CONFIG_CMD_UBI=y
+ CONFIG_ISO_PARTITION=y
+ CONFIG_OF_CONTROL=y
+--- a/include/configs/dns325.h
++++ b/include/configs/dns325.h
+@@ -66,46 +66,12 @@
+  */
+ 
+ #define CONFIG_EXTRA_ENV_SETTINGS \
+-	"stdin=serial\0" \
+-	"stdout=serial\0" \
+-	"stderr=serial\0" \
+-	"loadaddr=0x800000\0" \
+-	"autoload=no\0" \
+-	"console=ttyS0,115200\0" \
+-	"mtdparts="CONFIG_MTDPARTS_DEFAULT \
+-	"optargs=\0" \
+-	"bootenv=uEnv.txt\0" \
+-	"importbootenv=echo Importing environment ...; " \
+-		"env import -t ${loadaddr} ${filesize}\0" \
+-	"loadbootenv=fatload usb 0 ${loadaddr} ${bootenv}\0" \
+-	"setbootargs=setenv bootargs console=${console} " \
+-		"${optargs} " \
+-		"${mtdparts} " \
+-		"root=${bootenvroot} " \
+-		"rootfstype=${bootenvrootfstype}\0" \
+-	"subbootcmd=run setbootargs; " \
+-		"if run bootenvloadimage; then " \
+-			"bootm ${loadaddr};" \
+-		"fi;\0" \
+-	"nandroot=ubi0:rootfs ubi.mtd=rootfs\0" \
+-	"nandrootfstype=ubifs\0" \
+-	"nandloadimage=nand read ${loadaddr} kernel\0" \
+-	"setnandbootenv=echo Booting from nand ...; " \
+-		"setenv bootenvroot ${nandroot}; " \
+-		"setenv bootenvrootfstype ${nandrootfstype}; " \
+-		"setenv bootenvloadimage ${nandloadimage}\0"
++	"mtdids="CONFIG_MTDIDS_DEFAULT "\0" \
++	"mtdparts="CONFIG_MTDPARTS_DEFAULT "\0"
+ 
+ #define CONFIG_BOOTCOMMAND \
+-	"if test -n ${bootenv} && usb start; then " \
+-		"if run loadbootenv; then " \
+-			"echo Loaded environment ${bootenv} from usb;" \
+-			"run importbootenv;" \
+-		"fi;" \
+-		"if test -n ${bootenvcmd}; then " \
+-			"echo Running bootenvcmd ...;" \
+-			"run bootenvcmd;" \
+-		"fi;" \
+-	"fi;" \
+-	"run setnandbootenv subbootcmd;"
++	"ubi part ubi; " \
++	"ubi read 0x800000 kernel; " \
++	"bootm 0x800000"
+ 
+ #endif /* _CONFIG_DNS325_H */

--- a/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
+++ b/package/boot/uboot-kirkwood/patches/200-openwrt-config.patch
@@ -214,3 +214,23 @@
 +CONFIG_FIT_VERBOSE=y
  CONFIG_LZMA=y
 +CONFIG_LZO=y
+--- a/configs/dns325_defconfig
++++ b/configs/dns325_defconfig
+@@ -48,3 +48,8 @@ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_STORAGE=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_LZMA=y
++CONFIG_LZO=y
+--- a/include/configs/dns325.h
++++ b/include/configs/dns325.h
+@@ -74,4 +74,6 @@
+ 	"ubi read 0x800000 kernel; " \
+ 	"bootm 0x800000"
+ 
++#include "openwrt-kirkwood-common.h"
++
+ #endif /* _CONFIG_DNS325_H */

--- a/package/boot/uboot-tools/uboot-envtools/files/kirkwood
+++ b/package/boot/uboot-tools/uboot-envtools/files/kirkwood
@@ -16,6 +16,7 @@ checkpoint,l-50|\
 cloudengines,pogoe02|\
 cloudengines,pogoplugv4|\
 dlink,dns320l|\
+dlink,dns-325-a1\
 globalscale,sheevaplug|\
 iom,ix2-200|\
 iom,ix4-200d|\

--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -20,6 +20,7 @@ kirkwood_setup_interfaces()
 	cloudengines,pogoplugv4|\
 	ctera,c200-v1|\
 	dlink,dns320l|\
+	dlink,dns-325-a1|\
 	globalscale,sheevaplug|\
 	iom,iconnect-1.1|\
 	iom,ix2-200|\

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -189,6 +189,18 @@ define Device/dlink_dns320l
 endef
 TARGET_DEVICES += dlink_dns320l
 
+define Device/dlink_dns-325-a1
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DNS-325
+  DEVICE_VARIANT := A1
+  DEVICE_DTS := kirkwood-dns325
+  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-hwmon-lm75 kmod-hwmon-gpiofan \
+	kmod-thermal kmod-usb-ledtrig-usbport kmod-gpio-button-hotplug block-mount \
+  mdadm kmod-md-linear kmod-usb-storage kmod-fs-ext4 e2fsprogs partx-utils \
+  fdisk kmod-rtc-mv
+endef
+TARGET_DEVICES += dlink_dns-325-a1
+
 define Device/endian_4i-edge-200
   DEVICE_VENDOR := Endian
   DEVICE_MODEL := 4i Edge 200

--- a/target/linux/kirkwood/patches-6.12/108-dns325-add-led-labels-and-thermal-zones.patch
+++ b/target/linux/kirkwood/patches-6.12/108-dns325-add-led-labels-and-thermal-zones.patch
@@ -1,0 +1,107 @@
+--- a/arch/arm/boot/dts/marvell/kirkwood-dns325.dts
++++ b/arch/arm/boot/dts/marvell/kirkwood-dns325.dts
+@@ -2,11 +2,19 @@
+ /dts-v1/;
+ 
+ #include "kirkwood-dnskw.dtsi"
++#include <dt-bindings/thermal/thermal.h>
+ 
+ / {
+ 	model = "D-Link DNS-325 NAS (Rev A1)";
+ 	compatible = "dlink,dns-325-a1", "dlink,dns-325", "dlink,dns-kirkwood", "marvell,kirkwood-88f6281", "marvell,kirkwood";
+ 
++	aliases {
++		led-boot = &led_white_power;
++		led-failsafe = &led_white_power;
++		led-running = &led_white_power;
++		led-upgrade = &led_white_power;
++	};
++
+ 	memory {
+ 		device_type = "memory";
+ 		reg = <0x00000000 0x10000000>;
+@@ -24,24 +32,25 @@
+ 			     &pmx_led_white_usb>;
+ 		pinctrl-names = "default";
+ 
+-		led-white-power {
++		led_white_power: white-power {
+ 			label = "dns325:white:power";
+ 			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
+ 			default-state = "keep";
+ 		};
+-		led-white-usb {
++		led_white_usb: white-usb {
+ 			label = "dns325:white:usb";
+ 			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>; /* GPIO 43 */
++			linux,default-trigger = "usb-host";
+ 		};
+-		led-red-l_hdd {
++		led_red_l_hdd: red-l_hdd {
+ 			label = "dns325:red:l_hdd";
+ 			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+ 		};
+-		led-red-r_hdd {
++		led_red_r_hdd: red-r_hdd {
+ 			label = "dns325:red:r_hdd";
+ 			gpios = <&gpio0 27 GPIO_ACTIVE_LOW>;
+ 		};
+-		led-red-usb {
++		led_red_usb: red-usb {
+ 			label = "dns325:red:usb";
+ 			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
+ 		};
+@@ -54,10 +63,53 @@
+ 			lm75: lm75@48 {
+ 				compatible = "national,lm75";
+ 				reg = <0x48>;
++				#thermal-sensor-cells = <0>;
+ 			};
+ 		};
+ 		serial@12000 {
+ 			status = "okay";
+ 		};
+ 	};
++
++	thermal-zones {
++		chassis-thermal {
++			polling-delay = <20000>;
++			polling-delay-passive = <2000>;
++
++			thermal-sensors = <&lm75>;
++
++			trips {
++				chassis_alert0: chassis-alert0 {
++					temperature = <43000>;
++					hysteresis = <3000>;
++					type = "active";
++				};
++				chassis_alert1: chassis-alert1 {
++					temperature = <47000>;
++					hysteresis = <3000>;
++					type = "active";
++				};
++				chassis-crit {
++					temperature = <60000>;
++					hysteresis = <2000>;
++					type = "critical";
++				};
++			};
++
++			cooling-maps {
++				map0 {
++					trip = <&chassis_alert0>;
++					cooling-device = <&fan0 1 1>;
++				};
++				map1 {
++					trip = <&chassis_alert1>;
++					cooling-device = <&fan0 2 2>;
++				};
++			};
++		};
++	};
++};
++
++&fan0 {
++	#cooling-cells = <2>;
+ };

--- a/target/linux/kirkwood/patches-6.12/109-dns325-add-fan-label-and-update-partitions.patch
+++ b/target/linux/kirkwood/patches-6.12/109-dns325-add-fan-label-and-update-partitions.patch
@@ -1,0 +1,52 @@
+--- a/arch/arm/boot/dts/marvell/kirkwood-dnskw.dtsi
++++ b/arch/arm/boot/dts/marvell/kirkwood-dnskw.dtsi
+@@ -29,7 +29,7 @@
+ 		};
+ 	};
+ 
+-	gpio_fan {
++	fan0: gpio_fan {
+ 		/* Fan: ADDA AD045HB-G73 40mm 6000rpm@5v */
+ 		compatible = "gpio-fan";
+ 		pinctrl-0 = <&pmx_fan_high_speed &pmx_fan_low_speed>;
+@@ -187,33 +187,18 @@
+ 
+ 	partition@0 {
+ 		label = "u-boot";
+-		reg = <0x0000000 0x100000>;
++		reg = <0x0000000 0x0e0000>;
+ 		read-only;
+ 	};
+ 
+-	partition@100000 {
+-		label = "uImage";
+-		reg = <0x0100000 0x500000>;
+-	};
+-
+-	partition@600000 {
+-		label = "ramdisk";
+-		reg = <0x0600000 0x500000>;
+-	};
+-
+-	partition@b00000 {
+-		label = "image";
+-		reg = <0x0b00000 0x6600000>;
+-	};
+-
+-	partition@7100000 {
+-		label = "mini firmware";
+-		reg = <0x7100000 0xa00000>;
++	partition@e0000 {
++		label = "u-boot-env";
++		reg = <0x00e0000 0x020000>;
+ 	};
+ 
+-	partition@7b00000 {
+-		label = "config";
+-		reg = <0x7b00000 0x500000>;
++	partition@100000 {
++		label = "ubi";
++		reg = <0x0100000 0x7f00000>;
+ 	};
+ };
+ 


### PR DESCRIPTION
The D-Link DNS-325 A1 is NAS with 2x HDD (3.5 inch) bays, 1x 10/100/1000Base-T port and 1x USB 2.0 port

Device specification:

    SoC: Marvell 88F6281-A1 1.2 GHz
    RAM: 256 MB (2xSEC K4T1G084QF-HCF7:128Mx8 @400 CL6)
    Flash: 128 MB (SAMSUNG 946 K9F1G08U0B PCB0)
    SATA: 2x internal SATA II drives
    Ethernet: 1x Gigabit (Marvell 88E1116R-NNC1)
    LED: 7x (white: Power, white/red: Right SATA Activity, USB Activity, Left SATA Activity)
    Key: 3x (Power, Reset, USB Copy/Unmount)
    Serial: 5 pin header (RXD,GAP,3.3V,GND,TXD), (115200,8,N,1), 3.3V TTL
    USB ports: 1x USB 2.0

Flash instruction:

NOTE: this process uses a serial connection. It will upgrade the bootloader and reset the bootloader environment variables

USB flash stick setup

    Format to FAT32 without mbr
    Copy these files to USB flash stick: dlink_dns-325-a1-initramfs-uImage dlink_dns-325-a1-squashfs-factory.bin dlink_dns-325-a1-squashfs-sysupgrade.bin u-boot.kwb (from u-boot-dns325 directory)

NAS setup

    Connect LAN cable between router and NAS device
    Connetc USB flash stick to NAS device
    Connect serial to NAS device

Boot from new u-boot and install it

    $ kwboot -p -b u-boot.kwb -B115200 -t /dev/ttyUSB0
    Power on NAS
    After download copleted and booted NAS device with new u-boot stop in bootloader by pressing any key
    => usb start
    => fatload usb 0 0x1000000 /u-boot.kwb
    => nand erase.part u-boot
    => nand write 0x1000000 u-boot ${filesize}
    => reset

Update MAC address in u-boot env

    Stop in bootloader by pressing any key
    Get your MAC address from label on chassis
    => setenv ethaddr XX:XX:XX:XX:XX:XX
    => saveenv

Install OpenWrt by flashing factory image from u-boot

    => usb start
    => fatload usb 0 0x1000000 /dlink_dns-325-a1-squashfs-factory.bin
    => nand erase.part ubi
    => nand write 0x1000000 ubi ${filesize}
    => reset

Based on https://github.com/openwrt/openwrt/pull/9296

Signed-off-by: Konstantin Meshkov <skyline@mail.ru>