### PR TITLE
realtek: rtl931x: Configure SFP fixed speeds based on DT

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -653,9 +653,6 @@ static void rtl93xx_pcs_get_state(struct phylink_pcs *pcs,
 	if (priv->family_id == RTL9300_FAMILY_ID)
 		media = sw_r32(RTL930X_MAC_LINK_MEDIA_STS);
 
-	if (media & BIT_ULL(port))
-		state->link = 1;
-
 	pr_debug("%s: link state port %d: %llx, media %llx\n", __func__, port,
 		 link & BIT_ULL(port), media);
 


### PR DESCRIPTION
The function `rtl93xx_pcs_get_state()` configures the internal SerDes to a fixed speed depending on the port number, which is necessary for proper SFP+ module operation.

However, port numbers for SFP+ modules varies across different boards. To handle this correctly, whether a port uses an SFP+ module must be determined from the device tree rather than hardcoded port numbers.

A new struct field `isSFP` is introduced to make it easier to access this information later without trying to access the devicetree in a later stage.