### PR TITLE
imagebuilder: limit IB build to only selected profiles.

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -951,6 +951,8 @@ define Device
 
 endef
 
+IB_DEVICE_CHECK_PROFILE = $(if $(CONFIG_IB_BUILD_SELECTED_PROFILES_ONLY),$(CONFIG_TARGET_$(if $(CONFIG_TARGET_MULTI_PROFILE),DEVICE_)$(BOARD)_$(SUBTARGET)_DEVICE_$(1)),$(1))
+
 define BuildImage
 
   ifneq ($(DUMP),)
@@ -993,7 +995,7 @@ define BuildImage
 	$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS),$(if $(IB),,$(call Image/BuildKernel/Initramfs)))
 	$(call Image/InstallKernel)
 
-  $(foreach device,$(TARGET_DEVICES),$(call Device,$(device)))
+  $(foreach device,$(TARGET_DEVICES),$(if $(call IB_DEVICE_CHECK_PROFILE,$(device)),$(call Device,$(device))))
 
   install-images: kernel_prepare $(foreach fs,$(filter-out $(if $(UBIFS_OPTS),,ubifs),$(TARGET_FILESYSTEMS) $(fs-subtypes-y)),$(KDIR)/root.$(fs))
 	$(foreach fs,$(TARGET_FILESYSTEMS),

--- a/target/imagebuilder/Config.in
+++ b/target/imagebuilder/Config.in
@@ -15,3 +15,13 @@ config IB_STANDALONE
 	  Disabling this option will cause the ImageBuilder to embed only
 	  toolchain and kmod packages while all other ipk archives will be
 	  fetched from online repositories.
+
+config IB_BUILD_SELECTED_PROFILES_ONLY
+	bool "Build selected target profiles only"
+	default n
+	depends on IB
+	help
+	  Enabling this will build the ImageBuilder with kernel images
+	  for selected target profiles (devices) only. This could speed up
+	  the build significantly if the ImageBuilder will be used to target
+	  only the limited number of devices.


### PR DESCRIPTION
Adds  new config variable: `CONFIG_IB_BUILD_SELECTED_PROFILES_ONLY`

If set, the build for ImageBuilder only builds kernel images for selected profiles (devices) in BOARD/SUBTARGET category.
This can save the build for IB build time when the ImageBuilder is used to build different images for single or limited set of devices, which differ only by configuration or installed packages.