### PR TITLE
mediatek: filogic: add Teltonika RUTC50 support

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -130,6 +130,33 @@ define Build/append-gl-metadata
 	}
 endef
 
+define Build/append-teltonika-metadata
+	echo \
+		'{$(if $(IMAGE_METADATA),$(IMAGE_METADATA)$(comma)) \
+			"metadata_version": "1.1", \
+			"compat_version": "$(call json_quote,$(compat_version))", \
+			"version":"$(call json_quote,$(VERSION_DIST))-$(call json_quote,$(VERSION_NUMBER))-$(call json_quote,$(REVISION))", \
+			"device_code": [".*"], \
+			"hwver": [".*"], \
+			"batch": [".*"], \
+			"serial": [".*"], \
+			$(if $(DEVICE_COMPAT_MESSAGE),"compat_message": "$(call json_quote,$(DEVICE_COMPAT_MESSAGE))"$(comma)) \
+			$(if $(filter-out 1.0,$(compat_version)),"new_supported_devices": \
+				[$(call metadata_devices,$(SUPPORTED_TELTONIKA_DEVICES))]$(comma) \
+				"supported_devices": ["$(call json_quote,$(legacy_supported_message))"]$(comma)) \
+			$(if $(filter 1.0,$(compat_version)),"supported_devices":[$(call metadata_devices,$(SUPPORTED_TELTONIKA_DEVICES))]$(comma)) \
+			"version_wrt": { \
+			"dist": "$(call json_quote,$(VERSION_DIST))", \
+			"version": "$(call json_quote,$(VERSION_NUMBER))", \
+			"revision": "$(call json_quote,$(REVISION))", \
+			"target": "$(call json_quote,$(TARGETID))", \
+			"board": "$(call json_quote,$(if $(BOARD_NAME),$(BOARD_NAME),$(DEVICE_NAME)))" \
+		}, \
+			"hw_support": {}, \
+			"hw_mods": {$(shell i=1; for mod in $(SUPPORTED_TELTONIKA_HW_MODS); do [ $$i -gt 1 ] && echo -n ,; echo -n "\"mod$$i\": \"$$mod\""; i=$$((i+1)); done)} \
+		}' | fwtool -I - $@
+endef
+
 define Build/append-rootfs
 	dd if=$(IMAGE_ROOTFS) >> $@
 endef

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -127,6 +127,10 @@ tplink,archer-ax80-v1)
 ubnt,unifi-6-plus)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x10000"
 	;;
+teltonika,rutc50)
+	local envdev=/dev/mtd$(find_mtd_index "u-boot-env")
+	ubootenv_add_uci_config "$envdev" "0x0" "0x10000" "0x10000"
+	;;
 xiaomi,mi-router-ax3000t|\
 xiaomi,mi-router-wr30u-stock|\
 xiaomi,redmi-router-ax6000-stock)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -13,6 +13,7 @@ DEVICE_VARS += ELECOM_HWID
 DEVICE_VARS += MOXA_MAGIC MOXA_HWID
 DEVICE_VARS += OPENMESH_CE_TYPE ZYXEL_MODEL_STRING
 DEVICE_VARS += SUPPORTED_TELTONIKA_DEVICES
+DEVICE_VARS += SUPPORTED_TELTONIKA_HW_MODS
 
 define Build/addpattern
 	-$(STAGING_DIR_HOST)/bin/addpattern -B $(ADDPATTERN_ID) \
@@ -151,35 +152,6 @@ define Build/teltonika-v1-header
 		-m $(TPLINK_HEADER_VERSION) -N "$(VERSION_DIST)" -V "RUT2xx      " \
 		-k $@ -o $@.new $(1)
 	@mv $@.new $@
