### PR TITLE
mediatek: add support for ipTIME AX3000SM

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000sm.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000sm.dts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "ipTIME AX3000SM";
+	compatible = "iptime,ax3000sm", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		label-mac-device = &gmac1;
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		button-1 {
+			label = "reset";
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_cpu: led-3 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&pio 15 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 (3)>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 (1)>;
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x6E00000>;
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan4";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan3";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan1";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 (0)>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 (0)>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -78,6 +78,9 @@ glinet,gl-xe3000)
 huasifei,wh3000)
 	ucidef_set_led_netdev "wan" "WAN" "red:wan" "eth1" "link tx rx"
 	;;
+iptime,ax3000sm)
+	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
+	;;
 mercusys,mr80x-v3)
 	ucidef_set_led_netdev "lan1" "lan-1" "green:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan-2" "green:lan-2" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -49,6 +49,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;
 	asus,tuf-ax4200|\
+	iptime,ax3000sm|\
 	jdcloud,re-cp-03|\
 	mediatek,mt7981-rfb|\
 	netcore,n60|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -109,6 +109,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	iptime,ax3000sm)
+		addr=$(mtd_get_mac_binary "Factory" 0x4)
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_setbit $addr 26) 25) 27) 28) > \
+			/sys${DEVPATH}/macaddress
+		;;
 	jcg,q30-pro|\
 	netcore,n60|\
 	netcore,n60-pro)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1101,6 +1101,17 @@ define Device/huasifei_wh3000-pro
 endef
 TARGET_DEVICES += huasifei_wh3000-pro
 
+define Device/iptime_ax3000sm
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := AX3000SM
+  DEVICE_DTS := mt7981b-iptime-ax3000sm
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
+endef
+TARGET_DEVICES += iptime_ax3000sm
+
 define Device/jcg_q30-pro
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := Q30 PRO


### PR DESCRIPTION
This is a pull request in order to add support for ipTIME AX3000SM. The architecture is similar to Routerich AX3000 v1, so it is possible to run the Routerich AX3000 v1 kernel with minor issues(MAC addressing, LED indication, and LAN 4 is missing). This commit is based on pull request #18601, with some customizations to suit the ipTIME router.

Specification
-------------
- SoC       : MediaTek MT7981BA dual-core ARM Cortex-A53 1.3GHz
- RAM       : DDR3 256Mbytes, Nanya Technology NT5CC128M16IP
- Flash     : 128Mbytes NAND Flash, ESMT F50L1G41LB
- WLAN      : MediaTek MT7976CN dual-band Wi-Fi 6
  - 2.4GHz  : b/g/n/ax, MU-MIMO
  - 5GHz    : a/n/ac/ax, MU-MIMO
- Ethernet  : 
  - 10/100/1000 Mbps x4, LAN (MediaTek MT7531AE)
  - 10/100/1000 Mbps x1, WAN (MT7981 internal PHY)
- UART      : 1x4 pin header on PCB
  - [J500] 3.3V, TX, RX, GND (115200, 8N1)
- Buttons   : WPS, Reset
- LEDs      : 9 LEDs
  - 1x Power (Amber) 
  - 1x CPU (Amber)
  - 1x Wi-Fi 5GHz (Amber)
  - 1x Wi-Fi 2.4GHz (Amber)
  - 1x WAN activity (Amber)
  - 4x LAN activity (Amber)
- Power     : 12VDC, 1A (Center positive polarity)

MAC address
-----------

| Interface      | MAC                        | Algorithm |
|-------------------|---------------------------|----------------|
| WLAN 2.4G  | B0:38:6C:xx:xx:xx | label           |
| WLAN 5G     | B2:38:6C:4x:xx:xx |                     |
| WAN             | B0:38:6C:xx:xx:xx | label + 1     |
| LAN              | B0:38:6C:xx:xx:xx | label + 3     |

The WLAN 2.4G MAC address was found in 'Factory' partition, 0x4

Installation
------------
1. Download the *initramfs-kernel.bin file from the OpenWrt website
2. Attach UART to the router, and interrupt the boot process by pressing '0'
> If you successfully interrupt the boot process, a terminal prompt name should look like this:
```
   MT7981>
```
3. Connect the router(LAN port) to the PC
4. Assign the PC IP address: 192.168.0.100/24
5. Load and run the *initramfs-kernel.bin:
```
  tftpboot 0x46000000 initramfs-kernel.bin
  bootm
```
6. Upload the OpenWrt *squashfs-sysupgrade.bin to the router
7. Run `sysupgrade -n` with the sysupgrade OpenWrt image

Screenshot
----------
<details><summary>OpenWrt Luci Web Interface</summary>
<p>

