### PR TITLE
toolchain: gcc: fix build error with glibc for aarch64 targets

### DIFF
--- a/toolchain/gcc/patches-14.x/830-aarch64-libatomic.patch
+++ b/toolchain/gcc/patches-14.x/830-aarch64-libatomic.patch
@@ -1,0 +1,32 @@
+libatomic: Do not enforce march on aarch64
+
+Inspired by The Yocto Project [1].
+
+[1] https://github.com/yoctoproject/poky/blob/51192a79f1717786dda42776f916c3d97ada7971/meta/recipes-devtools/gcc/gcc/0022-libatomic-Do-not-enforce-march-on-aarch64.patch
+
+Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>
+
+ libatomic/Makefile.am | 1 -
+ libatomic/Makefile.in | 1 -
+ 2 files changed, 2 deletions(-)
+
+--- a/libatomic/Makefile.am
++++ b/libatomic/Makefile.am
+@@ -130,7 +130,6 @@ libatomic_la_LIBADD = $(foreach s,$(SIZES),$(addsuffix _$(s)_.lo,$(SIZEOBJS)))
+ ## On a target-specific basis, include alternates to be selected by IFUNC.
+ if HAVE_IFUNC
+ if ARCH_AARCH64_LINUX
+-IFUNC_OPTIONS	     = -march=armv8-a+lse
+ libatomic_la_LIBADD += $(foreach s,$(SIZES),$(addsuffix _$(s)_1_.lo,$(SIZEOBJS)))
+ 
+ endif
+--- a/libatomic/Makefile.in
++++ b/libatomic/Makefile.in
+@@ -452,7 +452,6 @@ M_SRC = $(firstword $(filter %/$(M_FILE), $(all_c_files)))
+ libatomic_la_LIBADD = $(foreach s,$(SIZES),$(addsuffix \
+ 	_$(s)_.lo,$(SIZEOBJS))) $(am__append_1) $(am__append_2) \
+ 	$(am__append_3) $(am__append_4)
+-@ARCH_AARCH64_LINUX_TRUE@@HAVE_IFUNC_TRUE@IFUNC_OPTIONS = -march=armv8-a+lse
+ @ARCH_ARM_LINUX_TRUE@@HAVE_IFUNC_TRUE@IFUNC_OPTIONS = -march=armv7-a+fp -DHAVE_KERNEL64
+ @ARCH_I386_TRUE@@HAVE_IFUNC_TRUE@IFUNC_OPTIONS = -march=i586
+ @ARCH_X86_64_TRUE@@HAVE_IFUNC_TRUE@IFUNC_OPTIONS = -mcx16 -mcx16


### PR DESCRIPTION
GCC 14+ fails to build due to libatomic specific -march handling.
This build error triggers only with glibc and not with musl libc which is default.

Closes: https://github.com/openwrt/openwrt/issues/16073