### PR TITLE
kernel: Minor fixes to kernel packages

### DIFF
--- a/package/kernel/linux/modules/crypto.mk
+++ b/package/kernel/linux/modules/crypto.mk
@@ -559,18 +559,6 @@ endef
 
 $(eval $(call KernelPackage,crypto-kpp))
 
-define KernelPackage/crypto-lib-aescfb
-  TITLE:=AES cipher operations feedback mode library
-  DEPENDS:=@!LINUX_6_6
-  HIDDEN:=1
-  KCONFIG:=CONFIG_CRYPTO_LIB_AESCFB
-  FILES:=$(LINUX_DIR)/lib/crypto/libaescfb.ko
-  AUTOLOAD:=$(call AutoLoad,09,libaescfb)
-  $(call AddDepends/crypto)
-endef
-
-$(eval $(call KernelPackage,crypto-lib-aescfb))
-
 define KernelPackage/crypto-lib-chacha20
   TITLE:=ChaCha library interface
   KCONFIG:=CONFIG_CRYPTO_LIB_CHACHA

--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -585,7 +585,7 @@ $(eval $(call KernelPackage,drm-imx))
 define KernelPackage/drm-imx-hdmi
   SUBMENU:=$(VIDEO_MENU)
   TITLE:=Freescale i.MX HDMI DRM support
-  DEPENDS:=+kmod-sound-core kmod-drm-imx kmod-drm-display-helper
+  DEPENDS:=+kmod-sound-core kmod-drm-imx +kmod-drm-display-helper
   KCONFIG:=CONFIG_DRM_IMX_HDMI \
 	CONFIG_DRM_DW_HDMI_AHB_AUDIO \
 	CONFIG_DRM_DW_HDMI_I2S_AUDIO

--- a/target/linux/gemini/image/Makefile
+++ b/target/linux/gemini/image/Makefile
@@ -135,7 +135,7 @@ endef
 # A reasonable set of default packages handling the NAS type
 # of devices out of the box (former NAS42x0 IcyBox defaults)
 GEMINI_NAS_PACKAGES := $(DEFAULT_PACKAGES.nas) \
-		kmod-md-mod kmod-md-linear kmod-md-multipath \
+		kmod-md-mod kmod-md-linear \
 		kmod-md-raid0 kmod-md-raid1 kmod-md-raid10 kmod-md-raid456 \
 		kmod-fs-btrfs kmod-fs-cifs kmod-fs-nfs \
 		kmod-fs-nfsd kmod-fs-ntfs3 kmod-fs-reiserfs kmod-fs-vfat \


### PR DESCRIPTION
* gemini: Remove kmod-md-multipath dependency
    
    kmod-md-multipath was removed in kernel 6.12, remove the dependency here
    too.
    
    This fixes the build of the gemini target.
    
    Fixes: d12a603de575 ("kernel: kmod-md-multipath: Depend on kernel 6.6")
    Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

 * kernel: kmod-drm-imx-hdmi: Fix kmod-drm-display-helper dependency
    
    Select the kmod-drm-display-helper package instead of depending on it.
    kmod-drm-display-helper is hidden now, so the user can not manually
    select it.
    
    This fixes the build of the imx target.
    
    Fixes: 8bcc6d1894eb ("kernel: kmod-drm-display-helper: Mark hidden")
    Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>

 * kernel: kmod-crypto-lib-aescfb: Remove package
    
    kmod-crypto-lib-aescfb is marked hidden and not selected by any other
    package, it can not be build.
    
    The Kconfig option in the kernel has no title, so it can not be
    selected, it is only selected by CONFIG_TCG_TPM2_HMAC in the kernel.
    
    Fixes: ef2310b031a9 ("kernel: modules: update dependency for kmod-tpm")
    Fixes: aa51a1c13a3a ("kernel: kmod-crypto-lib-aescfb: Mark hidden")
    Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
