### PR TITLE
sunxi: add support for Beelink X2

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -92,6 +92,12 @@ define U-Boot/Bananapro
   BUILD_DEVICES:=lemaker_bananapro
 endef
 
+define U-Boot/beelink_x2
+  BUILD_SUBTARGET:=cortexa7
+  NAME:=Beelink X2 (H3)
+  BUILD_DEVICES:=roofull_beelink-x2
+endef
+
 define U-Boot/Cubieboard
   BUILD_SUBTARGET:=cortexa8
   NAME:=Cubieboard
@@ -388,6 +394,7 @@ UBOOT_TARGETS := \
 	bananapi_p2_zero \
 	Bananapi_M2_Ultra \
 	Bananapro \
+	beelink_x2 \
 	Cubieboard \
 	Cubieboard2 \
 	Cubietruck \

--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -186,6 +186,15 @@ define Device/olimex_a20-olinuxino-micro
 endef
 TARGET_DEVICES += olimex_a20-olinuxino-micro
 
+define Device/roofull_beelink-x2
+  DEVICE_VENDOR := Roofull
+  DEVICE_MODEL := Beelink-X2
+  DEVICE_PACKAGES:=kmod-leds-gpio kmod-gpio-button-hotplug \
+	kmod-brcmfmac cypress-firmware-43430-sdio wpad-basic-mbedtls
+  SOC := sun8i-h3
+endef
+TARGET_DEVICES += roofull_beelink-x2
+
 define Device/sinovoip_bananapi-m2-plus
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2+


### PR DESCRIPTION
Specifications:
- SoC: Allwinner H3 Quad Cortex-A7 1.2GHz
- Flash: 8GB eMMC
- RAM: 1GB DDR3
- Ethernet: 1x100M
- Wifi: RTL8189FTV or AP6181
- 1x USB-A Host
- 1x USB-A Host/Device
- 2x Button
- 2x LED
- HDMI, SPDIF, IR

Install by following standard SD card flashing instructions.
Image can also be flashed to eMMC.
