### PR TITLE
build: allow to skip stricter hash validation

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -159,9 +159,11 @@ $(if $(if $(MIRROR), \
 		( $(3) ) \
 		$(if $(filter-out x,$(MIRROR_HASH)), && ( \
 			file_hash="$$$$($(MKHASH) sha256 "$(DL_DIR)/$(FILE)")"; \
-			[ "$$$$file_hash" = "$(MIRROR_HASH)" ] || { \
-				echo "Hash mismatch for file $(FILE): expected $(MIRROR_HASH), got $$$$file_hash"; \
-				false; \
+			[ "$(MIRROR_HASH)" = "skip" ] || { \
+				[ "$$$$file_hash" = "$(MIRROR_HASH)" ] || { \
+					echo "Hash mismatch for file $(FILE): expected $(MIRROR_HASH), got $$$$file_hash"; \
+					false; \
+				}; \
 			}; \
 		)),
 	$(3)) \


### PR DESCRIPTION
Do not check the hash after packing the checkout if `MIRROR_HASH`
(`PKG_MIRROR_HASH`) variable is set to `skip` and do not fail the
build.

Fixes: https://github.com/openwrt/openwrt/commit/042996b46bd41292ef1fa2d58e3b824a547f4c55
Closes: https://github.com/openwrt/openwrt/issues/19757