### PR TITLE
qualcommax: ipq807x: Create working factory tar for WAX620 and WAX630.

### DIFF
--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -28,7 +28,7 @@ define Build/wax6xx-netgear-tar
 	mv $@ $@.tmp/nand-ipq807x-apps.img
 	md5sum $@.tmp/nand-ipq807x-apps.img | cut -c 1-32 > $@.tmp/nand-ipq807x-apps.md5sum
 	echo $(DEVICE_MODEL) > $@.tmp/metadata.txt
-	echo $(DEVICE_MODEL)"_V9.9.9.9" > $@.tmp/version
+	echo $(DEVICE_MODEL)"_V99.9.9.9" > $@.tmp/version
 	tar -C $@.tmp/ -cf $@ .
 	rm -rf $@.tmp
 endef
@@ -326,6 +326,8 @@ define Device/netgear_wax620
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	SOC := ipq8072
+	IMAGES += ui-factory.tar
+	IMAGE/ui-factory.tar := append-ubi | qsdk-ipq-factory-nand | pad-to 4096 | wax6xx-netgear-tar
 	DEVICE_PACKAGES := kmod-spi-gpio kmod-gpio-nxp-74hc164 \
 		ipq-wifi-netgear_wax620
 endef
@@ -341,7 +343,7 @@ define Device/netgear_wax630
 	PAGESIZE := 2048
 	SOC := ipq8074
 	IMAGES += ui-factory.tar
-	IMAGE/ui-factory.tar := append-ubi | wax6xx-netgear-tar
+	IMAGE/ui-factory.tar := append-ubi | qsdk-ipq-factory-nand | pad-to 4096 | wax6xx-netgear-tar
 	DEVICE_PACKAGES := kmod-spi-gpio ipq-wifi-netgear_wax630
 endef
 TARGET_DEVICES += netgear_wax630

--- a/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/init.d/bootcount
@@ -17,5 +17,9 @@ boot() {
 	linksys,mx8500)
 		mtd resetbc s_env || true
 	;;
+	netgear,wax620|\
+	netgear,wax630)
+		fw_setenv boot_count 0
+	;;
 	esac
 }


### PR DESCRIPTION
Create factory tar for WAX620 and WAX630 which is accepted by the stock UI.
Must use 'Boot up Backup Firmware' button on stock upgrade page after install and reboot to swap partitions.