### PR TITLE
sunxi: add FIT support and enable initramfs builds

### DIFF
--- a/package/boot/uboot-sunxi/uEnv-a64.txt
+++ b/package/boot/uboot-sunxi/uEnv-a64.txt
@@ -1,7 +1,6 @@
 setenv mmc_rootpart 2
 part uuid mmc ${mmc_bootdev}:${mmc_rootpart} uuid
-setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_addr_r uImage
-setenv loaddtb fatload mmc \$mmc_bootdev \$fdt_addr_r dtb
+setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_comp_addr_r uImage
 setenv bootargs console=ttyS0,115200 earlyprintk root=PARTUUID=${uuid} rootwait earlycon=uart,mmio32,0x01c28000
-setenv uenvcmd run loadkernel \&\& run loaddtb \&\& booti \$kernel_addr_r - \$fdt_addr_r
+setenv uenvcmd run loadkernel \&\& bootm \$kernel_comp_addr_r
 run uenvcmd

--- a/package/boot/uboot-sunxi/uEnv-default.txt
+++ b/package/boot/uboot-sunxi/uEnv-default.txt
@@ -1,8 +1,6 @@
-setenv fdt_high ffffffff
 setenv mmc_rootpart 2
 part uuid mmc ${mmc_bootdev}:${mmc_rootpart} uuid
 setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_addr_r uImage
-setenv loaddtb fatload mmc \$mmc_bootdev \$fdt_addr_r dtb
 setenv bootargs console=ttyS0,115200 earlyprintk root=PARTUUID=${uuid} rootwait
-setenv uenvcmd run loadkernel \&\& run loaddtb \&\& bootm \$kernel_addr_r - \$fdt_addr_r
+setenv uenvcmd run loadkernel \&\& bootm \$kernel_addr_r
 run uenvcmd

--- a/package/boot/uboot-sunxi/uEnv-h6.txt
+++ b/package/boot/uboot-sunxi/uEnv-h6.txt
@@ -1,7 +1,6 @@
 setenv mmc_rootpart 2
 part uuid mmc ${mmc_bootdev}:${mmc_rootpart} uuid
-setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_addr_r uImage
-setenv loaddtb fatload mmc \$mmc_bootdev \$fdt_addr_r dtb
+setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_comp_addr_r uImage
 setenv bootargs console=ttyS0,115200 earlyprintk root=PARTUUID=${uuid} rootwait
-setenv uenvcmd run loadkernel \&\& run loaddtb \&\& booti \$kernel_addr_r - \$fdt_addr_r
+setenv uenvcmd run loadkernel \&\& bootm \$kernel_comp_addr_r
 run uenvcmd

--- a/package/boot/uboot-sunxi/uEnv-h616.txt
+++ b/package/boot/uboot-sunxi/uEnv-h616.txt
@@ -1,7 +1,6 @@
 setenv mmc_rootpart 2
 part uuid mmc ${mmc_bootdev}:${mmc_rootpart} uuid
-setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_addr_r uImage
-setenv loaddtb fatload mmc \$mmc_bootdev \$fdt_addr_r dtb
+setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_comp_addr_r uImage
 setenv bootargs console=ttyS0,115200 earlyprintk root=PARTUUID=${uuid} rootwait
-setenv uenvcmd run loadkernel \&\& run loaddtb \&\& booti \$kernel_addr_r - \$fdt_addr_r
+setenv uenvcmd run loadkernel \&\& bootm \$kernel_comp_addr_r
 run uenvcmd

--- a/package/boot/uboot-sunxi/uEnv-pangolin.txt
+++ b/package/boot/uboot-sunxi/uEnv-pangolin.txt
@@ -1,6 +1,4 @@
-setenv fdt_high ffffffff
 setenv loadkernel fatload mmc 0 \$kernel_addr_r uImage
-setenv loaddtb fatload mmc 0 \$fdt_addr_r dtb
 setenv bootargs console=ttyS2,115200 earlyprintk root=/dev/mmcblk0p2 rootwait
