### PR TITLE
ramips: use openwrt,netdev-name to fix port name conflict on TP-Link Deco M4R v4

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_deco-m4r-v4.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_deco-m4r-v4.dts
@@ -181,19 +181,19 @@
 &gmac0 {
 	nvmem-cells = <&macaddr_config_8>;
 	nvmem-cell-names = "mac-address";
-	label = "dsa";
+	openwrt,netdev-name = "dsa";
 };
 
 &switch0 {
 	ports {
 		port@0 {
 			status = "okay";
-			label = "eth0";
+			openwrt,netdev-name = "eth0";
 		};
 
 		port@1 {
 			status = "okay";
-			label = "eth1";
+			openwrt,netdev-name = "eth1";
 		};
 	};
 };


### PR DESCRIPTION
Since 24.10.0, eth0, used for the WAN interface, does not work. From dmesg:

```
...
[    1.831126] mt7530-mdio mdio-bus:1f: MT7530 adapts as multi-chip module
[    1.846204] mtk_soc_eth 1e100000.ethernet eth0: mediatek frame engine at 0xbe100000, irq 19
...
[    1.933969] mt7530-mdio mdio-bus:1f: MT7530 adapts as multi-chip module
[    1.967668] mt7530-mdio mdio-bus:1f: configuring for fixed/rgmii link mode
[    1.975999] mt7530-mdio mdio-bus:1f eth0 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7530 PHY] (irq=21)
[    1.986907] mt7530-mdio mdio-bus:1f: Link is Up - 1Gbps/Full - flow control rx/tx
[    1.987149] mtk_soc_eth 1e100000.ethernet eth0: error -17 registering interface eth0
[    2.004157] mt7530-mdio mdio-bus:1f eth1 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7530 PHY] (irq=22)
[    2.017698] mtk_soc_eth 1e100000.ethernet eth0: entered promiscuous mode
[    2.024849] DSA: tree 0 setup
...
[    4.249680] mtk_soc_eth 1e100000.ethernet dsa: renamed from eth0
...
```

Like #15865, it seems that gmac0 does not rename eth0 to dsa until after the switch ports are initialized, leading to a name collision (error -17 = EEXIST).

This patch follows #17062 by using `openwrt,netdev-name` to fix the collision.
