### PR TITLE
realtek: dsa: rename tagged_ports to member_ports

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -155,9 +155,9 @@ static void rtl838x_vlan_tables_read(u32 vlan, struct rtl838x_vlan_info *info)
 	struct table_reg *r = rtl_table_get(RTL8380_TBL_0, 0);
 
 	rtl_table_read(r, vlan);
-	info->tagged_ports = sw_r32(rtl_table_data(r, 0));
+	info->member_ports = sw_r32(rtl_table_data(r, 0));
 	v = sw_r32(rtl_table_data(r, 1));
-	pr_debug("VLAN_READ %d: %016llx %08x\n", vlan, info->tagged_ports, v);
+	pr_debug("VLAN_READ %d: %016llx %08x\n", vlan, info->member_ports, v);
 	rtl_table_release(r);
 
 	info->profile_id = v & 0x7;
@@ -178,7 +178,7 @@ static void rtl838x_vlan_set_tagged(u32 vlan, struct rtl838x_vlan_info *info)
 	/* Access VLAN table (0) via register 0 */
 	struct table_reg *r = rtl_table_get(RTL8380_TBL_0, 0);
 
-	sw_w32(info->tagged_ports, rtl_table_data(r, 0));
+	sw_w32(info->member_ports, rtl_table_data(r, 0));
 
 	v = info->profile_id;
 	v |= info->hash_mc_fid ? 0x8 : 0;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -709,7 +709,7 @@ struct rtl838x_pcs {
 
 struct rtl838x_vlan_info {
 	u64 untagged_ports;
-	u64 tagged_ports;
+	u64 member_ports;
 	u8 profile_id;
 	bool hash_mc_fid;
 	bool hash_uc_fid;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -172,8 +172,8 @@ static void rtl839x_vlan_tables_read(u32 vlan, struct rtl838x_vlan_info *info)
 	w = sw_r32(rtl_table_data(r, 2));
 	rtl_table_release(r);
 
-	info->tagged_ports = u;
-	info->tagged_ports = (info->tagged_ports << 21) | ((v >> 11) & 0x1fffff);
+	info->member_ports = u;
+	info->member_ports = (info->member_ports << 21) | ((v >> 11) & 0x1fffff);
 	info->profile_id = w >> 30 | ((v & 1) << 2);
 	info->hash_mc_fid = !!(w & BIT(2));
 	info->hash_uc_fid = !!(w & BIT(3));
@@ -196,8 +196,8 @@ static void rtl839x_vlan_set_tagged(u32 vlan, struct rtl838x_vlan_info *info)
 	/* Access VLAN table (0) via register 0 */
 	struct table_reg *r = rtl_table_get(RTL8390_TBL_0, 0);
 
-	u = info->tagged_ports >> 21;
-	v = info->tagged_ports << 11;
+	u = info->member_ports >> 21;
+	v = info->member_ports << 11;
 	v |= ((u32)info->fid) << 3;
 	v |= info->hash_uc_fid ? BIT(2) : 0;
 	v |= info->hash_mc_fid ? BIT(1) : 0;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -184,7 +184,7 @@ static void rtl930x_vlan_tables_read(u32 vlan, struct rtl838x_vlan_info *info)
 	pr_debug("VLAN_READ %d: %08x %08x\n", vlan, v, w);
 	rtl_table_release(r);
 
-	info->tagged_ports = v >> 3;
+	info->member_ports = v >> 3;
 	info->profile_id = (w >> 24) & 7;
 	info->hash_mc_fid = !!(w & BIT(27));
 	info->hash_uc_fid = !!(w & BIT(28));
@@ -205,7 +205,7 @@ static void rtl930x_vlan_set_tagged(u32 vlan, struct rtl838x_vlan_info *info)
 	/* Access VLAN table (1) via register 0 */
 	struct table_reg *r = rtl_table_get(RTL9300_TBL_0, 1);
 
-	v = info->tagged_ports << 3;
+	v = info->member_ports << 3;
 	v |= ((u32)info->fid) >> 3;
 
 	w = ((u32)info->fid) << 29;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -198,7 +198,7 @@ static void rtl931x_vlan_tables_read(u32 vlan, struct rtl838x_vlan_info *info)
 	rtl_table_release(r);
 
 	pr_debug("VLAN_READ %d: %08x %08x %08x %08x\n", vlan, v, w, x, y);
-	info->tagged_ports = ((u64) v) << 25 | (w >> 7);
+	info->member_ports = ((u64) v) << 25 | (w >> 7);
 	info->profile_id = (x >> 16) & 0xf;
 	info->fid = w & 0x7f;				/* AKA MSTI depending on context */
 	info->hash_uc_fid = !!(x & BIT(31));
@@ -209,8 +209,8 @@ static void rtl931x_vlan_tables_read(u32 vlan, struct rtl838x_vlan_info *info)
 		info->l2_tunnel_list_id = y >> 18;
 	else
 		info->l2_tunnel_list_id = -1;
-	pr_debug("%s read tagged %016llx, profile-id %d, uc %d, mc %d, intf-id %d\n", __func__,
-		info->tagged_ports, info->profile_id, info->hash_uc_fid, info->hash_mc_fid,
+	pr_debug("%s read member %016llx, profile-id %d, uc %d, mc %d, intf-id %d\n", __func__,
+		info->member_ports, info->profile_id, info->hash_uc_fid, info->hash_mc_fid,
 		info->if_id);
 
 	/* Read UNTAG table via table register 3 */
@@ -227,8 +227,8 @@ static void rtl931x_vlan_set_tagged(u32 vlan, struct rtl838x_vlan_info *info)
 	struct table_reg *r;
 	u32 v, w, x, y;
 
-	v = info->tagged_ports >> 25;
-	w = (info->tagged_ports & GENMASK(24, 0)) << 7;
+	v = info->member_ports >> 25;
+	w = (info->member_ports & GENMASK(24, 0)) << 7;
 	w |= info->fid & 0x7f;
 	x = info->hash_uc_fid ? BIT(31) : 0;
 	x |= info->hash_mc_fid ? BIT(30) : 0;


### PR DESCRIPTION
The current variables tagged_ports and untagged_ports suggest that these are distinct and describe only the ports in each of these configuration types.

That is wrong. The hardware is configured via member ports and untagged ports. The first one being a superset of the second. Rename the variables to reflect that.