### PR TITLE
Add dumpimage to uboot tools package

### DIFF
--- a/package/boot/uboot-tools/Makefile
+++ b/package/boot/uboot-tools/Makefile
@@ -1,0 +1,53 @@
+include $(TOPDIR)/rules.mk
+
+PKG_DISTNAME:=u-boot
+PKG_VERSION:=2025.01
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_DISTNAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE_URL:= \
+	https://ftp.denx.de/pub/u-boot \
+	https://mirror.cyberbits.eu/u-boot \
+	ftp://ftp.denx.de/pub/u-boot
+PKG_HASH:=cdef7d507c93f1bbd9f015ea9bc21fa074268481405501945abc6f854d5b686f
+PKG_SOURCE_SUBDIR:=$(PKG_DISTNAME)-$(PKG_VERSION)
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_DISTNAME)-$(PKG_VERSION)
+
+PKG_BUILD_DEPENDS:=fstools
+
+PKG_LICENSE:=GPL-2.0 GPL-2.0+
+PKG_LICENSE_FILES:=Licenses/README
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/uboot-tools
+	SECTION:=utils
+	CATEGORY:=Utilities
+	SUBMENU:=Boot Loaders
+	TITLE:=U-Boot bootloader Tools
+	URL:=http://www.denx.de/wiki/U-Boot
+endef
+
+define Package/uboot-tools/description
+	U-Boot tools are a collection of utilities designed
+	to work with the U-Boot bootloader,
+endef
+
+define Build/Configure
+	$(MAKE) -C $(PKG_BUILD_DIR) tools-only_defconfig
+	$(MAKE) -C $(PKG_BUILD_DIR) syncconfig
+endef
+
+MAKE_FLAGS += \
+	ARCH="sandbox" \
+	TARGET_CFLAGS="$(TARGET_CFLAGS)" \
+	TARGET_LDFLAGS="$(TARGET_LDFLAGS)"
+
+define Build/Compile
+endef
+
+
+
+

--- a/package/boot/uboot-tools/Makefile
+++ b/package/boot/uboot-tools/Makefile
@@ -35,19 +35,92 @@ define Package/uboot-tools/description
 	to work with the U-Boot bootloader,
 endef
 
+define Package/dumpimage
+	SECTION:=utils
+	CATEGORY:=Utilities
+	SUBMENU:=Boot Loaders
+	DEPENDS := +libopenssl
+	TITLE:=dumpimage lists and extracts data from U-Boot images.
+	URL:=http://www.denx.de/wiki/U-Boot
+endef
+
+define Package/dumpimage/description
+	dumpimage lists and extracts data from U-Boot images.
+	If -l is specified, dumpimage lists the components in
+	image.Otherwise, dumpimage extracts the component at
+	position to outfile.
+endef
+
+define Package/dumpimage/prepare
+	$(CP) ./dumpimage/patches ./patches
+endef
+
+define Package/uboot-envtools
+	SECTION:=utils
+	CATEGORY:=Utilities
+	SUBMENU:=Boot Loaders
+	PKG_FLAGS+=nonshared
+	TITLE:=read/modify U-Boot bootloader environment
+	URL:=http://www.denx.de/wiki/U-Boot
+endef
+
+define Package/uboot-envtools/description
+	This package includes tools to read and modify U-Boot
+	bootloader environment.
+endef
+
+define Package/uboot-envtools/conffiles
+	/etc/config/ubootenv
+	/etc/fw_env.config
+	/etc/fw_sys.config
+endef
+
+define Package/uboot-envtools/prepare
+	$(CP) ./uboot-envtools/patches ./patches
+endef
+
 define Build/Configure
 	$(MAKE) -C $(PKG_BUILD_DIR) tools-only_defconfig
 	$(MAKE) -C $(PKG_BUILD_DIR) syncconfig
+	$(SED) 's/CONFIG_TOOLS_LIBCRYPTO=y/# CONFIG_TOOLS_LIBCRYPTO is not set/' $(PKG_BUILD_DIR)/.config
 endef
 
 MAKE_FLAGS += \
-	ARCH="sandbox" \
+	ARCH="sandbox" cross_tools \
 	TARGET_CFLAGS="$(TARGET_CFLAGS)" \
 	TARGET_LDFLAGS="$(TARGET_LDFLAGS)"
 
 define Build/Compile
+	$(call Build/Compile/Default,envtools)
+	$(call Build/Compile/Default,cross_tools)
 endef
 
+define Package/dumpimage/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/dumpimage $(1)/usr/bin
+endef
 
+define Package/uboot-envtools/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tools/env/fw_printenv $(1)/usr/sbin
+	$(LN) fw_printenv $(1)/usr/sbin/fw_setenv
+	$(INSTALL_BIN) ./uboot-envtools/files/fw_printsys $(1)/usr/sbin
+	$(INSTALL_BIN) ./uboot-envtools/files/fw_setsys $(1)/usr/sbin
+	$(INSTALL_BIN) ./uboot-envtools/files/fw_loadenv $(1)/usr/sbin
+	$(INSTALL_DIR) $(1)/etc/board.d
+	$(INSTALL_DATA) ./uboot-envtools/files/fw_defaults $(1)/etc/board.d/05_fw_defaults
+	$(INSTALL_DIR) $(1)/lib
+	$(INSTALL_DATA) ./uboot-envtools/files/uboot-envtools.sh $(1)/lib
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(if $(wildcard ./uboot-envtools/files/$(BOARD)_$(SUBTARGET)), \
+		$(INSTALL_DATA) ./uboot-envtools/files/$(BOARD)_$(SUBTARGET) \
+		$(1)/etc/uci-defaults/30_uboot-envtools, \
+		$(if $(wildcard ./uboot-envtools/files/$(BOARD)), \
+			$(INSTALL_DATA) ./uboot-envtools/files/$(BOARD) \
+			$(1)/etc/uci-defaults/30_uboot-envtools \
+		) \
+	)
+endef
 
-
+$(eval $(call BuildPackage,dumpimage))
+$(eval $(call BuildPackage,uboot-envtools))

--- a/package/boot/uboot-tools/dumpimage/patches/0001-dumpimage-tools-disable-kwbimage.patch
+++ b/package/boot/uboot-tools/dumpimage/patches/0001-dumpimage-tools-disable-kwbimage.patch
@@ -1,0 +1,32 @@
+diff --git a/package/boot/u-boot-tools/patches/0001-tools-disable-kwbimage.patch b/package/boot/u-boot-tools/patches/0001-tools-disable-kwbimage.patch
+new file mode 100644
+index 0000000000..69a42ec383
+--- /dev/null
++++ b/package/boot/u-boot-tools/patches/0001-tools-disable-kwbimage.patch
+@@ -0,0 +1,25 @@
++From: =?UTF-8?q?Rafa=C5=82=20Mi=C5=82ecki?= <rafal at milecki.pl>
++Date: Tue, 30 Nov 2021 11:29:19 +0100
++Subject: [PATCH] tools: disable kwbimage
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++Without CONFIG_TOOLS_LIBCRYPTO kwbimage doesn't compile because of
++multiple "undefined reference"s to SSL functions.
++
++Signed-off-by: Rafał Miłecki <rafal at milecki.pl>
++---
++ tools/Makefile | 1 -
++ 1 file changed, 1 deletion(-)
++
++--- a/tools/Makefile
+++++ b/tools/Makefile
++@@ -117,7 +117,6 @@ dumpimage-mkimage-objs := aisimage.o \
++ 			imximage.o \
++ 			imx8image.o \
++ 			imx8mimage.o \
++-			kwbimage.o \
++ 			lib/md5.o \
++ 			lpc32xximage.o \
++ 			mxsimage.o \
+

