### PR TITLE
ipq40xx: add support for Aliyun AP4220

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/ipq40xx
@@ -32,6 +32,7 @@ ubootenv_mtdinfo () {
 
 case "$board" in
 alfa-network,ap120c-ac|\
+aliyun,ap4220|\
 devolo,magic-2-wifi-next|\
 edgecore,ecw5211|\
 glinet,gl-a1300 |\

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -28,6 +28,7 @@ endef
 
 ALLWIFIBOARDS:= \
 	8devices_mango \
+	aliyun_ap4220 \
 	aliyun_ap8220 \
 	arcadyan_aw1000 \
 	asus_rt-ax89x \
@@ -177,6 +178,7 @@ endef
 #   board-<devicename>.<qca4019|qca9888|qca9889|qca9984|qca99x0|ipq6018|ipq8074>
 
 $(eval $(call generate-ipq-wifi-package,8devices_mango,8devices Mango))
+$(eval $(call generate-ipq-wifi-package,aliyun_ap4220,Aliyun AP4220))
 $(eval $(call generate-ipq-wifi-package,aliyun_ap8220,Aliyun AP8220))
 $(eval $(call generate-ipq-wifi-package,arcadyan_aw1000,Arcadyan AW1000))
 $(eval $(call generate-ipq-wifi-package,asus_rt-ax89x,Asus RT-AX89X))

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -31,6 +31,7 @@ ipq40xx_setup_interfaces()
 		;;
 	8dev,jalapeno|\
 	alfa-network,ap120c-ac|\
+	aliyun,ap4220|\
 	asus,map-ac2200|\
 	cilab,meshpoint-one|\
 	edgecore,ecw5211|\
@@ -170,6 +171,11 @@ ipq40xx_setup_macs()
 	case "$board" in
 	8dev,habanero-dvk)
 		label_mac=$(mtd_get_mac_binary "ART" 0x1006)
+		;;
+	aliyun,ap4220)
+		wan_mac=$(mtd_get_mac_text product_info 0x40)
+		lan_mac=$(macaddr_add "$wan_mac" 1)
+		label_mac="$wan_mac"
 		;;
 	asus,rt-ac42u)
 		label_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -57,6 +57,10 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-ahb-a000000.wifi.bin")
 	case "$board" in
+	aliyun,ap4220)
+		caldata_extract "ART" 0x1000 0x2f20
+		ath10k_patch_mac $(macaddr_add "$(mtd_get_mac_text product_info 0x40)" 2)
+		;;
 	asus,map-ac2200|\
 	asus,rt-ac42u)
 		caldata_extract_ubi "Factory" 0x1000 0x2f20
@@ -157,6 +161,10 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-ahb-a800000.wifi.bin")
 	case "$board" in
