### PR TITLE
[24.10] mediatek: add support for TP-Link Archer AX80v1(US/RU/CA)

### DIFF
--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -129,6 +129,9 @@ smartrg,sdg-8734)
 	local envdev=$(find_mmc_part "u-boot-env" "mmcblk0")
 	ubootenv_add_uci_config "$envdev" "0x0" "0x8000" "0x8000"
 	;;
+tplink,archer-ax80-v1)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000" "8"
+	;;
 ubnt,unifi-6-plus)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x10000"
 	;;

--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -299,6 +299,23 @@ endef
 $(eval $(call KernelPackage,leds-lp55xx-common))
 
 
+define KernelPackage/leds-lp5523
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=LED driver for LP5523/LP55231 controllers
+  DEPENDS:=+kmod-i2c-core +kmod-leds-lp55xx-common
+  KCONFIG:=CONFIG_LEDS_LP5523
+  FILES:=$(LINUX_DIR)/drivers/leds/leds-lp5523.ko
+  AUTOLOAD:=$(call AutoLoad,60,leds-lp5523,1)
+endef
+
+define KernelPackage/leds-lp5523/description
+ This option enables support for Texas Instruments LP5523/LP55231
+ LED controllers.
+endef
+
+$(eval $(call KernelPackage,leds-lp5523))
+
+
 define KernelPackage/leds-lp5562
   SUBMENU:=$(LEDS_MENU)
   TITLE:=LED driver for LP5562 controllers

--- a/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1.dts
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	compatible = "tplink,archer-ax80-v1", "mediatek,mt7986a";
+	model = "TP-Link Archer AX80V1";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_B;
+		led-failsafe = &led_R;
+		led-running = &led_B;
+		led-upgrade = &led_G;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		button-ledswitch {
+			label = "ledswitch";
+			linux,code = <KEY_BRIGHTNESS_ZERO>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wifi {
+			label = "wlan";
+			linux,code = <KEY_WLAN>;
+			gpios = <&pio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	reg_1p8v: regulator-1p8v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-1.8V";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&auxadc {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy6>;
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <1500000>;
+		reset-post-delay-us = <1000000>;
+
+		phy6: phy@6 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <6>;
+		};
+
+		switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <0>;
+					label = "lan0";
+				};
+				port@1 {
+					reg = <1>;
+					label = "lan1";
+				};
+				port@2 {
+					reg = <2>;
+					label = "lan2";
+				};
+				port@3 {
+					reg = <3>;
+					label = "lan3";
+				};
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+					};
+				};
+			};
+		};
+	};
+};
+
+&i2c0 {
+	status = "okay";
+
+	lp55231: led-controller@32 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "ti,lp55231";
+		reg = <0x32>;
+		status = "okay";
+		clock-mode = /bits/ 8 <1>;
+
+		led_B: led@0 {
+			chan-name = "B";
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			reg = <0>;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+
+		led_G: led@3 {
+			chan-name = "G";
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			reg = <3>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		led_R: led@6 {
+			chan-name = "R";
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			reg = <6>;
+			color = <LED_COLOR_ID_RED>;
+		};
+
+	};
+};
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	spi_nand_flash: flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x0 0x200000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "u-boot-env";
+				reg = <0x200000 0x100000>;
+			};
+
+			partition@300000 {
+				label = "ubi0";
+				reg = <0x300000 0x3200000>;
+			};
+
+			partition@3500000 {
+				label = "ubi1";
+				reg = <0x3500000 0x3200000>;
+			};
+
+			partition@6700000 {
+				label = "userconfig";
+				reg = <0x6700000 0x800000>;
+			};
+
+			factory:partition@6f00000 {
+				label = "tp_data";
+				reg = <0x6f00000 0x400000>;
+			};
+
+			partition@7300000 {
+				label = "mali_data";
+				reg = <0x7300000 0x800000>;
+			};
+		};
+	};
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <4>;
+			mediatek,pull-up-adv = <0>;
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <4>;
+			mediatek,pull-down-adv = <0>;
+		};
+	};
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			"WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&ssusb {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -125,6 +125,9 @@ mediatek_setup_interfaces()
 	wavlink,wl-wn586x3)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" eth1
 		;;
