### PR TITLE
wifi-scripts: fix mac address addition logic

### DIFF
--- a/package/network/config/wifi-scripts/files/usr/share/hostap/common.uc
+++ b/package/network/config/wifi-scripts/files/usr/share/hostap/common.uc
@@ -174,6 +174,19 @@ function macaddr_join(addr)
 	return join(":", map(addr, (val) => sprintf("%02x", val)));
 }
 
+function macaddr_add(addr, offset)
+{
+	for (let i = 5; i > 0; i--) {
+		let sum = addr[i] + offset;
+		addr[i] = sum % 256;
+		offset = int(sum / 256);
+		if (offset == 0) {
+			break;
+		}
+	}
+	return addr;
+}
+
 function wdev_macaddr(wdev)
 {
 	return trim(readfile(`/sys/class/net/${wdev}/address`));
@@ -266,12 +279,7 @@ const phy_proto = {
 			addr[5] ^= idx;
 			break;
 		default:
-			for (let i = 5; i > 0; i--) {
-				addr[i] += idx;
-				if (addr[i] < 256)
-					break;
-				addr[i] %= 256;
-			}
+			addr = macaddr_add(addr, idx);
 			break;
 		}
 


### PR DESCRIPTION
Previous implementation added the full index value on a carry over, causing the next byte to be increased too much for offsets >1.

This PR fixes the carry handling, ensuring proper increments.

For example:
  base = 00:11:22:00:**00:FF**, idx = 3
  old result ->00:11:22:00:**03:02**
  correct    -> 00:11:22:00:**01:02**

@nbd168 