### PR TITLE
[RFC] toolchain: glibc: tune malloc arenas

### DIFF
--- a/toolchain/Config.in
+++ b/toolchain/Config.in
@@ -312,6 +312,7 @@ choice
 endchoice
 
 source "toolchain/musl/Config.in"
+source "toolchain/glibc/Config.in"
 
 comment "Debuggers"
 	depends on TOOLCHAINOPTS

--- a/toolchain/glibc/Config.in
+++ b/toolchain/glibc/Config.in
@@ -1,0 +1,51 @@
+# malloc tuning
+
+config GLIBC_TUNE_MALLOC_ARENA
+	bool "glibc: tune default malloc arena behavior" if TOOLCHAINOPTS
+	default y
+	depends on USE_GLIBC && !EXTERNAL_TOOLCHAIN
+	help
+	  By default, glibc will allocate a number of "arenas" for dynamic memory allocation.
+	  Notes from official documentation:
+
+	    For 32-bit systems the limit (note: maximum number of arenas) is twice the number of cores online
+	    and on 64-bit systems, it is eight times the number of cores online.
+
+	  Thus:
+	  1) it takes time to reserve memory (with O(n) complexity);
+	  2) it takes somewhat excessive native memory.
+
+	  OpenWrt changes this behavior by:
+	  1) limiting per-core multiplier;
+	  2) limiting number of online cores to be accounted.
+
+	  If this option is disabled then default glibc behavior is in effect.
+
+if GLIBC_TUNE_MALLOC_ARENA
+
+config GLIBC_MALLOC_ARENA_PERCORE_MULT
+	int "glibc: malloc: per-core arena multiplier"
+	range 1 16
+	default 2
+	help
+	  Set per-core arena multiplier for maximum number of arenas.
+
+	  Note: glibc default value depends on target system:
+	    32-bit systems: 2
+	    64-bit systems: 8
+
+	  Default: 2.
+
+config GLIBC_MALLOC_ARENA_CORE_LIMIT
+	int "glibc: malloc: online core limit"
+	range 1 16
+	default 4
+	help
+	  Limit number of online cores to be accounted for maximum number of arenas.
+
+	  Note: glibc doesn't have this setting.
+
+	  Default: 4.
+
+# GLIBC_TUNE_MALLOC_ARENA
+endif

--- a/toolchain/glibc/common.mk
+++ b/toolchain/glibc/common.mk
@@ -41,6 +41,13 @@ ifeq ($(ARCH),mips64)
   endif
 endif
 
+ifeq ($(CONFIG_GLIBC_TUNE_MALLOC_ARENA),y)
+  TARGET_CFLAGS += \
+    -DOPENWRT_TUNE_MALLOC_ARENA=1 \
+    -DOPENWRT_MALLOC_ARENA_PERCORE_MULT=$(CONFIG_GLIBC_MALLOC_ARENA_PERCORE_MULT) \
+    -DOPENWRT_MALLOC_ARENA_CORE_LIMIT=$(CONFIG_GLIBC_MALLOC_ARENA_CORE_LIMIT)
+endif
+
 # -Os miscompiles w. 2.24 gcc5/gcc6
 # only -O2 tested by upstream changeset
 # "Optimize i386 syscall inlining for GCC 5"

--- a/toolchain/glibc/patches/900-tune-malloc-arena-count.patch
+++ b/toolchain/glibc/patches/900-tune-malloc-arena-count.patch
@@ -1,0 +1,78 @@
+ malloc/arena.c          |  8 +++++++-
+ malloc/malloc.c         |  5 +++--
+ malloc/openwrt-malloc.h | 24 ++++++++++++++++++++++++
+ 3 files changed, 34 insertions(+), 3 deletions(-)
+
+--- a/malloc/arena.c
++++ b/malloc/arena.c
+@@ -813,6 +813,8 @@ out:
+   return result;
+ }
+ 
++#include "openwrt-malloc.h"
++
+ static mstate
+ arena_get2 (size_t size, mstate avoid_arena)
+ {
+@@ -832,8 +834,12 @@ arena_get2 (size_t size, mstate avoid_ar
+             {
+               int n = __get_nprocs ();
+ 
+-              if (n >= 1)
++              if (n >= 1) {
++            #if OPENWRT_TUNE_MALLOC_ARENA
++                if (n > OPENWRT_MALLOC_ARENA_CORE_LIMIT) n = OPENWRT_MALLOC_ARENA_CORE_LIMIT;
++            #endif
+                 narenas_limit = NARENAS_FROM_NCORES (n);
++              }
+               else
+                 /* We have no information about the system.  Assume two
+                    cores.  */
+--- a/malloc/malloc.c
++++ b/malloc/malloc.c
+@@ -1816,6 +1816,8 @@ static struct malloc_state main_arena =
+   .attached_threads = 1
+ };
+ 
++#include "openwrt-malloc.h"
++
+ /* There is only one instance of the malloc parameters.  */
+ 
+ static struct malloc_par mp_ =
+@@ -1824,8 +1826,7 @@ static struct malloc_par mp_ =
+   .n_mmaps_max = DEFAULT_MMAP_MAX,
+   .mmap_threshold = DEFAULT_MMAP_THRESHOLD,
+   .trim_threshold = DEFAULT_TRIM_THRESHOLD,
+-#define NARENAS_FROM_NCORES(n) ((n) * (sizeof (long) == 4 ? 2 : 8))
+-  .arena_test = NARENAS_FROM_NCORES (1),
++  .arena_test = 2,
+   .thp_mode = malloc_thp_mode_not_supported
+ #if USE_TCACHE
+   ,
+--- /dev/null
++++ b/malloc/openwrt-malloc.h
+@@ -0,0 +1,24 @@
++#ifndef OPENWRT_MALLOC_HEADER
++#define OPENWRT_MALLOC_HEADER 1
++
++#ifndef OPENWRT_TUNE_MALLOC_ARENA
++#define OPENWRT_TUNE_MALLOC_ARENA 0
++#endif
++
++#ifndef OPENWRT_MALLOC_ARENA_PERCORE_MULT
++#define OPENWRT_MALLOC_ARENA_PERCORE_MULT 2
++#endif
++
++#ifndef OPENWRT_MALLOC_ARENA_CORE_LIMIT
++#define OPENWRT_MALLOC_ARENA_CORE_LIMIT 4
++#endif
++
++#define OPENWRT_MALLOC_ARENA_DEFAULT_MULT (sizeof(long) == 4 ? 2 : 8)
++
++#if OPENWRT_TUNE_MALLOC_ARENA
++#define NARENAS_FROM_NCORES(n) ((n) * OPENWRT_MALLOC_ARENA_PERCORE_MULT)
++#else
++#define NARENAS_FROM_NCORES(n) ((n) * OPENWRT_MALLOC_ARENA_DEFAULT_MULT)
++#endif
++
++#endif /* OPENWRT_MALLOC_HEADER */


### PR DESCRIPTION
1. add configuration options to enable tuning for glibc malloc arenas.
2. unify arena per-core multiplier for both 32- and 64-bit platforms (set to 2).
3. set upper limit for detected "online cores" by malloc/arena code to 4.

These changes should reduce (excessive) memory usage on any target especially on 64-bit ones.