### PR TITLE
[23.05]: backport wolfssl and openssl 

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.0.15
+PKG_VERSION:=3.0.16
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -25,7 +25,7 @@ PKG_SOURCE_URL:= \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/ \
 	ftp://ftp.pca.dfn.de/pub/tools/net/openssl/source/old/$(PKG_BASE)/
 
-PKG_HASH:=23c666d0edf20f14249b3d8f0368acaee9ab585b09e1de82107c66e1f3ec9533
+PKG_HASH:=57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wolfssl
-PKG_VERSION:=5.7.2-stable
+PKG_VERSION:=5.7.6-stable
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/wolfSSL/wolfssl/archive/v$(PKG_VERSION)
-PKG_HASH:=0f2ed82e345b833242705bbc4b08a2a2037a33f7bf9c610efae6464f6b10e305
+PKG_HASH:=52b1e439e30d1ed8162a16308a8525a862183b67aa30373b11166ecbab000d63
 
 PKG_FIXUP:=libtool libtool-abiver
 PKG_INSTALL:=1

--- a/package/libs/wolfssl/patches/100-disable-hardening-check.patch
+++ b/package/libs/wolfssl/patches/100-disable-hardening-check.patch
@@ -1,6 +1,6 @@
 --- a/wolfssl/wolfcrypt/settings.h
 +++ b/wolfssl/wolfcrypt/settings.h
-@@ -3046,7 +3046,7 @@ extern void uITRON4_free(void *p) ;
+@@ -3722,7 +3722,7 @@ extern void uITRON4_free(void *p) ;
  
  /* warning for not using harden build options (default with ./configure) */
  /* do not warn if big integer support is disabled */


### PR DESCRIPTION
 * wolfssl: Update to version 5.7.6
    
    This fixes multiple bugs and also minor security problems.
    
    Changelog:
    https://github.com/wolfSSL/wolfssl/releases/tag/v5.7.4-stable
    https://github.com/wolfSSL/wolfssl/releases/tag/v5.7.6-stable
    
    The package size increases:
    525814 bin/packages/mips_24kc/base/libwolfssl5.7.2.e624513f-5.7.2-r1.apk
    549408 bin/packages/mips_24kc/base/libwolfssl5.7.6.e624513f-5.7.6-r1.apk
    
    Link: https://github.com/openwrt/openwrt/pull/17742
    Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
    (cherry picked from commit 0a7e92c2442bc09eec3875aae21996d9a5430806)
    (cherry picked from commit 6f7bbd03954e8aa79484b7c5b727dd814bfee78d)


* openssl: update to 3.0.16
    
    Changes between 3.0.15 and 3.0.16 [11 Feb 2025]
    
    CVE-2024-13176[1] - Fixed timing side-channel in ECDSA signature
    computation.
    
    There is a timing signal of around 300 nanoseconds when the top word of
    the inverted ECDSA nonce value is zero. This can happen with significant
    probability only for some of the supported elliptic curves. In
    particular the NIST P-521 curve is affected. To be able to measure this
    leak, the attacker process must either be located in the same physical
    computer or must have a very fast network connection with low latency.
    
    CVE-2024-9143[2] - Fixed possible OOB memory access with invalid
    low-level GF(2^m) elliptic curve parameters.
    
    Use of the low-level GF(2^m) elliptic curve APIs with untrusted explicit
    values for the field polynomial can lead to out-of-bounds memory reads
    or writes. Applications working with "exotic" explicit binary (GF(2^m))
    curve parameters, that make it possible to represent invalid field
    polynomials with a zero constant term, via the above or similar APIs,
    may terminate abruptly as a result of reading or writing outside of
    array bounds. Remote code execution cannot easily be ruled out.
    
    1. https://www.openssl.org/news/vulnerabilities.html#CVE-2024-13176
    2. https://www.openssl.org/news/vulnerabilities.html#CVE-2024-9143
    
    Build system: x86/64
    Build-tested: bcm27xx/bcm2712
    Run-tested: bcm27xx/bcm2712
    
    Signed-off-by: John Audia <therealgraysky@proton.me>
    Link: https://github.com/openwrt/openwrt/pull/17947
    Signed-off-by: Robert Marko <robimarko@gmail.com>
    (cherry picked from commit b4e6fd7b76440076eeff3a0789d40acbb5363ecf)
    (cherry picked from commit 3abbc154546042af5efe6d299e3e40133dfb3d7f)
