### PR TITLE
optee-os.mk: override default PATH to not use hostpkg python

### DIFF
--- a/include/optee-os.mk
+++ b/include/optee-os.mk
@@ -85,7 +85,7 @@ endef
 
 define Build/Compile/Optee-os
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
-		PATH=$(LINUX_DIR)/scripts/dtc/:$(PATH) \
+		PATH=$(LINUX_DIR)/scripts/dtc/:$(STAGING_DIR_HOST)/bin:$(PATH) \
 		CROSS_COMPILE=$(TARGET_CROSS) \
 		CROSS_COMPILE_core="$(TARGET_CROSS)" \
 		CROSS_COMPILE_ta_arm64="$(TARGET_CROSS)" \


### PR DESCRIPTION
In some cases hostpkg python from packages feed is used (hostpkg has higher priority in PATH) which causes build failure (cryptography module is missing). So override PATH to not use hostpkg python.

Shall also be backported to openwrt-24.10