### PR TITLE
procd: procd.sh: remove invalid exec in procd_lock

### DIFF
--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=procd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/procd.git

--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -39,7 +39,6 @@
 # procd_send_signal(service, [instance], [signal])
 #   Send a signal to a service instance (or all instances)
 #
-
 . "$IPKG_INSTROOT/usr/share/libubox/jshn.sh"
 
 PROCD_RELOAD_DELAY=1000
@@ -49,13 +48,10 @@ procd_lock() {
 	local basescript=$(readlink "$initscript")
 	local service_name="$(basename ${basescript:-$initscript})"
 
-	flock -n 1000 &> /dev/null
+	exec 1000>"$IPKG_INSTROOT/var/lock/procd_${service_name}.lock"
+	flock -n 1000
 	if [ "$?" != "0" ]; then
-		exec 1000>"$IPKG_INSTROOT/var/lock/procd_${service_name}.lock"
-		flock 1000
-		if [ "$?" != "0" ]; then
-			logger "warning: procd flock for $service_name failed"
-		fi
+		logger "warning: procd flock for $service_name failed"
 	fi
 }
 


### PR DESCRIPTION
Avoid calling 'exec' with no arguments, which replaces the shell and halts init.d scripts mid-execution. Lock file is now correctly opened before flock is attempted, preventing service stop/start hangs.

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc