### PR TITLE
ipq806x: add support for IgniteNet SunSpot AC Wave2 (SS-W2-AC2600)

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ipq806x
+++ b/package/boot/uboot-tools/uboot-envtools/files/ipq806x
@@ -42,6 +42,11 @@ extreme,ap3935)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x10000" "0x10000"
 	;;
+ignitenet,ss-w2-ac2600|\
+qcom,ipq8064-ap148|\
+qcom,ipq8064-db149)
+	ubootenv_add_uci_config $(ubootenv_mtdinfo)
+	;;
 linksys,ea7500-v1|\
 linksys,ea8500)
 	ubootenv_add_uci_config "/dev/mtd10" "0x0" "0x20000" "0x20000"
@@ -51,10 +56,6 @@ netgear,r7800)
 	;;
 nokia,ac400i)
 	ubootenv_add_uci_config "/dev/mtd20" "0x0" "0x040000" "0x20000"
-	;;
-qcom,ipq8064-ap148|\
-qcom,ipq8064-db149)
-	ubootenv_add_uci_config $(ubootenv_mtdinfo)
 	;;
 ubnt,unifi-ac-hd|\
 zyxel,nbg6817)

--- a/package/boot/uboot-tools/uboot-envtools/files/ipq806x
+++ b/package/boot/uboot-tools/uboot-envtools/files/ipq806x
@@ -12,7 +12,7 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 ubootenv_mtdinfo () {
-	UBOOTENV_PART=$(cat /proc/mtd | grep APPSBLENV)
+	UBOOTENV_PART=$(cat /proc/mtd | grep -i APPSBLENV)
 	mtd_dev=$(echo $UBOOTENV_PART | awk '{print $1}' | sed 's/:$//')
 	mtd_size=$(echo $UBOOTENV_PART | awk '{print "0x"$2}')
 	mtd_erase=$(echo $UBOOTENV_PART | awk '{print "0x"$3}')

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -6,9 +6,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firmware/qca-wireless.git
-PKG_SOURCE_DATE:=2025-06-13
-PKG_SOURCE_VERSION:=4810aacf3b1c5de99923b9a424a1f0e6341c6bca
-PKG_MIRROR_HASH:=78d1102702a9d5894c6e70620c144fcf40d27cac8682dc340b31786e4bd190b8
+PKG_SOURCE_DATE:=2025-06-14
+PKG_SOURCE_VERSION:=3ac4a6421880443de2f4562ff0f33aefaaf75585
+PKG_MIRROR_HASH:=5e55fcc00585c16c0da0f9b1c2e24d444b36f326867be4f8640fae01901686c5
 PKG_FLAGS:=nonshared
 
 include $(INCLUDE_DIR)/package.mk
@@ -43,6 +43,7 @@ ALLWIFIBOARDS:= \
 	glinet_gl-ax1800 \
 	glinet_gl-axt1800 \
 	glinet_gl-b3000 \
+	ignitenet_ss-w2-ac2600 \
 	iodata_wn-dax3000gr \
 	linksys_homewrk \
 	linksys_mr5500 \
@@ -200,6 +201,7 @@ $(eval $(call generate-ipq-wifi-package,elecom_wrc-x3000gs2,ELECOM WRC-X3000GS2)
 $(eval $(call generate-ipq-wifi-package,glinet_gl-ax1800,GL.iNet GL-AX1800))
 $(eval $(call generate-ipq-wifi-package,glinet_gl-axt1800,GL.iNet GL-AXT1800))
 $(eval $(call generate-ipq-wifi-package,glinet_gl-b3000,GL.iNet GL-B3000))
+$(eval $(call generate-ipq-wifi-package,ignitenet_ss-w2-ac2600,Ignitenet SS-W2-AC2600))
 $(eval $(call generate-ipq-wifi-package,iodata_wn-dax3000gr,I-O DATA WN-DAX3000GR))
 $(eval $(call generate-ipq-wifi-package,linksys_homewrk,Linksys HomeWRK))
 $(eval $(call generate-ipq-wifi-package,linksys_mr5500,Linksys MR5500))

--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -46,6 +46,10 @@ fortinet,fap-421e)
 	ucidef_set_led_wlan "wlan5g" "5G" "yellow:5g" "phy0tpt"
 	ucidef_set_led_usbport "usb" "USB" "amber:power" "usb1-port1" "usb2-port1"
 	;;
+ignitenet,ss-w2-ac2600)
+	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy1tpt"
+	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy0tpt"
+	;;
 linksys,e8350-v1)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wifi" "phy0tpt"
 	;;

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -58,6 +58,7 @@ ipq806x_setup_interfaces()
 		ucidef_set_interface_lan "eth1 eth2 eth3 lan1 lan2 lan3 lan4" "wan"
 		;;
 	fortinet,fap-421e |\
