### PR TITLE
qualcommax: ipq807x: Create working factory images for EAP620 HD v1 and EAP660 HD v1

### DIFF
--- a/scripts/tplink-mkimage-2022.py
+++ b/scripts/tplink-mkimage-2022.py
@@ -19,7 +19,9 @@ import argparse
 import hashlib
 import os
 import pprint
+import re
 import struct
+
 
 def decode_header(datafile):
     '''Read the tplink2022 image header anbd decode it into a dictionary'''
@@ -151,7 +153,7 @@ def create_image(output_image, root, support):
 
     support_list = {}
     support_list['name'] = 'support-list'
-    support_list['data'] = support.replace(" ", "\r\n").encode('utf-8')
+    support_list['data'] = re.sub("\\\\r\\\\n ?", "\r\n", support).encode("utf-8")
     support_list['offset'] = header['rootfs_size']
     support_list['size'] = len(support_list['data'])
     header['items'].append(support_list)

--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -1,3 +1,5 @@
+DEVICE_VARS += TPLINK_SUPPORT_STRING
+
 define Device/8devices_mango-dvk
 	$(call Device/FitImageLzma)
 	DEVICE_VENDOR := 8devices
@@ -107,9 +109,9 @@ define Device/tplink_eap610-outdoor
 	DEVICE_PACKAGES := ipq-wifi-tplink_eap610-outdoor
 	IMAGES += web-ui-factory.bin
 	IMAGE/web-ui-factory.bin := append-ubi | tplink-image-2022
-	TPLINK_SUPPORT_STRING := SupportList: \
-		EAP610-Outdoor(TP-Link|UN|AX1800-D):1.0 \
-		EAP610-Outdoor(TP-Link|JP|AX1800-D):1.0 \
+	TPLINK_SUPPORT_STRING := SupportList:\r\n \
+		EAP610-Outdoor(TP-Link|UN|AX1800-D):1.0\r\n \
+		EAP610-Outdoor(TP-Link|JP|AX1800-D):1.0\r\n \
 		EAP610-Outdoor(TP-Link|CA|AX1800-D):1.0
 endef
 TARGET_DEVICES += tplink_eap610-outdoor

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -1,4 +1,4 @@
-DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
+DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID TPLINK_SUPPORT_STRING
 
 define Build/asus-fake-ramdisk
 	rm -rf $(KDIR)/tmp/fakerd
@@ -402,6 +402,8 @@ define Device/tplink_eap620hd-v1
 	PAGESIZE := 2048
 	SOC := ipq8072
 	DEVICE_PACKAGES := ipq-wifi-tplink_eap620hd-v1
+	IMAGES += web-ui-factory.bin
+	IMAGE/web-ui-factory.bin := append-ubi | tplink-image-2022
 	TPLINK_SUPPORT_STRING := SupportList:\r\nEAP620 HD(TP-Link|UN|AX1800-D):1.0\r\n
 endef
 TARGET_DEVICES += tplink_eap620hd-v1
@@ -416,6 +418,8 @@ define Device/tplink_eap660hd-v1
 	PAGESIZE := 2048
 	SOC := ipq8072
 	DEVICE_PACKAGES := ipq-wifi-tplink_eap660hd-v1
+	IMAGES += web-ui-factory.bin
+	IMAGE/web-ui-factory.bin := append-ubi | tplink-image-2022
 	TPLINK_SUPPORT_STRING := SupportList:\r\nEAP660 HD(TP-Link|UN|AX3600-D):1.0\r\n
 endef
 TARGET_DEVICES += tplink_eap660hd-v1


### PR DESCRIPTION
Create factory tar for EAP620 HD v1 and EAP660 HD v1 which is accepted by the stock UI.

The following are related changes in this commit:
* Fix bug in ipq807x and ipq60xx makefiles so TPLINK_SUPPORT_STRING is handled properly.
* Modify tplink-mkimage-2022 script and relevant makefiles to allow spaces in support strings (required for EAP620 HD v1 and EAP660 HD v1).
    
Installation steps are identical to EAP610-Outdoor #14922:
## Web UI method

Set up the device using the vendor's web UI. After that go to Management->SSH and enable the "SSH Login" checkbox. Select "Save". The connect to the machine via SSH:

`ssh -o hostkeyalgorithms=ssh-rsa <ip_of_device>`

Disable signature verification:

`cliclientd stopcs`

Rename the "-web-ui-factory" image to something less than 63 characters, maintaining the ".bin" suffix.

* Go to System -> Firmware Update.
* Under "New Firmware File", click "Browse" and select the image
*  Select "Update" and confirm by clicking "OK".

If the update fails, the web UI should show an error message. Otherwise, the device should reboot into OpenWRT.