### PR TITLE
realtek: convert access to RTL931x analog serdes pages

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
@@ -469,4 +469,7 @@ int rtmdio_930x_write_sds_phy(int sds, int page, int regnum, u16 val);
 int rtmdio_931x_read_sds_phy(int sds, int page, int regnum);
 int rtmdio_931x_write_sds_phy(int sds, int page, int regnum, u16 val);
 
+int rtmdio_931x_read_sds_phy_new(int sds, int page, int regnum);
+int rtmdio_931x_write_sds_phy_new(int sds, int page, int regnum, u16 val);
+
 #endif /* _RTL838X_ETH_H */


### PR DESCRIPTION
The RTL931x has 14 frontend and at least 26 backend serdes. Currently the programming functions always need to determine the right backend serdes from the given frontend serdes on their own.

We plan to provide a consistent serdes mapping to all callers as follows

```
Frontend SerDes  |  0  1  2  3  4  5  6  7  8  9 10 11 12 13 
-----------------+------------------------------------------ 
Backend SerDes 1 |  0  1  2  3  6  7 10 11 14 15 18 19 22 23 
Backend SerDes 2 |  0  1  2  4  6  8 10 12 14 16 18 20 22 24 
Backend SerDes 3 |  0  1  2  5  6  9 10 13 14 17 18 21 22 25

frontend page               "even" frontend SerDes     "odd" frontend SerDes
page 0x000-0x03f (analog):  page 0x000-0x03f back SDS  page 0x000-0x03f back SDS
page 0x100-0x13f (XSGMII1): page 0x000-0x03f back SDS  page 0x000-0x03f back SDS+1
page 0x200-0x23f (XSGMII2): page 0x000-0x03f back SDS  page 0x000-0x03f back SDS+2
```

As a first micro step provide some helpers that simply operate on frontend serdes and will determine the backend serdes on their own.

So rtmdio_931x_read_sds_phy() and rtmdio_931x_write_sds_phy() operate on backend serdes. While rtmdio_931x_read_sds_phy_**new**() and rtmdio_931x_write_sds_phy_**new**() operate on frontend serdes.

This is only an intermediate naming convention and will be cleanup afterwards.

In a first step make use of these new functions whenever we want to access the analog page. As the pages stay unchanged in the new functions conversion is as simple as this:

Old:
asds = rtl931x_get_analog_sds(...)
rtmdio_931x_read_sds_phy(asds, ...)

New:
rtmdio_931x_read_sds_phy_new(sds, ...)
