### PR TITLE
qualcommax: fix ECC strength of SPI-NAND flash on GL-iNet GL-B3000

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
@@ -226,7 +226,7 @@
 		#size-cells = <1>;
 
 		nand-ecc-engine = <&qpic_nand>;
-		nand-ecc-strength = <8>;
+		nand-ecc-strength = <4>;
 		nand-ecc-step-size = <512>;
 		nand-bus-width = <8>;
 


### PR DESCRIPTION
Fix nand-ecc-strength property in the spi-nand node of GL-iNet GL-B3000 to 4, to solve the following ECC error on that spi-nand chip.

```
[    1.551618] ubi0: attaching mtd11
[    1.552331] ubi0 warning: ubi_io_read: error -74 (ECC error) while reading 64 bytes from PEB 0:0, read only 64 bytes, retry
[    1.554455] ubi0 warning: ubi_io_read: error -74 (ECC error) while reading 64 bytes from PEB 0:0, read only 64 bytes, retry
[    1.565931] ubi0 warning: ubi_io_read: error -74 (ECC error) while reading 64 bytes from PEB 0:0, read only 64 bytes, retry
[    1.576568] ubi0 error: ubi_io_read: error -74 (ECC error) while reading 64 bytes from PEB 0:0, read 64 bytes
[    1.587146] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 6.6.87 #0
[    1.597153] Hardware name: GL.iNet GL-B3000 (DT)
[    1.602881] Call trace:
[    1.607739]  dump_backtrace+0xa0/0xe0
[    1.609910]  show_stack+0x18/0x24
[    1.613728]  dump_stack_lvl+0x48/0x60
[    1.617027]  dump_stack+0x18/0x24
[    1.620672]  ubi_io_read+0x11c/0x32c
[    1.623972]  ubi_io_read_ec_hdr+0x50/0x1f0
[    1.627618]  ubi_attach+0x35c/0x133c
[    1.631524]  ubi_attach_mtd_dev+0x494/0xaf4
[    1.635257]  ubi_init_attach+0xac/0x2e4
[    1.639163]  do_one_initcall+0x6c/0x1fc
[    1.642983]  kernel_init_freeable+0x204/0x2e4
[    1.646803]  kernel_init+0x28/0x1dc
[    1.651316]  ret_from_fork+0x10/0x20
```

The GL-B3000 has a Winbond W25N01GW and the spare size (oobsize) of it is 64. So the maximum available ECC strength with the qpic-snand driver is 4 but not 8.
The "nand-ecc-strength" property was not used before the commit fc3ff2af0c ("qualcommax: allow overriding ECC strength for qpic-snand") and calculated from the registered spare size in the Linux Kernel. As a result, we had no issues on the GL-B3000 with the wrong ECC strength value.

Fixes: 3307fe8ee4 ("qualcommax: ipq50xx: add support for GL.iNET GL-B3000")
