### PR TITLE
treewide: move default WLAN LED trigger to dts for some targets

### DIFF
--- a/target/linux/ath79/dts/ar9331_hiwifi_hc6361.dts
+++ b/target/linux/ath79/dts/ar9331_hiwifi_hc6361.dts
@@ -41,6 +41,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 		wan {
 			function = LED_FUNCTION_WAN;

--- a/target/linux/ath79/dts/ar9344_netgear_pgzng1.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_pgzng1.dts
@@ -83,6 +83,7 @@
 				color = <LED_COLOR_ID_GREEN>;
 				function = LED_FUNCTION_WLAN;
 				type = <PCA955X_TYPE_LED>;
+				linux,default-trigger = "phy0tpt";
 			};
 
 			led@5 {

--- a/target/linux/ath79/dts/ar9344_qihoo_c301.dts
+++ b/target/linux/ath79/dts/ar9344_qihoo_c301.dts
@@ -25,6 +25,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_wlan_o: wlan_o {

--- a/target/linux/ath79/dts/qca9531_asus_rp-ac51.dts
+++ b/target/linux/ath79/dts/qca9531_asus_rp-ac51.dts
@@ -58,6 +58,7 @@
 		wlan5g {
 			label = "blue:wlan5g";
 			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0radio";
 		};
 	};
 };

--- a/target/linux/ath79/dts/qca9563_asus_pl-ac56.dts
+++ b/target/linux/ath79/dts/qca9563_asus_pl-ac56.dts
@@ -51,6 +51,7 @@
 		wlan5g {
 			label = "green:wlan5g";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
 		};
 	};
 };

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -81,11 +81,9 @@ alfa-network,tube-2hq)
 	;;
 asus,pl-ac56)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x3e"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan5g" "wlan0" "link"
 	;;
 asus,rp-ac51)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan5G" "wlan0" "link"
 	;;
 asus,rp-ac66)
 	ucidef_set_rssimon "wlan0" "200000" "1"
@@ -141,7 +139,6 @@ buffalo,wzr-hp-g300nh-s)
 comfast,cf-e110n-v2)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth1"
 	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x02"
-	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "RSSILOW" "red:rssilow" "wlan0" "1" "100"
 	ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "red:rssimediumlow" "wlan0" "26" "100"
@@ -290,7 +287,6 @@ yuncore,xd3200)
 	;;
 hiwifi,hc6361)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
-	ucidef_set_led_wlan "wlan" "WLAN" "blue:wlan" "phy0tpt"
 	;;
 kuwfi,c910)
 	ucidef_set_led_netdev "wan" "WAN" "white:wan" "eth1"
@@ -362,9 +358,6 @@ qca,ap143-16m)
 	ucidef_set_led_switch "lan2" "LAN2" "green:lan2" "switch0" "0x04"
 	ucidef_set_led_switch "lan3" "LAN3" "green:lan3" "switch0" "0x08"
 	ucidef_set_led_switch "lan4" "LAN4" "green:lan4" "switch0" "0x10"
-	;;
-qihoo,c301)
-	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
 ruckus,zf7025)
 	ucidef_set_led_netdev "lan" "LAN5" "green:lan5" "eth0"

--- a/target/linux/ath79/nand/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/nand/base-files/etc/board.d/01_leds
@@ -20,7 +20,6 @@ glinet,gl-xe300)
 	ucidef_set_led_netdev "3gnet" "LTE" "green:lte" "wwan0"
 	;;
 netgear,pgzng1)
-	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	ucidef_set_led_switch "wan" "WAN" "green:wan-1" "switch0" "0x02" "0xf" "link tx rx"
 	ucidef_set_led_switch "wan-green" "wan link" "green:wan-0" "switch0" "0x02" "0xf" "link"
 	ucidef_set_led_switch "wan-amber" "wan act" "amber:wan" "switch0" "0x02" "0xf" "tx rx"

--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -24,22 +24,14 @@ asus,rt-ac58u)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "br-lan"
 	;;
 avm,fritzbox-4040)
-	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt" "phy1tpt"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x1e"
 	;;
 avm,fritzbox-7530)
 	ucidef_set_led_netdev "dsl" "DSL" "green:info" "dsl0"
-	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
-	;;
-edgecore,oap100)
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "blue:wlan2g" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "blue:wlan5g" "phy1tpt"
 	;;
 engenius,eap1300)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "blue:wlan2g" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "yellow:wlan5g" "phy1tpt"
 	ucidef_set_led_default "mesh" "MESH" "blue:mesh" "0"
 	;;
 engenius,eap2200)
@@ -47,17 +39,11 @@ engenius,eap2200)
 	ucidef_set_led_netdev "lan2" "LAN2" "blue:lan2" "eth1"
 	;;
 engenius,ens620ext)
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy1tpt"
 	ucidef_set_led_netdev "lan1" "LAN1" "green:lan1" "eth0"
 	ucidef_set_led_netdev "lan2" "LAN2" "green:lan2" "eth1"
 	;;
 glinet,gl-ap1300)
 	ucidef_set_led_netdev "wan" "WAN" "white:wan" "wan"
-	;;
-glinet,gl-b1300|\
-mikrotik,lhgg-60ad)
-	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
 meraki,gx20|\
 meraki,z3)
@@ -87,8 +73,6 @@ mikrotik,cap-ac)
 	ucidef_set_led_default "user" "USER" "green:user" "0"
 	ucidef_set_led_netdev "eth1" "ETH1" "green:eth1" "wan"
 	ucidef_set_led_netdev "eth2" "ETH2" "green:eth2" "lan"
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy1tpt"
 	;;
 mikrotik,hap-ac3)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
@@ -118,25 +102,10 @@ mobipromo,cm520-79f)
 	ucidef_set_led_netdev "lan1" "LAN1" "blue:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "LAN2" "blue:lan2" "lan2"
 	;;
