### PR TITLE
qualcommax: ipq50xx: fix NAND ECC for ELECOM WRC-X3000GS2

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wrc-x3000gs2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wrc-x3000gs2.dts
@@ -164,6 +164,10 @@
 		#size-cells = <1>;
 
 		nand-ecc-engine = <&qpic_nand>;
+
+		/* strength=8 breaks NAND I/O, use 4 instead */
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
 		nand-bus-width = <8>;
 
 		partitions {


### PR DESCRIPTION
Specify 4-bit ECC strength instead of 8-bit, to resolve NAND I/O errors on ELECOM WRC-X3000GS2.

ELECOM WRC-X3000GS2 has a Macronix MX35UF1G24AD SPI-NAND chip as a flash storage. That chip is registered as a chip that has 128 bytes OOB and requires 8-bit ECC, and described as the same in the Macronix's datasheet.

But on WRC-X3000GS2, 8-bit ECC breaks NAND I/O on mtdblock devices with the following errors and 4-bit ECC needs to be used to resolve this issue.

current (ECC strength=8):

```
[    1.401566] 0x000000480000-0x000000500000 : "0:appsblenv"
[    1.407128] 1 fixed-partitions partitions found on MTD device 0:appsblenv
[    1.410663] Creating 1 MTD partitions on "0:appsblenv":
[    1.417359] 0x000000000000-0x000000040000 : "env-data"
[    1.479865] u-boot-env-layout: probe of 79b0000.qpic-nand:flash@0:partitions:partition-0-appsblenv:partition@0:nvmem-layout failed with error -74

root@OpenWrt:~# strings /dev/mtdblock10
[   55.693754] mtdblock: MTD device '0:appsblenv' is NAND, please consider using UBI block devices instead.
[   55.694660] I/O error, dev mtdblock10, sector 0 op 0x0:(READ) flags 0x80700 phys_seg 4 prio class 2
[   55.703147] I/O error, dev mtdblock10, sector 8 op 0x0:(READ) flags 0x80700 phys_seg 3 prio class 2
[   55.711884] I/O error, dev mtdblock10, sector 16 op 0x0:(READ) flags 0x80700 phys_seg 2 prio class 2
[   55.720778] I/O error, dev mtdblock10, sector 24 op 0x0:(READ) flags 0x80700 phys_seg 1 prio class 2
[   55.730310] I/O error, dev mtdblock10, sector 0 op 0x0:(READ) flags 0x0 phys_seg 1 prio class 2
[   55.738607] Buffer I/O error on dev mtdblock10, logical block 0, async page read
```

after fixing (ECC strength=4):

```
[    1.402301] 0x000000480000-0x000000500000 : "0:appsblenv"
[    1.407909] 1 fixed-partitions partitions found on MTD device 0:appsblenv
[    1.411370] Creating 1 MTD partitions on "0:appsblenv":
[    1.418075] 0x000000000000-0x000000040000 : "env-data"
(no error)

root@OpenWrt:~# strings /dev/mtdblock10
[   39.131008] mtdblock: MTD device '0:appsblenv' is NAND, please consider using UBI block devices instead.
bootcmd=bootipq
baudrate=115200
wifi2=7C:F8:54:01:BD:F3
CRASH_COUNT=0
...

```

Fixes: 01b72ce61e ("qualcommax: ipq50xx: remove ECC user config from board files")
