### PR TITLE
ltq-ptm: add NVMEM MAC support for ADSL

### DIFF
--- a/package/kernel/lantiq/ltq-ptm/Makefile
+++ b/package/kernel/lantiq/ltq-ptm/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=ltq-ptm
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_MAINTAINER:=John Crispin <john@phrozen.org>
 PKG_LICENSE:=GPL-2.0+

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
@@ -46,6 +46,7 @@
 #include <linux/netdevice.h>
 #include <linux/platform_device.h>
 #include <linux/of_device.h>
+#include <linux/of_net.h>
 #include <asm/io.h>
 
 /*
@@ -119,7 +120,7 @@ MODULE_PARM_DESC(eth_efmtc_crc_cfg, "Configuration for PTM TX/RX ethernet/efm-tc
 /*
  *  Network Operations
  */
-static void ptm_setup(struct net_device *, int);
+static int ptm_setup(struct device_node *np, struct net_device *, int);
 static struct net_device_stats *ptm_get_stats(struct net_device *);
 static int ptm_open(struct net_device *);
 static int ptm_stop(struct net_device *);
@@ -275,9 +276,10 @@ static int g_showtime = 0;
  * ####################################
  */
 
-static void ptm_setup(struct net_device *dev, int ndev)
+static int ptm_setup(struct device_node *np, struct net_device *dev, int ndev)
 {
     u8 addr[ETH_ALEN];
+    int err;
 
 #if defined(CONFIG_IFXMIPS_DSL_CPE_MEI) || defined(CONFIG_IFXMIPS_DSL_CPE_MEI_MODULE)
     netif_carrier_off(dev);
@@ -294,13 +296,20 @@ static void ptm_setup(struct net_device *dev, int ndev)
 #endif
     dev->watchdog_timeo  = ETH_WATCHDOG_TIMEOUT;
 
-    addr[0] = 0x00;
-    addr[1] = 0x20;
-    addr[2] = 0xda;
-    addr[3] = 0x86;
-    addr[4] = 0x23;
-    addr[5] = 0x75 + ndev;
-    eth_hw_addr_set(dev, addr);
+    err = of_get_ethdev_address(np, dev);
+    if (err == -EPROBE_DEFER)
+	    return err;
+    if (err) {
+        addr[0] = 0x00;
+        addr[1] = 0x20;
+        addr[2] = 0xda;
+        addr[3] = 0x86;
+        addr[4] = 0x23;
+        addr[5] = 0x75 + ndev;
+        eth_hw_addr_set(dev, addr);
+    }
+
+    return 0;
 }
 
 static struct net_device_stats *ptm_get_stats(struct net_device *dev)
@@ -1463,6 +1472,7 @@ static int ltq_ptm_probe(struct platform_device *pdev)
 {
     int ret;
     struct port_cell_info port_cell = {0};
+    struct device_node *np = pdev->dev.of_node;
     void *xdata_addr = NULL;
     int i;
     char ver_str[256];
@@ -1482,7 +1492,9 @@ static int ltq_ptm_probe(struct platform_device *pdev)
         g_net_dev[i] = alloc_netdev(0, g_net_dev_name[i], NET_NAME_UNKNOWN, ether_setup);
         if ( g_net_dev[i] == NULL )
             goto ALLOC_NETDEV_FAIL;
-        ptm_setup(g_net_dev[i], i);
+        ret = ptm_setup(np, g_net_dev[i], i);
+        if (ret == -EPROBE_DEFER)
+            goto ALLOC_NETDEV_FAIL;
     }
 
     for ( i = 0; i < ARRAY_SIZE(g_net_dev); i++ ) {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
@@ -391,7 +391,7 @@
 			lantiq,rx-burst-length = <8>;
 		};
 
