### PR TITLE
treewide: fix various dtc warnings

### DIFF
--- a/target/linux/apm821xx/dts/netgear-wndr4700.dts
+++ b/target/linux/apm821xx/dts/netgear-wndr4700.dts
@@ -181,9 +181,11 @@
 			#size-cells = <1>;
 
 			partition@0 {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
 				label = "uboot";
 				reg = <0x00000000 0x00180000>;
-				compatible = "fixed-partitions";
 				read-only;
 
 				partition@40000 {

--- a/target/linux/ath79/dts/qca9557_fortinet_fap-221-c.dts
+++ b/target/linux/ath79/dts/qca9557_fortinet_fap-221-c.dts
@@ -205,7 +205,7 @@
 &pcie0 {
 	status = "okay";
 
-	wifi@0,0,0 {
+	wifi@0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x0 0 0 0 0>;
 		nvmem-cells = <&calibration_pcie>, <&macaddr_uboot_3ff80 2>;

--- a/target/linux/bmips/dts/bcm6328-dlink-dsl-2750b-b1.dts
+++ b/target/linux/bmips/dts/bcm6328-dlink-dsl-2750b-b1.dts
@@ -206,8 +206,9 @@
 		#size-cells = <2>;
 		#address-cells = <3>;
 		device_type = "pci";
+		ranges;
 
-		ath9k: wifi@168c,002e {
+		ath9k: wifi@0,0 {
 			compatible = "pci168c,002e";
 			reg = <0 0 0 0 0>;
 

--- a/target/linux/kirkwood/patches-6.12/203-blackarmor-nas220.patch
+++ b/target/linux/kirkwood/patches-6.12/203-blackarmor-nas220.patch
@@ -62,13 +62,15 @@
  	};
  
  	regulators {
-@@ -153,6 +176,33 @@
+@@ -153,6 +176,35 @@
  
  &nand {
  	status = "okay";
 +
 +	partitions {
 +		compatible = "fixed-partitions";
++		#address-cells = <1>;
++		#size-cells = <1>;
 +
 +		partition@0 {
 +			label = "uboot";

--- a/target/linux/kirkwood/patches-6.6/203-blackarmor-nas220.patch
+++ b/target/linux/kirkwood/patches-6.6/203-blackarmor-nas220.patch
@@ -63,13 +63,15 @@
  	};
  
  	regulators {
-@@ -153,6 +176,33 @@
+@@ -153,6 +176,35 @@
  
  &nand {
  	status = "okay";
 +
 +	partitions {
 +		compatible = "fixed-partitions";
++		#address-cells = <1>;
++		#size-cells = <1>;
 +
 +		partition@0 {
 +			label = "uboot";

--- a/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-385-wd_cloud-mirror-gen2.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-385-wd_cloud-mirror-gen2.dts
@@ -145,24 +145,24 @@
 						#address-cells = <1>;
 						#size-cells = <1>;
 
-						partition@00000000 {
+						partition@0 {
 							label = "U-Boot";
 							reg = <0x00000000 0x00500000>;    /*   5 MB */
 							read-only;
 						};
 
-						partition@00500000 {
+						partition@500000 {
 							label = "kernel";
 							reg = <0x00500000 0x00500000>;    /*   5 MB */
 						};
 
-						partition@00a00000 {
+						partition@a00000 {
 							label = "uRamdisk";
 							reg = <0x00a00000 0x00500000>;    /*   5 MB */
 							read-only;
 						};
 
-						partition@00f00000 {
+						partition@f00000 {
 							label = "ubi";
 							reg = <0x00f00000 0x0b900000>;    /* 185 MB */
 						};

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9130-clearfog-pro.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9130-clearfog-pro.dts
@@ -30,7 +30,7 @@
 		spi1 = &cp0_spi1;
 	};
 
-	memory@00000000 {
+	memory@0 {
 		reg = <0x0 0x0 0x1 0x0>;
 		device_type = "memory";
 	};

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9131-puzzle-m901.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9131-puzzle-m901.dts
@@ -40,7 +40,7 @@
 		led-upgrade = &led_info;
 	};
 
-	memory@00000000 {
+	memory@0 {
 		device_type = "memory";
 		reg = <0x0 0x0 0x0 0x80000000>;
 	};

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
@@ -47,7 +47,7 @@
 		led-upgrade = &led_info;
 	};
 
-	memory@00000000 {
+	memory@0 {
 		device_type = "memory";
 		reg = <0x0 0x0 0x0 0x80000000>;
 	};

--- a/target/linux/mvebu/patches-6.12/320-arm-dts-armada-370-synology-ds213j-mtd-parts.patch
+++ b/target/linux/mvebu/patches-6.12/320-arm-dts-armada-370-synology-ds213j-mtd-parts.patch
@@ -42,7 +42,7 @@
  };
  
  &pinctrl {
-@@ -259,48 +280,50 @@
+@@ -259,48 +280,52 @@
  		reg = <0>; /* Chip select 0 */
  		spi-max-frequency = <20000000>;
  
@@ -66,47 +66,46 @@
 -		};
 +		partitions {
 +			compatible = "fixed-partitions";
- 
--		partition@c0000 { /* uImage */
--			label = "zImage";
--			reg = <0x000c0000 0x002d0000>; /* 2880KB */
--		};
++			#address-cells = <1>;
++			#size-cells = <1>;
++
 +			partition@0 { /* u-boot */
 +				label = "u-boot";
 +				reg = <0x00000000 0x000c0000>; /* 768KB */
 +				read-only;
 +			};
  
--		partition@390000 { /* uInitramfs */
--			label = "rd.gz";
--			reg = <0x00390000 0x00440000>; /* 4250KB */
+-		partition@c0000 { /* uImage */
+-			label = "zImage";
+-			reg = <0x000c0000 0x002d0000>; /* 2880KB */
 -		};
 +			mtd_gap: partition@c0000 { /* gap */
 +				label = "gap";
 +				reg = <0x000c0000 0x00040000>; /* 256KB */
 +			};
  
--		partition@7d0000 { /* MAC address and serial number */
--			label = "vendor";
--			reg = <0x007d0000 0x00010000>; /* 64KB */
+-		partition@390000 { /* uInitramfs */
+-			label = "rd.gz";
+-			reg = <0x00390000 0x00440000>; /* 4250KB */
 -		};
 +			partition@100000 { /* u-boot-env */
 +				label = "u-boot-env";
 +				reg = <0x00100000 0x00010000>; /* 64KB */
 +			};
  
--		partition@7e0000 {
--			label = "RedBoot config";
--			reg = <0x007e0000 0x00010000>; /* 64KB */
+-		partition@7d0000 { /* MAC address and serial number */
+-			label = "vendor";
+-			reg = <0x007d0000 0x00010000>; /* 64KB */
 -		};
 +			mtd_kernel: partition@110000 {
 +				label = "kernel";
 +				reg = <0x00110000 0x006c0000>; /* 6912KB */
 +			};
  
--		partition@7f0000 {
--			label = "FIS directory";
--			reg = <0x007f0000 0x00010000>; /* 64KB */
+-		partition@7e0000 {
+-			label = "RedBoot config";
+-			reg = <0x007e0000 0x00010000>; /* 64KB */
+-		};
 +			partition@7d0000 { /* MAC address and serial number */
 +				reg = <0x007d0000 0x00010000>; /* 64KB */
 +				label = "vendor";
@@ -122,7 +121,10 @@
 +					};
 +				};
 +			};
-+
+ 
+-		partition@7f0000 {
+-			label = "FIS directory";
+-			reg = <0x007f0000 0x00010000>; /* 64KB */
 +			mtd_gap2: partition@7e0000 {
 +				label = "gap2";
 +				reg = <0x007e0000 0x00020000>; /* 128KB */

--- a/target/linux/mvebu/patches-6.12/325-arm-dts-marvell-add-LED-aliases-and-USB-ports-to-Cte.patch
+++ b/target/linux/mvebu/patches-6.12/325-arm-dts-marvell-add-LED-aliases-and-USB-ports-to-Cte.patch
@@ -102,8 +102,8 @@ Signed-off-by: Stefan Kalscheuer <stefan@stklcode.de>
 +				/* Renesas uPD720202 */
 +				compatible = "pci1912,0015";
 +				reg = <0x1000 0 0 0 0>;
-+				#address-cells = <3>;
-+				#size-cells = <2>;
++				#address-cells = <1>;
++				#size-cells = <0>;
 +
 +				usb1_port: port@1 {
 +					reg = <1>;

--- a/target/linux/qoriq/files/arch/powerpc/boot/dts/fsl/watchguard-firebox-m300.dts
+++ b/target/linux/qoriq/files/arch/powerpc/boot/dts/fsl/watchguard-firebox-m300.dts
@@ -362,6 +362,7 @@
 			reg = <0x32>;
 		};
 		pca9547@77 {
+			reg = <0x77>;
 			status = "disabled";
 		};
 	};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rt-ax89x.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rt-ax89x.dts
@@ -554,6 +554,9 @@
 		reg = <0x10>;
 
 		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
 			port@0 {
 				reg = <0>;
 				label = "cpu";

--- a/target/linux/ramips/dts/mt7621_gemtek_wvrtm-130acn.dts
+++ b/target/linux/ramips/dts/mt7621_gemtek_wvrtm-130acn.dts
@@ -38,7 +38,7 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
-		#address-cells = <2>;
+		#address-cells = <1>;
 		#size-cells = <0>;
 
 		band@0 {

--- a/target/linux/ramips/dts/mt7621_ruijie_rg-ew1200g-pro-v1.1.dts
+++ b/target/linux/ramips/dts/mt7621_ruijie_rg-ew1200g-pro-v1.1.dts
@@ -54,6 +54,8 @@
 
 		partitions {
 			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
 
 			partition@0 {
 				label = "u-boot";


### PR DESCRIPTION
These patches have not been tested. Most warnings are caused by `#address-cells` and `#size-cells`.