### PR TITLE
mediatek: 6.12: fix cci driver probe for mt7988d

### DIFF
--- a/target/linux/mediatek/patches-6.12/350-21-cpufreq-mediatek-Add-support-for-MT7988.patch
+++ b/target/linux/mediatek/patches-6.12/350-21-cpufreq-mediatek-Add-support-for-MT7988.patch
@@ -1,0 +1,45 @@
+From patchwork Fri Apr 19 16:59:07 2024
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Daniel Golle <daniel@makrotopia.org>
+X-Patchwork-Id: 13636668
+Return-Path: 
+ <linux-mediatek-bounces+linux-mediatek=archiver.kernel.org@lists.infradead.org>
+Date: Fri, 19 Apr 2024 17:59:07 +0100
+From: Daniel Golle <daniel@makrotopia.org>
+To: "Rafael J. Wysocki" <rafael@kernel.org>,
+	Viresh Kumar <viresh.kumar@linaro.org>,
+	Matthias Brugger <matthias.bgg@gmail.com>,
+	AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>,
+	linux-pm@vger.kernel.org, linux-kernel@vger.kernel.org,
+	linux-arm-kernel@lists.infradead.org,
+	linux-mediatek@lists.infradead.org
+Subject: [PATCH] cpufreq: mediatek: Add support for MT7988A
+Message-ID: 
+ <acf4fb446aacfbf6ce7b6e94bf3aad303e0ad4d1.1713545923.git.daniel@makrotopia.org>
+Content-Disposition: inline
+List-Id: <linux-mediatek.lists.infradead.org>
+
+From: Sam Shih <sam.shih@mediatek.com>
+
+This add cpufreq support for mediatek MT7988A SoC.
+
+The platform data of MT7988A is different from previous MediaTek SoCs,
+so we add a new compatible and platform data for it.
+
+Signed-off-by: Sam Shih <sam.shih@mediatek.com>
+---
+ drivers/cpufreq/mediatek-cpufreq.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+--- a/drivers/cpufreq/mediatek-cpufreq.c
++++ b/drivers/cpufreq/mediatek-cpufreq.c
+@@ -744,6 +744,7 @@ static const struct of_device_id mtk_cpu
+ 	{ .compatible = "mediatek,mt7622", .data = &mt7622_platform_data },
+ 	{ .compatible = "mediatek,mt7623", .data = &mt7623_platform_data },
+ 	{ .compatible = "mediatek,mt7988a", .data = &mt7988_platform_data },
++	{ .compatible = "mediatek,mt7988d", .data = &mt7988_platform_data },
+ 	{ .compatible = "mediatek,mt8167", .data = &mt8516_platform_data },
+ 	{ .compatible = "mediatek,mt817x", .data = &mt2701_platform_data },
+ 	{ .compatible = "mediatek,mt8173", .data = &mt2701_platform_data },


### PR DESCRIPTION
The patch of kernel 6.12 missing cpufreq part for mt7988d, causing the ccifreq driver probe to fail.
Add it to avoid mt7988d devices boot hang. ping @dangowrt 
```
root@OpenWrt-failsafe:/# dmesg | grep cci
[    1.767340] mtk-ccifreq cci: failed to add devfreq device: -517
[    2.935284] mtk-ccifreq cci: failed to add devfreq device: -517
[    3.215787] mtk-ccifreq cci: failed to add devfreq device: -517
[    3.224570] mtk-ccifreq cci: failed to add devfreq device: -517
[    3.475719] mtk-ccifreq cci: failed to add devfreq device: -517
[    3.492549] mtk-ccifreq cci: failed to add devfreq device: -517
[   13.924858] mtk-ccifreq cci: failed to add devfreq device: -517
[   13.930982] platform cci: deferred probe pending: mtk-ccifreq: devfreq_add_device: Unable to start governor for the device
```