### PR TITLE
[24.10] mediatek: add support for ipTIME AX3000SM

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000sm.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000sm.dts
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "ipTIME AX3000SM";
+	compatible = "iptime,ax3000sm", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		label-mac-device = &gmac1;
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		button-1 {
+			label = "reset";
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_cpu: led-3 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&pio 15 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 (3)>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 (1)>;
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x6E00000>;
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan4";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan3";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan1";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 (0)>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 (0)>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -64,6 +64,9 @@ glinet,gl-xe3000)
 huasifei,wh3000)
 	ucidef_set_led_netdev "wan" "WAN" "red:wan" "eth1" "link tx rx"
 	;;
+iptime,ax3000sm)
+	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
+	;;
 mercusys,mr80x-v3)
 	ucidef_set_led_netdev "lan1" "lan-1" "green:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan-2" "green:lan-2" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -46,6 +46,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;
 	asus,tuf-ax4200|\
+	iptime,ax3000sm|\
 	jdcloud,re-cp-03|\
 	mediatek,mt7981-rfb|\
 	netcore,n60|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -108,6 +108,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	iptime,ax3000sm)
+		addr=$(mtd_get_mac_binary "Factory" 0x4)
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_setbit $addr 26) 25) 27) 28) > \
+			/sys${DEVPATH}/macaddress
+		;;
 	jcg,q30-pro|\
 	netcore,n60)
 		# Originally, phy1 is phy0 mac with LA bit set. However, this would conflict

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1031,6 +1031,17 @@ define Device/huasifei_wh3000
 endef
 TARGET_DEVICES += huasifei_wh3000
 
+define Device/iptime_ax3000sm
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := AX3000SM
+  DEVICE_DTS := mt7981b-iptime-ax3000sm
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
+endef
+TARGET_DEVICES += iptime_ax3000sm
+
 define Device/jcg_q30-pro
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := Q30 PRO


### PR DESCRIPTION
This pull request adds support for the ipTIME AX3000SM to the stable branch (24.10).

Specification
-------------
- SoC       : MediaTek MT7981BA dual-core ARM Cortex-A53 1.3GHz
- RAM       : DDR3 256Mbytes, Nanya Technology NT5CC128M16IP
- Flash     : 128Mbytes NAND Flash, ESMT F50L1G41LB
- WLAN      : MediaTek MT7976CN dual-band Wi-Fi 6
  - 2.4GHz  : b/g/n/ax, MU-MIMO
  - 5GHz    : a/n/ac/ax, MU-MIMO
- Ethernet  : 
  - 10/100/1000 Mbps x4, LAN (MediaTek MT7531AE)
  - 10/100/1000 Mbps x1, WAN (MT7981 internal PHY)
- UART      : 1x4 pin header on PCB
  - [J500] 3.3V, TX, RX, GND (115200, 8N1)
- Buttons   : WPS, Reset
- LEDs      : 9 LEDs
  - 1x Power (Amber) 
  - 1x CPU (Amber)
  - 1x Wi-Fi 5GHz (Amber)
  - 1x Wi-Fi 2.4GHz (Amber)
  - 1x WAN activity (Amber)
  - 4x LAN activity (Amber)
- Power     : 12VDC, 1A (Center positive polarity)

MAC address
-----------
| Interface      | MAC                        | Algorithm |
|-------------------|---------------------------|----------------|
| WLAN 2.4G  | B0:38:6C:xx:xx:xx | label           |
| WLAN 5G     | B2:38:6C:4x:xx:xx |                     |
| WAN             | B0:38:6C:xx:xx:xx | label + 1     |
| LAN              | B0:38:6C:xx:xx:xx | label + 3     |

The WLAN 2.4G MAC address was found in 'Factory' partition, 0x4

Installation
------------
1. Download the *initramfs-kernel.bin file from the OpenWrt website
2. Attach UART to the router, and interrupt the boot process by pressing '0'
> If you successfully interrupt the boot process, a terminal prompt name should look like this:
```
   MT7981>
```
3. Connect the router(LAN port) to the PC
4. Assign the PC IP address: 192.168.0.100/24
5. Load and run the *initramfs-kernel.bin:
```
  tftpboot 0x46000000 initramfs-kernel.bin
  bootm
```
6. Upload the OpenWrt *squashfs-sysupgrade.bin to the router
7. Run 'sysupgrade -n' with the sysupgrade OpenWrt image

Screenshot
----------
<details><summary>OpenWrt Luci Web Interface</summary>
<p>

