### PR TITLE
target: introduce default location for external target linux generic

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -187,7 +187,7 @@ define Kernel/CompileImage/Initramfs
 	$(call locked,{ \
 		$(if $(2),$(call Kernel/PrepareConfigPerRootfs,$(LINUX_DIR)$(2));) \
 		$(call Kernel/Configure/Initramfs,$(if $(1),$(1),$(TARGET_DIR)),$(LINUX_DIR)$(2)); \
-		$(CP) $(GENERIC_PLATFORM_DIR)/other-files/init $(if $(1),$(1),$(TARGET_DIR))/init; \
+		$(CP) $(GENERIC_OTHER_FILES_DIR)/init $(if $(1),$(1),$(TARGET_DIR))/init; \
 		$(if $(SOURCE_DATE_EPOCH),touch -hcd "@$(SOURCE_DATE_EPOCH)" $(if $(1),$(1),$(TARGET_DIR)) $(if $(1),$(1),$(TARGET_DIR))/init;) \
 		rm -rf $(LINUX_DIR)$(2)/usr/initramfs_data.cpio*; \
 		$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE), \

--- a/include/target.mk
+++ b/include/target.mk
@@ -155,7 +155,7 @@ ifeq ($(TARGET_BUILD),1)
   endif
 endif
 
-GENERIC_PLATFORM_DIR := $(TOPDIR)/target/linux/generic
+GENERIC_PLATFORM_DIR := $(firstword $(wildcard $(TOPDIR)/target/linux/feeds/$(BOARD)/../linux/generic $(TOPDIR)/target/linux/generic))
 
 ifneq ($(TARGET_BUILD)$(if $(DUMP),,1),)
   include $(INCLUDE_DIR)/kernel-version.mk

--- a/include/target.mk
+++ b/include/target.mk
@@ -165,6 +165,7 @@ GENERIC_BACKPORT_DIR := $(GENERIC_PLATFORM_DIR)/backport$(if $(wildcard $(GENERI
 GENERIC_PATCH_DIR := $(GENERIC_PLATFORM_DIR)/pending$(if $(wildcard $(GENERIC_PLATFORM_DIR)/pending-$(KERNEL_PATCHVER)),-$(KERNEL_PATCHVER))
 GENERIC_HACK_DIR := $(GENERIC_PLATFORM_DIR)/hack$(if $(wildcard $(GENERIC_PLATFORM_DIR)/hack-$(KERNEL_PATCHVER)),-$(KERNEL_PATCHVER))
 GENERIC_FILES_DIR := $(foreach dir,$(wildcard $(GENERIC_PLATFORM_DIR)/files $(GENERIC_PLATFORM_DIR)/files-$(KERNEL_PATCHVER)),"$(dir)")
+GENERIC_OTHER_FILES_DIR := $(TOPDIR)/target/linux/generic/other-files
 
 __config_name_list = $(1)/config-$(KERNEL_PATCHVER) $(1)/config-default
 __config_list = $(firstword $(wildcard $(call __config_name_list,$(1))))

--- a/include/target.mk
+++ b/include/target.mk
@@ -158,6 +158,12 @@ endif
 GENERIC_PLATFORM_DIR := $(firstword $(wildcard $(TOPDIR)/target/linux/feeds/$(BOARD)/../linux/generic $(TOPDIR)/target/linux/generic))
 
 ifneq ($(TARGET_BUILD)$(if $(DUMP),,1),)
+  # On generating the index for an external feed, use the SCAN_DIR path as
+  # the target still needs to be installed (with scripts/feeds install ...)
+  # and the link in target/linux/feeds created.
+  ifneq ($(filter feeds/%,$(SCAN_DIR)),)
+    GENERIC_PLATFORM_DIR := $(firstword $(wildcard $(TOPDIR)/$(SCAN_DIR)/linux/generic $(TOPDIR)/target/linux/generic))
+  endif
   include $(INCLUDE_DIR)/kernel-version.mk
 endif
 


### PR DESCRIPTION
An external target provided by a custom feed might depend on a specific
kernel version and might need to apply generic patches for the specific
kernel version.

Now that the kernel version file is defined in the generic target
director, it's possible to handle this scenario for an external target
from feed.

To do this, we introduce additional logic for GENERIC_PLATFORM_DIR where
we check if the target feed have in his upper directory a linux/generic
path and use that instead of the default TOPLEVEL linux/generic path.

An example for an external target from feed would have the following
path structure:

mediatek/Makefile
linux/generic
linux/generic/config-6.6
...

An external target from feed is also defined by creating a symbolic link
in target/linux/${BOARD} to the feed directory with board as the name of
the external target.

This is to try to enforce a more consistent way to handle external
target in downstream project that makes use of OpenWrt build system.

---

To add more info to this, in also every downstream SDK stuff is included to
OpenWrt with this hack of providing stuff with feeds. Introducing these
kind of change at least improves from their side the situation by forcing
them to use a more organized repository structure.