### PR TITLE
gmp: fix compilation with GCC 15.1

### DIFF
--- a/package/libs/gmp/Makefile
+++ b/package/libs/gmp/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gmp
 PKG_VERSION:=6.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/gmp/

--- a/package/libs/gmp/patches/001-acinclude-m4-fix-std23.patch
+++ b/package/libs/gmp/patches/001-acinclude-m4-fix-std23.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Marc Glisse <marc.glisse@inria.fr>
+# Date 1738186682 -3600
+#      Wed Jan 29 22:38:02 2025 +0100
+# Node ID 8e7bb4ae7a18b1405ea7f9cbcda450b7d920a901
+# Parent  e84c5c785bbe8ed8c3620194e50b65adfc2f5d83
+Complete function prototype in acinclude.m4 for C23 compatibility
+
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@ GMP_PROG_CC_WORKS_PART([$1], [long long
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(){}
++void g(int,t1 const*,t1,t2,t1 const*,int){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}

--- a/package/libs/gmp/patches/002-acinclude-m4-add-parameter-names.patch
+++ b/package/libs/gmp/patches/002-acinclude-m4-add-parameter-names.patch
@@ -1,0 +1,22 @@
+# HG changeset patch
+# User Marc Glisse <marc.glisse@inria.fr>
+# Date 1743513946 -7200
+#      Tue Apr 01 15:25:46 2025 +0200
+# Node ID d66d66d82dbbe4f561920d28c1e1cbe6818452c7
+# Parent  1a2ad0e32507e842486c8ac9d5cdc772fd0c335e
+Add parameter names to function prototype
+
+ 2025-02-01  Marc Glisse <marc.glisse@inria.fr>
+ 
+ 	* longlong.h (loongarch64 umul_ppmm): __int128__ -> __int128.
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -609,7 +609,7 @@ GMP_PROG_CC_WORKS_PART([$1], [long long
+ 
+ #if defined (__GNUC__) && ! defined (__cplusplus)
+ typedef unsigned long long t1;typedef t1*t2;
+-void g(int,t1 const*,t1,t2,t1 const*,int){}
++void g(int a,t1 const*b,t1 c,t2 d,t1 const*e,int f){}
+ void h(){}
+ static __inline__ t1 e(t2 rp,t2 up,int n,t1 v0)
+ {t1 c,x,r;int i;if(v0){c=1;for(i=1;i<n;i++){x=up[i];r=x+1;rp[i]=r;}}return c;}


### PR DESCRIPTION
Apply same patches to gmp on the host side to fix GCC 15 build errors.

https://github.com/openwrt/openwrt/commit/31800db91d43042813b7249a09fd61c356b39767