### PR TITLE
tools/elftosb: fix compilation with C++17

### DIFF
--- a/tools/elftosb/patches/010-no-register.patch
+++ b/tools/elftosb/patches/010-no-register.patch
@@ -1,0 +1,113 @@
+--- a/elftosb2/elftosb_lexer.cpp
++++ b/elftosb2/elftosb_lexer.cpp
+@@ -722,9 +722,9 @@ static int yy_flex_strlen (yyconst char
+  */
+ YY_DECL
+ {
+-	register yy_state_type yy_current_state;
+-	register char *yy_cp, *yy_bp;
+-	register int yy_act;
++	yy_state_type yy_current_state;
++	char *yy_cp, *yy_bp;
++	int yy_act;
+     
+ #line 38 "/Users/creed/projects/fsl/fromsvr/elftosb/elftosb2/elftosb_lexer.l"
+ 
+@@ -773,7 +773,7 @@ YY_DECL
+ yy_match:
+ 		do
+ 			{
+-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
++			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+ 			if ( yy_accept[yy_current_state] )
+ 				{
+ 				(yy_last_accepting_state) = yy_current_state;
+@@ -1555,9 +1555,9 @@ void yyFlexLexer::LexerOutput( const cha
+  */
+ int yyFlexLexer::yy_get_next_buffer()
+ {
+-    	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+-	register char *source = (yytext_ptr);
+-	register int number_to_move, i;
++    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
++	char *source = (yytext_ptr);
++	int number_to_move, i;
+ 	int ret_val;
+ 
+ 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
+@@ -1689,14 +1689,14 @@ int yyFlexLexer::yy_get_next_buffer()
+ 
+     yy_state_type yyFlexLexer::yy_get_previous_state()
+ {
+-	register yy_state_type yy_current_state;
+-	register char *yy_cp;
++	yy_state_type yy_current_state;
++	char *yy_cp;
+     
+ 	yy_current_state = (yy_start);
+ 
+ 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
+ 		{
+-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
++		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+ 		if ( yy_accept[yy_current_state] )
+ 			{
+ 			(yy_last_accepting_state) = yy_current_state;
+@@ -1721,10 +1721,10 @@ int yyFlexLexer::yy_get_next_buffer()
+  */
+     yy_state_type yyFlexLexer::yy_try_NUL_trans( yy_state_type yy_current_state )
+ {
+-	register int yy_is_jam;
+-    	register char *yy_cp = (yy_c_buf_p);
++	int yy_is_jam;
++    	char *yy_cp = (yy_c_buf_p);
+ 
+-	register YY_CHAR yy_c = 1;
++	YY_CHAR yy_c = 1;
+ 	if ( yy_accept[yy_current_state] )
+ 		{
+ 		(yy_last_accepting_state) = yy_current_state;
+@@ -1742,9 +1742,9 @@ int yyFlexLexer::yy_get_next_buffer()
+ 	return yy_is_jam ? 0 : yy_current_state;
+ }
+ 
+-    void yyFlexLexer::yyunput( int c, register char* yy_bp)
++    void yyFlexLexer::yyunput( int c, char* yy_bp)
+ {
+-	register char *yy_cp;
++	char *yy_cp;
+     
+     yy_cp = (yy_c_buf_p);
+ 
+@@ -1754,10 +1754,10 @@ int yyFlexLexer::yy_get_next_buffer()
+ 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
+ 		{ /* need to shift things up to make room */
+ 		/* +2 for EOB chars. */
+-		register yy_size_t number_to_move = (yy_n_chars) + 2;
+-		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
++		yy_size_t number_to_move = (yy_n_chars) + 2;
++		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
+ 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
+-		register char *source =
++		char *source =
+ 				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
+ 
+ 		while ( source > YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
+@@ -2190,7 +2190,7 @@ void yyFlexLexer::LexerError( yyconst ch
+ #ifndef yytext_ptr
+ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+ {
+-	register int i;
++	int i;
+ 	for ( i = 0; i < n; ++i )
+ 		s1[i] = s2[i];
+ }
+@@ -2199,7 +2199,7 @@ static void yy_flex_strncpy (char* s1, y
+ #ifdef YY_NEED_STRLEN
+ static int yy_flex_strlen (yyconst char * s )
+ {
+-	register int n;
++	int n;
+ 	for ( n = 0; s[n]; ++n )
+ 		;
+ 


### PR DESCRIPTION
Newer GCC and Clang default to C++17, which does not support register. Just remove it.