### PR TITLE
include/rootfs.mk: disable real chroot in fakeroot

### DIFF
--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -45,6 +45,7 @@ opkg = \
 
 apk = \
   IPKG_INSTROOT=$(1) \
+  FAKEROOTDONTTRYCHOWN=1 \
   $(FAKEROOT) $(STAGING_DIR_HOST)/bin/apk \
 	--root $(1) \
 	--keys-dir $(if $(APK_KEYS),$(APK_KEYS),$(TOPDIR)) \


### PR DESCRIPTION
When building openwrt in user namespaces, the forwarded chown error would not be masked by fakeroot properly and fails the build. 

There is no reason to try forward chown calls when building rootfs. Set FAKEROOTDONTTRYCHOWN disables this behavior.