### PR TITLE
modules: Add kmod-w1-slave-ds2438

### DIFF
--- a/package/kernel/linux/modules/w1.mk
+++ b/package/kernel/linux/modules/w1.mk
@@ -174,3 +174,19 @@ define KernelPackage/w1-slave-ds2413/description
 endef
 
 $(eval $(call KernelPackage,w1-slave-ds2413))
+
+
+define KernelPackage/w1-slave-ds2438
+  TITLE:=DS2438 Smart Battery Monitor
+  KCONFIG:= \
+       CONFIG_W1_SLAVE_DS2438
+  FILES:=$(W1_SLAVES_DIR)/w1_ds2438.ko
+  AUTOLOAD:=$(call AutoProbe,w1_ds2438)
+  $(call AddDepends/w1)
+endef
+
+define KernelPackage/w1-slave-ds2438/description
+ Kernel module for 1-wire DS2438 Smart Battery Monitor support
+endef
+
+$(eval $(call KernelPackage,w1-slave-ds2438))


### PR DESCRIPTION
This patch adds support for building the ds2438 one-wire kernel module.

I've been compiling this module for my humidity sensor since 19.07. I hope it can be added to the mainline.