### PR TITLE
config: drop kernel config symbols removed before kernel v6.6

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -137,13 +137,6 @@ config KERNEL_UBSAN_BOUNDS
 	  {str,mem}*cpy() family of functions (that is addressed by
 	  FORTIFY_SOURCE).
 
-config KERNEL_UBSAN_NULL
-	bool "Enable checking of null pointers"
-	depends on KERNEL_UBSAN
-	help
-	  This option enables detection of memory accesses via a
-	  null pointer.
-
 config KERNEL_UBSAN_TRAP
 	bool "On Sanitizer warnings, abort the running kernel code"
 	depends on KERNEL_UBSAN
@@ -498,16 +491,10 @@ config KERNEL_FRAME_WARN
 # KConfig wont evaluate them unless KERNEL_EARLY_PRINTK is selected
 # which means that buildroot wont override the DEBUG_LL symbols in target
 # kernel configurations and lead to devices that dont have working console
-config KERNEL_DEBUG_LL_UART_NONE
-	bool
-	default n
-	depends on arm
-
 config KERNEL_DEBUG_LL
 	bool
 	default n
 	depends on arm
-	select KERNEL_DEBUG_LL_UART_NONE
 	help
 	  ARM low level debugging.
 
@@ -743,11 +730,6 @@ config KERNEL_SLUB_DEBUG_ON
 	  This enables by default sanity_checks, red_zone, poison and store_user
 	  debugging options for all caches.
 
-config KERNEL_SLABINFO
-	select KERNEL_SLUB_DEBUG
-	select KERNEL_SLUB_DEBUG_ON
-	bool "Enable /proc slab debug info"
-
 config KERNEL_STACKDEPOT_MAX_FRAMES
 	int
 	default 64
@@ -900,22 +882,10 @@ if KERNEL_CGROUPS
 		  Provides a simple Resource Controller for monitoring the
 		  total CPU consumed by the tasks in a cgroup.
 
-	config KERNEL_RESOURCE_COUNTERS
-		bool "Resource counters"
-		default y
-		help
-		  This option enables controller independent resource accounting
-		  infrastructure that works with cgroups.
-
-	config KERNEL_MM_OWNER
-		bool
-		default y if KERNEL_MEMCG
-
 	config KERNEL_MEMCG
 		bool "Memory Resource Controller for Control Groups"
 		default y
 		select KERNEL_FREEZER
-		depends on KERNEL_RESOURCE_COUNTERS
 		help
 		  Provides a memory resource controller that manages both anonymous
 		  memory and page cache. (See Documentation/cgroups/memory.txt)
@@ -934,40 +904,6 @@ if KERNEL_CGROUPS
 
 		  This config option also selects MM_OWNER config option, which
 		  could in turn add some fork/exit overhead.
-
-	config KERNEL_MEMCG_SWAP
-		bool "Memory Resource Controller Swap Extension"
-		default y
-		depends on KERNEL_MEMCG
-		help
-		  Add swap management feature to memory resource controller. When you
-		  enable this, you can limit mem+swap usage per cgroup. In other words,
-		  when you disable this, memory resource controller has no cares to
-		  usage of swap...a process can exhaust all of the swap. This extension
-		  is useful when you want to avoid exhaustion swap but this itself
-		  adds more overheads and consumes memory for remembering information.
-		  Especially if you use 32bit system or small memory system, please
-		  be careful about enabling this. When memory resource controller
-		  is disabled by boot option, this will be automatically disabled and
-		  there will be no overhead from this. Even when you set this config=y,
-		  if boot option "swapaccount=0" is set, swap will not be accounted.
-		  Now, memory usage of swap_cgroup is 2 bytes per entry. If swap page
-		  size is 4096bytes, 512k per 1Gbytes of swap.
-
-	config KERNEL_MEMCG_SWAP_ENABLED
-		bool "Memory Resource Controller Swap Extension enabled by default"
-		depends on KERNEL_MEMCG_SWAP
-		help
-		  Memory Resource Controller Swap Extension comes with its price in
-		  a bigger memory consumption. General purpose distribution kernels
-		  which want to enable the feature but keep it disabled by default
-		  and let the user enable it by swapaccount boot command line
-		  parameter should have this option unselected.
-
-		  Those who want to have the feature enabled by default should
-		  select this option (if, for some reason, they need to disable it,
-		  then swapaccount=0 does the trick).
-
 
 	config KERNEL_MEMCG_KMEM
 		bool "Memory Resource Controller Kernel Memory accounting (EXPERIMENTAL)"
