### PR TITLE
mediatek: Add support for Acer Predator Connect W6x

### DIFF
--- a/package/boot/uboot-sunxi/uEnv-a64.txt
+++ b/package/boot/uboot-sunxi/uEnv-a64.txt
@@ -1,7 +1,6 @@
 setenv mmc_rootpart 2
 part uuid mmc ${mmc_bootdev}:${mmc_rootpart} uuid
-setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_addr_r uImage
-setenv loaddtb fatload mmc \$mmc_bootdev \$fdt_addr_r dtb
+setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_comp_addr_r uImage
 setenv bootargs console=ttyS0,115200 earlyprintk root=PARTUUID=${uuid} rootwait earlycon=uart,mmio32,0x01c28000
-setenv uenvcmd run loadkernel \&\& run loaddtb \&\& booti \$kernel_addr_r - \$fdt_addr_r
+setenv uenvcmd run loadkernel \&\& bootm \$kernel_comp_addr_r
 run uenvcmd

--- a/package/boot/uboot-sunxi/uEnv-default.txt
+++ b/package/boot/uboot-sunxi/uEnv-default.txt
@@ -1,8 +1,6 @@
-setenv fdt_high ffffffff
 setenv mmc_rootpart 2
 part uuid mmc ${mmc_bootdev}:${mmc_rootpart} uuid
 setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_addr_r uImage
-setenv loaddtb fatload mmc \$mmc_bootdev \$fdt_addr_r dtb
 setenv bootargs console=ttyS0,115200 earlyprintk root=PARTUUID=${uuid} rootwait
-setenv uenvcmd run loadkernel \&\& run loaddtb \&\& bootm \$kernel_addr_r - \$fdt_addr_r
+setenv uenvcmd run loadkernel \&\& bootm \$kernel_addr_r
 run uenvcmd

--- a/package/boot/uboot-sunxi/uEnv-h6.txt
+++ b/package/boot/uboot-sunxi/uEnv-h6.txt
@@ -1,7 +1,6 @@
 setenv mmc_rootpart 2
 part uuid mmc ${mmc_bootdev}:${mmc_rootpart} uuid
-setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_addr_r uImage
-setenv loaddtb fatload mmc \$mmc_bootdev \$fdt_addr_r dtb
+setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_comp_addr_r uImage
 setenv bootargs console=ttyS0,115200 earlyprintk root=PARTUUID=${uuid} rootwait
-setenv uenvcmd run loadkernel \&\& run loaddtb \&\& booti \$kernel_addr_r - \$fdt_addr_r
+setenv uenvcmd run loadkernel \&\& bootm \$kernel_comp_addr_r
 run uenvcmd

--- a/package/boot/uboot-sunxi/uEnv-h616.txt
+++ b/package/boot/uboot-sunxi/uEnv-h616.txt
@@ -1,7 +1,6 @@
 setenv mmc_rootpart 2
 part uuid mmc ${mmc_bootdev}:${mmc_rootpart} uuid
-setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_addr_r uImage
-setenv loaddtb fatload mmc \$mmc_bootdev \$fdt_addr_r dtb
+setenv loadkernel fatload mmc \$mmc_bootdev \$kernel_comp_addr_r uImage
 setenv bootargs console=ttyS0,115200 earlyprintk root=PARTUUID=${uuid} rootwait
-setenv uenvcmd run loadkernel \&\& run loaddtb \&\& booti \$kernel_addr_r - \$fdt_addr_r
+setenv uenvcmd run loadkernel \&\& bootm \$kernel_comp_addr_r
 run uenvcmd

--- a/package/boot/uboot-sunxi/uEnv-pangolin.txt
+++ b/package/boot/uboot-sunxi/uEnv-pangolin.txt
@@ -1,6 +1,4 @@
-setenv fdt_high ffffffff
 setenv loadkernel fatload mmc 0 \$kernel_addr_r uImage
-setenv loaddtb fatload mmc 0 \$fdt_addr_r dtb
 setenv bootargs console=ttyS2,115200 earlyprintk root=/dev/mmcblk0p2 rootwait
-setenv uenvcmd run loadkernel \&\& run loaddtb \&\& bootm \$kernel_addr_r - \$fdt_addr_r
+setenv uenvcmd run loadkernel \&\& run loaddtb \&\& bootm \$kernel_addr_r
 run uenvcmd

--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -73,6 +73,7 @@ endef
 export GNULIB_SRCDIR:=$(HOST_GNULIB_SRCDIR)
 
 TARGET_CFLAGS += $(FPIC)
