### PR TITLE
[24.10] Backport fixes for toolchain: gdb, gcc with MacOS (Xcode 16.3)

### DIFF
--- a/toolchain/gcc/patches-11.x/980-fix-build-error-with-Xcode-16.3.patch
+++ b/toolchain/gcc/patches-11.x/980-fix-build-error-with-Xcode-16.3.patch
@@ -1,0 +1,52 @@
+From 93954654b87552c4fe0273cab99d0f42f213f7f8 Mon Sep 17 00:00:00 2001
+From: Georgi Valkov <gvalkov@gmail.com>
+Date: Mon, 14 Apr 2025 15:45:59 +0300
+Subject: [PATCH] zlib: fix build error with Xcode 16.3
+
+Xcode 16.3 defines TARGET_OS_MAC, it was not defined in prior versions.
+zutil.h conditionally defines fdopen as NULL when this macro is defined,
+resulting in the following build error:
+
+/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
+  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
+      |          ^
+./zutil.h:147:33: note: expanded from macro 'fdopen'
+  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
+
+In Xcode 16.2 and earlier, TARGET_OS_MAC was not defined so this entire
+block was ignored, gcc and gdb used to compile and work fine.
+
+This may have been used for compatibility with older versions of macOS,
+but is no longer needed. By pure luck, the build worked fine for a long
+time, because it did not properly detect macOS.
+Fixed by removing the check for TARGET_OS_MAC.
+
+Note that since Xcode 16.3, an entire set of TARGET_OS macros
+are now defined, most of which are set to 0:
+TARGET_OS_LINUX 0
+TARGET_OS_MAC 1
+TARGET_OS_OSX 1
+
+[1] https://github.com/openwrt/openwrt/pull/18467
+
+Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
+---
+ zlib/zutil.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/zlib/zutil.h b/zlib/zutil.h
+index 4b596adf629..9ea8d840643 100644
+--- a/zlib/zutil.h
++++ b/zlib/zutil.h
+@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  endif
+ #endif
+ 
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+ #  ifndef Z_SOLO
+ #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-- 
+2.49.0
+

--- a/toolchain/gcc/patches-12.x/980-fix-build-error-with-Xcode-16.3.patch
+++ b/toolchain/gcc/patches-12.x/980-fix-build-error-with-Xcode-16.3.patch
@@ -1,0 +1,52 @@
+From 93954654b87552c4fe0273cab99d0f42f213f7f8 Mon Sep 17 00:00:00 2001
+From: Georgi Valkov <gvalkov@gmail.com>
+Date: Mon, 14 Apr 2025 15:45:59 +0300
+Subject: [PATCH] zlib: fix build error with Xcode 16.3
+
+Xcode 16.3 defines TARGET_OS_MAC, it was not defined in prior versions.
+zutil.h conditionally defines fdopen as NULL when this macro is defined,
+resulting in the following build error:
+
+/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
+  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
+      |          ^
+./zutil.h:147:33: note: expanded from macro 'fdopen'
+  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
+
+In Xcode 16.2 and earlier, TARGET_OS_MAC was not defined so this entire
+block was ignored, gcc and gdb used to compile and work fine.
+
+This may have been used for compatibility with older versions of macOS,
+but is no longer needed. By pure luck, the build worked fine for a long
+time, because it did not properly detect macOS.
+Fixed by removing the check for TARGET_OS_MAC.
+
+Note that since Xcode 16.3, an entire set of TARGET_OS macros
+are now defined, most of which are set to 0:
+TARGET_OS_LINUX 0
+TARGET_OS_MAC 1
+TARGET_OS_OSX 1
+
+[1] https://github.com/openwrt/openwrt/pull/18467
+
+Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
+---
+ zlib/zutil.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/zlib/zutil.h b/zlib/zutil.h
+index 4b596adf629..9ea8d840643 100644
+--- a/zlib/zutil.h
++++ b/zlib/zutil.h
+@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  endif
+ #endif
+ 
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+ #  ifndef Z_SOLO
+ #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-- 
+2.49.0
+

