### PR TITLE
mediatek: some fixes for kernel 6.12

### DIFF
--- a/target/linux/generic/pending-6.12/417-mtd-spi-nand-macronix-disable-continuous-read-for-MX.patch
+++ b/target/linux/generic/pending-6.12/417-mtd-spi-nand-macronix-disable-continuous-read-for-MX.patch
@@ -1,0 +1,39 @@
+From 435afd182e8f5997033da1d69e56094ecb112cad Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Thu, 10 Jun 2025 23:10:16 +0800
+Subject: [PATCH] mtd: spi-nand: macronix: disable continuous read for
+ MX35LFxGE4AD
+
+In on-die ECC mode, enabling continuous read will cause ubi_io_read error.
+[    7.852000] ubi0 warning: ubi_io_read: error -5 while reading ...
+
+So disable it first. Tested on GL.iNet GL-MT3000 with MX35LF2GE4AD flash.
+
+Fixes: 11813857864f ("mtd: spi-nand: macronix: Continuous read support")
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+---
+ drivers/mtd/nand/spi/macronix.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+--- a/drivers/mtd/nand/spi/macronix.c
++++ b/drivers/mtd/nand/spi/macronix.c
+@@ -167,8 +167,7 @@ static const struct spinand_info macroni
+ 					      &update_cache_variants),
+ 		     SPINAND_HAS_QE_BIT,
+ 		     SPINAND_ECCINFO(&mx35lfxge4ab_ooblayout,
+-				     macronix_ecc_get_status),
+-		     SPINAND_CONT_READ(macronix_set_cont_read)),
++				     macronix_ecc_get_status)),
+ 	SPINAND_INFO("MX35LF4GE4AD",
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x37, 0x03),
+ 		     NAND_MEMORG(1, 4096, 128, 64, 2048, 40, 1, 1, 1),
+@@ -178,8 +177,7 @@ static const struct spinand_info macroni
+ 					      &update_cache_variants),
+ 		     SPINAND_HAS_QE_BIT,
+ 		     SPINAND_ECCINFO(&mx35lfxge4ab_ooblayout,
+-				     macronix_ecc_get_status),
+-		     SPINAND_CONT_READ(macronix_set_cont_read)),
++				     macronix_ecc_get_status)),
+ 	SPINAND_INFO("MX35LF1G24AD",
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x14, 0x03),
+ 		     NAND_MEMORG(1, 2048, 128, 64, 1024, 20, 1, 1, 1),

--- a/target/linux/mediatek/dts/mt7988a-arcadyan-mozart.dts
+++ b/target/linux/mediatek/dts/mt7988a-arcadyan-mozart.dts
@@ -67,8 +67,6 @@
 		/* cooling level (0, 1, 2) : (0% duty, 50% duty, 100% duty) */
 		cooling-levels = <0 128 255>;
 		pwms = <&pwm 1 40000 0>;
-
-		status = "okay";
 	};
 };
 
@@ -81,8 +79,6 @@
 };
 
 &mdio_bus {
-	#address-cells = <1>;
-	#size-cells = <0>;
 	reset-gpios = <&pio 72 GPIO_ACTIVE_LOW>;
 	reset-assert-us = <100000>;
 	reset-deassert-us = <100000>;
@@ -163,11 +159,11 @@
 	};
 };
 
-&serial1 {
+&pwm {
 	status = "okay";
 };
 
-&pwm {
+&serial1 {
 	status = "okay";
 };
 

--- a/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
+++ b/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
@@ -152,8 +152,6 @@
 		interrupt-parent = <&pio>;
 		interrupts = <21 IRQ_TYPE_EDGE_FALLING>;
 		pulses-per-revolution = <2>;
-
-		status = "okay";
 	};
 };
 
@@ -735,8 +733,6 @@
 			groups = "uart2";
 		};
 	};
-
-
 };
 
 &pwm {
@@ -754,10 +750,9 @@
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 	};
-
 };
 
 &ssusb0 {

--- a/target/linux/mediatek/dts/mt7988d-asus-zenwifi-bt8-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7988d-asus-zenwifi-bt8-ubootmod.dts
@@ -21,8 +21,8 @@
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;
-		spi-tx-buswidth = <4>;
-		spi-rx-buswidth = <4>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
+++ b/target/linux/mediatek/files-6.6/arch/arm64/boot/dts/mediatek/mt7988a-bananapi-bpi-r4.dtsi
@@ -76,6 +76,17 @@
 		};
 	};
 
+	fan: pwm-fan {
+		compatible = "pwm-fan";
+		/* cooling level (0, 1, 2, 3) : (0% duty, 30% duty, 50% duty, 100% duty) */
+		cooling-levels = <0 80 128 255>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&pwm0_pins>;
+		pwms = <&pwm 0 50000>;
+		#cooling-cells = <2>;
+		#thermal-sensor-cells = <1>;
+	};
+
 	reg_1p8v: regulator-1p8v {
 		compatible = "regulator-fixed";
 		regulator-name = "fixed-1.8V";
@@ -441,19 +452,6 @@
 			function = "spi";
 			groups = "spi0", "spi0_wp_hold";
 		};
-	};
-
-	fan: pwm-fan {
-		compatible = "pwm-fan";
-		pinctrl-names = "default";
-		pinctrl-0 = <&pwm0_pins>;
-		pwms = <&pwm 0 50000>;
-		/* cooling level (0, 1, 2, 3) : (0% duty, 30% duty, 50% duty, 100% duty) */
-		cooling-levels = <0 80 128 255>;
-		#cooling-cells = <2>;
-		#thermal-sensor-cells = <1>;
-
-		status = "okay";
 	};
 };
 


### PR DESCRIPTION
- Cleanup device tree for mt7988 devices
Fix some errors introduced by commit b992aa11
- Fix the problem of mt3000 bricking on kernel 6.12
For the bricked mt3000, you needs to enter uboot to erase
the nmbm area: `mtd erase spi-nand0 0xfc00000 0x400000`
Then you can upgrade the firmware normally.

ping @dangowrt @EPinci @zcluo
