### PR TITLE
ath79: add support for Yuncore WB5G08

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -6,9 +6,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2025-05-30
-PKG_SOURCE_VERSION:=fde3d2a7ce59be389224304049a4a5b9ca49a45e
-PKG_MIRROR_HASH:=2e149366118192d4976baf42ac23d22ef32e477feb111d2756a2411278b6cf46
+PKG_SOURCE_DATE:=2025-05-24
+PKG_SOURCE_VERSION:=09e5afab85b28fa58d3639bfa340ee0e57018725
+PKG_MIRROR_HASH:=08a07dbce047efa28f12b3d67e5ddb3d1ccae506d5ddfd83c64b4a12fe8450b6
 PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/package.mk
@@ -79,9 +79,10 @@ ALLWIFIBOARDS:= \
 	wallys_dr40x9 \
 	xiaomi_ax3600 \
 	xiaomi_ax9000 \
-	yyets_le1 \
 	yuncore_ax880 \
 	yuncore_fap650 \
+	yuncore_wb5g08 \
+	yyets_le1 \
 	zbtlink_zbt-z800ax \
 	zte_mf269 \
 	zte_mf286ar\
@@ -234,9 +235,10 @@ $(eval $(call generate-ipq-wifi-package,tplink_archer-c6-v2,TP-Link Archer C6 V2
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax9000,Xiaomi AX9000))
-$(eval $(call generate-ipq-wifi-package,yyets_le1,YYeTs LE1))
 $(eval $(call generate-ipq-wifi-package,yuncore_ax880,Yuncore AX880))
 $(eval $(call generate-ipq-wifi-package,yuncore_fap650,Yuncore FAP650))
+$(eval $(call generate-ipq-wifi-package,yuncore_wb5g08,Yuncore WB5G08))
+$(eval $(call generate-ipq-wifi-package,yyets_le1,YYeTs LE1))
 $(eval $(call generate-ipq-wifi-package,zbtlink_zbt-z800ax,Zbtlink ZBT-Z800AX))
 $(eval $(call generate-ipq-wifi-package,zte_mf269,ZTE MF269))
 $(eval $(call generate-ipq-wifi-package,zte_mf286ar,ZTE MF286A/R))

--- a/target/linux/ath79/dts/qca9563_yuncore_wb5g08.dts
+++ b/target/linux/ath79/dts/qca9563_yuncore_wb5g08.dts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca956x.dtsi"
+
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "yuncore,wb5g08", "qca,qca9563";
+	model = "Yuncore WB5G08";
+
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		link1 {
+			label = "green:signal0";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+
+		link2 {
+			label = "green:signal1";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		link3 {
+			label = "green:signal2";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		link4 {
+			label = "green:signal3";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset button";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+
+		mode {
+			label = "mode";
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0000 0 0 0 0>;
+		qcom,ath10k-calibration-variant = "Yuncore-WB5G08";
+		nvmem-cells = <&macaddr_art_5006>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		phy-mode = "sgmii";
+		qca,mib-poll-interval = <500>;
+
+		qca,ar8327-initvals = <
+			0x04 0x00080080 /* PORT0 PAD MODE CTRL */
+			0x10 0x81000080 /* POWER_ON_STRAP */
+			0x7c 0x0000007e /* PORT0_STATUS */
+		>;
+	};
+};
+
+&gmac {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x050000 0xfa0000>;
+			};
+
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_5006: macaddr@5006 {
+						reg = <0x5006 0x6>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -554,6 +554,13 @@ yuncore,cpe830)
 	ucidef_set_led_rssi "wifi_mediumhigh" "WIFIMEDIUMHIGH" "green:signal2" "wlan0" "51" "100"
 	ucidef_set_led_rssi "wifi_high" "WIFIHIGH" "green:signal3" "wlan0" "76" "100"
 	;;
+yuncore,wb5g08)
+        ucidef_set_rssimon "wlan0" "200000" "1"
+        ucidef_set_led_rssi "rssilow" "RSSILOW" "green:link1" "wlan0" "1" "100"
+        ucidef_set_led_rssi "rssimediumlow" "RSSIMEDIUMLOW" "green:link2" "wlan0" "26" "100"
+        ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:link3" "wlan0" "51" "100"
+        ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:link4" "wlan0" "76" "100"
+        ;;
 zbtlink,zbt-wd323)
 	ucidef_set_led_switch "lan1" "LAN1" "orange:lan1" "switch0" "0x10"
 	ucidef_set_led_switch "lan2" "LAN2" "orange:lan2" "switch0" "0x08"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -442,11 +442,6 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:1" "3:lan:2" "4:lan:3" "5:lan:4" "1:wan"
 		;;
-	nec,wf1200cr)
-		ucidef_set_interface_wan "eth1"
-		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan"
-		;;
 	nec,wg1200cr|\
 	qxwlan,e1700ac-v2-8m|\
 	qxwlan,e1700ac-v2-16m|\
@@ -455,11 +450,17 @@ ath79_setup_interfaces()
 	ubnt,nanobeam-ac-gen2|\
 	ubnt,nanostation-ac|\
 	yuncore,a782|\
+	yuncore,wb5g08|\
 	yuncore,xd3200|\
 	yuncore,xd4200)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan" "3:wan"
 		;;
+	nec,wf1200cr)
+                ucidef_set_interface_wan "eth1"
+                ucidef_add_switch "switch0" \
+                        "0@eth0" "1:lan"
+                ;;
 	nec,wg800hp|\
 	xiaomi,aiot-ac2350)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -3383,6 +3383,17 @@ define Device/yuncore_cpe830
 endef
 TARGET_DEVICES += yuncore_cpe830
 
+define Device/yuncore_wb5g08
+  SOC := qca9563
+  DEVICE_VENDOR := Yuncore
+  DEVICE_MODEL := WB5G08
+  IMAGE_SIZE := 16000k
+  IMAGES += tftp.bin
+  IMAGE/tftp.bin := $$(IMAGE/sysupgrade.bin) | yuncore-tftp-header-16m
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9888 -ath9k ipq-wifi-yuncore_wb5g08
+endef
+TARGET_DEVICES += yuncore_wb5g08
+
 define Device/yuncore_xd4200
   SOC := qca9563
   DEVICE_VENDOR := YunCore


### PR DESCRIPTION
Short specifications:

- QCA9563+9886
- 2x 100/1000 Mbps Ethernet, passive PoE support
- 128 MB of RAM (DDR2)
- 16 MB of FLASH
- 2x internal 18 dBi antennas, up to 25 dBm (316mW)
- 8x LED, 1x button
- Wifi 2.4G disabled

Flash instructions

1. Connect PC with 192.168.0.141 to WAN port
2. Install a TFTP server on your PC ('atftp' is doing the job for instance)
3. Copy your firmware (ending with -tftp) in the TFTP folder as upgrade.bin
4. Power up device pushing the 'reset' button
5. The device shall upload upgrade.bin, install it and reboot
6. Device shall be booting on 192.168.1.1 as default

**Important note : the POE is on WAN, whereas the 192.168.1.1 will be available by default on the LAN port.**

Signed-off-by: Joan Moreau <jom@grosjo.net>