### PR TITLE
ramips: mt7621: only include uboot-envtools on devices which require it

### DIFF
--- a/target/linux/ramips/image/common-sercomm.mk
+++ b/target/linux/ramips/image/common-sercomm.mk
@@ -193,6 +193,8 @@ define Device/sercomm_cxx_dxx
   LZMA_TEXT_START := 0x82800000
   SERCOMM_KERNEL_OFFSET := 0x400100
   SERCOMM_ROOTFS_OFFSET := 0x1000000
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3 \
+	uboot-envtools
 endef
 
 define Device/sercomm_cxx
@@ -230,5 +232,5 @@ define Device/sercomm_s1500
 	lzma -a0 | uImage lzma
   IMAGE/sysupgrade.bin := append-kernel | sercomm-kernel | \
 	sysupgrade-tar kernel=$$$$@ | append-metadata
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 uboot-envtools
 endef

--- a/target/linux/ramips/image/common-sercomm.mk
+++ b/target/linux/ramips/image/common-sercomm.mk
@@ -180,8 +180,7 @@ define Device/sercomm_cpj
   SERCOMM_KERNEL2_OFFSET := 0x800100
   SERCOMM_ROOTFS2_OFFSET := 0xa00000
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
-	sercomm-sysupgrade-cpj | pad-rootfs | check-size | \
-	append-metadata
+	sercomm-sysupgrade-cpj | pad-rootfs | check-size | append-metadata
   ARTIFACTS := initramfs-factory.img
   DEVICE_PACKAGES := kmod-mt76x2
 endef
@@ -193,8 +192,7 @@ define Device/sercomm_cxx_dxx
   LZMA_TEXT_START := 0x82800000
   SERCOMM_KERNEL_OFFSET := 0x400100
   SERCOMM_ROOTFS_OFFSET := 0x1000000
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3 \
-	uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3 uboot-envtools
 endef
 
 define Device/sercomm_cxx
@@ -205,8 +203,8 @@ define Device/sercomm_cxx
 	uImage lzma
   IMAGE/sysupgrade.bin := append-kernel | sercomm-kernel | \
 	sysupgrade-tar kernel=$$$$@ | append-metadata
-  IMAGE/factory.img := append-kernel | sercomm-kernel-factory | \
-	append-ubi | sercomm-factory-cqr | sercomm-mkhash
+  IMAGE/factory.img := append-kernel | sercomm-kernel-factory | append-ubi | \
+	sercomm-factory-cqr | sercomm-mkhash
 endef
 
 define Device/sercomm_dxx
@@ -216,9 +214,9 @@ define Device/sercomm_dxx
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | \
 	lzma -a0 | uImage lzma
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGE/factory.img := append-ubi | check-size | \
-	sercomm-part-tag rootfs | sercomm-prepend-tagged-kernel kernel | \
-	gzip | sercomm-payload | sercomm-crypto
+  IMAGE/factory.img := append-ubi | check-size | sercomm-part-tag rootfs | \
+	sercomm-prepend-tagged-kernel kernel | gzip | sercomm-payload | \
+	sercomm-crypto
 endef
 
 define Device/sercomm_s1500

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -263,8 +263,8 @@ define Device/afoundry_ew1200
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := AFOUNDRY
   DEVICE_MODEL := EW1200
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mt76x2 kmod-mt7603 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-mt7603 kmod-mt76x2 \
+	kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += ew1200
 endef
 TARGET_DEVICES += afoundry_ew1200
@@ -275,7 +275,8 @@ define Device/alfa-network_ax1800rm
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := AX1800RM
   DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGES += recovery.bin
   IMAGE/recovery.bin := append-kernel | append-rootfs | pad-rootfs | check-size
 endef
@@ -286,8 +287,8 @@ define Device/alfa-network_quad-e4g
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := Quad-E4G
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-usb3 uboot-envtools \
-	-wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-ata-ahci kmod-mmc-mtk kmod-usb3 \
+	uboot-envtools
   SUPPORTED_DEVICES += quad-e4g
 endef
 TARGET_DEVICES += alfa-network_quad-e4g
@@ -298,7 +299,8 @@ define Device/ampedwireless_ally_common
   DEVICE_VENDOR := Amped Wireless
   DEVICE_PACKAGES := kmod-mt7615-firmware uboot-envtools
   IMAGE_SIZE := 32768k
-  KERNEL_INITRAMFS := $$(KERNEL) | edimax-header -s CSYS -m RN68 -f 0x001c0000 -S 0x01100000
+  KERNEL_INITRAMFS := $$(KERNEL) | \
+	edimax-header -s CSYS -m RN68 -f 0x001c0000 -S 0x01100000
 endef
 
 define Device/ampedwireless_ally-r1900k
@@ -327,12 +329,13 @@ define Device/arcadyan_we420223-99
   PAGESIZE := 1
   SUBPAGESIZE := 1
   VID_HDR_OFFSET := 64
-  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | \
-	uImage none | arcadyan-trx 0x746f435d
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | uImage none | \
+	arcadyan-trx 0x746f435d
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | \
 	uImage none
   IMAGES += factory.trx
-  IMAGE/factory.trx := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | check-size
+  IMAGE/factory.trx := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
@@ -344,8 +347,7 @@ define Device/asiarf_ap7621-001
   IMAGE_SIZE := 16000k
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AP7621-001
-  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt76x2 kmod-usb3 \
-	-wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-mmc-mtk kmod-mt76x2 kmod-usb3
 endef
 TARGET_DEVICES += asiarf_ap7621-001
 
@@ -355,8 +357,7 @@ define Device/asiarf_ap7621-nv1
   IMAGE_SIZE := 16000k
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AP7621-NV1
-  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt76x2 kmod-usb3 \
-	-wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-mmc-mtk kmod-mt76x2 kmod-usb3
 endef
 TARGET_DEVICES += asiarf_ap7621-nv1
 
@@ -366,8 +367,7 @@ define Device/asus_rp-ac56
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RP-AC56
   IMAGE_SIZE := 16000k
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 \
-	kmod-sound-mt7620
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-sound-mt7620
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
@@ -397,8 +397,7 @@ define Device/asus_rt-ac57u-v1
   DEVICE_ALT0_VENDOR := ASUS
   DEVICE_ALT0_MODEL := RT-AC1200GU
   IMAGE_SIZE := 16064k
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += asus,rt-ac57u
 endef
 TARGET_DEVICES += asus_rt-ac57u-v1
@@ -434,8 +433,7 @@ define Device/asus_rt-n56u-b1
   DEVICE_MODEL := RT-N56U
   DEVICE_VARIANT := B1
   IMAGE_SIZE := 16064k
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += asus_rt-n56u-b1
 
@@ -449,8 +447,8 @@ define Device/asus_rt-ax53u
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb-ledtrig-usbport \
-	kmod-usb3 uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb-ledtrig-usbport kmod-usb3 \
+	uboot-envtools
 endef
 TARGET_DEVICES += asus_rt-ax53u
 
@@ -493,8 +491,8 @@ define Device/beeline_smartbox-flash
   DEVICE_MODEL := SmartBox Flash
   IMAGE_SIZE := 32768k
   KERNEL_SIZE := 4352k
-  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | \
-	uImage none | arcadyan-trx 0x746f435d | pad-to $$(KERNEL_SIZE)
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | uImage none | \
+	arcadyan-trx 0x746f435d | pad-to $$(KERNEL_SIZE)
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | \
 	uImage none
   IMAGES += factory.trx
@@ -512,8 +510,7 @@ define Device/beeline_smartbox-giga
   SERCOMM_SWVER := 1001
   DEVICE_VENDOR := Beeline
   DEVICE_MODEL := SmartBox GIGA
-  DEVICE_PACKAGES := -kmod-mt7615-firmware kmod-mt7615e \
-	kmod-mt7663-firmware-ap
+  DEVICE_PACKAGES := -kmod-mt7615-firmware kmod-mt7615e kmod-mt7663-firmware-ap
 endef
 TARGET_DEVICES += beeline_smartbox-giga
 
@@ -610,12 +607,13 @@ define Device/buffalo_wsr-2533dhplx
   KERNEL_SIZE := 6144k
   IMAGES += factory.bin factory-uboot.bin
   IMAGE/factory.bin = append-ubi | \
-	buffalo-trx $$$$(BUFFALO_TRX_MAGIC) $$$$@ $(KDIR)/ubi_mark |\
+	buffalo-trx $$$$(BUFFALO_TRX_MAGIC) $$$$@ $(KDIR)/ubi_mark | \
 	buffalo-enc $$(DEVICE_MODEL) 9.99 -l | \
 	buffalo-tag-dhp $$(DEVICE_MODEL) JP JP | buffalo-enc-tag -l | \
 	buffalo-dhp-image
   IMAGE/factory-uboot.bin := append-ubi | \
-	buffalo-trx $$$$(BUFFALO_TRX_MAGIC) $$$$@ $(KDIR)/ubi_mark | append-metadata
+	buffalo-trx $$$$(BUFFALO_TRX_MAGIC) $$$$@ $(KDIR)/ubi_mark | \
+	append-metadata
   IMAGE/sysupgrade.bin := \
 	buffalo-trx $$$$(BUFFALO_TRX_MAGIC) $(KDIR)/tmp/$$(DEVICE_NAME).null | \
 	sysupgrade-tar kernel=$$$$@ | append-metadata
@@ -673,16 +671,16 @@ endef
 TARGET_DEVICES += comfast_cf-e390ax
 
 define Device/comfast_cf-ew72-v2
-    $(Device/dsa-migration)
-    $(Device/uimage-lzma-loader)
-    IMAGE_SIZE := 15808k
-    DEVICE_VENDOR := COMFAST
-    DEVICE_MODEL := CF-EW72 V2
-    DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
-    IMAGES += factory.bin
-    IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
-		check-size | append-metadata
-    IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 15808k
+  DEVICE_VENDOR := COMFAST
+  DEVICE_MODEL := CF-EW72 V2
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
+	check-size | append-metadata
+  IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
 endef
 TARGET_DEVICES += comfast_cf-ew72-v2
 
@@ -725,8 +723,8 @@ define Device/cudy_wr1300-v1
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := WR1300
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport \
+	kmod-usb2 kmod-usb3
   SUPPORTED_DEVICES += cudy,wr1300 R10
 endef
 TARGET_DEVICES += cudy_wr1300-v1
@@ -813,8 +811,8 @@ define Device/dlink_covr-x1860-a1
 	append-squashfs4-fakeroot
   IMAGES += factory.bin recovery.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size
+  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
   IMAGE/factory.bin := $$(IMAGE/recovery.bin) | \
 	append-dlink-covr-metadata $$(DEVICE_MODEL) | \
 	dlink-sge-image $$(DEVICE_MODEL)
@@ -826,9 +824,9 @@ define Device/dlink_dxx-1xx0-x1
   DEVICE_PACKAGES := kmod-mt7615-firmware rssileds
   IMAGE_SIZE := 16064k
   IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | append-rootfs | \
-    pad-rootfs -x 60 | append-md5sum-ascii-salted ffff | \
-    append-string $$$$(DLINK_HWID) | check-size
+  IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs -x 60 | \
+	append-md5sum-ascii-salted ffff | append-string $$$$(DLINK_HWID) | \
+	check-size
 endef
 
 define Device/dlink_dap-1620-b1
@@ -864,7 +862,8 @@ define Device/dlink_dir-8xx-a1
   KERNEL := $$(KERNEL) | uimage-sgehdr
   IMAGES += recovery.bin factory.bin
   IMAGE/recovery.bin := append-kernel | append-rootfs | check-size
-  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | dlink-sge-image $$$$(DEVICE_MODEL)
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | \
+	dlink-sge-image $$$$(DEVICE_MODEL)
 endef
 
 define Device/dlink_dir-8xx-r1
@@ -881,8 +880,7 @@ define Device/dlink_dir_nand_128m
   $(Device/nand)
   IMAGE_SIZE := 40960k
   DEVICE_VENDOR := D-Link
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport kmod-usb3
   KERNEL := $$(KERNEL) | uimage-sgehdr
   IMAGES += recovery.bin
   IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
@@ -916,9 +914,10 @@ define Device/dlink_dir-2150-a1
   $(Device/dlink_dir_nand_128m)
   DEVICE_MODEL := DIR-2150
   DEVICE_VARIANT := A1
-  DEVICE_PACKAGES += kmod-mt7603 -kmod-usb3 -kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES += -kmod-usb-ledtrig-usbport -kmod-usb3 kmod-mt7603
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | dlink-sge-image $$(DEVICE_MODEL)
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | \
+	dlink-sge-image $$(DEVICE_MODEL)
 endef
 TARGET_DEVICES += dlink_dir-2150-a1
 
@@ -968,7 +967,7 @@ define Device/dlink_dir-853-a1
   $(Device/dlink_dir-8xx-a1)
   DEVICE_MODEL := DIR-853
   DEVICE_VARIANT := A1
-  DEVICE_PACKAGES += kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES += kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += dlink_dir-853-a1
 
@@ -977,7 +976,8 @@ define Device/dlink_dir-853-a3
   DEVICE_MODEL := DIR-853
   DEVICE_VARIANT := A3
   IMAGES += factory.bin
-  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | dlink-sge-image $$(DEVICE_MODEL)
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | \
+	dlink-sge-image $$(DEVICE_MODEL)
 endef
 TARGET_DEVICES += dlink_dir-853-a3
 
@@ -985,7 +985,7 @@ define Device/dlink_dir-853-r1
   $(Device/dlink_dir-8xx-r1)
   DEVICE_MODEL := DIR-853
   DEVICE_VARIANT := R1
-  DEVICE_PACKAGES += kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES += kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += dlink_dir-853-r1
 
@@ -997,7 +997,7 @@ define Device/dlink_dir-860l-b1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-860L
   DEVICE_VARIANT := B1
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += dir-860l-b1
 endef
 TARGET_DEVICES += dlink_dir-860l-b1
@@ -1031,7 +1031,7 @@ define Device/dlink_dir-882-a1
   $(Device/dlink_dir-8xx-a1)
   DEVICE_MODEL := DIR-882
   DEVICE_VARIANT := A1
-  DEVICE_PACKAGES += kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES += kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += dlink_dir-882-a1
 
@@ -1039,7 +1039,7 @@ define Device/dlink_dir-882-r1
   $(Device/dlink_dir-8xx-r1)
   DEVICE_MODEL := DIR-882
   DEVICE_VARIANT := R1
-  DEVICE_PACKAGES += kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES += kmod-usb-ledtrig-usbport kmod-usb3
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | append-rootfs | check-size | \
 	sign-dlink-ru 57c5375741c30ca9ebcb36713db4ba51 \
@@ -1061,8 +1061,7 @@ define Device/dual-q_h721
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Dual-Q
   DEVICE_MODEL := H721
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-usb3 \
-	-wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-ata-ahci kmod-mmc-mtk kmod-usb3
 endef
 TARGET_DEVICES += dual-q_h721
 
