### PR TITLE
linux-firmware: update to 20250627

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
-PKG_VERSION:=20250613
+PKG_VERSION:=20250627
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=d40743337ca8bf9d2587e220ab30dec6a07b52cc5cb4a4ff8d92be14391a7fde
+PKG_HASH:=edefb1d2a538367abf9558802fee3cd135ebb19a4a5890c8eefb3416a92a6b89
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
```
% git log --no-merges --pretty=oneline --abbrev-commit 20250613...20250627
cb826c70e912 WHENCE: extract license texts
db6e24385793 WHENCE: expand the advansys license statement
e8a4acb51210 WHENCE: some older AMD drivers are MIT licensed
ebbcfe361cbf qcom: update firmware binary for SM8550
09db581815f8 amdgpu: DMCUB updates for DCN401
c319d6bea7a6 qcom: venus-5.4: add the firmware binary for qcs615
dbfe16e9e8ac Revert "qcom: Add sdx61 Foxconn vendor firmware image file"
cbbce56d6dcc amdgpu: update dmcub fw for dcn401
8c091f4b0ec5 qcom: Add sdx61 Foxconn vendor firmware image file
1c4846b614e0 brcm: Fix symlinks for Khadas VIM SDIO wifi config
f191695a00ba amdgpu: update renoir firmware
c71a6daecc53 amdgpu: update vcn 5.0.0 firmware
72a8d25438c0 amdgpu: update smu 14.0.3 firmware
9f33f83a3245 amdgpu: update sdma 7.0.1 firmware
ef19800204dd amdgpu: update psp 14.0.3 firmware
103e235bafd0 amdgpu: update gc 12.0.1 firmware
f69dbbbd61b1 amdgpu: update navy flounder firmware
839067097384 amdgpu: update psp 14.0.4 firmware
0fde9638f26e amdgpu: update gc 11.5.2 firmware
128b759e5c8f amdgpu: update sienna cichlid firmware
94e718de8906 amdgpu: add raven2 ip discovery firmware
cbd24c08ceff amdgpu: update smu 14.0.2 firmware
fe7f99e3d01b amdgpu: update sdma 7.0.0 firmware
20e709912411 amdgpu: update psp 14.0.2 firmware
0e6cf73ebe2a amdgpu: update gc 12.0.0 firmware
00ce8ee06be2 amdgpu: update vcn 4.0.6 firmware
ed9525cb5743 amdgpu: update psp 14.0.1 firmware
cd7f739592db amdgpu: update gc 11.5.1 firmware
56accbf3cc71 amdgpu: update psp 13.0.11 firmware
03523034b0a5 amdgpu: update gc 11.0.4 firmware
1035014812d6 amdgpu: add picasso ip discovery firmware
7e14bde8ffdf amdgpu: add raven ip discovery firmware
2427860b84e9 amdgpu: update vega20 firmware
c354a0967253 amdgpu: update vega12 firmware
6e36b3917519 amdgpu: update smu 13.0.7 firmware
97e3e9cb4d96 amdgpu: update vcn 4.0.4 firmware
52f8bb5fd748 amdgpu: update psp 13.0.7 firmware
b2f81cf8dd1d amdgpu: update gc 11.0.2 firmware
46646de90c81 amdgpu: update navi14 firmware
6d59ec7d67dd amdgpu: update vega10 firmware
6a451a89f175 amdgpu: update gc 10.3.6 firmware
aa3e04655f08 amdgpu: update smu 13.0.10 firmware
97c3f575f445 amdgpu: update psp 13.0.10 firmware
c58be58dc9b4 amdgpu: update gc 11.0.3 firmware
403f1c578204 amdgpu: update navi12 firmware
a21004dd4edb amdgpu: update vangogh firmware
d45a9e3e51f5 amdgpu: update navi10 firmware
c70bcef9759d amdgpu: add smu 13.0.0 kicker firmware
c5077ee16e2c amdgpu: add psp 13.0.0 kicker firmware
25fbfc9a9fe6 amdgpu: add gc 11.0.0 kicker firmware
9fff2b17d3b1 amdgpu: add vcn 5.0.1 firmware
fea4ac9c76cb amdgpu: add sdma 4.4.4 firmware
8a9e3b47ef3d amdgpu: add psp 13.0.12 firmware
41e2f753b3a7 amdgpu: add gc 9.5.0 firmware
38945107950a amdgpu: add arcturus IP discovery firmware
49447aed4821 amdgpu: update vcn 4.0.0 firmware
734cc9b82e60 amdgpu: update smu 13.0.0 firmware
36934f24c008 amdgpu: update psp 13.0.0 firmware
464402529b3f amdgpu: update gc 11.0.0 firmware
1f9ea1b74498 amdgpu: update psp 13.0.14 firmware
877eed711964 amdgpu: update gc 9.4.4 firmware
a4a2882f0391 amdgpu: update psp 13.0.6 firmware
49105d8ee7e1 amdgpu: update gc 9.4.3 firmware
976433406ee3 amdgpu: update beige_goby firmware
3073095c049f amdgpu: update vcn 4.0.5 firmware
f2f8b021e7ca amdgpu: update gc 11.5.0 firmware
ad90939ad7a8 amdgpu: update vcn 4.0.2 firmware
6937d2e155c9 amdgpu: update gc 11.0.1 firmware
00198a7ab7a8 amdgpu: update dimgrey_cavefish firmware
95f5f3cc1044 amdgpu: update aldebaran firmware
b8369884e1db WHENCE: fix subtly incorrect licensing
a26e413e7481 amdgpu: update dmcub fw for dcn32 and dcn401
3c5341f382e0 mediatek: Update mt8186 SCP firmware
9096bad65cb9 amdgpu: Update DMCUB fw for DCN401 & DCN315
0a0b23e207c9 WHENCE: unify Driver statements
4cb2b59c30c2 qcom: add gpu firmwares for X1P42100 chipset
```
Build system: x86/64
Build-tested: x86/64
Run-tested: x86/64