### PR TITLE
ramips: fixes for Keenetic KN-1613,1711,1713,1910

### DIFF
--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1711.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1711.dts
@@ -45,14 +45,14 @@
 			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
 		};
 
-		wifi2 {
+		fn {
 			function = LED_FUNCTION_WLAN_2GHZ;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 
-		wifi5 {
+		wifi {
 			function = LED_FUNCTION_WLAN_5GHZ;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
@@ -95,7 +95,7 @@
 			partition@0 {
 				compatible = "denx,uimage";
 				label = "firmware";
-				reg = <0x0 0x1CC0000>;
+				reg = <0x0 0x1cc0000>;
 			};
 		};
 	};
@@ -203,7 +203,7 @@
 				reg = <0x1050000 0xe60000>;
 			};
 			
-			partition@1EB0000 {
+			partition@1eb0000 {
 				label = "Config_2";
 				reg = <0x1eb0000 0x40000>;
 				read-only;

--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1713.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1713.dts
@@ -45,14 +45,14 @@
 			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
 		};
 
-		wifi2 {
+		fn {
 			function = LED_FUNCTION_WLAN_2GHZ;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 
-		wifi5 {
+		wifi {
 			function = LED_FUNCTION_WLAN_5GHZ;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1804,7 +1804,7 @@ define Device/keenetic_kn-1910
   $(Device/uimage-lzma-loader)
   BLOCKSIZE := 128k
   PAGESIZE := 2048
-  IMAGE_SIZE := 20368588
+  IMAGE_SIZE := 29097984
   DEVICE_VENDOR := Keenetic
   DEVICE_MODEL := KN-1910
   DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -356,7 +356,7 @@ endef
 TARGET_DEVICES += jotale_js76x8-32m
 
 define Device/keenetic_kn-1613
-  IMAGE_SIZE := 31488k
+  IMAGE_SIZE := 15073280
   DEVICE_VENDOR := Keenetic
   DEVICE_MODEL := KN-1613
   DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
@@ -368,7 +368,7 @@ TARGET_DEVICES += keenetic_kn-1613
 
 define Device/keenetic_kn-1711
   BLOCKSIZE := 64k
-  IMAGE_SIZE := 10551296
+  IMAGE_SIZE := 15073280
   DEVICE_VENDOR := Keenetic
   DEVICE_MODEL := KN-1711
   DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap kmod-usb2
@@ -380,7 +380,7 @@ TARGET_DEVICES += keenetic_kn-1711
 
 define Device/keenetic_kn-1713
   BLOCKSIZE := 64k
-  IMAGE_SIZE := 10551296
+  IMAGE_SIZE := 15073280
   DEVICE_VENDOR := Keenetic
   DEVICE_MODEL := KN-1713
   DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap kmod-usb2

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -126,6 +126,11 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary Factory 0x4)" > /sys${DEVPATH}/macaddress
 		;;
+	keenetic,kn-1910)
+		lan_mac_addr="$(mtd_get_mac_binary RF-EEPROM 0x4)"
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_add $lan_mac_addr 2 > /sys${DEVPATH}/macaddress
+		;;
 	keenetic,kn-3510)
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary rf-eeprom 0x4)" > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
Fixed the 5G mac address on KN-1910, rolled back the image size to stock (there are no errors with loading large images in version 24.10.0), minor spelling errors.

Signed-off-by: Anton Yu. Ivanusev <ivanusevanton@yandex.ru>
