### PR TITLE
ath79: ar9344: use led-sources for ath9k

### DIFF
--- a/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
+++ b/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
@@ -70,13 +70,6 @@
 			label = "green:signal3";
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 		};
-
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
 	};
 
 	watchdog {
@@ -174,4 +167,10 @@
 
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <12>;
+		led-active-low;
+
+	};
 };

--- a/target/linux/ath79/dts/ar9344_comfast_cf-e120a-v3.dts
+++ b/target/linux/ath79/dts/ar9344_comfast_cf-e120a-v3.dts
@@ -35,13 +35,6 @@
 			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
 		};
 
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		rssilow {
 			label = "red:rssilow";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
@@ -163,4 +156,9 @@
 
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <0>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/dts/ar9344_devolo_dlan_wifi.dtsi
+++ b/target/linux/ath79/dts/ar9344_devolo_dlan_wifi.dtsi
@@ -17,13 +17,6 @@
 	leds {
 		compatible = "gpio-leds";
 
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_WHITE>;
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
 		led_dlan_white: dlan_white {
 			label = "white:dlan";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
@@ -164,6 +157,11 @@
 
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <12>;
+		led-active-low;
+	};
 };
 
 &pcie {

--- a/target/linux/ath79/dts/ar9344_fortinet_fap-221-b.dts
+++ b/target/linux/ath79/dts/ar9344_fortinet_fap-221-b.dts
@@ -43,12 +43,6 @@
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
-
-		wifi2g {
-			label = "amber:wifi2g";
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
 	};
 
 	virtual_flash {
@@ -73,6 +67,11 @@
 
 	nvmem-cells = <&calibration_wmac>, <&macaddr_uboot_3ff80 1>;
 	nvmem-cell-names = "calibration", "mac-address";
+
+	led {
+		led-sources = <19>;
+		led-active-low;
+	};
 };
 
 &art {

--- a/target/linux/ath79/dts/ar9344_huawei_ap6010dn.dts
+++ b/target/linux/ath79/dts/ar9344_huawei_ap6010dn.dts
@@ -191,7 +191,7 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,0033";
 		reg = <0x0000 0 0 0 0>;
 		gpio-controller;

--- a/target/linux/ath79/dts/ar9344_longdata_aps256.dts
+++ b/target/linux/ath79/dts/ar9344_longdata_aps256.dts
@@ -21,13 +21,6 @@
 	leds: leds {
 		compatible = "gpio-leds";
 
-		wlan2g {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_BLUE>;
-			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		led_system: system {
 			function = LED_FUNCTION_STATUS;
 			color = <LED_COLOR_ID_BLUE>;
@@ -138,6 +131,11 @@
 
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <13>;
+		led-active-low;
+	};
 };
 
 &gpio {

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-2011uias-2hnd.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-2011uias-2hnd.dts
@@ -65,17 +65,6 @@
 		los-gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
 		maximum-power-milliwatt = <1000>;
 	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led-0 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_WLAN_2GHZ;
-			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
 };
 
 &ref {
@@ -341,4 +330,9 @@
 	status = "okay";
 
 	qca,no-eeprom;
+
+	led {
+		led-sources = <4>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/dts/ar9344_netgear_r6100.dts
+++ b/target/linux/ath79/dts/ar9344_netgear_r6100.dts
@@ -87,13 +87,6 @@
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
 		};
-
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_BLUE>;
-			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
 	};
 };
 
@@ -235,4 +228,9 @@
 
 	nvmem-cells = <&cal_ath9k>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <0>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/dts/ar9344_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/ar9344_netgear_wndr.dtsi
@@ -61,12 +61,6 @@
 			default-state = "keep";
 		};
 
-		wlan2g_green {
-			label = "green:wlan2g";
-			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		wlan5g_blue {
 			label = "blue:wlan5g";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
@@ -273,6 +267,11 @@
 
 	nvmem-cells = <&macaddr_caldata_0>, <&cal_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
+
+	led {
+		led-sources = <11>;
+		led-active-low;
+	};
 };
 
 &pcie {

--- a/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
+++ b/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
@@ -31,25 +31,9 @@
 			default-state = "on";
 		};
 
-		wlan2g {
-			label = "yellow:wlan24";
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		led_system: system {
 			label = "blue:sys";
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wlan5g {
-			label = "red:wlan5";
-			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
 		};
 	};
 
@@ -149,13 +133,16 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_c>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
 	};
 };
 
@@ -164,6 +151,11 @@
 
 	nvmem-cells = <&macaddr_art_6>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
+
+	led {
+		led-sources = <12>;
+		led-active-low;
+	};
 };
 
 &mdio0 {

--- a/target/linux/ath79/dts/ar9344_pcs_cap324.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cap324.dts
@@ -54,13 +54,6 @@
 			linux,default-trigger = "phy1tpt";
 		};
 
-		wlan_green {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		lan_amber {
 			function = LED_FUNCTION_LAN;
 			color = <LED_COLOR_ID_AMBER>;
@@ -142,8 +135,8 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
-		compatible = "168c,0030";
+	wifi@0,0 {
+		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_0 (-2)>, <&cal_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
@@ -159,6 +152,11 @@
 	ieee80211-freq-limit = <4900000 5990000>;
 	nvmem-cells = <&macaddr_art_0 (-1)>, <&cal_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
+
+	led {
+		led-sources = <18>;
+		led-active-low;
+	};
 };
 
 &mdio0 {

--- a/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
@@ -49,13 +49,6 @@
 			default-state = "on";
 		};
 
-		wlan2g {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_BLUE>;
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		wps_white {
 			function = LED_FUNCTION_WPS;
 			color = <LED_COLOR_ID_WHITE>;
@@ -137,7 +130,7 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_5002>;
@@ -224,4 +217,9 @@
 
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <14>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750x.dtsi
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750x.dtsi
@@ -44,13 +44,6 @@
 			label = "green:sig2";
 			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
 		};
-
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
 	};
 };
 
@@ -129,4 +122,9 @@
 
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <21>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/dts/ar9344_samsung_wam250.dts
+++ b/target/linux/ath79/dts/ar9344_samsung_wam250.dts
@@ -55,13 +55,6 @@
 			label = "white:repeater";
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
-
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_WHITE>;
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
 	};
 };
 
@@ -175,4 +168,9 @@
 
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <12>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/dts/ar9344_senao_ap-dual.dtsi
+++ b/target/linux/ath79/dts/ar9344_senao_ap-dual.dtsi
@@ -25,16 +25,6 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wifi2g {
-			label = "blue:wifi2g";
-			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-	};
 };
 
 &mdio0 {
@@ -59,12 +49,15 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0 0 0 0 0>;
 		ieee80211-freq-limit = <2402000 2482000>;
-		#gpio-cells = <2>;
-		gpio-controller;
+
+		led {
+			led-sources = <0>;
+			led-active-low;
+		};
 	};
 };
 

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wr841hp-v2.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wr841hp-v2.dts
@@ -63,13 +63,6 @@
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
 		};
 
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		led_system: system {
 			label = "green:system";
 			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
@@ -159,6 +152,11 @@
 
 	nvmem-cells = <&macaddr_uboot_1fc00 0>, <&cal_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
+
+	led {
+		led-sources = <21>;
+		led-active-low;
+	};
 };
 
 &eth0 {

--- a/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
@@ -41,12 +41,6 @@
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
-		wifi_amber {
-			label = "amber:wifi";
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
 		wifi_green {
 			label = "green:wifi";
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
@@ -78,6 +72,11 @@
 
 	nvmem-cells = <&macaddr_art_0 (-2)>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
+
+	led {
+		led-sources = <19>;
+		led-active-low;
+	};
 };
 
 &art {

--- a/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
@@ -41,12 +41,6 @@
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
-		wifi_amber {
-			label = "amber:wifi";
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
-		};
-
 		wifi_green {
 			label = "green:wifi";
 			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
@@ -74,6 +68,11 @@
 &wmac {
 	nvmem-cells = <&macaddr_art_0 (-2)>, <&calibration_art_1000>;
 	nvmem-cell-names = "mac-address", "calibration";
+
+	led {
+		led-sources = <19>;
+		led-active-low;
+	};
 };
 
 &art {

--- a/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
+++ b/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
@@ -43,12 +43,6 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&enable_gpio20_gpio22>;
 
-		wifi {
-			label = "green:wifi";
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
 		lan1 {
 			label = "orange:lan1";
 			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
@@ -162,6 +156,11 @@
 
 	nvmem-cells = <&cal_art_1000>;
 	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <12>;
+		led-active-low;
+	};
 };
 
 &pinmux {


### PR DESCRIPTION
The ath9k driver creates an ath9k LED by default. Instead of having a non functional LED, configure it properly and remove the extra as it's not needed.