### PR TITLE
ath79: fix chipidea usb controller detection

### DIFF
--- a/target/linux/ath79/dts/ar9330.dtsi
+++ b/target/linux/ath79/dts/ar9330.dtsi
@@ -121,7 +121,7 @@
 			interrupts = <3>;
 			resets = <&rst 5>;
 
-			phy-names = "usb";
+			phy-names = "usb-phy";
 			phys = <&usb_phy>;
 
 			status = "disabled";


### PR DESCRIPTION
RUT240 does not detect usb hub after phy-names changed to "usb"
https://github.com/openwrt/openwrt/commit/787cb9d87edbf3c853328bf26e41dcff2ddde8c8
