### PR TITLE
[RFC] treewide: validate unified uImage.FIT images before flashing

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -384,8 +384,9 @@ json_load "$(/usr/libexec/validate_firmware_image "$IMAGE")" || {
 	exit 1
 }
 json_get_var valid "valid"
+json_get_var forceable "forceable"
 [ "$valid" -eq 0 ] && {
-	if [ $FORCE -eq 1 ]; then
+	if [ $FORCE -eq 1 ] && [ "$forceable" -eq 1 ]; then
 		echo "Image check failed but --force given - will update anyway!" >&2
 	else
 		echo "Image check failed." >&2

--- a/package/base-files/files/usr/libexec/validate_firmware_image
+++ b/package/base-files/files/usr/libexec/validate_firmware_image
@@ -56,7 +56,17 @@ json_init
 		# Call platform_check_image() here so it can add its test
 		# results and still mark image properly.
 		json_set_namespace $old_ns
-		platform_check_image "$1" >&2 || notify_firmware_invalid
+		platform_check_image "$1" >&2
+		case "$?" in
+		0)
+			;;
+		74)
+			notify_firmware_broken
+			;;
+		*)
+			notify_firmware_invalid
+			;;
+		esac
 		json_set_namespace validate_firmware_image old_ns
 	json_close_object
 	json_add_boolean valid "$VALID"

--- a/package/utils/fitblk/Makefile
+++ b/package/utils/fitblk/Makefile
@@ -16,6 +16,7 @@ define Package/fitblk
   SECTION:=base
   CATEGORY:=Base system
   TITLE:=fitblk firmware release tool
+  DEPENDS:=+fit-check-sign
 endef
 
 define Package/fitblk/description

--- a/package/utils/fitblk/files/fit.sh
+++ b/package/utils/fitblk/files/fit.sh
@@ -61,3 +61,13 @@ fit_do_upgrade() {
 		;;
 	esac
 }
+
+fit_check_image() {
+	local magic="$(get_magic_long "$1")"
+	[ "$magic" != "d00dfeed" ] && {
+		echo "Invalid image type."
+		return 74
+	}
+
+	fit_check_sign -f "$1" >/dev/null || return 74
+}

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -192,17 +192,38 @@ PART_NAME=firmware
 
 platform_check_image() {
 	local board=$(board_name)
-	local magic="$(get_magic_long "$1")"
 
 	[ "$#" -gt 1 ] && return 1
 
 	case "$board" in
+	abt,asr3000|\
 	asus,zenwifi-bt8-ubootmod|\
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\
 	bananapi,bpi-r4|\
 	bananapi,bpi-r4-poe|\
-	cmcc,rax3000m)
+	cmcc,a10-ubootmod|\
+	cmcc,rax3000m|\
+	gatonetworks,gdsp|\
+	h3c,magic-nx30-pro|\
+	jcg,q30-pro|\
+	jdcloud,re-cp-03|\
+	mediatek,mt7981-rfb|\
+	mediatek,mt7988a-rfb|\
+	mercusys,mr90x-v1-ubi|\
+	nokia,ea0326gmp|\
+	openwrt,one|\
+	netcore,n60|\
+	qihoo,360t7|\
+	routerich,ax3000-ubootmod|\
+	tplink,tl-xdr4288|\
+	tplink,tl-xdr6086|\
+	tplink,tl-xdr6088|\
+	tplink,tl-xtr8488|\
+	xiaomi,mi-router-ax3000t-ubootmod|\
+	xiaomi,redmi-router-ax6000-ubootmod|\
+	xiaomi,mi-router-wr30u-ubootmod|\
+	zyxel,ex5601-t0-ubootmod)
 		[ "$magic" != "d00dfeed" ] && {
 			echo "Invalid image type."
 			return 1

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -1,5 +1,5 @@
 REQUIRE_IMAGE_METADATA=1
-RAMFS_COPY_BIN='fitblk'
+RAMFS_COPY_BIN='fitblk fit_check_sign'
 
 asus_initial_setup()
 {
@@ -224,11 +224,8 @@ platform_check_image() {
 	xiaomi,redmi-router-ax6000-ubootmod|\
 	xiaomi,mi-router-wr30u-ubootmod|\
 	zyxel,ex5601-t0-ubootmod)
-		[ "$magic" != "d00dfeed" ] && {
-			echo "Invalid image type."
-			return 1
-		}
-		return 0
+		fit_check_image "$1"
+		return $?
 		;;
 	nradio,c8-668gl)
 		# tar magic `ustar`

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -1,5 +1,5 @@
 REQUIRE_IMAGE_METADATA=1
-RAMFS_COPY_BIN='fitblk'
+RAMFS_COPY_BIN='fitblk fit_check_sign'
 
 platform_do_upgrade() {
 	local board=$(board_name)

--- a/target/linux/mediatek/mt7623/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7623/base-files/lib/upgrade/platform.sh
@@ -1,5 +1,5 @@
 REQUIRE_IMAGE_METADATA=1
-RAMFS_COPY_BIN='fitblk'
+RAMFS_COPY_BIN='fitblk fit_check_sign'
 
 # Legacy full system upgrade including preloader for MediaTek SoCs on eMMC or SD
 legacy_mtk_mmc_full_upgrade() {

--- a/target/linux/siflower/sf21/base-files/lib/upgrade/platform.sh
+++ b/target/linux/siflower/sf21/base-files/lib/upgrade/platform.sh
@@ -1,5 +1,5 @@
 REQUIRE_IMAGE_METADATA=1
-RAMFS_COPY_BIN='fitblk'
+RAMFS_COPY_BIN='fitblk fit_check_sign'
 
 platform_do_upgrade() {
 	local board=$(board_name)
@@ -18,17 +18,13 @@ PART_NAME=firmware
 
 platform_check_image() {
 	local board=$(board_name)
-	local magic="$(get_magic_long "$1")"
 
 	[ "$#" -gt 1 ] && return 1
 
 	case "$board" in
 	*)
-		[ "$magic" != "d00dfeed" ] && {
-			echo "Invalid image type."
-			return 1
-		}
-		return 0
+		fit_check_image "$1"
+		return $?
 		;;
 	esac
 


### PR DESCRIPTION
Prevent flashing truncated or otherwise corrupted uImage.FIT images by verifying checksums and hashes of all sub-images before flashing using the newly packaged `fit_check_sign` tool.

Requires https://github.com/openwrt/openwrt/pull/18370 to be merged first.