### PR TITLE
rockchip: fix eMMC corruption on NanoPC-T6 with A3A444 chips

### DIFF
--- a/target/linux/rockchip/patches-6.12/131-arm64-dts-rockchip-rk3588-fix-A3A444-nanopc-t6.patch
+++ b/target/linux/rockchip/patches-6.12/131-arm64-dts-rockchip-rk3588-fix-A3A444-nanopc-t6.patch
@@ -1,0 +1,12 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
+@@ -619,8 +619,7 @@
+ 	no-sd;
+ 	non-removable;
+ 	max-frequency = <200000000>;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
++	mmc-hs200-1_8v;
+ 	status = "okay";
+ };
+ 


### PR DESCRIPTION
Some NanoPC-T6 boards with A3A444 eMMC chips experience I/O errors and corruption when using HS400 mode. Downgrade to HS200 mode to ensure stable operation.

Fixes: https://github.com/openwrt/openwrt/issues/18844