### PR TITLE
generic: fix broken ARM gc sections patch

### DIFF
--- a/target/linux/generic/pending-6.6/200-ARM-9404-1-arm32-fix-boot-hang-with-HAVE_LD_DEAD_COD.patch
+++ b/target/linux/generic/pending-6.6/200-ARM-9404-1-arm32-fix-boot-hang-with-HAVE_LD_DEAD_COD.patch
@@ -1,0 +1,79 @@
+From cf3d39cfd29ab7bcbd6aa79d4a2f132817969e3d Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 15 Apr 2025 23:16:40 +0200
+Subject: [PATCH] ARM: 9404/1: arm32: fix boot hang with
+ HAVE_LD_DEAD_CODE_DATA_ELIMINATION
+
+It was reported that some SoC (mvebu based for example) hang on kernel
+loading. A variant of the feature was present in OpenWrt from long ago
+and adding the additional entry with KEEP, fix the problem.
+
+Fixes: ed0f94102251 ("ARM: 9404/1: arm32: enable HAVE_LD_DEAD_CODE_DATA_ELIMINATION")
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ arch/arm/include/asm/vmlinux.lds.h | 10 +++++-----
+ arch/arm/kernel/vmlinux.lds.S      |  4 ++--
+ 2 files changed, 7 insertions(+), 7 deletions(-)
+
+--- a/arch/arm/include/asm/vmlinux.lds.h
++++ b/arch/arm/include/asm/vmlinux.lds.h
+@@ -48,7 +48,7 @@
+ #define IDMAP_TEXT							\
+ 		ALIGN_FUNCTION();					\
+ 		__idmap_text_start = .;					\
+-		*(.idmap.text)						\
++		KEEP(*(.idmap.text))					\
+ 		__idmap_text_end = .;					\
+ 
+ #define ARM_DISCARD							\
+@@ -108,12 +108,12 @@
+ 	. = ALIGN(8);							\
+ 	.ARM.unwind_idx : {						\
+ 		__start_unwind_idx = .;					\
+-		*(.ARM.exidx*)						\
++		KEEP(*(.ARM.exidx*))					\
+ 		__stop_unwind_idx = .;					\
+ 	}								\
+ 	.ARM.unwind_tab : {						\
+ 		__start_unwind_tab = .;					\
+-		*(.ARM.extab*)						\
++		KEEP(*(.ARM.extab*))					\
+ 		__stop_unwind_tab = .;					\
+ 	}
+ 
+@@ -125,7 +125,7 @@
+ 	__vectors_lma = .;						\
+ 	OVERLAY 0xffff0000 : NOCROSSREFS AT(__vectors_lma) {		\
+ 		.vectors {						\
+-			*(.vectors)					\
++			KEEP(*(.vectors))				\
+ 		}							\
+ 		.vectors.bhb.loop8 {					\
+ 			*(.vectors.bhb.loop8)				\
+@@ -143,7 +143,7 @@
+ 									\
+ 	__stubs_lma = .;						\
+ 	.stubs ADDR(.vectors) + 0x1000 : AT(__stubs_lma) {		\
+-		*(.stubs)						\
++		KEEP(*(.stubs))						\
+ 	}								\
+ 	ARM_LMA(__stubs, .stubs);					\
+ 	. = __stubs_lma + SIZEOF(.stubs);				\
+--- a/arch/arm/kernel/vmlinux.lds.S
++++ b/arch/arm/kernel/vmlinux.lds.S
+@@ -104,13 +104,13 @@ SECTIONS
+ 	}
+ 	.init.tagtable : {
+ 		__tagtable_begin = .;
+-		*(.taglist.init)
++		KEEP(*(.taglist.init))
+ 		__tagtable_end = .;
+ 	}
+ #ifdef CONFIG_SMP_ON_UP
+ 	.init.smpalt : {
+ 		__smpalt_begin = .;
+-		*(.alt.smp.init)
++		KEEP(*(.alt.smp.init))
+ 		__smpalt_end = .;
+ 	}
+ #endif


### PR DESCRIPTION
Upstream version of ARM gc sections skip eeping some section. It was reported some kernel load hang hence restore what we original did and introduce a new patch that add the additional entry on top of the upstream version.

Fixes: 7843f21c5120 ("generic: replace ARM gc sections patch with upstream version")