### PR TITLE
mediatek: remove loglevel in bootargs

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-unielec-u7981-01.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-unielec-u7981-01.dtsi
@@ -10,9 +10,7 @@
 	compatible = "unielec,u7981-01-emmc", "mediatek,mt7981";
 
 	chosen {
-		bootargs = "console=ttyS0,115200n1 loglevel=8  \
-				earlycon=uart8250,mmio32,0x11002000 \
-				";
+		bootargs = "console=ttyS0,115200n1 earlycon=uart8250,mmio32,0x11002000";
 	};
 
 	gpio-keys {

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax.dts
@@ -19,7 +19,7 @@
 
 	chosen {
 		stdout-path = "serial0:115200n8";
-		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8 loglevel=8";
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8";
 	};
 
 	memory {

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dts
@@ -19,7 +19,7 @@
 
 	chosen {
 		stdout-path = "serial0:115200n8";
-		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8 loglevel=8";
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8";
 	};
 
 	memory {

--- a/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
+++ b/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
@@ -24,7 +24,7 @@
 
 	chosen {
 		stdout-path = &serial0;
-		bootargs = "console=ttyS0,115200n1 loglevel=8 pci=pcie_bus_perf root=PARTLABEL=rootfs";
+		bootargs = "console=ttyS0,115200n1 pci=pcie_bus_perf root=PARTLABEL=rootfs";
 	};
 
 	memory {

--- a/target/linux/mediatek/patches-6.12/188-arm64-dts-mediatek-add-MT7988A-reference-board-devic.patch
+++ b/target/linux/mediatek/patches-6.12/188-arm64-dts-mediatek-add-MT7988A-reference-board-devic.patch
@@ -831,7 +831,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		     "mediatek,mt7988a";
 +
 +	chosen {
-+		bootargs = "console=ttyS0,115200n1 loglevel=8  \
++		bootargs = "console=ttyS0,115200n1 \
 +			    earlycon=uart8250,mmio32,0x11000000 \
 +			    pci=pcie_bus_perf";
 +	};

--- a/target/linux/mediatek/patches-6.12/189-arm64-dts-mediatek-mt7988a-complete-bpi-r4.patch
+++ b/target/linux/mediatek/patches-6.12/189-arm64-dts-mediatek-mt7988a-complete-bpi-r4.patch
@@ -189,7 +189,7 @@ Subject: [PATCH 32/32] WIP: add BPi-R4
  / {
  	chosen {
  		stdout-path = "serial0:115200n8";
-+		bootargs = "console=ttyS0,115200n1 loglevel=8 pci=pcie_bus_perf ubi.block=0,fit root=/dev/fit0";
++		bootargs = "console=ttyS0,115200n1 pci=pcie_bus_perf ubi.block=0,fit root=/dev/fit0";
 +		rootdisk-spim-nand = <&ubi_rootfs>;
  	};
  


### PR DESCRIPTION
Remove `loglevel=8`