### PR TITLE
[pre-6.12] realtek: refactor RTL838x mdio serdes read/write functions

### DIFF
--- a/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.c
@@ -422,22 +422,6 @@ int rtl931x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v)
 	return 0;
 }
 
-/* On the RTL838x SoCs, the internal SerDes is accessed through direct access to
- * standard PHY registers, where a 32 bit register holds a 16 bit word as found
- * in a standard page 0 of a PHY
- */
-int rtl838x_read_sds_phy(int phy_addr, int phy_reg)
-{
-	int offset = 0;
-	u32 val;
-
-	if (phy_addr == 26)
-		offset = 0x100;
-	val = sw_r32(RTL838X_SDS4_FIB_REG0 + offset + (phy_reg << 2)) & 0xffff;
-
-	return val;
-}
-
 int rtl839x_write_sds_phy(int phy_addr, int phy_reg, u16 v)
 {
 	int offset = 0;


### PR DESCRIPTION
There are still a lot of mdio functions scattered around the code. Move the RTL838x serdes helpers closer to the bus, add the proper prefix and simplify the functions.

How to test:

- you mast have a **RTL838X** device with internal SFP ports (no RTL8214FC or so)
- check if fibre functionality works as before (ping, ethtool, ...)