### PR TITLE
wifi-scripts: add missing entries for mesh_nolearn

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -21,7 +21,7 @@ const mesh_param_list = [
 	"mesh_hwmp_rann_interval", "mesh_gate_announcements", "mesh_sync_offset_max_neighor",
 	"mesh_rssi_threshold", "mesh_hwmp_active_path_to_root_timeout", "mesh_hwmp_root_interval",
 	"mesh_hwmp_confirmation_interval", "mesh_awake_window", "mesh_plink_timeout",
-	"mesh_auto_open_plinks", "mesh_fwding", "mesh_power_mode"
+	"mesh_auto_open_plinks", "mesh_fwding", "mesh_nolearn", "mesh_power_mode"
 ];
 
 function phy_suffix(radio, sep) {

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -617,6 +617,10 @@
 			"description": "Enable 802.11s layer-2 routing and forwarding",
 			"type": "boolean"
 		},
+		"mesh_nolearn": {
+			"description": "Disable 802.11s path discovery",
+			"type": "boolean"
+		},
 		"mesh_gate_announcements": {
 			"type": "number"
 		},


### PR DESCRIPTION
The plumbing is there in the ucode files to set the parameter using nl80211. However, the option is never forwarded because it was missing in mac80211.sh. Add it there and in the schema file.

I think that this is needed for freifunk-gluon/gluon#3512 to work. Only tested the equivalent change on the old version of the file, but inserting the param in mac80211.sh fixes the issue and I can set the option.