### PR TITLE
ramips: mt76x8: add support for Wodesys WD-R1208U

### DIFF
--- a/target/linux/ramips/dts/mt7628an_wodesys_wd-r1208u.dts
+++ b/target/linux/ramips/dts/mt7628an_wodesys_wd-r1208u.dts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "wodesys,wd-r1208u", "mediatek,mt7628an-soc";
+	model = "Wodesys WD-R1208U";
+
+	aliases {
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+		label-mac-device = &wmac;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset { // both reset and wps button
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		// non-GPIO LEDs:
+		// Power, WLAN_2GHZ, WLAN_5GHZ, LAN
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					macaddr_factory_28: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "refclk", "p4led_an";
+		function = "gpio";
+	};
+
+        wlan {
+                groups = "wled_an";
+                function = "wled_an";
+        };
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portdisable = <0x27>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1228,6 +1228,15 @@ define Device/wiznet_wizfi630s
 endef
 TARGET_DEVICES += wiznet_wizfi630s
 
+define Device/wodesys_wd-r1208u
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Wodesys
+  DEVICE_MODEL := WD-R1208U
+  DEVICE_PACKAGES := kmod-mt76x2
+  SUPPORTED_DEVICES += mtk-apsoc-demo
+endef
+TARGET_DEVICES += wodesys_wd-r1208u
+
 define Device/wrtnode_wrtnode2p
   IMAGE_SIZE := 32448k
   DEVICE_VENDOR := WRTnode


### PR DESCRIPTION
This commit adds support for a dual-band AC1200 wall plug manufactured by Shenzhen Century Xinyang Tech Co., Ltd.

**SoC**:     Mediatek MT7628AN (MIPS 24KEc single core, 580 MHz)
**RAM**:     128 MiB DDR2 (Hynix HY5PS1G1631C)
**ROM**:     8 MiB SPI NOR (Zbit ZB25VQ64ASIG)
**Wired**:   one FE RJ45 port (+ an unpopulated footprint for a 2nd)
**WiFi**:    Mediatek MT7612E
**Ant.**:    four 2 dBi external antennas (two 2.4GHz, two 5 GHz)
**LEDs**:    - Power    (green, always on)
         - 2.4G     (green, controlled by MT7628)
         - 5G       (green, controlled by MT7612)
         - Extender (green, GPIO 37, used as status LED)
         - LAN      (green/yellow, controlled by RT3050 ESW)
**Buttons**: WPS and reset (both connected to GPIO 38)
**Power**:   5V 2-pin JST-XH on main PCB
         110/220V AC to 5V 1.5A DC on auxiliary PCB
**UART**:    57600 8n1 3.3v, holes available on the PCB as J5
         pinout is (Gnd) (Tx) (Rx)
**MAC**:     1C:BF:CE:xx:xx:xx       (2.4 GHz, label)
         1C:BF:CE:xx:xx:xx + 1   (LAN)
         1C:BF:CE:xx:xx:xx + 2   (WAN, not in use)
         1C:BF:CE:xx:xx:xx + 3   (5 GHz)

Original firmware is Chaos Calmer 15.05.01 (kernel 3.10.108) with a few custom packages and a non-LuCI web interface. Telnet is enabled, requiring an unknown root password [1]. Root password is also needed to access the router via UART console, but passwordless telnet can be enabled via a trivial web exploit [2] and then the root password can be removed by editing `/etc/shadow`.

Installation: Upload `sysupgrade` binary via web interface at `http://192.168.188.1/settings.shtml`. Alternatively, remove root password and use u-boot menu to flash image via TFTP.

Notes:
- Device model in Chaos Calmer is "mtk-apsoc-demo".
- It is sold under several brands, e.g., Fenvi and Linkavenir. It is available in two colors: white and black.
- PCB is marked "WD206AD v1.0".
- Instead of a standard ethernet transformer, the PCB has a few tiny SMD coils.
- The housing is identical to the one used by a 2020 model, WD-R1203U, which is RTL8812-based. The older model has an FCC listing with external and internal images: ZNPWD-R1203U. The FCC listing contains a letter [3] claiming WD-R1203U and WD-R1208U are internally identical, but evidently they are not.

[1] `root:$1$7rmMiPJj$91iv9LWhfkZE/t7aCBdo.0:18388:0:99999:7:::`
    This is the same hash as in Wodesys WD-R1802U.
    There are other root password hashes in `/etc/shadow_sf` and `/etc/shadow_yn`.
[2] `curl -X POST http://192.168.188.1/cgi-bin/adm.cgi -d page=Lang -d langType="en;killall telnetd;telnetd -l /bin/sh"`
[3] https://fcc.report/FCC-ID/ZNPWD-R1203U/4767033
