### PR TITLE
bcm53xx: add support for ASUS RT-AC3200 and RT-AC5300

### DIFF
--- a/package/utils/nvram/Makefile
+++ b/package/utils/nvram/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nvram
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/package/utils/nvram/files/nvram-bcm53xx.init
+++ b/package/utils/nvram/files/nvram-bcm53xx.init
@@ -19,15 +19,22 @@ clear_partialboots() {
 
 set_wireless_led_behaviour() {
 	# set Broadcom wireless LED behaviour for both radios
-	# 0:ledbh9 -> Behaviour of 2.4GHz LED
-	# 1:ledbh9 -> Behaviour of 5GHz LED
+	# 0:ledbh9 -> Behaviour of 2.4GHz LED of Broadcom BCM4366
+	# 1:ledbh9 -> Behaviour of 5GHz LED of Broadcom BCM4366
+	# 0:ledbh10 -> Behaviour of 2.4GHz LED of Broadcom BCM43602
+	# 1:ledbh10 -> Behaviour of 5GHz LED of Broadcom BCM43602
 	# 0x7 makes the wireless LEDs on, when radios are enabled, and blink when there's activity
 
 	case $(board_name) in
 		asus,rt-ac3100|\
+		asus,rt-ac5300|\
 		asus,rt-ac88u)
 			COMMIT=1
 			nvram set 0:ledbh9=0x7 set 1:ledbh9=0x7
+			;;
+		asus,rt-ac3200)
+			COMMIT=1
+			nvram set 0:ledbh10=0x7 set 1:ledbh10=0x7
 			;;
 	esac
 }

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -176,6 +176,22 @@ define Device/asus_rt-ac3100
 endef
 TARGET_DEVICES += asus_rt-ac3100
 
+define Device/asus_rt-ac3200
+  $(call Device/asus)
+  DEVICE_MODEL := RT-AC3200
+  DEVICE_PACKAGES := $(BRCMFMAC_43602A1) $(USB3_PACKAGES)
+  ASUS_PRODUCTID := RT-AC3200
+endef
+TARGET_DEVICES += asus_rt-ac3200
+
+define Device/asus_rt-ac5300
+  $(call Device/asus)
+  DEVICE_MODEL := RT-AC5300
+  DEVICE_PACKAGES := $(BRCMFMAC_4366B1) $(BRCMFMAC_4366C0) $(USB3_PACKAGES)
+  ASUS_PRODUCTID := RT-AC5300
+endef
+TARGET_DEVICES += asus_rt-ac5300
+
 define Device/asus_rt-ac56u
   $(call Device/asus)
   DEVICE_MODEL := RT-AC56U

