### PR TITLE
[24.10] ramips: Add support for Cudy M1200 v1

### DIFF
--- a/target/linux/ramips/dts/mt7628an_cudy_m1200-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_m1200-v1.dts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "cudy,m1200-v1", "mediatek,mt7628an-soc";
+	model = "Cudy M1200 v1";
+
+	aliases {
+		led-boot = &led_status_white;
+		led-running = &led_status_white;
+		led-failsafe = &led_status_red;
+		led-upgrade = &led_status_red;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+ 
+
+		wps {
+ 			label = "wps";
+ 			linux,code = <KEY_WPS_BUTTON>;
+ 			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-status-red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_white: led-status-white {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "debug";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "backup";
+				reg = <0xfe000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "bdinfo";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "gpio", "wdt", "p0led_an", "wled_an";
+		function = "gpio";
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_bdinfo_de00 2>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 1>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3d>;
+	mediatek,portdisable = <0x3c>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -167,6 +167,17 @@ define Device/comfast_cf-wr758ac-v2
 endef
 TARGET_DEVICES += comfast_cf-wr758ac-v2
 
+define Device/cudy_m1200-v1
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := M1200
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
+  UIMAGE_NAME := R22
+  SUPPORTED_DEVICES += R22
+endef
+TARGET_DEVICES += cudy_m1200-v1
+
 define Device/cudy_tr1200-v1
   IMAGE_SIZE := 15872k
   DEVICE_VENDOR := Cudy

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -97,6 +97,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan" "6@eth0"
 		;;
+	cudy,m1200-v1|\
 	cudy,tr1200-v1)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:wan" "6@eth0"


### PR DESCRIPTION
The M1200 v1 is similar to the TR1200 series from Cudy. Differences:
- Only 1 LAN port
- No USB

Specifications:
- MT7628
- MT7628AN (2.4G b/g/n) and MT7613BE (5G ac/n) wifi
- 128 MB RAM
- 16 MB flash

MAC Addresses:
- There is one on the label, e.g. xx:xx:xx:xx:xx:A4
- LAN (bottom connector) is the same as the label, e.g. xx:xx:xx:xx:xx:A4
- WAN (top connector) is label + 1, e.g. xx:xx:xx:xx:xx:A5
- WLAN (2.4G) is the same as the label, e.g. xx:xx:xx:xx:xx:A4
- WLAN (5G) is label + 2, e.g. xx:xx:xx:xx:xx:A6

UART:
- is available via the pin holes on the board
- The pinout is printed to the board: P: VCC, G: GND, R: RX, T:TX
- RX and TX require solder bridges to be installed
- Do NOT connect VCC
- Settings: 3.3V, 115200, 8N1

GPIO:
- There are two LEDs: Red (GPIO 4) and White (GPIO 0)
- There are two buttons: Reset (GPIO 11) and WPS (GPIO 5)

Migration to OpenWrt:
- Download the migration image from the Cudy website (it should be available as soon as OpenWrt officially supports the device)
- Connect computer to LAN (bottom connector) and flash the migration image via OEM web interface
- OpenWrt is now accessible via 192.168.1.1

Revert back to OEM firmware:
- Set up a TFTP server on IP 192.168.1.88 and connect to the WAN port (upper port)
- Provide the Cudy firmware as recovery.bin in the TFTP server
- Press the reset button while powering on the device
- Recovery process is started now
- When recovery process is done, OEM firmware is accessible via 192.168.10.1 again

General information:
- No possibility to load a initramfs image via U-Boot because there is no option to interrupt U-Boot

