### PR TITLE
[24.10] mediatek: add factory image for ipTIME AX3000SM

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1055,8 +1055,16 @@ define Device/iptime_ax3000sm
   DEVICE_MODEL := AX3000SM
   DEVICE_DTS := mt7981b-iptime-ax3000sm
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 32768k
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3ksm
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
   SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
 endef
 TARGET_DEVICES += iptime_ax3000sm


### PR DESCRIPTION
Adds the capability to flash the factory image using the OEM recovery software, ipTIME Firmware Wizard(11ac).

Installation
------------
1. Download the OEM recovery software from the manufacturer's website
2. Download the *squashfs-factory.bin file from the OpenWrt website
3. Press a reset button, and power up the router(keep pressing the reset button)
4. Wait more than 10 seconds until the CPU LED stop blinking
5. Connect the router(LAN port) to the PC
6. Run the OEM recovery software and follow the instructions
7. Select the *squashfs-factory.bin file during the router recovery process
8. Wait for the router to boot from *squashfs-factory.bin

Screenshot
------------
<details><summary>OpenWrt Luci Web Interface</summary>
<p>

<img width="903" height="956" alt="iptime-ax3000sm-factory-24 10" src="https://github.com/user-attachments/assets/ecb1992a-9327-461c-818c-ea017ad7f5d0" />

</p>
</details> 

Logs
------------
<details><summary>squashfs-factory.bin upgrade log</summary>
<p>

