### PR TITLE
realtek: RTL930x/RTL931x led_set defines, and led-set count debug print tidy-up

### DIFF
--- a/target/linux/realtek/dts/macros.dtsi
+++ b/target/linux/realtek/dts/macros.dtsi
@@ -61,3 +61,19 @@
 			full-duplex; \
 		}; \
 	};
+
+// LED Set mode definitions
+#define RTL93XX_LED_SET_NONE        (0)
+#define RTL93XX_LED_SET_10G         (1 << 0)
+#define RTL93XX_LED_SET_5G          (1 << 1)
+#define RTL93XX_LED_SET_2P5G        (1 << 3)
+#define RTL93XX_LED_SET_1G          (1 << 5)
+#define RTL93XX_LED_SET_100M        (1 << 7)
+#define RTL93XX_LED_SET_10M         (1 << 8)
+#define RTL93XX_LED_SET_LINK        (1 << 9)
+#define RTL93XX_LED_SET_LINK_BLINK  (1 << 10)
+#define RTL93XX_LED_SET_ACT         (1 << 11)
+#define RTL93XX_LED_SET_RX          (1 << 12)
+#define RTL93XX_LED_SET_TX          (1 << 13)
+#define RTL93XX_LED_SET_COLLISION   (1 << 14)
+#define RTL93XX_LED_SET_DUPLEX      (1 << 15)

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -2244,12 +2244,12 @@ static void rtl930x_set_distribution_algorithm(int group, int algoidx, u32 algom
 static void rtl930x_led_init(struct rtl838x_switch_priv *priv)
 {
 	struct device_node *node;
+	struct device *dev = priv->dev;
 	u32 pm = 0;
 
-	pr_debug("%s called\n", __func__);
 	node = of_find_compatible_node(NULL, NULL, "realtek,rtl9300-leds");
 	if (!node) {
-		pr_debug("%s No compatible LED node found\n", __func__);
+		dev_dbg(dev, "No compatible LED node found\n");
 		return;
 	}
 
@@ -2271,10 +2271,14 @@ static void rtl930x_led_init(struct rtl838x_switch_priv *priv)
 		sprintf(set_name, "led_set%d", set);
 		leds_in_this_set = of_property_count_u32_elems(node, set_name);
 
-		if (leds_in_this_set == 0 || leds_in_this_set > sizeof(set_config)) {
-			pr_err("%s led_set configuration invalid skipping over this set\n", __func__);
+		if (leds_in_this_set <= 0 || leds_in_this_set > sizeof(set_config)) {
+			if (leds_in_this_set != -EINVAL) {
+				dev_err(dev, "%s invalid, skipping this set, leds_in_this_set=%d, should be (0, %d]\n",
+					set_name, leds_in_this_set, sizeof(set_config));
+			}
 			continue;
 		}
+		dev_info(dev, "%s has %d LEDs configured\n", set_name, leds_in_this_set);
 
 		if (of_property_read_u32_array(node, set_name, set_config, leds_in_this_set)) {
 			break;
@@ -2323,7 +2327,7 @@ static void rtl930x_led_init(struct rtl838x_switch_priv *priv)
 	sw_w32(pm, RTL930X_LED_PORT_COMBO_MASK_CTRL);
 
 	for (int i = 0; i < 24; i++)
-		pr_debug("%s %08x: %08x\n",__func__, 0xbb00cc00 + i * 4, sw_r32(0xcc00 + i * 4));
+		dev_dbg(dev, "%08x: %08x\n", 0xbb00cc00 + i * 4, sw_r32(0xcc00 + i * 4));
 }
 
 const struct rtl838x_reg rtl930x_reg = {


### PR DESCRIPTION
Add defines for RTL930x and RTL931x led_set 'modes' (to avoid magic numbers in dts files).

Also tidy up the handling of led_sets on rtl930x devices (so it doesn't produce errors for missing led_sets)

Tested-on: Hasivo S1100WP-8GT-SE, RTL9303, 3xHC595 chips for LEDs
Signed-off-by: Bevan Weiss <bevan.weiss@gmail.com>