### PR TITLE
ramips: add backport to fix build for GCC 15.1

### DIFF
--- a/target/linux/generic/backport-6.12/201-v6.16-mips-Add-std-flag-specified.patch
+++ b/target/linux/generic/backport-6.12/201-v6.16-mips-Add-std-flag-specified.patch
@@ -1,0 +1,44 @@
+From 0f4ae7c6ecb89bfda026d210dcf8216fb67d2333 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 29 Mar 2025 08:39:03 -0700
+Subject: mips: Add -std= flag specified in KBUILD_CFLAGS to vdso CFLAGS
+
+GCC 15 changed the default C standard dialect from gnu17 to gnu23,
+which should not have impacted the kernel because it explicitly requests
+the gnu11 standard in the main Makefile. However, mips/vdso code uses
+its own CFLAGS without a '-std=' value, which break with this dialect
+change because of the kernel's own definitions of bool, false, and true
+conflicting with the C23 reserved keywords.
+
+  include/linux/stddef.h:11:9: error: cannot use keyword 'false' as enumeration constant
+     11 |         false   = 0,
+        |         ^~~~~
+  include/linux/stddef.h:11:9: note: 'false' is a keyword with '-std=c23' onwards
+  include/linux/types.h:35:33: error: 'bool' cannot be defined via 'typedef'
+     35 | typedef _Bool                   bool;
+        |                                 ^~~~
+  include/linux/types.h:35:33: note: 'bool' is a keyword with '-std=c23' onwards
+
+Add -std as specified in KBUILD_CFLAGS to the decompressor and purgatory
+CFLAGS to eliminate these errors and make the C standard version of these
+areas match the rest of the kernel.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Cc: stable@vger.kernel.org
+Signed-off-by: Thomas Bogendoerfer <tsbogend@alpha.franken.de>
+---
+ arch/mips/vdso/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+(limited to 'arch/mips/vdso')
+
+--- a/arch/mips/vdso/Makefile
++++ b/arch/mips/vdso/Makefile
+@@ -27,6 +27,7 @@ endif
+ # offsets.
+ cflags-vdso := $(ccflags-vdso) \
+ 	$(filter -W%,$(filter-out -Wa$(comma)%,$(KBUILD_CFLAGS))) \
++	$(filter -std=%,$(KBUILD_CFLAGS)) \
+ 	-O3 -g -fPIC -fno-strict-aliasing -fno-common -fno-builtin -G 0 \
+ 	-mrelax-pic-calls $(call cc-option, -mexplicit-relocs) \
+ 	-fno-stack-protector -fno-jump-tables -DDISABLE_BRANCH_PROFILING \

--- a/target/linux/generic/backport-6.6/201-v6.16-mips-Add-std-flag-specified.patch
+++ b/target/linux/generic/backport-6.6/201-v6.16-mips-Add-std-flag-specified.patch
@@ -1,0 +1,44 @@
+From 0f4ae7c6ecb89bfda026d210dcf8216fb67d2333 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sat, 29 Mar 2025 08:39:03 -0700
+Subject: mips: Add -std= flag specified in KBUILD_CFLAGS to vdso CFLAGS
+
+GCC 15 changed the default C standard dialect from gnu17 to gnu23,
+which should not have impacted the kernel because it explicitly requests
+the gnu11 standard in the main Makefile. However, mips/vdso code uses
+its own CFLAGS without a '-std=' value, which break with this dialect
+change because of the kernel's own definitions of bool, false, and true
+conflicting with the C23 reserved keywords.
+
+  include/linux/stddef.h:11:9: error: cannot use keyword 'false' as enumeration constant
+     11 |         false   = 0,
+        |         ^~~~~
+  include/linux/stddef.h:11:9: note: 'false' is a keyword with '-std=c23' onwards
+  include/linux/types.h:35:33: error: 'bool' cannot be defined via 'typedef'
+     35 | typedef _Bool                   bool;
+        |                                 ^~~~
+  include/linux/types.h:35:33: note: 'bool' is a keyword with '-std=c23' onwards
+
+Add -std as specified in KBUILD_CFLAGS to the decompressor and purgatory
+CFLAGS to eliminate these errors and make the C standard version of these
+areas match the rest of the kernel.
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Cc: stable@vger.kernel.org
+Signed-off-by: Thomas Bogendoerfer <tsbogend@alpha.franken.de>
+---
+ arch/mips/vdso/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+(limited to 'arch/mips/vdso')
+
+--- a/arch/mips/vdso/Makefile
++++ b/arch/mips/vdso/Makefile
+@@ -30,6 +30,7 @@ endif
+ # offsets.
+ cflags-vdso := $(ccflags-vdso) \
+ 	$(filter -W%,$(filter-out -Wa$(comma)%,$(KBUILD_CFLAGS))) \
++	$(filter -std=%,$(KBUILD_CFLAGS)) \
+ 	-O3 -g -fPIC -fno-strict-aliasing -fno-common -fno-builtin -G 0 \
+ 	-mrelax-pic-calls $(call cc-option, -mexplicit-relocs) \
+ 	-fno-stack-protector -fno-jump-tables -DDISABLE_BRANCH_PROFILING \


### PR DESCRIPTION
Add -std=gnu11 to build flags in arch/mips/vdso/Makefile to fix compiling with GCC 15.1. The vDSO is compiled using different flags which ignores KBUILD_CFLAGS. This is a known quirk in the kernel's build system.
```
% dmesg | grep gcc
[    0.000000] Linux version 6.6.93 (facade@redline) (mipsel-openwrt-linux-musl-gcc (OpenWrt GCC 15.1.0 r29972+15-7d617804cfe7) 15.1.0, GNU ld (GNU Binutils) 2.44) #0 SMP Sat Jun  7 12:13:18 2025
```
Error for reference:
```
./include/linux/stddef.h:11:9: error: cannot use keyword 'false' as enumeration constant
   11 |         false   = 0,
      |         ^~~~~
./include/linux/stddef.h:11:9: note: 'false' is a keyword with '-std=c23' onwards
./include/linux/types.h:35:33: error: 'bool' cannot be defined via 'typedef'
   35 | typedef _Bool                   bool;
      |                                 ^~~~
./include/linux/types.h:35:33: note: 'bool' is a keyword with '-std=c23' onwards
./include/linux/types.h:35:1: error: useless type name in empty declaration [-Werror]
   35 | typedef _Bool                   bool;
      | ^~~~~~~
  CC      arch/mips/lib/delay.o
  AR      arch/mips/fw/lib/built-in.a
  AR      arch/mips/fw/lib/lib.a
  CC      arch/mips/ralink/of.o
  CC      fs/read_write.o
  CC      block/elevator.o
cc1: all warnings being treated as errors
make[9]: *** [scripts/Makefile.build:243: arch/mips/vdso/vgettimeofday.o] Error 1
make[8]: *** [scripts/Makefile.build:480: arch/mips/vdso] Error 2
```
Build system: x86/64
Build-tested: ramips/tplink_archer-a6-v3
Run-tested: ramips/tplink_archer-a6-v3
