### PR TITLE
selinux-policy: update to version v2.5

### DIFF
--- a/package/system/selinux-policy/Makefile
+++ b/package/system/selinux-policy/Makefile
@@ -8,8 +8,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=selinux-policy
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.defensec.nl/selinux-policy.git
-PKG_VERSION:=1.2.5
-PKG_MIRROR_HASH:=0b485aefed7ecc1ba3c5f5843cb3b10e9d7c55c09b361cd56933081c0dbdc223
+PKG_VERSION:=2.5
+PKG_MIRROR_HASH:=798f35f405863600ee31b1d168abb5a27f78653a609874b2a518129bec1d8a63
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=secilc/host policycoreutils/host
 
@@ -44,10 +44,14 @@ endef
 define Package/selinux-policy/install
 	$(INSTALL_DIR) $(1)/etc/selinux/$(PKG_NAME)/contexts/files/
 	$(INSTALL_DIR) $(1)/etc/selinux/$(PKG_NAME)/policy/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/customizable_types $(1)/etc/selinux/$(PKG_NAME)/contexts/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/file_contexts.subs_dist $(1)/etc/selinux/$(PKG_NAME)/contexts/files/
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/file_contexts $(1)/etc/selinux/$(PKG_NAME)/contexts/files/
 	$(INSTALL_CONF) $(PKG_BUILD_DIR)/policy.* $(1)/etc/selinux/$(PKG_NAME)/policy/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/customizable_types $(1)/etc/selinux/$(PKG_NAME)/contexts/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/default_contexts $(1)/etc/selinux/$(PKG_NAME)/contexts/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/default_type $(1)/etc/selinux/$(PKG_NAME)/contexts/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/failsafe_context $(1)/etc/selinux/$(PKG_NAME)/contexts/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/file_contexts $(1)/etc/selinux/$(PKG_NAME)/contexts/files/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/file_contexts.subs_dist $(1)/etc/selinux/$(PKG_NAME)/contexts/files/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/seusers $(1)/etc/selinux/$(PKG_NAME)/
 	$(INSTALL_DATA) ./files/selinux-config $(1)/etc/selinux/config
 endef
 


### PR DESCRIPTION
Rebased onto dssp5-base. Baseline is:
ss, tc, stubby, irqbalance, usbutils, ethtool, tcpdump, mtr, bmon, zram-swap, parted, e2fsprogs, gdisk, block-mount, kmod-fs-ext4, kmod-fs-f2fs, kmod-usb-storage, f2fs-tools-selinux, kmod-usb-storage-uas, kmod-usb3, wireguard-tools,
openssh-sftp-server, luci-light, resolveip, blockd

