### PR TITLE
ath79: refresh 6.12 kernel patches

### DIFF
--- a/target/linux/ath79/patches-6.12/900-unaligned_access_hacks.patch
+++ b/target/linux/ath79/patches-6.12/900-unaligned_access_hacks.patch
@@ -323,7 +323,7 @@ SVN-Revision: 35130
  					 SKB_DROP_REASON_IP_INHDR);
 --- a/include/linux/types.h
 +++ b/include/linux/types.h
-@@ -247,5 +247,11 @@ typedef void (*swap_func_t)(void *a, voi
+@@ -248,5 +248,11 @@ typedef void (*swap_func_t)(void *a, voi
  typedef int (*cmp_r_func_t)(const void *a, const void *b, const void *priv);
  typedef int (*cmp_func_t)(const void *a, const void *b);
  


### PR DESCRIPTION
Refresh patches to fix the GitHub CI warning.

Ref: https://github.com/openwrt/openwrt/actions/runs/15231709908/job/42845624979?pr=18632
