### PR TITLE
mediatek: add missing #address/size-cells for ELECOM WRC-X3000GS3

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-elecom-wrc-x3000gs3.dts
+++ b/target/linux/mediatek/dts/mt7981b-elecom-wrc-x3000gs3.dts
@@ -108,6 +108,8 @@
 	pinctrl-0 = <&mdio_pins>;
 	pinctrl-names = "default";
 	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
 
 	gmac0: mac@0 {
 		compatible = "mediatek,eth-mac";
@@ -367,6 +369,8 @@
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
 
 	band@0 {
 		reg = <0>;


### PR DESCRIPTION
Add missing `#address-cells = <1>;` and `#size-cells = <0>;` properties to `&eth` and `&wifi` nodes to resolve the following warnings.

```
../dts/mt7981b-elecom-wrc-x3000gs3.dts:114.3-13: Warning (reg_format): /soc/ethernet@15100000/mac@0:reg: property has invalid length (4 bytes) (#address-cells == 2, #size-cells == 1)
../dts/mt7981b-elecom-wrc-x3000gs3.dts:129.3-13: Warning (reg_format): /soc/ethernet@15100000/mac@1:reg: property has invalid length (4 bytes) (#address-cells == 2, #size-cells == 1)
../dts/mt7981b-elecom-wrc-x3000gs3.dts:372.3-13: Warning (reg_format): /soc/wifi@18000000/band@0:reg: property has invalid length (4 bytes) (#address-cells == 2, #size-cells == 1)
../dts/mt7981b-elecom-wrc-x3000gs3.dts:378.3-13: Warning (reg_format): /soc/wifi@18000000/band@1:reg: property has invalid length (4 bytes) (#address-cells == 2, #size-cells == 1)
../dts/mt7981b-elecom-wrc-x3000gs3.dts:112.15-125.4: Warning (avoid_default_addr_size): /soc/ethernet@15100000/mac@0: Relying on default #address-cells value
../dts/mt7981b-elecom-wrc-x3000gs3.dts:112.15-125.4: Warning (avoid_default_addr_size): /soc/ethernet@15100000/mac@0: Relying on default #size-cells value
../dts/mt7981b-elecom-wrc-x3000gs3.dts:127.15-136.4: Warning (avoid_default_addr_size): /soc/ethernet@15100000/mac@1: Relying on default #address-cells value
../dts/mt7981b-elecom-wrc-x3000gs3.dts:127.15-136.4: Warning (avoid_default_addr_size): /soc/ethernet@15100000/mac@1: Relying on default #size-cells value
../dts/mt7981b-elecom-wrc-x3000gs3.dts:371.9-375.4: Warning (avoid_default_addr_size): /soc/wifi@18000000/band@0: Relying on default #address-cells value
../dts/mt7981b-elecom-wrc-x3000gs3.dts:371.9-375.4: Warning (avoid_default_addr_size): /soc/wifi@18000000/band@0: Relying on default #size-cells value
../dts/mt7981b-elecom-wrc-x3000gs3.dts:377.9-381.4: Warning (avoid_default_addr_size): /soc/wifi@18000000/band@1: Relying on default #address-cells value
../dts/mt7981b-elecom-wrc-x3000gs3.dts:377.9-381.4: Warning (avoid_default_addr_size): /soc/wifi@18000000/band@1: Relying on default #size-cells value
```
