### PR TITLE
[24.10] strace: Update to version 6.12

### DIFF
--- a/package/devel/strace/Makefile
+++ b/package/devel/strace/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=strace
-PKG_VERSION:=6.11
+PKG_VERSION:=6.12
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://strace.io/files/$(PKG_VERSION)
-PKG_HASH:=83262583a3529f02c3501aa8b8ac772b4cbc03dc934e98bab6e4883626e283a5
+PKG_HASH:=c47da93be45b6055f4dc741d7f20efaf50ca10160a5b100c109b294fd9c0bdfe
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Fixes:
```
ERROR: package/devel/strace failed to build.
make -r world: build failed. Please re-run make with -j1 V=s or V=sc for a higher verbosity level to see what's going on
make: *** [/__w/openwrt/openwrt/openwrt/include/toplevel.mk:233: world] Error 1
====== Make errors from logs/package/devel/strace/compile.txt ======
                 from list.h:90,
                 from defs.h:40,
                 from ptp.c:10:
ptp.c: In function 'ptp_ioctl':
macros.h:141:9: error: static assertion failed: "Unexpected size of sysoff.rsv (sizeof(unsigned int) * 3 expected).  --enabled-bundled=yes configure option may be used to work around that."
  141 |         static_assert(sizeof(type_) == (sz_), \
      |         ^~~~~~~~~~~~~
ptp.c:306:17: note: in expansion of macro 'CHECK_TYPE_SIZE'
  306 |                 CHECK_TYPE_SIZE(sysoff.rsv, sizeof(unsigned int) * 3);
      |                 ^~~~~~~~~~~~~~~
make[7]: *** [Makefile:7187: libstrace_a-ptp.o] Error 1
```

Found in https://github.com/BKPepe/openwrt/actions/runs/15588025038/job/43899384213#step:34:83 while submitting PR here

Backport of: https://github.com/openwrt/openwrt/pull/17457

In upstream, this is fixed by https://github.com/strace/strace/commit/1526f2d255698d4f69a5282cdf61366f31f8dd5c