### PR TITLE
ath79: wb2000: use led-sources for ath9k

### DIFF
--- a/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
+++ b/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
@@ -38,12 +38,6 @@
 	leds {
 		compatible = "gpio-leds";
 
-		wlan2g {
-			label = "green:2g";
-			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		usb {
 			function = LED_FUNCTION_USB;
 			color = <LED_COLOR_ID_GREEN>;
@@ -66,16 +60,6 @@
 			linux,code = <KEY_RESTART>;
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 			debounce-interval = <60>;
-		};
-	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wlan {
-			label = "green:5g";
-			gpios = <&ath9k 6 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
 		};
 	};
 };
@@ -170,8 +154,11 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&macaddr_addr_0 0x10>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <6>;
+			led-active-low;
+		};
 	};
 };
 
@@ -188,6 +175,10 @@
 
 	nvmem-cells = <&macaddr_addr_0 0>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
+
+	led {
+		led-sources = <20>;
+	};
 };
 
 &mdio0 {


### PR DESCRIPTION
The ath9k driver creates an ath9k LED by default. Instead of having a non functional LED, configure it properly and remove the extra as it's not needed.