### PR TITLE
arm-trusted-firmware-tools: update to version 2.12

### DIFF
--- a/package/boot/arm-trusted-firmware-tools/Makefile
+++ b/package/boot/arm-trusted-firmware-tools/Makefile
@@ -8,9 +8,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=arm-trusted-firmware-tools
-PKG_VERSION:=2.9
+PKG_VERSION:=2.12
 PKG_RELEASE:=1
-PKG_HASH:=76a66a1de0c01aeb83dfc7b72b51173fe62c6e51d6fca17cc562393117bed08b
+PKG_HASH:=b4c047493cac1152203e1ba121ae57267e4899b7bf56eb365e22a933342d31c9
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 PKG_HOST_ONLY:=1
@@ -33,7 +33,8 @@ define Host/Compile
 	$(MAKE) -C \
 		$(HOST_BUILD_DIR)/tools/fiptool \
 		CPPFLAGS="$(HOST_CFLAGS)" \
-		LDFLAGS="$(HOST_LDFLAGS)"
+		LDFLAGS="$(HOST_LDFLAGS)" \
+		OPENSSL_DIR="$(STAGING_DIR_HOST)"
 endef
 
 define Host/Install

--- a/package/boot/arm-trusted-firmware-tools/patches/001-respect-LDFLAGS.patch
+++ b/package/boot/arm-trusted-firmware-tools/patches/001-respect-LDFLAGS.patch
@@ -1,11 +1,11 @@
 --- a/tools/fiptool/Makefile
 +++ b/tools/fiptool/Makefile
-@@ -38,7 +38,7 @@
+@@ -74,7 +74,7 @@ all: --openssl ${PROJECT}
  
  ${PROJECT}: ${OBJECTS} Makefile
- 	@echo "  HOSTLD  $@"
--	${Q}${HOSTCC} ${OBJECTS} -o $@ ${LDLIBS}
-+	${Q}${HOSTCC} ${OBJECTS} -o $@ ${LDLIBS} $(LDFLAGS)
- 	@${ECHO_BLANK_LINE}
- 	@echo "Built $@ successfully"
- 	@${ECHO_BLANK_LINE}
+ 	$(s)echo "  HOSTLD  $@"
+-	$(q)$(host-cc) ${OBJECTS} -o $@ $(LDOPTS)
++	$(q)$(host-cc) ${OBJECTS} -o $@ $(LDOPTS) $(LDFLAGS)
+ 	$(s)echo
+ 	$(s)echo "Built $@ successfully"
+ 	$(s)echo

--- a/package/boot/arm-trusted-firmware-tools/patches/002-darwin_compile.patch
+++ b/package/boot/arm-trusted-firmware-tools/patches/002-darwin_compile.patch
@@ -1,15 +1,6 @@
 --- a/tools/fiptool/fiptool.c
 +++ b/tools/fiptool/fiptool.c
-@@ -3,7 +3,7 @@
-  *
-  * SPDX-License-Identifier: BSD-3-Clause
-  */
--
-+#define _DARWIN_C_SOURCE
- #ifndef _MSC_VER
- #include <sys/mount.h>
- #endif
-@@ -18,6 +18,9 @@
+@@ -19,6 +19,9 @@
  #include <stdio.h>
  #include <stdlib.h>
  #include <string.h>
@@ -19,3 +10,13 @@
  
  #include "fiptool.h"
  #include "tbbr_config.h"
+--- a/tools/fiptool/fiptool_platform.h
++++ b/tools/fiptool/fiptool_platform.h
+@@ -12,6 +12,7 @@
+ #ifndef FIPTOOL_PLATFORM_H
+ #define FIPTOOL_PLATFORM_H
+ 
++#define _DARWIN_C_SOURCE
+ #ifndef _MSC_VER
+ 
+ /* Not Visual Studio, so include Posix Headers. */


### PR DESCRIPTION
Upstream changes:
 ARM-software/arm-trusted-firmware@3789c3c00 build: determine toolchain tools dynamically
 ARM-software/arm-trusted-firmware@ccbfd01d9 fix(tools): update the fiptool and certtool to fix POSIX build
 ARM-software/arm-trusted-firmware@7c4e1eea6 build: unify verbosity handling
 ARM-software/arm-trusted-firmware@10327628c Merge "feat(stm32mp2): add ddr-fw parameter for fiptool" into integration
 ARM-software/arm-trusted-firmware@a11230ad0 refactor(fiptool): change all occurrences of RSS to RSE
 ARM-software/arm-trusted-firmware@e494afc05 feat(stm32mp2): add ddr-fw parameter for fiptool
 ARM-software/arm-trusted-firmware@ffb774212 build: use new toolchain variables for tools
 ARM-software/arm-trusted-firmware@cc277de81 build: refactor toolchain detection
 ARM-software/arm-trusted-firmware@503cf9927 refactor(juno): move plat_def_uuid_config to fiptool
 ARM-software/arm-trusted-firmware@4d4fec281 feat(fiptool): add ability to build statically
 ARM-software/arm-trusted-firmware@352366ede refactor(ethos-n): move build flags to ethosn_npu.mk
 ARM-software/arm-trusted-firmware@aa57ce632 build(tools): avoid unnecessary link
 ARM-software/arm-trusted-firmware@d4affdce8 Merge "fix(stm32mp1): add void entry in plat_def_toc_entries" into integration
 ARM-software/arm-trusted-firmware@570a23099 fix(fiptool): move juno plat_fiptool.mk
 ARM-software/arm-trusted-firmware@8214ecdab fix(stm32mp1): add void entry in plat_def_toc_entries
