### PR TITLE
qualcommax: dts: fix "property has invalid length" and "missing or empty reg property" warning

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-eap620hd-v1.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-eap620hd-v1.dts
@@ -71,7 +71,7 @@
 
 &mdio {
 	status = "okay";
-	#size-cells = <1>;
+
 	pinctrl-0 = <&mdio_pins>;
 	pinctrl-names = "default";
 	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
@@ -89,20 +89,6 @@
 	cs-gpios = <0>;
 	status = "okay";
 
-	/*
-	 * Bootloader will find the NAND DT node by the compatible and
-	 * then "fixup" it by adding the partitions from the SMEM table
-	 * using the legacy bindings thus making it impossible for us
-	 * to change the partition table or utilize NVMEM for calibration.
-	 * So add a dummy partitions node that bootloader will populate
-	 * and set it as disabled so the kernel ignores it instead of
-	 * printing warnings due to the broken way bootloader adds the
-	 * partitions.
-	 */
-	partitions {
-		status = "disabled";
-	};
-
 	flash@0 {
 		#address-cells = <1>;
 		#size-cells = <1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
@@ -237,6 +237,8 @@
 
 				nvmem-layout {
 					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
 					aqr_fw: aqr-fw@0 {
 						/* Skip the QCOM MBN Header of 40 bytes */


### PR DESCRIPTION
Fix two warnings (TP-Link EAP620 HD v1 and Zyxel NBG7815):
- `property has invalid length`
- `missing or empty reg property`
