### PR TITLE
package: add dumpimage package

### DIFF
--- a/package/boot/dumpimage/Makefile
+++ b/package/boot/dumpimage/Makefile
@@ -1,0 +1,56 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=dumpimage
+PKG_DISTNAME:=u-boot
+PKG_VERSION:=2025.01
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_DISTNAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:= \
+	https://ftp.denx.de/pub/u-boot \
+	https://mirror.cyberbits.eu/u-boot \
+ftp://ftp.denx.de/pub/u-boot
+PKG_HASH:=cdef7d507c93f1bbd9f015ea9bc21fa074268481405501945abc6f854d5b686f
+PKG_SOURCE_SUBDIR:=$(PKG_DISTNAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_DISTNAME)-$(PKG_VERSION)
+
+PKG_BUILD_DEPENDS:=fstools
+
+PKG_LICENSE:=GPL-2.0 GPL-2.0+
+PKG_LICENSE_FILES:=Licenses/README
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/dumpimage
+	SECTION:=utils
+	CATEGORY:=Utilities
+	SUBMENU:=Boot Loaders
+	TITLE:= U-Boot bootloader Tools
+	DEPENDS := +libopenssl
+	URL:=http://www.denx.de/wiki/U-Boot
+endef
+
+define Package/dumpimage/description
+	dumpimage is used to extract the ubi from .img file
+	to allow luci to handle upgrades of .img files.
+endef
+
+define Build/Configure
+	$(MAKE) -C $(PKG_BUILD_DIR) defconfig
+	$(MAKE) -C $(PKG_BUILD_DIR) syncconfig
+	$(SED) 's/CONFIG_TOOLS_LIBCRYPTO=y/# CONFIG_TOOLS_LIBCRYPTO is not set/' $(PKG_BUILD_DIR)/.config
+endef
+
+MAKE_FLAGS += \
+	ARCH="sandbox" cross_tools \
+	TARGET_CFLAGS="$(TARGET_CFLAGS)" \
+	TARGET_LDFLAGS="$(TARGET_LDFLAGS)"
+
+define Package/dumpimage/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/dumpimage $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,dumpimage))

--- a/package/boot/dumpimage/patches/0001-tools-disable-kwbimage.patch
+++ b/package/boot/dumpimage/patches/0001-tools-disable-kwbimage.patch
@@ -1,0 +1,32 @@
+diff --git a/package/boot/u-boot-tools/patches/0001-tools-disable-kwbimage.patch b/package/boot/u-boot-tools/patches/0001-tools-disable-kwbimage.patch
+new file mode 100644
+index 0000000000..69a42ec383
+--- /dev/null
++++ b/package/boot/u-boot-tools/patches/0001-tools-disable-kwbimage.patch
+@@ -0,0 +1,25 @@
++From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal at milecki.pl>
++Date: Tue, 30 Nov 2021 11:29:19 +0100
++Subject: [PATCH] tools: disable kwbimage
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++Without CONFIG_TOOLS_LIBCRYPTO kwbimage doesn't compile because of
++multiple "undefined reference"s to SSL functions.
++
++Signed-off-by: Rafał Miłecki <rafal at milecki.pl>
++---
++ tools/Makefile | 1 -
++ 1 file changed, 1 deletion(-)
++
++--- a/tools/Makefile
+++++ b/tools/Makefile
++@@ -117,7 +117,6 @@ dumpimage-mkimage-objs := aisimage.o \
++ 			imximage.o \
++ 			imx8image.o \
++ 			imx8mimage.o \
++-			kwbimage.o \
++ 			lib/md5.o \
++ 			lpc32xximage.o \
++ 			mxsimage.o \
+

