### PR TITLE
mediatek: rename PHY LEDs to match upstream bindings

### DIFF
--- a/target/linux/mediatek/dts/mt7622-smartrg-SDG-841-t6.dts
+++ b/target/linux/mediatek/dts/mt7622-smartrg-SDG-841-t6.dts
@@ -188,13 +188,13 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				led@0 {
+				led-0 {
 					reg = <0>;
 					color = <LED_COLOR_ID_GREEN>;
 					function = LED_FUNCTION_LAN;
 				};
 
-				led@1 {
+				led-1 {
 					reg = <1>;
 					color = <LED_COLOR_ID_AMBER>;
 					function = LED_FUNCTION_LAN;
@@ -214,13 +214,13 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				led@1 {
+				led-1 {
 					reg = <1>;
 					color = <LED_COLOR_ID_AMBER>;
 					function = LED_FUNCTION_WAN;
 				};
 
-				led@2 {
+				led-2 {
 					reg = <2>;
 					color = <LED_COLOR_ID_GREEN>;
 					function = LED_FUNCTION_WAN;

--- a/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
+++ b/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
@@ -171,13 +171,13 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			led@0 {
+			led-0 {
 				reg = <0>;
 				function = LED_FUNCTION_WAN;
 				color = <LED_COLOR_ID_AMBER>;
 			};
 
-			led@1 {
+			led-1 {
 				reg = <1>;
 				function = LED_FUNCTION_WAN;
 				color = <LED_COLOR_ID_GREEN>;

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
@@ -140,7 +140,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			led@0 {
+			led-0 {
 				reg = <0>;
 				color = <LED_COLOR_ID_WHITE>;
 				function = LED_FUNCTION_WAN;

--- a/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
+++ b/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
@@ -187,13 +187,13 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				led@0 {
+				led-0 {
 					reg = <0>;
 					function = LED_FUNCTION_LAN;
 					color = <LED_COLOR_ID_YELLOW>;
 				};
 
-				led@1 {
+				led-1 {
 					reg = <1>;
 					function = LED_FUNCTION_LAN;
 					color = <LED_COLOR_ID_GREEN>;
@@ -223,13 +223,13 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				led@0 {
+				led-0 {
 					reg = <0>;
 					function = LED_FUNCTION_WAN;
 					color = <LED_COLOR_ID_YELLOW>;
 				};
 
-				led@1 {
+				led-1 {
 					reg = <1>;
 					function = LED_FUNCTION_WAN;
 					color = <LED_COLOR_ID_GREEN>;

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -219,7 +219,7 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				led@0 {
+				led-0 {
 					reg = <0>;
 					color = <LED_COLOR_ID_GREEN>;
 					function = LED_FUNCTION_LAN;
@@ -235,7 +235,7 @@
 				#address-cells = <1>;
 				#size-cells = <0>;
 
-				led@0 {
+				led-0 {
 					reg = <0>;
 					color = <LED_COLOR_ID_GREEN>;
 					function = LED_FUNCTION_WAN;

--- a/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
+++ b/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
@@ -425,19 +425,19 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			led@0 {
+			led-0 {
 				reg = <0>;
 				function = LED_FUNCTION_WAN;
 				color = <LED_COLOR_ID_GREEN>;
 			};
 
-			led@1 {
+			led-1 {
 				reg = <1>;
 				function = LED_FUNCTION_WAN;
 				color = <LED_COLOR_ID_ORANGE>;
 			};
 
-			led@2 {
+			led-2 {
 				reg = <2>;
 				function = LED_FUNCTION_WAN;
 				color = <LED_COLOR_ID_WHITE>;
@@ -459,19 +459,19 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			aqr_green_led: led@0 {
+			aqr_green_led: led-0 {
 				reg = <0>;
 				function = LED_FUNCTION_LAN;
 				color = <LED_COLOR_ID_GREEN>;
 			};
 
-			aqr_orange_led: led@1 {
+			aqr_orange_led: led-1 {
 				reg = <1>;
 				function = LED_FUNCTION_LAN;
 				color = <LED_COLOR_ID_ORANGE>;
 			};
 
-			aqr_white_led: led@2 {
+			aqr_white_led: led-2 {
 				reg = <2>;
 				function = LED_FUNCTION_LAN;
 				color = <LED_COLOR_ID_WHITE>;


### PR DESCRIPTION
Kernel docs recommends the following pattern "(^led-[0-9a-f]$|led)"[1].

1. https://elixir.bootlin.com/linux/v6.14-rc6/source/Documentation/devicetree/bindings/leds/leds-gpio.yaml#L24

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>