### PR TITLE
imx: fix venice sysupgrade

### DIFF
--- a/target/linux/imx/cortexa53/base-files/lib/upgrade/platform.sh
+++ b/target/linux/imx/cortexa53/base-files/lib/upgrade/platform.sh
@@ -12,6 +12,7 @@ platform_check_image() {
 	local board=$(board_name)
 
 	case "$board" in
+	gateworks,imx8m*|\
 	gw,imx8m*)
 		return 0
 		;;
@@ -25,6 +26,7 @@ platform_do_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	gateworks,imx8m*|\
 	gw,imx8m*)
 		export_bootdevice && export_partdevice diskdev 0 || {
 			echo "Unable to find root device."
@@ -41,6 +43,7 @@ platform_copy_config() {
 	local partdev
 
 	case "$board" in
+	gateworks,imx8m*|\
 	gw,imx8m*)
 		export_partdevice partdev 1 && {
 			v "Storing $UPGRADE_BACKUP on /dev/$partdev..."

--- a/target/linux/imx/image/cortexa53.mk
+++ b/target/linux/imx/image/cortexa53.mk
@@ -46,6 +46,21 @@ define Device/gateworks_venice
   FILESYSTEMS := squashfs ext4
   DEVICE_VENDOR := Gateworks
   DEVICE_MODEL := i.MX8M Venice
+  SUPPORTED_DEVICES := \
+	gw,imx8mm-gw71xx-0x \
+	gw,imx8mm-gw72xx-0x \
+	gw,imx8mp-gw72xx-2x \
+	gw,imx8mm-gw73xx-0x \
+	gw,imx8mp-gw73xx-2x \
+	gw,imx8mm-gw7901 \
+	gw,imx8mm-gw7902 \
+	gw,imx8mn-gw7902 \
+	gw,imx8mm-gw7903 \
+	gateworks,imx8mp-gw71xx-2x \
+	gateworks,imx8mp-gw74xx \
+	gateworks,imx8mm-gw7904 \
+	gateworks,imx8mm-gw7905-0x \
+	gateworks,imx8mp-gw7905-2x
   BOOT_SCRIPT := gateworks_venice
   PARTITION_OFFSET := 16M
   DEVICE_DTS := $(basename $(notdir $(wildcard $(DTS_DIR)/freescale/imx8m*-venice*.dts)))


### PR DESCRIPTION
When upstream device-tree maintainers required new boards to use the vendor name of 'gateworks' instead of 'gw' this affected dt compatible board names for all new boards.

Add the 'gateworks,imx8m*' pattern to the checks in platform.sh required for sysupgrade to be board compatible.

Additionally set SUPPORTED_DEVICES so that the sysupgrade image is compatble with the various venice boards.
