### PR TITLE
include: move generic riscv64 ISA to rv64gc

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -274,8 +274,8 @@ ifeq ($(DUMP),1)
     CPU_CFLAGS_archs = -mcpu=archs
   endif
   ifeq ($(ARCH),riscv64)
-    CPU_TYPE ?= riscv64
-    CPU_CFLAGS_riscv64:=-mabi=lp64d -march=rv64imafdc
+    CPU_TYPE ?= generic
+    CPU_CFLAGS_generic:=-mabi=lp64d -march=rv64gc
   endif
   ifeq ($(ARCH),loongarch64)
     CPU_TYPE ?= generic


### PR DESCRIPTION
The current CFLAGS (rv64imafdc) for the riscv64 targets do not contain the full generic compute extension (g), as that also includes the zicsr and zifencei extensions/instructions. Rename the default ISA to 'generic' to add distinction to the current binaries (although it's very minimal), and use rv64gc for CFLAGS.

This is also a prep step for the upcoming gcv (vector-extension supporting) targets like the Spacemit K1, and the thead-cores like the TH1520.

Compile-tested: all riscv64 targets
Runtime-tested:
 - SiFive Unleashed (FU540)
 - SiFive Unmatched (FU740)
 - Nezha D1 (D1)
 - VisionFive2 (JH7110)
