### PR TITLE
nss-dp: switchdev: apply flag dependency directives

### DIFF
--- a/package/kernel/qca-nss-dp/patches/0009-nss-dp-switchdev-fix-FDB-roaming.patch
+++ b/package/kernel/qca-nss-dp/patches/0009-nss-dp-switchdev-fix-FDB-roaming.patch
@@ -22,20 +22,22 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/nss_dp_switchdev.c
 +++ b/nss_dp_switchdev.c
-@@ -29,6 +29,8 @@
+@@ -29,6 +29,10 @@
  #include "nss_dp_dev.h"
  #include "fal/fal_stp.h"
  #include "fal/fal_ctrlpkt.h"
++#if defined(NSS_DP_PPE_SUPPORT)
 +#include "fal/fal_fdb.h"
 +#include "ref/ref_vsi.h"
++#endif
  
  #define NSS_DP_SWITCH_ID		0
  #define NSS_DP_SW_ETHTYPE_PID		0 /* PPE ethtype profile ID for slow protocols */
-@@ -534,7 +536,76 @@ static struct notifier_block *nss_dp_sw_
+@@ -534,8 +538,82 @@ static struct notifier_block *nss_dp_sw_
  
  #else
  
--static struct notifier_block *nss_dp_sw_ev_nb;
++#if defined(NSS_DP_PPE_SUPPORT)
 +/*
 + * nss_dp_switchdev_fdb_del_event
 + *
@@ -106,6 +108,11 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +};
 +
 +static struct notifier_block *nss_dp_sw_ev_nb = &nss_dp_switchdev_notifier_nb;
++
++#else
+ static struct notifier_block *nss_dp_sw_ev_nb;
  
++#endif
  /*
   * nss_dp_bridge_attr_set()
+  *	Sets bridge attributes


### PR DESCRIPTION
The FDB roaming issues were observed on ipq807x and ipq60xx boards. The fix depends on API exposed only when NSS_DP_PPE_SUPPORT is enabled. However, this flag applies to above mentioned platforms only and is causing the logs to be flooded on other QCA platforms, including ipq50xx, with:

```
[   34.893418] nss-dp 39c00000.dp1 lan: cannot get VSI ID for port 1
[   34.898370] nss-dp 39c00000.dp1 lan: cannot get VSI ID for port 1
[   34.904598] nss-dp 39c00000.dp1 lan: cannot get VSI ID for port 1
[   34.910661] nss-dp 39c00000.dp1 lan: cannot get VSI ID for port 1
```

So let's apply a dependency on the NSS_DP_PPE_SUPPORT flag and contain the patch code for ipq807x and ipq60xx within conditional directives.

Tested on: Linksys SPNMX56