-netgear,ex6100v2|\
-netgear,ex6150v2)
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:router" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:client" "phy1tpt"
-	;;
-qxwlan,e2600ac-c1|\
-qxwlan,e2600ac-c2)
-	ucidef_set_led_wlan "wlan2g" "WLAN0" "green:wlan0" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN1" "green:wlan1" "phy1tpt"
-	;;
 sony,ncp-hg100-cellular)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "lan"
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	ucidef_set_led_netdev "wwan" "WWAN" "green:wan-4" "wwan0"
-	;;
-zyxel,nbg6617|\
-zyxel,wre6606)
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy1tpt"
 	;;
 esac
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-cap-ac.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-cap-ac.dts
@@ -89,11 +89,13 @@
 		wlan2g {
 			label = "green:wlan2g";
 			gpios = <&tlmm 1 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan5g {
 			label = "green:wlan5g";
 			gpios = <&tlmm 58 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		eth1 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-eap1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-eap1300.dts
@@ -72,11 +72,13 @@
 		wlan2g {
 			label = "blue:wlan2g";
 			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan5g {
 			label = "yellow:wlan5g";
 			gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 	};
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ens620ext.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ens620ext.dts
@@ -83,11 +83,13 @@
 		wlan2g {
 			label = "green:wlan2g";
 			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan5g {
 			label = "green:wlan5g";
 			gpios = <&tlmm 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 	};
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ex61x0v2.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ex61x0v2.dtsi
@@ -118,6 +118,7 @@
 		client_green {
 			label = "green:client";
 			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		client_red {
@@ -128,6 +129,7 @@
 		router_green {
 			label = "green:router";
 			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		router_red {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-fritzbox-4040.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-fritzbox-4040.dts
@@ -68,6 +68,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&ethphy0 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		panic: info_red {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-nbg6617.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-nbg6617.dts
@@ -100,11 +100,13 @@
 		wlan2g {
 			label = "green:wlan2g";
 			gpios = <&tlmm 58 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan5g {
 			label = "green:wlan5g";
 			gpios = <&tlmm 5 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wps {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-wre6606.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-wre6606.dts
@@ -68,6 +68,7 @@
 		wlan5g_green {
 			label = "green:wlan5g";
 			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		power: power {
@@ -89,6 +90,7 @@
 		wlan2g_green {
 			label = "green:wlan2g";
 			gpios = <&tlmm 59 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac.dtsi
@@ -53,11 +53,13 @@
 			led1 {
 				label = "green:wlan0";
 				gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+				linux,default-trigger = "phy0tpt";
 			};
 
 			led2 {
 				label = "green:wlan1";
 				gpios = <&tlmm 36 GPIO_ACTIVE_LOW>;
+				linux,default-trigger = "phy1tpt";
 			};
 
 			led3 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-fritzbox-7530.dts
@@ -88,6 +88,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&tlmm 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		fon {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-lhgg-60ad.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-lhgg-60ad.dts
@@ -98,6 +98,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&tlmm 58 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		align-left {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-oap100.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-oap100.dts
@@ -70,11 +70,13 @@
 		led_2g {
 			label = "blue:wlan2g";
 			gpios = <&tlmm 34 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_5g {
 			label = "blue:wlan5g";
 			gpios = <&tlmm 35 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 	};
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-gl-b1300.dts
@@ -102,6 +102,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&tlmm 2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -22,17 +22,11 @@ askey,rt4230w-rev6)
 	ucidef_set_led_netdev "lan4-port-activity" "LAN4-PORT-ACTIVITY" "qca8k-0.0:04:amber:lan" "lan4" "tx rx"
 	;;
 buffalo,wxr-2533dhp)
-	ucidef_set_led_wlan "wlan" "WLAN" "white:wireless" "phy0tpt"
 	ucidef_set_led_netdev "wan" "WAN" "white:internet" "wan"
 	;;
 compex,wpq864)
 	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "pcie-usb" "PCIe USB" "green:usb-pcie" "usb3-port1"
-	;;
-edgecore,ecw5410|\
-ignitenet,ss-w2-ac2600)
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy1tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy0tpt"
 	;;
 extreme,ap3935)
 	ucidef_set_led_netdev "wan" "wan" "orange:lan1" "eth0"
@@ -43,20 +37,13 @@ fortinet,fap-421e)
 	ucidef_set_led_netdev "eth1-1000" "ETH1-1000" "yellow:eth1" "eth0" "link_1000"
 	ucidef_set_led_netdev "eth2-100" "ETH2-100" "amber:eth2" "eth1" "link_100"
 	ucidef_set_led_netdev "eth2-1000" "ETH2-1000" "yellow:eth2" "eth1" "link_1000"
-	ucidef_set_led_wlan "wlan2g" "2.4G" "yellow:2g" "phy1tpt"
-	ucidef_set_led_wlan "wlan5g" "5G" "yellow:5g" "phy0tpt"
 	ucidef_set_led_usbport "usb" "USB" "amber:power" "usb1-port1" "usb2-port1"
-	;;
-linksys,e8350-v1)
-	ucidef_set_led_wlan "wlan" "WLAN" "green:wifi" "phy0tpt"
 	;;
 meraki,mr52)
 	ucidef_set_led_netdev "eth0" "eth0" "green:lan1" "eth0"
 	ucidef_set_led_netdev "eth1" "eth1" "green:lan2" "eth1"
 	;;
 nec,wg2600hp)
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy1tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy0tpt"
 	ucidef_set_led_netdev "wan" "WAN" "green:active" "wan"
 	;;
 nec,wg2600hp3)
@@ -89,8 +76,6 @@ netgear,xr500)
 	ucidef_set_led_ide "esata" "eSATA" "white:esata"
 	;;
 nokia,ac400i)
-	ucidef_set_led_wlan "wlan5g" "5G" "green:wlan5g" "wlan0"
-	ucidef_set_led_wlan "wlan2g" "2.4G" "green:wlan2g" "wlan1"
 	ucidef_set_led_netdev "eth1" "ETH1" "green:eth1" "eth0"
 	ucidef_set_led_netdev "eth2" "ETH2" "green:eth2" "eth1"
 	ucidef_set_led_default "ctrl" "CTRL" "green:ctrl" "0"
@@ -101,8 +86,6 @@ tplink,ad7200)
 	ucidef_set_led_usbport "usb2" "USB 2" "blue:usb3" "usb3-port1" "usb4-port1"
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	ucidef_set_led_netdev "lan" "lan" "blue:lan" "br-lan"
-	ucidef_set_led_wlan "wlan2g" "wlan2g" "blue:wlan2g" "phy2tpt"
-	ucidef_set_led_wlan "wlan5g" "wlan5g" "blue:wlan5g" "phy1tpt"
 	ucidef_set_led_netdev "wlan60g" "wlan60g" "blue:wlan60g" "wlan0"
 	;;
 tplink,c2600)
@@ -114,8 +97,6 @@ tplink,c2600)
 tplink,vr2600v)
 	ucidef_set_led_usbport "usb" "USB" "white:usb" "usb1-port1" "usb2-port1" "usb3-port1" "usb4-port1"
 	ucidef_set_led_netdev "lan" "lan" "white:lan" "br-lan"
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "white:wlan2g" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "white:wlan5g" "phy1tpt"
 	ucidef_set_led_netdev "wan" "WAN" "white:wan" "wan"
 	;;
 zyxel,nbg6817)

--- a/target/linux/ipq806x/dts/qcom-ipq8064-ad7200.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8064-ad7200.dts
@@ -72,6 +72,7 @@
 		wlan5g {
 			label = "blue:wlan5g";
 			gpios = <&qcom_pinmux 15 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		usb3 {
@@ -82,6 +83,7 @@
 		wlan2g {
 			label = "blue:wlan2g";
 			gpios = <&qcom_pinmux 17 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy2tpt";
 		};
 
 		wan_orange {

--- a/target/linux/ipq806x/dts/qcom-ipq8064-e8350-v1.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8064-e8350-v1.dts
@@ -71,6 +71,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/ipq806x/dts/qcom-ipq8064-fap-421e.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8064-fap-421e.dts
@@ -88,11 +88,13 @@
 		2g-yellow {
 			label = "yellow:2g";
 			gpios = <&qcom_pinmux 30 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		5g-yellow {
 			label = "yellow:5g";
 			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/ipq806x/dts/qcom-ipq8064-vr2600v.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8064-vr2600v.dts
@@ -92,11 +92,13 @@
 		wlan2g {
 			label = "white:wlan2g";
 			gpios = <&qcom_pinmux 16 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan5g {
 			label = "white:wlan5g";
 			gpios = <&qcom_pinmux 17 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		power: power {

--- a/target/linux/ipq806x/dts/qcom-ipq8064-wg2600hp.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8064-wg2600hp.dts
@@ -101,6 +101,7 @@
 		wlan2g_green {
 			label = "green:wlan2g";
 			gpios = <&qcom_pinmux 55 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan2g_red {
@@ -111,6 +112,7 @@
 		wlan5g_green {
 			label = "green:wlan5g";
 			gpios = <&qcom_pinmux 57 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan5g_red {

--- a/target/linux/ipq806x/dts/qcom-ipq8064-wxr-2533dhp.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8064-wxr-2533dhp.dts
@@ -66,6 +66,7 @@
 		wireless_white {
 			label = "white:wireless";
 			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		router_orange {

--- a/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
@@ -47,6 +47,7 @@
 		5g_green {
 			label = "green:5g";
 			gpios = <&qcom_pinmux 64 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		2g_red {
@@ -57,6 +58,7 @@
 		2g_green {
 			label = "green:2g";
 			gpios = <&qcom_pinmux 54 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		eth1_red {

--- a/target/linux/ipq806x/dts/qcom-ipq8068-ecw5410.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8068-ecw5410.dts
@@ -76,6 +76,7 @@
 		wlan2g_green {
 			label = "green:wlan2g";
 			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan2g_yellow {
@@ -86,6 +87,7 @@
 		wlan5g_green {
 			label = "green:wlan5g";
 			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_power_red: power_red {

--- a/target/linux/ipq806x/dts/qcom-ipq8068-ss-w2-ac2600.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8068-ss-w2-ac2600.dts
@@ -69,6 +69,7 @@
 		wlan2g_green {
 			label = "green:wlan2g";
 			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan2g_yellow {
@@ -79,6 +80,7 @@
 		wlan5g_green {
 			label = "green:wlan5g";
 			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_power_red: power_red {

--- a/target/linux/mediatek/dts/mt7981a-glinet-gl-x3000-xe3000-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981a-glinet-gl-x3000-xe3000-common.dtsi
@@ -81,11 +81,13 @@
 		wifi2g {
 			label = "green:wifi2g";
 			gpios = <&pio 30 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wifi5g {
 			label = "green:wifi5g";
 			gpios = <&pio 38 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		5g_led1 {

--- a/target/linux/mediatek/dts/mt7981b-abt-asr3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-abt-asr3000.dts
@@ -71,12 +71,14 @@
 			function = LED_FUNCTION_WLAN_2GHZ;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led-4 {
 			function = LED_FUNCTION_WLAN_5GHZ;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 	};
 };

--- a/target/linux/mediatek/dts/mt7981b-imou-hx21.dts
+++ b/target/linux/mediatek/dts/mt7981b-imou-hx21.dts
@@ -63,6 +63,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
 		};
 
 		led-2 {

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000se.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000se.dts
@@ -55,6 +55,7 @@
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WLAN;
 			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 	};
 };

--- a/target/linux/mediatek/dts/mt7981b-nokia-ea0326gmp.dts
+++ b/target/linux/mediatek/dts/mt7981b-nokia-ea0326gmp.dts
@@ -78,6 +78,7 @@
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WLAN;
 			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
 		};
 
 		led-5 {

--- a/target/linux/mediatek/dts/mt7981b-nradio-c8-668gl.dts
+++ b/target/linux/mediatek/dts/mt7981b-nradio-c8-668gl.dts
@@ -82,6 +82,7 @@
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WLAN;
 			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
 		};
 	};
 };

--- a/target/linux/mediatek/dts/mt7981b-tplink-fr365v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-tplink-fr365v1.dts
@@ -64,6 +64,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		led_port2_act: led_port2_act {

--- a/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
+++ b/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
@@ -62,6 +62,7 @@
 			color = <LED_COLOR_ID_BLUE>;
 			function-enumerator = <1>;
 			gpios = <&pio 1 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led-2 {
@@ -69,6 +70,7 @@
 			color = <LED_COLOR_ID_BLUE>;
 			function-enumerator = <2>;
 			gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 	};
 

--- a/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
+++ b/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
@@ -72,7 +72,7 @@
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WLAN;
 			gpios = <&pio 32 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "phy1radio";
 		};
 	};
 

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -86,12 +86,14 @@
 			label = "green:wifi24g";
 			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
 			default-state = "off";
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_green_wifi5g {
 			label = "green:wifi5g";
 			gpios = <&pio 2 GPIO_ACTIVE_LOW>;
 			default-state = "off";
+			linux,default-trigger = "phy1tpt";
 		};
 
 		led_green_inet {

--- a/target/linux/mediatek/dts/mt7986b-zyxel-wx5600-t0-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7986b-zyxel-wx5600-t0-ubootmod.dts
@@ -101,6 +101,7 @@
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WLAN;
 			function-enumerator = <0>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_green_wps: green_wps {

--- a/target/linux/mediatek/dts/mt7987a-routerich-be7200.dts
+++ b/target/linux/mediatek/dts/mt7987a-routerich-be7200.dts
@@ -65,6 +65,7 @@
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WLAN_5GHZ;
 			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		led-2 {

--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
@@ -77,6 +77,7 @@
 			function = LED_FUNCTION_INDICATOR;
 			function-enumerator = <1>;
 			gpios = <&pio 43 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		/* wifi */
@@ -84,6 +85,7 @@
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WLAN;
 			gpios = <&pio 47 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		/* internet */

--- a/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
+++ b/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
@@ -90,12 +90,14 @@
 			gpios = <&pio 28 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WLAN_5GHZ;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		led-2 {
 			gpios = <&pio 29 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WLAN_2GHZ;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_status: led-3 {

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -6,14 +6,8 @@ board=$(board_name)
 board_config_update
 
 case $board in
-airpi,ap3000m)
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "orange:wlan-2ghz" "phy0-ap0" "link tx rx"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "white:wlan-5ghz" "phy1-ap0" "link tx rx"
-	;;
 abt,asr3000)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan-2ghz" "phy0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan-5ghz" "phy1-ap0"
 	;;
 acer,predator-w6|\
 acer,predator-w6d)
@@ -48,8 +42,6 @@ bananapi,bpi-r3-mini)
 	ucidef_set_led_netdev "lan2" "LAN" "mdio-bus:0e:yellow:lan" "eth0" "link_2500 link_100 tx rx"
 	ucidef_set_led_netdev "wan1" "WAN" "mdio-bus:0f:green:wan" "eth1" "link_2500 link_1000 tx rx"
 	ucidef_set_led_netdev "wan2" "WAN" "mdio-bus:0f:yellow:wan" "eth1" "link_2500 link_100 tx rx"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan-1" "phy0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan-2" "phy1-ap0"
 	;;
 bananapi,bpi-r4|\
 bananapi,bpi-r4-2g5|\
@@ -108,17 +100,12 @@ glinet,gl-xe3000)
 	ucidef_set_led_netdev "5g_2" "5G_2" "green:5g:led2" "wwan0"
 	ucidef_set_led_netdev "5g_3" "5G_3" "green:5g:led3" "wwan0"
 	ucidef_set_led_netdev "5g_4" "5G_4" "green:5g:led4" "wwan0"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wifi2g" "phy0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wifi5g" "phy1-ap0"
 	;;
 huasifei,wh3000)
 	ucidef_set_led_netdev "wan" "WAN" "red:wan" "eth1" "link tx rx"
 	;;
 iptime,ax3000q)
 	ucidef_set_led_netdev "wan" "WAN" "amber:wan" "wan" "link tx rx"
-	;;
-iptime,ax3000se)
-	ucidef_set_led_netdev "wlan" "WLAN" "blue:wlan" "phy1-ap0"
 	;;
 iptime,ax3000sm)
 	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
@@ -128,8 +115,6 @@ iptime,ax7800m-6e)
 	;;
 keenetic,kn-1812|\
 netcraze,nc-1812)
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:indicator-1" "phy0.0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan" "phy0.1-ap0"
 	ucidef_set_led_netdev "internet" "internet" "green:wan-online" "wan" "link"
 	;;
 keenetic,kn-3711|\
@@ -191,10 +176,8 @@ imou,hx21|\
 nokia,ea0326gmp)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1" "link"
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan" "link"
-	ucidef_set_led_netdev "wlan" "WLAN" "green:wlan" "phy1-ap0" "link"
 	;;
 nradio,c8-668gl)
-	ucidef_set_led_netdev "wifi" "WIFI" "blue:wlan" "phy1-ap0" "link"
 	ucidef_set_led_netdev "5g" "5G" "blue:indicator-0" "eth1" "link"
 	;;
 openembed,som7981)
@@ -231,7 +214,6 @@ routerich,be7200)
 	ucidef_set_led_netdev "lan-3" "lan-3" "blue:lan-3" "lan3" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
 	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
-	ucidef_set_led_netdev "wlan5g" "wlan-5ghz" "blue:wlan-5ghz" "phy0.1-ap0" "link tx rx"
 	;;
 smartrg,sdg-8612)
 	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:amber:lan" "lan4" "link_10 link_100"
@@ -290,13 +272,10 @@ tplink,archer-ax80-v1-eu)
 	;;
 tplink,be450)
 	ucidef_set_led_netdev "br-lan" "lan" "blue:lan" "br-lan" "link tx rx"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan-2ghz" "phy0.0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan-5ghz" "phy0.1-ap0"
 	;;
 tplink,fr365-v1)
 	ucidef_set_led_netdev "port2-green-act" "port-2" "green:port2_act" "port2" "link tx rx"
 	ucidef_set_led_netdev "port1-green-act" "port-1" "green:sfp" "port1" "link tx rx"
-	ucidef_set_led_netdev "wlan" "wlan" "green:wlan" "phy1-ap0"
 	;;
 tplink,re6000xd)
 	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-0" "lan1" "link tx rx"
@@ -304,7 +283,6 @@ tplink,re6000xd)
 	ucidef_set_led_netdev "eth1" "lan-3" "blue:lan-2" "eth1" "link tx rx"
 	;;
 wavlink,wl-wn536ax6-a)
-	ucidef_set_led_netdev "wifi" "wifi" "blue:wlan" "phy1-ap0" "link"
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
 	;;
 wavlink,wl-wn551x3)
@@ -336,8 +314,6 @@ zyxel,ex5601-t0-ubootmod)
 	ucidef_set_led_netdev "wan" "2.5G-WAN" "mdio-bus:06:green:wan" "wan" "link_2500"
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link tx rx"
 	ucidef_set_led_netdev "internet" "INTERNET" "green:inet" "wan" "link tx rx"
-	ucidef_set_led_netdev "wifi-24g" "WIFI-2.4G" "green:wifi24g" "phy0-ap0" "link tx rx"
-	ucidef_set_led_netdev "wifi-5g" "WIFI-5G" "green:wifi5g" "phy1-ap0" "link tx rx"
 	;;
 zyxel,nwa50ax-pro)
 	ucidef_set_led_netdev "uplink" "UPLINK" "mdio-bus:05:amber:wan" "eth0" "link_10 link_100 link_2500 tx rx"
@@ -352,7 +328,6 @@ zyxel,ex5700-telenor)
 zyxel,wx5600-t0-ubootmod)
 	ucidef_set_led_netdev "lan1" "LAN1" "mdio-bus:06:green:lan" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "LAN2" "mdio-bus:05:green:lan" "lan2" "link tx rx"
-	ucidef_set_led_netdev "wlan5" "wlan5" "green:wlan-0" "phy1-ap0" "link tx rx"
 	;;
 esac
 

--- a/target/linux/qualcommax/dts/ipq8072-linkhub-hh500v.dts
+++ b/target/linux/qualcommax/dts/ipq8072-linkhub-hh500v.dts
@@ -104,6 +104,7 @@
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WLAN;
 			gpios = <&aw9523 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
 		};
 
 		led_power_blue: power_blue {

--- a/target/linux/qualcommax/dts/ipq8072-wax218.dts
+++ b/target/linux/qualcommax/dts/ipq8072-wax218.dts
@@ -76,11 +76,13 @@
 		led_wlan_2g {
 			label = "blue:wlan2g";
 			gpios = <&led_gpio 3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		led_wlan_5g {
 			label = "blue:wlan5g";
 			gpios = <&led_gpio 4 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -29,8 +29,6 @@ netgear,rax120v2)
 	;;
 netgear,wax218)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "lan"
-	ucidef_set_led_wlan "wlan5g" "WIFI 5GHz" "blue:wlan5g" "phy0radio"
-	ucidef_set_led_wlan "wlan2g" "WIFI 2.4GHz" "blue:wlan2g" "phy1radio"
 	;;
 netgear,wax620)
 	ucidef_set_led_netdev "lan" "LAN" "lan:green" "lan"
