### PR TITLE
[24.10] kernel: r81xx: backport improvements

### DIFF
--- a/package/kernel/r8101/Makefile
+++ b/package/kernel/r8101/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8101
 PKG_VERSION:=1.039.00
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8101/releases/download/$(PKG_VERSION)
@@ -20,7 +20,7 @@ define KernelPackage/r8101
   TITLE:=Realtek RTL8101 PCI Fast Ethernet driver
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8101.ko
-  AUTOLOAD:=$(call AutoProbe,r8101)
+  AUTOLOAD:=$(call AutoProbe,r8101,1)
   PROVIDES:=kmod-r8169
 endef
 

--- a/package/kernel/r8125/Makefile
+++ b/package/kernel/r8125/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8125
 PKG_VERSION:=9.015.00
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8125/releases/download/$(PKG_VERSION)
@@ -34,7 +34,9 @@ $(call KernelPackage/r8125)
 endef
 
 ifeq ($(BUILD_VARIANT),rss)
-  PKG_MAKE_FLAGS += ENABLE_RSS_SUPPORT=y
+  PKG_MAKE_FLAGS += \
+    ENABLE_MULTIPLE_TX_QUEUE=y \
+    ENABLE_RSS_SUPPORT=y
 endif
 
 define Build/Compile

--- a/package/kernel/r8125/Makefile
+++ b/package/kernel/r8125/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8125
 PKG_VERSION:=9.015.00
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8125/releases/download/$(PKG_VERSION)
@@ -23,6 +23,7 @@ define KernelPackage/r8125
   AUTOLOAD:=$(call AutoProbe,r8125,1)
   PROVIDES:=kmod-r8169
   VARIANT:=regular
+  PKG_MAKE_FLAGS += CONFIG_ASPM=n
 endef
 
 define KernelPackage/r8125-rss

--- a/package/kernel/r8125/Makefile
+++ b/package/kernel/r8125/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8125
 PKG_VERSION:=9.015.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8125/releases/download/$(PKG_VERSION)
@@ -20,7 +20,7 @@ define KernelPackage/r8125
   TITLE:=Realtek RTL8125 PCI 2.5 Gigabit Ethernet driver
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8125.ko
-  AUTOLOAD:=$(call AutoProbe,r8125)
+  AUTOLOAD:=$(call AutoProbe,r8125,1)
   PROVIDES:=kmod-r8169
   VARIANT:=regular
 endef

--- a/package/kernel/r8126/Makefile
+++ b/package/kernel/r8126/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8126
 PKG_VERSION:=10.015.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8126/releases/download/$(PKG_VERSION)
@@ -20,7 +20,7 @@ define KernelPackage/r8126
   TITLE:=Realtek RTL8126 PCI 5 Gigabit Ethernet driver
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8126.ko
-  AUTOLOAD:=$(call AutoProbe,r8126)
+  AUTOLOAD:=$(call AutoProbe,r8126,1)
   PROVIDES:=kmod-r8169
   VARIANT:=regular
 endef

--- a/package/kernel/r8126/Makefile
+++ b/package/kernel/r8126/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8126
 PKG_VERSION:=10.015.00
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8126/releases/download/$(PKG_VERSION)
@@ -33,7 +33,9 @@ $(call KernelPackage/r8126)
 endef
 
 ifeq ($(BUILD_VARIANT),rss)
-  PKG_MAKE_FLAGS += ENABLE_RSS_SUPPORT=y
+  PKG_MAKE_FLAGS += \
+    ENABLE_MULTIPLE_TX_QUEUE=y \
+    ENABLE_RSS_SUPPORT=y
 endif
 
 define Build/Compile

--- a/package/kernel/r8127/Makefile
+++ b/package/kernel/r8127/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8127
 PKG_VERSION:=11.014.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8127/releases/download/$(PKG_VERSION)
@@ -20,7 +20,7 @@ define KernelPackage/r8127
   TITLE:=Realtek RTL8127 PCI 10 Gigabit Ethernet driver
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8127.ko
-  AUTOLOAD:=$(call AutoProbe,r8127)
+  AUTOLOAD:=$(call AutoProbe,r8127,1)
   PROVIDES:=kmod-r8169
   VARIANT:=regular
 endef

--- a/package/kernel/r8127/Makefile
+++ b/package/kernel/r8127/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8127
 PKG_VERSION:=11.014.00
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8127/releases/download/$(PKG_VERSION)
@@ -33,7 +33,9 @@ $(call KernelPackage/r8127)
 endef
 
 ifeq ($(BUILD_VARIANT),rss)
-  PKG_MAKE_FLAGS += ENABLE_RSS_SUPPORT=y
+  PKG_MAKE_FLAGS += \
+    ENABLE_MULTIPLE_TX_QUEUE=y \
+    ENABLE_RSS_SUPPORT=y
 endif
 
 define Build/Compile

--- a/package/kernel/r8168/Makefile
+++ b/package/kernel/r8168/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8168
 PKG_VERSION:=8.055.00
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8168/releases/download/$(PKG_VERSION)
@@ -22,7 +22,21 @@ define KernelPackage/r8168
   FILES:=$(PKG_BUILD_DIR)/src/r8168.ko
   AUTOLOAD:=$(call AutoProbe,r8168,1)
   PROVIDES:=kmod-r8169
+  VARIANT:=regular
 endef
+
+define KernelPackage/r8168-rss
+$(call KernelPackage/r8168)
+  CONFLICTS:=kmod-r8168
+  TITLE+= (RSS)
+  VARIANT:=rss
+endef
+
+ifeq ($(BUILD_VARIANT),rss)
+  PKG_MAKE_FLAGS += \
+    ENABLE_MULTIPLE_TX_QUEUE=y \
+    ENABLE_RSS_SUPPORT=y
+endif
 
 define Build/Compile
 	+$(KERNEL_MAKE) $(PKG_JOBS) \
@@ -31,3 +45,4 @@ define Build/Compile
 endef
 
 $(eval $(call KernelPackage,r8168))
+$(eval $(call KernelPackage,r8168-rss))

--- a/package/kernel/r8168/Makefile
+++ b/package/kernel/r8168/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8168
 PKG_VERSION:=8.055.00
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8168/releases/download/$(PKG_VERSION)
@@ -20,7 +20,7 @@ define KernelPackage/r8168
   TITLE:=Realtek RTL8168 PCI Gigabit Ethernet driver
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8168.ko
-  AUTOLOAD:=$(call AutoProbe,r8168)
+  AUTOLOAD:=$(call AutoProbe,r8168,1)
   PROVIDES:=kmod-r8169
 endef
 


### PR DESCRIPTION
cb3fc1aef9 kernel: r8168: add RSS variant
7615de6ef0 kernel: r8127: rss: enable ENABLE_MULTIPLE_TX_QUEUE
a3e51a3956 kernel: r8126: rss: enable ENABLE_MULTIPLE_TX_QUEUE
d127963a46 kernel: r8125: rss: enable ENABLE_MULTIPLE_TX_QUEUE
f99b39fd0c kernel: r8125: disable ASPM
b5680bd113 kernel: r8127: load module at boot time
9bb151d0c6 kernel: r8126: load module at boot time
ce9f539672 kernel: r8125: load module at boot time
617961403c kernel: r8168: load module at boot time
7aeb837bf4 kernel: r8101: load module at boot time