### PR TITLE
qualcommax: ipq50xx: Add support for Yuncore AX850

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
@@ -25,7 +25,8 @@ xiaomi,ax6000)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x20000"
 	ubootenv_add_sys_mtd "bdata" "0x0" "0x10000" "0x20000"
 	;;
-yuncore,ax830)
+yuncore,ax830|\
+yuncore,ax850)
 	ubootenv_add_mtd "0:APPSBLENV" "0x0" "0x10000" "0x10000"
 	;;
 esac

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (c) 2025, Shubham Vishwakarma <shubhamvis98@fossfrog.in>
+ */
+
+/dts-v1/;
+
+#include "ipq5018.dtsi"
+#include "ipq5018-ess.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Yuncore AX850";
+	compatible = "yuncore,ax850", "qcom,ipq5018";
+
+	aliases {
+		serial0 = &blsp1_uart1;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+	};
+
+	chosen {
+		bootargs-append = " root=/dev/ubiblock0_1 swiotlb=1 coherent_pool=2M";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: system {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&tlmm 26 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&tlmm 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+
+	reserved-memory {
+		q6_mem_regions: q6_mem_regions@4b000000 {
+			no-map;
+			reg = <0x0 0x4b000000 0x0 0x3000000>;
+		};
+	};
+
+	gpio-watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&tlmm 27 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		hw_margin_ms = <5000>;
+		always-running;
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
+
+	qcom,port_phyinfo {
+		// MAC0 -> GE Phy
+		port@0 {
+			port_id = <1>;
+			mdiobus = <&mdio0>;
+			phy_address = <7>;
+		};
+
+		// MAC1 -> Uniphy --- SGMII --- QCA8081
+		port@1 {
+			port_id = <2>;
+			mdiobus = <&mdio1>;
+			phy_address = <28>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+// MAC0 -> GE Phy
+&dp1 {
+	status = "okay";
+
+	label = "lan";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
+	phy-mode = "sgmii";
+};
+
+// MAC1 ---SGMII---> QCA8081
+&dp2 {
+	status = "okay";
+
+	label = "wan";
+	phy-handle = <&qca8081>;
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+&mdio1 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio1_pins>;
+	pinctrl-names = "default";
+
+	qca8081: ethernet-phy@28 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <28>;
+		reset-deassert-us = <10000>;
+		reset-gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&xo_board_clk {
+	clock-frequency = <24000000>;
+};
+
+&blsp1_uart1 {
+	status = "okay";
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qfprom {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&blsp1_spi1 {
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x00 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "0:MIBIB";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "0:BOOTCONFIG";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "0:BOOTCONFIG1";
+				reg = <0x50000 0x10000>;
+				read-only;
+			};
+
+			partition@60000 {
+				label = "0:QSEE";
+				reg = <0x60000 0xa0000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "0:QSEE_1";
+				reg = <0x100000 0xa0000>;
+				read-only;
+			};
+
+			partition@1a0000 {
+				label = "0:DEVCFG";
+				reg = <0x1a0000 0x10000>;
+				read-only;
+			};
+
+			partition@1b0000 {
+				label = "0:DEVCFG_1";
+				reg = <0x1b0000 0x10000>;
+				read-only;
+			};
+
+			partition@1c0000 {
+				label = "0:CDT";
+				reg = <0x1c0000 0x10000>;
+				read-only;
+			};
+
+			partition@1d0000 {
+				label = "0:CDT_1";
+				reg = <0x1d0000 0x10000>;
+				read-only;
+			};
+
+			partition@1e0000 {
+				label = "0:APPSBLENV";
+				reg = <0x1e0000 0x10000>;
+			};
+
+			partition@1f0000 {
+				label = "0:APPSBL";
+				reg = <0x1f0000 0xa0000>;
+				read-only;
+			};
+
+			partition@290000 {
+				label = "0:APPSBL_1";
+				reg = <0x290000 0xa0000>;
+				read-only;
+			};
+
+			partition@330000 {
+				label = "0:ART";
+				reg = <0x330000 0x70000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					hw_mac_addr: hw_mac_addr {
+						#nvmem-cell-cells = <1>;
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&qpic_nand {
+	pinctrl-0 = <&qpic_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	partitions {
+		status = "disabled";
+	};
+
+	nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		nand-ecc-engine = <&qpic_nand>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:TRAINING";
+				reg = <0x00 0x80000>;
+			};
+
+			partition@80000 {
+				label = "rootfs_1";
+				reg = <0x80000 0x3e00000>;
+			};
+
+			partition@3e80000 {
+				label = "rootfs";
+				reg = <0x3e80000 0x3e00000>;
+			};
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		pins = "gpio38";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+
+	mdio1_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio36";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio37";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	qpic_pins: qpic-state {
+		clock-pins {
+			pins = "gpio9";
+			function = "qspi_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		cs-pins {
+			pins = "gpio8";
+			function = "qspi_cs";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		data-pins {
+			pins = "gpio4", "gpio5", "gpio6", "gpio7";
+			function = "qspi_data";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	serial_0_pins: uart0-state {
+		pins = "gpio20", "gpio21";
+		function = "blsp0_uart0";
+		bias-disable;
+	};
+};
+
+&tsens {
+	status = "okay";
+};
+
+&q6v5_wcss {
+	status = "okay";
+
+	memory-region = <&q6_mem_regions>;
+	firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt",
+			"ath11k/IPQ5018/hw1.0/m3_fw.mdt";
+
+	// IPQ5018
+	q6_wcss_pd1: pd-1 {
+		firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt";
+
+		resets =
+			<&gcc GCC_WCSSAON_RESET>,
+			<&gcc GCC_WCSS_BCR>,
+			<&gcc GCC_CE_BCR>;
+		reset-names =
+			"wcss_aon_reset",
+			"wcss_reset",
+			"ce_reset";
+
+		clocks =
+			<&gcc GCC_WCSS_AHB_S_CLK>,
+			<&gcc GCC_WCSS_ACMT_CLK>,
+			<&gcc GCC_WCSS_AXI_M_CLK>;
+		clock-names =
+			"gcc_wcss_ahb_s_clk",
+			"gcc_wcss_acmt_clk",
+			"gcc_wcss_axi_m_clk";
+
+		interrupts-extended =
+			<&wcss_smp2p_in 8 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 9 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 12 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 11 IRQ_TYPE_NONE>;
+		interrupt-names =
+			"fatal",
+			"ready",
+			"spawn-ack",
+			"stop-ack";
+
+		qcom,smem-states =
+			<&wcss_smp2p_out 8>,
+			<&wcss_smp2p_out 9>,
+			<&wcss_smp2p_out 10>;
+		qcom,smem-state-names =
+			"shutdown",
+			"stop",
+			"spawn";
+	};
+};
+
+&wifi0 {
+	// IPQ5018
+	status = "okay";
+	qcom,rproc = <&q6_wcss_pd1>;
+	qcom,ath11k-calibration-variant = "Yuncore-AX850";
+	qcom,ath11k-fw-memory-mode = <1>;
+	qcom,bdf-addr = <0x4c400000>;
+};
+
+&pcie0_phy {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpios = <&tlmm 15 GPIO_ACTIVE_LOW>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			status = "okay";
+			/* QCN9074: ath11k lacks DT compatible for PCI cards */
+			compatible = "pci17cb,1104";
+			reg = <0x00010000 0 0 0 0>;
+			qcom,ath11k-calibration-variant = "Yuncore-AX850";
+		};
+	};
+};

--- a/target/linux/qualcommax/image/ipq50xx.mk
+++ b/target/linux/qualcommax/image/ipq50xx.mk
@@ -165,3 +165,19 @@ define Device/yuncore_ax830
 		ipq-wifi-yuncore_ax830
 endef
 TARGET_DEVICES += yuncore_ax830
+
+define Device/yuncore_ax850
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Yuncore
+	DEVICE_MODEL := AX850
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	SOC := ipq5018
+	DEVICE_DTS_CONFIG := config@mp03.1
+	DEVICE_PACKAGES := kmod-ath11k-pci \
+		ath11k-firmware-ipq5018 \
+		ath11k-firmware-qcn9074 \
+		ipq-wifi-yuncore_ax850
+endef
+TARGET_DEVICES += yuncore_ax850

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
@@ -21,7 +21,8 @@ ipq50xx_setup_interfaces()
 	xiaomi,ax6000)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
-	yuncore,ax830)
+	yuncore,ax830|\
+	yuncore,ax850)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	esac

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -34,7 +34,8 @@ case "$FIRMWARE" in
 	xiaomi,ax6000)
 		caldata_extract "0:art" 0x1000 0x20000
 		;;
-	yuncore,ax830)
+	yuncore,ax830|\
+	yuncore,ax850)
 		caldata_extract "0:ART" 0x1000 0x20000
 		label_mac=$(mtd_get_mac_binary 0:ART 0)
 		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
@@ -86,6 +87,13 @@ case "$FIRMWARE" in
 		;;
 	xiaomi,ax6000)
 		caldata_extract "0:art" 0x26800 0x20000
+		;;
+	yuncore,ax850)
+		caldata_extract "0:ART" 0x26800 0x20000
+		label_mac=$(mtd_get_mac_binary 0:ART 0)
+		ath11k_patch_mac $(macaddr_add $label_mac 3) 0
+		ath11k_remove_regdomain
+		ath11k_set_macflag
 		;;
 	esac
 	;;

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
@@ -145,7 +145,8 @@ platform_do_upgrade() {
 		CI_ROOT_UBIPART="rootfs"
 		nand_do_upgrade "$1"
 		;;
-	yuncore,ax830)
+	yuncore,ax830|\
+	yuncore,ax850)
 		CI_UBIPART="rootfs"
 		remove_oem_ubi_volume ubi_rootfs
 		remove_oem_ubi_volume bt_fw


