### PR TITLE
Fix failure to bring qmi interface up due to too small SIM power-cycle timeouts

### DIFF
--- a/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
+++ b/package/network/utils/uqmi/files/lib/netifd/proto/qmi.sh
@@ -107,7 +107,7 @@ proto_qmi_setup() {
 	# Check if UIM application is stuck in illegal state
 	local uim_state_timeout=0
 	while true; do
-		json_load "$(uqmi -s -d "$device" -t 1000 --uim-get-sim-state)"
+		json_load "$(uqmi -s -d "$device" -t 2000 --uim-get-sim-state)"
 		json_get_var card_application_state card_application_state
 
 		# SIM card is either completely absent or state is labeled as illegal
@@ -122,7 +122,7 @@ proto_qmi_setup() {
 
 			if [ "$uim_state_timeout" -lt "$timeout" ] || [ "$timeout" = "0" ]; then
 				let uim_state_timeout++
-				sleep 1
+				sleep 5
 				continue
 			fi
 


### PR DESCRIPTION
Some modems and SIM cards take a bit longer to initialize after UIM has been powered off. Waiting too little time can cause the qmi protocol to end up in a loop repeatedly power-cycling the SIM card until openwrt gives up.

This loop can be observed in log as follows:
```
Sat May 10 10:16:45 2025 daemon.notice netifd: Interface 'lte' is setting up now
Sat May 10 10:16:46 2025 daemon.notice netifd: lte (2437): Waiting for SIM initialization
Sat May 10 10:16:47 2025 daemon.notice netifd: lte (2437): Failed to parse message data
Sat May 10 10:16:47 2025 daemon.notice netifd: lte (2437): SIM in illegal state - Power-cycling SIM
Sat May 10 10:16:52 2025 daemon.notice netifd: lte (2437): Failed to parse message data
Sat May 10 10:16:52 2025 daemon.notice netifd: lte (2437): SIM in illegal state - Power-cycling SIM
Sat May 10 10:16:56 2025 daemon.notice netifd: lte (2437): SIM in illegal state - Power-cycling SIM
Sat May 10 10:17:00 2025 daemon.notice netifd: lte (2437): "Failed to connect to service"
Sat May 10 10:17:01 2025 daemon.notice netifd: lte (2437): SIM in illegal state - Power-cycling SIM
Sat May 10 10:17:06 2025 daemon.notice netifd: lte (2437): SIM in illegal state - Power-cycling SIM
Sat May 10 10:17:10 2025 daemon.notice netifd: lte (2437): SIM in illegal state - Power-cycling SIM
Sat May 10 10:17:15 2025 daemon.notice netifd: lte (2437): SIM in illegal state - Power-cycling SIM
Sat May 10 10:17:20 2025 daemon.notice netifd: lte (2437): SIM in illegal state - Power-cycling SIM
Sat May 10 10:17:25 2025 daemon.notice netifd: lte (2437): SIM in illegal state - Power-cycling SIM
Sat May 10 10:17:30 2025 daemon.notice netifd: lte (2437): SIM in illegal state - Power-cycling SIM
Sat May 10 10:17:35 2025 daemon.notice netifd: lte (2437): SIM in illegal state - Power-cycling SIM
Sat May 10 10:17:38 2025 daemon.notice netifd: lte (3552): Stopping network lte
Sat May 10 10:17:38 2025 daemon.notice netifd: Interface 'lte' is now down
```

This PR tries to avoid that by
  a) increasing the time we unconditionally sleep after `--uim-power-on`
  b) increasing the time we allow uqmi to wait for response for `--uim-get-sim-state`
 