--- a/package/boot/uboot-tools/dumpimage/patches/0002-dumpimage-fix-tools-compile.patch
+++ b/package/boot/uboot-tools/dumpimage/patches/0002-dumpimage-fix-tools-compile.patch
@@ -1,0 +1,40 @@
+diff --git a/tools/Makefile b/tools/Makefile
+index ee08a9675d..18ab715f22 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -22,6 +22,26 @@
+ #    That's as long as the features of those tools aren't modified.
+ #
+ 
++override HOSTCC = $(CC)
++
++ifneq ($(TARGET_CFLAGS),)
++KBUILD_HOSTCFLAGS = $(TARGET_CFLAGS)
++endif
++ifneq ($(TARGET_LDFLAGS),)
++KBUILD_HOSTLDFLAGS = $(TARGET_LDFLAGS)
++endif
++
++# Compile for a hosted environment on the target
++HOST_EXTRACFLAGS  = -I$(srctree)/tools \
++		$(patsubst -I%,-idirafter%, $(filter -I%, $(UBOOTINCLUDE))) \
++		-idirafter $(srctree)/tools/env \
++		-DUSE_HOSTCC \
++		-DTEXT_BASE=$(TEXT_BASE)
++
++ifeq ($(MTD_VERSION),old)
++HOST_EXTRACFLAGS += -DMTD_OLD
++endif
++
+ # Enable all the config-independent tools
+ ifneq ($(HOST_TOOLS_ALL),)
+ CONFIG_ARCH_KIRKWOOD = y
+@@ -316,7 +336,7 @@ HOST_EXTRACFLAGS += -include $(srctree)/include/compiler.h \
+ 		-D__KERNEL_STRICT_NAMES \
+ 		-D_GNU_SOURCE
+ 
+-__build:	$(LOGO-y)
++__build:	$(LOGO-n)
+ 
+ $(LOGO_H):	$(obj)/bmp_logo $(LOGO_BMP)
+ 	$(obj)/bmp_logo --gen-info $(LOGO_BMP) > $@

--- a/package/boot/uboot-tools/uboot-envtools/files/apm821xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/apm821xx
@@ -1,0 +1,35 @@
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+meraki,mr24)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x4000" "0x4000" "4"
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x4000" "0x4000" "4"
+	;;
+meraki,mx60)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000" "4"
+	;;
+netgear,wndap620|\
+netgear,wndap660)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x4000" "0x4000" "4"
+	;;
+netgear,wndr4700)
+	ubootenv_add_uci_config "/dev/mtd0" "0x40000" "0x20000" "0x20000" "1"
+	ubootenv_add_uci_config "/dev/mtd0" "0x60000" "0x20000" "0x20000" "1"
+	;;
+wd,mybooklive)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x1000" "1"
+	ubootenv_add_uci_config "/dev/mtd1" "0x1000" "0x1000" "0x1000" "1"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/ath79
+++ b/package/boot/uboot-tools/uboot-envtools/files/ath79
@@ -1,0 +1,187 @@
+#
+# Copyright (C) 2011-2014 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+alcatel,hh40v|\
+alfa-network,ap121f|\
+alfa-network,ap121fe|\
+alfa-network,n2q|\
+alfa-network,n5q|\
+alfa-network,pi-wifi4|\
+alfa-network,r36a|\
+alfa-network,tube-2hq|\
+alfa-network,wifi-camppro-nano-duo|\
+araknis,an-300-ap-i-n|\
+arduino,yun|\
+asus,rt-ac59u|\
+asus,rt-ac59u-v2|\
+asus,zenwifi-cd6n|\
+asus,zenwifi-cd6r|\
+buffalo,bhr-4grv2|\
+buffalo,wzr-450hp2|\
+devolo,magic-2-wifi|\
+engenius,eap300-v2|\
+engenius,eap350-v1|\
+engenius,eap600|\
+engenius,ecb1200|\
+engenius,ecb1750|\
+engenius,ecb350-v1|\
+engenius,ecb600|\
+engenius,enh202-v1|\
+engenius,ens202ext-v1|\
+etactica,eg200|\
+glinet,gl-ar750s-nor|\
+glinet,gl-ar750s-nor-nand|\
+librerouter,librerouter-v1|\
+moxa,awk-1137c|\
+netgear,ex7300|\
+netgear,ex7300-v2|\
+netgear,wndr4300-v2|\
+netgear,wndr4500-v3|\
+netgear,wnr1000-v2|\
+netgear,wnr2000-v3|\
+netgear,wnr2200-8m|\
+netgear,wnr2200-16m|\
+netgear,wnr612-v2|\
+ocedo,koala|\
+ocedo,raccoon|\
+openmesh,a40|\
+openmesh,a60|\
+openmesh,mr600-v1|\
+openmesh,mr600-v2|\
+openmesh,mr900-v1|\
+openmesh,mr900-v2|\
+openmesh,mr1750-v1|\
+openmesh,mr1750-v2|\
+openmesh,om5p|\
+openmesh,om5p-an|\
+openmesh,om5p-ac-v1|\
+openmesh,om5p-ac-v2|\
+samsung,wam250|\
+ubnt,airrouter|\
+ubnt,bullet-m-ar7240|\
+ubnt,bullet-m-ar7241|\
+ubnt,nanobridge-m|\
+ubnt,nanostation-loco-m|\
+ubnt,nanostation-m|\
+ubnt,picostation-m|\
+ubnt,powerbridge-m|\
+ubnt,rocket-m|\
+watchguard,ap100|\
+watchguard,ap200|\
+yuncore,a770|\
+yuncore,a782|\
+yuncore,a930|\
+yuncore,xd3200|\
+yuncore,xd4200|\
+ziking,cpe46b|\
+zyxel,nbg6616)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
+	;;
+aruba,ap-105|\
+aruba,ap-115|\
+aruba,ap-175|\
+belkin,f9j1108-v2|\
+belkin,f9k1115-v2|\
+dongwon,dw02-412h-64m|\
+dongwon,dw02-412h-128m|\
+glinet,gl-ar300m-lite|\
+glinet,gl-ar300m-nand|\
+glinet,gl-ar300m-nor|\
+glinet,gl-ar300m16|\
+glinet,gl-s200-nor|\
+glinet,gl-s200-nor-nand)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"
+	;;
+buffalo,wzr-hp-ag300h)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
+	;;
+buffalo,wzr-hp-g300nh-rb|\
+buffalo,wzr-hp-g300nh-s|\
+linksys,ea4500-v3)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	;;
+dell,apl26-0ae)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x10000"
+	;;
+domywifi,dw33d)
+	ubootenv_add_uci_config "/dev/mtd4" "0x0" "0x10000" "0x10000"
+	;;
+glinet,gl-ar150)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x8000" "0x10000"
+	;;
+huawei,ap5030dn|\
+huawei,ap6010dn)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x20000" "0x20000"
+	;;
+netgear,wndr3700|\
+netgear,wndr3700-v2|\
+netgear,wndrmac-v1)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x10000"
+	;;
+netgear,pgzng1|\
+netgear,wndr3700-v4|\
+netgear,wndr4300|\
+netgear,wndr4300tn|\
+netgear,wndr4300sw)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x20000"
+	;;
+openmesh,om2p-v1|\
+openmesh,om2p-v2|\
+openmesh,om2p-v4|\
+openmesh,om2p-hs-v1|\
+openmesh,om2p-hs-v2|\
+openmesh,om2p-hs-v3|\
+openmesh,om2p-hs-v4|\
+openmesh,om2p-lc|\
+plasmacloud,pa300|\
+plasmacloud,pa300e)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x40000"
+	;;
+qihoo,c301)
+	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x10000" "0x10000"
+	;;
+ruckus,zf7025|\
+ruckus,zf7341|\
+ruckus,zf7351|\
+ruckus,zf7363)
+	ubootenv_add_uci_config "/dev/mtd5" "0x0" "0x40000" "0x40000"
+	;;
+ruckus,zf7321|\
+ruckus,zf7372)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x40000" "0x10000"
+	;;
+sophos,ap15|\
+sophos,ap15c|\
+sophos,ap55|\
+sophos,ap55c|\
+sophos,ap100|\
+sophos,ap100c)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
+	;;
+wallys,dr531)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0xf800" "0x10000"
+	;;
+zte,mf286|\
+zte,mf286a|\
+zte,mf286r)
+	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x20000" "0x10000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/cns3xxx
+++ b/package/boot/uboot-tools/uboot-envtools/files/cns3xxx
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2013 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+laguna)
+	# Laguna uboot env size/erasesize vary depending on NOR vs SPI FLASH
+	size=$(grep mtd1 /proc/mtd | awk '{print $2}')
+	erasesize=$(grep mtd1 /proc/mtd | awk '{print $3}')
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x$size" "0x$erasesize"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/fw_defaults
+++ b/package/boot/uboot-tools/uboot-envtools/files/fw_defaults
@@ -1,0 +1,17 @@
+. /lib/functions/uci-defaults.sh
+
+fw_loadenv
+
+board_config_update
+
+[ -f /var/run/uboot-env/owrt_ssid -a -f /var/run/uboot-env/owrt_wifi_key ] &&
+	ucidef_set_wireless all "$(cat /var/run/uboot-env/owrt_ssid)" sae-mixed "$(cat /var/run/uboot-env/owrt_wifi_key)"
+[ -f /var/run/uboot-env/owrt_country ] && ucidef_set_country "$(cat /var/run/uboot-env/owrt_country)"
+[ -f /var/run/uboot-env/owrt_ssh_auth_key ] && ucidef_set_ssh_authorized_key "$(cat /var/run/uboot-env/owrt_ssh_auth_key)"
+[ -f /var/run/uboot-env/owrt_root_password_plain ] && ucidef_set_root_password_plain "$(cat /var/run/uboot-env/owrt_root_password_plain)"
+[ -f /var/run/uboot-env/owrt_root_password_hash ] && ucidef_set_root_password_hash "$(cat /var/run/uboot-env/owrt_root_password_hash)"
+[ -f /var/run/uboot-env/owrt_timezone ] && ucidef_set_timezone "$(cat /var/run/uboot-env/owrt_timezone)"
+
+board_config_flush
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/fw_loadenv
+++ b/package/boot/uboot-tools/uboot-envtools/files/fw_loadenv
@@ -1,0 +1,26 @@
+#!/usr/bin/ucode
+
+'use strict';
+
+const path = '/var/run/uboot-env/';
+
+import * as fs from 'fs';
+
+if (fs.lsdir(path)) {
+	warn(`env has already been loaded to ${path}\n`);
+	exit(0);
+}
+
+let fp = fs.popen('fw_printenv');
+let raw = fp.read('all');
+fp.close();
+
+if (!length(raw))
+	exit(0);
+
+fs.mkdir(path);
+for (let line in split(raw, '\n')) {
+	let vals = split(line, '=');
+	if (vals[0] && vals[1])
+		fs.writefile(path + vals[0], vals[1]);
+}

