### PR TITLE
tools: lzop: add patch bumping minimum CMake version to 3.5

### DIFF
--- a/tools/lzop/patches/002-bump-minimum-cmake-version.patch
+++ b/tools/lzop/patches/002-bump-minimum-cmake-version.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,7 +8,7 @@
+ # All Rights Reserved.
+ #
+ 
+-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+ 
+ #
+ # simple usage example (Unix):


### PR DESCRIPTION
Recent CMake releases require at least version 3.5.
