### PR TITLE
lldpd: enable hardware inventory information (TLV) management

### DIFF
--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2008-2015 OpenWrt.org
-# shellcheck disable=1091,2034,3037,3043,3045
+# shellcheck disable=1091,2034,3037,3043,3045,3057
 
 START=90
 STOP=01
@@ -24,13 +24,61 @@ LLDPD_RESTART_HASH=${LLDPD_RUN}/lldpd.restart_hash
 
 . "$IPKG_INSTROOT/lib/functions/network.sh"
 
+# Load release info once for all 'find_*' functions
+[ -s /etc/os-release ] && . /etc/os-release
+
+# Helper function to truncate output to 31 characters
+truncate_output() {
+	# Some devices have trouble decoding inventory TLV strings > 31 chars
+	# lldpd truncates inventory TLV to a total TLV length of 36 (of which string = 32)
+	echo "${1:0:31}"
+}
+
 find_release_info()
 {
-	[ -s /etc/os-release ] && . /etc/os-release
 	[ -z "$PRETTY_NAME" ] && [ -s /etc/openwrt_version ] && \
 		PRETTY_NAME="$(cat /etc/openwrt_version)"
 
 	echo "${PRETTY_NAME:-Unknown OpenWrt release} @ $(cat /proc/sys/kernel/hostname)"
+}
+
+find_hardware_revision()
+{
+	echo "${OPENWRT_DEVICE_REVISION:-Unknown hardware revision}"
+}
+
+find_firmware_info()
+{
+	echo "${PRETTY_NAME:-Unknown firmware release}"
+}
+
+find_software_revision()
+{
+	echo "${BUILD_ID:-Unknown software revision}"
+}
+
+# Helper function to extract JSON values using jsonfilter
+extract_json_field() {
+	local _path="$1"
+	jsonfilter -q -i /etc/board.json -e "$_path" 2>/dev/null
+}
+
+find_manufacturer_info()
+{
+	local _id
+	# extract the model->id field, e.g.: "id": "glinet,gl-mt6000",
+	_id=$(extract_json_field '@.model.id')
+	# stash text up to first comma
+	_id="${_id%%,*}"
+	echo "${_id:-Unknown manufacturer}"
+}
+
+find_model_info()
+{
+	local _name
+	# extract the model->name field, e.g.: "name": "GL.iNet GL-MT6000"
+	_name=$(extract_json_field '@.model.name')
+	echo "${_name:-Unknown model name}"
 }
 
 get_config_restart_hash() {
@@ -120,6 +168,48 @@ write_lldpd_conf()
 	config_load 'lldpd'
 	config_get lldp_description 'config' 'lldp_description' "$(find_release_info)"
 
+	# Check the 'do not send inventory' flag
+	local lldpmed_no_inventory
+	config_get_bool lldpmed_no_inventory 'config' 'lldpmed_no_inventory' 0
+
+	if [ "$lldpmed_no_inventory" = 0 ]; then
+		# lldpmed_no_inventory=1 ('-i' in start_service()) prevents these from being sent
+		# TIA TR-41 TLV 127 subtype 0x05
+		local lldp_med_inv_hardware_revision
+		config_get lldp_med_inv_hardware_revision 'config' 'lldp_med_inv_hardware_revision' "$(find_hardware_revision)"
+		lldp_med_inv_hardware_revision=$(truncate_output "$lldp_med_inv_hardware_revision")
+
+		# TIA TR-41 TLV 127 subtype 0x06
+		local lldp_med_inv_firmware_revision
+		config_get lldp_med_inv_firmware_revision 'config' 'lldp_med_inv_firmware_revision' "$(find_firmware_info)"
+		lldp_med_inv_firmware_revision=$(truncate_output "$lldp_med_inv_firmware_revision")
+
+		# TIA TR-41 TLV 127 subtype 0x07
+		local lldp_med_inv_software_revision
+		config_get lldp_med_inv_software_revision 'config' 'lldp_med_inv_software_revision' "$(find_software_revision)"
+		lldp_med_inv_software_revision=$(truncate_output "$lldp_med_inv_software_revision")
+
+		# TIA TR-41 TLV 127 subtype 0x08
+		local lldp_med_inv_serial_number
+		config_get lldp_med_inv_serial_number 'config' 'lldp_med_inv_serial_number'
+		lldp_med_inv_serial_number=$(truncate_output "$lldp_med_inv_serial_number")
+
+		# TIA TR-41 TLV 127 subtype 0x09
+		local lldp_med_inv_manufacturer_name
+		config_get lldp_med_inv_manufacturer_name 'config' 'lldp_med_inv_manufacturer_name' "$(find_manufacturer_info)"
+		lldp_med_inv_manufacturer_name=$(truncate_output "$lldp_med_inv_manufacturer_name")
+
+		# TIA TR-41 TLV 127 subtype 0x0a
+		local lldp_med_inv_model_name
+		config_get lldp_med_inv_model_name 'config' 'lldp_med_inv_model_name' "$(find_model_info)"
+		lldp_med_inv_model_name=$(truncate_output "$lldp_med_inv_model_name")
+
+		# TIA TR-41 TLV 127 subtype 0x0b
+		local lldp_med_inv_asset_id
+		config_get lldp_med_inv_asset_id 'config' 'lldp_med_inv_asset_id'
+		lldp_med_inv_asset_id=$(truncate_output "$lldp_med_inv_asset_id")
+	fi
+
 	local lldp_hostname
 	config_get lldp_hostname 'config' 'lldp_hostname' "$(cat /proc/sys/kernel/hostname)"
 
@@ -181,6 +271,17 @@ write_lldpd_conf()
 	[ -n "$lldp_hostname" ] && echo "configure system hostname" "\"$lldp_hostname\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_mgmt_ip" ] && echo "configure system ip management pattern" "\"$lldp_mgmt_ip\"" >> "$LLDPD_CONF"
 	[ -n "$lldp_syscapabilities" ] && echo "configure system capabilities enabled $lldp_syscapabilities" >> "$LLDPD_CONF"