@@ -1072,8 +1071,7 @@ define Device/d-team_newifi-d2
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := D-Team
   DEVICE_MODEL := Newifi D2
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += d-team_newifi-d2
 
@@ -1082,8 +1080,8 @@ define Device/d-team_pbr-m1
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := PandoraBox
   DEVICE_MODEL := PBR-M1
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mt7603 kmod-mt76x2 kmod-mmc-mtk \
-	kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 \
+	kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += pbr-m1
 endef
 TARGET_DEVICES += d-team_pbr-m1
@@ -1315,8 +1313,8 @@ define Device/elecom_wrc-x1800gs
 ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
   ARTIFACTS := initramfs-factory.bin
   ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | \
-	znet-header 4.04(XVF.1)b90 COMC 0x68 | elecom-product-header WRC-X1800GS | \
-	check-size
+	znet-header 4.04(XVF.1)b90 COMC 0x68 | \
+	elecom-product-header WRC-X1800GS | check-size
 endif
   DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools
 endef
@@ -1358,7 +1356,7 @@ define Device/firefly_firewrt
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Firefly
   DEVICE_MODEL := FireWRT
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += firewrt
 endef
 TARGET_DEVICES += firefly_firewrt
@@ -1368,8 +1366,7 @@ define Device/gehua_ghl-r-001
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := GeHua
   DEVICE_MODEL := GHL-R-001
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += gehua_ghl-r-001
 
@@ -1378,8 +1375,7 @@ define Device/gemtek_wvrtm-1xxacn
   $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 122368k
   DEVICE_VENDOR := Gemtek
-  DEVICE_PACKAGES := kmod-gpio-nxp-74hc164 kmod-spi-gpio \
-	kmod-usb3 
+  DEVICE_PACKAGES := kmod-gpio-nxp-74hc164 kmod-spi-gpio kmod-usb3
 endef
 
 define Device/gemtek_wvrtm-127acn
@@ -1401,8 +1397,8 @@ define Device/genexis_pulse-ex400/common
   $(Device/dsa-migration)
   IMAGE_SIZE := 117m
   PAGESIZE := 2048
-  MKUBIFS_OPTS := --min-io-size=$$(PAGESIZE) --leb-size=124KiB --max-leb-cnt=96 \
-    --log-lebs=2 --space-fixup --squash-uids
+  MKUBIFS_OPTS := --min-io-size=$$(PAGESIZE) --leb-size=124KiB \
+	--max-leb-cnt=96 --log-lebs=2 --space-fixup --squash-uids
   KERNEL := kernel-bin | lzma | uImage lzma
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma
 ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
@@ -1411,10 +1407,10 @@ ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
 	inteno-bootfs | inteno-y3-header EX400 | append-md5sum-ascii-salted
 endif
   IMAGE/sysupgrade.bin := append-kernel | inteno-bootfs | pad-to 10M | \
-    sysupgrade-tar kernel=$$$$@ | check-size | append-metadata
+	sysupgrade-tar kernel=$$$$@ | check-size | append-metadata
   DEVICE_IMG_NAME = $$(DEVICE_IMG_PREFIX)-$$(2)
-  DEVICE_PACKAGES := kmod-button-hotplug kmod-keyboard-sx951x \
-	kmod-mt7603 kmod-mt7615-firmware kmod-usb3 uboot-envtools
+  DEVICE_PACKAGES := kmod-button-hotplug kmod-keyboard-sx951x kmod-mt7603 \
+	kmod-mt7615-firmware kmod-usb3 uboot-envtools
 endef
 
 define Device/genexis_pulse-ex400
@@ -1440,8 +1436,7 @@ define Device/gnubee_gb-pc1
   $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := GB-PC1
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-mmc-mtk \
-	-wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-ata-ahci kmod-mmc-mtk kmod-usb3
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc1
@@ -1451,8 +1446,7 @@ define Device/gnubee_gb-pc2
   $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := GB-PC2
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-mmc-mtk \
-	-wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-ata-ahci kmod-mmc-mtk kmod-usb3
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc2
@@ -1463,7 +1457,7 @@ define Device/hanyang_hyc-g920
   DEVICE_VENDOR := Hanyang
   DEVICE_MODEL := CJ-Hello HYC-G920
   IMAGE_SIZE := 15744k
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt76x2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += hanyang_hyc-g920
 
@@ -1554,8 +1548,8 @@ define Device/humax_e10
 	check-size | append-metadata
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | \
-	edimax-header -s CSYS -m EA03 -f 0x70000 -S 0x01100000 | \
-	check-size | zip upg -P f013c26cf0a320fb71d03356dcb6bb63
+	edimax-header -s CSYS -m EA03 -f 0x70000 -S 0x01100000 | check-size | \
+	zip upg -P f013c26cf0a320fb71d03356dcb6bb63
   DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3
 endef
 TARGET_DEVICES += humax_e10
@@ -1566,9 +1560,9 @@ define Device/huasifei_ws1208v2
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Huasifei
   DEVICE_MODEL := WS1208V2
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mt7603 kmod-mt76x2 kmod-mmc-mtk \
-	kmod-usb3 kmod-usb-net-cdc-mbim kmod-usb-net-qmi-wwan \
-	kmod-usb-serial-option
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 \
+	kmod-usb-net-cdc-mbim kmod-usb-net-qmi-wwan kmod-usb-serial-option \
+	kmod-usb3
 endef
 TARGET_DEVICES += huasifei_ws1208v2
 
@@ -1705,7 +1699,7 @@ define Device/iptime_a3004ns-dual
   UIMAGE_NAME := a3004nd
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := A3004NS-dual
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt76x2 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += iptime_a3004ns-dual
 
@@ -1727,8 +1721,7 @@ define Device/iptime_a6004ns-m
   UIMAGE_NAME := a6004nm
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := A6004NS-M
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += iptime_a6004ns-m
 
@@ -1738,8 +1731,7 @@ define Device/iptime_a6ns-m
   UIMAGE_NAME := a6nm
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := A6ns-M
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += iptime_a6ns-m
 
@@ -1778,7 +1770,7 @@ define Device/iptime_t5004
   UIMAGE_NAME := t5004
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := T5004
-  DEVICE_PACKAGES := uboot-envtools -wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls uboot-envtools
 endef
 TARGET_DEVICES += iptime_t5004
 
@@ -1790,8 +1782,7 @@ define Device/jcg_jhr-ac876m
   JCG_MAXSIZE := 16064k
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := JHR-AC876M
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += jcg_jhr-ac876m
 
@@ -1826,7 +1817,7 @@ define Device/jdcloud_re-cp-02
   IMAGE_SIZE := 16000k
   DEVICE_VENDOR := JD-Cloud
   DEVICE_MODEL := RE-CP-02
-  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-mmc-mtk
+  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7915-firmware
 endef
 TARGET_DEVICES += jdcloud_re-cp-02
 
@@ -1840,8 +1831,8 @@ define Device/keenetic_kn-1910
   DEVICE_MODEL := KN-1910
   DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3
   IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | zyimage -d 0x801910 -v "KN-1910"
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size | zyimage -d 0x801910 -v "KN-1910"
 endef
 TARGET_DEVICES += keenetic_kn-1910
 
@@ -1877,8 +1868,8 @@ define Device/lenovo_newifi-d1
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := Lenovo
   DEVICE_MODEL := Newifi D1
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-mmc-mtk \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 \
+	kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += newifi-d1
 endef
 TARGET_DEVICES += lenovo_newifi-d1
@@ -1889,7 +1880,8 @@ define Device/linksys_e5600
   IMAGE_SIZE := 26624k
   DEVICE_VENDOR := Linksys
   DEVICE_MODEL := E5600
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+	uboot-envtools
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
 	append-ubi | check-size | gemtek-trailer
@@ -2005,8 +1997,8 @@ define Device/mediatek_ap-mt7621a-v60
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Mediatek
   DEVICE_MODEL := AP-MT7621A-V60 EVB
-  DEVICE_PACKAGES := kmod-usb3 kmod-mmc-mtk kmod-sound-mt7620 \
-	-wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-mmc-mtk kmod-sound-mt7620 \
+	kmod-usb3
 endef
 TARGET_DEVICES += mediatek_ap-mt7621a-v60
 
@@ -2026,8 +2018,8 @@ define Device/meig_slt866
   DEVICE_VENDOR := MeiG
   DEVICE_MODEL := SLT866
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	kmod-usb-net-qmi-wwan kmod-usb-net-rndis kmod-usb-serial-option \
-	kmod-usb3 uboot-envtools
+	kmod-usb-net-qmi-wwan kmod-usb-net-rndis kmod-usb-serial-option kmod-usb3 \
+	uboot-envtools
 endef
 TARGET_DEVICES += meig_slt866
 
@@ -2076,7 +2068,7 @@ TARGET_DEVICES += mikrotik_routerboard-750gr3
 define Device/mikrotik_routerboard-760igs
   $(Device/MikroTik)
   DEVICE_MODEL := RouterBOARD 760iGS
-  DEVICE_PACKAGES += kmod-sfp -wpad-basic-mbedtls
+  DEVICE_PACKAGES += -wpad-basic-mbedtls kmod-sfp
 endef
 TARGET_DEVICES += mikrotik_routerboard-760igs
 
@@ -2102,8 +2094,8 @@ define Device/mofinetwork_mofi5500-5gxelte
   IMAGE_SIZE := 27656k
   DEVICE_VENDOR := MoFi Network
   DEVICE_MODEL := MOFI5500-5GXeLTE
-  DEVICE_PACKAGES := kmod-usb3 kmod-mmc-mtk kmod-mt7615-firmware \
-	kmod-usb-net-qmi-wwan kmod-usb-net-cdc-mbim
+  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7615-firmware kmod-usb-net-cdc-mbim \
+	kmod-usb-net-qmi-wwan kmod-usb3
   SUPPORTED_DEVICES += mofi5500 # Needed in order to flash through Mofi stock firmware
 endef
 TARGET_DEVICES += mofinetwork_mofi5500-5gxelte
@@ -2114,8 +2106,8 @@ define Device/mqmaker_witi
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := MQmaker
   DEVICE_MODEL := WiTi
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mt76x2 kmod-mmc-mtk kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-mt76x2 \
+	kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += witi mqmaker,witi-256m mqmaker,witi-512m
 endef
 TARGET_DEVICES += mqmaker_witi
@@ -2127,8 +2119,8 @@ define Device/mtc_wr1201
   DEVICE_VENDOR := MTC
   DEVICE_MODEL := Wireless Router WR1201
   KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma -n 'WR1201_8_128'
-  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt76x2 kmod-usb-ledtrig-usbport \
+	kmod-usb3
 endef
 TARGET_DEVICES += mtc_wr1201
 
@@ -2139,8 +2131,8 @@ define Device/mts_wg430223
   DEVICE_MODEL := WG430223
   IMAGE_SIZE := 32768k
   KERNEL_SIZE := 4352k
-  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | \
-	uImage none | arcadyan-trx 0x53485231 | pad-to $$(KERNEL_SIZE)
+  KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | uImage none | \
+	arcadyan-trx 0x53485231 | pad-to $$(KERNEL_SIZE)
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | \
 	uImage none
   IMAGES += factory.trx
@@ -2170,8 +2162,8 @@ define Device/netgear_eax12
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
 	append-squashfs4-fakeroot
   IMAGES += factory.img
-  IMAGE/factory.img := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | netgear-encrypted-factory
+  IMAGE/factory.img := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size | netgear-encrypted-factory
 endef
 TARGET_DEVICES += netgear_eax12
 
@@ -2198,7 +2190,7 @@ define Device/netgear_sercomm_nand
   IMAGE/kernel.bin := append-kernel
   IMAGE/rootfs.bin := append-ubi | check-size
   DEVICE_VENDOR := NETGEAR
-  DEVICE_PACKAGES := kmod-mt7603 kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-usb-ledtrig-usbport kmod-usb3
 endef
 
 define Device/netgear_r6220
@@ -2356,8 +2348,8 @@ define Device/netgear_wax202
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
 	append-squashfs4-fakeroot
   IMAGES += factory.img
-  IMAGE/factory.img := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | netgear-encrypted-factory
+  IMAGE/factory.img := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size | netgear-encrypted-factory
 endef
 TARGET_DEVICES += netgear_wax202
 
@@ -2374,8 +2366,8 @@ define Device/netgear_wax214v2
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
 	append-squashfs4-fakeroot
   IMAGES += factory.img
-  IMAGE/factory.img := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | netgear-encrypted-factory
+  IMAGE/factory.img := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size | netgear-encrypted-factory
 endef
 TARGET_DEVICES += netgear_wax214v2
 
@@ -2391,8 +2383,8 @@ define Device/netgear_wndr3700-v5
   SERCOMM_HWVER := A001
   SERCOMM_SWVER := 0x1054
   SERCOMM_PAD := 320k
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport \
+	kmod-usb3
   SUPPORTED_DEVICES += wndr3700v5
 endef
 TARGET_DEVICES += netgear_wndr3700-v5
@@ -2407,10 +2399,10 @@ define Device/netis_n6
   KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | append-netis-n6-metadata
-  DEVICE_PACKAGES += kmod-mt7915-firmware kmod-usb-ledtrig-usbport \
-	kmod-usb3 uboot-envtools
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size | append-netis-n6-metadata
+  DEVICE_PACKAGES += kmod-mt7915-firmware kmod-usb-ledtrig-usbport kmod-usb3 \
+	uboot-envtools
 endef
 TARGET_DEVICES += netis_n6
 
@@ -2422,11 +2414,11 @@ define Device/netis_wf2881
   UIMAGE_NAME := WF2881_0.0.00
   KERNEL_INITRAMFS := $$(KERNEL) | netis-tail WF2881
   IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | \
-	check-size
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
+	append-ubi | check-size
   DEVICE_VENDOR := NETIS
   DEVICE_MODEL := WF2881
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += netis_wf2881
 
@@ -2435,8 +2427,8 @@ define Device/openfi_5pro
   IMAGE_SIZE := 65216k
   DEVICE_VENDOR := OpenFi
   DEVICE_MODEL := 5Pro
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap kmod-usb3 \
-	kmod-mmc-mtk
+  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt7615e \
+	kmod-mt7663-firmware-ap kmod-usb3	
 endef
 TARGET_DEVICES += openfi_5pro
 
@@ -2468,7 +2460,7 @@ define Device/planex_vr500
   IMAGE_SIZE := 65216k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := VR500
-  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3
   SUPPORTED_DEVICES += vr500
 endef
 TARGET_DEVICES += planex_vr500
@@ -2482,8 +2474,8 @@ define Device/raisecom_msg1500-x-00
   DEVICE_VARIANT := X.00
   DEVICE_ALT0_VENDOR := Nokia
   DEVICE_ALT0_MODEL := A-040W-Q
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport \
-	kmod-usb3 uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport kmod-usb3 \
+	uboot-envtools
 endef
 TARGET_DEVICES += raisecom_msg1500-x-00
 
