### PR TITLE
qualcommax: add support for ELECOM WRC-X3000GS2

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
@@ -8,6 +8,11 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+elecom,wrc-x3000gs2)
+	idx="$(find_mtd_index 0:appsblenv)"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000"
+	;;
 glinet,gl-b3000)
 	idx="$(find_mtd_index 0:APPSBLENV)"
 	[ -n "$idx" ] && \

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -38,6 +38,7 @@ ALLWIFIBOARDS:= \
 	dynalink_dl-wrx36 \
 	edgecore_eap102 \
 	edimax_cax1800 \
+	elecom_wrc-x3000gs2 \
 	glinet_gl-ax1800 \
 	glinet_gl-axt1800 \
 	glinet_gl-b3000 \
@@ -189,6 +190,7 @@ $(eval $(call generate-ipq-wifi-package,compex_wpq873,Compex WPQ-873))
 $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))
 $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))
+$(eval $(call generate-ipq-wifi-package,elecom_wrc-x3000gs2,ELECOM WRC-X3000GS2))
 $(eval $(call generate-ipq-wifi-package,glinet_gl-ax1800,GL.iNet GL-AX1800))
 $(eval $(call generate-ipq-wifi-package,glinet_gl-axt1800,GL.iNet GL-AXT1800))
 $(eval $(call generate-ipq-wifi-package,glinet_gl-b3000,GL.iNet GL-B3000))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wrc-x3000gs2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wrc-x3000gs2.dts
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq5018.dtsi"
+#include "ipq5018-ess.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "ELECOM WRC-X3000GS2";
+	compatible = "elecom,wrc-x3000gs2", "qcom,ipq5018";
+
+	aliases {
+		serial0 = &blsp1_uart1;
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+		label-mac-device = <&dp1>;
+	};
+
+	chosen {
+		bootargs-append = " root=/dev/ubiblock0_1 coherent_pool=2M";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		switch-router {
+			label = "router";
+			gpios = <&tlmm 14 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		reset-button {
+			label = "reset";
+			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps";
+			gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		led-0 {
+			gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WPS;
+		};
+
+		led_power_green: led-1 {
+			gpios = <&tlmm 13 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led_power_red: led-2 {
+			gpios = <&tlmm 16 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led-3 {
+			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			linux,default-trigger = "phy1radio";
+		};
+
+		led-4 {
+			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+		};
+
+		led-5 {
+			gpios = <&tlmm 26 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			linux,default-trigger = "phy0radio";
+		};
+
+		led-6 {
+			gpios = <&tlmm 28 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+		};
+
+		led-7 {
+			gpios = <&tlmm 46 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+		};
+	};
+
+	reserved-memory {
+		q6_mem_regions: q6_mem_regions@4b000000 {
+			no-map;
+			reg = <0x0 0x4b000000 0x0 0x3000000>;
+			status = "disabled";
+		};
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&xo_board_clk {
+	clock-frequency = <24000000>;
+};
+
+&blsp1_uart1 {
+	status = "okay";
+
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qfprom {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	pinctrl-0 = <&qpic_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		nand-ecc-engine = <&qpic_nand>;
+
+		/* strength=8 breaks NAND I/O, use 4 instead */
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+
+			partition-0-appsblenv {
+				compatible = "fixed-partitions";
+				label = "0:appsblenv";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "env-data";
+					reg = <0x0 0x40000>;
+
+					nvmem-layout {
+						compatible = "u-boot,env";
+
+						macaddr_appsblenv_ethaddr: ethaddr {
+							compatible = "mac-base";
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
+
+	qcom,port_phyinfo {
+		port@0 {
+			port_id = <1>;
+			mdiobus = <&mdio0>;
+			phy_address = <7>;
+		};
+
+		port@1 {
+			port_id = <2>;
+			forced-speed = <1000>;
+			forced-duplex = <1>;
+		};
+	};
+};
+
+&dp1 {
+	status = "okay";
+
+	label = "wan";
+	nvmem-cells = <&macaddr_appsblenv_ethaddr 3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&dp2 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_appsblenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+&mdio1 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio1_pins>, <&switch_reset_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 39 GPIO_ACTIVE_LOW>;
+
+	qca8337_0: ethernet-phy@0 {
+		reg = <0>;
+	};
+
+	qca8337_1: ethernet-phy@1 {
+		reg = <1>;
+	};
+
+	qca8337_2: ethernet-phy@2 {
+		reg = <2>;
+	};
+
+	qca8337_3: ethernet-phy@3 {
+		reg = <3>;
+	};
+
+	ethernet-switch@18 {
+		compatible = "qca,qca8337";
+		reg = <0x18>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@1 {
+				reg = <1>;
+				label = "lan1";
+				phy-handle = <&qca8337_0>;
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+				phy-handle = <&qca8337_1>;
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan3";
+				phy-handle = <&qca8337_2>;
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "lan4";
+				phy-handle = <&qca8337_3>;
+			};
+
+			port@6 {
+				reg = <6>;
+				phy-mode = "sgmii";
+				ethernet = <&dp2>;
+				qca,sgmii-enable-pll;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		button-pins {
+			pins = "gpio22", "gpio38";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		switch-pins {
+			pins = "gpio14";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+	};
+
+	led_pins: led-state {
+		pins = "gpio12", "gpio13", "gpio16", "gpio24",
+		       "gpio25", "gpio26", "gpio28", "gpio46";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	mdio1_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio36";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio37";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	qpic_pins: qpic-state {
+		clock-pins {
+			pins = "gpio9";
+			function = "qspi_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		cs-pins {
+			pins = "gpio8";
+			function = "qspi_cs";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		data-pins {
+			pins = "gpio4", "gpio5", "gpio6", "gpio7";
+			function = "qspi_data";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	serial_0_pins: uart0-state {
+		pins = "gpio20", "gpio21";
+		function = "blsp0_uart0";
+		bias-disable;
+	};
+
+	switch_reset_pins: switch-reset-state {
+		pins = "gpio39";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+};
+
+&tsens {
+	status = "okay";
+};
+
+/*
+ * ath11k Wi-Fi consumes too large memory spaces and too few spaces are
+ * available for users. To prevent OOM when using LuCI or other softwares,
+ * disable Wi-Fi related peripherals at the moment.
+ */
+&q6v5_wcss {
+	status = "disabled";
+
+	memory-region = <&q6_mem_regions>;
+	firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt",
+			"ath11k/IPQ5018/hw1.0/m3_fw.mdt",
+			"ath11k/QCN6122/hw1.0/m3_fw.mdt";
+
+	boot-args = <0x2 4 2 18 0 0>; /* pcie:1, len:4, updid:2, reset:gpio18 */
+
+	q6_wcss_pd1: pd-1 {
+		firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt";
+
+		resets =
+			<&gcc GCC_WCSSAON_RESET>,
+			<&gcc GCC_WCSS_BCR>,
+			<&gcc GCC_CE_BCR>;
+		reset-names =
+			"wcss_aon_reset",
+			"wcss_reset",
+			"ce_reset";
+
+		clocks =
+			<&gcc GCC_WCSS_AHB_S_CLK>,
+			<&gcc GCC_WCSS_ACMT_CLK>,
+			<&gcc GCC_WCSS_AXI_M_CLK>;
+		clock-names =
+			"gcc_wcss_ahb_s_clk",
+			"gcc_wcss_acmt_clk",
+			"gcc_wcss_axi_m_clk";
+
+		interrupts-extended =
+			<&wcss_smp2p_in 8 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 9 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 12 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 11 IRQ_TYPE_NONE>;
+		interrupt-names =
+			"fatal",
+			"ready",
+			"spawn-ack",
+			"stop-ack";
+
+		qcom,smem-states =
+			<&wcss_smp2p_out 8>,
+			<&wcss_smp2p_out 9>,
+			<&wcss_smp2p_out 10>;
+		qcom,smem-state-names =
+			"shutdown",
+			"stop",
+			"spawn";
+	};
+
+	q6_wcss_pd2: pd-2 {
+		firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt";
+
+		interrupts-extended =
+			<&wcss_smp2p_in 16 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 17 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 20 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 19 IRQ_TYPE_NONE>;
+		interrupt-names =
+			"fatal",
+			"ready",
+			"spawn-ack",
+			"stop-ack";
+
+		qcom,smem-states =
+			<&wcss_smp2p_out 16>,
+			<&wcss_smp2p_out 17>,
+			<&wcss_smp2p_out 18>;
+		qcom,smem-state-names =
+			"shutdown",
+			"stop",
+			"spawn";
+	};
+};
+
+&wifi0 {
+	qcom,rproc = <&q6_wcss_pd1>;
+	qcom,userpd-subsys-name = "q6v5_wcss_userpd1";
+	qcom,ath11k-calibration-variant = "ELECOM-WRC-X3000GS2";
+	qcom,ath11k-fw-memory-mode = <2>;
+	qcom,bdf-addr = <0x4c400000>;
+
+	ieee80211-freq-limit = <2400000 2483000>;
+
+	status = "disabled";
+};
+
+&wifi1 {
+	qcom,rproc = <&q6_wcss_pd2>;
+	qcom,userpd-subsys-name = "q6v5_wcss_userpd2";
+	qcom,ath11k-calibration-variant = "ELECOM-WRC-X3000GS2";
+	qcom,ath11k-fw-memory-mode = <2>;
+	qcom,bdf-addr = <0x4d100000>;
+	qcom,m3-dump-addr = <0x4df00000>;
+
+	ieee80211-freq-limit = <5150000 5730000>;
+
+	status = "disabled";
+};

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/01_leds
@@ -9,6 +9,9 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+elecom,wrc-x3000gs2)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan" "tx rx link_10 link_100 link_1000"
+	;;
 linksys,mr5500)
 	ucidef_set_led_netdev "lan1-port-link" "LAN1-PORT-LINK" "qca8k-0.0:00:green:lan" "lan1" "link_10 link_100 link_1000"
 	ucidef_set_led_netdev "lan1-port-activity" "LAN1-PORT-ACTIVITY" "qca8k-0.0:00:amber:lan" "lan1" "tx rx"

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
@@ -7,11 +7,12 @@ ipq50xx_setup_interfaces()
 {
 	local board="$1"
 	case $board in
-	glinet,gl-b3000)
-		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
-		;;
+	elecom,wrc-x3000gs2|\
 	linksys,mr5500)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+		;;
+	glinet,gl-b3000)
+		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
 	linksys,mx2000|\
 	linksys,mx5500|\

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -9,6 +9,12 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath11k/IPQ5018/hw1.0/cal-ahb-c000000.wifi.bin")
 	case "$board" in
+	elecom,wrc-x3000gs2)
+		caldata_extract "0:art" 0x1000 0x20000
+		wlan_mac=$(mtd_get_mac_ascii 0:appsblenv wifi0)
+		ath11k_patch_mac $wlan_mac 0
+		ath11k_set_macflag
+		;;
 	glinet,gl-b3000)
 		caldata_extract "0:art" 0x1000 0x20000
 		ath11k_patch_mac $(macaddr_add $(get_mac_label_dt) 3) 0
@@ -28,6 +34,12 @@ case "$FIRMWARE" in
 	;;
 "ath11k/QCN6122/hw1.0/cal-ahb-b00a040.wifi1.bin")
 	case "$board" in
+	elecom,wrc-x3000gs2)
+		caldata_extract "0:art" 0x26800 0x20000
+		wlan_mac=$(mtd_get_mac_ascii 0:appsblenv wifi1)
+		ath11k_patch_mac $wlan_mac 0
+		ath11k_set_macflag
+		;;
 	glinet,gl-b3000)
 		caldata_extract "0:art" 0x26800 0x20000
 		ath11k_patch_mac $(macaddr_add $(get_mac_label_dt) 4) 0

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/elecom.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/elecom.sh
@@ -1,0 +1,119 @@
+. /lib/functions.sh
+
+bootconfig_find_entry() {
+	local cfgbin="$1"
+	local partname="$2"
+	local i part parts offset
+
+	parts=$(hexdump -n 4 -s 8 -e '1/4 "%d"' "$cfgbin")
+	# partition count: <= 10
+	[ -z "$parts" ] || [ "$parts" = "0" ] || [ "$parts" -gt "10" ] && \
+		return 1
+
+	for i in $(seq 1 $parts); do
+		offset=$((0xc + 0x14 * (i - 1)))
+		part=$(dd if="$cfgbin" iflag=skip_bytes \
+			skip=$offset bs=16 count=1 2>/dev/null)
+		if [ "$part" = "$partname" ]; then
+			printf "0x%08x" $offset
+			return
+		fi
+	done
+
+	return 1
+}
+
+# Read or update an entry in Qualcomm bootconfig partition
+#
+# parameters:
+#   $1: partition name of bootconfig (ex.: "0:bootconfig", "0:bootconfig1", etc)
+#   $2: entry name in bootconfig (ex.: "0:hlos", "rootfs", etc)
+#   $3: index to set for the entry (0/1)
+#
+# operations:
+#   read : bootconfig_rw_index <bootconfig> <entry>
+#   write: bootconfig_rw_index <bootconfig> <entry> <index>
+bootconfig_rw_index() {
+	local bootcfg="$1"
+	local partname="$2"
+	local index="$3"
+	local mtddev
+	local offset
+	local current
+
+	if [ -z "$bootcfg" ] || [ -z "$partname" ]; then
+		echo "no value specified for bootconfig or partition entry"
+		return 1
+	fi
+
+	case "$index" in
+	0|1|"") ;;
+	*) echo "invalid bootconfig index specified \"$index\""; return 1 ;;
+	esac
+
+	mtddev="$(find_mtd_part $bootcfg)"
+	[ -z "$mtddev" ] && \
+		return 1
+
+	dd if=$mtddev of=/tmp/${mtddev##*/} bs=1k
+
+	offset=$(bootconfig_find_entry "/tmp/${mtddev##*/}" $partname) || return 1
+	current=$(hexdump -n 4 -s $((offset + 0x10)) -e '1/4 "%d"' /tmp/${mtddev##*/})
+
+	[ -z "$index" ] && \
+		echo "$current" && return 0
+
+	if [ "$current" != "$index" ]; then
+		printf "\x$index" | \
+			dd of=$mtddev conv=notrunc bs=1 seek=$((offset + 0x10))
+	fi
+}
+
+# Qcom U-Boot always sets a name of current active partition to "rootfs" and
+# inactive partition is named as "rootfs_1", in the smem partition table.
+# When the second partition is active, "rootfs" and "rootfs_1" are swapped.
+smempart_next_root() {
+	local index="$1"
+	local root_idx="$(find_mtd_index rootfs)"
+	local root1_idx="$(find_mtd_index rootfs_1)"
+	local root_offset root1_offset
+
+	[ -z "$root_idx" ] || [ -z "$root1_idx" ] && \
+		return 1
+
+	root_offset=$(cat /sys/block/mtdblock$root_idx/device/offset)
+	root1_offset=$(cat /sys/block/mtdblock$root1_idx/device/offset)
+
+	case "$index" in
+	0)
+		[ "$root_offset" -lt "$root1_offset" ] && \
+			echo "rootfs" || \
+			echo "rootfs_1"
+		;;
+	1)
+		[ "$root_offset" -lt "$root1_offset" ] && \
+			echo "rootfs_1" || \
+			echo "rootfs"
+		;;
+	*)
+		echo "invalid index specified..."
+		return 1
+		;;
+	esac
+}
+
+elecom_upgrade_prepare() {
+	local index
+
+	if ! index=$(bootconfig_rw_index "0:bootconfig" rootfs); then
+		v "failed to read bootconfig index..."
+		nand_do_upgrade_failed
+	fi
+
+	if ! CI_UBIPART=$(smempart_next_root $index); then
+		v "failed to get next root..."
+		nand_do_upgrade_failed
+	fi
+
+	v "next rootfs: $index (current: $CI_UBIPART)"
+}

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
@@ -1,7 +1,7 @@
 PART_NAME=firmware
 REQUIRE_IMAGE_METADATA=1
 
-RAMFS_COPY_BIN='dumpimage fw_printenv fw_setenv head'
+RAMFS_COPY_BIN='dumpimage fw_printenv fw_setenv head seq'
 RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
 remove_oem_ubi_volume() {
@@ -71,6 +71,19 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
+	elecom,wrc-x3000gs2)
+		local delay index
+
+		delay=$(fw_printenv bootdelay)
+		[ -z "$delay" ] || [ "$delay" -eq "0" ] && \
+			fw_setenv bootdelay 3
+
+		elecom_upgrade_prepare
+
+		remove_oem_ubi_volume ubi_rootfs
+		remove_oem_ubi_volume wifi_fw
+		nand_do_upgrade "$1"
+		;;
 	glinet,gl-b3000)
 		glinet_do_upgrade "$1"
 		;;

--- a/target/linux/qualcommax/patches-6.6/0413-spi-spi-qpic-snand-add-user-config-support.patch
+++ b/target/linux/qualcommax/patches-6.6/0413-spi-spi-qpic-snand-add-user-config-support.patch
@@ -1,0 +1,35 @@
+From 589b7e9600b1e50574ce91e4d6fc903ef81d957f Mon Sep 17 00:00:00 2001
+From: INAGAKI Hiroshi <musashino.open@gmail.com>
+Date: Fri, 14 Feb 2025 18:19:58 +0900
+Subject: [PATCH] spi: spi-qpic-snand: add user_config support for ECC
+
+Make the ECC strength in the qpic-snand driver configurable via device
+tree to use the device-specific ECC strength value.
+
+Signed-off-by: INAGAKI Hiroshi <musashino.open@gmail.com>
+---
+--- a/drivers/spi/spi-qpic-snand.c
++++ b/drivers/spi/spi-qpic-snand.c
+@@ -274,8 +274,20 @@ static int qcom_spi_ecc_init_ctx_pipelin
+ 	nand->ecc.ctx.priv = ecc_cfg;
+ 	snandc->qspi->mtd = mtd;
+ 
+-	/* BCH8 or BCH4 */
+-	ecc_mode = mtd->oobsize > 64 ? 1 : 0;
++	/* BCH4 or BCH8 */
++	switch (nand->ecc.user_conf.strength) {
++	case 4:
++		ecc_mode = 0;
++		break;
++	case 8:
++		ecc_mode = 1;
++		break;
++	default:
++		ecc_mode = mtd->oobsize > 64 ? 1 : 0;
++		dev_warn(snandc->dev,
++			 "invalid ECC strength detected, configured from mtd oobsize\n");
++		break;
++	}
+ 
+ 	ecc_cfg->ecc_bytes_hw = ecc_mode ? 13 : 7;
+ 	ecc_cfg->spare_bytes = ecc_mode ? 2 : 4;


### PR DESCRIPTION
This patch series adds support for ELECOM WRC-X3000GS2.

This depends on https://github.com/openwrt/firmware_qca-wireless/pull/85.

Note: Wi-Fi related peripherals are disabled to save available memory