### PR TITLE
ramips: adjust the power regulators of MMC and XHCI controllers

### DIFF
--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -32,26 +32,20 @@
 		compatible = "mti,cpu-interrupt-controller";
 	};
 
-	mmc_reg_1v8: regulator-1v8 {
+	reg_vmmc: regulator-vmmc {
 		compatible = "regulator-fixed";
-
-		enable-active-high;
-
-		regulator-always-on;
-		regulator-max-microvolt = <1800000>;
-		regulator-min-microvolt = <1800000>;
-		regulator-name = "mmc_io";
-	};
-
-	mmc_reg_3v3: regulator-3v3 {
-		compatible = "regulator-fixed";
-
-		enable-active-high;
-
 		regulator-always-on;
 		regulator-max-microvolt = <3300000>;
 		regulator-min-microvolt = <3300000>;
 		regulator-name = "mmc_power";
+	};
+
+	reg_vqmmc: regulator-vqmmc {
+		compatible = "regulator-fixed";
+		regulator-always-on;
+		regulator-max-microvolt = <3300000>;
+		regulator-min-microvolt = <3300000>;
+		regulator-name = "mmc_io";
 	};
 
 	palmbus: palmbus@10000000 {
@@ -528,19 +522,17 @@
 		reg = <0x10130000 0x4000>;
 
 		bus-width = <4>;
-
+		max-frequency = <24000000>;
 		cap-mmc-highspeed;
 		cap-sd-highspeed;
+		disable-wp;
+		no-1-8-v;
 
 		clocks = <&sysc 15>, <&sysc 15>;
 		clock-names = "source", "hclk";
 
-		disable-wp;
-
 		interrupt-parent = <&intc>;
 		interrupts = <14>;
-
-		max-frequency = <24000000>;
 
 		pinctrl-names = "default", "state_uhs";
 		pinctrl-0 = <&sdhci_pins>;
@@ -549,8 +541,8 @@
 		resets = <&sysc 30>;
 		reset-names = "hrst";
 
-		vmmc-supply = <&mmc_reg_3v3>;
-		vqmmc-supply = <&mmc_reg_1v8>;
+		vmmc-supply = <&reg_vmmc>;
+		vqmmc-supply = <&reg_vqmmc>;
 
 		status = "disabled";
 	};

--- a/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
+++ b/target/linux/ramips/dts/mt7620a_hiwifi_hc5861.dts
@@ -87,12 +87,6 @@
 	mediatek,ephy-base = /bits/ 8 <12>;
 };
 
-&mmc_reg_3v3 {
-	/delete-property/ enable-active-high;
-
-	gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
-};
-
 &pcie {
 	status = "okay";
 };
@@ -105,6 +99,10 @@
 		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
+};
+
+&reg_vmmc {
+	gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 };
 
 &wmac {

--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -64,6 +64,22 @@
 		regulator-name = "mmc_power";
 	};
 
