### PR TITLE
realtek: i2c: rtl9300: Fix multi-byte I2C operations

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/i2c/busses/i2c-rtl9300.c
+++ b/target/linux/realtek/files-6.12/drivers/i2c/busses/i2c-rtl9300.c
@@ -299,6 +299,10 @@ static int rtl9300_i2c_smbus_xfer(struct i2c_adapter * adap, u16 addr,
 		pr_debug("I2C_SMBUS_BLOCK_DATA %02x, read %d, len %d\n",
 			addr, read_write, data->block[0]);
 		drv_data->reg_addr_set(i2c, command, 1);
+		if (data->block[0] < 1 || data->block[0] > I2C_SMBUS_BLOCK_MAX) {
+			ret = -EINVAL;
+			goto out_unlock;
+		}
 		drv_data->config_xfer(i2c, addr, data->block[0]);
 		if (read_write == I2C_SMBUS_WRITE)
 			drv_data->write(i2c, &data->block[1], data->block[0]);
@@ -312,6 +316,7 @@ static int rtl9300_i2c_smbus_xfer(struct i2c_adapter * adap, u16 addr,
 
 	ret = drv_data->execute_xfer(i2c, read_write, size, data, len);
 
+out_unlock:
 	mutex_unlock(&i2c_lock);
 
 	return ret;

--- a/target/linux/realtek/files-6.12/drivers/i2c/busses/i2c-rtl9300.c
+++ b/target/linux/realtek/files-6.12/drivers/i2c/busses/i2c-rtl9300.c
@@ -305,10 +305,10 @@ static int rtl9300_i2c_smbus_xfer(struct i2c_adapter * adap, u16 addr,
 			ret = -EINVAL;
 			goto out_unlock;
 		}
-		drv_data->config_xfer(i2c, addr, data->block[0]);
+		drv_data->config_xfer(i2c, addr, data->block[0] + 1);
 		if (read_write == I2C_SMBUS_WRITE)
-			drv_data->write(i2c, &data->block[1], data->block[0]);
-		len = data->block[0];
+			drv_data->write(i2c, &data->block[0], data->block[0] + 1);
+		len = data->block[0] + 1;
 		break;
 
 	default:

--- a/target/linux/realtek/files-6.12/drivers/i2c/busses/i2c-rtl9300.c
+++ b/target/linux/realtek/files-6.12/drivers/i2c/busses/i2c-rtl9300.c
@@ -141,19 +141,21 @@ static int i2c_read(void __iomem *r0, u8 *buf, int len)
 
 static int i2c_write(void __iomem *r0, u8 *buf, int len)
 {
+	u32 vals[4] = {};
+	int i;
+
 	if (len > 16)
 		return -EIO;
 
-	for (int i = 0; i < len; i++) {
-		u32 v;
+	for (i = 0; i < len; i++) {
+		unsigned int shift = (i % 4) * 8;
+		unsigned int reg = i / 4;
 
-		if (! (i % 4))
-			v = 0;
-		v <<= 8;
-		v |= buf[i];
-		if (i % 4 == 3 || i == len - 1)
-			writel(v, r0 + (i / 4) * 4);
+		vals[reg] |= buf[i] << shift;
 	}
+
+	for (i = 0; i < ARRAY_SIZE(vals); i++)
+		writel(vals[i], r0 + i * 4);
 
 	return len;
 }


### PR DESCRIPTION
This PR is just a backport of https://lore.kernel.org/r/20250809-i2c-rtl9300-multi-byte-v4-0-d71dd5eb6121@narfation.org to the OpenWrt I2C host driver for rtl93xx.

@jonasjelonek is working on the [integration of the upstream Linux kernel driver](https://github.com/jonasjelonek/openwrt/tree/rtl93xx-i2cdrv-backport). If the PR for Jonas' effort is posted then it has a higher priority than the PR in front of you. In this case, just close this PR.

---

During the integration of the RTL8239 POE chip + its frontend MCU, it was noticed that multi-byte operations were basically broken in the current driver.

Tests using SMBus Block Writes showed that the data (after the `Wr` maker + `Ack`) was mixed up on the wire. At first glance, it looked like an endianness problem. But for transfers where the number of count + data bytes was not divisible by 4, the last bytes were not looking like an endianness problem because they were in the wrong order but not for example 0 - which would be the case for an endianness problem with 32 bit registers. At the end, it turned out to be the way how i2c_write tried to add the bytes to the send registers.

Each 32 bit register was used similar to a shift register - shifting the various bytes up the register while the next one is added to the least significant byte. But the I2C controller expects the first byte of the transmission in the least significant byte of the first register. And the last byte (assuming it is a 16 byte transfer) is expected in the most significant byte of the fourth register.

While doing these tests, it was also observed that the count byte was missing from the SMBus Block Writes. The driver just removed them from the `data->block` (from the I2C subsystem). But the I2C controller DOES NOT automatically add this byte - for example by using the configured transmission length.


The RTL8239 MCU is not actually an SMBus compliant device. Instead, it expects I2C Block Reads + I2C Block Writes. But according to the already identified bugs in the driver, it was clear that the I2C controller can simply be modified to not send the count byte for `I2C_SMBUS_I2C_BLOCK_DATA`. The receive part just needs to write the content of the receive buffer to the correct position in `data->block`.

Detailed explanations can be found in the commit messages.