### PR TITLE
mediatek: filogic: migrate ASUS TUF AX6000 to upstream PHY LED control

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -146,16 +146,33 @@
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <5>;
 
-		mxl,led-drive-vdd;
-		mxl,led-config = <0x03f0 0x0 0x0 0x0>;
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led-0 {
+				reg = <0>;
+				active-high;
+				color = <LED_COLOR_ID_WHITE>;
+				function = LED_FUNCTION_LAN;
+			};
+		};
 	};
 
 	phy6: phy@6 {
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <6>;
 
-		/* LED0: CONN (WAN white) */
-		mxl,led-config = <0x03f0 0x0 0x0 0x0>;
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led-0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_WHITE>;
+				function = LED_FUNCTION_WAN;
+			};
+		};
 	};
 
 	switch: switch@1f {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -19,6 +19,10 @@ acer,predator-w6d)
 asus,tuf-ax4200)
 	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:white:wan" "eth1" "link tx rx"
 	;;
+asus,tuf-ax6000)
+	ucidef_set_led_netdev "lan5" "LAN5" "mdio-bus:05:white:lan" "lan5" "link tx rx"
+	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:white:wan" "eth1" "link tx rx"
+	;;
 confiabits,mt7981)
 	ucidef_set_led_netdev "lan1" "lan1" "blue:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan2" "blue:lan-2" "lan2" "link tx rx"


### PR DESCRIPTION
This commit switches the control of the leds connected to the Maxlinear GPY211C PHY to an upstream solution. There should be no functional changes. I don't have the device, but the migration is quite straightforward, so everything should work ok. Testing on the hardware welcome.

Signed-off-by: Aleksander Jan Bajkowski [olek2@wp.pl](mailto:olek2@wp.pl)


