### PR TITLE
mediatek: Fix possible emmc communication anomalies in GL.iNet MT2500/X3000/XE3000.

### DIFF
--- a/target/linux/mediatek/dts/mt7981a-glinet-gl-x3000-xe3000-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981a-glinet-gl-x3000-xe3000-common.dtsi
@@ -131,7 +131,7 @@
 	pinctrl-0 = <&mmc0_pins_default>;
 	pinctrl-1 = <&mmc0_pins_uhs>;
 	bus-width = <8>;
-	max-frequency = <52000000>;
+	max-frequency = <26000000>;
 	cap-mmc-highspeed;
 	vmmc-supply = <&reg_3p3v>;
 	non-removable;
@@ -215,11 +215,37 @@
 			function = "flash";
 			groups = "emmc_8";
 		};
+		conf-cmd-dat {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO",
+				"SPI0_CS", "SPI0_HOLD", "SPI0_WP",
+				"SPI1_CLK", "SPI1_MOSI", "SPI1_MISO";
+			input-enable;
+			drive-strength = <MTK_DRIVE_12mA>;
+			mediatek,pull-up-adv = <1>;
+		};
+		conf-clk {
+			pins = "SPI1_CS";
+			drive-strength = <MTK_DRIVE_12mA>;
+			mediatek,pull-down-adv = <2>;
+		};
 	};
 	mmc0_pins_uhs: mmc0-pins-uhs {
 		mux {
 			function = "flash";
 			groups = "emmc_8";
+		};
+		conf-cmd-dat {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO",
+				"SPI0_CS", "SPI0_HOLD", "SPI0_WP",
+				"SPI1_CLK", "SPI1_MOSI", "SPI1_MISO";
+			input-enable;
+			drive-strength = <MTK_DRIVE_12mA>;
+			mediatek,pull-up-adv = <1>;
+		};
+		conf-clk {
+			pins = "SPI1_CS";
+			drive-strength = <MTK_DRIVE_12mA>;
+			mediatek,pull-down-adv = <2>;
 		};
 	};
 	pcie_pins: pcie-pins {

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dts
@@ -78,11 +78,37 @@
 			function = "flash";
 			groups = "emmc_45";
 		};
+		conf-cmd-dat {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO",
+				"SPI0_CS", "SPI0_HOLD", "SPI0_WP",
+				"SPI1_CLK", "SPI1_MOSI", "SPI1_MISO";
+			input-enable;
+			drive-strength = <MTK_DRIVE_12mA>;
+			mediatek,pull-up-adv = <1>;
+		};
+		conf-clk {
+			pins = "SPI1_CS";
+			drive-strength = <MTK_DRIVE_12mA>;
+			mediatek,pull-down-adv = <2>;
+		};
 	};
 	mmc0_pins_uhs: mmc0-pins-uhs {
 		mux {
 			function = "flash";
 			groups = "emmc_45";
+		};
+		conf-cmd-dat {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO",
+				"SPI0_CS", "SPI0_HOLD", "SPI0_WP",
+				"SPI1_CLK", "SPI1_MOSI", "SPI1_MISO";
+			input-enable;
+			drive-strength = <MTK_DRIVE_12mA>;
+			mediatek,pull-up-adv = <1>;
+		};
+		conf-clk {
+			pins = "SPI1_CS";
+			drive-strength = <MTK_DRIVE_12mA>;
+			mediatek,pull-down-adv = <2>;
 		};
 	};
 };
@@ -148,7 +174,7 @@
 	pinctrl-0 = <&mmc0_pins_default>;
 	pinctrl-1 = <&mmc0_pins_uhs>;
 	bus-width = <8>;
-	max-frequency = <52000000>;
+	max-frequency = <26000000>;
 	vmmc-supply = <&reg_3p3v>;
 	cap-mmc-highspeed;
 	non-removable;


### PR DESCRIPTION

use 26Mhz for max-frequency and 12mA for drive-strength.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
