### PR TITLE
realtek: rt-loader bootbase device enhancement

### DIFF
--- a/target/linux/realtek/image/rt-loader/include/globals.h
+++ b/target/linux/realtek/image/rt-loader/include/globals.h
@@ -11,6 +11,13 @@
 #define HEAP_SIZE		0x40000
 #define MEMORY_ALIGNMENT	32
 
+#define CP0_COUNT		$9
+#define CP0_COMPARE		$11
+#define CP0_STATUS		$12
+#define CP0_CAUSE		$13
+#define CP0_WATCHLO		$18
+#define CP0_WATCHHI		$19
+
 #define printf(fmt, ...)	npf_pprintf(board_putchar, NULL, fmt, ##__VA_ARGS__)
 #define snprintf		npf_snprintf
 

--- a/target/linux/realtek/image/rt-loader/src/board.c
+++ b/target/linux/realtek/image/rt-loader/src/board.c
@@ -21,10 +21,8 @@
 #define RTL93XX_CHIP_INFO_EN		0xa0000
 
 /*
- * board_putchar() is the central function to write to serial console of the device. Some printf
- * libraries (e.g. https://github.com/mpaland/printf) need a fixed function name like _putchar.
- * To keep the original library as is, link the two functions with gcc compiler option
- * -D_putchar=board_putchar
+ * board_putchar() is the central function to write to serial console of the device. This is
+ * linked to printf() and the provider library via globals.h.
  */
 
 void board_putchar(int ch, void *ctx)

--- a/target/linux/realtek/image/rt-loader/src/main.c
+++ b/target/linux/realtek/image/rt-loader/src/main.c
@@ -69,7 +69,7 @@ void welcome(void)
 
 	board_get_system(system, sizeof(system));
 
-	printf("rt-loader\n");
+	printf("\nrt-loader\n");
 	printf("Running on %s with %dMB\n", system, board_get_memory() >> 20);
 }
 

--- a/target/linux/realtek/image/rt-loader/src/startup.S
+++ b/target/linux/realtek/image/rt-loader/src/startup.S
@@ -14,6 +14,10 @@
 	add \reg, $t9
 .endm
 
+.macro  _EHB
+	sll     $zero, 3
+.endm
+
 	.section .text
 	.globl _start
 	.ent _start
@@ -28,6 +32,21 @@ _where_am_i:
 	move	$t9, $ra
 	subu	$t9, $t9, 0x8
 
+# This loader might be run in environments that are not properly initialized - e.g. ZyXEL
+# devices with BootBase loader. Be careful and setup the coprocessor registers.
+
+	mtc0	$zero, CP0_WATCHLO
+	mtc0	$zero, CP0_WATCHHI
+	mtc0	$zero, CP0_CAUSE
+	mfc0	$t0, CP0_STATUS
+	li	$t1, 0x1000001f
+	or	$t0, $t1
+	xori	$t0, 0x1f
+	mtc0	$t0, CP0_STATUS
+	_EHB
+	mtc0	$zero, CP0_COUNT
+	mtc0	$zero, CP0_COMPARE
+	_EHB
 
 # Check if this our first run (_kernel_load_addr = 0?)
 


### PR DESCRIPTION
Until now the rt-loader only works on U-Boot driven devices where the environment (e.g. coprocessor) is usually setup properly. Devices like the ZyXEL GS1920 series use BootBase as start environment and skip some of the basic initialization steps. rt-loader will fail in these cases. Take care about the CP0 registers.

Additionally enhance the documentation of the printf implementation. It was optimized during the different revisions of the initial PR.