### PR TITLE
qualcommax: ipq6018 rework nss_port5 clock to multiple conf

### DIFF
--- a/target/linux/qualcommax/patches-6.12/0151-arm64-qcom-ipq6018-nss_port5.patch
+++ b/target/linux/qualcommax/patches-6.12/0151-arm64-qcom-ipq6018-nss_port5.patch
@@ -1,0 +1,125 @@
+From 9989fcd49c52500a2bf1f6d49411690dec45d2dc Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marko=20M=C3=A4kel=C3=A4?= <marko.makela@iki.fi>
+Date: Sat, 2 Aug 2025 12:47:08 +0300
+Subject: [PATCH] clk: qcom: gcc-ipq6018: rework nss_port5 clock to multiple
+ conf
+
+Rework nss_port5 to use the new multiple configuration implementation
+and correctly fix the clocks for this port under some corner case.
+
+In OpenWrt, this patch avoids intermittent dmesg errors of the form
+nss_port5_rx_clk_src: rcg didn't update its configuration.
+
+This is a mechanical, straightforward port of
+commit e88f03230dc07aa3293b6aeb078bd27370bb2594
+("clk: qcom: gcc-ipq8074: rework nss_port5/6 clock to multiple conf")
+to gcc-ipq6018, with two conflicts resolved: different frequency of the
+P_XO clock source, and only 5 Ethernet ports.
+
+This was originally developed by JiaY-shi <shi05275@163.com>.
+
+Link: https://lore.kernel.org/all/20231220221724.3822-4-ansuelsmth@gmail.com/
+Signed-off-by: Marko Mäkelä <marko.makela@iki.fi>
+Tested-by: Marko Mäkelä <marko.makela@iki.fi>
+---
+ drivers/clk/qcom/gcc-ipq6018.c | 60 +++++++++++++++++++++-------------
+ 1 file changed, 38 insertions(+), 22 deletions(-)
+
+--- a/drivers/clk/qcom/gcc-ipq6018.c
++++ b/drivers/clk/qcom/gcc-ipq6018.c
+@@ -511,15 +511,23 @@ static struct clk_rcg2 apss_ahb_clk_src
+ 	},
+ };
+ 
+-static const struct freq_tbl ftbl_nss_port5_rx_clk_src[] = {
+-	F(24000000, P_XO, 1, 0, 0),
+-	F(25000000, P_UNIPHY1_RX, 12.5, 0, 0),
+-	F(25000000, P_UNIPHY0_RX, 5, 0, 0),
+-	F(78125000, P_UNIPHY1_RX, 4, 0, 0),
+-	F(125000000, P_UNIPHY1_RX, 2.5, 0, 0),
+-	F(125000000, P_UNIPHY0_RX, 1, 0, 0),
+-	F(156250000, P_UNIPHY1_RX, 2, 0, 0),
+-	F(312500000, P_UNIPHY1_RX, 1, 0, 0),
++static const struct freq_conf ftbl_nss_port5_rx_clk_src_25[] = {
++	C(P_UNIPHY1_RX, 12.5, 0, 0),
++	C(P_UNIPHY0_RX, 5, 0, 0),
++};
++
++static const struct freq_conf ftbl_nss_port5_rx_clk_src_125[] = {
++	C(P_UNIPHY1_RX, 2.5, 0, 0),
++	C(P_UNIPHY0_RX, 1, 0, 0),
++};
++
++static const struct freq_multi_tbl ftbl_nss_port5_rx_clk_src[] = {
++	FMS(24000000, P_XO, 1, 0, 0),
++	FM(25000000, ftbl_nss_port5_rx_clk_src_25),
++	FMS(78125000, P_UNIPHY1_RX, 4, 0, 0),
++	FM(125000000, ftbl_nss_port5_rx_clk_src_125),
++	FMS(156250000, P_UNIPHY1_RX, 2, 0, 0),
++	FMS(312500000, P_UNIPHY1_RX, 1, 0, 0),
+ 	{ }
+ };
+ 
+@@ -547,26 +555,34 @@ gcc_xo_uniphy0_rx_tx_uniphy1_rx_tx_ubi32
+ 
+ static struct clk_rcg2 nss_port5_rx_clk_src = {
+ 	.cmd_rcgr = 0x68060,
+-	.freq_tbl = ftbl_nss_port5_rx_clk_src,
++	.freq_multi_tbl = ftbl_nss_port5_rx_clk_src,
+ 	.hid_width = 5,
+ 	.parent_map = gcc_xo_uniphy0_rx_tx_uniphy1_rx_tx_ubi32_bias_map,
+ 	.clkr.hw.init = &(struct clk_init_data){
+ 		.name = "nss_port5_rx_clk_src",
+ 		.parent_data = gcc_xo_uniphy0_rx_tx_uniphy1_rx_tx_ubi32_bias,
+ 		.num_parents = 7,
+-		.ops = &clk_rcg2_ops,
++		.ops = &clk_rcg2_fm_ops,
+ 	},
+ };
+ 
+-static const struct freq_tbl ftbl_nss_port5_tx_clk_src[] = {
+-	F(24000000, P_XO, 1, 0, 0),
+-	F(25000000, P_UNIPHY1_TX, 12.5, 0, 0),
+-	F(25000000, P_UNIPHY0_TX, 5, 0, 0),
+-	F(78125000, P_UNIPHY1_TX, 4, 0, 0),
+-	F(125000000, P_UNIPHY1_TX, 2.5, 0, 0),
+-	F(125000000, P_UNIPHY0_TX, 1, 0, 0),
+-	F(156250000, P_UNIPHY1_TX, 2, 0, 0),
+-	F(312500000, P_UNIPHY1_TX, 1, 0, 0),
++static const struct freq_conf ftbl_nss_port5_tx_clk_src_25[] = {
++	C(P_UNIPHY1_TX, 12.5, 0, 0),
++	C(P_UNIPHY0_TX, 5, 0, 0),
++};
++
++static const struct freq_conf ftbl_nss_port5_tx_clk_src_125[] = {
++	C(P_UNIPHY1_TX, 2.5, 0, 0),
++	C(P_UNIPHY0_TX, 1, 0, 0),
++};
++
++static const struct freq_multi_tbl ftbl_nss_port5_tx_clk_src[] = {
++	FMS(24000000, P_XO, 1, 0, 0),
++	FM(25000000, ftbl_nss_port5_tx_clk_src_25),
++	FMS(78125000, P_UNIPHY1_TX, 4, 0, 0),
++	FM(125000000, ftbl_nss_port5_tx_clk_src_125),
++	FMS(156250000, P_UNIPHY1_TX, 2, 0, 0),
++	FMS(312500000, P_UNIPHY1_TX, 1, 0, 0),
+ 	{ }
+ };
+ 
+@@ -594,14 +610,14 @@ gcc_xo_uniphy0_tx_rx_uniphy1_tx_rx_ubi32
+ 
+ static struct clk_rcg2 nss_port5_tx_clk_src = {
+ 	.cmd_rcgr = 0x68068,
+-	.freq_tbl = ftbl_nss_port5_tx_clk_src,
++	.freq_multi_tbl = ftbl_nss_port5_tx_clk_src,
+ 	.hid_width = 5,
+ 	.parent_map = gcc_xo_uniphy0_tx_rx_uniphy1_tx_rx_ubi32_bias_map,
+ 	.clkr.hw.init = &(struct clk_init_data){
+ 		.name = "nss_port5_tx_clk_src",
+ 		.parent_data = gcc_xo_uniphy0_tx_rx_uniphy1_tx_rx_ubi32_bias,
+ 		.num_parents = 7,
+-		.ops = &clk_rcg2_ops,
++		.ops = &clk_rcg2_fm_ops,
+ 	},
+ };
+ 

--- a/target/linux/qualcommax/patches-6.12/0904-clk-qcom-ipq6018-workaround-networking-clock-parenti.patch
+++ b/target/linux/qualcommax/patches-6.12/0904-clk-qcom-ipq6018-workaround-networking-clock-parenti.patch
@@ -28,7 +28,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  	{ .hw = &gpll0.clkr.hw },
  	{ .hw = &gpll4.clkr.hw },
  	{ .hw = &nss_crypto_pll.clkr.hw },
-@@ -526,12 +526,12 @@ static const struct freq_tbl ftbl_nss_po
+@@ -534,12 +534,12 @@ static const struct freq_multi_tbl ftbl_
  static const struct clk_parent_data
  gcc_xo_uniphy0_rx_tx_uniphy1_rx_tx_ubi32_bias[] = {
  	{ .fw_name = "xo" },
@@ -46,7 +46,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  };
  
  static const struct parent_map
-@@ -573,12 +573,12 @@ static const struct freq_tbl ftbl_nss_po
+@@ -589,12 +589,12 @@ static const struct freq_multi_tbl ftbl_
  static const struct clk_parent_data
  gcc_xo_uniphy0_tx_rx_uniphy1_tx_rx_ubi32_bias[] = {
  	{ .fw_name = "xo" },
@@ -64,7 +64,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  };
  
  static const struct parent_map
-@@ -714,10 +714,10 @@ static const struct freq_tbl ftbl_nss_po
+@@ -730,10 +730,10 @@ static const struct freq_tbl ftbl_nss_po
  
  static const struct clk_parent_data gcc_xo_uniphy0_rx_tx_ubi32_bias[] = {
  	{ .fw_name = "xo" },
@@ -78,7 +78,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  };
  
  static const struct parent_map gcc_xo_uniphy0_rx_tx_ubi32_bias_map[] = {
-@@ -750,10 +750,10 @@ static const struct freq_tbl ftbl_nss_po
+@@ -766,10 +766,10 @@ static const struct freq_tbl ftbl_nss_po
  
  static const struct clk_parent_data gcc_xo_uniphy0_tx_rx_ubi32_bias[] = {
  	{ .fw_name = "xo" },
@@ -92,7 +92,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  };
  
  static const struct parent_map gcc_xo_uniphy0_tx_rx_ubi32_bias_map[] = {
-@@ -1899,12 +1899,11 @@ static const struct freq_tbl ftbl_ubi32_
+@@ -1915,12 +1915,11 @@ static const struct freq_tbl ftbl_ubi32_
  	{ }
  };
  


### PR DESCRIPTION
This is a port of the gcc-ipq8074 patch https://lore.kernel.org/all/20231220221724.3822-4-ansuelsmth@gmail.com/ to the ipq6018 SoC.

This fixes intermittent `dmesg` errors of the following form:
```
nss_port5_rx_clk_src: rcg didn't update its configuration.
```
This was originally contributed by @JiaY-shi; see #14950 and https://forum.openwrt.org/t/qualcommax-nss-port5-rx-clk-src-rcg-didnt-update-its-configuration/232618/4.

I had this patch running for 31 days and 10 hours on my gl.Inet GL-AX1800 router with no issues. I just rebuilt and installed this version on the current OpenWrt version.