### PR TITLE
dnsmasq: add append_conf_file() to dnsmasq.init

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1045,6 +1045,7 @@ dnsmasq_start()
 	config_list_foreach "$cfg" "server" append_server
 	config_list_foreach "$cfg" "rev_server" append_rev_server
 	config_list_foreach "$cfg" "address" append_address
+	config_list_foreach "$cfg" "conf_file" append_conf_file
 
 	local connmark_allowlist_enable
 	config_get connmark_allowlist_enable "$cfg" connmark_allowlist_enable 0

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -161,6 +161,14 @@ append_parm() {
 	xappend "$switch=$_loctmp"
 }
 
+append_conf_file() {
+        if [ -r "$1" ]
+        then
+                xappend "--conf-file=$1"
+                append_extramount "$1"
+        fi
+}
+
 append_server() {
 	xappend "--server=$1"
 }


### PR DESCRIPTION
Added a function to append additional conf files in dnsmasq.conf format which can be configured in /etc/config/dhcp as:

list conf_file "/path/to/additional-conf"

The function uses xappend and append_extramount to add config files to the config file in /var/etc/dnsmasq-*.conf

Compile tested: x86, mt7621, ath79
Run tested: x86, mt7621, ath79

Signed-off-by: Nishant Sharma <nishant@hopbox.in>