### PR TITLE
[24.10] busybox: fix login applet on selinux

### DIFF
--- a/package/utils/busybox/patches/600-loginutils-login.c-libselinux-get_default_context-ex.patch
+++ b/package/utils/busybox/patches/600-loginutils-login.c-libselinux-get_default_context-ex.patch
@@ -1,0 +1,51 @@
+From 850a6d031039237b0b13d8fab9f10a7cd4752907 Mon Sep 17 00:00:00 2001
+From: Dominick Grift <dominick.grift@defensec.nl>
+Date: Sat, 5 Apr 2025 13:40:26 +0200
+Subject: [PATCH] loginutils/login.c: libselinux get_default_context() expects
+ seuser
+
+Use getseuserbyname() to get the seuser associated with username and use that
+instead with get_default_context()
+
+>From get_default_context.3:
+"These functions takes a SELinux user identity that must be defined in the SELinux policy as their input, not a Linux username."
+
+Fixes: #19075
+Upstream-Status: Submitted [https://lists.busybox.net/pipermail/busybox/2025-April/091407.html]
+Signed-off-by: Dominick Grift <dominick.grift@defensec.nl>
+---
+ loginutils/login.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+--- a/loginutils/login.c
++++ b/loginutils/login.c
+@@ -183,12 +183,16 @@ static void die_if_nologin(void)
+ static void initselinux(char *username, char *full_tty,
+ 						security_context_t *user_sid)
+ {
++	char *seuser = NULL, *level = NULL;
+ 	security_context_t old_tty_sid, new_tty_sid;
+ 
+ 	if (!is_selinux_enabled())
+ 		return;
+ 
+-	if (get_default_context(username, NULL, user_sid)) {
++	if (getseuserbyname(username, &seuser, &level)) {
++		bb_error_msg_and_die("can't get seuser for %s", username);
++	}
++	if (get_default_context(seuser, NULL, user_sid)) {
+ 		bb_error_msg_and_die("can't get SID for %s", username);
+ 	}
+ 	if (getfilecon(full_tty, &old_tty_sid) < 0) {
+@@ -201,6 +205,11 @@ static void initselinux(char *username,
+ 	if (setfilecon(full_tty, new_tty_sid) != 0) {
+ 		bb_perror_msg_and_die("chsid(%s, %s) failed", full_tty, new_tty_sid);
+ 	}
++
++	if (ENABLE_FEATURE_CLEAN_UP) {
++		free(seuser);
++		free(level);
++	}
+ }
+ #endif
+ 


### PR DESCRIPTION
Currently the system boots up, but is unusable because pressing enter does not provide login with error:

  login: can't get SID for root

This is happenning, because login.c passes the Linux username directly to get_default_context(), while libselinux expects an SELinux user identity, causing the call to fail for users without a matching SELinux name (e.g., root) and aborting login on SELinux-enabled systems.

Fixes: #19075
Upstream-Status: Submitted [https://lists.busybox.net/pipermail/busybox/2025-April/091407.html]
Link: https://github.com/openwrt/openwrt/pull/19080
(cherry picked from commit 5809bfaaacca1d10c2e77bd073065d1d3b77527e)