### PR TITLE
[WiP] kirkwood: Add partial support for D-Link DGS-1210-10P B1

### DIFF
--- a/target/linux/kirkwood/files-6.6/arch/arm/boot/dts/marvell/kirkwood-dgs-1210-10p-b1.dts
+++ b/target/linux/kirkwood/files-6.6/arch/arm/boot/dts/marvell/kirkwood-dgs-1210-10p-b1.dts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Device Tree file for D-Link DGS-1210-10P (B1)
+ *
+ * Copyright (C) 2025, Linus Lüssing <linus.luessing@c0d3.blue>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version
+ * 2 of the License, or (at your option) any later version.
+ */
+
+/dts-v1/;
+
+#include "kirkwood.dtsi"
+#include "kirkwood-98dx4122.dtsi"
+
+/ {
+	model = "D-Link DGS-1210-10P (B1)";
+	compatible = "d-link,dgs-1210-10p-b1", "marvell,kirkwood-98DX4122", "marvell,kirkwood";
+
+	aliases {
+		serial0 = &uart0;
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200 earlyprintk";
+		stdout-path = "serial0:115200n8";
+	};
+
+	ocp@f1000000 {
+		serial@12000 {
+			status = "okay";
+		};
+
+                core_clk: core-clocks@10030 {
+                        compatible = "marvell,mv98dx3053b0-core-clock";
+                        reg = <0x10030 0x4>;
+                        #clock-cells = <1>;
+                };
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x00000000 0x00080000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x00080000 0x00080000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "kernel";
+				reg = <0x00100000 0x00200000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "rootfs";
+				reg = <0x00300000 0x00900000>;
+				read-only;
+			};
+
+			partition@c00000 {
+				label = "jffs2";
+				reg = <0x00c00000 0x00400000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -189,6 +189,13 @@ define Device/dlink_dns320l
 endef
 TARGET_DEVICES += dlink_dns320l
 
+define Device/d-link_dgs-1210-10p-b1
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DGS-1210-10P-B1
+  IMAGE_SIZE := 15360k
+endef
+TARGET_DEVICES += d-link_dgs-1210-10p-b1
+
 define Device/endian_4i-edge-200
   DEVICE_VENDOR := Endian
   DEVICE_MODEL := 4i Edge 200

--- a/target/linux/kirkwood/patches-6.6/119-clk-kirkwood-Add-support-for-Marvell-98DX3053B0.patch
+++ b/target/linux/kirkwood/patches-6.6/119-clk-kirkwood-Add-support-for-Marvell-98DX3053B0.patch
@@ -1,0 +1,235 @@
+From 5ecf24089a7af962bb0f848c3aeef6e2e5ab8622 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+Date: Sat, 15 Feb 2025 20:56:49 +0100
+Subject: [PATCH] clk: kirkwood: Add support for Marvell 98DX3053B0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This adds support for the Marvell 98DX3053B0, a switch SoC from the
+Kirkwood family.
+
+The 98DX3053B0 seems generally bootable via "marvell,kirkwood-core-clock",
+but would output unreadable output on the UART on a
+D-Link DGS-1210-10P rev. B1 switch due to a wrong tclk internal bus clock.
+
+I don't have a datasheet for this chip but got the correct offsets and
+methods to get the CPU, TCLK, RAM and L2 frequencies via SAR0 from the
+original vendor's source code of the D-Link DGS-1210-10P rev. B1 (*).
+
+I could verify that they would result in the same frequencies as the
+original vendor firmware's u-boot would output on this device during
+boot, with:
+
+* cpuclk: 500 MHz
+* tclk: 167 MHz
+* l2clk: 250 MHz
+* ddrclk: 250 MHz
+
+Also: u-boot would say "MARVELL BOARD: DB-98DX4122-48G (Rev 2) LE"
+and "Soc: MV88F6281 Rev 3 (DDR2)". However the printing on the SoC would
+mention none of these two and instead says 98DX3053B0. The "pci" command
+in u-boot would further say: "The chip type is xCat2." and
+"The chip package is QFP." which helped to identify the specific
+sections in the vendor source code.
+
+(*): One small change from the original source code: It would have two
+entries with 600 MHz, instead of 600 MHz + 660 MHz in the CPU clocks
+array. I assumed that this was a bug/typo, as the code comment right
+above it would say 600+660 MHz.
+
+Link: https://openwrt.org/toh/d-link/dgs-1210#availability_of_source_code
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+---
+ drivers/clk/mvebu/kirkwood.c | 121 ++++++++++++++++++++++++++++++++++-
+ 1 file changed, 120 insertions(+), 1 deletion(-)
+
+--- a/drivers/clk/mvebu/kirkwood.c
++++ b/drivers/clk/mvebu/kirkwood.c
+@@ -22,7 +22,8 @@
+  * Core Clocks
+  *
+  * Kirkwood PLL sample-at-reset configuration
+- * (6180 has different SAR layout than other Kirkwood SoCs)
++ * (6180 and mv98dx3053b0 have different SAR layouts than other
++ *  Kirkwood SoCs)
+  *
+  * SAR0[4:3,22,1] : CPU frequency (6281,6292,6282)
+  *	4  =  600 MHz
+@@ -35,12 +36,28 @@
+  *	15 = 2000 MHz
+  *	others reserved.
+  *
++ * SAR0[4:3,22,1] : CPU frequency (mv98dx3053b0)
++ *	0 = 333 MHz
++ *	1 = 400 MHz
++ *	2 = 533 MHz
++ *	3 = 600 MHz
++ *	4 = 660 MHz
++ *	5 = 800 MHz
++ *	others reserved.
++ *
+  * SAR0[19,10:9] : CPU to L2 Clock divider ratio (6281,6292,6282)
+  *	1 = (1/2) * CPU
+  *	3 = (1/3) * CPU
+  *	5 = (1/4) * CPU
+  *	others reserved.
+  *
++ * SAR0[19,10:9] : CPU to L2 Clock divider ratio (mv98dx3053b0)
++ *	0 = (2/5) * CPU
++ *	1 = (1/2) * CPU
++ *	2 = (2/5) * CPU
++ *	3 = (1/3) * CPU
++ *	others reserved.
++ *
+  * SAR0[8:5] : CPU to DDR DRAM Clock divider ratio (6281,6292,6282)
+  *	2 = (1/2) * CPU
+  *	4 = (1/3) * CPU
+@@ -50,6 +67,16 @@
+  *	9 = (1/6) * CPU
+  *	others reserved.
+  *
++ * SAR0[8:5] : CPU to DDR DRAM Clock divider ratio (mv98dx3053b0)
++ *	2 = (1/2) * CPU
++ *	3 = (2/5) * CPU
++ *	4 = (1/3) * CPU
++ *	6 = (1/4) * CPU
++ *	7 = (2/9) * CPU
++ *	8 = (1/5) * CPU
++ *	9 = (1/6) * CPU
++ *	others reserved.
++ *
+  * SAR0[4:2] : Kirkwood 6180 cpu/l2/ddr clock configuration (6180 only)
+  *	5 = [CPU =  600 MHz, L2 = (1/2) * CPU, DDR = 200 MHz = (1/3) * CPU]
+  *	6 = [CPU =  800 MHz, L2 = (1/2) * CPU, DDR = 200 MHz = (1/4) * CPU]
+@@ -60,6 +87,16 @@
+  *	0 = 200 MHz
+  *	1 = 166 MHz
+  *	others reserved.
++ *
++ * SAR0[28] : TCLK frequency (mv98dx3053b0)
++ *	0 = 250 MHz
++ *	1 = 220 MHz
++ *	2 = 200 MHz
++ *	3 = 182 MHz
++ *	4 = 167 MHz
++ *	5 = 154 MHz
++ *	6 = 133 MHz
++ *	others reserved.
+  */
+ 
+ #define SAR_KIRKWOOD_CPU_FREQ(x)	\
+@@ -75,6 +112,8 @@
+ #define SAR_MV88F6180_CLK_MASK		0x7
+ #define SAR_KIRKWOOD_TCLK_FREQ		21
+ #define SAR_KIRKWOOD_TCLK_FREQ_MASK	0x1
++#define SAR_MV98DX3053B0_TCLK_FREQ	28
++#define SAR_MV98DX3053B0_TCLK_FREQ_MASK	0x7
+ 
+ enum { KIRKWOOD_CPU_TO_L2, KIRKWOOD_CPU_TO_DDR };
+ 
+@@ -190,6 +229,74 @@ static u32 __init mv98dx1135_get_tclk_fr
+ 	return 166666667;
+ }
+ 
++static const u32 mv98dx3053b0_tclk_freqs[] __initconst = {
++	250000000,
++	220000000,
++	200000000,
++	182000000,
++	167000000,
++	154000000,
++	133000000,
++};
++
++static u32 __init mv98dx3053b0_get_tclk_freq(void __iomem *sar)
++{
++	u32 opt = (readl(sar) >> SAR_MV98DX3053B0_TCLK_FREQ) &
++		SAR_MV98DX3053B0_TCLK_FREQ_MASK;
++	return mv98dx3053b0_tclk_freqs[opt];
++}
++
++static const u32 mv98dx3053b0_cpu_freqs[] __initconst = {
++	333000000,
++	400000000,
++	500000000,
++	533000000,
++	600000000,
++	660000000,
++	800000000,
++	0,
++};
++
++static u32 __init mv98dx3053b0_get_cpu_freq(void __iomem *sar)
++{
++	u32 opt = SAR_KIRKWOOD_CPU_FREQ(readl(sar));
++	return mv98dx3053b0_cpu_freqs[opt];
++}
++
++static const int mv98dx3053b0_cpu_l2_ratios[8][2] __initconst = {
++	{ 2, 5 }, { 1, 2 }, { 2, 5 }, { 1, 3 },
++	{ 0, 1 }, { 0, 1 }, { 0, 1 }, { 0, 1 }
++};
++
++static const int mv98dx3053b0_cpu_ddr_ratios[16][2] __initconst = {
++	{0, 1}, {0, 1}, {1, 2}, {2, 5},
++	{1, 3}, {0, 1}, {1, 4}, {2, 9},
++	{1, 5}, {1, 6}, {0, 1}, {0, 1},
++	{0, 1}, {0, 1}, {0, 1}, {0, 1}
++};
++
++static void __init mv98dx3053b0_get_clk_ratio(
++	void __iomem *sar, int id, int *mult, int *div)
++{
++	switch (id) {
++	case KIRKWOOD_CPU_TO_L2:
++	{
++		u32 opt = SAR_KIRKWOOD_L2_RATIO(readl(sar));
++		*mult = mv98dx3053b0_cpu_l2_ratios[opt][0];
++		*div = mv98dx3053b0_cpu_l2_ratios[opt][1];
++		break;
++	}
++	case KIRKWOOD_CPU_TO_DDR:
++	{
++		u32 opt = (readl(sar) >> SAR_KIRKWOOD_DDR_RATIO) &
++			SAR_KIRKWOOD_DDR_RATIO_MASK;
++		*mult = mv98dx3053b0_cpu_ddr_ratios[opt][0];
++		*div = mv98dx3053b0_cpu_ddr_ratios[opt][1];
++		break;
++	}
++	}
++}
++
+ static const struct coreclk_soc_desc kirkwood_coreclks = {
+ 	.get_tclk_freq = kirkwood_get_tclk_freq,
+ 	.get_cpu_freq = kirkwood_get_cpu_freq,
+@@ -214,6 +321,14 @@ static const struct coreclk_soc_desc mv9
+ 	.num_ratios = ARRAY_SIZE(kirkwood_coreclk_ratios),
+ };
+ 
++static const struct coreclk_soc_desc mv98dx3053b0_coreclks = {
++	.get_tclk_freq = mv98dx3053b0_get_tclk_freq,
++	.get_cpu_freq = mv98dx3053b0_get_cpu_freq,
++	.get_clk_ratio = mv98dx3053b0_get_clk_ratio,
++	.ratios = kirkwood_coreclk_ratios,
++	.num_ratios = ARRAY_SIZE(kirkwood_coreclk_ratios),
++};
++
+ /*
+  * Clock Gating Control
+  */
+@@ -341,6 +456,8 @@ static void __init kirkwood_clk_init(str
+ 		mvebu_coreclk_setup(np, &mv88f6180_coreclks);
+ 	else if (of_device_is_compatible(np, "marvell,mv98dx1135-core-clock"))
+ 		mvebu_coreclk_setup(np, &mv98dx1135_coreclks);
++	else if (of_device_is_compatible(np, "marvell,mv98dx3053b0-core-clock"))
++		mvebu_coreclk_setup(np, &mv98dx3053b0_coreclks);
+ 	else
+ 		mvebu_coreclk_setup(np, &kirkwood_coreclks);
+ 
+@@ -357,3 +474,5 @@ CLK_OF_DECLARE(mv88f6180_clk, "marvell,m
+ 	       kirkwood_clk_init);
+ CLK_OF_DECLARE(98dx1135_clk, "marvell,mv98dx1135-core-clock",
+ 	       kirkwood_clk_init);
++CLK_OF_DECLARE(98dx3053b0_clk, "marvell,mv98dx3053b0-core-clock",
++	       kirkwood_clk_init);


### PR DESCRIPTION
This adds partial support for the D-Link DGS-1210-10P B1, a 10 copper + 2 SFP ports PoE switch.

Specifications:

* SoC/CPU: Marvell 98DX3053B0 (500 MHz)
* RAM: 128 MiB (Nanya NT5TU64M16GG-AC)
* Flash: 16 MiB (Macronix MX25L12845EMI-10G)
* Switch1: Marvell 88E1543-LKJ2 (2x copper + 2x SFP)
* Switch2: Marvell 88E1545-LKJ2 (4x copper)
* Switch3: Marvell 88E1545-LKJ2 (4x copper)
* UART0: 115200,8n1, 3.3V on JP4 (pinout: VCC/TX/RX/GND)

Booting an initramfs image via TFTP:

* set your network IP to 10.90.90.5/8, attach a network cable, start TFTP server with initramfs image
* attach serial to JP4/UART0
* power on device, hit enter to interrupt boot process, to enter u-boot console
* DGS-1210-10P>> tftpboot $(linux_loadaddr) <openwrt-initramfs-uImage-name.img>
* DGS-1210-10P>> bootm

WiP/unsupported:

* Switch1/2/3 -> any ethernet
* PoE (uses a daughter board which the Marvell SoC communicates with)
* sysupgrade and factory flashing