### PR TITLE
realtek: create central DTS macro include

### DIFF
--- a/target/linux/realtek/dts/macros.dtsi
+++ b/target/linux/realtek/dts/macros.dtsi
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#define STRINGIZE(s) #s
+#define LAN_LABEL(p, s) STRINGIZE(p ## s)
+#define SWITCH_PORT_LABEL(n) LAN_LABEL(lan, n)
+
+#define INTERNAL_PHY(n) \
+	phy##n: ethernet-phy@##n { \
+		reg = <##n>; \
+		compatible = "ethernet-phy-ieee802.3-c22"; \
+		phy-is-integrated; \
+	};
+
+#define INTERNAL_PHY_SDS(n, s) \
+	phy##n: ethernet-phy@##n { \
+		reg = <##n>; \
+		compatible = "ethernet-phy-ieee802.3-c22"; \
+		phy-is-integrated; \
+		sds = <##s>; \
+	};
+
+#define EXTERNAL_PHY(n) \
+	phy##n: ethernet-phy@##n { \
+		reg = <##n>; \
+		compatible = "ethernet-phy-ieee802.3-c22"; \
+	};
+
+#define EXTERNAL_SFP_PHY(n) \
+	phy##n: ethernet-phy@##n { \
+		compatible = "ethernet-phy-ieee802.3-c22"; \
+		sfp; \
+		media = "fibre"; \
+		reg = <##n>; \
+	};
+
+#define EXTERNAL_SFP_PHY_FULL(n, s) \
+	phy##n: ethernet-phy@##n { \
+		compatible = "ethernet-phy-ieee802.3-c22"; \
+		sfp = <&sfp##s>; \
+		reg = <##n>; \
+	};
+
+#define SWITCH_PORT(n, s, m) \
+	port##n: port@##n { \
+		reg = <##n>; \
+		label = SWITCH_PORT_LABEL(s) ; \
+		phy-handle = <&phy##n>; \
+		phy-mode = #m ; \
+	};
+
+#define SWITCH_SFP_PORT(n, s, m) \
+	port##n: port@##n { \
+		reg = <##n>; \
+		label = SWITCH_PORT_LABEL(s) ; \
+		phy-handle = <&phy##n>; \
+		phy-mode = #m ; \
+		fixed-link { \
+			speed = <1000>; \
+			full-duplex; \
+		}; \
+	};

--- a/target/linux/realtek/dts/rtl838x.dtsi
+++ b/target/linux/realtek/dts/rtl838x.dtsi
@@ -1,69 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
+#include "macros.dtsi"
 #include <dt-bindings/clock/rtl83xx-clk.h>
 #include <dt-bindings/gpio/gpio.h>
 
 /dts-v1/;