@@ -1139,16 +1075,6 @@ if KERNEL_NAMESPACES
 		  of the network stack.
 
 endif
-
-config KERNEL_DEVPTS_MULTIPLE_INSTANCES
-	bool "Support multiple instances of devpts"
-	default y if !SMALL_FLASH
-	help
-	  Enable support for multiple instances of devpts filesystem.
-	  If you want to have isolated PTY namespaces (eg: in containers),
-	  say Y here. Otherwise, say N. If enabled, each mount of devpts
-	  filesystem with the '-o newinstance' option will create an
-	  independent PTY namespace.
 
 config KERNEL_POSIX_MQUEUE
 	bool "POSIX Message Queues"
@@ -1444,13 +1370,6 @@ config KERNEL_DEVMEM
 	  The /dev/mem device is used to access areas of physical
 	  memory.
 
-config KERNEL_DEVKMEM
-	bool "/dev/kmem virtual device support"
-	help
-	  Say Y here if you want to support the /dev/kmem device. The
-	  /dev/kmem device is rarely used, but can be used for certain
-	  kind of kernel debugging operations.
-
 config KERNEL_SQUASHFS_FRAGMENT_CACHE_SIZE
 	int "Number of squashfs fragments cached"
 	default 2 if (SMALL_FLASH && !LOW_MEMORY_FOOTPRINT)
@@ -1500,10 +1419,6 @@ config KERNEL_SECURITY_SELINUX_BOOTPARAM
 	bool "NSA SELinux boot parameter"
 	depends on KERNEL_SECURITY_SELINUX
 	default y
-
-config KERNEL_SECURITY_SELINUX_DISABLE
-	bool "NSA SELinux runtime disable"
-	depends on KERNEL_SECURITY_SELINUX
 
 config KERNEL_SECURITY_SELINUX_DEVELOP
 	bool "NSA SELinux Development Support"


### PR DESCRIPTION
The current kernel config has a lot of options that have been removed by kernel 6.6. Since we don't support any kernel versions below v6.6 this PR removes these options.

This commit removes the following obsolete kernel config options:
- KERNEL_UBSAN_NULL: Removed in v4.18 (3ca17b1f3628)
- KERNEL_DEBUG_LL_UART_NONE: Removed in v4.0 (6f5194553c84)
- KERNEL_SLABINFO: Removed in v4.15 (5b36577109be)
- KERNEL_RESOURCE_COUNTERS: Removed in v3.18 (5b1efc027c0b)
- KERNEL_MM_OWNER: Removed in v3.16 (f98bafa06a28)
- KERNEL_MEMCG_SWAP: Removed in v6.1 (e55b9f96860f)
- KERNEL_MEMCG_SWAP_ENABLED: Removed in v5.7 (2d1c498072de)
- KERNEL_DEVPTS_MULTIPLE_INSTANCES: Removed in v4.7 (eedf265aa003)
- KERNEL_DEVKMEM: Removed in v5.13 (bbcd53c96071)
- KERNEL_SECURITY_SELINUX_DISABLE: Removed in v6.4 (f22f9aaf6c3d)

I couldn't find any other usage for any of these symbols with the exception of the lxc package which uses DEVPTS_MULTIPLE_INSTANCES. I will open a pr in the packages repo to address this.