### PR TITLE
toolchain: mold: add PKG_NAME to Makefile

### DIFF
--- a/toolchain/mold/Makefile
+++ b/toolchain/mold/Makefile
@@ -3,6 +3,9 @@
 # See /LICENSE for more information.
 #
 include $(TOPDIR)/rules.mk
+
+PKG_NAME:=ld.mold
+
 include $(INCLUDE_DIR)/toolchain-build.mk
 
 define Host/Configure


### PR DESCRIPTION
In `include/host-build.mk`, `HOST_BUILD_DIR` is set by default value: `HOST_BUILD_DIR ?= $(BUILD_DIR_HOST)/$(PKG_NAME)`

However the mold package has no `PKG_NAME` set at all. This means the `HOST_BUILD_DIR` is identical to `$(BUILD_DIR_HOST)`.

In the `Host/Prepare stage`, by default, the `$(HOST_BUILD_DIR)` will be deleted at first unconditionally. Since `HOST_BUILD_DIR` is identical to `$(BUILD_DIR_HOST)`, the entire `build_dir/toolchain-*` directory will be removed and this will cause build failure.

Adding PKG_NAME:=ld.mold can solve this issue.

NG log:
```
make[2]: Leaving directory '/home/hackpascal/openwrt/'
make[2]: Entering directory '/home/hackpascal/openwrt/'
make[3]: Entering directory '/home/hackpascal/openwrt/toolchain/binutils'
make[3]: Entering directory '/home/hackpascal/openwrt/toolchain/gdb'
make[3]: Entering directory '/home/hackpascal/openwrt/toolchain/fortify-headers'
make[3]: Entering directory '/home/hackpascal/openwrt/toolchain/mold'
rm -rf /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/binutils-2.42
rm -rf /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/gdb-15.2
mkdir -p /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/binutils-2.42
mkdir -p /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/gdb-15.2
**rm -rf /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/**
rm -rf /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/fortify-headers-1.1
. /home/hackpascal/openwrt/include/shell.sh; xzcat /home/hackpascal/openwrt/dl/binutils-2.42.tar.xz | tar -C /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/binutils-2.42/.. -xf - --exclude='*.rej'
. /home/hackpascal/openwrt/include/shell.sh; xzcat /home/hackpascal/openwrt/dl/gdb-15.2.tar.xz | tar -C /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/gdb-15.2/.. -xf -
mkdir -p /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/
mkdir -p /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/fortify-headers-1.1
tar: /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/binutils-2.42/..: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
[ ! -d ./src/ ] || cp -fpR ./src/* /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/
. /home/hackpascal/openwrt/include/shell.sh; zstdcat /home/hackpascal/openwrt/dl/fortify-headers-1.1.tar.zst | tar -C /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/fortify-headers-1.1/.. -xf -
make[3]: *** [Makefile:106: /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/binutils-2.42/.prepared] Error 2
make[3]: Leaving directory '/home/hackpascal/openwrt/toolchain/binutils'
tar: /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/gdb-15.2/..: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
time: toolchain/binutils/compile#0.01#0.01#0.04
make[3]: *** [Makefile:80: /home/hackpascal/openwrt/build_dir/toolchain-aarch64_cortex-a53_gcc-13.3.0_musl/gdb-15.2/.prepared] Error 2
make[3]: Leaving directory '/home/hackpascal/openwrt/toolchain/gdb'
time: toolchain/gdb/compile#0.01#0.01#0.04
    ERROR: toolchain/binutils failed to build.
make[2]: *** [toolchain/Makefile:93: toolchain/binutils/compile] Error 1
make[2]: *** Waiting for unfinished jobs....
    ERROR: toolchain/gdb failed to build.
make[2]: *** [toolchain/Makefile:93: toolchain/gdb/compile] Error 1
```