### PR TITLE
qualcommax: ipq60xx: LED mapping update for Netgear WAX610 and WAX610Y

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-wax610-base.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-wax610-base.dtsi
@@ -80,6 +80,7 @@
 			function = LED_FUNCTION_WLAN;
 			function-enumerator = <0>;
 			gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1radio";
 		};
 
 		led_2g_g {
@@ -87,7 +88,6 @@
 			function = LED_FUNCTION_WLAN;
 			function-enumerator = <1>;
 			gpios = <&tlmm 33 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy0radio";
 		};
 
 		led_5g_b {
@@ -95,6 +95,7 @@
 			function = LED_FUNCTION_WLAN;
 			function-enumerator = <2>;
 			gpios = <&tlmm 36 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0radio";
 		};
 
 		led_5g_g {
@@ -102,7 +103,6 @@
 			function = LED_FUNCTION_WLAN;
 			function-enumerator = <3>;
 			gpios = <&tlmm 37 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy1radio";
 		};
 	};
 };

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/01_leds
@@ -35,6 +35,11 @@ yuncore,fap650)
 	ucidef_set_led_netdev "wlan5ghz" "WLAN 5GHz LED" "blue:wlan-5ghz" "wlan0" "tx rx"
 	ucidef_set_led_netdev "wlan2ghz" "WLAN 2.4GHz LED" "green:wlan-2ghz" "wlan1" "tx rx"
 	;;
+netgear,wax610|\
+netgear,wax610y)
+	ucidef_set_led_netdev "lan-port-link" "LAN-PORT-LINK" "green:lan-0" "lan" "link_10 link_100 link_1000 link_2500"
+	ucidef_set_led_netdev "lan-port-traffic" "LAN-PORT-TRAFFIC" "orange:lan-1" "lan" "tx rx link_10 link_100 link_1000 link_2500"
+	;;
 esac
 
 board_config_flush


### PR DESCRIPTION
Fix swapped WLAN LEDs and move to blue LEDs to match stock behavior. Add LAN LED mappings.
