### PR TITLE
imagebuilder: exclude "Default" profile from metadata

### DIFF
--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -441,7 +441,8 @@ sub gen_profile_mk() {
 	my @targets = parse_target_metadata($file);
 	foreach my $cur (@targets) {
 		next unless $cur->{id} eq $target;
-		my @profile_ids_unique =  do { my %seen; grep { !$seen{$_}++} map { $_->{id} } grep { $_->{default} !~ /^n/ } @{$cur->{profiles}}};
+		my @profiles = grep { $_->{id} !~ /^(Default|Generic)$/ and $_->{default} !~ /^n/ } @{$cur->{profiles}};
+		my @profile_ids_unique =  do { my %seen; grep { !$seen{$_}++ } map { $_->{id} } @profiles };
 		print "PROFILE_NAMES = ".join(" ", @profile_ids_unique)."\n";
 		foreach my $profile (@{$cur->{profiles}}) {
 			print $profile->{id}.'_NAME:='.$profile->{name}."\n";


### PR DESCRIPTION
The device profile named "Default" is useless in the imagebuilder and generates errors when attempting to build it.  Exclude these profiles from the imagebuilder, avoiding these errors.

Fixes: https://github.com/openwrt/openwrt/issues/18410