--- a/package/boot/uboot-tools/uboot-envtools/files/fw_printsys
+++ b/package/boot/uboot-tools/uboot-envtools/files/fw_printsys
@@ -1,0 +1,2 @@
+#!/bin/sh
+[ -e /etc/fw_sys.config ] && exec /usr/sbin/fw_printenv -c /etc/fw_sys.config "$@"

--- a/package/boot/uboot-tools/uboot-envtools/files/fw_setsys
+++ b/package/boot/uboot-tools/uboot-envtools/files/fw_setsys
@@ -1,0 +1,2 @@
+#!/bin/sh
+[ -e /etc/fw_sys.config ] && exec /usr/sbin/fw_setenv -c /etc/fw_sys.config "$@"

--- a/package/boot/uboot-tools/uboot-envtools/files/imx_cortexa7
+++ b/package/boot/uboot-tools/uboot-envtools/files/imx_cortexa7
@@ -1,0 +1,19 @@
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+technexion,imx7d-pico-pi)
+	ubootenv_add_uci_config "/dev/mmcblk2" "0xc0000" "0x2000" "0x2000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/imx_cortexa9
+++ b/package/boot/uboot-tools/uboot-envtools/files/imx_cortexa9
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2013-2014 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/imx.sh
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+gw,imx6dl-gw51xx|\
+gw,imx6dl-gw52xx|\
+gw,imx6dl-gw53xx|\
+gw,imx6dl-gw54xx|\
+gw,imx6dl-gw551x|\
+gw,imx6dl-gw552x|\
+gw,imx6dl-gw553x|\
+gw,imx6dl-gw5904|\
+gw,imx6dl-gw5907|\
+gw,imx6dl-gw5910|\
+gw,imx6dl-gw5912|\
+gw,imx6dl-gw5913|\
+gw,imx6q-gw51xx|\
+gw,imx6q-gw52xx|\
+gw,imx6q-gw53xx|\
+gw,imx6q-gw5400-a|\
+gw,imx6q-gw54xx|\
+gw,imx6q-gw551x|\
+gw,imx6q-gw552x|\
+gw,imx6q-gw553x|\
+gw,imx6q-gw5904|\
+gw,imx6q-gw5907|\
+gw,imx6q-gw5910|\
+gw,imx6q-gw5912|\
+gw,imx6q-gw5913)
+	if [ -c /dev/mtd1 ]; then
+		# board boots from NAND
+		ubootenv_add_uci_config /dev/mtd1 0x0 0x20000 0x40000
+		ubootenv_add_uci_config /dev/mtd1 0x80000 0x20000 0x40000
+	else
+		# board boots from microSD
+		ubootenv_add_uci_config /dev/mmcblk0 0xb1400 0x20000
+		ubootenv_add_uci_config /dev/mmcblk0 0xd1400 0x20000
+	fi
+	;;
+toradex,apalis_imx6q-eval|\
+toradex,apalis_imx6q-ixora|\
+toradex,apalis_imx6q-ixora-v1.1)
+	ubootenv_add_uci_config $(bootdev_from_uuid)boot0 -0x2200 0x2000 0x200 10
+	;;
+wand,imx6dl-wandboard)
+	ubootenv_add_uci_config "/dev/mmcblk0" "0x60000" "0x2000" "0x2000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/ipq40xx
@@ -1,0 +1,84 @@
+#
+# Copyright (C) 2016 LEDE
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+ubootenv_mtdinfo () {
+	UBOOTENV_PART=$(cat /proc/mtd | grep APPSBLENV)
+	mtd_dev=$(echo $UBOOTENV_PART | awk '{print $1}' | sed 's/:$//')
+	mtd_size=$(echo $UBOOTENV_PART | awk '{print "0x"$2}')
+	mtd_erase=$(echo $UBOOTENV_PART | awk '{print "0x"$3}')
+	nor_flash=$(find /sys/bus/spi/devices/*/mtd -name ${mtd_dev})
+
+	if [ -n "$nor_flash" ]; then
+		ubootenv_size=$mtd_size
+	else
+		# size is fixed to 0x40000 in u-boot
+		ubootenv_size=0x40000
+	fi
+
+	sectors=$(( $ubootenv_size / $mtd_erase ))
+	sectors=$(printf "0x%x" $sectors )
+	echo /dev/$mtd_dev 0x0 $ubootenv_size $mtd_erase $sectors
+}
+
+case "$board" in
+alfa-network,ap120c-ac|\
+devolo,magic-2-wifi-next|\
+edgecore,ecw5211|\
+glinet,gl-a1300 |\
+glinet,gl-ap1300|\
+glinet,gl-b1300|\
+glinet,gl-b2200|\
+luma,wrtq-329acn|\
+netgear,wac510|\
+openmesh,a42|\
+openmesh,a62|\
+pakedge,wr-1|\
+plasmacloud,pa1200|\
+plasmacloud,pa2200)
+	ubootenv_add_uci_config "/dev/mtd5" "0x0" "0x10000" "0x10000"
+	;;
+aruba,ap-303)
+	ubootenv_add_uci_config "/dev/mtd13" "0x0" "0x10000" "0x10000"
+	;;
+aruba,ap-365)
+	ubootenv_add_uci_config "/dev/mtd8" "0x0" "0x10000" "0x10000"
+	;;
+buffalo,wtr-m2133hp|\
+netgear,lbr20)
+	ubootenv_add_uci_config "/dev/mtd8" "0x0" "0x40000" "0x20000"
+	;;
+linksys,ea6350v3)
+	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x20000" "0x20000"
+	;;
+linksys,ea8300|\
+linksys,mr8300)
+	ubootenv_add_uci_config "/dev/mtd7" "0x0" "0x40000" "0x20000"
+	;;
+linksys,whw01)
+	ubootenv_add_uci_config "/dev/mtd6" "0x0" "0x40000" "0x10000"
+	;;
+linksys,whw03)
+        ubootenv_add_uci_config "/dev/mmcblk0p11" "0x0" "0x100000"
+        ;;
+linksys,whw03v2)
+	ubootenv_add_uci_config "/dev/mtd6" "0x0" "0x80000" "0x20000"
+	;;
+zyxel,nbg6617)
+	ubootenv_add_uci_config "/dev/mtd6" "0x0" "0x10000" "0x10000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/ipq806x
+++ b/package/boot/uboot-tools/uboot-envtools/files/ipq806x
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2016 LEDE
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+ubootenv_mtdinfo () {
+	UBOOTENV_PART=$(cat /proc/mtd | grep APPSBLENV)
+	mtd_dev=$(echo $UBOOTENV_PART | awk '{print $1}' | sed 's/:$//')
+	mtd_size=$(echo $UBOOTENV_PART | awk '{print "0x"$2}')
+	mtd_erase=$(echo $UBOOTENV_PART | awk '{print "0x"$3}')
+	nor_flash=$(find /sys/bus/spi/devices/*/mtd -name ${mtd_dev})
+
+	if [ -n "$nor_flash" ]; then
+		ubootenv_size=$mtd_size
+	else
+		# size is fixed to 0x40000 in u-boot
+		ubootenv_size=0x40000
+	fi
+
+	sectors=$(( $ubootenv_size / $mtd_erase ))
+	sectors=$(printf "0x%x" $sectors )
+	echo /dev/$mtd_dev 0x0 $ubootenv_size $mtd_erase $sectors
+}
+
+case "$board" in
+arris,tr4400-v2|\
+askey,rt4230w-rev6)
+	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x40000" "0x20000"
+	;;
+edgecore,ecw5410)
+	ubootenv_add_uci_config "/dev/mtd11" "0x0" "0x10000" "0x10000"
+	;;
+extreme,ap3935)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
+	;;
+linksys,ea7500-v1|\
+linksys,ea8500)
+	ubootenv_add_uci_config "/dev/mtd10" "0x0" "0x20000" "0x20000"
+	;;
+netgear,r7800)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x040000" "0x20000"
+	;;
+nokia,ac400i)
+	ubootenv_add_uci_config "/dev/mtd20" "0x0" "0x040000" "0x20000"
+	;;
+qcom,ipq8064-ap148|\
+qcom,ipq8064-db149)
+	ubootenv_add_uci_config $(ubootenv_mtdinfo)
+	;;
+ubnt,unifi-ac-hd|\
+zyxel,nbg6817)
+	ubootenv_add_uci_config "/dev/mtdblock9" "0x0" "0x10000" "0x10000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/kirkwood
+++ b/package/boot/uboot-tools/uboot-envtools/files/kirkwood
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2012-2014 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+checkpoint,l-50|\
+cloudengines,pogoe02|\
+cloudengines,pogoplugv4|\
+dlink,dns320l|\
+globalscale,sheevaplug|\
+iom,ix2-200|\
+iom,ix4-200d|\
+linksys,e4200-v2|\
+linksys,ea4500|\
+netgear,readynas-duo-v2|\
+raidsonic,ib-nas62x0|\
+seagate,dockstar|\
+zyxel,nsa310b|\
+zyxel,nsa310s|\
+zyxel,nsa325)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	;;
+linksys,ea3500)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x4000" "0x4000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/lantiq
+++ b/package/boot/uboot-tools/uboot-envtools/files/lantiq
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2012 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+bt,homehub-v2b)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000" "1"
+	;;
+bt,homehub-v3a)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x4000" "0x4000" "1"
+	;;
+siemens,gigaset-sx76x)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000" "1"
+	;;
+zyxel,p-2812hnu-f1)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x2000" "0x20000" "1"
+	;;
+buffalo,wbmr-300hpd)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x2000" "0x1000" "2"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/layerscape
+++ b/package/boot/uboot-tools/uboot-envtools/files/layerscape
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2016 LEDE
+#
+
+[ -f /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+	traverse,ten64)
+		ubootenv_add_uci_config "/dev/mtd3" "0x0000" "0x80000" "0x80000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -1,0 +1,150 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+ubootenv_add_mmc_default() {
+	local envdev="$(find_mmc_part "ubootenv" "${1:-mmcblk0}")"
+	ubootenv_add_uci_config "$envdev" "0x0" "0x40000" "0x40000" "1"
+	ubootenv_add_uci_config "$envdev" "0x40000" "0x40000" "0x40000" "1"
+}
+
+ubootenv_add_nor_default() {
+	local envdev="/dev/mtd$(find_mtd_index "u-boot-env")"
+	ubootenv_add_uci_config "$envdev" "0x0" "0x20000" "0x20000" "1"
+	ubootenv_add_uci_config "$envdev" "0x20000" "0x20000" "0x20000" "1"
+}
+
+ubootenv_add_ubi_default() {
+	. /lib/upgrade/nand.sh
+	local envubi=$(nand_find_ubi ubi)
+	local envdev=/dev/$(nand_find_volume $envubi ubootenv)
+	local envdev2=/dev/$(nand_find_volume $envubi ubootenv2)
+	ubootenv_add_uci_config "$envdev" "0x0" "0x1f000" "0x1f000" "1"
+	ubootenv_add_uci_config "$envdev2" "0x0" "0x1f000" "0x1f000" "1"
+}
+
+case "$board" in
+abt,asr3000|\
+h3c,magic-nx30-pro|\
+jcg,q30-pro|\
+mercusys,mr90x-v1-ubi|\
+netcore,n60|\
+nokia,ea0326gmp|\
+qihoo,360t7|\
+routerich,ax3000-ubootmod|\
+tplink,tl-xdr4288|\
+tplink,tl-xdr6086|\
+tplink,tl-xdr6088|\
+tplink,tl-xtr8488|\
+xiaomi,mi-router-ax3000t-ubootmod|\
+xiaomi,mi-router-wr30u-ubootmod|\
+xiaomi,redmi-router-ax6000-ubootmod|\
+zyxel,ex5601-t0-ubootmod)
+	ubootenv_add_ubi_default
+	;;
+acer,predator-w6|\
+acer,predator-w6d|\
+acer,vero-w6m|\
+glinet,gl-mt2500|\
+glinet,gl-mt6000|\
+glinet,gl-x3000|\
+glinet,gl-xe3000|\
+nradio,c8-668gl)
+	local envdev=$(find_mmc_part "u-boot-env")
+	ubootenv_add_uci_config "$envdev" "0x0" "0x80000"
+	;;
+asus,rt-ax59u)
+	ubootenv_add_uci_config "/dev/mtd0" "0x100000" "0x20000" "0x20000"
+	;;
+bananapi,bpi-r3|\
+bananapi,bpi-r3-mini|\
+bananapi,bpi-r4|\
+bananapi,bpi-r4-poe|\
+cmcc,rax3000m|\
+jdcloud,re-cp-03)
+	. /lib/upgrade/fit.sh
+	export_fitblk_bootdev
+	case "$CI_METHOD" in
+	ubi)
+		ubootenv_add_ubi_default
+		;;
+	emmc)
+		bootdev=${EMMC_KERN_DEV%%p[0-9]*}
+		ubootenv_add_mmc_default "${bootdev#/dev/}"
+		;;
+	default)
+		ubootenv_add_nor_default
+		;;
+	esac
+	;;
+comfast,cf-e393ax)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x80000"
+	;;
+cetron,ct3003|\
+edgecore,eap111|\
+netgear,wax220|\
+zbtlink,zbt-z8102ax|\
+zbtlink,zbt-z8103ax)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	;;
+dlink,aquila-pro-ai-m30-a1|\
+dlink,aquila-pro-ai-m60-a1)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x40000"
+	;;
+gatonetworks,gdsp)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
+	;;
+glinet,gl-mt3000)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x20000"
+	;;
+mercusys,mr90x-v1|\
+routerich,ax3000|\
+tenbay,wr3000k|\
+tplink,re6000xd)
+	local envdev=/dev/mtd$(find_mtd_index "u-boot-env")
+	ubootenv_add_uci_config "$envdev" "0x0" "0x20000" "0x20000" "1"
+	;;
+openembed,som7981)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x80000"
+	ubootenv_add_uci_sys_config "/dev/mtd3" "0x0" "0x100000" "0x100000"
+	;;
+openwrt,one)
+	ubootenv_add_ubi_default
+	;;
+smartrg,sdg-8733|\
+smartrg,sdg-8733a|\
+smartrg,sdg-8734)
+	local envdev=$(find_mmc_part "u-boot-env" "mmcblk0")
+	ubootenv_add_uci_config "$envdev" "0x0" "0x8000" "0x8000"
+	;;
+ubnt,unifi-6-plus)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x10000"
+	;;
+xiaomi,mi-router-ax3000t|\
+xiaomi,mi-router-wr30u-stock|\
+xiaomi,redmi-router-ax6000-stock)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x20000"
+	ubootenv_add_uci_sys_config "/dev/mtd2" "0x0" "0x10000" "0x20000"
+	;;
+zyxel,ex5601-t0)
+	local envdev=/dev/mtd$(find_mtd_index "u-boot-env")
+	ubootenv_add_uci_config "$envdev" "0x0" "0x20000" "0x40000" "2"
+	;;
+zyxel,ex5700-telenor)
+	ubootenv_add_uci_config "/dev/ubootenv" "0x0" "0x4000" "0x4000" "1"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7622
@@ -1,0 +1,72 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+ubootenv_add_mmc_default() {
+	local envdev="$(find_mmc_part "ubootenv" "${1:-mmcblk0}")"
+	ubootenv_add_uci_config "$envdev" "0x0" "0x80000" "0x80000" "1"
+	ubootenv_add_uci_config "$envdev" "0x80000" "0x80000" "0x80000" "1"
+}
+
+ubootenv_add_ubi_default() {
+	. /lib/upgrade/nand.sh
+	local envubi=$(nand_find_ubi ubi)
+	local envdev=/dev/$(nand_find_volume $envubi ubootenv)
+	local envdev2=/dev/$(nand_find_volume $envubi ubootenv2)
+	ubootenv_add_uci_config "$envdev" "0x0" "0x1f000" "0x1f000" "1"
+	ubootenv_add_uci_config "$envdev2" "0x0" "0x1f000" "0x1f000" "1"
+}
+
+board=$(board_name)
+
+case "$board" in
+dlink,eagle-pro-ai-m32-a1|\
+dlink,eagle-pro-ai-r32-a1)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x2000" "0x2000"
+	;;
+bananapi,bpi-r64|\
+linksys,e8450-ubi)
+	. /lib/upgrade/fit.sh
+	export_fitblk_bootdev
+	case "$CI_METHOD" in
+	emmc)
+		bootdev=${EMMC_KERN_DEV%%p[0-9]*}
+		ubootenv_add_mmc_default "${bootdev#/dev/}"
+		;;
+	ubi)
+		ubootenv_add_ubi_default
+		;;
+	esac
+	;;
+buffalo,wsr-2533dhp2)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x1000" "0x20000"
+	;;
+ruijie,rg-ew3200gx-pro)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x20000" "0x20000"
+	;;
+ubnt,unifi-6-lr-v1-ubootmod|\
+ubnt,unifi-6-lr-v2-ubootmod|\
+ubnt,unifi-6-lr-v3-ubootmod)
+	ubootenv_add_uci_config "/dev/mtd$(find_mtd_index "u-boot-env")" "0x0" "0x4000" "0x1000"
+	;;
+ubnt,unifi-6-lr-v2|\
+ubnt,unifi-6-lr-v3)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x1000" "0x1000" "1"
+	;;
+xiaomi,redmi-router-ax6s)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x40000"
+	ubootenv_add_uci_sys_config "/dev/mtd4" "0x0" "0x10000" "0x40000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7623
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7623
@@ -1,0 +1,28 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+bananapi,bpi-r2)
+	. /lib/upgrade/common.sh
+	bootdev="$(fitblk_get_bootdev)"
+	ubootenv_add_uci_config "/dev/${bootdev%p[0-9]*}p1" "0xb0000" "0x10000" "0x10000" "1"
+	;;
+unielec,u7623-02)
+	ubootenv_add_uci_config "/dev/mmcblk0p1" "0xc0000" "0x10000" "0x10000" "1"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7629
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7629
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2021 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+iptime,a6004mx|\
+netgear,ex6250-v2)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000"
+	;;
+linksys,ea7500-v3)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/mpc85xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/mpc85xx
@@ -1,0 +1,34 @@
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+enterasys,ws-ap3715i)
+	ubootenv_add_uci_config "$(find_mtd_part 'cfg1')" "0x0" "0x10000" "0x10000"
+	ubootenv_add_uci_config "$(find_mtd_part 'cfg2')" "0x0" "0x10000" "0x10000"
+	;;
+extreme-networks,ws-ap3825i)
+	ubootenv_add_uci_config "$(find_mtd_part 'cfg1')" "0x0" "0x10000" "0x20000"
+	ubootenv_add_uci_config "$(find_mtd_part 'cfg2')" "0x0" "0x10000" "0x20000"
+	;;
+ocedo,panda)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x20000" "0x20000"
+	;;
+watchguard,firebox-t10)
+	ubootenv_add_uci_config "$(find_mtd_part 'u-boot-env')" "0x0" "0x2000" "0x10000"
+	;;
+aerohive,hiveap-330)
+	ubootenv_add_uci_config "$(find_mtd_part 'u-boot-env')" "0x0" "0x20000" "0x10000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/mvebu
+++ b/package/boot/uboot-tools/uboot-envtools/files/mvebu
@@ -1,0 +1,80 @@
+#
+# Copyright (C) 2014-2016 OpenWrt.org
+# Copyright (C) 2016 LEDE-Project.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+buffalo,ls220de|\
+buffalo,ls421de)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000"
+	;;
+cznic,turris-omnia)
+	idx="$(find_mtd_index u-boot-env)"
+	if [ -n "$idx" ]; then
+		ubootenv_add_uci_config "/dev/mtd${idx}" "0x0" "0x10000" "0x10000"
+	elif grep -q 'U-Boot 2015.10-rc2' /dev/mtd0; then
+		ubootenv_add_uci_config "/dev/mtd0" "0xc0000" "0x10000" "0x40000"
+	else
+		ubootenv_add_uci_config "/dev/mtd0" "0xf0000" "0x10000" "0x10000"
+	fi
+	;;
+glinet,gl-mv1000)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x8000" "0x8000" "1"
+	;;
+globalscale,espressobin|\
+globalscale,espressobin-emmc|\
+globalscale,espressobin-ultra|\
+globalscale,espressobin-v7|\
+globalscale,espressobin-v7-emmc|\
+globalscale,mochabin)
+	idx="$(find_mtd_index u-boot-env)"
+	if [ -n "$idx" ]; then
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000" "1"
+	else
+		ubootenv_add_uci_config "/dev/mtd0" "0x3f0000" "0x10000" "0x10000" "1"
+	fi
+	;;
+marvell,armada8040-mcbin-doubleshot|\
+marvell,armada8040-mcbin-singleshot)
+	ubootenv_add_uci_config "/dev/mtd0" "0x3f0000" "0x10000" "0x10000" "1"
+	;;
+linksys,wrt1200ac|\
+linksys,wrt1900ac-v2|\
+linksys,wrt1900acs)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x40000"
+	;;
+linksys,wrt1900ac-v1)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x20000"
+	;;
+linksys,wrt3200acm|\
+linksys,wrt32x)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	;;
+methode,udpu|\
+methode,edpu)
+	idx="$(find_mtd_index u-boot-env)"
+	if [ -n "$idx" ]; then
+	ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000" "1"
+	else
+	ubootenv_add_uci_config "/dev/mtd0" "0x180000" "0x10000" "0x10000"
+	fi
+	;;
+synology,ds213j)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/mxs
+++ b/package/boot/uboot-tools/uboot-envtools/files/mxs
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2013 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+i2se,duckbill)
+	ubootenv_add_uci_config "/dev/mmcblk0" "0x20000" "0x20000"
+	ubootenv_add_uci_config "/dev/mmcblk0" "0x40000" "0x20000"
+	;;
+olimex,imx23-olinuxino)
+	ubootenv_add_uci_config "/dev/mmcblk0" "0x40000" "0x4000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/octeon
+++ b/package/boot/uboot-tools/uboot-envtools/files/octeon
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2023 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+cisco,vedge1000)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/oxnas
+++ b/package/boot/uboot-tools/uboot-envtools/files/oxnas
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2013 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+"cloudengines,pogoplug"*|\
+"shuttle,kd20")
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x2000" "0x20000" "1"
+	;;
+"mitrastar,stg-212")
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x20000" "0x20000" "1"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/pistachio
+++ b/package/boot/uboot-tools/uboot-envtools/files/pistachio
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+img,pistachio-marduk)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x2000" "0x1000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/qoriq
+++ b/package/boot/uboot-tools/uboot-envtools/files/qoriq
@@ -1,0 +1,19 @@
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+watchguard,firebox-m300)
+	ubootenv_add_uci_config "/dev/mtd9" "0x0" "0x2000" "0x10000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
@@ -1,0 +1,27 @@
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+glinet,gl-b3000)
+	idx="$(find_mtd_index 0:APPSBLENV)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000"
+	;;
+linksys,mx2000|\
+linksys,mx5500)
+	idx="$(find_mtd_index u_env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
@@ -1,0 +1,37 @@
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+ubootenv_add_mtd() {
+	local idx="$(find_mtd_index "${1}")"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "${2}" "${3}" "${4}"
+}
+
+case "$board" in
+8devices,mango-dvk|\
+8devices,mango-dvk-sfp|\
+cambiumnetworks,xe3-4)
+	ubootenv_add_mtd "0:APPSBLENV" "0x0" "0x10000" "0x10000"
+	;;
+linksys,mr7350)
+	ubootenv_add_mtd "u_env" "0x0" "0x40000" "0x20000"
+	;;
+netgear,wax214|\
+tplink,eap610-outdoor)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
+	;;
+yuncore,fap650)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x10000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
@@ -1,0 +1,81 @@
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+ubootenv_add_mtd() {
+	local idx="$(find_mtd_index "${1}")"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "${2}" "${3}" "${4}"
+}
+
+ubootenv_add_sys_mtd() {
+	local idx="$(find_mtd_index "${1}")"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_sys_config "/dev/mtd$idx" "${2}" "${3}" "${4}"
+}
+
+ubootenv_add_mmc() {
+	local mmcpart="$(find_mmc_part "${1}")"
+	[ -n "$mmcpart" ] && \
+		ubootenv_add_uci_config "$mmcpart" "${2}" "${3}" "${4}" "${5}"
+}
+
+case "$board" in
+dynalink,dl-wrx36|\
+netgear,rax120v2|\
+netgear,sxr80|\
+netgear,sxs80|\
+netgear,wax218|\
+netgear,wax620|\
+netgear,wax630|\
+tplink,eap620hd-v1|\
+tplink,eap660hd-v1)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
+	;;
+compex,wpq873|\
+edgecore,eap102|\
+zyxel,nbg7815)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x10000"
+	;;
+edimax,cax1800)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x20000"
+	;;
+linksys,homewrk)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x40000"
+	;;
+linksys,mx4200v1|\
+linksys,mx4200v2|\
+linksys,mx5300|\
+linksys,mx8500)
+	ubootenv_add_mtd "u_env" "0x0" "0x40000" "0x20000"
+	;;
+linksys,mx4300)
+	ubootenv_add_mtd "u_env" "0x0" "0x40000" "0x40000"
+	;;
+redmi,ax6|\
+xiaomi,ax3600|\
+xiaomi,ax9000)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x20000"
+	ubootenv_add_sys_mtd "bdata" "0x0" "0x10000" "0x20000"
+	;;
+prpl,haze)
+	ubootenv_add_mmc "0:APPSBLENV" "0x0" "0x40000" "0x400" "0x100"
+	;;
+asus,rt-ax89x|\
+qnap,301w)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x20000" "0x20000"
+	;;
+spectrum,sax1v1k)
+	ubootenv_add_mmc "0:APPSBLENV" "0x0" "0x40000" "0x40000" "1"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -1,0 +1,164 @@
+#
+# Copyright (C) 2011-2012 OpenWrt.org
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+alfa-network,ac1200rm|\
+alfa-network,awusfree1|\
+alfa-network,quad-e4g|\
+alfa-network,r36m-e4g|\
+alfa-network,tube-e4g|\
+engenius,epg600|\
+engenius,esr600h|\
+linksys,re7000|\
+meig,slt866|\
+sitecom,wlr-4100-v1-002|\
+zyxel,keenetic-lite-iii-a)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x1000"
+	;;
+alfa-network,ax1800rm|\
+allnet,all0256n-4m|\
+allnet,all0256n-8m|\
+allnet,all5002|\
+yuncore,ax820)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
+	;;
+arcadyan,we420223-99|\
+dlink,dir-806a-b1)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x1000" "0x1000"
+	;;
+ampedwireless,ally-00x19k|\
+ampedwireless,ally-r1900k)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000" "4"
+	;;
+beeline,smartbox-giga|\
+beeline,smartbox-turbo|\
+beeline,smartbox-turbo-plus|\
+etisalat,s3|\
+rostelecom,rt-fe-1a|\
+rostelecom,rt-sf-1)
+	ubootenv_add_uci_config "/dev/mtd0" "0x80000" "0x1000" "0x20000"
+	;;
+beeline,smartbox-pro|\
+tplink,ec330-g5u-v1|\
+wifire,s1500-nbn)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x20000"
+	;;
+buffalo,wsr-1166dhp|\
+buffalo,wsr-600dhp|\
+kroks,kndrt31r16|\
+kroks,kndrt31r19|\
+mediatek,linkit-smart-7688|\
+samknows,whitebox-v8|\
+xiaomi,mi-router-4c|\
+xiaomi,miwifi-nano|\
+zbtlink,zbt-wg2626|\
+zte,mf283plus)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
+	;;
+asus,rt-ax53u|\
+asus,rt-ax54|\
+asus,4g-ax56|\
+belkin,rt1800|\
+elecom,wrc-x1800gs|\
+h3c,tx1800-plus|\
+h3c,tx1801-plus|\
+h3c,tx1806|\
+iptime,ax2004m|\
+jcg,q20|\
+linksys,e7350|\
+netgear,eax12|\
+netgear,wax202|\
+netis,n6|\
+zyxel,wsm20)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	;;
+haier,har-20s2u1|\
+sim,simax1800t)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	ubootenv_add_uci_sys_config "/dev/mtd1" "0x40000" "0x40000" "0x20000"
+	;;
+hootoo,ht-tm05|\
+ravpower,rp-wd03)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x4000" "0x1000" "0x1000"
+	;;
+beeline,smartbox-flash|\
+iptime,t5004|\
+linksys,ea6350-v4|\
+linksys,ea7300-v1|\
+linksys,ea7300-v2|\
+linksys,ea7500-v2|\
+linksys,ea8100-v1|\
+linksys,ea8100-v2|\
+mts,wg430223|\
+ubnt,edgerouter-x|\
+ubnt,edgerouter-x-sfp)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
+	;;
+snr,snr-cpe-me1|\
+snr,snr-cpe-me2-sfp|\
+snr,cpe-w4n-mt)
+	idx="$(find_mtd_index uboot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x1000"
+	;;
+xiaomi,miwifi-mini)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
+	ubootenv_add_uci_sys_config "/dev/mtd9" "0x0" "0x4000" "0x10000"
+	;;
+xiaomi,mi-router-3g-v2|\
+xiaomi,mi-router-4a-gigabit|\
+xiaomi,miwifi-3c)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
+	ubootenv_add_uci_sys_config "/dev/mtd2" "0x0" "0x4000" "0x10000"
+	;;
+xiaomi,mi-router-3g|\
+xiaomi,mi-router-3-pro|\
+xiaomi,mi-router-4|\
+xiaomi,mi-router-ac2100|\
+xiaomi,redmi-router-ac2100)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
+	ubootenv_add_uci_sys_config "/dev/mtd2" "0x0" "0x4000" "0x20000"
+	;;
+zyxel,lte3301-plus)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x80000"
+	;;
+zyxel,lte5398-m904|\
+zyxel,nr7101)
+	idx="$(find_mtd_index Config)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x1000" "0x80000"
+	;;
+bolt,arion|\
+xiaomi,mi-router-cr6606|\
+xiaomi,mi-router-cr6608|\
+xiaomi,mi-router-cr6609)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x20000"
+	;;
+dna,valokuitu-plus-ex400)
+	ubootenv_add_uci_config "/dev/ubi0_0" "0x0" "0x1f000" "0x1f000" "1"
+	ubootenv_add_uci_config "/dev/ubi0_1" "0x0" "0x1f000" "0x1f000" "1"
+	;;
+netgear,wax214v2)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	ubootenv_add_uci_sys_config "/dev/mtd1" "0x20000" "0x8000" "0x20000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/realtek
+++ b/package/boot/uboot-tools/uboot-envtools/files/realtek
@@ -1,0 +1,69 @@
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+apresia,aplgs120gtss)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x10000"
+	idx2="$(find_mtd_index u-boot-env2)"
+	[ -n "$idx2" ] && \
+		ubootenv_add_uci_sys_config "/dev/mtd$idx2" "0x0" "0x40000" "0x10000"
+	;;
+d-link,dgs-1210-10mp|\
+d-link,dgs-1210-10p|\
+d-link,dgs-1210-16|\
+d-link,dgs-1210-20|\
+d-link,dgs-1210-28|\
+zyxel,gs1900-8|\
+zyxel,gs1900-8hp-v1|\
+zyxel,gs1900-8hp-v2|\
+zyxel,gs1900-10hp|\
+zyxel,gs1900-16|\
+zyxel,gs1900-24-v1|\
+zyxel,gs1900-24e|\
+zyxel,gs1900-24ep|\
+zyxel,gs1900-24hp-v1|\
+zyxel,gs1900-24hp-v2)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x400" "0x10000"
+	idx2="$(find_mtd_index u-boot-env2)"
+	[ -n "$idx2" ] && \
+		ubootenv_add_uci_sys_config "/dev/mtd$idx2" "0x0" "0x1000" "0x10000"
+	;;
+tplink,sg2008p-v1|\
+tplink,sg2210p-v3|\
+tplink,sg2452p-v4)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x20000" "0x10000"
+	;;
+iodata,bsh-g24mb)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"
+	idx2="$(find_mtd_index u-boot-env2)"
+	[ -n "$idx2" ] && \
+		ubootenv_add_uci_sys_config "/dev/mtd$idx2" "0x0" "0x3800" "0x10000"
+	;;
+*)
+	idx="$(find_mtd_index u-boot-env)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x10000" "0x10000"
+	idx2="$(find_mtd_index u-boot-env2)"
+	[ -n "$idx2" ] && \
+		ubootenv_add_uci_sys_config "/dev/mtd$idx2" "0x0" "0x1000" "0x10000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/rockchip_armv8
+++ b/package/boot/uboot-tools/uboot-envtools/files/rockchip_armv8
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2024 OpenWrt.org
+#
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+xunlong,orangepi-r1-plus|\
+xunlong,orangepi-r1-plus-lts)
+	ubootenv_add_uci_config "/dev/mmcblk0" "0x3f8000" "0x8000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config
+
+exit 0

