### PR TITLE
Use parallel gzip compression via host pigz

### DIFF
--- a/config/Config-images.in
+++ b/config/Config-images.in
@@ -335,6 +335,17 @@ menu "Target Images"
 		depends on TARGET_ROOTFS_EXT4FS || TARGET_x86 || TARGET_armsr || TARGET_malta || TARGET_loongarch64
 		default y
 
+	config TARGET_IMAGES_PIGZ
+		bool "Use pigz for parallel gzip compression"
+		depends on TARGET_IMAGES_GZIP
+		help
+		  Use pigz (parallel implementation of gzip, pronounced pig-zee) for much faster compression
+		  of gz images. This will significantly reduce compression times on multi-core systems. Enabling
+		  this will require pigz to be present on the host.
+
+		  Note that unless the build bots are also using pigz, images built with it will not be
+		  reproducible. See: https://openwrt.org/docs/guide-developer/security#reproducible_builds
+
 	comment "Image Options"
 
 	source "target/linux/*/image/Config.in"

--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -3,6 +3,12 @@
 IMAGE_KERNEL = $(word 1,$^)
 IMAGE_ROOTFS = $(word 2,$^)
 
+ifeq ($(CONFIG_TARGET_IMAGES_PIGZ),y)
+  GZIPCMD:=pigz
+else
+  GZIPCMD:=gzip
+endif
+
 define ModelNameLimit16
 $(shell printf %.16s "$(word 2, $(subst _, ,$(1)))")
 endef
@@ -472,7 +478,7 @@ define Build/libdeflate-gzip
 endef
 
 define Build/gzip
-	$(STAGING_DIR_HOST)/bin/gzip -f -9n -c $@ $(1) > $@.new
+	$(STAGING_DIR_HOST)/bin/$(GZIPCMD) -f -9n -c $@ $(1) > $@.new
 	@mv $@.new $@
 endef
 
@@ -480,7 +486,7 @@ define Build/gzip-filename
 	@mkdir -p $@.tmp
 	@cp $@ $@.tmp/$(word 1,$(1))
 	$(if $(SOURCE_DATE_EPOCH),touch -hcd "@$(SOURCE_DATE_EPOCH)" $@.tmp/$(word 1,$(1)) $(word 2,$(1)))
-	$(STAGING_DIR_HOST)/bin/gzip -f -9 -N -c $@.tmp/$(word 1,$(1)) $(word 2,$(1)) > $@.new
+	$(STAGING_DIR_HOST)/bin/$(GZIPCMD) -f -9 -N -c $@.tmp/$(word 1,$(1)) $(word 2,$(1)) > $@.new
 	@mv $@.new $@
 	@rm -rf $@.tmp
 endef

--- a/include/image.mk
+++ b/include/image.mk
@@ -15,6 +15,14 @@ ifndef IB
   endif
 endif
 
+ifeq ($(CONFIG_TARGET_IMAGES_PIGZ),y)
+  $(eval $(call SetupHostCommand,pigz,Please install 'pigz', \
+    pigz --version 2>&1 | grep pigz))
+  GZIPCMD:=pigz
+else
+  GZIPCMD:=gzip
+endif
+
 include $(INCLUDE_DIR)/feeds.mk
 include $(INCLUDE_DIR)/rootfs.mk
 
@@ -188,7 +196,7 @@ endef
 ifdef CONFIG_TARGET_IMAGES_GZIP
   define Image/Gzip
 	rm -f $(1).gz
-	gzip -9n $(1)
+	$(GZIPCMD) -9n $(1)
   endef
 endif
 
@@ -378,7 +386,7 @@ ifdef CONFIG_TARGET_ROOTFS_TARGZ
   define Image/Build/targz
 	$(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
 		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
-		-C $(TARGET_DIR)/ . | gzip -9n > $(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED))-rootfs.tar.gz
+		-C $(TARGET_DIR)/ . | $(GZIPCMD) -9n > $(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED))-rootfs.tar.gz
   endef
 endif
 endif
@@ -386,7 +394,7 @@ endif
 ifeq ($(filter-out cpiogz,$(ROOTFS_FILESYSTEM)),)
 ifdef CONFIG_TARGET_ROOTFS_CPIOGZ
   define Image/Build/cpiogz
-	( cd $(TARGET_DIR); find . | $(STAGING_DIR_HOST)/bin/cpio -o -H newc -R 0:0 | gzip -9n >$(BIN_DIR)/$(IMG_ROOTFS).cpio.gz )
+	( cd $(TARGET_DIR); find . | $(STAGING_DIR_HOST)/bin/cpio -o -H newc -R 0:0 | $(GZIPCMD) -9n >$(BIN_DIR)/$(IMG_ROOTFS).cpio.gz )
   endef
 endif
 endif
