### PR TITLE
ltq-*-app: correctly report downstream band borders

### DIFF
--- a/package/network/config/ltq-adsl-app/Makefile
+++ b/package/network/config/ltq-adsl-app/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=dsl_cpe_control_danube
 PKG_VERSION:=3.24.4.4
-PKG_RELEASE:=14
+PKG_RELEASE:=15
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_BUILD_DIR:=$(BUILD_DIR)/dsl_cpe_control-$(PKG_VERSION)
 PKG_SOURCE_URL:=@OPENWRT

--- a/package/network/config/ltq-vdsl-vr11-app/Makefile
+++ b/package/network/config/ltq-vdsl-vr11-app/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ltq-vdsl-vr11-app
 PKG_VERSION:=4.23.1
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 PKG_BASE_NAME:=dsl_cpe_control
 
 UGW_VERSION=8.5.2.10

--- a/package/network/config/ltq-vdsl-vr9-app/Makefile
+++ b/package/network/config/ltq-vdsl-vr9-app/Makefile
@@ -9,7 +9,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ltq-vdsl-vr9-app
 PKG_VERSION:=4.17.18.6
-PKG_RELEASE:=7
+PKG_RELEASE:=8
 PKG_BASE_NAME:=dsl_cpe_control
 PKG_SOURCE:=$(PKG_BASE_NAME)_vrx-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=@OPENWRT

--- a/package/network/config/ltq-vdsl-vr9-app/src/src/dsl_cpe_ubus.c
+++ b/package/network/config/ltq-vdsl-vr9-app/src/src/dsl_cpe_ubus.c
@@ -447,7 +447,7 @@ static void pilot_tones_status(int fd) {
 }
 
 static void band_border_status(int fd, DSL_AccessDir_t direction) {
-	IOCTL(DSL_BandBorderStatus_t, DSL_FIO_BAND_BORDER_STATUS_GET);
+	IOCTL_DIR(DSL_BandBorderStatus_t, DSL_FIO_BAND_BORDER_STATUS_GET, direction);
 
 	void *c, *c2;
 


### PR DESCRIPTION
The direction needs to be included in the IOCTL call.

Fixes: b91d7d9d78ea ("ltq-*-app: extend ubus metrics/statistics")
(so this affects 23.05 and 24.10)

Tested on Fritzbox 7320.