### PR TITLE
ramips: add support for Mofi 5500

### DIFF
--- a/target/linux/ramips/dts/mt7621_mofinetwork_mofi5500-5gxelte.dts
+++ b/target/linux/ramips/dts/mt7621_mofinetwork_mofi5500-5gxelte.dts
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "mofinetwork,mofi5500-5gxelte", "mediatek,mt7621-soc";
+	model = "MoFi Network MOFI5500-5GXeLTE";
+
+	aliases {
+		label-mac-device = &wifi0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: led-0 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_BLUE>;
+			function-enumerator = <1>; // Case says Module #1
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_BLUE>;
+			function-enumerator = <2>; // Case says Module #2
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_internet: led-3 {
+			function = LED_FUNCTION_WAN_ONLINE;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e006 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&i2c {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi0: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4 0>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&sdhci {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+
+					macaddr_factory_e000: macaddr@e000 {
+						compatible = "mac-base";
+						reg = <0xe000 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_e006: macaddr@e006 {
+						compatible = "mac-base";
+						reg = <0xe006 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+				};
+
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x1ab0000>;
+			};
+
+			partition@1b00000 {
+				label = "Recovery";
+				reg = <0x1b00000 0x500000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2052,6 +2052,18 @@ define Device/mikrotik_routerboard-m33g
 endef
 TARGET_DEVICES += mikrotik_routerboard-m33g
 
+define Device/mofinetwork_mofi5500-5gxelte
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 27656k
+  DEVICE_VENDOR := MoFi Network
+  DEVICE_MODEL := MOFI5500-5GXeLTE
+  DEVICE_PACKAGES := kmod-usb3 kmod-mmc-mtk kmod-mt7615-firmware \
+	kmod-usb-net-qmi-wwan kmod-usb-net-cdc-mbim
+  SUPPORTED_DEVICES += mofi5500 # Needed in order to flash through Mofi stock firmware
+endef
+TARGET_DEVICES += mofinetwork_mofi5500-5gxelte
+
 define Device/mqmaker_witi
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -164,6 +164,9 @@ mikrotik,routerboard-m11g)
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssi3" "wlan0" "60" "100"
 	ucidef_set_led_rssi "rssiveryhigh" "RSSIVERYHIGH" "green:rssi4" "wlan0" "80" "100"
 	;;
+mofinetwork,mofi5500-5gxelte)
+	ucidef_set_led_netdev "internet" "Internet" "green:wan-online" "wan"
+	;;
 mtc,wr1201)
 	ucidef_set_led_netdev "eth_link" "LAN link" "green:eth_link" "br-lan"
 	;;


### PR DESCRIPTION
Specifications:

SoC: Mediatek MT7621AT (880 MHz MIPS dual-core, quad-thread, CPU)
512 Megabyte DDR3 SDRAM
32 Megabyte NOR Flash
4 Gigabit RJ45 PoE ports
2 MT7615N wifi chips (2.4GHz and 5GHz)
2 USB ports (1xUSB2 and 1xUSB3 - GL3510 chip)
RJ45 RS232 port on front panel (Max3232 chip)
2x mPCIe 2.0 slots for 4G/5G cards
2x SIM slot
1x SDCard Slot
Power via DC12V
4x Cell Antennae
4x Wifi Antennae

MAC Address Locations:
Purpose	Ex.		Partition	Offset
2.4 Ghz	*:01	factory		0x4
5 GHz	*:02	factory		0x8004
LAN		*:03	factory		0xe000
WAN		*:04	factory		0xe006

MAC address prefix E4:3A:65 is registered to MofiNetwork Inc and used as the prefix for all MAC addresses.

Manual: https://mofinetwork.com/files/MoFi_Network_MOFI5500_5GXeLTE_EM7690_SPECS.pdf
WiFi chip specs: https://www.mediatek.com/products/broadband-wifi/mt7615
CPU chip specs: https://www.mediatek.com/products/home-networking/mt7621

Installation:

Update Mofi 5500 to at least stock firmware version 4.8.6. (Available on the Mofi website.) Previous versions are untested in the upgrade process. Log into the LuCI web interface, usually at 192.168.10.1 and visit the 'System->Backup/Flash Firmware' page. Upload and flash the firmware as usual.

Note to Maintainers: Do not remove SUPPORTED_DEVICES from the Makefile! The customized Mofi version of OpenWRT (stock firmware) expects to see mofi5500 as the device name. The stock firmware does not allow for forcing an installation. Without this line, users cannot upload the new firmware through the stock Mofi firmware.

This device uses cell modems that could use QMI or MBIM. Add LuCI Modem Manager to allow people to use these. Also, if they have two cell network cards, ethernet, USB, or other kinds of networks, they may wish to use MWAN3 to allow failover amongst their networks. Please compile it with mwan3 for multiple WAN connections.