-setenv uenvcmd run loadkernel \&\& run loaddtb \&\& bootm \$kernel_addr_r - \$fdt_addr_r
+setenv uenvcmd run loadkernel \&\& run loaddtb \&\& bootm \$kernel_addr_r
 run uenvcmd

--- a/target/linux/sunxi/Makefile
+++ b/target/linux/sunxi/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=sunxi
 BOARDNAME:=Allwinner ARM SoCs
-FEATURES:=ext4 display rootfs-part rtc squashfs usb usbgadget
+FEATURES:=ext4 display ramdisk rootfs-part rtc squashfs usb usbgadget
 SUBTARGETS:=cortexa8 cortexa7 cortexa53
 
 KERNEL_PATCHVER:=6.12

--- a/target/linux/sunxi/image/Makefile
+++ b/target/linux/sunxi/image/Makefile
@@ -16,7 +16,6 @@ define Build/sunxi-sdcard
 	mkfs.fat $@.boot -C $(FAT32_BLOCKS)
 
 	mcopy -i $@.boot $(STAGING_DIR_IMAGE)/$(DEVICE_NAME)-boot.scr ::boot.scr
-	mcopy -i $@.boot $(DTS_DIR)/$(SUNXI_DTS).dtb ::dtb
 	mcopy -i $@.boot $(IMAGE_KERNEL) ::uImage
 	./gen_sunxi_sdcard_img.sh $@ \
 		$@.boot \
@@ -34,8 +33,16 @@ define Device/Default
   KERNEL := kernel-bin | uImage none
   IMAGES := sdcard.img.gz
   IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | gzip
-  SUNXI_DTS_DIR :=allwinner/
+  SUNXI_DTS_DIR := allwinner/
   SUNXI_DTS = $$(SUNXI_DTS_DIR)$$(SOC)-$(lastword $(subst _, ,$(1)))
+endef
+
+define Device/FitImageLzma
+  KERNEL = kernel-bin | lzma | fit lzma $$(DTS_DIR)/$$(SUNXI_DTS).dtb
+endef
+
+define Device/FitImageGzip
+  KERNEL = kernel-bin | gzip | fit gzip $$(DTS_DIR)/$$(SUNXI_DTS).dtb
 endef
 
 include $(SUBTARGET).mk

--- a/target/linux/sunxi/image/cortexa53.mk
+++ b/target/linux/sunxi/image/cortexa53.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2013-2016 OpenWrt.org
 # Copyright (C) 2016 Yousong Zhou
 
-KERNEL_LOADADDR:=0x40008000
+KERNEL_LOADADDR:=0x40080000
 
 define Device/sun50i
+  $(call Device/FitImageLzma)
   SUNXI_DTS_DIR := allwinner/
   KERNEL_NAME := Image
-  KERNEL := kernel-bin
 endef
 
 define Device/sun50i-a64

--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -6,6 +6,7 @@
 KERNEL_LOADADDR:=0x40008000
 
 define Device/cubietech_cubieboard2
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubieboard2
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
@@ -14,6 +15,7 @@ endef
 TARGET_DEVICES += cubietech_cubieboard2
 
 define Device/cubietech_cubietruck
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubietruck
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi kmod-brcmfmac
@@ -22,6 +24,7 @@ endef
 TARGET_DEVICES += cubietech_cubietruck
 
 define Device/friendlyarm_nanopi-m1-plus
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi M1 Plus
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
@@ -31,6 +34,7 @@ endef
 TARGET_DEVICES += friendlyarm_nanopi-m1-plus
 
 define Device/friendlyarm_nanopi-neo
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO
   SOC := sun8i-h3
@@ -38,6 +42,7 @@ endef
 TARGET_DEVICES += friendlyarm_nanopi-neo
 
 define Device/friendlyarm_nanopi-neo-air
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO Air
   DEVICE_PACKAGES := kmod-leds-gpio kmod-brcmfmac \
