### PR TITLE
wireless-regdb: Permit 320 MHz bandwidth in 6 GHz band in ETSI/CEPT

### DIFF
--- a/package/firmware/wireless-regdb/patches/600-allow-6GHz-ETSI-CEPT.patch
+++ b/package/firmware/wireless-regdb/patches/600-allow-6GHz-ETSI-CEPT.patch
@@ -1,0 +1,274 @@
+diff --git a/db.txt b/db.txt
+index e282e3b..2badb01 100644
+--- a/db.txt
++++ b/db.txt
+@@ -125,7 +125,7 @@ country AT: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -225,7 +225,7 @@ country BE: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -276,7 +276,7 @@ country BG: DFS-ETSI
+ 	# I.43 of the List, BDS EN 300 440-2, BDS EN 300 440-1
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# WiFi 6E
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	# II.H03 of the List, BDS EN 302 567-2
+ 	(57000 - 66000 @ 2160), (40)
+@@ -396,7 +396,7 @@ country CH: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# https://www.ofcomnet.ch/api/rir/1010/11
+-	(5945 - 6425 @ 160), (200 mW), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (200 mW), NO-OUTDOOR, wmmrule=ETSI
+ 	# https://www.ofcomnet.ch/api/rir/1010/07
+ 	(57000 - 71000 @ 2160), (40)
+ 
+@@ -487,7 +487,7 @@ country CY: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -507,7 +507,7 @@ country CZ: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -551,7 +551,7 @@ country DE: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# WiFi 6E
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -572,7 +572,7 @@ country DK: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -624,7 +624,7 @@ country EE: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -650,7 +650,7 @@ country ES: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# WiFi 6E
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -674,7 +674,7 @@ country FI: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -700,7 +700,7 @@ country FR: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# WiFi 6E low power indoor
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-6 (ETSI EN 302 567 v2.2.1)
+ 	(57000 - 71000 @ 2160), (40)
+ 
+@@ -778,7 +778,7 @@ country GR: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -847,7 +847,7 @@ country HR: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# WiFi 6E
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -875,7 +875,7 @@ country HU: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -901,7 +901,7 @@ country IE: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -967,7 +967,7 @@ country IT: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1153,7 +1153,7 @@ country LT: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1172,7 +1172,7 @@ country LU: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1191,7 +1191,7 @@ country LV: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1333,7 +1333,7 @@ country MT: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1424,7 +1424,7 @@ country NL: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# WiFi 6E
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1444,7 +1444,7 @@ country NO: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# WiFi 6E
+-	(5945 - 6425 @ 160), (200 mW), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (200 mW), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 71000 @ 2160), (40)
+ 
+@@ -1549,7 +1549,7 @@ country PL: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1581,7 +1581,7 @@ country PT: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1631,7 +1631,7 @@ country RO: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1693,7 +1693,7 @@ country SE: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1738,7 +1738,7 @@ country SI: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1759,7 +1759,7 @@ country SK: DFS-ETSI
+ 	# short range devices (ETSI EN 300 440-1)
+ 	(5725 - 5875 @ 80), (25 mW)
+ 	# 6 GHz band
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4 (ETSI EN 302 567)
+ 	(57000 - 66000 @ 2160), (40)
+ 
+@@ -1847,7 +1847,7 @@ country TR: DFS-ETSI
+ 	(5150 - 5250 @ 80), (23), NO-OUTDOOR, AUTO-BW, wmmrule=ETSI
+ 	(5250 - 5330 @ 80), (20), DFS, NO-OUTDOOR, AUTO-BW, wmmrule=ETSI
+ 	(5470 - 5725 @ 160), (27), DFS, wmmrule=ETSI
+-	(5945 - 6425 @ 160), (23), NO-OUTDOOR, wmmrule=ETSI
++	(5945 - 6425 @ 320), (23), NO-OUTDOOR, wmmrule=ETSI
+ 	# 60 GHz band channels 1-4, ref: Etsi En 302 567
+ 	(57000 - 66000 @ 2160), (40)
+ 


### PR DESCRIPTION
Patch taken from https://patchwork.kernel.org/project/linux-wireless/patch/20250125011210.56371-1-rj@quartiq.de/ this fixes a number of issues for users in EU that want to use 802.11be on 320MHz band.

This increases the allowed bandwidth from 160 to 320 MHz for the 5945-6425 MHz band to support 802.11be (Wi-Fi 7) EHT-320 for the ETSI/CEPT harmonized countries (EU + CH/LI/NO and TR).

Previously the bandwidth limit was set to 160 MHz to match 802.11ax (including the 6 GHz extension called Wi-Fi 6e). This limit is not supported by the current regulatory documents and should be relaxed to 320 MHz.

The 802.11be (Wi-Fi 7) standard defines EHT-OFDMA for a 320 MHz bandwidth. Devices (both AP and STA) supporting and using this are widely available now. The "6 GHz" band starting at 5945 MHz is the prime target for these wide channels. In the ETSI/CEPT harmonized countries the 5945-6425 MHz range has been allocated to WLAN. It can contain one 320 MHz channel centered at channel 31 (6105 MHz) and one overlapping channel at centered at 63 (6265 MHz).

Note that the supporting documents quoted currently do not have an upper bandwidth limit:

EU: https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32021D1067&from=EN
    and https://docdb.cept.org/download/4577

Adoption by e.g.
DE: https://www.bundesnetzagentur.de/SharedDocs/Downloads/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Frequenzen/Allgemeinzuteilungen/MobilfunkDectWlanCBFunk/vfg552021WLAN6GHz.pdf

CH and LI: https://www.ofcomnet.ch/api/rir/1010/11 (note the explicit empty bandwidth limit)
NO: https://lovdata.no/dokument/SF/forskrift/2012-01-19-77
TR: https://www.btk.gov.tr/uploads/pages/ftm-teknik-olcutler-ek-5.pdf

Note also that the EC mandate to the CEPT to investigate the upper 6425-7125 MHz band for future use explicitly confirms that there is now (2024-12) one non-overlapping 320 MHz channel for 802.11be available in the existing "mid-band" (i.e. 2.4, 5, and 6 GHz) allocations: https://cept.org/files/6813/Mandate%20to%20CEPT%20upper%206%20GHz%20band.pdf (page 3).

The 160 MHz limits for the 5 GHz and 2.4 GHz bands can remain since there is no possible configuration for a 320 MHz channel there.

