### PR TITLE
mbedtls: Re-prepare when configuration changes

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -137,14 +137,12 @@ CMAKE_OPTIONS += \
 	-DENABLE_TESTING:Bool=OFF \
 	-DENABLE_PROGRAMS:Bool=ON
 
-define Build/Prepare
-       $(call Build/Prepare/Default)
-
-       $(if $(strip $(foreach opt,$(MBEDTLS_BUILD_OPTS),$($(opt)))),
-	 $(foreach opt,$(MBEDTLS_BUILD_OPTS),
-	 $(PKG_BUILD_DIR)/scripts/config.py \
-	 -f $(PKG_BUILD_DIR)/include/mbedtls/mbedtls_config.h \
-	 $(if $($(opt)),set,unset) $(patsubst CONFIG_%,%,$(opt))),)
+define Build/Configure
+	$(call Build/Configure/Default,)
+	$(foreach opt,$(MBEDTLS_BUILD_OPTS),
+	$(PKG_BUILD_DIR)/scripts/config.py \
+		-f $(PKG_BUILD_DIR)/include/mbedtls/mbedtls_config.h \
+		$(if $($(opt)),set,unset) $(patsubst CONFIG_%,%,$(opt)))
 endef
 
 define Build/InstallDev


### PR DESCRIPTION
Configuration options are applied to mbedtls_config.h in the Prepare step (not in Configure), so Prepare needs to depend on those options to ensure the build tree gets re-prepared when they change.
