### PR TITLE
kernel: Fix setsockopt(SO_ATTACH_FILTER) failed on kernel 6.12

### DIFF
--- a/target/linux/generic/hack-6.12/299-bpf-Fall-back-to-the-interpreter-if-possible.patch
+++ b/target/linux/generic/hack-6.12/299-bpf-Fall-back-to-the-interpreter-if-possible.patch
@@ -1,0 +1,75 @@
+From 14719e09ccc345bbec01b61c7f5d004822c52a5d Mon Sep 17 00:00:00 2001
+From: KaFai Wan <kafai.wan@linux.dev>
+Date: Tue, 29 Jul 2025 22:40:10 +0800
+Subject: [PATCH] bpf: Fall back to the interpreter if possible
+
+Fixes: 6ebc5030e0c5 ("bpf: Fix array bounds error with may_goto")
+Fixes: 86bc9c742426 ("bpf: Avoid __bpf_prog_ret0_warn when jit fails")
+---
+ kernel/bpf/core.c | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/kernel/bpf/core.c b/kernel/bpf/core.c
+index 68a327158989..9559d5945c19 100644
+--- a/kernel/bpf/core.c
++++ b/kernel/bpf/core.c
+@@ -2296,8 +2296,7 @@ static unsigned int __bpf_prog_ret0_warn(const void *ctx,
+ 					 const struct bpf_insn *insn)
+ {
+ 	/* If this handler ever gets executed, then BPF_JIT_ALWAYS_ON
+-	 * is not working properly, or interpreter is being used when
+-	 * prog->jit_requested is not 0, so warn about it!
++	 * or stack size > 512 is not working properly, so warn about it!
+ 	 */
+ 	WARN_ON_ONCE(1);
+ 	return 0;
+@@ -2382,7 +2381,7 @@ static int bpf_check_tail_call(const struct bpf_prog *fp)
+ 	return ret;
+ }
+ 
+-static void bpf_prog_select_func(struct bpf_prog *fp)
++static bool bpf_prog_select_func_interpreter(struct bpf_prog *fp)
+ {
+ #ifndef CONFIG_BPF_JIT_ALWAYS_ON
+ 	u32 stack_depth = max_t(u32, fp->aux->stack_depth, 1);
+@@ -2392,15 +2391,16 @@ static void bpf_prog_select_func(struct bpf_prog *fp)
+ 	 * But for non-JITed programs, we don't need bpf_func, so no bounds
+ 	 * check needed.
+ 	 */
+-	if (!fp->jit_requested &&
+-	    !WARN_ON_ONCE(idx >= ARRAY_SIZE(interpreters))) {
++	if (idx < ARRAY_SIZE(interpreters)) {
+ 		fp->bpf_func = interpreters[idx];
+ 	} else {
++		WARN_ON_ONCE(!fp->jit_requested);
+ 		fp->bpf_func = __bpf_prog_ret0_warn;
+ 	}
+ #else
+ 	fp->bpf_func = __bpf_prog_ret0_warn;
+ #endif
++	return fp->bpf_func != __bpf_prog_ret0_warn;
+ }
+ 
+ /**
+@@ -2419,7 +2419,7 @@ struct bpf_prog *bpf_prog_select_runtime(struct bpf_prog *fp, int *err)
+ 	/* In case of BPF to BPF calls, verifier did all the prep
+ 	 * work with regards to JITing, etc.
+ 	 */
+-	bool jit_needed = fp->jit_requested;
++	bool jit_needed = false;
+ 
+ 	if (fp->bpf_func)
+ 		goto finalize;
+@@ -2428,7 +2428,8 @@ struct bpf_prog *bpf_prog_select_runtime(struct bpf_prog *fp, int *err)
+ 	    bpf_prog_has_kfunc_call(fp))
+ 		jit_needed = true;
+ 
+-	bpf_prog_select_func(fp);
++	if (!bpf_prog_select_func_interpreter(fp))
++		jit_needed = true;
+ 
+ 	/* eBPF JITs can rewrite the program in case constant
+ 	 * blinding is active. However, in case of error during
+-- 
+2.43.0
+


### PR DESCRIPTION
Fixes: https://github.com/openwrt/openwrt/issues/19405
