### PR TITLE
mbedtls: restore previous configuration behavior

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -138,11 +138,13 @@ CMAKE_OPTIONS += \
 	-DENABLE_PROGRAMS:Bool=ON
 
 define Build/Configure
-	$(call Build/Configure/Default,)
-	$(foreach opt,$(MBEDTLS_BUILD_OPTS),
-	$(PKG_BUILD_DIR)/scripts/config.py \
-		-f $(PKG_BUILD_DIR)/include/mbedtls/mbedtls_config.h \
-		$(if $($(opt)),set,unset) $(patsubst CONFIG_%,%,$(opt)))
+	$(call Build/Configure/Default)
+
+	$(if $(strip $(foreach opt,$(MBEDTLS_BUILD_OPTS),$($(opt)))),
+		$(foreach opt,$(MBEDTLS_BUILD_OPTS),
+			$(PKG_BUILD_DIR)/scripts/config.py \
+			-f $(PKG_BUILD_DIR)/include/mbedtls/mbedtls_config.h \
+			$(if $($(opt)),set,unset) $(patsubst CONFIG_%,%,$(opt))),)
 endef
 
 define Build/InstallDev


### PR DESCRIPTION
Fallback to default mbedtls configurations in case of the package is not configured.
It is possible for some reasons it get built even if it's unselected because of build system bugs or other build-only dependencies.
In this case current behavior will comment out all necessary configurations and lead build errors.

Fixes: 5359639c2b74 ("mbedtls: Apply configuration in Configure instead of Prepare")
