### PR TITLE
qualcommax: ipq50xx: Add support for Xiaomi AX6000

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
@@ -7,6 +7,18 @@ touch /etc/config/ubootenv
 
 board=$(board_name)
 
+ubootenv_add_mtd() {
+	local idx="$(find_mtd_index "${1}")"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_config "/dev/mtd$idx" "${2}" "${3}" "${4}"
+}
+
+ubootenv_add_sys_mtd() {
+	local idx="$(find_mtd_index "${1}")"
+	[ -n "$idx" ] && \
+		ubootenv_add_uci_sys_config "/dev/mtd$idx" "${2}" "${3}" "${4}"
+}
+
 case "$board" in
 elecom,wrc-x3000gs2|\
 iodata,wn-dax3000gr)
@@ -26,6 +38,10 @@ linksys,spnmx56)
 	idx="$(find_mtd_index u_env)"
 	[ -n "$idx" ] && \
 		ubootenv_add_uci_config "/dev/mtd$idx" "0x0" "0x40000" "0x20000"
+	;;
+xiaomi,ax6000)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x20000"
+	ubootenv_add_sys_mtd "bdata" "0x0" "0x10000" "0x20000"
 	;;
 esac
 

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -79,6 +79,7 @@ ALLWIFIBOARDS:= \
 	tplink_archer-c6-v2 \
 	wallys_dr40x9 \
 	xiaomi_ax3600 \
+	xiaomi_ax6000 \
 	xiaomi_ax9000 \
 	yyets_le1 \
 	yuncore_ax880 \
@@ -235,6 +236,7 @@ $(eval $(call generate-ipq-wifi-package,tplink_eap660hd-v1,TP-Link EAP660 HD v1)
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c6-v2,TP-Link Archer C6 V2))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))
+$(eval $(call generate-ipq-wifi-package,xiaomi_ax6000,Xiaomi AX6000))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax9000,Xiaomi AX9000))
 $(eval $(call generate-ipq-wifi-package,yyets_le1,YYeTs LE1))
 $(eval $(call generate-ipq-wifi-package,yuncore_ax880,Yuncore AX880))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
