### PR TITLE
qualcommax: ipq50xx: gl-b3000: add board.d script: 03_set_oem_name

### DIFF
--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/03_set_oem_name
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/03_set_oem_name
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+. /lib/functions/uci-defaults.sh
+. /lib/functions/system.sh
+
+ipq50xx_set_oem_name()
+{
+	local board="$1"
+	case $board in
+	glinet,gl-b3000)
+		oem_name=${board#*-}
+		echo "$oem_name"  > "$oem_file"
+		;;
+	esac
+}
+
+oem_file=/tmp/sysinfo/oem_name
+board=$(board_name)
+ipq50xx_set_oem_name $board
+
+exit 0


### PR DESCRIPTION
This script is used to create the "/tmp/sysinfo/oem_name" file and populate it with the "supported_devices" metadata entry (b3000).

This is used by the new fwtool.sh feature to dectect oem firmware and properly advise via visual warning messages and directions to proceed safely.


 #18554  : add oem image dectection to fwtool.sh