@@ -2562,8 +2554,8 @@ define Device/sercomm_na502s
   IMAGE_SIZE := 20971520
   DEVICE_VENDOR := SERCOMM
   DEVICE_MODEL := NA502S
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-mt7603 kmod-usb3 kmod-usb-serial \
-		kmod-usb-serial-xr
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-mt7603 kmod-usb-serial \
+	kmod-usb-serial-xr kmod-usb3
 endef
 TARGET_DEVICES += sercomm_na502s
 
@@ -2575,14 +2567,14 @@ endef
 TARGET_DEVICES += sim_simax1800t
 
 define Device/snr_snr-cpe-me1
-	$(Device/dsa-migration)
-	$(Device/uimage-lzma-loader)
-	IMAGE_SIZE := 15040k
-	DEVICE_VENDOR := SNR
-	DEVICE_MODEL := SNR-CPE-ME1
-	UIMAGE_NAME := SNR-CPE-ME1-5GHZ-MT
-	DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x0e kmod-usb3 \
-		kmod-usb-ledtrig-usbport uboot-envtools
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 15040k
+  DEVICE_VENDOR := SNR
+  DEVICE_MODEL := SNR-CPE-ME1
+  UIMAGE_NAME := SNR-CPE-ME1-5GHZ-MT
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x0e kmod-usb-ledtrig-usbport \
+	kmod-usb3 uboot-envtools
 endef
 TARGET_DEVICES += snr_snr-cpe-me1
 
@@ -2604,8 +2596,8 @@ define Device/snr_snr-cpe-me2-sfp
   DEVICE_VENDOR := SNR
   DEVICE_MODEL := SNR-CPE-ME2-SFP
   UIMAGE_NAME := $$(DEVICE_MODEL)
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
-	    kmod-sfp kmod-usb-ledtrig-usbport uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-sfp kmod-usb-ledtrig-usbport \
+	kmod-usb3 uboot-envtools
 endef
 TARGET_DEVICES += snr_snr-cpe-me2-sfp
 
@@ -2616,7 +2608,7 @@ define Device/storylink_sap-g3200u3
   UIMAGE_NAME := SAP-G3200
   DEVICE_VENDOR := STORYLiNK
   DEVICE_MODEL := SAP-G3200U3
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += sap-g3200u3
 endef
 TARGET_DEVICES += storylink_sap-g3200u3
@@ -2626,7 +2618,7 @@ define Device/telco-electronics_x1
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Telco Electronics
   DEVICE_MODEL := X1
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7603 kmod-mt76x2
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3
 endef
 TARGET_DEVICES += telco-electronics_x1
 
@@ -2636,7 +2628,8 @@ define Device/tenbay_t-mb5eu-v01
   DEVICE_MODEL := T-MB5EU-V01
   DEVICE_DTS_CONFIG := config@1
   DEVICE_PACKAGES += kmod-mt7915-firmware kmod-usb3
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGE_SIZE := 15808k
   SUPPORTED_DEVICES += mt7621-dm2-t-mb5eu-v01-nor
 endef
@@ -2648,7 +2641,7 @@ define Device/thunder_timecloud
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Thunder
   DEVICE_MODEL := Timecloud
-  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3
   SUPPORTED_DEVICES += timecloud
 endef
 TARGET_DEVICES += thunder_timecloud
@@ -2679,7 +2672,7 @@ define Device/tozed_zlt-s12-pro
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := TOZED
   DEVICE_MODEL := ZLT S12 PRO
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 comgt-ncm
+  DEVICE_PACKAGES := comgt-ncm kmod-mt7603 kmod-mt76x2 kmod-usb3 
 endef
 TARGET_DEVICES += tozed_zlt-s12-pro
 
@@ -2700,8 +2693,7 @@ define Device/tplink_archer-a6-v3
   $(Device/tplink-safeloader)
   DEVICE_MODEL := Archer A6
   DEVICE_VARIANT := V3
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e \
-	kmod-mt7663-firmware-ap
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
   TPLINK_BOARD_ID := ARCHER-A6-V3
   KERNEL := $(KERNEL_DTB) | uImage lzma
   IMAGE_SIZE := 15744k
@@ -2726,7 +2718,7 @@ define Device/tplink_archer-c6u-v1
   DEVICE_MODEL := Archer C6U
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	kmod-usb3 kmod-usb-ledtrig-usbport
+	kmod-usb-ledtrig-usbport kmod-usb3
   KERNEL := $(KERNEL_DTB) | uImage lzma
   TPLINK_BOARD_ID := ARCHER-C6U-V1
   IMAGE_SIZE := 15744k
@@ -2765,8 +2757,10 @@ define Device/tplink_eap613-v1
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7915-firmware
   TPLINK_BOARD_ID := EAP610-V3
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | pad-to 64k
-  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | pad-to 64k
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
   IMAGE_SIZE := 13248k
 endef
 TARGET_DEVICES += tplink_eap613-v1
@@ -2778,8 +2772,10 @@ define Device/tplink_eap615-wall-v1
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7915-firmware
   TPLINK_BOARD_ID := EAP615-WALL-V1
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | pad-to 64k
-  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | pad-to 64k
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
   IMAGE_SIZE := 13248k
 endef
 TARGET_DEVICES += tplink_eap615-wall-v1
@@ -2793,8 +2789,8 @@ define Device/tplink_ec330-g5u-v1
   DEVICE_ALT0_VENDOR := TP-Link
   DEVICE_ALT0_MODEL := Archer C9ERT
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport \
-	kmod-usb3 uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport kmod-usb3 \
+	uboot-envtools
   KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | \
 	uImage-tplink-c9 standalone '$(call toupper,$(LINUX_KARCH)) \
 		$(VERSION_DIST) Linux-$(LINUX_VERSION)' | \
@@ -2847,7 +2843,7 @@ define Device/tplink_mr600-v2-eu
   DEVICE_VARIANT := v2 (EU)
   TPLINK_FLASHLAYOUT := 16Mltq
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-		kmod-usb-net-qmi-wwan uqmi kmod-usb3
+	kmod-usb-net-qmi-wwan kmod-usb3 uqmi
   IMAGE/factory.bin := tplink-v2-image -e -a 0x10000
   IMAGE/sysupgrade.bin := tplink-v2-image -s -e -a 0x10000 | check-size | \
 	append-metadata
@@ -2925,8 +2921,8 @@ define Device/ubnt_edgerouter_common
   DEVICE_PACKAGES += -wpad-basic-mbedtls
   DEVICE_COMPAT_VERSION := 2.0
   DEVICE_COMPAT_MESSAGE :=  Partition table has been changed due to kernel size restrictions. \
-    Refer to the wiki page for instructions to migrate to the new layout: \
-    https://openwrt.org/toh/ubiquiti/edgerouter_x_er-x_ka
+	Refer to the wiki page for instructions to migrate to the new layout: \
+	https://openwrt.org/toh/ubiquiti/edgerouter_x_er-x_ka
 endef
 
 define Device/ubnt_edgerouter-x
@@ -2941,7 +2937,7 @@ define Device/ubnt_edgerouter-x-sfp
   DEVICE_MODEL := EdgeRouter X SFP
   DEVICE_ALT0_VENDOR := Ubiquiti
   DEVICE_ALT0_MODEL := EdgePoint R6
-  DEVICE_PACKAGES += kmod-i2c-algo-pca kmod-gpio-pca953x kmod-sfp
+  DEVICE_PACKAGES += kmod-gpio-pca953x kmod-i2c-algo-pca kmod-sfp
   SUPPORTED_DEVICES += ubnt-erx-sfp ubiquiti,edgerouterx-sfp
 endef
 TARGET_DEVICES += ubnt_edgerouter-x-sfp
@@ -2953,7 +2949,8 @@ define Device/ubnt_unifi-6-lite
   DEVICE_DTS_CONFIG := config@1
   DEVICE_DTS_LOADADDR := 0x87000000
   DEVICE_PACKAGES += kmod-mt7603 kmod-mt7915-firmware
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGE_SIZE := 15424k
 endef
 TARGET_DEVICES += ubnt_unifi-6-lite
@@ -2964,8 +2961,9 @@ define Device/ubnt_unifi-flexhd
   DEVICE_MODEL := UniFi FlexHD
   DEVICE_DTS_CONFIG := config@2
   DEVICE_DTS_LOADADDR := 0x87000000
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7615-firmware kmod-leds-ubnt-ledbar
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  DEVICE_PACKAGES += kmod-leds-ubnt-ledbar kmod-mt7603 kmod-mt7615-firmware
   IMAGE_SIZE := 15552k
 endef
 TARGET_DEVICES += ubnt_unifi-flexhd
@@ -2985,7 +2983,8 @@ define Device/ubnt_usw-flex
   DEVICE_MODEL := UniFi Switch Flex
   DEVICE_DTS_CONFIG := config@1
   DEVICE_DTS_LOADADDR := 0x87000000
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGE_SIZE := 14720k
 endef
 TARGET_DEVICES += ubnt_usw-flex
@@ -3008,8 +3007,7 @@ define Device/unielec_u7621-06-16m
   DEVICE_VENDOR := UniElec
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 16M
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-usb3 \
-	-wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-ata-ahci kmod-mmc-mtk kmod-usb3
   SUPPORTED_DEVICES += u7621-06-256M-16M unielec,u7621-06-256m-16m
 endef
 TARGET_DEVICES += unielec_u7621-06-16m
@@ -3021,8 +3019,7 @@ define Device/unielec_u7621-06-32m
   DEVICE_VENDOR := UniElec
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 32M
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-usb3 \
-	-wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-ata-ahci kmod-mmc-mtk kmod-usb3
   SUPPORTED_DEVICES += unielec,u7621-06-32m
 endef
 TARGET_DEVICES += unielec_u7621-06-32m
@@ -3034,8 +3031,7 @@ define Device/unielec_u7621-06-64m
   DEVICE_VENDOR := UniElec
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 64M
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-usb3 \
-	-wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-ata-ahci kmod-mmc-mtk kmod-usb3
   SUPPORTED_DEVICES += unielec,u7621-06-512m-64m
 endef
 TARGET_DEVICES += unielec_u7621-06-64m
@@ -3070,8 +3066,8 @@ define Device/wavlink_ws-wn572hp3-4g
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | check-size | append-metadata
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	kmod-usb3 kmod-usb-net-rndis comgt-ncm
+  DEVICE_PACKAGES := comgt-ncm kmod-mt7603 kmod-mt7615e \
+	kmod-mt7663-firmware-ap kmod-usb-net-rndis kmod-usb3
 endef
 TARGET_DEVICES += wavlink_ws-wn572hp3-4g
 
@@ -3095,8 +3091,7 @@ define Device/wevo_11acnas
   UIMAGE_NAME := 11AC-NAS-Router(0.0.0)
   DEVICE_VENDOR := WeVO
   DEVICE_MODEL := 11AC NAS Router
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += 11acnas
 endef
 TARGET_DEVICES += wevo_11acnas
@@ -3109,8 +3104,7 @@ define Device/wevo_w2914ns-v2
   DEVICE_VENDOR := WeVO
   DEVICE_MODEL := W2914NS
   DEVICE_VARIANT := v2
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += w2914nsv2
 endef
 TARGET_DEVICES += wevo_w2914ns-v2
@@ -3139,8 +3133,7 @@ define Device/winstars_ws-wn536p3
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Winstars
   DEVICE_MODEL := WS-WN536P3
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	kmod-usb3
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap kmod-usb3
 endef
 TARGET_DEVICES += winstars_ws-wn536p3
 
@@ -3182,8 +3175,7 @@ define Device/xiaomi_mi-router-3g
   $(Device/xiaomi_nand_separate)
   DEVICE_MODEL := Mi Router 3G
   IMAGE_SIZE := 124416k
-  DEVICE_PACKAGES += kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES += kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += R3G mir3g xiaomi,mir3g
 endef
 TARGET_DEVICES += xiaomi_mi-router-3g
@@ -3209,8 +3201,8 @@ define Device/xiaomi_mi-router-3-pro
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport \
-	kmod-usb3 uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport kmod-usb3 \
+	uboot-envtools
   SUPPORTED_DEVICES += xiaomi,mir3p
 endef
 TARGET_DEVICES += xiaomi_mi-router-3-pro
@@ -3295,7 +3287,7 @@ define Device/xiaoyu_xy-c5
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := XiaoYu
   DEVICE_MODEL := XY-C5
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 -wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-ata-ahci kmod-usb3
 endef
 TARGET_DEVICES += xiaoyu_xy-c5
 
@@ -3304,8 +3296,8 @@ define Device/xzwifi_creativebox-v1
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := CreativeBox
   DEVICE_MODEL := v1
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mt7603 kmod-mt76x2 kmod-mmc-mtk \
-	kmod-usb3 -wpad-basic-mbedtls
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-ata-ahci kmod-mmc-mtk \
+	kmod-mt7603 kmod-mt76x2 kmod-usb3
 endef
 TARGET_DEVICES += xzwifi_creativebox-v1
 
@@ -3314,8 +3306,7 @@ define Device/youhua_wr1200js
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := YouHua
   DEVICE_MODEL := WR1200JS
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += youhua_wr1200js
 
@@ -3324,8 +3315,7 @@ define Device/youku_yk-l2
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Youku
   DEVICE_MODEL := YK-L2
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
   UIMAGE_MAGIC := 0x12291000
   UIMAGE_NAME := 400000000000000000003000
 endef
@@ -3393,7 +3383,7 @@ define Device/zbtlink_zbt-we1326
   DEVICE_MODEL := ZBT-WE1326
   DEVICE_ALT0_VENDOR := Wiflyer
   DEVICE_ALT0_MODEL := WF3526-P
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-mmc-mtk
+  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 kmod-usb3
   SUPPORTED_DEVICES += zbt-we1326
 endef
 TARGET_DEVICES += zbtlink_zbt-we1326
@@ -3404,8 +3394,8 @@ define Device/zbtlink_zbt-we3526
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WE3526
-  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 \
+	kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += zbtlink_zbt-we3526
 
@@ -3416,8 +3406,8 @@ define Device/zbtlink_zbt-wg1602-16m
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WG1602
   DEVICE_VARIANT := 16M
-  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 \
+	kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1602-16m
 
@@ -3428,8 +3418,8 @@ define Device/zbtlink_zbt-wg1602-v04-16m
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WG1602-V04
   DEVICE_VARIANT := 16M
-  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-        kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 \
+	kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1602-v04-16m
 
@@ -3440,8 +3430,8 @@ define Device/zbtlink_zbt-wg1602-v04-32m
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WG1602-V04
   DEVICE_VARIANT := 32M
-  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-        kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 \
+	kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1602-v04-32m
 
