### PR TITLE
qualcommax: ipq60xx: add TP-Link EAP625-Outdoor support.

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
@@ -29,7 +29,8 @@ netgear,wax214|\
 netgear,wax610|\
 netgear,wax610y|\
 tplink,eap610-outdoor|\
-tplink,eap623od-hd-v1)
+tplink,eap623od-hd-v1|\
+tplink,eap625-outdoor)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
 	;;
 yuncore,fap650)

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -69,6 +69,7 @@ ALLWIFIBOARDS:= \
 	tplink_eap610-outdoor \
 	tplink_eap620hd-v1 \
 	tplink_eap623od-hd-v1 \
+	tplink_eap625-outdoor \
 	tplink_eap660hd-v1 \
 	wallys_dr40x9 \
 	xiaomi_ax3600 \
@@ -218,6 +219,7 @@ $(eval $(call generate-ipq-wifi-package,spectrum_sax1v1k,Spectrum SAX1V1K))
 $(eval $(call generate-ipq-wifi-package,tplink_eap610-outdoor,TPLink EAP610-Outdoor))
 $(eval $(call generate-ipq-wifi-package,tplink_eap620hd-v1,TP-Link EAP620 HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap623od-hd-v1,TP-Link EAP623-Outdoor HD v1))
+$(eval $(call generate-ipq-wifi-package,tplink_eap625-outdoor,TP-Link EAP625-Outdoor))
 $(eval $(call generate-ipq-wifi-package,tplink_eap660hd-v1,TP-Link EAP660 HD v1))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-eap625-outdoor.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-eap625-outdoor.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: (GPL-2.0+)
+
+/dts-v1/;
+
+#include "ipq6018-eap6XX-outdoor-base.dtsi"
+
+/ {
+	model = "TP-Link EAP625-Outdoor";
+	compatible = "tplink,eap625-outdoor", "qcom,ipq6018";
+};
+
+&wifi {
+	qcom,ath11k-calibration-variant = "TPLink-EAP625-Outdoor";
+	status = "okay";
+};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-eap6XX-outdoor-base.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-eap6XX-outdoor-base.dtsi
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT, GPL-2.0 or later
+/* Copyright (c) 2025, Yang Xiwen <forbidden405@outlook.com> */
+
+/dts-v1/;
+
+#include "ipq6018.dtsi"
+#include "ipq6018-cp-cpu.dtsi"
+#include "ipq6018-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		serial0 = &blsp1_uart3;
+		led-boot = &led_sys_green;
+		led-failsafe = &led_sys_yellow;
+		led-running = &led_sys_green;
+		led-upgrade = &led_sys_yellow;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys_green: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 37 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_sys_yellow: led-1 {
+			color = <LED_COLOR_ID_YELLOW>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&blsp1_uart3 {
+	pinctrl-0 = <&serial_3_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio64";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio65";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	phy_pins: phy-reset-pin {
+		pins = "gpio77";
+		function = "gpio";
+		bias-pull-up;
+	};
+};
+
+&mdio {
+	status = "okay";
+	reset-gpios = <&tlmm 77 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <10000>;
+	reset-post-delay-us = <50000>;
+	pinctrl-0 = <&mdio_pins>, <&phy_pins>;
+	pinctrl-names = "default";
+
+	rtl8211f: ethernet-phy@4 {
+		reg = <4>;
+
+		realtek,clkout-disable;
+		realtek,aldps-enable;
+	};
+};
+
+&switch {
+	status = "okay";
+	switch_lan_bmp = <ESS_PORT5>; /* lan port bitmap */
+	switch_mac_mode1 = <MAC_MODE_SGMII_PLUS>; /* mac mode for uniphy instance0*/
+
+	qcom,port_phyinfo {
+		port@5 {
+			port_id = <5>;
+			phy_address = <4>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&rtl8211f>;
+	phy-mode = "sgmii";
+	label = "lan";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};

--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -149,6 +149,29 @@ define Device/qihoo_360v6
 endef
 TARGET_DEVICES += qihoo_360v6
 
+define Device/tplink_eap6XX-outdoor-base
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := TP-Link
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq6018
+	IMAGE/web-ui-factory.bin := append-ubi | tplink-image-2022
+	TPLINK_SUPPORT_STRING := SupportList:\r\n \
+		EAP610-Outdoor(TP-Link|UN|AX1800-D):1.0\r\n \
+		EAP610-Outdoor(TP-Link|JP|AX1800-D):1.0\r\n \
+		EAP610-Outdoor(TP-Link|CA|AX1800-D):1.0
+		EAP625-Outdoor HD(TP-Link|UN|AX1800-D):1.0\r\n \
+		EAP625-Outdoor HD(TP-Link|CA|AX1800-D):1.0\r\n \
+		EAP625-Outdoor HD(TP-Link|AU|AX1800-D):1.0\r\n \
+		EAP625-Outdoor HD(TP-Link|KR|AX1800-D):1.0\r\n \
+		EAP623-Outdoor HD(TP-Link|UN|AX1800-D):1.0\r\n \
+		EAP623-Outdoor HD(TP-Link|EG|AX1800-D):1.0\r\n \
+		EAP623-Outdoor HD(TP-Link|JP|AX1800-D):1.0\r\n \
+		EAP623-Outdoor HD(TP-Link|AU|AX1800-D):1.0\r\n \
+		EAP623-Outdoor HD(TP-Link|KR|AX1800-D):1.0
+endef 
+
 define Device/tplink_eap610-outdoor
 	$(call Device/FitImage)
 	$(call Device/UbiFit)
@@ -182,6 +205,13 @@ define Device/tplink_eap623od-hd-v1
 	TPLINK_SUPPORT_STRING := SupportList:\r\nEAP623-Outdoor HD(TP-Link|UN|AX1800-D):1.0\r\n
 endef
 TARGET_DEVICES += tplink_eap623od-hd-v1
+
+define Device/tplink_eap625-outdoor
+	$(Device/tplink_eap6XX-outdoor-base)
+	DEVICE_MODEL := EAP625-Outdoor
+	DEVICE_PACKAGES := ipq-wifi-tplink_eap625-outdoor kmod-phy-realtek
+endef
+TARGET_DEVICES += tplink_eap625-outdoor
 
 define Device/yuncore_fap650
 	$(call Device/FitImage)

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
@@ -33,7 +33,8 @@ ipq60xx_setup_interfaces()
 	netgear,wax610|\
 	netgear,wax610y|\
 	tplink,eap610-outdoor|\
-	tplink,eap623od-hd-v1)
+	tplink,eap623od-hd-v1|\
+	tplink,eap625-outdoor)
 		ucidef_set_interface_lan "lan" "dhcp"
 		;;
 	*)
