### PR TITLE
odhcp6c: Conditionally request S46 OROs

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -96,12 +96,22 @@ proto_dhcpv6_setup() {
 
 	[ "$verbose" = "1" ] && append opts "-v"
 
+	json_for_each_item proto_dhcpv6_add_sendopts sendopts opts
+
+	# Dynamically add OROs to support loaded packages.
+	json_load "$(ubus call network get_proto_handlers)"
+	json_get_vars handler_map map
+	json_get_vars handler_dslite dslite
+
+	[ -n "$handler_dslite" ] && append reqopts "64"
+	[ -n "$handler_map" ] && append reqopts "94"
+	[ -n "$handler_map" ] && append reqopts "95"
+	[ -n "$handler_map" ] && append reqopts "96"
+
 	local opt
 	for opt in $reqopts; do
 		append opts "-r$opt"
 	done
-
-	json_for_each_item proto_dhcpv6_add_sendopts sendopts opts
 
 	append opts "-t${soltimeout:-120}"
 


### PR DESCRIPTION
Request Softwire46 (S46) [RFC 7598] options when the map and/or ds-lite packages are installed. 
This is required as the behaviour of odhcp6c has changed to not include these OROs by default.
See openwrt/odhcp6c#89

Separate version bump PR for odhcpv6 here: https://github.com/openwrt/openwrt/pull/17974

This PR replaces https://github.com/openwrt/openwrt/pull/16209

