### PR TITLE
base-files: MAJOR/MINOR not sequential, use DISKSEQ instead

### DIFF
--- a/target/linux/stm32/base-files/lib/upgrade/platform.sh
+++ b/target/linux/stm32/base-files/lib/upgrade/platform.sh
@@ -31,8 +31,7 @@ export_bootdevice() {
 		while read line; do
 			export -n "$line"
 		done < "$uevent"
-		export BOOTDEV_MAJOR=$MAJOR
-		export BOOTDEV_MINOR=$MINOR
+		export BOOTDEV_DISKSEQ=$DISKSEQ
 		return 0
 	fi
 


### PR DESCRIPTION
```
Export the unique, monotonic DISKSEQ sequence drive number instead of its
major/minor numbers to identify the boot disk and directly match the partition
in export_partdevice with PARTN.

The MINOR blockdevice numbers are not guaranteed sequential across disks, it
can happen that disks enumerate before their partitions are probed, resulting
in interleaved MINOR numbers breaking the partition offset calculation:

major minor  #blocks  name
259        0  250059096 nvme0n1
259        2       8192 nvme0n1p1
259        3     491520 nvme0n1p2
259        4        239 nvme0n1p128
259        1  250059096 nvme1n1
259        5  250057728 nvme1n1p1

Signed-off-by: Clemens Hopfer <openwrt@wireloss.net>
```