### PR TITLE
generic: fix broken TCP fraglist GRO patch

### DIFF
--- a/target/linux/generic/backport-6.6/621-v6.10-03-net-add-code-for-TCP-fraglist-GRO.patch
+++ b/target/linux/generic/backport-6.6/621-v6.10-03-net-add-code-for-TCP-fraglist-GRO.patch
@@ -20,7 +20,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/net/ipv4/tcp_offload.c
 +++ b/net/ipv4/tcp_offload.c
-@@ -342,6 +342,18 @@ found:
+@@ -342,6 +342,19 @@ found:
  	flush |= p->decrypted ^ skb->decrypted;
  #endif
  
@@ -28,6 +28,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 +		flush |= (__force int)(flags ^ tcp_flag_word(th2));
 +		flush |= skb->ip_summed != p->ip_summed;
 +		flush |= skb->csum_level != p->csum_level;
++		flush |= !pskb_may_pull(skb, skb_gro_offset(skb));
 +		flush |= NAPI_GRO_CB(p)->count >= 64;
 +
 +		if (flush || skb_gro_receive_list(p, skb))
@@ -39,7 +40,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	if (flush || skb_gro_receive(p, skb)) {
  		mss = 1;
  		goto out_check_final;
-@@ -406,6 +418,15 @@ INDIRECT_CALLABLE_SCOPE int tcp4_gro_com
+@@ -406,6 +419,15 @@ INDIRECT_CALLABLE_SCOPE int tcp4_gro_com
  	const struct iphdr *iph = ip_hdr(skb);
  	struct tcphdr *th = tcp_hdr(skb);
  

--- a/target/linux/generic/backport-6.6/621-v6.10-05-net-create-tcp_gro_header_pull-helper-function.patch
+++ b/target/linux/generic/backport-6.6/621-v6.10-05-net-create-tcp_gro_header_pull-helper-function.patch
@@ -96,7 +96,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	len = skb_gro_len(skb);
  	flags = tcp_flag_word(th);
  
-@@ -384,7 +390,6 @@ out_check_final:
+@@ -385,7 +391,6 @@ out_check_final:
  	if (p && (!NAPI_GRO_CB(skb)->same_flow || flush))
  		pp = p;
  
@@ -104,7 +104,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	NAPI_GRO_CB(skb)->flush |= (flush != 0);
  
  	return pp;
-@@ -411,15 +416,23 @@ EXPORT_SYMBOL(tcp_gro_complete);
+@@ -412,15 +417,23 @@ EXPORT_SYMBOL(tcp_gro_complete);
  INDIRECT_CALLABLE_SCOPE
  struct sk_buff *tcp4_gro_receive(struct list_head *head, struct sk_buff *skb)
  {

--- a/target/linux/generic/backport-6.6/621-v6.10-06-net-add-heuristic-for-enabling-TCP-fraglist-GRO.patch
+++ b/target/linux/generic/backport-6.6/621-v6.10-06-net-add-heuristic-for-enabling-TCP-fraglist-GRO.patch
@@ -35,7 +35,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/net/ipv4/tcp_offload.c
 +++ b/net/ipv4/tcp_offload.c
-@@ -413,6 +413,36 @@ void tcp_gro_complete(struct sk_buff *sk
+@@ -414,6 +414,36 @@ void tcp_gro_complete(struct sk_buff *sk
  }
  EXPORT_SYMBOL(tcp_gro_complete);
  
@@ -72,7 +72,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  INDIRECT_CALLABLE_SCOPE
  struct sk_buff *tcp4_gro_receive(struct list_head *head, struct sk_buff *skb)
  {
-@@ -428,6 +458,8 @@ struct sk_buff *tcp4_gro_receive(struct
+@@ -429,6 +459,8 @@ struct sk_buff *tcp4_gro_receive(struct
  	if (!th)
  		goto flush;
  


### PR DESCRIPTION
Some regression were reported with the backported upstream version. Old kernel require an additional flush in some case and this was handled in the old downstream patch.

Reintroduce the flush to fix the regression.

Fixes: f63d64ede06b ("generic: move patch from pending to backport")