### PR TITLE
stm32: modules: fix stm32-hash package build

### DIFF
--- a/target/linux/stm32/modules.mk
+++ b/target/linux/stm32/modules.mk
@@ -216,13 +216,14 @@ define KernelPackage/stm32-hash
   SUBMENU:=$(CRYPTO_MENU)
   TITLE:=Support for STM32 hash accelerators
   DEPENDS:=@TARGET_stm32 \
+	   +kmod-crypto-engine \
 	   +kmod-crypto-md5 \
 	   +kmod-crypto-sha1 \
 	   +kmod-crypto-sha256 \
 	   +kmod-crypto-sha3 \
 	   +kmod-crypto-rsa
   KCONFIG:=CONFIG_CRYPTO_DEV_STM32_HASH \
-	   CONFIG_CRYPTO_ENGINE=y \
+	   CONFIG_CRYPTO_ENGINE=y
   FILES:=$(LINUX_DIR)/drivers/crypto/stm32/stm32-hash.ko
   AUTOLOAD:=$(call AutoProbe,stm32-hash)
 endef


### PR DESCRIPTION
Remove misplaced backslash to fix the build warning:

WARNING: can't parse line: FILES:=/drivers/crypto/stm32/stm32-hash.ko
