### PR TITLE
iw: fix WiFi 6 (HE) Scan on big endian platforms

### DIFF
--- a/package/network/utils/iw/Makefile
+++ b/package/network/utils/iw/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=iw
 PKG_VERSION:=6.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
  
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/software/network/iw

--- a/package/network/utils/iw/patches/101-iw-fix-HE-capabilities-on-Big-Endian-platforms.patch
+++ b/package/network/utils/iw/patches/101-iw-fix-HE-capabilities-on-Big-Endian-platforms.patch
@@ -1,0 +1,77 @@
+From c41971e27a8359f88122593a2700f270f58cb2fa Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Sat, 5 Apr 2025 20:48:05 +0200
+Subject: [PATCH 1/2] iw: fix HE capabilities on Big Endian platforms
+
+IE fields are encoded in Little Endian and are not correctly
+printed on Big Endian platforms.
+
+Fixes: c741be9f6ca3 ("iw: print HE capabilities")
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Link: https://patch.msgid.link/20250405184807.701728-2-olek2@wp.pl
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+ util.c | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+--- a/util.c
++++ b/util.c
+@@ -1245,14 +1245,15 @@ static void __print_he_capa(const __u16
+ 
+ 	#define PRINT_HE_CAP(_var, _idx, _bit, _str) \
+ 	do { \
+-		if (_var[_idx] & BIT(_bit)) \
++		if (le16toh(_var[_idx]) & BIT(_bit)) \
+ 			printf("%s\t\t\t" _str "\n", pre); \
+ 	} while (0)
+ 
+ 	#define PRINT_HE_CAP_MASK(_var, _idx, _shift, _mask, _str) \
+ 	do { \
+-		if ((_var[_idx] >> _shift) & _mask) \
+-			printf("%s\t\t\t" _str ": %d\n", pre, (_var[_idx] >> _shift) & _mask); \
++		if ((le16toh(_var[_idx]) >> _shift) & _mask) \
++			printf("%s\t\t\t" _str ": %d\n", pre, \
++			       (le16toh(_var[_idx]) >> _shift) & _mask); \
+ 	} while (0)
+ 
+ 	#define PRINT_HE_MAC_CAP(...) PRINT_HE_CAP(mac_cap, __VA_ARGS__)
+@@ -1263,7 +1264,7 @@ static void __print_he_capa(const __u16
+ 
+ 	printf("%s\t\tHE MAC Capabilities (0x", pre);
+ 	for (i = 0; i < 3; i++)
+-		printf("%04x", mac_cap[i]);
++		printf("%04x", le16toh(mac_cap[i]));
+ 	printf("):\n");
+ 
+ 	PRINT_HE_MAC_CAP(0, 0, "+HTC HE Supported");
+@@ -1377,18 +1378,18 @@ static void __print_he_capa(const __u16
+ 		char *bw[] = { "<= 80", "160", "80+80" };
+ 		int j;
+ 
+-		if ((phy_cap[0] & (phy_cap_support[i] << 8)) == 0)
++		if ((le16toh(phy_cap[0]) & (phy_cap_support[i] << 8)) == 0)
+ 			continue;
+ 
+ 		/* Supports more, but overflow? Abort. */
+-		if ((i * 2 + 2) * sizeof(mcs_set[0]) >= mcs_len)
++		if ((i * 2 + 2) * sizeof(le16toh(mcs_set[0])) >= mcs_len)
+ 			return;
+ 
+ 		for (j = 0; j < 2; j++) {
+ 			int k;
+ 			printf("%s\t\tHE %s MCS and NSS set %s MHz\n", pre, j ? "TX" : "RX", bw[i]);
+ 			for (k = 0; k < 8; k++) {
+-				__u16 mcs = mcs_set[(i * 2) + j];
++				__u16 mcs = le16toh(mcs_set[(i * 2) + j]);
+ 				mcs >>= k * 2;
+ 				mcs &= 0x3;
+ 				printf("%s\t\t\t%d streams: ", pre, k + 1);
+@@ -1411,7 +1412,7 @@ static void __print_he_capa(const __u16
+ 			ppet_len = 0;
+ 	}
+ 
+-	if (ppet_len && (phy_cap[3] & BIT(15))) {
++	if (ppet_len && (le16toh(phy_cap[3]) & BIT(15))) {
+ 		printf("%s\t\tPPE Threshold ", pre);
+ 		for (i = 0; i < ppet_len; i++)
+ 			if (ppet[i])

--- a/package/network/utils/iw/patches/102-iw-fix-HE-operation-on-Big-Endian-platforms.patch
+++ b/package/network/utils/iw/patches/102-iw-fix-HE-operation-on-Big-Endian-platforms.patch
@@ -1,0 +1,36 @@
+From 41a07a818090da424ddd24bf07f468cf5725cdc6 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Sat, 5 Apr 2025 20:48:06 +0200
+Subject: [PATCH 2/2] iw: fix HE operation on Big Endian platforms
+
+IE fields are encoded in Little Endian and are not correctly
+printed on Big Endian platforms.
+
+Fixes: 422419e06d55 ("scan: Add printing of HE Operation Element")
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Link: https://patch.msgid.link/20250405184807.701728-3-olek2@wp.pl
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+ util.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/util.c
++++ b/util.c
+@@ -1738,7 +1738,7 @@ void print_he_operation(const uint8_t *i
+ {
+ 	uint8_t oper_parameters[3] = {ie[0], ie[1], ie[2] };
+ 	uint8_t bss_color = ie[3];
+-	uint16_t nss_mcs_set = *(uint16_t*)(&ie[4]);
++	uint16_t nss_mcs_set = le16toh(*(uint16_t *)(&ie[4]));
+ 	uint8_t vht_oper_present = oper_parameters[1] & 0x40;
+ 	uint8_t co_hosted_bss_present = oper_parameters[1] & 0x80;
+ 	uint8_t uhb_operation_info_present = oper_parameters[2] & 0x02;
+@@ -1751,7 +1751,7 @@ void print_he_operation(const uint8_t *i
+ 		printf("\t\t\tTWT Required\n");
+ 
+ 	printf("\t\t\tTXOP Duration RTS Threshold: %hu\n",
+-	       (*(uint16_t*)(oper_parameters)) >> 4 & 0x03ff);
++	       le16toh((*(uint16_t *)(oper_parameters))) >> 4 & 0x03ff);
+ 	if (oper_parameters[1] & 0x40)
+ 		printf("\t\t\tVHT Operation Information Present\n");
+ 


### PR DESCRIPTION
On big endian platforms, scans show invalid info for WiFi 6 APs. This commit backports patches to fix this issue.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>