### PR TITLE
realtek: activate MIPS power cluster controller for RTL931x

### DIFF
--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -45,6 +45,11 @@
 		clock-frequency = <200000000>;
 	};
 
+	cpc: cpc@1bde0000 {
+		compatible = "mti,mips-cpc";
+		reg = <0x1bde0000 0x8000>;
+	};
+
 	cpuclock: cpuclock@0 {
 		#clock-cells = <0>;
 		compatible = "fixed-clock";


### PR DESCRIPTION
The SMP environment is prepared well for the RTL93X. Now describe the power cluster controller in the DTS. Tested on RTL9311 based Linksys LGS352C.

Without patch:

root@OpenWrt:~# dmesg | grep CPU
[    0.140425] CPU1 revision is: 0001a120 (MIPS interAptiv (multi))
[    0.191952] Synchronize counters for CPU 1: done.
[    1.232191] CPU2: failed to start
[    1.237863] No online CPU in core 1 to start CPU3
[    2.273784] CPU3: failed to start
[    2.277589] smp: Brought up 1 node, 2 CPUs

root@OpenWrt:~# cat /proc/cpuinfo  | grep -E "model|proc"
processor               : 0
cpu model               : MIPS interAptiv (multi) V2.0
processor               : 1
cpu model               : MIPS interAptiv (multi) V2.0

With patch:

root@OpenWrt:~# dmesg | grep CPU
[    0.000000] CPU0 revision is: 0001a120 (MIPS interAptiv (multi))
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] Failed to get CPU clock: -2
[    0.000000] CPU frequency from device tree: 1000MHz
[    0.133360] smp: Bringing up secondary CPUs ...
[    0.140418] CPU1 revision is: 0001a120 (MIPS interAptiv (multi))
[    0.191950] Synchronize counters for CPU 1: done.
[    0.230103] CPU2 revision is: 0001a120 (MIPS interAptiv (multi))
[    0.289220] Synchronize counters for CPU 2: done.
[    0.326189] CPU3 revision is: 0001a120 (MIPS interAptiv (multi))
[    0.378861] Synchronize counters for CPU 3: done.
[    0.413829] smp: Brought up 1 node, 4 CPUs

processor               : 0
cpu model               : MIPS interAptiv (multi) V2.0
processor               : 1
cpu model               : MIPS interAptiv (multi) V2.0
processor               : 2
cpu model               : MIPS interAptiv (multi) V2.0
processor               : 3
cpu model               : MIPS interAptiv (multi) V2.0