### PR TITLE
realtek: fix compatible for TP-Link TL-ST1008F v2.0

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -56,7 +56,7 @@ tplink,t1600g-28ts-v3)
 	label_mac=$(get_mac_label)
 	lan_mac="$label_mac"
 	;;
-tplink,tl-st1008f,v2)
+tplink,tl-st1008f-v2)
 	lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 	[ -z "$lan_mac" ] || [ "$lan_mac" = "00:e0:4c:00:00:00" ] && lan_mac=$(macaddr_random)
 	;;

--- a/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
+++ b/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
@@ -10,7 +10,7 @@ BOARD_CFG=/etc/board.json
 [ "$(rootfs_type)" = "tmpfs" ] && exit 0
 
 case "$(board_name)" in
-tplink,tl-st1008f,v2)
+tplink,tl-st1008f-v2)
 	env_ethaddr=$(macaddr_canonicalize "$(fw_printenv -n ethaddr 2>/dev/null)")
 
 	# This device ships with a dummy ethaddr because it's an unmanaged switch.

--- a/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f-v2.dts
+++ b/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f-v2.dts
@@ -7,7 +7,7 @@
 #include <dt-bindings/leds/common.h>
 
 / {
-	compatible = "tplink,tl-st1008f,v2", "realtek,rtl930x-soc";
+	compatible = "tplink,tl-st1008f-v2", "realtek,rtl930x-soc";
 	model = "TP-Link TL-ST1008F v2.0";
 
 	memory@0 {

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -40,17 +40,18 @@ define Device/plasmacloud_psx10
 endef
 TARGET_DEVICES += plasmacloud_psx10
 
-define Device/tplink_tl-st1008f_v2
+define Device/tplink_tl-st1008f-v2
   SOC := rtl9303
   UIMAGE_MAGIC := 0x93030000
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := TL-ST1008F
   DEVICE_VARIANT := v2.0
   DEVICE_PACKAGES := kmod-gpio-pca953x
+  SUPPORTED_DEVICES += tplink,tl-st1008f,v2
   IMAGE_SIZE := 31808k
   $(Device/kernel-lzma)
 endef
-TARGET_DEVICES += tplink_tl-st1008f_v2
+TARGET_DEVICES += tplink_tl-st1008f-v2
 
 define Device/vimin_vm-s100-0800ms
   SOC := rtl9303


### PR DESCRIPTION
Fix the compatible in the DTS for TP-Link TL-ST1008F v2.0 by using a dash instead of a comma. To align with all other devices in OpenWrt and match with profiles.json.

'tplink,tl-st1008f,v2' --> 'tplink,tl-st1008f-v2'

Fixes: 39b9b491bb ("realtek: add support for TP-Link TL-ST1008F v2.0")
Fixes: #19930
