### PR TITLE
[24.10] rockchip: fix the SD card detection on NanoPi R6C/R6S

### DIFF
--- a/target/linux/rockchip/patches-6.6/402-v6.13-arm64-dts-rockchip-Fix-the-SD-card-detection-on-Nano.patch
+++ b/target/linux/rockchip/patches-6.6/402-v6.13-arm64-dts-rockchip-Fix-the-SD-card-detection-on-Nano.patch
@@ -1,0 +1,25 @@
+From 95147bb42bc163866fc103c957820345fefa96cd Mon Sep 17 00:00:00 2001
+From: Anton Kirilov <anton.kirilov@arm.com>
+Date: Thu, 19 Dec 2024 11:31:45 +0000
+Subject: [PATCH] arm64: dts: rockchip: Fix the SD card detection on NanoPi
+ R6C/R6S
+
+Fix the SD card detection on FriendlyElec NanoPi R6C/R6S boards.
+
+Signed-off-by: Anton Kirilov <anton.kirilov@arm.com>
+Link: https://lore.kernel.org/r/20241219113145.483205-1-anton.kirilov@arm.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6.dtsi
+@@ -410,6 +410,7 @@
+ &sdmmc {
+ 	bus-width = <4>;
+ 	cap-sd-highspeed;
++	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+ 	disable-wp;
+ 	max-frequency = <150000000>;
+ 	no-mmc;


### PR DESCRIPTION
Cherry-picking this fix from the master branch that fixes SD card detection on the NanoPi R6C/R6S (backport of https://github.com/openwrt/openwrt/pull/18553).

While I did not encounter this issue, I have been running this fix in a 24.10.1 build on an R6S for weeks without any side effects. Therefore, it should be safe to backport this to the 24.10 branch.

(cherry picked from commit 5c83301107d238e6c3ea829ae09d87396da0b4db)