### PR TITLE
imagebuilder: add missing support to declare packages to skip

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -142,9 +142,10 @@ _call_info: FORCE
 
 BUILD_PACKAGES:=$(sort $(DEFAULT_PACKAGES) $($(USER_PROFILE)_PACKAGES) kernel)
 # "-pkgname" in the package list means remove "pkgname" from the package list
-BUILD_PACKAGES:=$(filter-out $(filter -%,$(BUILD_PACKAGES)) $(patsubst -%,%,$(filter -%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
+# "~pkgname" in the package list means that "pkgname" needs to be dropped from the package list as its used for InstallDev step only
+BUILD_PACKAGES:=$(filter-out $(filter -% ~%,$(BUILD_PACKAGES)) $(patsubst -% %~,%,$(filter -% ~%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
 BUILD_PACKAGES:=$(USER_PACKAGES) $(BUILD_PACKAGES)
-BUILD_PACKAGES:=$(filter-out $(filter -%,$(BUILD_PACKAGES)) $(patsubst -%,%,$(filter -%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
+BUILD_PACKAGES:=$(filter-out $(filter -% ~%,$(BUILD_PACKAGES)) $(patsubst -% %~,%,$(filter -% ~%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
 PACKAGES:=
 
 _call_image: staging_dir/host/.prereq-build


### PR DESCRIPTION
Support to declare packages that are meant to be skipped for installation if they are marked with tilde (~) was added for regular building, but it was not added in imagebuilder as well.

Layerscape target uses this feature to mark certain packages which are part of the DEVICE_PACKAGES and thus imagebuilder also tries to install them but it will fail with:
`ERROR: '~trusted-firmware-a-ls1012a-frdm' is not a valid world dependency, format is name(@tag)([<>~=]version)`

Since packages marked with tilde prefix are not stripped from the package list in imagebuilder.

So, lets add the same feature to imagebuilder as well.

Fixes: #18412
Fixes: 377b66990b97 ("build: introduce support to declare skip package")
