### PR TITLE
uboot-bcm4908: fix build with GCC14

### DIFF
--- a/include/u-boot.mk
+++ b/include/u-boot.mk
@@ -78,6 +78,7 @@ UBOOT_MAKE_FLAGS = \
 	PKG_CONFIG_PATH="$(STAGING_DIR_HOST)/lib/pkgconfig" \
 	PKG_CONFIG_LIBDIR="$(STAGING_DIR_HOST)/lib/pkgconfig" \
 	PKG_CONFIG_EXTRAARGS="--static" \
+	$(if $(KBUILD_CFLAGS),KCFLAGS="$(KBUILD_CFLAGS)") \
 	$(if $(findstring c,$(OPENWRT_VERBOSE)),V=1,V='')
 
 define Build/U-Boot/Target

--- a/package/boot/uboot-bcm4908/Makefile
+++ b/package/boot/uboot-bcm4908/Makefile
@@ -32,6 +32,12 @@ define U-Boot/bcm4912
   SOC:=bcm4912
 endef
 
+KBUILD_CFLAGS := \
+	-Wno-error=implicit-function-declaration \
+	-Wno-error=implicit-int \
+	-Wno-error=incompatible-pointer-types \
+	-Wno-error=int-conversion
+
 UBOOT_TARGETS := \
 	bcm4908 \
 	bcm4912


### PR DESCRIPTION
A lot of warnings were treated as errors after the default compiler switched to GCC14. It's hard to fix them one by one, and this u-boot is not maintained by upstream, so let's just silence these warnings.

The bcm4908 target has been broken for several weeks, it's time to fix it.
ref:
https://buildbot.openwrt.org/images/#/builders/234
https://github.com/u-boot/u-boot/blob/126a88d49bcae04bbfc0d6723097cd6341355ade/README#L1572-L1577