<img width="860" height="923" alt="iptime-ax3000sm-openwrt-stable" src="https://github.com/user-attachments/assets/ae1c93c3-84eb-44d4-aaf1-34d50942a5a5" />

</p>
</details> 

Bootlogs
--------
<details><summary>Uploading initramfs</summary>
<p>

```
F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 024F [010F]
Jump to BL

NOTICE:  BL2: v2.7(release):0697eafa43-dirty
NOTICE:  BL2: Built : 17:33:02, Jan 26 2024
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a083f1 000003ff 00100000 00000000
1001d040 | 00000000 00000000 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0x8 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 564, worse bit 2, min window 68
Window Sum 580, worse bit 11, min window 68
Window Sum 402, worse bit 3, min window 48
Window Sum 394, worse bit 9, min window 46
Window Sum 410, worse bit 1, min window 50
Window Sum 404, worse bit 9, min window 48
Window Sum 424, worse bit 1, min window 52
Window Sum 418, worse bit 9, min window 50
Window Sum 436, worse bit 3, min window 52
Window Sum 424, worse bit 9, min window 50
Window Sum 446, worse bit 1, min window 54
Window Sum 444, worse bit 8, min window 54
Window Sum 462, worse bit 3, min window 56
Window Sum 450, worse bit 8, min window 54
Window Sum 472, worse bit 1, min window 58
Window Sum 456, worse bit 8, min window 54
Window Sum 478, worse bit 3, min window 58
Window Sum 460, worse bit 8, min window 56
Window Sum 482, worse bit 1, min window 60
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc8
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 1 found in block 960
NOTICE:  Second info table with writecount 1 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):0697eafa43-dirty
NOTICE:  BL31: Built : 17:33:04, Jan 26 2024
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Jan 26 2024 - 17:32:30 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: GigaDevice SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 1 found in block 960
Second info table with writecount 1 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H1. Startup system (Default)[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H[7m0. U-Boot console[0m[?25h[2J[1;1HMT7981> 0 tftpboot 0x46000000 initramfs-kernel.bin
Using ethernet@15100000 device
TFTP from server 192.168.0.100; our IP address is 192.168.0.1
Filename 'initramfs-kernel.bin'.
Load address: 0x46000000
Loading: *T #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 ########
	 1.5 MiB/s
done
Bytes transferred = 8696040 (84b0e8 hex)
MT7981> bootm
## Loading kernel from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.6.95
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x460000e8
     Data Size:    4298849 Bytes = 4.1 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x48000000
     Entry Point:  0x48000000
     Hash algo:    crc32
     Hash value:   138258fe
     Hash algo:    sha1
     Hash value:   f3e87cb770c20fb8194a55ca8b0eb722769d18a6
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading ramdisk from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'initrd-1' ramdisk subimage
     Description:  ARM64 OpenWrt iptime_ax3000sm initrd
     Type:         RAMDisk Image
     Compression:  Unknown Compression
     Data Start:   0x46419a88
     Data Size:    4372088 Bytes = 4.2 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: unavailable
     Entry Point:  unavailable
     Hash algo:    crc32
     Hash value:   545097e8
     Hash algo:    sha1
     Hash value:   69306e73dcd04492d90af1b64319d5c99eceb56a
   Verifying Hash Integrity ... crc32+ sha1+ OK
WARNING: 'compression' nodes for ramdisks are deprecated, please fix your .its file!
## Loading fdt from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt iptime_ax3000sm device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x4684520c
     Data Size:    22950 Bytes = 22.4 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   dfc332ed
     Hash algo:    sha1
     Hash value:   bf7fc01f19dafa2240d223de48ff6902d0158672
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x4684520c
   Uncompressing Kernel Image
   Loading Ramdisk to 4f3cf000, end 4f7fa678 ... OK
   Loading Device Tree to 000000004f3c6000, end 000000004f3ce9a5 ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.6.95 (nyanko@DevBox) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 13.3.0 r0+28760-cb2c7fb8a6) 13.3.0, GNU ld (GNU Binutils) 2.42) #0 SMP Mon Jul 14 09:45:28 2025
[    0.000000] Machine model: ipTIME AX3000SM
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004302ffff (192 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x0000000047c80000..0x0000000047d7ffff (1024 KiB) nomap non-reusable wmcpu-reserved@47c80000
[    0.000000] OF: reserved mem: 0x0000000047d80000..0x0000000047dbffff (256 KiB) nomap non-reusable wo-emi@47d80000
[    0.000000] OF: reserved mem: 0x0000000047dc0000..0x0000000047ffffff (2304 KiB) nomap non-reusable wo-data@47dc0000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004302ffff]
[    0.000000]   node   0: [mem 0x0000000043030000-0x0000000047c7ffff]
[    0.000000]   node   0: [mem 0x0000000047c80000-0x0000000047ffffff]
[    0.000000]   node   0: [mem 0x0000000048000000-0x000000004fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 18 pages/cpu s35112 r8192 d30424 u73728
[    0.000000] pcpu-alloc: s35112 r8192 d30424 u73728 alloc=18*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: 
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 64512
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[    0.000000] software IO TLB: area num 2.
[    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 0MB
[    0.000000] software IO TLB: mapped [mem 0x000000004fe47000-0x000000004fec7000] (0MB)
[    0.000000] Memory: 234904K/262144K available (8832K kernel code, 994K rwdata, 2568K rodata, 448K init, 289K bss, 27240K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000070] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000077] pid_max: default: 32768 minimum: 301
[    0.002970] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.002978] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.005099] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.005621] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.005770] rcu: Hierarchical SRCU implementation.
[    0.005773] rcu: 	Max phase no-delay instances is 1000.
[    0.006162] smp: Bringing up secondary CPUs ...
[    0.006516] Detected VIPT I-cache on CPU1
[    0.006558] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.006587] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.006652] smp: Brought up 1 node, 2 CPUs
[    0.006658] SMP: Total of 2 processors activated.
[    0.006661] CPU features: detected: 32-bit EL0 Support
[    0.006664] CPU features: detected: CRC32 instructions
[    0.006695] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.006698] CPU: All CPU(s) started at EL2
[    0.006700] alternatives: applying system-wide alternatives
[    0.010205] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.010221] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.011483] pinctrl core: initialized pinctrl subsystem
[    0.012623] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.012939] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.012964] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.012986] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.013365] thermal_sys: Registered thermal governor 'fair_share'
[    0.013369] thermal_sys: Registered thermal governor 'bang_bang'
[    0.013371] thermal_sys: Registered thermal governor 'step_wise'
[    0.013373] thermal_sys: Registered thermal governor 'user_space'
[    0.013421] ASID allocator initialised with 65536 entries
[    0.014126] pstore: Using crash dump compression: deflate
[    0.014131] pstore: Registered ramoops as persistent store backend
[    0.014133] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.015546] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.020839] Modules: 29440 pages in range for non-PLT usage
[    0.020846] Modules: 520960 pages in range for PLT usage
[    0.021772] cryptd: max_cpu_qlen set to 1000
[    0.023853] SCSI subsystem initialized
[    0.024039] libata version 3.00 loaded.
[    0.025639] clocksource: Switched to clocksource arch_sys_counter
[    0.027956] NET: Registered PF_INET protocol family
[    0.028060] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.029106] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.029119] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.029128] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.029146] TCP bind hash table entries: 2048 (order: 4, 65536 bytes, linear)
[    0.029197] TCP: Hash tables configured (established 2048 bind 2048)
[    0.029509] MPTCP token hash table entries: 256 (order: 0, 6144 bytes, linear)
[    0.029612] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.029627] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.029826] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.029849] PCI: CLS 0 bytes, default 64
[    0.030108] Unpacking initramfs...
[    0.036768] workingset: timestamp_bits=46 max_order=16 bucket_order=0
[    0.041578] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.041587] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.108400] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.109609] printk: console [ttyS0] disabled
[    0.129966] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 72, base_baud = 2500000) is a ST16650V2
[    0.130005] printk: console [ttyS0] enabled
[    0.888019] loop: module loaded
[    0.893990] spi-nand spi0.0: calibration result: 0x3
[    0.899096] spi-nand spi0.0: ESMT SPI NAND was found.
[    0.904148] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.912933] Signature found at block 1023 [0x07fe0000]
[    0.918111] NMBM management region starts at block 960 [0x07800000]
[    0.926350] First info table with writecount 1 found in block 960
[    0.938378] Second info table with writecount 1 found in block 963
[    0.944568] NMBM has been successfully attached
[    1.317458] Freeing initrd memory: 4268K
[    1.328417] 5 fixed-partitions partitions found on MTD device spi0.0
[    1.334776] Creating 5 MTD partitions on "spi0.0":
[    1.339569] 0x000000000000-0x000000100000 : "BL2"
[    1.345472] 0x000000100000-0x000000180000 : "u-boot-env"
[    1.351609] 0x000000180000-0x000000380000 : "Factory"
[    1.359227] 0x000000380000-0x000000580000 : "FIP"
[    1.365895] 0x000000580000-0x000007380000 : "ubi"
[    1.578058] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081300000, irq 75
[    1.587935] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc081300000, irq 75
[    1.597632] i2c_dev: i2c /dev entries driver
[    1.603606] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.612753] NET: Registered PF_INET6 protocol family
[    1.618773] Segment Routing with IPv6
[    1.622458] In-situ OAM (IOAM) with IPv6
[    1.626456] NET: Registered PF_PACKET protocol family
[    1.631630] 8021q: 802.1Q VLAN Support v1.8
[    1.752488] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.761511] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.772265] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=79)
[    1.795115] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=80)
[    1.817136] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=81)
[    1.839149] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=82)
[    1.850708] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.857465] DSA: tree 0 setup
[    1.861242] UBI: auto-attach mtd4
[    1.864583] ubi0: default fastmap pool size: 40
[    1.869136] ubi0: default fastmap WL pool size: 20
[    1.873915] ubi0: attaching mtd4
[    2.669974] ubi0: scanning is finished
[    2.684885] ubi0: attached mtd4 (name "ubi", size 110 MiB)
[    2.690395] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    2.697267] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.704047] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.710998] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    2.716995] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[    2.724202] ubi0: max/mean erase counter: 2/1, WL threshold: 4096, image sequence number: 0
[    2.732541] ubi0: available PEBs: 0, total reserved PEBs: 880, PEBs reserved for bad PEB handling: 19
[    2.741756] ubi0: background thread "ubi_bgt0d" started, PID 542
[    2.748615] block ubiblock0_1: created from ubi0:1(rootfs)
[    2.754100] ubiblock: device ubiblock0_1 (rootfs) set to be root filesystem
[    2.761206] clk: Disabling unused clocks
[    2.765794] Freeing unused kernel memory: 448K
[    2.770283] Run /init as init process
[    2.773933]   with arguments:
[    2.776897]     /init
[    2.779157]   with environment:
[    2.782285]     HOME=/
[    2.784633]     TERM=linux
[    2.981977] init: Console is alive
[    2.985489] init: - watchdog -
[    2.993157] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.002871] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    3.014649] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.030149] init: - preinit -
[    3.137226] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    3.145784] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    3.168910] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    6.335647] random: crng init done
[    7.326192] procd: - early -
[    7.329136] procd: - watchdog -
[    7.856510] procd: - watchdog -
[    7.859805] procd: - ubus -
[    7.914096] procd: - init -
Please press Enter to activate this console.
[    8.091489] kmodloader: loading kernel modules from /etc/modules.d/*
[    8.107728] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    8.122218] Loading modules backported from Linux version v6.12.6-0-ge9d65b48ce1a
[    8.129718] Backport generated by backports.git v6.1.110-1-35-g410656ef04d2
[    8.344487] urngd: v1.0.2 started.
[    8.515832] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[    8.515832] 
[    8.537705] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[    8.577594] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[    8.676333] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[    8.758586] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[    8.821019] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[    8.893096] PPP generic driver version 2.4.2
[    8.898707] NET: Registered PF_PPPOX protocol family
[    8.907582] kmodloader: done loading kernel modules from /etc/modules.d/*
[    8.957381] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   14.534308] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   14.559747] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   14.572785] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   14.579610] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   14.592905] br-lan: port 1(lan1) entered blocking state
[   14.598192] br-lan: port 1(lan1) entered disabled state
[   14.603441] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   14.609765] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   14.619253] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   14.655119] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   14.673551] br-lan: port 2(lan2) entered blocking state
[   14.678870] br-lan: port 2(lan2) entered disabled state
[   14.684130] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   14.694051] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   14.713291] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   14.740802] br-lan: port 3(lan3) entered blocking state
[   14.746117] br-lan: port 3(lan3) entered disabled state
[   14.751380] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   14.762009] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   14.785447] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   14.803791] br-lan: port 4(lan4) entered blocking state
[   14.809116] br-lan: port 4(lan4) entered disabled state
[   14.814376] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   14.830104] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[   14.863767] mtk_soc_eth 15100000.ethernet eth1: PHY [mdio-bus:00] driver [MediaTek MT7981 PHY] (irq=POLL)
[   14.873391] mtk_soc_eth 15100000.ethernet eth1: configuring for phy/gmii link mode
[   18.463540] mt7530-mdio mdio-bus:1f lan2: Link is Up - 1Gbps/Full - flow control rx/tx
[   18.463566] br-lan: port 2(lan2) entered blocking state
[   18.476682] br-lan: port 2(lan2) entered forwarding state



BusyBox v1.36.1 (2025-07-14 09:45:28 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt 24.10-SNAPSHOT, r0+28760-cb2c7fb8a6
 -----------------------------------------------------
=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------
root@OpenWrt:~# 
```

