### PR TITLE
uboot-envtools: set nonshared flag correctly

### DIFF
--- a/package/boot/uboot-tools/Makefile
+++ b/package/boot/uboot-tools/Makefile
@@ -9,6 +9,7 @@ PKG_SOURCE_URL:= \
 	https://ftp.denx.de/pub/u-boot \
 	https://mirror.cyberbits.eu/u-boot \
 	ftp://ftp.denx.de/pub/u-boot
+PKG_URL:=http://www.denx.de/wiki/U-Boot
 PKG_HASH:=cdef7d507c93f1bbd9f015ea9bc21fa074268481405501945abc6f854d5b686f
 PKG_SOURCE_SUBDIR:=$(PKG_DISTNAME)-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_DISTNAME)-$(PKG_VERSION)
@@ -19,6 +20,7 @@ PKG_LICENSE:=GPL-2.0 GPL-2.0+
 PKG_LICENSE_FILES:=Licenses/README
 
 PKG_BUILD_PARALLEL:=1
+#PKG_FLAGS:=nonshared # Use PKGFLAGS instead of PKG_FLAGS for per-binary flags
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -27,7 +29,6 @@ define Package/dumpimage
 	CATEGORY:=Utilities
 	SUBMENU:=Boot Loaders
 	TITLE:=dumpimage lists and extracts data from U-Boot images.
-	URL:=http://www.denx.de/wiki/U-Boot
 endef
 
 define Package/dumpimage/description
@@ -42,7 +43,6 @@ define Package/fit-check-sign
 	CATEGORY:=Utilities
 	SUBMENU:=Boot Loaders
 	TITLE:=verify uImage.FIT
-	URL:=http://www.denx.de/wiki/U-Boot
 endef
 
 define Package/fit-check-sign/description
@@ -53,9 +53,8 @@ define Package/uboot-envtools
 	SECTION:=utils
 	CATEGORY:=Utilities
 	SUBMENU:=Boot Loaders
-	PKG_FLAGS+=nonshared
+	PKGFLAGS+=nonshared
 	TITLE:=read/modify U-Boot bootloader environment
-	URL:=http://www.denx.de/wiki/U-Boot
 endef
 
 define Package/uboot-envtools/description


### PR DESCRIPTION
Currently, uboot-envtools is being built for a (shared) instruction set (phase2 in buildbots) instead of target-specific (phase1 in builbots). So the package does not contain the uci-defaults file specific for each target_subtarget. (Only the fortunate target with coincidentally the same instruction set as the SDK chosen by the buildbot will have the uci-defaults file.)

This commit sets the nonshared flag correctly in the Makefile so that uboot-envtools is built for the target-specific.

Fixes: #19040
Fixes: 46e376c ("uboot-tools: migrate uboot-envtools to uboot-tools")
