### PR TITLE
toolchain: gcc: switch default to 14

### DIFF
--- a/toolchain/gcc/Config.in
+++ b/toolchain/gcc/Config.in
@@ -2,7 +2,7 @@
 
 choice
 	prompt "GCC compiler Version" if TOOLCHAINOPTS
-	default GCC_USE_VERSION_13
+	default GCC_USE_VERSION_14
 	help
 	  Select the version of gcc you wish to use.
 

--- a/toolchain/gcc/Config.version
+++ b/toolchain/gcc/Config.version
@@ -6,8 +6,8 @@ config GCC_VERSION_12
 	default y if GCC_USE_VERSION_12
 	bool
 
-config GCC_VERSION_14
-	default y if GCC_USE_VERSION_14
+config GCC_VERSION_13
+	default y if GCC_USE_VERSION_13
 	bool
 
 config GCC_VERSION
@@ -15,10 +15,10 @@ config GCC_VERSION
 	default EXTERNAL_GCC_VERSION	if EXTERNAL_TOOLCHAIN && !NATIVE_TOOLCHAIN
 	default "11.3.0"	if GCC_VERSION_11
 	default "12.3.0"	if GCC_VERSION_12
-	default "14.2.0"	if GCC_VERSION_14
-	default "13.3.0"
+	default "13.3.0"	if GCC_VERSION_13
+	default "14.2.0"
 
 config GCC_USE_DEFAULT_VERSION
 	bool
-	default y if !TOOLCHAINOPTS || GCC_USE_VERSION_13
+	default y if !TOOLCHAINOPTS || GCC_USE_VERSION_14
 	imply KERNEL_WERROR


### PR DESCRIPTION
Its time to use GCC14 as the default compiler instead of GCC13.
