### PR TITLE
bcm27xx: add support for BRCMSTB I2C controller

### DIFF
--- a/target/linux/bcm27xx/modules/i2c.mk
+++ b/target/linux/bcm27xx/modules/i2c.mk
@@ -16,3 +16,19 @@ define KernelPackage/i2c-bcm2835/description
 endef
 
 $(eval $(call KernelPackage,i2c-bcm2835))
+
+
+I2C_BRCMSTB_MODULES:=\
+  CONFIG_I2C_BRCMSTB:drivers/i2c/busses/i2c-brcmstb
+
+define KernelPackage/i2c-brcmstb
+  $(call i2c_defaults,$(I2C_BRCMSTB_MODULES),59)
+  TITLE:=Broadcom BRCMSTB I2C master controller driver
+  DEPENDS:=@TARGET_bcm27xx +kmod-i2c-core
+endef
+
+define KernelPackage/i2c-brcmstb/description
+  This package contains the BRCM Settop/DSL I2C master controller driver
+endef
+
+$(eval $(call KernelPackage,i2c-brcmstb))


### PR DESCRIPTION
Add kernel package for Broadcom Settop/DSL I2C controller.
This controller is used on RPi devices.