### PR TITLE
mpc85xx: tl-wdr4900: add back 5ghz LED

### DIFF
--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
@@ -398,18 +398,25 @@
 		compatible = "gpio-leds";
 
 		led-0 {
+			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-1 {
 			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WPS;
 		};
 
-		system_green: led-1 {
+		system_green: led-2 {
 			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
 		};
 
-		led-2 {
+		led-3 {
 			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_USB;
@@ -418,7 +425,7 @@
 			trigger-sources = <&hub_port1>;
 		};
 
-		led-3 {
+		led-4 {
 			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_USB;


### PR DESCRIPTION
In the conversion to dts, qca,led-pin was used for both interfaces. Unfortunately, it's mutually exclusive with gpio-controller which made it not do anything.

Fixes: 949e1a0 ("mpc85xx: tl-wdr4900: move platform code to dts")

ping @y3rs1n14 @urkelbundy @CHKDSK88

edit:
Fixes: https://github.com/openwrt/openwrt/issues/19677