### PR TITLE
realtek: rtl93xx: i2c: Add multi byte xfer and block transfer support

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/i2c/busses/i2c-rtl9300.c
+++ b/target/linux/realtek/files-6.12/drivers/i2c/busses/i2c-rtl9300.c
@@ -149,10 +149,14 @@ static int i2c_write(void __iomem *r0, u8 *buf, int len)
 
 		if (! (i % 4))
 			v = 0;
-		v <<= 8;
-		v |= buf[i];
-		if (i % 4 == 3 || i == len - 1)
+		/* Write from left to right */
+		v |= (buf[i] << 24);
+
+		if (i % 4 == 3 || i == len - 1) {
+			v >>= (8 * (3 - i % 4));
 			writel(v, r0 + (i / 4) * 4);
+		} else
+			v >>= 8;
 	}
 
 	return len;
@@ -213,7 +217,7 @@ static int rtl9300_execute_xfer(struct rtl9300_i2c *i2c, char read_write,
 		} else if (size == I2C_SMBUS_WORD_DATA) {
 			data->word = readl(REG(i2c, RTL9300_I2C_DATA_WORD0));
 		} else if (len > 0) {
-			rtl9300_i2c_read(i2c, &data->block[0], len);
+			rtl9300_i2c_read(i2c, &data->block[1], len);
 		}
 	}
 
@@ -244,7 +248,7 @@ static int rtl9310_execute_xfer(struct rtl9300_i2c *i2c, char read_write,
 		} else if (size == I2C_SMBUS_WORD_DATA) {
 			data->word = readl(REG(i2c, RTL9310_I2C_DATA));
 		} else if (len > 0) {
-			rtl9310_i2c_read(i2c, &data->block[0], len);
+			rtl9310_i2c_read(i2c, &data->block[1], len);
 		}
 	}
 


### PR DESCRIPTION
The original implementation of the i2c-rtl9300 driver assumed a xfer size of exactly one byte. For more bytes, the order of bytes in the register has to adjusted and the length must be taken into account.

And the original driver didn't support `I2C_SMBUS_I2C_BLOCK_DATA` emulation. This is required for devices which are not actually SMBUS compliant - see https://linux.kernel.narkive.com/PeNlDZ1K/i2c-smbus-question for more details.