### PR TITLE
qualcommax: ipq60xx: unify EAP623 with other EAP6xx variants

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
@@ -7,6 +7,12 @@ touch /etc/config/ubootenv
 
 board=$(board_name)
 
+ubootenv_add_mtd() {
+	local idx="$(find_mtd_index "${1}")"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "${2}" "${3}" "${4}"
+}
+
 case "$board" in
 8devices,mango-dvk|\
 8devices,mango-dvk-sfp|\
@@ -25,7 +31,7 @@ netgear,wax214|\
 netgear,wax610|\
 netgear,wax610y|\
 tplink,eap610-outdoor|\
-tplink,eap623od-hd-v1|\
+tplink,eap623-outdoor-hd-v1|\
 tplink,eap620-hd-v3|\
 tplink,eap625-outdoor-hd-v1)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"

--- a/target/linux/qualcommax/dts/ipq6018-tplink-eap6xx-outdoor.dtsi
+++ b/target/linux/qualcommax/dts/ipq6018-tplink-eap6xx-outdoor.dtsi
@@ -14,9 +14,9 @@
 	aliases {
 		serial0 = &blsp1_uart3;
 		led-boot = &led_sys_green;
-		led-failsafe = &led_sys_amber;
+		led-failsafe = &led_sys_yellow;
 		led-running = &led_sys_green;
-		led-upgrade = &led_sys_amber;
+		led-upgrade = &led_sys_yellow;
 	};
 
 	chosen {
@@ -37,9 +37,9 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_sys_amber: led-0 {
+		led_sys_yellow: led-0 {
 			function = "system";
-			color = <LED_COLOR_ID_AMBER>;
+			color = <LED_COLOR_ID_YELLOW>;
 			gpios = <&tlmm 35 GPIO_ACTIVE_HIGH>;
 		};
 

--- a/target/linux/qualcommax/dts/ipq6018-tplink-eap6xx-outdoor.dtsi
+++ b/target/linux/qualcommax/dts/ipq6018-tplink-eap6xx-outdoor.dtsi
@@ -115,6 +115,8 @@
 
 	rtl8211f_4: ethernet-phy@4 {
 		reg = <4>;
+		realtek,clkout-disable;
+		realtek,aldps-enable;
 	};
 };
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-eap623-outdoor-hd-v1.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-eap623-outdoor-hd-v1.dts
@@ -12,7 +12,7 @@
 
 / {
 	model = "TP-Link EAP623-Outdoor HD V1.0";
-	compatible = "tplink,eap623od-hd-v1", "qcom,ipq6018";
+	compatible = "tplink,eap623-outdoor-hd-v1", "qcom,ipq6018";
 
 	aliases {
 		serial0 = &blsp1_uart3;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-eap623-outdoor-hd-v1.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-eap623-outdoor-hd-v1.dts
@@ -3,145 +3,16 @@
 
 /dts-v1/;
 
-#include "ipq6018.dtsi"
-#include "ipq6018-cp-cpu.dtsi"
-#include "ipq6018-ess.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
+#include "ipq6018-tplink-eap6xx-outdoor.dtsi"
 
 / {
 	model = "TP-Link EAP623-Outdoor HD V1.0";
 	compatible = "tplink,eap623-outdoor-hd-v1", "qcom,ipq6018";
-
-	aliases {
-		serial0 = &blsp1_uart3;
-		led-boot = &led_sys_green;
-		led-failsafe = &led_sys_yellow;
-		led-running = &led_sys_green;
-		led-upgrade = &led_sys_yellow;
-	};
-
-	chosen {
-		stdout-path = "serial0:115200n8";
-		bootargs-append = " root=/dev/ubiblock0_1";
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			gpios = <&tlmm 9 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_sys_green: led-0 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&tlmm 37 GPIO_ACTIVE_HIGH>;
-		};
-
-		led_sys_yellow: led-1 {
-			color = <LED_COLOR_ID_YELLOW>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
-		};
-	};
 };
 
-&blsp1_uart3 {
-	pinctrl-0 = <&serial_3_pins>;
-	pinctrl-names = "default";
-	status = "okay";
-};
-
-&tlmm {
-	mdio_pins: mdio-pins {
-		mdc {
-			pins = "gpio64";
-			function = "mdc";
-			drive-strength = <8>;
-			bias-pull-up;
-		};
-
-		mdio {
-			pins = "gpio65";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-pull-up;
-		};
-	};
-
-	phy_pins: phy-reset-pin {
-		pins = "gpio77";
-		function = "gpio";
-		bias-pull-up;
-	};
-};
-
-&mdio {
-	status = "okay";
-	reset-gpios = <&tlmm 77 GPIO_ACTIVE_LOW>;
-	reset-delay-us = <10000>;
-	reset-post-delay-us = <50000>;
-	pinctrl-0 = <&mdio_pins>, <&phy_pins>;
-	pinctrl-names = "default";
-
-	rtl8211f: ethernet-phy@4 {
-		reg = <4>;
-
-		realtek,clkout-disable;
-		realtek,aldps-enable;
-	};
-};
-
-&switch {
-	status = "okay";
-	switch_lan_bmp = <ESS_PORT5>; /* lan port bitmap */
-	switch_mac_mode1 = <MAC_MODE_SGMII_PLUS>; /* mac mode for uniphy instance0*/
-
-	qcom,port_phyinfo {
-		port@5 {
-			port_id = <5>;
-			phy_address = <4>;
-			port_mac_sel = "QGMAC_PORT";
-		};
-	};
-};
-
-&edma {
-	status = "okay";
-};
-
-&dp5 {
-	status = "okay";
-	phy-handle = <&rtl8211f>;
-	phy-mode = "sgmii";
-	label = "lan";
-};
-
-&qpic_bam {
-	status = "okay";
-};
-
-&qpic_nand {
-	status = "okay";
-
-	nand@0 {
-		reg = <0>;
-		nand-ecc-strength = <4>;
-		nand-ecc-step-size = <512>;
-		nand-bus-width = <8>;
-
-		partitions {
-			compatible = "qcom,smem-part";
-		};
-	};
+&led_sys_yellow {
+		function = LED_FUNCTION_STATUS;
+		gpios = <&tlmm 32 GPIO_ACTIVE_HIGH>;
 };
 
 &wifi {

--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -234,17 +234,22 @@ define Device/qihoo_360v6
 endef
 TARGET_DEVICES += qihoo_360v6
 
-define Device/tplink_eap610-outdoor
+define Device/tplink_eap6xx-common
 	$(call Device/FitImage)
 	$(call Device/UbiFit)
 	DEVICE_VENDOR := TP-Link
-	DEVICE_MODEL := EAP610-Outdoor
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	SOC := ipq6018
-	DEVICE_PACKAGES := ipq-wifi-tplink_eap610-outdoor
+	DEVICE_PACKAGES := kmod-phy-realtek
 	IMAGES += web-ui-factory.bin
 	IMAGE/web-ui-factory.bin := append-ubi | tplink-image-2022
+endef
+
+define Device/tplink_eap610-outdoor
+	$(call Device/tplink_eap6xx-common)
+	DEVICE_MODEL := EAP610-Outdoor
+	DEVICE_PACKAGES += ipq-wifi-tplink_eap610-outdoor
 	TPLINK_SUPPORT_STRING := SupportList:\r\n \
 		EAP610-Outdoor(TP-Link|UN|AX1800-D):1.0\r\n \
 		EAP610-Outdoor(TP-Link|JP|AX1800-D):1.0\r\n \
@@ -253,32 +258,19 @@ endef
 TARGET_DEVICES += tplink_eap610-outdoor
 
 define Device/tplink_eap623-outdoor-hd-v1
-	$(call Device/FitImage)
-	$(call Device/UbiFit)
-	DEVICE_VENDOR := TP-Link
+	$(call Device/tplink_eap6xx-common)
 	DEVICE_MODEL := EAP623-Outdoor HD
 	DEVICE_VARIANT := v1
-	BLOCKSIZE := 128k
-	PAGESIZE := 2048
-	SOC := ipq6018
-	DEVICE_PACKAGES := ipq-wifi-tplink_eap623-outdoor-hd-v1 kmod-phy-realtek
-	IMAGES += web-ui-factory.bin
-	IMAGE/web-ui-factory.bin := append-ubi | tplink-image-2022
+	DEVICE_PACKAGES += ipq-wifi-tplink_eap623-outdoor-hd-v1
 	TPLINK_SUPPORT_STRING := SupportList:\r\nEAP623-Outdoor HD(TP-Link|UN|AX1800-D):1.0\r\n
 endef
 TARGET_DEVICES += tplink_eap623-outdoor-hd-v1
 
 define Device/tplink_eap625-outdoor-hd-v1
-	$(call Device/FitImage)
-	$(call Device/UbiFit)
-	DEVICE_VENDOR := TP-Link
-	DEVICE_MODEL := EAP625-Outdoor HD v1 and v1.6
-	BLOCKSIZE := 128k
-	PAGESIZE := 2048
-	SOC := ipq6018
-	DEVICE_PACKAGES := ipq-wifi-tplink_eap625-outdoor-hd-v1
-	IMAGES += web-ui-factory.bin
-	IMAGE/web-ui-factory.bin := append-ubi | tplink-image-2022
+	$(call Device/tplink_eap6xx-common)
+	DEVICE_MODEL := EAP625-Outdoor HD
+	DEVICE_VARIANT := v1
+	DEVICE_PACKAGES += ipq-wifi-tplink_eap625-outdoor-hd-v1
 	TPLINK_SUPPORT_STRING := SupportList:\r\n \
 		EAP625-Outdoor HD(TP-Link|UN|AX1800-D):1.0\r\n \
 		EAP625-Outdoor HD(TP-Link|CA|AX1800-D):1.0\r\n \

--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -252,7 +252,7 @@ define Device/tplink_eap610-outdoor
 endef
 TARGET_DEVICES += tplink_eap610-outdoor
 
-define Device/tplink_eap623od-hd-v1
+define Device/tplink_eap623-outdoor-hd-v1
 	$(call Device/FitImage)
 	$(call Device/UbiFit)
 	DEVICE_VENDOR := TP-Link
@@ -266,7 +266,7 @@ define Device/tplink_eap623od-hd-v1
 	IMAGE/web-ui-factory.bin := append-ubi | tplink-image-2022
 	TPLINK_SUPPORT_STRING := SupportList:\r\nEAP623-Outdoor HD(TP-Link|UN|AX1800-D):1.0\r\n
 endef
-TARGET_DEVICES += tplink_eap623od-hd-v1
+TARGET_DEVICES += tplink_eap623-outdoor-hd-v1
 
 define Device/tplink_eap625-outdoor-hd-v1
 	$(call Device/FitImage)

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
@@ -41,8 +41,8 @@ ipq60xx_setup_interfaces()
 	netgear,wax610|\
 	netgear,wax610y|\
 	tplink,eap610-outdoor|\
-	tplink,eap623od-hd-v1|\
 	tplink,eap620-hd-v3|\
+	tplink,eap623-outdoor-hd-v1|\
 	tplink,eap625-outdoor-hd-v1)
 		ucidef_set_interface_lan "lan" "dhcp"
 		;;
@@ -70,7 +70,7 @@ ipq60xx_setup_macs()
 		;;
 	tplink,eap610-outdoor|\
 	tplink,eap620-hd-v3|\
-	tplink,eap623od-hd-v1|\
+	tplink,eap623-outdoor-hd-v1|\
 	tplink,eap625-outdoor-hd-v1)
 		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
 		lan_mac=$label_mac

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -70,7 +70,7 @@ case "$FIRMWARE" in
 		ath11k_set_macflag
 		;;
 	tplink,eap610-outdoor|\
-	tplink,eap623od-hd-v1|\
+	tplink,eap623-outdoor-hd-v1|\
 	tplink,eap625-outdoor-hd-v1)
 		caldata_from_file "/tmp/factory_data/radio" 0 0x10000
 		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/preinit/09_mount_factory_data
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/preinit/09_mount_factory_data
@@ -9,7 +9,7 @@ preinit_mount_factory_data() {
 	case $(board_name) in
 	tplink,eap610-outdoor|\
 	tplink,eap620-hd-v3|\
-	tplink,eap623od-hd-v1|\
+	tplink,eap623-outdoor-hd-v1|\
 	tplink,eap625-outdoor-hd-v1)
 		mtd_path=$(find_mtd_chardev "factory_data")
 		ubiattach --dev-path="$mtd_path" --devn=1

--- a/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
@@ -205,7 +205,7 @@ platform_do_upgrade() {
 		;;
 	tplink,eap610-outdoor|\
 	tplink,eap620-hd-v3|\
-	tplink,eap623od-hd-v1|\
+	tplink,eap623-outdoor-hd-v1|\
 	tplink,eap625-outdoor-hd-v1)
 		tplink_do_upgrade "$1"
 		;;


### PR DESCRIPTION
- [x] Confirm PHY ID and max speed for EAP623
- [x] Find if there is a led-enable gpio that should be hogged on EAP623
- [x] Confirm numbering of LED GPIOs on EAP623
- [x] Board data file rename PR: https://github.com/openwrt/firmware_qca-wireless/pull/89

The EAP625 and EAP623 are extremely similar. The only difference in
the vendor's device tree is that EAP625 also enables USB and UART2.

There are some differences remaining. Reflect those in the eap625 dts
until they can be investigated and double-checked.
