### PR TITLE
filogic: add support for Arcadyan WG620443

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -57,6 +57,10 @@ huasifei,wh3000|\
 nradio,c8-668gl)
 	ubootenv_add_mmc "u-boot-env" "" "0x0" "0x80000"
 	;;
+arcadyan,wg620443)
+	local envdev=/dev/mtd$(find_mtd_index "u-boot-env")
+	ubootenv_add_uci_config "$envdev" "0x0" "0x20000" "0x20000" "1"
+	;;
 asus,rt-ax59u)
 	ubootenv_add_uci_config "/dev/mtd0" "0x100000" "0x20000" "0x20000"
 	;;
@@ -138,6 +142,10 @@ zyxel,ex5601-t0)
 	;;
 zyxel,ex5700-telenor)
 	ubootenv_add_uci_config "/dev/ubootenv" "0x0" "0x4000" "0x4000" "1"
+	;;
+arcadyan,wg620443)
+	local envdev=/dev/mtd$(find_mtd_index "u-boot-env")
+	ubootenv_add_uci_config "$envdev" "0x0" "0x20000" "0x20000" "1"
 	;;
 esac
 

--- a/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
+++ b/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	model = "Arcadyan WG620443";
+	compatible = "arcadyan,wg620443", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+		ethernet0 = &gmac0;
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+
+		// Stock U-Boot crashes unless /chosen/bootargs exists
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8";
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		poll-interval = <20>;
+
+		reset-button {
+			label = "reset";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: red {
+			label = "red:net";
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_status_green: green {
+			label = "green:net";
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_status_blue: blue {
+			label = "blue:net";
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+	};
+
+};
+
+&eth {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&mdio {
+
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+	};
+
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "wan";
+			phy-handle = <&swphy0>;
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan1";
+			phy-handle = <&swphy1>;
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+
+	};
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		swphy0: phy@0 {
+			reg = <0>;
+
+			mediatek,led-config = <
+				0x21 0x8009 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0x8000 /* LED0_ON_CTRL */
+				0x25 0x0000 /* LED0_BLINK_CTRL */
+				0x26 0xc007 /* LED1_ON_CTRL */
+				0x27 0x003f /* LED1_BLINK_CTRL */
+			>;
+		};
+
+		swphy1: phy@1 {
+			reg = <1>;
+
+			mediatek,led-config = <
+				0x21 0x8009 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0x8000 /* LED0_ON_CTRL */
+				0x25 0x0000 /* LED0_BLINK_CTRL */
+				0x26 0xc007 /* LED1_ON_CTRL */
+				0x27 0x003f /* LED1_BLINK_CTRL */
+			>;
+		};
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie_pins>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			nvmem-cells = <&eeprom_6g>;
+			nvmem-cell-names = "eeprom";
+		};
+	};
+};
+
+&pcie_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+
+	nvmem-cells = <&eeprom_2g_5g>;
+	nvmem-cell-names = "eeprom";
+};
+
+&pio {
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "switch_int", "mdc_mdio";
+		};
+	};
+
+	pcie_pins: pcie-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_pereset"; // "pcie_clk" and "pcie_wake" is unused?
+		};
+	};
+
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <8>;
+			mediatek,pull-down-adv = <0>; /* bias-disable */
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	cs-gpios = <0>, <0>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+	};
+
+	flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		spi-max-frequency = <20000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x000000 0x100000>;
+				read-only;
+			};
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_2g_5g: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					eeprom_6g: eeprom@a0000 {
+						reg = <0xa0000 0x1000>;
+					};
+				};
+			};
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x2400000>;
+			};
+			partition@2980000 {
+				label = "Kernel2";
+				reg = <0x2980000 0x2400000>;
+			};
+			partition@4d80000 {
+				label = "pricfg";
+				reg = <0x4d80000 0x200000>;
+			};
+
+			partition@4f80000 {
+				label = "seccfg";
+				reg = <0x4f80000 0x200000>;
+			};
+
+			partition@5180000 {
+				label = "arc_log";
+				reg = <0x5180000 0x200000>;
+			};
+
+			partition@5380000 {
+				label = "board_data";
+				reg = <0x5380000 0x200000>;
+			};
+
+			partition@5580000 {
+				label = "boot_data";
+				reg = <0x5580000 0x200000>;
+			};
+
+			partition@5780000 {
+				label = "User_data";
+				reg = <0x5780000 0x1000000>;
+			};
+
+		};
+	};
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -27,6 +27,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && mmc_get_mac_ascii u-boot-env 2gMAC > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && mmc_get_mac_ascii u-boot-env 5gMAC > /sys${DEVPATH}/macaddress
 		;;
