### PR TITLE
mediatek: add support for Zyxel NWA90AX PRO

### DIFF
--- a/package/utils/zyxel-bootconfig/files/95_apply_bootconfig
+++ b/package/utils/zyxel-bootconfig/files/95_apply_bootconfig
@@ -4,6 +4,7 @@ apply_bootconfig() {
 	case $(board_name) in
 	zyxel,nwa50ax|\
 	zyxel,nwa50ax-pro|\
+	zyxel,nwa90ax-pro|\
 	zyxel,nwa55axe)
 		mtd_idx=$(find_mtd_index "bootconfig")
 		zyxel-bootconfig "/dev/mtd$mtd_idx" set-image-status 0 valid

--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -14,7 +14,8 @@ set_preinit_iface() {
 	cudy,ap3000outdoor-v1|\
 	cudy,re3000-v1|\
 	ubnt,unifi-6-lr|\
-	zyxel,nwa50ax-pro)
+	zyxel,nwa50ax-pro|\
+	zyxel,nwa90ax-pro)
 		ip link set eth0 up
 		ifname=eth0
 		;;

--- a/target/linux/mediatek/dts/mt7981b-zyxel-nwa90ax-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-zyxel-nwa90ax-pro.dts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: (GPL-2.0-or-later OR MIT)
+/dts-v1/;
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "Zyxel NWA90AX Pro";
+	compatible = "zyxel,nwa90ax-pro", "mediatek,mt7981";
+
+	aliases {
+		led-boot = &led_green;
+		led-failsafe = &led_red;
+		led-running = &led_green;
+		led-upgrade = &led_red;
+		serial0 = &uart0;
+		label-mac-device = &gmac1;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_green: led-0 {
+			label = "green:system";
+			gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-1 {
+			label = "blue:system";
+			gpios = <&pio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_red: led-2 {
+			label = "red:system";
+			gpios = <&pio 7 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	status = "okay";
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+
+		phy-handle = <&phy0>;
+
+		nvmem-cells = <&macaddr_mrd_1fff8>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&mdio_bus {
+	reset-gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <1500000>;
+	reset-post-delay-us = <1000000>;
+
+	phy0: ethernet-phy@5 {
+		reg = <5>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_AMBER>;
+				function = LED_FUNCTION_WAN;
+			};
+
+			led@3 {
+				reg = <3>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x0200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr: macaddr@a {
+						reg = <0xa 0x6>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x0200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x3200000>;
+			};
+
+			partition@3780000 {
+				label = "ubi_1";
+				reg = <0x3780000 0x3200000>;
+				read-only;
+			};
+
+			partition@6980000 {
+				label = "rootfs-data";
+				reg = <0x6980000 0x3c00000>;
+				read-only;
+			};
+
+			partition@a580000 {
+				label = "logs";
+				reg = <0xa580000 0x3a80000>;
+				read-only;
+			};
+
+			partition@e000000 {
+				label = "myzyxel";
+				reg = <0xe000000 0xf00000>;
+				read-only;
+			};
+
+			partition@ef00000 {
+				label = "bootconfig";
+				reg = <0xef00000 0x80000>;
+			};
+
+			partition@ef80000 {
+				label = "mrd";
+				reg = <0xef80000 0x80000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_mrd_1fff8: macaddr@1fff8 {
+						reg = <0x1fff8 0x6>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+
+	pwm_pins: pwm0-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm0_1";
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	mediatek,mtd-eeprom = <&factory 0x0>;
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -93,7 +93,8 @@ mediatek_setup_interfaces()
 	netgear,wax220|\
 	ubnt,unifi-6-plus|\
 	wavlink,wl-wn573hx3|\
-	zyxel,nwa50ax-pro)
+	zyxel,nwa50ax-pro|\
++	zyxel,nwa90ax-pro)
 		ucidef_set_interface_lan "eth0"
 		;;
 	cudy,m3000-v1|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -197,7 +197,8 @@ case "$board" in
 		addr=$(mtd_get_mac_binary factory 0x04)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr -0x300000) > /sys${DEVPATH}/macaddress
 		;;
-	zyxel,nwa50ax-pro)
+	zyxel,nwa50ax-pro|\
+	zyxel,nwa90ax-pro)
 		hw_mac_addr="$(mtd_get_mac_binary mrd 0x1fff8)"
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2156,3 +2156,21 @@ define Device/zyxel_nwa50ax-pro
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += zyxel_nwa50ax-pro
+
+define Device/zyxel_nwa90ax-pro
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := NWA90AX Pro
+  DEVICE_DTS := mt7981b-zyxel-nwa90ax-pro
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware zyxel-bootconfig
+  DEVICE_DTS_LOADADDR := 0x44000000
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 51200k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE) | zyxel-nwa-fit-filogic
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zyxel_nwa90ax-pro


### PR DESCRIPTION
Changes based on existing support for Zyxel NWA50AX PRO. Same hardware.
