### PR TITLE
generic: silence led set_brightness error message

### DIFF
--- a/target/linux/generic/backport-6.6/890-v6.11-leds-core-Omit-set_brightness-error-message-for-a.patch
+++ b/target/linux/generic/backport-6.6/890-v6.11-leds-core-Omit-set_brightness-error-message-for-a.patch
@@ -1,0 +1,57 @@
+From d33d1214a1ddf9e7e4d14c62637518252927f0be Mon Sep 17 00:00:00 2001
+From: Lee Jones <lee@kernel.org>
+Date: Wed, 12 Jun 2024 16:36:40 +0100
+Subject: [PATCH] leds: core: Omit set_brightness error message for a LED
+ supporting hw trigger only
+
+If both set_brightness functions return -ENOTSUPP, then the LED doesn't
+support setting a fixed brightness value, and the error message isn't
+helpful. This can be the case e.g. for LEDs supporting a specific hw
+trigger only.
+
+Pinched the subject line and commit message from Heiner:
+Link: https://lore.kernel.org/all/44177e37-9512-4044-8991-bb23b184bf37@gmail.com/
+
+Reworked the function to provide Heiner's required semantics whilst
+simultaneously increasing readability and flow.
+
+Cc: Pavel Machek <pavel@ucw.cz>
+Cc: linux-leds@vger.kernel.org
+Suggested-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Heiner Kallweit <hkallweit1@gmail.com>
+Signed-off-by: Lee Jones <lee@kernel.org>
+---
+ drivers/leds/led-core.c | 19 +++++++++++++------
+ 1 file changed, 13 insertions(+), 6 deletions(-)
+
+--- a/drivers/leds/led-core.c
++++ b/drivers/leds/led-core.c
+@@ -122,15 +122,22 @@ static void led_timer_function(struct ti
+ static void set_brightness_delayed_set_brightness(struct led_classdev *led_cdev,
+ 						  unsigned int value)
+ {
+-	int ret = 0;
++	int ret;
+ 
+ 	ret = __led_set_brightness(led_cdev, value);
+-	if (ret == -ENOTSUPP)
++	if (ret == -ENOTSUPP) {
+ 		ret = __led_set_brightness_blocking(led_cdev, value);
+-	if (ret < 0 &&
+-	    /* LED HW might have been unplugged, therefore don't warn */
+-	    !(ret == -ENODEV && (led_cdev->flags & LED_UNREGISTERING) &&
+-	    (led_cdev->flags & LED_HW_PLUGGABLE)))
++		if (ret == -ENOTSUPP)
++			/* No back-end support to set a fixed brightness value */
++			return;
++	}
++
++	/* LED HW might have been unplugged, therefore don't warn */
++	if (ret == -ENODEV && led_cdev->flags & LED_UNREGISTERING &&
++	    led_cdev->flags & LED_HW_PLUGGABLE)
++		return;
++
++	if (ret < 0)
+ 		dev_err(led_cdev->dev,
+ 			"Setting an LED's brightness failed (%d)\n", ret);
+ }


### PR DESCRIPTION
Currently, if the phy driver does not implement the led_brightness_set
function, setting the LED will result in the following error message:

leds mdio-bus:*:green:lan: Setting an LED's brightness failed (-524)

Backport a patch to silence this error message.
