### PR TITLE
ramips: set packet steering to all CPUs as default on mt7621

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/uci-defaults/01_enable_packet_steering
+++ b/target/linux/ramips/mt7621/base-files/etc/uci-defaults/01_enable_packet_steering
@@ -1,5 +1,5 @@
 uci -q get network.globals.packet_steering > /dev/null || {
 	uci set network.globals='globals'
-	uci set network.globals.packet_steering=1
+	uci set network.globals.packet_steering='2'
 	uci commit network
 }


### PR DESCRIPTION
Setting Packet Steering to "Enabled (all CPUs)" significantly boosts network performance compared to the default "Enabled".

Bandwidth differences observed with a 350/350 Mbps connection:

Packet Steering (Enabled) - default
eth - 220/350 mbps
wifi - 200/350 mbps

Packet Steering (Enabled (all CPUs))
eth - 350/350 mbps
wifi - 350/350 mbps

Original commit: https://github.com/openwrt/openwrt/commit/dfd62e575c6c39a188a2dbf4aa0c5d1ecf92c57d

Tested on: ramips/mt7621

Option 2:

Remove this file since the default is already set to Enabled.