### PR TITLE
realtek: add support for TP-Link TL-ST1008F v2.0

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -54,6 +54,10 @@ tplink,t1600g-28ts-v3)
 	label_mac=$(get_mac_label)
 	lan_mac="$label_mac"
 	;;
+tplink,tl-st1008f,v2)
+	lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+	[ -z "$lan_mac" ] || [ "$lan_mac" = "00:e0:4c:00:00:00" ] && lan_mac=$(macaddr_random)
+	;;
 xikestor,sks8300-8x)
 	lan_mac=$(mtd_get_mac_binary board-info 0x1f1)
 	;;

--- a/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
+++ b/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
@@ -1,0 +1,29 @@
+[ ! -e /etc/fw_env.config ] && exit 0
+
+BOARD_CFG=/etc/board.json
+[ ! -e "$BOARD_CFG" ] && exit 0
+
+. /lib/functions/system.sh
+. /lib/upgrade/common.sh
+. /usr/share/libubox/jshn.sh
+
+[ "$(rootfs_type)" = "tmpfs" ] && exit 0
+
+case "$(board_name)" in
+tplink,tl-st1008f,v2)
+	env_ethaddr=$(macaddr_canonicalize "$(fw_printenv -n ethaddr 2>/dev/null)")
+
+	# This device ships with a dummy ethaddr because it's an unmanaged switch.
+	# If it hasn't been updated to another one yet, do that now.
+	if [ -z "$env_ethaddr" ] || [ "$env_ethaddr" = "00:e0:4c:00:00:00" ]; then
+		json_init
+		json_load_file "$BOARD_CFG"
+		json_select network_device
+		json_select eth0
+		json_get_var board_ethaddr macaddr
+		[ -n "$board_ethaddr" ] && fw_setenv ethaddr "$board_ethaddr"
+	fi
+	;;
+esac
+
+exit 0

