### PR TITLE
realtek: make RTL8226/RTL8221B work on RTL930x

### DIFF
--- a/target/linux/generic/backport-6.12/781-28-v6.18-net-phy-realtek-convert-RTL8226-CG-to-c45-only.patch
+++ b/target/linux/generic/backport-6.12/781-28-v6.18-net-phy-realtek-convert-RTL8226-CG-to-c45-only.patch
@@ -1,0 +1,169 @@
+From 34167f1a024d2c5abae0b0325a6d0b8257160f86 Mon Sep 17 00:00:00 2001
+From: Markus Stockhausen <markus.stockhausen@gmx.de>
+Date: Wed, 13 Aug 2025 01:44:07 -0400
+Subject: net: phy: realtek: convert RTL8226-CG to c45 only
+
+Short: Convert the RTL8226-CG to c45 so it can be used in its
+Realtek based ecosystems.
+
+Long: The RTL8226-CG can be mainly found on devices of the
+Realtek Otto switch platform. Devices like the Zyxel XGS1210-12
+are based on it. These implement a hardware based phy polling
+in the background to update SoC status registers.
+
+The hardware provides 4 smi busses where phys are attached to.
+For each bus one can decide if it is polled in c45 or c22 mode.
+See https://svanheule.net/realtek/longan/register/smi_glb_ctrl
+With this setting the register access will be limited by the
+hardware. This is very complex (including caching and special
+c45-over-c22 handling). But basically it boils down to "enable
+protocol x and SoC will disable register access via protocol y".
+
+Mainline already gained support for the rtl9300 mdio driver
+in commit 24e31e474769 ("net: mdio: Add RTL9300 MDIO driver").
+
+It covers the basic features, but a lot effort is still needed
+to understand hardware properly. So it runs a simple setup by
+selecting the proper bus mode during startup.
+
+	/* Put the interfaces into C45 mode if required */
+	glb_ctrl_mask = GENMASK(19, 16);
+	for (i = 0; i < MAX_SMI_BUSSES; i++)
+		if (priv->smi_bus_is_c45[i])
+			glb_ctrl_val |= GLB_CTRL_INTF_SEL(i);
+	...
+	err = regmap_update_bits(regmap, SMI_GLB_CTRL,
+				 glb_ctrl_mask, glb_ctrl_val);
+
+To avoid complex coding later on, it limits access by only
+providing either c22 or c45:
+
+	bus->name = "Realtek Switch MDIO Bus";
+	if (priv->smi_bus_is_c45[mdio_bus]) {
+		bus->read_c45 = rtl9300_mdio_read_c45;
+		bus->write_c45 =  rtl9300_mdio_write_c45;
+	} else {
+		bus->read = rtl9300_mdio_read_c22;
+		bus->write = rtl9300_mdio_write_c22;
+	}
+
+Because of these limitations the existing RTL8226 phy driver
+is not working at all on Realtek switches. Convert the driver
+to c45-only.
+
+Luckily the RTL8226 seems to support proper MDIO_PMA_EXTABLE
+flags. So standard function genphy_c45_pma_read_abilities() can
+call genphy_c45_pma_read_ext_abilities() and 10/100/1000 is
+populated right. Thus conversion is straight forward.
+
+Outputs before - REMARK: For this a "hacked" bus was used that
+toggles the mode for each c22/c45 access. But that is slow and
+produces unstable data in the SoC status registers).
+
+Settings for lan9:
+        Supported ports: [ TP MII ]
+        Supported link modes:   10baseT/Half 10baseT/Full
+                                100baseT/Half 100baseT/Full
+                                1000baseT/Full
+                                2500baseT/Full
+        Supported pause frame use: Symmetric Receive-only
+        Supports auto-negotiation: Yes
+        Supported FEC modes: Not reported
+        Advertised link modes:  10baseT/Half 10baseT/Full
+                                100baseT/Half 100baseT/Full
+                                1000baseT/Full
+                                2500baseT/Full
+        Advertised pause frame use: Symmetric Receive-only
+        Advertised auto-negotiation: Yes
+        Advertised FEC modes: Not reported
+        Speed: Unknown!
+        Duplex: Unknown! (255)
+        Port: Twisted Pair
+        PHYAD: 24
+        Transceiver: external
+        Auto-negotiation: on
+        MDI-X: Unknown
+        Supports Wake-on: d
+        Wake-on: d
+        Link detected: no
+
+Outputs with this commit:
+
+Settings for lan9:
+        Supported ports: [ TP ]
+        Supported link modes:   10baseT/Half 10baseT/Full
+                                100baseT/Half 100baseT/Full
+                                1000baseT/Full
+                                2500baseT/Full
+        Supported pause frame use: Symmetric Receive-only
+        Supports auto-negotiation: Yes
+        Supported FEC modes: Not reported
+        Advertised link modes:  10baseT/Half 10baseT/Full
+                                100baseT/Half 100baseT/Full
+                                1000baseT/Full
+                                2500baseT/Full
+        Advertised pause frame use: Symmetric Receive-only
+        Advertised auto-negotiation: Yes
+        Advertised FEC modes: Not reported
+        Speed: Unknown!
+        Duplex: Unknown! (255)
+        Port: Twisted Pair
+        PHYAD: 24
+        Transceiver: external
+        Auto-negotiation: on
+        MDI-X: Unknown
+        Supports Wake-on: d
+        Wake-on: d
+        Link detected: no
+
+Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
+Link: https://patch.msgid.link/20250813054407.1108285-1-markus.stockhausen@gmx.de
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/realtek/realtek_main.c | 28 +++++++++++++++++++++-------
+ 1 file changed, 21 insertions(+), 7 deletions(-)
+
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -1274,6 +1274,21 @@ static int rtl822x_c45_read_status(struc
+ 	return 0;
+ }
+ 
++static int rtl822x_c45_soft_reset(struct phy_device *phydev)
++{
++	int ret, val;
++
++	ret = phy_modify_mmd(phydev, MDIO_MMD_PMAPMD, MDIO_CTRL1,
++			     MDIO_CTRL1_RESET, MDIO_CTRL1_RESET);
++	if (ret < 0)
++		return ret;
++
++	return phy_read_mmd_poll_timeout(phydev, MDIO_MMD_PMAPMD,
++					 MDIO_CTRL1, val,
++					 !(val & MDIO_CTRL1_RESET),
++					 5000, 100000, true);
++}
++
+ static int rtl822xb_c45_read_status(struct phy_device *phydev)
+ {
+ 	int ret;
+@@ -1660,13 +1675,12 @@ static struct phy_driver realtek_drvs[]
+ 	}, {
+ 		PHY_ID_MATCH_EXACT(0x001cc838),
+ 		.name           = "RTL8226-CG 2.5Gbps PHY",
+-		.get_features   = rtl822x_get_features,
+-		.config_aneg    = rtl822x_config_aneg,
+-		.read_status    = rtl822x_read_status,
+-		.suspend        = genphy_suspend,
+-		.resume         = rtlgen_resume,
+-		.read_page      = rtl821x_read_page,
+-		.write_page     = rtl821x_write_page,
++		.soft_reset     = rtl822x_c45_soft_reset,
++		.get_features   = rtl822x_c45_get_features,
++		.config_aneg    = rtl822x_c45_config_aneg,
++		.read_status    = rtl822x_c45_read_status,
++		.suspend        = genphy_c45_pma_suspend,
++		.resume         = rtlgen_c45_resume,
+ 	}, {
+ 		PHY_ID_MATCH_EXACT(0x001cc848),
+ 		.name           = "RTL8226B-CG_RTL8221B-CG 2.5Gbps PHY",

--- a/target/linux/generic/backport-6.12/781-29-v6.18-net-phy-realtek-enable-serdes-option-mode-for-RTL8226-CG.patch
+++ b/target/linux/generic/backport-6.12/781-29-v6.18-net-phy-realtek-enable-serdes-option-mode-for-RTL8226-CG.patch
@@ -1,0 +1,92 @@
+From 3a752e67800106a5c42d802d67e06c60aa71d07b Mon Sep 17 00:00:00 2001
+From: Markus Stockhausen <markus.stockhausen@gmx.de>
+Date: Fri, 15 Aug 2025 04:20:09 -0400
+Subject: net: phy: realtek: enable serdes option mode for RTL8226-CG
+
+The RTL8226-CG can make use of the serdes option mode feature to
+dynamically switch between SGMII and 2500base-X. From what is
+known the setup sequence is much simpler with no magic values.
+
+Convert the exiting config_init() into a helper that configures
+the PHY depending on generation 1 or 2. Call the helper from two
+separated new config_init() functions.
+
+Finally convert the phy_driver specs of the RTL8226-CG to make
+use of the new configuration and switch over to the extended
+read_status() function to dynamically change the interface
+according to the serdes mode.
+
+Remark! The logic could be simpler if the serdes mode could be
+set before all other generation 2 magic values. Due to missing
+RTL8221B test hardware the mmd command order was kept.
+
+Tested on Zyxel XGS1210-12.
+
+Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
+Link: https://patch.msgid.link/20250815082009.3678865-1-markus.stockhausen@gmx.de
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/realtek/realtek_main.c | 26 ++++++++++++++++++++------
+ 1 file changed, 20 insertions(+), 6 deletions(-)
+
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -1032,7 +1032,7 @@ static int rtl822x_probe(struct phy_devi
+ 	return 0;
+ }
+ 
+-static int rtl822xb_config_init(struct phy_device *phydev)
++static int rtl822x_set_serdes_option_mode(struct phy_device *phydev, bool gen1)
+ {
+ 	bool has_2500, has_sgmii;
+ 	u16 mode;
+@@ -1067,15 +1067,18 @@ static int rtl822xb_config_init(struct p
+ 	/* the following sequence with magic numbers sets up the SerDes
+ 	 * option mode
+ 	 */
+-	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x75f3, 0);
+-	if (ret < 0)
+-		return ret;
++
++	if (!gen1) {
++		ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x75f3, 0);
++		if (ret < 0)
++			return ret;
++	}
+ 
+ 	ret = phy_modify_mmd_changed(phydev, MDIO_MMD_VEND1,
+ 				     RTL822X_VND1_SERDES_OPTION,
+ 				     RTL822X_VND1_SERDES_OPTION_MODE_MASK,
+ 				     mode);
+-	if (ret < 0)
++	if (gen1 || ret < 0)
+ 		return ret;
+ 
+ 	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x6a04, 0x0503);
+@@ -1089,6 +1092,16 @@ static int rtl822xb_config_init(struct p
+ 	return phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x6f11, 0x8020);
+ }
+ 
++static int rtl822x_config_init(struct phy_device *phydev)
++{
++	return rtl822x_set_serdes_option_mode(phydev, true);
++}
++
++static int rtl822xb_config_init(struct phy_device *phydev)
++{
++	return rtl822x_set_serdes_option_mode(phydev, false);
++}
++
+ static int rtl822xb_get_rate_matching(struct phy_device *phydev,
+ 				      phy_interface_t iface)
+ {
+@@ -1678,7 +1691,8 @@ static struct phy_driver realtek_drvs[]
+ 		.soft_reset     = rtl822x_c45_soft_reset,
+ 		.get_features   = rtl822x_c45_get_features,
+ 		.config_aneg    = rtl822x_c45_config_aneg,
+-		.read_status    = rtl822x_c45_read_status,
++		.config_init    = rtl822x_config_init,
++		.read_status    = rtl822xb_c45_read_status,
+ 		.suspend        = genphy_c45_pma_suspend,
+ 		.resume         = rtlgen_c45_resume,
+ 	}, {

--- a/target/linux/generic/pending-6.12/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
+++ b/target/linux/generic/pending-6.12/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
@@ -15,7 +15,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1653,6 +1653,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1666,6 +1666,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.name		= "RTL8226 2.5Gbps PHY",
  		.match_phy_device = rtl8226_match_phy_device,
@@ -23,7 +23,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features	= rtl822x_get_features,
  		.config_aneg	= rtl822x_config_aneg,
  		.read_status	= rtl822x_read_status,
-@@ -1663,6 +1664,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1676,6 +1677,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_match_phy_device,
  		.name		= "RTL8226B_RTL8221B 2.5Gbps PHY",
@@ -31,7 +31,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features	= rtl822x_get_features,
  		.config_aneg	= rtl822x_config_aneg,
  		.config_init    = rtl822xb_config_init,
-@@ -1684,6 +1686,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1698,6 +1700,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		PHY_ID_MATCH_EXACT(0x001cc848),
  		.name           = "RTL8226B-CG_RTL8221B-CG 2.5Gbps PHY",
@@ -39,7 +39,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
  		.config_init    = rtl822xb_config_init,
-@@ -1696,6 +1699,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1710,6 +1713,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vb_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C22)",
@@ -47,7 +47,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.probe		= rtl822x_probe,
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
-@@ -1709,6 +1713,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1723,6 +1727,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vb_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C45)",
@@ -55,7 +55,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.probe		= rtl822x_probe,
  		.config_init    = rtl822xb_config_init,
  		.get_rate_matching = rtl822xb_get_rate_matching,
