### PR TITLE
ath79: tl-wdr4900-v2: set ath9k led-pin

### DIFF
--- a/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
@@ -40,25 +40,9 @@
 			linux,default-trigger = "usbport";
 		};
 
-		wlan2g {
-			label = "blue:wlan2g";
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		qss {
 			label = "blue:qss";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wlan5g {
-			label = "blue:wlan5g";
-			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
 		};
 	};
 
@@ -93,13 +77,16 @@
 &pcie1 {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,0033";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&macaddr_uboot_1fc00 (-2)>, <&cal_ath9k_pci>;
 		nvmem-cell-names = "mac-address", "calibration";
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
 	};
 };
 
@@ -230,4 +217,9 @@
 
 	nvmem-cells = <&macaddr_uboot_1fc00 (-1)>, <&cal_ath9k_soc>;
 	nvmem-cell-names = "mac-address", "calibration";
+
+	led {
+		led-sources = <12>;
+		led-active-low;
+	};
 };


### PR DESCRIPTION
Instead of having two LED entries that supposedly control the same thing, set the pin properly.