### PR TITLE
mediatek: filogic: fix SPI-NAND driving and increase to 52MHz on ZyXEL EX5601

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -168,7 +168,7 @@
                 #size-cells = <1>;
                 compatible = "spi-nand";
                 reg = <1>;
-                spi-max-frequency = <50000000>;
+                spi-max-frequency = <52000000>;
                 spi-tx-bus-width = <4>;
                 spi-rx-bus-width = <4>;
 
@@ -327,12 +327,12 @@
 		};
 		conf-pu {
 			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
-			drive-strength = <8>;
+			drive-strength = <4>;
 			mediatek,pull-up-adv = <0>;	/* bias-disable */
 		};
 		conf-pd {
 			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
-			drive-strength = <8>;
+			drive-strength = <4>;
 			mediatek,pull-down-adv = <0>;	/* bias-disable */
 		};
 	};


### PR DESCRIPTION
8mA driving will cause overshoot issue on SPI NAND. Change it to 4mA.
- Reference: https://git01.mediatek.com/plugins/gitiles/openwrt/feeds/mtk-openwrt-feeds/+/003744197aa3a587828b4330ab1112ebdb9e840a

On Linux mainline (mt7986.dtsi), spi's source clock is: clocks = <&topckgen CLK_TOP_MPLL_D2>, which is 208MHz. Usable clock division will be:
- 208/4=52MHz
- 208/6~=35MHz
- 208/8=26MHz and so on

If we specify 50MHz for spi-max-frequency, it will actually run under about 35MHz. Most SPI NAND & NOR flashes are capable of running with more than 52MHz, include Micorn MT29F4G01ABAFDWB on ZyXEL EX5601. [Ref: #18752] To reach highest performance on mt7986, use spi-max-frequency = <520000000>. Basically, this setting should work on all mt7986 PCBs since most mt7986 boards follow reference design. However, other boards needs further test to guarantee stability.