### PR TITLE
qualcommax: ipq807x: use ascii-env driver for Linksys MX devices

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx8500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx8500.dts
@@ -257,6 +257,15 @@
 				label = "devinfo";
 				reg = <0x1060000 0x20000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "ascii-eq-delim-env";
+
+					hw_mac_addr: hw_mac_addr {
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@1080000 {
@@ -446,6 +455,8 @@
 	phy-mode = "qsgmii";
 	phy-handle = <&qca8075_0>;
 	label = "lan1";
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp2 {
@@ -453,6 +464,8 @@
 	phy-mode = "qsgmii";
 	phy-handle = <&qca8075_1>;
 	label = "lan2";
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp3 {
@@ -460,6 +473,8 @@
 	phy-mode = "qsgmii";
 	phy-handle = <&qca8075_2>;
 	label = "lan3";
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp4 {
@@ -467,6 +482,8 @@
 	phy-mode = "qsgmii";
 	phy-handle = <&qca8075_3>;
 	label = "lan4";
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp6_syn {
@@ -474,6 +491,8 @@
 	phy-mode = "usxgmii";
 	phy-handle = <&aqr114c>;
 	label = "wan";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &ssphy_0 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-homewrk.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-homewrk.dts
@@ -9,6 +9,8 @@
 	compatible = "linksys,homewrk", "qcom,ipq8074";
 
 	aliases {
+		ethernet1 = &dp2;
+		ethernet2 = &dp3;
 		ethernet3 = &dp4;
 		ethernet4 = &dp5;
 	};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
@@ -3,13 +3,6 @@
 
 #include "ipq8174-mx4x00.dtsi"
 
-/ {
-	aliases {
-		ethernet3 = &dp4;
-		ethernet4 = &dp5;
-	};
-};
-
 &tlmm {
 	iot_pins: iot-state {
 		recovery-pins {
@@ -184,6 +177,15 @@
 				label = "devinfo";
 				reg = <0x1060000 0x20000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "ascii-eq-delim-env";
+
+					hw_mac_addr: hw_mac_addr {
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@1080000 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
@@ -9,6 +9,13 @@
 / {
 	model = "Linksys MX4200v1";
 	compatible = "linksys,mx4200v1", "qcom,ipq8074";
+
+	aliases {
+		ethernet1 = &dp2;
+		ethernet2 = &dp3;
+		ethernet3 = &dp4;
+		ethernet4 = &dp5;
+	};
 };
 
 &wifi {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v2.dts
@@ -8,6 +8,30 @@
 / {
 	model = "Linksys MX4200v2";
 	compatible = "linksys,mx4200v2", "qcom,ipq8074";
+
+	aliases {
+		label-mac-device = &dp2;
+	};
+};
+
+&dp2 {
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&dp3 {
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&dp4 {
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&dp5 {
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &wifi {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4300.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4300.dts
@@ -20,6 +20,10 @@
 		bootargs-find-2 = "ubi.mtd=24,2048";
 		bootargs-replace-2 = "ubi.mtd=24,4096";
 	};
+
+	aliases {
+		label-mac-device = &dp2;
+	};
 };
 
 &qpic_nand {
@@ -175,6 +179,15 @@
 				label = "devinfo";
 				reg = <0x1200000 0x40000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "ascii-eq-delim-env";
+
+					hw_mac_addr: hw_mac_addr {
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@1240000 {
@@ -246,24 +259,32 @@
 	status = "okay";
 	phy-handle = <&qca8075_1>;
 	label = "wan";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp3 {
 	status = "okay";
 	phy-handle = <&qca8075_2>;
 	label = "lan3";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp4 {
 	status = "okay";
 	phy-handle = <&qca8075_3>;
 	label = "lan2";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp5 {
 	status = "okay";
 	phy-handle = <&qca8075_4>;
 	label = "lan1";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &wifi {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4x00.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4x00.dtsi
@@ -12,12 +12,6 @@
 	aliases {
 		serial0 = &blsp1_uart5;
 		serial1 = &blsp1_uart3;
-		/*
-		 * Aliases as required by u-boot
-		 * to patch MAC addresses
-		 */
-		ethernet1 = &dp2;
-		ethernet2 = &dp3;
 		led-boot = &led_system_blue;
 		led-running = &led_system_blue;
 		led-failsafe = &led_system_red;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -90,17 +90,6 @@ ipq807x_setup_macs()
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac="$wan_mac"
 		;;
-	linksys,mx4200v2|\
-	linksys,mx4300)
-		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
-		[ "$(mtd_get_mac_ascii u_env eth1addr)" != "$label_mac" ] && wan_mac=$label_mac
-		[ "$(mtd_get_mac_ascii u_env eth2addr)" != "$label_mac" ] && lan_mac=$label_mac
-		;;
-	linksys,mx8500)
-		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
-		lan_mac=$(macaddr_add $label_mac 1)
-		wan_mac=$label_mac
-		;;
 	tplink,deco-x80-5g)
 		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
 		lan_mac=$(macaddr_add $label_mac 1)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -45,7 +45,7 @@ case "$FIRMWARE" in
 		;;
 	linksys,mx4200v2)
 		caldata_extract "0:art" 0x1000 0x20000
-		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
+		label_mac=$(get_mac_label)
 		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
 		ath11k_patch_mac $(macaddr_add $label_mac 1) 1
 		ath11k_patch_mac $(macaddr_add $label_mac 3) 2
@@ -54,7 +54,7 @@ case "$FIRMWARE" in
 		;;
 	linksys,mx4300)
 		caldata_extract "0:art" 0x1000 0x20000
-		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
+		label_mac=$(get_mac_label)
 		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
 		ath11k_patch_mac $(macaddr_add $label_mac 1) 1
 		ath11k_patch_mac $(macaddr_add $label_mac 3) 2


### PR DESCRIPTION
ascii-env driver allows reading mac addresses directly from devinfo partition from dts level.

Additionally label mac address have been set.