+	aliyun,ap4220)
+		caldata_extract "ART" 0x5000 0x2f20
+		ath10k_patch_mac $(macaddr_add "$(mtd_get_mac_text product_info 0x40)" 3)
+		;;
 	asus,map-ac2200)
 		caldata_extract_ubi "Factory" 0x5000 0x2f20
 		;;

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -134,7 +134,8 @@ platform_do_upgrade() {
 		CI_DATAPART="rootfs_data"
 		emmc_do_upgrade "$1"
 		;;
-	alfa-network,ap120c-ac)
+	alfa-network,ap120c-ac|\
+	aliyun,ap4220)
 		part="$(awk -F 'ubi.mtd=' '{printf $2}' /proc/cmdline | sed -e 's/ .*$//')"
 		if [ "$part" = "rootfs1" ]; then
 			fw_setenv active 2 || exit 1

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap4220.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ap4220.dts
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	compatible = "aliyun,ap4220", "qcom,ipq4019";
+	model = "Aliyun AP4220";
+
+	aliases {
+		label-mac-device = &gmac;
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	chosen {
+		bootargs-append = " root=/dev/ubiblock0_1";
+		stdout-path = "serial:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&tlmm 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_status: led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&tlmm 5 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+	};
+
+	reg_usb: regulator-usb {
+		compatible = "regulator-fixed";
+		gpios = <&tlmm 1 GPIO_ACTIVE_LOW>;
+		regulator-max-microvolt = <5000000>;
+		regulator-min-microvolt = <5000000>;
+		regulator-name = "reg_usb";
+	};
+
+	soc {
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_spi1 {
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+	num-cs = <2>;
+	pinctrl-0 = <&spi0_pins>;
+	pinctrl-names = "default";
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>, <&tlmm 4 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <24000000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "SBL1";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "MIBIB";
+				reg = <0x40000 0x20000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "QSEE";
+				reg = <0x60000 0x60000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				label = "CDT";
+				reg = <0xc0000 0x10000>;
+				read-only;
+			};
+
+			partition@d0000 {
+				label = "DDRPARAMS";
+				reg = <0xd0000 0x10000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				compatible = "u-boot,env";
+				label = "APPSBLENV";
+				reg = <0xe0000 0x10000>;
+			};
+
+			partition@f0000 {
+				label = "APPSBL";
+				reg = <0xf0000 0x80000>;
+				read-only;
+			};
+
+			partition@170000 {
+				label = "ART";
+				reg = <0x170000 0x10000>;
+				read-only;
+			};
+
+			partition@180000 {
+				label = "product_info";
+				reg = <0x180000 0x10000>;
+				read-only;
+			};
+
+			partition@190000 {
+				label = "mtdoops";
+				reg = <0x190000 0x20000>;
+			};
+
+			partition@1b0000 {
+				label = "priv_data1";
+				reg = <0x1b0000 0x10000>;
+				read-only;
+			};
+
+			partition@1c0000 {
+				label = "priv_data2";
+				reg = <0x1c0000 0x10000>;
+				read-only;
+			};
+
+			partition@1d0000 {
+				label = "priv_data3";
+				reg = <0x1d0000 0x200000>;
+				read-only;
+			};
+		};
+	};
+
+	spi-nand@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "rootfs1";
+				reg = <0x0 0x3000000>;
+			};
+
+			partition@3000000 {
+				label = "rootfs2";
+				reg = <0x3000000 0x3000000>;
+			};
+
+			partition@6000000 {
+				label = "usrdata";
+				reg = <0x6000000 0x2000000>;
+			};
+		};
+	};
+};
+
+&blsp1_uart1 {
+	status = "okay";
+
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&ethphy0 {
+	status = "disabled";
+};
+
+&ethphy1 {
+	status = "disabled";
+};
+
+&ethphy2 {
+	status = "disabled";
+};
+
+&ethphy3 {
+	status = "okay";
+};
+
+&ethphy4 {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+};
+
+&prng {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "wan";
+};
+
+&swport5 {
+	status = "okay";
+
+	label = "lan";
+};
+
+&tlmm {
+	mdio_pins: mdio_pinmux {
+		mdc {
+			pins = "gpio52";
+			function = "mdc";
+			drive-strength = <4>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio53";
+			function = "mdio";
+			drive-strength = <4>;
+			bias-pull-up;
+		};
+	};
+
+	serial_pins: serial_pinmux {
+		blsp_uart0 {
+			pins = "gpio60", "gpio61";
+			function = "blsp_uart0";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	spi0_pins: spi0_pinmux {
+		blsp_spi0 {
+			pins = "gpio55", "gpio56", "gpio57";
+			function = "blsp_spi0";
+			drive-strength = <12>;
+			bias-disable;
+		};
+
+		gpio {
+			pins = "gpio54", "gpio4";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+
+	phy-supply = <&reg_usb>;
+};
+
+&usb3_ss_phy {
+	status = "okay";
+
+	phy-supply = <&reg_usb>;
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi0 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Aliyun-AP4220";
+};
+
+&wifi1 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Aliyun-AP4220";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -170,6 +170,18 @@ define Device/alfa-network_ap120c-ac
 endef
 TARGET_DEVICES += alfa-network_ap120c-ac
 
+define Device/aliyun_ap4220
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Aliyun
+	DEVICE_MODEL := AP4220
+	SOC := qcom-ipq4018
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_PACKAGES := ipq-wifi-aliyun_ap4220
+endef
+TARGET_DEVICES += aliyun_ap4220
+
 define Device/aruba_glenmorangie
 	$(call Device/FitImageLzma)
 	DEVICE_VENDOR := Aruba


### PR DESCRIPTION
Hardware specifications
-------------
- SoC       : Qualcomm IPQ4018
- RAM       : 256 MiB DDR3
- Flash     : 4 MiB SPI NOR (Winbond) + 128 MiB SPI NAND (Winbond)
- WLAN      : IPQ4018 built-in
  - 2.4 GHz : 2x2 MIMO WiFi4
  - 5 GHz   : 2x2 MIMO WiFi5
- Ethernet  : QCA8072 10/100/1000 Mbps 1x WAN (PoE); 1x LAN
- USB       : 1x 2.0
- UART      : 1x Rj45 port, 115200n8
- Buttons   : 1x Reset
- LEDs      : 1x Power (green)
              1x WiFi 2.4 GHz (green)
              1x WiFi 5 GHz (green)
- Power     : 802.3at PoE

Flash instructions
-------------
  1. Connect the router via serial port
  2. Keep pressing "@" until uboot is interrupted
  3. Download the initramfs image, rename it to initramfs.bin, host it with tftp server
  4. Run these commands: "tftpboot initramfs.bin && bootm"
  5. After openwrt boots up, use scp or luci to upload sysupgrade.bin to upgrade.
