### PR TITLE
bmips: bcm6358: add support for Huawei HG556a ver C

### DIFF
--- a/target/linux/bmips/bcm6358/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm6358/base-files/etc/board.d/01_leds
@@ -7,7 +7,8 @@ board_config_update
 
 case "$(board_name)" in
 huawei,hg556a-a |\
-huawei,hg556a-b)
+huawei,hg556a-b |\
+huawei,hg556a-c)
 	ucidef_set_led_netdev "lan1" "LAN1" "green:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "LAN2" "green:lan2" "lan2"
 	ucidef_set_led_netdev "lan3" "LAN3" "green:lan3" "lan3"

--- a/target/linux/bmips/bcm6358/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6358/base-files/etc/board.d/02_network
@@ -6,7 +6,8 @@ board_config_update
 
 case "$(board_name)" in
 huawei,hg556a-a |\
-huawei,hg556a-b)
+huawei,hg556a-b |\
+huawei,hg556a-c)
 	ucidef_set_bridge_device switch
 	ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 	;;

--- a/target/linux/bmips/dts/bcm6358-huawei-hg556a-c.dts
+++ b/target/linux/bmips/dts/bcm6358-huawei-hg556a-c.dts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6358-huawei-hg556a.dtsi"
+
+/ {
+	model = "Huawei EchoLife HG556a (version C)";
+	compatible = "huawei,hg556a-c", "brcm,bcm6358";
+};
+
+&gpio_keys {
+	help {
+		label = "help";
+		gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		linux,code = <KEY_HELP>;
+		debounce-interval = <60>;
+	};
+};
+
+&gpio_leds {
+	led-0 {
+		label = "green:lan1";
+		gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+	};
+
+	led-1 {
+		label = "green:lan2";
+		gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+	};
+
+	led-12 {
+		label = "red:message";
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+	};
+
+	led-15 {
+		label = "red:hspa";
+		gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&pci {
+	status = "okay";
+
+	wifi@1,0 {
+		compatible = "pci0,0";
+		reg = <0x0800 0 0 0 0>;
+
+		ralink,mtd-eeprom = <&cal_data 0x1fe00>;
+
+		nvmem-cells = <&macaddr_cfe_6a0 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/bmips/image/Makefile
+++ b/target/linux/bmips/image/Makefile
@@ -366,6 +366,7 @@ endef
 ### Package helpers ###
 ATH9K_PACKAGES := kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
 B43_PACKAGES := kmod-b43 wpad-basic-mbedtls
+RT28_PACKAGES := kmod-rt2800-pci wpad-basic-mbedtls
 USB1_PACKAGES := kmod-usb-ohci kmod-usb-ledtrig-usbport
 USB2_PACKAGES := $(USB1_PACKAGES) kmod-usb2
 

--- a/target/linux/bmips/image/bcm6358.mk
+++ b/target/linux/bmips/image/bcm6358.mk
@@ -27,3 +27,17 @@ define Device/huawei_hg556a-b
     kmod-leds-gpio
 endef
 TARGET_DEVICES += huawei_hg556a-b
+
+define Device/huawei_hg556a-c
+  $(Device/bcm63xx-cfe-legacy)
+  DEVICE_VENDOR := Huawei
+  DEVICE_MODEL := EchoLife HG556a
+  DEVICE_VARIANT := C
+  CHIP_ID := 6358
+  CFE_BOARD_ID := HW556
+  CFE_EXTRAS += --rsa-signature "EchoLife_HG556a" --tag-version 8
+  BLOCKSIZE := 0x20000
+  DEVICE_PACKAGES += $(USB2_PACKAGES) $(RT28_PACKAGES) \
+    kmod-leds-gpio
+endef
+TARGET_DEVICES += huawei_hg556a-c


### PR DESCRIPTION
This board is pretty similar to the HG556a ver B but uses Ralink for wifi
instead of Atheros.

I do not own this device, so it would be great if someone could test if everything is working.