### PR TITLE
kernel: Fix kernel regression in local-broadcast routes

### DIFF
--- a/target/linux/generic/backport-6.12/626-v6.17-net-ipv4-fix-regression-in-local-broadcast-routes.patch
+++ b/target/linux/generic/backport-6.12/626-v6.17-net-ipv4-fix-regression-in-local-broadcast-routes.patch
@@ -1,0 +1,47 @@
+From 5189446ba995556eaa3755a6e875bc06675b88bd Mon Sep 17 00:00:00 2001
+From: Oscar Maes <oscmaes92@gmail.com>
+Date: Wed, 27 Aug 2025 08:23:21 +0200
+Subject: [PATCH] net: ipv4: fix regression in local-broadcast routes
+
+Commit 9e30ecf23b1b ("net: ipv4: fix incorrect MTU in broadcast routes")
+introduced a regression where local-broadcast packets would have their
+gateway set in __mkroute_output, which was caused by fi = NULL being
+removed.
+
+Fix this by resetting the fib_info for local-broadcast packets. This
+preserves the intended changes for directed-broadcast packets.
+
+Cc: stable@vger.kernel.org
+Fixes: 9e30ecf23b1b ("net: ipv4: fix incorrect MTU in broadcast routes")
+Reported-by: Brett A C Sheffield <bacs@librecast.net>
+Closes: https://lore.kernel.org/regressions/20250822165231.4353-4-bacs@librecast.net
+Signed-off-by: Oscar Maes <oscmaes92@gmail.com>
+Reviewed-by: David Ahern <dsahern@kernel.org>
+Link: https://patch.msgid.link/20250827062322.4807-1-oscmaes92@gmail.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ net/ipv4/route.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+--- a/net/ipv4/route.c
++++ b/net/ipv4/route.c
+@@ -2532,12 +2532,16 @@ static struct rtable *__mkroute_output(c
+ 		    !netif_is_l3_master(dev_out))
+ 			return ERR_PTR(-EINVAL);
+ 
+-	if (ipv4_is_lbcast(fl4->daddr))
++	if (ipv4_is_lbcast(fl4->daddr)) {
+ 		type = RTN_BROADCAST;
+-	else if (ipv4_is_multicast(fl4->daddr))
++
++		/* reset fi to prevent gateway resolution */
++		fi = NULL;
++	} else if (ipv4_is_multicast(fl4->daddr)) {
+ 		type = RTN_MULTICAST;
+-	else if (ipv4_is_zeronet(fl4->daddr))
++	} else if (ipv4_is_zeronet(fl4->daddr)) {
+ 		return ERR_PTR(-EINVAL);
++	}
+ 
+ 	if (dev_out->flags & IFF_LOOPBACK)
+ 		flags |= RTCF_LOCAL;

--- a/target/linux/generic/backport-6.6/626-v6.17-net-ipv4-fix-regression-in-local-broadcast-routes.patch
+++ b/target/linux/generic/backport-6.6/626-v6.17-net-ipv4-fix-regression-in-local-broadcast-routes.patch
@@ -1,0 +1,47 @@
+From 5189446ba995556eaa3755a6e875bc06675b88bd Mon Sep 17 00:00:00 2001
+From: Oscar Maes <oscmaes92@gmail.com>
+Date: Wed, 27 Aug 2025 08:23:21 +0200
+Subject: [PATCH] net: ipv4: fix regression in local-broadcast routes
+
+Commit 9e30ecf23b1b ("net: ipv4: fix incorrect MTU in broadcast routes")
+introduced a regression where local-broadcast packets would have their
+gateway set in __mkroute_output, which was caused by fi = NULL being
+removed.
+
+Fix this by resetting the fib_info for local-broadcast packets. This
+preserves the intended changes for directed-broadcast packets.
+
+Cc: stable@vger.kernel.org
+Fixes: 9e30ecf23b1b ("net: ipv4: fix incorrect MTU in broadcast routes")
+Reported-by: Brett A C Sheffield <bacs@librecast.net>
+Closes: https://lore.kernel.org/regressions/20250822165231.4353-4-bacs@librecast.net
+Signed-off-by: Oscar Maes <oscmaes92@gmail.com>
+Reviewed-by: David Ahern <dsahern@kernel.org>
+Link: https://patch.msgid.link/20250827062322.4807-1-oscmaes92@gmail.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ net/ipv4/route.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+--- a/net/ipv4/route.c
++++ b/net/ipv4/route.c
+@@ -2547,12 +2547,16 @@ static struct rtable *__mkroute_output(c
+ 		    !netif_is_l3_master(dev_out))
+ 			return ERR_PTR(-EINVAL);
+ 
+-	if (ipv4_is_lbcast(fl4->daddr))
++	if (ipv4_is_lbcast(fl4->daddr)) {
+ 		type = RTN_BROADCAST;
+-	else if (ipv4_is_multicast(fl4->daddr))
++
++		/* reset fi to prevent gateway resolution */
++		fi = NULL;
++	} else if (ipv4_is_multicast(fl4->daddr)) {
+ 		type = RTN_MULTICAST;
+-	else if (ipv4_is_zeronet(fl4->daddr))
++	} else if (ipv4_is_zeronet(fl4->daddr)) {
+ 		return ERR_PTR(-EINVAL);
++	}
+ 
+ 	if (dev_out->flags & IFF_LOOPBACK)
+ 		flags |= RTCF_LOCAL;


### PR DESCRIPTION
Backport a patch from upstream kernel 6.17-rc4 which fixes a regression introduced in the latest stable kernel versions.

This is already in the Linus stable queues for the next minor kernel updates.

Fixes: 1c92e468d544 ("kernel: bump 6.6 to 6.6.103")
Fixes: f39c7e103f9a ("kernel: bump 6.12 to 6.12.43")
Reported-by: Goetz Goerisch <ggoerisch@gmail.com>