--- a/toolchain/gcc/patches-13.x/980-fix-build-error-with-Xcode-16.3.patch
+++ b/toolchain/gcc/patches-13.x/980-fix-build-error-with-Xcode-16.3.patch
@@ -1,0 +1,52 @@
+From 93954654b87552c4fe0273cab99d0f42f213f7f8 Mon Sep 17 00:00:00 2001
+From: Georgi Valkov <gvalkov@gmail.com>
+Date: Mon, 14 Apr 2025 15:45:59 +0300
+Subject: [PATCH] zlib: fix build error with Xcode 16.3
+
+Xcode 16.3 defines TARGET_OS_MAC, it was not defined in prior versions.
+zutil.h conditionally defines fdopen as NULL when this macro is defined,
+resulting in the following build error:
+
+/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
+  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
+      |          ^
+./zutil.h:147:33: note: expanded from macro 'fdopen'
+  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
+
+In Xcode 16.2 and earlier, TARGET_OS_MAC was not defined so this entire
+block was ignored, gcc and gdb used to compile and work fine.
+
+This may have been used for compatibility with older versions of macOS,
+but is no longer needed. By pure luck, the build worked fine for a long
+time, because it did not properly detect macOS.
+Fixed by removing the check for TARGET_OS_MAC.
+
+Note that since Xcode 16.3, an entire set of TARGET_OS macros
+are now defined, most of which are set to 0:
+TARGET_OS_LINUX 0
+TARGET_OS_MAC 1
+TARGET_OS_OSX 1
+
+[1] https://github.com/openwrt/openwrt/pull/18467
+
+Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
+---
+ zlib/zutil.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/zlib/zutil.h b/zlib/zutil.h
+index 4b596adf629..9ea8d840643 100644
+--- a/zlib/zutil.h
++++ b/zlib/zutil.h
+@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  endif
+ #endif
+ 
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+ #  ifndef Z_SOLO
+ #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-- 
+2.49.0
+

--- a/toolchain/gcc/patches-14.x/980-fix-build-error-with-Xcode-16.3.patch
+++ b/toolchain/gcc/patches-14.x/980-fix-build-error-with-Xcode-16.3.patch
@@ -1,0 +1,52 @@
+From 93954654b87552c4fe0273cab99d0f42f213f7f8 Mon Sep 17 00:00:00 2001
+From: Georgi Valkov <gvalkov@gmail.com>
+Date: Mon, 14 Apr 2025 15:45:59 +0300
+Subject: [PATCH] zlib: fix build error with Xcode 16.3
+
+Xcode 16.3 defines TARGET_OS_MAC, it was not defined in prior versions.
+zutil.h conditionally defines fdopen as NULL when this macro is defined,
+resulting in the following build error:
+
+/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
+  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
+      |          ^
+./zutil.h:147:33: note: expanded from macro 'fdopen'
+  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
+
+In Xcode 16.2 and earlier, TARGET_OS_MAC was not defined so this entire
+block was ignored, gcc and gdb used to compile and work fine.
+
+This may have been used for compatibility with older versions of macOS,
+but is no longer needed. By pure luck, the build worked fine for a long
+time, because it did not properly detect macOS.
+Fixed by removing the check for TARGET_OS_MAC.
+
+Note that since Xcode 16.3, an entire set of TARGET_OS macros
+are now defined, most of which are set to 0:
+TARGET_OS_LINUX 0
+TARGET_OS_MAC 1
+TARGET_OS_OSX 1
+
+[1] https://github.com/openwrt/openwrt/pull/18467
+
+Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
+---
+ zlib/zutil.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/zlib/zutil.h b/zlib/zutil.h
+index 4b596adf629..9ea8d840643 100644
+--- a/zlib/zutil.h
++++ b/zlib/zutil.h
+@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  endif
+ #endif
+ 
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+ #  ifndef Z_SOLO
+ #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-- 
+2.49.0
+

