### PR TITLE
realtek: correct whitespace in hp dts files

### DIFF
--- a/target/linux/realtek/dts/rtl8393_hpe_1920-48g-poe.dts
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920-48g-poe.dts
@@ -17,81 +17,81 @@
 		#cooling-cells = <2>;
 	};
 
-        i2c0: i2c-gpio-0 {
-                compatible = "i2c-gpio";
-                sda-gpios = <&gpio1 13 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                scl-gpios = <&gpio1 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                i2c-gpio,delay-us = <2>;
-                #address-cells = <1>;
-                #size-cells = <0>;
-        };
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 13 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
 
-        sfp0: sfp-p49 {
-                compatible = "sff,sfp";
-                i2c-bus = <&i2c0>;
-                los-gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
-                mod-def0-gpio = <&gpio1 21 GPIO_ACTIVE_LOW>;
-                // tx-fault unconnected (TODO?)
-                // tx-disable connected to RTL8214FC (TODO?)
-        };
+	sfp0: sfp-p49 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 21 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
 
-        i2c1: i2c-gpio-1 {
-                compatible = "i2c-gpio";
-                sda-gpios = <&gpio1 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                scl-gpios = <&gpio1 24 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                i2c-gpio,delay-us = <2>;
-                #address-cells = <1>;
-                #size-cells = <0>;
-        };
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 24 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
 
-        sfp1: sfp-p50 {
-                compatible = "sff,sfp";
-                i2c-bus = <&i2c1>;
-                los-gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
-                mod-def0-gpio = <&gpio1 25 GPIO_ACTIVE_LOW>;
-                // tx-fault unconnected (TODO?)
-                // tx-disable connected to RTL8214FC (TODO?)
-        };
+	sfp1: sfp-p50 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 25 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
 
-        i2c2: i2c-gpio-2 {
-                compatible = "i2c-gpio";
-                sda-gpios = <&gpio1 27 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                scl-gpios = <&gpio1 28 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                i2c-gpio,delay-us = <2>;
-                #address-cells = <1>;
-                #size-cells = <0>;
-        };
+	i2c2: i2c-gpio-2 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 27 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 28 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
 
-        sfp2: sfp-p51 {
-                compatible = "sff,sfp";
-                i2c-bus = <&i2c2>;
-                los-gpio = <&gpio1 30 GPIO_ACTIVE_HIGH>;
-                mod-def0-gpio = <&gpio1 29 GPIO_ACTIVE_LOW>;
-                // tx-fault unconnected (TODO?)
-                // tx-disable connected to RTL8214FC (TODO?)
-        };
+	sfp2: sfp-p51 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio1 30 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 29 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
 
-        i2c3: i2c-gpio-3 {
-                compatible = "i2c-gpio";
-                sda-gpios = <&gpio1 31 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                scl-gpios = <&gpio1 32 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                i2c-gpio,delay-us = <2>;
-                #address-cells = <1>;
-                #size-cells = <0>;
-        };
+	i2c3: i2c-gpio-3 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 31 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 32 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
 
