### PR TITLE
[24.10] mediatek: spinand: force update_cache_variants to use reset for FORESEE spi nand

### DIFF
--- a/target/linux/mediatek/patches-6.6/411-mtd-spinand-fix-support-for-FORESEE.patch
+++ b/target/linux/mediatek/patches-6.6/411-mtd-spinand-fix-support-for-FORESEE.patch
@@ -1,0 +1,19 @@
+Force update_cache_variants to use reset for Foresee NAND with bad blocks
+
+Tested on Xiaomi AX3000T + F35SQA001G with bad blocks and without bad blocks
+
+Signed-off-by: Dim Fish <dimfish@gmail.com>
+
+--- a/drivers/mtd/nand/spi/foresee.c
++++ b/drivers/mtd/nand/spi/foresee.c
+@@ -22,8 +22,8 @@ static SPINAND_OP_VARIANTS(write_cache_v
+ 		SPINAND_PROG_LOAD(true, 0, NULL, 0));
+ 
+ static SPINAND_OP_VARIANTS(update_cache_variants,
+-		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
+-		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++		SPINAND_PROG_LOAD_X4(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD(true, 0, NULL, 0));
+ 
+ static int f35sqa002g_ooblayout_ecc(struct mtd_info *mtd, int section,
+ 				    struct mtd_oob_region *region)


### PR DESCRIPTION
Force update_cache_variantsvariants to use reset for Foresee NAND with bad blocks.

Fixes: https://github.com/openwrt/openwrt/issues/17962

Build- and run-tested.

P.S. U-Boot patch hasn't been cherry-picked since OpenWrt U-Boot 24.10 has no FORESEE spi nand support.