### PR TITLE
generic: update "disable common USB quirks" patch

### DIFF
--- a/target/linux/generic/pending-6.12/811-pci_disable_usb_common_quirks.patch
+++ b/target/linux/generic/pending-6.12/811-pci_disable_usb_common_quirks.patch
@@ -20,16 +20,25 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static struct amd_chipset_info {
  	struct pci_dev	*nb_dev;
  	struct pci_dev	*smbus_dev;
-@@ -590,6 +592,8 @@ bool usb_amd_pt_check_port(struct device
+@@ -590,6 +592,9 @@ bool usb_amd_pt_check_port(struct device
  EXPORT_SYMBOL_GPL(usb_amd_pt_check_port);
  #endif /* CONFIG_USB_PCI_AMD */
  
 +#endif /* CONFIG_PCI_DISABLE_COMMON_QUIRKS */
 +
++#if defined(CONFIG_USB_PCI) && !defined(CONFIG_PCI_DISABLE_COMMON_QUIRKS)
  static int usb_asmedia_wait_write(struct pci_dev *pdev)
  {
  	unsigned long retry_count;
-@@ -724,6 +728,10 @@ reset_needed:
+@@ -633,6 +638,7 @@ void usb_asmedia_modifyflowcontrol(struc
+ 	pci_write_config_byte(pdev, ASMT_CONTROL_REG, ASMT_CONTROL_WRITE_BIT);
+ }
+ EXPORT_SYMBOL_GPL(usb_asmedia_modifyflowcontrol);
++#endif /* CONFIG_USB_PCI */
+ 
+ static inline int io_type_enabled(struct pci_dev *pdev, unsigned int mask)
+ {
+@@ -724,6 +730,10 @@ reset_needed:
  	return 1;
  }
  EXPORT_SYMBOL_GPL(uhci_check_and_reset_hc);
@@ -40,7 +49,23 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  #define pio_enabled(dev) io_type_enabled(dev, PCI_COMMAND_IO)
  
-@@ -1304,3 +1312,4 @@ static void quirk_usb_early_handoff(stru
+@@ -1037,6 +1047,7 @@ static int handshake(void __iomem *ptr,
+ 					 delay_usec, wait_usec);
+ }
+ 
++#if defined(CONFIG_USB_PCI) && !defined(CONFIG_PCI_DISABLE_COMMON_QUIRKS)
+ /*
+  * Intel's Panther Point chipset has two host controllers (EHCI and xHCI) that
+  * share some number of ports.  These ports can be switched between either
+@@ -1146,6 +1157,7 @@ void usb_disable_xhci_ports(struct pci_d
+ 	pci_write_config_dword(xhci_pdev, USB_INTEL_XUSB2PR, 0x0);
+ }
+ EXPORT_SYMBOL_GPL(usb_disable_xhci_ports);
++#endif /* CONFIG_USB_PCI */
+ 
+ /*
+  * PCI Quirks for xHCI.
+@@ -1304,3 +1316,4 @@ static void quirk_usb_early_handoff(stru
  }
  DECLARE_PCI_FIXUP_CLASS_FINAL(PCI_ANY_ID, PCI_ANY_ID,
  			PCI_CLASS_SERIAL_USB, 8, quirk_usb_early_handoff);


### PR DESCRIPTION
For kernel 6.12 there is a compilation error for ramips/mt7621: 
```
drivers/usb/host/pci-quirks.c:621:6: error: redefinition of 'usb_asmedia_modifyflowcontrol'
  621 | void usb_asmedia_modifyflowcontrol(struct pci_dev *pdev)
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from drivers/usb/host/pci-quirks.c:22:
drivers/usb/host/pci-quirks.h:49:20: note: previous definition of 'usb_asmedia_modifyflowcontrol' with type 'void(struct pci_dev *)'
   49 | static inline void usb_asmedia_modifyflowcontrol(struct pci_dev *pdev) {}
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[9]: *** [scripts/Makefile.build:229: drivers/usb/host/pci-quirks.o] Error 1
```

Adding additional conditions solves this problem and similar ones for functions usb_enable_intel_xhci_ports and usb_disable_xhci_ports

