### PR TITLE
qca-nss-dp: rebuild package whenever target changes

### DIFF
--- a/package/kernel/qca-nss-dp/Makefile
+++ b/package/kernel/qca-nss-dp/Makefile
@@ -12,6 +12,11 @@ PKG_MIRROR_HASH:=45568d7f1268b67d752f7085f6ef8397ca8ee4e5456ef121b8a285bded99dc8
 PKG_BUILD_PARALLEL:=1
 PKG_FLAGS:=nonshared
 
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_TARGET_qualcommax_ipq807x \
+	CONFIG_TARGET_qualcommax_ipq60xx \
+	CONFIG_TARGET_qualcommax_ipq50xx
+
 include $(INCLUDE_DIR)/kernel.mk
 include $(INCLUDE_DIR)/package.mk
 


### PR DESCRIPTION
Since we overwrite `nss_dp_arch.h` based on the current subtarget:

```make
define Build/Configure
	$(CP) $(NSS_DP_HAL_DIR)/soc_ops/$(CONFIG_TARGET_SUBTARGET)/nss_$(CONFIG_TARGET_SUBTARGET).h \
		$(PKG_BUILD_DIR)/exports/nss_dp_arch.h
endef
```

And install to staging:

```sh
$(CP) $(PKG_BUILD_DIR)/exports/* $(1)/usr/include/qca-nss-dp/
```

We need to ensure it rebuilds whenever switching targets so it will reinstall the correct header.