### PR TITLE
imx venice

### DIFF
--- a/target/linux/imx/cortexa53/target.mk
+++ b/target/linux/imx/cortexa53/target.mk
@@ -2,6 +2,7 @@ ARCH:=aarch64
 BOARDNAME:=NXP i.MX with Cortex-A53 (ARM64)
 CPU_TYPE:=cortex-a53
 KERNELNAME:=Image dtbs
+FEATURES+=dt-overlay
 
 define Target/Description
 	Build firmware images for NXP i.MX (Cortex-A53) based boards.

--- a/target/linux/imx/image/bootscript-gateworks_venice
+++ b/target/linux/imx/image/bootscript-gateworks_venice
@@ -22,7 +22,7 @@ echo "Gateworks Venice OpenWrt Boot script v1.0"
 #    partition, therefore we add 1 to the current partition
 setexpr rootpart ${distro_bootpart} + 1 # root on 'next' partition
 part uuid ${devtype} ${devnum}:${rootpart} uuid
-setenv bootargs ${bootargs} console=${console} root=PARTUUID=${uuid} rootfstype=squashfs,ext4,f2fs rootwait
+setenv bootargs ${bootargs} console=${console} root=PARTUUID=${uuid} rootfstype=squashfs,ext4,f2fs rootwait pci=noaer
 
 # load dtb (we try fdt_file and then fdt_file{1,2,3,4,5})
 echo "loading DTB..."

--- a/target/linux/imx/image/bootscript-gateworks_venice
+++ b/target/linux/imx/image/bootscript-gateworks_venice
@@ -29,7 +29,7 @@ echo "loading DTB..."
 setenv fdt_addr
 setenv fdt_list $fdt_file $fdt_file1 $fdt_file2 $fdt_file3 $fdt_file4 $fdt_file5
 setenv load_fdt 'echo Loading $fdt...; load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${prefix}${fdt} && setenv fdt_addr ${fdt_addr_r}'
-setenv apply_overlays 'fdt addr $fdt_addr_r && fdt resize && for fdt in "$fdt_overlays"; do load ${devtype} ${devnum}:${distro_bootpart} $loadaddr $prefix/$fdt && fdt apply $loadaddr && echo applied $prefix/$fdt; done'
+setenv apply_overlays 'fdt addr $fdt_addr_r && for fdt in "$fdt_overlays"; do load ${devtype} ${devnum}:${distro_bootpart} $loadaddr $prefix/$fdt && fdt resize $filesize && fdt apply $loadaddr && echo applied $prefix/$fdt; done'
 for fdt in ${fdt_list}; do if test -e ${devtype} ${devnum}:${distro_bootpart} ${prefix}${fdt}; then run load_fdt; fi; done
 if test -z "$fdt_addr"; then echo "Warning: Using bootloader DTB"; setenv fdt_addr $fdtcontroladdr; fi
 if test -n "$fdt_overlays"; then echo "Applying overlays"; run apply_overlays; fi

--- a/target/linux/imx/image/cortexa53.mk
+++ b/target/linux/imx/image/cortexa53.mk
@@ -8,6 +8,7 @@ define Build/boot-img-ext4
 	rm -fR $@.boot
 	mkdir -p $@.boot
 	$(foreach dts,$(DEVICE_DTS), $(CP) $(KDIR)/image-$(dts).dtb $@.boot/$(dts).dtb;)
+	$(foreach dtbo,$(DEVICE_DTS_OVERLAY), $(CP) $(KDIR)/image-$(dtbo).dtbo $@.boot/$(dtbo).dtbo;)
 	$(CP) $(IMAGE_KERNEL) $@.boot/$(KERNEL_NAME)
 	-$(CP) $@-boot.scr $@.boot/boot.scr
 	make_ext4fs -J -L kernel -l $(CONFIG_TARGET_KERNEL_PARTSIZE)M \
@@ -64,6 +65,7 @@ define Device/gateworks_venice
   BOOT_SCRIPT := gateworks_venice
   PARTITION_OFFSET := 16M
   DEVICE_DTS := $(basename $(notdir $(wildcard $(DTS_DIR)/freescale/imx8m*-venice*.dts)))
