### PR TITLE
mtd: fix potential NULL pointer dereference in jffs2.c

### DIFF
--- a/package/system/mtd/src/jffs2.c
+++ b/package/system/mtd/src/jffs2.c
@@ -81,6 +81,10 @@ static inline int rbytes(void)
 
 static inline void add_data(char *ptr, int len)
 {
+    if (ptr == NULL) {
+        fprintf(stderr, "Error: NULL pointer passed to add_data\\n");
+        return;
+    }
 	if (ofs + len > erasesize) {
 		pad(erasesize);
 		prep_eraseblock();


### PR DESCRIPTION
Fix a potential NULL pointer dereference in jffs2.c when a NULL pointer
is passed to add_data(). Previously, the code could cause undefined
behavior due to a memcpy() with a NULL source. This patch adds a NULL
check to prevent such issues and improve robustness.