### PR TITLE
mediatek: add support for CreatLentem CLT-R30B1

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-creatlentem-clt-r30b1-112m.dts
+++ b/target/linux/mediatek/dts/mt7981b-creatlentem-clt-r30b1-112m.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7981b-creatlentem-clt-r30b1-common.dtsi"
+
+/ {
+	model = "CreatLentem CLT-R30B1 (112M)";
+	compatible = "creatlentem,clt-r30b1-112m", "mediatek,mt7981";
+};
+
+&partitions {
+	partition@580000 {
+		label = "ubi";
+		reg = <0x0580000 0x7000000>;
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-creatlentem-clt-r30b1-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-creatlentem-clt-r30b1-common.dtsi
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x10000000>;
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_24 0>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		label = "wan";
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_2a 0>;
+	};
+
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_24: macaddr@24 {
+						compatible = "mac-base";
+						reg = <0x24 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_2a: macaddr@2a {
+						compatible = "mac-base";
+						reg = <0x2a 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+		};
+	};
+};
+
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-creatlentem-clt-r30b1.dts
+++ b/target/linux/mediatek/dts/mt7981b-creatlentem-clt-r30b1.dts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7981b-creatlentem-clt-r30b1-common.dtsi"
+
+/ {
+	model = "CreatLentem CLT-R30B1";
+	compatible = "creatlentem,clt-r30b1", "mediatek,mt7981";
+};
+
+&partitions {
+	partition@580000 {
+		label = "ubi";
+		reg = <0x0580000 0x4000000>;
+	};
+	partition@4580000 {
+		label = "data";
+		reg = <0x4580000 0x2000000>;
+	};
+
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -39,6 +39,8 @@ mediatek_setup_interfaces()
 	cmcc,a10-stock|\
 	cmcc,a10-ubootmod|\
 	confiabits,mt7981|\
+	creatlentem,clt-r30b1|\
+	creatlentem,clt-r30b1-112m|\
 	cudy,wr3000-v1|\
 	jcg,q30-pro|\
 	keenetic,kn-3811|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -256,6 +256,8 @@ platform_check_image() {
 		fit_check_image "$1"
 		return $?
 		;;
+	creatlentem,clt-r30b1|\
+	creatlentem,clt-r30b1-112m|\
 	nradio,c8-668gl)
 		# tar magic `ustar`
 		magic="$(dd if="$1" bs=1 skip=257 count=5 2>/dev/null)"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -711,6 +711,41 @@ define Device/confiabits_mt7981
 endef
 TARGET_DEVICES += confiabits_mt7981
 
+define Device/creatlentem_clt-r30b1-common
+  DEVICE_VENDOR := CreatLentem
+  DEVICE_MODEL := CLT-R30B1
+  DEVICE_ALT0_VENDOR := EDUP
+  DEVICE_ALT0_MODEL := RT2980
+  DEVICE_ALT1_VENDOR := Dragonglass
+  DEVICE_ALT1_MODEL := DXG21
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+
+define Device/creatlentem_clt-r30b1-112m
+  DEVICE_VARIANT := 112M
+  DEVICE_ALT0_VARIANT := 112M
+  DEVICE_ALT1_VARIANT := 112M
+  DEVICE_DTS := mt7981b-creatlentem-clt-r30b1-112m
+  SUPPORTED_DEVICES += clt,r30b1 clt,r30b1-112m
+  IMAGE_SIZE := 114688k
+  $(call Device/creatlentem_clt-r30b1-common)
+endef
+TARGET_DEVICES += creatlentem_clt-r30b1-112m
+
+define Device/creatlentem_clt-r30b1
+  DEVICE_DTS := mt7981b-creatlentem-clt-r30b1
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
+  IMAGE_SIZE := 65536k
+  $(call Device/creatlentem_clt-r30b1-common)
+endef
+TARGET_DEVICES += creatlentem_clt-r30b1
+
 define Device/cudy_ap3000outdoor-v1
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := AP3000 Outdoor


### PR DESCRIPTION
```
CreatLentem CLT-R30B1 is a wireless WiFi 6 router.
This device uses the CLT-R30B1_0824_V1.1 board
shared by EDUP RT2980, Dragonglass DXG21,
and other diamond-shaped 5-antenna routers.

Specification
-------------
- SoC          : MediaTek MT7981B dual-core ARM Cortex-A53 1.3 GHz
- RAM          : DDR3 256 MiB
- Flash        : SPI-NAND 128 MiB (ESMT F50L1G41LB)
- WLAN         : MediaTek MT7976CN dual-band WiFi 6
  - 2.4 GHz    : b/g/n/ax, MU-MIMO (2x 5 dBi antennas)
  - 5 GHz      : a/n/ac/ax, MU-MIMO (3x 5 dBi antennas)
- Ethernet     :
  - LAN x3     : 10/100/1000 Mbps (MediaTek MT7531AE)
  - WAN x1     : 10/100/1000 Mbps (MT7981 internal PHY)
- UART         : through-hole on PCB
  - assignment : (RX), (TX), (GND), [3.3V]
  - settings   : 115200n8
- Buttons x2   : Mesh/WPS, Reset
- LEDs x2      : Status (Red, Green)
- Power        : 12 VDC, 1 A, 2.1*5.5 mm

Important notes
---------------
The device is supplied in two variants.
The main difference is the size of the mtd5 (ubi)
partition in the flash layout: 64M or 112M.
112M version: Has ImmortalWrt firmware installed with LuCI WebUI.
64M version: Has stock firmware based on OpenWrt,
with the WaveLink/GL.iNet WebUI and older U-Boot
compared to the 112M version.

Flash instructions for 112M version
-----------------------------------
Follow the standard OpenWrt sysupgrade procedure without saving data.
Use the clt-r30b1-112m-squashfs-sysupgrade.bin image.
All checks should pass - don't proceed if a "not supported"
warning is issued.

Flash instructions for 64M version
----------------------------------
WebUI Method:

1. Prepare the upgrade image with clt-r30b1-squashfs-sysupgrade.bin
   using the script: make_staged_upgrade_tar.sh
   or use the prepared image: staged_openwrt_upgrade.bin
   Downloaded from:
   https://github.com/andros-ua/owrt-misc/tree/main/clt-r30b1
2. Install the prepared image using the stock WebUI update page.
3. Press and hold the reset button after reboot
   to wipe the stock config and gain access.

SSH Method:

1. Connect via SSH using dg:ivanlee credentials.
2. Upload the clt-r30b1-squashfs-sysupgrade.bin image.
3. Use the command: sysupgrade -n
   All checks should pass - don't proceed if a "not supported"
   warning is issued.

Return to stock
---------------
Flash a backup of the ubi mtdblock (mtd5)
using the OpenWrt sysupgrade method.

Recovery
--------
Both variants:
Connect UART and use the U-Boot menu to flash the firmware image
or boot an OpenWrt initramfs image.

112M with newer U-Boot:
Power on the router while pressing the mesh button for 3 seconds.
The U-Boot Flash WebUI will be available at http://192.168.1.1/

MAC Addresses:
------------------------------------------------------
| Interface   |  MAC              | Source           |
--------------|-------------------|-------------------
|LAN          | B4:4D:43:D1:xx:xx | Factory, 0x2A    |
|WAN          | B4:4D:43:D1:xx:xx | Factory, 0x24    |
|WLAN 2.4 GHz | B4:4D:43:D2:xx:xx | Factory, 0x4     |
|WLAN 5 GHz   | B4:4D:43:D2:xx:xx | Factory, 0x4 + 1 |
------------------------------------------------------


```