### PR TITLE
uboot-layerscape: do not build efimkcapsule tool

### DIFF
--- a/package/boot/uboot-layerscape/Makefile
+++ b/package/boot/uboot-layerscape/Makefile
@@ -151,6 +151,9 @@ UBOOT_TARGETS := \
   fsl_ls1021a-twr-sdboot \
   fsl_ls1021a-iot-sdboot
 
+UBOOT_CUSTOMIZE_CONFIG := \
+	--disable TOOLS_MKEFICAPSULE
+
 define Build/InstallDev
 	$(INSTALL_DIR) $(STAGING_DIR_IMAGE)
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/$(UBOOT_IMAGE) \


### PR DESCRIPTION
OpenWrt layerscape target does not use this command. If the host is missing gnutls, this tool will fail to build. Fix build error:

tools/mkeficapsule.c:20:10: fatal error: gnutls/gnutls.h: No such file or directory
   20 | #include <gnutls/gnutls.h>
      |          ^~~~~~~~~~~~~~~~~

Fixes: c773c3f4d377 ("uboot-layerscape: bump to lf-6.12.20-2.0.0")

cc @CHKDSK88

Ref: https://buildbot.openwrt.org/images/#/builders/156/builds/301