@@ -47,6 +52,7 @@ endef
 TARGET_DEVICES += friendlyarm_nanopi-neo-air
 
 define Device/friendlyarm_nanopi-r1
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R1
   DEVICE_PACKAGES := kmod-usb-net-rtl8152 kmod-leds-gpio \
@@ -56,6 +62,7 @@ endef
 TARGET_DEVICES += friendlyarm_nanopi-r1
 
 define Device/friendlyarm_zeropi
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := ZeroPi
   DEVICE_PACKAGES := kmod-rtc-sunxi
@@ -64,6 +71,7 @@ endef
 TARGET_DEVICES += friendlyarm_zeropi
 
 define Device/lamobo_lamobo-r1
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Lamobo
   DEVICE_MODEL := Lamobo R1
   DEVICE_ALT0_VENDOR := Bananapi
@@ -76,6 +84,7 @@ endef
 TARGET_DEVICES += lamobo_lamobo-r1
 
 define Device/lemaker_bananapi
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pi
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi
@@ -84,6 +93,7 @@ endef
 TARGET_DEVICES += lemaker_bananapi
 
 define Device/sinovoip_bananapi-m2-berry
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Berry
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
@@ -94,6 +104,7 @@ endef
 TARGET_DEVICES += sinovoip_bananapi-m2-berry
 
 define Device/sinovoip_bananapi-m2-ultra
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Ultra
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
@@ -104,6 +115,7 @@ endef
 TARGET_DEVICES += sinovoip_bananapi-m2-ultra
 
 define Device/lemaker_bananapro
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pro
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi kmod-brcmfmac \
@@ -113,6 +125,7 @@ endef
 TARGET_DEVICES += lemaker_bananapro
 
 define Device/licheepi_licheepi-zero-dock
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LicheePi
   DEVICE_MODEL := Zero with Dock (V3s)
   DEVICE_PACKAGES:=kmod-rtc-sunxi
@@ -121,6 +134,7 @@ endef
 TARGET_DEVICES += licheepi_licheepi-zero-dock
 
 define Device/linksprite_pcduino3
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino3
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtc-sunxi kmod-ata-sunxi kmod-rtl8xxxu \
@@ -130,6 +144,7 @@ endef
 TARGET_DEVICES += linksprite_pcduino3
 
 define Device/linksprite_pcduino3-nano
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino3 Nano
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi
@@ -138,6 +153,7 @@ endef
 TARGET_DEVICES += linksprite_pcduino3-nano
 
 define Device/mele_m9
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Mele
   DEVICE_MODEL := M9
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtl8192cu
@@ -146,6 +162,7 @@ endef
 TARGET_DEVICES += mele_m9
 
 define Device/merrii_hummingbird
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Merrii
   DEVICE_MODEL := Hummingbird
   DEVICE_PACKAGES:=kmod-brcmfmac cypress-firmware-43362-sdio wpad-basic-mbedtls
@@ -154,6 +171,7 @@ endef
 TARGET_DEVICES += merrii_hummingbird
 
 define Device/olimex_a20-olinuxino-lime
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi
@@ -162,6 +180,7 @@ endef
 TARGET_DEVICES += olimex_a20-olinuxino-lime
 
 define Device/olimex_a20-olinuxino-lime2
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME2
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi kmod-usb-hid
@@ -170,6 +189,7 @@ endef
 TARGET_DEVICES += olimex_a20-olinuxino-lime2
 
 define Device/olimex_a20-olinuxino-lime2-emmc
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME2
   DEVICE_VARIANT := eMMC
