### PR TITLE
tools/ccache: update to 4.11.3

### DIFF
--- a/tools/ccache/Makefile
+++ b/tools/ccache/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ccache
-PKG_VERSION:=4.10.2
+PKG_VERSION:=4.11.3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ccache/ccache/releases/download/v$(PKG_VERSION)
-PKG_HASH:=108100960bb7e64573ea925af2ee7611701241abb36ce0aae3354528403a7d87
+PKG_HASH:=28a407314f03a7bd7a008038dbaffa83448bc670e2fc119609b1d99fb33bb600
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk

--- a/tools/ccache/patches/100-honour-copts.patch
+++ b/tools/ccache/patches/100-honour-copts.patch
@@ -1,6 +1,6 @@
 --- a/src/ccache/ccache.cpp
 +++ b/src/ccache/ccache.cpp
-@@ -1914,6 +1914,7 @@ get_manifest_key(Context& ctx, Hash& has
+@@ -2018,6 +2018,7 @@ get_manifest_key(Context& ctx, Hash& has
      "OBJCPLUS_INCLUDE_PATH",        // Clang
      "CLANG_CONFIG_FILE_SYSTEM_DIR", // Clang
      "CLANG_CONFIG_FILE_USER_DIR",   // Clang


### PR DESCRIPTION
Update ccache to the latest version. All patches are automatically refreshed. Changelogs:

https://github.com/ccache/ccache/blob/v4.11.3/doc/NEWS.adoc