### PR TITLE
kernel: modules: update dependency for kmod-usb-xhci-pci-renesas

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -1807,10 +1807,7 @@ define KernelPackage/usb3
 	+TARGET_bcm53xx:kmod-usb-bcma \
 	+TARGET_bcm53xx:kmod-phy-bcm-ns-usb3 \
 	+TARGET_ramips_mt7621:kmod-usb-xhci-mtk \
-	+TARGET_mediatek:kmod-usb-xhci-mtk \
-	+TARGET_apm821xx_nand:kmod-usb-xhci-pci-renesas \
-	+TARGET_lantiq_xrx200:kmod-usb-xhci-pci-renesas \
-	+TARGET_mvebu_cortexa9:kmod-usb-xhci-pci-renesas
+	+TARGET_mediatek:kmod-usb-xhci-mtk
   KCONFIG:= \
 	CONFIG_USB_PCI=y \
 	CONFIG_USB_XHCI_PCI \
@@ -1897,8 +1894,8 @@ $(eval $(call KernelPackage,usb-xhci-mtk))
 
 define KernelPackage/usb-xhci-pci-renesas
   TITLE:=Support for additional Renesas xHCI controller with firmware
+  DEPENDS:=+kmod-usb3
   KCONFIG:=CONFIG_USB_XHCI_PCI_RENESAS
-  HIDDEN:=1
   FILES:=$(LINUX_DIR)/drivers/usb/host/xhci-pci-renesas.ko
   AUTOLOAD:=$(call AutoLoad,54,xhci-pci-renesas,1)
   $(call AddDepends/usb)

--- a/target/linux/apm821xx/image/nand.mk
+++ b/target/linux/apm821xx/image/nand.mk
@@ -96,7 +96,7 @@ define Device/netgear_wndr4700
   DEVICE_PACKAGES := badblocks block-mount e2fsprogs kmod-hwmon-drivetemp \
 	kmod-dm kmod-fs-ext4 kmod-fs-vfat kmod-usb-ledtrig-usbport \
 	kmod-md-mod kmod-nls-cp437 kmod-nls-iso8859-1 kmod-nls-iso8859-15 \
-	kmod-nls-utf8 kmod-usb3 kmod-usb-dwc2 kmod-usb-storage \
+	kmod-nls-utf8 kmod-usb-xhci-pci-renesas kmod-usb-dwc2 kmod-usb-storage \
 	partx-utils kmod-ata-dwc
   BOARD_NAME := wndr4700
   PAGESIZE := 2048

--- a/target/linux/apm821xx/nand/profiles/00-default.mk
+++ b/target/linux/apm821xx/nand/profiles/00-default.mk
@@ -8,7 +8,7 @@ define Profile/Default
   PACKAGES := badblocks block-mount e2fsprogs \
 	kmod-dm kmod-fs-ext4 kmod-fs-vfat kmod-usb-ledtrig-usbport \
 	kmod-md-mod kmod-nls-cp437 kmod-nls-iso8859-1 kmod-nls-iso8859-15 \
-	kmod-nls-utf8 kmod-usb3 kmod-usb-dwc2 kmod-usb-storage \
+	kmod-nls-utf8 kmod-usb-xhci-pci-renesas kmod-usb-dwc2 kmod-usb-storage \
 	kmod-spi-gpio partx-utils
 endef
 

--- a/target/linux/bcm27xx/patches-6.6/950-0061-Revert-Revert-xhci-add-quirk-for-host-controllers-th.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-0061-Revert-Revert-xhci-add-quirk-for-host-controllers-th.patch
@@ -14,7 +14,7 @@ We don't agree with upstream revert so undo it.
 
 --- a/drivers/usb/host/xhci-pci.c
 +++ b/drivers/usb/host/xhci-pci.c
