### PR TITLE
bcm47xx: defer initializing fixed PHY and b44

### DIFF
--- a/target/linux/bcm47xx/patches-6.6/850-deferred-phy-registration.patch
+++ b/target/linux/bcm47xx/patches-6.6/850-deferred-phy-registration.patch
@@ -1,0 +1,53 @@
+--- a/arch/mips/bcm47xx/setup.c
++++ b/arch/mips/bcm47xx/setup.c
+@@ -34,6 +34,7 @@
+ #include <linux/ethtool.h>
+ #include <linux/phy.h>
+ #include <linux/phy_fixed.h>
++#include <linux/mdio.h>
+ #include <linux/ssb/ssb.h>
+ #include <linux/ssb/ssb_embedded.h>
+ #include <linux/bcma/bcma_soc.h>
+@@ -265,6 +266,24 @@ static struct fixed_phy_status bcm47xx_f
+ 
+ static struct gpio_wdt_platform_data gpio_wdt_data;
+ 
++static int bcm47xx_fixed_phy_probe(struct platform_device *pdev)
++{
++	struct phy_device *phydev;
++
++	phydev = fixed_phy_register(PHY_POLL, &bcm47xx_fixed_phy_status, NULL);
++	if (IS_ERR(phydev)) {
++		return dev_err_probe(&pdev->dev, PTR_ERR(phydev), "failed to register the fixed PHY\n");
++	}
++
++	dev_info(&pdev->dev, "probed fixed PHY\n");
++	return 0;
++}
++
++static struct platform_driver bcm47xx_fixed_phy_drv = {
++	.probe = bcm47xx_fixed_phy_probe,
++	.driver = { .name = "bcm47xx-fixed-phy", },
++};
++
+ static struct platform_device gpio_wdt_device = {
+ 	.name			= "gpio-wdt",
+ 	.id			= 0,
+@@ -310,7 +329,16 @@ static int __init bcm47xx_register_bus_c
+ 	bcm47xx_leds_register();
+ 	bcm47xx_workarounds();
+ 
+-	fixed_phy_add(PHY_POLL, 0, &bcm47xx_fixed_phy_status);
++	if (platform_driver_register(&bcm47xx_fixed_phy_drv)) {
++		pr_err("fixed-phy: failed to register driver\n");
++		return 0;
++	}
++
++	if (IS_ERR(platform_device_register_simple(
++		    "bcm47xx-fixed-phy", PLATFORM_DEVID_NONE, NULL, 0))) {
++		pr_err("fixed-phy: failed to register device\n");
++	}
++
+ 	bcm47xx_register_gpio_watchdog();
+ 	return 0;
+ }

--- a/target/linux/bcm47xx/patches-6.6/860-deferred-b44-init.patch
+++ b/target/linux/bcm47xx/patches-6.6/860-deferred-b44-init.patch
@@ -1,0 +1,20 @@
+--- a/drivers/net/ethernet/broadcom/b44.c
++++ b/drivers/net/ethernet/broadcom/b44.c
+@@ -2417,10 +2417,17 @@ static void b44_unregister_phy_one(struc
+ static int b44_init_one(struct ssb_device *sdev,
+ 			const struct ssb_device_id *ent)
+ {
++	struct device *phy;
+ 	struct net_device *dev;
+ 	struct b44 *bp;
+ 	int err;
+ 
++	phy = bus_find_device_by_name(&mdio_bus_type, NULL, "fixed-0:00");
++	if (!phy) {
++		dev_err(sdev->dev, "fixed phy is not ready, deferring\n");
++		return -EPROBE_DEFER;
++	}
++
+ 	instance++;
+ 
+ 	dev = alloc_etherdev(sizeof(*bp));


### PR DESCRIPTION
Hi, this is my first time making a PR to OpenWrt. Thanks to whoever reviews this, and let me know if I should improve the patch or fix something. Thank you!

## Commit description

Starting from f75b530 (bcm47xx: default to kernel 6.1), the fixed PHY needs to be registered using fixed_phy_register rather than using fixed_phy_add, or the PHY will not be discovered by b44_init_one (probe function).

Also, the fixed MDIO bus, fixed PHY, and b44 must be initialized in the proper order so they can locate the components they depend on.

850-deferred-phy-registration.patch replaces the fixed_phy_add() call with a tiny platform driver that registers the fixed PHY. It defers the registration if the fixed MDIO bus isn't initialized.

860-deferred-b44-init.patch adds an availability check section in the very beginning of b44_init_one to make sure if the fixed PHY (fixed-0:00) is registered and available.

The resulting boot log, tested on Linksys WRT54GS v1:

[    0.623801] bcm47xx-fixed-phy bcm47xx-fixed-phy: fixed MDIO bus is not ready, deferring
...
[    1.910067] b44 ssb0:1: fixed phy is not ready, deferring
...
[    2.091570] bcm47xx-fixed-phy bcm47xx-fixed-phy: probed fixed PHY
...
[    2.121193] adm6996: adm6996_gpio: ADM6996L model PHY found.
[    2.155104] b44 ssb0:1: could not find PHY at 30, use fixed one
[    2.162116] Generic PHY fixed-0:00: attached PHY driver (mii_bus:phy_addr=fixed-0:00, irq=POLL)
[    2.171237] b44 ssb0:1 eth0: Broadcom 44xx/47xx 10/100 PCI ethernet driver 00:0f:66:ce:c0:e3