### PR TITLE
mediatek: filogic: add support for Cudy WR3000E v1

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000e-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000e-v1.dts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include "mt7981b-cudy-wr3000-nand.dtsi"
+
+/ {
+	model = "Cudy WR3000E v1";
+	compatible = "cudy,wr3000e-v1", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		serial0 = &uart0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: led-power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan-1 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan-2 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wan {
+			function = LED_FUNCTION_WAN_ONLINE;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wps-1 {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wps-2 {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wlan2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-wlan5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "wan";
+
+			nvmem-cell-names = "mac-address";
+			nvmem-cells = <&macaddr_bdinfo_de00 1>;
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan1";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan3";
+		};
+
+		port@4 {
+			reg = <4>;
+			label = "lan4";
+		};
+
+		port@6 {
+			reg = <6>;
+			label = "cpu";
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -81,6 +81,7 @@ case "$board" in
 	cudy,re3000-v1|\
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
+	cudy,wr3000e-v1|\
 	cudy,wr3000s-v1|\
 	cudy,wr3000h-v1|\
 	cudy,wr3000-v1)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -823,6 +823,23 @@ define Device/cudy_wr3000-v1
 endef
 TARGET_DEVICES += cudy_wr3000-v1
 
+define Device/cudy_wr3000e-v1
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := WR3000E
+  DEVICE_VARIANT := v1
+  DEVICE_DTS := mt7981b-cudy-wr3000e-v1
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES += R53
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_IN_UBI := 1
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+endef
+TARGET_DEVICES += cudy_wr3000e-v1
+
 define Device/cudy_wr3000s-v1
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := WR3000S


### PR DESCRIPTION
The WR3000E has the same board layout as the WR3000S. Differences:
- Different flash chip
- LEDs with red/blue colour intead of white

Hardware:
- MediaTek MT7981 WiSoC
- 256MB DDR3 RAM
- 128MB SPI-NAND (F50L1G41LB)
- MediaTek MT7981 2x2 DBDC 802.11ax 2T2R (2.4 / 5)

MAC Addresses in OEM firmware:
- There is one on the label, e.g. AA:BB:CC:DD:EE:FF
- WLAN (2.4G) uses the same as on the label
- WLAN (5G) is the one on the label but
  - first byte (e.g. AA) + 2
  - fourth byte (e.g. DD) - 0x40
- WAN is the one on the label + 1
- LAN is the one on the label

MAC Addresses in OpenWrt:
- Same handling as in WR3000s is used

GPIO:
- 2 Buttons (all low active):
  - WPS on GPIO 0
  - Reset on GPIO 1
- 6 LEDs (all low active):
  - Power: Blue on GPIO 8, no red LED
  - WPS: Blue on GPIO 10, Red on GPIO 4
  - Internet: Blue on GPIO 11, no red LED
  - LAN: Blue on GPIO 9, Red on GPIO 5
  - WiFi 2.4G: Blue on GPIO 6, no red LED
  - WiFi 5G: Blue on GPIO 7, no red LED

Disassembly:
- Remove the 4 screws at the bottom of the case
- Cover is clipped to the bottom part of the case with clips in the front and the back

UART:
- UART pins are accessible on the bottom of the board
- The connector with the square shape is TX
- Pins: [ ] TX, ( ) RX, ( ) GND, ( ) VCC
- Settings: 115200 8N1 3.3V

Migration to OpenWrt via OEM firmware:
- There should be a migration image available from Cudy as soon as there is official OpenWrt support
- Download the migration image via OEM web interface
- After flashing, OpenWrt is accessible via 192.168.1.1
- Flash the official OpenWrt image

Migration to OpenWrt using TFTP:
- Connect UART as described above
- Press the reset button while powering on the device
- U-Boot will now try to load a recovery.bin via TFTP, this must be ignored
- After detecting a timeout, the U-Boot console is available via UART
- Set up a TFTP server on IP 192.168.1.88 and connect it to one of the LAN ports
- Provide the initramfs image via TFTP as cudy3000e.bin
- Run the following command in U-Boot: tftpboot 0x46000000 cudy3000e.bin; bootm 0x46000000
- OpenWrt initramfs image is now booting and accessible via 192.168.1.1
- Flash the sysupgrade image

Revert back to OEM:
- Set up a TFTP server on IP 192.168.1.88 and connect it to one of the LAN ports
- Provide the Cudy firmware via TFTP as recovery.bin
- Press the reset button while powering on the device
- Recovery process will start now
- After recovery is done, the OEM firmware is available at 192.168.10.1 again
