### PR TITLE
mediatek: add factory image for ipTIME AX3000SM

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1180,8 +1180,16 @@ define Device/iptime_ax3000sm
   DEVICE_MODEL := AX3000SM
   DEVICE_DTS := mt7981b-iptime-ax3000sm
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 32768k
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3ksm
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
   SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
 endef
 TARGET_DEVICES += iptime_ax3000sm


### PR DESCRIPTION
Adds the capability to flash the factory image using the OEM recovery software, ipTIME Firmware Wizard (11ac).

Installation
------------
1. Download the OEM recovery software from the manufacturer's website
2. Download the *squashfs-factory.bin file from the OpenWrt website
3. Press a reset button, and power up the router(keep pressing the reset button)
4. Wait more than 10 seconds until the CPU LED stop blinking
5. Connect the router(LAN port) to the PC
6. Run the OEM recovery software and follow the instructions
7. Select the *squashfs-factory.bin file during the router recovery process
8. Wait for the router to boot from *squashfs-factory.bin

Screenshot
------------
<details><summary>OpenWrt Luci Web Interface</summary>
<p>

<img width="1113" height="940" alt="iptime-ax3000sm-factory" src="https://github.com/user-attachments/assets/b3121b85-c485-4c35-b702-3c41b6cd19dd" />

</p>
</details> 

Logs
------------
<details><summary>squashfs-factory.bin upgrade log</summary>
<p>

