### PR TITLE
bmips: bcm6358: add support for Huawei HG553

### DIFF
--- a/target/linux/bmips/bcm6358/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm6358/base-files/etc/board.d/01_leds
@@ -6,6 +6,11 @@
 board_config_update
 
 case "$(board_name)" in
+huawei,hg553)
+	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "br-lan"
+	ucidef_set_led_netdev "wlan" "WLAN" "blue:wlan" "phy0-ap0"
+	ucidef_set_led_usbport "usb" "USB" "blue:hspa" "usb1-port2" "usb2-port2"
+	;;
 huawei,hg556a-a |\
 huawei,hg556a-b |\
 huawei,hg556a-c)

--- a/target/linux/bmips/bcm6358/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm6358/base-files/etc/board.d/02_network
@@ -5,6 +5,7 @@
 board_config_update
 
 case "$(board_name)" in
+huawei,hg553 |\
 huawei,hg556a-a |\
 huawei,hg556a-b |\
 huawei,hg556a-c)

--- a/target/linux/bmips/dts/bcm6358-huawei-hg553.dts
+++ b/target/linux/bmips/dts/bcm6358-huawei-hg553.dts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm6358.dtsi"
+
+/ {
+	model = "Huawei EchoLife HG553";
+	compatible = "huawei,hg553", "brcm,bcm6358";
+
+	aliases {
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+			debounce-interval = <60>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_blue: led-4 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_red: led-5 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led-12 {
+			label = "red:hspa";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led-13 {
+			label = "blue:hspa";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led-22 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		led-23 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led-25 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led-34 {
+			label = "red:dsl";
+			gpios = <&gpio 34 GPIO_ACTIVE_LOW>;
+		};
+
+		led-35 {
+			label = "blue:dsl";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	bcm4318-sprom {
+		compatible = "brcm,ssb-sprom";
+
+		pci-bus = <0>;
+		pci-dev = <1>;
+
+		nvmem-cells = <&macaddr_cfe_6a0 1>;
+		nvmem-cell-names = "mac-address";
+
+		brcm,sprom = "brcm/bcm4318-sprom.bin";
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cfe_6a0 0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-mode = "mii";
+
+	fixed-link {
+		speed = <100>;
+		full-duplex;
+	};
+};
+
+&iudma {
+	status = "okay";
+};
+
+&mdio1 {
+	switch@1e {
+		compatible = "brcm,bcm5325";
+		reg = <30>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan1";
+
+				phy-mode = "mii";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan2";
+
+				phy-mode = "mii";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+
+				phy-mode = "mii";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan4";
+
+				phy-mode = "mii";
+			};
+
+			port@5 {
+				reg = <5>;
+				label = "cpu";
+
+				phy-mode = "internal";
+				ethernet = <&ethernet1>;
+
+				fixed-link {
+					speed = <100>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pflash {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "cfe";
+			reg = <0x000000 0x020000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_cfe_6a0: macaddr@6a0 {
+					compatible = "mac-base";
+					reg = <0x6a0 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@20000 {
+			label = "firmware";
+			reg = <0x020000 0xfc0000>;
+			compatible = "brcm,bcm963xx-imagetag";
+		};
+
+		partition@fe0000 {
+			label = "nvram";
+			reg = <0xfe0000 0x020000>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};

--- a/target/linux/bmips/image/bcm6358.mk
+++ b/target/linux/bmips/image/bcm6358.mk
@@ -1,5 +1,18 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+define Device/huawei_hg553
+  $(Device/bcm63xx-cfe-legacy)
+  DEVICE_VENDOR := Huawei
+  DEVICE_MODEL := EchoLife HG553
+  CHIP_ID := 6358
+  CFE_BOARD_ID := HW553
+  CFE_EXTRAS += --rsa-signature "EchoLife_HG553" --tag-version 7
+  BLOCKSIZE := 0x20000
+  DEVICE_PACKAGES += $(USB2_PACKAGES) $(B43_PACKAGES) \
+    kmod-leds-gpio
+endef
+TARGET_DEVICES += huawei_hg553
+
 define Device/huawei_hg556a-a
   $(Device/bcm63xx-cfe-legacy)
   DEVICE_VENDOR := Huawei


### PR DESCRIPTION
Specifications:
- SoC: Broadcom BCM6358 dual 300MHz MIPS
- Flash: 16MB NOR
- RAM: 64MB DDR
- Ethernet: 4x 100M
- Wifi: Broadcom BCM4318
- 2x USB 2.0 port
- 2x Button
- 9x LED
- RJ11 2x FXS VoIP (unsupported)
- RJ11 xDSL (unsupported)

Install instructions:
- Assign static IP 192.168.1.100 to PC.
- Unplug the power source.
- Press the RESTART button at the router, don't release it yet!
- Plug the power source and wait at least 15 seconds.
- Release the RESTART button.
- Browse to http://192.168.1.1 with your PC.
- Upload the openwrt-bmips-bcm6358-huawei_hg553-squashfs-cfe.bin file.
- Wait some minutes until the firmware upgrade completes.