### PR TITLE
ltq-adsl: use remove_new for platform_device

### DIFF
--- a/package/kernel/lantiq/ltq-adsl/patches/120-platform.patch
+++ b/package/kernel/lantiq/ltq-adsl/patches/120-platform.patch
@@ -14,7 +14,7 @@
  
  /* Entry point of driver */
 -int __init DSL_ModuleInit(void)
-+static int __devinit ltq_adsl_probe(struct platform_device *pdev)
++static int ltq_adsl_probe(struct platform_device *pdev)
  {
     struct class *dsl_class;
     DSL_int_t i;
@@ -23,20 +23,20 @@
  }
  
 -void __exit DSL_ModuleCleanup(void)
-+static int __devexit ltq_adsl_remove(struct platform_device *pdev)
++static void ltq_adsl_remove(struct platform_device *pdev)
  {
     printk("Module will be unloaded"DSL_DRV_CRLF);
  
-@@ -1143,7 +1143,7 @@ void __exit DSL_ModuleCleanup(void)
+@@ -1142,8 +1142,6 @@ void __exit DSL_ModuleCleanup(void)
+                DSL_FPGA_BND_REGS_SZ_BYTE,
                 (DSL_uint8_t**)&g_BndFpgaBase);
  #endif /* defined(INCLUDE_DSL_CPE_API_VINAX) && defined(INCLUDE_DSL_BONDING)*/
- 
+-
 -   return;
-+   return 0;
  }
  
  #ifndef _lint
-@@ -1159,8 +1159,29 @@ module_param(debug_level, byte, 0);
+@@ -1159,8 +1157,29 @@ module_param(debug_level, byte, 0);
  MODULE_PARM_DESC(debug_level, "set to get more (1) or fewer (4) debug outputs");
  #endif /* #ifndef DSL_DEBUG_DISABLE*/
  
@@ -56,7 +56,7 @@
 +
 +static struct platform_driver ltq_adsl_driver = {
 +	.probe = ltq_adsl_probe,
-+	.remove = __devexit_p(ltq_adsl_remove),
++	.remove_new = ltq_adsl_remove,
 +	.driver = {
 +		.name = "adsl",
 +		.of_match_table = ltq_adsl_match,

--- a/package/kernel/lantiq/ltq-adsl/patches/130-linux3.8.patch
+++ b/package/kernel/lantiq/ltq-adsl/patches/130-linux3.8.patch
@@ -80,13 +80,7 @@
  
           pThrCntrl->bValid = DSL_TRUE;
  
-@@ -1070,12 +1045,12 @@ static void DSL_DRV_DebugInit(void)
- #endif
- 
- /* Entry point of driver */
--static int __devinit ltq_adsl_probe(struct platform_device *pdev)
-+static int ltq_adsl_probe(struct platform_device *pdev)
- {
+@@ -1075,7 +1050,7 @@ static int ltq_adsl_probe(struct platfor
     struct class *dsl_class;
     DSL_int_t i;
  
@@ -95,24 +89,6 @@
        &(dsl_cpe_api_version[4]));
  
     DSL_DRV_MemSet( ifxDevices, 0, sizeof(DSL_devCtx_t) * DSL_DRV_MAX_DEVICE_NUMBER );
-@@ -1128,7 +1103,7 @@ static int __devinit ltq_adsl_probe(stru
-    return 0;
- }
- 
--static int __devexit ltq_adsl_remove(struct platform_device *pdev)
-+static int ltq_adsl_remove(struct platform_device *pdev)
- {
-    printk("Module will be unloaded"DSL_DRV_CRLF);
- 
-@@ -1173,7 +1148,7 @@ MODULE_DEVICE_TABLE(of, ltq_adsl_match);
- 
- static struct platform_driver ltq_adsl_driver = {
- 	.probe = ltq_adsl_probe,
--	.remove = __devexit_p(ltq_adsl_remove),
-+	.remove = ltq_adsl_remove,
- 	.driver = {
- 		.name = "adsl",
- 		.owner = THIS_MODULE,
 --- a/src/include/drv_dsl_cpe_os_lint_map.h
 +++ b/src/include/drv_dsl_cpe_os_lint_map.h
 @@ -247,7 +247,7 @@ typedef struct


### PR DESCRIPTION
Easy way to add compatibility for kernel 6.12.

Since the linux 3.8 patch undoes a bunch of stuff in platform, just modiify everything in platform.

ping @robimarko @Ansuel 