### PR TITLE
Fix misc problems with GCC 14

### DIFF
--- a/package/boot/uboot-lantiq/patches/0115-MIPS-add-board-support-for-Arcadyan-ARV7506PW11.patch
+++ b/package/boot/uboot-lantiq/patches/0115-MIPS-add-board-support-for-Arcadyan-ARV7506PW11.patch
@@ -89,7 +89,7 @@
 +void show_boot_progress(int arg)
 +{
 +	if (!do_gpio_init)
-+		return 0;
++		return;
 +
 +	if (arg >= 0) {
 +		/* Success - turn off the red power LED and turn on the green power LED */
@@ -101,7 +101,7 @@
 +		gpio_set_value(GPIO_POWER_RED, 0);
 +	}
 +
-+	return 0;
++	return;
 +}
 +
 +static const struct ltq_eth_port_config eth_port_config[] = {

--- a/package/network/config/ltq-adsl-app/Makefile
+++ b/package/network/config/ltq-adsl-app/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=dsl_cpe_control_danube
 PKG_VERSION:=3.24.4.4
-PKG_RELEASE:=13
+PKG_RELEASE:=14
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_BUILD_DIR:=$(BUILD_DIR)/dsl_cpe_control-$(PKG_VERSION)
 PKG_SOURCE_URL:=@OPENWRT

--- a/package/network/config/ltq-adsl-app/patches/020-gcc-14-fixes.patch
+++ b/package/network/config/ltq-adsl-app/patches/020-gcc-14-fixes.patch
@@ -1,0 +1,104 @@
+ltq-adsl-app: Fix compilation with GCC 14
+
+This fixes the following compile problem:
+```
+checking for asm/types.h... dsl_cpe_linux.c: In function 'DSL_CPE_ThreadInit':
+dsl_cpe_linux.c:779:25: error: assignment to 'DSL_CPE_Thread_t' {aka 'int'} from 'pthread_t' {aka 'struct __pthread *'} makes integer from pointer without a cast [-Wint-conversion]
+  779 |          pThrCntrl->tid = tid;
+      |                         ^
+dsl_cpe_linux.c: In function 'DSL_CPE_ThreadDelete':
+dsl_cpe_linux.c:862:44: error: passing argument 1 of 'pthread_cancel' makes pointer from integer without a cast [-Wint-conversion]
+  862 |             switch(pthread_cancel(pThrCntrl->tid))
+      |                                   ~~~~~~~~~^~~~~
+      |                                            |
+      |                                            DSL_CPE_Thread_t {aka int}
+In file included from dsl_cpe_linux.h:35:
+/builder/shared-workdir/build/staging_dir/toolchain-mips_mips32_gcc-14.2.0_musl/include/pthread.h:98:20: note: expected 'pthread_t' {aka 'struct __pthread *'} but argument is of type 'DSL_CPE_Thread_t' {aka 'int'}
+   98 | int pthread_cancel(pthread_t);
+      |                    ^~~~~~~~~
+dsl_cpe_linux.c: In function 'DSL_CPE_ThreadIdGet':
+dsl_cpe_linux.c:1123:11: error: returning 'pthread_t' {aka 'struct __pthread *'} from a function with return type 'DSL_CPE_Thread_t' {aka 'int'} makes integer from pointer without a cast [-Wint-conversion]
+ 1123 |    return pthread_self();
+      |           ^~~~~~~~~~~~~~
+```
+
+While at it, fix also some additional build warnings.
+
+--- a/src/dsl_cpe_linux.h
++++ b/src/dsl_cpe_linux.h
+@@ -21,7 +21,7 @@
+ #include <stdlib.h>
+ #include <getopt.h>
+ #include <stdio.h>               /* fdopen */
+-#include <sys/fcntl.h>           /* open */
++#include <fcntl.h>               /* open */
+ #include <sys/ioctl.h>           /* ioctl */
+ #include <string.h>              /* memset, strstr, strlen */
+ #include <stdlib.h>              /* strtoul */
+@@ -233,7 +233,7 @@ typedef struct stat              DSL_CPE
+ /**
+    LINUX User Thread - map the Thread ID.
+ */
+-typedef int    DSL_CPE_Thread_t;
++typedef pthread_t    DSL_CPE_Thread_t;
+ 
+ /**
+    LINUX User Thread - function type LINUX User Thread Start Routine.
+--- a/src/dsl_cpe_os_lint_map.h
++++ b/src/dsl_cpe_os_lint_map.h
+@@ -168,7 +168,7 @@ typedef struct timeval           DSL_Tim
+ /**
+    LINUX User Thread - map the Thread ID.
+ */
+-typedef int    DSL_CPE_Thread_t;
++typedef pthread_t    DSL_CPE_Thread_t;
+ 
+ /**
+    LINUX User Thread - function type LINUX User Thread Start Routine.
+--- a/src/dsl_cpe_control.c
++++ b/src/dsl_cpe_control.c
+@@ -2062,7 +2062,7 @@ DSL_Error_t DSL_CPE_ScriptExecute (
+ 
+       /* if the line is empty or a special "#" symbol detected,
+          then go on to the next */
+-      if ((sscanf (buf, "%s", &str_command) == 0) || (buf[0] == '#'))
++      if ((sscanf (buf, "%s", str_command) == 0) || (buf[0] == '#'))
+       {
+          continue;
+       }
+@@ -2075,7 +2075,7 @@ DSL_Error_t DSL_CPE_ScriptExecute (
+ 
+       while(*pFile__++ != '\n');
+ 
+-      if ((sscanf (buf, "%s", &str_command) == 0) || (buf[0] == '#'))
++      if ((sscanf (buf, "%s", str_command) == 0) || (buf[0] == '#'))
+       {
+          continue;
+       }
+@@ -2269,7 +2269,7 @@ DSL_Error_t DSL_CPE_ScriptExecute (
+       {
+          meireg regrdwr;
+ 
+-         sscanf (buf, "%s %s %s", &str_command, &op1, &op2);
++         sscanf (buf, "%s %s %s", str_command, &op1, &op2);
+          regrdwr.iAddress = strtoul (op1, DSL_NULL, 0) + MEI_SPACE_ACCESS;
+ 
+ 
+@@ -2302,7 +2302,7 @@ DSL_Error_t DSL_CPE_ScriptExecute (
+       {
+          meireg regrdwr;
+ 
+-         sscanf (buf, "%s %s %s", &str_command, &op1, &op2);
++         sscanf (buf, "%s %s %s", str_command, &op1, &op2);
+          regrdwr.iAddress = strtoul (op1, DSL_NULL, 0) + MEI_SPACE_ACCESS;
+          if (ioctl (pContext->fd, DANUBE_MEI_CMV_READ, &regrdwr) < 0)
+          {
+@@ -3522,7 +3522,7 @@ DSL_CPE_STATIC  DSL_int_t DSL_CPE_Event_
+          sprintf(sVarName, "DSL_DATARATE_%s_BC%d",
+             pEvent->data.nAccessDir == DSL_DOWNSTREAM ? "DS" : "US",
+             pEvent->data.nChannel == 0 ? 0 : pEvent->data.nChannel == 1 ? 1 : 0);
+-         sprintf(sVarVal, "%lu", pEvent->data.pData->channelStatusData.ActualDataRate);
++         sprintf(sVarVal, "%u", pEvent->data.pData->channelStatusData.ActualDataRate);
+ 
+          if (DSL_CPE_SetEnv(sVarName, sVarVal) == DSL_SUCCESS)
+          {

--- a/package/utils/dns320l-mcu/Makefile
+++ b/package/utils/dns320l-mcu/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dns320l-mcu
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/wigyori/dns320l-daemon.git

--- a/package/utils/dns320l-mcu/patches/010-gcc-14-fixes.patch
+++ b/package/utils/dns320l-mcu/patches/010-gcc-14-fixes.patch
@@ -1,0 +1,50 @@
+dns320l-mcu: Fix compilation with GCC 14
+
+This fixes the following compile problem:
+```
+dns320l-daemon.c: In function 'main':
+dns320l-daemon.c:740:18: error: implicit declaration of function 'isprint' [-Wimplicit-function-declaration]
+  740 |         else if (isprint (optopt))
+      |                  ^~~~~~~
+dns320l-daemon.c:50:1: note: include '<ctype.h>' or provide a declaration of 'isprint'
+   49 | #include "dns320l-daemon.h"
+  +++ |+#include <ctype.h>
+   50 | 
+dns320l-daemon.c:799:5: error: implicit declaration of function 'umask' [-Wimplicit-function-declaration]
+  799 |     umask(0);
+      |     ^~~~~
+dns320l-daemon.c:864:5: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
+  864 |     return;
+      |     ^~~~~~
+dns320l-daemon.c:691:5: note: declared here
+  691 | int main(int argc, char *argv[])
+      |     ^~~~
+```
+
+--- a/dns320l-daemon.c
++++ b/dns320l-daemon.c
+@@ -26,6 +26,7 @@
+ 
+ */
+ 
++#include <ctype.h>
+ #include <errno.h>
+ #include <termios.h>
+ #include <unistd.h>
+@@ -39,6 +40,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/types.h>
+ #include <sys/time.h>
++#include <sys/stat.h>
+ #include <time.h>
+ #include <arpa/inet.h>
+ #include <netinet/in.h>
+@@ -861,7 +863,7 @@ int main(int argc, char *argv[])
+   if (fd < 0)
+   {
+     syslog(LOG_ERR, "error %d opening %s: %s", errno, stDaemonConfig.portName, strerror (errno));
+-    return;
++    return EXIT_FAILURE;
+   }
+ 
+   set_interface_attribs (fd, B115200, 0);  // set speed to 115,200 bps, 8n1 (no parity)

--- a/toolchain/gcc/patches-11.x/020-Include-safe-ctype.h-after-C-standard-headers-to-avo.patch
+++ b/toolchain/gcc/patches-11.x/020-Include-safe-ctype.h-after-C-standard-headers-to-avo.patch
@@ -70,11 +70,9 @@ Signed-off-by: Dimitry Andric <dimitry@andric.com>
  gcc/system.h | 39 ++++++++++++++++++---------------------
  1 file changed, 18 insertions(+), 21 deletions(-)
 
-diff --git a/gcc/system.h b/gcc/system.h
-index b0edab02885..ab29fc19776 100644
 --- a/gcc/system.h
 +++ b/gcc/system.h
-@@ -194,27 +194,8 @@ extern int fprintf_unlocked (FILE *, const char *, ...);
+@@ -194,27 +194,8 @@ extern int fprintf_unlocked (FILE *, con
  #undef fread_unlocked
  #undef fwrite_unlocked
  
@@ -134,6 +132,3 @@ index b0edab02885..ab29fc19776 100644
  /* Some of glibc's string inlines cause warnings.  Plus we'd rather
     rely on (and therefore test) GCC's string builtins.  */
  #define __NO_STRING_INLINES
--- 
-2.39.3
-

--- a/toolchain/gcc/patches-11.x/980-fix-build-error-with-Xcode-16.3.patch
+++ b/toolchain/gcc/patches-11.x/980-fix-build-error-with-Xcode-16.3.patch
@@ -34,11 +34,9 @@ Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
  zlib/zutil.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/zlib/zutil.h b/zlib/zutil.h
-index 4b596adf629..9ea8d840643 100644
 --- a/zlib/zutil.h
 +++ b/zlib/zutil.h
-@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]
  #  endif
  #endif
  
@@ -47,6 +45,3 @@ index 4b596adf629..9ea8d840643 100644
  #  define OS_CODE  7
  #  ifndef Z_SOLO
  #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
--- 
-2.49.0
-

--- a/toolchain/gcc/patches-12.x/020-Include-safe-ctype.h-after-C-standard-headers-to-avo.patch
+++ b/toolchain/gcc/patches-12.x/020-Include-safe-ctype.h-after-C-standard-headers-to-avo.patch
@@ -70,11 +70,9 @@ Signed-off-by: Dimitry Andric <dimitry@andric.com>
  gcc/system.h | 39 ++++++++++++++++++---------------------
  1 file changed, 18 insertions(+), 21 deletions(-)
 
-diff --git a/gcc/system.h b/gcc/system.h
-index b0edab02885..ab29fc19776 100644
 --- a/gcc/system.h
 +++ b/gcc/system.h
-@@ -194,27 +194,8 @@ extern int fprintf_unlocked (FILE *, const char *, ...);
+@@ -194,27 +194,8 @@ extern int fprintf_unlocked (FILE *, con
  #undef fread_unlocked
  #undef fwrite_unlocked
  
@@ -134,6 +132,3 @@ index b0edab02885..ab29fc19776 100644
  /* Some of glibc's string inlines cause warnings.  Plus we'd rather
     rely on (and therefore test) GCC's string builtins.  */
  #define __NO_STRING_INLINES
--- 
-2.39.3
-

--- a/toolchain/gcc/patches-12.x/021-libcc1-fix-vector-include.patch
+++ b/toolchain/gcc/patches-12.x/021-libcc1-fix-vector-include.patch
@@ -18,8 +18,6 @@ libcc1/ChangeLog:
  libcc1/libcp1plugin.cc | 3 +--
  2 files changed, 2 insertions(+), 4 deletions(-)
 
-diff --git a/libcc1/libcc1plugin.cc b/libcc1/libcc1plugin.cc
-index 72d17c3b81c..e64847466f4 100644
 --- a/libcc1/libcc1plugin.cc
 +++ b/libcc1/libcc1plugin.cc
 @@ -32,6 +32,7 @@
@@ -39,8 +37,6 @@ index 72d17c3b81c..e64847466f4 100644
  using namespace cc1_plugin;
  
  
-diff --git a/libcc1/libcp1plugin.cc b/libcc1/libcp1plugin.cc
-index 0eff7c68d29..da68c5d0ac1 100644
 --- a/libcc1/libcp1plugin.cc
 +++ b/libcc1/libcp1plugin.cc
 @@ -33,6 +33,7 @@
@@ -60,6 +56,3 @@ index 0eff7c68d29..da68c5d0ac1 100644
  using namespace cc1_plugin;
  
  
--- 
-2.39.3
-

--- a/toolchain/gcc/patches-12.x/980-fix-build-error-with-Xcode-16.3.patch
+++ b/toolchain/gcc/patches-12.x/980-fix-build-error-with-Xcode-16.3.patch
@@ -34,11 +34,9 @@ Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
  zlib/zutil.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/zlib/zutil.h b/zlib/zutil.h
-index 4b596adf629..9ea8d840643 100644
 --- a/zlib/zutil.h
 +++ b/zlib/zutil.h
-@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]
  #  endif
  #endif
  
@@ -47,6 +45,3 @@ index 4b596adf629..9ea8d840643 100644
  #  define OS_CODE  7
  #  ifndef Z_SOLO
  #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
--- 
-2.49.0
-

--- a/toolchain/gcc/patches-13.x/980-fix-build-error-with-Xcode-16.3.patch
+++ b/toolchain/gcc/patches-13.x/980-fix-build-error-with-Xcode-16.3.patch
@@ -34,11 +34,9 @@ Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
  zlib/zutil.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/zlib/zutil.h b/zlib/zutil.h
-index 4b596adf629..9ea8d840643 100644
 --- a/zlib/zutil.h
 +++ b/zlib/zutil.h
-@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]
  #  endif
  #endif
  
@@ -47,6 +45,3 @@ index 4b596adf629..9ea8d840643 100644
  #  define OS_CODE  7
  #  ifndef Z_SOLO
  #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
--- 
-2.49.0
-

--- a/toolchain/gcc/patches-14.x/020-MIPS-Include-missing-mips16.S-in-libgcc-lib1funcs.S.patch
+++ b/toolchain/gcc/patches-14.x/020-MIPS-Include-missing-mips16.S-in-libgcc-lib1funcs.S.patch
@@ -1,0 +1,34 @@
+From 75892d97979f397a66730b97e8279941169e0316 Mon Sep 17 00:00:00 2001
+From: YunQiang Su <syq@gcc.gnu.org>
+Date: Fri, 23 Aug 2024 23:46:16 +0800
+Subject: MIPS: Include missing mips16.S in libgcc/lib1funcs.S
+
+mips16.S was missing since
+commit 29b74545531f6afbee9fc38c267524326dbfbedf
+Date:   Thu Jun 1 10:14:24 2023 +0800
+
+    MIPS: Add speculation_barrier support
+
+Without mips16.S included, some symbols will miss for mips16, and
+so some software will fail to build.
+
+libgcc/ChangeLog:
+
+	* config/mips/lib1funcs.S: Includes mips16.S.
+
+(cherry picked from commit 9522fc8bb7812f2ad50eb038e0938bfd958e730f)
+---
+ libgcc/config/mips/lib1funcs.S | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/libgcc/config/mips/lib1funcs.S
++++ b/libgcc/config/mips/lib1funcs.S
+@@ -19,7 +19,7 @@ a copy of the GCC Runtime Library Except
+ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+ <http://www.gnu.org/licenses/>.  */
+ 
+-//#include "mips16.S"
++#include "mips16.S"
+ 
+ #ifdef L_speculation_barrier
+ 

--- a/toolchain/gcc/patches-14.x/300-mips_Os_cpu_rtx_cost_model.patch
+++ b/toolchain/gcc/patches-14.x/300-mips_Os_cpu_rtx_cost_model.patch
@@ -10,7 +10,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/gcc/config/mips/mips.cc
 +++ b/gcc/config/mips/mips.cc
-@@ -20453,7 +20453,7 @@ mips_option_override (void)
+@@ -20447,7 +20447,7 @@ mips_option_override (void)
      flag_pcc_struct_return = 0;
  
    /* Decide which rtx_costs structure to use.  */

--- a/toolchain/gcc/patches-14.x/980-fix-build-error-with-Xcode-16.3.patch
+++ b/toolchain/gcc/patches-14.x/980-fix-build-error-with-Xcode-16.3.patch
@@ -34,11 +34,9 @@ Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
  zlib/zutil.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/zlib/zutil.h b/zlib/zutil.h
-index 4b596adf629..9ea8d840643 100644
 --- a/zlib/zutil.h
 +++ b/zlib/zutil.h
-@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]
  #  endif
  #endif
  
@@ -47,6 +45,3 @@ index 4b596adf629..9ea8d840643 100644
  #  define OS_CODE  7
  #  ifndef Z_SOLO
  #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
--- 
-2.49.0
-


### PR DESCRIPTION
 * ltq-adsl-app: Fix compilation with GCC 14
    
    This fixes the following compile problem:
    ```
    checking for asm/types.h... dsl_cpe_linux.c: In function 'DSL_CPE_ThreadInit':
    dsl_cpe_linux.c:779:25: error: assignment to 'DSL_CPE_Thread_t' {aka 'int'} from 'pthread_t' {aka 'struct __pthread *'} makes integer from pointer without a cast [-Wint-conversion]
      779 |          pThrCntrl->tid = tid;
          |                         ^
    dsl_cpe_linux.c: In function 'DSL_CPE_ThreadDelete':
    dsl_cpe_linux.c:862:44: error: passing argument 1 of 'pthread_cancel' makes pointer from integer without a cast [-Wint-conversion]
      862 |             switch(pthread_cancel(pThrCntrl->tid))
          |                                   ~~~~~~~~~^~~~~
          |                                            |
          |                                            DSL_CPE_Thread_t {aka int}
    In file included from dsl_cpe_linux.h:35:
    /builder/shared-workdir/build/staging_dir/toolchain-mips_mips32_gcc-14.2.0_musl/include/pthread.h:98:20: note: expected 'pthread_t' {aka 'struct __pthread *'} but argument is of type 'DSL_CPE_Thread_t' {aka 'int'}
       98 | int pthread_cancel(pthread_t);
          |                    ^~~~~~~~~
    dsl_cpe_linux.c: In function 'DSL_CPE_ThreadIdGet':
    dsl_cpe_linux.c:1123:11: error: returning 'pthread_t' {aka 'struct __pthread *'} from a function with return type 'DSL_CPE_Thread_t' {aka 'int'} makes integer from pointer without a cast [-Wint-conversion]
     1123 |    return pthread_self();
          |           ^~~~~~~~~~~~~~
    ```
    
    While at it, fix also some additional build warnings.
    
 * boot-lantiq: Fix compilation with GCC 14
    
    This fixes the following compile problem:
    ```
    arv7506pw11.c: In function 'show_boot_progress':
    arv7506pw11.c:59:24: error: 'return' with a value, in function returning void [-Wreturn-mismatch]
       59 |                 return 0;
          |                        ^
    arv7506pw11.c:56:6: note: declared here
       56 | void show_boot_progress(int arg)
          |      ^~~~~~~~~~~~~~~~~~
    arv7506pw11.c:71:16: error: 'return' with a value, in function returning void [-Wreturn-mismatch]
       71 |         return 0;
          |                ^
    arv7506pw11.c:56:6: note: declared here
       56 | void show_boot_progress(int arg)
          |      ^~~~~~~~~~~~~~~~~~
    ```
    
 * dns320l-mcu: Fix compilation with GCC 14
    
    This fixes the following compile problem:
    ```
    dns320l-daemon.c: In function 'main':
    dns320l-daemon.c:740:18: error: implicit declaration of function 'isprint' [-Wimplicit-function-declaration]
      740 |         else if (isprint (optopt))
          |                  ^~~~~~~
    dns320l-daemon.c:50:1: note: include '<ctype.h>' or provide a declaration of 'isprint'
       49 | #include "dns320l-daemon.h"
      +++ |+#include <ctype.h>
       50 |
    dns320l-daemon.c:799:5: error: implicit declaration of function 'umask' [-Wimplicit-function-declaration]
      799 |     umask(0);
          |     ^~~~~
    dns320l-daemon.c:864:5: error: 'return' with no value, in function returning non-void [-Wreturn-mismatch]
      864 |     return;
          |     ^~~~~~
    dns320l-daemon.c:691:5: note: declared here
      691 | int main(int argc, char *argv[])
          |     ^~~~
    ```

 * toolchain: gcc: Refresh patches
    
    Refresh all GCC patches.
    
 * toolchain: gcc: Backport patch to fix mips16 linking
    
    Backport patch from upstream GCC 14 branch which fixes linking with
    MIPS16 on the pistachio target.
    
    This fixes the following link problem:
    ```
    /builder/shared-workdir/build/staging_dir/toolchain-mipsel_24kc+24kf_gcc-14.2.0_musl/lib/gcc/mipsel-openwrt-linux-musl/14.2.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: ./liblua.so: undefined reference to `__mips16_ledf2'
    /builder/shared-workdir/build/staging_dir/toolchain-mipsel_24kc+24kf_gcc-14.2.0_musl/lib/gcc/mipsel-openwrt-linux-musl/14.2.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: ./liblua.so: undefined reference to `__mips16_call_stub_df_2'
    /builder/shared-workdir/build/staging_dir/toolchain-mipsel_24kc+24kf_gcc-14.2.0_musl/lib/gcc/mipsel-openwrt-linux-musl/14.2.0/../../../../mipsel-openwrt-linux-musl/bin/ld.bfd: ./liblua.so: undefined reference to `__mips16_muldf3'
    ```
   