### PR TITLE
linux: remove of_match_ptr from OF only drivers

### DIFF
--- a/target/linux/ath79/files/drivers/mfd/rb4xx-cpld.c
+++ b/target/linux/ath79/files/drivers/mfd/rb4xx-cpld.c
@@ -162,7 +162,7 @@ static struct spi_driver rb4xx_cpld_driver = {
 	.driver = {
 		.name = "rb4xx-cpld",
 		.bus = &spi_bus_type,
-		.of_match_table = of_match_ptr(rb4xx_cpld_dt_match),
+		.of_match_table = rb4xx_cpld_dt_match,
 	},
 };
 

--- a/target/linux/ath79/patches-6.6/311-MIPS-pci-ar71xx-convert-to-OF.patch
+++ b/target/linux/ath79/patches-6.6/311-MIPS-pci-ar71xx-convert-to-OF.patch
@@ -200,7 +200,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  	.probe = ar71xx_pci_probe,
  	.driver = {
  		.name = "ar71xx-pci",
-+		.of_match_table = of_match_ptr(ar71xx_pci_ids),
++		.of_match_table = ar71xx_pci_ids,
  	},
  };
  

--- a/target/linux/ath79/patches-6.6/313-MIPS-pci-ar724x-convert-to-OF.patch
+++ b/target/linux/ath79/patches-6.6/313-MIPS-pci-ar724x-convert-to-OF.patch
@@ -207,7 +207,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  	.probe = ar724x_pci_probe,
  	.driver = {
  		.name = "ar724x-pci",
-+		.of_match_table = of_match_ptr(ar724x_pci_ids),
++		.of_match_table = ar724x_pci_ids,
  	},
  };
  

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6348-enet.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6348-enet.c
@@ -285,7 +285,7 @@ MODULE_DEVICE_TABLE(of, bcm6348_emac_of_match);
 static struct platform_driver bcm6348_iudma_driver = {
 	.driver = {
 		.name = "bcm6348-iudma",
-		.of_match_table = of_match_ptr(bcm6348_iudma_of_match),
+		.of_match_table = bcm6348_iudma_of_match,
 	},
 	.probe	= bcm6348_iudma_probe,
 };
@@ -1701,7 +1701,7 @@ MODULE_DEVICE_TABLE(of, bcm6348_emac_of_match);
 static struct platform_driver bcm6348_emac_driver = {
 	.driver = {
 		.name = "bcm6348-emac",
-		.of_match_table = of_match_ptr(bcm6348_emac_of_match),
+		.of_match_table = bcm6348_emac_of_match,
 	},
 	.probe	= bcm6348_emac_probe,
 	.remove_new	= bcm6348_emac_remove,

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -1133,7 +1133,7 @@ MODULE_DEVICE_TABLE(of, bcm6368_enetsw_of_match);
 static struct platform_driver bcm6368_enetsw_driver = {
 	.driver = {
 		.name = "bcm6368-enetsw",
-		.of_match_table = of_match_ptr(bcm6368_enetsw_of_match),
+		.of_match_table = bcm6368_enetsw_of_match,
 	},
 	.probe	= bcm6368_enetsw_probe,
 	.remove_new	= bcm6368_enetsw_remove,

--- a/target/linux/lantiq/patches-6.6/0035-owrt-lantiq-wifi-and-ethernet-eeprom-handling.patch
+++ b/target/linux/lantiq/patches-6.6/0035-owrt-lantiq-wifi-and-ethernet-eeprom-handling.patch
@@ -149,7 +149,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +static struct platform_driver ath5k_eeprom_driver = {
 +	.driver		= {
 +		.name		= "ath5k,eeprom",
-+		.of_match_table	= of_match_ptr(ath5k_eeprom_ids),
++		.of_match_table	= ath5k_eeprom_ids,
 +	},
 +};
 +


### PR DESCRIPTION
There's no need for it. Kernel update to 6.12 found that it now needs linux/of.h explicitly included.

ping @DragonBluep @robimarko @Noltari 

kept the changes only to local patches/drivers.