--- a/toolchain/gdb/Makefile
+++ b/toolchain/gdb/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gdb
 PKG_VERSION:=15.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/gdb

--- a/toolchain/gdb/patches/130-fix-build-error-with-Xcode-16.3.patch
+++ b/toolchain/gdb/patches/130-fix-build-error-with-Xcode-16.3.patch
@@ -1,0 +1,52 @@
+From 0a084bb6c04e453183530c3e20727be1cc55ff9a Mon Sep 17 00:00:00 2001
+From: Georgi Valkov <gvalkov@gmail.com>
+Date: Mon, 14 Apr 2025 15:18:00 +0300
+Subject: [PATCH] zlib: fix build error with Xcode 16.3
+
+Xcode 16.3 defines TARGET_OS_MAC, it was not defined in prior versions.
+zutil.h conditionally defines fdopen as NULL when this macro is defined,
+resulting in the following build error:
+
+/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
+  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
+      |          ^
+./zutil.h:147:33: note: expanded from macro 'fdopen'
+  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
+
+In Xcode 16.2 and earlier, TARGET_OS_MAC was not defined so this entire
+block was ignored, gcc and gdb used to compile and work fine.
+
+This may have been used for compatibility with older versions of macOS,
+but is no longer needed. By pure luck, the build worked fine for a long
+time, because it did not properly detect macOS.
+Fixed by removing the check for TARGET_OS_MAC.
+
+Note that since Xcode 16.3, an entire set of TARGET_OS macros
+are now defined, most of which are set to 0:
+TARGET_OS_LINUX 0
+TARGET_OS_MAC 1
+TARGET_OS_OSX 1
+
+[1] https://github.com/openwrt/openwrt/pull/18467
+
+Signed-off-by: Georgi Valkov <gvalkov@gmail.com>
+---
+ zlib/zutil.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/zlib/zutil.h b/zlib/zutil.h
+index d9a20ae1bf4..183e51b96b6 100644
+--- a/zlib/zutil.h
++++ b/zlib/zutil.h
+@@ -137,7 +137,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  endif
+ #endif
+ 
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+ #  ifndef Z_SOLO
+ #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
+-- 
+2.49.0
+


### PR DESCRIPTION
I tried to compile gcc and gdb on MacOS and it fails on OpenWrt 24.10.

My log:
```
In file included from zutil.c:10:
In file included from ./gzguts.h:21:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdio.h:61:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: error: expected identifier or '('
  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
      |          ^
./zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:16: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                ^
In file included from zutil.c:10:
In file included from ./gzguts.h:21:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdio.h:61:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: error: expected ')'
./zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:16: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: note: to match this '('
./zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:15: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |               ^
In file included from zutil.c:10:
In file included from ./gzguts.h:21:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdio.h:61:
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: error: expected ')'
  318 | FILE    *fdopen(int, const char *) __DARWIN_ALIAS_STARTING(__MAC_10_6, __IPHONE_2_0, __DARWIN_ALIAS(fdopen));
      |          ^
./zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:22: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_stdio.h:318:7: note: to match this '('
./zutil.h:147:33: note: expanded from macro 'fdopen'
  147 | #        define fdopen(fd,mode) NULL /* No fdopen() */
      |                                 ^
/Library/Developer/CommandLineTools/usr/lib/clang/17/include/__stddef_null.h:26:14: note: expanded from macro 'NULL'
   26 | #define NULL ((void*)0)
      |              ^
zutil.c:133:22: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C23 [-Wdeprecated-non-prototype]
  133 | const char * ZEXPORT zError(err)
      |                      ^
zutil.c:305:22: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C23 [-Wdeprecated-non-prototype]
  305 | voidpf ZLIB_INTERNAL zcalloc (opaque, items, size)
      |                      ^
zutil.c:315:20: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C23 [-Wdeprecated-non-prototype]
  315 | void ZLIB_INTERNAL zcfree (opaque, ptr)
      |                    ^
4 warnings and 3 errors generated.
```

Backport of https://github.com/openwrt/openwrt/pull/18467