### PR TITLE
tools: libdeflate: update to 1.24

### DIFF
--- a/tools/libdeflate/Makefile
+++ b/tools/libdeflate/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdeflate
-PKG_VERSION:=1.22
+PKG_VERSION:=1.24
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ebiggers/libdeflate/releases/download/v$(PKG_VERSION)
-PKG_HASH:=7834d9adbc9a809e0fb0d7b486060a9ae5f7819eb7f55bb8c22b10d7b3bed8da
+PKG_HASH:=a0dda1c4b804742066db07b9510876edd09cc0ca06cdc32c5dfe1b2016a26463
 
 include $(INCLUDE_DIR)/host-build.mk
 


### PR DESCRIPTION
Release notes:
https://github.com/ebiggers/libdeflate/releases/tag/v1.23
https://github.com/ebiggers/libdeflate/releases/tag/v1.24

Changelog can be found in NEWS.md in relevant tags.

cc: @robimarko , who updated this in the past.
