### PR TITLE
linux-firmware: update to 20250708

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
-PKG_VERSION:=20250627
+PKG_VERSION:=20250708
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=edefb1d2a538367abf9558802fee3cd135ebb19a4a5890c8eefb3416a92a6b89
+PKG_HASH:=6f3efee7f600c201f9b2d675889a4ccdb8cfe56e0d283641796ed10e64c72047
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
```
% git log --no-merges --pretty=oneline --abbrev-commit 20250627...20250708
    74d80fcf8ce2 xe: Add fan_control v203.0.0.0 for BMG
    331eac914440 linux-firmware: Update AMD cpu microcode
    847cd5aaabe0 amdgpu: Add DCN 3.6
    5e95c44fb4a7 amdgpu: Add PSP 14.0.5
    520262d1d0a8 amdgpu: Add SDMA 6.1.3
    84f443352785 amdgpu: Add GC 11.5.3
    1f861a48042a mediatek MT7921: update bluetooth firmware to 20250625154126
    d3e7e025210a qcom/adreno: document firmware revisions
    4e7094412cd2 qcom/adreno: move A610 and A702 ZAP files to Adreno driver section
    ed3c42722a02 qcom: Add sdx61 Foxconn vendor firmware image file
    f534fd76aaa8 Revert "linux-firmware: Update firmware file for Intel Pulsar core"
    ce7108f47ef6 qcom/adreno: sort entries in WHENCE
    0ef7a160552a xe: First HuC release for Pantherlake
    bbe12d522f4e xe: First GuC release for Pantherlake
    5cf85776762a linux-firmware: update firmware for MT7921 WiFi device
    78478bfc4431 rtw89: 8922a: update fw to v0.35.80.0
    4e34a870bdb8 rtw89: 8852c: update fw to v0.27.129.1
    4729093efd12 rtw89: 8852c: update fw to v0.27.128.0
```

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc (Intel N150-based system)