### PR TITLE
[23.05] mbedtls: update to 2.28.10

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=2.28.9
+PKG_VERSION:=2.28.10
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/ARMmbed/mbedtls/tar.gz/v$(PKG_VERSION)?
-PKG_HASH:=e4dbcf86a4fb31506482888560f02b161e0ecfb82fee0643abcfc86abee5817e
+PKG_HASH:=0f2e0525903a89ae1d39ce439d858be66933bda54c5b6102b72a29ed8fe7c088
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=gpl-2.0.txt


### PR DESCRIPTION
This release of Mbed TLS provides bug fixes and minor enhancements. This release includes fixes for security issues.

Mbed TLS 2.28.10 is the last release of the 2.28 LTS and won't receive bug fixes or security fixes anymore. Users are advised to upgrade to a maintained version.

* Potential authentication bypass in TLS handshake [1]
* TLS clients should generally call mbedtls_ssl_set_hostname [2]

[1] https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-2/
[2] https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-03-1/

Full release announcement:
https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-2.28.10
