### PR TITLE
tools/expat: fix compilation with ccache

### DIFF
--- a/tools/expat/Makefile
+++ b/tools/expat/Makefile
@@ -20,6 +20,7 @@ HOST_BUILD_PARALLEL:=1
 include $(INCLUDE_DIR)/host-build.mk
 
 HOSTCC := $(HOSTCC_NOCACHE)
+HOSTCXX := $(HOSTCXX_NOCACHE)
 
 HOST_CONFIGURE_ARGS += \
 	--disable-shared \


### PR DESCRIPTION
Even though expat is a C library, the configure script tests both C and C++ compilers so a fix is needed for the latter.