-@@ -1720,6 +1725,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1734,6 +1739,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vn_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VM-CG 2.5Gbps PHY (C22)",
@@ -63,7 +63,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.probe		= rtl822x_probe,
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
-@@ -1733,6 +1739,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1747,6 +1753,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vn_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VN-CG 2.5Gbps PHY (C45)",

--- a/target/linux/generic/pending-6.12/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
+++ b/target/linux/generic/pending-6.12/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
@@ -15,7 +15,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1638,6 +1638,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1653,6 +1653,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.name		= "RTL8226 2.5Gbps PHY",
  		.match_phy_device = rtl8226_match_phy_device,
@@ -23,7 +23,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features	= rtl822x_get_features,
  		.config_aneg	= rtl822x_config_aneg,
  		.read_status	= rtl822x_read_status,
-@@ -1648,6 +1649,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1663,6 +1664,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_match_phy_device,
  		.name		= "RTL8226B_RTL8221B 2.5Gbps PHY",
@@ -31,15 +31,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features	= rtl822x_get_features,
  		.config_aneg	= rtl822x_config_aneg,
  		.config_init    = rtl822xb_config_init,
-@@ -1660,6 +1662,7 @@ static struct phy_driver realtek_drvs[]
- 	}, {
- 		PHY_ID_MATCH_EXACT(0x001cc838),
- 		.name           = "RTL8226-CG 2.5Gbps PHY",
-+		.soft_reset     = genphy_soft_reset,
- 		.get_features   = rtl822x_get_features,
- 		.config_aneg    = rtl822x_config_aneg,
- 		.read_status    = rtl822x_read_status,
-@@ -1670,6 +1673,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1684,6 +1686,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		PHY_ID_MATCH_EXACT(0x001cc848),
  		.name           = "RTL8226B-CG_RTL8221B-CG 2.5Gbps PHY",
@@ -47,7 +39,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
  		.config_init    = rtl822xb_config_init,
-@@ -1682,6 +1686,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1696,6 +1699,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vb_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C22)",
@@ -55,7 +47,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.probe		= rtl822x_probe,
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
-@@ -1695,6 +1700,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1709,6 +1713,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vb_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C45)",
@@ -63,7 +55,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.probe		= rtl822x_probe,
  		.config_init    = rtl822xb_config_init,
  		.get_rate_matching = rtl822xb_get_rate_matching,
