### PR TITLE
ipq806x: fix Extreme Networks WS-AP3935i ethernet LED / port assignment

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -34,8 +34,8 @@ edgecore,ecw5410)
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy0tpt"
 	;;
 extreme,ap3935)
-	ucidef_set_led_netdev "wan" "wan" "orange:lan1" "eth1"
-	ucidef_set_led_netdev "lan" "lan" "orange:lan2" "eth0"
+	ucidef_set_led_netdev "wan" "wan" "orange:lan1" "eth0"
+	ucidef_set_led_netdev "lan" "lan" "orange:lan2" "eth1"
 	;;
 fortinet,fap-421e)
 	ucidef_set_led_netdev "eth1-100" "ETH1-100" "amber:eth1" "eth0" "link_100"

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -47,7 +47,8 @@ ipq806x_setup_interfaces()
 		ucidef_set_network_device_conduit "lan1" "eth1"
 		ucidef_set_network_device_conduit "wan" "eth0"
 		;;
-	edgecore,ecw5410)
+	edgecore,ecw5410 |\
+	extreme,ap3935)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
 	qcom,ipq8064-ap161)
@@ -63,7 +64,6 @@ ipq806x_setup_interfaces()
 	meraki,mr42)
 		ucidef_set_interface_lan "eth0"
 		;;
-	extreme,ap3935 |\
 	meraki,mr52)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		;;


### PR DESCRIPTION
This PR fixes two bugs present in the current AP3935:
- LAN2 is WAN and LAN1 is LAN
- The "LAN1" LED is showing activity of the LAN2 interface and vice versa.
