### PR TITLE
wifi-scripts: ucode: export HE and EHT operation in scan results

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/bin/iwinfo
+++ b/package/network/config/wifi-scripts/files-ucode/usr/bin/iwinfo
@@ -91,6 +91,20 @@ function print_scan(cells) {
 			printf('\t\tChannel Width: %s\n', cell.vht.chan_width);
 		}
 
+		if (cell.he) {
+			printf('\t  HE Operation:\n');
+			printf('\t\tCenter Frequency 1: %d\n', cell.he.center_chan_1);
+			printf('\t\tCenter Frequency 2: %s\n', cell.he.center_chan_2);
+			printf('\t\tChannel Width: %s\n', cell.he.chan_width);
+		}
+
+		if (cell.eht) {
+			printf('\t  EHT Operation:\n');
+			printf('\t\tCenter Frequency 1: %d\n', cell.eht.center_chan_1);
+			printf('\t\tCenter Frequency 2: %s\n', cell.eht.center_chan_2);
+			printf('\t\tChannel Width: %s\n', cell.eht.chan_width);
+		}
+
 		printf('\n'); 
 	}
 }

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/iwinfo.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/iwinfo.uc
@@ -481,6 +481,42 @@ export function countrylist(dev) {
 	return list;
 };
 
+function scan_extension(ext, cell) {
+	const eht_chan_width = [ '20 MHz', '40 MHz', '80 MHz', '160 MHz', '320 MHz'];
+
+	switch(ord(ext, 0)) {
+	case 36:
+		let offset = 7;
+
+		if (!(ord(ext, 3) & 0x2))
+			break;
+
+		if (ord(ext, 2) & 0x40)
+			offset += 3;
+
+		if (ord(ext, 2) & 0x80)
+			offset += 1;
+
+		cell.he = {
+			chan_width: eht_chan_width[ord(ext, offset + 1) & 0x3],
+			center_chan_1: ord(ext, offset + 2),
+			center_chan_2: ord(ext, offset + 3),
+		};
+		break;
+
+	case 106:
+		if (!(ord(ext, 1) & 0x1))
+			break;
+
+		cell.eht = {
+			chan_width: eht_chan_width[ord(ext, 6) & 0x7],
+			center_chan_1: ord(ext, 7),
+			center_chan_2: ord(ext, 8),
+		};
+		break;
+	}
+};
+
 export function scan(dev) {
 	const rsn_cipher = [ 'NONE', 'WEP-40', 'TKIP', 'WRAP', 'CCMP', 'WEP-104', 'AES-OCB', 'CKIP', 'GCMP', 'GCMP-256', 'CCMP-256' ];
 	const ht_chan_offset = [ 'no secondary', 'above', '[reserved]', 'below' ];
@@ -590,6 +626,10 @@ export function scan(dev) {
 					center_chan_1: ord(ie.data, 1),
 					center_chan_2: ord(ie.data, 2),
 				};
+				break;
+
+			case 255:
+				scan_extension(ie.data, cell);
 				break;
 			};
 


### PR DESCRIPTION
Export WiFi 6E (HE) and WiFi 7 (EHT) operation data in scan results. These additional data can be useful to check wifi channel utilization by nearby stations.

In combination with https://github.com/openwrt/iwinfo/pull/21 and https://github.com/openwrt/rpcd/pull/11, it adds support for AP scans in the 6 GHz band in LUCI.


Example:
~~~
Cell 32 - Address: xx:xx:xx:xx:xx:xx
          Mode: Master  Frequency: 6.115 GHz  Band: 6 GHz  Channel: 33
          Signal: -14 dBm  Quality: 70/70
          Encryption: SAE (CCMP)
          HE Operation:
                Center Frequency 1: 39
                Center Frequency 2: 47
                Channel Width: 160 MHz
          EHT Operation:
                Center Frequency 1: 47
                Center Frequency 2: 63
                Channel Width: 320 MHz
~~~

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>