### PR TITLE
bcm53xx: add support for ASUS RT-AC3200 and RT-AC5300

### DIFF
--- a/package/utils/nvram/Makefile
+++ b/package/utils/nvram/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nvram
-PKG_RELEASE:=12
+PKG_RELEASE:=13
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 
@@ -49,6 +49,10 @@ endif
 ifneq ($(CONFIG_TARGET_bcm53xx),)
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/nvram-bcm53xx.init $(1)/etc/init.d/nvram
+endif
+ifneq ($(CONFIG_TARGET_bcm53xx),)
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_BIN) ./files/04-nvram-firstboot $(1)/etc/uci-defaults/04-nvram-firstboot
 endif
 endef
 

--- a/package/utils/nvram/files/04-nvram-firstboot
+++ b/package/utils/nvram/files/04-nvram-firstboot
@@ -1,0 +1,166 @@
+#!/bin/sh
+
+. /lib/functions/system.sh
+
+[ "$(board_name)" = "asus,rt-ac3200" ] || exit 0
+
+CHANGED=0
+
+while IFS='=' read -r K V; do
+	[ -n "$K" ] || continue
+	case "$K" in \#*) continue ;; esac
+	CUR="$(nvram get "$K" || true)"
+	if [ -z "$CUR" ]; then
+		nvram set "$K=$V"
+		CHANGED=1
+	fi
+done <<'EOF'
+2:sromrev=11
+2:aga0=0x0
+2:rawtempsense=0x1ff
+2:aga1=0x0
+2:aga2=0x0
+2:papdcap5g=0
+2:pdgain5g=4
+2:rxgains5ghtrelnabypa0=1
+2:rxgains5ghtrelnabypa1=1
+2:rxgains5ghtrelnabypa2=1
+1:temps_period=5
+2:boardvendor=0x14e4
+2:devpath2=sb/1/
+1:devpath1=sb/1/
+0:devpath0=sb/1/
+2:mcsbw1605ghpo=0
+1:boardrev=0x1421
+0:boardvendor=0x14e4
+1:rxchain=7
+2:boardflags=0x30040000
+1:gainctrlsph=0
+2:antswitch=0
+2:epagain5g=0
+1:femctrl=3
+0:venid=0x14e4
+2:rxgains5ghelnagaina0=2
+1:txchain=7
+2:rxgains5ghelnagaina1=2
+2:rxgains5ghelnagaina2=2
+2:tempcorrx=0x3f
+1:xtalfreq=40000
+2:xtalfreq=40000
+2:rxgains5gmtrisoa0=5
+0:xtalfreq=40000
+2:rxgains5gmtrisoa1=5
+2:rxgains5gmtrisoa2=5
+2:rxgains5gtrisoa2=5
+2:boardflags2=0x00220102
+2:rxgains5gtrisoa0=5
+2:boardflags3=0x0
+2:rxgains5gtrisoa1=5
+0:dot11agduphrpo=0
+2:rxgains5gelnagaina0=2
+2:rxgains5gelnagaina1=2
+2:rxgains5gelnagaina2=2
+2:phycal_tempdelta=15
+0:boardflags3=0x0
+0:boardflags2=0x00220102
+2:temps_hysteresis=5
+0:tempoffset=255
+2:mcslr5ghpo=0
+0:subband5gver=0x4
+2:tworangetssi5g=0
+0:devid=0x43bc
+2:mcsbw1605glpo=0
+0:dot11agduplrpo=0
+2:venid=0x14e4
+2:rxgains5gtrelnabypa0=1
+2:rxgains5gtrelnabypa1=1
+2:rxgains5gtrelnabypa2=1
+0:pdoffset40ma1=4369
+0:pdoffset40ma2=4369
+0:pdoffset40ma0=4369
+2:femctrl=3
+2:mcsbw1605gmpo=0
+2:subband5gver=0x4
+2:dot11agduphrpo=0
+2:txchain=7
+1:rawtempsense=0x1ff
+1:tempoffset=255
+2:devid=0x43bc
+0:temps_period=5
+2:tempsense_option=0x3
+2:dot11agduplrpo=0
+1:tempsense_option=0x3
+2:rxgains5gmelnagaina0=2
+2:rxgains5gmelnagaina1=2
+2:rxgains5gmelnagaina2=2
+2:rxchain=7
+1:phycal_tempdelta=15
+0:phycal_tempdelta=15
+1:temps_hysteresis=5
+1:boardvendor=0x14e4
+2:temps_period=5
+2:mcslr5glpo=0
+2:tempsense_slope=0xff
+2:gainctrlsph=0
+0:sromrev=11
+2:tempoffset=255
+0:gainctrlsph=0
+2:mcslr5gmpo=0
+0:tempthresh=125
+0:tempcorrx=0x3f
+2:rxgains5ghtrisoa2=5
+devpath2=pcie/2/1
+1:tempsense_slope=0xff
+2:rxgains5ghtrisoa0=5
+devpath0=pcie/1/3
+2:rxgains5ghtrisoa1=5
+devpath1=pcie/1/4
+0:aga1=0x0
+0:aga2=0x0
+0:aga0=0x0
+0:tempsense_option=0x3
+0:femctrl=3
+1:boardflags2=0x00100002
+1:boardflags3=0x40000005
+2:rxgains5gmtrelnabypa1=1
+2:rxgains5gmtrelnabypa2=1
+2:rxgains5gmtrelnabypa0=1
+2:tssiposslope5g=1
+1:sromrev=11
+1:tempthresh=120
+0:antswitch=0
+0:txchain=7
+0:boardflags=0x30040000
+0:temps_hysteresis=5
+0:tempsense_slope=0xff
+1:tempcorrx=0x3f
+1:dot11agduphrpo=0
+1:agbg0=0x0
+1:agbg1=0x0
+1:agbg2=0x0
+2:aa5g=7
+0:pdoffset80ma1=0
+0:rawtempsense=0x1ff
+0:pdoffset80ma2=0
+1:devid=0x43bb
+0:pdoffset80ma0=0
+0:rxchain=7
+1:dot11agduplrpo=0
+2:tempthresh=120
+1:antswitch=0
+1:boardflags=0x20001000
+EOF
+
+[ "$CHANGED" -eq 0 ] && exit 0
+
+nvram commit
+
+if lsmod | grep -q '^brcmfmac'; then
+	rmmod brcmfmac || true
+fi
+modprobe brcmfmac || true
+
+[ -f /etc/config/wireless ] || wifi config || true
+
+exit 0
+

