### PR TITLE
kernel: kmod-fs-nfs: add several feature and kmods

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -444,7 +444,7 @@ $(eval $(call KernelPackage,fs-nilfs2))
 define KernelPackage/fs-nfs
   SUBMENU:=$(FS_MENU)
   TITLE:=NFS filesystem client support
-  DEPENDS:=+kmod-fs-nfs-common +kmod-dnsresolver
+  DEPENDS:=+kmod-fs-nfs-common +kmod-dnsresolver +kmod-fs-netfs
   KCONFIG:= \
 	CONFIG_NFS_FS \
 	CONFIG_NFS_USE_LEGACY_DNS=n \
@@ -474,12 +474,21 @@ define KernelPackage/fs-nfs-common
 	CONFIG_NFS_V4_1_IMPLEMENTATION_ID_DOMAIN="kernel.org" \
 	CONFIG_NFS_V4_1_MIGRATION=n \
 	CONFIG_NFS_V4_2=y \
-	CONFIG_NFS_V4_2_READ_PLUS=n
+	CONFIG_NFS_V4_2_READ_PLUS=n \
+	CONFIG_NFS_V4_SECURITY_LABEL=y \
+	CONFIG_NFS_USE_KERNEL_DNS=y \
+	CONFIG_NFS_DEBUG=y \
+	CONFIG_NFS_COMMON_LOCALIO_SUPPORT=y \
+	CONFIG_NFS_LOCALIO=y \
+	CONFIG_NFS_V4_2_SSC_HELPER=y \
+	CONFIG_PNFS_BLOCK=n
+
   FILES:= \
 	$(LINUX_DIR)/fs/lockd/lockd.ko \
 	$(LINUX_DIR)/net/sunrpc/sunrpc.ko \
-	$(LINUX_DIR)/fs/nfs_common/grace.ko
-  AUTOLOAD:=$(call AutoLoad,30,grace sunrpc lockd)
+	$(LINUX_DIR)/fs/nfs_common/grace.ko \
+	$(LINUX_DIR)/fs/nfs_common/nfs_localio.ko
+  AUTOLOAD:=$(call AutoLoad,30,grace sunrpc lockd nfs_localio)
 endef
 
 $(eval $(call KernelPackage,fs-nfs-common))
@@ -557,12 +566,13 @@ define KernelPackage/fs-nfsd
   KCONFIG:= \
 	CONFIG_NFSD \
 	CONFIG_NFSD_V4=y \
-	CONFIG_NFSD_V4_SECURITY_LABEL=n \
+	CONFIG_NFSD_PNFS=y \
 	CONFIG_NFSD_BLOCKLAYOUT=n \
-	CONFIG_NFSD_SCSILAYOUT=n \
 	CONFIG_NFSD_FLEXFILELAYOUT=n \
-	CONFIG_NFSD_FAULT_INJECTION=n \
-	CONFIG_NFSD_V4_2_INTER_SSC=n
+	CONFIG_NFSD_SCSILAYOUT=y \
+	CONFIG_NFSD_V4_2_INTER_SSC=y \
+	CONFIG_NFSD_V4_SECURITY_LABEL=y
+
   FILES:=$(LINUX_DIR)/fs/nfsd/nfsd.ko
   AUTOLOAD:=$(call AutoLoad,40,nfsd)
 endef


### PR DESCRIPTION
This commit builds in support for some NFS features including:
* LOCALIO (useful for containerzied clients on the same system as the NFS server.
* NFSD_PNFS (allows for parallel access directly to storage, available for NFSv4.1+ servers).
* NFS_FSCACHE (speeds up some operations via caching of from remote mounts on the local disk).
* NFS_DEBUG (allow flexibility to help debug issues, simply load kmod and use rpcdebug to set flags via the -s swtich).

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc