### PR TITLE
mold: Update to 2.40.1

### DIFF
--- a/tools/mold/Makefile
+++ b/tools/mold/Makefile
@@ -3,12 +3,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mold
-PKG_VERSION:=2.39.1
+PKG_VERSION:=2.40.1
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL_FILE:=v$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/rui314/mold/archive/refs/tags
-PKG_HASH:=231ea3643a14fe5b88478c97b68b31f7c975b57b247a81356ffd889d015b5cc1
+PKG_HASH:=d1ce09a69941f8158604c3edcc96c7178231e7dba2da66b20f5ef6e112c443b7
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/cmake.mk


### PR DESCRIPTION
Update mold to 2.40.1 from https://github.com/rui314/mold/releases/tag/v2.40.1