### PR TITLE
x86: base-files: improve dummy strings handling

### DIFF
--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -17,6 +17,7 @@ do_sysinfo_x86() {
 		Default\ [sS]tring | \
 		System\ manufacturer | \
 		To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\.)
+			vendor="Unknown vendor"
 			continue
 			;;
 		esac
@@ -30,6 +31,7 @@ do_sysinfo_x86() {
 		?*:Default\ [sS]tring | \
 		?*:System\ Product\ Name | \
 		?*:To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\.)
+			product="Unknown product"
 			continue
 			;;
 		"PC Engines:APU")

--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -14,6 +14,7 @@ do_sysinfo_x86() {
 		vendor="$(cat /sys/devices/virtual/dmi/id/$file 2>/dev/null)"
 		case "$vendor" in
 		empty | \
+		Default\ [sS]tring | \
 		System\ manufacturer | \
 		To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\.)
 			continue
@@ -26,6 +27,7 @@ do_sysinfo_x86() {
 		product="$(cat /sys/devices/virtual/dmi/id/$file 2>/dev/null)"
 		case "$vendor:$product" in
 		?*:empty | \
+		?*:Default\ [sS]tring | \
 		?*:System\ Product\ Name | \
 		?*:To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\.)
 			continue


### PR DESCRIPTION
For the second commit, when `/sys/devices/virtual/dmi/id/(sys_vendor|board_vendor)` and `/sys/devices/virtual/dmi/id/(product_name|board_name)` all contain dummy info, showing `Unknown vendor/product` should be more user-friendly. I'm not sure if there are any other unanticipated impact.