-        sfp3: sfp-p52 {
-                compatible = "sff,sfp";
-                i2c-bus = <&i2c3>;
-                los-gpio = <&gpio1 34 GPIO_ACTIVE_HIGH>;
-                mod-def0-gpio = <&gpio1 33 GPIO_ACTIVE_LOW>;
-                // tx-fault unconnected (TODO?)
-                // tx-disable connected to RTL8214FC (TODO?)
-        };
+	sfp3: sfp-p52 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio1 34 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 33 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
 };
 
 &ethernet0 {
-        mdio: mdio-bus {
+	mdio: mdio-bus {
 		EXTERNAL_SFP_PHY_FULL(48, 0)
 		EXTERNAL_SFP_PHY_FULL(49, 1)
 		EXTERNAL_SFP_PHY_FULL(50, 2)

--- a/target/linux/realtek/dts/rtl8393_hpe_1920-48g.dts
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920-48g.dts
@@ -6,82 +6,82 @@
 	compatible = "hpe,1920-48g", "realtek,rtl8393-soc";
 	model = "HPE 1920-48G (JG927A)";
 
-        i2c-gpio-shared0 {
-                compatible = "i2c-gpio-shared";
-                scl-gpios = <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                #address-cells = <1>;
-                #size-cells = <0>;
+	i2c-gpio-shared0 {
+		compatible = "i2c-gpio-shared";
+		scl-gpios = <&gpio0 17 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-                i2c0: i2c@0 {
-                        sda-gpios = <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                        i2c-gpio,delay-us = <2>;
-                };
+		i2c0: i2c@0 {
+			sda-gpios = <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+			i2c-gpio,delay-us = <2>;
+		};
 
-                i2c2: i2c@2 {
-                        sda-gpios = <&gpio0 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                        i2c-gpio,delay-us = <2>;
+		i2c2: i2c@2 {
+			sda-gpios = <&gpio0 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+			i2c-gpio,delay-us = <2>;
 
-                };
-        };
+		};
+	};
 
-        i2c-gpio-shared1 {
-                compatible = "i2c-gpio-shared";
-                scl-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                #address-cells = <1>;
-                #size-cells = <0>;
+	i2c-gpio-shared1 {
+		compatible = "i2c-gpio-shared";
+		scl-gpios = <&gpio0 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		#address-cells = <1>;
+		#size-cells = <0>;
 
-                i2c1: i2c@1 {
-                        sda-gpios = <&gpio0 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                        i2c-gpio,delay-us = <2>;
-                };
+		i2c1: i2c@1 {
+			sda-gpios = <&gpio0 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+			i2c-gpio,delay-us = <2>;
+		};
 
-                i2c3: i2c@3 {
-                        sda-gpios = <&gpio0 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-                        i2c-gpio,delay-us = <2>;
+		i2c3: i2c@3 {
+			sda-gpios = <&gpio0 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+			i2c-gpio,delay-us = <2>;
 
-                };
-        };
+		};
+	};
 
-        sfp0: sfp-p49 {
-                compatible = "sff,sfp";
-                i2c-bus = <&i2c0>;
-                los-gpio = <&gpio0 20 GPIO_ACTIVE_HIGH>;
-                mod-def0-gpio = <&gpio0 19 GPIO_ACTIVE_LOW>;
-                // tx-fault unconnected (TODO?)
-                // tx-disable connected to RTL8214FC (TODO?)
-        };
+	sfp0: sfp-p49 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 19 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
 
-        sfp1: sfp-p50 {
-                compatible = "sff,sfp";
-                i2c-bus = <&i2c1>;
-                los-gpio = <&gpio0 13 GPIO_ACTIVE_HIGH>;
-                mod-def0-gpio = <&gpio0 12 GPIO_ACTIVE_LOW>;
-                // tx-fault unconnected (TODO?)
-                // tx-disable connected to RTL8214FC (TODO?)
-        };
+	sfp1: sfp-p50 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
 
-        sfp2: sfp-p51 {
-                compatible = "sff,sfp";
-                i2c-bus = <&i2c2>;
-                los-gpio = <&gpio0 23 GPIO_ACTIVE_HIGH>;
-                mod-def0-gpio = <&gpio0 22 GPIO_ACTIVE_LOW>;
-                // tx-fault unconnected (TODO?)
-                // tx-disable connected to RTL8214FC (TODO?)
-        };
+	sfp2: sfp-p51 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 22 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
 
-        sfp3: sfp-p52 {
-                compatible = "sff,sfp";
-                i2c-bus = <&i2c3>;
-                los-gpio = <&gpio0 16 GPIO_ACTIVE_HIGH>;
-                mod-def0-gpio = <&gpio0 15 GPIO_ACTIVE_LOW>;
-                // tx-fault unconnected (TODO?)
-                // tx-disable connected to RTL8214FC (TODO?)
-        };
+	sfp3: sfp-p52 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		// tx-fault unconnected (TODO?)
+		// tx-disable connected to RTL8214FC (TODO?)
+	};
 
 };
 
 &ethernet0 {
-        mdio: mdio-bus {
+	mdio: mdio-bus {
 		EXTERNAL_SFP_PHY_FULL(48, 1)
 		EXTERNAL_SFP_PHY_FULL(49, 3)
 		EXTERNAL_SFP_PHY_FULL(50, 0)
@@ -91,7 +91,7 @@
 
 
 &switch0 {
-        ports {
+	ports {
 		SWITCH_PORT(48, 50, qsgmii)
 		SWITCH_PORT(49, 52, qsgmii)
 		SWITCH_PORT(50, 49, qsgmii)


### PR DESCRIPTION
Make whitespace consistent, replace 8 spaces by tab
Fixes 502b2f4ee5a4a823f2350aa45e70f98b8a6c3fd3