### PR TITLE
util-linux: add include linux/unistd.h patch

### DIFF
--- a/package/utils/util-linux/patches/0100-include-linux-unistd-h.patch
+++ b/package/utils/util-linux/patches/0100-include-linux-unistd-h.patch
@@ -1,0 +1,33 @@
+From 0033f97482a7979e0de71de0a16b583e8d74dbdc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Thomas=20Wei=C3=9Fschuh?= <thomas@t-8ch.de>
+Date: Sat, 19 Apr 2025 22:02:11 +0200
+Subject: [PATCH] include/mount-api-utils: include linux/unistd.h
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+If SYS_statmount/SYS_listmount is not provided by the libc,
+util-linux will fall back to __NR_statmount/__NR_listmount from the
+kernel UAPI headers.
+However it is not guaranteed that these symbols are actually visible in
+mount-api-utils.
+
+Include linux/unistd.h which provides syscall numbers.
+While this header is specific to Linux, the code is already using
+linux/mount.h.
+
+Signed-off-by: Thomas Weißschuh <thomas@t-8ch.de>
+---
+ include/mount-api-utils.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/include/mount-api-utils.h
++++ b/include/mount-api-utils.h
+@@ -8,6 +8,7 @@
+ #ifdef HAVE_LINUX_MOUNT_H
+ #include <sys/mount.h>
+ #include <linux/mount.h>
++#include <linux/unistd.h>
+ #include <sys/syscall.h>
+ #include <inttypes.h>
+ 


### PR DESCRIPTION
If SYS_statmount/SYS_listmount is not provided by the libc, util-linux will fall back to __NR_statmount/__NR_listmount from the kernel UAPI headers.
However it is not guaranteed that these symbols are actually visible in mount-api-utils.

Include linux/unistd.h which provides syscall numbers. While this header is specific to Linux, the code is already using linux/mount.h.
