### PR TITLE
mediatek: port patch: add tx_power check during eeprom loading for BE14

### DIFF
--- a/package/kernel/mt76/patches/001-Add-tx_power-check.patch
+++ b/package/kernel/mt76/patches/001-Add-tx_power-check.patch
@@ -1,0 +1,27 @@
+From 8088940ffd047a6d282a95af829562e8038f5b2d Mon Sep 17 00:00:00 2001
+From: Yukari Yakumo <mistelinn@gmail.com>
+Date: Wed, 5 Feb 2025 09:33:47 +0300
+Subject: [PATCH] Add tx_power check
+
+---
+ mt7996/eeprom.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/mt7996/eeprom.c b/mt7996/eeprom.c
+index 53dfac02f..a699668ca 100644
+--- a/mt7996/eeprom.c
++++ b/mt7996/eeprom.c
+@@ -206,6 +206,13 @@ static int mt7996_eeprom_load(struct mt7996_dev *dev)
+ 				goto out;
+ 			}
+ 		}
++
++		/* read tx_power values from fw */
++		u8 *eeprom = dev->mt76.eeprom.data;
++		if (!eeprom[MT_EE_TX0_POWER_2G] || !eeprom[MT_EE_TX0_POWER_5G] || !eeprom[MT_EE_TX0_POWER_6G] ) {
++			use_default = true;
++			goto out;
++		}
+ 	}
+ 
+ out:


### PR DESCRIPTION
Some Banana Pi BPI-R4 BE14 WiFi modules are shipped with zeroed tx_power fields in EEPROM (2G/5G/6G). This leads to low transmit power on affected bands.

Fallback to default values if invalid EEPROM content is detected.

Original patch was done in mt76 project [1].
Related to: https://github.com/openwrt/openwrt/issues/17489

[1] https://github.com/openwrt/mt76/pull/954