### PR TITLE
[WIP] realtek: power off SerDes when link down

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -126,6 +126,7 @@ irqreturn_t rtl839x_switch_irq(int irq, void *dev_id);
 void rtl930x_vlan_profile_dump(int index);
 int rtl9300_sds_power(int mac, int val);
 extern int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode);
+extern void rtsds_930x_force_mode(int sds, phy_interface_t interface);
 void rtl930x_print_matrix(void);
 
 /* RTL931x-specific */

--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
@@ -1815,8 +1815,9 @@ static int rtsds_930x_init_state_machine(int sds, phy_interface_t interface)
 	return ret;
 }
 
-static void rtsds_930x_force_mode(int sds, phy_interface_t interface)
+void rtsds_930x_force_mode(int sds, phy_interface_t interface)
 {
+	const char *modename = interface == PHY_INTERFACE_MODE_NA ? "off" : phy_modes(interface);
 	int mode;
 
 	/*
@@ -1825,6 +1826,8 @@ static void rtsds_930x_force_mode(int sds, phy_interface_t interface)
 	 * needed for modes that cannot be set by the SoC itself. Additionally it is unclear
 	 * if this sequence should quit early in case of errors.
 	 */
+
+	pr_info("%s: switch SDS %d to %s\n", __func__, sds, modename);
 
 	switch (interface) {
 	case PHY_INTERFACE_MODE_SGMII:

--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.h
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.h
@@ -74,6 +74,7 @@ int rtl839x_write_sds_phy(int phy_addr, int phy_reg, u16 v);
 int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode);
 int rtl930x_read_sds_phy(int phy_addr, int page, int phy_reg);
 int rtl930x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v);
+void rtsds_930x_force_mode(int sds, phy_interface_t interface);
 
 int rtl931x_read_sds_phy(int phy_addr, int page, int phy_reg);
 int rtl931x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v);


### PR DESCRIPTION
When a link goes down the SerDes is left in the active operation mode. This is usually no problem for a switch because network interfaces are usually in a fixed up or down state during the whole uptime.

A SerDes pair (odd/even) on a RTL930x has restrictions regarding the possible speeds. Especially switching between 1G/2.5G/10G has a very sophisticated logic because the allowed PLL combinations ar limited.

For greater fexlibility switch of the SerDes when there is no link. With this the neighbour SerDes can easier handle PLL selection.
