### PR TITLE
qualcommax: fap650: fix dtc warnings on partitions

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-fap650.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-fap650.dts
@@ -225,6 +225,8 @@
 		spi-max-frequency = <50000000>;
 
 		partitions {
+			#address-cells = <1>;
+			#size-cells = <1>;
 			compatible = "fixed-partitions";
 
 			partition@0 {


### PR DESCRIPTION
This commit adds the missing properties to address the following warnings: Warning (reg_format): /soc@0/spi@78b5000/flash@0/partitions/partition@x:reg: property has invalid length (8 bytes) (#address-cells == 2, #size-cells == 1)"
