### PR TITLE
ltq-vdsl-vr[9|11]-mei: fix runtime warning and some cleanup bits

### DIFF
--- a/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/030-no-static-linking.patch
+++ b/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/030-no-static-linking.patch
@@ -1,0 +1,47 @@
+This removes -static compile option. The -static option tells GCC to
+link this statically with the libc, which we do not want in OpenWrt. We
+want to link everything dynamically to the libc. This fixes a compile
+problem with glibc.
+
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -198,10 +198,10 @@ AM_CFLAGS = -Wall -Wimplicit -Wunused -W
+ 
+ if IFXOS_ENABLE
+ AM_LDFLAGS= \
+-	-Bstatic -dn -static @IFXOS_LIBRARY_PATH@
++	-Bstatic -dn @IFXOS_LIBRARY_PATH@
+ else
+ AM_LDFLAGS= \
+-	-Bstatic -dn -static
++	-Bstatic -dn
+ endif
+ 
+ #
+@@ -302,7 +302,7 @@ mei_cpe_appl_ldflags= $(ADD_APPL_LDFLAGS
+ else
+ if TARGET_ADM5120_MIPSEL
+ mei_cpe_appl_cflags =  -O1 -g
+-mei_cpe_appl_ldflags = -static
++mei_cpe_appl_ldflags =
+ else
+ mei_cpe_appl_cflags =  -DPPC
+ endif
+@@ -335,7 +335,7 @@ endif
+ mei_cpe_drv_test_CFLAGS = $(mei_cpe_app_common_cflags) \
+ 				$(mei_cpe_appl_cflags) $(MEI_DRV_TARGET_OPTIONS)
+ 
+-mei_cpe_drv_test_LDFLAGS = $(mei_cpe_appl_ldflags) -Bstatic -dn -static @IFXOS_LIBRARY_PATH@ \
++mei_cpe_drv_test_LDFLAGS = $(mei_cpe_appl_ldflags) -Bstatic -dn @IFXOS_LIBRARY_PATH@ \
+ 							$(dsl_cpe_mei_LDFLAGS)
+ 
+ mei_cpe_drv_test_LDADD = -lifxos $(dsl_cpe_mei_LDADD)
+@@ -356,7 +356,7 @@ endif
+ 
+ mei_cpe_drv_dbg_strm_dmp_CFLAGS = $(mei_cpe_app_common_cflags) \
+ 				$(mei_cpe_appl_cflags) $(MEI_DRV_TARGET_OPTIONS)
+-mei_cpe_drv_dbg_strm_dmp_LDFLAGS = $(mei_cpe_appl_ldflags) -Bstatic -dn -static @IFXOS_LIBRARY_PATH@ \
++mei_cpe_drv_dbg_strm_dmp_LDFLAGS = $(mei_cpe_appl_ldflags) -Bstatic -dn @IFXOS_LIBRARY_PATH@ \
+ 									$(dsl_cpe_mei_LDFLAGS)
+ mei_cpe_drv_dbg_strm_dmp_LDADD = -lifxos $(dsl_cpe_mei_LDADD)
+ 

--- a/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/100-compat.patch
+++ b/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/100-compat.patch
@@ -10,13 +10,11 @@
  
 --- a/src/drv_mei_cpe_linux.h
 +++ b/src/drv_mei_cpe_linux.h
-@@ -110,6 +110,10 @@ typedef irqreturn_t (*usedIsrHandler_t)(
+@@ -110,6 +110,8 @@ typedef irqreturn_t (*usedIsrHandler_t)(
  #  endif
  #endif
  
-+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))
 +#define PDE_DATA pde_data
-+#endif
 +
  /**
     Function typedef for the Linux request_threaded_irq()

--- a/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/130-support-kernel-6.6.patch
+++ b/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/130-support-kernel-6.6.patch
@@ -1,14 +1,11 @@
 --- a/src/drv_mei_cpe_linux.c
 +++ b/src/drv_mei_cpe_linux.c
-@@ -2779,7 +2779,11 @@ static int MEI_InitModuleRegCharDev(cons
+@@ -2779,7 +2779,7 @@ static int MEI_InitModuleRegCharDev(cons
              ("Using major number %d" MEI_DRV_CRLF, MAJOR(mei_devt)));
        }
  
-+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-       mei_class = class_create(THIS_MODULE, devName);
-+#else
+-      mei_class = class_create(THIS_MODULE, devName);
 +      mei_class = class_create(devName);
-+#endif
        if (IS_ERR(mei_class))
        {
           PRN_DBG_USR_NL( MEI_DRV,MEI_DRV_PRN_LEVEL_HIGH,


### PR DESCRIPTION
Two patches I found in my local tree and two from @janh, which may have fallen through the cracks on the mailing list