### PR TITLE
kernel: package modules for I2C HID devices

### DIFF
--- a/package/kernel/linux/modules/input.mk
+++ b/package/kernel/linux/modules/input.mk
@@ -37,6 +37,23 @@ endef
 
 $(eval $(call KernelPackage,hid-generic))
 
+
+define KernelPackage/hid-alps
+  SUBMENU:=$(INPUT_MODULES_MENU)
+  TITLE:=Alps HID device support
+  DEPENDS:=+kmod-hid
+  KCONFIG:=CONFIG_HID_ALPS
+  FILES:=$(LINUX_DIR)/drivers/hid/hid-alps.ko
+  AUTOLOAD:=$(call AutoProbe,hid-alps)
+endef
+
+define KernelPackage/hid-alps/description
+ Support for Alps I2C HID touchpads and StickPointer.
+endef
+
+$(eval $(call KernelPackage,hid-alps))
+
+
 define KernelPackage/input-core
   SUBMENU:=$(INPUT_MODULES_MENU)
   TITLE:=Input device core


### PR DESCRIPTION
Package driver modules for I2C HID devices such as touchpads, touchscreens and trackpoints found on some laptops. Only the ACPI firmware variant of the driver is packaged for now as that's what I got for testing.
Also package the hid-alps driver to support a specific I2C touchpad and trackpoint.