### PR TITLE
rockchip: fix the SD card detection on NanoPi R6C/R6S

### DIFF
--- a/target/linux/rockchip/patches-6.6/402-v6.13-arm64-dts-rockchip-Fix-the-SD-card-detection-on-Nano.patch
+++ b/target/linux/rockchip/patches-6.6/402-v6.13-arm64-dts-rockchip-Fix-the-SD-card-detection-on-Nano.patch
@@ -1,0 +1,25 @@
+From 95147bb42bc163866fc103c957820345fefa96cd Mon Sep 17 00:00:00 2001
+From: Anton Kirilov <anton.kirilov@arm.com>
+Date: Thu, 19 Dec 2024 11:31:45 +0000
+Subject: [PATCH] arm64: dts: rockchip: Fix the SD card detection on NanoPi
+ R6C/R6S
+
+Fix the SD card detection on FriendlyElec NanoPi R6C/R6S boards.
+
+Signed-off-by: Anton Kirilov <anton.kirilov@arm.com>
+Link: https://lore.kernel.org/r/20241219113145.483205-1-anton.kirilov@arm.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
+@@ -410,6 +410,7 @@
+ &sdmmc {
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
++	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+ 	disable-wp;
+ 	max-frequency = <150000000>;
+ 	no-mmc;


### PR DESCRIPTION
This patch backport a fix for the SD card detection on NanoPi R6c/R6S from upstream commit https://github.com/torvalds/linux/commit/95147bb42bc163866fc103c957820345fefa96cd
Tested on NanoPi R6C .
```
[226844.978911] mmc_host mmc0: Bus speed (slot 0) = 148500000Hz (slot req 150000000Hz, actual 148500000HZ div = 0)
[226845.357685] dwmmc_rockchip fe2c0000.mmc: Successfully tuned phase to 199
[226845.358310] mmc0: new ultra high speed SDR104 SDXC card at address 0001
[226845.359608] mmcblk0: mmc0:0001 SD64G 58.3 GiB
```

