### PR TITLE
ramips: add RUT200 and RUT241 support

### DIFF
--- a/target/linux/ramips/dts/mt7628an_teltonika_rut200.dts
+++ b/target/linux/ramips/dts/mt7628an_teltonika_rut200.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_teltonika_rut2xx.dtsi"
+
+/ {
+	//hardware version up to 4
+	compatible = "teltonika,rut200", "mediatek,mt7628an-soc";
+	model = "Teltonika RUT200";
+};

--- a/target/linux/ramips/dts/mt7628an_teltonika_rut241.dts
+++ b/target/linux/ramips/dts/mt7628an_teltonika_rut241.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_teltonika_rut2xx.dtsi"
+
+/ {
+	//hardware version up to 4
+	compatible = "teltonika,rut241", "mediatek,mt7628an-soc";
+	model = "Teltonika RUT241";
+};

--- a/target/linux/ramips/dts/mt7628an_teltonika_rut2xx.dtsi
+++ b/target/linux/ramips/dts/mt7628an_teltonika_rut2xx.dtsi
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include "mt7628an.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		led-boot = &rssi1;
+		led-failsafe = &rssi1;
+		led-upgrade = &rssi1;
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_modem_reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <0>;
+			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_modem_power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <0>;
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_din {
+			gpio-export,name = "digital_input";
+			gpio-export,input = <0>;
+			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_dout {
+			gpio-export,name = "digital_output";
+			gpio-export,output = <0>;
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		modem_2g {
+			gpios = <&gpio 39 GPIO_ACTIVE_HIGH>;
+			label = "green:modem-2g";
+		};
+
+		modem_3g {
+			gpios = <&gpio 40 GPIO_ACTIVE_HIGH>;
+			label = "green:modem-3g";
+		};
+
+		modem_4g {
+			gpios = <&gpio 41 GPIO_ACTIVE_HIGH>;
+			label = "green:modem-4g";
+		};
+
+		rssi1: rssi1 {
+			gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+			label = "green:rssi-1";
+		};
+
+		rssi2 {
+			gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
+			label = "green:rssi-2";
+		};
+
+		rssi3 {
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+			label = "green:rssi-3";
+		};
+
+		rssi4 {
+			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+			label = "green:rssi-4";
+		};
+
+		rssi5 {
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			label = "green:rssi-5";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "config";
+				reg = <0x020000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_0: macaddr@0 {
+						reg = <0x0 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@30000 {
+				label = "factory";
+				reg = <0x030000 0x030000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x20000 0x400>;
+					};
+				};
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x060000 0xf10000>;
+			};
+
+			partition@f70000 {
+				label = "event-log";
+				reg = <0xf70000 0x90000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "uart1", "p4led_an", "p3led_an", "p2led_an", "p1led_an", "p0led_an", "gpio", "wled_an", "perst", "spi cs1";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_config_0 2>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_config_0 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1256,6 +1256,19 @@ define Device/zyxel_keenetic-extra-ii
 endef
 TARGET_DEVICES += zyxel_keenetic-extra-ii
 
+define Device/teltonika_rut200
+  DEVICE_VENDOR := Teltonika
+  DEVICE_MODEL := RUT200
+  DEVICE_VARIANT := v1-v4
+  IMAGE_SIZE := 15424k
+  BLOCKSIZE := 64k
+  DEVICE_PACKAGES +=kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-serial-option kmod-usb-net-cdc-ether
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-teltonika-metadata rut2m
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+TARGET_DEVICES += teltonika_rut200
+
 define Device/teltonika_rut241
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT241

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -28,6 +28,22 @@ define Build/ravpower-wd009-factory
 	@mv $@.new $@
 endef
 
+define Build/append-teltonika-metadata
+  $(eval model_id=$(1))
+	echo \
+		'{ \
+			"metadata_version": "1.1", \
+			"compat_version": "1.0", \
+			"version": "", \
+			"device_code": [".*"], \
+			"hwver": [".*"], \
+			"batch": [".*"], \
+			"serial": [".*"], \
+			"supported_devices":["teltonika,$(model_id)"], \
+			"hw_support": { }, \
+			"hw_mods": { } \
+		}' | fwtool -I - $@
+endef
 
 define Device/7links_wlr-12xx
   IMAGE_SIZE := 7872k
@@ -1239,3 +1255,16 @@ define Device/zyxel_keenetic-extra-ii
 	check-size | zyimage -d 6162 -v "ZyXEL Keenetic Extra II"
 endef
 TARGET_DEVICES += zyxel_keenetic-extra-ii
+
+define Device/teltonika_rut241
+  DEVICE_VENDOR := Teltonika
+  DEVICE_MODEL := RUT241
+  DEVICE_VARIANT := v1-v4
+  IMAGE_SIZE := 15424k
+  BLOCKSIZE := 64k
+  DEVICE_PACKAGES += uqmi kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-serial-option
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-teltonika-metadata rut2m
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+TARGET_DEVICES += teltonika_rut241

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -76,6 +76,10 @@ tama,w06)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
+teltonika,rut241)
+	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x02"
+	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
+	;;
 tplink,archer-c20-v4|\
 tplink,archer-c20-v5|\
 tplink,tl-wr850n-v2)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -76,6 +76,7 @@ tama,w06)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
+teltonika,rut200|\
 teltonika,rut241)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x02"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -108,7 +108,8 @@ ramips_setup_interfaces()
 			"2:lan:2" "3:lan:1" "4:wan" "6@eth0"
 		;;
 	duzun,dm06|\
-	glinet,gl-mt300n-v2)
+	glinet,gl-mt300n-v2|\
+	teltonika,rut241)
 		ucidef_add_switch "switch0" \
 			"1:lan" "0:wan" "6@eth0"
 		;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -109,6 +109,7 @@ ramips_setup_interfaces()
 		;;
 	duzun,dm06|\
 	glinet,gl-mt300n-v2|\
+	teltonika,rut200|\
 	teltonika,rut241)
 		ucidef_add_switch "switch0" \
 			"1:lan" "0:wan" "6@eth0"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2025 OpenWrt.org
+#
+
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+
+case "$board" in
+teltonika,rut241)
+	ucidef_add_gpio_switch "digital_output" "Digital output" "digital_output" "0"
+	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "1"
+	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
@@ -9,6 +9,7 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+teltonika,rut200|\
 teltonika,rut241)
 	ucidef_add_gpio_switch "digital_output" "Digital output" "digital_output" "0"
 	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "1"


### PR DESCRIPTION
This pull request add support for RUT200 and RUT241.
Boards are the same just modems differ.

Specs:
    SoC: MediaTek MT7628AN
    RAM: 128 MB EtronTech EM68C16CWQG-25IH
    Flash: 16MB Winbond W25Q128 SPI
    Switch: MediaTek MT7628AN, 2 ports 100 Mbps
    WiFi: MediaTek MT7628AN 2.4 GHz 802.11n
    Modem: MeigLink SLM750 or Quectel EC25xx for RUT241 and Meiglink SLM770 or Quectel EC200A for RUT200
    GPIO: 1 button (Reset), 8 LEDs (2G, 3G, 4G, RSSI 1,2,3,4,5), 2 Modem control (power button, reset), 1 Digital input, 1 Digital output
