### PR TITLE
ramips: mt76x8: add support for Keenetic Start (KN-1112)

### DIFF
--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1112.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1112.dts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "keenetic,kn-1112", "mediatek,mt7628an-soc";
+	model = "Keenetic KN-1112";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+
+	keys {
+		compatible = "gpio-keys";
+
+		mode {
+			label = "mode";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		reset {
+			label = "restart";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0 0x1ec0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "i2c", "gpio", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <104000000>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "rf-eeprom";
+				reg = <0x40000 0x10000>;
+				read-only;
+				
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+				};
+			};
+
+			firmware1: partition@50000 {
+				label = "firmware_1";
+				reg = <0x50000 0xf60000>;
+			};
+
+			partition@fb0000 {
+				label = "config_1";
+				reg = <0xfb0000 0x40000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "dump";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+
+			partition@1000000 {
+				label = "u-state";
+				reg = <0x1000000 0x30000>;
+				read-only;
+			};
+
+			partition@1030000 {
+				label = "u-config_res";
+				reg = <0x1030000 0x10000>;
+				read-only;
+			};
+			
+			partition@1040000 {
+				label = "rf-eeprom_res";
+				reg = <0x1040000 0x10000>;
+				read-only;
+			};
+
+			firmware2: partition@1050000 {
+				label = "firmware_2";
+				reg = <0x1050000 0xf60000>;
+			};
+			
+			partition@1fb0000 {
+				label = "config_2";
+				reg = <0x1fb0000 0x40000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -384,6 +384,17 @@ define Device/jotale_js76x8-32m
 endef
 TARGET_DEVICES += jotale_js76x8-32m
 
+define Device/keenetic_kn-1112
+  BLOCKSIZE := 64k
+  IMAGE_SIZE := 16121856
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-1112
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to $$$$(BLOCKSIZE) | \
+	check-size | zyimage -d 0x801112 -v "KN-1112"
+endef
+TARGET_DEVICES += keenetic_kn-1112
+
 define Device/keenetic_kn-1221
   BLOCKSIZE := 64k
   IMAGE_SIZE := 29440k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -58,6 +58,7 @@ hiwifi,hc5661a|\
 hiwifi,hc5761a)
 	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x10"
 	;;
+keenetic,kn-1112|\
 keenetic,kn-1221|\
 keenetic,kn-1613|\
 keenetic,kn-1711|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -137,6 +137,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "0:wan" "6@eth0"
 		;;
+	keenetic,kn-1112|\
 	keenetic,kn-1613|\
 	keenetic,kn-1713|\
 	motorola,mwr03)


### PR DESCRIPTION
Specification:
SoC: MediaTek MT7628NN
RAM: 128 MB, EtronTech EM68C16CWQG-25H (DDR2)
Flash: 32MB, Winbond 25Q256JVFQ (Dual Boot, SPI)
Switch: MediaTek MT7628AN, 4 ports 100 Mbps
WiFi: MediaTek MT7603 2T2R/2.4GHz 802.11n
GPIO: 2 buttons (Wi-Fi, Reset), 3 LEDs (Power, Internet, Wi-Fi), 1 mode switch

Disassembly:
At the bottom, under the LEDs, there are 2 screws hidden by rubber feet. After removing the screws, pry the gray plastic part around (it is secured with latches) and remove it.

Serial Interface:
The serial interface can be connected to the 5 pin dots located on the right between the operating mode switch and the antenna. Pins (from antenna to operating mode switch):
VCC
TX
RX
NC
GND
Settings: 115200, 8N1

Flashing via OEM recovery software:
1. Download the OEM recovery software from the manufacturer's website
2. Download the firmware image (for OpenWRT it is *-squashfs-factory.bin), rename it to KN-1112_recovery.bin
3. Replace the file in the fw folder OEM recovery software with the file from step 2.
4. Run the OEM recovery software and follow the instructions.

Flashing via TFTP:
1. Connect your PC and router to port 1-3, configure PC interface using IP 192.168.1.2, mask 255.255.255.252
2. Serve the firmware image (for OpenWRT it is *-squashfs-factory.bin) renamed to KN-1112_recovery.bin via TFTP
3. Power up the router while pressing Reset button on the back
4. Release Restart button when Power LED starts blinking

To revert back to OEM firmware:
The return to the OEM firmware is carried out by using the methods described above with the help of the appropriate firmware image.

When using OEM bootloader, the firmware image size cannot exceed the size of one OEM «Firmware_x» partition or Kernel + rootFS size.
