### PR TITLE
kernel: remove expired i40evf drivers

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1253,11 +1253,9 @@ define KernelPackage/iavf
   TITLE:=Intel(R) Ethernet Adaptive Virtual Function support
   DEPENDS:=@PCI_SUPPORT +!LINUX_6_6:kmod-libie
   KCONFIG:= \
-       CONFIG_I40EVF \
        CONFIG_IAVF
   FILES:= \
        $(LINUX_DIR)/drivers/net/ethernet/intel/iavf/iavf.ko
-  AUTOLOAD:=$(call AutoProbe,i40evf iavf)
   AUTOLOAD:=$(call AutoProbe,iavf)
 endef
 


### PR DESCRIPTION
I40evf has been replaced by iavf, and i40evf has expired
blamed commit: https://github.com/openwrt/openwrt/commit/5d81b28a829ac20fb60991e71ee7a7c53d14fd58

> In the development history of Intel's drivers, the i40evf driver was later renamed the iavf driver. For example, some documents mention that Intel® Network Connections Software Version 24.0 renamed the i40evf and ixlv drivers to iavf. In subsequent versions, the i40evf driver was gradually removed, and its functions were taken over by the iavf driver. In the Linux system, relevant configuration instructions also exist. For instance, the User Guide for intel X722 Onboard Network Card states that the i40evf driver module should be disabled, and the iavf driver should be installed and used.

=====
Update your compilation menu from 'CONFIG_I40EVF' to 'CONFIG_IAVF'

```
# find /lib/modules/$(uname -r) -name "ia*"
/lib/modules/$(uname -r)/iavf.ko
# modprobe --show-depends iavf
insmod /lib/modules/$(uname -r)/iavf.ko
# modprobe --show-depends i40evf
insmod /lib/modules/$(uname -r)/iavf.ko
```
![image](https://github.com/user-attachments/assets/30d1ae53-2360-4696-a9ba-efdaca4d3ffd)

link: https://github.com/torvalds/linux/blob/dfba48a70cb68888efb494c9642502efe73614ed/Documentation/networking/device_drivers/ethernet/index.rst

Signed-off-by: xiao bo [peterwillcn@gmail.com](mailto:peterwillcn@gmail.com)