### PR TITLE
hostapd: fix Kirkwood EA3500/4500 5GHz Wi-Fi

### DIFF
--- a/package/network/services/hostapd/patches/750-include-DS-parameter-set-element-in-5-GHz.patch
+++ b/package/network/services/hostapd/patches/750-include-DS-parameter-set-element-in-5-GHz.patch
@@ -1,0 +1,28 @@
+From: Antony Kolitsos <zeusomighty@hotmail.com>
+Date: Sat, 28 Jun 2025 9:12:05 -0800
+Subject: [PATCH] Include DS Parameters Set element in 5 GHz
+
+It's possible that the mlw8k driver or firmware is unexpectedly reliant on the presence of the DS Parameters Set element even in 5 GHz. This would be a non-standard behavior, as the IEEE 802.11 standard doesn't typically require it for 5 GHz.
+
+Fixes: https://github.com/openwrt/openwrt/issues/19088
+Signed-off-by: Antony Kolitsos <zeusomighty@hotmail.com>
+---
+ src/ap/beacon.c | 2 +++++
+ 1 file changed, 2 insertions(+)
+ 
+--- a/src/ap/beacon.c
++++ b/src/ap/beacon.c
+@@ -88,11 +88,13 @@ static u8 ieee802_11_erp_info(struct hos
+ 
+ static u8 * hostapd_eid_ds_params(struct hostapd_data *hapd, u8 *eid)
+ {
++#if defined(CONFIG_IEEE80211AC) || defined(CONFIG_IEEE80211AX) || defined(CONFIG_IEEE80211BE)
+ 	enum hostapd_hw_mode hw_mode = hapd->iconf->hw_mode;
+ 
+ 	if (hw_mode != HOSTAPD_MODE_IEEE80211G &&
+ 	    hw_mode != HOSTAPD_MODE_IEEE80211B)
+ 		return eid;
++#endif /* CONFIG_IEEE80211AC || CONFIG_IEEE80211AX || CONFIG_IEEE80211BE */
+ 
+ 	*eid++ = WLAN_EID_DS_PARAMS;
+ 	*eid++ = 1;

--- a/package/network/services/hostapd/patches/762-AP-don-t-ignore-probe-requests-with-invalid-DSSS-par.patch
+++ b/package/network/services/hostapd/patches/762-AP-don-t-ignore-probe-requests-with-invalid-DSSS-par.patch
@@ -28,7 +28,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 
 --- a/src/ap/beacon.c
 +++ b/src/ap/beacon.c
-@@ -1498,7 +1498,7 @@ void handle_probe_req(struct hostapd_dat
+@@ -1500,7 +1500,7 @@ void handle_probe_req(struct hostapd_dat
  	 * is less likely to see them (Probe Request frame sent on a
  	 * neighboring, but partially overlapping, channel).
  	 */


### PR DESCRIPTION
Fix kernel warning on Kirkwood EA3500/4500 devices introduced by hostapd commit Add DSSS Parameter Set element only for 2.4 GHz [1] resulting in 5GHz failing.

**fixes:**
kernel WARNING: CPU: 0 PID: 0 at backports-6.12.6/net/mac80211/rx.c:5361
[ 117.144709] __warn from warn_slowpath_fmt+0x4c/0x84
[ 117.149722] warn_slowpath_fmt from ieee80211_rx_list+0x664/0xc64 [mac80211]
[ 117.157216] ieee80211_rx_list [mac80211] from ieee80211_rx_napi+0x20/0xa4 [mac80211]
[ 117.165811] ieee80211_rx_napi [mac80211] from ieee80211_handle_queued_frames+0xc8/0xd4 [mac80211]

It's possible that the mlw8k driver or firmware is  unexpectedly reliant on the presence of the DS Parameters Set element even in 5 GHz. This would be a non-standard behavior, as the IEEE 802.11 standard doesn't typically require it for 5 GHz.

This patch continues to pass the DSSS param IE to the 5GHz (IEEE 802.11a) modes. Not ideal.

[1]https://w1.fi/cgit/hostap/commit/src/ap/beacon.c?id=8056b79ff1e5d746a82c2ea12011e69e99c11d3d

Resolves: https://github.com/openwrt/openwrt/issues/19088

Tested on: kirkwood/ea3500, ramips/mt7621

Unknown: Impact of this change on other devices.

**Suggestions needed:**

1. patch naming
2. should the patch be included in a similar patch: https://github.com/openwrt/openwrt/blob/main/package/network/services/hostapd/patches/762-AP-don-t-ignore-probe-requests-with-invalid-DSSS-par.patch
3. is there a better approach to minimizing potential impact on non-legacy devices? ifdef?