@@ -3453,7 +3443,7 @@ define Device/zbtlink_zbt-wg1608-16m
   DEVICE_MODEL := ZBT-WG1608
   DEVICE_VARIANT := 16M
   DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt7615e \
-	kmod-mt7663-firmware-ap kmod-usb3 kmod-usb-ledtrig-usbport
+	kmod-mt7663-firmware-ap kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1608-16m
 
@@ -3465,7 +3455,7 @@ define Device/zbtlink_zbt-wg1608-32m
   DEVICE_MODEL := ZBT-WG1608
   DEVICE_VARIANT := 32M
   DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt7615e \
-	kmod-mt7663-firmware-ap kmod-usb3 kmod-usb-ledtrig-usbport
+	kmod-mt7663-firmware-ap kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1608-32m
 
@@ -3475,8 +3465,8 @@ define Device/zbtlink_zbt-wg2626
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WG2626
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-mt76x2 \
+	kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += zbt-wg2626
 endef
 TARGET_DEVICES += zbtlink_zbt-wg2626
@@ -3489,7 +3479,7 @@ define Device/zbtlink_zbt-wg3526-16m
   DEVICE_MODEL := ZBT-WG3526
   DEVICE_VARIANT := 16M
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 \
-	kmod-usb3 kmod-usb-ledtrig-usbport
+	kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += zbt-wg3526 zbt-wg3526-16M
 endef
 TARGET_DEVICES += zbtlink_zbt-wg3526-16m
@@ -3502,7 +3492,7 @@ define Device/zbtlink_zbt-wg3526-32m
   DEVICE_MODEL := ZBT-WG3526
   DEVICE_VARIANT := 32M
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 \
-	kmod-usb3 kmod-usb-ledtrig-usbport
+	kmod-usb-ledtrig-usbport kmod-usb3
   SUPPORTED_DEVICES += ac1200pro zbt-wg3526-32M
 endef
 TARGET_DEVICES += zbtlink_zbt-wg3526-32m
@@ -3512,8 +3502,7 @@ define Device/zio_freezio
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := ZIO
   DEVICE_MODEL := FREEZIO
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport kmod-usb3
 endef
 TARGET_DEVICES += zio_freezio
 
@@ -3523,8 +3512,7 @@ define Device/zyxel_lte3301-plus
   DEVICE_MODEL := LTE3301-PLUS
   KERNEL_SIZE := 31488k
   DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport \
-	kmod-usb-net-qmi-wwan kmod-usb-serial-option kmod-usb3 uboot-envtools \
-	uqmi
+	kmod-usb-net-qmi-wwan kmod-usb-serial-option kmod-usb3 uboot-envtools uqmi
   KERNEL := $(KERNEL_DTB) | uImage lzma | \
 	zytrx-header $$(DEVICE_MODEL) $$(VERSION_DIST)-$$(REVISION)
   KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma | \
@@ -3554,8 +3542,8 @@ define Device/zyxel_lte7490-m904
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := LTE7490-M904
   KERNEL_SIZE := 31488k
-  DEVICE_PACKAGES := kmod-mt7603 kmod-usb-net-qmi-wwan \
-	kmod-usb-serial-option kmod-usb3 uboot-envtools uqmi
+  DEVICE_PACKAGES := kmod-mt7603 kmod-usb-net-qmi-wwan kmod-usb-serial-option \
+	kmod-usb3 uboot-envtools uqmi
   KERNEL := $(KERNEL_DTB) | uImage lzma | \
 	zytrx-header $$(DEVICE_MODEL) $$(VERSION_DIST)-$$(REVISION)
   KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma | \
@@ -3569,10 +3557,12 @@ define Device/zyxel_nr7101
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := NR7101
   KERNEL_SIZE := 31488k
-  DEVICE_PACKAGES := kmod-mt7603 kmod-usb-net-qmi-wwan \
-	kmod-usb-serial-option kmod-usb3 uboot-envtools uqmi
-  KERNEL := $(KERNEL_DTB) | uImage lzma | zytrx-header $$(DEVICE_MODEL) $$(VERSION_DIST)-$$(REVISION)
-  KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma | zytrx-header $$(DEVICE_MODEL) 9.99(ABUV.9)$$(VERSION_DIST)-recovery
+  DEVICE_PACKAGES := kmod-mt7603 kmod-usb-net-qmi-wwan kmod-usb-serial-option \
+	kmod-usb3 uboot-envtools uqmi
+  KERNEL := $(KERNEL_DTB) | uImage lzma | \
+	zytrx-header $$(DEVICE_MODEL) $$(VERSION_DIST)-$$(REVISION)
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma | \
+	zytrx-header $$(DEVICE_MODEL) 9.99(ABUV.9)$$(VERSION_DIST)-recovery
   KERNEL_INITRAMFS_SUFFIX := -recovery.bin
 endef
 TARGET_DEVICES += zyxel_nr7101
@@ -3582,10 +3572,13 @@ define Device/zyxel_nwa-ax
   DEVICE_VENDOR := Zyxel
   KERNEL_SIZE := 8192k
   DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools zyxel-bootconfig
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGES += factory.bin ramboot-factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | zyxel-nwa-fit
-  IMAGE/ramboot-factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	zyxel-nwa-fit
+  IMAGE/ramboot-factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi
 endef
 
 define Device/zyxel_nwa50ax
@@ -3618,7 +3611,11 @@ define Device/zyxel_wsm20
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := WSM20
   DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | znet-header V1.00(ABZF.0)C0
-  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | znet-header V1.00(ABZF.0)C0
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
+	znet-header V1.00(ABZF.0)C0
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
+	znet-header V1.00(ABZF.0)C0
 endef
 TARGET_DEVICES += zyxel_wsm20

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -274,7 +274,7 @@ define Device/alfa-network_ax1800rm
   IMAGE_SIZE := 15488k
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := AX1800RM
-  DEVICE_PACKAGES := kmod-mt7915-firmware
+  DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGES += recovery.bin
   IMAGE/recovery.bin := append-kernel | append-rootfs | pad-rootfs | check-size
@@ -286,7 +286,7 @@ define Device/alfa-network_quad-e4g
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := Quad-E4G
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-usb3 \
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-usb3 uboot-envtools \
 	-wpad-basic-mbedtls
   SUPPORTED_DEVICES += quad-e4g
 endef
@@ -296,7 +296,7 @@ define Device/ampedwireless_ally_common
   $(Device/nand)
   $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := Amped Wireless
-  DEVICE_PACKAGES := kmod-mt7615-firmware
+  DEVICE_PACKAGES := kmod-mt7615-firmware uboot-envtools
   IMAGE_SIZE := 32768k
   KERNEL_INITRAMFS := $$(KERNEL) | edimax-header -s CSYS -m RN68 -f 0x001c0000 -S 0x01100000
 endef
@@ -411,7 +411,7 @@ define Device/asus_rt-ac65p
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7615-firmware
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 uboot-envtools
 endef
 TARGET_DEVICES += asus_rt-ac65p
 
@@ -423,7 +423,7 @@ define Device/asus_rt-ac85p
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7615-firmware
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 uboot-envtools
 endef
 TARGET_DEVICES += asus_rt-ac85p
 
@@ -449,7 +449,8 @@ define Device/asus_rt-ax53u
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb-ledtrig-usbport \
+	kmod-usb3 uboot-envtools
 endef
 TARGET_DEVICES += asus_rt-ax53u
 
@@ -467,7 +468,7 @@ define Device/asus_rt-ax54
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES := kmod-mt7915-firmware
+  DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools
 endef
 TARGET_DEVICES += asus_rt-ax54
 
@@ -480,8 +481,8 @@ define Device/asus_4g-ax56
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb3 kmod-usb-serial-option \
-	kmod-usb-net-cdc-ncm
+  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb-net-cdc-ncm \
+	kmod-usb-serial-option kmod-usb3 uboot-envtools
 endef
 TARGET_DEVICES += asus_4g-ax56
 
@@ -498,7 +499,8 @@ define Device/beeline_smartbox-flash
 	uImage none
   IMAGES += factory.trx
   IMAGE/factory.trx := append-kernel | append-ubi | check-size
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7615-firmware uencrypt-mbedtls
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 uboot-envtools \
+	uencrypt-mbedtls
 endef
 TARGET_DEVICES += beeline_smartbox-flash
 
@@ -510,8 +512,8 @@ define Device/beeline_smartbox-giga
   SERCOMM_SWVER := 1001
   DEVICE_VENDOR := Beeline
   DEVICE_MODEL := SmartBox GIGA
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	kmod-usb3
+  DEVICE_PACKAGES := -kmod-mt7615-firmware kmod-mt7615e \
+	kmod-mt7663-firmware-ap
 endef
 TARGET_DEVICES += beeline_smartbox-giga
 
@@ -540,7 +542,6 @@ define Device/beeline_smartbox-turbo
   SERCOMM_SWVER := 1004
   DEVICE_VENDOR := Beeline
   DEVICE_MODEL := SmartBox TURBO
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3
 endef
 TARGET_DEVICES += beeline_smartbox-turbo
 
@@ -552,7 +553,6 @@ define Device/beeline_smartbox-turbo-plus
   SERCOMM_SWVER := 2010
   DEVICE_VENDOR := Beeline
   DEVICE_MODEL := SmartBox TURBO+
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3
 endef
 TARGET_DEVICES += beeline_smartbox-turbo-plus
 
@@ -561,7 +561,7 @@ define Device/belkin_rt1800
   IMAGE_SIZE := 49152k
   DEVICE_VENDOR := Belkin
   DEVICE_MODEL := RT1800
-  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb3
+  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb3 uboot-envtools
   KERNEL_LOADADDR := 0x82000000
   KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
@@ -654,7 +654,7 @@ define Device/bolt_arion
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := BOLT
   DEVICE_MODEL := Arion
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 uboot-envtools
 endef
 TARGET_DEVICES += bolt_arion
 
@@ -1325,7 +1325,7 @@ ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
 	znet-header 4.04(XVF.1)b90 COMC 0x68 | elecom-product-header WRC-X1800GS | \
 	check-size
 endif
-  DEVICE_PACKAGES := kmod-mt7915-firmware
+  DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools
 endef
 TARGET_DEVICES += elecom_wrc-x1800gs
 
@@ -1357,7 +1357,6 @@ define Device/etisalat_s3
   DEVICE_MODEL := S3
   DEVICE_ALT0_VENDOR := Sercomm
   DEVICE_ALT0_MODEL := S3
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3
 endef
 TARGET_DEVICES += etisalat_s3
 
@@ -1422,7 +1421,8 @@ endif
   IMAGE/sysupgrade.bin := append-kernel | inteno-bootfs | pad-to 10M | \
     sysupgrade-tar kernel=$$$$@ | check-size | append-metadata
   DEVICE_IMG_NAME = $$(DEVICE_IMG_PREFIX)-$$(2)
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3 kmod-keyboard-sx951x kmod-button-hotplug
+  DEVICE_PACKAGES := kmod-button-hotplug kmod-keyboard-sx951x \
+	kmod-mt7603 kmod-mt7615-firmware kmod-usb3 uboot-envtools
 endef
 
 define Device/genexis_pulse-ex400
@@ -1484,7 +1484,7 @@ define Device/h3c_tx180x
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL := $$(KERNEL_INITRAMFS) | h3c-blank-header
   DEVICE_VENDOR := H3C
-  DEVICE_PACKAGES := kmod-mt7915-firmware
+  DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools
 endef
 
 define Device/h3c_tx1800-plus
@@ -1516,7 +1516,7 @@ ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
   ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | \
 	haier-sim_wr1800k-factory
 endif
-  DEVICE_PACKAGES := kmod-mt7915-firmware
+  DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools
 endef
 
 define Device/haier_har-20s2u1
@@ -1774,7 +1774,7 @@ define Device/iptime_ax2004m
 	check-size | iptime-crc32 ax2004m
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := AX2004M
-  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb3
+  DEVICE_PACKAGES := kmod-mt7915-firmware kmod-usb3 uboot-envtools
   DEVICE_COMPAT_VERSION := 2.0
   DEVICE_COMPAT_MESSAGE := NMBM has been newly enabled, and its flash block \
 	mapping might be incompatible with existing installation. \
@@ -1788,7 +1788,7 @@ define Device/iptime_t5004
   UIMAGE_NAME := t5004
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := T5004
-  DEVICE_PACKAGES := -wpad-basic-mbedtls
+  DEVICE_PACKAGES := uboot-envtools -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += iptime_t5004
 
@@ -1814,7 +1814,7 @@ define Device/jcg_q20
 	check-size
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := Q20
-  DEVICE_PACKAGES := kmod-mt7915-firmware
+  DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools
 endef
 TARGET_DEVICES += jcg_q20
 
@@ -1900,7 +1900,7 @@ define Device/linksys_e5600
   IMAGE_SIZE := 26624k
   DEVICE_VENDOR := Linksys
   DEVICE_MODEL := E5600
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap uboot-envtools
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
 	append-ubi | check-size | gemtek-trailer
@@ -1921,7 +1921,7 @@ define Device/linksys_ea7xxx
   $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 36864k
   DEVICE_VENDOR := Linksys
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7615-firmware
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 uboot-envtools
   IMAGES := sysupgrade.bin factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
 	append-ubi | check-size | linksys-image type=$$$$(LINKSYS_HWNAME)
@@ -1993,7 +1993,7 @@ define Device/linksys_re7000
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Linksys
   DEVICE_MODEL := RE7000
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware uboot-envtools
 endef
 TARGET_DEVICES += linksys_re7000
 
@@ -2037,8 +2037,8 @@ define Device/meig_slt866
   DEVICE_VENDOR := MeiG
   DEVICE_MODEL := SLT866
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	kmod-usb-net-qmi-wwan kmod-usb-serial-option kmod-usb3 \
-	kmod-usb-net-rndis
+	kmod-usb-net-qmi-wwan kmod-usb-net-rndis kmod-usb-serial-option \
+	kmod-usb3 uboot-envtools
 endef
 TARGET_DEVICES += meig_slt866
 
@@ -2156,7 +2156,7 @@ define Device/mts_wg430223
 	uImage none
   IMAGES += factory.trx
   IMAGE/factory.trx := append-kernel | append-ubi | check-size
-  DEVICE_PACKAGES := kmod-mt7615-firmware uencrypt-mbedtls
+  DEVICE_PACKAGES := kmod-mt7615-firmware uboot-envtools uencrypt-mbedtls
 endef
 TARGET_DEVICES += mts_wg430223
 
@@ -2377,7 +2377,7 @@ define Device/netgear_wax214v2
   $(Device/nand)
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := WAX214v2
-  DEVICE_PACKAGES := kmod-mt7915-firmware
+  DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools
   NETGEAR_ENC_MODEL := WAX214v2
   NETGEAR_ENC_REGION := US
   IMAGE_SIZE := 38912k
