### PR TITLE
hostapd/RADIUS server: configuration and logging enhancements

### DIFF
--- a/package/network/services/hostapd/files/radius.config
+++ b/package/network/services/hostapd/files/radius.config
@@ -1,6 +1,17 @@
 config radius
 	option disabled '1'
 	option ipv6 '1'
+
+	# Logging levels:
+	#   0: ALL
+	#   1: MSGDUMP
+	#   2: DEBUG
+	#   3: INFO
+	#   4: WARNING
+	#   5: ERROR
+	# Default: INFO
+	option log_level '3'
+
 	option ca_cert '/etc/radius/ca.pem'
 	option cert '/etc/radius/cert.pem'
 	option key '/etc/radius/key.pem'

--- a/package/network/services/hostapd/files/radius.config
+++ b/package/network/services/hostapd/files/radius.config
@@ -1,5 +1,6 @@
 config radius
 	option disabled '1'
+	option ipv6 '1'
 	option ca_cert '/etc/radius/ca.pem'
 	option cert '/etc/radius/cert.pem'
 	option key '/etc/radius/key.pem'

--- a/package/network/services/hostapd/files/radius.init
+++ b/package/network/services/hostapd/files/radius.init
@@ -13,6 +13,7 @@ radius_start() {
 	[ "$disabled" -gt 0 ] && return
 
 	config_get_bool ipv6 "$cfg" ipv6 1
+	config_get log_level "$cfg" log_level 3
 	config_get ca "$cfg" ca_cert
 	config_get key "$cfg" key
 	config_get cert "$cfg" cert
@@ -24,12 +25,14 @@ radius_start() {
 
 	procd_open_instance $cfg
 	procd_set_param command /usr/sbin/hostapd-radius \
-		-C "$ca" \
+		-l "$log_level" -C "$ca" \
 		-c "$cert" -k "$key" \
 		-s "$clients" -u "$users" \
 		-p "$auth_port" -P "$acct_port" \
 		-i "$identity"
 	[ "$ipv6" -gt 0 ] && procd_append_param command -6
+	procd_set_param stdout 1
+	procd_set_param stderr 1
 	procd_close_instance
 }
 

--- a/package/network/services/hostapd/files/radius.init
+++ b/package/network/services/hostapd/files/radius.init
@@ -12,6 +12,7 @@ radius_start() {
 
 	[ "$disabled" -gt 0 ] && return
 
+	config_get_bool ipv6 "$cfg" ipv6 1
 	config_get ca "$cfg" ca_cert
 	config_get key "$cfg" key
 	config_get cert "$cfg" cert
@@ -28,6 +29,7 @@ radius_start() {
 		-s "$clients" -u "$users" \
 		-p "$auth_port" -P "$acct_port" \
 		-i "$identity"
+	[ "$ipv6" -gt 0 ] && procd_append_param command -6
 	procd_close_instance
 }
 

--- a/package/network/services/hostapd/src/hostapd/radius.c
+++ b/package/network/services/hostapd/src/hostapd/radius.c
@@ -624,7 +624,6 @@ int radius_main(int argc, char **argv)
 	int ch;
 
 	wpa_debug_setup_stdout();
-	wpa_debug_level = 0;
 
 	if (eloop_init()) {
 		wpa_printf(MSG_ERROR, "Failed to initialize event loop");
@@ -634,10 +633,13 @@ int radius_main(int argc, char **argv)
 	eap_server_register_methods();
 	radius_init(&state);
 
-	while ((ch = getopt(argc, argv, "6C:c:d:i:k:K:p:P:s:u:")) != -1) {
+	while ((ch = getopt(argc, argv, "6l:C:c:d:i:k:K:p:P:s:u:")) != -1) {
 		switch (ch) {
 		case '6':
 			config.radius.ipv6 = 1;
+			break;
+		case 'l':
+			wpa_debug_level = atoi(optarg);
 			break;
 		case 'C':
 			config.tls.ca_cert = optarg;


### PR DESCRIPTION
Even though IPv6 support for hostapd RADIUS server is implemented (flag `-6`), it's not possible to enable it from configuration.

Logging level of the RADIUS server is a constant corresponding to the highest verbosity (EXCESSIVE, ALL), but when running as a system service, the output is discarded anyway.

This commits add missing `ipv6` UCI config option, make logging verbosity configurable by `log_level` option and redirect all server logs to `logd`.