@@ -1,0 +1,642 @@
+/dts-v1/;
+
+#include "ipq5018.dtsi"
+#include "ipq5018-ess.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Xiaomi AX6000";
+	compatible = "xiaomi,ax6000", "qcom,ipq5018";
+
+	aliases {
+		label-mac-device = &dp1;
+		led-boot = &led_system_blue;
+		led-failsafe = &led_system_yellow;
+		led-running = &led_system_blue;
+		led-upgrade = &led_system_yellow;
+		serial0 = &blsp1_uart1;
+	};
+
+	chosen {
+		/* Xiaomi's U-boot sets bootargs to:
+		 * ubi.mtd=rootfs_1 root=mtd:ubi_rootfs rootfstype=squashfs rootwait uart_en=1
+		 * so we need to override and set ubi.mtd=rootfs
+		 */
+		bootargs-append = " ubi.mtd=rootfs root=/dev/ubiblock0_0 coherent_pool=2M";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset-button {
+			label = "reset";
+			gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-0 = <&leds_pins>;
+		pinctrl-names = "default";
+
+		led_wlan_green: wlan-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			gpio = <&tlmm 23 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_system_blue: system-blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpio = <&tlmm 24 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_system_yellow: system-yellow {
+			color = <LED_COLOR_ID_YELLOW>;
+			function = LED_FUNCTION_POWER;
+			gpio = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_net_blue: net-blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN_ONLINE;
+			gpio = <&tlmm 26 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_net_yellow: net-yellow {
+			color = <LED_COLOR_ID_YELLOW>;
+			function = LED_FUNCTION_WAN;
+			gpio = <&tlmm 27 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_phy_green: phy-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			gpio = <&tlmm 28 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	reserved-memory {
+		q6_mem_regions: q6_mem_regions@4b000000 {
+			no-map;
+			reg = <0x0 0x4b000000 0x0 0x3000000>;
+		};
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&xo_board_clk {
+	clock-frequency = <24000000>;
+};
+
+&blsp1_uart1 {
+	status = "okay";
+
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qfprom {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	pinctrl-0 = <&qpic_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		nand-ecc-engine = <&qpic_nand>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:sbl1";
+				reg = <0x00000000 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "0:mibib";
+				reg = <0x00080000 0x80000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "0:bootconfig";
+				reg = <0x00100000 0x40000>;
+				read-only;
+			};
+
+			partition@140000 {
+				label = "0:bootconfig1";
+				reg = <0x00140000 0x40000>;
+				read-only;
+			};
+
+			partition@180000 {
+				label = "0:qsee";
+				reg = <0x00180000 0x100000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "0:qsee_1";
+				reg = <0x00280000 0x100000>;
+				read-only;
+			};
+
+			partition@380000 {
+				label = "0:devcfg";
+				reg = <0x00380000 0x40000>;
+				read-only;
+			};
+
+			partition@3c0000 {
+				label = "0:devcfg_1";
+				reg = <0x003c0000 0x40000>;
+				read-only;
+			};
+
+			partition@400000 {
+				label = "0:cdt";
+				reg = <0x00400000 0x40000>;
+				read-only;
+			};
+
+			partition@440000 {
+				label = "0:cdt_1`";
+				reg = <0x00440000 0x40000>;
+				read-only;
+			};
+
+			partition@480000 {
+				label = "0:appsblenv";
+				reg = <0x00480000 0x80000>;
+			};
+
+			partition@500000 {
+				label = "0:appsbl";
+				reg = <0x00500000 0x140000>;
+				read-only;
+			};
+
+			partition@640000 {
+				label = "0:appsbl_1";
+				reg = <0x00640000 0x140000>;
+				read-only;
+			};
+
+			partition@780000 {
+				label = "0:art";
+				reg = <0x00780000 0x100000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					mac_addr_dp1: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					mac_addr_dp2: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+
+					caldata_qca9889: caldata@4d000 {
+						reg = <0x4d000 0x844>;
+					};
+				};
+			};
+
+			partition@880000 {
+				label = "0:training";
+				reg = <0x00880000 0x80000>;
+				read-only;
+			};
+
+			partition@900000 {
+				label = "bdata";
+				reg = <0x00900000 0x80000>;
+			};
+
+			partition@980000 {
+				label = "crash";
+				reg = <0x00980000 0x80000>;
+			};
+
+			partition@a00000 {
+				label = "crash_syslog";
+				reg = <0x00a00000 0x80000>;
+			};
+
+			partition@a80000 {
+				label = "ubi_kernel";
+				reg = <0x00a80000 0x2400000>;
+			};
+
+			partition@2e80000 {
+				label = "rootfs";
+				reg = <0x02e80000 0x5180000>;
+			};
+		};
+	};
+};
+
+/*
+* =================================================================
+*     _______________________             _______________________
+*    |        IPQ5018        |           |        QCA8337        |
+*    | +------+   +--------+ |           | +--------+   +------+ |
+*    | | MAC0 |---| GE Phy |-+--- MDI ---+ | Phy3   |---| MAC4 | |
+*    | +------+   +--------+ |           | +--------+   +------+ |
+*    |                       |           |_______________________|
+*    |                       |            _______________________
+*    |                       |           |        QCA8081        |
+*    | +------+   +--------+ |           | +-------------------+ |
+*    | | MAC1 |---| Uniphy |-+-- SGMII+--+ |        Phy        | |
+*    | +------+   +--------+ |           | +-------------------+ |
+*    |_______________________|           |_______________________|
+*
+* =================================================================
+*/
+
+&switch {
+	status = "okay";
+
+	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
+
+	qcom,port_phyinfo {
+		// MAC0 -> GE Phy --- MDI --- QCA8337 Switch
+		port@0 {
+			port_id = <1>;
+			mdiobus = <&mdio0>;
+			phy_address = <7>;
+			phy_dac = <0x10 0x10>;
+		};
+
+		// MAC1 -> Uniphy --- SGMII --- QCA8081
+		port@1 {
+			port_id = <2>;
+			mdiobus = <&mdio1>;
+			phy_address = <8>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+// MAC0 -> GE Phy
+&dp1 {
+	status = "okay";
+
+	nvmem-cells = <&mac_addr_dp1 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+// MAC1 ---SGMII---> QCA8081
+&dp2 {
+	status = "okay";
+
+	label = "wan";
+	phy-handle = <&qca8081>;
+	nvmem-cells = <&mac_addr_dp2 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+// IPQ5018 GE Phy -> QCA8337 PHY0
+&ge_phy {
+	qcom,dac-preset-short-cable;
+};
+
+&mdio1 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio1_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 39 GPIO_ACTIVE_LOW>;
+
+	// QCA8337 Phy0 -> LAN1
+	qca8337_0: ethernet-phy@0 {
+		reg = <0>;
+	};
+
+	// QCA8337 Phy1 -> LAN2
+	qca8337_1: ethernet-phy@1 {
+		reg = <1>;
+	};
+
+	// QCA8337 Phy2 -> LAN3
+	qca8337_2: ethernet-phy@2 {
+		reg = <2>;
+	};
+
+	// QCA8337 Phy3 -> IPQ5018 GE Phy
+	qca8337_3: ethernet-phy@3 {
+		reg = <3>;
+	};
+
+	// QCA8081 Phy -> WAN
+	qca8081: ethernet-phy@8 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <8>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+				default-state = "keep";
+			};
+		};
+	};
+
+	// QCA8337 switch
+	ethernet-switch@11 {
+		compatible = "qca,qca8337";
+		reg = <17>;
+
+		ports {
+			port@1 {
+				reg = <1>;
+				label = "lan1";
+				phy-handle = <&qca8337_0>;
+
+				leds {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					led@0 {
+						reg = <0>;
+						color = <LED_COLOR_ID_GREEN>;
+						function = LED_FUNCTION_LAN;
+						default-state = "keep";
+					};
+				};
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+				phy-handle = <&qca8337_1>;
+
+				leds {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					led@0 {
+						reg = <0>;
+						color = <LED_COLOR_ID_GREEN>;
+						function = LED_FUNCTION_LAN;
+						default-state = "keep";
+					};
+				};
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan3";
+				phy-handle = <&qca8337_2>;
+
+				leds {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					led@0 {
+						reg = <0>;
+						color = <LED_COLOR_ID_GREEN>;
+						function = LED_FUNCTION_LAN;
+						default-state = "keep";
+					};
+				};
+			};
+
+			port@4 {
+				reg = <4>;
+				phy-handle = <&qca8337_3>;
+				phy-mode = "gmii";
+				ethernet = <&dp1>;
+			};
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		pins = "gpio38";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+
+	leds_pins: leds-state {
+		pins = "gpio23", "gpio24", "gpio25",
+		       "gpio26", "gpio27", "gpio28";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	mdio1_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio36";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio37";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	qpic_pins: qpic-state {
+		clock-pins {
+			pins = "gpio9";
+			function = "qspi_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		cs-pins {
+			pins = "gpio8";
+			function = "qspi_cs";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		data-pins {
+			pins = "gpio4", "gpio5", "gpio6", "gpio7";
+			function = "qspi_data";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	serial_0_pins: uart0-state {
+		pins = "gpio20", "gpio21";
+		function = "blsp0_uart0";
+		bias-disable;
+	};
+};
+
+&tsens {
+	status = "okay";
+};
+
+&pcie0_phy {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpios = <&tlmm 15 GPIO_ACTIVE_LOW>;
+
+	pcie@0 {
+		wifi@0,0 {
+			status = "okay";
+
+			/* QCN9074: ath11k lacks DT compatible for PCI cards */
+			compatible = "pci17cb,1104";
+			reg = <0x00010000 0 0 0 0>;
+
+			qcom,ath11k-calibration-variant = "Xiaomi-AX6000";
+		};
+	};
+};
+
+&pcie1_phy {
+	status = "okay";
+};
+
+&pcie1 {
+	/*
+	 * although the pcie1 phy probes successfully, the controller is unable
+	 * to bring it up. So let's disable it until a solution is found.
+	 */
+	status = "disbled";
+
+	perst-gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+
+	pcie@0 {
+		wifi@0,0 {
+			status = "okay";
+
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+
+			qcom,ath10k-calibration-variant = "Xiaomi-AX6000";
+			nvmem-cell-names = "calibration";
+			nvmem-cells = <&caldata_qca9889>;
+		};
+	};
+};
+
+&q6v5_wcss {
+	status = "okay";
+
+	memory-region = <&q6_mem_regions>;
+	firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt",
+			"ath11k/IPQ5018/hw1.0/m3_fw.mdt";
+
+	// IPQ5018
+	q6_wcss_pd1: pd-1 {
+		firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt";
+
+		resets =
+			<&gcc GCC_WCSSAON_RESET>,
+			<&gcc GCC_WCSS_BCR>,
+			<&gcc GCC_CE_BCR>;
+		reset-names =
+			"wcss_aon_reset",
+			"wcss_reset",
+			"ce_reset";
+
+		clocks =
+			<&gcc GCC_WCSS_AHB_S_CLK>,
+			<&gcc GCC_WCSS_ACMT_CLK>,
+			<&gcc GCC_WCSS_AXI_M_CLK>;
+		clock-names =
+			"gcc_wcss_ahb_s_clk",
+			"gcc_wcss_acmt_clk",
+			"gcc_wcss_axi_m_clk";
+
+		interrupts-extended =
+			<&wcss_smp2p_in 8 0>,
+			<&wcss_smp2p_in 9 0>,
+			<&wcss_smp2p_in 12 0>,
+			<&wcss_smp2p_in 11 0>;
+		interrupt-names =
+			"fatal",
+			"ready",
+			"spawn-ack",
+			"stop-ack";
+
+		qcom,smem-states =
+			<&wcss_smp2p_out 8>,
+			<&wcss_smp2p_out 9>,
+			<&wcss_smp2p_out 10>;
+		qcom,smem-state-names =
+			"shutdown",
+			"stop",
+			"spawn";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+
+	qcom,rproc = <&q6_wcss_pd1>;
+	qcom,ath11k-calibration-variant = "Xiaomi-AX6000";
+	qcom,ath11k-fw-memory-mode = <1>;
+	qcom,bdf-addr = <0x4c400000>;
+};

--- a/target/linux/qualcommax/image/ipq50xx.mk
+++ b/target/linux/qualcommax/image/ipq50xx.mk
@@ -127,3 +127,26 @@ define Device/linksys_spnmx56
 		ipq-wifi-linksys_spnmx56
 endef
 TARGET_DEVICES += linksys_spnmx56
+
+define Device/xiaomi_ax6000
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Xiaomi
+	DEVICE_MODEL := AX6000
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_DTS_CONFIG := config@mp03.1
+	SOC := ipq5018
+	KERNEL_SIZE := 36864k
+	NAND_SIZE := 128m
+	DEVICE_PACKAGES := kmod-ath11k-pci \
+		ath11k-firmware-qcn9074 \
+		kmod-ath10k-ct-smallbuffers \
+		ath10k-firmware-qca9887-ct \
+		ipq-wifi-xiaomi_ax6000
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+	ARTIFACTS := initramfs-factory.ubi
+	ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-uImage.itb | ubinize-kernel
+endif
+endef
+TARGET_DEVICES += xiaomi_ax6000

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/01_leds
@@ -25,6 +25,14 @@ linksys,mr5500)
 	ucidef_set_led_netdev "wan-port-link" "WAN-PORT-LINK" "qca8k-0.0:04:green:wan" "wan" "link_10 link_100 link_1000"
 	ucidef_set_led_netdev "wan-port-activity" "WAN-PORT-ACTIVITY" "qca8k-0.0:04:amber:wan" "wan" "tx rx"
 	;;
+xiaomi,ax6000)
+	ucidef_set_led_netdev "lan1-port-link" "LAN1-PORT-LINK" "90000.mdio-1:00:green:lan" "lan1" "tx rx link_10 link_100 link_1000"
+	ucidef_set_led_netdev "lan2-port-link" "LAN2-PORT-LINK" "90000.mdio-1:01:green:lan" "lan2" "tx rx link_10 link_100 link_1000"
+	ucidef_set_led_netdev "lan3-port-link" "LAN3-PORT-LINK" "90000.mdio-1:02:green:lan" "lan3" "tx rx link_10 link_100 link_1000"
+	ucidef_set_led_netdev "wan-port-link" "WAN-PORT-LINK" "90000.mdio-1:08:green:wan" "wan" "tx rx link_10 link_100 link_1000 link_2500"
+	ucidef_set_led_netdev "wan-port-link-top-blue" "WAN-PORT-LINK-TOP-BLUE" "blue:wan" "wan" "link_1000 link_2500"
+	ucidef_set_led_netdev "wan-port-link-top-yellow" "WAN-PORT-LINK-TOP-YELLOW" "yellow:wan" "wan" "link_10 link_100"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
@@ -17,7 +17,8 @@ ipq50xx_setup_interfaces()
 		;;
 	linksys,mx2000|\
 	linksys,mx5500|\
-	linksys,spnmx56)
+	linksys,spnmx56|\
+	xiaomi,ax6000)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
 	esac

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -31,6 +31,9 @@ case "$FIRMWARE" in
 		ath11k_remove_regdomain
 		ath11k_set_macflag
 		;;
+	xiaomi,ax6000)
+		caldata_extract "0:art" 0x1000 0x20000
+		;;
 	esac
 	;;
 "ath11k/QCN6122/hw1.0/cal-ahb-b00a040.wifi1.bin")
@@ -66,6 +69,9 @@ case "$FIRMWARE" in
 		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
 		ath11k_remove_regdomain
 		ath11k_set_macflag
+		;;
+	xiaomi,ax6000)
+		caldata_extract "0:art" 0x26800 0x20000
 		;;
 	esac
 	;;

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
@@ -4,6 +4,29 @@ REQUIRE_IMAGE_METADATA=1
 RAMFS_COPY_BIN='dumpimage fw_printenv fw_setenv head seq'
 RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
+xiaomi_initramfs_prepare() {
+	# Wipe UBI if running initramfs
+	[ "$(rootfs_type)" = "tmpfs" ] || return 0
+
+	local rootfs_mtdnum="$( find_mtd_index rootfs )"
+	if [ ! "$rootfs_mtdnum" ]; then
+		echo "unable to find mtd partition rootfs"
+		return 1
+	fi
+
+	local kern_mtdnum="$( find_mtd_index ubi_kernel )"
+	if [ ! "$kern_mtdnum" ]; then
+		echo "unable to find mtd partition ubi_kernel"
+		return 1
+	fi
+
+	ubidetach -m "$rootfs_mtdnum"
+	ubiformat /dev/mtd$rootfs_mtdnum -y
+
+	ubidetach -m "$kern_mtdnum"
+	ubiformat /dev/mtd$kern_mtdnum -y
+}
+
 remove_oem_ubi_volume() {
 	local oem_volume_name="$1"
 	local oem_ubivol
@@ -69,6 +92,14 @@ platform_check_image() {
 	return 0;
 }
 
+platform_pre_upgrade() {
+	case "$(board_name)" in
+	xiaomi,ax6000)
+		xiaomi_initramfs_prepare
+		;;
+	esac
+}
+
 platform_do_upgrade() {
 	case "$(board_name)" in
 	elecom,wrc-x3000gs2|\
@@ -95,6 +126,23 @@ platform_do_upgrade() {
 	linksys,spnmx56)
 		linksys_mx_pre_upgrade "$1"
 		remove_oem_ubi_volume squashfs
+		nand_do_upgrade "$1"
+		;;
+	xiaomi,ax6000)
+		# Make sure that UART is enabled
+		fw_setenv boot_wait on
+		fw_setenv uart_en 1
+
+		# Enforce single partition.
+		fw_setenv flag_boot_rootfs 0
+		fw_setenv flag_last_success 0
+		fw_setenv flag_boot_success 1
+		fw_setenv flag_try_sys1_failed 8
+		fw_setenv flag_try_sys2_failed 8
+
+		# Kernel and rootfs are placed in 2 different UBI
+		CI_KERN_UBIPART="ubi_kernel"
+		CI_ROOT_UBIPART="rootfs"
 		nand_do_upgrade "$1"
 		;;
 	*)

--- a/target/linux/qualcommax/patches-6.12/0055-v6.16-mtd-spinand-esmt-fix-id-code-for-F50D1G41LB.patch
+++ b/target/linux/qualcommax/patches-6.12/0055-v6.16-mtd-spinand-esmt-fix-id-code-for-F50D1G41LB.patch
@@ -1,0 +1,35 @@
+From dd26402642a0899fde59ea6b0852fad3d799b4cc Mon Sep 17 00:00:00 2001
+From: George Moussalem <george.moussalem@outlook.com>
+Date: Thu, 15 May 2025 21:46:05 +0400
+Subject: mtd: spinand: esmt: fix id code for F50D1G41LB
+
+Upon detecting the ID for the ESMT F50D1G41LB chip, the fifth byte
+returned is always 0x00 instead of the expected JEDEC continuation code
+of 0x7f. This causes detection to fail:
+
+[    0.304399] spi-nand spi0.0: unknown raw ID c8117f7f00
+[    0.508943] spi-nand: probe of spi0.0 failed with error -524
+
+So let's revert back to the 4 byte ID code for this chip
+specifically.
+
+Fixes: 4bd14b2fd8a8 ("mtd: spinand: esmt: Extend IDs to 5 bytes")
+Signed-off-by: George Moussalem <george.moussalem@outlook.com>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+---
+ drivers/mtd/nand/spi/esmt.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+(limited to 'drivers/mtd/nand/spi/esmt.c')
+
+--- a/drivers/mtd/nand/spi/esmt.c
++++ b/drivers/mtd/nand/spi/esmt.c
+@@ -115,7 +115,7 @@ static const struct spinand_info esmt_c8
+ 		     SPINAND_ECCINFO(&f50l1g41lb_ooblayout, NULL)),
+ 	SPINAND_INFO("F50D1G41LB",
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_ADDR, 0x11, 0x7f,
+-				0x7f, 0x7f),
++				0x7f),
+ 		     NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
+ 		     NAND_ECCREQ(1, 512),
+ 		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,