-		ppe@e234000 {
+		ppe: ppe@e234000 {
 			compatible = "lantiq,ppe-arx100";
 			reg = <0xe234000 0x3ffd>;
 			interrupt-parent = <&icu0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7312.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7312.dts
@@ -115,6 +115,11 @@
 	};
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_ath9k_cal_a91 1>;
+	nvmem-cell-names = "mac-address";
+};
+
 &localbus {
 	flash@0 {
 		compatible = "lantiq,nor";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7320.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_avm_fritz7320.dts
@@ -116,6 +116,11 @@
 	};
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_ath9k_cal_a91 1>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gpio {
 	pinctrl-names = "default";
 	pinctrl-0 = <&state_default>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube.dtsi
@@ -303,7 +303,7 @@
 			lantiq,rx-burst-length = <4>;
 		};
 
-		ppe@e234000 {
+		ppe: ppe@e234000 {
 			compatible = "lantiq,ppe-danube";
 			reg = <0xe234000 0x40000>;
 			interrupt-parent = <&icu0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7506pw11.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7506pw11.dts
@@ -108,6 +108,11 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_boardconfig_16 2>;
+	nvmem-cell-names = "mac-address";
+};
+
 &localbus {
 	flash@0 {
 		compatible = "lantiq,nor";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7519pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7519pw.dts
@@ -143,7 +143,12 @@
 
 &gsw {
 	phy-mode = "mii";
-	nvmem-cells = <&macaddr_boardconfig_16>;
+	nvmem-cells = <&macaddr_boardconfig_16 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ppe {
+	nvmem-cells = <&macaddr_boardconfig_16 1>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -185,7 +190,9 @@
 					#size-cells = <1>;
 
 					macaddr_boardconfig_16: macaddr@16 {
+						compatible = "mac-base";
 						reg = <0x16 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_arv7519rw22.dts
@@ -98,7 +98,12 @@
 };
 
 &eth0 {
-	nvmem-cells = <&macaddr_boardconfig_16>;
+	nvmem-cells = <&macaddr_boardconfig_16 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ppe {
+	nvmem-cells = <&macaddr_boardconfig_16 1>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -218,7 +223,9 @@
 					#size-cells = <1>;
 
 					macaddr_boardconfig_16: macaddr@16 {
+						compatible = "mac-base";
 						reg = <0x16 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
@@ -136,6 +136,11 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_boardconfig_16 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gphy0 {
 	lantiq,gphy-mode = <GPHY_MODE_GE>;
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vrv9510kwac23.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vrv9510kwac23.dts
@@ -224,6 +224,11 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_boardconfig_16 0>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gphy0 {
 	lantiq,gphy-mode = <GPHY_MODE_GE>;
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360sl.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360sl.dts
@@ -86,6 +86,11 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_urlader_a91 1>;
+	nvmem-cell-names = "mac-address";
+};
+
 &phy0 {
 	reset-gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
@@ -156,6 +156,11 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_caldata_110c 4>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gswip {
 	pinctrl-0 = <&mdio_pins>;
 	pinctrl-names = "default";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_netgear_dm200.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_netgear_dm200.dts
@@ -87,6 +87,16 @@
 	};
 };
 
+&eth0 {
+	nvmem-cells = <&macaddr_art_0 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ppe {
+	nvmem-cells = <&macaddr_art_0 1>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gphy1 {
 	lantiq,gphy-mode = <GPHY_MODE_FE>;
 };
@@ -156,6 +166,18 @@
 				reg = <0x7f2000 0x1000>;
 				label = "ART";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@7f3000 {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_tdw89x0.dtsi
@@ -117,6 +117,11 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_ath9k_cal_f100 1>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gphy0 {
 	lantiq,gphy-mode = <GPHY_MODE_GE>;
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_tplink_vr200.dtsi
@@ -109,6 +109,11 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_romfile_f100 1>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gphy0 {
 	lantiq,gphy-mode = <GPHY_MODE_GE>;
 };


### PR DESCRIPTION
fcc48204d2 added support for VDSL. This is the same commit but for ADSL.

ping @robimarko 