### PR TITLE
linux-firmware: allow cherry-picks at build time

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,13 +8,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
-PKG_VERSION:=20250613
-PKG_RELEASE:=1
+PKG_SOURCE_VERSION:=20250613
+PKG_RELEASE:=2
 
-PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://gitlab.com/kernel-firmware/linux-firmware.git
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=d40743337ca8bf9d2587e220ab30dec6a07b52cc5cb4a4ff8d92be14391a7fde
-
+PKG_MIRROR_HASH:=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 
 SCAN_DEPS = *.mk
@@ -24,10 +25,22 @@ include $(INCLUDE_DIR)/package.mk
 RSTRIP:=:
 STRIP:=:
 
+# optional build step override to add backport commits or revert commits
+define Build/Prepare
+	cd $(PKG_BUILD_DIR) && \
+		git init && \
+		git remote add origin $(PKG_SOURCE_URL) && \
+		git fetch --depth=100 origin && \
+		git checkout $(PKG_SOURCE_VERSION) && \
+		git cherry-pick 9096bad65cb92da2925fe9ad891cbd4961fa6cda && \
+		git cherry-pick a26e413e7481d12ab5a53f77e0cdde2d5be937d8 && \
+		echo "Cherry-pick completed"
+endef
+
 define Package/firmware-default
   SECTION:=firmware
   CATEGORY:=Firmware
-  URL:=http://git.kernel.org/cgit/linux/kernel/git/firmware/linux-firmware.git
+  URL:=https://gitlab.com/kernel-firmware/linux-firmware
   TITLE:=$(1)
   DEPENDS:=$(2)
   LICENSE_FILES:=$(3)


### PR DESCRIPTION
This commit add the flexibility of cherry-picking post-release commits such as backports and reverts at build time by switching to a git  source and by adding an optional build step override.

This change needed when post-release changes are made to binary files since quilt does not support binary diffs but git does.

Additionally, this commit incorporates two post-20250613 version back-ports to fix a breaking bug affecting users with some AMD GPUs.

References to the two commits we are cherry-picking:
1. https://gitlab.archlinux.org/archlinux/packaging/packages/linux-firmware/-/issues/12
2. https://gitlab.archlinux.org/archlinux/packaging/packages/linux-firmware/-/issues/16
