### PR TITLE
lantiq/ramips: mark some sub-targets as source only

### DIFF
--- a/target/linux/lantiq/ase/target.mk
+++ b/target/linux/lantiq/ase/target.mk
@@ -5,7 +5,7 @@
 ARCH:=mips
 SUBTARGET:=ase
 BOARDNAME:=Amazon-SE
-FEATURES+=atm mips16 small_flash
+FEATURES+=atm mips16 small_flash source-only
 CPU_TYPE:=mips32
 
 DEFAULT_PACKAGES+=kmod-leds-gpio kmod-gpio-button-hotplug \

--- a/target/linux/lantiq/image/amazonse.mk
+++ b/target/linux/lantiq/image/amazonse.mk
@@ -5,7 +5,6 @@ define Device/allnet_all0333cj
   DEVICE_PACKAGES := kmod-ltq-adsl-ase kmod-ltq-adsl-ase-mei \
 	kmod-ltq-adsl-ase-fw-b kmod-ltq-atm-ase \
 	ltq-adsl-app ppp-mod-pppoe
-  DEFAULT := n
 endef
 TARGET_DEVICES += allnet_all0333cj
 
@@ -17,6 +16,5 @@ define Device/netgear_dgn1000b
 	kmod-ltq-adsl-ase-fw-b kmod-ltq-atm-ase \
 	ltq-adsl-app ppp-mod-pppoe
   SUPPORTED_DEVICES += DGN1000B
-  DEFAULT := n
 endef
 TARGET_DEVICES += netgear_dgn1000b

--- a/target/linux/lantiq/image/xway_legacy.mk
+++ b/target/linux/lantiq/image/xway_legacy.mk
@@ -8,7 +8,6 @@ define Device/arcadyan_arv4518pwr01
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ath5k wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV4518PWR01
-  DEFAULT := n
 endef
 TARGET_DEVICES += arcadyan_arv4518pwr01
 
@@ -22,7 +21,6 @@ define Device/arcadyan_arv4518pwr01a
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ath5k wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV4518PWR01A
-  DEFAULT := n
 endef
 TARGET_DEVICES += arcadyan_arv4518pwr01a
 
@@ -40,7 +38,6 @@ define Device/arcadyan_arv4520pw
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-rt61-pci wpad-basic-mbedtls
   SUPPORTED_DEVICES += ARV4520PW
-  DEFAULT := n
 endef
 TARGET_DEVICES += arcadyan_arv4520pw
 
@@ -56,7 +53,6 @@ define Device/arcadyan_arv4525pw
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa -swconfig
   SUPPORTED_DEVICES += ARV4525PW
-  DEFAULT := n
 endef
 TARGET_DEVICES += arcadyan_arv4525pw
 
@@ -72,6 +68,5 @@ define Device/arcadyan_arv452cqw
 	kmod-ltq-adsl-danube-fw-b kmod-ltq-atm-danube \
 	ltq-adsl-app ppp-mod-pppoa
   SUPPORTED_DEVICES += ARV452CQW
-  DEFAULT := n
 endef
 TARGET_DEVICES += arcadyan_arv452cqw

--- a/target/linux/lantiq/xway_legacy/target.mk
+++ b/target/linux/lantiq/xway_legacy/target.mk
@@ -1,7 +1,7 @@
 ARCH:=mips
 SUBTARGET:=xway_legacy
 BOARDNAME:=XWAY Legacy
-FEATURES+=atm ramdisk small_flash
+FEATURES+=atm ramdisk small_flash source-only
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES+=kmod-leds-gpio kmod-gpio-button-hotplug swconfig

--- a/target/linux/ramips/image/rt288x.mk
+++ b/target/linux/ramips/image/rt288x.mk
@@ -20,7 +20,6 @@ define Device/airlink101_ar670w
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	wrg-header wrgn16a_airlink_ar670w
   SUPPORTED_DEVICES += ar670w
-  DEFAULT := n
 endef
 TARGET_DEVICES += airlink101_ar670w
 
@@ -32,7 +31,6 @@ define Device/airlink101_ar725w
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size 3328k | \
 	gemtek-header ar725w
   SUPPORTED_DEVICES += ar725w
-  DEFAULT := n
 endef
 TARGET_DEVICES += airlink101_ar725w
 
@@ -42,7 +40,6 @@ define Device/asus_rt-n15
   DEVICE_MODEL := RT-N15
   DEVICE_PACKAGES := kmod-switch-rtl8366s
   SUPPORTED_DEVICES += rt-n15
-  DEFAULT := n
 endef
 TARGET_DEVICES += asus_rt-n15
 
@@ -54,7 +51,6 @@ define Device/belkin_f5d8235-v1
   DEVICE_PACKAGES := kmod-switch-rtl8366s kmod-usb-ohci kmod-usb-ohci-pci \
 	kmod-usb2 kmod-usb2-pci kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += f5d8235-v1
-  DEFAULT := n
 endef
 TARGET_DEVICES += belkin_f5d8235-v1
 
@@ -64,7 +60,6 @@ define Device/buffalo_wli-tx4-ag300n
   DEVICE_MODEL := WLI-TX4-AG300N
   DEVICE_PACKAGES := kmod-switch-ip17xx
   SUPPORTED_DEVICES += wli-tx4-ag300n
-  DEFAULT := n
 endef
 TARGET_DEVICES += buffalo_wli-tx4-ag300n
 
@@ -74,7 +69,6 @@ define Device/buffalo_wzr-agl300nh
   DEVICE_MODEL := WZR-AGL300NH
   DEVICE_PACKAGES := kmod-switch-rtl8366s
   SUPPORTED_DEVICES += wzr-agl300nh
-  DEFAULT := n
 endef
 TARGET_DEVICES += buffalo_wzr-agl300nh
 
@@ -89,7 +83,6 @@ define Device/dlink_dap-1522-a1
   IMAGE/factory.bin := append-kernel | pad-offset $$$$(BLOCKSIZE) 96 | \
 	append-rootfs | pad-rootfs -x 96 | wrg-header wapnd01_dlink_dap1522 | \
 	check-size
-  DEFAULT := n
 endef
 TARGET_DEVICES += dlink_dap-1522-a1
 
@@ -98,6 +91,5 @@ define Device/ralink_v11st-fe
   DEVICE_VENDOR := Ralink
   DEVICE_MODEL := V11ST-FE
   SUPPORTED_DEVICES += v11st-fe
-  DEFAULT := n
 endef
 TARGET_DEVICES += ralink_v11st-fe

--- a/target/linux/ramips/rt288x/target.mk
+++ b/target/linux/ramips/rt288x/target.mk
@@ -4,7 +4,7 @@
 
 SUBTARGET:=rt288x
 BOARDNAME:=RT288x based boards
-FEATURES+=small_flash
+FEATURES+=small_flash source-only
 CPU_TYPE:=24kc
 
 DEFAULT_PACKAGES += kmod-rt2800-soc wpad-basic-mbedtls swconfig


### PR DESCRIPTION
Due to RAM/ROM size limitations, these sub-targets have been unable to generate usable images for a long time. Mark them as source-only to save some resource for the buildbot.

Ref:
https://downloads.openwrt.org/snapshots/targets/lantiq/ase/
https://downloads.openwrt.org/snapshots/targets/lantiq/xway_legacy/
https://downloads.openwrt.org/snapshots/targets/ramips/rt288x/

cc @hauke @PolynomialDivision @robimarko