### PR TITLE
wifi-scripts: fix default value of vlan_naming

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -1090,7 +1090,7 @@ hostapd_set_bss_options() {
 
 	[ -n "$vlan_possible" -a -n "$dynamic_vlan" ] && {
 		json_get_vars vlan_naming vlan_tagged_interface vlan_bridge vlan_file vlan_no_bridge
-		set_default vlan_naming 1
+		set_default vlan_naming 0
 		[ -z "$vlan_file" ] && set_default vlan_file /var/run/hostapd-$ifname.vlan
 		append bss_conf "dynamic_vlan=$dynamic_vlan" "$N"
 		append bss_conf "vlan_naming=$vlan_naming" "$N"


### PR DESCRIPTION
LuCI removes `vlan_naming` when disabled, but `hostapd.sh` defaults to 1 when `vlan_naming` is absent.

Disabling `vlan_naming` in LuCI therefore has no effect.

This commit resolves the issue by changing the default to 0.

Fixes: https://github.com/openwrt/luci/issues/7640