### PR TITLE
[24.10] imx venice - fix overlay support and imx8mp pci support

### DIFF
--- a/target/linux/imx/cortexa53/target.mk
+++ b/target/linux/imx/cortexa53/target.mk
@@ -2,6 +2,7 @@ ARCH:=aarch64
 BOARDNAME:=NXP i.MX with Cortex-A53 (ARM64)
 CPU_TYPE:=cortex-a53
 KERNELNAME:=Image dtbs
+FEATURES+=dt-overlay
 
 define Target/Description
 	Build firmware images for NXP i.MX (Cortex-A53) based boards.

--- a/target/linux/imx/image/bootscript-gateworks_venice
+++ b/target/linux/imx/image/bootscript-gateworks_venice
@@ -22,7 +22,7 @@ echo "Gateworks Venice OpenWrt Boot script v1.0"
 #    partition, therefore we add 1 to the current partition
 setexpr rootpart ${distro_bootpart} + 1 # root on 'next' partition
 part uuid ${devtype} ${devnum}:${rootpart} uuid
-setenv bootargs ${bootargs} console=${console} root=PARTUUID=${uuid} rootfstype=squashfs,ext4,f2fs rootwait
+setenv bootargs ${bootargs} console=${console} root=PARTUUID=${uuid} rootfstype=squashfs,ext4,f2fs rootwait pci=noaer
 
 # load dtb (we try fdt_file and then fdt_file{1,2,3,4,5})
 echo "loading DTB..."

--- a/target/linux/imx/image/bootscript-gateworks_venice
+++ b/target/linux/imx/image/bootscript-gateworks_venice
@@ -29,7 +29,7 @@ echo "loading DTB..."
 setenv fdt_addr
 setenv fdt_list $fdt_file $fdt_file1 $fdt_file2 $fdt_file3 $fdt_file4 $fdt_file5
 setenv load_fdt 'echo Loading $fdt...; load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${prefix}${fdt} && setenv fdt_addr ${fdt_addr_r}'
-setenv apply_overlays 'fdt addr $fdt_addr_r && fdt resize && for fdt in "$fdt_overlays"; do load ${devtype} ${devnum}:${distro_bootpart} $loadaddr $prefix/$fdt && fdt apply $loadaddr && echo applied $prefix/$fdt; done'
+setenv apply_overlays 'fdt addr $fdt_addr_r && for fdt in "$fdt_overlays"; do load ${devtype} ${devnum}:${distro_bootpart} $loadaddr $prefix/$fdt && fdt resize $filesize && fdt apply $loadaddr && echo applied $prefix/$fdt; done'
 for fdt in ${fdt_list}; do if test -e ${devtype} ${devnum}:${distro_bootpart} ${prefix}${fdt}; then run load_fdt; fi; done
 if test -z "$fdt_addr"; then echo "Warning: Using bootloader DTB"; setenv fdt_addr $fdtcontroladdr; fi
 if test -n "$fdt_overlays"; then echo "Applying overlays"; run apply_overlays; fi

--- a/target/linux/imx/image/cortexa53.mk
+++ b/target/linux/imx/image/cortexa53.mk
@@ -8,6 +8,7 @@ define Build/boot-img-ext4
 	rm -fR $@.boot
 	mkdir -p $@.boot
 	$(foreach dts,$(DEVICE_DTS), $(CP) $(KDIR)/image-$(dts).dtb $@.boot/$(dts).dtb;)
+	$(foreach dtbo,$(DEVICE_DTS_OVERLAY), $(CP) $(KDIR)/image-$(dtbo).dtbo $@.boot/$(dtbo).dtbo;)
 	$(CP) $(IMAGE_KERNEL) $@.boot/$(KERNEL_NAME)
 	-$(CP) $@-boot.scr $@.boot/boot.scr
 	make_ext4fs -J -L kernel -l $(CONFIG_TARGET_KERNEL_PARTSIZE)M \
@@ -64,6 +65,7 @@ define Device/gateworks_venice
   BOOT_SCRIPT := gateworks_venice
   PARTITION_OFFSET := 16M
   DEVICE_DTS := $(basename $(notdir $(wildcard $(DTS_DIR)/freescale/imx8m*-venice*.dts)))
+  DEVICE_DTS_OVERLAY := $(basename $(notdir $(wildcard $(DTS_DIR)/freescale/imx8m*-venice*.dtso)))
   DEVICE_PACKAGES := \
 	kmod-hwmon-gsc kmod-rtc-ds1672 kmod-eeprom-at24 \
 	kmod-gpio-button-hotplug kmod-leds-gpio kmod-pps-gpio \

