### PR TITLE
ramips: fix tplink_mr200v1 wan interface

### DIFF
--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -247,7 +247,7 @@ ramips_setup_interfaces()
 	tplink,archer-mr200)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "6t@eth0"
-		ucidef_set_interface_wan "usb0"
+		ucidef_set_interface_wan "eth1"
 		;;
 	tplink,ec220-g5-v2)
 		ucidef_add_switch "switch0"


### PR DESCRIPTION
TPlink archer MR200 v1 devices use a RNDIS interface for wan and since upstream kernel switched naming this interfaces from usbX to ethX all images starting from 24.10.0 and main break the default network setup so backport is needed to fix also 24.10 branch.
This patch should fix this issue.
see also https://forum.openwrt.org/t/lte-modem-not-working-after-upgrade/227644