### PR TITLE
siflower: sf21: fix usb_vbus for Bananapi BPI-RV2

### DIFF
--- a/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2.dtsi
+++ b/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2.dtsi
@@ -22,6 +22,16 @@
 		gpio = <&gpio 37 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
+
+	m2keyb_pwren: regulator@1 {
+		compatible = "regulator-fixed";
+		regulator-name = "m2keyb_pwren";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&gpio 38 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+	};
 };
 
 &spi0_pins {

--- a/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2.dtsi
+++ b/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2.dtsi
@@ -184,6 +184,7 @@
 };
 
 &usb {
+	vbus-supply = <&usb_vbus>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Add usb_vbus regulator ref to usb device.