-endef
-
-metadata_json_teltonika = \
-	'{ $(if $(IMAGE_METADATA),$(IMAGE_METADATA)$(comma)) \
-		"metadata_version": "1.1", \
-		"compat_version": "$(call json_quote,$(compat_version))", \
-		"version":"$(call json_quote,$(VERSION_DIST))-$(call json_quote,$(VERSION_NUMBER))-$(call json_quote,$(REVISION))", \
-		"device_code": [".*"], \
-		"hwver": [".*"], \
-		"batch": [".*"], \
-		"serial": [".*"], \
-		$(if $(DEVICE_COMPAT_MESSAGE),"compat_message": "$(call json_quote,$(DEVICE_COMPAT_MESSAGE))"$(comma)) \
-		$(if $(filter-out 1.0,$(compat_version)),"new_supported_devices": \
-			[$(call metadata_devices,$(SUPPORTED_TELTONIKA_DEVICES))]$(comma) \
-			"supported_devices": ["$(call json_quote,$(legacy_supported_message))"]$(comma)) \
-		$(if $(filter 1.0,$(compat_version)),"supported_devices":[$(call metadata_devices,$(SUPPORTED_TELTONIKA_DEVICES))]$(comma)) \
-		"version_wrt": { \
-			"dist": "$(call json_quote,$(VERSION_DIST))", \
-			"version": "$(call json_quote,$(VERSION_NUMBER))", \
-			"revision": "$(call json_quote,$(REVISION))", \
-			"target": "$(call json_quote,$(TARGETID))", \
-			"board": "$(call json_quote,$(if $(BOARD_NAME),$(BOARD_NAME),$(DEVICE_NAME)))" \
-		}, \
-		"hw_support": {}, \
-		"hw_mods": {} \
-	}'
-
-define Build/append-metadata-teltonika
-	echo $(call metadata_json_teltonika) | fwtool -I - $@
 endef
 
 define Build/wrgg-pad-rootfs
@@ -3152,7 +3124,7 @@ define Device/teltonika_rut300
   IMAGE_SIZE := 15552k
   IMAGES += factory.bin
   IMAGE/factory.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | \
-			 append-rootfs | pad-rootfs | append-metadata-teltonika | \
+			 append-rootfs | pad-rootfs | append-teltonika-metadata | \
 			 check-size $$$$(IMAGE_SIZE)
   IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | \
 			 append-rootfs | pad-rootfs | append-metadata | \

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -2,6 +2,8 @@
 DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
 DEVICE_VARS += RAS_BOARD RAS_ROOTFS_SIZE RAS_VERSION
 DEVICE_VARS += WRGG_DEVNAME WRGG_SIGNATURE
+DEVICE_VARS += SUPPORTED_TELTONIKA_DEVICES
+DEVICE_VARS += SUPPORTED_TELTONIKA_HW_MODS
 
 define Build/netgear-fit-padding
 	./netgear-fit-padding.py $@ $@.new
@@ -50,17 +52,6 @@ define Build/append-rootfshdr
 		-n root.squashfs -d $(IMAGE_ROOTFS) $@.new
 	cat $(IMAGE_KERNEL) > $@.$1
 	dd if=$@.new bs=64 count=1 >> $@.$1
-endef
-
-define Build/append-rutx-metadata
-	echo \
-		'{ \
-			"device_code": [".*"], \
-			"hwver": [".*"], \
-			"batch": [".*"], \
-			"serial": [".*"], \
-			"supported_devices":["teltonika,rutx"] \
-		}' | fwtool -I - $@
 endef
 
 define Build/copy-file
@@ -1122,13 +1113,15 @@ define Device/teltonika_rutx10
 	$(call Device/UbiFit)
 	DEVICE_VENDOR := Teltonika
 	DEVICE_MODEL := RUTX10
+	SUPPORTED_TELTONIKA_DEVICES := teltonika,rutx
+	SUPPORTED_TELTONIKA_HW_MODS := W25N02KV NAND_GD5F2GXX EG060K RUTX_V12
 	SOC := qcom-ipq4018
 	DEVICE_DTS_CONFIG := config@5
 	KERNEL_INSTALL := 1
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 	FILESYSTEMS := squashfs
-	IMAGE/factory.ubi := append-ubi | qsdk-ipq-factory-nand | append-rutx-metadata
+	IMAGE/factory.ubi := append-ubi | qsdk-ipq-factory-nand | append-teltonika-metadata
 	DEVICE_PACKAGES := kmod-btusb
 endef
 # Missing DSA Setup

