### PR TITLE
qualcommax: fix upgrade function for Linksys MX dual boot devices

### DIFF
--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
@@ -27,7 +27,7 @@ remove_oem_ubi_volume() {
 	fi
 }
 
-linksys_mx_do_upgrade() {
+linksys_mx_pre_upgrade() {
 	local setenv_script="/tmp/fw_env_upgrade"
 
 	CI_UBIPART="rootfs"
@@ -63,7 +63,6 @@ linksys_mx_do_upgrade() {
 			return 1
 		}
 	fi
-	nand_do_upgrade "$1"
 }
 
 platform_check_image() {
@@ -75,8 +74,9 @@ platform_do_upgrade() {
 	linksys,mx2000|\
 	linksys,mx5500|\
 	linksys,spnmx56)
+		linksys_mx_pre_upgrade "$1"
 		remove_oem_ubi_volume squashfs
-		linksys_mx_do_upgrade "$1"
+		nand_do_upgrade "$1"
 		;;
 	*)
 		default_do_upgrade "$1"

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -108,7 +108,7 @@ tplink_do_upgrade() {
 	nand_do_upgrade "$1"
 }
 
-linksys_mx_do_upgrade() {
+linksys_mx_pre_upgrade() {
 	local setenv_script="/tmp/fw_env_upgrade"
 
 	CI_UBIPART="rootfs"
@@ -144,7 +144,6 @@ linksys_mx_do_upgrade() {
 			return 1
 		}
 	fi
-	nand_do_upgrade "$1"
 }
 
 platform_check_image() {
@@ -222,13 +221,15 @@ platform_do_upgrade() {
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
 	linksys,mx4300)
+		linksys_mx_pre_upgrade "$1"
 		remove_oem_ubi_volume squashfs
-		linksys_mx_do_upgrade "$1"
+		nand_do_upgrade "$1"
 		;;
 	linksys,mx5300|\
 	linksys,mx8500)
+		linksys_mx_pre_upgrade "$1"
 		remove_oem_ubi_volume ubifs
-		linksys_mx_do_upgrade "$1"
+		nand_do_upgrade "$1"
 		;;
 	prpl,haze|\
 	qnap,301w)


### PR DESCRIPTION
Function remove_oem_ubi_volume was called before CI_UBIPART variable was defined.
