### PR TITLE
tools/autoconf: Fix 000-relocatable patch

### DIFF
--- a/tools/autoconf/patches/000-relocatable.patch
+++ b/tools/autoconf/patches/000-relocatable.patch
@@ -1,3 +1,34 @@
+--- a/bin/autoconf.in
++++ b/bin/autoconf.in
+@@ -29,7 +29,10 @@ use warnings FATAL => 'all';
+ 
+ BEGIN
+ {
+-  my $pkgdatadir = $ENV{'autom4te_perllibdir'} || '@pkgdatadir@';
++  my $pkgdatadir = $ENV{'autom4te_perllibdir'} ||
++		($ENV{'STAGING_DIR_HOST'} ?
++			$ENV{'STAGING_DIR_HOST'} . '/share/autoconf' :
++			'@pkgdatadir@');
+   unshift @INC, $pkgdatadir;
+ 
+   # Override SHELL.  On DJGPP SHELL may not be set to a shell
+@@ -44,8 +47,14 @@ use Autom4te::Channels qw(msg);
+ use Autom4te::General;
+ 
+ # Lib files.
+-my $autom4te = $ENV{'AUTOM4TE'} || '@bindir@/@autom4te-name@';
+-my $trailer_m4 = $ENV{'trailer_m4'} || '@pkgdatadir@/autoconf/trailer.m4';
++my $autom4te = $ENV{'AUTOM4TE'} ||
++	($ENV{'STAGING_DIR_HOST'} ?
++		$ENV{'STAGING_DIR_HOST'} . '/bin/@autom4te-name@' :
++		'@bindir@/@autom4te-name@');
++my $trailer_m4 = $ENV{'trailer_m4'} ||
++	($ENV{'STAGING_DIR_HOST'} ?
++		$ENV{'STAGING_DIR_HOST'} . '/share/autoconf/autoconf/trailer.m4' :
++		'@pkgdatadir@/autoconf/trailer.m4');
+ 
+ # $HELP
+ # -----
 --- a/bin/autoheader.in
 +++ b/bin/autoheader.in
 @@ -30,9 +30,12 @@ use 5.006;


### PR DESCRIPTION
cc @robimarko @Ansuel 

Fix the 000-relocatable.patch broken by e0f5ce9. The patch segment about detecting `STAGING_DIR_HOST` was erroneously removed, as upstream had deleted the previous `bin/autoconf.as` and had implemented it in perl in `bin/autoconf.in.` Re-create the previous functionality in that.

The erroneously removed section was: https://github.com/openwrt/openwrt/commit/e0f5ce9746323f0c38e49594411dbeb5394e2f15#diff-3a6566ac67b53ff73ff207e25f03fd126675208f4cd8c9882219fa074da91047L178-L195

Fixes: #18059
Fixes: e0f5ce974 ("tools/autoconf: bump to 2.72")

Compile-tested for DL-WRX36
I haven't tested this in buildbot-like environment and my perl knowledge is minimal, so I hope that somebody with perl skills and understanding about the buildbot and/or SDK checks this.
