### PR TITLE
mediatek: Ruijie RG-X60 Pro: add OpenWrt UBI layout

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -832,6 +832,18 @@ define U-Boot/mt7986_netcore_n60-pro
   DEPENDS:=+trusted-firmware-a-mt7986-spim-nand-ddr4
 endef
 
+define U-Boot/mt7986_ruijie_rg-x60-pro-ubi
+  NAME:=Ruijie RG-X60 Pro
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=ruijie_rg-x60-pro-ubi
+  UBOOT_CONFIG:=mt7986_ruijie_rg-x60-pro-ubi
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand-ubi
+  BL2_SOC:=mt7986
+  BL2_DDRTYPE:=ddr3
+  DEPENDS:=+trusted-firmware-a-mt7986-spim-nand-ubi-ddr3
+endef
+
 define U-Boot/mt7986_tplink_tl-xdr4288
   NAME:=TP-LINK TL-XDR4288
   BUILD_SUBTARGET:=filogic
@@ -1239,6 +1251,7 @@ UBOOT_TARGETS := \
 	mt7986_mercusys_mr90x-v1 \
 	mt7986_netcore_n60 \
 	mt7986_netcore_n60-pro \
+  mt7986_ruijie_rg-x60-pro-ubi \
 	mt7986_tplink_tl-xdr4288 \
 	mt7986_tplink_tl-xdr6086 \
 	mt7986_tplink_tl-xdr6088 \

