### PR TITLE
bcm27xx: package modules for official 7" touchscreen TFT display

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -318,6 +318,9 @@ ifeq ($(DUMP),1)
     ifneq ($(CONFIG_PINCTRL),)
       FEATURES += pinctrl
     endif
+    ifneq ($(CONFIG_PM),)
+      FEATURES += pm
+    endif
     ifneq ($(CONFIG_PWM),)
       FEATURES += pwm
     endif

--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -600,13 +600,12 @@ endef
 
 $(eval $(call KernelPackage,drm-imx-hdmi))
 
+
 define KernelPackage/drm-imx-ldb
   SUBMENU:=$(VIDEO_MENU)
   TITLE:=Freescale i.MX LVDS DRM support
-  DEPENDS:=@(TARGET_imx&&TARGET_imx_cortexa9) +kmod-backlight kmod-drm-imx
+  DEPENDS:=@(TARGET_imx&&TARGET_imx_cortexa9) +kmod-backlight +kmod-drm-panel-simple kmod-drm-imx
   KCONFIG:=CONFIG_DRM_IMX_LDB \
-	CONFIG_DRM_PANEL_SIMPLE \
-	CONFIG_DRM_PANEL=y \
 	CONFIG_DRM_PANEL_SAMSUNG_LD9040=n \
 	CONFIG_DRM_PANEL_SAMSUNG_S6E8AA0=n \
 	CONFIG_DRM_PANEL_LG_LG4573=n \
@@ -615,8 +614,7 @@ define KernelPackage/drm-imx-ldb
 	CONFIG_DRM_PANEL_S6E8AA0=n \
 	CONFIG_DRM_PANEL_SITRONIX_ST7789V=n
   FILES:= \
-	$(LINUX_DIR)/drivers/gpu/drm/imx/ipuv3/imx-ldb.ko \
-	$(LINUX_DIR)/drivers/gpu/drm/panel/panel-simple.ko
+	$(LINUX_DIR)/drivers/gpu/drm/imx/ipuv3/imx-ldb.ko
   AUTOLOAD:=$(call AutoLoad,08,imx-ldb)
 endef
 
@@ -643,6 +641,24 @@ define KernelPackage/drm-panel-mipi-dbi/description
 endef
 
 $(eval $(call KernelPackage,drm-panel-mipi-dbi))
+
+
+define KernelPackage/drm-panel-simple
+  SUBMENU:=$(VIDEO_MENU)
+  TITLE:=Simple (non-eDP) TFT panels
+  DEPENDS:=@USES_DEVICETREE @USES_PM +kmod-drm +kmod-backlight
+  KCONFIG:=CONFIG_DRM_PANEL_SIMPLE \
+	CONFIG_DRM_PANEL=y
+  FILES:=$(LINUX_DIR)/drivers/gpu/drm/panel/panel-simple.ko
+  AUTOLOAD:=$(call AutoProbe,panel-simple)
+endef
+
+define KernelPackage/drm-panel-simple/description
+  Generic driver for simple raw (ie. non-eDP) TFT panels.
+endef
+
+$(eval $(call KernelPackage,drm-panel-simple))
+
 
 define KernelPackage/drm-radeon
   SUBMENU:=$(VIDEO_MENU)

--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -660,6 +660,27 @@ endef
 $(eval $(call KernelPackage,drm-panel-simple))
 
 
+define KernelPackage/drm-panel-tc358762
+  SUBMENU:=$(VIDEO_MENU)
+  TITLE:=TC358762 DSI/DPI bridge
+  DEPENDS:=+kmod-drm-kms-helper
+  KCONFIG:=CONFIG_DRM_TOSHIBA_TC358762 \
+	CONFIG_DRM_BRIDGE=y \
+	CONFIG_DRM_MIPI_DSI=y \
+	CONFIG_DRM_PANEL=y
+	CONFIG_DRM_PANEL_BRIDGE=y
+  FILES:= \
+	$(LINUX_DIR)/drivers/gpu/drm/bridge/tc358762.ko
+  AUTOLOAD:=$(call AutoProbe,tc358762)
+endef
+
+define KernelPackage/drm-panel-tc358762/description
+ Toshiba TC358762 DSI/DPI bridge driver
+endef
+
+$(eval $(call KernelPackage,drm-panel-tc358762))
+
+
 define KernelPackage/drm-radeon
   SUBMENU:=$(VIDEO_MENU)
   TITLE:=Radeon DRM support

