### PR TITLE
qualcommax: ipq50xx: drop unused factory.ubi for ELECOM WRC-X3000GS2

### DIFF
--- a/target/linux/qualcommax/image/ipq50xx.mk
+++ b/target/linux/qualcommax/image/ipq50xx.mk
@@ -19,11 +19,11 @@ endef
 
 define Device/elecom_wrc-x3000gs2
 	$(call Device/FitImageLzma)
-	$(call Device/UbiFit)
 	DEVICE_VENDOR := ELECOM
 	DEVICE_MODEL := WRC-X3000GS2
 	DEVICE_DTS_CONFIG := config@mp03.3
 	SOC := ipq5018
+	KERNEL_IN_UBI := 1
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	IMAGE_SIZE := 52480k


### PR DESCRIPTION
Drop the firmware image entry "factory.ubi" from IMAGES for ELECOM WRC-X3000GS2.
`Device/UbiFit` is added in the early stage of working for adding support of the device, but finally, only `KERNEL_IN_UBI` is neccesary and factory.ubi is not. So `Device/UbiFit` should have been replaced to `KERNEL_IN_UBI` but it was forgotten.

Fixes: 3b7d72bc2e ("qualcommax: add support for ELECOM WRC-X3000GS2")
