### PR TITLE
realtek: fix ethtool stats for RTL839x and RTL930x

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -55,53 +55,192 @@ static void rtl83xx_enable_phy_polling(struct rtl838x_switch_priv *priv)
 		sw_w32_mask(0, 0x8000, RTL838X_SMI_GLB_CTRL);
 }
 
-const struct rtl83xx_mib_desc rtl83xx_mib[] = {
-	MIB_DESC(2, 0xf8, "ifInOctets"),
-	MIB_DESC(2, 0xf0, "ifOutOctets"),
-	MIB_DESC(1, 0xec, "dot1dTpPortInDiscards"),
-	MIB_DESC(1, 0xe8, "ifInUcastPkts"),
-	MIB_DESC(1, 0xe4, "ifInMulticastPkts"),
-	MIB_DESC(1, 0xe0, "ifInBroadcastPkts"),
-	MIB_DESC(1, 0xdc, "ifOutUcastPkts"),
-	MIB_DESC(1, 0xd8, "ifOutMulticastPkts"),
-	MIB_DESC(1, 0xd4, "ifOutBroadcastPkts"),
-	MIB_DESC(1, 0xd0, "ifOutDiscards"),
-	MIB_DESC(1, 0xcc, ".3SingleCollisionFrames"),
-	MIB_DESC(1, 0xc8, ".3MultipleCollisionFrames"),
-	MIB_DESC(1, 0xc4, ".3DeferredTransmissions"),
-	MIB_DESC(1, 0xc0, ".3LateCollisions"),
-	MIB_DESC(1, 0xbc, ".3ExcessiveCollisions"),
-	MIB_DESC(1, 0xb8, ".3SymbolErrors"),
-	MIB_DESC(1, 0xb4, ".3ControlInUnknownOpcodes"),
-	MIB_DESC(1, 0xb0, ".3InPauseFrames"),
-	MIB_DESC(1, 0xac, ".3OutPauseFrames"),
-	MIB_DESC(1, 0xa8, "DropEvents"),
-	MIB_DESC(1, 0xa4, "tx_BroadcastPkts"),
-	MIB_DESC(1, 0xa0, "tx_MulticastPkts"),
-	MIB_DESC(1, 0x9c, "CRCAlignErrors"),
-	MIB_DESC(1, 0x98, "tx_UndersizePkts"),
-	MIB_DESC(1, 0x94, "rx_UndersizePkts"),
-	MIB_DESC(1, 0x90, "rx_UndersizedropPkts"),
-	MIB_DESC(1, 0x8c, "tx_OversizePkts"),
-	MIB_DESC(1, 0x88, "rx_OversizePkts"),
-	MIB_DESC(1, 0x84, "Fragments"),
-	MIB_DESC(1, 0x80, "Jabbers"),
-	MIB_DESC(1, 0x7c, "Collisions"),
-	MIB_DESC(1, 0x78, "tx_Pkts64Octets"),
-	MIB_DESC(1, 0x74, "rx_Pkts64Octets"),
-	MIB_DESC(1, 0x70, "tx_Pkts65to127Octets"),
-	MIB_DESC(1, 0x6c, "rx_Pkts65to127Octets"),
-	MIB_DESC(1, 0x68, "tx_Pkts128to255Octets"),
-	MIB_DESC(1, 0x64, "rx_Pkts128to255Octets"),
-	MIB_DESC(1, 0x60, "tx_Pkts256to511Octets"),
-	MIB_DESC(1, 0x5c, "rx_Pkts256to511Octets"),
-	MIB_DESC(1, 0x58, "tx_Pkts512to1023Octets"),
-	MIB_DESC(1, 0x54, "rx_Pkts512to1023Octets"),
-	MIB_DESC(1, 0x50, "tx_Pkts1024to1518Octets"),
-	MIB_DESC(1, 0x4c, "rx_StatsPkts1024to1518Octets"),
-	MIB_DESC(1, 0x48, "tx_Pkts1519toMaxOctets"),
-	MIB_DESC(1, 0x44, "rx_Pkts1519toMaxOctets"),
-	MIB_DESC(1, 0x40, "rxMacDiscards")
+const struct rtldsa_mib_list_item rtldsa_838x_mib_list[] = {
+	MIB_LIST_ITEM("ifInOctets", MIB_ITEM(MIB_REG_STD, 0xf8, 2)),
+	MIB_LIST_ITEM("ifOutOctets", MIB_ITEM(MIB_REG_STD, 0xf0, 2)),
+	MIB_LIST_ITEM("dot1dTpPortInDiscards", MIB_ITEM(MIB_REG_STD, 0xec, 1)),
+	MIB_LIST_ITEM("ifInUcastPkts", MIB_ITEM(MIB_REG_STD, 0xe8, 1)),
+	MIB_LIST_ITEM("ifInMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xe4, 1)),
+	MIB_LIST_ITEM("ifInBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xe0, 1)),
+	MIB_LIST_ITEM("ifOutUcastPkts", MIB_ITEM(MIB_REG_STD, 0xdc, 1)),
+	MIB_LIST_ITEM("ifOutMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xd8, 1)),
+	MIB_LIST_ITEM("ifOutBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xd4, 1)),
+	MIB_LIST_ITEM("ifOutDiscards", MIB_ITEM(MIB_REG_STD, 0xd0, 1)),
+	MIB_LIST_ITEM(".3SingleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xcc, 1)),
+	MIB_LIST_ITEM(".3MultipleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xc8, 1)),
+	MIB_LIST_ITEM(".3DeferredTransmissions", MIB_ITEM(MIB_REG_STD, 0xc4, 1)),
+	MIB_LIST_ITEM(".3LateCollisions", MIB_ITEM(MIB_REG_STD, 0xc0, 1)),
+	MIB_LIST_ITEM(".3ExcessiveCollisions", MIB_ITEM(MIB_REG_STD, 0xbc, 1)),
+	MIB_LIST_ITEM(".3SymbolErrors", MIB_ITEM(MIB_REG_STD, 0xb8, 1)),
+	MIB_LIST_ITEM(".3ControlInUnknownOpcodes", MIB_ITEM(MIB_REG_STD, 0xb4, 1)),
+	MIB_LIST_ITEM(".3InPauseFrames", MIB_ITEM(MIB_REG_STD, 0xb0, 1)),
+	MIB_LIST_ITEM(".3OutPauseFrames", MIB_ITEM(MIB_REG_STD, 0xac, 1)),
+	MIB_LIST_ITEM("DropEvents", MIB_ITEM(MIB_REG_STD, 0xa8, 1)),
+	MIB_LIST_ITEM("tx_BroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xa4, 1)),
+	MIB_LIST_ITEM("tx_MulticastPkts", MIB_ITEM(MIB_REG_STD, 0xa0, 1)),
+	MIB_LIST_ITEM("CRCAlignErrors", MIB_ITEM(MIB_REG_STD, 0x9c, 1)),
+	MIB_LIST_ITEM("tx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x98, 1)),
+	MIB_LIST_ITEM("rx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x94, 1)),
+	MIB_LIST_ITEM("rx_UndersizeDropPkts", MIB_ITEM(MIB_REG_STD, 0x90, 1)),
+	MIB_LIST_ITEM("tx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x8c, 1)),
+	MIB_LIST_ITEM("rx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x88, 1)),
+	MIB_LIST_ITEM("Fragments", MIB_ITEM(MIB_REG_STD, 0x84, 1)),
+	MIB_LIST_ITEM("Jabbers", MIB_ITEM(MIB_REG_STD, 0x80, 1)),
+	MIB_LIST_ITEM("Collisions", MIB_ITEM(MIB_REG_STD, 0x7c, 1)),
+	MIB_LIST_ITEM("tx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x78, 1)),
+	MIB_LIST_ITEM("rx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x74, 1)),
+	MIB_LIST_ITEM("tx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x70, 1)),
+	MIB_LIST_ITEM("rx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x6c, 1)),
+	MIB_LIST_ITEM("tx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x68, 1)),
+	MIB_LIST_ITEM("rx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x64, 1)),
+	MIB_LIST_ITEM("tx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x60, 1)),
+	MIB_LIST_ITEM("rx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x5c, 1)),
+	MIB_LIST_ITEM("tx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x58, 1)),
+	MIB_LIST_ITEM("rx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x54, 1)),
+	MIB_LIST_ITEM("tx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x50, 1)),
+	MIB_LIST_ITEM("rx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x4c, 1)),
+	MIB_LIST_ITEM("tx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_STD, 0x48, 1)),
+	MIB_LIST_ITEM("rx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_STD, 0x44, 1)),
+	MIB_LIST_ITEM("rx_MacDiscards", MIB_ITEM(MIB_REG_STD, 0x40, 1))
+};
+
+const struct rtldsa_mib_desc rtldsa_838x_mib = {
+	.list_count = ARRAY_SIZE(rtldsa_838x_mib_list),
+	.list = rtldsa_838x_mib_list
+};
+
+const struct rtldsa_mib_list_item rtldsa_839x_mib_list[] = {
+	MIB_LIST_ITEM("ifInOctets", MIB_ITEM(MIB_REG_STD, 0xf8, 2)),
+	MIB_LIST_ITEM("ifOutOctets", MIB_ITEM(MIB_REG_STD, 0xf0, 2)),
+	MIB_LIST_ITEM("ifInUcastPkts", MIB_ITEM(MIB_REG_STD, 0xec, 1)),
+	MIB_LIST_ITEM("ifInMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xe8, 1)),
+	MIB_LIST_ITEM("ifInBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xe4, 1)),
+	MIB_LIST_ITEM("ifOutUcastPkts", MIB_ITEM(MIB_REG_STD, 0xe0, 1)),
+	MIB_LIST_ITEM("ifOutMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xdc, 1)),
+	MIB_LIST_ITEM("ifOutBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xd8, 1)),
+	MIB_LIST_ITEM("ifOutDiscards", MIB_ITEM(MIB_REG_STD, 0xd4, 1)),
+	MIB_LIST_ITEM("dot1dTpPortInDiscards", MIB_ITEM(MIB_REG_STD, 0xd0, 1)),
+	MIB_LIST_ITEM(".3SingleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xcc, 1)),
+	MIB_LIST_ITEM(".3MultipleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xc8, 1)),
+	MIB_LIST_ITEM(".3DeferredTransmissions", MIB_ITEM(MIB_REG_STD, 0xc4, 1)),
+	MIB_LIST_ITEM(".3LateCollisions", MIB_ITEM(MIB_REG_STD, 0xc0, 1)),
+	MIB_LIST_ITEM(".3ExcessiveCollisions", MIB_ITEM(MIB_REG_STD, 0xbc, 1)),
+	MIB_LIST_ITEM(".3SymbolErrors", MIB_ITEM(MIB_REG_STD, 0xb8, 1)),
+	MIB_LIST_ITEM(".3ControlInUnknownOpcodes", MIB_ITEM(MIB_REG_STD, 0xb4, 1)),
+	MIB_LIST_ITEM(".3InPauseFrames", MIB_ITEM(MIB_REG_STD, 0xb0, 1)),
+	MIB_LIST_ITEM(".3OutPauseFrames", MIB_ITEM(MIB_REG_STD, 0xac, 1)),
+	MIB_LIST_ITEM("DropEvents", MIB_ITEM(MIB_REG_STD, 0xa8, 1)),
+	MIB_LIST_ITEM("tx_BroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xa4, 1)),
+	MIB_LIST_ITEM("tx_MulticastPkts", MIB_ITEM(MIB_REG_STD, 0xa0, 1)),
+	MIB_LIST_ITEM("CRCAlignErrors", MIB_ITEM(MIB_REG_STD, 0x9c, 1)),
+	MIB_LIST_ITEM("tx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x98, 1)),
+	MIB_LIST_ITEM("rx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x94, 1)),
+	MIB_LIST_ITEM("rx_UndersizeDropPkts", MIB_ITEM(MIB_REG_STD, 0x90, 1)),
+	MIB_LIST_ITEM("tx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x8c, 1)),
+	MIB_LIST_ITEM("rx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x88, 1)),
+	MIB_LIST_ITEM("Fragments", MIB_ITEM(MIB_REG_STD, 0x84, 1)),
+	MIB_LIST_ITEM("Jabbers", MIB_ITEM(MIB_REG_STD, 0x80, 1)),
+	MIB_LIST_ITEM("Collisions", MIB_ITEM(MIB_REG_STD, 0x7c, 1)),
+	MIB_LIST_ITEM("tx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x78, 1)),
+	MIB_LIST_ITEM("rx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x74, 1)),
+	MIB_LIST_ITEM("tx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x70, 1)),
+	MIB_LIST_ITEM("rx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x6c, 1)),
+	MIB_LIST_ITEM("tx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x68, 1)),
+	MIB_LIST_ITEM("rx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x64, 1)),
+	MIB_LIST_ITEM("tx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x60, 1)),
+	MIB_LIST_ITEM("rx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x5c, 1)),
+	MIB_LIST_ITEM("tx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x58, 1)),
+	MIB_LIST_ITEM("rx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x54, 1)),
+	MIB_LIST_ITEM("tx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x50, 1)),
+	MIB_LIST_ITEM("rx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x4c, 1)),
+	MIB_LIST_ITEM("tx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_STD, 0x48, 1)),
+	MIB_LIST_ITEM("rx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_STD, 0x44, 1)),
+	MIB_LIST_ITEM("rx_LengthFieldError", MIB_ITEM(MIB_REG_STD, 0x40, 1)),
+	MIB_LIST_ITEM("rx_FalseCarrierTimes", MIB_ITEM(MIB_REG_STD, 0x3c, 1)),
+	MIB_LIST_ITEM("rx_UnderSizeOctets", MIB_ITEM(MIB_REG_STD, 0x38, 1)),
+	MIB_LIST_ITEM("tx_Fragments", MIB_ITEM(MIB_REG_STD, 0x34, 1)),
+	MIB_LIST_ITEM("tx_Jabbers", MIB_ITEM(MIB_REG_STD, 0x30, 1)),
+	MIB_LIST_ITEM("tx_CRCAlignErrors", MIB_ITEM(MIB_REG_STD, 0x2c, 1)),
+	MIB_LIST_ITEM("rx_FramingErrors", MIB_ITEM(MIB_REG_STD, 0x28, 1)),
+	MIB_LIST_ITEM("rx_MacDiscards", MIB_ITEM(MIB_REG_STD, 0x24, 1))
+};
+
+const struct rtldsa_mib_desc rtldsa_839x_mib = {
+	.list_count = ARRAY_SIZE(rtldsa_839x_mib_list),
+	.list = rtldsa_839x_mib_list
+};
+
+const struct rtldsa_mib_list_item rtldsa_930x_mib_list[] = {
+	MIB_LIST_ITEM("ifInOctets", MIB_ITEM(MIB_REG_STD, 0xf8, 2)),
+	MIB_LIST_ITEM("ifOutOctets", MIB_ITEM(MIB_REG_STD, 0xf0, 2)),
+	MIB_LIST_ITEM("ifInUcastPkts", MIB_ITEM(MIB_REG_STD, 0xe8, 2)),
+	MIB_LIST_ITEM("ifInMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xe0, 2)),
+	MIB_LIST_ITEM("ifInBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xd8, 2)),
+	MIB_LIST_ITEM("ifOutUcastPkts", MIB_ITEM(MIB_REG_STD, 0xd0, 2)),
+	MIB_LIST_ITEM("ifOutMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xc8, 2)),
+	MIB_LIST_ITEM("ifOutBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xc0, 2)),
+	MIB_LIST_ITEM("ifOutDiscards", MIB_ITEM(MIB_REG_STD, 0xbc, 1)),
+	MIB_LIST_ITEM("dot1dTpPortInDiscards", MIB_ITEM(MIB_REG_STD, 0xb8, 1)),
+	MIB_LIST_ITEM(".3SingleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xb4, 1)),
+	MIB_LIST_ITEM(".3MultipleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xb0, 1)),
+	MIB_LIST_ITEM(".3DeferredTransmissions", MIB_ITEM(MIB_REG_STD, 0xac, 1)),
+	MIB_LIST_ITEM(".3LateCollisions", MIB_ITEM(MIB_REG_STD, 0xa8, 1)),
+	MIB_LIST_ITEM(".3ExcessiveCollisions", MIB_ITEM(MIB_REG_STD, 0xa4, 1)),
+	MIB_LIST_ITEM(".3SymbolErrors", MIB_ITEM(MIB_REG_STD, 0xa0, 1)),
+	MIB_LIST_ITEM(".3ControlInUnknownOpcodes", MIB_ITEM(MIB_REG_STD, 0x9c, 1)),
+	MIB_LIST_ITEM(".3InPauseFrames", MIB_ITEM(MIB_REG_STD, 0x98, 1)),
+	MIB_LIST_ITEM(".3OutPauseFrames", MIB_ITEM(MIB_REG_STD, 0x94, 1)),
+	MIB_LIST_ITEM("DropEvents", MIB_ITEM(MIB_REG_STD, 0x90, 1)),
+	MIB_LIST_ITEM("tx_BroadcastPkts", MIB_ITEM(MIB_REG_STD, 0x8c, 1)),
+	MIB_LIST_ITEM("tx_MulticastPkts", MIB_ITEM(MIB_REG_STD, 0x88, 1)),
+	MIB_LIST_ITEM("tx_CRCAlignErrors", MIB_ITEM(MIB_REG_STD, 0x84, 1)),
+	MIB_LIST_ITEM("rx_CRCAlignErrors", MIB_ITEM(MIB_REG_STD, 0x80, 1)),
+	MIB_LIST_ITEM("tx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x7c, 1)),
+	MIB_LIST_ITEM("rx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x78, 1)),
+	MIB_LIST_ITEM("tx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x74, 1)),
+	MIB_LIST_ITEM("rx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x70, 1)),
+	MIB_LIST_ITEM("tx_Fragments", MIB_ITEM(MIB_REG_STD, 0x6c, 1)),
+	MIB_LIST_ITEM("rx_Fragments", MIB_ITEM(MIB_REG_STD, 0x68, 1)),
+	MIB_LIST_ITEM("tx_Jabbers", MIB_ITEM(MIB_REG_STD, 0x64, 1)),
+	MIB_LIST_ITEM("rx_Jabbers", MIB_ITEM(MIB_REG_STD, 0x60, 1)),
+	MIB_LIST_ITEM("tx_Collisions", MIB_ITEM(MIB_REG_STD, 0x5c, 1)),
+	MIB_LIST_ITEM("tx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x58, 1)),
+	MIB_LIST_ITEM("rx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x54, 1)),
+	MIB_LIST_ITEM("tx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x50, 1)),
+	MIB_LIST_ITEM("rx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x4c, 1)),
+	MIB_LIST_ITEM("tx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x48, 1)),
+	MIB_LIST_ITEM("rx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x44, 1)),
+	MIB_LIST_ITEM("tx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x40, 1)),
+	MIB_LIST_ITEM("rx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x3c, 1)),
+	MIB_LIST_ITEM("tx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x38, 1)),
+	MIB_LIST_ITEM("rx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x34, 1)),
+	MIB_LIST_ITEM("tx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x30, 1)),
+	MIB_LIST_ITEM("rx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x2c, 1)),
+	MIB_LIST_ITEM("rx_UndersizeDropPkts", MIB_ITEM(MIB_REG_PRV, 0x7c, 1)),
+	MIB_LIST_ITEM("tx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_PRV, 0x78, 1)),
+	MIB_LIST_ITEM("rx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_PRV, 0x74, 1)),
+	MIB_LIST_ITEM("tx_PktsOverMaxOctets", MIB_ITEM(MIB_REG_PRV, 0x70, 1)),
+	MIB_LIST_ITEM("rx_PktsOverMaxOctets", MIB_ITEM(MIB_REG_PRV, 0x6c, 1)),
+	MIB_LIST_ITEM("tx_PktsFlexibleOctetsSet1", MIB_ITEM(MIB_REG_PRV, 0x68, 1)),
+	MIB_LIST_ITEM("rx_PktsFlexibleOctetsSet1", MIB_ITEM(MIB_REG_PRV, 0x64, 1)),
+	MIB_LIST_ITEM("tx_PktsFlexibleOctetsCRCSet1", MIB_ITEM(MIB_REG_PRV, 0x60, 1)),
+	MIB_LIST_ITEM("rx_PktsFlexibleOctetsCRCSet1", MIB_ITEM(MIB_REG_PRV, 0x5c, 1)),
+	MIB_LIST_ITEM("tx_PktsFlexibleOctetsSet0", MIB_ITEM(MIB_REG_PRV, 0x58, 1)),
+	MIB_LIST_ITEM("rx_PktsFlexibleOctetsSet0", MIB_ITEM(MIB_REG_PRV, 0x54, 1)),
+	MIB_LIST_ITEM("tx_PktsFlexibleOctetsCRCSet0", MIB_ITEM(MIB_REG_PRV, 0x50, 1)),
+	MIB_LIST_ITEM("rx_PktsFlexibleOctetsCRCSet0", MIB_ITEM(MIB_REG_PRV, 0x4c, 1)),
+	MIB_LIST_ITEM("LengthFieldError", MIB_ITEM(MIB_REG_PRV, 0x48, 1)),
+	MIB_LIST_ITEM("FalseCarrierTimes", MIB_ITEM(MIB_REG_PRV, 0x44, 1)),
+	MIB_LIST_ITEM("UndersizeOctets", MIB_ITEM(MIB_REG_PRV, 0x40, 1)),
+	MIB_LIST_ITEM("FramingErrors", MIB_ITEM(MIB_REG_PRV, 0x3c, 1)),
+	MIB_LIST_ITEM("ParserErrors", MIB_ITEM(MIB_REG_PRV, 0x38, 1)),
+	MIB_LIST_ITEM("rx_MacDiscards", MIB_ITEM(MIB_REG_PRV, 0x34, 1)),
+	MIB_LIST_ITEM("rx_MacIPGShortDrop", MIB_ITEM(MIB_REG_PRV, 0x30, 1))
+};
+
+const struct rtldsa_mib_desc rtldsa_930x_mib = {
+	.list_count = ARRAY_SIZE(rtldsa_930x_mib_list),
+	.list = rtldsa_930x_mib_list
 };
 
 
@@ -836,40 +975,114 @@ static void rtl93xx_phylink_mac_link_up(struct dsa_switch *ds, int port,
 	sw_w32_mask(0, 0x3, priv->r->mac_port_ctrl(port));
 }
 
-static void rtl83xx_get_strings(struct dsa_switch *ds,
-				int port, u32 stringset, u8 *data)
+static const struct rtldsa_mib_desc *rtldsa_get_mib_desc(struct rtl838x_switch_priv *priv)
 {
-	if (stringset != ETH_SS_STATS)
-		return;
-
-	for (int i = 0; i < ARRAY_SIZE(rtl83xx_mib); i++)
-		ethtool_puts(&data, rtl83xx_mib[i].name);
-}
-
-static void rtl83xx_get_ethtool_stats(struct dsa_switch *ds, int port,
-				      uint64_t *data)
-{
-	struct rtl838x_switch_priv *priv = ds->priv;
-	const struct rtl83xx_mib_desc *mib;
-	u64 h;
-
-	for (int i = 0; i < ARRAY_SIZE(rtl83xx_mib); i++) {
-		mib = &rtl83xx_mib[i];
-
-		data[i] = sw_r32(priv->r->stat_port_std_mib + (port << 8) + 252 - mib->offset);
-		if (mib->size == 2) {
-			h = sw_r32(priv->r->stat_port_std_mib + (port << 8) + 248 - mib->offset);
-			data[i] |= h << 32;
-		}
+	switch (priv->family_id) {
+	case RTL8380_FAMILY_ID:
+		return &rtldsa_838x_mib;
+	case RTL8390_FAMILY_ID:
+		return &rtldsa_839x_mib;
+	case RTL9300_FAMILY_ID:
+		return &rtldsa_930x_mib;
+	default:
+		return NULL;
 	}
 }
 
-static int rtl83xx_get_sset_count(struct dsa_switch *ds, int port, int sset)
+static bool rtldsa_read_mib_item(struct rtl838x_switch_priv *priv, int port,
+				 const struct rtldsa_mib_item *mib_item,
+				 uint64_t *data)
 {
+	uint32_t high1, high2;
+	int reg, reg_offset, addr_low;
+
+	switch (mib_item->reg) {
+	case MIB_REG_STD:
+		reg = priv->r->stat_port_std_mib;
+		reg_offset = 256;
+		break;
+	case MIB_REG_PRV:
+		reg = priv->r->stat_port_prv_mib;
+		reg_offset = 128;
+		break;
+	default:
+		return false;
+	}
+
+	addr_low = reg + (port + 1) * reg_offset - 4 - mib_item->offset;
+
+	if (mib_item->size == 2) {
+		high1 = sw_r32(addr_low - 4);
+		*data = sw_r32(addr_low);
+		high2 = sw_r32(addr_low - 4);
+		if (high1 != high2) {
+			/* Low must have wrapped and overflowed into high, read again */
+			*data = sw_r32(addr_low);
+		}
+		*data |= (uint64_t)high2 << 32;
+	} else {
+		*data = sw_r32(addr_low);
+	}
+
+	return true;
+}
+
+static void rtldsa_get_strings(struct dsa_switch *ds,
+			       int port, u32 stringset, u8 *data)
+{
+	struct rtl838x_switch_priv *priv = ds->priv;
+	const struct rtldsa_mib_desc *mib_desc;
+
+	if (stringset != ETH_SS_STATS)
+		return;
+
+	if (port < 0 || port >= priv->cpu_port)
+		return;
+
+	mib_desc = rtldsa_get_mib_desc(priv);
+	if (!mib_desc)
+		return;
+
+	for (int i = 0; i < mib_desc->list_count; i++)
+		ethtool_puts(&data, mib_desc->list[i].name);
+}
+
+static void rtldsa_get_ethtool_stats(struct dsa_switch *ds, int port,
+				     uint64_t *data)
+{
+	struct rtl838x_switch_priv *priv = ds->priv;
+	const struct rtldsa_mib_desc *mib_desc;
+	const struct rtldsa_mib_item *mib_item;
+
+	if (port < 0 || port >= priv->cpu_port)
+		return;
+
+	mib_desc = rtldsa_get_mib_desc(priv);
+	if (!mib_desc)
+		return;
+
+	for (int i = 0; i < mib_desc->list_count; i++) {
+		mib_item = &mib_desc->list[i].item;
+		rtldsa_read_mib_item(priv, port, mib_item, &data[i]);
+	}
+}
+
+static int rtldsa_get_sset_count(struct dsa_switch *ds, int port, int sset)
+{
+	struct rtl838x_switch_priv *priv = ds->priv;
+	const struct rtldsa_mib_desc *mib_desc;
+
 	if (sset != ETH_SS_STATS)
 		return 0;
 
-	return ARRAY_SIZE(rtl83xx_mib);
+	if (port < 0 || port >= priv->cpu_port)
+		return 0;
+
+	mib_desc = rtldsa_get_mib_desc(priv);
+	if (!mib_desc)
+		return 0;
+
+	return mib_desc->list_count;
 }
 
 static int rtl83xx_mc_group_alloc(struct rtl838x_switch_priv *priv, int port)
@@ -2068,9 +2281,9 @@ const struct dsa_switch_ops rtl83xx_switch_ops = {
 	.phylink_mac_link_up	= rtl83xx_phylink_mac_link_up,
 	.phylink_mac_select_pcs	= rtl83xx_phylink_mac_select_pcs,
 
-	.get_strings		= rtl83xx_get_strings,
-	.get_ethtool_stats	= rtl83xx_get_ethtool_stats,
-	.get_sset_count		= rtl83xx_get_sset_count,
+	.get_strings		= rtldsa_get_strings,
+	.get_ethtool_stats	= rtldsa_get_ethtool_stats,
+	.get_sset_count		= rtldsa_get_sset_count,
 
 	.port_enable		= rtl83xx_port_enable,
 	.port_disable		= rtl83xx_port_disable,
@@ -2125,9 +2338,9 @@ const struct dsa_switch_ops rtl930x_switch_ops = {
 	.phylink_mac_link_up	= rtl93xx_phylink_mac_link_up,
 	.phylink_mac_select_pcs	= rtl83xx_phylink_mac_select_pcs,
 
-	.get_strings		= rtl83xx_get_strings,
-	.get_ethtool_stats	= rtl83xx_get_ethtool_stats,
-	.get_sset_count		= rtl83xx_get_sset_count,
+	.get_strings		= rtldsa_get_strings,
+	.get_ethtool_stats	= rtldsa_get_ethtool_stats,
+	.get_sset_count		= rtldsa_get_sset_count,
 
 	.port_enable		= rtl83xx_port_enable,
 	.port_disable		= rtl83xx_port_disable,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -56,105 +56,88 @@ static void rtl83xx_enable_phy_polling(struct rtl838x_switch_priv *priv)
 }
 
 const struct rtldsa_mib_list_item rtldsa_838x_mib_list[] = {
-	MIB_LIST_ITEM("ifInOctets", MIB_ITEM(MIB_REG_STD, 0xf8, 2)),
-	MIB_LIST_ITEM("ifOutOctets", MIB_ITEM(MIB_REG_STD, 0xf0, 2)),
 	MIB_LIST_ITEM("dot1dTpPortInDiscards", MIB_ITEM(MIB_REG_STD, 0xec, 1)),
-	MIB_LIST_ITEM("ifInUcastPkts", MIB_ITEM(MIB_REG_STD, 0xe8, 1)),
-	MIB_LIST_ITEM("ifInMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xe4, 1)),
-	MIB_LIST_ITEM("ifInBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xe0, 1)),
-	MIB_LIST_ITEM("ifOutUcastPkts", MIB_ITEM(MIB_REG_STD, 0xdc, 1)),
-	MIB_LIST_ITEM("ifOutMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xd8, 1)),
-	MIB_LIST_ITEM("ifOutBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xd4, 1)),
 	MIB_LIST_ITEM("ifOutDiscards", MIB_ITEM(MIB_REG_STD, 0xd0, 1)),
-	MIB_LIST_ITEM(".3SingleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xcc, 1)),
-	MIB_LIST_ITEM(".3MultipleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xc8, 1)),
-	MIB_LIST_ITEM(".3DeferredTransmissions", MIB_ITEM(MIB_REG_STD, 0xc4, 1)),
-	MIB_LIST_ITEM(".3LateCollisions", MIB_ITEM(MIB_REG_STD, 0xc0, 1)),
-	MIB_LIST_ITEM(".3ExcessiveCollisions", MIB_ITEM(MIB_REG_STD, 0xbc, 1)),
-	MIB_LIST_ITEM(".3SymbolErrors", MIB_ITEM(MIB_REG_STD, 0xb8, 1)),
-	MIB_LIST_ITEM(".3ControlInUnknownOpcodes", MIB_ITEM(MIB_REG_STD, 0xb4, 1)),
-	MIB_LIST_ITEM(".3InPauseFrames", MIB_ITEM(MIB_REG_STD, 0xb0, 1)),
-	MIB_LIST_ITEM(".3OutPauseFrames", MIB_ITEM(MIB_REG_STD, 0xac, 1)),
 	MIB_LIST_ITEM("DropEvents", MIB_ITEM(MIB_REG_STD, 0xa8, 1)),
 	MIB_LIST_ITEM("tx_BroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xa4, 1)),
 	MIB_LIST_ITEM("tx_MulticastPkts", MIB_ITEM(MIB_REG_STD, 0xa0, 1)),
-	MIB_LIST_ITEM("CRCAlignErrors", MIB_ITEM(MIB_REG_STD, 0x9c, 1)),
 	MIB_LIST_ITEM("tx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x98, 1)),
-	MIB_LIST_ITEM("rx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x94, 1)),
 	MIB_LIST_ITEM("rx_UndersizeDropPkts", MIB_ITEM(MIB_REG_STD, 0x90, 1)),
 	MIB_LIST_ITEM("tx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x8c, 1)),
-	MIB_LIST_ITEM("rx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x88, 1)),
-	MIB_LIST_ITEM("Fragments", MIB_ITEM(MIB_REG_STD, 0x84, 1)),
-	MIB_LIST_ITEM("Jabbers", MIB_ITEM(MIB_REG_STD, 0x80, 1)),
 	MIB_LIST_ITEM("Collisions", MIB_ITEM(MIB_REG_STD, 0x7c, 1)),
-	MIB_LIST_ITEM("tx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x78, 1)),
-	MIB_LIST_ITEM("rx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x74, 1)),
-	MIB_LIST_ITEM("tx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x70, 1)),
-	MIB_LIST_ITEM("rx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x6c, 1)),
-	MIB_LIST_ITEM("tx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x68, 1)),
-	MIB_LIST_ITEM("rx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x64, 1)),
-	MIB_LIST_ITEM("tx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x60, 1)),
-	MIB_LIST_ITEM("rx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x5c, 1)),
-	MIB_LIST_ITEM("tx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x58, 1)),
-	MIB_LIST_ITEM("rx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x54, 1)),
-	MIB_LIST_ITEM("tx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x50, 1)),
-	MIB_LIST_ITEM("rx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x4c, 1)),
-	MIB_LIST_ITEM("tx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_STD, 0x48, 1)),
-	MIB_LIST_ITEM("rx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_STD, 0x44, 1)),
 	MIB_LIST_ITEM("rx_MacDiscards", MIB_ITEM(MIB_REG_STD, 0x40, 1))
 };
 
 const struct rtldsa_mib_desc rtldsa_838x_mib = {
+	.symbol_errors = MIB_ITEM(MIB_REG_STD, 0xb8, 1),
+
+	.if_in_octets = MIB_ITEM(MIB_REG_STD, 0xf8, 2),
+	.if_out_octets = MIB_ITEM(MIB_REG_STD, 0xf0, 2),
+	.if_in_ucast_pkts = MIB_ITEM(MIB_REG_STD, 0xe8, 1),
+	.if_in_mcast_pkts = MIB_ITEM(MIB_REG_STD, 0xe4, 1),
+	.if_in_bcast_pkts = MIB_ITEM(MIB_REG_STD, 0xe0, 1),
+	.if_out_ucast_pkts = MIB_ITEM(MIB_REG_STD, 0xdc, 1),
+	.if_out_mcast_pkts = MIB_ITEM(MIB_REG_STD, 0xd8, 1),
+	.if_out_bcast_pkts = MIB_ITEM(MIB_REG_STD, 0xd4, 1),
+	.single_collisions = MIB_ITEM(MIB_REG_STD, 0xcc, 1),
+	.multiple_collisions = MIB_ITEM(MIB_REG_STD, 0xc8, 1),
+	.deferred_transmissions = MIB_ITEM(MIB_REG_STD, 0xc4, 1),
+	.late_collisions = MIB_ITEM(MIB_REG_STD, 0xc0, 1),
+	.excessive_collisions = MIB_ITEM(MIB_REG_STD, 0xbc, 1),
+	.crc_align_errors = MIB_ITEM(MIB_REG_STD, 0x9c, 1),
+
+	.unsupported_opcodes = MIB_ITEM(MIB_REG_STD, 0xb4, 1),
+
+	.rx_undersize_pkts = MIB_ITEM(MIB_REG_STD, 0x94, 1),
+	.rx_oversize_pkts = MIB_ITEM(MIB_REG_STD, 0x88, 1),
+	.rx_fragments = MIB_ITEM(MIB_REG_STD, 0x84, 1),
+	.rx_jabbers = MIB_ITEM(MIB_REG_STD, 0x80, 1),
+
+	.tx_pkts = {
+		MIB_ITEM(MIB_REG_STD, 0x78, 1),
+		MIB_ITEM(MIB_REG_STD, 0x70, 1),
+		MIB_ITEM(MIB_REG_STD, 0x68, 1),
+		MIB_ITEM(MIB_REG_STD, 0x60, 1),
+		MIB_ITEM(MIB_REG_STD, 0x58, 1),
+		MIB_ITEM(MIB_REG_STD, 0x50, 1),
+		MIB_ITEM(MIB_REG_STD, 0x48, 1)
+	},
+	.rx_pkts = {
+		MIB_ITEM(MIB_REG_STD, 0x74, 1),
+		MIB_ITEM(MIB_REG_STD, 0x6c, 1),
+		MIB_ITEM(MIB_REG_STD, 0x64, 1),
+		MIB_ITEM(MIB_REG_STD, 0x5c, 1),
+		MIB_ITEM(MIB_REG_STD, 0x54, 1),
+		MIB_ITEM(MIB_REG_STD, 0x4c, 1),
+		MIB_ITEM(MIB_REG_STD, 0x44, 1)
+	},
+	.rmon_ranges = {
+		{ 0, 64 },
+		{ 65, 127 },
+		{ 128, 255 },
+		{ 256, 511 },
+		{ 512, 1023 },
+		{ 1024, 1518 },
+		{ 1519, 10000 }
+	},
+
+	.rx_pause_frames = MIB_ITEM(MIB_REG_STD, 0xb0, 1),
+	.tx_pause_frames = MIB_ITEM(MIB_REG_STD, 0xac, 1),
+
 	.list_count = ARRAY_SIZE(rtldsa_838x_mib_list),
 	.list = rtldsa_838x_mib_list
 };
 
 const struct rtldsa_mib_list_item rtldsa_839x_mib_list[] = {
-	MIB_LIST_ITEM("ifInOctets", MIB_ITEM(MIB_REG_STD, 0xf8, 2)),
-	MIB_LIST_ITEM("ifOutOctets", MIB_ITEM(MIB_REG_STD, 0xf0, 2)),
-	MIB_LIST_ITEM("ifInUcastPkts", MIB_ITEM(MIB_REG_STD, 0xec, 1)),
-	MIB_LIST_ITEM("ifInMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xe8, 1)),
-	MIB_LIST_ITEM("ifInBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xe4, 1)),
-	MIB_LIST_ITEM("ifOutUcastPkts", MIB_ITEM(MIB_REG_STD, 0xe0, 1)),
-	MIB_LIST_ITEM("ifOutMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xdc, 1)),
-	MIB_LIST_ITEM("ifOutBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xd8, 1)),
 	MIB_LIST_ITEM("ifOutDiscards", MIB_ITEM(MIB_REG_STD, 0xd4, 1)),
 	MIB_LIST_ITEM("dot1dTpPortInDiscards", MIB_ITEM(MIB_REG_STD, 0xd0, 1)),
-	MIB_LIST_ITEM(".3SingleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xcc, 1)),
-	MIB_LIST_ITEM(".3MultipleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xc8, 1)),
-	MIB_LIST_ITEM(".3DeferredTransmissions", MIB_ITEM(MIB_REG_STD, 0xc4, 1)),
-	MIB_LIST_ITEM(".3LateCollisions", MIB_ITEM(MIB_REG_STD, 0xc0, 1)),
-	MIB_LIST_ITEM(".3ExcessiveCollisions", MIB_ITEM(MIB_REG_STD, 0xbc, 1)),
-	MIB_LIST_ITEM(".3SymbolErrors", MIB_ITEM(MIB_REG_STD, 0xb8, 1)),
-	MIB_LIST_ITEM(".3ControlInUnknownOpcodes", MIB_ITEM(MIB_REG_STD, 0xb4, 1)),
-	MIB_LIST_ITEM(".3InPauseFrames", MIB_ITEM(MIB_REG_STD, 0xb0, 1)),
-	MIB_LIST_ITEM(".3OutPauseFrames", MIB_ITEM(MIB_REG_STD, 0xac, 1)),
 	MIB_LIST_ITEM("DropEvents", MIB_ITEM(MIB_REG_STD, 0xa8, 1)),
 	MIB_LIST_ITEM("tx_BroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xa4, 1)),
 	MIB_LIST_ITEM("tx_MulticastPkts", MIB_ITEM(MIB_REG_STD, 0xa0, 1)),
-	MIB_LIST_ITEM("CRCAlignErrors", MIB_ITEM(MIB_REG_STD, 0x9c, 1)),
 	MIB_LIST_ITEM("tx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x98, 1)),
-	MIB_LIST_ITEM("rx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x94, 1)),
 	MIB_LIST_ITEM("rx_UndersizeDropPkts", MIB_ITEM(MIB_REG_STD, 0x90, 1)),
 	MIB_LIST_ITEM("tx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x8c, 1)),
-	MIB_LIST_ITEM("rx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x88, 1)),
-	MIB_LIST_ITEM("Fragments", MIB_ITEM(MIB_REG_STD, 0x84, 1)),
-	MIB_LIST_ITEM("Jabbers", MIB_ITEM(MIB_REG_STD, 0x80, 1)),
 	MIB_LIST_ITEM("Collisions", MIB_ITEM(MIB_REG_STD, 0x7c, 1)),
-	MIB_LIST_ITEM("tx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x78, 1)),
-	MIB_LIST_ITEM("rx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x74, 1)),
-	MIB_LIST_ITEM("tx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x70, 1)),
-	MIB_LIST_ITEM("rx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x6c, 1)),
-	MIB_LIST_ITEM("tx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x68, 1)),
-	MIB_LIST_ITEM("rx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x64, 1)),
-	MIB_LIST_ITEM("tx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x60, 1)),
-	MIB_LIST_ITEM("rx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x5c, 1)),
-	MIB_LIST_ITEM("tx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x58, 1)),
-	MIB_LIST_ITEM("rx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x54, 1)),
-	MIB_LIST_ITEM("tx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x50, 1)),
-	MIB_LIST_ITEM("rx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x4c, 1)),
-	MIB_LIST_ITEM("tx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_STD, 0x48, 1)),
-	MIB_LIST_ITEM("rx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_STD, 0x44, 1)),
 	MIB_LIST_ITEM("rx_LengthFieldError", MIB_ITEM(MIB_REG_STD, 0x40, 1)),
 	MIB_LIST_ITEM("rx_FalseCarrierTimes", MIB_ITEM(MIB_REG_STD, 0x3c, 1)),
 	MIB_LIST_ITEM("rx_UnderSizeOctets", MIB_ITEM(MIB_REG_STD, 0x38, 1)),
@@ -166,61 +149,78 @@ const struct rtldsa_mib_list_item rtldsa_839x_mib_list[] = {
 };
 
 const struct rtldsa_mib_desc rtldsa_839x_mib = {
+	.symbol_errors = MIB_ITEM(MIB_REG_STD, 0xb8, 1),
+
+	.if_in_octets = MIB_ITEM(MIB_REG_STD, 0xf8, 2),
+	.if_out_octets = MIB_ITEM(MIB_REG_STD, 0xf0, 2),
+	.if_in_ucast_pkts = MIB_ITEM(MIB_REG_STD, 0xec, 1),
+	.if_in_mcast_pkts = MIB_ITEM(MIB_REG_STD, 0xe8, 1),
+	.if_in_bcast_pkts = MIB_ITEM(MIB_REG_STD, 0xe4, 1),
+	.if_out_ucast_pkts = MIB_ITEM(MIB_REG_STD, 0xe0, 1),
+	.if_out_mcast_pkts = MIB_ITEM(MIB_REG_STD, 0xdc, 1),
+	.if_out_bcast_pkts = MIB_ITEM(MIB_REG_STD, 0xd8, 1),
+	.single_collisions = MIB_ITEM(MIB_REG_STD, 0xcc, 1),
+	.multiple_collisions = MIB_ITEM(MIB_REG_STD, 0xc8, 1),
+	.deferred_transmissions = MIB_ITEM(MIB_REG_STD, 0xc4, 1),
+	.late_collisions = MIB_ITEM(MIB_REG_STD, 0xc0, 1),
+	.excessive_collisions = MIB_ITEM(MIB_REG_STD, 0xbc, 1),
+	.crc_align_errors = MIB_ITEM(MIB_REG_STD, 0x9c, 1),
+
+	.unsupported_opcodes = MIB_ITEM(MIB_REG_STD, 0xb4, 1),
+
+	.rx_undersize_pkts = MIB_ITEM(MIB_REG_STD, 0x94, 1),
+	.rx_oversize_pkts = MIB_ITEM(MIB_REG_STD, 0x88, 1),
+	.rx_fragments = MIB_ITEM(MIB_REG_STD, 0x84, 1),
+	.rx_jabbers = MIB_ITEM(MIB_REG_STD, 0x80, 1),
+
+	.tx_pkts = {
+		MIB_ITEM(MIB_REG_STD, 0x78, 1),
+		MIB_ITEM(MIB_REG_STD, 0x70, 1),
+		MIB_ITEM(MIB_REG_STD, 0x68, 1),
+		MIB_ITEM(MIB_REG_STD, 0x60, 1),
+		MIB_ITEM(MIB_REG_STD, 0x58, 1),
+		MIB_ITEM(MIB_REG_STD, 0x50, 1),
+		MIB_ITEM(MIB_REG_STD, 0x48, 1)
+	},
+	.rx_pkts = {
+		MIB_ITEM(MIB_REG_STD, 0x74, 1),
+		MIB_ITEM(MIB_REG_STD, 0x6c, 1),
+		MIB_ITEM(MIB_REG_STD, 0x64, 1),
+		MIB_ITEM(MIB_REG_STD, 0x5c, 1),
+		MIB_ITEM(MIB_REG_STD, 0x54, 1),
+		MIB_ITEM(MIB_REG_STD, 0x4c, 1),
+		MIB_ITEM(MIB_REG_STD, 0x44, 1)
+	},
+	.rmon_ranges = {
+		{ 0, 64 },
+		{ 65, 127 },
+		{ 128, 255 },
+		{ 256, 511 },
+		{ 512, 1023 },
+		{ 1024, 1518 },
+		{ 1519, 12288 }
+	},
+
+	.rx_pause_frames = MIB_ITEM(MIB_REG_STD, 0xb0, 1),
+	.tx_pause_frames = MIB_ITEM(MIB_REG_STD, 0xac, 1),
+
 	.list_count = ARRAY_SIZE(rtldsa_839x_mib_list),
 	.list = rtldsa_839x_mib_list
 };
 
 const struct rtldsa_mib_list_item rtldsa_930x_mib_list[] = {
-	MIB_LIST_ITEM("ifInOctets", MIB_ITEM(MIB_REG_STD, 0xf8, 2)),
-	MIB_LIST_ITEM("ifOutOctets", MIB_ITEM(MIB_REG_STD, 0xf0, 2)),
-	MIB_LIST_ITEM("ifInUcastPkts", MIB_ITEM(MIB_REG_STD, 0xe8, 2)),
-	MIB_LIST_ITEM("ifInMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xe0, 2)),
-	MIB_LIST_ITEM("ifInBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xd8, 2)),
-	MIB_LIST_ITEM("ifOutUcastPkts", MIB_ITEM(MIB_REG_STD, 0xd0, 2)),
-	MIB_LIST_ITEM("ifOutMulticastPkts", MIB_ITEM(MIB_REG_STD, 0xc8, 2)),
-	MIB_LIST_ITEM("ifOutBroadcastPkts", MIB_ITEM(MIB_REG_STD, 0xc0, 2)),
 	MIB_LIST_ITEM("ifOutDiscards", MIB_ITEM(MIB_REG_STD, 0xbc, 1)),
 	MIB_LIST_ITEM("dot1dTpPortInDiscards", MIB_ITEM(MIB_REG_STD, 0xb8, 1)),
-	MIB_LIST_ITEM(".3SingleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xb4, 1)),
-	MIB_LIST_ITEM(".3MultipleCollisionFrames", MIB_ITEM(MIB_REG_STD, 0xb0, 1)),
-	MIB_LIST_ITEM(".3DeferredTransmissions", MIB_ITEM(MIB_REG_STD, 0xac, 1)),
-	MIB_LIST_ITEM(".3LateCollisions", MIB_ITEM(MIB_REG_STD, 0xa8, 1)),
-	MIB_LIST_ITEM(".3ExcessiveCollisions", MIB_ITEM(MIB_REG_STD, 0xa4, 1)),
-	MIB_LIST_ITEM(".3SymbolErrors", MIB_ITEM(MIB_REG_STD, 0xa0, 1)),
-	MIB_LIST_ITEM(".3ControlInUnknownOpcodes", MIB_ITEM(MIB_REG_STD, 0x9c, 1)),
-	MIB_LIST_ITEM(".3InPauseFrames", MIB_ITEM(MIB_REG_STD, 0x98, 1)),
-	MIB_LIST_ITEM(".3OutPauseFrames", MIB_ITEM(MIB_REG_STD, 0x94, 1)),
 	MIB_LIST_ITEM("DropEvents", MIB_ITEM(MIB_REG_STD, 0x90, 1)),
 	MIB_LIST_ITEM("tx_BroadcastPkts", MIB_ITEM(MIB_REG_STD, 0x8c, 1)),
 	MIB_LIST_ITEM("tx_MulticastPkts", MIB_ITEM(MIB_REG_STD, 0x88, 1)),
 	MIB_LIST_ITEM("tx_CRCAlignErrors", MIB_ITEM(MIB_REG_STD, 0x84, 1)),
-	MIB_LIST_ITEM("rx_CRCAlignErrors", MIB_ITEM(MIB_REG_STD, 0x80, 1)),
 	MIB_LIST_ITEM("tx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x7c, 1)),
-	MIB_LIST_ITEM("rx_UndersizePkts", MIB_ITEM(MIB_REG_STD, 0x78, 1)),
 	MIB_LIST_ITEM("tx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x74, 1)),
-	MIB_LIST_ITEM("rx_OversizePkts", MIB_ITEM(MIB_REG_STD, 0x70, 1)),
 	MIB_LIST_ITEM("tx_Fragments", MIB_ITEM(MIB_REG_STD, 0x6c, 1)),
-	MIB_LIST_ITEM("rx_Fragments", MIB_ITEM(MIB_REG_STD, 0x68, 1)),
 	MIB_LIST_ITEM("tx_Jabbers", MIB_ITEM(MIB_REG_STD, 0x64, 1)),
-	MIB_LIST_ITEM("rx_Jabbers", MIB_ITEM(MIB_REG_STD, 0x60, 1)),
 	MIB_LIST_ITEM("tx_Collisions", MIB_ITEM(MIB_REG_STD, 0x5c, 1)),
-	MIB_LIST_ITEM("tx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x58, 1)),
-	MIB_LIST_ITEM("rx_Pkts64Octets", MIB_ITEM(MIB_REG_STD, 0x54, 1)),
-	MIB_LIST_ITEM("tx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x50, 1)),
-	MIB_LIST_ITEM("rx_Pkts65to127Octets", MIB_ITEM(MIB_REG_STD, 0x4c, 1)),
-	MIB_LIST_ITEM("tx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x48, 1)),
-	MIB_LIST_ITEM("rx_Pkts128to255Octets", MIB_ITEM(MIB_REG_STD, 0x44, 1)),
-	MIB_LIST_ITEM("tx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x40, 1)),
-	MIB_LIST_ITEM("rx_Pkts256to511Octets", MIB_ITEM(MIB_REG_STD, 0x3c, 1)),
-	MIB_LIST_ITEM("tx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x38, 1)),
-	MIB_LIST_ITEM("rx_Pkts512to1023Octets", MIB_ITEM(MIB_REG_STD, 0x34, 1)),
-	MIB_LIST_ITEM("tx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x30, 1)),
-	MIB_LIST_ITEM("rx_Pkts1024to1518Octets", MIB_ITEM(MIB_REG_STD, 0x2c, 1)),
 	MIB_LIST_ITEM("rx_UndersizeDropPkts", MIB_ITEM(MIB_REG_PRV, 0x7c, 1)),
-	MIB_LIST_ITEM("tx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_PRV, 0x78, 1)),
-	MIB_LIST_ITEM("rx_Pkts1519toMaxOctets", MIB_ITEM(MIB_REG_PRV, 0x74, 1)),
-	MIB_LIST_ITEM("tx_PktsOverMaxOctets", MIB_ITEM(MIB_REG_PRV, 0x70, 1)),
-	MIB_LIST_ITEM("rx_PktsOverMaxOctets", MIB_ITEM(MIB_REG_PRV, 0x6c, 1)),
 	MIB_LIST_ITEM("tx_PktsFlexibleOctetsSet1", MIB_ITEM(MIB_REG_PRV, 0x68, 1)),
 	MIB_LIST_ITEM("rx_PktsFlexibleOctetsSet1", MIB_ITEM(MIB_REG_PRV, 0x64, 1)),
 	MIB_LIST_ITEM("tx_PktsFlexibleOctetsCRCSet1", MIB_ITEM(MIB_REG_PRV, 0x60, 1)),
@@ -239,6 +239,64 @@ const struct rtldsa_mib_list_item rtldsa_930x_mib_list[] = {
 };
 
 const struct rtldsa_mib_desc rtldsa_930x_mib = {
+	.symbol_errors = MIB_ITEM(MIB_REG_STD, 0xa0, 1),
+
+	.if_in_octets = MIB_ITEM(MIB_REG_STD, 0xf8, 2),
+	.if_out_octets = MIB_ITEM(MIB_REG_STD, 0xf0, 2),
+	.if_in_ucast_pkts = MIB_ITEM(MIB_REG_STD, 0xe8, 2),
+	.if_in_mcast_pkts = MIB_ITEM(MIB_REG_STD, 0xe0, 2),
+	.if_in_bcast_pkts = MIB_ITEM(MIB_REG_STD, 0xd8, 2),
+	.if_out_ucast_pkts = MIB_ITEM(MIB_REG_STD, 0xd0, 2),
+	.if_out_mcast_pkts = MIB_ITEM(MIB_REG_STD, 0xc8, 2),
+	.if_out_bcast_pkts = MIB_ITEM(MIB_REG_STD, 0xc0, 2),
+	.single_collisions = MIB_ITEM(MIB_REG_STD, 0xb4, 1),
+	.multiple_collisions = MIB_ITEM(MIB_REG_STD, 0xb0, 1),
+	.deferred_transmissions = MIB_ITEM(MIB_REG_STD, 0xac, 1),
+	.late_collisions = MIB_ITEM(MIB_REG_STD, 0xa8, 1),
+	.excessive_collisions = MIB_ITEM(MIB_REG_STD, 0xa4, 1),
+	.crc_align_errors = MIB_ITEM(MIB_REG_STD, 0x80, 1),
+
+	.unsupported_opcodes = MIB_ITEM(MIB_REG_STD, 0x9c, 1),
+
+	.rx_undersize_pkts = MIB_ITEM(MIB_REG_STD, 0x78, 1),
+	.rx_oversize_pkts = MIB_ITEM(MIB_REG_STD, 0x70, 1),
+	.rx_fragments = MIB_ITEM(MIB_REG_STD, 0x68, 1),
+	.rx_jabbers = MIB_ITEM(MIB_REG_STD, 0x60, 1),
+
+	.tx_pkts = {
+		MIB_ITEM(MIB_REG_STD, 0x58, 1),
+		MIB_ITEM(MIB_REG_STD, 0x50, 1),
+		MIB_ITEM(MIB_REG_STD, 0x48, 1),
+		MIB_ITEM(MIB_REG_STD, 0x40, 1),
+		MIB_ITEM(MIB_REG_STD, 0x38, 1),
+		MIB_ITEM(MIB_REG_STD, 0x30, 1),
+		MIB_ITEM(MIB_REG_PRV, 0x78, 1),
+		MIB_ITEM(MIB_REG_PRV, 0x70, 1)
+	},
+	.rx_pkts = {
+		MIB_ITEM(MIB_REG_STD, 0x54, 1),
+		MIB_ITEM(MIB_REG_STD, 0x4c, 1),
+		MIB_ITEM(MIB_REG_STD, 0x44, 1),
+		MIB_ITEM(MIB_REG_STD, 0x3c, 1),
+		MIB_ITEM(MIB_REG_STD, 0x34, 1),
+		MIB_ITEM(MIB_REG_STD, 0x2c, 1),
+		MIB_ITEM(MIB_REG_PRV, 0x74, 1),
+		MIB_ITEM(MIB_REG_PRV, 0x6c, 1),
+	},
+	.rmon_ranges = {
+		{ 0, 64 },
+		{ 65, 127 },
+		{ 128, 255 },
+		{ 256, 511 },
+		{ 512, 1023 },
+		{ 1024, 1518 },
+		{ 1519, 12288 },
+		{ 12289, 65535 }
+	},
+
+	.rx_pause_frames = MIB_ITEM(MIB_REG_STD, 0x98, 1),
+	.tx_pause_frames = MIB_ITEM(MIB_REG_STD, 0x94, 1),
+
 	.list_count = ARRAY_SIZE(rtldsa_930x_mib_list),
 	.list = rtldsa_930x_mib_list
 };
@@ -1083,6 +1141,161 @@ static int rtldsa_get_sset_count(struct dsa_switch *ds, int port, int sset)
 		return 0;
 
 	return mib_desc->list_count;
+}
+
+
+static void rtldsa_get_eth_phy_stats(struct dsa_switch *ds, int port,
+				     struct ethtool_eth_phy_stats *phy_stats)
+{
+	struct rtl838x_switch_priv *priv = ds->priv;
+	const struct rtldsa_mib_desc *mib_desc;
+
+	if (port < 0 || port >= priv->cpu_port)
+		return;
+
+	mib_desc = rtldsa_get_mib_desc(priv);
+	if (!mib_desc)
+		return;
+
+	rtldsa_read_mib_item(priv, port, &mib_desc->symbol_errors,
+			     &phy_stats->SymbolErrorDuringCarrier);
+}
+
+static void rtldsa_get_eth_mac_stats(struct dsa_switch *ds, int port,
+				     struct ethtool_eth_mac_stats *mac_stats)
+{
+	struct rtl838x_switch_priv *priv = ds->priv;
+	const struct rtldsa_mib_desc *mib_desc;
+
+	if (port < 0 || port >= priv->cpu_port)
+		return;
+
+	mib_desc = rtldsa_get_mib_desc(priv);
+	if (!mib_desc)
+		return;
+
+	/* Ideally, frame and octet counters should be calculated based on RFC3635.
+	 * However, this would cause inconsistent results due to some counters being
+	 * 32-bit only.
+	 */
+
+	if (rtldsa_read_mib_item(priv, port, &mib_desc->if_in_ucast_pkts,
+				 &mac_stats->FramesReceivedOK)) {
+		if (rtldsa_read_mib_item(priv, port, &mib_desc->if_in_mcast_pkts,
+					 &mac_stats->MulticastFramesReceivedOK))
+			mac_stats->FramesReceivedOK += mac_stats->MulticastFramesReceivedOK;
+		if (rtldsa_read_mib_item(priv, port, &mib_desc->if_in_bcast_pkts,
+					 &mac_stats->BroadcastFramesReceivedOK))
+			mac_stats->FramesReceivedOK += mac_stats->BroadcastFramesReceivedOK;
+	}
+
+	if (rtldsa_read_mib_item(priv, port, &mib_desc->if_out_ucast_pkts,
+				 &mac_stats->FramesTransmittedOK)) {
+		if (rtldsa_read_mib_item(priv, port, &mib_desc->if_out_mcast_pkts,
+					 &mac_stats->MulticastFramesXmittedOK))
+			mac_stats->FramesTransmittedOK += mac_stats->MulticastFramesXmittedOK;
+		if (rtldsa_read_mib_item(priv, port, &mib_desc->if_out_bcast_pkts,
+					 &mac_stats->BroadcastFramesXmittedOK))
+			mac_stats->FramesTransmittedOK += mac_stats->BroadcastFramesXmittedOK;
+	}
+
+	rtldsa_read_mib_item(priv, port, &mib_desc->if_in_octets,
+			     &mac_stats->OctetsReceivedOK);
+	rtldsa_read_mib_item(priv, port, &mib_desc->if_out_octets,
+			     &mac_stats->OctetsTransmittedOK);
+
+	rtldsa_read_mib_item(priv, port, &mib_desc->single_collisions,
+			     &mac_stats->SingleCollisionFrames);
+	rtldsa_read_mib_item(priv, port, &mib_desc->multiple_collisions,
+			     &mac_stats->MultipleCollisionFrames);
+	rtldsa_read_mib_item(priv, port, &mib_desc->deferred_transmissions,
+			     &mac_stats->FramesWithDeferredXmissions);
+	rtldsa_read_mib_item(priv, port, &mib_desc->late_collisions,
+			     &mac_stats->LateCollisions);
+	rtldsa_read_mib_item(priv, port, &mib_desc->excessive_collisions,
+			     &mac_stats->FramesAbortedDueToXSColls);
+
+	rtldsa_read_mib_item(priv, port, &mib_desc->crc_align_errors,
+			     &mac_stats->FrameCheckSequenceErrors);
+}
+
+static void rtldsa_get_eth_ctrl_stats(struct dsa_switch *ds, int port,
+				      struct ethtool_eth_ctrl_stats *ctrl_stats)
+{
+	struct rtl838x_switch_priv *priv = ds->priv;
+	const struct rtldsa_mib_desc *mib_desc;
+
+	if (port < 0 || port >= priv->cpu_port)
+		return;
+
+	mib_desc = rtldsa_get_mib_desc(priv);
+	if (!mib_desc)
+		return;
+
+	rtldsa_read_mib_item(priv, port, &mib_desc->unsupported_opcodes,
+			     &ctrl_stats->UnsupportedOpcodesReceived);
+}
+
+static void rtldsa_get_rmon_stats(struct dsa_switch *ds, int port,
+				  struct ethtool_rmon_stats *rmon_stats,
+				  const struct ethtool_rmon_hist_range **ranges)
+{
+	struct rtl838x_switch_priv *priv = ds->priv;
+	const struct rtldsa_mib_desc *mib_desc;
+
+	if (port < 0 || port >= priv->cpu_port)
+		return;
+
+	mib_desc = rtldsa_get_mib_desc(priv);
+	if (!mib_desc)
+		return;
+
+	rtldsa_read_mib_item(priv, port, &mib_desc->rx_undersize_pkts,
+			     &rmon_stats->undersize_pkts);
+	rtldsa_read_mib_item(priv, port, &mib_desc->rx_oversize_pkts,
+			     &rmon_stats->oversize_pkts);
+	rtldsa_read_mib_item(priv, port, &mib_desc->rx_fragments,
+			     &rmon_stats->fragments);
+	rtldsa_read_mib_item(priv, port, &mib_desc->rx_jabbers,
+			     &rmon_stats->jabbers);
+
+	for (int i = 0; i < ARRAY_SIZE(mib_desc->rx_pkts); i++) {
+		if (mib_desc->rx_pkts[i].reg == MIB_REG_INVALID)
+			break;
+
+		rtldsa_read_mib_item(priv, port, &mib_desc->rx_pkts[i],
+				     &rmon_stats->hist[i]);
+	}
+
+
+	for (int i = 0; i < ARRAY_SIZE(mib_desc->tx_pkts); i++) {
+		if (mib_desc->tx_pkts[i].reg == MIB_REG_INVALID)
+			break;
+
+		rtldsa_read_mib_item(priv, port, &mib_desc->tx_pkts[i],
+				     &rmon_stats->hist_tx[i]);
+	}
+
+	*ranges = mib_desc->rmon_ranges;
+}
+
+static void rtldsa_get_pause_stats(struct dsa_switch *ds, int port,
+				   struct ethtool_pause_stats *pause_stats)
+{
+	struct rtl838x_switch_priv *priv = ds->priv;
+	const struct rtldsa_mib_desc *mib_desc;
+
+	if (port < 0 || port >= priv->cpu_port)
+		return;
+
+	mib_desc = rtldsa_get_mib_desc(priv);
+	if (!mib_desc)
+		return;
+
+	rtldsa_read_mib_item(priv, port, &mib_desc->tx_pause_frames,
+			     &pause_stats->tx_pause_frames);
+	rtldsa_read_mib_item(priv, port, &mib_desc->rx_pause_frames,
+			     &pause_stats->rx_pause_frames);
 }
 
 static int rtl83xx_mc_group_alloc(struct rtl838x_switch_priv *priv, int port)
@@ -2284,6 +2497,11 @@ const struct dsa_switch_ops rtl83xx_switch_ops = {
 	.get_strings		= rtldsa_get_strings,
 	.get_ethtool_stats	= rtldsa_get_ethtool_stats,
 	.get_sset_count		= rtldsa_get_sset_count,
+	.get_eth_phy_stats	= rtldsa_get_eth_phy_stats,
+	.get_eth_mac_stats	= rtldsa_get_eth_mac_stats,
+	.get_eth_ctrl_stats	= rtldsa_get_eth_ctrl_stats,
+	.get_rmon_stats		= rtldsa_get_rmon_stats,
+	.get_pause_stats	= rtldsa_get_pause_stats,
 
 	.port_enable		= rtl83xx_port_enable,
 	.port_disable		= rtl83xx_port_disable,
@@ -2341,6 +2559,11 @@ const struct dsa_switch_ops rtl930x_switch_ops = {
 	.get_strings		= rtldsa_get_strings,
 	.get_ethtool_stats	= rtldsa_get_ethtool_stats,
 	.get_sset_count		= rtldsa_get_sset_count,
+	.get_eth_phy_stats	= rtldsa_get_eth_phy_stats,
+	.get_eth_mac_stats	= rtldsa_get_eth_mac_stats,
+	.get_eth_ctrl_stats	= rtldsa_get_eth_ctrl_stats,
+	.get_rmon_stats		= rtldsa_get_rmon_stats,
+	.get_pause_stats	= rtldsa_get_pause_stats,
 
 	.port_enable		= rtl83xx_port_enable,
 	.port_disable		= rtl83xx_port_disable,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -639,6 +639,51 @@ enum pbvlan_mode {
 	PBVLAN_MODE_ALL_PKT,
 };
 
+struct rtldsa_counter {
+	uint64_t val;
+	uint32_t last;
+};
+
+struct rtldsa_counter_state {
+	spinlock_t lock;
+	ktime_t last_update;
+
+	struct rtldsa_counter symbol_errors;
+
+	struct rtldsa_counter if_in_octets;
+	struct rtldsa_counter if_out_octets;
+	struct rtldsa_counter if_in_ucast_pkts;
+	struct rtldsa_counter if_in_mcast_pkts;
+	struct rtldsa_counter if_in_bcast_pkts;
+	struct rtldsa_counter if_out_ucast_pkts;
+	struct rtldsa_counter if_out_mcast_pkts;
+	struct rtldsa_counter if_out_bcast_pkts;
+	struct rtldsa_counter if_out_discards;
+	struct rtldsa_counter single_collisions;
+	struct rtldsa_counter multiple_collisions;
+	struct rtldsa_counter deferred_transmissions;
+	struct rtldsa_counter late_collisions;
+	struct rtldsa_counter excessive_collisions;
+	struct rtldsa_counter crc_align_errors;
+	struct rtldsa_counter rx_pkts_over_max_octets;
+
+	struct rtldsa_counter unsupported_opcodes;
+
+	struct rtldsa_counter rx_undersize_pkts;
+	struct rtldsa_counter rx_oversize_pkts;
+	struct rtldsa_counter rx_fragments;
+	struct rtldsa_counter rx_jabbers;
+
+	struct rtldsa_counter tx_pkts[ETHTOOL_RMON_HIST_MAX];
+	struct rtldsa_counter rx_pkts[ETHTOOL_RMON_HIST_MAX];
+
+	struct rtldsa_counter drop_events;
+	struct rtldsa_counter collisions;
+
+	struct rtldsa_counter rx_pause_frames;
+	struct rtldsa_counter tx_pause_frames;
+};
+
 struct rtl838x_port {
 	bool enable;
 	u64 pm;
@@ -651,6 +696,7 @@ struct rtl838x_port {
 	int sds_num;
 	int led_set;
 	int leds_on_this_port;
+	struct rtldsa_counter_state counters;
 	const struct dsa_port *dp;
 };
 
@@ -1116,6 +1162,7 @@ struct rtl838x_switch_priv {
 	struct rtl838x_l3_intf *interfaces[MAX_INTERFACES];
 	u16 intf_mtus[MAX_INTF_MTUS];
 	int intf_mtu_count[MAX_INTF_MTUS];
+	struct delayed_work counters_work;
 };
 
 void rtl838x_dbgfs_init(struct rtl838x_switch_priv *priv);

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -34,6 +34,7 @@
 #define RTL838X_STAT_PORT_STD_MIB		(0x1200)
 #define RTL839X_STAT_PORT_STD_MIB		(0xC000)
 #define RTL930X_STAT_PORT_MIB_CNTR		(0x0664)
+#define RTL930X_STAT_PORT_PRVTE_CNTR		(0x2364)
 #define RTL838X_STAT_RST			(0x3100)
 #define RTL839X_STAT_RST			(0xF504)
 #define RTL930X_STAT_RST			(0x3240)
@@ -981,6 +982,7 @@ struct rtl838x_reg {
 	int stat_port_rst;
 	int stat_rst;
 	int stat_port_std_mib;
+	int stat_port_prv_mib;
 	int (*port_iso_ctrl)(int p);
 	void (*traffic_enable)(int source, int dest);
 	void (*traffic_disable)(int source, int dest);

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -17,11 +17,32 @@ struct fdb_update_work {
 	u64 macs[];
 };
 
-#define MIB_DESC(_size, _offset, _name) {.size = _size, .offset = _offset, .name = _name}
-struct rtl83xx_mib_desc {
-	unsigned int size;
+enum mib_reg {
+	MIB_REG_INVALID = 0,
+	MIB_REG_STD,
+	MIB_REG_PRV
+};
+
+#define MIB_ITEM(_reg, _offset, _size) \
+		{.reg = _reg, .offset = _offset, .size = _size}
+
+#define MIB_LIST_ITEM(_name, _item) \
+		{.name = _name, .item = _item}
+
+struct rtldsa_mib_item {
+	enum mib_reg reg;
 	unsigned int offset;
+	unsigned int size;
+};
+
+struct rtldsa_mib_list_item {
 	const char *name;
+	struct rtldsa_mib_item item;
+};
+
+struct rtldsa_mib_desc {
+	size_t list_count;
+	const struct rtldsa_mib_list_item *list;
 };
 
 /* API for switch table access */

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -58,6 +58,7 @@ struct rtldsa_mib_desc {
 	struct rtldsa_mib_item late_collisions;
 	struct rtldsa_mib_item excessive_collisions;
 	struct rtldsa_mib_item crc_align_errors;
+	struct rtldsa_mib_item rx_pkts_over_max_octets;
 
 	struct rtldsa_mib_item unsupported_opcodes;
 

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -41,6 +41,37 @@ struct rtldsa_mib_list_item {
 };
 
 struct rtldsa_mib_desc {
+	struct rtldsa_mib_item symbol_errors;
+
+	struct rtldsa_mib_item if_in_octets;
+	struct rtldsa_mib_item if_out_octets;
+	struct rtldsa_mib_item if_in_ucast_pkts;
+	struct rtldsa_mib_item if_in_mcast_pkts;
+	struct rtldsa_mib_item if_in_bcast_pkts;
+	struct rtldsa_mib_item if_out_ucast_pkts;
+	struct rtldsa_mib_item if_out_mcast_pkts;
+	struct rtldsa_mib_item if_out_bcast_pkts;
+	struct rtldsa_mib_item single_collisions;
+	struct rtldsa_mib_item multiple_collisions;
+	struct rtldsa_mib_item deferred_transmissions;
+	struct rtldsa_mib_item late_collisions;
+	struct rtldsa_mib_item excessive_collisions;
+	struct rtldsa_mib_item crc_align_errors;
+
+	struct rtldsa_mib_item unsupported_opcodes;
+
+	struct rtldsa_mib_item rx_undersize_pkts;
+	struct rtldsa_mib_item rx_oversize_pkts;
+	struct rtldsa_mib_item rx_fragments;
+	struct rtldsa_mib_item rx_jabbers;
+
+	struct rtldsa_mib_item tx_pkts[ETHTOOL_RMON_HIST_MAX];
+	struct rtldsa_mib_item rx_pkts[ETHTOOL_RMON_HIST_MAX];
+	struct ethtool_rmon_hist_range rmon_ranges[ETHTOOL_RMON_HIST_MAX];
+
+	struct rtldsa_mib_item rx_pause_frames;
+	struct rtldsa_mib_item tx_pause_frames;
+
 	size_t list_count;
 	const struct rtldsa_mib_list_item *list;
 };

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -51,6 +51,7 @@ struct rtldsa_mib_desc {
 	struct rtldsa_mib_item if_out_ucast_pkts;
 	struct rtldsa_mib_item if_out_mcast_pkts;
 	struct rtldsa_mib_item if_out_bcast_pkts;
+	struct rtldsa_mib_item if_out_discards;
 	struct rtldsa_mib_item single_collisions;
 	struct rtldsa_mib_item multiple_collisions;
 	struct rtldsa_mib_item deferred_transmissions;
@@ -68,6 +69,9 @@ struct rtldsa_mib_desc {
 	struct rtldsa_mib_item tx_pkts[ETHTOOL_RMON_HIST_MAX];
 	struct rtldsa_mib_item rx_pkts[ETHTOOL_RMON_HIST_MAX];
 	struct ethtool_rmon_hist_range rmon_ranges[ETHTOOL_RMON_HIST_MAX];
+
+	struct rtldsa_mib_item drop_events;
+	struct rtldsa_mib_item collisions;
 
 	struct rtldsa_mib_item rx_pause_frames;
 	struct rtldsa_mib_item tx_pause_frames;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -2439,6 +2439,7 @@ const struct rtl838x_reg rtl930x_reg = {
 	.stat_port_rst = RTL930X_STAT_PORT_RST,
 	.stat_rst = RTL930X_STAT_RST,
 	.stat_port_std_mib = RTL930X_STAT_PORT_MIB_CNTR,
+	.stat_port_prv_mib = RTL930X_STAT_PORT_PRVTE_CNTR,
 	.traffic_enable = rtl930x_traffic_enable,
 	.traffic_disable = rtl930x_traffic_disable,
 	.traffic_get = rtl930x_traffic_get,


### PR DESCRIPTION
The MIB registers contain different stats depending on the SoC, and for RTL930x some stats are in an additional register.

RTL931x remains unsupported, because it uses a table and thus requires a separate implementation.

Tested on: HPE 1920-8G (rtl838x), HPE-1920-48G (rtl839x), Zyxel XGS1010-12 (rtl930x)
The reported stats seem plausible on all devices.