-@@ -1706,6 +1712,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1720,6 +1725,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vn_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VM-CG 2.5Gbps PHY (C22)",
@@ -71,7 +63,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.probe		= rtl822x_probe,
  		.get_features   = rtl822x_get_features,
  		.config_aneg    = rtl822x_config_aneg,
-@@ -1719,6 +1726,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1733,6 +1739,7 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vn_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VN-CG 2.5Gbps PHY (C45)",

--- a/target/linux/generic/pending-6.12/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
+++ b/target/linux/generic/pending-6.12/720-01-net-phy-realtek-use-genphy_soft_reset-for-2.5G-PHYs.patch
@@ -51,7 +51,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	}, {
  		.match_phy_device = rtl8221b_vb_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C45)",
-+		.soft_reset     = genphy_soft_reset,
++		.soft_reset     = rtl822x_c45_soft_reset,
  		.probe		= rtl822x_probe,
  		.config_init    = rtl822xb_config_init,
  		.get_rate_matching = rtl822xb_get_rate_matching,
@@ -67,7 +67,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	}, {
  		.match_phy_device = rtl8221b_vn_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VN-CG 2.5Gbps PHY (C45)",
-+		.soft_reset     = genphy_soft_reset,
++		.soft_reset     = rtl822x_c45_soft_reset,
  		.probe		= rtl822x_probe,
  		.config_init    = rtl822xb_config_init,
  		.get_rate_matching = rtl822xb_get_rate_matching,

--- a/target/linux/generic/pending-6.12/720-02-net-phy-realtek-disable-SGMII-in-band-AN-for-2-5G-PHYs.patch
+++ b/target/linux/generic/pending-6.12/720-02-net-phy-realtek-disable-SGMII-in-band-AN-for-2-5G-PHYs.patch
@@ -21,7 +21,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
 @@ -1035,8 +1035,8 @@ static int rtl822x_probe(struct phy_devi
- static int rtl822xb_config_init(struct phy_device *phydev)
+ static int rtl822x_set_serdes_option_mode(struct phy_device *phydev, bool gen1)
  {
  	bool has_2500, has_sgmii;
 +	int ret, val;
@@ -30,14 +30,27 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  	has_2500 = test_bit(PHY_INTERFACE_MODE_2500BASEX,
  			    phydev->host_interfaces) ||
-@@ -1086,7 +1086,29 @@ static int rtl822xb_config_init(struct p
- 	if (ret < 0)
- 		return ret;
- 
--	return phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x6f11, 0x8020);
-+	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x6f11, 0x8020);
+@@ -1078,18 +1078,42 @@ static int rtl822x_set_serdes_option_mod
+ 				     RTL822X_VND1_SERDES_OPTION,
+ 				     RTL822X_VND1_SERDES_OPTION_MODE_MASK,
+ 				     mode);
+-	if (gen1 || ret < 0)
 +	if (ret < 0)
 +		return ret;
++
++	if (!gen1) {
++		ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x6a04, 0x0503);
++		if (ret < 0)
++			return ret;
++
++		ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x6f10, 0xd455);
++		if (ret < 0)
++			return ret;
++
++		ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x6f11, 0x8020);
++		if (ret < 0)
++			return ret;
++	}
 +
 +	/* Disable SGMII AN */
 +	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x7588, 0x2);
