### PR TITLE
ramips: mt7621: add support for Arcadyan WG630223

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -88,7 +88,10 @@ mtd_get_mac_ascii() {
 
 mtd_get_mac_encrypted_arcadyan() {
 	local iv="00000000000000000000000000000000"
-	local key="2A4B303D7644395C3B2B7053553C5200"
+	local key="$2"
+	if [ -z "$2" ]; then
+		key="2A4B303D7644395C3B2B7053553C5200"
+	fi
 	local mac_dirty
 	local mtdname="$1"
 	local part

--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -142,6 +142,10 @@ zyxel,ex5601-t0)
 zyxel,ex5700-telenor)
 	ubootenv_add_uci_config "/dev/ubootenv" "0x0" "0x4000" "0x4000" "1"
 	;;
+arcadyan,wg620443)
+	local envdev=/dev/mtd$(find_mtd_index "u-boot-env")
+	ubootenv_add_uci_config "$envdev" "0x0" "0x20000" "0x20000" "1"
+	;;
 esac
 
 config_load ubootenv

--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -84,6 +84,9 @@ netis,n6|\
 zyxel,wsm20)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
+arcadyan,wg630223)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x80000"
+	;;
 haier,har-20s2u1|\
 sim,simax1800t)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"

--- a/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
+++ b/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
@@ -1,0 +1,397 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	model = "Arcadyan WG620443";
+	compatible = "arcadyan,wg620443", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+		ethernet0 = &gmac0;
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+
+		// Stock U-Boot crashes unless /chosen/bootargs exists
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+
+	keys {
+		compatible = "gpio-keys";
+		poll-interval = <20>;
+
+		reset-button {
+			label = "reset";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: red {
+			label = "red:net";
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_status_green: green {
+			label = "green:net";
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_status_blue: blue {
+			label = "blue:net";
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+	};
+
+};
+
+&eth {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&mdio {
+	reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <50000>;
+	reset-post-delay-us = <20000>;
+
+	phy5: phy@5 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <5>;
+		mxl,led-config = <0x0 0x0 0x370 0x380>;
+	};
+
+	phy6: phy@6 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <6>;
+		mxl,led-config = <0x0 0x0 0x370 0x380>;
+	};
+
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+	};
+
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "wan";
+			phy-handle = <&swphy0>;
+		};
+		
+		port@1 {
+			reg = <1>;
+			label = "lan1";
+			phy-handle = <&swphy1>;
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+
+	};
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		swphy0: phy@0 {
+			reg = <0>;
+
+			mediatek,led-config = <
+				0x21 0x8009 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0x8000 /* LED0_ON_CTRL */
+				0x25 0x0000 /* LED0_BLINK_CTRL */
+				0x26 0xc007 /* LED1_ON_CTRL */
+				0x27 0x003f /* LED1_BLINK_CTRL */
+			>;
+		};
+
+		swphy1: phy@1 {
+			reg = <1>;
+
+			mediatek,led-config = <
+				0x21 0x8009 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0x8000 /* LED0_ON_CTRL */
+				0x25 0x0000 /* LED0_BLINK_CTRL */
+				0x26 0xc007 /* LED1_ON_CTRL */
+				0x27 0x003f /* LED1_BLINK_CTRL */
+			>;
+		};
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie_pins>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			mediatek,mtd-eeprom = <&factory 0xa0000>;
+		};
+	};
+};
+
+&pcie_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};
+
+&pio {
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "switch_int", "mdc_mdio";
+		};
+	};
+
+	pcie_pins: pcie-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_pereset"; // "pcie_clk" and "pcie_wake" is unused?
+		};
+	};
+
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <8>;
+			mediatek,pull-down-adv = <0>; /* bias-disable */
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	cs-gpios = <0>, <0>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+	};
+
+	flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		spi-max-frequency = <20000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x000000 0x100000>;
+				read-only;
+			};
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+			};
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x2400000>;
+			};
+			partition@2980000 {
+				label = "Kernel2";
+				reg = <0x2980000 0x2400000>;
+			};
+			partition@4d80000 {
+				label = "pricfg";
+				reg = <0x4d80000 0x200000>;
+			};
+
+			partition@4f80000 {
+				label = "seccfg";
+				reg = <0x4f80000 0x200000>;
+			};
+
+			partition@5180000 {
+				label = "arc_log";
+				reg = <0x5180000 0x200000>;
+			};
+
+		 	partition@5380000 {
+				label = "board_data";
+				reg = <0x5380000 0x200000>;
+			};
+
+			partition@5580000 {
+				label = "boot_data";
+				reg = <0x5580000 0x200000>;
+			};
+
+			partition@5780000 {
+				label = "User_data";
+				reg = <0x5780000 0x1000000>;
+			};
+			
+		};
+	};
+};
+
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+

