### PR TITLE
ramips: fix wrg-header image recipe

### DIFF
--- a/target/linux/ramips/image/Makefile
+++ b/target/linux/ramips/image/Makefile
@@ -163,7 +163,8 @@ define Build/umedia-header
 endef
 
 define Build/wrg-header
-	mkwrgimg -i $@ -d "/dev/mtdblock/2" -s $(1) -o $@.new
+	-[ -f "$@" ] && \
+	mkwrgimg -i $@ -d "/dev/mtdblock/2" -s $(1) -o $@.new && \
 	mv $@.new $@
 endef
 


### PR DESCRIPTION
Before generating the factory image, check if the input file exists. Fix the build error when sysupgrade image is too big:

`[mkwrgimg] *** error: stat failed on /builder/shared-workdir/build/build_dir/target-mipsel_24kc_musl/linux-ramips_rt288x/tmp/openwrt-ramips-rt288x-airlink101_ar670w-squashfs-factory.bin, No such file or directory`
