### PR TITLE
[23.05] Cherry-pick python 3.12 checks in pereq-build.mk

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -197,7 +197,8 @@ $(eval $(call SetupHostCommand,python3,Please install Python >= 3.6, \
 
 $(eval $(call TestHostCommand,python3-distutils, \
 	Please install the Python3 distutils module, \
-	$(STAGING_DIR_HOST)/bin/python3 -c 'from distutils import util'))
+	printf 'from sys import version_info\nif version_info < (3, 12):\n\tfrom distutils import util' | \
+		$(STAGING_DIR_HOST)/bin/python3 -))
 
 $(eval $(call TestHostCommand,python3-stdlib, \
 	Please install the Python3 stdlib module, \

--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -176,6 +176,7 @@ $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 	perl --version | grep "perl.*v5"))
 
 $(eval $(call SetupHostCommand,python,Please install Python >= 3.6, \
+	python3.12 -V 2>&1 | grep 'Python 3', \
 	python3.11 -V 2>&1 | grep 'Python 3', \
 	python3.10 -V 2>&1 | grep 'Python 3', \
 	python3.9 -V 2>&1 | grep 'Python 3', \
@@ -185,6 +186,7 @@ $(eval $(call SetupHostCommand,python,Please install Python >= 3.6, \
 	python3 -V 2>&1 | grep -E 'Python 3\.([6-9]|[0-9][0-9])\.?'))
 
 $(eval $(call SetupHostCommand,python3,Please install Python >= 3.6, \
+	python3.12 -V 2>&1 | grep 'Python 3', \
 	python3.11 -V 2>&1 | grep 'Python 3', \
 	python3.10 -V 2>&1 | grep 'Python 3', \
 	python3.9 -V 2>&1 | grep 'Python 3', \


### PR DESCRIPTION
Cherry-pick two small commits in prereq-build which are required to make 23.05 build with Python 3.12 which is the default Python on Fedora 42 and other more recent Linux distributions.

* bf059f7108e7 (prereq-build: add Python 3.12 support, 2024-08-17)
* 8191c8980f04 (prereq-build: limit python distutils check to <v3.12, 2023-01-09)



