### PR TITLE
mediatek: filogic: migrate Zyxel NWA50AX Pro to upstream PHY LED control

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
@@ -85,8 +85,22 @@
 		reg = <5>;
 		compatible = "ethernet-phy-ieee802.3-c45";
 
-		/* LED0: Amber ; LED1: nc ; LED2: nc ; LED3: Green */
-		mxl,led-config = <0x3b0 0x0 0x0 0x3c0>;
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led-0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_AMBER>;
+				function = LED_FUNCTION_WAN;
+			};
+
+			led-3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+			};
+		};
 	};
 };
 

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -150,6 +150,10 @@ zyxel,ex5601-t0-ubootmod)
 	ucidef_set_led_netdev "wifi-24g" "WIFI-2.4G" "green:wifi24g" "phy0-ap0" "link tx rx"
 	ucidef_set_led_netdev "wifi-5g" "WIFI-5G" "green:wifi5g" "phy1-ap0" "link tx rx"
 	;;
+zyxel,nwa50ax-pro)
+	ucidef_set_led_netdev "uplink" "UPLINK" "mdio-bus:05:amber:wan" "eth0" "link_10 link_100 link_2500 tx rx"
+	ucidef_set_led_netdev "uplink" "UPLINK" "mdio-bus:05:green:wan" "eth0" "link_1000 link_2500 tx rx"
+	;;
 esac
 
 board_config_flush


### PR DESCRIPTION
This commit switches the control of the leds connected to the Maxlinear GPY211C PHY to an upstream solution. There should be no functional changes. I don't have the device, but the migration is quite straightforward, so everything should work ok. Testing on the hardware welcome.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
