### PR TITLE
realtek: rtl930x: convert Hasivo S1100W to lzma only.

### DIFF
--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -10,11 +10,7 @@ define Device/hasivo_s1100w-8xgt-se
   DEVICE_VENDOR := Hasivo
   DEVICE_MODEL := S1100W-8XGT-SE
   IMAGE_SIZE := 12288k
-  KERNEL_INITRAMFS := \
-	kernel-bin | \
-	append-dtb | \
-	lzma | \
-	uImage lzma
+  $(Device/kernel-lzma)
 endef
 TARGET_DEVICES += hasivo_s1100w-8xgt-se
 


### PR DESCRIPTION
The current build recipe creates a lzma based initramfs and a gzip based sysupgrade (installation) image. No need to use different compression methods. Use lzma for both.