--- a/package/boot/uboot-mediatek/patches/465-add-ruijie-rg-x60-pro-ubi.patch
+++ b/package/boot/uboot-mediatek/patches/465-add-ruijie-rg-x60-pro-ubi.patch
@@ -1,0 +1,319 @@
+--- /dev/null
++++ b/arch/arm/dts/mt7986a-ruijie_rg-x60-pro-ubi.dts
+@@ -0,0 +1,130 @@
++/dts-v1/;
++#include "mt7986.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/input/linux-event-codes.h>
++
++/ {
++	model = "Ruijie RG-X60 Pro";
++	compatible = "ruijie,rg-x60-pro-ubi", "mediatek,mt7986";
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x20000000>;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++		};
++
++		wps {
++			label = "wps";
++			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_WPS_BUTTON>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_WHITE>;
++			gpios = <&pio 22 GPIO_ACTIVE_LOW>;
++			default-state = "off";
++		};
++
++		led-1 {
++			function = LED_FUNCTION_ALARM;
++			color = <LED_COLOR_ID_PURPLE>;
++			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
++			default-state = "off";
++		};
++	};
++};
++
++&uart0 {
++	status = "okay";
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <0>;
++	phy-mode = "2500base-x";
++	mediatek,switch = "mt7531";
++	reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++	};
++};
++
++&pio {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_00>;
++		};
++
++		conf-pd {
++			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_00>;
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <1>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++		spi-tx-bus-width = <4>;
++		spi-rx-bus-width = <4>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "BL2";
++				reg = <0x000000 0x100000>;
++			};
++
++			partition@100000 {
++				label = "ubi";
++				reg = <0x100000 0x7F00000>;
++			};
++		};
++	};
++};
+--- /dev/null
++++ b/configs/mt7986_ruijie_rg-x60-pro-ubi_defconfig
+@@ -0,0 +1,124 @@
++CONFIG_ARM=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7986a-ruijie_rg-x60-pro-ubi"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7986=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_PCI=y
++CONFIG_DEBUG_UART=y
++CONFIG_AHCI=y
++CONFIG_FIT=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7986> "
++CONFIG_CMD_CPU=y
++CONFIG_CMD_LICENSE=y
++# CONFIG_CMD_BOOTEFI_BOOTMGR is not set
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_LINK_LOCAL=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_FAT=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_FS_UUID=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_REDUNDANT=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_RELOC_GD_ENV_ADDR=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/ruijie_rg-x60-pro-ubi_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_SCSI_AHCI=y
++CONFIG_AHCI_PCI=y
++CONFIG_MTK_AHCI=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PCIE_MEDIATEK=y
++CONFIG_PHY=y
++CONFIG_PHY_MTK_TPHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7986=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_RAM=y
++CONFIG_SCSI=y
++CONFIG_DM_SERIAL=y
++CONFIG_SERIAL_RX_BUFFER=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_MTK=y
++CONFIG_USB_STORAGE=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/defenvs/ruijie_rg-x60-pro-ubi_env
+@@ -0,0 +1,56 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootargs=root=/dev/fit0 rootwait
++bootcmd=if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
++bootconf=config-1
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-ruijie_rg-x60-pro-ubi-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-ruijie_rg-x60-pro-ubi-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-ruijie_rg-x60-pro-ubi-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-ruijie_rg-x60-pro-ubi-squashfs-sysupgrade.itb
++bootled_pwr=white:status
++bootled_rec=purple:alarm
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_production ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_recovery ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_6=[31mLoad BL31+U-Boot FIP via TFTP then write to NAND.[0m=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=[31mLoad BL2 preloader via TFTP then write to NAND.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_first=if button reset ; then led $bootled_rec on ; run boot_tftp_recovery ; setenv flag_recover 1 ; run boot_default ; fi ; bootmenu
++boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
++boot_production=led $bootled_pwr on ; run ubi_read_production && bootm $loadaddr#$bootconf ; led $bootled_pwr off
++boot_recovery=led $bootled_rec on ; run ubi_read_recovery && bootm $loadaddr#$bootconf ; led $bootled_rec off
++boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
++boot_tftp_forever=led $bootled_rec on ; while true ; do run boot_tftp_recovery ; sleep 1 ; done
++boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run ubi_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_production=tftpboot $loadaddr $bootfile_upg && env exists replacevol && iminfo $loadaddr && run ubi_write_production ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run ubi_write_fip && run reset_factory
++boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run mtd_write_bl2
++part_fit=fit
++reset_factory=ubi part ubi ; mw $loadaddr 0x0 0x800 ; ubi write $loadaddr ubootenv 0x800 ; ubi write $loadaddr ubootenv2 0x800
++ubi_write_fip=run ubi_remove_rootfs ; ubi check fip && ubi remove fip ; ubi create fip 0x200000 static ; ubi write $loadaddr fip 0x200000
++mtd_write_bl2=mtd erase BL2 && mtd write BL2 $loadaddr
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x100000 dynamic ; ubi check ubootenv2 || ubi create ubootenv2 0x100000 dynamic
++ubi_format=ubi detach ; mtd erase ubi && ubi part ubi ; reset
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_read_production=ubi read $loadaddr $part_fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run _switch_to_menu ; run _init_env ; run boot_first
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -48,6 +48,7 @@ openwrt,one|\
 qihoo,360t7|\
 routerich,ax3000-ubootmod|\
 routerich,be7200|\
+ruijie,rg-x60-pro-ubi|\
 snr,snr-cpe-ax2|\
 tplink,tl-xdr4288|\
 tplink,tl-xdr6086|\

--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro-common.dtsi
@@ -9,9 +9,6 @@
 #include "mt7986a.dtsi"
 
 / {
-	compatible = "ruijie,rg-x60-pro", "mediatek,mt7986a";
-	model = "Ruijie RG-X60 Pro";
-
 	aliases {
 		serial0 = &uart0;
 		led-boot = &led_system;
@@ -20,8 +17,8 @@
 		led-upgrade = &led_alarm;
 	};
 
-	chosen {
-		bootargs = "console=ttyS0,115200n8 earlycon=uart8250,mmio32,0x11002000";
+	chosen: chosen {
+		stdout-path = "serial0:115200n8";
 	};
 
 	memory@40000000 {
@@ -69,6 +66,7 @@
 		compatible = "mediatek,eth-mac";
 		reg = <0>;
 		phy-mode = "2500base-x";
+
 		fixed-link {
 			speed = <2500>;
 			full-duplex;
@@ -151,7 +149,7 @@
 	pinctrl-0 = <&spi_flash_pins>;
 	status = "okay";
 
-	flash@0 {
+	spi_flash: flash@0 {
 		compatible = "spi-nand";
 		reg = <0>;
 
@@ -159,11 +157,7 @@
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 
-		mediatek,nmbm;
-		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
-
-		partitions {
+		partitions: partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -172,51 +166,6 @@
 				label = "BL2";
 				reg = <0x000000 0x100000>;
 				read-only;
-			};
-
-			partition@100000 {
-				label = "u-boot-env";
-				reg = <0x100000 0x80000>;
-				read-only;
-			};
-
-			partition@180000 {
-				label = "Factory";
-				reg = <0x180000 0x200000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					eeprom_factory_0: eeprom@0 {
-						reg = <0x0 0x1000>;
-					};
-				};
-			};
-
-			partition@380000 {
-				label = "FIP";
-				reg = <0x380000 0x200000>;
-				read-only;
-			};
-
-			partition@580000 {
-				label = "product_info";
-				reg = <0x580000 0x80000>;
-				read-only;
-			};
-
-			partition@600000 {
-				label = "kdump";
-				reg = <0x600000 0x80000>;
-				read-only;
-			};
-
-			partition@680000 {
-				label = "ubi";
-				reg = <0x680000 0x3f00000>;
 			};
 		};
 	};

--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro-stock.dts
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro-stock.dts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7986a-ruijie-rg-x60-pro-common.dtsi"
+
+/ {
+	compatible = "ruijie,rg-x60-pro", "mediatek,mt7986a";
+	model = "Ruijie RG-X60 Pro";
+};
+
+&spi_flash {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};
+
+&partitions {
+	partition@100000 {
+		label = "u-boot-env";
+		reg = <0x100000 0x80000>;
+		read-only;
+	};
+
+	partition@180000 {
+		label = "Factory";
+		reg = <0x180000 0x200000>;
+		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x1000>;
+			};
+		};
+	};
+
+	partition@380000 {
+		label = "FIP";
+		reg = <0x380000 0x200000>;
+		read-only;
+	};
+
+	partition@580000 {
+		label = "product_info";
+		reg = <0x580000 0x80000>;
+		read-only;
+	};
+
+	partition@600000 {
+		label = "kdump";
+		reg = <0x600000 0x80000>;
+		read-only;
+	};
+
+	partition@680000 {
+		label = "ubi";
+		reg = <0x680000 0x3f00000>;
+	};
+};

--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro-ubi.dts
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro-ubi.dts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7986a-ruijie-rg-x60-pro-common.dtsi"
+
+/ {
+	compatible = "ruijie,rg-x60-pro-ubi", "mediatek,mt7986a";
+	model = "Ruijie RG-X60 Pro (UBI)";
+};
+
+&chosen {
+	rootdisk = <&ubi_rootdisk>;
+};
+
+&partitions {
+	partition@100000 {
+		compatible = "linux,ubi";
+		reg = <0x100000 0x7F00000>;
+		label = "ubi";
+
+		volumes {
+			ubi_factory: ubi-volume-factory {
+				volname = "factory";
+			};
+
+			ubi-volume-fip {
+				volname = "fip";
+			};
+
+			ubi_rootdisk: ubi-volume-fit {
+				volname = "fit";
+			};
+
+			ubi_ubootenv: ubi-volume-ubootenv {
+				volname = "ubootenv";
+			};
+
+			ubi_ubootenv2: ubi-volume-ubootenv2 {
+				volname = "ubootenv2";
+			};
+		};
+	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		eeprom_factory_0: eeprom@0 {
+			reg = <0x0 0x1000>;
+		};
+
+		macaddr_factory_24: macaddr@24 {
+			compatible = "mac-base";
+			reg = <0x24 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_24 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_24 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wifi {
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_24 2>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_24 3>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
@@ -155,7 +155,7 @@
 		compatible = "spi-nand";
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -72,6 +72,7 @@ mediatek_setup_interfaces()
 	netcore,n60-pro|\
 	nradio,c8-668gl|\
 	ruijie,rg-x60-pro|\
+	ruijie,rg-x60-pro-ubi|\
 	unielec,u7981-01*|\
 	wavlink,wl-wn536ax6-a|\
 	zbtlink,zbt-z8102ax|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -116,6 +116,7 @@ platform_do_upgrade() {
 	qihoo,360t7|\
 	routerich,ax3000-ubootmod|\
 	routerich,be7200|\
+	ruijie,rg-x60-pro-ubi|\
 	snr,snr-cpe-ax2|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
@@ -311,6 +312,7 @@ platform_check_image() {
 	netcore,n60|\
 	qihoo,360t7|\
 	routerich,ax3000-ubootmod|\
+	ruijie,rg-x60-pro-ubi|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2782,12 +2782,42 @@ TARGET_DEVICES += routerich_be7200
 define Device/ruijie_rg-x60-pro
   DEVICE_VENDOR := Ruijie
   DEVICE_MODEL := RG-X60 Pro
-  DEVICE_DTS := mt7986a-ruijie-rg-x60-pro
+  DEVICE_VARIANT := (Stock Layout)
+  DEVICE_DTS := mt7986a-ruijie-rg-x60-pro-stock
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += ruijie_rg-x60-pro
+
+define Device/ruijie_rg-x60-pro-common
+  DEVICE_VENDOR := Ruijie
+  DEVICE_MODEL := RG-X60 Pro
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  IMAGES := sysupgrade.itb
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+endef
+
+define Device/ruijie_rg-x60-pro-ubi
+  DEVICE_VARIANT := (UBI)
+  DEVICE_DTS := mt7986a-ruijie-rg-x60-pro-ubi
+  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot ruijie_rg-x60-pro-ubi
+  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ubi-ddr3
+  $(call Device/ruijie_rg-x60-pro-common)
+endef
+TARGET_DEVICES += ruijie_rg-x60-pro-ubi
 
 define Device/snr_snr-cpe-ax2
   DEVICE_VENDOR := SNR


### PR DESCRIPTION
mediatek: add support for Ruijie RG-X60 Pro (UBI layout)

This commit adds support for Ruijie RG-X60 Pro (UBI layout).

OpenWrt U-Boot UBI flash instructions
-------------------------------------

Back up critical data
---------------------
  1. While the device is running OpenWrt with stock MTD partitions:
     ```BASH
     mtd dump Factory > /tmp/Factory.bin
     mtd dump product_info > /tmp/product_info.bin
     mtd dump BL2 > /tmp/BL2.bin
     mtd dump FIP > /tmp/FIP.bin
     mtd dump u-boot-env > /tmp/u-boot-env.bin
     ```
  3. Copy the backup files to your PC via SCP.

Create a new Factory image
--------------------------
Use this python script to create a new factory image
```python
FACTORY_IMAGE = "Factory.bin"
PRODUCT_INFO_IMAGE = "product_info.bin"
NEW_FACRORY_IMAGE = "Factory_new.bin"
def main():
  with (open(PRODUCT_INFO_IMAGE, "rb") as fp,
        open(FACTORY_IMAGE, "rb") as ff,
        open(NEW_FACRORY_IMAGE, "wb") as fn):
    groups_str = [part.decode('utf-8', errors="ignore") for part in fp.read()[4:].split(b'\x00') if part]
    mac_bytes = next((bytes.fromhex(p.split('=')[1].replace(':', '')) for p in groups_str if p.startswith('ethaddr=')), b"")
    if mac_bytes is None or len(mac_bytes) != 6:
      print("Error: cannot found ethaddr in product_info")
      return
    data = bytearray(ff.read())
    data[0x24:0x24 + 6] = mac_bytes
    fn.write(data)
main()

```

Using the installer image
-------------------------
1. Download openwrt-mediatek-filogic-ruijie_rg-x60-pro-initramfs-ubi-install.bin
   from https://github.com/airjinkela/owrt-misc/tree/master/ruijie-rg-x60pro-ubi

2. Force flash openwrt-mediatek-filogic-ruijie_rg-x60-pro-initramfs-ubi-install.bin
   via sysupgrade.

4. Upload files Via SCP:
   Factory_new.bin
   openwrt*ruijie_rg-x60-pro-ubi-preloader.bin
   openwrt*ruijie_rg-x60-pro-ubi-bl31-uboot.fip
   openwrt*ruijie_rg-x60-pro-ubi-initramfs-recovery.itb

5. Connect via SSH/UART.
6. Prepare the factory file:
   ```BASH
   dd if=/tmp/Factory_new.bin of=/tmp/factory bs=4096 count=1
   ```
7. Prepare UBI:
   ```BASH
   mtd write /tmp/*preloader.bin BL2
   ubidetach -p /dev/mtd1 ; ubiformat -y /dev/mtd1 ; ubiattach -p /dev/mtd1
   ubimkvol /dev/ubi0 -n 0 -t static -s $(du -b /tmp/*uboot.fip | awk '{print $1}') -N fip
   ubiupdatevol /dev/ubi0_0 /tmp/*uboot.fip
   ubimkvol /dev/ubi0 -n 1 -t static -s 4096 -N factory
   ubiupdatevol /dev/ubi0_1 /tmp/factory
   ubimkvol /dev/ubi0 -n 2 -s 126976 -N ubootenv
   ubimkvol /dev/ubi0 -n 3 -s 126976 -N ubootenv2
   ubimkvol /dev/ubi0 -n 4 -s $(du -b /tmp/*recovery.itb | awk '{print $1}') -N recovery
   ubiupdatevol /dev/ubi0_4 /tmp/*recovery.itb
   ```
8. Reboot the device to recovery mode:
   ```BASH
   reboot
   ```
9. Flash openwrt*ruijie_rg-x60-pro-ubi-squashfs-sysupgrade.itb
   via sysupgrade.

Return to stock MTD
-------------------
1. Force flash openwrt*ruijie_rg-x60-pro-initramfs-kernel.bin
   via sysupgrade
2. Copy files to /tmp on the device via SCP:
   BL2.bin
   Factory.bin
   FIP.bin
   product_info.bin
   openwrt*ruijie_rg-x60-pro-squashfs-sysupgrade.bin
3. Restore stock MTD partitions:
   ```BASH
   apk add kmod-mtd-rw
   insmod mtd-rw i_want_a_brick=1
   mtd write /tmp/BL2.bin BL2
   mtd write /tmp/FIP.bin FIP
   mtd write /tmp/u-boot-env.bin u-boot-env
   mtd write /tmp/Factory.bin Factory
   mtd write /tmp/product_info.bin product_info
   ```
4. Install the system:
   ```BASH
   sysupgrade /tmp/*sysupgrade.bin
   ```

BL2 and FIP recovery
--------------------
Use mtk_uartboot and UART connection if BL2 or FIP is destroyed
Link: https://github.com/981213/mtk_uartboot

Stock layout
```
-----------------------------------------
| dev:    size   erasesize  name        |
| mtd0: 00100000 00020000 "BL2"         |
| mtd1: 00080000 00020000 "u-boot-env"  |
| mtd2: 00200000 00020000 "Factory"     |
| mtd3: 00200000 00020000 "FIP"         |
| mtd4: 00080000 00020000 "product_info"|
| mtd5: 00080000 00020000 "kdump"       |
| mtd6: 03f00000 00020000 "ubi"         |
-----------------------------------------
```
OpenWrt U-Boot UBI layout
```
----------------------------------
| dev:    size   erasesize  name |
| mtd0: 00100000 00020000 "BL2"  |
| mtd1: 07f00000 00020000 "ubi"  |
----------------------------------
```
