### PR TITLE
[openwrt-24.10] rockchip: fix eMMC corruption on NanoPC-T6 with A3A444 chips

### DIFF
--- a/target/linux/rockchip/patches-6.6/121-arm64-dts-rockchip-lower-mmc-speed-for-nanopc-t6.patch
+++ b/target/linux/rockchip/patches-6.6/121-arm64-dts-rockchip-lower-mmc-speed-for-nanopc-t6.patch
@@ -1,6 +1,16 @@
 --- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dtsi
-@@ -634,7 +634,7 @@
+@@ -621,8 +621,7 @@
+ 	no-sd;
+ 	non-removable;
+ 	max-frequency = <200000000>;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
++	mmc-hs200-1_8v;
+ 	status = "okay";
+ };
+ 
+@@ -634,7 +633,7 @@
  	disable-wp;
  	no-mmc;
  	no-sdio;


### PR DESCRIPTION
Some NanoPC-T6 boards with A3A444 eMMC chips experience I/O errors and corruption when using HS400 mode.
Downgrade to HS200 mode to ensure stable operation.