### PR TITLE
qualcommax: mr7350: switch to ascii-eq-delim-env for reading mac addr…

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-mr7350.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-mr7350.dts
@@ -175,6 +175,32 @@
 
 		partitions {
 			compatible = "qcom,smem-part";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition-0-devinfo {
+				compatible = "fixed-partitions";
+				label = "devinfo";
+				read-only;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "env-data";
+					reg = <0x0 0x40000>;
+
+					nvmem-layout {
+						compatible = "ascii-eq-delim-env";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						hw_mac_addr: hw_mac_addr {
+							compatible = "mac-base";
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+			};
 		};
 	};
 };
@@ -368,30 +394,40 @@
 	status = "okay";
 	phy-handle = <&qca8075_0>;
 	label = "lan1";
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp2 {
 	status = "okay";
 	phy-handle = <&qca8075_1>;
 	label = "lan2";
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp3 {
 	status = "okay";
 	phy-handle = <&qca8075_2>;
 	label = "lan3";
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp4 {
 	status = "okay";
 	phy-handle = <&qca8075_3>;
 	label = "lan4";
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp5 {
 	status = "okay";
 	phy-handle = <&qca8075_4>;
 	label = "wan";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &wifi {

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
@@ -44,11 +44,6 @@ ipq60xx_setup_macs()
 	local label_mac=""
 
 	case $board in
-	linksys,mr7350)
-		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
-		lan_mac=$label_mac
-		wan_mac=$label_mac
-		;;
 	qihoo,360v6)
 		lan_mac=$(mtd_get_mac_ascii factory lanMac)
 		wan_mac=$(macaddr_add "$lan_mac" 1)


### PR DESCRIPTION
…esses

like eacc4d8c9b31ac17df034d2140558bdaaa56c16b, except for using smem and only fixed partitions for devinfo
