### PR TITLE
mediatek: filogic: add support for Huasifei WH3000

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -89,6 +89,7 @@ xiaomi,redmi-router-ax6000-ubootmod)
 glinet,gl-mt3000)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x20000"
 	;;
+huasifei,wh3000|\
 glinet,gl-mt6000)
 	local envdev=$(find_mmc_part "u-boot-env")
 	ubootenv_add_uci_config "$envdev" "0x0" "0x80000"

--- a/target/linux/mediatek/dts/mt7981b-huasifei-wh3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-huasifei-wh3000.dts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "Huasifei WH3000";
+	compatible = "huasifei,wh3000", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &wlan_led;
+		led-failsafe = &wlan_led;
+		led-upgrade = &wlan_led;
+	};
+
+	chosen {
+		bootargs = "root=PARTLABEL=rootfs rootwait";
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-mode {
+			label = "mode";
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		wan_led: led-0 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan_led: led-1 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+
+	usb_vbus: regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "usb-vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		regulator-boot-on;
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy1>;
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&mdio_bus {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	phy1: ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <1>;
+		interrupts = <38 IRQ_TYPE_LEVEL_LOW>;
+		interrupt-parent = <&pio>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		realtek,aldps-enable;
+	};
+};
+
+&mmc0 {
+	bus-width = <8>;
+	cap-mmc-highspeed;
+	max-frequency = <52000000>;
+	no-sd;
+	no-sdio;
+	non-removable;
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_default>;
+	pinctrl-1 = <&mmc0_pins_uhs>;
+	vmmc-supply = <&reg_3p3v>;
+	status = "okay";
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+
+			partitions {
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x0 0x1000>;
+						};
+
+						macaddr_factory_4: macaddr@4 {
+							compatible = "mac-base";
+							reg = <0x4 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+	mmc0_pins_default: mmc0-pins-default {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+
+	mmc0_pins_uhs: mmc0-pins-uhs {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&xhci {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -18,6 +18,9 @@ cudy,re3000-v1)
 cudy,wr3000-v1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	;;
+huasifei,wh3000)
+	ucidef_set_led_netdev "wan" "WAN" "red:wan" "eth1"
+	;;
 mercusys,mr90x-v1)
 	ucidef_set_led_netdev "lan0" "lan0" "green:lan0" "lan0" "link tx rx"
 	ucidef_set_led_netdev "lan1" "lan2" "green:lan1" "lan1" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -76,6 +76,9 @@ mediatek_setup_interfaces()
 	zyxel,nwa50ax-pro)
 		ucidef_set_interface_lan "eth0"
 		;;
+	huasifei,wh3000)
+		ucidef_set_interfaces_lan_wan eth0 eth1
+		;;
 	smartrg,sdg-8622|\
 	smartrg,sdg-8632|\
 	yuncore,ax835)
@@ -144,6 +147,11 @@ mediatek_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii pdt_data_1 ethaddr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac=$wan_mac
+		;;
+	huasifei,wh3000)
+		local wifi_mac=$(mmc_get_mac_binary factory 0x4)
+		lan_mac="$(macaddr_add $wifi_mac 2)"
+		wan_mac="$(macaddr_add $wifi_mac 3)"
 		;;
 	jdcloud,re-cp-03)
 		wan_mac=$(mmc_get_mac_binary factory 0x24)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -24,7 +24,8 @@ case "$FIRMWARE" in
 	;;
 "mediatek/mt7981_eeprom_mt7976_dbdc.bin")
 	case "$board" in
