### PR TITLE
 kernel: modules: netdevices: Add kmod-sfc-siena for Solarflare SFN5000/6000 series NICs

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -2071,6 +2071,27 @@ endef
 $(eval $(call KernelPackage,sfc-falcon))
 
 
+define KernelPackage/sfc-siena
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Solarflare SFN5000/6000 'Siena' based card support
+  DEPENDS:=@PCI_SUPPORT +kmod-mdio +kmod-lib-crc32c +kmod-i2c-algo-bit +kmod-ptp +kmod-hwmon-core
+  KCONFIG:= \
+	CONFIG_SFC_SIENA \
+	CONFIG_SFC_SIENA_MTD=y \
+	CONFIG_SFC_SIENA_MCDI_MON=y \
+	CONFIG_SFC_SIENA_MCDI_LOGGING=y \
+	CONFIG_SFC_SIENA_SRIOV=y
+  FILES:=$(LINUX_DIR)/drivers/net/ethernet/sfc/siena/sfc-siena.ko
+  AUTOLOAD:=$(call AutoProbe,sfc-siena)
+endef
+
+define KernelPackage/sfc-siena/description
+  Solarflare SFN5000/6000 'Siena' based card support
+endef
+
+$(eval $(call KernelPackage,sfc-siena))
+
+
 define KernelPackage/wwan
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=WWAN Driver Core

--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -97,6 +97,9 @@ sophos-sg-135r3|sophos-xg-135r3| \
 sophos-sg-135wr3|sophos-xg-135wr3)
 	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth5 eth7 eth8" "eth6"
 	;;
+sophos-xg-210r3)
+	ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5 eth6 eth7" "eth0"
+	;;
 supermicro-sys-e302-9d)
 	ucidef_set_interface_lan "eth0 eth1 eth2 eth3 eth4 eth5 eth6 eth7"
 	;;


### PR DESCRIPTION
kmod-sfc should add support for Solarflare SFC9000 series based cards. However after kernel 5.19, support for the 'Siena' subclass of SFN5000/6000 devices has been separated out since they went EOL as they are no longer being actively developed. As kmod-sfc no longer provides driver support for these cards and hasn't since kernel 5.2, a new kernel module is needed to support these 10Gb Ethernet cards. More info here: https://cateee.net/lkddb/web-lkddb/SFC_SIENA.html and here: https://www.phoronix.com/news/Solarflare-SFC-Siena-Linux-5.19

The module can be compiled in separately and works if kernel is custom compiled;

OpenWRT has made these changes already with the SFC 'falcon' subclass of drivers already. See [3c5d70a](https://github.com/openwrt/openwrt/commit/3c5d70ad26ed8ba54b558bbfbceaedee5d9a1ca5) and [e5ba6e9](https://github.com/openwrt/openwrt/commit/e5ba6e9c28ad3ee8624a5df0e056cffead765779)

This is building on excellent work by @ynezz and @nasbdh9