### PR TITLE
base-files: ignore initscript output in sysupgrade

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -273,7 +273,7 @@ create_backup_archive() {
 
 		if [ $ret -eq 0 ]; then
 			for service in /etc/init.d/*; do
-				if ! $service enabled; then
+				if ! $service enabled >/dev/null 2>&1; then
 				disabled="$disabled$service disable\n"
 				fi
 			done


### PR DESCRIPTION
Suppress output from `/etc/init.d/service enabled` to avoid corrupting of the sysupgrade tarball.
