### PR TITLE
libnl: update to 3.11.0

### DIFF
--- a/package/libs/libnl/Makefile
+++ b/package/libs/libnl/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnl
-PKG_VERSION:=3.10.0
+PKG_VERSION:=3.11.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/thom311/libnl/releases/download/libnl$(subst .,_,$(PKG_VERSION))
-PKG_HASH:=49b3e2235fdb58f5910bbb3ed0de8143b71ffc220571540502eb6c2471f204f5
+PKG_HASH:=2a56e1edefa3e68a7c00879496736fdbf62fc94ed3232c0baba127ecfa76874d
 
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
Changes:
c7edc38f libnl-3.11.0 release
b75e27de lib/route: add support for bridge msti
8a73b245 lib/route: add support for bridge info boolopts 3b284a11 lib/route: extend bridge info support
a43a41cd lib/route: add missing bridge info getter functions 756d5161 lib/route: add missing entry in libnl-route-3.sym file 014c33a6 lib/route: add rtnl_neigh ext flags support acf572b5 route: add support for getting permanent mac address of link afafe78a lib/route: extend bridge flags
11597b73 xfrm: remove redundant check in xfrm_sa_update_cache() 2abfb089 xfrm: use the new _nl_auto_nl_object helper 831e9868 cache: use the new _nl_auto_nl_object helper 4b9daa6d add _nl_auto_nl_object helper
379a1405 black: fix "target-version" in "pyproject.toml" 8460c9b7 link/bonding: implement parsing link type d60535c9 link/bonding: implement comparing bond links 22b6cf5c link/bonding: implement io_clone()
e1c75bff link/bonding: add getters for attributes
ee4612ca link/bonding: rename bn_mask to ce_mask
81c40cbb tests: optimize _nltst_assert_route_list_permutate() to short cut search through permutations 9f5fac78 tests: in _nltst_assert_route_list() accept arbitrary order 01f06b57 base: add _nl_swap() helper macro
5b570259 tests: ensure that there are all expected routes in _nltst_assert_route_list() 1aa16ea9 tests: print route list before failure in _nltst_assert_route_list() 7f099cf0 tests: add _nltst_objects_to_string() helper e76d5697 tests: add _nltst_malloc0() and _nltst_sprintf() helpers d94a3e81 tests: move definition of asserts in "tests/nl-test-util.h" 798278ea tests: use _nl_ptrarray_len() helper in _nltst_assert_route_list() def89a2c base: add _nl_ptrarray_len() helper
64fad14b link: link_msg_parser(): keep link info instead of release and reacquire b8d3cfb2 lib/attr: add nla functions for variable-length integers 2ae88c48 lib/attr: add NLA_{SINT|UINT} attribute types
