### PR TITLE
WIP: realtek: rtl93xx: Enable port based isolation

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1114,6 +1114,7 @@ struct rtl838x_switch_priv {
 	struct rtl838x_l3_intf *interfaces[MAX_INTERFACES];
 	u16 intf_mtus[MAX_INTF_MTUS];
 	int intf_mtu_count[MAX_INTF_MTUS];
+	u64 isolated_ports;
 };
 
 void rtl838x_dbgfs_init(struct rtl838x_switch_priv *priv);


### PR DESCRIPTION
In RTL93XX traffic_enable and disable uses the port_isolation table (PORT_ISO_CTRL).

It is therefore logical to reuse enable and disable to implement port isolation.

Care is also take that the feature is only enabled for the intended chips and other chips are unaffected.
