### PR TITLE
ipv6 iol intact certification

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -35,16 +35,21 @@ setup_interface () {
 		proto_add_dns_server "$dns" "$lifetime"
 	done
 
-	for radomain in $RA_DOMAINS; do
+	for entry in $RA_DOMAINS; do
 		local duplicate=0
-		for domain in $DOMAINS; do
+		local radomain="${entry%%,*}"
+		for dentry in $DOMAINS; do
+			local domain="${dentry%%,*}"
 			[ "$radomain" = "$domain" ] && duplicate=1
 		done
-		[ "$duplicate" = 0 ] && DOMAINS="$DOMAINS $radomain"
+		[ "$duplicate" = 0 ] && DOMAINS="$DOMAINS $entry"
 	done
 
-	for domain in $DOMAINS; do
-		proto_add_dns_search "$domain"
+	for entry in $DOMAINS; do
+		local domain="${entry%%,*}"
+		entry="${entry#*,}"
+		local lifetime="${entry%%,*}"
+		proto_add_dns_search "$domain" "$lifetime"
 	done
 
 	for prefix in $PREFIXES; do

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -18,16 +18,21 @@ setup_interface () {
 	proto_init_update "*" 1
 
 	# Merge RA-DNS
-	for radns in $RA_DNS; do
+	for entry in $RA_DNS; do
 		local duplicate=0
-		for dns in $RDNSS; do
+		local radns="${entry%%,*}"
+		for dentry in $RDNSS; do
+			local dns="${dentry%%,*}"
 			[ "$radns" = "$dns" ] && duplicate=1
 		done
-		[ "$duplicate" = 0 ] && RDNSS="$RDNSS $radns"
+		[ "$duplicate" = 0 ] && RDNSS="$RDNSS $entry"
 	done
 
-	for dns in $RDNSS; do
-		proto_add_dns_server "$dns"
+	for entry in $RDNSS; do
+		local dns="${entry%%,*}"
+		entry="${entry#*,}"
+		local lifetime="${entry%%,*}"
+		proto_add_dns_server "$dns" "$lifetime"
 	done
 
 	for radomain in $RA_DOMAINS; do

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -3,17 +3,26 @@
 . /lib/functions.sh
 . /lib/netifd/netifd-proto.sh
 
-setup_interface () {
+setup_interface_neigh () {
 	local device="$1"
-	local prefsig=""
-	local addrsig=""
 
 	# Apply IPv6 / ND configuration
 	HOPLIMIT=$(cat /proc/sys/net/ipv6/conf/$device/hop_limit)
 	[ -n "$RA_HOPLIMIT" -a -n "$HOPLIMIT" ] && [ "$RA_HOPLIMIT" -gt "$HOPLIMIT" ] && echo "$RA_HOPLIMIT" > /proc/sys/net/ipv6/conf/$device/hop_limit
 	[ -n "$RA_MTU" ] && [ "$RA_MTU" -ge 1280 ] && echo "$RA_MTU" > /proc/sys/net/ipv6/conf/$device/mtu 2>/dev/null
-	[ -n "$RA_REACHABLE" ] && [ "$RA_REACHABLE" -gt 0 ] && echo "$RA_REACHABLE" > /proc/sys/net/ipv6/neigh/$device/base_reachable_time_ms
 	[ -n "$RA_RETRANSMIT" ] && [ "$RA_RETRANSMIT" -gt 0 ] && echo "$RA_RETRANSMIT" > /proc/sys/net/ipv6/neigh/$device/retrans_time_ms
+	REACHABLE=$(cat /proc/sys/net/ipv6/neigh/$device/base_reachable_time_ms)
+	if [ -n "$RA_REACHABLE" ] && [ "$RA_REACHABLE" -gt 0 ] && [ "$RA_REACHABLE" -ne "$REACHABLE" ]; then
+		echo "$RA_REACHABLE" > /proc/sys/net/ipv6/neigh/$device/base_reachable_time_ms
+		GC_STALE_TIME=$((RA_REACHABLE / 1000 * 3))
+		echo "$GC_STALE_TIME" > /proc/sys/net/ipv6/neigh/$device/gc_stale_time
+	fi
+}
+
+setup_interface () {
+	local device="$1"
+	local prefsig=""
+	local addrsig=""
 
 	proto_init_update "*" 1
 
@@ -232,12 +241,15 @@ teardown_interface() {
 case "$2" in
 	bound)
 		teardown_interface "$1"
+		setup_interface_neigh "$1"
 		setup_interface "$1"
 	;;
 	informed|updated|rebound)
+		setup_interface_neigh "$1"
 		setup_interface "$1"
 	;;
 	ra-updated)
+		setup_interface_neigh "$1"
 		[ -n "$ADDRESSES$RA_ADDRESSES$PREFIXES$USERPREFIX" ] && setup_interface "$1"
 	;;
 	started|stopped|unbound)


### PR DESCRIPTION
IPV6 IOL INTACT certification:

### 1-Test 'v6LC.2.2.25 (C): Recursive DNS (RDNSS) Option Expired' Failed

**Test Description**

1. TR1 to transmit Router Advertisement A with a lifetime 60 in the RDNSS Option.
2. Configure the HUT to transmit an Echo Request with a destination of 'node1.test.example.com'.
3. Observe the HUT transmitting a DNS Query to DNS-Server.
4. Wait 65 seconds.
5. Configure the HUT to transmit an Echo Request with a destination of node1.test.example.com.
6. Observe the HUT doesn't transmit a DNS Query to DNS-Server

**Fail Reason**

- openwrt doesn't support DNS server expiry time. We have to add support on odhcp6c , netifd and dhcpv6.script

**Solution**

- odhcp6c RA_DNS format is changed from RA_DNS="dns1 dns2 dns3 ..." to RA_DNS="dns1,valid1 dns2,valid2 dns3,valid3..."
- dhvpv6.script should parse the entries correctly and call 'proto_add_dns_server' using two arguments: proto_add_dns_server  "$dns" "$lifetime"


### 2-Test 'v6LC.2.2.25 (F): Search List (DNSSL) Option Expired' Failed

**Test Description**

1. TR1 to transmit Router Advertisement A. The RDNSS Option has a lifetime that lasts the
2. entire test. The DNSSL Option has a lifetime of 60.
3. Configure the HUT to transmit an Echo Request with a destination of 'node1'.
4. Observe the HUT transmitting a DNS Query to DNS-Server.
5. Wait 65 seconds.
6. Configure the HUT to transmit an Echo Request with a destination of 'node1'.
7. Observe the HUT doesn't transmit a DNS Query to DNS-Server.

**Fail Reason**

- openwrt doesn't support search domain expiry time. We have to add support on odhcp6c, netifd and dhcpv6.script

**Solution**

- odhcp6c RA_DNS format is changed from RA_DOMAINS="domain1 domain2 domain3 ..." to RA_DOMAINS="domain1,valid1 domain2,valid2 domain3,valid3 ..."
- dhvpv6.script should parse the entries correctly and call 'proto_add_dns_search'
    using two arguments: proto_add_dns_search  "$dns" "$lifetime"

### 3-Test 'v6LC.2.2.15 (A) RA Processing – Reachable Time' Failed

**Test Description**

1. TR1 transmits the Router Advertisement with a Router Lifetime of 0 seconds and a Reachable Time of 10 seconds.
2. TN1 transmits a link-local Echo Request to the HUT. TN1 must reply to any Neighbor Solicitations from the HUT.
3. The HUT should solicit for TN1’s link-local address and transmit an Echo Reply.
4. Repeat Step 2 every second for 40 seconds.
5. The HUT should transmit a Neighbor Solicitation with a Target Address of TN1’s link-local address at an interval between 10 and 20 seconds. [ReachableTime time (between 5 and 15 seconds) + DELAY_FIRST_PROBE_TIME (5 seconds)].
6. TR1 transmits the Router Advertisement with a Reachable Time of 40 seconds.
7.  Repeat Step 2 every second for 140 seconds.
8. The HUT should transmit Neighbor Solicitations at an interval between 25 and 65 seconds. [ReachableTime time (between 20 and 60 seconds) + DELAY_FIRST_PROBE_TIME (5 seconds)].

**Fail Reason**

- reachable time isn't set correctly when we receive a Router Advertisement

**Solution**

-dhcpv6.script is writing on sysctl path : /proc/sys/net/ipv6/neigh/$device/base_reachable_time_ms and /proc/sys/net/ipv6/neigh/$device/retrans_time_ms when ra-updated is called with condition "$ADDRESSES$RA_ADDRESSES$PREFIXES$USERPREFIX" is not empty.
-RA is sent with Lifetime equal  to Zero that mean that no ipv6 addresses are set mean that  "$ADDRESSES$RA_ADDRESSES$PREFIXES$USERPREFIX" is false. We have to set configure sysctl params
even if no ipv6 address assigned  according to RFC486:

>     If the received Reachable Time value is non-zero, the host SHOULD set
>     its BaseReachableTime variable to the received value. If the new
>     value differs from the previous value, the host SHOULD re-compute a
>     new random ReachableTime value. ReachableTime is computed as a
>     uniformly distributed random value between MIN_RANDOM_FACTOR and
>     MAX_RANDOM_FACTOR times the BaseReachableTime. Using a random
>     component eliminates the possibility that Neighbor Unreachability
>     Detection messages will synchronize with each other.

-We split the setup configuration to setup_interface_neigh and setup_interface. setup_interface_neigh should always be called.
-Modify REACHABLE TIME sysctl path only when we the value is changed and set 'gc_stale_time' three times reachable time
as the Kernel code source process when 'accept_ra' sysctl paramater is true.