### PR TITLE
tools: m4: update to 1.4.20

### DIFF
--- a/tools/m4/Makefile
+++ b/tools/m4/Makefile
@@ -8,17 +8,16 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=m4
 PKG_CPE_ID:=cpe:/a:gnu:m4
-PKG_VERSION:=1.4.19
+PKG_VERSION:=1.4.20
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)
-PKG_HASH:=3be4a26d825ffdfda52a56fc43246456989a3630093cced3fbddf4771ee58a70
+PKG_HASH:=6ac4fc31ce440debe63987c2ebbf9d7b6634e67a7c3279257dc7361de8bdb3ef
 
 HOST_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/host-build.mk
 
-HOST_CFLAGS += -std=gnu17
 HOST_CONFIGURE_VARS += gl_cv_func_strstr_linear=no
 
 define Host/Uninstall


### PR DESCRIPTION
New m4 release was made after a long time, for us most importantly it ships newer gnulib so it compiles against GCC15 without forcing GNU17.

```
* Noteworthy changes in release 1.4.20 (2025-05-10) [stable]

** Fix a bug in the `eval' builtin where it does not suppress warnings
   about division by zero that occurs within a more complex expression on
   the right hand side of || or && (present since short-circuiting was
   introduced in 1.4.8b).

** The `syscmd' and `esyscmd' builtins no longer mishandle a command line
   starting with `-' or `+' (present since "the beginning").

** Fix regression introduced in 1.4.19 where trace output (such as with
   `debugmode(t)') could read invalid memory when tracing a series of
   pushed macros that are popped during argument collection.

** Fix regression introduced in 1.4.19 where the `format' builtin
   inadvertently took on locale-dependent parsing and output of floating
   point numbers as a side-effect of introducing message translations.
   While it would be nice for m4 to be fully locale-aware, such a behavior
   change belongs in a major version release such as 1.6, and not a minor
   release.

** Fix regression introduced in 1.4.11 where the experimental `changeword'
   builtin could cause a crash if given a regex that does not match all
   one-byte prefixes of valid longer matches.  As a reminder, `changeword'
   is not recommended for production use, and will likely not be present
   in the next major version release.

** On non-Unix platforms where binary files differ from text, loading a
   frozen file (which should be cross-platform compatible) now correctly
   uses binary mode.

** Several documentation improvements to the manual.

** Update to comply with newer C standards, and inherit portability
   improvements from gnulib.
```
