### PR TITLE
hostapd: explicitly initialize wpabuf->flags to 0 in wpabuf_alloc()

### DIFF
--- a/package/network/services/hostapd/patches/260-fix-wpabuf-free.patch
+++ b/package/network/services/hostapd/patches/260-fix-wpabuf-free.patch
@@ -1,0 +1,10 @@
+--- a/src/utils/wpabuf.c
++++ b/src/utils/wpabuf.c
+@@ -128,6 +128,7 @@ struct wpabuf * wpabuf_alloc(size_t len)
+ 
+ 	buf->size = len;
+ 	buf->buf = (u8 *) (buf + 1);
++	buf->flags = 0;
+ 	return buf;
+ }
+ 


### PR DESCRIPTION
explicitly initialize wpabuf->flags to 0 in wpabuf_alloc()

This avoids warnings such as:
_warning: free called on pointer 36 with nonzero offset 32 [-Wfree-nonheap-object]_

by explicitly setting wpabuf->flags to 0 ensures and prevents from misinterpreting the state of the buffer
