### PR TITLE
selinux-policy: fix PKG_MIRROR_HASH after update to v2.6

### DIFF
--- a/package/system/selinux-policy/Makefile
+++ b/package/system/selinux-policy/Makefile
@@ -9,7 +9,7 @@ PKG_NAME:=selinux-policy
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.defensec.nl/selinux-policy.git
 PKG_VERSION:=2.6
-PKG_MIRROR_HASH:=92e59cb86adcf0837fae53d75905cdd360f5f094b087c27d0abcb725d1b4b617
+PKG_MIRROR_HASH:=3604ce2d2874f58a7fc03998daa81628fca43aa8ac0a7436f07612365b6ce7ad
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=secilc/host policycoreutils/host
 


### PR DESCRIPTION
PKG_MIRROR_HASH is incorrect and fails the download from mirrors.

Fixes: 0aaabffdea2c ("selinux-policy: update to version v2.6")

CC @dangowrt