### PR TITLE
imagebuilder: exclude metadata for profiles that are not built by default

### DIFF
--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -441,7 +441,7 @@ sub gen_profile_mk() {
 	my @targets = parse_target_metadata($file);
 	foreach my $cur (@targets) {
 		next unless $cur->{id} eq $target;
-		my @profile_ids_unique =  do { my %seen; grep { !$seen{$_}++} map { $_->{id} } @{$cur->{profiles}}};
+		my @profile_ids_unique =  do { my %seen; grep { !$seen{$_}++} map { $_->{id} } grep { $_->{default} !~ /^n/ } @{$cur->{profiles}}};
 		print "PROFILE_NAMES = ".join(" ", @profile_ids_unique)."\n";
 		foreach my $profile (@{$cur->{profiles}}) {
 			print $profile->{id}.'_NAME:='.$profile->{name}."\n";


### PR DESCRIPTION
Device profiles that specify 'DEFAULT := n' are being included in the imagebuilder metadata, specifically in .profiles.mk, even though there is no kernel built for the device.  This results in 'make info' showing the device as valid, but then 'make image PROFILE=xxx' failing with 'No rule to make target xxx-kernel.bin ...'

We exclude these profiles from the imagebuilder, avoiding these errors.

Links: https://github.com/openwrt/openwrt/issues/18410