### PR TITLE
mediatek: filogic: migrate Acer W6/W6d to upstream PHY LED control

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6.dts
@@ -186,8 +186,23 @@
 		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
 		reset-assert-us = <10000>;
 		reset-deassert-us = <10000>;
-		/* LED0: nc ; LED1: nc ; LED2: amber ; LED3: green */
-		mxl,led-config = <0x0 0x0 0x370 0x380>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led-2 {
+				reg = <2>;
+				color = <LED_COLOR_ID_AMBER>;
+				function = LED_FUNCTION_WAN;
+			};
+
+			led-3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+			};
+		};
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6d.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6d.dts
@@ -172,8 +172,23 @@
 		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
 		reset-assert-us = <10000>;
 		reset-deassert-us = <10000>;
-		/* LED0: nc ; LED1: nc ; LED2: amber ; LED3: green */
-		mxl,led-config = <0x0 0x0 0x370 0x380>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led-2 {
+				reg = <2>;
+				color = <LED_COLOR_ID_AMBER>;
+				function = LED_FUNCTION_WAN;
+			};
+
+			led-3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+			};
+		};
 	};
 };
 

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -11,6 +11,11 @@ abt,asr3000)
 	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan-2ghz" "phy0-ap0"
 	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan-5ghz" "phy1-ap0"
 	;;
+acer,predator-w6|\
+acer,predator-w6d)
+	ucidef_set_led_netdev "internet" "INTERNET" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100 link_1000 tx rx"
+	ucidef_set_led_netdev "internet" "INTERNET" "mdio-bus:06:green:wan" "eth1" "link_2500 tx rx"
+	;;
 asus,tuf-ax4200)
 	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:white:wan" "eth1" "link tx rx"
 	;;


### PR DESCRIPTION
This commit switches the control of the leds connected to the Maxlinear GPY211C PHY to an upstream solution. There should be no functional changes.I don't have the device, but the migration is quite straightforward, so everything should work ok. Testing on the hardware welcome.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>