### PR TITLE
ramips: Add support for Xiaomi MiWiFi 3A

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -63,6 +63,7 @@ kroks,kndrt31r19|\
 mediatek,linkit-smart-7688|\
 samknows,whitebox-v8|\
 xiaomi,mi-router-4c|\
+xiaomi,miwifi-3a|\
 xiaomi,miwifi-nano|\
 zbtlink,zbt-wg2626|\
 zte,mf283plus)

--- a/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3a.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_miwifi-3a.dts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "xiaomi,miwifi-3a", "mediatek,mt7628an-soc";
+	model = "Xiaomi MiWiFi 3A";
+
+	aliases {
+		led-boot = &led_status_amber;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_amber;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: status_blue {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: status_red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_amber: status_amber {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "gpio", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x2a>;
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Bootloader";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "Config";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "Bdata";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "factory";
+				reg = <0x50000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+
+					macaddr_factory_8004: macaddr@8004 {
+						reg = <0x8004 0x6>;
+					};
+				};
+			};
+
+			partition@60000 {
+				label = "crash";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "crash_syslog";
+				reg = <0x70000 0x10000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "overlay";
+				reg = <0x80000 0x100000>;
+				read-only;
+			};
+
+			partition@180000 {
+				label = "firmware";
+				compatible = "denx,uimage";
+				reg = <0x180000 0xe80000>;
+			};
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1213,6 +1213,14 @@ define Device/xiaomi_mi-router-4c
 endef
 TARGET_DEVICES += xiaomi_mi-router-4c
 
+define Device/xiaomi_miwifi-3a
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := MiWiFi 3A
+  DEVICE_PACKAGES := kmod-mt76x2
+endef
+TARGET_DEVICES += xiaomi_miwifi-3a
+
 define Device/xiaomi_miwifi-3c
   IMAGE_SIZE := 15104k
   DEVICE_VENDOR := Xiaomi

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -216,6 +216,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan:1" "2:lan:2" "1:wan" "6@eth0"
 		;;
+	xiaomi,miwifi-3a)
+		ucidef_add_switch "switch0" \
+			"0:wan" "2:lan:1" "4:lan:2" "6@eth0"
+		;;
 	xiaomi,miwifi-3c)
 		ucidef_add_switch "switch0" \
 			"0:wan" "2:lan:2" "4:lan:1" "6@eth0"

--- a/target/linux/ramips/mt76x8/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt76x8/base-files/etc/init.d/bootcount
@@ -9,6 +9,7 @@ boot() {
 			echo -e "bootcount\nbootchanged\n" | /usr/sbin/fw_setenv -s -
 		;;
 	xiaomi,mi-router-4c|\
+	xiaomi,miwifi-3a|\
 	xiaomi,miwifi-nano)
 		fw_setenv flag_boot_success 1
 		;;


### PR DESCRIPTION
The Xiaomi MiWiFi 3A wireless router has a similar system architecture as the Xiaomi Mi 4A (100M) router, which is already officially supported by OpenWrt.

Product website: https://www.mi.com/miwifi3a

Device specification
--------------------
SoC:      MT7628AN MIPS_24KEc @ 580 MHz 2.4G-bgn 2x2
WiFi:     MT7612EN 5G-an, ac 80 MHz 2T2R
Flash:    16 MB 
DRAM:     64 MB 
Switch:   MT7628AN (integrated in SoC)
Ethernet: 1 x 10 /100 Mbps
USB:      None
Antennas: 2 x 2,4 GHz and 2 x 5 GHz (all are external and non-detachable)
LEDs:     blue/red/amber
Buttons:  Reset
Serial:   115200,8n1

MAC addresses as verified by OEM firmware:
------------------------------------------
**use address source**
LAN *:DD factory 0x28
WAN *:DD factory 0x28
2g *:DE factory 0x4
5g *:DF factory 0x8004

OEM firmware uses VLAN's to create the network interface for WAN and LAN.

Bootloader info:
----------------
The stock bootloader uses a "Dual ROM Partition System".  OS1 is a deep copy of OS2.
The bootloader starts OS2 by default.
To force start OS1 it is needed to set "flag_try_sys2_failed=1".

How to install:
---------------
1- Use OpenWRTInvasion to gain Telnet, SSH and FTP access: https://github.com/acecilia/OpenWRTInvasion 
[IP: 192.168.31.1 | Username: root | Password: root | FTP-Port: 21] 
2- Connect to router using Telnet or SSH.
3- Backup all partitions. Use command "dd if=/dev/mtd0 of=/tmp/mtd0". Copy /tmp/mtd0 to computer using FTP. 
4- Copy openwrt-ramips-mt76x8-xiaomi_miwifi-3a-squashfs-sysupgrade.bin to /tmp in router using FTP. 
5- Enable UART access and change start image to OS1.

```
nvram set uart_en=1
nvram set flag_last_success=1
nvram set boot_wait=on
nvram set flag_try_sys2_failed=1
nvram commit
```

6- Erase OS1 & OS2 and install OpenWrt

```
mtd erase OS1
mtd erase OS2
mtd -r write /tmp/openwrt-ramips-mt76x8-xiaomi_miwifi-3a-squashfs-sysupgrade.bin OS1
```
Credits:
--------
This PR is based on the work of Zehao Zhang (Github: @ZZH-Finalize) that he had published in the PR: https://github.com/openwrt/openwrt/pull/15698

Signed-off-by: Olgun Demir <olgun.demir@mail.com.tr>