### PR TITLE
realtek: Identify RTL9311 properly

### DIFF
--- a/target/linux/realtek/files-6.6/arch/mips/rtl838x/prom.c
+++ b/target/linux/realtek/files-6.6/arch/mips/rtl838x/prom.c
@@ -181,6 +181,10 @@ void __init prom_init(void)
 		soc_info.name = "RTL9303";
 		soc_info.family = RTL9300_FAMILY_ID;
 		break;
+	case 0x9311:
+		soc_info.name = "RTL9311";
+		soc_info.family = RTL9310_FAMILY_ID;
+		break;
 	case 0x9313:
 		soc_info.name = "RTL9313";
 		soc_info.family = RTL9310_FAMILY_ID;


### PR DESCRIPTION
RTL9311 switches (like the Linksys LGS352C) will boot but have not set the right family id in the soc_info structure. Fix that so drivers do their work right when checking for that.