### PR TITLE
realtek: add support for XikeStor SKS8310-8X

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -61,6 +61,10 @@ tplink,tl-st1008f,v2)
 xikestor,sks8300-8x)
 	lan_mac=$(mtd_get_mac_binary board-info 0x1f1)
 	;;
+xikestor,sks8310-8x)
+	lan_mac=$(mtd_get_mac_binary factory 0x80)
+	label_mac="$lan_mac"
+	;;
 *)
 	lan_mac=$(mtd_get_mac_ascii u-boot-env2 mac_start)
 	lan_mac_end=$(mtd_get_mac_ascii u-boot-env2 mac_end)

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "xikestor,sks8310-8x", "realtek,rtl9303-soc";
+	model = "XikeStor SKS8310-8X";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* first 256 MiB */
+		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: led-0 {
+			gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		/*
+		 * LED set 0
+		 *
+		 * - LED[0](Green): 10G/LINK/ACT
+		 * - LED[1](Amber): 10M/100M/1G/2.5G/5G/LINK/ACT
+		 */
+		led_set0 = <0x0a01 0x0baa>;
+	};
+
+	sfp0: sfp-p1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2900>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp1: sfp-p2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp2: sfp-p3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp3: sfp-p4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp4: sfp-p5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c4>;
+		los-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp5: sfp-p6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c5>;
+		los-gpio = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 22 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp6: sfp-p7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c6>;
+		los-gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 25 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp7: sfp-p8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c7>;
+		los-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 28 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2900>;
+		#thermal-sensor-cells = <0>;
+	};
+
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	/* SDA0-7 correspond to GPIO9-16 */
+	i2c0: i2c@0 {
+		reg = <0>;
+	};
+	i2c1: i2c@1 {
+		reg = <1>;
+	};
+	i2c2: i2c@2 {
+		reg = <2>;
+	};
+	i2c3: i2c@3 {
+		reg = <3>;
+	};
+	i2c4: i2c@4 {
+		reg = <4>;
+	};
+	i2c5: i2c@5 {
+		reg = <5>;
+	};
+	i2c6: i2c@6 {
+		reg = <6>;
+	};
+	i2c7: i2c@7 {
+		reg = <7>;
+	};
+};
+
+&mdio_aux {
+	status = "okay";
+
+	gpio1: gpio@0 {
+		compatible = "realtek,rtl8231";
+		reg = <0>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio1 0 0 37>;
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x1c0000>;
+				read-only;
+			};
+
+			partition@1c0000 {
+				label = "u-boot-env";
+				reg = <0x1c0000 0x10000>;
+			};
+
+			partition@1d0000 {
+				label = "sysinfo";
+				reg = <0x1d0000 0x10000>;
+				read-only;
+			};
+
+			partition@1e0000 {
+				label = "factory";
+				reg = <0x1e0000 0x10000>;
+				read-only;
+			};
+
+			partition@1f0000 {
+				label = "sysdata";
+				reg = <0x1f0000 0x10000>;
+			};
+
+			partition@200000 {
+				label = "jffs2_filesystem";
+				reg = <0x200000 0xa00000>;
+			};
+
+			partition@c00000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0xc00000 0x1400000>;
+				openwrt,ih-magic = <0x93000000>;
+				openwrt,offset = <0x10>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		INTERNAL_PHY_SDS(0, 2)
+		INTERNAL_PHY_SDS(8, 3)
+		INTERNAL_PHY_SDS(16, 4)
+		INTERNAL_PHY_SDS(20, 5)
+		INTERNAL_PHY_SDS(24, 6)
+		INTERNAL_PHY_SDS(25, 7)
+		INTERNAL_PHY_SDS(26, 8)
+		INTERNAL_PHY_SDS(27, 9)
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			phy-handle = <&phy0>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp0>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@8 {
+			reg = <8>;
+			label = "lan2";
+			phy-handle = <&phy8>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp1>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@10 {
+			reg = <16>;
+			label = "lan3";
+			phy-handle = <&phy16>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp2>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@14 {
+			reg = <20>;
+			label = "lan4";
+			phy-handle = <&phy20>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp3>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@18 {
+			reg = <24>;
+			label = "lan5";
+			phy-handle = <&phy24>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp4>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@19 {
+			reg = <25>;
+			label = "lan6";
+			phy-handle = <&phy25>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp5>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@1a {
+			reg = <26>;
+			label = "lan7";
+			phy-handle = <&phy26>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp6>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@1b {
+			reg = <27>;
+			label = "lan8";
+			phy-handle = <&phy27>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp7>;
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@1c {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&thermal_zones {
+	sfp-thermal {
+		polling-delay-passive = <10000>;
+		polling-delay = <10000>;
+		thermal-sensors = <&sfp0>, <&sfp1>, <&sfp2>, <&sfp3>, <&sfp4>, <&sfp5>, <&sfp6>, <&sfp7>;
+		trips {
+			sfp-crit {
+				temperature = <110000>;
+				hysteresis = <1000>;
+				type = "critical";
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -51,6 +51,24 @@ define Device/xikestor_sks8300-8x
 endef
 TARGET_DEVICES += xikestor_sks8300-8x
 
+define Device/xikestor_sks8310-8x
+  SOC := rtl9303
+  UIMAGE_MAGIC := 0x93000000
+  DEVICE_VENDOR := XikeStor
+  DEVICE_MODEL := SKS8310-8X
+  IMAGE_SIZE := 20480k
+  $(Device/kernel-lzma)
+  IMAGE/sysupgrade.bin := \
+    pad-extra 16 | \
+    append-kernel | \
+    pad-to 64k | \
+    append-rootfs | \
+    pad-rootfs | \
+    check-size | \
+    append-metadata
+endef
+TARGET_DEVICES += xikestor_sks8310-8x
+
 define Device/zyxel_xgs1210-12
   SOC := rtl9302
   UIMAGE_MAGIC := 0x93001210


### PR DESCRIPTION
realtek: add support for XikeStor SKS8310-8X

XikeStor SKS8310-8X is a 8 ports Multi-Gig switch, based on
RTL9303.

Specification:

- SoC             : Realtek RTL9303
- RAM             : DDR3 512 MiB
- Flash           : SPI-NOR 32 MiB (Macronix)
- Ethernet        : 8x 1/2.5/10 Gbps (SFP+)
- LEDs/Keys (GPIO): 1x/1x
- UART            : "Console" port on the front panel
  - type          : RS-232C
  - connector     : RJ-45
  - settings      : 115200n8
- Power           : 12 VDC, 2 A

Flash instruction using initramfs image:

 1. Prepare TFTP server & connect to serial port. 
 2. Connect your PC to Port1 on SKS8310-8X
 3. Power on SKS8310-8X and interrupt with Ctrl + A
 4. Bypass vendor CLI with Ctrl + Q to enter U-Boot
 6. Set Switch IP and TFTP Server IP
	
	setenv ipaddr 192.168.10.12
	setenv serverip 192.168.10.232
	saveenv

 7. Enable Ethernet with the following commands

    	rtk network on

 7. Download initramfs image from TFTP server

    	tftpboot 0x82000000 <image name>

 8. Boot with the downloaded image

    	bootm

 9. On the initramfs image, backup the stock firmware if needed
10. Copy sysupgrade image to the device
11. Erase "firmware" partition 

    	mtd erase firmware

12. Perform sysupgrade with the sysupgrade image
13. Wait ~120 sec to complete flashing
14. Change the U-Boot Environment with 

	setenv bootcmd bootm 0xb4c00000
	saveenv

15. Power cycle and boot into OpenWrt

##############

Reverting to stock firmware:

1. Write the Stock Binary using sysupgrade - ignore the warnings

2. After writing, reboot the device by power cycle

3. Interrupt Boot with Ctrl + A
 
4. Bypass vendor CLI with Ctrl + Q to enter U-Boot

5. setenv bootcmd boota
   saveenv

6. Power cycle and boot into Stock Firmware