--- a/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
+++ b/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
@@ -115,19 +115,6 @@
 };
 
 &mdio {
-	reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
-	reset-delay-us = <50000>;
-	reset-post-delay-us = <20000>;
-
-	phy5: phy@5 {
-		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <5>;
-	};
-
-	phy6: phy@6 {
-		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <6>;
-	};
 
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";

--- a/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
+++ b/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
@@ -120,6 +120,9 @@
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
 		interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
 	};
 

--- a/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
+++ b/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
@@ -122,13 +122,11 @@
 	phy5: phy@5 {
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <5>;
-		mxl,led-config = <0x0 0x0 0x370 0x380>;
 	};
 
 	phy6: phy@6 {
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <6>;
-		mxl,led-config = <0x0 0x0 0x370 0x380>;
 	};
 
 	switch: switch@1f {

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -176,4 +176,9 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		;;
+	arcadyan,wg620443)
+		hw_mac_addr=$(mtd_get_mac_encrypted_arcadyan_mt7986 "pricfg" "89c72f31eb3243e8b0a781fe46a51c56" "87d81103921f4c17cbfd078b056f397a")
+		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
+		;;
 esac

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -174,6 +174,10 @@ platform_do_upgrade() {
 		CI_ROOT_UBIPART=ubi
 		nand_do_upgrade "$1"
 		;;
+	arcadyan,wg620443)
+		fw_setenv boot_select 0
+		nand_do_upgrade $1
+		;;
 	*)
 		nand_do_upgrade "$1"
 		;;
@@ -267,6 +271,15 @@ platform_pre_upgrade() {
 	xiaomi,mi-router-wr30u-stock|\
 	xiaomi,redmi-router-ax6000-stock)
 		xiaomi_initial_setup
+		;;
+	arcadyan,wg620443)
+		if [ "$(rootfs_type)" = "tmpfs" ]; then
+			echo -e "/dev/mtd1\t0x0\t0x20000\t0x20000" > /etc/fw_env.config
+			fw_setenv bootargs console=ttyS0,115200n1 ubi.mtd=4 init=/sbin/init loglevel=8 earlycon=uart8250,mmio32,0x11002000
+			ubidetach -m 4 | true
+			ubiformat /dev/mtd4
+		fi
+		
 		;;
 	esac
 }

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -274,7 +274,6 @@ platform_pre_upgrade() {
 		;;
 	arcadyan,wg620443)
 		if [ "$(rootfs_type)" = "tmpfs" ]; then
-			echo -e "/dev/mtd1\t0x0\t0x20000\t0x20000" > /etc/fw_env.config
 			fw_setenv bootargs console=ttyS0,115200n1 ubi.mtd=4 init=/sbin/init loglevel=8 earlycon=uart8250,mmio32,0x11002000
 			ubidetach -m 4 | true
 			ubiformat /dev/mtd4

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1809,3 +1809,24 @@ define Device/zyxel_nwa50ax-pro
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += zyxel_nwa50ax-pro
+
+define Device/arcadyan_wg620443
+  DEVICE_VENDOR := Arcadyan
+  DEVICE_MODEL := WG620443
+  DEVICE_DTS := mt7986a-arcadyan-wg620443
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-ubootenv-nvram kmod-mt7986-firmware mt7986-wo-firmware uencrypt-mbedtls kmod-mt7915e
+  DEVICE_DTS_LOADADDR := 0x44000000
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 51200k
+  KERNEL_IN_UBI := 1
+  IMAGE += initramfs-kernel.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+    ARTIFACTS += initramfs-factory.bin
+    ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | sysupgrade-tar kernel=$$$$@ | append-metadata
+  endif
+endef
+TARGET_DEVICES += arcadyan_wg620443

