### PR TITLE
ipq40xx: Add support for Linksys MR6350

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/ipq40xx
@@ -63,6 +63,7 @@ linksys,ea6350v3)
 	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x20000" "0x20000"
 	;;
 linksys,ea8300|\
+linksys,mr6350|\
 linksys,mr8300)
 	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x40000" "0x20000"
 	;;

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -48,6 +48,7 @@ ALLWIFIBOARDS:= \
 	iodata_wn-dax3000gr \
 	linksys_homewrk \
 	linksys_mr5500 \
+	linksys_mr6350 \
 	linksys_mr7350 \
 	linksys_mr7500 \
 	linksys_mx2000 \
@@ -225,6 +226,7 @@ $(eval $(call generate-ipq-wifi-package,ignitenet_ss-w2-ac2600,Ignitenet SS-W2-A
 $(eval $(call generate-ipq-wifi-package,iodata_wn-dax3000gr,I-O DATA WN-DAX3000GR))
 $(eval $(call generate-ipq-wifi-package,linksys_homewrk,Linksys HomeWRK))
 $(eval $(call generate-ipq-wifi-package,linksys_mr5500,Linksys MR5500))
+$(eval $(call generate-ipq-wifi-package,linksys_mr6350,Linksys MR6350))
 $(eval $(call generate-ipq-wifi-package,linksys_mr7350,Linksys MR7350))
 $(eval $(call generate-ipq-wifi-package,linksys_mr7500,Linksys MR7500))
 $(eval $(call generate-ipq-wifi-package,linksys_mx2000,Linksys MX2000))

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -17,6 +17,7 @@ ipq40xx_setup_interfaces()
 	asus,rt-ac58u|\
 	linksys,ea6350v3|\
 	linksys,ea8300|\
+	linksys,mr6350|\
 	linksys,mr8300|\
 	mikrotik,hap-ac2|\
 	mikrotik,hap-ac3|\
@@ -221,6 +222,7 @@ ipq40xx_setup_macs()
 		;;
 	linksys,ea6350v3|\
 	linksys,ea8300|\
+	linksys,mr6350|\
 	linksys,mr8300)
 		wan_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -21,6 +21,7 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
 	linksys,ea8300|\
+	linksys,mr6350|\
 	linksys,mr8300)
 		caldata_extract "ART" 0x9000 0x2f20
 		# OEM assigns 4 sequential MACs
@@ -88,6 +89,7 @@ case "$FIRMWARE" in
 		ath10k_patch_mac $(mtd_get_mac_ascii CFG1 RADIOADDR0)
 		;;
 	linksys,ea8300|\
+	linksys,mr6350|\
 	linksys,mr8300)
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
@@ -179,6 +181,7 @@ case "$FIRMWARE" in
 		ath10k_patch_mac $(mtd_get_mac_ascii CFG1 RADIOADDR1)
 		;;
 	linksys,ea8300|\
+	linksys,mr6350|\
 	linksys,mr8300)
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 3)

--- a/target/linux/ipq40xx/base-files/etc/init.d/bootcount
+++ b/target/linux/ipq40xx/base-files/etc/init.d/bootcount
@@ -39,6 +39,7 @@ boot() {
 		;;
 	linksys,ea6350v3|\
 	linksys,ea8300|\
+	linksys,mr6350|\
 	linksys,mr8300|\
 	linksys,whw01|\
 	linksys,whw03v2)

--- a/target/linux/ipq40xx/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/ipq40xx/base-files/etc/uci-defaults/05_fix-compat-version
@@ -4,6 +4,7 @@ case "$(board_name)" in
 ezviz,cs-w3-wd1200g-eup|\
 linksys,ea6350v3|\
 linksys,ea8300|\
+linksys,mr6350|\
 linksys,mr8300)
 	uci set system.@system[0].compat_version="2.0"
 	uci commit system

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -20,6 +20,7 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address $(mtd_get_mac_ascii CFG1 ethaddr)
 		;;
 	linksys,ea8300|\
+	linksys,mr6350|\
 	linksys,mr8300)
 		base_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		ip link set dev lan1 address $(macaddr_add "$base_mac" 1)