+	ignitenet,ss-w2-ac2600 |\
 	ubnt,unifi-ac-hd)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;

--- a/target/linux/ipq806x/base-files/etc/init.d/bootcount
+++ b/target/linux/ipq806x/base-files/etc/init.d/bootcount
@@ -9,7 +9,8 @@ boot() {
 	asrock,g10)
 		asrock_bootconfig_mangle "bootcheck" && reboot
 		;;
-	edgecore,ecw5410)
+	edgecore,ecw5410 |\
+	ignitenet,ss-w2-ac2600)
 		fw_setenv bootcount 0
 		;;
 	extreme,ap3935)

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -35,7 +35,8 @@ platform_do_upgrade() {
 		CI_ROOTPART="ubi_rootfs"
 		nand_do_upgrade "$1"
 		;;
-	edgecore,ecw5410)
+	edgecore,ecw5410 |\
+	ignitenet,ss-w2-ac2600)
 		part="$(awk -F 'ubi.mtd=' '{printf $2}' /proc/cmdline | sed -e 's/ .*$//')"
 		if [ "$part" = "rootfs1" ]; then
 			fw_setenv active 2 || exit 1

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ss-w2-ac2600.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ss-w2-ac2600.dts
@@ -1,0 +1,309 @@
+#include "qcom-ipq8064-v2.0-smb208.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	model = "IgniteNet SunSpot AC Wave2";
+	compatible = "ignitenet,ss-w2-ac2600", "qcom,ipq8068";
+
+	aliases {
+		ethernet0 = &gmac2;
+		ethernet1 = &gmac3;
+
+		led-boot = &led_power_red;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_red;
+		led-upgrade = &led_power_red;
+	};
+
+	chosen {
+		bootargs-append = " console=ttyMSM0,115200n8 root=/dev/ubiblock0_1";
+	};
+
+	reserved-memory {
+		nss@40000000 {
+			reg = <0x40000000 0x1000000>;
+			no-map;
+		};
+
+		smem: smem@41000000 {
+			reg = <0x41000000 0x200000>;
+			no-map;
+		};
+
+		wifi_dump@44000000 {
+			reg = <0x44000000 0x600000>;
+			no-map;
+		};
+	};
+
+	cpus {
+		idle-states {
+			CPU_SPC: spc {
+				status = "disabled";
+			};
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&qcom_pinmux 25 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+			wakeup-source;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		wlan2g_green {
+			label = "green:wlan2g";
+			gpios = <&qcom_pinmux 23 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g_yellow {
+			label = "yellow:wlan2g";
+			gpios = <&qcom_pinmux 24 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g_green {
+			label = "green:wlan5g";
+			gpios = <&qcom_pinmux 26 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_red: power_red {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&qcom_pinmux 28 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan5g_yellow {
+			label = "yellow:wlan5g";
+			gpios = <&qcom_pinmux 59 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&qcom_pinmux {
+	spi_pins: spi_pins {
+		mux {
+			pins = "gpio18", "gpio19";
+			function = "gsbi5";
+			drive-strength = <10>;
+			bias-pull-down;
+		};
+
+		clk {
+			pins = "gpio21";
+			function = "gsbi5";
+			drive-strength = <12>;
+			bias-pull-down;
+		};
+
+		cs {
+			pins = "gpio20";
+			function = "gpio";
+			drive-strength = <10>;
+			bias-pull-up;
+		};
+	};
+
+	led_pins: led_pins {
+		mux {
+			pins = "gpio16", "gpio23", "gpio24", "gpio26",
+				   "gpio28", "gpio59";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	button_pins: button_pins {
+		mux {
+			pins = "gpio25";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+};
+
+&gsbi5 {
+	qcom,mode = <GSBI_PROT_SPI>;
+	status = "okay";
+
+	spi4: spi@1a280000 {
+		status = "okay";
+		spi-max-frequency = <50000000>;
+
+		pinctrl-0 = <&spi_pins>;
+		pinctrl-names = "default";
+
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
+
+		w25q128@0 {
+			compatible = "jedec,spi-nor";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			spi-max-frequency = <50000000>;
+			reg = <0>;
+
+			partitions {
+				compatible = "qcom,smem-part";
+
+				art: partition-0-art {
+					label = "0:art";
+				};
+			};
+		};
+	};
+};
+
+&art {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_art_0: macaddr@0 {
+			reg = <0x0 0x6>;
+		};
+
+		macaddr_art_6: macaddr@6 {
+			reg = <0x6 0x6>;
+		};
+
+		precal_art_1000: precal@1000 {
+			reg = <0x1000 0x2f20>;
+		};
+
+		precal_art_5000: precal@5000 {
+			reg = <0x5000 0x2f20>;
+		};
+	};
+};
+
+&pcie1 {
+	status = "okay";
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			status = "okay";
+			reg = <0x00010000 0 0 0 0>;
+			qcom,ath10k-calibration-variant = "IgniteNet-SS-W2-AC2600";
+			nvmem-cells = <&precal_art_1000>;
+			nvmem-cell-names = "pre-calibration";
+		};
+	};
+};
+
+&pcie2 {
+	status = "okay";
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			status = "okay";
+			reg = <0x00010000 0 0 0 0>;
+			qcom,ath10k-calibration-variant = "IgniteNet-SS-W2-AC2600";
+			nvmem-cells = <&precal_art_5000>;
+			nvmem-cell-names = "pre-calibration";
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	nand@0 {
+		compatible = "qcom,nandcs";
+
+		reg = <0>;
+
+		nand-ecc-strength = <4>;
+		nand-bus-width = <8>;
+		nand-ecc-step-size = <512>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			rootfs1@0 {
+				label = "rootfs1";
+				reg = <0x0000000 0x4000000>;
+			};
+
+			rootfs2@4000000 {
+				label = "rootfs2";
+				reg = <0x4000000 0x4000000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+	};
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+	};
+};
+
+&gmac2 {
+	status = "okay";
+
+	qcom,id = <2>;
+	mdiobus = <&mdio0>;
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy1>;
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac3 {
+	status = "okay";
+
+	qcom,id = <3>;
+	mdiobus = <&mdio0>;
+
+	phy-mode = "sgmii";
+	phy-handle = <&phy0>;
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&adm_dma {
+	status = "okay";
+};

--- a/target/linux/ipq806x/image/generic.mk
+++ b/target/linux/ipq806x/image/generic.mk
@@ -201,6 +201,21 @@ define Device/fortinet_fap-421e
 endef
 TARGET_DEVICES += fortinet_fap-421e
 
+define Device/ignitenet_ss-w2-ac2600
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := IgniteNet
+	DEVICE_MODEL := SunSpot AC Wave2
+	DEVICE_ALT0_VENDOR := Accton Technology Corporation
+	DEVICE_ALT0_MODEL := EAP1024A
+	DEVICE_ALT0_VARIANT := V2
+	SOC := qcom-ipq8068
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct ipq-wifi-ignitenet_ss-w2-ac2600
+endef
+TARGET_DEVICES += ignitenet_ss-w2-ac2600
+
 define Device/linksys_e8350-v1
 	$(call Device/LegacyImage)
 	DEVICE_VENDOR := Linksys


### PR DESCRIPTION
The IgniteNet SunSpot AC Wave2 is an 802.11ac outdoor access point.
FCC ID: HEDSSW2AC2600

Product info: https://www.ignitenet.com/wireless-access-points/sunspot-ac-wave2/

Specification:
 - Qualcomm dual-core IPQ8068 @ 1.4 GHz
 - 256 MB of DDR3L RAM (2x Winbond W631GU6KB-12)
 - 16 MB of SPI NOR (Winbond W25Q128FW)
 - 128 MB of NAND (Macronix MX30UF1G18AC)
 - Qualcomm QCA9994 2.4GHz 802.11bgn
 - Qualcomm QCA9994 5GHz 802.11ac
 - 2 x 10/100/1000 Mbit/s Ethernet
 - 115200, 8N1 RS-232 console (unpopulated RJ-45)
 - Reset button
 - Power and WLAN LEDs
 - Powered via PoE or 12V 2A via barrel connector

Required BDF has been merged, see https://github.com/openwrt/firmware_qca-wireless/commit/3ac4a6421880443de2f4562ff0f33aefaaf75585