### PR TITLE
bmips: use wan ports as standalone ports

### DIFF
--- a/target/linux/bmips/bcm6318/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6318/base-files/etc/board.d/02_network
@@ -7,7 +7,6 @@ board_config_update
 case "$(board_name)" in
 comtrend,ar-5315u |\
 tp-link,td-w8968-v3)
-	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;
 esac

--- a/target/linux/bmips/bcm63268/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm63268/base-files/etc/board.d/02_network
@@ -9,17 +9,14 @@ actiontec,t1200h |\
 comtrend,vg-8050 |\
 sagem,fast-3864-op |\
 sercomm,shg2500)
-	ucidef_set_bridge_device switch
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 	;;
 comtrend,vr-3032u |\
 smartrg,sr505n)
-	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;
 sercomm,h500-s-lowi |\
 sercomm,h500-s-vfes)
-	ucidef_set_bridge_device switch
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 	ucidef_set_interface "qtn" device "wifi" protocol "static" ipaddr "1.1.1.1" netmask "255.255.255.252"
 	uci add_list firewall.@zone[0].network='qtn'

--- a/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6328/base-files/etc/board.d/02_network
@@ -6,7 +6,6 @@ board_config_update
 
 case "$(board_name)" in
 arcadyan,ar7516)
-	ucidef_set_bridge_device switch
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 	;;
 inteno,xg6846)
@@ -17,11 +16,9 @@ comtrend,ar-5387un |\
 dlink,dsl-2750b-b1 |\
 innacomm,w3400v6 |\
 nucom,r5010unv2)
-	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;
 sercomm,ad1018)
-	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 fibre"
 	;;
 esac

--- a/target/linux/bmips/bcm6358/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6358/base-files/etc/board.d/02_network
@@ -6,7 +6,6 @@ board_config_update
 
 case "$(board_name)" in
 huawei,hg556a-b)
-	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;
 esac

--- a/target/linux/bmips/bcm6362/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6362/base-files/etc/board.d/02_network
@@ -7,7 +7,6 @@ board_config_update
 case "$(board_name)" in
 huawei,hg253s-v2 |\
 netgear,dgnd3700-v2)
-	ucidef_set_bridge_device switch
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 	;;
 esac

--- a/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6368/base-files/etc/board.d/02_network
@@ -7,11 +7,9 @@ board_config_update
 case "$(board_name)" in
 comtrend,vr-3025u |\
 observa,vh4032n)
-	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;
 comtrend,vr-3025un)
-	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 iptv"
 	;;
 actiontec,r1000h |\
@@ -19,7 +17,6 @@ comtrend,wap-5813n |\
 netgear,dgnd3700-v1 |\
 netgear,dgnd3800b |\
 netgear,evg2000)
-	ucidef_set_bridge_device switch
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 	;;
 esac


### PR DESCRIPTION
With the recent fixes backported to 6.12, b53 ports should now fully work as standalone ports outside of a switch.

So move them out of the switch and use them as standalone ports, which makes configuring easier as VLANs don't need to be defined and reserved anymore to use the wan port.

Tested on DGND3700v1.

While most devices do not define a wan port, I dropped the ucidef_set_bridge_device() from all devices for consistency.
