### PR TITLE
mediatek: filogic: fix for new GL.iNet GL-MT2500/GL-MT2500A hardware revision

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v1.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7981b-glinet-gl-mt2500.dtsi"
+
+&gmac0 {
+	phy-handle = <&phy5>;
+};
+
+&mdio_bus {
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v2.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7981b-glinet-gl-mt2500.dtsi"
+
+&gmac0 {
+	phy-handle = <&phy13>;
+};
+
+&mdio_bus {
+	phy13: ethernet-phy@13 {
+		reg = <13>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dtsi
@@ -108,7 +108,6 @@
 		reg = <0>;
 
 		phy-mode = "2500base-x";
-		phy-handle = <&phy5>;
 	};
 
 	gmac1: mac@1 {
@@ -125,11 +124,6 @@
 	reset-gpios = <&pio 14 GPIO_ACTIVE_LOW>;
 	reset-delay-us = <600>;
 	reset-post-delay-us = <20000>;
-
-	phy5: ethernet-phy@5 {
-		reg = <5>;
-		compatible = "ethernet-phy-ieee802.3-c45";
-	};
 };
 
 &usb_phy {

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -927,15 +927,30 @@ TARGET_DEVICES += gatonetworks_gdsp
 define Device/glinet_gl-mt2500
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MT2500
-  DEVICE_DTS := mt7981b-glinet-gl-mt2500
+  DEVICE_VARIANT := MaxLinear PHY
+  DEVICE_DTS := mt7981b-glinet-gl-mt2500-v1
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTS_LOADADDR := 0x47000000
   DEVICE_PACKAGES := -wpad-basic-mbedtls e2fsprogs f2fsck mkf2fs kmod-usb3
-  SUPPORTED_DEVICES += glinet,mt2500-emmc
+  SUPPORTED_DEVICES += glinet,mt2500-emmc glinet,gl-mt2500-airoha
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
 endef
 TARGET_DEVICES += glinet_gl-mt2500
+
+define Device/glinet_gl-mt2500-airoha
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GL-MT2500
+  DEVICE_VARIANT := Airoha PHY
+  DEVICE_DTS := mt7981b-glinet-gl-mt2500-v2
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  DEVICE_PACKAGES := -wpad-basic-mbedtls e2fsprogs f2fsck mkf2fs kmod-usb3 kmod-phy-airoha-en8811h airoha-en8811h-firmware
+  SUPPORTED_DEVICES += glinet,mt2500-emmc glinet,gl-mt2500
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
+endef
+TARGET_DEVICES += glinet_gl-mt2500-airoha
 
 define Device/glinet_gl-mt3000
   DEVICE_VENDOR := GL.iNet


### PR DESCRIPTION
GL.iNet shipped a hardware change of the WAN PHY going from the MaxLinear GPY211C to the Airoha EN8811H. This surfaced fairly recently at the time of writing with the changes required documented on [GL.iNet's forum](https://forum.gl-inet.com/t/gl-mt2500a-wan-issues-openwrt/57835/2) by a user marked as GL.iNet staff.

In GL.iNet's own OpenWrt fork, they did no DTS change, but they did some change somewhere, likely on the kernel side, because log messages produced by Airoha's driver for the Airoha EN8811H say it uses reg `0xd` for accessing the PHY rather than `0x5` like the DTS states.
```
[    2.812362] Airoha EN8811H mdio-bus:05: PHY(0xd) = 3a2 - a411
[    2.818523] Airoha EN8811H mdio-bus:05: Bootmode: Download Code
[    2.840144] Airoha EN8811H mdio-bus:05: EthMD32.dm.bin: crc32=0x9658cbc2
[    3.100840] Airoha EN8811H mdio-bus:05: EthMD32.DSP.bin: crc32=0xca79d6c4
[    5.269504] Airoha EN8811H mdio-bus:05: EN8811H PHY ready!
[    5.275443] Airoha EN8811H mdio-bus:05: en8811h_of_init: start
[    5.281865] Airoha EN8811H mdio-bus:05: Tx, Rx Polarity : 01a01501
[    5.288234] Airoha EN8811H mdio-bus:05: MD32 FW Version : 24030702
[    5.294404] Airoha EN8811H mdio-bus:05: Surge Protection Mode - 0R
[    5.302788] Airoha EN8811H mdio-bus:05: LED initialize OK !
[    5.308353] Airoha EN8811H mdio-bus:05: EN8811H initialize OK! (v1.2.5)
```

I verified this change makes the WAN port function on this "v2" hardware.

Before change:
```
[   18.215833] mtk_soc_eth 15100000.ethernet eth0: validation of  with support 00,00000000,00000000,00006000 and advertisement 00,00000000,00000000,00000000 failed: -EINVAL
[   18.231136] mtk_soc_eth 15100000.ethernet eth0: mtk_open: could not attach PHY: -22
```

After change:
```
[   21.175497] mtk_soc_eth 15100000.ethernet eth0: PHY [mdio-bus:0d] driver [Airoha EN8811H] (irq=POLL)
[   21.184684] mtk_soc_eth 15100000.ethernet eth0: configuring for phy/2500base-x link mode
```

I am submitting this PR at the request of hecatae over on the [GL-MT2500/GL-MT2500A thread](https://forum.openwrt.org/t/gl-inet-brume-2-gl-mt2500-2500a-discussions/202091/75) on the OpenWrt forum. This is marked as a draft to seek feedback on how to handle the PHY reg address changing between hardware revisions.