+
+	if [ "$lldpmed_no_inventory" = 0 ]; then
+		# Hardware inventory info
+		[ -n "$lldp_med_inv_hardware_revision" ] && echo "configure inventory hardware-revision \"$lldp_med_inv_hardware_revision\"" >> "$LLDPD_CONF"
+		[ -n "$lldp_med_inv_firmware_revision" ] && echo "configure inventory firmware-revision \"$lldp_med_inv_firmware_revision\"" >> "$LLDPD_CONF"
+		[ -n "$lldp_med_inv_software_revision" ] && echo "configure inventory software-revision \"$lldp_med_inv_software_revision\"" >> "$LLDPD_CONF"
+		[ -n "$lldp_med_inv_serial_number" ] && echo "configure inventory serial-number \"$lldp_med_inv_serial_number\"" >> "$LLDPD_CONF"
+		[ -n "$lldp_med_inv_manufacturer_name" ] && echo "configure inventory manufacturer \"$lldp_med_inv_manufacturer_name\"" >> "$LLDPD_CONF"
+		[ -n "$lldp_med_inv_model_name" ] && echo "configure inventory model \"$lldp_med_inv_model_name\"" >> "$LLDPD_CONF"
+		[ -n "$lldp_med_inv_asset_id" ] && echo "configure inventory asset \"$lldp_med_inv_asset_id\"" >> "$LLDPD_CONF"
+	fi
 
 	if [ "$CONFIG_LLDPD_WITH_LLDPMED" = "y" ] && [ "$lldpmed_fast_start" -gt 0 ]; then
 		if [ "$lldpmed_fast_start_tx_interval" -gt 0 ]; then
@@ -401,6 +502,14 @@ reload_service() {
 		unconfigure system hostname
 		unconfigure system ip management pattern
 		unconfigure system platform
+		# Hardware inventory info
+		unconfigure inventory hardware-revision
+		unconfigure inventory firmware-revision
+		unconfigure inventory software-revision
+		unconfigure inventory serial-number
+		unconfigure inventory manufacturer
+		unconfigure inventory model
+		unconfigure inventory asset
 	EOF
 	if [ "$CONFIG_LLDPD_WITH_LLDPMED" = "y" ]; then
 		$LLDPCLI -u "$LLDPSOCKET" >/dev/null 2>&1 <<-EOF


### PR DESCRIPTION
lldpd can send several hardware inventory TLV fields. Extend the init script to provide these when the existing flag `lldpmed_no_inventory` is disabled. Five new methods provide default values for some of them, taken from /etc/os-release and /etc/board.json.

There is no homogeneous method to determine the hardware serial number, so it can be provided manually, as can asset ID.

Note: properties >= 32 characters are truncated at send time (by lldpd), and some (Cisco) equipment displays junk after strings >= 32 characters. So truncate to 31.

Tested on: 24.10.0 (known compatible with 22 and 23 also)


ping @pprindeville for a review of the shell stuff (which follows the existing conventions)