--- a/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
+++ b/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "Teltonika RUTC50";
+	compatible = "teltonika,rutc50", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		label-mac-device = &gmac0;
+		led-boot = &power;
+		led-failsafe = &power;
+		led-running = &power;
+		led-upgrade = &power;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x10000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_pcie_reset {
+			gpio-export,name = "pcie_reset";
+			gpio-export,output = <1>;
+			gpios = <&pio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_modem_power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <0>;
+			gpios = <&pio 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_modem_reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <0>;
+			gpios = <&pio 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_modem_status {
+			gpio-export,name = "modem_status";
+			gpio-export,input = <0>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_digital_input {
+			gpio-export,name = "digital_input";
+			gpio-export,input = <0>;
+			gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_digital_output {
+			gpio-export,name = "digital_output";
+			gpio-export,output = <0>;
+			gpios = <&pio 35 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_eth {
+			function = "wan-eth";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_wifi {
+			function = "wan-wifi";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 1 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_sim1 {
+			function = "wan-sim1";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_sim2 {
+			function = "wan-sim2";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi_2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 14 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		3G {
+			function = "3G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		4G {
+			function = "4G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		5G {
+			function = "5G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi1 {
+			function = "rssi-1";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi2 {
+			function = "rssi-2";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 2 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi3 {
+			function = "rssi-3";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 1 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1000>;
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&gbe_led0_pins>, <&gbe_led1_pins>;
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		nvmem-cells = <&macaddr_config_0 0>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		label = "wan";
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cells = <&macaddr_config_0 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&int_gbe_phy_led0{
+	function = LED_FUNCTION_WAN;
+	color = <LED_COLOR_ID_AMBER>;
+	status = "okay";
+};
+
+&int_gbe_phy_led1{
+	function = LED_FUNCTION_WAN;
+	color = <LED_COLOR_ID_GREEN>;
+	status = "okay";
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				phy-handle = <&swphy0>;
+				label = "lan4";
+			};
+
+			port@1 {
+				reg = <1>;
+				phy-handle = <&swphy1>;
+				label = "lan3";
+			};
+
+			port@2 {
+				reg = <2>;
+				phy-handle = <&swphy2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				phy-handle = <&swphy3>;
+				label = "lan1";
+			};
+
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+
+		mdio {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			swphy0: phy@0 {
+				reg = <0>;
+
+				mediatek,led-config = <
+					0x21 0x8009 /* BASIC_CTRL */
+					0x22 0x0c00 /* ON_DURATION */
+					0x23 0x1400 /* BLINK_DURATION */
+					0x24 0xc001 /* LED0_ON_CTRL */
+					0x25 0x0003 /* LED0_BLINK_CTRL */
+					0x26 0xc006 /* LED1_ON_CTRL */
+					0x27 0x003c /* LED1_BLINK_CTRL */
+				>;
+			};
+
+			swphy1: phy@1 {
+				reg = <1>;
+			};
+
+			swphy2: phy@2 {
+				reg = <2>;
+			};
+
+			swphy3: phy@3 {
+				reg = <3>;
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "rutos-a";
+				reg = <0x00000000 0x10000000>;
+			};
+
+			partition@10000000 {
+				label = "rutos-b";
+				reg = <0x10000000 0x10000000>;
+			};
+		};
+	};
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spic_pins>;
+	status = "okay";
+
+	gpio_hc595: gpio_hc595@0 {
+		compatible = "fairchild,74hc595";
+		reg = <0>;
+		gpio-controller;
+		#gpio-cells = <2>;
+		registers-number = <1>;
+		spi-max-frequency = <10000000>;
+		enable-gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&spi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+
+		spi-max-frequency = <4000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@00000 {
+				label = "bl2";
+				reg = <0x00000 0x0040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x0010000>;
+			};
+
+			factory: partition@50000 {
+				label = "factory";
+				reg = <0x50000 0x00A0000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
+			};
+
+			config: partition@f0000	{
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				label = "config";
+				reg = <0xF0000 0x0010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_0: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			boot: partition@100000 {
+				label = "fip";
+				reg = <0x100000 0x0100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "bootconfig-a";
+				reg = <0x200000 0x010000>;
+			};
+
+			partition@210000 {
+				label = "bootconfig-b";
+				reg = <0x210000 0x010000>;
+			};
+
+			partition@220000 {
+				label = "event-log";
+				reg = <0x220000 0x090000>;
+			};
+
+			partition@2B0000 {
+				label = "recovery";
+				reg = <0x2B0000 0xD50000>;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+	spic_pins: spi1-pins {
+		mux {
+			function = "spi";
+			groups = "spi1_1";
+		};
+	};
+
+	spi2_flash_pins: spi2-pins {
+		mux {
+			function = "spi";
+			groups = "spi2", "spi2_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};
+
+&wifi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	status = "okay";
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_config_0 2>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_config_0 3>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -199,6 +199,10 @@ smartrg,sdg-8733a)
 	ucidef_set_led_netdev "wan-orange" "WAN" "mdio-bus:08:orange:wan" "wan" "link_100 link_1000"
 	ucidef_set_led_netdev "wan-white" "WAN" "mdio-bus:08:white:wan" "wan" "link_10000"
 	;;
+teltonika,rutc50)
+	ucidef_set_led_netdev "wan-green" "WAN" "mdio-bus:00:green:wan" "wan" "link_1000 tx rx"
+	ucidef_set_led_netdev "wan-amber" "WAN" "mdio-bus:00:amber:wan" "wan" "link_100 link_10 tx rx"
+	;;
 tplink,fr365-v1)
 	ucidef_set_led_netdev "port2-green-act" "port-2" "green:port2_act" "port2" "link tx rx"
 	ucidef_set_led_netdev "port1-green-act" "port-1" "green:sfp" "port1" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
@@ -8,6 +8,10 @@ case "$board" in
 huasifei,wh3000-pro)
 	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "0"
 	;;
+teltonika,rutc50)
+	ucidef_add_gpio_switch "modem_power" "Modem power button" "modem_power" "1"
+	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
+	;;
 zbtlink,zbt-z8102ax|\
 zbtlink,zbt-z8102ax-v2)
 	ucidef_add_gpio_switch "5g1" "Power 1st modem" "5g1" "1"

--- a/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount
+++ b/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount
@@ -23,6 +23,28 @@ boot() {
 		EOF
 		logger "bootcount: rd23 model detected, nvram was updated"
 		;;
+	teltonika,rutc50)
+		#Bootloader expect successfull startup value after update, we need to write success value to bootconfig partition
+		#otherwise bootloader will fallback to previous root partition
+		. /lib/functions.sh
+		local PART="$(cmdline_get_var ubi.mtd)"
+		local MTD_INDEX=$(find_mtd_index bootconfig-a)
+
+		case "$PART" in
+		rutos-a)
+			[ "$(md5sum /dev/mtd$MTD_INDEX | awk '{print $1}')" = "adc4a78e76efc6b4afdc41925e4017c6" ] || {
+				logger -t "bootcount" "saving new failsafe boot config in /dev/mtd$MTD_INDEX bootconfig-a partition rutos-a"
+				echo -ne "\xe1\xb0\xba\xba\x01\x00\xf9\x01\xf8\x01\xf0\x00\x3d\xd4\xfb\x95" | mtd -e bootconfig-a write - bootconfig-a
+			}
+			;;
+		rutos-b)
+			[ "$(md5sum /dev/mtd$MTD_INDEX | awk '{print $1}')" = "2904b3476604ef153d1925acdde062e8" ] || {
+				logger -t "bootcount" "saving new failsafe boot config in /dev/mtd$MTD_INDEX bootconfig-a partition rutos-b"
+				echo -ne "\xe1\xb0\xba\xba\x01\x01\xf7\x01\xf8\x00\xf0\x00\xce\xd4\x44\x08" | mtd -e bootconfig-a write - bootconfig-a
+				}
+			;;
+		esac
+		;;
 	zyxel,ex5700-telenor)
 		fw_setenv uboot_bootcount 0
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -174,6 +174,10 @@ platform_do_upgrade() {
 		CI_ROOTPART="rootfs"
 		nand_do_upgrade "$1"
 		;;
+	teltonika,rutc50)
+		CI_UBIPART="$(cmdline_get_var ubi.mtd)"
+		nand_do_upgrade "$1"
+		;;
 	nradio,c8-668gl)
 		CI_DATAPART="rootfs_data"
 		CI_KERNPART="kernel_2nd"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1,4 +1,6 @@
 DTS_DIR := $(DTS_DIR)/mediatek
+DEVICE_VARS += SUPPORTED_TELTONIKA_DEVICES
+DEVICE_VARS += SUPPORTED_TELTONIKA_HW_MODS
 
 define Image/Prepare
 	# For UBI we want only one extra block
@@ -1868,6 +1870,24 @@ define Device/snr_snr-cpe-ax2
   ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot snr_snr-cpe-ax2
 endef
 TARGET_DEVICES += snr_snr-cpe-ax2
+
+define Device/teltonika_rutc50
+  DEVICE_VENDOR := Teltonika
+  DEVICE_MODEL := RUTC50
+  SUPPORTED_TELTONIKA_DEVICES := teltonika,rutc
+  DEVICE_DTS := mt7981a-teltonika-rutc50
+  DEVICE_DTS_DIR := ../dts
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  UBINIZE_OPTS := -E 5
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-net-qmi-wwan \
+  kmod-usb-serial-option kmod-gpio-nxp-74hc164
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | append-teltonika-metadata
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += teltonika_rutc50
 
 define Device/tenbay_wr3000k
   DEVICE_VENDOR := Tenbay

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -5,6 +5,8 @@
 include ./common-tp-link.mk
 
 DEFAULT_SOC := mt7628an
+DEVICE_VARS += SUPPORTED_TELTONIKA_DEVICES
+DEVICE_VARS += SUPPORTED_TELTONIKA_HW_MODS
 
 define Build/creality_wb-01-factory
 	mv $@ $(dir $@)factory.bin
@@ -40,25 +42,6 @@ define Build/ravpower-wd009-factory
 		-n "OpenWrt Bootloader" -d $(UBOOT_PATH) $@.new
 	cat $@ >> $@.new
 	@mv $@.new $@
-endef
-
-define Build/append-teltonika-metadata
-  $(eval model_id=$(word 1,$(1)))
-  $(eval hw_mods=$(subst $(space),$(comma),$(wordlist 2,$(words $(1)),$(1))))
-
-	echo \
-		'{ \
-			"metadata_version": "1.1", \
-			"compat_version": "1.0", \
-			"version": "OpenWrt", \
-			"device_code": [".*"], \
-			"hwver": [".*"], \
-			"batch": [".*"], \
-			"serial": [".*"], \
-			"supported_devices":["teltonika,$(model_id)"], \
-			"hw_support": { }, \
-			"hw_mods": { $(hw_mods) } \
-		}' | fwtool -I - $@
 endef
 
 define Device/7links_wlr-12xx
@@ -700,6 +683,8 @@ define Device/teltonika_rut9x1
   DEVICE_MODEL := RUT951
   DEVICE_ALT0_VENDOR := Teltonika
   DEVICE_ALT0_MODEL := RUT901
+  SUPPORTED_TELTONIKA_DEVICES := teltonika,rut9m
+  SUPPORTED_TELTONIKA_HW_MODS := 2c7c_6005 TLA2021 CH343 esim ala440
   IMAGE_SIZE := 15424k
   BLOCKSIZE := 64k
   DEVICE_PACKAGES := uqmi kmod-mt76x2 kmod-usb2 kmod-usb-ohci \
@@ -707,8 +692,7 @@ define Device/teltonika_rut9x1
 	kmod-i2c-mt7628 kmod-usb-net-cdc-ether
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size | append-teltonika-metadata rut9m \
-	"mod1":"2c7c_6005" "mod2":"TLA2021" "mod3":"CH343" "mod4":"esim" "mod5":"ala440"
+	append-rootfs | pad-rootfs | check-size | append-teltonika-metadata
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 TARGET_DEVICES += teltonika_rut9x1
@@ -718,6 +702,8 @@ define Device/teltonika_rut9x6
   DEVICE_MODEL := RUT956
   DEVICE_ALT0_VENDOR := Teltonika
   DEVICE_ALT0_MODEL := RUT906
+  SUPPORTED_TELTONIKA_DEVICES := teltonika,rut9m
+  SUPPORTED_TELTONIKA_HW_MODS := 2c7c_6005 TLA2021 CH343 esim ala440
   IMAGE_SIZE := 15424k
   BLOCKSIZE := 64k
   DEVICE_PACKAGES := uqmi kmod-mt76x2 kmod-usb2 kmod-usb-ohci \
@@ -725,8 +711,7 @@ define Device/teltonika_rut9x6
 	kmod-hwmon-mcp3021 kmod-scsi-core kmod-usb-storage kmod-usb-acm kmod-usb-net-cdc-ether
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
-	append-rootfs | pad-rootfs | check-size | append-teltonika-metadata rut9m \
-	"mod1":"2c7c_6005" "mod2":"TLA2021" "mod3":"CH343" "mod4":"esim" "mod5":"ala440"
+	append-rootfs | pad-rootfs | check-size | append-teltonika-metadata
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 TARGET_DEVICES += teltonika_rut9x6
@@ -1407,11 +1392,12 @@ define Device/teltonika_rut200
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT200
   DEVICE_VARIANT := v1-v4
+  SUPPORTED_TELTONIKA_DEVICES := teltonika,rut2m
   IMAGE_SIZE := 15424k
   BLOCKSIZE := 64k
   DEVICE_PACKAGES +=kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-serial-option kmod-usb-net-cdc-ether
   IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-teltonika-metadata rut2m
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-teltonika-metadata
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 TARGET_DEVICES += teltonika_rut200
@@ -1420,11 +1406,12 @@ define Device/teltonika_rut241
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT241
   DEVICE_VARIANT := v1-v4
+  SUPPORTED_TELTONIKA_DEVICES := teltonika,rut2m
   IMAGE_SIZE := 15424k
   BLOCKSIZE := 64k
   DEVICE_PACKAGES += uqmi kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-serial-option
   IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-teltonika-metadata rut2m
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-teltonika-metadata
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 TARGET_DEVICES += teltonika_rut241


### PR DESCRIPTION
This pull request add support for Teltonika RUTC50.
The Teltonika RUTC50 is an industrial mobile router, it supports WiFi 6, have 5G REL 16 modem and external USB port.

## Specification:
- MediaTek MT7981A SoC
- 512 MB RAM
- 16MB SPI NOR Flash
- 512MB NAND (split in half for firmware fallback)
- 5x 10/100/1000 Mbps Ethernet, with passive PoE support on LAN1
- WLAN      : MediaTek dual-band WiFi 6
  - 2.4 GHz : b/g/n/ax, MIMO 2x2
  - 5 GHz   : a/n/ac/ax, MIMO 2x2
- Quectel RG520N-EB 5G R16 modem
- 2.0 USB Type-A HOST port
- 1x Digital input
- 1x Digital output
- 2x SIM slot (can be swapped via AT commands)

GPIO:
- 1 button (Reset)
- 13 LEDs (power, 4x WAN status, Wifi 2G, Wifi 5G, 3G, 4G, 5G, RSSI 1,2,3)
- 3 Modem control (power button, reset, status)
- 1 USB reset
- 1 Digital input
- 1 Digital output

## Installation
Flashing via OEM WebUI:
1. Download the firmware image *-squashfs-factory.bin
2. Upload firmware image via OEM WebUI firmware update, do not keep settings

To revert back to OEM firmware:
https://wiki.teltonika-networks.com/view/Bootloader_menu

## Additional info:
Use "ModemManager" to establish mobile data connection.