### PR TITLE
mediatek: filogic: upstream LEDs control on 2.5G ports on EX5601

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -214,13 +214,33 @@
 		phy5: phy@5 {
 			compatible = "ethernet-phy-ieee802.3-c45";
 			reg = <5>;
-			mxl,led-config = <0x03f0 0x0 0x0 0x0>;
+
+			leds {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				led@0 {
+					reg = <0>;
+					color = <LED_COLOR_ID_GREEN>;
+					function = LED_FUNCTION_LAN;
+				};
+			};
 		};
 
 		phy6: phy@6 {
 			compatible = "ethernet-phy-ieee802.3-c45";
 			reg = <6>;
-			mxl,led-config = <0x00f0 0x0 0x0 0x0>;
+
+			leds {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				led@0 {
+					reg = <0>;
+					color = <LED_COLOR_ID_GREEN>;
+					function = LED_FUNCTION_WAN;
+				};
+			};
 		};
 
 		switch@1f {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -143,8 +143,10 @@ zbtlink,zbt-z8103ax)
 	;;
 zyxel,ex5601-t0-stock|\
 zyxel,ex5601-t0-ubootmod)
+	ucidef_set_led_netdev "lan1" "LAN1" "mdio-bus:05:green:lan" "lan1" "link tx rx"
+	ucidef_set_led_netdev "wan" "2.5G-WAN" "mdio-bus:06:green:wan" "eth1" "link_2500"
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link tx rx"
-	ucidef_set_led_netdev "wan" "WAN" "green:inet" "eth1" "link tx rx"
+	ucidef_set_led_netdev "internet" "INTERNET" "green:inet" "eth1" "link tx rx"
 	ucidef_set_led_netdev "wifi-24g" "WIFI-2.4G" "green:wifi24g" "phy0-ap0" "link tx rx"
 	ucidef_set_led_netdev "wifi-5g" "WIFI-5G" "green:wifi5g" "phy1-ap0" "link tx rx"
 	;;


### PR DESCRIPTION
This commit switches the control of the leds connected to the Maxlinear GPY211C PHY to an upstream solution. The behaviour of LED1 is the same as before. The behaviour of 2.5G-WAN LED has been changed. It is only active when a 2.5G link is detected, which matches the stock software. Additionally, the name of the WAN led has been changed to INTERNET.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
