### PR TITLE
kernel: enable memory mapped TPM interface on armsr

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -968,7 +968,7 @@ $(eval $(call KernelPackage,tpm))
 define KernelPackage/tpm-tis
   SUBMENU:=$(OTHER_MENU)
   TITLE:=TPM TIS 1.2 Interface / TPM 2.0 FIFO Interface
-	DEPENDS:= @TARGET_x86 +kmod-tpm
+	DEPENDS:= @(TARGET_x86||TARGET_armsr) +kmod-tpm
   KCONFIG:= CONFIG_TCG_TIS
   FILES:= \
 	$(LINUX_DIR)/drivers/char/tpm/tpm_tis.ko \


### PR DESCRIPTION
The memory mapped TPM interface (TIS) can be used for emulated or virtualized TPM instances with QEMU and a simulation package like swtpm. There is already a kmod for this (`kmod-tpm-tis`), but it is only visible in the build system for x86.

On QEMU the device will appear in the device tree with a "tcg,tpm-tis-mmio" compatible.

For example:
```
qemu-system-aarch64 -machine virt -cpu max \
    -bios u-boot.bin \
    -nographic \
    .... \
    -hda openwrt-armsr-armv8-combined-efi.img \
    -chardev socket,id=chrtpm,path=/tmp/mytpm/swtpm-sock \
    -tpmdev emulator,id=tpm0,chardev=chrtpm \
    -device tpm-tis-device,tpmdev=tpm0
```

```
root@OpenWrt:~# dmesg | grep tpm
[    0.877378] tpm_tis c000000.tpm_tis: 2.0 TPM (device-id 0x1, rev-id 1)
```

I have only tested that the driver loads and that data can be read through sysfs (e.g `/sys/class/tpm/tpm0/pcr-sha1/*`). A TPM2 stack like tpm2-tss is needed to access more functionality.