### PR TITLE
mediatek: filogic: migrate Netgate N60 to upstream PHY LED control

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-netcore-n60.dts
+++ b/target/linux/mediatek/dts/mt7986a-netcore-n60.dts
@@ -109,7 +109,17 @@
 	phy6: phy@6 {
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <6>;
-		mxl,led-config = <0x0 0x0 0x0 0x3f0>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led-3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+			};
+		};
 	};
 
 	switch: switch@1f {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -76,6 +76,9 @@ mercusys,mr90x-v1-ubi)
 	ucidef_set_led_netdev "lan-2" "lan-2" "green:lan-2" "lan2" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
+netcore,n60|)
+	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan" "eth1" "link tx rx"
+	;;
 netgear,wax220)
 	ucidef_set_led_netdev "eth0" "LAN" "green:lan" "eth0"
 	;;


### PR DESCRIPTION
This commit switches the control of the leds connected to the Maxlinear GPY211C PHY to an upstream solution. There should be no functional changes. I don't have the device, but the migration is quite straightforward, so everything should work fine. Testing on the hardware welcome.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>