### PR TITLE
mediatek: Add support for Acer Predator Connect W6x Ubootmod

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -568,6 +568,18 @@ define U-Boot/mt7986_rfb
   DEPENDS:=+trusted-firmware-a-mt7986-sdmmc-ddr4
 endef
 
+define U-Boot/mt7986_acer_predator-w6x
+  NAME:=Acer Predator Connect W6x
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=acer_predator-w6x-ubootmod
+  UBOOT_CONFIG:=mt7986_acer_predator-w6x
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand
+  BL2_SOC:=mt7986
+  BL2_DDRTYPE:=ddr4
+  DEPENDS:=+trusted-firmware-a-mt7986-spim-nand-ddr4
+endef
+
 define U-Boot/mt7986_bananapi_bpi-r3-emmc
   NAME:=BananaPi BPi-R3
   BUILD_SUBTARGET:=filogic
@@ -978,6 +990,7 @@ UBOOT_TARGETS := \
 	mt7981_snr_snr-cpe-ax2 \
 	mt7981_xiaomi_mi-router-ax3000t \
 	mt7981_xiaomi_mi-router-wr30u \
+	mt7986_acer_predator-w6x \
 	mt7986_bananapi_bpi-r3-emmc \
 	mt7986_bananapi_bpi-r3-sdmmc \
 	mt7986_bananapi_bpi-r3-snand \

