### PR TITLE
zram-swap: allow setting algorithm parameters

### DIFF
--- a/package/system/zram-swap/Makefile
+++ b/package/system/zram-swap/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=zram-swap
-PKG_RELEASE:=32
+PKG_RELEASE:=33
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 

--- a/package/system/zram-swap/files/zram.init
+++ b/package/system/zram-swap/files/zram.init
@@ -58,10 +58,15 @@ zram_comp_algo()
 {
 	local dev="$1"
 	local zram_comp_algo="$( uci -q get system.@system[0].zram_comp_algo )"
+	local zram_algo_params="$( uci -q get system.@system[0].zram_algo_params )"
 
 	if [ -z "$zram_comp_algo" ]; then
 		# default to lzo, which is always available
 		zram_comp_algo="lzo"
+	fi
+
+	if [ -e "/sys/block/$( basename "$dev" )/algorithm_params" ] && [ -n "$zram_algo_params" ]; then
+		echo "$zram_algo_params" > "/sys/block/$( basename "$dev" )/algorithm_params"
 	fi
 
 	if [ $(grep -c "$zram_comp_algo" /sys/block/$( basename $dev )/comp_algorithm) -ne 0 ]; then


### PR DESCRIPTION
Add a new system section option, zram_algo_params, in order to pass additional parameters to the zram compression algorithm. Note that the parameters are algorithm-specific, e.g. setting compression level to 9 for zstd:

	option zram_algo_params 'algo=zstd level=9'

This feature is only present in Linux 6.12+ and will be a no-op in previous kernel versions.

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>
