### PR TITLE
kernel: kmod-btmtk: Extract btmtk.ko into own package

### DIFF
--- a/package/kernel/linux/modules/bluetooth.mk
+++ b/package/kernel/linux/modules/bluetooth.mk
@@ -60,7 +60,7 @@ $(eval $(call KernelPackage,hci-uart))
 define KernelPackage/btusb
   SUBMENU:=$(BLUETOOTH_MENU)
   TITLE:=Bluetooth HCI USB support
-  DEPENDS:=@USB_SUPPORT +kmod-usb-core +kmod-bluetooth
+  DEPENDS:=@USB_SUPPORT +kmod-usb-core +kmod-bluetooth +kmod-btmtk
   KCONFIG:= \
 	CONFIG_BT_HCIBTUSB \
 	CONFIG_BT_HCIBTUSB_BCM=n \
@@ -69,8 +69,7 @@ define KernelPackage/btusb
   FILES:= \
 	$(LINUX_DIR)/drivers/bluetooth/btusb.ko \
 	$(LINUX_DIR)/drivers/bluetooth/btintel.ko \
-	$(LINUX_DIR)/drivers/bluetooth/btrtl.ko \
-	$(LINUX_DIR)/drivers/bluetooth/btmtk.ko
+	$(LINUX_DIR)/drivers/bluetooth/btrtl.ko
   AUTOLOAD:=$(call AutoProbe,btusb)
 endef
 
@@ -79,6 +78,18 @@ define KernelPackage/btusb/description
 endef
 
 $(eval $(call KernelPackage,btusb))
+
+
+define KernelPackage/btmtk
+  SUBMENU:=$(BLUETOOTH_MENU)
+  TITLE:=MTK Bluetooth support
+  HIDDEN:=1
+  DEPENDS:=+kmod-bluetooth
+  KCONFIG:=CONFIG_BT_MTK
+  FILES:=$(LINUX_DIR)/drivers/bluetooth/btmtk.ko
+endef
+
+$(eval $(call KernelPackage,btmtk))
 
 
 define KernelPackage/ath3k

--- a/target/linux/mediatek/modules.mk
+++ b/target/linux/mediatek/modules.mk
@@ -18,7 +18,7 @@ $(eval $(call KernelPackage,ata-ahci-mtk))
 define KernelPackage/btmtkuart
   SUBMENU:=Other modules
   TITLE:=MediaTek HCI UART driver
-  DEPENDS:=@TARGET_mediatek_mt7622 +kmod-bluetooth +mt7622bt-firmware
+  DEPENDS:=@TARGET_mediatek_mt7622 +kmod-bluetooth +kmod-btmtk +mt7622bt-firmware
   KCONFIG:=CONFIG_BT_MTKUART
   FILES:= \
 	$(LINUX_DIR)/drivers/bluetooth/btmtkuart.ko


### PR DESCRIPTION
btmtk.ko is used by btusb.ko and btmtkuart.ko, add it into an own package and make both packages depend on it.

Fixes: 1c42a0be3619 ("kernel: modules: bluetooth: separating UART and USB drivers")
