### PR TITLE
realtek: actually enable 2500Base-X

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -678,6 +678,7 @@ static void rtl93xx_phylink_mac_config(struct dsa_switch *ds, int port,
 	if (sds_num >= 0 &&
 	    (state->interface == PHY_INTERFACE_MODE_1000BASEX ||
 	     state->interface == PHY_INTERFACE_MODE_SGMII ||
+	     state->interface == PHY_INTERFACE_MODE_2500BASEX ||
 	     state->interface == PHY_INTERFACE_MODE_10GBASER))
 		rtl9300_serdes_setup(port, sds_num, state->interface);
 }


### PR DESCRIPTION
The SerDes setup function needs to be called to make 2500Base-X work.

---

There have been several related pull requests recently (#19220, #19429), but this small part is still missing.