### PR TITLE
mediatek: filogic: D-Link M30/M60: add OpenWrt partition layout

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -110,6 +110,7 @@ zbtlink,zbt-z8103ax)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
 dlink,aquila-pro-ai-m30-a1|\
+dlink,aquila-pro-ai-m30-a1-ubootmod|\
 dlink,aquila-pro-ai-m60-a1)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x40000"
 	;;

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -142,7 +142,8 @@ comfast,cf-wa933-128m)
 dlink,aquila-pro-ai-e30-a1|\
 dlink,aquila-pro-ai-m30-a1|\
 dlink,aquila-pro-ai-m30-a1-ubootmod|\
-dlink,aquila-pro-ai-m60-a1)
+dlink,aquila-pro-ai-m60-a1|\
+dlink,aquila-pro-ai-m60-a1-ubootmod)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x40000"
 	;;
 gatonetworks,gdsp)

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -141,6 +141,7 @@ comfast,cf-wa933-128m)
 	;;
 dlink,aquila-pro-ai-e30-a1|\
 dlink,aquila-pro-ai-m30-a1|\
+dlink,aquila-pro-ai-m30-a1-ubootmod|\
 dlink,aquila-pro-ai-m60-a1)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x40000"
 	;;

--- a/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-m30-a1-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-m30-a1-ubootmod.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include "mt7981b-dlink-aquila-pro-ai-m30-a1.dts"
+
+/ {
+	model = "D-Link AQUILA PRO AI M30 A1 (OpenWrt partition layout)";
+	compatible = "dlink,aquila-pro-ai-m30-a1-ubootmod", "mediatek,mt7981";
+};
+
+&partitions {
+	/* ubi is the result of squashing
+	 * consecutive stock partitions:
+	 * - ubi
+	 * - ubi1
+	 */
+	partition@580000 {
+		reg = <0x580000 0x6400000>;
+	};
+
+	/delete-node/ partition@3780000;
+};

--- a/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-m30-a1.dts
+++ b/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-m30-a1.dts
@@ -148,7 +148,7 @@
 		mediatek,bmt-max-ratio = <1>;
 		mediatek,bmt-max-reserved-blocks = <64>;
 
-		partitions {
+		partitions: partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1-ubootmod.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include "mt7986a-dlink-aquila-pro-ai-m60-a1.dts"
+
+/ {
+	model = "D-Link AQUILA PRO AI M60 A1 (OpenWrt partition layout)";
+	compatible = "dlink,aquila-pro-ai-m60-a1-ubootmod", "mediatek,mt7986a";
+};
+
+&partitions {
+	/* ubi is the result of squashing
+	 * consecutive stock partitions:
+	 * - ubi
+	 * - ubi1
+	 */
+	partition@580000 {
+		reg = <0x580000 0x6400000>;
+	};
+
+	/delete-node/ partition@3780000;
+};

--- a/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
+++ b/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
@@ -220,7 +220,7 @@
 		mediatek,bmt-max-ratio = <1>;
 		mediatek,bmt-max-reserved-blocks = <64>;
 
-		partitions {
+		partitions: partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -129,6 +129,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan eth1 eth0
 		;;
 	dlink,aquila-pro-ai-m30-a1|\
+	dlink,aquila-pro-ai-m30-a1-ubootmod|\
 	dlink,aquila-pro-ai-m60-a1)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" internet
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -187,7 +187,8 @@ mediatek_setup_interfaces()
 		;;
 	dlink,aquila-pro-ai-m30-a1|\
 	dlink,aquila-pro-ai-m30-a1-ubootmod|\
-	dlink,aquila-pro-ai-m60-a1)
+	dlink,aquila-pro-ai-m60-a1|\
+	dlink,aquila-pro-ai-m60-a1-ubootmod)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" internet
 		;;
 	comfast,cf-wr632ax|\

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -186,6 +186,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interface_lan "lan"
 		;;
 	dlink,aquila-pro-ai-m30-a1|\
+	dlink,aquila-pro-ai-m30-a1-ubootmod|\
 	dlink,aquila-pro-ai-m60-a1)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" internet
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -101,7 +101,8 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr 1) > /sys${DEVPATH}/macaddress
 		;;
-	dlink,aquila-pro-ai-m30-a1)
+	dlink,aquila-pro-ai-m30-a1|\
+	dlink,aquila-pro-ai-m30-a1-ubootmod)
 		addr=$(mtd_get_mac_binary "Odm" 0x81)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -118,7 +118,8 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr 1) > /sys${DEVPATH}/macaddress
 		;;
