### PR TITLE
ath79: remove platform_device_id from drivers

### DIFF
--- a/target/linux/ath79/files/drivers/gpio/gpio-rb4xx.c
+++ b/target/linux/ath79/files/drivers/gpio/gpio-rb4xx.c
@@ -141,15 +141,8 @@ static int rb4xx_gpio_probe(struct platform_device *pdev)
 	return devm_gpiochip_add_data(&pdev->dev, &gpio->chip, gpio);
 }
 
-static const struct platform_device_id rb4xx_gpio_id_table[] = {
-	{ "mikrotik,rb4xx-gpio", },
-	{ },
-};
-MODULE_DEVICE_TABLE(platform, rb4xx_gpio_id_table);
-
 static struct platform_driver rb4xx_gpio_driver = {
 	.probe = rb4xx_gpio_probe,
-	.id_table = rb4xx_gpio_id_table,
 	.driver = {
 		.name = "rb4xx-gpio",
 	},

--- a/target/linux/ath79/files/drivers/mtd/nand/raw/nand_rb4xx.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/nand_rb4xx.c
@@ -222,16 +222,9 @@ static void rb4xx_nand_remove(struct platform_device *pdev)
 	nand_cleanup(&nand->chip);
 }
 
-static const struct platform_device_id rb4xx_nand_id_table[] = {
-	{ "mikrotik,rb4xx-nand", },
-	{ },
-};
-MODULE_DEVICE_TABLE(platform, rb4xx_nand_id_table);
-
 static struct platform_driver rb4xx_nand_driver = {
 	.probe = rb4xx_nand_probe,
 	.remove_new = rb4xx_nand_remove,
-	.id_table = rb4xx_nand_id_table,
 	.driver = {
 		.name = "rb4xx-nand",
 	},


### PR DESCRIPTION
This was needed while ar71xx was in tree. This is no longer the case. Not only that, these have already been converted to OF.

ping @robimarko @DragonBluep 