### PR TITLE
realtek: rtl93xx: fix incorrect physical port selection

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -156,7 +156,8 @@ static void rtl839x_create_tx_header(struct p_hdr *h, unsigned int dest_port, in
 static void rtl930x_create_tx_header(struct p_hdr *h, unsigned int dest_port, int prio)
 {
 	h->cpu_tag[0] = 0x8000;  /* CPU tag marker */
-	h->cpu_tag[1] = h->cpu_tag[2] = 0;
+	h->cpu_tag[1] = 0x0200; /* Set FWD_TYPE to LOGICAL (2) */
+	h->cpu_tag[2] = 0;
 	h->cpu_tag[3] = 0;
 	h->cpu_tag[4] = 0;
 	h->cpu_tag[5] = 0;
@@ -171,7 +172,8 @@ static void rtl930x_create_tx_header(struct p_hdr *h, unsigned int dest_port, in
 static void rtl931x_create_tx_header(struct p_hdr *h, unsigned int dest_port, int prio)
 {
 	h->cpu_tag[0] = 0x8000;  /* CPU tag marker */
-	h->cpu_tag[1] = h->cpu_tag[2] = 0;
+	h->cpu_tag[1] = 0x0200; /* Set FWD_TYPE to LOGICAL (2) */
+	h->cpu_tag[2] = 0;
 	h->cpu_tag[3] = 0;
 	h->cpu_tag[4] = h->cpu_tag[5] = h->cpu_tag[6] = h->cpu_tag[7] = 0;
 	if (dest_port >= 32) {


### PR DESCRIPTION
When testing LLDP and STP, we observed that locally generated multicast packets (e.g. LLDP, STP) were not restricted to the designated output port(s). For example, when transmitting on `lan1`, the same packet was also forwarded to other ports such as `lan2`.

Steps to reproduce:

1. Configure lldpd to use `lan1` in UCI and restart the service
2. Connect devices to `lan1` and `lan2`
3. Observe that the device on `lan2` still receives LLDP packets

The issue was caused by an incorrect `FWD_TYPE` setting in the TX CPU TAG, which failed to enforce the selected egress port(s).

Fix this by updating the TX CPU TAG to set `FWD_TYPE` correctly, ensuring that locally generated packets are transmitted only on the intended port(s).
