### PR TITLE
realtek: fix/add switchcore syscon nodes for RTL838x/RTL839x/RTL931x

### DIFF
--- a/target/linux/realtek/dts/rtl838x.dtsi
+++ b/target/linux/realtek/dts/rtl838x.dtsi
@@ -252,7 +252,7 @@
 
 	switchcore@1b000000 {
 		compatible = "syscon", "simple-mfd";
-		reg = <0x1b000000 0x20000>;
+		reg = <0x1b000000 0x10000>;
 
 		mdio_aux: mdio-aux {
 			compatible = "realtek,rtl8380-aux-mdio";

--- a/target/linux/realtek/dts/rtl839x.dtsi
+++ b/target/linux/realtek/dts/rtl839x.dtsi
@@ -260,7 +260,7 @@
 
 	switchcore@1b000000 {
 		compatible = "syscon", "simple-mfd";
-		reg = <0x1b000000 0x20000>;
+		reg = <0x1b000000 0x10000>;
 
 		mdio_aux: mdio-aux {
 			compatible = "realtek,rtl8390-aux-mdio";

--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -161,6 +161,11 @@
 		};
 	};
 
+	switchcore@1b000000 {
+		compatible = "syscon", "simple-mfd";
+		reg = <0x1b000000 0x10000>;
+	};
+
 	pinmux: pinmux@1b001358 {
 		compatible = "pinctrl-single";
 		reg = <0x1b001358 0x4>;


### PR DESCRIPTION
The switchcore node is the central location that describes the Realtek switch register addresses starting at 0x1b000000. It will be used by current and future regmap enabled device drivers. The upstream MDIO driver already makes use of it by calling syscon_node_to_regmap(dev->parent->of_node);

In the current DTS base we have 3 issues that should be fixed:

- rtl838x.dtsi has a length of 0x20000 instead of 0x10000
- rtl839x.dtsi has a length of 0x20000 instead of 0x10000
- rtl831x.dtsi has no switchcore node at all

Align these mismatches with the "good" RTL930x template.