Changes since v1.2.5:
fdfc313 dnsmasq
b66a3d2 do_stage2 related
5e13212 more do_stage2 related
c5bea19 absolute paths
84ed620 various hacks
6b43706 mtdstordev nand
9c6bfe5 mtdstordev: nand install
2e1c55a mtdblock supposedly for nor
58dd1bc blockd
633f99e pciutils
99e82ec README
e7e65f2 ethtool
426537f lspci
becac0d lspci
8418000 surpress leaks
a892349 hotplugcall
4daddc6 f2fstools
385feb7 pciutils rules
295e128 lspci and picocom skels
d2088a6 netifd and ipcalc
c7f123e adds uqmi sysagent
aeb416e hotplugcall and adds cdc serial
35b5afd rpcd
6eb727d ucode and netifd
d299acd blkid and modem serial
1c3cc50 adds pstore nodedev
4503902 showed up on bpi r4 (boot from sd)
d0dba85 sandbox
647777f sandbox
6b10e8a sandbox
d276333 sandbox
3e1e232 sandbox
aa5cc92 sandbox
f02a0a6 sandbox
ddc2c12 sandbox
2242c9e sandbox
e763f2d sandbox
cb1239a sandbox
449ad9a sandbox
1ec532b sandbox
6cef851 sandbox
b8b5522 sandbox
95f0bb6 sandbox
2bf87a9 sandbox stordev
74bf2e3 README
5f1640c silenced.type loose ends
a80682a README
5664b1a uci: /tmp/run/uci overrides
73c4e6a sandbox
de9a088 sandbox
8c51986 sandbox
0fe32da sandbox
68e376b sandbox
fe59dfa sandbox
5d16966 sandbox
cf9a186 adds sandbox domain
77bd3a4 adds silenced.type
ff3ff8f README
73e3be8 dnsmasq: /etc/dnsmasq.hosts
2b3491c Revert "adds tmux"
9fe54dd adds tmux
bc34b62 misc.cil be a bit more specific because usually dos is not supported 26a4784 sshsftpserver: gets attributes of fs
9510bc0 rename vdstordev and blockmount transition 13960b4 cgiscript agent: anon_subj_type_transition e69687f README fixes
a2bca07 README updates
0cc10ff vdastordev: adds one more partition
3867574 blkid adds alternative --cache-file
009b441 blkid run file
f9b75d0 README: adds blkid to baseline
f7332c8 fixes README
3dcc957 three issues:
434bad8 /new_root related
04d18a5 README armsr combined-efi
506d8c1 /efi is not a thing in armsr combined-efi
c0db1ed efivarfs remove these filecons
4eb35b7 adds efivars noseclabelfs for armsr combined-efi bbc6a6b adds /dev/ttyS3 to tty serialtermdev
1467206 README local logins
6ae3185 rename eficapsulemiscnodedev
d43ded0 rename to vportserialtermdev
a47d2f8 fixes virtio port serialtermdev
03aec70 blockmount: make it a bit more robust
70f1ed3 hotplugcall not sure what config triggers this 3338764 boarddetect: i was expecting this
d97548a deal with /dev/tty and /dev/vcs
c6ba4a5 adds virtio block device
d03e216 adds virtio vport serialtermdev for qemu guest agent 2dc0291 validatefirmwareimage: allow getattr of *all* dev chr files fdfb3a7 adds /dev/efi_capsule_loader for armsr combined target b129fb9 validatefirmwareimage ordering
b5e81b4 validatefirmwareimage clean up
0932dc5 README typo fixes
a1f88f0 README fix
e6c68be README typo fixes
a232c21 hvcloginserialtermdev: macro not used
d7edd95 support /usr/local and update README
c0d2947 validatefirmwareimage comment
7dbc9b3 validatefirmwareimage: allow find to getattr of dev.except char f647175 platformtmpfile: elaborate a bit in comment 52f32c1 reintroduce misc.cil
320d77f validatefirmwareimage: /lib/upgrade/platform.sh 365fc65 deal with /efi for combined images
183b412 adds hvc logserialtermdev
20cd42a sshdsysagent: limited support for legacy scp -O with firmware images 1ccee8d validatefirmwareimages: some events related to "combined" images 9b47fc3 jshn reads /dev/urandom
f86def7 adds /tmp/log/apk.log
f1247b3 these are relative to the current namespace 32c0cc8 hotplugcall qemu virtio-console-helper
5cc41f5 uclient-fetch for manually downloading sysupgrade related c8140bd cgi-io creates firmware and backup atomically edf517b factoryreset deal with firstboot compatibility f5116b5 pppd: redundant, is implied with shell client type 86be72c updates README
8c08ca1 luci-mod-system: a bit of speculation here 417f4a5 adds /dev/autofs
1ed537c misc.cil: remove
01d014a selinuxsecfile: be more specific
53fca71 rename blockd module
b4c9b15 ttyloginserialtermdev: ordering
016c3c1 sysagent traversal of /root is enough
d0d7c91 hotplugcall: net/00-sysctl
2821746 adds ttyAMA0 and some incomplete rules for board-detect 97abd39 fixes filecon
8f786b0 allow these pipes
997c0c0 rpcd network diag
5092aff logread: this is not a leak
1e78455 iproute and nft
aa403f3 rpcd and netifd
7c07cde luci related
889bb50 automount related and fsck
20d1e7a adds blockd
d2e91fc ucode comment/note
b3c0a31 passwd/shadow
bb88aab passwd related
62672ad passwd did not work
da32b18 leaks
f74a8d3 more leaks
3854954 lots of leaks
e21f607 some rules
d40427c some rules
9d25635 some rules
ffa4504 some rules
6ce593f some rules
ca1e1ca some rules
3739e61 luci related skeletons
2367c87 Revert "netifd and ucode: hostapd related" 461ae97 netifd and ucode: hostapd related
677522b ordering
85e251c sysagent: ordering
e0da530 README
d045c35 sshsftpserver: redundant
743cf83 adds cron spooltmp file
a1c8157 blockmount sftpserver
91cc43d adds back in /tmp/spool for cron
9aab68f README
5363ad4 adds cpuprocfile
2d4ef97 README
12a2cc3 mediafile adds comment
2c77fee sshsftpserver
6ca4633 sshsftpserver
8e5ae5d adds sshsftpserver
950a895 README
0d8a7ba README
0c6b34b README
be47410 README
3c9bb2b sshd reads banner file and validatedata does file tests 758f781 adds inittab conf file
8b302e7 remove comments about leaks
bb1e175 pppd adds a comment
4fec7cb odhcpd server: was inconsistent but cannot reproduce 0c38653 boarddetect: get over it
2d6523e fixes kvm gmem anon inode
9dabef0 adds cachetmp for apk
be4d7db netifd and ucode
e7a5823 mtr
25fb344 iproute2 ss
9123474 README
de7d1f6 README
6af2579 iwinfo
cf222cd various mostly leaks
ba13ba3 mainly ppp related
cc57eb0 various
a7f4bff various
3f391be various
09afa10 validatefirmwareimage
20a62b0 validatefirmwareimage
56a7a5a related to sysupgrade (its a bit fragile)
71dcfb4 mr8300 related
3c4589c switches from one to mr8300 and added wireguard-tools 9926576 rules and solved dropbear hostkey mystery
c0912da some rules
7f3bc26 hwdatam getdnsquery skeletons and various rules a36b10a adds mtr and iproute2 ss/tc
871a5d6 adds kvm nodedev and kvm-gmem anon inode
1f1267a extroot related
e62667a blockmount adds comment about extroot setup considerations 79c1722 get to the bottom of this
9c0d025 dropbear fix
3470c53 dropbear agentforwarding but also a place to read/write (scp) 32b7015 adds bmon
ceb11a7 adds a qos nodedev (this one shows up in my mr8300) 1a29dcf pppd dupe sysagents are allowed to rw inherited tty serialtermdevs e61cac8 README
488be96 irqbalance and stubby
b4dac27 add some tty serialtermdevs and irqbalance skel 9807fd6 README
8415a2f parted and dhcpclient
d17a977 some uclient-fetch rules
24f6c02 adds back in questionable /new_root
2edc836 extroot related
c9a9d83 adds a mmcstordev
c60ca86 blockmount related
5939142 logread
93c9913 adds blockmount
f2f4302 rootfile: /tmp/root/upper
9e8ed4e extroot related
f4a0b2b ignore hotplug.call for now and add parted skel 550ac26 extroot related
49b58df extroot
ac3e0c9 leave this for now
eabd7af rootfile: block is going to call this too
47b598a rootfile: this seems to work
c884f5b /rom and /rwm
3409f4e sysagent: ujailnoa: no access
8bb59e2 tmp and xattr: elaborate because this can't be clear enough bf68b42 some uclient-fetch rules
b237645 subj: ordering
010f7b8 subj: this should be dontaudited
eec48ba verious loose ends
bbd1685 extroot: probably not strictly needed
bd50faf this stuff makes no sense to me
d502a8f README
25f62e4 README: add notes
01e1f0f validatefirmwareimage
870d9ec adds e2fsprogs skeleton
095f1b5 adds ethtool skeleton
4e7add7 adds tcpdump
b9d670d adds uclient fetch
651cd90 usbnodedev: support some more
2e6b142 rename netifd module
5ea3887 see if logread-ubox can get with logread
3c3ade5 validate firmware image skeleton
1d5039c netifd
ccd010e adds various skels
41b57ff adds type for /run/apk
83140ff sshserver
52a664c sshserver
14bbfe4 sshserver
3e39ef5 adds pppd
7172193 dnsmasq the compromise
e551132 the hard way
3357a29 dnsmasq attempt to deal with the nasty bits 27e4540 dnsmasq rules
99b7475 dnsmasq related
76c2bf2 adds a dnsmasq skel
66be0ef add led skeleton
bd1a11f adds usign skeleton
5342527 ubihealthd rule
cd96711 adds odhcp6c
fa8a94f adds a fitblk skel
a8b126e adds more ubiutils
c6774a2 adds validatedata skeleton
51d6582 some ubihealthd rules
175d8ac README
457b1a9 README
5337e52 README
9b0caaf README
6d65ec7 README
26c8e27 README
42184cd adds README
19e00c5 systemav be more specific here
5b4c42a fsck dont pretend to support anything other than f2fs 3b7b1b9 adds fwtool skel
afa58e7 wpad
d46fd23 adds ubiutils
174f7de uci and wpad
43f622d wpad/wpasupplicant
a03d797 wifi: should not config_generate be doing this bbfab28 rules
31d8258 rules
f4eb4d2 rules
97f9f80 rules
d039265 some (questionable) rules
f1cdc16 ucode make this a bit more robust
77e3c52 hotplugcall
09f5c2c hotplugcall and ucode rules
cbfe741 various rules
4ba9f62 fixes leaked udp socket handling
90d17d0 various new skels passwdav and misc stuff
1d4b06b rootfile: theres a squashfs mounted under /rom 2d119c8 rename urngd to urng.server
7f201b0 sysagent
4b7b2b5 ubus and jshn cwd traversals
857796a ubus and jshn see if i can get away with this 13614ce ucode
cf176cd envtools and ucode
6c0d5e3 nft ucode and envtools
0333922 envtools (shell scripts) and ucode probably creates fw4.state 7b9b2d5 not pretty but imply cap_net_bind_service
4b7fabf envtools be more specific
6a4817f adds uboot envtools skel and some boarddetect rules 2e37d72 various rules
8e3e0db firewall and odhcpd related fixes
bcbf204 various:
f906388 rename ujailnoatempfile
1b78cea agents: update example skeletons
e0f262d fixes socketav
c75d4f2 fix "not sure about this but it was inconsistent" 1df5a7f fs.cil typo fix
2edd26a anoninode be more specific
28427d2 file nodedev be more specific
0163d75 stordev be more specific
a96db83 not sure about this but it was inconsistent c1f9974 2025
938cf75 initscript/cgiscript sysagent script type
8de254d typo in comment
e200c96 agent transitions: allow signal and signull (cont.) 7522241 agent transitions: allow signal and signull bd7f9de more macros for consistent experience
8c09e73 sockets: simplification
a671f44 subj.cil: subj.entry add some macros for consistent experience 0a35fff rename resolvconf to dns
4a8a0f7 fix "netport: imply these here"
462b33f unlabeled/invalid i think this should be ok 41c38e8 netport: imply these here
99af2a1 adds fsck f2fs sysagent
7ddd46b misc questionable stuff
8faee7a jshn repro this
3ef447e adds reloadconfig and moves files belonging to it eebc039 some rules
6849200 sysagent skels and redo board.json
5b905ab ucisysagent: /tmp/run/config.check probably belongs here c491fd7 try to deal with leaks on a low level
cc91342 adds some more sysagent skeletons
f0c041f redo dhcpreservedport
d84b3f3 adds some sysagent skeletons
459a6fa adds some common network port types
6cd2adc initscript and cgiscript sys subj type transition macros 31fc400 netport be more specific
ea4703e cron redone
b88b5d4 comment fix
44a32c1 uci and tmpfile
306c11c redo logsysagent adds lastlogtmpfile
37059f6 adds logd and ubus sysagent skeletons
62e48ba adds jshn and jsonfilter sysagent skels
029933a adds ucisysagent skeleton
f65ee2b execdatafiles: macros to transition to sys.subj 80ea34f adds apk exec, conf, data (state), runtmp
cd61420 comments on secmark and netlabel
3f23875 disables always_check_network, rely on ioctl_skip_cloexec c9d9355 invalidpeers,packets and associations
6ea4137 nameserviceconffile and resolvconftmpfile
22e1cd4 resolvconftmpfile.client implies dns resolving and networking 96397c0 adds anon_agent macros fro cgi/init scripts 7ef83b6 wwwcgiscriptfile: there are symlinks here
0acf44a wwwcgiscriptfile: this is redundant
452062e upgradedatafile and cgi/init script agents 6f3164a adds wwwcgiscriptfile
bc64d5f initscriptfile
418e061 revisit resolvconftmpfile
0c01f05 udhcpcconffile dropins
0229f42 adds iproute2conffile
d99c662 udhcpc files
27ea2be adds libuboxdatafile
cee1133 removes ucodedatafile and adds sysupgrade
92919dc subj traverse /
1883e07 adds data files
ef36ee7 adds more files
68f1816 adds more files
f177a1f remove spooltmpfile
096f98a remove unused stuff and note about /etc/board.json 8808f92 drop dropbearconffile
d03364d boardconffile
9fc7dc2 dropbear hostkey
7188de0 adds in various file types
5228716 fixes iouringav: (for dev.unconfined clean up) 4fd0dcb sysctlfile and sysfile clean up
5ecb361 sysagent
79128d1 fix wwwfile
8c2c14c fix initscriptfile
b37c73b adds wwwfile for /www and initscriptfile for /etc/init.d 5ea597d adds resolvconftmpfile
0b3a18b shell clients read os-release
121ee50 adds shell exec and shells conf
972375c adds various file types
f164d13 adds firmware data file
f581035 locales: /usr/share/zoneinfo actually seems optional ee06ee9 adds locales data/tmp
49c0470 adds lost+found for ext4
762790c adds certfile
7e4e393 misc.cil: add some build-time sanity checks b2be5bf misc/av clean up
b5ea138 moves userspace initial context to sys.cil adbebd5 fix sysagent traverse /root
b3e1f12 sysagent: traverse /root
575a53d adds homefile and syshomefile for /home and /root 53eb69f net clean up
ff6ce6e adds sys loginptytermdev
0a68efd agent, sysagent and rules common to all processes 293a008 shadow conf
336c436  selinux config
4795e6c adds hoststmpfile for /tmp/hosts
96f0c90 adds in some low level file types
a62b337 adds in basic network port partitioning
a829ffb ttyMSM0 and console none spec
26f7f8a adds in stordev
0350f52 traceseclabelfs: probably not needed
feb0c88 adds in terminal devices
94a14bc adds loopcontrol device node
d32600a removes fitnodedev: is a stordev
4471b74 cleans up dev.unconfined
6e6164e adds is device nodes
c739fd8 hypervisorsysfile: not used in openwrt
e74dac7 kcoreprofile make i casesensitive for easy grep ccfb1c0 populate /proc
d6bbccc kcoreprocfile.cil: note about kcore procfile 45158b7 openwrt uses /tmp/shm instead
2e6e64e adds in policycaps
c03193b misc.cil: root.fs is questionable here
2e6007d /dev labeling: ensure consistency with file context specs d78bb5f adds overlayfile
15499e4 Revert "rootfile: not sure about this"
fd818b8 adds pstore and bpf fs for /sys/fs/{bpf,pstore} edce700 rootfile: not sure about this
a98704d git attributes dont add support
a1c81a1 misc.cil we dont need this
e36b32a removes misc/modular.cil: we dont do modular b071efc remove cgroupfile, debugfile and tracefile 86174fc /proc, /dev, /tmp, /sys
9fbade4 tmp.fs assoc. with xattr for /dev and /tmp 844c17a removes devtmpseclabelfs
04bdbe6 file_contexts.subs_dist: this needs review c689704 Adds a package makefile and adjusts main makefile 78b50ed Makefile: we only do a minimal monolithic policy 10e40a8 Import dssp5-base
a891035 README. adds a todo item for TIOCLINUX filtering 2caca81 Makefile: fixes previous commit
32e9051 for busybox new version
e960ddf iwinfo: reads uci wireless config
ac421c2 README: adds wiki url
2af34b2 nftables/ucode: leaks