### PR TITLE
mediatek: add support for OpenFi 6C

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -138,11 +138,13 @@ CMAKE_OPTIONS += \
 	-DENABLE_PROGRAMS:Bool=ON
 
 define Build/Configure
-	$(call Build/Configure/Default,)
-	$(foreach opt,$(MBEDTLS_BUILD_OPTS),
-	$(PKG_BUILD_DIR)/scripts/config.py \
-		-f $(PKG_BUILD_DIR)/include/mbedtls/mbedtls_config.h \
-		$(if $($(opt)),set,unset) $(patsubst CONFIG_%,%,$(opt)))
+	$(call Build/Configure/Default)
+
+	$(if $(strip $(foreach opt,$(MBEDTLS_BUILD_OPTS),$($(opt)))),
+		$(foreach opt,$(MBEDTLS_BUILD_OPTS),
+			$(PKG_BUILD_DIR)/scripts/config.py \
+			-f $(PKG_BUILD_DIR)/include/mbedtls/mbedtls_config.h \
+			$(if $($(opt)),set,unset) $(patsubst CONFIG_%,%,$(opt))),)
 endef
 
 define Build/InstallDev

--- a/package/utils/ucode/patches/100-ucode-add-padding-to-uc_resource_ext_t.patch
+++ b/package/utils/ucode/patches/100-ucode-add-padding-to-uc_resource_ext_t.patch
@@ -1,0 +1,21 @@
+From: Felix Fietkau <nbd@nbd.name>
+Date: Mon, 21 Jul 2025 21:07:17 +0200
+Subject: [PATCH] ucode: add padding to uc_resource_ext_t
+
+This ensures that user data structures tied to the ext resource are aligned
+to 64 bit, as usually guaranteed by the memory allocator.
+
+Signed-off-by: Felix Fietkau <nbd@nbd.name>
+---
+
+--- a/include/ucode/types.h
++++ b/include/ucode/types.h
+@@ -213,6 +213,8 @@ typedef struct {
+ 	uint32_t persistent:1;
+ 	uint32_t uvcount:8;
+ 	uint32_t datasize:20;
++
++	uint32_t _pad;
+ } uc_resource_ext_t;
+ 
+ uc_declare_vector(uc_resource_types_t, uc_resource_type_t *);

