### PR TITLE
[pre-6.12] realtek: align declaration/static/extern function definitions

### DIFF
--- a/target/linux/realtek/files-6.6/arch/mips/rtl838x/prom.c
+++ b/target/linux/realtek/files-6.6/arch/mips/rtl838x/prom.c
@@ -19,6 +19,7 @@
 #include <asm/page.h>
 #include <asm/cpu.h>
 #include <asm/fw/fw.h>
+#include <asm/prom.h>
 #include <asm/smp-ops.h>
 #include <asm/mips-cps.h>
 
@@ -95,7 +96,7 @@ void __init device_tree_init(void)
 	register_up_smp_ops();
 }
 
-void __init identify_rtl9302(void)
+static void __init identify_rtl9302(void)
 {
 	switch (sw_r32(RTL93XX_MODEL_NAME_INFO) & 0xfffffff0) {
 	case 0x93020810:

--- a/target/linux/realtek/files-6.6/arch/mips/rtl838x/setup.c
+++ b/target/linux/realtek/files-6.6/arch/mips/rtl838x/setup.c
@@ -46,7 +46,7 @@ void __init plat_mem_setup(void)
 	__dt_setup_arch(dtb);
 }
 
-void plat_time_init_fallback(void)
+static void plat_time_init_fallback(void)
 {
 	struct device_node *np;
 	u32 freq = 500000000;

--- a/target/linux/realtek/files-6.6/drivers/clk/realtek/clk-rtl83xx.c
+++ b/target/linux/realtek/files-6.6/drivers/clk/realtek/clk-rtl83xx.c
@@ -504,7 +504,7 @@ static int rtcl_ccu_create(struct device_node *np)
 	return 0;
 }
 
-int rtcl_register_clkhw(int clk_idx)
+static int rtcl_register_clkhw(int clk_idx)
 {
 	int ret;
 	struct clk *clk;
@@ -592,7 +592,7 @@ err_hw_unregister:
 	return ret;
 }
 
-int rtcl_init_sram(void)
+static int rtcl_init_sram(void)
 {
 	struct gen_pool *sram_pool;
 	phys_addr_t sram_pbase;
@@ -665,7 +665,7 @@ err_put_device:
 	return -ENXIO;
 }
 
-void rtcl_ccu_log_early(void)
+static void rtcl_ccu_log_early(void)
 {
 	char meminfo[80], clkinfo[255], msg[255] = "rtl83xx-clk: initialized";
 
@@ -680,7 +680,7 @@ void rtcl_ccu_log_early(void)
 	pr_info("%s\n", msg);
 }
 
-void rtcl_ccu_log_late(void)
+static void rtcl_ccu_log_late(void)
 {
 	struct rtcl_clk *rclk;
 	bool overclock = false;

--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/common.c
@@ -627,7 +627,7 @@ int rtl83xx_packet_cntr_alloc(struct rtl838x_switch_priv *priv)
  * Called from the L3 layer
  * The index in the L2 hash table is filled into nh->l2_id;
  */
-int rtl83xx_l2_nexthop_add(struct rtl838x_switch_priv *priv, struct rtl83xx_nexthop *nh)
+static int rtl83xx_l2_nexthop_add(struct rtl838x_switch_priv *priv, struct rtl83xx_nexthop *nh)
 {
 	struct rtl838x_l2_entry e;
 	u64 seed = priv->r->l2_hash_seed(nh->mac, nh->rvid);
@@ -694,7 +694,7 @@ int rtl83xx_l2_nexthop_add(struct rtl838x_switch_priv *priv, struct rtl83xx_next
  * If it was static, the entire entry is removed, otherwise the nexthop bit is cleared
  * and we wait until the entry ages out
  */
-int rtl83xx_l2_nexthop_rm(struct rtl838x_switch_priv *priv, struct rtl83xx_nexthop *nh)
+static int rtl83xx_l2_nexthop_rm(struct rtl838x_switch_priv *priv, struct rtl83xx_nexthop *nh)
 {
 	struct rtl838x_l2_entry e;
 	u32 key = nh->l2_id >> 2;
@@ -819,7 +819,7 @@ static int rtl83xx_netdevice_event(struct notifier_block *this,
 	return NOTIFY_DONE;
 }
 
-const static struct rhashtable_params route_ht_params = {
+static const struct rhashtable_params route_ht_params = {
 	.key_len     = sizeof(u32),
 	.key_offset  = offsetof(struct rtl83xx_route, gw_ip),
 	.head_offset = offsetof(struct rtl83xx_route, linkage),
@@ -954,7 +954,7 @@ static int rtl83xx_port_lower_walk(struct net_device *lower, struct netdev_neste
 	return ret;
 }
 
-int rtl83xx_port_dev_lower_find(struct net_device *dev, struct rtl838x_switch_priv *priv)
+static int rtl83xx_port_dev_lower_find(struct net_device *dev, struct rtl838x_switch_priv *priv)
 {
 	struct rtl83xx_walk_data data;
 	struct netdev_nested_priv _priv;

--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/debugfs.c
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/debugfs.c
@@ -37,15 +37,6 @@
 #define RTL930X_STAT_PRVTE_DROP_COUNTERS	(0xB5B8)
 #define RTL931X_STAT_PRVTE_DROP_COUNTERS	(0xd800)
 
-int rtl83xx_port_get_stp_state(struct rtl838x_switch_priv *priv, int port);
-void rtl83xx_port_stp_state_set(struct dsa_switch *ds, int port, u8 state);
-void rtl83xx_fast_age(struct dsa_switch *ds, int port);
-u32 rtl838x_get_egress_rate(struct rtl838x_switch_priv *priv, int port);
-u32 rtl839x_get_egress_rate(struct rtl838x_switch_priv *priv, int port);
-int rtl838x_set_egress_rate(struct rtl838x_switch_priv *priv, int port, u32 rate);
-int rtl839x_set_egress_rate(struct rtl838x_switch_priv *priv, int port, u32 rate);
-
-
 const char *rtl838x_drop_cntr[] = {
     "ALE_TX_GOOD_PKTS", "MAC_RX_DROP", "ACL_FWD_DROP", "HW_ATTACK_PREVENTION_DROP",
     "RMA_DROP", "VLAN_IGR_FLTR_DROP", "INNER_OUTER_CFI_EQUAL_1_DROP", "PORT_MOVE_DROP",
@@ -449,7 +440,7 @@ static const struct debugfs_reg32 port_ctrl_regs[] = {
 	{ .name = "mac_force_mode", .offset = RTL838X_MAC_FORCE_MODE_CTRL, },
 };
 
-void rtl838x_dbgfs_cleanup(struct rtl838x_switch_priv *priv)
+static void rtl838x_dbgfs_cleanup(struct rtl838x_switch_priv *priv)
 {
 	debugfs_remove_recursive(priv->dbgfs_dir);
 

--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/dsa.c
@@ -1343,7 +1343,7 @@ void rtl83xx_fast_age(struct dsa_switch *ds, int port)
 	mutex_unlock(&priv->reg_mutex);
 }
 
-void rtl931x_fast_age(struct dsa_switch *ds, int port)
+static void rtl931x_fast_age(struct dsa_switch *ds, int port)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 
@@ -1358,7 +1358,7 @@ void rtl931x_fast_age(struct dsa_switch *ds, int port)
 	mutex_unlock(&priv->reg_mutex);
 }
 
-void rtl930x_fast_age(struct dsa_switch *ds, int port)
+static void rtl930x_fast_age(struct dsa_switch *ds, int port)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 
@@ -1862,7 +1862,7 @@ out:
 	return err;
 }
 
-int rtl83xx_port_mdb_del(struct dsa_switch *ds, int port,
+static int rtl83xx_port_mdb_del(struct dsa_switch *ds, int port,
 			 const struct switchdev_obj_port_mdb *mdb,
 			 const struct dsa_db db)
 {
@@ -2171,7 +2171,7 @@ out:
 	return 0;
 }
 
-int dsa_phy_read(struct dsa_switch *ds, int phy_addr, int phy_reg)
+static int rtl83xx_dsa_phy_read(struct dsa_switch *ds, int phy_addr, int phy_reg)
 {
 	u32 val;
 	u32 offset = 0;
@@ -2190,7 +2190,7 @@ int dsa_phy_read(struct dsa_switch *ds, int phy_addr, int phy_reg)
 	return val;
 }
 
-int dsa_phy_write(struct dsa_switch *ds, int phy_addr, int phy_reg, u16 val)
+static int rtl83xx_dsa_phy_write(struct dsa_switch *ds, int phy_addr, int phy_reg, u16 val)
 {
 	u32 offset = 0;
 	struct rtl838x_switch_priv *priv = ds->priv;
@@ -2217,8 +2217,8 @@ const struct dsa_switch_ops rtl83xx_switch_ops = {
 	.get_tag_protocol	= rtl83xx_get_tag_protocol,
 	.setup			= rtl83xx_setup,
 
-	.phy_read		= dsa_phy_read,
-	.phy_write		= dsa_phy_write,
+	.phy_read		= rtl83xx_dsa_phy_read,
+	.phy_write		= rtl83xx_dsa_phy_write,
 
 	.phylink_get_caps	= rtl83xx_phylink_get_caps,
 	.phylink_mac_config	= rtl83xx_phylink_mac_config,
@@ -2275,8 +2275,8 @@ const struct dsa_switch_ops rtl930x_switch_ops = {
 	.get_tag_protocol	= rtl83xx_get_tag_protocol,
 	.setup			= rtl93xx_setup,
 
-	.phy_read		= dsa_phy_read,
-	.phy_write		= dsa_phy_write,
+	.phy_read		= rtl83xx_dsa_phy_read,
+	.phy_write		= rtl83xx_dsa_phy_write,
 
 	.phylink_get_caps	= rtl83xx_phylink_get_caps,
 	.phylink_mac_config	= rtl93xx_phylink_mac_config,

--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/qos.c
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/qos.c
@@ -188,7 +188,7 @@ int rtl839x_set_egress_rate(struct rtl838x_switch_priv *priv, int port, u32 rate
 /* Set the rate limit for a particular queue in Bits/s
  * units of the rate is 16Kbps
  */
-void rtl839x_egress_rate_queue_limit(struct rtl838x_switch_priv *priv, int port,
+static void rtl839x_egress_rate_queue_limit(struct rtl838x_switch_priv *priv, int port,
 					int queue, u32 rate)
 {
 	int lsb = 128 + queue * 20;
@@ -289,7 +289,7 @@ static void rtl839x_rate_control_init(struct rtl838x_switch_priv *priv)
 
 
 
-void rtl838x_setup_prio2queue_matrix(int *min_queues)
+static void rtl838x_setup_prio2queue_matrix(int *min_queues)
 {
 	u32 v = 0;
 
@@ -299,7 +299,7 @@ void rtl838x_setup_prio2queue_matrix(int *min_queues)
 	sw_w32(v, RTL838X_QM_INTPRI2QID_CTRL);
 }
 
-void rtl839x_setup_prio2queue_matrix(int *min_queues)
+static void rtl839x_setup_prio2queue_matrix(int *min_queues)
 {
 	pr_info("Current Intprio2queue setting: %08x\n", sw_r32(RTL839X_QM_INTPRI2QID_CTRL(0)));
 	for (int i = 0; i < MAX_PRIOS; i++) {
@@ -309,7 +309,7 @@ void rtl839x_setup_prio2queue_matrix(int *min_queues)
 }
 
 /* Sets the CPU queue depending on the internal priority of a packet */
-void rtl83xx_setup_prio2queue_cpu_matrix(int *max_queues)
+static void rtl83xx_setup_prio2queue_cpu_matrix(int *max_queues)
 {
 	int reg = soc_info.family == RTL8380_FAMILY_ID ? RTL838X_QM_PKT2CPU_INTPRI_MAP
 					: RTL839X_QM_PKT2CPU_INTPRI_MAP;
@@ -321,7 +321,7 @@ void rtl83xx_setup_prio2queue_cpu_matrix(int *max_queues)
 	sw_w32(v, reg);
 }
 
-void rtl83xx_setup_default_prio2queue(void)
+static void rtl83xx_setup_default_prio2queue(void)
 {
 	if (soc_info.family == RTL8380_FAMILY_ID) {
 		rtl838x_setup_prio2queue_matrix(max_available_queue);
@@ -338,7 +338,7 @@ void rtl839x_set_egress_queue(int port, int queue)
 }
 
 /* Sets the priority assigned of an ingress port, the port can be the CPU-port */
-void rtl83xx_set_ingress_priority(int port, int priority)
+static void rtl83xx_set_ingress_priority(int port, int priority)
 {
 	if (soc_info.family == RTL8380_FAMILY_ID)
 		sw_w32(priority << ((port % 10) *3), RTL838X_PRI_SEL_PORT_PRI(port));
@@ -346,7 +346,7 @@ void rtl83xx_set_ingress_priority(int port, int priority)
 		sw_w32(priority << ((port % 10) *3), RTL839X_PRI_SEL_PORT_PRI(port));
 }
 
-int rtl839x_get_scheduling_algorithm(struct rtl838x_switch_priv *priv, int port)
+static int rtl839x_get_scheduling_algorithm(struct rtl838x_switch_priv *priv, int port)
 {
 	u32 v;
 
@@ -363,7 +363,7 @@ int rtl839x_get_scheduling_algorithm(struct rtl838x_switch_priv *priv, int port)
 	return WEIGHTED_FAIR_QUEUE;
 }
 
-void rtl839x_set_scheduling_algorithm(struct rtl838x_switch_priv *priv, int port,
+static void rtl839x_set_scheduling_algorithm(struct rtl838x_switch_priv *priv, int port,
 				      enum scheduler_type sched)
 {
 	enum scheduler_type t = rtl839x_get_scheduling_algorithm(priv, port);
@@ -421,7 +421,7 @@ void rtl839x_set_scheduling_algorithm(struct rtl838x_switch_priv *priv, int port
 	mutex_unlock(&priv->reg_mutex);
 }
 
-void rtl839x_set_scheduling_queue_weights(struct rtl838x_switch_priv *priv, int port,
+static void rtl839x_set_scheduling_queue_weights(struct rtl838x_switch_priv *priv, int port,
 					  int *queue_weights)
 {
 	mutex_lock(&priv->reg_mutex);
@@ -445,7 +445,7 @@ void rtl839x_set_scheduling_queue_weights(struct rtl838x_switch_priv *priv, int 
 	mutex_unlock(&priv->reg_mutex);
 }
 
-void rtl838x_config_qos(void)
+static void rtl838x_config_qos(void)
 {
 	u32 v;
 
@@ -490,7 +490,7 @@ void rtl838x_config_qos(void)
 	sw_w32_mask(0, 7, RTL838X_QM_PKT2CPU_INTPRI_1);
 }
 
-void rtl839x_config_qos(void)
+static void rtl839x_config_qos(void)
 {
 	u32 v;
 	struct rtl838x_switch_priv *priv = switch_priv;

--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -577,22 +577,22 @@ static void rtl838x_stp_set(struct rtl838x_switch_priv *priv, u16 msti, u32 port
 	priv->r->exec_tbl0_cmd(cmd);
 }
 
-u64 rtl838x_traffic_get(int source)
+static u64 rtl838x_traffic_get(int source)
 {
 	return rtl838x_get_port_reg(rtl838x_port_iso_ctrl(source));
 }
 
-void rtl838x_traffic_set(int source, u64 dest_matrix)
+static void rtl838x_traffic_set(int source, u64 dest_matrix)
 {
 	rtl838x_set_port_reg(dest_matrix, rtl838x_port_iso_ctrl(source));
 }
 
-void rtl838x_traffic_enable(int source, int dest)
+static void rtl838x_traffic_enable(int source, int dest)
 {
 	rtl838x_mask_port_reg(0, BIT(dest), rtl838x_port_iso_ctrl(source));
 }
 
-void rtl838x_traffic_disable(int source, int dest)
+static void rtl838x_traffic_disable(int source, int dest)
 {
 	rtl838x_mask_port_reg(BIT(dest), 0, rtl838x_port_iso_ctrl(source));
 }
@@ -1606,7 +1606,7 @@ static int rtl838x_l3_setup(struct rtl838x_switch_priv *priv)
 	return 0;
 }
 
-void rtl838x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
+static void rtl838x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
 {
 	sw_w32(FIELD_PREP(RTL838X_VLAN_PORT_TAG_STS_CTRL_OTAG_STS_MASK,
 			  keep_outer ? RTL838X_VLAN_PORT_TAG_STS_TAGGED : RTL838X_VLAN_PORT_TAG_STS_UNTAG) |
@@ -1615,7 +1615,7 @@ void rtl838x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
 	       RTL838X_VLAN_PORT_TAG_STS_CTRL(port));
 }
 
-void rtl838x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan_mode mode)
+static void rtl838x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan_mode mode)
 {
 	if (type == PBVLAN_TYPE_INNER)
 		sw_w32_mask(0x3, mode, RTL838X_VLAN_PORT_PB_VLAN + (port << 2));
@@ -1623,7 +1623,7 @@ void rtl838x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan
 		sw_w32_mask(0x3 << 14, mode << 14, RTL838X_VLAN_PORT_PB_VLAN + (port << 2));
 }
 
-void rtl838x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid)
+static void rtl838x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid)
 {
 	if (type == PBVLAN_TYPE_INNER)
 		sw_w32_mask(0xfff << 2, pvid << 2, RTL838X_VLAN_PORT_PB_VLAN + (port << 2));
@@ -1659,7 +1659,7 @@ static void rtl838x_set_egr_filter(int port, enum egr_filter state)
 		    RTL838X_VLAN_PORT_EGR_FLTR + (((port / 29) << 2)));
 }
 
-void rtl838x_set_distribution_algorithm(int group, int algoidx, u32 algomsk)
+static void rtl838x_set_distribution_algorithm(int group, int algoidx, u32 algomsk)
 {
 	algoidx &= 1; /* RTL838X only supports 2 concurrent algorithms */
 	sw_w32_mask(1 << (group % 8), algoidx << (group % 8),
@@ -1667,7 +1667,7 @@ void rtl838x_set_distribution_algorithm(int group, int algoidx, u32 algomsk)
 	sw_w32(algomsk, RTL838X_TRK_HASH_CTRL + (algoidx << 2));
 }
 
-void rtl838x_set_receive_management_action(int port, rma_ctrl_t type, action_type_t action)
+static void rtl838x_set_receive_management_action(int port, rma_ctrl_t type, action_type_t action)
 {
 	switch(type) {
 	case BPDU:

--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -529,22 +529,22 @@ static void rtl839x_vlan_profile_setup(int profile)
 	rtl839x_write_mcast_pmask(UNKNOWN_MC_PMASK, 0x001fffffffffffff);
 }
 
-u64 rtl839x_traffic_get(int source)
+static u64 rtl839x_traffic_get(int source)
 {
 	return rtl839x_get_port_reg_be(rtl839x_port_iso_ctrl(source));
 }
 
-void rtl839x_traffic_set(int source, u64 dest_matrix)
+static void rtl839x_traffic_set(int source, u64 dest_matrix)
 {
 	rtl839x_set_port_reg_be(dest_matrix, rtl839x_port_iso_ctrl(source));
 }
 
-void rtl839x_traffic_enable(int source, int dest)
+static void rtl839x_traffic_enable(int source, int dest)
 {
 	rtl839x_mask_port_reg_be(0, BIT_ULL(dest), rtl839x_port_iso_ctrl(source));
 }
 
-void rtl839x_traffic_disable(int source, int dest)
+static void rtl839x_traffic_disable(int source, int dest)
 {
 	rtl839x_mask_port_reg_be(BIT_ULL(dest), 0, rtl839x_port_iso_ctrl(source));
 }
@@ -858,7 +858,7 @@ static void rtl839x_stp_set(struct rtl838x_switch_priv *priv, u16 msti, u32 port
 }
 
 /* Enables or disables the EEE/EEEP capability of a port */
-void rtl839x_port_eee_set(struct rtl838x_switch_priv *priv, int port, bool enable)
+static void rtl839x_port_eee_set(struct rtl838x_switch_priv *priv, int port, bool enable)
 {
 	u32 v;
 
@@ -881,7 +881,7 @@ void rtl839x_port_eee_set(struct rtl838x_switch_priv *priv, int port, bool enabl
 }
 
 /* Get EEE own capabilities and negotiation result */
-int rtl839x_eee_port_ability(struct rtl838x_switch_priv *priv, struct ethtool_eee *e, int port)
+static int rtl839x_eee_port_ability(struct rtl838x_switch_priv *priv, struct ethtool_eee *e, int port)
 {
 	u64 link, a;
 
@@ -1127,7 +1127,7 @@ static void rtl839x_write_pie_templated(u32 r[], struct pie_rule *pr, enum templ
  * however the RTL9310 has 2 more registers / fields and the physical field-ids
  * On the RTL8390 the template mask registers are not word-aligned!
  */
-void rtl839x_read_pie_templated(u32 r[], struct pie_rule *pr, enum template_field_id t[])
+static void rtl839x_read_pie_templated(u32 r[], struct pie_rule *pr, enum template_field_id t[])
 {
 	for (int i = 0; i < N_FIXED_FIELDS; i++) {
 		enum template_field_id field_type = t[i];
@@ -1400,7 +1400,7 @@ static void rtl839x_read_pie_action(u32 r[],  struct pie_rule *pr)
 	pr->bypass_ibc_sc = r[16] & BIT(7);
 }
 
-void rtl839x_pie_rule_dump_raw(u32 r[])
+static void rtl839x_pie_rule_dump_raw(u32 r[])
 {
 	pr_debug("Raw IACL table entry:\n");
 	pr_debug("Match  : %08x %08x %08x %08x %08x %08x\n", r[0], r[1], r[2], r[3], r[4], r[5]);
@@ -1736,14 +1736,14 @@ static void rtl839x_setup_port_macs(struct rtl838x_switch_priv *priv)
 	}
 }
 
-int rtl839x_l3_setup(struct rtl838x_switch_priv *priv)
+static int rtl839x_l3_setup(struct rtl838x_switch_priv *priv)
 {
 	rtl839x_setup_port_macs(priv);
 
 	return 0;
 }
 
-void rtl839x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
+static void rtl839x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
 {
 	sw_w32(FIELD_PREP(RTL839X_VLAN_PORT_TAG_STS_CTRL_OTAG_STS_MASK,
 			  keep_outer ? RTL839X_VLAN_PORT_TAG_STS_TAGGED : RTL839X_VLAN_PORT_TAG_STS_UNTAG) |
@@ -1752,7 +1752,7 @@ void rtl839x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
 	       RTL839X_VLAN_PORT_TAG_STS_CTRL(port));
 }
 
-void rtl839x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan_mode mode)
+static void rtl839x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan_mode mode)
 {
 	if (type == PBVLAN_TYPE_INNER)
 		sw_w32_mask(0x3, mode, RTL839X_VLAN_PORT_PB_VLAN + (port << 2));
@@ -1760,7 +1760,7 @@ void rtl839x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan
 		sw_w32_mask(0x3 << 14, mode << 14, RTL839X_VLAN_PORT_PB_VLAN + (port << 2));
 }
 
-void rtl839x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid)
+static void rtl839x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid)
 {
 	if (type == PBVLAN_TYPE_INNER)
 		sw_w32_mask(0xfff << 2, pvid << 2, RTL839X_VLAN_PORT_PB_VLAN + (port << 2));
@@ -1796,14 +1796,14 @@ static void rtl839x_set_egr_filter(int port,  enum egr_filter state)
 			RTL839X_VLAN_PORT_EGR_FLTR + (((port >> 5) << 2)));
 }
 
-void rtl839x_set_distribution_algorithm(int group, int algoidx, u32 algomsk)
+static void rtl839x_set_distribution_algorithm(int group, int algoidx, u32 algomsk)
 {
 	sw_w32_mask(3 << ((group & 0xf) << 1), algoidx << ((group & 0xf) << 1),
 		    RTL839X_TRK_HASH_IDX_CTRL + ((group >> 4) << 2));
 	sw_w32(algomsk, RTL839X_TRK_HASH_CTRL + (algoidx << 2));
 }
 
-void rtl839x_set_receive_management_action(int port, rma_ctrl_t type, action_type_t action)
+static void rtl839x_set_receive_management_action(int port, rma_ctrl_t type, action_type_t action)
 {
 	switch(type) {
 	case BPDU:

--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -75,32 +75,38 @@ inline void rtl_table_data_w(struct table_reg *r, u32 v, int i);
 
 void __init rtl83xx_setup_qos(struct rtl838x_switch_priv *priv);
 
+void rtl83xx_fast_age(struct dsa_switch *ds, int port);
 int rtl83xx_packet_cntr_alloc(struct rtl838x_switch_priv *priv);
-
+int rtl83xx_port_get_stp_state(struct rtl838x_switch_priv *priv, int port);
 int rtl83xx_port_is_under(const struct net_device * dev, struct rtl838x_switch_priv *priv);
+void rtl83xx_port_stp_state_set(struct dsa_switch *ds, int port, u8 state);
+int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type_data);
 
 int read_phy(u32 port, u32 page, u32 reg, u32 *val);
 int write_phy(u32 port, u32 page, u32 reg, u32 val);
 
 /* Port register accessor functions for the RTL839x and RTL931X SoCs */
 void rtl839x_mask_port_reg_be(u64 clear, u64 set, int reg);
+u32 rtl839x_get_egress_rate(struct rtl838x_switch_priv *priv, int port);
 u64 rtl839x_get_port_reg_be(int reg);
 void rtl839x_set_port_reg_be(u64 set, int reg);
 void rtl839x_mask_port_reg_le(u64 clear, u64 set, int reg);
+int rtl839x_set_egress_rate(struct rtl838x_switch_priv *priv, int port, u32 rate);
 void rtl839x_set_port_reg_le(u64 set, int reg);
 u64 rtl839x_get_port_reg_le(int reg);
 
 /* Port register accessor functions for the RTL838x and RTL930X SoCs */
 void rtl838x_mask_port_reg(u64 clear, u64 set, int reg);
 void rtl838x_set_port_reg(u64 set, int reg);
+u32 rtl838x_get_egress_rate(struct rtl838x_switch_priv *priv, int port);
 u64 rtl838x_get_port_reg(int reg);
+int rtl838x_set_egress_rate(struct rtl838x_switch_priv *priv, int port, u32 rate);
 
 /* RTL838x-specific */
 u32 rtl838x_hash(struct rtl838x_switch_priv *priv, u64 seed);
 irqreturn_t rtl838x_switch_irq(int irq, void *dev_id);
 void rtl8380_get_version(struct rtl838x_switch_priv *priv);
 void rtl838x_vlan_profile_dump(int index);
-int rtl83xx_dsa_phy_read(struct dsa_switch *ds, int phy_addr, int phy_reg);
 void rtl8380_sds_rst(int mac);
 int rtl8380_sds_power(int mac, int val);
 void rtl838x_print_matrix(void);
@@ -110,7 +116,6 @@ u32 rtl839x_hash(struct rtl838x_switch_priv *priv, u64 seed);
 irqreturn_t rtl839x_switch_irq(int irq, void *dev_id);
 void rtl8390_get_version(struct rtl838x_switch_priv *priv);
 void rtl839x_vlan_profile_dump(int index);
-int rtl83xx_dsa_phy_write(struct dsa_switch *ds, int phy_addr, int phy_reg, u16 val);
 void rtl839x_exec_tbl2_cmd(u32 cmd);
 void rtl839x_print_matrix(void);
 
@@ -120,17 +125,50 @@ irqreturn_t rtl930x_switch_irq(int irq, void *dev_id);
 irqreturn_t rtl839x_switch_irq(int irq, void *dev_id);
 void rtl930x_vlan_profile_dump(int index);
 int rtl9300_sds_power(int mac, int val);
-void rtl9300_sds_rst(int sds_num, u32 mode);
-int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode);
+extern int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode);
 void rtl930x_print_matrix(void);
 
 /* RTL931x-specific */
 irqreturn_t rtl931x_switch_irq(int irq, void *dev_id);
 int rtl931x_sds_cmu_band_get(int sds, phy_interface_t mode);
 int rtl931x_sds_cmu_band_set(int sds, bool enable, u32 band, phy_interface_t mode);
-void rtl931x_sds_init(u32 sds, phy_interface_t mode);
+extern void rtl931x_sds_init(u32 sds, phy_interface_t mode);
 
 int rtl83xx_lag_add(struct dsa_switch *ds, int group, int port, struct netdev_lag_upper_info *info);
 int rtl83xx_lag_del(struct dsa_switch *ds, int group, int port);
+
+/* phy functions that will need to be moved to the future mdio driver */
+
+int rtl838x_read_mmd_phy(u32 port, u32 addr, u32 reg, u32 *val);
+int rtl838x_write_mmd_phy(u32 port, u32 addr, u32 reg, u32 val);
+
+int rtl839x_read_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 *val);
+int rtl839x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
+
+int rtl930x_read_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 *val);
+int rtl930x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
+
+int rtl931x_read_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 *val);
+int rtl931x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
+
+/*
+ * TODO: The following functions are currently not in use. So compiler will complain if
+ * they are static and not made available externally. To preserve them for future use
+ * collect them in this section.
+ */
+
+void rtl838x_egress_rate_queue_limit(struct rtl838x_switch_priv *priv, int port,
+				     int queue, u32 rate);
+
+int rtl8390_sds_power(int mac, int val);
+void rtl839x_pie_rule_dump(struct  pie_rule *pr);
+void rtl839x_set_egress_queue(int port, int queue);
+
+void rtl9300_dump_debug(void);
+void rtl930x_pie_rule_dump_raw(u32 r[]);
+
+void rtl931x_print_matrix(void);
+void rtl931x_set_receive_management_action(int port, rma_ctrl_t type, action_type_t action);
+void rtl931x_sw_init(struct rtl838x_switch_priv *priv);
 
 #endif /* _NET_DSA_RTL83XX_H */

--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -638,7 +638,7 @@ static void rtl930x_write_mcast_pmask(int idx, u64 portmask)
 	rtl_table_release(q);
 }
 
-u64 rtl930x_traffic_get(int source)
+static u64 rtl930x_traffic_get(int source)
 {
 	u32 v;
 	struct table_reg *r = rtl_table_get(RTL9300_TBL_0, 6);
@@ -652,7 +652,7 @@ u64 rtl930x_traffic_get(int source)
 }
 
 /* Enable traffic between a source port and a destination port matrix */
-void rtl930x_traffic_set(int source, u64 dest_matrix)
+static void rtl930x_traffic_set(int source, u64 dest_matrix)
 {
 	struct table_reg *r = rtl_table_get(RTL9300_TBL_0, 6);
 
@@ -661,7 +661,7 @@ void rtl930x_traffic_set(int source, u64 dest_matrix)
 	rtl_table_release(r);
 }
 
-void rtl930x_traffic_enable(int source, int dest)
+static void rtl930x_traffic_enable(int source, int dest)
 {
 	struct table_reg *r = rtl_table_get(RTL9300_TBL_0, 6);
 	rtl_table_read(r, source);
@@ -670,7 +670,7 @@ void rtl930x_traffic_enable(int source, int dest)
 	rtl_table_release(r);
 }
 
-void rtl930x_traffic_disable(int source, int dest)
+static void rtl930x_traffic_disable(int source, int dest)
 {
 	struct table_reg *r = rtl_table_get(RTL9300_TBL_0, 6);
 	rtl_table_read(r, source);
@@ -892,7 +892,7 @@ u32 rtl930x_hash(struct rtl838x_switch_priv *priv, u64 seed)
 }
 
 /* Enables or disables the EEE/EEEP capability of a port */
-void rtl930x_port_eee_set(struct rtl838x_switch_priv *priv, int port, bool enable)
+static void rtl930x_port_eee_set(struct rtl838x_switch_priv *priv, int port, bool enable)
 {
 	u32 v;
 
@@ -914,7 +914,7 @@ void rtl930x_port_eee_set(struct rtl838x_switch_priv *priv, int port, bool enabl
 }
 
 /* Get EEE own capabilities and negotiation result */
-int rtl930x_eee_port_ability(struct rtl838x_switch_priv *priv, struct ethtool_eee *e, int port)
+static int rtl930x_eee_port_ability(struct rtl838x_switch_priv *priv, struct ethtool_eee *e, int port)
 {
 	u32 link, a;
 
@@ -2204,7 +2204,7 @@ static void rtl930x_set_l3_egress_mac(u32 idx, u64 mac)
  * - The router's MAC address on which routed packets are expected
  * - MAC addresses used as source macs of routed packets
  */
-int rtl930x_l3_setup(struct rtl838x_switch_priv *priv)
+static int rtl930x_l3_setup(struct rtl838x_switch_priv *priv)
 {
 	/* Setup MTU with id 0 for default interface */
 	for (int i = 0; i < MAX_INTF_MTUS; i++)
@@ -2300,7 +2300,7 @@ static void rtl930x_packet_cntr_clear(int counter)
 	rtl_table_release(r);
 }
 
-void rtl930x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
+static void rtl930x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
 {
 	sw_w32(FIELD_PREP(RTL930X_VLAN_PORT_TAG_STS_CTRL_EGR_OTAG_STS_MASK,
 			  keep_outer ? RTL930X_VLAN_PORT_TAG_STS_TAGGED : RTL930X_VLAN_PORT_TAG_STS_UNTAG) |
@@ -2309,7 +2309,7 @@ void rtl930x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
 	       RTL930X_VLAN_PORT_TAG_STS_CTRL(port));
 }
 
-void rtl930x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan_mode mode)
+static void rtl930x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan_mode mode)
 {
 	if (type == PBVLAN_TYPE_INNER)
 		sw_w32_mask(0x3, mode, RTL930X_VLAN_PORT_PB_VLAN + (port << 2));
@@ -2317,7 +2317,7 @@ void rtl930x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan
 		sw_w32_mask(0x3 << 14, mode << 14 ,RTL930X_VLAN_PORT_PB_VLAN + (port << 2));
 }
 
-void rtl930x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid)
+static void rtl930x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid)
 {
 	if (type == PBVLAN_TYPE_INNER)
 		sw_w32_mask(0xfff << 2, pvid << 2, RTL930X_VLAN_PORT_PB_VLAN + (port << 2));
@@ -2353,7 +2353,7 @@ static void rtl930x_set_egr_filter(int port,  enum egr_filter state)
 		    RTL930X_VLAN_PORT_EGR_FLTR + (((port / 29) << 2)));
 }
 
-void rtl930x_set_distribution_algorithm(int group, int algoidx, u32 algomsk)
+static void rtl930x_set_distribution_algorithm(int group, int algoidx, u32 algomsk)
 {
 	u32 l3shift = 0;
 	u32 newmask = 0;

--- a/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.6/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -136,7 +136,7 @@ inline int rtl931x_tbl_access_data_0(int i)
 	return RTL931X_TBL_ACCESS_DATA_0(i);
 }
 
-void rtl931x_vlan_profile_dump(int index)
+static void rtl931x_vlan_profile_dump(int index)
 {
 	u64 profile[4];
 
@@ -528,7 +528,7 @@ void rtl931x_set_receive_management_action(int port, rma_ctrl_t type, action_typ
 	}
 }
 
-u64 rtl931x_traffic_get(int source)
+static u64 rtl931x_traffic_get(int source)
 {
 	u32 v;
 	struct table_reg *r = rtl_table_get(RTL9310_TBL_0, 6);
@@ -542,7 +542,7 @@ u64 rtl931x_traffic_get(int source)
 }
 
 /* Enable traffic between a source port and a destination port matrix */
-void rtl931x_traffic_set(int source, u64 dest_matrix)
+static void rtl931x_traffic_set(int source, u64 dest_matrix)
 {
 	struct table_reg *r = rtl_table_get(RTL9310_TBL_0, 6);
 
@@ -551,7 +551,7 @@ void rtl931x_traffic_set(int source, u64 dest_matrix)
 	rtl_table_release(r);
 }
 
-void rtl931x_traffic_enable(int source, int dest)
+static void rtl931x_traffic_enable(int source, int dest)
 {
 	struct table_reg *r = rtl_table_get(RTL9310_TBL_0, 6);
 	rtl_table_read(r, source);
@@ -560,7 +560,7 @@ void rtl931x_traffic_enable(int source, int dest)
 	rtl_table_release(r);
 }
 
-void rtl931x_traffic_disable(int source, int dest)
+static void rtl931x_traffic_disable(int source, int dest)
 {
 	struct table_reg *r = rtl_table_get(RTL9310_TBL_0, 6);
 	rtl_table_read(r, source);
@@ -941,7 +941,7 @@ static void rtl931x_pie_lookup_enable(struct rtl838x_switch_priv *priv, int inde
  * pie_data_fill function for all SoCs, provided we have also for each SoC a
  * function to map between physical and intermediate field type
  */
-int rtl931x_pie_data_fill(enum template_field_id field_type, struct pie_rule *pr, u16 *data, u16 *data_m)
+static int rtl931x_pie_data_fill(enum template_field_id field_type, struct pie_rule *pr, u16 *data, u16 *data_m)
 {
 	*data = *data_m = 0;
 
@@ -1233,7 +1233,7 @@ static void rtl931x_write_pie_action(u32 r[],  struct pie_rule *pr)
 	r[17] |= pr->bypass_ibc_sc ? BIT(16) : 0;
 }
 
-void rtl931x_pie_rule_dump_raw(u32 r[])
+static void rtl931x_pie_rule_dump_raw(u32 r[])
 {
 	pr_debug("Raw IACL table entry:\n");
 	pr_debug("r 0 - 7: %08x %08x %08x %08x %08x %08x %08x %08x\n",
@@ -1477,12 +1477,12 @@ static void rtl931x_pie_init(struct rtl838x_switch_priv *priv)
 
 }
 
-int rtl931x_l3_setup(struct rtl838x_switch_priv *priv)
+static int rtl931x_l3_setup(struct rtl838x_switch_priv *priv)
 {
 	return 0;
 }
 
-void rtl931x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
+static void rtl931x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
 {
 	sw_w32(FIELD_PREP(RTL931X_VLAN_PORT_TAG_EGR_OTAG_STS_MASK,
 			  keep_outer ? RTL931X_VLAN_PORT_TAG_STS_TAGGED : RTL931X_VLAN_PORT_TAG_STS_UNTAG) |
@@ -1491,7 +1491,7 @@ void rtl931x_vlan_port_keep_tag_set(int port, bool keep_outer, bool keep_inner)
 	       RTL931X_VLAN_PORT_TAG_CTRL(port));
 }
 
-void rtl931x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan_mode mode)
+static void rtl931x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan_mode mode)
 {
 	if (type == PBVLAN_TYPE_INNER)
 		sw_w32_mask(0x3 << 12, mode << 12, RTL931X_VLAN_PORT_IGR_CTRL + (port << 2));
@@ -1499,7 +1499,7 @@ void rtl931x_vlan_port_pvidmode_set(int port, enum pbvlan_type type, enum pbvlan
 		sw_w32_mask(0x3 << 26, mode << 26, RTL931X_VLAN_PORT_IGR_CTRL + (port << 2));
 }
 
-void rtl931x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid)
+static void rtl931x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid)
 {
 	if (type == PBVLAN_TYPE_INNER)
 		sw_w32_mask(0xfff, pvid, RTL931X_VLAN_PORT_IGR_CTRL + (port << 2));
@@ -1519,7 +1519,7 @@ static void rtl931x_set_egr_filter(int port,  enum egr_filter state)
 		    RTL931X_VLAN_PORT_EGR_FLTR + (((port >> 5) << 2)));
 }
 
-void rtl931x_set_distribution_algorithm(int group, int algoidx, u32 algomsk)
+static void rtl931x_set_distribution_algorithm(int group, int algoidx, u32 algomsk)
 {
 	u32 l3shift = 0;
 	u32 newmask = 0;

--- a/target/linux/realtek/files-6.6/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.6/drivers/net/ethernet/rtl838x_eth.c
@@ -25,6 +25,34 @@
 
 extern struct rtl83xx_soc_info soc_info;
 
+extern int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type_data);
+
+extern int rtl838x_read_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 *val);
+extern int rtl838x_read_phy(u32 port, u32 page, u32 reg, u32 *val);
+extern int rtl838x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
+extern int rtl838x_write_phy(u32 port, u32 page, u32 reg, u32 val);
+
+extern int rtl839x_read_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 *val);
+extern int rtl839x_read_phy(u32 port, u32 page, u32 reg, u32 *val);
+extern int rtl839x_read_sds_phy(int phy_addr, int phy_reg);
+extern int rtl839x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
+extern int rtl839x_write_phy(u32 port, u32 page, u32 reg, u32 val);
+extern int rtl839x_write_sds_phy(int phy_addr, int phy_reg, u16 v);
+
+extern int rtl930x_read_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 *val);
+extern int rtl930x_read_phy(u32 port, u32 page, u32 reg, u32 *val);
+extern int rtl930x_read_sds_phy(int phy_addr, int page, int phy_reg);
+extern int rtl930x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
+extern int rtl930x_write_phy(u32 port, u32 page, u32 reg, u32 val);
+extern int rtl930x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v);
+
+extern int rtl931x_read_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 *val);
+extern int rtl931x_read_phy(u32 port, u32 page, u32 reg, u32 *val);
+extern int rtl931x_read_sds_phy(int phy_addr, int page, int phy_reg);
+extern int rtl931x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
+extern int rtl931x_write_phy(u32 port, u32 page, u32 reg, u32 val);
+extern int rtl931x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v);
+
 /* Maximum number of RX rings is 8 on RTL83XX and 32 on the 93XX
  * The ring is assigned by switch based on packet/port priortity
  * Maximum number of TX rings is 2, Ring 2 being the high priority
@@ -204,34 +232,22 @@ struct rtl838x_eth_priv {
 	u16 rxringlen;
 };
 
-extern int rtl838x_phy_init(struct rtl838x_eth_priv *priv);
-extern int rtl839x_read_sds_phy(int phy_addr, int phy_reg);
-extern int rtl839x_write_sds_phy(int phy_addr, int phy_reg, u16 v);
-extern int rtl930x_read_sds_phy(int phy_addr, int page, int phy_reg);
-extern int rtl930x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v);
-extern int rtl931x_read_sds_phy(int phy_addr, int page, int phy_reg);
-extern int rtl931x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v);
-extern int rtl930x_read_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 *val);
-extern int rtl930x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
-extern int rtl931x_read_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 *val);
-extern int rtl931x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
-
 /* On the RTL93XX, the RTL93XX_DMA_IF_RX_RING_CNTR track the fill level of
  * the rings. Writing x into these registers substracts x from its content.
  * When the content reaches the ring size, the ASIC no longer adds
  * packets to this receive queue.
  */
