### PR TITLE
build: add dash before abi_version if pkg name ends with digits

### DIFF
--- a/scripts/package-metadata.pl
+++ b/scripts/package-metadata.pl
@@ -685,6 +685,9 @@ sub gen_image_cyclonedxsbom() {
 	foreach my $name (@abipkgs) {
 		my $pkg = $package{$name};
 		my $abipkg = $name . $pkg->{abi_version};
+		if ($name =~ /\d$/) {
+			$abipkg = $name . "-" . $pkg->{abi_version};
+		}
 		$abimap{$abipkg} = $name;
 	}
 


### PR DESCRIPTION
When a package name ends with a digit (e.g. "libssl3"), concatenating the abi_version directly results in an error key (e.g. "libssl31.1") in the `%abi_map`.  Add a dash between the package name and abi_version to make the name in `%image_packages` maps correctly (e.g. "libssl3-1.1").