```
F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 024F [010F]
Jump to BL

NOTICE:  BL2: v2.7(release):0697eafa43-dirty
NOTICE:  BL2: Built : 17:33:02, Jan 26 2024
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a083f1 000003ff 00100000 00000000
1001d040 | 00000000 00000000 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0x8 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 560, worse bit 0, min window 68
Window Sum 560, worse bit 8, min window 68
Window Sum 398, worse bit 3, min window 46
Window Sum 390, worse bit 9, min window 46
Window Sum 410, worse bit 1, min window 50
Window Sum 404, worse bit 9, min window 48
Window Sum 422, worse bit 0, min window 52
Window Sum 418, worse bit 9, min window 50
Window Sum 438, worse bit 3, min window 52
Window Sum 428, worse bit 9, min window 52
Window Sum 448, worse bit 3, min window 54
Window Sum 442, worse bit 14, min window 52
Window Sum 460, worse bit 3, min window 54
Window Sum 446, worse bit 8, min window 54
Window Sum 472, worse bit 1, min window 58
Window Sum 456, worse bit 8, min window 54
Window Sum 476, worse bit 1, min window 58
Window Sum 458, worse bit 9, min window 54
Window Sum 482, worse bit 7, min window 58
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc8
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 1 found in block 960
NOTICE:  Second info table with writecount 1 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):0697eafa43-dirty
NOTICE:  BL31: Built : 17:33:04, Jan 26 2024
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Jan 26 2024 - 17:32:30 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: GigaDevice SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 1 found in block 960
Second info table with writecount 1 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[?25h[2J[1;1HWait for a few seconds(3s<:RST,10s<:FIRMUP)...........
Using ethernet@15100000 device
Listening for TFTP transfer on 192.168.0.1
Load address: 0x46000000
Loading: *T T T T T T T T T T 
Retry count exceeded; starting again
Using ethernet@15100000 device
Listening for TFTP transfer on 192.168.0.1
Load address: 0x46000000
Loading: *T T ###T ##############################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 #################################################################
	 ############
	 85.9 KiB/s
done
Bytes transferred = 9042820 (89fb84 hex)
Check My Firmware ... [OK]
Saving Environment to MTD... Erasing on MTD device 'nmbm0'... OK
Writing to MTD device 'nmbm0'... OK
OK
ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 110 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 5, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 6/3, WL threshold: 4096, image sequence number: 0
ubi0: available PEBs: 438, total reserved PEBs: 442, PEBs reserved for bad PEB handling: 19
Updating volume 'kernel' from 0x46000838, size 0x41fde0 ... OK
Updating volume 'rootfs' from 0x46420838, size 0x47c800 ... OK
ubi0: detaching mtd6
ubi0: mtd6 is detached
resetting ...

F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 024F [010F]
Jump to BL

NOTICE:  BL2: v2.7(release):0697eafa43-dirty
NOTICE:  BL2: Built : 17:33:02, Jan 26 2024
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a003f1 000000ff 00100000 00000000
1001d040 | 00027e71 000200a0 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0xc 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 568, worse bit 2, min window 68
Window Sum 572, worse bit 8, min window 68
Window Sum 398, worse bit 3, min window 46
Window Sum 392, worse bit 9, min window 46
Window Sum 414, worse bit 1, min window 50
Window Sum 402, worse bit 9, min window 48
Window Sum 422, worse bit 1, min window 52
Window Sum 414, worse bit 9, min window 50
Window Sum 436, worse bit 3, min window 52
Window Sum 424, worse bit 9, min window 50
Window Sum 448, worse bit 1, min window 54
Window Sum 438, worse bit 14, min window 52
Window Sum 460, worse bit 3, min window 54
Window Sum 444, worse bit 8, min window 54
Window Sum 470, worse bit 1, min window 58
Window Sum 456, worse bit 14, min window 54
Window Sum 476, worse bit 3, min window 58
Window Sum 458, worse bit 8, min window 56
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc8
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 1 found in block 960
NOTICE:  Second info table with writecount 1 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):0697eafa43-dirty
NOTICE:  BL31: Built : 17:33:04, Jan 26 2024
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Jan 26 2024 - 17:32:30 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: GigaDevice SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 1 found in block 960
Second info table with writecount 1 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[?25h[2J[1;1HCheck RST button - wait 1 second

ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 110 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 5, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 6/3, WL threshold: 4096, image sequence number: 0
ubi0: available PEBs: 442, total reserved PEBs: 438, PEBs reserved for bad PEB handling: 19
Saving Environment to MTD... Erasing on MTD device 'nmbm0'... OK
Writing to MTD device 'nmbm0'... OK
OK
Reading from volume 'kernel' to 0x46000000, size 0x0 ... OK
## Loading kernel from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.6.102
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x460000e8
     Data Size:    4299979 Bytes = 4.1 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x48000000
     Entry Point:  0x48000000
     Hash algo:    crc32
     Hash value:   5a5adccb
     Hash algo:    sha1
     Hash value:   f4c80dbca60f9d51f25eecb73c85781163c0551b
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt iptime_ax3000sm device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x46419ef4
     Data Size:    22950 Bytes = 22.4 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   dfc332ed
     Hash algo:    sha1
     Hash value:   bf7fc01f19dafa2240d223de48ff6902d0158672
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x46419ef4
   Uncompressing Kernel Image
   Loading Device Tree to 000000004f7f0000, end 000000004f7f89a5 ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.6.102 (nyanko@DevBox) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 13.3.0 r0+28832-444abb7481) 13.3.0, GNU ld (GNU Binutils) 2.42) #0 SMP Mon Sep  1 18:28:38 2025
[    0.000000] Machine model: ipTIME AX3000SM
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004302ffff (192 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x0000000047c80000..0x0000000047d7ffff (1024 KiB) nomap non-reusable wmcpu-reserved@47c80000
[    0.000000] OF: reserved mem: 0x0000000047d80000..0x0000000047dbffff (256 KiB) nomap non-reusable wo-emi@47d80000
[    0.000000] OF: reserved mem: 0x0000000047dc0000..0x0000000047ffffff (2304 KiB) nomap non-reusable wo-data@47dc0000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004302ffff]
[    0.000000]   node   0: [mem 0x0000000043030000-0x0000000047c7ffff]
[    0.000000]   node   0: [mem 0x0000000047c80000-0x0000000047ffffff]
[    0.000000]   node   0: [mem 0x0000000048000000-0x000000004fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 18 pages/cpu s35112 r8192 d30424 u73728
[    0.000000] pcpu-alloc: s35112 r8192 d30424 u73728 alloc=18*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: console=ttyS0,115200 boot_from=A
[    0.000000] Unknown kernel command line parameters "boot_from=A", will be passed to user space.
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 64512
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[    0.000000] software IO TLB: area num 2.
[    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 0MB
[    0.000000] software IO TLB: mapped [mem 0x000000004fe47000-0x000000004fec7000] (0MB)
[    0.000000] Memory: 239180K/262144K available (8832K kernel code, 994K rwdata, 2568K rodata, 448K init, 289K bss, 22964K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000069] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000078] pid_max: default: 32768 minimum: 301
[    0.002971] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.002978] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.005109] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.005641] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.005790] rcu: Hierarchical SRCU implementation.
[    0.005793] rcu: 	Max phase no-delay instances is 1000.
[    0.006189] smp: Bringing up secondary CPUs ...
[    0.006552] Detected VIPT I-cache on CPU1
[    0.006595] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.006623] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.006690] smp: Brought up 1 node, 2 CPUs
[    0.006695] SMP: Total of 2 processors activated.
[    0.006698] CPU features: detected: 32-bit EL0 Support
[    0.006701] CPU features: detected: CRC32 instructions
[    0.006732] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.006736] CPU: All CPU(s) started at EL2
[    0.006738] alternatives: applying system-wide alternatives
[    0.010261] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.010278] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.011544] pinctrl core: initialized pinctrl subsystem
[    0.012693] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.013035] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.013062] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.013084] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.013469] thermal_sys: Registered thermal governor 'fair_share'
[    0.013473] thermal_sys: Registered thermal governor 'bang_bang'
[    0.013476] thermal_sys: Registered thermal governor 'step_wise'
[    0.013478] thermal_sys: Registered thermal governor 'user_space'
[    0.013546] ASID allocator initialised with 65536 entries
[    0.014257] pstore: Using crash dump compression: deflate
[    0.014263] pstore: Registered ramoops as persistent store backend
[    0.014265] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.015688] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.021051] Modules: 29440 pages in range for non-PLT usage
[    0.021059] Modules: 520960 pages in range for PLT usage
[    0.022012] cryptd: max_cpu_qlen set to 1000
[    0.024099] SCSI subsystem initialized
[    0.024288] libata version 3.00 loaded.
[    0.025900] clocksource: Switched to clocksource arch_sys_counter
[    0.028243] NET: Registered PF_INET protocol family
[    0.028349] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.029399] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.029413] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.029421] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.029440] TCP bind hash table entries: 2048 (order: 4, 65536 bytes, linear)
[    0.029489] TCP: Hash tables configured (established 2048 bind 2048)
[    0.029804] MPTCP token hash table entries: 256 (order: 0, 6144 bytes, linear)
[    0.029909] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.029925] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.030204] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.030231] PCI: CLS 0 bytes, default 64
[    0.031326] workingset: timestamp_bits=46 max_order=16 bucket_order=0
[    0.036195] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.036204] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.103155] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.104376] printk: console [ttyS0] disabled
[    0.124748] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 72, base_baud = 2500000) is a ST16650V2
[    0.124788] printk: console [ttyS0] enabled
[    0.890395] loop: module loaded
[    0.896526] spi-nand spi0.0: calibration result: 0x3
[    0.901577] spi-nand spi0.0: ESMT SPI NAND was found.
[    0.906631] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.915334] Signature found at block 1023 [0x07fe0000]
[    0.920487] NMBM management region starts at block 960 [0x07800000]
[    0.928659] First info table with writecount 1 found in block 960
[    0.940386] Second info table with writecount 1 found in block 963
[    0.946579] NMBM has been successfully attached
[    0.951394] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.957760] Creating 5 MTD partitions on "spi0.0":
[    0.962541] 0x000000000000-0x000000100000 : "BL2"
[    0.968455] 0x000000100000-0x000000180000 : "u-boot-env"
[    0.974527] 0x000000180000-0x000000380000 : "Factory"
[    0.981518] 0x000000380000-0x000000580000 : "FIP"
[    0.987827] 0x000000580000-0x000007380000 : "ubi"
[    1.194018] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081580000, irq 75
[    1.203897] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc081580000, irq 75
[    1.213606] i2c_dev: i2c /dev entries driver
[    1.219668] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.228799] NET: Registered PF_INET6 protocol family
[    1.234827] Segment Routing with IPv6
[    1.238539] In-situ OAM (IOAM) with IPv6
[    1.242507] NET: Registered PF_PACKET protocol family
[    1.248034] 8021q: 802.1Q VLAN Support v1.8
[    1.346393] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.355373] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.366117] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=79)
[    1.388334] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=80)
[    1.410330] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=81)
[    1.432343] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=82)
[    1.443892] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.450667] DSA: tree 0 setup
[    1.454486] UBI: auto-attach mtd4
[    1.457845] ubi0: default fastmap pool size: 40
[    1.462366] ubi0: default fastmap WL pool size: 20
[    1.467161] ubi0: attaching mtd4
[    2.264796] ubi0: scanning is finished
[    2.279969] ubi0: attached mtd4 (name "ubi", size 110 MiB)
[    2.285460] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    2.292340] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.299125] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.306077] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    2.312070] ubi0: user volume: 5, internal volumes: 1, max. volumes count: 128
[    2.319281] ubi0: max/mean erase counter: 6/3, WL threshold: 4096, image sequence number: 0
[    2.327624] ubi0: available PEBs: 440, total reserved PEBs: 440, PEBs reserved for bad PEB handling: 19
[    2.337013] ubi0: background thread "ubi_bgt0d" started, PID 545
[    2.337947] block ubiblock0_1: created from ubi0:1(rootfs)
[    2.348499] ubiblock: device ubiblock0_1 (rootfs) set to be root filesystem
[    2.355553] clk: Disabling unused clocks
[    2.368039] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[    2.375351] Freeing unused kernel memory: 448K
[    2.379895] Run /sbin/init as init process
[    2.383979]   with arguments:
[    2.386948]     /sbin/init
[    2.389643]   with environment:
[    2.392771]     HOME=/
[    2.395119]     TERM=linux
[    2.397848]     boot_from=A
[    2.666588] init: Console is alive
[    2.670105] init: - watchdog -
[    3.121059] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.152776] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    3.162664] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.177647] init: - preinit -
[    3.385926] random: crng init done
[    3.586553] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    3.595002] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    3.625548] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    7.803541] UBIFS (ubi0:2): Mounting in unauthenticated mode
[    7.809308] UBIFS (ubi0:2): background thread "ubifs_bgt0_2" started, PID 686
[    7.864942] UBIFS (ubi0:2): recovery needed
[    8.024074] UBIFS (ubi0:2): recovery completed
[    8.028596] UBIFS (ubi0:2): UBIFS: mounted UBI device 0, volume 2, name "rootfs_data"
[    8.036424] UBIFS (ubi0:2): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[    8.046327] UBIFS (ubi0:2): FS size: 32378880 bytes (30 MiB, 255 LEBs), max 265 LEBs, journal size 1650688 bytes (1 MiB, 13 LEBs)
[    8.057967] UBIFS (ubi0:2): reserved for root: 1529334 bytes (1493 KiB)
[    8.064567] UBIFS (ubi0:2): media format: w5/r0 (latest is w5/r0), UUID 7E7D48CF-4037-4B4D-8E14-CF871DA99AAB, small LPT model
[    8.081375] mount_root: switching to ubifs overlay
[    8.094487] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[    8.112192] urandom-seed: Seeding with /etc/urandom.seed
[    8.177318] procd: - early -
[    8.180260] procd: - watchdog -
[    8.728970] procd: - watchdog -
[    8.797775] procd: - ubus -
[    8.874144] procd: - init -
Please press Enter to activate this console.
[    9.292236] kmodloader: loading kernel modules from /etc/modules.d/*
[    9.335740] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    9.352944] Loading modules backported from Linux version v6.12.6-0-ge9d65b48ce1a
[    9.360460] Backport generated by backports.git v6.1.110-1-35-g410656ef04d2
[    9.478529] urngd: v1.0.2 started.
[    9.699528] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[    9.699528] 
[    9.959304] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[   10.073408] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[   10.171708] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[   10.278100] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[   10.387372] PPP generic driver version 2.4.2
[   10.389094] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   10.401005] NET: Registered PF_PPPOX protocol family
[   10.409887] kmodloader: done loading kernel modules from /etc/modules.d/*
[   10.733949] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   14.256852] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   14.273051] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   14.282629] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   14.298727] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   14.310713] br-lan: port 1(lan1) entered blocking state
[   14.316044] br-lan: port 1(lan1) entered disabled state
[   14.321341] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   14.327673] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   14.337985] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   14.359864] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   14.367875] br-lan: port 2(lan2) entered blocking state
[   14.373106] br-lan: port 2(lan2) entered disabled state
[   14.378402] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   14.388956] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   14.406755] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   14.428818] br-lan: port 3(lan3) entered blocking state
[   14.434053] br-lan: port 3(lan3) entered disabled state
[   14.439359] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   14.449292] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   14.465699] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   14.473970] br-lan: port 4(lan4) entered blocking state
[   14.479259] br-lan: port 4(lan4) entered disabled state
[   14.484512] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   14.492991] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[   14.529021] mtk_soc_eth 15100000.ethernet eth1: PHY [mdio-bus:00] driver [MediaTek MT7981 PHY] (irq=POLL)
[   14.538640] mtk_soc_eth 15100000.ethernet eth1: configuring for phy/gmii link mode
[   17.996201] mt7530-mdio mdio-bus:1f lan3: Link is Up - 1Gbps/Full - flow control rx/tx
[   17.996229] br-lan: port 3(lan3) entered blocking state
[   18.009338] br-lan: port 3(lan3) entered forwarding state



BusyBox v1.36.1 (2025-09-01 18:28:38 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt 24.10-SNAPSHOT, r0+28832-444abb7481
 -----------------------------------------------------
=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------
root@OpenWrt:~# 
```

</p>
</details> 

Related links
--------
- Snapshot PR (main branch): https://github.com/openwrt/openwrt/pull/19497
- Cherry picked from commit 0e4a69e340083f78ef1e6ec148042d8cde415b78


