### PR TITLE
realtek: fix mdio parent/child locking issues

### DIFF
--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1081,7 +1081,7 @@ struct rtl838x_switch_priv {
 	struct mutex pie_mutex;		/* Mutex for Packet Inspection Engine */
 	int link_state_irq;
 	int mirror_group_ports[4];
-	struct mii_bus *mii_bus;
+	struct mii_bus *parent_bus;
 	const struct rtl838x_reg *r;
 	u8 cpu_port;
 	u8 port_mask;


### PR DESCRIPTION
Since the early beginning of the Realtek DSA driver we have an uncovered locking issue between the standard (parent) mdio bus and the DSA (child) mdio bus. This comes from the fact that the DSA bus simply links to the parent read and write functions and calls them directly. This leads to the following lock issue.

- Child bus calls phy_read/write functions and uses its internal lock
- Parent bus calls phy_read/write functions and uses its internal lock

It becomes clear that critical section can be accessed twice without knowing that a operation from the other bus is currently active. This can lead to critical malfunctions because the mdio driver needs a lot of internal magic to get page selection done right. Effects are:

- The original page is lost after a phy_write/read_paged() call
- dmesg like "Realtek RTL8218B (external) rtl838x slave mii-0:00: Expected external RTL8218B, found PHY-ID 6b23"

Other DSA drivers simply use the read/write functions from the parent bus and thus avoid locking issues. Do it the same way.

Fixes: 2b88563ee5aafd9 ("realtek: update the tree to the latest refactored version")

How to test:

- Generally check if DSA driver initializes properly (no dmesg errors) and switching works  
- Especially on rtl838x check if messages "Realtek RTL8218B (external) rtl838x slave mii-0:00: Expected external RTL8218B, found PHY-ID 6b23" disappear

