### PR TITLE
mediatek: Xiaomi AX3000t: enable SPI calibration

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
@@ -315,6 +315,13 @@
 		compatible = "spi-nand";
 		reg = <0>;
 
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
 		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;


### PR DESCRIPTION
Xiaomi enabled SPI calibration in stock fw 1.0.84. Let's enable SPI calibration routines for this device in OpenWrt too.
