### PR TITLE
qualcommax: ipq807x: Xiaomi AX9000 add EMC2305 fan controller support

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
@@ -9,6 +9,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/leds/common.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	model = "Xiaomi AX9000";
@@ -121,6 +122,17 @@
 
 	pinctrl-0 = <&i2c_pins>;
 	pinctrl-names = "default";
+
+	emc2305@2f {
+		compatible = "microchip,emc2305";
+		reg = <0x2f>;
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+
+		fan@0 {
+			reg = <0>;
+		};
+	};
 };
 
 &prng {

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -468,7 +468,7 @@ define Device/xiaomi_ax9000
 	SOC := ipq8072
 	KERNEL_SIZE := 57344k
 	DEVICE_PACKAGES := ipq-wifi-xiaomi_ax9000 kmod-ath11k-pci ath11k-firmware-qcn9074 \
-		kmod-ath10k-ct ath10k-firmware-qca9887-ct
+		kmod-ath10k-ct ath10k-firmware-qca9887-ct kmod-hwmon-emc2305
 ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
 	ARTIFACTS := initramfs-factory.ubi
 	ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-uImage.itb | ubinize-kernel


### PR DESCRIPTION
The Xiaomi AX9000 router has an integrated 6cm cooling fan controlled by an EMC2305 fan controller. This commit adds support for it using the in-tree emc2305 driver.

The driver will create a hwmon interface at `/sys/class/hwmon/hwmonN`. On Xiaomi AX9000, the EMC2305 typically appears as hwmon12.

Fan speed can be adjusted by writing to the pwm1 control file, where <fan_pwm_speed> is an integer between 0-255.
```
echo <fan_pwm_speed> > /sys/class/hwmon/hwmonN/pwm1
```

Thanks for @devrus91's work in https://forum.openwrt.org/t/openwrt-support-for-xiaomi-ax9000/98908/1935

