### PR TITLE
mold: update to 2.39.1

### DIFF
--- a/tools/mold/Makefile
+++ b/tools/mold/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mold
-PKG_VERSION:=2.38.1
+PKG_VERSION:=2.39.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL_FILE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rui314/mold/archive/refs/tags
-PKG_HASH:=14bfb259fd7d0a1fdce9b66f8ed2dd0b134d15019cb359699646afeee1f18118
+PKG_HASH:=231ea3643a14fe5b88478c97b68b31f7c975b57b247a81356ffd889d015b5cc1
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
Update to latest mold linker version 2.39.1.
