### PR TITLE
realtek: dsa: rtl83xx: flush scheduled work on removal

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -1236,7 +1236,8 @@ static void rtldsa_poll_counters(struct work_struct *work)
 		spin_unlock(&counters->lock);
 	}
 
-	schedule_delayed_work(&priv->counters_work, RTLDSA_COUNTERS_POLL_INTERVAL);
+	queue_delayed_work(priv->wq, &priv->counters_work,
+			   RTLDSA_COUNTERS_POLL_INTERVAL);
 }
 
 static void rtldsa_init_counters(struct rtl838x_switch_priv *priv)
@@ -1254,7 +1255,8 @@ static void rtldsa_init_counters(struct rtl838x_switch_priv *priv)
 	}
 
 	INIT_DELAYED_WORK(&priv->counters_work, rtldsa_poll_counters);
-	schedule_delayed_work(&priv->counters_work, RTLDSA_COUNTERS_POLL_INTERVAL);
+	queue_delayed_work(priv->wq, &priv->counters_work,
+			   RTLDSA_COUNTERS_POLL_INTERVAL);
 }
 
 static void rtldsa_get_strings(struct dsa_switch *ds,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1143,6 +1143,7 @@ struct rtl838x_switch_priv {
 	u32 lag_primary[MAX_LAGS];
 	u32 is_lagmember[57];
 	u64 lagmembers;
+	struct workqueue_struct *wq;
 	struct notifier_block nb;  /* TODO: change to different name */
 	struct notifier_block ne_nb;
 	struct notifier_block fib_nb;


### PR DESCRIPTION
The workqueue items don't need to be processed directly when they are scheduled. It can happen that they are simply processed at a much later time. It is therefore necessary to ensure that all workqueue items of a driver are no longer being processed before the driver (or structures of this driver) are destroyed.

When skipping this step, the driver driver can cause a kernel Oops on reboot.

Unfortunately, it is not recommended [1] to flush items out of the system workqueue - simply because this can cause deadlocks. The driver itself must have a private workqueue which is then flushed.

[1] https://lkml.kernel.org/r/49925af7-78a8-a3dd-bce6-cfc02e1a9236@I-love.SAKURA.ne.jp