### PR TITLE
netifd: add loglevel config option (fixes #18001)

### DIFF
--- a/package/network/config/netifd/files/etc/init.d/network
+++ b/package/network/config/netifd/files/etc/init.d/network
@@ -15,8 +15,11 @@ init_switch() {
 start_service() {
 	init_switch
 
+	validate_netifd_loglevel
+
 	procd_open_instance
 	procd_set_param command /sbin/netifd
+	procd_append_param command -l ${netifd_loglevel}
 	procd_set_param respawn
 	procd_set_param watch network.interface
 	[ -e /proc/sys/kernel/core_pattern ] && {
@@ -37,6 +40,12 @@ stop_service() {
 	[ -x /sbin/wifi ] && /sbin/wifi down
 	ifdown -a
 	sleep 1
+}
+
+validate_netifd_loglevel()
+{
+	uci_validate_section network "globals" "globals" \
+		'netifd_loglevel:uinteger:2'
 }
 
 validate_atm_bridge_section()


### PR DESCRIPTION
Add netifd_loglevel to /etc/config/network:

config globals 'globals'
	option netifd_loglevel '1'

The netifd's default value is 2.
