### PR TITLE
mediatek: backport patches fixing thermal on MT7988

### DIFF
--- a/target/linux/mediatek/patches-6.12/051-v6.17-thermal-drivers-mediatek-lvts_thermal-Change-lvts-co.patch
+++ b/target/linux/mediatek/patches-6.12/051-v6.17-thermal-drivers-mediatek-lvts_thermal-Change-lvts-co.patch
@@ -1,0 +1,77 @@
+From 4bbb3598b81eaa329df9c03d9a0cd4d1c70e73a4 Mon Sep 17 00:00:00 2001
+From: Mason Chang <mason-cw.chang@mediatek.com>
+Date: Mon, 26 May 2025 18:26:57 +0800
+Subject: [PATCH 1/3] thermal/drivers/mediatek/lvts_thermal: Change lvts
+ commands array to static const
+
+Change the LVTS commands array to static const in preparation for
+adding different commands.
+
+Signed-off-by: Mason Chang <mason-cw.chang@mediatek.com>
+Link: https://lore.kernel.org/r/20250526102659.30225-2-mason-cw.chang@mediatek.com
+Signed-off-by: Daniel Lezcano <daniel.lezcano@linaro.org>
+(cherry picked from commit c5d5a72c01f7faabe7cc0fd63942c18372101daf)
+---
+ drivers/thermal/mediatek/lvts_thermal.c | 29 +++++++++++++------------
+ 1 file changed, 15 insertions(+), 14 deletions(-)
+
+--- a/drivers/thermal/mediatek/lvts_thermal.c
++++ b/drivers/thermal/mediatek/lvts_thermal.c
+@@ -92,6 +92,17 @@
+ 
+ #define LVTS_MINIMUM_THRESHOLD		20000
+ 
++static const u32 default_conn_cmds[] = { 0xC103FFFF, 0xC502FF55 };
++/*
++ * Write device mask: 0xC1030000
++ */
++static const u32 default_init_cmds[] = {
++	0xC1030E01, 0xC1030CFC, 0xC1030A8C, 0xC103098D, 0xC10308F1,
++	0xC10307A6, 0xC10306B8, 0xC1030500, 0xC1030420, 0xC1030300,
++	0xC1030030, 0xC10300F6, 0xC1030050, 0xC1030060, 0xC10300AC,
++	0xC10300FC, 0xC103009D, 0xC10300F1, 0xC10300E1
++};
++
+ static int golden_temp = LVTS_GOLDEN_TEMP_DEFAULT;
+ static int golden_temp_offset;
+ 
+@@ -880,7 +891,7 @@ static void lvts_ctrl_monitor_enable(str
+  * each write in the configuration register must be separated by a
+  * delay of 2 us.
+  */
+-static void lvts_write_config(struct lvts_ctrl *lvts_ctrl, u32 *cmds, int nr_cmds)
++static void lvts_write_config(struct lvts_ctrl *lvts_ctrl, const u32 *cmds, int nr_cmds)
+ {
+ 	int i;
+ 
+@@ -963,9 +974,9 @@ static int lvts_ctrl_set_enable(struct l
+ 
+ static int lvts_ctrl_connect(struct device *dev, struct lvts_ctrl *lvts_ctrl)
+ {
+-	u32 id, cmds[] = { 0xC103FFFF, 0xC502FF55 };
++	u32 id;
+ 
+-	lvts_write_config(lvts_ctrl, cmds, ARRAY_SIZE(cmds));
++	lvts_write_config(lvts_ctrl, default_conn_cmds, ARRAY_SIZE(default_conn_cmds));
+ 
+ 	/*
+ 	 * LVTS_ID : Get ID and status of the thermal controller
+@@ -984,17 +995,7 @@ static int lvts_ctrl_connect(struct devi
+ 
+ static int lvts_ctrl_initialize(struct device *dev, struct lvts_ctrl *lvts_ctrl)
+ {
+-	/*
+-	 * Write device mask: 0xC1030000
+-	 */
+-	u32 cmds[] = {
+-		0xC1030E01, 0xC1030CFC, 0xC1030A8C, 0xC103098D, 0xC10308F1,
+-		0xC10307A6, 0xC10306B8, 0xC1030500, 0xC1030420, 0xC1030300,
+-		0xC1030030, 0xC10300F6, 0xC1030050, 0xC1030060, 0xC10300AC,
+-		0xC10300FC, 0xC103009D, 0xC10300F1, 0xC10300E1
+-	};
+-
+-	lvts_write_config(lvts_ctrl, cmds, ARRAY_SIZE(cmds));
++	lvts_write_config(lvts_ctrl, default_init_cmds, ARRAY_SIZE(default_init_cmds));
+ 
+ 	return 0;
+ }

--- a/target/linux/mediatek/patches-6.12/052-v6.17-thermal-drivers-mediatek-lvts_thermal-Add-lvts-comma.patch
+++ b/target/linux/mediatek/patches-6.12/052-v6.17-thermal-drivers-mediatek-lvts_thermal-Add-lvts-comma.patch
@@ -1,0 +1,186 @@
+From 75d0dd334963fb3e3a85b8ceadd48071daa8165f Mon Sep 17 00:00:00 2001
+From: Mason Chang <mason-cw.chang@mediatek.com>
+Date: Mon, 26 May 2025 18:26:58 +0800
+Subject: [PATCH 2/3] thermal/drivers/mediatek/lvts_thermal: Add lvts commands
+ and their sizes to driver data
+
+Add LVTS commands and their sizes to driver data in preparation for
+adding different commands.
+
+Signed-off-by: Mason Chang <mason-cw.chang@mediatek.com>
+Link: https://lore.kernel.org/r/20250526102659.30225-3-mason-cw.chang@mediatek.com
+Signed-off-by: Daniel Lezcano <daniel.lezcano@linaro.org>
+(cherry picked from commit 6203a5e6fd090ed05f6d9b92e33bc7e7679a3dd6)
+---
+ drivers/thermal/mediatek/lvts_thermal.c | 65 ++++++++++++++++++++-----
+ 1 file changed, 52 insertions(+), 13 deletions(-)
+
+--- a/drivers/thermal/mediatek/lvts_thermal.c
++++ b/drivers/thermal/mediatek/lvts_thermal.c
+@@ -92,17 +92,6 @@
+ 
+ #define LVTS_MINIMUM_THRESHOLD		20000
+ 
+-static const u32 default_conn_cmds[] = { 0xC103FFFF, 0xC502FF55 };
+-/*
+- * Write device mask: 0xC1030000
+- */
+-static const u32 default_init_cmds[] = {
+-	0xC1030E01, 0xC1030CFC, 0xC1030A8C, 0xC103098D, 0xC10308F1,
+-	0xC10307A6, 0xC10306B8, 0xC1030500, 0xC1030420, 0xC1030300,
+-	0xC1030030, 0xC10300F6, 0xC1030050, 0xC1030060, 0xC10300AC,
+-	0xC10300FC, 0xC103009D, 0xC10300F1, 0xC10300E1
+-};
+-
+ static int golden_temp = LVTS_GOLDEN_TEMP_DEFAULT;
+ static int golden_temp_offset;
+ 
+@@ -132,7 +121,11 @@ struct lvts_ctrl_data {
+ 
+ struct lvts_data {
+ 	const struct lvts_ctrl_data *lvts_ctrl;
++	const u32 *conn_cmd;
++	const u32 *init_cmd;
+ 	int num_lvts_ctrl;
++	int num_conn_cmd;
++	int num_init_cmd;
+ 	int temp_factor;
+ 	int temp_offset;
+ 	int gt_calib_bit_offset;
+@@ -974,9 +967,10 @@ static int lvts_ctrl_set_enable(struct l
+ 
+ static int lvts_ctrl_connect(struct device *dev, struct lvts_ctrl *lvts_ctrl)
+ {
++	const struct lvts_data *lvts_data = lvts_ctrl->lvts_data;
+ 	u32 id;
+ 
+-	lvts_write_config(lvts_ctrl, default_conn_cmds, ARRAY_SIZE(default_conn_cmds));
++	lvts_write_config(lvts_ctrl, lvts_data->conn_cmd, lvts_data->num_conn_cmd);
+ 
+ 	/*
+ 	 * LVTS_ID : Get ID and status of the thermal controller
+@@ -995,7 +989,9 @@ static int lvts_ctrl_connect(struct devi
+ 
+ static int lvts_ctrl_initialize(struct device *dev, struct lvts_ctrl *lvts_ctrl)
+ {
+-	lvts_write_config(lvts_ctrl, default_init_cmds, ARRAY_SIZE(default_init_cmds));
++	const struct lvts_data *lvts_data = lvts_ctrl->lvts_data;
++
++	lvts_write_config(lvts_ctrl, lvts_data->init_cmd, lvts_data->num_init_cmd);
+ 
+ 	return 0;
+ }
+@@ -1424,6 +1420,17 @@ static int lvts_resume(struct device *de
+ 	return 0;
+ }
+ 
++static const u32 default_conn_cmds[] = { 0xC103FFFF, 0xC502FF55 };
++/*
++ * Write device mask: 0xC1030000
++ */
++static const u32 default_init_cmds[] = {
++	0xC1030E01, 0xC1030CFC, 0xC1030A8C, 0xC103098D, 0xC10308F1,
++	0xC10307A6, 0xC10306B8, 0xC1030500, 0xC1030420, 0xC1030300,
++	0xC1030030, 0xC10300F6, 0xC1030050, 0xC1030060, 0xC10300AC,
++	0xC10300FC, 0xC103009D, 0xC10300F1, 0xC10300E1
++};
++
+ /*
+  * The MT8186 calibration data is stored as packed 3-byte little-endian
+  * values using a weird layout that makes sense only when viewed as a 32-bit
+@@ -1718,7 +1725,11 @@ static const struct lvts_ctrl_data mt819
+ 
+ static const struct lvts_data mt7988_lvts_ap_data = {
+ 	.lvts_ctrl	= mt7988_lvts_ap_data_ctrl,
++	.conn_cmd	= default_conn_cmds,
++	.init_cmd	= default_init_cmds,
+ 	.num_lvts_ctrl	= ARRAY_SIZE(mt7988_lvts_ap_data_ctrl),
++	.num_conn_cmd	= ARRAY_SIZE(default_conn_cmds),
++	.num_init_cmd	= ARRAY_SIZE(default_init_cmds),
+ 	.temp_factor	= LVTS_COEFF_A_MT7988,
+ 	.temp_offset	= LVTS_COEFF_B_MT7988,
+ 	.gt_calib_bit_offset = 24,
+@@ -1726,7 +1737,11 @@ static const struct lvts_data mt7988_lvt
+ 
+ static const struct lvts_data mt8186_lvts_data = {
+ 	.lvts_ctrl	= mt8186_lvts_data_ctrl,
++	.conn_cmd	= default_conn_cmds,
++	.init_cmd	= default_init_cmds,
+ 	.num_lvts_ctrl	= ARRAY_SIZE(mt8186_lvts_data_ctrl),
++	.num_conn_cmd	= ARRAY_SIZE(default_conn_cmds),
++	.num_init_cmd	= ARRAY_SIZE(default_init_cmds),
+ 	.temp_factor	= LVTS_COEFF_A_MT7988,
+ 	.temp_offset	= LVTS_COEFF_B_MT7988,
+ 	.gt_calib_bit_offset = 24,
+@@ -1735,7 +1750,11 @@ static const struct lvts_data mt8186_lvt
+ 
+ static const struct lvts_data mt8188_lvts_mcu_data = {
+ 	.lvts_ctrl	= mt8188_lvts_mcu_data_ctrl,
++	.conn_cmd	= default_conn_cmds,
++	.init_cmd	= default_init_cmds,
+ 	.num_lvts_ctrl	= ARRAY_SIZE(mt8188_lvts_mcu_data_ctrl),
++	.num_conn_cmd	= ARRAY_SIZE(default_conn_cmds),
++	.num_init_cmd	= ARRAY_SIZE(default_init_cmds),
+ 	.temp_factor	= LVTS_COEFF_A_MT8195,
+ 	.temp_offset	= LVTS_COEFF_B_MT8195,
+ 	.gt_calib_bit_offset = 20,
+@@ -1744,7 +1763,11 @@ static const struct lvts_data mt8188_lvt
+ 
+ static const struct lvts_data mt8188_lvts_ap_data = {
+ 	.lvts_ctrl	= mt8188_lvts_ap_data_ctrl,
++	.conn_cmd	= default_conn_cmds,
++	.init_cmd	= default_init_cmds,
+ 	.num_lvts_ctrl	= ARRAY_SIZE(mt8188_lvts_ap_data_ctrl),
++	.num_conn_cmd	= ARRAY_SIZE(default_conn_cmds),
++	.num_init_cmd	= ARRAY_SIZE(default_init_cmds),
+ 	.temp_factor	= LVTS_COEFF_A_MT8195,
+ 	.temp_offset	= LVTS_COEFF_B_MT8195,
+ 	.gt_calib_bit_offset = 20,
+@@ -1753,7 +1776,11 @@ static const struct lvts_data mt8188_lvt
+ 
+ static const struct lvts_data mt8192_lvts_mcu_data = {
+ 	.lvts_ctrl	= mt8192_lvts_mcu_data_ctrl,
++	.conn_cmd	= default_conn_cmds,
++	.init_cmd	= default_init_cmds,
+ 	.num_lvts_ctrl	= ARRAY_SIZE(mt8192_lvts_mcu_data_ctrl),
++	.num_conn_cmd	= ARRAY_SIZE(default_conn_cmds),
++	.num_init_cmd	= ARRAY_SIZE(default_init_cmds),
+ 	.temp_factor	= LVTS_COEFF_A_MT8195,
+ 	.temp_offset	= LVTS_COEFF_B_MT8195,
+ 	.gt_calib_bit_offset = 24,
+@@ -1762,7 +1789,11 @@ static const struct lvts_data mt8192_lvt
+ 
+ static const struct lvts_data mt8192_lvts_ap_data = {
+ 	.lvts_ctrl	= mt8192_lvts_ap_data_ctrl,
++	.conn_cmd	= default_conn_cmds,
++	.init_cmd	= default_init_cmds,
+ 	.num_lvts_ctrl	= ARRAY_SIZE(mt8192_lvts_ap_data_ctrl),
++	.num_conn_cmd	= ARRAY_SIZE(default_conn_cmds),
++	.num_init_cmd	= ARRAY_SIZE(default_init_cmds),
+ 	.temp_factor	= LVTS_COEFF_A_MT8195,
+ 	.temp_offset	= LVTS_COEFF_B_MT8195,
+ 	.gt_calib_bit_offset = 24,
+@@ -1771,7 +1802,11 @@ static const struct lvts_data mt8192_lvt
+ 
+ static const struct lvts_data mt8195_lvts_mcu_data = {
+ 	.lvts_ctrl	= mt8195_lvts_mcu_data_ctrl,
++	.conn_cmd	= default_conn_cmds,
++	.init_cmd	= default_init_cmds,
+ 	.num_lvts_ctrl	= ARRAY_SIZE(mt8195_lvts_mcu_data_ctrl),
++	.num_conn_cmd	= ARRAY_SIZE(default_conn_cmds),
++	.num_init_cmd	= ARRAY_SIZE(default_init_cmds),
+ 	.temp_factor	= LVTS_COEFF_A_MT8195,
+ 	.temp_offset	= LVTS_COEFF_B_MT8195,
+ 	.gt_calib_bit_offset = 24,
+@@ -1780,7 +1815,11 @@ static const struct lvts_data mt8195_lvt
+ 
+ static const struct lvts_data mt8195_lvts_ap_data = {
+ 	.lvts_ctrl	= mt8195_lvts_ap_data_ctrl,
++	.conn_cmd	= default_conn_cmds,
++	.init_cmd	= default_init_cmds,
+ 	.num_lvts_ctrl	= ARRAY_SIZE(mt8195_lvts_ap_data_ctrl),
++	.num_conn_cmd	= ARRAY_SIZE(default_conn_cmds),
++	.num_init_cmd	= ARRAY_SIZE(default_init_cmds),
+ 	.temp_factor	= LVTS_COEFF_A_MT8195,
+ 	.temp_offset	= LVTS_COEFF_B_MT8195,
+ 	.gt_calib_bit_offset = 24,

--- a/target/linux/mediatek/patches-6.12/053-v6.17-thermal-drivers-mediatek-lvts_thermal-Add-mt7988-lvt.patch
+++ b/target/linux/mediatek/patches-6.12/053-v6.17-thermal-drivers-mediatek-lvts_thermal-Add-mt7988-lvt.patch
@@ -1,0 +1,57 @@
+From 744e2e82b28cb28f8cd2cc4ee788a5c950b12aa2 Mon Sep 17 00:00:00 2001
+From: Mason Chang <mason-cw.chang@mediatek.com>
+Date: Mon, 26 May 2025 18:26:59 +0800
+Subject: [PATCH 3/3] thermal/drivers/mediatek/lvts_thermal: Add mt7988 lvts
+ commands
+
+These commands are necessary to avoid severely abnormal and inaccurate
+temperature readings that are caused by using the default commands.
+
+Signed-off-by: Mason Chang <mason-cw.chang@mediatek.com>
+Link: https://lore.kernel.org/r/20250526102659.30225-4-mason-cw.chang@mediatek.com
+Signed-off-by: Daniel Lezcano <daniel.lezcano@linaro.org>
+(cherry picked from commit 685a755089f95b7e205c0202567d9a647f9de096)
+---
+ drivers/thermal/mediatek/lvts_thermal.c | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+--- a/drivers/thermal/mediatek/lvts_thermal.c
++++ b/drivers/thermal/mediatek/lvts_thermal.c
+@@ -1421,6 +1421,8 @@ static int lvts_resume(struct device *de
+ }
+ 
+ static const u32 default_conn_cmds[] = { 0xC103FFFF, 0xC502FF55 };
++static const u32 mt7988_conn_cmds[] = { 0xC103FFFF, 0xC502FC55 };
++
+ /*
+  * Write device mask: 0xC1030000
+  */
+@@ -1431,6 +1433,12 @@ static const u32 default_init_cmds[] = {
+ 	0xC10300FC, 0xC103009D, 0xC10300F1, 0xC10300E1
+ };
+ 
++static const u32 mt7988_init_cmds[] = {
++	0xC1030300, 0xC1030420, 0xC1030500, 0xC10307A6, 0xC1030CFC,
++	0xC1030A8C, 0xC103098D, 0xC10308F1, 0xC1030B04, 0xC1030E01,
++	0xC10306B8
++};
++
+ /*
+  * The MT8186 calibration data is stored as packed 3-byte little-endian
+  * values using a weird layout that makes sense only when viewed as a 32-bit
+@@ -1725,11 +1733,11 @@ static const struct lvts_ctrl_data mt819
+ 
+ static const struct lvts_data mt7988_lvts_ap_data = {
+ 	.lvts_ctrl	= mt7988_lvts_ap_data_ctrl,
+-	.conn_cmd	= default_conn_cmds,
+-	.init_cmd	= default_init_cmds,
++	.conn_cmd	= mt7988_conn_cmds,
++	.init_cmd	= mt7988_init_cmds,
+ 	.num_lvts_ctrl	= ARRAY_SIZE(mt7988_lvts_ap_data_ctrl),
+-	.num_conn_cmd	= ARRAY_SIZE(default_conn_cmds),
+-	.num_init_cmd	= ARRAY_SIZE(default_init_cmds),
++	.num_conn_cmd	= ARRAY_SIZE(mt7988_conn_cmds),
++	.num_init_cmd	= ARRAY_SIZE(mt7988_init_cmds),
+ 	.temp_factor	= LVTS_COEFF_A_MT7988,
+ 	.temp_offset	= LVTS_COEFF_B_MT7988,
+ 	.gt_calib_bit_offset = 24,


### PR DESCRIPTION
Import upstream patches fixing issues with unreliable temperature reading on some batches of the MediaTek MT7988 SoCs.