```
F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 024F [010F]
Jump to BL

NOTICE:  BL2: v2.7(release):0697eafa43-dirty
NOTICE:  BL2: Built : 17:33:02, Jan 26 2024
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a083f1 000003ff 00100000 00000000
1001d040 | 00000000 00000000 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0x8 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 560, worse bit 2, min window 68
Window Sum 580, worse bit 8, min window 72
Window Sum 400, worse bit 3, min window 46
Window Sum 394, worse bit 9, min window 46
Window Sum 412, worse bit 1, min window 50
Window Sum 404, worse bit 9, min window 48
Window Sum 426, worse bit 1, min window 52
Window Sum 418, worse bit 9, min window 50
Window Sum 442, worse bit 3, min window 52
Window Sum 428, worse bit 9, min window 52
Window Sum 448, worse bit 3, min window 54
Window Sum 442, worse bit 9, min window 54
Window Sum 462, worse bit 3, min window 56
Window Sum 452, worse bit 9, min window 54
Window Sum 470, worse bit 1, min window 58
Window Sum 476, worse bit 1, min window 58
Window Sum 462, worse bit 8, min window 56
Window Sum 482, worse bit 7, min window 58
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc8
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 1 found in block 960
NOTICE:  Second info table with writecount 1 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):0697eafa43-dirty
NOTICE:  BL31: Built : 17:33:04, Jan 26 2024
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Jan 26 2024 - 17:32:30 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: GigaDevice SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 1 found in block 960
Second info table with writecount 1 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[?25h[2J[1;1HWait for a few seconds(3s<:RST,10s<:FIRMUP)...........
Using ethernet@15100000 device
Listening for TFTP transfer on 192.168.0.1
Load address: 0x46000000
Loading: *T T T T T #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #######################
	 187.5 KiB/s
done
Bytes transferred = 9431402 (8fe96a hex)
Check My Firmware ... [OK]
Saving Environment to MTD... Erasing on MTD device 'nmbm0'... OK
Writing to MTD device 'nmbm0'... OK
OK
ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 110 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 2/1, WL threshold: 4096, image sequence number: 0
ubi0: available PEBs: 2, total reserved PEBs: 878, PEBs reserved for bad PEB handling: 19
Updating volume 'kernel' from 0x46000838, size 0x443718 ... OK
Updating volume 'rootfs' from 0x46444238, size 0x4b8800 ... OK
ubi0: detaching mtd6
ubi0: mtd6 is detached
resetting ...

F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 024F [010F]
Jump to BL

NOTICE:  BL2: v2.7(release):0697eafa43-dirty
NOTICE:  BL2: Built : 17:33:02, Jan 26 2024
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a003f1 000000ff 00100000 00000000
1001d040 | 00027e71 000200a0 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0xc 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 560, worse bit 0, min window 68
Window Sum 576, worse bit 11, min window 68
Window Sum 400, worse bit 1, min window 48
Window Sum 390, worse bit 9, min window 46
Window Sum 412, worse bit 1, min window 50
Window Sum 404, worse bit 9, min window 48
Window Sum 426, worse bit 1, min window 52
Window Sum 416, worse bit 9, min window 50
Window Sum 438, worse bit 3, min window 52
Window Sum 424, worse bit 9, min window 50
Window Sum 450, worse bit 3, min window 54
Window Sum 438, worse bit 9, min window 52
Window Sum 460, worse bit 3, min window 54
Window Sum 448, worse bit 8, min window 54
Window Sum 470, worse bit 1, min window 58
Window Sum 452, worse bit 8, min window 54
Window Sum 478, worse bit 3, min window 58
Window Sum 460, worse bit 8, min window 54
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc8
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 1 found in block 960
NOTICE:  Second info table with writecount 1 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):0697eafa43-dirty
NOTICE:  BL31: Built : 17:33:04, Jan 26 2024
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Jan 26 2024 - 17:32:30 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: GigaDevice SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 1 found in block 960
Second info table with writecount 1 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[?25h[2J[1;1HCheck RST button - wait 1 second

ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 110 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 2/1, WL threshold: 4096, image sequence number: 0
ubi0: available PEBs: 0, total reserved PEBs: 880, PEBs reserved for bad PEB handling: 19
Saving Environment to MTD... Erasing on MTD device 'nmbm0'... OK
Writing to MTD device 'nmbm0'... OK
OK
Reading from volume 'kernel' to 0x46000000, size 0x0 ... OK
## Loading kernel from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.12.39
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x460000e8
     Data Size:    4446081 Bytes = 4.2 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x48000000
     Entry Point:  0x48000000
     Hash algo:    crc32
     Hash value:   c4e7b97e
     Hash algo:    sha1
     Hash value:   3e2b55c6141fd338ba2c21430a915066dc641fa2
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt iptime_ax3000sm device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x4643d9ac
     Data Size:    22566 Bytes = 22 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   17b8b739
     Hash algo:    sha1
     Hash value:   d54cf2b2c20bb17e89db765ee11ead7e7d276bca
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x4643d9ac
   Uncompressing Kernel Image
   Loading Device Tree to 000000004f7f0000, end 000000004f7f8825 ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.12.39 (nyanko@DevBox) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r0+30506-677fbb8463) 14.3.0, GNU ld (GNU Binutils) 2.42) #0 SMP Tue Jul 22 18:59:25 2025
[    0.000000] Machine model: ipTIME AX3000SM
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004302ffff (192 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x0000000047c80000..0x0000000047d7ffff (1024 KiB) nomap non-reusable wmcpu-reserved@47c80000
[    0.000000] OF: reserved mem: 0x0000000047d80000..0x0000000047dbffff (256 KiB) nomap non-reusable wo-emi@47d80000
[    0.000000] OF: reserved mem: 0x0000000047dc0000..0x0000000047ffffff (2304 KiB) nomap non-reusable wo-data@47dc0000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004302ffff]
[    0.000000]   node   0: [mem 0x0000000043030000-0x0000000047c7ffff]
[    0.000000]   node   0: [mem 0x0000000047c80000-0x0000000047ffffff]
[    0.000000]   node   0: [mem 0x0000000048000000-0x000000004fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 20 pages/cpu s42520 r8192 d31208 u81920
[    0.000000] pcpu-alloc: s42520 r8192 d31208 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: console=ttyS0,115200 boot_from=A
[    0.000000] Unknown kernel command line parameters "boot_from=A", will be passed to user space.
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 65536
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[    0.000000] software IO TLB: area num 2.
[    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 0MB
[    0.000000] software IO TLB: mapped [mem 0x000000004fe49000-0x000000004fec9000] (0MB)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
[    0.000000] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: GICD_CTRL.DS=0, SCR_EL3.FIQ=0
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000072] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000080] pid_max: default: 32768 minimum: 301
[    0.003047] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.003055] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.005139] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.005958] rcu: Hierarchical SRCU implementation.
[    0.005964] rcu: 	Max phase no-delay instances is 1000.
[    0.006157] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.006385] smp: Bringing up secondary CPUs ...
[    0.006733] Detected VIPT I-cache on CPU1
[    0.006777] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.006805] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.006885] smp: Brought up 1 node, 2 CPUs
[    0.006890] SMP: Total of 2 processors activated.
[    0.006892] CPU: All CPU(s) started at EL2
[    0.006895] CPU features: detected: 32-bit EL0 Support
[    0.006898] CPU features: detected: CRC32 instructions
[    0.006925] alternatives: applying system-wide alternatives
[    0.007058] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.007174] Memory: 237040K/262144K available (9216K kernel code, 974K rwdata, 2732K rodata, 448K init, 298K bss, 23476K reserved, 0K cma-reserved)
[    0.010131] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.010149] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.010208] 29312 pages in range for non-PLT usage
[    0.010211] 520832 pages in range for PLT usage
[    0.011689] pinctrl core: initialized pinctrl subsystem
[    0.012858] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.013166] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.013190] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.013212] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.013587] thermal_sys: Registered thermal governor 'fair_share'
[    0.013590] thermal_sys: Registered thermal governor 'bang_bang'
[    0.013593] thermal_sys: Registered thermal governor 'step_wise'
[    0.013596] thermal_sys: Registered thermal governor 'user_space'
[    0.013664] ASID allocator initialised with 65536 entries
[    0.014298] pstore: Using crash dump compression: deflate
[    0.014303] pstore: Registered ramoops as persistent store backend
[    0.014306] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.015767] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.031927] cryptd: max_cpu_qlen set to 1000
[    0.034262] SCSI subsystem initialized
[    0.034429] libata version 3.00 loaded.
[    0.036092] clocksource: Switched to clocksource arch_sys_counter
[    0.038370] NET: Registered PF_INET protocol family
[    0.038465] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.039502] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.039516] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.039526] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.039546] TCP bind hash table entries: 2048 (order: 4, 65536 bytes, linear)
[    0.039595] TCP: Hash tables configured (established 2048 bind 2048)
[    0.039898] MPTCP token hash table entries: 256 (order: 0, 6144 bytes, linear)
[    0.039997] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.040070] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.040280] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.040312] PCI: CLS 0 bytes, default 64
[    0.041490] workingset: timestamp_bits=46 max_order=16 bucket_order=0
[    0.046504] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.046512] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.112735] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.113896] printk: legacy console [ttyS0] disabled
[    0.134297] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 72, base_baud = 2500000) is a ST16650V2
[    0.134340] printk: legacy console [ttyS0] enabled
[    0.911831] loop: module loaded
[    0.917922] spi-nand spi0.0: calibration result: 0x3
[    0.922971] spi-nand spi0.0: ESMT SPI NAND was found.
[    0.928048] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.936821] Signature found at block 1023 [0x07fe0000]
[    0.941957] NMBM management region starts at block 960 [0x07800000]
[    0.950319] First info table with writecount 1 found in block 960
[    0.962103] Second info table with writecount 1 found in block 963
[    0.968294] NMBM has been successfully attached
[    0.973023] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.979387] Creating 5 MTD partitions on "spi0.0":
[    0.984169] 0x000000000000-0x000000100000 : "BL2"
[    0.990127] 0x000000100000-0x000000180000 : "u-boot-env"
[    0.996319] 0x000000180000-0x000000380000 : "Factory"
[    1.003642] 0x000000380000-0x000000580000 : "FIP"
[    1.010353] 0x000000580000-0x000007380000 : "ubi"
[    1.223952] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081480000, irq 75
[    1.233859] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc081480000, irq 75
[    1.243648] i2c_dev: i2c /dev entries driver
[    1.249607] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.258646] NET: Registered PF_INET6 protocol family
[    1.264753] Segment Routing with IPv6
[    1.268468] In-situ OAM (IOAM) with IPv6
[    1.272439] NET: Registered PF_PACKET protocol family
[    1.277726] 8021q: 802.1Q VLAN Support v1.8
[    1.356056] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.365095] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.374829] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=79)
[    1.395995] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=80)
[    1.416996] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=81)
[    1.437983] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=82)
[    1.449491] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.456253] DSA: tree 0 setup
[    1.459888] UBI: auto-attach mtd4
[    1.463228] ubi0: default fastmap pool size: 40
[    1.467766] ubi0: default fastmap WL pool size: 20
[    1.472546] ubi0: attaching mtd4
[    2.304029] ubi0: scanning is finished
[    2.318378] ubi0 warning: ubi_eba_init: cannot reserve enough PEBs for bad PEB handling, reserved 17, need 19
[    2.328837] ubi0: attached mtd4 (name "ubi", size 110 MiB)
[    2.334326] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    2.341204] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.347986] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.354935] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    2.360934] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[    2.368149] ubi0: max/mean erase counter: 2/1, WL threshold: 4096, image sequence number: 0
[    2.376491] ubi0: available PEBs: 0, total reserved PEBs: 880, PEBs reserved for bad PEB handling: 17
[    2.385706] ubi0: background thread "ubi_bgt0d" started, PID 562
[    2.386629] block ubiblock0_1: created from ubi0:1(rootfs)
[    2.397195] ubiblock: device ubiblock0_1 (rootfs) set to be root filesystem
[    2.404259] clk: Disabling unused clocks
[    2.408439] PM: genpd: Disabling unused power domains
[    2.421768] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[    2.429098] Freeing unused kernel memory: 448K
[    2.433585] Run /sbin/init as init process
[    2.437683]   with arguments:
[    2.440638]     /sbin/init
[    2.443334]   with environment:
[    2.446493]     HOME=/
[    2.448842]     TERM=linux
[    2.451537]     boot_from=A
[    2.698506] init: Console is alive
[    2.702051] init: - watchdog -
[    3.149490] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.167186] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    3.181494] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.194468] init: - preinit -
[    3.587858] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    3.596512] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    3.622901] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    3.736109] random: crng init done
[    7.782602] UBIFS (ubi0:2): Mounting in unauthenticated mode
[    7.788394] UBIFS (ubi0:2): background thread "ubifs_bgt0_2" started, PID 702
[    7.851952] UBIFS (ubi0:2): recovery needed
[    8.017031] UBIFS (ubi0:2): recovery completed
[    8.021523] UBIFS (ubi0:2): UBIFS: mounted UBI device 0, volume 2, name "rootfs_data"
[    8.029358] UBIFS (ubi0:2): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[    8.039265] UBIFS (ubi0:2): FS size: 97898496 bytes (93 MiB, 771 LEBs), max 782 LEBs, journal size 4952064 bytes (4 MiB, 39 LEBs)
[    8.050906] UBIFS (ubi0:2): reserved for root: 4623987 bytes (4515 KiB)
[    8.057514] UBIFS (ubi0:2): media format: w5/r0 (latest is w5/r0), UUID 7EB17257-A46C-4C00-8661-75A67458A995, small LPT model
[    8.072376] mount_root: switching to ubifs overlay
[    8.084988] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[    8.101846] urandom-seed: Seeding with /etc/urandom.seed
[    8.169474] procd: - early -
[    8.172416] procd: - watchdog -
[    8.715913] procd: - watchdog -
[    8.726030] procd: - ubus -
[    8.804164] procd: - init -
Please press Enter to activate this console.
[    9.129233] kmodloader: loading kernel modules from /etc/modules.d/*
[    9.157345] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    9.174411] Loading modules backported from Linux version v6.14.11-0-gb9d5d463c216
[    9.182038] Backport generated by backports.git v6.1.110-1-43-g2e32643b84e8
[    9.363499] urngd: v1.0.2 started.
[    9.536611] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[    9.536611] 
[    9.773175] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[    9.888411] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[    9.986654] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[   10.058304] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[   10.170557] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   10.193459] PPP generic driver version 2.4.2
[   10.199089] NET: Registered PF_PPPOX protocol family
[   10.207767] kmodloader: done loading kernel modules from /etc/modules.d/*
[   10.527742] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   13.846404] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   13.867574] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   13.876637] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   13.892210] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   13.909485] br-lan: port 1(lan1) entered blocking state
[   13.914746] br-lan: port 1(lan1) entered disabled state
[   13.920088] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   13.926423] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   13.936983] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   13.957519] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   13.968840] br-lan: port 2(lan2) entered blocking state
[   13.974075] br-lan: port 2(lan2) entered disabled state
[   13.979400] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   13.988159] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   14.003937] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   14.016664] br-lan: port 3(lan3) entered blocking state
[   14.021900] br-lan: port 3(lan3) entered disabled state
[   14.027247] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   14.036628] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   14.052316] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   14.063479] br-lan: port 4(lan4) entered blocking state
[   14.068788] br-lan: port 4(lan4) entered disabled state
[   14.074046] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   14.082731] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[   14.124117] mtk_soc_eth 15100000.ethernet eth1: PHY [mdio-bus:00] driver [MediaTek MT7981 PHY] (irq=POLL)
[   14.133755] mtk_soc_eth 15100000.ethernet eth1: configuring for phy/gmii link mode
[   17.490072] mt7530-mdio mdio-bus:1f lan2: Link is Up - 1Gbps/Full - flow control rx/tx
[   17.490098] br-lan: port 2(lan2) entered blocking state
[   17.503208] br-lan: port 2(lan2) entered forwarding state



BusyBox v1.37.0 (2025-07-22 18:59:25 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt SNAPSHOT, r0+30506-677fbb8463
 -----------------------------------------------------
=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------

 OpenWrt recently switched to the "apk" package manager!

 OPKG Command           APK Equivalent      Description
 ------------------------------------------------------------------
 opkg install <pkg>     apk add <pkg>       Install a package
 opkg remove <pkg>      apk del <pkg>       Remove a package
 opkg upgrade           apk upgrade         Upgrade all packages
 opkg files <pkg>       apk info -L <pkg>   List package contents
 opkg list-installed    apk info            List installed packages
 opkg update            apk update          Update package lists
 opkg search <pkg>      apk search <pkg>    Search for packages
 ------------------------------------------------------------------

For more https://openwrt.org/docs/guide-user/additional-software/opkg-to-apk-cheatsheet

root@OpenWrt:~# 


```

</p>
</details> 


Related links
--------
The pull request adding support the `ax3ksm` to the firmware-utils repo: [https://github.com/openwrt/firmware-utils/pull/44](https://github.com/openwrt/firmware-utils/pull/44)