+TARGET_CFLAGS += -std=gnu23
 ifneq ($(HOST_OS),Linux)
   TARGET_CFLAGS += -I$(STAGING_DIR_HOSTPKG)/include
 endif

--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -25,8 +25,6 @@ PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=gettext-full/host libunistring libxml2
 PKG_BUILD_PARALLEL:=0
 
-PKG_FIXUP:=autoreconf
-
 HOST_BUILD_DEPENDS:=gnulib-l10n/host gperf/host libiconv-full/host libunistring/host libxml2/host
 HOST_BUILD_PARALLEL:=0
 

--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dts
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7986a-acer-w6-common.dtsi"
+
+/ {
+	model = "Acer Predator Connect W6x";
+	compatible = "acer,predator-w6x", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+	};
+	chosen {
+		bootargs-override = "";
+	};
+};
+
+&eth {
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy6>;
+	};
+};
+
+&mdio {
+	phy6: phy@6 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <6>;
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <10000>;
+		/* LED0: nc ; LED1: nc ; LED2: amber ; LED3: green */
+		mxl,led-config = <0x0 0x0 0x370 0x380>;
+	};
+};
+
+/delete-node/&mmc0;
+
+&pio {
+	/delete-node/mmc0_pins_default;
+	/delete-node/mmc0_pins_uhs;
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <8>;
+			mediatek,pull-down-adv = <0>; /* bias-disable */
+		};
+	};
+
+	spi_led_pins: spic-pins-29-to-32 {
+		mux {
+			function = "spi";
+			groups = "spi1_2";
+		};
+	};
+
+};
+
+&slot0 {
+	radio0: mt7915@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	spi_nand_flash: spi_nand@0 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bl2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
+			};
+			factory: partition@380000 {
+				label = "fip";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "prod";
+				reg = <0x580000 0x20000>;
+				read-only;
+			};
+			partition@600000 {
+				label = "dual";
+				reg = <0x600000 0x100000>;
+				read-only;
+			};
+			partition@700000 {
+				label = "pot";
+				reg = <0x700000 0x100000>;
+				read-only;
+			};
+			partition@800000 {
+				label = "ubi";
+				reg = <0x800000 0x6400000>;
+			};
+			partition@6C00000 {
+				label = "ubi1";
+				reg = <0x6C00000 0x6400000>;
+			};
+			partition@D000000 {
+				label = "storage";
+				reg = <0xD000000 0x800000>;
+			};
+		};
+	};
+};
+
+&ssusb {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+	status = "okay";
+};
+
+&switch {
+	/delete-node/ports;
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		swport0: port@1 {
+			reg = <1>;
+			label = "lan1";
+			phy-handle = <&swphy1>;
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+			phy-handle = <&swphy2>;
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan3";
+			phy-handle = <&swphy3>;
+		};
+
+		port@4 {
+			reg = <4>;
+			label = "lan4";
+			phy-handle = <&swphy4>;
+		};
+
+		port@6 {
+			reg = <6>;
+			label = "cpu";
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+	/delete-node/mdio;
+	mdio {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		swphy1: phy@1 {
+			reg = <1>;
+
+			mediatek,led-config = <
+				0x21 0x8008 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0xc001 /* LED0_ON_CTRL */
+				0x25 0x0003 /* LED0_BLINK_CTRL */
+				0x26 0xc006 /* LED1_ON_CTRL */
+				0x27 0x003c /* LED1_BLINK_CTRL */
+			>;
+		};
+
+		swphy2: phy@2 {
+			reg = <2>;
+
+			mediatek,led-config = <
+				0x21 0x8008 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0xc001 /* LED0_ON_CTRL */
+				0x25 0x0003 /* LED0_BLINK_CTRL */
+				0x26 0xc006 /* LED1_ON_CTRL */
+				0x27 0x003c /* LED1_BLINK_CTRL */
+			>;
+		};
+
+		swphy3: phy@3 {
+			reg = <3>;
+
+			mediatek,led-config = <
+				0x21 0x8008 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0xc001 /* LED0_ON_CTRL */
+				0x25 0x0003 /* LED0_BLINK_CTRL */
+				0x26 0xc006 /* LED1_ON_CTRL */
+				0x27 0x003c /* LED1_BLINK_CTRL */
+			>;
+		};
+
+		swphy4: phy@4 {
+			reg = <4>;
+
+			mediatek,led-config = <
+				0x21 0x8008 /* BASIC_CTRL */
+				0x22 0x0c00 /* ON_DURATION */
+				0x23 0x1400 /* BLINK_DURATION */
+				0x24 0xc001 /* LED0_ON_CTRL */
+				0x25 0x0003 /* LED0_BLINK_CTRL */
+				0x26 0xc006 /* LED1_ON_CTRL */
+				0x27 0x003c /* LED1_BLINK_CTRL */
+			>;
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -25,6 +25,9 @@ mediatek_setup_interfaces()
 	acer,predator-w6d)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 game" eth1
 		;;
+	acer,predator-w6x)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
+		;;
 	acer,vero-w6m)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" internet
 		;;
@@ -178,6 +181,11 @@ mediatek_setup_macs()
 	acer,vero-w6m)
 		wan_mac=$(mmc_get_mac_ascii u-boot-env WANMAC)
 		lan_mac=$(mmc_get_mac_ascii u-boot-env LANMAC)
