### PR TITLE
ramips: mt7621: relocate kernel for ELECOM WRC-X1800GS

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1311,10 +1311,11 @@ define Device/elecom_wrc-x1800gs
   $(Device/nand)
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-X1800GS
-  KERNEL := kernel-bin | lzma | \
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
 	znet-header 4.04(XVF.1)b90 COMC 0x68 | elecom-product-header WRC-X1800GS
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
+  KERNEL_INITRAMFS := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL_SIZE := 8192k
   IMAGE_SIZE := 51456k


### PR DESCRIPTION
Relocate the kernel in the firmware images for WRC-X1800GS when booting, to fix the LZMA error while extraction by U-Boot with the following messages.

log (official initramfs image (ffde9a9fe9)):

```
=> bootm
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  MIPS OpenWrt Linux-6.6.89
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x800100e4
     Data Size:    7365490 Bytes = 7 MiB
     Architecture: MIPS
     OS:           Linux
     Load Address: 0x80001000
     Entry Point:  0x80001000
     Hash algo:    crc32
     Hash value:   f27303e3
     Hash algo:    sha1
     Hash value:   7715e6d2d27eeef34ea88ad7ae0c6f73b6748ba4
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  MIPS OpenWrt elecom_wrc-x1800gs device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x8071659c
     Data Size:    13578 Bytes = 13.3 KiB
     Architecture: MIPS
     Hash algo:    crc32
     Hash value:   d37ef67f
     Hash algo:    sha1
     Hash value:   e66ac0a2e8024a276bf9b3712dffa2192d7a70dc
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x8071659c
   Uncompressing Kernel Image ... lzma compressed: uncompress error 1
Must RESET board to recover

===================================================================
                MT7621   stage1 code Dec 16 2019 17:45:55 (ASIC)
                CPU=500000000 HZ BUS=166666666 HZ
==================================================================
...

```
