### PR TITLE
ipq60xx: add support for TP-Link EAP623-Outdoor HD v1

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
@@ -28,7 +28,8 @@ linksys,mr7500)
 netgear,wax214|\
 netgear,wax610|\
 netgear,wax610y|\
-tplink,eap610-outdoor)
+tplink,eap610-outdoor|\
+tplink,eap623od-hd-v1)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
 	;;
 yuncore,fap650)

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -68,6 +68,7 @@ ALLWIFIBOARDS:= \
 	spectrum_sax1v1k \
 	tplink_eap610-outdoor \
 	tplink_eap620hd-v1 \
+	tplink_eap623od-hd-v1 \
 	tplink_eap660hd-v1 \
 	wallys_dr40x9 \
 	xiaomi_ax3600 \
@@ -216,6 +217,7 @@ $(eval $(call generate-ipq-wifi-package,skspruce_wia3300-20,SKSpruce WIA3300-20)
 $(eval $(call generate-ipq-wifi-package,spectrum_sax1v1k,Spectrum SAX1V1K))
 $(eval $(call generate-ipq-wifi-package,tplink_eap610-outdoor,TPLink EAP610-Outdoor))
 $(eval $(call generate-ipq-wifi-package,tplink_eap620hd-v1,TP-Link EAP620 HD v1))
+$(eval $(call generate-ipq-wifi-package,tplink_eap623od-hd-v1,TP-Link EAP623-Outdoor HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap660hd-v1,TP-Link EAP660 HD v1))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-eap623od-hd-v1.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-eap623od-hd-v1.dts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT, GPL-2.0 or later
+/* Copyright (c) 2025, Yang Xiwen <forbidden405@outlook.com> */
+
+/dts-v1/;
+
+#include "ipq6018.dtsi"
+#include "ipq6018-cp-cpu.dtsi"
+#include "ipq6018-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "TP-Link EAP623-Outdoor HD V1.0";
+	compatible = "tplink,eap623od-hd-v1", "qcom,ipq6018";
+
+	aliases {
+		serial0 = &blsp1_uart3;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 37 GPIO_ACTIVE_HIGH>;
+		};
+
+		wlan {
+			color = <LED_COLOR_ID_YELLOW>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&blsp1_uart3 {
+	pinctrl-0 = <&serial_3_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio64";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio65";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	phy_pins: phy-reset-pin {
+		pins = "gpio77";
+		function = "gpio";
+		bias-pull-up;
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+
+	rtl8211f: ethernet-phy@4 {
+		compatible = "ethernet-phy-id001c.c916";
+		reg = <4>;
+		reset-gpios = <&tlmm 77 GPIO_ACTIVE_LOW>;
+		pinctrl-0 = <&phy_pins>;
+		pinctrl-names = "default";
+
+		realtek,clkout-disable;
+		realtek,aldps-enable;
+	};
+};
+
+&switch {
+	status = "okay";
+	switch_lan_bmp = <ESS_PORT5>; /* lan port bitmap */
+	switch_mac_mode1 = <MAC_MODE_SGMII_PLUS>; /* mac mode for uniphy instance0*/
+
+	qcom,port_phyinfo {
+		port@5 {
+			port_id = <5>;
+			phy_address = <4>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&rtl8211f>;
+	phy-mode = "sgmii";
+	label = "lan";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&wifi {
+	qcom,ath11k-calibration-variant = "TPLink-EAP623-Outdoor-HD-v1";
+	status = "okay";
+};

--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -167,6 +167,22 @@ define Device/tplink_eap610-outdoor
 endef
 TARGET_DEVICES += tplink_eap610-outdoor
 
+define Device/tplink_eap623od-hd-v1
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := TP-Link
+	DEVICE_MODEL := EAP623-Outdoor HD
+	DEVICE_VARIANT := v1
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq6018
+	DEVICE_PACKAGES := ipq-wifi-tplink_eap623od-hd-v1 kmod-phy-realtek
+	IMAGES += web-ui-factory.bin
+	IMAGE/web-ui-factory.bin := append-ubi | tplink-image-2022
+	TPLINK_SUPPORT_STRING := SupportList:\r\nEAP623-Outdoor HD(TP-Link|UN|AX1800-D):1.0\r\n
+endef
+TARGET_DEVICES += tplink_eap623od-hd-v1
+
 define Device/yuncore_fap650
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
@@ -32,7 +32,8 @@ ipq60xx_setup_interfaces()
 		;;
 	netgear,wax610|\
 	netgear,wax610y|\
-	tplink,eap610-outdoor)
+	tplink,eap610-outdoor|\
+	tplink,eap623od-hd-v1)
 		ucidef_set_interface_lan "lan" "dhcp"
 		;;
 	*)
@@ -54,7 +55,8 @@ ipq60xx_setup_macs()
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		label_mac=$lan_mac
 		;;
-	tplink,eap610-outdoor)
+	tplink,eap610-outdoor|\
+	tplink,eap623od-hd-v1)
 		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
 		lan_mac=$label_mac
 		;;

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -50,7 +50,8 @@ case "$FIRMWARE" in
 		ath11k_patch_mac $(macaddr_add $label_mac 2) 1
 		ath11k_set_macflag
 		;;
-	tplink,eap610-outdoor)
+	tplink,eap610-outdoor|\
+	tplink,eap623od-hd-v1)
 		caldata_from_file "/tmp/factory_data/radio" 0 0x10000
 		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
 		ath11k_patch_mac $label_mac 1

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/preinit/09_mount_factory_data
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/preinit/09_mount_factory_data
@@ -7,7 +7,8 @@ preinit_mount_factory_data() {
 	. /lib/functions/system.sh
 
 	case $(board_name) in
-	tplink,eap610-outdoor)
+	tplink,eap610-outdoor|\
+	tplink,eap623od-hd-v1)
 		mtd_path=$(find_mtd_chardev "factory_data")
 		ubiattach --dev-path="$mtd_path" --devn=1
 		mkdir /tmp/factory_data

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
@@ -133,7 +133,8 @@ platform_do_upgrade() {
 		fw_setenv auto_recovery yes
 		nand_do_upgrade "$1"
 		;;
-	tplink,eap610-outdoor)
+	tplink,eap610-outdoor|\
+	tplink,eap623od-hd-v1)
 		tplink_do_upgrade "$1"
 		;;
 	yuncore,fap650)


### PR DESCRIPTION
Specifications:
* SoC: Qualcomm IPQ6018 (64-bit Quad-core Arm Cortex-A53 @ 1800MHz)
* Memory: 1 GiB
* Serial Port: 3v3 TTL 115200n8
* Wi-Fi: QCN9074 (4x4 5 GHz 802.11ax)
* Wi-Fi: IPQ6018 (4x4 2.4 GHz 802.11b/g/n/ax)
* Ethernet: RTL8211F (10/100/1GBASE-T)
* Flash: ESMT F59D1G81MB (128 MiB)
* LEDs: 1x Green Status (GPIO 37 Active High), 1x Yellow Status (GPIO 32 Active High) and an LED global control GPIO (GPIO 36 Active High, set up by U-Boot)
* Buttons: 1x Reset (GPIO 9 Active Low)

Installation Instructions (Serial+TFTP):
1. Solder 4 pin header to the pads near T32 and T31.
2. Connect 3V3 TTL port to TX, RX, and GND, which are pad T31, T32 and the pad near T31 respectively. Be sure not to connect VCC and crossover TX and RX.
3. Copy RAM firmware image openwrt-qualcommax-ipq60xx-tplink_eap623od-hd-v1-initramfs-uImage.itb to TFTP server root, available at 192.168.0.1.
4. Connect PoE ethernet cable to the RJ45 port and hold Ctrl+B in the serial console (115200 baud) until autoboot is halted.
5. Run the following commands in the U-boot prompt: # setenv serverip 192.168.0.1 # setenv ipaddr 192.168.0.99 # tftpboot 0x44000000 openwrt-qualcommax-ipq60xx-tplink_eap623od-hd-v1-initramfs-uImage.itb # bootm You may need to type Ctrl+C and Enter before running these commands to clear invisible characters from the buffer.
6. Run the following command in a terminal to copy the sysupgrade image to be installed (check IP address): $ scp openwrt-qualcommax-ipq60xx-tplink_eap623od-hd-v1-squashfs-sysupgrade.bin root@192.168.1.1:/tmp/
7. Activate the OpenWrt serial console and run the following commands: # cd /tmp # sysupgrade -n openwrt-qualcommax-ipq60xx-tplink_eap623od-hd-v1-squashfs-sysupgrade.bin
8. The AP will reboot and OpenWrt will be successfully installed.

bdf change: https://github.com/openwrt/firmware_qca-wireless/pull/78

The makefile seems somehow broken. Only `make -j1 world` can generate a complete itb for booting from tftp, `make -j12` won't work.