### PR TITLE
imagebuilder: fix addition of local packages

### DIFF
--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -49,7 +49,6 @@ ifneq ($(CONFIG_USE_APK),)
 	$(call FeedSourcesAppendAPK,$(PKG_BUILD_DIR)/repositories)
 	$(VERSION_SED_SCRIPT) $(PKG_BUILD_DIR)/repositories
   endif
-	echo "packages/packages.adb" >> $(PKG_BUILD_DIR)/repositories
 
 	$(INSTALL_DATA) ./files/README.apk.md $(PKG_BUILD_DIR)/packages/README.md
 else

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -99,6 +99,7 @@ OPKG:=$(call opkg,$(TARGET_DIR)) \
 export APK_KEYS:=$(TOPDIR)/keys
 APK:=$(call apk,$(TARGET_DIR)) \
 	--repositories-file $(TOPDIR)/repositories \
+	--repository $(PACKAGE_DIR)/packages.adb \
 	$(if $(CONFIG_SIGNATURE_CHECK),,--allow-untrusted) \
 	--cache-dir $(DL_DIR)
 


### PR DESCRIPTION
Since alpinelinux/apk-tools@460d62ee743c, relative paths are no longer accepted in repositories file.

Add local repository in APK command instead to fix this issue.

Fixes: 83d2d21904e0 ("apk: update to Git HEAD (2025-02-08)")
Fixes: https://github.com/openwrt/openwrt/issues/18032
