### PR TITLE
kernel: add Microchip ENC28J60 SPI Ethernet controller module

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -2125,3 +2125,19 @@ define KernelPackage/amazon-ena/description
 endef
 
 $(eval $(call KernelPackage,amazon-ena))
+
+define KernelPackage/enc28j60
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Microchip ENC28J60 SPI Ethernet driver
+  KCONFIG:=\
+    CONFIG_ENC28J60 \
+    CONFIG_ENC28J60_WRITEVERIFY=n
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/microchip/enc28j60.ko
+  AUTOLOAD:=$(call AutoProbe,enc28j60)
+endef
+
+define KernelPackage/enc28j60/description
+  Kernel module for Microchip ENC28J60 SPI Ethernet controller
+endef
+
+$(eval $(call KernelPackage,enc28j60))


### PR DESCRIPTION
The ENC28J60 is a 10Mbit/s half-duplex Ethernet controller interfaced via SPI. It achieves real-world bandwidth up to 5Mbit/s on devices like the Raspberry Pi Zero due SPI limits. Commonly used with Raspberry Pi Zero boards for wired network connectivity.