### PR DESCRIPTION
qualcommax: ipq50xx: Add support for Yuncore AX850

Specifications:
SOC: Qualcomm IPQ5018 (64-bit dual-core ARM Cortex-A53 @ 1.0Ghz)
Flash: SPI NOR 8MB (Winbond W25Q64DW) + NAND 128MB (Winbond W25N01GWZEIG)
Memory: 512MB DDR3L
Standard: 802.11ax/ac/b/g/n
2.4G Frequency: 2.4GHz - 2.484GHz
2.4G Wi-Fi standard: 802.11b/g/n/ax
5G Frequency: 5.150GHz~5.850GHz
5G Wi-Fi Standard: 802.11 a/n/ac/ax
Buttons: 1 * Reset button, press 10 seconds to revert to default setting
2.4G Antenna: 2*2.4GHz/5.8GHz dual band antenna: 4dBi
5G Antenna: 2*5.8G antenna: 4dBi
Data Rate: 2.4GHz: 574Mbps, 5GHz:4800Mbps
Power: PoE 802.3at，DC2.0 12V/2A
Max Power Consumption: < 22W
LED Light: WAN, LAN, tricolor LED(sys-red, 2.4G-green, 5.8G-blue)

BACKUP YOUR STOCK FIRMWARE:
- Put openwrt-*-initramfs-uImage.itb to your
	TFTP server and rename it to initramfs.bin
