### PR TITLE
tools/coreutils: bump to 9.7

### DIFF
--- a/tools/coreutils/Makefile
+++ b/tools/coreutils/Makefile
@@ -8,11 +8,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=coreutils
 PKG_CPE_ID:=cpe:/a:gnu:coreutils
-PKG_VERSION:=9.6
+PKG_VERSION:=9.7
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@GNU/coreutils
-PKG_HASH:=2bec616375002c92c1ed5ead32a092b174fe44c14bc736d32e5961053b821d84
+PKG_HASH:=e8bb26ad0293f9b5a1fc43fb42ba970e312c66ce92c1b0b16713d7500db251bf
 
 HOST_BUILD_PARALLEL := 1
 
@@ -39,6 +39,8 @@ HOST_MAKE_FLAGS += \
 	MAINTAINERCLEANFILES='$$$$(filter-out lib/iconv_open% %.texi,$$$$(BUILT_SOURCES))' \
 	PROGRAMS="$(patsubst %,src/%,$(PKG_PROGRAMS))" \
 	LIBRARIES= MANS= SUBDIRS=.
+
+HOST_CFLAGS += -fPIC -std=gnu17
 
 define Host/Bootstrap
 	( \


### PR DESCRIPTION
Single patche automatically rebased.
Added -std=gnu23 to CFLAGS

Release news: https://savannah.gnu.org/news/?id=10751