### PR TITLE
realtek: register ethernet device after NAPI context init

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -3277,10 +3277,6 @@ static int __init rtl838x_eth_probe(struct platform_device *pdev)
 	if (err)
 		return err;
 
-	err = devm_register_netdev(&pdev->dev, dev);
-	if (err)
-		return err;
-
 	for (int i = 0; i < priv->rxrings; i++) {
 		priv->rx_qs[i].id = i;
 		priv->rx_qs[i].priv = priv;
@@ -3288,6 +3284,10 @@ static int __init rtl838x_eth_probe(struct platform_device *pdev)
 	}
 
 	platform_set_drvdata(pdev, dev);
+
+	err = devm_register_netdev(&pdev->dev, dev);
+	if (err)
+		return err;
 
 	phy_mode = PHY_INTERFACE_MODE_NA;
 	err = of_get_phy_mode(dn, &phy_mode);


### PR DESCRIPTION
Booting Realtek switches via TFTP will have a chance of ~5% to fail with the following dump on SMP devices. Sample taken from RTL931x.

```
[    1.318320] rtl931x_chip_init: init ENCAP done
[    1.323360] rtl931x_chip_init: init MIB done
[    1.328337] rtl931x_chip_init: init ACL done
[    1.333219] rtl931x_chip_init: init ALE done
[    1.344307] CPU 0 Unable to handle kernel paging request at virtual address 00000000, epc == 00000000, ra == 806c5c4c
[    1.356418] Oops[#1]:
[    1.359067] CPU: 0 UID: 0 PID: 1 Comm: swapper/0 Not tainted 6.12.40 #0
[    1.366582] Hardware name: Linksys LGS352C
[    1.371226] $ 0   : 00000000 00000001 00000000 80b6cc44
[    1.377179] $ 4   : 836b0540 00000000 00000000 83011d38
[    1.383119] $ 8   : 00000000 ffffefff 00000001 80b08c08
[    1.389071] $12   : ffffffea 83011d34 00000072 00000558
[    1.395060] $16   : 836b0540 00000000 00000100 83011ebf
[    1.401003] $20   : 83011ec0 83011ec8 ffff8b3c 80b00000
[    1.406984] $24   : 00000000 80b08c38
[    1.412922] $28   : 83038000 83011e70 82fb37a0 806c5c4c
[    1.418888] Hi    : 0000014b
[    1.422201] Lo    : c74d8000
[    1.425490] epc   : 00000000 0x0
[    1.429191] ra    : 806c5c4c __napi_poll+0x4c/0x208
[    1.434728] Status: 11000403 KERNEL EXL IE
[    1.439497] Cause : 50800008 (ExcCode 02)
[    1.444040] BadVA : 00000000
[    1.447330] PrId  : 0001a120 (MIPS interAptiv (multi))
[    1.453157] Modules linked in:
[    1.456641] Process swapper/0 (pid: 1, threadinfo=(ptrval), task=(ptrval), tls=00000000)
[    1.465742] Stack : 82faf248 80a8d558 817ed500 ffff8b3a 836b0540 8066a348 82fb2bc0 836b0540
[    1.475209]         82fb3600 00000100 0000012c 806c6274 00000000 00000017 00000002 80196134
[    1.484701]         80b00000 83011ed0 83011eb8 83011e00 83011ec0 83011ec0 83011ec8 83011ec8
[    1.494233]         00000001 81920000 81920000 80aefe4c 836b0000 00000000 00000000 00000001
[    1.503686]         00000100 00000000 83011f20 80aefde0 00000000 8019ac14 80b01550 00000000
[    1.513144]         ...
[    1.515957] Call Trace:
[    1.515996]
[    1.520458] [<8066a348>] rtl93xx_net_irq+0x1a4/0x1ac
[    1.526116] [<806c6274>] net_rx_action+0x18c/0x360
[    1.531576] [<80196134>] __handle_irq_event_percpu+0x58/0x16c
[    1.538111] [<8019ac14>] handle_level_irq+0x1e0/0x1f4
[    1.543870] [<80133588>] handle_softirqs+0x14c/0x2ec
[    1.549488] [<801339e4>] irq_exit+0x84/0xb4
[    1.554183] [<805527dc>] plat_irq_dispatch+0x90/0xdc
[    1.559764] [<801019f0>] except_vec_vi_end+0xc4/0xd0
[    1.565337]
```

An network interrupt may be received before the device is setup properly. In this case NAPI structures are missing and __napi_poll() will find a NULL pointer in n->poll. Avoid this by registering the device after initialization is complete.

