### PR TITLE
mediatek: filogic: fix sysupgrade for ex5601-t0-stock

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1729,7 +1729,6 @@ define Device/zyxel_ex5601-t0-stock
   DEVICE_DTS := mt7986a-zyxel-ex5601-t0-stock
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-usb3
-  SUPPORTED_DEVICES := mediatek,mt7986a-rfb-snand
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 256k
   PAGESIZE := 4096


### PR DESCRIPTION
fix undesired red warning when upgrading in place ex5601-t0-stock model.
![Screenshot 2025-02-14 165200](https://github.com/user-attachments/assets/1435090d-ab3b-4356-8113-b7b8b75bcf87)
