### PR TITLE
[RFC] ipq806x: Use leds_pins like upstream to avoid duplicate pinctrl group and free up unused GPIOs.

### DIFF
--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-ad7200.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-ad7200.dts
@@ -55,7 +55,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		lan {
@@ -125,7 +125,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio2", "gpio8", "gpio15", "gpio16", "gpio17", "gpio26",
 					"gpio33", "gpio55", "gpio56", "gpio66";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-c2600.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-c2600.dts
@@ -53,7 +53,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		lan {
@@ -114,7 +114,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio6", "gpio7", "gpio8", "gpio9", "gpio26", "gpio33",
 					"gpio53", "gpio66";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-d7800.dts
@@ -64,7 +64,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		usb1 {
@@ -130,7 +130,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
 				"gpio24","gpio26", "gpio53", "gpio64";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-e8350-v1.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-e8350-v1.dts
@@ -54,7 +54,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		led_power: power {
@@ -112,7 +112,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio26","gpio53", "gpio54";
 			function = "gpio";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-ea7500-v1.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-ea7500-v1.dts
@@ -49,7 +49,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		led_power: power {
@@ -71,7 +71,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio6";
 			function = "gpio";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-ea8500.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-ea8500.dts
@@ -52,7 +52,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		wps {
@@ -85,7 +85,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio6", "gpio53", "gpio54";
 			function = "gpio";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-fap-421e.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-fap-421e.dts
@@ -50,7 +50,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		eth1-amber {
@@ -106,7 +106,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			bias-pull-down;
 			drive-strength = <2>;

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-g10.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-g10.dts
@@ -26,7 +26,7 @@
 	leds {
 		compatible = "gpio-leds";
 
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		/*
@@ -318,7 +318,7 @@
 };
 
 &qcom_pinmux {
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9", "gpio26";
 			function = "gpio";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-r7500.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-r7500.dts
@@ -68,7 +68,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		usb1 {
@@ -134,7 +134,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
 				"gpio24","gpio26", "gpio53", "gpio64";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-r7500v2.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-r7500v2.dts
@@ -64,7 +64,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		usb1 {
@@ -133,7 +133,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9", "gpio22", "gpio23",
 				"gpio24","gpio26", "gpio53", "gpio64";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
@@ -22,7 +22,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		led_dome_blue: dome_blue {
@@ -61,7 +61,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio9", "gpio53";
 			function = "gpio";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-vr2600v.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-vr2600v.dts
@@ -69,7 +69,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		dsl {
@@ -125,7 +125,7 @@
 };
 
 &qcom_pinmux {
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9", "gpio16", "gpio17",
 				"gpio26", "gpio53", "gpio56", "gpio66";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wg2600hp.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wg2600hp.dts
@@ -63,7 +63,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		converter_green {
@@ -505,7 +505,7 @@ switch@10 {
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio6", "gpio7", "gpio8", "gpio9", "gpio14",
 				"gpio15", "gpio55", "gpio56", "gpio57", "gpio58",

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wpq864.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wpq864.dts
@@ -29,7 +29,7 @@
 	leds {
 		compatible = "gpio-leds";
 
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		rss4 {
@@ -482,7 +482,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9", "gpio22",
 			       "gpio23", "gpio24", "gpio25", "gpio53";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wxr-2533dhp.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-wxr-2533dhp.dts
@@ -27,7 +27,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		usb {
@@ -567,7 +567,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9", "gpio16", "gpio22",
 				"gpio23", "gpio24", "gpio25", "gpio26", "gpio53";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-ac400i.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-ac400i.dts
@@ -36,7 +36,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		5g_red {
@@ -125,7 +125,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio65", "gpio64",
 				   "gpio53", "gpio54",

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-nbg6817.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-nbg6817.dts
@@ -60,7 +60,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		internet {
@@ -101,7 +101,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio9", "gpio26", "gpio33", "gpio64";
 			function = "gpio";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-nighthawk.dtsi
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-nighthawk.dtsi
@@ -68,7 +68,7 @@
 
 	leds: leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		power_white: power_white {
@@ -119,7 +119,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio7", "gpio8", "gpio9",
 				"gpio22", "gpio23", "gpio24",

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-rt4230w-rev6.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-rt4230w-rev6.dts
@@ -44,7 +44,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		ledctrl1: ledctrl1 {
@@ -75,7 +75,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio22", "gpio23", "gpio24";
 			function = "gpio";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-tr4400-v2.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8065-tr4400-v2.dts
@@ -48,7 +48,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		led_status_red: status_red {
@@ -75,7 +75,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio7", "gpio8";
 			function = "gpio";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ap3935.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ap3935.dts
@@ -48,7 +48,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		led_power_green: power_green {
@@ -122,7 +122,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio22", "gpio23", "gpio24", "gpio25",
 				    "gpio26", "gpio27", "gpio28", "gpio29";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ecw5410.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ecw5410.dts
@@ -64,7 +64,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		led_power_green: power_green {
@@ -126,7 +126,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio16", "gpio23", "gpio24", "gpio26",
 				   "gpio28", "gpio59";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-mr42.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-mr42.dts
@@ -35,7 +35,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		led_power: power {
@@ -182,7 +182,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio31", "gpio32";
 			function = "gpio";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-mr52.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-mr52.dts
@@ -37,7 +37,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		led_power: power {
@@ -169,7 +169,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio19", "gpio26";
 			function = "gpio";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ss-w2-ac2600.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8068-ss-w2-ac2600.dts
@@ -63,7 +63,7 @@
 
 	leds {
 		compatible = "gpio-leds";
-		pinctrl-0 = <&led_pins>;
+		pinctrl-0 = <&leds_pins>;
 		pinctrl-names = "default";
 
 		wlan2g_green {
@@ -118,7 +118,7 @@
 		};
 	};
 
-	led_pins: led_pins {
+	leds_pins: leds_pins {
 		mux {
 			pins = "gpio16", "gpio23", "gpio24", "gpio26",
 				   "gpio28", "gpio59";


### PR DESCRIPTION
Upstream (qcom-ipq8064.dtsi) uses leds_pins, but OpenWRT has led_pins. This ends up creating an extra pinctrl group instead of modifying the existing one, possibly using 5 GPIOs that aren't actually needed.

For example the qcom-ipq8065-ac400i.dts currently generates:
```
leds_pins {

	mux {
		pins = "gpio7", "gpio8", "gpio9", "gpio26", "gpio53";
		function = "gpio";
		drive-strength = <0x02>;
		bias-pull-down;
		output-low;
	};
};

led_pins {
	phandle = <0x34>;

	mux {
		pins = "gpio65", "gpio64", "gpio53", "gpio54", "gpio68", "gpio22", "gpio67", "gpio23", "gpio55", "gpio56", "gpio2", "gpio26";
		function = "gpio";
		drive-strength = <0x02>;
		bias-pull-up;
	};
};	

```
Which takes up gpio7-9, that might be used somewhere else.

After the change only leds_pins are generated:
```
leds_pins {
	phandle = <0x34>;

	mux {
		pins = "gpio65", "gpio64", "gpio53", "gpio54", "gpio68", "gpio22", "gpio67", "gpio23", "gpio55", "gpio56", "gpio2", "gpio26";
		function = "gpio";
		drive-strength = <0x02>;
		bias-pull-down;
		output-low;
		bias-pull-up;
	};
};
```
