### PR TITLE
ramips: add support for Mercury KM08-708H

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -101,6 +101,7 @@ linksys,ea7300-v2|\
 linksys,ea7500-v2|\
 linksys,ea8100-v1|\
 linksys,ea8100-v2|\
+mercury,km08-708h|\
 mts,wg430223|\
 ubnt,edgerouter-x|\
 ubnt,edgerouter-x-sfp)

--- a/target/linux/ramips/dts/mt7621_mercury_km08-708h.dts
+++ b/target/linux/ramips/dts/mt7621_mercury_km08-708h.dts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Copyright (c) 2023, Muhammad Al-Qady <m.ismael@gmail.com>
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "mercury,km08-708h", "mediatek,mt7621-soc";
+	model = "Mercury KM08-708H";
+
+	aliases {
+		label-mac-device = &wan;
+		led-boot = &led_wlan;
+		led-failsafe = &led_wlan;
+		led-upgrade = &led_wlan;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+		bootargs-override = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wlan: wlan {
+			label = "green_wlan";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_lan2: lan2 {
+			label = "green_lan2";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			linux,default-trigger = "lan2";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&gpio {
+	usbpower-hog {
+		gpio-hog;
+		gpios = <15 GPIO_ACTIVE_LOW>;
+		output-high;
+		line-name = "usbpower";
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x40000>;
+		};
+
+		factory: partition@c0000 {
+			label = "factory";
+			reg = <0xc0000 0x80000>;
+			read-only;
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_factory_4: macaddr@4 {
+					compatible = "mac-base";
+					reg = <0x4 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+
+				eeprom_factory_40000: eeprom@40000 {
+					reg = <0x40000 0x8C04>;
+				};
+			};
+		};
+
+		partition@140000 {
+			label = "firmware";
+			reg = <0x140000 0x7100000>;
+
+			compatible = "denx,uimage";
+			#address-cells = <1>;
+			#size-cells = <1>;
+		};
+
+		partition@7240000 {
+			label = "recoverk";
+			reg = <0x7240000 0x720000>;
+			read-only;
+		};
+
+		partition@7960000 {
+			label = "recoverr";
+			reg = <0x7960000 0xe0000>;
+			read-only;
+		};
+
+		partition@7a40000 {
+			label = "nvram";
+			reg = <0x7a40000 0xe0000>;
+			read-only;
+		};
+
+		partition@7b20000 {
+			label = "log";
+			reg = <0x7b20000 0x4e0000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_40000>;
+		nvmem-cell-names = "eeprom";
+		mediatek,disable-radar-background;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_factory_4 2>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_factory_4 3>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	nvmem-cells = <&macaddr_factory_4 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		wan: port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_4 0>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2069,6 +2069,23 @@ define Device/meig_slt866
 endef
 TARGET_DEVICES += meig_slt866
 
+define Device/mercury_km08-708h
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  PAGESIZE := 2048
+  BLOCKSIZE := 128k
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 115712k
+  DEVICE_VENDOR := Mercury
+  DEVICE_MODEL := KM08-708H
+  UBINIZE_OPTS := -E 5
+  IMAGES += factory.bin sysupgrade.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | check-size
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-mt7615e kmod-usb3 uboot-envtools
+endef
+TARGET_DEVICES += mercury_km08-708h
+
 define Device/mercusys_mr70x-v1
   $(Device/dsa-migration)
   $(Device/tplink-safeloader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -150,6 +150,10 @@ linksys,ea8100-v2)
 	ucidef_set_led_netdev "lan4" "lan4 link" "green:lan4" "lan4" "link"
 	ucidef_set_led_netdev "wan" "wan link" "green:wan" "wan" "link"
 	;;
+mercury,km08-708h)
+	ucidef_set_led_netdev "lan2" "lan2 link" "green_lan2" "lan2" "link tx rx"
+	ucidef_set_led_netdev "wlan2g" "wlan2g link" "green_wlan" "phy0tpt" "link tx rx"
+	;;
 meig,slt866)
 	ucidef_set_led_netdev "lan" "eth" "blue:lanwan" "lan" "link tx rx"
 	ucidef_set_led_netdev "wwan0" "net" "blue:internet" "wwan0" "link tx rx"


### PR DESCRIPTION
Mercury
MSIP-CMM-MCS-KM08-708H
KM08-708H

SoC : MediaTek MT7621AT
RAM : 256M (Hanya NT5CC128M16IP-DI)
FLASH : NAND (Winbond W29N01HVSINA)
WiFi : MediaTek MT7615DN DUAL Band
BTN : Reset
BTN : WPS
USB: 1 port

LEDS :

WAN Green
LAN {1-4} Green
WiFi Green
UART : J1 TX - RX - 3V3 - GND / 115200-8N1

UART Menu
```
U-Boot 1.1.3 (Apr 14 2017 - 11:33:48)

Board: Ralink APSoC DRAM:  256 MB

 ##### The CPU freq = 880 MHZ ####

Please choose the operation:
   1: Load system code to SDRAM via TFTP.
   2: Load system code then write to Flash via TFTP.
   3: Boot system code via Flash (default).
   4: Entr boot command line interface.
   7: Load Boot Loader code then write to Flash via Serial.
   9: Load Boot Loader code then write to Flash via TFTP.
default: 3
```
Steps

Prepare TFTP server on your Computer

Connect UART Console

Press `4: Entr boot command line interface.`
remove checksum `mcr remove_checksum`
reset
Press `2: Load system code then write to Flash via TFTP.`

Enter IP information and file name

After uploading firmware image, device will boot Openwrt.

Signed-off-by: Muhammad AL-Qady [m.ismael@gmail.com]
