### PR TITLE
treewide: initial conversion to .remove_new

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -674,7 +674,7 @@ static void gpio_keys_irq_close(struct gpio_keys_button_dev *bdev)
 	}
 }
 
-static int gpio_keys_remove(struct platform_device *pdev)
+static void gpio_keys_remove(struct platform_device *pdev)
 {
 	struct gpio_keys_button_dev *bdev = platform_get_drvdata(pdev);
 
@@ -684,13 +684,11 @@ static int gpio_keys_remove(struct platform_device *pdev)
 		gpio_keys_polled_close(bdev);
 	else
 		gpio_keys_irq_close(bdev);
-
-	return 0;
 }
 
 static struct platform_driver gpio_keys_driver = {
 	.probe	= gpio_keys_probe,
-	.remove	= gpio_keys_remove,
+	.remove_new = gpio_keys_remove,
 	.driver	= {
 		.name	= "gpio-keys",
 		.of_match_table = of_match_ptr(gpio_keys_of_match),
@@ -699,7 +697,7 @@ static struct platform_driver gpio_keys_driver = {
 
 static struct platform_driver gpio_keys_polled_driver = {
 	.probe	= gpio_keys_polled_probe,
-	.remove	= gpio_keys_remove,
+	.remove_new = gpio_keys_remove,
 	.driver	= {
 		.name	= "gpio-keys-polled",
 		.of_match_table = of_match_ptr(gpio_keys_polled_of_match),

--- a/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
+++ b/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
@@ -2780,7 +2780,7 @@ static int ltq_mei_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int ltq_mei_remove(struct platform_device *pdev)
+static void ltq_mei_remove(struct platform_device *pdev)
 {
 	int i = 0;
 	int num;
@@ -2794,7 +2794,6 @@ static int ltq_mei_remove(struct platform_device *pdev)
 			IFX_MEI_ExitDevice (i);
 		}
 	}
-	return 0;
 }
 
 static const struct of_device_id ltq_mei_match[] = {
@@ -2804,7 +2803,7 @@ static const struct of_device_id ltq_mei_match[] = {
 
 static struct platform_driver ltq_mei_driver = {
 	.probe = ltq_mei_probe,
-	.remove = ltq_mei_remove,
+	.remove_new = ltq_mei_remove,
 	.driver = {
 		.name = "lantiq,mei-xway",
 		.of_match_table = ltq_mei_match,

--- a/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
+++ b/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
@@ -1865,7 +1865,7 @@ INIT_PRIV_DATA_FAIL:
 	return ret;
 }
 
-static int ltq_atm_remove(struct platform_device *pdev)
+static void ltq_atm_remove(struct platform_device *pdev)
 {
 	int port_num;
 	struct ltq_atm_ops *ops = platform_get_drvdata(pdev);
@@ -1885,13 +1885,11 @@ static int ltq_atm_remove(struct platform_device *pdev)
 	ops->shutdown();
 
 	clear_priv_data();
-
-	return 0;
 }
 
 static struct platform_driver ltq_atm_driver = {
 	.probe = ltq_atm_probe,
-	.remove = ltq_atm_remove,
+	.remove_new = ltq_atm_remove,
 	.driver = {
 		.name = "atm",
 		.of_match_table = ltq_atm_match,

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_deu.c
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_deu.c
@@ -143,7 +143,7 @@ static int ltq_deu_probe(struct platform_device *pdev)
  *  \ingroup IFX_DEU_FUNCTIONS
  *  \brief remove the loaded crypto algorithms   
 */                                 
-static int ltq_deu_remove(struct platform_device *pdev)
+static void ltq_deu_remove(struct platform_device *pdev)
 {
 //#ifdef CONFIG_CRYPTO_DEV_PWR_SAVE_MODE
     #if defined(CONFIG_CRYPTO_DEV_DES)
@@ -168,8 +168,6 @@ static int ltq_deu_remove(struct platform_device *pdev)
     ifxdeu_fini_md5_hmac ();
     #endif
     printk("DEU has exited successfully\n");
-
-	return 0;
 }
 
 
@@ -193,7 +191,7 @@ MODULE_DEVICE_TABLE(of, ltq_deu_match);
 
 static struct platform_driver ltq_deu_driver = {
 	.probe = ltq_deu_probe,
-	.remove = ltq_deu_remove,
+	.remove_new = ltq_deu_remove,
 	.driver = {
 		.name = "deu",
 		.of_match_table = ltq_deu_match,

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
@@ -1566,7 +1566,7 @@ INIT_PRIV_DATA_FAIL:
  *  Output:
  *   none
  */
-static int ltq_ptm_remove(struct platform_device *pdev)
+static void ltq_ptm_remove(struct platform_device *pdev)
 {
     int i;
 
@@ -1591,13 +1591,11 @@ static int ltq_ptm_remove(struct platform_device *pdev)
     ifx_ptm_uninit_chip();
 
     clear_priv_data();
-
-    return 0;
 }
 
 static struct platform_driver ltq_ptm_driver = {
        .probe = ltq_ptm_probe,
-       .remove = ltq_ptm_remove,
+       .remove_new = ltq_ptm_remove,
        .driver = {
                .name = "ptm",
                .of_match_table = ltq_ptm_match,

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
@@ -1079,7 +1079,7 @@ INIT_PRIV_DATA_FAIL:
     return ret;
 }
 
-static int ltq_ptm_remove(struct platform_device *pdev)
+static void ltq_ptm_remove(struct platform_device *pdev)
 {
     int i;
 	ifx_mei_atm_showtime_enter = NULL;
@@ -1103,8 +1103,6 @@ static int ltq_ptm_remove(struct platform_device *pdev)
     ifx_ptm_uninit_chip();
 
     clear_priv_data();
-
-    return 0;
 }
 
 #ifndef MODULE
@@ -1135,7 +1133,7 @@ static int __init queue_gamma_map_setup(char *line)
 #endif
 static struct platform_driver ltq_ptm_driver = {
 	.probe = ltq_ptm_probe,
-	.remove = ltq_ptm_remove,
+	.remove_new = ltq_ptm_remove,
 	.driver = {
 		.name = "ptm",
 		.of_match_table = ltq_ptm_match,

--- a/package/kernel/ubootenv-nvram/src/ubootenv-nvram.c
+++ b/package/kernel/ubootenv-nvram/src/ubootenv-nvram.c
@@ -132,18 +132,17 @@ static int ubootenv_probe(struct platform_device *pdev)
 	return misc_register(&data->misc);
 }
 
-static int ubootenv_remove(struct platform_device *pdev)
+static void ubootenv_remove(struct platform_device *pdev)
 {
 	struct ubootenv_drvdata *data = platform_get_drvdata(pdev);
 
 	data->env = NULL;
 	misc_deregister(&data->misc);
-	return 0;
 }
 
 static struct platform_driver ubootenv_driver = {
 	.probe = ubootenv_probe,
-	.remove = ubootenv_remove,
+	.remove_new = ubootenv_remove,
 	.driver = {
 		.name           = NAME,
 		.of_match_table = of_ubootenv_match,

--- a/target/linux/generic/files/drivers/net/phy/adm6996.c
+++ b/target/linux/generic/files/drivers/net/phy/adm6996.c
@@ -1199,19 +1199,17 @@ static int adm6996_gpio_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int adm6996_gpio_remove(struct platform_device *pdev)
+static void adm6996_gpio_remove(struct platform_device *pdev)
 {
 	struct adm6996_priv *priv = platform_get_drvdata(pdev);
 
 	if (priv && (priv->model == ADM6996M || priv->model == ADM6996L))
 		unregister_switch(&priv->dev);
-
-	return 0;
 }
 
 static struct platform_driver adm6996_gpio_driver = {
 	.probe = adm6996_gpio_probe,
-	.remove = adm6996_gpio_remove,
+	.remove_new = adm6996_gpio_remove,
 	.driver = {
 		.name = "adm6996_gpio",
 	},

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_mmap.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_mmap.c
@@ -217,19 +217,17 @@ static int b53_mmap_probe(struct platform_device *pdev)
 	return b53_swconfig_switch_register(dev);
 }
 
-static int b53_mmap_remove(struct platform_device *pdev)
+static void b53_mmap_remove(struct platform_device *pdev)
 {
 	struct b53_device *dev = platform_get_drvdata(pdev);
 
 	if (dev)
 		b53_switch_remove(dev);
-
-	return 0;
 }
 
 static struct platform_driver b53_mmap_driver = {
 	.probe = b53_mmap_probe,
-	.remove = b53_mmap_remove,
+	.remove_new = b53_mmap_remove,
 	.driver = {
 		.name = "b53-switch",
 	},

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_srab.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_srab.c
@@ -354,19 +354,17 @@ static int b53_srab_probe(struct platform_device *pdev)
 	return b53_swconfig_switch_register(dev);
 }
 
-static int b53_srab_remove(struct platform_device *pdev)
+static void b53_srab_remove(struct platform_device *pdev)
 {
 	struct b53_device *dev = platform_get_drvdata(pdev);
 
 	if (dev)
 		b53_switch_remove(dev);
-
-	return 0;
 }
 
 static struct platform_driver b53_srab_driver = {
 	.probe = b53_srab_probe,
-	.remove = b53_srab_remove,
+	.remove_new = b53_srab_remove,
 	.driver = {
 		.name = "b53-srab-switch",
 	},

--- a/target/linux/generic/files/drivers/net/phy/rtl8366rb.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366rb.c
@@ -1478,7 +1478,7 @@ static int rtl8366rb_probe(struct platform_device *pdev)
 	return err;
 }
 
-static int rtl8366rb_remove(struct platform_device *pdev)
+static void rtl8366rb_remove(struct platform_device *pdev)
 {
 	struct rtl8366_smi *smi = platform_get_drvdata(pdev);
 
@@ -1488,8 +1488,6 @@ static int rtl8366rb_remove(struct platform_device *pdev)
 		rtl8366_smi_cleanup(smi);
 		kfree(smi);
 	}
-
-	return 0;
 }
 
 #ifdef CONFIG_OF
@@ -1506,7 +1504,7 @@ static struct platform_driver rtl8366rb_driver = {
 		.of_match_table = of_match_ptr(rtl8366rb_match),
 	},
 	.probe		= rtl8366rb_probe,
-	.remove		= rtl8366rb_remove,
+	.remove_new		= rtl8366rb_remove,
 };
 
 static int __init rtl8366rb_module_init(void)

--- a/target/linux/generic/files/drivers/net/phy/rtl8366s.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366s.c
@@ -1266,7 +1266,7 @@ static int rtl8366s_probe(struct platform_device *pdev)
 	return err;
 }
 
-static int rtl8366s_remove(struct platform_device *pdev)
+static void rtl8366s_remove(struct platform_device *pdev)
 {
 	struct rtl8366_smi *smi = platform_get_drvdata(pdev);
 
@@ -1276,8 +1276,6 @@ static int rtl8366s_remove(struct platform_device *pdev)
 		rtl8366_smi_cleanup(smi);
 		kfree(smi);
 	}
-
-	return 0;
 }
 
 #ifdef CONFIG_OF
@@ -1296,7 +1294,7 @@ static struct platform_driver rtl8366s_driver = {
 #endif
 	},
 	.probe		= rtl8366s_probe,
-	.remove		= rtl8366s_remove,
+	.remove_new	= rtl8366s_remove,
 };
 
 static int __init rtl8366s_module_init(void)

--- a/target/linux/generic/files/drivers/net/phy/rtl8367.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367.c
@@ -1801,7 +1801,7 @@ static int rtl8367_probe(struct platform_device *pdev)
 	return err;
 }
 
-static int rtl8367_remove(struct platform_device *pdev)
+static void rtl8367_remove(struct platform_device *pdev)
 {
 	struct rtl8366_smi *smi = platform_get_drvdata(pdev);
 
@@ -1811,8 +1811,6 @@ static int rtl8367_remove(struct platform_device *pdev)
 		rtl8366_smi_cleanup(smi);
 		kfree(smi);
 	}
-
-	return 0;
 }
 
 static void rtl8367_shutdown(struct platform_device *pdev)
@@ -1839,7 +1837,7 @@ static struct platform_driver rtl8367_driver = {
 #endif
 	},
 	.probe		= rtl8367_probe,
-	.remove		= rtl8367_remove,
+	.remove_new	= rtl8367_remove,
 	.shutdown	= rtl8367_shutdown,
 };
 

--- a/target/linux/generic/files/drivers/net/phy/rtl8367b.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367b.c
@@ -1600,7 +1600,7 @@ static int  rtl8367b_probe(struct platform_device *pdev)
 	return err;
 }
 
-static int rtl8367b_remove(struct platform_device *pdev)
+static void rtl8367b_remove(struct platform_device *pdev)
 {
 	struct rtl8366_smi *smi = platform_get_drvdata(pdev);
 
@@ -1610,8 +1610,6 @@ static int rtl8367b_remove(struct platform_device *pdev)
 		rtl8366_smi_cleanup(smi);
 		kfree(smi);
 	}
-
-	return 0;
 }
 
 static void rtl8367b_shutdown(struct platform_device *pdev)
@@ -1638,7 +1636,7 @@ static struct platform_driver rtl8367b_driver = {
 #endif
 	},
 	.probe		= rtl8367b_probe,
-	.remove		= rtl8367b_remove,
+	.remove_new	= rtl8367b_remove,
 	.shutdown	= rtl8367b_shutdown,
 };
 


### PR DESCRIPTION
Convert generic driver and package to .remove_new in preparation for kernel 6.12 support.

Specific target are not converted as that will come later once 6.12 is introduced for the specific target.