### PR TITLE
[23.05] tools: add cmake dependency to bzip2

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -90,6 +90,7 @@ $(curdir)/automake/compile := $(curdir)/autoconf/compile $(curdir)/pkgconf/compi
 $(curdir)/b43-tools/compile := $(curdir)/bison/compile
 $(curdir)/bc/compile := $(curdir)/bison/compile $(curdir)/libtool/compile
 $(curdir)/bison/compile := $(curdir)/flex/compile
+$(curdir)/bzip2/compile := $(curdir)/cmake/compile
 $(curdir)/cbootimage/compile += $(curdir)/automake/compile
 $(curdir)/cmake/compile += $(curdir)/libressl/compile $(curdir)/ninja/compile $(curdir)/expat/compile $(curdir)/xz/compile $(curdir)/zlib/compile $(curdir)/zstd/compile
 $(curdir)/dosfstools/compile := $(curdir)/automake/compile


### PR DESCRIPTION
It's using cmake.mk so it needs CMake to build.

Link: https://github.com/openwrt/openwrt/pull/18880

(cherry picked from commit 9deb8fad2fbe6fcdc7fbe5d2eb6d8fd78992f485)

@robimarko Just thought it might make sense to backport this by one further release since there will be one final release of OpenWrt 23.05 at some point.