### PR TITLE
qualcommax: ipq5018: gl-b3000: fix rootfs_size in bootscript

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -511,14 +511,14 @@ define Build/gl-qsdk-factory
 	$(CP) $(BOOT_SCRIPT) $(KDIR_TMP)/
 	$(shell mv $(GL_IMGK) $(GL_IMGK).tmp)
 
+	sed -i "s/rootfs_size/`wc -c $(GL_IMGK) | \
+	cut -d " " -f 1 | xargs printf "0x%x"`/g" $(KDIR_TMP)/$(BOOT_SCRIPT);
+
 	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh \
 		$(GL_ITS) \
 		$(BOOT_SCRIPT) \
 		$(GL_UBI) \
 		$(GL_IMGK)
-
-	sed -i "s/rootfs_size/`wc -c $(GL_IMGK) | \
-	cut -d " " -f 1 | xargs printf "0x%x"`/g" $(BOOT_SCRIPT);
 
 	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f \
 		$(GL_ITS) \


### PR DESCRIPTION
rootfs_size was being set after the bootscript was already copied to KDIR_TMP/ this was sneaky because it only affected the initial compile. All subsequent compiles the rootfs_size is correct before the copy is made and the bug goes un discovered. Hence the reason I missed it during testing.

this patch fixes the issue and also refactors the
make recipe to update rootfs_size after the copy
is made, and updates the copy exclusively.