### PR TITLE
kernel: Fix patch folders setting for test kernel

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -156,14 +156,15 @@ ifeq ($(TARGET_BUILD),1)
 endif
 
 GENERIC_PLATFORM_DIR := $(TOPDIR)/target/linux/generic
-GENERIC_BACKPORT_DIR := $(GENERIC_PLATFORM_DIR)/backport$(if $(wildcard $(GENERIC_PLATFORM_DIR)/backport-$(KERNEL_PATCHVER)),-$(KERNEL_PATCHVER))
-GENERIC_PATCH_DIR := $(GENERIC_PLATFORM_DIR)/pending$(if $(wildcard $(GENERIC_PLATFORM_DIR)/pending-$(KERNEL_PATCHVER)),-$(KERNEL_PATCHVER))
-GENERIC_HACK_DIR := $(GENERIC_PLATFORM_DIR)/hack$(if $(wildcard $(GENERIC_PLATFORM_DIR)/hack-$(KERNEL_PATCHVER)),-$(KERNEL_PATCHVER))
-GENERIC_FILES_DIR := $(foreach dir,$(wildcard $(GENERIC_PLATFORM_DIR)/files $(GENERIC_PLATFORM_DIR)/files-$(KERNEL_PATCHVER)),"$(dir)")
 
 ifneq ($(TARGET_BUILD)$(if $(DUMP),,1),)
   include $(INCLUDE_DIR)/kernel-version.mk
 endif
+
+GENERIC_BACKPORT_DIR := $(GENERIC_PLATFORM_DIR)/backport$(if $(wildcard $(GENERIC_PLATFORM_DIR)/backport-$(KERNEL_PATCHVER)),-$(KERNEL_PATCHVER))
+GENERIC_PATCH_DIR := $(GENERIC_PLATFORM_DIR)/pending$(if $(wildcard $(GENERIC_PLATFORM_DIR)/pending-$(KERNEL_PATCHVER)),-$(KERNEL_PATCHVER))
+GENERIC_HACK_DIR := $(GENERIC_PLATFORM_DIR)/hack$(if $(wildcard $(GENERIC_PLATFORM_DIR)/hack-$(KERNEL_PATCHVER)),-$(KERNEL_PATCHVER))
+GENERIC_FILES_DIR := $(foreach dir,$(wildcard $(GENERIC_PLATFORM_DIR)/files $(GENERIC_PLATFORM_DIR)/files-$(KERNEL_PATCHVER)),"$(dir)")
 
 __config_name_list = $(1)/config-$(KERNEL_PATCHVER) $(1)/config-default
 __config_list = $(firstword $(wildcard $(call __config_name_list,$(1))))

--- a/package/kernel/bpf-headers/Makefile
+++ b/package/kernel/bpf-headers/Makefile
@@ -15,7 +15,7 @@ include $(INCLUDE_DIR)/kernel.mk
 PKG_NAME:=linux
 PKG_PATCHVER:=6.6
 # Manually include kernel version and hash from kernel details file
-include $(INCLUDE_DIR)/kernel-$(PKG_PATCHVER)
+include $(TOPDIR)/target/linux/generic/kernel-$(PKG_PATCHVER)
 
 PKG_VERSION:=$(PKG_PATCHVER)$(strip $(LINUX_VERSION-$(PKG_PATCHVER)))
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz


### PR DESCRIPTION
Move kernel-version.mk include to proper place to properly set patch folders for test kernel.

Fixes: 8865dadea7b94e7859b416d3b1931b897ea43c48

Compilation error without this patch:
```
if [ -s "/__w/openwrt/openwrt/openwrt/build_dir/target-mipsel_24kc_musl/linux-ramips_mt7620/linux-6.12.24/patches/series" ]; then (cd "/__w/openwrt/openwrt/openwrt/build_dir/target-mipsel_24kc_musl/linux-ramips_mt7620/linux-6.12.24"; if quilt --quiltrc=- next >/dev/null 2>&1; then quilt --quiltrc=- push -a; else quilt --quiltrc=- top >/dev/null 2>&1; fi ); fi
Applying patch generic-backport/0080-v6.9-smp-Avoid-setup_max_cpus_namespace_collision_shadowing.patch
patching file include/linux/cpu.h
Hunk #1 FAILED at 109.
1 out of 1 hunk FAILED -- rejects in file include/linux/cpu.h
patching file kernel/cpu.c
Hunk #1 FAILED at 1905.
1 out of 1 hunk FAILED -- rejects in file kernel/cpu.c
Patch generic-backport/0080-v6.9-smp-Avoid-setup_max_cpus_namespace_collision_shadowing.patch can be reverse-applied
```
It incorrectly loads patches from kernel 6.6 even though the kernel is set to 6.12.


Additionally fixed kernel-$(PKG_PATCHVER) localization for bpf-headers.