### PR TITLE
realtek: rtl931x: add missing function reference for l2_hash_seed

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -569,14 +569,9 @@ static void rtl931x_traffic_disable(int source, int dest)
 	rtl_table_release(r);
 }
 
-static u64 rtl931x_l2_hash_seed(u64 mac, u32 vid)
+static u64 rtldsa_931x_l2_hash_seed(u64 mac, u32 vid)
 {
-	u64 v = vid;
-
-	v <<= 48;
-	v |= mac;
-
-	return v;
+	return (u64)vid << 48 | mac;
 }
 
 /* Calculate both the block 0 and the block 1 hash by applyingthe same hash
@@ -787,7 +782,7 @@ static u64 rtl931x_read_l2_entry_using_hash(u32 hash, u32 pos, struct rtl838x_l2
 	      ((u64)e->mac[4]) << 8 |
 	      ((u64)e->mac[5]);
 
-	seed = rtl931x_l2_hash_seed(mac, e->rvid);
+	seed = rtldsa_931x_l2_hash_seed(mac, e->rvid);
 	pr_debug("%s: mac %016llx, seed %016llx\n", __func__, mac, seed);
 
 	/* return vid with concatenated mac as unique id */
@@ -1682,6 +1677,7 @@ const struct rtl838x_reg rtl931x_reg = {
 	.set_vlan_egr_filter = rtl931x_set_egr_filter,
 	.set_distribution_algorithm = rtl931x_set_distribution_algorithm,
 	.l2_hash_key = rtl931x_l2_hash_key,
+	.l2_hash_seed = rtldsa_931x_l2_hash_seed,
 	.read_mcast_pmask = rtl931x_read_mcast_pmask,
 	.write_mcast_pmask = rtl931x_write_mcast_pmask,
 	.pie_init = rtl931x_pie_init,


### PR DESCRIPTION
Add missing function reference for the l2_hash_seed call in rtl931x_reg in the rtl83xx DSA driver part.

The missing reference causes a hard crash after a short time (on MS510TXM) because the driver assumes the reference always exists.

```
[  111.785559] CPU 0 Unable to handle kernel paging request at virtual address 00000000, epc == 00000000, ra == 805469a0
[  111.800991] Oops[#1]:
[  111.801026] CPU: 0 PID: 11 Comm: kworker/u8:0 Tainted: G           O       6.12.33 #0
[  111.801046] Workqueue: dsa_ordered dsa_slave_switchdev_event_work
...
[  111.880600] epc   : 00000000 0x0
[  111.884219] ra    : 805469a0 rtl83xx_port_fdb_add+0x7c/0x204
[  111.890570] Status: 11000403 KERNEL EXL IE
[  111.895263] Cause : 50800008 (ExcCode 02)
[  111.899731] BadVA : 00000000
[  111.902946] PrId  : 0001a120 (MIPS interAptiv (multi))
[  111.956086] Process kworker/u8:0 (pid: 11, threadinfo=0b107c25, task=265aeb31, tls=00000000)
...
[  112.015167] Call Trace:
[  112.019549] [<80170b04>] load_balance+0x494/0x708
[  112.025022] [<807bb368>] dsa_port_do_fdb_add+0x24c/0x340
[  112.031048] [<807bc868>] dsa_switch_event+0xd44/0x13cc
[  112.036845] [<8015867c>] raw_notifier_call_chain+0x48/0x88
[  112.043031] [<807bcf3c>] dsa_tree_notify+0x10/0x3c
[  112.048395] [<807b2a64>] dsa_port_bridge_host_fdb_add+0x15c/0x190
[  112.055459] [<807b4e40>] dsa_slave_switchdev_event_work+0x164/0x1cc
...
```

-----
This issue came up while working on RTL9313-based MS510TXM.