### PR TITLE
mediatek: Remove modules.builtin file

### DIFF
--- a/target/linux/mediatek/files/drivers/net/phy/rtk/modules.builtin
+++ b/target/linux/mediatek/files/drivers/net/phy/rtk/modules.builtin
@@ -1,1 +1,0 @@
-kernel/drivers/net/phy/rtk/rtl8367s_gsw.ko


### PR DESCRIPTION
This file should be generated automatically at runtime by the kernel build system.
