### PR TITLE
realtek: switch HP-1920-48G to new shared gpio driver

### DIFF
--- a/target/linux/realtek/dts/rtl8393_hpe_1920-48g-poe.dts
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920-48g-poe.dts
@@ -16,6 +16,97 @@
 		alarm-gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
 		#cooling-cells = <2>;
 	};
+
+        i2c0: i2c-gpio-0 {
+                compatible = "i2c-gpio";
+                sda-gpios = <&gpio1 13 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                scl-gpios = <&gpio1 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                i2c-gpio,delay-us = <2>;
+                #address-cells = <1>;
+                #size-cells = <0>;
+        };
+
+        sfp0: sfp-p49 {
+                compatible = "sff,sfp";
+                i2c-bus = <&i2c0>;
+                los-gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+                mod-def0-gpio = <&gpio1 21 GPIO_ACTIVE_LOW>;
+                // tx-fault unconnected (TODO?)
+                // tx-disable connected to RTL8214FC (TODO?)
+        };
+
+        i2c1: i2c-gpio-1 {
+                compatible = "i2c-gpio";
+                sda-gpios = <&gpio1 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                scl-gpios = <&gpio1 24 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                i2c-gpio,delay-us = <2>;
+                #address-cells = <1>;
+                #size-cells = <0>;
+        };
+
+        sfp1: sfp-p50 {
+                compatible = "sff,sfp";
+                i2c-bus = <&i2c1>;
+                los-gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
+                mod-def0-gpio = <&gpio1 25 GPIO_ACTIVE_LOW>;
+                // tx-fault unconnected (TODO?)
+                // tx-disable connected to RTL8214FC (TODO?)
+        };
+
+        i2c2: i2c-gpio-2 {
+                compatible = "i2c-gpio";
+                sda-gpios = <&gpio1 27 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                scl-gpios = <&gpio1 28 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                i2c-gpio,delay-us = <2>;
+                #address-cells = <1>;
+                #size-cells = <0>;
+        };
+
+        sfp2: sfp-p51 {
+                compatible = "sff,sfp";
+                i2c-bus = <&i2c2>;
+                los-gpio = <&gpio1 30 GPIO_ACTIVE_HIGH>;
+                mod-def0-gpio = <&gpio1 29 GPIO_ACTIVE_LOW>;
+                // tx-fault unconnected (TODO?)
+                // tx-disable connected to RTL8214FC (TODO?)
+        };
+
+        i2c3: i2c-gpio-3 {
+                compatible = "i2c-gpio";
+                sda-gpios = <&gpio1 31 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                scl-gpios = <&gpio1 32 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                i2c-gpio,delay-us = <2>;
+                #address-cells = <1>;
+                #size-cells = <0>;
+        };
+
+        sfp3: sfp-p52 {
+                compatible = "sff,sfp";
+                i2c-bus = <&i2c3>;
+                los-gpio = <&gpio1 34 GPIO_ACTIVE_HIGH>;
+                mod-def0-gpio = <&gpio1 33 GPIO_ACTIVE_LOW>;
+                // tx-fault unconnected (TODO?)
+                // tx-disable connected to RTL8214FC (TODO?)
+        };
+};
+
+&ethernet0 {
+        mdio: mdio-bus {
+		EXTERNAL_SFP_PHY_FULL(48, 0)
+		EXTERNAL_SFP_PHY_FULL(49, 1)
+		EXTERNAL_SFP_PHY_FULL(50, 2)
+		EXTERNAL_SFP_PHY_FULL(51, 3)
+	};
+};
+
+
+&switch0 {
+	ports {
+		SWITCH_PORT(48, 49, qsgmii)
+		SWITCH_PORT(49, 50, qsgmii)
+		SWITCH_PORT(50, 51, qsgmii)
+		SWITCH_PORT(51, 52, qsgmii)
+	};
 };
 
 &uart1 {

--- a/target/linux/realtek/dts/rtl8393_hpe_1920-48g.dts
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920-48g.dts
@@ -5,4 +5,100 @@
 / {
 	compatible = "hpe,1920-48g", "realtek,rtl8393-soc";
 	model = "HPE 1920-48G (JG927A)";
+
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p49 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 19 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
+
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p50 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
+
+	// not enabled due to shared I2C clock
+	i2c2: i2c-gpio-2 {
+		status = "disabled";
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp2: sfp-p51 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 22 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
+
+	// not enabled due to shared I2C clock
+	i2c3: i2c-gpio-3 {
+		status = "disabled";
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp3: sfp-p52 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
+
+};
+
+&ethernet0 {
+        mdio: mdio-bus {
+		EXTERNAL_SFP_PHY_FULL(48, 1)
+		EXTERNAL_SFP_PHY_FULL(49, 3)
+		EXTERNAL_SFP_PHY_FULL(50, 0)
+		EXTERNAL_SFP_PHY_FULL(51, 2)
+	};
+};
+
+
+&switch0 {
+        ports {
+		SWITCH_PORT(48, 50, qsgmii)
+		SWITCH_PORT(49, 52, qsgmii)
+		SWITCH_PORT(50, 49, qsgmii)
+		SWITCH_PORT(51, 51, qsgmii)
+	};
 };

--- a/target/linux/realtek/dts/rtl8393_hpe_1920-48g.dts
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920-48g.dts
@@ -6,81 +6,77 @@
 	compatible = "hpe,1920-48g", "realtek,rtl8393-soc";
 	model = "HPE 1920-48G (JG927A)";
 
-	i2c0: i2c-gpio-0 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
+        i2c-gpio-shared0 {
+                compatible = "i2c-gpio-shared";
+                scl-gpios = <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                #address-cells = <1>;
+                #size-cells = <0>;
 
-	sfp0: sfp-p49 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c0>;
-		los-gpio = <&gpio0 20 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 19 GPIO_ACTIVE_LOW>;
-		// tx-fault unconnected (TODO?)
-		// tx-disable connected to RTL8214FC (TODO?)
-	};
+                i2c0: i2c@0 {
+                        sda-gpios = <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                        i2c-gpio,delay-us = <2>;
+                };
 
-	i2c1: i2c-gpio-1 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio0 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
+                i2c2: i2c@2 {
+                        sda-gpios = <&gpio0 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                        i2c-gpio,delay-us = <2>;
 
-	sfp1: sfp-p50 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c1>;
-		los-gpio = <&gpio0 13 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 12 GPIO_ACTIVE_LOW>;
-		// tx-fault unconnected (TODO?)
-		// tx-disable connected to RTL8214FC (TODO?)
-	};
+                };
+        };
 
-	// not enabled due to shared I2C clock
-	i2c2: i2c-gpio-2 {
-		status = "disabled";
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio0 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
+        i2c-gpio-shared1 {
+                compatible = "i2c-gpio-shared";
+                scl-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                #address-cells = <1>;
+                #size-cells = <0>;
 
-	sfp2: sfp-p51 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c2>;
-		los-gpio = <&gpio0 23 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 22 GPIO_ACTIVE_LOW>;
-		// tx-fault unconnected (TODO?)
-		// tx-disable connected to RTL8214FC (TODO?)
-	};
+                i2c1: i2c@1 {
+                        sda-gpios = <&gpio0 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                        i2c-gpio,delay-us = <2>;
+                };
 
-	// not enabled due to shared I2C clock
-	i2c3: i2c-gpio-3 {
-		status = "disabled";
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio0 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
+                i2c3: i2c@3 {
+                        sda-gpios = <&gpio0 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+                        i2c-gpio,delay-us = <2>;
 
-	sfp3: sfp-p52 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c3>;
-		los-gpio = <&gpio0 16 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 15 GPIO_ACTIVE_LOW>;
-		// tx-fault unconnected (TODO?)
-		// tx-disable connected to RTL8214FC (TODO?)
-	};
+                };
+        };
+
+        sfp0: sfp-p49 {
+                compatible = "sff,sfp";
+                i2c-bus = <&i2c0>;
+                los-gpio = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+                mod-def0-gpio = <&gpio0 19 GPIO_ACTIVE_LOW>;
+                // tx-fault unconnected (TODO?)
+                // tx-disable connected to RTL8214FC (TODO?)
+        };
+
+        sfp1: sfp-p50 {
+                compatible = "sff,sfp";
+                i2c-bus = <&i2c1>;
+                los-gpio = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+                mod-def0-gpio = <&gpio0 12 GPIO_ACTIVE_LOW>;
+                // tx-fault unconnected (TODO?)
+                // tx-disable connected to RTL8214FC (TODO?)
+        };
+
+        sfp2: sfp-p51 {
+                compatible = "sff,sfp";
+                i2c-bus = <&i2c2>;
+                los-gpio = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+                mod-def0-gpio = <&gpio0 22 GPIO_ACTIVE_LOW>;
+                // tx-fault unconnected (TODO?)
+                // tx-disable connected to RTL8214FC (TODO?)
+        };
+
+        sfp3: sfp-p52 {
+                compatible = "sff,sfp";
+                i2c-bus = <&i2c3>;
+                los-gpio = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+                mod-def0-gpio = <&gpio0 15 GPIO_ACTIVE_LOW>;
+                // tx-fault unconnected (TODO?)
+                // tx-disable connected to RTL8214FC (TODO?)
+        };
 
 };
 

