### PR TITLE
generic: net: phy: psb6970: fix missing-prototypes warnings

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/psb6970.c
+++ b/target/linux/generic/files/drivers/net/phy/psb6970.c
@@ -423,7 +423,7 @@ static struct phy_driver psb6970_driver = {
 	.read_status = &psb6970_read_status,
 };
 
-int __init psb6970_init(void)
+static int __init psb6970_init(void)
 {
 	phy_register_fixup_for_id(PHY_ANY_ID, psb6970_fixup);
 	return phy_driver_register(&psb6970_driver, THIS_MODULE);
@@ -431,7 +431,7 @@ int __init psb6970_init(void)
 
 module_init(psb6970_init);
 
-void __exit psb6970_exit(void)
+static void __exit psb6970_exit(void)
 {
 	phy_driver_unregister(&psb6970_driver);
 }


### PR DESCRIPTION
Fix the following build warnings on 6.12 kernel:
```
drivers/net/phy/psb6970.c:426:12: error: no previous prototype for 'psb6970_init' [-Werror=missing-prototypes]
  426 | int __init psb6970_init(void)
      |            ^~~~~~~~~~~~
drivers/net/phy/psb6970.c:434:13: error: no previous prototype for 'psb6970_exit' [-Werror=missing-prototypes]
  434 | void __exit psb6970_exit(void)
      |             ^~~~~~~~~~~~
```