### PR TITLE
ramips: add support for TP-Link EX220 v2

### DIFF
--- a/target/linux/ramips/dts/mt7621_tplink_ex220-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_ex220-v2.dts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,ex220-v2", "mediatek,mt7621-soc";
+	model = "TP-Link EX220 v2";
+
+	aliases {
+		led-boot = &power_led;
+	        led-failsafe = &status_led;
+	        led-upgrade = &power_led;
+	        led-running = &wan_led;
+	        label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-wps {
+			label = "rfkill";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan_led: led-wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "netdev";
+		};
+
+		status_led: led-status {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		power_led: led-power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x00 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "config";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "isp_config";
+				reg = <0x60000 0x10000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "rom_file";
+				reg = <0x70000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_rom_file_f100: macaddr@f100 {
+						compatible = "mac-base";
+						reg = <0xf100 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@80000 {
+				label = "cloud";
+				reg = <0x80000 0x10000>;
+				read-only;
+			};
+
+			partition@90000 {
+				label = "radio";
+				reg = <0x90000 0x20000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+
+					precal_radio_e10: precal@e10 {
+						reg = <0xe10 0x19c10>;
+					};
+				};
+			};
+
+			partition@b0000 {
+				label = "config_bak";
+				reg = <0xb0000 0x10000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0xc0000 0xf30000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_radio_0>, <&precal_radio_e10>, <&macaddr_rom_file_f100 0>;
+		nvmem-cell-names = "eeprom", "precal", "mac-address";
+		mediatek,disable-radar-background;
+
+		band@1 { 
+			reg = <1>;
+			nvmem-cells = <&macaddr_rom_file_f100 2>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_rom_file_f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_rom_file_f100 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2885,6 +2885,20 @@ define Device/tplink_ex220-v1
 endef
 TARGET_DEVICES += tplink_ex220-v1
 
+define Device/tplink_ex220-v2
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := EX220
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
+  TPLINK_BOARD_ID := EX220-V2
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  IMAGE_SIZE := 15744k
+endef
+TARGET_DEVICES += tplink_ex220-v2
+
 define Device/tplink_mr600-v2-eu
   $(Device/dsa-migration)
   $(Device/tplink-v2)


### PR DESCRIPTION
This device is similar to the TP-Link EX220 v1.
The differences are the number of ports (3 LANs
and 1 WAN) and the number of LEDs (1 LED RGB)

Hardware
--------

CPU:    MediaTek MT7621 DAT
RAM:    128MB DDR3 (integrated)
FLASH:  16MB SPI-NOR
WiFi:   MediaTek MT7905 + MT7975 (2.4 / 5 DBDC) 802.11ax
SERIAL: 115200 8N1
        LED - (TX - RX - GND - 3V3 ) - ETH ports

Installation
------------

Flashing is only possible via a serial connection using the sysupgrade image; the factory image must be signed. You can flash the sysupgrade image directly through the U-Boot console, or preferably, by booting the initramfs image and flashing with the sysupgrade command. Follow these steps for sysupgrade flashing:

1. Establish a UART serial connection.
2. Set up a TFTP server at 192.168.0.2 and copy the initramfs image there.
3. Power on the device and press any key to interrupt normal boot.
4. Load the initramfs image using tftpboot.
5. Boot with bootm.
6. If you haven't done so already, back up all stock mtd partitions.
7. Copy the sysupgrade image to the router.
8. Flash OpenWrt through either LuCI or the sysupgrade command. Remember not to attempt saving settings.

Revert to stock firmware
------------------------

Flash stock firmware via OEM web-recovery mode. If you don't have access to the stock firmware image, you will need to restore the firmware partition backed up earlier.

Web-Recovery
------------

The router supports an HTTP recovery mode:

1. Turn off the router.
2. Press the reset button and power on the device.
3. When the LED start flashing, release reset and quickly press it again.

The interface is reachable at 192.168.0.1 and supports installation of the OEM factory image. Note that flashing OpenWrt this way is not possible, as mentioned above.