### PR TITLE
ead: fix compilation with GCC14

### DIFF
--- a/package/network/services/ead/Makefile
+++ b/package/network/services/ead/Makefile
@@ -15,6 +15,7 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/ead
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=GPL-2.0
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/kernel.mk
@@ -36,7 +37,8 @@ CONFIGURE_PATH = tinysrp
 TARGET_CFLAGS += \
 	-I$(PKG_BUILD_DIR) \
 	-I$(PKG_BUILD_DIR)/tinysrp \
-	$(TARGET_CPPFLAGS)
+	$(TARGET_CPPFLAGS) \
+	-Wno-error=implicit-function-declaration
 
 MAKE_FLAGS += \
 	CONFIGURE_ARGS="$(CONFIGURE_ARGS)" \


### PR DESCRIPTION
Trying to compile EAD with now default GCC14 will fail due to now erroring out on implicit int type as well as implicit function declarations.

Due to this, the packaged configure script will fail on the simple compiler test as the generated test uses main loop with an implicit int type.

So, instead of patching multiple test cases in the shipped configure script for tinysrp lets run autoreconf on it so its regenerated.

We also need to pass -Wno-error=implicit-function-declaration as there are multiple instances of tinysrp code relying on implicit function declarations.