### PR TITLE
CI: packages: exclude some paths to save computing resources

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -3,16 +3,12 @@ name: Build Kernel
 on:
   pull_request:
     paths:
-      - '.github/workflows/check-kernel-patches.yml'
-      - '.github/workflows/build.yml'
       - '.github/workflows/kernel.yml'
       - 'include/kernel*'
       - 'package/kernel/**'
       - 'target/linux/**'
   push:
     paths:
-      - '.github/workflows/check-kernel-patches.yml'
-      - '.github/workflows/build.yml'
       - '.github/workflows/kernel.yml'
       - 'include/kernel*'
       - 'package/kernel/**'

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -9,6 +9,7 @@ on:
       - 'package/**'
       - 'target/linux/generic/**'
       - 'toolchain/**'
+      - '!package/base-files/files/**'
   push:
     paths:
       - '.github/workflows/packages.yml'
@@ -17,6 +18,7 @@ on:
       - 'package/**'
       - 'target/linux/generic/**'
       - 'toolchain/**'
+      - '!package/base-files/files/**'
     branches-ignore:
       - master
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -10,6 +10,7 @@ on:
       - 'target/linux/generic/**'
       - 'toolchain/**'
       - '!package/base-files/files/**'
+      - '!package/boot/uboot-tools/uboot-envtools/files/**'
   push:
     paths:
       - '.github/workflows/packages.yml'
@@ -19,6 +20,7 @@ on:
       - 'target/linux/generic/**'
       - 'toolchain/**'
       - '!package/base-files/files/**'
+      - '!package/boot/uboot-tools/uboot-envtools/files/**'
     branches-ignore:
       - master
 


### PR DESCRIPTION
This patchset aims to reduce some useless _GitHub Actions_ triggered when adding a new device support. 

Ref:
https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#example-including-and-excluding-paths