### PR TITLE
qualcommax: migrate wifi configuration (ath10k) device paths for 6.12…

### DIFF
--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
@@ -29,11 +29,14 @@ check_path()
 	config_get path "$config" path
 
 	to=${path/soc\//soc@0\/}
+	to=${to/pci\//pcie\/}
 
 	# Checks if kernel version is less than 6.6.0, if it is and the path is using the new format,
 	# then path should be migrated to the old format. This would allow users on platforms with two partitions,
 	# to test 6.1 and 6.6.
-	[ "$(get_linux_version)" -lt "606000" ] && to=${path/soc@0\//soc\/}
+	[ "$(get_linux_version)" -lt "606000" ] && to=${to/soc@0\//soc\/}
+
+	[ "$(get_linux_version)" -lt "612000" ] && to=${to/pcie\//pci\/}
 
 	[ "$path" = "$to" ] || do_migrate_radio "$config" "$path" "$to"
 }


### PR DESCRIPTION
Migrate wifi configuration (ath10k) device paths for 6.12 kernel
The device tree PCIe host node name has been changed in the new
6.12 kernel[1]. Hence we have to update the wifi device path to
make sure it can work properly.

This script is based on:
target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate

[1] https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-6.12.y&id=07299ba2e7d98045e6b522f7c5b97f402b15bc82

FYI @robimarko @Ansuel 