### PR TITLE
mediatek: filogic: migrate SmartRG Bonanza to upstream PHY LED control

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-smartrg-bonanza-peak.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-smartrg-bonanza-peak.dtsi
@@ -220,8 +220,33 @@
 		compatible = "maxlinear,gpy211", "ethernet-phy-ieee802.3-c45";
 		reg = <5>;
 
-		mxl,led-drive-vdd;
-		mxl,led-config = <0x30 0x40 0x80 0x0>;
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led-0 {
+				reg = <0>;
+				active-high;
+				color = <LED_COLOR_ID_AMBER>;
+				function = LED_FUNCTION_LAN;
+			};
+
+			led-1 {
+				reg = <1>;
+				active-high;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <0>;
+			};
+
+			led-2 {
+				reg = <2>;
+				active-high;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				function-enumerator = <1>;
+			};
+		};
 	};
 
 	phy6: ethernet-phy@6 {
@@ -229,8 +254,33 @@
 		compatible = "maxlinear,gpy211", "ethernet-phy-ieee802.3-c45";
 		reg = <6>;
 
-		mxl,led-drive-vdd;
-		mxl,led-config = <0x30 0x40 0x80 0x0>;
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led-0 {
+				reg = <0>;
+				active-high;
+				color = <LED_COLOR_ID_AMBER>;
+				function = LED_FUNCTION_WAN;
+			};
+
+			led-1 {
+				reg = <1>;
+				active-high;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+				function-enumerator = <0>;
+			};
+
+			led-2 {
+				reg = <2>;
+				active-high;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+				function-enumerator = <1>;
+			};
+		};
 	};
 };
 

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -109,6 +109,28 @@ routerich,ax3000-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
 	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
 	;;
+smartrg,sdg-8612)
+	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:amber:lan" "lan4" "link_10 link_100"
+	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-0" "lan4" "link_1000"
+	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-1" "lan4" "link_2500"
+	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100"
+	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-0" "eth1" "link_1000"
+	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-1" "eth1" "link_2500"
+	;;
+smartrg,sdg-8614)
+	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:amber:lan" "lan4" "link_10 link_100"
+	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-0" "lan4" "link_1000"
+	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-1" "lan4" "link_2500"
+	;;
+smartrg,sdg-8622|\
+smartrg,sdg-8632)
+	ucidef_set_led_netdev "lan" "LAN" "mdio-bus:05:amber:lan" "lan" "link_10 link_100"
+	ucidef_set_led_netdev "lan" "LAN" "mdio-bus:05:green:lan-0" "lan" "link_1000"
+	ucidef_set_led_netdev "lan" "LAN" "mdio-bus:05:green:lan-1" "lan" "link_2500"
+	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100"
+	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-0" "eth1" "link_1000"
+	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-1" "eth1" "link_2500"
+	;;
 smartrg,sdg-8733|\
 smartrg,sdg-8734)
 	ucidef_set_led_netdev "lan-1-green" "LAN1" "mdio-bus:08:green:lan" "lan1" "link_2500 link_5000"


### PR DESCRIPTION
This commit switches the control of the leds connected to the Maxlinear GPY211C PHY to an upstream solution. There should be no functional changes. I don't have the device, but the migration is quite straightforward, so everything should work fine. Testing on the hardware welcome.
