### PR TITLE
generic: fix trivial driver error

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/ar8327.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8327.c
@@ -1210,7 +1210,7 @@ ar8327_sw_hw_apply(struct switch_dev *dev)
 	return 0;
 }
 
-int
+static int
 ar8327_sw_get_port_igmp_snooping(struct switch_dev *dev,
 				 const struct switch_attr *attr,
 				 struct switch_val *val)
@@ -1228,7 +1228,7 @@ ar8327_sw_get_port_igmp_snooping(struct switch_dev *dev,
 	return 0;
 }
 
-int
+static int
 ar8327_sw_set_port_igmp_snooping(struct switch_dev *dev,
 				 const struct switch_attr *attr,
 				 struct switch_val *val)
@@ -1246,7 +1246,7 @@ ar8327_sw_set_port_igmp_snooping(struct switch_dev *dev,
 	return 0;
 }
 
-int
+static int
 ar8327_sw_get_igmp_snooping(struct switch_dev *dev,
 			    const struct switch_attr *attr,
 			    struct switch_val *val)
@@ -1263,7 +1263,7 @@ ar8327_sw_get_igmp_snooping(struct switch_dev *dev,
 	return 0;
 }
 
-int
+static int
 ar8327_sw_set_igmp_snooping(struct switch_dev *dev,
 			    const struct switch_attr *attr,
 			    struct switch_val *val)
@@ -1279,7 +1279,7 @@ ar8327_sw_set_igmp_snooping(struct switch_dev *dev,
 	return 0;
 }
 
-int
+static int
 ar8327_sw_get_igmp_v3(struct switch_dev *dev,
 		      const struct switch_attr *attr,
 		      struct switch_val *val)
@@ -1295,7 +1295,7 @@ ar8327_sw_get_igmp_v3(struct switch_dev *dev,
 	return 0;
 }
 
-int
+static int
 ar8327_sw_set_igmp_v3(struct switch_dev *dev,
 		      const struct switch_attr *attr,
 		      struct switch_val *val)

--- a/target/linux/generic/files/drivers/net/phy/ar8327.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8327.c
@@ -23,6 +23,7 @@
 #include <linux/lockdep.h>
 #include <linux/ar8216_platform.h>
 #include <linux/workqueue.h>
+#include <linux/of.h>
 #include <linux/of_device.h>
 #include <linux/leds.h>
 #include <linux/mdio.h>

--- a/target/linux/generic/files/drivers/net/phy/rtl8366_smi.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366_smi.c
@@ -254,7 +254,7 @@ static int __rtl8366_smi_read_reg(struct rtl8366_smi *smi, u32 addr, u32 *data)
 #define MDC_MDIO_WRITE_OP		0x0003
 #define MDC_REALTEK_PHY_ADDR		0x0
 
-int __rtl8366_mdio_read_reg(struct rtl8366_smi *smi, u32 addr, u32 *data)
+static int __rtl8366_mdio_read_reg(struct rtl8366_smi *smi, u32 addr, u32 *data)
 {
 	u32 phy_id = smi->phy_id;
 	struct mii_bus *mbus = smi->ext_mbus;
@@ -1527,7 +1527,7 @@ static void rtl8366_smi_reset(struct rtl8366_smi *smi, bool active)
 		reset_control_deassert(smi->reset);
 }
 
-int rtl8366_smi_probe_of(struct platform_device *pdev, struct rtl8366_smi *smi)
+static int rtl8366_smi_probe_of(struct platform_device *pdev, struct rtl8366_smi *smi)
 {
 	int sck = of_get_named_gpio(pdev->dev.of_node, "gpio-sck", 0);
 	int sda = of_get_named_gpio(pdev->dev.of_node, "gpio-sda", 0);
@@ -1577,7 +1577,7 @@ static inline int rtl8366_smi_probe_of(struct platform_device *pdev, struct rtl8
 }
 #endif
 
-int rtl8366_smi_probe_plat(struct platform_device *pdev, struct rtl8366_smi *smi)
+static int rtl8366_smi_probe_plat(struct platform_device *pdev, struct rtl8366_smi *smi)
 {
 	struct rtl8366_platform_data *pdata = pdev->dev.platform_data;
 

--- a/target/linux/generic/files/drivers/net/phy/swconfig.c
+++ b/target/linux/generic/files/drivers/net/phy/swconfig.c
@@ -1057,7 +1057,7 @@ static struct genl_family switch_fam = {
 };
 
 #ifdef CONFIG_OF
-void
+static void
 of_switch_load_portmap(struct switch_dev *dev)
 {
 	struct device_node *port;


### PR DESCRIPTION
It seems new kernel linux version reorganized the header include and now
of.h needs to be explicitly included. This should have been done from
when the driver was introduced.

Add the missing of.h header to fix compilation error in later kernel
version.

It seems new kernel version introduced -Wmissing-prototypes. This new
warning reported drivers that define non static function that are used
statically in the driver.

Fix this by declaring making those function actually static if not
defined in any header and not used outside of the single driver.