### PR TITLE
config: bring BLK_CGROUP options inline kernel v6.6

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1042,7 +1042,7 @@ if KERNEL_CGROUPS
 	endif
 
 	config KERNEL_BLK_CGROUP
-		bool "Block IO controller"
+		bool "IO controller"
 		default y
 		help
 		  Generic block IO controller cgroup interface. This is the common
@@ -1062,24 +1062,33 @@ if KERNEL_CGROUPS
 
 	if KERNEL_BLK_CGROUP
 
-		config KERNEL_CFQ_GROUP_IOSCHED
-			bool "Proportional weight of disk bandwidth in CFQ"
+		config KERNEL_BLK_CGROUP_RWSTAT
+			bool
 
 		config KERNEL_BLK_DEV_THROTTLING
-			bool "Enable throttling policy"
+			bool "Block layer bio throttling support"
 			default y
+			select KERNEL_BLK_CGROUP_RWSTAT
+			help
+			  Block layer bio throttling support. It can be used to limit
+			  the IO rate to a device. IO rate policies are per cgroup and
+			  one needs to mount and use blkio cgroup controller for creating
+			  cgroups and specifying per device IO rate policies.
+
+			  See Documentation/admin-guide/cgroup-v1/blkio-controller.rst for more information.
 
 		config KERNEL_BLK_DEV_THROTTLING_LOW
 			bool "Block throttling .low limit interface support (EXPERIMENTAL)"
 			depends on KERNEL_BLK_DEV_THROTTLING
-	endif
+			help
+			  Add .low limit interface for block throttling. The low limit is a best
+			  effort limit to prioritize cgroups. Depending on the setting, the limit
+			  can be used to protect cgroups in terms of bandwidth/iops and better
+			  utilize disk resource.
 
-	config KERNEL_DEBUG_BLK_CGROUP
-		bool "Enable Block IO controller debugging"
-		depends on KERNEL_BLK_CGROUP
-		help
-		  Enable some debugging help. Currently it exports additional stat
-		  files in a cgroup which can be useful for debugging.
+			  Note, this is an experimental interface and could be changed someday.
+
+	endif
 
 	config KERNEL_NET_CLS_CGROUP
 		bool "legacy Control Group Classifier"


### PR DESCRIPTION
The current BLK_CGROUP-related options are outdated and have been since kernel v4.5. This PR updates those options to reflect kernel v6.6.

Relevant change as of kernel v6.6:
- The prompt for BLK_CGROUP was renamed from "Block IO controller" to "IO controller" in v4.5 (a0166ec4b099)
- CFQ_GROUP_IOSCHED was removed in v5.0 (f382fb0bcef4)
- DEBUG_BLK_CGROUP was renamed to BFQ_CGROUP_DEBUG in v5.3 (8060c47ba853)
- BLK_CGROUP_RWSTAT was introduced and is now selected by BLK_DEV_THROTTLING in v5.5 (1d156646e0d8)

Update the configuration to reflect kernel v6.6:
- Rename BLK_CGROUP prompt to "IO controller"
- Remove deprecated KERNEL_CFQ_GROUP_IOSCHED
- Remove renamed KERNEL_DEBUG_BLK_CGROUP as we have no other BFQ symbols
- Add new KERNEL_BLK_CGROUP_RWSTAT option
- Make KERNEL_BLK_DEV_THROTTLING select KERNEL_BLK_CGROUP_RWSTAT
- Add missing help text for KERNEL_BLK_DEV_THROTTLING and KERNEL_BLK_DEV_THROTTLING_LOW

No other usage of any of these symbols where found with the exception of CFQ_GROUP_IOSCHED in dockerd which I will open a pr for.
