### PR TITLE
ath79,bmips,mediatek,ramips: convert driver to .remove_new

### DIFF
--- a/target/linux/ath79/files/drivers/mtd/nand/raw/ar934x_nand.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/ar934x_nand.c
@@ -1452,7 +1452,7 @@ err_free_buf:
 	return ret;
 }
 
-static int ar934x_nfc_remove(struct platform_device *pdev)
+static void ar934x_nfc_remove(struct platform_device *pdev)
 {
 	struct ar934x_nfc *nfc;
 
@@ -1462,8 +1462,6 @@ static int ar934x_nfc_remove(struct platform_device *pdev)
 		nand_cleanup(&nfc->nand_chip);
 		ar934x_nfc_free_buf(nfc);
 	}
-
-	return 0;
 }
 
 static const struct of_device_id ar934x_nfc_match[] = {
@@ -1475,7 +1473,7 @@ MODULE_DEVICE_TABLE(of, ar934x_nfc_match);
 
 static struct platform_driver ar934x_nfc_driver = {
 	.probe		= ar934x_nfc_probe,
-	.remove		= ar934x_nfc_remove,
+	.remove_new	= ar934x_nfc_remove,
 	.driver = {
 		.name	= AR934X_NFC_DRIVER_NAME,
 		.of_match_table = ar934x_nfc_match,

--- a/target/linux/ath79/files/drivers/mtd/nand/raw/nand_rb4xx.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/nand_rb4xx.c
@@ -214,14 +214,12 @@ static int rb4xx_nand_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int rb4xx_nand_remove(struct platform_device *pdev)
+static void rb4xx_nand_remove(struct platform_device *pdev)
 {
 	struct rb4xx_nand *nand = platform_get_drvdata(pdev);
 
 	mtd_device_unregister(nand_to_mtd(&nand->chip));
 	nand_cleanup(&nand->chip);
-
-	return 0;
 }
 
 static const struct platform_device_id rb4xx_nand_id_table[] = {
@@ -232,7 +230,7 @@ MODULE_DEVICE_TABLE(platform, rb4xx_nand_id_table);
 
 static struct platform_driver rb4xx_nand_driver = {
 	.probe = rb4xx_nand_probe,
-	.remove = rb4xx_nand_remove,
+	.remove_new = rb4xx_nand_remove,
 	.id_table = rb4xx_nand_id_table,
 	.driver = {
 		.name = "rb4xx-nand",

--- a/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
@@ -335,13 +335,11 @@ static int rb91x_nand_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int rb91x_nand_remove(struct platform_device *pdev)
+static void rb91x_nand_remove(struct platform_device *pdev)
 {
 	struct rb91x_nand_drvdata *drvdata = platform_get_drvdata(pdev);
 
 	rb91x_nand_release(drvdata);
-
-	return 0;
 }
 
 static const struct of_device_id rb91x_nand_match[] = {
@@ -353,7 +351,7 @@ MODULE_DEVICE_TABLE(of, rb91x_nand_match);
 
 static struct platform_driver rb91x_nand_driver = {
 	.probe	= rb91x_nand_probe,
-	.remove	= rb91x_nand_remove,
+	.remove_new	= rb91x_nand_remove,
 	.driver	= {
 		.name	= "rb91x-nand",
 		.of_match_table = rb91x_nand_match,

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_legacy_mdio.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_legacy_mdio.c
@@ -221,12 +221,11 @@ static int ag71xx_mdio_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int ag71xx_mdio_remove(struct platform_device *pdev)
+static void ag71xx_mdio_remove(struct platform_device *pdev)
 {
 	struct ag71xx_mdio *am = platform_get_drvdata(pdev);
 
 	mdiobus_unregister(am->mii_bus);
-	return 0;
 }
 
 static const struct of_device_id ag71xx_mdio_match[] = {
@@ -239,7 +238,7 @@ static const struct of_device_id ag71xx_mdio_match[] = {
 
 static struct platform_driver ag71xx_mdio_driver = {
 	.probe		= ag71xx_mdio_probe,
-	.remove		= ag71xx_mdio_remove,
+	.remove_new	= ag71xx_mdio_remove,
 	.driver = {
 		.name	 = "ag71xx-legacy-mdio",
 		.of_match_table = ag71xx_mdio_match,

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -1731,20 +1731,20 @@ err_phy_disconnect:
 	return err;
 }
 
-static int ag71xx_remove(struct platform_device *pdev)
+static void ag71xx_remove(struct platform_device *pdev)
 {
 	struct net_device *dev = platform_get_drvdata(pdev);
 	struct ag71xx *ag;
 
 	if (!dev)
-		return 0;
+		return;
 
 	ag = netdev_priv(dev);
 	ag71xx_debugfs_exit(ag);
 	ag71xx_phy_disconnect(ag);
 	unregister_netdev(dev);
 	platform_set_drvdata(pdev, NULL);
-	return 0;
+
 }
 
 static const struct of_device_id ag71xx_match[] = {
@@ -1763,7 +1763,7 @@ static const struct of_device_id ag71xx_match[] = {
 
 static struct platform_driver ag71xx_driver = {
 	.probe		= ag71xx_probe,
-	.remove		= ag71xx_remove,
+	.remove_new	= ag71xx_remove,
 	.driver = {
 		.name	= AG71XX_DRV_NAME,
 		.of_match_table = ag71xx_match,

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6348-enet.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6348-enet.c
@@ -1675,7 +1675,7 @@ out_disable_clk:
 	return ret;
 }
 
-static int bcm6348_emac_remove(struct platform_device *pdev)
+static void bcm6348_emac_remove(struct platform_device *pdev)
 {
 	struct net_device *ndev = platform_get_drvdata(pdev);
 	struct bcm6348_emac *emac = netdev_priv(ndev);
@@ -1688,8 +1688,6 @@ static int bcm6348_emac_remove(struct platform_device *pdev)
 
 	for (i = 0; i < emac->num_clocks; i++)
 		clk_disable_unprepare(emac->clock[i]);
-
-	return 0;
 }
 
 static const struct of_device_id bcm6348_emac_of_match[] = {
@@ -1706,7 +1704,7 @@ static struct platform_driver bcm6348_emac_driver = {
 		.of_match_table = of_match_ptr(bcm6348_emac_of_match),
 	},
 	.probe	= bcm6348_emac_probe,
-	.remove	= bcm6348_emac_remove,
+	.remove_new	= bcm6348_emac_remove,
 };
 
 int bcm6348_iudma_drivers_register(struct platform_device *pdev)

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -1100,7 +1100,7 @@ out_disable_clk:
 	return ret;
 }
 
-static int bcm6368_enetsw_remove(struct platform_device *pdev)
+static void bcm6368_enetsw_remove(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
 	struct net_device *ndev = platform_get_drvdata(pdev);
@@ -1118,8 +1118,6 @@ static int bcm6368_enetsw_remove(struct platform_device *pdev)
 
 	for (i = 0; i < priv->num_clocks; i++)
 		clk_disable_unprepare(priv->clock[i]);
-
-	return 0;
 }
 
 static const struct of_device_id bcm6368_enetsw_of_match[] = {
@@ -1138,7 +1136,7 @@ static struct platform_driver bcm6368_enetsw_driver = {
 		.of_match_table = of_match_ptr(bcm6368_enetsw_of_match),
 	},
 	.probe	= bcm6368_enetsw_probe,
-	.remove	= bcm6368_enetsw_remove,
+	.remove_new	= bcm6368_enetsw_remove,
 };
 module_platform_driver(bcm6368_enetsw_driver);
 

--- a/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s_mdio.c
+++ b/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s_mdio.c
@@ -283,17 +283,15 @@ static int rtk_gsw_probe(struct platform_device *pdev)
 	
 }
 
-static int rtk_gsw_remove(struct platform_device *pdev)
+static void rtk_gsw_remove(struct platform_device *pdev)
 {
 	platform_set_drvdata(pdev, NULL);
 	gsw_debug_proc_exit();
-
-	return 0;
 }
 
 static struct platform_driver gsw_driver = {
 	.probe = rtk_gsw_probe,
-	.remove = rtk_gsw_remove,
+	.remove_new = rtk_gsw_remove,
 	.driver = {
 		.name = "rtk-gsw",
 		.of_match_table = rtk_gsw_match,

--- a/target/linux/ramips/files/drivers/dma/mediatek/hsdma-mt7621.c
+++ b/target/linux/ramips/files/drivers/dma/mediatek/hsdma-mt7621.c
@@ -733,7 +733,7 @@ err_uninit_hsdma:
 	return ret;
 }
 
-static int mtk_hsdma_remove(struct platform_device *pdev)
+static void mtk_hsdma_remove(struct platform_device *pdev)
 {
 	struct mtk_hsdam_engine *hsdma = platform_get_drvdata(pdev);
 
@@ -741,13 +741,11 @@ static int mtk_hsdma_remove(struct platform_device *pdev)
 
 	of_dma_controller_free(pdev->dev.of_node);
 	dma_async_device_unregister(&hsdma->ddev);
-
-	return 0;
 }
 
 static struct platform_driver mtk_hsdma_driver = {
 	.probe = mtk_hsdma_probe,
-	.remove = mtk_hsdma_remove,
+	.remove_new = mtk_hsdma_remove,
 	.driver = {
 		.name = KBUILD_MODNAME,
 		.of_match_table = mtk_hsdma_of_match,

--- a/target/linux/ramips/files/drivers/dma/ralink-gdma.c
+++ b/target/linux/ramips/files/drivers/dma/ralink-gdma.c
@@ -890,20 +890,18 @@ err_unregister:
 	return ret;
 }
 
-static int gdma_dma_remove(struct platform_device *pdev)
+static void gdma_dma_remove(struct platform_device *pdev)
 {
 	struct gdma_dma_dev *dma_dev = platform_get_drvdata(pdev);
 
 	tasklet_kill(&dma_dev->task);
 	of_dma_controller_free(pdev->dev.of_node);
 	dma_async_device_unregister(&dma_dev->ddev);
-
-	return 0;
 }
 
 static struct platform_driver gdma_dma_driver = {
 	.probe = gdma_dma_probe,
-	.remove = gdma_dma_remove,
+	.remove_new = gdma_dma_remove,
 	.driver = {
 		.name = "gdma-rt2880",
 		.of_match_table = gdma_of_match_table,

--- a/target/linux/ramips/files/drivers/mmc/host/mtk-mmc/sd.c
+++ b/target/linux/ramips/files/drivers/mmc/host/mtk-mmc/sd.c
@@ -2346,7 +2346,7 @@ host_free:
 }
 
 /* 4 device share one driver, using "drvdata" to show difference */
-static int msdc_drv_remove(struct platform_device *pdev)
+static void msdc_drv_remove(struct platform_device *pdev)
 {
 	struct mmc_host *mmc;
 	struct msdc_host *host;
@@ -2371,8 +2371,6 @@ static int msdc_drv_remove(struct platform_device *pdev)
 			  host->dma.bd,  host->dma.bd_addr);
 
 	mmc_free_host(host->mmc);
-
-	return 0;
 }
 
 /* Fix me: Power Flow */
@@ -2412,7 +2410,7 @@ MODULE_DEVICE_TABLE(of, mt7620_sdhci_match);
 
 static struct platform_driver mt_msdc_driver = {
 	.probe   = msdc_drv_probe,
-	.remove  = msdc_drv_remove,
+	.remove_new  = msdc_drv_remove,
 #ifdef CONFIG_PM
 	.suspend = msdc_drv_suspend,
 	.resume  = msdc_drv_resume,

--- a/target/linux/ramips/files/drivers/mtd/nand/raw/mt7621_nand.c
+++ b/target/linux/ramips/files/drivers/mtd/nand/raw/mt7621_nand.c
@@ -1312,7 +1312,7 @@ static int mt7621_nfc_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int mt7621_nfc_remove(struct platform_device *pdev)
+static void mt7621_nfc_remove(struct platform_device *pdev)
 {
 	struct mt7621_nfc *nfc = platform_get_drvdata(pdev);
 	struct nand_chip *nand = &nfc->nand;
@@ -1321,8 +1321,6 @@ static int mt7621_nfc_remove(struct platform_device *pdev)
 	mtk_bmt_detach(mtd);
 	mtd_device_unregister(mtd);
 	nand_cleanup(nand);
-
-	return 0;
 }
 
 static const struct of_device_id mt7621_nfc_id_table[] = {
@@ -1333,7 +1331,7 @@ MODULE_DEVICE_TABLE(of, match);
 
 static struct platform_driver mt7621_nfc_driver = {
 	.probe = mt7621_nfc_probe,
-	.remove = mt7621_nfc_remove,
+	.remove_new = mt7621_nfc_remove,
 	.driver = {
 		.name = MT7621_NFC_NAME,
 		.of_match_table = mt7621_nfc_id_table,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
@@ -1437,7 +1437,7 @@ static int esw_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int esw_remove(struct platform_device *pdev)
+static void esw_remove(struct platform_device *pdev)
 {
 	struct rt305x_esw *esw = platform_get_drvdata(pdev);
 
@@ -1445,8 +1445,6 @@ static int esw_remove(struct platform_device *pdev)
 		esw_w32(esw, ~0, RT305X_ESW_REG_IMR);
 		platform_set_drvdata(pdev, NULL);
 	}
-
-	return 0;
 }
 
 static const struct of_device_id ralink_esw_match[] = {
@@ -1522,7 +1520,7 @@ int rt3050_esw_init(struct fe_priv *priv)
 
 static struct platform_driver esw_driver = {
 	.probe = esw_probe,
-	.remove = esw_remove,
+	.remove_new = esw_remove,
 	.driver = {
 		.name = "rt3050-esw",
 		.of_match_table = ralink_esw_match,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
@@ -284,16 +284,14 @@ static int mt7620_gsw_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int mt7620_gsw_remove(struct platform_device *pdev)
+static void mt7620_gsw_remove(struct platform_device *pdev)
 {
 	platform_set_drvdata(pdev, NULL);
-
-	return 0;
 }
 
 static struct platform_driver gsw_driver = {
 	.probe = mt7620_gsw_probe,
-	.remove = mt7620_gsw_remove,
+	.remove_new = mt7620_gsw_remove,
 	.driver = {
 		.name = "mt7620-gsw",
 		.of_match_table = mediatek_gsw_match,

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -1638,7 +1638,7 @@ static int fe_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static int fe_remove(struct platform_device *pdev)
+static void fe_remove(struct platform_device *pdev)
 {
 	struct net_device *dev = platform_get_drvdata(pdev);
 	struct fe_priv *priv = netdev_priv(dev);
@@ -1648,13 +1648,11 @@ static int fe_remove(struct platform_device *pdev)
 	cancel_work_sync(&priv->pending_work);
 
 	platform_set_drvdata(pdev, NULL);
-
-	return 0;
 }
 
 static struct platform_driver fe_driver = {
 	.probe = fe_probe,
-	.remove = fe_remove,
+	.remove_new = fe_remove,
 	.driver = {
 		.name = "mtk_soc_eth",
 		.of_match_table = of_fe_match,


### PR DESCRIPTION
Convert driver to .remove_new in preparation for kernel 6.12 support.
