### PR TITLE
realtek: switch Zyxel GS1900 initramfs recipe to rt-loader

### DIFF
--- a/target/linux/realtek/image/common.mk
+++ b/target/linux/realtek/image/common.mk
@@ -86,8 +86,9 @@ define Device/zyxel_gs1900
   KERNEL_INITRAMFS := \
 	kernel-bin | \
 	append-dtb | \
-	libdeflate-gzip | \
+	rt-compress | \
 	zyxel-vers | \
-	uImage gzip | \
+	rt-loader | \
+	uImage none | \
 	check-size 6976k
 endef


### PR DESCRIPTION
These devices need a tiny (<8MB) initramfs. There are first occurrences where this fails with newer kernels and diagnostic packages.

Switch the recipe over to use lzma compression and rt-loader.
