### PR TITLE
wifi-scripts: add missing 'network' property to wifi-iface schema

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -724,6 +724,13 @@
 			"type": "alias",
 			"default": "nas_identifier"
 		},
+		"network": {
+			"description": "Specifies one or multiple logical network interfaces declared in the network configuration, each one should be a L3 bridge to be able to attach this L2 wireless interface.",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
 		"network_auth_type": {
 			"description": "Network Authentication Type",
 			"type": "string"


### PR DESCRIPTION
The ucode-based wifi interface validation is based on `hostapd.conf` specific options, which means it's missing the OpenWrt-specific 'network' property.

This causes schema validation warnings like:
```
daemon.notice netifd: radio1 (1340): wifi-scripts: network is not present in the schema
```

The description is taken from the OpenWrt wiki:
https://openwrt.org/docs/guide-user/network/wifi/basic#common_options1

Mentions:
@nbd168 @robimarko 