### PR TITLE
[24.10] ramips/mt7621: mark EEE as broken in devicetree

### DIFF
--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -522,26 +522,36 @@
 					ethphy0: ethernet-phy@0 {
 						reg = <0>;
 						interrupts = <0>;
+						eee-broken-100tx;
+						eee-broken-1000t;
 					};
 
 					ethphy1: ethernet-phy@1 {
 						reg = <1>;
 						interrupts = <1>;
+						eee-broken-100tx;
+						eee-broken-1000t;
 					};
 
 					ethphy2: ethernet-phy@2 {
 						reg = <2>;
 						interrupts = <2>;
+						eee-broken-100tx;
+						eee-broken-1000t;
 					};
 
 					ethphy3: ethernet-phy@3 {
 						reg = <3>;
 						interrupts = <3>;
+						eee-broken-100tx;
+						eee-broken-1000t;
 					};
 
 					ethphy4: ethernet-phy@4 {
 						reg = <4>;
 						interrupts = <4>;
+						eee-broken-100tx;
+						eee-broken-1000t;
 					};
 				};
 


### PR DESCRIPTION
This PR backports to 24.10 a patch that fixes a release notes bug.

Primary PR: https://github.com/openwrt/openwrt/pull/18585 

Multiple users have reported a regression [1] in OpenWRT 24.10 with the ramips/mt7621 target, which has the MT7530 PHYs: the Ethernet link is periodically going down for a brief period of time:

        mt7530-mdio mdio-bus:1f lan1: Link is Down
        br-lan: port 1(lan1) entered disabled state
        mt7530-mdio mdio-bus:1f lan1: Link is Up - 1Gbps/Full - flow control rx/tx

The symptoms stop after disabling EEE and it was reported by Mediatek in 2021 that EEE is unstable for the MT7530 PHYs [2]:

> EEE of the 10-year-old MT7530 internal gephy has many IOT problems, so
> it is recommended to disable its EEE.

EEE is enabled by default for these devices in OpenWRT 24.10 whereas in the previous version (OpenWRT 23.05, Linux 5.15) it was not. It was determined that in Linux 6.6, the PHY driver tries to disable EEE in mtk_gephy_config_init() in drivers/net/phy/mediatek-ge.c, but this is later overridden by a subsequent execution of the genphy_c45_write_eee_adv() function, which enables every EEE mode supported.

The best way forward for now seems to be to mark EEE as broken directly in the devicetree, which affects the genphy_c45_write_eee_adv() function.

There are some devices, like GnuBee GB-PC2, that define additional PHYs, for example ethernet-phy@5 or ethernet-phy@7. As reported by Chester A. Unal, these are not MT7530 PHYs and they are not affected.

[1] https://github.com/openwrt/openwrt/issues/17351
[2] https://lore.kernel.org/all/0adde34f936a2dafca40b06b408d82afe0852327.camel@mediatek.com/

Tested-by: Darren Tucker

Signed-off-by: Mateusz Jończyk <mat.jonczyk@o2.pl>

Closes: https://github.com/openwrt/openwrt/issues/17351

Link: https://github.com/openwrt/openwrt/pull/18585

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

(cherry picked from commit b7fa9d92aef86453c28875b50ae27fbab3b500a4)

Signed-off-by: Mateusz Jończyk <mat.jonczyk@o2.pl>

Tested-by: Mateusz Jończyk <mat.jonczyk@o2.pl>