### PR TITLE
mediatek: fix label for better indicate, more common logic

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
@@ -102,17 +102,17 @@
 
 		port@1 {
 			reg = <1>;
-			label = "lan2";
+			label = "lan1";
 		};
 
 		port@2 {
 			reg = <2>;
-			label = "lan3";
+			label = "lan2";
 		};
 
 		port@3 {
 			reg = <3>;
-			label = "lan4";
+			label = "lan3";
 		};
 
 		port@6 {


### PR DESCRIPTION
It not common sense to start count port with lan2, default dts should start with lan1
For device than have number at the port and start with 2 should use seperate .dts config
