### PR TITLE
mediatek: add support for Cudy TR3000  256MB  v1 flash version

### DIFF
--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -1,6 +1,7 @@
 set_preinit_iface() {
 	case $(board_name) in
 	cudy,m3000-v1|\
+	cudy,tr3000-256mb-v1|\
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
 	glinet,gl-mt3000|\

--- a/target/linux/mediatek/dts/mt7981b-cudy-tr3000-256mb-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-tr3000-256mb-v1.dts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+#include "mt7981b-cudy-tr3000-v1.dtsi"
+
+/ {
+	model = "Cudy TR3000 256MB v1";
+	compatible = "cudy,tr3000-256mb-v1", "mediatek,mt7981";
+};
+
+&spi_nand {
+	spi-cal-enable;
+	spi-cal-mode = "read-data";
+	spi-cal-datalen = <7>;
+	spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
+	spi-cal-addrlen = <5>;
+	spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};
+
+&ubi {
+	reg = <0x5c0000 0xe600000>;
+};
+

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -89,6 +89,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interface_lan "eth0"
 		;;
 	cudy,m3000-v1|\
+	cudy,tr3000-256mb-v1|\
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
 	glinet,gl-mt2500|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -78,6 +78,7 @@ case "$board" in
 	cudy,ap3000-v1|\
 	cudy,m3000-v1|\
 	cudy,re3000-v1|\
+	cudy,tr3000-256mb-v1|\
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
 	cudy,wr3000e-v1|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -720,6 +720,23 @@ define Device/cudy_re3000-v1
 endef
 TARGET_DEVICES += cudy_re3000-v1
 
+define Device/cudy_tr3000-256mb-v1
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := TR3000
+  DEVICE_VARIANT := 256mb v1
+  DEVICE_DTS := mt7981b-cudy-tr3000-256mb-v1
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES += R103
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 235520k
+  KERNEL_IN_UBI := 1
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+endef
+TARGET_DEVICES += cudy_tr3000-256mb-v1
+
 define Device/cudy_tr3000-v1
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := TR3000


### PR DESCRIPTION
This device is similar to the Cudy TR3000 v1 128MB version. The difference is that the flash memory is 128mb and the other is 256mb

Hardware:
 - SoC: MediaTek MT7981B
 - CPU: 2x 1.3 GHz Cortex-A53
 - Flash: 256 MiB SPI NAND
 - RAM: 512 MiB
 - WLAN: 2.4 GHz, 5 GHz (MediaTek MT7976CN, 802.11ax)
 - Ethernet: 1x 10/100/1000/2500 Mbps RTL8221B WAN, 1x10/100/1000 Mbps MT7981 LAN
 - USB 3.0 port
 - Buttons: 1 Reset button, 1 slider button
 - LEDs: 1x Red, 1x White
 - Power: 5 VDC, 3 A

Installation:
Cudy has distributed intermediate firmware to make installation easier
1. Go to [Cudy CN official website](https://www.cudy.com/zh-cn/pages/download-center/tr3000-1-0) and download the intermediate firmware
2. Upgrade the intermediate firmware on the page
3. Visit the intermediate firmware 192.168.1.1 webpage and use the sysupgrade image to update

other:
If you fail to flash the device, you can use TFTP to flash back to the original firmware.
1. Ask Cudy CN official customer service for the original firmware
2. With the router off, press the RESET button. While the router is turning on, the button should continue to be pressed for at least 5 seconds.
3. A u-boot shell will automatically open.
4. Connect to LAN and set your IP to 192.168.1.88/24. Configure a TFTP server and an recovery.bin firmware file.


Link: https://github.com/openwrt/openwrt/pull/19167

(cherry picked from commit 594da824a4f2f9582941e612f1a912773d43ff1d)