### PR TITLE
wifi-scripts: Add support for VHT80P80/HE80P80 htmodes

### DIFF
--- a/package/network/config/wifi-scripts/files/usr/share/hostap/wifi-detect.uc
+++ b/package/network/config/wifi-scripts/files/usr/share/hostap/wifi-detect.uc
@@ -236,7 +236,10 @@ function wiphy_detect() {
 				push(modes, "HE160");
 			if (eht_phy_cap && he_phy_cap & 0x18)
 				push(modes, "EHT160");
-
+			if ((band.vht_capa >> 2) & 0x2)
+				push(modes, "VHT80P80");
+			if (he_phy_cap & 0x10)
+				push(modes, "HE80P80");
 			if (eht_phy_cap & 2)
 				push(modes, "EHT320");
 		}


### PR DESCRIPTION
Adds support for 80+80MHz channel width configuration for VHT (802.11ac/WiFi 5) and HE (802.11ax/WiFi 6) modes.
A new uci parameter channel2 is introduced for the wifi-device indicating the channel to be used for the second 80MHz segment.

Example config:
```
config wifi-device 'radio0'
    option band '5g'
    option channel '36'
    option channel2 '149'
    option htmode 'VHT80P80'
```