### PR TITLE
mediatek: add the aquantia kmod to bpi-r4

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -672,7 +672,7 @@ define Device/bananapi_bpi-r4-common
   DEVICE_DTS_OVERLAY:= mt7988a-bananapi-bpi-r4-emmc mt7988a-bananapi-bpi-r4-rtc mt7988a-bananapi-bpi-r4-sd
   DEVICE_DTC_FLAGS := --pad 4096
   DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-i2c-mux-pca954x kmod-eeprom-at24 kmod-mt7996-firmware kmod-mt7996-233-firmware \
-		     kmod-rtc-pcf8563 kmod-sfp kmod-usb3 e2fsprogs f2fsck mkf2fs mt7988-wo-firmware
+		     kmod-rtc-pcf8563 kmod-sfp kmod-phy-aquantia kmod-usb3 e2fsprogs f2fsck mkf2fs mt7988-wo-firmware
   DEVICE_COMPAT_VERSION := 1.1
   DEVICE_COMPAT_MESSAGE := The non-switch ports were renamed to match the board/case labels
   IMAGES := sysupgrade.itb


### PR DESCRIPTION
The banana pi r4 comes with 2 sfp+ ports running at 10gbps Readd support for aquantia sfp+ modules that was removed by 57a127c9e79db96f4dbf262db9e1a808bd474ddf

Closes: #19878

____________________________________

Further devices in filogic.mk with the package kmod-sfp only support sfp but not sfp+:
Banana Pi R3 (SFP 2.5 gigabit)
TP-Link FR365 v1 (SFP gigabit)

I therefore assume they don't require support for Aquantia Modules, but I'm not certain.