### PR TITLE
base-files: restore once fw3 enforced sysctl defaults

### DIFF
--- a/package/base-files/files/etc/sysctl.d/10-default.conf
+++ b/package/base-files/files/etc/sysctl.d/10-default.conf
@@ -13,6 +13,10 @@ net.core.bpf_jit_kallsyms=1
 
 net.ipv4.conf.default.arp_ignore=1
 net.ipv4.conf.all.arp_ignore=1
+net.ipv4.conf.default.accept_redirects=0
+net.ipv4.conf.all.accept_redirects=0
+net.ipv4.conf.default.accept_source_route=0
+net.ipv4.conf.all.accept_source_route=0
 net.ipv4.ip_forward=1
 net.ipv4.icmp_echo_ignore_broadcasts=1
 net.ipv4.icmp_ignore_bogus_error_responses=1
@@ -24,5 +28,9 @@ net.ipv4.tcp_timestamps=1
 net.ipv4.tcp_sack=1
 net.ipv4.tcp_dsack=1
 
+net.ipv6.conf.default.accept_redirects=0
+net.ipv6.conf.all.accept_redirects=0
+net.ipv6.conf.default.accept_source_route=0
+net.ipv6.conf.all.accept_source_route=0
 net.ipv6.conf.default.forwarding=1
 net.ipv6.conf.all.forwarding=1


### PR DESCRIPTION
Add safer routing configuration defaults lost in fw3 to fw4 transition
Individual per-interface overrides are configured by netifd if needed

Signed-off-by: Andris PE <neandris@gmail.com>