### PR TITLE
ipq50xx: package: add glinet-uboot-scr package

### DIFF
--- a/package/boot/glinet-uboot-scr/Makefile
+++ b/package/boot/glinet-uboot-scr/Makefile
@@ -1,0 +1,52 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=glinet-uboot-scr
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL=https://github.com/TheRootED24/glinet-uboot-scr.git
+PKG_MIRROR_HASH:=28971e9b76e3735bff687bdd8836e6c02b6cd5e769155e60b9365c82dec9d5a0
+PKG_SOURCE_VERSION:=9be98e03cce950334b88324a52ed6cb583ec2df0
+PKG_SOURCE_DATE:=2025-03-05
+
+PKG_MAINTAINER:=Scott Mercer <TheRootED24@gmail.com>
+PKG_LICENSE:=GPL-3.0
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/glinet-uboot-scr
+	SECTION:=utils
+	CATEGORY:=Utilities
+	SUBMENU:=Boot Loaders
+	TITLE:= Uboot flash.scr Files
+	URL:=https://github.com/TheRootED24/glinet-uboot-scr.git
+endef
+
+define Package/glinet-uboot-scr/description
+  This package contains the uboot scr file needed to
+  enable uboot webui recovery and firmware upgrades
+  for OpenWrt Firmwares.
+
+           REQUIRED INSTALLATION NOTES
+
+  This package MUST be included <*> in the firmware to
+  effectively enable uboot webui recovery and upgrades
+  for Openwrt.
+
+  Installation of this package post-build will have
+  zero effect and will not enable uboot upgrades and
+  recovery options for Openwrt Firmwares.
+endef
+
+MAKE_PATH:=src
+
+define Build/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include/glinet-uboot-scr
+	$(CP) \
+		$(PKG_BUILD_DIR)/src/*.scr \
+		$(1)/usr/include/glinet-uboot-scr/
+endef
+
+$(eval $(call BuildPackage,glinet-uboot-scr))
+


### PR DESCRIPTION
** glinet-uboot-scr package

* This package contians the required uboot scr file required to enable uboot webui firmware upgrades and recovery options. These scripts, like bdf files are device specific. This seems to be the first device with these requirements, but i suspect more to be discovered now that that method is known and proven. This is an option not a requirement for the GL.iNet GL-b3000 device port. It must be included in the build to have any effect, as the title and description explain in detail
