### PR TITLE
mt76: replace strlcpy with strscpy

### DIFF
--- a/package/kernel/mt76/patches/002-wifi-mt76-replace-strlcpy-with-strscpy.patch
+++ b/package/kernel/mt76/patches/002-wifi-mt76-replace-strlcpy-with-strscpy.patch
@@ -1,0 +1,73 @@
+From d6b484b5cb2a7d509b36a220911509ddd8b777c4 Mon Sep 17 00:00:00 2001
+From: Azeem Shaikh <azeemshaikh38@gmail.com>
+Date: Mon, 3 Jul 2023 18:12:56 +0000
+Subject: wifi: mt76: Replace strlcpy() with strscpy()
+
+strlcpy() reads the entire source buffer first.
+This read may exceed the destination size limit.
+This is both inefficient and can lead to linear read
+overflows if a source string is not NUL-terminated [1].
+In an effort to remove strlcpy() completely [2], replace
+strlcpy() here with strscpy().
+
+Direct replacement is safe here since DEV_ASSIGN is only used by
+TRACE macros and the return values are ignored.
+
+[1] https://www.kernel.org/doc/html/latest/process/deprecated.html#strlcpy
+[2] https://github.com/KSPP/linux/issues/89
+
+Signed-off-by: Azeem Shaikh <azeemshaikh38@gmail.com>
+Reviewed-by: Kees Cook <keescook@chromium.org>
+Signed-off-by: Kalle Valo <kvalo@kernel.org>
+Link: https://lore.kernel.org/r/20230703181256.3712079-1-azeemshaikh38@gmail.com
+---
+ mt7615/mt7615_trace.h | 2 +-
+ mt76x02_trace.h       | 2 +-
+ trace.h               | 2 +-
+ usb_trace.h           | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+--- a/mt7615/mt7615_trace.h
++++ b/mt7615/mt7615_trace.h
+@@ -14,7 +14,7 @@
+ 
+ #define MAXNAME		32
+ #define DEV_ENTRY	__array(char, wiphy_name, 32)
+-#define DEV_ASSIGN	strlcpy(__entry->wiphy_name,	\
++#define DEV_ASSIGN	strscpy(__entry->wiphy_name,	\
+ 				wiphy_name(mt76_hw(dev)->wiphy), MAXNAME)
+ #define DEV_PR_FMT	"%s"
+ #define DEV_PR_ARG	__entry->wiphy_name
+--- a/mt76x02_trace.h
++++ b/mt76x02_trace.h
+@@ -14,7 +14,7 @@
+ 
+ #define MAXNAME		32
+ #define DEV_ENTRY	__array(char, wiphy_name, 32)
+-#define DEV_ASSIGN	strlcpy(__entry->wiphy_name,	\
++#define DEV_ASSIGN	strscpy(__entry->wiphy_name,	\
+ 				wiphy_name(mt76_hw(dev)->wiphy), MAXNAME)
+ #define DEV_PR_FMT	"%s"
+ #define DEV_PR_ARG	__entry->wiphy_name
+--- a/trace.h
++++ b/trace.h
+@@ -14,7 +14,7 @@
+ 
+ #define MAXNAME		32
+ #define DEV_ENTRY	__array(char, wiphy_name, 32)
+-#define DEVICE_ASSIGN	strlcpy(__entry->wiphy_name,	\
++#define DEVICE_ASSIGN	strscpy(__entry->wiphy_name,	\
+ 				wiphy_name(dev->hw->wiphy), MAXNAME)
+ #define DEV_PR_FMT	"%s"
+ #define DEV_PR_ARG	__entry->wiphy_name
+--- a/usb_trace.h
++++ b/usb_trace.h
+@@ -14,7 +14,7 @@
+ 
+ #define MAXNAME		32
+ #define DEV_ENTRY	__array(char, wiphy_name, 32)
+-#define DEV_ASSIGN	strlcpy(__entry->wiphy_name,	\
++#define DEV_ASSIGN	strscpy(__entry->wiphy_name,	\
+ 				wiphy_name(dev->hw->wiphy), MAXNAME)
+ #define DEV_PR_FMT	"%s "
+ #define DEV_PR_ARG	__entry->wiphy_name


### PR DESCRIPTION
Change deprecated function strlcpy to strscpy for compatibility with kernel 6.12.

strlcpy() reads the entire source buffer first. This read may exceed the destination size limit.
This is both inefficient and can lead to linear read overflows if a source string is not NUL-terminated [1].
In an effort to remove strlcpy() completely [2], replace strlcpy() here with strscpy().

Direct replacement is safe here since DEV_ASSIGN is only used by TRACE macros and the return values are ignored.

[1] https://www.kernel.org/doc/html/latest/process/deprecated.html#strlcpy
[2] https://github.com/KSPP/linux/issues/89