### PR TITLE
libcrypt-compat: introduce package

### DIFF
--- a/package/libs/xcrypt/Makefile
+++ b/package/libs/xcrypt/Makefile
@@ -15,14 +15,31 @@ PKG_LICENSE_FILES:=COPYING.LIB
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
+PKG_CONFIG_DEPENDS:= \
+	CONFIG_USE_GLIBC \
+	CONFIG_PACKAGE_libcrypt-compat \
+	CONFIG_PACKAGE_libxcrypt
+
 include $(INCLUDE_DIR)/package.mk
 
-define Package/libxcrypt
+define Package/libxcrypt/Default
   SECTION:=libs
   CATEGORY:=Libraries
   URL:=https://github.com/besser82/libxcrypt
   TITLE:=Extended crypt library
+endef
+
+define Package/libxcrypt
+$(Package/libxcrypt/Default)
+  VARIANT:=regular
   BUILDONLY:=1
+endef
+
+define Package/libcrypt-compat
+$(Package/libxcrypt/Default)
+  VARIANT:=compat
+  TITLE+= - libc compatibility
+  DEPENDS:=@USE_GLIBC
 endef
 
 define Package/libxcrypt/description
@@ -35,21 +52,62 @@ define Package/libxcrypt/description
   crypt_gensalt_rn, and crypt_gensalt_ra.
 endef
 
+Package/libcrypt-compat/description=$(Package/libxcrypt/description)
+
 CONFIGURE_ARGS += \
+	--with-pic \
+	--enable-year2038 \
+	--disable-xcrypt-compat-files
+
+ifeq ($(BUILD_VARIANT),regular)
+  CONFIGURE_ARGS += \
 	--disable-shared \
 	--disable-failure-tokens \
-	--disable-xcrypt-compat-files \
 	--disable-obsolete-api \
-	--enable-hashes=solaris \
-	--with-pic
+	--enable-hashes=solaris
+endif
 
-define Build/InstallDev
+ifeq ($(BUILD_VARIANT),compat)
+  CONFIGURE_ARGS += \
+	--enable-obsolete-api=glibc \
+	--enable-hashes=glibc
+endif
+
+define Package/libxcrypt/install
+	true
+endef
+
+define Package/libcrypt-compat/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcrypt.so.* $(1)/usr/lib/
+endef
+
+define Build/libxcrypt/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include
 	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
 	$(INSTALL_DIR) $(1)/usr/lib/libxcrypt
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcrypt.{a,la} $(1)/usr/lib/libxcrypt
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/*crypt.pc $(1)/usr/lib/pkgconfig/
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libxcrypt.pc $(1)/usr/lib/pkgconfig/
 endef
 
+define Build/libcrypt-compat/InstallDev
+	$(INSTALL_DIR) $(1)/usr/include
+	$(CP) $(PKG_INSTALL_DIR)/usr/include/*.h $(1)/usr/include/
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libcrypt.{a,la,so*} $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
+	# libcrypt.pc is symlink to libxcrypt.pc
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libxcrypt.pc $(1)/usr/lib/pkgconfig/libcrypt.pc
+endef
+
+ifeq ($(BUILD_VARIANT),regular)
+  Build/InstallDev=$(Build/libxcrypt/InstallDev)
+endif
+
+ifeq ($(BUILD_VARIANT),compat)
+  Build/InstallDev=$(Build/libcrypt-compat/InstallDev)
+endif
+
+$(eval $(call BuildPackage,libcrypt-compat))
 $(eval $(call BuildPackage,libxcrypt))


### PR DESCRIPTION
glibc 2.39 has removed libcrypt completely.
solution: build libxcrypt with glibc compatibility.