### PR TITLE
ath79: qcn5502: use led-sources for WMAC

### DIFF
--- a/target/linux/ath79/dts/qcn5502_asus_rt-ac59u.dtsi
+++ b/target/linux/ath79/dts/qcn5502_asus_rt-ac59u.dtsi
@@ -49,12 +49,6 @@
 			linux,default-trigger = "usbport";
 		};
 
-		wlan2g {
-			label = "blue:wlan2g";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
 		wlan5g {
 			label = "blue:wlan5g";
 			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
@@ -69,4 +63,11 @@
 
 &usb0 {
 	status = "okay";
+};
+
+&wmac {
+	led {
+		led-sources = <15>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/dts/qcn5502_tplink_archer-a9-v6.dts
+++ b/target/linux/ath79/dts/qcn5502_tplink_archer-a9-v6.dts
@@ -66,12 +66,6 @@
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 		};
 
-		wlan2g {
-			label = "green:wlan2g";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
 		wlan5g {
 			label = "green:wlan5g";
 			gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
@@ -246,4 +240,9 @@
 
 	nvmem-cells = <&cal_art_1000>, <&macaddr_info_8 0>;
 	nvmem-cell-names = "calibration", "mac-address";
+
+	led {
+		led-sources = <15>;
+		led-active-low;
+	};
 };


### PR DESCRIPTION
The ath9k driver creates an ath9k LED by default. Instead of having a non functional LED, configure it properly and remove the extra as it's not needed.

It's also a bit funny matching against phy0 and phy1 when both differ between ath9k and ath10k.