### PR TITLE
qualcommax: ipq60xx: WAX610 / WAXY610Y remove unmountable oem partitions on upgrade

### DIFF
--- a/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
@@ -118,9 +118,13 @@ platform_do_upgrade() {
 	glinet,gl-ax1800|\
 	glinet,gl-axt1800|\
 	netgear,wax214|\
-	netgear,wax610|\
-	netgear,wax610y|\
 	qihoo,360v6)
+		nand_do_upgrade "$1"
+		;;
+	netgear,wax610|\
+	netgear,wax610y)
+		remove_oem_ubi_volume wifi_fw
+		remove_oem_ubi_volume ubi_rootfs
 		nand_do_upgrade "$1"
 		;;
 	linksys,mr7350|\


### PR DESCRIPTION
When using TFTP install method on a fresh unit, oem wifi_fw and ubi_rootfs UBI volumes must be removed or will hang when mounting during boot.