--- a/package/boot/uboot-mediatek/patches/465-add-acer_predator-w6x.patch
+++ b/package/boot/uboot-mediatek/patches/465-add-acer_predator-w6x.patch
@@ -1,0 +1,318 @@
+--- /dev/null
++++ b/arch/arm/dts/mt7986a-acer_predator-w6x.dts
+@@ -0,0 +1,150 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++/dts-v1/;
++#include <dt-bindings/input/linux-event-codes.h>
++#include "mt7986.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++
++/ {
++	#address-cells = <1>;
++	#size-cells = <1>;
++	model = "Acer Predator Connect W6x";
++	compatible = "mediatek,mt7986", "mediatek,mt7986-sd-rfb";
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x20000000>;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		factory {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
++		};
++
++		wps {
++			label = "wps";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <0>;
++	phy-mode = "2500base-x";
++	mediatek,switch = "mt7531";
++	reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++	};
++};
++
++&pio {
++	spic_pins: spi1-pins-func-1 {
++		mux {
++			function = "spi";
++			groups = "spi1_2";
++		};
++	};
++
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
++		};
++
++		conf-pd {
++			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <1>;
++	sample_sel = <0>;
++	pinctrl-names = "default";
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++		spi-tx-bus-width = <4>;
++		spi-rx-bus-width = <4>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "bl2";
++				reg = <0x0 0x100000>;
++			};
++
++			partition@100000 {
++				label = "u-boot-env";
++				reg = <0x100000 0x80000>;
++			};
++
++			partition@180000 {
++				label = "factory";
++				reg = <0x180000 0x200000>;
++			};
++
++			partition@380000 {
++				label = "fip";
++				reg = <0x380000 0x200000>;
++			};
++
++			partition@580000 {
++				label = "prod";
++				reg = <0x580000 0x20000>;
++				read-only;
++			};
++
++			partition@600000 {
++				label = "ubi";
++				reg = <0x600000 0xD200000>;
++			};
++		};
++	};
++};
++
++&uart0 {
++	mediatek,force-highspeed;
++	status = "okay";
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/configs/mt7986_acer_predator-w6x_defconfig
+@@ -0,0 +1,105 @@
++CONFIG_ARM=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7986a-acer_predator-w6x"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7986=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_DEFAULT_FDT_FILE="mediatek/mt7986a-acer_predator-w6x.dtb"
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7986> "
++CONFIG_CMD_CPU=y
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_LINK_LOCAL=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_REDUNDANT=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_RELOC_GD_ENV_ADDR=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/acer_predator-w6x_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++# CONFIG_I2C is not set
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7986=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_RAM=y
++CONFIG_DM_SERIAL=y
++CONFIG_SERIAL_RX_BUFFER=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_RANDOM_UUID=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/defenvs/acer_predator-w6x_env
+@@ -0,0 +1,54 @@
++ethaddr_factory=mtd read u-boot-env 0x40080000 0x0 0x18000 && env import -t 0x40080004 0x18000 ethaddr ; setenv ethaddr_factory
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++bootargs=console=ttyS0,115200n8 console_msg_format=syslog
++bootcmd=if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
++bootconf=config-1
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-squashfs-sysupgrade.itb
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )[0m
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_production ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_recovery ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_6=[31mLoad BL31+U-Boot FIP via TFTP then write to NAND.[0m=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=[31mLoad BL2 preloader via TFTP then write to NAND.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_first=if button reset ; then run boot_tftp_recovery ; setenv flag_recover 1 ; run boot_default ; fi ; bootmenu
++boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
++boot_production=run ubi_read_production && bootm $loadaddr#$bootconf
++boot_recovery=run ubi_read_recovery && bootm $loadaddr#$bootconf
++boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
++boot_tftp_forever=while true ; do run boot_tftp_recovery ; sleep 1 ; done
++boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run ubi_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_production=tftpboot $loadaddr $bootfile_upg && env exists replacevol && iminfo $loadaddr && run ubi_write_production ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run mtd_write_fip && run reset_factory
++boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run mtd_write_bl2
++part_fit=fit
++reset_factory=ubi part ubi ; mw $loadaddr 0x0 0x800 ; ubi write $loadaddr ubootenv 0x800 ; ubi write $loadaddr ubootenv2 0x800
++mtd_write_fip=mtd erase fip && mtd write fip $loadaddr
++mtd_write_bl2=mtd erase bl2 && mtd write bl2 $loadaddr
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x100000 dynamic ; ubi check ubootenv2 || ubi create ubootenv2 0x100000 dynamic
++ubi_format=ubi detach ; mtd erase ubi && ubi part ubi ; reset
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_read_production=ubi read $loadaddr $part_fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run ethaddr_factory ; run _switch_to_menu ; run _init_env ; run boot_first
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -23,6 +23,7 @@ ubootenv_add_nor_default() {
 
 case "$board" in
 abt,asr3000|\
+acer,predator-w6x-ubootmod|\
 asus,zenwifi-bt8-ubootmod|\
 cmcc,a10-ubootmod|\
 cudy,tr3000-v1-ubootmod|\

--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6x-stock.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6x-stock.dts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7986a-acer-predator-w6x.dtsi"
+
+/ {
+	model = "Acer Predator Connect W6x (Stock Layout)";
+	compatible = "acer,predator-w6x-stock", "mediatek,mt7986a";
+};
+
+&partitions {
+	partition@600000 {
+		label = "dual";
+		reg = <0x600000 0x100000>;
+		read-only;
+	};
+
+	partition@700000 {
+		label = "pot";
+		reg = <0x700000 0x100000>;
+		read-only;
+	};
+
+	partition@800000 {
+		label = "ubi";
+		reg = <0x800000 0x6400000>;
+	};
+
+	partition@6C00000 {
+		label = "ubi1";
+		reg = <0x6C00000 0x6400000>;
+	};
+
+	partition@D000000 {
+		label = "storage";
+		reg = <0xD000000 0x800000>;
+	};
+};

--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6x-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6x-ubootmod.dts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7986a-acer-predator-w6x.dtsi"
+
+/ {
+	model = "Acer Predator Connect W6x (OpenWrt U-Boot Layout)";
+	compatible = "acer,predator-w6x-ubootmod", "mediatek,mt7986a";
+};
+
+&chosen {
+	rootdisk = <&ubi_rootdisk>;
+	bootargs-append = " root=/dev/fit0 rootwait";
+};
+
+&partitions {
+	partition@600000 {
+		label = "ubi";
+		reg = <0x600000 0xD200000>;
+		compatible = "linux,ubi";
+
+		volumes {
+			ubi_rootdisk: ubi-volume-fit {
+				volname = "fit";
+			};
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dtsi
@@ -9,14 +9,11 @@
 #include "mt7986a.dtsi"
 
 / {
-	model = "Acer Predator Connect W6x";
-	compatible = "acer,predator-w6x", "mediatek,mt7986a";
-
 	aliases {
 		serial0 = &uart0;
 	};
 
-    chosen {
+	chosen: chosen {
 		stdout-path = "serial0:115200n8";
 	};
 
@@ -56,15 +53,14 @@
 		compatible = "gpio-keys";
 
 		factory {
-			label = "factory";
+			label = "reset";
 			linux,code = <KEY_RESTART>;
-			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
 		};
-
 		wps {
 			label = "wps";
 			linux,code = <KEY_WPS_BUTTON>;
-			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
 		};
 	};
 };
@@ -159,12 +155,12 @@
 		conf-pu {
 			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
 			drive-strength = <MTK_DRIVE_8mA>;
-			bias-disable; /* bias-disable */
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
 		};
 		conf-pd {
 			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
 			drive-strength = <MTK_DRIVE_8mA>;
-			bias-disable; /* bias-disable */
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
 		};
 	};
 
@@ -225,7 +221,7 @@
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 
-		partitions {
+		partitions: partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -267,33 +263,6 @@
 				label = "prod";
 				reg = <0x580000 0x20000>;
 				read-only;
-			};
-
-			partition@600000 {
-				label = "dual";
-				reg = <0x600000 0x100000>;
-				read-only;
-			};
-
-			partition@700000 {
-				label = "pot";
-				reg = <0x700000 0x100000>;
-				read-only;
-			};
-
-			partition@800000 {
-				label = "ubi";
-				reg = <0x800000 0x6400000>;
-			};
-
-			partition@6C00000 {
-				label = "ubi1";
-				reg = <0x6C00000 0x6400000>;
-			};
-
-			partition@D000000 {
-				label = "storage";
-				reg = <0xD000000 0x800000>;
 			};
 		};
 	};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -16,7 +16,8 @@ acer,predator-w6d)
 	ucidef_set_led_netdev "internet" "INTERNET" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100 link_1000 tx rx"
 	ucidef_set_led_netdev "internet" "INTERNET" "mdio-bus:06:green:wan" "eth1" "link_2500 tx rx"
 	;;
-acer,predator-w6x)
+acer,predator-w6x-stock|\
+acer,predator-w6x-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "rgb:status" "eth1"
 	;;
 asus,rt-ax52|\

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -27,7 +27,8 @@ mediatek_setup_interfaces()
 	acer,predator-w6d)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 game" eth1
 		;;
-	acer,predator-w6x)
+	acer,predator-w6x-stock|\
+	acer,predator-w6x-ubootmod)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
 		;;
 	acer,vero-w6m)
