### PR TITLE
ath79: move RE450 V1 & V2 to tiny, restore sysupgrade support

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -464,9 +464,6 @@ tplink,tl-wr902ac-v1)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	ucidef_set_led_netdev "internet" "Internet" "green:internet" "eth0"
 	;;
-tplink,re355-v1|\
-tplink,re450-v1|\
-tplink,re450-v2|\
 tplink,re450-v3|\
 tplink,re455-v1)
 	ucidef_set_led_netdev "lan_data" "LAN Data" "green:lan_data" "eth0" "tx rx"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -98,9 +98,6 @@ ath79_setup_interfaces()
 	tplink,eap225-v4|\
 	tplink,eap245-v1|\
 	tplink,re350k-v1|\
-	tplink,re355-v1|\
-	tplink,re450-v1|\
-	tplink,re450-v2|\
 	tplink,re450-v3|\
 	tplink,re455-v1|\
 	tplink,tl-wa1201-v2|\

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -537,45 +537,6 @@ define Device/tplink_re350k-v1
 endef
 TARGET_DEVICES += tplink_re350k-v1
 
-define Device/tplink_rex5x-v1
-  $(Device/tplink-safeloader)
-  SOC := qca9558
-  IMAGE_SIZE := 6016k
-  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
-  DEFAULT := n
-endef
-
-define Device/tplink_re355-v1
-  $(Device/tplink_rex5x-v1)
-  DEVICE_MODEL := RE355
-  DEVICE_VARIANT := v1
-  TPLINK_BOARD_ID := RE355
-  SUPPORTED_DEVICES += re355
-endef
-TARGET_DEVICES += tplink_re355-v1
-
-define Device/tplink_re450-v1
-  $(Device/tplink_rex5x-v1)
-  DEVICE_MODEL := RE450
-  DEVICE_VARIANT := v1
-  TPLINK_BOARD_ID := RE450
-  SUPPORTED_DEVICES += re450
-endef
-TARGET_DEVICES += tplink_re450-v1
-
-define Device/tplink_re450-v2
-  $(Device/tplink-safeloader)
-  SOC := qca9563
-  IMAGE_SIZE := 6016k
-  DEVICE_MODEL := RE450
-  DEVICE_VARIANT := v2
-  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
-  TPLINK_BOARD_ID := RE450-V2
-  LOADER_TYPE := elf
-  DEFAULT := n
-endef
-TARGET_DEVICES += tplink_re450-v2
-
 define Device/tplink_re450-v3
   $(Device/tplink-safeloader)
   SOC := qca9563

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -1,5 +1,44 @@
 include ./common-tp-link.mk
 
+define Device/tplink_rex5x-v1
+  $(Device/tplink-safeloader)
+  SOC := qca9558
+  IMAGE_SIZE := 6016k
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
+  DEFAULT := n
+endef
+
+define Device/tplink_re355-v1
+  $(Device/tplink_rex5x-v1)
+  DEVICE_MODEL := RE355
+  DEVICE_VARIANT := v1
+  TPLINK_BOARD_ID := RE355
+  SUPPORTED_DEVICES += re355
+endef
+TARGET_DEVICES += tplink_re355-v1
+
+define Device/tplink_re450-v1
+  $(Device/tplink_rex5x-v1)
+  DEVICE_MODEL := RE450
+  DEVICE_VARIANT := v1
+  TPLINK_BOARD_ID := RE450
+  SUPPORTED_DEVICES += re450
+endef
+TARGET_DEVICES += tplink_re450-v1
+
+define Device/tplink_re450-v2
+  $(Device/tplink-safeloader)
+  SOC := qca9563
+  IMAGE_SIZE := 6016k
+  DEVICE_MODEL := RE450
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
+  TPLINK_BOARD_ID := RE450-V2
+  LOADER_TYPE := elf
+  DEFAULT := n
+endef
+TARGET_DEVICES += tplink_re450-v2
+
 define Device/tplink_tl-mr10u
   $(Device/tplink-4mlzma)
   SOC := ar9331

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -59,6 +59,12 @@ on,n150r)
 	ucidef_set_led_switch "lan1" "LAN1" "green:lan1" "switch0" "0x02" "0x0f"
 	ucidef_set_led_switch "lan2" "LAN2" "green:lan2" "switch0" "0x04" "0x0f"
 	;;
+tplink,re355-v1|\
+tplink,re450-v1|\
+tplink,re450-v2)
+	ucidef_set_led_netdev "lan_data" "LAN Data" "green:lan_data" "eth0" "tx rx"
+	ucidef_set_led_netdev "lan_link" "LAN Link" "green:lan_link" "eth0" "link"
+	;;
 tplink,tl-mr3020-v1|\
 tplink,tl-mr3040-v2|\
 tplink,tl-wa701nd-v1|\

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -16,6 +16,9 @@ ath79_setup_interfaces()
 	engenius,eap350-v1|\
 	engenius,ecb350-v1|\
 	pqi,air-pen|\
+	tplink,re355-v1|\
+	tplink,re450-v1|\
+	tplink,re450-v2|\
 	tplink,tl-mr10u|\
 	tplink,tl-mr3020-v1|\
 	tplink,tl-mr3040-v2|\


### PR DESCRIPTION
Since OpenWrt 23.05, the firmware selector no longer provides sysupgrade images for RE450 V1 & V2 due to image size constraints. The maximum allowed image size is approximately 5.7MB, making the generic build unusable.

Due to flash size limitations, community members often prioritize LuCI over security, replacing `wpad `with `wpad-mini` and sacrificing support for `wpad-wolfssl` and `wpad-mbedtls`. Without an official build that fits within the flash size limit, users are forced to create custom images, which may lack proper security defaults. Moving RE450 V1 & V2 to the tiny target ensures a secure-by-default wireless setup while allowing full management via UCI commands.

This commit moves RE450 V1 & V2 + RE355 V1 to the tiny target, enabling:
- Smaller image builds within the flash size limit (~5.7MB).
- Better control over package selection while maintaining security defaults.

Image size calculations (custom builds):
```
5.0M openwrt-ath79-tiny-tplink_re355-v1-initramfs-kernel.bin
5.5M openwrt-ath79-tiny-tplink_re355-v1-squashfs-factory.bin
5.5M openwrt-ath79-tiny-tplink_re355-v1-squashfs-sysupgrade.bin

5.0M openwrt-ath79-tiny-tplink_re450-v1-initramfs-kernel.bin
5.5M openwrt-ath79-tiny-tplink_re450-v1-squashfs-factory.bin
5.5M openwrt-ath79-tiny-tplink_re450-v1-squashfs-sysupgrade.bin

5.0M openwrt-ath79-tiny-tplink_re450-v2-initramfs-kernel.bin
5.5M openwrt-ath79-tiny-tplink_re450-v2-squashfs-factory.bin
5.5M openwrt-ath79-tiny-tplink_re450-v2-squashfs-sysupgrade.bin
```

Tested on RE450 V2. Patches and further support available as needed.