### PR TITLE
mediatek: add Huasifei WH3000 Pro support

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-huasifei-wh3000-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-huasifei-wh3000-pro.dts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "Huasifei WH3000 Pro";
+	compatible = "huasifei,wh3000-pro", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_sys_red;
+		led-failsafe = &led_sys_red;
+		led-running = &led_sys_blue;
+		led-upgrade = &led_sys_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=PARTLABEL=rootfs rootwait";
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		modem-power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <0>;
+			gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		mode {
+			label = "mode";
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_sys_red: led-0 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sys_blue: led-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy1>;
+
+		nvmem-cells = <&macaddr_factory_4 2>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cells = <&macaddr_factory_4 3>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&mdio_bus {
+	phy1: ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <1>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		interrupts = <38 IRQ_TYPE_LEVEL_LOW>;
+		interrupt-parent = <&pio>;
+		realtek,aldps-enable;
+	};
+};
+
+&fan {
+	interrupt-parent = <&pio>;
+	interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
+	pwms = <&pwm 1 40000 0>;
+	status = "okay";
+};
+
+&mmc0 {
+	bus-width = <8>;
+	cap-mmc-highspeed;
+	max-frequency = <52000000>;
+	non-removable;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_default>;
+	pinctrl-1 = <&mmc0_pins_uhs>;
+	vmmc-supply = <&reg_3p3v>;
+	status = "okay";
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+
+			partitions {
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x0 0x1000>;
+						};
+
+						macaddr_factory_4: macaddr@4 {
+							compatible = "mac-base";
+							reg = <0x4 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+	mmc0_pins_default: mmc0-pins-default {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+
+	mmc0_pins_uhs: mmc0-pins-uhs {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+
+	pwm1_pins: pwm1-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm1_0";
+		};
+	};
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm1_pins>;
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -74,7 +74,8 @@ mediatek_setup_interfaces()
 		;;
 	bananapi,bpi-r3-mini|\
 	edgecore,eap111|\
-	huasifei,wh3000)
+	huasifei,wh3000|\
+	huasifei,wh3000-pro)
 		ucidef_set_interfaces_lan_wan eth0 eth1
 		;;
 	bananapi,bpi-r4)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
@@ -5,6 +5,9 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+huasifei,wh3000-pro)
+	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "0"
+	;;
 zbtlink,zbt-z8102ax|\
 zbtlink,zbt-z8102ax-v2)
 	ucidef_add_gpio_switch "5g1" "Power 1st modem" "5g1" "1"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -110,6 +110,7 @@ platform_do_upgrade() {
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
 	huasifei,wh3000|\
+	huasifei,wh3000-pro|\
 	smartrg,sdg-8612|\
 	smartrg,sdg-8614|\
 	smartrg,sdg-8622|\
@@ -276,6 +277,7 @@ platform_copy_config() {
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
 	huasifei,wh3000|\
+	huasifei,wh3000-pro|\
 	jdcloud,re-cp-03|\
 	nradio,c8-668gl|\
 	smartrg,sdg-8612|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1088,6 +1088,19 @@ define Device/huasifei_wh3000
 endef
 TARGET_DEVICES += huasifei_wh3000
 
+define Device/huasifei_wh3000-pro
+  DEVICE_VENDOR := Huasifei
+  DEVICE_MODEL := WH3000 Pro
+  DEVICE_DTS := mt7981b-huasifei-wh3000-pro
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7981-firmware mt7981-wo-firmware kmod-hwmon-pwmfan kmod-usb3 f2fsck mkf2fs
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += huasifei_wh3000-pro
+
 define Device/jcg_q30-pro
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := Q30 PRO


### PR DESCRIPTION
**Huasifei WH3000 Pro**
Portable Wi-Fi 6 travel router based on MediaTek MT7981A SoC. MT7981B+MT7976CN+RTL8221B Dual Core 1.3GHZ with 5G modems module and PWM Fan.

**Specifications**
SoC: Filogic 820 MT7981A (1.3GHz)
RAM: DDR4 1GB
Flash: eMMC 8GB
WiFi: 2.4GHz and 5GHz with 3 antennas
Ethernet:
1x WAN (10/100/1000M)
1x LAN (10/100/1000/2500M)
USB: 1x USB 3.0 port
Two buttons: power/reset and mode (BTN_0)
LEDS: blue, red, blue+red=pink
UART: 3.3V, TX, RX, GND / 115200 8N1

**Installation via U-Boot rescue**
1. Set static IP 192.168.1.2 on your computer and default route as 192.168.1.1
2. Connect to the WAN port and hold the reset button while booting the device.
3. Wait for the LED to blink 5 times, and release the reset button.
4. Open U-boot web page on your browser at http://192.168.1.1
5. Select the OpenWRT sysupgrade image, upload it, and start the upgrade.
6. Wait for the router to flash the new firmware.
7. Wait for the router to reboot itself.

**Installation via sysupgrade**
Just flash sysupgrade file via [LuCI upgrade page](http://192.168.1.1/cgi-bin/luci/admin/system/flash) without saving the settings.

**Installation via SSH**
Upload the file to the router `/tmp` directory, `ssh root@192.168.1.1` and issue a command:
```
sysupgrade -n /tmp/openwrt-mediatek-filogic-huasifei_wh3000-pro-squashfs-sysupgrade.bin
```

**Factory MAC**
You can find your Factory MAC which is mentioned on the box at `/dev/mmcblck0p2` partition `factory` starting from `0x4`
```
dd if=/dev/mmcblk0p2 bs=1 skip=4 count=6 | hexdump -C
```

Cherry-picked from https://github.com/coolsnowwolf/lede/commit/949d0bd77a2e97c2d982531f72b76c575fb28839

Fixed `green` to `blue` LED in dts, added `SUPPORTED_DEVICES += huasifei,fudy-pro` - to make sysupgrade compatible with factory QWRT/Lede fork firmware.

Signed-off-by: Fil Dunsky <filipp.dunsky@gmail.com>