### PR TITLE
[24.10]mediatek: Ruijie RG-X60 Pro: Fix LAN port status light

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
@@ -230,21 +230,25 @@
 		port@0 {
 			reg = <0>;
 			label = "lan1";
+			phy-handle = <&swphy0>;
 		};
 
 		port@1 {
 			reg = <1>;
 			label = "lan2";
+			phy-handle = <&swphy1>;
 		};
 
 		port@2 {
 			reg = <2>;
 			label = "lan3";
+			phy-handle = <&swphy2>;
 		};
 
 		port@3 {
 			reg = <3>;
 			label = "lan4";
+			phy-handle = <&swphy3>;
 		};
 
 		port@6 {
@@ -258,6 +262,67 @@
 				full-duplex;
 				pause;
 			};
+		};
+	};
+
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		swphy0: phy@0 {
+			reg = <0>;
+
+			mediatek,led-config = <
+				0x21 0x8009 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0x8000 /* LED0_ON_CTRL */
+				0x25 0x0000 /* LED0_BLINK_CTRL */
+				0x26 0xc007 /* LED1_ON_CTRL */
+				0x27 0x003f /* LED1_BLINK_CTRL */
+			>;
+		};
+
+		swphy1: phy@1 {
+			reg = <1>;
+
+			mediatek,led-config = <
+				0x21 0x8009 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0x8000 /* LED0_ON_CTRL */
+				0x25 0x0000 /* LED0_BLINK_CTRL */
+				0x26 0xc007 /* LED1_ON_CTRL */
+				0x27 0x003f /* LED1_BLINK_CTRL */
+			>;
+		};
+
+		swphy2: phy@2 {
+			reg = <2>;
+
+			mediatek,led-config = <
+				0x21 0x8009 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0x8000 /* LED0_ON_CTRL */
+				0x25 0x0000 /* LED0_BLINK_CTRL */
+				0x26 0xc007 /* LED1_ON_CTRL */
+				0x27 0x003f /* LED1_BLINK_CTRL */
+			>;
+		};
+
+		swphy3: phy@3 {
+			reg = <3>;
+
+			mediatek,led-config = <
+				0x21 0x8009 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0x8000 /* LED0_ON_CTRL */
+				0x25 0x0000 /* LED0_BLINK_CTRL */
+				0x26 0xc007 /* LED1_ON_CTRL */
+				0x27 0x003f /* LED1_BLINK_CTRL */
+			>;
 		};
 	};
 };


### PR DESCRIPTION
Fix the status indicator light of the LAN port.

cherry-pick from 1e00b92597a1e14b5eb07cc2f87d3b943b4bd876
Link: https://github.com/openwrt/openwrt/pull/19135
