### PR TITLE
realtek: add support for Vimin VM-S100-0800MS

### DIFF
--- a/target/linux/realtek/dts/rtl9303_vimin_vm-s100-0800ms.dts
+++ b/target/linux/realtek/dts/rtl9303_vimin_vm-s100-0800ms.dts
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "vimin,vm-s100-0800ms", "realtek,rtl930x-soc";
+	model = "Vimin VM-S100-0800MS";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* first 256 MiB */
+		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	i2c_master: i2c@1b00036c {
+		compatible = "realtek,rtl9300-i2c";
+		reg = <0x1b00036c 0x3c>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		scl-pin = <8>;
+		sda-pin = <9>;
+		clock-frequency = <100000>;
+	};
+
+	i2c-mux {
+		compatible = "realtek,i2c-mux-rtl9300";
+		i2c-parent = <&i2c_master>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c0: i2c@0 {
+			reg = <0>;
+			scl-pin = <8>;
+			sda-pin = <9>;
+		};
+
+		i2c1: i2c@1 {
+			reg = <1>;
+			scl-pin = <8>;
+			sda-pin = <10>;
+		};
+
+		i2c2: i2c@2 {
+			reg = <2>;
+			scl-pin = <8>;
+			sda-pin = <11>;
+		};
+
+		i2c3: i2c@3 {
+			reg = <3>;
+			scl-pin = <8>;
+			sda-pin = <12>;
+		};
+
+		i2c4: i2c@4 {
+			reg = <4>;
+			scl-pin = <8>;
+			sda-pin = <13>;
+		};
+
+		i2c5: i2c@5 {
+			reg = <5>;
+			scl-pin = <8>;
+			sda-pin = <14>;
+		};
+
+		i2c6: i2c@6 {
+			reg = <6>;
+			scl-pin = <8>;
+			sda-pin = <15>;
+		};
+
+		i2c7: i2c@7 {
+			reg = <7>;
+			scl-pin = <8>;
+			sda-pin = <16>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		/*
+		 * LED set 0
+		 *
+		 * - LED[0](Green): 10M/100M/1G/2.5G/5G/10G/LINK/ACT
+		 */
+		led_set0 = <0x0bab>;
+	};
+
+	sfp0: sfp-p1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2900>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp1: sfp-p2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp2: sfp-p3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp3: sfp-p4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp4: sfp-p5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c4>;
+		los-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp5: sfp-p6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c5>;
+		los-gpio = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 22 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp6: sfp-p7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c6>;
+		los-gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 25 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp7: sfp-p8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c7>;
+		los-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 28 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2900>;
+		#thermal-sensor-cells = <0>;
+	};
+};
+
+&mdio_aux {
+	status = "okay";
+
+	gpio1: gpio@0 {
+		compatible = "realtek,rtl8231";
+		reg = <0>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio1 0 0 37>;
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x10000>;
+			};
+
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0xf0000 0x10000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "jffs";
+				reg = <0x100000 0x100000>;
+			};
+
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x200000 0x100000>;
+			};
+
+			partition@300000 {
+				label = "firmware";
+				reg = <0x300000 0xd00000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x93000000>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		INTERNAL_PHY_SDS(0, 2)
+		INTERNAL_PHY_SDS(8, 3)
+		INTERNAL_PHY_SDS(16, 4)
+		INTERNAL_PHY_SDS(20, 5)
+		INTERNAL_PHY_SDS(24, 6)
+		INTERNAL_PHY_SDS(25, 7)
+		INTERNAL_PHY_SDS(26, 8)
+		INTERNAL_PHY_SDS(27, 9)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			pseudo-phy-handle = <&phy0>;
+			phy-mode = "10gbase-r";
+			sfp = <&sfp0>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@8 {
+			reg = <8>;
+			label = "lan2";
+			pseudo-phy-handle = <&phy8>;
+			phy-mode = "10gbase-r";
+			sfp = <&sfp1>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@10 {
+			reg = <16>;
+			label = "lan3";
+			pseudo-phy-handle = <&phy16>;
+			phy-mode = "10gbase-r";
+			sfp = <&sfp2>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@14 {
+			reg = <20>;
+			label = "lan4";
+			pseudo-phy-handle = <&phy20>;
+			phy-mode = "10gbase-r";
+			sfp = <&sfp3>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@18 {
+			reg = <24>;
+			label = "lan5";
+			pseudo-phy-handle = <&phy24>;
+			phy-mode = "10gbase-r";
+			sfp = <&sfp4>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@19 {
+			reg = <25>;
+			label = "lan6";
+			pseudo-phy-handle = <&phy25>;
+			phy-mode = "10gbase-r";
+			sfp = <&sfp5>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@1a {
+			reg = <26>;
+			label = "lan7";
+			pseudo-phy-handle = <&phy26>;
+			phy-mode = "10gbase-r";
+			sfp = <&sfp6>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@1b {
+			reg = <27>;
+			label = "lan8";
+			pseudo-phy-handle = <&phy27>;
+			phy-mode = "10gbase-r";
+			sfp = <&sfp7>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@1c {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&thermal_zones {
+	sfp-thermal {
+		polling-delay-passive = <10000>;
+		polling-delay = <10000>;
+		thermal-sensors = <&sfp0>, <&sfp1>, <&sfp2>, <&sfp3>, <&sfp4>, <&sfp5>, <&sfp6>, <&sfp7>;
+		trips {
+			sfp-crit {
+				temperature = <110000>;
+				hysteresis = <1000>;
+				type = "critical";
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/Makefile
+++ b/target/linux/realtek/image/Makefile
@@ -119,6 +119,19 @@ define Device/Default
 	append-metadata
 endef
 
+define Device/kernel-lzma
+  KERNEL := \
+	kernel-bin | \
+	append-dtb | \
+	lzma | \
+	uImage lzma
+  KERNEL_INITRAMFS := \
+	kernel-bin | \
+	append-dtb | \
+	lzma | \
+	uImage lzma
+endef
+
 define Device/uimage-rt-loader
 	KERNEL/rt-loader := kernel-bin | append-dtb | rt-compress | rt-loader
 	KERNEL := $$(KERNEL/rt-loader) | uImage none

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -29,6 +29,16 @@ define Device/tplink_tl-st1008f_v2
 endef
 TARGET_DEVICES += tplink_tl-st1008f_v2
 
+define Device/vimin_vm-s100-0800ms
+  SOC := rtl9303
+  UIMAGE_MAGIC := 0x93000000
+  DEVICE_VENDOR := Vimin
+  DEVICE_MODEL := VM-S100-0800MS
+  IMAGE_SIZE := 13312k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += vimin_vm-s100-0800ms
+
 define Device/xikestor_sks8300-8x
   SOC := rtl9303
   DEVICE_VENDOR := XikeStor


### PR DESCRIPTION
Vimin VM-S100-0800MS is an 8 port Multi-Gig switch, based on RTL9303. Ported from XikeStor SKS8300-8X with changes to support different u-boot build.

Specification:

- SoC             : Realtek RTL9303
- RAM             : DDR3 512 MiB
- Flash           :  SPI-NOR 16 MiB (Winbond W25Q128JVSQ)
- Ethernet        : 8x 1/2.5/10 Gbps (SFP+)
- LEDs/Keys (GPIO): 0x/1x
- UART            : "Console" port on the front panel
  - type          : RS-232C
  - connector     : RJ-45
  - settings      : 115200n8
- Power           : AC100-240V 50/60Hz

Flash instruction using initramfs image:

 1. Prepare TFTP server with an IP address "192.168.1.111"
 2. Connect your PC to Port1 on VM-S100-0800MS
 3. Power on VM-S100-0800MS and interrupt boot by pressing Esc
 4. Enable Port1 with the following commands

    rtk 10g 0 fiber1g (or fiber10g if 10GBase-*R, dac300cm for DAC cable) rtk ext-devInit 0 rtk ext-pinSet 2 0

    Note: the last command sets tx-disable to low

 7. Download initramfs image from TFTP server

    tftpboot 0x82000000 <image name>

 8. Boot with the downloaded image

    bootm

 9. On the initramfs image, backup the stock firmware if needed
10. Upload (or download) sysupgrade image to the device
11. Erase "firmware" partition to cleanup JFFS2 of stock FW

    mtd erase firmware

12. Perform sysupgrade with the sysupgrade image
13. Wait ~120 sec to complete flashing

Reverting to stock firmware:
 1. Prepare by downloading the stock firmware. Vimin doesn't have the firmware on their website, tested using firmware for shared hardware Nicgiga S100-0800S-M. Filename: vmlinux-nicgiga-S100-0800S-M-241126EN.bix

 2. Prepare TFTP server with an IP address "192.168.1.111"
 3. Connect your PC to Port1 on VM-S100-0800MS
 4. Power on VM-S100-0800MS and interrupt boot by pressing Esc
 5. Enable Port1 with the following commands

    rtk 10g 0 fiber1g (or fiber10g if 10GBase-*R, dac300cm for DAC cable) rtk ext-devInit 0 rtk ext-pinSet 2 0

    Note: the last command sets tx-disable to low

 6. Download initramfs image from TFTP server

    tftpboot 0x82000000 <image name>

 7. Boot with the downloaded image

    bootm

 8. Under Management -> Firmware -> Upgrade/Backup, upload bix file.
 9. Reboot device