### PR TITLE
build: bpf trivial fixup for LLVM_PATH and clean step

### DIFF
--- a/include/bpf.mk
+++ b/include/bpf.mk
@@ -76,6 +76,9 @@ BPF_CFLAGS := \
 
 ifneq ($(CONFIG_HAS_BPF_TOOLCHAIN),)
 ifeq ($(DUMP)$(filter download refresh,$(MAKECMDGOALS)),)
+  ifeq ($(LLVM_PATH), /invalid)
+   $(error ERROR: invalid LLVM path)
+  endif
   CLANG_VER:=$(shell $(CLANG) --target=$(BPF_TARGET) -dM -E - < /dev/null | grep __clang_major__ | cut -d' ' -f3)
   CLANG_VER_VALID:=$(shell [ "$(CLANG_VER)" -ge "$(CLANG_MIN_VER)" ] && echo 1 )
   ifeq ($(CLANG_VER_VALID),)

--- a/include/bpf.mk
+++ b/include/bpf.mk
@@ -75,7 +75,7 @@ BPF_CFLAGS := \
 	-O2 -emit-llvm -Xclang -disable-llvm-passes
 
 ifneq ($(CONFIG_HAS_BPF_TOOLCHAIN),)
-ifeq ($(DUMP)$(filter download refresh,$(MAKECMDGOALS)),)
+ifeq ($(DUMP)$(filter download refresh clean,$(MAKECMDGOALS)),)
   ifeq ($(LLVM_PATH), /invalid)
    $(error ERROR: invalid LLVM path)
   endif


### PR DESCRIPTION
Make sure we have a valid LLVM_PATH and error out if the PATH is set to
'/invalid'. This prevents bash error from reading Clang version from a
non existing tool.

On package clean, we shouldn't care of the presence of Clang or Clang
version as we really want to clean it.

Skip these check as we already do for download and refresh step.