### PR TITLE
base-files: Update /etc/init.d/boot to set permissions on /etc to 755

### DIFF
--- a/package/base-files/files/etc/init.d/boot
+++ b/package/base-files/files/etc/init.d/boot
@@ -20,6 +20,8 @@ boot() {
 	[ -f /proc/mounts ] || /sbin/mount_root
 	[ -f /proc/jffs2_bbc ] && echo "S" > /proc/jffs2_bbc
 
+	chmod 755 /etc
+
 	mkdir -p /var/lock
 	chmod 1777 /var/lock
 	mkdir -p /var/log


### PR DESCRIPTION
Make sure that the permsissions of `/etc` are always set to 755. This is absolutely neccessary after dropbear update from https://github.com/openwrt/openwrt/pull/18606 because the old patch to make dropbear ignore permissions was removed/reworked.
