### PR TITLE
realtek rtl931x: mark subtarget as source-only

### DIFF
--- a/target/linux/realtek/rtl931x/target.mk
+++ b/target/linux/realtek/rtl931x/target.mk
@@ -4,6 +4,7 @@ SUBTARGET:=rtl931x
 CPU_TYPE:=24kc
 BOARD:=realtek
 BOARDNAME:=Realtek MIPS RTL931X
+FEATURES+=source-only
 
 define Target/Description
 	Build firmware images for Realtek RTL931x based boards.


### PR DESCRIPTION
There are no supported devices on this sub-target. It can be considered that it is still under development. Therefore, there is no need to make the buildbot build it every day.

@svanheule What do you think about?
