### PR TITLE
RFC: use upstream ARM Trusted Firmware for rk3588

### DIFF
--- a/include/trusted-firmware-a.mk
+++ b/include/trusted-firmware-a.mk
@@ -1,12 +1,20 @@
 PKG_NAME ?= trusted-firmware-a
 PKG_CPE_ID ?= cpe:/a:arm:trusted_firmware-a
 
-ifndef PKG_SOURCE_PROTO
-PKG_SOURCE = trusted-firmware-a-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://codeload.github.com/TrustedFirmware-A/trusted-firmware-a/tar.gz/v$(PKG_VERSION)?
+PKG_LTS ?=
+
+ifneq ($(PKG_LTS),)
+PKG_VERSION_PREFIX:=lts-v
+PKG_BUILD_DIR = $(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION_PREFIX)$(PKG_VERSION)
+else
+PKG_VERSION_PREFIX:=v
+PKG_BUILD_DIR = $(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 endif
 
-PKG_BUILD_DIR = $(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+ifndef PKG_SOURCE_PROTO
+PKG_SOURCE = trusted-firmware-a-$(PKG_VERSION_PREFIX)$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://codeload.github.com/TrustedFirmware-A/trusted-firmware-a/tar.gz/$(PKG_VERSION_PREFIX)$(PKG_VERSION)?
+endif
 
 PKG_TARGETS := bin
 PKG_FLAGS:=nonshared
@@ -83,7 +91,7 @@ define Build/Compile/Trusted-Firmware-A
 		OPENSSL_DIR=$(STAGING_DIR_HOST) \
 		$(if $(DTC),DTC="$(DTC)") \
 		PLAT=$(PLAT) \
-		BUILD_STRING="OpenWrt v$(PKG_VERSION)-$(PKG_RELEASE) ($(VARIANT))" \
+		BUILD_STRING="OpenWrt $(PKG_VERSION_PREFIX)$(PKG_VERSION)-$(PKG_RELEASE) ($(VARIANT))" \
 		$(TFA_MAKE_FLAGS)
 endef
 

--- a/package/boot/arm-trusted-firmware-rockchip/Makefile
+++ b/package/boot/arm-trusted-firmware-rockchip/Makefile
@@ -7,10 +7,11 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_VERSION:=2.10
+PKG_VERSION:=2.12.1
 PKG_RELEASE:=1
+PKG_LTS:=1
 
-PKG_HASH:=88215a62291b9ba87da8e50b077741103cdc08fb6c9e1ebd34dfaace746d3201
+PKG_HASH:=c0d432a851da452d927561feaf45f569c1cde57985782beadfe29e616e260440
 
 PKG_MAINTAINER:=Sarah Maedel <openwrt@tbspace.de>
 
@@ -36,9 +37,6 @@ endef
 TFA_TARGETS:= \
 	rk3328 \
 	rk3399
-
-TFA_MAKE_FLAGS+= \
-	$(if $(CONFIG_BINUTILS_VERSION_2_37)$(CONFIG_BINUTILS_VERSION_2_38),,LDFLAGS="-no-warn-rwx-segments")
 
 ifeq ($(BUILD_VARIANT),rk3399)
   M0_GCC_NAME:=gcc-arm

--- a/package/boot/arm-trusted-firmware-rockchip/Makefile
+++ b/package/boot/arm-trusted-firmware-rockchip/Makefile
@@ -34,9 +34,15 @@ define Trusted-Firmware-A/rk3399
   PLAT:=rk3399
 endef
 
+define Trusted-Firmware-A/rk3588
+  BUILD_SUBTARGET:=armv8
+  PLAT:=rk3588
+endef
+
 TFA_TARGETS:= \
 	rk3328 \
-	rk3399
+	rk3399 \
+	rk3588
 
 ifeq ($(BUILD_VARIANT),rk3399)
   M0_GCC_NAME:=gcc-arm

--- a/package/boot/rkbin/Makefile
+++ b/package/boot/rkbin/Makefile
@@ -57,9 +57,8 @@ define Trusted-Firmware-A/rk3568-e25
   TPL:=rk35/rk3568_ddr_1560MHz_uart2_m0_115200_v1.21.bin
 endef
 
-define Trusted-Firmware-A/rk3588
+define Trusted-Firmware-A/rk3588-tpl
   BUILD_SUBTARGET:=armv8
-  ATF:=rk35/rk3588_bl31_v1.45.elf
   TPL:=rk35/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin
 endef
 
@@ -69,7 +68,7 @@ TFA_TARGETS:= \
 	rk3566 \
 	rk3568 \
 	rk3568-e25 \
-	rk3588
+	rk3588-tpl
 
 ifeq ($(BUILD_VARIANT),rk3308-rock-pi-s)
   TPL_FILE:=rk3308_ddr_589MHz_uart0_m0_v2.07.bin
@@ -109,7 +108,9 @@ endef
 define Package/trusted-firmware-a/install
 	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
 
+ifneq ($(ATF),)
 	$(CP) $(PKG_BUILD_DIR)/bin/$(ATF) $(STAGING_DIR_IMAGE)/
+endif
 	$(CP) $(PKG_BUILD_DIR)/bin/$(TPL) $(STAGING_DIR_IMAGE)/
 endef
 

--- a/package/boot/rkbin/Makefile
+++ b/package/boot/rkbin/Makefile
@@ -71,9 +71,6 @@ TFA_TARGETS:= \
 	rk3568-e25 \
 	rk3588
 
-TFA_MAKE_FLAGS+= \
-	$(if $(CONFIG_BINUTILS_VERSION_2_37)$(CONFIG_BINUTILS_VERSION_2_38),,LDFLAGS="-no-warn-rwx-segments")
-
 ifeq ($(BUILD_VARIANT),rk3308-rock-pi-s)
   TPL_FILE:=rk3308_ddr_589MHz_uart0_m0_v2.07.bin
   define Download/rk3308-tpl-rock-pi-s

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -247,8 +247,10 @@ endef
 
 define U-Boot/rk3588/Default
   BUILD_SUBTARGET:=armv8
-  DEPENDS:=+PACKAGE_u-boot-$(1):trusted-firmware-a-rk3588
-  ATF:=rk3588_bl31_v1.45.elf
+  DEPENDS:= \
+	+PACKAGE_u-boot-$(1):trusted-firmware-a-rk3588 \
+	+PACKAGE_u-boot-$(1):trusted-firmware-a-rk3588-tpl
+  ATF:=rk3588_bl31.elf
   TPL:=rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin
 endef
 


### PR DESCRIPTION
Build-tested on x86_64
Runtime-tested on rockchip/armv8 on Radxa ROCK 5B+

Please check individual commit messages.