### PR TITLE
ath79: fix calibration size for AR9285

### DIFF
--- a/target/linux/ath79/dts/ar7240_netgear_wnr1000-v2.dts
+++ b/target/linux/ath79/dts/ar7240_netgear_wnr1000-v2.dts
@@ -190,6 +190,10 @@
 					macaddr_art_6: macaddr@6 {
 						reg = <0x6 0x6>;
 					};
+
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x200>;
+					};
 				};
 			};
 		};
@@ -214,9 +218,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,002b";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0 1>;
-		nvmem-cell-names = "mac-address";
-		qca,no-eeprom;
+		nvmem-cells = <&macaddr_art_0 1>, <&calibration_art_1000>;
+		nvmem-cell-names = "mac-address", "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
 	};

--- a/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
+++ b/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
@@ -120,6 +120,10 @@
 					macaddr_art_6: macaddr@6 {
 						reg = <0x6 0x6>;
 					};
+
+					calibration_art_1000: calibration@1000 {
+						reg = <0x1000 0x200>;
+					};
 				};
 			};
 		};
@@ -144,9 +148,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,002b";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0 1>;
-		nvmem-cell-names = "mac-address";
-		qca,no-eeprom;
+		nvmem-cells = <&macaddr_art_0 1>, <&calibration_art_1000>;
+		nvmem-cell-names = "mac-address", "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
 	};

--- a/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
+++ b/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
@@ -145,7 +145,7 @@
 					};
 
 					calibration_art_1000: calibration@1000 {
-						reg = <0x1000 0x440>;
+						reg = <0x1000 0x200>;
 					};
 				};
 			};

--- a/target/linux/ath79/dts/ar7240_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink.dtsi
@@ -103,6 +103,15 @@
 				reg = <0x3f0000 0x10000>;
 				label = "art";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					calibration_art_1000: calibration@1000 {
+					};
+				};
 			};
 		};
 	};
@@ -117,9 +126,8 @@
 
 	ath9k: wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		qca,no-eeprom;
-		nvmem-cells = <&macaddr_uboot_1fc00 0>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_uboot_1fc00 0>, <&calibration_art_1000>;
+		nvmem-cell-names = "mac-address", "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
 	};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wa.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wa.dtsi
@@ -20,7 +20,3 @@
 	nvmem-cells = <&macaddr_uboot_1fc00 0>;
 	nvmem-cell-names = "mac-address";
 };
-
-&ath9k {
-	compatible = "pci168c,002a";
-};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wa701nd-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wa701nd-v1.dts
@@ -6,3 +6,11 @@
 	model = "TP-Link TL-WA701ND v1";
 	compatible = "tplink,tl-wa701nd-v1", "qca,ar7240";
 };
+
+&ath9k {
+	compatible = "pci168c,002b";
+};
+
+&calibration_art_1000 {
+	reg = <0x1000 0x200>;
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wa730re-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wa730re-v1.dts
@@ -6,3 +6,11 @@
 	model = "TP-Link TL-WA730RE v1";
 	compatible = "tplink,tl-wa730re-v1", "qca,ar7240";
 };
+
+&ath9k {
+	compatible = "pci168c,002b";
+};
+
+&calibration_art_1000 {
+	reg = <0x1000 0x200>;
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wa801nd-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wa801nd-v1.dts
@@ -6,3 +6,11 @@
 	model = "TP-Link TL-WA801ND v1";
 	compatible = "tplink,tl-wa801nd-v1", "qca,ar7240";
 };
+
+&ath9k {
+	compatible = "pci168c,002a";
+};
+
+&calibration_art_1000 {
+	reg = <0x1000 0xeb8>;
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wa830re-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wa830re-v1.dts
@@ -6,3 +6,11 @@
 	model = "TP-Link TL-WA830RE v1";
 	compatible = "tplink,tl-wa830re-v1", "qca,ar7240";
 };
+
+&ath9k {
+	compatible = "pci168c,002a";
+};
+
+&calibration_art_1000 {
+	reg = <0x1000 0xeb8>;
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wa901nd-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wa901nd-v1.dts
@@ -6,3 +6,11 @@
 	model = "TP-Link TL-WA901ND v1";
 	compatible = "tplink,tl-wa901nd-v1", "qca,ar7240";
 };
