### PR TITLE
tools: util-linux: allow building with 32-bit time

### DIFF
--- a/tools/util-linux/Makefile
+++ b/tools/util-linux/Makefile
@@ -18,6 +18,7 @@ include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/meson.mk
 
 MESON_HOST_ARGS += \
+	$(if $(findstring y,$(YEAR_2038)),,-Dallow-32bit-time=true) \
 	-Dauto_features=disabled \
 	-Dbuild-hexdump=enabled \
 	-Dbuild-libuuid=enabled \


### PR DESCRIPTION
@PolynomialDivision @neheb small regression of #19598 

Similar to several GNU tools, util-linux when built using meson
is configured by default to error when 64-bit time is not supported.

To solve this in the same way as standard configure scripts,
check for 64-bit time support ahead of time,
and allow 32-bit time when not supported.

In the future, the YEAR_2038 variable
can be used as a build prerequisite
instead of being used for configuration.

Ref: 39e8ef33bf ("build: add test for 64-bit time support")
Fixes: e15d5cf752 ("tools/util-linux: build with meson")