### PR TITLE
qualcommax: dts: fix PCI unit address format error

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
@@ -563,7 +563,7 @@
 	perst-gpio = <&tlmm 62 GPIO_ACTIVE_HIGH>;
 
 	bridge@1,0 {
-		reg = <0x00010000 0 0 0 0>;
+		reg = <0x00000800 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
 		ranges;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
@@ -300,7 +300,7 @@
 	perst-gpio = <&tlmm 61 GPIO_ACTIVE_LOW>;
 
 	bridge@1,0 {
-		reg = <0x00010000 0 0 0 0>;
+		reg = <0x00000800 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
 		ranges;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
@@ -470,7 +470,7 @@
 	perst-gpio = <&tlmm 62 GPIO_ACTIVE_HIGH>;
 
 	bridge@1,0 {
-		reg = <0x00010000 0 0 0 0>;
+		reg = <0x00000800 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
 		ranges;


### PR DESCRIPTION
With some extra inspection of checks.c of the dtc tool, it was finally discovered how DTC actually parse the PCI reg address.

In details it defined as bridge@device,function

- device is in the mask 0xf800 that is GENMASK(15, 11)
- function is in the mask 0x700 that is GENMASK(10, 8)

Hence to translate a bridge@1,0 0x00000800 should be used that sets
- device to 0x1 (0x800)
- function to 0x0 (0x0)

With this change these following warning gets muted.

arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts:473.13-478.4: Warning (pci_device_reg): /soc@0/pci@10000000/bridge@1,0: PCI unit address format error, expected "0,0"
arch/arm64/boot/dts/qcom/ipq8072-haze.dts:303.13-318.4: Warning (pci_device_reg): /soc@0/pci@10000000/bridge@1,0: PCI unit address format error, expected "0,0"
arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts:566.13-582.4: Warning (pci_device_reg): /soc@0/pci@10000000/bridge@1,0: PCI unit address format error, expected "0,0"

Update any affected DTS to the correct reg value.

---

@robimarko magic magic :D it was easier then expected.
(This is a continuation of #18106)

ChatGPT also say that GENMASK(23, 16) is PCI bus number.

So is it correct that bridge@1,0 refers to device,function ? 

Or should be PCI bus,device ???

Also any idea for the wifi node? Should that match the bridge value?