--- a/package/boot/uboot-tools/uboot-envtools/files/uboot-envtools.sh
+++ b/package/boot/uboot-tools/uboot-envtools/files/uboot-envtools.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+#
+# Copyright (C) 2011-2012 OpenWrt.org
+#
+
+_ubootenv_add_uci_config() {
+	local cfgtype=$1
+	local dev=$2
+	local offset=$3
+	local envsize=$4
+	local secsize=$5
+	local numsec=$6
+	uci batch <<EOF
+add ubootenv $cfgtype
+set ubootenv.@$cfgtype[-1].dev='$dev'
+set ubootenv.@$cfgtype[-1].offset='$offset'
+set ubootenv.@$cfgtype[-1].envsize='$envsize'
+set ubootenv.@$cfgtype[-1].secsize='$secsize'
+set ubootenv.@$cfgtype[-1].numsec='$numsec'
+EOF
+	uci commit ubootenv
+}
+
+ubootenv_add_uci_config() {
+	_ubootenv_add_uci_config "ubootenv" "$@"
+}
+
+ubootenv_add_uci_sys_config() {
+	_ubootenv_add_uci_config "ubootsys" "$@"
+}
+
+ubootenv_add_app_config() {
+	local cfgtype
+	local dev
+	local offset
+	local envsize
+	local secsize
+	local numsec
+	config_get cfgtype "$1" TYPE
+	config_get dev "$1" dev
+	config_get offset "$1" offset
+	config_get envsize "$1" envsize
+	config_get secsize "$1" secsize
+	config_get numsec "$1" numsec
+	grep -q "^[[:space:]]*${dev}[[:space:]]*${offset}" "/etc/fw_${cfgtype#uboot}.config" || echo "$dev $offset $envsize $secsize $numsec" >>"/etc/fw_${cfgtype#uboot}.config"
+}