-	dlink,aquila-pro-ai-m30-a1)
+	dlink,aquila-pro-ai-m30-a1|\
+	dlink,aquila-pro-ai-m30-a1-ubootmod)
 		addr=$(mtd_get_mac_binary "Odm" 0x81)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -24,6 +24,20 @@ buffalo_initial_setup()
 	ubiformat /dev/mtd$mtdnum -y
 }
 
+dlink_initial_setup()
+{
+	# setup uboot-env if it's running on initramfs
+	[ "$(rootfs_type)" = "tmpfs" ] || return 0
+
+	local board=$(board_name)
+	case "$board" in
+	dlink,aquila-pro-ai-m30-a1-ubootmod)
+		fw_setenv mtdparts "nmbm0:1024k(bl2),512k(u-boot-env),2048k(factory),2048k(fip),102400k(ubi),256k(Odm),512k(Config1),512k(Config2),5120k(Storage)"
+		fw_setenv mupgrade_en 0
+		;;
+	esac
+}
+
 xiaomi_initial_setup()
 {
 	# initialize UBI and setup uboot-env if it's running on initramfs
@@ -164,6 +178,7 @@ platform_do_upgrade() {
 		default_do_upgrade "$1"
 		;;
 	dlink,aquila-pro-ai-m30-a1|\
+	dlink,aquila-pro-ai-m30-a1-ubootmod|\
 	dlink,aquila-pro-ai-m60-a1)
 		fw_setenv sw_tryactive 0
 		nand_do_upgrade "$1"
@@ -375,6 +390,9 @@ platform_pre_upgrade() {
 		;;
 	buffalo,wsr-6000ax8)
 		buffalo_initial_setup
+		;;
+	dlink,aquila-pro-ai-m30-a1-ubootmod)
+		dlink_initial_setup
 		;;
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-wr30u-stock|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -31,7 +31,8 @@ dlink_initial_setup()
 
 	local board=$(board_name)
 	case "$board" in
-	dlink,aquila-pro-ai-m30-a1-ubootmod)
+	dlink,aquila-pro-ai-m30-a1-ubootmod|\
+	dlink,aquila-pro-ai-m60-a1-ubootmod)
 		fw_setenv mtdparts "nmbm0:1024k(bl2),512k(u-boot-env),2048k(factory),2048k(fip),102400k(ubi),256k(Odm),512k(Config1),512k(Config2),5120k(Storage)"
 		fw_setenv mupgrade_en 0
 		;;
@@ -317,7 +318,8 @@ platform_do_upgrade() {
 	dlink,aquila-pro-ai-e30-a1|\
 	dlink,aquila-pro-ai-m30-a1|\
 	dlink,aquila-pro-ai-m30-a1-ubootmod|\
-	dlink,aquila-pro-ai-m60-a1)
+	dlink,aquila-pro-ai-m60-a1|\
+	dlink,aquila-pro-ai-m60-a1-ubootmod)
 		fw_setenv sw_tryactive 0
 		nand_do_upgrade "$1"
 		;;
@@ -558,7 +560,8 @@ platform_pre_upgrade() {
 	buffalo,wsr-6000ax8)
 		buffalo_initial_setup
 		;;
-	dlink,aquila-pro-ai-m30-a1-ubootmod)
+	dlink,aquila-pro-ai-m30-a1-ubootmod|\
+	dlink,aquila-pro-ai-m60-a1-ubootmod)
 		dlink_initial_setup
 		;;
 	elecom,wrc-x6000gsd|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -24,6 +24,20 @@ buffalo_initial_setup()
 	ubiformat /dev/mtd$mtdnum -y
 }
 
+dlink_initial_setup()
+{
+	# setup uboot-env if it's running on initramfs
+	[ "$(rootfs_type)" = "tmpfs" ] || return 0
+
+	local board=$(board_name)
+	case "$board" in
+	dlink,aquila-pro-ai-m30-a1-ubootmod)
+		fw_setenv mtdparts "nmbm0:1024k(bl2),512k(u-boot-env),2048k(factory),2048k(fip),102400k(ubi),256k(Odm),512k(Config1),512k(Config2),5120k(Storage)"
+		fw_setenv mupgrade_en 0
+		;;
+	esac
+}
+
 jiorouter_initial_setup()
 {
 	[ "$(rootfs_type)" = "tmpfs" ] || return 0
@@ -302,6 +316,7 @@ platform_do_upgrade() {
 		;;
 	dlink,aquila-pro-ai-e30-a1|\
 	dlink,aquila-pro-ai-m30-a1|\
+	dlink,aquila-pro-ai-m30-a1-ubootmod|\
 	dlink,aquila-pro-ai-m60-a1)
 		fw_setenv sw_tryactive 0
 		nand_do_upgrade "$1"
@@ -542,6 +557,9 @@ platform_pre_upgrade() {
 		;;
 	buffalo,wsr-6000ax8)
 		buffalo_initial_setup
+		;;
+	dlink,aquila-pro-ai-m30-a1-ubootmod)
+		dlink_initial_setup
 		;;
 	elecom,wrc-x6000gsd|\
 	elecom,wrc-x6000qs)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1220,6 +1220,13 @@ endif
 endef
 TARGET_DEVICES += dlink_aquila-pro-ai-m30-a1
 
