### PR TITLE
[24.10] uboot-envtools: add support for Gateworks venice

### DIFF
--- a/package/boot/uboot-envtools/files/imx_cortexa53
+++ b/package/boot/uboot-envtools/files/imx_cortexa53
@@ -1,0 +1,21 @@
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+gw,imx8m*|\
+gateworks,imx8m*)
+	# board boots from emmc boot0 hardware partition
+	ubootenv_add_uci_config /dev/mmcblk2boot0 0x3f0000 0x8000
+	ubootenv_add_uci_config /dev/mmcblk2boot0 0x3f8000 0x8000
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0


### PR DESCRIPTION
Add uboot-envtools support for Gateworks venice boards based on i.MX8M SoC's (imx_cortexa53) which boot from and store their U-Boot env on eMMC boot0 hardware partition.

root@OpenWrt:~# fw_printenv
Cannot parse config file '/etc/fw_env.config': No such file or directory
Failed to find NVMEM device


