### PR TITLE
toolchain/wrapper: add missing qstrip to info.mk export

### DIFF
--- a/toolchain/wrapper/Makefile
+++ b/toolchain/wrapper/Makefile
@@ -42,7 +42,7 @@ define Host/SetToolchainInfo
 	if [ -f $(CONFIG_TOOLCHAIN_ROOT)/info.mk ]; then \
 		$(CP) $(CONFIG_TOOLCHAIN_ROOT)/info.mk $(TOOLCHAIN_DIR)/; \
 	else \
-		$(SED) 's,GCC_VERSION=.*,GCC_VERSION=$(CONFIG_GCC_VERSION),' $(TOOLCHAIN_DIR)/info.mk; \
+		$(SED) 's,GCC_VERSION=.*,GCC_VERSION=$(call qstrip,$(CONFIG_GCC_VERSION)),' $(TOOLCHAIN_DIR)/info.mk; \
 	fi
 endef
 


### PR DESCRIPTION
When using an external toolchain, the `SetToolchainInfo` function is missing a `qstrip` call on `GCC_VERSION`, which results in quotes making it to the toolchain `info.mk` file.

This leads to a failure to build the `libgcc` ipk package because the quotes make it to its version and filename. For some reason, it only fails on the first make invocation, but succeeds on subsequent ones on my setup.

Fix this issue by adding the `qstrip`, making it consistent with the [internal toolchain approach](https://github.com/openwrt/openwrt/blob/68cb84183e385f95c579ffeb14a80150a203f431/toolchain/gcc/common.mk#L24).