### PR TITLE
kirkwood: add kmod-ata-ahci as default to ix4-200d

### DIFF
--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -240,7 +240,7 @@ define Device/iom_ix4-200d
   $(Device/kernel-size-migration-iomega)
   DEVICE_VENDOR := Iomega
   DEVICE_MODEL := StorCenter ix4-200d
-  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
+  DEVICE_PACKAGES := kmod-ata-ahci kmod-ata-marvell-sata kmod-fs-ext4 \
 	kmod-gpio-button-hotplug kmod-gpio-nxp-74hc164 \
 	kmod-hwmon-adt7475 kmod-mvsdio kmod-spi-gpio kmod-rtc-mv
   PAGESIZE := 512


### PR DESCRIPTION
The ix4-200d is a 4 bay NAS supported since OpenWrt 23.05 (https://github.com/openwrt/openwrt/pull/12659). Drive trays 3 and 4 are connected to the SoC, trays 1 and 2 to a SATA controller. Due to a kernel-related issue with the SATA controller, trays 1 and 2 were not recognized. This issue has been fixed in kernel 6.10, so with the adoption of kernel 6.12 in the Kirkwood target trays 1 and 2 can now be made accessible. This requires the `kmod-ata-ahci` package, which this commit adds as default to the makefile.