### PR TITLE
ramips: mt7620: dwr92x: add 464xlat pkg

### DIFF
--- a/target/linux/ramips/image/mt7620.mk
+++ b/target/linux/ramips/image/mt7620.mk
@@ -318,7 +318,7 @@ define Device/dlink_dwr-921-c1
   DLINK_ROM_ID := DLK6E2414001
   DLINK_FAMILY_MEMBER := 0x6E24
   DLINK_FIRMWARE_SIZE := 0xFE0000
-  DEVICE_PACKAGES += kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+  DEVICE_PACKAGES += kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi 464xlat
 endef
 TARGET_DEVICES += dlink_dwr-921-c1
 


### PR DESCRIPTION
Add package 464xlat to fix error
"Failed to load config file: : Parse error (invalid command) at line 59, byte 1" when restart the lte with IPv6 configuration.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
