### PR TITLE
ath10k-ct: fix return type of ath10k_ahb_remove

### DIFF
--- a/package/kernel/ath10k-ct/patches/003-fix-platform-driver-remove.patch
+++ b/package/kernel/ath10k-ct/patches/003-fix-platform-driver-remove.patch
@@ -1,0 +1,20 @@
+--- a/ath10k-6.14/ahb.c
++++ b/ath10k-6.14/ahb.c
+@@ -820,7 +820,7 @@ err_core_destroy:
+ 	return ret;
+ }
+ 
+-static void ath10k_ahb_remove(struct platform_device *pdev)
++static int ath10k_ahb_remove(struct platform_device *pdev)
+ {
+ 	struct ath10k *ar = platform_get_drvdata(pdev);
+ 
+@@ -834,6 +834,8 @@ static void ath10k_ahb_remove(struct pla
+ 	ath10k_ahb_clock_disable(ar);
+ 	ath10k_ahb_resource_deinit(ar);
+ 	ath10k_core_destroy(ar);
++
++	return 0;
+ }
+ 
+ static struct platform_driver ath10k_ahb_driver = {


### PR DESCRIPTION
In newer kernels the callback platform_driver::remove returns 'void', while on the kernel in OpenWRT it still returns 'int'. This leads to a compilation error:

../build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/linux-ipq40xx_generic/ath10k-ct-regular/ath10k-ct-2025.03.14~63f5b605/ath10k-6.14/ahb.c:845:19: error: initialization of 'int (*)(struct platform_device *)' from incompatible pointer type 'void (*)(struct platform_device *)' [-Wincompatible-pointer-types]
  845 |         .remove = ath10k_ahb_remove,
      |                   ^~~~~~~~~~~~~~~~~

Patch the return type of the backported driver to match the used kernel.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
