### PR TITLE
x86: modules: add packages for Intel LPSS drivers

### DIFF
--- a/package/kernel/linux/modules/i2c.mk
+++ b/package/kernel/linux/modules/i2c.mk
@@ -162,6 +162,38 @@ endef
 $(eval $(call KernelPackage,i2c-gpio))
 
 
+I2C_HID_MODULES:= \
+  CONFIG_I2C_HID_CORE:drivers/hid/i2c-hid/i2c-hid
+
+define KernelPackage/i2c-hid
+  $(call i2c_defaults,$(I2C_HID_MODULES),60)
+  TITLE:=I2C HID support
+  KCONFIG+= CONFIG_I2C_HID
+  DEPENDS:=+kmod-hid
+  HIDDEN:=1
+endef
+
+$(eval $(call KernelPackage,i2c-hid))
+
+
+I2C_HID_ACPI_MODULES:= \
+  CONFIG_I2C_HID_ACPI:drivers/hid/i2c-hid/i2c-hid-acpi
+
+define KernelPackage/i2c-hid-acpi
+  $(call i2c_defaults,$(I2C_HID_ACPI_MODULES),61)
+  TITLE:=HID over I2C transport layer ACPI driver
+  DEPENDS:=@TARGET_armsr_armv8||TARGET_loongarch64||TARGET_x86 +kmod-i2c-hid
+endef
+
+define KernelPackage/i2c-hid-acpi/description
+  Support for keyboard, touchpad, touchscreen, or any
+  other HID based devices which is connected to your computer via I2C.
+  This driver supports ACPI-based systems.
+endef
+
+$(eval $(call KernelPackage,i2c-hid-acpi))
+
+
 I2C_I801_MODULES:= \
   CONFIG_I2C_I801:drivers/i2c/busses/i2c-i801
 

--- a/target/linux/x86/modules.mk
+++ b/target/linux/x86/modules.mk
@@ -99,6 +99,62 @@ endef
 
 $(eval $(call KernelPackage,ib700-wdt))
 
+
+define KernelPackage/intel-lpss
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Intel LPSS common
+  DEPENDS:=@TARGET_x86
+  KCONFIG:=CONFIG_INTEL_LPSS
+  FILES:=$(LINUX_DIR)/drivers/mfd/intel-lpss.ko
+  HIDDEN:=1
+  AUTOLOAD:=$(call AutoProbe,intel-lpss)
+endef
+
+$(eval $(call KernelPackage,intel-lpss))
+
+
+define KernelPackage/intel-lpss-acpi
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Intel LPSS ACPI
+  DEPENDS:=+kmod-intel-lpss
+  KCONFIG:=CONFIG_INTEL_LPSS_ACPI
+  FILES:=$(LINUX_DIR)/drivers/mfd/intel-lpss-acpi.ko
+  AUTOLOAD:=$(call AutoProbe,intel-lpss-acpi)
+endef
+
+define KernelPackage/intel-lpss-acpi/description
+Kernel module to support Intel Low Power Subsystem (LPSS) devices such as
+I2C, SPI and HS-UART starting from Intel Sunrisepoint (Intel Skylake
+PCH) in ACPI mode.
+
+The actual hardware driver (eg. kmod-i2c-designware-platform) is still
+needed in addition to this package.
+endef
+
+$(eval $(call KernelPackage,intel-lpss-acpi))
+
+
+define KernelPackage/intel-lpss-pci
+  SUBMENU:=$(OTHER_MENU)
+  TITLE:=Intel LPSS PCI
+  DEPENDS:=+kmod-intel-lpss
+  KCONFIG:=CONFIG_INTEL_LPSS_PCI
+  FILES:=$(LINUX_DIR)/drivers/mfd/intel-lpss-pci.ko
+  AUTOLOAD:=$(call AutoProbe,intel-lpss-pci)
+endef
+
+define KernelPackage/intel-lpss-pci/description
+Kernel module to support Intel Low Power Subsystem (LPSS) devices such as
+I2C, SPI and HS-UART starting from Intel Sunrisepoint (Intel Skylake
+PCH) in PCI mode.
+
+The actual hardware driver (eg. kmod-i2c-designware-platform) is still
+needed in addition to this package.
+endef
+
+$(eval $(call KernelPackage,intel-lpss-pci))
+
+
 define KernelPackage/it87-wdt
   SUBMENU:=$(OTHER_MENU)
   TITLE:=ITE IT87 Watchdog Timer


### PR DESCRIPTION
Add driver packages for Intel Low-Power Subsystem devices which are part of some Intel chipsets. They are mainly needed to have access to the I2C bus used for HID devices.