### PR TITLE
mac80211: ath9k: replace qca,led-sources

### DIFF
--- a/package/kernel/mac80211/patches/ath9k/550-ath9k-of.patch
+++ b/package/kernel/mac80211/patches/ath9k/550-ath9k-of.patch
@@ -94,22 +94,18 @@
  /**************************/
  /*     Initialization     */
  /**************************/
-@@ -670,6 +750,8 @@ static int ath9k_of_init(struct ath_soft
+@@ -670,6 +750,7 @@ static int ath9k_of_init(struct ath_soft
  	struct ath_common *common = ath9k_hw_common(ah);
  	enum ath_bus_type bus_type = common->bus_ops->ath_bus_type;
  	char eeprom_name[100];
-+	u8 led_pin;
 +	u32 mask;
  	int ret;
  
  	if (!of_device_is_available(np))
-@@ -677,6 +759,49 @@ static int ath9k_of_init(struct ath_soft
+@@ -677,6 +758,46 @@ static int ath9k_of_init(struct ath_soft
  
  	ath_dbg(common, CONFIG, "parsing configuration from OF node\n");
  
-+	if (!of_property_read_u8(np, "qca,led-pin", &led_pin))
-+		ah->led_pin = led_pin;
-+
 +	if (!of_property_read_u32(np, "qca,gpio-mask", &mask))
 +		ah->caps.gpio_mask = mask;
 +
@@ -153,3 +149,21 @@
  	if (of_property_read_bool(np, "qca,no-eeprom")) {
  		/* ath9k-eeprom-<bus>-<id>.bin */
  		scnprintf(eeprom_name, sizeof(eeprom_name),
+@@ -693,6 +814,17 @@ static int ath9k_of_init(struct ath_soft
+ 
+ 	of_get_mac_address(np, common->macaddr);
+ 
++	np = of_get_child_by_name(np, "led");
++	if (np && of_device_is_available(np)) {
++		u32 led_pin;
++
++		if (!of_property_read_u32(np, "led-sources", &led_pin))
++			ah->led_pin = led_pin;
++
++		ah->config.led_active_high = !of_property_read_bool(np, "led-active-low");
++		of_node_put(np);
++	}
++
+ 	return 0;
+ }
+ 

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951ui-2hnd.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951ui-2hnd.dts
@@ -70,5 +70,8 @@
 };
 
 &wmac {
-	qca,led-pin = /bits/ 8 <11>;
+	led {
+		led-sources = <11>;
+		led-active-low;
+	};
 };

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
@@ -349,7 +349,6 @@
 				reg = <0x0000 0 0 0 0>;
 				#gpio-cells = <2>;
 				gpio-controller;
-				qca,led-pin = /bits/ 8 <0>;
 				nvmem-cells = <&cal_caldata_1000>, <&macaddr_uboot_4fc00 0>;
 				nvmem-cell-names = "calibration", "mac-address";
 			};
@@ -380,9 +379,13 @@
 				*/
 				device-id = <0x0030>;
 				class-code = <0x028000>;
-				qca,led-pin = /bits/ 8 <0>;
 				nvmem-cells = <&cal_caldata_5000>, <&macaddr_uboot_4fc00 (-1)>;
 				nvmem-cell-names = "calibration", "mac-address";
+
+				led {
+					led-sources = <0>;
+					led-active-low;
+				};
 			};
 		};
 	};


### PR DESCRIPTION
Upstream seems to be using led-sources instead of custom properties.

Code mostly taken from mt76.

Changed all(few) users of qca,led_pin to use the new format.

ping @kempniu @CHKDSK88 

The way the gpio controller patch is written the led_pin stuff and it are mutually exclusive. I'm guessing the WDR4900 will still operate correctly.