### PR TITLE
umbim: add support for wwan device class

### DIFF
--- a/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
+++ b/package/network/utils/umbim/files/lib/netifd/proto/mbim.sh
@@ -73,7 +73,7 @@ _proto_mbim_setup() {
 	}
 
 	devname="$(basename "$device")"
-	devpath="$(readlink -f /sys/class/usbmisc/$devname/device/)"
+	devpath="$(readlink -f /sys/class/usbmisc/$devname/device/ || readlink -f /sys/class/wwan/$devname/device/)"
 	ifname="$( ls "$devpath"/net )"
 
 	[ -n "$ifname" ] || {


### PR DESCRIPTION
Some MBIM devices can exist on an MHI bus (over PCIe) instead of being presented as USB devices.

In such cases the interface name lookup needs to be done from `/sys/class/wwan/` instead of `/sys/class/usbmisc/`

Add another readlink call in case the first lookup fails.

This allows the MBIM protocol to find the interface name and then work with both type of devices provided that /etc/config/network has the right device for MBIM interface (such as `/dev/wwan0mbim0` in case of MHI)

This PR was tested on Quectel RM520N-GL modem. For it to work [#18794](https://github.com/openwrt/openwrt/pull/18794) needs to be merged to make the device node function correctly.