### PR TITLE
ramips: dts: remove redundant console bootargs

### DIFF
--- a/target/linux/ramips/dts/mt7620a_bolt_bl100.dts
+++ b/target/linux/ramips/dts/mt7620a_bolt_bl100.dts
@@ -19,10 +19,6 @@
 		label-mac-device = &ethernet;
 	};
 
-	chosen {
-		bootargs = "console=ttyS0,57600";
-	};
-
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ramips/dts/mt7621_confiabits_mt7621-v1.dts
+++ b/target/linux/ramips/dts/mt7621_confiabits_mt7621-v1.dts
@@ -17,10 +17,6 @@
 		led-upgrade = &led_power_green;
 	};
 
-	chosen {
-		bootargs = "console=ttyS0,57600";
-	};
-
 	keys {
 		compatible = "gpio-keys";
 

--- a/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
@@ -17,11 +17,6 @@
 		led-upgrade = &led_power;
 	};
 
-
-	chosen {
-		bootargs = "console=ttyS0,57600";
-	};
-
 	gpio_export {
 		compatible = "gpio-export";
 		#size-cells = <0>;

--- a/target/linux/ramips/dts/mt7628an_yuncore_cpe200.dts
+++ b/target/linux/ramips/dts/mt7628an_yuncore_cpe200.dts
@@ -8,10 +8,6 @@
 	compatible = "yuncore,cpe200", "mediatek,mt7628an-soc";
 	model = "Yuncore CPE200";
 
-	chosen {
-		bootargs = "console=ttyS0,57600";
-	};
-
 	aliases {
 		label-mac = &ethernet;
 		led-boot = &led_power;

--- a/target/linux/ramips/dts/mt7628an_yuncore_m300.dts
+++ b/target/linux/ramips/dts/mt7628an_yuncore_m300.dts
@@ -8,10 +8,6 @@
 	compatible = "yuncore,m300", "mediatek,mt7628an-soc";
 	model = "Yuncore M300";
 
-	chosen {
-		bootargs = "console=ttyS0,57600";
-	};
-
 	keys {
 		compatible = "gpio-keys";
 


### PR DESCRIPTION
`bootargs = "console=ttyS0,57600";` is already defined on all ramips target SoCs' dtsi. We don't need to override it with the same value.