-
-#define STRINGIZE(s) #s
-#define LAN_LABEL(p, s) STRINGIZE(p ## s)
-#define SWITCH_PORT_LABEL(n) LAN_LABEL(lan, n)
-
-#define INTERNAL_PHY(n) \
-	phy##n: ethernet-phy@##n { \
-		reg = <##n>; \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-		phy-is-integrated; \
-	};
-
-#define INTERNAL_PHY_SDS(n, s) \
-	phy##n: ethernet-phy@##n { \
-		reg = <##n>; \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-		phy-is-integrated; \
-		sds = <##s>; \
-	};
-
-#define EXTERNAL_PHY(n) \
-	phy##n: ethernet-phy@##n { \
-		reg = <##n>; \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-	};
-
-#define EXTERNAL_SFP_PHY(n) \
-	phy##n: ethernet-phy@##n { \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-		sfp; \
-		media = "fibre"; \
-		reg = <##n>; \
-	};
-
-#define EXTERNAL_SFP_PHY_FULL(n, s) \
-	phy##n: ethernet-phy@##n { \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-		sfp = <&sfp##s>; \
-		reg = <##n>; \
-	};
-
-#define SWITCH_PORT(n, s, m) \
-	port##n: port@##n { \
-		reg = <##n>; \
-		label = SWITCH_PORT_LABEL(s) ; \
-		phy-handle = <&phy##n>; \
-		phy-mode = #m ; \
-	};
-
-#define SWITCH_SFP_PORT(n, s, m) \
-	port##n: port@##n { \
-		reg = <##n>; \
-		label = SWITCH_PORT_LABEL(s) ; \
-		phy-handle = <&phy##n>; \
-		phy-mode = #m ; \
-		fixed-link { \
-			speed = <1000>; \
-			full-duplex; \
-		}; \
-	};
 
 / {
 	#address-cells = <1>;

--- a/target/linux/realtek/dts/rtl839x.dtsi
+++ b/target/linux/realtek/dts/rtl839x.dtsi
@@ -1,68 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
+#include "macros.dtsi"
 #include <dt-bindings/clock/rtl83xx-clk.h>
 
 /dts-v1/;
-
-#define STRINGIZE(s) #s
-#define LAN_LABEL(p, s) STRINGIZE(p ## s)
-#define SWITCH_PORT_LABEL(n) LAN_LABEL(lan, n)
-
-#define INTERNAL_PHY(n) \
-	phy##n: ethernet-phy@##n { \
-		reg = <##n>; \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-		phy-is-integrated; \
-	};
-
-#define INTERNAL_PHY_SDS(n, s) \
-	phy##n: ethernet-phy@##n { \
-		reg = <##n>; \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-		phy-is-integrated; \
-		sds = <##s>; \
-	};
-
-#define EXTERNAL_PHY(n) \
-	phy##n: ethernet-phy@##n { \
-		reg = <##n>; \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-	};
-
-#define EXTERNAL_SFP_PHY(n) \
-	phy##n: ethernet-phy@##n { \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-		sfp; \
-		media = "fibre"; \
-		reg = <##n>; \
-	};
-
-#define EXTERNAL_SFP_PHY_FULL(n, s) \
-	phy##n: ethernet-phy@##n { \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-		sfp = <&sfp##s>; \
-		reg = <##n>; \
-	};
-
-#define SWITCH_PORT(n, s, m) \
-	port@##n { \
-		reg = <##n>; \
-		label = SWITCH_PORT_LABEL(s) ; \
-		phy-handle = <&phy##n>; \
-		phy-mode = #m ; \
-	};
-
-#define SWITCH_SFP_PORT(n, s, m) \
-	port@##n { \
-		reg = <##n>; \
-		label = SWITCH_PORT_LABEL(s) ; \
-		phy-handle = <&phy##n>; \
-		phy-mode = #m ; \
-		fixed-link { \
-			speed = <1000>; \
-			full-duplex; \
-		}; \
-	};
 
 / {
 	#address-cells = <1>;

--- a/target/linux/realtek/dts/rtl930x.dtsi
+++ b/target/linux/realtek/dts/rtl930x.dtsi
@@ -1,14 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-/dts-v1/;
+#include "macros.dtsi"
 
-#define INTERNAL_PHY_SDS(n, s) \
-	phy##n: ethernet-phy@##n { \
-		reg = <##n>; \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-		phy-is-integrated; \
-		sds = <##s>; \
-	};
+/dts-v1/;
 
 / {
 	#address-cells = <1>;

--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -1,16 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
+#include "macros.dtsi"
 #include <dt-bindings/interrupt-controller/mips-gic.h>
 
 /dts-v1/;
-
-#define INTERNAL_PHY_SDS(n, s) \
-	phy##n: ethernet-phy@##n { \
-		reg = <##n>; \
-		compatible = "ethernet-phy-ieee802.3-c22"; \
-		phy-is-integrated; \
-		sds = <##s>; \
-	};
 
 / {
 	#address-cells = <1>;


### PR DESCRIPTION
The Realtek DTS's use several macros for convenient phy/port definition. These are repeated for the RTL83xx targets and most are missing for the RTL93xx targets. In the near future we want to add high port count switches with 1GBit Ethernet for them too. As a preparation provide a central include so the definition is only needed once and is available for all targets.