### PR TITLE
qualcommax: ipq60xx: add support for Netgear WAX610 and WAX610Y

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
@@ -26,6 +26,8 @@ linksys,mr7500)
 	ubootenv_add_mtd "u_env" "0x0" "0x40000" "0x20000"
 	;;
 netgear,wax214|\
+netgear,wax610|\
+netgear,wax610y|\
 tplink,eap610-outdoor)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
 	;;

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -6,9 +6,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2025-02-17
-PKG_SOURCE_VERSION:=dd3577ec9f2d9d3ef5e35602d3fe731cb259ff39
-PKG_MIRROR_HASH:=0da921982b33a831dd19e570974a22ad2b1f3324397b1203a8a38d7d044b073a
+PKG_SOURCE_DATE:=2025-04-01
+PKG_SOURCE_VERSION:=c220fac7fdb35628ba53ff53ed36cf883a401161
+PKG_MIRROR_HASH:=26338b4f165eb2e90273cd61ed26715b99e496ccf738167e22ff9213ca42c973
 PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/package.mk
@@ -56,6 +56,8 @@ ALLWIFIBOARDS:= \
 	netgear_sxk80 \
 	netgear_wax214 \
 	netgear_wax218 \
+	netgear_wax610 \
+	netgear_wax610y \
 	netgear_wax620 \
 	netgear_wax630 \
 	prpl_haze \
@@ -171,7 +173,7 @@ endef
 # 2. Add $(eval $(call generate-ipq-wifi-package,<devicename>,<display name>))
 #
 # Board files should follow this name structure:
-#   board-<devicename>.<qca4019|qca9888|qca9889|qca9984|qca99x0|ipq8074>
+#   board-<devicename>.<qca4019|qca9888|qca9889|qca9984|qca99x0|ipq6018|ipq8074>
 
 $(eval $(call generate-ipq-wifi-package,8devices_mango,8devices Mango))
 $(eval $(call generate-ipq-wifi-package,aliyun_ap8220,Aliyun AP8220))
@@ -202,6 +204,8 @@ $(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))
 $(eval $(call generate-ipq-wifi-package,netgear_sxk80,Netgear SXK80))
 $(eval $(call generate-ipq-wifi-package,netgear_wax214,Netgear WAX214))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))
+$(eval $(call generate-ipq-wifi-package,netgear_wax610,Netgear WAX610))
+$(eval $(call generate-ipq-wifi-package,netgear_wax610y,Netgear WAX610Y))
 $(eval $(call generate-ipq-wifi-package,netgear_wax620,Netgear WAX620))
 $(eval $(call generate-ipq-wifi-package,netgear_wax630,Netgear WAX630))
 $(eval $(call generate-ipq-wifi-package,qihoo_360v6,Qihoo 360V6))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-wax610-base.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-wax610-base.dtsi
