### PR TITLE
realtek: rtl930x: Fix bringup of SFP modules

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
@@ -1711,9 +1711,11 @@ static int rtsds_930x_get_internal_mode(int sds)
 
 static void rtsds_930x_set_power(int sds, bool on)
 {
-	int power = on ? 0 : 3;
+	int power_down = on ? 0x0 : 0x3;
+	int rx_enable = on ? 0x3 : 0x1;
 
-	rtl9300_sds_field_w(sds, 0x20, 0x00, 7, 6, power);
+	rtl9300_sds_field_w(sds, 0x20, 0x00, 7, 6, power_down);
+	rtl9300_sds_field_w(sds, 0x20, 0x00, 5, 4, rx_enable);
 }
 
 static int rtsds_930x_config_pll(int sds, phy_interface_t interface)


### PR DESCRIPTION
The commit d2108c2c5896 ("realtek: enhance RTL930x SerDes/PLL/CMU interoperability") removed a couple of commands for the PLL configuration. One of these commands was necessary to bring up SFP modules correctly. This one can also be [found in the RTLSDK](https://gitlab.com/olliver/openwrt/realtek_sdk/-/blob/0e2e45341a268147e3e935a8d0276b60787c1f57/loader/u-boot-2011.12/board/Realtek/switch/sdk/src/dal/longan/dal_longan_sds.c#L1104).

It is currently unknown what this command actually does but this line is essential and must not be omitted.

---

There is actually another one which was lost "in" `rtsds_930x_set_pll_data`:

```diff
 	rtl9300_sds_field_w(base_sds, 0x20, 0x12, 3, 0, 0xf);
 	rtl9300_sds_field_w(base_sds, 0x20, 0x12, pbit + 1, pbit, pll);
 	rtl9300_sds_field_w(base_sds, 0x20, 0x12, sbit + 3, sbit, speed);
-	rtl9300_sds_field_w(base_sds, 0x21, 11, 3, 0, 0xf);
```

I have no idea what it does but in the rtlsdk source code, it is:

```
    /*analog force LC & ring enable*/
    SDS_FIELD_W(unit, lane0Sds, 0x21, 11, 3, 0,  0xf);

```

but the order is quite different than the OpenWrt implementation. This line is followed in the RTLSDK by an equivalent of following OpenWrt line:

```
rtl9300_sds_field_w(base_sds, 0x20, 0x12, pbit + 1, pbit, pll);
```

(which is OpenWrt done a lot earlier)