### PR TITLE
openssl: update to 3.5.1

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.5.0
+PKG_VERSION:=3.5.1
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -21,7 +21,7 @@ PKG_SOURCE_URL:= \
 	https://www.openssl.org/source/old/$(PKG_BASE)/ \
 	https://github.com/openssl/openssl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 
-PKG_HASH:=344d0a79f1a9b08029b0744e2cc401a43f9c90acd1044d09a530b4885a8e9fc0
+PKG_HASH:=529043b15cffa5f36077a4d0af83f3de399807181d607441d734196d889b641f
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE

--- a/package/libs/openssl/patches/100-Configure-afalg-support.patch
+++ b/package/libs/openssl/patches/100-Configure-afalg-support.patch
@@ -10,7 +10,7 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
 --- a/Configure
 +++ b/Configure
-@@ -1810,7 +1810,9 @@ $config{CFLAGS} = [ map { $_ eq '--ossl-
+@@ -1811,7 +1811,9 @@ $config{CFLAGS} = [ map { $_ eq '--ossl-
  
  unless ($disabled{afalgeng}) {
      $config{afalgeng}="";


### PR DESCRIPTION
Automatically rebased: 100-Configure-afalg-support.patch

Changes between 3.5.0 and 3.5.1:
Fix x509 application adds trusted use instead of rejected use. Issue summary: Use of -addreject option with the openssl x509 application adds a trusted use instead of a rejected use for a certificate.

Impact summary: If a user intends to make a trusted certificate rejected for a particular use it will be instead marked as trusted for that use. (CVE-2025-4575)

Aligned the behaviour of TLS and DTLS in the event of a no_renegotiation alert being received. Older versions of OpenSSL failed with DTLS if a no_renegotiation alert was received. All versions of OpenSSL do this for TLS. From 3.2 a bug was exposed that meant that DTLS ignored no_rengotiation. We have now restored the original behaviour and brought DTLS back into line with TLS.