### PR TITLE
kernel/modules: add MCP342x I2C ADCs kernel module support

### DIFF
--- a/package/kernel/linux/modules/iio.mk
+++ b/package/kernel/linux/modules/iio.mk
@@ -149,6 +149,20 @@ endef
 
 $(eval $(call KernelPackage,iio-ads1015))
 
+define KernelPackage/iio-mcp3422
+  TITLE:=Microchip MCP342x ADC driver
+  KCONFIG:=CONFIG_MCP3422
+  FILES:=$(LINUX_DIR)/drivers/iio/adc/mcp3422.ko
+  AUTOLOAD:=$(call AutoProbe,mcp3422)
+  $(call AddDepends/iio, +kmod-i2c-core)
+endef
+
+define KernelPackage/iio-mcp3422/description
+  Kernel module for the Microchip MCP342x I2C ADCs.
+endef
+
+$(eval $(call KernelPackage,iio-mcp3422))
+
 define KernelPackage/iio-hmc5843
   DEPENDS:=+kmod-i2c-core +kmod-regmap-i2c +kmod-industrialio-triggered-buffer
   TITLE:=Honeywell HMC58x3 Magnetometer


### PR DESCRIPTION
This commit adds kernel module support for Microchip MCP342x family of I2C ADCs.

Tested on a custom board based on Hi-Link HLK-7628N.
