### PR TITLE
lantiq: fix syntax error for fritz736x

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
@@ -56,11 +56,11 @@
 		};
 
 		fon {
-			function = "fon"
+			function = "fon";
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
 		};
-		
+
 		led_power_red: power_red {
 			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
@@ -68,7 +68,7 @@
 		};
 
 		led_info_green: info_green {
-			function = "info"
+			function = "info";
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
 		};
@@ -80,13 +80,13 @@
 		};
 
 		info_red {
-			function = "info"
-			color = <LED_COLOR_ID_RED
+			function = "info";
+			color = <LED_COLOR_ID_RED>;
 			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
 		};
 
 		dect {
-			function = "dect"
+			function = "dect";
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
 		};


### PR DESCRIPTION
Add missing semicolon to the end of the property.
Remove whitespace while at it.

Fixes: 5a3b9d88f158 ("lantiq: Improve support for LED's fritz736x")

Cc: @hauke