--- a/target/linux/mediatek/dts/mt7981b-openfi-6c.dts
+++ b/target/linux/mediatek/dts/mt7981b-openfi-6c.dts
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "OpenFi 6C";
+	compatible = "openfi,6c", "mediatek,mt7981b";
+
+	aliases {
+		led-boot = &led_sys_green;
+		led-failsafe = &led_sys_green;
+		led-running = &led_sys_green;
+		led-upgrade = &led_sys_green;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		mode {
+			label = "mode";
+			linux,input-type = <EV_SW>;
+			linux,code = <BTN_0>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_sys_green: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led_eth_green: led-1 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wlan5g_green: led-2 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+		};
+
+		led_modem_green: led-3 {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		hub_reset {
+			gpio-export,name = "hub_reset";
+			gpio-export,output = <0>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		modem_power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <1>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		modem_reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <1>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		modem_reset_2 {
+			gpio-export,name = "modem_reset_2";
+			gpio-export,output = <0>;
+			gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&fan {
+	pwms = <&pwm 0 40000 0>;
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&spi0 {
+		pinctrl-names = "default";
+		pinctrl-0 = <&spi0_flash_pins>;
+		status = "okay";
+
+		spi_nand: flash@0 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "spi-nand";
+			reg = <0>;
+			spi-max-frequency = <52000000>;
+
+			spi-cal-enable;
+			spi-cal-mode = "read-data";
+			spi-cal-datalen = <7>;
+			spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
+			spi-cal-addrlen = <5>;
+			spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+			spi-tx-bus-width = <4>;
+			spi-rx-bus-width = <4>;
+			mediatek,nmbm;
+			mediatek,bmt-max-ratio = <1>;
+			mediatek,bmt-max-reserved-blocks = <64>;
+
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "BL2";
+					reg = <0x00000 0x0100000>;
+					read-only;
+				};
+
+				partition@100000 {
+					label = "u-boot-env";
+					reg = <0x0100000 0x0080000>;
+				};
+
+				factory: partition@180000 {
+					label = "Factory";
+					reg = <0x180000 0x0200000>;
+
+					nvmem-layout {
+                        			compatible = "fixed-layout";
+                        			#address-cells = <1>;
+                        			#size-cells = <1>;
+
+                        			eeprom_factory_0: eeprom@0 {
+                            				reg = <0x0 0x1000>;
+                        			};
+
+                        			macaddr_factory_4: macaddr@4 {
+                            				compatible = "mac-base";
+                            				reg = <0x4 0x6>;
+                            				#nvmem-cell-cells = <1>;
+                        			};
+				    	};
+				};
+
+				partition@380000 {
+					label = "FIP";
+					reg = <0x380000 0x0200000>;
+					read-only;
+				};
+
+				partition@580000 {
+					label = "hw";
+					reg = <0x0580000 0x0080000>;
+				};
+
+				partition@600000 {
+					label = "cfg";
+					reg = <0x0600000 0x0080000>;
+				};
+
+				partition@680000 {
+					label = "ubi";
+					reg = <0x680000 0xe980000>;
+				};
+			};
+		};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+
+	pwm_pins: pwm-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm0_0", "pwm1_0";
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 2>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 3>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_pins>;
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -127,6 +127,10 @@ openembed,som7981)
 	ucidef_set_led_netdev "lanact" "LANACT" "amber:lan" "eth1" "rx tx"
 	ucidef_set_led_netdev "lanlink" "LANLINK" "green:lan" "eth1" "link"
 	;;
+openfi,6c)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link tx rx"
+	ucidef_set_led_netdev "wlan" "WLAN" "green:wlan" "phy1-ap0"
+	;;
 openwrt,one)
 	ucidef_set_led_netdev "wanact" "WANACT" "mdio-bus:0f:green:wan" "eth0" "rx tx"
 	ucidef_set_led_netdev "wanlink" "WANLINK" "mdio-bus:0f:amber:wan" "eth0" "link"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -93,6 +93,7 @@ mediatek_setup_interfaces()
 	cudy,ap3000-v1|\
 	cudy,re3000-v1|\
 	netgear,wax220|\
+	openfi,6c|\
 	ubnt,unifi-6-plus|\
 	wavlink,wl-wn573hx3|\
 	zyxel,nwa50ax-pro)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1638,6 +1638,19 @@ define Device/openembed_som7981
 endef
 TARGET_DEVICES += openembed_som7981
 
+define Device/openfi_6c
+  DEVICE_VENDOR := OpenFi
+  DEVICE_MODEL := 6C
+  DEVICE_DTS := mt7981b-openfi-6c
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += openfi_6c
+
 define Device/openwrt_one
   DEVICE_VENDOR := OpenWrt
   DEVICE_MODEL := One

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -340,152 +340,6 @@ static int rtl93xx_get_sds(struct phy_device *phydev)
 	return sds_num;
 }
 