--- a/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f_v2.dts
+++ b/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f_v2.dts
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,tl-st1008f,v2", "realtek,rtl930x-soc";
+	model = "TP-Link TL-ST1008F v2.0";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* first 256 MiB */
+		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		m1 {
+			label = "M1";
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <50>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		m2 {
+			label = "M2";
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
+			debounce-interval = <50>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+
+		m3 {
+			label = "M3";
+			gpios = <&gpio0 19 GPIO_ACTIVE_LOW>;
+			debounce-interval = <50>;
+			linux,code = <BTN_2>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-high;
+
+		led_set0 = <0x0ba0 0x0a08 0x0a01>;
+	};
+
+	i2c_gpio {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-gpio,delay-us = <2>;
+		scl-gpios = <&gpio0 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+
+		gpioexp0: i2c@38 {
+			reg = <0x38>;
+			compatible = "nxp,pca9534";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	i2c_main: i2c@1b00036c {
+		compatible = "realtek,rtl9300-i2c";
+		reg = <0x1b00036c 0x3c>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		scl-pin = <8>;
+		sda-pin = <9>;
+		clock-frequency = <100000>;
+	};
+
+	i2c-mux {
+		compatible = "realtek,i2c-mux-rtl9300";
+		i2c-parent = <&i2c_main>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c0: i2c@0 {
+			reg = <0>;
+			scl-pin = <8>;
+			sda-pin = <9>;
+		};
+
+		i2c1: i2c@1 {
+			reg = <1>;
+			scl-pin = <8>;
+			sda-pin = <10>;
+		};
+
+		i2c2: i2c@2 {
+			reg = <2>;
+			scl-pin = <8>;
+			sda-pin = <11>;
+		};
+
+		i2c3: i2c@3 {
+			reg = <3>;
+			scl-pin = <8>;
+			sda-pin = <12>;
+		};
+
+		i2c4: i2c@4 {
+			reg = <4>;
+			scl-pin = <8>;
+			sda-pin = <13>;
+		};
+
+		i2c5: i2c@5 {
+			reg = <5>;
+			scl-pin = <8>;
+			sda-pin = <14>;
+		};
+
+		i2c6: i2c@6 {
+			reg = <6>;
+			scl-pin = <8>;
+			sda-pin = <15>;
+		};
+
+		i2c7: i2c@7 {
+			reg = <7>;
+			scl-pin = <8>;
+			sda-pin = <16>;
+		};
+	};
+
+	sfp0: sfp-p1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		mod-def0-gpio = <&gpio0 0 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpioexp0 0 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2900>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp1: sfp-p2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		mod-def0-gpio = <&gpio0 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpioexp0 1 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp2: sfp-p3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		mod-def0-gpio = <&gpio0 2 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpioexp0 2 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp3: sfp-p4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		mod-def0-gpio = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpioexp0 3 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp4: sfp-p5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c4>;
+		mod-def0-gpio = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpioexp0 4 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp5: sfp-p6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c5>;
+		mod-def0-gpio = <&gpio0 5 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpioexp0 5 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp6: sfp-p7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c6>;
+		mod-def0-gpio = <&gpio0 6 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpioexp0 6 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp7: sfp-p8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c7>;
+		mod-def0-gpio = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpioexp0 7 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2900>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1200>;
+		always-running;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <100000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x10000>;
+			};
+
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0xf0000 0x10000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "jffs2-cfg";
+				reg = <0x100000 0x100000>;
+			};
+
+			partition@200000 {
+				label = "jffs2-log";
+				reg = <0x200000 0x100000>;
+			};
+
+			partition@300000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				reg = <0x300000 0x1d00000>;
+				label = "firmware";
+				openwrt,ih-magic = <0x93030000>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: ethernet-phy@0 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+			reg = <0>;
+			sds = <2>;
+		};
+
+		phy8: ethernet-phy@8 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+			reg = <8>;
+			sds = <3>;
+		};
+
+		phy16: ethernet-phy@10 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+			reg = <16>;
+			sds = <4>;
+		};
+
+		phy20: ethernet-phy@14 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+			reg = <20>;
+			sds = <5>;
+		};
+
+		phy24: ethernet-phy@18 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+			reg = <24>;
+			sds = <6>;
+		};
+
+		phy25: ethernet-phy@19 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+			reg = <25>;
+			sds = <7>;
+		};
+
+		phy26: ethernet-phy@1a {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+			reg = <26>;
+			sds = <8>;
+		};
+
+		phy27: ethernet-phy@1b {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			phy-is-integrated;
+			reg = <27>;
+			sds = <9>;
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			phy-mode = "10gbase-r";
+			pseudo-phy-handle = <&phy0>;
+			sfp = <&sfp0>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@8 {
+			reg = <8>;
+			label = "lan2";
+			phy-mode = "10gbase-r";
+			pseudo-phy-handle = <&phy8>;
+			sfp = <&sfp1>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@10 {
+			reg = <16>;
+			label = "lan3";
+			phy-mode = "10gbase-r";
+			pseudo-phy-handle = <&phy16>;
+			sfp = <&sfp2>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@14 {
+			reg = <20>;
+			label = "lan4";
+			phy-mode = "10gbase-r";
+			pseudo-phy-handle = <&phy20>;
+			sfp = <&sfp3>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@18 {
+			reg = <24>;
+			label = "lan5";
+			phy-mode = "10gbase-r";
+			pseudo-phy-handle = <&phy24>;
+			sfp = <&sfp4>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@19 {
+			reg = <25>;
+			label = "lan6";
+			phy-mode = "10gbase-r";
+			pseudo-phy-handle = <&phy25>;
+			sfp = <&sfp5>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@1a {
+			reg = <26>;
+			label = "lan7";
+			phy-mode = "10gbase-r";
+			pseudo-phy-handle = <&phy26>;
+			sfp = <&sfp6>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@1b {
+			reg = <27>;
+			label = "lan8";
+			phy-mode = "10gbase-r";
+			pseudo-phy-handle = <&phy27>;
+			sfp = <&sfp7>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@1c {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&thermal_zones {
+	sfp-thermal {
+		polling-delay-passive = <10000>;
+		polling-delay = <10000>;
+		thermal-sensors = <&sfp0>, <&sfp1>, <&sfp2>, <&sfp3>, <&sfp4>, <&sfp5>, <&sfp6>, <&sfp7>;
+		trips {
+			sfp-crit {
+				temperature = <110000>;
+				hysteresis = <1000>;
+				type = "critical";
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -5,6 +5,17 @@ define Build/xikestor-nosimg
   mv $@.new $@
 endef
 
+define Device/tplink_tl-st1008f_v2
+  SOC := rtl9303
+  UIMAGE_MAGIC := 0x93030000
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := TL-ST1008F
+  DEVICE_VARIANT := v2.0
+  DEVICE_PACKAGES := kmod-gpio-pca953x
+  IMAGE_SIZE := 31808k
+endef
+TARGET_DEVICES += tplink_tl-st1008f_v2
+
 define Device/xikestor_sks8300-8x
   SOC := rtl9303
   DEVICE_VENDOR := XikeStor


### PR DESCRIPTION
The TP-Link TL-ST1008F is an 8-port multi-gig switch with 8x SFP+ ports which support 1G/2.5G/10G speeds. Out of the box it is an unmanaged switch but with RTL9303 and sufficient RAM + Flash it easily can run as a managed Linux switch.

Hardware:
 - Realtek RTL9303 Switch SoC
 - Winbond 25Q256JVFQ (32MB flash)
 - Samsung K4B4G1646E-BYMA (512MB DDR3 SDRAM)
 - TCA9534 GPIO extender to control the port LEDs
 - 8x SFP+ 1/2.5/10G slot
 - Serial: 3V3 logic, 115200 8N1
 - 5-pin JTAG
 - physical tri-state switch (used by stock firmware for port speed config)
 - 24-LED port speed matrix
 - robust full-metal case

This device is quite similar to the already supported Xikestor SXS8300-8x but has some significant differences, especially regarding GPIO. It seems to be intended for the Chinese market and can be purchased e.g. on AliExpress.

The board script to set mac addr is taken/inspired by work from @janh.

If #18851 is merged before, I'll add a commit making use of the dts helpers to reduce the boilerplate in the dts.

-------

v2: moved script from board.d to uci-defaults