### PR TITLE
build: call ipkg-remove using xargs if #args>=512

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -18,10 +18,20 @@ define gen_package_wildcard
   $(1)$$(if $$(filter -%,$$(ABIV_$(1))),,[^a-z$(if $(CONFIG_USE_APK),,-)])*
 endef
 
+# 1: command and initial arguments
+# 2: arguments list
+# 3: tmp filename
+define maybe_use_xargs
+  $(if $(word 512,$(2)), \
+    $(file >$(3),$(2)) $(XARGS) $(1) < "$(3)"; rm "$(3)", \
+    $(1) $(2))
+endef
+
 # 1: package name
 # 2: candidate ipk files
 define remove_ipkg_files
-  $(if $(strip $(2)),$(SCRIPT_DIR)/ipkg-remove $(1) $(2))
+  $(if $(strip $(2)), \
+    $(call maybe_use_xargs,$(SCRIPT_DIR)/ipkg-remove $(1),$(2),$(TMP_DIR)/$(1).in))
 endef
 
 # 1: package name


### PR DESCRIPTION
(Fixes buildbot breakage of `luci` package.  Commit message below from original patch submission.)

The wildcard call to clean up luci package (luci*) can pick up over 2,300 files when the full tree is built. Running make package/luci/clean or a second run of make package/luci/compile would fail with an 'Argument list too long' error.

To avoid that, a maybe_use_xargs function was created that runs the command straight as usual if the number of arguments is < 512, or saves the list in a temporary file and feeds it to xargs otherwise.

This is an update to current file names and resubmission of https://lists.openwrt.org/pipermail/openwrt-devel/2020-February/027525.html

Fixes: https://github.com/openwrt/luci/issues/7869
Authored-by: Eneas U de Queiroz <cotequeiroz@gmail.com>
Suggested-by: @kuanyili

---
NOTE:  Before being committed, we should have confirmation by both @cotequeiroz and @kuanyili  that they approve of the attributions and their name formats in the commit message.  In particular, that "Suggested-by" seems a bit off to me, and I think we want real name for @kuanyili (or is that fine here?).