@@ -41,9 +39,6 @@ netgear,wax630)
 	;;
 redmi,ax6)
 	ucidef_set_led_netdev "wan" "WAN" "blue:network" "wan"
-	;;
-tcl,linkhub-hh500v)
-	ucidef_set_led_wlan "wlan5g" "WiFi 5GHz" "blue:wlan" "phy0radio"
 	;;
 xiaomi,ax3600)
 	ucidef_set_led_netdev "wan-port-link" "WAN-PORT-LINK" "90000.mdio-1:01:green:wan" "wan" "tx rx link_10 link_100 link_1000"

--- a/target/linux/ramips/dts/mt7620a_aigale_ai-br100.dts
+++ b/target/linux/ramips/dts/mt7620a_aigale_ai-br100.dts
@@ -28,6 +28,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
+++ b/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
@@ -39,6 +39,7 @@
 		wlan2g {
 			label = "green:wlan2g";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		led_wps: wps {

--- a/target/linux/ramips/dts/mt7620a_asus_rp-n53.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rp-n53.dts
@@ -61,6 +61,7 @@
 		wifi3 {
 			label = "blue:wifi";
 			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wifi4 {

--- a/target/linux/ramips/dts/mt7620a_bdcom_wap2100-sk.dts
+++ b/target/linux/ramips/dts/mt7620a_bdcom_wap2100-sk.dts
@@ -39,6 +39,7 @@
 		wlan2g {
 			label = "green:wlan2g";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
@@ -34,6 +34,7 @@
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WLAN;
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;	// #72
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wps_led: wps {

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
@@ -56,6 +56,7 @@
 		wlan2g {
 			label = "green:wlan2g";
 			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		usb {

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
@@ -53,6 +53,7 @@
 		wlan2g {
 			label = "green:wlan2g";
 			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		usb {

--- a/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
+++ b/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
@@ -22,6 +22,7 @@
 		wifi {
 			label = "orange:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
@@ -51,6 +51,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		usb {

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
@@ -46,6 +46,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		usb {

--- a/target/linux/ramips/dts/mt7620a_engenius_esr600.dts
+++ b/target/linux/ramips/dts/mt7620a_engenius_esr600.dts
@@ -38,11 +38,13 @@
 		wlan5g {
 			label = "blue:wlan5g";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan2g {
 			label = "blue:wlan2g";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt300a.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt300a.dts
@@ -31,6 +31,7 @@
 		wlan {
 			label = "gl-mt300a:wlan";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		usb {

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt300n.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt300n.dts
@@ -31,6 +31,7 @@
 		wlan {
 			label = "gl-mt300n:wlan";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
@@ -31,6 +31,7 @@
 		wlan {
 			label = "gl-mt750:wlan";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_head-weblink_hdrm200.dts
+++ b/target/linux/ramips/dts/mt7620a_head-weblink_hdrm200.dts
@@ -36,6 +36,7 @@
 		air {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
@@ -30,6 +30,7 @@
 		wlan2g {
 			label = "green:wlan2g";
 			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
 		};
 
 		notification {
@@ -40,6 +41,7 @@
 		wlan5g {
 			label = "green:wlan5g";
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac733gr3.dts
@@ -35,11 +35,13 @@
 		wlan2g {
 			label = "green:wlan2g";
 			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
 		};
 
 		wlan5g {
 			label = "green:wlan5g";
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_kimax_u25awf-h1.dts
+++ b/target/linux/ramips/dts/mt7620a_kimax_u25awf-h1.dts
@@ -31,6 +31,7 @@
 		led_wifi: wifi {
 			label = "red:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		lan {

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dts
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dts
@@ -26,11 +26,13 @@
 		wlan1 {
 			label = "blue:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan2 {
 			label = "blue:wifi5g";
 			gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		usb {

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1s.dts
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1s.dts
@@ -52,11 +52,13 @@
 		wlan1 {
 			label = "yellow:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan2 {
 			label = "blue:wifi";
 			gpios = <&gpio2 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		usb1 {

--- a/target/linux/ramips/dts/mt7620a_netgear_ex2700.dts
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex2700.dts
@@ -65,6 +65,7 @@
 		router_g {
 			label = "green:router";
 			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		router_r {

--- a/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
@@ -47,6 +47,7 @@
 		router_green {
 			label = "green:router";
 			gpios = <&gpio2 25 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		router_red {
@@ -57,6 +58,7 @@
 		device_green {
 			label = "green:device";
 			gpios = <&gpio2 20 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		device_red {

--- a/target/linux/ramips/dts/mt7620a_netgear_wn3x00rp.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_wn3x00rp.dtsi
@@ -59,6 +59,7 @@
 		router_g {
 			label = "green:router";
 			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		router_r {

--- a/target/linux/ramips/dts/mt7620a_ohyeah_oy-0001.dts
+++ b/target/linux/ramips/dts/mt7620a_ohyeah_oy-0001.dts
@@ -31,6 +31,7 @@
 		wifiled {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
@@ -27,6 +27,7 @@
 		wlan {
 			label = "white:wlan2g";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-ex300np.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-ex300np.dts
@@ -21,6 +21,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_wps: wps {

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
@@ -27,6 +27,7 @@
 		wifi {
 			label = "red:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps {

--- a/target/linux/ramips/dts/mt7620a_sanlinking_d240.dts
+++ b/target/linux/ramips/dts/mt7620a_sanlinking_d240.dts
@@ -61,6 +61,7 @@
 		air {
 			label = "blue:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
@@ -17,11 +17,13 @@
 		sys1 {
 			label = "green:sys1";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		sys2 {
 			label = "green:sys2";
 			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		sys3 {
@@ -37,6 +39,7 @@
 		wlan2g4 {
 			label = "green:wlan2g4";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026-5g.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026-5g.dtsi
@@ -28,6 +28,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026-h.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026-h.dtsi
@@ -32,6 +32,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-e.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826-e.dts
@@ -29,6 +29,7 @@
 		air {
 			label = "red:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we826.dtsi
@@ -38,6 +38,7 @@
 		air {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
+++ b/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
@@ -41,6 +41,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_power_green: power {

--- a/target/linux/ramips/dts/mt7620n_asus_rt-n12p.dts
+++ b/target/linux/ramips/dts/mt7620n_asus_rt-n12p.dts
@@ -43,6 +43,7 @@
 		air {
 			label = "green:air";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_asus_rt-n14u.dts
+++ b/target/linux/ramips/dts/mt7620n_asus_rt-n14u.dts
@@ -47,6 +47,7 @@
 		air {
 			label = "blue:air";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_comfast_cf-wr800n.dts
+++ b/target/linux/ramips/dts/mt7620n_comfast_cf-wr800n.dts
@@ -30,6 +30,7 @@
 		wifi {
 			label = "white:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_wps: wps {

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-116-a1.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-116-a1.dts
@@ -44,6 +44,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c1.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c1.dts
@@ -67,6 +67,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-922-e2.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-922-e2.dts
@@ -70,6 +70,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_elecom_wrh-300cr.dts
+++ b/target/linux/ramips/dts/mt7620n_elecom_wrh-300cr.dts
@@ -33,6 +33,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_kimax_u35wf.dts
+++ b/target/linux/ramips/dts/mt7620n_kimax_u35wf.dts
@@ -30,6 +30,7 @@
 		led_wifi: wifi {
 			label = "blue:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		lan {

--- a/target/linux/ramips/dts/mt7620n_kingston_mlw221.dts
+++ b/target/linux/ramips/dts/mt7620n_kingston_mlw221.dts
@@ -25,6 +25,7 @@
 		wifi {
 			label = "blue:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_kingston_mlwg2.dts
+++ b/target/linux/ramips/dts/mt7620n_kingston_mlwg2.dts
@@ -25,6 +25,7 @@
 		wifi {
 			label = "blue:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_snr_cpe-w4n-mt.dts
+++ b/target/linux/ramips/dts/mt7620n_snr_cpe-w4n-mt.dts
@@ -37,6 +37,7 @@
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WLAN;
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>; // GPIO#72
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wa05.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wa05.dts
@@ -39,6 +39,7 @@
 		air {
 			label = "blue:air";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-we2026.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-we2026.dts
@@ -32,6 +32,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wr8305rt.dts
+++ b/target/linux/ramips/dts/mt7620n_zbtlink_zbt-wr8305rt.dts
@@ -34,6 +34,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-lite-iii-a.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-lite-iii-a.dts
@@ -64,6 +64,7 @@
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WLAN;
 			gpios = <&gpio3 0 GPIO_ACTIVE_HIGH>; // #GPIO72
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
@@ -35,6 +35,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_power: power {

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
@@ -35,6 +35,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio3 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_power: power {

--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -48,11 +48,13 @@
 		wlan2g {
 			label = "blue:wlan2g";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan5g {
 			label = "blue:wlan5g";
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		usb {

--- a/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
@@ -27,11 +27,13 @@
 		wifi2g {
 			label = "blue:wifi2G";
 			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wifi5g {
 			label = "blue:wifi5G";
 			gpios = <&gpio 24 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wps_r {

--- a/target/linux/ramips/dts/mt7628an_alfa-network_awusfree1.dts
+++ b/target/linux/ramips/dts/mt7628an_alfa-network_awusfree1.dts
@@ -47,6 +47,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
@@ -40,6 +40,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
+++ b/target/linux/ramips/dts/mt7628an_hilink_hlk-7628n.dts
@@ -27,6 +27,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
+++ b/target/linux/ramips/dts/mt7628an_mediatek_linkit-smart-7688.dts
@@ -28,6 +28,7 @@
 		led_wifi: wifi {
 			label = "orange:wifi";
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7628an_oraybox_x1.dts
+++ b/target/linux/ramips/dts/mt7628an_oraybox_x1.dts
@@ -28,6 +28,7 @@
 			function = LED_FUNCTION_STATUS;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio 37 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_status_red: status-red {

--- a/target/linux/ramips/dts/mt7628an_rakwireless_rak633.dts
+++ b/target/linux/ramips/dts/mt7628an_rakwireless_rak633.dts
@@ -15,6 +15,7 @@
 		wifi {
 			label = "blue:wifi";
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_skylab_skw92a.dts
+++ b/target/linux/ramips/dts/mt7628an_skylab_skw92a.dts
@@ -28,6 +28,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7628an_tama_w06.dts
+++ b/target/linux/ramips/dts/mt7628an_tama_w06.dts
@@ -27,6 +27,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
@@ -59,11 +59,13 @@
 		wlan {
 			label = "green:wlan2g";
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan5 {
 			label = "green:wlan5g";
 			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wps {

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v4.dts
@@ -43,11 +43,13 @@
 		wlan2 {
 			label = "green:wlan2g";
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan5 {
 			label = "green:wlan5g";
 			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		lan {

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v6.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v6.dts
@@ -43,11 +43,13 @@
 		wlan2 {
 			label = "green:wlan2g";
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan5 {
 			label = "green:wlan5g";
 			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
 		};
 
 		lan {

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr3420-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr3420-v5.dts
@@ -68,6 +68,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps {

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr840n-v4.dts
@@ -48,6 +48,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps {

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v13.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr841n-v13.dts
@@ -80,6 +80,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr842n-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr842n-v5.dts
@@ -68,6 +68,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps {

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v3.dts
@@ -74,6 +74,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps {

--- a/target/linux/ramips/dts/mt7628an_unielec_u7628-01.dtsi
+++ b/target/linux/ramips/dts/mt7628an_unielec_u7628-01.dtsi
@@ -48,6 +48,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wan {

--- a/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
+++ b/target/linux/ramips/dts/mt7628an_zbtlink_zbt-we1226.dts
@@ -52,6 +52,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -58,6 +58,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		usb {

--- a/target/linux/ramips/dts/rt3050_alphanetworks_asl26555.dtsi
+++ b/target/linux/ramips/dts/rt3050_alphanetworks_asl26555.dtsi
@@ -54,6 +54,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_power_green: power-green {

--- a/target/linux/ramips/dts/rt3050_edimax_3g-6200n.dts
+++ b/target/linux/ramips/dts/rt3050_edimax_3g-6200n.dts
@@ -88,6 +88,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_AMBER>;
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		3g {

--- a/target/linux/ramips/dts/rt3050_edimax_3g-6200nl.dts
+++ b/target/linux/ramips/dts/rt3050_edimax_3g-6200nl.dts
@@ -87,6 +87,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/rt3052_aximcom_mr-102n.dts
+++ b/target/linux/ramips/dts/rt3052_aximcom_mr-102n.dts
@@ -97,6 +97,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/rt3052_fon_fonera-20n.dts
+++ b/target/linux/ramips/dts/rt3052_fon_fonera-20n.dts
@@ -72,6 +72,7 @@
 		wifi {
 			label = "orange:wifi";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		led_power: power {

--- a/target/linux/ramips/dts/rt3052_hauppauge_broadway.dts
+++ b/target/linux/ramips/dts/rt3052_hauppauge_broadway.dts
@@ -71,6 +71,7 @@
 		wps_active {
 			label = "red:wps_active";
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/rt3052_huawei_hg255d.dts
+++ b/target/linux/ramips/dts/rt3052_huawei_hg255d.dts
@@ -90,6 +90,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		usb {

--- a/target/linux/ramips/dts/rt3052_netgear_wnce2001.dts
+++ b/target/linux/ramips/dts/rt3052_netgear_wnce2001.dts
@@ -38,6 +38,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan-red {

--- a/target/linux/ramips/dts/rt3052_planex_mzk-w300nh2.dts
+++ b/target/linux/ramips/dts/rt3052_planex_mzk-w300nh2.dts
@@ -85,6 +85,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_AMBER>;
 			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wps {

--- a/target/linux/ramips/dts/rt3352_dlink_dir-620-d1.dts
+++ b/target/linux/ramips/dts/rt3352_dlink_dir-620-d1.dts
@@ -27,6 +27,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/rt5350_7links_px-4885.dtsi
+++ b/target/linux/ramips/dts/rt5350_7links_px-4885.dtsi
@@ -29,6 +29,7 @@
 		led_wifi: wifi {
 			label = "orange:wifi";
 			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		storage {

--- a/target/linux/ramips/dts/rt5350_airlive_air3gii.dts
+++ b/target/linux/ramips/dts/rt5350_airlive_air3gii.dts
@@ -15,6 +15,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		mobile {

--- a/target/linux/ramips/dts/rt5350_dlink_dcs-930l-b1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dcs-930l-b1.dts
@@ -28,6 +28,7 @@
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/dts/rt5350_hootoo_ht-tm02.dts
+++ b/target/linux/ramips/dts/rt5350_hootoo_ht-tm02.dts
@@ -22,6 +22,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		lan {

--- a/target/linux/ramips/dts/rt5350_intenso_memory2move.dts
+++ b/target/linux/ramips/dts/rt5350_intenso_memory2move.dts
@@ -25,6 +25,7 @@
 		led_wifi: wifi {
 			label = "blue:wifi";
 			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wan {

--- a/target/linux/ramips/dts/rt5350_omnima_miniembplug.dts
+++ b/target/linux/ramips/dts/rt5350_omnima_miniembplug.dts
@@ -15,6 +15,7 @@
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
 		};
 
 		mobile {

--- a/target/linux/ramips/dts/rt5350_trendnet_tew-714tru.dts
+++ b/target/linux/ramips/dts/rt5350_trendnet_tew-714tru.dts
@@ -22,6 +22,7 @@
 		wifi {
 			label = "green:wifi";
 			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/01_leds
@@ -9,10 +9,6 @@ board_config_update
 case $board in
 aigale,ai-br100)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth0.2"
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wlan" "wlan0"
-	;;
-alfa-network,ac1200rm)
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan2g" "wlan1"
 	;;
 alfa-network,r36m-e4g)
 	ucidef_set_led_netdev "4g" "4g" "orange:4g" "wwan0"
@@ -25,20 +21,14 @@ alfa-network,tube-e4g)
 	;;
 asus,rp-n53)
 	ucidef_set_led_netdev "eth" "Network" "white:back" "eth0"
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wifi" "wlan0"
 	;;
 asus,rt-n12p)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" eth0.1
 	ucidef_set_led_netdev "wan" "wan" "green:wan" eth0.2
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:air" "wlan0"
 	;;
 asus,rt-n14u)
 	ucidef_set_led_netdev "lan" "lan" "blue:lan" eth0.1
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" eth0.2
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:air" "wlan0"
-	;;
-bdcom,wap2100-sk)
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan2g" "wlan0"
 	;;
 bolt,bl100)
 	ucidef_set_led_default "power" "power" "blue:power" "1"
@@ -47,44 +37,24 @@ bolt,bl100)
 	;;
 comfast,cf-wr800n)
 	ucidef_set_led_netdev "lan" "lan" "white:ethernet" eth0.1
-	ucidef_set_led_netdev "wifi_led" "wifi" "white:wifi" "wlan0"
-	;;
-dlink,dir-806a-b1)
-	ucidef_set_led_netdev "wifi_led" "2.4g" "green:wlan" "phy1-ap0"
 	;;
 dlink,dir-810l|\
 trendnet,tew-810dr)
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
-dlink,dwr-116-a1|\
-head-weblink,hdrm200|\
-ohyeah,oy-0001|\
-planex,mzk-ex300np|\
-zbtlink,zbt-we826-16m|\
-zbtlink,zbt-we826-32m|\
-zbtlink,zbt-wr8305rt|\
-zyxel,keenetic-lite-iii-a|\
-zyxel,keenetic-omni|\
-zyxel,keenetic-omni-ii|\
-zyxel,keenetic-viva)
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wifi" "wlan0"
-	;;
 dlink,dwr-118-a1)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x1f"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x20"
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan2g" "wlan1"
 	;;
 dlink,dwr-118-a2)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan2g" "wlan1"
 	;;
 dlink,dwr-921-c1|\
 dlink,dwr-922-e2)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x0f"
 	ucidef_set_led_netdev "signalstrength" "signalstrength" "green:sigstrength" "wwan0" "link"
 	ucidef_set_led_netdev "4g" "4g" "green:4g" "wwan0" "tx rx"
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wifi" "wlan0"
 	;;
 dlink,dwr-960)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x2e"
@@ -102,20 +72,10 @@ domywifi,dw22d)
 	ucidef_set_led_switch "lan3" "lan3" "amber:lan3" "switch0" "0x08"
 	ucidef_set_led_switch "lan4" "lan4" "amber:lan4" "switch0" "0x10"
 	ucidef_set_led_switch "wan" "wan" "amber:wan" "switch0" "0x01"
-		;;
-dovado,tiny-ac)
-	ucidef_set_led_netdev "wifi_led" "wifi" "orange:wifi" "wlan0"
 	;;
 edimax,br-6208ac-v2)
 	ucidef_set_led_netdev "wan" "Internet" "green:internet" "eth0.2" "tx rx"
-	ucidef_set_led_netdev "wifi_led" "WLAN 2.4 GHz" "green:wlan2g" "wlan1"
-	ucidef_set_led_netdev "wifi_led" "WLAN 5 GHz" "green:wlan5g" "wlan1"
-	ucidef_set_led_netdev "wifi_led" "Firmware" "green:firmware" "wlan1"
 	ucidef_set_led_netdev "lan" "VPN" "green:vpn" "switch0" "0x20"
-	;;
-edimax,br-6478ac-v2|\
-edimax,ew-7478apc)
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wlan" "wlan0"
 	;;
 ampedwireless,b1200ex|\
 edimax,ew-7476rpc|\
@@ -124,16 +84,6 @@ edimax,ew-7478ac)
 	;;
 elecom,wrh-300cr)
 	ucidef_set_led_netdev "lan" "lan" "green:ethernet" "eth0"
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
-	;;
-engenius,esr600)
-	ucidef_set_led_netdev "wlan5g" "5.0GHz" "blue:wlan5g" "wlan0"
-	ucidef_set_led_netdev "wlan2g" "2.4GHz" "blue:wlan2g" "wlan1"
-	;;
-glinet,gl-mt300a|\
-glinet,gl-mt300n|\
-glinet,gl-mt750)
-	ucidef_set_led_netdev "wifi_led" "wifi" "wlan" "wlan0"
 	;;
 hiwifi,hc5661|\
 hiwifi,hc5761)
@@ -149,37 +99,20 @@ hnet,c108)
 humax,e2)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
-iodata,wn-ac1167gr|\
-iodata,wn-ac733gr3)
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy0radio"
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy1radio"
-	;;
 kimax,u25awf-h1)
 	ucidef_set_led_netdev "eth" "eth" "green:lan" "eth0"
-	ucidef_set_led_netdev "wifi_led" "wifi" "red:wifi" "wlan0"
 	;;
 kimax,u35wf)
 	ucidef_set_led_netdev "eth" "ETH" "green:eth" "eth0"
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wifi" "wlan0"
-	;;
-kingston,mlw221|\
-kingston,mlwg2|\
-sanlinking,d240)
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wifi" "wlan0"
 	;;
 snr,cpe-w4n-mt)
 	ucidef_set_led_heartbeat "wps" "WPS" "green:wps"
 	ucidef_set_led_timer "sys" "System" "green:sys" "500" "500"
-	ucidef_set_led_wlan "wlan" "Wi-Fi" "green:wlan" "phy0tpt"
 	;;
 lenovo,newifi-y1)
-	ucidef_set_led_netdev "wifi" "WIFI" "blue:wifi" "wlan1"
-	ucidef_set_led_netdev "wifi5g" "WIFI5G" "blue:wifi5g" "wlan0"
 	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x03"
 	;;
 lenovo,newifi-y1s)
-	ucidef_set_led_netdev "wifi" "WIFI" "yellow:wifi" "wlan1"
-	ucidef_set_led_netdev "wifi5g" "WIFI5G" "blue:wifi" "wlan0"
 	ucidef_set_led_netdev "wan" "WAN" "blue:internet" "eth0.2" "tx rx"
 	;;
 netcore,nw5212|\
@@ -190,25 +123,8 @@ netgear,jwnr2010-v5)
 	ucidef_set_led_switch "lan4" "lan4" "green:lan4" "switch0" "0x01"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
-netgear,ex2700|\
-netgear,wn3000rp-v3|\
-netgear,wn3100rp-v2)
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:router" "wlan0"
-	;;
-netgear,ex3700|\
-netgear,ex6130)
-	ucidef_set_led_netdev "wlan5g" "ROUTER (green)" "green:router" "wlan0"
-	ucidef_set_led_netdev "wlan2g" "DEVICE (green)" "green:device" "wlan1"
-	;;
 netgear,pr2000)
 	ucidef_set_led_switch "internet" "internet" "green:internet" "switch0" "0x01"
-	;;
-phicomm,psg1208)
-	ucidef_set_led_netdev "wifi_led" "wifi" "white:wlan2g" "wlan0"
-	;;
-planex,mzk-ex750np|\
-zbtlink,zbt-we826-e)
-	ucidef_set_led_netdev "wifi_led" "wifi" "red:wifi" "wlan0"
 	;;
 ravpower,rp-wd03)
 	ucidef_set_led_netdev "internet" "internet" "green:wifi" "eth0"
@@ -270,25 +186,12 @@ xiaomi,miwifi-mini)
 	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x01"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
-zbtlink,zbt-ape522ii)
-	ucidef_set_led_netdev "wlan2g4" "wlan1-link" "green:wlan2g4" "wlan1"
-	ucidef_set_led_netdev "sys1" "wlan1" "green:sys1" "wlan1" "tx rx"
-	ucidef_set_led_netdev "sys2" "wlan0" "green:sys2" "wlan0" "tx rx"
-	;;
-zbtlink,zbt-wa05)
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:air" "wlan0"
-	;;
 zbtlink,zbt-we1026-5g-16m)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wifi" "wlan0"
 	;;
 zbtlink,zbt-we1026-h-32m)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x8"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wifi" "wlan0"
-	;;
-zbtlink,zbt-we2026)
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
 	;;
 esac
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -27,13 +27,6 @@ asus,rp-ac87)
 	;;
 asus,rt-ax53u)
 	ucidef_set_led_usbport "usb" "USB" "blue:usb" "usb1-port2"
-	ucidef_set_led_wlan "wlan2g" "WiFi 2.4GHz" "mt76-phy0" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "WiFi 5GHz" "mt76-phy1" "phy1tpt"
-	;;
-asus,rt-ax54|\
-yuncore,g720)
-	ucidef_set_led_wlan "wlan2g" "WiFi 2.4GHz" "mt76-phy0" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "WiFi 5GHz" "mt76-phy1" "phy1tpt"
 	;;
 asus,rt-n56u-b1)
 	ucidef_set_led_netdev "lan" "LAN link" "blue:lan" "br-lan"
@@ -75,8 +68,6 @@ cudy,wr2100)
 	;;
 d-team,newifi-d2)
 	ucidef_set_led_netdev "internet" "internet" "amber:internet" "wan"
-	ucidef_set_led_netdev "wlan2g" "WiFi 2.4GHz" "blue:wlan2g" "wlan0"
-	ucidef_set_led_netdev "wlan5g" "WiFi 5GHz" "blue:wlan5g" "wlan1"
 	;;
 d-team,pbr-m1|\
 gehua,ghl-r-001|\
@@ -229,8 +220,6 @@ tplink,ec330-g5u-v1)
 	ucidef_set_led_netdev "wan-off" "Internet-off" "amber:wan" "wan" "link"
 	;;
 tplink,re350-v1)
-	ucidef_set_led_netdev "wifi2g" "Wifi 2.4G" "blue:wifi2G" "wlan0"
-	ucidef_set_led_netdev "wifi5g" "Wifi 5G" "blue:wifi5G" "wlan1"
 	ucidef_set_led_netdev "eth_act" "LAN act" "green:eth_act" "lan" "tx rx"
 	ucidef_set_led_netdev "eth_link" "LAN link" "green:eth_link" "lan" "link"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -10,9 +10,6 @@ case $board in
 7links,wlr-1230)
 	ucidef_set_led_switch "lan" "lan" "orange:lan" "switch0" "0x10"
 	;;
-alfa-network,awusfree1)
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wlan" "wlan0"
-	;;
 asus,rt-n10p-v3|\
 asus,rt-n11p-b1|\
 asus,rt-n12-vp-b1|\
@@ -55,15 +52,7 @@ elecom,wrc-1167fs)
 	ucidef_set_led_switch "internet" "internet" "green:internet" "switch0" "0x10"
 	;;
 glinet,gl-mt300n-v2)
-	ucidef_set_led_netdev "wifi_led" "wifi" "red:wlan" "wlan0"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x1"
-	;;
-hilink,hlk-7628n|\
-skylab,skw92a)
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
-	;;
-hilink,hlk-7688a)
-	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
 hiwifi,hc5611)
 	ucidef_set_led_netdev "wan" "WAN" "red:wan" "br-lan" "tx rx"
@@ -80,18 +69,8 @@ keenetic,kn-1711|\
 keenetic,kn-1713)
 	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x01"
 	;;
-mediatek,linkit-smart-7688)
-	ucidef_set_led_wlan "wifi" "wifi" "orange:wifi" "phy0tpt"
-	;;
-oraybox,x1)
-	ucidef_set_led_netdev "wifi" "wifi" "blue:status" "wlan0"
-	;;
-rakwireless,rak633)
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wifi" "wlan0"
-	;;
 tama,w06)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
-	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
 teltonika,rut200|\
 teltonika,rut241)
@@ -117,8 +96,6 @@ tplink,archer-c50-v4|\
 tplink,archer-c50-v6)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
-	ucidef_set_led_wlan "wlan2g" "wlan2g" "green:wlan2g" "phy0tpt"
-	ucidef_set_led_wlan "wlan5g" "wlan5g" "green:wlan5g" "phy1tpt"
 	;;
 tplink,archer-mr200-v5|\
 tplink,archer-mr200-v6)
@@ -144,7 +121,6 @@ tplink,re365-v1)
 tplink,tl-mr3420-v5|\
 tplink,tl-wr840n-v4|\
 tplink,tl-wr842n-v5)
-	ucidef_set_led_wlan "wlan2g" "wlan2g" "green:wlan" "phy0tpt"
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
 	;;
@@ -158,7 +134,6 @@ tplink,tl-mr6400-v7)
 	ucidef_set_led_switch "wan" "wan" "white:wan" "switch0" "0x08"
 	;;
 tplink,tl-wr841n-v13)
-	ucidef_set_led_wlan "wlan2g" "wlan2g" "green:wlan" "phy0tpt"
 	ucidef_set_led_switch "lan1" "lan1" "green:lan1" "switch0" "0x2"
 	ucidef_set_led_switch "lan2" "lan2" "green:lan2" "switch0" "0x4"
 	ucidef_set_led_switch "lan3" "lan3" "green:lan3" "switch0" "0x8"
@@ -168,10 +143,8 @@ tplink,tl-wr841n-v13)
 tplink,tl-wr841n-v14)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x1e"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
-	ucidef_set_led_wlan "wifi_led" "wifi" "green:wlan" "phy0tpt"
 	;;
 tplink,tl-wr902ac-v3)
-	ucidef_set_led_wlan "wlan2g" "wlan2g" "green:wlan" "phy0tpt"
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x10"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
 	;;
@@ -184,7 +157,6 @@ unielec,u7628-01-16m)
 	ucidef_set_led_switch "lan3" "lan3" "green:lan3" "switch0" "0x8"
 	ucidef_set_led_switch "lan4" "lan4" "green:lan4" "switch0" "0x10"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
 	;;
 wavlink,wl-wn570ha1)
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
@@ -224,7 +196,6 @@ xiaomi,mi-router-4c)
 	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x02"
 	;;
 zbtlink,zbt-we1226)
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
 	ucidef_set_led_switch "lan1" "LAN1" "green:lan1" "switch0" "0x01"
 	ucidef_set_led_switch "lan2" "LAN2" "green:lan2" "switch0" "0x02"
 	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x10"
@@ -237,7 +208,6 @@ zbtlink,zbt-we2426-b)
 	ucidef_set_led_switch "lan4" "lan4" "green:lan-4" "switch0" "0x08"
 	;;
 zyxel,keenetic-extra-ii)
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wifi" "wlan0"
 	ucidef_set_led_switch "internet" "internet" "green:internet" "switch0" "0x01"
 	;;
 esac

--- a/target/linux/ramips/rt305x/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/rt305x/base-files/etc/board.d/01_leds
@@ -7,17 +7,6 @@ board=$(board_name)
 board_config_update
 
 case $board in
-7links,px-4885-4m|\
-7links,px-4885-8m|\
-fon,fonera-20n)
-	ucidef_set_led_netdev "wifi_led" "wifi" "orange:wifi" "wlan0"
-	;;
-airlive,air3gii|\
-aximcom,mr-102n|\
-edimax,3g-6200nl|\
-netgear,wnce2001)
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
-	;;
 alfa-network,w502u|\
 dlink,dir-300-b1|\
 dlink,dir-300-b7|\
@@ -48,43 +37,22 @@ allnet,all0256n-8m)
 alphanetworks,asl26555-8m|\
 alphanetworks,asl26555-16m)
 	ucidef_set_led_netdev "eth" "ETH" "green:eth" "eth0"
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
 	;;
 asiarf,awapn2403)
 	ucidef_set_led_netdev "wifi_led" "wifi" "rt2800soc-phy0::radio" "wlan0"
-	;;
-dlink,dcs-930l-b1)
-	ucidef_set_led_netdev "wifi" "WiFi" "blue:wps"
 	;;
 dlink,dir-615-d)
 	ucidef_set_led_netdev "wan" "WAN (green)" "green:wan" "eth0.2"
 	ucidef_set_led_netdev "wifi_led" "wifi" "rt2800soc-phy0::radio" "wlan0"
 	;;
-dlink,dir-620-d1|\
-trendnet,tew-714tru)
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wifi" "wlan0"
-	;;
-edimax,3g-6200n|\
-planex,mzk-w300nh2)
-	ucidef_set_led_netdev "wifi_led" "wifi" "amber:wlan" "wlan0"
-	;;
-hauppauge,broadway)
-	ucidef_set_led_netdev "wifi_led" "wifi" "red:wps_active" "wlan0"
-	;;
 hootoo,ht-tm02)
 	ucidef_set_led_netdev "eth" "Ethernet" "green:lan" "eth0"
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wlan" "wlan0"
 	;;
 huawei,hg255d)
-	ucidef_set_led_netdev "wifi_led" "wifi" "green:wlan" "wlan0"
 	ucidef_set_led_netdev "internet" "internet" "green:internet" "eth0.2"
 	;;
 intenso,memory2move)
-	ucidef_set_led_netdev "wifi_led" "wifi" "blue:wifi" "wlan0"
 	ucidef_set_led_netdev "eth" "Ethernet" "green:wan" "eth0"
-	;;
-omnima,miniembplug)
-	ucidef_set_led_netdev "wifi_led" "wifi" "red:wlan" "wlan0"
 	;;
 vocore,vocore-8m|\
 vocore,vocore-16m)


### PR DESCRIPTION
Set WLAN LED trigger in the device tree to simplify LED init script.

1. Move "phytpt" and "phyradio" triggers to dts.
2. Convert wlan netdev trigger to "phytpt".
3. Convert wlan netdev link trigger to "phyradio".

* "phytpt" trigger will blink LED when there are tx/rx activities.
* "phyradio" trigger only shows the radio on/off status.