### PR TITLE
ath79: add support for Fortinet FAP-221-C

### DIFF
--- a/target/linux/ath79/dts/qca9557_fortinet_fap-221-c.dts
+++ b/target/linux/ath79/dts/qca9557_fortinet_fap-221-c.dts
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	compatible = "fortinet,fap-221-c", "qca,qca9557";
+	model = "Fortinet FAP-221-C";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,9600";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&enable_gpio_2_3 &jtag_disable_pins>;
+
+		led_power: power_green {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wifi1_green {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi1_amber {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2_green {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi2_amber {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		warning_green {
+			function = "warning";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		};
+
+		warning_amber {
+			function = "warning";
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		lan_green {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+	
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwconcat0 &fwconcat1 &fwconcat2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x73714f4b>;
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&pinmux {
+	enable_gpio_2_3: pinmux_enable_gpio_2_3 {
+		pinctrl-single,bits = <0x00 0x0  0xffff0000>;
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			uboot: partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_3ff80: mac-address@3ff80 {
+						compatible = "mac-base";
+						reg = <0x3ff80 0xc>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			fwconcat0: partition@40000 {
+				label = "fwconcat0";
+				reg = <0x0040000 0x1400000>;
+			};
+
+			partition@1440000 {
+				label = "loader";
+				reg = <0x1440000 0x0010000>;
+			};
+
+			fwconcat1: partition@145000 {
+				label = "fwconcat1";
+				reg = <0x1450000 0x03f0000>;
+			};
+
+			fwconcat2: partition@1840000 {
+				label = "reserved";
+				reg = <0x1840000 0x07b0000>;
+			};
+
+			art: partition@1ff0000 {
+				label = "art";
+				reg = <0x1ff0000 0x0010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+	nvmem-cells = <&macaddr_uboot_3ff80 0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-handle = <&phy5>;
+	phy-mode = "rgmii-id";
+
+	pll-data = <0x82000000 0x80000101 0x80001313>;
+};
+
+&wmac {
+	status = "okay";
+	
+	nvmem-cells = <&calibration_wmac>, <&macaddr_uboot_3ff80 1>;
+	nvmem-cell-names = "calibration", "mac-address";
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0 0 0 0 0>;
+		nvmem-cells = <&calibration_pcie>, <&macaddr_uboot_3ff80 2>;
+		nvmem-cell-names = "calibration", "mac-address";
+	};
+};
+
+&art {
+	  nvmem-layout {
+		  compatible = "fixed-layout";
+		  #address-cells = <1>;
+		  #size-cells = <1>;
+
+		  calibration_wmac: calibration@1000 {
+			  reg = <0x1000 0x440>;
+		  };
+
+		  calibration_pcie: calibration@5000 {
+			  reg = <0x5000 0x844>;
+		  };
+	  };
+};
+

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -50,6 +50,7 @@ ath79_setup_interfaces()
 	extreme-networks,ws-ap3805i|\
 	fortinet,fap-220-b|\
 	fortinet,fap-221-b|\
+	fortinet,fap-221-c|\
 	glinet,gl-ar300m-lite|\
 	glinet,gl-usb150|\
 	hak5,wifi-pineapple-nano|\

--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
@@ -68,7 +68,8 @@ platform_do_upgrade() {
 		platform_do_upgrade_failsafe_datachk "$1"
 		;;
 	fortinet,fap-220-b|\
-	fortinet,fap-221-b)
+	fortinet,fap-221-b|\
+	fortinet,fap-221-c)
 		SKIP_HASH="1"
 		ENV_SCRIPT="/dev/null"
 		IMAGE_LIST="tar tzf $1"

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1669,6 +1669,23 @@ define Device/fortinet_fap-221-b
 endef
 TARGET_DEVICES += fortinet_fap-221-b
 
+define Device/fortinet_fap-221-c
+  $(Device/senao_loader_okli)
+  SOC := qca9557
+  DEVICE_VENDOR := Fortinet
+  DEVICE_MODEL := FAP-221-C
+  FACTORY_IMG_NAME := FP221C-9.99-AP-build999-999999-patch99
+  DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
+  IMAGE_SIZE := 20480k
+  LOADER_FLASH_OFFS := 0x040000
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+        append-rootfs | pad-rootfs | \
+        check-size | pad-to $$$$(IMAGE_SIZE) | \
+        append-loader-okli-uimage $(1) | pad-to 11520k | \
+        gzip-filename $$$$(FACTORY_IMG_NAME)
+endef
+TARGET_DEVICES += fortinet_fap-221-c
+
 define Device/glinet_6408
   $(Device/tplink-8mlzma)
   SOC := ar9331


### PR DESCRIPTION
FCC ID: TVE-121402

Fortinet FAP-221-C is an indoor access point with 1gb ethernet port, dual-band wireless, internal antenna plates, and 802.3at PoE+.

Hardware and board design are from Senao. The device appears very similar to the EnGenius EAP1200H, albeit with double the flash and RAM.

**Specifications:**

  - QCA9557 SOC
  - QCA9882 WLAN PCI card, 5 GHz, 2x2, 26dBm
  - AR8035-A PHY RGMII GbE with PoE+ IN
  - 40 MHz clock
  - 32 MB FLASH FL256SAIFR0
  - 2x 128 MB RAM NT5TU64M16HG
  - UART populated
  - 4 internal antenna plates
  - 5 LEDs, 1 button (power, 'warning', eth0, wifi1, wifi2) (reset)

  Amber LAN LED appears hardwired to ethernet port. Power LED is green
only. Other LEDs are amber/green.

**MAC addresses:**

1 MAC Address in flash at end of uboot
ASCII encoded, no delimiters
Labeled as "MAC Address" on case

**Serial Access:**

Pinout: (arrow) VCC GND RX TX

Pins are populated with a header and traces not blocked. Bootloader is set to 9600 baud, 8 data, 1 stop.

**Console Access:**

Bootloader:

Interrupt boot with Ctrl+C
Press "k" and enter password "1"
OR
Hold reset button for 5 sec during power on
Interrupt the TFTP transfer with Ctrl+C

to print commands available, enter "help"

OEM:

default username is "admin", password blank
telnet is available at default address 192.168.1.2 serial is available with baud 9600

to print commands available, enter "help"
or tab-tab (busybox list of commands)

**Installation:**

Use factory.bin with OEM upgrade procedures
OR
Use initramfs.bin with uboot TFTP commands.
Then perform a sysupgrade with sysupgrade.bin

**TFTP Recovery:**

Using serial console, load initramfs.bin using TFTP to boot openwrt without touching the flash.

**Return to OEM:**

The best way to return to OEM firmware
is to have a copy of the MTD partitions
before flashing Openwrt.

Backup copies should be made of partitions
"fwconcat0", "loader", and "fwconcat1"
which together is the same flash range
as OEM's "rootfs" and "uimage"
by loading an initramfs.bin
and using LuCI to download the mtdblocks.

It is also possible to extract from the
OEM firmware upgrade image by splitting it up
in parts of lengths that correspond
to the partitions in openwrt
and write them to flash,
after gzip decompression.

After writing to the firmware partitions,
erase the "reserved" partition and reboot.

Signed-off-by: Bernardus Jansen <bernardus@bajansen.nl>
