### PR TITLE
base-files: move config_generate to preinit

### DIFF
--- a/package/base-files/files/etc/init.d/boot
+++ b/package/base-files/files/etc/init.d/boot
@@ -43,22 +43,15 @@ boot() {
 	grep -q pstore /proc/filesystems && /bin/mount -o nosuid,nodev,noexec,noatime -t pstore pstore /sys/fs/pstore
 	[ "$FAILSAFE" = "true" ] && touch /tmp/.failsafe
 
-	touch /tmp/.config_pending
+	# update wifi config before additional ieee80211 hotplug events
+	# get executed because of '/sbin/kmodloader' kmod loading.
+	[ -f /etc/board.json ] && /sbin/wifi config
+
 	/sbin/kmodloader
 
-	[ ! -f /etc/config/wireless ] && {
-		# compat for bcm47xx and mvebu
-		sleep 1
-	}
-
-	mkdir -p /tmp/.uci
-	[ -f /etc/uci-defaults/30_uboot-envtools ] && (. /etc/uci-defaults/30_uboot-envtools)
-	/bin/config_generate
-	rm -f /tmp/.config_pending
-	/sbin/wifi config
 	uci_apply_defaults
 	sync
-	
+
 	# temporary hack until configd exists
 	/sbin/reload_config
 }

--- a/package/base-files/files/lib/preinit/82_config_generate
+++ b/package/base-files/files/lib/preinit/82_config_generate
@@ -1,0 +1,16 @@
+do_config_generate() {
+	[ -f /etc/board.json ] || {
+		# This allows /etc/board.d/* scripts to use values from the uboot environment
+		mkdir -p /tmp/.uci
+		[ -f /etc/uci-defaults/30_uboot-envtools ] && (. /etc/uci-defaults/30_uboot-envtools)
+
+		echo "- generating board file -"
+		/bin/board_detect /tmp/board.json
+		mv /tmp/board.json /etc/board.json
+
+		/bin/config_generate > /dev/null
+	}
+}
+
+boot_hook_add preinit_main do_config_generate
+boot_hook_add initramfs do_config_generate

--- a/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/10-wifi-detect
+++ b/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/10-wifi-detect
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-[ "${ACTION}" = "add" ] && {
+[ "${ACTION}" = "add" ] && [ -f /etc/board.json ] && {
 	/sbin/wifi config
 	ubus call network.wireless retry
 }

--- a/package/network/config/wifi-scripts/files/sbin/wifi
+++ b/package/network/config/wifi-scripts/files/sbin/wifi
@@ -62,7 +62,6 @@ wifi_detect_notice() {
 }
 
 wifi_config() {
-	[ -e /tmp/.config_pending ] && return
 	ucode /usr/share/hostap/wifi-detect.uc
 	[ ! -f /etc/config/wireless ] && touch /etc/config/wireless
 	ucode /lib/wifi/mac80211.uc | uci -q batch


### PR DESCRIPTION
Maintainer: @nbd168
The mutex file via `/tmp/.config_pending` should prevent the command `/sbin/wifi config` from being called in the ieee80211 hotplug when loading the kernel modules [1]. Since the file `/etc/board.json` does not yet exist and could be incomplete.

The `/etc/board.json` file is modified in the `/sbin/wifi config` script. This is only generated during the first boot when `/bin/config_generate` is called.
This whole handling is unclean. Therefore the creation of the default configuration `/etc/config/network`, `/etc/config/system` and `/etc/board.json` via `/sbin/config_generate` is moved to the preinit phase after the root file system has been mounted.

The advantage now is that on an ieee80211 hotplug event, the `/etc/board.json` is already present which simplifies the whole thing.

[1] https://github.com/openwrt/openwrt/blob/main/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/10-wifi-detect

Fixes: b993a00b82b1 ("base-files: fix duplicate wifi radio sections when using phy renaming")
