### PR TITLE
openssl: Enable `QUIC` and `KTLS` support.

### DIFF
--- a/package/libs/openssl/Config.in
+++ b/package/libs/openssl/Config.in
@@ -112,6 +112,25 @@ config OPENSSL_WITH_CMS
 		Cryptographic Message Syntax (CMS) is used to digitally sign,
 		digest, authenticate, or encrypt arbitrary message content.
 
+config OPENSSL_WITH_QUIC
+	bool
+	prompt "Enable QUIC support"
+	select OPENSSL_WITH_TLS13
+	help
+		Enable support for QUIC (Quick UDP Internet Connections) in OpenSSL 3.
+		This allows OpenSSL to provide cryptographic support for QUIC-based protocols,
+		such as HTTP/3. QUIC requires TLSv1.3 to be enabled.
+
+config OPENSSL_WITH_KTLS
+	bool
+	prompt "Enable KTLS support"
+	depends on PACKAGE_kmod-tls
+	select OPENSSL_WITH_TLS13
+	help
+		Enable Kernel TLS (kTLS) offload support. This allows OpenSSL to
+		offload TLS record processing to the kernel, reducing CPU usage
+		and improving performance for high-traffic TLS connections.
+
 comment "Algorithm Selection"
 
 config OPENSSL_WITH_EC2M

--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -49,9 +49,11 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_OPENSSL_WITH_EC2M \
 	CONFIG_OPENSSL_WITH_ERROR_MESSAGES \
 	CONFIG_OPENSSL_WITH_IDEA \
+	CONFIG_OPENSSL_WITH_KTLS \
 	CONFIG_OPENSSL_WITH_MDC2 \
 	CONFIG_OPENSSL_WITH_NPN \
 	CONFIG_OPENSSL_WITH_PSK \
+	CONFIG_OPENSSL_WITH_QUIC \
 	CONFIG_OPENSSL_WITH_RFC3779 \
 	CONFIG_OPENSSL_WITH_SEED \
 	CONFIG_OPENSSL_WITH_SM234 \
@@ -215,7 +217,8 @@ and https://openwrt.org/docs/techref/hardware/cryptographic.hardware.accelerator
 The engine_id is "padlock"
 endef
 
-OPENSSL_OPTIONS:= shared no-tests
+TARGET_LDFLAGS += -lpthread
+OPENSSL_OPTIONS := shared no-tests no-docs threads
 
 ifndef CONFIG_OPENSSL_WITH_BLAKE2
   OPENSSL_OPTIONS += no-blake2
@@ -350,6 +353,18 @@ ifdef CONFIG_i386
   ifndef CONFIG_OPENSSL_WITH_SSE2
     OPENSSL_OPTIONS += no-sse2
   endif
+endif
+
+ifndef CONFIG_OPENSSL_WITH_QUIC
+  OPENSSL_OPTIONS += no-quic
+else
+  OPENSSL_OPTIONS += enable-quic
+endif
+
+ifndef CONFIG_OPENSSL_WITH_KTLS
+  OPENSSL_OPTIONS += no-ktls
+else
+  OPENSSL_OPTIONS += enable-ktls
 endif
 
 OPENSSL_TARGET:=linux-$(call qstrip,$(CONFIG_ARCH))-openwrt


### PR DESCRIPTION
`quic` and `ktls` in openssl version 3.5.0 is disabled by default.