--- a/package/utils/nvram/files/04-nvram-firstboot
+++ b/package/utils/nvram/files/04-nvram-firstboot
@@ -1,4 +1,10 @@
 #!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright (C) 2025 Tom Brautaset <tbrautaset@gmail.com>
+#
+# NVRAM initialization patch for bcm53xx
+# Applies required NVRAM fixes for ASUS RT-AC3200 and
+# ensures missing values are set correctly.
 
 . /lib/functions/system.sh
 

--- a/package/utils/nvram/files/nvram-bcm53xx.init
+++ b/package/utils/nvram/files/nvram-bcm53xx.init
@@ -19,15 +19,24 @@ clear_partialboots() {
 
 set_wireless_led_behaviour() {
 	# set Broadcom wireless LED behaviour for both radios
-	# 0:ledbh9 -> Behaviour of 2.4GHz LED
-	# 1:ledbh9 -> Behaviour of 5GHz LED
+	# 0:ledbh9 -> Behaviour of 2.4GHz LED of Broadcom BCM4366
+	# 1:ledbh9 -> Behaviour of 5GHz LED of Broadcom BCM4366
+	# 0:ledbh10 -> Behaviour of 2.4GHz LED of Broadcom BCM43602
+	# 1:ledbh10 -> Behaviour of 5GHz LED of Broadcom BCM43602
 	# 0x7 makes the wireless LEDs on, when radios are enabled, and blink when there's activity
 
 	case $(board_name) in
 		asus,rt-ac3100|\
+		asus,rt-ac5300|\
 		asus,rt-ac88u)
 			COMMIT=1
-			nvram set 0:ledbh9=0x7 set 1:ledbh9=0x7
+			nvram set 0:ledbh9=0x7
+			nvram set 1:ledbh9=0x7
+			;;
+		asus,rt-ac3200)
+			COMMIT=1
+			nvram set 0:ledbh10=0x7
+			nvram set 1:ledbh10=0x7
 			;;
 	esac
 }