+		;;
+	acer,predator-w6x)
+		wan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		lan_mac=$(macaddr_add "$wan_mac" 1)
+		label_mac=$wan_mac
 		;;
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -27,6 +27,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && mmc_get_mac_ascii u-boot-env 2gMAC > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && mmc_get_mac_ascii u-boot-env 5gMAC > /sys${DEVPATH}/macaddress
 		;;
+	acer,predator-w6x)
+		hw_mac_addr="$(mtd_get_mac_ascii u-boot-env ethaddr)"
+		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
+		;;
 	asus,rt-ax59u)
 		CI_UBIPART="UBI_DEV"
 		addr=$(mtd_get_mac_binary_ubi "Factory" 0x4)

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -12,6 +12,15 @@ preinit_set_mac_address() {
 		ip link set dev game address "$lan_mac"
 		ip link set dev eth1 address "$wan_mac"
 		;;
+	acer,predator-w6x)
+		wan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		lan_mac=$(macaddr_add "$wan_mac" 1)
+		ip link set dev lan1 address "$lan_mac"
+		ip link set dev lan2 address "$lan_mac"
+		ip link set dev lan3 address "$lan_mac"
+		ip link set dev lan4 address "$lan_mac"
+		ip link set dev eth1 address "$wan_mac"
+		;;
 	acer,vero-w6m)
 		wan_mac=$(mmc_get_mac_ascii u-boot-env WANMAC)
 		lan_mac=$(mmc_get_mac_ascii u-boot-env LANMAC)

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -131,7 +131,8 @@ platform_do_upgrade() {
 		CI_KERNPART="linux"
 		nand_do_upgrade "$1"
 		;;
-	cudy,wr3000h-v1)
+	cudy,wr3000h-v1|\
+	acer,predator-w6x)
 		CI_UBIPART="ubi"
 		nand_do_upgrade "$1"
 		;;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -191,6 +191,23 @@ define Device/acer_predator-w6d
 endef
 TARGET_DEVICES += acer_predator-w6d
 
+define Device/acer_predator-w6x
+  DEVICE_VENDOR := Acer
+  DEVICE_MODEL := Predator Connect W6x
+  DEVICE_DTS := mt7986a-acer-predator-w6x
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7916-firmware kmod-mt7986-firmware mt7986-wo-firmware e2fsprogs f2fsck mkf2fs
+  IMAGES := sysupgrade.bin
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += acer_predator-w6x
+
 define Device/acer_vero-w6m
   DEVICE_VENDOR := Acer
   DEVICE_MODEL := Connect Vero W6m

--- a/target/linux/sunxi/Makefile
+++ b/target/linux/sunxi/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=sunxi
 BOARDNAME:=Allwinner ARM SoCs
-FEATURES:=ext4 display rootfs-part rtc squashfs usb usbgadget
+FEATURES:=ext4 display ramdisk rootfs-part rtc squashfs usb usbgadget
 SUBTARGETS:=cortexa8 cortexa7 cortexa53
 
 KERNEL_PATCHVER:=6.12

--- a/target/linux/sunxi/image/Makefile
+++ b/target/linux/sunxi/image/Makefile
@@ -16,7 +16,6 @@ define Build/sunxi-sdcard
 	mkfs.fat $@.boot -C $(FAT32_BLOCKS)
 
 	mcopy -i $@.boot $(STAGING_DIR_IMAGE)/$(DEVICE_NAME)-boot.scr ::boot.scr
