### PR TITLE
toolchain/binutils: export ZSTD_CFLAGS/LIBS to fix non-Linux build

### DIFF
--- a/toolchain/binutils/Makefile
+++ b/toolchain/binutils/Makefile
@@ -38,6 +38,9 @@ PATCH_DIR:=./patches/$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/toolchain-build.mk
 
+export ZSTD_CFLAGS=-I$(STAGING_DIR_HOST)/include -pthread
+export ZSTD_LIBS=-L$(STAGING_DIR_HOST)/lib -lzstd -lpthread
+
 ifdef CONFIG_GCC_USE_GRAPHITE
   GRAPHITE_CONFIGURE:= --with-isl=$(STAGING_DIR_HOST)
 else


### PR DESCRIPTION
This is what 66dfbca262f4e6ebc1b4f94fb1c4482894c26d0c (updated by 2872ff7be19cfd20c95c4cbc880c0af38f82ea15) did for toolchain/gdb, but for toolchain/binutils, following the switch to binutils-2.44 by default in 854d88be8ad4f26059deeb3748617ca32dfdff15.

@nbd168