+	reg_vbus: regulator-vbus {
+		compatible = "regulator-fixed";
+		regulator-always-on;
+		regulator-max-microvolt = <5000000>;
+		regulator-min-microvolt = <5000000>;
+		regulator-name = "usb_power";
+	};
+
+	reg_vusb33: regulator-vusb33 {
+		compatible = "regulator-fixed";
+		regulator-always-on;
+		regulator-max-microvolt = <3300000>;
+		regulator-min-microvolt = <3300000>;
+		regulator-name = "usb_io";
+	};
+
 	palmbus: palmbus@1e000000 {
 		compatible = "palmbus";
 		reg = <0x1e000000 0x100000>;
@@ -394,6 +410,9 @@
 
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SHARED 22 IRQ_TYPE_LEVEL_HIGH>;
+
+		vbus-supply = <&reg_vbus>;
+		vusb33-supply = <&reg_vusb33>;
 
 		/*
 		 * Port 1 of both hubs is one usb slot and referenced here.

--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -42,26 +42,20 @@
 		bootargs = "console=ttyS0,57600";
 	};
 
-	mmc_reg_1v8: regulator-1v8 {
+	reg_vmmc: regulator-vmmc {
 		compatible = "regulator-fixed";
-
-		enable-active-high;
-
-		regulator-always-on;
-		regulator-max-microvolt = <1800000>;
-		regulator-min-microvolt = <1800000>;
-		regulator-name = "mmc_io";
-	};
-
-	mmc_reg_3v3: regulator-3v3 {
-		compatible = "regulator-fixed";
-
-		enable-active-high;
-
 		regulator-always-on;
 		regulator-max-microvolt = <3300000>;
 		regulator-min-microvolt = <3300000>;
 		regulator-name = "mmc_power";
+	};
+
+	reg_vqmmc: regulator-vqmmc {
+		compatible = "regulator-fixed";
+		regulator-always-on;
+		regulator-max-microvolt = <3300000>;
+		regulator-min-microvolt = <3300000>;
+		regulator-name = "mmc_io";
 	};
 
 	reg_vbus: regulator-vbus {
@@ -369,19 +363,17 @@
 		reg = <0x1e130000 0x4000>;
 
 		bus-width = <4>;
-
+		max-frequency = <48000000>;
 		cap-mmc-highspeed;
 		cap-sd-highspeed;
+		disable-wp;
+		no-1-8-v;
 
 		clocks = <&sysc MT7621_CLK_SHXC>, <&sysc MT7621_CLK_SHXC>;
 		clock-names = "source", "hclk";
 
-		disable-wp;
-
 		interrupt-parent = <&gic>;
 		interrupts = <GIC_SHARED 20 IRQ_TYPE_LEVEL_HIGH>;
-
-		max-frequency = <48000000>;
 
 		pinctrl-names = "default", "state_uhs";
 		pinctrl-0 = <&sdhci_pins>;
@@ -390,8 +382,8 @@
 		resets = <&sysc MT7621_RST_SDXC>;
 		reset-names = "hrst";
 
-		vmmc-supply = <&mmc_reg_3v3>;
-		vqmmc-supply = <&mmc_reg_1v8>;
+		vmmc-supply = <&reg_vmmc>;
+		vqmmc-supply = <&reg_vqmmc>;
 
 		status = "disabled";
 	};

--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -79,16 +79,6 @@
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
-
-	reg_power_usb3: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "power_usb3";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-		regulator-boot-on;
-	};
 };
 
 &spi0 {
@@ -154,10 +144,6 @@
 	};
 };
 
-&xhci {
-	vbus-supply = <&reg_power_usb3>;
-};
-
 &pcie {
 	status = "okay";
 };
@@ -182,6 +168,13 @@
 &gmac0 {
 	nvmem-cells = <&macaddr_factory_e000>;
 	nvmem-cell-names = "mac-address";
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+	regulator-boot-on;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
@@ -60,24 +60,6 @@
 		};
 	};
 
-	reg_usb_vbus: regulator-usb {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-
-	reg_3p3v: regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-
 	gpio_export {
 		compatible = "gpio-export";
 
@@ -106,11 +88,6 @@
 
 &sdhci {
 	status = "okay";
-};
-
-&xhci {
-	vusb33-supply = <&reg_3p3v>;
-	vbus-supply = <&reg_usb_vbus>;
 };
 
 &spi0 {
@@ -217,6 +194,18 @@
 &gmac0 {
 	nvmem-cells = <&macaddr_factory_e000>;
 	nvmem-cell-names = "mac-address";
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
+&reg_vusb33 {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_dual-q_h721.dts
+++ b/target/linux/ramips/dts/mt7621_dual-q_h721.dts
@@ -75,27 +75,6 @@
 			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	reg_usb_vbus: regulator-usb {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
-	};
-
-	reg_3p3v: regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
-	};
-};
-
-&xhci {
-	vusb33-supply = <&reg_3p3v>;
-	vbus-supply = <&reg_usb_vbus>;
 };
 
 &spi0 {
@@ -156,6 +135,16 @@
 
 &pcie {
 	status = "okay";
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+};
+
+&reg_vusb33 {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_gemtek_wvrtm-1xxacn.dtsi
+++ b/target/linux/ramips/dts/mt7621_gemtek_wvrtm-1xxacn.dtsi
@@ -119,24 +119,6 @@
 		reg = <0x0 0x8000000>;
 	};
 
-	reg_usb_vbus: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
-
-	reg_3p3v: regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
-
 	ubi-concat {
 		compatible = "mtd-concat";
 		devices = <&ubiconcat0 &ubiconcat1 &ubiconcat2 &ubiconcat3>;
@@ -279,9 +261,4 @@
 			nvmem-cell-names = "mac-address";
 		};
 	};
-};
-
-&xhci {
-	vbus-supply = <&reg_usb_vbus>;
-	vusb33-supply = <&reg_3p3v>;
 };

--- a/target/linux/ramips/dts/mt7621_humax_e10.dts
+++ b/target/linux/ramips/dts/mt7621_humax_e10.dts
@@ -55,16 +55,6 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
-
-	reg_power_usb: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "power:usb";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-		regulator-boot-on;
-	};
 };
 
 &spi0 {
@@ -131,10 +121,6 @@
 	};
 };
 
-&xhci {
-	vbus-supply = <&reg_power_usb>;
-};
-
 &pcie {
 	status = "okay";
 };
@@ -175,6 +161,13 @@
 
 &ethphy0 {
 	/delete-property/ interrupts;
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+	regulator-boot-on;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_keenetic_kn-1910.dts
+++ b/target/linux/ramips/dts/mt7621_keenetic_kn-1910.dts
@@ -17,24 +17,6 @@
 		label-mac-device = &gmac0;
 	};
 
-	reg_usb_vbus: regulator-usb {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-
-	reg_3p3v: regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-
 	keys {
 		compatible = "gpio-keys";
 
@@ -113,11 +95,6 @@
 			};
 		};
 	};
-};
-
-&xhci {
-	vbus-supply = <&reg_usb_vbus>;
-	vusb33-supply = <&reg_3p3v>;
 };
 
 &nand {
@@ -257,6 +234,18 @@
 
 	nvmem-cells = <&macaddr_factory_28>;
 	nvmem-cell-names = "mac-address";
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
+&reg_vusb33 {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -58,33 +58,10 @@
 			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
-
-	reg_usb_vbus: regulator-usb {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-
-	reg_3p3v: regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
 };
 
 &sdhci {
 	status = "okay";
-};
-
-&xhci {
-	vusb33-supply = <&reg_3p3v>;
-	vbus-supply = <&reg_usb_vbus>;
 };
 
 &spi0 {
@@ -187,6 +164,18 @@
 
 &ethphy4 {
 	/delete-property/ interrupts;
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
+&reg_vusb33 {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
+++ b/target/linux/ramips/dts/mt7621_mikrotik_routerboard-7xx.dtsi
@@ -13,20 +13,6 @@
 			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
 		};
 	};
-
-	reg_usb_power: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_power";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-		regulator-boot-on;
-	};
-};
-
-&xhci {
-	vbus-supply = <&reg_usb_power>;
 };
 
 &keys {
@@ -43,6 +29,13 @@
 		label = "firmware";
 		reg = <0x040000 0xfc0000>;
 	};
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+	regulator-boot-on;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_ayx.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_ayx.dtsi
@@ -73,19 +73,6 @@
 			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	reg_usb_vbus: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
-&xhci {
-	vbus-supply = <&reg_usb_vbus>;
 };
 
 &pcie {
@@ -120,6 +107,12 @@
 
 &ethphy4 {
 	/delete-property/ interrupts;
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
@@ -62,19 +62,6 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
-
-	reg_usb_vbus: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
-&xhci {
-	vbus-supply = <&reg_usb_vbus>;
 };
 
 &pcie {
@@ -117,6 +104,12 @@
 
 &ethphy4 {
 	/delete-property/ interrupts;
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
@@ -65,15 +65,6 @@
 		gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
-
-	reg_3p3v: regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
 };
 
 &gmac0 {
@@ -218,5 +209,4 @@
 
 &xhci {
 	vbus-supply = <&reg_usb_vbus>;
-	vusb33-supply = <&reg_3p3v>;
 };

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me1.dts
@@ -56,15 +56,6 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
-
-	reg_usb_vbus: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
 };
 
 &gmac0 {
@@ -107,6 +98,12 @@
 		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &spi0 {
@@ -205,8 +202,4 @@
 			label = "lan1";
 		};
 	};
-};
-
-&xhci {
-	vbus-supply = <&reg_usb_vbus>;
 };

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
@@ -58,15 +58,12 @@
 		tx-disable-gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
 		maximum-power-milliwatt = <1000>;
 	};
+};
 
-	reg_usb_vbus: regulator-usb {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &state_default {
@@ -191,10 +188,6 @@
 			label = "lan4";
 		};
 	};
-};
-
-&xhci {
-	vbus-supply = <&reg_usb_vbus>;
 };
 
 &pcie {

--- a/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-cpe-me2-sfp.dts
@@ -67,15 +67,6 @@
 		gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
-
-	reg_3p3v: regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
 };
 
 &state_default {
@@ -203,7 +194,6 @@
 };
 
 &xhci {
-	vusb33-supply = <&reg_3p3v>;
 	vbus-supply = <&reg_usb_vbus>;
 };
 

--- a/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
@@ -85,15 +85,6 @@
 			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	reg_usb_vbus: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
 };
 
 &spi0 {
@@ -210,6 +201,12 @@
 	/delete-property/ interrupts;
 };
 
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
 &switch0 {
 	ports {
 		port@1 {
@@ -239,8 +236,4 @@
 		groups = "i2c", "uart2", "uart3", "jtag", "wdt", "sdhci";
 		function = "gpio";
 	};
-};
-
-&xhci {
-	vbus-supply = <&reg_usb_vbus>;
 };

--- a/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
@@ -58,15 +58,6 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
-
-	reg_usb_vbus: regulator-usb {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
 };
 
 &gmac0 {
@@ -150,6 +141,12 @@
 	/delete-property/ interrupts;
 };
 
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
 &state_default {
 	gpio {
 		groups = "uart2", "uart3", "pcie", "jtag";
@@ -160,8 +157,3 @@
 &spi0 {
 	status = "disabled";
 };
-
-&xhci {
-	vbus-supply = <&reg_usb_vbus>;
-};
-

--- a/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_er605-v2.dts
@@ -67,15 +67,6 @@
 		gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
-
-	reg_3p3v: regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		regulator-boot-on;
-		regulator-always-on;
-	};
 };
 
 &gmac0 {
@@ -171,7 +162,6 @@
 };
 
 &xhci {
-	vusb33-supply = <&reg_3p3v>;
 	vbus-supply = <&reg_usb_vbus>;
 };
 

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
@@ -84,19 +84,6 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
-
-	reg_usb_vbus: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
-&xhci {
-	vbus-supply = <&reg_usb_vbus>;
 };
 
 &nand {
@@ -226,6 +213,12 @@
 
 &ethphy4 {
 	/delete-property/ interrupts;
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3g.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3g.dts
@@ -57,19 +57,6 @@
 			linux,default-trigger = "mt7530-0:02:1Gbps";
 		};
 	};
-
-	reg_usb_vbus: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
-&xhci {
-	vbus-supply = <&reg_usb_vbus>;
 };
 
 &pcie {
@@ -99,6 +86,12 @@
 &gmac0 {
 	nvmem-cells = <&macaddr_factory_e006>;
 	nvmem-cell-names = "mac-address";
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
+++ b/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
@@ -73,29 +73,6 @@
 			gpios = <&gpio 27 GPIO_ACTIVE_HIGH>;
 		};
 	};
-
-	reg_usb_vbus: regulator-usb {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_vbus";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-
-	reg_3p3v: regulator-3p3v {
-		compatible = "regulator-fixed";
-		regulator-name = "fixed-3.3V";
-		regulator-min-microvolt = <3300000>;
-		regulator-max-microvolt = <3300000>;
-		gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-};
-
-&xhci {
-	vusb33-supply = <&reg_3p3v>;
-	vbus-supply = <&reg_usb_vbus>;
 };
 
 &spi0 {
@@ -193,6 +170,18 @@
 &gmac0 {
 	nvmem-cells = <&macaddr_factory_e000 0>;
 	nvmem-cell-names = "mac-address";
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
+&reg_vusb33 {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
@@ -48,15 +48,6 @@
 		};
 	};
 
-	reg_power_usb: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "power_usb";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-
 	watchdog {
 		compatible = "linux,wdt-gpio";
 		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
@@ -81,10 +72,6 @@
 			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
 		};
 	};
-};
-
-&xhci {
-	vbus-supply = <&reg_power_usb>;
 };
 
 &sdhci {
@@ -195,6 +182,12 @@
 
 &ethphy4 {
 	/delete-property/ interrupts;
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
@@ -47,15 +47,6 @@
 		};
 	};
 
-	reg_power_usb: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "power_usb";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
-
 	watchdog {
 		compatible = "linux,wdt-gpio";
 		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
@@ -80,10 +71,6 @@
 			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
 		};
 	};
-};
-
-&xhci {
-	vbus-supply = <&reg_power_usb>;
 };
 
 &sdhci {
@@ -194,6 +181,12 @@
 
 &ethphy4 {
 	/delete-property/ interrupts;
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
 };
 
 &switch0 {

--- a/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
@@ -89,20 +89,6 @@
 		};
 
 	};
-
-	reg_power_usb: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "power_usb";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-		regulator-boot-on;
-	};
-};
-
-&xhci {
-	vbus-supply = <&reg_power_usb>;
 };
 
 &nand {
@@ -213,4 +199,11 @@
 		nvmem-cell-names = "eeprom", "mac-address";
 	};
 
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+	regulator-boot-on;
 };

--- a/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte5398-m904.dts
@@ -92,20 +92,6 @@
 			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	reg_usb_power: regulator {
-		compatible = "regulator-fixed";
-		regulator-name = "usb_power";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-		gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-		regulator-boot-on;
-	};
-};
-
-&xhci {
-	vbus-supply = <&reg_usb_power>;
 };
 
 &nand {
@@ -238,4 +224,11 @@
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
 	};
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+	regulator-boot-on;
 };

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -30,26 +30,20 @@
 		compatible = "mti,cpu-interrupt-controller";
 	};
 
-	mmc_reg_1v8: regulator-1v8 {
+	reg_vmmc: regulator-vmmc {
 		compatible = "regulator-fixed";
-
-		enable-active-high;
-
-		regulator-always-on;
-		regulator-max-microvolt = <1800000>;
-		regulator-min-microvolt = <1800000>;
-		regulator-name = "mmc_io";
-	};
-
-	mmc_reg_3v3: regulator-3v3 {
-		compatible = "regulator-fixed";
-
-		enable-active-high;
-
 		regulator-always-on;
 		regulator-max-microvolt = <3300000>;
 		regulator-min-microvolt = <3300000>;
 		regulator-name = "mmc_power";
+	};
+
+	reg_vqmmc: regulator-vqmmc {
+		compatible = "regulator-fixed";
+		regulator-always-on;
+		regulator-max-microvolt = <3300000>;
+		regulator-min-microvolt = <3300000>;
+		regulator-name = "mmc_io";
 	};
 
 	palmbus: palmbus@10000000 {
@@ -382,19 +376,17 @@
 		reg = <0x10130000 0x4000>;
 
 		bus-width = <4>;
-
+		max-frequency = <24000000>;
 		cap-mmc-highspeed;
 		cap-sd-highspeed;
+		disable-wp;
+		no-1-8-v;
 
 		clocks = <&sysc 16>, <&sysc 16>;
 		clock-names = "source", "hclk";
 
-		disable-wp;
-
 		interrupt-parent = <&intc>;
 		interrupts = <14>;
-
-		max-frequency = <24000000>;
 
 		pinctrl-names = "default", "state_uhs";
 		pinctrl-0 = <&sdxc_pins>;
@@ -403,8 +395,8 @@
 		resets = <&sysc 30>;
 		reset-names = "hrst";
 
-		vmmc-supply = <&mmc_reg_3v3>;
-		vqmmc-supply = <&mmc_reg_1v8>;
+		vmmc-supply = <&reg_vmmc>;
+		vqmmc-supply = <&reg_vqmmc>;
 
 		status = "disabled";
 	};


### PR DESCRIPTION
- Add default voltage regulators to `mt7621.dtsi`.
- Fix MMC controller IO voltage.