### PR TITLE
sunxi: add support for OrangePi Zero 2W

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -351,6 +351,15 @@ define U-Boot/orangepi_zero2
   ATF:=h616
 endef
 
+define U-Boot/orangepi_zero2w
+  BUILD_SUBTARGET:=cortexa53
+  NAME:=Xunlong Orange Pi Zero2W
+  BUILD_DEVICES:=xunlong_orangepi-zero2w
+  DEPENDS:=+PACKAGE_u-boot-orangepi_zero2w:trusted-firmware-a-sunxi-h616
+  UENV:=h616
+  ATF:=h616
+endef
+
 define U-Boot/orangepi_zero3
   BUILD_SUBTARGET:=cortexa53
   NAME:=Xunlong Orange Pi Zero3
@@ -425,6 +434,7 @@ UBOOT_TARGETS := \
 	orangepi_2 \
 	orangepi_pc2 \
 	orangepi_zero2 \
+	orangepi_zero2w \
 	orangepi_zero3 \
 	pangolin \
 	pine64_plus \

--- a/target/linux/sunxi/image/cortexa53.mk
+++ b/target/linux/sunxi/image/cortexa53.mk
@@ -127,6 +127,13 @@ define Device/xunlong_orangepi-zero2
 endef
 TARGET_DEVICES += xunlong_orangepi-zero2
 
+define Device/xunlong_orangepi-zero2w
+  DEVICE_VENDOR := Xunlong
+  DEVICE_MODEL := Orange Pi Zero 2W
+  $(Device/sun50i-h618)
+endef
+TARGET_DEVICES += xunlong_orangepi-zero2w
+
 define Device/xunlong_orangepi-zero3
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Zero 3


### PR DESCRIPTION
Specifications:
SoC:     Allwinner H618 SoC (Quad core Cortex-A53)
DRAM:    1/1.5/2/4 GB LPDDR4 DRAM (1.5GB version not supported)
Power:   5V USB-C
Video:   HDMI (Type 2.0A - micro)
Storage: microSD / 16MByte SPI flash
Network: Unisoc UWE5622 (no driver currently)
Debug:   serial UART

Flashing instructions:
  Standard sunxi SD card installation procedure - copy image to SD card,
  insert into SD card slot on the device and boot.
