### PR TITLE
[24.10] armsr: backport serial console behaviour fix

### DIFF
--- a/target/linux/armsr/image/Makefile
+++ b/target/linux/armsr/image/Makefile
@@ -12,7 +12,6 @@ GRUB_TERMINAL_CONFIG =
 GRUB_CONSOLE_CMDLINE = earlycon
 
 ifneq ($(CONFIG_GRUB_CONSOLE),)
-  GRUB_CONSOLE_CMDLINE += console=tty1
   GRUB_TERMINALS += console
 endif
 

--- a/target/linux/armsr/patches-6.6/300-printk-always-setup-default-consoles.patch
+++ b/target/linux/armsr/patches-6.6/300-printk-always-setup-default-consoles.patch
@@ -1,0 +1,47 @@
+From 0059efbd0f9c291795078fb4e50722641d525f38 Mon Sep 17 00:00:00 2001
+From: Mathew McBride <matt@traverse.com.au>
+Date: Thu, 16 Jan 2025 11:48:44 +1100
+Subject: [PATCH] printk: always setup default (tty0 + stdout / SPCR) consoles
+ when no console= present
+
+(This is a hack specific to OpenWrt's armsr target)
+
+This change resolves a difference in behaviour between arm64 ACPI
+and DT systems.
+Our usecase is to ensure the system console is always present
+regardless of display mode (serial port or screen).
+
+Both ACPI and DT have mechanisms to setup a serial console from
+information passed by firmware (SPCR and stdout-path respectively).
+
+On ACPI systems, the SPCR table is parsed very early on in the kernel
+boot which prevents the screen console (tty0) from appearing if it is
+not explicitly set.
+
+We would like to avoid specifying console= arguments as there are many
+possible configurations on the serial side (like ttyS0, ttyAMA0, ttymxc0
+etc.).
+
+If the kernel does not consume the serial port in SPCR/stdout-path,
+then the 'default' settings from the firmware (baud rate etc.) are lost.
+
+If the system administrator explicitly specifies a console= argument,
+then the old behaviour is returned.
+
+Signed-off-by: Mathew McBride <matt@traverse.com.au>
+Link: https://github.com/openwrt/openwrt/pull/17012#issuecomment-2591751115
+---
+ kernel/printk/printk.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/kernel/printk/printk.c
++++ b/kernel/printk/printk.c
+@@ -3515,7 +3515,7 @@ void register_console(struct console *ne
+ 	 * Note that a console with tty binding will have CON_CONSDEV
+ 	 * flag set and will be first in the list.
+ 	 */
+-	if (preferred_console < 0) {
++	if (!console_set_on_cmdline) {
+ 		if (hlist_empty(&console_list) || !console_first()->device ||
+ 		    console_first()->flags & CON_BOOT) {
+ 			try_enable_default_console(newcon);


### PR DESCRIPTION
This pull request backports the changes to the system console from #17012 to the 24.10 branch.

As a refresher, the purpose is to ensure OpenWrt correctly spawns a serial console if the firmware specifies one (DT: `stdout-path`, ACPI: SPCR). 
Due to a difference in how ACPI and DT systems enumerate firmware attributes, the only way to achieve this is to tweak the kernel's handling of the "default" console, so it will always try to setup the firmware specified ones, unless a `console=` parameter exists on the command line.