### PR TITLE
tools/llvm-bpf: fix compilation with GCC15

### DIFF
--- a/tools/llvm-bpf/patches/100-gcc15.patch
+++ b/tools/llvm-bpf/patches/100-gcc15.patch
@@ -1,0 +1,23 @@
+From 7e44305041d96b064c197216b931ae3917a34ac1 Mon Sep 17 00:00:00 2001
+From: Sam James <sam@gentoo.org>
+Date: Fri, 2 Aug 2024 23:07:21 +0100
+Subject: [PATCH] [ADT] Add `<cstdint>` to SmallVector (#101761)
+
+SmallVector uses `uint32_t`, `uint64_t` without including `<cstdint>`
+which fails to build w/ GCC 15 after a change in libstdc++ [0]
+
+[0] https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=3a817a4a5a6d94da9127af3be9f84a74e3076ee2
+---
+ llvm/include/llvm/ADT/SmallVector.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/llvm/include/llvm/ADT/SmallVector.h
++++ b/llvm/include/llvm/ADT/SmallVector.h
+@@ -19,6 +19,7 @@
+ #include <algorithm>
+ #include <cassert>
+ #include <cstddef>
++#include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
+ #include <functional>


### PR DESCRIPTION
Add cstdint include to SmallVector.h.

Backported from
https://github.com/llvm/llvm-project/commit/7e44305041d96b064c197216b931ae3917a34ac1.

Fixes #18761