### PR TITLE
bcm27xx/rockchip/x86: increase rootfs size to 448 MiB

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -336,7 +336,7 @@ menu "Target Images"
 		int "Root filesystem partition size (in MiB)"
 		depends on USES_ROOTFS_PART || TARGET_ROOTFS_EXT4FS
 		default 232 if TARGET_loongarch64
-		default 448 if TARGET_mediatek || TARGET_microchipsw
+		default 448 if TARGET_bcm27xx || TARGET_mediatek || TARGET_microchipsw || TARGET_rockchip || TARGET_x86
 		default 104
 		help
 		  Select the root filesystem partition size.


### PR DESCRIPTION
Increase the default rootfs size (104 MiB)image for bcm27xx and rockchip to 448 MiB.
This help users to to install packages like docker, default size currently in not enough.
Image size comparison:
bcm2712
```
104MiB
# ls -l
total 25040
-rw-rw-r-- 1 13540288 Jul 14 21:06 openwrt-bcm27xx-bcm2712-rpi-5-ext4-sysupgrade.img.gz
-rw-rw-r-- 1 12098109 Jul 14 21:06 openwrt-bcm27xx-bcm2712-rpi-5-squashfs-sysupgrade.img.gz
```
```
448MiB
# ls -l
total 25384
-rw-rw-r-- 1 13890983 Jul 14 23:25 openwrt-bcm27xx-bcm2712-rpi-5-ext4-sysupgrade.img.gz
-rw-rw-r-- 1 12097107 Jul 14 23:25 openwrt-bcm27xx-bcm2712-rpi-5-squashfs-sysupgrade.img.gz
```
rockchip

```
104MiB
# ls -l
total 21288
-rw-rw-r-- 1 11505239 Jul 14 21:18 openwrt-rockchip-armv8-friendlyarm_nanopi-r5c-ext4-sysupgrade.img.gz
-rw-rw-r-- 1 10290714 Jul 14 21:18 openwrt-rockchip-armv8-friendlyarm_nanopi-r5c-squashfs-sysupgrade.img.gz
```
```
448MiB
# ls -l
total 21972
-rw-rw-r-- 1 11855994 Jul 14 23:44 openwrt-rockchip-armv8-friendlyarm_nanopi-r5c-ext4-sysupgrade.img.gz
-rw-rw-r-- 1 10640868 Jul 14 23:44 openwrt-rockchip-armv8-friendlyarm_nanopi-r5c-squashfs-sysupgrade.img.gz
```
x86/64

```
104MiB
# ls -l
total 25220
-rw-rw-r-- 1 13509783 Jul 14 20:58  openwrt-x86-64-generic-ext4-combined-efi.img.gz
-rw-rw-r-- 1 12305524 Jul 14 20:58  openwrt-x86-64-generic-squashfs-combined-efi.img.gz
```
```
448MiB
# ls -l
total 26008
-rw-rw-r-- 1 13917177 Jul 14 23:23 openwrt-x86-64-generic-ext4-combined-efi.img.gz
-rw-rw-r-- 1 12709941 Jul 14 23:23 openwrt-x86-64-generic-squashfs-combined-efi.img.gz
```