### PR TITLE
bcm63xx-cfe: install into image staging dir

### DIFF
--- a/package/kernel/bcm63xx-cfe/Makefile
+++ b/package/kernel/bcm63xx-cfe/Makefile
@@ -35,9 +35,9 @@ define Package/bcm63xx-cfe/install
 endef
 
 define Build/InstallDev
-	rm -rf $(KERNEL_BUILD_DIR)/$(PKG_NAME)
-	mkdir -p $(KERNEL_BUILD_DIR)/$(PKG_NAME)
-	$(CP) -r $(PKG_BUILD_DIR)/* $(KERNEL_BUILD_DIR)/$(PKG_NAME)
+	rm -rf $(STAGING_DIR_IMAGE)/$(PKG_NAME)
+	mkdir -p $(STAGING_DIR_IMAGE)/$(PKG_NAME)
+	$(CP) -r $(PKG_BUILD_DIR)/* $(STAGING_DIR_IMAGE)/$(PKG_NAME)
 endef
 
 $(eval $(call BuildPackage,bcm63xx-cfe))

--- a/target/linux/bcm4908/image/Makefile
+++ b/target/linux/bcm4908/image/Makefile
@@ -33,7 +33,7 @@ define Build/bcm4908img
 	cp -r $(DEVICE_NAME)/* $@-bootfs/
 	touch $@-bootfs/1-openwrt
 	cp $(DTS_DIR)/$(firstword $(DEVICE_DTS)).dtb $@-bootfs/94908.dtb
-	cp $(KDIR)/bcm63xx-cfe/$(subst _,$(comma),$(DEVICE_NAME))/cferam.000 $@-bootfs/
+	cp $(STAGING_DIR_IMAGE)/bcm63xx-cfe/$(subst _,$(comma),$(DEVICE_NAME))/cferam.000 $@-bootfs/
 	cp $(IMAGE_KERNEL) $@-bootfs/vmlinux.lz
 
 	$(STAGING_DIR_HOST)/bin/mkfs.jffs2 --pad=0x800000 --little-endian --squash-uids \

--- a/target/linux/bmips/image/Makefile
+++ b/target/linux/bmips/image/Makefile
@@ -136,7 +136,7 @@ define Build/cfe-jffs2-cferam
 	# will have version 0 and let cferam be the second (version 1).
 	touch $@-cferam/1-openwrt
 	# Add cferam as the last file in the JFFS2 partition
-	cp $(KDIR)/bcm63xx-cfe/$(CFE_RAM_FILE) $@-cferam/$(CFE_RAM_JFFS2_NAME)
+	cp $(STAGING_DIR_IMAGE)/bcm63xx-cfe/$(CFE_RAM_FILE) $@-cferam/$(CFE_RAM_JFFS2_NAME)
 
 	# The JFFS2 partition creation should result in the following
 	# layout:


### PR DESCRIPTION
Currently, bcm63xx-cfe is being installed into kernel build dir, however that does not work for Image Builder as only certain artifacts from kernel build dir are included in Image Builder.

So, simply install bcm63xx-cfe into image staging dir so its artifacts can be used in Image Builder as well.

Fixes: #18408
Fixes: #18409
