### PR TITLE
qualcommax: TP-Link EAP620HD fix factory data mount script

### DIFF
--- a/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/preinit/09_mount_factory_data
@@ -24,7 +24,7 @@ preinit_mount_factory_partitions() {
 		;;
 	tplink,eap620hd-v1|\
 	tplink,eap660hd-v1)
-		preinit_mount_factory_data "tp_data"
+		preinit_mount_factory_data "factory_data"
 		;;
 	esac
 }


### PR DESCRIPTION
The re-factoring of the preinit factory partition mount script [6180724](https://github.com/openwrt/openwrt/commit/6180724737d936542102dc6e1b8186dd287411fb) used the incorrect mtd name for the EAP620HD and (I assume incorrect) for EAP660HD. This corrects it to "factory_data".
