### PR TITLE
[24.10] generic: backport bcm63xx SPI reset fix

### DIFF
--- a/target/linux/generic/backport-6.6/421-01-v6.16-spi-bcm63xx-spi-fix-shared-reset.patch
+++ b/target/linux/generic/backport-6.6/421-01-v6.16-spi-bcm63xx-spi-fix-shared-reset.patch
@@ -1,0 +1,32 @@
+From 5ad20e3d8cfe3b2e42bbddc7e0ebaa74479bb589 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Thu, 29 May 2025 15:09:14 +0200
+Subject: [PATCH] spi: bcm63xx-spi: fix shared reset
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some bmips SoCs (bcm6362, bcm63268) share the same SPI reset for both SPI
+and HSSPI controllers, so reset shouldn't be exclusive.
+
+Fixes: 38807adeaf1e ("spi: bcm63xx-spi: add reset support")
+Reported-by: Jonas Gorski <jonas.gorski@gmail.com>
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
+Link: https://patch.msgid.link/20250529130915.2519590-2-noltari@gmail.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ drivers/spi/spi-bcm63xx.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/spi/spi-bcm63xx.c
++++ b/drivers/spi/spi-bcm63xx.c
+@@ -523,7 +523,7 @@ static int bcm63xx_spi_probe(struct plat
+ 		return PTR_ERR(clk);
+ 	}
+ 
+-	reset = devm_reset_control_get_optional_exclusive(dev, NULL);
++	reset = devm_reset_control_get_optional_shared(dev, NULL);
+ 	if (IS_ERR(reset))
+ 		return PTR_ERR(reset);
+ 

--- a/target/linux/generic/backport-6.6/421-02-v6.16-spi-bcm63xx-hsspi-fix-shared-reset.patch
+++ b/target/linux/generic/backport-6.6/421-02-v6.16-spi-bcm63xx-hsspi-fix-shared-reset.patch
@@ -1,0 +1,32 @@
+From 3d6d84c8f2f66d3fd6a43a1e2ce8e6b54c573960 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Thu, 29 May 2025 15:09:15 +0200
+Subject: [PATCH] spi: bcm63xx-hsspi: fix shared reset
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some bmips SoCs (bcm6362, bcm63268) share the same SPI reset for both SPI
+and HSSPI controllers, so reset shouldn't be exclusive.
+
+Fixes: 0eeadddbf09a ("spi: bcm63xx-hsspi: add reset support")
+Reported-by: Jonas Gorski <jonas.gorski@gmail.com>
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
+Link: https://patch.msgid.link/20250529130915.2519590-3-noltari@gmail.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ drivers/spi/spi-bcm63xx-hsspi.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/spi/spi-bcm63xx-hsspi.c
++++ b/drivers/spi/spi-bcm63xx-hsspi.c
+@@ -745,7 +745,7 @@ static int bcm63xx_hsspi_probe(struct pl
+ 	if (IS_ERR(clk))
+ 		return PTR_ERR(clk);
+ 
+-	reset = devm_reset_control_get_optional_exclusive(dev, NULL);
++	reset = devm_reset_control_get_optional_shared(dev, NULL);
+ 	if (IS_ERR(reset))
+ 		return PTR_ERR(reset);
+ 


### PR DESCRIPTION
Fixes SPI and HSSPI coexistance on bmips bcm6362 and bcm63268.

(cherry picked from commit ba1017bf74a6735a23d8873623fb48b42d831c56)