### PR TITLE
mt76: move mt798[16] wo firmware to the mt76 package

### DIFF
--- a/package/firmware/linux-firmware/mediatek.mk
+++ b/package/firmware/linux-firmware/mediatek.mk
@@ -78,25 +78,6 @@ define Package/mt7925bt-firmware/install
 endef
 $(eval $(call BuildPackage,mt7925bt-firmware))
 
-Package/mt7981-wo-firmware = $(call Package/firmware-default,MT7981 offload firmware,,LICENCE.mediatek)
-define Package/mt7981-wo-firmware/install
-	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/mediatek/mt7981_wo.bin \
-		$(1)/lib/firmware/mediatek
-endef
-$(eval $(call BuildPackage,mt7981-wo-firmware))
-
-Package/mt7986-wo-firmware = $(call Package/firmware-default,MT7986 offload firmware,,LICENCE.mediatek)
-define Package/mt7986-wo-firmware/install
-	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/mediatek/mt7986_wo_0.bin \
-		$(PKG_BUILD_DIR)/mediatek/mt7986_wo_1.bin \
-		$(1)/lib/firmware/mediatek
-endef
-$(eval $(call BuildPackage,mt7986-wo-firmware))
-
 Package/mt7988-2p5g-phy-firmware = $(call Package/firmware-default,MT7988 built-in 2.5G Ethernet PHY firmware,,LICENCE.mediatek)
 define Package/mt7988-2p5g-phy-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek/mt7988

--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -251,10 +251,22 @@ define KernelPackage/mt7981-firmware
   TITLE:=MediaTek MT7981 firmware
 endef
 
+define KernelPackage/mt7981-wo-firmware
+  $(KernelPackage/mt76-default)
+  DEPENDS:=@TARGET_mediatek_filogic
+  TITLE:=MT7981 offload firmware
+endef
+
 define KernelPackage/mt7986-firmware
   $(KernelPackage/mt76-default)
   DEPENDS:=@TARGET_mediatek_filogic
   TITLE:=MediaTek MT7986 firmware
+endef
+
+define KernelPackage/mt7986-wo-firmware
+  $(KernelPackage/mt76-default)
+  DEPENDS:=@TARGET_mediatek_filogic
+  TITLE:=MT7986 offload firmware
 endef
 
 define KernelPackage/mt7921-firmware
@@ -620,6 +632,13 @@ define KernelPackage/mt7981-firmware/install
 		$(1)/lib/firmware/mediatek
 endef
 
+define KernelPackage/mt7981-wo-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
+	cp \
+		$(PKG_BUILD_DIR)/firmware/mt7981_wo.bin \
+		$(1)/lib/firmware/mediatek
+endef
+
 define KernelPackage/mt7986-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
 	cp \
@@ -628,6 +647,14 @@ define KernelPackage/mt7986-firmware/install
 		$(PKG_BUILD_DIR)/firmware/mt7986_wm.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7986_rom_patch_mt7975.bin \
 		$(PKG_BUILD_DIR)/firmware/mt7986_rom_patch.bin \
+		$(1)/lib/firmware/mediatek
+endef
+
+define KernelPackage/mt7986-wo-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/mediatek
+	cp \
+		$(PKG_BUILD_DIR)/firmware/mt7986_wo_0.bin \
+		$(PKG_BUILD_DIR)/firmware/mt7986_wo_1.bin \
 		$(1)/lib/firmware/mediatek
 endef
 
@@ -745,7 +772,9 @@ $(eval $(call KernelPackage,mt7915-firmware))
 $(eval $(call KernelPackage,mt7915e))
 $(eval $(call KernelPackage,mt7916-firmware))
 $(eval $(call KernelPackage,mt7981-firmware))
+$(eval $(call KernelPackage,mt7981-wo-firmware))
 $(eval $(call KernelPackage,mt7986-firmware))
+$(eval $(call KernelPackage,mt7986-wo-firmware))
 $(eval $(call KernelPackage,mt7921-firmware))
 $(eval $(call KernelPackage,mt7922-firmware))
 $(eval $(call KernelPackage,mt7925-firmware))


### PR DESCRIPTION
Use the mt76 package as a source of wireless offload firmware files
for mt7981 and mt7986. Harmonize the wireless offload firmware 
with other firmware files.

mt7981 wa/wm/rom_patch  20240823
mt7981 wo&nbsp;&nbsp;&nbsp;&nbsp;20221208 -> 20240823

mt7986 wa/wm/rom_patch  20240823
mt7986 wo_0 20221012 -> 20240823
mt7986 wo_1 20221012 -> 20240823