### PR TITLE
qualcommax: dts: fix PCI unit address format error

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
@@ -562,7 +562,7 @@
 
 	perst-gpio = <&tlmm 62 GPIO_ACTIVE_HIGH>;
 
-	bridge@1,0 {
+	bridge@0,0 {
 		reg = <0x00010000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
@@ -299,7 +299,7 @@
 
 	perst-gpio = <&tlmm 61 GPIO_ACTIVE_LOW>;
 
-	bridge@1,0 {
+	bridge@0,0 {
 		reg = <0x00010000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
@@ -469,7 +469,7 @@
 
 	perst-gpio = <&tlmm 62 GPIO_ACTIVE_HIGH>;
 
-	bridge@1,0 {
+	bridge@0,0 {
 		reg = <0x00010000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;


### PR DESCRIPTION
arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts:473.13-478.4: Warning (pci_device_reg): /soc@0/pci@10000000/bridge@1,0: PCI unit address format error, expected "0,0"
arch/arm64/boot/dts/qcom/ipq8072-haze.dts:303.13-318.4: Warning (pci_device_reg): /soc@0/pci@10000000/bridge@1,0: PCI unit address format error, expected "0,0"
arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts:566.13-582.4: Warning (pci_device_reg): /soc@0/pci@10000000/bridge@1,0: PCI unit address format error, expected "0,0"
