### PR TITLE
[24.10] ramips: add support for Hongdian H8922 v30

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -19,6 +19,7 @@ alfa-network,r36m-e4g|\
 alfa-network,tube-e4g|\
 engenius,epg600|\
 engenius,esr600h|\
+hongdian,h8922-v30|\
 linksys,re7000|\
 meig,slt866|\
 sitecom,wlr-4100-v1-002|\

--- a/package/kernel/mac80211/patches/rt2x00/603-wifi-rt2x00-Add-support-for-loading-EEPROM-from-devicetree-embedded-data.patch
+++ b/package/kernel/mac80211/patches/rt2x00/603-wifi-rt2x00-Add-support-for-loading-EEPROM-from-devicetree-embedded-data.patch
@@ -1,0 +1,76 @@
+From adf957124a115bdf3e4728e1ea8c70a632648cf0 Mon Sep 17 00:00:00 2001
+From: Coia Prant <coiaprant@gmail.com>
+Date: Fri, 14 Feb 2025 15:49:55 +0800
+Subject: [PATCH] wifi: rt2x00: Add support for loading EEPROM from devicetree
+ embedded data
+
+This patch allows rt2x00 to load eeprom from devicetree embedded data.
+
+Example:
+
+/* load eeprom from embedded data 'eeprom-data' */
+&wmac {
+	ralink,eeprom-data = <0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff>;
+};
+
+Signed-off-by: Coia Prant <coiaprant@gmail.com>
+---
+ .../net/wireless/ralink/rt2x00/rt2x00eeprom.c | 25 +++++++++++++++++++
+ 1 file changed, 25 insertions(+)
+
+--- a/drivers/net/wireless/ralink/rt2x00/rt2x00eeprom.c
++++ b/drivers/net/wireless/ralink/rt2x00/rt2x00eeprom.c
+@@ -33,6 +33,27 @@ static void rt2800lib_eeprom_swap(struct
+ 		rt2x00dev->eeprom[i] = swab16(rt2x00dev->eeprom[i]);
+ }
+ 
++static int rt2800lib_read_eeprom_data(struct rt2x00_dev *rt2x00dev)
++{
++	struct device_node *np = rt2x00dev->dev->of_node;
++	unsigned int len = rt2x00dev->ops->eeprom_size;
++	const void *data;
++	int size;
++
++	data = of_get_property(np, "ralink,eeprom-data", &size);
++	if (!data)
++		return -ENOENT;
++
++	if (size != len) {
++		dev_err(rt2x00dev->dev, "invalid eeprom size, required: 0x%04x\n", len);
++		return -EINVAL;
++	}
++
++	memcpy(rt2x00dev->eeprom, data, size);
++
++	return 0;
++}
++
+ #if IS_ENABLED(CONFIG_MTD)
+ static int rt2800lib_read_eeprom_mtd(struct rt2x00_dev *rt2x00dev)
+ {
+@@ -193,6 +214,10 @@ int rt2x00lib_read_eeprom(struct rt2x00_
+ {
+ 	int ret;
+ 
++	ret = rt2800lib_read_eeprom_data(rt2x00dev);
++	if (!ret)
++		return 0;
++
+ #if IS_ENABLED(CONFIG_MTD)
+ 	ret = rt2800lib_read_eeprom_mtd(rt2x00dev);
+ 	if (!ret)

--- a/target/linux/ramips/dts/mt7620a_hongdian_h8922-v30.dts
+++ b/target/linux/ramips/dts/mt7620a_hongdian_h8922-v30.dts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7620a.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "hongdian,h8922-v30", "ralink,mt7620a-soc";
+	model = "Hongdian H8922 v30";
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-wps {
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+		};
+
+		led-rf-2 {
+			gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = "rf";
+			function-enumerator = <2>;
+		};
+
+		led_sys: led-sys {
+			gpios = <&gpio1 2 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			default-state = "on";
+		};
+
+		led-net-1 {
+			gpios = <&gpio2 26 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_MOBILE;
+			function-enumerator = <1>;
+		};
+
+		led-rf-1 {
+			gpios = <&gpio2 27 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = "rf";
+			function-enumerator = <1>;
+		};
+
+		led-net-2 {
+			gpios = <&gpio2 31 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_MOBILE;
+			function-enumerator = <2>;
+		};
+
+		led-wlan {
+			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+
+		gpios = <&gpio2 22 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <600>;
+		always-running;
+	};
+};
+
+&watchdog {
+	status = "disabled";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&gpio2 {
+	status = "okay";
+};
+
+&gpio3 {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x2f000>;
+				read-only;
+			};
+
+			partition@2f000 {
+				label = "u-boot-env";
+				reg = <0x2f000 0x1000>;
+				read-only;
+			};
+
+			partition@30000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x30000 0xffd000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wled", "rgmii1", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&ephy_pins>;
+
+	mediatek,portmap = "llllw";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&wmac {
+	ralink,eeprom-data = <0x20760501 0x000c4376 0x2058ffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0x000c4376 0x2077000c 0x43762066 0x220c0000 0xffffb701 0x5577a8aa
+			      0x8c88ffff 0x0a000000 0x00000000 0x0000ffff 0xffff0a0a 0x0a0a0808 0x08080808 0x08080808
+			      0x0e0e0e0e 0x0e0e0e0e 0x0e0e0e0e 0x0e0e80ff 0xffff80ff 0xffff0000 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0x20ffffff 0xffffffff 0xffffffff 0xffff0606
+			      0x06060402 0x06060400 0x06060400 0x07070400 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff
+			      0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff 0xffffffff>;
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};

--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -604,6 +604,18 @@ define Device/hnet_c108
 endef
 TARGET_DEVICES += hnet_c108
 
+define Device/hongdian_h8922-v30
+  SOC := mt7620a
+  IMAGE_SIZE := 15808k
+  DEVICE_VENDOR := Hongdian
+  DEVICE_MODEL := H8922
+  DEVICE_VARIANT := v30
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi uboot-envtools
+  IMAGES += rootfs.bin
+  IMAGE/rootfs.bin := append-rootfs | check-size 10560k
+endef
+TARGET_DEVICES += hongdian_h8922-v30
+
 define Device/humax_e2
   SOC := mt7620a
   IMAGE_SIZE := 7744k

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -15,6 +15,7 @@ ramips_setup_interfaces()
 	dlink,dwr-921-c1|\
 	dlink,dwr-922-e2|\
 	dovado,tiny-ac|\
+	hongdian,h8922-v30|\
 	ohyeah,oy-0001|\
 	phicomm,psg1208|\
 	planex,db-wrt01|\


### PR DESCRIPTION
Backported from #17472 

---

This is an industrial 4G router equipped with OpenWrt 14.07 OEM customized version

WARNING: The original firmware device tree is common to multiple boards, and the device tree name is H9350. This submitted device tree is a modified version, which deletes the non-this-device parts and adds GPIO watchdog.

Specification:
- SoC: MediaTek MT7620A
- Flash: 16 MB
- RAM: 128 MB
- Power: DC 5V-36V 1.5A
- Ethernet: 1x WAN, 4x LAN (10/100 Mbps)
- Wireless radio: 802.11n 2.4g-only
- LED: 
  - System/Power (RUN): GPIO/26 active-low
  - Ethernet: 1x WAN, 4x LAN
  - Modem 1: GPIO/66 active-low
  - RF 1 (Modem 1 Signal): GPIO/67 active-low
  - Modem 2: GPIO 71 active-low
  - RF 2 (Modem 2 Signal): GPIO/24 active-low 
  - WLAN: GPIO/72 active-low
  - WPS: GPIO/12 active-low
- Button: 
  - WPS / RESET: GPIO/34 active-low
- UART: 1x UART on PCB - 115200 8N1
- GPIO Watchdog: GPIO/62 mode=toggle timeout=1s
- PCIe: 2x miniPCIe for modem
- SIM Slots: 2x SIM Slots

Issue:
- No factory partition, eeprom is located at /lib/firmware/mt7620a.eeprom

Flash instruction:
Using UART:
1. Configure PC with a static IP address and setup an TFTP server.
2. Put rootfs into the tftp directory.
3. Connect the UART line as described on the PCB.
4. Power up the device and press Ctrl+C to break auto boot.
5. Use `system 6` command and follow the instruction to set device and tftp server IP address and input the rootfs file name. U-boot will then load the rootfs and write it into the flash.
6. Use `system 1` command and follow the instruction to set device and tftp server IP address and input the firmware file name. U-boot will then load the firmware once.
7. Login to LuCI and use LuCI upgrade firmware.

Original Firmware Dump / More details:
https://blog.gov.cooking/archives/research-hongdian-h8922-and-flash.html

---

Original U-Boot WebUI and UART Console upgrade firmware has header magic verification. We do not know it now.
But boot linux once, update kernel and update rootfs also check header. But its uImage and squashfs header.
Unfortunately, the kernel accepts a maximum of 1.5M.
So we must update rootfs first, and boot firmware once. (Directly boot initramfs-kernel was failed, it will auto reboot)
Then we can go to openwrt and flash full firmware to nor.
