### PR TITLE
generic: mtd: spinand: fix Foresee update_cache_variants initialization

### DIFF
--- a/package/boot/uboot-mediatek/patches/101-03-mtd-spinand-fix-support-for-FORESEE.patch
+++ b/package/boot/uboot-mediatek/patches/101-03-mtd-spinand-fix-support-for-FORESEE.patch
@@ -1,0 +1,19 @@
+Force update_cache_variants to use reset for Foresee NAND with bad blocks
+
+Tested on Xiaomi AX3000T + F35SQA001G with bad blocks and without bad blocks
+
+Signed-off-by: Dim Fish <dimfish@gmail.com>
+
+--- a/drivers/mtd/nand/spi/foresee.c
++++ b/drivers/mtd/nand/spi/foresee.c
+@@ -22,8 +22,8 @@ static SPINAND_OP_VARIANTS(write_cache_v
+ 		SPINAND_PROG_LOAD(true, 0, NULL, 0));
+ 
+ static SPINAND_OP_VARIANTS(update_cache_variants,
+-		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
+-		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++		SPINAND_PROG_LOAD_X4(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD(true, 0, NULL, 0));
+ 
+ static int f35sqa002g_ooblayout_ecc(struct mtd_info *mtd, int section,
+ 				    struct mtd_oob_region *region)

--- a/target/linux/mediatek/patches-6.12/411-mtd-spinand-fix-support-for-FORESEE.patch
+++ b/target/linux/mediatek/patches-6.12/411-mtd-spinand-fix-support-for-FORESEE.patch
@@ -1,0 +1,19 @@
+Force update_cache_variants to use reset for Foresee NAND with bad blocks
+
+Tested on Xiaomi AX3000T + F35SQA001G with bad blocks and without bad blocks
+
+Signed-off-by: Dim Fish <dimfish@gmail.com>
+
+--- a/drivers/mtd/nand/spi/foresee.c
++++ b/drivers/mtd/nand/spi/foresee.c
+@@ -22,8 +22,8 @@ static SPINAND_OP_VARIANTS(write_cache_v
+ 		SPINAND_PROG_LOAD(true, 0, NULL, 0));
+ 
+ static SPINAND_OP_VARIANTS(update_cache_variants,
+-		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
+-		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++		SPINAND_PROG_LOAD_X4(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD(true, 0, NULL, 0));
+ 
+ static int f35sqa002g_ooblayout_ecc(struct mtd_info *mtd, int section,
+ 				    struct mtd_oob_region *region)

--- a/target/linux/mediatek/patches-6.6/411-mtd-spinand-fix-support-for-FORESEE.patch
+++ b/target/linux/mediatek/patches-6.6/411-mtd-spinand-fix-support-for-FORESEE.patch
@@ -1,0 +1,19 @@
+Force update_cache_variants to use reset for Foresee NAND with bad blocks
+
+Tested on Xiaomi AX3000T + F35SQA001G with bad blocks and without bad blocks
+
+Signed-off-by: Dim Fish <dimfish@gmail.com>
+
+--- a/drivers/mtd/nand/spi/foresee.c
++++ b/drivers/mtd/nand/spi/foresee.c
+@@ -22,8 +22,8 @@ static SPINAND_OP_VARIANTS(write_cache_v
+ 		SPINAND_PROG_LOAD(true, 0, NULL, 0));
+ 
+ static SPINAND_OP_VARIANTS(update_cache_variants,
+-		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
+-		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++		SPINAND_PROG_LOAD_X4(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD(true, 0, NULL, 0));
+ 
+ static int f35sqa002g_ooblayout_ecc(struct mtd_info *mtd, int section,
+ 				    struct mtd_oob_region *region)


### PR DESCRIPTION
Fix update_cache_variants initialization for Foresee NAND with bad blocks

Tested on Xiaomi AX3000T + F35SQA001G with bad blocks and without bad blocks

See issue https://github.com/openwrt/openwrt/issues/17962