### PR TITLE
apm821xx: pcie node number fixes

### DIFF
--- a/target/linux/apm821xx/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
+++ b/target/linux/apm821xx/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# This must run before 10-wifi-detect
+
+[ "${ACTION}" = "add" ] || return
+
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+do_migrate_radio()
+{
+	local config="$1"
+
+	config_get from "$config" path
+
+	to=${from/pciex\//pcie\/}
+
+	# Checks if kernel version is less than 6.12.0, if it is and the path is
+	# using the new format, then path should be migrated to the old format.
+	[ "$(get_linux_version)" -lt "612000" ] && to=${from/pcie\//pciex\/}
+
+	[ "$from" = "$to" ] && return
+
+	uci set "wireless.${config}.path=${to}"
+	WIRELESS_CHANGED=true
+
+	logger -t wifi-migrate "Updated path of wireless.${config} from '${from}' to '${to}'"
+}
+
+migrate_radio()
+{
+	config_load wireless
+
+	config_foreach do_migrate_radio wifi-device
+}
+
+WIRELESS_CHANGED=false
+
+case "$(board_name)" in
+*)
+	migrate_radio
+	;;
+esac
+
+$WIRELESS_CHANGED && uci commit wireless
+
+exit 0

--- a/target/linux/apm821xx/dts/apm82181.dtsi
+++ b/target/linux/apm821xx/dts/apm82181.dtsi
@@ -418,7 +418,7 @@
 			#size-cells = <0>;
 		};
 
