### PR TITLE
config: add new TRANSPARENT_HUGEPAGE choice for 6.12 kernel

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -607,6 +607,10 @@ choice
 
 	config KERNEL_TRANSPARENT_HUGEPAGE_MADVISE
 		bool "madvise"
+
+	config KERNEL_TRANSPARENT_HUGEPAGE_NEVER
+		bool "never"
+		depends on !LINUX_6_6
 endchoice
 
 config KERNEL_HUGETLBFS


### PR DESCRIPTION
Kernel 6.12 has a new selection for TRANSPARENT_HUGEPAGE. Add them here to avoid missing symbols.

Ref: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-6.12.y&id=683ec99f12f4c386c23bed7f6a8ef44db5a4999a