### PR TITLE
kernel: allow kmod packages to specify add'l CFLAGS

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -105,7 +105,7 @@ endif
 KERNEL_MAKE = $(MAKE) $(KERNEL_MAKEOPTS)
 
 KERNEL_MAKE_FLAGS = \
-	KCFLAGS="$(call iremap,$(BUILD_DIR),$(notdir $(BUILD_DIR))) $(filter-out -fno-plt,$(call qstrip,$(CONFIG_EXTRA_OPTIMIZATION))) $(call qstrip,$(CONFIG_KERNEL_CFLAGS))" \
+	KCFLAGS="$(call iremap,$(BUILD_DIR),$(notdir $(BUILD_DIR))) $(filter-out -fno-plt,$(call qstrip,$(CONFIG_EXTRA_OPTIMIZATION))) $(call qstrip,$(CONFIG_KERNEL_CFLAGS)) $(call qstrip,$(KERNEL_EXTRACFLAGS))" \
 	HOSTCFLAGS="$(HOST_CFLAGS) -Wall -Wmissing-prototypes -Wstrict-prototypes" \
 	CROSS_COMPILE="$(KERNEL_CROSS)" \
 	ARCH="$(LINUX_KARCH)" \


### PR DESCRIPTION
Sometimes a kernel module is stable but not updated to the latest toolchain, and subsequent gcc updates might choke on it. This change permits a kmod package to specify additional options, such as turning off -Wall -Werror settings that are preventing it from compiling.
