### PR TITLE
ath79: dlink,dir-615-e4: use nvmem

### DIFF
--- a/target/linux/ath79/dts/ar7240_dlink_dir-615-e4.dts
+++ b/target/linux/ath79/dts/ar7240_dlink_dir-615-e4.dts
@@ -138,6 +138,16 @@
 				reg = <0x3f0000 0x10000>;
 				label = "art";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x3d8>;
+					};
+				};
 			};
 		};
 	};
@@ -151,9 +161,10 @@
 	status = "okay";
 
 	ath9k: wifi@0,0 {
-		compatible = "pci168c,002b";
+		compatible = "pci168c,002e";
 		reg = <0x0000 0 0 0 0>;
-		qca,no-eeprom;
+		nvmem-cells = <&cal_art_1000>;
+		nvmem-cell-names = "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
 	};

--- a/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -14,10 +14,6 @@ case "$FIRMWARE" in
 	engenius,enh202-v1)
 		caldata_extract "art" 0x1000 0xeb8
 		;;
-	dlink,dir-615-e4)
-		caldata_extract "art" 0x1000 0x1000
-		ath9k_patch_mac_crc $(mtd_get_mac_ascii "nvram" "lan_mac") 0x10c
-		;;
 	netgear,wnr2000-v3|\
 	ubnt,airrouter|\
 	ubnt,bullet-m-ar7240|\

--- a/target/linux/ath79/tiny/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/tiny/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -1,0 +1,19 @@
+#!/bin/ash
+
+[ "$ACTION" = "add" ] || exit 0
+
+PHYNBR=${DEVPATH##*/phy}
+
+[ -n $PHYNBR ] || exit 0
+
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+board=$(board_name)
+
+case "$board" in
+	dlink,dir-615-e4)
+		[ "$PHYNBR" -eq 0 ] && \
+			mtd_get_mac_ascii "nvram" "lan_mac" > /sys${DEVPATH}/macaddress
+		;;
+esac


### PR DESCRIPTION
Userspace handling is deprecated.

Move the mac address patch to 10_fix_wifi_mac.

This uses an AR9287, which uses a smaller size for its calibration.

The PCI ID is also wrong.


ping @DragonBluep 