### PR TITLE
realtek: use lzma recipe for TP-Link TL-ST1008F v2.0

### DIFF
--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -26,6 +26,7 @@ define Device/tplink_tl-st1008f_v2
   DEVICE_VARIANT := v2.0
   DEVICE_PACKAGES := kmod-gpio-pca953x
   IMAGE_SIZE := 31808k
+  $(Device/kernel-lzma)
 endef
 TARGET_DEVICES += tplink_tl-st1008f_v2
 


### PR DESCRIPTION
Use the lzma recipe for the device for both initramfs and sysupgrade to save some flash space due to smaller image. U-Boot build on this device has native lzma support.

As discussed in #19651.
