### PR TITLE
[openwrt-24.10] rockchip: fix eMMC corruption on NanoPC-T6 with A3A444 chips

### DIFF
--- a/target/linux/rockchip/patches-6.6/131-arm64-dts-rockchip-rk3588-fix-A3A444-nanopc-t6.patch
+++ b/target/linux/rockchip/patches-6.6/131-arm64-dts-rockchip-rk3588-fix-A3A444-nanopc-t6.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Grzegorz Sterniczuk <grzegorz@sternicz.uk>
+Date: Mon, 21 Jul 2025 23:24:11 +0200
+Subject: rockchip: fix eMMC corruption on NanoPC-T6 with A3A444 chips
+
+Some NanoPC-T6 boards with A3A444 eMMC chips experience I/O errors and
+corruption when using HS400 mode. Downgrade to HS200 mode to ensure
+stable operation.
+
+Fixes: #18844
+Signed-off-by: Grzegorz Sterniczuk <grzegorz@sternicz.uk>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -621,8 +621,7 @@
+ 	no-sd;
+ 	non-removable;
+ 	max-frequency = <200000000>;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
++	mmc-hs200-1_8v;
+ 	status = "okay";
+ };
+ 


### PR DESCRIPTION
Some NanoPC-T6 boards with A3A444 eMMC chips experience I/O errors and corruption when using HS400 mode. Downgrade to HS200 mode to ensure stable operation.

Fixes: #18844