### PR TITLE
toolchain: gcc: make config consistent with glibc/musl

### DIFF
--- a/toolchain/gcc/common.mk
+++ b/toolchain/gcc/common.mk
@@ -89,6 +89,13 @@ else
   GRAPHITE_CONFIGURE:= --without-isl --without-cloog
 endif
 
+## sane and common defaults for different libc implementations
+export lt_cv_prog_compiler_static_works=yes
+export lt_cv_prog_compiler_static_works_CXX=yes
+export lt_cv_sys_max_cmd_len=1572864
+
+GCC_CONFIGURE_VARS :=
+
 GCC_CONFIGURE:= \
 	SHELL="$(BASH)" \
 	$(HOST_SOURCE_DIR)/configure \
@@ -222,6 +229,7 @@ endif
 
 define Host/Configure
 	(cd $(GCC_BUILD_DIR) && rm -f config.cache; \
+		$(if $(strip $(GCC_CONFIGURE_VARS)),export $(GCC_CONFIGURE_VARS);) \
 		$(GCC_CONFIGURE) \
 	);
 endef

--- a/toolchain/gcc/final/Makefile
+++ b/toolchain/gcc/final/Makefile
@@ -17,7 +17,7 @@ ifndef CONFIG_USE_GLIBC
 endif
 
 ifdef CONFIG_USE_MUSL
-  GCC_MAKE += gcc_cv_libc_provides_ssp=yes
+  GCC_CONFIGURE_VARS += gcc_cv_libc_provides_ssp=yes
 endif
 
 ifneq ($(CONFIG_SJLJ_EXCEPTIONS),)
@@ -39,6 +39,7 @@ define Host/Configure
 	$(CleanupToolchain)
 	mkdir -p $(GCC_BUILD_DIR)
 	(cd $(GCC_BUILD_DIR) && rm -f config.cache; \
+		$(if $(strip $(GCC_CONFIGURE_VARS)),export $(GCC_CONFIGURE_VARS);) \
 		$(GCC_CONFIGURE) \
 	);
 endef
@@ -53,7 +54,10 @@ endif
 
 define Host/Compile
 	$(FixGogccCrt)
-	+$(GCC_MAKE) $(HOST_JOBS) -C $(GCC_BUILD_DIR) all
+
+	$(GCC_MAKE) $(HOST_JOBS) -C $(GCC_BUILD_DIR) \
+		$(GCC_CONFIGURE_VARS) \
+		all
 endef
 
 define SetupExtraArch
@@ -71,7 +75,11 @@ endef
 
 define Host/Install
 	$(CleanupToolchain)
-	+$(GCC_MAKE) $(HOST_JOBS) -C $(GCC_BUILD_DIR) install
+
+	+$(GCC_MAKE) $(HOST_JOBS) -C $(GCC_BUILD_DIR) \
+		$(GCC_CONFIGURE_VARS) \
+		install
+
 	# Set up the symlinks to enable lying about target name.
 	set -e; \
 	(cd $(TOOLCHAIN_DIR); \

--- a/toolchain/gcc/initial/Makefile
+++ b/toolchain/gcc/initial/Makefile
@@ -12,6 +12,7 @@ GCC_CONFIGURE += \
 
 define Host/Compile
 	+$(GCC_MAKE) $(HOST_JOBS) -C $(GCC_BUILD_DIR) \
+		$(GCC_CONFIGURE_VARS) \
 		all-build-libiberty \
 		all-gcc \
 		all-target-libgcc
@@ -19,6 +20,7 @@ endef
 
 define Host/Install
 	+$(GCC_MAKE) $(HOST_JOBS) -C $(GCC_BUILD_DIR) \
+		$(GCC_CONFIGURE_VARS) \
 		install-gcc \
 		install-target-libgcc
 

--- a/toolchain/gcc/minimal/Makefile
+++ b/toolchain/gcc/minimal/Makefile
@@ -13,11 +13,17 @@ GCC_CONFIGURE += \
 	--disable-threads
 
 define Host/Compile
-	+$(GCC_MAKE) $(HOST_JOBS) -C $(GCC_BUILD_DIR) all-gcc all-target-libgcc
+	+$(GCC_MAKE) $(HOST_JOBS) -C $(GCC_BUILD_DIR) \
+		$(GCC_CONFIGURE_VARS) \
+		all-gcc \
+		all-target-libgcc
 endef
 
 define Host/Install
-	$(GCC_MAKE) -C $(GCC_BUILD_DIR) install-gcc install-target-libgcc
+	$(GCC_MAKE) -C $(GCC_BUILD_DIR) \
+		$(GCC_CONFIGURE_VARS) \
+		install-gcc \
+		install-target-libgcc
 endef
 
 define Host/Clean


### PR DESCRIPTION
I've observed configuration drift for GCC between musl and glibc (especially it's final stage):

```sh
  # musl
  lt_cv_prog_compiler_static_works=yes
  lt_cv_prog_compiler_static_works_CXX=yes
  lt_cv_sys_max_cmd_len=1572864

  # glibc
  lt_cv_prog_compiler_static_works=no
  lt_cv_prog_compiler_static_works_CXX=no
  lt_cv_sys_max_cmd_len=512
```

These changes should prevent this issue in future:

```sh
  export lt_cv_prog_compiler_static_works=yes
  export lt_cv_prog_compiler_static_works_CXX=yes
  export lt_cv_sys_max_cmd_len=1572864
```

Also:

- provide custom autotools/libtool variables via properly named variable ("`GCC_CONFIGURE_VARS`"),
- move variables from "`GCC_MAKE`" to "`GCC_CONFIGURE_VARS`" (at this moment only "`gcc_cv_libc_provides_ssp=yes`" for musl),
- propagate it's usage for both "./configure" and "make".

---

This is correct and fixed version of #18646.