### PR TITLE
realtek: add support for D-Link DGS-1210-26

### DIFF
--- a/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-26.dts
+++ b/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-26.dts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl838x.dtsi"
+#include "rtl83xx_d-link_dgs-1210_common.dtsi"
+#include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
+
+/ {
+	compatible = "d-link,dgs-1210-26", "realtek,rtl838x-soc";
+	model = "D-Link DGS-1210-26";
+
+	/* Left SFP slot, port 25 */
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p25 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* Right SFP slot, port 26 */
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		EXTERNAL_PHY(0)
+		EXTERNAL_PHY(1)
+		EXTERNAL_PHY(2)
+		EXTERNAL_PHY(3)
+		EXTERNAL_PHY(4)
+		EXTERNAL_PHY(5)
+		EXTERNAL_PHY(6)
+		EXTERNAL_PHY(7)
+
+		INTERNAL_PHY(8)
+		INTERNAL_PHY(9)
+		INTERNAL_PHY(10)
+		INTERNAL_PHY(11)
+		INTERNAL_PHY(12)
+		INTERNAL_PHY(13)
+		INTERNAL_PHY(14)
+		INTERNAL_PHY(15)
+
+		EXTERNAL_PHY(16)
+		EXTERNAL_PHY(17)
+		EXTERNAL_PHY(18)
+		EXTERNAL_PHY(19)
+		EXTERNAL_PHY(20)
+		EXTERNAL_PHY(21)
+		EXTERNAL_PHY(22)
+		EXTERNAL_PHY(23)
+
+		INTERNAL_PHY(24)
+		INTERNAL_PHY(26)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+
+		port@24 {
+			reg = <24>;
+			label = "lan25";
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp0>;
+		};
+
+		port@26 {
+			reg = <26>;
+			label = "lan26";
+			phy-mode = "1000base-x";
+			managed = "in-band-status";
+			sfp = <&sfp1>;
+		};
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -59,6 +59,13 @@ define Device/d-link_dgs-1210-20
 endef
 TARGET_DEVICES += d-link_dgs-1210-20
 
+define Device/d-link_dgs-1210-26
+  $(Device/d-link_dgs-1210)
+  SOC := rtl8382
+  DEVICE_MODEL := DGS-1210-26
+endef
+TARGET_DEVICES += d-link_dgs-1210-26
+
 define Device/d-link_dgs-1210-28
   $(Device/d-link_dgs-1210)
   SOC := rtl8382


### PR DESCRIPTION
This patch adds support for D-Link DGS-1210-26 rev. F1

Hardware specification
----------------------

* RTL8382M SoC, 1 MIPS 4KEc core @ 500MHz
* 128MB DRAM
* 32MB NOR Flash (MX25L25635E)
* 24 x 10/100/1000BASE-T ports
* 2 x SFP ports
* Power LED
* Reset button on front panel

Installation using OEM webinterface
-----------------------------------

1. Make sure you are running OEM firmware from secondary slot. If not, switch to image2 using the menus
     System > Firmware Information > Boot from image2
     Tools > reboot
2. Upload image squashfs-factory_image1.bin via Tools > Backup / Upgrade Firmware > image1
3. Toogle startup image via System > Firmware Information > Boot from image1
4. Tools > reboot

Known working firmware version for this procedure: 6.20.007

Installation using TFTP and serial console
------------------------------------------

1. Prepare a TFTP server with the OpenWrt *initramfs-kernel.bin and assign it an IP from 10.90.90.0/24 (except 10.90.90.90)
2. Connect the TFTP server to one of switch's ports
3. Connect to the serial console (115200 baud) and power on the switch
4. Press the ESC key once you see `Hit Esc key to stop autoboot` in the console output
5. Press CTRL+C keys to get into the real U-Boot prompt
6. Init the network with the command `rtk network on`
7. Load the OpenWrt image with the command `tftpboot 0x8f000000 <TFTP_SERVER_IP>:<IMAGE_FILE>`
   (<TFTP_SERVER_IP> is the TFTP server's IP, e.g. 10.90.90.100; <IMAGE_FILE> is the name of the image provided by the TFTP server)
8. Boot the OpenWrt image with the command `bootm`
9. Browse to https://192.168.1.1/cgi-bin/luci/admin/system/flash
10. Upload the the OpenWrt *squashfs-sysupgrade.bin to the switch
11. Wait for it to reboot