### PR TITLE
x86: fix PATH_MAX macro redefined in exec-cmd.c on macOS 15.4

### DIFF
--- a/target/linux/generic/hack-6.6/200-tools_portability.patch
+++ b/target/linux/generic/hack-6.6/200-tools_portability.patch
@@ -61,6 +61,19 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #define __cold
  
  typedef __u16 __bitwise __le16;
+--- a/tools/lib/subcmd/exec-cmd.c
++++ b/tools/lib/subcmd/exec-cmd.c
+@@ -12,7 +12,10 @@
+ #include "subcmd-config.h"
+ 
+ #define MAX_ARGS	32
++
++#ifndef PATH_MAX
+ #define PATH_MAX	4096
++#endif
+ 
+ static const char *argv_exec_path;
+ static const char *argv0_path;
 --- a/tools/objtool/include/objtool/objtool.h
 +++ b/tools/objtool/include/objtool/objtool.h
 @@ -12,6 +12,7 @@


### PR DESCRIPTION
Fix an error while building `target/linux` for target x64, on macOS 15.4 host, due to the `PATH_MAX` macro being redefined:

``` C
mkdir -p /Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-6.6.86/tools/objtool && make O=/Volumes/test/openwrt/build_dir/target-x86_64_musl/linux-x86_64/linux-6.6.86 subdir=tools/objtool --no-print-directory -C objtool exec-cmd.c:15:9: error: 'PATH_MAX' macro redefined [-Werror,-Wmacro-redefined]
   15 | #define PATH_MAX        4096
      |         ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/syslimits.h:103:9: note: previous definition is here
  103 | #define PATH_MAX                 1024   /* max bytes in pathname */
      |         ^
```
Complete build log [2025-04-18 linux PATH_MAX redefined.txt](https://httpstorm.com/share/.openwrt/test/2025-04-18_linux/2025-04-18%20linux%20PATH_MAX%20redefined.txt)

`exec-cmd.c` is compiled as part of `objtool` to run on the host, and therefore host headers are used, where `PATH_MAX` is already defined. Using an old OpenWRT snapshot from 2025-02-16, where `linux-6.6.77` used to build correctly, does not help. Reverting from Xcode 16.3 to 16.2 does not help either.

I am not sure if this is the correct approach to fix the error. It might be possible to fix it by changing header paths, but I don't know how to do it or how to check what paths are used in the build. Any help or suggestions are welcome. It may also be more appropriate to place the patch in `generic` instead of `x86`. But my build for WRT3200ACM completes successfully and does not attempt to build `objtool`, while the `x64` target fails.

Build tested: WRT3200ACM on macOS 15.4.1 Intel
Build and run tested: x64 on macOS 15.4.1 Intel

@robimarko @hauke @Ansuel @aparcar @PolynomialDivision @ynezz @namiltd  @Noltari @dangowrt @rsalvaterra 