### PR TITLE
ca-certificates: Update to 20250419

### DIFF
--- a/package/system/ca-certificates/Makefile
+++ b/package/system/ca-certificates/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ca-certificates
-PKG_VERSION:=20241223
+PKG_VERSION:=20250419
 PKG_RELEASE:=1
 PKG_MAINTAINER:=
 
@@ -16,7 +16,7 @@ PKG_LICENSE_FILES:=debian/copyright
 
 PKG_SOURCE:=$(PKG_NAME)_$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@DEBIAN/pool/main/c/ca-certificates
-PKG_HASH:=dd8286d0a9dd35c756fea5f1df3fed1510fb891f376903891b003cd9b1ad7e03
+PKG_HASH:=33b44ef78653ecd3f0f2f13e5bba6be466be2e7da72182f737912b81798ba5d2
 PKG_INSTALL:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
upstream changelog:

```
[ Alexander Kanavin ]
* update-ca-certificates: add a --sysroot option

[ Julien Cristau ]
* Update Mozilla certificate authority bundle to version 2.74.
  The following certificate authorities were added (+):
  + D-TRUST BR Root CA 2 2023
  + D-TRUST EV Root CA 2 2023
  The following certificate authorities were removed (-):
  - Entrust Root Certification Authority - G4
  - SecureSign RootCA11
  - Security Communication RootCA3
  - SwissSign Silver CA - G2
```
