### PR TITLE
ramips: mt76x8: add support for Keenetic Launcher (KN-1221)

### DIFF
--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1221.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1221.dts
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "keenetic,kn-1221", "mediatek,mt7628an-soc";
+	model = "Keenetic KN-1221";
+
+	aliases {
+		label-mac-device = &ethernet;
+
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "USB-power";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+		};
+
+		fn {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "restart";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0 0x1cc0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "spi cs1", "gpio", "refclk", "wdt";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <32000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "rf-eeprom";
+				reg = <0x40000 0x10000>;
+				read-only;
+				
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+				};
+			};
+
+			firmware1: partition@50000 {
+				label = "firmware_1";
+				reg = <0x50000 0xe60000>;
+			};
+
+			partition@eb0000 {
+				label = "config_1";
+				reg = <0xeb0000 0x40000>;
+				read-only;
+			};
+
+			partition@ef0000 {
+				label = "storage";
+				reg = <0xef0000 0x100000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "dump";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+
+			partition@1000000 {
+				label = "u-state";
+				reg = <0x1000000 0x30000>;
+				read-only;
+			};
+
+			partition@1030000 {
+				label = "u-config_res";
+				reg = <0x1030000 0x10000>;
+				read-only;
+			};
+			
+			partition@1040000 {
+				label = "rf-eeprom_res";
+				reg = <0x1040000 0x10000>;
+				read-only;
+			};
+
+			firmware2: partition@1050000 {
+				label = "firmware_2";
+				reg = <0x1050000 0xe60000>;
+			};
+			
+			partition@1eb0000 {
+				label = "Config_2";
+				reg = <0x1eb0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x38>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -366,6 +366,18 @@ define Device/jotale_js76x8-32m
 endef
 TARGET_DEVICES += jotale_js76x8-32m
 
+define Device/keenetic_kn-1221
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 29440k
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-1221
+  DEVICE_PACKAGES := kmod-usb2
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to $$$$(BLOCKSIZE) | \
+	check-size 14720k | zyimage -d 0x801221 -v "KN-1221"
+endef
+TARGET_DEVICES += keenetic_kn-1221
+
 define Device/keenetic_kn-1613
   IMAGE_SIZE := 15073280
   DEVICE_VENDOR := Keenetic

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -58,6 +58,7 @@ hiwifi,hc5661a|\
 hiwifi,hc5761a)
 	ucidef_set_led_switch "internet" "internet" "blue:internet" "switch0" "0x10"
 	;;
+keenetic,kn-1221|\
 keenetic,kn-1613|\
 keenetic,kn-1711|\
 keenetic,kn-1713)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -131,6 +131,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "6@eth0"
 		;;
+	keenetic,kn-1221)
+		ucidef_add_switch "switch0" \
+			"1:lan" "2:lan" "0:wan" "6@eth0"
+		;;
 	keenetic,kn-1613|\
 	keenetic,kn-1713|\
 	motorola,mwr03)
@@ -287,6 +291,7 @@ ramips_setup_macs()
 	totolink,lr1200)
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		;;
+	keenetic,kn-1221|\
 	keenetic,kn-1613|\
 	keenetic,kn-3211|\
 	zyxel,keenetic-extra-ii)


### PR DESCRIPTION
```
Specification:
SoC: MediaTek MT7628AN
RAM: 128M DDR2, ESMT M14D128168A (2Y)
Flash: 32M, cFeon EN25QH256A (Dual Boot on OEM, concatenated on OpenWrt,
SPI)
Switch: MediaTek MT7628AN, 3 ports 100 Mbps
WiFi: MediaTek MT7628AN 2.4 GHz 802.11n
USB: 1 port USB 2.0
GPIO: 1 button (Wi-Fi & Reset on OEM, Reset on OpenWrt), 3 LEDs (Power,
Internet, Wi-Fi), USB port power controls

Disassembly:
There are 2 screws at the bottom near the LEDs hidden by rubber mounts.
After removing the screws, pry the gray plastic part around (it is secured
with latches) and remove it.

UART Interface:
The UART interface can be connected to the 5 pin located between LAN
ports and the WAN one.
Pins (from the second LAN port to the WAN one): VCC, TX, RX, NC, GND
Settings: 115200, 8N1

Flashing via TFTP:
1. Connect your PC and router to the first LAN port, configure PC
interface using IP 192.168.1.2, mask 255.255.255.0
2. Serve the firmware image (for OpenWrt it is *-squashfs-factory.bin)
renamed to KN-1221_recovery.bin via TFTP
3. Power up the router while pressing Wi-Fi button
4. Release Wi-Fi button when Power LED starts blinking

To revert back to OEM firmware:
The return to the OEM firmware is carried out by using the methods
described above with the help of the appropriate firmware image found on
osvault.keenetic.net.

When using OEM bootloader, the firmware image size cannot exceed the size
of one OEM «Firmware_x» partition or Kernel + rootFS size.

Signed-off-by: Ivan Davydov <lotigara@lotigara.ru>
```