### PR TITLE
realtek: rtl931x: Implement SFP support

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
@@ -3883,12 +3883,16 @@ static int rtl8390_serdes_probe(struct phy_device *phydev)
 
 static int rtl9300_serdes_probe(struct phy_device *phydev)
 {
-	if (soc_info.family != RTL9300_FAMILY_ID)
+	switch (soc_info.family) {
+	case RTL9300_FAMILY_ID:
+		phydev_info(phydev, "Detected internal RTL9300 Serdes\n");
+		return 0;
+	case RTL9310_FAMILY_ID:
+		phydev_info(phydev, "Detected internal RTL9310 Serdes\n");
+		return 0;
+	default:
 		return -ENODEV;
-
-	phydev_info(phydev, "Detected internal RTL9300 Serdes\n");
-
-	return 0;
+	}
 }
 
 static struct phy_driver rtl83xx_phy_driver[] = {


### PR DESCRIPTION
The RTL931x code for SFP support was there but seemed to never have been working. `rtl9300_read_status()` was for example using (incompatible) registers from RTL930x.

The SerDes "probe" handler in rtl83xx-phy was also always rejecting RTL931x

Additionally, SDS field writes to enable USXGMII, 10G-BaseR, and 1000-BaseX modes were incorrect, causing SerDes initialization failures. These have been corrected to properly initialize the SerDes for these modes.