### PR TITLE
mpc85xx: HPE MSM460 add HPE MSM430 alias

### DIFF
--- a/target/linux/mpc85xx/image/p1020.mk
+++ b/target/linux/mpc85xx/image/p1020.mk
@@ -94,6 +94,8 @@ TARGET_DEVICES += extreme-networks_ws-ap3825i
 define Device/hpe_msm460
   DEVICE_VENDOR := Hewlett-Packard
   DEVICE_MODEL := MSM460
+  DEVICE_ALT0_VENDOR := Hewlett-Packard
+  DEVICE_ALT0_MODEL := MSM430
   KERNEL = kernel-bin | fit none $(KDIR)/image-$$(DEVICE_DTS).dtb
   KERNEL_NAME := zImage.la3000000
   KERNEL_ENTRY := 0x3000000


### PR DESCRIPTION
Define MSM430 as alternative name, to explicitly show the device is supported using existing image (MSM460).

I can confirm that the guide from https://github.com/blocktrron/msm460-flashing works perfectly fine with the HP MSM430 as well.

In fact, the MSM430 running the original firmware operates as a 2x3:2 access point, but after flashing it with OpenWRT, it functions as a 3x3:3 access point — just like the MSM460 model.

It seems that the MSM430 is essentially the same hardware as the MSM460, with limitations imposed by the original (HP) software.

Signed-off-by: Jan Taczanowski <jan.taczanowski@gmail.com>