### PR TITLE
qualcommax: ipq60xx: add support for tp-link eap620-hd-v2

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
@@ -39,6 +39,7 @@ netgear,wax610|\
 netgear,wax610y|\
 tplink,eap610-outdoor|\
 tplink,eap623-outdoor-hd-v1|\
+tplink,eap620-hd-v2|\
 tplink,eap620-hd-v3|\
 tplink,eap625-outdoor-hd-v1)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -95,6 +95,7 @@ ALLWIFIBOARDS:= \
 	tplink_deco-x80-5g \
 	tplink_eap225-wall-v2 \
 	tplink_eap610-outdoor \
+	tplink_eap620-hd-v2 \
 	tplink_eap620-hd-v3 \
 	tplink_eap620hd-v1 \
 	tplink_eap623-outdoor-hd-v1 \
@@ -293,6 +294,7 @@ $(eval $(call generate-ipq-wifi-package,tplink_archer-c60-v2,TP-Link Archer C60 
 $(eval $(call generate-ipq-wifi-package,tplink_deco-x80-5g,TP-Link Deco X80-5G))
 $(eval $(call generate-ipq-wifi-package,tplink_eap225-wall-v2,TP-Link EAP225-Wall v2))
 $(eval $(call generate-ipq-wifi-package,tplink_eap610-outdoor,TPLink EAP610-Outdoor))
+$(eval $(call generate-ipq-wifi-package,tplink_eap620-hd-v2,TP-Link EAP620 HD v2))
 $(eval $(call generate-ipq-wifi-package,tplink_eap620-hd-v3,TP-Link EAP620 HD v3))
 $(eval $(call generate-ipq-wifi-package,tplink_eap620hd-v1,TP-Link EAP620 HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap623-outdoor-hd-v1,TP-Link EAP623-Outdoor HD v1))

--- a/target/linux/qualcommax/dts/ipq6018-eap620-hd-v2.dts
+++ b/target/linux/qualcommax/dts/ipq6018-eap620-hd-v2.dts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq6018-tplink-eap6xx-outdoor.dtsi"
+
+/ {
+	model = "TP-Link EAP620HD v2";
+	compatible = "tplink,eap620-hd-v2", "qcom,ipq6018";
+
+	/* Delete EAP6xx outdoor leds node to redefine it. */
+	/delete-node/ leds;
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status-blue {
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 35 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+	};
+};
+
+&mdio {
+	rtl8211f_4: ethernet-phy@4 {
+		reg = <4>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+	};
+};
+
+&tlmm {
+	gpio-reserved-ranges = <20 1>;
+};
+
+&swport5 {
+	phy-handle = <&rtl8211f_4>;
+};
+
+&wifi {
+	qcom,ath11k-calibration-variant = "TP-Link-EAP620-HD-v2";
+	status = "okay";
+};

--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -299,6 +299,25 @@ define Device/tplink_eap625-outdoor-hd-v1
 endef
 TARGET_DEVICES += tplink_eap625-outdoor-hd-v1
 
+define Device/tplink_eap620-hd-v2
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := TP-Link
+	DEVICE_MODEL := EAP620 HD v2
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq6018
+	DEVICE_PACKAGES := ipq-wifi-tplink_eap620-hd-v2
+	IMAGES += web-ui-factory.bin
+	IMAGE/web-ui-factory.bin := append-ubi | tplink-image-2022
+	TPLINK_SUPPORT_STRING := SupportList:\r\n \
+		EAP620 HD(TP-Link|UN|AX1800-D):2.0\r\n \
+		EAP620 HD(TP-Link|CA|AX1800-D):2.0\r\n \
+		EAP620 HD(TP-Link|JP|AX1800-D):2.0\r\n \
+		EAP620 HD(TP-Link|EG|AX1800-D):2.0\r\n
+endef
+TARGET_DEVICES += tplink_eap620-hd-v2
+
 define Device/tplink_eap620-hd-v3
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
@@ -43,6 +43,7 @@ ipq60xx_setup_interfaces()
 	netgear,wax610|\
 	netgear,wax610y|\
 	tplink,eap610-outdoor|\
+	tplink,eap620-hd-v2|\
 	tplink,eap620-hd-v3|\
 	tplink,eap623-outdoor-hd-v1|\
 	tplink,eap625-outdoor-hd-v1)
@@ -71,6 +72,7 @@ ipq60xx_setup_macs()
 		label_mac=$lan_mac
 		;;
 	tplink,eap610-outdoor|\
+	tplink,eap620-hd-v2|\
 	tplink,eap620-hd-v3|\
 	tplink,eap623-outdoor-hd-v1|\
 	tplink,eap625-outdoor-hd-v1)

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -86,6 +86,7 @@ case "$FIRMWARE" in
 		ath11k_patch_mac $(macaddr_add $label_mac 1) 0
 		ath11k_set_macflag
 		;;
+	tplink,eap620-hd-v2|\
 	tplink,eap620-hd-v3)
 		caldata_from_file "/tmp/factory_data/radio" 0 0x20000
 		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/preinit/09_mount_factory_data
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/preinit/09_mount_factory_data
@@ -8,6 +8,7 @@ preinit_mount_factory_data() {
 
 	case $(board_name) in
 	tplink,eap610-outdoor|\
+	tplink,eap620-hd-v2|\
 	tplink,eap620-hd-v3|\
 	tplink,eap623-outdoor-hd-v1|\
 	tplink,eap625-outdoor-hd-v1)

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
@@ -235,6 +235,7 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	tplink,eap610-outdoor|\
+	tplink,eap620-hd-v2|\
 	tplink,eap620-hd-v3|\
 	tplink,eap623-outdoor-hd-v1|\
 	tplink,eap625-outdoor-hd-v1)


### PR DESCRIPTION
TP-Link EAP620HD V2 is a 802.11ax AP claiming AX1800 support.

Specifications:
---------------
* CPU: Qualcomm IPQ6018 Quad core Cortex-A53
* RAM: 1 GB
* Storage: ESMT PSR1GA30DT 128MB NAND
* Ethernet:
  * Gigabit RJ45 port with PoE input
* WLAN:
  * 2.4GHz/5GHz
* LEDs:
  * Single-color LED (Blue)
* Buttons:
  * 1x Reset
* UART: 4-pin unpopulated header
  * 1.8 V level, Pinout 1 - TX, 2 - RX, 3 - GND, 4 - 1.8V

Installation:
=============

Web UI method
-------------

Set up the device using the vendor's web UI. After that go to
Management->SSH and enable the "SSH Login" checkbox. Select "Save".
The connect to the machine via SSH:

    ssh -o hostkeyalgorithms=ssh-rsa <ip_of_device>

Disable signature verification:

    cliclientd stopcs

Rename the "-web-ui-factory" image to something less than 63
characters, maintaining the ".bin" suffix.
 * Go to System -> Firmware Update.
 * Under "New Firmware File", click "Browse" and select the image
 * Select "Update" and confirm by clicking "OK".

If the update fails, the web UI should show an error message.
Otherwise, the device should reboot into OpenWRT.

TFTP method
-----------

To flash via tftp, first place the initramfs image on the TFTP server.

    setenv serverip <ip of tftp server>
    setenv ipaddr <ip in same subnet as tftp server>
    tftpboot tplink_eap620-hd-v2-initramfs-uImage.itb
    bootm

This should boot OpenWRT. Once booted, flash the sysupgrade.bin image
using either luci or the commandline.

Big thanks to @mrnuke for the groundwork and support.

Signed-off-by: Ryan S <rspierz@gmail.com>