![OpenWrt-iptime-ax3000sm](https://github.com/user-attachments/assets/044e12e6-5b25-46fa-b4e8-5ab026d29d40)

</p>
</details> 

Bootlogs
--------
<details><summary>OEM Bootlog</summary>
<p>

```
F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 024B [010F]
Jump to BL

NOTICE:  BL2: v2.7(release):0697eafa43-dirty
NOTICE:  BL2: Built : 17:33:02, Jan 26 2024
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a083f1 000003ff 00100000 00000000
1001d040 | 00000000 00000000 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0x8 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 536, worse bit 0, min window 64
Window Sum 536, worse bit 9, min window 64
Window Sum 386, worse bit 6, min window 46
Window Sum 378, worse bit 9, min window 44
Window Sum 402, worse bit 6, min window 48
Window Sum 386, worse bit 9, min window 44
Window Sum 408, worse bit 2, min window 50
Window Sum 400, worse bit 9, min window 48
Window Sum 420, worse bit 0, min window 52
Window Sum 406, worse bit 8, min window 48
Window Sum 430, worse bit 6, min window 52
Window Sum 418, worse bit 9, min window 50
Window Sum 448, worse bit 6, min window 54
Window Sum 432, worse bit 9, min window 50
Window Sum 450, worse bit 6, min window 54
Window Sum 440, worse bit 8, min window 52
Window Sum 462, worse bit 3, min window 56
Window Sum 446, worse bit 9, min window 52
Window Sum 466, worse bit 7, min window 56
Window Sum 450, worse bit 8, min window 54
Window Sum 454, worse bit 14, min window 54
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xef
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 0 found in block 960
NOTICE:  Second info table with writecount 0 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):0697eafa43-dirty
NOTICE:  BL31: Built : 17:33:04, Jan 26 2024
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Jan 26 2024 - 17:32:30 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: Winbond SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 0 found in block 960
Second info table with writecount 0 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[?25h[2J[1;1HCheck RST button - wait 1 second

ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 110 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 2/0, WL threshold: 4096, image sequence number: 75211564
ubi0: available PEBs: 432, total reserved PEBs: 448, PEBs reserved for bad PEB handling: 19
Reading from volume 'kernel' to 0x46000000, size 0x0 ... OK
## Loading kernel from FIT Image at 46000000 ...
   Using 'config@1' configuration
   Trying 'kernel@1' kernel subimage
     Description:  ARM64 OpenWrt Linux-5.4.246
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x460000e8
     Data Size:    3389456 Bytes = 3.2 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x48080000
     Entry Point:  0x48080000
     Hash algo:    crc32
     Hash value:   2100c096
     Hash algo:    sha1
     Hash value:   304061e0aa19750f1b75d7dc6075ffe018f39488
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 46000000 ...
   Using 'config@1' configuration
   Trying 'fdt@1' fdt subimage
     Description:  ARM64 OpenWrt image-mt7981-spim-nand-rfb device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x4633ba44
     Data Size:    18357 Bytes = 17.9 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   3285a880
     Hash algo:    sha1
     Hash value:   7727b6b4f4cfab12c7fb053e97f639bb8234ddb9
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x4633ba44
   Uncompressing Kernel Image
   Loading Device Tree to 000000004f7f1000, end 000000004f7f87b4 ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 5.4.246 (hykim@7962c431c69e) (gcc version 8.4.0 (OpenWrt GCC 8.4.0 r16910-95d5b0a7a8)) #0 SMP Wed Jul 17 09:20:54 2024
[    0.000000] Machine model: ipTIME AX3000
[    0.000000] On node 0 totalpages: 64512
[    0.000000]   DMA32 zone: 1024 pages used for memmap
[    0.000000]   DMA32 zone: 0 pages reserved
[    0.000000]   DMA32 zone: 64512 pages, LIFO batch:15
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.0
[    0.000000] percpu: Embedded 20 pages/cpu s43672 r8192 d30056 u81920
[    0.000000] pcpu-alloc: s43672 r8192 d30056 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 63488
[    0.000000] Kernel command line: console=ttyS0,115200 boot_from=A
[    0.000000] get_boot_firmware_name(66) boot_from=rootfs
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 230152K/258048K available (7038K kernel code, 494K rwdata, 1996K rodata, 448K init, 296K bss, 27896K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	CONFIG_RCU_FANOUT set to non-default value of 32.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] GICv3: Distributor has no Range Selector support
[    0.000000] GICv3: 16 PPIs implemented
[    0.000000] GICv3: no VLPI support, no direct LPI support
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000004] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000144] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=52000)
[    0.000151] pid_max: default: 32768 minimum: 301
[    0.000217] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.000222] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.000920] ASID allocator initialised with 65536 entries
[    0.000976] rcu: Hierarchical SRCU implementation.
[    0.001253] smp: Bringing up secondary CPUs ...
[    0.001526] Detected VIPT I-cache on CPU1
[    0.001545] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.001566] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.001624] smp: Brought up 1 node, 2 CPUs
[    0.001633] SMP: Total of 2 processors activated.
[    0.001637] CPU features: detected: 32-bit EL0 Support
[    0.001641] CPU features: detected: CRC32 instructions
[    0.001740] CPU: All CPU(s) started at EL2
[    0.001750] alternatives: patching kernel code
[    0.002237] devtmpfs: initialized
[    0.004074] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.004090] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.004166] pinctrl core: initialized pinctrl subsystem
[    0.004784] NET: Registered protocol family 16
[    0.004985] DMA: preallocated 256 KiB pool for atomic allocations
[    0.018801] cryptd: max_cpu_qlen set to 1000
[    0.020575] SCSI subsystem initialized
[    0.020723] libata version 3.00 loaded.
[    0.020862] usbcore: registered new interface driver usbfs
[    0.020888] usbcore: registered new interface driver hub
[    0.020912] usbcore: registered new device driver usb
[    0.021507] Bluetooth: Core ver 2.22
[    0.021530] NET: Registered protocol family 31
[    0.021533] Bluetooth: HCI device and connection manager initialized
[    0.021540] Bluetooth: HCI socket layer initialized
[    0.021545] Bluetooth: L2CAP socket layer initialized
[    0.021553] Bluetooth: SCO socket layer initialized
[    0.021866] rbus 18000000.wbsys: PCI host bridge to bus 0000:00
[    0.021874] pci_bus 0000:00: root bus resource [mem 0x18000000-0x18ffffff]
[    0.021880] pci_bus 0000:00: root bus resource [bus 00-ff]
[    0.021885] pci_bus 0000:00: scanning bus
[    0.021901] pci 0000:00:00.0: [14c3:7981] type 00 class 0x000280
[    0.021915] pci 0000:00:00.0: reg 0x10: [mem 0x18000000-0x1800000f 64bit]
[    0.021921] pci 0000:00:00.0: reg 0x18: [mem 0x00000000-0x0000000f]
[    0.021927] pci 0000:00:00.0: reg 0x1c: [mem 0x00000000-0x0000000f]
[    0.021933] pci 0000:00:00.0: reg 0x20: [mem 0x00000000-0x0000000f]
[    0.021939] pci 0000:00:00.0: reg 0x24: [mem 0x00000000-0x0000000f]
[    0.022825] pci_bus 0000:00: fixups for bus
[    0.022831] pci_bus 0000:00: bus scan returning with max=00
[    0.024760] clocksource: Switched to clocksource arch_sys_counter
[    0.025638] thermal_sys: Registered thermal governor 'fair_share'
[    0.025640] thermal_sys: Registered thermal governor 'bang_bang'
[    0.025648] thermal_sys: Registered thermal governor 'step_wise'
[    0.025651] thermal_sys: Registered thermal governor 'user_space'
[    0.025654] thermal_sys: Registered thermal governor 'power_allocator'
[    0.025862] NET: Registered protocol family 2
[    0.025955] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.026268] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.026285] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.026303] TCP bind hash table entries: 2048 (order: 3, 32768 bytes, linear)
[    0.026329] TCP: Hash tables configured (established 2048 bind 2048)
[    0.026388] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.026402] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.026494] NET: Registered protocol family 1
[    0.026520] PCI: CLS 0 bytes, default 64
[    0.027145] workingset: timestamp_bits=62 max_order=16 bucket_order=0
[    0.029569] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.029583] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.042234] phy phy-usb-phy@11e10000.1: type_sw - reg 0x218, index 0
[    0.052741] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.053566] printk: console [ttyS0] disabled
[    0.073705] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 12, base_baud = 2500000) is a ST16650V2
[    0.714791] printk: console [ttyS0] enabled
[    0.719652] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.728110] loop: module loaded
[    0.731403] mediatek,mt2701-ice_debug ice_debug: get dbg_sel clock fail: -2
[    0.738367] mediatek,mt2701-ice_debug: probe of ice_debug failed with error -2
[    0.746443] mt7981-pinctrl 11d00000.pinctrl: pin_config_set op failed for pin 19
[    0.753844] mtk-spi 1100a000.spi: Error applying setting, reverse things back
[    0.761421] spi-nand spi0.0: Failed to calibrate SPI-NAND (err = -22)
[    0.767975] spi-nand spi0.0: Winbond SPI NAND was found.
[    0.773288] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.783868] [mtk_hw_init] reset_lock:0, force:0
[    0.788442] [mtk_hw_init] execute fe cold reset
[    0.803980] mtk_soc_eth 15100000.ethernet: MDC is running on 2500000 Hz
[    0.831235] mtk_soc_eth 15100000.ethernet: generated random MAC address 0e:43:15:2f:ef:1d
[    0.839704] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc011980000, irq 79
[    0.848793] mtk_soc_eth 15100000.ethernet: generated random MAC address f6:f6:39:3f:a6:5b
[    0.857216] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc011980000, irq 79
[    0.866259] (unnamed net_device) (dummy): netif_napi_add() called with weight 256
[    0.874003] usbcore: registered new interface driver usblp
[    0.879597] usbcore: registered new interface driver uas
[    0.884943] usbcore: registered new interface driver usb-storage
[    0.891119] i2c /dev entries driver
[    0.895693] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    0.903727] device-mapper: ioctl: 4.41.0-ioctl (2019-09-16) initialised: dm-devel@redhat.com
[    0.912335] Bluetooth: HCI UART driver ver 2.3
[    0.916778] Bluetooth: HCI UART protocol H4 registered
[    0.921907] Bluetooth: HCI UART protocol BCSP registered
[    0.927288] Bluetooth: HCI UART protocol Broadcom registered
[    0.932959] Bluetooth: HCI UART protocol QCA registered
[    0.938687] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    0.953241] Twin IP Module Init
[    0.956383] --> Init Smart QoS Monitor
[    0.960443] NET: Registered protocol family 10
[    0.965495] Segment Routing with IPv6
[    0.969214] NET: Registered protocol family 17
[    0.973691] Bridge firewalling registered
[    0.977772] 8021q: 802.1Q VLAN Support v1.8
[    0.990961] nmbm nmbm_spim_nand: Signature found at block 1023 [0x07fe0000]
[    0.998687] nmbm nmbm_spim_nand: First info table with writecount 0 found in block 960
[    1.008872] nmbm nmbm_spim_nand: Second info table with writecount 0 found in block 963
[    1.016872] nmbm nmbm_spim_nand: NMBM has been successfully attached 
[    1.023458] 5 fixed-partitions partitions found on MTD device nmbm_spim_nand
[    1.030503] Creating 5 MTD partitions on "nmbm_spim_nand":
[    1.035981] 0x000000000000-0x000000100000 : "BL2"
[    1.041280] 0x000000100000-0x000000180000 : "u-boot-env"
[    1.047102] 0x000000180000-0x000000380000 : "Factory"
[    1.052687] 0x000000380000-0x000000580000 : "FIP"
[    1.057924] 0x000000580000-0x000007380000 : "ubi"
[    1.286680] mt7530 mdio-bus:1f lan0 (uninitialized): PHY [dsa-0.0:00] driver [MediaTek MT7531 PHY]
[    1.305322] mt7530 mdio-bus:1f lan1 (uninitialized): PHY [dsa-0.0:01] driver [MediaTek MT7531 PHY]
[    1.323931] mt7530 mdio-bus:1f lan2 (uninitialized): PHY [dsa-0.0:02] driver [MediaTek MT7531 PHY]
[    1.342539] mt7530 mdio-bus:1f lan3 (uninitialized): PHY [dsa-0.0:03] driver [MediaTek MT7531 PHY]
[    1.352079] mt7530 mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.359151] DSA: tree 0 setup
[    1.359398] mt7530 mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.362113] mt7530-nl: genl_register_family_with_ops 
[    1.374754] UBI: auto-attach mtd5
[    1.378078] ubi0: attaching mtd5
[    1.691203] ubi0: scanning is finished
[    1.699885] ubi0: attached mtd5 (name "ubi", size 110 MiB)
[    1.705379] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    1.712243] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    1.719019] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    1.725967] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    1.731962] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[    1.739171] ubi0: max/mean erase counter: 2/0, WL threshold: 4096, image sequence number: 75211564
[    1.748116] ubi0: available PEBs: 432, total reserved PEBs: 448, PEBs reserved for bad PEB handling: 19
[    1.757503] ubi0: background thread "ubi_bgt0d" started, PID 725
[    1.763659] block ubiblock0_2: created from ubi0:2(rootfs)
[    1.769157] ubiblock: device ubiblock0_2 (rootfs) set to be root filesystem
[    1.776115] hctosys: unable to open rtc device (rtc0)
[    1.784061] VFS: Mounted root (squashfs filesystem) readonly on device 253:0.
[    1.793574] devtmpfs: mounted
[    1.796739] Freeing unused kernel memory: 448K
[    1.816801] Run /sbin/init as init process
Start inittime
---> init fs


Checking Uboot Env ---> [ OK : ax3ksm ]


check_and_install_mtk_eeprom:Check EEPROM (wl_mode:0) -> [ OK ]
check_and_install_mtk_eeprom:Check EEPROM (wl_mode:1) -> [ OK ]
---> init elog
---> init dump_core
---> init version
Product ID:ax3ksm Version:15.018
---> init hw spec

Checking System Requirements *******************************************

DRAM SIZE  : Requirement->256 Mbytes / Mounted->256 Mbytes -----------> [OK]
FLASH SIZE : Requirement->128 Mbytes / Mounted->128 Mbytes -----------> [OK]


---> init sys
Install Module Failed: nf_conntrack_netlink.ko
 
---> init sysctl
---> init restore_config
	--> Restoring Config...
		--> 1st Config - Default
		 -- Default account : Do macfmt conversion admin/admin
		 -- mgmt access - credential patched : admin /  admin
		 -- patched (login --> removed)
		 -- patched (password --> removed)
---> init restore_session
---> init net_files
---> init nfrule
---> init servd
---> init config
rm: can't remove '/etc/snmp*': No such file or directory
---> init ftm
---> init tz
---> init gpio
  ---> gpio.init end
---> init mac
    =================================================================
    press magic key to change default setting ...
    LAN MAC : B0:38:6C:38:56:A7
    WAN MAC : B0:38:6C:38:56:A5
---> init bridge
---> init wireless
	--> Bridge multicast snooping : 1
	--> Bridge multicast querier :0
  ---> wl.preinit
		--->Pre-Interface up/down:ra0
	Scanning best channel for wl_mode:0 --->[ 2 ]
	--> set_profile WL_MODE:0
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b0.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b0.dat
	--> set_profile WL_MODE:1
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b1.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b1.dat
set 0x7d3 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d3=0x82
set 0x7d4 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d4=0x82
No need to scan for wl_mode:0 (channel:2) is already found
	--> set_profile WL_MODE:0
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b0.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b0.dat
	--> set_profile WL_MODE:1
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b1.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b1.dat
set 0x7d3 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d3=0x82
set 0x7d4 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d4=0x82
---> init diag
---> init iptables
  ---> NAT:enabled
---> init lan
---> init wan
---> init dns
---> init resume_lan
---> init iptables_chain
route: SIOCDELRT: No such process
---> init dos
---> init connctrl
  ---> init_connctrl
---> init disable_switch
---> init switch
  ---> IPTV mode: 2
---> init macvlan
---> init enable_switch
---> init port_mirroring
---> init port_config
---> init stacache
---> init portcache
---> init optimization
Optimize CPU : wireless
---> init resume_wan
---> init route
---> init services
killall: gpioctld: no process killed
killall: apcpd: no process killed
  ---> init_connctrl
---> Initialize HostName
killall: httpd: no process killed
Install mtk nat module
insmod: can't insert '/lib/modules/5.4.246/mtkhnat.ko': File exists
rtcs:initial:1543,interval:21600
rtcs:initial:1245,interval:21600
killall: snmpd: no process killed
killall: snmptrapd: no process killed
Terminated
Stop MTK 8021x Daemon for ra0.
Stop MTK 8021x Daemon for rax0.
killall: inotifywait: no process killed
killall: saved: no process killed
End inittime
Setting up watches.  Beware: since -r was given, this may take a while!
Watches established.
Stopping strongSwan IPsec failed: starter is not running
helper_timer_handler:Start wl_helper
killall: dhcpd.helper: no process killed
timer helper_timer has not finished yet
```

</p>
</details> 

<details><summary>OpenWrt Bootlog</summary>
<p>

```
F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 024F [010F]
Jump to BL

NOTICE:  BL2: v2.7(release):0697eafa43-dirty
NOTICE:  BL2: Built : 17:33:02, Jan 26 2024
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a083f1 000003ff 00100000 00000000
1001d040 | 00000000 00000000 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0x8 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 560, worse bit 0, min window 68
Window Sum 568, worse bit 8, min window 68
Window Sum 398, worse bit 1, min window 48
Window Sum 386, worse bit 9, min window 44
Window Sum 414, worse bit 3, min window 48
Window Sum 402, worse bit 9, min window 48
Window Sum 424, worse bit 1, min window 52
Window Sum 412, worse bit 9, min window 48
Window Sum 436, worse bit 1, min window 54
Window Sum 426, worse bit 9, min window 50
Window Sum 442, worse bit 1, min window 54
Window Sum 436, worse bit 9, min window 52
Window Sum 460, worse bit 3, min window 54
Window Sum 442, worse bit 8, min window 52
Window Sum 466, worse bit 3, min window 56
Window Sum 452, worse bit 14, min window 52
Window Sum 474, worse bit 3, min window 56
Window Sum 452, worse bit 8, min window 54
Window Sum 474, worse bit 3, min window 58
Window Sum 454, worse bit 8, min window 54
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc8
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 0 found in block 960
NOTICE:  Second info table with writecount 0 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):0697eafa43-dirty
NOTICE:  BL31: Built : 17:33:04, Jan 26 2024
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Jan 26 2024 - 17:32:30 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: GigaDevice SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 0 found in block 960
Second info table with writecount 0 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[?25h[2J[1;1HCheck RST button - wait 1 second

ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 110 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 22/8, WL threshold: 4096, image sequence number: 75211564
ubi0: available PEBs: 2, total reserved PEBs: 878, PEBs reserved for bad PEB handling: 19
Reading from volume 'kernel' to 0x46000000, size 0x0 ... OK
## Loading kernel from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.6.90
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x460000e8
     Data Size:    4312874 Bytes = 4.1 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x48000000
     Entry Point:  0x48000000
     Hash algo:    crc32
     Hash value:   088462c7
     Hash algo:    sha1
     Hash value:   5c0e1093703ac6c839507b354b758e1778ee3196
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt iptime_ax3000sm device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x4641d154
     Data Size:    22942 Bytes = 22.4 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   7c81636b
     Hash algo:    sha1
     Hash value:   8220467958a88624eed4c752513a5262cedf9603
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x4641d154
   Uncompressing Kernel Image
   Loading Device Tree to 000000004f7f0000, end 000000004f7f899d ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.6.90 (nyanko@DevBox) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.2.0 r29446+217-d0d9b7b612) 14.2.0, GNU ld (GNU Binutils) 2.42) #0 SMP Sun May 18 02:12:12 2025
[    0.000000] Machine model: ipTIME AX3000SM
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004302ffff (192 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x0000000047c80000..0x0000000047d7ffff (1024 KiB) nomap non-reusable wmcpu-reserved@47c80000
[    0.000000] OF: reserved mem: 0x0000000047d80000..0x0000000047dbffff (256 KiB) nomap non-reusable wo-emi@47d80000
[    0.000000] OF: reserved mem: 0x0000000047dc0000..0x0000000047ffffff (2304 KiB) nomap non-reusable wo-data@47dc0000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004302ffff]
[    0.000000]   node   0: [mem 0x0000000043030000-0x0000000047c7ffff]
[    0.000000]   node   0: [mem 0x0000000047c80000-0x0000000047ffffff]
[    0.000000]   node   0: [mem 0x0000000048000000-0x000000004fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 18 pages/cpu s35048 r8192 d30488 u73728
[    0.000000] pcpu-alloc: s35048 r8192 d30488 u73728 alloc=18*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: console=ttyS0,115200 boot_from=A
[    0.000000] Unknown kernel command line parameters "boot_from=A", will be passed to user space.
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 64512
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[    0.000000] software IO TLB: area num 2.
[    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 0MB
[    0.000000] software IO TLB: mapped [mem 0x000000004fe47000-0x000000004fec7000] (0MB)
[    0.000000] Memory: 239180K/262144K available (8832K kernel code, 994K rwdata, 2568K rodata, 448K init, 289K bss, 22964K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000071] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000080] pid_max: default: 32768 minimum: 301
[    0.003036] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.003044] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.005201] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.005731] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.005880] rcu: Hierarchical SRCU implementation.
[    0.005882] rcu: 	Max phase no-delay instances is 1000.
[    0.006279] smp: Bringing up secondary CPUs ...
[    0.006636] Detected VIPT I-cache on CPU1
[    0.006678] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.006706] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.006770] smp: Brought up 1 node, 2 CPUs
[    0.006775] SMP: Total of 2 processors activated.
[    0.006778] CPU features: detected: 32-bit EL0 Support
[    0.006781] CPU features: detected: CRC32 instructions
[    0.006813] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.006816] CPU: All CPU(s) started at EL2
[    0.006818] alternatives: applying system-wide alternatives
[    0.010387] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.010403] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.011680] pinctrl core: initialized pinctrl subsystem
[    0.012828] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.013166] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.013192] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.013212] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.013595] thermal_sys: Registered thermal governor 'fair_share'
[    0.013599] thermal_sys: Registered thermal governor 'bang_bang'
[    0.013602] thermal_sys: Registered thermal governor 'step_wise'
[    0.013604] thermal_sys: Registered thermal governor 'user_space'
[    0.013673] ASID allocator initialised with 65536 entries
[    0.014383] pstore: Using crash dump compression: deflate
[    0.014388] pstore: Registered ramoops as persistent store backend
[    0.014390] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.015775] OF: /soc/wifi@18000000/band@0: #nvmem-cell-cells = 1 found 0
[    0.015796] OF: /soc/wifi@18000000/band@1: #nvmem-cell-cells = 1 found 0
[    0.015811] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.021144] Modules: 29440 pages in range for non-PLT usage
[    0.021151] Modules: 520960 pages in range for PLT usage
[    0.022088] cryptd: max_cpu_qlen set to 1000
[    0.024195] SCSI subsystem initialized
[    0.024382] libata version 3.00 loaded.
[    0.025985] clocksource: Switched to clocksource arch_sys_counter
[    0.028327] NET: Registered PF_INET protocol family
[    0.028423] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.029486] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.029498] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.029507] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.029525] TCP bind hash table entries: 2048 (order: 4, 65536 bytes, linear)
[    0.029573] TCP: Hash tables configured (established 2048 bind 2048)
[    0.029887] MPTCP token hash table entries: 256 (order: 0, 6144 bytes, linear)
[    0.029992] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.030079] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.030295] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.030319] PCI: CLS 0 bytes, default 64
[    0.031412] workingset: timestamp_bits=46 max_order=16 bucket_order=0
[    0.036382] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.036390] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.104369] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.105579] printk: console [ttyS0] disabled
[    0.125920] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 72, base_baud = 2500000) is a ST16650V2
[    0.125960] printk: console [ttyS0] enabled
[    0.905191] loop: module loaded
[    0.911505] spi-nand spi0.0: calibration result: 0x3
[    0.916575] spi-nand spi0.0: ESMT SPI NAND was found.
[    0.921616] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.931009] Signature found at block 1023 [0x07fe0000]
[    0.936163] NMBM management region starts at block 960 [0x07800000]
[    0.944322] First info table with writecount 0 found in block 960
[    0.956007] Second info table with writecount 0 found in block 963
[    0.962180] NMBM has been successfully attached
[    0.967004] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.973356] Creating 5 MTD partitions on "spi0.0":
[    0.978155] 0x000000000000-0x000000100000 : "BL2"
[    0.983854] 0x000000100000-0x000000180000 : "u-boot-env"
[    0.989999] 0x000000180000-0x000000380000 : "Factory"
[    0.996957] 0x000000380000-0x000000580000 : "FIP"
[    1.003246] 0x000000580000-0x000007380000 : "ubi"
[    1.214066] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081580000, irq 75
[    1.223963] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc081580000, irq 75
[    1.233673] i2c_dev: i2c /dev entries driver
[    1.239711] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.248809] NET: Registered PF_INET6 protocol family
[    1.254832] Segment Routing with IPv6
[    1.258545] In-situ OAM (IOAM) with IPv6
[    1.262503] NET: Registered PF_PACKET protocol family
[    1.268025] 8021q: 802.1Q VLAN Support v1.8
[    1.366504] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.375481] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.386241] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=79)
[    1.408456] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=80)
[    1.430531] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=81)
[    1.452573] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=82)
[    1.464131] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.470890] DSA: tree 0 setup
[    1.474692] UBI: auto-attach mtd4
[    1.478046] ubi0: default fastmap pool size: 40
[    1.482566] ubi0: default fastmap WL pool size: 20
[    1.487358] ubi0: attaching mtd4
[    2.281148] ubi0: scanning is finished
[    2.296264] ubi0: attached mtd4 (name "ubi", size 110 MiB)
[    2.301753] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    2.308629] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.315405] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.322366] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    2.328366] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[    2.335573] ubi0: max/mean erase counter: 22/8, WL threshold: 4096, image sequence number: 75211564
[    2.344606] ubi0: available PEBs: 0, total reserved PEBs: 880, PEBs reserved for bad PEB handling: 19
[    2.353820] ubi0: background thread "ubi_bgt0d" started, PID 542
[    2.360676] block ubiblock0_1: created from ubi0:1(rootfs)
[    2.366205] ubiblock: device ubiblock0_1 (rootfs) set to be root filesystem
[    2.373281] clk: Disabling unused clocks
[    2.385714] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[    2.393062] Freeing unused kernel memory: 448K
[    2.397581] Run /sbin/init as init process
[    2.401666]   with arguments:
[    2.404620]     /sbin/init
[    2.407326]   with environment:
[    2.410455]     HOME=/
[    2.412803]     TERM=linux
[    2.415496]     boot_from=A
[    2.668904] init: Console is alive
[    2.672437] init: - watchdog -
[    3.111321] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.128838] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    3.138744] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.156282] init: - preinit -
[    3.496230] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    3.504682] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    3.532361] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    3.695998] random: crng init done
[    7.729066] UBIFS (ubi0:2): Mounting in unauthenticated mode
[    7.734802] UBIFS (ubi0:2): background thread "ubifs_bgt0_2" started, PID 679
[    7.797469] UBIFS (ubi0:2): recovery needed
[    7.969900] UBIFS (ubi0:2): recovery completed
[    7.974407] UBIFS (ubi0:2): UBIFS: mounted UBI device 0, volume 2, name "rootfs_data"
[    7.982244] UBIFS (ubi0:2): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[    7.992149] UBIFS (ubi0:2): FS size: 97771520 bytes (93 MiB, 770 LEBs), max 781 LEBs, journal size 4952064 bytes (4 MiB, 39 LEBs)
[    8.003789] UBIFS (ubi0:2): reserved for root: 4617990 bytes (4509 KiB)
[    8.010395] UBIFS (ubi0:2): media format: w5/r0 (latest is w5/r0), UUID C8920BC4-8E26-4E13-94DD-D1F7AA907CEC, small LPT model
[    8.027165] mount_root: switching to ubifs overlay
[    8.040226] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[    8.058002] urandom-seed: Seeding with /etc/urandom.seed
[    8.126213] procd: - early -
[    8.129157] procd: - watchdog -
[    8.673528] procd: - watchdog -
[    8.683513] procd: - ubus -
[    8.837476] procd: - init -
Please press Enter to activate this console.
[    9.175652] kmodloader: loading kernel modules from /etc/modules.d/*
[    9.205271] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    9.222322] Loading modules backported from Linux version v6.12.6-0-ge9d65b48ce1a
[    9.229832] Backport generated by backports.git v6.1.110-1-35-g410656ef04d2
[    9.361382] urngd: v1.0.2 started.
[    9.590756] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[    9.590756] 
[    9.850563] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[    9.962659] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[   10.059801] OF: /soc/wifi@18000000/band@0: #nvmem-cell-cells = 1 found 0
[   10.066580] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[   10.167623] OF: /soc/wifi@18000000/band@1: #nvmem-cell-cells = 1 found 0
[   10.174372] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[   10.252199] PPP generic driver version 2.4.2
[   10.257891] NET: Registered PF_PPPOX protocol family
[   10.267597] kmodloader: done loading kernel modules from /etc/modules.d/*
[   10.269412] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   10.552854] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   13.636240] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   13.650292] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   13.658857] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   13.670683] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   13.696225] br-lan: port 1(lan1) entered blocking state
[   13.701468] br-lan: port 1(lan1) entered disabled state
[   13.706785] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   13.713071] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   13.722671] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   13.743405] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   13.754901] br-lan: port 2(lan2) entered blocking state
[   13.760174] br-lan: port 2(lan2) entered disabled state
[   13.765420] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   13.773934] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   13.790070] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   13.806802] br-lan: port 3(lan3) entered blocking state
[   13.812032] br-lan: port 3(lan3) entered disabled state
[   13.817356] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   13.837987] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   13.865250] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   13.890007] br-lan: port 4(lan4) entered blocking state
[   13.895240] br-lan: port 4(lan4) entered disabled state
[   13.900562] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   13.921458] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[   13.962355] mtk_soc_eth 15100000.ethernet eth1: PHY [mdio-bus:00] driver [MediaTek MT7981 PHY] (irq=POLL)
[   13.971978] mtk_soc_eth 15100000.ethernet eth1: configuring for phy/gmii link mode



BusyBox v1.37.0 (2025-05-18 01:28:20 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt SNAPSHOT, r29446+217-d0d9b7b612
 -----------------------------------------------------
=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------

 OpenWrt recently switched to the "apk" package manager!

 OPKG Command           APK Equivalent      Description
 ------------------------------------------------------------------
 opkg install <pkg>     apk add <pkg>       Install a package
 opkg remove <pkg>      apk del <pkg>       Remove a package
 opkg upgrade           apk upgrade         Upgrade all packages
 opkg files <pkg>       apk info -L <pkg>   List package contents
 opkg list-installed    apk info            List installed packages
 opkg update            apk update          Update package lists
 opkg search <pkg>      apk search <pkg>    Search for packages
 ------------------------------------------------------------------

For more https://openwrt.org/docs/guide-user/additional-software/opkg-to-apk-cheatsheet

root@OpenWrt:~# 
```

</p>
</details> 
