### PR TITLE
scripts/feeds: do not call refresh_config() at end of update()

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -875,8 +875,6 @@ sub update {
 		};
 	}
 
-	refresh_config();
-
 	return $failed;
 }
 


### PR DESCRIPTION
refresh_config() purges undefined symbols from the config. However, if you have feeds A and B and packages from feed B depend on packages from feed A and your config has symbols set for packages from B (and therewith implicitly also from feed A), those symbols get purged from config during `feed update`.

That is, because at the time of parsing and evaluating packages from feed B, symlinks for packages from feed A are not yet installed, which causes unfulfilled dependencies for packages from feed B.

However, the commit having introduced the refresh_config() call (0e158467a4a56cef517429787d132a8a1d6e4f2d from 2008) is covering something larger and I'm not sure I understand the entirety of it. Also, removing that single call to refresh_config() might also only be a tiny workaround to a bigger problem. Hence the "DO NOT MERGE", but rather initiating a discussion.

Also I wonder how the issue did not yet pop up with e.g. packages in luci depending on packages from the packages-feed. Or packages from routing depending on the packages feed.