### PR TITLE
lldpd: bump to 1.0.19

### DIFF
--- a/package/network/services/lldpd/Makefile
+++ b/package/network/services/lldpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=lldpd
-PKG_VERSION:=1.0.18
-PKG_RELEASE:=2
+PKG_VERSION:=1.0.19
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/lldpd/lldpd/releases/download/$(PKG_VERSION)/
-PKG_HASH:=38cd319aa02ab61d9a2ad130e22f906795ccca9ac73a0a0d9dac19ca99a8a870
+PKG_HASH:=4de17fe5137b4d44a7bd57f8dfc80cffe2c8bb3691b4ae3012b5a6ea20d79ee0
 
 PKG_MAINTAINER:=Stijn Tintel <stijn@linux-ipv6.be>
 PKG_LICENSE:=ISC


### PR DESCRIPTION
Changes:
- Support of both Apple Silicon and Intel for macOS package.
- Add cvlan/svlan/tpmr capabilities.
- Disable LLDP in firmware for Intel X7xx cards on FreeBSD.
- Add lldpctl_watch_sync_unblock to liblldpctl.
- Add C++ wrapper for lldpctl.

Fix:
- Fix AppArmor policy for /run/lldpd/lldpd.socket.lock.
- Do not query stats for a down interface on Linux.

Link: https://github.com/openwrt/openwrt/pull18345

```
 # lldpd -vv
lldpd 1.0.19
  Built on 2025-03-24T17:43:44Z

Additional LLDP features:    LLDP-MED, Dot1, Dot3, Custom TLV
Additional protocols:        CDP, FDP, EDP, SONMP
SNMP support:                no
Old kernel support:          no (Linux 2.6.39+)
Privilege separation:        enabled
Privilege separation user:   lldp
Privilege separation group:  lldp
Privilege separation chroot: /var/run/lldp
Configuration directory:     /tmp

C compiler command: C compiler command is not available for reproducible builds
Linker command:     Linker compiler command is not available for reproducible builds
```

Tested on: 24.10.0