### PR TITLE
kernel: mtk_bmt: counteracting calloc-transposed-args compiler warning

### DIFF
--- a/target/linux/generic/files/drivers/mtd/nand/mtk_bmt_v2.c
+++ b/target/linux/generic/files/drivers/mtd/nand/mtk_bmt_v2.c
@@ -304,7 +304,7 @@ mtk_bmt_get_mapping_mask(void)
 	unsigned long *used;
 	int i, k;
 
-	used = kcalloc(sizeof(unsigned long), BIT_WORD(bmtd.bmt_blk_idx) + 1, GFP_KERNEL);
+	used = kcalloc(BIT_WORD(bmtd.bmt_blk_idx) + 1, sizeof(unsigned long), GFP_KERNEL);
 	if (!used)
 		return NULL;
 


### PR DESCRIPTION
For kernel 6.12 there is a warning causing an error:
```
drivers/mtd/nand/mtk_bmt_v2.c: In function 'mtk_bmt_get_mapping_mask':
drivers/mtd/nand/mtk_bmt_v2.c:307:31: error: 'kmalloc_array_noprof' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]
  307 |         used = kcalloc(sizeof(unsigned long), BIT_WORD(bmtd.bmt_blk_idx) + 1, GFP_KERNEL);
      |                               ^~~~~~~~
```
Swapping the arguments solves the problem.