### PR TITLE
pcre2: bump to 10.46

### DIFF
--- a/package/libs/pcre2/Makefile
+++ b/package/libs/pcre2/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pcre2
-PKG_VERSION:=10.42
+PKG_VERSION:=10.46
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/PCRE2Project/pcre2/releases/download/$(PKG_NAME)-$(PKG_VERSION)
-PKG_HASH:=8d36cd8cb6ea2a4c2bb358ff6411b0c788633a2a45dabbf1aeb4b701d1b5e840
+PKG_HASH:=15fbc5aba6beee0b17aecb04602ae39432393aba1ebd8e39b7cabf7db883299f
 
 PKG_MAINTAINER:=Shane Peelar <lookatyouhacker@gmail.com>
 PKG_LICENSE:=BSD-3-Clause


### PR DESCRIPTION
Update to latest version.

Changelog: https://github.com/PCRE2Project/pcre2/blob/pcre2-10.46/ChangeLog

Tested with snort3, no regressions.

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc (Intel N150 based box)