### PR TITLE
ath79: araknis_an-300-ap-i-n: fix wifi LEDs

### DIFF
--- a/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
+++ b/target/linux/ath79/dts/ar9344_araknis_an-300-ap-i-n.dts
@@ -38,26 +38,10 @@
 			default-state = "off";
 		};
 
-		wifi5g {
-			label = "blue:wifi5g";
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		wps {
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wifi2g {
-			label = "blue:wifi2g";
-			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
 		};
 	};
 };
@@ -87,14 +71,17 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_0 1>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
 		ieee80211-freq-limit = <2402000 2482000>;
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
 	};
 };
 
@@ -105,6 +92,11 @@
 
 	nvmem-cells = <&macaddr_art_0 2>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
+
+	led {
+		led-sources = <12>;
+		led-active-low;
+	};
 };
 
 &art {


### PR DESCRIPTION
There seems to have been some confusion with the newer araknis devices using ath10k and this one. phy0 and phy1 vary between ath10k and ath9k.

Use the new led pin support in ath9k to clear this up.

ping @mcprat 