### PR TITLE
comgt-ncm: fix modem manufacturer detection

### DIFF
--- a/package/network/utils/comgt/files/ncm.sh
+++ b/package/network/utils/comgt/files/ncm.sh
@@ -91,7 +91,7 @@ proto_ncm_setup() {
 
 	start=$(date +%s)
 	while true; do
-		manufacturer=$(gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk 'NF && $0 !~ /AT\+CGMI/ { sub(/\+CGMI: /,""); print tolower($1); exit; }')
+		manufacturer=$(gcom -d "$device" -s /etc/gcom/getcardinfo.gcom | awk -v RS='\r?\n' 'NF && $0 !~ /AT\+CGMI/ { sub(/\+CGMI: /,""); print tolower($1); exit; }')
 		[ "$manufacturer" = "error" ] && {
 			manufacturer=""
 		}


### PR DESCRIPTION
Fix an issue where NCM interface initialization fails because of wrong modem manufacturer detection.

gcom call returns an output with Windows-style line breaks (containing \r) what makes awk call return empty or malformed manufacturer name. Changing awk RS variable to handle both \n and \r\n as line break fixes this issue.

Fixes #17448 and #17998 GitHub issues.