@@ -186,7 +187,8 @@ mediatek_setup_macs()
 		wan_mac=$(mmc_get_mac_ascii u-boot-env WANMAC)
 		lan_mac=$(mmc_get_mac_ascii u-boot-env LANMAC)
 		;;
-	acer,predator-w6x)
+	acer,predator-w6x-stock|\
+	acer,predator-w6x-ubootmod)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac=$wan_mac

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -27,7 +27,8 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && mmc_get_mac_ascii u-boot-env 2gMAC > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && mmc_get_mac_ascii u-boot-env 5gMAC > /sys${DEVPATH}/macaddress
 		;;
-	acer,predator-w6x)
+	acer,predator-w6x-stock|\
+	acer,predator-w6x-ubootmod)
 		hw_mac_addr="$(mtd_get_mac_ascii u-boot-env ethaddr)"
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -12,7 +12,8 @@ preinit_set_mac_address() {
 		ip link set dev game address "$lan_mac"
 		ip link set dev eth1 address "$wan_mac"
 		;;
-	acer,predator-w6x)
+	acer,predator-w6x-stock|\
+	acer,predator-w6x-ubootmod)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		ip link set dev lan1 address "$lan_mac"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -79,6 +79,7 @@ platform_do_upgrade() {
 
 	case "$board" in
 	abt,asr3000|\
+	acer,predator-w6x-ubootmod|\
 	asus,zenwifi-bt8-ubootmod|\
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\
@@ -243,6 +244,7 @@ platform_check_image() {
 
 	case "$board" in
 	abt,asr3000|\
+	acer,predator-w6x-ubootmod|\
 	asus,zenwifi-bt8-ubootmod|\
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -193,10 +193,11 @@ define Device/acer_predator-w6d
 endef
 TARGET_DEVICES += acer_predator-w6d
 
-define Device/acer_predator-w6x
+define Device/acer_predator-w6x-stock
   DEVICE_VENDOR := Acer
-  DEVICE_MODEL := Predator Connect W6x
-  DEVICE_DTS := mt7986a-acer-predator-w6x
+  DEVICE_MODEL := Predator Connect W6x (Stock Layout)
+  DEVICE_DTS := mt7986a-acer-predator-w6x-stock
+  SUPPORTED_DEVICES += acer,predator-w6x
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTS_LOADADDR := 0x47000000
   KERNEL_IN_UBI := 1
@@ -208,7 +209,31 @@ define Device/acer_predator-w6x
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += acer_predator-w6x
+TARGET_DEVICES += acer_predator-w6x-stock
+
+define Device/acer_predator-w6x-ubootmod
+  DEVICE_VENDOR := Acer
+  DEVICE_MODEL := Predator Connect W6x (OpenWrt U-Boot Layout)
+  DEVICE_DTS := mt7986a-acer-predator-w6x-ubootmod
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-usb3 kmod-leds-ws2812b kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  IMAGES := sysupgrade.itb
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr4
+  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot acer_predator-w6x
+endef
+TARGET_DEVICES += acer_predator-w6x-ubootmod
 
 define Device/acer_vero-w6m
   DEVICE_VENDOR := Acer


### PR DESCRIPTION
Product name: Acer Predator Connect W6x
Product link: https://www.acer.com/us-en/predator/networking/wi-fi/predator-connect-w6x/pdp/FF.G2TTA.001

* Specifications:

SOC: MT7986AV
RAM: 1024MB
Flash: 256 MB SPI NAND
Ports: 4 LAN (1G) & 1 WAN (2.5G)
WIFI: MT7976GN + MT7976AN
LED: 1, ws2812b controller

** This commit includes a fix to swap gpio pins for reset/factory and WPS.

* U-Boot Mod Openwrt Installation via UART:

Openwrt Stock Layout Commit: https://github.com/openwrt/openwrt/commit/6e04dccb7ad3191e9a48597a1b354bf548ead1d8
NOTE: Stock Openwrt is not necessary. You can go straight to ubootmod version of the firmware. However, it is recommended to follow stock layout instructions to backup NAND.

1. Configure TFTP server with IP 192.168.1.66. Copy `openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-initramfs-recovery.itb` to TFTP root and rename to `predator.bin`
2. Interrupt boot by pressing 0 on startup or select `U-Boot Console` in U-Boot Boot Menu.
3. Run `setenv serverip 192.168.1.66; setenv ipaddr 192.168.1.1; tftpboot 0x46000000 predator.bin; bootm` in uboot console.
4. Wait for boot complete on Openwrt initramfs env.
5. Transfer `openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-initramfs-recovery.itb`, `openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-squashfs-sysupgrade.itb`, `openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-bl31-uboot.fip`, `openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-preloader.bin` to router's /tmp/ directory.
6. run `ubidetach -p /dev/mtd5; ubiformat /dev/mtd5 -y; ubiattach -p /dev/mtd5`
7. run `ubimkvol /dev/ubi0 -n 0 -N ubootenv -s 128KiB`
8. run `ubimkvol /dev/ubi0 -n 1 -N ubootenv2 -s 128KiB`
9. run `ubimkvol /dev/ubi0 -n 2 -N recovery -s 10MiB`
10. run `ubiupdatevol /dev/ubi0_2 /tmp/openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-initramfs-recovery.itb`
11. install kmod-mtd-rw via opkg or apk.
12. run `insmod /lib/modules/$(uname -r)/mtd-rw.ko i_want_a_brick=1`
13. run `mtd write /tmp/openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-preloader.bin bl2`
14. run `mtd write /tmp/openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-bl31-uboot.fip fip`
15. run `sysupgrade -n /tmp/openwrt-mediatek-filogic-acer_predator-w6x-ubootmod-squashfs-sysupgrade.itb`
16. reboot to ubootmod layout

MTD layout before ubootmod:
```
dev:    size   erasesize  name
mtd0: 00100000 00020000 "bl2"
mtd1: 00080000 00020000 "u-boot-env"
mtd2: 00200000 00020000 "factory"
mtd3: 00200000 00020000 "fip"
mtd4: 00020000 00020000 "prod"
mtd5: 00100000 00020000 "dual"
mtd6: 00100000 00020000 "pot"
mtd7: 06400000 00020000 "ubi"
mtd8: 06400000 00020000 "ubi1"
mtd9: 00800000 00020000 "storage"
```

MTD layout after ubootmod:
```
dev:    size   erasesize  name
mtd0: 00100000 00020000 "bl2"
mtd1: 00080000 00020000 "u-boot-env"
mtd2: 00200000 00020000 "factory"
mtd3: 00200000 00020000 "fip"
mtd4: 00020000 00020000 "prod"
mtd5: 0d200000 00020000 "ubi"
```
