### PR TITLE
ubox: fix logging to external filesystem

### DIFF
--- a/package/system/ubox/files/log.init
+++ b/package/system/ubox/files/log.init
@@ -52,8 +52,12 @@ start_service_file()
 	}
 	[ -z "${log_file}" ] && return
 
+	local mountpoint="$(procd_get_mountpoints "${log_file}")"
+
 	[ "$_BOOT" = "1" ] &&
-		[ "$(procd_get_mountpoints "${log_file}")" ] && return 0
+		[ "$mountpoint" ] &&
+		! grep -q ".* $mountpoint " /proc/mounts &&
+		return 0
 
 	mkdir -p "$(dirname "${log_file}")"
 


### PR DESCRIPTION
As described in #13873, from 23.05.0 onwards logging to a file on an external filesystem fails.

This occurs because the log initscript had code added to prevent start logging to an external filesystem on boot, and added a trigger to start said logging when the external filesystem gets mounted.

The issue is that for filesystems mount with fstab uci, the fstab scripts runs at START=11 while log runs at START=12, which means the external filesystem is already mounted by the time the log initscript runs. Since the external filesystem is already mounted it does not trigger a hotplug event to trigger starting logging. This combination means the logging never automatically starts when the logfile is on an external filesystem.

We therefore add a check for the presence of a mounted filesystem when the log file is being sent to an fstab mounted filesystem. If the filesystem is mounted, we don't skip starting logging during boot.

If the filesystem is not mounted then file logging is not started and the trigger will start the logging when the filesystem is mounted.

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>