@@ -46,18 +59,21 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +
 +	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x7589, 0x71d0);
 +	if (ret < 0)
-+		return ret;
-+
+ 		return ret;
+ 
+-	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x6a04, 0x0503);
 +	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x7587, 0x3);
-+	if (ret < 0)
-+		return ret;
-+
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	ret = phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x6f10, 0xd455);
 +	ret = phy_read_mmd_poll_timeout(phydev, MDIO_MMD_VEND1, 0x7587,
 +					val, !(val & BIT(0)), 500, 100000, false);
-+	if (ret < 0)
-+		return ret;
-+
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	return phy_write_mmd(phydev, MDIO_MMD_VEND1, 0x6f11, 0x8020);
 +	return 0;
  }
  
- static int rtl822xb_get_rate_matching(struct phy_device *phydev,
+ static int rtl822x_config_init(struct phy_device *phydev)

--- a/target/linux/generic/pending-6.12/720-03-net-phy-realtek-make-sure-paged-read-is-protected-by.patch
+++ b/target/linux/generic/pending-6.12/720-03-net-phy-realtek-make-sure-paged-read-is-protected-by.patch
@@ -18,7 +18,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1313,9 +1313,11 @@ static bool rtlgen_supports_2_5gbps(stru
+@@ -1328,9 +1328,11 @@ static bool rtlgen_supports_2_5gbps(stru
  {
  	int val;
  

--- a/target/linux/generic/pending-6.12/720-03-net-phy-realtek-make-sure-paged-read-is-protected-by.patch
+++ b/target/linux/generic/pending-6.12/720-03-net-phy-realtek-make-sure-paged-read-is-protected-by.patch
@@ -18,7 +18,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1328,9 +1328,11 @@ static bool rtlgen_supports_2_5gbps(stru
+@@ -1343,9 +1343,11 @@ static bool rtlgen_supports_2_5gbps(stru
  {
  	int val;
  

--- a/target/linux/generic/pending-6.12/720-04-net-phy-realtek-setup-aldps.patch
+++ b/target/linux/generic/pending-6.12/720-04-net-phy-realtek-setup-aldps.patch
@@ -24,9 +24,9 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  #define RTL8366RB_POWER_SAVE			0x15
  #define RTL8366RB_POWER_SAVE_ON			BIT(12)
  
-@@ -1090,6 +1094,15 @@ static int rtl822xb_config_init(struct p
- 	if (ret < 0)
- 		return ret;
+@@ -1095,6 +1099,15 @@ static int rtl822x_set_serdes_option_mod
+ 			return ret;
+ 	}
  
 +	if (of_property_read_bool(phydev->mdio.dev.of_node, "realtek,aldps-enable"))
 +		ret = phy_set_bits_mmd(phydev, MDIO_MMD_VEND1, RTL8221B_PHYCR1,

--- a/target/linux/generic/pending-6.12/720-05-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.12/720-05-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -14,7 +14,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 Signed-off-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1368,10 +1368,32 @@ static int rtl8226_match_phy_device(stru
+@@ -1383,10 +1383,32 @@ static int rtl8226_match_phy_device(stru
  static int rtlgen_is_c45_match(struct phy_device *phydev, unsigned int id,
  			       bool is_c45)
  {

--- a/target/linux/generic/pending-6.12/720-05-net-phy-realtek-detect-early-version-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.12/720-05-net-phy-realtek-detect-early-version-of-RTL8221B.patch
@@ -14,7 +14,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 Signed-off-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1383,10 +1383,32 @@ static int rtl8226_match_phy_device(stru
+@@ -1398,10 +1398,32 @@ static int rtl8226_match_phy_device(stru
  static int rtlgen_is_c45_match(struct phy_device *phydev, unsigned int id,
  			       bool is_c45)
  {

--- a/target/linux/generic/pending-6.12/720-06-net-phy-realtek-support-interrupt-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.12/720-06-net-phy-realtek-support-interrupt-of-RTL8221B.patch
@@ -12,7 +12,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1580,6 +1580,51 @@ static irqreturn_t rtl9000a_handle_inter
+@@ -1595,6 +1595,51 @@ static irqreturn_t rtl9000a_handle_inter
  	return IRQ_HANDLED;
  }
  
@@ -64,7 +64,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  static struct phy_driver realtek_drvs[] = {
  	{
  		PHY_ID_MATCH_EXACT(0x00008201),
-@@ -1745,6 +1790,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1758,6 +1803,8 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vb_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C22)",
@@ -73,7 +73,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.soft_reset     = genphy_soft_reset,
  		.probe		= rtl822x_probe,
  		.get_features   = rtl822x_get_features,
-@@ -1759,6 +1806,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1772,6 +1819,8 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vb_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C45)",
@@ -82,7 +82,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.soft_reset     = genphy_soft_reset,
  		.probe		= rtl822x_probe,
  		.config_init    = rtl822xb_config_init,
-@@ -1771,6 +1820,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1784,6 +1833,8 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vn_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VM-CG 2.5Gbps PHY (C22)",
@@ -91,7 +91,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.soft_reset     = genphy_soft_reset,
  		.probe		= rtl822x_probe,
  		.get_features   = rtl822x_get_features,
-@@ -1785,6 +1836,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1798,6 +1849,8 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vn_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VN-CG 2.5Gbps PHY (C45)",

--- a/target/linux/generic/pending-6.12/720-06-net-phy-realtek-support-interrupt-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.12/720-06-net-phy-realtek-support-interrupt-of-RTL8221B.patch
@@ -12,7 +12,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1595,6 +1595,51 @@ static irqreturn_t rtl9000a_handle_inter
+@@ -1610,6 +1610,51 @@ static irqreturn_t rtl9000a_handle_inter
  	return IRQ_HANDLED;
  }
  
@@ -64,7 +64,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  static struct phy_driver realtek_drvs[] = {
  	{
  		PHY_ID_MATCH_EXACT(0x00008201),
-@@ -1758,6 +1803,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1774,6 +1819,8 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vb_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C22)",
@@ -73,7 +73,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.soft_reset     = genphy_soft_reset,
  		.probe		= rtl822x_probe,
  		.get_features   = rtl822x_get_features,
-@@ -1772,6 +1819,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1788,6 +1835,8 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vb_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C45)",
@@ -82,7 +82,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.soft_reset     = genphy_soft_reset,
  		.probe		= rtl822x_probe,
  		.config_init    = rtl822xb_config_init,
-@@ -1784,6 +1833,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1800,6 +1849,8 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vn_cg_c22_match_phy_device,
  		.name           = "RTL8221B-VM-CG 2.5Gbps PHY (C22)",
@@ -91,7 +91,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.soft_reset     = genphy_soft_reset,
  		.probe		= rtl822x_probe,
  		.get_features   = rtl822x_get_features,
-@@ -1798,6 +1849,8 @@ static struct phy_driver realtek_drvs[]
+@@ -1814,6 +1865,8 @@ static struct phy_driver realtek_drvs[]
  	}, {
  		.match_phy_device = rtl8221b_vn_cg_c45_match_phy_device,
  		.name           = "RTL8221B-VN-CG 2.5Gbps PHY (C45)",

--- a/target/linux/generic/pending-6.12/720-06-net-phy-realtek-support-interrupt-of-RTL8221B.patch
+++ b/target/linux/generic/pending-6.12/720-06-net-phy-realtek-support-interrupt-of-RTL8221B.patch
@@ -79,7 +79,7 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.name           = "RTL8221B-VB-CG 2.5Gbps PHY (C45)",
 +		.config_intr	= rtl8221b_config_intr,
 +		.handle_interrupt = rtl8221b_handle_interrupt,
- 		.soft_reset     = genphy_soft_reset,
+ 		.soft_reset     = rtl822x_c45_soft_reset,
  		.probe		= rtl822x_probe,
  		.config_init    = rtl822xb_config_init,
 @@ -1800,6 +1849,8 @@ static struct phy_driver realtek_drvs[]
@@ -97,6 +97,6 @@ Signed-off-by: Jianhui Zhao <zhaojh329@gmail.com>
  		.name           = "RTL8221B-VN-CG 2.5Gbps PHY (C45)",
 +		.config_intr	= rtl8221b_config_intr,
 +		.handle_interrupt = rtl8221b_handle_interrupt,
- 		.soft_reset     = genphy_soft_reset,
+ 		.soft_reset     = rtl822x_c45_soft_reset,
  		.probe		= rtl822x_probe,
  		.config_init    = rtl822xb_config_init,

--- a/target/linux/generic/pending-6.12/720-07-net-phy-realtek-mark-existing-MMDs-as-present.patch
+++ b/target/linux/generic/pending-6.12/720-07-net-phy-realtek-mark-existing-MMDs-as-present.patch
@@ -15,7 +15,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1244,6 +1244,9 @@ static int rtl822x_c45_get_features(stru
+@@ -1259,6 +1259,9 @@ static int rtl822x_c45_get_features(stru
  	linkmode_set_bit(ETHTOOL_LINK_MODE_TP_BIT,
  			 phydev->supported);
  

--- a/target/linux/generic/pending-6.12/720-08-net-phy-realtek-work-around-broken-serdes.patch
+++ b/target/linux/generic/pending-6.12/720-08-net-phy-realtek-work-around-broken-serdes.patch
@@ -15,8 +15,8 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 ---
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1124,6 +1124,22 @@ static int rtl822xb_config_init(struct p
- 	return 0;
+@@ -1139,6 +1139,22 @@ static int rtl822xb_config_init(struct p
+ 	return rtl822x_set_serdes_option_mode(phydev, false);
  }
  
 +static int rtl822xb_config_init_war(struct phy_device *phydev)
@@ -38,7 +38,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int rtl822xb_get_rate_matching(struct phy_device *phydev,
  				      phy_interface_t iface)
  {
-@@ -1826,7 +1842,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1842,7 +1858,7 @@ static struct phy_driver realtek_drvs[]
  		.handle_interrupt = rtl8221b_handle_interrupt,
  		.soft_reset     = genphy_soft_reset,
  		.probe		= rtl822x_probe,
@@ -47,7 +47,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_rate_matching = rtl822xb_get_rate_matching,
  		.get_features   = rtl822x_c45_get_features,
  		.config_aneg    = rtl822x_c45_config_aneg,
-@@ -1856,7 +1872,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1872,7 +1888,7 @@ static struct phy_driver realtek_drvs[]
  		.handle_interrupt = rtl8221b_handle_interrupt,
  		.soft_reset     = genphy_soft_reset,
  		.probe		= rtl822x_probe,

--- a/target/linux/generic/pending-6.12/720-08-net-phy-realtek-work-around-broken-serdes.patch
+++ b/target/linux/generic/pending-6.12/720-08-net-phy-realtek-work-around-broken-serdes.patch
@@ -40,7 +40,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  {
 @@ -1842,7 +1858,7 @@ static struct phy_driver realtek_drvs[]
  		.handle_interrupt = rtl8221b_handle_interrupt,
- 		.soft_reset     = genphy_soft_reset,
+ 		.soft_reset     = rtl822x_c45_soft_reset,
  		.probe		= rtl822x_probe,
 -		.config_init    = rtl822xb_config_init,
 +		.config_init    = rtl822xb_config_init_war,
@@ -49,7 +49,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.config_aneg    = rtl822x_c45_config_aneg,
 @@ -1872,7 +1888,7 @@ static struct phy_driver realtek_drvs[]
  		.handle_interrupt = rtl8221b_handle_interrupt,
- 		.soft_reset     = genphy_soft_reset,
+ 		.soft_reset     = rtl822x_c45_soft_reset,
  		.probe		= rtl822x_probe,
 -		.config_init    = rtl822xb_config_init,
 +		.config_init    = rtl822xb_config_init_war,

--- a/target/linux/generic/pending-6.12/720-08-net-phy-realtek-work-around-broken-serdes.patch
+++ b/target/linux/generic/pending-6.12/720-08-net-phy-realtek-work-around-broken-serdes.patch
@@ -38,7 +38,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  static int rtl822xb_get_rate_matching(struct phy_device *phydev,
  				      phy_interface_t iface)
  {
-@@ -1813,7 +1829,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1826,7 +1842,7 @@ static struct phy_driver realtek_drvs[]
  		.handle_interrupt = rtl8221b_handle_interrupt,
  		.soft_reset     = genphy_soft_reset,
  		.probe		= rtl822x_probe,
@@ -47,7 +47,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		.get_rate_matching = rtl822xb_get_rate_matching,
  		.get_features   = rtl822x_c45_get_features,
  		.config_aneg    = rtl822x_c45_config_aneg,
-@@ -1843,7 +1859,7 @@ static struct phy_driver realtek_drvs[]
+@@ -1856,7 +1872,7 @@ static struct phy_driver realtek_drvs[]
  		.handle_interrupt = rtl8221b_handle_interrupt,
  		.soft_reset     = genphy_soft_reset,
  		.probe		= rtl822x_probe,

--- a/target/linux/generic/pending-6.12/720-09-net-phy-realtek-disable-MDIO-broadcast.patch
+++ b/target/linux/generic/pending-6.12/720-09-net-phy-realtek-disable-MDIO-broadcast.patch
@@ -13,7 +13,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 ---
 --- a/drivers/net/phy/realtek/realtek_main.c
 +++ b/drivers/net/phy/realtek/realtek_main.c
-@@ -1050,6 +1050,11 @@ static int rtl822xb_config_init(struct p
+@@ -1050,6 +1050,11 @@ static int rtl822x_set_serdes_option_mod
  			     phydev->host_interfaces) ||
  		    phydev->interface == PHY_INTERFACE_MODE_SGMII;
  

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12.dts
@@ -290,14 +290,14 @@
 		port@24 {
 			reg = <24>;
 			label = "lan9";
-			phy-mode = "hsgmii";
+			phy-mode = "2500base-x";
 			phy-handle = <&phy24>;
 			led-set = <1>;
 		};
 		port@25 {
 			reg = <25>;
 			label = "lan10";
-			phy-mode = "hsgmii";
+			phy-mode = "2500base-x";
 			phy-handle = <&phy25>;
 			led-set = <1>;
 		};


### PR DESCRIPTION
This series backports two RTL8226 phy patches, that went upstream in the last weeks. With that:

- RTL8226 will be detected by upstream driver
- RTL8226 will switch its serdes depending on the connection speed (SGMII or 2500base-x)
- The ZyXEL XGS1210-10 DTS needs to be converted to 2500base-x
- The RTL8221B soft_reset() downstream patch gets a fix.

This small series comes with a caveat. The RTL8226 ports give new/other/more issues than before. We cannot fix them all in one series. But now there is only the way forward - no time to look back. Luckily we already have other PRs that will take care about the remaining bits.

- https://github.com/openwrt/openwrt/pull/19518
- https://github.com/openwrt/openwrt/pull/19834