### PR TITLE
image: respect DEFAULT:=n when Default profile is selected

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -567,6 +567,13 @@ endef
 
 define Device/Check/Common
   _PROFILE_SET = $$(strip $$(foreach profile,$$(PROFILES) DEVICE_$(1),$$(call DEVICE_CHECK_PROFILE,$$(profile))))
+  # Check if device is disabled and if so do not mark to be installed
+  ifeq ($$(DEFAULT),n)
+    _PROFILE_SET :=
+  endif
+  ifeq ($$(BROKEN),y)
+    _PROFILE_SET :=
+  endif
   DEVICE_PACKAGES += $$(call extra_packages,$$(DEVICE_PACKAGES))
   ifdef TARGET_PER_DEVICE_ROOTFS
     $$(eval $$(call merge_packages,_PACKAGES,$$(DEVICE_PACKAGES) $$(call DEVICE_EXTRA_PACKAGES,$(1))))


### PR DESCRIPTION
Currently, when you select the Default profile it does not honor DEFAULT:=n in device profiles but rather just tries to build all of them.

This may work when building directly, but when using Image Builder it will always fail since no kernel or anything else is present for devices that have DEFAULT:=n set since those are skipped during build.

So, lets look for DEFAULT variable being set and then mark the target for those devices as install-disabled as to not try and install them.

Fixes: #18410 