### PR TITLE
lantiq: fix some dtc warnings

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse.dtsi
@@ -163,7 +163,7 @@
 				};
 			};
 
-			spi_pins: spi {
+			spi_pins: spi-pins {
 				mux-0 {
 					lantiq,groups = "spi_di";
 					lantiq,function = "spi";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
@@ -283,7 +283,7 @@
 				};
 			};
 
-			spi_pins: spi {
+			spi_pins: spi-pins {
 				mux-0 {
 					lantiq,groups = "spi_di";
 					lantiq,function = "spi";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw22.dts
@@ -262,7 +262,7 @@
 		nvmem-cell-names = "eeprom", "mac-address";
 	};
 
-	usb@0f,0 {
+	usb@f,0 {
 		#address-cells = <1>;
 		#size-cells = <0>;
 		compatible = "pci1106,3038";
@@ -274,7 +274,7 @@
 		};
 	};
 
-	usb@0f,2 {
+	usb@f,2 {
 		#address-cells = <1>;
 		#size-cells = <0>;
 		compatible = "pci1106,3038";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
@@ -323,7 +323,7 @@
 				};
 			};
 
-			spi_pins: spi {
+			spi_pins: spi-pins {
 				mux-0 {
 					lantiq,groups = "spi_di";
 					lantiq,function = "spi";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz3390.dts
@@ -288,8 +288,8 @@
 	pcie@0 {
 		reg = <0 0 0 0 0>;
 		#interrupt-cells = <1>;
-		#size-cells = <1>;
-		#address-cells = <2>;
+		#address-cells = <3>;
+		#size-cells = <2>;
 		device_type = "pci";
 
 		wifi@0,0 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
@@ -106,11 +106,6 @@
 
 &pcie0 {
 	gpio-reset = <&gpio 21 GPIO_ACTIVE_LOW>;
-
-	pcie@0 {
-		#size-cells = <1>;
-		#address-cells = <2>;
-	};
 };
 
 &eth0 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
@@ -161,8 +161,8 @@
 	pcie@0 {
 		reg = <0 0 0 0 0>;
 		#interrupt-cells = <1>;
-		#size-cells = <1>;
-		#address-cells = <2>;
+		#address-cells = <3>;
+		#size-cells = <2>;
 		device_type = "pci";
 
 		wifi: wifi@0,0 {


### PR DESCRIPTION
This is a part of https://github.com/openwrt/openwrt/pull/18242. The original patch is a bit complicated so I split it into some small commits according to the warning type.