### PR TITLE
realtek: rtl93xx: Add LED Sync configuration 

### DIFF
--- a/target/linux/realtek/dts/rtl930x.dtsi
+++ b/target/linux/realtek/dts/rtl930x.dtsi
@@ -195,6 +195,44 @@
 		};
 	};
 
+	pinmux@1b000200 {
+		compatible = "pinctrl-single";
+		reg = <0x1b000200 0x4>;
+
+		pinctrl-single,bit-per-mux;
+		pinctrl-single,register-width = <32>;
+		pinctrl-single,function-mask = <0x1>;
+		#pinctrl-cells = <2>;
+
+		/* Enable GPIO 19 */
+		pinmux_disable_led_sync: disable-led-sync {
+			pinctrl-single,bits = <0x0 0x0 0x800>;
+		};
+
+		pinmux_enable_led_sync: enable-led-sync {
+			pinctrl-single,bits = <0x0 0x800 0x800>;
+		};
+
+		/* Enable GPIO 18 */
+		pinmux_disable_usb_led: disable-usb-led {
+			pinctrl-single,bits = <0x0 0x0 0x400>;
+		};
+
+		pinmux_enable_usb_led: enable-usb-led {
+			pinctrl-single,bits = <0x0 0x400 0x400>;
+		};
+
+		/* Disable SLV SPI CS - freeing any associated GPIOs */
+		pinmux_disable_slv_spi_cs: disable-slv-spi-cs {
+			pinctrl-single,bits = <0x0 0x0 0x3E0>;
+		};
+
+		/* Disable SLV SPI SDO - freeing any associated GPIOs */
+		pinmux_disable_slv_spi_sdo: disable-slv-spi-sdo {
+			pinctrl-single,bits = <0x0 0x0 0x1F>;
+		};
+	};
+
 	pinmux@1b00c600 {
 		compatible = "pinctrl-single";
 		reg = <0x1b00c600 0x4>;

--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -222,6 +222,26 @@
 		};
 	};
 
