### PR TITLE
ramips: Add Support Wavlink WS-WN572HP3 A-V1.4

### DIFF
--- a/target/linux/ramips/dts/mt7621_wavlink_ws-wn572hp3-a-v1-4.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_ws-wn572hp3-a-v1-4.dts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "wavlink,ws-wn572hp3-a-v1-4", "mediatek,mt7621-soc";
+	model = "Wavlink WS-WN572HP3-A-V1.4";
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		label-mac-device = &wifi1;
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "Reset Button";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		rssihigh {
+			label = "blue:rssihigh";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		rssimedium {
+			label = "blue:rssimedium";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		rssilow {
+			label = "blue:rssilow";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status_blue {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		// gpio 15 would be Quectels PWRKEY if used
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+
+					macaddr_factory_e000: macaddr@e000 {
+						reg = <0xe000 0x6>;
+					};
+
+					macaddr_factory_e006: macaddr@e006 {
+						reg = <0xe006 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0x50000 0xf30000>;
+			};
+
+			partition@f00000 {
+				label = "vendor";
+				reg = <0xf80000 0x80000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&pcie1 {
+	wifi1: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3144,6 +3144,22 @@ define Device/wavlink_ws-wn572hp3-4g
 endef
 TARGET_DEVICES += wavlink_ws-wn572hp3-4g
 
+define Device/wavlink_ws-wn572hp3-a-v1-4
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WS-WN572HP3
+  DEVICE_VARIANT := A-V1.4
+  IMAGE_SIZE := 15040k
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
+	append-rootfs | pad-rootfs | check-size | append-metadata
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+	-uboot-envtools
+endef
+TARGET_DEVICES += wavlink_ws-wn572hp3-a-v1-4
+
 define Device/wavlink_wl-wn573hx1
   $(Device/uimage-lzma-loader)
   IMAGE_SIZE := 15808k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -81,6 +81,7 @@ ramips_setup_interfaces()
 	maginon,mc-1200ac|\
 	meig,slt866|\
 	openfi,5pro|\
+	wavlink,ws-wn572hp3-a-v1-4|\
 	wavlink,ws-wn572hp3-4g|\
 	winstars,ws-wn583a6|\
 	yuncore,ax820|\


### PR DESCRIPTION
Wavlink WS-WN572HP3 A-V1.4 - The same as WS-WN572HP3 4g, without the 4G
 WING 12M – AC1200 Dual-band High Power Outdoor Wireless AP/Range Extender/Mesh with Passive POE and High Gain Antennas
Removed "kmod-usb3 kmod-usb-net-rndis comgt-ncm"

SoC : MediaTe MT7621AT @ 880Mhz
RAM : 128MB
Flash : Fudan FM25Q128 16M
WLAN :
2.4 GHz : b/g/n/ MT7603E
5 GHz : n/ac, MT7613BE
Ethernet :
LAN x1 : 10/100/1000 Mbps
WAN x1 : 10/100/1000 Mbps
UART : through-hole on PCB
Assignment : (GND) (TX),(RX),
Settings : 115200n8
Buttons x1 : WPS, Reset
LEDs x7 : 1x Power, 1x WAN,1x LAN,1x WIFI, 3x Signal 
Power : DC24V / 0.6A Power over Ethernet ( Passive PoE)

Flash instructions.

Prepare TFTP Server and host file.
Connect UART and load console.
Connect to network via Wan port
Switch device on
Stop Auto-boot by pressing any key
Select TFTP server and set to the host IP and subnet to the host ip Flash sysupgrade or initramfs

Return to stock \ Recovery
Connect UART and use the U-Boot menu to flash the firmware image or boot an OpenWrt initramfs image.