### PR TITLE
apm821xx: correct layout of u-boot-env for meraki mx60

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/apm821xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/apm821xx
@@ -14,6 +14,7 @@ meraki,mr24)
 	;;
 meraki,mx60)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000" "4"
+	ubootenv_add_uci_config "/dev/mtd1" "0x80000" "0x20000" "0x20000" "4"
 	;;
 netgear,wndap620|\
 netgear,wndap660)

--- a/target/linux/apm821xx/dts/meraki-mx60.dts
+++ b/target/linux/apm821xx/dts/meraki-mx60.dts
@@ -64,7 +64,6 @@
 			partition@100000 {
 				label = "u-boot-env";
 				reg = <0x00100000 0x00100000>;
-				read-only;
 
 				nvmem-layout {
 					compatible = "u-boot,env";


### PR DESCRIPTION
uboot-envtools used not to work on meraki mx60, believing the checksum of env block is bad. It turns out that the env block is stored redundantly on offset 0x0 and 0x80000 of the "u-boot-env" partition.

Testing: Modifying /etc/fw_env.config into

	 /dev/mtd1 0x0 0x20000 0x20000 4
	 /dev/mtd1 0x80000 0x20000 0x20000 4

can make fw_loadenv and fw_printenv work, and after unlocking the "u-boot-env" partition by force with kmod-mtd-rw, updated env block written with fw_setenv could be recognized by u-boot.

Thus, writing to "u-boot-env" partition could also be allowed in the device tree with the correct layout.

ISSUE: Linux kernel remains complaining "Invalid calculated CRC32" for
       "u-boot-env" partition.

