### PR TITLE
kernel: igc: enable HW vlan tag insertion/stripping by default

### DIFF
--- a/target/linux/generic/pending-6.6/792-igc-enable-HW-vlan-tag-insertion-stripping-by-defaul.patch
+++ b/target/linux/generic/pending-6.6/792-igc-enable-HW-vlan-tag-insertion-stripping-by-defaul.patch
@@ -1,0 +1,32 @@
+From 8cae5a0d91fea01d90ce7c1827e26934a22ca2fa Mon Sep 17 00:00:00 2001
+From: Rui Salvaterra <rsalvaterra@gmail.com>
+Date: Wed, 5 Mar 2025 11:53:56 +0000
+Subject: [PATCH] igc: enable HW vlan tag insertion/stripping by default
+
+This is enabled by default in other Intel drivers I've checked (e1000, e1000e,
+iavf, igb and ice). Fixes an out-of-the-box performance issue when running
+OpenWrt on typical mini-PCs with igc-supported Ethernet controllers and 802.1Q
+VLAN configurations, as ethtool isn't part of the default packages and sane
+defaults are expected.
+
+In my specific case, with an Intel N100-based machine with four I226-V Ethernet
+controllers, my upload performance increased from under 30 Mb/s to the expected
+~1 Gb/s.
+
+Signed-off-by: Rui Salvaterra <rsalvaterra@gmail.com>
+---
+ drivers/net/ethernet/intel/igc/igc_main.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/net/ethernet/intel/igc/igc_main.c
++++ b/drivers/net/ethernet/intel/igc/igc_main.c
+@@ -6850,6 +6850,9 @@ static int igc_probe(struct pci_dev *pde
+ 	netdev->xdp_features = NETDEV_XDP_ACT_BASIC | NETDEV_XDP_ACT_REDIRECT |
+ 			       NETDEV_XDP_ACT_XSK_ZEROCOPY;
+ 
++	/* enable HW vlan tag insertion/stripping by default */
++	netdev->features |= NETIF_F_HW_VLAN_CTAG_TX | NETIF_F_HW_VLAN_CTAG_RX;
++
+ 	/* MTU range: 68 - 9216 */
+ 	netdev->min_mtu = ETH_MIN_MTU;
+ 	netdev->max_mtu = MAX_STD_JUMBO_FRAME_SIZE;


### PR DESCRIPTION
For some unfathomable reason, the Intel `igc` driver does not enable hardware VLAN tag insertion/stripping by default. This causes abysmal performance when using VLANs, on router devices containing these Ethernet controllers (e. g., a whole bunch of mini-PCs out there). More details in the patch commit message.

Add the respective [pending patch](https://lore.kernel.org/netdev/20250313093615.8037-1-rsalvaterra@gmail.com/).

Note that it's highly desirable to backport this to at least 24.10 ASAP.

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>