### PR TITLE
uboot-mvebu: update to version 2025.07

### DIFF
--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -8,10 +8,10 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
-PKG_VERSION:=2025.04
+PKG_VERSION:=2025.07
 PKG_RELEASE:=1
 
-PKG_HASH:=439d3bef296effd54130be6a731c5b118be7fddd7fcc663ccbc5fb18294d8718
+PKG_HASH:=0f933f6c5a426895bf306e93e6ac53c60870e4b54cda56d95211bec99e63bec7
 
 include $(INCLUDE_DIR)/u-boot.mk
 include $(INCLUDE_DIR)/package.mk

--- a/package/boot/uboot-mvebu/patches/102-arm-mvebu-add-support-for-MikroTik-RB5009UG-S-IN.patch
+++ b/package/boot/uboot-mvebu/patches/102-arm-mvebu-add-support-for-MikroTik-RB5009UG-S-IN.patch
@@ -31,7 +31,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -165,6 +165,7 @@ dtb-$(CONFIG_ARCH_MVEBU) +=			\
+@@ -172,6 +172,7 @@ dtb-$(CONFIG_ARCH_MVEBU) +=			\
  	armada-3720-uDPU.dtb			\
  	armada-7040-db-nand.dtb			\
  	armada-7040-db.dtb			\


### PR DESCRIPTION
Update package to the latest stable version.
All patches automatically refreshed.

----

Build-tested for all supported subtargets
Run-tested on Turris Omnia (cortexa9)
