### PR TITLE
mac80211: ath12k: fix regdb parsing for 6GHz

### DIFF
--- a/package/kernel/mac80211/patches/ath11k/932-wifi-ath11k-poll-reo-status-ipq5018.patch
+++ b/package/kernel/mac80211/patches/ath11k/932-wifi-ath11k-poll-reo-status-ipq5018.patch
@@ -34,7 +34,7 @@ Signed-off-by: Sriram R <srirrama@codeaurora.org>
  		.name = "qca2066 hw2.1",
 --- a/drivers/net/wireless/ath/ath11k/dp.c
 +++ b/drivers/net/wireless/ath/ath11k/dp.c
-@@ -361,12 +361,66 @@ void ath11k_dp_stop_shadow_timers(struct
+@@ -348,12 +348,66 @@ void ath11k_dp_stop_shadow_timers(struct
  	ath11k_dp_shadow_stop_timer(ab, &ab->dp.reo_cmd_timer);
  }
  
@@ -101,7 +101,7 @@ Signed-off-by: Sriram R <srirrama@codeaurora.org>
  	ath11k_dp_srng_cleanup(ab, &dp->wbm_desc_rel_ring);
  	ath11k_dp_srng_cleanup(ab, &dp->tcl_cmd_ring);
  	ath11k_dp_srng_cleanup(ab, &dp->tcl_status_ring);
-@@ -388,6 +442,8 @@ static int ath11k_dp_srng_common_setup(s
+@@ -375,6 +429,8 @@ static int ath11k_dp_srng_common_setup(s
  	int i, ret;
  	u8 tcl_num, wbm_num;
  
@@ -112,7 +112,7 @@ Signed-off-by: Sriram R <srirrama@codeaurora.org>
  				   DP_WBM_RELEASE_RING_SIZE);
 --- a/drivers/net/wireless/ath/ath11k/dp.h
 +++ b/drivers/net/wireless/ath/ath11k/dp.h
-@@ -44,6 +44,8 @@ struct dp_rx_tid {
+@@ -46,6 +46,8 @@ struct dp_rx_tid {
  #define DP_MON_PURGE_TIMEOUT_MS     100
  #define DP_MON_SERVICE_BUDGET       128
  
@@ -121,7 +121,7 @@ Signed-off-by: Sriram R <srirrama@codeaurora.org>
  struct dp_reo_cache_flush_elem {
  	struct list_head list;
  	struct dp_rx_tid data;
-@@ -286,6 +288,10 @@ struct ath11k_dp {
+@@ -288,6 +290,10 @@ struct ath11k_dp {
  	spinlock_t reo_cmd_lock;
  	struct ath11k_hp_update_timer reo_cmd_timer;
  	struct ath11k_hp_update_timer tx_ring_timer[DP_TCL_NUM_RING_MAX];
@@ -132,7 +132,7 @@ Signed-off-by: Sriram R <srirrama@codeaurora.org>
  };
  
  /* HTT definitions */
-@@ -1689,5 +1695,6 @@ void ath11k_dp_shadow_init_timer(struct
+@@ -1691,5 +1697,6 @@ void ath11k_dp_shadow_init_timer(struct
  				 struct ath11k_hp_update_timer *update_timer,
  				 u32 interval, u32 ring_id);
  void ath11k_dp_stop_shadow_timers(struct ath11k_base *ab);

--- a/package/kernel/mac80211/patches/ath12k/003-wifi-ath12k-fix-handling-of-6-GHz-rules.patch
+++ b/package/kernel/mac80211/patches/ath12k/003-wifi-ath12k-fix-handling-of-6-GHz-rules.patch
@@ -1,0 +1,140 @@
+From 64a1ba4072b34af1b76bf15fca5c2075b8cc4d64 Mon Sep 17 00:00:00 2001
+From: Aditya Kumar Singh <aditya.kumar.singh@oss.qualcomm.com>
+Date: Thu, 23 Jan 2025 21:51:38 +0530
+Subject: [PATCH] wifi: ath12k: fix handling of 6 GHz rules
+
+In the US country code, to avoid including 6 GHz rules in the 5 GHz rules
+list, the number of 5 GHz rules is set to a default constant value of 4
+(REG_US_5G_NUM_REG_RULES). However, if there are more than 4 valid 5 GHz
+rules, the current logic will bypass the legitimate 6 GHz rules.
+
+For example, if there are 5 valid 5 GHz rules and 1 valid 6 GHz rule, the
+current logic will only consider 4 of the 5 GHz rules, treating the last
+valid rule as a 6 GHz rule. Consequently, the actual 6 GHz rule is never
+processed, leading to the eventual disabling of 6 GHz channels.
+
+To fix this issue, instead of hardcoding the value to 4, use a helper
+function to determine the number of 6 GHz rules present in the 5 GHz rules
+list and ignore only those rules.
+
+Tested-on: QCN9274 hw2.0 PCI WLAN.WBE.1.3.1-00173-QCAHKSWPL_SILICONZ-1
+
+Cc: stable@vger.kernel.org
+Fixes: d889913205cf ("wifi: ath12k: driver for Qualcomm Wi-Fi 7 devices")
+Signed-off-by: Aditya Kumar Singh <aditya.kumar.singh@oss.qualcomm.com>
+Link: https://patch.msgid.link/20250123-fix_6ghz_rules_handling-v1-1-d734bfa58ff4@oss.qualcomm.com
+Signed-off-by: Jeff Johnson <jeff.johnson@oss.qualcomm.com>
+---
+ drivers/net/wireless/ath/ath12k/wmi.c | 61 ++++++++++++++++++++++++++---------
+ drivers/net/wireless/ath/ath12k/wmi.h |  1 -
+ 2 files changed, 45 insertions(+), 17 deletions(-)
+
+--- a/drivers/net/wireless/ath/ath12k/wmi.c
++++ b/drivers/net/wireless/ath/ath12k/wmi.c
+@@ -4790,6 +4790,22 @@ static struct ath12k_reg_rule
+ 	return reg_rule_ptr;
+ }
+ 
++static u8 ath12k_wmi_ignore_num_extra_rules(struct ath12k_wmi_reg_rule_ext_params *rule,
++					    u32 num_reg_rules)
++{
++	u8 num_invalid_5ghz_rules = 0;
++	u32 count, start_freq;
++
++	for (count = 0; count < num_reg_rules; count++) {
++		start_freq = le32_get_bits(rule[count].freq_info, REG_RULE_START_FREQ);
++
++		if (start_freq >= ATH12K_MIN_6G_FREQ)
++			num_invalid_5ghz_rules++;
++	}
++
++	return num_invalid_5ghz_rules;
++}
++
+ static int ath12k_pull_reg_chan_list_ext_update_ev(struct ath12k_base *ab,
+ 						   struct sk_buff *skb,
+ 						   struct ath12k_reg_info *reg_info)
+@@ -4800,6 +4816,7 @@ static int ath12k_pull_reg_chan_list_ext
+ 	u32 num_2g_reg_rules, num_5g_reg_rules;
+ 	u32 num_6g_reg_rules_ap[WMI_REG_CURRENT_MAX_AP_TYPE];
+ 	u32 num_6g_reg_rules_cl[WMI_REG_CURRENT_MAX_AP_TYPE][WMI_REG_MAX_CLIENT_TYPE];
++	u8 num_invalid_5ghz_ext_rules;
+ 	u32 total_reg_rules = 0;
+ 	int ret, i, j;
+ 
+@@ -4893,20 +4910,6 @@ static int ath12k_pull_reg_chan_list_ext
+ 
+ 	memcpy(reg_info->alpha2, &ev->alpha2, REG_ALPHA2_LEN);
+ 
+-	/* FIXME: Currently FW includes 6G reg rule also in 5G rule
+-	 * list for country US.
+-	 * Having same 6G reg rule in 5G and 6G rules list causes
+-	 * intersect check to be true, and same rules will be shown
+-	 * multiple times in iw cmd. So added hack below to avoid
+-	 * parsing 6G rule from 5G reg rule list, and this can be
+-	 * removed later, after FW updates to remove 6G reg rule
+-	 * from 5G rules list.
+-	 */
+-	if (memcmp(reg_info->alpha2, "US", 2) == 0) {
+-		reg_info->num_5g_reg_rules = REG_US_5G_NUM_REG_RULES;
+-		num_5g_reg_rules = reg_info->num_5g_reg_rules;
+-	}
+-
+ 	reg_info->dfs_region = le32_to_cpu(ev->dfs_region);
+ 	reg_info->phybitmap = le32_to_cpu(ev->phybitmap);
+ 	reg_info->num_phy = le32_to_cpu(ev->num_phy);
+@@ -5009,8 +5012,29 @@ static int ath12k_pull_reg_chan_list_ext
+ 		}
+ 	}
+ 
++	ext_wmi_reg_rule += num_2g_reg_rules;
++
++	/* Firmware might include 6 GHz reg rule in 5 GHz rule list
++	 * for few countries along with separate 6 GHz rule.
++	 * Having same 6 GHz reg rule in 5 GHz and 6 GHz rules list
++	 * causes intersect check to be true, and same rules will be
++	 * shown multiple times in iw cmd.
++	 * Hence, avoid parsing 6 GHz rule from 5 GHz reg rule list
++	 */
++	num_invalid_5ghz_ext_rules = ath12k_wmi_ignore_num_extra_rules(ext_wmi_reg_rule,
++								       num_5g_reg_rules);
++
++	if (num_invalid_5ghz_ext_rules) {
++		ath12k_dbg(ab, ATH12K_DBG_WMI,
++			   "CC: %s 5 GHz reg rules number %d from fw, %d number of invalid 5 GHz rules",
++			   reg_info->alpha2, reg_info->num_5g_reg_rules,
++			   num_invalid_5ghz_ext_rules);
++
++		num_5g_reg_rules = num_5g_reg_rules - num_invalid_5ghz_ext_rules;
++		reg_info->num_5g_reg_rules = num_5g_reg_rules;
++	}
++
+ 	if (num_5g_reg_rules) {
+-		ext_wmi_reg_rule += num_2g_reg_rules;
+ 		reg_info->reg_rules_5g_ptr =
+ 			create_ext_reg_rules_from_wmi(num_5g_reg_rules,
+ 						      ext_wmi_reg_rule);
+@@ -5022,7 +5046,12 @@ static int ath12k_pull_reg_chan_list_ext
+ 		}
+ 	}
+ 
+-	ext_wmi_reg_rule += num_5g_reg_rules;
++	/* We have adjusted the number of 5 GHz reg rules above. But still those
++	 * many rules needs to be adjusted in ext_wmi_reg_rule.
++	 *
++	 * NOTE: num_invalid_5ghz_ext_rules will be 0 for rest other cases.
++	 */
++	ext_wmi_reg_rule += (num_5g_reg_rules + num_invalid_5ghz_ext_rules);
+ 
+ 	for (i = 0; i < WMI_REG_CURRENT_MAX_AP_TYPE; i++) {
+ 		reg_info->reg_rules_6g_ap_ptr[i] =
+--- a/drivers/net/wireless/ath/ath12k/wmi.h
++++ b/drivers/net/wireless/ath/ath12k/wmi.h
+@@ -3965,7 +3965,6 @@ struct ath12k_wmi_eht_rate_set_params {
+ #define MAX_REG_RULES 10
+ #define REG_ALPHA2_LEN 2
+ #define MAX_6G_REG_RULES 5
+-#define REG_US_5G_NUM_REG_RULES 4
+ 
+ struct wmi_set_current_country_arg {
+ 	u8 alpha2[REG_ALPHA2_LEN];

--- a/package/kernel/mac80211/patches/ath12k/103-wifi-ath12k-fix-5GHz-operation-on-wideband-QCN.patch
+++ b/package/kernel/mac80211/patches/ath12k/103-wifi-ath12k-fix-5GHz-operation-on-wideband-QCN.patch
@@ -124,7 +124,7 @@ Best regards,
 
 --- a/drivers/net/wireless/ath/ath12k/mac.c
 +++ b/drivers/net/wireless/ath/ath12k/mac.c
-@@ -5185,9 +5185,7 @@ static void ath12k_mac_setup_ht_vht_cap(
+@@ -5186,9 +5186,7 @@ static void ath12k_mac_setup_ht_vht_cap(
  						    rate_cap_rx_chainmask);
  	}
  

--- a/package/kernel/mac80211/patches/ath12k/104-1-wifi-ath12k-push-HE-MU-MIMO-params-to-hardware.patch
+++ b/package/kernel/mac80211/patches/ath12k/104-1-wifi-ath12k-push-HE-MU-MIMO-params-to-hardware.patch
@@ -284,7 +284,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  		ath12k_control_beaconing(arvif, info);
  
  		if (arvif->is_up && vif->bss_conf.he_support &&
-@@ -5351,11 +5483,14 @@ static void ath12k_mac_copy_he_cap(struc
+@@ -5352,11 +5484,14 @@ static void ath12k_mac_copy_he_cap(struc
  
  	he_cap_elem->mac_cap_info[1] &=
  		IEEE80211_HE_MAC_CAP1_TF_MAC_PAD_DUR_MASK;
@@ -302,7 +302,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	he_cap_elem->phy_cap_info[5] |= num_tx_chains - 1;
  
  	switch (iftype) {
-@@ -6317,71 +6452,6 @@ static int ath12k_mac_setup_vdev_create_
+@@ -6318,71 +6453,6 @@ static int ath12k_mac_setup_vdev_create_
  	return 0;
  }
  
@@ -374,7 +374,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  static void ath12k_mac_update_vif_offload(struct ath12k_vif *arvif)
  {
  	struct ieee80211_vif *vif = arvif->vif;
-@@ -7339,7 +7409,6 @@ ath12k_mac_vdev_start_restart(struct ath
+@@ -7340,7 +7410,6 @@ ath12k_mac_vdev_start_restart(struct ath
  	struct ath12k_base *ab = ar->ab;
  	struct wmi_vdev_start_req_arg arg = {};
  	const struct cfg80211_chan_def *chandef = &ctx->def;
@@ -382,7 +382,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	int ret;
  
  	lockdep_assert_held(&ar->conf_mutex);
-@@ -7395,14 +7464,6 @@ ath12k_mac_vdev_start_restart(struct ath
+@@ -7396,14 +7465,6 @@ ath12k_mac_vdev_start_restart(struct ath
  		spin_unlock_bh(&ab->base_lock);
  
  		/* TODO: Notify if secondary 80Mhz also needs radar detection */

--- a/package/kernel/mac80211/patches/ath12k/104-3-wifi-ath12k-move-HE-MCS-mapper-to-a-separate-function.patch
+++ b/package/kernel/mac80211/patches/ath12k/104-3-wifi-ath12k-move-HE-MCS-mapper-to-a-separate-function.patch
@@ -119,7 +119,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
 
 --- a/drivers/net/wireless/ath/ath12k/mac.c
 +++ b/drivers/net/wireless/ath/ath12k/mac.c
-@@ -5518,12 +5518,24 @@ static __le16 ath12k_mac_setup_he_6ghz_c
+@@ -5519,12 +5519,24 @@ static __le16 ath12k_mac_setup_he_6ghz_c
  	return cpu_to_le16(bcap->he_6ghz_capa);
  }
  
@@ -145,7 +145,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  
  	he_cap->has_he = true;
  	memcpy(he_cap_elem->mac_cap_info, band_cap->he_cap_info,
-@@ -5561,13 +5573,7 @@ static void ath12k_mac_copy_he_cap(struc
+@@ -5562,13 +5574,7 @@ static void ath12k_mac_copy_he_cap(struc
  		break;
  	}
  

--- a/package/kernel/mac80211/patches/ath12k/104-4-wifi-ath12k-generate-rx-and-tx-mcs-maps-for-supported-HE-mcs.patch
+++ b/package/kernel/mac80211/patches/ath12k/104-4-wifi-ath12k-generate-rx-and-tx-mcs-maps-for-supported-HE-mcs.patch
@@ -117,7 +117,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
 
 --- a/drivers/net/wireless/ath/ath12k/mac.c
 +++ b/drivers/net/wireless/ath/ath12k/mac.c
-@@ -5518,20 +5518,40 @@ static __le16 ath12k_mac_setup_he_6ghz_c
+@@ -5519,20 +5519,40 @@ static __le16 ath12k_mac_setup_he_6ghz_c
  	return cpu_to_le16(bcap->he_6ghz_capa);
  }
  
@@ -166,7 +166,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  				   int iftype, u8 num_tx_chains,
  				   struct ieee80211_sta_he_cap *he_cap)
  {
-@@ -5573,7 +5593,7 @@ static void ath12k_mac_copy_he_cap(struc
+@@ -5574,7 +5594,7 @@ static void ath12k_mac_copy_he_cap(struc
  		break;
  	}
  
@@ -175,7 +175,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	memset(he_cap->ppe_thres, 0, sizeof(he_cap->ppe_thres));
  	if (he_cap_elem->phy_cap_info[6] &
  	    IEEE80211_HE_PHY_CAP6_PPE_THRESHOLD_PRESENT)
-@@ -5762,7 +5782,7 @@ static int ath12k_mac_copy_sband_iftype_
+@@ -5763,7 +5783,7 @@ static int ath12k_mac_copy_sband_iftype_
  
  		data[idx].types_mask = BIT(i);
  

--- a/package/kernel/mac80211/patches/ath12k/104-6-wifi-ath12k-add-support-for-setting-fixed-HE-rate-GI-LTF.patch
+++ b/package/kernel/mac80211/patches/ath12k/104-6-wifi-ath12k-add-support-for-setting-fixed-HE-rate-GI-LTF.patch
@@ -604,7 +604,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  			ath12k_peer_assoc_prepare(ar, arvif->vif, sta,
  						  &peer_arg, true);
  
-@@ -7058,10 +7317,13 @@ static int ath12k_mac_op_add_interface(s
+@@ -7059,10 +7318,13 @@ static int ath12k_mac_op_add_interface(s
  
  	for (i = 0; i < ARRAY_SIZE(arvif->bitrate_mask.control); i++) {
  		arvif->bitrate_mask.control[i].legacy = 0xffffffff;
@@ -618,7 +618,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	}
  
  	/* Allocate Default Queue now and reassign during actual vdev create */
-@@ -8222,19 +8484,40 @@ ath12k_mac_has_single_legacy_rate(struct
+@@ -8223,19 +8485,40 @@ ath12k_mac_has_single_legacy_rate(struct
  	if (ath12k_mac_bitrate_mask_num_vht_rates(ar, band, mask))
  		return false;
  
@@ -659,7 +659,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	int i;
  
  	/* No need to consider legacy here. Basic rates are always present
-@@ -8261,7 +8544,24 @@ ath12k_mac_bitrate_mask_get_single_nss(s
+@@ -8262,7 +8545,24 @@ ath12k_mac_bitrate_mask_get_single_nss(s
  			return false;
  	}
  
@@ -685,7 +685,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  		return false;
  
  	if (ht_nss_mask == 0)
-@@ -8308,54 +8608,158 @@ ath12k_mac_get_single_legacy_rate(struct
+@@ -8309,54 +8609,158 @@ ath12k_mac_get_single_legacy_rate(struct
  	return 0;
  }
  
@@ -864,7 +864,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	return 0;
  }
  
-@@ -8384,6 +8788,31 @@ ath12k_mac_vht_mcs_range_present(struct
+@@ -8385,6 +8789,31 @@ ath12k_mac_vht_mcs_range_present(struct
  	return true;
  }
  
@@ -896,7 +896,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  static void ath12k_mac_set_bitrate_mask_iter(void *data,
  					     struct ieee80211_sta *sta)
  {
-@@ -8423,6 +8852,54 @@ static void ath12k_mac_disable_peer_fixe
+@@ -8424,6 +8853,54 @@ static void ath12k_mac_disable_peer_fixe
  }
  
  static int
@@ -951,7 +951,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  ath12k_mac_op_set_bitrate_mask(struct ieee80211_hw *hw,
  			       struct ieee80211_vif *vif,
  			       const struct cfg80211_bitrate_mask *mask)
-@@ -8433,13 +8910,17 @@ ath12k_mac_op_set_bitrate_mask(struct ie
+@@ -8434,13 +8911,17 @@ ath12k_mac_op_set_bitrate_mask(struct ie
  	enum nl80211_band band;
  	const u8 *ht_mcs_mask;
  	const u16 *vht_mcs_mask;
@@ -970,7 +970,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  
  	if (ath12k_mac_vif_chan(vif, &def))
  		return -EPERM;
-@@ -8447,6 +8928,7 @@ ath12k_mac_op_set_bitrate_mask(struct ie
+@@ -8448,6 +8929,7 @@ ath12k_mac_op_set_bitrate_mask(struct ie
  	band = def.chan->band;
  	ht_mcs_mask = mask->control[band].ht_mcs;
  	vht_mcs_mask = mask->control[band].vht_mcs;
@@ -978,7 +978,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	ldpc = !!(ar->ht_cap_info & WMI_HT_CAP_LDPC);
  
  	sgi = mask->control[band].gi;
-@@ -8455,6 +8937,9 @@ ath12k_mac_op_set_bitrate_mask(struct ie
+@@ -8456,6 +8938,9 @@ ath12k_mac_op_set_bitrate_mask(struct ie
  		goto out;
  	}
  
@@ -988,7 +988,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	/* mac80211 doesn't support sending a fixed HT/VHT MCS alone, rather it
  	 * requires passing at least one of used basic rates along with them.
  	 * Fixed rate setting across different preambles(legacy, HT, VHT) is
-@@ -8474,15 +8959,27 @@ ath12k_mac_op_set_bitrate_mask(struct ie
+@@ -8475,15 +8960,27 @@ ath12k_mac_op_set_bitrate_mask(struct ie
  		ieee80211_iterate_stations_mtx(hw,
  					       ath12k_mac_disable_peer_fixed_rate,
  					       arvif);
@@ -1020,7 +1020,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  
  		/* If multiple rates across different preambles are given
  		 * we can reconfigure this info with all peers using PEER_ASSOC
-@@ -8518,12 +9015,22 @@ ath12k_mac_op_set_bitrate_mask(struct ie
+@@ -8519,12 +9016,22 @@ ath12k_mac_op_set_bitrate_mask(struct ie
  			goto out;
  		}
  
@@ -1045,7 +1045,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  		arvif->bitrate_mask = *mask;
  		ieee80211_iterate_stations_mtx(hw,
  					       ath12k_mac_set_bitrate_mask_iter,
-@@ -8534,9 +9041,10 @@ ath12k_mac_op_set_bitrate_mask(struct ie
+@@ -8535,9 +9042,10 @@ ath12k_mac_op_set_bitrate_mask(struct ie
  
  	mutex_lock(&ar->conf_mutex);
  

--- a/package/kernel/mac80211/patches/ath12k/104-7-wifi-ath12k-clean-up-80P80-support.patch
+++ b/package/kernel/mac80211/patches/ath12k/104-7-wifi-ath12k-clean-up-80P80-support.patch
@@ -200,7 +200,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	}
  
  	if (sta->deflink.bandwidth == IEEE80211_STA_RX_BW_80)
-@@ -5805,8 +5779,6 @@ static void ath12k_mac_set_hemcsmap(stru
+@@ -5806,8 +5780,6 @@ static void ath12k_mac_set_hemcsmap(stru
  	mcs_nss->tx_mcs_80 = cpu_to_le16(txmcs_map & 0xffff);
  	mcs_nss->rx_mcs_160 = cpu_to_le16(rxmcs_map & 0xffff);
  	mcs_nss->tx_mcs_160 = cpu_to_le16(txmcs_map & 0xffff);
@@ -209,7 +209,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  }
  
  static void ath12k_mac_copy_he_cap(struct ath12k *ar,
-@@ -5828,6 +5800,7 @@ static void ath12k_mac_copy_he_cap(struc
+@@ -5829,6 +5801,7 @@ static void ath12k_mac_copy_he_cap(struc
  		IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_40MHZ_IN_2G |
  		IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_40MHZ_80MHZ_IN_5G |
  		IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_160MHZ_IN_5G;
@@ -217,7 +217,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	he_cap_elem->phy_cap_info[0] &=
  		~IEEE80211_HE_PHY_CAP0_CHANNEL_WIDTH_SET_80PLUS80_MHZ_IN_5G;
  	he_cap_elem->phy_cap_info[5] &=
-@@ -8494,10 +8467,6 @@ static __le16
+@@ -8495,10 +8468,6 @@ static __le16
  ath12k_mac_get_tx_mcs_map(const struct ieee80211_sta_he_cap *he_cap)
  {
  	if (he_cap->he_cap_elem.phy_cap_info[0] &

--- a/package/kernel/mac80211/patches/ath12k/104-8-wifi-ath12k-add-support-for-160-MHz-bandwidth.patch
+++ b/package/kernel/mac80211/patches/ath12k/104-8-wifi-ath12k-add-support-for-160-MHz-bandwidth.patch
@@ -263,7 +263,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	ath12k_peer_assoc_h_smps(sta, arg);
  
  	/* TODO: amsdu_disable req? */
-@@ -5551,10 +5612,8 @@ ath12k_create_vht_cap(struct ath12k *ar,
+@@ -5552,10 +5613,8 @@ ath12k_create_vht_cap(struct ath12k *ar,
  
  	ath12k_set_vht_txbf_cap(ar, &vht_cap.cap);
  
@@ -276,7 +276,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  
  	rxmcs_map = 0;
  	txmcs_map = 0;
-@@ -9710,7 +9769,8 @@ static int ath12k_mac_setup_iface_combin
+@@ -9711,7 +9770,8 @@ static int ath12k_mac_setup_iface_combin
  	combinations[0].radar_detect_widths = BIT(NL80211_CHAN_WIDTH_20_NOHT) |
  						BIT(NL80211_CHAN_WIDTH_20) |
  						BIT(NL80211_CHAN_WIDTH_40) |
@@ -286,7 +286,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  
  	wiphy->iface_combinations = combinations;
  	wiphy->n_iface_combinations = 1;
-@@ -9926,6 +9986,9 @@ static int ath12k_mac_hw_register(struct
+@@ -9927,6 +9987,9 @@ static int ath12k_mac_hw_register(struct
  	ieee80211_hw_set(hw, SUPPORTS_TX_FRAG);
  	ieee80211_hw_set(hw, REPORTS_LOW_ACK);
  

--- a/package/kernel/mac80211/patches/ath12k/104-9-wifi-ath12k-add-extended-NSS-bandwidth-support-for-160-MHz.patch
+++ b/package/kernel/mac80211/patches/ath12k/104-9-wifi-ath12k-add-extended-NSS-bandwidth-support-for-160-MHz.patch
@@ -133,7 +133,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  		arg->peer_bw_rxnss_override = ATH12K_BW_NSS_MAP_ENABLE;
  
  		if (!rx_nss) {
-@@ -5635,6 +5637,12 @@ ath12k_create_vht_cap(struct ath12k *ar,
+@@ -5636,6 +5638,12 @@ ath12k_create_vht_cap(struct ath12k *ar,
  	vht_cap.vht_mcs.rx_mcs_map = cpu_to_le16(rxmcs_map);
  	vht_cap.vht_mcs.tx_mcs_map = cpu_to_le16(txmcs_map);
  
@@ -146,7 +146,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	return vht_cap;
  }
  
-@@ -5815,11 +5823,12 @@ static void ath12k_mac_set_hemcsmap(stru
+@@ -5816,11 +5824,12 @@ static void ath12k_mac_set_hemcsmap(stru
  				    struct ieee80211_sta_he_cap *he_cap)
  {
  	struct ieee80211_he_mcs_nss_supp *mcs_nss = &he_cap->he_mcs_nss_supp;
@@ -162,7 +162,7 @@ Acked-by: Jeff Johnson <quic_jjohnson@quicinc.com>
  	for (i = 0; i < 8; i++) {
  		if (i < ar->num_tx_chains &&
  		    (ar->cfg_tx_chainmask >> cap->tx_chain_mask_shift) & BIT(i))
-@@ -5832,12 +5841,24 @@ static void ath12k_mac_set_hemcsmap(stru
+@@ -5833,12 +5842,24 @@ static void ath12k_mac_set_hemcsmap(stru
  			rxmcs_map |= IEEE80211_HE_MCS_SUPPORT_0_11 << (i * 2);
  		else
  			rxmcs_map |= IEEE80211_HE_MCS_NOT_SUPPORTED << (i * 2);

--- a/package/kernel/mac80211/patches/build/300-backports-handle-genlmsg_multicast_allns-upstream-ba.patch
+++ b/package/kernel/mac80211/patches/build/300-backports-handle-genlmsg_multicast_allns-upstream-ba.patch
@@ -43,8 +43,8 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 +compat-$(CPTCFG_KERNEL_5_15) += backport-5.15.o backport-genetlink.o
 +compat-$(CPTCFG_KERNEL_6_1) += backport-genetlink.o
  compat-$(CPTCFG_KERNEL_6_4) += backport-6.4.o
+ compat-$(CPTCFG_KERNEL_6_11) += backport-6.11.o
  
- compat-$(CPTCFG_BPAUTO_BUILD_CRYPTO_LIB_ARC4) += lib-crypto-arc4.o
 --- a/compat/backport-genetlink.c
 +++ b/compat/backport-genetlink.c
 @@ -17,6 +17,7 @@


### PR DESCRIPTION
Add backport patch that fixes ath12k regdomain parsing failure in 6GHz band triggered by the latest regdb/board-2.bin update.
