### PR TITLE
wifi-scripts: iface should be optional in wifi-vlan definition

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
@@ -143,22 +143,24 @@ function config_init(uci)
 	}
 
 	for (let name, data in sections.vlan) {
-		if (!data.iface || !vifs[data.iface])
-			continue;
-
-		for (let vif in vifs[data.iface]) {
-			let dev = devices[vif.device];
-			let handler = handlers[vif.device];
-			if (!dev || !handler)
+		for (let iface, iface_vifs in vifs) {
+			if (data.iface && data.iface != iface)
 				continue;
 
-			let config = parse_attribute_list(data, handler.vlan);
+			for (let vif in iface_vifs) {
+				let dev = devices[vif.device];
+				let handler = handlers[vif.device];
+				if (!dev || !handler)
+					continue;
 
-			let vlan = {
-				name,
-				config
-			};
-			push(vif.vlan, vlan);
+				let config = parse_attribute_list(data, handler.vlan);
+
+				let vlan = {
+					name,
+					config
+				};
+				push(vif.vlan, vlan);
+			}
 		}
 	}
 


### PR DESCRIPTION
The option iface should be optional according to the description of /etc/config/wireless in order to avoid repeating the definition for each virtual interface.

On [https://openwrt.org/docs/guide-user/network/wifi/basic#wi-fi_vlans](https://openwrt.org/docs/guide-user/network/wifi/basic#wi-fi_vlans) iface is defined as "Required: no". This was also the behaviour before switching to ucode scripts