### PR TITLE
mediatek: filogic: build initramfs.trx for ASUS RT-AX59U

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -317,7 +317,15 @@ define Device/asus_rt-ax59u
   DEVICE_DTS := mt7986a-asus-rt-ax59u
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  IMAGES := sysupgrade.bin
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  ARTIFACTS := initramfs.trx
+  ARTIFACT/initramfs.trx := append-image-stage initramfs-kernel.bin | \
+	uImage none | asus-trx -v 3 -n $$(DEVICE_MODEL)
 endef
 TARGET_DEVICES += asus_rt-ax59u
 


### PR DESCRIPTION
Currently one needs to resort to unofficial .trx file to perform first-time flashing using vendor's webUI on this router.

This PR aims at adding support for building this .trx file for ASUS RT-AX59U, the same way as it is done for RT-AX52 (I've actually just copied relevant lines).

Verified the file is being created on build:

<img width="1796" height="111" alt="image" src="https://github.com/user-attachments/assets/082a6eca-63e6-4b91-a176-05a48580513e" />

Didn't test the image, I'm a bit scared, I've just purchased this router and have no real hands-on experience with OpenWrt development.

