### PR TITLE
util-linux: add last util

### DIFF
--- a/package/utils/util-linux/Makefile
+++ b/package/utils/util-linux/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=util-linux
 PKG_VERSION:=2.41.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/$(PKG_NAME)/v2.41
@@ -315,6 +315,18 @@ define Package/ipcs/description
   which the calling process has read access. By default it shows information
   about all three resources: shared memory segments, message queues, and
   semaphore arrays.
+endef
+
+define Package/last
+$(call Package/util-linux/Default)
+  TITLE:=display history of user logins and logout sessions
+  LICENSE=BSD-4-Clause-UC
+  LICENSE_FILES:=Documentation/licenses/COPYING.BSD-4-Clause-UC
+endef
+
+define Package/last/description
+ last utility displays a history of user login and logout sessions, system reboots,
+ and other events recorded in /var/log/wtmp (or a specified file)
 endef
 
 define Package/logger
@@ -706,7 +718,6 @@ MESON_ARGS += \
 	-Dbuild-rfkill=disabled \
 	-Dbuild-tunelp=disabled \
 	-Dbuild-kill=disabled \
-	-Dbuild-last=disabled \
 	-Dbuild-utmpdump=disabled \
 	-Dbuild-line=disabled \
 	-Dbuild-mesg=disabled \
@@ -860,6 +871,11 @@ endef
 define Package/ipcs/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ipcs $(1)/usr/bin/
+endef
+
+define Package/last/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/last $(1)/usr/bin/
 endef
 
 define Package/logger/install
@@ -1032,6 +1048,7 @@ $(eval $(call BuildPackage,fstrim))
 $(eval $(call BuildPackage,getopt))
 $(eval $(call BuildPackage,hwclock))
 $(eval $(call BuildPackage,ipcs))
+$(eval $(call BuildPackage,last))
 $(eval $(call BuildPackage,logger))
 $(eval $(call BuildPackage,look))
 $(eval $(call BuildPackage,losetup))


### PR DESCRIPTION
Add a package for the last util needed to query `/var/log/wtmp`

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc