### PR TITLE
tools: automake: fix MAINTAINERCLEANFILES warnings

### DIFF
--- a/tools/automake/patches/310-maintainer-clean-built_sources.patch
+++ b/tools/automake/patches/310-maintainer-clean-built_sources.patch
@@ -21,7 +21,7 @@
 +      if (! grep { $_ eq '$(BUILT_SOURCES)' } $mcleanvar->value_as_list ($rcond)) {
 +	Automake::Variable::define ($mcleanvar->name, VAR_MAKEFILE, '+', $rcond,
 +				    '$(BUILT_SOURCES)', '', INTERNAL, VAR_ASIS)
-+	  if vardef ('BUILT_SOURCES', $rcond);
++	  if var ('BUILT_SOURCES');
 +      }
 +    }
 +    my $bsources = var ('BUILT_SOURCES');
@@ -30,9 +30,9 @@
 +      {
 +	Automake::Variable::define ($mcleanvar->name, VAR_MAKEFILE, '', $rcond,
 +				    '$(BUILT_SOURCES)', '', INTERNAL, VAR_ASIS)
-+	  if ! vardef ($mcleanvar, $rcond);
++	  if ! ($mcleanvar->def ($rcond) || $mcleanvar->def (TRUE));
 +      }
-+      if (! vardef ($mcleanvar, TRUE)) {
++      if (! $mcleanvar->def (TRUE)) {
 +	Automake::Variable::define ($mcleanvar->name, VAR_MAKEFILE, '', TRUE,
 +				    '$(BUILT_SOURCES)', '', INTERNAL, VAR_ASIS);
 +      }


### PR DESCRIPTION
ping @robimarko 

It seems that, for whatever reason in this case,
the function "vardef ($var, $cond)" does not work
while "$var->def ($cond)" does work for conditionals.

Also, do not define it conditionally when defined unconditionally. Even though the reordering patch would make that functionally sound, it still throws a warning which can cause a build to fail when warnings are treated as errors.

Instead, just add BUILT_SOURCES to every existing case rather than only when BUILT_SOURCES is defined.

Fixes: 6d2bfe50d3 ("tools/automake: control all cleaning with clean variables")
Closes: #19537
