### PR TITLE
ath79: dir-825-c1: set LED pin properly

### DIFF
--- a/target/linux/ath79/dts/ar9344_dlink_dir-825-c1.dts
+++ b/target/linux/ath79/dts/ar9344_dlink_dir-825-c1.dts
@@ -41,12 +41,6 @@
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 		};
 
-		wlan2g {
-			label = "blue:wlan2g";
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		wps {
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_BLUE>;
@@ -65,15 +59,19 @@
 			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
 		};
 	};
+};
 
-	leds-ath9k {
-		compatible = "gpio-leds";
+&ath9k {
+	led {
+		led-sources = <0>;
+		led-active-low;
+	};
+};
 
-		wlan5g {
-			label = "blue:wlan5g";
-			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
+&wmac {
+	led {
+		led-sources = <13>;
+		led-active-low;
 	};
 };
 

--- a/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
+++ b/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
@@ -65,8 +65,6 @@
 		   nvmem-cell-names = "mac-address", "calibration";
 		 */
 		qca,no-eeprom; /* remove this when "mac-address" works  */
-		gpio-controller;
-		#gpio-cells = <2>;
 	};
 };
 


### PR DESCRIPTION
The ath9k driver creates an ath9k LED by default. Instead of having a non functional LED, configure it properly and remove the extra as it's not needed.

ping @micmac1 