### PR TITLE
realtek: mdio: rtl93xx: point phy read/writes to SerDes fiber page

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -1995,10 +1995,10 @@ static int rtmdio_93xx_read(struct mii_bus *bus, int addr, int regnum)
 	if (priv->phy_is_internal[addr]) {
 		if (priv->family_id == RTL9300_FAMILY_ID)
 			return rtl930x_read_sds_phy(priv->sds_id[addr],
-						    priv->page[addr], regnum);
+						    priv->page[addr] + 2, regnum);
 		else
 			return rtl931x_read_sds_phy(priv->sds_id[addr],
-						    priv->page[addr], regnum);
+						    priv->page[addr] + 2, regnum);
 	}
 
 	err = (*priv->read_phy)(addr, priv->page[addr], regnum, &val);
@@ -2089,10 +2089,10 @@ static int rtmdio_93xx_write(struct mii_bus *bus, int addr, int regnum, u16 val)
 		if (priv->phy_is_internal[addr]) {
 			if (priv->family_id == RTL9300_FAMILY_ID)
 				return rtl930x_write_sds_phy(priv->sds_id[addr],
-							     page, regnum, val);
+							     page + 2, regnum, val);
 			else
 				return rtl931x_write_sds_phy(priv->sds_id[addr],
-							     page, regnum, val);
+							     page + 2, regnum, val);
 		}
 
 		err = (*priv->write_phy)(addr, page, regnum, val);


### PR DESCRIPTION
The MDIO bus already provides phy register access for ports that are directly driven by a SerDes. The SerDes Fiber (aka phy) pages are 2/3 and behave nearly like an external standard phy. For RTL838x this access is already implemented the right way. For RTL93xx the bus wrongly accesses pages 0/1 that contain SerDes internal data. Reroute reads/writes to be consistent.