### PR TITLE
tools: bison: do not install or uninstall macros

### DIFF
--- a/tools/bison/Makefile
+++ b/tools/bison/Makefile
@@ -21,13 +21,13 @@ include $(INCLUDE_DIR)/host-build.mk
 HOST_CONFIGURE_ARGS += --enable-threads=posix --disable-nls
 
 define Host/Install
-	$(call Host/Install/Default)
+	$(call Host/Compile/Default,install aclocal_DATA=) # Macro provided by gnulib
 	$(INSTALL_BIN) ./scripts/yacc $(STAGING_DIR_HOST)/bin/yacc
 endef
 
 define Host/Uninstall
 	rm -f $(STAGING_DIR_HOST)/bin/yacc
-	-$(call Host/Compile/Default,uninstall)
+	-$(call Host/Compile/Default,uninstall aclocal_DATA=) # Macro provided by gnulib
 endef
 
 $(eval $(call HostBuild))


### PR DESCRIPTION
ping @1715173329 @robimarko

There is a clobbering between bison and gnulib for installing the macro file bison-i18n.m4 where gnulib has a newer version while bison will replace it with an outdated version if built afterward.

Other builds depend on the changes made to the bison-i18n.m4 file and are only included using aclocal unless other modifications are made in each case in order to force imported macros from gnulib to override aclocal macros.

Gnulib is integrated within bison, however it is not with a bootstrap script and there is already a reverse dependency between the two, where bison is indirectly required for gnulib to start building. Therefore, do not allow the building or cleaning of bison to install or uninstall m4 files.

Reported-by: Tianling Shen <cnsztl@immortalwrt.org>
Fixes: d19f8bc199 ("tools/gnulib: update to branch stable-202501")
Closes: #19601 