### PR TITLE
realtek: switch Netgear NGE devices to rt-loader

### DIFF
--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -217,16 +217,7 @@ TARGET_DEVICES += linksys_lgs310c
 
 # "NGE" refers to the uImage magic
 define Device/netgear_nge
-  KERNEL := \
-	kernel-bin | \
-	append-dtb | \
-	lzma | \
-	uImage lzma
-  KERNEL_INITRAMFS := \
-	kernel-bin | \
-	append-dtb | \
-	lzma | \
-	uImage lzma
+  $(Device/uimage-rt-loader)
   SOC := rtl8380
   IMAGE_SIZE := 14848k
   UIMAGE_MAGIC := 0x4e474520


### PR DESCRIPTION
The bootloader on these devices uses 0x81000000 as load address for the compressed image. Since the kernel uses a load address 0x80100000, this only leaves a space of 15 MiB for the uncompressed image. For larger images, the compressed data starts to get overwritten, and at some point the boot will fail:

    ## Booting image from partition ... 0
    ## Booting kernel from Legacy Image at 81000000 ...
       Version:      9.9.9.9
       Created:      2025-08-07  14:56:09 UTC
       Data Size:    6756645 Bytes = 6.4 MB
       Checksum ... OK
       Uncompressing ... LZMA: uncompress or overwrite error 1 - must RESET board to recover

Currently, initramfs images with default config are already over the limit. And while they still happen to work regardless, adding additional packages easily pushes the size so much that the boot fails.

Fix this by switching to rt-loader (which relocates the data to the upper end of the RAM before decompression). The switch includes regular kernel images to avoid this becoming an issue again in the future.

---

Note: This might also affect Netgear NGG (GS110TUP).
@j4cbo: Since you added support for that device, maybe you can check this to avoid surprises in the future.