### PR TITLE
arm64: dts: qcom: ipq5018: add #clock-cells to GE Phy

### DIFF
--- a/target/linux/qualcommax/patches-6.6/0713-arm64-dts-qcom-ipq5018-add-ge_phy-node.patch
+++ b/target/linux/qualcommax/patches-6.6/0713-arm64-dts-qcom-ipq5018-add-ge_phy-node.patch
@@ -13,26 +13,30 @@ Signed-off-by: George Moussalem <george.moussalem@outlook.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq5018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq5018.dtsi
-@@ -200,6 +200,18 @@
- 			clocks = <&gcc GCC_MDIO0_AHB_CLK>;
+@@ -210,6 +210,22 @@
+ 			clocks = <&gcc GCC_MDIO1_AHB_CLK>;
  			clock-names = "gcc_mdio_ahb_clk";
  			status = "disabled";
 +
 +			ge_phy: ethernet-phy@7 {
 +				compatible = "ethernet-phy-id004d.d0c0";
 +				reg = <7>;
++
++				clocks = <&gcc GCC_GEPHY_RX_CLK>,
++					 <&gcc GCC_GEPHY_TX_CLK>;
++
 +				resets = <&gcc GCC_GEPHY_BCR>,
 +					 <&gcc GCC_GEPHY_MDC_SW_ARES>,
 +					 <&gcc GCC_GEPHY_DSP_HW_ARES>,
 +					 <&gcc GCC_GEPHY_RX_ARES>,
 +					 <&gcc GCC_GEPHY_TX_ARES>;
-+				clocks = <&gcc GCC_GEPHY_RX_CLK>,
-+					 <&gcc GCC_GEPHY_TX_CLK>;
++
++				#clock-cells = <1>;
 +			};
  		};
  
- 		mdio1: mdio@90000 {
-@@ -394,8 +406,8 @@
+ 		cmn_pll: clock-controller@9b000 {
+@@ -394,8 +410,8 @@
  				 <&pcie0_phy>,
  				 <&pcie1_phy>,
  				 <0>,

--- a/target/linux/qualcommax/patches-6.6/0816-arm64-dts-qcom-ipq5018-add-wifi-support.patch
+++ b/target/linux/qualcommax/patches-6.6/0816-arm64-dts-qcom-ipq5018-add-wifi-support.patch
@@ -13,7 +13,7 @@ Signed-off-by: George Moussalem <george.moussalem@outlook.com>
 ---
 --- a/arch/arm64/boot/dts/qcom/ipq5018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq5018.dtsi
-@@ -692,6 +692,225 @@
+@@ -696,6 +696,225 @@
  			};
  		};
  


### PR DESCRIPTION
The IPQ5018 GE Phy driver registers two fixed rate clocks which are passed on to the GCC which gatekeeps and passes them back to the phy. Fix 'bad phandle' warning and tell consumer (GCC) how many cells to expect when compiling.

Warning (clocks_property): /soc@0/clock-controller@1800000: Missing property '#clock-cells' in node /soc@0/mdio@88000/ethernet-phy@7 or bad phandle (referred from clocks[5])