### PR TITLE
realtek: fix cpu port link type

### DIFF
--- a/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52.dts
+++ b/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52.dts
@@ -153,7 +153,7 @@
 		port@52 {
 			ethernet = <&ethernet0>;
 			reg = <52>;
-			phy-mode = "qsgmii";
+			phy-mode = "internal";
 			fixed-link {
 				speed = <1000>;
 				full-duplex;

--- a/target/linux/realtek/dts/rtl8393_netgear_gs750e.dts
+++ b/target/linux/realtek/dts/rtl8393_netgear_gs750e.dts
@@ -243,7 +243,7 @@
 		port@52 {
 			ethernet = <&ethernet0>;
 			reg = <52>;
-			phy-mode = "qsgmii";
+			phy-mode = "internal";
 			fixed-link {
 				speed = <1000>;
 				full-duplex;

--- a/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48.dts
+++ b/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48.dts
@@ -313,7 +313,7 @@
 		port@52 {
 			ethernet = <&ethernet0>;
 			reg = <52>;
-			phy-mode = "qsgmii";
+			phy-mode = "internal";
 			fixed-link {
 				speed = <1000>;
 				full-duplex;


### PR DESCRIPTION
Some DTS files have a qsgmii link mode for the CPU port. This does not harm but it is wrong. The CPU port of the realtek switch is always directly connected to the switch by some unknown wiring and should therefore be described as internal. Align the wrongly defined DTS files to the standard.