--- a/target/linux/bcm53xx/patches-6.6/311-ARM-BCM5301X-Add-DT-for-Asus-RT-AC3200.patch
+++ b/target/linux/bcm53xx/patches-6.6/311-ARM-BCM5301X-Add-DT-for-Asus-RT-AC3200.patch
@@ -1,0 +1,182 @@
+From: Arınç ÜNAL <arinc.unal@arinc9.com>
+
+Add the device tree for ASUS RT-AC3200 which is an AC3200 router featuring
+5 Ethernet ports over the integrated Broadcom switch.
+
+Hardware info:
+* Processor: Broadcom BCM4709A0 dual-core @ 1.0 GHz
+* Switch: BCM53012 in BCM4709A0
+* DDR3 RAM: 256 MB
+* Flash: 128 MB
+* 2.4GHz: BCM43602 3x3 single chip 802.11b/g/n SoC
+* 5GHz: BCM43602 3x3 two chips 802.11a/n/ac SoC
+* Ports: 4 LAN Ports, 1 WAN Port
+
+Co-developed-by: Tom Brautaset <tbrautaset@gmail.com>
+Signed-off-by: Tom Brautaset <tbrautaset@gmail.com>
+Signed-off-by: Arınç ÜNAL <arinc.unal@arinc9.com>
+---
+
+--- a/arch/arm/boot/dts/broadcom/Makefile
++++ b/arch/arm/boot/dts/broadcom/Makefile
+@@ -64,6 +64,7 @@ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm47081-luxul-xap-1410.dtb \
+ 	bcm47081-luxul-xwr-1200.dtb \
+ 	bcm47081-tplink-archer-c5-v2.dtb \
++	bcm4709-asus-rt-ac3200.dtb \
+ 	bcm4709-asus-rt-ac87u.dtb \
+ 	bcm4709-buffalo-wxr-1900dhp.dtb \
+ 	bcm4709-linksys-ea9200.dtb \
+--- /dev/null
++++ b/arch/arm/boot/dts/broadcom/bcm4709-asus-rt-ac3200.dts
+@@ -0,0 +1,150 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++/*
++ * Author: Tom Brautaset <tbrautaset@gmail.com>
++ */
++
++/dts-v1/;
++
++#include "bcm4709.dtsi"
++#include "bcm5301x-nand-cs0-bch8.dtsi"
++
++#include <dt-bindings/leds/common.h>
++
++/ {
++	compatible = "asus,rt-ac3200", "brcm,bcm4709", "brcm,bcm4708";
++	model = "ASUS RT-AC3200";
++
++	memory@0 {
++		reg = <0x00000000 0x08000000>,
++		      <0x88000000 0x08000000>;
++		device_type = "memory";
++	};
++
++	nvram@1c080000 {
++		compatible = "brcm,nvram";
++		reg = <0x1c080000 0x00180000>;
++
++		et0macaddr: et0macaddr {
++			#nvmem-cell-cells = <1>;
++		};
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		button-reset {
++			label = "Reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&chipcommon 11 GPIO_ACTIVE_LOW>;
++		};
++
++		button-wifi {
++			label = "Wi-Fi";
++			linux,code = <KEY_RFKILL>;
++			gpios = <&chipcommon 4 GPIO_ACTIVE_LOW>;
++		};
++
++		button-wps {
++			label = "WPS";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&chipcommon 7 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-power {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_POWER;
++			gpios = <&chipcommon 3 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "default-on";
++		};
++
++		led-wan-red {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_WAN;
++			gpios = <&chipcommon 5 GPIO_ACTIVE_HIGH>;
++		};
++
++		led-wps {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_WPS;
++			gpios = <&chipcommon 14 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&gmac0 {
++	nvmem-cells = <&et0macaddr 0>;
++	nvmem-cell-names = "mac-address";
++};
++
++&gmac1 {
++	nvmem-cells = <&et0macaddr 1>;
++	nvmem-cell-names = "mac-address";
++};
++
++&gmac2 {
++	nvmem-cells = <&et0macaddr 2>;
++	nvmem-cell-names = "mac-address";
++};
++
++&nandcs {
++	partitions {
++		compatible = "fixed-partitions";
++		#address-cells = <1>;
++		#size-cells = <1>;
++
++		partition@0 {
++			reg = <0x00000000 0x00080000>;
++			label = "boot";
++			read-only;
++		};
++
++		partition@80000 {
++			reg = <0x00080000 0x00180000>;
++			label = "nvram";
++		};
++
++		partition@200000 {
++			compatible = "brcm,trx";
++			reg = <0x00200000 0x07e00000>;
++			label = "firmware";
++		};
++	};
++};
++
++&srab {
++	status = "okay";
++
++	ports {
++		port@0 {
++			label = "wan";
++		};
++
++		port@1 {
++			label = "lan4";
++		};
++
++		port@2 {
++			label = "lan3";
++		};
++
++		port@3 {
++			label = "lan2";
++		};
++
++		port@4 {
++			label = "lan1";
++		};
++	};
++};
++
++&usb2 {
++	vcc-gpio = <&chipcommon 9 GPIO_ACTIVE_HIGH>;
++};
++
++&usb3_phy {
++	status = "okay";
++};

--- a/target/linux/bcm53xx/patches-6.6/312-ARM-BCM5301X-Add-DT-for-Asus-RT-AC5300.patch
+++ b/target/linux/bcm53xx/patches-6.6/312-ARM-BCM5301X-Add-DT-for-Asus-RT-AC5300.patch
@@ -1,0 +1,188 @@
+From: Arınç ÜNAL <arinc.unal@arinc9.com>
+
+Add the device tree for ASUS RT-AC5300 which is an AC5300 router featuring
+5 Ethernet ports over the integrated Broadcom switch.
+
+Hardware info:
+* Processor: Broadcom BCM4709C0 dual-core @ 1.4 GHz
+* Switch: BCM53012 in BCM4709C0
+* DDR3 RAM: 512 MB
+* Flash: 128 MB
+* 2.4GHz: BCM4366 4x4 single chip 802.11b/g/n SoC
+* 5GHz: BCM4366 4x4 two chips 802.11a/n/ac SoC
+* Ports: 4 LAN Ports, 1 WAN Port
+
+Co-developed-by: Tom Brautaset <tbrautaset@gmail.com>
+Signed-off-by: Tom Brautaset <tbrautaset@gmail.com>
+Signed-off-by: Arınç ÜNAL <arinc.unal@arinc9.com>
+---
+
+--- a/arch/arm/boot/dts/broadcom/Makefile
++++ b/arch/arm/boot/dts/broadcom/Makefile
+@@ -72,6 +72,7 @@ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm4709-netgear-r8000.dtb \
+ 	bcm4709-tplink-archer-c9-v1.dtb \
+ 	bcm47094-asus-rt-ac3100.dtb \
++	bcm47094-asus-rt-ac5300.dtb \
+ 	bcm47094-asus-rt-ac88u.dtb \
+ 	bcm47094-dlink-dir-885l.dtb \
+ 	bcm47094-dlink-dir-890l.dtb \
+--- /dev/null
++++ b/arch/arm/boot/dts/broadcom/bcm47094-asus-rt-ac5300.dts
+@@ -0,0 +1,156 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++/*
++ * Author: Tom Brautaset <tbrautaset@gmail.com>
++ */
++
++/dts-v1/;
++
++#include "bcm47094.dtsi"
++#include "bcm5301x-nand-cs0-bch8.dtsi"
++
++#include <dt-bindings/leds/common.h>
++
++/ {
++	compatible = "asus,rt-ac5300", "brcm,bcm47094", "brcm,bcm4708";
++	model = "ASUS RT-AC5300";
++
++	memory@0 {
++		reg = <0x00000000 0x08000000>,
++		      <0x88000000 0x18000000>;
++		device_type = "memory";
++	};
++
++	nvram@1c080000 {
++		compatible = "brcm,nvram";
++		reg = <0x1c080000 0x00180000>;
++
++		et1macaddr: et1macaddr {
++			#nvmem-cell-cells = <1>;
++		};
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		button-reset {
++			label = "Reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&chipcommon 11 GPIO_ACTIVE_LOW>;
++		};
++
++		button-wifi {
++			label = "Wi-Fi";
++			linux,code = <KEY_RFKILL>;
++			gpios = <&chipcommon 20 GPIO_ACTIVE_LOW>;
++		};
++
++		button-wps {
++			label = "WPS";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&chipcommon 18 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-lan {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_LAN;
++			gpios = <&chipcommon 21 GPIO_ACTIVE_LOW>;
++		};
++
++		led-power {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_POWER;
++			gpios = <&chipcommon 3 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "default-on";
++		};
++
++		led-wan-red {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_WAN;
++			gpios = <&chipcommon 5 GPIO_ACTIVE_HIGH>;
++		};
++
++		led-wps {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_WPS;
++			gpios = <&chipcommon 19 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&gmac0 {
++	nvmem-cells = <&et1macaddr 0>;
++	nvmem-cell-names = "mac-address";
++};
++
++&gmac1 {
++	nvmem-cells = <&et1macaddr 1>;
++	nvmem-cell-names = "mac-address";
++};
++
++&gmac2 {
++	nvmem-cells = <&et1macaddr 2>;
++	nvmem-cell-names = "mac-address";
++};
++
++&nandcs {
++	partitions {
++		compatible = "fixed-partitions";
++		#address-cells = <1>;
++		#size-cells = <1>;
++
++		partition@0 {
++			reg = <0x00000000 0x00080000>;
++			label = "boot";
++			read-only;
++		};
++
++		partition@80000 {
++			reg = <0x00080000 0x00180000>;
++			label = "nvram";
++		};
++
++		partition@200000 {
++			compatible = "brcm,trx";
++			reg = <0x00200000 0x07e00000>;
++			label = "firmware";
++		};
++	};
++};
++
++&srab {
++	status = "okay";
++
++	ports {
++		port@0 {
++			label = "wan";
++		};
++
++		port@1 {
++			label = "lan1";
++		};
++
++		port@2 {
++			label = "lan2";
++		};
++
++		port@3 {
++			label = "lan3";
++		};
++
++		port@4 {
++			label = "lan4";
++		};
++	};
++};
++
++&usb2 {
++	vcc-gpio = <&chipcommon 9 GPIO_ACTIVE_HIGH>;
++};
++
++&usb3_phy {
++	status = "okay";
++};


### PR DESCRIPTION
This commit adds OpenWrt support for the ASUS RT-AC3200 and RT-AC5300 routers, which are based on the Broadcom BCM4709x SoC with 256/512 MB RAM and 128 MB NAND flash.

Specifications:

ASUS RT-AC3200:
- SoC: Broadcom BCM4709A0 dual-core @ 1.0 GHz
- RAM: 256 MB DDR3
- Flash: 128 MB NAND
- 2.4GHz radio: BCM43602 3x3 802.11b/g/n
- 5GHz radios: BCM43602 3x3 x2 802.11a/n/ac
- Switch: BCM53012
- Ports: 4x LAN, 1x WAN

ASUS RT-AC5300:
- SoC: Broadcom BCM4709C0 dual-core @ 1.4 GHz
- RAM: 512 MB DDR3
- Flash: 128 MB NAND
- 2.4GHz radio: BCM4366 4x4 802.11b/g/n
- 5GHz radios: BCM4366 4x4 x2 802.11a/n/ac
- Switch: BCM53012
- Ports: 4x LAN, 1x WAN

Flashing Instructions

Recovery mode:
To flash from OEM or 3rd party firmware:
1. Press and hold the reset button while powering on.
2. Wait until the power LED flashes white.
3. Use a TFTP client to upload the `<model>.trx` firmware.
4. The router will reboot automatically and start OpenWrt.

Sysupgrade:
To upgrade OpenWrt, upload the `<model>.trx` firmware via the web interface.
For example, the file may be named `asus_rt-ac3200-squashfs.trx` or `asus_rt-ac5300-squashfs.trx`.

Tested on both devices:
- Booting and sysupgrade
- Ethernet connectivity
- LEDs and buttons

Looking forward to seeing these devices added to the OpenWrt Firmware Selector. This has been pending since 2024.

Please let me know if anything further should be adjusted.

Thank you for reviewing!