+	arcadyan,wg620443)
+		hw_mac_addr=$(mtd_get_mac_encrypted_arcadyan_mt7986 "pricfg" "89c72f31eb3243e8b0a781fe46a51c56" "87d81103921f4c17cbfd078b056f397a")
+		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
+		;;
 	asus,rt-ax59u)
 		CI_UBIPART="UBI_DEV"
 		addr=$(mtd_get_mac_binary_ubi "Factory" 0x4)

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -122,6 +122,10 @@ platform_do_upgrade() {
 		CI_ROOTPART="rootfs"
 		emmc_do_upgrade "$1"
 		;;
+	arcadyan,wg620443)
+		fw_setenv boot_select 0
+		nand_do_upgrade $1
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax59u|\
 	asus,tuf-ax4200|\
@@ -303,6 +307,13 @@ platform_pre_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	arcadyan,wg620443)
+		if [ "$(rootfs_type)" = "tmpfs" ]; then
+			fw_setenv bootargs console=ttyS0,115200n1 ubi.mtd=4 init=/sbin/init loglevel=8 earlycon=uart8250,mmio32,0x11002000
+			ubidetach -m 4 | true
+			ubiformat /dev/mtd4
+		fi
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax59u|\
 	asus,tuf-ax4200|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -269,6 +269,27 @@ define Device/arcadyan_mozart
 endef
 TARGET_DEVICES += arcadyan_mozart
 
+define Device/arcadyan_wg620443
+  DEVICE_VENDOR := Arcadyan
+  DEVICE_MODEL := WG620443
+  DEVICE_DTS := mt7986a-arcadyan-wg620443
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-ubootenv-nvram kmod-mt7986-firmware mt7986-wo-firmware uencrypt-mbedtls kmod-mt7915e
+  DEVICE_DTS_LOADADDR := 0x44000000
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 51200k
+  KERNEL_IN_UBI := 1
+  IMAGE += initramfs-kernel.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+    ARTIFACTS += initramfs-factory.bin
+    ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | sysupgrade-tar kernel=$$$$@ | append-metadata
+  endif
+endef
+TARGET_DEVICES += arcadyan_wg620443
+
 define Device/asus_rt-ax52
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AX52


### PR DESCRIPTION
Inherit https://github.com/openwrt/openwrt/pull/17960 as the original PR has not been updated in a long time.

---
### Specification
Model: Arcadyan WG620443(-TC)
CPU: Mediatek MT7986a
RAM: 512MB DDR3
Flash: 128MB W25N01GVZE1G
WiFi: 2.4GHz 5GHz 4x4
GbE: 1 WAN and 1 LAN
Power: 12V 1A DC 5.5/2.1 Jack
LED: 3

### Installation for TC variant by CHT
#### Enable Telnet from stock WebUI
* Launch the browser to WebUI
* Navigate to `System` -`Remote Management`
* Launch Web DevTools then select the iframe of `remote_management.htm`
* Execute `closeDiv()` in the web console.
* Enable Telnet from LAN access, then click 'Save' button

#### Bypass the firmware validation
* Telnet into access point via LAN
* Login with default credential.
* In `Please enter No. or input command: ` prompt, type `Switch_To_SH` then Enter key
* In `Please input command!!>` prompt, type `cht_arc_JE1xxxxxxx` then Enter key
  
  * `JE1xxxxxxx` is the serial number of the access point, it shows in `System` -`Information`
* When shell popup, type `echo 1 /tmp/FW_check_dev.log` then Enter key to bypass firmware validation.

#### Install recovery image
* Navigate to `System` -`Firmware Update` in WebUI
* Select `openwrt-xx.xx.xx-initramfs-factory.bin` file
* Launch Web DevTools then select the iframe of `system_f.htm`
* Execute following JS script to starting flash the stage 1 firmware.

```
$("input[type=file]").attr("name","file")
var f=document.webForm;
f.action="upload.cgi";
f.ENCTYPE='multipart/form-data';
subForm({frm:f,genfrm:0,cmd:'',uploadtype:1,wizard:1,wait:2,done:function(){check_FW_and_jump();}});
```

* When the green LED light up,the recovery image is installed and booted

#### Install full image
* Launch browser to `http://192.168.1.1`
* Upgrade OpenWrt with `openwrt-xx.xx.xx-squashfs-sysupgrade.bin`
* Reboot