### PR TITLE
kernel: fix Mediatek queue size patch

### DIFF
--- a/target/linux/generic/pending-6.6/738-01-net-ethernet-mtk_eth_soc-reduce-rx-ring-size-for-older.patch
+++ b/target/linux/generic/pending-6.6/738-01-net-ethernet-mtk_eth_soc-reduce-rx-ring-size-for-older.patch
@@ -30,6 +30,24 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+@@ -5401,7 +5401,7 @@ static const struct mtk_soc_data mt2701_
+ 		.desc_size = sizeof(struct mtk_rx_dma),
+ 		.irq_done_mask = MTK_RX_DONE_INT,
+ 		.dma_l4_valid = RX_DMA_L4_VALID,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(512),
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+ 	},
+@@ -5429,7 +5429,7 @@ static const struct mtk_soc_data mt7621_
+ 		.desc_size = sizeof(struct mtk_rx_dma),
+ 		.irq_done_mask = MTK_RX_DONE_INT,
+ 		.dma_l4_valid = RX_DMA_L4_VALID,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(512),
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+ 	},
 @@ -5459,7 +5459,7 @@ static const struct mtk_soc_data mt7622_
  		.desc_size = sizeof(struct mtk_rx_dma),
  		.irq_done_mask = MTK_RX_DONE_INT,
@@ -57,3 +75,30 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
+@@ -5546,7 +5546,7 @@ static const struct mtk_soc_data mt7981_
+ 		.dma_l4_valid = RX_DMA_L4_VALID_V2,
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(512),
+ 	},
+ };
+ 
+@@ -5576,7 +5576,7 @@ static const struct mtk_soc_data mt7986_
+ 		.dma_l4_valid = RX_DMA_L4_VALID_V2,
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(1K),
+ 	},
+ };
+ 
+@@ -5629,7 +5629,7 @@ static const struct mtk_soc_data rt5350_
+ 		.dma_l4_valid = RX_DMA_L4_VALID_PDMA,
+ 		.dma_max_len = MTK_TX_DMA_BUF_LEN,
+ 		.dma_len_offset = 16,
+-		.dma_size = MTK_DMA_SIZE(2K),
++		.dma_size = MTK_DMA_SIZE(256),
+ 	},
+ };
+ 


### PR DESCRIPTION
This got added in commit 15887235, cherry-picked into the 24.10 branch as 642b5b61 and was partially lost in a manual patch refresh in 3a2a2c99.

The main branch still contains the full set of rx DMA size changes, so I assume it was lost by accident.

With rx.dma_size=2K, my TP-Link Archer MR600v2 (MT7621) randomly reboots due to OOM.

Signed-off-by: Stefan Dösinger <stefandoesinger@gmail.com>

---

See
forum.openwrt.org/t/debugging-memory-use-oom-crashes/238751 for my debugging.
