### PR TITLE
Extend use of shallow clone for feeds update

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -157,7 +157,7 @@ my %update_method = (
 	'src-git' => {
 		'init'          => "git clone --depth 1 '%s' '%s'",
 		'init_branch'   => "git clone --depth 1 --branch '%s' '%s' '%s'",
-		'init_commit'   => "git clone '%s' '%s' && cd '%s' && git checkout -b '%s' '%s' && cd -",
+		'init_commit'   => "git clone --depth 1 '%s' '%s' && cd '%s' && git fetch --depth=1 origin '%s' && git -c advice.detachedHead=false checkout '%s' && cd -",
 		'update'	=> "git pull --ff-only",
 		'update_rebase'	=> "git pull --rebase=merges",
 		'update_stash'	=> "git pull --rebase=merges --autostash",

--- a/scripts/feeds
+++ b/scripts/feeds
@@ -162,7 +162,7 @@ my %update_method = (
 		'update_rebase'	=> "git pull --rebase=merges",
 		'update_stash'	=> "git pull --rebase=merges --autostash",
 		'update_force'	=> "git pull --ff-only || (git reset --hard HEAD; git pull --ff-only; exit 1)",
-		'post_update'	=> "git submodule update --init --recursive",
+		'post_update'	=> "git submodule update --init --recursive --depth 1",
 		'controldir'	=> ".git",
 		'revision'	=> "git rev-parse HEAD | tr -d '\n'"},
 	'src-git-full' => {


### PR DESCRIPTION
* scripts/feeds: perform shallow clone on feed update referenced by a SHA1
* scripts/feeds: perform shallow clone on submodules on feed update referenced by SHA1, branch or default

**How to test**

1. Update the `feeds.conf.default` to point at specific commit (issued from prplos configuration)
```
src-git packages https://github.com/openwrt/packages.git^eb6939fdeb5eecb321d40bc94d06ccd9df728658
src-git luci https://github.com/openwrt/luci.git^74b688cd2b2ae804904b8fa2cdec9f2e7f654d76
src-git routing https://github.com/openwrt/routing.git^31e66c083940775508b29b9ec2776db4be3f3633
src-git telephony https://github.com/openwrt/telephony.git^98c8a5aa4624312ed758e2e2b6d4039050a1649d
```

2. Run the update and see it is as fast as referencing a specific branch or trunk
```
$ ./scripts/feeds update
```

