### PR TITLE
bcm27xx: pull 6.6 patches from RPi repo

### DIFF
--- a/target/linux/bcm27xx/patches-6.6/950-1558-media-i2c-imx477-Add-further-link-frequency-options.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1558-media-i2c-imx477-Add-further-link-frequency-options.patch
@@ -1,0 +1,77 @@
+From 0553897d77e849a86e836ddf1e0c0dbbd8e64f83 Mon Sep 17 00:00:00 2001
+From: Dave Stevenson <dave.stevenson@raspberrypi.com>
+Date: Mon, 20 Jan 2025 10:40:09 +0000
+Subject: [PATCH] media: i2c: imx477: Add further link frequency options
+
+https://github.com/raspberrypi/linux/issues/6004 reports further
+issues with GPS interference.
+
+Untested, but adds further link frequency options.
+
+Signed-off-by: Dave Stevenson <dave.stevenson@raspberrypi.com>
+---
+ drivers/media/i2c/imx477.c | 33 +++++++++++++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+
+--- a/drivers/media/i2c/imx477.c
++++ b/drivers/media/i2c/imx477.c
+@@ -169,12 +169,18 @@ enum {
+ 	IMX477_LINK_FREQ_450MHZ,
+ 	IMX477_LINK_FREQ_453MHZ,
+ 	IMX477_LINK_FREQ_456MHZ,
++	IMX477_LINK_FREQ_459MHZ,
++	IMX477_LINK_FREQ_462MHZ,
++	IMX477_LINK_FREQ_498MHZ,
+ };
+ 
+ static const s64 link_freqs[] = {
+ 	[IMX477_LINK_FREQ_450MHZ] = 450000000,
+ 	[IMX477_LINK_FREQ_453MHZ] = 453000000,
+ 	[IMX477_LINK_FREQ_456MHZ] = 456000000,
++	[IMX477_LINK_FREQ_459MHZ] = 459000000,
++	[IMX477_LINK_FREQ_462MHZ] = 462000000,
++	[IMX477_LINK_FREQ_498MHZ] = 498000000,
+ };
+ 
+ /* 450MHz is the nominal "default" link frequency */
+@@ -193,6 +199,21 @@ static const struct imx477_reg link_456M
+ 	{0x030F, 0x98},
+ };
+ 
++static const struct imx477_reg link_459Mhz_regs[] = {
++	{0x030E, 0x00},
++	{0x030F, 0x99},
++};
++
++static const struct imx477_reg link_462Mhz_regs[] = {
++	{0x030E, 0x00},
++	{0x030F, 0x9a},
++};
++
++static const struct imx477_reg link_498Mhz_regs[] = {
++	{0x030E, 0x00},
++	{0x030F, 0xa6},
++};
++
+ static const struct imx477_reg_list link_freq_regs[] = {
+ 	[IMX477_LINK_FREQ_450MHZ] = {
+ 		.regs = link_450Mhz_regs,
+@@ -206,6 +227,18 @@ static const struct imx477_reg_list link
+ 		.regs = link_456Mhz_regs,
+ 		.num_of_regs = ARRAY_SIZE(link_456Mhz_regs)
+ 	},
++	[IMX477_LINK_FREQ_459MHZ] = {
++		.regs = link_459Mhz_regs,
++		.num_of_regs = ARRAY_SIZE(link_459Mhz_regs)
++	},
++	[IMX477_LINK_FREQ_462MHZ] = {
++		.regs = link_462Mhz_regs,
++		.num_of_regs = ARRAY_SIZE(link_462Mhz_regs)
++	},
++	[IMX477_LINK_FREQ_498MHZ] = {
++		.regs = link_498Mhz_regs,
++		.num_of_regs = ARRAY_SIZE(link_498Mhz_regs)
++	},
+ };
+ 
+ static const struct imx477_reg mode_common_regs[] = {

--- a/target/linux/bcm27xx/patches-6.6/950-1559-overlays-Fix-some-unusable-fragments.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1559-overlays-Fix-some-unusable-fragments.patch
@@ -1,0 +1,82 @@
+From 9da8d6df2051478f0ba16d73c65995955c19cb3a Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.com>
+Date: Tue, 18 Mar 2025 13:09:11 +0000
+Subject: [PATCH] overlays: Fix some unusable fragments
+
+A forthcoming overlaycheck update looks for dormant fragments with no
+parameters to enable them. The test discovered some real errors, which
+this patch fixes, and one case where some fragments aren't yet being
+used, which this comments out until they are.
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+---
+ arch/arm/boot/dts/overlays/rpi-poe-overlay.dts           | 2 +-
+ arch/arm/boot/dts/overlays/rpi-poe-plus-overlay.dts      | 2 +-
+ arch/arm/boot/dts/overlays/sx150x-overlay.dts            | 2 +-
+ arch/arm/boot/dts/overlays/vc4-kms-dpi-panel-overlay.dts | 4 ++++
+ 4 files changed, 7 insertions(+), 3 deletions(-)
+
+--- a/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
++++ b/arch/arm/boot/dts/overlays/rpi-poe-overlay.dts
+@@ -145,7 +145,7 @@
+ 		poe_fan_temp2_hyst =	<&trip2>,"hysteresis:0";
+ 		poe_fan_temp3 =		<&trip3>,"temperature:0";
+ 		poe_fan_temp3_hyst =	<&trip3>,"hysteresis:0";
+-		i2c =			<0>, "+5+6",
++		i2c =			<0>, "+7+8",
+ 					<&fwpwm>,"status=disabled",
+ 					<&i2c_bus>,"status=okay",
+ 					<&poe_mfd>,"status=okay",
+--- a/arch/arm/boot/dts/overlays/rpi-poe-plus-overlay.dts
++++ b/arch/arm/boot/dts/overlays/rpi-poe-plus-overlay.dts
+@@ -28,7 +28,7 @@
+ 	};
+ 
+ 	__overrides__ {
+-		i2c =	<0>, "+5+6",
++		i2c =	<0>, "+7+8",
+ 			<&fwpwm>,"status=disabled",
+ 			<&rpi_poe_power_supply>,"status=disabled",
+ 			<&i2c_bus>,"status=okay",
+--- a/arch/arm/boot/dts/overlays/sx150x-overlay.dts
++++ b/arch/arm/boot/dts/overlays/sx150x-overlay.dts
+@@ -1681,7 +1681,7 @@
+ 		sx1507-1-3E-int-gpio = <0>,"+67+99",  <&sx150x_1_3E_pins>,"brcm,pins:0", <&sx1507_1_3E>,"interrupts:0";
+ 		sx1507-0-3F-int-gpio = <0>,"+68+100", <&sx150x_0_3F_pins>,"brcm,pins:0", <&sx1507_0_3F>,"interrupts:0";
+ 		sx1507-1-3F-int-gpio = <0>,"+69+101", <&sx150x_1_3F_pins>,"brcm,pins:0", <&sx1507_1_3F>,"interrupts:0";
+-		sx1507-0-70-int-gpio = <0>,"+60+102", <&sx150x_0_70_pins>,"brcm,pins:0", <&sx1507_0_70>,"interrupts:0";
++		sx1507-0-70-int-gpio = <0>,"+70+102", <&sx150x_0_70_pins>,"brcm,pins:0", <&sx1507_0_70>,"interrupts:0";
+ 		sx1507-1-70-int-gpio = <0>,"+71+103", <&sx150x_1_70_pins>,"brcm,pins:0", <&sx1507_1_70>,"interrupts:0";
+ 		sx1507-0-71-int-gpio = <0>,"+72+104", <&sx150x_0_71_pins>,"brcm,pins:0", <&sx1507_0_71>,"interrupts:0";
+ 		sx1507-1-71-int-gpio = <0>,"+73+105", <&sx150x_1_71_pins>,"brcm,pins:0", <&sx1507_1_71>,"interrupts:0";
+--- a/arch/arm/boot/dts/overlays/vc4-kms-dpi-panel-overlay.dts
++++ b/arch/arm/boot/dts/overlays/vc4-kms-dpi-panel-overlay.dts
+@@ -42,24 +42,28 @@
+ 			pinctrl-0 = <&dpi_18bit_gpio0>;
+ 		};
+ 	};
++#if 0
+ 	fragment@92 {
+ 		target = <&dpi>;
+ 		__dormant__  {
+ 			pinctrl-0 = <&dpi_gpio0>;
+ 		};
+ 	};
++#endif
+ 	fragment@93 {
+ 		target = <&dpi>;
+ 		__dormant__  {
+ 			pinctrl-0 = <&dpi_16bit_cpadhi_gpio0>;
+ 		};
+ 	};
++#if 0
+ 	fragment@94 {
+ 		target = <&dpi>;
+ 		__dormant__  {
+ 			pinctrl-0 = <&dpi_16bit_gpio0>;
+ 		};
+ 	};
++#endif
+ 
+ 	__overrides__ {
+ 		at056tn53v1 = <0>, "+0+90";

--- a/target/linux/bcm27xx/patches-6.6/950-1560-dts-rp1-Don-t-use-DMA-with-UARTs.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-1560-dts-rp1-Don-t-use-DMA-with-UARTs.patch
@@ -1,0 +1,33 @@
+From bba53a117a4a5c29da892962332ff1605990e17a Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.com>
+Date: Wed, 26 Mar 2025 11:28:28 +0000
+Subject: [PATCH] dts: rp1: Don't use DMA with UARTs
+
+DMA has been enabled on RP1's UART0, but with mixed success. Transmits
+seem to work, but the DMA interface is not well suited to receiving
+arbitrary amounts of data. In particular, the PL011 driver is slow to
+pass on the received data, batching it into large blocks.
+
+On balance, it's better to just disable the DMA support. As with the
+other UARTs, the required runes are left in the DTS as comments.
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+---
+ arch/arm64/boot/dts/broadcom/rp1.dtsi | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/arch/arm64/boot/dts/broadcom/rp1.dtsi
++++ b/arch/arm64/boot/dts/broadcom/rp1.dtsi
+@@ -65,9 +65,9 @@
+ 			interrupts = <RP1_INT_UART0 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&rp1_clocks RP1_CLK_UART &rp1_clocks RP1_PLL_SYS_PRI_PH>;
+ 			clock-names = "uartclk", "apb_pclk";
+-			dmas = <&rp1_dma RP1_DMA_UART0_TX>,
+-			       <&rp1_dma RP1_DMA_UART0_RX>;
+-			dma-names = "tx", "rx";
++			// dmas = <&rp1_dma RP1_DMA_UART0_TX>,
++			//        <&rp1_dma RP1_DMA_UART0_RX>;
++			// dma-names = "tx", "rx";
+ 			pinctrl-names = "default";
+ 			arm,primecell-periphid = <0x00341011>;
+ 			uart-has-rtscts;


### PR DESCRIPTION
Adds latest 6.6 patches from the Raspberry Pi repository.

These patches were generated from:
https://github.com/raspberrypi/linux/commits/rpi-6.6.y/ With the following command:
git format-patch -N v6.6.85..HEAD
(HEAD -> bba53a117a4a5c29da892962332ff1605990e17a)