### PR TITLE
generic: refresh patches

### DIFF
--- a/target/linux/generic/backport-6.6/806-03-v6.12-xhci-pci-Make-xhci-pci-renesas-a-proper-modular-driver.patch
+++ b/target/linux/generic/backport-6.6/806-03-v6.12-xhci-pci-Make-xhci-pci-renesas-a-proper-modular-driver.patch
@@ -271,7 +271,7 @@ Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
  #endif
 --- a/drivers/usb/host/xhci.h
 +++ b/drivers/usb/host/xhci.h
-@@ -1648,7 +1648,7 @@ struct xhci_hcd {
+@@ -1645,7 +1645,7 @@ struct xhci_hcd {
  #define XHCI_DEFAULT_PM_RUNTIME_ALLOW	BIT_ULL(33)
  #define XHCI_RESET_PLL_ON_DISCONNECT	BIT_ULL(34)
  #define XHCI_SNPS_BROKEN_SUSPEND    BIT_ULL(35)


### PR DESCRIPTION
Made: 'make target/linux/refresh'

Fixes: fbd31da8402e ("generic: make xhci-pci-renesas a proper modular driver")