+	pinmux@1b001358 {
+		compatible = "pinctrl-single";
+		reg = <0x1b001358 0x4>;
+
+		pinctrl-single,bit-per-mux;
+		pinctrl-single,register-width = <32>;
+		pinctrl-single,function-mask = <0x1>;
+		#pinctrl-cells = <2>;
+
+		/* Enable GPIO6 and GPIO7, possibly unknown others */
+		pinmux_disable_jtag: disable_jtag {
+			pinctrl-single,bits = <0x0 0x0 0x8000>;
+		};
+
+		/* Controls GPIO0 */
+		pinmux_disable_sys_led: disable_sys_led {
+			pinctrl-single,bits = <0x0 0x0 0x100>;
+		};
+	};
+
 	pinmux@1b0007d4 {
 		compatible = "pinctrl-single";
 		reg = <0x1b0007d4 0x4>;

--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -231,6 +231,15 @@
 		pinctrl-single,function-mask = <0x1>;
 		#pinctrl-cells = <2>;
 
+		/* Enable GPIO 31 */
+		pinmux_disable_led_sync: disable-led-sync {
+			pinctrl-single,bits = <0x0 0x0 0x10000>;
+		};
+
+		pinmux_enable_led_sync: enable-led-sync {
+			pinctrl-single,bits = <0x0 0x10000 0x10000>;
+		};
+
 		/* Enable GPIO6 and GPIO7, possibly unknown others */
 		pinmux_disable_jtag: disable_jtag {
 			pinctrl-single,bits = <0x0 0x0 0x8000>;

--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -240,6 +240,22 @@
 			pinctrl-single,bits = <0x0 0x10000 0x10000>;
 		};
 
+		pinmux_enable_mdc_mdio_3: enable-mdc-mdio-3 {
+			pinctrl-single,bits = <0x0 0x1000 0x1000>;
+		};
+
+		pinmux_enable_mdc_mdio_2: enable-mdc-mdio-2 {
+			pinctrl-single,bits = <0x0 0x800 0x800>;
+		};
+
+		pinmux_enable_mdc_mdio_1: enable-mdc-mdio-1 {
+			pinctrl-single,bits = <0x0 0x400 0x400>;
+		};
+
+		pinmux_enable_mdc_mdio_0: enable-mdc-mdio-0 {
+			pinctrl-single,bits = <0x0 0x200 0x200>;
+		};
+
 		/* Enable GPIO6 and GPIO7, possibly unknown others */
 		pinmux_disable_jtag: disable_jtag {
 			pinctrl-single,bits = <0x0 0x0 0x8000>;
@@ -248,6 +264,10 @@
 		/* Controls GPIO0 */
 		pinmux_disable_sys_led: disable_sys_led {
 			pinctrl-single,bits = <0x0 0x0 0x100>;
+		};
+
+		pinmux_disable_ext_cpu: disable-ext-cpu {
+			pinctrl-single,bits = <0x0 0x0 0x4>;
 		};
 	};
 
@@ -273,6 +293,10 @@
 		#interrupt-cells = <3>;
 		interrupts = <GIC_SHARED 16 IRQ_TYPE_LEVEL_HIGH>;
 		phy-mode = "internal";
+
+		pinctrl-0 = <&pinmux_disable_ext_cpu>;
+		pinctrl-names = "default";
+
 		fixed-link {
 			speed = <1000>;
 			full-duplex;


### PR DESCRIPTION
The LED sync configuration in `GPIO_SEL_CTRL` (RTL930x) and `MAC_L2_GLOBAL_CTRL2` (RTL931x) allows the LED controller to generate an additional positive edge on the `STCP` ("STore Clock Pin", also known as `RCLK`) of the LED shift register after the actual content has already been shifted in using the normal shift clock. The LED shift register is then expected to copy the content from the shift register section into the storage registers, which act as the actual LED output control. This functionality is available in, and commonly used with, the[ SNx4HC595 family of shift registers](https://www.ti.com/lit/ds/symlink/sn74hc595.pdf).

To activate it, simply register it in the default state of the `realtek,rtl83xx-switch` node:

```
&switch0 {
    pinctrl-names = "default";
    pinctrl-0 = <&pinmux_enable_led_sync>;
    ....
};
```

It would be nicer when this can be directly added to the `led_set` node. But for this to work, `realtek,rtl9300-leds` must first be an actual device (known to the device core).

---

The pinmux-related registers on the RTL93xX SoC family are spread across various non-consecutive registers. It might be tempting to modify them directly in a specific driver (SPI, LED, etc.), but this would cause issues with parallel, non-locked read-modify-write operations, which are required to update individual portions of these registers.

This PR is therefore picking up the LED sync functionality from #19791 and adjusting the implementation to avoid access by different drivers without proper protection. This protection is implemented in the pinctrl driver using mutexes.

Future RTL931xx devices must now also specify the correct MDC configuration. For example, the Plasma Cloud PSX28 requires following in the `realtek,rtl83xx-switch` configuration:

```
@@ -417,6 +417,10 @@
 };
 
 &switch0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinmux_enable_mdc_mdio_0>,
+		    <&pinmux_enable_mdc_mdio_1>;
+
 	ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
```

It would be nicer when this can be directly added to the mdio_bus node. But for this to work, `realtek,rtl838x-mdio` must first be an actual device (known to the device core). Right now, it is all managed by the state of the actual device `realtek,rtl83xx-switch`.

It can be seen that only SET0 and SET1 must be enabled because all `rtl9300,smi-address` properties are one of two types:

```
			rtl9300,smi-address = <0 XXXXXXXXXX>;
			rtl9300,smi-address = <1 XXXXXXXXXX>;
```

---

The actual state of the selected functions can be seen in

```
grep '' /sys/kernel/debug/pinctrl/*.pinmux-pinctrl-single/pinmux-functions
```