### PR TITLE
package: include abiversion tag in package metadata

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -376,6 +376,7 @@ else
 	$(FAKEROOT) $(STAGING_DIR_HOST)/bin/apk mkpkg \
 	  --info "name:$(1)$$(ABIV_$(1))" \
 	  --info "version:$(VERSION)" \
+	  $$(if $$(ABIV_$(1)),--info "tags:openwrt:abiversion=$$(ABIV_$(1))") \
 	  --info "description:$$(call description_escape,$$(strip $$(Package/$(1)/description)))" \
 	  $(if $(findstring all,$(PKGARCH)),--info "arch:noarch",--info "arch:$(PKGARCH)") \
 	  --info "license:$(LICENSE)" \


### PR DESCRIPTION
~~DO NOT MERGE until https://github.com/openwrt/openwrt/pull/19043 has been merged.~~  Merging is now possible [f244ff2](https://github.com/openwrt/openwrt/commit/f244ff22d904f9cd9ea733a3d0cd1bc3a834bb67)

Add custom tag 'openwrt:abiversion=\<ABI version>' in the apk v3 package metadata.  Made possible in apk-tools 3.0 rc5 release.

Links: https://gitlab.alpinelinux.org/alpine/apk-tools/-/commit/1925de55beef8859c987f72c3b2727d756296ddb