@@ -786,7 +794,7 @@ define Device/Build/image
   .IGNORE: $(BIN_DIR)/$(call DEVICE_IMG_NAME,$(1),$(2))
 
   $(BIN_DIR)/$(call DEVICE_IMG_NAME,$(1),$(2)).gz: $(KDIR)/tmp/$(call DEVICE_IMG_NAME,$(1),$(2))
-	gzip -c -9n $$^ > $$@
+	$(GZIPCMD) -c -9n $$^ > $$@
 
   $(BIN_DIR)/$(call DEVICE_IMG_NAME,$(1),$(2)): $(KDIR)/tmp/$(call DEVICE_IMG_NAME,$(1),$(2))
 	cp $$^ $$@

--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -173,6 +173,11 @@ $(eval $(call SetupHostCommand,unzip,Please install 'unzip', \
 $(eval $(call SetupHostCommand,bzip2,Please install 'bzip2', \
 	bzip2 --version </dev/null))
 
+ifeq ($(CONFIG_TARGET_IMAGES_PIGZ),y)
+  $(eval $(call SetupHostCommand,pigz,Please install 'pigz', \
+    pigz --version 2>&1 | grep pigz))
+endif
+
 $(eval $(call SetupHostCommand,wget,Please install GNU 'wget', \
 	wget --version | grep GNU))
 

--- a/package/Makefile
+++ b/package/Makefile
@@ -10,6 +10,12 @@ curdir:=package
 include $(INCLUDE_DIR)/feeds.mk
 include $(INCLUDE_DIR)/rootfs.mk
 
+ifeq ($(CONFIG_TARGET_IMAGES_PIGZ),y)
+  GZIPCMD:=pigz
+else
+  GZIPCMD:=gzip
+endif
+
 -include $(TMP_DIR)/.packagedeps
 package-y += kernel/linux
 $(curdir)/autoremove:=1
@@ -164,7 +170,7 @@ else
 			{ echo ""; echo ""; } >> Packages;; \
 		esac; \
 		$(SCRIPT_DIR)/make-index-json.py -f opkg -a "$(ARCH_PACKAGES)" Packages > index.json; \
-		gzip -9nc Packages > Packages.gz; \
+		$(GZIPCMD) -9nc Packages > Packages.gz; \
 	); done
 ifdef CONFIG_SIGNED_PACKAGES
 	@echo Signing package index...

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -30,6 +30,12 @@ include $(INCLUDE_DIR)/version.mk
 export REVISION
 export SOURCE_DATE_EPOCH
 
+ifeq ($(CONFIG_TARGET_IMAGES_PIGZ),y)
+  GZIPCMD:=pigz
+else
+  GZIPCMD:=gzip
+endif
+
 define Helptext
 Available Commands:
 	help:	This help text
@@ -216,7 +222,7 @@ package_index: FORCE
 	@mkdir -p $(TMP_DIR) $(TARGET_DIR)/tmp
 ifeq ($(CONFIG_USE_APK),)
 	(cd $(PACKAGE_DIR); $(SCRIPT_DIR)/ipkg-make-index.sh . > Packages && \
-		gzip -9nc Packages > Packages.gz; \
+		$(GZIPCMD) -9nc Packages > Packages.gz; \
 		$(if $(CONFIG_SIGNATURE_CHECK), \
 			$(STAGING_DIR_HOST)/bin/usign -S -m Packages -s $(BUILD_KEY)) \
 	) >/dev/null 2>/dev/null

--- a/target/linux/apm821xx/image/Makefile
+++ b/target/linux/apm821xx/image/Makefile
@@ -3,6 +3,12 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
+ifeq ($(CONFIG_TARGET_IMAGES_PIGZ),y)
+  GZIPCMD:=pigz
+else
+  GZIPCMD:=gzip
+endif
+
 define Build/boot-img
 	$(RM) -rf $@.bootdir
 	mkdir -p $@.bootdir/boot
@@ -66,7 +72,7 @@ define Build/prepend-dtb
 endef
 
 define Image/cpiogz
-	( cd $(TARGET_DIR); find . | cpio -o -H newc | gzip -9n >$(KDIR_TMP)/$(IMG_PREFIX)-rootfs.cpio.gz )
+	( cd $(TARGET_DIR); find . | cpio -o -H newc | $(GZIPCMD) -9n >$(KDIR_TMP)/$(IMG_PREFIX)-rootfs.cpio.gz )
 endef
 
 define Device/Default

--- a/target/linux/ath79/image/lzma-loader/Makefile
+++ b/target/linux/ath79/image/lzma-loader/Makefile
@@ -8,6 +8,12 @@
 
 include $(TOPDIR)/rules.mk
 
+ifeq ($(CONFIG_TARGET_IMAGES_PIGZ),y)
+  GZIPCMD:=pigz
+else
+  GZIPCMD:=gzip
+endif
+
 LZMA_TEXT_START	:= 0x81800000
 LOADADDR	:= 0x80060000
 LOADER		:= loader.bin
@@ -53,7 +59,7 @@ loader.gz: $(PKG_BUILD_DIR)/loader.bin
 	# (TP-Link TL-WR1043ND v1) don't work correctly when
 	# the uncompressed loader is too small (probably a cache
 	# invalidation issue)
-	dd if=$< bs=512K conv=sync | gzip -nc9 > $(LOADER_GZ)
+	dd if=$< bs=512K conv=sync | $(GZIPCMD) -nc9 > $(LOADER_GZ)
 
 loader.elf: $(PKG_BUILD_DIR)/loader.elf
 	$(CP) $< $(LOADER_ELF)

--- a/target/linux/bcm47xx/image/Makefile
+++ b/target/linux/bcm47xx/image/Makefile
@@ -5,6 +5,12 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
+ifeq ($(CONFIG_TARGET_IMAGES_PIGZ),y)
+  GZIPCMD:=pigz
+else
+  GZIPCMD:=gzip
+endif
+
 USB1_PACKAGES := kmod-usb-ohci
 USB2_PACKAGES := $(USB1_PACKAGES) kmod-usb2
 
@@ -19,7 +25,7 @@ define Image/Prepare
 	# Less optimal LZMA compression (no dictionary), handled by CFE.
 	$(STAGING_DIR_HOST)/bin/lzma e -so -d16 $(KDIR)/vmlinux > $(KDIR)/vmlinux-nodictionary.lzma
 
-	gzip -nc9 $(KDIR)/vmlinux > $(KDIR)/vmlinux.gz
+	$(GZIPCMD) -nc9 $(KDIR)/vmlinux > $(KDIR)/vmlinux.gz
 ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
 	cat $(KDIR)/vmlinux-initramfs | $(STAGING_DIR_HOST)/bin/lzma e -si -so -eos -lc1 -lp2 -pb2 > $(KDIR)/vmlinux-initramfs.lzma
 	$(STAGING_DIR_HOST)/bin/lzma e -so -d16 $(KDIR)/vmlinux-initramfs > $(KDIR)/vmlinux-initramfs-nodictionary.lzma

--- a/target/linux/bcm47xx/image/lzma-loader/src/Makefile
+++ b/target/linux/bcm47xx/image/lzma-loader/src/Makefile
@@ -17,6 +17,12 @@
 #   Cleaned up, modified for lzma support, removed from kernel
 #
 
+ifeq ($(CONFIG_TARGET_IMAGES_PIGZ),y)
+  GZIPCMD:=pigz
+else
+  GZIPCMD:=gzip
+endif
+
 TEXT_START	:= 0x80001000
 BZ_TEXT_START	:= 0x80d00000
 BZ_STACK_START	:= 0x80e00000
@@ -43,7 +49,7 @@ dep:
 install:
 
 loader.gz: loader
-	gzip -nc9 $< > $@
+	$(GZIPCMD) -nc9 $< > $@
 
 loader.elf: loader.o
 	cp $< $@

--- a/target/linux/lantiq/image/lzma-loader/Makefile
+++ b/target/linux/lantiq/image/lzma-loader/Makefile
@@ -8,6 +8,12 @@
 
 include $(TOPDIR)/rules.mk
 
+ifeq ($(CONFIG_TARGET_IMAGES_PIGZ),y)
+  GZIPCMD:=pigz
+else
+  GZIPCMD:=gzip
+endif
+
 LZMA_TEXT_START	:=
 LOADADDR	:=
 LOADER		:= loader.bin
@@ -53,7 +59,7 @@ loader-compile: $(PKG_BUILD_DIR)/.prepared
 		clean all
 
 loader.gz: $(PKG_BUILD_DIR)/loader.bin
-	gzip -nc9 $< > $(LOADER_GZ)
+	$(GZIPCMD) -nc9 $< > $(LOADER_GZ)
 
 loader.elf: $(PKG_BUILD_DIR)/loader.elf
 	$(CP) $< $(LOADER_ELF)

--- a/target/linux/ramips/image/lzma-loader/Makefile
+++ b/target/linux/ramips/image/lzma-loader/Makefile
@@ -8,6 +8,12 @@
 
 include $(TOPDIR)/rules.mk
 
+ifeq ($(CONFIG_TARGET_IMAGES_PIGZ),y)
+  GZIPCMD:=pigz
+else
+  GZIPCMD:=gzip
+endif
+
 LZMA_TEXT_START	:= 0x80a00000
 LOADER		:= loader.bin
 LOADER_NAME	:= $(basename $(notdir $(LOADER)))
@@ -53,7 +59,7 @@ loader-compile: $(PKG_BUILD_DIR)/.prepared
 		clean all
 
 loader.gz: $(PKG_BUILD_DIR)/loader.bin
-	gzip -nc9 $< > $(LOADER_GZ)
+	$(GZIPCMD) -nc9 $< > $(LOADER_GZ)
 
 loader.elf: $(PKG_BUILD_DIR)/loader.elf
 	$(CP) $< $(LOADER_ELF)


### PR DESCRIPTION
[pigz](https://www.zlib.net/pigz) is a drop-in/fully functional replacement for `gzip` that exploits multiple processors and multiple cores when compressing data. To enable it, a new option has been introduced under:
```
Target Images > Use pigz for parallel gzip compression
```
which serves as an opt-in to insure that users wanting reproducible builds are not surprised by different checksum values when building on their own (see: https://openwrt.org/docs/guide-developer/security#reproducible_builds). This assume that the build bot farm will be using single-threaded `gzip` and not `pigz` for compression.

Value proposition of using `pigz` is a speed up appox 10-20x on pure compression tasks such as the build system compressing the images for x86/64 and nearly 50% faster build times considering build tasks. See details from the commit msg:
```
    Data
    Compression task:
     Significant time savings are realized when compressing images, eg.
     openwrt-x86-64-generic-ext4-combined.img (962 MB total size/192 MB
     kernel + 768 MB rootfs with 34% data use with the rest of the
     partitions being empty space) with pigz.

     Processor         | Compute | gzip -9  | pigz -9  | pigz time advantage
                       | Units   | time (s) | time (s) | as %'age | as fold
     ------------------|---------|----------|----------|----------|---------
     AMD Ryzen 9 9950X | 16C/32T | ~20      | ~1       | ~1,900%  | ~20x
     AMD Ryzen 5 7600  |  6C/12T | ~24      | ~2       | ~1,100%  | ~12x
     Intel i7-4790K    |  4C/4T  | ~31      | ~6       | ~417%    | ~5x

     Each compression task was run 3x and the approx avg value reported above.
     The spread in the times measured were so close together that computing
     the sigma value is nonsensical. Even the now 11-year old 4th Gen i7 CPU
     saw some significant gains in compression times with pigz.
    
    Build image task:
     Another measure is simply running make after having already built all
     the packages which effectively just recreates the images after checking
     that everything is built. Here the task finished 47% faster with pigz.
    
     On the Ryzen 9 9950X:
     * with gzip avg. time was 100±1 sec (n=3 runs)
     * with pigz avg. time was 68±6 sec (n=3 runs)
```

Compressing with pigz results in archives that are slightly larger (fractions of a percent) than those compressed with gzip. From the commit message:
```
Size comparison
pigz compressed files are a fraction of a percent larger than those
compressed with gzip. To illustrate, several official OpenWrt 24.10.2
images[3] were first decompressed and then compressed with each util.

file       : openwrt-24.10.2-x86-64-generic-ext4-combined-efi.img.gz
pigz -9    : 13,866,611 bytes
gzip -9    : 13,849,201 bytes
net change :     17,410 bytes (+0.13%)

file       : openwrt-24.10.2-x86-64-rootfs.tar.gz
pigz -9    : 4,599,973 bytes
gzip -9    : 4,591,862 bytes
net change :     8,111 bytes (+0.18%)
```

The PR has been tested both with and without `pigz` on the host system, and with and without the new option set. All cases behaved as expected:
| CONFIG_TARGET_IMAGES_PIGZ     | pigz on host | compression used* |
| ---      | ---       |  ---       |
|# CONFIG_TARGET_IMAGES_PIGZ is not set|n|gzip|
|# CONFIG_TARGET_IMAGES_PIGZ is not set|y|gzip|
|CONFIG_TARGET_IMAGES_PIGZ=y|n|refused to run as expected|
|CONFIG_TARGET_IMAGES_PIGZ=y|y|pigz|

* Assessed by running the following during the various builds:
```
% watch -n 0.05 ./is_gzip_or_pigz_being_used.sh
```
Where `is_gzip_or_pigz_being_used.sh` is:
```
#!/bin/bash
LOG_FILE=/scratch/ok.log
# Get current timestamp
TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')

# Check if pigz is running using pidof
PIDZ=$(pidof pigz)
PIDG=$(pidof gzip)

isz() {
  if [ -n "$PIDZ" ]; then
    # pigz is running, echo PIDs to log file
    echo "[$TIMESTAMP] pigz is running with PID(s): $PIDZ" >> "$LOG_FILE"
  fi
}

isg() {
  if [ -n "$PIDG" ]; then
    # pigz is running, echo PIDs to log file
    echo "[$TIMESTAMP] gzip is running with PID(s): $PIDG" >> "$LOG_FILE"
  fi
}

isz
isg
```
Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc (Intel N150 based box)