@@ -2422,7 +2422,7 @@ define Device/netis_n6
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
 	append-ubi | check-size | append-netis-n6-metadata
   DEVICE_PACKAGES += kmod-mt7915-firmware kmod-usb-ledtrig-usbport \
-	kmod-usb3
+	kmod-usb3 uboot-envtools
 endef
 TARGET_DEVICES += netis_n6
 
@@ -2495,7 +2495,8 @@ define Device/raisecom_msg1500-x-00
   DEVICE_VARIANT := X.00
   DEVICE_ALT0_VENDOR := Nokia
   DEVICE_ALT0_MODEL := A-040W-Q
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport \
+	kmod-usb3 uboot-envtools
 endef
 TARGET_DEVICES += raisecom_msg1500-x-00
 
@@ -2521,7 +2522,7 @@ define Device/rostelecom_rt-fe-1a
   DEVICE_MODEL := RT-FE-1A
   DEVICE_ALT0_VENDOR := Sercomm
   DEVICE_ALT0_MODEL := RT-FE-1A
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware
+  DEVICE_PACKAGES := -kmod-usb3
 endef
 TARGET_DEVICES += rostelecom_rt-fe-1a
 
@@ -2533,7 +2534,6 @@ define Device/rostelecom_rt-sf-1
   SERCOMM_SWVER := 1026
   DEVICE_VENDOR := Rostelecom
   DEVICE_MODEL := RT-SF-1
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3
 endef
 TARGET_DEVICES += rostelecom_rt-sf-1
 
@@ -2554,8 +2554,8 @@ define Device/samknows_whitebox-v8
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := SamKnows
   DEVICE_MODEL := Whitebox 8
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb-ledtrig-usbport \
+	kmod-usb3 uboot-envtools
   SUPPORTED_DEVICES += sk-wb8
 endef
 TARGET_DEVICES += samknows_whitebox-v8
@@ -2812,7 +2812,8 @@ define Device/tplink_ec330-g5u-v1
   DEVICE_ALT0_VENDOR := TP-Link
   DEVICE_ALT0_MODEL := Archer C9ERT
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport kmod-usb3
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport \
+	kmod-usb3 uboot-envtools
   KERNEL := kernel-bin | append-dtb | lzma | loader-kernel | \
 	uImage-tplink-c9 standalone '$(call toupper,$(LINUX_KARCH)) \
 		$(VERSION_DIST) Linux-$(LINUX_VERSION)' | \
@@ -3193,6 +3194,7 @@ define Device/xiaomi_nand_separate
   $(Device/nand)
   $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := Xiaomi
+  DEVICE_PACKAGES := uboot-envtools
   IMAGES += kernel1.bin rootfs0.bin
   IMAGE/kernel1.bin := append-kernel
   IMAGE/rootfs0.bin := append-ubi | check-size
@@ -3229,7 +3231,8 @@ define Device/xiaomi_mi-router-3-pro
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport \
+	kmod-usb3 uboot-envtools
   SUPPORTED_DEVICES += xiaomi,mir3p
 endef
 TARGET_DEVICES += xiaomi_mi-router-3-pro
@@ -3281,7 +3284,7 @@ define Device/xiaomi_mi-router-cr660x
   IMAGES += firmware.bin
   IMAGE/firmware.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size
-  DEVICE_PACKAGES += kmod-mt7915-firmware
+  DEVICE_PACKAGES += kmod-mt7915-firmware uboot-envtools
 endef
 
 define Device/xiaomi_mi-router-cr6606
@@ -3545,8 +3548,9 @@ define Device/zyxel_lte3301-plus
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := LTE3301-PLUS
   KERNEL_SIZE := 31488k
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 kmod-usb-ledtrig-usbport \
-	kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb-ledtrig-usbport \
+	kmod-usb-net-qmi-wwan kmod-usb-serial-option kmod-usb3 uboot-envtools \
+	uqmi
   KERNEL := $(KERNEL_DTB) | uImage lzma | \
 	zytrx-header $$(DEVICE_MODEL) $$(VERSION_DIST)-$$(REVISION)
   KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma | \
@@ -3560,8 +3564,9 @@ define Device/zyxel_lte5398-m904
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := LTE5398-M904
   KERNEL_SIZE := 31488k
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3 uqmi \
-  kmod-usb-net-qmi-wwan kmod-usb-serial-option kmod-usb-ledtrig-usbport
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware \
+	kmod-usb-ledtrig-usbport kmod-usb-net-qmi-wwan kmod-usb-serial-option \
+	kmod-usb3 uboot-envtools uqmi
   KERNEL := $(KERNEL_DTB) | uImage lzma | \
 	zytrx-header $$(DEVICE_MODEL) $$(VERSION_DIST)-$$(REVISION)
   KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma | \
@@ -3575,7 +3580,8 @@ define Device/zyxel_lte7490-m904
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := LTE7490-M904
   KERNEL_SIZE := 31488k
-  DEVICE_PACKAGES := kmod-mt7603 kmod-usb3 kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+  DEVICE_PACKAGES := kmod-mt7603 kmod-usb-net-qmi-wwan \
+	kmod-usb-serial-option kmod-usb3 uboot-envtools uqmi
   KERNEL := $(KERNEL_DTB) | uImage lzma | \
 	zytrx-header $$(DEVICE_MODEL) $$(VERSION_DIST)-$$(REVISION)
   KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma | \
@@ -3589,7 +3595,8 @@ define Device/zyxel_nr7101
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := NR7101
   KERNEL_SIZE := 31488k
-  DEVICE_PACKAGES := kmod-mt7603 kmod-usb3 kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+  DEVICE_PACKAGES := kmod-mt7603 kmod-usb-net-qmi-wwan \
+	kmod-usb-serial-option kmod-usb3 uboot-envtools uqmi
   KERNEL := $(KERNEL_DTB) | uImage lzma | zytrx-header $$(DEVICE_MODEL) $$(VERSION_DIST)-$$(REVISION)
   KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma | zytrx-header $$(DEVICE_MODEL) 9.99(ABUV.9)$$(VERSION_DIST)-recovery
   KERNEL_INITRAMFS_SUFFIX := -recovery.bin
@@ -3600,7 +3607,7 @@ define Device/zyxel_nwa-ax
   $(Device/nand)
   DEVICE_VENDOR := Zyxel
   KERNEL_SIZE := 8192k
-  DEVICE_PACKAGES := kmod-mt7915-firmware zyxel-bootconfig
+  DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools zyxel-bootconfig
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGES += factory.bin ramboot-factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | zyxel-nwa-fit
@@ -3636,7 +3643,7 @@ define Device/zyxel_wsm20
   IMAGE_SIZE := 41943040
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := WSM20
-  DEVICE_PACKAGES := kmod-mt7915-firmware
+  DEVICE_PACKAGES := kmod-mt7915-firmware uboot-envtools
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | znet-header V1.00(ABZF.0)C0
   KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | znet-header V1.00(ABZF.0)C0
 endef

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -253,7 +253,7 @@ define Device/adslr_g7
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := ADSLR
   DEVICE_MODEL := G7
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += adslr_g7
 
@@ -264,7 +264,7 @@ define Device/afoundry_ew1200
   DEVICE_VENDOR := AFOUNDRY
   DEVICE_MODEL := EW1200
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mt76x2 kmod-mt7603 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += ew1200
 endef
 TARGET_DEVICES += afoundry_ew1200
@@ -334,7 +334,7 @@ define Device/arcadyan_we420223-99
   IMAGES += factory.trx
   IMAGE/factory.trx := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | check-size
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += arcadyan_we420223-99
 
@@ -345,7 +345,7 @@ define Device/asiarf_ap7621-001
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AP7621-001
   DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt76x2 kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	-wpad-basic-mbedtls
 endef
 TARGET_DEVICES += asiarf_ap7621-001
 
@@ -356,7 +356,7 @@ define Device/asiarf_ap7621-nv1
   DEVICE_VENDOR := AsiaRF
   DEVICE_MODEL := AP7621-NV1
   DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt76x2 kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	-wpad-basic-mbedtls
 endef
 TARGET_DEVICES += asiarf_ap7621-nv1
 
@@ -367,11 +367,11 @@ define Device/asus_rp-ac56
   DEVICE_MODEL := RP-AC56
   IMAGE_SIZE := 16000k
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 \
-	kmod-sound-mt7620 -uboot-envtools
+	kmod-sound-mt7620
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
-        check-size | append-metadata
+	check-size | append-metadata
 endef
 TARGET_DEVICES += asus_rp-ac56
 
@@ -385,7 +385,7 @@ define Device/asus_rp-ac87
   IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
 	check-size | append-metadata
-  DEVICE_PACKAGES := kmod-mt7615-firmware rssileds -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware rssileds
 endef
 TARGET_DEVICES += asus_rp-ac87
 
@@ -435,7 +435,7 @@ define Device/asus_rt-n56u-b1
   DEVICE_VARIANT := B1
   IMAGE_SIZE := 16064k
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += asus_rt-n56u-b1
 
@@ -579,7 +579,7 @@ define Device/buffalo_wsr-1166dhp
   IMAGE_SIZE := 15936k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WSR-1166DHP
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2
   SUPPORTED_DEVICES += wsr-1166
 endef
 TARGET_DEVICES += buffalo_wsr-1166dhp
@@ -593,14 +593,14 @@ define Device/buffalo_wsr-2533dhpl
   DEVICE_ALT0_VENDOR := Buffalo
   DEVICE_ALT0_MODEL := WSR-2533DHP
   IMAGE/sysupgrade.bin := trx | pad-rootfs | append-metadata
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += buffalo_wsr-2533dhpl
 
 define Device/buffalo_wsr-2533dhplx
   $(Device/dsa-migration)
   DEVICE_VENDOR := Buffalo
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
   BUFFALO_TAG_PLATFORM := MTK
   BUFFALO_TAG_VERSION := 9.99
   BUFFALO_TAG_MINOR := 9.99
@@ -643,7 +643,7 @@ define Device/buffalo_wsr-600dhp
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Buffalo
   DEVICE_MODEL := WSR-600DHP
-  DEVICE_PACKAGES := kmod-mt7603 kmod-rt2800-pci -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-rt2800-pci
   SUPPORTED_DEVICES += wsr-600
 endef
 TARGET_DEVICES += buffalo_wsr-600dhp
@@ -664,7 +664,7 @@ define Device/comfast_cf-e390ax
   IMAGE_SIZE := 15808k
   DEVICE_VENDOR := COMFAST
   DEVICE_MODEL := CF-E390AX
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
 	check-size | append-metadata
@@ -678,11 +678,10 @@ define Device/comfast_cf-ew72-v2
     IMAGE_SIZE := 15808k
     DEVICE_VENDOR := COMFAST
     DEVICE_MODEL := CF-EW72 V2
-    DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-        -uboot-envtools
+    DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
     IMAGES += factory.bin
     IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
-        check-size | append-metadata
+		check-size | append-metadata
     IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | check-size
 endef
 TARGET_DEVICES += comfast_cf-ew72-v2
@@ -694,8 +693,7 @@ define Device/confiabits_mt7621-v1
   DEVICE_VENDOR := Confiabits
   DEVICE_MODEL := MT7621
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
 endef
 TARGET_DEVICES += confiabits_mt7621-v1
 
@@ -705,8 +703,7 @@ define Device/cudy_m1300-v2
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := M1300
   DEVICE_VARIANT := v2
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
   UIMAGE_NAME := R15
   SUPPORTED_DEVICES += R15
 endef
@@ -718,7 +715,7 @@ define Device/cudy_m1800
   DEVICE_MODEL := M1800
   IMAGE_SIZE := 16064k
   UIMAGE_NAME := R17
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
 endef
 TARGET_DEVICES += cudy_m1800
 
@@ -729,7 +726,7 @@ define Device/cudy_wr1300-v1
   DEVICE_MODEL := WR1300
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += cudy,wr1300 R10
 endef
 TARGET_DEVICES += cudy_wr1300-v1
@@ -740,8 +737,7 @@ define Device/cudy_wr1300-v2
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := WR1300
   DEVICE_VARIANT := v2
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
   SUPPORTED_DEVICES += cudy,wr1300 R23
 endef
 TARGET_DEVICES += cudy_wr1300-v2
@@ -752,8 +748,7 @@ define Device/cudy_wr1300-v3
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := WR1300
   DEVICE_VARIANT := v3
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
   SUPPORTED_DEVICES += cudy,wr1300 R30
 endef
 TARGET_DEVICES += cudy_wr1300-v3
@@ -764,7 +759,7 @@ define Device/cudy_wr2100
   DEVICE_MODEL := WR2100
   IMAGE_SIZE := 15872k
   UIMAGE_NAME := R11
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware
 endef
 TARGET_DEVICES += cudy_wr2100
 
@@ -774,7 +769,6 @@ define Device/cudy_r700
   DEVICE_MODEL := R700
   IMAGE_SIZE := 15872k
   UIMAGE_NAME := R29
-  DEVICE_PACKAGES := -uboot-envtools
 endef
 TARGET_DEVICES += cudy_r700
 
@@ -785,7 +779,7 @@ define Device/cudy_x6-v1
   DEVICE_MODEL := X6
   DEVICE_VARIANT := v1
   UIMAGE_NAME := R13
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   SUPPORTED_DEVICES += cudy,x6 R13
 endef
 TARGET_DEVICES += cudy_x6-v1
@@ -797,7 +791,7 @@ define Device/cudy_x6-v2
   DEVICE_MODEL := X6
   DEVICE_VARIANT := v2
   UIMAGE_NAME := R30
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   SUPPORTED_DEVICES += cudy,x6 R30
 endef
 TARGET_DEVICES += cudy_x6-v2
@@ -829,7 +823,7 @@ TARGET_DEVICES += dlink_covr-x1860-a1
 
 define Device/dlink_dxx-1xx0-x1
   DEVICE_VENDOR := D-Link
-  DEVICE_PACKAGES := kmod-mt7615-firmware rssileds -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware rssileds
   IMAGE_SIZE := 16064k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | append-rootfs | \
@@ -858,7 +852,7 @@ define Device/dlink_dap-x1860-a1
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size | elx-header 011b0060 8844A2D168B45A2D
-  DEVICE_PACKAGES := kmod-mt7915-firmware rssileds -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware rssileds
 endef
 TARGET_DEVICES += dlink_dap-x1860-a1
 
@@ -866,7 +860,7 @@ define Device/dlink_dir-8xx-a1
   $(Device/dsa-migration)
   IMAGE_SIZE := 16000k
   DEVICE_VENDOR := D-Link
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
   KERNEL := $$(KERNEL) | uimage-sgehdr
   IMAGES += recovery.bin factory.bin
   IMAGE/recovery.bin := append-kernel | append-rootfs | check-size
@@ -877,7 +871,7 @@ define Device/dlink_dir-8xx-r1
   $(Device/dsa-migration)
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := D-Link
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
   KERNEL_INITRAMFS := $$(KERNEL)
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
 	check-size | append-metadata
