### PR TITLE
qualcommax: ipq50xx: qcom_scm: fix passing metadata size

### DIFF
--- a/target/linux/qualcommax/patches-6.6/0802-firmware-qcom_scm-ipq5332-add-support-to-pass-metada.patch
+++ b/target/linux/qualcommax/patches-6.6/0802-firmware-qcom_scm-ipq5332-add-support-to-pass-metada.patch
@@ -16,9 +16,9 @@ Signed-off-by: Manikanta Mylavarapu <quic_mmanikan@quicinc.com>
 
 --- a/drivers/firmware/qcom_scm.c
 +++ b/drivers/firmware/qcom_scm.c
-@@ -592,6 +592,14 @@ int qcom_scm_pas_mem_setup(u32 periphera
- 	if (ret)
- 		goto disable_clk;
+@@ -525,6 +525,14 @@ int qcom_scm_pas_init_image(u32 peripher
+ 
+ 	desc.args[1] = mdata_phys;
  
 +	if (__qcom_scm_is_call_available(__scm->dev, QCOM_SCM_SVC_PIL,
 +					 QCOM_SCM_PAS_INIT_IMAGE_V2)) {


### PR DESCRIPTION
Upon rebasing, support for passing metadata size was accidentally moved under a different function. So, let's fix this and place the code under the right function (qcom_scm_pas_init_image).

It does not impact or fix anything as currently there are no devices in the qualcommax family using it, but it is a dependency and part of the qcom q6v5 mpd driver (targeting ipq5332 in the be family).
