### PR TITLE
tools: fix compilation with GCC15

### DIFF
--- a/tools/cpio/patches/cpio-c23.patch
+++ b/tools/cpio/patches/cpio-c23.patch
@@ -1,0 +1,23 @@
+--- a/src/extern.h
++++ b/src/extern.h
+@@ -97,7 +97,8 @@ extern char input_is_special;
+ extern char output_is_special;
+ extern char input_is_seekable;
+ extern char output_is_seekable;
+-extern int (*xstat) ();
++//void not good enough
++extern int (*xstat) (const char * restrict,  struct stat * restrict);
+ extern void (*copy_function) ();
+ extern char *change_directory_option;
+ 
+--- a/src/global.c
++++ b/src/global.c
+@@ -185,7 +185,7 @@ bool to_stdout_option = false;
+ 
+ /* A pointer to either lstat or stat, depending on whether
+    dereferencing of symlinks is done for input files.  */
+-int (*xstat) ();
++int (*xstat) (const char * restrict,  struct stat * restrict);
+ 
+ /* Which copy operation to perform. (-i, -o, -p) */
+ void (*copy_function) () = 0;

--- a/tools/elfutils/Makefile
+++ b/tools/elfutils/Makefile
@@ -69,7 +69,7 @@ ifeq ($(HOST_OS),Darwin)
   HOST_CFLAGS += -I/opt/homebrew/include
 endif
 
-HOST_CFLAGS += -Wno-error -fPIC
+HOST_CFLAGS += -Wno-error -fPIC -std=gnu17
 
 HOST_CONFIGURE_ARGS += \
 	--without-libintl-prefix \

--- a/tools/gmp/patches/001-acinclude-m4-fix-std23.patch
+++ b/tools/gmp/patches/001-acinclude-m4-fix-std23.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Marc Glisse <marc.glisse@inria.fr>
+# Date 1738186682 -3600
+#      Wed Jan 29 22:38:02 2025 +0100
+# Node ID 8e7bb4ae7a18b1405ea7f9cbcda450b7d920a901
+# Parent  e84c5c785bbe8ed8c3620194e50b65adfc2f5d83
+Complete function prototype in acinclude.m4 for C23 compatibility
+
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@ GMP_PROG_CC_WORKS_PART([$1], [long long
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}

--- a/tools/gmp/patches/002-acinclude-m4-add-parameter-names.patch
+++ b/tools/gmp/patches/002-acinclude-m4-add-parameter-names.patch
@@ -1,0 +1,22 @@
+# HG changeset patch
+# User Marc Glisse <marc.glisse@inria.fr>
+# Date 1743513946 -7200
+#      Tue Apr 01 15:25:46 2025 +0200
+# Node ID d66d66d82dbbe4f561920d28c1e1cbe6818452c7
+# Parent  1a2ad0e32507e842486c8ac9d5cdc772fd0c335e
+Add parameter names to function prototype
+
+ 2025-02-01  Marc Glisse <marc.glisse@inria.fr>
+ 
+ 	* longlong.h (loongarch64 umul_ppmm): __int128__ -> __int128.
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@ GMP_PROG_CC_WORKS_PART([$1], [long long
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(int,t1 const*,t1,t2,t1 const*,int){}
++void g(int a,t1 const*b,t1 c,t2 d,t1 const*e,int f){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}


### PR DESCRIPTION
Fedora 42 updated to GCC15 which now defaults to GNU23 as the default
instead of GNU17[1], and this breaks compilation for some of our tools.

[1] https://gcc.gnu.org/gcc-15/porting_to.html#c23