### PR TITLE
realtek: switch cameo devices from gzip to lzma images

### DIFF
--- a/target/linux/realtek/image/common.mk
+++ b/target/linux/realtek/image/common.mk
@@ -5,9 +5,16 @@ define Device/cameo-fw
   KERNEL := \
 	kernel-bin | \
 	append-dtb | \
-	libdeflate-gzip | \
-	uImage gzip | \
+	rt-compress | \
+	rt-loader | \
+	uImage none | \
 	cameo-tag
+  KERNEL_INITRAMFS := \
+	kernel-bin | \
+	append-dtb | \
+	rt-compress | \
+	rt-loader | \
+	uImage none
   IMAGES += factory_image1.bin
   IMAGE/factory_image1.bin := \
 	append-kernel | \


### PR DESCRIPTION
These RTL83xx devices have a simple U-Boot that only supports gzip compression. These are mainly D-Link DGS-1210 and the Apresia Light GS120GT-SS. Reduce the image size by ~1MB by switching over to lzma compression and rt-loader.