### PR TITLE
ath79: iodata: extract calibration with nvmem

### DIFF
--- a/target/linux/ath79/dts/ar1022_iodata_wn-ag300dgr.dts
+++ b/target/linux/ath79/dts/ar1022_iodata_wn-ag300dgr.dts
@@ -159,6 +159,16 @@
 				label = "art";
 				reg = <0xff0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+				};
 			};
 		};
 	};
@@ -207,5 +217,6 @@
 &wmac {
 	status = "okay";
 
-	qca,no-eeprom;
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/dts/ar1022_iodata_wn-ag300dgr.dts
+++ b/target/linux/ath79/dts/ar1022_iodata_wn-ag300dgr.dts
@@ -40,12 +40,6 @@
 			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		};
 
-		wlan2g {
-			label = "green:wlan2g";
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		wlan5g {
 			label = "green:wlan5g";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
@@ -219,4 +213,9 @@
 
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <12>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
@@ -148,6 +148,10 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
 					cal_art_5000: calibration@5000 {
 						reg = <0x5000 0x844>;
 					};
@@ -199,5 +203,6 @@
 &wmac {
 	status = "okay";
 
-	qca,no-eeprom;
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
@@ -35,12 +35,6 @@
 			linux,default-trigger = "phy0tpt";
 		};
 
-		wlan2g {
-			label = "green:wlan2g";
-			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
 		notification {
 			label = "amber:notification";
 			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
@@ -185,7 +179,7 @@
 	status = "okay";
 
 	wifi@0,0 {
-		compatible = "pci168c,003c";
+		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&cal_art_5000>;
 		nvmem-cell-names = "calibration";
@@ -205,4 +199,9 @@
 
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <22>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -45,10 +45,6 @@ case "$FIRMWARE" in
 		caldata_extract "art" 0x1000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii cfg1 RADIOADDR1)
 		;;
-	iodata,wn-ac1167dgr|\
-	iodata,wn-ac1600dgr|\
-	iodata,wn-ac1600dgr2|\
-	iodata,wn-ag300dgr|\
 	sitecom,wlr-7100|\
 	sitecom,wlr-8100)
 		caldata_extract "art" 0x1000 0x440

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -73,18 +73,23 @@ case "$board" in
 		;;
 	iodata,wn-ac1167dgr|\
 	iodata,wn-ac1600dgr|\
-	iodata,wn-ac1600dgr2|\
-	sitecom,wlr-7100|\
-	sitecom,wlr-8100)
+	iodata,wn-ac1600dgr2)
 		# There is no eeprom data for 5 GHz wlan in "art" partition
 		# which would allow to patch the macaddress
 		[ "$PHYNBR" -eq 0 ] && \
 			macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" 1 > /sys${DEVPATH}/macaddress
 		;;
+		[ "$PHYNBR" -eq 1 ] && \
+			macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" 0 > /sys${DEVPATH}/macaddress
+		;;
 	iodata,wn-ag300dgr)
 		# There is no eeprom data for 5 GHz wlan in "art" partition
 		# which would allow to patch the macaddress
-		[ "$PHYNBR" -eq 1 ] && \
+		macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" $PHYNBR > /sys${DEVPATH}/macaddress
+		;;
+	sitecom,wlr-7100|\
+	sitecom,wlr-8100)
+		[ "$PHYNBR" -eq 0 ] && \
 			macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" 1 > /sys${DEVPATH}/macaddress
 		;;
 	nec,wf1200cr|\


### PR DESCRIPTION
Userspace handling is deprecated.

ping @musashino205 

IIRC the uboot-env driver can't be used because of "" usage.