</p>
</details> 


<details><summary>Sysupgrade</summary>
<p>

```
root@OpenWrt:~# ls
squashfs-sysupgrade.bin
root@OpenWrt:~# sysupgrade -n squashfs-sysupgrade.bin
Mon Jul 14 10:56:55 UTC 2025 upgrade: Image not in /tmp, copying...
verifying sysupgrade tar file integrity
Mon Jul 14 10:56:55 UTC 2025 upgrade: Commencing upgrade. Closing all shell sessions.
Command failed: Connection faile[ 1619.215094] mt798x-wmac 18000000.wifi phy1-ap0: left allmulticast mode
[ 1619.222479] mt798x-wmac 18000000.wifi phy1-ap0: left promiscuous mode
[ 1619.229030] br-lan: port 5(phy1-ap0) entered disabled state
Watchdog handover: fd=3
- watchdog -
Watchdog does not have CARDRESET support
[ 1619.442853] mt798x-wmac 18000000.wifi phy0-ap0: left allmulticast mode
[ 1619.449461] mt798x-wmac 18000000.wifi phy0-ap0: left promiscuous mode
[ 1619.455950] br-lan: port 6(phy0-ap0) entered disabled state
Mon Jul 14 10:56:56 UTC 2025 upgrade: Sending TERM to remaining processes ...
Mon Jul 14 10:56:56 UTC 2025 upgrade: Sending signal TERM to hostapd (1755)
Mon Jul 14 10:56:56 UTC 2025 upgrade: Sending signal TERM to hostapd (1775)
Mon Jul 14 10:56:56 UTC 2025 upgrade: Sending signal TERM to iperf3 (6884)
Mon Jul 14 10:57:00 UTC 2025 upgrade: Sending KILL to remaining processes ...
[ 1629.688565] stage2 (7045): drop_caches: 3
Mon Jul 14 10:57:06 UTC 2025 upgrade: Switching to ramdisk...
[ 1631.027565] UBIFS (ubi0:2): background thread "ubifs_bgt0_2" stops
[ 1631.040673] UBIFS (ubi0:2): un-mount UBI device 0
Mon Jul 14 10:57:07 UTC 2025 upgrade: Performing system upgrade...
verifying sysupgrade tar file integrity
[ 1631.475318] block ubiblock0_1: released
Volume ID 0, size 35 LEBs (4444160 bytes, 4.2 MiB), LEB size 126976 bytes (124.0 KiB), dynamic, name "kernel", alignment 1
[ 1631.940427] block ubiblock0_1: created from ubi0:1(rootfs)
Volume ID 1, size 38 LEBs (4825088 bytes, 4.6 MiB), LEB size 126976 bytes (124.0 KiB), dynamic, name "rootfs", alignment 1
Set volume size to 99295232
Volume ID 2, size 782 LEBs (99295232 bytes, 94.6 MiB), LEB size 126976 bytes (124.0 KiB), dynamic, name "rootfs_data", alignment 1
sysupgrade successful
umount: can't unmount /dev: Resource busy
umoun[ 1636.170242] reboot: Restarting system
t: can't unmount

F0: 102B 0000

FA: 1040 0000

FA: 1040 0000 [0200]

F9: 0000 0000

V0: 0000 0000 [0001]

00: 0000 0000

BP: 2400 0041 [0000]

G0: 1190 0000

EC: 0000 0000 [1000]

T0: 0000 024F [010F]

Jump to BL


NOTICE:  BL2: v2.7(release):0697eafa43-dirty
NOTICE:  BL2: Built : 17:33:02, Jan 26 2024
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a003f1 000000ff 00100000 00000000
1001d040 | 00027e71 000200a0 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0xc 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 564, worse bit 2, min window 68
Window Sum 552, worse bit 8, min window 68
Window Sum 392, worse bit 1, min window 48
Window Sum 380, worse bit 9, min window 46
Window Sum 408, worse bit 3, min window 48
Window Sum 392, worse bit 9, min window 46
Window Sum 418, worse bit 1, min window 50
Window Sum 410, worse bit 9, min window 48
Window Sum 434, worse bit 1, min window 54
Window Sum 424, worse bit 9, min window 50
Window Sum 434, worse bit 9, min window 52
Window Sum 454, worse bit 3, min window 54
Window Sum 440, worse bit 9, min window 52
Window Sum 460, worse bit 1, min window 56
Window Sum 452, worse bit 8, min window 54
Window Sum 468, worse bit 3, min window 56
Window Sum 470, worse bit 3, min window 58
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc8
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 1 found in block 960
NOTICE:  Second info table with writecount 1 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):0697eafa43-dirty
NOTICE:  BL31: Built : 17:33:04, Jan 26 2024
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Jan 26 2024 - 17:32:30 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: GigaDevice SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 1 found in block 960
Second info table with writecount 1 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[?25h[2J[1;1HCheck RST button - wait 1 second

ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 110 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 2/1, WL threshold: 4096, image sequence number: 0
ubi0: available PEBs: 2, total reserved PEBs: 878, PEBs reserved for bad PEB handling: 19
Reading from volume 'kernel' to 0x46000000, size 0x0 ... OK
## Loading kernel from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.6.95
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x460000e8
     Data Size:    4299088 Bytes = 4.1 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x48000000
     Entry Point:  0x48000000
     Hash algo:    crc32
     Hash value:   3a9366b0
     Hash algo:    sha1
     Hash value:   dafb89b1de1a6b2419d2df2afec862d3d8e39ea7
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt iptime_ax3000sm device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x46419b78
     Data Size:    22950 Bytes = 22.4 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   dfc332ed
     Hash algo:    sha1
     Hash value:   bf7fc01f19dafa2240d223de48ff6902d0158672
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x46419b78
   Uncompressing Kernel Image
   Loading Device Tree to 000000004f7f0000, end 000000004f7f89a5 ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.6.95 (nyanko@DevBox) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 13.3.0 r0+28760-cb2c7fb8a6) 13.3.0, GNU ld (GNU Binutils) 2.42) #0 SMP Mon Jul 14 09:45:28 2025
[    0.000000] Machine model: ipTIME AX3000SM
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004302ffff (192 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x0000000047c80000..0x0000000047d7ffff (1024 KiB) nomap non-reusable wmcpu-reserved@47c80000
[    0.000000] OF: reserved mem: 0x0000000047d80000..0x0000000047dbffff (256 KiB) nomap non-reusable wo-emi@47d80000
[    0.000000] OF: reserved mem: 0x0000000047dc0000..0x0000000047ffffff (2304 KiB) nomap non-reusable wo-data@47dc0000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004302ffff]
[    0.000000]   node   0: [mem 0x0000000043030000-0x0000000047c7ffff]
[    0.000000]   node   0: [mem 0x0000000047c80000-0x0000000047ffffff]
[    0.000000]   node   0: [mem 0x0000000048000000-0x000000004fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 18 pages/cpu s35112 r8192 d30424 u73728
[    0.000000] pcpu-alloc: s35112 r8192 d30424 u73728 alloc=18*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: console=ttyS0,115200 boot_from=A
[    0.000000] Unknown kernel command line parameters "boot_from=A", will be passed to user space.
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 64512
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[    0.000000] software IO TLB: area num 2.
[    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 0MB
[    0.000000] software IO TLB: mapped [mem 0x000000004fe47000-0x000000004fec7000] (0MB)
[    0.000000] Memory: 239180K/262144K available (8832K kernel code, 994K rwdata, 2568K rodata, 448K init, 289K bss, 22964K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000070] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000078] pid_max: default: 32768 minimum: 301
[    0.002973] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.002980] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.005103] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.005626] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.005772] rcu: Hierarchical SRCU implementation.
[    0.005775] rcu: 	Max phase no-delay instances is 1000.
[    0.006165] smp: Bringing up secondary CPUs ...
[    0.006523] Detected VIPT I-cache on CPU1
[    0.006566] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.006595] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.006662] smp: Brought up 1 node, 2 CPUs
[    0.006667] SMP: Total of 2 processors activated.
[    0.006670] CPU features: detected: 32-bit EL0 Support
[    0.006673] CPU features: detected: CRC32 instructions
[    0.006705] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.006708] CPU: All CPU(s) started at EL2
[    0.006710] alternatives: applying system-wide alternatives
[    0.010270] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.010285] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.011545] pinctrl core: initialized pinctrl subsystem
[    0.012682] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.013020] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.013045] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.013065] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.013444] thermal_sys: Registered thermal governor 'fair_share'
[    0.013448] thermal_sys: Registered thermal governor 'bang_bang'
[    0.013451] thermal_sys: Registered thermal governor 'step_wise'
[    0.013453] thermal_sys: Registered thermal governor 'user_space'
[    0.013520] ASID allocator initialised with 65536 entries
[    0.014235] pstore: Using crash dump compression: deflate
[    0.014240] pstore: Registered ramoops as persistent store backend
[    0.014242] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.015654] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.020985] Modules: 29440 pages in range for non-PLT usage
[    0.020993] Modules: 520960 pages in range for PLT usage
[    0.021917] cryptd: max_cpu_qlen set to 1000
[    0.023994] SCSI subsystem initialized
[    0.024178] libata version 3.00 loaded.
[    0.025795] clocksource: Switched to clocksource arch_sys_counter
[    0.028117] NET: Registered PF_INET protocol family
[    0.028221] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.029266] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.029279] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.029287] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.029306] TCP bind hash table entries: 2048 (order: 4, 65536 bytes, linear)
[    0.029355] TCP: Hash tables configured (established 2048 bind 2048)
[    0.029668] MPTCP token hash table entries: 256 (order: 0, 6144 bytes, linear)
[    0.029773] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.029788] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.029988] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.030085] PCI: CLS 0 bytes, default 64
[    0.031178] workingset: timestamp_bits=46 max_order=16 bucket_order=0
[    0.036054] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.036064] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.103268] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.104513] printk: console [ttyS0] disabled
[    0.124870] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 72, base_baud = 2500000) is a ST16650V2
[    0.124909] printk: console [ttyS0] enabled
[    0.890758] loop: module loaded
[    0.896881] spi-nand spi0.0: calibration result: 0x3
[    0.901928] spi-nand spi0.0: ESMT SPI NAND was found.
[    0.907001] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.915871] Signature found at block 1023 [0x07fe0000]
[    0.921001] NMBM management region starts at block 960 [0x07800000]
[    0.929787] First info table with writecount 1 found in block 960
[    0.941492] Second info table with writecount 1 found in block 963
[    0.947682] NMBM has been successfully attached
[    0.952500] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.958904] Creating 5 MTD partitions on "spi0.0":
[    0.963685] 0x000000000000-0x000000100000 : "BL2"
[    0.969537] 0x000000100000-0x000000180000 : "u-boot-env"
[    0.975625] 0x000000180000-0x000000380000 : "Factory"
[    0.982497] 0x000000380000-0x000000580000 : "FIP"
[    0.988782] 0x000000580000-0x000007380000 : "ubi"
[    1.193850] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081580000, irq 75
[    1.203743] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc081580000, irq 75
[    1.213460] i2c_dev: i2c /dev entries driver
[    1.219465] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.228536] NET: Registered PF_INET6 protocol family
[    1.234532] Segment Routing with IPv6
[    1.238243] In-situ OAM (IOAM) with IPv6
[    1.242203] NET: Registered PF_PACKET protocol family
[    1.247435] 8021q: 802.1Q VLAN Support v1.8
[    1.348650] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.357654] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.368396] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=79)
[    1.390760] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=80)
[    1.412950] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=81)
[    1.435018] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=82)
[    1.446579] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.453319] DSA: tree 0 setup
[    1.457145] UBI: auto-attach mtd4
[    1.460467] ubi0: default fastmap pool size: 40
[    1.464985] ubi0: default fastmap WL pool size: 20
[    1.469784] ubi0: attaching mtd4
[    2.265981] ubi0: scanning is finished
[    2.280978] ubi0: attached mtd4 (name "ubi", size 110 MiB)
[    2.286485] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    2.293348] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.300130] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.307083] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    2.313075] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[    2.320286] ubi0: max/mean erase counter: 2/1, WL threshold: 4096, image sequence number: 0
[    2.328625] ubi0: available PEBs: 0, total reserved PEBs: 880, PEBs reserved for bad PEB handling: 19
[    2.337840] ubi0: background thread "ubi_bgt0d" started, PID 543
[    2.344693] block ubiblock0_1: created from ubi0:1(rootfs)
[    2.350224] ubiblock: device ubiblock0_1 (rootfs) set to be root filesystem
[    2.357325] clk: Disabling unused clocks
[    2.369771] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[    2.377122] Freeing unused kernel memory: 448K
[    2.381638] Run /sbin/init as init process
[    2.385724]   with arguments:
[    2.388691]     /sbin/init
[    2.391386]   with environment:
[    2.394514]     HOME=/
[    2.396895]     TERM=linux
[    2.399590]     boot_from=A
[    2.667887] init: Console is alive
[    2.671401] init: - watchdog -
[    3.121842] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.153640] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    3.163669] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.178939] init: - preinit -
[    3.365825] random: crng init done
[    3.589759] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    3.598451] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    3.621001] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    4.705020] mt7530-mdio mdio-bus:1f lan1: Link is Up - 1Gbps/Full - flow control rx/tx
[    7.796758] UBIFS (ubi0:2): default file-system created
[    7.802885] UBIFS (ubi0:2): Mounting in unauthenticated mode
[    7.808671] UBIFS (ubi0:2): background thread "ubifs_bgt0_2" started, PID 681
[    7.897396] UBIFS (ubi0:2): UBIFS: mounted UBI device 0, volume 2, name "rootfs_data"
[    7.905224] UBIFS (ubi0:2): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[    7.915152] UBIFS (ubi0:2): FS size: 97898496 bytes (93 MiB, 771 LEBs), max 782 LEBs, journal size 4952064 bytes (4 MiB, 39 LEBs)
[    7.926798] UBIFS (ubi0:2): reserved for root: 4623987 bytes (4515 KiB)
[    7.933399] UBIFS (ubi0:2): media format: w5/r0 (latest is w5/r0), UUID 7EB17257-A46C-4C00-8661-75A67458A995, small LPT model
[    7.946910] mount_root: overlay filesystem has not been fully initialized yet
[    7.954259] mount_root: switching to ubifs overlay
[    7.962774] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[    7.974860] urandom-seed: Seed file not found (/etc/urandom.seed)
[    8.025896] mt7530-mdio mdio-bus:1f lan1: Link is Down
[    8.035244] procd: - early -
[    8.038223] procd: - watchdog -
[    8.587554] procd: - watchdog -
[    8.656452] procd: - ubus -
[    8.810258] procd: - init -
Please press Enter to activate this console.
[    9.196088] kmodloader: loading kernel modules from /etc/modules.d/*
[    9.237861] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    9.254819] Loading modules backported from Linux version v6.12.6-0-ge9d65b48ce1a
[    9.262351] Backport generated by backports.git v6.1.110-1-35-g410656ef04d2
[    9.382207] urngd: v1.0.2 started.
[    9.610576] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[    9.610576] 
[    9.870801] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[    9.982685] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[   10.081321] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[   10.178498] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[   10.281092] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   10.300130] PPP generic driver version 2.4.2
[   10.305561] NET: Registered PF_PPPOX protocol family
[   10.314863] kmodloader: done loading kernel modules from /etc/modules.d/*
[   10.429198] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   17.544810] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   17.566832] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   17.575363] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   17.591406] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   17.599657] br-lan: port 1(lan1) entered blocking state
[   17.604886] br-lan: port 1(lan1) entered disabled state
[   17.610171] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   17.616489] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   17.627372] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   17.653773] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   17.664845] br-lan: port 2(lan2) entered blocking state
[   17.670137] br-lan: port 2(lan2) entered disabled state
[   17.675386] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   17.683437] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   17.700559] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   17.709434] br-lan: port 3(lan3) entered blocking state
[   17.714665] br-lan: port 3(lan3) entered disabled state
[   17.719978] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   17.728196] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   17.751776] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   17.763487] br-lan: port 4(lan4) entered blocking state
[   17.768816] br-lan: port 4(lan4) entered disabled state
[   17.774075] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   17.804226] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[   17.872853] mtk_soc_eth 15100000.ethernet eth1: PHY [mdio-bus:00] driver [MediaTek MT7981 PHY] (irq=POLL)
[   17.882506] mtk_soc_eth 15100000.ethernet eth1: configuring for phy/gmii link mode
[   17.895391] mtk_soc_eth 15100000.ethernet eth1: Link is Up - 1Gbps/Full - flow control rx/tx
[   20.451213] mt7530-mdio mdio-bus:1f lan1: Link is Up - 1Gbps/Full - flow control rx/tx
[   20.451236] br-lan: port 1(lan1) entered blocking state
[   20.464350] br-lan: port 1(lan1) entered forwarding state
[   21.802871] mt7530-mdio mdio-bus:1f lan2: Link is Up - 1Gbps/Full - flow control rx/tx
[   21.802894] br-lan: port 2(lan2) entered blocking state
[   21.816014] br-lan: port 2(lan2) entered forwarding state



BusyBox v1.36.1 (2025-07-14 09:45:28 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt 24.10-SNAPSHOT, r0+28760-cb2c7fb8a6
 -----------------------------------------------------
=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------
root@OpenWrt:~# 
```

</p>
</details> 

Related links
----------
- Snapshot PR (main branch): https://github.com/openwrt/openwrt/pull/18689
- Cherry picked from commit 1c6cb6d5be10281d3b45ef8deec50b9e1e9aa8bb


