### PR TITLE
Add support for sae_password_file in hostapd.sh - Fix 19717

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -315,6 +315,7 @@ hostapd_common_add_bss_config() {
 	config_add_string 'key1:wepkey' 'key2:wepkey' 'key3:wepkey' 'key4:wepkey' 'password:wpakey'
 
 	config_add_string wpa_psk_file
+	config_add_string sae_password_file
 
 	config_add_int multi_ap
 


### PR DESCRIPTION
Add support for sae_password_file in hostapd.sh (config_add_string)

Fix 19717