### PR TITLE
Add variable for x86 partition alignment

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -220,6 +220,19 @@ menu "Target Images"
 		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
 		default y
 
+	config ALIGN_SIZE
+		int "Partition Aignment Size (in kB)"
+		depends on GRUB_IMAGES || GRUB_EFI_IMAGES
+		default 256
+		help
+		  Define the partition alignment value to pass to ptgen at image creation.
+		  Many SSD devices and Advanced Format drives are known to suffer performance
+		  problems if partitions are not aligned properly for their internal data
+		  structures.
+		    256 kB will start the partitions at block 512
+		    1024 kB will start the partitions at block 2048
+		    and so on.
+
 	config GRUB_BAUDRATE
 		int "Serial port baud rate"
 		depends on GRUB_IMAGES || GRUB_EFI_IMAGES

--- a/target/linux/armsr/image/Makefile
+++ b/target/linux/armsr/image/Makefile
@@ -46,7 +46,7 @@ define Build/combined
 		$@ \
 		$(CONFIG_TARGET_KERNEL_PARTSIZE) $@.boot \
 		$(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS) \
-		256
+		$(CONFIG_ALIGN_SIZE)
 endef
 
 define Build/grub-config

--- a/target/linux/loongarch64/image/Makefile
+++ b/target/linux/loongarch64/image/Makefile
@@ -44,7 +44,7 @@ define Build/combined
 		$@ \
 		$(CONFIG_TARGET_KERNEL_PARTSIZE) $@.boot \
 		$(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS) \
-		256
+		$(CONFIG_ALIGN_SIZE)
 endef
 
 define Build/grub-config

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -49,7 +49,7 @@ define Build/combined
 		$@ \
 		$(CONFIG_TARGET_KERNEL_PARTSIZE) $@.boot \
 		$(CONFIG_TARGET_ROOTFS_PARTSIZE) $(IMAGE_ROOTFS) \
-		256
+		$(CONFIG_ALIGN_SIZE)
 endef
 
 define Build/grub-config


### PR DESCRIPTION
This PR adds a new variable to allow the user to select a starting block for the kernel and rootfs partitions. If none is defined the default value (currently hard-coded) will be used. Affected flavors include: armsr, loongarch64, and x86.

Rationale is that SSDs operate on physical block sizes (e.g., 4KB or larger), and misaligned partitions can cause a single logical write to span multiple physical blocks, reducing performance and increasing wear. To address this, tools like fdisk, gdisk, parted etc. have been defaulted to align partitions to start at block 2048 for quite some time.

