### PR TITLE
ramips: Add support for Mercusys MR1800X as alt name of MR70X

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1992,6 +1992,8 @@ define Device/mercusys_mr70x-v1
   $(Device/tplink-safeloader)
   DEVICE_VENDOR := MERCUSYS
   DEVICE_MODEL := MR70X
+  DEVICE_ALT0_VENDOR := MERCUSYS
+  DEVICE_ALT0_MODEL := MR1800X
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
   TPLINK_BOARD_ID := MR70X


### PR DESCRIPTION
Both share the same OEM firmware but differ in product_name for safeloader product_name:MR1800X,product_ver:1.0.0,special_id:45550000

This change depend on [PR42](https://github.com/openwrt/firmware-utils/pull/42)

referenced firmwares:
MR70Xv1_eu_jp_us_br_eg-up-ver1-1-0-P1[20240311-rel52779]_2024-03-11_14.43.29.bin
MR1800Xv1_eu-up-ver1-1-0-P1[20240311-rel52779]_2024-03-11_14.43.29.bin