### PR TITLE
kernel: generic: include backported/pending patches to fix build with GCC15

### DIFF
--- a/target/linux/generic/backport-6.12/807-v6.15-power-supply-sysfs-remove-duplicate-nul-termination-to-fix-build-with-GCC15.patch
+++ b/target/linux/generic/backport-6.12/807-v6.15-power-supply-sysfs-remove-duplicate-nul-termination-to-fix-build-with-GCC15.patch
@@ -1,0 +1,39 @@
+From 77f5bb150132bbbcd6bc37ffdc80c9e140e373a4 Mon Sep 17 00:00:00 2001
+From: Kees Cook <kees@kernel.org>
+Date: Wed, 16 Apr 2025 15:27:41 -0700
+Subject: [PATCH] power: supply: sysfs: Remove duplicate NUL termination
+
+GCC 15's new -Wunterminated-string-initialization notices that one of
+the sysfs attr strings would lack the implicit trailing NUL byte during
+initialization:
+
+drivers/power/supply/power_supply_sysfs.c:183:57: warning: initializer-string for array of 'char' truncates NUL terminator but destination lacks 'nonstring' attribute (32 chars into 31 available) [-Wunterminated-string-initialization]
+  183 |         POWER_SUPPLY_ATTR(CHARGE_CONTROL_START_THRESHOLD),
+      |                                                         ^
+drivers/power/supply/power_supply_sysfs.c:36:23: note: in definition of macro '_POWER_SUPPLY_ATTR'
+   36 |         .attr_name = #_name "\0",               \
+      |                       ^~~~~
+drivers/power/supply/power_supply_sysfs.c:183:9: note: in expansion of macro 'POWER_SUPPLY_ATTR'
+  183 |         POWER_SUPPLY_ATTR(CHARGE_CONTROL_START_THRESHOLD),
+      |         ^~~~~~~~~~~~~~~~~
+
+However, the macro used was explicitly adding a trailing NUL byte (which
+is not needed). Remove this to avoid the GCC warning. No binary
+differences are seen after this change (there was always run for a NUL
+byte, it's just that the _second_ NUL byte was getting truncated).
+
+Signed-off-by: Kees Cook <kees@kernel.org>
+Link: https://lore.kernel.org/r/20250416222740.work.569-kees@kernel.org
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+
+--- a/drivers/power/supply/power_supply_sysfs.c
++++ b/drivers/power/supply/power_supply_sysfs.c
+@@ -33,7 +33,7 @@ struct power_supply_attr {
+ [POWER_SUPPLY_PROP_ ## _name] =			\
+ {						\
+ 	.prop_name = #_name,			\
+-	.attr_name = #_name "\0",		\
++	.attr_name = #_name,			\
+ 	.text_values = _text,			\
+ 	.text_values_len = _len,		\
+ }

--- a/target/linux/generic/backport-6.6/807-v6.15-power-supply-sysfs-remove-duplicate-nul-termination-to-fix-build-with-GCC15.patch
+++ b/target/linux/generic/backport-6.6/807-v6.15-power-supply-sysfs-remove-duplicate-nul-termination-to-fix-build-with-GCC15.patch
@@ -1,0 +1,39 @@
+From 77f5bb150132bbbcd6bc37ffdc80c9e140e373a4 Mon Sep 17 00:00:00 2001
+From: Kees Cook <kees@kernel.org>
+Date: Wed, 16 Apr 2025 15:27:41 -0700
+Subject: [PATCH] power: supply: sysfs: Remove duplicate NUL termination
+
+GCC 15's new -Wunterminated-string-initialization notices that one of
+the sysfs attr strings would lack the implicit trailing NUL byte during
+initialization:
+
+drivers/power/supply/power_supply_sysfs.c:183:57: warning: initializer-string for array of 'char' truncates NUL terminator but destination lacks 'nonstring' attribute (32 chars into 31 available) [-Wunterminated-string-initialization]
+  183 |         POWER_SUPPLY_ATTR(CHARGE_CONTROL_START_THRESHOLD),
+      |                                                         ^
+drivers/power/supply/power_supply_sysfs.c:36:23: note: in definition of macro '_POWER_SUPPLY_ATTR'
+   36 |         .attr_name = #_name "\0",               \
+      |                       ^~~~~
+drivers/power/supply/power_supply_sysfs.c:183:9: note: in expansion of macro 'POWER_SUPPLY_ATTR'
+  183 |         POWER_SUPPLY_ATTR(CHARGE_CONTROL_START_THRESHOLD),
+      |         ^~~~~~~~~~~~~~~~~
+
+However, the macro used was explicitly adding a trailing NUL byte (which
+is not needed). Remove this to avoid the GCC warning. No binary
+differences are seen after this change (there was always run for a NUL
+byte, it's just that the _second_ NUL byte was getting truncated).
+
+Signed-off-by: Kees Cook <kees@kernel.org>
+Link: https://lore.kernel.org/r/20250416222740.work.569-kees@kernel.org
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+
+--- a/drivers/power/supply/power_supply_sysfs.c
++++ b/drivers/power/supply/power_supply_sysfs.c
+@@ -32,7 +32,7 @@ struct power_supply_attr {
+ [POWER_SUPPLY_PROP_ ## _name] =			\
+ {						\
+ 	.prop_name = #_name,			\
+-	.attr_name = #_name "\0",		\
++	.attr_name = #_name,			\
+ 	.text_values = _text,			\
+ 	.text_values_len = _len,		\
+ }

--- a/target/linux/generic/pending-6.12/152-net-wireguard-add-nonstring-annotation-to-fix-build-with-GCC15.patch
+++ b/target/linux/generic/pending-6.12/152-net-wireguard-add-nonstring-annotation-to-fix-build-with-GCC15.patch
@@ -1,0 +1,63 @@
+From 71e5da46e78c1cd24e2feed251a2845327447ad8 Mon Sep 17 00:00:00 2001
+From: Kees Cook <kees@kernel.org>
+Date: Wed, 21 May 2025 23:27:04 +0200
+Subject: wireguard: global: add __nonstring annotations for unterminated
+ strings
+
+When a character array without a terminating NUL character has a static
+initializer, GCC 15's -Wunterminated-string-initialization will only
+warn if the array lacks the "nonstring" attribute[1]. Mark the arrays
+with __nonstring to correctly identify the char array as "not a C string"
+and thereby eliminate the warning:
+
+../drivers/net/wireguard/cookie.c:29:56: warning: initializer-string for array of 'unsigned char' truncates NUL terminator but destination lacks 'nonstring' attribute (9 chars into 8 available) [-Wunterminated-string-initialization]
+   29 | static const u8 mac1_key_label[COOKIE_KEY_LABEL_LEN] = "mac1----";
+      |                                                        ^~~~~~~~~~
+../drivers/net/wireguard/cookie.c:30:58: warning: initializer-string for array of 'unsigned char' truncates NUL terminator but destination lacks 'nonstring' attribute (9 chars into 8 available) [-Wunterminated-string-initialization]
+   30 | static const u8 cookie_key_label[COOKIE_KEY_LABEL_LEN] = "cookie--";
+      |                                                          ^~~~~~~~~~
+../drivers/net/wireguard/noise.c:28:38: warning: initializer-string for array of 'unsigned char' truncates NUL terminator but destination lacks 'nonstring' attribute (38 chars into 37 available) [-Wunterminated-string-initialization]
+   28 | static const u8 handshake_name[37] = "Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s";
+      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../drivers/net/wireguard/noise.c:29:39: warning: initializer-string for array of 'unsigned char' truncates NUL terminator but destination lacks 'nonstring' attribute (35 chars into 34 available) [-Wunterminated-string-initialization]
+   29 | static const u8 identifier_name[34] = "WireGuard v1 zx2c4 Jason@zx2c4.com";
+      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The arrays are always used with their fixed size, so use __nonstring.
+
+Link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117178 [1]
+Signed-off-by: Kees Cook <kees@kernel.org>
+Signed-off-by: Jason A. Donenfeld <Jason@zx2c4.com>
+Link: https://patch.msgid.link/20250521212707.1767879-3-Jason@zx2c4.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/wireguard/cookie.c | 4 ++--
+ drivers/net/wireguard/noise.c  | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/wireguard/cookie.c
++++ b/drivers/net/wireguard/cookie.c
+@@ -26,8 +26,8 @@ void wg_cookie_checker_init(struct cooki
+ }
+ 
+ enum { COOKIE_KEY_LABEL_LEN = 8 };
+-static const u8 mac1_key_label[COOKIE_KEY_LABEL_LEN] = "mac1----";
+-static const u8 cookie_key_label[COOKIE_KEY_LABEL_LEN] = "cookie--";
++static const u8 mac1_key_label[COOKIE_KEY_LABEL_LEN] __nonstring = "mac1----";
++static const u8 cookie_key_label[COOKIE_KEY_LABEL_LEN] __nonstring = "cookie--";
+ 
+ static void precompute_key(u8 key[NOISE_SYMMETRIC_KEY_LEN],
+ 			   const u8 pubkey[NOISE_PUBLIC_KEY_LEN],
+--- a/drivers/net/wireguard/noise.c
++++ b/drivers/net/wireguard/noise.c
+@@ -25,8 +25,8 @@
+  * <- e, ee, se, psk, {}
+  */
+ 
+-static const u8 handshake_name[37] = "Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s";
+-static const u8 identifier_name[34] = "WireGuard v1 zx2c4 Jason@zx2c4.com";
++static const u8 handshake_name[37] __nonstring = "Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s";
++static const u8 identifier_name[34] __nonstring = "WireGuard v1 zx2c4 Jason@zx2c4.com";
+ static u8 handshake_init_hash[NOISE_HASH_LEN] __ro_after_init;
+ static u8 handshake_init_chaining_key[NOISE_HASH_LEN] __ro_after_init;
+ static atomic64_t keypair_counter = ATOMIC64_INIT(0);

--- a/target/linux/generic/pending-6.6/152-net-wireguard-add-nonstring-annotation-to-fix-build-with-GCC15.patch
+++ b/target/linux/generic/pending-6.6/152-net-wireguard-add-nonstring-annotation-to-fix-build-with-GCC15.patch
@@ -1,0 +1,63 @@
+From 71e5da46e78c1cd24e2feed251a2845327447ad8 Mon Sep 17 00:00:00 2001
+From: Kees Cook <kees@kernel.org>
+Date: Wed, 21 May 2025 23:27:04 +0200
+Subject: wireguard: global: add __nonstring annotations for unterminated
+ strings
+
+When a character array without a terminating NUL character has a static
+initializer, GCC 15's -Wunterminated-string-initialization will only
+warn if the array lacks the "nonstring" attribute[1]. Mark the arrays
+with __nonstring to correctly identify the char array as "not a C string"
+and thereby eliminate the warning:
+
+../drivers/net/wireguard/cookie.c:29:56: warning: initializer-string for array of 'unsigned char' truncates NUL terminator but destination lacks 'nonstring' attribute (9 chars into 8 available) [-Wunterminated-string-initialization]
+   29 | static const u8 mac1_key_label[COOKIE_KEY_LABEL_LEN] = "mac1----";
+      |                                                        ^~~~~~~~~~
+../drivers/net/wireguard/cookie.c:30:58: warning: initializer-string for array of 'unsigned char' truncates NUL terminator but destination lacks 'nonstring' attribute (9 chars into 8 available) [-Wunterminated-string-initialization]
+   30 | static const u8 cookie_key_label[COOKIE_KEY_LABEL_LEN] = "cookie--";
+      |                                                          ^~~~~~~~~~
+../drivers/net/wireguard/noise.c:28:38: warning: initializer-string for array of 'unsigned char' truncates NUL terminator but destination lacks 'nonstring' attribute (38 chars into 37 available) [-Wunterminated-string-initialization]
+   28 | static const u8 handshake_name[37] = "Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s";
+      |                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+../drivers/net/wireguard/noise.c:29:39: warning: initializer-string for array of 'unsigned char' truncates NUL terminator but destination lacks 'nonstring' attribute (35 chars into 34 available) [-Wunterminated-string-initialization]
+   29 | static const u8 identifier_name[34] = "WireGuard v1 zx2c4 Jason@zx2c4.com";
+      |                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The arrays are always used with their fixed size, so use __nonstring.
+
+Link: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117178 [1]
+Signed-off-by: Kees Cook <kees@kernel.org>
+Signed-off-by: Jason A. Donenfeld <Jason@zx2c4.com>
+Link: https://patch.msgid.link/20250521212707.1767879-3-Jason@zx2c4.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/wireguard/cookie.c | 4 ++--
+ drivers/net/wireguard/noise.c  | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+--- a/drivers/net/wireguard/cookie.c
++++ b/drivers/net/wireguard/cookie.c
+@@ -26,8 +26,8 @@ void wg_cookie_checker_init(struct cooki
+ }
+ 
+ enum { COOKIE_KEY_LABEL_LEN = 8 };
+-static const u8 mac1_key_label[COOKIE_KEY_LABEL_LEN] = "mac1----";
+-static const u8 cookie_key_label[COOKIE_KEY_LABEL_LEN] = "cookie--";
++static const u8 mac1_key_label[COOKIE_KEY_LABEL_LEN] __nonstring = "mac1----";
++static const u8 cookie_key_label[COOKIE_KEY_LABEL_LEN] __nonstring = "cookie--";
+ 
+ static void precompute_key(u8 key[NOISE_SYMMETRIC_KEY_LEN],
+ 			   const u8 pubkey[NOISE_PUBLIC_KEY_LEN],
+--- a/drivers/net/wireguard/noise.c
++++ b/drivers/net/wireguard/noise.c
+@@ -25,8 +25,8 @@
+  * <- e, ee, se, psk, {}
+  */
+ 
+-static const u8 handshake_name[37] = "Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s";
+-static const u8 identifier_name[34] = "WireGuard v1 zx2c4 Jason@zx2c4.com";
++static const u8 handshake_name[37] __nonstring = "Noise_IKpsk2_25519_ChaChaPoly_BLAKE2s";
++static const u8 identifier_name[34] __nonstring = "WireGuard v1 zx2c4 Jason@zx2c4.com";
+ static u8 handshake_init_hash[NOISE_HASH_LEN] __ro_after_init;
+ static u8 handshake_init_chaining_key[NOISE_HASH_LEN] __ro_after_init;
+ static atomic64_t keypair_counter = ATOMIC64_INIT(0);


### PR DESCRIPTION
Include those upstream patches fixing build with GCC15. They affect kernel in-tree `drivers/net/wireguard` and `drivers/power/supply` and are both caused by `-Wunterminated-string-initialization` which is default in GCC15.

Patch for `drivers/net/wireguard` is accepted in `wireguard-linux` and pending in upstream kernel.
Patch for `drivers/power/supply` is already fixed upstream, included in v6.15.
Links to the upstream patches are included in the commit messages.

I included both patches for both v6.6 and v6.12 however, v6.6 didn't fail to build `drivers/power/supply`. Not really sure why, would be great if someone can verify this.
Not sure if the numbering of the patches within `pending-6.X` and `backport-6.X` is correct, if not I'll adjust this.

tested with #18600 on mediatek/filogic (Banana Pi R4)