@@ -888,7 +882,7 @@ define Device/dlink_dir_nand_128m
   IMAGE_SIZE := 40960k
   DEVICE_VENDOR := D-Link
   DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
   KERNEL := $$(KERNEL) | uimage-sgehdr
   IMAGES += recovery.bin
   IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
@@ -934,7 +928,7 @@ define Device/dlink_dir-2150-r1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-2150
   DEVICE_VARIANT := R1
-  DEVICE_PACKAGES :=  -uboot-envtools kmod-mt7603 kmod-mt7615-firmware kmod-usb3
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3
   KERNEL := $$(KERNEL)
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
@@ -1003,8 +997,7 @@ define Device/dlink_dir-860l-b1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-860L
   DEVICE_VARIANT := B1
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += dir-860l-b1
 endef
 TARGET_DEVICES += dlink_dir-860l-b1
@@ -1069,7 +1062,7 @@ define Device/dual-q_h721
   DEVICE_VENDOR := Dual-Q
   DEVICE_MODEL := H721
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	-wpad-basic-mbedtls
 endef
 TARGET_DEVICES += dual-q_h721
 
@@ -1080,7 +1073,7 @@ define Device/d-team_newifi-d2
   DEVICE_VENDOR := D-Team
   DEVICE_MODEL := Newifi D2
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += d-team_newifi-d2
 
@@ -1090,7 +1083,7 @@ define Device/d-team_pbr-m1
   DEVICE_VENDOR := PandoraBox
   DEVICE_MODEL := PBR-M1
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mt7603 kmod-mt76x2 kmod-mmc-mtk \
-	kmod-usb3 kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb3 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += pbr-m1
 endef
 TARGET_DEVICES += d-team_pbr-m1
@@ -1114,7 +1107,7 @@ define Device/edimax_ra21s
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elx-header 02020040 8844A2D168B45A2D
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += edimax_ra21s
 
@@ -1133,7 +1126,7 @@ define Device/edimax_re23s
   IMAGE/factory.bin := append-kernel | append-rootfs | \
 	edimax-header -s CSYS -m RN76 -f 0x70000 -S 0x01100000 | pad-rootfs | \
 	check-size
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += edimax_re23s
 
@@ -1146,7 +1139,7 @@ define Device/edimax_rg21s
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elx-header 02020038 8844A2D168B45A2D
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += edimax_rg21s
 
@@ -1158,7 +1151,7 @@ define Device/elecom_wrc-gs
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elecom-wrc-gs-factory $$$$(ELECOM_HWNAME) 0.00 -N | \
 	append-string MT7621_ELECOM_$$$$(ELECOM_HWNAME)
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 
 define Device/elecom_wmc-m1267gst2
@@ -1191,7 +1184,7 @@ ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
 	check-size $$$$(KERNEL_SIZE) | elecom-wrc-gs-factory WMC-2LX 0.00 -N | \
 	append-string MT7621_ELECOM_WMC-2LX
 endif
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
 endef
 TARGET_DEVICES += elecom_wmc-x1800gst
 
@@ -1203,7 +1196,7 @@ define Device/elecom_wrc-1167ghbk2-s
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elecom-wrc-gs-factory WRC-1167GHBK2-S 0.00
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += elecom_wrc-1167ghbk2-s
 
@@ -1265,7 +1258,7 @@ define Device/elecom_wrc-2533ghbk2-t
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elx-header 0107003b 8844A2D168B45A2D | \
 	elecom-product-header WRC-2533GHBK2-T
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += elecom_wrc-2533ghbk2-t
 
@@ -1279,7 +1272,7 @@ define Device/elecom_wrc-2533ghbk-i
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elx-header 0107002d 8844A2D168B45A2D | \
 	elecom-product-header WRC-2533GHBK-I
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += elecom_wrc-2533ghbk-i
 
@@ -1343,7 +1336,7 @@ ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
 	check-size $$$$(KERNEL_SIZE) | elecom-wrc-gs-factory WMC-2LX 0.00 -N | \
 	append-string MT7621_ELECOM_WMC-2LX
 endif
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
 endef
 TARGET_DEVICES += elecom_wsc-x1800gs
 
@@ -1365,8 +1358,7 @@ define Device/firefly_firewrt
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Firefly
   DEVICE_MODEL := FireWRT
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += firewrt
 endef
 TARGET_DEVICES += firefly_firewrt
@@ -1377,7 +1369,7 @@ define Device/gehua_ghl-r-001
   DEVICE_VENDOR := GeHua
   DEVICE_MODEL := GHL-R-001
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += gehua_ghl-r-001
 
@@ -1387,7 +1379,7 @@ define Device/gemtek_wvrtm-1xxacn
   IMAGE_SIZE := 122368k
   DEVICE_VENDOR := Gemtek
   DEVICE_PACKAGES := kmod-gpio-nxp-74hc164 kmod-spi-gpio \
-  kmod-usb3 -uboot-envtools 
+	kmod-usb3 
 endef
 
 define Device/gemtek_wvrtm-127acn
@@ -1439,7 +1431,7 @@ define Device/glinet_gl-mt1300
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MT1300
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3
 endef
 TARGET_DEVICES += glinet_gl-mt1300
 
@@ -1449,7 +1441,7 @@ define Device/gnubee_gb-pc1
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := GB-PC1
   DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-mmc-mtk \
-	-wpad-basic-mbedtls -uboot-envtools
+	-wpad-basic-mbedtls
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc1
@@ -1460,7 +1452,7 @@ define Device/gnubee_gb-pc2
   DEVICE_VENDOR := GnuBee
   DEVICE_MODEL := GB-PC2
   DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 kmod-mmc-mtk \
-	-wpad-basic-mbedtls -uboot-envtools
+	-wpad-basic-mbedtls
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += gnubee_gb-pc2
@@ -1531,7 +1523,7 @@ define Device/hilink_hlk-7621a-evb
   $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := HiLink
   DEVICE_MODEL := HLK-7621A evaluation board
-  DEVICE_PACKAGES += kmod-mt76x2 kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES += kmod-mt76x2 kmod-usb3
   IMAGE_SIZE := 32448k
 endef
 TARGET_DEVICES += hilink_hlk-7621a-evb
@@ -1545,7 +1537,7 @@ define Device/hiwifi_hc5962
 	check-size
   DEVICE_VENDOR := HiWiFi
   DEVICE_MODEL := HC5962
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3
 endef
 TARGET_DEVICES += hiwifi_hc5962
 
@@ -1564,7 +1556,7 @@ define Device/humax_e10
   IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | \
 	edimax-header -s CSYS -m EA03 -f 0x70000 -S 0x01100000 | \
 	check-size | zip upg -P f013c26cf0a320fb71d03356dcb6bb63
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3
 endef
 TARGET_DEVICES += humax_e10
 
@@ -1576,7 +1568,7 @@ define Device/huasifei_ws1208v2
   DEVICE_MODEL := WS1208V2
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mt7603 kmod-mt76x2 kmod-mmc-mtk \
 	kmod-usb3 kmod-usb-net-cdc-mbim kmod-usb-net-qmi-wwan \
-	kmod-usb-serial-option -uboot-envtools
+	kmod-usb-serial-option
 endef
 TARGET_DEVICES += huasifei_ws1208v2
 
@@ -1589,7 +1581,7 @@ define Device/iodata_wn-ax1167gr
   ARTIFACTS := initramfs-factory.bin
   ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | \
 	check-size 7680k | senao-header -r 0x30a -p 0x1055 -t 4
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2
 endef
 TARGET_DEVICES += iodata_wn-ax1167gr
 
@@ -1612,7 +1604,7 @@ define Device/iodata_wn-ax1167gr2
   DEVICE_MODEL := WN-AX1167GR2
   KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel | lzma | \
 	uImage lzma -M 0x434f4d42 -n '3.10(XBC.1)b10' | iodata-mstc-header
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += iodata_wn-ax1167gr2
 
@@ -1621,7 +1613,7 @@ define Device/iodata_wn-ax2033gr
   DEVICE_MODEL := WN-AX2033GR
   KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel | lzma | \
 	uImage lzma -M 0x434f4d42 -n '3.10(VST.1)C10' | iodata-mstc-header
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware
 endef
 TARGET_DEVICES += iodata_wn-ax2033gr
 
@@ -1651,7 +1643,7 @@ define Device/iodata_wn-dx1167r
   DEVICE_MODEL := WN-DX1167R
   KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel | lzma | \
 	uImage lzma -M 0x434f4d43 -n '3.10(XIK.1)b10' | iodata-mstc-header
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += iodata_wn-dx1167r
 
@@ -1660,8 +1652,7 @@ define Device/iodata_wn-dx1200gr
   DEVICE_MODEL := WN-DX1200GR
   KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel | lzma | \
 	uImage lzma -M 0x434f4d43 -n '3.10(XIQ.0)b20' | iodata-mstc-header
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
 endef
 TARGET_DEVICES += iodata_wn-dx1200gr
 
@@ -1670,7 +1661,7 @@ define Device/iodata_wn-dx2033gr
   DEVICE_MODEL := WN-DX2033GR
   KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel | lzma | \
 	uImage lzma -M 0x434f4d42 -n '3.10(XID.0)b30' | iodata-mstc-header
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware
 endef
 TARGET_DEVICES += iodata_wn-dx2033gr
 
@@ -1680,7 +1671,7 @@ define Device/iodata_wn-gx300gr
   IMAGE_SIZE := 7616k
   DEVICE_VENDOR := I-O DATA
   DEVICE_MODEL := WN-GX300GR
-  DEVICE_PACKAGES := kmod-mt7603 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603
 endef
 TARGET_DEVICES += iodata_wn-gx300gr
 
@@ -1693,7 +1684,7 @@ define Device/iodata_wnpr2600g
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | check-size | \
 	elx-header 0104003a 8844A2D168B45A2D
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += iodata_wnpr2600g
 
@@ -1703,7 +1694,7 @@ define Device/iptime_a3002mesh
   UIMAGE_NAME := a3002me
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := A3002MESH
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += iptime_a3002mesh
 
@@ -1714,8 +1705,7 @@ define Device/iptime_a3004ns-dual
   UIMAGE_NAME := a3004nd
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := A3004NS-dual
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt76x2 kmod-usb-ledtrig-usbport \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt76x2 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += iptime_a3004ns-dual
 
@@ -1727,7 +1717,7 @@ define Device/iptime_a3004t
   UIMAGE_NAME := a3004t
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := A3004T
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3
 endef
 TARGET_DEVICES += iptime_a3004t
 
@@ -1738,7 +1728,7 @@ define Device/iptime_a6004ns-m
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := A6004NS-M
   DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += iptime_a6004ns-m
 
@@ -1749,7 +1739,7 @@ define Device/iptime_a6ns-m
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := A6ns-M
   DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += iptime_a6ns-m
 
@@ -1759,7 +1749,7 @@ define Device/iptime_a8004t
   UIMAGE_NAME := a8004t
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := A8004T
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3
 endef
 TARGET_DEVICES += iptime_a8004t
 
@@ -1801,7 +1791,7 @@ define Device/jcg_jhr-ac876m
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := JHR-AC876M
   DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += jcg_jhr-ac876m
 
@@ -1827,7 +1817,7 @@ define Device/jcg_y2
   JCG_MAXSIZE := 16064k
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := Y2
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3
 endef
 TARGET_DEVICES += jcg_y2
 
@@ -1861,8 +1851,7 @@ define Device/keenetic_kn-3010
   IMAGE_SIZE := 31488k
   DEVICE_VENDOR := Keenetic
   DEVICE_MODEL := KN-3010
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
   IMAGES += factory.bin
   IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to $$$$(BLOCKSIZE) | \
 	check-size | zyimage -d 0x803010 -v "KN-3010"
@@ -1875,7 +1864,7 @@ define Device/keenetic_kn-3510
   IMAGE_SIZE := 121088k
   DEVICE_VENDOR := Keenetic
   DEVICE_MODEL := KN-3510
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
 	check-size | zyimage -d 0x803510 -v "KN-3510"
@@ -1889,7 +1878,7 @@ define Device/lenovo_newifi-d1
   DEVICE_VENDOR := Lenovo
   DEVICE_MODEL := Newifi D1
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-mmc-mtk \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += newifi-d1
 endef
 TARGET_DEVICES += lenovo_newifi-d1
@@ -1983,7 +1972,7 @@ define Device/linksys_re6500
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Linksys
   DEVICE_MODEL := RE6500
-  DEVICE_PACKAGES := kmod-mt76x2 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt76x2
   SUPPORTED_DEVICES += re6500
 endef
 TARGET_DEVICES += linksys_re6500
@@ -2001,7 +1990,7 @@ define Device/maginon_mc-1200ac
   $(Device/dsa-migration)
   DEVICE_VENDOR := Maginon
   DEVICE_MODEL := MC-1200AC
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap kmod-usb3
   KERNEL_LOADADDR := 0x82000000
   KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
@@ -2017,7 +2006,7 @@ define Device/mediatek_ap-mt7621a-v60
   DEVICE_VENDOR := Mediatek
   DEVICE_MODEL := AP-MT7621A-V60 EVB
   DEVICE_PACKAGES := kmod-usb3 kmod-mmc-mtk kmod-sound-mt7620 \
-	-wpad-basic-mbedtls -uboot-envtools
+	-wpad-basic-mbedtls
 endef
 TARGET_DEVICES += mediatek_ap-mt7621a-v60
 
@@ -2026,7 +2015,7 @@ define Device/mediatek_mt7621-eval-board
   IMAGE_SIZE := 15104k
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7621 EVB
-  DEVICE_PACKAGES := -wpad-basic-mbedtls -uboot-envtools
+  DEVICE_PACKAGES := -wpad-basic-mbedtls
   SUPPORTED_DEVICES += mt7621
 endef
 TARGET_DEVICES += mediatek_mt7621-eval-board
@@ -2050,7 +2039,7 @@ define Device/mercusys_mr70x-v1
   DEVICE_ALT0_VENDOR := MERCUSYS
   DEVICE_ALT0_MODEL := MR1800X
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   TPLINK_BOARD_ID := MR70X
   KERNEL := $(KERNEL_DTB) | uImage lzma
   IMAGE_SIZE := 15744k
@@ -2061,7 +2050,7 @@ define Device/MikroTik
   $(Device/dsa-migration)
   DEVICE_VENDOR := MikroTik
   IMAGE_SIZE := 16128k
-  DEVICE_PACKAGES := kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-usb3
   KERNEL_NAME := vmlinuz
   KERNEL := kernel-bin | append-dtb-elf
   IMAGE/sysupgrade.bin := append-kernel | yaffs-filesystem -L | \