--- a/scripts/target-metadata.pl
+++ b/scripts/target-metadata.pl
@@ -34,6 +34,7 @@ sub target_config_features(@) {
 		/^pcie$/ and $ret .= "\tselect PCIE_SUPPORT\n";
 		/^pcmcia$/ and $ret .= "\tselect PCMCIA_SUPPORT\n";
 		/^pinctrl$/ and $ret .= "\tselect PINCTRL_SUPPORT\n";
+		/^pm$/ and $ret .= "\tselect USES_PM\n";
 		/^powerpc64$/ and $ret .= "\tselect powerpc64\n";
 		/^pwm$/ and $ret .= "\select PWM_SUPPORT\n";
 		/^ramdisk$/ and $ret .= "\tselect USES_INITRAMFS\n";

--- a/target/Config.in
+++ b/target/Config.in
@@ -51,6 +51,9 @@ config RTC_SUPPORT
 config BIG_ENDIAN
 	bool
 
+config USES_PM
+	bool
+
 config USES_DEVICETREE
 	bool
 

--- a/target/linux/bcm27xx/modules/video.mk
+++ b/target/linux/bcm27xx/modules/video.mk
@@ -39,6 +39,42 @@ endef
 $(eval $(call KernelPackage,rp1-cfe))
 
 
+define KernelPackage/rpi-panel-attiny-regulator
+  TITLE:=Raspberry Pi 7-inch touchscreen panel ATTINY regulator
+  SUBMENU:=$(VIDEO_MENU)
+  KCONFIG:=CONFIG_REGULATOR_RASPBERRYPI_TOUCHSCREEN_ATTINY
+  FILES:=$(LINUX_DIR)/drivers/regulator/rpi-panel-attiny-regulator.ko
+  AUTOLOAD:=$(call AutoLoad,67,rpi-panel-attiny-regulator)
+  DEPENDS:=+kmod-regmap-i2c +kmod-backlight
+endef
+
+define KernelPackage/rpi-panel-attiny-regulator/description
+ Driver for the ATTINY regulator on the Raspberry Pi 7-inch
+ touchscreen unit. The regulator is used to enable power to the
+ TC358762, display and to control backlight.
+endef
+
+$(eval $(call KernelPackage,rpi-panel-attiny-regulator))
+
+
+define KernelPackage/rpi-panel-7inch-touchscreen
+  TITLE:=Raspberry Pi 7-inch touchscreen panel
+  SUBMENU:=$(VIDEO_MENU)
+  KCONFIG:= \
+    CONFIG_DRM_PANEL_RASPBERRYPI_TOUCHSCREEN
+    CONFIG_DRM_MIPI_DSI=y
+  FILES:=$(LINUX_DIR)/drivers/gpu/drm/panel/panel-raspberrypi-touchscreen.ko
+  AUTOLOAD:=$(call AutoProbe,/panel-raspberrypi-touchscreen)
+  DEPENDS:=+kmod-drm
+endef
+
+define KernelPackage/rpi-panel-7inch-touchscreen/description
+ Driver for the Raspberry Pi 7" Touchscreen.
+endef
+
+$(eval $(call KernelPackage,rpi-panel-7inch-touchscreen))
+
+
 define KernelPackage/codec-bcm2835
   TITLE:=BCM2835 Video Codec
   KCONFIG:= \


### PR DESCRIPTION
Allow platforms other than Freescale i.MX to use simple (ie. raw, non-eDP) TFT panels connected via MIPI DSI or MIPI DPI.
This is necessary in order to be able to support the official RaspberryPi 7" TFT display.
