### PR TITLE
ath79: mikrotik: fix reference clock of Routerboard 911G

### DIFF
--- a/target/linux/ath79/dts/ar9342_mikrotik_routerboard-911g-xhpnd.dts
+++ b/target/linux/ath79/dts/ar9342_mikrotik_routerboard-911g-xhpnd.dts
@@ -9,3 +9,7 @@
 	compatible = "mikrotik,routerboard-911g-xhpnd", "qca,ar9342";
 	model = "MikroTik RouterBOARD 911G-(2,5)HPnD";
 };
+
+&ref {
+	clock-frequency = <25000000>;
+};

--- a/target/linux/ath79/dts/ar9342_mikrotik_routerboard-911g.dtsi
+++ b/target/linux/ath79/dts/ar9342_mikrotik_routerboard-911g.dtsi
@@ -146,10 +146,6 @@
 	};
 };
 
-&ref {
-	clock-frequency = <40000000>;
-};
-
 &spi {
 	status = "okay";
 

--- a/target/linux/ath79/dts/ar9342_mikrotik_routerboard-912uag-2hpnd.dts
+++ b/target/linux/ath79/dts/ar9342_mikrotik_routerboard-912uag-2hpnd.dts
@@ -10,6 +10,10 @@
 	model = "MikroTik RouterBOARD 912UAG-(2,5)HPnD";
 };
 
+&ref {
+	clock-frequency = <40000000>;
+};
+
 &pcie {
 	status = "okay";
 };


### PR DESCRIPTION
When support for Routerboard 911G was introduced, Routerboad 912UAG device tree was used as a base, and the common part. This led to use of 40MHz as the reference clock frequency for both [1], while RB911G uses 25MHz crystal on the board, causing heavy system clock drift.

Split the definition, and set the reference clock frequency for RB911G back to 25MHz.

Fixes: bcc44b1212b2 ("ath79: support for MikroTik RouterBOARD 911G-(2,5)HPnD")
[1] a716ac556497 ("ath79: fix reference clock for RouterBoard 912UAG")

Closes #17941 