### PR TITLE
qualcommax: ipq5018: gl-b3000: fix uboot support

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -513,9 +513,9 @@ define Build/gl-qsdk-factory
 
 	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh \
 		$(GL_ITS) \
+		$(BOOT_SCRIPT) \
 		$(GL_UBI) \
-		$(GL_IMGK) \
-		$(BOOT_SCRIPT)
+		$(GL_IMGK)
 
 	sed -i "s/rootfs_size/`wc -c $(GL_IMGK) | \
 	cut -d " " -f 1 | xargs printf "0x%x"`/g" $(BOOT_SCRIPT);


### PR DESCRIPTION
The bootscript parameter in gl-qsdk-factory.sh was moved from arg[4] to arg[2] (1 based index) This patch reflects these changes
