### PR TITLE
kernel: fix rtl8261n driver for Realtek chips and support RTL8264 (non-B)

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/phy_patch.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/phy_patch.c
@@ -98,6 +98,11 @@ static int32 _phy_patch_process(uint32 unit, rtk_port_t port, uint8 portOffset, 
     return (chk_ret == RT_ERR_CHECK_FAILED) ? chk_ret : RT_ERR_OK;
 }
 
+rtk_hwpatch_t rtl826XB_patch_rtk_conf[] = {
+    {RTK_PATCH_OP_PSDS0   , 0xff , 0x07  , 0x10  , 15, 0, 0x80aa, RTK_PATCH_CMP_WC  , 0, 0, 0, 0},
+    {RTK_PATCH_OP_PSDS0   , 0xff , 0x06  , 0x12  , 15, 0, 0x5078, RTK_PATCH_CMP_WC  , 0, 0, 0, 0},
+};
+
 /* Function Name:
  *      phy_patch
  * Description:
@@ -170,10 +175,14 @@ int32 phy_patch(uint32 unit, rtk_port_t port, uint8 portOffset, uint8 patch_mode
             break;
         }
     }
+    ret = _phy_patch_process(unit, port, portOffset, rtl826XB_patch_rtk_conf, sizeof(rtl826XB_patch_rtk_conf), patch_mode);
+    if (ret == RT_ERR_CHECK_FAILED)
+        chk_ret = ret;
+    else if (ret  != RT_ERR_OK)
+    {
+        RT_LOG(LOG_MAJOR_ERR, (MOD_HAL | MOD_PHY), "U%u P%u patch_mode:%u id:%u patch-%u failed. ret:0x%X\n", unit, port, patch_mode, i, patch_type, ret);
+        return ret;
+    }
 
     return (chk_ret == RT_ERR_CHECK_FAILED) ? chk_ret : RT_ERR_OK;
 }
-
-
-
-

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
@@ -69,7 +69,9 @@ static int rtkphy_config_init(struct phy_device *phydev)
         case REALTEK_PHY_ID_RTL8264B:
         case REALTEK_PHY_ID_RTL8264:
             phydev_info(phydev, "%s:%u [RTL8261N/RTL8264/RTL826XB] phy_id: 0x%X PHYAD:%d\n", __FUNCTION__, __LINE__, phydev->drv->phy_id, phydev->mdio.addr);
-
+#ifdef CONFIG_MACH_REALTEK_RTL
+            return 0;
+#endif
 
           #if 1 /* toggle reset */
             phy_modify_mmd_changed(phydev, 30, 0x145, BIT(0)  , 1);
@@ -128,7 +130,9 @@ static int rtkphy_c45_suspend(struct phy_device *phydev)
 {
     int ret = 0;
 
+#ifndef CONFIG_MACH_REALTEK_RTL
     ret = rtk_phylib_c45_power_low(phydev);
+#endif
 
     phydev->speed = SPEED_UNKNOWN;
     phydev->duplex = DUPLEX_UNKNOWN;
@@ -140,7 +144,11 @@ static int rtkphy_c45_suspend(struct phy_device *phydev)
 
 static int rtkphy_c45_resume(struct phy_device *phydev)
 {
+#ifndef CONFIG_MACH_REALTEK_RTL
     return rtk_phylib_c45_power_normal(phydev);
+#else
+    return 0;
+#endif
 }
 
 static int rtkphy_c45_config_aneg(struct phy_device *phydev)

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
@@ -13,6 +13,7 @@
 
 #define REALTEK_PHY_ID_RTL8261N         0x001CCAF3
 #define REALTEK_PHY_ID_RTL8264B         0x001CC813
+#define REALTEK_PHY_ID_RTL8264          0x001CCAF2
 
 static int rtl826xb_get_features(struct phy_device *phydev)
 {
@@ -66,7 +67,8 @@ static int rtkphy_config_init(struct phy_device *phydev)
     {
         case REALTEK_PHY_ID_RTL8261N:
         case REALTEK_PHY_ID_RTL8264B:
-            phydev_info(phydev, "%s:%u [RTL8261N/RTL826XB] phy_id: 0x%X PHYAD:%d\n", __FUNCTION__, __LINE__, phydev->drv->phy_id, phydev->mdio.addr);
+        case REALTEK_PHY_ID_RTL8264:
+            phydev_info(phydev, "%s:%u [RTL8261N/RTL8264/RTL826XB] phy_id: 0x%X PHYAD:%d\n", __FUNCTION__, __LINE__, phydev->drv->phy_id, phydev->mdio.addr);
 
 
           #if 1 /* toggle reset */
@@ -264,6 +266,18 @@ static struct phy_driver rtk_phy_drivers[] = {
         .aneg_done          = rtkphy_c45_aneg_done,
         .read_status        = rtkphy_c45_read_status,
     },
+    {
+        PHY_ID_MATCH_EXACT(REALTEK_PHY_ID_RTL8264),
+        .name               = "Realtek RTL8264",
+        .get_features       = rtl826xb_get_features,
+        .config_init        = rtkphy_config_init,
+        .probe              = rtl826xb_probe,
+        .suspend            = rtkphy_c45_suspend,
+        .resume             = rtkphy_c45_resume,
+        .config_aneg        = rtkphy_c45_config_aneg,
+        .aneg_done          = rtkphy_c45_aneg_done,
+        .read_status        = rtkphy_c45_read_status,
+    },
 };
 
 module_phy_driver(rtk_phy_drivers);
@@ -272,6 +286,7 @@ module_phy_driver(rtk_phy_drivers);
 static struct mdio_device_id __maybe_unused rtk_phy_tbl[] = {
     { PHY_ID_MATCH_EXACT(REALTEK_PHY_ID_RTL8261N) },
     { PHY_ID_MATCH_EXACT(REALTEK_PHY_ID_RTL8264B) },
+    { PHY_ID_MATCH_EXACT(REALTEK_PHY_ID_RTL8264) },
     { },
 };
 


### PR DESCRIPTION
The out-of-tree rtl8261n driver appears to have been written for Mediatek. This fixes some power functionality for Realtek-based devices and adds support for the RTL8264 non-B PHY.

Tested on Hasivo S1100W-8XGT-SE: https://github.com/openwrt/openwrt/pull/17137, 100M, 1G, 2.5G and 10G negotiate and pass traffic.