### PR TITLE
ath79: enable USB by default on hAP ac

### DIFF
--- a/target/linux/ath79/dts/qca9558_mikrotik_routerboard-96x.dtsi
+++ b/target/linux/ath79/dts/qca9558_mikrotik_routerboard-96x.dtsi
@@ -44,7 +44,7 @@
 
 		usb_power {
 			gpio-export,name = "usb-power";
-			gpio-export,output = <0>;
+			gpio-export,output = <1>;
 			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
 		};
 	};


### PR DESCRIPTION
Due to a bug, USB is not powered on after boot on hAP ac. This prevents extroot configurations from working as overlayfs is mounted before USB device can be powered on. This commit fixes this by enabling USB in devicetree.

Related discussion links:
- https://forum.openwrt.org/t/usb-power-is-off-on-boot/229007

---

Extroot configuration requires the USB to be powered on before preinit_main/80_mount_root. Probably the simplest approach is to enable it in the devicetree. Another approach would be to add a script into /lib/preinit that will power on USB via /sys/class/gpio/usb-power/value

E.g.
```
cat /lib/preinit/79_power_on_usb
do_power_on_usb(){
  echo '1' > /sys/class/gpio/usb-power/value
}
boot_hook_add preinit_main do_power_on_usb
```