### PR TITLE
firmware: intel-microcode: update to 20250211

### DIFF
--- a/package/firmware/intel-microcode/Makefile
+++ b/package/firmware/intel-microcode/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=intel-microcode
-PKG_VERSION:=20240531
+PKG_VERSION:=20250211
 PKG_RELEASE:=1
 
 PKG_SOURCE:=intel-microcode_3.$(PKG_VERSION).1.tar.xz
 PKG_SOURCE_URL:=@DEBIAN/pool/non-free-firmware/i/intel-microcode/
-PKG_HASH:=808cbb57a790dab7060b59b31e70e54ac47d3798d75e9784ed57a65b9f951fc4
+PKG_HASH:=06b7aca49790d673623cb42f7a62a517d82555ce96371d2967b568d6e30fd787
 PKG_BUILD_DIR:=$(BUILD_DIR)/intel-microcode-3.$(PKG_VERSION).1
 PKG_CPE_ID:=cpe:/a:intel:microcode
 


### PR DESCRIPTION
Debian Changelogs from 20240531:
```
intel-microcode (3.20241112.1) unstable; urgency=medium

  * New upstream microcode datafile 20241112 (closes: #1086483)
    - Mitigations for INTEL-SA-01101 (CVE-2024-21853)
      Improper Finite State Machines (FSMs) in the Hardware logic in some
      4th and 5th Generation Intel Xeon Processors may allow an authorized
      user to potentially enable denial of service via local access.
    - Mitigations for INTEL-SA-01079 (CVE-2024-23918)
      Potential security vulnerabilities in some Intel Xeon processors
      using Intel SGX may allow escalation of privilege.  Intel disclosed
      that some processor models were already fixed by a previous
      microcode update.
    - Updated mitigations for INTEL-SA-01097 (CVE-2024-24968)
      Improper finite state machines (FSMs) in hardware logic in some
      Intel Processors may allow an privileged user to potentially enable a
      denial of service via local access.
    - Mitigations for INTEL-SA-01103 (CVE-2024-23984)
      A potential security vulnerability in the Running Average Power Limit
      (RAPL) interface for some Intel Processors may allow information
      disclosure.  Added mitigations for more processor models.
  * Updated Microcodes:
    sig 0x000806f8, pf_mask 0x87, 2024-06-20, rev 0x2b000603, size 588800
    sig 0x000806f7, pf_mask 0x87, 2024-06-20, rev 0x2b000603
    sig 0x000806f6, pf_mask 0x87, 2024-06-20, rev 0x2b000603
    sig 0x000806f5, pf_mask 0x87, 2024-06-20, rev 0x2b000603
    sig 0x000806f4, pf_mask 0x87, 2024-06-20, rev 0x2b000603
    sig 0x00090672, pf_mask 0x07, 2024-05-29, rev 0x0037, size 224256
    sig 0x00090675, pf_mask 0x07, 2024-05-29, rev 0x0037
    sig 0x000b06f2, pf_mask 0x07, 2024-05-29, rev 0x0037
    sig 0x000b06f5, pf_mask 0x07, 2024-05-29, rev 0x0037
    sig 0x000906a3, pf_mask 0x80, 2024-06-03, rev 0x0435, size 223232
    sig 0x000906a4, pf_mask 0x80, 2024-06-03, rev 0x0435
    sig 0x000a06a4, pf_mask 0xe6, 2024-08-02, rev 0x0020, size 138240
    sig 0x000b06a2, pf_mask 0xe0, 2024-05-29, rev 0x4123, size 220160
    sig 0x000b06a3, pf_mask 0xe0, 2024-05-29, rev 0x4123
    sig 0x000b06a8, pf_mask 0xe0, 2024-05-29, rev 0x4123
    sig 0x000c06f2, pf_mask 0x87, 2024-06-20, rev 0x21000283, size 560128
    sig 0x000c06f1, pf_mask 0x87, 2024-06-20, rev 0x21000283
  * source: update symlinks to reflect id of the latest release, 20241112
  * Update changelog for 3.20240910.1 and 3.20240813.1 with new information:
    INTEL-SA-1103 was addressed by 3.20240813.1 for some processor models,
    and not by 3.20240910. INTEL-SA-1079 was addressed by 3.20240910.1 for
    some processor models.

 -- Henrique de Moraes Holschuh <hmh@debian.org>  Thu, 14 Nov 2024 15:37:40 -0300

intel-microcode (3.20241029.1) UNRELEASED; urgency=medium

  * New upstream microcode datafile 20241029
    - Not relevant for operating system microcode updates
    - Only when loaded from firmware, this update fixes the critical,
      potentially hardware-damaging errata RPL061: Incorrect Internal
      Voltage Request on Raptor Lake (Core 13th/14th gen) Intel
      processors.
  * Updated Microcodes:
    sig 0x000b0671, pf_mask 0x32, 2024-08-29, rev 0x012b, size 211968

 -- Henrique de Moraes Holschuh <hmh@debian.org>  Thu, 14 Nov 2024 14:49:03 -0300

intel-microcode (3.20240910.1) unstable; urgency=medium

  * New upstream microcode datafile 20240910 (closes: #1081363)
    - Mitigations for INTEL-SA-01097 (CVE-2024-24968)
      Improper finite state machines (FSMs) in hardware logic in some
      Intel Processors may allow an privileged user to potentially enable a
      denial of service via local access.
    - Fixes for unspecified functional issues on several processor models
    - The processor voltage limit issue on Core 13rd/14th gen REQUIRES A
      FIRMWARE UPDATE.  It is present in this release for sig 0xb0671, but
      THE VOLTAGE ISSUE FIX ONLY WORKS WHEN THE MICROCODE UPDATE IS LOADED
      THROUGH THE FIT TABLE IN FIRMWARE.  Contact your system vendor for a
      firmware update that includes the appropriate microcode update for
      your processor.
  * Updated Microcodes:
    sig 0x00090672, pf_mask 0x07, 2024-02-22, rev 0x0036, size 224256
    sig 0x00090675, pf_mask 0x07, 2024-02-22, rev 0x0036
    sig 0x000b06f2, pf_mask 0x07, 2024-02-22, rev 0x0036
    sig 0x000b06f5, pf_mask 0x07, 2024-02-22, rev 0x0036
    sig 0x000906a3, pf_mask 0x80, 2024-02-22, rev 0x0434, size 222208
    sig 0x000906a4, pf_mask 0x80, 2024-02-22, rev 0x0434
    sig 0x000a06a4, pf_mask 0xe6, 2024-06-17, rev 0x001f, size 137216
    sig 0x000b0671, pf_mask 0x32, 2024-07-18, rev 0x0129, size 215040
    sig 0x000b06a2, pf_mask 0xe0, 2024-02-22, rev 0x4122, size 220160
    sig 0x000b06a3, pf_mask 0xe0, 2024-02-22, rev 0x4122
    sig 0x000b06a8, pf_mask 0xe0, 2024-02-22, rev 0x4122
    sig 0x000b06e0, pf_mask 0x19, 2024-03-25, rev 0x001a, size 138240
  * Update changelog for 3.20240813.1 with new information
  * Update changelog for 3.20240514.1 with new information
  * source: update symlinks to reflect id of the latest release, 20240910

 -- Henrique de Moraes Holschuh <hmh@debian.org>  Sat, 21 Sep 2024 16:40:07 -0300

intel-microcode (3.20240813.2) unstable; urgency=high

  * Merge changes from intel-microcode/3.20240531.1+nmu1, which were left out
    from 3.20240813.1 by an oversight, regressing merged-usr. Closes: #1060200

 -- Henrique de Moraes Holschuh <hmh@debian.org>  Sat, 17 Aug 2024 11:31:32 -0300

intel-microcode (3.20240813.1) unstable; urgency=medium

  * New upstream microcode datafile 20240813 (closes: #1078742)
    - Mitigations for INTEL-SA-01083 (CVE-2024-24853)
      Incorrect behavior order in transition between executive monitor and SMI
      transfer monitor (STM) in some Intel Processors may allow a privileged
      user to potentially enable escalation of privilege via local access.
    - Mitigations for INTEL-SA-01118 (CVE-2024-25939)
      Mirrored regions with different values in 3rd Generation Intel Xeon
      Scalable Processors may allow a privileged user to potentially enable
      denial of service via local access.
    - Mitigations for INTEL-SA-01100 (CVE-2024-24980)
      Protection mechanism failure in some 3rd, 4th, and 5th Generation Intel
      Xeon Processors may allow a privileged user to potentially enable
      escalation of privilege via local access.
    - Mitigations for INTEL-SA-01038 (CVE-2023-42667)
      Improper isolation in the Intel Core Ultra Processor stream cache
      mechanism may allow an authenticated user to potentially enable
      escalation of privilege via local access.  Intel disclosed that some
      processor models were already fixed by the previous microcode update.
    - Mitigations for INTEL-SA-01046 (CVE-2023-49141)
      Improper isolation in some Intel Processors stream cache mechanism may
      allow an authenticated user to potentially enable escalation of
      privilege via local access.  Intel disclosed that some processor models
      were already fixed by the previous microcode update.
    - Mitigations for INTEL-SA-01079 (CVE-2024-23918)
      Potential security vulnerabilities in some Intel Xeon processors
      using Intel SGX may allow escalation of privilege.  Intel released this
      information during the full disclosure for the 20241112 update.
      Processor signatures 0x606a6 and 0x606c1.
    - Mitigations for INTEL-SA-01103 (CVE-2024-23984)
      A potential security vulnerability in the Running Average Power Limit
      (RAPL) interface for some Intel Processors may allow information
      disclosure. Intel released this information during the full disclosure
      for the 20240910 update.  Processor signatures 0x5065b, 0x606a6,
      0x606c1.
    - Fix for unspecified functional issues on several processor models
    - Fix for errata TGL068/ADL075/ICL088/... "Processor may hang during a
      microcode update".  It is not clear which processors were fixed by this
      release, or by one of the microcode updates from 2024-05.
    - Mitigations for INTEL-SA-01213 (CVE-2024-36293)
      Improper access control in the EDECCSSA user leaf function for some
      Intel Processors with Intel SGX may allow an authenticated user to
      potentially enable denial of service via local access.  Intel released
      this information during the full disclosure for the 20250211 update.
      Processor signature 0x906ec (9th Generation Intel Core processor).
  * Updated microcodes:
    sig 0x00050657, pf_mask 0xbf, 2024-03-01, rev 0x5003707, size 39936
    sig 0x0005065b, pf_mask 0xbf, 2024-04-01, rev 0x7002904, size 30720
    sig 0x000606a6, pf_mask 0x87, 2024-04-01, rev 0xd0003e7, size 308224
    sig 0x000606c1, pf_mask 0x10, 2024-04-03, rev 0x10002b0, size 300032
    sig 0x000706e5, pf_mask 0x80, 2024-02-15, rev 0x00c6, size 114688
    sig 0x000806c1, pf_mask 0x80, 2024-02-15, rev 0x00b8, size 112640
    sig 0x000806c2, pf_mask 0xc2, 2024-02-15, rev 0x0038, size 99328
    sig 0x000806d1, pf_mask 0xc2, 2024-02-15, rev 0x0052, size 104448
    sig 0x000806e9, pf_mask 0xc0, 2024-02-01, rev 0x00f6, size 106496
    sig 0x000806e9, pf_mask 0x10, 2024-02-01, rev 0x00f6, size 106496
    sig 0x000806ea, pf_mask 0xc0, 2024-02-01, rev 0x00f6, size 105472
    sig 0x000806eb, pf_mask 0xd0, 2024-02-01, rev 0x00f6, size 106496
    sig 0x000806ec, pf_mask 0x94, 2024-02-05, rev 0x00fc, size 106496
    sig 0x00090661, pf_mask 0x01, 2024-04-05, rev 0x001a, size 20480
    sig 0x000906ea, pf_mask 0x22, 2024-02-01, rev 0x00f8, size 105472
    sig 0x000906eb, pf_mask 0x02, 2024-02-01, rev 0x00f6, size 106496
    sig 0x000906ec, pf_mask 0x22, 2024-02-01, rev 0x00f8, size 106496
    sig 0x000906ed, pf_mask 0x22, 2024-02-05, rev 0x0100, size 106496
    sig 0x000a0652, pf_mask 0x20, 2024-02-01, rev 0x00fc, size 97280
    sig 0x000a0653, pf_mask 0x22, 2024-02-01, rev 0x00fc, size 98304
    sig 0x000a0655, pf_mask 0x22, 2024-02-01, rev 0x00fc, size 97280
    sig 0x000a0660, pf_mask 0x80, 2024-02-01, rev 0x00fe, size 97280
    sig 0x000a0661, pf_mask 0x80, 2024-02-01, rev 0x00fc, size 97280
    sig 0x000a0671, pf_mask 0x02, 2024-03-07, rev 0x0062, size 108544
    sig 0x000a06a4, pf_mask 0xe6, 2024-04-15, rev 0x001e, size 137216
  * source: update symlinks to reflect id of the latest release, 20240813
  * postinst, postrm: switch to dpkg-trigger to run update-initramfs

 -- Henrique de Moraes Holschuh <hmh@debian.org>  Thu, 15 Aug 2024 14:41:50 -0300
```