### PR TITLE
mbedtls: update to 3.6.3

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=3.6.2
+PKG_VERSION:=3.6.3
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL=https://github.com/Mbed-TLS/$(PKG_NAME)/releases/download/$(PKG_NAME)-$(PKG_VERSION)
-PKG_HASH:=8b54fb9bcf4d5a7078028e0520acddefb7900b3e66fec7f7175bb5b7d85ccdca
+PKG_HASH:=64cd73842cdc05e101172f7b437c65e7312e476206e1dbfd644433d11bc56327
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/mbedtls/patches/101-remove-test.patch
+++ b/package/libs/mbedtls/patches/101-remove-test.patch
@@ -1,6 +1,7 @@
 --- a/programs/CMakeLists.txt
 +++ b/programs/CMakeLists.txt
-@@ -1,13 +1,9 @@
+@@ -3,14 +3,10 @@ add_custom_target(${programs_target})
+ 
  add_subdirectory(aes)
  add_subdirectory(cipher)
 -if (NOT WIN32)


### PR DESCRIPTION
This release of Mbed TLS provides the fix for a tls compatibility issue of handling fragmented handshake messages. This release includes fixes for security issues.

* [Potential authentication bypass in TLS handshake](https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-2/) (CVE-2025-27810)
* [TLS clients should generally call mbedtls_ssl_set_hostname](https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-1/) (CVE-2025-27809)

[Full release announcement](https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.3)

Compile-tested by compiling libustream-mbedtls, wpad-basic-mbedtls, openvpn-mbedtls and cURL with MbedTLS on mvebu/cortexa9. More testing pending.