### PR TITLE
mold: update to 2.37.1, allow on more targets and disable on MacOS

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -174,7 +174,7 @@ menu "Global build settings"
 		  Packages can choose to opt-out via setting PKG_BUILD_FLAGS:=no-lto
 
 	config MOLD
-		depends on (aarch64 || arm || i386 || i686 || m68k || powerpc || powerpc64 || sh4 || x86_64)
+		depends on (aarch64 || arm || i386 || i686 || loongarch64 || m68k || powerpc || powerpc64 || sh4 || x86_64)
 		depends on !GCC_USE_VERSION_11
 		def_bool $(shell, ./config/check-hostcxx.sh 10 2 12)
 

--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -176,6 +176,7 @@ menu "Global build settings"
 	config MOLD
 		depends on (aarch64 || arm || i386 || i686 || loongarch64 || m68k || powerpc || powerpc64 || riscv64 || sh4 || x86_64)
 		depends on !GCC_USE_VERSION_11
+		depends on !HOST_OS_MACOS
 		def_bool $(shell, ./config/check-hostcxx.sh 10 2 12)
 
 	config USE_MOLD

--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -174,7 +174,7 @@ menu "Global build settings"
 		  Packages can choose to opt-out via setting PKG_BUILD_FLAGS:=no-lto
 
 	config MOLD
-		depends on (aarch64 || arm || i386 || i686 || loongarch64 || m68k || powerpc || powerpc64 || sh4 || x86_64)
+		depends on (aarch64 || arm || i386 || i686 || loongarch64 || m68k || powerpc || powerpc64 || riscv64 || sh4 || x86_64)
 		depends on !GCC_USE_VERSION_11
 		def_bool $(shell, ./config/check-hostcxx.sh 10 2 12)
 

--- a/tools/mold/Makefile
+++ b/tools/mold/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mold
-PKG_VERSION:=2.33.0
+PKG_VERSION:=2.37.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL_FILE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rui314/mold/archive/refs/tags
-PKG_HASH:=37b3aacbd9b6accf581b92ba1a98ca418672ae330b78fe56ae542c2dcb10a155
+PKG_HASH:=b8e36086c95bd51e9829c9755c138f5c4daccdd63b6c35212b84229419f3ccbe
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
Update mold to 2.37.1 and allow usage on our current LoongArch and RISC-V targets.

While testing on MacOS I noticed that mold does not support MacOS so disable it on MacOS.