### PR TITLE
wifi-scripts: mac80211.sh: add EHT and HE160 support to iw_htmode

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless/mac80211.sh
@@ -740,8 +740,10 @@ mac80211_prepare_vif() {
 
 mac80211_prepare_iw_htmode() {
 	case "$htmode" in
-		VHT20|HT20|HE20) iw_htmode=HT20;;
-		HT40*|VHT40|VHT160|HE40)
+		HT20|VHT20|HE20|EHT20)
+			iw_htmode=HT20
+		;;
+		HT40*|VHT40|HE40|EHT40)
 			case "$band" in
 				2g)
 					case "$htmode" in
@@ -765,8 +767,11 @@ mac80211_prepare_iw_htmode() {
 			esac
 			[ "$auto_channel" -gt 0 ] && iw_htmode="HT40+"
 		;;
-		VHT80|HE80)
-			iw_htmode="80MHZ"
+		VHT80|HE80|EHT80)
+			iw_htmode="80MHz"
+		;;
+		VHT160|HE160|EHT160)
+			iw_htmode="160MHz"
 		;;
 		NONE|NOHT)
 			iw_htmode="NOHT"


### PR DESCRIPTION
For WIFI7 devices (such as mt7925e), the dev width is currently always "20 MHz (no HT)" in monitor mode.

Add EHT and HE160 support to iw_htmode to fix this issue. Additionally, the following changes are made:
1. Set iw_htmode to 160MHz for VHT160. The reason for the current VHT160 setting is unclear and seems to have been in place for over a decade (ibss_htmode [1]). If anyone knows its impact, please inform me so I can restore it.
2. Modify MHZ to MHz. The original matching table in the current iw tool uses MHz. Although the match is case-insensitive, correcting this won't hurt.

[1]: https://github.com/openwrt/openwrt/commit/768d09be8781228d3553142c0f1e1231c6aacc7c