### PR TITLE
qualcommax: ipq50xx: fix tsens node status to enable thermal sensor

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax830.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax830.dts
@@ -386,7 +386,7 @@
 };
 
 &tsens {
-	status = "okay ";
+	status = "okay";
 };
 
 &q6v5_wcss {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
@@ -321,7 +321,7 @@
 };
 
 &tsens {
-	status = "okay ";
+	status = "okay";
 };
 
 &q6v5_wcss {


### PR DESCRIPTION
The tsens node had an extra space in the "okay" status string, preventing thermal sensors from being properly registered. This patch corrects it to enable proper thermal monitoring support.

Fix in two files:
- target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax830.dts
- target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts