### PR TITLE
hostapd: fix wpa_supplicant authentication failure on Raspberry Pi Zero 2W

### DIFF
--- a/package/network/services/hostapd/patches/805-wpa_supplicant-2.11-Revert-Mark-authorization-completed-on-driver-indica.patch
+++ b/package/network/services/hostapd/patches/805-wpa_supplicant-2.11-Revert-Mark-authorization-completed-on-driver-indica.patch
@@ -1,0 +1,53 @@
+Bug: https://bugs.gentoo.org/937452
+Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2302577
+
+From 071336247683d82a74f3567abf67a0b37db856ae Mon Sep 17 00:00:00 2001
+From: Christopher Byrne <salah.coronya@gmail.com>
+Date: Fri, 21 Feb 2025 18:58:19 -0600
+Subject: [PATCH] Revert "Mark authorization completed on driver indication
+ during 4-way HS offload"
+
+This reverts commit 41638606054a09867fe3f9a2b5523aa4678cbfa5.
+---
+ wpa_supplicant/events.c | 25 ++++++++-----------------
+ 1 file changed, 8 insertions(+), 17 deletions(-)
+
+diff --git a/wpa_supplicant/events.c b/wpa_supplicant/events.c
+index 49917f7aa..bbb3a3eda 100644
+--- a/wpa_supplicant/events.c
++++ b/wpa_supplicant/events.c
+@@ -4327,23 +4327,14 @@ static void wpa_supplicant_event_assoc(struct wpa_supplicant *wpa_s,
+ 		eapol_sm_notify_eap_success(wpa_s->eapol, true);
+ 	} else if ((wpa_s->drv_flags & WPA_DRIVER_FLAGS_4WAY_HANDSHAKE_PSK) &&
+ 		   wpa_key_mgmt_wpa_psk(wpa_s->key_mgmt)) {
+-		if (already_authorized) {
+-			/*
+-			 * We are done; the driver will take care of RSN 4-way
+-			 * handshake.
+-			 */
+-			wpa_supplicant_cancel_auth_timeout(wpa_s);
+-			wpa_supplicant_set_state(wpa_s, WPA_COMPLETED);
+-			eapol_sm_notify_portValid(wpa_s->eapol, true);
+-			eapol_sm_notify_eap_success(wpa_s->eapol, true);
+-		} else {
+-			/* Update port, WPA_COMPLETED state from the
+-			 * EVENT_PORT_AUTHORIZED handler when the driver is done
+-			 * with the 4-way handshake.
+-			 */
+-			wpa_msg(wpa_s, MSG_DEBUG,
+-				"ASSOC INFO: wait for driver port authorized indication");
+-		}
++		/*
++		 * We are done; the driver will take care of RSN 4-way
++		 * handshake.
++		 */
++		wpa_supplicant_cancel_auth_timeout(wpa_s);
++		wpa_supplicant_set_state(wpa_s, WPA_COMPLETED);
++		eapol_sm_notify_portValid(wpa_s->eapol, true);
++		eapol_sm_notify_eap_success(wpa_s->eapol, true);
+ 	} else if ((wpa_s->drv_flags & WPA_DRIVER_FLAGS_4WAY_HANDSHAKE_8021X) &&
+ 		   wpa_key_mgmt_wpa_ieee8021x(wpa_s->key_mgmt)) {
+ 		/*
+-- 
+2.45.3
+


### PR DESCRIPTION
add patch originally created by Christopher Byrne <salah.coronya@gmail.com> for Gentoo project
original subject: [PATCH] Revert "Mark authorization completed on driver indication during 4-way HS offload"

fix hostapd (wpa_supplicant) error on authentication on Raspberry Pi Zero 2W

error has been reproduced on official OpenWrt images:
- 24.10.0
- 24.10.1
- 24.10.2
- snapshot

Example of wpa_supplicant output on error
```
# wpa_supplicant -Dnl80211 -iphy0-sta0 -c/root/wpa_supplicant_test.conf
phy0-sta0: Associated with XX:XX:XX:XX:XX:XX
phy0-sta0: CTRL-EVENT-SUBNET-STATUS-UPDATE status=0
phy0-sta0: Authentication with XX:XX:XX:XX:XX:XX timed out.
phy0-sta0: Added BSSID XX:XX:XX:XX:XX:XX into ignore list, ignoring for 10 seconds
nl80211: send_event_marker failed: Source based routing not supported
phy0-sta0: CTRL-EVENT-DISCONNECTED bssid=XX:XX:XX:XX:XX:XX reason=3 locally_generated=1
phy0-sta0: BSSID XX:XX:XX:XX:XX:XX ignore list count incremented to 2, ignoring for 10 seconds
phy0-sta0: CTRL-EVENT-SSID-TEMP-DISABLED id=0 ssid="redacted" auth_failures=1 duration=10 reason=CONN_FAILED
```

tested on:
- sdk: `openwrt-sdk-24.10.0-bcm27xx-bcm2710_gcc-13.3.0_musl.Linux-x86_64`
- image from: `openwrt-imagebuilder-24.10.0-bcm27xx-bcm2710.Linux-x86_64`