### PR TITLE
bcm2712: add kmod-r8169 and kmod-usb-net-rtl8152

### DIFF
--- a/target/linux/bcm27xx/image/Makefile
+++ b/target/linux/bcm27xx/image/Makefile
@@ -193,6 +193,7 @@ define Device/rpi-4
 	kmod-spi-bcm2835-aux \
 	kmod-i2c-brcmstb \
 	kmod-usb-net-lan78xx \
+	kmod-usb-net-rtl8152 \
 	kmod-r8169
   IMAGE/sysupgrade.img.gz := boot-common | boot-2711 | sdcard-img | gzip | append-metadata
   IMAGE/factory.img.gz := boot-common | boot-2711 | sdcard-img | gzip
@@ -222,7 +223,10 @@ define Device/rpi-5
 	kmod-i2c-bcm2835 kmod-spi-bcm2835 \
 	kmod-i2c-brcmstb \
 	kmod-i2c-designware-platform kmod-spi-dw-mmio \
-	kmod-hwmon-pwmfan kmod-thermal
+	kmod-hwmon-pwmfan kmod-thermal \
+	kmod-usb-net-lan78xx \
+	kmod-usb-net-rtl8152 \
+	kmod-r8169
   IMAGE/sysupgrade.img.gz := boot-common | sdcard-img | gzip | append-metadata
   IMAGE/factory.img.gz := boot-common | sdcard-img | gzip
 endef


### PR DESCRIPTION
Boards such as [CM5-DUAL-ETH-MINI] and [PCIe_TO_Gigabit_ETH] add an extra Ethernet port to Raspberry Pi (CM)5. These typically use Realtek PCIe or USB Ethernet NICs. Include `kmod-r8169` and `kmod-usb-net-rtl8152` by default to make it easy to configure LAN/WAN ports with these parts on Raspberry Pi 5.

Because CM5 can fit in the same carrier boards as CM4, also ensure that both devices have the same Ethernet NIC kmods.

[CM5-DUAL-ETH-MINI]: https://www.waveshare.com/wiki/CM5-DUAL-ETH-MINI
[PCIe_TO_Gigabit_ETH]: https://www.waveshare.com/wiki/PCIe_TO_Gigabit_ETH_Board_(C)


