### PR TITLE
wifi-scripts: ucode: set default wildcard mac for wifi-station

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -208,6 +208,9 @@ function setup() {
 		case 'mesh':
 			if (mode != "ap")
 				data.config.noscan = true;
+			for (let _, sta in v.stas) {
+				validate('station', sta.config);
+			}
 			validate('iface', v.config);
 			iface.prepare(v.config, data.phy + data.phy_suffix, data.config.num_global_macaddr, data.config.macaddr_base);
 			netifd.set_vif(k, v.config.ifname);

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-station.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-station.json
@@ -6,7 +6,8 @@
 	"properties": {
 		"mac": {
 			"description": "The stations MAC",
-			"type": "string"
+			"type": "string",
+			"default": "00:00:00:00:00:00"
 		},
 		"key": {
 			"description": "The passphrase that shall be used",


### PR DESCRIPTION
When creating the PSK file, the old script sets `mac` to `00:00:00:00:00:00` when `mac` is not specified (see [here][1]), creating hostapd configuration lines like:

```
vlanid=10 00:00:00:00:00:00 MyStrongPassword
```

That matches any MAC address (a wildcard). The `ucode` script alternative misses the default, so set it.

[1]: https://github.com/openwrt/openwrt/blob/9c26d144893c25e484ca97c7a3f58cdec6767465/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh#L428

**Note:** The `default` set in `wireless.wifi-station.json` has to be applied by calling a `validate('station', config)` function, but I was really not sure where to do it. I also found that `wireless.wifi-vlan.json` is not used at all for verification, so it would be good to call it, so that any possibile future addition of default values works.

Compile-tested: TP-Link Archer C7 v4, v5
Run-tested: TP-Link Archer C7 v4, v5