-	mcopy -i $@.boot $(DTS_DIR)/$(SUNXI_DTS).dtb ::dtb
 	mcopy -i $@.boot $(IMAGE_KERNEL) ::uImage
 	./gen_sunxi_sdcard_img.sh $@ \
 		$@.boot \
@@ -34,8 +33,16 @@ define Device/Default
   KERNEL := kernel-bin | uImage none
   IMAGES := sdcard.img.gz
   IMAGE/sdcard.img.gz := sunxi-sdcard | append-metadata | gzip
-  SUNXI_DTS_DIR :=allwinner/
+  SUNXI_DTS_DIR := allwinner/
   SUNXI_DTS = $$(SUNXI_DTS_DIR)$$(SOC)-$(lastword $(subst _, ,$(1)))
+endef
+
+define Device/FitImageLzma
+  KERNEL = kernel-bin | lzma | fit lzma $$(DTS_DIR)/$$(SUNXI_DTS).dtb
+endef
+
+define Device/FitImageGzip
+  KERNEL = kernel-bin | gzip | fit gzip $$(DTS_DIR)/$$(SUNXI_DTS).dtb
 endef
 
 include $(SUBTARGET).mk

--- a/target/linux/sunxi/image/cortexa53.mk
+++ b/target/linux/sunxi/image/cortexa53.mk
@@ -3,12 +3,12 @@
 # Copyright (C) 2013-2016 OpenWrt.org
 # Copyright (C) 2016 Yousong Zhou
 
-KERNEL_LOADADDR:=0x40008000
+KERNEL_LOADADDR:=0x40080000
 
 define Device/sun50i
+  $(call Device/FitImageLzma)
   SUNXI_DTS_DIR := allwinner/
   KERNEL_NAME := Image
-  KERNEL := kernel-bin
 endef
 
 define Device/sun50i-a64

--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -6,6 +6,7 @@
 KERNEL_LOADADDR:=0x40008000
 
 define Device/cubietech_cubieboard2
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubieboard2
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
@@ -14,6 +15,7 @@ endef
 TARGET_DEVICES += cubietech_cubieboard2
 
 define Device/cubietech_cubietruck
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubietruck
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi kmod-brcmfmac
@@ -22,6 +24,7 @@ endef
 TARGET_DEVICES += cubietech_cubietruck
 
 define Device/friendlyarm_nanopi-m1-plus
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi M1 Plus
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
@@ -31,6 +34,7 @@ endef
 TARGET_DEVICES += friendlyarm_nanopi-m1-plus
 
 define Device/friendlyarm_nanopi-neo
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO
   SOC := sun8i-h3
@@ -38,6 +42,7 @@ endef
 TARGET_DEVICES += friendlyarm_nanopi-neo
 
 define Device/friendlyarm_nanopi-neo-air
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO Air
   DEVICE_PACKAGES := kmod-leds-gpio kmod-brcmfmac \
@@ -47,6 +52,7 @@ endef
 TARGET_DEVICES += friendlyarm_nanopi-neo-air
 
 define Device/friendlyarm_nanopi-r1
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R1
   DEVICE_PACKAGES := kmod-usb-net-rtl8152 kmod-leds-gpio \
@@ -56,6 +62,7 @@ endef
 TARGET_DEVICES += friendlyarm_nanopi-r1
 
 define Device/friendlyarm_zeropi
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := ZeroPi
   DEVICE_PACKAGES := kmod-rtc-sunxi
@@ -64,6 +71,7 @@ endef
 TARGET_DEVICES += friendlyarm_zeropi
 
 define Device/lamobo_lamobo-r1
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Lamobo
   DEVICE_MODEL := Lamobo R1
   DEVICE_ALT0_VENDOR := Bananapi
@@ -76,6 +84,7 @@ endef
 TARGET_DEVICES += lamobo_lamobo-r1
 
 define Device/lemaker_bananapi
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pi
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi
@@ -84,6 +93,7 @@ endef
 TARGET_DEVICES += lemaker_bananapi
 
 define Device/sinovoip_bananapi-m2-berry
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Berry
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
@@ -94,6 +104,7 @@ endef
 TARGET_DEVICES += sinovoip_bananapi-m2-berry
 
 define Device/sinovoip_bananapi-m2-ultra
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Ultra
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
@@ -104,6 +115,7 @@ endef
 TARGET_DEVICES += sinovoip_bananapi-m2-ultra
 
 define Device/lemaker_bananapro
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LeMaker
   DEVICE_MODEL := Banana Pro
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi kmod-brcmfmac \
@@ -113,6 +125,7 @@ endef
 TARGET_DEVICES += lemaker_bananapro
 
 define Device/licheepi_licheepi-zero-dock
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LicheePi
   DEVICE_MODEL := Zero with Dock (V3s)
   DEVICE_PACKAGES:=kmod-rtc-sunxi
