### PR TITLE
libxml2: hostbuild: provide headers in $(STAGING_DIR_HOSTPKG)/include…

### DIFF
--- a/package/libs/libxml2/Makefile
+++ b/package/libs/libxml2/Makefile
@@ -169,6 +169,7 @@ define Host/Install
 	$(call Host/Install/Default)
 	mv $(1)/bin/xml2-config $(1)/bin/$(GNU_HOST_NAME)-xml2-config
 	$(LN) $(GNU_HOST_NAME)-xml2-config $(1)/bin/xml2-config
+	$(LN) -r $(1)/include/libxml2/libxml $(1)/include/libxml
 endef
 
 define Package/libxml2/install


### PR DESCRIPTION
Currently the header files of libxml2 package can be found under STAGING_DIR_HOSTPKG/include/libxml2/libxml. However, packages look for libxml header files under STAGING_DIR_HOSTPKG/include/libxml.

On a target build, header files can already be found under STAGING_DIR/usr/include/libxml.

@hauke @PolynomialDivision 