@@ -179,6 +199,7 @@ endef
 TARGET_DEVICES += olimex_a20-olinuxino-lime2-emmc
 
 define Device/olimex_a20-olinuxino-micro
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-MICRO
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
@@ -187,6 +208,7 @@ endef
 TARGET_DEVICES += olimex_a20-olinuxino-micro
 
 define Device/roofull_beelink-x2
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Roofull
   DEVICE_MODEL := Beelink-X2
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-gpio-button-hotplug \
@@ -196,6 +218,7 @@ endef
 TARGET_DEVICES += roofull_beelink-x2
 
 define Device/sinovoip_bananapi-m2-plus
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2+
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
@@ -205,6 +228,7 @@ endef
 TARGET_DEVICES += sinovoip_bananapi-m2-plus
 
 define Device/sinovoip_bananapi-m3
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M3
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-leds-gpio kmod-rtc-ac100 \
@@ -214,6 +238,7 @@ endef
 TARGET_DEVICES += sinovoip_bananapi-m3
 
 define Device/sinovoip_bananapi-p2-zero
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi P2 Zero
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
@@ -223,6 +248,7 @@ endef
 TARGET_DEVICES += sinovoip_bananapi-p2-zero
 
 define Device/xunlong_orangepi-one
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi One
   DEVICE_PACKAGES:=kmod-rtc-sunxi
@@ -231,6 +257,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-one
 
 define Device/xunlong_orangepi-pc
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC
   DEVICE_PACKAGES:=kmod-gpio-button-hotplug
@@ -239,6 +266,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-pc
 
 define Device/xunlong_orangepi-pc-plus
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC Plus
   DEVICE_PACKAGES:=kmod-gpio-button-hotplug
@@ -247,6 +275,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-pc-plus
 
 define Device/xunlong_orangepi-plus
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Plus
   DEVICE_PACKAGES:=kmod-rtc-sunxi
@@ -255,6 +284,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-plus
 
 define Device/xunlong_orangepi-r1
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi R1
   DEVICE_PACKAGES:=kmod-usb-net-rtl8152
@@ -263,6 +293,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-r1
 
 define Device/xunlong_orangepi-zero
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Zero
   DEVICE_PACKAGES:=kmod-rtc-sunxi
@@ -271,6 +302,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-zero
 
 define Device/xunlong_orangepi-2
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi 2
   DEVICE_PACKAGES:=kmod-rtc-sunxi

--- a/target/linux/sunxi/image/cortexa8.mk
+++ b/target/linux/sunxi/image/cortexa8.mk
@@ -6,6 +6,7 @@
 KERNEL_LOADADDR:=0x40008000
 
 define Device/cubietech_a10-cubieboard
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubieboard
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
@@ -14,6 +15,7 @@ endef
 TARGET_DEVICES += cubietech_a10-cubieboard
 
 define Device/haoyu_a10-marsboard
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := HAOYU Electronics
   DEVICE_MODEL := MarsBoard A10
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac \
@@ -24,6 +26,7 @@ endef
 TARGET_DEVICES += haoyu_a10-marsboard
 
 define Device/linksprite_a10-pcduino
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtc-sunxi kmod-rtl8192cu
@@ -32,6 +35,7 @@ endef
 TARGET_DEVICES += linksprite_a10-pcduino
 
 define Device/olimex_a10-olinuxino-lime
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A10-OLinuXino-LIME
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
@@ -40,6 +44,7 @@ endef
 TARGET_DEVICES += olimex_a10-olinuxino-lime
 
 define Device/olimex_a13-olimex-som
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A13-SOM
   DEVICE_PACKAGES:=kmod-rtl8192cu
@@ -50,6 +55,7 @@ endef
 TARGET_DEVICES += olimex_a13-olimex-som
 
 define Device/olimex_a13-olinuxino
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A13-OLinuXino
   DEVICE_PACKAGES:=kmod-rtl8192cu


### PR DESCRIPTION
Modernize the target slightly to use kernel+dtb FIT images in all
subtargets. LZMA compression will be used for the cortexa53 devices,
and we'll stay conservative and use gzip for the cortexa7/a8 devices
due to performance differences.

Also enable initramfs builds.