### PR TITLE
toolchain: glibc: set min kernel version to 6.6

### DIFF
--- a/toolchain/glibc/common.mk
+++ b/toolchain/glibc/common.mk
@@ -69,7 +69,7 @@ GLIBC_CONFIGURE:= \
 		  $(if $(CONFIG_PKG_RELRO_FULL),--enable-bind-now) \
 		  $(if $(CONFIG_PKG_FORTIFY_SOURCE_1),--enable-fortify-source=1) \
 		  $(if $(CONFIG_PKG_FORTIFY_SOURCE_2),--enable-fortify-source=2) \
-		--enable-kernel=5.15.0
+		--enable-kernel=6.6.0
 
 export libc_cv_ssp=no
 export libc_cv_ssp_strong=no


### PR DESCRIPTION
Minimum kernel version is 6.6 so it's safe to increase minimum kernel version to 6.6 for glibc too.

This change effectively removes last compatibility quirk in [1] which leads to better/faster detection of SVE support in string ifuncs for aarch64.

Furthermore, this change will allow to use "fchmodat2" syscall within fchmodat() wrapper in future glibc versions (starting from 2.39) as noted in [2] and [3].

[1] https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/aarch64/cpu-features.c;h=4a205a6b35050ffcfac771b4b4ff2d9fb7581f93;hb=refs/heads/release/2.38/master
[2] https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/kernel-features.h;h=86b2d3ce512588c8823c11076c91116092836402;hb=refs/heads/release/2.41/master
[3] https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/fchmodat.c;h=dd1fa5db86bde99fe3eb4804b06c5adf11914b94;hb=refs/heads/release/2.41/master