+  DEVICE_DTS_OVERLAY := $(basename $(notdir $(wildcard $(DTS_DIR)/freescale/imx8m*-venice*.dtso)))
   DEVICE_PACKAGES := \
 	kmod-hwmon-gsc kmod-rtc-ds1672 kmod-eeprom-at24 \
 	kmod-gpio-button-hotplug kmod-leds-gpio kmod-pps-gpio \

--- a/target/linux/imx/patches-6.12/505-6.13-arm64-dts-imx8mm-venice-gw73xx-remove-compatible-in-overlay-files.patch
+++ b/target/linux/imx/patches-6.12/505-6.13-arm64-dts-imx8mm-venice-gw73xx-remove-compatible-in-overlay-files.patch
@@ -1,0 +1,56 @@
+From d3fdc7ae2ca9cb93d634e84a2b90ebf340d6e622 Mon Sep 17 00:00:00 2001
+From: Frank Li <Frank.Li@nxp.com>
+Date: Fri, 18 Oct 2024 14:28:23 -0400
+Subject: [PATCH] arm64: dts: imx8mm-venice-gw73xx: remove compatible in
+ overlay file
+
+Remove compatible string in overlay file to fix below warning:
+'gw,imx8mm-gw73xx-0x' is not one of ['fsl,ls1043a-rdb', 'fsl,ls1043a-qds']
+
+Signed-off-by: Frank Li <Frank.Li@nxp.com>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ .../boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs232-rts.dtso | 4 ----
+ .../boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs422.dtso     | 4 ----
+ .../boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs485.dtso     | 4 ----
+ 3 files changed, 12 deletions(-)
+
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs232-rts.dtso
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs232-rts.dtso
+@@ -15,10 +15,6 @@
+ /dts-v1/;
+ /plugin/;
+ 
+-&{/} {
+-	compatible = "gw,imx8mm-gw73xx-0x";
+-};
+-
+ &gpio4 {
+ 	rs485-en-hog {
+ 		gpio-hog;
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs422.dtso
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs422.dtso
+@@ -18,10 +18,6 @@
+ /dts-v1/;
+ /plugin/;
+ 
+-&{/} {
+-	compatible = "gw,imx8mm-gw73xx-0x";
+-};
+-
+ &gpio4 {
+ 	rs485-en-hog {
+ 		gpio-hog;
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs485.dtso
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs485.dtso
+@@ -18,10 +18,6 @@
+ /dts-v1/;
+ /plugin/;
+ 
+-&{/} {
+-	compatible = "gw,imx8mm-gw73xx-0x";
+-};
+-
+ &gpio4 {
+ 	rs485-en-hog {
+ 		gpio-hog;

--- a/target/linux/imx/patches-6.12/506-6.16-PCI-imx6-Skip-link-up-workaround-for-newer-platforms.patch
+++ b/target/linux/imx/patches-6.12/506-6.16-PCI-imx6-Skip-link-up-workaround-for-newer-platforms.patch
@@ -1,0 +1,101 @@
+From 42042e33451e380f45ad13ae725bf28ed6f0110d Mon Sep 17 00:00:00 2001
+From: Richard Zhu <hongxing.zhu@nxp.com>
+Date: Wed, 16 Apr 2025 16:13:08 +0800
+Subject: [PATCH] PCI: imx6: Skip link up workaround for newer platforms
+
+The current link setup procedure has one workaround to detect the devices
+behind PCIe switches on some i.MX6 platforms. But this workaround is not
+needed on recent i.MX7 platforms. So skip the workaround for platforms that
+do not set the flag and start LTSSM directly.
+
+Also, change the flag name from IMX_PCIE_FLAG_IMX_SPEED_CHANGE to
+IMX_PCIE_FLAG_SPEED_CHANGE_WORKAROUND to match the usecase.
+
+Signed-off-by: Richard Zhu <hongxing.zhu@nxp.com>
+[mani: subject and description rewording]
+Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+Reviewed-by: Frank Li <Frank.Li@nxp.com>
+Reviewed-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+Link: https://patch.msgid.link/20250416081314.3929794-2-hongxing.zhu@nxp.com
+---
+ drivers/pci/controller/dwc/pci-imx6.c | 34 +++++++++++----------------
+ 1 file changed, 14 insertions(+), 20 deletions(-)
+
+--- a/drivers/pci/controller/dwc/pci-imx6.c
++++ b/drivers/pci/controller/dwc/pci-imx6.c
+@@ -74,7 +74,7 @@ enum imx_pcie_variants {
+ };
+ 
+ #define IMX_PCIE_FLAG_IMX_PHY			BIT(0)
+-#define IMX_PCIE_FLAG_IMX_SPEED_CHANGE		BIT(1)
++#define IMX_PCIE_FLAG_SPEED_CHANGE_WORKAROUND	BIT(1)
+ #define IMX_PCIE_FLAG_SUPPORTS_SUSPEND		BIT(2)
+ #define IMX_PCIE_FLAG_HAS_PHYDRV		BIT(3)
+ #define IMX_PCIE_FLAG_HAS_APP_RESET		BIT(4)
+@@ -847,6 +847,12 @@ static int imx_pcie_start_link(struct dw
+ 	u32 tmp;
+ 	int ret;
+ 
++	if (!(imx_pcie->drvdata->flags &
++	    IMX_PCIE_FLAG_SPEED_CHANGE_WORKAROUND)) {
++		imx_pcie_ltssm_enable(dev);
++		return 0;
++	}
++
+ 	/*
+ 	 * Force Gen1 operation when starting the link.  In case the link is
+ 	 * started in Gen2 mode, there is a possibility the devices on the
+@@ -883,22 +889,10 @@ static int imx_pcie_start_link(struct dw
+ 		dw_pcie_writel_dbi(pci, PCIE_LINK_WIDTH_SPEED_CONTROL, tmp);
+ 		dw_pcie_dbi_ro_wr_dis(pci);
+ 
+-		if (imx_pcie->drvdata->flags &
+-		    IMX_PCIE_FLAG_IMX_SPEED_CHANGE) {
+-			/*
+-			 * On i.MX7, DIRECT_SPEED_CHANGE behaves differently
+-			 * from i.MX6 family when no link speed transition
+-			 * occurs and we go Gen1 -> yep, Gen1. The difference
+-			 * is that, in such case, it will not be cleared by HW
+-			 * which will cause the following code to report false
+-			 * failure.
+-			 */
+-
+-			ret = imx_pcie_wait_for_speed_change(imx_pcie);
+-			if (ret) {
+-				dev_err(dev, "Failed to bring link up!\n");
+-				goto err_reset_phy;
+-			}
++		ret = imx_pcie_wait_for_speed_change(imx_pcie);
++		if (ret) {
++			dev_err(dev, "Failed to bring link up!\n");
++			goto err_reset_phy;
+ 		}
+ 
+ 		/* Make sure link training is finished as well! */
+@@ -1520,7 +1514,7 @@ static const struct imx_pcie_drvdata drv
+ 	[IMX6Q] = {
+ 		.variant = IMX6Q,
+ 		.flags = IMX_PCIE_FLAG_IMX_PHY |
+-			 IMX_PCIE_FLAG_IMX_SPEED_CHANGE |
++			 IMX_PCIE_FLAG_SPEED_CHANGE_WORKAROUND |
+ 			 IMX_PCIE_FLAG_BROKEN_SUSPEND |
+ 			 IMX_PCIE_FLAG_SUPPORTS_SUSPEND,
+ 		.dbi_length = 0x200,
+@@ -1538,7 +1532,7 @@ static const struct imx_pcie_drvdata drv
+ 	[IMX6SX] = {
+ 		.variant = IMX6SX,
+ 		.flags = IMX_PCIE_FLAG_IMX_PHY |
+-			 IMX_PCIE_FLAG_IMX_SPEED_CHANGE |
++			 IMX_PCIE_FLAG_SPEED_CHANGE_WORKAROUND |
+ 			 IMX_PCIE_FLAG_SUPPORTS_SUSPEND,
+ 		.gpr = "fsl,imx6q-iomuxc-gpr",
+ 		.clk_names = imx6sx_clks,
+@@ -1554,7 +1548,7 @@ static const struct imx_pcie_drvdata drv
+ 	[IMX6QP] = {
+ 		.variant = IMX6QP,
+ 		.flags = IMX_PCIE_FLAG_IMX_PHY |
+-			 IMX_PCIE_FLAG_IMX_SPEED_CHANGE |
++			 IMX_PCIE_FLAG_SPEED_CHANGE_WORKAROUND |
+ 			 IMX_PCIE_FLAG_SUPPORTS_SUSPEND,
+ 		.dbi_length = 0x200,
+ 		.gpr = "fsl,imx6q-iomuxc-gpr",

--- a/target/linux/imx/patches-6.12/506-pending-PCI-imx6-Remove-apps_reset-toggle-in-_core_reset-function.patch
+++ b/target/linux/imx/patches-6.12/506-pending-PCI-imx6-Remove-apps_reset-toggle-in-_core_reset-function.patch
@@ -1,0 +1,52 @@
+From d8588b5b9fddffd51962c13db7d00ae6f2ac945b Mon Sep 17 00:00:00 2001
+From: Tim Harvey <tharvey@gateworks.com>
+Date: Thu, 19 Jun 2025 16:04:53 -0700
+Subject: [PATCH] PCI: imx6: Remove apps_reset toggle in _core_reset functions
+
+apps_reset is LTSSM_EN on i.MX7, i.MX8MQ, i.MX8MM and i.MX8MP platforms.
+Since the assertion/de-assertion of apps_reset(LTSSM_EN bit) had been
+wrappered in imx_pcie_ltssm_enable() and imx_pcie_ltssm_disable();
+
+Remove apps_reset toggle in imx_pcie_assert_core_reset() and
+imx_pcie_deassert_core_reset() functions. Use imx_pcie_ltssm_enable()
+and imx_pcie_ltssm_disable() to configure apps_reset directly.
+
+Fix fail to enumerate reliably PI7C9X2G608GP (hotplug) at i.MX8MM, which
+reported By Tim.
+
+Reported-by: Tim Harvey <tharvey@gateworks.com>
+Closes: https://lore.kernel.org/all/CAJ+vNU3ohR2YKTwC4xoYrc1z-neDoH2TTZcMHDy+poj9=jSy+w@mail.gmail.com/
+Fixes: ef61c7d8d032 ("PCI: imx6: Deassert apps_reset in imx_pcie_deassert_core_reset()")
+Signed-off-by: Richard Zhu <hongxing.zhu@nxp.com>
+---
+ drivers/pci/controller/dwc/pci-imx6.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+--- a/drivers/pci/controller/dwc/pci-imx6.c
++++ b/drivers/pci/controller/dwc/pci-imx6.c
+@@ -763,7 +763,6 @@ static int imx7d_pcie_core_reset(struct
+ static void imx_pcie_assert_core_reset(struct imx_pcie *imx_pcie)
+ {
+ 	reset_control_assert(imx_pcie->pciephy_reset);
+-	reset_control_assert(imx_pcie->apps_reset);
+ 
+ 	if (imx_pcie->drvdata->core_reset)
+ 		imx_pcie->drvdata->core_reset(imx_pcie, true);
+@@ -775,7 +774,6 @@ static void imx_pcie_assert_core_reset(s
+ static int imx_pcie_deassert_core_reset(struct imx_pcie *imx_pcie)
+ {
+ 	reset_control_deassert(imx_pcie->pciephy_reset);
+-	reset_control_deassert(imx_pcie->apps_reset);
+ 
+ 	if (imx_pcie->drvdata->core_reset)
+ 		imx_pcie->drvdata->core_reset(imx_pcie, false);
+@@ -976,6 +974,9 @@ static int imx_pcie_host_init(struct dw_
+ 		}
+ 	}
+ 
++	/* Make sure that PCIe LTSSM is cleared */
++	imx_pcie_ltssm_disable(dev);
++
+ 	ret = imx_pcie_deassert_core_reset(imx_pcie);
+ 	if (ret < 0) {
+ 		dev_err(dev, "pcie deassert core reset failed: %d\n", ret);


### PR DESCRIPTION
This series adds some patches necessary for the Gateworks Venice i.MX8MM/i.MX8MP boards (cortexa53):
 - imx: 6-12: add additional patches; these are backported patches related to dt overlay and PCI issues 
 - imx: venice: add dt overlay support; adds dt overlay support
 - imx: venice: disable PCI AER; workaround an i.MX8MP+PI7C9X3G606 switch by disabling PCI AER in venice bootscript