### PR TITLE
wifi-scripts: ucode: fix dynamic_vlan value handling

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -293,8 +293,10 @@
 			"type": "boolean"
 		},
 		"dynamic_vlan": {
-			"description": "Allow RADIUS authentication server to decide which VLAN is used for the stations",
-			"type": "boolean"
+			"description": "Allow RADIUS authentication server to decide which VLAN is used for the stations (0 = disabled, 1 = optional, 2 = required)",
+			"type": "number",
+			"enum": [ 0, 1, 2 ],
+			"default": 0
 		},
 		"eap_reauth_period": {
 			"description": "EAP reauthentication period in seconds",

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -131,7 +131,6 @@ function iface_auth_type(config) {
 
 		set_default(config, 'wpa_psk_file', `/var/run/hostapd-${config.ifname}.psk`);
 		touch_file(config.wpa_psk_file);
-		set_default(config, 'dynamic_vlan', 0);
 		break;
 
 	case 'eap':


### PR DESCRIPTION
The `dynamic_vlan` has values `0` (disabled), `1` (optional) and `2` (required).

Compile-tested: TP-Link Archer C7 v4, v5
Run-tested: TP-Link Archer C7 v4, v5