### PR TITLE
gettext-full: fix m4 path after gettextize update

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -163,8 +163,8 @@ define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/lib/libintl-full/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libintl.{a,so*} $(1)/usr/lib/libintl-full/lib/
 
-	$(INSTALL_DIR) $(1)/usr/share/aclocal
-	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/aclocal/* $(1)/usr/share/aclocal/
+	$(INSTALL_DIR) $(1)/usr/share/gettext/m4
+	$(INSTALL_DATA) $(PKG_INSTALL_DIR)/usr/share/gettext/m4/* $(1)/usr/share/gettext/m4/
 
 	$(SED) '/read dummy/d' $(STAGING_DIR_HOSTPKG)/bin/gettextize
 endef


### PR DESCRIPTION
Recent changes to gettextize altered the default path for .m4 files from $datadir/aclocal to $datadir/gettext/m4 [0]. This caused build issues when compiling gettext-full in OpenWrt.

This patch, originally provided by @nxhack [1], updates the OpenWrt Makefile accordingly to ensure compatibility with the new path.

[0] https://gitweb.git.savannah.gnu.org/gitweb/?p=gettext.git;a=commit;h=fa98427c774aad9dade7702becc2c3eef5a8434d
[1] https://github.com/openwrt/openwrt/commit/da541f7acd62bc33e7b0a891cf65a39d4bfe0b96#commitcomment-163048847

Fixes: da541f7acd62 ("gettext-full: update to 0.24.1")