+define Device/dlink_aquila-pro-ai-m30-a1-ubootmod
+  $(Device/dlink_aquila-pro-ai-m30-a1)
+  DEVICE_MODEL := AQUILA PRO AI M30 (OpenWrt partition layout)
+  DEVICE_DTS := mt7981b-dlink-aquila-pro-ai-m30-a1-ubootmod
+endef
+TARGET_DEVICES += dlink_aquila-pro-ai-m30-a1-ubootmod
+
 define Device/dlink_aquila-pro-ai-m60-a1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := AQUILA PRO AI M60

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1772,6 +1772,13 @@ endif
 endef
 TARGET_DEVICES += dlink_aquila-pro-ai-m60-a1
 
+define Device/dlink_aquila-pro-ai-m60-a1-ubootmod
+  $(Device/dlink_aquila-pro-ai-m60-a1)
+  DEVICE_VARIANT := A1 (OpenWrt partition layout)
+  DEVICE_DTS := mt7986a-dlink-aquila-pro-ai-m60-a1-ubootmod
+endef
+TARGET_DEVICES += dlink_aquila-pro-ai-m60-a1-ubootmod
+
 define Device/edgecore_eap111
   DEVICE_VENDOR := Edgecore
   DEVICE_MODEL := EAP111

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1746,6 +1746,13 @@ endif
 endef
 TARGET_DEVICES += dlink_aquila-pro-ai-m30-a1
 
+define Device/dlink_aquila-pro-ai-m30-a1-ubootmod
+  $(Device/dlink_aquila-pro-ai-m30-a1)
+  DEVICE_VARIANT := A1 (OpenWrt partition layout)
+  DEVICE_DTS := mt7981b-dlink-aquila-pro-ai-m30-a1-ubootmod
+endef
+TARGET_DEVICES += dlink_aquila-pro-ai-m30-a1-ubootmod
+
 define Device/dlink_aquila-pro-ai-m60-a1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := AQUILA PRO AI M60


### PR DESCRIPTION
This commit adds OpenWrt partition layout support for D-Link Aquila M30/M60. The aim is to concatenate ubi and ubi1 for additional 50MB space for user data.

Suffix 'ubootmod' is added because it is not possible to directly sysupgrade to this version. Stock version is kept for people who want to keep stock 50/50 layout.

Recovery image is built with iniramfs, so that OpenWRT can boot even if current partition layout is different. Then, on sysupgrade partition layout is updated in u-boot-env and system can boot normally.

Setting mupgrade_en to 0 is required to avoid u-boot running 'aup' command (Auto Upgrade?), because it restores stock partition layout.

Install:
--------
From any firmware (OEM or OpenWrt):
 - Set your IP address to 192.168.200.2, subnetmask 255.255.255.0
 - Press the reset button while powering on the device
 - Keep the reset button pressed until the LED blinks red
 - Open a Chromium based and goto http://192.168.200.1 (recovery web interface)
 - Download openwrt-mediatek-filogic-dlink_aquila-pro-ai-m30-a1-ubootmod-squashfs-recovery.bin
 - The recovery web interface always reports successful flashing, even if it fails
 - After flashing, the recovery web interface will try to forward the browser to 192.168.0.1 (can be ignored)
 - OpenWrt initramfs should start - the LED will blink white and stay white at the end
 - Perform a sysupgrade using openwrt-mediatek-filogic-dlink_aquila-pro-ai-m30-a1-ubootmod-squashfs-sysupgrade.bin

Return to stock:
----------------

1. Prepare DECRYPTED OEM firmware.

2. Start OpenWRT and run:
```
fw_setenv sw_tryactive 0
fw_setenv boot_by_tryactive "env default -a; saveenv; aup; reset"
```

3. After a reboot, router will boot into OEM recovery, where you can flash a DECRYPTED OEM image.
