### PR TITLE
build: do not set disk signature in PMBR of GPT

### DIFF
--- a/scripts/gen_image_generic.sh
+++ b/scripts/gen_image_generic.sh
@@ -21,7 +21,7 @@ head=16
 sect=63
 
 # create partition table
-set $(ptgen -o "$OUTPUT" -h $head -s $sect ${GUID:+-g} -t "${KERNELPARTTYPE}" -p "${KERNELSIZE}m${PARTOFFSET:+@$PARTOFFSET}" -t "${ROOTFSPARTTYPE}" -p "${ROOTFSSIZE}m" ${ALIGN:+-l $ALIGN} ${SIGNATURE:+-S 0x$SIGNATURE} ${GUID:+-G $GUID})
+set $(ptgen -o "$OUTPUT" -h $head -s $sect ${GUID:+-g} -t "${KERNELPARTTYPE}" -p "${KERNELSIZE}m${PARTOFFSET:+@$PARTOFFSET}" -t "${ROOTFSPARTTYPE}" -p "${ROOTFSSIZE}m" ${ALIGN:+-l $ALIGN} $([ -z "$GUID" ] && echo "${SIGNATURE:+-S 0x$SIGNATURE}") ${GUID:+-G $GUID})
 
 KERNELOFFSET="$(($1 / 512))"
 KERNELSIZE="$2"


### PR DESCRIPTION
Do not set MBR disk signature when building GPT partition tables. This avoids setting an unwanted explicit disk signature in the so called Protective MBR of GPT partition tables.

Related to #19434 This fixes what made me aware of this and other issues I described in that PR.
