### PR TITLE
ath79: fix LED GPIOs for COMFAST CF-EW71 v2

### DIFF
--- a/target/linux/ath79/dts/qca9531_comfast_cf-ew71-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-ew71-v2.dts
@@ -32,13 +32,13 @@
 		led_wan: wan {
 			function = LED_FUNCTION_WAN;
 			color = <LED_COLOR_ID_BLUE>;
-			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
 		};
 
 		wlan {
 			function = LED_FUNCTION_WLAN;
 			color = <LED_COLOR_ID_BLUE>;
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 	};


### PR DESCRIPTION
The vendor DTS defined incorrect GPIOs for the LEDs, which caused them to not function properly. Initially, the WAN, WLAN LEDs appeared to work, but further testing showed that they were non-functional.

This patch corrects the GPIO assignments in the DTS, restoring full LED functionality including blinking, except the power LED which cannot be software controlled.

Tested on a CF-EW71 v2 unit.
