### PR TITLE
rockchip: explicitly specify pine64_rockpro64 supported devices

### DIFF
--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -135,6 +135,7 @@ define Device/pine64_rockpro64
   DEVICE_VENDOR := Pine64
   DEVICE_MODEL := RockPro64
   SOC := rk3399
+  SUPPORTED_DEVICES += pine64,rockpro64-v2.1
 endef
 TARGET_DEVICES += pine64_rockpro64
 


### PR DESCRIPTION
I went to upgrade my [Pine64 RockPro64](https://openwrt.org/toh/hwdata/pine64/pine64_rockpro64_2.1)  from OpenWrt 24.10 to OpenWrt 24.10.1 and image verification was failing.

After figuring out how the device model is determined by sysupgrade and getting a slight understanding
of how metadata ends up in the image through the build system I believe this to be the best fix - changing the detection
seems far more invasive and like it would affect a lot more than this specific target.

Here is the error that occurs before this change:

```
root@router-1:/tmp# sysupgrade --test openwrt-24.10.1-rockchip-armv8-pine64_rockpro64-squashfs-sysupgrade.img.gz 
Sun Apr 20 10:04:06 UTC 2025 upgrade: Device pine64,rockpro64-v2.1 not supported by this image
Sun Apr 20 10:04:06 UTC 2025 upgrade: Supported devices: pine64,rockpro64
Sun Apr 20 10:04:06 UTC 2025 upgrade: Reading partition table from bootdisk...
Sun Apr 20 10:04:06 UTC 2025 upgrade: Reading partition table from image...
Image check failed.
root@router-1:/tmp# echo $?
1
```


And here is the expected behaviour after this change is applied:

```
root@router-1:/tmp# sysupgrade --test openwrt-24.10.1-rockchip-armv8-pine64_rockpro64-squashfs-sysupgrade.img.gz 
Sun Apr 20 10:02:41 UTC 2025 upgrade: Reading partition table from bootdisk...
Sun Apr 20 10:02:41 UTC 2025 upgrade: Reading partition table from image...
root@router-1:/tmp# echo $?
0
```