### PR TITLE
ath79: fix initramfs execution for NEC Aterm devices

### DIFF
--- a/target/linux/ath79/image/common-nec.mk
+++ b/target/linux/ath79/image/common-nec.mk
@@ -8,6 +8,7 @@ endef
 define Device/nec-netbsd-aterm
   DEVICE_VENDOR := NEC
   LOADER_TYPE := bin
+  LZMA_TEXT_START := 0x82800000
   KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
   ARTIFACTS := uboot.bin


### PR DESCRIPTION
Fix execution of initramfs image on NEC Aterm devices by increasing available memory for lzma extraction of lzma-loader.

The size of initramfs image of v24.10.0 exceeds available memory (LZMA_TEXT_START - LOADADDR) and loader data running at LZMA_TEXT_START will be overwritten by extracted data. As a result, LZMA extraction will be broken and stuck (or unexpectedly reset).
Fix that issue by setting higher LZMA_TEXT_START address to increase available memory by LZMA extraction.

log (v24.10.0):

```
boot> tftpd
tftpd start 192.168.0.1
boot> start tftp load openwrt-24.10.0-ath79-generic-ne
end tftp load length = 6569768
start memory load ...
memory load complete
  begin  : 0x80040000
  length : 6567044
  startup: 0x80040000

boot> boot
begin  : 0x80040000
length : 6567044
startup: 0x80040000
option: 0x0
NEC Aterm series (QCA9558)

Calibrating SGMII
SGMII cal value = 0xe

Configuring SGMII force mode
  SGMII_CONFIG : 0x000000a2
  MR_AN_CONTROL: 0x00008140
  MR_AN_CONTROL: 0x00000140

OpenWrt kernel loader for AR7XXX/AR9XXX
Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org> 
Decompressing kernel... [:<syntax:value>]');retu  <--- (stuck)
IPL:SOFT-RESET                    <--- (reset by WDT)
memory test ... ok
flinstall OK

boot version: 1.0.0
...
```

This fix needs to be backported to v24.10.