### PR TITLE
realtek: fix RTL8214FC probing on RTL839x

### DIFF
--- a/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.c
@@ -3740,10 +3740,6 @@ static int rtl8214fc_phy_probe(struct phy_device *phydev)
 	int addr = phydev->mdio.addr;
 	int ret = 0;
 
-	/* 839x has internal SerDes */
-	if (soc_info.id == 0x8393)
-		return -ENODEV;
-
 	/* All base addresses of the PHYs start at multiples of 8 */
 	devm_phy_package_join(dev, phydev, addr & (~7),
 				sizeof(struct rtl83xx_shared_private));
@@ -3752,7 +3748,8 @@ static int rtl8214fc_phy_probe(struct phy_device *phydev)
 		struct rtl83xx_shared_private *shared = phydev->shared->priv;
 		shared->name = "RTL8214FC";
 		/* Configuration must be done while patching still possible */
-		ret = rtl8380_configure_rtl8214fc(phydev);
+		if (soc_info.family == RTL8380_FAMILY_ID)
+			ret = rtl8380_configure_rtl8214fc(phydev);
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
Probing of the RTL8214FC on RTL839x is currently very strange.

- On RTL8393 nothing is detected and only generic PHY is reported
- On RTL8392 the port 1 is not detected while port 2-4 seem to work

Someone left a special RTL8393 detection rules that seems to indicate that the we probe the internal SerDes instead. That is not true. Since upgrade to kernel 6.6 the RTL8218/RTL8214FC detection is 100% accurate and probing functions are only called when really needed.

Fix the issue by removing the condition. For now do PHY patching only on the RTL838x where it already worked before.