### PR TITLE
image: also show GRUB options for EROFS

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -231,7 +231,7 @@ menu "Target Images"
 	config GRUB_IMAGES
 		bool "Build GRUB images (Linux x86 or x86_64 host only)"
 		depends on TARGET_x86
-		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS
+		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS || TARGET_ROOTFS_EROFS
 		select PACKAGE_grub2
 		select PACKAGE_grub2-bios-setup
 		default y
@@ -239,7 +239,7 @@ menu "Target Images"
 	config GRUB_EFI_IMAGES
 		bool "Build GRUB EFI images"
 		depends on TARGET_x86 || TARGET_armsr || TARGET_loongarch64
-		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS
+		depends on TARGET_ROOTFS_EXT4FS || TARGET_ROOTFS_JFFS2 || TARGET_ROOTFS_SQUASHFS || TARGET_ROOTFS_EROFS
 		select PACKAGE_grub2 if TARGET_x86
 		select PACKAGE_grub2-efi if TARGET_x86
 		select PACKAGE_grub2-bios-setup if TARGET_x86


### PR DESCRIPTION
f7fa414d3b4d967a7e40b162977f48e1be430c1c added support for EROFS image generation.
Generating combined GRUB images for EROFS is possible, but currently hidden if neither ext4, jffs2, or squashfs is selected.

This commit adds EROFS as a dependency to the GRUB options.
This was probably just an oversight while adding support for the filesystem.