### PR TITLE
selinux: update to 3.8.1 and fix build with GCC14

### DIFF
--- a/package/libs/libselinux/Makefile
+++ b/package/libs/libselinux/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libselinux
-PKG_VERSION:=3.5
+PKG_VERSION:=3.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PKG_VERSION)
-PKG_HASH:=9a3a3705ac13a2ccca2de6d652b6356fead10f36fb33115c185c5ccdf29eec19
+PKG_HASH:=ec2d2789f931152d21c1db1eb4bc202ce4eccede34d9be9e360e3b45243cee2c
 
 PKG_LICENSE:=libselinux-1.0
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/libselinux/patches/0001-Inject-matchpathcon_filespec_add64-if-defined-__INO_.patch
+++ b/package/libs/libselinux/patches/0001-Inject-matchpathcon_filespec_add64-if-defined-__INO_.patch
@@ -1,0 +1,75 @@
+From 5c3fcbd931b7f9752b5ce29cec3b6813991d61c0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=BD=D0=B0=D0=B1?= <nabijaczleweli@nabijaczleweli.xyz>
+Date: Thu, 20 Mar 2025 16:55:17 +0100
+Subject: [PATCH] Inject matchpathcon_filespec_add64() if
+ !defined(__INO_T_MATCHES_INO64_T) instead of using __BITS_PER_LONG < 64 as
+ proxy
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The __INO_T_MATCHES_INO64_T is defined
+if ino_t would be the same size as ino64_t
+if -D_FILE_OFFSET_BITS=64 were not defined.
+
+This is /exactly/ what
+  /* ABI backwards-compatible shim for non-LFS 32-bit systems */
+  #if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && __BITS_PER_LONG < 64
+is trying to get at, but currently fails because x32/RV32 are "LFS"
+with 32-bit longs and 64-bit time_ts natively.
+
+Thus, the
+  static_assert(sizeof(unsigned long) == sizeof(__ino_t), "inode size mismatch");
+assertion fails (__ino_t is the "kernel ino_t" type,
+which generally corresponds to the kernel's ulong, which is u64 on x32).
+
+glibc headers allow us to check the condition we care about directly.
+
+Fixes: commit 9395cc0322 ("Always build for LFS mode on 32-bit archs.")
+Closes: #463
+Closes: Debian#1098481
+Signed-off-by: наб <nabijaczleweli@nabijaczleweli.xyz>
+Cc: Alba Mendez <me@alba.sh>
+Acked-by: James Carter <jwcart2@gmail.com>
+---
+ include/selinux/selinux.h | 2 +-
+ src/matchpathcon.c        | 8 ++++++--
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+--- a/include/selinux/selinux.h
++++ b/include/selinux/selinux.h
+@@ -537,7 +537,7 @@ extern int matchpathcon_index(const char
+    with the same inode (e.g. due to multiple hard links).  If so, then
+    use the latter of the two specifications based on their order in the 
+    file contexts configuration.  Return the used specification index. */
+-#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && __BITS_PER_LONG < 64
++#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && !defined(__INO_T_MATCHES_INO64_T)
+ #define matchpathcon_filespec_add matchpathcon_filespec_add64
+ #endif
+ extern int matchpathcon_filespec_add(ino_t ino, int specind, const char *file);
+--- a/src/matchpathcon.c
++++ b/src/matchpathcon.c
+@@ -261,7 +261,7 @@ int matchpathcon_filespec_add(ino_t ino,
+ 	return -1;
+ }
+ 
+-#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && __BITS_PER_LONG < 64
++#if (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64) && !defined(__INO_T_MATCHES_INO64_T)
+ /* alias defined in the public header but we undefine it here */
+ #undef matchpathcon_filespec_add
+ 
+@@ -280,9 +280,13 @@ int matchpathcon_filespec_add(unsigned l
+ {
+ 	return matchpathcon_filespec_add64(ino, specind, file);
+ }
++#elif (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64) || defined(__INO_T_MATCHES_INO64_T)
++
++static_assert(sizeof(uint64_t) == sizeof(ino_t), "inode size mismatch");
++
+ #else
+ 
+-static_assert(sizeof(unsigned long) == sizeof(ino_t), "inode size mismatch");
++static_assert(sizeof(uint32_t) == sizeof(ino_t), "inode size mismatch");
+ 
+ #endif
+ 

--- a/package/libs/libselinux/patches/100-v2-libselinux-be-careful-with-non-portable-LFS-macro.patch
+++ b/package/libs/libselinux/patches/100-v2-libselinux-be-careful-with-non-portable-LFS-macro.patch
@@ -1,0 +1,158 @@
+From patchwork Sat Apr 26 15:13:57 2025
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+X-Patchwork-Submitter: Alyssa Ross <hi@alyssa.is>
+X-Patchwork-Id: 14067708
+Received: from fhigh-b7-smtp.messagingengine.com
+ (fhigh-b7-smtp.messagingengine.com [202.12.124.158])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+	(No client certificate requested)
+	by smtp.subspace.kernel.org (Postfix) with ESMTPS id 33F71A31
+	for <selinux@vger.kernel.org>; Sat, 26 Apr 2025 15:15:54 +0000 (UTC)
+Authentication-Results: smtp.subspace.kernel.org;
+ arc=none smtp.client-ip=202.12.124.158
+ARC-Seal: i=1; a=rsa-sha256; d=subspace.kernel.org; s=arc-20240116;
+	t=1745680559; cv=none;
+ b=Pq1cEfDSDJ0fkBMv6QVCQI8UUqLnYGihmK9UeuLduv0kwLuwpvD6WOxM/TSLMRIywjgR8gd2c853qlcX7DDrHAnyddbljBfUmT7TClUWm+eES9n51wREeMkgpjwZEvuOCVXfWzMNnBJNztbAVx+10PtGeluwXSHG1odCX/NjgQI=
+ARC-Message-Signature: i=1; a=rsa-sha256; d=subspace.kernel.org;
+	s=arc-20240116; t=1745680559; c=relaxed/simple;
+	bh=pJMDSW9OyFQkw5+mTn23RDQ0ioaHtTd6I+0qBZvmwP4=;
+	h=From:To:Cc:Subject:Date:Message-ID:MIME-Version:Content-Type;
+ b=VY6d+x8V7xkeJ2uh/a5R7YERgjbG4KKpSH0LL+z/D5ebQqDoQYyVyuQAhANwGBuFP81lunmLcZc2wMIkhtTTIzrFJyVwMsKJnPT2vLUBI6Um9ow9ZAwrpU3bMzV3KjnKaTZMGAZ87fAstIzB5jJaPIF2rhU9NiBHjpTAn5ofXYo=
+ARC-Authentication-Results: i=1; smtp.subspace.kernel.org;
+ dmarc=none (p=none dis=none) header.from=alyssa.is;
+ spf=pass smtp.mailfrom=alyssa.is;
+ dkim=pass (2048-bit key) header.d=alyssa.is header.i=@alyssa.is
+ header.b=sVvu9/jU;
+ dkim=pass (2048-bit key) header.d=messagingengine.com
+ header.i=@messagingengine.com
+ header.b=Oe16/9D7; arc=none smtp.client-ip=202.12.124.158
+Authentication-Results: smtp.subspace.kernel.org;
+ dmarc=none (p=none dis=none) header.from=alyssa.is
+Authentication-Results: smtp.subspace.kernel.org;
+ spf=pass smtp.mailfrom=alyssa.is
+Authentication-Results: smtp.subspace.kernel.org;
+	dkim=pass (2048-bit key) header.d=alyssa.is header.i=@alyssa.is
+ header.b="sVvu9/jU";
+	dkim=pass (2048-bit key) header.d=messagingengine.com
+ header.i=@messagingengine.com header.b="Oe16/9D7"
+Received: from phl-compute-02.internal (phl-compute-02.phl.internal
+ [10.202.2.42])
+	by mailfhigh.stl.internal (Postfix) with ESMTP id ED5B02540205;
+	Sat, 26 Apr 2025 11:15:53 -0400 (EDT)
+Received: from phl-mailfrontend-02 ([10.202.2.163])
+  by phl-compute-02.internal (MEProxy); Sat, 26 Apr 2025 11:15:54 -0400
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=alyssa.is; h=cc
+	:cc:content-transfer-encoding:content-type:content-type:date
+	:date:from:from:in-reply-to:message-id:mime-version:reply-to
+	:subject:subject:to:to; s=fm2; t=1745680553; x=1745766953; bh=rW
+	uOFM2rzwdFfxgV2+EnHMjhI780MNjU9R+9eFq8dvg=; b=sVvu9/jU9LemQ6RFQI
+	DtSKhUj2+dsfX0he1Ov1CofCaTdNc+esuMzB8dGEgQnIY6sfB7FHrPAuDDQaCTEb
+	Qb0MW0FQNzuTyNO94P8IXvcPEN7XWpcH1UKkWyohOsX/DRQYs8YP/oyrZB7gy8h+
+	LPbqcyracjmJriUdC8aesJ3FKHmyQiXY8ka08VFQyiVrksvEwfM7tleNW0mQVrVG
+	VpHxDigwP71zXB3gHl0ogks6VloaqH0f3EKo1nT19xuzWGcMPKtBrs3jHJFSgy8X
+	9+jY/qFSAq6OvItkKnwXf08McbuKVuPnYZrrsVgx3NZFcaCo+tklqEvWJUJCPxnz
+	BfXw==
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=
+	messagingengine.com; h=cc:cc:content-transfer-encoding
+	:content-type:content-type:date:date:feedback-id:feedback-id
+	:from:from:in-reply-to:message-id:mime-version:reply-to:subject
+	:subject:to:to:x-me-proxy:x-me-sender:x-me-sender:x-sasl-enc; s=
+	fm3; t=1745680553; x=1745766953; bh=rWuOFM2rzwdFfxgV2+EnHMjhI780
+	MNjU9R+9eFq8dvg=; b=Oe16/9D7/7d67cUSyAPHmj+rekiHlxK3tMneIFP/5hTG
+	MlpQlyg5QLsVRSUxfGn/OjX1vvg5VrpRpeGYaxJyNU/oPy2jFBSwUmB1lR7/W4Lz
+	M4NYele9Nufotym19hpJylkMpOi266PNIqG1lT4OfK7d+ZEJSoZygq/tnsgE08ql
+	2AFSMbYbTQC6YM8sk+9tk2ypCjb7W1NouIshFQ33J7LNniu67KJDcPtH3VqfkG6q
+	RYkGhc21tTZl/e9EQ6m8Z4c6yWk8kDqozOBI0lOh6GrhAaDEj1+/2v0DF7OAcqwG
+	KhqGnYTkH2Qj8pshvMSctbOWckywkqxX+fREJWN9Gw==
+X-ME-Sender: <xms:qfgMaJE8VrzV69Ds-EsG48fFI5UaqMSYVinivYKJ4ML0p0Qd_UDicQ>
+    <xme:qfgMaOUrxIYKlodKAw1Xg57c4yZT6ZBIwMc_Jxf2xmsgkKIf3HHUkRikoeiSWWlvF
+    2vLA9kyO05KG8VGKQ>
+X-ME-Received: 
+ <xmr:qfgMaLLGcqX6upspD9CqnV5CuWYyVoe7dkYN-ilEpG08JiM1cEurmgjMsOzEj6QU>
+X-ME-Proxy-Cause: 
+ gggruggvucftvghtrhhoucdtuddrgeefvddrtddtgddvheehheefucetufdoteggodetrf
+    dotffvucfrrhhofhhilhgvmecuhfgrshhtofgrihhlpdggtfgfnhhsuhgsshgtrhhisggv
+    pdfurfetoffkrfgpnffqhgenuceurghilhhouhhtmecufedttdenucesvcftvggtihhpih
+    gvnhhtshculddquddttddmnecujfgurhephffvvefufffkofggtgfgsehtkeertdertdej
+    necuhfhrohhmpeetlhihshhsrgcutfhoshhsuceohhhisegrlhihshhsrgdrihhsqeenuc
+    ggtffrrghtthgvrhhnpeevieegveegkeefieekffeuuddtuefhtdfhgfdvfeeugfffvdeh
+    tdekveeufedtjeenucffohhmrghinhepghhithhhuhgsrdgtohhmnecuvehluhhsthgvrh
+    fuihiivgeptdenucfrrghrrghmpehmrghilhhfrhhomhephhhisegrlhihshhsrgdrihhs
+    pdhnsggprhgtphhtthhopeegpdhmohguvgepshhmthhpohhuthdprhgtphhtthhopehmvg
+    esrghlsggrrdhshhdprhgtphhtthhopehjfigtrghrthdvsehgmhgrihhlrdgtohhmpdhr
+    tghpthhtohepnhgrsghijhgrtgiilhgvfigvlhhisehnrggsihhjrggtiihlvgifvghlih
+    drgiihiidprhgtphhtthhopehsvghlihhnuhigsehvghgvrhdrkhgvrhhnvghlrdhorhhg
+X-ME-Proxy: <xmx:qfgMaPHxXV0etoyRJkgcYPe-u5lQsB6cvXgoxiMYU6OgH09vt9RJJA>
+    <xmx:qfgMaPVNzmzj8XlzIEYZvhuhOvK7xCeHS_NHGryjhfN_xqE-mmaCSA>
+    <xmx:qfgMaKPro4JgdEKJ3LZ0e1t9yipSpo-CqpVMe_Xg9n4ohUp0rhtvEw>
+    <xmx:qfgMaO1XYewudNFS8g1h7cOv-f3pWJTH7mubtCGLTV6fyEUJfKdQJQ>
+    <xmx:qfgMaPC5FGWuV_5Cknij04lvxGSeCOFW3wA8lCW6fChGDgA8HzuEfqKb>
+Feedback-ID: i12284293:Fastmail
+Received: by mail.messagingengine.com (Postfix) with ESMTPA; Sat,
+ 26 Apr 2025 11:15:52 -0400 (EDT)
+Received: by mbp.qyliss.net (Postfix, from userid 1000)
+	id E07A2117F8; Sat, 26 Apr 2025 17:15:46 +0200 (CEST)
+From: Alyssa Ross <hi@alyssa.is>
+To: selinux@vger.kernel.org
+Cc: =?utf-8?b?0L3QsNCx?= <nabijaczleweli@nabijaczleweli.xyz>,
+ James Carter <jwcart2@gmail.com>, Alba Mendez <me@alba.sh>
+Subject: [PATCH v2] libselinux: be careful with non-portable LFS macro
+Date: Sat, 26 Apr 2025 17:13:57 +0200
+Message-ID: <20250426151356.7116-2-hi@alyssa.is>
+X-Mailer: git-send-email 2.47.2
+Precedence: bulk
+X-Mailing-List: selinux@vger.kernel.org
+List-Id: <selinux.vger.kernel.org>
+List-Subscribe: <mailto:selinux+subscribe@vger.kernel.org>
+List-Unsubscribe: <mailto:selinux+unsubscribe@vger.kernel.org>
+MIME-Version: 1.0
+
+musl does not provide the obsolete LFS64 APIs (like ino64_t) — ino_t
+has always been 64-bit on all platforms there.  That means there's
+also no __INO_T_MATCHES_INO64_T macro, meaning the check would pass
+and reach the static asserts for the shim, which would fail due to
+there being no ino64_t to check the size of.  Fix this by only
+assuming the absense of __INO_T_MATCHES_INO64_t is meaningful when
+another non-portable Glibc macro, __INO64_T_TYPE, is defined.  If both
+are missing, that probably just means there is no ino64_t.
+
+Fixes: 5c3fcbd9 ("Inject matchpathcon_filespec_add64() if !defined(__INO_T_MATCHES_INO64_T) instead of using __BITS_PER_LONG < 64 as proxy")
+Signed-off-by: Alyssa Ross <hi@alyssa.is>
+Acked-by: James Carter <jwcart2@gmail.com>
+---
+v2: Made the same change to the condition in the header, as suggested
+    in a GitHub comment.  The omission didn't seem to break anything,
+    but it makes sense to change it there too.
+    https://github.com/NixOS/nixpkgs/pull/391728#issuecomment-2832282846
+
+ include/selinux/selinux.h | 2 +-
+ src/matchpathcon.c        | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+
+base-commit: 2647cc0fdca326b81ee3c08718cbe19b7866b53a
+
+--- a/include/selinux/selinux.h
++++ b/include/selinux/selinux.h
+@@ -537,7 +537,7 @@ extern int matchpathcon_index(const char
+    with the same inode (e.g. due to multiple hard links).  If so, then
+    use the latter of the two specifications based on their order in the 
+    file contexts configuration.  Return the used specification index. */
+-#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && !defined(__INO_T_MATCHES_INO64_T)
++#if defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64 && defined(__INO64_T_TYPE) && !defined(__INO_T_MATCHES_INO64_T)
+ #define matchpathcon_filespec_add matchpathcon_filespec_add64
+ #endif
+ extern int matchpathcon_filespec_add(ino_t ino, int specind, const char *file);
+--- a/src/matchpathcon.c
++++ b/src/matchpathcon.c
+@@ -261,7 +261,7 @@ int matchpathcon_filespec_add(ino_t ino,
+ 	return -1;
+ }
+ 
+-#if (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64) && !defined(__INO_T_MATCHES_INO64_T)
++#if (defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64) && defined(__INO64_T_TYPE) && !defined(__INO_T_MATCHES_INO64_T)
+ /* alias defined in the public header but we undefine it here */
+ #undef matchpathcon_filespec_add
+ 

--- a/package/libs/libsemanage/Makefile
+++ b/package/libs/libsemanage/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsemanage
-PKG_VERSION:=3.5
+PKG_VERSION:=3.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PKG_VERSION)
-PKG_HASH:=f53534e50247538280ed0d76c6ce81d8fb3939bd64cadb89da10dba42e40dd9c
+PKG_HASH:=7b39127b219cc70bfd935a4af6b0f2ba83d4b35c916f253c7e942c23ab490f07
 PKG_MAINTAINER:=Thomas Petazzoni <thomas.petazzoni@bootlin.com>
 PKG_LICENSE:=LGPL-2.1
 PKG_LICENSE_FILES:=COPYING
@@ -48,7 +48,6 @@ endef #'
 HOST_MAKE_FLAGS += \
 	DESTDIR=$(STAGING_DIR_HOSTPKG) \
 	PREFIX=""
-
 
 define Build/Configure
 endef

--- a/package/libs/libsemanage/patches/0001-libsemanage-create-semanage_basename-to-ensure-posix.patch
+++ b/package/libs/libsemanage/patches/0001-libsemanage-create-semanage_basename-to-ensure-posix.patch
@@ -1,0 +1,157 @@
+From a339594da6f027aed5d66ec6798a3d732df235e4 Mon Sep 17 00:00:00 2001
+From: Rahul Sandhu <nvraxn@gmail.com>
+Date: Fri, 21 Feb 2025 09:39:10 +0000
+Subject: [PATCH] libsemanage: create semanage_basename to ensure posix
+ compliance
+
+Passing a const char * to basename(3) is a glibc-specific extension, so
+create our own basename implementation. As it's a trivial 2 LOC, always
+use our implementation of basename even if glibc is available to avoid
+the complications of attaining the non-posix glibc implementation of
+basename(3) as _GNU_SOURCE needs to be defined, but libgen.h also needs
+to have not been included.
+
+Also fix a missing check for selinux_policy_root(3). From the man page:
+On failure, selinux_policy_root returns NULL.
+
+As the glibc basename(3) (unlike posix basename(3)) does not support
+having a nullptr passed to it, only pass the policy_root to basename(3)
+if it is non-null.
+
+Signed-off-by: Rahul Sandhu <nvraxn@gmail.com>
+Acked-by: James Carter <jwcart2@gmail.com>
+---
+ src/conf-parse.y       | 13 ++++++++++---
+ src/direct_api.c       |  1 +
+ src/utilities.c        |  9 +++++++++
+ src/utilities.h        | 13 +++++++++++++
+ tests/test_utilities.c | 26 ++++++++++++++++++++++++++
+ 5 files changed, 59 insertions(+), 3 deletions(-)
+
+--- a/src/conf-parse.y
++++ b/src/conf-parse.y
+@@ -21,6 +21,7 @@
+ %{
+ 
+ #include "semanage_conf.h"
++#include "utilities.h"
+ 
+ #include <sepol/policydb.h>
+ #include <selinux/selinux.h>
+@@ -382,7 +383,10 @@ external_opt:   PROG_PATH '=' ARG  { PAS
+ static int semanage_conf_init(semanage_conf_t * conf)
+ {
+ 	conf->store_type = SEMANAGE_CON_DIRECT;
+-	conf->store_path = strdup(basename(selinux_policy_root()));
++	const char *policy_root = selinux_policy_root();
++	if (policy_root != NULL) {
++		conf->store_path = strdup(semanage_basename(policy_root));
++	}
+ 	conf->ignoredirs = NULL;
+ 	conf->store_root_path = strdup("/var/lib/selinux");
+ 	conf->compiler_directory_path = strdup("/usr/libexec/selinux/hll");
+@@ -544,8 +548,11 @@ static int parse_module_store(char *arg)
+ 	free(current_conf->store_path);
+ 	if (strcmp(arg, "direct") == 0) {
+ 		current_conf->store_type = SEMANAGE_CON_DIRECT;
+-		current_conf->store_path =
+-		    strdup(basename(selinux_policy_root()));
++		const char *policy_root = selinux_policy_root();
++		if (policy_root != NULL) {
++			current_conf->store_path =
++			    strdup(semanage_basename(policy_root));
++		}
+ 		current_conf->server_port = -1;
+ 	} else if (*arg == '/') {
+ 		current_conf->store_type = SEMANAGE_CON_POLSERV_LOCAL;
+--- a/src/direct_api.c
++++ b/src/direct_api.c
+@@ -26,6 +26,7 @@
+ 
+ #include <assert.h>
+ #include <fcntl.h>
++#include <libgen.h>
+ #include <stdio.h>
+ #include <stdio_ext.h>
+ #include <stdlib.h>
+--- a/src/utilities.c
++++ b/src/utilities.c
+@@ -349,3 +349,12 @@ int write_full(int fd, const void *buf,
+ 
+ 	return 0;
+ }
++
++#ifdef __GNUC__
++__attribute__((nonnull))
++#endif
++char *semanage_basename(const char *filename)
++{
++	char *p = strrchr(filename, '/');
++	return p ? p + 1 : (char *)filename;
++}
+--- a/src/utilities.h
++++ b/src/utilities.h
+@@ -156,4 +156,17 @@ semanage_list_t *semanage_slurp_file_fil
+ 
+ int write_full(int fd, const void *buf, size_t len) WARN_UNUSED;
+ 
++/**
++ * Portable implementation of the glibc version of basename(3).
++ *
++ * @param filename  path to find basename of
++ *
++ * @return          basename of filename
++ */
++
++#ifdef __GNUC__
++__attribute__((nonnull))
++#endif
++char *semanage_basename(const char *filename);
++
+ #endif
+--- a/tests/test_utilities.c
++++ b/tests/test_utilities.c
+@@ -46,6 +46,7 @@ static void test_semanage_rtrim(void);
+ static void test_semanage_str_replace(void);
+ static void test_semanage_findval(void);
+ static void test_slurp_file_filter(void);
++static void test_semanage_basename(void);
+ 
+ static char fname[] = {
+ 	'T', 'E', 'S', 'T', '_', 'T', 'E', 'M', 'P', '_', 'X', 'X', 'X', 'X',
+@@ -117,6 +118,10 @@ int semanage_utilities_add_tests(CU_pSui
+ 				test_slurp_file_filter)) {
+ 		goto err;
+ 	}
++	if (NULL == CU_add_test(suite, "semanage_basename",
++				test_semanage_basename)) {
++		goto err;
++	}
+ 	return 0;
+       err:
+ 	CU_cleanup_registry();
+@@ -346,3 +351,24 @@ static void test_slurp_file_filter(void)
+ 
+ 	semanage_list_destroy(&data);
+ }
++
++static void test_semanage_basename(void)
++{
++	char *basename1 = semanage_basename("/foo/bar");
++	CU_ASSERT_STRING_EQUAL(basename1, "bar");
++
++	char *basename2 = semanage_basename("/foo/bar/");
++	CU_ASSERT_STRING_EQUAL(basename2, "");
++
++	char *basename3 = semanage_basename("/foo.bar");
++	CU_ASSERT_STRING_EQUAL(basename3, "foo.bar");
++
++	char *basename5 = semanage_basename(".");
++	CU_ASSERT_STRING_EQUAL(basename5, ".");
++
++	char *basename6 = semanage_basename("");
++	CU_ASSERT_STRING_EQUAL(basename6, "");
++
++	char *basename7 = semanage_basename("/");
++	CU_ASSERT_STRING_EQUAL(basename7, "");
++}

--- a/package/libs/libsepol/Makefile
+++ b/package/libs/libsepol/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libsepol
-PKG_VERSION:=3.5
+PKG_VERSION:=3.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PKG_VERSION)
-PKG_HASH:=78fdaf69924db780bac78546e43d9c44074bad798c2c415d0b9bb96d065ee8a2
+PKG_HASH:=0e78705305f955abd4c0654d37a5477ee26349ab74db9e2b03a7868897ae1ddf
 
 PKG_MAINTAINER:=Thomas Petazzoni <thomas.petazzoni@bootlin.com>
 PKG_CPE_ID:=cpe:/a:selinuxproject:libsepol

--- a/package/utils/checkpolicy/Makefile
+++ b/package/utils/checkpolicy/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=checkpolicy
-PKG_VERSION:=3.5
+PKG_VERSION:=3.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PKG_VERSION)
-PKG_HASH:=7aa48ab2222a0b9881111d6d7f70c3014d3d9338827d9e02df105a68c0df5dbc
+PKG_HASH:=7b477c516e2693d8b6c511386323177f1d7db51c2e04eb6d0de8ca2b36120e5d
 PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=libselinux
 HOST_BUILD_DEPENDS:=libselinux/host

--- a/package/utils/policycoreutils/Makefile
+++ b/package/utils/policycoreutils/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=policycoreutils
-PKG_VERSION:=3.5
+PKG_VERSION:=3.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PKG_VERSION)
-PKG_HASH:=78453e1529fbbf800e88860094d555e781ce1fba11a7ef77b5aabb43e1173276
+PKG_HASH:=eef23196b501d141cb95f5fc52ef1a7289f459b65e4415ea0fe9aeedc5d80ef2
 PKG_INSTALL:=1
 HOST_BUILD_DEPENDS:=libsemanage/host gettext-full/host
 PKG_BUILD_DEPENDS:=BUSYBOX_CONFIG_PAM:libpam gettext-full/host

--- a/package/utils/policycoreutils/patches/0001-policycoreutils-run_init-define-_GNU_SOURCE.patch
+++ b/package/utils/policycoreutils/patches/0001-policycoreutils-run_init-define-_GNU_SOURCE.patch
@@ -1,0 +1,29 @@
+From 2ffd51650fb1886d6466f652d2e626b1bb6a5ce3 Mon Sep 17 00:00:00 2001
+From: Robert Marko <robimarko@gmail.com>
+Date: Thu, 1 May 2025 21:15:11 +0200
+Subject: [PATCH] policycoreutils: run_init: define _GNU_SOURCE
+
+Trying to compile run_init with musl will fail with:
+run_init.c: In function 'authenticate_via_shadow_passwd':
+run_init.c:206:40: error: implicit declaration of function 'getpass' [-Wimplicit-function-declaration]
+  206 |         if (!(unencrypted_password_s = getpass(PASSWORD_PROMPT))) {
+
+This is because getpass in musl is guarded only for _GNU_SOURCE, so
+define _GNU_SOURCE for run_init.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+---
+ run_init/run_init.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/run_init/run_init.c
++++ b/run_init/run_init.c
+@@ -37,6 +37,8 @@
+  *
+  *************************************************************************/
+ 
++#define _GNU_SOURCE
++
+ #include <stdio.h>
+ #include <stdlib.h>		/* for malloc(), realloc(), free() */
+ #include <pwd.h>		/* for getpwuid() */

--- a/package/utils/secilc/Makefile
+++ b/package/utils/secilc/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=secilc
-PKG_VERSION:=3.5
+PKG_VERSION:=3.8.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/SELinuxProject/selinux/releases/download/$(PKG_VERSION)
-PKG_HASH:=3eebc5a1f97847fa530cf90654b9f3b8f21a13c9ea3d07495325651580cd3373
+PKG_HASH:=3db2974dd9a3c8403ada0392deff267b0398a74b4e7a0b051af76457270848d1
 HOST_BUILD_DEPENDS:=libsepol/host
 
 PKG_MAINTAINER:=Dominick Grift <dominick.grift@defensec.nl>


### PR DESCRIPTION
Update all of the selinux libraries and tools to latest 3.8.1 release and fix building with GCC14.