### PR TITLE
[24.10] ipq40xx: dts: reduce the maximum SPI clock frequency to 24MHz

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cap-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-cap-ac.dts
@@ -160,7 +160,7 @@
 	flash@0 {
 		reg = <0>;
 		compatible = "jedec,spi-nor";
-		spi-max-frequency = <40000000>;
+		spi-max-frequency = <24000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ens620ext.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ens620ext.dts
@@ -150,7 +150,7 @@
 		#size-cells = <0>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <50000000>;
+		spi-max-frequency = <24000000>;
 		m25p,fast-read;
 
 		partitions {

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-ex61x0v2.dtsi
@@ -190,7 +190,7 @@
 	mx25l12805d@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <45000000>;
+		spi-max-frequency = <24000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-hap-ac2.dts
@@ -155,7 +155,7 @@
 	flash@0 {
 		reg = <0>;
 		compatible = "jedec,spi-nor";
-		spi-max-frequency = <40000000>;
+		spi-max-frequency = <24000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-nbg6617.dts
@@ -170,7 +170,7 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <50000000>;
+		spi-max-frequency = <24000000>;
 		status = "okay";
 		m25p,fast-read;
 

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-rt-ac58u.dts
@@ -182,7 +182,7 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		linux,modalias = "m25p80", "mx25l1606e", "n25q128a11";
-		spi-max-frequency = <30000000>;
+		spi-max-frequency = <24000000>;
 
 		partitions {
 			compatible = "fixed-partitions";
@@ -236,7 +236,7 @@
 	spi-nand@1 {
 		compatible = "spi-nand";
 		reg = <1>;
-		spi-max-frequency = <30000000>;
+		spi-max-frequency = <24000000>;
 
 		/*
 		 * U-boot looks for "spinand,mt29f" node,

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-sxtsq-5-ac.dts
@@ -159,7 +159,7 @@
 	flash@0 {
 		reg = <0>;
 		compatible = "jedec,spi-nor";
-		spi-max-frequency = <40000000>;
+		spi-max-frequency = <24000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wac510.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wac510.dts
@@ -206,7 +206,7 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		spi-max-frequency = <50000000>;
+		spi-max-frequency = <24000000>;
 		reg = <0>;
 
 		partitions {
@@ -298,7 +298,7 @@
 	nand@1 {
 		compatible = "spi-nand";
 		reg = <1>;
-		spi-max-frequency = <48000000>;
+		spi-max-frequency = <24000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wap-ac.dtsi
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-wap-ac.dtsi
@@ -123,7 +123,7 @@
 	flash@0 {
 		reg = <0>;
 		compatible = "jedec,spi-nor";
-		spi-max-frequency = <40000000>;
+		spi-max-frequency = <24000000>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3.dts
@@ -226,7 +226,7 @@
 	flash@0 {
 		reg = <0>;
 		compatible = "jedec,spi-nor";
-		spi-max-frequency = <40000000>;
+		spi-max-frequency = <24000000>;
 
 		partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
The IPQ4019 datasheet indicates that the maximum supported SPI
frequency is 25 MHz. My experiment on SKSpruce WIA3300-20 shows
that exceeding this threshold can lead to instability of SPI
peripheral. Limit the SPI clock frequency to the QSDK recommended
value 24MHz to enhance stability.

Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
Link: https://github.com/openwrt/openwrt/pull/19744
Signed-off-by: Robert Marko <robimarko@gmail.com>
(cherry picked from commit 3ff8a3dca8bc24296f501b3c74214eb5005354bf)

Original PR: https://github.com/openwrt/openwrt/pull/19744