### PR TITLE
port-split: add new package for port-splitting support

### DIFF
--- a/package/network/config/port-split/Makefile
+++ b/package/network/config/port-split/Makefile
@@ -1,0 +1,29 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=port-split
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/port-split
+  SECTION:=net
+  CATEGORY:=Network
+  MAINTAINER:=Til Kaiser <mail@tk154.de>
+  TITLE:=Port split config support
+  DEPENDS:=+devlink
+endef
+
+define Package/port-split/description
+ Port split config support in /etc/config/network
+ to split front panel ports using the devlink utility.
+endef
+
+Build/Compile=
+
+define Package/port-split/install
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/port_split $(1)/etc/init.d/
+endef
+
+$(eval $(call BuildPackage,port-split))

--- a/package/network/config/port-split/files/port_split
+++ b/package/network/config/port-split/files/port_split
@@ -1,0 +1,58 @@
+#!/bin/sh /etc/rc.common
+
+START=15
+USE_PROCD=1
+
+print_error() {
+    local msg="$1"
+    echo -e "\033[33m${msg}\033[m" >&2
+}
+
+get_next_port_split() {
+    devlink port show | grep -m1 split_group | sed 's/: .*//'
+}
+
+split_port() {
+    local device_config="$1"
+    local device_name
+    local split_count
+    local error
+
+    config_get device_name "$device_config" "name"
+    config_get split_count "$device_config" "split"
+
+    [ -z "$device_name" ] || [ -z "$split_count" ] && return
+    error="$(devlink port split "$device_name" count "$split_count" 2>&1)"
+
+    if [ -n "$error" ]; then
+        print_error "$device_name: port split error"
+        print_error "$error\n"
+    fi
+}
+
+unsplit_ports() {
+    local port="$(get_next_port_split)"
+
+    while [ -n "$port" ]; do
+        devlink port unsplit "$port"
+        port="$(get_next_port_split)"
+    done
+}
+
+start_service() {
+    config_load network
+    config_foreach split_port "device"
+}
+
+stop_service() {
+	unsplit_ports
+}
+
+reload_service() {
+    unsplit_ports
+    start
+}
+
+service_triggers() {
+    procd_add_reload_trigger network
+}


### PR DESCRIPTION
Adds a new package to split a device's front panel port into multiple using the devlink tool in the backend, commonly used on network switches where users can insert a so-called breakout cable into a network port.

This is implemented as a `procd` service and introduces a new `split` option to the device configuration section inside `/etc/config/network` that specifies the split count for the front panel port.

I was thinking about directly implementing this into `netifd` but since this is currently only supported by a few devices (https://elixir.bootlin.com/linux/v6.13.2/A/ident/port_split), I decided to make a separate package for it. But I wouldn't mind integrating it into `netifd` if it is better suited there.

E.g., a device configuration could look like this:
```
config device
        option name 'swp1'
        option split '4'
```