### PR TITLE
wifi-scripts: fix calculation for eht_oper_centr_freq_seg0_idx

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -272,7 +272,7 @@ function device_htmode_append(config) {
 			];
 
 			for (let k, v in eht_center_seg0_map)
-				if (v[0] <= config.channel) {
+				if (config.channel <= v[0]) {
 					config.eht_oper_centr_freq_seg0_idx = v[1];
 					break;
 				}


### PR DESCRIPTION
Inverted condition caused wrong value for eht_oper_centr_freq_seg0_idx get selected in ETH320 mode, causing AP fail to start.