### PR TITLE
rampis: revert fix tplink_mr200v1 wan interface

### DIFF
--- a/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7620/base-files/etc/board.d/02_network
@@ -247,7 +247,7 @@ ramips_setup_interfaces()
 	tplink,archer-mr200)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "6t@eth0"
-		ucidef_set_interface_wan "eth1"
+		ucidef_set_interface_wan "usb0"
 		;;
 	tplink,ec220-g5-v2)
 		ucidef_add_switch "switch0"


### PR DESCRIPTION
This reverts commit 7aa3dfdbda829c04475cffbd6708f1ff96e4849b. As the kernel is now fixed with https://github.com/openwrt/openwrt/commit/ecd609f509f29ed1f75db5c7a623f359c64efb72
