### PR TITLE
mediatek: add support for Mercusys MR85X

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -88,6 +88,7 @@ jdcloud,re-cp-03)
 	;;
 buffalo,wsr-6000ax8|\
 mercusys,mr80x-v3|\
+mercusys,mr85x|\
 mercusys,mr90x-v1|\
 routerich,ax3000|\
 routerich,ax3000-v1|\

--- a/target/linux/mediatek/dts/mt7981b-mercusys-mr85x.dts
+++ b/target/linux/mediatek/dts/mt7981b-mercusys-mr85x.dts
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: GPL-2.0
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7981b.dtsi"
+/ {
+	model = "MERCUSYS MR85X";
+	compatible = "mercusys,mr85x", "mediatek,mt7981";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_amber;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_amber: led-0 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <0>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	rtkgsw@0 {
+		compatible = "mediatek,rtk-gsw";
+		mediatek,ethsys = <&ethsys>;
+		mediatek,mdio = <&mdio_bus>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		status = "okay";
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy15>;
+	};
+};
+
+
+&mdio_bus {
+	phy15: phy@f {
+		compatible = "ethernet-phy-id03a2.a411";
+		reg = <15>;
+		reset-gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <200000>;
+		reset-post-delay-us = <1000000>;
+		phy-mode = "2500base-x";
+		full-duplex;
+		pause;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x00000 0x0200000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "u-boot-env";
+				reg = <0x0200000 0x0100000>;
+			};
+
+			partition@300000 {
+				label = "ubi0";
+				reg = <0x300000 0x3200000>;
+			};
+
+			partition@3500000 {
+				label = "ubi1";
+				reg = <0x3500000 0x3200000>;
+				read-only;
+			};
+
+			partition@6700000 {
+				label = "userconfig";
+				reg = <0x6700000 0x800000>;
+				read-only;
+			};
+
+			partition@6f00000 {
+				label = "tp_data";
+				reg = <0x6f00000 0x800000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -108,6 +108,12 @@ mercusys,mr80x-v3)
 	ucidef_set_led_netdev "lan3" "lan-3" "green:lan-3" "lan3" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
 	;;
+mercusys,mr85x)
+	ucidef_set_led_switch "lan0" "lan-0" "green:lan-0" "switch0" "0x01"
+	ucidef_set_led_switch "lan1" "lan-1" "green:lan-1" "switch0" "0x02"
+	ucidef_set_led_switch "lan2" "lan-2" "green:lan-2" "switch0" "0x04"
+	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
+	;;
 mercusys,mr90x-v1|\
 mercusys,mr90x-v1-ubi)
 	ucidef_set_led_netdev "lan-0" "lan-0" "green:lan-0" "lan0" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -149,6 +149,10 @@ mediatek_setup_interfaces()
 	mediatek,mt7988a-rfb)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 eth2" eth1
 		;;
+	mercusys,mr85x)
+		ucidef_add_switch "switch0" "0:lan0" "1:lan1" "2:lan2" "6@eth0"
+		ucidef_set_interfaces_lan_wan "eth0.1 eth0.2 eth0.3" eth1
+		;;
 	mercusys,mr90x-v1|\
 	mercusys,mr90x-v1-ubi)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2" eth1
@@ -216,7 +220,8 @@ mediatek_setup_macs()
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac=$wan_mac
 		;;
-	mercusys,mr80x-v3)
+	mercusys,mr80x-v3|\
+	mercusys,mr85x)
 		mac_dirty=$(cat "/tmp/tp_data/default-mac" | sed -n 's/^'"MAC"'://p')
 		label_mac=$(macaddr_canonicalize "$mac_dirty")
 		lan_mac=$label_mac

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -9,7 +9,8 @@ board=$(board_name)
 case "$FIRMWARE" in
 "mediatek/mt7981_eeprom_mt7976_dbdc.bin")
 	case "$board" in
-	mercusys,mr80x-v3)
+	mercusys,mr80x-v3|\
+	mercusys,mr85x)
 		ln -sf /tmp/tp_data/MT7981_EEPROM.bin \
 			/lib/firmware/$FIRMWARE
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -150,7 +150,8 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary rf-eeprom 0x4)" > /sys${DEVPATH}/macaddress
 		;;
