### PR TITLE
octeon: ubnt-*: Add device specific DTS pruning

### DIFF
--- a/target/linux/octeon/patches-6.6/400-ubnt_dts_pruning.patch
+++ b/target/linux/octeon/patches-6.6/400-ubnt_dts_pruning.patch
@@ -1,0 +1,81 @@
+commit eb6c3ba1d42fd087708f568ca220ff557f22104e
+Author: Jakob Haufe <sur5r@sur5r.net>
+Date:   Tue Jun 17 13:58:19 2025 +0200
+
+    MIPS: OCTEON: Add UBNT specific DTS pruning
+    
+    This imports device specific DTS pruning from
+    https://github.com/UI-Packages/kernel_e200/blob/master/arch/mips/cavium-octeon/octeon-platform.c#L1067
+    
+    - Reduce MMC clock frequency on E200/E220 to make
+      MMC communication reliable again. See linked issue.
+    - Remove unused MMC node on E300.
+    
+    Related: https://github.com/openwrt/openwrt/issues/13762
+    
+    Signed-off-by: Jakob Haufe <sur5r@sur5r.net>
+
+--- a/arch/mips/cavium-octeon/octeon-platform.c
++++ b/arch/mips/cavium-octeon/octeon-platform.c
+@@ -1133,6 +1133,41 @@ end_led:
+ 	}
+ #endif
+ 
++
++	return 0;
++}
++
++int __init ubnt_prune_device_tree(void)
++{
++	/* MMC on UBNT */
++	pr_info("UBNT board DTS pruning...\n");
++	if (octeon_bootinfo->board_type == CVMX_BOARD_TYPE_UBNT_E300) {
++		pr_info("UBNT E300 found, looking for mmc-slot@2\n");
++		// Remove unused MMC slot definition
++		int mmc_slot2 = fdt_path_offset(initial_boot_params, "/soc/mmc/mmc-slot@2");
++
++		if (mmc_slot2 > 0) {
++			pr_info("UBNT E300 found, deleting mmc-slot@2\n");
++			fdt_nop_node(initial_boot_params, mmc_slot2);
++		} else {
++			pr_info("mmc-slot@2 not found\n");
++		}
++	} else if (octeon_bootinfo->board_type == CVMX_BOARD_TYPE_UBNT_E200 ||
++		   octeon_bootinfo->board_type == CVMX_BOARD_TYPE_UBNT_E220) {
++		pr_info("UBNT E200/E220 found, looking for mmc-slot@0\n");
++		int mmc_slot0 = fdt_path_offset(initial_boot_params, "/soc/mmc/mmc-slot@0");
++
++		u32 freq = 26000000;
++
++		if (mmc_slot0 > 0) {
++			pr_info("UBNT E200/E220 mmc-slot@0 found, setting frequency to 26MHz");
++			fdt_setprop_inplace_cell(initial_boot_params, mmc_slot0,
++						 "spi-max-frequency", freq);
++		} else {
++			pr_info("mmc-slot@0 not found\n");
++		}
++	}
++
+ 	return 0;
+ }
+ 
+--- a/arch/mips/cavium-octeon/setup.c
++++ b/arch/mips/cavium-octeon/setup.c
+@@ -1168,6 +1168,7 @@ void __init prom_free_prom_memory(void)
+ 	}
+ }
+ 
++int __init ubnt_prune_device_tree(void);
+ void __init octeon_fill_mac_addresses(void);
+ 
+ void __init device_tree_init(void)
+@@ -1207,6 +1208,9 @@ void __init device_tree_init(void)
+ 		octeon_prune_device_tree();
+ 		pr_info("Using internal Device Tree.\n");
+ 	}
++
++	ubnt_prune_device_tree();
++
+ 	if (fill_mac)
+ 		octeon_fill_mac_addresses();
+ 	unflatten_and_copy_device_tree();


### PR DESCRIPTION
This imports device specific DTS pruning from
https://github.com/UI-Packages/kernel_e200/blob/master/arch/mips/cavium-octeon/octeon-platform.c#L1067

- Reduce MMC clock frequency on E200/E220 to make
  MMC communication reliable again. See linked issue.
- Removes unused MMC node on E300.

Link: https://github.com/openwrt/openwrt/issues/13762
Signed-off-by: Jakob Haufe <sur5r@sur5r.net>