### PR TITLE
ramips: EAP615-Wall v1: fix bootloop by reducing LZMA dictionary

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2824,8 +2824,8 @@ define Device/tplink_eap615-wall-v1
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
   TPLINK_BOARD_ID := EAP615-WALL-V1
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | pad-to 64k
-  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+  KERNEL := kernel-bin | lzma -d22 | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | pad-to 64k
+  KERNEL_INITRAMFS := kernel-bin | lzma -d22 | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
   IMAGE_SIZE := 13248k
 endef
 TARGET_DEVICES += tplink_eap615-wall-v1


### PR DESCRIPTION
Fix bootloop on TP-Link EAP615-Wall v1 by reducing LZMA dictionary size. Before this patch and after an upgrade to kernel 6.12 this device couldn't boot a kernel because of an error: "lzma compressed: uncompress error 1".
    
I have chosen -d22 as dictionary size as suggested by @namiltd. The usual sizes for problematic devices are -d16, -d20, -d22. I have confirmed with my tests that this device can boot with a value up to -d27, but there is no size benefit from values above -d21, therefore -d22 is good enough.

This PR fixes #19403