-void rtl838x_update_cntr(int r, int released)
+static void rtl838x_update_cntr(int r, int released)
 {
 	/* This feature is not available on RTL838x SoCs */
 }
 
-void rtl839x_update_cntr(int r, int released)
+static void rtl839x_update_cntr(int r, int released)
 {
 	/* This feature is not available on RTL839x SoCs */
 }
 
-void rtl930x_update_cntr(int r, int released)
+static void rtl930x_update_cntr(int r, int released)
 {
 	int pos = (r % 3) * 10;
 	u32 reg = RTL930X_DMA_IF_RX_RING_CNTR + ((r / 3) << 2);
@@ -243,7 +259,7 @@ void rtl930x_update_cntr(int r, int released)
 	sw_w32(v, reg);
 }
 
-void rtl931x_update_cntr(int r, int released)
+static void rtl931x_update_cntr(int r, int released)
 {
 	int pos = (r % 3) * 10;
 	u32 reg = RTL931X_DMA_IF_RX_RING_CNTR + ((r / 3) << 2);
@@ -263,7 +279,7 @@ struct dsa_tag {
 	bool	crc_error;
 };
 
-bool rtl838x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
+static bool rtl838x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
 {
 	/* cpu_tag[0] is reserved. Fields are off-by-one */
 	t->reason = h->cpu_tag[4] & 0xf;
@@ -280,7 +296,7 @@ bool rtl838x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
 	return t->l2_offloaded;
 }
 
-bool rtl839x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
+static bool rtl839x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
 {
 	/* cpu_tag[0] is reserved. Fields are off-by-one */
 	t->reason = h->cpu_tag[5] & 0x1f;
@@ -298,7 +314,7 @@ bool rtl839x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
 	return t->l2_offloaded;
 }
 
-bool rtl930x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
+static bool rtl930x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
 {
 	t->reason = h->cpu_tag[7] & 0x3f;
 	t->queue =  (h->cpu_tag[2] >> 11) & 0x1f;
@@ -314,7 +330,7 @@ bool rtl930x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
 	return t->l2_offloaded;
 }
 
-bool rtl931x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
+static bool rtl931x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
 {
 	t->reason = h->cpu_tag[7] & 0x3f;
 	t->queue =  (h->cpu_tag[2] >> 11) & 0x1f;
@@ -370,7 +386,7 @@ struct fdb_update_work {
 	u64 macs[NOTIFY_EVENTS + 1];
 };
 
-void rtl838x_fdb_sync(struct work_struct *work)
+static void rtl838x_fdb_sync(struct work_struct *work)
 {
 	const struct fdb_update_work *uw = container_of(work, struct fdb_update_work, work);
 
@@ -1197,7 +1213,7 @@ txdone:
 /* Return queue number for TX. On the RTL83XX, these queues have equal priority
  * so we do round-robin
  */
-u16 rtl83xx_pick_tx_queue(struct net_device *dev, struct sk_buff *skb,
+static u16 rtl83xx_pick_tx_queue(struct net_device *dev, struct sk_buff *skb,
 			  struct net_device *sb_dev)
 {
 	static u8 last = 0;
@@ -1208,7 +1224,7 @@ u16 rtl83xx_pick_tx_queue(struct net_device *dev, struct sk_buff *skb,
 
 /* Return queue number for TX. On the RTL93XX, queue 1 is the high priority queue
  */
-u16 rtl93xx_pick_tx_queue(struct net_device *dev, struct sk_buff *skb,
+static u16 rtl93xx_pick_tx_queue(struct net_device *dev, struct sk_buff *skb,
 			  struct net_device *sb_dev)
 {
 	if (skb->priority >= TC_PRIO_CONTROL)
@@ -1791,14 +1807,14 @@ int phy_port_read_paged(struct phy_device *phydev, int port, int page, u32 regnu
 
 /* SerDes reader/writer functions for the ports without external phy. */
 
-int rtmdio_838x_read_sds(int addr, int regnum)
+static int rtmdio_838x_read_sds(int addr, int regnum)
 {
 	int offset = addr == 26 ? 0x100 : 0x0;
 
 	return sw_r32(RTL838X_SDS4_FIB_REG0 + offset + (regnum << 2)) & 0xffff;
 }
 
-int rtmdio_838x_write_sds(int addr, int regnum, u16 val)
+static int rtmdio_838x_write_sds(int addr, int regnum, u16 val)
 {
 	int offset = addr == 26 ? 0x100 : 0x0;
 

--- a/target/linux/realtek/files-6.6/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.6/drivers/net/ethernet/rtl838x_eth.h
@@ -445,18 +445,11 @@ struct rtl838x_eth_reg {
 	bool (*decode_tag)(struct p_hdr *h, struct dsa_tag *tag);
 };
 
-int rtl838x_write_phy(u32 port, u32 page, u32 reg, u32 val);
-int rtl838x_read_phy(u32 port, u32 page, u32 reg, u32 *val);
-int rtl838x_write_mmd_phy(u32 port, u32 addr, u32 reg, u32 val);
-int rtl838x_read_mmd_phy(u32 port, u32 addr, u32 reg, u32 *val);
-int rtl839x_write_phy(u32 port, u32 page, u32 reg, u32 val);
-int rtl839x_read_phy(u32 port, u32 page, u32 reg, u32 *val);
-int rtl839x_read_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 *val);
-int rtl839x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);
-int rtl930x_write_phy(u32 port, u32 page, u32 reg, u32 val);
-int rtl930x_read_phy(u32 port, u32 page, u32 reg, u32 *val);
-int rtl931x_write_phy(u32 port, u32 page, u32 reg, u32 val);
-int rtl931x_read_phy(u32 port, u32 page, u32 reg, u32 *val);
-int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type_data);
+int phy_package_port_read_paged(struct phy_device *phydev, int port, int page, u32 regnum);
+int phy_package_port_write_paged(struct phy_device *phydev, int port, int page, u32 regnum, u16 val);
+int phy_package_read_paged(struct phy_device *phydev, int page, u32 regnum);
+int phy_package_write_paged(struct phy_device *phydev, int page, u32 regnum, u16 val);
+int phy_port_read_paged(struct phy_device *phydev, int port, int page, u32 regnum);
+int phy_port_write_paged(struct phy_device *phydev, int port, int page, u32 regnum, u16 val);
 
 #endif /* _RTL838X_ETH_H */

--- a/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.c
@@ -147,7 +147,7 @@ static int resume_polling(u64 saved_state)
 	return 0;
 }
 
-int rtl821x_match_phy_device(struct phy_device *phydev)
+static int rtl821x_match_phy_device(struct phy_device *phydev)
 {
 	u64 poll_state;
 	int rawpage, port = phydev->mdio.addr & ~3;
@@ -238,7 +238,7 @@ u8  rtl9300_sds_lsb[]  = { 0, 6, 12, 18, 0, 6, 12, 18, 0, 6, 0, 6};
 /* Reset the SerDes by powering it off and set a new operation mode
  * of the SerDes.
  */
-void rtl9300_sds_rst(int sds_num, u32 mode)
+static void rtl9300_sds_rst(int sds_num, u32 mode)
 {
 	pr_info("%s %d\n", __func__, mode);
 	if (sds_num < 0 || sds_num > 11) {
@@ -275,7 +275,7 @@ void rtl9300_sds_set(int sds_num, u32 mode)
 	         sw_r32(0x194), sw_r32(0x198), sw_r32(0x2a0), sw_r32(0x2a4));
 }
 
-u32 rtl9300_sds_mode_get(int sds_num)
+static u32 rtl9300_sds_mode_get(int sds_num)
 {
 	u32 v;
 
@@ -1147,7 +1147,7 @@ static int rtl8214fc_config_aneg(struct phy_device *phydev)
  * but the only way that works since the kernel first enables EEE in the MAC
  * and then sets up the PHY. The MAC-based approach would require the oppsite.
  */
-void rtl8218d_eee_set(struct phy_device *phydev, bool enable)
+static void rtl8218d_eee_set(struct phy_device *phydev, bool enable)
 {
 	u32 val;
 	bool an_enabled;
@@ -1668,7 +1668,7 @@ static int rtl8390_configure_serdes(struct phy_device *phydev)
 	return 0;
 }
 
-void rtl9300_sds_field_w(int sds, u32 page, u32 reg, int end_bit, int start_bit, u32 v)
+static void rtl9300_sds_field_w(int sds, u32 page, u32 reg, int end_bit, int start_bit, u32 v)
 {
 	int l = end_bit - start_bit + 1;
 	u32 data = v;
@@ -1684,7 +1684,7 @@ void rtl9300_sds_field_w(int sds, u32 page, u32 reg, int end_bit, int start_bit,
 	rtl930x_write_sds_phy(sds, page, reg, data);
 }
 
-u32 rtl9300_sds_field_r(int sds, u32 page, u32 reg, int end_bit, int start_bit)
+static u32 rtl9300_sds_field_r(int sds, u32 page, u32 reg, int end_bit, int start_bit)
 {
 	int l = end_bit - start_bit + 1;
 	u32 v = rtl930x_read_sds_phy(sds, page, reg);
@@ -1752,7 +1752,7 @@ static int rtl9300_read_status(struct phy_device *phydev)
 	return 0;
 }
 
-void rtl930x_sds_rx_rst(int sds_num, phy_interface_t phy_if)
+static void rtl930x_sds_rx_rst(int sds_num, phy_interface_t phy_if)
 {
 	int page = 0x2e; /* 10GR and USXGMII */
 
@@ -1766,7 +1766,7 @@ void rtl930x_sds_rx_rst(int sds_num, phy_interface_t phy_if)
 
 /* Force PHY modes on 10GBit Serdes
  */
-void rtl9300_force_sds_mode(int sds, phy_interface_t phy_if)
+static void rtl9300_force_sds_mode(int sds, phy_interface_t phy_if)
 {
 	int lc_value;
 	int sds_mode;
@@ -1927,7 +1927,7 @@ void rtl9300_force_sds_mode(int sds, phy_interface_t phy_if)
 	pr_info("%s --------------------- serdes %d forced to %x DONE\n", __func__, sds, sds_mode);
 }
 
-void rtl9300_sds_tx_config(int sds, phy_interface_t phy_if)
+static void rtl9300_sds_tx_config(int sds, phy_interface_t phy_if)
 {
 	/* parameters: rtl9303_80G_txParam_s2 */
 	int impedance = 0x8;
@@ -1994,7 +1994,7 @@ int rtl9300_sds_clock_wait(int timeout)
 	return 1;
 }
 
-void rtl9300_serdes_mac_link_config(int sds, bool tx_normal, bool rx_normal)
+static void rtl9300_serdes_mac_link_config(int sds, bool tx_normal, bool rx_normal)
 {
 	u32 v10, v1;
 
@@ -2175,7 +2175,7 @@ void rtl9300_sds_rxcal_dcvs_get(u32 sds_num, u32 dcvs_id, u32 dcvs_list[])
 	dcvs_list[1] = dcvs_coef_bin;
 }
 
-void rtl9300_sds_rxcal_leq_manual(u32 sds_num, bool manual, u32 leq_gray)
+static void rtl9300_sds_rxcal_leq_manual(u32 sds_num, bool manual, u32 leq_gray)
 {
 	if (manual) {
 		rtl9300_sds_field_w(sds_num, 0x2e, 0x18, 15, 15, 0x1);
@@ -2186,7 +2186,7 @@ void rtl9300_sds_rxcal_leq_manual(u32 sds_num, bool manual, u32 leq_gray)
 	}
 }
 
-void rtl9300_sds_rxcal_leq_offset_manual(u32 sds_num, bool manual, u32 offset)
+static void rtl9300_sds_rxcal_leq_offset_manual(u32 sds_num, bool manual, u32 offset)
 {
 	if (manual) {
 		rtl9300_sds_field_w(sds_num, 0x2e, 0x17, 6, 2, offset);
@@ -2197,7 +2197,7 @@ void rtl9300_sds_rxcal_leq_offset_manual(u32 sds_num, bool manual, u32 offset)
 }
 
 #define GRAY_BITS 5
-u32 rtl9300_sds_rxcal_gray_to_binary(u32 gray_code)
+static u32 rtl9300_sds_rxcal_gray_to_binary(u32 gray_code)
 {
 	int i, j, m;
 	u32 g[GRAY_BITS];
@@ -2223,7 +2223,7 @@ u32 rtl9300_sds_rxcal_gray_to_binary(u32 gray_code)
 	return leq_binary;
 }
 
-u32 rtl9300_sds_rxcal_leq_read(int sds_num)
+static u32 rtl9300_sds_rxcal_leq_read(int sds_num)
 {
 	u32 leq_gray, leq_bin;
 	bool leq_manual;
@@ -2251,7 +2251,7 @@ u32 rtl9300_sds_rxcal_leq_read(int sds_num)
 	return leq_bin;
 }
 
-void rtl9300_sds_rxcal_vth_manual(u32 sds_num, bool manual, u32 vth_list[])
+static void rtl9300_sds_rxcal_vth_manual(u32 sds_num, bool manual, u32 vth_list[])
 {
 	if (manual) {
 		rtl9300_sds_field_w(sds_num, 0x2e, 0x0f, 13, 13, 0x1);
@@ -2263,7 +2263,7 @@ void rtl9300_sds_rxcal_vth_manual(u32 sds_num, bool manual, u32 vth_list[])
 	}
 }
 
-void rtl9300_sds_rxcal_vth_get(u32  sds_num, u32 vth_list[])
+static void rtl9300_sds_rxcal_vth_get(u32  sds_num, u32 vth_list[])
 {
 	u32 vth_manual;
 
@@ -2294,7 +2294,7 @@ void rtl9300_sds_rxcal_vth_get(u32  sds_num, u32 vth_list[])
 	pr_info("Vth Maunal = %d", vth_manual);
 }
 
-void rtl9300_sds_rxcal_tap_manual(u32 sds_num, int tap_id, bool manual, u32 tap_list[])
+static void rtl9300_sds_rxcal_tap_manual(u32 sds_num, int tap_id, bool manual, u32 tap_list[])
 {
 	if (manual) {
 		switch(tap_id) {
@@ -2341,7 +2341,7 @@ void rtl9300_sds_rxcal_tap_manual(u32 sds_num, int tap_id, bool manual, u32 tap_
 	}
 }
 
-void rtl9300_sds_rxcal_tap_get(u32 sds_num, u32 tap_id, u32 tap_list[])
+static void rtl9300_sds_rxcal_tap_get(u32 sds_num, u32 tap_id, u32 tap_list[])
 {
 	u32 tap0_sign_out;
 	u32 tap0_coef_bin;
@@ -2419,7 +2419,7 @@ void rtl9300_sds_rxcal_tap_get(u32 sds_num, u32 tap_id, u32 tap_list[])
 	}
 }
 
-void rtl9300_do_rx_calibration_1(int sds, phy_interface_t phy_mode)
+static void rtl9300_do_rx_calibration_1(int sds, phy_interface_t phy_mode)
 {
 	/* From both rtl9300_rxCaliConf_serdes_myParam and rtl9300_rxCaliConf_phy_myParam */
 	int tap0_init_val = 0x1f; /* Initial Decision Fed Equalizer 0 tap */
@@ -2514,7 +2514,7 @@ void rtl9300_do_rx_calibration_1(int sds, phy_interface_t phy_mode)
 	pr_info("end_1.1.5\n");
 }
 
-void rtl9300_do_rx_calibration_2_1(u32 sds_num)
+static void rtl9300_do_rx_calibration_2_1(u32 sds_num)
 {
 	pr_info("start_1.2.1 ForegroundOffsetCal_Manual\n");
 
@@ -2527,7 +2527,7 @@ void rtl9300_do_rx_calibration_2_1(u32 sds_num)
 	pr_info("end_1.2.1");
 }
 
-void rtl9300_do_rx_calibration_2_2(int sds_num)
+static void rtl9300_do_rx_calibration_2_2(int sds_num)
 {
 	/* Force Rx-Run = 0 */
 	rtl9300_sds_field_w(sds_num, 0x2e, 0x15, 8, 8, 0x0);
@@ -2535,7 +2535,7 @@ void rtl9300_do_rx_calibration_2_2(int sds_num)
 	rtl930x_sds_rx_rst(sds_num, PHY_INTERFACE_MODE_10GBASER);
 }
 
-void rtl9300_do_rx_calibration_2_3(int sds_num)
+static void rtl9300_do_rx_calibration_2_3(int sds_num)
 {
 	u32 fgcal_binary, fgcal_gray;
 	u32 offset_range;
@@ -2582,7 +2582,7 @@ void rtl9300_do_rx_calibration_2_3(int sds_num)
 	pr_info("%s: end_1.2.3\n", __func__);
 }
 
-void rtl9300_do_rx_calibration_2(int sds)
+static void rtl9300_do_rx_calibration_2(int sds)
 {
 	rtl930x_sds_rx_rst(sds, PHY_INTERFACE_MODE_10GBASER);
 	rtl9300_do_rx_calibration_2_1(sds);
@@ -2590,7 +2590,7 @@ void rtl9300_do_rx_calibration_2(int sds)
 	rtl9300_do_rx_calibration_2_3(sds);
 }
 
-void rtl9300_sds_rxcal_3_1(int sds_num, phy_interface_t phy_mode)
+static void rtl9300_sds_rxcal_3_1(int sds_num, phy_interface_t phy_mode)
 {
 	pr_info("start_1.3.1");
 
@@ -2606,7 +2606,7 @@ void rtl9300_sds_rxcal_3_1(int sds_num, phy_interface_t phy_mode)
 	pr_info("end_1.3.1");
 }
 
-void rtl9300_sds_rxcal_3_2(int sds_num, phy_interface_t phy_mode)
+static void rtl9300_sds_rxcal_3_2(int sds_num, phy_interface_t phy_mode)
 {
 	u32 sum10 = 0, avg10, int10;
 	int dac_long_cable_offset;
@@ -2678,7 +2678,7 @@ void rtl9300_do_rx_calibration_3(int sds_num, phy_interface_t phy_mode)
 		rtl9300_sds_rxcal_3_2(sds_num, phy_mode);
 }
 
-void rtl9300_do_rx_calibration_4_1(int sds_num)
+static void rtl9300_do_rx_calibration_4_1(int sds_num)
 {
 	u32 vth_list[2] = {0, 0};
 	u32 tap0_list[4] = {0, 0, 0, 0};
@@ -2693,7 +2693,7 @@ void rtl9300_do_rx_calibration_4_1(int sds_num)
 	pr_info("end_1.4.1");
 }
 
-void rtl9300_do_rx_calibration_4_2(u32 sds_num)
+static void rtl9300_do_rx_calibration_4_2(u32 sds_num)
 {
 	u32 vth_list[2];
 	u32 tap_list[4];
@@ -2711,13 +2711,13 @@ void rtl9300_do_rx_calibration_4_2(u32 sds_num)
 	pr_info("end_1.4.2");
 }
 
-void rtl9300_do_rx_calibration_4(u32 sds_num)
+static void rtl9300_do_rx_calibration_4(u32 sds_num)
 {
 	rtl9300_do_rx_calibration_4_1(sds_num);
 	rtl9300_do_rx_calibration_4_2(sds_num);
 }
 
-void rtl9300_do_rx_calibration_5_2(u32 sds_num)
+static void rtl9300_do_rx_calibration_5_2(u32 sds_num)
 {
 	u32 tap1_list[4] = {0};
 	u32 tap2_list[4] = {0};
@@ -2736,14 +2736,14 @@ void rtl9300_do_rx_calibration_5_2(u32 sds_num)
 	pr_info("end_1.5.2");
 }
 
-void rtl9300_do_rx_calibration_5(u32 sds_num, phy_interface_t phy_mode)
+static void rtl9300_do_rx_calibration_5(u32 sds_num, phy_interface_t phy_mode)
 {
 	if (phy_mode == PHY_INTERFACE_MODE_10GBASER) /* dfeTap1_4Enable true */
 		rtl9300_do_rx_calibration_5_2(sds_num);
 }
 
 
-void rtl9300_do_rx_calibration_dfe_disable(u32 sds_num)
+static void rtl9300_do_rx_calibration_dfe_disable(u32 sds_num)
 {
 	u32 tap1_list[4] = {0};
 	u32 tap2_list[4] = {0};
@@ -2758,7 +2758,7 @@ void rtl9300_do_rx_calibration_dfe_disable(u32 sds_num)
 	mdelay(10);
 }
 
-void rtl9300_do_rx_calibration(int sds, phy_interface_t phy_mode)
+static void rtl9300_do_rx_calibration(int sds, phy_interface_t phy_mode)
 {
 	u32 latch_sts;
 
@@ -2782,7 +2782,7 @@ void rtl9300_do_rx_calibration(int sds, phy_interface_t phy_mode)
 	}
 }
 
-int rtl9300_sds_sym_err_reset(int sds_num, phy_interface_t phy_mode)
+static int rtl9300_sds_sym_err_reset(int sds_num, phy_interface_t phy_mode)
 {
 	switch (phy_mode) {
 	case PHY_INTERFACE_MODE_XGMII:
@@ -2809,7 +2809,7 @@ int rtl9300_sds_sym_err_reset(int sds_num, phy_interface_t phy_mode)
 	return 0;
 }
 
-u32 rtl9300_sds_sym_err_get(int sds_num, phy_interface_t phy_mode)
+static u32 rtl9300_sds_sym_err_get(int sds_num, phy_interface_t phy_mode)
 {
 	u32 v = 0;
 
@@ -2830,7 +2830,7 @@ u32 rtl9300_sds_sym_err_get(int sds_num, phy_interface_t phy_mode)
 	return v;
 }
 
-int rtl9300_sds_check_calibration(int sds_num, phy_interface_t phy_mode)
+static int rtl9300_sds_check_calibration(int sds_num, phy_interface_t phy_mode)
 {
 	u32 errors1, errors2;
 
@@ -2865,7 +2865,7 @@ int rtl9300_sds_check_calibration(int sds_num, phy_interface_t phy_mode)
 	return 0;
 }
 
-void rtl9300_phy_enable_10g_1g(int sds_num)
+static void rtl9300_phy_enable_10g_1g(int sds_num)
 {
 	u32 v;
 
@@ -3107,7 +3107,7 @@ int rtl9300_sds_cmu_band_get(int sds)
 	return cmu_band;
 }
 
-void rtl9310_sds_field_w(int sds, u32 page, u32 reg, int end_bit, int start_bit, u32 v)
+static void rtl9310_sds_field_w(int sds, u32 page, u32 reg, int end_bit, int start_bit, u32 v)
 {
 	int l = end_bit - start_bit + 1;
 	u32 data = v;
@@ -3123,7 +3123,7 @@ void rtl9310_sds_field_w(int sds, u32 page, u32 reg, int end_bit, int start_bit,
 	rtl931x_write_sds_phy(sds, page, reg, data);
 }
 
-u32 rtl9310_sds_field_r(int sds, u32 page, u32 reg, int end_bit, int start_bit)
+static u32 rtl9310_sds_field_r(int sds, u32 page, u32 reg, int end_bit, int start_bit)
 {
 	int l = end_bit - start_bit + 1;
 	u32 v = rtl931x_read_sds_phy(sds, page, reg);

--- a/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.h
+++ b/target/linux/realtek/files-6.6/drivers/net/phy/rtl83xx-phy.h
@@ -67,3 +67,32 @@ struct __attribute__ ((__packed__)) fw_header {
 #define RTL931X_SERDES_MODE_CTRL		(0x13cc)
 #define RTL931X_PS_SERDES_OFF_MODE_CTRL_ADDR	(0x13F4)
 #define RTL931X_MAC_SERDES_MODE_CTRL(sds)	(0x136C + (((sds) << 2)))
+
+int rtl839x_read_sds_phy(int phy_addr, int phy_reg);
+int rtl839x_write_sds_phy(int phy_addr, int phy_reg, u16 v);
+
+int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode);
+int rtl930x_read_sds_phy(int phy_addr, int page, int phy_reg);
+int rtl930x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v);
+
+int rtl931x_read_sds_phy(int phy_addr, int page, int phy_reg);
+int rtl931x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v);
+int rtl931x_sds_cmu_band_get(int sds, phy_interface_t mode);
+void rtl931x_sds_init(u32 sds, phy_interface_t mode);
+
+/*
+ * TODO: The following functions are currently not in use. So compiler will complain if
+ * they are static and not made available externally. Collect them in this section to
+ * preserve for future use.
+ */
+
+void rtl9300_do_rx_calibration_3(int sds_num, phy_interface_t phy_mode);
+int rtl9300_sds_clock_wait(int timeout);
+int rtl9300_sds_cmu_band_get(int sds);
+void rtl9300_sds_rxcal_dcvs_get(u32 sds_num, u32 dcvs_id, u32 dcvs_list[]);
+void rtl9300_sds_rxcal_dcvs_manual(u32 sds_num, u32 dcvs_id, bool manual, u32 dvcs_list[]);
+void rtl9300_sds_set(int sds_num, u32 mode);
+
+int rtl931x_link_sts_get(u32 sds);
+void rtl931x_sds_fiber_disable(u32 sds);
+int rtl931x_sds_cmu_band_set(int sds, bool enable, u32 band, phy_interface_t mode);


### PR DESCRIPTION
In 2023 upstream has tightened compiler checks with [this patch](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/scripts/Makefile.extrawarn?h=v6.15&id=0fcb70851fbfea1776ae62f67c503fef8f0292b9). A consistent function definition is now needed. I.e.

- functions must be either declared with "static" or
- functions need an additional declaration (in the header file)

Before upgrading the Realtek target to 6.12 clean the code so that the main 6.12 PR can focus on real issues from the version bump.

How to test:

- rebuild OpenWrt and check for compiler errors
- Start image on (any) Realtek switch and check if verything works as before