### PR TITLE
qualcommax: ipq50xx: fix ipq5018 GE PHY and tidy up mdio nodes

### DIFF
--- a/target/linux/qualcommax/patches-6.6/0712-arm64-dts-qcom-ipq5018-add-mdio-node.patch
+++ b/target/linux/qualcommax/patches-6.6/0712-arm64-dts-qcom-ipq5018-add-mdio-node.patch
@@ -14,27 +14,31 @@ Signed-off-by: George Moussalem <george.moussalem@outlook.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq5018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq5018.dtsi
-@@ -192,6 +192,26 @@
+@@ -192,6 +192,30 @@
  			status = "disabled";
  		};
  
 +		mdio0: mdio@88000 {
++			compatible = "qcom,ipq5018-mdio", "qcom,qca-mdio";
++			reg = <0x00088000 0x64>;
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			compatible = "qcom,ipq5018-mdio", "qcom,qca-mdio";
-+			reg = <0x88000 0x64>;
++
 +			clocks = <&gcc GCC_MDIO0_AHB_CLK>;
 +			clock-names = "gcc_mdio_ahb_clk";
++
 +			status = "disabled";
 +		};
 +
 +		mdio1: mdio@90000 {
++			compatible = "qcom,ipq5018-mdio";
++			reg = <0x00090000 0x64>;
 +			#address-cells = <1>;
 +			#size-cells = <0>;
-+			compatible = "qcom,ipq5018-mdio";
-+			reg = <0x90000 0x64>;
++
 +			clocks = <&gcc GCC_MDIO1_AHB_CLK>;
 +			clock-names = "gcc_mdio_ahb_clk";
++
 +			status = "disabled";
 +		};
 +

--- a/target/linux/qualcommax/patches-6.6/0713-arm64-dts-qcom-ipq5018-add-ge_phy-node.patch
+++ b/target/linux/qualcommax/patches-6.6/0713-arm64-dts-qcom-ipq5018-add-ge_phy-node.patch
@@ -13,15 +13,14 @@ Signed-off-by: George Moussalem <george.moussalem@outlook.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq5018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq5018.dtsi
-@@ -210,6 +210,22 @@
- 			clocks = <&gcc GCC_MDIO1_AHB_CLK>;
+@@ -202,6 +202,21 @@
  			clock-names = "gcc_mdio_ahb_clk";
+ 
  			status = "disabled";
 +
 +			ge_phy: ethernet-phy@7 {
 +				compatible = "ethernet-phy-id004d.d0c0";
 +				reg = <7>;
-+
 +				clocks = <&gcc GCC_GEPHY_RX_CLK>,
 +					 <&gcc GCC_GEPHY_TX_CLK>;
 +
@@ -35,8 +34,8 @@ Signed-off-by: George Moussalem <george.moussalem@outlook.com>
 +			};
  		};
  
- 		cmn_pll: clock-controller@9b000 {
-@@ -394,8 +410,8 @@
+ 		mdio1: mdio@90000 {
+@@ -398,8 +413,8 @@
  				 <&pcie0_phy>,
  				 <&pcie1_phy>,
  				 <0>,

--- a/target/linux/qualcommax/patches-6.6/0816-arm64-dts-qcom-ipq5018-add-wifi-support.patch
+++ b/target/linux/qualcommax/patches-6.6/0816-arm64-dts-qcom-ipq5018-add-wifi-support.patch
@@ -13,7 +13,7 @@ Signed-off-by: George Moussalem <george.moussalem@outlook.com>
 ---
 --- a/arch/arm64/boot/dts/qcom/ipq5018.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq5018.dtsi
-@@ -696,6 +696,225 @@
+@@ -699,6 +699,225 @@
  			};
  		};
  


### PR DESCRIPTION
As part of the previous commit to add the #clock-cells property to the GE PHY, the PHY was inadvertently moved under the second mdio node in the dtsi, and therefore broke the init sequence as the driver was trying to use the wrong mdio bus to set the init values (ex. DAC, MSE, and AZ). So let's move it back under the right mdio node and, while at it, pad the register addresses to 8 hex numbers and re-order properties in line with Linux DTS coding standards.

Fixes: 6782d0e66fd607a3536d5fd94e998d2d700ffeaf