### PR TITLE
realtek: Rename XGS1210-12 to XGS1210-12 A1

### DIFF
--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-a1.dts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl9302_zyxel_xgs1210-12-common.dtsi"
+
+/ {
+	compatible = "zyxel,xgs1210-12-a1", "realtek,rtl838x-soc";
+	model = "Zyxel XGS1210-12 A1 Switch";
+};
+
+&mdio {
+	phy24: ethernet-phy@24 {
+		reg = <24>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <1 8>;
+		sds = < 6 >;
+		// Disabled because we do not know how to bring up again
+		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+	};
+
+	phy25: ethernet-phy@25 {
+		reg = <25>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <2 9>;
+		sds = < 7 >;
+		// Disabled because we do not know how to bring up again
+		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@24 {
+			reg = <24>;
+			label = "lan9";
+			phy-mode = "2500base-x";
+			phy-handle = <&phy24>;
+			led-set = <1>;
+		};
+		port@25 {
+			reg = <25>;
+			label = "lan10";
+			phy-mode = "2500base-x";
+			phy-handle = <&phy25>;
+			led-set = <1>;
+		};
+	};
+};

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-common.dtsi
@@ -9,9 +9,6 @@
 #include <dt-bindings/thermal/thermal.h>
 
 / {
-	compatible = "zyxel,xgs1210-12", "realtek,rtl838x-soc";
-	model = "Zyxel XGS1210-12 Switch";
-
 	aliases {
 		led-boot = &led_pwr_sys;
 		led-failsafe = &led_pwr_sys;
@@ -201,25 +198,6 @@
 			rtl9300,smi-address = <0 7>;
 		};
 
-		/* External RTL8226 PHYs */
-		phy24: ethernet-phy@24 {
-			reg = <24>;
-			compatible = "ethernet-phy-ieee802.3-c45";
-			rtl9300,smi-address = <1 8>;
-			sds = < 6 >;
-			// Disabled because we do not know how to bring up again
-			// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
-		};
-
-		phy25: ethernet-phy@25 {
-			reg = <25>;
-			compatible = "ethernet-phy-ieee802.3-c45";
-			rtl9300,smi-address = <2 9>;
-			sds = < 7 >;
-			// Disabled because we do not know how to bring up again
-			// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
-		};
-
 		INTERNAL_PHY_SDS(26, 8)
 		INTERNAL_PHY_SDS(27, 9)
 	};
@@ -285,21 +263,6 @@
 			phy-handle = <&phy7>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
-		};
-
-		port@24 {
-			reg = <24>;
-			label = "lan9";
-			phy-mode = "2500base-x";
-			phy-handle = <&phy24>;
-			led-set = <1>;
-		};
-		port@25 {
-			reg = <25>;
-			label = "lan10";
-			phy-mode = "2500base-x";
-			phy-handle = <&phy25>;
-			led-set = <1>;
 		};
 
 		port@26 {

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -96,12 +96,14 @@ define Device/xikestor_sks8310-8x
 endef
 TARGET_DEVICES += xikestor_sks8310-8x
 
-define Device/zyxel_xgs1210-12
+define Device/zyxel_xgs1210-12-a1
   SOC := rtl9302
+  SUPPORTED_DEVICES += zyxel,xgs1210-12
   UIMAGE_MAGIC := 0x93001210
   ZYXEL_VERS := ABTY
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := XGS1210-12
+  DEVICE_VARIANT := A1
   IMAGE_SIZE := 13312k
   KERNEL_INITRAMFS := \
         kernel-bin | \
@@ -110,7 +112,7 @@ define Device/zyxel_xgs1210-12
         zyxel-vers | \
         uImage gzip
 endef
-TARGET_DEVICES += zyxel_xgs1210-12
+TARGET_DEVICES += zyxel_xgs1210-12-a1
 
 define Device/zyxel_xgs1250-12
   SOC := rtl9302


### PR DESCRIPTION
A new version of the XGS1210-12 has been seen in the wild. It includes at least two known hardware changes

- lan9/lan10 use RTL8221B instead of RTL8226
- lan9/lan10 use different SMI busses

Pave the new device the way by splitting the existing DTS into a common DTSI and an a1 specific DTS part.
