### PR TITLE
package: add_package_uboot-tools pt 1 of 3

### DIFF
--- a/package/boot/uboot-tools/Makefile
+++ b/package/boot/uboot-tools/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_DISTNAME:=u-boot
+PKG_VERSION:=2025.01
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_DISTNAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:= \
+	https://ftp.denx.de/pub/u-boot \
+	https://mirror.cyberbits.eu/u-boot \
+	ftp://ftp.denx.de/pub/u-boot
+PKG_HASH:=cdef7d507c93f1bbd9f015ea9bc21fa074268481405501945abc6f854d5b686f
+PKG_SOURCE_SUBDIR:=$(PKG_DISTNAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_DISTNAME)-$(PKG_VERSION)
+
+PKG_BUILD_DEPENDS:=fstools
+
+PKG_LICENSE:=GPL-2.0 GPL-2.0+
+PKG_LICENSE_FILES:=Licenses/README
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/uboot-tools
+	SECTION:=utils
+	CATEGORY:=Utilities
+	SUBMENU:=Boot Loaders
+	TITLE:=U-Boot bootloader Tools
+	URL:=http://www.denx.de/wiki/U-Boot
+endef
+
+define Package/uboot-tools/description
+	U-Boot tools are a collection of utilities designed
+	to work with the U-Boot bootloader,
+endef
+
+define Build/Configure
+	$(MAKE) -C $(PKG_BUILD_DIR) tools-only_defconfig
+	$(MAKE) -C $(PKG_BUILD_DIR) syncconfig
+endef
+
+MAKE_FLAGS += \
+	ARCH="sandbox" \
+	TARGET_CFLAGS="$(TARGET_CFLAGS)" \
+	TARGET_LDFLAGS="$(TARGET_LDFLAGS)"
+
+define Build/Compile
+endef
+
+
+
+


### PR DESCRIPTION
the uboot-tools package contains various tools for working with uboot images. With the addition of the new dumpimage package, it no longer makes sense to have multi specific packages for each set of tools. Instead lets create a new uboot-tools package with configurable options to build the tools individually. 

A breakdown of the scheduled items as part of a 3 part commit

>part 1 - a basic makefile for the uboot-tools package

>part 2 - merge existing uboot-envtools, as a generalized sub-package, with new uboot-tools package

>part 3 - add new dumpimage,  generalized sub package, to uboot-tools package 

** add new uboot-tools package pt 1 of 3 **
 * add basic makefile for package uboot-tools
 * add patches directory