--- a/package/boot/dumpimage/patches/0002-fix-tools-compile.patch
+++ b/package/boot/dumpimage/patches/0002-fix-tools-compile.patch
@@ -1,0 +1,68 @@
+From def1f90be9f79c0c021ed6c04d02c6d4a308c5a0 Mon Sep 17 00:00:00 2001
+From: Scott Mercer <TheRootEd24@gmail.com>
+Date: Thu, 6 Mar 2025 08:18:54 -0500
+Subject: [PATCH] ipq50xx: packages: dumpimage: fix compile patch
+
+This patch is to fix compilation for uboot-tool V2025.01 in openwrt.
+
+* same "compile for enviroment patch" to makefile, that is used
+  in uboot-envtools.
+
+* remove mkeficapsule from build to avoid gnulib dependencies
+
+* disable bmp_logo from build to allow compilation
+
+Signed-off-by: Scott Mercer <TheRootEd24@gmail.com>
+---
+ tools/Makefile | 24 ++++++++++++++++++++++--
+ 1 file changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/tools/Makefile b/tools/Makefile
+index ee08a9675df8..15d92a1f9422 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -22,6 +22,26 @@
+ #    That's as long as the features of those tools aren't modified.
+ #
+ 
++override HOSTCC = $(CC)
++
++ifneq ($(TARGET_CFLAGS),)
++KBUILD_HOSTCFLAGS = $(TARGET_CFLAGS)
++endif
++ifneq ($(TARGET_LDFLAGS),)
++KBUILD_HOSTLDFLAGS = $(TARGET_LDFLAGS)
++endif
++
++# Compile for a hosted environment on the target
++HOST_EXTRACFLAGS  = -I$(srctree)/tools \
++		$(patsubst -I%,-idirafter%, $(filter -I%, $(UBOOTINCLUDE))) \
++		-idirafter $(srctree)/tools/env \
++		-DUSE_HOSTCC \
++		-DTEXT_BASE=$(TEXT_BASE)
++
++ifeq ($(MTD_VERSION),old)
++HOST_EXTRACFLAGS += -DMTD_OLD
++endif
++
+ # Enable all the config-independent tools
+ ifneq ($(HOST_TOOLS_ALL),)
+ CONFIG_ARCH_KIRKWOOD = y
+@@ -252,7 +272,7 @@ mkeficapsule-objs := generated/lib/uuid.o \
+ 	generated/lib/sha1.o \
+ 	$(LIBFDT_OBJS) \
+ 	mkeficapsule.o
+-hostprogs-$(CONFIG_TOOLS_MKEFICAPSULE) += mkeficapsule
++hostprogs-$(CONFIG_TOOLS_MKEFICAPSULE) +=
+ 
+ mkfwumdata-objs := mkfwumdata.o generated/lib/crc32.o
+ HOSTLDLIBS_mkfwumdata += -luuid
+@@ -316,7 +336,7 @@ HOST_EXTRACFLAGS += -include $(srctree)/include/compiler.h \
+ 		-D__KERNEL_STRICT_NAMES \
+ 		-D_GNU_SOURCE
+ 
+-__build:	$(LOGO-y)
++__build:	$(LOGO-n)
+ 
+ $(LOGO_H):	$(obj)/bmp_logo $(LOGO_BMP)
+ 	$(obj)/bmp_logo --gen-info $(LOGO_BMP) > $@


### PR DESCRIPTION
* dumpimage V2025.01

* used to extract ubi file from oem .img files and openwrt .img files built with legacy MultiFit format. The addition of this package to Openwrt, enables luci to handle sysupgrades using files in the .img format.This in turn, enables universal upgrade/recovery options in both OEM and OpenWrt firmware. Either .img file, Openwrt or OEM, can be used to upgrade or recovery in any available of the available options in either firmware.

* Methods of upgrade and recovery include
	* uboot webui update and recovery ( OEM <=> OpenWRt )
	* cli firmware upgrades via sysupgrade ( OEM <=> OpenWrt)
	* webui firmware upgrades   ( OEM <=> OpenWrt )

This has been tested thorougly in development of the GL.iNet B3000. The complete discussion, tests, and results can been seen in the current pr here --> https://github.com/openwrt/openwrt/pull/17903#issuecomment-2680048294