### PR TITLE
mvebu: armada37xx: fix I2C recovery support

### DIFF
--- a/target/linux/mvebu/patches-6.6/0001-v6.16-pinctrl-armada-37xx-use-correct-OUTPUT_VAL-register-.patch
+++ b/target/linux/mvebu/patches-6.6/0001-v6.16-pinctrl-armada-37xx-use-correct-OUTPUT_VAL-register-.patch
@@ -1,0 +1,44 @@
+From 947c93eb29c2a581c0b0b6d5f21af3c2b7ff6d25 Mon Sep 17 00:00:00 2001
+From: Gabor Juhos <j4g8y7@gmail.com>
+Date: Wed, 14 May 2025 21:18:32 +0200
+Subject: [PATCH 1/7] pinctrl: armada-37xx: use correct OUTPUT_VAL register for
+ GPIOs > 31
+
+The controller has two consecutive OUTPUT_VAL registers and both
+holds output value for 32 GPIOs. Due to a missing adjustment, the
+current code always uses the first register while setting the
+output value whereas it should use the second one for GPIOs > 31.
+
+Add the missing armada_37xx_update_reg() call to adjust the register
+according to the 'offset' parameter of the function to fix the issue.
+
+Cc: stable@vger.kernel.org
+Fixes: 6702abb3bf23 ("pinctrl: armada-37xx: Fix direction_output() callback behavior")
+Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Gabor Juhos <j4g8y7@gmail.com>
+Link: https://lore.kernel.org/20250514-pinctrl-a37xx-fixes-v2-1-07e9ac1ab737@gmail.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/mvebu/pinctrl-armada-37xx.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
++++ b/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
+@@ -417,6 +417,7 @@ static int armada_37xx_gpio_direction_ou
+ 					     unsigned int offset, int value)
+ {
+ 	struct armada_37xx_pinctrl *info = gpiochip_get_data(chip);
++	unsigned int val_offset = offset;
+ 	unsigned int reg = OUTPUT_EN;
+ 	unsigned int mask, val, ret;
+ 
+@@ -429,6 +430,8 @@ static int armada_37xx_gpio_direction_ou
+ 		return ret;
+ 
+ 	reg = OUTPUT_VAL;
++	armada_37xx_update_reg(&reg, &val_offset);
++
+ 	val = value ? mask : 0;
+ 	regmap_update_bits(info->regmap, reg, mask, val);
+ 

--- a/target/linux/mvebu/patches-6.6/0002-v6.16-pinctrl-armada-37xx-set-GPIO-output-value-before-set.patch
+++ b/target/linux/mvebu/patches-6.6/0002-v6.16-pinctrl-armada-37xx-set-GPIO-output-value-before-set.patch
@@ -1,0 +1,58 @@
+From e6ebd4942981f8ad37189bbb36a3c8495e21ef4c Mon Sep 17 00:00:00 2001
+From: Gabor Juhos <j4g8y7@gmail.com>
+Date: Wed, 14 May 2025 21:18:33 +0200
+Subject: [PATCH 2/7] pinctrl: armada-37xx: set GPIO output value before
+ setting direction
+
+Changing the direction before updating the output value in the
+OUTPUT_VAL register may result in a glitch on the output line
+if the previous value in the OUTPUT_VAL register is different
+from the one we want to set.
+
+In order to avoid that, update the output value before changing
+the direction.
+
+Cc: stable@vger.kernel.org
+Fixes: 6702abb3bf23 ("pinctrl: armada-37xx: Fix direction_output() callback behavior")
+Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Gabor Juhos <j4g8y7@gmail.com>
+Link: https://lore.kernel.org/20250514-pinctrl-a37xx-fixes-v2-2-07e9ac1ab737@gmail.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/mvebu/pinctrl-armada-37xx.c | 15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+--- a/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
++++ b/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
+@@ -417,23 +417,22 @@ static int armada_37xx_gpio_direction_ou
+ 					     unsigned int offset, int value)
+ {
+ 	struct armada_37xx_pinctrl *info = gpiochip_get_data(chip);
+-	unsigned int val_offset = offset;
+-	unsigned int reg = OUTPUT_EN;
++	unsigned int en_offset = offset;
++	unsigned int reg = OUTPUT_VAL;
+ 	unsigned int mask, val, ret;
+ 
+ 	armada_37xx_update_reg(&reg, &offset);
+ 	mask = BIT(offset);
++	val = value ? mask : 0;
+ 
+-	ret = regmap_update_bits(info->regmap, reg, mask, mask);
+-
++	ret = regmap_update_bits(info->regmap, reg, mask, val);
+ 	if (ret)
+ 		return ret;
+ 
+-	reg = OUTPUT_VAL;
+-	armada_37xx_update_reg(&reg, &val_offset);
++	reg = OUTPUT_EN;
++	armada_37xx_update_reg(&reg, &en_offset);
+ 
+-	val = value ? mask : 0;
+-	regmap_update_bits(info->regmap, reg, mask, val);
++	regmap_update_bits(info->regmap, reg, mask, mask);
+ 
+ 	return 0;
+ }

--- a/target/linux/mvebu/patches-6.6/0003-v6.16-pinctrl-armada-37xx-propagate-error-from-armada_37xx.patch
+++ b/target/linux/mvebu/patches-6.6/0003-v6.16-pinctrl-armada-37xx-propagate-error-from-armada_37xx.patch
@@ -1,0 +1,31 @@
+From 0396a8731efd17aec4719ad9981fefeaa13ffa56 Mon Sep 17 00:00:00 2001
+From: Gabor Juhos <j4g8y7@gmail.com>
+Date: Wed, 14 May 2025 21:18:34 +0200
+Subject: [PATCH 3/7] pinctrl: armada-37xx: propagate error from
+ armada_37xx_gpio_direction_output()
+
+The regmap_update_bits() function can fail, so propagate its error
+up to the stack instead of silently ignoring that.
+
+Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Gabor Juhos <j4g8y7@gmail.com>
+Link: https://lore.kernel.org/20250514-pinctrl-a37xx-fixes-v2-3-07e9ac1ab737@gmail.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/mvebu/pinctrl-armada-37xx.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+--- a/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
++++ b/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
+@@ -432,9 +432,7 @@ static int armada_37xx_gpio_direction_ou
+ 	reg = OUTPUT_EN;
+ 	armada_37xx_update_reg(&reg, &en_offset);
+ 
+-	regmap_update_bits(info->regmap, reg, mask, mask);
+-
+-	return 0;
++	return regmap_update_bits(info->regmap, reg, mask, mask);
+ }
+ 
+ static int armada_37xx_gpio_get(struct gpio_chip *chip, unsigned int offset)

--- a/target/linux/mvebu/patches-6.6/0004-v6.16-pinctrl-armada-37xx-propagate-error-from-armada_37xx.patch
+++ b/target/linux/mvebu/patches-6.6/0004-v6.16-pinctrl-armada-37xx-propagate-error-from-armada_37xx.patch
@@ -1,0 +1,36 @@
+From 57273ff8bb16f3842c2597b5bbcd49e7fa12edf7 Mon Sep 17 00:00:00 2001
+From: Gabor Juhos <j4g8y7@gmail.com>
+Date: Wed, 14 May 2025 21:18:35 +0200
+Subject: [PATCH 4/7] pinctrl: armada-37xx: propagate error from
+ armada_37xx_gpio_get()
+
+The regmap_read() function can fail, so propagate its error up to
+the stack instead of silently ignoring that.
+
+Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Gabor Juhos <j4g8y7@gmail.com>
+Link: https://lore.kernel.org/20250514-pinctrl-a37xx-fixes-v2-4-07e9ac1ab737@gmail.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/mvebu/pinctrl-armada-37xx.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
++++ b/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
+@@ -440,11 +440,14 @@ static int armada_37xx_gpio_get(struct g
+ 	struct armada_37xx_pinctrl *info = gpiochip_get_data(chip);
+ 	unsigned int reg = INPUT_VAL;
+ 	unsigned int val, mask;
++	int ret;
+ 
+ 	armada_37xx_update_reg(&reg, &offset);
+ 	mask = BIT(offset);
+ 
+-	regmap_read(info->regmap, reg, &val);
++	ret = regmap_read(info->regmap, reg, &val);
++	if (ret)
++		return ret;
+ 
+ 	return (val & mask) != 0;
+ }

