### PR TITLE
realtek: rtl931x: Disable BPDU flooding initialization

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -1691,8 +1691,9 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		goto err_register_fib_nb;
 
 	/* TODO: put this into l2_setup() */
-	/* Flood BPDUs to all ports including cpu-port */
-	if (soc_info.family != RTL9300_FAMILY_ID) {
+	switch (soc_info.family) {
+	default:
+		/* Flood BPDUs to all ports including cpu-port */
 		bpdu_mask = soc_info.family == RTL8380_FAMILY_ID ? 0x1FFFFFFF : 0x1FFFFFFFFFFFFF;
 		priv->r->set_port_reg_be(bpdu_mask, priv->r->rma_bpdu_fld_pmask);
 
@@ -1700,8 +1701,11 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		sw_w32(7, priv->r->spcl_trap_eapol_ctrl);
 
 		rtl838x_dbgfs_init(priv);
-	} else {
+		break;
+	case RTL9300_FAMILY_ID:
+	case RTL9310_FAMILY_ID:
 		rtl930x_dbgfs_init(priv);
+		break;
 	}
 
 	return 0;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -1696,6 +1696,7 @@ const struct rtl838x_reg rtl931x_reg = {
 	.vlan_port_pvidmode_set = rtl931x_vlan_port_pvidmode_set,
 	.vlan_port_pvid_set = rtl931x_vlan_port_pvid_set,
 	.trk_mbr_ctr = rtldsa_931x_trk_mbr_ctr,
+	.rma_bpdu_fld_pmask = RTL931X_RMA_BPDU_FLD_PMSK,
 	.set_vlan_igr_filter = rtl931x_set_igr_filter,
 	.set_vlan_egr_filter = rtl931x_set_egr_filter,
 	.set_distribution_algorithm = rtl931x_set_distribution_algorithm,


### PR DESCRIPTION
Neither the RTL930x nor the RT931x use the BPDU flooding mechanism employed by other SoCs. However, RTL931x shares the same debugfs initialization function as RTL930x.

Even though BPDU flooding is currently unused, it's still appropriate to correctly initialize the `rma_bpdu_fld_pmask` field to ensure consistent and predictable behavior in the future.