--- a/target/linux/imx/patches-6.6/505-6.13-arm64-dts-imx8mm-venice-gw73xx-remove-compatible-in-overlay-files.patch
+++ b/target/linux/imx/patches-6.6/505-6.13-arm64-dts-imx8mm-venice-gw73xx-remove-compatible-in-overlay-files.patch
@@ -1,0 +1,56 @@
+From d3fdc7ae2ca9cb93d634e84a2b90ebf340d6e622 Mon Sep 17 00:00:00 2001
+From: Frank Li <Frank.Li@nxp.com>
+Date: Fri, 18 Oct 2024 14:28:23 -0400
+Subject: [PATCH] arm64: dts: imx8mm-venice-gw73xx: remove compatible in
+ overlay file
+
+Remove compatible string in overlay file to fix below warning:
+'gw,imx8mm-gw73xx-0x' is not one of ['fsl,ls1043a-rdb', 'fsl,ls1043a-qds']
+
+Signed-off-by: Frank Li <Frank.Li@nxp.com>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ .../boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs232-rts.dtso | 4 ----
+ .../boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs422.dtso     | 4 ----
+ .../boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs485.dtso     | 4 ----
+ 3 files changed, 12 deletions(-)
+
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs232-rts.dtso
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs232-rts.dtso
+@@ -15,10 +15,6 @@
+ /dts-v1/;
+ /plugin/;
+ 
+-&{/} {
+-	compatible = "gw,imx8mm-gw73xx-0x";
+-};
+-
+ &gpio4 {
+ 	rs485_en {
+ 		gpio-hog;
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs422.dtso
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs422.dtso
+@@ -18,10 +18,6 @@
+ /dts-v1/;
+ /plugin/;
+ 
+-&{/} {
+-	compatible = "gw,imx8mm-gw73xx-0x";
+-};
+-
+ &gpio4 {
+ 	rs485_en {
+ 		gpio-hog;
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs485.dtso
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw73xx-0x-rs485.dtso
+@@ -18,10 +18,6 @@
+ /dts-v1/;
+ /plugin/;
+ 
+-&{/} {
+-	compatible = "gw,imx8mm-gw73xx-0x";
+-};
+-
+ &gpio4 {
+ 	rs485_en {
+ 		gpio-hog;

--- a/target/linux/imx/patches-6.6/506-6.12-arm64-dts-imx8mm-venice-gw72xx-remove-compatible-in-overlay-files.patch
+++ b/target/linux/imx/patches-6.6/506-6.12-arm64-dts-imx8mm-venice-gw72xx-remove-compatible-in-overlay-files.patch
@@ -1,0 +1,60 @@
+From f384d2828f0d5be67fcd69a7c4756f82465a7f2a Mon Sep 17 00:00:00 2001
+From: Fabio Estevam <festevam@denx.de>
+Date: Mon, 1 Jul 2024 20:12:29 -0300
+Subject: [PATCH] arm64: dts: imx8mm-venice-gw72xx-0x: Remove compatible from
+ dtso
+
+There is no need to describe the compatible string inside
+a dtso file.
+
+dt-schema produces super verbose warnings about that.
+
+Signed-off-by: Fabio Estevam <festevam@denx.de>
+Acked-by: Parthiban Nallathambi <parthiban@linumiz.com>
+Acked-by: Tim Harvey <tharvey@gateworks.com>
+Signed-off-by: Shawn Guo <shawnguo@kernel.org>
+---
+ .../boot/dts/freescale/imx8mm-venice-gw72xx-0x-rs232-rts.dtso | 4 ----
+ .../boot/dts/freescale/imx8mm-venice-gw72xx-0x-rs422.dtso     | 4 ----
+ .../boot/dts/freescale/imx8mm-venice-gw72xx-0x-rs485.dtso     | 4 ----
+ 3 files changed, 12 deletions(-)
+
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw72xx-0x-rs232-rts.dtso
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw72xx-0x-rs232-rts.dtso
+@@ -15,10 +15,6 @@
+ /dts-v1/;
+ /plugin/;
+ 
+-&{/} {
+-	compatible = "gw,imx8mm-gw72xx-0x";
+-};
+-
+ &gpio4 {
+ 	rs485_en {
+ 		gpio-hog;
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw72xx-0x-rs422.dtso
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw72xx-0x-rs422.dtso
+@@ -18,10 +18,6 @@
+ /dts-v1/;
+ /plugin/;
+ 
+-&{/} {
+-	compatible = "gw,imx8mm-gw72xx-0x";
+-};
+-
+ &gpio4 {
+ 	rs485_en {
+ 		gpio-hog;
+--- a/arch/arm64/boot/dts/freescale/imx8mm-venice-gw72xx-0x-rs485.dtso
++++ b/arch/arm64/boot/dts/freescale/imx8mm-venice-gw72xx-0x-rs485.dtso
+@@ -18,10 +18,6 @@
+ /dts-v1/;
+ /plugin/;
+ 
+-&{/} {
+-	compatible = "gw,imx8mm-gw72xx-0x";
+-};
+-
+ &gpio4 {
+ 	rs485_en {
+ 		gpio-hog;


### PR DESCRIPTION
This series adds some patches necessary for the Gateworks Venice i.MX8MM/i.MX8MP boards (cortexa53):

imx: 6-12: add additional patches; these are backported patches related to dt overlay and PCI issues
imx: venice: add dt overlay support; adds dt overlay support
imx: venice: disable PCI AER; workaround an i.MX8MP+PI7C9X3G606 switch by disabling PCI AER in venice bootscript

(backports of #19189)