### PR TITLE
uboot-mk: Enable specifying defconfig fragments

### DIFF
--- a/include/u-boot.mk
+++ b/include/u-boot.mk
@@ -111,7 +111,11 @@ define Build/U-Boot/Target
 endef
 
 define Build/Configure/U-Boot
-	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) CROSS_COMPILE=$(TARGET_CROSS) $(UBOOT_CONFIGURE_VARS) $(UBOOT_CONFIG)_config
+	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
+		CROSS_COMPILE=$(TARGET_CROSS) \
+		$(UBOOT_CONFIGURE_VARS) \
+		$(firstword $(UBOOT_CONFIG))_config \
+		$(wordlist 2,$(words $(UBOOT_CONFIG)),$(UBOOT_CONFIG:%=%.config))
 	$(if $(strip $(UBOOT_CUSTOMIZE_CONFIG)),
 		$(PKG_BUILD_DIR)/scripts/config --file $(PKG_BUILD_DIR)/.config $(UBOOT_CUSTOMIZE_CONFIG)
 		+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) CROSS_COMPILE=$(TARGET_CROSS) $(UBOOT_CONFIGURE_VARS) oldconfig)


### PR DESCRIPTION
U-Boot allows specifying additional KConfig fragments to be applied on
top of a defconfig. These are usually located in the board
sub-directory.

    make foo_defconfig bar.config baz.config

Add support for specifying additional KConfig fragments using the
UBOOT_CONFIG variable. Treat the first word in UBOOT_CONFIG as the name
of the defconfig, any additional words as additional fragments.

This can be useful to distinguish between different variants of U-Boot
builds such as different RAM, storage (NAND/eMMC), security etc.

While c05c0699d479 (u-boot.mk: add support for config customization,
2023-06-02) already added means to modify specific KConfig options
directly from the OpenWrt Makefile, leveraging existing fragments the
U-Boot source-dir provides a more convenient way to extend the config
when customising more than just one or two options. Furthermore it is
desirable to leverage existing fragments from upstream U-Boot where they
exist.