### PR TITLE
uboot-tools: remove uneeded syncconfig

### DIFF
--- a/package/boot/uboot-tools/Makefile
+++ b/package/boot/uboot-tools/Makefile
@@ -80,7 +80,8 @@ MAKE_FLAGS += \
 	ARCH="sandbox" \
 	TARGET_CFLAGS="$(TARGET_CFLAGS)" \
 	TARGET_LDFLAGS="$(TARGET_LDFLAGS)" \
-	NO_PYTHON=1
+	NO_PYTHON=1 \
+	V=$(if $(findstring c,$(OPENWRT_VERBOSE)),1,)
 
 define Build/Compile
 

--- a/package/boot/uboot-tools/Makefile
+++ b/package/boot/uboot-tools/Makefile
@@ -71,7 +71,6 @@ endef
 
 define Build/Configure
 	$(call Build/Compile/Default,tools-only_defconfig)
-	$(call Build/Compile/Default,syncconfig)
 	$(SED) 's/CONFIG_TOOLS_LIBCRYPTO=y/# CONFIG_TOOLS_LIBCRYPTO is not set/' $(PKG_BUILD_DIR)/.config
 	$(SED) 's/CONFIG_TOOLS_KWBIMAGE=y/# CONFIG_TOOLS_KWBIMAGE is not set/' $(PKG_BUILD_DIR)/.config
 endef


### PR DESCRIPTION
During envtools conversion to the generic uboot-tools package, a syncconfig
call was added to the configure step which was previously not there.

We received multiple spourious reports that now envtools were failing to
build [1], but it was not reproducible.

However, it seems that this could easily be reproduced on MacOS 15 and
somehow that syncconfig call is breaking build by Makefile.autoconf not
being executed and thus no "include/config.h" is generated.

So, since this call was not previously there and U-Boot will actually do
syncconfig on its own when needed lets drop it.

[1] https://github.com/openwrt/openwrt/commit/293d5f1366e099cc343a3fc8a6f936ab27bcad6a#commitcomment-154347516

While debugging, I noticed that there was no verbose print, so a change to also cover this was added.

Signed-off-by: Robert Marko <robimarko@gmail.com>