### PR TITLE
dnsmasq: fix handlers for options `filter_rr` and `cache_rr`

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -226,6 +226,14 @@ append_interface_name() {
 	xappend "--interface-name=$1,$2"
 }
 
+append_filter_rr() {
+	xappend "--filter-rr=$1"
+}
+
+append_cache_rr() {
+	xappend "--cache-rr=$1"
+}
+
 filter_dnsmasq() {
 	local cfg="$1" func="$2" match_cfg="$3" found_cfg
 
@@ -1000,8 +1008,8 @@ dnsmasq_start()
 	# deprecate or remove filter-X in favor of filter-rr?
 	append_bool "$cfg" filter_aaaa "--filter-AAAA"
 	append_bool "$cfg" filter_a "--filter-A"
-	append_parm "$cfg" filter_rr "--filter-rr"
-	append_parm "$cfg" cache_rr "--cache-rr"
+	config_list_foreach "$cfg" filter_rr append_filter_rr
+	config_list_foreach "$cfg" cache_rr append_cache_rr
 
 	append_parm "$cfg" logfacility "--log-facility"
 	config_get logfacility "$cfg" "logfacility"


### PR DESCRIPTION
According to:
- https://github.com/openwrt/luci/blob/master/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js#L700
- https://github.com/openwrt/luci/blob/master/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js#L402

These two options should be of type `MultiValue` but here there're used as single value. This results in dnsmasq crashes when either of these options are set with multiple values, which leads to an invalid space-separated value.

As these options are designed to take multiple values, I think it's better to use list format eg. `list filter_rr 'AAAA'`, instead of `option filter_rr 'AAAA,HTTPS'`.

See: https://forum.openwrt.org/t/selecting-more-than-one-filter-arbitrary-rr-or-cache-arbitrary-rr-in-v24-10-0-crashes-dnsmasq/225801

Tested on 24.10.0
