### PR TITLE
ath79: compex_wpj531: remove wrong wifi device

### DIFF
--- a/target/linux/ath79/dts/qca9531_compex_wpj531-16m.dts
+++ b/target/linux/ath79/dts/qca9531_compex_wpj531-16m.dts
@@ -147,11 +147,6 @@
 
 &pcie0 {
 	status = "okay";
-
-	wifi@0,0 {
-		compatible = "pci168c,003c";
-		reg = <0x0000 0 0 0 0>;
-	};
 };
 
 &usb_phy {


### PR DESCRIPTION
This device does not come with a pci card. It has a slot where one can get supplied. What's more, nvmem or ieee80211 frequency limits are not applied here. It can just get removed.

ping @DragonBluep 