### PR TITLE
hostapd: removed OSU support from configuration files

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -381,13 +381,6 @@
 			"type": "number",
 			"default": 60
 		},
-		"hs20_oper_friendly_name": {
-			"description": "Operator Friendly Name",
-			"type": "array",
-			"items": {
-				"type": "string"
-			}
-		},
 		"hs20_operating_class": {
 			"description": "Operating Class Indication",
 			"type": "string"
@@ -748,23 +741,6 @@
 		"okc": {
 			"description": "PMKSA and Opportunistic Key Caching",
 			"type": "boolean"
-		},
-		"operator_icon": {
-			"type": "array"
-		},
-		"osen": {
-			"description": "OSU Server-Only Authenticated L2 Encryption Network",
-			"type": "boolean",
-			"default": false
-		},
-		"osu_provider": {
-			"type": "array",
-			"items": {
-				"type": "string"
-			}
-		},
-		"osu_ssid": {
-			"type": "string"
 		},
 		"owe_transition": {
 			"description": "Indicate that an OWE BSS shall automatically add an unencrypted transition interface",

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -398,18 +398,11 @@ function iface_key_caching(config) {
 function iface_hs20(config) {
 	if (!config.hs20)
 		return;
-	
-	let uci = libuci.cursor();
-	let icons = uci.get_all('wireless');
-	for (let k, icon in icons)
-		if (icon['.type'] == 'hs20-icon')
-			append('hs20_icon', `${icon.width}:${icon.heigth}:${icon.lang}:${icon.type}:${k}:${icon.path}`);
 
 	append_vars(config, [
-		'hs20', 'disable_dgaf', 'osen', 'anqp_domain_id', 'hs20_deauth_req_timeout', 'osu_ssid', 
+		'hs20', 'disable_dgaf', 'anqp_domain_id', 'hs20_deauth_req_timeout',
 		'hs20_wan_metrics', 'hs20_operating_class', 'hs20_t_c_filename', 'hs20_t_c_timestamp',
-		'hs20_t_c_server_url', 'hs20_oper_friendly_name', 'hs20_conn_capab', 'osu_provider',
-		'operator_icon'
+		'hs20_t_c_server_url', 'hs20_conn_capab'
 	]);
 }
 

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -97,11 +97,6 @@ hostapd_append_wpa_key_mgmt() {
 			;;
 		esac
 	}
-
-	[ "$auth_osen" = "1" ] && {
-		append wpa_key_mgmt "OSEN"
-		[ "$rsn_override" -gt 0 ] && append rsn_override_key_mgmt OSEN
-	}
 }
 
 hostapd_add_log_config() {
@@ -377,14 +372,11 @@ hostapd_common_add_bss_config() {
 	config_add_array iw_roaming_consortium iw_domain_name iw_anqp_3gpp_cell_net iw_nai_realm
 	config_add_array iw_anqp_elem iw_venue_name iw_venue_url
 
-	config_add_boolean hs20 disable_dgaf osen
+	config_add_boolean hs20 disable_dgaf
 	config_add_int anqp_domain_id
 	config_add_int hs20_deauth_req_timeout
-	config_add_array hs20_oper_friendly_name
-	config_add_array osu_provider
-	config_add_array operator_icon
 	config_add_array hs20_conn_capab
-	config_add_string osu_ssid hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp
+	config_add_string hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp
 
 	config_add_string hs20_t_c_server_url
 
@@ -506,67 +498,6 @@ append_iw_venue_name() {
 
 append_iw_venue_url() {
 	append bss_conf "venue_url=$1" "$N"
-}
-
-append_hs20_oper_friendly_name() {
-	append bss_conf "hs20_oper_friendly_name=$1" "$N"
-}
-
-append_osu_provider_friendly_name() {
-	append bss_conf "osu_friendly_name=$1" "$N"
-}
-
-append_osu_provider_service_desc() {
-	append bss_conf "osu_service_desc=$1" "$N"
-}
-
-append_hs20_icon() {
-	local width height lang type path
-	config_get width "$1" width
-	config_get height "$1" height
-	config_get lang "$1" lang
-	config_get type "$1" type
-	config_get path "$1" path
-
-	append bss_conf "hs20_icon=$width:$height:$lang:$type:$1:$path" "$N"
-}
-
-append_hs20_icons() {
-	config_load wireless
-	config_foreach append_hs20_icon hs20-icon
-}
-
-append_operator_icon() {
-	append bss_conf "operator_icon=$1" "$N"
-}
-
-append_osu_icon() {
-	append bss_conf "osu_icon=$1" "$N"
-}
-
-append_osu_provider() {
-	local cfgtype osu_server_uri osu_friendly_name osu_nai osu_nai2 osu_method_list
-
-	config_load wireless
-	config_get cfgtype "$1" TYPE
-	[ "$cfgtype" != "osu-provider" ] && return
-
-	append bss_conf "# provider $1" "$N"
-	config_get osu_server_uri "$1" osu_server_uri
-	config_get osu_nai "$1" osu_nai
-	config_get osu_nai2 "$1" osu_nai2
-	config_get osu_method_list "$1" osu_method
-
-	append bss_conf "osu_server_uri=$osu_server_uri" "$N"
-	append bss_conf "osu_nai=$osu_nai" "$N"
-	append bss_conf "osu_nai2=$osu_nai2" "$N"
-	append bss_conf "osu_method_list=$osu_method_list" "$N"
-
-	config_list_foreach "$1" osu_service_desc append_osu_provider_service_desc
-	config_list_foreach "$1" osu_friendly_name append_osu_friendly_name
-	config_list_foreach "$1" osu_icon append_osu_icon
-
-	append bss_conf "$N"
 }
 
 append_hs20_conn_capab() {
@@ -1185,35 +1116,28 @@ hostapd_set_bss_options() {
 	esac
 	[ -n "$iw_qos_map_set" ] && append bss_conf "qos_map_set=$iw_qos_map_set" "$N"
 
-	local hs20 disable_dgaf osen anqp_domain_id hs20_deauth_req_timeout \
-		osu_ssid hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp \
+	local hs20 disable_dgaf anqp_domain_id hs20_deauth_req_timeout \
+		hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp \
 		hs20_t_c_server_url
-	json_get_vars hs20 disable_dgaf osen anqp_domain_id hs20_deauth_req_timeout \
-		osu_ssid hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp \
+	json_get_vars hs20 disable_dgaf anqp_domain_id hs20_deauth_req_timeout \
+		hs20_wan_metrics hs20_operating_class hs20_t_c_filename hs20_t_c_timestamp \
 		hs20_t_c_server_url
 
 	set_default hs20 0
 	set_default disable_dgaf $hs20
-	set_default osen 0
 	set_default anqp_domain_id 0
 	set_default hs20_deauth_req_timeout 60
 	if [ "$hs20" = "1" ]; then
 		append bss_conf "hs20=1" "$N"
-		append_hs20_icons
 		append bss_conf "disable_dgaf=$disable_dgaf" "$N"
-		append bss_conf "osen=$osen" "$N"
 		append bss_conf "anqp_domain_id=$anqp_domain_id" "$N"
 		append bss_conf "hs20_deauth_req_timeout=$hs20_deauth_req_timeout" "$N"
-		[ -n "$osu_ssid" ] && append bss_conf "osu_ssid=$osu_ssid" "$N"
 		[ -n "$hs20_wan_metrics" ] && append bss_conf "hs20_wan_metrics=$hs20_wan_metrics" "$N"
 		[ -n "$hs20_operating_class" ] && append bss_conf "hs20_operating_class=$hs20_operating_class" "$N"
 		[ -n "$hs20_t_c_filename" ] && append bss_conf "hs20_t_c_filename=$hs20_t_c_filename" "$N"
 		[ -n "$hs20_t_c_timestamp" ] && append bss_conf "hs20_t_c_timestamp=$hs20_t_c_timestamp" "$N"
 		[ -n "$hs20_t_c_server_url" ] && append bss_conf "hs20_t_c_server_url=$hs20_t_c_server_url" "$N"
-		json_for_each_item append_hs20_oper_friendly_name hs20_oper_friendly_name
 		json_for_each_item append_hs20_conn_capab hs20_conn_capab
-		json_for_each_item append_osu_provider osu_provider
-		json_for_each_item append_operator_icon operator_icon
 	fi
 
 	if [ "$eap_server" = "1" ]; then

--- a/package/network/config/wifi-scripts/files/lib/netifd/netifd-wireless.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/netifd-wireless.sh
@@ -308,12 +308,6 @@ wireless_vif_parse_encryption() {
 			esac
 		;;
 	esac
-
-	case "$encryption" in
-		*osen*)
-			auth_osen=1
-		;;
-	esac
 }
 
 _wireless_set_brsnoop_isolation() {


### PR DESCRIPTION
Hi boys,

In the last hostapd sync support for OSEN was removed but not removed from the OpenWRT configuration.

So, who has been using this has had problems to get the WiFi up if he did not clean the configuration before.

Therefore, this commit is to clean all OSEN remnants from the configuration files.

Can you test? @badnbusy

Link (upstream): https://w1.fi/cgit/hostap/commit/hostapd?id=e835288592fd672469f46dc35a03e64115b996e5
Link (upstream): https://w1.fi/cgit/hostap/commit/hostapd?id=7bb11e35d55e3d50199efc45921e76696bebd8ef

Fixes: https://github.com/openwrt/openwrt/issues/19142

Regards, Agustin