### PR TITLE
ramips: switch TP-Link RE305 v1 to new partition layout

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_re305-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305-v1.dts
@@ -5,6 +5,23 @@
 / {
 	compatible = "tplink,re305-v1", "mediatek,mt7628an-soc";
 	model = "TP-Link RE305 v1";
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0>, <&fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
 };
 
 &spi0 {
@@ -26,9 +43,8 @@
 				read-only;
 			};
 
-			partition@20000 {
-				compatible = "tplink,firmware";
-				label = "firmware";
+			fwconcat0: partition@20000 {
+				label = "fwconcat0";
 				reg = <0x20000 0x5e0000>;
 			};
 
@@ -50,10 +66,10 @@
 				};
 			};
 
-			/*
-				The flash space between 0x650000 and 0x7f0000 is blank in the
-				stock firmware so it is left out as well.
-			*/
+			fwconcat1: partition@650000 {
+				label = "fwconcat1";
+				reg = <0x650000 0x1a0000>;
+			};
 
 			partition@7f0000 {
 				label = "radio";

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -889,10 +889,16 @@ TARGET_DEVICES += tplink_re220-v2
 
 define Device/tplink_re305-v1
   $(Device/tplink-safeloader)
-  IMAGE_SIZE := 6016k
+  IMAGE_SIZE := 7680k
+  KERNEL_SIZE := 6016k
   DEVICE_MODEL := RE305
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt76x2
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Partition design has changed compared to older versions due to size restrictions and unsused flash. \
+	Upgrade via sysupgrade mechanism is not possible, so new installation via TFTP is required.
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size | append-metadata
   TPLINK_BOARD_ID := RE305-V1
 endef
 TARGET_DEVICES += tplink_re305-v1

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/05_compat-version
@@ -1,0 +1,15 @@
+
+. /lib/functions.sh
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+case "$(board_name)" in
+	tplink,re305-v1)
+		ucidef_set_compat_version "2.0"
+		;;
+esac
+
+board_config_flush
+
+exit 0


### PR DESCRIPTION
After trying to implement the gluon support for this device I ended up in a boot loop due to the usable amount of flash left. With this patch layout it uses the unused and empty flash space in the original partiton layout. The version 3 of this device the RE365 share the same approach to have more usable space.