--- a/target/linux/realtek/dts/rtl8393_hpe_1920.dtsi
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920.dtsi
@@ -22,82 +22,6 @@
 			gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
 		};
 	};
-
-	i2c0: i2c-gpio-0 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp0: sfp-p49 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c0>;
-		los-gpio = <&gpio0 20 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 19 GPIO_ACTIVE_LOW>;
-		// tx-fault unconnected (TODO?)
-		// tx-disable connected to RTL8214FC (TODO?)
-	};
-
-	i2c1: i2c-gpio-1 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio0 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp1: sfp-p50 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c1>;
-		los-gpio = <&gpio0 13 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 12 GPIO_ACTIVE_LOW>;
-		// tx-fault unconnected (TODO?)
-		// tx-disable connected to RTL8214FC (TODO?)
-	};
-
-	// not enabled due to shared I2C clock
-	i2c2: i2c-gpio-2 {
-		status = "disabled";
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio0 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp2: sfp-p51 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c2>;
-		los-gpio = <&gpio0 23 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 22 GPIO_ACTIVE_LOW>;
-		// tx-fault unconnected (TODO?)
-		// tx-disable connected to RTL8214FC (TODO?)
-	};
-
-	// not enabled due to shared I2C clock
-	i2c3: i2c-gpio-3 {
-		status = "disabled";
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio0 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp3: sfp-p52 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c3>;
-		los-gpio = <&gpio0 16 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 15 GPIO_ACTIVE_LOW>;
-		// tx-fault unconnected (TODO?)
-		// tx-disable connected to RTL8214FC (TODO?)
-	};
 };
 
 &ethernet0 {
@@ -160,11 +84,6 @@
 		EXTERNAL_PHY(45)
 		EXTERNAL_PHY(46)
 		EXTERNAL_PHY(47)
-
-		EXTERNAL_SFP_PHY_FULL(48, 1)
-		EXTERNAL_SFP_PHY_FULL(49, 3)
-		EXTERNAL_SFP_PHY_FULL(50, 0)
-		EXTERNAL_SFP_PHY_FULL(51, 2)
 	};
 };
 
@@ -226,11 +145,6 @@
 		SWITCH_PORT(45, 46, qsgmii)
 		SWITCH_PORT(46, 47, qsgmii)
 		SWITCH_PORT(47, 48, qsgmii)
-
-		SWITCH_PORT(48, 50, qsgmii)
-		SWITCH_PORT(49, 52, qsgmii)
-		SWITCH_PORT(50, 49, qsgmii)
-		SWITCH_PORT(51, 51, qsgmii)
 
 		port@52 {
 			ethernet = <&ethernet0>;


### PR DESCRIPTION
This allows the SFPs to work without manually switching port type.

Depends on #18737 and #18696 