### PR TITLE
mvebu: expand rootfs to "part1" for Fortinet devices

### DIFF
--- a/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/mvebu/cortexa9/base-files/etc/uci-defaults/05_fix-compat-version
@@ -1,6 +1,12 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
+	fortinet,fg-30e|\
+	fortinet,fg-50e|\
+	fortinet,fg-51e|\
+	fortinet,fg-52e|\
+	fortinet,fwf-50e-2r|\
+	fortinet,fwf-51e|\
 	linksys,wrt1900ac-v1|\
         linksys,wrt32x)
 		uci set system.@system[0].compat_version="2.0"

--- a/target/linux/mvebu/cortexa9/base-files/lib/upgrade/fortinet.sh
+++ b/target/linux/mvebu/cortexa9/base-files/lib/upgrade/fortinet.sh
@@ -121,22 +121,23 @@ fortinet_update_fwinfo() {
 fortinet_do_upgrade() {
 	local board_dir="$(tar tf "$1" | grep -m 1 '^sysupgrade-.*/$')"
 	local kern_mtd="$(find_mtd_part kernel)"
-	local root_mtd="$(find_mtd_part rootfs)"
+	local root_mtd="$(find_mtd_part rfs1)"
 	local kern_len kern_ofs root_len root_ofs
 	local imgname
 
 	board_dir="${board_dir%/}"
 
 	if [ -z "$kern_mtd" ] || [ -z "$root_mtd" ]; then
-		echo "ERROR: MTD device \"kernel\" or \"rootfs\" not found"
+		echo "ERROR: MTD device \"kernel\" or \"rfs1\" not found"
 		umount -a
 		reboot -f
 	fi
 	kern_ofs=$(cat /sys/class/mtd/${kern_mtd//\/dev\/mtdblock/mtd}/offset)
 	root_ofs=$(cat /sys/class/mtd/${root_mtd//\/dev\/mtdblock/mtd}/offset)
 
+	# Note: use the offset of "rfs1" instead of concatenated "rootfs"
 	if [ -z "$kern_ofs" ] || [ -z "$root_ofs" ]; then
-		echo "ERROR: failed to get offset of kernel or rootfs"
+		echo "ERROR: failed to get offset of kernel or rootfs (rfs1)"
 		umount -a
 		reboot -f
 	fi

--- a/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-xxe.dtsi
+++ b/target/linux/mvebu/files-6.6/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-xxe.dtsi
@@ -154,6 +154,22 @@
 		gpios = <&gpio1 21 GPIO_ACTIVE_LOW>;
 		regulator-always-on;
 	};
+
+	virtual-flash {
+		compatible = "mtd-concat";
+		devices = <&mtd_rfs1 &mtd_part1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x2a00000>;
+				label = "rootfs";
+			};
+		};
+	};
 };
 
 &i2c0 {
@@ -307,9 +323,9 @@
 				label = "kernel";
 			};
 
-			partition@800000 {
+			mtd_rfs1: partition@800000 {
 				reg = <0x800000 0x1800000>;
-				label = "rootfs";
+				label = "rfs1";
 			};
 
 			partition@2000000 {
@@ -324,10 +340,9 @@
 				read-only;
 			};
 
-			partition@3e00000 {
+			mtd_part1: partition@3e00000 {
 				reg = <0x3e00000 0x1200000>;
 				label = "part1";
-				read-only;
 			};
 
 			partition@5000000 {

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -124,6 +124,9 @@ define Device/fortinet
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | \
     sysupgrade-tar rootfs=$$$$@ | append-metadata
   DEVICE_PACKAGES := kmod-hwmon-nct7802 kmod-dsa-mv88e6xxx
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Partition design has changed compared to older versions (up to 24.10). \
+	Upgrade via sysupgrade mechanism is not possible, so new installation via initramfs image is required.
 endef
 
 define Device/fortinet_fg-30e


### PR DESCRIPTION
Expand rootfs area on Fortinet FortiGate/FortiWiFi devices in mvebu target by concatenating "rfs1" (old: "rootfs") and "part1" partitions. This change will increase the size of "rootfs" partition by 18 MiB.
