### PR TITLE
urngd: run as regular user rather than as root

### DIFF
--- a/package/system/urngd/Makefile
+++ b/package/system/urngd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=urngd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/urngd.git
@@ -19,6 +19,7 @@ define Package/urngd
   SECTION:=utils
   CATEGORY:=Base system
   TITLE:=OpenWrt non-physical true random number generator based on timing jitter
+  USERID:=urngd=210:urngd=210
   DEPENDS:=+libubox
 endef
 
@@ -41,6 +42,8 @@ define Package/urngd/install
 	$(INSTALL_BIN) ./files/$(PKG_NAME).init $(1)/etc/init.d/$(PKG_NAME)
 	$(INSTALL_DIR) $(1)/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(PKG_NAME) $(1)/sbin/$(PKG_NAME)
+	$(INSTALL_DIR) $(1)/etc/capabilities
+	$(INSTALL_DATA) ./files/urngd.json $(1)/etc/capabilities
 endef
 
 $(eval $(call BuildPackage,urngd))

--- a/package/system/urngd/files/urngd.init
+++ b/package/system/urngd/files/urngd.init
@@ -9,6 +9,12 @@ PROG=/sbin/urngd
 start_service() {
 	procd_open_instance
 	procd_set_param command "$PROG"
+	[ -x /sbin/ujail -a -e /etc/capabilities/urngd.json ] && {
+		procd_add_jail urngd
+		procd_set_param user urngd
+		procd_set_param group urngd
+		procd_set_param capabilities /etc/capabilities/urngd.json
+	}
 	procd_close_instance
 }
 

--- a/package/system/urngd/files/urngd.json
+++ b/package/system/urngd/files/urngd.json
@@ -1,0 +1,17 @@
+{
+	"bounding": [
+		"CAP_SYS_ADMIN"
+	],
+	"effective": [
+		"CAP_SYS_ADMIN"
+	],
+	"ambient": [
+		"CAP_SYS_ADMIN"
+	],
+	"permitted": [
+		"CAP_SYS_ADMIN"
+	],
+	"inheritable": [
+		"CAP_SYS_ADMIN"
+	]
+}


### PR DESCRIPTION
Running as a dedicated user is better from both a security and an isolation perspective than running as root.

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc