### PR TITLE
realtek: Add support for ZyXEL XGS1210-12 Switch

### DIFF
--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12.dts
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/thermal/thermal.h>
+
+/ {
+	compatible = "zyxel,xgs1210-12", "realtek,rtl838x-soc";
+	model = "Zyxel XGS1210-12 Switch";
+
+	aliases {
+		led-boot = &led_pwr_sys;
+		led-failsafe = &led_pwr_sys;
+		led-running = &led_pwr_sys;
+		led-upgrade = &led_pwr_sys;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		mode {
+			label = "reset";
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	/* i2c of the SFP cage: port 11 & port 12 */
+	i2c0: i2c-rtl9300@1b00036c {
+		compatible = "realtek,rtl9300-i2c";
+		reg = <0x1b00036c 0x3c>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		sda-pin = <9>;
+		scl-pin = <8>;
+		clock-frequency = <100000>;
+	};
+
+	i2cmux {
+		compatible = "realtek,rtl9302-i2c-mux", "realtek,i2c-mux-rtl9300";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-parent = <&i2c0>;
+
+		/* i2c of the left SFP+ cage as seen from the front: port 11 */
+		i2c0_0: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			sda-pin = <9>;
+			scl-pin = <8>;
+		};
+
+		/* i2c of the right SFP+ cage as seen from the front: port 12 */
+		i2c0_1: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			sda-pin = <10>;
+			scl-pin = <8>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>;
+
+		led_pwr_sys: led-0 {
+			label = "green:power";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	sfp0: sfp-p11 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_0>;
+		los-gpio = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp1: sfp-p12 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0_1>;
+		los-gpio = <&gpio0 17 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 15 GPIO_ACTIVE_HIGH>;
+	};
+
+	led_set: led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		// LED set 0:
+		// Amber: 100M/10M
+		// Yellow: 1G
+		led_set0 = <0x0a20 0x0b80>;
+
+		// LED set 1:
+		// Blue: 2.5G
+		// Green: 2.5G
+		// Yellow: 1G
+		// Amber: 100M/10M
+		// (Blue + Green = Cyan)
+		led_set1 = <0x0b80 0x0a20 0x0a08 0x0a08>;
+
+		// LED set 2:
+		// Blue: 10G/5G/2.5G
+		// Yellow: 5G/2.5G/1G
+		// (Blue + Yellow = Purple)
+		led_set2 = <0x0a2a 0x0a0b>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x10000>;
+			};
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0xf0000 0x10000>;
+				read-only;
+			};
+			partition@100000 {
+				label = "jffs2-cfg";
+				reg = <0x100000 0x100000>;
+			};
+			partition@200000 {
+				label = "jffs2-log";
+				reg = <0x200000 0x100000>;
+			};
+			partition@b300000 {
+				label = "firmware";
+				reg = <0x300000 0xce0000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x93001210>;
+			};
+			partition@fe0000 {
+				label = "log";
+				reg = <0xfe0000 0x20000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* External RTL8218D PHY */
+		phy0: ethernet-phy@0 {
+			reg = <0>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 0>;
+			sds = < 2 >;
+			// Disabled because we do not know how to bring up again
+			// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+		};
+		phy1: ethernet-phy@1 {
+			reg = <1>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 1>;
+		};
+		phy2: ethernet-phy@2 {
+			reg = <2>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 2>;
+		};
+		phy3: ethernet-phy@3 {
+			reg = <3>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 3>;
+		};
+		phy4: ethernet-phy@4 {
+			reg = <4>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 4>;
+		};
+		phy5: ethernet-phy@5 {
+			reg = <5>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 5>;
+		};
+		phy6: ethernet-phy@6 {
+			reg = <6>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 6>;
+		};
+		phy7: ethernet-phy@7 {
+			reg = <7>;
+			compatible = "ethernet-phy-ieee802.3-c22";
+			rtl9300,smi-address = <0 7>;
+		};
+
+		/* External RTL8226 PHYs */
+		phy24: ethernet-phy@24 {
+			reg = <24>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <1 8>;
+			sds = < 6 >;
+			// Disabled because we do not know how to bring up again
+			// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+		};
+
+		phy25: ethernet-phy@25 {
+			reg = <25>;
+			compatible = "ethernet-phy-ieee802.3-c45";
+			rtl9300,smi-address = <2 9>;
+			sds = < 7 >;
+			// Disabled because we do not know how to bring up again
+			// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+		};
+
+		/* SFP0 Ports */
+		phy26: ethernet-phy@26 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+			reg = <26>;
+			sds = < 8 >;
+		};
+
+		/* SFP1 Ports */
+		phy27: ethernet-phy@27 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+			reg = <27>;
+			sds = < 9 >;
+		};
+
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			phy-handle = <&phy0>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+			phy-handle = <&phy1>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+			phy-handle = <&phy2>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+			phy-handle = <&phy3>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@4 {
+			reg = <4>;
+			label = "lan5";
+			phy-handle = <&phy4>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@5 {
+			reg = <5>;
+			label = "lan6";
+			phy-handle = <&phy5>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@6 {
+			reg = <6>;
+			label = "lan7";
+			phy-handle = <&phy6>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@7 {
+			reg = <7>;
+			label = "lan8";
+			phy-handle = <&phy7>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+
+		port@24 {
+			reg = <24>;
+			label = "lan9";
+			phy-mode = "hsgmii";
+			phy-handle = <&phy24>;
+			led-set = <1>;
+		};
+		port@25 {
+			reg = <25>;
+			label = "lan10";
+			phy-mode = "hsgmii";
+			phy-handle = <&phy25>;
+			led-set = <1>;
+		};
+
+		port@26 {
+			reg = <26>;
+			label = "lan11";
+			phy-mode = "1000base-x";	//"10gbase-r";
+			pseudo-phy-handle = <&phy26>;
+			sfp = <&sfp0>;
+			led-set = <2>;
+			managed = "in-band-status";
+		};
+
+		port@27 {
+			reg = <27>;
+			label = "lan12";
+			phy-mode = "1000base-x";
+			pseudo-phy-handle = <&phy27>;
+			sfp = <&sfp1>;
+			led-set = <2>;
+			managed = "in-band-status";
+		};
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -20,6 +20,22 @@ define Device/xikestor_sks8300-8x
 endef
 TARGET_DEVICES += xikestor_sks8300-8x
 
+define Device/zyxel_xgs1210-12
+  SOC := rtl9302
+  UIMAGE_MAGIC := 0x93001210
+  ZYXEL_VERS := ABTY
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := XGS1210-12
+  IMAGE_SIZE := 13312k
+  KERNEL_INITRAMFS := \
+        kernel-bin | \
+        append-dtb | \
+        gzip | \
+        zyxel-vers | \
+        uImage gzip
+endef
+TARGET_DEVICES += zyxel_xgs1210-12
+
 define Device/zyxel_xgs1250-12
   SOC := rtl9302
   UIMAGE_MAGIC := 0x93001250
@@ -36,3 +52,4 @@ define Device/zyxel_xgs1250-12
 	uImage gzip
 endef
 TARGET_DEVICES += zyxel_xgs1250-12
+


### PR DESCRIPTION
The ZyXEL XGS1210-12 Switch is a 10 + 2 port multi-GBit switch:
- 8 x 10/100/1000BaseT Ethernet ports
- 2 x 10/100/1000/2500BaseT Ethernet ports
- 2 SFP+ cages (1G and 10G)

Hardware:
- RTL9302B SoC
- Macronix MX25L12833F (16MB flash)
- Nanja NT5CC64M16GP-1 (128MB DDR3 SDRAM)
- RTL8231 GPIO extender to control the port LEDs
- RTL8218D 8x Gigabit PHY
- RTL8226 2x 2.5Gigabit PHY
- SFP+ 2x 10GBit slot

At this commit, all ethernet ports work under OpenWRT, including the various NBaseT modes and the SFP+ are working with 10G and 1G module with i2c support for both ports, tested with:
- SFP FS SFP1G-LX-31
- SFP FS SFP-10GLR-31
- SFP Arpers SFP-10G-T-COM
- DAC Molex 10G
- DAC FS SFP-PC02 1G

EDIT: The support for these SFP have been moved to an other branch.

There was a previous request with [23.05](https://github.com/openwrt/openwrt/pull/17161) this request has the minimum changes in order to test with the hardware I have. There was also other adjustement for the [led](https://github.com/openwrt/openwrt/commit/005edf9428b5efe38d1da3d26878cf4787a53cf4) register and [debugfs](https://github.com/openwrt/openwrt/commit/9f19c6321b99580597314bdfb7f53891ed3f5062) for testing.