@@ -121,6 +134,7 @@ endef
 TARGET_DEVICES += licheepi_licheepi-zero-dock
 
 define Device/linksprite_pcduino3
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino3
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtc-sunxi kmod-ata-sunxi kmod-rtl8xxxu \
@@ -130,6 +144,7 @@ endef
 TARGET_DEVICES += linksprite_pcduino3
 
 define Device/linksprite_pcduino3-nano
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino3 Nano
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-ata-sunxi
@@ -138,6 +153,7 @@ endef
 TARGET_DEVICES += linksprite_pcduino3-nano
 
 define Device/mele_m9
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Mele
   DEVICE_MODEL := M9
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtl8192cu
@@ -146,6 +162,7 @@ endef
 TARGET_DEVICES += mele_m9
 
 define Device/merrii_hummingbird
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Merrii
   DEVICE_MODEL := Hummingbird
   DEVICE_PACKAGES:=kmod-brcmfmac cypress-firmware-43362-sdio wpad-basic-mbedtls
@@ -154,6 +171,7 @@ endef
 TARGET_DEVICES += merrii_hummingbird
 
 define Device/olimex_a20-olinuxino-lime
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi
@@ -162,6 +180,7 @@ endef
 TARGET_DEVICES += olimex_a20-olinuxino-lime
 
 define Device/olimex_a20-olinuxino-lime2
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME2
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-rtc-sunxi kmod-usb-hid
@@ -170,6 +189,7 @@ endef
 TARGET_DEVICES += olimex_a20-olinuxino-lime2
 
 define Device/olimex_a20-olinuxino-lime2-emmc
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-LIME2
   DEVICE_VARIANT := eMMC
@@ -179,6 +199,7 @@ endef
 TARGET_DEVICES += olimex_a20-olinuxino-lime2-emmc
 
 define Device/olimex_a20-olinuxino-micro
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A20-OLinuXino-MICRO
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
@@ -187,6 +208,7 @@ endef
 TARGET_DEVICES += olimex_a20-olinuxino-micro
 
 define Device/roofull_beelink-x2
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Roofull
   DEVICE_MODEL := Beelink-X2
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-gpio-button-hotplug \
@@ -196,6 +218,7 @@ endef
 TARGET_DEVICES += roofull_beelink-x2
 
 define Device/sinovoip_bananapi-m2-plus
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2+
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
@@ -205,6 +228,7 @@ endef
 TARGET_DEVICES += sinovoip_bananapi-m2-plus
 
 define Device/sinovoip_bananapi-m3
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M3
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-leds-gpio kmod-rtc-ac100 \
@@ -214,6 +238,7 @@ endef
 TARGET_DEVICES += sinovoip_bananapi-m3
 
 define Device/sinovoip_bananapi-p2-zero
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi P2 Zero
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
@@ -223,6 +248,7 @@ endef
 TARGET_DEVICES += sinovoip_bananapi-p2-zero
 
 define Device/xunlong_orangepi-one
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi One
   DEVICE_PACKAGES:=kmod-rtc-sunxi
@@ -231,6 +257,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-one
 
 define Device/xunlong_orangepi-pc
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC
   DEVICE_PACKAGES:=kmod-gpio-button-hotplug
@@ -239,6 +266,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-pc
 
 define Device/xunlong_orangepi-pc-plus
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi PC Plus
   DEVICE_PACKAGES:=kmod-gpio-button-hotplug
@@ -247,6 +275,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-pc-plus
 
 define Device/xunlong_orangepi-plus
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Plus
   DEVICE_PACKAGES:=kmod-rtc-sunxi
@@ -255,6 +284,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-plus
 
 define Device/xunlong_orangepi-r1
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi R1
   DEVICE_PACKAGES:=kmod-usb-net-rtl8152
@@ -263,6 +293,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-r1
 
 define Device/xunlong_orangepi-zero
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi Zero
   DEVICE_PACKAGES:=kmod-rtc-sunxi
@@ -271,6 +302,7 @@ endef
 TARGET_DEVICES += xunlong_orangepi-zero
 
 define Device/xunlong_orangepi-2
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi 2
   DEVICE_PACKAGES:=kmod-rtc-sunxi

