### PR TITLE
ead: replace legacy RETSIGTYPE with void in signal handler

### DIFF
--- a/package/network/services/ead/src/tinysrp/t_getpass.c
+++ b/package/network/services/ead/src/tinysrp/t_getpass.c
@@ -44,7 +44,7 @@ static  struct  sigaction sigact;
 #endif
 
 /*ARGSUSED*/
-static RETSIGTYPE
+static void
 sig_catch (sig)
 int     sig;
 {


### PR DESCRIPTION
The RETSIGTYPE macro was historically used for signal handler return types, defaulting to int on some legacy systems. This is no longer needed, so we now use void as the return type.

Fixes a compiler error:
  error: assignment to 'void (*)(int)' from incompatible pointer type 'int (*)()' [-Wincompatible-pointer-types]

