### PR TITLE
layerscape: fix Image Builder

### DIFF
--- a/package/boot/tfa-layerscape/Makefile
+++ b/package/boot/tfa-layerscape/Makefile
@@ -43,6 +43,7 @@ endef
 define Trusted-Firmware-A/Default
   BUILD_TARGET:=layerscape
   BUILD_SUBTARGET:=armv8_64b
+  BUILD_DEVICES:=fsl_$(1)
   DEPENDS:=+layerscape-rcw +u-boot-fsl_$(1)
 endef
 

--- a/package/firmware/layerscape/fman-ucode/Makefile
+++ b/package/firmware/layerscape/fman-ucode/Makefile
@@ -25,6 +25,8 @@ define Package/layerscape-fman
   CATEGORY:=Firmware
   TITLE:=NXP FMan ucode
   DEPENDS:=@TARGET_layerscape
+  DEFAULT:=y if TARGET_layerscape_armv8_64b
+  HIDDEN:=1
 endef
 
 define Build/Compile

--- a/package/firmware/layerscape/ls-ddr-phy/Makefile
+++ b/package/firmware/layerscape/ls-ddr-phy/Makefile
@@ -27,6 +27,8 @@ define Package/layerscape-ddr-phy
   CATEGORY:=Firmware
   TITLE:=NXP Layerscape DDR PHY firmware
   DEPENDS:=@TARGET_layerscape
+  DEFAULT:=y if TARGET_layerscape_armv8_64b
+  HIDDEN:=1
 endef
 
 define Build/Compile

--- a/package/firmware/layerscape/ls-dpl/Makefile
+++ b/package/firmware/layerscape/ls-dpl/Makefile
@@ -26,6 +26,8 @@ define Package/layerscape-dpl
   CATEGORY:=Firmware
   TITLE:=NXP DPL firmware
   DEPENDS:=@TARGET_layerscape
+  DEFAULT:=y if TARGET_layerscape_armv8_64b
+  HIDDEN:=1
 endef
 
 MAKE_PATH:=config

--- a/package/firmware/layerscape/ls-mc/Makefile
+++ b/package/firmware/layerscape/ls-mc/Makefile
@@ -25,6 +25,8 @@ define Package/layerscape-mc
   CATEGORY:=Firmware
   TITLE:=NXP MC firmware
   DEPENDS:=@TARGET_layerscape
+  DEFAULT:=y if TARGET_layerscape_armv8_64b
+  HIDDEN:=1
 endef
 
 define Build/Compile

--- a/package/firmware/layerscape/ls-rcw/Makefile
+++ b/package/firmware/layerscape/ls-rcw/Makefile
@@ -25,6 +25,8 @@ define Package/layerscape-rcw
   CATEGORY:=Firmware
   TITLE:=NXP Layerscape RCW binaries
   DEPENDS:=@TARGET_layerscape
+  DEFAULT:=y if TARGET_layerscape_armv7
+  HIDDEN:=1
 endef
 
 BOARDS := \

--- a/target/linux/layerscape/image/armv7.mk
+++ b/target/linux/layerscape/image/armv7.mk
@@ -31,7 +31,6 @@ define Device/fsl_ls1021a-twr
   DEVICE_VENDOR := NXP
   DEVICE_MODEL := TWR-LS1021A
   DEVICE_VARIANT := Default
-  DEVICE_PACKAGES += ~layerscape-rcw
   IMAGE/firmware.bin := \
     ls-clean | \
     ls-append $(1)-rcw.bin | pad-to 1M | \

--- a/target/linux/layerscape/image/armv8_64b.mk
+++ b/target/linux/layerscape/image/armv8_64b.mk
@@ -30,7 +30,6 @@ define Device/fsl_ls1012a-frdm
   DEVICE_MODEL := FRDM-LS1012A
   DEVICE_PACKAGES += \
     layerscape-ppfe \
-    ~trusted-firmware-a-ls1012a-frdm \
     kmod-ppfe
   BLOCKSIZE := 256KiB
   IMAGE/firmware.bin := \
@@ -56,7 +55,6 @@ define Device/fsl_ls1012a-rdb
   DEVICE_MODEL := LS1012A-RDB
   DEVICE_PACKAGES += \
     layerscape-ppfe \
-    ~trusted-firmware-a-ls1012a-rdb \
     kmod-hwmon-ina2xx \
     kmod-iio-fxas21002c-i2c \
     kmod-iio-fxos8700-i2c \
@@ -80,7 +78,6 @@ define Device/fsl_ls1012a-frwy-sdboot
   DEVICE_MODEL := FRWY-LS1012A
   DEVICE_PACKAGES += \
     layerscape-ppfe \
-    ~trusted-firmware-a-ls1012a-frwy-sdboot \
     kmod-ppfe
   DEVICE_DTS := fsl-ls1012a-frwy
   IMAGES += firmware.bin
@@ -105,7 +102,6 @@ define Device/fsl_ls1028a-rdb
   DEVICE_VARIANT := Default
   KERNEL = kernel-bin | gzip | fit gzip $$(DEVICE_DTS_DIR)/$$(DEVICE_DTS).dtb
   DEVICE_PACKAGES += \
-    ~trusted-firmware-a-ls1028a-rdb \
     kmod-hwmon-ina2xx \
     kmod-hwmon-lm90 \
     kmod-rtc-pcf2127
@@ -130,7 +126,6 @@ define Device/fsl_ls1028a-rdb-sdboot
   DEVICE_VARIANT := SD Card Boot
   DEVICE_DTS := fsl-ls1028a-rdb
   DEVICE_PACKAGES += \
-    ~trusted-firmware-a-ls1028a-rdb-sdboot \
     kmod-hwmon-ina2xx \
     kmod-hwmon-lm90 \
     kmod-rtc-pcf2127
@@ -151,8 +146,6 @@ define Device/fsl_ls1043a-rdb
   DEVICE_MODEL := LS1043A-RDB
   DEVICE_VARIANT := Default
   DEVICE_PACKAGES += \
-    ~layerscape-fman \
-    ~trusted-firmware-a-ls1043a-rdb \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
     kmod-hwmon-lm90
@@ -175,8 +168,6 @@ define Device/fsl_ls1043a-rdb-sdboot
   DEVICE_MODEL := LS1043A-RDB
   DEVICE_VARIANT := SD Card Boot
   DEVICE_PACKAGES += \
-    ~layerscape-fman \
-    ~trusted-firmware-a-ls1043a-rdb-sdboot \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
     kmod-hwmon-lm90
@@ -197,9 +188,6 @@ define Device/fsl_ls1046a-frwy
   DEVICE_VENDOR := NXP
   DEVICE_MODEL := FRWY-LS1046A
   DEVICE_VARIANT := Default
-  DEVICE_PACKAGES += \
-    ~layerscape-fman \
-    ~trusted-firmware-a-ls1046a-frwy
   IMAGE/firmware.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
@@ -217,9 +205,6 @@ define Device/fsl_ls1046a-frwy-sdboot
   DEVICE_VENDOR := NXP
   DEVICE_MODEL := FRWY-LS1046A
   DEVICE_VARIANT := SD Card Boot
-  DEVICE_PACKAGES += \
-    ~layerscape-fman \
-    ~trusted-firmware-a-ls1046a-frwy-sdboot
   DEVICE_DTS := fsl-ls1046a-frwy
   IMAGE/sdcard.img.gz := \
     ls-clean | \
@@ -239,8 +224,6 @@ define Device/fsl_ls1046a-rdb
   DEVICE_MODEL := LS1046A-RDB
   DEVICE_VARIANT := Default
   DEVICE_PACKAGES += \
-    ~layerscape-fman \
-    ~trusted-firmware-a-ls1046a-rdb \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
     kmod-hwmon-lm90
@@ -263,8 +246,6 @@ define Device/fsl_ls1046a-rdb-sdboot
   DEVICE_MODEL := LS1046A-RDB
   DEVICE_VARIANT := SD Card Boot
   DEVICE_PACKAGES += \
-    ~layerscape-fman \
-    ~trusted-firmware-a-ls1046a-rdb-sdboot \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
     kmod-hwmon-lm90
@@ -287,9 +268,6 @@ define Device/fsl_ls1088a-rdb
   DEVICE_MODEL := LS1088A-RDB
   DEVICE_VARIANT := Default
   DEVICE_PACKAGES += \
-    ~layerscape-mc \
-    ~layerscape-dpl \
-    ~trusted-firmware-a-ls1088a-rdb \
     restool \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
@@ -315,9 +293,6 @@ define Device/fsl_ls1088a-rdb-sdboot
   DEVICE_MODEL := LS1088A-RDB
   DEVICE_VARIANT := SD Card Boot
   DEVICE_PACKAGES += \
-    ~layerscape-mc \
-    ~layerscape-dpl \
-    ~trusted-firmware-a-ls1088a-rdb-sdboot \
     restool \
     kmod-ahci-qoriq \
     kmod-hwmon-ina2xx \
@@ -342,9 +317,6 @@ define Device/fsl_ls2088a-rdb
   DEVICE_VENDOR := NXP
   DEVICE_MODEL := LS2088ARDB
   DEVICE_PACKAGES += \
-    ~layerscape-mc \
-    ~layerscape-dpl \
-    ~trusted-firmware-a-ls2088a-rdb \
     restool \
     kmod-ahci-qoriq
   IMAGE/firmware.bin := \
@@ -365,12 +337,7 @@ define Device/fsl_lx2160a-rdb
   DEVICE_VENDOR := NXP
   DEVICE_MODEL := LX2160A-RDB
   DEVICE_VARIANT := Rev2.0 silicon
-  DEVICE_PACKAGES += \
-    ~layerscape-mc \
-    ~layerscape-dpl \
-    ~layerscape-ddr-phy \
-    ~trusted-firmware-a-lx2160a-rdb \
-    restool
+  DEVICE_PACKAGES += restool
   IMAGE/firmware.bin := \
     ls-clean | \
     ls-append $(1)-bl2.pbl | pad-to 1M | \
@@ -391,12 +358,7 @@ define Device/fsl_lx2160a-rdb-sdboot
   DEVICE_VENDOR := NXP
   DEVICE_MODEL := LX2160A-RDB
   DEVICE_VARIANT := Rev2.0 silicon SD Card Boot
-  DEVICE_PACKAGES += \
-    ~layerscape-mc \
-    ~layerscape-dpl \
-    ~layerscape-ddr-phy \
-    ~trusted-firmware-a-lx2160a-rdb-sdboot \
-    restool
+  DEVICE_PACKAGES += restool
   DEVICE_DTS := fsl-lx2160a-rdb
   IMAGE/sdcard.img.gz := \
     ls-clean | \


### PR DESCRIPTION
Currently, Image Builder for layerscape is broken on both subtargets due to both of the relying on skipping package
inclusion in the end image package list if prefixed with a tilde(~) which was added in:
https://github.com/openwrt/openwrt/commit/377b66990b9718ea2a508f86b5c9f520ea31639f ("build: introduce support to declare skip package")

But it not added to Image Builder so currently trying to build layerscape device images in Image Builder will fail errors like:
`ERROR: '~trusted-firmware-a-ls1012a-frdm' is not a valid world dependency, format is name(@tag)([<>~=]version)`

So, instead of adding the support for the same feature to Image Builder, lets fix the root cause and drop its usage.

I would also suggest reverting the support for skipping packages to not promote this further.

Fixes: #18411
Fixes: #18412 