### PR TITLE
mediatek: filogic: increase spi flash memory speed on ZyXEL EX5601

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -168,7 +168,7 @@
                 #size-cells = <1>;
                 compatible = "spi-nand";
                 reg = <1>;
-                spi-max-frequency = <20000000>;
+                spi-max-frequency = <50000000>;
                 spi-tx-bus-width = <4>;
                 spi-rx-bus-width = <4>;
 


### PR DESCRIPTION
Reduces boot time by 3s on a freshly installed image. This device has a large flash and the gain can be higher with more packages installed. According to the datasheet, this is the maximum frequency supported by the Micron and Macronix chips that are installed in these devices. Tested on three units over a two month period.

Before:
~~~
$ dd if=/dev/mtd5 of=/dev/null bs=10M count=1 status=progress 1+0 records in
1+0 records out
10485760 bytes (10 MB, 10 MiB) copied, 1.51901 s, 6.9 MB/s
~~~

After:
~~~
$ dd if=/dev/mtd5 of=/dev/null bs=10M count=1 status=progress 1+0 records in
1+0 records out
10485760 bytes (10 MB, 10 MiB) copied, 0.899474 s, 11.7 MB/s
~~~

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
