### PR TITLE
config: cleanup kernel FS ACL/xattr options

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1239,7 +1239,7 @@ config KERNEL_NF_CONNTRACK_TIMEOUT
 	   Increases the (uncompressed) size of nf_conntrack.ko by ~8kB.
 
 #
-# NFS related symbols
+# Filesystem related symbols
 #
 config KERNEL_IP_PNP
 	bool "Compile the kernel with rootfs on NFS"
@@ -1278,6 +1278,9 @@ config KERNEL_BTRFS_FS
 	  Say Y here if you want to make the kernel to be able to boot off a
 	  BTRFS partition.
 
+menu "Filesystem ACL and xattr support options"
+	config USE_FS_ACL_XATTR
+		bool "Use filesystem ACLs and xattr support by default"
 config KERNEL_EROFS_FS
 	bool "Compile the kernel with built-in EROFS support"
 	help
@@ -1303,70 +1306,89 @@ menu "Filesystem ACL and attr support options"
 		  Make using ACLs (e.g. POSIX ACL, NFSv4 ACL) the default
 		  for kernel and packages, except old NFS.
 		  Also enable userspace extended attribute support
-		  by default.  (OpenWrt already has an expection it will be
+		  by default.  (OpenWrt already has an expectation it will be
 		  present in the kernel).
 
 	config KERNEL_FS_POSIX_ACL
 		bool "Enable POSIX ACL support"
-		default y if USE_FS_ACL_ATTR
+		default y if USE_FS_ACL_XATTR
 
 	config KERNEL_BTRFS_FS_POSIX_ACL
-		bool "Enable POSIX ACL for BtrFS Filesystems"
+		bool "Enable POSIX ACL for BtrFS"
 		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
+		default y if USE_FS_ACL_XATTR
 
 	config KERNEL_EROFS_FS_POSIX_ACL
 		bool "Enable POSIX ACL for EROFS Filesystems"
 		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
+		default y if USE_FS_ACL_XATTR
 
 	config KERNEL_EXT4_FS_POSIX_ACL
-		bool "Enable POSIX ACL for Ext4 Filesystems"
+		bool "Enable POSIX ACLs for Ext4"
 		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
+		default y if USE_FS_ACL_XATTR
 
 	config KERNEL_F2FS_FS_POSIX_ACL
-		bool "Enable POSIX ACL for F2FS Filesystems"
+		bool "Enable POSIX ACLs for F2FS"
 		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
+		default y if USE_FS_ACL_XATTR
+
+    config KERNEL_F2FS_FS_XATTR
+    	bool "Enable XATTR for F2FS"
+    	default y if USE_FS_ACL_XATTR
 
 	config KERNEL_JFFS2_FS_POSIX_ACL
-		bool "Enable POSIX ACL for JFFS2 Filesystems"
+		bool "Enable POSIX ACLs for JFFS2"
 		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
+		default y if USE_FS_ACL_XATTR
+
+    config KERNEL_JFFS2_FS_XATTR
+    	bool "Enable XATTR for JFFS2"
+        default y if USE_FS_ACL_XATTR
 
 	config KERNEL_TMPFS_POSIX_ACL
-		bool "Enable POSIX ACL for TMPFS Filesystems"
+		bool "Enable POSIX ACLs for TMPFS"
 		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
+		default y if USE_FS_ACL_XATTR
 
 	config KERNEL_NFS_ACL_SUPPORT
-		bool "Enable ACLs for NFS"
-		default y if USE_FS_ACL_ATTR
+		bool "Enable POSIX ACLs for NFS"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_XATTR
 
 	config KERNEL_NFS_V3_ACL
-		bool "Enable ACLs for NFSv3"
+		bool "Enable POSIX ACLs for NFSv3"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_XATTR
 
 	config KERNEL_NFSD_V2_ACL
-		bool "Enable ACLs for NFSDv2"
+		bool "Enable POSIX ACLs for NFSDv2"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_XATTR
 
 	config KERNEL_NFSD_V3_ACL
-		bool "Enable ACLs for NFSDv3"
+		bool "Enable POSIX ACLs for NFSDv3"
+		select KERNEL_FS_POSIX_ACL
+		default y if USE_FS_ACL_XATTR
 
 	config KERNEL_REISERFS_FS_POSIX_ACL
 		bool "Enable POSIX ACLs for ReiserFS"
 		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
+		default y if USE_FS_ACL_XATTR
 
 	config KERNEL_XFS_POSIX_ACL
 		bool "Enable POSIX ACLs for XFS"
 		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
+		default y if USE_FS_ACL_XATTR
 
 	config KERNEL_JFS_POSIX_ACL
 		bool "Enable POSIX ACLs for JFS"
 		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
+		default y if USE_FS_ACL_XATTR
+
+    config KERNEL_SQUASHFS_XATTR
+        bool "Enable XATTR for Squashfs"
+	    default y if USE_FS_ACL_XATTR
 
 endmenu
 
@@ -1382,8 +1404,6 @@ config KERNEL_SQUASHFS_FRAGMENT_CACHE_SIZE
 	default 2 if (SMALL_FLASH && !LOW_MEMORY_FOOTPRINT)
 	default 3
 
-config KERNEL_SQUASHFS_XATTR
-	bool "Squashfs XATTR support"
 
 #
 # compile optimization setting

--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1340,35 +1340,20 @@ menu "Filesystem ACL and attr support options"
 		select KERNEL_FS_POSIX_ACL
 		default y if USE_FS_ACL_ATTR
 
-	config KERNEL_CIFS_ACL
-		bool "Enable CIFS ACLs"
-		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
-
-	config KERNEL_HFS_FS_POSIX_ACL
-		bool "Enable POSIX ACL for HFS Filesystems"
-		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
-
-	config KERNEL_HFSPLUS_FS_POSIX_ACL
-		bool "Enable POSIX ACL for HFS+ Filesystems"
-		select KERNEL_FS_POSIX_ACL
-		default y if USE_FS_ACL_ATTR
-
 	config KERNEL_NFS_ACL_SUPPORT
 		bool "Enable ACLs for NFS"
 		default y if USE_FS_ACL_ATTR
 
-	config KERNEL_NFS_V3_ACL_SUPPORT
+	config KERNEL_NFS_V3_ACL
 		bool "Enable ACLs for NFSv3"
 
-	config KERNEL_NFSD_V2_ACL_SUPPORT
+	config KERNEL_NFSD_V2_ACL
 		bool "Enable ACLs for NFSDv2"
 
-	config KERNEL_NFSD_V3_ACL_SUPPORT
+	config KERNEL_NFSD_V3_ACL
 		bool "Enable ACLs for NFSDv3"
 
-	config KERNEL_REISER_FS_POSIX_ACL
+	config KERNEL_REISERFS_FS_POSIX_ACL
 		bool "Enable POSIX ACLs for ReiserFS"
 		select KERNEL_FS_POSIX_ACL
 		default y if USE_FS_ACL_ATTR


### PR DESCRIPTION
Cleans-up and improve the filesystem ACL and xattr kernel config
options by addressing inconsistencies, removing obsolete symbols, and
better aligning/syncing with kernel v6.6.

Key changes:
* Dropped deprecated/removed options:

  * `KERNEL_CIFS_ACL` (removed upstream since v5.3)
  * `KERNEL_HFSPLUS_FS_POSIX_ACL` (removed since v4.7)
  * `KERNEL_HFS_FS_POSIX_ACL` (never existed in either kernel or openwrt?)

* Fixed incorrect ACL config names:

  * `NFSD_V2_ACL_SUPPORT` to `NFSD_V2_ACL`
  * `NFSD_V3_ACL_SUPPORT` to `NFSD_V3_ACL`
  * `NFS_V3_ACL_SUPPORT` to `NFS_V3_ACL`
  * `REISER_FS_POSIX_ACL` to `REISERFS_FS_POSIX_ACL`

* Standardized and expanded the "Filesystem ACL and xattr support options" menu:

  * Renamed `USE_FS_ACL_ATTR` to `USE_FS_ACL_XATTR` for clarity
  * Changed all "attr" references to "xattr"
  * Moved `KERNEL_SQUASHFS_XATTR` into the submenu
  * Added xattr support options for JFFS2 and F2FS
  * Ensured all ACL options select `KERNEL_FS_POSIX_ACL`
  * Enabled several ACL/xattr options by default when `USE_FS_ACL_XATTR` is set

I have not tested but but everything compiles fine.
I found no other usages of any of the effected symbols within OpenWRT or the standard feeds.