### PR TITLE
perf: fix build on mips

### DIFF
--- a/package/devel/perf/Makefile
+++ b/package/devel/perf/Makefile
@@ -74,7 +74,7 @@ MAKE_FLAGS = \
 	O=$(PKG_BUILD_DIR) \
 	prefix=/usr
 
-ifeq ($(LINUX_KARCH),powerpc)
+ifneq ($(filter $(LINUX_KARCH),powerpc mips),)
 	MAKE_FLAGS += NO_AUXTRACE=1
 endif
 


### PR DESCRIPTION
#### Maintainer: @nbd168 

#### Description:
Building perf on mips/malta fails on intel-pt-decoder due to a header issue previously seen in f434643857 ("perf: fix build on PowerPC"):
```
In file included from util/intel-pt-decoder/intel-pt-insn-decoder.c:12: util/intel-pt-decoder/../../../arch/x86/include/asm/insn.h: In function 'insn_field_set': util/intel-pt-decoder/../../../arch/x86/include/asm/insn.h:56:21: error: implicit declaration of function '__cpu_to_le32'; did you mean 'cpu_to_le32'? [-Wimplicit-function-declaration]
   56 |         p->little = __cpu_to_le32(v);
      |                     ^~~~~~~~~~~~~
      |                     cpu_to_le32
util/intel-pt-decoder/../../../arch/x86/include/asm/insn.h: In function 'insn_set_byte':
util/intel-pt-decoder/../../../arch/x86/include/asm/insn.h:64:20: error: implicit declaration of function '__le32_to_cpu'; did you mean 'le32_to_cpu'? [-Wimplicit-function-declaration]
   64 |         p->value = __le32_to_cpu(p->little);
      |                    ^~~~~~~~~~~~~
      |                    le32_to_cpu
```
Extend the previous powerpc fix to mips, disabling intel-pt-decoder build.

#### Review:
Experience with related fixes: @stintel @robimarko 
