### PR TITLE
kernel: mediatek: mt7986a: Fix spi max frequency

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-asus-rt-ax59u.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-rt-ax59u.dts
@@ -215,7 +215,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
@@ -222,7 +222,7 @@
 		#size-cells = <1>;
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -253,7 +253,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
+++ b/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
@@ -511,7 +511,7 @@
 		#size-cells = <1>;
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
+++ b/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
@@ -212,7 +212,7 @@
 		#size-cells = <1>;
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
@@ -238,7 +238,7 @@
 		#size-cells = <1>;
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-netcore-n60.dts
+++ b/target/linux/mediatek/dts/mt7986a-netcore-n60.dts
@@ -183,7 +183,7 @@
 		#size-cells = <1>;
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
@@ -155,7 +155,7 @@
 		#size-cells = <1>;
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
@@ -167,7 +167,7 @@
 		#size-cells = <1>;
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
@@ -212,7 +212,7 @@
 		#size-cells = <1>;
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
@@ -136,7 +136,7 @@
 		#size-cells = <1>;
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -168,7 +168,7 @@
                 #size-cells = <1>;
                 compatible = "spi-nand";
                 reg = <1>;
-                spi-max-frequency = <50000000>;
+                spi-max-frequency = <52000000>;
                 spi-tx-bus-width = <4>;
                 spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5700-telenor.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5700-telenor.dts
@@ -343,7 +343,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 	};
 
 	flash@1 {
@@ -354,7 +354,7 @@
 		mediatek,bmt-max-ratio = <1>;
 		mediatek,bmt-max-reserved-blocks = <64>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 


### PR DESCRIPTION
On Linux mainline (mt7986.dtsi), spi's source clock is: clocks = <&topckgen CLK_TOP_MPLL_D2>, which is 208MHz. Usable clock division will be:
 - 208/4=52MHz
 - 208/6~=35MHz
 - 208/8=26MHz and so on

If we specify 50MHz for spi-max-frequency, it will actually run under about 35MHz. Most SPI NAND & NOR flashes are capable of running with more than 52MHz. To reach highest performance on mt7986, use spi-max-frequency = <520000000> for all SPI NAND/NOR.
