### PR TITLE
ramips: add Teltonika RUT9xx series support

### DIFF
--- a/target/linux/ramips/dts/mt7628an_teltonika_rut9x1.dts
+++ b/target/linux/ramips/dts/mt7628an_teltonika_rut9x1.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_teltonika_rut9xx.dtsi"
+
+/ {
+	compatible = "teltonika,rut9x1", "mediatek,mt7628an-soc";
+	model = "Teltonika RUT951/RUT901";
+};

--- a/target/linux/ramips/dts/mt7628an_teltonika_rut9x6.dts
+++ b/target/linux/ramips/dts/mt7628an_teltonika_rut9x6.dts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_teltonika_rut9xx.dtsi"
+
+/ {
+	compatible = "teltonika,rut9x6", "mediatek,mt7628an-soc";
+	model = "Teltonika RUT956/RUT906";
+
+	gpio-export {
+		gpio_dcd {
+			gpio-export,name = "dcd";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_din2 {
+			gpio-export,name = "digital_input2";
+			gpio-export,input = <0>;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_output2 {
+			gpio-export,name = "digital_output2";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_adcin {
+			gpio-export,name = "adc_input";
+			gpio-export,input = <0>;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_relay {
+			gpio-export,name = "relay";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_rs485_rx_en {
+			gpio-export,name = "rs485_rx_enable";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_rs485_tx_en {
+			gpio-export,name = "rs485_tx_enable";
+			gpio-export,output = <0>;
+			gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_isolated_input {
+			gpio-export,name = "isolated_input";
+			gpio-export,input = <0>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+	hwmon@4d {
+		compatible = "mcp3221";
+		reg = <0x4d>;
+		reference-voltage-microvolt = <3300000>;
+	};
+
+	hwmon@48 {
+		compatible = "ti,tla2021";
+		reg = <0x48>;
+	};
+};
+
+&uart1 {
+	linux,rs485-enabled-at-boot-time;
+	rs485-rts-delay = <0 0>;
+	rs485-rx-during-tx;
+	status = "okay";
+};

--- a/target/linux/ramips/dts/mt7628an_teltonika_rut9xx.dtsi
+++ b/target/linux/ramips/dts/mt7628an_teltonika_rut9xx.dtsi
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include "mt7628an.dtsi"
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-upgrade = &led_power;
+		led-running = &led_power;
+	};
+
+	gpio_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <1>;
+
+		gpio_hc595: gpio_hc595@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <2>;
+			spi-max-frequency = <10000000>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_modem_reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_modem_power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_sim_select {
+			gpio-export,name = "sim_sel";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 7 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_esim_select {
+			gpio-export,name = "esim_sel";
+			gpio-export,output = <0>;
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_modem_status {
+			gpio-export,name = "modem_status";
+			gpio-export,input = <0>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_din1 {
+			gpio-export,name = "digital_input1";
+			gpio-export,input = <0>;
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_dout1 {
+			gpio-export,name = "digital_output1";
+			gpio-export,output = <0>;
+			gpios = <&gpio_hc595 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan1 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <1>;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <2>;
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <3>;
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		modem_status_red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio_hc595 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		modem_status_green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi1{
+			label = "green:rssi-1";
+			gpios = <&gpio_hc595 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi2 {
+			label = "green:rssi-2";
+			gpios = <&gpio_hc595 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi3 {
+			label = "green:rssi-3";
+			gpios = <&gpio_hc595 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi4 {
+			label = "green:rssi-4";
+			gpios = <&gpio_hc595 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi5 {
+			label = "green:rssi-5";
+			gpios = <&gpio_hc595 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power: power {
+			gpios = <&gpio_hc595 15 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "config";
+				reg = <0x020000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_0: macaddr@0 {
+						reg = <0x0 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@30000 {
+				label = "factory";
+				reg = <0x030000 0x030000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x20000 0x400>;
+					};
+				};
+			};
+
+			partition@60000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x060000 0xf10000>;
+			};
+
+			partition@f70000 {
+				label = "event-log";
+				reg = <0xf70000 0x90000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "p4led_an", "p3led_an", "p2led_an", "p1led_an", "p0led_an", "gpio", "wled_an", "perst", "refclk", "spi cs1";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_config_0 2>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_config_0 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -29,19 +29,21 @@ define Build/ravpower-wd009-factory
 endef
 
 define Build/append-teltonika-metadata
-  $(eval model_id=$(1))
+  $(eval model_id=$(word 1,$(1)))
+  $(eval hw_mods=$(subst $(space),$(comma),$(wordlist 2,$(words $(1)),$(1))))
+
 	echo \
 		'{ \
 			"metadata_version": "1.1", \
 			"compat_version": "1.0", \
-			"version": "", \
+			"version": "OpenWrt", \
 			"device_code": [".*"], \
 			"hwver": [".*"], \
 			"batch": [".*"], \
 			"serial": [".*"], \
 			"supported_devices":["teltonika,$(model_id)"], \
 			"hw_support": { }, \
-			"hw_mods": { } \
+			"hw_mods": { $(hw_mods) } \
 		}' | fwtool -I - $@
 endef
 
@@ -635,6 +637,24 @@ define Device/tama_w06
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
 endef
 TARGET_DEVICES += tama_w06
+
+define Device/teltonika_rut9x6
+  DEVICE_VENDOR := Teltonika
+  DEVICE_MODEL := RUT956
+  DEVICE_ALT0_VENDOR := Teltonika
+  DEVICE_ALT0_MODEL := RUT906
+  IMAGE_SIZE := 15424k
+  BLOCKSIZE := 64k
+  DEVICE_PACKAGES := uqmi kmod-mt76x2 kmod-usb2 kmod-usb-ohci \
+	kmod-usb-serial-option kmod-spi-gpio kmod-gpio-nxp-74hc164 kmod-i2c-mt7628 \
+	kmod-hwmon-mcp3021 kmod-scsi-core kmod-usb-storage kmod-usb-acm kmod-usb-net-cdc-ether
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | append-teltonika-metadata rut9m \
+	"mod1":"2c7c_6005" "mod2":"TLA2021" "mod3":"CH343" "mod4":"esim" "mod5":"ala440"
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+TARGET_DEVICES += teltonika_rut9x6
 
 define Device/totolink_a3
   IMAGE_SIZE := 7936k

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -638,6 +638,24 @@ define Device/tama_w06
 endef
 TARGET_DEVICES += tama_w06
 
+define Device/teltonika_rut9x1
+  DEVICE_VENDOR := Teltonika
+  DEVICE_MODEL := RUT951
+  DEVICE_ALT0_VENDOR := Teltonika
+  DEVICE_ALT0_MODEL := RUT901
+  IMAGE_SIZE := 15424k
+  BLOCKSIZE := 64k
+  DEVICE_PACKAGES := uqmi kmod-mt76x2 kmod-usb2 kmod-usb-ohci \
+	kmod-usb-serial-option kmod-spi-gpio kmod-gpio-nxp-74hc164 \
+	kmod-i2c-mt7628 kmod-usb-net-cdc-ether
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | append-teltonika-metadata rut9m \
+	"mod1":"2c7c_6005" "mod2":"TLA2021" "mod3":"CH343" "mod4":"esim" "mod5":"ala440"
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+TARGET_DEVICES += teltonika_rut9x1
+
 define Device/teltonika_rut9x6
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT956

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -82,6 +82,7 @@ teltonika,rut241)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x02"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
 	;;
+teltonika,rut9x1|\
 teltonika,rut9x6)
 	ucidef_set_led_switch "lan1" "lan1" "green:lan-1" "switch0" "0x1"
 	ucidef_set_led_switch "lan2" "lan2" "green:lan-2" "switch0" "0x2"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -82,6 +82,12 @@ teltonika,rut241)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x02"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
 	;;
+teltonika,rut9x6)
+	ucidef_set_led_switch "lan1" "lan1" "green:lan-1" "switch0" "0x1"
+	ucidef_set_led_switch "lan2" "lan2" "green:lan-2" "switch0" "0x2"
+	ucidef_set_led_switch "lan3" "lan3" "green:lan-3" "switch0" "0x4"
+	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x10"
+	;;
 tplink,archer-c20-v4|\
 tplink,archer-c20-v5|\
 tplink,tl-wr850n-v2)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -179,6 +179,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
 		;;
+	teltonika,rut9x1|\
 	teltonika,rut9x6)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "4:wan" "6t@eth0"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -179,6 +179,10 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:wan" "1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
 		;;
+	teltonika,rut9x6)
+		ucidef_add_switch "switch0" \
+			"0:lan" "1:lan" "2:lan" "4:wan" "6t@eth0"
+		;;
 	tplink,archer-mr200-v5|\
 	tplink,archer-mr200-v6)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
@@ -15,6 +15,13 @@ teltonika,rut241)
 	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "1"
 	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
 	;;
+teltonika,rut9x1)
+	ucidef_add_gpio_switch "digital_output" "Digital output 1" "digital_output1" "0"
+	ucidef_add_gpio_switch "modem_power" "Modem power button" "modem_power" "1"
+	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
+	ucidef_add_gpio_switch "sim_sel" "SIM select" "sim_sel" "0"
+	ucidef_add_gpio_switch "esim_sel" "eSIM select" "esim_sel" "0"
+	;;
 teltonika,rut9x6)
 	ucidef_add_gpio_switch "digital_output" "Digital output 1" "digital_output1" "0"
 	ucidef_add_gpio_switch "digital_output" "Digital output 2" "digital_output2" "0"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
@@ -15,6 +15,17 @@ teltonika,rut241)
 	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "1"
 	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
 	;;
+teltonika,rut9x6)
+	ucidef_add_gpio_switch "digital_output" "Digital output 1" "digital_output1" "0"
+	ucidef_add_gpio_switch "digital_output" "Digital output 2" "digital_output2" "0"
+	ucidef_add_gpio_switch "rs485_rx_enable" "RS485 RX enable" "rs485_rx_enable" "1"
+	ucidef_add_gpio_switch "rs485_tx_enable" "RS485 TX enable" "rs485_tx_enable" "1"
+	ucidef_add_gpio_switch "modem_power" "Modem power button" "modem_power" "1"
+	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
+	ucidef_add_gpio_switch "sim_sel" "SIM select" "sim_sel" "0"
+	ucidef_add_gpio_switch "esim_sel" "SIM select" "esim_sel" "0"
+	ucidef_add_gpio_switch "relay" "Relay" "relay" "0"
+	;;
 esac
 
 board_config_flush


### PR DESCRIPTION
This pull request add support for RUT9xx series.
The Teltonika RUT9XX series is an industrial mobile router series, it supports WiFi 5, have CAT 4 modem and various I/Os like RS232, RS485.
Base boards are the same just modems and I/O differ depending on model.

Specifications:
- MediaTek MT7628AN SoC
- 128 MB of RAM EtronTech EM68C16CWQG-25IH
- 16MB of Flash Winbond W25Q128 SPI
- 4x 10/100 Mbps Ethernet, with passive PoE support on LAN1
- MediaTek MT7628AN 2.4 GHz 802.11n WiFi
- cat 4 modem
- RS232, DB9 connector, Cypress ACM via USB, /dev/ttyACM0
- RS485 /dev/ttyS1
- microSD card slot
- 2.0 USB Type-A HOST port
- analog 0-24V input (MCP3221)
- Relay
- 2x Digital input
- 2x Digital output
- 2x SIM slot (can be swapped via GPIO)
- eSIM (depends on hardware configuration, can be swapped via GPIO)

Flashing via OEM WebUI:
1. Download the firmware image *-squashfs-factory.bin
2. Upload firmware image via OEM WebUI firmware update, do not keep settings

To revert back to OEM firmware:
https://wiki.teltonika-networks.com/view/Bootloader_menu
