### PR TITLE
[24.10] ramips: Add support for Mercusys MR1800X as alt name of MR70X

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1963,6 +1963,8 @@ define Device/mercusys_mr70x-v1
   $(Device/tplink-safeloader)
   DEVICE_VENDOR := MERCUSYS
   DEVICE_MODEL := MR70X
+  DEVICE_ALT0_VENDOR := MERCUSYS
+  DEVICE_ALT0_MODEL := MR1800X
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
   TPLINK_BOARD_ID := MR70X


### PR DESCRIPTION
Both share the same OEM firmware but differ in product_name for safeloader product_name:MR1800X,product_ver:1.0.0,special_id:45550000

Signed-off-by: Robert Senderek <robert.senderek@10g.pl>
Link: https://github.com/openwrt/openwrt/pull/17965
Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
(cherry picked from commit f93367227e1458fb366304d0f431f12e95d244cd)

Depends on success of https://github.com/openwrt/openwrt/pull/18030
