### PR TITLE
mac80211: fix Intel BE200 probe

### DIFF
--- a/package/firmware/linux-firmware/intel.mk
+++ b/package/firmware/linux-firmware/intel.mk
@@ -219,7 +219,7 @@ $(eval $(call BuildPackage,iwlwifi-firmware-ax411))
 Package/iwlwifi-firmware-be200 = $(call Package/firmware-default,Intel BE200 firmware)
 define Package/iwlwifi-firmware-be200/install
 	$(INSTALL_DIR) $(1)/lib/firmware
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-gl-c0-fm-c0-92.ucode $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-gl-c0-fm-c0-98.ucode $(1)/lib/firmware
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/iwlwifi-gl-c0-fm-c0.pnvm $(1)/lib/firmware
 endef
 $(eval $(call BuildPackage,iwlwifi-firmware-be200))

--- a/package/kernel/mac80211/intel.mk
+++ b/package/kernel/mac80211/intel.mk
@@ -1,6 +1,6 @@
 PKG_DRIVERS += iwlwifi
 
-config-$(call config_package,iwlwifi) += IWLWIFI IWLDVM IWLMVM
+config-$(call config_package,iwlwifi) += IWLWIFI IWLDVM IWLMVM IWLMLD
 config-$(CONFIG_PACKAGE_IWLWIFI_DEBUG)+= IWLWIFI_DEBUG
 config-$(CONFIG_PACKAGE_IWLWIFI_DEBUGFS)+= IWLWIFI_DEBUGFS
 
@@ -11,8 +11,9 @@ define KernelPackage/iwlwifi
   FILES:= \
 	$(PKG_BUILD_DIR)/drivers/net/wireless/intel/iwlwifi/iwlwifi.ko \
 	$(PKG_BUILD_DIR)/drivers/net/wireless/intel/iwlwifi/dvm/iwldvm.ko \
-	$(PKG_BUILD_DIR)/drivers/net/wireless/intel/iwlwifi/mvm/iwlmvm.ko
-  AUTOLOAD:=$(call AutoProbe,iwlwifi iwldvm iwlmvm)
+	$(PKG_BUILD_DIR)/drivers/net/wireless/intel/iwlwifi/mvm/iwlmvm.ko \
+	$(PKG_BUILD_DIR)/drivers/net/wireless/intel/iwlwifi/mld/iwlmld.ko
+  AUTOLOAD:=$(call AutoProbe,iwlwifi iwldvm iwlmvm iwlmld)
   MENU:=1
 endef
 


### PR DESCRIPTION
Latest backports using iwlmld.ko for BE200. Fix it and allow probe. Latest backports also require newer firmware.