### PR TITLE
kernel: mtdsplit_uimage: return 0 if not fatal

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
@@ -186,8 +186,8 @@ static int __mtdsplit_parse_uimage(struct mtd_info *master,
 	}
 
 	if (uimage_size == 0) {
-		pr_debug("no uImage found in \"%s\"\n", master->name);
-		ret = -ENODEV;
+		pr_info("no uImage found in \"%s\"\n", master->name);
+		ret = 0;
 		goto err_free_buf;
 	}
 


### PR DESCRIPTION
Introduced with Linux 6.7, in commit: 5c2f7727d437 ("mtd: mtdpart: check for subpartitions parsing result"), when a parser returns an error, this will be passed up, and consequently, all parent mtd partitions get torn down.

Adjust the mtdsplit_uimage driver to only return an error if there is a critical problem in reading from the mtd device or allocating memory. Otherwise return 0 to indicate that no partitions were found. Also add logging to indicate what went wrong.

E.g. on Realtek devices that are booted for the first time through initramfs with OpenWrt never installed before boot log will show

```
[    0.932985] Creating 8 MTD partitions on "spi0.0":
[    0.938412] 0x000000000000-0x000000080000 : "u-boot"
[    0.990151] 0x000000080000-0x0000000c0000 : "u-boot-env"
[    0.999907] 0x0000000c0000-0x000000100000 : "board-name"
[    1.019971] 0x000000100000-0x000000e80000 : "firmware"
[    1.051582] mtdsplit_uimage: no uImage found in "firmware"
[    1.069365] 0x000000e80000-0x000001000000 : "kernel2"
[    1.078959] 0x000001000000-0x000001040000 : "sysinfo"
[    1.099747] 0x000001040000-0x000001c40000 : "rootfs2"
[    1.119865] 0x000001c40000-0x000002000000 : "jffs2"
```

Similar issue was fixed before with commit https://github.com/openwrt/openwrt/commit/ade045084bd3f86969eaf0b35234aaa01e430fe1 ("kernel: mtdsplit_minor: return 0 if not fatal")