### PR TITLE
mips: ralink: add missing include

### DIFF
--- a/target/linux/generic/hack-6.12/931-mips-ralink-add-missing-include.patch
+++ b/target/linux/generic/hack-6.12/931-mips-ralink-add-missing-include.patch
@@ -1,0 +1,25 @@
+From: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Date: Mon, 18 Nov 2024 21:28:05 +0100
+Subject: mips: ralink: add missing include
+
+Missing headers causes an error on kernel 6.12:
+arch/mips/ralink/irq.c:86:5: error: no previous prototype for 'get_c0_perfcount_int' [-Werror=missing-prototypes]
+   86 | int get_c0_perfcount_int(void)
+      |     ^~~~~~~~~~~~~~~~~~~~
+arch/mips/ralink/irq.c:92:14: error: no previous prototype for 'get_c0_compare_int' [-Werror=missing-prototypes]
+   92 | unsigned int get_c0_compare_int(void)
+      |              ^~~~~~~~~~~~~~~~~~
+cc1: all warnings being treated as errors
+
+Signed-off-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+---
+--- a/arch/mips/ralink/irq.c
++++ b/arch/mips/ralink/irq.c
+@@ -15,6 +15,7 @@
+ 
+ #include <asm/irq_cpu.h>
+ #include <asm/mipsregs.h>
++#include <asm/time.h>
+ 
+ #include "common.h"
+ 


### PR DESCRIPTION
Missing headers causes an error on kernel 6.12:
```
arch/mips/ralink/irq.c:86:5: error: no previous prototype for 'get_c0_perfcount_int' [-Werror=missing-prototypes]
   86 | int get_c0_perfcount_int(void)
      |     ^~~~~~~~~~~~~~~~~~~~
arch/mips/ralink/irq.c:92:14: error: no previous prototype for 'get_c0_compare_int' [-Werror=missing-prototypes]
   92 | unsigned int get_c0_compare_int(void)
      |              ^~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```