### PR TITLE
treewide: add const to struct of_device_id

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -416,13 +416,13 @@ gpio_keys_get_devtree_pdata(struct device *dev)
 	return pdata;
 }
 
-static struct of_device_id gpio_keys_of_match[] = {
+static const struct of_device_id gpio_keys_of_match[] = {
 	{ .compatible = "gpio-keys", },
 	{ },
 };
 MODULE_DEVICE_TABLE(of, gpio_keys_of_match);
 
-static struct of_device_id gpio_keys_polled_of_match[] = {
+static const struct of_device_id gpio_keys_polled_of_match[] = {
 	{ .compatible = "gpio-keys-polled", },
 	{ },
 };

--- a/target/linux/generic/hack-6.12/800-GPIO-add-named-gpio-exports.patch
+++ b/target/linux/generic/hack-6.12/800-GPIO-add-named-gpio-exports.patch
@@ -22,7 +22,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +#ifdef CONFIG_GPIO_SYSFS
 +
-+static struct of_device_id gpio_export_ids[] = {
++static const struct of_device_id gpio_export_ids[] = {
 +	{ .compatible = "gpio-export" },
 +	{ /* sentinel */ }
 +};

--- a/target/linux/generic/hack-6.6/800-GPIO-add-named-gpio-exports.patch
+++ b/target/linux/generic/hack-6.6/800-GPIO-add-named-gpio-exports.patch
@@ -22,7 +22,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +
 +#ifdef CONFIG_GPIO_SYSFS
 +
-+static struct of_device_id gpio_export_ids[] = {
++static const struct of_device_id gpio_export_ids[] = {
 +	{ .compatible = "gpio-export" },
 +	{ /* sentinel */ }
 +};

--- a/target/linux/lantiq/patches-6.12/035-owrt-lantiq-wifi-and-ethernet-eeprom-handling.patch
+++ b/target/linux/lantiq/patches-6.12/035-owrt-lantiq-wifi-and-ethernet-eeprom-handling.patch
@@ -141,7 +141,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	return 0;
 +}
 +
-+static struct of_device_id ath5k_eeprom_ids[] = {
++static const struct of_device_id ath5k_eeprom_ids[] = {
 +	{ .compatible = "ath5k,eeprom" },
 +	{ }
 +};

--- a/target/linux/qualcommax/patches-6.12/0900-power-Add-Qualcomm-APM.patch
+++ b/target/linux/qualcommax/patches-6.12/0900-power-Add-Qualcomm-APM.patch
@@ -873,7 +873,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +
 +#endif
 +
-+static struct of_device_id msm_apm_match_table[] = {
++static const struct of_device_id msm_apm_match_table[] = {
 +	{
 +		.compatible = "qcom,msm-apm",
 +		.data = (void *)(uintptr_t)MSM8996_ID,

--- a/target/linux/qualcommax/patches-6.12/0901-regulator-add-Qualcomm-CPR-regulators.patch
+++ b/target/linux/qualcommax/patches-6.12/0901-regulator-add-Qualcomm-CPR-regulators.patch
@@ -631,7 +631,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +	.cpr_clk_rate = IPQ9574_NPU_CPR_CLOCK_RATE,
 +};
 +
-+static struct of_device_id cpr3_regulator_match_table[] = {
++static const struct of_device_id cpr3_regulator_match_table[] = {
 +	{
 +		.compatible = "qcom,cpr3-ipq807x-npu-regulator",
 +		.data = &ipq807x_cpr_npu
@@ -11538,7 +11538,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 +	.mem_acc_funcs = NULL,
 +};
 +
-+static struct of_device_id cpr4_regulator_match_table[] = {
++static const struct of_device_id cpr4_regulator_match_table[] = {
 +	{
 +		.compatible = "qcom,cpr4-ipq807x-apss-regulator",
 +		.data = &ipq807x_cpr_apss


### PR DESCRIPTION
Most drivers have this as const. Especially upstream in the kernel.

ping @robimarko 