### PR TITLE
kernel: modules: i2c: package i2c-mux-pinctrl

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -315,6 +315,9 @@ ifeq ($(DUMP),1)
     ifneq ($(CONFIG_PCIEPORTBUS),)
       FEATURES += pcie
     endif
+    ifneq ($(CONFIG_PINCTRL),)
+      FEATURES += pinctrl
+    endif
     ifneq ($(CONFIG_PWM),)
       FEATURES += pwm
     endif

--- a/package/kernel/linux/modules/i2c.mk
+++ b/package/kernel/linux/modules/i2c.mk
@@ -288,6 +288,22 @@ endef
 $(eval $(call KernelPackage,i2c-mux-mlxcpld))
 
 
+I2C_MUX_PINCTRL_MODULES:= \
+  CONFIG_I2C_MUX_PINCTRL:drivers/i2c/muxes/i2c-mux-pinctrl
+
+define KernelPackage/i2c-mux-pinctrl
+  $(call i2c_defaults,$(I2C_MUX_PINCTRL_MODULES),51)
+  TITLE:=Pinctrl-based I2C mux/switches
+  DEPENDS:=@PINCTRL_SUPPORT @USES_DEVICETREE +kmod-i2c-mux
+endef
+
+define KernelPackage/i2c-mux-pinctrl/description
+ Kernel modules for Pinctrl-based I2C bus mux/switching devices
+endef
+
+$(eval $(call KernelPackage,i2c-mux-pinctrl))
+
+
 I2C_MUX_REG_MODULES:= \
   CONFIG_I2C_MUX_REG:drivers/i2c/muxes/i2c-mux-reg
 

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -33,6 +33,7 @@ sub target_config_features(@) {
 		/^pci$/ and $ret .= "\tselect PCI_SUPPORT\n";
 		/^pcie$/ and $ret .= "\tselect PCIE_SUPPORT\n";
 		/^pcmcia$/ and $ret .= "\tselect PCMCIA_SUPPORT\n";
+		/^pinctrl$/ and $ret .= "\tselect PINCTRL_SUPPORT\n";
 		/^powerpc64$/ and $ret .= "\tselect powerpc64\n";
 		/^pwm$/ and $ret .= "\select PWM_SUPPORT\n";
 		/^ramdisk$/ and $ret .= "\tselect USES_INITRAMFS\n";

--- a/target/Config.in
+++ b/target/Config.in
@@ -32,6 +32,9 @@ config PCIE_SUPPORT
 config PCMCIA_SUPPORT
 	bool
 
+config PINCTRL_SUPPORT
+	bool
+
 config PWM_SUPPORT
 	bool
 


### PR DESCRIPTION
Package kernel module `i2c-mux-pinctrl` and make sure it only gets built on platforms which already got `CONFIG_PINCTRL=y` set.
