### PR TITLE
tools/7z: update to 25.01

### DIFF
--- a/tools/7z/Makefile
+++ b/tools/7z/Makefile
@@ -1,11 +1,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=7z
-PKG_VERSION:=25.00
+PKG_VERSION:=25.01
 
 PKG_SOURCE:=$(PKG_NAME)$(subst .,,$(PKG_VERSION))-src.tar.xz
 PKG_SOURCE_URL:=https://7-zip.org/a/
-PKG_HASH:=bff9e69b6ca73a5b8715d7623870a39dc90ad6ce1f4d1070685843987af1af9b
+PKG_HASH:=ed087f83ee789c1ea5f39c464c55a5c9d4008deb0efe900814f2df262b82c36e
 
 PKG_CPE_ID:=cpe:/a:7-zip:7-zip
 


### PR DESCRIPTION
This version contains fixes for CVE-2025-55188.
Changelog: https://www.7-zip.org/history.txt