### PR TITLE
ramips: fix wifi nodes to upstream standards

### DIFF
--- a/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
+++ b/target/linux/ramips/dts/mt7620a_alfa-network_ac1200rm.dts
@@ -84,7 +84,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_asus_rt-ac51u.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rt-ac51u.dts
@@ -7,6 +7,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_asus_rt-ac54u.dts
+++ b/target/linux/ramips/dts/mt7620a_asus_rt-ac54u.dts
@@ -9,6 +9,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_bdcom_wap2100-sk.dts
+++ b/target/linux/ramips/dts/mt7620a_bdcom_wap2100-sk.dts
@@ -155,6 +155,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_bolt_bl100.dts
+++ b/target/linux/ramips/dts/mt7620a_bolt_bl100.dts
@@ -238,7 +238,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_cameo_810.dtsi
+++ b/target/linux/ramips/dts/mt7620a_cameo_810.dtsi
@@ -176,6 +176,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_28 2>;

--- a/target/linux/ramips/dts/mt7620a_dlink_dir-510l.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-510l.dts
@@ -134,7 +134,8 @@
 };
 
 &pcie0 {
-	mt76x0e@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_config_e05d>, <&macaddr_config_e490 2>;
 		nvmem-cell-names = "eeprom", "mac-address";

--- a/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dir-806a-b1.dts
@@ -157,6 +157,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_8004 (-3)>;

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a1.dts
@@ -163,6 +163,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_config_e083>, <&macaddr_config_e496 2>;
 		nvmem-cell-names = "eeprom", "mac-address";

--- a/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
+++ b/target/linux/ramips/dts/mt7620a_dlink_dwr-118-a2.dts
@@ -156,6 +156,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&macaddr_config_e4a8 2>;

--- a/target/linux/ramips/dts/mt7620a_domywifi.dtsi
+++ b/target/linux/ramips/dts/mt7620a_domywifi.dtsi
@@ -183,6 +183,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
+++ b/target/linux/ramips/dts/mt7620a_dovado_tiny-ac.dts
@@ -162,7 +162,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6208ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6208ac-v2.dts
@@ -213,6 +213,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_br-6478ac-v2.dts
@@ -215,6 +215,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-7478apc.dts
@@ -207,6 +207,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_edimax_ew-747x.dtsi
@@ -208,6 +208,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_4 2>;

--- a/target/linux/ramips/dts/mt7620a_fon_fon2601.dts
+++ b/target/linux/ramips/dts/mt7620a_fon_fon2601.dts
@@ -175,7 +175,7 @@
 };
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
+++ b/target/linux/ramips/dts/mt7620a_glinet_gl-mt750.dts
@@ -156,7 +156,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
+++ b/target/linux/ramips/dts/mt7620a_iodata_wn-ac1167gr.dts
@@ -228,6 +228,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_iNIC_rf_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
+++ b/target/linux/ramips/dts/mt7620a_lava_lr-25g001.dts
@@ -165,7 +165,8 @@
 };
 
 &pcie0 {
-	mt76x0e@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_config_e08a>, <&macaddr_config_e07e 2>;
 		nvmem-cell-names = "eeprom", "mac-address";

--- a/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_lenovo_newifi-y1.dtsi
@@ -100,7 +100,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
+++ b/target/linux/ramips/dts/mt7620a_netgear_ex3x00_ex61xx.dtsi
@@ -151,7 +151,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
+++ b/target/linux/ramips/dts/mt7620a_phicomm_k2x.dtsi
@@ -111,7 +111,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
+++ b/target/linux/ramips/dts/mt7620a_phicomm_psg1208.dts
@@ -130,7 +130,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-750dhp.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-750dhp.dts
@@ -146,7 +146,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
+++ b/target/linux/ramips/dts/mt7620a_planex_mzk-ex750np.dts
@@ -171,7 +171,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7610e-evb.dts
+++ b/target/linux/ramips/dts/mt7620a_ralink_mt7620a-mt7610e-evb.dts
@@ -91,6 +91,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_tplink_8m.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_8m.dtsi
@@ -137,7 +137,8 @@
 };
 
 &pcie0 {
-	wifi: mt76@0,0 {
+	wifi: wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};

--- a/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-mr200.dts
@@ -218,7 +218,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_radio_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
+++ b/target/linux/ramips/dts/mt7620a_tplink_re2x0-v1.dtsi
@@ -115,7 +115,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_uboot_1fc00 2>;

--- a/target/linux/ramips/dts/mt7620a_trendnet_tha103ac.dts
+++ b/target/linux/ramips/dts/mt7620a_trendnet_tha103ac.dts
@@ -193,6 +193,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_8004 0>;

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn530hg4.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn530hg4.dts
@@ -145,7 +145,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn531g3-a2.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn531g3-a2.dts
@@ -175,7 +175,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_radio_8000>;

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn531g3.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn531g3.dts
@@ -181,7 +181,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_radio_8000>;

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn535k1.dts
@@ -141,6 +141,7 @@
 
 &pcie0 {
 	wifi0: wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_wavlink_wl-wn579x3.dts
+++ b/target/linux/ramips/dts/mt7620a_wavlink_wl-wn579x3.dts
@@ -175,6 +175,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
+++ b/target/linux/ramips/dts/mt7620a_xiaomi_miwifi-mini.dts
@@ -179,7 +179,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-ape522ii.dts
@@ -135,7 +135,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026-5g.dtsi
+++ b/target/linux/ramips/dts/mt7620a_zbtlink_zbt-we1026-5g.dtsi
@@ -46,7 +46,7 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_ampedwireless_ally.dtsi
+++ b/target/linux/ramips/dts/mt7621_ampedwireless_ally.dtsi
@@ -66,7 +66,7 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci14c3,7615";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -76,7 +76,7 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "pci14c3,7615";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_arcadyan_we420223-99.dts
+++ b/target/linux/ramips/dts/mt7621_arcadyan_we420223-99.dts
@@ -212,7 +212,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_asus_rt-acx5p.dtsi
+++ b/target/linux/ramips/dts/mt7621_asus_rt-acx5p.dtsi
@@ -134,7 +134,7 @@
 
 &pcie0 {
 	wifi0: wifi@0,0 {
-		compatible = "pci14c3,7615";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -144,7 +144,7 @@
 
 &pcie1 {
 	wifi1: wifi@0,0 {
-		compatible = "pci14c3,7615";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo.dts
+++ b/target/linux/ramips/dts/mt7621_beeline_smartbox-turbo.dts
@@ -9,6 +9,8 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_21000 5>;
 		nvmem-cell-names = "eeprom", "mac-address";
 	};
@@ -16,6 +18,8 @@
 
 &pcie1 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_21000 4>;
 		nvmem-cell-names = "eeprom", "mac-address";
 	};

--- a/target/linux/ramips/dts/mt7621_bolt_arion.dts
+++ b/target/linux/ramips/dts/mt7621_bolt_arion.dts
@@ -143,7 +143,7 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci14c3,7603";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -153,7 +153,7 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-1166dhp.dts
@@ -214,7 +214,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
@@ -223,7 +224,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhplx.dtsi
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-2533dhplx.dtsi
@@ -147,6 +147,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -156,6 +157,7 @@
 
 &pcie1 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
+++ b/target/linux/ramips/dts/mt7621_buffalo_wsr-600dhp.dts
@@ -179,7 +179,8 @@
 };
 
 &pcie0 {
-	rt5592@0,0 {
+	wifi@0,0 {
+		compatible = "pci1814,5592";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
@@ -187,7 +188,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_wr1300-v1.dts
@@ -152,7 +152,7 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci14c3,7603";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 0>;
 		nvmem-cell-names = "eeprom", "mac-address";
@@ -166,7 +166,7 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_bdinfo_de00 2>;
 		nvmem-cell-names = "eeprom", "mac-address";

--- a/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_newifi-d2.dts
@@ -149,7 +149,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
@@ -158,7 +159,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
+++ b/target/linux/ramips/dts/mt7621_d-team_pbr-m1.dts
@@ -171,7 +171,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
@@ -180,7 +181,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-860l-b1.dts
@@ -180,7 +180,8 @@
 };
 
 &pcie0 {
-	wifi0: mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_radio_2000>;
 		nvmem-cell-names = "eeprom";
@@ -189,7 +190,8 @@
 };
 
 &pcie1 {
-	wifi1: mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_radio_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_firefly_firewrt.dts
+++ b/target/linux/ramips/dts/mt7621_firefly_firewrt.dts
@@ -111,7 +111,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
@@ -120,7 +121,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_gehua_ghl-r-001.dts
+++ b/target/linux/ramips/dts/mt7621_gehua_ghl-r-001.dts
@@ -110,6 +110,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -118,6 +119,7 @@
 
 &pcie1 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_huasifei_ws1208v2.dts
+++ b/target/linux/ramips/dts/mt7621_huasifei_ws1208v2.dts
@@ -134,7 +134,7 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci14c3,7603";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -143,7 +143,7 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax1167gr.dts
@@ -214,7 +214,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_iNIC_rf_0>;
 		nvmem-cell-names = "eeprom";
@@ -222,7 +223,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_iodata_wn-gx300gr.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-gx300gr.dts
@@ -200,7 +200,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
+++ b/target/linux/ramips/dts/mt7621_lenovo_newifi-d1.dts
@@ -132,7 +132,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
@@ -141,7 +142,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_linksys_e5600.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_e5600.dts
@@ -152,7 +152,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
@@ -161,7 +161,7 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;

--- a/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
@@ -180,7 +180,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
@@ -189,7 +189,7 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;

--- a/target/linux/ramips/dts/mt7621_linksys_re6500.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_re6500.dts
@@ -117,7 +117,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -126,7 +127,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_linksys_re7000.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_re7000.dts
@@ -131,7 +131,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -140,7 +141,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_meig_slt866.dts
+++ b/target/linux/ramips/dts/mt7621_meig_slt866.dts
@@ -217,7 +217,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>, <&macaddr_custom_100 0>;
@@ -226,7 +226,7 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_mqmaker_witi.dts
+++ b/target/linux/ramips/dts/mt7621_mqmaker_witi.dts
@@ -96,7 +96,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_e000 0>;
@@ -105,7 +106,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <2400000 2500000>;
 		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000 0>;

--- a/target/linux/ramips/dts/mt7621_mtc_wr1201.dts
+++ b/target/linux/ramips/dts/mt7621_mtc_wr1201.dts
@@ -182,6 +182,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_factory_8000>;
@@ -196,6 +197,7 @@
 
 &pcie1 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <2400000 2500000>;
 		nvmem-cells = <&eeprom_factory_0>;

--- a/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_ex6150.dts
@@ -235,6 +235,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
@@ -244,6 +245,7 @@
 
 &pcie1 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_ayx.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_ayx.dtsi
@@ -82,7 +82,7 @@
 &pcie0 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
-		reg = <0x0 0 0 0 0>;
+		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom1>;
 		nvmem-cell-names = "eeprom";
@@ -92,7 +92,7 @@
 &pcie2 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
-		reg = <0x0 0 0 0 0>;
+		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <2400000 2500000>;
 		nvmem-cells = <&eeprom0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_bzv.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_bzv.dtsi
@@ -153,7 +153,7 @@
 &pcie0 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
-		reg = <0x0 0 0 0 0>;
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -163,7 +163,7 @@
 &pcie1 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
-		reg = <0x0 0 0 0 0>;
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
+++ b/target/linux/ramips/dts/mt7621_netgear_sercomm_chj.dtsi
@@ -71,7 +71,7 @@
 &pcie0 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
-		reg = <0x0 0 0 0 0>;
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
@@ -81,7 +81,7 @@
 &pcie1 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
-		reg = <0x0 0 0 0 0>;
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7621_netgear_wac104.dts
+++ b/target/linux/ramips/dts/mt7621_netgear_wac104.dts
@@ -137,7 +137,7 @@
 &pcie0 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
-		reg = <0x0 0 0 0 0>;
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
@@ -147,7 +147,7 @@
 &pcie2 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
-		reg = <0x0 0 0 0 0>;
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7621_rostelecom_rt-sf-1.dts
+++ b/target/linux/ramips/dts/mt7621_rostelecom_rt-sf-1.dts
@@ -9,6 +9,8 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_21000 3>;
 		nvmem-cell-names = "eeprom", "mac-address";
 	};
@@ -16,6 +18,8 @@
 
 &pcie1 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_21000 2>;
 		nvmem-cell-names = "eeprom", "mac-address";
 	};

--- a/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
+++ b/target/linux/ramips/dts/mt7621_samknows_whitebox-v8.dts
@@ -116,7 +116,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
@@ -125,7 +126,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_sercomm_na502.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502.dts
@@ -206,7 +206,7 @@
 &pcie2 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
-		reg = <0x0 0 0 0 0>;
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000 2>;
 		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7621_sercomm_na502s.dts
+++ b/target/linux/ramips/dts/mt7621_sercomm_na502s.dts
@@ -310,7 +310,7 @@
 &pcie2 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
-		reg = <0x0 0 0 0 0>;
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000 2>;
 		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;

--- a/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
+++ b/target/linux/ramips/dts/mt7621_telco-electronics_x1.dts
@@ -193,7 +193,7 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci14c3,7603";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -203,7 +203,7 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_tenbay_t-mb5eu-v01.dts
+++ b/target/linux/ramips/dts/mt7621_tenbay_t-mb5eu-v01.dts
@@ -104,7 +104,7 @@
 &pcie1 {
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
-		reg = <0x0 0 0 0 0>;
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;

--- a/target/linux/ramips/dts/mt7621_tozed_zlt-s12-pro.dts
+++ b/target/linux/ramips/dts/mt7621_tozed_zlt-s12-pro.dts
@@ -199,7 +199,7 @@
 };
 
 &pcie0 {
-	wifi0: mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
@@ -209,7 +209,7 @@
 };
 
 &pcie1 {
-	wifi1: mt76@0,0 {
+	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;

--- a/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_archer-c6u-v1.dts
@@ -164,7 +164,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_8 0>;
@@ -174,7 +174,7 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_8 (-1)>;

--- a/target/linux/ramips/dts/mt7621_tplink_eap235-wall-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap235-wall-v1.dts
@@ -160,6 +160,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_radio_0>, <&macaddr_info_8 0>;
 		nvmem-cell-names = "eeprom", "mac-address";
@@ -168,6 +169,7 @@
 
 &pcie1 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_info_8 1>;

--- a/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
@@ -165,7 +165,7 @@
 
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_radio_0>, <&macaddr_romfile_f100 0>;
@@ -175,7 +175,7 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_re350-v1.dts
@@ -157,7 +157,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_radio_0>, <&macaddr_config_10008 1>;
 		nvmem-cell-names = "eeprom", "mac-address";
@@ -165,7 +166,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_10008 2>;

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
@@ -118,8 +118,6 @@
 };
 
 &wlan_5g {
-	compatible = "mediatek,mt76";
-
 	/* This is a workaround.
 	 *
 	 * Ubiquiti uses a +2 offset in the first octet relative

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-flexhd.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-flexhd.dts
@@ -141,7 +141,8 @@
 
 &pcie0 {
 	wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
 		// On newer devices there is a MediaTek MAC in the above
 		// device EEPROM, so override it with a calculated one.
 		nvmem-cells = <&eeprom_factory_0>, <&macaddr_eeprom_0 1>;
@@ -151,7 +152,8 @@
 
 &pcie1 {
 	wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
 		// On newer devices there is a MediaTek MAC in the above
 		// device EEPROM, so override it with a calculated one.
 		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_eeprom_0 2>;

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi.dtsi
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi.dtsi
@@ -49,13 +49,15 @@
 
 &pcie0 {
 	wlan_2g: wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
 	};
 };
 
 &pcie1 {
 	wlan_5g: wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn53xax.dtsi
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn53xax.dtsi
@@ -142,7 +142,7 @@
 };
 
 &pcie0 {
-	wifi0: mt76@0,0 {
+	wifi0: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
@@ -151,7 +151,7 @@
 };
 
 &pcie1 {
-	wifi1: mt76@0,0 {
+	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;

--- a/target/linux/ramips/dts/mt7621_wavlink_ws-wn572hp3-4g.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_ws-wn572hp3-4g.dts
@@ -133,7 +133,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <2400000 2500000>;
@@ -143,7 +143,7 @@
 };
 
 &pcie1 {
-	wifi1: mt76@0,0 {
+	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3g.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3g.dts
@@ -65,7 +65,7 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci14c3,7603";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -75,7 +75,7 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-4.dts
@@ -53,7 +53,7 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci14c3,7603";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -63,7 +63,7 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
+++ b/target/linux/ramips/dts/mt7621_xzwifi_creativebox-v1.dts
@@ -146,7 +146,7 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci1400,7603";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -155,7 +155,7 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
+++ b/target/linux/ramips/dts/mt7621_youhua_wr1200js.dts
@@ -130,7 +130,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -138,7 +139,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
+++ b/target/linux/ramips/dts/mt7621_youku_yk-l2.dts
@@ -136,7 +136,7 @@
 
 &pcie0 {
 	wifi@0,0 {
-		compatible = "pci14c3,7603";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -149,7 +149,7 @@
 
 &pcie1 {
 	wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602-v04.dtsi
@@ -145,7 +145,7 @@
 
 &pcie0 {
 	wifi0: wifi@0,0 {
-		compatible = "pci14c3,7603";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -154,7 +154,7 @@
 
 &pcie1 {
 	wifi1: wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg1602.dtsi
@@ -144,7 +144,7 @@
 
 &pcie0 {
 	wifi0: wifi@0,0 {
-		compatible = "pci14c3,7603";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -153,7 +153,7 @@
 
 &pcie1 {
 	wifi1: wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg2626.dts
@@ -116,7 +116,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";
@@ -125,7 +126,8 @@
 };
 
 &pcie1 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
@@ -113,7 +113,7 @@
 
 &pcie0 {
 	wifi0: wifi@0,0 {
-		compatible = "pci14c3,7603";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
@@ -122,7 +122,7 @@
 
 &pcie1 {
 	wifi1: wifi@0,0 {
-		compatible = "pci14c3,7662";
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
@@ -189,10 +189,9 @@
 };
 
 &pcie0 {
-	status = "okay";
-	mt7615d@0,0 {
-		/* In reality  at hangs at pcie1, this is a driver bug */
-		compatible = "pci14c3,7615";
+	/* In reality  at hangs at pcie1, this is a driver bug */
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		mediatek,firmware-eeprom = "mt7615e_eeprom.bin";
 		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_fe6e 1>;

--- a/target/linux/ramips/dts/mt7621_zyxel_nr7101.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_nr7101.dts
@@ -151,7 +151,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
+++ b/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
@@ -130,8 +130,8 @@
 
 &pcie1 {
 	wlan_5g: wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
 		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
 		nvmem-cell-names = "eeprom", "precal";
 		/* MAC-Address set in userspace */

--- a/target/linux/ramips/dts/mt7621_zyxel_wap6805.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_wap6805.dts
@@ -138,7 +138,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_asus_rt-ac1200.dtsi
@@ -138,7 +138,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;

--- a/target/linux/ramips/dts/mt7628an_buffalo_wcr-1166ds.dts
+++ b/target/linux/ramips/dts/mt7628an_buffalo_wcr-1166ds.dts
@@ -102,7 +102,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_mercury_mac1200r-v2.dts
@@ -121,7 +121,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_art_1000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
+++ b/target/linux/ramips/dts/mt7628an_motorola_mwr03.dts
@@ -140,6 +140,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
+++ b/target/linux/ramips/dts/mt7628an_netgear_r6xxx.dtsi
@@ -137,6 +137,7 @@
 
 &pcie0 {
 	wifi5: wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};

--- a/target/linux/ramips/dts/mt7628an_ravpower_rp-wd009.dts
+++ b/target/linux/ramips/dts/mt7628an_ravpower_rp-wd009.dts
@@ -127,6 +127,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
+++ b/target/linux/ramips/dts/mt7628an_totolink_lr1200.dts
@@ -98,7 +98,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v4.dts
@@ -112,7 +112,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_factory_28000>, <&macaddr_factory_f100 (-1)>;

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c20-v5.dts
@@ -100,6 +100,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100 (-1)>;

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v3.dts
@@ -111,7 +111,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_factory_28000>, <&macaddr_factory_f100 (-1)>;

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v4.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v4.dts
@@ -98,6 +98,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100 (-1)>;

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v6.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-c50-v6.dts
@@ -92,6 +92,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_rom_f100 (-1)>;

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-mr200-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-mr200-v5.dts
@@ -183,7 +183,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_romfile_f100 (-1)>;

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-mr200-v6.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-mr200-v6.dts
@@ -184,6 +184,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_f100 (-1)>;

--- a/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_re200.dtsi
@@ -165,7 +165,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_config_2008 2>;

--- a/target/linux/ramips/dts/mt7628an_tplink_re305.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_re305.dtsi
@@ -76,7 +76,7 @@
 };
 
 &pcie0 {
-	wlan5g: mt76@0,0 {
+	wlan5g: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7628an_tplink_re365-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re365-v1.dts
@@ -119,7 +119,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-wr902ac-v3.dts
@@ -108,7 +108,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_factory_28000>, <&macaddr_factory_f100 (-1)>;

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn531a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn531a3.dts
@@ -78,7 +78,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn570ha1.dts
@@ -69,6 +69,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
@@ -62,7 +62,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn576a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn576a2.dts
@@ -103,6 +103,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn577a2.dts
@@ -68,7 +68,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn578a2.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn578a2.dts
@@ -99,6 +99,7 @@
 
 &pcie0 {
 	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;
 		nvmem-cell-names = "eeprom";

--- a/target/linux/ramips/dts/mt7628an_yuncore_cpe200.dts
+++ b/target/linux/ramips/dts/mt7628an_yuncore_cpe200.dts
@@ -137,7 +137,8 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_8004>;

--- a/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
+++ b/target/linux/ramips/dts/mt7628an_zyxel_keenetic-extra-ii.dts
@@ -222,7 +222,7 @@
 };
 
 &pcie0 {
-	mt76@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;


### PR DESCRIPTION
Replaced all mt76@ with wifi@ per upstream requirement for all wifi nodes.

Added missing compatible string where appropriate as stated by mt76.yaml upstream.

Also updated reg value to be consistent everywhere.

ping @DragonBluep 