### PR TITLE
mediatek: filogic: add support for 7Links WLR-1300

### DIFF
--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -3,7 +3,8 @@ set_preinit_iface() {
 	cudy,m3000-v1|\
 	cudy,tr3000-v1|\
 	glinet,gl-mt3000|\
-	openembed,som7981)
+	openembed,som7981|\
+	wavlink,wl-wn573hx3)
 		ip link set eth1 up
 		ifname=eth1
 		;;

--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn573hx3.dts
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn573hx3.dts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "WAVLINK WL-WN573HX3";
+	compatible = "wavlink,wl-wn573hx3", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &wifi;
+
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			gpios = <&pio 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_blue: led-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	status = "okay";
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cells = <&macaddr_hw_44e 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&spi0 {
+	status = "disabled";
+};
+
+&spi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@00000 {
+				label = "bl2";
+				reg = <0x00000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@50000 {
+				label = "factory";
+				reg = <0x50000 0xb0000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
+			};
+
+			partition@100000 {
+				label = "fip";
+				reg = <0x100000 0x80000>;
+				read-only;
+			};
+
+			partition@f0000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0x180000 0xe00000>;
+			};
+
+			partition@f80000 {
+				label = "hw";
+				reg = <0xf80000 0x80000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_hw_44e: macaddr@44e {
+						compatible = "mac-base";
+						reg = <0x44e 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+	spi2_flash_pins: spi2-pins {
+		mux {
+			function = "spi";
+			groups = "spi2", "spi2_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <8>;
+			bias-pull-up = <103>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <8>;
+			bias-pull-down = <103>;
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -44,7 +44,8 @@ bananapi,bpi-r4-poe)
 	ucidef_set_led_netdev "lan2" "lan2" "mt7530-0:02:green:lan" "lan2" "link tx rx"
 	ucidef_set_led_netdev "lan3" "lan3" "mt7530-0:03:green:lan" "lan3" "link tx rx"
 	;;
-cudy,re3000-v1)
+cudy,re3000-v1|\
+wavlink,wl-wn573hx3)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0" "link tx rx"
 	;;
 cudy,wr3000-v1)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -82,6 +82,7 @@ mediatek_setup_interfaces()
 	cudy,re3000-v1|\
 	netgear,wax220|\
 	ubnt,unifi-6-plus|\
+	wavlink,wl-wn573hx3|\
 	zyxel,nwa50ax-pro)
 		ucidef_set_interface_lan "eth0"
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -171,6 +171,10 @@ case "$board" in
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		;;
+	wavlink,wl-wn573hx3)
+		addr=$(mtd_get_mac_binary factory 0x04)
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr -0x300000) > /sys${DEVPATH}/macaddress
+		;;
 	zyxel,nwa50ax-pro)
 		hw_mac_addr="$(mtd_get_mac_binary mrd 0x1fff8)"
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -127,7 +127,8 @@ platform_do_upgrade() {
 		;;
 	cudy,re3000-v1|\
 	cudy,wr3000-v1|\
-	yuncore,ax835)
+	yuncore,ax835|\
+	wavlink,wl-wn573hx3)
 		default_do_upgrade "$1"
 		;;
 	dlink,aquila-pro-ai-m30-a1|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1586,6 +1586,24 @@ define Device/wavlink_wl-wn586x3
 endef
 TARGET_DEVICES += wavlink_wl-wn586x3
 
+define Device/wavlink_wl-wn573hx3
+  DEVICE_VENDOR := WAVLINK
+  DEVICE_MODEL := WL-WN573HX3
+  DEVICE_ALT0_VENDOR := 7Links
+  DEVICE_ALT0_MODEL := WLR-1300
+  DEVICE_DTS := mt7981b-wavlink-wl-wn573hx3
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  IMAGE_SIZE := 14336k
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-nor-rfb
+  IMAGES = WN573HX3-sysupgrade.bin
+  IMAGE/WN573HX3-sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+TARGET_DEVICES += wavlink_wl-wn573hx3
+
 define Device/xiaomi_mi-router-ax3000t
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router AX3000T


### PR DESCRIPTION
The WLR-1300 (ZX-5612) is an AX3000 outdoor Access Point sold in Europe, based on the Wavlink WL-WN573HX3.

Specifications:

- MT7981B + MT7976 AX3000 2x2 DBDC (160 MHz)
- 16 MiB SPI NOR, 256 MiB RAM
- Gigabit ethernet port, 802.3af PoE
- IP67 outdoor case for wall or pole mounting with four single band RP-SMA fiberglass antennas (8 dBi)

Installation:

- OEM Web UI is at 192.168.30.1 which will forward to http://netlogin.link (using a captive portal)
- login with default password `admin`
- skip setup wizard by navigating directly to http://netlogin.link/html/meshUpgrade.html
- rename sysupgrade to contain `WN573HX3` before upload
- reset to factory defaults to discard OEM UCI settings

MAC address assignment:
```
LAN         80:xx:xx:76:xx:25  hw 0x44e
WLAN 2.4G   80:xx:xx:76:xx:27  factory 0x04 (label MAC)
WLAN 5G	    82:xx:xx:46:xx:27
pair key    8a:xx:xx:76:xx:27  also on label, not used by OpenWrt
```
---------------------------

The OEM firmware on this device uses sysupgrade without the option to discard current UCI settings,
so the user should perform a factory reset after flashing to obtain a clean default configuration.

A script that would automatically call `firstboot` after initial flashing, triggered by the existence of a certain vendor-specific UCI key, was previously rejected while adding support for another device affected by this (https://github.com/openwrt/openwrt/pull/4174#issuecomment-842434735).


The hardware of this device seems to be quite identical to the WL-WN573HX3 available directly from china.
I wonder if we could create something like an alias to support both names for the device; however the full human-readable model name given in the .dts should read 7Links here, since the WN573HX3 model name is not visible anywhere on the device label or packaging.
(Also a major use case for this access point would be as an outdoor node for gluon, and the name displayed e.g. on Freifunk maps should reflect what the user would actually search for to buy this device (e.g. on ebay, Kleinanzeigen etc.), not the chinese version that would be more expensive to buy from overseas).

I do not own the chinese model (there might indeed be further differences e.g. in the eeprom partition due to the different regdomain), however the Wavlink firmware was accepted by the updater of the 7Links-branded device, although the "7Links" brand still remained at some places in the web config, as it is also stored in UCI, which will be kept during sysupgrade.

Does it make any sense to keep `wavlink,wl-wn573hx3` in the compatible property though?


The string `WN573HX3` needs to be present within the uploaded filename to be accepted by the OEM web-based updater.
I wonder if we could somehow append this to the sysupgrade image without breaking lots of downstream projects / firmware selectors etc.?
(e.g. something like `openwrt-mediatek-filogic-7links_wlr-1300-squashfs-WN573HX3-sysupgrade.bin`)

For the Zyxel NWA112x series this was done, but for the factory images; this device however does not need a special factory image besides sysupgrade, and I would prefer not to have an identical copy of the sysupgrade image named "factory" just for the different filename.


Regarding MAC addresses, there is an additional interface for meshing in OEM firmware that would use MAC address
`82:xx:xx:76:xx:27` (i.e. just the 2.4G MAC with `la` bit set), however the BSSID used as AP for STA connections has bits 20-21 set to zero. Maybe this correlates to the warning from `11_fix_wifi_mac` about conflicting VIF addresses, which is why they introduced yet another offset here?

I'm not sure if `macaddr_add $addr -0x300000` is the ideal solution though, however I currently just own this one device, so I have no idea what the assignment might look like for different addresses (e.g. if that nibble were less than 3 initially). 
