### PR TITLE
dnsmasq: add append_conf_file() to dnsmasq.init

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -161,6 +161,14 @@ append_parm() {
 	xappend "$switch=$_loctmp"
 }
 
+append_conf_file(){
+	if [ -r "$1" ]
+	then
+		xappend "--conf-file=$1"
+		append_extramount "$1"
+	fi
+}
+
 append_server() {
 	xappend "--server=$1"
 }


### PR DESCRIPTION
Package: dnsmasq
Compile tested: x86, mt7621, ath79
Run tested: x86, mt7621, ath79

Added a function to append additional conf files in dnsmasq.conf format which can be configured in /etc/config/dhcp as:

list conf_file "/path/to/additional-conf"

The function uses xappend and  append_extramount to add config files to the config file in /var/etc/dnsmasq-*.conf

Signed-off-by: Nishant Sharma <codemarauder@gmail.com>