--- a/package/boot/uboot-tools/uboot-envtools/patches/001-envtools-compile.patch
+++ b/package/boot/uboot-tools/uboot-envtools/patches/001-envtools-compile.patch
@@ -1,0 +1,16 @@
+--- a/tools/env/Makefile
++++ b/tools/env/Makefile
+@@ -8,6 +8,13 @@
+ # with "CC" here for the maximum code reuse of scripts/Makefile.host.
+ override HOSTCC = $(CC)
+ 
++ifneq ($(TARGET_CFLAGS),)
++KBUILD_HOSTCFLAGS = $(TARGET_CFLAGS)
++endif
++ifneq ($(TARGET_LDFLAGS),)
++KBUILD_HOSTLDFLAGS = $(TARGET_LDFLAGS)
++endif
++
+ # Compile for a hosted environment on the target
+ HOST_EXTRACFLAGS  = -I$(srctree)/tools \
+ 		$(patsubst -I%,-idirafter%, $(filter -I%, $(UBOOTINCLUDE))) \

--- a/package/boot/uboot-tools/uboot-envtools/patches/002-envtools-Revert-tools-env-use-run-to-store-lockfile.patch
+++ b/package/boot/uboot-tools/uboot-envtools/patches/002-envtools-Revert-tools-env-use-run-to-store-lockfile.patch
@@ -1,0 +1,41 @@
+Revert "tools: env: use /run to store lockfile"
+
+In OpenWRT we still use /var/lock as default location for lock files and
+/run might not even exist. Revert the upstream change and restore the
+previous default path.
+
+This reverts upstream commit
+ https://source.denx.de/u-boot/u-boot/-/commit/aeb40f1166e072856f865d26d42a4bea1ec3a514
+---
+ tools/env/fw_env_main.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/tools/env/fw_env_main.c
++++ b/tools/env/fw_env_main.c
+@@ -73,7 +73,7 @@ void usage_printenv(void)
+ 		" -c, --config         configuration file, default:" CONFIG_FILE "\n"
+ #endif
+ 		" -n, --noheader       do not repeat variable name in output\n"
+-		" -l, --lock           lock node, default:/run\n"
++		" -l, --lock           lock node, default:/var/lock\n"
+ 		"\n");
+ }
+ 
+@@ -88,7 +88,7 @@ void usage_env_set(void)
+ #ifdef CONFIG_FILE
+ 		" -c, --config         configuration file, default:" CONFIG_FILE "\n"
+ #endif
+-		" -l, --lock           lock node, default:/run\n"
++		" -l, --lock           lock node, default:/var/lock\n"
+ 		" -s, --script         batch mode to minimize writes\n"
+ 		"\n"
+ 		"Examples:\n"
+@@ -206,7 +206,7 @@ int parse_setenv_args(int argc, char *ar
+ 
+ int main(int argc, char *argv[])
+ {
+-	char *lockname = "/run/" CMD_PRINTENV ".lock";
++	char *lockname = "/var/lock/" CMD_PRINTENV ".lock";
+ 	int lockfd = -1;
+ 	int retval = EXIT_SUCCESS;
+ 	char *_cmdname;


### PR DESCRIPTION
the uboot-tools package contians various tools for working with uboot images. With the addition of the new dumpimage package, it no longer makes sense to have multi specific packages for each set of tools. Instead lets create a new uboot-tools package with configurable options to build the tools individually.

A breakdown of the scheduled items as part of a 3 part commit

    part 1 - a basic makefile for the uboot-tools package

    part 2 - merge existing uboot-envtools, as a generalized sub-package, with new uboot-tools package

    part 3 - add new dumpimage, generalized sub package, to uboot-tools package

** add new uboot-tools package pt 3 of 3 **

  *  add new generalized dumpimage sub-package to new uboot-tools package