### PR TITLE
iproute2: don't check for setns()

### DIFF
--- a/package/network/utils/iproute2/patches/210-always-use-setns.patch
+++ b/package/network/utils/iproute2/patches/210-always-use-setns.patch
@@ -1,0 +1,16 @@
+--- a/configure
++++ b/configure
+@@ -151,13 +151,9 @@ int main(int argc, char **argv)
+ 	return 0;
+ }
+ EOF
+-    if $CC -I$INCLUDE -o $TMPDIR/setnstest $TMPDIR/setnstest.c >/dev/null 2>&1; then
+ 	echo "IP_CONFIG_SETNS:=y" >>$CONFIG
+ 	echo "yes"
+ 	echo "CFLAGS += -DHAVE_SETNS" >>$CONFIG
+-    else
+-	echo "no"
+-    fi
+     rm -f $TMPDIR/setnstest.c $TMPDIR/setnstest
+ }
+ 


### PR DESCRIPTION
"configure" script is unable to detect setns() presense with libc (musl or glibc), so we're unconditionally enable HAVE_SETNS.