### PR TITLE
siflower: riscv64: fix unaligned access for 64bit data

### DIFF
--- a/target/linux/generic/pending-6.6/352-riscv-introduce-ioremap_wc-pgprot_val.patch
+++ b/target/linux/generic/pending-6.6/352-riscv-introduce-ioremap_wc-pgprot_val.patch
@@ -1,0 +1,42 @@
+From 5ec6b493183c4706216347853d3446c36ed399d1 Mon Sep 17 00:00:00 2001
+From: Yunhui Cui <cuiyunhui@bytedance.com>
+Date: Tue, 22 Jul 2025 17:15:04 +0800
+Subject: riscv: introduce ioremap_wc()
+
+Compared with IO attributes, NC attributes can improve performance,
+specifically in these aspects: Relaxed Order, Gathering, Supports Read
+Speculation, Supports Unaligned Access.
+
+Signed-off-by: Yunhui Cui <cuiyunhui@bytedance.com>
+Signed-off-by: Qingfang Deng <qingfang.deng@siflower.com.cn>
+Reviewed-by: Alexandre Ghiti <alexghiti@rivosinc.com>
+Link: https://lore.kernel.org/r/20250722091504.45974-2-cuiyunhui@bytedance.com
+Signed-off-by: Alexandre Ghiti <alexghiti@rivosinc.com>
+---
+ arch/riscv/include/asm/io.h      | 4 ++++
+ arch/riscv/include/asm/pgtable.h | 1 +
+ 2 files changed, 5 insertions(+)
+
+--- a/arch/riscv/include/asm/io.h
++++ b/arch/riscv/include/asm/io.h
+@@ -28,6 +28,10 @@
+ #ifdef CONFIG_MMU
+ #define IO_SPACE_LIMIT		(PCI_IO_SIZE - 1)
+ #define PCI_IOBASE		((void __iomem *)PCI_IO_START)
++
++#define ioremap_wc(addr, size)	\
++	ioremap_prot((addr), (size), _PAGE_KERNEL_NC)
++
+ #endif /* CONFIG_MMU */
+ 
+ /*
+--- a/arch/riscv/include/asm/pgtable.h
++++ b/arch/riscv/include/asm/pgtable.h
+@@ -205,6 +205,7 @@ extern struct pt_alloc_ops pt_ops __init
+ 
+ #define PAGE_TABLE		__pgprot(_PAGE_TABLE)
+ 
++#define _PAGE_KERNEL_NC ((_PAGE_KERNEL & ~_PAGE_MTMASK) | _PAGE_NOCACHE)
+ #define _PAGE_IOREMAP	((_PAGE_KERNEL & ~_PAGE_MTMASK) | _PAGE_IO)
+ #define PAGE_KERNEL_IO		__pgprot(_PAGE_IOREMAP)
+ 

--- a/target/linux/siflower/patches-6.6/021-set_pgprot_dmacoherent_to_pgprot_writecombine.patch
+++ b/target/linux/siflower/patches-6.6/021-set_pgprot_dmacoherent_to_pgprot_writecombine.patch
@@ -1,0 +1,11 @@
+--- a/arch/riscv/include/asm/pgtable.h
++++ b/arch/riscv/include/asm/pgtable.h
+@@ -619,6 +619,8 @@ static inline pgprot_t pgprot_writecombi
+ 	return __pgprot(prot);
+ }
+ 
++#define pgprot_dmacoherent pgprot_writecombine
++
+ /*
+  * THP functions
+  */


### PR DESCRIPTION
This fix need to prevent panic for access to 64bit data not aligned to 64bit address but aligned to 32bit address. This situation possible for example for MHI bus driver, where descriptors (in hardware) looks like:

```C
struct mhi_event_ctxt {
	__le32 intmod;
	__le32 ertype;
	__le32 msivec;

	__le64 rbase __packed __aligned(4);
	__le64 rlen __packed __aligned(4);
	__le64 rp __packed __aligned(4);
	__le64 wp __packed __aligned(4);
};
```

64bit access to 64bit fields of this structures gives kernel panic with reason (5) for read and (7) for write ops. 32bit access to this fields is OK.

This was tested by next code:

```C
#include <stdio.h>
#include <stdlib.h>
#include <stdint.h>
#include <signal.h>
#include <fcntl.h>
#include <sys/mman.h>
#include <unistd.h>

static const char *resource_path = "/sys/bus/pci/devices/0001:00:00.0/resource0"; static int failed = 0;

static void sig_hdl(int s) {
    failed++;
}

int main() {
    int fd, rv = 1;
    size_t page_size = sysconf(_SC_PAGESIZE);
    void *base;
    uint64_t *tstp, tstv;

    if (signal(SIGBUS, sig_hdl) == SIG_ERR) {
        perror("signal");
        return rv;
    }

    if ((fd = open(resource_path, O_RDWR | O_SYNC)) < 0) {
        perror("open");
        return rv;
    }

    base = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
    if (base == MAP_FAILED) {
        perror("mmap");
        goto out_close;
    }

    tstp = base + 4;
    tstv = tstp[0];
    printf("0x%llx\n", tstv);

    munmap(base, page_size);

    if (!failed) {
        printf("pass\n");
        rv = 0;
    } else {
        printf("fail\n");
    }

out_close:
    close(fd);
    return rv;
}
```
