### PR TITLE
wifi-scripts: fix missing VHT capabilities detection

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-device.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-device.json
@@ -635,7 +635,8 @@
 		},
 		"short_gi_80": {
 			"description": "Short GI for 80 MHz",
-			"type": "boolean"
+			"type": "boolean",
+			"default": true
 		},
 		"spectrum_mgmt_required": {
 			"description": "Set Spectrum Management subfield in the Capability Information field",
@@ -712,7 +713,8 @@
 			"description": "Indicates the maximum length of A-MPDU pre-EOF padding that the STA can recv",
 			"type": "number",
 			"minimum": 0,
-			"maximum": 7
+			"maximum": 7,
+			"default": 7
 		},
 		"vht_max_mpdu": {
 			"description": "Maximum MPDU length",

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -329,7 +329,7 @@ function device_htmode_append(config) {
 			config.vht_capab += '[RX-ANTENNA-PATTERN]';
 		if (vht_capab & 0x20000000 && config.tx_antenna_pattern)
 			config.vht_capab += '[TX-ANTENNA-PATTERN]';
-		let rx_stbc = [ '', '[RX-STBC1]', '[RX-STBC12]', '[RX-STBC123]', '[RX-STBC-1234]' ];
+		let rx_stbc = [ '', '[RX-STBC-1]', '[RX-STBC-12]', '[RX-STBC-123]', '[RX-STBC-1234]' ];
 		config.vht_capab += rx_stbc[min(config.rx_stbc, (vht_capab >> 8) & 7)];
 
 		if (vht_capab & 0x800 && config.su_beamformer)

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -242,7 +242,7 @@ function device_htmode_append(config) {
 				[ 29, 15 ], [ 61, 47 ], [ 93, 79 ], [ 125, 111 ],
 				[ 157, 143 ], [ 189, 175 ], [ 221, 207 ]];
 		for (let k, v in vht_oper_centr_freq_seg0_idx_map)
-			if (v[0] <= config.channel) {
+			if (config.channel >= (v[0] - 28) && config.channel <= v[0]) {
 				config.vht_oper_centr_freq_seg0_idx = v[1];
 				break;
 			}

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -338,15 +338,15 @@ function device_htmode_append(config) {
 			config.vht_capab += '[BF-ANTENNA-' + min(((vht_capab >> 13) & 3) + 1, config.beamformer_antennas) + ']';
 
 		/* supported Channel widths */
-		if (vht_capab & 0xc == 8 && config.vht160 <= 2)
+		if ((vht_capab & 0xc) == 8 && config.vht160 <= 2)
 			config.vht_capab += '[VHT160-80PLUS80]';
-		else if (vht_capab & 0xc == 4 && config.vht160 <= 1)
+		else if ((vht_capab & 0xc) == 4 && config.vht160 <= 2)
 			config.vht_capab += '[VHT160]';
 
 		/* maximum MPDU length */
-		if (vht_capab & 3 > 1 && config.vht_max_mpdu > 11454)
+		if ((vht_capab & 3) > 1 && config.vht_max_mpdu >= 11454)
 			config.vht_capab += '[MAX-MPDU-11454]';
-		else if (vht_capab & 3 && config.vht_max_mpdu > 7991)
+		else if ((vht_capab & 3) && config.vht_max_mpdu >= 7991)
 			config.vht_capab += '[MAX-MPDU-7991]';
 
 		/* maximum A-MPDU length exponent */


### PR DESCRIPTION
* Notation for **RX-STBC VHT** capabilities when specifying number of spatial
  streams should be hyphenated, e.g. RX-STBC-1, RX-STBC-2. HT capabilities
  use without hyphen, e.g. RX-STBC1, RX-STBC2. This is consistent with
  what hostapd expects.

* When selecting channels above 100 in VHT160+ modes the center
  frequency segment was incorrectly set to 50, causing the interface
  to not come up. Fixes #17972

* Add missing parentheses in the conditionals for VHT160/VHT160-80PLUS80
  and `VHT_MAX_MPDU` capabilities. The missing parentheses caused the bitwise
  AND to be evaluated after the equality comparison due to ECMA's operator
  precedence, where `==` has higher precedence than `&`.

* Fix Max MPDU length detection by changing the comparison operators to
  `>=` vs `>` otherwise the condition would never be met.

* Add missing default values:
  - `true` value for `short_gi_80` (As it exists for `short_gi_20`, `short_gi_40`, `short_gi_160`)
  - `7` for `vht_max_mpdu` (Without it the loop in MAX-MPDU-* calculation always compares with null)

* Change the `vht160` condition to `config.vht160 <= 2`. This flag is
  `2` by default, and only ever set to `0` when `vht_oper_chwidth < 2`.

  This aligns with the logic in non-ucode `mac80211.sh`:

```sh
  [ "$(($vht_cap & 12))" -eq 4 -a 1 -le "$vht160" ]
  [ "$(($vht_cap & 12))" -eq 8 -a 2 -le "$vht160" ]
```

Adds the following flags to the `hostapd` config:
```toml
[MAX-A-MPDU-LEN-EXP7]
[MAX-MPDU-11454]
[RX-STBC-1]
[SHORT-GI-80]
[VHT160]
```

`hostapd` generated config

Before:
```yaml
vht_capab=[RXLDPC][SHORT-GI-160][TX-STBC-2BY1][SU-BEAMFORMER][SU-BEAMFORMEE][MU-BEAMFORMER][MU-BEAMFORMEE][RX-ANTENNA-PATTERN][TX-ANTENNA-PATTERN][RX-STBC1][SOUNDING-DIMENSION-4][BF-ANTENNA-4]
```

After:
```yaml
vht_capab=[RXLDPC][SHORT-GI-80][SHORT-GI-160][TX-STBC-2BY1][SU-BEAMFORMER][SU-BEAMFORMEE][MU-BEAMFORMER][MU-BEAMFORMEE][RX-ANTENNA-PATTERN][TX-ANTENNA-PATTERN][RX-STBC-1][SOUNDING-DIMENSION-4][BF-ANTENNA-4][VHT160][MAX-MPDU-11454][MAX-A-MPDU-LEN-EXP7]
```

Compared to `iw phy0 info`:
```
  VHT Capabilities (0x339b79f6):
      Max MPDU length: 11454
      Supported Channel Width: 160 MHz
      RX LDPC
      short GI (80 MHz)
      short GI (160/80+80 MHz)
      TX STBC
      SU Beamformer
      SU Beamformee
      MU Beamformer
      MU Beamformee
      RX antenna pattern consistency
      TX antenna pattern consistency
```
