### PR TITLE
mediatek: fix bad lan count logic in mt7981b-xiaomi-mi-router-common.dtsi

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
@@ -102,17 +102,17 @@
 
 		port@1 {
 			reg = <1>;
-			label = "lan2";
+			label = "lan1";
 		};
 
 		port@2 {
 			reg = <2>;
-			label = "lan3";
+			label = "lan2";
 		};
 
 		port@3 {
 			reg = <3>;
-			label = "lan4";
+			label = "lan3";
 		};
 
 		port@6 {


### PR DESCRIPTION
It not common sense to start count port with lan2, default dts should start with lan1
For device that have number at the port and start with 2 , user should use seperate .dts config if need

there no port number, just some device some git user set lan1 to wan i not understand why, start with lan2 is not common sense. some device should use wan at lan3,4 not lan1.

mt7981b-xiaomi-mi-router-common.dtsi as it name "common" start with lan2 is bad design logic. lan2 not good for new device in the future. and i not understand which kind of logic start count lan port with number two. On none specific port number label should start count with lan1. For specific device that have port number start with number two should use specific *.dts per device.

It is not:
Port 2 = LAN2
Port 3 = LAN3
Port 4 = LAN4

The logic is:
Port 2 = LAN1
Port 3 = LAN2
Port 4 = LAN3

or for better indicate
Port 1 = LAN1
Port 2 = LAN2
Port 3 = LAN3
Port 4 = WAN