### PR TITLE
bmips: bcm6358: add support for Huawei HG556a ver A

### DIFF
--- a/target/linux/bmips/bcm6358/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm6358/base-files/etc/board.d/01_leds
@@ -6,6 +6,7 @@
 board_config_update
 
 case "$(board_name)" in
+huawei,hg556a-a |\
 huawei,hg556a-b)
 	ucidef_set_led_netdev "lan1" "LAN1" "green:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "LAN2" "green:lan2" "lan2"

--- a/target/linux/bmips/bcm6358/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6358/base-files/etc/board.d/02_network
@@ -5,6 +5,7 @@
 board_config_update
 
 case "$(board_name)" in
+huawei,hg556a-a |\
 huawei,hg556a-b)
 	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"

--- a/target/linux/bmips/bcm6358/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/bmips/bcm6358/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -23,6 +23,9 @@ caldata_extract_swap() {
 case "$FIRMWARE" in
 	"ath9k-eeprom-pci-0000:00:01.0.bin")
 		case "$(board_name)" in
+			huawei,hg556a-a)
+				caldata_extract_swap "cal_data" 0x9e000 0xeb8
+				;;
 			huawei,hg556a-b)
 				caldata_extract_swap "cal_data" 0x1e000 0xeb8
 				;;

--- a/target/linux/bmips/dts/bcm6358-huawei-hg556a-a.dts
+++ b/target/linux/bmips/dts/bcm6358-huawei-hg556a-a.dts
@@ -3,8 +3,8 @@
 #include "bcm6358-huawei-hg556a.dtsi"
 
 / {
-	model = "Huawei EchoLife HG556a (version B)";
-	compatible = "huawei,hg556a-b", "brcm,bcm6358";
+	model = "Huawei EchoLife HG556a (version A)";
+	compatible = "huawei,hg556a-a", "brcm,bcm6358";
 
 	ath9k-leds {
 		compatible = "gpio-leds";
@@ -59,7 +59,7 @@
 	status = "okay";
 
 	ath9k: wifi@1,0 {
-		compatible = "pci168c,0029";
+		compatible = "pci168c,ff1d";
 		reg = <0x0800 0 0 0 0>;
 
 		qca,no-eeprom;

--- a/target/linux/bmips/dts/bcm6358-huawei-hg556a.dtsi
+++ b/target/linux/bmips/dts/bcm6358-huawei-hg556a.dtsi
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6358.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_power_red;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_red;
+		led-upgrade = &led_power_red;
+	};
+
+	gpio_keys: keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		wlan {
+			label = "wlan";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+
+		restart {
+			label = "restart";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_CONFIG>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio_leds: leds {
+		compatible = "gpio-leds";
+
+		led-2 {
+			label = "red:dsl";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_red: led-3 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led-13 {
+			label = "red:lan1";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led-22 {
+			label = "red:lan2";
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		led-23 {
+			label = "green:lan3";
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led-26 {
+			label = "red:lan3";
+			gpios = <&gpio 26 GPIO_ACTIVE_LOW>;
+		};
+
+		led-27 {
+			label = "green:lan4";
+			gpios = <&gpio 27 GPIO_ACTIVE_LOW>;
+		};
+
+		led-28 {
+			label = "red:lan4";
+			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0 0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "mii";
+
+	fixed-link {
+		speed = <100>;
+		full-duplex;
+	};
+};
+
+&iudma {
+	status = "okay";
+};
+
+&mdio1 {
+	switch@1e {
+		compatible = "brcm,bcm5325";
+		reg = <30>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan1";
+
+				phy-mode = "mii";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan2";
+
+				phy-mode = "mii";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+
+				phy-mode = "mii";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan4";
+
+				phy-mode = "mii";
+			};
+
+			port@5 {
+				reg = <5>;
+				label = "cpu";
+
+				phy-mode = "internal";
+				ethernet = <&ethernet1>;
+
+				fixed-link {
+					speed = <100>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pflash {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "cfe";
+			reg = <0x000000 0x020000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_cfe_6a0: macaddr@6a0 {
+					compatible = "mac-base";
+					reg = <0x6a0 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@20000 {
+			label = "firmware";
+			reg = <0x020000 0xec0000>;
+			compatible = "brcm,bcm963xx-imagetag";
+		};
+
+		cal_data: partition@ee0000 {
+			label = "cal_data";
+			reg = <0xee0000 0x100000>;
+			read-only;
+		};
+
+		partition@fe0000 {
+			label = "nvram";
+			reg = <0xfe0000 0x020000>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};

--- a/target/linux/bmips/image/bcm6358.mk
+++ b/target/linux/bmips/image/bcm6358.mk
@@ -1,5 +1,19 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+define Device/huawei_hg556a-a
+  $(Device/bcm63xx-cfe-legacy)
+  DEVICE_VENDOR := Huawei
+  DEVICE_MODEL := EchoLife HG556a
+  DEVICE_VARIANT := A
+  CHIP_ID := 6358
+  CFE_BOARD_ID := HW556
+  CFE_EXTRAS += --rsa-signature "EchoLife_HG556a" --tag-version 8
+  IMAGE_OFFSET := 0x20000
+  DEVICE_PACKAGES += $(USB2_PACKAGES) $(ATH9K_PACKAGES) \
+    kmod-leds-gpio
+endef
+TARGET_DEVICES += huawei_hg556a-a
+
 define Device/huawei_hg556a-b
   $(Device/bcm63xx-cfe-legacy)
   DEVICE_VENDOR := Huawei


### PR DESCRIPTION
This board is pretty similar to the HG556a ver A but the Atheros calibration data is located on a different offset and the flash erasesize is 0x10000 instead of 0x20000.