### PR TITLE
[24.10] ipq-wifi: add missing dependency on TARGET_ath79

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -73,7 +73,7 @@ define Package/ipq-wifi-default
   SUBMENU:=ath10k Board-Specific Overrides
   SECTION:=firmware
   CATEGORY:=Firmware
-  DEPENDS:=@(TARGET_ipq40xx||TARGET_ipq806x||TARGET_qualcommax)
+  DEPENDS:=@(TARGET_ath79||TARGET_ipq40xx||TARGET_ipq806x||TARGET_qualcommax)
   TITLE:=Custom Board
 endef
 


### PR DESCRIPTION
A previous commit backported the ipq-wifi update to fix support for the TP-Link Archer C6 v2 by adding the device to the package. However, it missed adding the required TARGET_ath79 dependency, causing the ipq-tplink_archer-c6-v2 build to fail.

The dependency was previously added in commit 4990ce613b7d ("ipq-wifi: update to 2024-02-17") when several ath79 devices were introduced. However, since this backport only fixes support for the Archer C6 v2, it is not feasible to backport all related changes. Therefore, this commit adds only the missing dependency to resolve the build issue without pulling in unrelated updates.

Fixes: 0c43acc349a7 ("ipq-wifi: update to Git HEAD (2025-05-30)")