-static int rtl83xx_pcs_validate(struct phylink_pcs *pcs,
-				unsigned long *supported,
-				const struct phylink_link_state *state)
-{
-	struct rtl838x_pcs *rtpcs = container_of(pcs, struct rtl838x_pcs, pcs);
-	struct rtl838x_switch_priv *priv = rtpcs->priv;
-	int port = rtpcs->port;
-	__ETHTOOL_DECLARE_LINK_MODE_MASK(mask) = { 0, };
-
-	pr_debug("In %s port %d, state is %d", __func__, port, state->interface);
-
-	if (!phy_interface_mode_is_rgmii(state->interface) &&
-	    state->interface != PHY_INTERFACE_MODE_NA &&
-	    state->interface != PHY_INTERFACE_MODE_1000BASEX &&
-	    state->interface != PHY_INTERFACE_MODE_MII &&
-	    state->interface != PHY_INTERFACE_MODE_REVMII &&
-	    state->interface != PHY_INTERFACE_MODE_GMII &&
-	    state->interface != PHY_INTERFACE_MODE_QSGMII &&
-	    state->interface != PHY_INTERFACE_MODE_INTERNAL &&
-	    state->interface != PHY_INTERFACE_MODE_SGMII) {
-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
-		dev_err(priv->ds->dev,
-			"Unsupported interface: %d for port %d\n",
-			state->interface, port);
-		return -EINVAL;
-	}
-
-	/* Allow all the expected bits */
-	phylink_set(mask, Autoneg);
-	phylink_set_port_modes(mask);
-	phylink_set(mask, Pause);
-	phylink_set(mask, Asym_Pause);
-
-	/* With the exclusion of MII and Reverse MII, we support Gigabit,
-	 * including Half duplex
-	 */
-	if (state->interface != PHY_INTERFACE_MODE_MII &&
-	    state->interface != PHY_INTERFACE_MODE_REVMII) {
-		phylink_set(mask, 1000baseT_Full);
-		phylink_set(mask, 1000baseT_Half);
-	}
-
-	/* On both the 8380 and 8382, ports 24-27 are SFP ports */
-	if (port >= 24 && port <= 27 && priv->family_id == RTL8380_FAMILY_ID)
-		phylink_set(mask, 1000baseX_Full);
-
-	/* On the RTL839x family of SoCs, ports 48 to 51 are SFP ports */
-	if (port >= 48 && port <= 51 && priv->family_id == RTL8390_FAMILY_ID)
-		phylink_set(mask, 1000baseX_Full);
-
-	phylink_set(mask, 10baseT_Half);
-	phylink_set(mask, 10baseT_Full);
-	phylink_set(mask, 100baseT_Half);
-	phylink_set(mask, 100baseT_Full);
-
-	bitmap_and(supported, supported, mask,
-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
-
-	return 0;
-}
-
-static int rtl93xx_pcs_validate(struct phylink_pcs *pcs,
-				unsigned long *supported,
-				const struct phylink_link_state *state)
-{
-	struct rtl838x_pcs *rtpcs = container_of(pcs, struct rtl838x_pcs, pcs);
-	struct rtl838x_switch_priv *priv = rtpcs->priv;
-	int port = rtpcs->port;
-	__ETHTOOL_DECLARE_LINK_MODE_MASK(mask) = { 0, };
-
-	pr_debug("In %s port %d, state is %d (%s)", __func__, port, state->interface,
-		 phy_modes(state->interface));
-
-	if (!phy_interface_mode_is_rgmii(state->interface) &&
-	    state->interface != PHY_INTERFACE_MODE_NA &&
-	    state->interface != PHY_INTERFACE_MODE_1000BASEX &&
-	    state->interface != PHY_INTERFACE_MODE_MII &&
-	    state->interface != PHY_INTERFACE_MODE_REVMII &&
-	    state->interface != PHY_INTERFACE_MODE_GMII &&
-	    state->interface != PHY_INTERFACE_MODE_QSGMII &&
-	    state->interface != PHY_INTERFACE_MODE_XGMII &&
-	    state->interface != PHY_INTERFACE_MODE_HSGMII &&
-	    state->interface != PHY_INTERFACE_MODE_10GBASER &&
-	    state->interface != PHY_INTERFACE_MODE_10GKR &&
-	    state->interface != PHY_INTERFACE_MODE_USXGMII &&
-	    state->interface != PHY_INTERFACE_MODE_INTERNAL &&
-	    state->interface != PHY_INTERFACE_MODE_SGMII) {
-		bitmap_zero(supported, __ETHTOOL_LINK_MODE_MASK_NBITS);
-		dev_err(priv->ds->dev,
-			"Unsupported interface: %d for port %d\n",
-			state->interface, port);
-		return -EINVAL;
-	}
-
-	/* Allow all the expected bits */
-	phylink_set(mask, Autoneg);
-	phylink_set_port_modes(mask);
-	phylink_set(mask, Pause);
-	phylink_set(mask, Asym_Pause);
-
-	/* With the exclusion of MII and Reverse MII, we support Gigabit,
-	 * including Half duplex
-	 */
-	if (state->interface != PHY_INTERFACE_MODE_MII &&
-	    state->interface != PHY_INTERFACE_MODE_REVMII) {
-		phylink_set(mask, 1000baseT_Full);
-		phylink_set(mask, 1000baseT_Half);
-	}
-
-	/* Internal phys of the RTL93xx family provide 10G */
-	if (priv->ports[port].phy_is_integrated &&
-	    state->interface == PHY_INTERFACE_MODE_1000BASEX) {
-		phylink_set(mask, 1000baseX_Full);
-	} else if (priv->ports[port].phy_is_integrated) {
-		phylink_set(mask, 1000baseX_Full);
-		phylink_set(mask, 10000baseKR_Full);
-		phylink_set(mask, 10000baseSR_Full);
-		phylink_set(mask, 10000baseCR_Full);
-	}
-	if (state->interface == PHY_INTERFACE_MODE_INTERNAL) {
-		phylink_set(mask, 1000baseX_Full);
-		phylink_set(mask, 1000baseT_Full);
-		phylink_set(mask, 10000baseKR_Full);
-		phylink_set(mask, 10000baseT_Full);
-		phylink_set(mask, 10000baseSR_Full);
-		phylink_set(mask, 10000baseCR_Full);
-	}
-
-	if (state->interface == PHY_INTERFACE_MODE_USXGMII) {
-		phylink_set(mask, 2500baseT_Full);
-		phylink_set(mask, 5000baseT_Full);
-		phylink_set(mask, 10000baseT_Full);
-	}
-
-	phylink_set(mask, 10baseT_Half);
-	phylink_set(mask, 10baseT_Full);
-	phylink_set(mask, 100baseT_Half);
-	phylink_set(mask, 100baseT_Full);
-
-	bitmap_and(supported, supported, mask,
-		   __ETHTOOL_LINK_MODE_MASK_NBITS);
-	pr_debug("%s leaving supported: %*pb", __func__, __ETHTOOL_LINK_MODE_MASK_NBITS, supported);
-
-	return 0;
-}
-
 static void rtl83xx_pcs_get_state(struct phylink_pcs *pcs,
 				  struct phylink_link_state *state)
 {
@@ -680,8 +534,8 @@ static void rtl83xx_config_interface(int port, phy_interface_t interface)
 	pr_debug("configured port %d for interface %s\n", port, phy_modes(interface));
 }
 
-static void rtl83xx_phylink_get_caps(struct dsa_switch *ds, int port,
-				     struct phylink_config *config)
+static void rtldsa_phylink_get_caps(struct dsa_switch *ds, int port,
+				    struct phylink_config *config)
 {
 	/*
 	 * TODO: This capability check will need some love. Depending on the model and the
@@ -692,14 +546,14 @@ static void rtl83xx_phylink_get_caps(struct dsa_switch *ds, int port,
 	config->mac_capabilities = MAC_ASYM_PAUSE | MAC_SYM_PAUSE | MAC_10 | MAC_100 |
 				   MAC_1000FD | MAC_2500FD | MAC_5000FD | MAC_10000FD;
 
+	__set_bit(PHY_INTERFACE_MODE_1000BASEX, config->supported_interfaces);
+	__set_bit(PHY_INTERFACE_MODE_10GBASER, config->supported_interfaces);
+	__set_bit(PHY_INTERFACE_MODE_2500BASEX, config->supported_interfaces);
 	__set_bit(PHY_INTERFACE_MODE_GMII, config->supported_interfaces);
 	__set_bit(PHY_INTERFACE_MODE_INTERNAL, config->supported_interfaces);
 	__set_bit(PHY_INTERFACE_MODE_QSGMII, config->supported_interfaces);
 	__set_bit(PHY_INTERFACE_MODE_SGMII, config->supported_interfaces);
 	__set_bit(PHY_INTERFACE_MODE_USXGMII, config->supported_interfaces);
-	__set_bit(PHY_INTERFACE_MODE_XGMII, config->supported_interfaces);
-	__set_bit(PHY_INTERFACE_MODE_1000BASEX, config->supported_interfaces);
-	__set_bit(PHY_INTERFACE_MODE_10GBASER, config->supported_interfaces);
 }
 
 static void rtl83xx_phylink_mac_config(struct dsa_switch *ds, int port,
@@ -2191,7 +2045,6 @@ static int rtl83xx_dsa_phy_write(struct dsa_switch *ds, int phy_addr, int phy_re
 
 const struct phylink_pcs_ops rtl83xx_pcs_ops = {
 	.pcs_an_restart		= rtl83xx_pcs_an_restart,
-	.pcs_validate		= rtl83xx_pcs_validate,
 	.pcs_get_state		= rtl83xx_pcs_get_state,
 	.pcs_config		= rtl83xx_pcs_config,
 };
@@ -2203,7 +2056,7 @@ const struct dsa_switch_ops rtl83xx_switch_ops = {
 	.phy_read		= rtl83xx_dsa_phy_read,
 	.phy_write		= rtl83xx_dsa_phy_write,
 
-	.phylink_get_caps	= rtl83xx_phylink_get_caps,
+	.phylink_get_caps	= rtldsa_phylink_get_caps,
 	.phylink_mac_config	= rtl83xx_phylink_mac_config,
 	.phylink_mac_link_down	= rtl83xx_phylink_mac_link_down,
 	.phylink_mac_link_up	= rtl83xx_phylink_mac_link_up,
@@ -2249,7 +2102,6 @@ const struct dsa_switch_ops rtl83xx_switch_ops = {
 
 const struct phylink_pcs_ops rtl93xx_pcs_ops = {
 	.pcs_an_restart		= rtl83xx_pcs_an_restart,
-	.pcs_validate		= rtl93xx_pcs_validate,
 	.pcs_get_state		= rtl93xx_pcs_get_state,
 	.pcs_config		= rtl83xx_pcs_config,
 };
@@ -2261,7 +2113,7 @@ const struct dsa_switch_ops rtl930x_switch_ops = {
 	.phy_read		= rtl83xx_dsa_phy_read,
 	.phy_write		= rtl83xx_dsa_phy_write,
 
-	.phylink_get_caps	= rtl83xx_phylink_get_caps,
+	.phylink_get_caps	= rtldsa_phylink_get_caps,
 	.phylink_mac_config	= rtl93xx_phylink_mac_config,
 	.phylink_mac_link_down	= rtl93xx_phylink_mac_link_down,
 	.phylink_mac_link_up	= rtl93xx_phylink_mac_link_up,

--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
@@ -38,6 +38,7 @@ extern int phy_package_read_paged(struct phy_device *phydev, int page, u32 regnu
 #define RTL821X_PAGE_MAC		0x0a43
 #define RTL821X_PAGE_STATE		0x0b80
 #define RTL821X_PAGE_PATCH		0x0b82
+#define RTL821X_MAC_SDS_PAGE(sds, page)	(0x404 + (sds) * 0x20 + (page))
 
 /* Using the special page 0xfff with the MDIO controller found in
  * RealTek SoCs allows to access the PHY in RAW mode, ie. bypassing
@@ -3811,6 +3812,55 @@ static int rtl821x_config_init(struct phy_device *phydev)
 	return 0;
 }
 
+static void rtl8218b_cmu_reset(struct phy_device *phydev, int reset_id)
+{
+	int bitpos = reset_id * 2;
+
+	/* CMU seems to have 8 pairs of reset bits that always work the same way */
+	phy_modify_paged(phydev, 0x467, 0x14, 0, BIT(bitpos));
+	phy_modify_paged(phydev, 0x467, 0x14, 0, BIT(bitpos + 1));
+	phy_write_paged(phydev, 0x467, 0x14, 0x0);
+}
+
+static int rtl8218b_config_init(struct phy_device *phydev)
+{
+	int oldpage, oldxpage;
+
+	rtl821x_config_init(phydev);
+
+	if (phydev->mdio.addr % 8)
+		return 0;
+	/*
+	 * Realtek provides two ways of initializing the PHY package. Either by U-Boot or via
+	 * vendor software and SDK. In case U-Boot setup is missing, run basic configuration
+	 * so that ports at least get link up and pass traffic.
+	 */
+
+	oldpage = phy_read(phydev, RTL8XXX_PAGE_SELECT);
+	oldxpage = phy_read(phydev, RTL821XEXT_MEDIA_PAGE_SELECT);
+	phy_write(phydev, RTL821XEXT_MEDIA_PAGE_SELECT, 0x8);
+
+	/* activate 32/40 bit redundancy algorithm for first MAC serdes */
+	phy_modify_paged(phydev, RTL821X_MAC_SDS_PAGE(0, 1), 0x14, 0, BIT(3));
+	/* magic CMU setting for stable connectivity of first MAC serdes */
+	phy_write_paged(phydev, 0x462, 0x15, 0x6e58);
+	rtl8218b_cmu_reset(phydev, 0);
+
+	for (int sds = 0; sds < 2; sds++) {
+		/* force negative clock edge */
+		phy_modify_paged(phydev, RTL821X_MAC_SDS_PAGE(sds, 0), 0x17, 0, BIT(14));
+		rtl8218b_cmu_reset(phydev, 5 + sds);
+		/* soft reset */
+		phy_modify_paged(phydev, RTL821X_MAC_SDS_PAGE(sds, 0), 0x13, 0, BIT(6));
+		phy_modify_paged(phydev, RTL821X_MAC_SDS_PAGE(sds, 0), 0x13, BIT(6), 0);
+	}
+
+	phy_write(phydev, RTL821XEXT_MEDIA_PAGE_SELECT, oldxpage);
+	phy_write(phydev, RTL8XXX_PAGE_SELECT, oldpage);
+
+	return 0;
+}
+
 static int rtl838x_serdes_probe(struct phy_device *phydev)
 {
 	int addr = phydev->mdio.addr;
@@ -3898,7 +3948,7 @@ static struct phy_driver rtl83xx_phy_driver[] = {
 	{
 		.match_phy_device = rtl8218b_ext_match_phy_device,
 		.name		= "Realtek RTL8218B (external)",
-		.config_init	= rtl821x_config_init,
+		.config_init	= rtl8218b_config_init,
 		.features	= PHY_GBIT_FEATURES,
 		.probe		= rtl8218b_ext_phy_probe,
 		.read_mmd	= rtl821x_read_mmd,


### PR DESCRIPTION
OpenFi 6C is a portable Wi-Fi 6 travel router based on MediaTek MT7981B+MT7976CN.

Specifications:
- SoC: MediaTek MT7981B (Filogic 820) 1.3GHz dual-core ARM Cortex-A53
- RAM: 1GB DDR4
- Flash: 256MB SPI NAND
- Wireless: 2.4GHz/5GHz 802.11ax
- Ethernet: 1x 10/100/1000M LAN
- USB: 1x USB 3.0 Type-A port
- Expansion: M.2 slot for 5G modem
- Cooling: PWM-controlled fan
- Buttons: Reset, Mode switch
- LEDs: System, Ethernet, 5G WiFi, Modem status

**Installation via U-Boot web page**

1. Set static IP 192.168.21.2/255.255.255.0 on your computer.
2. Connect to the Ethernet port and hold the reset button while booting the device. Wait for 6-8 seconds, and release the reset button.
3. Open U-boot web page on your browser at http://192.168.21.1
4. Select the OpenWRT sysupgrade image, upload it, and start the upgrade.
5. Wait for automatic reboot.


**Installation via sysupgrade**

Flash the sysupgrade file via LuCI upgrade page without saving the settings.

Signed-off-by: Jiasheng Zhu <newbanyaya@gmail.com>