### PR TITLE
gettext-full: force-enable stdalign.h support

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -93,6 +93,9 @@ CONFIGURE_ARGS += \
 	--with-libxml2-prefix=$(STAGING_DIR) \
 	--without-emacs
 
+CONFIGURE_VARS += \
+	ac_cv_header_stdalign_h=yes
+
 HOST_CONFIGURE_ARGS += \
 	--disable-shared \
 	--enable-static \


### PR DESCRIPTION
Add 'ac_cv_header_stdalign_h=yes' to CONFIGURE_VARS to override the configure check and ensure stdalign.h is always considered available. This fixes compilation errors related to alignof() in mbsstr.c when building with certain toolchains.
