### PR TITLE
ramips: fix reading mac address for hiwifi hc5962

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -264,7 +264,7 @@ ramips_setup_macs()
 		wan_mac=$label_mac
 		;;
 	hiwifi,hc5962)
-		lan_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
+		lan_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac")
 		label_mac=$lan_mac
 		[ -n "$lan_mac" ] || lan_mac=$(cat /sys/class/net/eth0/address)
 		wan_mac=$(macaddr_add "$lan_mac" 1)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -103,7 +103,7 @@ case "$board" in
 			macaddr_setbit_la "$(mtd_get_mac_binary factory 0x4)" > /sys${DEVPATH}/macaddress
 		;;
 	hiwifi,hc5962)
-		label_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac ")
+		label_mac=$(mtd_get_mac_ascii bdinfo "Vfac_mac")
 		[ "$PHYNBR" = "0" ] && [ -n "$label_mac" ] && \
 		echo -n "$label_mac" > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && [ -n "$label_mac" ] && \


### PR DESCRIPTION
The spaces in variables have been stripped since commit 551e04f3c9c0
("base-files: strip space and tab characters from ASCII mac address"),
resulting "Vfac_mac " matches nothing. Fix the issue by removing the space at end.

Fixes: https://github.com/immortalwrt/immortalwrt/issues/1723