### PR TITLE
mediatek: add support for TP-Link FR365 v1

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-tplink-fr365v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-tplink-fr365v1.dts
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "TP-Link FR365 v1";
+	compatible = "tplink,fr365-v1", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: led_status {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_usb: led_usb {
+			function = LED_FUNCTION_USB;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sfp: led_sfp {
+			label = "green:sfp";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wlan: led_wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+		};
+
+		led_port2_act: led_port2_act {
+			label = "green:port2_act";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_port2_linespeed: led_port2_linespeed {
+			label = "green:port2_linespeed";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+	};
+
+	sfp1: sfp-1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		maximum-power-milliwatt = <3000>;
+		tx-disable-gpios = <&pio 10 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		label = "port2";
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bl2";
+				reg = <0x0000000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x0180000 0x0200000>;
+				read-only;
+			};
+
+			partition@380000 {
+				label = "fip";
+				reg = <0x0380000 0x0200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x0580000 0x2400000>;
+				compatible = "linux,ubi";
+
+				volumes {
+					ubi_rootdisk: ubi-volume-fit {
+						volname = "kernel";
+					};
+				};
+			};
+
+			partition@2980000 {
+				label = "ubi.b";
+				reg = <0x2980000 0x2400000>;
+
+				volumes {
+					ubi_rootdisk_2: ubi-volume-fit {
+						volname = "kernel";
+					};
+				};
+			};
+
+			partition@4d80000 {
+				label = "support-list";
+				reg = <0x4d80000 0x0020000>;
+				read-only;
+			};
+
+			partition@4da0000 {
+				label = "user-config";
+				reg = <0x4da0000 0x0a00000>;
+				read-only;
+			};
+
+			partition@57a0000 {
+				label = "partition-table";
+				reg = <0x57a0000 0x0020000>;
+				read-only;
+			};
+
+			partition@57c0000 {
+				label = "device-info";
+				reg = <0x57c0000 0x0020000>;
+				read-only;
+			};
+
+			partition@57e0000 {
+				label = "device-info.b";
+				reg = <0x57e0000 0x0020000>;
+				read-only;
+			};
+
+			partition@5800000 {
+				label = "tddp";
+				reg = <0x5800000 0x0020000>;
+				read-only;
+			};
+
+			partition@5820000 {
+				label = "tddp.b";
+				reg = <0x5820000 0x0020000>;
+				read-only;
+			};
+
+			partition@5840000 {
+				label = "extra-para-ubi";
+				reg = <0x5840000 0x0200000>;
+			};
+
+			partition@5a40000 {
+				label = "firmware-info";
+				reg = <0x5a40000 0x0020000>;
+				read-only;
+			};
+
+			partition@5a60000 {
+				label = "firmware-info.b";
+				reg = <0x5a60000 0x0020000>;
+				read-only;
+			};
+
+			partition@5a80000 {
+				label = "log";
+				reg = <0x5a80000 0x0200000>;
+				read-only;
+			};
+
+			partition@5c80000 {
+				label = "log.b";
+				reg = <0x5c80000 0x0200000>;
+				read-only;
+			};
+
+			partition@5e80000 {
+				label = "wlan";
+				reg = <0x5e80000 0x0500000>;
+				read-only;
+			};
+
+			partition@6380000 {
+				label = "wlan.b";
+				reg = <0x6380000 0x0500000>;
+				read-only;
+			};
+
+			partition@6880000 {
+				label = "database";
+				reg = <0x6880000 0x1100000>;
+				read-only;
+			};
+
+			partition@7980000 {
+				label = "log_recovery";
+				reg = <0x7980000 0x0080000>;
+				read-only;
+			};
+
+			partition@7a00000 {
+				label = "panic-oops";
+				reg = <0x7a00000 0x0080000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "port3";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "port4";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "port5";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "port6";
+		};
+
+		port@5 {
+			reg = <5>;
+			label = "port1";
+			phy-mode = "2500base-x";
+			managed = "in-band-status";
+			sfp = <&sfp1>;
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&pio {
+	i2c0_pins: i2c0-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+	};
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	clock-frequency = <400000>;
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+	mediatek,u3p-dis-msk = <0x01>;
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -184,6 +184,11 @@ smartrg,sdg-8733a)
 	ucidef_set_led_netdev "wan-orange" "WAN" "mdio-bus:08:orange:wan" "wan" "link_100 link_1000"
 	ucidef_set_led_netdev "wan-white" "WAN" "mdio-bus:08:white:wan" "wan" "link_10000"
 	;;
+tplink,fr365-v1)
+	ucidef_set_led_netdev "port2-green-act" "port-2" "green:port2_act" "port2" "link tx rx"
+	ucidef_set_led_netdev "port1-green-act" "port-1" "green:sfp" "port1" "link tx rx"
+	ucidef_set_led_netdev "wlan" "wlan" "green:wlan" "phy1-ap0"
+	;;
 tplink,re6000xd)
 	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-0" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-1" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -133,6 +133,9 @@ mediatek_setup_interfaces()
 	mercusys,mr90x-v1-ubi)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2" eth1
 		;;
