### PR TITLE
Fix build problems on non-FHS systems

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -315,11 +315,11 @@ PATCH:=patch
 PYTHON:=python3
 
 ifeq ($(HOST_OS),Darwin)
-  TRUE:=/usr/bin/env gtrue
-  FALSE:=/usr/bin/env gfalse
+  TRUE:=gtrue
+  FALSE:=gfalse
 else
-  TRUE:=/usr/bin/env true
-  FALSE:=/usr/bin/env false
+  TRUE:=true
+  FALSE:=false
 endif
 
 INSTALL_BIN:=install -m0755


### PR DESCRIPTION
Remove `/usr/bin/env` from Makefiles where it causes build failures on systems that have `true` & `false` but lack `/usr/bin/env` with that exact filepath.

Affected systems include:
* systems with alternative filesystem layouts (not FHS compliant), that typically simply lack `/usr` entirely; this includes Android, which has `/system/bin` rather than `/bin` + `/usr/bin`.
*  intentionally minimalist containers that don't have `env` by default, such as NixOS build containers.

(All commands in a Makefile are handled by a shell, which means that they're subject to normal `PATH` search. The point of inserting `/usr/bin/env` is to facilitate `PATH` search but in this case that's a pointless duplication of effort.)