### PR TITLE
rockchip: Add Realtek RTL8821CU support for the Radxa ROCK Pi E v3

### DIFF
--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -237,7 +237,7 @@ define Device/radxa_rock-pi-e-v3
   DEVICE_MODEL := ROCK Pi E v3.0
   SOC := rk3328
   DEVICE_DTS := rockchip/rk3328-rock-pi-e
-  DEVICE_PACKAGES := kmod-rtw88-8723du kmod-usb-net-cdc-ncm kmod-usb-net-rndis wpad-basic-mbedtls
+  DEVICE_PACKAGES := kmod-rtw88-8723du kmod-rtw88-8821cu kmod-usb-net-cdc-ncm kmod-usb-net-rndis wpad-basic-mbedtls
 endef
 TARGET_DEVICES += radxa_rock-pi-e-v3
 


### PR DESCRIPTION
There is a variant of the Radxa ROCK Pi E v3 equipped with the Realtek RTL8821CU. Add the kmod-rtw88-8821cu package for it.