### PR TITLE
ramips: add support for SIM SIMAX1800U

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -85,7 +85,8 @@ zyxel,wsm20)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
 haier,har-20s2u1|\
-sim,simax1800t)
+sim,simax1800t|\
+sim,simax1800u)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	ubootenv_add_uci_sys_config "/dev/mtd1" "0x40000" "0x40000" "0x20000"
 	;;

--- a/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
+++ b/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
@@ -67,14 +67,8 @@
 &gmac1 {
 	status = "okay";
 	label = "wan";
-	phy-handle = <&ethphy4>;
-
 	nvmem-cells = <&macaddr_factory_8004 (-3)>;
 	nvmem-cell-names = "mac-address";
-};
-
-&ethphy4 {
-	/delete-property/ interrupts;
 };
 
 &nand {
@@ -166,7 +160,6 @@
 	ports {
 		port@1 {
 			status = "okay";
-			label = "lan3";
 		};
 
 		port@2 {
@@ -176,7 +169,6 @@
 
 		port@3 {
 			status = "okay";
-			label = "lan1";
 		};
 	};
 };

--- a/target/linux/ramips/dts/mt7621_sim_simax1800t.dts
+++ b/target/linux/ramips/dts/mt7621_sim_simax1800t.dts
@@ -6,3 +6,23 @@
 	compatible = "sim,simax1800t", "mediatek,mt7621-soc";
 	model = "SIM SIMAX1800T";
 };
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&gmac1 {
+	phy-handle = <&ethphy4>;
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			label = "lan3";
+		};
+
+		port@3 {
+			label = "lan1";
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_sim_simax1800u.dts
+++ b/target/linux/ramips/dts/mt7621_sim_simax1800u.dts
@@ -3,26 +3,26 @@
 #include "mt7621_haier-sim_wr1800k.dtsi"
 
 / {
-	compatible = "haier,har-20s2u1", "mediatek,mt7621-soc";
-	model = "Haier HAR-20S2U1";
+	compatible = "sim,simax1800u", "mediatek,mt7621-soc";
+	model = "SIM SIMAX1800U";
 };
 
-&ethphy4 {
+&ethphy0 {
 	/delete-property/ interrupts;
 };
 
 &gmac1 {
-	phy-handle = <&ethphy4>;
+	phy-handle = <&ethphy0>;
 };
 
 &switch0 {
 	ports {
 		port@1 {
-			label = "lan3";
+			label = "lan1";
 		};
 
 		port@3 {
-			label = "lan1";
+			label = "lan3";
 		};
 	};
 };

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2615,6 +2615,13 @@ define Device/sim_simax1800t
 endef
 TARGET_DEVICES += sim_simax1800t
 
+define Device/sim_simax1800u
+  $(Device/haier-sim_wr1800k)
+  DEVICE_VENDOR := SIM
+  DEVICE_MODEL := SIMAX1800U
+endef
+TARGET_DEVICES += sim_simax1800u
+
 define Device/snr_snr-cpe-me1
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -22,6 +22,7 @@ ramips_setup_interfaces()
 	mercusys,mr70x-v1|\
 	netgear,wax202|\
 	sim,simax1800t|\
+	sim,simax1800u|\
 	tplink,mr600-v2-eu|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-ac2100|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -105,7 +105,8 @@ case "$board" in
 		;;
 	haier,har-20s2u1|\
 	jcg,y2|\
-	sim,simax1800t)
+	sim,simax1800t|\
+	sim,simax1800u)
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary factory 0x4)" > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -138,6 +138,7 @@ platform_do_upgrade() {
 	sercomm,na502|\
 	sercomm,na502s|\
 	sim,simax1800t|\
+	sim,simax1800u|\
 	tplink,ec330-g5u-v1|\
 	wifire,s1500-nbn|\
 	xiaomi,mi-router-3g|\


### PR DESCRIPTION
```
SIM SIMAX1800U has the similar hardware design as the SIMAX1800T. The
only difference is the Ethernet portmap.

Specification
-------------
- SoC       : Mediatek MT7621
- RAM       : 256 MiB DDR3
- Flash     : 128 MiB NAND Flash
- WLAN      : Mediatek MT7905 DBDC
  - 2.4 GHz : 2x2 MIMO WiFi6
  - 5 GHz   : 2x2 MIMO WiFi6
- Ethernet  : MT7621 built-in 10/100/1000 Mbps 1x WAN; 3x LAN
- UART      : 3.3V, 115200n8
- Buttons   : 1x RESET; 1x WPS/MESH
- LEDs      : 1x Multi-Color(Blue;Green;Red)
- Power     : DC 12V1A
- CMIIT ID  : 2022AP7163
- TFTP IP   :
  - server  : 192.168.1.254
  - router  : 192.168.1.28

TFTP Installation(recommend)
------------
1. Set local tftp server IP "192.168.1.254" and NetMask "255.255.255.0".
2. Rename initramfs-kernel.bin to "factory.bin" and put it in the root
   directory of the tftp server. tftpd64 is a good choice for Windows.
3. Remove all Ethernet cables and WiFi connections from the PC, except
   for the one connected to the SIMAX1800U. Start the TFTP server, plug
   in the power adapter and wait for the OpenWrt system to boot.
4. Backup "firmware" partition and rename it to "firmware.bin". We need
   it to back to the stock firmware.
5. Use "fw_printenv" command to list envs. If "firmware_select=2" is
   observed then set u-boot env variable via command:
   `fw_setenv firmware_select 1`
6. Apply sysupgrade.bin in OpenWrt LuCI.

Web UI Installation
------------
1. Apply update by uploading initramfs-factory.bin to the web UI.
2. Use "fw_printenv" command to list envs. If "firmware_select=2" is
   observed then set u-boot env variable via command:
   `fw_setenv firmware_select 1`
3. Apply squashfs-sysupgrade.bin in OpenWrt LuCI.

Return to Stock Firmware
----------------------------
  Restore the backup firmware partition in the installation step 4.

MAC addresses
-------------
+---------+-------------------+
|         | MAC example       |
+---------+-------------------+
| LABEL   | 98:xx:xx:xx:xx:b2 |
| LAN     | 98:xx:xx:xx:xx:b5 |
| WAN     | 98:xx:xx:xx:xx:b2 |
| WLAN2G  | 98:xx:xx:xx:xx:b4 |
| WLAN5G  | 9a:xx:xx:xx:xx:b4 |
+---------+-------------------+

Tips:
-----------
  User can use `TFTP Installation` method to recover a brick device.
```
cc @huytran456