### PR TITLE
at91: fix building in imagebuilder

### DIFF
--- a/package/boot/at91bootstrap/Makefile
+++ b/package/boot/at91bootstrap/Makefile
@@ -201,4 +201,9 @@ define Build/Compile
 		CROSS_COMPILE=$(TARGET_CROSS)
 endef
 
+define Build/InstallDev
+	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/$(BINARIES_DIR)/at91bootstrap.bin $(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-at91bootstrap.bin
+endef
+
 $(eval $(call BuildPackage/AT91Bootstrap))

--- a/package/boot/uboot-at91/Makefile
+++ b/package/boot/uboot-at91/Makefile
@@ -179,4 +179,9 @@ define Build/Compile
 		$(UBOOT_MAKE_FLAGS)
 endef
 
+define Build/InstallDev
+	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/$(UBOOT_IMAGE) $(STAGING_DIR_IMAGE)/$(BUILD_VARIANT)-$(UBOOT_IMAGE)
+endef
+
 $(eval $(call BuildPackage/U-Boot))

--- a/target/linux/at91/image/sam9x.mk
+++ b/target/linux/at91/image/sam9x.mk
@@ -20,7 +20,7 @@ define Build/at91-sdcard
 	::u-boot.bin
 
   mcopy -i $@.boot \
-	$(BIN_DIR)/at91bootstrap-$(if $(findstring sam9x60,$@),$(DEVICE_DTS:at91-%=%),at91sam9x5ek)sd_uboot/at91bootstrap.bin \
+	$(STAGING_DIR_IMAGE)/$(if $(findstring sam9x60,$@),$(DEVICE_DTS:at91-%=%),at91sam9x5ek)sd_uboot-at91bootstrap.bin \
 	::BOOT.bin
 
   $(CP) uboot-env.txt $@-uboot-env.txt

--- a/target/linux/at91/image/sam9x.mk
+++ b/target/linux/at91/image/sam9x.mk
@@ -16,7 +16,7 @@ define Build/at91-sdcard
 	::$(DEVICE_NAME)-fit.itb
 
   mcopy -i $@.boot \
-	$(BIN_DIR)/u-boot-$(if $(findstring sam9x60,$@),$(DEVICE_DTS:at91-%=%),at91sam9x5ek)_mmc/u-boot.bin \
+	$(STAGING_DIR_IMAGE)/$(if $(findstring sam9x60,$@),$(DEVICE_DTS:at91-%=%),at91sam9x5ek)_mmc-u-boot.bin \
 	::u-boot.bin
 
   mcopy -i $@.boot \

--- a/target/linux/at91/image/sama5.mk
+++ b/target/linux/at91/image/sama5.mk
@@ -21,10 +21,10 @@ define Build/at91-sdcard
 
   $(if $(findstring sama5d4-xplained,$@), \
 	  mcopy -i $@.boot \
-              $(BIN_DIR)/at91bootstrap-$(DEVICE_DTS:at91-%=%)sd_uboot_secure/at91bootstrap.bin \
+              $(STAGING_DIR_IMAGE)/$(DEVICE_DTS:at91-%=%)sd_uboot_secure-at91bootstrap.bin \
               ::BOOT.bin,
           mcopy -i $@.boot \
-              $(BIN_DIR)/at91bootstrap-$(DEVICE_DTS:at91-%=%)sd_uboot/at91bootstrap.bin \
+              $(STAGING_DIR_IMAGE)/$(DEVICE_DTS:at91-%=%)sd_uboot-at91bootstrap.bin \
               ::BOOT.bin)
 
   $(CP) uboot-env.txt $@-uboot-env.txt

--- a/target/linux/at91/image/sama5.mk
+++ b/target/linux/at91/image/sama5.mk
@@ -16,7 +16,7 @@ define Build/at91-sdcard
 	::$(DEVICE_NAME)-fit.itb
 
   mcopy -i $@.boot \
-	$(BIN_DIR)/u-boot-$(DEVICE_DTS:at91-%=%)_mmc/u-boot.bin \
+	$(STAGING_DIR_IMAGE)/$(DEVICE_DTS:at91-%=%)_mmc-u-boot.bin \
 	::u-boot.bin
 
   $(if $(findstring sama5d4-xplained,$@), \

--- a/target/linux/at91/image/sama7.mk
+++ b/target/linux/at91/image/sama7.mk
@@ -20,7 +20,7 @@ define Build/at91-sdcard
 	::u-boot.bin
 
   mcopy -i $@.boot \
-	$(BIN_DIR)/at91bootstrap-$(DEVICE_DTS:at91-%=%)sd_uboot/at91bootstrap.bin \
+	$(STAGING_DIR_IMAGE)/$(DEVICE_DTS:at91-%=%)sd_uboot-at91bootstrap.bin \
 	::BOOT.bin
 
   $(CP) uboot-env.txt $@-uboot-env.txt

--- a/target/linux/at91/image/sama7.mk
+++ b/target/linux/at91/image/sama7.mk
@@ -16,7 +16,7 @@ define Build/at91-sdcard
 	::$(DEVICE_NAME)-fit.itb
 
   mcopy -i $@.boot \
-	$(BIN_DIR)/u-boot-$(DEVICE_DTS:at91-%=%)_mmc1/u-boot.bin \
+	$(STAGING_DIR_IMAGE)/$(DEVICE_DTS:at91-%=%)_mmc1-u-boot.bin \
 	::u-boot.bin
 
   mcopy -i $@.boot \


### PR DESCRIPTION
Currently, building at91 subtargets via imagebuilder is broken as both u-boot and at91bootstrap images are not present in the built imagebuilder at all.

So, lets fix this by installing them to image staging directory as well and use that instead of the default binary directory for building the images.
