### PR TITLE
tools: xz: update to 5.8.1

### DIFF
--- a/tools/xz/Makefile
+++ b/tools/xz/Makefile
@@ -7,13 +7,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xz
-PKG_VERSION:=5.8.0
+PKG_VERSION:=5.8.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/tukaani-project/xz/releases/download/v$(PKG_VERSION) \
 		@SF/lzmautils \
 		http://tukaani.org/xz
-PKG_HASH:=8c107270289807e2047f35d687b4d7a5bb029137f7c89ebdcfa909cb3b674440
+PKG_HASH:=5965c692c4c8800cd4b33ce6d0f6ac9ac9d6ab227b17c512b6561bce4f08d47e
 PKG_CPE_ID:=cpe:/a:tukaani:xz
 
 HOST_BUILD_PARALLEL:=1


### PR DESCRIPTION
```
5.8.1 (2025-04-03)

    * Multithreaded .xz decoder (lzma_stream_decoder_mt()):

        - Fix a bug that could at least result in a crash with invalid input. (CVE-2025-31115)

        - Fix a performance bug: Only one thread was used if the whole
          input file was provided at once to lzma_code(), the output
          buffer was big enough, timeout was disabled, and LZMA_FINISH
          was used. There are no bug reports about this, thus it's
          possible that no real-world application was affected.

    * Avoid <stdalign.h> even with C11/C17 compilers. This fixes the build with Oracle Developer Studio 12.6 on Solaris 10 when the compiler is in C11 mode (the header doesn't exist).

    * Autotools: Restore compatibility with GNU make versions older than 4.0 by creating the package using GNU gettext 0.23.1 infrastructure instead of 0.24.

    * Update Croatian translation.
```