### PR TITLE
Ipq40xx: force usb2 for rbx50 targets

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -911,6 +911,7 @@ define Device/netgear_rbx50
 	KERNEL_SIZE := 3932160
 	ROOTFS_SIZE := 32243712
 	IMAGE_SIZE := 36175872
+	DEVICE_PACKAGES := -kmod-usb3 kmod-usb2
 endef
 
 define Device/netgear_rbr50


### PR DESCRIPTION
RBX50 targets (RBR50 and RBS50) only support USB2

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
