### PR TITLE
qualcommax: fix minor Xiaomi AX6000 dts compiler warning

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
@@ -402,6 +402,9 @@
 		reg = <17>;
 
 		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
 			port@1 {
 				reg = <1>;
 				label = "lan1";


### PR DESCRIPTION
* Fix minor compiler warning on build IPQ5018