### PR TITLE
[24.10] qualcommax: ipq807x: add support for Linksys HomeWRK

### DIFF
--- a/package/boot/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-envtools/files/qualcommax_ipq807x
@@ -29,6 +29,11 @@ edimax,cax1800)
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x20000"
 	;;
+linksys,homewrk)
+	idx="$(find_mtd_index 0:appsblenv)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x40000"
+	;;
 linksys,mx4200v1|\
 linksys,mx4200v2|\
 linksys,mx5300|\

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -37,6 +37,7 @@ ALLWIFIBOARDS:= \
 	dynalink_dl-wrx36 \
 	edgecore_eap102 \
 	edimax_cax1800 \
+	linksys_homewrk \
 	linksys_mx4200 \
 	linksys_mx5300 \
 	linksys_mx8500 \
@@ -168,6 +169,7 @@ $(eval $(call generate-ipq-wifi-package,compex_wpq873,Compex WPQ-873))
 $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))
 $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
+$(eval $(call generate-ipq-wifi-package,linksys_homewrk,Linksys HomeWRK))
 $(eval $(call generate-ipq-wifi-package,linksys_mx4200,Linksys MX4200))
 $(eval $(call generate-ipq-wifi-package,linksys_mx5300,Linksys MX5300))
 $(eval $(call generate-ipq-wifi-package,linksys_mx8500,Linksys MX8500))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-homewrk.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-homewrk.dts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq8174-mx4x00.dtsi"
+
+/ {
+	model = "Linksys HomeWRK";
+	compatible = "linksys,homewrk", "qcom,ipq8074";
+
+	aliases {
+		ethernet3 = &dp4;
+		ethernet4 = &dp5;
+	};
+
+	chosen {
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		/*
+		 * Some devices use Micron NAND with with 8 bit ECC 
+		 * other AMD/Spansion NAND with 4 bit ECC
+		 *nand-ecc-strength = <4>;
+		 *nand-ecc-step-size = <512>;
+		 */
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&dp2 {
+	status = "okay";
+	phy-handle = <&qca8075_1>;
+	label = "wan";
+};
+
+&dp3 {
+	status = "okay";
+	phy-handle = <&qca8075_2>;
+	label = "lan3";
+};
+
+&dp4 {
+	status = "okay";
+	phy-handle = <&qca8075_3>;
+	label = "lan2";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8075_4>;
+	label = "lan1";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Linksys-HomeWRK";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -156,6 +156,21 @@ define Device/edimax_cax1800
 endef
 TARGET_DEVICES += edimax_cax1800
 
+define Device/linksys_homewrk
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Linksys
+	DEVICE_MODEL := HomeWRK
+	DEVICE_DTS_CONFIG := config@oak03
+	BLOCKSIZE := 256k
+	PAGESIZE := 4096
+	IMAGE_SIZE := 475m
+	NAND_SIZE := 1024m
+	SOC := ipq8174
+	DEVICE_PACKAGES += kmod-leds-pca963x ipq-wifi-linksys_homewrk
+endef
+TARGET_DEVICES += linksys_homewrk
+
 define Device/linksys_mx
 	$(call Device/FitImage)
 	DEVICE_VENDOR := Linksys

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -27,6 +27,7 @@ ipq807x_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan plc" "wan"
 		;;
 	compex,wpq873|\
+	linksys,homewrk|\
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
 	linksys,mx4300|\

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -30,6 +30,7 @@ case "$FIRMWARE" in
 	zte,mf269)
 		caldata_extract "0:art" 0x1000 0x20000
 		;;
+	linksys,homewrk|\
 	linksys,mx4200v1|\
 	linksys,mx8500)
 		caldata_extract "0:art" 0x1000 0x20000

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -166,6 +166,11 @@ platform_do_upgrade() {
 		fw_setenv upgrade_available 1
 		nand_do_upgrade "$1"
 		;;
+	linksys,homewrk)
+		CI_UBIPART="rootfs"
+		remove_oem_ubi_volume ubi_rootfs
+		nand_do_upgrade "$1"
+		;;
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
 	linksys,mx4300|\


### PR DESCRIPTION
Backport support for Linksys HomeWRK to 24.10 branch:

https://github.com/openwrt/openwrt/commit/07f8319d2d9166a41c2fd94ec1422bcd80ada991 qualcommax: ipq807x: add support for Linksys HomeWRK

Link: https://github.com/openwrt/openwrt/pull/17463
