### PR TITLE
tools: xz: update to 5.6.4

### DIFF
--- a/tools/xz/Makefile
+++ b/tools/xz/Makefile
@@ -7,12 +7,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
-PKG_VERSION:=5.4.6
+PKG_VERSION:=5.6.4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=@SF/lzmautils \
+PKG_SOURCE_URL:=https://github.com/tukaani-project/xz/releases/download/v$(PKG_VERSION) \
+		@SF/lzmautils \
 		http://tukaani.org/xz
-PKG_HASH:=913851b274e8e1d31781ec949f1c23e8dbcf0ecf6e73a2436dc21769dd3e6f49
+PKG_HASH:=176d510c30d80a23b8050bbc048f2ecaacb823ae48b6821727ed6591f0df9200
 PKG_CPE_ID:=cpe:/a:tukaani:xz
 
 HOST_BUILD_PARALLEL:=1


### PR DESCRIPTION
The serious liblzma backdoor vulnerability (CVE-2024-3094) has been fixed since v5.6.2. It's time to bump this tool to the latest version. This patch also added a new GitHub package URL.

Changelogs:
https://github.com/tukaani-project/xz/releases/tag/v5.6.2
https://github.com/tukaani-project/xz/releases/tag/v5.6.3
https://github.com/tukaani-project/xz/releases/tag/v5.6.4