### PR TITLE
[23.05] libxml2: update to 2.14.5

### DIFF
--- a/package/libs/libxml2/Makefile
+++ b/package/libs/libxml2/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libxml2
-PKG_VERSION:=2.13.6
+PKG_VERSION:=2.14.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNOME/libxml2/$(basename $(PKG_VERSION))
-PKG_HASH:=f453480307524968f7a04ec65e64f2a83a825973bcd260a2e7691be82ae70c96
+PKG_HASH:=03d006f3537616833c16c53addcdc32a0eb20e55443cba4038307e3fa7d8d44b
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=COPYING
@@ -61,7 +61,7 @@ endef
 CMAKE_HOST_OPTIONS += \
 	-DBUILD_SHARED_LIBS=OFF \
 	-DLIBXML2_WITH_C14N=ON \
-	-DLIBXML2_WITH_CATALOG=OFF \
+	-DLIBXML2_WITH_CATALOG=ON \
 	-DLIBXML2_WITH_DEBUG=ON \
 	-DLIBXML2_WITH_FTP=OFF \
 	-DLIBXML2_WITH_HTML=ON \
@@ -99,7 +99,7 @@ CMAKE_HOST_OPTIONS += \
 CMAKE_OPTIONS += \
 	-DBUILD_SHARED_LIBS=ON \
 	-DLIBXML2_WITH_C14N=ON \
-	-DLIBXML2_WITH_CATALOG=OFF \
+	-DLIBXML2_WITH_CATALOG=ON \
 	-DLIBXML2_WITH_DEBUG=ON \
 	-DLIBXML2_WITH_FTP=OFF \
 	-DLIBXML2_WITH_HTML=ON \
@@ -160,9 +160,6 @@ define Build/InstallDev
 
 	$(INSTALL_DIR) $(1)/usr/lib/pkgconfig
 	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/lib/pkgconfig/libxml-2.0.pc $(1)/usr/lib/pkgconfig/
-
-	$(INSTALL_DIR) $(2)/share/aclocal/
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/aclocal/* $(2)/share/aclocal
 endef
 
 define Host/Install
@@ -190,9 +187,6 @@ define Package/libxml2-dev/install
 	$(INSTALL_DIR) $(1)/usr/lib/{cmake,pkgconfig}
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/{cmake,pkgconfig} $(1)/usr/lib/
 	$(SED) "s,$(STAGING_DIR),,g" $(1)/usr/lib/pkgconfig/*.pc
-
-	$(INSTALL_DIR) $(1)/usr/share/aclocal
-	$(CP) $(PKG_INSTALL_DIR)/usr/share/aclocal/* $(1)/usr/share/aclocal
 endef
 
 define Package/libxml2-utils/install


### PR DESCRIPTION
Release Notes:
    https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.7
    https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.8
    https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.14.3
    https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.14.4
    https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.14.5

Fixes:
CVE-2025-32415 CVE-2025-32414 CVE-2025-6170 CVE-2025-49794 CVE-2025-49795 CVE-2025-49796

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc


Link: https://github.com/openwrt/openwrt/pull/19383

(cherry picked from commit c08c2d6eb39dd5e040d6a50fdb46471b268fad1a)