### PR TITLE
mediatek: add work-around for ASUS bootloader MTD behavior

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-asus-rt-ax59u.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-rt-ax59u.dts
@@ -210,7 +210,7 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		compatible = "spi-nand";
+		compatible = "u-boot-dont-touch-spi-nand";
 		reg = <0>;
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -224,7 +224,7 @@
 		 * Device Tree and by that also deletes all additional properties
 		 * needed for UBI and NVMEM-on-UBI.
 		 * Prevent this from happening by tricking the loader to delete and
-		 * replace a bait node instead.
+		 * replace a bait node instead (works with older bootloaders).
 		 */
 		partitions: dummy {
 			compatible = "u-boot-dummy-partitions";

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
@@ -217,7 +217,7 @@
 	status = "okay";
 
 	spi_nand_flash: flash@0 {
-		compatible = "spi-nand";
+		compatible = "u-boot-dont-touch-spi-nand";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		reg = <0>;
@@ -231,7 +231,7 @@
 		 * Device Tree and by that also deletes all additional properties
 		 * needed for UBI and NVMEM-on-UBI.
 		 * Prevent this from happening by tricking the loader to delete and
-		 * replace a bait node instead.
+		 * replace a bait node instead (works with older bootloaders).
 		 */
 		partitions: dummy {
 			compatible = "u-boot-dummy-partitions";

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -231,7 +231,7 @@
 	status = "okay";
 
 	spi_nand_flash: flash@0 {
-		compatible = "spi-nand";
+		compatible = "u-boot-dont-touch-spi-nand";
 		reg = <0>;
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -245,7 +245,7 @@
 		 * Device Tree and by that also deletes all additional properties
 		 * needed for UBI and NVMEM-on-UBI.
 		 * Prevent this from happening by tricking the loader to delete and
-		 * replace a bait node instead.
+		 * replace a bait node instead (works with older bootloaders).
 		 */
 		partitions: dummy {
 			compatible = "u-boot-dummy-partitions";

--- a/target/linux/mediatek/patches-6.6/960-asus-hack-u-boot-ignore-mtdparts.patch
+++ b/target/linux/mediatek/patches-6.6/960-asus-hack-u-boot-ignore-mtdparts.patch
@@ -1,0 +1,47 @@
+From 30a04cf5b6ffa1249df72ccd98cef05f37890f89 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Thu, 6 Feb 2025 05:07:20 +0000
+Subject: [PATCH] mtd: spinand: add work-around to prevent bootloader wiping
+ mtdparts
+
+ASUS makes use of U-Boot's fdt_fixup_mtdparts() function which applies
+the partitions defined in U-Boot's mtdparts and mtdids environment
+variables to the devicetree passed over to Linux.
+
+The undesired side-effect is that in this way also all additional
+properties and child nodes get wiped, preventing NVMEM cells to be
+defined for MTD partitions or UBI volumes.
+
+To work-around this issue, add an additional compatible string
+'u-boot-dont-touch-spi-nand' which can be used instead of 'spi-nand' in
+case the replacement of the MTD partitions by U-Boot should be skipped
+alltogether.
+
+In practise this is mostly relevant for SPI-NAND which anyway comes only
+with two partitions nowadays: 'Bootloader' and 'UBI_DEV'. Hence this
+work-around is applicable for SPI-NAND only. Similar work-arounds for
+other MTD devices can be created as well should they actually be needed.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ drivers/mtd/nand/spi/core.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -1441,6 +1441,7 @@ static int spinand_remove(struct spi_mem
+ 
+ static const struct spi_device_id spinand_ids[] = {
+ 	{ .name = "spi-nand" },
++	{ .name = "u-boot-dont-touch-spi-nand" },
+ 	{ /* sentinel */ },
+ };
+ MODULE_DEVICE_TABLE(spi, spinand_ids);
+@@ -1448,6 +1449,7 @@ MODULE_DEVICE_TABLE(spi, spinand_ids);
+ #ifdef CONFIG_OF
+ static const struct of_device_id spinand_of_ids[] = {
+ 	{ .compatible = "spi-nand" },
++	{ .compatible = "u-boot-dont-touch-spi-nand" },
+ 	{ /* sentinel */ },
+ };
+ MODULE_DEVICE_TABLE(of, spinand_of_ids);


### PR DESCRIPTION
ASUS makes use of [U-Boot's fdt_fixup_mtdparts() function](https://github.com/u-boot/u-boot/blob/1cfdac985298c65480bd2517ac4d6efb9337e89a/boot/fdt_support.c#L1066) which applies the partitions defined in U-Boot's mtdparts and mtdids environment variables to the devicetree passed over to Linux.

The undesired side-effect is that in this way also all additional properties and child nodes get wiped, preventing NVMEM cells to be defined for MTD partitions or UBI volumes.

To work-around this issue, add an additional compatible string 'u-boot-dont-touch-spi-nand' which can be used instead of 'spi-nand' in case the replacement of the MTD partitions by U-Boot should be skipped alltogether.

In practise this is mostly relevant for SPI-NAND which anyway comes only with two partitions nowadays: 'Bootloader' and 'UBI_DEV'. Hence this work-around is applicable for SPI-NAND only. Similar work-arounds for other MTD devices can be created as well should they actually be needed.

Apply "u-boot-dont-touch-spi-nand" to ASUS RT-AX59U, ASUS TUF-AX4200 as well as ASUS TUF-AX6000 routers to prevent U-Boot from wiping MTD child nodes from DT.