@@ -2126,7 +2115,7 @@ define Device/mqmaker_witi
   DEVICE_VENDOR := MQmaker
   DEVICE_MODEL := WiTi
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mt76x2 kmod-mmc-mtk kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += witi mqmaker,witi-256m mqmaker,witi-512m
 endef
 TARGET_DEVICES += mqmaker_witi
@@ -2139,7 +2128,7 @@ define Device/mtc_wr1201
   DEVICE_MODEL := Wireless Router WR1201
   KERNEL_INITRAMFS := $(KERNEL_DTB) | uImage lzma -n 'WR1201_8_128'
   DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += mtc_wr1201
 
@@ -2170,7 +2159,7 @@ define Device/netgear_eax12
   DEVICE_ALT1_VENDOR := NETGEAR
   DEVICE_ALT1_MODEL := EAX15
   DEVICE_ALT1_VARIANT := v2
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   NETGEAR_ENC_MODEL := EAX12
   NETGEAR_ENC_REGION := US
   NETGEAR_ENC_HW_ID_LIST := 1010000004540000_NETGEAR
@@ -2191,7 +2180,7 @@ define Device/netgear_ex6150
   $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := EX6150
-  DEVICE_PACKAGES := kmod-mt76x2 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt76x2
   NETGEAR_BOARD_ID := U12H318T00_NETGEAR
   IMAGE_SIZE := 14848k
   IMAGES += factory.chk
@@ -2209,8 +2198,7 @@ define Device/netgear_sercomm_nand
   IMAGE/kernel.bin := append-kernel
   IMAGE/rootfs.bin := append-ubi | check-size
   DEVICE_VENDOR := NETGEAR
-  DEVICE_PACKAGES := kmod-mt7603 kmod-usb3 kmod-usb-ledtrig-usbport \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-usb3 kmod-usb-ledtrig-usbport
 endef
 
 define Device/netgear_r6220
@@ -2359,7 +2347,7 @@ define Device/netgear_wax202
   $(Device/nand)
   DEVICE_VENDOR := NETGEAR
   DEVICE_MODEL := WAX202
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   NETGEAR_ENC_MODEL := WAX202
   NETGEAR_ENC_REGION := US
   IMAGE_SIZE := 38912k
@@ -2404,7 +2392,7 @@ define Device/netgear_wndr3700-v5
   SERCOMM_SWVER := 0x1054
   SERCOMM_PAD := 320k
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += wndr3700v5
 endef
 TARGET_DEVICES += netgear_wndr3700-v5
@@ -2438,8 +2426,7 @@ define Device/netis_wf2881
 	check-size
   DEVICE_VENDOR := NETIS
   DEVICE_MODEL := WF2881
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += netis_wf2881
 
@@ -2459,7 +2446,7 @@ define Device/oraybox_x3a
   IMAGE_SIZE := 15360k
   DEVICE_VENDOR := OrayBox
   DEVICE_MODEL := X3A
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += oraybox_x3a
 
@@ -2471,7 +2458,7 @@ define Device/phicomm_k2p
   DEVICE_ALT0_VENDOR := Phicomm
   DEVICE_ALT0_MODEL := KE 2P
   SUPPORTED_DEVICES += k2p
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += phicomm_k2p
 
@@ -2481,7 +2468,7 @@ define Device/planex_vr500
   IMAGE_SIZE := 65216k
   DEVICE_VENDOR := Planex
   DEVICE_MODEL := VR500
-  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-mbedtls -uboot-envtools
+  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-mbedtls
   SUPPORTED_DEVICES += vr500
 endef
 TARGET_DEVICES += planex_vr500
@@ -2504,8 +2491,7 @@ define Device/renkforce_ws-wn530hp3-a
   $(Device/dsa-migration)
   DEVICE_VENDOR := Renkforce
   DEVICE_MODEL := WS-WN530HP3-A
-  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
   IMAGE/sysupgrade.bin := append-kernel | pad-to 65536 | append-rootfs | \
 	check-size | append-metadata
   IMAGE_SIZE := 15040k
@@ -2566,7 +2552,7 @@ define Device/sercomm_na502
   IMAGE_SIZE := 20480k
   DEVICE_VENDOR := SERCOMM
   DEVICE_MODEL := NA502
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-mt7603 kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-mt7603 kmod-usb3
 endef
 TARGET_DEVICES += sercomm_na502
 
@@ -2577,7 +2563,7 @@ define Device/sercomm_na502s
   DEVICE_VENDOR := SERCOMM
   DEVICE_MODEL := NA502S
   DEVICE_PACKAGES := kmod-mt76x2 kmod-mt7603 kmod-usb3 kmod-usb-serial \
-		kmod-usb-serial-xr -uboot-envtools
+		kmod-usb-serial-xr
 endef
 TARGET_DEVICES += sercomm_na502s
 
@@ -2607,8 +2593,7 @@ define Device/snr_snr-cpe-me2-lite
   DEVICE_VENDOR := SNR
   DEVICE_MODEL := SNR-CPE-ME2-Lite
   UIMAGE_NAME := $$(DEVICE_MODEL)
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
 endef
 TARGET_DEVICES += snr_snr-cpe-me2-lite
 
@@ -2631,8 +2616,7 @@ define Device/storylink_sap-g3200u3
   UIMAGE_NAME := SAP-G3200
   DEVICE_VENDOR := STORYLiNK
   DEVICE_MODEL := SAP-G3200U3
-  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += sap-g3200u3
 endef
 TARGET_DEVICES += storylink_sap-g3200u3
@@ -2642,7 +2626,7 @@ define Device/telco-electronics_x1
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Telco Electronics
   DEVICE_MODEL := X1
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7603 kmod-mt76x2 -uboot-envtools
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7603 kmod-mt76x2
 endef
 TARGET_DEVICES += telco-electronics_x1
 
@@ -2651,7 +2635,7 @@ define Device/tenbay_t-mb5eu-v01
   DEVICE_VENDOR := Tenbay
   DEVICE_MODEL := T-MB5EU-V01
   DEVICE_DTS_CONFIG := config@1
-  DEVICE_PACKAGES += kmod-mt7915-firmware kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES += kmod-mt7915-firmware kmod-usb3
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGE_SIZE := 15808k
   SUPPORTED_DEVICES += mt7621-dm2-t-mb5eu-v01-nor
@@ -2664,7 +2648,7 @@ define Device/thunder_timecloud
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := Thunder
   DEVICE_MODEL := Timecloud
-  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-mbedtls -uboot-envtools
+  DEVICE_PACKAGES := kmod-usb3 -wpad-basic-mbedtls
   SUPPORTED_DEVICES += timecloud
 endef
 TARGET_DEVICES += thunder_timecloud
@@ -2675,7 +2659,7 @@ define Device/totolink_a7000r
   UIMAGE_NAME := C8340R1C-9999
   DEVICE_VENDOR := TOTOLINK
   DEVICE_MODEL := A7000R
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
 endef
 TARGET_DEVICES += totolink_a7000r
 
@@ -2685,7 +2669,7 @@ define Device/totolink_x5000r
   UIMAGE_NAME := C8343R-9999
   DEVICE_VENDOR := TOTOLINK
   DEVICE_MODEL := X5000R
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
 endef
 TARGET_DEVICES += totolink_x5000r
 
@@ -2695,7 +2679,7 @@ define Device/tozed_zlt-s12-pro
   IMAGE_SIZE := 16064k
   DEVICE_VENDOR := TOZED
   DEVICE_MODEL := ZLT S12 PRO
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 comgt-ncm -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 comgt-ncm
 endef
 TARGET_DEVICES += tozed_zlt-s12-pro
 
@@ -2704,7 +2688,7 @@ define Device/tplink_archer-ax23-v1
   $(Device/tplink-safeloader)
   DEVICE_MODEL := Archer AX23
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   TPLINK_BOARD_ID := ARCHER-AX23-V1
   KERNEL := $(KERNEL_DTB) | uImage lzma
   IMAGE_SIZE := 15744k
@@ -2717,7 +2701,7 @@ define Device/tplink_archer-a6-v3
   DEVICE_MODEL := Archer A6
   DEVICE_VARIANT := V3
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e \
-	kmod-mt7663-firmware-ap -uboot-envtools
+	kmod-mt7663-firmware-ap
   TPLINK_BOARD_ID := ARCHER-A6-V3
   KERNEL := $(KERNEL_DTB) | uImage lzma
   IMAGE_SIZE := 15744k
@@ -2729,8 +2713,7 @@ define Device/tplink_archer-c6-v3
   $(Device/tplink-safeloader)
   DEVICE_MODEL := Archer C6
   DEVICE_VARIANT := V3
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
   TPLINK_BOARD_ID := ARCHER-C6-V3
   KERNEL := $(KERNEL_DTB) | uImage lzma
   IMAGE_SIZE := 15744k
@@ -2743,7 +2726,7 @@ define Device/tplink_archer-c6u-v1
   DEVICE_MODEL := Archer C6U
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	kmod-usb3 kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb3 kmod-usb-ledtrig-usbport
   KERNEL := $(KERNEL_DTB) | uImage lzma
   TPLINK_BOARD_ID := ARCHER-C6U-V1
   IMAGE_SIZE := 15744k
@@ -2755,8 +2738,7 @@ define Device/tplink_deco-m4r-v4
   $(Device/tplink-safeloader)
   DEVICE_MODEL := Deco M4R
   DEVICE_VARIANT := v4
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
   KERNEL := $(KERNEL_DTB) | uImage lzma
   TPLINK_BOARD_ID := DECO-M4R-V4
   IMAGE_SIZE := 15744k
@@ -2768,8 +2750,7 @@ define Device/tplink_eap235-wall-v1
   $(Device/tplink-safeloader)
   DEVICE_MODEL := EAP235-Wall
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
   TPLINK_BOARD_ID := EAP235-WALL-V1
   IMAGE_SIZE := 13440k
   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory | \
@@ -2782,7 +2763,7 @@ define Device/tplink_eap613-v1
   $(Device/tplink-safeloader)
   DEVICE_MODEL := EAP613
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   TPLINK_BOARD_ID := EAP610-V3
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | pad-to 64k
   KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
@@ -2795,7 +2776,7 @@ define Device/tplink_eap615-wall-v1
   $(Device/tplink-safeloader)
   DEVICE_MODEL := EAP615-Wall
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   TPLINK_BOARD_ID := EAP615-WALL-V1
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | pad-to 64k
   KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
@@ -2836,7 +2817,7 @@ define Device/tplink_er605-v2
   DEVICE_ALT0_VENDOR := TP-Link
   DEVICE_ALT0_MODEL := FR205
   DEVICE_ALT0_VARIANT := v1
-  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := -wpad-basic-mbedtls kmod-usb3
   KERNEL_IN_UBI := 1
   KERNEL_LOADADDR := 0x82000000
   KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
@@ -2850,7 +2831,7 @@ define Device/tplink_ex220-v1
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := EX220
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   TPLINK_BOARD_ID := EX220-V1
   KERNEL_LOADADDR := 0x82000000
   KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
@@ -2866,7 +2847,7 @@ define Device/tplink_mr600-v2-eu
   DEVICE_VARIANT := v2 (EU)
   TPLINK_FLASHLAYOUT := 16Mltq
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-		kmod-usb-net-qmi-wwan uqmi kmod-usb3 -uboot-envtools
+		kmod-usb-net-qmi-wwan uqmi kmod-usb3
   IMAGE/factory.bin := tplink-v2-image -e -a 0x10000
   IMAGE/sysupgrade.bin := tplink-v2-image -s -e -a 0x10000 | check-size | \
 	append-metadata
@@ -2882,7 +2863,7 @@ define Device/tplink_re350-v1
   $(Device/tplink-safeloader)
   DEVICE_MODEL := RE350
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2
   TPLINK_BOARD_ID := RE350-V1
   IMAGE_SIZE := 6016k
   SUPPORTED_DEVICES += re350-v1
@@ -2894,7 +2875,7 @@ define Device/tplink_re500-v1
   $(Device/tplink-safeloader)
   DEVICE_MODEL := RE500
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
   TPLINK_BOARD_ID := RE500-V1
   IMAGE_SIZE := 14208k
 endef
@@ -2905,7 +2886,7 @@ define Device/tplink_re650-v1
   $(Device/tplink-safeloader)
   DEVICE_MODEL := RE650
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
   TPLINK_BOARD_ID := RE650-V1
   IMAGE_SIZE := 14208k
 endef
@@ -2916,7 +2897,7 @@ define Device/tplink_re650-v2
   $(Device/tplink-safeloader)
   DEVICE_MODEL := RE650
   DEVICE_VARIANT := v2
-  DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware
   TPLINK_BOARD_ID := RE650-V2
   IMAGE_SIZE := 7994k
 endef
@@ -2927,8 +2908,7 @@ define Device/tplink_tl-wpa8631p-v3
   $(Device/tplink-safeloader)
   DEVICE_MODEL := TL-WPA8631P
   DEVICE_VARIANT := v3
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
   TPLINK_BOARD_ID := TL-WPA8631P-V3
   IMAGE_SIZE := 7232k
 endef
@@ -2942,7 +2922,7 @@ define Device/ubnt_edgerouter_common
   FILESYSTEMS := squashfs
   KERNEL_SIZE := 6144k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES += -wpad-basic-mbedtls -uboot-envtools
+  DEVICE_PACKAGES += -wpad-basic-mbedtls
   DEVICE_COMPAT_VERSION := 2.0
   DEVICE_COMPAT_MESSAGE :=  Partition table has been changed due to kernel size restrictions. \
     Refer to the wiki page for instructions to migrate to the new layout: \
@@ -2972,7 +2952,7 @@ define Device/ubnt_unifi-6-lite
   DEVICE_MODEL := UniFi U6 Lite
   DEVICE_DTS_CONFIG := config@1
   DEVICE_DTS_LOADADDR := 0x87000000
-  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7915-firmware
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGE_SIZE := 15424k
 endef
@@ -2985,8 +2965,7 @@ define Device/ubnt_unifi-flexhd
   DEVICE_DTS_CONFIG := config@2
   DEVICE_DTS_LOADADDR := 0x87000000
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7615-firmware kmod-leds-ubnt-ledbar \
-	-uboot-envtools
+  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7615-firmware kmod-leds-ubnt-ledbar
   IMAGE_SIZE := 15552k
 endef
 TARGET_DEVICES += ubnt_unifi-flexhd
@@ -2995,7 +2974,7 @@ define Device/ubnt_unifi-nanohd
   $(Device/dsa-migration)
   DEVICE_VENDOR := Ubiquiti
   DEVICE_MODEL := UniFi nanoHD
-  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7615-firmware
   IMAGE_SIZE := 15552k
 endef
 TARGET_DEVICES += ubnt_unifi-nanohd
@@ -3006,7 +2985,6 @@ define Device/ubnt_usw-flex
   DEVICE_MODEL := UniFi Switch Flex
   DEVICE_DTS_CONFIG := config@1
   DEVICE_DTS_LOADADDR := 0x87000000