--- a/target/linux/ramips/dts/mt7621_arcadyan_wg630223.dts
+++ b/target/linux/ramips/dts/mt7621_arcadyan_wg630223.dts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "arcadyan,wg630223", "mediatek,mt7621-soc";
+	model = "Arcadyan WG630223";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+		bootargs-override = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led_status_blue: led-1 {
+			label = "blue:status";
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_green: led-2 {
+			label = "green:status";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: led-3 {
+			label = "red:status";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		key-restart {
+			label = "reset";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+};
+
+&nand {
+	status = "okay";
+	mediatek,nmbm;
+	mediatek,bmt-remap-range = <0x0000000 0x05c0000>, <0x1980000 0x3800000>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x80000>;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_fff0: macaddr@fff0 {
+				reg = <0xfff0 0x6>;
+			};
+		};
+
+		partition@180000 {
+			label = "firmware";
+			reg = <0x180000 0x1800000>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x440000>;
+			};
+
+			partition@440000 {
+				label = "ubi";
+				reg = <0x440000 0x13c0000>;
+			};
+		};
+
+		partition@1980000 {
+			label = "firmware_backup";
+			reg = <0x1980000 0x1800000>;
+		};
+
+		partition@3180000 {
+			label = "firmware_mp";
+			reg = <0x3180000 0x1800000>;
+		};
+
+		partition@4980000 {
+			label = "pricfg";
+			reg = <0x4980000 0x200000>;
+		};
+
+		partition@4b80000 {
+			label = "seccfg";
+			reg = <0x4b80000 0x200000>;
+		};
+
+		partition@4d80000 {
+			label = "arc_log";
+			reg = <0x4d80000 0x200000>;
+		};
+
+		partition@4f80000 {
+			label = "board_data";
+			reg = <0x4f80000 0x200000>;
+		};
+
+		partition@5180000 {
+			label = "boot_data";
+			reg = <0x5180000 0x200000>;
+		};
+
+		partition@5380000 {
+			label = "User_data";
+			reg = <0x5380000 0x1800000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_fff0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&phy4>;
+
+	nvmem-cells = <&macaddr_factory_fff0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3555,3 +3555,25 @@ define Device/zyxel_wsm20
   KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | znet-header V1.00(ABZF.0)C0
 endef
 TARGET_DEVICES += zyxel_wsm20
+
+define Device/arcadyan_wg630223
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Arcadyan
+  DEVICE_MODEL := WG630223
+  IMAGE_SIZE := 24576k
+  KERNEL_SIZE := 4352k
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb \
+	    | arcadyan-trx 0x30524448 | pad-to $$(KERNEL_SIZE)
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+		      fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS += initramfs-factory.trx
+  ARTIFACT/initramfs-factory.trx := append-image-stage initramfs-kernel.bin | arcadyan-trx 0x30524448
+endif
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools uencrypt-mbedtls
+endef
+TARGET_DEVICES += arcadyan_wg630223

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -78,6 +78,7 @@ ramips_setup_interfaces()
 		;;
 	asiarf,ap7621-nv1|\
 	beeline,smartbox-flash|\
+	arcadayan,wg630223|\
 	beeline,smartbox-giga|\
 	elecom,wmc-x1800gst|\
 	elecom,wrc-x1800gs|\
@@ -197,6 +198,12 @@ ramips_setup_macs()
 	local label_mac=""
 
 	case $board in
+
+	arcadyan,wg630223)
+		label_mac=$(mtd_get_mac_encrypted_arcadyan "board_data" "42583038694070636D5964652324252A")
+		lan_mac=$label_mac
+		wan_mac=$(macaddr_add "$lan_mac" 3)
+		;;
 	alfa-network,ax1800rm|\
 	jcg,y2|\
 	wavlink,wl-wn531a6|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -10,6 +10,16 @@ PHYNBR=${DEVPATH##*/phy}
 board=$(board_name)
 
 case "$board" in
+
+	arcadyan,wg630223)
+		hw_mac_addr=$(mtd_get_mac_encrypted_arcadyan "board_data" "42583038694070636D5964652324252A")
+		hw_mac_addr=$(macaddr_setbit $hw_mac_addr 7)
+		hw_mac_addr=$(macaddr_unsetbit $hw_mac_addr 25)
+		hw_mac_addr=$(macaddr_setbit $hw_mac_addr 28)
+		[ "$PHYNBR" = "0" ] && macaddr_setbit_la $hw_mac_addr > /sys${DEVPATH}/macaddress
+		hw_mac_addr=$(macaddr_setbit $hw_mac_addr 27)
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $hw_mac_addr > /sys${DEVPATH}/macaddress
+		;;
 	arcadyan,we420223-99)
 		if [ "$PHYNBR" = "0" ]; then
 			mac24=$(macaddr_add "$(get_mac_label)" "0xf00001")

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -64,12 +64,22 @@ platform_do_upgrade() {
 		dd if=/dev/mtd5 bs=1024 count=52224 >> /tmp/backup_firmware.bin
 		mtd -e firmware2 write /tmp/backup_firmware.bin firmware2
 		;;
+	arcadyan,wg630223)
+		dd if=/dev/mtd12 of=/tmp/mtd12.bin bs=1024
+		local boot_sect=`dd if=/tmp/mtd12.bin bs=1 skip=8 count=2 2>/dev/null | hexdump -v -e '1/1 "%02x"'`
+		if [ "$boot_sect" == "0100" ]; then
+			echo 'Switching boot partition to "firmware" ...'
+			printf '\x00\x00' | dd of=/tmp/mtd12.bin bs=1 seek=8 count=2 conv=notrunc
+			mtd write /tmp/mtd12.bin /dev/mtd12
+		fi
+		;;
 	esac
 
 	case "$board" in
 	ampedwireless,ally-00x19k|\
 	ampedwireless,ally-r1900k|\
 	arcadyan,we420223-99|\
+	arcadyan,wg630223|\
 	asus,rt-ac65p|\
 	asus,rt-ac85p|\
 	asus,rt-ax53u|\


### PR DESCRIPTION
### Specification
Model: Arcadyan WG630223(-TC)
CPU: Mediatek MT7621A
RAM: 256MB DDR3
Flash: 128MB
WiFi: 2.4GHz 5GHz 4x4
GbE: 1 WAN and 2 LANs
Power: 12V 1A DC 5.5/2.1 Jack
LED: 3

### Installation for TC variant by CHT
#### Install recovery image
 * Navigate to `System` -> `Firmware Update` in WebUI
 * Select `openwrt-xx.xx.xx-initramfs-factory.trx` file
 * Launch Web DevTools then select the iframe of `system_f.htm`
 * Execute following JS script to starting flash the stage 1 firmware.
```
$("input[type=file]").attr("name","mtkfile")
var f=document.webForm;
f.action="upload.cgi";
f.ENCTYPE='multipart/form-data';
subForm({frm:f,genfrm:0,cmd:'',uploadtype:1,wizard:1,wait:2,done:function(){check_FW_and_jump();}});
```
* When the green LED light up,the recovery image is installed and booted

#### Install full image
* Launch browser to `http://192.168.1.1`
* Upgrade OpenWrt with `openwrt-xx.xx.xx-squashfs-sysupgrade.bin`
* Reboot