- Enable serial console and enter to u-boot cli
	and exec these commands:
	```
	tftpboot <your_tftp_server_ip>:initramfs.bin
	bootm
	```
- Once boot completed and you get the openwrt shell
	execute below commands:
	```
	device=ax850
	mkdir -p /tmp/fw_backup; cd /tmp/fw_backup
	rootfs=$(cat /proc/mtd | grep \"rootfs\" | cut -d: -f1)
	rootfs_1=$(cat /proc/mtd | grep \"rootfs_1\" | cut -d: -f1)
	dd if=/dev/${rootfs} of=rootfs_${rootfs} bs=1M
	dd if=/dev/${rootfs_1} of=rootfs_1_${rootfs_1} bs=1M
	cp /sys/firmware/fdt fdt.dtb
	md5sum * > md5sum
	tar -cvzf /tmp/${device}.tar.gz .
	sum=$(md5sum /tmp/${device}.tar.gz | cut -d' ' -f1)
	mv /tmp/${device}.tar.gz /tmp/${device}_${sum}.tar.gz
	echo "stock fw backup saved to: /tmp/${device}_${sum}.tar.gz"
	```
- Upload/save your backup to a safe place.

STOCK FIRMWARE RECOVERY:
- Boot initramfs image
- Upload your backed-up stock fw tarball to the device
	using scp or download it from the device using wget.
- Enter device ssh cli or tty and exec:
	```
	cd /tmp && wget <your_web_server_ip>/${stock_fw_backup}.tar.gz`
	tar -xpzf ${stock_fw_backup}.tar.gz
	rootfs=$(cat /proc/mtd | grep \"rootfs\" | cut -d: -f1)
	rootfs_1=$(cat /proc/mtd | grep \"rootfs_1\" | cut -d: -f1)
	ubiformat /dev/${rootfs} -y -f /tmp/rootfs_${rootfs}
	ubiformat /dev/${rootfs_1} -y -f /tmp/rootfs_1_${rootfs_1}
	reboot
	```

INSTALLATION:
1. initramfs method
- Put openwrt-*-initramfs-uImage.itb to your
	TFTP server and rename it to initramfs.bin
- Enable serial console and enter to u-boot cli
	and exec these commands:
	```
	tftpboot <your_tftp_server_ip>:initramfs.bin
	bootm
	```
- Once boot completed and you get the openwrt shell
	execute below commands:
	```
	cd /tmp && wget <your_web_server_ip>/factory.ubi`
	export rootfs=$(cat /proc/mtd | grep rootfs | cut -d: -f1)
	export rootfs_1=$(cat /proc/mtd | grep rootfs_1 | cut -d: -f1)
	ubiformat /dev/${rootfs} -y -f factory.ubi
	ubiformat /dev/${rootfs_1} -y -f factory.ubi
	reboot
	```

2. u-boot factory.ubi image method
- Put factory.ubi to your TFTP server and
	enter u-boot cli and exec these commands:
	```
	tftpboot <your_tftp_server_ip>:factory.ubi
	#After downloading is finished:
	flash rootfs
	flash rootfs_1
	reset
	```