### PR TITLE
realtek: rtl930x: move serdes functions over to mdio bus

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
@@ -456,4 +456,7 @@ int phy_port_write_paged(struct phy_device *phydev, int port, int page, u32 regn
 int rtmdio_838x_read_phy(u32 port, u32 page, u32 reg, u32 *val);
 int rtmdio_838x_write_phy(u32 port, u32 page, u32 reg, u32 val);
 
+int rtmdio_930x_read_sds_phy(int sds, int page, int regnum);
+int rtmdio_930x_write_sds_phy(int sds, int page, int regnum, u16 val);
+
 #endif /* _RTL838X_ETH_H */

--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.h
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.h
@@ -57,8 +57,6 @@ struct __attribute__ ((__packed__)) fw_header {
 #define RTL839X_SDS12_13_XSG0			(0xB800)
 
 /* Registers of the internal Serdes of the 9300 */
-#define RTL930X_SDS_INDACS_CMD			(0x03B0)
-#define RTL930X_SDS_INDACS_DATA			(0x03B4)
 #define RTL930X_MAC_FORCE_MODE_CTRL		(0xCA1C)
 
 /* Registers of the internal SerDes of the 9310 */
@@ -69,8 +67,6 @@ struct __attribute__ ((__packed__)) fw_header {
 #define RTL931X_MAC_SERDES_MODE_CTRL(sds)	(0x136C + (((sds) << 2)))
 
 int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode);
-int rtl930x_read_sds_phy(int phy_addr, int page, int phy_reg);
-int rtl930x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v);
 
 int rtl931x_read_sds_phy(int phy_addr, int page, int phy_reg);
 int rtl931x_write_sds_phy(int phy_addr, int page, int phy_reg, u16 v);


### PR DESCRIPTION
The migration of the RTL930x mdio/serdes access functions over to the mdio bus is a little more complicated than for RTL83xx. There are several places where the serdes is accessed directly. So do it in two steps. With this first step:

- use the rtmdio prefix for the serdes reader/writer functions
- move the functions over to the bus (inside the ethernet driver)
- Adapt all callers.

This is not only a copy/paste but the serdes access will be hardened too. For this:

- put a mutex around the read/write functions because we have only indirect register access through a mdio style bus.
- Verify input values to avoid data mess.