### PR TITLE
[24.10] generic: backport pmdomain dummy release patch

### DIFF
--- a/target/linux/generic/backport-6.6/910-v6.13-pmdomain-core-add-dummy-release-function-to-genpd-de.patch
+++ b/target/linux/generic/backport-6.6/910-v6.13-pmdomain-core-add-dummy-release-function-to-genpd-de.patch
@@ -1,0 +1,46 @@
+From f64f610ec6ab59dd0391b03842cea3a4cd8ee34f Mon Sep 17 00:00:00 2001
+From: Lucas Stach <l.stach@pengutronix.de>
+Date: Wed, 18 Dec 2024 19:44:33 +0100
+Subject: [PATCH] pmdomain: core: add dummy release function to genpd device
+
+The genpd device, which is really only used as a handle to lookup
+OPP, but not even registered to the device core otherwise and thus
+lifetime linked to the genpd struct it is contained in, is missing
+a release function. After b8f7bbd1f4ec ("pmdomain: core: Add
+missing put_device()") the device will be cleaned up going through
+the driver core device_release() function, which will warn when no
+release callback is present for the device. Add a dummy release
+function to shut up the warning.
+
+Signed-off-by: Lucas Stach <l.stach@pengutronix.de>
+Tested-by: Luca Ceresoli <luca.ceresoli@bootlin.com>
+Fixes: b8f7bbd1f4ec ("pmdomain: core: Add missing put_device()")
+Cc: stable@vger.kernel.org
+Message-ID: <20241218184433.1930532-1-l.stach@pengutronix.de>
+Signed-off-by: Ulf Hansson <ulf.hansson@linaro.org>
+---
+ drivers/base/power/domain.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/drivers/base/power/domain.c
++++ b/drivers/base/power/domain.c
+@@ -2040,6 +2040,11 @@ static void genpd_lock_init(struct gener
+ 	}
+ }
+ 
++static void genpd_provider_release(struct device *dev)
++{
++	/* nothing to be done here */
++}
++
+ /**
+  * pm_genpd_init - Initialize a generic I/O PM domain object.
+  * @genpd: PM domain object to initialize.
+@@ -2106,6 +2111,7 @@ int pm_genpd_init(struct generic_pm_doma
+ 		return ret;
+ 
+ 	device_initialize(&genpd->dev);
++	genpd->dev.release = genpd_provider_release;
+ 	dev_set_name(&genpd->dev, "%s", genpd->name);
+ 
+ 	mutex_lock(&gpd_list_lock);


### PR DESCRIPTION
Fixes the following warning trace on bcm27xx devices when bcm2835-power is deferred:
```
[    0.216800] ------------[ cut here ]------------
[    0.216807] Device 'grafx' does not have a release() function, it is broken and must be fixed. See Documentation/core-api/kobject.rst.
[    0.216863] WARNING: CPU: 0 PID: 1 at drivers/base/core.c:2516 device_release+0x80/0x90
[    0.216887] Modules linked in:
[    0.216896] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 6.6.85 #0
[    0.216905] Hardware name: Raspberry Pi 4 Model B Rev 1.1 (DT)
[    0.216911] pstate: 60400005 (nZCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[    0.216919] pc : device_release+0x80/0x90
[    0.216928] lr : device_release+0x80/0x90
[    0.216936] sp : ffffffc080ccb6d0
[    0.216940] x29: ffffffc080ccb6d0 x28: 0000000000000000 x27: ffffff8040d49810
[    0.216953] x26: ffffff8040c904b8 x25: ffffff8040c904a0 x24: ffffffc0808a7f08
[    0.216964] x23: ffffffc080a1a6d8 x22: 0000000000000000 x21: ffffffc080a1afe0
[    0.216976] x20: 0000000000000000 x19: ffffff8040c900b8 x18: 000000000000009f
[    0.216987] x17: 206e656b6f726220 x16: 7369207469202c6e x15: ffffffc080b4ee88
[    0.216998] x14: 00000000000001dd x13: 000000000000009f x12: 00000000ffffffea
[    0.217009] x11: 00000000ffffefff x10: ffffffc080ba6e88 x9 : ffffffc080b4ee30
[    0.217020] x8 : 0000000000017fe8 x7 : c0000000ffffefff x6 : 0000000000057fa8
[    0.217031] x5 : 0000000000000fff x4 : 0000000000000000 x3 : ffffffc080ccb4d0
[    0.217042] x2 : ffffffc080b4edc8 x1 : ffffffc080b4edc8 x0 : 000000000000007a
[    0.217053] Call trace:
[    0.217058]  device_release+0x80/0x90
[    0.217067]  kobject_put+0xac/0x100
[    0.217078]  put_device+0x14/0x24
[    0.217086]  genpd_remove+0x16c/0x244
[    0.217093]  pm_genpd_remove+0x2c/0x50
[    0.217099]  bcm2835_power_probe+0x1f8/0x2b8
[    0.217107]  platform_probe+0x68/0xc4
[    0.217118]  really_probe+0x148/0x2b0
[    0.217125]  __driver_probe_device+0x78/0x128
[    0.217131]  driver_probe_device+0x40/0xdc
[    0.217138]  __device_attach_driver+0xb8/0xf8
[    0.217145]  bus_for_each_drv+0x70/0xb8
[    0.217151]  __device_attach+0xa0/0x184
[    0.217158]  device_initial_probe+0x14/0x20
[    0.217165]  bus_probe_device+0xac/0xb0
[    0.217171]  device_add+0x5a8/0x760
[    0.217177]  platform_device_add+0x184/0x240
[    0.217184]  mfd_add_device+0x3e8/0x4c0
[    0.217195]  devm_mfd_add_devices+0xa0/0x118
[    0.217202]  bcm2835_pm_probe+0x144/0x1d8
[    0.217210]  platform_probe+0x68/0xc4
[    0.217217]  really_probe+0x148/0x2b0
[    0.217224]  __driver_probe_device+0x78/0x128
[    0.217230]  driver_probe_device+0x40/0xdc
[    0.217237]  __driver_attach+0x90/0x160
[    0.217243]  bus_for_each_dev+0x64/0xa4
[    0.217249]  driver_attach+0x24/0x30
[    0.217256]  bus_add_driver+0xe4/0x208
[    0.217262]  driver_register+0x5c/0x124
[    0.217269]  __platform_driver_register+0x28/0x34
[    0.217276]  bcm2835_pm_driver_init+0x1c/0x28
[    0.217286]  do_one_initcall+0x6c/0x1fc
[    0.217294]  kernel_init_freeable+0x208/0x2e4
[    0.217306]  kernel_init+0x28/0x1e4
[    0.217313]  ret_from_fork+0x10/0x20
[    0.217320] ---[ end trace 0000000000000000 ]---
```

This issue was introduced in v6.6.69 with the following backport: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=36a6e8aeae4a41767bb59f56b100c8cc9ffae2cb

The upstream patch has been adapted to v6.6:
https://github.com/torvalds/linux/commit/f64f610ec6ab59dd0391b03842cea3a4cd8ee34f

More info: https://github.com/raspberrypi/linux/issues/6777

Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
(cherry picked from commit f65c44f67f5d435cb552310f2d455fbfdac935c2)