--- a/target/linux/qualcommax/patches-6.12/0753-net-dsa-qca8k-fix-led-devicename-when-using-external-mdio-bus.patch
+++ b/target/linux/qualcommax/patches-6.12/0753-net-dsa-qca8k-fix-led-devicename-when-using-external-mdio-bus.patch
@@ -1,0 +1,34 @@
+From ec0031908d3abb24e791af2d5be9f3b0e265c945 Mon Sep 17 00:00:00 2001
+From: George Moussalem <george.moussalem@outlook.com>
+Date: Fri, 25 Apr 2025 10:51:28 +0400
+Subject: [PATCH] net: dsa: qca8k: fix led devicename when using external mdio bus
+
+The qca8k dsa switch can use either an external or internal mdio bus.
+This depends on whether the mdio node is defined under the switch node
+itself and, as such, the internal_mdio_mask is populated with its
+internal phys. Upon registering the internal mdio bus, the slave_mii_bus
+of the dsa switch is assigned to this bus. When an external mdio bus is
+used, it is left unassigned, though its id is used to create the device
+names of the leds.
+This leads to the leds being named '(efault):00:green:lan' and so on as
+the slave_mii_bus is null. So let's fix this by adding a null check and
+use the devicename of the external bus instead when an external bus is
+configured.
+
+Signed-off-by: George Moussalem <george.moussalem@outlook.com>
+---
+ drivers/net/dsa/qca/qca8k-leds.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/qca/qca8k-leds.c
++++ b/drivers/net/dsa/qca/qca8k-leds.c
+@@ -429,7 +429,8 @@ qca8k_parse_port_leds(struct qca8k_priv
+ 		init_data.fwnode = led;
+ 		init_data.devname_mandatory = true;
+ 		init_data.devicename = kasprintf(GFP_KERNEL, "%s:0%d",
+-						 priv->internal_mdio_bus->id,
++						 priv->internal_mdio_bus ?
++						 priv->internal_mdio_bus->id : priv->bus->id,
+ 						 port_num);
+ 		if (!init_data.devicename) {
+ 			fwnode_handle_put(led);


### PR DESCRIPTION
Add support for Xiaomi AX6000

Two prerequisite commits are needed:
1. net: dsa: qca8k: fix led devicename when using external mdio bus (pending upstream review)
2. mtd: spinand: esmt: fix id code for F50D1G41LB (accepted upstream)

Speficiations:
    * SoC: Qualcomm IPQ5018 (64-bit dual-core ARM Cortex-A53 @ 1.0Ghz)
    * Memory: Etrontech EM6HE16EWAKG 512 MiB DDR3L-933
    * Serial Port: 1v8 TTL 115200n8
    * Wi-Fi: IPQ5018 (2x2 2.4 Ghz 802.11b/g/n/ax - up to 574 Mbps)
             QCN9024 (4x4 5 Ghz 802.11an/ac/ax - up to 4804 Mbps)
             QCA9887 (1x1 5 Ghz 802.11ac/n - up to 433 Mbps)
    * Ethernet: IPQ5018 integrated virtual switch connected to:
                - external QCA8337 switch   (3 LAN Ports 10/100/1000)
                - QCA8081 Phy WAN port      (10/100/1000/2500)
    * Flash: Either of:
            - Gigadevice GD5F1GQ4RE9IGD (128 MiB)
            - ESMT F50D1G41LB (128 MiB)
    * LEDs: 1x WLAN Link         (GPIO 23 Active High)
            1x System Blue       (GPIO 24 Active High)
            1x System Yellow     (GPIO 25 Active High)
            1x WAN Link Blue     (GPIO 26 Active High)
            1x WAN Link Yellow   (GPIO 27 Active High)
            1x Green - Unused    (GPIO 28 Active High)
            3x LAN Phy Green
            1x WAN Phy Green
    * Buttons: 1x Reset          (GPIO 38 Active Low)
    
    Known issues:
    - QCA9887 doesn't come up (possibly due to 1-lane PCIe phy not coming up or missing method drive power)
    
    Flash instructions:
    
    Download XMIR Patcher: https://github.com/openwrt-xiaomi/xmir-patcher
    
    First flash a ubinized OpenWrt initramfs that will serve as the intermediate step, since
    OpenWrt uses unified rootfs in order to fully utilize NAND and provide enough space for
    packages, through either of the below two methods:
    
    Installation via XMIR Patcher:
    
    1. Load the initramfs image: openwrt-qualcommax-ipq50xx-xiaomi_ax6000-initramfs-factory.ubi
    
    Installation via ubiformat method, through SSH:
    
    1. If needed, enable SSH using XMIR Patcher.
    2. Copy the file openwrt-qualcommax-ipq50xx-xiaomi_ax6000-initramfs-factory.ubi to the /tmp directory
    3. Open an SSH shell to the router
    4. Check which rootfs partition is your router booted in (0 = rootfs | 1 = rootfs_1):
    nvram get flag_boot_rootfs
    5. Find the rootfs and rootfs_1 mtd indexes respectively:
    cat /proc/mtd
    Please confirm if mtd18 and mtd19 are the correct indexes from above!
    6. Use the command ubiformat to flash the opposite mtd with UBI image:
    If nvram get flag_boot_rootfs returned 0:
    ubiformat /dev/mtd19 -y -f /tmp/openwrt-qualcommax-ipq50xx-xiaomi_ax6000-initramfs-factory.ubi && nvram set flag_boot_rootfs=1 && nvram set flag_last_success=1 && nvram commit
    otherwise:
    ubiformat /dev/mtd18 -y -f /tmp/openwrt-qualcommax-ipq50xx-xiaomi_ax6000-initramfs-factory.ubi && nvram set flag_boot_rootfs=0 && nvram set flag_last_success=0 && nvram commit
    7. Reboot the device by:
    reboot
    
    Continue in order to pernamently flash OpenWrt:
    1. Upload the sysupgrade image to /tmp/ using SCP:
    scp -O <path to image> root@192.168.1.1:/tmp/
    2. Open an SSH shell to 192.168.1.1 from a PC within the same subnet
    3. Use sysupgrade to flash the sysupgrade image:
    sysupgrade -n -v /tmp/openwrt-qualcommax-ipq50xx-xiaomi_ax6000-squashfs-sysupgrade.bin
    
    Device will reboot with OpenWrt, and then sysupgrade can be used to upgrade the device when desired.
    
    Signed-off-by: George Moussalem <george.moussalem@outlook.com>