### PR TITLE
at91: add USB kmods only for subtargets that support USB

### DIFF
--- a/target/linux/at91/Makefile
+++ b/target/linux/at91/Makefile
@@ -16,6 +16,4 @@ include $(INCLUDE_DIR)/target.mk
 
 KERNELNAME:=zImage dtbs
 
-DEFAULT_PACKAGES += kmod-usb-ohci kmod-at91-udc kmod-usb-gadget-eth
-
 $(eval $(call BuildTarget))

--- a/target/linux/at91/sam9x/target.mk
+++ b/target/linux/at91/sam9x/target.mk
@@ -1,6 +1,8 @@
 BOARDNAME:= SAM9X Boards (ARMv5)
 CPU_TYPE:=arm926ej-s
 
+DEFAULT_PACKAGES += kmod-usb-ohci kmod-at91-udc kmod-usb-gadget-eth
+
 define Target/Description
 	Build generic firmware for Microchip AT91 SAM9x platforms
 	using the ARMv5 instruction set.

--- a/target/linux/at91/sama5/target.mk
+++ b/target/linux/at91/sama5/target.mk
@@ -2,7 +2,7 @@ BOARDNAME:=SAMA5 boards(Cortex-A5)
 CPU_TYPE:=cortex-a5
 CPU_SUBTYPE:=vfpv4
 FEATURES+=fpu
-DEFAULT_PACKAGES += kmod-usb2
+DEFAULT_PACKAGES += kmod-usb2 kmod-usb-ohci kmod-at91-udc kmod-usb-gadget-eth
 
 define Target/Description
 	Build generic firmware for Microchip(Atmel AT91) SAMA5D2,


### PR DESCRIPTION
Currently, kmod-usb-ohci,kmod-at91-udc and kmod-usb-gadget-eth are included as the default packages for all at91 subtargets.

However, this is breaking image builder as kmod-at91-udc is not being built on sama7 since it depends on USB_SUPPORT and sama7 does not have USB support enabled in the kernel as its not supported upstream so its not even selectable in the config.

So, move to include these as default packages only for sama5 and sama9x as both of those have USB support enabled.

Fixes: #18407 
