### PR TITLE
ath79: dts: disable redundant built-in watchdog

### DIFF
--- a/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
+++ b/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
@@ -177,3 +177,7 @@
 		gpio-controller;
 	};
 };
+
+&wdt {
+	status = "disabled";
+};

--- a/target/linux/ath79/dts/ar9330_openmesh_om2p.dtsi
+++ b/target/linux/ath79/dts/ar9330_openmesh_om2p.dtsi
@@ -163,6 +163,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/ar9341_openmesh_om2p-hs.dtsi
+++ b/target/linux/ath79/dts/ar9341_openmesh_om2p-hs.dtsi
@@ -173,6 +173,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
+++ b/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
@@ -166,6 +166,10 @@
 	};
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/ar9344_openmesh_mr600-v2.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_mr600-v2.dts
@@ -73,3 +73,7 @@
 		always-running;
 	};
 };
+
+&wdt {
+	status = "disabled";
+};

--- a/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
@@ -218,6 +218,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/ar9344_openmesh_om5p.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_om5p.dts
@@ -178,6 +178,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
+++ b/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
@@ -62,6 +62,9 @@
 	
 	watchdog {
 		compatible = "linux,wdt-gpio";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&enable_gpio21>;
 		gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
 		hw_algo = "toggle";
 		hw_margin_ms = <30000>;
@@ -70,10 +73,7 @@
 };
 
 &wdt {
-	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&enable_gpio21>;
+	status = "disabled";
 };
 
 &gpio {

--- a/target/linux/ath79/dts/qca9531_8dev_carambola3.dts
+++ b/target/linux/ath79/dts/qca9531_8dev_carambola3.dts
@@ -41,10 +41,6 @@
 	status = "okay";
 };
 
-&wdt {
-	status = "okay";
-};
-
 &spi {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9531_8dev_lima.dts
+++ b/target/linux/ath79/dts/qca9531_8dev_lima.dts
@@ -32,10 +32,6 @@
 	status = "okay";
 };
 
-&wdt {
-	status = "okay";
-};
-
 &spi {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
+++ b/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
@@ -121,6 +121,10 @@
 	status = "okay";
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e560ac.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e560ac.dts
@@ -182,6 +182,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-ew71-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-ew71-v2.dts
@@ -138,6 +138,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-ew72.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-ew72.dts
@@ -149,6 +149,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9531_engenius_ews511ap.dts
+++ b/target/linux/ath79/dts/qca9531_engenius_ews511ap.dts
@@ -75,7 +75,7 @@
 };
 
 &wdt {
-	status = "okay";
+	status = "disabled";
 };
 
 &rst {

--- a/target/linux/ath79/dts/qca9533_openmesh_om2p-v4.dtsi
+++ b/target/linux/ath79/dts/qca9533_openmesh_om2p-v4.dtsi
@@ -170,6 +170,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9533_plasmacloud_pa300.dtsi
+++ b/target/linux/ath79/dts/qca9533_plasmacloud_pa300.dtsi
@@ -148,6 +148,10 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9558_comfast_cf-e380ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-e380ac-v2.dts
@@ -149,7 +149,7 @@
 };
 
 &wdt {
-	status = "okay";
+	status = "disabled";
 };
 
 &wmac {

--- a/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac.dtsi
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac.dtsi
@@ -104,6 +104,10 @@
 	};
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 };

--- a/target/linux/ath79/dts/qca9558_devolo_dvl1xxx.dtsi
+++ b/target/linux/ath79/dts/qca9558_devolo_dvl1xxx.dtsi
@@ -137,6 +137,10 @@
 	};
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
+++ b/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
@@ -210,6 +210,10 @@
 	};
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
+++ b/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
@@ -194,6 +194,10 @@
 	phy-handle = <&phy2>;
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9558_openmesh_mr.dtsi
+++ b/target/linux/ath79/dts/qca9558_openmesh_mr.dtsi
@@ -175,6 +175,10 @@
 	};
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v1.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v1.dts
@@ -213,6 +213,10 @@
 	phy-handle = <&phy2>;
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
@@ -252,6 +252,10 @@
 	phy-handle = <&phy1>;
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 

--- a/target/linux/ath79/dts/qca9563_comfast_cf-e375ac.dts
+++ b/target/linux/ath79/dts/qca9563_comfast_cf-e375ac.dts
@@ -157,6 +157,10 @@
 	phy-handle = <&phy0>;
 };
 
+&wdt {
+	status = "disabled";
+};
+
 &wmac {
 	status = "okay";
 


### PR DESCRIPTION
The built-in watchdog is redundant when the device has an external GPIO based hardware watchdog. And there is a conflict that both of them will attempt to register the same device entry in sysfs. This resulted in the built-in watchdog being unable to be activated. This patch explicitly disables the built-in watchdog for devices that use GPIO watchdog to fix the error:

[    1.779206] ath79-wdt 18060008.wdt: unable to register misc device, err=-16
[    1.786355] ath79-wdt: probe of 18060008.wdt failed with error -16