### PR TITLE
projectsmirrors: drop ftp.kddilabs.jp

### DIFF
--- a/scripts/projectsmirrors.json
+++ b/scripts/projectsmirrors.json
@@ -29,7 +29,6 @@
 		"https://ftpmirror.gnu.org",
 		"https://mirror.csclub.uwaterloo.ca/gnu",
 		"https://mirror.netcologne.de/gnu",
-		"https://ftp.kddilabs.jp/GNU/gnu",
 		"https://www.nic.funet.fi/pub/gnu/gnu",
 		"https://mirror.navercorp.com/gnu",
 		"https://mirrors.rit.edu/gnu",


### PR DESCRIPTION
`ftp.kddilabs.jp` has been shutdown and
now returns 404.