-	cmcc,rax3000m)
+	cmcc,rax3000m|\
+	huasifei,wh3000)
 		case "$(cmdline_get_var root)" in
 		/dev/mmc*)
 			caldata_extract_mmc "factory" 0x0 0x1000

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -90,6 +90,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	huasifei,wh3000)
+		addr="$(mmc_get_mac_binary "factory" 0x4)"
+		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
+		;;
 	jcg,q30-pro|\
 	netcore,n60)
 		# Originally, phy1 is phy0 mac with LA bit set. However, this would conflict

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/81_fix_eeprom
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/81_fix_eeprom
@@ -1,0 +1,15 @@
+. /lib/functions/caldata.sh
+
+preinit_fix_eeprom() {
+	case $(board_name) in
+	huasifei,wh3000)
+		mmc_part=$(find_mmc_part factory)
+		FIRMWARE="mediatek/mt7981_eeprom_mt7976_dbdc.bin"
+		[ ! -e /lib/firmware/"$FIRMWARE" ] && \
+			export FIRMWARE="$FIRMWARE" && \
+			caldata_extract_mmc "factory" 0x0 0x1000
+		;;
+	esac
+}
+
+boot_hook_add preinit_main preinit_fix_eeprom

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -116,6 +116,7 @@ platform_do_upgrade() {
 	yuncore,ax835)
 		default_do_upgrade "$1"
 		;;
+	huasifei,wh3000|\
 	glinet,gl-mt6000)
 		CI_KERNPART="kernel"
 		CI_ROOTPART="rootfs"
@@ -219,6 +220,7 @@ platform_copy_config() {
 			;;
 		esac
 		;;
+	huasifei,wh3000|\
 	glinet,gl-mt6000|\
 	jdcloud,re-cp-03|\
 	ubnt,unifi-6-plus)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -105,6 +105,21 @@ define Build/cetron-header
 	rm $@.tmp
 endef
 
+define Device/huasifei_wh3000
+  DEVICE_VENDOR := Huasifei
+  DEVICE_MODEL := WH3000
+  DEVICE_DTS := mt7981b-huasifei-wh3000
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
+  kmod-usb3 f2fsck mkf2fs
+  SUPPORTED_DEVICES += huasifei,wh3000-emmc
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+  fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += huasifei_wh3000
+
 define Device/acelink_ew-7886cax
   DEVICE_VENDOR := Acelink
   DEVICE_MODEL := EW-7886CAX


### PR DESCRIPTION
**Huasifei WH3000 eMMC / Fudy MT3000**
Portable Wi-Fi 6 travel router based on MediaTek MT7981A SoC. MT7981B+MT7976CN+RTL8221B Dual Core 1.3GHZ

**Specifications**
SoC: Filogic 820 MT7981A (1.3GHz)
RAM: DDR4 1GB
Flash: eMMC 8GB
WiFi: 2.4GHz and 5GHz with 3 antennas
Ethernet:
1x WAN (10/100/1000M)
1x LAN (10/100/1000/2500M)
USB: 1x USB 3.0 port
Two buttons: power/reset and mode (BTN_0)
LEDS: blue, red, blue+red=pink
UART: 3.3V, TX, RX, GND / 115200 8N1

**Installation via U-Boot rescue**
1. Set static IP 192.168.1.2 on your computer and default route as 192.168.1.1
2. Connect to the WAN port and hold the reset button while booting the device.
3. Wait for the LED to blink 5 times, and release the reset button.
4. Open the U-boot web page on your browser at http://192.168.1.1
5. Select the OpenWRT sysupgrade image, upload it, and start the upgrade.
6. Wait for the router to flash the new firmware.
7. Wait for the router to reboot itself.

**Installation via sysupgrade**
Just flash the sysupgrade file via [LuCI upgrade page](http://192.168.1.1/cgi-bin/luci/admin/system/flash) without saving the settings.

**Installation via SSH**
Upload the file to the router `/tmp` directory, `ssh root@192.168.1.1` and issue a command:
```
sysupgrade -n /tmp/openwrt-mediatek-filogic-huasifei_wh3000-squashfs-sysupgrade.bin
```

**Factory MAC**
You can find your Factory MAC, which is mentioned on the box, at `/dev/mmcblck0p2` partition `factory` starting from `0x4`
```
dd if=/dev/mmcblk0p2 bs=1 skip=4 count=6 | hexdump -C
```

Signed-off-by: Fil Dunsky <filipp.dunsky@gmail.com>