### PR TITLE
qualcommax: ipq50xx: update qcn6122 caldata offset of yuncore ax830

### DIFF
--- a/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -64,8 +64,8 @@ case "$FIRMWARE" in
 		ath11k_remove_regdomain
 		ath11k_set_macflag
 		;;
-        yuncore,ax830)
-		caldata_extract "0:ART" 0x26800 0x20000
+	yuncore,ax830)
+		caldata_extract "0:ART" 0x4c000 0x20000
 		label_mac=$(mtd_get_mac_binary 0:ART 0)
 		ath11k_patch_mac $(macaddr_add $label_mac 3) 0
 		ath11k_remove_regdomain


### PR DESCRIPTION
 Hi @robimarko,
The current offset for the QCN6122's caldata is incorrect for the Yuncore AX830. I missed that detail while opening the initial PR.