### PR TITLE
mediatek: add BeeconMini SEED AC2 support

### DIFF
--- a/package/kernel/rtl8373/Makefile
+++ b/package/kernel/rtl8373/Makefile
@@ -1,0 +1,24 @@
+include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
+
+PKG_NAME:=switch-rtl8373
+PKG_RELEASE:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define KernelPackage/switch-rtl8373
+  SECTION:=kernel
+  CATEGORY:=Kernel modules
+  SUBMENU:=Network Devices
+  TITLE:=Realtek RTL8373 switch support
+  DEPENDS:=
+  FILES:= $(PKG_BUILD_DIR)/rtl8373.ko
+  AUTOLOAD:=$(call AutoProbe,rtl8373)
+endef
+
+include $(INCLUDE_DIR)/kernel-defaults.mk
+
+define Build/Compile
+endef
+
+$(eval $(call KernelPackage,switch-rtl8373))

--- a/package/kernel/rtl8373/Makefile
+++ b/package/kernel/rtl8373/Makefile
@@ -11,7 +11,7 @@ define KernelPackage/switch-rtl8373
   CATEGORY:=Kernel modules
   SUBMENU:=Network Devices
   TITLE:=Realtek RTL8373 switch support
-  DEPENDS:=
+  DEPENDS:=+kmod-i2c-gpio
   FILES:= $(PKG_BUILD_DIR)/rtl8373.ko
   AUTOLOAD:=$(call AutoProbe,rtl8373)
 endef

--- a/target/linux/mediatek/dts/mt7981b-beeconmini-seed-ac2.dts
+++ b/target/linux/mediatek/dts/mt7981b-beeconmini-seed-ac2.dts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "BeeconMini SEED AC2";
+	compatible = "beeconmini,seed-ac2", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "root=PARTLABEL=rootfs rootfstype=squashfs,f2fs rootwait fstools_partname_fallback_scan=1";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: led_sys {
+			label = "led_sys";
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	rtl8373 {
+		compatible = "realtek,rtl8373";
+		mediatek,mdio = <&mdio_bus>;
+		mediatek,reset-pin = <&pio 1 GPIO_ACTIVE_HIGH>;
+		interrupt-parent = <&pio>;
+		interrupts = <6 IRQ_TYPE_LEVEL_LOW>;
+		status = "okay";
+	};
+
+	i2c_rtl8238b {
+		compatible = "i2c-gpio";
+		sda-gpios = <&pio 47 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&pio 46 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		rtl8238b: rtl8238b@20 {
+			compatible = "realtek,rtl8238b";
+			reg = <0x20>;
+		};
+	};
+};
+
+&sgmiisys0 {
+	/delete-property/ mediatek,pnswap;
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&rtl8221b_phy>;
+	};
+
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		rtl8221b_phy: ethernet-phy@7 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <7>;
+			reset-gpios = <&pio 49 GPIO_ACTIVE_LOW>;
+			interrupt-parent = <&pio>;
+			interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
+			reset-assert-us = <100000>;
+			reset-deassert-us = <100000>;
+		};
+	};
+};
+
+&mmc0 {
+	max-frequency = <26000000>;
+	no-sd;
+	no-sdio;
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_default>;
+	pinctrl-1 = <&mmc0_pins_uhs>;
+	vmmc-supply = <&reg_3p3v>;
+	non-removable;
+	status = "okay";
+	bus-width = <8>;
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spic_pins>;
+	status = "disabled";
+};
+
+&spi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+	status = "okay";
+
+	spi_nor@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partition@00000 {
+			label = "BL2";
+			reg = <0x00000 0x0040000>;
+		};
+
+		partition@40000 {
+			label = "u-boot-env";
+			reg = <0x40000 0x0010000>;
+		};
+
+		partition@50000 {
+			label = "Factory";
+			reg = <0x50000 0x00A0000>;
+		};
+
+		partition@F0000 {
+			label = "art";
+			reg = <0xF0000 0x0010000>;
+		};
+
+		partition@100000 {
+			label = "FIP";
+			reg = <0x100000 0x0200000>;
+		};
+	};
+};
+
+&pio {
+	spic_pins: spi1-pins {
+		mux {
+			function = "spi";
+			groups = "spi1_1";
+		};
+	};
+
+	spi2_flash_pins: spi2-pins {
+		mux {
+			function = "spi";
+			groups = "spi2", "spi2_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+	mmc0_pins_default: mmc0-pins-default {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+
+	mmc0_pins_uhs: mmc0-pins-uhs {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -54,6 +54,9 @@ mediatek_setup_interfaces()
 	zyxel,ex5601-t0-ubootmod)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
 		;;
+        beeconmini,seed-ac2)
+		ucidef_set_interfaces_lan_wan eth0 eth1
+		;;
 	asus,tuf-ax6000|\
 	glinet,gl-mt6000|\
 	tplink,tl-xdr4288|\
@@ -199,6 +202,10 @@ mediatek_setup_macs()
 		;;
 	yuncore,ax835)
 		label_mac=$(mtd_get_mac_binary "Factory" 0x4)
+		;;
+	beeconmini,seed-ac2)
+		lan_mac=$(mtd_get_mac_binary "art" 0x0)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
 	esac
 

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -168,6 +168,12 @@ platform_do_upgrade() {
 			;;
 		esac
 		;;
+  	beeconmini,seed-ac2)
+		CI_KERNPART="kernel"
+		CI_ROOTPART="rootfs"
+		CI_DATAPART="rootfs_data"
+		emmc_do_upgrade "$1"
+		;;
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-wr30u-stock|\
 	xiaomi,redmi-router-ax6000-stock)
