### PR TITLE
wifi: ath11k: support fetching mac-address from nvmem

### DIFF
--- a/package/kernel/mac80211/patches/ath11k/101-wifi-ath11k-support-fetching-mac-address-from-nvmem.patch
+++ b/package/kernel/mac80211/patches/ath11k/101-wifi-ath11k-support-fetching-mac-address-from-nvmem.patch
@@ -1,0 +1,45 @@
+From f97897dde57d45b962a2636876cd84c9baed61c4 Mon Sep 17 00:00:00 2001
+From: George Moussalem <george.moussalem@outlook.com>
+Date: Wed, 19 Mar 2025 10:19:41 +0400
+Subject: [PATCH] wifi: ath11k: support fetching mac address from nvmem
+
+Many embedded devices with ath11k wifi chips store their mac address in
+nvmem partitions. Currently, the ath11k driver supports getting the
+mac address from the 'mac-address', 'local-mac-address', and 'address'
+device tree properties only. As such, add support for obtaining the mac
+address from nvmem if defined in a 'mac-address' cell by replacing the
+call to device_get_mac_address by of_get_mac_address which does exactly
+the same as the former but tries to get it from nvmem if it is not set
+by above mentioned DT properties.
+
+Tested-on: IPQ5018, QCN6122, and QCN9074
+
+Signed-off-by: George Moussalem <george.moussalem@outlook.com>
+---
+ drivers/net/wireless/ath/ath11k/mac.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/wireless/ath/ath11k/mac.c b/drivers/net/wireless/ath/ath11k/mac.c
+index 1556392f7ad4..6cee616693b3 100644
+--- a/drivers/net/wireless/ath/ath11k/mac.c
++++ b/drivers/net/wireless/ath/ath11k/mac.c
+@@ -9,6 +9,7 @@
+ #include <linux/etherdevice.h>
+ #include <linux/bitfield.h>
+ #include <linux/inetdevice.h>
++#include <linux/of_net.h>
+ #include <net/if_inet6.h>
+ #include <net/ipv6.h>
+ 
+@@ -10324,7 +10325,7 @@ int ath11k_mac_register(struct ath11k_base *ab)
+ 	if (ret)
+ 		return ret;
+ 
+-	device_get_mac_address(ab->dev, mac_addr);
++	of_get_mac_address(ab->dev->of_node, mac_addr);
+ 
+ 	for (i = 0; i < ab->num_radios; i++) {
+ 		pdev = &ab->pdevs[i];
+-- 
+2.48.1
+

--- a/package/kernel/mac80211/patches/ath11k/201-wifi-ath11k-Support-setting-bdf-addr-and-caldb-addr-.patch
+++ b/package/kernel/mac80211/patches/ath11k/201-wifi-ath11k-Support-setting-bdf-addr-and-caldb-addr-.patch
@@ -41,7 +41,7 @@ Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
  				}
  			} else {
  				ab->qmi.target_mem[idx].paddr = 0;
-@@ -2292,6 +2296,7 @@ static int ath11k_qmi_load_file_target_m
+@@ -2295,6 +2299,7 @@ static int ath11k_qmi_load_file_target_m
  	struct qmi_wlanfw_bdf_download_resp_msg_v01 resp;
  	struct qmi_txn txn;
  	const u8 *temp = data;
@@ -49,7 +49,7 @@ Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
  	void __iomem *bdf_addr = NULL;
  	int ret = 0;
  	u32 remaining = len;
-@@ -2303,7 +2308,9 @@ static int ath11k_qmi_load_file_target_m
+@@ -2306,7 +2311,9 @@ static int ath11k_qmi_load_file_target_m
  	memset(&resp, 0, sizeof(resp));
  
  	if (ab->hw_params.fixed_bdf_addr) {

--- a/package/kernel/mac80211/patches/ath11k/923-wifi-ath11k-update-hif_and-pci_ops-for-QCN6122.patch
+++ b/package/kernel/mac80211/patches/ath11k/923-wifi-ath11k-update-hif_and-pci_ops-for-QCN6122.patch
@@ -91,9 +91,9 @@ Signed-off-by: George Moussalem <george.moussalem@outlook.com>
  #endif /* _HIF_H_ */
 --- a/drivers/net/wireless/ath/ath11k/qmi.c
 +++ b/drivers/net/wireless/ath/ath11k/qmi.c
-@@ -2184,6 +2184,8 @@ static int ath11k_qmi_request_device_inf
- 	ab->mem = bar_addr_va;
- 	ab->mem_len = resp.bar_size;
+@@ -2187,6 +2187,8 @@ static int ath11k_qmi_request_device_inf
+ 	if (!ab->hw_params.ce_remap)
+ 		ab->mem_ce = ab->mem;
  
 +	ath11k_hif_config_static_window(ab);
 +

--- a/package/kernel/mac80211/patches/ath11k/924-wifi-ath11k-add-multipd-support-for-QCN6122.patch
+++ b/package/kernel/mac80211/patches/ath11k/924-wifi-ath11k-add-multipd-support-for-QCN6122.patch
@@ -37,7 +37,7 @@ Signed-off-by: George Moussalem <george.moussalem@outlook.com>
 +	ret = of_property_read_string(dev->of_node,
 +				      "qcom,userpd-subsys-name",
 +				      &subsys_name);
-+	if (ret) 
++	if (ret)
 +		return 0;
 +
 +	if (strcmp(subsys_name, "q6v5_wcss_userpd2") == 0)
@@ -89,7 +89,7 @@ Signed-off-by: George Moussalem <george.moussalem@outlook.com>
  /* SMBIOS type containing Board Data File Name Extension */
  #define ATH11K_SMBIOS_BDF_EXT_TYPE 0xF8
  
-@@ -945,6 +948,7 @@ struct ath11k_base {
+@@ -951,6 +954,7 @@ struct ath11k_base {
  	struct list_head peers;
  	wait_queue_head_t peer_mapping_wq;
  	u8 mac_addr[ETH_ALEN];

--- a/package/kernel/mac80211/patches/ath11k/932-wifi-ath11k-poll-reo-status-ipq5018.patch
+++ b/package/kernel/mac80211/patches/ath11k/932-wifi-ath11k-poll-reo-status-ipq5018.patch
@@ -132,7 +132,7 @@ Signed-off-by: Sriram R <srirrama@codeaurora.org>
  };
  
  /* HTT definitions */
-@@ -1712,5 +1718,6 @@ void ath11k_dp_shadow_init_timer(struct
+@@ -1689,5 +1695,6 @@ void ath11k_dp_shadow_init_timer(struct
  				 struct ath11k_hp_update_timer *update_timer,
  				 u32 interval, u32 ring_id);
  void ath11k_dp_stop_shadow_timers(struct ath11k_base *ab);

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mr5500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mr5500.dts
@@ -288,7 +288,7 @@
 };
 
 &usb_dwc {
-	address-cells = <1>;
+	#address-cells = <1>;
 	#size-cells = <0>;
 	dr_mode = "host";
 
@@ -321,6 +321,9 @@
 			reg = <0x00010000 0 0 0 0>;
 
 			qcom,ath11k-calibration-variant = "Linksys-MR5500";
+
+			nvmem-cells = <&hw_mac_addr 2>;
+			nvmem-cell-names = "mac-address";
 		};
 	};
 };
@@ -382,6 +385,9 @@
 	qcom,ath11k-calibration-variant = "Linksys-MR5500";
 	qcom,ath11k-fw-memory-mode = <2>;
 	qcom,bdf-addr = <0x4c400000>;
+
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
 
 	status = "okay";
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx2000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx2000.dts
@@ -241,6 +241,9 @@
 	qcom,ath11k-fw-memory-mode = <2>;
 	qcom,bdf-addr = <0x4c400000>;
 
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
+
 	status = "okay";
 };
 
