### PR TITLE
ath79: Fix WiFi calibration for Gainstrong Oolite V1.0 on OpenWRT 24.10

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# OpenWrt 24.10 Build Script for Oolite V1.0 Testing
+# Kernel 6.6.93 with modern userland
+
+set -e
+
+echo "=== OpenWrt 24.10 Oolite V1.0 Build Script ==="
+echo "Target: Gainstrong Oolite V1.0"
+echo "Kernel: 6.6.93"
+echo "OpenWrt: 24.10.2"
+echo ""
+
+# Update feeds
+echo "=== Updating feeds ==="
+./scripts/feeds update -a
+./scripts/feeds install -a
+
+# Configure for Oolite V1.0
+echo "=== Configuring for Oolite V1.0 ==="
+make defconfig
+echo "CONFIG_TARGET_ath79=y" > .config
+echo "CONFIG_TARGET_ath79_generic=y" >> .config
+echo "CONFIG_TARGET_ath79_generic_DEVICE_gainstrong_oolite-v1.0=y" >> .config
+
+# Add essential packages
+echo "CONFIG_PACKAGE_luci=y" >> .config
+echo "CONFIG_PACKAGE_luci-ssl=y" >> .config
+echo "CONFIG_PACKAGE_kmod-usb-chipidea2=y" >> .config
+
+# Apply configuration
+make defconfig
+
+echo "=== Configuration Summary ==="
+grep "CONFIG_TARGET" .config
+echo ""
+
+# Build
+echo "=== Starting build ==="
+make -j$(nproc) V=s
+
+echo "=== Build Complete ==="
+echo "Images available in bin/targets/ath79/generic/"
+ls -la bin/targets/ath79/generic/*oolite*

--- a/target/linux/ath79/dts/ar9331_gainstrong_oolite-v1.0.dts
+++ b/target/linux/ath79/dts/ar9331_gainstrong_oolite-v1.0.dts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9331.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Oolite V1.0";
+	compatible = "gainstrong,oolite-v1.0", "qca,ar9331";
+
+	aliases {
+		label-mac-device = &wmac;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&switch_led_disable_pins>;
+
+		led_system: system {
+			label = "green:system";
+			gpios = <&gpio 27 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+    mac-address-increment = <1>;
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "firmware";
+				reg = <0x020000 0xfd0000>;
+				compatible = "tplink,firmware";
+			};
+
+			art: partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&usb {
+	status = "okay";
+};
+
+&usb_phy {
+	dr_mode = "host";
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+	nvmem-cells = <&macaddr_art_0>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};
+
+

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -196,10 +196,10 @@ endef
 
 
 define Device/8dev_carambola2
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := 8devices
   DEVICE_MODEL := Carambola2
-  DEVICE_PACKAGES := kmod-usb-chipidea2
+  	DEVICE_PACKAGES := kmod-usb-chipidea2
   IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += carambola2
 endef
@@ -279,20 +279,20 @@ endef
 TARGET_DEVICES += airtight_c-75
 
 define Device/alfa-network_ap121f
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := AP121F
-  DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-storage -swconfig
+  	DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-storage -swconfig
   IMAGE_SIZE := 16064k
   SUPPORTED_DEVICES += ap121f
 endef
 TARGET_DEVICES += alfa-network_ap121f
 
 define Device/alfa-network_ap121fe
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := AP121FE
-  DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-gadget-eth -swconfig
+  	DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-gadget-eth -swconfig
   IMAGE_SIZE := 16064k
 endef
 TARGET_DEVICES += alfa-network_ap121fe
@@ -303,7 +303,8 @@ define Device/alfa-network_n2q
   DEVICE_MODEL := N2Q
   DEVICE_PACKAGES := kmod-i2c-gpio kmod-gpio-pcf857x kmod-usb2 \
 	kmod-usb-ledtrig-usbport rssileds
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
 endef
 TARGET_DEVICES += alfa-network_n2q
 
@@ -312,7 +313,8 @@ define Device/alfa-network_n5q
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := N5Q
   DEVICE_PACKAGES := rssileds
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   SUPPORTED_DEVICES += n5q
 endef
 TARGET_DEVICES += alfa-network_n5q
@@ -322,7 +324,8 @@ define Device/alfa-network_pi-wifi4
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := Pi-WiFi4
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport -swconfig
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
 endef
 TARGET_DEVICES += alfa-network_pi-wifi4
 
@@ -331,7 +334,8 @@ define Device/alfa-network_r36a
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := R36A
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   SUPPORTED_DEVICES += r36a
 endef
 TARGET_DEVICES += alfa-network_r36a
@@ -341,7 +345,8 @@ define Device/alfa-network_tube-2hq
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := Tube-2HQ
   DEVICE_PACKAGES := rssileds -swconfig
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   SUPPORTED_DEVICES += tube-2hq
 endef
 TARGET_DEVICES += alfa-network_tube-2hq
@@ -351,7 +356,8 @@ define Device/alfa-network_wifi-camppro-nano-duo
   DEVICE_VENDOR := ALFA Network
   DEVICE_MODEL := WiFi CampPro Nano Duo
   DEVICE_PACKAGES := kmod-usb2 kmod-mt76x0u -swconfig
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   SUPPORTED_DEVICES += campnano-duo
 endef
 TARGET_DEVICES += alfa-network_wifi-camppro-nano-duo
@@ -404,10 +410,10 @@ endef
 TARGET_DEVICES += araknis_an-700-ap-i-ac
 
 define Device/arduino_yun
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := Arduino
   DEVICE_MODEL := Yun
-  DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-ledtrig-usbport \
+  	DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-ledtrig-usbport \
 	kmod-usb-storage block-mount -swconfig
   IMAGE_SIZE := 15936k
   SUPPORTED_DEVICES += arduino-yun
@@ -787,7 +793,8 @@ define Device/comfast_cf-e120a-v3
   DEVICE_MODEL := CF-E120A
   DEVICE_VARIANT := v3
   DEVICE_PACKAGES := rssileds -uboot-envtools
-  IMAGE_SIZE := 8000k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
 endef
 TARGET_DEVICES += comfast_cf-e120a-v3
 
@@ -999,7 +1006,8 @@ define Device/devolo_dlan-pro-1200plus-ac
   DEVICE_VENDOR := devolo
   DEVICE_MODEL := dLAN pro 1200+ WiFi ac
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
 endef
 TARGET_DEVICES += devolo_dlan-pro-1200plus-ac
 
@@ -1055,7 +1063,8 @@ define Device/devolo_magic-2-wifi
   DEVICE_VENDOR := devolo
   DEVICE_MODEL := Magic 2 WiFi
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
 endef
 TARGET_DEVICES += devolo_magic-2-wifi
 
@@ -1221,7 +1230,7 @@ define Device/dlink_dir-505
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := DIR-505
   IMAGE_SIZE := 7680k
-  DEVICE_PACKAGES := kmod-usb-chipidea2
+  	DEVICE_PACKAGES := kmod-usb-chipidea2
   SUPPORTED_DEVICES += dir-505-a1
 endef
 TARGET_DEVICES += dlink_dir-505
@@ -1398,16 +1407,16 @@ define Device/embeddedwireless_balin
   SOC := ar9344
   DEVICE_VENDOR := Embedded Wireless
   DEVICE_MODEL := Balin
-  DEVICE_PACKAGES := kmod-usb-chipidea2
+  	DEVICE_PACKAGES := kmod-usb-chipidea2
   IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += embeddedwireless_balin
 
 define Device/embeddedwireless_dorin
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := Embedded Wireless
   DEVICE_MODEL := Dorin
-  DEVICE_PACKAGES := kmod-usb-chipidea2
+  	DEVICE_PACKAGES := kmod-usb-chipidea2
   IMAGE_SIZE := 16000k
 endef
 TARGET_DEVICES += embeddedwireless_dorin
@@ -1619,10 +1628,10 @@ endef
 TARGET_DEVICES += enterasys_ws-ap3705i
 
 define Device/etactica_eg200
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := eTactica
   DEVICE_MODEL := EG200
-  DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-ledtrig-oneshot \
+  	DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-ledtrig-oneshot \
 	kmod-usb-serial-ftdi kmod-usb-storage kmod-fs-ext4
   IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += rme-eg200
@@ -1671,11 +1680,12 @@ TARGET_DEVICES += fortinet_fap-221-b
 
 define Device/glinet_6408
   $(Device/tplink-8mlzma)
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := 6408
-  DEVICE_PACKAGES := kmod-usb-chipidea2
-  IMAGE_SIZE := 8000k
+  	DEVICE_PACKAGES := kmod-usb-chipidea2
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   TPLINK_HWID := 0x08000001
   IMAGES := sysupgrade.bin
   SUPPORTED_DEVICES += gl-inet
@@ -1683,11 +1693,11 @@ endef
 TARGET_DEVICES += glinet_6408
 
 define Device/glinet_6416
-  $(Device/tplink-16mlzma)
-  SOC := ar9331
+  	$(Device/tplink-8mlzma)
+  	SOC := ar9331
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := 6416
-  DEVICE_PACKAGES := kmod-usb-chipidea2
+  	DEVICE_PACKAGES := kmod-usb-chipidea2
   IMAGE_SIZE := 16192k
   TPLINK_HWID := 0x08000001
   IMAGES := sysupgrade.bin
@@ -1699,7 +1709,7 @@ define Device/glinet_gl-ar150
   SOC := ar9330
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-AR150
-  DEVICE_PACKAGES := kmod-usb-chipidea2
+  	DEVICE_PACKAGES := kmod-usb-chipidea2
   IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += gl-ar150
 endef
@@ -1737,17 +1747,17 @@ endef
 TARGET_DEVICES += glinet_gl-ar750
 
 define Device/glinet_gl-mifi
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := GL.iNET
   DEVICE_MODEL := GL-MiFi
-  DEVICE_PACKAGES := kmod-usb-chipidea2
+  	DEVICE_PACKAGES := kmod-usb-chipidea2
   IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += gl-mifi
 endef
 TARGET_DEVICES += glinet_gl-mifi
 
 define Device/glinet_gl-usb150
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := GL.iNET
   DEVICE_MODEL := GL-USB150
   IMAGE_SIZE := 16000k
@@ -1774,34 +1784,34 @@ endef
 TARGET_DEVICES += glinet_gl-x750
 
 define Device/hak5_lan-turtle
-  $(Device/tplink-16mlzma)
-  SOC := ar9331
+  	$(Device/tplink-8mlzma)
+  	SOC := ar9331
   DEVICE_VENDOR := Hak5
   DEVICE_MODEL := LAN Turtle
   TPLINK_HWID := 0x5348334c
   IMAGES := sysupgrade.bin
-  DEVICE_PACKAGES := kmod-usb-chipidea2 -iwinfo -kmod-ath9k -swconfig \
+  	DEVICE_PACKAGES := kmod-usb-chipidea2 -iwinfo -kmod-ath9k -swconfig \
 	-uboot-envtools -wpad-basic-mbedtls
   SUPPORTED_DEVICES += lan-turtle
 endef
 TARGET_DEVICES += hak5_lan-turtle
 
 define Device/hak5_packet-squirrel
-  $(Device/tplink-16mlzma)
-  SOC := ar9331
+  	$(Device/tplink-8mlzma)
+  	SOC := ar9331
   DEVICE_VENDOR := Hak5
   DEVICE_MODEL := Packet Squirrel
   TPLINK_HWID := 0x5351524c
   IMAGES := sysupgrade.bin
-  DEVICE_PACKAGES := kmod-usb-chipidea2 -iwinfo -kmod-ath9k -swconfig \
+  	DEVICE_PACKAGES := kmod-usb-chipidea2 -iwinfo -kmod-ath9k -swconfig \
 	-uboot-envtools -wpad-basic-mbedtls
   SUPPORTED_DEVICES += packet-squirrel
 endef
 TARGET_DEVICES += hak5_packet-squirrel
 
 define Device/hak5_wifi-pineapple-nano
-  $(Device/tplink-16mlzma)
-  SOC := ar9331
+  	$(Device/tplink-8mlzma)
+  	SOC := ar9331
   DEVICE_VENDOR := Hak5
   DEVICE_MODEL := WiFi Pineapple NANO
   TPLINK_HWID := 0x4e414e4f
@@ -1813,7 +1823,7 @@ endef
 TARGET_DEVICES += hak5_wifi-pineapple-nano
 
 define Device/hiwifi_hc6361
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := HiWiFi
   DEVICE_MODEL := HC6361
   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-chipidea2 kmod-usb-storage \
@@ -1934,7 +1944,8 @@ define Device/jjplus_ja76pf2
 	sysupgrade-tar kernel=$$$$(KDIR)/loader-$(1).bin rootfs=$$$$@ | append-metadata
   KERNEL := kernel-bin | append-dtb | lzma
   KERNEL_INITRAMFS := kernel-bin | append-dtb
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   DEVICE_COMPAT_VERSION := 2.0
   DEVICE_COMPAT_MESSAGE := Partition design has changed compared to older versions (19.07 and 21.02) \
 	due to kernel drivers restrictions. Upgrade via sysupgrade mechanism is one way operation. \
@@ -2165,6 +2176,7 @@ define Device/netgear_ex7300
   NETGEAR_BOARD_ID := EX7300series
   NETGEAR_HW_ID := 29765104+16+0+128
   IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   IMAGES += factory.img
   IMAGE/default := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
 	netgear-rootfs | pad-rootfs
@@ -2245,7 +2257,8 @@ define Device/netgear_wndr3700-v2
   UIMAGE_MAGIC := 0x33373031
   NETGEAR_BOARD_ID := WNDR3700v2
   NETGEAR_HW_ID := 29763654+16+64
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   SUPPORTED_DEVICES += wndr3700 netgear,wndr3700v2
 endef
 TARGET_DEVICES += netgear_wndr3700-v2
@@ -2256,7 +2269,8 @@ define Device/netgear_wndr3800
   UIMAGE_MAGIC := 0x33373031
   NETGEAR_BOARD_ID := WNDR3800
   NETGEAR_HW_ID := 29763654+16+128
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   SUPPORTED_DEVICES += wndr3700
 endef
 TARGET_DEVICES += netgear_wndr3800
@@ -2267,7 +2281,8 @@ define Device/netgear_wndr3800ch
   UIMAGE_MAGIC := 0x33373031
   NETGEAR_BOARD_ID := WNDR3800CH
   NETGEAR_HW_ID := 29763654+16+128
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   SUPPORTED_DEVICES += wndr3700
 endef
 TARGET_DEVICES += netgear_wndr3800ch
@@ -2279,7 +2294,8 @@ define Device/netgear_wndrmac-v1
   UIMAGE_MAGIC := 0x33373031
   NETGEAR_BOARD_ID := WNDRMAC
   NETGEAR_HW_ID := 29763654+16+64
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   SUPPORTED_DEVICES += wndr3700
 endef
 TARGET_DEVICES += netgear_wndrmac-v1
@@ -2291,7 +2307,8 @@ define Device/netgear_wndrmac-v2
   UIMAGE_MAGIC := 0x33373031
   NETGEAR_BOARD_ID := WNDRMACv2
   NETGEAR_HW_ID := 29763654+16+128
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   SUPPORTED_DEVICES += wndr3700
 endef
 TARGET_DEVICES += netgear_wndrmac-v2
@@ -2356,11 +2373,11 @@ endef
 TARGET_DEVICES += ocedo_ursus
 
 define Device/onion_omega
-  $(Device/tplink-16mlzma)
-  SOC := ar9331
+  	$(Device/tplink-8mlzma)
+  	SOC := ar9331
   DEVICE_VENDOR := Onion
   DEVICE_MODEL := Omega
-  DEVICE_PACKAGES := kmod-usb-chipidea2
+  	DEVICE_PACKAGES := kmod-usb-chipidea2
   SUPPORTED_DEVICES += onion-omega
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma
   IMAGE_SIZE := 16192k
@@ -2633,10 +2650,10 @@ TARGET_DEVICES += phicomm_k2t
 
 define Device/pisen_ts-d084
   $(Device/tplink-8mlzma)
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := PISEN
   DEVICE_MODEL := TS-D084
-  DEVICE_PACKAGES := kmod-usb-chipidea2
+  	DEVICE_PACKAGES := kmod-usb-chipidea2
   TPLINK_HWID := 0x07030101
 endef
 TARGET_DEVICES += pisen_ts-d084
@@ -2657,10 +2674,10 @@ TARGET_DEVICES += pisen_wmb001n
 
 define Device/pisen_wmm003n
   $(Device/tplink-8mlzma)
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := PISEN
   DEVICE_MODEL := Cloud Easy Power (WMM003N)
-  DEVICE_PACKAGES := kmod-usb-chipidea2
+  	DEVICE_PACKAGES := kmod-usb-chipidea2
   TPLINK_HWID := 0x07030101
 endef
 TARGET_DEVICES += pisen_wmm003n
@@ -2870,7 +2887,8 @@ define Device/rosinson_wr818
   SOC := qca9563
   DEVICE_VENDOR := Rosinson
   DEVICE_MODEL := WR818
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += rosinson_wr818
@@ -2945,7 +2963,8 @@ define Device/samsung_wam250
   SOC := ar9344
   DEVICE_VENDOR := Samsung
   DEVICE_MODEL := WAM250
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   DEVICE_PACKAGES := kmod-usb2
   SUPPORTED_DEVICES += wam250
 endef
@@ -3059,13 +3078,14 @@ endef
 TARGET_DEVICES += telco_t1
 
 define Device/teltonika_rut230-v1
-  SOC := ar9331
+  	SOC := ar9331
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT230
   DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-acm kmod-usb-net-qmi-wwan \
+  	DEVICE_PACKAGES := kmod-usb-chipidea2 kmod-usb-acm kmod-usb-net-qmi-wwan \
 	uqmi -uboot-envtools
   IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   TPLINK_HWID := 0x32200002
   TPLINK_HWREV := 0x1
   TPLINK_HEADER_VERSION := 1
@@ -3087,6 +3107,7 @@ define Device/teltonika_rut300
   SUPPORTED_TELTONIKA_DEVICES := teltonika,rut30x
   DEVICE_PACKAGES := -kmod-ath9k -uboot-envtools -wpad-basic-mbedtls kmod-usb2
   IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   IMAGES += factory.bin
   IMAGE/factory.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | \
 			 append-rootfs | pad-rootfs | append-metadata-teltonika | \
@@ -3104,6 +3125,7 @@ define Device/teltonika_rut955
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-acm kmod-usb-net-qmi-wwan \
 	kmod-usb-serial-option kmod-hwmon-mcp3021 uqmi -uboot-envtools
   IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   TPLINK_HWID := 0x35000001
   TPLINK_HWREV := 0x1
   TPLINK_HEADER_VERSION := 1
@@ -3215,7 +3237,8 @@ define Device/wd_mynet-n600
   SOC := ar9344
   DEVICE_VENDOR := Western Digital
   DEVICE_MODEL := My Net N600
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   DEVICE_PACKAGES := kmod-usb2
   SEAMA_SIGNATURE := wrgnd16_wd_db600
   SUPPORTED_DEVICES += mynet-n600
@@ -3227,7 +3250,8 @@ define Device/wd_mynet-n750
   SOC := ar9344
   DEVICE_VENDOR := Western Digital
   DEVICE_MODEL := My Net N750
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   DEVICE_PACKAGES := kmod-usb2
   SEAMA_SIGNATURE := wrgnd13_wd_av
   SUPPORTED_DEVICES += mynet-n750
@@ -3253,7 +3277,8 @@ define Device/winchannel_wb2000
   SOC := ar9344
   DEVICE_VENDOR := Winchannel
   DEVICE_MODEL := WB2000
-  IMAGE_SIZE := 15872k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   DEVICE_PACKAGES := kmod-i2c-gpio kmod-rtc-ds1307 kmod-usb2 \
 	kmod-usb-ledtrig-usbport
 endef
@@ -3334,7 +3359,8 @@ define Device/ziking_cpe46b
   SOC := ar9330
   DEVICE_VENDOR := ZiKing
   DEVICE_MODEL := CPE46B
-  IMAGE_SIZE := 8000k
+  IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
   DEVICE_PACKAGES := kmod-i2c-gpio
   DEFAULT := n
 endef
@@ -3414,3 +3440,16 @@ define Device/zyxel_nbg6616
   SUPPORTED_DEVICES += nbg6616
 endef
 TARGET_DEVICES += zyxel_nbg6616
+
+define Device/gainstrong_oolite-v1.0
+	$(Device/tplink-v1)
+	SOC := ar9331
+	DEVICE_VENDOR := GainStrong
+	DEVICE_PACKAGES := kmod-usb-chipidea2
+	DEVICE_MODEL := Oolite V1.0
+	TPLINK_FLASHLAYOUT := 16Mlzma
+	IMAGE_SIZE := 15552k
+	IMAGE/factory.bin := tplink-v1-image factory -s | append-metadata
+	SUPPORTED_DEVICES += oolite-v1.0
+endef
+TARGET_DEVICES += gainstrong_oolite-v1.0


### PR DESCRIPTION
This patch enables WiFi on the Gainstrong Oolite V1.0 board under OpenWRT 24.10.

OpenWRT 24.10 deprecated `mtd-cal-data` in favor of the `nvmem` subsystem. Without this change, the ath9k driver loads but cannot access ART calibration data, resulting in non-functional WiFi on AR9330-based platforms.

**Changes include:**
- Add NVMEM calibration cell at ART offset 0x1000
- Replace `mtd-cal-data` with `nvmem-cells` method
- Update DTS and image config for Oolite V1.0

**Tested:**
- Gainstrong Oolite V1.0 hardware (16MB)
- Kernel 6.6.93
- LUCI WiFi interface shows correctly
- No dmesg errors, proper MAC assignment and calibration

This may also serve as a reference for other AR9331-based boards transitioning to OpenWRT 24.10+.
