### PR TITLE
realtek: DSA: do not open-code PHY access

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -29,9 +29,6 @@ extern const struct dsa_switch_ops rtl930x_switch_ops;
 extern const struct phylink_pcs_ops rtl83xx_pcs_ops;
 extern const struct phylink_pcs_ops rtl93xx_pcs_ops;
 
-extern int rtmdio_838x_read_phy(u32 port, u32 page, u32 reg, u32 *val);
-extern int rtmdio_838x_write_phy(u32 port, u32 page, u32 reg, u32 val);
-
 DEFINE_MUTEX(smi_lock);
 
 int rtl83xx_port_get_stp_state(struct rtl838x_switch_priv *priv, int port)
@@ -241,38 +238,6 @@ u64 rtl839x_get_port_reg_le(int reg)
 	v |= sw_r32(reg);
 
 	return v;
-}
-
-int read_phy(u32 port, u32 page, u32 reg, u32 *val)
-{
-	switch (soc_info.family) {
-	case RTL8380_FAMILY_ID:
-		return rtmdio_838x_read_phy(port, page, reg, val);
-	case RTL8390_FAMILY_ID:
-		return rtl839x_read_phy(port, page, reg, val);
-	case RTL9300_FAMILY_ID:
-		return rtl930x_read_phy(port, page, reg, val);
-	case RTL9310_FAMILY_ID:
-		return rtl931x_read_phy(port, page, reg, val);
-	}
-
-	return -1;
-}
-
-int write_phy(u32 port, u32 page, u32 reg, u32 val)
-{
-	switch (soc_info.family) {
-	case RTL8380_FAMILY_ID:
-		return rtmdio_838x_write_phy(port, page, reg, val);
-	case RTL8390_FAMILY_ID:
-		return rtl839x_write_phy(port, page, reg, val);
-	case RTL9300_FAMILY_ID:
-		return rtl930x_write_phy(port, page, reg, val);
-	case RTL9310_FAMILY_ID:
-		return rtl931x_write_phy(port, page, reg, val);
-	}
-
-	return -1;
 }
 
 static int rtldsa_bus_read(struct mii_bus *bus, int addr, int regnum)

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -2674,39 +2674,18 @@ out:
 	return 0;
 }
 
-static int rtl83xx_dsa_phy_read(struct dsa_switch *ds, int phy_addr, int phy_reg)
+static int rtldsa_phy_read(struct dsa_switch *ds, int addr, int regnum)
 {
-	u32 val;
-	u32 offset = 0;
 	struct rtl838x_switch_priv *priv = ds->priv;
 
-	if ((phy_addr >= 24) &&
-	    (phy_addr <= 27) &&
-	    (priv->ports[24].phy == PHY_RTL838X_SDS)) {
-		if (phy_addr == 26)
-			offset = 0x100;
-		val = sw_r32(RTL838X_SDS4_FIB_REG0 + offset + (phy_reg << 2)) & 0xffff;
-		return val;
-	}
-
-	read_phy(phy_addr, 0, phy_reg, &val);
-	return val;
+	return mdiobus_read_nested(priv->parent_bus, addr, regnum);
 }
 
-static int rtl83xx_dsa_phy_write(struct dsa_switch *ds, int phy_addr, int phy_reg, u16 val)
+static int rtldsa_phy_write(struct dsa_switch *ds, int addr, int regnum, u16 val)
 {
-	u32 offset = 0;
 	struct rtl838x_switch_priv *priv = ds->priv;
 
-	if ((phy_addr >= 24) &&
-	    (phy_addr <= 27) &&
-	    (priv->ports[24].phy == PHY_RTL838X_SDS)) {
-		if (phy_addr == 26)
-			offset = 0x100;
-		sw_w32(val, RTL838X_SDS4_FIB_REG0 + offset + (phy_reg << 2));
-		return 0;
-	}
-	return write_phy(phy_addr, 0, phy_reg, val);
+	return mdiobus_write_nested(priv->parent_bus, addr, regnum, val);
 }
 
 const struct phylink_pcs_ops rtl83xx_pcs_ops = {
@@ -2719,8 +2698,8 @@ const struct dsa_switch_ops rtl83xx_switch_ops = {
 	.get_tag_protocol	= rtl83xx_get_tag_protocol,
 	.setup			= rtl83xx_setup,
 
-	.phy_read		= rtl83xx_dsa_phy_read,
-	.phy_write		= rtl83xx_dsa_phy_write,
+	.phy_read		= rtldsa_phy_read,
+	.phy_write		= rtldsa_phy_write,
 
 	.phylink_get_caps	= rtldsa_phylink_get_caps,
 	.phylink_mac_config	= rtl83xx_phylink_mac_config,
@@ -2782,8 +2761,8 @@ const struct dsa_switch_ops rtl930x_switch_ops = {
 	.get_tag_protocol	= rtl83xx_get_tag_protocol,
 	.setup			= rtl93xx_setup,
 
-	.phy_read		= rtl83xx_dsa_phy_read,
-	.phy_write		= rtl83xx_dsa_phy_write,
+	.phy_read		= rtldsa_phy_read,
+	.phy_write		= rtldsa_phy_write,
 
 	.phylink_get_caps	= rtldsa_phylink_get_caps,
 	.phylink_mac_config	= rtl93xx_phylink_mac_config,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -139,9 +139,6 @@ int rtl83xx_port_is_under(const struct net_device * dev, struct rtl838x_switch_p
 void rtl83xx_port_stp_state_set(struct dsa_switch *ds, int port, u8 state);
 int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type_data);
 
-int read_phy(u32 port, u32 page, u32 reg, u32 *val);
-int write_phy(u32 port, u32 page, u32 reg, u32 val);
-
 /* Port register accessor functions for the RTL839x and RTL931X SoCs */
 void rtl839x_mask_port_reg_be(u64 clear, u64 set, int reg);
 u32 rtl839x_get_egress_rate(struct rtl838x_switch_priv *priv, int port);
@@ -196,9 +193,6 @@ int rtl83xx_lag_add(struct dsa_switch *ds, int group, int port, struct netdev_la
 int rtl83xx_lag_del(struct dsa_switch *ds, int group, int port);
 
 /* phy functions that will need to be moved to the future mdio driver */
-
-int rtl838x_read_mmd_phy(u32 port, u32 addr, u32 reg, u32 *val);
-int rtl838x_write_mmd_phy(u32 port, u32 addr, u32 reg, u32 val);
 
 int rtl839x_read_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 *val);
 int rtl839x_write_mmd_phy(u32 port, u32 devnum, u32 regnum, u32 val);


### PR DESCRIPTION
The DSA has a link to the MDIO bus and already uses the read/write functions that are provided. In parallel the dsa_switch_ops structure provides an interface for phy_read and phy_write. These are still open coded and sadly circumvent the bus. Simplify the implementation and avoid inconsistencies by reusing the existing bus infrastructure.
