### PR TITLE
base-files: find_mmc_part: Silence error when no MMC exists

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -447,7 +447,7 @@ find_mmc_part() {
 	fi
 
 	for DEVNAME in /sys/block/$ROOTDEV/mmcblk*p*; do
-		PARTNAME="$(grep PARTNAME ${DEVNAME}/uevent | cut -f2 -d'=')"
+		PARTNAME="$(grep PARTNAME ${DEVNAME}/uevent | cut -f2 -d'=' 2>/dev/null)"
 		[ "$PARTNAME" = "$1" ] && echo "/dev/$(basename $DEVNAME)" && return 0
 	done
 }


### PR DESCRIPTION
When running find_mmc_part on a system without MMC or when the given root device does not exist, an error message is printed to stderr.

    grep: /sys/block/mmcblk*/mmcblk*p*/uevent: No such file or directory

Silence this error message.

Since find_mmc_part is mostly used to get block devices of MMC partitions and the negative result (partion not found) is checked for by the caller, the error message can be silenced without causing any negative impact.
