### PR TITLE
generic: dsa:  backport upstream realtek patches 

### DIFF
--- a/target/linux/generic/backport-6.6/911-v6.13-2-net-dsa-realtek-Use-for_each_child_of_node_scoped.patch
+++ b/target/linux/generic/backport-6.6/911-v6.13-2-net-dsa-realtek-Use-for_each_child_of_node_scoped.patch
@@ -1,0 +1,47 @@
+From 51c884291a94fd6598427d7d6c211f1f20780d57 Mon Sep 17 00:00:00 2001
+From: Jinjie Ruan <ruanjinjie@huawei.com>
+Date: Fri, 30 Aug 2024 11:13:19 +0800
+Subject: [PATCH 02/12] net: dsa: realtek: Use for_each_child_of_node_scoped()
+
+Avoid need to manually handle of_node_put() by using
+for_each_child_of_node_scoped(), which can simplfy code.
+
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Reviewed-by: Jonathan Cameron <Jonathan.Cameron@huawei.com>
+Signed-off-by: Jinjie Ruan <ruanjinjie@huawei.com>
+Reviewed-by: Linus Walleij <linus.walleij@linaro.org>
+Reviewed-by: Florian Fainelli <florian.fainelli@broadcom.com>
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+---
+ drivers/net/dsa/realtek/rtl8366rb.c | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+--- a/drivers/net/dsa/realtek/rtl8366rb.c
++++ b/drivers/net/dsa/realtek/rtl8366rb.c
+@@ -1013,8 +1013,8 @@ static int rtl8366rb_setup_all_leds_off(
+ 
+ static int rtl8366rb_setup_leds(struct realtek_priv *priv)
+ {
+-	struct device_node *leds_np, *led_np;
+ 	struct dsa_switch *ds = &priv->ds;
++	struct device_node *leds_np;
+ 	struct dsa_port *dp;
+ 	int ret = 0;
+ 
+@@ -1029,13 +1029,11 @@ static int rtl8366rb_setup_leds(struct r
+ 			continue;
+ 		}
+ 
+-		for_each_child_of_node(leds_np, led_np) {
++		for_each_child_of_node_scoped(leds_np, led_np) {
+ 			ret = rtl8366rb_setup_led(priv, dp,
+ 						  of_fwnode_handle(led_np));
+-			if (ret) {
+-				of_node_put(led_np);
++			if (ret)
+ 				break;
+-			}
+ 		}
+ 
+ 		of_node_put(leds_np);

--- a/target/linux/generic/backport-6.6/911-v6.13-3-net-dsa-realtek-rtl8365mb-Make-use-of-irq_get_trigge.patch
+++ b/target/linux/generic/backport-6.6/911-v6.13-3-net-dsa-realtek-rtl8365mb-Make-use-of-irq_get_trigge.patch
@@ -1,0 +1,32 @@
+From 517c29247557bf4a28065cb758a59ad545fe925d Mon Sep 17 00:00:00 2001
+From: Vasileios Amoiridis <vassilisamir@gmail.com>
+Date: Wed, 4 Sep 2024 17:10:16 +0200
+Subject: [PATCH 03/12] net: dsa: realtek: rtl8365mb: Make use of
+ irq_get_trigger_type()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Convert irqd_get_trigger_type(irq_get_irq_data(irq)) cases to the more
+simple irq_get_trigger_type(irq).
+
+Signed-off-by: Vasileios Amoiridis <vassilisamir@gmail.com>
+Reviewed-by: Alvin Šipraga <alsi@bang-olufsen.dk>
+Link: https://patch.msgid.link/20240904151018.71967-2-vassilisamir@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+---
+ drivers/net/dsa/realtek/rtl8365mb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/realtek/rtl8365mb.c
++++ b/drivers/net/dsa/realtek/rtl8365mb.c
+@@ -1735,7 +1735,7 @@ static int rtl8365mb_irq_setup(struct re
+ 	}
+ 
+ 	/* Configure chip interrupt signal polarity */
+-	irq_trig = irqd_get_trigger_type(irq_get_irq_data(irq));
++	irq_trig = irq_get_trigger_type(irq);
+ 	switch (irq_trig) {
+ 	case IRQF_TRIGGER_RISING:
+ 	case IRQF_TRIGGER_HIGH:

--- a/target/linux/generic/backport-6.6/911-v6.13-4-net-dsa-realtek-rtl8366rb-Make-use-of-irq_get_trigge.patch
+++ b/target/linux/generic/backport-6.6/911-v6.13-4-net-dsa-realtek-rtl8366rb-Make-use-of-irq_get_trigge.patch
@@ -1,0 +1,32 @@
+From 36a5faec5658736e8d3d9047c1387a69ffda3354 Mon Sep 17 00:00:00 2001
+From: Vasileios Amoiridis <vassilisamir@gmail.com>
+Date: Wed, 4 Sep 2024 17:10:17 +0200
+Subject: [PATCH 04/12] net: dsa: realtek: rtl8366rb: Make use of
+ irq_get_trigger_type()
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Convert irqd_get_trigger_type(irq_get_irq_data(irq)) cases to the more
+simple irq_get_trigger_type(irq).
+
+Reviewed-by: Alvin Šipraga <alsi@bang-olufsen.dk>
+Signed-off-by: Vasileios Amoiridis <vassilisamir@gmail.com>
+Link: https://patch.msgid.link/20240904151018.71967-3-vassilisamir@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>
+---
+ drivers/net/dsa/realtek/rtl8366rb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/dsa/realtek/rtl8366rb.c
++++ b/drivers/net/dsa/realtek/rtl8366rb.c
+@@ -603,7 +603,7 @@ static int rtl8366rb_setup_cascaded_irq(
+ 	}
+ 
+ 	/* Fetch IRQ edge information from the descriptor */
+-	irq_trig = irqd_get_trigger_type(irq_get_irq_data(irq));
++	irq_trig = irq_get_trigger_type(irq);
+ 	switch (irq_trig) {
+ 	case IRQF_TRIGGER_RISING:
+ 	case IRQF_TRIGGER_HIGH:


### PR DESCRIPTION
- net: dsa: realtek: Use for_each_child_of_node_scoped()
Avoid need to manually handle of_node_put() by using for_each_child_of_node_scoped(), which can simplfy code.
- net: dsa: realtek: rtl8365mb: Make use of irq_get_trigger_type()
 Convert irqd_get_trigger_type(irq_get_irq_data(irq)) cases to the more simple irq_get_trigger_type(irq).
- net: dsa: realtek: rtl8366rb: Make use of irq_get_trigger_type()
 Convert irqd_get_trigger_type(irq_get_irq_data(irq)) cases to the more simple irq_get_trigger_type(irq).

The current kernel from the 6.12 branch - 6.12.37, already contains these fixes.