### PR TITLE
build: ipkg-remove: fix source name / package confusion, optimize

### DIFF
--- a/scripts/ipkg-remove
+++ b/scripts/ipkg-remove
@@ -3,16 +3,23 @@
 sourcename="$1"; shift
 
 for pkg in "$@"; do
-	tar -Ozxf "$pkg" ./control.tar.gz 2>/dev/null | tar -Ozxf - ./control 2>/dev/null | \
-	while read field value; do
-		if [ "$field" = "SourceName:" ] && [ "$value" = "$sourcename" ]; then
-			rm -vf "$pkg"
-			break
-		fi
-	done
 	case "$pkg" in
 		*/"${sourcename}_"*.ipk)
 			rm -vf "$pkg"
+		;;
+		*)
+			tar -Ozxf "$pkg" ./control.tar.gz 2>/dev/null | tar -Ozxf - ./control 2>/dev/null | {
+				packagename=
+				abiversion=
+				while read field value; do
+					case "$field" in
+						Package:) packagename="$value";;
+						ABIVersion:) abiversion="$value";;
+					esac
+				done
+				[ -n "$abiversion" ] && packagename="${packagename%%$abiversion}"
+				[ "$packagename" = "$sourcename" ] && rm -vf "$pkg"
+			}
 		;;
 	esac
 done


### PR DESCRIPTION
This is a backport pullrequest.

fixes #18939

```
The script always gets passed the package name, not the source name.
Optimize for the default case where the package name matches the
filename prefix.
```