### PR TITLE
realtek: align port names

### DIFF
--- a/target/linux/realtek/dts/rtl8393_tplink_sg2452p-v4.dts
+++ b/target/linux/realtek/dts/rtl8393_tplink_sg2452p-v4.dts
@@ -350,16 +350,16 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		SWITCH_PORT(0, 01, qsgmii)
-		SWITCH_PORT(1, 02, qsgmii)
-		SWITCH_PORT(2, 03, qsgmii)
-		SWITCH_PORT(3, 04, qsgmii)
-		SWITCH_PORT(4, 05, qsgmii)
-		SWITCH_PORT(5, 06, qsgmii)
-		SWITCH_PORT(6, 07, qsgmii)
-		SWITCH_PORT(7, 08, qsgmii)
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
 
-		SWITCH_PORT(8, 09, qsgmii)
+		SWITCH_PORT(8, 9, qsgmii)
 		SWITCH_PORT(9, 10, qsgmii)
 		SWITCH_PORT(10, 11, qsgmii)
 		SWITCH_PORT(11, 12, qsgmii)

--- a/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48.dts
+++ b/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48.dts
@@ -224,16 +224,16 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		SWITCH_PORT(0, 01, qsgmii)
-		SWITCH_PORT(1, 02, qsgmii)
-		SWITCH_PORT(2, 03, qsgmii)
-		SWITCH_PORT(3, 04, qsgmii)
-		SWITCH_PORT(4, 05, qsgmii)
-		SWITCH_PORT(5, 06, qsgmii)
-		SWITCH_PORT(6, 07, qsgmii)
-		SWITCH_PORT(7, 08, qsgmii)
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
 
-		SWITCH_PORT(8, 09, qsgmii)
+		SWITCH_PORT(8, 9, qsgmii)
 		SWITCH_PORT(9, 10, qsgmii)
 		SWITCH_PORT(10, 11, qsgmii)
 		SWITCH_PORT(11, 12, qsgmii)


### PR DESCRIPTION
Only 2 devices use leading zeroes to pad interface names, align the remaining ones so that it is consistent.
