### PR TITLE
ath79: fix calibration size for AR9287

### DIFF
--- a/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
+++ b/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
@@ -169,7 +169,7 @@
 	status = "okay";
 
 	wifi@0,0 {
-		compatible = "pci168c,002a";
+		compatible = "pci168c,002b";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&calibration_art_1000>;
 		nvmem-cell-names = "calibration";


### PR DESCRIPTION
This device uses AR9287, which uses 3d8 as the calibration size, not 440 like newer chips do. Add a compatible line to make it clear that this is the case.