### PR TITLE
mac80211: remove kmod-ath dependency from ath11k

### DIFF
--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -308,7 +308,7 @@ define KernelPackage/ath11k
   $(call KernelPackage/mac80211/Default)
   TITLE:=Qualcomm 802.11ax wireless chipset support (common code)
   URL:=https://wireless.wiki.kernel.org/en/users/drivers/ath11k
-  DEPENDS+= +kmod-ath +@DRIVER_11AC_SUPPORT +@DRIVER_11AX_SUPPORT \
+  DEPENDS+= +@DRIVER_11AC_SUPPORT +@DRIVER_11AX_SUPPORT \
   +kmod-crypto-michael-mic +ATH11K_THERMAL:kmod-hwmon-core \
   +ATH11K_THERMAL:kmod-thermal +kmod-qcom-qmi-helpers
   FILES:=$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath11k/ath11k.ko


### PR DESCRIPTION
`ath11k` doesn't use any symbols from `kmod-ath` and `modinfo` also confirms it doesn't depend on it.

```sh
➤ modinfo ath11k
filename:	/lib/modules/6.12.35/ath11k.ko
license:	Dual BSD/GPL
depends:	mac80211,cfg80211,qmi_helpers,compat
name:		ath11k
vermagic:	6.12.35 SMP mod_unload aarch64
```

Further verified by checking all exported functions from ath module and finding references:
```sh
❯ rg -N --no-filename --no-heading -Po 'EXPORT_SYMBOL\(\K[^)]+' ./drivers/net/wireless/ath/*c
ath_rxbuf_alloc
ath_is_mybeacon
ath_printk
ath_bus_type_strings
ath_hw_keyreset
ath_hw_keysetmac
ath_key_config
ath_key_delete
dfs_pattern_detector_init
ath_opmode_to_string
ath_hw_setbssidmask
ath_hw_cycle_counters_update
ath_hw_get_listen_time
ath_is_world_regd
ath_is_49ghz_allowed
ath_regd_find_country_by_name
ath_reg_notifier_apply
ath_regd_init
ath_regd_get_band_ctl
```

The only modules that actually reference it are:
|module|refs|
|--- | --- |
ath10k|6
ath5k|18
ath9k|35
carl9170|6

Ones that don't
|module|refs|
|--- | --- |
ar5523|0
ath11k|0
ath12k|0
ath6kl|0
wcn36xx|0
wil6210|0

@robimarko