### PR TITLE
ramips: update drivers to be compatible with kernel 6.12

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
@@ -19,6 +19,7 @@
 #include <asm/mach-ralink/ralink_regs.h>
 #include <linux/of_device.h>
 #include <linux/of_irq.h>
+#include <linux/of_platform.h>
 
 #include <linux/switch.h>
 #include <linux/reset.h>

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/ethtool.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/ethtool.c
@@ -13,6 +13,7 @@
  */
 
 #include "mtk_eth_soc.h"
+#include "ethtool.h"
 
 static const char fe_gdma_str[][ETH_GSTRING_LEN] = {
 #define _FE(x...)	# x,
@@ -70,9 +71,9 @@ static void fe_get_drvinfo(struct net_device *dev,
 	struct fe_priv *priv = netdev_priv(dev);
 	struct fe_soc_data *soc = priv->soc;
 
-	strlcpy(info->driver, priv->dev->driver->name, sizeof(info->driver));
-	strlcpy(info->version, MTK_FE_DRV_VERSION, sizeof(info->version));
-	strlcpy(info->bus_info, dev_name(priv->dev), sizeof(info->bus_info));
+	strscpy(info->driver, priv->dev->driver->name, sizeof(info->driver));
+	strscpy(info->version, MTK_FE_DRV_VERSION, sizeof(info->version));
+	strscpy(info->bus_info, dev_name(priv->dev), sizeof(info->bus_info));
 
 	if (soc->reg_table[FE_REG_FE_COUNTER_BASE])
 		info->n_stats = ARRAY_SIZE(fe_gdma_str);

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
@@ -19,6 +19,7 @@
 #include <linux/platform_device.h>
 #include <linux/of_device.h>
 #include <linux/of_irq.h>
+#include <linux/of_platform.h>
 
 #include <ralink_regs.h>
 

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mt7530.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mt7530.c
@@ -31,6 +31,7 @@
 #include <linux/lockdep.h>
 #include <linux/workqueue.h>
 #include <linux/of_device.h>
+#include <linux/of.h>
 #include <asm/byteorder.h>
 
 #include "mt7530.h"
@@ -209,7 +210,7 @@ struct mt7530_mapping {
 	},
 };
 
-struct mt7530_mapping*
+static struct mt7530_mapping*
 mt7530_find_mapping(struct device_node *np)
 {
 	const char *map;


### PR DESCRIPTION
Update drivers to be compatible with kernel 6.12:
 - change deprecate function strlcpy to strscpy
 - fix kernel warning "no previous prototype", by static declaration
 - add missing of.h headers
