### PR TITLE
mediatek: Add support for DLink M32 with merged kernel1 and kernel2 partitions for more storage

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7622
@@ -21,6 +21,7 @@ asiarf,ap7622-wh1)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x1000" "0x10000"
 	;;
 dlink,eagle-pro-ai-m32-a1|\
+dlink,eagle-pro-ai-m32-a1-large|\
 dlink,eagle-pro-ai-r32-a1)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x2000" "0x2000"
 	;;

--- a/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-m32-a1-large.dts
+++ b/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-m32-a1-large.dts
@@ -64,12 +64,12 @@
 &snand {
 	partitions {
 		/* Delete Kernel2 */
-		/delete-node/ partition@2FC0000;
+		/delete-node/ partition@2fc0000;
 
 		/* Override Kernel1 */
-		partition@2C0000 {
+		partition@2c0000 {
 			label = "Kernel1";
-			reg = <0x002C0000 0x05A00000>;
+			reg = <0x002c0000 0x05a00000>;
 
 			compatible = "denx,fit";
 			openwrt,cmdline-match = "boot_part=Kernel1";

--- a/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-m32-a1-large.dts
+++ b/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-m32-a1-large.dts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7622-dlink-eagle-pro-ai-ax3200-a1.dtsi"
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "D-Link EAGLE PRO AI M32 A1 LARGE";
+	compatible = "dlink,eagle-pro-ai-m32-a1-large", "mediatek,mt7622";
+
+	aliases {
+		led-boot = &led_status_orange;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_white;
+		led-upgrade = &led_status_red;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_white: led-status-white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 85 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_orange: led-status-orange {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 20 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_status_red: led-status-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&switch {
+	ports {
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan1";
+		};
+	};
+};
+
+&odm_partition {
+	macaddr_odm: macaddr@83 {
+		compatible = "mac-base";
+		reg = <0x83 0x6>;
+		#nvmem-cell-cells = <1>;
+	};
+};
+
+&snand {
+	partitions {
+		/* Delete Kernel2 */
+		/delete-node/ partition@2FC0000;
+
+		/* Override Kernel1 */
+		partition@2C0000 {
+			label = "Kernel1";
+			reg = <0x002C0000 0x05A00000>;
+
+			compatible = "denx,fit";
+			openwrt,cmdline-match = "boot_part=Kernel1";
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x00000000 0x00800000>;
+			};
+
+			partition@800000 {
+				label = "ubi";
+				reg = <0x00800000 0x05200000>;
+			};
+		};
+	};
+};
+

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -196,6 +196,14 @@ define Device/dlink_eagle-pro-ai-m32-a1
 endef
 TARGET_DEVICES += dlink_eagle-pro-ai-m32-a1
 
+define Device/dlink_eagle-pro-ai-m32-a1-large
+  $(Device/dlink_eagle-pro-ai-ax3200-a1)
+  DEVICE_MODEL := EAGLE PRO AI M32 LARGE
+  DEVICE_DTS := mt7622-dlink-eagle-pro-ai-m32-a1-large
+  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | pad-to $$(IMAGE_SIZE) | dlink-ai-recovery-header DLK6E6010001 \x8D\x57\x30\x0B \x00\x00\x2C\x00 \x00\x00\xA0\x05 \x60\x6E
+endef
+TARGET_DEVICES += dlink_eagle-pro-ai-m32-a1-large
+
 define Device/dlink_eagle-pro-ai-r32-a1
   $(Device/dlink_eagle-pro-ai-ax3200-a1)
   DEVICE_MODEL := EAGLE PRO AI R32

--- a/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
@@ -12,8 +12,8 @@ mediatek_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
-	dlink,eagle-pro-ai-m32-a1-large|\
-	dlink,eagle-pro-ai-m32-a1)
+	dlink,eagle-pro-ai-m32-a1|\
+	dlink,eagle-pro-ai-m32-a1-large)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" wan
 		;;
 	elecom,wrc-2533gent|\

--- a/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
@@ -12,6 +12,7 @@ mediatek_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
+	dlink,eagle-pro-ai-m32-a1-large|\
 	dlink,eagle-pro-ai-m32-a1)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" wan
 		;;

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -19,6 +19,7 @@ platform_do_upgrade() {
 		buffalo_do_upgrade "$1"
 		;;
 	dlink,eagle-pro-ai-m32-a1|\
+	dlink,eagle-pro-ai-m32-a1-large|\
 	dlink,eagle-pro-ai-r32-a1|\
 	elecom,wrc-x3200gst3|\
 	mediatek,mt7622-rfb1-ubi|\
@@ -59,6 +60,7 @@ platform_check_image() {
 		buffalo_check_image "$board" "$magic" "$1" || return 1
 		;;
 	dlink,eagle-pro-ai-m32-a1|\
+	dlink,eagle-pro-ai-m32-a1-large|\
 	dlink,eagle-pro-ai-r32-a1|\
 	elecom,wrc-x3200gst3|\
 	mediatek,mt7622-rfb1-ubi|\


### PR DESCRIPTION
This PR merges kernel1 and kernel2 into a single partition, removing kernel2 from the DTSI. This increases available storage from ~30 MB to ~60 MB while maintaining compatibility with standard M32 builds. Kernel2 is not used and the original developer wanted to preserve the OEM flash layout, but this is no longer needed as decryption of firmware is possible. I will make an effort to update the wiki with this information once this is approved.

As I only own M32 routers, I am unable to test on R32, but I was able to migrate an existing OpenWRT small storage build over to this new one.

This change is based on RolandoMagico’s M32-R32-large fork
https://github.com/RolandoMagico/openwrt/tree/M32-R32-large
* Merges kernel1 and kernel2 partitions into a single kernel.
* Removes kernel2 from the main DLink MT7622 DTSI.
* Provides compatibility with both standard M32 builds and large-storage builds.
By merging kernel1 and kernel2, devices gain ~60 MB of usable storage space instead of the ~30 MB available before.

Migration Instructions
To migrate from an existing OpenWrt build (with the original kernel1+kernel2 layout):
1. Revert to stock firmware using the Recovery Web Interface
    * Set your computer IP to 192.168.0.10, subnet mask 255.255.255.0.
    * Hold the reset button while powering on the device.
    * Keep holding until the top LED blinks rapidly.
    * Open a Chromium-based browser and go to http://192.168.0.1.
    * Flash a decrypted D-Link firmware image (see below).
    * Perform a reset once flashing completes.
2. Decrypt a D-Link firmware image
    * Download m32-firmware-util.c.
    * (Optional) Use GitHub Codespaces instead of local compilation.
    * Compile the tool:
    * gcc m32-firmware-util.c -lcrypto -o m32-firmware-util
    * Run the decryption:./m32-firmware-util M32 --DecryptFactoryImage <OriginalFirmware> <OutputFile>
    * Example:./m32-firmware-util M32 --DecryptFactoryImage M32A1_FW103B01.bin M32A1_FW103B01.decrypted.bin
3. Flash OpenWrt with the new partition layout
    * Return to the Recovery Web Interface.
    * Flash the OpenWrt M32-large recovery firmware bin.

After reboot, the device should report the increased available storage space.

Signed-off-by: Dan T. <daniyo27@gmail.com>