@@ -56,7 +57,8 @@ ipq60xx_setup_macs()
 		label_mac=$lan_mac
 		;;
 	tplink,eap610-outdoor|\
-	tplink,eap623od-hd-v1)
+	tplink,eap623od-hd-v1|\
+	tplink,eap625-outdoor)
 		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
 		lan_mac=$label_mac
 		;;

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -51,7 +51,8 @@ case "$FIRMWARE" in
 		ath11k_set_macflag
 		;;
 	tplink,eap610-outdoor|\
-	tplink,eap623od-hd-v1)
+	tplink,eap623od-hd-v1|\
+	tplink,eap625-outdoor)
 		caldata_from_file "/tmp/factory_data/radio" 0 0x10000
 		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
 		ath11k_patch_mac $label_mac 1

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/preinit/09_mount_factory_data
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/preinit/09_mount_factory_data
@@ -8,7 +8,8 @@ preinit_mount_factory_data() {
 
 	case $(board_name) in
 	tplink,eap610-outdoor|\
-	tplink,eap623od-hd-v1)
+	tplink,eap623od-hd-v1|\
+	tplink,eap625-outdoor)
 		mtd_path=$(find_mtd_chardev "factory_data")
 		ubiattach --dev-path="$mtd_path" --devn=1
 		mkdir /tmp/factory_data

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
@@ -134,7 +134,8 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	tplink,eap610-outdoor|\
-	tplink,eap623od-hd-v1)
+	tplink,eap623od-hd-v1|\
+	tplink,eap625-outdoor)
 		tplink_do_upgrade "$1"
 		;;
 	yuncore,fap650)


### PR DESCRIPTION
TP-Link EAP625-Outdoor PoE only, wall / pole mountable, external antenna AP that is marketed as AX1800.

Specifications:
---------------
* CPU: Qualcomm IPQ6018 Quad core Cortex-A53 (64-bit Quad-core Arm Cortex-A53 @ 1800MHz)
* RAM: 1024 MB
* Storage: GigaDevice PSR1GA30DT 128MB NAND
* Ethernet: Realtek RTL8211F Gigabit RJ45 port with PoE input
* Wi-Fi: QCN9074 (4x4 5 GHz 802.11ax)
* Wi-Fi: IPQ6018 (4x4 2.4 GHz 802.11b/g/n/ax)
* Wi-Fi: 2 external RP-SMA antennas
* LEDs: 1x Green Status (GPIO 37 Active High), 1x Yellow Status (GPIO 32 Active High) and an LED global control GPIO (GPIO 36 Active High, set up by U-Boot)
* Buttons: 1x Reset (GPIO 9 Active Low)
* Serial Port / UART: 4-pin unpopulated header. Pinout 1 - TX, 2 - RX, 3 - GND, 4 - VCC 115200baud

Installation (instructions cribbed from the EAP610-Outdoor, courtesy mrnuke):

Web UI method
-------------

Set up the device using the vendor's web UI. After that go to Management->SSH and enable the "SSH Login" checkbox. Select "Save". The connect to the machine via SSH:

ssh -o hostkeyalgorithms=ssh-rsa <ip_of_device>

Disable signature verification:

cliclientd stopcs

Rename the "-web-ui-factory" image to something less than 63 characters, maintaining the ".bin" suffix.
* Go to System -> Firmware Update.
* Under "New Firmware File", click "Browse" and select the image
* Select "Update" and confirm by clicking "OK".

If the update fails, the web UI should show an error message. Otherwise, the device should reboot into OpenWRT.

TFTP method
-----------

To flash via tftp, first place the initramfs image on the TFTP server, then access the device via serial connection. Once connected, stop the boot process point u-boot at your tftp server:

setenv serverip <ip of tftp server>
setenv ipaddr <ip in same subnet as tftp server>
tftpboot tplink_eap610-outdoor-initramfs-uImage.itb bootm

This should boot OpenWRT. Once booted, flash the sysupgrade.bin image using either luci or the commandline.

Signed-off-by: James Sweeney <code@swny.io>
