### PR TITLE
dnsmasq: fix start if dhcp-range is not correct

### DIFF
--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -133,8 +133,7 @@ _ip2str START "$start"
 _ip2str END "$end"
 
 if [ "$start" -le "$ipaddr" ] && [ "$ipaddr" -le "$end" ]; then
-    echo "error: address $IP inside range $START..$END" >&2
-    exit 1
+    echo "warning: address $IP inside range $START..$END" >&2
 fi
 
 echo "START=$START"

--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.91
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -597,10 +597,20 @@ dhcp_add() {
 	nettag="${networkid:+set:${networkid},}"
 
 	# make sure the DHCP range is not empty
-	if [ "$dhcpv4" != "disabled" ] && ipcalc "$ipaddr/$prefix_or_netmask" "$start" "$limit" ; then
-		[ "$dynamicdhcpv4" = "0" ] && END="static"
+	if [ "$dhcpv4" != "disabled" ]; then
+		unset START
+		unset END
+		unset NETMASK
+		ipcalc "$ipaddr/$prefix_or_netmask" "$start" "$limit"
 
-		xappend "--dhcp-range=$tags$nettag$START,$END,$NETMASK,$leasetime${options:+ $options}"
+		if [ -z "$START" ] || [ -z "$END" ] || [ -z "$NETMASK" ]; then
+			logger -t dnsmasq \
+				"unable to set dhcp-range for dhcp uci config section '$cfg'" \
+				"on interface '$ifname', please check your config"
+		else
+			[ "$dynamicdhcpv4" = "0" ] && END="static"
+			xappend "--dhcp-range=$tags$nettag$START,$END,$NETMASK,$leasetime${options:+ $options}"
+		fi
 	fi
 
 	if [ "$dynamicdhcpv6" = "0" ] ; then


### PR DESCRIPTION
```
dnsmasq: fix start if dhcp-range is not correct

If the uci 'dhcp' configuration for the dhcp leases is incorrect then
the call to 'ipclac' fails. However, the problem is that the dnsmasq
configuration option 'dhcp-range' is still written for this uci section
even though the information generated by ipcalc is incorrect or not set.

Due to the incorrectly generated configuration for dnsmasq, the service
cannot start.

To prevent an incorrect configuration from being written to the configuration,
a check is now made beforehand to ensure that the required variables are
present and valid. If the configuration is incorrect, a message is emitted
to the log that this configuration section is incorrect and this uci
configuration section is omitted.
```
```
base-files: treat 'ipaddr is inside range' as warning again

The call to 'ipcalc' is used in 'dnsmasq' init script to create the
configuration. If the 'ipaddr' is in the configured range then 'ipcalc' exited
with an error whereby the START/STOP variables are unavailable.

This behaviour has changed during 'ipcalc' refactoring and now leads to a
problem when starting 'dnsmasq' if the 'ipaddr' is inside this range. To
restore the old behaviour, only a warning is issued as before and the
required variables for the 'dnsmasq' are still set.

Fixes: 854739b32c7f (base-files: ipcalc.sh: Rewrite in pure shell)
```

This should fixes from my point of view the issue [166539](https://forum.openwrt.org/t/dhcp-doesnt-work-anymore-when-router-ip-is-inside-dhcp-range/166539) in the openwrt forum.