### PR TITLE
[24.10] tools/expat: bump to 2.7.1 to fix several CVEs

### DIFF
--- a/tools/expat/Makefile
+++ b/tools/expat/Makefile
@@ -9,10 +9,10 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
 PKG_CPE_ID:=cpe:/a:libexpat:libexpat
-PKG_VERSION:=2.6.3
+PKG_VERSION:=2.7.1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_HASH:=17aa6cfc5c4c219c09287abfc10bc13f0c06f30bb654b28bfe6f567ca646eb79
+PKG_HASH:=0cce2e6e69b327fc607b8ff264f4b66bdf71ead55a87ffd5f3143f535f15cfa2
 PKG_SOURCE_URL:=https://github.com/libexpat/libexpat/releases/download/R_$(subst .,_,$(PKG_VERSION))
 
 HOST_BUILD_PARALLEL:=1


### PR DESCRIPTION
Addresses CVE-2024-8176 and CVE-2024-50602.

Changelog: https://github.com/libexpat/libexpat/blob/R_2_7_1/expat/Changes
Fixes: https://github.com/openwrt/packages/issues/26255
Fixes: https://github.com/advisories/GHSA-9hcv-xw76-m4h6
Fixes: https://github.com/advisories/GHSA-79wf-qgrg-2p6c

Link: https://github.com/openwrt/openwrt/pull/18421

cherry-picked: 14a88ba520b44cf22216d1819d936cea1ec509a9
tested on: ramips/mt7621
tested compiling packages: ubound, lua
