### PR TITLE
mediatek: filogic: increase nand flash speed on Redmi AX6000

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
@@ -136,7 +136,7 @@
 		#size-cells = <1>;
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 


### PR DESCRIPTION
This commit increases the SPI bus frequency from 20 to 52 MHz. Reduces boot time by 2s. Below is a performance comparison.

Before:
```
root@OpenWrt:~# dd if=/dev/mtd5 of=/dev/null bs=10M count=1 status=progress
10485760 bytes (10 MB, 10 MiB) copied, 2 s, 5.8 MB/
```

After:
```
root@OpenWrt:~# dd if=/dev/mtd5 of=/dev/null bs=10M count=1 status=progress
10485760 bytes (10 MB, 10 MiB) copied, 1 s, 9.7 MB/s
```

Taken out of PR #18752 as each device should be tested individually, so I have created a separate PR for this.
Signed-off-by: Sky Huang <SkyLake.Huang@mediatek.com>
Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