+	tplink,fr365-v1)
+		ucidef_set_interfaces_lan_wan "port1 port3 port4 port5 port6" "port2"
+		;;
 	tplink,tl-xdr6086|\
 	wavlink,wl-wn586x3)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" eth1
@@ -211,6 +214,10 @@ mediatek_setup_macs()
 		label_mac=$(mtd_get_mac_ascii product_info ethaddr)
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add "$label_mac" 1)
+		;;
+	tplink,fr365-v1)
+		lan_mac=$(strings /dev/mtd11 | grep 'option macaddr' | awk -F"'" '{print $2}')
+		wan_mac="$(macaddr_add $lan_mac 1)"
 		;;
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-ax3000t-ubootmod|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -13,6 +13,9 @@ case "$FIRMWARE" in
 		ln -sf /tmp/tp_data/MT7981_EEPROM.bin \
 			/lib/firmware/$FIRMWARE
 		;;
+	tplink,fr365-v1)
+		ln -sf /tmp/wlan/radio /lib/firmware/$FIRMWARE
+		;;
 	ubnt,unifi-6-plus)
 		caldata_extract_mmc "factory" 0x0 0x1000
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -170,6 +170,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	tplink,fr365-v1)
+		addr=$(strings /dev/mtd11 | grep 'option macaddr' | awk -F"'" '{print $2}')
+		[ "$PHYNBR" = "0" ] && echo $addr > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
+		;;
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088)

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -19,6 +19,9 @@ preinit_mount_cfg_part() {
 	tplink,re6000xd)
 		mount_ubi_part "tp_data" "tp_data"
 		;;
+	tplink,fr365-v1)
+		mount_ubi_part "wlan" "ubi_wlan_factory_data"
+		;;
 	*)
 		;;
 	esac

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -1,13 +1,14 @@
 . /lib/functions/system.sh
 
 mount_ubi_part() {
-	local part_name="$1"
-	local mtd_num=$(grep $part_name /proc/mtd | cut -c4)
+	local mtd_name="$1"
+	local part_name="$2"
+	local mtd_num=$(grep \"$mtd_name\" /proc/mtd | cut -d: -f1 | sed 's/mtd//g')
 	local ubi_num=$(ubiattach -m $mtd_num | \
 		awk -F',' '/UBI device number [0-9]{1,}/{print $1}' | \
 		awk '{print $4}')
-	mkdir /tmp/$part_name
-	mount -r -t ubifs ubi$ubi_num:$part_name /tmp/$part_name
+	mkdir /tmp/$mtd_name
+	mount -r -t ubifs ubi$ubi_num:$part_name /tmp/$mtd_name
 }
 
 preinit_mount_cfg_part() {
@@ -16,7 +17,7 @@ preinit_mount_cfg_part() {
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
 	tplink,re6000xd)
-		mount_ubi_part "tp_data"
+		mount_ubi_part "tp_data" "tp_data"
 		;;
 	*)
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -33,6 +33,16 @@ preinit_set_mac_address() {
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		ip link set dev eth1 address "$(macaddr_add $addr 1)"
 		;;
+	tplink,fr365-v1)
+		lan_mac=$(strings /dev/mtd11 | grep 'option macaddr' | awk -F"'" '{print $2}')
+		wan_mac="$(macaddr_add $lan_mac 1)"
+		ip link set dev port2 address "$wan_mac"
+		ip link set dev port1 address "$lan_mac"
+		ip link set dev port3 address "$lan_mac"
+		ip link set dev port4 address "$lan_mac"
+		ip link set dev port5 address "$lan_mac"
+		ip link set dev port6 address "$lan_mac"
+		;;
 	*)
 		;;
 	esac

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -153,6 +153,12 @@ platform_do_upgrade() {
 		CI_UBIPART="ubi0"
 		nand_do_upgrade "$1"
 		;;
+	tplink,fr365-v1)
+		CI_UBIPART="ubi"
+		CI_KERNPART="kernel"
+		CI_ROOTPART="rootfs"
+		nand_do_upgrade "$1"
+		;;
 	nradio,c8-668gl)
 		CI_DATAPART="rootfs_data"
 		CI_KERNPART="kernel_2nd"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1760,6 +1760,26 @@ define Device/tplink_re6000xd
 endef
 TARGET_DEVICES += tplink_re6000xd
 
+define Device/tplink_fr365-v1
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := FR365
+  DEVICE_VARIANT := v1
+  DEVICE_DTS := mt7981b-tplink-fr365v1
+  DEVICE_DTS_DIR := ../dts
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 32768k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/factory.ubi := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := fitblk kmod-sfp kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+endef
+TARGET_DEVICES += tplink_fr365-v1
+
 define Device/tplink_tl-xdr-common
   DEVICE_VENDOR := TP-Link
   DEVICE_DTS_DIR := ../dts


### PR DESCRIPTION
This commit adds support for TP-Link FR365 v1 router.

### Device specification:
- SoC: MediaTek MT7981B 2x A53
- RAM: NT5AD256M16E4-JR 512MiB
- Flash: ESMT F50L1G41LB 128MB
- Ethernet: 5x 1GbE (1x WAN, 4x LAN)
- Ethernet: 1x SFP+ (2.5 GbE)
- Switch: MediaTek MT7531AE
- Wireless: MediaTek MT7976D
- LEDs: 4 status LEDs and 2 green GPIO-controlled LEDs on Ethernet port labeled as "WAN"
- Buttons: Reset
- Power: DC 12V 2A

### Installation (UART):
1. Disassemble the device
2. Create solder bridge on R85, R86, Solder 4-pin header on J4.
3. Connect UART console.
4. In U-Boot shell, enter the following commands to prepare flashing
```
enable_phy
extra_para set extra-para score 100
extra_para set extra-para fwFlag good
```
5. Use `mtkupgrade` command to TFTP flash openwrt-mediatek-filogic-tplink_fr365-v1-squashfs-factory.bin
6. Reboot the device

### Stock /proc/mtd layout
```
mtd0: 00100000 00020000 "bl2"
mtd1: 00080000 00020000 "u-boot-env"
mtd2: 00200000 00020000 "Factory"
mtd3: 00200000 00020000 "fip"
mtd4: 02400000 00020000 "ubi"
mtd5: 02400000 00020000 "ubi.b"
mtd6: 00020000 00020000 "support-list"
mtd7: 00a00000 00020000 "user-config"
mtd8: 00020000 00020000 "partition-table"
mtd9: 00020000 00020000 "device-info"
mtd10: 00020000 00020000 "device-info.b"
mtd11: 00020000 00020000 "tddp"
mtd12: 00020000 00020000 "tddp.b"
mtd13: 00200000 00020000 "extra-para-ubi"
mtd14: 00020000 00020000 "firmware-info"
mtd15: 00020000 00020000 "firmware-info.b"
mtd16: 00200000 00020000 "log"
mtd17: 00200000 00020000 "log.b"
mtd18: 00500000 00020000 "wlan"
mtd19: 00500000 00020000 "wlan.b"
mtd20: 01100000 00020000 "database"
mtd21: 00080000 00020000 "log_recovery"
mtd22: 00080000 00020000 "panic-oops"
```

### What does not work (yet)

The following SFP port signaling is missing for now.

* rate-select0-gpios
* rate-select1-gpios
* tx-fault-gpios