### PR TITLE
generic: move TCP fraglist GRO patch to separate file in pending

### DIFF
--- a/target/linux/generic/backport-6.6/621-v6.10-03-net-add-code-for-TCP-fraglist-GRO.patch
+++ b/target/linux/generic/backport-6.6/621-v6.10-03-net-add-code-for-TCP-fraglist-GRO.patch
@@ -20,7 +20,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/net/ipv4/tcp_offload.c
 +++ b/net/ipv4/tcp_offload.c
-@@ -342,6 +342,19 @@ found:
+@@ -342,6 +342,18 @@ found:
  	flush |= p->decrypted ^ skb->decrypted;
  #endif
  
@@ -28,7 +28,6 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 +		flush |= (__force int)(flags ^ tcp_flag_word(th2));
 +		flush |= skb->ip_summed != p->ip_summed;
 +		flush |= skb->csum_level != p->csum_level;
-+		flush |= !pskb_may_pull(skb, skb_gro_offset(skb));
 +		flush |= NAPI_GRO_CB(p)->count >= 64;
 +
 +		if (flush || skb_gro_receive_list(p, skb))
@@ -40,7 +39,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	if (flush || skb_gro_receive(p, skb)) {
  		mss = 1;
  		goto out_check_final;
-@@ -406,6 +419,15 @@ INDIRECT_CALLABLE_SCOPE int tcp4_gro_com
+@@ -406,6 +418,15 @@ INDIRECT_CALLABLE_SCOPE int tcp4_gro_com
  	const struct iphdr *iph = ip_hdr(skb);
  	struct tcphdr *th = tcp_hdr(skb);
  

--- a/target/linux/generic/backport-6.6/621-v6.10-05-net-create-tcp_gro_header_pull-helper-function.patch
+++ b/target/linux/generic/backport-6.6/621-v6.10-05-net-create-tcp_gro_header_pull-helper-function.patch
@@ -96,7 +96,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	len = skb_gro_len(skb);
  	flags = tcp_flag_word(th);
  
-@@ -385,7 +391,6 @@ out_check_final:
+@@ -384,7 +390,6 @@ out_check_final:
  	if (p && (!NAPI_GRO_CB(skb)->same_flow || flush))
  		pp = p;
  
@@ -104,7 +104,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	NAPI_GRO_CB(skb)->flush |= (flush != 0);
  
  	return pp;
-@@ -412,15 +417,23 @@ EXPORT_SYMBOL(tcp_gro_complete);
+@@ -411,15 +416,23 @@ EXPORT_SYMBOL(tcp_gro_complete);
  INDIRECT_CALLABLE_SCOPE
  struct sk_buff *tcp4_gro_receive(struct list_head *head, struct sk_buff *skb)
  {

--- a/target/linux/generic/backport-6.6/621-v6.10-06-net-add-heuristic-for-enabling-TCP-fraglist-GRO.patch
+++ b/target/linux/generic/backport-6.6/621-v6.10-06-net-add-heuristic-for-enabling-TCP-fraglist-GRO.patch
@@ -35,7 +35,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/net/ipv4/tcp_offload.c
 +++ b/net/ipv4/tcp_offload.c
-@@ -414,6 +414,36 @@ void tcp_gro_complete(struct sk_buff *sk
+@@ -413,6 +413,36 @@ void tcp_gro_complete(struct sk_buff *sk
  }
  EXPORT_SYMBOL(tcp_gro_complete);
  
@@ -72,7 +72,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  INDIRECT_CALLABLE_SCOPE
  struct sk_buff *tcp4_gro_receive(struct list_head *head, struct sk_buff *skb)
  {
-@@ -429,6 +459,8 @@ struct sk_buff *tcp4_gro_receive(struct
+@@ -428,6 +458,8 @@ struct sk_buff *tcp4_gro_receive(struct
  	if (!th)
  		goto flush;
  

--- a/target/linux/generic/pending-6.6/690-net-add-missing-check-for-TCP-fraglist-GRO.patch
+++ b/target/linux/generic/pending-6.6/690-net-add-missing-check-for-TCP-fraglist-GRO.patch
@@ -1,0 +1,26 @@
+From 4498f0aa561092bc656bfabe7c4bdae41bc4a5b4 Mon Sep 17 00:00:00 2001
+From: Felix Fietkau <nbd@nbd.name>
+Date: Tue, 7 May 2024 11:24:50 +0200
+Subject: [PATCH] net: add missing check for TCP fraglist GRO
+
+It turns out that the existing checks do not guarantee that the skb can be
+pulled up to the GRO offset. When using the usb r8152 network driver with
+GRO fraglist, the BUG() in __skb_pull is often triggered.
+Fix the crash by adding the missing check.
+
+Fixes: 8d95dc474f85 ("net: add code for TCP fraglist GRO")
+Signed-off-by: Felix Fietkau <nbd@nbd.name>
+---
+ net/ipv4/tcp_offload.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/net/ipv4/tcp_offload.c
++++ b/net/ipv4/tcp_offload.c
+@@ -367,6 +367,7 @@ struct sk_buff *tcp_gro_receive(struct l
+ 		flush |= (__force int)(flags ^ tcp_flag_word(th2));
+ 		flush |= skb->ip_summed != p->ip_summed;
+ 		flush |= skb->csum_level != p->csum_level;
++		flush |= !pskb_may_pull(skb, skb_gro_offset(skb));
+ 		flush |= NAPI_GRO_CB(p)->count >= 64;
+ 
+ 		if (flush || skb_gro_receive_list(p, skb))


### PR DESCRIPTION
Patch 87cb0446b7da also applies to higher kernel versions. 
To apply to them it has been moved to a separate file in pending.

<details><summary>Without this patch, a crash occurs on kernel 6.12:</summary>

```
[ 1567.136669] Oops: invalid opcode: 0000 [#1] SMP PTI
[ 1567.154310] CPU: 1 UID: 0 PID: 985 Comm: irq/24-iwlwifi Tainted: G           O       6.12.23 #0
[ 1567.162784] Tainted: [O]=OOT_MODULE
[ 1567.165293] Hardware name: Microsoft Corporation Virtual Machine/Virtual Machine, BIOS Hyper-V UEFI Release v4.1 05/13/2024
[ 1567.177443] RIP: 0010:skb_pull+0x29/0x30
[ 1567.181772] Code: 00 f3 0f 1e fa 8b 47 70 39 f0 72 1b 29 f0 89 47 70 3b 47 74 72 14 89 f0 48 03 87 c8 00 00 00 48 89 87 c8 00 00 00 c3 31 c0 c3 <0f> 0b 90 0f 1f 40 00 41 57 41 56 41 55 41 54 55 53 48 83 ec 08 8b
[ 1567.198192] RSP: 0018:ffff99ed8001ec68 EFLAGS: 00010297
[ 1567.204628] RAX: 0000000000000550 RBX: ffff96d95a0e2a00 RCX: 0000000000000000
[ 1567.210937] RDX: 0000000000000000 RSI: 0000000000000028 RDI: ffff96d95a0e2200
[ 1567.216329] RBP: ffff96d95a0e2200 R08: ffff96d958873280 R09: 0000000000000000
[ 1567.221385] R10: 0000000000000000 R11: 0000000000000000 R12: ffff96d95a0e2200
[ 1567.227682] R13: 00000000f50f1050 R14: 0000000000000550 R15: 0000000000000550
[ 1567.236943] FS:  0000000000000000(0000) GS:ffff96d952700000(0000) knlGS:0000000000000000
[ 1567.243654] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[ 1567.250600] CR2: 00007fcbc05cffb2 CR3: 0000000018a4c006 CR4: 00000000003706b0
[ 1567.257339] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
[ 1567.265619] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
[ 1567.271937] Call Trace:
[ 1567.274696]  <IRQ>
[ 1567.277185]  skb_gro_receive_list+0x30/0x90
[ 1567.281424]  tcp_gro_receive+0x428/0x460
[ 1567.285430]  inet_gro_receive+0x192/0x230
[ 1567.289693]  dev_gro_receive+0x62c/0x700
[ 1567.300990]  napi_gro_receive+0xad/0x1a0
[ 1567.305405]  ieee80211_rx_napi+0x69/0xa0 [mac80211]
[ 1567.310836]  iwl_pcie_rxq_alloc_rbs+0x416/0x13a0 [iwlwifi]
[ 1567.316259]  iwl_pcie_rxq_alloc_rbs+0xc82/0x13a0 [iwlwifi]
[ 1567.322580]  __napi_poll+0x23/0x160
[ 1567.326945]  net_rx_action+0x18b/0x320
[ 1567.331083]  ? ttwu_do_activate.isra.0+0x9a/0x130
[ 1567.336104]  ? _raw_spin_unlock_irqrestore+0x9/0x20
[ 1567.341231]  ? try_to_wake_up+0xde/0x360
[ 1567.345322]  ? hrtimer_wakeup+0x1d/0x20
[ 1567.349108]  handle_softirqs+0xc0/0x1f0
[ 1567.354695]  do_softirq+0x3b/0x50
[ 1567.358525]  </IRQ>
[ 1567.361090]  <TASK>
[ 1567.363453]  __local_bh_enable_ip+0x35/0x40
[ 1567.367350]  iwl_pcie_irq_handler+0x410/0xab0 [iwlwifi]
[ 1567.372597]  irq_thread_fn+0x1b/0x50
[ 1567.376371]  irq_thread+0x103/0x1b0
[ 1567.379888]  ? irq_thread_dtor+0xa0/0xa0
[ 1567.383909]  ? irq_finalize_oneshot.part.0+0xd0/0xd0
[ 1567.388772]  ? irq_forced_thread_fn+0x70/0x70
[ 1567.393062]  kthread+0xa7/0xd0
[ 1567.396407]  ? kthread_park+0x60/0x60
[ 1567.400132]  ret_from_fork+0x2c/0x50
[ 1567.404247]  ? kthread_park+0x60/0x60
[ 1567.409022]  ret_from_fork_asm+0x11/0x20
[ 1567.412676]  </TASK>
[ 1567.415078] Modules linked in: mt7921e(O) mt7921_common(O) iwlmvm(O) iwldvm(O) ath12k(O) ath11k_pci(O) ath11k(O) ath10k_pci(O) ath10k_core(O) ath(O) mt792x_lib(O) mt76_connac_lib(O) mt76(O) mac80211(O) iwlwifi(O) cfg80211(O) qmi_helpers(O) compat(O) button_hotplug(O)
[ 1567.437536] ---[ end trace 0000000000000000 ]---
[ 1567.443389] RIP: 0010:skb_pull+0x29/0x30
[ 1567.449113] Code: 00 f3 0f 1e fa 8b 47 70 39 f0 72 1b 29 f0 89 47 70 3b 47 74 72 14 89 f0 48 03 87 c8 00 00 00 48 89 87 c8 00 00 00 c3 31 c0 c3 <0f> 0b 90 0f 1f 40 00 41 57 41 56 41 55 41 54 55 53 48 83 ec 08 8b
[ 1567.467459] RSP: 0018:ffff99ed8001ec68 EFLAGS: 00010297
[ 1567.474027] RAX: 0000000000000550 RBX: ffff96d95a0e2a00 RCX: 0000000000000000
[ 1567.482262] RDX: 0000000000000000 RSI: 0000000000000028 RDI: ffff96d95a0e2200
[ 1567.489693] RBP: ffff96d95a0e2200 R08: ffff96d958873280 R09: 0000000000000000
[ 1567.498521] R10: 0000000000000000 R11: 0000000000000000 R12: ffff96d95a0e2200
[ 1567.505923] R13: 00000000f50f1050 R14: 0000000000000550 R15: 0000000000000550
[ 1567.513600] FS:  0000000000000000(0000) GS:ffff96d952700000(0000) knlGS:0000000000000000
[ 1567.523123] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[ 1567.530159] CR2: 00007fcbc05cffb2 CR3: 0000000018a4c006 CR4: 00000000003706b0
[ 1567.538418] DR0: 0000000000000000 DR1: 0000000000000000 DR2: 0000000000000000
[ 1567.546283] DR3: 0000000000000000 DR6: 00000000fffe0ff0 DR7: 0000000000000400
[ 1567.555170] Kernel panic - not syncing: Fatal exception in interrupt
[ 1567.564360] Kernel Offset: 0x31c00000 from 0xffffffff81000000 (relocation range: 0xffffffff80000000-0xffffffffbfffffff)
[ 1567.604057] Rebooting in 3 seconds..
```
</details> 