### PR TITLE
uboot-tools: dont build tools unconditionally

### DIFF
--- a/package/boot/uboot-tools/Makefile
+++ b/package/boot/uboot-tools/Makefile
@@ -59,8 +59,8 @@ define Package/uboot-envtools/conffiles
 endef
 
 define Build/Configure
-	$(MAKE) -C $(PKG_BUILD_DIR) tools-only_defconfig
-	$(MAKE) -C $(PKG_BUILD_DIR) syncconfig
+	$(call Build/Compile/Default,tools-only_defconfig)
+	$(call Build/Compile/Default,syncconfig)
 	$(SED) 's/CONFIG_TOOLS_LIBCRYPTO=y/# CONFIG_TOOLS_LIBCRYPTO is not set/' $(PKG_BUILD_DIR)/.config
 endef
 
@@ -71,8 +71,14 @@ MAKE_FLAGS += \
 	NO_PYTHON=1
 
 define Build/Compile
+
+ifneq ($(CONFIG_PACKAGE_uboot-envtools),)
 	$(call Build/Compile/Default,envtools)
+endif
+ifneq ($(CONFIG_PACKAGE_dumpimage),)
 	$(call Build/Compile/Default,cross_tools)
+endif
+
 endef
 
 define Package/dumpimage/install

--- a/package/boot/uboot-tools/Makefile
+++ b/package/boot/uboot-tools/Makefile
@@ -22,19 +22,6 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/uboot-tools
-	SECTION:=utils
-	CATEGORY:=Utilities
-	SUBMENU:=Boot Loaders
-	TITLE:=U-Boot bootloader Tools
-	URL:=http://www.denx.de/wiki/U-Boot
-endef
-
-define Package/uboot-tools/description
-	U-Boot tools are a collection of utilities designed
-	to work with the U-Boot bootloader,
-endef
-
 define Package/dumpimage
 	SECTION:=utils
 	CATEGORY:=Utilities


### PR DESCRIPTION
Currently, both envtools and the rest of U-Boot tools are being built
regardless if the dumpimage package has been selected.

This will fail if only envtools are selected since the rest of tools
require OpenSSL while envtools do not require them.

So, only build tools if dumpimage is selected.

While we are here, remove the useless uboot-tools package definition.

Fixes: https://github.com/openwrt/openwrt/commit/46e376c93514b63ca130075dc8b968c517f12ff7 ("uboot-tools: migrate uboot-envtools to uboot-tools")
Fixes: https://github.com/openwrt/openwrt/issues/18327
Signed-off-by: Robert Marko <robimarko@gmail.com>
