### PR TITLE
wifi-scripts: Avoid syslog message variable data does not exist

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
@@ -221,7 +221,7 @@ function __run_next_handler()
 	wdev.dbg("run " + op);
 	if (name != mlo_name)
 		wdev_mlo_fixup(wdev.handler_config);
-	wdev.handler_config.data = wdev.handler_data[wdev.name];
+	wdev.handler_config.data = wdev.handler_data[wdev.name] || {};
 	wdev_script_task = netifd.process({
 		cb: () => run_handler_cb(wdev, cb),
 		dir: netifd.wireless.path,


### PR DESCRIPTION
Initialize data to {} if null before calling mac80211.sh to avoid a confusing error message in the syslog.

Fixes: https://github.com/openwrt/openwrt/issues/14010