-	mercusys,mr80x-v3)
+	mercusys,mr80x-v3|\
+	mercusys,mr85x)
 		mac_dirty=$(cat "/tmp/tp_data/default-mac" | sed -n 's/^'"MAC"'://p')
 		label_mac=$(macaddr_canonicalize "$mac_dirty")
 		[ "$PHYNBR" = "0" ] && macaddr_add $label_mac -1 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -14,6 +14,7 @@ mount_ubi_part() {
 preinit_mount_cfg_part() {
 	case $(board_name) in
 	mercusys,mr80x-v3|\
+	mercusys,mr85x|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
 	tplink,be450|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -183,6 +183,7 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	mercusys,mr80x-v3|\
+	mercusys,mr85x|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
 	tplink,be450|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1927,6 +1927,19 @@ define Device/mercusys_mr80x-v3
 endef
 TARGET_DEVICES += mercusys_mr80x-v3
 
+define Device/mercusys_mr85x
+  DEVICE_VENDOR := MERCUSYS
+  DEVICE_MODEL := MR85X
+  DEVICE_DTS := mt7981b-mercusys-mr85x
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-airoha-en8811h swconfig kmod-switch-rtl8367s
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += mercusys_mr85x
+
 define Device/mercusys_mr90x-v1
   DEVICE_VENDOR := MERCUSYS
   DEVICE_MODEL := MR90X v1

--- a/target/linux/mediatek/modules.mk
+++ b/target/linux/mediatek/modules.mk
@@ -37,3 +37,17 @@ define KernelPackage/iio-mt6577-auxadc
   $(call AddDepends/iio)
 endef
 $(eval $(call KernelPackage,iio-mt6577-auxadc))
+
+define KernelPackage/switch-rtl8367s
+  SUBMENU:=Network Devices
+  TITLE:=Realtek RTL8367S switch support
+  KCONFIG:= \
+	CONFIG_RTL8367S_GSW \
+	CONFIG_SWCONFIG=y
+  DEPENDS:=@TARGET_mediatek +kmod-swconfig
+  FILES:= \
+	$(LINUX_DIR)/drivers/net/phy/rtk/rtl8367s_gsw.ko
+  AUTOLOAD:=$(call AutoProbe,rtl8367s_gsw,1)
+endef
+
+$(eval $(call KernelPackage,switch-rtl8367s))


### PR DESCRIPTION
This commit adds support for Mercusys MR85X router.

Device specification:
```
 - SoC: Mediatek MT7981b, Cortex-A53, 64-bit
 - RAM: 512MB
 - Flash: SPI NAND GigaDevice GD5F1GQ5UEYIGY (128 MB)
 - Ethernet: Realtek rtl8367s + 2.5Gbe Airoha en8811h
 - Ethernet: 1x2.5Gbe (WAN 2.5Gbps), 3xGbe (LAN 1Gbps, port0, port1, port2)
 - Wireless: 2.4GHz (802.11 b/g/n/ax)
 - Wireless: 5GHz (802.11 a/n/ac/ax)
 - LEDs: 1 amber and 1 green status LEDs, 4 green gpio-controlled LEDs
   on ethernet ports
 - Buttons: 2 (reset,wps)
 - Bootloader: Main U-Boot - U-Boot 2022.07-rc3. Additionally, both UBI
   slots contain "seconduboot" (also U-Boot 2022.07-rc3)
```

Installation (UART):
```
 - Place OpenWrt initramfs-kernel image on tftp server with IP 192.168.1.2
 - Attach UART, switch on the router and interrupt the boot process by
   pressing 'Ctrl-C'.
 - Set the uboot environment for startup.
   setenv tp_boot_idx 0; saveenv
   If the bootarg is set to boot from ubi1, also change it to ubi0.
 - Load and run OpenWrt initramfs image.
   setenv serverip 192.168.1.2; setenv ipaddr 192.168.1.1; tftpboot initramfs-kernel.bin; bootm
 - Browse IP 192.168.1.1, upload the 'sysupgrade' image and do upgrade.
```

Recovery:
```
 - Press Reset button and power on the router.
 - Navigate to U-Boot recovery web server (http://192.168.1.1/) and
   upload the OEM firmware.
```

Stock layout:
```
0x000000000000-0x000000200000 : "boot"
0x000000200000-0x000000300000 : "u-boot-env"
0x000000300000-0x000003500000 : "ubi0"
0x000003500000-0x000006700000 : "ubi1"
0x000006700000-0x000006f00000 : "userconfig"
0x000006f00000-0x000007300000 : "tp_data"
```

ubi0/ubi1 format:
U-Boot at boot checks that all volumes are in place:
```
+-------------------------------+
| Volume Name: uboot   Vol ID: 0|
| Volume Name: kernel  Vol ID: 1|
| Volume Name: rootfs  Vol ID: 2|
+-------------------------------+
```

MAC addresses:
```
+---------+-------------------+-----------+
|         | MAC               | Algorithm |
+---------+-------------------+-----------+
| label   | 00:FF:xx:xx:xx:EE | label     |
| WAN     | 00:FF:xx:xx:xx:EF | label+1   |
| LAN     | 00:FF:xx:xx:xx:EE | label     |
| WLAN 2g | 00:FF:xx:xx:xx:ED | label-1   |
| WLAN 5g | 00:FF:xx:xx:xx:EC | label-2   |
+---------+-------------------+-----------+
```
label MAC address was found in UBI partition "tp_data", file "default-mac".
OEM wireless eeprom is also there, file "MT7981_EEPROM.bin".
