### PR TITLE
mac80211: ath9k: remove wrong devm for request_irq

### DIFF
--- a/package/kernel/mac80211/patches/ath9k/509-ath9k-use-devm-for-irq-and-ioremap-resource.patch
+++ b/package/kernel/mac80211/patches/ath9k/509-ath9k-use-devm-for-irq-and-ioremap-resource.patch
@@ -1,22 +1,22 @@
-From da57e63c91ce11a640b1d38412be8c0d8655b8d9 Mon Sep 17 00:00:00 2001
+From 454255e44bf48d8498ac3413389513138ab57bf6 Mon Sep 17 00:00:00 2001
 From: Rosen Penev <rosenp@gmail.com>
 Date: Sat, 4 Jan 2025 14:24:46 -0800
-Subject: [PATCH] ath9k: use devm for irq and ioremap resource
+Subject: [PATCH] wifi: ath9k: ahb: do ioremap resource in one step
 
-Avoids having to manually free. Both of these get called and removed in
-probe only and are safe to convert.
+Simplifies probe slightly and adds extra error codes.
 
-devm_platform_ioremap_resource is different as it also calls
-devm_request_memory_region, which requires non overlapping memory
-regions. Luckily, that seems to be the case.
+Switching from devm_ioremap to the platform variant ends up calling
+devm_request_mem_region, which reserves the memory region for the
+various wmacs. Per board, there is only one wmac and after some fairly
+thorough analysis, there are no overlapping memory regions between wmacs
+and other devices on the ahb.
 
 Tested on a TP-Link Archer C7v2.
 
 Signed-off-by: Rosen Penev <rosenp@gmail.com>
 ---
- drivers/net/wireless/ath/ath9k/ahb.c | 22 ++++++----------------
- drivers/net/wireless/ath/ath9k/pci.c |  9 +++------
- 2 files changed, 9 insertions(+), 22 deletions(-)
+ drivers/net/wireless/ath/ath9k/ahb.c | 13 +++----------
+ 1 file changed, 3 insertions(+), 10 deletions(-)
 
 --- a/drivers/net/wireless/ath/ath9k/ahb.c
 +++ b/drivers/net/wireless/ath/ath9k/ahb.c
@@ -48,80 +48,3 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
  	}
  
  	irq = platform_get_irq(pdev, 0);
-@@ -118,16 +111,16 @@ static int ath_ahb_probe(struct platform
- 	sc->mem = mem;
- 	sc->irq = irq;
- 
--	ret = request_irq(irq, ath_isr, IRQF_SHARED, "ath9k", sc);
-+	ret = devm_request_irq(&pdev->dev, irq, ath_isr, IRQF_SHARED, "ath9k", sc);
- 	if (ret) {
- 		dev_err(&pdev->dev, "request_irq failed\n");
--		goto err_free_hw;
-+		return ret;
- 	}
- 
- 	ret = ath9k_init_device(id->driver_data, sc, &ath_ahb_bus_ops);
- 	if (ret) {
- 		dev_err(&pdev->dev, "failed to initialize device\n");
--		goto err_irq;
-+		goto err_free_hw;
- 	}
- 
- 	ah = sc->sc_ah;
-@@ -137,8 +130,6 @@ static int ath_ahb_probe(struct platform
- 
- 	return 0;
- 
-- err_irq:
--	free_irq(irq, sc);
-  err_free_hw:
- 	ieee80211_free_hw(hw);
- 	return ret;
-@@ -152,7 +143,6 @@ static void ath_ahb_remove(struct platfo
- 		struct ath_softc *sc = hw->priv;
- 
- 		ath9k_deinit_device(sc);
--		free_irq(sc->irq, sc);
- 		ieee80211_free_hw(sc->hw);
- 	}
- }
---- a/drivers/net/wireless/ath/ath9k/pci.c
-+++ b/drivers/net/wireless/ath/ath9k/pci.c
-@@ -965,9 +965,9 @@ static int ath_pci_probe(struct pci_dev
- 	}
- 
- 	if (!msi_enabled)
--		ret = request_irq(pdev->irq, ath_isr, IRQF_SHARED, "ath9k", sc);
-+		ret = devm_request_irq(&pdev->dev, pdev->irq, ath_isr, IRQF_SHARED, "ath9k", sc);
- 	else
--		ret = request_irq(pdev->irq, ath_isr, 0, "ath9k", sc);
-+		ret = devm_request_irq(&pdev->dev, pdev->irq, ath_isr, 0, "ath9k", sc);
- 
- 	if (ret) {
- 		dev_err(&pdev->dev, "request_irq failed\n");
-@@ -979,7 +979,7 @@ static int ath_pci_probe(struct pci_dev
- 	ret = ath9k_init_device(id->device, sc, &ath_pci_bus_ops);
- 	if (ret) {
- 		dev_err(&pdev->dev, "Failed to initialize device\n");
--		goto err_init;
-+		goto err_irq;
- 	}
- 
- 	sc->sc_ah->msi_enabled = msi_enabled;
-@@ -991,8 +991,6 @@ static int ath_pci_probe(struct pci_dev
- 
- 	return 0;
- 
--err_init:
--	free_irq(sc->irq, sc);
- err_irq:
- 	ieee80211_free_hw(hw);
- 	return ret;
-@@ -1006,7 +1004,6 @@ static void ath_pci_remove(struct pci_de
- 	if (!is_ath9k_unloaded)
- 		sc->sc_ah->ah_flags |= AH_UNPLUGGED;
- 	ath9k_deinit_device(sc);
--	free_irq(sc->irq, sc);
- 	ieee80211_free_hw(sc->hw);
- }
- 

--- a/package/kernel/mac80211/patches/ath9k/552-ath9k-ahb_of.patch
+++ b/package/kernel/mac80211/patches/ath9k/552-ath9k-ahb_of.patch
@@ -234,17 +234,17 @@
 +#ifdef CONFIG_OF
 +	dev_id = of_ath_ahb_probe(pdev);
 +#endif
- 	ret = devm_request_irq(&pdev->dev, irq, ath_isr, IRQF_SHARED, "ath9k", sc);
+ 	ret = request_irq(irq, ath_isr, IRQF_SHARED, "ath9k", sc);
  	if (ret) {
  		dev_err(&pdev->dev, "request_irq failed\n");
- 		return ret;
+ 		goto err_free_hw;
  	}
  
 -	ret = ath9k_init_device(id->driver_data, sc, &ath_ahb_bus_ops);
 +	ret = ath9k_init_device(dev_id, sc, &ath_ahb_bus_ops);
  	if (ret) {
  		dev_err(&pdev->dev, "failed to initialize device\n");
- 		goto err_free_hw;
+ 		goto err_irq;
  	}
 +#ifdef CONFIG_OF
 +	pdev->dev.platform_data = NULL;
@@ -252,7 +252,7 @@
  
  	ah = sc->sc_ah;
  	ath9k_hw_name(ah, hw_name, sizeof(hw_name));
-@@ -152,6 +363,9 @@ static struct platform_driver ath_ahb_dr
+@@ -155,6 +366,9 @@ static struct platform_driver ath_ahb_dr
  	.remove_new = ath_ahb_remove,
  	.driver		= {
  		.name	= "ath9k",


### PR DESCRIPTION
Since the irq gets copied to sc, it's a really bad idea to use devm, especially when probe fails.


Fixes: 4e18d22 ("mac80211: ath9k: simplify probe with devm")

ping @robimarko 