### PR TITLE
include: always set macro-prefix-map for reproducibility

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -174,7 +174,7 @@ else
 endif
 
 ifeq ($(or $(CONFIG_EXTERNAL_TOOLCHAIN),$(CONFIG_TARGET_uml)),)
-  iremap = -f$(if $(CONFIG_REPRODUCIBLE_DEBUG_INFO),file,macro)-prefix-map=$(1)=$(2)
+  iremap = -fmacro-prefix-map=$(1)=$(2) $(if $(CONFIG_REPRODUCIBLE_DEBUG_INFO),-ffile-prefix-map=$(1)=$(2))
 endif
 
 PACKAGE_DIR?=$(BIN_DIR)/packages


### PR DESCRIPTION
The current implementation either adds macro-prefix-map XOR file-prefix-map (if REPRODUCIBLE_DEBUG_INFO is defined). Let's have the former always active to improve the reproducibility.