### PR TITLE
[24.10] ramips: Fix Hongdian H8922 v30 pinctrl default state

### DIFF
--- a/target/linux/ramips/dts/mt7620a_hongdian_h8922-v30.dts
+++ b/target/linux/ramips/dts/mt7620a_hongdian_h8922-v30.dts
@@ -145,7 +145,7 @@
 
 &state_default {
 	gpio {
-		groups = "wled", "rgmii1", "rgmii2";
+		groups = "uartf", "wled", "rgmii1", "rgmii2";
 		function = "gpio";
 	};
 };


### PR DESCRIPTION
Backported from #18278

---

According to the MT7620A hardware datasheet, GPIO/14 was originally used for RIN of UARTF, but is now used as the WPS LED.

Corrected pinctrl to ensure it works properly in the future.
