### PR TITLE
siflower: sf21: fix usb_vbus for Bananapi BPI-RV2

### DIFF
--- a/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2.dtsi
+++ b/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2.dtsi
@@ -194,6 +194,7 @@
 };
 
 &usb {
+	vbus-supply = <&usb_vbus>;
 	status = "okay";
 };
 


### PR DESCRIPTION
Add usb_vbus ref to usb device.
