### PR TITLE
bmips: add RFC v2 bcm5325 patches

### DIFF
--- a/target/linux/bmips/patches-6.12/130-net-dsa-b53-add-support-for-FDB-operations-on-5325-5365.patch
+++ b/target/linux/bmips/patches-6.12/130-net-dsa-b53-add-support-for-FDB-operations-on-5325-5365.patch
@@ -1,7 +1,8 @@
-From fec493475d7f0b17dc64f682a584faae5efe640e Mon Sep 17 00:00:00 2001
+From 1cd53b29d573aef79ea69f6f502517a71e3f04a7 Mon Sep 17 00:00:00 2001
 From: Florian Fainelli <f.fainelli@gmail.com>
 Date: Sat, 9 Sep 2017 16:41:26 -0700
-Subject: [PATCH] net: dsa: b53: add support for FDB operations on 5325/5365
+Subject: [RFC PATCH net-next v2 01/10] net: dsa: b53: add support for FDB
+ operations on 5325/5365
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -15,34 +16,60 @@ converting ARL entries in both directions.
 Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>
 Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 ---
- drivers/net/dsa/b53/b53_common.c | 64 ++++++++++++++++++++------------
- drivers/net/dsa/b53/b53_priv.h   | 57 ++++++++++++++++++++--------
- drivers/net/dsa/b53/b53_regs.h   |  7 ++--
- 3 files changed, 86 insertions(+), 42 deletions(-)
+ drivers/net/dsa/b53/b53_common.c | 104 +++++++++++++++++++++++++------
+ drivers/net/dsa/b53/b53_priv.h   |  29 +++++++++
+ drivers/net/dsa/b53/b53_regs.h   |   7 ++-
+ 3 files changed, 117 insertions(+), 23 deletions(-)
 
 --- a/drivers/net/dsa/b53/b53_common.c
 +++ b/drivers/net/dsa/b53/b53_common.c