-  DEVICE_PACKAGES += -uboot-envtools
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGE_SIZE := 14720k
 endef
@@ -3019,7 +2997,7 @@ define Device/unielec_u7621-01-16m
   DEVICE_VENDOR := UniElec
   DEVICE_MODEL := U7621-01
   DEVICE_VARIANT := 16M
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3
 endef
 TARGET_DEVICES += unielec_u7621-01-16m
 
@@ -3031,7 +3009,7 @@ define Device/unielec_u7621-06-16m
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 16M
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	-wpad-basic-mbedtls
   SUPPORTED_DEVICES += u7621-06-256M-16M unielec,u7621-06-256m-16m
 endef
 TARGET_DEVICES += unielec_u7621-06-16m
@@ -3044,7 +3022,7 @@ define Device/unielec_u7621-06-32m
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 32M
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	-wpad-basic-mbedtls
   SUPPORTED_DEVICES += unielec,u7621-06-32m
 endef
 TARGET_DEVICES += unielec_u7621-06-32m
@@ -3057,7 +3035,7 @@ define Device/unielec_u7621-06-64m
   DEVICE_MODEL := U7621-06
   DEVICE_VARIANT := 64M
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-usb3 \
-	-wpad-basic-mbedtls -uboot-envtools
+	-wpad-basic-mbedtls
   SUPPORTED_DEVICES += unielec,u7621-06-512m-64m
 endef
 TARGET_DEVICES += unielec_u7621-06-64m
@@ -3066,7 +3044,7 @@ define Device/wavlink_wl-wn531a6
   $(Device/dsa-migration)
   DEVICE_VENDOR := Wavlink
   DEVICE_MODEL := WL-WN531A6
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-usb3
   IMAGE_SIZE := 15040k
 endef
 TARGET_DEVICES += wavlink_wl-wn531a6
@@ -3076,7 +3054,7 @@ define Device/wavlink_wl-wn533a8
   DEVICE_VENDOR := Wavlink
   DEVICE_MODEL := WL-WN533A8
   KERNEL_INITRAMFS_SUFFIX := -WN533A8$$(KERNEL_SUFFIX)
-  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3
   IMAGE_SIZE := 15040k
 endef
 TARGET_DEVICES += wavlink_wl-wn533a8
@@ -3093,7 +3071,7 @@ define Device/wavlink_ws-wn572hp3-4g
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | check-size | append-metadata
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	kmod-usb3 kmod-usb-net-rndis comgt-ncm -uboot-envtools
+	kmod-usb3 kmod-usb-net-rndis comgt-ncm
 endef
 TARGET_DEVICES += wavlink_ws-wn572hp3-4g
 
@@ -3102,7 +3080,7 @@ define Device/wavlink_wl-wn573hx1
   IMAGE_SIZE := 15808k
   DEVICE_VENDOR := Wavlink
   DEVICE_MODEL := WL-WN573HX1
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   IMAGES += factory.bin
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
 	check-size | append-metadata
@@ -3118,7 +3096,7 @@ define Device/wevo_11acnas
   DEVICE_VENDOR := WeVO
   DEVICE_MODEL := 11AC NAS Router
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += 11acnas
 endef
 TARGET_DEVICES += wevo_11acnas
@@ -3132,7 +3110,7 @@ define Device/wevo_w2914ns-v2
   DEVICE_MODEL := W2914NS
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += w2914nsv2
 endef
 TARGET_DEVICES += wevo_w2914ns-v2
@@ -3162,7 +3140,7 @@ define Device/winstars_ws-wn536p3
   DEVICE_VENDOR := Winstars
   DEVICE_MODEL := WS-WN536P3
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	kmod-usb3 -uboot-envtools
+	kmod-usb3
 endef
 TARGET_DEVICES += winstars_ws-wn536p3
 
@@ -3175,7 +3153,7 @@ define Device/winstars_ws-wn583a6
   DEVICE_ALT0_VENDOR := Gemeita
   DEVICE_ALT0_MODEL := AC2100
   KERNEL_INITRAMFS_SUFFIX := -WN583A6$$(KERNEL_SUFFIX)
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware
 endef
 TARGET_DEVICES += winstars_ws-wn583a6
 
@@ -3185,7 +3163,7 @@ define Device/wodesys_wd-r1802u
   IMAGE_SIZE := 15808k
   DEVICE_VENDOR := Wodesys
   DEVICE_MODEL := WD-R1802U
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
   SUPPORTED_DEVICES += mt7621-rfb-ax-nor
 endef
 TARGET_DEVICES += wodesys_wd-r1802u
@@ -3205,7 +3183,7 @@ define Device/xiaomi_mi-router-3g
   DEVICE_MODEL := Mi Router 3G
   IMAGE_SIZE := 124416k
   DEVICE_PACKAGES += kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += R3G mir3g xiaomi,mir3g
 endef
 TARGET_DEVICES += xiaomi_mi-router-3g
@@ -3217,7 +3195,7 @@ define Device/xiaomi_mi-router-3g-v2
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router 3G
   DEVICE_VARIANT := v2
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2
   SUPPORTED_DEVICES += xiaomi,mir3g-v2
 endef
 TARGET_DEVICES += xiaomi_mi-router-3g-v2
@@ -3252,7 +3230,7 @@ define Device/xiaomi_mi-router-4a-gigabit
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router 4A
   DEVICE_VARIANT := Gigabit Edition
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2
 endef
 TARGET_DEVICES += xiaomi_mi-router-4a-gigabit
 
@@ -3263,8 +3241,7 @@ define Device/xiaomi_mi-router-4a-gigabit-v2
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router 4A
   DEVICE_VARIANT := Gigabit Edition v2
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
 endef
 TARGET_DEVICES += xiaomi_mi-router-4a-gigabit-v2
 
@@ -3272,7 +3249,7 @@ define Device/xiaomi_mi-router-ac2100
   $(Device/xiaomi_nand_separate)
   DEVICE_MODEL := Mi Router AC2100
   IMAGE_SIZE := 120320k
-  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7615-firmware -uboot-envtools
+  DEVICE_PACKAGES += kmod-mt7603 kmod-mt7615-firmware
 endef
 TARGET_DEVICES += xiaomi_mi-router-ac2100
 
@@ -3318,8 +3295,7 @@ define Device/xiaoyu_xy-c5
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := XiaoYu
   DEVICE_MODEL := XY-C5
-  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 -wpad-basic-mbedtls \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-usb3 -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += xiaoyu_xy-c5
 
@@ -3329,7 +3305,7 @@ define Device/xzwifi_creativebox-v1
   DEVICE_VENDOR := CreativeBox
   DEVICE_MODEL := v1
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mt7603 kmod-mt76x2 kmod-mmc-mtk \
-	kmod-usb3 -wpad-basic-mbedtls -uboot-envtools
+	kmod-usb3 -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += xzwifi_creativebox-v1
 
@@ -3339,7 +3315,7 @@ define Device/youhua_wr1200js
   DEVICE_VENDOR := YouHua
   DEVICE_MODEL := WR1200JS
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += youhua_wr1200js
 
@@ -3349,7 +3325,7 @@ define Device/youku_yk-l2
   DEVICE_VENDOR := Youku
   DEVICE_MODEL := YK-L2
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
   UIMAGE_MAGIC := 0x12291000
   UIMAGE_NAME := 400000000000000000003000
 endef
@@ -3360,7 +3336,7 @@ define Device/yuncore_ax820
   IMAGE_SIZE := 15808k
   DEVICE_VENDOR := YunCore
   DEVICE_MODEL := AX820
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
 endef
 TARGET_DEVICES += yuncore_ax820
 
@@ -3370,7 +3346,7 @@ define Device/yuncore_fap640
   IMAGE_SIZE := 15808k
   DEVICE_VENDOR := YunCore
   DEVICE_MODEL := FAP640
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
 endef
 TARGET_DEVICES += yuncore_fap640
 
@@ -3380,7 +3356,7 @@ define Device/yuncore_fap690
   IMAGE_SIZE := 15808k
   DEVICE_VENDOR := YunCore
   DEVICE_MODEL := FAP690
-  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7915-firmware
 endef
 TARGET_DEVICES += yuncore_fap690
 
@@ -3405,7 +3381,7 @@ define Device/z-router_zr-2660
   KERNEL_LOADADDR := 0x82000000
   KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  DEVICE_PACKAGES += kmod-mt7915-firmware kmod-usb3 -uboot-envtools
+  DEVICE_PACKAGES += kmod-mt7915-firmware kmod-usb3
 endef
 TARGET_DEVICES += z-router_zr-2660
 
@@ -3417,8 +3393,7 @@ define Device/zbtlink_zbt-we1326
   DEVICE_MODEL := ZBT-WE1326
   DEVICE_ALT0_VENDOR := Wiflyer
   DEVICE_ALT0_MODEL := WF3526-P
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-mmc-mtk \
-	-uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-mmc-mtk
   SUPPORTED_DEVICES += zbt-we1326
 endef
 TARGET_DEVICES += zbtlink_zbt-we1326
@@ -3430,7 +3405,7 @@ define Device/zbtlink_zbt-we3526
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WE3526
   DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += zbtlink_zbt-we3526
 
@@ -3442,7 +3417,7 @@ define Device/zbtlink_zbt-wg1602-16m
   DEVICE_MODEL := ZBT-WG1602
   DEVICE_VARIANT := 16M
   DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1602-16m
 
@@ -3454,7 +3429,7 @@ define Device/zbtlink_zbt-wg1602-v04-16m
   DEVICE_MODEL := ZBT-WG1602-V04
   DEVICE_VARIANT := 16M
   DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-        kmod-usb-ledtrig-usbport -uboot-envtools
+        kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1602-v04-16m
 
@@ -3466,7 +3441,7 @@ define Device/zbtlink_zbt-wg1602-v04-32m
   DEVICE_MODEL := ZBT-WG1602-V04
   DEVICE_VARIANT := 32M
   DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-        kmod-usb-ledtrig-usbport -uboot-envtools
+        kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1602-v04-32m
 
@@ -3478,8 +3453,7 @@ define Device/zbtlink_zbt-wg1608-16m
   DEVICE_MODEL := ZBT-WG1608
   DEVICE_VARIANT := 16M
   DEVICE_PACKAGES := kmod-mmc-mtk kmod-mt7603 kmod-mt7615e \
-	kmod-mt7663-firmware-ap kmod-usb3 kmod-usb-ledtrig-usbport \
-	-uboot-envtools
+	kmod-mt7663-firmware-ap kmod-usb3 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += zbtlink_zbt-wg1608-16m
 
@@ -3502,7 +3476,7 @@ define Device/zbtlink_zbt-wg2626
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-WG2626
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += zbt-wg2626
 endef
 TARGET_DEVICES += zbtlink_zbt-wg2626
@@ -3515,7 +3489,7 @@ define Device/zbtlink_zbt-wg3526-16m
   DEVICE_MODEL := ZBT-WG3526
   DEVICE_VARIANT := 16M
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 \
-	kmod-usb3 kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb3 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += zbt-wg3526 zbt-wg3526-16M
 endef
 TARGET_DEVICES += zbtlink_zbt-wg3526-16m
@@ -3528,7 +3502,7 @@ define Device/zbtlink_zbt-wg3526-32m
   DEVICE_MODEL := ZBT-WG3526
   DEVICE_VARIANT := 32M
   DEVICE_PACKAGES := kmod-ata-ahci kmod-mmc-mtk kmod-mt7603 kmod-mt76x2 \
-	kmod-usb3 kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb3 kmod-usb-ledtrig-usbport
   SUPPORTED_DEVICES += ac1200pro zbt-wg3526-32M
 endef
 TARGET_DEVICES += zbtlink_zbt-wg3526-32m
@@ -3539,7 +3513,7 @@ define Device/zio_freezio
   DEVICE_VENDOR := ZIO
   DEVICE_MODEL := FREEZIO
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 \
-	kmod-usb-ledtrig-usbport -uboot-envtools
+	kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += zio_freezio
 
@@ -3632,7 +3606,7 @@ define Device/zyxel_wap6805
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := WAP6805
-  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7621-qtn-rgmii -uboot-envtools
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7621-qtn-rgmii
   KERNEL := $$(KERNEL/lzma-loader) | uImage none | uimage-padhdr 160
 endef
 TARGET_DEVICES += zyxel_wap6805

--- a/target/linux/ramips/mt7621/target.mk
+++ b/target/linux/ramips/mt7621/target.mk
@@ -10,7 +10,7 @@ KERNELNAME:=vmlinux vmlinuz
 # make Kernel/CopyImage use $LINUX_DIR/vmlinuz
 IMAGES_DIR:=../../..
 
-DEFAULT_PACKAGES += wpad-basic-mbedtls uboot-envtools kmod-crypto-hw-eip93
+DEFAULT_PACKAGES += kmod-crypto-hw-eip93 wpad-basic-mbedtls
 
 define Target/Description
 	Build firmware images for Ralink MT7621 based boards.


### PR DESCRIPTION
Since commits from PR https://github.com/openwrt/openwrt/pull/12959 have fixed initramfs images, including correctly DEVICE_PACKAGES per device. This includes images generated by builbots, that is, using a config with:

 CONFIG_TARGET_MULTI_PROFILE=y
 CONFIG_TARGET_ALL_PROFILES=y
 CONFIG_TARGET_PER_DEVICE_ROOTFS=y

So, do not abuse of DEFAULT_PACKAGES anymore. I propose:
-Manually revert commit 79bd017 plus,
-Manually checking all new devices that have been added support since then(March 2023), for example following this git history: https://github.com/openwrt/openwrt/commits/main/package/boot/uboot-tools/uboot-envtools/files/ramips

Remove "uboot-envtools" from target.mk's DEFAULT_PACKAGES, remove about 158 occurrences of "-uboot-envtools" from DEVICE_PACKAGES and include 41 "uboot-envtools" only in the required recipes, approximately 50 devices (some of them use shared recipes).

While at here, make some clean up:
-wrap/unwrap lines to 80 characters,
-align indentations and
-sort the packages defined in DEVICE_PACKAGES alphabetically.

I've split the changes just trying to make easier the review. If it is better to only do the additions and removals of the package and do not change anything else, please, tell me.

-The indentations are mixed, two spaces but tabulations for the line wrappings. It seems a common practice with makefiles, Is it correct?
-Which max line size is preferred 80, 100?(I read about 80 characters limit being deprecated upstream)
-Should the packages in the DEVICE_PACKAGES lists be sorted alphabetically?

PS: My original intention was to fix the issue of some devices not including uboot-envtools (some Xiaomi devices using a shared recipe, ie:R3Gv1)

Fixes: 79bd017 ("mt7621: move uboot-envtools to DEFAULT_PACKAGES")
Fixes: https://github.com/openwrt/openwrt/issues/18960 ramips: mt7621: uboot-envtools is not included in some devices like Xiaomi R3Gv1