### PR TITLE
realtek: add support for RTL8218E

### DIFF
--- a/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.c
@@ -3846,6 +3846,27 @@ static int rtl8218d_phy_probe(struct phy_device *phydev)
 	return 0;
 }
 
+static int rtl8218e_phy_probe(struct phy_device *phydev)
+{
+	struct device *dev = &phydev->mdio.dev;
+	int addr = phydev->mdio.addr;
+
+	pr_debug("%s: id: %d\n", __func__, addr);
+	/* All base addresses of the PHYs start at multiples of 8 */
+	devm_phy_package_join(dev, phydev, addr & (~7),
+			      sizeof(struct rtl83xx_shared_private));
+
+	/* All base addresses of the PHYs start at multiples of 8 */
+	if (!(addr % 8)) {
+		struct rtl83xx_shared_private *shared = phydev->shared->priv;
+		shared->name = "RTL8218E";
+		/* Configuration must be done while patching still possible */
+/* TODO:		return configure_rtl8218e(phydev); */
+	}
+
+	return 0;
+}
+
 static int rtl838x_serdes_probe(struct phy_device *phydev)
 {
 	int addr = phydev->mdio.addr;
@@ -3947,6 +3968,19 @@ static struct phy_driver rtl83xx_phy_driver[] = {
 		.name		= "REALTEK RTL8218D",
 		.features	= PHY_GBIT_FEATURES,
 		.probe		= rtl8218d_phy_probe,
+		.read_page	= rtl821x_read_page,
+		.write_page	= rtl821x_write_page,
+		.suspend	= genphy_suspend,
+		.resume		= genphy_resume,
+		.set_loopback	= genphy_loopback,
+		.set_eee	= rtl8218d_set_eee,
+		.get_eee	= rtl8218d_get_eee,
+	},
+	{
+		PHY_ID_MATCH_EXACT(PHY_ID_RTL8218E),
+		.name		= "REALTEK RTL8218E",
+		.features	= PHY_GBIT_FEATURES,
+		.probe		= rtl8218e_phy_probe,
 		.read_page	= rtl821x_read_page,
 		.write_page	= rtl821x_write_page,
 		.suspend	= genphy_suspend,

--- a/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.h
+++ b/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.h
@@ -27,6 +27,7 @@ struct __attribute__ ((__packed__)) fw_header {
 #define PHY_ID_RTL8218B_E			0x001cc980
 #define PHY_ID_RTL8214_OR_8218			0x001cc981
 #define PHY_ID_RTL8218D				0x001cc983
+#define PHY_ID_RTL8218E				0x001cc984
 #define PHY_ID_RTL8218B_I			0x001cca40
 #define PHY_ID_RTL8221B				0x001cc849
 #define PHY_ID_RTL8226				0x001cc838


### PR DESCRIPTION
ZyXEL XGS1250-12 Rev.B1 has RTL8218E compared to RTL8218D in Rev.A1 but both of them seem very similar and pin compatible. The main thing is that when PHY_ID_MATCH_EXACT is called, it is now able to match. PHY identifier is set based on the datasheet from https://github.com/plappermaul/realtek-doc/blob/main/RTL8218E-CG_Datasheet.pdf
Before:
```
[    2.120161] rtl83xx-switch switch@1b000000 lan1 (uninitialized): PHY [mdio-bus:00] driver [Generic PHY] (irq=POLL)
[    2.134581] rtl83xx-switch switch@1b000000 lan2 (uninitialized): PHY [mdio-bus:01] driver [Generic PHY] (irq=POLL)
[    2.149043] rtl83xx-switch switch@1b000000 lan3 (uninitialized): PHY [mdio-bus:02] driver [Generic PHY] (irq=POLL)
[    2.163498] rtl83xx-switch switch@1b000000 lan4 (uninitialized): PHY [mdio-bus:03] driver [Generic PHY] (irq=POLL)
[    2.177963] rtl83xx-switch switch@1b000000 lan5 (uninitialized): PHY [mdio-bus:04] driver [Generic PHY] (irq=POLL)
[    2.192435] rtl83xx-switch switch@1b000000 lan6 (uninitialized): PHY [mdio-bus:05] driver [Generic PHY] (irq=POLL)
[    2.207009] rtl83xx-switch switch@1b000000 lan7 (uninitialized): PHY [mdio-bus:06] driver [Generic PHY] (irq=POLL)
[    2.221474] rtl83xx-switch switch@1b000000 lan8 (uninitialized): PHY [mdio-bus:07] driver [Generic PHY] (irq=POLL)
```
After:
```
[    2.119165] rtl83xx-switch switch@1b000000 lan1 (uninitialized): PHY [mdio-bus:00] driver [REALTEK RTL8218E] (irq=POLL)
[    2.132880] rtl83xx-switch switch@1b000000 lan2 (uninitialized): PHY [mdio-bus:01] driver [REALTEK RTL8218E] (irq=POLL)
[    2.146727] rtl83xx-switch switch@1b000000 lan3 (uninitialized): PHY [mdio-bus:02] driver [REALTEK RTL8218E] (irq=POLL)
[    2.160580] rtl83xx-switch switch@1b000000 lan4 (uninitialized): PHY [mdio-bus:03] driver [REALTEK RTL8218E] (irq=POLL)
[    2.174367] rtl83xx-switch switch@1b000000 lan5 (uninitialized): PHY [mdio-bus:04] driver [REALTEK RTL8218E] (irq=POLL)
[    2.188270] rtl83xx-switch switch@1b000000 lan6 (uninitialized): PHY [mdio-bus:05] driver [REALTEK RTL8218E] (irq=POLL)
[    2.202140] rtl83xx-switch switch@1b000000 lan7 (uninitialized): PHY [mdio-bus:06] driver [REALTEK RTL8218E] (irq=POLL)
[    2.216047] rtl83xx-switch switch@1b000000 lan8 (uninitialized): PHY [mdio-bus:07] driver [REALTEK RTL8218E] (irq=POLL)
```