@@ -252,6 +255,9 @@
 	qcom,ath11k-fw-memory-mode = <2>;
 	qcom,bdf-addr = <0x4d100000>;
 	qcom,m3-dump-addr = <0x4df00000>;
+
+	nvmem-cells = <&hw_mac_addr 2>;
+	nvmem-cell-names = "mac-address";
 
 	status = "okay";
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx5500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx5500.dts
@@ -168,6 +168,9 @@
 			reg = <0x00010000 0 0 0 0>;
 
 			qcom,ath11k-calibration-variant = "Linksys-MX5500";
+
+			nvmem-cells = <&hw_mac_addr 2>;
+			nvmem-cell-names = "mac-address";
 		};
 	};
 };
@@ -230,6 +233,9 @@
 	qcom,ath11k-calibration-variant = "Linksys-MX5500";
 	qcom,ath11k-fw-memory-mode = <2>;
 	qcom,bdf-addr = <0x4c400000>;
+
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
 
 	status = "okay";
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-spnmx56.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-spnmx56.dts
@@ -179,6 +179,9 @@
 			reg = <0x00010000 0 0 0 0>;
 
 			qcom,ath11k-calibration-variant = "Linksys-SPNMX56";
+
+			nvmem-cells = <&hw_mac_addr 2>;
+			nvmem-cell-names = "mac-address";
 		};
 	};
 };
@@ -240,6 +243,9 @@
 	qcom,ath11k-calibration-variant = "Linksys-SPNMX56";
 	qcom,ath11k-fw-memory-mode = <2>;
 	qcom,bdf-addr = <0x4c400000>;
+
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
 
 	status = "okay";
 };

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -14,10 +14,7 @@ case "$FIRMWARE" in
 	linksys,mx5500|\
 	linksys,spnmx56)
 		caldata_extract "0:ART" 0x1000 0x20000
-		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
-		ath11k_patch_mac $(macaddr_add $label_mac 1) 0
 		ath11k_remove_regdomain
-		ath11k_set_macflag
 		;;
 	esac
 	;;
@@ -25,10 +22,7 @@ case "$FIRMWARE" in
 	case "$board" in
 	linksys,mx2000)
 		caldata_extract "0:ART" 0x26800 0x20000
-		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
-		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
 		ath11k_remove_regdomain
-		ath11k_set_macflag
 		;;
 	esac
 	;;
@@ -38,10 +32,7 @@ case "$FIRMWARE" in
 	linksys,mx5500|\
 	linksys,spnmx56)
 		caldata_extract "0:ART" 0x26800 0x20000
-		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
-		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
 		ath11k_remove_regdomain
-		ath11k_set_macflag
 		;;
 	esac
 	;;


### PR DESCRIPTION
Many embedded devices with ath11k wifi chips store their mac address in
nvmem partitions. Currently, the ath11k driver supports getting the
mac address from the 'mac-address', 'local-mac-address', and 'address'
device tree properties only. As such, add support for obtaining the mac
address from nvmem if defined in a 'mac-address' cell by replacing the
call to device_get_mac_address by of_get_mac_address which does exactly
the same as the former but tries to get it from nvmem if it is not set
by above mentioned DT properties.

Set mac-addresses for Linksys devices directly in DTS files using nvmem
and, accordingly, skip setting them in user space while the driver is
loading caldata.

Tested-on: IPQ5018, QCN6122, and QCN9074 (Linksys MX2000 and SPNMX56)
