### PR TITLE
ath79: ubnt-amplifi-hd: Add 2nd USB bus (integrated ath3k bluetooth)

### DIFF
--- a/target/linux/ath79/dts/qca9563_ubnt_amplifi-router-hd.dts
+++ b/target/linux/ath79/dts/qca9563_ubnt_amplifi-router-hd.dts
@@ -192,6 +192,14 @@
 	status = "okay";
 };
 
+&usb_phy1 {
+	status = "okay";
+};
+
 &usb0 {
+	status = "okay";
+};
+
+&usb1 {
 	status = "okay";
 };


### PR DESCRIPTION
Add/enable 2nd USB bus (integrated ath3k bluetooth) to dts. This already exists in the qca956x dtsi, adding the pointer here to bring the bluetooth to life.

The 2nd bus hosts the integrated bluetooth at 0x1b400000.

See #c5b7ec in the comments for more info

Tested-by: Russ Innes russ.innes@gmail.com on Ubiquiti Amplifi HD .

Signed-off-by: Russ Innes <russ.innes@gmail.com>