-		PCIE0: pciex@d00000000 {
+		PCIE0: pcie@d00000000 {
 			device_type = "pci"; /* see ppc4xx_pci_find_bridge */
 			#interrupt-cells = <1>;
 			#size-cells = <2>;

--- a/target/linux/apm821xx/dts/meraki-mr24.dts
+++ b/target/linux/apm821xx/dts/meraki-mr24.dts
@@ -227,13 +227,13 @@
 	 *
 	 */
 
-	bridge@64,0 {
+	bridge@0,0 {
 		reg = <0x00400000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
 		ranges;
 
-		bridge@65,0 {
+		bridge@0,0 {
 			/* IDT PES3T3 PCI Express Switch */
 			compatible = "pci111d,8039";
 			reg = <0x00410000 0 0 0 0>;
@@ -241,14 +241,14 @@
 			#size-cells = <2>;
 			ranges;
 
-			bridge@66,2 {
+			bridge@2,0 {
 				compatible = "pci111d,8039";
 				reg = <0x00421000 0 0 0 0>;
 				#address-cells = <3>;
 				#size-cells = <2>;
 				ranges;
 
-				wifi0: wifi@67,0 {
+				wifi0: wifi@0,0 {
 					/* Atheros AR9380 2.4GHz */
 					compatible = "pci168c,0030";
 					reg = <0x00430000 0 0 0 0>;
@@ -256,14 +256,14 @@
 				};
 			};
 
-			bridge@66,3 {
+			bridge@3,0 {
 				compatible = "pci111d,8039";
 				reg = <0x00421800 0 0 0 0>;
 				#address-cells = <3>;
 				#size-cells = <2>;
 				ranges;
 
-				wifi1: wifi@68,0 {
+				wifi1: wifi@0,0 {
 					/* Atheros AR9380 5GHz */
 					compatible = "pci168c,0030";
 					reg = <0x00440000 0 0 0 0>;

--- a/target/linux/apm821xx/dts/meraki-mx60.dts
+++ b/target/linux/apm821xx/dts/meraki-mx60.dts
@@ -443,13 +443,13 @@
 	 *	-+-[0000:40]---00.0-[41-7f]----00.0
 	 */
 
-	bridge@64,0 {
+	bridge@0,0 {
 		reg = <0x00400000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
 		ranges;
 
-		wifi0: wifi@65,0 {
+		wifi0: wifi@0,0 {
 			/* Atheros AR9380 2.4/5GHz */
 			compatible = "pci168c,0030";
 			reg = <0x00410000 0 0 0 0>;

--- a/target/linux/apm821xx/dts/netgear-wndap620.dts
+++ b/target/linux/apm821xx/dts/netgear-wndap620.dts
@@ -31,13 +31,13 @@
 	 *	-+-[0000:40]---00.0-[41-7f]----00.0
 	 */
 
-	bridge@64,0 {
+	bridge@0,0 {
 		reg = <0x00400000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
 		ranges;
 
-		wifi0: wifi@65,0 {
+		wifi0: wifi@0,0 {
 			/* Atheros AR9380 5GHz */
 			compatible = "pci168c,0030";
 			reg = <0x00410000 0 0 0 0>;

--- a/target/linux/apm821xx/dts/netgear-wndap660.dts
+++ b/target/linux/apm821xx/dts/netgear-wndap660.dts
@@ -48,13 +48,13 @@
 	 *
 	 */
 
-	bridge@64,0 {
+	bridge@0,0 {
 		reg = <0x00400000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
 		ranges;
 
-		bridge@65,0 {
+		bridge@0,0 {
 			/* IDT PES3T3 PCI Express Switch */
 			compatible = "pci111d,8039";
 			reg = <0x00410000 0 0 0 0>;
@@ -62,14 +62,14 @@
 			#size-cells = <2>;
 			ranges;
 
-			bridge@66,2 {
+			bridge@2,0 {
 				compatible = "pci111d,8039";
 				reg = <0x00421000 0 0 0 0>;
 				#address-cells = <3>;
 				#size-cells = <2>;
 				ranges;
 
-				wifi0: wifi@67,0 {
+				wifi0: wifi@0,0 {
 					/* Atheros AR9380 2.4/5GHz */
 					compatible = "pci168c,0030";
 					reg = <0x00430000 0 0 0 0>;
@@ -77,14 +77,14 @@
 				};
 			};
 
-			bridge@66,3 {
+			bridge@3,0 {
 				compatible = "pci111d,8039";
 				reg = <0x00421800 0 0 0 0>;
 				#address-cells = <3>;
 				#size-cells = <2>;
 				ranges;
 
-		                wifi1: wifi@68,0 {
+		                wifi1: wifi@0,0 {
 					/* Atheros AR9380 2.4/5GHz */
 					compatible = "pci168c,0030";
 					reg = <0x00440000 0 0 0 0>;

--- a/target/linux/apm821xx/dts/netgear-wndr4700.dts
+++ b/target/linux/apm821xx/dts/netgear-wndr4700.dts
@@ -568,13 +568,13 @@
 	 *
 	 */
 
-	bridge@64,0 {
+	bridge@0,0 {
 		reg = <0x00400000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
 		ranges;
 
-		bridge@65,0 {
+		bridge@0,0 {
 			/* IDT PES4T4 PCI Express Switch */
 			compatible = "pci111d,803a";
 			reg = <0x00410000 0 0 0 0>;
@@ -582,14 +582,14 @@
 			#size-cells = <2>;
 			ranges;
 
-			bridge@66,2 {
+			bridge@2,0 {
 				compatible = "pci111d,803a";
 				reg = <0x00421000 0 0 0 0>;
 				#address-cells = <3>;
 				#size-cells = <2>;
 				ranges;
 
-				wifi0: wifi@67,0 {
+				wifi0: wifi@0,0 {
 					/* Atheros AR9380 5GHz */
 					compatible = "pci168c,0030";
 					reg = <0x00430000 0 0 0 0>;
@@ -605,14 +605,14 @@
 				};
 			};
 
-			bridge@66,3 {
+			bridge@3,0 {
 				compatible = "pci111d,803a";
 				reg = <0x00421800 0 0 0 0>;
 				#address-cells = <3>;
 				#size-cells = <2>;
 				ranges;
 
-				wifi1: wifi@68,0 {
+				wifi1: wifi@0,0 {
 					/* Atheros AR9381 2.4GHz */
 					compatible = "pci168c,0033";
 					reg = <0x00440000 0 0 0 0>;
@@ -622,14 +622,14 @@
 				};
 			};
 
-			bridge@66,4 {
+			bridge@4,0 {
 				compatible = "pci111d,803a";
 				reg = <0x00422000 0 0 0 0>;
 				#address-cells = <3>;
 				#size-cells = <2>;
 				ranges;
 
-				usb1: usb@69,0 {
+				usb1: usb@0,0 {
 					/* Renesas uPD720202 */
 					compatible = "pci1912,0015";
 					reg = <0x00450000 0 0 0 0>;


### PR DESCRIPTION
@chunkeey 

ping @DragonBluep @Ansuel maybe @paraka 

so it seems dtc only really warns on these if the device_type is pci. OTOH I see bridge@ being used in ipq806x, ipq40xx, and one mvebu device. Is this naming legacy?