### PR TITLE
ramips: mt7621: add support for Arcadyan WE410443

### DIFF
--- a/target/linux/ramips/dts/mt7621_arcadyan_we410443.dts
+++ b/target/linux/ramips/dts/mt7621_arcadyan_we410443.dts
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Arcadyan WE410443";
+	compatible = "arcadyan,we410443", "mediatek,mt7621-soc";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 41 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_green: green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "all";
+				reg = <0x0 0x2000000>;
+				read-only;
+			};
+
+			partition@1 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "fixed-partitions";
+				label = "firmware";
+				reg = <0x50000 0x1f60000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "kernel";
+					reg = <0x0 0x440000>;
+				};
+
+				partition@400000 {
+					label = "rootfs";
+					reg = <0x440000 0x1b20000>;
+				};
+			};
+
+			partition@1fb0000 {
+				label = "glbcfg";
+				reg = <0x1fb0000 0x10000>;
+				read-only;
+			};
+
+			partition@1fc0000 {
+				label = "config";
+				reg = <0x1fc0000 0x10000>;
+				read-only;
+			};
+
+			partition@1fd0000 {
+				label = "glbcfg2";
+				reg = <0x1fd0000 0x10000>;
+				read-only;
+			};
+
+			partition@1fe0000 {
+				label = "config2";
+				reg = <0x1fe0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "wdt", "sdhci";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&xhci {
+	status = "disabled";
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -314,6 +314,23 @@ define Device/ampedwireless_ally-00x19k
 endef
 TARGET_DEVICES += ampedwireless_ally-00x19k
 
+define Device/arcadyan_we410443
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := Arcadyan
+  DEVICE_MODEL := WE410443
+  IMAGE_SIZE := 32128k
+  KERNEL_SIZE := 4352k
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | \
+	uImage none | arcadyan-trx 0x746f435d
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | \
+	uImage none
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
+	append-rootfs | pad-rootfs | check-size | append-metadata
+  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+endef
+TARGET_DEVICES += arcadyan_we410443
+
 define Device/arcadyan_we420223-99
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -37,6 +37,7 @@ ramips_setup_interfaces()
 		ucidef_set_interface_lan "swp0 swp1"
 		;;
 	ampedwireless,ally-00x19k|\
+	arcadyan,we410443|\
 	asus,rp-ac56|\
 	asus,rp-ac87|\
 	dlink,dap-1620-b1|\
@@ -212,6 +213,10 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii hwconfig HW.LAN.MAC.Address)
 		wan_mac=$(mtd_get_mac_ascii hwconfig HW.WAN.MAC.Address)
 		label_mac=$lan_mac
+		;;
+	arcadyan,we410443)
+		label_mac=$(mtd_get_mac_ascii config mac)
+		lan_mac=$label_mac
 		;;
 	arcadyan,we420223-99)
 		label_mac=$(mtd_get_mac_ascii board_data mac)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -10,6 +10,13 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case "$board" in
+	arcadyan,we410443)
+		label_mac=$(mtd_get_mac_ascii config mac)
+		[ "$PHYNBR" = "0" ] && \
+			macaddr_add $label_mac 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && \
+			macaddr_add $label_mac 2 > /sys${DEVPATH}/macaddress
+		;;
 	arcadyan,we420223-99)
 		if [ "$PHYNBR" = "0" ]; then
 			mac24=$(macaddr_add "$(get_mac_label)" "0xf00001")


### PR DESCRIPTION
The Arcadyan WE410443 is a WiFi AC access point distributed by various ISPs under various names, including KPN SuperWifi and BT Whole Home Wi-Fi. It features one ethernet port, dual MT7615N radios and four internal antennas.

### Hardware:
- SoC: Mediatek MT7621AT
- Flash: 32 MB
- RAM: 128 MB
- Ethernet: 1x 10/100/1000 Mbps, built into the SoC
- WLAN: 2x MediaTek MT7615N
- Buttons: 1 Reset button, 1 WPS button
- LEDs: 1x Green, 1x Blue, 1x Red, all unmarked
- Power: 12 VDC, 1.5A barrel plug

### Installation:
The bootloader is locked with a password, so the image needs to be written directly to the SPI flash chip. To do this, you need to open up the case, remove the heatsink and connect the flash chip to a Raspberry Pi. Use the following connections:

```
Flash Chip      Raspberry Pi
+---------+     +----------+
| VCC     |---->| 3v3      |
| RESET   |---->| 3v3      |
| /CS     |---->| GPIO 8   |
| DO      |---->| GPIO 9   |
| CLK     |---->| GPIO 11  |
| DI      |---->| GPIO 10  |
| GND     |---->| Ground   |
+---------+     +----------+
```

You can solder wires to the flash chip, or use a SOIC16 clip. More details on the Raspberry Pi and SPI chip pinouts are available on the wiki [1]

When you have the Raspberry Pi connected to the flash chip, boot your Pi and follow the instructions:

1) Make sure your Pi has SPI enabled with `sudo raspi-config`
2) Install necessary tools: `sudo apt install xxd libubootenv-tool mtd-utils`
3) Upload overlay (see wiki [1]) and execute: `sudo dtc -@ -I dts -O dtb -o /boot/overlays/we410443.dtbo we410443-overlay.dts`
4) Enable in `/boot/firmware/config.txt` by adding a new line containing `dtoverlay=we410443`
5) Reboot your Pi and verify the mtd partitions with `cat /proc/mtd`, you should see:

```
dev:    size   erasesize  name
mtd0: 02000000 00001000 "all"
mtd1: 00030000 00001000 "u-boot"
mtd2: 00010000 00001000 "u-boot-env"
mtd3: 00010000 00001000 "factory"
mtd4: 01f60000 00001000 "firmware"
mtd5: 00010000 00001000 "glbcfg"
mtd6: 00010000 00001000 "config"
mtd7: 00010000 00001000 "glbcfg2"
mtd8: 00010000 00001000 "config2"
```

6) Optionally (but recommended), make a backup: `sudo dd if=/dev/mtd0 of=backup.bin` It can be restored with: `sudo flashcp backup.bin /dev/mtd0`

7) Set the variables for the bootloader: `echo '/dev/mtd2 0x0 0x1000 0x1000' > fw_env.config && sudo fw_setenv -c fw_env.config bootpartition 0`

8) Finally, flash the image: `sudo flashcp openwrt-ramips-mt7621-arcadyan_we410443-squashfs-sysupgrade.bin /dev/mtd4`

### MAC addresses
The label address is stored in ASCII in the config partition

```
+----------+----------+
| use      | address  |
+----------+----------+
| Device   | label    |
| Ethernet | label    |
| WLAN 2g  | + 1      |
| WLAN 5g  | + 2      |
+----------+----------+
```

### References:
[1] https://openwrt.org/toh/arcadyan/astoria/we410443