@@ -1,0 +1,206 @@
+#include "ipq6018.dtsi"
+#include "ipq6018-cp-cpu.dtsi"
+#include "ipq6018-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		serial0 = &blsp1_uart3;
+		ethernet0 = &dp5;
+		label-mac-device = &dp5;
+
+		led-boot = &led_system_blue;
+		led-failsafe = &led_system_orange;
+		led-running = &led_system_green;
+		led-upgrade = &led_system_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		/*
+		 * Netgear's U-Boot adds "ubi.mtd=rootfs root=mtd:ubi_rootfs"
+		 * That fails to create a UBI block device, so add it here.
+		*/
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_orange: system-orange {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_POWER;
+			function-enumerator = <0>;
+			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_system_green: system-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			function-enumerator = <1>;
+			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_system_blue: system-blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			function-enumerator = <2>;
+			gpios = <&tlmm 29 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_lan_g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <0>;
+			gpios = <&tlmm 30 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_lan_o {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_2g_b {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <0>;
+			gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_2g_g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <1>;
+			gpios = <&tlmm 33 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		led_5g_b {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <2>;
+			gpios = <&tlmm 36 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_5g_g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			function-enumerator = <3>;
+			gpios = <&tlmm 37 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+
+	switch_lan_bmp = <ESS_PORT5>;
+	switch_mac_mode1 = <MAC_MODE_SGMII_PLUS>;
+
+	qcom,port_phyinfo {
+		port@5 {
+			port_id = <5>;
+			phy_address = <24>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio64";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio65";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 77 GPIO_ACTIVE_LOW>;
+
+	qca8081_24: ethernet-phy@24 {
+		reg = <24>;
+	};
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8081_24>;
+	label = "lan";
+};
+
+&blsp1_uart3 {
+	pinctrl-0 = <&serial_3_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,m3-dump-addr = <0x50100000>;
+};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-wax610.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-wax610.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: (GPL-2.0+)
+
+/dts-v1/;
+
+#include "ipq6010-wax610-base.dtsi"
+
+/ {
+	model = "Netgear WAX610";
+	compatible = "netgear,wax610", "qcom,ipq6018";
+};
+
+&wifi {
+	qcom,ath11k-calibration-variant = "Netgear-WAX610";
+};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-wax610y.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-wax610y.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: (GPL-2.0+)
+
+/dts-v1/;
+
+#include "ipq6010-wax610-base.dtsi"
+
+/ {
+	model = "Netgear WAX610Y";
+	compatible = "netgear,wax610y", "qcom,ipq6018";
+};
+
+&wifi {
+	qcom,ath11k-calibration-variant = "Netgear-WAX610Y";
+};

--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -1,5 +1,15 @@
 DEVICE_VARS += TPLINK_SUPPORT_STRING
 
+define Build/wax610-netgear-tar
+	mkdir $@.tmp
+	mv $@ $@.tmp/nand-ipq6018-apps.img
+	md5sum $@.tmp/nand-ipq6018-apps.img | cut -c 1-32 > $@.tmp/nand-ipq6018-apps.md5sum
+	echo "WAX610" > $@.tmp/metadata.txt
+	echo "WAX610-610Y_V99.9.9.9" > $@.tmp/version
+ 	tar -C $@.tmp/ -cf $@ .
+	rm -rf $@.tmp
+endef
+
 define Device/8devices_mango-dvk
 	$(call Device/FitImageLzma)
 	DEVICE_VENDOR := 8devices
@@ -99,6 +109,32 @@ define Device/netgear_wax214
 	DEVICE_PACKAGES := ipq-wifi-netgear_wax214
 endef
 TARGET_DEVICES += netgear_wax214
+
+define Device/netgear_wax610-common
+	$(call Device/FitImage)
+	DEVICE_VENDOR := Netgear
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_DTS_CONFIG := config@cp03-c1
+	SOC := ipq6010
+	KERNEL_IN_UBI := 1
+	IMAGES += ui-factory.tar
+	IMAGE/ui-factory.tar := append-ubi | qsdk-ipq-factory-nand | pad-to 4096 | wax610-netgear-tar
+endef
+
+define Device/netgear_wax610
+	$(Device/netgear_wax610-common)
+	DEVICE_MODEL := WAX610
+	DEVICE_PACKAGES := ipq-wifi-netgear_wax610
+endef
+TARGET_DEVICES += netgear_wax610
+
+define Device/netgear_wax610y
+	$(Device/netgear_wax610-common)
+	DEVICE_MODEL := WAX610Y
+	DEVICE_PACKAGES := ipq-wifi-netgear_wax610y
+endef
+TARGET_DEVICES += netgear_wax610y
 
 define Device/qihoo_360v6
 	$(call Device/FitImage)

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
@@ -30,6 +30,8 @@ ipq60xx_setup_interfaces()
 	qihoo,360v6)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
+	netgear,wax610|\
+	netgear,wax610y|\
 	tplink,eap610-outdoor)
 		ucidef_set_interface_lan "lan" "dhcp"
 		;;

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -35,6 +35,14 @@ case "$FIRMWARE" in
 	netgear,wax214)
 		caldata_extract "0:art" 0x1000 0x10000
 		;;
+	netgear,wax610|\
+	netgear,wax610y)
+		caldata_extract "0:art" 0x1000 0x10000
+		label_mac=$(get_mac_label)
+		ath11k_patch_mac $(macaddr_add $label_mac -30) 1
+		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
+		ath11k_set_macflag
+		;;
 	qihoo,360v6)
 		caldata_extract "0:art" 0x1000 0x10000
 		label_mac=$(mtd_get_mac_ascii factory lanMac)

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/init.d/bootcount
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/init.d/bootcount
@@ -11,5 +11,9 @@ boot() {
 	yuncore,fap650)
 		fw_setenv owrt_bootcount 0
 	;;
+	netgear,wax610|\
+	netgear,wax610y)
+		fw_setenv boot_count 0
+	;;
 	esac
 }

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
@@ -113,6 +113,8 @@ platform_do_upgrade() {
 	glinet,gl-ax1800|\
 	glinet,gl-axt1800|\
 	netgear,wax214|\
+	netgear,wax610|\
+	netgear,wax610y|\
 	qihoo,360v6)
 		nand_do_upgrade "$1"
 		;;


### PR DESCRIPTION
Support depends on https://github.com/openwrt/firmware_qca-wireless/pull/73

Did not have a real WAX610Y on hand to test. Those builds were tested on the WAX610.

Netgear WAX610 / WAX610Y is a 802.11ax AP claiming AX1800 support.

Specifications:
---------------
* CPU: Qualcomm IPQ6018 Quad core Cortex-A53
* RAM: 512MB
* Storage: Winbond W29N01HZBINF 128MB NAND
* Ethernet:
  * 2.5GbE RJ45 port with PoE input
* WLAN:
  * 2.4GHz/5GHz
* LEDs:
  * Power: Dual-color LED (Green / Orange), Single-color LED (Blue)
  * Ethernet: Dual-color LED (Green / Orange)
  * 2.4Ghz WiFi: 2x Single-color LED (Blue, Green)
  * 5Ghz WiFi: 2x Single-color LED (Blue, Green)
* Buttons:
  * 1x Reset
* UART: 4-pin populated header
  * Pinout 1 - VCC, 2 - GND, 3 - TX, 4 - RX

Installation:
=============

Web UI method
-------------

Set up the device using the stock web UI in local management mode.

Download the ui-factory.tar image.
 * Enter the Management tab
 * Select Maintenance->Upgrade->Firmware Upgrade
 * Ensure the "Upgrade Options" field has "Local" selected
 * Click "Browse File" and select the image
 * Click "Upgrade" (NOT "Upgrade Now") at the bottom of the page

The device will install the image but reboot back into the vendor firmware. Return the to Firmware Upgrade page as above and select "Boot up Backup Firmware". The device should reboot into OpenWRT.

TFTP method
-----------

To flash via tftp, first place the initramfs image on the TFTP server.

    setenv serverip <ip of tftp server>
    setenv ipaddr <ip in same subnet as tftp server>
    tftpboot netgear_wax610-initramfs-uImage.itb
    bootm

This should boot OpenWRT. Once booted, flash the sysupgrade.bin image using either luci or the command line.
