### PR TITLE
treewide: dts: trim "#size-cells" from "gpio-export" node

### DIFF
--- a/target/linux/ath79/dts/ar7241_tplink_tl-mr3x20.dtsi
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-mr3x20.dtsi
@@ -5,7 +5,6 @@
 / {
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		gpio_usb_power {
 			gpio-export,name = "tp-link:power:usb";

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
@@ -50,7 +50,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		gpio_usb_power {
 			gpio-export,name = "buffalo:usb-power";

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
@@ -106,7 +106,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		gpio_usb_power {
 			gpio-export,name = "buffalo:usb-power";

--- a/target/linux/ath79/dts/ar9331_hak5_wifi-pineapple-nano.dts
+++ b/target/linux/ath79/dts/ar9331_hak5_wifi-pineapple-nano.dts
@@ -18,7 +18,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		microsd-detect {
 			gpio-export,name = "microsd-detect";

--- a/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
+++ b/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
@@ -19,7 +19,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		watchdog-enable {
 			gpio-export,name = "watchdog-enable";

--- a/target/linux/ath79/dts/ar9344_netgear_r6100.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_r6100.dts
@@ -20,7 +20,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb-power {
 			gpio-export,name = "usb-power";

--- a/target/linux/ath79/dts/qca9531_alfa-network_n2q.dts
+++ b/target/linux/ath79/dts/qca9531_alfa-network_n2q.dts
@@ -16,7 +16,6 @@
 
 	gpio-export-pcf8574 {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		poe-passthrough {
 			gpio-export,name = "poe-passthrough";

--- a/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
+++ b/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
@@ -12,7 +12,6 @@
 
 	gpio_export: gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		watchdog-enable {
 			gpio-export,name = "watchdog-enable";

--- a/target/linux/ath79/dts/qca9558_belkin_f9x-v2.dtsi
+++ b/target/linux/ath79/dts/qca9558_belkin_f9x-v2.dtsi
@@ -52,7 +52,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb2_power {
 			gpio-export,name = "usb2:power";

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
@@ -87,7 +87,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		gpio_pa_dcdc {
 			gpio-export,name = "om5pac:pa_dcdc";

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
@@ -66,7 +66,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		gpio_usb_power {
 			gpio-export,name = "tp-link:power:usb";

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
@@ -14,7 +14,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		gpio_usb_power {
 			gpio-export,name = "tp-link:power:usb";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-magic-2-wifi-next.dts
@@ -22,7 +22,6 @@
 	soc {
 		gpio_export {
 			compatible = "gpio-export";
-			#size-cells = <0>;
 
 			plc {
 				gpio-export,name = "plc-enable";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287_common.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287_common.dtsi
@@ -38,7 +38,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		gpio_modem_reset: modem {
 			gpio-export,name = "modem-reset";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx10.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx10.dts
@@ -25,7 +25,6 @@
 
 		gpio_export {
 			compatible = "gpio-export";
-			#size-cells = <0>;
 
 			gpio_out {
 				gpio-export,name = "gpio_out";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx50.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx50.dts
@@ -19,7 +19,6 @@
 	soc {
 		gpio-export {
 			compatible = "gpio-export";
-			#size-cells = <0>;
 
 			gpio_modem_reset {
 				gpio-export,name = "modem_reset";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
@@ -59,7 +59,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		lte_rst {
 			gpio-export,name = "lte_rst";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
@@ -31,7 +31,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		modem {
 			gpio-export,name = "modem-reset";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
@@ -80,7 +80,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb-power";

--- a/target/linux/kirkwood/files-6.6/arch/arm/boot/dts/marvell/kirkwood-dns320l.dts
+++ b/target/linux/kirkwood/files-6.6/arch/arm/boot/dts/marvell/kirkwood-dns320l.dts
@@ -39,7 +39,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		mcu_power {
 			gpio-export,name = "mcu_power";

--- a/target/linux/kirkwood/patches-6.6/118-dns-320l.patch
+++ b/target/linux/kirkwood/patches-6.6/118-dns-320l.patch
@@ -24,7 +24,7 @@
  	chosen {
  		bootargs = "console=ttyS0,115200n8 earlyprintk";
  		stdout-path = &uart0;
-@@ -79,7 +86,7 @@
+@@ -78,7 +85,7 @@
  			linux,default-trigger = "usbport";
  		};
  

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zte_h201l.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zte_h201l.dts
@@ -89,7 +89,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		switch {
 			gpio-export,name = "switch";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zyxel_p-2601hn.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_zyxel_p-2601hn.dts
@@ -89,7 +89,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		switch {
 			gpio-export,name = "switch";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7519pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7519pw.dts
@@ -110,7 +110,6 @@
 	/* is there another way to "reserve" the GPIO? */
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		switch {
 			gpio-export,name = "switch";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_siemens_gigaset-sx76x.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_siemens_gigaset-sx76x.dts
@@ -28,7 +28,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		switch {
 			gpio-export,name = "switch";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_alphanetworks_asl56026.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_alphanetworks_asl56026.dts
@@ -62,7 +62,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		power_led_blink {
 			gpio-export,name = "power_led_blink";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_netgear_dm200.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_netgear_dm200.dts
@@ -38,7 +38,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		annexa {
 			gpio-export,name = "annexa";

--- a/target/linux/mediatek/dts/mt7981b-cudy-ap3000outdoor-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-ap3000outdoor-v1.dts
@@ -57,7 +57,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		antctrl {
 			/* Not sure if this pin does anything.

--- a/target/linux/mediatek/dts/mt7981b-nradio-c8-668gl.dts
+++ b/target/linux/mediatek/dts/mt7981b-nradio-c8-668gl.dts
@@ -41,7 +41,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		cpepower {
 			gpio-export,name = "cpe-pwr";

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax.dts
@@ -93,7 +93,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		pcie {
 			gpio-export,name = "pcie_power";

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
@@ -427,7 +427,6 @@
 
 	gpio_export {
 			compatible = "gpio-export";
-			#size-cells = <0>;
 
 			usb-pwr {
 				gpio-export,name = "usb_pwr";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx8500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx8500.dts
@@ -29,7 +29,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		bt_pwr {
 			gpio-export,name = "bt_pwr";

--- a/target/linux/ramips/dts/mt7620a_alfa-network_r36m-e4g.dts
+++ b/target/linux/ramips/dts/mt7620a_alfa-network_r36m-e4g.dts
@@ -24,7 +24,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		modem-enable {
 			gpio-export,name = "modem-enable";

--- a/target/linux/ramips/dts/mt7620a_alfa-network_tube-e4g.dts
+++ b/target/linux/ramips/dts/mt7620a_alfa-network_tube-e4g.dts
@@ -24,7 +24,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		modem-enable {
 			gpio-export,name = "modem-enable";

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
@@ -69,7 +69,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
@@ -66,7 +66,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
+++ b/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
@@ -37,7 +37,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usbpower {
 			gpio-export,name = "usbpower";

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
@@ -64,7 +64,7 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
+
 		usb-power {
 			gpio-export,name="usb-power";
 			gpio-export,output=<1>;

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5761.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5761.dts
@@ -39,7 +39,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usbpower {
 			gpio-export,name = "usbpower";

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
@@ -44,7 +44,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usbpower {
 			gpio-export,name = "usbpower";

--- a/target/linux/ramips/dts/mt7620a_hnet_c108.dts
+++ b/target/linux/ramips/dts/mt7620a_hnet_c108.dts
@@ -27,7 +27,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		power_modem {
 			gpio-export,name = "power_modem";

--- a/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
+++ b/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
@@ -56,7 +56,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usbpower {
 			gpio-export,name = "usbpower";

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1s.dts
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1s.dts
@@ -16,7 +16,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb0 {
 			gpio-export,name = "usb0";

--- a/target/linux/ramips/dts/mt7620a_sanlinking_d240.dts
+++ b/target/linux/ramips/dts/mt7620a_sanlinking_d240.dts
@@ -27,7 +27,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		power_mpcie2 {
 			gpio-export,name = "power_mpcie2";

--- a/target/linux/ramips/dts/mt7620a_sercomm_na930.dts
+++ b/target/linux/ramips/dts/mt7620a_sercomm_na930.dts
@@ -105,7 +105,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		telit {
 			gpio-export,name = "telit";

--- a/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
+++ b/target/linux/ramips/dts/mt7620a_sitecom_wlr-4100-v1-002.dts
@@ -62,7 +62,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb-power {
 			gpio-export,name = "usb-power";

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
@@ -97,7 +97,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		power_usb {
 			gpio-export,name = "power_usb1";

--- a/target/linux/ramips/dts/mt7620a_yukai_bocco.dts
+++ b/target/linux/ramips/dts/mt7620a_yukai_bocco.dts
@@ -19,7 +19,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		s1 {
 			gpio-export,name = "rec";

--- a/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
+++ b/target/linux/ramips/dts/mt7620a_zyxel_keenetic-viva.dts
@@ -74,7 +74,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb_power {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c1.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-921-c1.dts
@@ -72,7 +72,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		lte_modem_enable {
 			gpio-export,name = "lte_modem_enable";

--- a/target/linux/ramips/dts/mt7620n_dlink_dwr-922-e2.dts
+++ b/target/linux/ramips/dts/mt7620n_dlink_dwr-922-e2.dts
@@ -75,7 +75,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		lte_modem_enable {
 			gpio-export,name = "lte_modem_enable";

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni-ii.dts
@@ -68,7 +68,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb_power {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
+++ b/target/linux/ramips/dts/mt7620n_zyxel_keenetic-omni.dts
@@ -68,7 +68,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb_power {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/mt7621_alfa-network_quad-e4g.dts
+++ b/target/linux/ramips/dts/mt7621_alfa-network_quad-e4g.dts
@@ -23,7 +23,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		m2-enable {
 			gpio-export,name = "m2-enable";

--- a/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
@@ -62,7 +62,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		power_usb2 {
 			gpio-export,name = "power_usb2";

--- a/target/linux/ramips/dts/mt7621_dual-q_h721.dts
+++ b/target/linux/ramips/dts/mt7621_dual-q_h721.dts
@@ -23,7 +23,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb-30-power {
 			gpio-export,name = "usb-30-power";

--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -61,7 +61,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb2power {
 			gpio-export,name = "usb2power";

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
@@ -5,7 +5,6 @@
 / {
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		buzzer {
 			/* Beeper requires PWM for frequency selection */

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-01.dtsi
@@ -11,7 +11,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		modem_reset {
 			gpio-export,name = "modem_reset";

--- a/target/linux/ramips/dts/mt7621_unielec_u7621-06.dtsi
+++ b/target/linux/ramips/dts/mt7621_unielec_u7621-06.dtsi
@@ -27,7 +27,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		modem_reset {
 			gpio-export,name = "modem_reset";

--- a/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
+++ b/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
@@ -66,7 +66,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		power_usb2 {
 			gpio-export,name = "power_usb2";

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
@@ -68,7 +68,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		4g1-pwr {
 			gpio-export,name = "4g1-pwr";

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
@@ -67,7 +67,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		4g1-pwr {
 			gpio-export,name = "4g1-pwr";

--- a/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
@@ -19,7 +19,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		power_modem {
 			gpio-export,name = "power_modem";

--- a/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
@@ -85,7 +85,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		lte_power {
 			gpio-export,name = "lte_power";

--- a/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_glinet_gl-mt300n-v2.dts
@@ -67,7 +67,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
+++ b/target/linux/ramips/dts/mt7628an_hak5_wifi-pineapple-mk7.dts
@@ -47,7 +47,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb-power {
 			gpio-export,name = "usb-power";

--- a/target/linux/ramips/dts/mt7628an_hiwifi_hc5761a.dts
+++ b/target/linux/ramips/dts/mt7628an_hiwifi_hc5761a.dts
@@ -34,7 +34,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb_power {
 			gpio-export,name = "usb_power";

--- a/target/linux/ramips/dts/mt7628an_kroks_kndrt31r16.dts
+++ b/target/linux/ramips/dts/mt7628an_kroks_kndrt31r16.dts
@@ -22,7 +22,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb1power {
 			gpio-export,name = "usb1power";

--- a/target/linux/ramips/dts/mt7628an_kroks_kndrt31r19.dts
+++ b/target/linux/ramips/dts/mt7628an_kroks_kndrt31r19.dts
@@ -21,7 +21,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		modem1power {
 			gpio-export,name = "modem1power";

--- a/target/linux/ramips/dts/mt7628an_minew_g1-c.dts
+++ b/target/linux/ramips/dts/mt7628an_minew_g1-c.dts
@@ -38,7 +38,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		ws2812 {
 			gpio-export,name = "ws2812";

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr3020-v3.dts
@@ -83,7 +83,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usbpower {
 			gpio-export,name = "usbpower";

--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -71,7 +71,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usbpower {
 			gpio-export,name = "usbpower";

--- a/target/linux/ramips/dts/rt3052_jcg_jhr-n926r.dts
+++ b/target/linux/ramips/dts/rt3052_jcg_jhr-n926r.dts
@@ -95,7 +95,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		display_data {
 			gpio-export,name = "display_data";

--- a/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
+++ b/target/linux/ramips/dts/rt3662_dlink_dir-645.dts
@@ -55,7 +55,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
+++ b/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
@@ -137,7 +137,6 @@
 	/*
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name="usb";

--- a/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
+++ b/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
@@ -46,7 +46,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/rt3662_omnima_hpm.dts
+++ b/target/linux/ramips/dts/rt3662_omnima_hpm.dts
@@ -69,7 +69,7 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
+
 		/* gpio 12 and 13 handle the OC input */
 
 		usb0 {

--- a/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
+++ b/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
@@ -42,7 +42,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/rt5350_dlink_dir-320-b1.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dir-320-b1.dts
@@ -55,7 +55,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/rt5350_dlink_dwr-512-b.dts
+++ b/target/linux/ramips/dts/rt5350_dlink_dwr-512-b.dts
@@ -63,7 +63,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		slic_int {
 			gpio-export,name = "slic_int";

--- a/target/linux/ramips/dts/rt5350_hame_mpr-a1.dts
+++ b/target/linux/ramips/dts/rt5350_hame_mpr-a1.dts
@@ -42,7 +42,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/rt5350_hame_mpr-a2.dts
+++ b/target/linux/ramips/dts/rt5350_hame_mpr-a2.dts
@@ -42,7 +42,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/rt5350_hilink_hlk-rm04.dts
+++ b/target/linux/ramips/dts/rt5350_hilink_hlk-rm04.dts
@@ -13,7 +13,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		/* I2C */
 		gpio1 {

--- a/target/linux/ramips/dts/rt5350_nixcore_x1.dtsi
+++ b/target/linux/ramips/dts/rt5350_nixcore_x1.dtsi
@@ -11,7 +11,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		gpio0 {
 			gpio-export,name = "gpio0";

--- a/target/linux/ramips/dts/rt5350_olimex_rt5350f-olinuxino-evb.dts
+++ b/target/linux/ramips/dts/rt5350_olimex_rt5350f-olinuxino-evb.dts
@@ -8,7 +8,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		relay1 {
 			gpio-export,name = "relay1";

--- a/target/linux/ramips/dts/rt5350_poray_x5.dts
+++ b/target/linux/ramips/dts/rt5350_poray_x5.dts
@@ -65,7 +65,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb-mode {
 			gpio-export,name = "usb-mode";

--- a/target/linux/ramips/dts/rt5350_tenda_3g150b.dts
+++ b/target/linux/ramips/dts/rt5350_tenda_3g150b.dts
@@ -42,7 +42,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/rt5350_trendnet_tew-714tru.dts
+++ b/target/linux/ramips/dts/rt5350_trendnet_tew-714tru.dts
@@ -43,7 +43,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		repeater {
 			gpio-export,name = "repeater_switch";

--- a/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
+++ b/target/linux/ramips/dts/rt5350_unbranded_a5-v11.dts
@@ -43,7 +43,6 @@
 
 	gpio_export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		usb {
 			gpio-export,name = "usb";

--- a/target/linux/ramips/dts/rt5350_vocore_vocore.dtsi
+++ b/target/linux/ramips/dts/rt5350_vocore_vocore.dtsi
@@ -16,7 +16,6 @@
 
 	gpio-export {
 		compatible = "gpio-export";
-		#size-cells = <0>;
 
 		gpio0 {
 			gpio-export,name = "gpio0";


### PR DESCRIPTION
The "gpio-export" driver doesn't require a "reg" property in the device tree, hence we don't need to use the "#size-cells" property to describe the size of "reg".