--- a/target/linux/sunxi/image/cortexa8.mk
+++ b/target/linux/sunxi/image/cortexa8.mk
@@ -6,6 +6,7 @@
 KERNEL_LOADADDR:=0x40008000
 
 define Device/cubietech_a10-cubieboard
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Cubietech
   DEVICE_MODEL := Cubieboard
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
@@ -14,6 +15,7 @@ endef
 TARGET_DEVICES += cubietech_a10-cubieboard
 
 define Device/haoyu_a10-marsboard
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := HAOYU Electronics
   DEVICE_MODEL := MarsBoard A10
   DEVICE_PACKAGES:=kmod-ata-core kmod-ata-sunxi kmod-sun4i-emac \
@@ -24,6 +26,7 @@ endef
 TARGET_DEVICES += haoyu_a10-marsboard
 
 define Device/linksprite_a10-pcduino
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := LinkSprite
   DEVICE_MODEL := pcDuino
   DEVICE_PACKAGES:=kmod-sun4i-emac kmod-rtc-sunxi kmod-rtl8192cu
@@ -32,6 +35,7 @@ endef
 TARGET_DEVICES += linksprite_a10-pcduino
 
 define Device/olimex_a10-olinuxino-lime
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A10-OLinuXino-LIME
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-sun4i-emac kmod-rtc-sunxi
@@ -40,6 +44,7 @@ endef
 TARGET_DEVICES += olimex_a10-olinuxino-lime
 
 define Device/olimex_a13-olimex-som
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A13-SOM
   DEVICE_PACKAGES:=kmod-rtl8192cu
@@ -50,6 +55,7 @@ endef
 TARGET_DEVICES += olimex_a13-olimex-som
 
 define Device/olimex_a13-olinuxino
+  $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A13-OLinuXino
   DEVICE_PACKAGES:=kmod-rtl8192cu

--- a/tools/gnulib/patches/195-c99-use-std-gnu23.patch
+++ b/tools/gnulib/patches/195-c99-use-std-gnu23.patch
@@ -1,0 +1,10 @@
+--- a/modules/c99
++++ b/modules/c99
+@@ -5,6 +5,7 @@ Files:
+ 
+ Depends-on:
+ std-gnu11
++std-gnu23
+ 
+ configure.ac:
+ 

--- a/tools/libtool/patches/001-always-install-aux.patch
+++ b/tools/libtool/patches/001-always-install-aux.patch
@@ -1,0 +1,11 @@
+--- a/libtoolize.in
++++ b/libtoolize.in
+@@ -1066,7 +1066,7 @@ func_install_pkgaux_files ()
+           func_ltmain_update "$file" "$pkgauxdir" "$aux_dir" pkgaux_header
+           ;;
+         *)
+-          test subproject = "$ltdl_mode" || continue
++          $opt_install || test subproject = "$ltdl_mode" || continue
+           func_copy "$file" "$pkgauxdir" "$aux_dir" pkgaux_header
+           ;;
+       esac


### PR DESCRIPTION
### **Specifications:**
SOC: MT7986AV
RAM: 1024MB
Flash: 256 MB SPI NAND
Ports: 4 LAN (1G) & 1 WAN (2.5G)
WIFI: MT7976GN + MT7976AN
LED: 1

### **Installation via UART:**

1. Configure TFTP server with IP 192.168.1.66. Copy `openwrt-mediatek-filogic-acer_predator-w6x-initramfs-kernel.bin` to TFTP root and rename to `predator.bin` 
2. Interrupt boot by pressing 0 on startup or select `U-Boot Console` in U-Boot Boot Menu.
3. Run `setenv serverip 192.168.1.66; setenv ipaddr 192.168.1.1; tftpboot 0x46000000 predator.bin` in uboot console.
4. Wait for boot complete on Openwrt.
5. On client PC, transfer `openwrt-mediatek-filogic-acer_predator-w6x-squashfs-sysupgrade.bin` to `/tmp/` - `scp -O openwrt-mediatek-filogic-acer_predator-w6x-squashfs-sysupgrade.bin root@192.168.1.1:/tmp/sysupgrade.bin`
6. On router, run sysupgrade - `sysupgrade -n /tmp/sysupgrade.bin`
7. Should now boot to Openwrt. Ensure it boots automatically to Openwrt by replugging the power.
 

Signed-off-by: Qing W.
ses1er@gmail.com