### PR TITLE
tools: m4: set -std=gnu17

### DIFF
--- a/tools/m4/Makefile
+++ b/tools/m4/Makefile
@@ -18,6 +18,7 @@ HOST_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/host-build.mk
 
+HOST_CFLAGS += -std=gnu17
 HOST_CONFIGURE_VARS += gl_cv_func_strstr_linear=no
 
 define Host/Uninstall


### PR DESCRIPTION
Fedora 42 updated to GCC15 which now defaults to GNU23 as the default instead of GNU17[1], and this breaks m4 compilation.

Its been reported upstream [2], so until its fixed lets simply set C language version back to GNU17.

[1] https://gcc.gnu.org/gcc-15/porting_to.html#c23
[2] https://savannah.gnu.org/support/?111150
