### PR TITLE
kernel: mtdsplit_uimage: return 0 if not fatal

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_uimage.c
@@ -201,8 +201,8 @@ static int __mtdsplit_parse_uimage(struct mtd_info *master,
 		ret = mtd_find_rootfs_from(master, uimage_offset + uimage_size,
 					   master->size, &rootfs_offset, &type);
 		if (ret) {
-			pr_debug("no rootfs after uImage in \"%s\"\n",
-				 master->name);
+			pr_info("no rootfs after uImage in \"%s\"\n", master->name);
+			ret = 0;
 			goto err_free_buf;
 		}
 
@@ -215,8 +215,8 @@ static int __mtdsplit_parse_uimage(struct mtd_info *master,
 		/* check rootfs presence at offset 0 */
 		ret = mtd_check_rootfs_magic(master, 0, &type);
 		if (ret) {
-			pr_debug("no rootfs before uImage in \"%s\"\n",
-				 master->name);
+			pr_info("no rootfs before uImage in \"%s\"\n", master->name);
+			ret = 0;
 			goto err_free_buf;
 		}
 


### PR DESCRIPTION
Introduced with Linux 6.7, in commit: 5c2f7727d437 ("mtd: mtdpart: check for subpartitions parsing result"), when a parser returns an error, this will be passed up, and consequently, all parent mtd partitions get torn down.

Adjust the mtdsplit_uimage driver to only return an error if there is a critical problem in reading from the mtd device or allocating memory. Otherwise return 0 to indicate that no partitions were found. Also add logging to indicate what went wrong.

E.g. on Realtek devices that are booted for the first time through initramfs with OpenWrt never installed before boot log will show

[    0.975518] Creating 7 MTD partitions on "spi0.0":
[    0.981062] 0x000000000000-0x0000000e0000 : "u-boot"
[    1.041320] 0x0000000e0000-0x0000000f0000 : "u-boot-env"
[    1.060683] 0x0000000f0000-0x000000100000 : "u-boot-env2"
[    1.080992] 0x000000100000-0x000000200000 : "jffs2-cfg"
[    1.100988] 0x000000200000-0x000000300000 : "jffs2-log"
[    1.120599] 0x000000300000-0x000000fe0000 : "firmware"
[    1.157426] mtdsplit_uimage: no rootfs after uImage in "firmware"
[    1.176456] mtdsplit_uimage: no rootfs after uImage in "firmware"
[    1.200262] 0x000000fe0000-0x000001000000 : "log"

Similar issues were fixed before with commit ade045084bd3f8696 ("kernel: mtdsplit_minor: return 0 if not fatal") and c78765213ecbe830204 ("kernel: mtdsplit_uimage: return 0 if not fatal")