--- a/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/linksys.sh
@@ -16,7 +16,7 @@ linksys_get_target_firmware() {
 			"${cur_boot_part}" "${mtd_ubi0}"
 	fi
 
-	# OEM U-Boot for EA6350v3, EA8300 and MR8300; bootcmd=
+	# OEM U-Boot for EA6350v3, EA8300, MR6350 and MR8300; bootcmd=
 	#  if test $auto_recovery = no;
 	#      then bootipq;
 	#  elif test $boot_part = 1;

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -169,6 +169,7 @@ platform_do_upgrade() {
 		;;
 	linksys,ea6350v3|\
 	linksys,ea8300|\
+	linksys,mr6350|\
 	linksys,mr8300|\
 	linksys,whw01|\
 	linksys,whw03v2)

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mr6350.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mr6350.dts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019-xx8300.dtsi"
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Linksys MR6350";
+	compatible = "linksys,mr6350", "qcom,ipq4019";
+
+	aliases {
+		led-boot = &led_blue;
+		led-failsafe = &led_red;
+		led-running = &led_green;
+		led-upgrade = &led_blue;
+		serial0 = &blsp1_uart1;
+	};
+
+	// Top panel LEDs, above Linksys logo
+	leds {
+		compatible = "gpio-leds";
+		
+		led_blue: led-blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 46 GPIO_ACTIVE_LOW>;
+		};
+
+		led_red: led-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 47 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		led_green: led-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 49 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
+	reset-post-delay-us = <5000>;
+};
+	
+&tlmm {
+	status = "okay";
+
+	mdio_pins: mdio_pinmux {
+		mdio {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mdc {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "linksys-mr6350";
+};
+
+&wifi1 {
+	status = "okay";
+	qcom,ath10k-calibration-variant = "linksys-mr6350";
+};
+
+&swport1 {
+	label = "wan";
+};
+
+&swport2 {
+	label = "lan1";
+};
+
+&swport3 {
+	label = "lan2";
+};
+
+&swport4 {
+	label = "lan3";
+};
+
+&swport5 {
+	label = "lan4";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -714,6 +714,23 @@ define Device/linksys_ea8300
 endef
 TARGET_DEVICES += linksys_ea8300
 
+define Device/linksys_mr6350
+	$(call Device/FitzImage)
+	$(call Device/kernel-size-6350-8300)
+	DEVICE_VENDOR := Linksys
+	DEVICE_MODEL := MR6350
+	SOC := qcom-ipq4019
+	KERNEL_SIZE := 5120k
+	IMAGE_SIZE := 84992k
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
+	IMAGES += factory.bin
+	IMAGE/factory.bin  := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | linksys-image type=MR6350
+	DEVICE_PACKAGES := ipq-wifi-linksys_mr6350 kmod-usb-ledtrig-usbport
+endef
+TARGET_DEVICES += linksys_mr6350
+
 define Device/linksys_mr8300
 	$(call Device/FitzImage)
 	$(call Device/kernel-size-6350-8300)


### PR DESCRIPTION
This pull request is based on
- the discussions in https://forum.openwrt.org/t/adding-openwrt-support-for-linksys-mr6350
- https://github.com/openwrt/openwrt/pull/11405 which added support for similar devices.
- https://github.com/openwrt/openwrt/pull/14098 which initally added support for this device.

Device Specs:
- IPQ4019
- Quad Core CPU
- 256 MB RAM
- 256 MB FLASH
- 4 LAN ports, 1 WAN port
- 2.4GHz (802.11n) and 5GHz (802.11c) wifi
- 3 LEDs (Red, blue, green) which are routed to one indicator at the top of the case
- 2 buttons (Reset, WPS)

Disassembling the device:
- There are 4 screws at the bottom of the device which must be removed
- Two are under the fron rubber feets
- Two are under the labels in the back (corner next to the rear rubber feets)

Serial interface:
- The serial interface is already populated on the device with a 6-pin header
- Pin 1 is next to the heatsink
- Pinout: 1: 3.3V, 2: TX, 3: RX, 4: unknown, 5: GND, 6: GND
- Settings: 115200, 8N1

Migrating to OpenWrt requires multiple steps:
- Load and boot the initramfs image
- Adapt U-Boot settings to support bigger kernels
- Flash the sysupgrade image

Load and boot initramfs:
- Connect serial interface
- Set up a TFTP server on IP 192.168.1.254
- Copy openwrt-ipq40xx-generic-linksys_mr6350-initramfs-zImage.itb to TFTP server
- Rename file to C0A80101.img
- Boot up the device and stop in U-Boot
- Run the following U-Boot commands after a link has been established: tftp bootm
- Initramfs image is started now.

Adapt U-Boot settings to support bigger kernels:
- Run "fw_printenv" in the initramfs image  after booting
- There should be an entry kernsize=300000 which indicates the maximum size for the kernel is 3MB
- Execute "fw_setenv kernsize 500000" to increase the max kernel size to 5MB
- Check that the change are applied with "fw_printenv"

Flash the sysupgrade image:
- Default sysupgrade routine either with a initramfs image containing LuCI or via command line.

Revert back to OEM firmware:
- Only tested with FW_MR6350_1.1.3.210129_prod.img
- Flash the OEM firmware via sysupgrade
- Forced update is required
