### PR TITLE
base-files: handle packages alternatives when apk removes packages

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -216,6 +216,10 @@ default_prerm() {
 	local filelist="${root}/usr/lib/opkg/info/${pkgname}.list"
 	[ -f "$root/lib/apk/packages/${pkgname}.list" ] && filelist="$root/lib/apk/packages/${pkgname}.list"
 
+	if [ -e "$root/lib/apk/packages/${pkgname}.alternatives" ]; then
+		update_alternatives remove "${pkgname}"
+	fi
+
 	if [ -f "$root/usr/lib/opkg/info/${pkgname}.prerm-pkg" ]; then
 		( . "$root/usr/lib/opkg/info/${pkgname}.prerm-pkg" )
 		ret=$?
@@ -352,8 +356,7 @@ default_postinst() {
 		add_group_and_user "${pkgname}"
 	fi
 
-	if [ -e "${root}/lib/apk/packages/${pkgname}.list" ]; then
-		filelist="${root}/lib/apk/packages/${pkgname}.list"
+	if [ -e "${root}/lib/apk/packages/${pkgname}.alternatives" ]; then
 		update_alternatives install "${pkgname}"
 	fi
 


### PR DESCRIPTION
On commit 3010ab8 ("base-files: add update_alternatives function") was implemented the function to handle ALTERNATIVES when using APK (OPKG handle it internally) but in commit bcc6415 ("base-files: add compatibility for APK and OPKG") was only called when adding a package, so call it also when removing packages.

Fixes: bcc6415 ("base-files: add compatibility for APK and OPKG")
Fixes: https://github.com/openwrt/openwrt/issues/19090
Fixes: https://github.com/openwrt/openwrt/issues/16991

<details><summary>TESTs (ramips/mt7621)</summary>
<p>

| Before |
| ------|
```shell
root@OpenWrt:~# for app in gunzip gzip zcat; do ls -lF /bin/$app; done
lrwxrwxrwx    1 root     root             7 Jun 12 10:42 /bin/gunzip -> busybox*
lrwxrwxrwx    1 root     root             7 Jun 12 10:42 /bin/gzip -> busybox*
lrwxrwxrwx    1 root     root             7 Jun 12 10:42 /bin/zcat -> busybox*
root@OpenWrt:~#
root@OpenWrt:~# apk add gzip
(1/1) Installing gzip (1.13-r1)
gzip-1.13-r1.post-install: Executing script...
gzip-1.13-r1.post-install: add alternative: /bin/gunzip -> /usr/libexec/gunzip-gnu
gzip-1.13-r1.post-install: add alternative: /bin/gzip -> /usr/libexec/gzip-gnu
gzip-1.13-r1.post-install: add alternative: /bin/zcat -> /usr/libexec/zcat-gnu
OK: 15 MiB in 127 packages
root@OpenWrt:~# for app in gunzip gzip zcat; do ls -lF /bin/$app; done
lrwxrwxrwx    1 root     root            23 Jun 13 22:52 /bin/gunzip -> /usr/libexec/gunzip-gnu*
lrwxrwxrwx    1 root     root            21 Jun 13 22:52 /bin/gzip -> /usr/libexec/gzip-gnu*
lrwxrwxrwx    1 root     root            21 Jun 13 22:52 /bin/zcat -> /usr/libexec/zcat-gnu*
root@OpenWrt:~#
root@OpenWrt:~# apk del gzip
(1/1) Purging gzip (1.13-r1)
gzip-1.13-r1.pre-deinstall: Executing script...
OK: 15 MiB in 126 packages
root@OpenWrt:~# for app in gunzip gzip zcat; do ls -lF /bin/$app; done
lrwxrwxrwx    1 root     root            23 Jun 13 22:52 /bin/gunzip -> /usr/libexec/gunzip-gnu
lrwxrwxrwx    1 root     root            21 Jun 13 22:52 /bin/gzip -> /usr/libexec/gzip-gnu
lrwxrwxrwx    1 root     root            21 Jun 13 22:52 /bin/zcat -> /usr/libexec/zcat-gnu
root@OpenWrt:~# gzip
-ash: gzip: not found
root@OpenWrt:~#
```
```shell
root@OpenWrt:~# ls -lF /usr/bin/wget
lrwxrwxrwx    1 root     root            18 Jun 13 23:07 /usr/bin/wget -> /bin/uclient-fetch*
root@OpenWrt:~# apk add wget-ssl
(1/6) Installing libatomic1 (14.3.0-r4)
libatomic1-14.3.0-r4.post-install: Executing script...
(2/6) Installing libopenssl3 (3.5.0-r1)
libopenssl3-3.5.0-r1.post-install: Executing script...
(3/6) Installing libpcre2 (10.42-r1)
libpcre2-10.42-r1.post-install: Executing script...
(4/6) Installing libpthread (1.2.5-r4)
libpthread-1.2.5-r4.post-install: Executing script...
(5/6) Installing librt (1.2.5-r4)
librt-1.2.5-r4.post-install: Executing script...
(6/6) Installing wget-ssl (1.25.0-r1)
wget-ssl-1.25.0-r1.post-install: Executing script...
wget-ssl-1.25.0-r1.post-install: add alternative: /usr/bin/wget -> /usr/libexec/wget-ssl
OK: 20 MiB in 133 packages
root@OpenWrt:~# ls -lF /usr/bin/wget
lrwxrwxrwx    1 root     root            21 Jun 13 22:35 /usr/bin/wget -> /usr/libexec/wget-ssl*
root@OpenWrt:~#
root@OpenWrt:~# apk del wget-ssl
(1/6) Purging wget-ssl (1.25.0-r1)
wget-ssl-1.25.0-r1.pre-deinstall: Executing script...
(2/6) Purging libopenssl3 (3.5.0-r1)
libopenssl3-3.5.0-r1.pre-deinstall: Executing script...
(3/6) Purging libatomic1 (14.3.0-r4)
libatomic1-14.3.0-r4.pre-deinstall: Executing script...
(4/6) Purging libpcre2 (10.42-r1)
libpcre2-10.42-r1.pre-deinstall: Executing script...
(5/6) Purging librt (1.2.5-r4)
librt-1.2.5-r4.pre-deinstall: Executing script...
(6/6) Purging libpthread (1.2.5-r4)
libpthread-1.2.5-r4.pre-deinstall: Executing script...
OK: 15 MiB in 126 packages
root@OpenWrt:~# ls -lF /usr/bin/wget
lrwxrwxrwx    1 root     root            21 Jun 13 22:35 /usr/bin/wget -> /usr/libexec/wget-ssl
root@OpenWrt:~# wget
-ash: wget: not found
root@OpenWrt:~#
```

| After|
|--------| 
```shell
root@OpenWrt:~# for app in gunzip gzip zcat; do ls -lF /bin/$app; done
lrwxrwxrwx    1 root     root            12 Jun 13 19:26 /bin/gunzip -> /bin/busybox*
lrwxrwxrwx    1 root     root            12 Jun 13 19:26 /bin/gzip -> /bin/busybox*
lrwxrwxrwx    1 root     root            12 Jun 13 19:26 /bin/zcat -> /bin/busybox*
root@OpenWrt:~# apk add gzip
(1/1) Installing gzip (1.13-r1)
gzip-1.13-r1.post-install: Executing script...
gzip-1.13-r1.post-install: add alternative: /bin/gunzip -> /usr/libexec/gunzip-gnu
gzip-1.13-r1.post-install: add alternative: /bin/gzip -> /usr/libexec/gzip-gnu
gzip-1.13-r1.post-install: add alternative: /bin/zcat -> /usr/libexec/zcat-gnu
OK: 18 MiB in 151 packages
root@OpenWrt:~# for app in gunzip gzip zcat; do ls -lF /bin/$app; done
lrwxrwxrwx    1 root     root            23 Jun 13 21:43 /bin/gunzip -> /usr/libexec/gunzip-gnu*
lrwxrwxrwx    1 root     root            21 Jun 13 21:43 /bin/gzip -> /usr/libexec/gzip-gnu*
lrwxrwxrwx    1 root     root            21 Jun 13 21:43 /bin/zcat -> /usr/libexec/zcat-gnu*
root@OpenWrt:~# apk del gzip
(1/1) Purging gzip (1.13-r1)
gzip-1.13-r1.pre-deinstall: Executing script...
gzip-1.13-r1.pre-deinstall: add alternative: /bin/gunzip -> /bin/busybox
gzip-1.13-r1.pre-deinstall: add alternative: /bin/gzip -> /bin/busybox
gzip-1.13-r1.pre-deinstall: add alternative: /bin/zcat -> /bin/busybox
OK: 18 MiB in 150 packages
root@OpenWrt:~# for app in gunzip gzip zcat; do ls -lF /bin/$app; done
lrwxrwxrwx    1 root     root            12 Jun 13 21:44 /bin/gunzip -> /bin/busybox*
lrwxrwxrwx    1 root     root            12 Jun 13 21:44 /bin/gzip -> /bin/busybox*
lrwxrwxrwx    1 root     root            12 Jun 13 21:44 /bin/zcat -> /bin/busybox*
root@OpenWrt:~#
```
```shell
root@OpenWrt:~# ls -lF /usr/bin/wget
lrwxrwxrwx    1 root     root            18 Jun 13 17:24 /usr/bin/wget -> /bin/uclient-fetch*
root@OpenWrt:~# apk add wget-ssl
(1/6) Installing libatomic1 (14.3.0-r4)
libatomic1-14.3.0-r4.post-install: Executing script...
(2/6) Installing libopenssl3 (3.5.0-r1)
libopenssl3-3.5.0-r1.post-install: Executing script...
(3/6) Installing libpcre2 (10.42-r1)
libpcre2-10.42-r1.post-install: Executing script...
(4/6) Installing libpthread (1.2.5-r4)
libpthread-1.2.5-r4.post-install: Executing script...
(5/6) Installing librt (1.2.5-r4)
librt-1.2.5-r4.post-install: Executing script...
(6/6) Installing wget-ssl (1.25.0-r1)
wget-ssl-1.25.0-r1.post-install: Executing script...
wget-ssl-1.25.0-r1.post-install: add alternative: /usr/bin/wget -> /usr/libexec/wget-ssl
OK: 23 MiB in 156 packages
root@OpenWrt:~# ls -lF /usr/bin/wget
lrwxrwxrwx    1 root     root            21 Jun 13 21:49 /usr/bin/wget -> /usr/libexec/wget-ssl*
root@OpenWrt:~# apk del wget-ssl
(1/6) Purging wget-ssl (1.25.0-r1)
wget-ssl-1.25.0-r1.pre-deinstall: Executing script...
wget-ssl-1.25.0-r1.pre-deinstall: add alternative: /usr/bin/wget -> /bin/uclient-fetch
(2/6) Purging libopenssl3 (3.5.0-r1)
libopenssl3-3.5.0-r1.pre-deinstall: Executing script...
(3/6) Purging libatomic1 (14.3.0-r4)
libatomic1-14.3.0-r4.pre-deinstall: Executing script...
(4/6) Purging libpcre2 (10.42-r1)
libpcre2-10.42-r1.pre-deinstall: Executing script...
(5/6) Purging librt (1.2.5-r4)
librt-1.2.5-r4.pre-deinstall: Executing script...
(6/6) Purging libpthread (1.2.5-r4)
libpthread-1.2.5-r4.pre-deinstall: Executing script...
OK: 18 MiB in 150 packages
root@OpenWrt:~# ls -lF /usr/bin/wget
lrwxrwxrwx    1 root     root            18 Jun 13 21:49 /usr/bin/wget -> /bin/uclient-fetch*
root@OpenWrt:~#
```
</p>
</details> 