### PR TITLE
[24.10] ramips: Add support for Cudy M1300 v2

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_m1300-v2.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_m1300-v2.dts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "cudy,m1300-v2", "mediatek,mt7621-soc";
+	model = "Cudy M1300 v2";
+};
+
+/ {
+	aliases {
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_white;
+		led-upgrade = &led_status_red;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-status-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_white: led-status-white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "debug";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "backup";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "bdinfo";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+       wifi@0,0 {
+               compatible = "mediatek,mt76";
+               reg = <0x0000 0 0 0 0>;
+               nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 0>;
+               nvmem-cell-names = "eeprom", "mac-address";
+               ieee80211-freq-limit = <2400000 2500000>;
+       };
+};
+
+&pcie1 {
+       wifi@0,0 {
+               compatible = "mediatek,mt76";
+               reg = <0x0000 0 0 0 0>;
+               nvmem-cells = <&eeprom_factory_8000>, <&macaddr_bdinfo_de00 2>;
+               nvmem-cell-names = "eeprom", "mac-address";
+               ieee80211-freq-limit = <5000000 6000000>;
+       };
+};
+
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_bdinfo_de00 2>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@3 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "jtag";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -685,6 +685,19 @@ define Device/confiabits_mt7621-v1
 endef
 TARGET_DEVICES += confiabits_mt7621-v1
 
+define Device/cudy_m1300-v2
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := M1300
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+	-uboot-envtools
+  UIMAGE_NAME := R15
+  SUPPORTED_DEVICES += R15
+endef
+TARGET_DEVICES += cudy_m1300-v2
+
 define Device/cudy_m1800
   $(Device/dsa-migration)
   DEVICE_VENDOR := Cudy

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -70,6 +70,7 @@ ramips_setup_interfaces()
 	asiarf,ap7621-001|\
 	comfast,cf-e390ax|\
 	comfast,cf-ew72-v2|\
+	cudy,m1300-v2|\
 	cudy,m1800|\
 	dna,valokuitu-plus-ex400|\
 	genexis,pulse-ex400|\


### PR DESCRIPTION
The M1300 v2 is similar to the WR1300 series from Cudy. Differences:
- Only 1 LAN port
- No USB

Specifications:
- MT7621
- MT7603E (2.4G b/g/n) and MT7613BE (5G ac/n) wifi
- 128 MB RAM
- 16 MB flash

MAC Addresses:
- There is one on the label, e.g. xx:xx:xx:xx:xx:1C
- LAN (bottom connector) is the same as the label, e.g. xx:xx:xx:xx:xx:1C
- WAN (top connector) is label +2, e.g. xx:xx:xx:xx:xx:1E
- WLAN (2.4G) is the same as the label, e.g. xx:xx:xx:xx:xx:1C
- WLAN (5G) is the same as WAN, e.g. xx:xx:xx:xx:xx:1E

UART:
- is available via the pin holes on the board
- From inner to outer pin: TX, RX, GND, VCC
- Do NOT connect VCC
- Settings: 3.3V, 115200, 8N1

GPIO:
- There are two LEDs: Red (GPIO 3) and White (GPIO 4)
- There are two buttons: Reset (GPIO 8) and WPS (GPIO 10)

Migration to OpenWrt:
- Download the migration image from the Cudy website (it should be available as soon as OpenWrt officially supports the device)
- The migration image is also available here until a image is provided by Cudy: https://github.com/RolandoMagico/openwrt-build/releases/tag/M1300_Build_20240222
- File: openwrt-ramips-mt7621-cudy_m1300-v2-squashfs-flash-signed.bin
- Connect computer to LAN (bottom connector) and flash the migration image via OEM web interface
- In the migration image, LAN and WAN are swapped. Computer must be connected to the other port after flashing
- OpenWrt is now accessible via 192.168.1.1
- After flashing an up to date OpenWrt image, LAN and WAN settings are again the same as in the OEM firmware
- So use the other connector again

Revert back to OEM firmware:
- Set up a TFTP server on IP 192.168.1.88 and connect to the LAN port (lower port)
- Provide the Cudy firmware as recovery.bin in the TFTP server
- Press the reset button while powering on the device
- Recovery process is started now
- When recovery process is done, OEM firmware is accessible via 192.168.10.1 again

General information:
- No possibility to load a initramfs image via U-Boot because there is no option to interrupt U-Boot