+
+&ath9k {
+	compatible = "pci168c,002b";
+};
+
+&calibration_art_1000 {
+	reg = <0x1000 0x200>;
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr.dtsi
@@ -41,7 +41,3 @@
 	nvmem-cells = <&macaddr_uboot_1fc00 1>;
 	nvmem-cell-names = "mac-address";
 };
-
-&ath9k {
-	compatible = "pci168c,002b";
-};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr740n-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr740n-v1.dts
@@ -6,3 +6,11 @@
 	model = "TP-Link TL-WR740N v1/v2";
 	compatible = "tplink,tl-wr740n-v1", "qca,ar7240";
 };
+
+&ath9k {
+	compatible = "pci168c,002b";
+};
+
+&calibration_art_1000 {
+	reg = <0x1000 0x200>;
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr740n-v3.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr740n-v3.dts
@@ -6,3 +6,11 @@
 	model = "TP-Link TL-WR740N v3";
 	compatible = "tplink,tl-wr740n-v3", "qca,ar7240";
 };
+
+&ath9k {
+	compatible = "pci168c,002b";
+};
+
+&calibration_art_1000 {
+	reg = <0x1000 0x200>;
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr741-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr741-v1.dts
@@ -6,3 +6,11 @@
 	model = "TP-Link TL-WR741N/ND v1/v2";
 	compatible = "tplink,tl-wr741-v1", "qca,ar7240";
 };
+
+&ath9k {
+	compatible = "pci168c,002b";
+};
+
+&calibration_art_1000 {
+	reg = <0x1000 0x200>;
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr743nd-v1.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr743nd-v1.dts
@@ -6,3 +6,11 @@
 	model = "TP-Link TL-WR743ND v1";
 	compatible = "tplink,tl-wr743nd-v1", "qca,ar7240";
 };
+
+&ath9k {
+	compatible = "pci168c,002b";
+};
+
+&calibration_art_1000 {
+	reg = <0x1000 0x200>;
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr841-v5.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr841-v5.dts
@@ -6,3 +6,11 @@
 	model = "TP-Link TL-WR841N/ND v5/v6";
 	compatible = "tplink,tl-wr841-v5", "qca,ar7240";
 };
+
+&ath9k {
+	compatible = "pci168c,002a";
+};
+
+&calibration_art_1000 {
+	reg = <0x1000 0xeb8>;
+};

--- a/target/linux/ath79/dts/ar7240_tplink_tl-wr941-v4.dts
+++ b/target/linux/ath79/dts/ar7240_tplink_tl-wr941-v4.dts
@@ -6,3 +6,11 @@
 	model = "TP-Link TL-WR941N/ND v4";
 	compatible = "tplink,tl-wr941-v4", "qca,ar7240";
 };
+
+&ath9k {
+	compatible = "pci168c,002a";
+};
+
+&calibration_art_1000 {
+	reg = <0x1000 0xeb8>;
+};

--- a/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -12,30 +12,16 @@ case "$FIRMWARE" in
 	buffalo,whr-g301n|\
 	engenius,eap350-v1|\
 	engenius,ecb350-v1|\
-	engenius,enh202-v1|\
-	tplink,tl-wa701nd-v1|\
-	tplink,tl-wa730re-v1|\
-	tplink,tl-wa801nd-v1|\
-	tplink,tl-wa830re-v1|\
-	tplink,tl-wa901nd-v1|\
-	tplink,tl-wr841-v5|\
-	tplink,tl-wr941-v4)
+	engenius,enh202-v1)
 		caldata_extract "art" 0x1000 0xeb8
 		;;
 	dlink,dir-615-e4)
 		caldata_extract "art" 0x1000 0x1000
 		ath9k_patch_mac_crc $(mtd_get_mac_ascii "nvram" "lan_mac") 0x10c
 		;;
-	netgear,wnr1000-v2|\
 	netgear,wnr2000-v3|\
-	netgear,wnr612-v2|\
-	on,n150r|\
 	tplink,tl-mr3220-v1|\
 	tplink,tl-mr3420-v1|\
-	tplink,tl-wr740n-v1|\
-	tplink,tl-wr740n-v3|\
-	tplink,tl-wr741-v1|\
-	tplink,tl-wr743nd-v1|\
 	tplink,tl-wr841-v7|\
 	ubnt,airrouter|\
 	ubnt,bullet-m-ar7240|\


### PR DESCRIPTION
These devices use AR9285, which uses 3d8 as the calibration size, not 440 like newer chips do. Add a compatible line to make it clear that this is the case.

ping @DragonBluep 