### PR TITLE
ltq-adsl-mei: check status register before reading mailbox messages

### DIFF
--- a/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
+++ b/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
@@ -1787,6 +1787,7 @@ extern void ifx_usb_enable_afe_oc(void);
  */
 static irqreturn_t IFX_MEI_IrqHandle (int int1, void *void0)
 {
+	u32 stat;
 	u32 scratch;
 	DSL_DEV_Device_t *pDev = (DSL_DEV_Device_t *) void0;
 #if defined(CONFIG_LTQ_MEI_FW_LOOPBACK) && defined(DFE_PING_TEST)
@@ -1820,6 +1821,12 @@ static irqreturn_t IFX_MEI_IrqHandle (int int1, void *void0)
                 if (dsl_bsp_event_callback[event].function)
                         (*dsl_bsp_event_callback[event].function)(pDev, event, dsl_bsp_event_callback[event].pData);
         } else { // normal message
+                IFX_MEI_LongWordReadOffset (pDev, (u32) ME_ARC2ME_STAT, &stat);
+                if (!(stat & ARC_TO_MEI_MSGAV)) {
+                        // status register indicates there is no message
+                        return IRQ_NONE;
+                }
+
                 IFX_MEI_MailboxRead (pDev, DSL_DEV_PRIVATE(pDev)->CMV_RxMsg, MSG_LENGTH);
                 if (DSL_DEV_PRIVATE(pDev)-> cmv_waiting == 1) {
                         DSL_DEV_PRIVATE(pDev)-> arcmsgav = 1;


### PR DESCRIPTION
The interrupt handler reads from the mailbox if no other reason for the interrupt is known. If a spurious interrupt is received just after a mailbox message has been sent, this means that the response to the previous message is read again and returned by DSL_BSP_SendCMV instead of the actual response.

To fix this, check the status register before reading from the mailbox in the interrupt handler.

Tested on Fritzbox 7320. Without this change, there is occasionally a kernel panic due to an out-of-bounds memory access in the ltq-adsl driver (in DSL_DRV_DEV_G997_SnrAllocationNscGet), as a result of an incorrect value returned by DSL_DRV_DANUBE_CmvRead. This is reproducible by calling "dsl_cpe_pipe.sh g997dsnrg 1 1" multiple times.

---

Here is an example of a kernel panic, including some additional debug output which shows the wrong data reurned by `DSL_DRV_DANUBE_CmvRead`:

```
root@OpenWrt:~# while true; do dsl_cpe_pipe.sh g997dsnrg 1 1 > /dev/null; done
[  366.045089] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  366.144706] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  366.246342] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  366.347606] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  366.443696] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  366.547907] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  366.643502] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  366.746488] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  366.846033] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  366.946816] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  367.047804] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  367.142688] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  367.241438] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  367.341958] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  367.445723] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  367.557549] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  367.657329] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  367.761547] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  367.864530] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  367.968506] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  368.069013] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  368.170047] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  368.269569] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  368.369107] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  368.466179] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  368.564866] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  368.670418] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  368.779104] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  368.867770] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  368.966818] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  369.065388] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  369.169087] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  369.268605] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  369.370621] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  369.473362] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  369.574891] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  369.677855] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  369.787478] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  369.888006] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  369.987292] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  370.086341] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  370.184397] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=61, nDsRangeU=511, nSnrAdd=0
[  370.281477] DSL_DRV_DEV_G997_SnrAllocationNscGet: len(nNSCData)=512, nNSC=512, nDsRangeD=13264, nDsRangeU=61, nSnrAdd=511
[  370.291300] CPU 1 Unable to handle kernel paging request at virtual address c0eb4000, epc == 82b61d48, ra == 82b61d2c
[  370.301671] Oops[#1]:
[  370.303740] CPU: 1 PID: 2313 Comm: dsl_cpe_control Tainted: G           O       6.6.95 #0
[  370.311844] $ 0   : 00000000 00000001 c0eb3ff6 000033d0
[  370.317015] $ 4   : ffffffff 00000040 c0eb63d0 00000000
[  370.322181] $ 8   : ffffefff 00000000 ffffffea 00000110
[  370.327370] $12   : 83989b5c 00000110 8095d2d8 ffffffff
[  370.332533] $16   : c077d000 00000001 00000000 c0eb3000
[  370.337717] $20   : 00000200 00000000 000001f8 00000008
[  370.342884] $24   : 00000018 00000000                  
[  370.348073] $28   : 83988000 83989c68 00000200 82b61d2c
[  370.353236] Hi    : 0000001c
[  370.356091] Lo    : 23d70aae
[  370.358930] epc   : 82b61d48 DSL_DRV_DEV_G997_SnrAllocationNscGet+0x54c/0x5d4 [drv_dsl_cpe_api]
[  370.367569] ra    : 82b61d2c DSL_DRV_DEV_G997_SnrAllocationNscGet+0x530/0x5d4 [drv_dsl_cpe_api]
[  370.376191] Status: 1100ff03	KERNEL EXL IE 
[  370.380323] Cause : 00800008 (ExcCode 02)
[  370.384291] BadVA : c0eb4000
[  370.387150] PrId  : 0001954c (MIPS 34Kc)
[  370.391020] Modules linked in: ltq_atm_ar9(O) ath9k(O) ath9k_common(O) nft_fib_inet nf_flow_table_inet ath9k_hw(O) ath(O) pppoe nft_reject_ipv6 nft_reject_ipv4 nft_reject_inet nft_reject nft_redir nft_quota nft_numgen nft_nat nft_masq nft_log nft_limit nft_hash nft_flow_offload nft_fib_ipv6 nft_fib_ipv4 nft_fib nft_ct nft_chain_nat nf_tables nf_nat nf_flow_table nf_conntrack mac80211(O) cfg80211(O) ath9k_pci_owl_loader(O) pppox ppp_async nfnetlink nf_reject_ipv6 nf_reject_ipv4 nf_log_syslog nf_defrag_ipv6 nf_defrag_ipv4 ltq_deu_ar9(O) libcrc32c crc_ccitt compat(O) drv_dsl_cpe_api(O) drv_mei_cpe(O) pppoatm ppp_generic slhc br2684 atm sha512_generic seqiv sha3_generic jitterentropy_rng drbg hmac geniv rng des_generic libdes cmac dwc2 roles gpio_button_hotplug(O) crc32c_generic
[  370.459181] Process dsl_cpe_control (pid: 2313, threadinfo=51608456, task=722765d9, tls=77cf5df4)
[  370.467979] Stack : 38e38e39 00000200 00000200 000033d0 0000003d 000001ff 000001ff 02000000
[  370.476257]         33d0003d 00000000 00000001 00000801 c0eb3fff ffffffff 00000000 00000000
[  370.484528]         00000000 00000000 37cf379e 37dc3736 37aa36f6 36ba3638 387337aa 385637c3
[  370.492820]         00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[  370.501099]         00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[  370.509385]         ...
[  370.511833] Call Trace:
[  370.514204] [<82b61d48>] DSL_DRV_DEV_G997_SnrAllocationNscGet+0x54c/0x5d4 [drv_dsl_cpe_api]
[  370.522688] [<82b63928>] DSL_DRV_DEV_G997_DeltSNRGet+0x11c/0x1d4 [drv_dsl_cpe_api]
[  370.530199] [<82b40e0c>] DSL_DRV_IoctlHandleHelperCall+0xc0/0x18c [drv_dsl_cpe_api]
[  370.537783] [<82b431e4>] DSL_DRV_IoctlHandle+0x474/0x63c [drv_dsl_cpe_api]
[  370.544575] [<82b453a0>] DSL_DRV_ErrorToOS+0x13c/0x16c [drv_dsl_cpe_api]
[  370.551183] 
[  370.552506] Code: 2404ffff  10c20007  00000000 <9047000a> 14e50002  00000000  a044000a  1000fff9  24420001 
[  370.562174] 
[  370.563902] ---[ end trace 0000000000000000 ]---
[  370.568346] Kernel panic - not syncing: Fatal exception
[  370.573409] Rebooting in 3 seconds..
```