### PR TITLE
ipq40xx: force usb2 for rbx50 targets

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -911,6 +911,7 @@ define Device/netgear_rbx50
 	KERNEL_SIZE := 3932160
 	ROOTFS_SIZE := 32243712
 	IMAGE_SIZE := 36175872
+	DEVICE_PACKAGES := -kmod-usb3 kmod-usb2
 endef
 
 define Device/netgear_rbr50


### PR DESCRIPTION
RBX50 targets only support USB2

Signed-off-by: Stephen Groat <stephengroat@gmail.com>
