### PR TITLE
treewide: fix compatible string for ath10k

### DIFF
--- a/target/linux/ath79/dts/qca9531_compex_wpj531-16m.dts
+++ b/target/linux/ath79/dts/qca9531_compex_wpj531-16m.dts
@@ -147,11 +147,6 @@
 
 &pcie0 {
 	status = "okay";
-
-	wifi@0,0 {
-		compatible = "pci168c,003c";
-		reg = <0x0000 0 0 0 0>;
-	};
 };
 
 &usb_phy {

--- a/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
@@ -196,7 +196,7 @@
 	status = "okay";
 
 	wifi@0,0 {
-		compatible = "pci168c,003c";
+		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&cal_art_5000>, <&macaddr_romfile_f100 2>;
 		nvmem-cell-names = "calibration", "mac-address";

--- a/target/linux/ath79/dts/qca9531_tplink_tl-wr902ac-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-wr902ac-v1.dts
@@ -197,7 +197,7 @@
 	status = "okay";
 
 	wifi@0,0 {
-		compatible = "pci168c,0050";
+		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&cal_art_5000>, <&macaddr_info_8 (-1)>;
 		nvmem-cell-names = "calibration", "mac-address";

--- a/target/linux/ath79/dts/qca9557_ruckus_r500.dts
+++ b/target/linux/ath79/dts/qca9557_ruckus_r500.dts
@@ -265,7 +265,7 @@
 	status = "okay";
 
 	ath10k: wifi@0,0 {
-		compatible = "pci168c,003c";
+		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
 		gpio-controller;
 		#gpio-cells = <2>;

--- a/target/linux/ath79/dts/qca9558_nec_aterm.dtsi
+++ b/target/linux/ath79/dts/qca9558_nec_aterm.dtsi
@@ -328,7 +328,7 @@
 	status = "okay";
 
 	wifi: wifi@0,0 {
-		compatible = "pci168c,003c";
+		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&cal_art_5000>, <&macaddr_config_12>;
 		nvmem-cell-names = "calibration", "mac-address";

--- a/target/linux/ath79/dts/qca9558_nec_wg2200hp.dts
+++ b/target/linux/ath79/dts/qca9558_nec_wg2200hp.dts
@@ -51,7 +51,6 @@
 };
 
 &wifi {
-	compatible = "pci168c,0046";
 	nvmem-cells = <&precal_art_5000>, <&macaddr_config_12>;
 	nvmem-cell-names = "pre-calibration", "mac-address";
 };

--- a/target/linux/ath79/dts/qca9563_kuwfi_n650.dts
+++ b/target/linux/ath79/dts/qca9563_kuwfi_n650.dts
@@ -170,7 +170,7 @@
 	status = "okay";
 
 	wifi@0,0 {
-		compatible = "pci168c,0056";
+		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&precal_art_5000>, <&macaddr_art_0 1>;
 		nvmem-cell-names = "pre-calibration", "mac-address";

--- a/target/linux/ath79/dts/qca9563_nec_wg1200cr.dts
+++ b/target/linux/ath79/dts/qca9563_nec_wg1200cr.dts
@@ -172,7 +172,7 @@
 	status = "okay";
 
 	wifi@0,0 {
-		compatible = "pci168c,0056";
+		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&precal_art_5000>;
 		nvmem-cell-names = "pre-calibration";

--- a/target/linux/ath79/dts/qca9563_yuncore_xd4200.dtsi
+++ b/target/linux/ath79/dts/qca9563_yuncore_xd4200.dtsi
@@ -55,7 +55,7 @@
 	status = "okay";
 
 	wifi@0,0 {
-		compatible = "pci168c,0056";
+		compatible = "qcom,ath10k";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&precal_art_5000>;
 		nvmem-cell-names = "pre-calibration";

--- a/target/linux/ath79/dts/qcn5502_tplink_archer-a9-v6.dts
+++ b/target/linux/ath79/dts/qcn5502_tplink_archer-a9-v6.dts
@@ -121,7 +121,7 @@
 	status = "okay";
 
 	wifi@0,0 {
-		compatible = "pci168c,0046";
+		compatible = "qcom,ath10k";
 		reg = <0 0 0 0 0>;
 
 		nvmem-cells = <&macaddr_info_8 (-1)>, <&precal_art_5000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -476,7 +476,7 @@
 
 &pcie_bridge0 {
 	wifi@0,0 {
-		compatible = "pci168c,0040";
+		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cell-names = "pre-calibration", "mac-address";
 		nvmem-cells = <&precal_art_9000>, <&macaddr_config_0 3>;

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-ad7200-c2600.dtsi
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-ad7200-c2600.dtsi
@@ -316,7 +316,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_defaultmac_8 (-1)>, <&precal_radio_1000>;
@@ -336,7 +336,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_defaultmac_8 0>, <&precal_radio_5000>;

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-d7800.dts
@@ -212,7 +212,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_art_6 1>, <&precal_art_1000>;
@@ -235,7 +235,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_art_6 2>, <&precal_art_5000>;

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-fap-421e.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-fap-421e.dts
@@ -329,7 +329,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_appsbl_7ff80 8>;
@@ -350,7 +350,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_appsbl_7ff80 16>;

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-r7500v2.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-r7500v2.dts
@@ -215,7 +215,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_art_6 1>, <&precal_art_1000>;
@@ -238,7 +238,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_art_6 2>, <&precal_art_5000>;

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-vr2600v.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-vr2600v.dts
@@ -344,7 +344,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_defaultmac_0 (-1)>, <&precal_ART_1000>;
@@ -364,7 +364,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_defaultmac_0 0>, <&precal_ART_5000>;

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wg2600hp.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wg2600hp.dts
@@ -466,7 +466,7 @@ switch@10 {
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_PRODUCTDATA_12>, <&precal_ART_1000>;
@@ -486,7 +486,7 @@ switch@10 {
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_PRODUCTDATA_c>, <&precal_ART_5000>;

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wxr-2533dhp.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wxr-2533dhp.dts
@@ -527,7 +527,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_ART_1e>, <&precal_ART_1000>;
@@ -547,7 +547,7 @@
 		ranges;
 
 		wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_ART_18>, <&precal_ART_5000>;

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-nighthawk.dtsi
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-nighthawk.dtsi
@@ -516,7 +516,7 @@
 		ranges;
 
 		wifi0: wifi@1,0 {
-			compatible = "pci168c,0046";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 		};
 	};
@@ -534,7 +534,7 @@
 		ranges;
 
 		wifi1: wifi@1,0 {
-			compatible = "pci168c,0046";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 		};
 	};

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-rt4230w-rev6.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-rt4230w-rev6.dts
@@ -569,7 +569,7 @@
 		ranges;
 
 		wifi0: wifi@1,0 {
-			compatible = "pci168c,0046";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&precal_ART_1000>;
@@ -592,7 +592,7 @@
 		ranges;
 
 		wifi1: wifi@1,0 {
-			compatible = "pci168c,0046";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&precal_ART_5000>;

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-tr4400-v2.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-tr4400-v2.dts
@@ -457,7 +457,7 @@
 		ranges;
 
 		wifi0: wifi@1,0 {
-			compatible = "pci168c,0046";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&precal_ART_1000>, <&macaddr_fw_env_12>;
@@ -480,7 +480,7 @@
 		ranges;
 
 		wifi1: wifi@1,0 {
-			compatible = "pci168c,0040";
+			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 
 			nvmem-cells = <&precal_ART_5000>, <&macaddr_fw_env_c>;


### PR DESCRIPTION
The ath9k documentation says to use pci168c strings for the compatible string, probably because the OWL loader uses it to overide bogus pci IDs like abcd. This is not the case with ath10k and the documentation explicitly states to use qcom,ath10k.

ping @DragonBluep @musashino205 