--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -176,6 +176,24 @@ define Device/asus_rt-ac3100
 endef
 TARGET_DEVICES += asus_rt-ac3100
 
+define Device/asus_rt-ac3200
+  $(call Device/asus)
+  DEVICE_MODEL := RT-AC3200
+  DEVICE_PACKAGES := $(BRCMFMAC_43602A1) $(USB3_PACKAGES) \
+	-kmod-usb-ledtrig-usbport
+  ASUS_PRODUCTID := RT-AC3200
+endef
+TARGET_DEVICES += asus_rt-ac3200
+
+define Device/asus_rt-ac5300
+  $(call Device/asus)
+  DEVICE_MODEL := RT-AC5300
+  DEVICE_PACKAGES := $(BRCMFMAC_4366C0) $(USB3_PACKAGES) \
+	-kmod-usb-ledtrig-usbport
+  ASUS_PRODUCTID := RT-AC5300
+endef
+TARGET_DEVICES += asus_rt-ac5300
+
 define Device/asus_rt-ac56u
   $(call Device/asus)
   DEVICE_MODEL := RT-AC56U

--- a/target/linux/bcm53xx/patches-6.6/311-ARM-BCM5301X-Add-DT-for-Asus-RT-AC3200.patch
+++ b/target/linux/bcm53xx/patches-6.6/311-ARM-BCM5301X-Add-DT-for-Asus-RT-AC3200.patch
@@ -1,0 +1,170 @@
+From: Tom Brautaset <tbrautaset@gmail.com>
+Subject: [PATCH] ARM: BCM5301X: Add DT for Asus RT-AC3200
+
+Signed-off-by: Tom Brautaset <tbrautaset@gmail.com>
+Co-developed-by: Arınç ÜNAL <arinc.unal@arinc9.com>
+---
+
+--- a/arch/arm/boot/dts/broadcom/Makefile
++++ b/arch/arm/boot/dts/broadcom/Makefile
+@@ -64,6 +64,7 @@ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm47081-luxul-xap-1410.dtb \
+ 	bcm47081-luxul-xwr-1200.dtb \
+ 	bcm47081-tplink-archer-c5-v2.dtb \
++	bcm4709-asus-rt-ac3200.dtb \
+ 	bcm4709-asus-rt-ac87u.dtb \
+ 	bcm4709-buffalo-wxr-1900dhp.dtb \
+ 	bcm4709-linksys-ea9200.dtb \
+--- /dev/null
++++ b/arch/arm/boot/dts/broadcom/bcm4709-asus-rt-ac3200.dts
+@@ -0,0 +1,150 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++/*
++ * Author: Tom Brautaset <tbrautaset@gmail.com>
++ */
++
++/dts-v1/;
++
++#include "bcm4709.dtsi"
++#include "bcm5301x-nand-cs0-bch8.dtsi"
++
++#include <dt-bindings/leds/common.h>
++
++/ {
++	compatible = "asus,rt-ac3200", "brcm,bcm4709", "brcm,bcm4708";
++	model = "ASUS RT-AC3200";
++
++	memory@0 {
++		reg = <0x00000000 0x08000000>,
++		      <0x88000000 0x08000000>;
++		device_type = "memory";
++	};
++
++	nvram@1c080000 {
++		compatible = "brcm,nvram";
++		reg = <0x1c080000 0x00180000>;
++
++		et0macaddr: et0macaddr {
++			#nvmem-cell-cells = <1>;
++		};
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		button-reset {
++			label = "Reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&chipcommon 11 GPIO_ACTIVE_LOW>;
++		};
++
++		button-wifi {
++			label = "Wi-Fi";
++			linux,code = <KEY_RFKILL>;
++			gpios = <&chipcommon 4 GPIO_ACTIVE_LOW>;
++		};
++
++		button-wps {
++			label = "WPS";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&chipcommon 7 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-power {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_POWER;
++			gpios = <&chipcommon 3 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "default-on";
++		};
++
++		led-wan-red {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_WAN;
++			gpios = <&chipcommon 5 GPIO_ACTIVE_HIGH>;
++		};
++
++		led-wps {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_WPS;
++			gpios = <&chipcommon 14 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&gmac0 {
++	nvmem-cells = <&et0macaddr 0>;
++	nvmem-cell-names = "mac-address";
++};
++
++&gmac1 {
++	nvmem-cells = <&et0macaddr 1>;
++	nvmem-cell-names = "mac-address";
++};
++
++&gmac2 {
++	nvmem-cells = <&et0macaddr 2>;
++	nvmem-cell-names = "mac-address";
++};
++
++&nandcs {
++	partitions {
++		compatible = "fixed-partitions";
++		#address-cells = <1>;
++		#size-cells = <1>;
++
++		partition@0 {
++			reg = <0x00000000 0x00080000>;
++			label = "boot";
++			read-only;
++		};
++
++		partition@80000 {
++			reg = <0x00080000 0x00180000>;
++			label = "nvram";
++		};
++
++		partition@200000 {
++			compatible = "brcm,trx";
++			reg = <0x00200000 0x07e00000>;
++			label = "firmware";
++		};
++	};
++};
++
++&srab {
++	status = "okay";
++
++	ports {
++		port@0 {
++			label = "wan";
++		};
++
++		port@1 {
++			label = "lan4";
++		};
++
++		port@2 {
++			label = "lan3";
++		};
++
++		port@3 {
++			label = "lan2";
++		};
++
++		port@4 {
++			label = "lan1";
++		};
++	};
++};
++
++&usb2 {
++	vcc-gpio = <&chipcommon 9 GPIO_ACTIVE_HIGH>;
++};
++
++&usb3_phy {
++	status = "okay";
++};

--- a/target/linux/bcm53xx/patches-6.6/311-ARM-BCM5301X-Add-DT-for-Asus-RT-AC3200.patch
+++ b/target/linux/bcm53xx/patches-6.6/311-ARM-BCM5301X-Add-DT-for-Asus-RT-AC3200.patch
@@ -1,9 +1,25 @@
-From: Tom Brautaset <tbrautaset@gmail.com>
-Subject: [PATCH] ARM: BCM5301X: Add DT for Asus RT-AC3200
+From: "Arınç ÜNAL" <arinc.unal@arinc9.com>
+Subject: [PATCH v3 3/5] ARM: dts: BCM5301X: Add DT for ASUS RT-AC3200
 
+Add the device tree for ASUS RT-AC3200 which is an AC3200 router featuring
+5 Ethernet ports over the integrated Broadcom switch.
+
+Hardware info:
+* Processor: Broadcom BCM4709A0 dual-core @ 1.0 GHz
+* Switch: BCM53012 in BCM4709A0
+* DDR3 RAM: 256 MB
+* Flash: 128 MB
+* 2.4GHz: BCM43602 3x3 single chip 802.11b/g/n SoC
+* 5GHz: BCM43602 3x3 two chips 802.11a/n/ac SoC
+* Ports: 4 LAN Ports, 1 WAN Port
+
+Co-developed-by: Tom Brautaset <tbrautaset@gmail.com>
 Signed-off-by: Tom Brautaset <tbrautaset@gmail.com>
-Co-developed-by: Arınç ÜNAL <arinc.unal@arinc9.com>
+Signed-off-by: Arınç ÜNAL <arinc.unal@arinc9.com>
 ---
+ arch/arm/boot/dts/broadcom/Makefile                |   1 +
+ .../boot/dts/broadcom/bcm4709-asus-rt-ac3200.dts   | 150 +++++++++++++++++++++
+ 2 files changed, 151 insertions(+)
 
 --- a/arch/arm/boot/dts/broadcom/Makefile
 +++ b/arch/arm/boot/dts/broadcom/Makefile

--- a/target/linux/bcm53xx/patches-6.6/312-ARM-BCM5301X-Add-DT-for-Asus-RT-AC5300.patch
+++ b/target/linux/bcm53xx/patches-6.6/312-ARM-BCM5301X-Add-DT-for-Asus-RT-AC5300.patch
@@ -1,0 +1,176 @@
+From: Tom Brautaset <tbrautaset@gmail.com>
+Subject: [PATCH] ARM: BCM5301X: Add DT for Asus RT-AC5300
+
+Signed-off-by: Tom Brautaset <tbrautaset@gmail.com>
+Co-developed-by: Arınç ÜNAL <arinc.unal@arinc9.com>
+---
+
+--- a/arch/arm/boot/dts/broadcom/Makefile
++++ b/arch/arm/boot/dts/broadcom/Makefile
+@@ -73,6 +73,7 @@ dtb-$(CONFIG_ARCH_BCM_5301X) += \
+ 	bcm4709-netgear-r8000.dtb \
+ 	bcm4709-tplink-archer-c9-v1.dtb \
+ 	bcm47094-asus-rt-ac3100.dtb \
++	bcm47094-asus-rt-ac5300.dtb \
+ 	bcm47094-asus-rt-ac88u.dtb \
+ 	bcm47094-dlink-dir-885l.dtb \
+ 	bcm47094-dlink-dir-890l.dtb \
+--- /dev/null
++++ b/arch/arm/boot/dts/broadcom/bcm47094-asus-rt-ac5300.dts
+@@ -0,0 +1,156 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++/*
++ * Author: Tom Brautaset <tbrautaset@gmail.com>
++ */
++
++/dts-v1/;
++
++#include "bcm47094.dtsi"
++#include "bcm5301x-nand-cs0-bch8.dtsi"
++
++#include <dt-bindings/leds/common.h>
++
++/ {
++	compatible = "asus,rt-ac5300", "brcm,bcm47094", "brcm,bcm4708";
++	model = "ASUS RT-AC5300";
++
++	memory@0 {
++		reg = <0x00000000 0x08000000>,
++		      <0x88000000 0x18000000>;
++		device_type = "memory";
++	};
++
++	nvram@1c080000 {
++		compatible = "brcm,nvram";
++		reg = <0x1c080000 0x00180000>;
++
++		et1macaddr: et1macaddr {
++			#nvmem-cell-cells = <1>;
++		};
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		button-reset {
++			label = "Reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&chipcommon 11 GPIO_ACTIVE_LOW>;
++		};
++
++		button-wifi {
++			label = "Wi-Fi";
++			linux,code = <KEY_RFKILL>;
++			gpios = <&chipcommon 20 GPIO_ACTIVE_LOW>;
++		};
++
++		button-wps {
++			label = "WPS";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&chipcommon 18 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-lan {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_LAN;
++			gpios = <&chipcommon 21 GPIO_ACTIVE_LOW>;
++		};
++
++		led-power {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_POWER;
++			gpios = <&chipcommon 3 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "default-on";
++		};
++
++		led-wan-red {
++			color = <LED_COLOR_ID_RED>;
++			function = LED_FUNCTION_WAN;
++			gpios = <&chipcommon 5 GPIO_ACTIVE_HIGH>;
++		};
++
++		led-wps {
++			color = <LED_COLOR_ID_WHITE>;
++			function = LED_FUNCTION_WPS;
++			gpios = <&chipcommon 19 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&gmac0 {
++	nvmem-cells = <&et1macaddr 0>;
++	nvmem-cell-names = "mac-address";
++};
++
++&gmac1 {
++	nvmem-cells = <&et1macaddr 1>;
++	nvmem-cell-names = "mac-address";
++};
++
++&gmac2 {
++	nvmem-cells = <&et1macaddr 2>;
++	nvmem-cell-names = "mac-address";
++};
++
++&nandcs {
++	partitions {
++		compatible = "fixed-partitions";
++		#address-cells = <1>;
++		#size-cells = <1>;
++
++		partition@0 {
++			reg = <0x00000000 0x00080000>;
++			label = "boot";
++			read-only;
++		};
++
++		partition@80000 {
++			reg = <0x00080000 0x00180000>;
++			label = "nvram";
++		};
++
++		partition@200000 {
++			compatible = "brcm,trx";
++			reg = <0x00200000 0x07e00000>;
++			label = "firmware";
++		};
++	};
++};
++
++&srab {
++	status = "okay";
++
++	ports {
++		port@0 {
++			label = "wan";
++		};
++
++		port@1 {
++			label = "lan1";
++		};
++
++		port@2 {
++			label = "lan2";
++		};
++
++		port@3 {
++			label = "lan3";
++		};
++
++		port@4 {
++			label = "lan4";
++		};
++	};
++};
++
++&usb2 {
++	vcc-gpio = <&chipcommon 9 GPIO_ACTIVE_HIGH>;
++};
++
++&usb3_phy {
++	status = "okay";
++};

--- a/target/linux/bcm53xx/patches-6.6/312-ARM-BCM5301X-Add-DT-for-Asus-RT-AC5300.patch
+++ b/target/linux/bcm53xx/patches-6.6/312-ARM-BCM5301X-Add-DT-for-Asus-RT-AC5300.patch
@@ -1,9 +1,25 @@
-From: Tom Brautaset <tbrautaset@gmail.com>
-Subject: [PATCH] ARM: BCM5301X: Add DT for Asus RT-AC5300
+From: "Arınç ÜNAL" <arinc.unal@arinc9.com>
+Subject: [PATCH v3 4/5] ARM: dts: BCM5301X: Add DT for ASUS RT-AC5300
 
+Add the device tree for ASUS RT-AC5300 which is an AC5300 router featuring
+5 Ethernet ports over the integrated Broadcom switch.
+
+Hardware info:
+* Processor: Broadcom BCM4709C0 dual-core @ 1.4 GHz
+* Switch: BCM53012 in BCM4709C0
+* DDR3 RAM: 512 MB
+* Flash: 128 MB
+* 2.4GHz: BCM4366 4x4 single chip 802.11b/g/n SoC
+* 5GHz: BCM4366 4x4 two chips 802.11a/n/ac SoC
+* Ports: 4 LAN Ports, 1 WAN Port
+
+Co-developed-by: Tom Brautaset <tbrautaset@gmail.com>
 Signed-off-by: Tom Brautaset <tbrautaset@gmail.com>
-Co-developed-by: Arınç ÜNAL <arinc.unal@arinc9.com>
+Signed-off-by: Arınç ÜNAL <arinc.unal@arinc9.com>
 ---
+ arch/arm/boot/dts/broadcom/Makefile                |   1 +
+ .../boot/dts/broadcom/bcm47094-asus-rt-ac5300.dts  | 156 +++++++++++++++++++++
+ 2 files changed, 157 insertions(+)
 
 --- a/arch/arm/boot/dts/broadcom/Makefile
 +++ b/arch/arm/boot/dts/broadcom/Makefile


### PR DESCRIPTION
## [Overview]

Adds initial OpenWrt support for the **ASUS RT-AC3200** and **ASUS RT-AC5300**.

Both are **BCM4709-based** devices (already supported under `bcm53xx`), with NAND flash and an integrated Gigabit switch.

- [RT-AC3200 hardware page](https://openwrt.org/toh/hwdata/asus/asus_rt-ac3200)  
- [RT-AC5300 hardware page](https://openwrt.org/toh/hwdata/asus/asus_rt-ac5300)

**Status**  

[OK] Bootable via CFE MiniWeb recovery and `sysupgrade`  

[OK] Ethernet LAN/WAN verified working  

[OK] Wi-Fi consistent with other BCM4709-based bcm53xx devices  

[NOTE] On **RT-AC3200**, radios only appear after reboot with the bcm43602_variables quirk applied.  
Without this one-time init, no radios are detected on first boot.  

Inside ASUS OEM firmware for ASUS RT-AC5300, the standard `dhd.ko` only includes support for **BCM4366C0**.  
Code paths for both **BCM4366B1** and **BCM4366C0** exist in `dhd24.ko` with much older firmware revisions.

---

## [Changes]

- Added DTS files: `bcm4709-asus-rt-ac3200.dts`, `bcm47094-asus-rt-ac5300.dts`
- Added image definitions under `target/linux/bcm53xx/image/Makefile`
- Added dedicated NVRAM handling:
  - Extended `nvram-bcm53xx.init` for proper Wi-Fi LED behavior
  - No USB Wi-Fi hardware present → ideally `brcmfmac-usb` should also be dropped; for now handled in `.config` with:  
    ```make
    # CONFIG_BRCMFMAC_USB is not set
    ```

**Files changed (6)**  
1. `package/utils/nvram/Makefile` — bump release  
3. `package/utils/nvram/files/nvram-bcm53xx.init` — extend LED handling for AC3200/AC5300 Wi-Fi LEDs  
4. `target/linux/bcm53xx/patches-6.6/311-ARM-BCM5301X-Add-DT-for-Asus-RT-AC3200.patch` — DTS for AC3200  
5. `target/linux/bcm53xx/patches-6.6/312-ARM-BCM5301X-Add-DT-for-Asus-RT-AC5300.patch` — DTS for AC5300  

---

## [Hardware Specs]

|                        | **ASUS RT-AC3200**                         | **ASUS RT-AC5300**                          |
|------------------------|--------------------------------------------|---------------------------------------------|
| SoC                    | Broadcom **BCM4709A0**, 2c @ **1.0 GHz**   | Broadcom **BCM4709C0**, 2c @ **1.4 GHz**    |
| RAM / Flash            | **256 MB DDR3** / **128 MB NAND**          | **512 MB DDR3** / **128 MB NAND**           |
| Radios                 | **3 × BCM43602** (1×2.4 G, 2×5 G)          | **3 × BCM4366C0** (1×2.4 G, 2×5 G)          |
| Ethernet               | **1× WAN + 4× LAN** (Gigabit)              | **1× WAN + 4× LAN** (Gigabit)               |
| USB                    | **USB2 ×1**, **USB3 ×1**                   | **USB2 ×1**, **USB3 ×1**                    |
| USB Wi-Fi / LEDs       | **Not present**                            | **Not present**                             |

---

## [Optional A/B Testing]

This section is outside the scope of this PR.  
Firmware updates are handled in `package/firmware/linux-firmware`.

Repo: [asus-brcm43602-brcm4366c](https://github.com/tbrautaset/asus-brcm43602-brcm4366c), Files:
  - brcmfmac43602-pcie.bin — 7.35.177.61 (from linux-firmware; newer than current OpenWrt)  
  - brcmfmac4366c-pcie.bin — 10.10.122.303 (OEM test blob; not suitable for inclusion)  

---

# Build-time override (on your build host)

mkdir -p files/lib/firmware/brcm

curl -fL -o files/lib/firmware/brcm/brcmfmac43602-pcie.bin&#x20;
[https://raw.githubusercontent.com/tbrautaset/asus-brcm43602-brcm4366c/main/brcmfmac43602-pcie.bin](https://raw.githubusercontent.com/tbrautaset/asus-brcm43602-brcm4366c/main/brcmfmac43602-pcie.bin)

curl -fL -o files/lib/firmware/brcm/brcmfmac4366c-pcie.bin&#x20;
[https://raw.githubusercontent.com/tbrautaset/asus-brcm43602-brcm4366c/main/brcmfmac4366c-pcie.bin](https://raw.githubusercontent.com/tbrautaset/asus-brcm43602-brcm4366c/main/brcmfmac4366c-pcie.bin)

sha256sum files/lib/firmware/brcm/brcmfmac436\*.bin

---

# Runtime override (copy to a running router)

ssh root\@router 'mkdir -p /lib/firmware/brcm'

scp brcmfmac43602-pcie.bin  root\@router:/lib/firmware/brcm/
scp brcmfmac4366c-pcie.bin  root\@router:/lib/firmware/brcm/
ssh root\@router 'sha256sum /lib/firmware/brcm/brcmfmac436\*.bin; sync; reboot'

---

Notes:

* `brcmfmac43602-pcie.bin` v7.35.177.61 is upstream in linux-firmware, but OpenWrt
  currently ships an older revision.
* The 4366C OEM blob cannot be included in OpenWrt due to licensing and is only
  provided here for voluntary A/B testing.

---

## [Acknowledgements]

* Replaces PR #19373
* Co-developed with @arinc9

---

Thanks for reviewing.