-@@ -485,6 +485,7 @@ static void xhci_pci_quirks(struct devic
+@@ -476,6 +476,7 @@ static void xhci_pci_quirks(struct devic
  	if (pdev->vendor == PCI_VENDOR_ID_VIA && pdev->device == PCI_DEVICE_ID_VIA_VL805) {
  		xhci->quirks |= XHCI_LPM_SUPPORT;
  		xhci->quirks |= XHCI_TRB_OVERFETCH;

--- a/target/linux/bcm27xx/patches-6.6/950-0482-xhci-quirks-add-link-TRB-quirk-for-VL805.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-0482-xhci-quirks-add-link-TRB-quirk-for-VL805.patch
@@ -24,7 +24,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
 
 --- a/drivers/usb/host/xhci-pci.c
 +++ b/drivers/usb/host/xhci-pci.c
-@@ -486,6 +486,7 @@ static void xhci_pci_quirks(struct devic
+@@ -477,6 +477,7 @@ static void xhci_pci_quirks(struct devic
  		xhci->quirks |= XHCI_LPM_SUPPORT;
  		xhci->quirks |= XHCI_TRB_OVERFETCH;
  		xhci->quirks |= XHCI_EP_CTX_BROKEN_DCS;

--- a/target/linux/bcm27xx/patches-6.6/950-0484-usb-xhci-add-VLI_SS_BULK_OUT_BUG-quirk.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-0484-usb-xhci-add-VLI_SS_BULK_OUT_BUG-quirk.patch
@@ -90,7 +90,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  	/* Allow 3 retries for everything but isoc, set CErr = 3 */
 --- a/drivers/usb/host/xhci-pci.c
 +++ b/drivers/usb/host/xhci-pci.c
-@@ -487,6 +487,7 @@ static void xhci_pci_quirks(struct devic
+@@ -478,6 +478,7 @@ static void xhci_pci_quirks(struct devic
  		xhci->quirks |= XHCI_TRB_OVERFETCH;
  		xhci->quirks |= XHCI_EP_CTX_BROKEN_DCS;
  		xhci->quirks |= XHCI_AVOID_DQ_ON_LINK;

--- a/target/linux/bcm27xx/patches-6.6/950-0485-usb-xhci-add-XHCI_VLI_HUB_TT_QUIRK.patch
+++ b/target/linux/bcm27xx/patches-6.6/950-0485-usb-xhci-add-XHCI_VLI_HUB_TT_QUIRK.patch
@@ -64,7 +64,7 @@ Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
  static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
  {
  	struct pci_dev                  *pdev = to_pci_dev(dev);
-@@ -488,6 +500,8 @@ static void xhci_pci_quirks(struct devic
+@@ -479,6 +491,8 @@ static void xhci_pci_quirks(struct devic
  		xhci->quirks |= XHCI_EP_CTX_BROKEN_DCS;
  		xhci->quirks |= XHCI_AVOID_DQ_ON_LINK;
  		xhci->quirks |= XHCI_VLI_SS_BULK_OUT_BUG;

--- a/target/linux/generic/backport-6.6/806-01-v6.10-xhci-pci-Use-PCI_VENDOR_ID_RENESAS.patch
+++ b/target/linux/generic/backport-6.6/806-01-v6.10-xhci-pci-Use-PCI_VENDOR_ID_RENESAS.patch
@@ -1,0 +1,30 @@
+From d6b2b694dd536d16566424c395d5642783ed6f34 Mon Sep 17 00:00:00 2001
+From: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Date: Mon, 29 Apr 2024 17:02:43 +0300
+Subject: [PATCH] xhci: pci: Use PCI_VENDOR_ID_RENESAS
+
+Instead of plain hexadecimal, use already defined PCI_VENDOR_ID_RENESAS.
+
+Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Signed-off-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+Link: https://lore.kernel.org/r/20240429140245.3955523-17-mathias.nyman@linux.intel.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/usb/host/xhci-pci.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/drivers/usb/host/xhci-pci.c
++++ b/drivers/usb/host/xhci-pci.c
+@@ -966,10 +966,10 @@ static const struct xhci_driver_data ren
+ 
+ /* PCI driver selection metadata; PCI hotplugging uses this */
+ static const struct pci_device_id pci_ids[] = {
+-	{ PCI_DEVICE(0x1912, 0x0014),
++	{ PCI_DEVICE(PCI_VENDOR_ID_RENESAS, 0x0014),
+ 		.driver_data =  (unsigned long)&reneses_data,
+ 	},
+-	{ PCI_DEVICE(0x1912, 0x0015),
++	{ PCI_DEVICE(PCI_VENDOR_ID_RENESAS, 0x0015),
+ 		.driver_data =  (unsigned long)&reneses_data,
+ 	},
+ 	/* handle any USB 3.0 xHCI controller */

--- a/target/linux/generic/backport-6.6/806-02-v6.11-usb-host-add-missing-MODULE_DESCRIPTION-macros.patch
+++ b/target/linux/generic/backport-6.6/806-02-v6.11-usb-host-add-missing-MODULE_DESCRIPTION-macros.patch
@@ -1,0 +1,35 @@
+From 9fdce69f674e49be669e97919d24b1ab5d2c9684 Mon Sep 17 00:00:00 2001
+From: Jeff Johnson <quic_jjohnson@quicinc.com>
+Date: Tue, 11 Jun 2024 17:53:37 -0700
+Subject: [PATCH] usb: host: add missing MODULE_DESCRIPTION() macros
+
+With ARCH=x86, make allmodconfig && make W=1 C=1 reports:
+WARNING: modpost: missing MODULE_DESCRIPTION() in drivers/usb/host/ohci-exynos.o
+WARNING: modpost: missing MODULE_DESCRIPTION() in drivers/usb/host/xhci-pci-renesas.o
+
+Add the missing invocations of the MODULE_DESCRIPTION() macro.
+
+Signed-off-by: Jeff Johnson <quic_jjohnson@quicinc.com>
+Link: https://lore.kernel.org/r/20240611-md-drivers-usb-host-v1-1-e2071a696ef8@quicinc.com
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/usb/host/ohci-exynos.c      | 1 +
+ drivers/usb/host/xhci-pci-renesas.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+--- a/drivers/usb/host/ohci-exynos.c
++++ b/drivers/usb/host/ohci-exynos.c
+@@ -308,4 +308,5 @@ module_exit(ohci_exynos_cleanup);
+ 
+ MODULE_ALIAS("platform:exynos-ohci");
+ MODULE_AUTHOR("Jingoo Han <jg1.han@samsung.com>");
++MODULE_DESCRIPTION("OHCI support for Samsung S5P/Exynos SoC Series");
+ MODULE_LICENSE("GPL v2");
+--- a/drivers/usb/host/xhci-pci-renesas.c
++++ b/drivers/usb/host/xhci-pci-renesas.c
+@@ -627,4 +627,5 @@ exit:
+ }
+ EXPORT_SYMBOL_GPL(renesas_xhci_check_request_fw);
+ 
++MODULE_DESCRIPTION("Support for Renesas xHCI controller with firmware");
+ MODULE_LICENSE("GPL v2");

--- a/target/linux/generic/backport-6.6/806-03-v6.12-xhci-pci-Make-xhci-pci-renesas-a-proper-modular-driver.patch
+++ b/target/linux/generic/backport-6.6/806-03-v6.12-xhci-pci-Make-xhci-pci-renesas-a-proper-modular-driver.patch
@@ -1,0 +1,282 @@
+From 25f51b76f90f10f9bf2fbc05fc51cf685da7ccad Mon Sep 17 00:00:00 2001
+From: Ben Hutchings <ben@decadent.org.uk>
+Date: Wed, 31 Jul 2024 22:32:29 +0200
+Subject: [PATCH] xhci-pci: Make xhci-pci-renesas a proper modular driver
+
+If CONFIG_USB_XHCI_PCI_RENESAS is enabled, xhci-pci conditionally
+calls into the xhci-pci-renesas module, which means both modules must
+be loaded to use any xHCI PCI controller.
+
+The MODULE_FIRMWARE declaration in the base xhci-pci module causes
+initramfs-tools to check for and warn about missing firmware for the
+Renesas xHCI controllers, when any xHCI PCI controller is present.
+And because of the previous oddity, simply moving this declaration to
+xhci-pci-renesas wouldn't help.
+
+To fix this, reverse the relationship between the modules:
+
+- Remove the quirk for the Renesas xHCIs, and the driver_data
+  structure used only for them
+- In xhci-pci:
+  - Rename xhci_pci_probe() to xhci_pci_common_probe()
+  - Export xhci_pci_common_probe() and xhci_pci_remove()
+  - Use a new probe function that rejects the Renesas xHCIs and then
+    calls the common probe function
+- In xhci-pci-renesas:
+  - Stop exporting renesas_xhci_check_request_fw()
+  - Add a probe function that calls renesas_xhci_check_request_fw()
+    followed by xhci_pci_common_probe()
+  - Add and register a new pci_driver matching only the Renesas xHCIs
+    and using its own probe function, but with other operations the
+    same as in xhci-pci
+- Make CONFIG_USB_XHCI_PCI_RENESAS depend on CONFIG_USB_XHCI_PCI,
+  not the other way around
+
+Finally, move the MODULE_FIRMWARE declaration to xhci-pci-renesas.
+
+Signed-off-by: Ben Hutchings <ben@decadent.org.uk>
+Tested-by: Cyril Brulebois <cyril@debamax.com>
+Link: https://lore.kernel.org/r/ZqqfXYRJf7kGaqus@decadent.org.uk
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/usb/host/Kconfig            |  2 +-
+ drivers/usb/host/xhci-pci-renesas.c | 48 ++++++++++++++++++++----
+ drivers/usb/host/xhci-pci.c         | 57 ++++++++++-------------------
+ drivers/usb/host/xhci-pci.h         | 19 +---------
+ drivers/usb/host/xhci.h             |  2 +-
+ 5 files changed, 64 insertions(+), 64 deletions(-)
+
+--- a/drivers/usb/host/Kconfig
++++ b/drivers/usb/host/Kconfig
+@@ -40,11 +40,11 @@ config USB_XHCI_DBGCAP
+ config USB_XHCI_PCI
+ 	tristate
+ 	depends on USB_PCI
+-	depends on USB_XHCI_PCI_RENESAS || !USB_XHCI_PCI_RENESAS
+ 	default y
+ 
+ config USB_XHCI_PCI_RENESAS
+ 	tristate "Support for additional Renesas xHCI controller with firmware"
++	depends on USB_XHCI_PCI
+ 	help
+ 	  Say 'Y' to enable the support for the Renesas xHCI controller with
+ 	  firmware. Make sure you have the firmware for the device and
+--- a/drivers/usb/host/xhci-pci-renesas.c
++++ b/drivers/usb/host/xhci-pci-renesas.c
+@@ -50,6 +50,8 @@
+ #define RENESAS_RETRY	10000
+ #define RENESAS_DELAY	10
+ 
++#define RENESAS_FW_NAME	"renesas_usb_fw.mem"
++
+ static int renesas_fw_download_image(struct pci_dev *dev,
+ 				     const u32 *fw, size_t step, bool rom)
+ {
+@@ -573,12 +575,10 @@ exit:
+ 	return err;
+ }
+ 
+-int renesas_xhci_check_request_fw(struct pci_dev *pdev,
+-				  const struct pci_device_id *id)
++static int renesas_xhci_check_request_fw(struct pci_dev *pdev,
++					 const struct pci_device_id *id)
+ {
+-	struct xhci_driver_data *driver_data =
+-			(struct xhci_driver_data *)id->driver_data;
+-	const char *fw_name = driver_data->firmware;
++	const char fw_name[] = RENESAS_FW_NAME;
+ 	const struct firmware *fw;
+ 	bool has_rom;
+ 	int err;
+@@ -625,7 +625,41 @@ exit:
+ 	release_firmware(fw);
+ 	return err;
+ }
+-EXPORT_SYMBOL_GPL(renesas_xhci_check_request_fw);
+ 
+-MODULE_DESCRIPTION("Support for Renesas xHCI controller with firmware");
++static int
++xhci_pci_renesas_probe(struct pci_dev *dev, const struct pci_device_id *id)
++{
++	int retval;
++
++	retval = renesas_xhci_check_request_fw(dev, id);
++	if (retval)
++		return retval;
++
++	return xhci_pci_common_probe(dev, id);
++}
++
++static const struct pci_device_id pci_ids[] = {
++	{ PCI_DEVICE(PCI_VENDOR_ID_RENESAS, 0x0014) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_RENESAS, 0x0015) },
++	{ /* end: all zeroes */ }
++};
++MODULE_DEVICE_TABLE(pci, pci_ids);
++
++static struct pci_driver xhci_renesas_pci_driver = {
++	.name =		"xhci-pci-renesas",
++	.id_table =	pci_ids,
++
++	.probe =	xhci_pci_renesas_probe,
++	.remove =	xhci_pci_remove,
++
++	.shutdown = 	usb_hcd_pci_shutdown,
++	.driver = {
++		.pm = pm_ptr(&usb_hcd_pci_pm_ops),
++	},
++};
++module_pci_driver(xhci_renesas_pci_driver);
++
++MODULE_DESCRIPTION("Renesas xHCI PCI Host Controller Driver");
++MODULE_FIRMWARE(RENESAS_FW_NAME);
++MODULE_IMPORT_NS(xhci);
+ MODULE_LICENSE("GPL v2");
+--- a/drivers/usb/host/xhci-pci.c
++++ b/drivers/usb/host/xhci-pci.c
+@@ -300,15 +300,6 @@ static int xhci_pci_reinit(struct xhci_h
+ static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
+ {
+ 	struct pci_dev                  *pdev = to_pci_dev(dev);
+-	struct xhci_driver_data         *driver_data;
+-	const struct pci_device_id      *id;
+-
+-	id = pci_match_id(to_pci_driver(pdev->dev.driver)->id_table, pdev);
+-
+-	if (id && id->driver_data) {
+-		driver_data = (struct xhci_driver_data *)id->driver_data;
+-		xhci->quirks |= driver_data->quirks;
+-	}
+ 
+ 	/* Look for vendor-specific quirks */
+ 	if (pdev->vendor == PCI_VENDOR_ID_FRESCO_LOGIC &&
+@@ -643,21 +634,13 @@ static int xhci_pci_update_hub_device(st
+  * We need to register our own PCI probe function (instead of the USB core's
+  * function) in order to create a second roothub under xHCI.
+  */
+-static int xhci_pci_probe(struct pci_dev *dev, const struct pci_device_id *id)
++int xhci_pci_common_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ {
+ 	int retval;
+ 	struct xhci_hcd *xhci;
+ 	struct usb_hcd *hcd;
+-	struct xhci_driver_data *driver_data;
+ 	struct reset_control *reset;
+ 
+-	driver_data = (struct xhci_driver_data *)id->driver_data;
+-	if (driver_data && driver_data->quirks & XHCI_RENESAS_FW_QUIRK) {
+-		retval = renesas_xhci_check_request_fw(dev, id);
+-		if (retval)
+-			return retval;
+-	}
+-
+ 	reset = devm_reset_control_get_optional_exclusive(&dev->dev, NULL);
+ 	if (IS_ERR(reset))
+ 		return PTR_ERR(reset);
+@@ -722,8 +705,24 @@ put_runtime_pm:
+ 	pm_runtime_put_noidle(&dev->dev);
+ 	return retval;
+ }
++EXPORT_SYMBOL_NS_GPL(xhci_pci_common_probe, xhci);
++
++static const struct pci_device_id pci_ids_reject[] = {
++	/* handled by xhci-pci-renesas */
++	{ PCI_DEVICE(PCI_VENDOR_ID_RENESAS, 0x0014) },
++	{ PCI_DEVICE(PCI_VENDOR_ID_RENESAS, 0x0015) },
++	{ /* end: all zeroes */ }
++};
++
++static int xhci_pci_probe(struct pci_dev *dev, const struct pci_device_id *id)
++{
++	if (pci_match_id(pci_ids_reject, dev))
++		return -ENODEV;
++
++	return xhci_pci_common_probe(dev, id);
++}
+ 
+-static void xhci_pci_remove(struct pci_dev *dev)
++void xhci_pci_remove(struct pci_dev *dev)
+ {
+ 	struct xhci_hcd *xhci;
+ 	bool set_power_d3;
+@@ -750,6 +749,7 @@ static void xhci_pci_remove(struct pci_d
+ 	if (set_power_d3)
+ 		pci_set_power_state(dev, PCI_D3hot);
+ }
++EXPORT_SYMBOL_NS_GPL(xhci_pci_remove, xhci);
+ 
+ /*
+  * In some Intel xHCI controllers, in order to get D3 working,
+@@ -959,19 +959,8 @@ static void xhci_pci_shutdown(struct usb
+ 
+ /*-------------------------------------------------------------------------*/
+ 
+-static const struct xhci_driver_data reneses_data = {
+-	.quirks  = XHCI_RENESAS_FW_QUIRK,
+-	.firmware = "renesas_usb_fw.mem",
+-};
+-
+ /* PCI driver selection metadata; PCI hotplugging uses this */
+ static const struct pci_device_id pci_ids[] = {
+-	{ PCI_DEVICE(PCI_VENDOR_ID_RENESAS, 0x0014),
+-		.driver_data =  (unsigned long)&reneses_data,
+-	},
+-	{ PCI_DEVICE(PCI_VENDOR_ID_RENESAS, 0x0015),
+-		.driver_data =  (unsigned long)&reneses_data,
+-	},
+ 	/* handle any USB 3.0 xHCI controller */
+ 	{ PCI_DEVICE_CLASS(PCI_CLASS_SERIAL_USB_XHCI, ~0),
+ 	},
+@@ -979,14 +968,6 @@ static const struct pci_device_id pci_id
+ };
+ MODULE_DEVICE_TABLE(pci, pci_ids);
+ 
+-/*
+- * Without CONFIG_USB_XHCI_PCI_RENESAS renesas_xhci_check_request_fw() won't
+- * load firmware, so don't encumber the xhci-pci driver with it.
+- */
+-#if IS_ENABLED(CONFIG_USB_XHCI_PCI_RENESAS)
+-MODULE_FIRMWARE("renesas_usb_fw.mem");
+-#endif
+-
+ /* pci driver glue; this is a "new style" PCI driver module */
+ static struct pci_driver xhci_pci_driver = {
+ 	.name =		hcd_name,
+--- a/drivers/usb/host/xhci-pci.h
++++ b/drivers/usb/host/xhci-pci.h
+@@ -4,22 +4,7 @@
+ #ifndef XHCI_PCI_H
+ #define XHCI_PCI_H
+ 
+-#if IS_ENABLED(CONFIG_USB_XHCI_PCI_RENESAS)
+-int renesas_xhci_check_request_fw(struct pci_dev *dev,
+-				  const struct pci_device_id *id);
+-
+-#else
+-static int renesas_xhci_check_request_fw(struct pci_dev *dev,
+-					 const struct pci_device_id *id)
+-{
+-	return 0;
+-}
+-
+-#endif
+-
+-struct xhci_driver_data {
+-	u64 quirks;
+-	const char *firmware;
+-};
++int xhci_pci_common_probe(struct pci_dev *dev, const struct pci_device_id *id);
++void xhci_pci_remove(struct pci_dev *dev);
+ 
+ #endif
+--- a/drivers/usb/host/xhci.h
++++ b/drivers/usb/host/xhci.h
+@@ -1648,7 +1648,7 @@ struct xhci_hcd {
+ #define XHCI_DEFAULT_PM_RUNTIME_ALLOW	BIT_ULL(33)
+ #define XHCI_RESET_PLL_ON_DISCONNECT	BIT_ULL(34)
+ #define XHCI_SNPS_BROKEN_SUSPEND    BIT_ULL(35)
+-#define XHCI_RENESAS_FW_QUIRK	BIT_ULL(36)
++/* Reserved. It was XHCI_RENESAS_FW_QUIRK */
+ #define XHCI_SKIP_PHY_INIT	BIT_ULL(37)
+ #define XHCI_DISABLE_SPARSE	BIT_ULL(38)
+ #define XHCI_SG_TRB_CACHE_SIZE_QUIRK	BIT_ULL(39)

--- a/target/linux/lantiq/image/vr9.mk
+++ b/target/linux/lantiq/image/vr9.mk
@@ -158,8 +158,8 @@ define Device/avm_fritz3490
   DEVICE_VARIANT := Other NAND
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-usb3 fritz-tffs xrx200-rev1.1-phy11g-firmware \
-	xrx200-rev1.2-phy11g-firmware -kmod-owl-loader
+  DEVICE_PACKAGES := kmod-usb-xhci-pci-renesas fritz-tffs \
+	xrx200-rev1.1-phy11g-firmware xrx200-rev1.2-phy11g-firmware -kmod-owl-loader
 endef
 TARGET_DEVICES += avm_fritz3490
 
@@ -171,8 +171,8 @@ define Device/avm_fritz3490-micron
   DEVICE_VARIANT := Micron NAND
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-usb3 fritz-tffs xrx200-rev1.1-phy11g-firmware \
-  	xrx200-rev1.2-phy11g-firmware -kmod-owl-loader
+  DEVICE_PACKAGES := kmod-usb-xhci-pci-renesas fritz-tffs \
+	xrx200-rev1.1-phy11g-firmware xrx200-rev1.2-phy11g-firmware -kmod-owl-loader
 endef
 TARGET_DEVICES += avm_fritz3490-micron
 
@@ -186,8 +186,8 @@ define Device/avm_fritz5490
   DEVICE_VARIANT := Other NAND
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-dsa-qca8k kmod-phy-qca83xx kmod-usb3 fritz-tffs \
-	xrx200-rev1.1-phy11g-firmware xrx200-rev1.2-phy11g-firmware \
+  DEVICE_PACKAGES := kmod-dsa-qca8k kmod-phy-qca83xx kmod-usb-xhci-pci-renesas \
+	fritz-tffs xrx200-rev1.1-phy11g-firmware xrx200-rev1.2-phy11g-firmware \
 	-ltq-vdsl-vr9-vectoring-fw-installer -kmod-ltq-vdsl-vr9-mei \
 	-kmod-ltq-vdsl-vr9 -kmod-ltq-atm-vr9 -kmod-ltq-ptm-vr9 \
 	-ltq-vdsl-vr9-app -kmod-owl-loader \
@@ -205,8 +205,8 @@ define Device/avm_fritz5490-micron
   DEVICE_VARIANT := Micron NAND
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-dsa-qca8k kmod-phy-qca83xx kmod-usb3 fritz-tffs \
-	xrx200-rev1.1-phy11g-firmware xrx200-rev1.2-phy11g-firmware \
+  DEVICE_PACKAGES := kmod-dsa-qca8k kmod-phy-qca83xx kmod-usb-xhci-pci-renesas \
+	fritz-tffs xrx200-rev1.1-phy11g-firmware xrx200-rev1.2-phy11g-firmware \
 	-ltq-vdsl-vr9-vectoring-fw-installer -kmod-ltq-vdsl-vr9-mei \
 	-kmod-ltq-vdsl-vr9 -kmod-ltq-atm-vr9 -kmod-ltq-ptm-vr9 \
 	-ltq-vdsl-vr9-app -kmod-owl-loader \
@@ -286,8 +286,8 @@ define Device/avm_fritz7490
   DEVICE_VARIANT := Other NAND
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-usb3 fritz-tffs xrx200-rev1.1-phy11g-firmware \
-	xrx200-rev1.2-phy11g-firmware -kmod-owl-loader
+  DEVICE_PACKAGES := kmod-usb-xhci-pci-renesas fritz-tffs \
+	xrx200-rev1.1-phy11g-firmware xrx200-rev1.2-phy11g-firmware -kmod-owl-loader
 endef
 TARGET_DEVICES += avm_fritz7490
 
@@ -299,8 +299,8 @@ define Device/avm_fritz7490-micron
   DEVICE_VARIANT := Micron NAND
   KERNEL_SIZE := 4096k
   IMAGE_SIZE := 49152k
-  DEVICE_PACKAGES := kmod-usb3 fritz-tffs xrx200-rev1.1-phy11g-firmware \
-	xrx200-rev1.2-phy11g-firmware -kmod-owl-loader
+  DEVICE_PACKAGES := kmod-usb-xhci-pci-renesas fritz-tffs \
+	xrx200-rev1.1-phy11g-firmware xrx200-rev1.2-phy11g-firmware -kmod-owl-loader
 endef
 TARGET_DEVICES += avm_fritz7490-micron
 

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -72,9 +72,9 @@ define Device/buffalo_ls421de
   KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
   DEVICE_DTS := armada-370-buffalo-ls421de
   DEVICE_PACKAGES :=  \
-    kmod-rtc-rs5c372a kmod-hwmon-gpiofan kmod-hwmon-drivetemp kmod-usb3 \
-    kmod-linkstation-poweroff kmod-md-raid0 kmod-md-raid1 kmod-md-mod \
-    kmod-fs-xfs mkf2fs e2fsprogs partx-utils
+    kmod-rtc-rs5c372a kmod-hwmon-gpiofan kmod-hwmon-drivetemp \
+    kmod-usb-xhci-pci-renesas kmod-linkstation-poweroff kmod-md-raid0 \
+    kmod-md-raid1 kmod-md-mod kmod-fs-xfs mkf2fs e2fsprogs partx-utils
 endef
 TARGET_DEVICES += buffalo_ls421de
 
@@ -91,7 +91,7 @@ define Device/ctera_c200-v2
   KERNEL_SUFFIX := -factory.firm
   DEVICE_PACKAGES :=  \
     kmod-gpio-button-hotplug kmod-hwmon-drivetemp kmod-hwmon-nct7802 \
-    kmod-rtc-s35390a kmod-usb3 kmod-usb-ledtrig-usbport
+    kmod-rtc-s35390a kmod-usb-xhci-pci-renesas kmod-usb-ledtrig-usbport
   IMAGES := sysupgrade.bin
 endef
 TARGET_DEVICES += ctera_c200-v2
@@ -209,7 +209,8 @@ TARGET_DEVICES += iij_sa-w2
 define Device/iptime_nas1dual
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := NAS1dual
-  DEVICE_PACKAGES := kmod-hwmon-drivetemp kmod-hwmon-gpiofan kmod-usb3
+  DEVICE_PACKAGES := kmod-hwmon-drivetemp kmod-hwmon-gpiofan \
+    kmod-usb-xhci-pci-renesas
   SOC := armada-385
   KERNEL := kernel-bin | append-dtb | iptime-naspkg nas1dual
   KERNEL_SIZE := 6144k


### PR DESCRIPTION
This PR aims to solve the `kmod-usb-xhci-pci-renesas` package dependency issue on 6.12 kernel. In the new 6.12 kernel, the dependencies of `kmod-usb3` and `kmod-usb-xhci-pci-renesas` have been reversed.

Fix the build error on lantiq 6.12 testing kernel:
```
Package kmod-usb-xhci-pci-renesas is missing dependencies for the following libraries:
xhci-pci.ko
```