### PR TITLE
prereq-build: fix typo on the IPC::Cmd module message

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -97,7 +97,7 @@ $(eval $(call TestHostCommand,perl-thread-queue, \
 	perl -MThread::Queue -e 1))
 
 $(eval $(call TestHostCommand,perl-ipc-cmd, \
-	Please install the Perl IPC:Cmd module, \
+	Please install the Perl IPC::Cmd module, \
 	perl -MIPC::Cmd -e 1))
 
 $(eval $(call SetupHostCommand,tar,Please install GNU 'tar', \


### PR DESCRIPTION
It took me a while to realize why `dnf` in my Fedora build container does not find `perl(IPC:Cmd)`.

This should make it easier for people who just copy-and-paste blindly, as well as making the message more correct.