### PR TITLE
bcm27xx: add support for raspberry pi 5 cm

### DIFF
--- a/target/linux/bcm27xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm27xx/base-files/etc/board.d/02_network
@@ -17,6 +17,8 @@ raspberrypi,3-model-b-plus |\
 raspberrypi,400 |\
 raspberrypi,4-compute-module |\
 raspberrypi,4-model-b |\
+raspberrypi,500 |\
+raspberrypi,5-compute-module |\
 raspberrypi,5-model-b |\
 raspberrypi,model-b |\
 raspberrypi,model-b-plus |\

--- a/target/linux/bcm27xx/base-files/lib/preinit/05_set_preinit_iface_brcm2708
+++ b/target/linux/bcm27xx/base-files/lib/preinit/05_set_preinit_iface_brcm2708
@@ -12,6 +12,8 @@ set_preinit_iface() {
 	raspberrypi,400 |\
 	raspberrypi,4-compute-module |\
 	raspberrypi,4-model-b |\
+	raspberrypi,500 |\
+	raspberrypi,5-compute-module |\
 	raspberrypi,5-model-b |\
 	raspberrypi,model-b |\
 	raspberrypi,model-b-plus |\

--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -193,10 +193,19 @@ ifeq ($(SUBTARGET),bcm2711)
 endif
 
 define Device/rpi-5
-  DEVICE_MODEL := 5
+  DEVICE_MODEL := 5/500/CM5
   KERNEL_IMG := kernel_2712.img
-  DEVICE_DTS := broadcom/bcm2712-rpi-5-b
-  SUPPORTED_DEVICES := raspberrypi,5-model-b
+  DEVICE_DTS := \
+	broadcom/bcm2712-rpi-5-b \
+	broadcom/bcm2712-rpi-cm5-cm4io \
+	broadcom/bcm2712-rpi-cm5-cm5io \
+	broadcom/bcm2712-rpi-cm5l-cm4io \
+	broadcom/bcm2712-rpi-cm5l-cm5io \
+	broadcom/bcm2712d0-rpi-5-b
+  SUPPORTED_DEVICES := \
+	raspberrypi,500 \
+	raspberrypi,5-compute-module \
+	raspberrypi,5-model-b
   DEVICE_PACKAGES := \
 	cypress-firmware-43455-sdio \
 	brcmfmac-nvram-43455-sdio \


### PR DESCRIPTION
Add support for the Raspberry Pi 5 Compute Module.

Includes relevant *.dtb files in the image.

Signed-off-by: Dave Marquard <dave-atx@users.noreply.github.com>