### PR TITLE
kernel: various kernel module build fixes for the upcoming 6.12 kernel

### DIFF
--- a/target/linux/generic/pending-6.12/811-pci_disable_usb_common_quirks.patch
+++ b/target/linux/generic/pending-6.12/811-pci_disable_usb_common_quirks.patch
@@ -1,35 +1,32 @@
-From 472e77e6edb548addfe9b1f71e307223e892b2a3 Mon Sep 17 00:00:00 2001
 From: Felix Fietkau <nbd@nbd.name>
 Date: Sat, 26 Apr 2025 21:10:40 +0200
 Subject: [PATCH] debloat: disable common USB quirks
 
 Signed-off-by: Felix Fietkau <nbd@nbd.name>
 ---
- drivers/usb/host/pci-quirks.c | 9 +++++++++
- drivers/usb/host/pci-quirks.h | 6 +++++-
- 2 files changed, 14 insertions(+), 1 deletion(-)
+ drivers/usb/host/pci-quirks.c | 7 +++++++
+ drivers/usb/host/pci-quirks.h | 4 ++++
+ 2 files changed, 11 insertions(+)
 
 --- a/drivers/usb/host/pci-quirks.c
 +++ b/drivers/usb/host/pci-quirks.c
-@@ -130,6 +130,8 @@ struct amd_chipset_type {
- 	u8 rev;
- };
- 
-+#ifndef CONFIG_PCI_DISABLE_COMMON_QUIRKS
-+
- static struct amd_chipset_info {
- 	struct pci_dev	*nb_dev;
- 	struct pci_dev	*smbus_dev;
-@@ -590,6 +592,8 @@ bool usb_amd_pt_check_port(struct device
+@@ -590,6 +590,7 @@ bool usb_amd_pt_check_port(struct device
  EXPORT_SYMBOL_GPL(usb_amd_pt_check_port);
  #endif /* CONFIG_USB_PCI_AMD */
  
-+#endif /* CONFIG_PCI_DISABLE_COMMON_QUIRKS */
-+
++#ifndef CONFIG_PCI_DISABLE_COMMON_QUIRKS
  static int usb_asmedia_wait_write(struct pci_dev *pdev)
  {
  	unsigned long retry_count;
-@@ -724,6 +728,10 @@ reset_needed:
+@@ -642,6 +643,7 @@ static inline int io_type_enabled(struct
+ }
+ 
+ #define mmio_enabled(dev) io_type_enabled(dev, PCI_COMMAND_MEMORY)
++#endif /* !CONFIG_PCI_DISABLE_COMMON_QUIRKS */
+ 
+ #if defined(CONFIG_HAS_IOPORT) && IS_ENABLED(CONFIG_USB_UHCI_HCD)
+ /*
+@@ -724,6 +726,10 @@ reset_needed:
  	return 1;
  }
  EXPORT_SYMBOL_GPL(uhci_check_and_reset_hc);
@@ -40,22 +37,13 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  #define pio_enabled(dev) io_type_enabled(dev, PCI_COMMAND_IO)
  
-@@ -1304,3 +1312,4 @@ static void quirk_usb_early_handoff(stru
+@@ -1304,3 +1310,4 @@ static void quirk_usb_early_handoff(stru
  }
  DECLARE_PCI_FIXUP_CLASS_FINAL(PCI_ANY_ID, PCI_ANY_ID,
  			PCI_CLASS_SERIAL_USB, 8, quirk_usb_early_handoff);
-+#endif
++#endif /* !CONFIG_PCI_DISABLE_COMMON_QUIRKS */
 --- a/drivers/usb/host/pci-quirks.h
 +++ b/drivers/usb/host/pci-quirks.h
-@@ -2,7 +2,7 @@
- #ifndef __LINUX_USB_PCI_QUIRKS_H
- #define __LINUX_USB_PCI_QUIRKS_H
- 
--#ifdef CONFIG_USB_PCI_AMD
-+#if defined(CONFIG_USB_PCI_AMD) && !defined(CONFIG_PCI_DISABLE_COMMON_QUIRKS)
- int usb_hcd_amd_remote_wakeup_quirk(struct pci_dev *pdev);
- bool usb_amd_hang_symptom_quirk(void);
- bool usb_amd_prefetch_quirk(void);
 @@ -38,12 +38,16 @@ static inline bool usb_amd_pt_check_port
  #ifdef CONFIG_USB_PCI
  void uhci_reset_hc(struct pci_dev *pdev, unsigned long base);


### PR DESCRIPTION
When I tried to build the 6.12 kernel pull request, I found that there were still many compilation errors. This PR fixes the kernel build errors that I can catch.