--- a/target/linux/mvebu/patches-6.6/0005-v6.16-pinctrl-armada-37xx-propagate-error-from-armada_37xx.patch
+++ b/target/linux/mvebu/patches-6.6/0005-v6.16-pinctrl-armada-37xx-propagate-error-from-armada_37xx.patch
@@ -1,0 +1,42 @@
+From bfa0ff804ffa8b1246ade8be08de98c9eb19d16f Mon Sep 17 00:00:00 2001
+From: Gabor Juhos <j4g8y7@gmail.com>
+Date: Wed, 14 May 2025 21:18:36 +0200
+Subject: [PATCH 5/7] pinctrl: armada-37xx: propagate error from
+ armada_37xx_pmx_gpio_set_direction()
+
+The armada_37xx_gpio_direction_{in,out}put() functions can fail, so
+propagate their error values back to the stack instead of silently
+ignoring those.
+
+Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Gabor Juhos <j4g8y7@gmail.com>
+Link: https://lore.kernel.org/20250514-pinctrl-a37xx-fixes-v2-5-07e9ac1ab737@gmail.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/mvebu/pinctrl-armada-37xx.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+--- a/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
++++ b/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
+@@ -472,16 +472,17 @@ static int armada_37xx_pmx_gpio_set_dire
+ {
+ 	struct armada_37xx_pinctrl *info = pinctrl_dev_get_drvdata(pctldev);
+ 	struct gpio_chip *chip = range->gc;
++	int ret;
+ 
+ 	dev_dbg(info->dev, "gpio_direction for pin %u as %s-%d to %s\n",
+ 		offset, range->name, offset, input ? "input" : "output");
+ 
+ 	if (input)
+-		armada_37xx_gpio_direction_input(chip, offset);
++		ret = armada_37xx_gpio_direction_input(chip, offset);
+ 	else
+-		armada_37xx_gpio_direction_output(chip, offset, 0);
++		ret = armada_37xx_gpio_direction_output(chip, offset, 0);
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ static int armada_37xx_gpio_request_enable(struct pinctrl_dev *pctldev,

--- a/target/linux/mvebu/patches-6.6/0006-v6.16-pinctrl-armada-37xx-propagate-error-from-armada_37xx.patch
+++ b/target/linux/mvebu/patches-6.6/0006-v6.16-pinctrl-armada-37xx-propagate-error-from-armada_37xx.patch
@@ -1,0 +1,35 @@
+From 6481c0a83367b0672951ccc876fbae7ee37b594b Mon Sep 17 00:00:00 2001
+From: Gabor Juhos <j4g8y7@gmail.com>
+Date: Wed, 14 May 2025 21:18:37 +0200
+Subject: [PATCH 6/7] pinctrl: armada-37xx: propagate error from
+ armada_37xx_gpio_get_direction()
+
+The regmap_read() function can fail, so propagate its error up to
+the stack instead of silently ignoring that.
+
+Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Gabor Juhos <j4g8y7@gmail.com>
+Link: https://lore.kernel.org/20250514-pinctrl-a37xx-fixes-v2-6-07e9ac1ab737@gmail.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/mvebu/pinctrl-armada-37xx.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+--- a/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
++++ b/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
+@@ -402,10 +402,13 @@ static int armada_37xx_gpio_get_directio
+ 	struct armada_37xx_pinctrl *info = gpiochip_get_data(chip);
+ 	unsigned int reg = OUTPUT_EN;
+ 	unsigned int val, mask;
++	int ret;
+ 
+ 	armada_37xx_update_reg(&reg, &offset);
+ 	mask = BIT(offset);
+-	regmap_read(info->regmap, reg, &val);
++	ret = regmap_read(info->regmap, reg, &val);
++	if (ret)
++		return ret;
+ 
+ 	if (val & mask)
+ 		return GPIO_LINE_DIRECTION_OUT;

--- a/target/linux/mvebu/patches-6.6/0007-v6.16-pinctrl-armada-37xx-propagate-error-from-armada_37xx.patch
+++ b/target/linux/mvebu/patches-6.6/0007-v6.16-pinctrl-armada-37xx-propagate-error-from-armada_37xx.patch
@@ -1,0 +1,31 @@
+From 4229c28323db141eda69cb99427be75d3edba071 Mon Sep 17 00:00:00 2001
+From: Gabor Juhos <j4g8y7@gmail.com>
+Date: Wed, 14 May 2025 21:18:38 +0200
+Subject: [PATCH 7/7] pinctrl: armada-37xx: propagate error from
+ armada_37xx_pmx_set_by_name()
+
+The regmap_update_bits() function can fail, so propagate its error
+up to the stack instead of silently ignoring that.
+
+Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Signed-off-by: Gabor Juhos <j4g8y7@gmail.com>
+Link: https://lore.kernel.org/20250514-pinctrl-a37xx-fixes-v2-7-07e9ac1ab737@gmail.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/mvebu/pinctrl-armada-37xx.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+--- a/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
++++ b/drivers/pinctrl/mvebu/pinctrl-armada-37xx.c
+@@ -358,9 +358,7 @@ static int armada_37xx_pmx_set_by_name(s
+ 
+ 	val = grp->val[func];
+ 
+-	regmap_update_bits(info->regmap, reg, mask, val);
+-
+-	return 0;
++	return regmap_update_bits(info->regmap, reg, mask, val);
+ }
+ 
+ static int armada_37xx_pmx_set(struct pinctrl_dev *pctldev,

--- a/target/linux/mvebu/patches-6.6/830-01-i2c-add-init_recovery-callback.patch
+++ b/target/linux/mvebu/patches-6.6/830-01-i2c-add-init_recovery-callback.patch
@@ -1,0 +1,189 @@
+From patchwork Sun May 11 13:31:05 2025
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Gabor Juhos <j4g8y7@gmail.com>
+X-Patchwork-Id: 14084055
+Return-Path: 
+ <linux-arm-kernel-bounces+linux-arm-kernel=archiver.kernel.org@lists.infradead.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+Received: from bombadil.infradead.org (bombadil.infradead.org
+ [198.137.202.133])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+	(No client certificate requested)
+	by smtp.lore.kernel.org (Postfix) with ESMTPS id 0802BC3ABC3
+	for <linux-arm-kernel@archiver.kernel.org>;
+ Sun, 11 May 2025 13:35:46 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/relaxed;
+	d=lists.infradead.org; s=bombadil.20210309; h=Sender:List-Subscribe:List-Help
+	:List-Post:List-Archive:List-Unsubscribe:List-Id:Cc:To:In-Reply-To:References
+	:Message-Id:Content-Transfer-Encoding:Content-Type:MIME-Version:Subject:Date:
+	From:Reply-To:Content-ID:Content-Description:Resent-Date:Resent-From:
+	Resent-Sender:Resent-To:Resent-Cc:Resent-Message-ID:List-Owner;
+	bh=n9RYlne5nhTN7kCu5Yc7zW4CF0YUJUWg2clQo/viA0M=; b=LBsqIvaHPjMCwZZfbGyry56BIg
+	sEpAZY6rWjqf0DWQjODfNe8G8EZOzfHbMRA8HElCRdUR54+uQkesdQ9CuQip0FUIEkRlfRHM8HYTB
+	iWLgZE6pnElndi/4uhAmfvgQFvMbDhxrsoAqAjLY4K+sPr53QSEGO7ygY+TPHmcpyVfD+kRqjMAv3
+	wbypdxFC5lHAOvIiAdaKreajEf7HBqztprh/D1aE29TQdWILixJTAl5isgLzJyZUOEnqrefGvBQ9g
+	+zg0jQwLLnjnsCMzkjho6mjwi1Q7I3ERQVRnebKf9eslmNstr9apYy5yfz6BKzHGxBk3yC+Boyvde
+	FP62KNGQ==;
+Received: from localhost ([::1] helo=bombadil.infradead.org)
+	by bombadil.infradead.org with esmtp (Exim 4.98.2 #2 (Red Hat Linux))
+	id 1uE6qC-00000007Glw-1vse;
+	Sun, 11 May 2025 13:35:40 +0000
+Received: from mail-ej1-x630.google.com ([2a00:1450:4864:20::630])
+	by bombadil.infradead.org with esmtps (Exim 4.98.2 #2 (Red Hat Linux))
+	id 1uE6mD-00000007GP8-397T
+	for linux-arm-kernel@lists.infradead.org;
+	Sun, 11 May 2025 13:31:34 +0000
+Received: by mail-ej1-x630.google.com with SMTP id
+ a640c23a62f3a-ad1f6aa2f84so764633466b.0
+        for <linux-arm-kernel@lists.infradead.org>;
+ Sun, 11 May 2025 06:31:33 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20230601; t=1746970292; x=1747575092;
+ darn=lists.infradead.org;
+        h=cc:to:in-reply-to:references:message-id:content-transfer-encoding
+         :mime-version:subject:date:from:from:to:cc:subject:date:message-id
+         :reply-to;
+        bh=n9RYlne5nhTN7kCu5Yc7zW4CF0YUJUWg2clQo/viA0M=;
+        b=mK6aKMspWjttCQGv7A/DF5F1n7JFLuDEaCeCKlEp4FrClZQD6JhAlON6yEPPTc86q2
+         XnRAAh8tIk3Gu/QyNYXIsrlBeqtv5b+sxUxV+ebyFg0AaMi+tbhf8koryKoVPDMQljmm
+         i/Rv5GrycEwvnGMNsTHc+xLCwkjAy15KoLGdsfc+Uw3HrPmX+/8UFaVCmxltLgEprwVA
+         drnzRzYh3IIFjsPYJIrp75cIMMXIHwm2IqKiGuzMaDeCsB3iA/En8PHWr2trxMV7K98g
+         442ZOjY0CqX1mAIKQLXmN7X3fCbOHinxxy7HefUe2YNclBf6UHr3pT2i9UBsalEpUWUl
+         OQ7A==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20230601; t=1746970292; x=1747575092;
+        h=cc:to:in-reply-to:references:message-id:content-transfer-encoding
+         :mime-version:subject:date:from:x-gm-message-state:from:to:cc
+         :subject:date:message-id:reply-to;
+        bh=n9RYlne5nhTN7kCu5Yc7zW4CF0YUJUWg2clQo/viA0M=;
+        b=HSWiBJsVViBeM5B5hMn4oUOZ7JTd6/O5/rjNuDl1Q//i4aFGGSy0L11zacjYVSLegk
+         2j9UiS7yLaVSlnNJle+YrtIy/kbCayoNUrYXtU5v9MvYAHjS0WMYijekCDQ9+lDLpXwg
+         kpERQ/Tu1Fmqb+8Yv/XycWLCyTPR0XGXxVvGiAPs1KnXsuj71MK7/HXof0p3IDqS444Q
+         dBuRDx1xby4/806P/EPvdr4Xj0lVF3tkimKtaPpBdXp+kkJ8xyYlMhLHAUX16F8Xktqs
+         yuzG1OASvIocfiEiluOxqrM6727wJhtt8qiBxCiI/UBaEr5bUkIBvmvktYSVy+/N4Itf
+         +qAw==
+X-Forwarded-Encrypted: i=1;
+ AJvYcCWF5SWWguUIUPp10Yp8M+dIc/7999B/vb7xwMluPb/Vj9FZyJ4hnhDgLC60CD9icfYXYWwLlHN06vKw5onkKXF5@lists.infradead.org
+X-Gm-Message-State: AOJu0Yx7y5pv/+Mt1FmIK+MTvi1kVFAvXtKteYPDneNKNfNZuwqrLoNt
+	F6DpKLyTyp8r/NQFiROomu/JLI5qMM4JRr5VwmbDeYC0dWKD4xH1
+X-Gm-Gg: ASbGncttO+Rf69HYuAf22AOp+cMso2pjn2/z/ZJhaxvqOUUqzypHmtdf5RV1S1/NJt+
+	2U8XzEy/JHeASbx9scc+3q0mJPtPNp8qCQpF+0zPaU8cbrfcsiggtSVfMhZP6sxqoI2iJtnMdLF
+	JVZhFcynNHOqZYLBh8pWdnToMBYILJM7VhgFcJZIeDPaGbC5JDSKus+OUR31/TKl/K/+83r309I
+	dYCCeBcJgLPA+Z5pDDHhFh/tjag+5ID+tTI3hH7IrEjz0LCb3DFL0QEsrwm9yQn4xUtQ9ms+KST
+	4DF3TYm4r0/Uqf8zWSPTbC4CL69YtYYBDCt22gKAW+PPDTQ4UBcDfIwI7MxiOOT2rnjfzWNtD+1
+	6uO29
+X-Google-Smtp-Source: 
+ AGHT+IFAmDDIIuhS51ef1EGvEQpU//VoeH0fQBhRPIfrKUiYydYis8s+qNymb53gRE7q67J/kVk0HA==
+X-Received: by 2002:a17:907:94d5:b0:acb:3acd:2845 with SMTP id
+ a640c23a62f3a-ad1fccfced9mr1181053766b.25.1746970291841;
+        Sun, 11 May 2025 06:31:31 -0700 (PDT)
+Received: from [192.168.0.253] (5D59A51C.catv.pool.telekom.hu. [93.89.165.28])
+        by smtp.googlemail.com with ESMTPSA id
+ a640c23a62f3a-ad2197bd398sm466765366b.152.2025.05.11.06.31.30
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Sun, 11 May 2025 06:31:31 -0700 (PDT)
+From: Gabor Juhos <j4g8y7@gmail.com>
+Date: Sun, 11 May 2025 15:31:05 +0200
+Subject: [PATCH 1/3] i2c: add init_recovery() callback
+MIME-Version: 1.0
+Message-Id: 
+ <20250511-i2c-pxa-fix-i2c-communication-v1-1-e9097d09a015@gmail.com>
+References: 
+ <20250511-i2c-pxa-fix-i2c-communication-v1-0-e9097d09a015@gmail.com>
+In-Reply-To: 
+ <20250511-i2c-pxa-fix-i2c-communication-v1-0-e9097d09a015@gmail.com>
+To: Wolfram Sang <wsa@kernel.org>, Andi Shyti <andi.shyti@kernel.org>,
+ Russell King <rmk+kernel@armlinux.org.uk>, Andrew Lunn <andrew@lunn.ch>
+Cc: Robert Marko <robert.marko@sartura.hr>,
+ Linus Walleij <linus.walleij@linaro.org>,
+ Russell King <rmk+kernel@armlinux.org.uk>, linux-i2c@vger.kernel.org,
+ linux-arm-kernel@lists.infradead.org, linux-kernel@vger.kernel.org,
+ Gabor Juhos <j4g8y7@gmail.com>, Imre Kaloz <kaloz@openwrt.org>,
+ stable@vger.kernel.org
+X-Mailer: b4 0.14.2
+X-CRM114-Version: 20100106-BlameMichelson ( TRE 0.8.0 (BSD) ) MR-646709E3 
+X-CRM114-CacheID: sfid-20250511_063133_790603_F3EAC078 
+X-CRM114-Status: GOOD (  20.27  )
+X-BeenThere: linux-arm-kernel@lists.infradead.org
+X-Mailman-Version: 2.1.34
+Precedence: list
+List-Id: <linux-arm-kernel.lists.infradead.org>
+List-Unsubscribe: 
+ <http://lists.infradead.org/mailman/options/linux-arm-kernel>,
+ <mailto:linux-arm-kernel-request@lists.infradead.org?subject=unsubscribe>
+List-Archive: <http://lists.infradead.org/pipermail/linux-arm-kernel/>
+List-Post: <mailto:linux-arm-kernel@lists.infradead.org>
+List-Help: <mailto:linux-arm-kernel-request@lists.infradead.org?subject=help>
+List-Subscribe: 
+ <http://lists.infradead.org/mailman/listinfo/linux-arm-kernel>,
+ <mailto:linux-arm-kernel-request@lists.infradead.org?subject=subscribe>
+Sender: "linux-arm-kernel" <linux-arm-kernel-bounces@lists.infradead.org>
+Errors-To: 
+ linux-arm-kernel-bounces+linux-arm-kernel=archiver.kernel.org@lists.infradead.org
+
+Add a new init_recovery() callback to struct 'i2c_bus_recovery_info'
+and modify the i2c_init_recovery() function to call that if specified
+instead of the generic i2c_gpio_init_recovery() function.
+
+This allows controller drivers to skip calling the generic code by
+implementing a dummy callback function, or alternatively to run a
+fine tuned custom implementation.
+
+This is needed for the 'i2c-pxa' driver in order to be able to fix
+a long standing bug for which the fix will be implemented in a
+followup patch.
+
+Cc: stable@vger.kernel.org # 6.3+
+Signed-off-by: Gabor Juhos <j4g8y7@gmail.com>
+Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
+Reviewed-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/i2c/i2c-core-base.c | 8 +++++++-
+ include/linux/i2c.h         | 4 ++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+--- a/drivers/i2c/i2c-core-base.c
++++ b/drivers/i2c/i2c-core-base.c
+@@ -427,12 +427,18 @@ static int i2c_init_recovery(struct i2c_
+ 	struct i2c_bus_recovery_info *bri = adap->bus_recovery_info;
+ 	bool is_error_level = true;
+ 	char *err_str;
++	int ret;
+ 
+ 	if (!bri)
+ 		return 0;
+ 
+-	if (i2c_gpio_init_recovery(adap) == -EPROBE_DEFER)
++	if (bri->init_recovery) {
++		ret = bri->init_recovery(adap);
++		if (ret)
++			return ret;
++	} else if (i2c_gpio_init_recovery(adap) == -EPROBE_DEFER) {
+ 		return -EPROBE_DEFER;
++	}
+ 
+ 	if (!bri->recover_bus) {
+ 		err_str = "no suitable method provided";
+--- a/include/linux/i2c.h
++++ b/include/linux/i2c.h
+@@ -622,6 +622,9 @@ struct i2c_timings {
+  *	for generic GPIO recovery.
+  * @get_bus_free: Returns the bus free state as seen from the IP core in case it
+  *	has a more complex internal logic than just reading SDA. Optional.
++ * @init_recovery: If specified, it will be called instead of the generic GPIO
++ *	recovery initialization code. Platform may use a dummy callback to skip
++ *	calling the generic code, or it may use a custom implementation.
+  * @prepare_recovery: This will be called before starting recovery. Platform may
+  *	configure padmux here for SDA/SCL line or something else they want.
+  * @unprepare_recovery: This will be called after completing recovery. Platform
+@@ -646,6 +649,7 @@ struct i2c_bus_recovery_info {
+ 	void (*set_sda)(struct i2c_adapter *adap, int val);
+ 	int (*get_bus_free)(struct i2c_adapter *adap);
+ 
++	int (*init_recovery)(struct i2c_adapter *adap);
+ 	void (*prepare_recovery)(struct i2c_adapter *adap);
+ 	void (*unprepare_recovery)(struct i2c_adapter *adap);
+ 

--- a/target/linux/mvebu/patches-6.6/830-02-i2c-pxa-prevent-calling-of-the-generic-recovery-init-code.patch
+++ b/target/linux/mvebu/patches-6.6/830-02-i2c-pxa-prevent-calling-of-the-generic-recovery-init-code.patch
@@ -1,0 +1,224 @@
+From patchwork Sun May 11 13:31:06 2025
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Gabor Juhos <j4g8y7@gmail.com>
+X-Patchwork-Id: 14084056
+Return-Path: 
+ <linux-arm-kernel-bounces+linux-arm-kernel=archiver.kernel.org@lists.infradead.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+Received: from bombadil.infradead.org (bombadil.infradead.org
+ [198.137.202.133])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+	(No client certificate requested)
+	by smtp.lore.kernel.org (Postfix) with ESMTPS id 72E7DC3ABC3
+	for <linux-arm-kernel@archiver.kernel.org>;
+ Sun, 11 May 2025 13:37:50 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/relaxed;
+	d=lists.infradead.org; s=bombadil.20210309; h=Sender:List-Subscribe:List-Help
+	:List-Post:List-Archive:List-Unsubscribe:List-Id:Cc:To:In-Reply-To:References
+	:Message-Id:Content-Transfer-Encoding:Content-Type:MIME-Version:Subject:Date:
+	From:Reply-To:Content-ID:Content-Description:Resent-Date:Resent-From:
+	Resent-Sender:Resent-To:Resent-Cc:Resent-Message-ID:List-Owner;
+	bh=BySnXAIGhp18eRP0sg1mjpdXdHwBsus0rtjMi26U9uM=; b=ba0yGs/0cSs2cep9T3wjo3iDxy
+	VSaQu2j7YGuiAMJt8ERY5OVL7YiPC/6+MqGcLqkrGunZq/TEjXRGX9ztKqyko6KY9fLbiH1wXYBjK
+	/9yxbEyt9bPrIw/r64uaUOdRzZMF0i2oBn53RgZJJFaD4ou1E28BMc22AuVGshj99Dlz63ncr/Lz7
+	M3/ptMOWGRp0SrImYRUdvnWj+LKyb4zqRFEYIQuq9WzyhhNuDZDaHFpdJn4go/eoS4kUvTFfixpwV
+	FevQupqdOn62R3ull5YYdI6BFQVL6dISjD34mjoNXJABSjuXmq8FRWuX/V3rPrvnVIflxOmzSrKrF
+	8rdYY/fg==;
+Received: from localhost ([::1] helo=bombadil.infradead.org)
+	by bombadil.infradead.org with esmtp (Exim 4.98.2 #2 (Red Hat Linux))
+	id 1uE6sA-00000007GuC-0j29;
+	Sun, 11 May 2025 13:37:42 +0000
+Received: from mail-ej1-x636.google.com ([2a00:1450:4864:20::636])
+	by bombadil.infradead.org with esmtps (Exim 4.98.2 #2 (Red Hat Linux))
+	id 1uE6mF-00000007GPb-1uOE
+	for linux-arm-kernel@lists.infradead.org;
+	Sun, 11 May 2025 13:31:36 +0000
+Received: by mail-ej1-x636.google.com with SMTP id
+ a640c23a62f3a-acae7e7587dso539429266b.2
+        for <linux-arm-kernel@lists.infradead.org>;
+ Sun, 11 May 2025 06:31:35 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20230601; t=1746970294; x=1747575094;
+ darn=lists.infradead.org;
+        h=cc:to:in-reply-to:references:message-id:content-transfer-encoding
+         :mime-version:subject:date:from:from:to:cc:subject:date:message-id
+         :reply-to;
+        bh=BySnXAIGhp18eRP0sg1mjpdXdHwBsus0rtjMi26U9uM=;
+        b=QtIYufKg61b066knR9OpyawErNmkYyoP/2lIkHhyGY7qtGXkc1jJmC0TpPyhp0WGlm
+         xWP3K/PG23VcjEuGj/880thPietuKQuTF029WPfm+yrQ3uHLMzkHqyOiMYyiBR9N0Zjw
+         NICgywX4iqVHVBnXZTiBA7sRSjQqteatDPTGbKgZxpIHpg4ZJtfXZcCE8RiKVVgZCWsq
+         JgTJuTO/4J0cq5TWVOIGLrt0XOslaMmuISPbUDdArr5yKfGZqu51i747A0o0RBdEuH9Y
+         UPI8/GExcWWa+62KCVEwB9OmCZR81ieb8To/XdZO8hIQAlExOzKa3OOPCkS0PF0M9BBa
+         d++Q==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20230601; t=1746970294; x=1747575094;
+        h=cc:to:in-reply-to:references:message-id:content-transfer-encoding
+         :mime-version:subject:date:from:x-gm-message-state:from:to:cc
+         :subject:date:message-id:reply-to;
+        bh=BySnXAIGhp18eRP0sg1mjpdXdHwBsus0rtjMi26U9uM=;
+        b=A+LfIVmyzogyr2akFoGR3PIbjd8E/TVXGlur91KBF7h2W8msMTeMyv0PDVjqEBxWFI
+         cqNLira3TWf9soXrRBGaJVB111/r5woARoN4aO5otCDrh3o5U2gJ5/eZLGbcX49TqJG5
+         rbI1Eq0GGXFdidQ4T5CMLtooa6B5pg7j+o2gcyG/vQlHr6MbG4/2sIDPX0JbL08xibWC
+         5LqP933W+yopGIbnp3YZ9pybbvOUA9x4cYkUm1Of3idmkTN0xUh8kmUWz7FJCH4R/PAN
+         5CA/vn8q1myUvXisU0oAbC9y/WrlExPfvguXjru1LTx9AdPaC9+D3Qxmh2Raz9b4NrKl
+         ZlVw==
+X-Forwarded-Encrypted: i=1;
+ AJvYcCWMm/Er5t6Xp05DMDNak7mbsqx8YZmOrqz9Y39eovLKPkbqcMhQwOzxqxCY8ZfQtETNpZ8X9NptEow+bBHo+z3t@lists.infradead.org
+X-Gm-Message-State: AOJu0YwBTrjBcryZjqJBq66bcSYfV2AWsDAqAfMinxG8gRUJjpKq8RXn
+	kKSKTp2XvMObVTWx7cEMM5BBPWl7LfLwBkjVIusbgScQ8qW8YA9H
+X-Gm-Gg: ASbGnctKtEUhBLJdOfPb7cKwM8a1ZTe5+8zPX9TaLdomZybHHeteF9o/ZyUNbunUsSK
+	fuMy3pPFmYcC4TZtPqfZPdpagbDpOb2R/9xbSTMd1TKDDj4vFnkTIzQHA9E1ZxX44Nw6JkxA0up
+	S94PBow9mEb3tkHLN9hbNe7W8ksyf7RZ25IGC4FYj/wEGQsMy2VidJsfG4bIeImZ8zj8ufUCNby
+	7jIjmP1taNt5U8omPEWhFuRdJfiPqIXx85tIsGVFwG7VSr/JW8LwxBCJLGhWLUZhxYqV4cEfSRC
+	zYKj2qkuRfx5AxzN+JGtfcxYPijsy/rI51OnjOv2CQRPuE6rESamNJiR7pmnDgvHSRm5nps5chp
+	/HVXU
+X-Google-Smtp-Source: 
+ AGHT+IG8Y/7VNg8lhY275mIfLbq8EaG9jCRvvK1wX7rlbuoMvEUYYC3k7sZOxh3RPmKhAB94Kfvlwg==
+X-Received: by 2002:a17:907:7b04:b0:ad1:fab8:88ab with SMTP id
+ a640c23a62f3a-ad219085c07mr897192766b.29.1746970293535;
+        Sun, 11 May 2025 06:31:33 -0700 (PDT)
+Received: from [192.168.0.253] (5D59A51C.catv.pool.telekom.hu. [93.89.165.28])
+        by smtp.googlemail.com with ESMTPSA id
+ a640c23a62f3a-ad2197bd398sm466765366b.152.2025.05.11.06.31.32
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Sun, 11 May 2025 06:31:33 -0700 (PDT)
+From: Gabor Juhos <j4g8y7@gmail.com>
+Date: Sun, 11 May 2025 15:31:06 +0200
+Subject: [PATCH 2/3] i2c: pxa: prevent calling of the generic recovery init
+ code
+MIME-Version: 1.0
+Message-Id: 
+ <20250511-i2c-pxa-fix-i2c-communication-v1-2-e9097d09a015@gmail.com>
+References: 
+ <20250511-i2c-pxa-fix-i2c-communication-v1-0-e9097d09a015@gmail.com>
+In-Reply-To: 
+ <20250511-i2c-pxa-fix-i2c-communication-v1-0-e9097d09a015@gmail.com>
+To: Wolfram Sang <wsa@kernel.org>, Andi Shyti <andi.shyti@kernel.org>,
+ Russell King <rmk+kernel@armlinux.org.uk>, Andrew Lunn <andrew@lunn.ch>
+Cc: Robert Marko <robert.marko@sartura.hr>,
+ Linus Walleij <linus.walleij@linaro.org>,
+ Russell King <rmk+kernel@armlinux.org.uk>, linux-i2c@vger.kernel.org,
+ linux-arm-kernel@lists.infradead.org, linux-kernel@vger.kernel.org,
+ Gabor Juhos <j4g8y7@gmail.com>, Imre Kaloz <kaloz@openwrt.org>,
+ stable@vger.kernel.org
+X-Mailer: b4 0.14.2
+X-CRM114-Version: 20100106-BlameMichelson ( TRE 0.8.0 (BSD) ) MR-646709E3 
+X-CRM114-CacheID: sfid-20250511_063135_499888_294068DC 
+X-CRM114-Status: GOOD (  21.30  )
+X-BeenThere: linux-arm-kernel@lists.infradead.org
+X-Mailman-Version: 2.1.34
+Precedence: list
+List-Id: <linux-arm-kernel.lists.infradead.org>
+List-Unsubscribe: 
+ <http://lists.infradead.org/mailman/options/linux-arm-kernel>,
+ <mailto:linux-arm-kernel-request@lists.infradead.org?subject=unsubscribe>
+List-Archive: <http://lists.infradead.org/pipermail/linux-arm-kernel/>
+List-Post: <mailto:linux-arm-kernel@lists.infradead.org>
+List-Help: <mailto:linux-arm-kernel-request@lists.infradead.org?subject=help>
+List-Subscribe: 
+ <http://lists.infradead.org/mailman/listinfo/linux-arm-kernel>,
+ <mailto:linux-arm-kernel-request@lists.infradead.org?subject=subscribe>
+Sender: "linux-arm-kernel" <linux-arm-kernel-bounces@lists.infradead.org>
+Errors-To: 
+ linux-arm-kernel-bounces+linux-arm-kernel=archiver.kernel.org@lists.infradead.org
+
+The I2C communication is completely broken on the Armada 3700 platform
+since commit 0b01392c18b9 ("i2c: pxa: move to generic GPIO recovery").
+
+For example, on the Methode uDPU board, probing of the two onboard
+temperature sensors fails ...
+
+  [    7.271713] i2c i2c-0: using pinctrl states for GPIO recovery
+  [    7.277503] i2c i2c-0:  PXA I2C adapter
+  [    7.282199] i2c i2c-1: using pinctrl states for GPIO recovery
+  [    7.288241] i2c i2c-1:  PXA I2C adapter
+  [    7.292947] sfp sfp-eth1: Host maximum power 3.0W
+  [    7.299614] sfp sfp-eth0: Host maximum power 3.0W
+  [    7.308178] lm75 1-0048: supply vs not found, using dummy regulator
+  [   32.489631] lm75 1-0048: probe with driver lm75 failed with error -121
+  [   32.496833] lm75 1-0049: supply vs not found, using dummy regulator
+  [   82.890614] lm75 1-0049: probe with driver lm75 failed with error -121
+
+... and accessing the plugged-in SFP modules also does not work:
+
+  [  511.298537] sfp sfp-eth1: please wait, module slow to respond
+  [  536.488530] sfp sfp-eth0: please wait, module slow to respond
+  ...
+  [ 1065.688536] sfp sfp-eth1: failed to read EEPROM: -EREMOTEIO
+  [ 1090.888532] sfp sfp-eth0: failed to read EEPROM: -EREMOTEIO
+
+After a discussion [1], there was an attempt to fix the problem by
+reverting the offending change by commit 7b211c767121 ("Revert "i2c:
+pxa: move to generic GPIO recovery""), but that only helped to fix
+the issue in the 6.1.y stable tree. The reason behind the partial succes
+is that there was another change in commit 20cb3fce4d60 ("i2c: Set i2c
+pinctrl recovery info from it's device pinctrl") in the 6.3-rc1 cycle
+which broke things further.
+
+The cause of the problem is the same in case of both offending commits
+mentioned above. Namely, the I2C core code changes the pinctrl state to
+GPIO while running the recovery initialization code. Although the PXA
+specific initialization also does this, but the key difference is that
+it happens before the conrtoller is getting enabled in i2c_pxa_reset(),
+whereas in the case of the generic initialization it happens after that.
+
+To resolve the problem, provide an empty init_recovery() callback
+function thus preventing the I2C core to call the generic recovery
+initialization code.
+
+As the result this change restores the original behaviour, which in
+turn makes the I2C communication to work again as it can be seen from
+the following log:
+
+  [    7.305277] i2c i2c-0:  PXA I2C adapter
+  [    7.310198] i2c i2c-1:  PXA I2C adapter
+  [    7.315012] sfp sfp-eth1: Host maximum power 3.0W
+  [    7.324061] lm75 1-0048: supply vs not found, using dummy regulator
+  [    7.331738] sfp sfp-eth0: Host maximum power 3.0W
+  [    7.337000] hwmon hwmon0: temp1_input not attached to any thermal zone
+  [    7.343593] lm75 1-0048: hwmon0: sensor 'tmp75c'
+  [    7.348526] lm75 1-0049: supply vs not found, using dummy regulator
+  [    7.356858] hwmon hwmon1: temp1_input not attached to any thermal zone
+  [    7.363463] lm75 1-0049: hwmon1: sensor 'tmp75c'
+  ...
+  [    7.730315] sfp sfp-eth1: module Mikrotik         S-RJ01           rev 1.0  sn 61B103C55C58     dc 201022
+  [    7.840318] sfp sfp-eth0: module MENTECHOPTO      POS22-LDCC-KR    rev 1.0  sn MNC208U90009     dc 200828
+  [    7.850083] mvneta d0030000.ethernet eth0: unsupported SFP module: no common interface modes
+  [    7.990335] hwmon hwmon2: temp1_input not attached to any thermal zone
+
+[1] https://lore.kernel.org/r/20230926160255.330417-1-robert.marko@sartura.hr
+
+Cc: stable@vger.kernel.org # 6.3+
+Fixes: 20cb3fce4d60 ("i2c: Set i2c pinctrl recovery info from it's device pinctrl")
+Signed-off-by: Gabor Juhos <j4g8y7@gmail.com>
+Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
+---
+ drivers/i2c/busses/i2c-pxa.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/drivers/i2c/busses/i2c-pxa.c
++++ b/drivers/i2c/busses/i2c-pxa.c
+@@ -1331,6 +1331,12 @@ static void i2c_pxa_unprepare_recovery(s
+ 	i2c_pxa_enable(i2c);
+ }
+ 
++static int i2c_pxa_init_recovery_cb(struct i2c_adapter *adap)
++{
++	/* We have initialized everything already, so nothing to do here. */
++	return 0;
++}
++
+ static int i2c_pxa_init_recovery(struct pxa_i2c *i2c)
+ {
+ 	struct i2c_bus_recovery_info *bri = &i2c->recovery;
+@@ -1399,6 +1405,7 @@ static int i2c_pxa_init_recovery(struct
+ 		return 0;
+ 	}
+ 
++	bri->init_recovery = i2c_pxa_init_recovery_cb;
+ 	bri->prepare_recovery = i2c_pxa_prepare_recovery;
+ 	bri->unprepare_recovery = i2c_pxa_unprepare_recovery;
+ 	bri->recover_bus = i2c_generic_scl_recovery;

--- a/target/linux/mvebu/patches-6.6/830-03-i2c-pxa-handle-Early-Bus-Busy-condition-on-Armada-3700.patch
+++ b/target/linux/mvebu/patches-6.6/830-03-i2c-pxa-handle-Early-Bus-Busy-condition-on-Armada-3700.patch
@@ -1,0 +1,309 @@
+From patchwork Sun May 11 13:31:07 2025
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Gabor Juhos <j4g8y7@gmail.com>
+X-Patchwork-Id: 14084057
+Return-Path: 
+ <linux-arm-kernel-bounces+linux-arm-kernel=archiver.kernel.org@lists.infradead.org>
+X-Spam-Checker-Version: SpamAssassin 3.4.0 (2014-02-07) on
+	aws-us-west-2-korg-lkml-1.web.codeaurora.org
+Received: from bombadil.infradead.org (bombadil.infradead.org
+ [198.137.202.133])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+	(No client certificate requested)
+	by smtp.lore.kernel.org (Postfix) with ESMTPS id E1323C3ABC3
+	for <linux-arm-kernel@archiver.kernel.org>;
+ Sun, 11 May 2025 13:39:50 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/relaxed;
+	d=lists.infradead.org; s=bombadil.20210309; h=Sender:List-Subscribe:List-Help
+	:List-Post:List-Archive:List-Unsubscribe:List-Id:Cc:To:In-Reply-To:References
+	:Message-Id:Content-Transfer-Encoding:Content-Type:MIME-Version:Subject:Date:
+	From:Reply-To:Content-ID:Content-Description:Resent-Date:Resent-From:
+	Resent-Sender:Resent-To:Resent-Cc:Resent-Message-ID:List-Owner;
+	bh=jCnitIQrLGML0v/ZGaz7m1EqKZaS5okX2gqREoZgqFA=; b=gjUPiYgZ9tzalLC8hdQSBahsEr
+	yHwsfVsfhm/onN8EySOnZ9iefbvCDb/y94s1ll7+f7UeDZ3epWr0Kl1WPgPVKwCa7AIYumKWi/l4S
+	rNqCfOmyVGO0CspTKlxvV/ZHk+jAJqKqHmd/QtVxJkMi4a9d1J8BMHWdltfYPvpkJkaKxx9WINZ5v
+	BftwJv2+35b3ZWGRWYXmCBFUXaV/w6I0+dE51I25k4NZcTMRbR1sGYEXTm5Eu2KBtJ/UbhiKKCk0b
+	+BTg/BJ/O7lSKl/W3DHnImYv6s65FMGxgHCaKZlN/IWCWLanqi2hg3hmGlDqyZUvezUrcuYEed2et
+	w6FrGCGg==;
+Received: from localhost ([::1] helo=bombadil.infradead.org)
+	by bombadil.infradead.org with esmtp (Exim 4.98.2 #2 (Red Hat Linux))
+	id 1uE6u7-00000007H4F-41sI;
+	Sun, 11 May 2025 13:39:43 +0000
+Received: from mail-ej1-x62e.google.com ([2a00:1450:4864:20::62e])
+	by bombadil.infradead.org with esmtps (Exim 4.98.2 #2 (Red Hat Linux))
+	id 1uE6mG-00000007GQ2-3M7w
+	for linux-arm-kernel@lists.infradead.org;
+	Sun, 11 May 2025 13:31:37 +0000
+Received: by mail-ej1-x62e.google.com with SMTP id
+ a640c23a62f3a-ad1a87d93f7so576360566b.0
+        for <linux-arm-kernel@lists.infradead.org>;
+ Sun, 11 May 2025 06:31:36 -0700 (PDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=gmail.com; s=20230601; t=1746970295; x=1747575095;
+ darn=lists.infradead.org;
+        h=cc:to:in-reply-to:references:message-id:content-transfer-encoding
+         :mime-version:subject:date:from:from:to:cc:subject:date:message-id
+         :reply-to;
+        bh=jCnitIQrLGML0v/ZGaz7m1EqKZaS5okX2gqREoZgqFA=;
+        b=dFmhAe55mI0ZYgTbA9z06jAcGpibU1yIvZWl8vsEWd0Cow+yYkQlcsnlJcoq22vUt+
+         An87/vI28iqdwgYZpu+vabyC6ytUUqI5IuqTOlv/QtLak3Oi6cbHjoebb9cVfGhTpO16
+         gN8BLLH5Lf9shCAy3lLQahAf3jiE41hB3YKxIusuBnm+DIMYVGMJID5Pt72YgU322uXW
+         hnMLbX75rnBu5DTGM12UT9+nOkBYjITOdnfEA+o3IVlzUEQRr/G7s9RNKTKnsjJDwaZb
+         91UdhJBE/yz2fiFrtN6PGr1B90kJd+GAxRjrbQ8UunMu6C4ggE6aRazKcsQEZIWLa6tR
+         n/Vg==
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20230601; t=1746970295; x=1747575095;
+        h=cc:to:in-reply-to:references:message-id:content-transfer-encoding
+         :mime-version:subject:date:from:x-gm-message-state:from:to:cc
+         :subject:date:message-id:reply-to;
+        bh=jCnitIQrLGML0v/ZGaz7m1EqKZaS5okX2gqREoZgqFA=;
+        b=tlFtjTi8qCbMBXjF1lESzpnVH51JUuhJV5lirRh7dyHdWcVtBgKdnrbGpR+ZDHFvvV
+         1FJUR377ZyrZPwleAZ8bfUcjMx1NSDhxGsHI+05Mpt7LzRZCCUE/nuTHROytYhalDR35
+         yh8YprIJwMhZ9zFNNXrZ/GQCPbRMA0fkOJYWCfMRPsf+VGHsDniGzF9Dbsy3aq0hG+mw
+         5r85WCALVE55cSW22kla9QPeOxpX6nheglHKz2svFKgo+nI9xXgcR2F9vsSah5DBTxkQ
+         WK1fEkdtF+6If4W/u3cZ1kQTbkrifLbpV8i+z6VqFq+iRZuf9eZjyyuMXP53A7PQGpW3
+         BKKA==
+X-Forwarded-Encrypted: i=1;
+ AJvYcCWtVH3IlKfQOiuwxLM94ic5Bi0XTfGdTLWK5BWhh9b026VHto4M4zjf8wBmIUmekjUFrgWvBcW3eJkv9VuD0NNu@lists.infradead.org
+X-Gm-Message-State: AOJu0YxUrhwcNLQkyGCiTZ3Ci5GaLENJhrPiMNwOQ2HqRWQ5fFYTksDJ
+	6eb+myA0GGrJOmcEortiBND+ipH4vXcxwtKOVyNjgBBJMq27NJBTQ16Asw==
+X-Gm-Gg: ASbGncu1guGFlZm8KpI1qJ3LeFM8WO7ZvfanWSzK7lzUZES0sLxvvjBNy8SgeycdGUF
+	QifE6Z+xBPK9i0m0CRfzWuNm9a/dr/W14EAzBiSWq5pOW0fbH1rGo/FFbaUZ8T7OroQ0wipdZ9J
+	tIZJz+dbSRk4kRsYhhm4cJZh4GfKL8me6+8NM/db/a0oKAE0VMhHLmqDw0BFjgpwdWO4YnaUBLt
+	MU5Pu+S3TKwVV7SHRma2c7662QZ2pxXIngJdGW2qnrr1TejUMaK39IRBPm7sgzBCntS8fd9uVdb
+	35NbstsZrboDcHBnDhFroXwe5QWwncAo1aJm/DVM39fE5OCOqNDp7iz6XZbPE/fzVdEDg00L9fR
+	x8yAy
+X-Google-Smtp-Source: 
+ AGHT+IFtWSfALiUVVnpFFz7ImelE+nmATZJYkY40gYG/szbhM9XPyGAl4heVD8RQkSCE7sXqGFzn6Q==
+X-Received: by 2002:a17:907:d30e:b0:ad2:4cad:9824 with SMTP id
+ a640c23a62f3a-ad24cad9bd2mr198358366b.28.1746970294838;
+        Sun, 11 May 2025 06:31:34 -0700 (PDT)
+Received: from [192.168.0.253] (5D59A51C.catv.pool.telekom.hu. [93.89.165.28])
+        by smtp.googlemail.com with ESMTPSA id
+ a640c23a62f3a-ad2197bd398sm466765366b.152.2025.05.11.06.31.33
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Sun, 11 May 2025 06:31:34 -0700 (PDT)
+From: Gabor Juhos <j4g8y7@gmail.com>
+Date: Sun, 11 May 2025 15:31:07 +0200
+Subject: [PATCH 3/3] i2c: pxa: handle 'Early Bus Busy' condition on Armada
+ 3700
+MIME-Version: 1.0
+Message-Id: 
+ <20250511-i2c-pxa-fix-i2c-communication-v1-3-e9097d09a015@gmail.com>
+References: 
+ <20250511-i2c-pxa-fix-i2c-communication-v1-0-e9097d09a015@gmail.com>
+In-Reply-To: 
+ <20250511-i2c-pxa-fix-i2c-communication-v1-0-e9097d09a015@gmail.com>
+To: Wolfram Sang <wsa@kernel.org>, Andi Shyti <andi.shyti@kernel.org>,
+ Russell King <rmk+kernel@armlinux.org.uk>, Andrew Lunn <andrew@lunn.ch>
+Cc: Robert Marko <robert.marko@sartura.hr>,
+ Linus Walleij <linus.walleij@linaro.org>,
+ Russell King <rmk+kernel@armlinux.org.uk>, linux-i2c@vger.kernel.org,
+ linux-arm-kernel@lists.infradead.org, linux-kernel@vger.kernel.org,
+ Gabor Juhos <j4g8y7@gmail.com>, Imre Kaloz <kaloz@openwrt.org>,
+ stable@vger.kernel.org
+X-Mailer: b4 0.14.2
+X-CRM114-Version: 20100106-BlameMichelson ( TRE 0.8.0 (BSD) ) MR-646709E3 
+X-CRM114-CacheID: sfid-20250511_063136_845554_2BF89522 
+X-CRM114-Status: GOOD (  32.59  )
+X-BeenThere: linux-arm-kernel@lists.infradead.org
+X-Mailman-Version: 2.1.34
+Precedence: list
+List-Id: <linux-arm-kernel.lists.infradead.org>
+List-Unsubscribe: 
+ <http://lists.infradead.org/mailman/options/linux-arm-kernel>,
+ <mailto:linux-arm-kernel-request@lists.infradead.org?subject=unsubscribe>
+List-Archive: <http://lists.infradead.org/pipermail/linux-arm-kernel/>
+List-Post: <mailto:linux-arm-kernel@lists.infradead.org>
+List-Help: <mailto:linux-arm-kernel-request@lists.infradead.org?subject=help>
+List-Subscribe: 
+ <http://lists.infradead.org/mailman/listinfo/linux-arm-kernel>,
+ <mailto:linux-arm-kernel-request@lists.infradead.org?subject=subscribe>
+Sender: "linux-arm-kernel" <linux-arm-kernel-bounces@lists.infradead.org>
+Errors-To: 
+ linux-arm-kernel-bounces+linux-arm-kernel=archiver.kernel.org@lists.infradead.org
+
+Under some circumstances I2C recovery fails on Armada 3700. At least
+on the Methode uDPU board, removing and replugging an SFP module fails
+often, like this:
+
+  [   36.953127] sfp sfp-eth1: module removed
+  [   38.468549] i2c i2c-1: i2c_pxa: timeout waiting for bus free
+  [   38.486960] sfp sfp-eth1: module MENTECHOPTO      POS22-LDCC-KR    rev 1.0  sn MNC208U90009     dc 200828
+  [   38.496867] mvneta d0040000.ethernet eth1: unsupported SFP module: no common interface modes
+  [   38.521448] hwmon hwmon2: temp1_input not attached to any thermal zone
+  [   39.249196] sfp sfp-eth1: module removed
+  ...
+  [  292.568799] sfp sfp-eth1: please wait, module slow to respond
+  ...
+  [  625.208814] sfp sfp-eth1: failed to read EEPROM: -EREMOTEIO
+
+Note that the 'unsupported SFP module' messages are not relevant. The
+module is used only for testing the I2C recovery funcionality, because
+the error can be triggered easily with this specific one.
+
+Enabling debug in the i2c-pxa driver reveals the following:
+
+  [   82.034678] sfp sfp-eth1: module removed
+  [   90.008654] i2c i2c-1: slave_0x50 error: timeout with active message
+  [   90.015112] i2c i2c-1: msg_num: 2 msg_idx: 0 msg_ptr: 0
+  [   90.020464] i2c i2c-1: IBMR: 00000003 IDBR: 000000a0 ICR: 000007e0 ISR: 00000802
+  [   90.027906] i2c i2c-1: log:
+  [   90.030787]
+
+This continues until the retries are exhausted ...
+
+  [  110.192489] i2c i2c-1: slave_0x50 error: exhausted retries
+  [  110.198012] i2c i2c-1: msg_num: 2 msg_idx: 0 msg_ptr: 0
+  [  110.203323] i2c i2c-1: IBMR: 00000003 IDBR: 000000a0 ICR: 000007e0 ISR: 00000802
+  [  110.210810] i2c i2c-1: log:
+  [  110.213633]
+
+... then the whole sequence starts again ...
+
+  [  115.368641] i2c i2c-1: slave_0x50 error: timeout with active message
+
+... while finally the SFP core gives up:
+
+  [  671.975258] sfp sfp-eth1: failed to read EEPROM: -EREMOTEIO
+
+When we analyze the log, it can be seen that bit 1 and 11 is set in the
+ISR (Interface Status Register). Bit 1 indicates the ACK/NACK status, but
+the purpose of bit 11 is not documented in the driver code unfortunately.
+
+The 'Functional Specification' document of the Armada 3700 SoCs family
+however says that this bit indicates an 'Early Bus Busy' condition. The
+document also notes that whenever this bit is set, it is not possible to
+initiate a transaction on the I2C bus. The observed behaviour corresponds
+to this statement.
+
+Unfortunately, I2C recovery does not help as it never runs in this
+special case. Although the driver checks the busyness of the bus at
+several places, but since it does not consider the A3700 specific bit
+in these checks it can't determine the actual status of the bus correctly
+which results in the errors above.
+
+In order to fix the problem, add a new member to struct 'i2c_pxa' to
+store a controller specific bitmask containing the bits indicating the
+busy status, and use that in the code while checking the actual status
+of the bus. This ensures that the correct status can be determined on
+the Armada 3700 based devices without causing functional changes on
+devices based on other SoCs.
+
+With the change applied, the driver detects the busy condition, and runs
+the recovery process:
+
+  [  742.617312] i2c i2c-1: state:i2c_pxa_wait_bus_not_busy:449: ISR=00000802, ICR=000007e0, IBMR=03
+  [  742.626099] i2c i2c-1: i2c_pxa: timeout waiting for bus free
+  [  742.631933] i2c i2c-1: recovery: resetting controller, ISR=0x00000802
+  [  742.638421] i2c i2c-1: recovery: IBMR 0x00000003 ISR 0x00000000
+
+This clears the EBB bit in the ISR register, so it makes it possible to
+initiate transactions on the I2C bus again.
+
+After this patch, the SFP module used for testing can be removed and
+replugged numerous times without causing the error described at the
+beginning. Previously, the error happened after a few such attempts.
+
+The patch has been tested also with the following kernel versions:
+5.10.237, 5.15.182, 6.1.138, 6.6.90, 6.12.28, 6.14.6. It improves
+recoverabilty on all of them.
+
+Cc: stable@vger.kernel.org # 5.8+
+Fixes: 7c9ec2c52518 ("i2c: pxa: implement generic i2c bus recovery")
+Signed-off-by: Gabor Juhos <j4g8y7@gmail.com>
+Signed-off-by: Imre Kaloz <kaloz@openwrt.org>
+---
+Note: the patch is included in this series for completeness however
+it can be applied independently from the preceding patches. On kernels
+6.3+, it restores I2C functionality even in itself because it recovers
+the controller from the bad state described in the previous patch.
+---
+ drivers/i2c/busses/i2c-pxa.c | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+--- a/drivers/i2c/busses/i2c-pxa.c
++++ b/drivers/i2c/busses/i2c-pxa.c
+@@ -70,6 +70,7 @@
+ #define ISR_GCAD	(1 << 8)	   /* general call address detected */
+ #define ISR_SAD		(1 << 9)	   /* slave address detected */
+ #define ISR_BED		(1 << 10)	   /* bus error no ACK/NAK */
++#define ISR_A3700_EBB	(1 << 11)	   /* early bus busy for armada 3700 */
+ 
+ #define ILCR_SLV_SHIFT		0
+ #define ILCR_SLV_MASK		(0x1FF << ILCR_SLV_SHIFT)
+@@ -262,6 +263,7 @@ struct pxa_i2c {
+ 	bool			highmode_enter;
+ 	u32			fm_mask;
+ 	u32			hs_mask;
++	u32			busy_mask;
+ 
+ 	struct i2c_bus_recovery_info recovery;
+ 	struct pinctrl		*pinctrl;
+@@ -428,7 +430,7 @@ static int i2c_pxa_wait_bus_not_busy(str
+ 
+ 	while (1) {
+ 		isr = readl(_ISR(i2c));
+-		if (!(isr & (ISR_IBB | ISR_UB)))
++		if (!(isr & i2c->busy_mask))
+ 			return 0;
+ 
+ 		if (isr & ISR_SAD)
+@@ -465,7 +467,7 @@ static int i2c_pxa_wait_master(struct px
+ 		 * quick check of the i2c lines themselves to ensure they've
+ 		 * gone high...
+ 		 */
+-		if ((readl(_ISR(i2c)) & (ISR_UB | ISR_IBB)) == 0 &&
++		if ((readl(_ISR(i2c)) & i2c->busy_mask) == 0 &&
+ 		    readl(_IBMR(i2c)) == (IBMR_SCLS | IBMR_SDAS)) {
+ 			if (i2c_debug > 0)
+ 				dev_dbg(&i2c->adap.dev, "%s: done\n", __func__);
+@@ -486,7 +488,7 @@ static int i2c_pxa_set_master(struct pxa
+ 	if (i2c_debug)
+ 		dev_dbg(&i2c->adap.dev, "setting to bus master\n");
+ 
+-	if ((readl(_ISR(i2c)) & (ISR_UB | ISR_IBB)) != 0) {
++	if ((readl(_ISR(i2c)) & i2c->busy_mask) != 0) {
+ 		dev_dbg(&i2c->adap.dev, "%s: unit is busy\n", __func__);
+ 		if (!i2c_pxa_wait_master(i2c)) {
+ 			dev_dbg(&i2c->adap.dev, "%s: error: unit busy\n", __func__);
+@@ -512,7 +514,7 @@ static int i2c_pxa_wait_slave(struct pxa
+ 			dev_dbg(&i2c->adap.dev, "%s: %ld: ISR=%08x, ICR=%08x, IBMR=%02x\n",
+ 				__func__, (long)jiffies, readl(_ISR(i2c)), readl(_ICR(i2c)), readl(_IBMR(i2c)));
+ 
+-		if ((readl(_ISR(i2c)) & (ISR_UB|ISR_IBB)) == 0 ||
++		if ((readl(_ISR(i2c)) & i2c->busy_mask) == 0 ||
+ 		    (readl(_ISR(i2c)) & ISR_SAD) != 0 ||
+ 		    (readl(_ICR(i2c)) & ICR_SCLE) == 0) {
+ 			if (i2c_debug > 1)
+@@ -1170,7 +1172,7 @@ static int i2c_pxa_pio_set_master(struct
+ 	/*
+ 	 * Wait for the bus to become free.
+ 	 */
+-	while (timeout-- && readl(_ISR(i2c)) & (ISR_IBB | ISR_UB))
++	while (timeout-- && readl(_ISR(i2c)) & i2c->busy_mask)
+ 		udelay(1000);
+ 
+ 	if (timeout < 0) {
+@@ -1317,7 +1319,7 @@ static void i2c_pxa_unprepare_recovery(s
+ 	 * handing control of the bus back to avoid the bus changing state.
+ 	 */
+ 	isr = readl(_ISR(i2c));
+-	if (isr & (ISR_UB | ISR_IBB)) {
++	if (isr & i2c->busy_mask) {
+ 		dev_dbg(&i2c->adap.dev,
+ 			"recovery: resetting controller, ISR=0x%08x\n", isr);
+ 		i2c_pxa_do_reset(i2c);
+@@ -1481,6 +1483,10 @@ static int i2c_pxa_probe(struct platform
+ 	i2c->fm_mask = pxa_reg_layout[i2c_type].fm;
+ 	i2c->hs_mask = pxa_reg_layout[i2c_type].hs;
+ 
++	i2c->busy_mask = ISR_UB | ISR_IBB;
++	if (i2c_type == REGS_A3700)
++		i2c->busy_mask |= ISR_A3700_EBB;
++
+ 	if (i2c_type != REGS_CE4100)
+ 		i2c->reg_isar = i2c->reg_base + pxa_reg_layout[i2c_type].isar;
+ 


### PR DESCRIPTION
Currently, when I2C recovery pinctrl is set in the DTS it will completely break I2C since kernel 6.6.

So, backport pinctrl patch series that was merged upstream and import the required PXA fixes that are pending upstream.