### PR TITLE
grub2: provide grub modules to boot an iso image

### DIFF
--- a/package/boot/grub2/Makefile
+++ b/package/boot/grub2/Makefile
@@ -7,7 +7,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=grub
 PKG_VERSION:=2.12
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/grub
@@ -26,6 +26,7 @@ endif
 
 PKG_FLAGS:=nonshared
 PKG_BUILD_FLAGS:=no-gc-sections no-lto no-mold
+RSTRIP:=:
 
 include $(INCLUDE_DIR)/host-build.mk
 include $(INCLUDE_DIR)/package.mk
@@ -43,6 +44,36 @@ Package/grub2=$(call Package/grub2/Default,x86,pc)
 Package/grub2-efi=$(call Package/grub2/Default,x86,efi)
 Package/grub2-efi-arm=$(call Package/grub2/Default,armsr,efi)
 Package/grub2-efi-loongarch64=$(call Package/grub2/Default,loongarch64,efi)
+
+define Package/grub2-efi-mods
+  CATEGORY:=Utilities
+  SECTION:=utils
+  SUBMENU:=Boot Loaders
+  TITLE:=Minimal set of modules for grub2 efi
+  URL:=http://www.gnu.org/software/grub/
+  DEPENDS:=+grub2-efi
+  VARIANT:=efi
+endef
+
+define Package/grub2-efi-mods/description
+	Minimal set of modules for grub2-efi which are need to boot a live linux iso
+	image directly from the grub menu.
+endef
+
+define Package/grub2-pc-mods
+  CATEGORY:=Utilities
+  SECTION:=utils
+  SUBMENU:=Boot Loaders
+  TITLE:=Minimal set of modules for grub2 i386
+  URL:=http://www.gnu.org/software/grub/
+  DEPENDS:=+grub2
+  VARIANT:=pc
+endef
+
+define Package/grub2-pc-mods/description
+	Minimal set of modules for grub2 which are need to boot a live linux iso
+	image directly from the grub menu.
+endef
 
 define Package/grub2-editenv
   CATEGORY:=Utilities
@@ -211,6 +242,20 @@ define Package/grub2-editenv/install
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/grub-editenv $(1)/usr/sbin/
 endef
 
+define Package/grub2-efi-mods/install
+	$(INSTALL_DIR) $(1)/boot/grub/x86_64-efi
+	for mod in ext2.mod iso9660.mod loopback.mod part_gpt.mod search.mod search_fs_file.mod search_fs_uuid.mod search_label.mod ; do \
+		$(CP) $(BUILD_DIR)/linux-x86_64/grub-efi/grub-2.12/grub-core/$$$$mod $(1)/boot/grub/x86_64-efi/ ; \
+	done
+endef
+
+define Package/grub2-pc-mods/install
+	$(INSTALL_DIR) $(1)/boot/grub/i386-pc
+	for mod in ext2.mod iso9660.mod loopback.mod part_gpt.mod search.mod search_fs_file.mod search_fs_uuid.mod search_label.mod ; do \
+		$(CP) $(BUILD_DIR)/linux-x86_64/grub-pc/grub-2.12/grub-core/$$$$mod $(1)/boot/grub/i386-pc/ ; \
+	done
+endef
+
 define Package/grub2-bios-setup/install
 	$(INSTALL_DIR) $(1)/usr/sbin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/grub-bios-setup $(1)/usr/sbin/
@@ -218,6 +263,8 @@ endef
 
 $(eval $(call HostBuild))
 $(eval $(call BuildPackage,grub2))
+$(eval $(call BuildPackage,grub2-pc-mods))
+$(eval $(call BuildPackage,grub2-efi-mods))
 $(eval $(call BuildPackage,grub2-efi))
 $(eval $(call BuildPackage,grub2-efi-arm))
 $(eval $(call BuildPackage,grub2-efi-loongarch64))


### PR DESCRIPTION
This commit create two new packages which contain a number of modules needed to boot a live linux iso such as an Arch Linux[1] image directly from the grub menu. The addition of `RSTRIP:=`: is needed or else the installed modules fail to load.

Rationale: A live linux environment is useful for system maintenance. A common way to access one is to boot from USB key which has been pre-imaged with such a distro. More convenient yet, is booting to one without the need and hassle of removable media, or editing boot order in the BIOS, etc.

Current size of modules:
grub2-efi-mods: approx 72 KiB
grub2-pc-mods: approx 44 KiB

Prerequisites for booting an image:
1. Either the grub2-efi-mods or grub2-pc-mods package
2. Manually downloaded copy of the target iso on an ext2/3/4 partition
3. Manually edited /boot/grub/grub.cfg with new menu entry

Example entry from step 3:

Change the `reldate` and `imgdevuuid` variables to match the values on your system. Optionally change the `isofile` variable if the iso is nested under directories and not on the root of the partition, for example: `/path/to/archlinux-$reldate-x86_64.iso`
```
menuentry "ISO loopback-Arch" {
  set reldate='2025.08.01'
  set imgdevuuid='781aae1f-e108-4434-be8d-5d426b7f63d7'
  set isofile="/archlinux-$reldate-x86_64.iso"

  insmod ext2
  insmod iso9660
  insmod loopback
  insmod search
  search --no-floppy --set=root --fs-uuid $imgdevuuid

  loopback loop $isofile
  linux (loop)/arch/boot/x86_64/vmlinuz-linux img_dev=UUID=$imgdevuuid img_loop=$isofile
  initrd (loop)/arch/boot/x86_64/initramfs-linux.img
}
```
Of course, this can be automatically added to `/boot/grub/grub.cfg` via a simple here document in `/etc/rc.local`. For example:
```
if ! grep -q 781aae1f-e108-4434-be8d-5d426b7f63d7 /boot/grub/grub.cfg; then
  cat <<'EOF' >> /boot/grub/grub.cfg

menuentry "ISO loopback-Arch" {
...
}
EOF
fi
```

1. https://archlinux.org/download/

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc (Intel N150 based box)