### PR TITLE
dnsmasq: prevent upstream resolution of addresses

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -170,7 +170,9 @@ append_rev_server() {
 }
 
 append_address() {
+	local address_as_local="$2"
 	xappend "--address=$1"
+	[ $address_as_local -gt 0 ] && xappend "--local=${1%/*}/"
 }
 
 append_connmark_allowlist() {
@@ -1036,7 +1038,10 @@ dnsmasq_start()
 	config_list_foreach "$cfg" "listen_address" append_listenaddress
 	config_list_foreach "$cfg" "server" append_server
 	config_list_foreach "$cfg" "rev_server" append_rev_server
-	config_list_foreach "$cfg" "address" append_address
+
+	local address_as_local
+	config_get address_as_local "$cfg" address_as_local 0
+	config_list_foreach "$cfg" "address" append_address "$address_as_local"
 
 	local connmark_allowlist_enable
 	config_get connmark_allowlist_enable "$cfg" connmark_allowlist_enable 0


### PR DESCRIPTION
`list address` entries in /etc/config/dhcp are sometimes (I'm not sure about the exact conditions) passed to upstream resolver, bypassing local resolution. Adding them (minus the IP) to --local prevents this. In the configuration, this means that

    # /etc/config/dhcp
    list address '/hello.com/world.com/1.2.3.4'
    list address '/foo.com/bar.com/4.3.2.1'

which previously translated into

    # /var/etc/dnsmasq.conf.*
    address=/hello.com/world.com/1.2.3.4
    address=/foo.com/bar.com/4.3.2.1

now becomes

    # /var/etc/dnsmasq.conf.*
    address=/hello.com/world.com/1.2.3.4
    local=/hello.com/world.com/
    address=/foo.com/bar.com/4.3.2.1
    local=/foo.com/bar.com/

A workaround for a small list of domains is to add them to `option local`, but this is very tedious to do for every `list address` entry and dnsmasq limits this option to 1024 characters.
