### PR TITLE
kernel/modules: add BQ32000 I2C RTC kernel module support

### DIFF
--- a/package/kernel/linux/modules/rtc.mk
+++ b/package/kernel/linux/modules/rtc.mk
@@ -7,6 +7,24 @@
 
 RTC_MENU:=RTC Real-Time Clock Support
 
+define KernelPackage/rtc-bq32k
+  SUBMENU:=$(RTC_MENU)
+  TITLE:=Texas Instruments BQ32000 RTC support
+  DEFAULT:=m if ALL_KMODS && RTC_SUPPORT
+  DEPENDS:=+kmod-i2c-core
+  KCONFIG:=CONFIG_RTC_DRV_BQ32K \
+	CONFIG_RTC_CLASS=y
+  FILES:=$(LINUX_DIR)/drivers/rtc/rtc-bq32k.ko
+  AUTOLOAD:=$(call AutoProbe,rtc-bq32k)
+endef
+
+define KernelPackage/rtc-bq32k/description
+ Kernel module for Texas Instruments BQ32000 I2C RTC.
+endef
+
+$(eval $(call KernelPackage,rtc-bq32k))
+
+
 define KernelPackage/rtc-ds1307
   SUBMENU:=$(RTC_MENU)
   TITLE:=Dallas/Maxim DS1307 (and compatible) RTC support


### PR DESCRIPTION
Add support for the Texas Instruments BQ32000 I2C real-time clock chip.

Tested on a custom board based on Hi-Link HLK-7628N.