### PR TITLE
Update 10_fix_wifi_mac for 24.10.x

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -19,7 +19,7 @@ case "$board" in
 		;;
 	linksys,ea7500-v1 |\
 	linksys,ea8500)
-		macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) $(($PHYNBR + 1)) > /sys${DEVPATH}/macaddress
+		macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) $(($PHYNBR + 2)) > /sys${DEVPATH}/macaddress
 esac
 
 OPATH=${DEVPATH##/devices/platform/}


### PR DESCRIPTION
Please backport to 24.10.x to avoid mac conflict.

https://github.com/openwrt/openwrt/issues/18052