### PR TITLE
build: fix processing for SCAN_DEPS with glob pattern inside

### DIFF
--- a/include/scan.mk
+++ b/include/scan.mk
@@ -45,7 +45,7 @@ endif
 
 define PackageDir
   $(TMP_DIR)/.$(SCAN_TARGET): $(TMP_DIR)/info/.$(SCAN_TARGET)-$(1)
-  $(TMP_DIR)/info/.$(SCAN_TARGET)-$(1): $(SCAN_DIR)/$(2)/Makefile $(foreach DEP,$(DEPS_$(SCAN_DIR)/$(2)/Makefile) $(SCAN_DEPS),$(wildcard $(if $(filter /%,$(DEP)),$(DEP),$(SCAN_DIR)/$(2)/$(DEP))))
+  $(TMP_DIR)/info/.$(SCAN_TARGET)-$(1): $(SCAN_DIR)/$(2)/Makefile $(foreach DEP,$(DEPS_$(SCAN_DIR)/$(2)/Makefile) $(SCAN_DEPS),$(wildcard $(if $(filter /%,$(DEP)),$(DEP),$(SCAN_DIR)/$(2)/$(DEP)))) $(TMP_DIR)/info/.$(SCAN_TARGET)-$(1).stamp
 	{ \
 		$$(call progress,Collecting $(SCAN_NAME) info: $(SCAN_DIR)/$(2)) \
 		echo Source-Makefile: $(SCAN_DIR)/$(2)/Makefile; \
@@ -60,6 +60,14 @@ define PackageDir
 		echo; \
 	} > $$@.tmp
 	mv $$@.tmp $$@
+
+  $(TMP_DIR)/info/.$(SCAN_TARGET)-$(1).stamp::
+	MD5SUM=$$$$(echo $(SCAN_DIR)/$(2)/Makefile $(foreach DEP,$(DEPS_$(SCAN_DIR)/$(2)/Makefile) $(SCAN_DEPS),$(wildcard $(if $(filter /%,$(DEP)),$(DEP),$(SCAN_DIR)/$(2)/$(DEP)))) | $(MKHASH) md5 | awk '{print $$$$1}'); \
+	[ -f "$$@.$$$$MD5SUM" ] || { \
+		rm -f $$@.*; \
+		touch $$@.$$$$MD5SUM; \
+		touch $$@; \
+	}
 endef
 
 $(OVERRIDELIST):


### PR DESCRIPTION
The linux-firmware package information not updated when some of `package/firmware/linux-firmware/*.mk` files removed:

    $ make defconfig
    $ grep -r 'ice-firmware\|iwl3945-firmware' .config # pkgs from intel.mk
    # CONFIG_PACKAGE_ice-firmware is not set
    # CONFIG_PACKAGE_iwl3945-firmware is not set
    $ # Remove ice-firmware package definition
    $ sed -i '/Package\/ice-firmware/,/BuildPackage,ice-firmware/d' package/firmware/linux-firmware/intel.mk
    $ make defconfig # Now information about removed package updated
    $ grep -r 'ice-firmware\|iwl3945-firmware' .config
    # CONFIG_PACKAGE_iwl3945-firmware is not set
    $ rm package/firmware/linux-firmware/intel.mk
    $ make defconfig # Now information about removed packages not updated
    $ grep -r 'ice-firmware\|iwl3945-firmware' .config
    # CONFIG_PACKAGE_iwl3945-firmware is not set

Issue related to cases when `SCAN_DEPS` described as wildcard:

    SCAN_DEPS = *.mk
    include $(wildcard ./*.mk)

In this case changes in existed `*.mk` files or creation a new `.mk` file would trigger regeneration of the `tmp/info/.packageinfo-<path_to_package>` file. The `tmp/info/.packageinfo-<path_to_package>` file used in generation of `tmp/.packageinfo` and `tmp/.config-package.in` files, that used for OpenWrt defconfig infrastructure. Unfortunately OpenWrt implementation can't correctly track cases when any of `*.mk` files
deleted.

In order to track files removing need to add a md5sum from string with dependency names as dependency for the
`tmp/info/.packageinfo-<path_to_package>` file. The code reuse the trick that already used for `tmp/.packageinfo` dependencies.