### PR TITLE
kernel: allow seamless migration from I40EVF

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1268,6 +1268,7 @@ define KernelPackage/iavf
   TITLE:=Intel(R) Ethernet Adaptive Virtual Function support
   DEPENDS:=@PCI_SUPPORT +!LINUX_6_6:kmod-libie
   KCONFIG:= \
+       CONFIG_I40EVF \
        CONFIG_IAVF
   FILES:= \
        $(LINUX_DIR)/drivers/net/ethernet/intel/iavf/iavf.ko


### PR DESCRIPTION
Resolve the issue of seamless migration from I40EVF

link: https://github.com/openwrt/openwrt/pull/19197/files#r2173571237
Reported-and-Tested-by: Stefan Hellermann <[stefan@the2masters.de](mailto:stefan@the2masters.de)>

Signed-off-by: xiao bo <peterwillcn@gmail.com>