-@@ -1738,13 +1738,15 @@ static int b53_arl_read(struct b53_devic
- 	/* Read the bins */
- 	for (i = 0; i < dev->num_arl_bins; i++) {
- 		u64 mac_vid;
--		u32 fwd_entry;
-+		u32 fwd_entry = 0;
+@@ -1763,6 +1763,45 @@ static int b53_arl_read(struct b53_devic
+ 	return *idx >= dev->num_arl_bins ? -ENOSPC : -ENOENT;
+ }
  
- 		b53_read64(dev, B53_ARLIO_PAGE,
- 			   B53_ARLTBL_MAC_VID_ENTRY(i), &mac_vid);
--		b53_read32(dev, B53_ARLIO_PAGE,
--			   B53_ARLTBL_DATA_ENTRY(i), &fwd_entry);
--		b53_arl_to_entry(ent, mac_vid, fwd_entry);
++static int b53_arl_read_25(struct b53_device *dev, u64 mac,
++			   u16 vid, struct b53_arl_entry *ent, u8 *idx)
++{
++	DECLARE_BITMAP(free_bins, B53_ARLTBL_MAX_BIN_ENTRIES);
++	unsigned int i;
++	int ret;
 +
-+		if (!is5325(dev) && !is5365(dev))
-+			b53_read32(dev, B53_ARLIO_PAGE,
-+				   B53_ARLTBL_DATA_ENTRY(i), &fwd_entry);
-+		b53_arl_to_entry(dev, ent, mac_vid, fwd_entry);
- 
- 		if (!(fwd_entry & ARLTBL_VALID)) {
- 			set_bit(i, free_bins);
-@@ -1777,7 +1779,8 @@ static int b53_arl_op(struct b53_device
++	ret = b53_arl_op_wait(dev);
++	if (ret)
++		return ret;
++
++	bitmap_zero(free_bins, dev->num_arl_bins);
++
++	/* Read the bins */
++	for (i = 0; i < dev->num_arl_bins; i++) {
++		u64 mac_vid;
++
++		b53_read64(dev, B53_ARLIO_PAGE,
++			   B53_ARLTBL_MAC_VID_ENTRY(i), &mac_vid);
++
++		b53_arl_to_entry_25(ent, mac_vid);
++
++		if (!(mac_vid & ARLTBL_VALID_25)) {
++			set_bit(i, free_bins);
++			continue;
++		}
++		if ((mac_vid & ARLTBL_MAC_MASK) != mac)
++			continue;
++		if (dev->vlan_enabled &&
++		    ((mac_vid >> ARLTBL_VID_S_65) & ARLTBL_VID_MASK_25) != vid)
++			continue;
++		*idx = i;
++		return 0;
++	}
++
++	*idx = find_first_bit(free_bins, dev->num_arl_bins);
++	return *idx >= dev->num_arl_bins ? -ENOSPC : -ENOENT;
++}
++
+ static int b53_arl_op(struct b53_device *dev, int op, int port,
+ 		      const unsigned char *addr, u16 vid, bool is_valid)
+ {
+@@ -1777,14 +1816,18 @@ static int b53_arl_op(struct b53_device
  
  	/* Perform a read for the given MAC and VID */
  	b53_write48(dev, B53_ARLIO_PAGE, B53_MAC_ADDR_IDX, mac);
@@ -52,12 +79,26 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  
  	/* Issue a read operation for this MAC */
  	ret = b53_arl_rw_op(dev, 1);
-@@ -1828,12 +1831,14 @@ static int b53_arl_op(struct b53_device
+ 	if (ret)
+ 		return ret;
+ 
+-	ret = b53_arl_read(dev, mac, vid, &ent, &idx);
++	if (is5325(dev) || is5365(dev))
++		ret = b53_arl_read_25(dev, mac, vid, &ent, &idx);
++	else
++		ret = b53_arl_read(dev, mac, vid, &ent, &idx);
+ 
+ 	/* If this is a read, just finish now */
+ 	if (op)
+@@ -1828,12 +1871,17 @@ static int b53_arl_op(struct b53_device
  	ent.is_static = true;
  	ent.is_age = false;
  	memcpy(ent.mac, addr, ETH_ALEN);
 -	b53_arl_from_entry(&mac_vid, &fwd_entry, &ent);
-+	b53_arl_from_entry(dev, &mac_vid, &fwd_entry, &ent);
++	if (is5325(dev) || is5365(dev))
++		b53_arl_from_entry_25(&mac_vid, &ent);
++	else
++		b53_arl_from_entry(&mac_vid, &fwd_entry, &ent);
  
  	b53_write64(dev, B53_ARLIO_PAGE,
  		    B53_ARLTBL_MAC_VID_ENTRY(idx), mac_vid);
@@ -70,7 +111,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  
  	return b53_arl_rw_op(dev, 0);
  }
-@@ -1845,12 +1850,6 @@ int b53_fdb_add(struct dsa_switch *ds, i
+@@ -1845,12 +1893,6 @@ int b53_fdb_add(struct dsa_switch *ds, i
  	struct b53_device *priv = ds->priv;
  	int ret;
  
@@ -83,7 +124,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  	mutex_lock(&priv->arl_mutex);
  	ret = b53_arl_op(priv, 0, port, addr, vid, true);
  	mutex_unlock(&priv->arl_mutex);
-@@ -1877,10 +1876,15 @@ EXPORT_SYMBOL(b53_fdb_del);
+@@ -1877,10 +1919,15 @@ EXPORT_SYMBOL(b53_fdb_del);
  static int b53_arl_search_wait(struct b53_device *dev)
  {
  	unsigned int timeout = 1000;
@@ -101,12 +142,11 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  		if (!(reg & ARL_SRCH_STDN))
  			return 0;
  
-@@ -1897,13 +1901,21 @@ static void b53_arl_search_rd(struct b53
+@@ -1897,13 +1944,24 @@ static void b53_arl_search_rd(struct b53
  			      struct b53_arl_entry *ent)
  {
  	u64 mac_vid;
 -	u32 fwd_entry;
-+	u32 fwd_entry = 0;
  
 -	b53_read64(dev, B53_ARLIO_PAGE,
 -		   B53_ARL_SRCH_RSTL_MACVID(idx), &mac_vid);
@@ -116,20 +156,24 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 +	if (is5325(dev)) {
 +		b53_read64(dev, B53_ARLIO_PAGE, B53_ARL_SRCH_RSTL_0_MACVID_25,
 +			   &mac_vid);
++		b53_arl_to_entry_25(ent, mac_vid);
 +	} else if (is5365(dev)) {
 +		b53_read64(dev, B53_ARLIO_PAGE, B53_ARL_SRCH_RSTL_0_MACVID_65,
 +			   &mac_vid);
++		b53_arl_to_entry_25(ent, mac_vid);
 +	} else {
++		u32 fwd_entry;
++
 +		b53_read64(dev, B53_ARLIO_PAGE, B53_ARL_SRCH_RSTL_MACVID(idx),
 +			   &mac_vid);
 +		b53_read32(dev, B53_ARLIO_PAGE, B53_ARL_SRCH_RSTL(idx),
 +			   &fwd_entry);
++		b53_arl_to_entry(ent, mac_vid, fwd_entry);
 +	}
-+	b53_arl_to_entry(dev, ent, mac_vid, fwd_entry);
  }
  
  static int b53_fdb_copy(int port, const struct b53_arl_entry *ent,
-@@ -1924,14 +1936,20 @@ int b53_fdb_dump(struct dsa_switch *ds,
+@@ -1924,14 +1982,20 @@ int b53_fdb_dump(struct dsa_switch *ds,
  	struct b53_device *priv = ds->priv;
  	struct b53_arl_entry results[2];
  	unsigned int count = 0;
@@ -153,78 +197,49 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  		ret = b53_arl_search_wait(priv);
 --- a/drivers/net/dsa/b53/b53_priv.h
 +++ b/drivers/net/dsa/b53/b53_priv.h
-@@ -286,30 +286,55 @@ struct b53_arl_entry {
- 	u8 is_static:1;
- };
- 
--static inline void b53_arl_to_entry(struct b53_arl_entry *ent,
-+static inline void b53_arl_to_entry(struct b53_device *dev,
-+				    struct b53_arl_entry *ent,
- 				    u64 mac_vid, u32 fwd_entry)
- {
- 	memset(ent, 0, sizeof(*ent));
--	ent->port = fwd_entry & ARLTBL_DATA_PORT_ID_MASK;
--	ent->is_valid = !!(fwd_entry & ARLTBL_VALID);
--	ent->is_age = !!(fwd_entry & ARLTBL_AGE);
--	ent->is_static = !!(fwd_entry & ARLTBL_STATIC);
--	u64_to_ether_addr(mac_vid, ent->mac);
--	ent->vid = mac_vid >> ARLTBL_VID_S;
-+	if (is5325(dev) || is5365(dev)) {
-+		ent->port = (mac_vid >> ARLTBL_DATA_PORT_ID_S_25) &
-+			    ARLTBL_DATA_PORT_ID_MASK_25;
-+		ent->is_valid = !!(mac_vid & ARLTBL_VALID_25);
-+		ent->is_age = !!(mac_vid & ARLTBL_AGE_25);
-+		ent->is_static = !!(mac_vid & ARLTBL_STATIC_25);
-+		u64_to_ether_addr(mac_vid, ent->mac);
-+		ent->vid = mac_vid >> ARLTBL_VID_S_65;
-+	} else {
-+		ent->port = fwd_entry & ARLTBL_DATA_PORT_ID_MASK;
-+		ent->is_valid = !!(fwd_entry & ARLTBL_VALID);
-+		ent->is_age = !!(fwd_entry & ARLTBL_AGE);
-+		ent->is_static = !!(fwd_entry & ARLTBL_STATIC);
-+		u64_to_ether_addr(mac_vid, ent->mac);
-+		ent->vid = mac_vid >> ARLTBL_VID_S;
-+	}
+@@ -298,6 +298,19 @@ static inline void b53_arl_to_entry(stru
+ 	ent->vid = mac_vid >> ARLTBL_VID_S;
  }
  
--static inline void b53_arl_from_entry(u64 *mac_vid, u32 *fwd_entry,
-+static inline void b53_arl_from_entry(struct b53_device *dev,
-+				      u64 *mac_vid, u32 *fwd_entry,
++static inline void b53_arl_to_entry_25(struct b53_arl_entry *ent,
++				       u64 mac_vid)
++{
++	memset(ent, 0, sizeof(*ent));
++	ent->port = (mac_vid >> ARLTBL_DATA_PORT_ID_S_25) &
++		     ARLTBL_DATA_PORT_ID_MASK_25;
++	ent->is_valid = !!(mac_vid & ARLTBL_VALID_25);
++	ent->is_age = !!(mac_vid & ARLTBL_AGE_25);
++	ent->is_static = !!(mac_vid & ARLTBL_STATIC_25);
++	u64_to_ether_addr(mac_vid, ent->mac);
++	ent->vid = mac_vid >> ARLTBL_VID_S_65;
++}
++
+ static inline void b53_arl_from_entry(u64 *mac_vid, u32 *fwd_entry,
  				      const struct b53_arl_entry *ent)
  {
- 	*mac_vid = ether_addr_to_u64(ent->mac);
--	*mac_vid |= (u64)(ent->vid & ARLTBL_VID_MASK) << ARLTBL_VID_S;
--	*fwd_entry = ent->port & ARLTBL_DATA_PORT_ID_MASK;
--	if (ent->is_valid)
--		*fwd_entry |= ARLTBL_VALID;
--	if (ent->is_static)
--		*fwd_entry |= ARLTBL_STATIC;
--	if (ent->is_age)
--		*fwd_entry |= ARLTBL_AGE;
-+	if (is5325(dev) || is5365(dev)) {
-+		*mac_vid |= (u64)(ent->port & ARLTBL_DATA_PORT_ID_MASK_25) <<
-+				  ARLTBL_DATA_PORT_ID_S_25;
-+		*mac_vid |= (u64)(ent->vid & ARLTBL_VID_MASK_25) <<
-+				  ARLTBL_VID_S_65;
-+		if (ent->is_valid)
-+			*mac_vid |= ARLTBL_VALID_25;
-+		if (ent->is_static)
-+			*mac_vid |= ARLTBL_STATIC_25;
-+		if (ent->is_age)
-+			*mac_vid |= ARLTBL_AGE_25;
-+	} else {
-+		*mac_vid |= (u64)(ent->vid & ARLTBL_VID_MASK) << ARLTBL_VID_S;
-+		*fwd_entry = ent->port & ARLTBL_DATA_PORT_ID_MASK;
-+		if (ent->is_valid)
-+			*fwd_entry |= ARLTBL_VALID;
-+		if (ent->is_static)
-+			*fwd_entry |= ARLTBL_STATIC;
-+		if (ent->is_age)
-+			*fwd_entry |= ARLTBL_AGE;
-+	}
+@@ -312,6 +325,22 @@ static inline void b53_arl_from_entry(u6
+ 		*fwd_entry |= ARLTBL_AGE;
  }
  
++static inline void b53_arl_from_entry_25(u64 *mac_vid,
++					 const struct b53_arl_entry *ent)
++{
++	*mac_vid = ether_addr_to_u64(ent->mac);
++	*mac_vid |= (u64)(ent->port & ARLTBL_DATA_PORT_ID_MASK_25) <<
++			  ARLTBL_DATA_PORT_ID_S_25;
++	*mac_vid |= (u64)(ent->vid & ARLTBL_VID_MASK_25) <<
++			  ARLTBL_VID_S_65;
++	if (ent->is_valid)
++		*mac_vid |= ARLTBL_VALID_25;
++	if (ent->is_static)
++		*mac_vid |= ARLTBL_STATIC_25;
++	if (ent->is_age)
++		*mac_vid |= ARLTBL_AGE_25;
++}
++
  #ifdef CONFIG_BCM47XX
+ 
+ #include <linux/bcm47xx_nvram.h>
 --- a/drivers/net/dsa/b53/b53_regs.h
 +++ b/drivers/net/dsa/b53/b53_regs.h
 @@ -324,9 +324,10 @@

--- a/target/linux/bmips/patches-6.12/131-net-dsa-b53-prevent-FAST_AGE-access-on-BCM5325.patch
+++ b/target/linux/bmips/patches-6.12/131-net-dsa-b53-prevent-FAST_AGE-access-on-BCM5325.patch
@@ -1,7 +1,8 @@
-From b9441e624e39428f57baf30043aba225f02bfc73 Mon Sep 17 00:00:00 2001
+From ccf1ce36586c922cf41d0bd41cd74804e6c1a7bc Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Fri, 30 May 2025 22:44:47 +0200
-Subject: [PATCH] net: dsa: b53: prevent FAST_AGE access on BCM5325
+Subject: [RFC PATCH net-next v2 02/10] net: dsa: b53: prevent FAST_AGE access
+ on BCM5325
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit

--- a/target/linux/bmips/patches-6.12/132-net-dsa-b53-prevent-SWITCH_CTRL-access-on-BCM5325.patch
+++ b/target/linux/bmips/patches-6.12/132-net-dsa-b53-prevent-SWITCH_CTRL-access-on-BCM5325.patch
@@ -1,7 +1,8 @@
-From 8cece037d71dd2464b7405871d5ba34d28695940 Mon Sep 17 00:00:00 2001
+From 6c08487730e4ac1c45daa87a5c836aecc9508299 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Fri, 30 May 2025 22:57:06 +0200
-Subject: [PATCH] net: dsa: b53: prevent SWITCH_CTRL access on BCM5325
+Subject: [RFC PATCH net-next v2 03/10] net: dsa: b53: prevent SWITCH_CTRL
+ access on BCM5325
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -11,6 +12,7 @@ or writing it.
 
 Fixes: a424f0de6163 ("net: dsa: b53: Include IMP/CPU port in dumb forwarding mode")
 Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
 ---
  drivers/net/dsa/b53/b53_common.c | 11 ++++++-----
  1 file changed, 6 insertions(+), 5 deletions(-)

--- a/target/linux/bmips/patches-6.12/133-net-dsa-b53-fix-IP_MULTICAST_CTRL-on-BCM5325.patch
+++ b/target/linux/bmips/patches-6.12/133-net-dsa-b53-fix-IP_MULTICAST_CTRL-on-BCM5325.patch
@@ -1,7 +1,8 @@
-From 85499f7068e67f82194170412617591d3d23a123 Mon Sep 17 00:00:00 2001
+From 566c3b4e4ad6167c5a2fb4357e75eb5ba8d94f64 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Fri, 30 May 2025 23:00:55 +0200
-Subject: [PATCH] net: dsa: b53: fix IP_MULTICAST_CTRL on BCM5325
+Subject: [RFC PATCH net-next v2 04/10] net: dsa: b53: fix IP_MULTICAST_CTRL on
+ BCM5325
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -11,33 +12,38 @@ BCM5325 doesn't implement B53_UC_FWD_EN, B53_MC_FWD_EN or B53_IPMC_FWD_EN.
 Fixes: 53568438e381 ("net: dsa: b53: Add support for port_egress_floods callback")
 Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 ---
- drivers/net/dsa/b53/b53_common.c | 13 +++++++++----
+ drivers/net/dsa/b53/b53_common.c | 18 +++++++++++-------
  drivers/net/dsa/b53/b53_regs.h   |  1 +
- 2 files changed, 10 insertions(+), 4 deletions(-)
+ 2 files changed, 12 insertions(+), 7 deletions(-)
 
 --- a/drivers/net/dsa/b53/b53_common.c
 +++ b/drivers/net/dsa/b53/b53_common.c
-@@ -368,11 +368,16 @@ static void b53_set_forwarding(struct b5
+@@ -366,14 +366,18 @@ static void b53_set_forwarding(struct b5
+ 		b53_read8(dev, B53_CTRL_PAGE, B53_SWITCH_CTRL, &mgmt);
+ 		mgmt |= B53_MII_DUMB_FWDG_EN;
  		b53_write8(dev, B53_CTRL_PAGE, B53_SWITCH_CTRL, mgmt);
- 	}
+-	}
  
 -	/* Look at B53_UC_FWD_EN and B53_MC_FWD_EN to decide whether
 -	 * frames should be flooded or not.
 -	 */
- 	b53_read8(dev, B53_CTRL_PAGE, B53_IP_MULTICAST_CTRL, &mgmt);
+-	b53_read8(dev, B53_CTRL_PAGE, B53_IP_MULTICAST_CTRL, &mgmt);
 -	mgmt |= B53_UC_FWD_EN | B53_MC_FWD_EN | B53_IPMC_FWD_EN;
-+	if (is5325(dev)) {
-+		/* Enable IP multicast address scheme. */
-+		mgmt |= B53_IP_MCAST_25;
-+	} else {
+-	b53_write8(dev, B53_CTRL_PAGE, B53_IP_MULTICAST_CTRL, mgmt);
 +		/* Look at B53_UC_FWD_EN and B53_MC_FWD_EN to decide whether
 +		 * frames should be flooded or not.
 +		 */
++		b53_read8(dev, B53_CTRL_PAGE, B53_IP_MULTICAST_CTRL, &mgmt);
 +		mgmt |= B53_UC_FWD_EN | B53_MC_FWD_EN | B53_IPMC_FWD_EN;
++		b53_write8(dev, B53_CTRL_PAGE, B53_IP_MULTICAST_CTRL, mgmt);
++	} else {
++		b53_read8(dev, B53_CTRL_PAGE, B53_IP_MULTICAST_CTRL, &mgmt);
++		mgmt |= B53_IP_MCAST_25;
++		b53_write8(dev, B53_CTRL_PAGE, B53_IP_MULTICAST_CTRL, mgmt);
 +	}
- 	b53_write8(dev, B53_CTRL_PAGE, B53_IP_MULTICAST_CTRL, mgmt);
  }
  
+ static void b53_enable_vlan(struct b53_device *dev, int port, bool enable,
 --- a/drivers/net/dsa/b53/b53_regs.h
 +++ b/drivers/net/dsa/b53/b53_regs.h
 @@ -106,6 +106,7 @@

--- a/target/linux/bmips/patches-6.12/134-net-dsa-b53-prevent-DIS_LEARNING-access-on-BCM5325.patch
+++ b/target/linux/bmips/patches-6.12/134-net-dsa-b53-prevent-DIS_LEARNING-access-on-BCM5325.patch
@@ -1,7 +1,8 @@
-From 077a4a60a89a0423295a8e5684f7f36bc4b0bc72 Mon Sep 17 00:00:00 2001
+From 2c09136c63be15b91cf39b52a707b3be8eb1fe71 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Fri, 30 May 2025 23:13:01 +0200
-Subject: [PATCH] net: dsa: b53: prevent DIS_LEARNING access on BCM5325
+Subject: [RFC PATCH net-next v2 05/10] net: dsa: b53: prevent DIS_LEARNING
+ access on BCM5325
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -12,12 +13,12 @@ or writing it.
 Fixes: f9b3827ee66c ("net: dsa: b53: Support setting learning on port")
 Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 ---
- drivers/net/dsa/b53/b53_common.c | 3 +++
- 1 file changed, 3 insertions(+)
+ drivers/net/dsa/b53/b53_common.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
 
 --- a/drivers/net/dsa/b53/b53_common.c
 +++ b/drivers/net/dsa/b53/b53_common.c
-@@ -594,6 +594,9 @@ static void b53_port_set_learning(struct
+@@ -593,6 +593,9 @@ static void b53_port_set_learning(struct
  {
  	u16 reg;
  
@@ -27,3 +28,18 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  	b53_read16(dev, B53_CTRL_PAGE, B53_DIS_LEARNING, &reg);
  	if (learning)
  		reg &= ~BIT(port);
+@@ -2246,7 +2249,13 @@ int b53_br_flags_pre(struct dsa_switch *
+ 		     struct switchdev_brport_flags flags,
+ 		     struct netlink_ext_ack *extack)
+ {
+-	if (flags.mask & ~(BR_FLOOD | BR_MCAST_FLOOD | BR_LEARNING))
++	struct b53_device *dev = ds->priv;
++	unsigned long mask = (BR_FLOOD | BR_MCAST_FLOOD);
++
++	if (!is5325(dev))
++		mask |= BR_LEARNING;
++
++	if (flags.mask & ~mask)
+ 		return -EINVAL;
+ 
+ 	return 0;

--- a/target/linux/bmips/patches-6.12/135-net-dsa-b53-prevent-BRCM_HDR-access-on-BCM5325.patch
+++ b/target/linux/bmips/patches-6.12/135-net-dsa-b53-prevent-BRCM_HDR-access-on-BCM5325.patch
@@ -1,7 +1,8 @@
-From 171f3a42be30e2a62c6590ec2b0e5a96ddad57a0 Mon Sep 17 00:00:00 2001
+From 2497ff2da6b938544868e49f6017bdbe56773d80 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Fri, 30 May 2025 23:18:03 +0200
-Subject: [PATCH] net: dsa: b53: prevent BRCM_HDR access on BCM5325
+Subject: [RFC PATCH net-next v2 06/10] net: dsa: b53: prevent BRCM_HDR access
+ on BCM5325
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -11,13 +12,14 @@ writing it.
 
 Fixes: b409a9efa183 ("net: dsa: b53: Move Broadcom header setup to b53")
 Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
 ---
  drivers/net/dsa/b53/b53_common.c | 4 ++++
  1 file changed, 4 insertions(+)
 
 --- a/drivers/net/dsa/b53/b53_common.c
 +++ b/drivers/net/dsa/b53/b53_common.c
-@@ -731,6 +731,10 @@ void b53_brcm_hdr_setup(struct dsa_switc
+@@ -730,6 +730,10 @@ void b53_brcm_hdr_setup(struct dsa_switc
  		hdr_ctl |= GC_FRM_MGMT_PORT_M;
  	b53_write8(dev, B53_MGMT_PAGE, B53_GLOBAL_CONFIG, hdr_ctl);
  

--- a/target/linux/bmips/patches-6.12/136-net-dsa-b53-prevent-GMII_PORT_OVERRIDE_CTRL-access-on-BCM5325.patch
+++ b/target/linux/bmips/patches-6.12/136-net-dsa-b53-prevent-GMII_PORT_OVERRIDE_CTRL-access-on-BCM5325.patch
@@ -1,8 +1,8 @@
-From d2dceddf182520b474d2aab0798d925e47a68c5a Mon Sep 17 00:00:00 2001
+From 4eecebbe332e3cfd8d0aaeb39d764748f25259f1 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Fri, 30 May 2025 23:33:13 +0200
-Subject: [PATCH] net: dsa: b53: prevent GMII_PORT_OVERRIDE_CTRL access on
- BCM5325
+Subject: [RFC PATCH net-next v2 07/10] net: dsa: b53: prevent
+ GMII_PORT_OVERRIDE_CTRL access on BCM5325
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -14,6 +14,7 @@ and we should use PORT_OVERRIDE_LP_FLOW_25 instead.
 
 Fixes: 5e004460f874 ("net: dsa: b53: Add helper to set link parameters")
 Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
 ---
  drivers/net/dsa/b53/b53_common.c | 21 +++++++++++++++++----
  drivers/net/dsa/b53/b53_regs.h   |  1 +
@@ -21,7 +22,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 
 --- a/drivers/net/dsa/b53/b53_common.c
 +++ b/drivers/net/dsa/b53/b53_common.c
-@@ -1279,6 +1279,8 @@ static void b53_force_link(struct b53_de
+@@ -1278,6 +1278,8 @@ static void b53_force_link(struct b53_de
  	if (port == dev->imp_port) {
  		off = B53_PORT_OVERRIDE_CTRL;
  		val = PORT_OVERRIDE_EN;
@@ -30,7 +31,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  	} else {
  		off = B53_GMII_PORT_OVERRIDE_CTRL(port);
  		val = GMII_PO_EN;
-@@ -1303,6 +1305,8 @@ static void b53_force_port_config(struct
+@@ -1302,6 +1304,8 @@ static void b53_force_port_config(struct
  	if (port == dev->imp_port) {
  		off = B53_PORT_OVERRIDE_CTRL;
  		val = PORT_OVERRIDE_EN;
@@ -39,7 +40,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  	} else {
  		off = B53_GMII_PORT_OVERRIDE_CTRL(port);
  		val = GMII_PO_EN;
-@@ -1333,10 +1337,19 @@ static void b53_force_port_config(struct
+@@ -1332,10 +1336,19 @@ static void b53_force_port_config(struct
  		return;
  	}
  

--- a/target/linux/bmips/patches-6.12/137-net-dsa-b53-fix-unicast-multicast-flooding-on-BCM5325.patch
+++ b/target/linux/bmips/patches-6.12/137-net-dsa-b53-fix-unicast-multicast-flooding-on-BCM5325.patch
@@ -1,7 +1,8 @@
-From 1124bbbad49e1a657cb12dd6ab938fcb3035e872 Mon Sep 17 00:00:00 2001
+From e087a6480f0601d2eb2823b2c920ba7929ffafc4 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Sat, 31 May 2025 09:31:55 +0200
-Subject: [PATCH] net: dsa: b53: fix unicast/multicast flooding on BCM5325
+Subject: [RFC PATCH net-next v2 08/10] net: dsa: b53: fix unicast/multicast
+ flooding on BCM5325
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -13,13 +14,13 @@ This has to be handled differently with other pages and registers.
 Fixes: a8b659e7ff75 ("net: dsa: act as passthrough for bridge port flags")
 Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 ---
- drivers/net/dsa/b53/b53_common.c | 85 +++++++++++++++++++++++++-------
- drivers/net/dsa/b53/b53_regs.h   | 38 ++++++++++++++
- 2 files changed, 105 insertions(+), 18 deletions(-)
+ drivers/net/dsa/b53/b53_common.c | 60 ++++++++++++++++++++++----------
+ drivers/net/dsa/b53/b53_regs.h   | 16 +++++++++
+ 2 files changed, 58 insertions(+), 18 deletions(-)
 
 --- a/drivers/net/dsa/b53/b53_common.c
 +++ b/drivers/net/dsa/b53/b53_common.c
-@@ -561,12 +561,36 @@ static void b53_port_set_ucast_flood(str
+@@ -560,12 +560,24 @@ static void b53_port_set_ucast_flood(str
  {
  	u16 uc;
  
@@ -30,8 +31,6 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 -		uc &= ~BIT(port);
 -	b53_write16(dev, B53_CTRL_PAGE, B53_UC_FLOOD_MASK, uc);
 +	if (is5325(dev)) {
-+		u8 rc;
-+
 +		if (port == B53_CPU_PORT_25)
 +			port = B53_CPU_PORT;
 +
@@ -41,16 +40,6 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 +		else
 +			uc &= ~BIT(port);
 +		b53_write16(dev, B53_IEEE_PAGE, B53_IEEE_UCAST_DLF, uc);
-+
-+		if (port >= B53_CPU_PORT_25)
-+			return;
-+
-+		b53_read8(dev, B53_RATE_CTL_PAGE, B53_RATE_CONTROL(port), &rc);
-+		if (unicast)
-+			rc |= (RC_DLF_EN | RC_BKT_SIZE_8K | RC_PERCENT_40);
-+		else
-+			rc &= ~(RC_DLF_EN);
-+		b53_write8(dev, B53_RATE_CTL_PAGE, B53_RATE_CONTROL(port), rc);
 +	} else {
 +		b53_read16(dev, B53_CTRL_PAGE, B53_UC_FLOOD_MASK, &uc);
 +		if (unicast)
@@ -62,7 +51,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
  }
  
  static void b53_port_set_mcast_flood(struct b53_device *dev, int port,
-@@ -574,19 +598,44 @@ static void b53_port_set_mcast_flood(str
+@@ -573,19 +585,31 @@ static void b53_port_set_mcast_flood(str
  {
  	u16 mc;
  
@@ -80,8 +69,6 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 -		mc &= ~BIT(port);
 -	b53_write16(dev, B53_CTRL_PAGE, B53_IPMC_FLOOD_MASK, mc);
 +	if (is5325(dev)) {
-+		u8 rc;
-+
 +		if (port == B53_CPU_PORT_25)
 +			port = B53_CPU_PORT;
 +
@@ -91,17 +78,6 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 +		else
 +			mc &= ~BIT(port);
 +		b53_write16(dev, B53_IEEE_PAGE, B53_IEEE_MCAST_DLF, mc);
-+
-+		if (port >= B53_CPU_PORT_25)
-+			return;
-+
-+		b53_read8(dev, B53_RATE_CTL_PAGE, B53_RATE_CONTROL(port), &rc);
-+		if (multicast)
-+			rc |= (RC_BCAST_EN | RC_MCAST_EN | RC_BKT_SIZE_8K |
-+			       RC_PERCENT_40);
-+		else
-+			rc &= ~(RC_BCAST_EN | RC_MCAST_EN);
-+		b53_write8(dev, B53_RATE_CTL_PAGE, B53_RATE_CONTROL(port), rc);
 +	} else {
 +		b53_read16(dev, B53_CTRL_PAGE, B53_MC_FLOOD_MASK, &mc);
 +		if (multicast)
@@ -157,34 +133,5 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 +
 +/*************************************************************************
   * Port VLAN Registers
-  *************************************************************************/
- 
-@@ -479,6 +495,28 @@
- #define B53_VLAN_PORT_DEF_TAG(i)	(0x10 + 2 * (i))
- 
- /*************************************************************************
-+ * Rate Control Page Registers
-+ *************************************************************************/
-+
-+#define B53_RATE_CONTROL(i)		(0x00 + (i))
-+#define   RC_PERCENT_S			0
-+#define   RC_PERCENT_10			(0 << RC_PERCENT_S)
-+#define   RC_PERCENT_20			(1 << RC_PERCENT_S)
-+#define   RC_PERCENT_30			(2 << RC_PERCENT_S)
-+#define   RC_PERCENT_40			(3 << RC_PERCENT_S)
-+#define   RC_PERCENT_MASK		(3 << RC_PERCENT_S)
-+#define   RC_BKT_SIZE_S			2
-+#define   RC_BKT_SIZE_2K		(0 << RC_BKT_SIZE_S)
-+#define   RC_BKT_SIZE_4K		(1 << RC_BKT_SIZE_S)
-+#define   RC_BKT_SIZE_6K		(2 << RC_BKT_SIZE_S)
-+#define   RC_BKT_SIZE_8K		(3 << RC_BKT_SIZE_S)
-+#define   RC_BKT_SIZE_MASK		(3 << RC_BKT_SIZE_S)
-+#define   RC_DLF_EN			BIT(4)
-+#define   RC_BCAST_EN			BIT(5)
-+#define   RC_MCAST_EN			BIT(6)
-+#define   RC_DROP_FRAME			BIT(7)
-+
-+/*************************************************************************
-  * Jumbo Frame Page Registers
   *************************************************************************/
  

--- a/target/linux/bmips/patches-6.12/138-net-dsa-b53-fix-b53_imp_vlan_setup-for-BCM5325.patch
+++ b/target/linux/bmips/patches-6.12/138-net-dsa-b53-fix-b53_imp_vlan_setup-for-BCM5325.patch
@@ -1,7 +1,8 @@
-From f5ad83d0a9ce63d0524c5838b7f3a7360bd647ec Mon Sep 17 00:00:00 2001
+From dd2bda07009f5c376a11b14c9445ccd11083c024 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Sat, 31 May 2025 11:11:42 +0200
-Subject: [PATCH] net: dsa: b53: fix b53_imp_vlan_setup for BCM5325
+Subject: [RFC PATCH net-next v2 09/10] net: dsa: b53: fix b53_imp_vlan_setup
+ for BCM5325
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -17,7 +18,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 
 --- a/drivers/net/dsa/b53/b53_common.c
 +++ b/drivers/net/dsa/b53/b53_common.c
-@@ -544,6 +544,10 @@ void b53_imp_vlan_setup(struct dsa_switc
+@@ -543,6 +543,10 @@ void b53_imp_vlan_setup(struct dsa_switc
  	unsigned int i;
  	u16 pvlan;
  

--- a/target/linux/bmips/patches-6.12/139-net-dsa-b53-ensure-BCM5325-PHYs-are-enabled.patch
+++ b/target/linux/bmips/patches-6.12/139-net-dsa-b53-ensure-BCM5325-PHYs-are-enabled.patch
@@ -1,28 +1,53 @@
-From 48d5f0b6bbead8e62647a94c18f23be931bcf7b0 Mon Sep 17 00:00:00 2001
+From 4368d82cccd1bdd9339a4aac1ce78873ef0d0031 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
 Date: Sat, 31 May 2025 11:20:13 +0200
-Subject: [PATCH] net: dsa: b53: ensure BCM5325 PHYs are enabled
+Subject: [RFC PATCH net-next v2 10/10] net: dsa: b53: ensure BCM5325 PHYs are
+ enabled
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
 According to the datasheet, BCM5325 uses B53_PD_MODE_CTRL_25 register to
 disable clocking to individual PHYs.
+Only ports 1-4 can be enabled or disabled and the datasheet is explicit
+about not toggling BIT(0) since it disables the PLL power and the switch.
 
 Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 ---
- drivers/net/dsa/b53/b53_common.c | 3 +++
- 1 file changed, 3 insertions(+)
+ drivers/net/dsa/b53/b53_common.c | 13 +++++++++++++
+ drivers/net/dsa/b53/b53_regs.h   |  2 ++
+ 2 files changed, 15 insertions(+)
 
 --- a/drivers/net/dsa/b53/b53_common.c
 +++ b/drivers/net/dsa/b53/b53_common.c
-@@ -1300,6 +1300,9 @@ static int b53_setup(struct dsa_switch *
+@@ -660,6 +660,19 @@ int b53_setup_port(struct dsa_switch *ds
+ 	if (dsa_is_user_port(ds, port))
+ 		b53_set_eap_mode(dev, port, EAP_MODE_SIMPLIFIED);
  
- 	b53_reset_mib(dev);
- 
-+	if (is5325(dev))
-+		b53_write8(dev, B53_CTRL_PAGE, B53_PD_MODE_CTRL_25, 0);
++	if (is5325(dev) &&
++	    (port >= B53_PD_MODE_PORT_MIN) &&
++	    (port <= B53_PD_MODE_PORT_MAX)) {
++		u8 reg;
 +
- 	ret = b53_apply_config(dev);
- 	if (ret) {
- 		dev_err(ds->dev, "failed to apply configuration\n");
++		b53_read8(dev, B53_CTRL_PAGE, B53_PD_MODE_CTRL_25, &reg);
++		if (dsa_is_unused_port(ds, port))
++			reg |= BIT(port);
++		else
++			reg &= ~BIT(port);
++		b53_write8(dev, B53_CTRL_PAGE, B53_PD_MODE_CTRL_25, reg);
++	}
++
+ 	return 0;
+ }
+ EXPORT_SYMBOL(b53_setup_port);
+--- a/drivers/net/dsa/b53/b53_regs.h
++++ b/drivers/net/dsa/b53/b53_regs.h
+@@ -108,6 +108,8 @@
+ 
+ /* Power-down mode control */
+ #define B53_PD_MODE_CTRL_25		0x0f
++#define  B53_PD_MODE_PORT_MIN		1
++#define  B53_PD_MODE_PORT_MAX		4
+ 
+ /* IP Multicast control (8 bit) */
+ #define B53_IP_MULTICAST_CTRL		0x21


### PR DESCRIPTION
Update BCM5325 patches to the latest version sent to netdev.