### PR TITLE
generic: mtk_eth_soc: increase RX ring size for MT7622 and MT7981

### DIFF
--- a/target/linux/generic/pending-6.6/738-01-net-ethernet-mtk_eth_soc-reduce-rx-ring-size-for-older.patch
+++ b/target/linux/generic/pending-6.6/738-01-net-ethernet-mtk_eth_soc-reduce-rx-ring-size-for-older.patch
@@ -53,7 +53,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.irq_done_mask = MTK_RX_DONE_INT,
  		.dma_l4_valid = RX_DMA_L4_VALID,
 -		.dma_size = MTK_DMA_SIZE(2K),
-+		.dma_size = MTK_DMA_SIZE(512),
++		.dma_size = MTK_DMA_SIZE(1K),
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
@@ -80,7 +80,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
 -		.dma_size = MTK_DMA_SIZE(2K),
-+		.dma_size = MTK_DMA_SIZE(512),
++		.dma_size = MTK_DMA_SIZE(1K),
  	},
  };
  


### PR DESCRIPTION
Increase RX ring size from 512 to 1024 for dual-core ARM64 SoCs MT7622 and MT7981.

Fixes: 15887235c1 ("generic: mtk_eth_soc: reduce driver memory usage")
