### PR TITLE
qualcommbe: ipq95xx: fix ipq-uniphy crash on IPQ9554

### DIFF
--- a/target/linux/qualcommbe/patches-6.6/200-06-net-pcs-ipq-uniphy-fix-NULL-pointer-dereference-in-p.patch
+++ b/target/linux/qualcommbe/patches-6.6/200-06-net-pcs-ipq-uniphy-fix-NULL-pointer-dereference-in-p.patch
@@ -1,0 +1,43 @@
+From 0c16deea166f6d890ac4aa9a73d28fc64fb26c3d Mon Sep 17 00:00:00 2001
+From: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+Date: Sat, 10 May 2025 14:59:05 -0500
+Subject: [PATCH] net: pcs: ipq-uniphy: fix NULL pointer dereference in probe()
+
+In .probe(), the clocks are stored one-by-one in the priv->clk[]
+array. Later, they are dereferenced directly when calling
+clk_set_rate(). When the clock value is PTR_ERR instead of a valid
+pointer, the system crashes with a NULL pointer dereference.
+
+The problem is seen on IPQ9554, where uniphy1 is not present, and
+cannot be enabled:
+
+    gcc_uniphy1_sys_clk status stuck at 'off'
+    ...
+    ipq_uniphy 7a10000.ethernet-uniphy: Failed to get the clock ID sys
+    ...
+    Unable to handle kernel read from unreadable memory at virtual address 000000000000002
+
+While disabling the uniphy1 node in devicetree also prevents the
+crash, fixing the driver logic is more generic. Abort .probe() if any
+of the clocks fail to resolve.
+
+Signed-off-by: Alexandru Gagniuc <mr.nuke.me@gmail.com>
+---
+ drivers/net/pcs/pcs-qcom-ipq-uniphy.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/pcs/pcs-qcom-ipq-uniphy.c
++++ b/drivers/net/pcs/pcs-qcom-ipq-uniphy.c
+@@ -1167,9 +1167,11 @@ static int ipq_uniphy_probe(struct platf
+ 		priv->clk[i] = devm_clk_get_optional_enabled(dev,
+ 							     pcs_clock_name[i]);
+ 
+-		if (IS_ERR(priv->clk[i]))
++		if (IS_ERR(priv->clk[i])) {
+ 			dev_err(dev, "Failed to get the clock ID %s\n",
+ 				pcs_clock_name[i]);
++			return PTR_ERR(priv->clk[i]);
++		}
+ 	}
+ 
+ 	for (i = 0; i < PCS_RESET_MAX; i++) {


### PR DESCRIPTION
IPQ9554 does not have uniphy1. The "gcc_uniphy1_sys_clk" cannot be enabled. This causes the ipq-uniphy driver to crash on .probe(). Add a patch to resolve the crash.

@Ansuel @robimarko 