### PR TITLE
[23.05]: mbedtls: Update to 2.28.10

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=2.28.9
+PKG_VERSION:=2.28.10
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ARMmbed/mbedtls/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=e4dbcf86a4fb31506482888560f02b161e0ecfb82fee0643abcfc86abee5817e
+PKG_HASH:=0f2e0525903a89ae1d39ce439d858be66933bda54c5b6102b72a29ed8fe7c088
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=gpl-2.0.txt


### PR DESCRIPTION
This update contains fixes for:
CVE-2025-27809
CVE-2025-27810

Release Notes:
https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-2.28.10