@@ -237,6 +243,7 @@ platform_copy_config() {
 	acer,vero-w6m|\
 	arcadyan,mozart|\
 	glinet,gl-mt2500|\
+ 	beeconmini,seed-ac2|\
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -380,6 +380,16 @@ endif
 endef
 TARGET_DEVICES += bananapi_bpi-r3
 
+define Device/beeconmini_seed-ac2
+  DEVICE_VENDOR := BeeconMini
+  DEVICE_MODEL := SEED AC2
+  DEVICE_DTS := mt7981b-beeconmini-seed-ac2
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-fs-f2fs kmod-fs-ext4 mkf2fs e2fsprogs kmod-switch-rtl8373 kmod-mt7981-firmware mt7981-wo-firmware
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += beeconmini_seed-ac2
+
 define Device/bananapi_bpi-r3-mini
   DEVICE_VENDOR := Bananapi
   DEVICE_MODEL := BPi-R3 Mini


### PR DESCRIPTION
Hardware:
    - SoC: MediaTek MT7981B
    - Flash: 64G
    - RAM: 1024 MiB
    - Ethernet: 1x 2500 Mbps WAN
    - RTL8373 8x 2500 Mbps WAN
    - Buttons: 1 Reset button
    - Power: 12 VDC, 1.5 A
    
‌Procedure for Flashing eMMC Using Factory U-Boot:‌

‌Power Off‌: Disconnect the device from the power source.
‌Enter U-Boot Mode‌:
Press and hold the ‌Reset‌ button.
Power on the device while keeping the Reset button pressed.
Release the Reset button after approximately ‌8 seconds‌.
‌Configure Network Settings‌:
Set the computer’s IP address to ‌192.168.88.2‌ with subnet mask ‌255.255.255.0‌.
‌Access U-Boot Interface‌:
Open a web browser and navigate to ‌http://192.168.88.1‌ to access the web-based U-Boot interface.
‌Firmware Upload‌:
Select the ‌Local Firmware Update‌ option.
Upload the firmware file and initiate the flashing process.
‌Restore Network Configuration‌:
After successful flashing, reconfigure the computer to use ‌DHCP‌ for IP assignment.
This procedure ensures reliable firmware deployment to eMMC storage via the factory U-Boot bootloader.

reference
https://github.com/BeeconMini/openwrt_v23.05.4/commit/8f8239d85a053e823c51f8d1d3ae5983bc60a23f

Tested-by: Hongchao Zheng <hnxyhc97@gmail.com>