### PR TITLE
Update selinux-policy and fix login applet in busybox

### DIFF
--- a/package/system/selinux-policy/Makefile
+++ b/package/system/selinux-policy/Makefile
@@ -8,8 +8,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=selinux-policy
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.defensec.nl/selinux-policy.git
-PKG_VERSION:=2.6
-PKG_MIRROR_HASH:=3604ce2d2874f58a7fc03998daa81628fca43aa8ac0a7436f07612365b6ce7ad
+PKG_VERSION:=2.8.2
+PKG_MIRROR_HASH:=7e81e6e9e933e6409b7f7bf2d5639960c440c82589c99b199b3540676f88eb8a
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=secilc/host policycoreutils/host
 

--- a/package/utils/busybox/patches/600-loginutils-login.c-libselinux-get_default_context-ex.patch
+++ b/package/utils/busybox/patches/600-loginutils-login.c-libselinux-get_default_context-ex.patch
@@ -1,0 +1,51 @@
+From 850a6d031039237b0b13d8fab9f10a7cd4752907 Mon Sep 17 00:00:00 2001
+From: Dominick Grift <dominick.grift@defensec.nl>
+Date: Sat, 5 Apr 2025 13:40:26 +0200
+Subject: [PATCH] loginutils/login.c: libselinux get_default_context() expects
+ seuser
+
+Use getseuserbyname() to get the seuser associated with username and use that
+instead with get_default_context()
+
+>From get_default_context.3:
+"These functions takes a SELinux user identity that must be defined in the SELinux policy as their input, not a Linux username."
+
+Fixes: #19075
+Upstream-Status: Submitted [https://lists.busybox.net/pipermail/busybox/2025-April/091407.html]
+Signed-off-by: Dominick Grift <dominick.grift@defensec.nl>
+---
+ loginutils/login.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+--- a/loginutils/login.c
++++ b/loginutils/login.c
+@@ -183,12 +183,16 @@ static void die_if_nologin(void)
+ static void initselinux(char *username, char *full_tty,
+ 						security_context_t *user_sid)
+ {
++	char *seuser = NULL, *level = NULL;
+ 	security_context_t old_tty_sid, new_tty_sid;
+ 
+ 	if (!is_selinux_enabled())
+ 		return;
+ 
+-	if (get_default_context(username, NULL, user_sid)) {
++	if (getseuserbyname(username, &seuser, &level)) {
++		bb_error_msg_and_die("can't get seuser for %s", username);
++	}
++	if (get_default_context(seuser, NULL, user_sid)) {
+ 		bb_error_msg_and_die("can't get SID for %s", username);
+ 	}
+ 	if (getfilecon(full_tty, &old_tty_sid) < 0) {
+@@ -201,6 +205,11 @@ static void initselinux(char *username,
+ 	if (setfilecon(full_tty, new_tty_sid) != 0) {
+ 		bb_perror_msg_and_die("chsid(%s, %s) failed", full_tty, new_tty_sid);
+ 	}
++
++	if (ENABLE_FEATURE_CLEAN_UP) {
++		free(seuser);
++		free(level);
++	}
+ }
+ #endif
+ 


### PR DESCRIPTION
### busybox: fix login applet on selinux

Currently the system boots up, but is unusable because pressing enter
does not provide login with error:

```
  login: can't get SID for root
```

This is happenning, because login.c passes the Linux username directly
to get_default_context(), while libselinux expects an SELinux user
identity, causing the call to fail for users without a matching SELinux
name (e.g., root) and aborting login on SELinux-enabled systems.

Fixes: #19075
Upstream-Status: Submitted [https://lists.busybox.net/pipermail/busybox/2025-April/091407.html]

### selinux-policy: update version to v2.8.2

Changes since v2.6:

a3383be configgenerate
8d04a3b adds modemnodedev and deletes cdcserialtermdev
77b52c4 README
3b8e1dc README
356211b README: add note about possible regression since selinux 3.6
171a3cc iwinfo
16ae0c1 haproxy
78bcb69 dufsysagent fix
6d88ac5 dufs fixes filecon
c9aa6cd adds dufs
5f15774 net: clean up
02c8e76 unneeded sys.moduleload calls
6334366 README: todo /usr/bin/fit_check_sign
12b659f README: add reminder on polvers
3e93844 related to bpi-r4 Linux 6.12
449cb74 sysagent: use logintermdev (no differences)
20ad31d unlabeled/invalid: these are relative to .
9c85622 iproute2sysagent: ss
c2a7863 README
6d7ad1c adds swaptools swapfile
5b69b63 rpcd related to luci mount tab
afeee67 hotplugcall: iwinfo
6ca7996 adds ttyGS0 tty login serial
f8b2fba wget: read shouldnt be needed
e2faf89 bmon adds ~/.bmonrc
5ede79b adds seccompconffile
3034b20 some comments
9b4b44e loginsysagent: loose end
fe0973c README
ea06908 loginsysagent
2405c46 loginsysagent
9413988 loginsysagent: adds skel for wrapper retry
22929cb Revert "login.cil: skel for login.sh wrapper"
fbcccf4 login.cil: skel for login.sh wrapper
1addde4 Revert "iproute2 ip protocol not supported"
f38fd20 iproute2 ip protocol not supported
5abde97 openssl for openssl s_client -connect ip:port
642ddd9 ttyd
be00125 iproute2 ip
1fbba89 iproute2 ip
342c981 no cap_userns
d241cfb iproute2 ip netns related
6778504 iproute2 ip netns related
491d3c4 iproute2 ip
d2dce16 iproute ip
8b43b1c iproute2 ip basic netns support
107e63f iproute2 ip
1b39905 README: looks like this is a no-go
b081dba acme note about expected removal of /tmp/run/acme/lock
4df51dd haproxy
ee825c8 coreutils: these dont have busybox equivalent
46f4a8b Revert "ucode: needed for custom rules in /etc/nftables.d"
048337a ucode: needed for custom rules in /etc/nftables.d
76b5a69 haproxy pid file
c90f840 openssl s_client -connect
dbbe475 haproxy local logging
7f58831 haproxy /etc/haproxy for stuff like proxy maps
050afc7 acmesysagent
031e0f3 README
2acf047 haproxy and iproute2
c5d1ce4 README
b9304a5 haproxy whitespace
b07c524 adds haproxy and iproute2 ss rules
9bc53b1 acme
6031379 openssl
8d6aaba adds sysfsutils skel
fc24d0c README
12cc1d4 openssl
79cf372 apk leaks memfd
9912075 adds socat dataexecfile
011bf9a adds wget (consolidate uclient-fetch)
0ba70c0 adds ftp reserved ports
5b35e96 README
bd02d73 README
4f6895f netifd comment fix
bd46c1f coreutils
ad13688 dnsmasq: more robust filecon
d5d6dd3 README
74f73d1 fwtool: do_stage2: online sysupgrade sdcard
8251117 README
badfb57 iw/tmux socket creation is implied in macros
5663f89 iwsysagent and readme
6815a6c README
bde5a56 README
6b89f0a hotplug and netif unconfined.exec.file underline "trusted"
862da9b unknown netifd protocols with netif.unconfined.exec.file

(patch taken from https://patchwork.ozlabs.org/project/openwrt/patch/20250601111649.441635-1-dominick.grift@defensec.nl/)