### PR TITLE
realtek: convert RTL838x toolchain to 24kc

### DIFF
--- a/target/linux/realtek/patches-6.12/308-tune-switch-4kec.patch
+++ b/target/linux/realtek/patches-6.12/308-tune-switch-4kec.patch
@@ -1,0 +1,24 @@
+From: Markus Stockhausen <markus.stockhausen@gmx.de>
+Date: Fri, 13 Jun 2025 20:25:37 +0100
+Subject: [PATCH] realtek: set mtune 4kec for RTL838x targets
+
+Generic patches will always force the gcc kernel tuning to 34kc. With RTL838x 
+being only 4kec this does not harm but is not right. Match the tuning properly.
+
+Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
+---
+
+--- a/arch/mips/Makefile
++++ b/arch/mips/Makefile
+@@ -164,6 +164,11 @@ cflags-$(CONFIG_CPU_R4X00)	+= $(call cc-
+ cflags-$(CONFIG_CPU_TX49XX)	+= $(call cc-option,-march=r4600,-march=mips3) -Wa,--trap
+ cflags-$(CONFIG_CPU_MIPS32_R1)	+= -march=mips32 -Wa,--trap
+ cflags-$(CONFIG_CPU_MIPS32_R2)	+= -march=mips32r2 -mtune=34kc -Wa,--trap
++
++#ifdef CONFIG_RTL838X
++cflags-$(CONFIG_CPU_MIPS32_R2) := $(subst 34kc,4kec,$(cflags-$(CONFIG_CPU_MIPS32_R2)))
++#endif
++
+ cflags-$(CONFIG_CPU_MIPS32_R5)	+= -march=mips32r5 -Wa,--trap -modd-spreg
+ cflags-$(CONFIG_CPU_MIPS32_R6)	+= -march=mips32r6 -Wa,--trap -modd-spreg
+ cflags-$(CONFIG_CPU_MIPS64_R1)	+= -march=mips64 -Wa,--trap

--- a/target/linux/realtek/rtl838x/target.mk
+++ b/target/linux/realtek/rtl838x/target.mk
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 ARCH:=mips
 SUBTARGET:=rtl838x
-CPU_TYPE:=4kec
+CPU_TYPE:=24kc
 BOARD:=realtek
 BOARDNAME:=Realtek MIPS RTL838X
 


### PR DESCRIPTION
Info: This is a resurrection of https://github.com/openwrt/openwrt/pull/11321 This time with more meaningful description.

The Realtek RTL838x devices have a MIPS 4Kec core. This has a very simple pipeline. OpenWrt uses CPU_TYPE:=4kec to honour this and adds a dedicated toolchain with some GB of extra space. There would be no problem if that toolchain would do what it is expected to do. Looking at the build process one can see:

during kernel builds:
```
      ps -ef | grep mtune
      ... -march=mips32r2 -mtune=34kc ...
```
during package builds
```
      ps -ef | grep mtune
      ... -mips32r2 -mtune=4kec ...
```

So the kernel is optimized for the wrong cpu type while the applications fit fine. Explanation for this is the generic/308-mips32r2_tune.patch. This forces kernel builds to -mtune=34kc. Nevertheless everything runs fine since years on the RTL838x targets.

It does not make sense to provide a dedicated 4kec toolchain for this mess. So change the setup as follows:

- switch CPU type to mips24kc for RTL838x -> This drops one toolchain and saves space
- Add a RTl838x specific mtune=4kec patch -> Builds kernel with the proper setting

Downside is: packages will be built with -mtune=24kc. But this is the lesser evil.


how to test:

- Set target to rtl838x and desired device
- make dirclean (cleanup everything including toolchain)
- make defconfig
- check that .config in root directory is set properly

```
$ grep CONFIG_CPU .config
CONFIG_CPU_TYPE="24kc"

```

- build
- run build on device