### PR TITLE
include: make APK .list files even more reproducible

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -353,7 +353,7 @@ else
 
 	if [ -n "$(USERID)" ]; then echo $(USERID) > $$(IDIR_$(1))/lib/apk/packages/$(1).rusers; fi;
 	if [ -n "$(ALTERNATIVES)" ]; then echo $(ALTERNATIVES) > $$(IDIR_$(1))/lib/apk/packages/$(1).alternatives; fi;
-	(cd $$(IDIR_$(1)) && find . -type f,l -printf "/%P\n" | sort > $$(IDIR_$(1))/lib/apk/packages/$(1).list)
+	(cd $$(IDIR_$(1)) && find . -type f,l -printf "/%P\n" | sort > $(TMP_DIR)/$(1).list && mv $(TMP_DIR)/$(1).list $$(IDIR_$(1))/lib/apk/packages/$(1).list)
 	# Move conffiles to IDIR and build conffiles_static with csums
 	if [ -f $$(ADIR_$(1))/conffiles ]; then \
 		mv -f $$(ADIR_$(1))/conffiles $$(IDIR_$(1))/lib/apk/packages/$(1).conffiles; \


### PR DESCRIPTION
This commit fixes "aff2f096235 include: make APK .list files reproducible" since it would create the .list file while `find` still runs. This causes the .list file to be part of itself. As an alternative, write the file to a temporary folder first and then move it.

Fix: aff2f096235 include: make APK .list files reproducible