+	tplink,archer-ax80-v1)
+		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" eth1
+		;;
 	tplink,re6000xd)
 		ucidef_set_interface_lan "lan1 lan2 eth1"
 		;;
@@ -173,6 +176,7 @@ mediatek_setup_macs()
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
 	mercusys,mr90x-v1|\
+	tplink,archer-ax80-v1|\
 	tplink,re6000xd)
 		label_mac=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		lan_mac=$label_mac

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -27,6 +27,14 @@ case "$FIRMWARE" in
 		;;
 	esac
 	;;
+"mediatek/mt7986_eeprom_mt7976_dual.bin")
+	case "$board" in
+	tplink,archer-ax80-v1)
+		ln -sf /tmp/tp_data/MT7986_EEPROM.bin \
+			/lib/firmware/$FIRMWARE
+		;;
+	esac
+	;;
 *)
 	exit 1
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -125,6 +125,7 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && macaddr_add $label_mac -2 > /sys${DEVPATH}/macaddress
 		;;
 	mercusys,mr90x-v1|\
+	tplink,archer-ax80-v1|\
 	tplink,re6000xd)
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -14,6 +14,7 @@ preinit_mount_cfg_part() {
 	case $(board_name) in
 	mercusys,mr80x-v3|\
 	mercusys,mr90x-v1|\
+	tplink,archer-ax80-v1|\
 	tplink,re6000xd)
 		mount_ubi_part "tp_data"
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -28,6 +28,7 @@ preinit_set_mac_address() {
 		ip link set dev eth1 address "$addr"
 		;;
 	mercusys,mr90x-v1|\
+	tplink,archer-ax80-v1|\
 	tplink,re6000xd)
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		ip link set dev eth1 address "$(macaddr_add $addr 1)"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -137,6 +137,7 @@ platform_do_upgrade() {
 		;;
 	mercusys,mr80x-v3|\
 	mercusys,mr90x-v1|\
+	tplink,archer-ax80-v1|\
 	tplink,re6000xd)
 		CI_UBIPART="ubi0"
 		nand_do_upgrade "$1"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1503,6 +1503,20 @@ define Device/ruijie_rg-x60-pro
 endef
 TARGET_DEVICES += ruijie_rg-x60-pro
 
+define Device/tplink_archer-ax80-v1
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := Archer AX80V1
+  DEVICE_DTS := mt7986a-tplink-archer-ax80-v1
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-leds-lp5523 kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 51200k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += tplink_archer-ax80-v1
+
 define Device/tplink_re6000xd
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := RE6000XD


### PR DESCRIPTION
### This pull request backports support for TP-Link Archer AX80v1(US/RU/CA).

![orig](https://github.com/user-attachments/assets/0de6fd6a-0b65-4d33-a77e-9ef49d329498)

### Device specification

```
SoC Type:   MediaTek MT7986AV, Cortex-A53, 64-bit
RAM:        ESMT M15T4G16256 (512MB)
Flash:      ESMT F50L1G41LB (128 MB)
Ethernet:   MediaTek MT7531AE + 2.5GbE MaxLinear GPY211C0VC (SLNW8)
Ethernet:   1x2.5Gbe (2.5Gbps WAN/LAN), 4xGbE (1Gbps WAN/LAN, LAN1, LAN2, LAN3)
WLAN 2g:    MediaTek MT7976GN
WLAN 5g:    MediaTek MT7976AN
LEDs:       1 red,1 green,1 blue status LEDs
Buttons:    4 (Reset,ledswitch,wps,wlan)
USB ports:  1 (USB 3.0)
Power:      12 VDC, 3,3 A
Connector:  Barrel
Bootloader: Main U-Boot - U-Boot 2022.01-rc4. Additionally, both UBI
            slots contain "seconduboot" (also U-Boot 2022.01-rc4)
```

Cherry picked from commits https://github.com/openwrt/openwrt/commit/64080b1dd674692dad36c7efeb29c9f72761951c and https://github.com/openwrt/openwrt/commit/82a66762a0dd381c4e39ad39760f23415f0607c5.

Successfully built and run tested.

Signed-off-by: HateTM <ichizakurain@gmail.com>