### PR TITLE
wifi-scripts: iwinfo: add definition for QCA9984

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/wifi_devices.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/wifi_devices.json
@@ -164,6 +164,7 @@
 		[ "0x168c", "0x003c", "0x19b6", "0xd03c", 0, 0, "Mikrotik", "R11e-5HacT" ],
 		[ "0x168c", "0x003c", "0x19b6", "0xd075", 0, 0, "Mikrotik", "R11e-5HacD" ],
 		[ "0x168c", "0x003e", "0x168c", "0x3361", 0, 0, "Qualcomm, Atheros", "QCA6174" ],
+		[ "0x168c", "0x0046", "0x168c", "0xcafe", 0, 0, "Qualcomm, Atheros", "QCA9984" ],
 		[ "0x168c", "0x0040", "0x168c", "0x0002", 0, 0, "Qualcomm, Atheros", "QCA9990" ],
 		[ "0x168c", "0x0046", "0x0777", "0xe535", 0, 0, "Qualcomm, Atheros", "QCA9994" ],
 		[ "0x168c", "0x0046", "0x0777", "0xe5a2", 0, 0, "Qualcomm, Atheros", "QCA9994" ],


### PR DESCRIPTION
Fixes iwinfo output for QCA9984 devices.

Before:
```
  Hardware: nl80211 [Generic MAC80211]
```

After:
```
  Hardware: 0x168c:0x0046 0x168c:0xcafe [Qualcomm, Atheros QCA9984]
```

Maintainers: @nbd168 @blogic