### PR TITLE
imagebuilder: implement STRIP_ABI option for manifest target

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -168,7 +168,8 @@ _call_manifest: FORCE
 ifeq ($(CONFIG_USE_APK),)
 	$(OPKG) list-installed $(if $(STRIP_ABI),--strip-abi)
 else
-	$(APK) list --quiet --manifest --no-network
+	$(APK) query --format json --fields name,version,$(if $(STRIP_ABI),tags) --installed '*' | \
+		$(SCRIPT_DIR)/make-index-json.py -a $(ARCH_PACKAGES) -f apk --manifest -
 endif
 
 package_index: FORCE


### PR DESCRIPTION
When using apk as the package manager, imagebuilder make command

    make manifest STRIP_ABI=1

does not strip package names of their ABI-version suffix.  The ASU server relies on this to validate builds, so many snapshot build requests are failing.

Fix this by using the already existing package data parser in make-index-json.py and augment it to write the result in manifest format.

Fixes: https://github.com/openwrt/openwrt/issues/19274