### PR TITLE
ramips: add support for Wavlink WL-WN570HA2

### DIFF
--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha2.dts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "wavlink,wl-wn570ha2", "mediatek,mt7628an-soc";
+	model = "Wavlink WL-WN570HA2";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-high {
+			label = "blue:wifi-high";
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-med {
+			label = "blue:wifi-med";
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi-low {
+			label = "blue:wifi-low";
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "wled_an", "p0led_an", "wdt", "refclk";
+		function = "gpio";
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						/* MT7613 has unique eeprom size '0x4da8' */
+						reg = <0x8000 0x4da8>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+
+					macaddr_factory_4004: macaddr@4004 {
+						reg = <0x4004 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf20000>;
+			};
+
+			partition@f70000 {
+				label = "vendor";
+				reg = <0xf70000 0x80000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "hw";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_4004>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x2f>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1154,6 +1154,14 @@ define Device/wavlink_wl-wn570ha1
 endef
 TARGET_DEVICES += wavlink_wl-wn570ha1
 
+define Device/wavlink_wl-wn570ha2
+  IMAGE_SIZE := 15488k
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN570HA2
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap kmod-mt7603
+endef
+TARGET_DEVICES += wavlink_wl-wn570ha2
+
 define Device/wavlink_wl-wn575a3
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Wavlink

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -177,6 +177,13 @@ wavlink,wl-wn570ha1)
 	ucidef_set_led_rssi "wifi-high" "wifi-high" "green:wifi-high" "wlan0" "85" "100"
 	ucidef_set_led_netdev "wifi_led" "wifi" "green:wifi" "wlan0"
 	;;
+wavlink,wl-wn570ha2)
+	ucidef_set_led_switch "lan" "lan" "blue:lan" "switch0" "0x01"
+	ucidef_set_rssimon "phy1-ap0" "200000" "1"
+	ucidef_set_led_rssi "wifi-low" "wifi-low" "blue:wifi-low" "phy1-ap0" "1" "100"
+	ucidef_set_led_rssi "wifi-med" "wifi-med" "blue:wifi-med" "phy1-ap0" "50" "100"
+	ucidef_set_led_rssi "wifi-high" "wifi-high" "blue:wifi-high" "phy1-ap0" "85" "100"
+	;;
 wavlink,wl-wn575a3)
 	ucidef_set_rssimon "wlan1" "200000" "1"
 	ucidef_set_led_rssi "wifi-low" "wifi-low" "green:wifi-low" "wlan1" "1" "49"


### PR DESCRIPTION
ramips: add support for Wavlink WL-WN570HA2

The Wavlink Aerial HD3 (WL-WN570HA2) is an AC1200 dual-band outdoor
access point.  It supports 802.3AT/AF PoE and is IP67 waterproof. It is based on the MediaTek MT7628DAN SoC and MT7613BEN WiFi 5 chip. This model uses the 100Mbit LAN and 2.4Ghz WiFi elements of the MT7628 and the 5Ghz WiFi of the MT7613.

Specification:
- SoC: MediaTek MT7628DAN (1C/1T) @ 580MHz
- RAM: 64MB DDR2 (integrated in SoC)
- FLASH: 16MB SPI NOR (Fudan FM25Q128A)
- Ethernet: 1x 10/100Mbps
- WiFi: 2.4/5 GHz 2T2R
  - 2.4GHz MediaTek MT7628DAN bgn
  - 5GHz MediaTek MT7613BEN nac
- Antennas: 2x detachable, dual-band 7dBi with RP-SMA connectors.
- USB: none
- BTN: Reset
- LED: 6 total: power; WAN/LAN; WiFi; WiFi low; WiFi med; Wifi high
- UART:  surface-mount on PCB.  Pins are marked via silkscreen. pin1 (square pad, towards Ethernet)=Vcc, pin2=RX, pin3=TX, pin4=GND.  Settings: 57600/8N1. NOTE: The TX & RX silkscreens were reversed on my test unit.

Installation:
1) This device requires a HTTP recovery procedure to do an initial load
  of OpenWRT.  You will need:
  a. A web browser (private window recommended)
  b. Configure an Ethernet interface to 192.168.1.x/24; don't use .1
  c. Connect a cable between the computer and the Wavlink's PoE injector.
2) Put the Wavlink in HTTP recovery mode.
  a. Do this by pressing and holding the reset button on the bottom while
  powering the unit on.
  b. As soon as all 6 LEDs light up blue (roughly 2-3 seconds), release
  the button.
  c. The LEDs should all remain lit, indicating it's in HTTP recovery.
3) Point the browser at http://192.168.1.1/index.html 4) Click "Choose File" and select the OpenWRT sysupgrade image. 5) Click the "Update Firmware" button and wait while the unit flashes the image and reboots.
6) When the system comes back up fully, only the power LED will be lit. Wait an extra minute then you should be able to reach OpenWRT on http://192.168.1.1
5) Log into LuCI as root; there is no password.

Revert to the OEM Firmware:
--------------------------
* U-boot HTTP: Follow the HTTP recovery steps, and use a firmware image downloaded from Wavlink.

