### PR TITLE
kernel: backport GCC15 fix for powerpc

### DIFF
--- a/target/linux/apm821xx/patches-6.6/900-powerpc-bootwrapper-force-gzip-as-mkimage-s-compress.patch
+++ b/target/linux/apm821xx/patches-6.6/900-powerpc-bootwrapper-force-gzip-as-mkimage-s-compress.patch
@@ -18,7 +18,7 @@ Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
 
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
-@@ -276,7 +276,7 @@ compressor-$(CONFIG_KERNEL_LZO) := lzo
+@@ -277,7 +277,7 @@ compressor-$(CONFIG_KERNEL_LZO) := lzo
  
  # args (to if_changed): 1 = (this rule), 2 = platform, 3 = dts 4=dtb 5=initrd
  quiet_cmd_wrap	= WRAP    $@

--- a/target/linux/generic/backport-6.12/220-v6.16-powerpc-boot-fix-build-with-gcc-15.patch
+++ b/target/linux/generic/backport-6.12/220-v6.16-powerpc-boot-fix-build-with-gcc-15.patch
@@ -1,0 +1,29 @@
+From 5a821e2d69e26b51b7f3740b6b0c3462b8cacaff Mon Sep 17 00:00:00 2001
+From: Michal Suchanek <msuchanek@suse.de>
+Date: Mon, 31 Mar 2025 12:57:19 +0200
+Subject: [PATCH] powerpc/boot: Fix build with gcc 15
+
+Similar to x86 the ppc boot code does not build with GCC 15.
+
+Copy the fix from
+commit ee2ab467bddf ("x86/boot: Use '-std=gnu11' to fix build with GCC 15")
+
+Signed-off-by: Michal Suchanek <msuchanek@suse.de>
+Tested-by: Amit Machhiwal <amachhiw@linux.ibm.com>
+Tested-by: Venkat Rao Bagalkote <venkat88@linux.ibm.com>
+Signed-off-by: Madhavan Srinivasan <maddy@linux.ibm.com>
+Link: https://patch.msgid.link/20250331105722.19709-1-msuchanek@suse.de
+---
+ arch/powerpc/boot/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/powerpc/boot/Makefile
++++ b/arch/powerpc/boot/Makefile
+@@ -70,6 +70,7 @@ BOOTCPPFLAGS	:= -nostdinc $(LINUXINCLUDE
+ BOOTCPPFLAGS	+= -isystem $(shell $(BOOTCC) -print-file-name=include)
+ 
+ BOOTCFLAGS	:= $(BOOTTARGETFLAGS) \
++		   -std=gnu11 \
+ 		   -Wall -Wundef -Wstrict-prototypes -Wno-trigraphs \
+ 		   -fno-strict-aliasing -O2 \
+ 		   -msoft-float -mno-altivec -mno-vsx \

--- a/target/linux/generic/backport-6.6/220-v6.16-powerpc-boot-fix-build-with-gcc-15.patch
+++ b/target/linux/generic/backport-6.6/220-v6.16-powerpc-boot-fix-build-with-gcc-15.patch
@@ -1,0 +1,29 @@
+From 5a821e2d69e26b51b7f3740b6b0c3462b8cacaff Mon Sep 17 00:00:00 2001
+From: Michal Suchanek <msuchanek@suse.de>
+Date: Mon, 31 Mar 2025 12:57:19 +0200
+Subject: [PATCH] powerpc/boot: Fix build with gcc 15
+
+Similar to x86 the ppc boot code does not build with GCC 15.
+
+Copy the fix from
+commit ee2ab467bddf ("x86/boot: Use '-std=gnu11' to fix build with GCC 15")
+
+Signed-off-by: Michal Suchanek <msuchanek@suse.de>
+Tested-by: Amit Machhiwal <amachhiw@linux.ibm.com>
+Tested-by: Venkat Rao Bagalkote <venkat88@linux.ibm.com>
+Signed-off-by: Madhavan Srinivasan <maddy@linux.ibm.com>
+Link: https://patch.msgid.link/20250331105722.19709-1-msuchanek@suse.de
+---
+ arch/powerpc/boot/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/powerpc/boot/Makefile
++++ b/arch/powerpc/boot/Makefile
+@@ -72,6 +72,7 @@ BOOTCPPFLAGS	:= -nostdinc $(LINUXINCLUDE
+ BOOTCPPFLAGS	+= -isystem $(shell $(BOOTCC) -print-file-name=include)
+ 
+ BOOTCFLAGS	:= $(BOOTTARGETFLAGS) \
++		   -std=gnu11 \
+ 		   -Wall -Wundef -Wstrict-prototypes -Wno-trigraphs \
+ 		   -fno-strict-aliasing -O2 \
+ 		   -msoft-float -mno-altivec -mno-vsx \

--- a/target/linux/mpc85xx/patches-6.6/010-powerpc-add-compressed-zImage-for-mpc85xx.patch
+++ b/target/linux/mpc85xx/patches-6.6/010-powerpc-add-compressed-zImage-for-mpc85xx.patch
@@ -16,7 +16,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
-@@ -177,6 +177,7 @@ src-plat-$(CONFIG_EMBEDDED6xx) += cuboot
+@@ -178,6 +178,7 @@ src-plat-$(CONFIG_EMBEDDED6xx) += cuboot
  src-plat-$(CONFIG_AMIGAONE) += cuboot-amigaone.c
  src-plat-$(CONFIG_PPC_PS3) += ps3-head.S ps3-hvcall.S ps3.c
  src-plat-$(CONFIG_EPAPR_BOOT) += epapr.c epapr-wrapper.c
@@ -24,7 +24,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  src-plat-$(CONFIG_PPC_PSERIES) += pseries-head.S
  src-plat-$(CONFIG_PPC_POWERNV) += pseries-head.S
  src-plat-$(CONFIG_PPC_IBM_CELL_BLADE) += pseries-head.S
-@@ -342,6 +343,7 @@ image-$(CONFIG_MPC834x_ITX)		+= cuImage.
+@@ -343,6 +344,7 @@ image-$(CONFIG_MPC834x_ITX)		+= cuImage.
  image-$(CONFIG_ASP834x)			+= dtbImage.asp834x-redboot
  
  # Board ports in arch/powerpc/platform/85xx/Kconfig

--- a/target/linux/mpc85xx/patches-6.6/100-powerpc-85xx-tl-wdr4900-v1-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/100-powerpc-85xx-tl-wdr4900-v1-support.patch
@@ -19,7 +19,7 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
 
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
-@@ -182,6 +182,7 @@ src-plat-$(CONFIG_PPC_PSERIES) += pserie
+@@ -183,6 +183,7 @@ src-plat-$(CONFIG_PPC_PSERIES) += pserie
  src-plat-$(CONFIG_PPC_POWERNV) += pseries-head.S
  src-plat-$(CONFIG_PPC_IBM_CELL_BLADE) += pseries-head.S
  src-plat-$(CONFIG_MVME7100) += motload-head.S mvme7100.c
@@ -27,7 +27,7 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
  
-@@ -353,7 +354,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
+@@ -354,7 +355,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
  image-$(CONFIG_TQM8555)			+= cuImage.tqm8555
  image-$(CONFIG_TQM8560)			+= cuImage.tqm8560
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560

--- a/target/linux/mpc85xx/patches-6.6/101-powerpc-85xx-hiveap-330-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/101-powerpc-85xx-hiveap-330-support.patch
@@ -30,7 +30,7 @@
  obj-$(CONFIG_MPC85xx_DS)  += mpc85xx_ds.o $(obj8259-y)
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
-@@ -182,6 +182,7 @@ src-plat-$(CONFIG_PPC_PSERIES) += pserie
+@@ -183,6 +183,7 @@ src-plat-$(CONFIG_PPC_PSERIES) += pserie
  src-plat-$(CONFIG_PPC_POWERNV) += pseries-head.S
  src-plat-$(CONFIG_PPC_IBM_CELL_BLADE) += pseries-head.S
  src-plat-$(CONFIG_MVME7100) += motload-head.S mvme7100.c
@@ -38,7 +38,7 @@
  src-plat-$(CONFIG_TL_WDR4900_V1) += simpleboot.c fixed-head.S
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
-@@ -354,6 +355,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
+@@ -355,6 +356,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
  image-$(CONFIG_TQM8555)			+= cuImage.tqm8555
  image-$(CONFIG_TQM8560)			+= cuImage.tqm8560
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560

--- a/target/linux/mpc85xx/patches-6.6/106-powerpc-85xx-ws-ap3710i-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/106-powerpc-85xx-ws-ap3710i-support.patch
@@ -30,7 +30,7 @@
  obj-$(CONFIG_RED_15W_REV1)	+= red15w_rev1.o
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
-@@ -184,6 +184,7 @@ src-plat-$(CONFIG_PPC_IBM_CELL_BLADE) +=
+@@ -185,6 +185,7 @@ src-plat-$(CONFIG_PPC_IBM_CELL_BLADE) +=
  src-plat-$(CONFIG_MVME7100) += motload-head.S mvme7100.c
  src-plat-$(CONFIG_HIVEAP_330) += simpleboot.c fixed-head.S
  src-plat-$(CONFIG_TL_WDR4900_V1) += simpleboot.c fixed-head.S
@@ -38,7 +38,7 @@
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
  
-@@ -357,6 +358,7 @@ image-$(CONFIG_TQM8560)			+= cuImage.tqm
+@@ -358,6 +359,7 @@ image-$(CONFIG_TQM8560)			+= cuImage.tqm
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560
  image-$(CONFIG_HIVEAP_330)		+= simpleImage.hiveap-330
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1

--- a/target/linux/mpc85xx/patches-6.6/107-powerpc-85xx-add-ws-ap3825i-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/107-powerpc-85xx-add-ws-ap3825i-support.patch
@@ -37,7 +37,7 @@ WS-AP3825i AP.
  obj-$(CONFIG_RED_15W_REV1)	+= red15w_rev1.o
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
-@@ -185,6 +185,7 @@ src-plat-$(CONFIG_MVME7100) += motload-h
+@@ -186,6 +186,7 @@ src-plat-$(CONFIG_MVME7100) += motload-h
  src-plat-$(CONFIG_HIVEAP_330) += simpleboot.c fixed-head.S
  src-plat-$(CONFIG_TL_WDR4900_V1) += simpleboot.c fixed-head.S
  src-plat-$(CONFIG_WS_AP3710I) += simpleboot.c fixed-head.S
@@ -45,7 +45,7 @@ WS-AP3825i AP.
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
  
-@@ -359,6 +360,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
+@@ -360,6 +361,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
  image-$(CONFIG_HIVEAP_330)		+= simpleImage.hiveap-330
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
  image-$(CONFIG_WS_AP3710I)		+= simpleImage.ws-ap3710i

--- a/target/linux/mpc85xx/patches-6.6/109-powerpc-85xx-add-ws-ap3715i-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/109-powerpc-85xx-add-ws-ap3715i-support.patch
@@ -30,7 +30,7 @@
  obj-$(CONFIG_CORENET_GENERIC)   += corenet_generic.o
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
-@@ -185,6 +185,7 @@ src-plat-$(CONFIG_MVME7100) += motload-h
+@@ -186,6 +186,7 @@ src-plat-$(CONFIG_MVME7100) += motload-h
  src-plat-$(CONFIG_HIVEAP_330) += simpleboot.c fixed-head.S
  src-plat-$(CONFIG_TL_WDR4900_V1) += simpleboot.c fixed-head.S
  src-plat-$(CONFIG_WS_AP3710I) += simpleboot.c fixed-head.S
@@ -38,7 +38,7 @@
  src-plat-$(CONFIG_WS_AP3825I) += simpleboot.c fixed-head.S
  
  src-plat-$(CONFIG_PPC_MICROWATT) += fixed-head.S microwatt.c
-@@ -360,6 +361,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
+@@ -361,6 +362,7 @@ image-$(CONFIG_KSI8560)			+= cuImage.ksi
  image-$(CONFIG_HIVEAP_330)		+= simpleImage.hiveap-330
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
  image-$(CONFIG_WS_AP3710I)		+= simpleImage.ws-ap3710i

--- a/target/linux/mpc85xx/patches-6.6/110-powerpc-85xx-br200-wp-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/110-powerpc-85xx-br200-wp-support.patch
@@ -29,7 +29,7 @@
  obj8259-$(CONFIG_PPC_I8259)   += mpc85xx_8259.o
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
-@@ -182,6 +182,7 @@ src-plat-$(CONFIG_PPC_PSERIES) += pserie
+@@ -183,6 +183,7 @@ src-plat-$(CONFIG_PPC_PSERIES) += pserie
  src-plat-$(CONFIG_PPC_POWERNV) += pseries-head.S
  src-plat-$(CONFIG_PPC_IBM_CELL_BLADE) += pseries-head.S
  src-plat-$(CONFIG_MVME7100) += motload-head.S mvme7100.c
@@ -37,7 +37,7 @@
  src-plat-$(CONFIG_HIVEAP_330) += simpleboot.c fixed-head.S
  src-plat-$(CONFIG_TL_WDR4900_V1) += simpleboot.c fixed-head.S
  src-plat-$(CONFIG_WS_AP3710I) += simpleboot.c fixed-head.S
-@@ -358,6 +359,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
+@@ -359,6 +360,7 @@ image-$(CONFIG_TQM8548)			+= cuImage.tqm
  image-$(CONFIG_TQM8555)			+= cuImage.tqm8555
  image-$(CONFIG_TQM8560)			+= cuImage.tqm8560
  image-$(CONFIG_KSI8560)			+= cuImage.ksi8560

--- a/target/linux/mpc85xx/patches-6.6/900-powerpc-bootwrapper-disable-uImage-generation.patch
+++ b/target/linux/mpc85xx/patches-6.6/900-powerpc-bootwrapper-disable-uImage-generation.patch
@@ -16,7 +16,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
 
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
-@@ -296,7 +296,6 @@ image-$(CONFIG_PPC_CHRP)		+= zImage.chrp
+@@ -297,7 +297,6 @@ image-$(CONFIG_PPC_CHRP)		+= zImage.chrp
  image-$(CONFIG_PPC_EFIKA)		+= zImage.chrp
  image-$(CONFIG_PPC_PMAC)		+= zImage.pmac
  image-$(CONFIG_PPC_HOLLY)		+= dtbImage.holly
@@ -24,7 +24,7 @@ Signed-off-by: David Bauer <mail@david-bauer.net>
  image-$(CONFIG_EPAPR_BOOT)		+= zImage.epapr
  
  #
-@@ -423,15 +422,6 @@ $(obj)/dtbImage.%: vmlinux $(wrapperbits
+@@ -424,15 +423,6 @@ $(obj)/dtbImage.%: vmlinux $(wrapperbits
  $(obj)/vmlinux.strip: vmlinux
  	$(STRIP) -s -R .comment $< -o $@
  


### PR DESCRIPTION
Comes with kernel 6.16. I assume it will be backported at some point.

ping @robimarko 