### PR TITLE
ath79: add support for TCL HH41V

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ath79
+++ b/package/boot/uboot-tools/uboot-envtools/files/ath79
@@ -171,6 +171,7 @@ sophos,ap100|\
 sophos,ap100c)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
 	;;
+tcl,hh41v|\
 wallys,dr531)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0xf800" "0x10000"
 	;;

--- a/target/linux/ath79/dts/qca9531_tcl_hh41v.dts
+++ b/target/linux/ath79/dts/qca9531_tcl_hh41v.dts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tcl,hh40v", "qca,qca9531";
+	model = "TCL HH41V";
+
+	aliases {
+		label-mac-device = &wmac;
+		led-boot = &led_lan_link;
+		led-failsafe = &led_lan_link;
+		led-upgrade = &led_lan_link;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		lan_active {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan_link: lan_link {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_active {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_link {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "blue:wifi";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	/* Winbond W25Q256 SPI flash */
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "oem";
+				reg = <0x050000 0x100000>;
+				read-only;
+			};
+
+			partition@150000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x150000 0xea0000>;
+			};
+
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: cal@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-handle = <&swphy4>;
+};
+
+&eth1 {
+	compatible = "qca,qca9530-eth", "syscon", "simple-mfd";
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -20,6 +20,12 @@ alcatel,hh40v)
 	ucidef_set_led_netdev "wan_data" "WAN Data" "green:wan" "eth0" "tx rx"
 	ucidef_set_led_netdev "wan_link" "WAN Link" "orange:wan" "eth0" "link"
 	;;
+tcl,hh41v)
+	ucidef_set_led_netdev "lan_data" "LAN Data" "green:lan" "eth1" "tx rx"
+	ucidef_set_led_netdev "lan_link" "LAN Link" "orange:lan" "eth1" "link"
+	ucidef_set_led_netdev "wan_data" "WAN Data" "green:wan" "eth0" "tx rx"
+	ucidef_set_led_netdev "wan_link" "WAN Link" "orange:wan" "eth0" "link"
+	;;
 alfa-network,ap121f|\
 alfa-network,ap121fe|\
 alfa-network,wifi-camppro-nano-duo|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -247,6 +247,7 @@ ath79_setup_interfaces()
 			"0@eth0" "1:lan:1" "3:lan:4" "4:lan:3" "5:lan:2" "2:wan"
 		;;
 	alcatel,hh40v|\
+	tcl,hh41v|\
 	comfast,cf-e110n-v2|\
 	comfast,cf-e120a-v3|\
 	comfast,cf-e314n-v2|\

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -264,6 +264,18 @@ define Device/alcatel_hh40v
 endef
 TARGET_DEVICES += alcatel_hh40v
 
+define Device/tcl_hh41v
+  SOC := qca9531
+  DEVICE_VENDOR := TCL
+  DEVICE_MODEL := HH41V
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-serial-option kmod-usb-net-rndis
+  IMAGE_SIZE := 14976k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs
+endef
+TARGET_DEVICES += TCL_hh41v
+
 define Device/airtight_c-75
   SOC := qca9550
   DEVICE_VENDOR := AirTight Networks

--- a/target/linux/ath79/qca9531_alcatel_hh41v.dts
+++ b/target/linux/ath79/qca9531_alcatel_hh41v.dts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca953x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "alcatel,hh41v", "qca,qca9531";
+	model = "Alcatel HH41V";
+
+	aliases {
+		label-mac-device = &wmac;
+		led-boot = &led_lan_link;
+		led-failsafe = &led_lan_link;
+		led-upgrade = &led_lan_link;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		lan_active {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan_link: lan_link {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_active {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_link {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "blue:wifi";
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	/* Winbond W25Q256 SPI flash */
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+			};
+
+			partition@50000 {
+				label = "oem";
+				reg = <0x050000 0x100000>;
+				read-only;
+			};
+
+			partition@150000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x150000 0xea0000>;
+			};
+
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: cal@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+
+	phy-handle = <&swphy4>;
+};
+
+&eth1 {
+	compatible = "qca,qca9530-eth", "syscon", "simple-mfd";
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
+};


### PR DESCRIPTION
ath79: add support for TCL HH41V
The TCL HH41V is a CAT4 LTE router used by various ISPs.

Specifications
==============
SoC: QCA9531 650MHz
RAM: 128MiB
Flash: 32MiB SPI NOR
LAN: 1x 10/100MBit
WAN: 1x 10/100MBit
LTE: MDM9207 USB 2.0 (rndis configuration)
WiFi: 802.11n (SoC integrated)

it is almost the same as HH40v with a telephone port