### PR TITLE
ramips: mt7621: fix broken hexdump expression in iodata.sh

### DIFF
--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/iodata.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/iodata.sh
@@ -20,7 +20,7 @@ iodata_mstc_rw_byte() {
 	local mtd="$1"
 	local offset="$2"
 	local setval="$3"
-	local _val=$(hexdump -s $offset -n 1 -e '"%d"' $mtd)
+	local _val=$(hexdump -s $offset -n 1 -e '1/1 "%d"' $mtd)
 
 	if [ -z "$setval" ]; then
 		echo $_val


### PR DESCRIPTION
Use the "1/1" as a iteration count of hexdump expression instead of the broken "1", to fix the issue that the invalid bootnum will be obtained.

Currently, the hexdump command always outputs "0" when the decimal format and the iteration count "1" are specified [[0]]. This is unexpected behaviour, but the cause is unknown and use this fix as a workaround.

[0]: https://github.com/openwrt/openwrt/issues/18808
