### PR TITLE
kernel: add missing submenu for diag modules

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -1651,6 +1651,7 @@ endef
 $(eval $(call KernelPackage,qrtr-mhi))
 
 define KernelPackage/unix-diag
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=UNIX socket monitoring interface
   KCONFIG:=CONFIG_UNIX_DIAG
   FILES:= $(LINUX_DIR)/net/unix/unix_diag.ko
@@ -1660,6 +1661,7 @@ endef
 $(eval $(call KernelPackage,unix-diag))
 
 define KernelPackage/packet-diag
+  SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=Packet sockets monitoring interface
   KCONFIG:=CONFIG_PACKET_DIAG
   FILES:= $(LINUX_DIR)/net/packet/af_packet_diag.ko


### PR DESCRIPTION
The submenu of two diag modules is missing, fixes it.

Fixes: 65de1e0 ("kernel: add missing symbols for lxc")