### PR TITLE
ath79: tl-wdr4900-v2: set ath9k led-pin

### DIFF
--- a/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
@@ -49,22 +49,6 @@
 		};
 	};
 
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wifi_2g_green {
-			label = "green:wlan2g";
-			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		wifi_5g_green {
-			label = "green:wlan5g";
-			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-	};
-
 	keys {
 		compatible = "gpio-keys";
 
@@ -97,22 +81,28 @@
 &pcie0 {
 	status = "okay";
 
-	ath9k0: wifi@11,0 { /* 2.4 GHz */
+	wifi@11,0 { /* 2.4 GHz */
 		compatible = "pci168c,0029";
+		reg = <0x8800 0 0 0 0>;
 		nvmem-cells = <&macaddr_hwinfo_1c 1>;
 		nvmem-cell-names = "mac-address";
-		reg = <0x8800 0 0 0 0>;
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <5>;
+			led-active-low;
+		};
 	};
 
-	ath9k1: wifi@12,0 { /* 5 GHz */
+	wifi@12,0 { /* 5 GHz */
 		compatible = "pci168c,0029";
+		reg = <0x9000 0 0 0 0>;
 		nvmem-cells = <&macaddr_hwinfo_1c 2>;
 		nvmem-cell-names = "mac-address";
-		reg = <0x9000 0 0 0 0>;
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <5>;
+			led-active-low;
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -58,22 +58,6 @@
 		};
 	};
 
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wlan2g {
-			label = "blue:wlan2g";
-			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		wlan5g {
-			label = "blue:wlan5g";
-			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-	};
-
 	keys {
 		compatible = "gpio-keys";
 
@@ -146,8 +130,11 @@
 		reg = <0x8800 0 0 0 0>;
 		nvmem-cells = <&macaddr_lan 0>, <&cal_art_1000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <5>;
+			led-active-low;
+		};
 	};
 
 	ath9k1: wifi@12,0 {
@@ -155,8 +142,11 @@
 		reg = <0x9000 0 0 0 0>;
 		nvmem-cells = <&macaddr_wan 1>, <&cal_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <5>;
+			led-active-low;
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -27,22 +27,6 @@
 		};
 	};
 
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wifi_2g_green {
-			label = "green:wlan2g";
-			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		wifi_5g_green {
-			label = "green:wlan5g";
-			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-	};
-
 	keys {
 		compatible = "gpio-keys";
 
@@ -149,21 +133,27 @@
 &pcie0 {
 	status = "okay";
 
-	ath9k0: wifi@11,0 {
+	wifi@11,0 {
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_120c>, <&calibration_art_1000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <5>;
+			led-active-low;
+		};
 	};
 
-	ath9k1: wifi@12,0 {
+	wifi@12,0 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_520c 1>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <5>;
+			led-active-low;
+		};
 	};
 };

--- a/target/linux/ath79/dts/ar7240_dlink_dir-615-e4.dts
+++ b/target/linux/ath79/dts/ar7240_dlink_dir-615-e4.dts
@@ -90,17 +90,6 @@
 			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
 };
 
 &spi {
@@ -160,13 +149,16 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,002e";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&cal_art_1000>;
 		nvmem-cell-names = "calibration";
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <1>;
+			led-actice-low;
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar7240_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink.dtsi
@@ -49,17 +49,6 @@
 			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
 };
 
 &spi {
@@ -128,8 +117,11 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&macaddr_uboot_1fc00 0>, <&calibration_art_1000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <1>;
+			led-active-low;
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
@@ -57,17 +57,6 @@
 		};
 	};
 
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
-
 	gpio-export {
 		compatible = "gpio-export";
 
@@ -149,10 +138,13 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,002e";
 		reg = <0x0000 0 0 0 0>;
-		#gpio-cells = <2>;
-		gpio-controller;
 		nvmem-cells = <&macaddr_uboot_1fc00 0>, <&cal_art_1000>;
 		nvmem-cell-names = "mac-address", "calibration";
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar9344_openmesh_mr600-v1.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_mr600-v1.dts
@@ -18,12 +18,6 @@
 	leds {
 		compatible = "gpio-leds";
 
-		wifi5g_green {
-			label = "green:wifi5g";
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		wps_blue {
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_BLUE>;
@@ -37,14 +31,18 @@
 			default-state = "on";
 		};
 	};
+};
 
-	leds-ath9k {
-		compatible = "gpio-leds";
+&wmac {
+	led {
+		led-sources = <12>;
+		led-active-low;
+	};
+};
 
-		wifi2g {
-			label = "blue:wifi2g";
-			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
+&ath9k {
+	led {
+		led-sources = <0>;
+		led-active-low;
 	};
 };

--- a/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
+++ b/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
@@ -138,13 +138,10 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_0 8>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-
-		gpio-controller;
-		#gpio-cells = <2>;
 	};
 };

--- a/target/linux/ath79/dts/qca9531_engenius_ews511ap.dts
+++ b/target/linux/ath79/dts/qca9531_engenius_ews511ap.dts
@@ -50,16 +50,10 @@
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
 
-		wlan2g {
-			label = "green:wlan2g";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		wlan5g {
 			label = "green:wlan5g";
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 
@@ -157,4 +151,9 @@
 
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <15>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
@@ -21,16 +21,10 @@
 	leds {
 		compatible = "gpio-leds";
 
-		wlan2g {
-			label = "white:wlan2g";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		wlan5g {
 			label = "white:wlan5g";
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "phy0tpt";
 		};
 
 		qss {
@@ -190,6 +184,11 @@
 
 	nvmem-cells = <&macaddr_romfile_f100 0>, <&cal_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
+
+	led {
+		led-sources = <14>;
+		led-active-low;
+	};
 };
 
 &pcie0 {


### PR DESCRIPTION
Instead of having two LED entries that supposedly control the same thing, set the pin properly.