### PR TITLE
tools: gnulib: do not cache C standard option test results

### DIFF
--- a/tools/gnulib/patches/190-stdc-m4-no-cache.patch
+++ b/tools/gnulib/patches/190-stdc-m4-no-cache.patch
@@ -1,0 +1,59 @@
+--- a/m4/std-gnu11.m4
++++ b/m4/std-gnu11.m4
+@@ -185,8 +185,7 @@ AC_LANG_POP(C++)dnl
+ # else ACTION-IF-UNAVAILABLE.
+ AC_DEFUN([_AC_C_STD_TRY],
+ [AC_MSG_CHECKING([for $CC option to enable ]m4_translit($1, [c], [C])[ features])
+-AC_CACHE_VAL(ac_cv_prog_cc_$1,
+-[ac_cv_prog_cc_$1=no
++ac_cv_prog_cc_$1=no
+ ac_save_CC=$CC
+ AC_LANG_CONFTEST([AC_LANG_PROGRAM([$2], [$3])])
+ for ac_arg in '' $4
+@@ -197,7 +196,6 @@ do
+ done
+ rm -f conftest.$ac_ext
+ CC=$ac_save_CC
+-])# AC_CACHE_VAL
+ ac_prog_cc_stdc_options=
+ case "x$ac_cv_prog_cc_$1" in
+   x)
+@@ -523,8 +521,7 @@ fi
+ AC_DEFUN([_AC_CXX_STD_TRY],
+ [AC_MSG_CHECKING([for $CXX option to enable ]m4_translit(m4_translit($1, [x], [+]), [a-z], [A-Z])[ features])
+ AC_LANG_PUSH(C++)dnl
+-AC_CACHE_VAL(ac_cv_prog_cxx_$1,
+-[ac_cv_prog_cxx_$1=no
++ac_cv_prog_cxx_$1=no
+ ac_save_CXX=$CXX
+ AC_LANG_CONFTEST([AC_LANG_PROGRAM([$2], [$3])])
+ for ac_arg in '' $4
+@@ -535,7 +532,6 @@ do
+ done
+ rm -f conftest.$ac_ext
+ CXX=$ac_save_CXX
+-])# AC_CACHE_VAL
+ ac_prog_cxx_stdcxx_options=
+ case "x$ac_cv_prog_cxx_$1" in
+   x)
+--- a/m4/std-gnu23.m4
++++ b/m4/std-gnu23.m4
+@@ -696,8 +696,7 @@ AC_DEFUN([_AC_PROG_CC_STDC_EDITION_TRY],
+ [AC_REQUIRE([_AC_C_C$1_TEST_PROGRAM])]dnl
+ [AS_IF([test x$ac_prog_cc_stdc = xno],
+ [AC_MSG_CHECKING([for $CC option to enable C$1 features])
+-AC_CACHE_VAL([ac_cv_prog_cc_c$1],
+-[ac_cv_prog_cc_c$1=no
++ac_cv_prog_cc_c$1=no
+ ac_save_CC=$CC
+ AC_LANG_CONFTEST([AC_LANG_DEFINES_PROVIDED][$][ac_c_conftest_c$1_program])
+ for ac_arg in '' m4_normalize(m4_defn([_AC_C_C$1_OPTIONS]))
+@@ -707,7 +706,7 @@ do
+   test "x$ac_cv_prog_cc_c$1" != "xno" && break
+ done
+ rm -f conftest.$ac_ext
+-CC=$ac_save_CC])
++CC=$ac_save_CC
+ AS_IF([test "x$ac_cv_prog_cc_c$1" = xno],
+   [AC_MSG_RESULT([unsupported])],
+   [AS_IF([test "x$ac_cv_prog_cc_c$1" = x],


### PR DESCRIPTION
@httpstorm @robimarko fixing the most unusual regression from #16522 

After eliminating the possibility of automake having a bug by testing a revert to the recent updates to automake, the problems regarding autoreconf with some packages was bisected to the gnulib update instead, through aclocal macros.

With the new module, std-gnu23, some packages are failing build due to both the host compiler and cross compiler being tested for availability of C23 standard features with the configure script. The results of one is being cached and used for the other, while the two compilers are different versions and may or may not both support C23 options and would otherwise have conflicting results.

Creating unique variables for each compiler tested is a difficult task and may require a much larger patch, therefore, just remove the caching.

A similar patch may have to be done
for the next release of Autoconf
if upstream GNU does not accept this solution.