### PR TITLE
[24.10] mediatek: filogic: add support for ipTIME AX3000Q

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000q.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000q.dts
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981.dtsi"
+
+/ {
+	model = "ipTIME AX3000Q";
+	compatible = "iptime,ax3000q", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		label-mac-device = &wan;
+
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		button-1 {
+			label = "reset";
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led_cpu: led-3 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 (3)>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x6E00000>;
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		wan: port@0 {
+			reg = <0>;
+			label = "wan";
+			nvmem-cell-names = "mac-address";
+			nvmem-cells = <&macaddr_factory_4 (1)>;
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan4";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan2";
+		};
+
+		port@4 {
+			reg = <4>;
+			label = "lan1";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 (0)>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 (0)>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -64,6 +64,9 @@ glinet,gl-xe3000)
 huasifei,wh3000)
 	ucidef_set_led_netdev "wan" "WAN" "red:wan" "eth1" "link tx rx"
 	;;
+iptime,ax3000q)
+	ucidef_set_led_netdev "wan" "WAN" "amber:wan" "wan" "link tx rx"
+	;;
 iptime,ax3000sm)
 	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -108,6 +108,10 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
+	iptime,ax3000q)
+		addr=$(mtd_get_mac_binary "Factory" 0x4)
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $addr > /sys${DEVPATH}/macaddress
+		;;
 	iptime,ax3000sm)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_setbit $addr 26) 25) 27) 28) > \

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1050,6 +1050,25 @@ define Device/huasifei_wh3000-pro
 endef
 TARGET_DEVICES += huasifei_wh3000-pro
 
+define Device/iptime_ax3000q
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := AX3000Q
+  DEVICE_DTS := mt7981b-iptime-ax3000q
+  DEVICE_DTS_DIR := ../dts
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 32768k
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3000q
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
+endef
+TARGET_DEVICES += iptime_ax3000q
+
 define Device/iptime_ax3000sm
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := AX3000SM


### PR DESCRIPTION
Specification
-------------
- SoC       : MediaTek MT7981BA dual-core ARM Cortex-A53 1.3GHz
- RAM       : DDR3 256Mbytes, ESMT M15T2G16128A
- Flash     : 128Mbytes NAND Flash, ESMT F50L1G41LB
- WLAN      : MediaTek MT7976CN dual-band Wi-Fi 6
  - 2.4GHz  : b/g/n/ax, MU-MIMO
  - 5GHz    : a/n/ac/ax, MU-MIMO
- Ethernet  : MediaTek MT7531AE
  - LAN     : 10/100/1000 Mbps x4
  - WAN     : 10/100/1000 Mbps x1
- UART      : 1x4 pin header on PCB
  - [J6] TX, RX, GND, 3.3V (115200, 8N1)
- Buttons   : WPS, Reset
- LEDs      :  8 LEDs
  - 1x CPU (Amber) 
  - 1x Wi-Fi 5GHz (Amber)
  - 1x Wi-Fi 2.4GHz (Amber)
  - 1x WAN activity (Amber)
  - 4x LAN activity (Amber)
- Power     : 12VDC, 1A (Center positive polarity)

MAC address
-----------

| Interface | MAC               | Algorithm             |
|-|-|-|
| WLAN 2.4G | B0:38:6C:48:xx:xx | label                 |
| WLAN 5G   | B2:38:6C:48:xx:xx | label with LA Bit Set |
| WAN       | B0:38:6C:48:xx:xx | label + 1             |
| LAN       | B0:38:6C:48:xx:xx | label + 3             |

The WLAN 2.4G MAC was found in 'Factory' partition, 0x4

Installation
------------
1. Download the OEM recovery software from the manufacturer's website
2. Download the *squashfs-factory.bin file from the OpenWrt website
3. Press a reset button, and power up the router(keep pressing the reset button)
4. Wait more than 10 seconds until the CPU LED stop blinking
5. Connect the router(LAN port) to the PC
6. Replace a file in the OEM recovery software with the file from step 2
7. Run the OEM recovery software and follow the instructions
8. Wait for the router to boot from *squashfs-factory.bin

Screenshot
----------
<details><summary>OpenWrt Luci Web Interface</summary>
<p>

<img width="905" height="948" alt="ax3000q-openwrt-24 10" src="https://github.com/user-attachments/assets/8cccad86-a09a-44e3-b6b2-9656de716eb2" />

</p>
</details> 

Bootlogs
--------
<details><summary>OEM Bootlog</summary>
<p>

```
F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 024F [010F]
Jump to BL

NOTICE:  BL2: v2.7(release):openwrt_update_for_driver_7672_update-13-g0a805fc63a-dirty
NOTICE:  BL2: Built : 13:59:19, Nov 20 2024
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a083f1 000003ff 00100000 00000000
1001d040 | 00000000 00000000 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0x8 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 512, worse bit 6, min window 60
Window Sum 512, worse bit 10, min window 60
Window Sum 346, worse bit 2, min window 42
Window Sum 330, worse bit 12, min window 40
Window Sum 362, worse bit 3, min window 44
Window Sum 344, worse bit 14, min window 40
Window Sum 372, worse bit 0, min window 46
Window Sum 362, worse bit 9, min window 44
Window Sum 382, worse bit 5, min window 46
Window Sum 368, worse bit 14, min window 44
Window Sum 392, worse bit 2, min window 48
Window Sum 382, worse bit 9, min window 46
Window Sum 402, worse bit 0, min window 50
Window Sum 392, worse bit 14, min window 46
Window Sum 414, worse bit 5, min window 50
Window Sum 404, worse bit 9, min window 50
Window Sum 418, worse bit 0, min window 52
Window Sum 410, worse bit 9, min window 50
Window Sum 420, worse bit 0, min window 52
Window Sum 418, worse bit 14, min window 50
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc8
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 0 found in block 960
NOTICE:  Second info table with writecount 0 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):openwrt_update_for_driver_7672_update-13-g0a805fc63a-dirty
NOTICE:  BL31: Built : 13:59:21, Nov 20 2024
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Nov 20 2024 - 13:58:45 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: GigaDevice SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 0 found in block 960
Second info table with writecount 0 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[?25h[2J[1;1H----------------------------> Turned on LEDS: 9
Check RST button - wait 1 second

ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 110 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 2/0, WL threshold: 4096, image sequence number: 916981975
ubi0: available PEBs: 432, total reserved PEBs: 448, PEBs reserved for bad PEB handling: 19
Reading from volume 'kernel' to 0x46000000, size 0x0 ... OK
## Loading kernel from FIT Image at 46000000 ...
   Using 'config@1' configuration
   Trying 'kernel@1' kernel subimage
     Description:  ARM64 OpenWrt Linux-5.4.246
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x460000e8
     Data Size:    3390262 Bytes = 3.2 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x48080000
     Entry Point:  0x48080000
     Hash algo:    crc32
     Hash value:   8e2b021e
     Hash algo:    sha1
     Hash value:   749a73ca0eb5edf69ccc2a4fbdd40b1ec28da691
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 46000000 ...
   Using 'config@1' configuration
   Trying 'fdt@1' fdt subimage
     Description:  ARM64 OpenWrt image-mt7981-spim-nand-ax3000q device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x4633bd70
     Data Size:    18374 Bytes = 17.9 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   c26e478a
     Hash algo:    sha1
     Hash value:   f41e66b6d7c8bb8989903eaea23fef2b3b8edf91
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x4633bd70
   Uncompressing Kernel Image
   Loading Device Tree to 000000004f7f1000, end 000000004f7f87c5 ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 5.4.246 (yerin@492a46e24817) (gcc version 8.4.0 (OpenWrt GCC 8.4.0 r16639-ce5ee4cb21)) #0 SMP Fri Oct 4 08:24:05 2024
[    0.000000] Machine model: ipTIME AX3000Q
[    0.000000] On node 0 totalpages: 64512
[    0.000000]   DMA32 zone: 1024 pages used for memmap
[    0.000000]   DMA32 zone: 0 pages reserved
[    0.000000]   DMA32 zone: 64512 pages, LIFO batch:15
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.0
[    0.000000] percpu: Embedded 20 pages/cpu s43672 r8192 d30056 u81920
[    0.000000] pcpu-alloc: s43672 r8192 d30056 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 63488
[    0.000000] Kernel command line: console=ttyS0,115200 boot_from=A
[    0.000000] get_boot_firmware_name(66) boot_from=rootfs
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 230152K/258048K available (7038K kernel code, 494K rwdata, 1996K rodata, 448K init, 296K bss, 27896K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	CONFIG_RCU_FANOUT set to non-default value of 32.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] GICv3: Distributor has no Range Selector support
[    0.000000] GICv3: 16 PPIs implemented
[    0.000000] GICv3: no VLPI support, no direct LPI support
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000004] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000136] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=52000)
[    0.000143] pid_max: default: 32768 minimum: 301
[    0.000209] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.000215] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.000917] ASID allocator initialised with 65536 entries
[    0.000972] rcu: Hierarchical SRCU implementation.
[    0.001242] smp: Bringing up secondary CPUs ...
[    0.001513] Detected VIPT I-cache on CPU1
[    0.001532] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.001553] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.001611] smp: Brought up 1 node, 2 CPUs
[    0.001619] SMP: Total of 2 processors activated.
[    0.001623] CPU features: detected: 32-bit EL0 Support
[    0.001628] CPU features: detected: CRC32 instructions
[    0.001728] CPU: All CPU(s) started at EL2
[    0.001737] alternatives: patching kernel code
[    0.002226] devtmpfs: initialized
[    0.004079] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.004094] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.004170] pinctrl core: initialized pinctrl subsystem
[    0.004782] NET: Registered protocol family 16
[    0.005035] DMA: preallocated 256 KiB pool for atomic allocations
[    0.018770] cryptd: max_cpu_qlen set to 1000
[    0.020521] SCSI subsystem initialized
[    0.020701] libata version 3.00 loaded.
[    0.020863] usbcore: registered new interface driver usbfs
[    0.020891] usbcore: registered new interface driver hub
[    0.020922] usbcore: registered new device driver usb
[    0.021763] Bluetooth: Core ver 2.22
[    0.021809] NET: Registered protocol family 31
[    0.021813] Bluetooth: HCI device and connection manager initialized
[    0.021826] Bluetooth: HCI socket layer initialized
[    0.021831] Bluetooth: L2CAP socket layer initialized
[    0.021842] Bluetooth: SCO socket layer initialized
[    0.022080] rbus 18000000.wbsys: PCI host bridge to bus 0000:00
[    0.022093] pci_bus 0000:00: root bus resource [mem 0x18000000-0x18ffffff]
[    0.022100] pci_bus 0000:00: root bus resource [bus 00-ff]
[    0.022105] pci_bus 0000:00: scanning bus
[    0.022121] pci 0000:00:00.0: [14c3:7981] type 00 class 0x000280
[    0.022136] pci 0000:00:00.0: reg 0x10: [mem 0x18000000-0x1800000f 64bit]
[    0.022142] pci 0000:00:00.0: reg 0x18: [mem 0x00000000-0x0000000f]
[    0.022148] pci 0000:00:00.0: reg 0x1c: [mem 0x00000000-0x0000000f]
[    0.022154] pci 0000:00:00.0: reg 0x20: [mem 0x00000000-0x0000000f]
[    0.022160] pci 0000:00:00.0: reg 0x24: [mem 0x00000000-0x0000000f]
[    0.022995] pci_bus 0000:00: fixups for bus
[    0.023002] pci_bus 0000:00: bus scan returning with max=00
[    0.023312] clocksource: Switched to clocksource arch_sys_counter
[    0.024108] thermal_sys: Registered thermal governor 'fair_share'
[    0.024111] thermal_sys: Registered thermal governor 'bang_bang'
[    0.024118] thermal_sys: Registered thermal governor 'step_wise'
[    0.024122] thermal_sys: Registered thermal governor 'user_space'
[    0.024125] thermal_sys: Registered thermal governor 'power_allocator'
[    0.024331] NET: Registered protocol family 2
[    0.024424] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.024755] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.024773] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.024792] TCP bind hash table entries: 2048 (order: 3, 32768 bytes, linear)
[    0.024818] TCP: Hash tables configured (established 2048 bind 2048)
[    0.024877] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.024893] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.024986] NET: Registered protocol family 1
[    0.025014] PCI: CLS 0 bytes, default 64
[    0.026469] workingset: timestamp_bits=62 max_order=16 bucket_order=0
[    0.028768] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.028783] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.042059] phy phy-usb-phy@11e10000.1: type_sw - reg 0x218, index 0
[    0.052453] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.053356] printk: console [ttyS0] disabled
[    0.073486] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 12, base_baud = 2500000) is a ST16650V2
[    0.714517] printk: console [ttyS0] enabled
[    0.719412] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.727962] loop: module loaded
[    0.731216] mediatek,mt2701-ice_debug ice_debug: get dbg_sel clock fail: -2
[    0.738183] mediatek,mt2701-ice_debug: probe of ice_debug failed with error -2
[    0.746226] mt7981-pinctrl 11d00000.pinctrl: pin_config_set op failed for pin 19
[    0.753621] mtk-spi 1100a000.spi: Error applying setting, reverse things back
[    0.761203] spi-nand spi0.0: Failed to calibrate SPI-NAND (err = -22)
[    0.767772] spi-nand spi0.0: GigaDevice SPI NAND was found.
[    0.773358] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.783904] [mtk_hw_init] reset_lock:0, force:0
[    0.788489] [mtk_hw_init] execute fe cold reset
[    0.804028] mtk_soc_eth 15100000.ethernet: MDC is running on 2500000 Hz
[    0.831273] mtk_soc_eth 15100000.ethernet: generated random MAC address ba:c9:62:f7:f4:74
[    0.839751] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc011880000, irq 79
[    0.848837] mtk_soc_eth 15100000.ethernet: generated random MAC address ce:16:6f:81:31:1c
[    0.857263] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc011880000, irq 79
[    0.866307] (unnamed net_device) (dummy): netif_napi_add() called with weight 256
[    0.874043] usbcore: registered new interface driver usblp
[    0.879633] usbcore: registered new interface driver uas
[    0.884981] usbcore: registered new interface driver usb-storage
[    0.891074] i2c /dev entries driver
[    0.895536] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    0.903576] device-mapper: ioctl: 4.41.0-ioctl (2019-09-16) initialised: dm-devel@redhat.com
[    0.912218] Bluetooth: HCI UART driver ver 2.3
[    0.916687] Bluetooth: HCI UART protocol H4 registered
[    0.921817] Bluetooth: HCI UART protocol BCSP registered
[    0.927203] Bluetooth: HCI UART protocol Broadcom registered
[    0.932877] Bluetooth: HCI UART protocol QCA registered
[    0.938574] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    0.953138] Twin IP Module Init
[    0.956299] --> Init Smart QoS Monitor
[    0.960346] NET: Registered protocol family 10
[    0.965387] Segment Routing with IPv6
[    0.969100] NET: Registered protocol family 17
[    0.973572] Bridge firewalling registered
[    0.977650] 8021q: 802.1Q VLAN Support v1.8
[    0.990860] nmbm nmbm_spim_nand: Signature found at block 1023 [0x07fe0000]
[    0.998730] nmbm nmbm_spim_nand: First info table with writecount 0 found in block 960
[    1.009314] nmbm nmbm_spim_nand: Second info table with writecount 0 found in block 963
[    1.017314] nmbm nmbm_spim_nand: NMBM has been successfully attached 
[    1.023902] 5 fixed-partitions partitions found on MTD device nmbm_spim_nand
[    1.030948] Creating 5 MTD partitions on "nmbm_spim_nand":
[    1.036428] 0x000000000000-0x000000100000 : "BL2"
[    1.041713] 0x000000100000-0x000000180000 : "u-boot-env"
[    1.047601] 0x000000180000-0x000000380000 : "Factory"
[    1.053164] 0x000000380000-0x000000580000 : "FIP"
[    1.058442] 0x000000580000-0x000007380000 : "ubi"
[    1.287385] mt7530 mdio-bus:1f lan0 (uninitialized): PHY [dsa-0.0:00] driver [MediaTek MT7531 PHY]
[    1.306011] mt7530 mdio-bus:1f lan1 (uninitialized): PHY [dsa-0.0:01] driver [MediaTek MT7531 PHY]
[    1.324643] mt7530 mdio-bus:1f lan2 (uninitialized): PHY [dsa-0.0:02] driver [MediaTek MT7531 PHY]
[    1.343259] mt7530 mdio-bus:1f lan3 (uninitialized): PHY [dsa-0.0:03] driver [MediaTek MT7531 PHY]
[    1.361868] mt7530 mdio-bus:1f lan4 (uninitialized): PHY [dsa-0.0:04] driver [MediaTek MT7531 PHY]
[    1.371418] mt7530 mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.378480] DSA: tree 0 setup
[    1.378732] mt7530 mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.381444] mt7530-nl: genl_register_family_with_ops 
[    1.394149] UBI: auto-attach mtd5
[    1.397536] ubi0: attaching mtd5
[    1.755567] ubi0: scanning is finished
[    1.764774] ubi0: attached mtd5 (name "ubi", size 110 MiB)
[    1.770261] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    1.777129] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    1.783905] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    1.790854] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    1.796849] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[    1.804059] ubi0: max/mean erase counter: 2/0, WL threshold: 4096, image sequence number: 916981975
[    1.813091] ubi0: available PEBs: 432, total reserved PEBs: 448, PEBs reserved for bad PEB handling: 19
[    1.822474] ubi0: background thread "ubi_bgt0d" started, PID 731
[    1.828632] block ubiblock0_2: created from ubi0:2(rootfs)
[    1.834132] ubiblock: device ubiblock0_2 (rootfs) set to be root filesystem
[    1.841086] hctosys: unable to open rtc device (rtc0)
[    1.849425] VFS: Mounted root (squashfs filesystem) readonly on device 253:0.
[    1.859239] devtmpfs: mounted
[    1.862431] Freeing unused kernel memory: 448K
[    1.871339] Run /sbin/init as init process
Start inittime
---> init fs


Checking Uboot Env ---> [ OK : ax3000q ]


check_and_install_mtk_eeprom:Check EEPROM (wl_mode:0) -> [ OK ]
check_and_install_mtk_eeprom:Check EEPROM (wl_mode:1) -> [ OK ]
---> init elog
---> init dump_core
---> init version
Product ID:ax3000q Version:15.056
---> init sys
Install Module Failed: nf_conntrack_netlink.ko
 
---> init sysctl
---> init restore_config
	--> Restoring Config...
		--> 1st Config - Default
		 -- Default account : Do macfmt conversion admin/admin
		 -- mgmt access - credential patched : admin /  admin
		 -- patched (login --> removed)
		 -- patched (password --> removed)
---> init restore_session
---> init net_files
---> init nfrule
---> init servd
---> init config
rm: can't remove '/etc/snmp*': No such file or directory
---> init ftm
---> init tz
---> init gpio
  ---> gpio.init end
---> init mac
    =================================================================
    press magic key to change default setting ...
    LAN MAC : B0:38:6C:48:32:FB
    WAN MAC : B0:38:6C:48:32:F9
---> init bridge
---> init wireless
  ---> wl.preinit
		--->Pre-Interface up/down:ra0
wps_stop --> STOP WPS
wps_stop --> STOP WPS
	Scanning best channel for wl_mode:0 --->[ 2 ]
	--> set_profile WL_MODE:0
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b0.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b0.dat
	--> set_profile WL_MODE:1
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b1.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b1.dat
set 0x7d3 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d3=0x82
set 0x7d4 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d4=0x82
wps_stop --> STOP WPS
wps_stop --> STOP WPS
No need to scan for wl_mode:0 (channel:2) is already found
	--> set_profile WL_MODE:0
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b0.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b0.dat
	--> set_profile WL_MODE:1
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b1.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b1.dat
set 0x7d3 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d3=0x82
set 0x7d4 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d4=0x82
---> init iptables
  ---> NAT:enabled
---> init lan
---> init wan
---> init dns
---> init resume_lan
---> init iptables_chain
  --> br-lan multicast_router=2
route: SIOCDELRT: No such process
---> init dos
---> init connctrl
  ---> init_connctrl
---> init disable_switch
---> init switch
  ---> IPTV mode: 2
---> init macvlan
---> init enable_switch
---> init port_mirroring
---> init port_config
---> init stacache
---> init portcache
---> init optimization
Optimize CPU : wireless
---> init resume_wan
---> init route
---> init services
killall: gpioctld: no process killed
killall: apcpd: no process killed
  ---> init_connctrl
---> Initialize HostName
killall: httpd: no process killed
---> Start station cache timer
---> set_hwnat: hwnat:1
Install mtk nat module
insmod: can't insert '/lib/modules/5.4.246/mtkhnat.ko': File exists
rtcs:initial:1766,interval:21600
rtcs:initial:391,interval:21600
killall: snmpd: no process killed
killall: snmptrapd: no process killed
Terminated
Stop MTK 8021x Daemon for ra0.
Stop MTK 8021x Daemon for rax0.
killall: inotifywait: no process killed
killall: saved: no process killed
End inittime
Setting up watches.  Beware: since -r was given, this may take a while!
Watches established.
Stopping strongSwan IPsec failed: starter is not running
helper_timer_handler:Start wl_helper
killall: dhcpd.helper: no process killed
timer helper_timer has not finished yet

```

</p>
</details> 

<details><summary>OpenWrt Bootlog</summary>
<p>

```
F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 024F [010F]
Jump to BL

NOTICE:  BL2: v2.7(release):openwrt_update_for_driver_7672_update-13-g0a805fc63a-dirty
NOTICE:  BL2: Built : 13:59:19, Nov 20 2024
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a083f1 000003ff 00100000 00000000
1001d040 | 00000000 00000000 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0x8 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 520, worse bit 0, min window 64
Window Sum 512, worse bit 10, min window 60
Window Sum 344, worse bit 2, min window 42
Window Sum 334, worse bit 9, min window 40
Window Sum 364, worse bit 5, min window 44
Window Sum 344, worse bit 14, min window 40
Window Sum 370, worse bit 6, min window 44
Window Sum 356, worse bit 14, min window 42
Window Sum 380, worse bit 0, min window 46
Window Sum 368, worse bit 14, min window 44
Window Sum 392, worse bit 2, min window 48
Window Sum 376, worse bit 9, min window 46
Window Sum 398, worse bit 6, min window 48
Window Sum 388, worse bit 14, min window 46
Window Sum 414, worse bit 4, min window 50
Window Sum 396, worse bit 14, min window 46
Window Sum 410, worse bit 9, min window 50
Window Sum 420, worse bit 0, min window 52
Window Sum 418, worse bit 14, min window 50
Window Sum 420, worse bit 15, min window 50
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc8
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 0 found in block 960
NOTICE:  Second info table with writecount 0 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):openwrt_update_for_driver_7672_update-13-g0a805fc63a-dirty
NOTICE:  BL31: Built : 13:59:21, Nov 20 2024
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Nov 20 2024 - 13:58:45 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: GigaDevice SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 0 found in block 960
Second info table with writecount 0 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[?25h[2J[1;1H----------------------------> Turned on LEDS: 9
Check RST button - wait 1 second

ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 110 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 5, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 3/1, WL threshold: 4096, image sequence number: 916981975
ubi0: available PEBs: 2, total reserved PEBs: 878, PEBs reserved for bad PEB handling: 19
Reading from volume 'kernel' to 0x46000000, size 0x0 ... OK
## Loading kernel from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.6.102
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x460000e8
     Data Size:    4300120 Bytes = 4.1 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x48000000
     Entry Point:  0x48000000
     Hash algo:    crc32
     Hash value:   c56afc6c
     Hash algo:    sha1
     Hash value:   f51ef3632324160724b183e2bf62bef0476f6066
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt iptime_ax3000q device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x46419f80
     Data Size:    22933 Bytes = 22.4 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   19b27fee
     Hash algo:    sha1
     Hash value:   cf95949edbed2eccaaa52fd73a519453cea469c5
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x46419f80
   Uncompressing Kernel Image
   Loading Device Tree to 000000004f7f0000, end 000000004f7f8994 ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.6.102 (nyanko@DevBox) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 13.3.0 r0+28834-099c643d28) 13.3.0, GNU ld (GNU Binutils) 2.42) #0 SMP Tue Sep  2 18:27:29 2025
[    0.000000] Machine model: ipTIME AX3000Q
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004302ffff (192 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x0000000047c80000..0x0000000047d7ffff (1024 KiB) nomap non-reusable wmcpu-reserved@47c80000
[    0.000000] OF: reserved mem: 0x0000000047d80000..0x0000000047dbffff (256 KiB) nomap non-reusable wo-emi@47d80000
[    0.000000] OF: reserved mem: 0x0000000047dc0000..0x0000000047ffffff (2304 KiB) nomap non-reusable wo-data@47dc0000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004302ffff]
[    0.000000]   node   0: [mem 0x0000000043030000-0x0000000047c7ffff]
[    0.000000]   node   0: [mem 0x0000000047c80000-0x0000000047ffffff]
[    0.000000]   node   0: [mem 0x0000000048000000-0x000000004fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 18 pages/cpu s35112 r8192 d30424 u73728
[    0.000000] pcpu-alloc: s35112 r8192 d30424 u73728 alloc=18*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: console=ttyS0,115200 boot_from=A
[    0.000000] Unknown kernel command line parameters "boot_from=A", will be passed to user space.
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 64512
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[    0.000000] software IO TLB: area num 2.
[    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 0MB
[    0.000000] software IO TLB: mapped [mem 0x000000004fe47000-0x000000004fec7000] (0MB)
[    0.000000] Memory: 239180K/262144K available (8832K kernel code, 994K rwdata, 2568K rodata, 448K init, 289K bss, 22964K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000069] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000078] pid_max: default: 32768 minimum: 301
[    0.002975] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.002983] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.005118] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.005654] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.005803] rcu: Hierarchical SRCU implementation.
[    0.005806] rcu: 	Max phase no-delay instances is 1000.
[    0.006196] smp: Bringing up secondary CPUs ...
[    0.006557] Detected VIPT I-cache on CPU1
[    0.006598] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.006627] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.006694] smp: Brought up 1 node, 2 CPUs
[    0.006699] SMP: Total of 2 processors activated.
[    0.006702] CPU features: detected: 32-bit EL0 Support
[    0.006705] CPU features: detected: CRC32 instructions
[    0.006736] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.006740] CPU: All CPU(s) started at EL2
[    0.006742] alternatives: applying system-wide alternatives
[    0.010262] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.010279] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.011535] pinctrl core: initialized pinctrl subsystem
[    0.012680] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.013024] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.013051] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.013073] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.013455] thermal_sys: Registered thermal governor 'fair_share'
[    0.013459] thermal_sys: Registered thermal governor 'bang_bang'
[    0.013462] thermal_sys: Registered thermal governor 'step_wise'
[    0.013464] thermal_sys: Registered thermal governor 'user_space'
[    0.013534] ASID allocator initialised with 65536 entries
[    0.014244] pstore: Using crash dump compression: deflate
[    0.014249] pstore: Registered ramoops as persistent store backend
[    0.014252] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.015676] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.021082] Modules: 29440 pages in range for non-PLT usage
[    0.021090] Modules: 520960 pages in range for PLT usage
[    0.022038] cryptd: max_cpu_qlen set to 1000
[    0.024124] SCSI subsystem initialized
[    0.024312] libata version 3.00 loaded.
[    0.025929] clocksource: Switched to clocksource arch_sys_counter
[    0.028262] NET: Registered PF_INET protocol family
[    0.028368] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.029417] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.029431] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.029440] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.029459] TCP bind hash table entries: 2048 (order: 4, 65536 bytes, linear)
[    0.029508] TCP: Hash tables configured (established 2048 bind 2048)
[    0.029820] MPTCP token hash table entries: 256 (order: 0, 6144 bytes, linear)
[    0.029924] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.029940] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.030220] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.030247] PCI: CLS 0 bytes, default 64
[    0.031334] workingset: timestamp_bits=46 max_order=16 bucket_order=0
[    0.036225] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.036234] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.103334] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.104542] printk: console [ttyS0] disabled
[    0.124905] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 72, base_baud = 2500000) is a ST16650V2
[    0.124945] printk: console [ttyS0] enabled
[    0.890393] loop: module loaded
[    0.896449] spi-nand spi0.0: calibration result: 0x3
[    0.901501] spi-nand spi0.0: ESMT SPI NAND was found.
[    0.906556] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.915261] Signature found at block 1023 [0x07fe0000]
[    0.920412] NMBM management region starts at block 960 [0x07800000]
[    0.928578] First info table with writecount 0 found in block 960
[    0.940758] Second info table with writecount 0 found in block 963
[    0.946958] NMBM has been successfully attached
[    0.951786] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.958159] Creating 5 MTD partitions on "spi0.0":
[    0.962940] 0x000000000000-0x000000100000 : "BL2"
[    0.968642] 0x000000100000-0x000000180000 : "u-boot-env"
[    0.974729] 0x000000180000-0x000000380000 : "Factory"
[    0.981642] 0x000000380000-0x000000580000 : "FIP"
[    0.987957] 0x000000580000-0x000007380000 : "ubi"
[    1.193497] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081580000, irq 75
[    1.203200] i2c_dev: i2c /dev entries driver
[    1.209200] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.218294] NET: Registered PF_INET6 protocol family
[    1.224222] Segment Routing with IPv6
[    1.227935] In-situ OAM (IOAM) with IPv6
[    1.231895] NET: Registered PF_PACKET protocol family
[    1.237282] 8021q: 802.1Q VLAN Support v1.8
[    1.343445] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.352185] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.370935] mt7530-mdio mdio-bus:1f wan (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=79)
[    1.393087] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=80)
[    1.415155] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=81)
[    1.437199] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=82)
[    1.459246] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:04] driver [MediaTek MT7531 PHY] (irq=83)
[    1.470523] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.477289] DSA: tree 0 setup
[    1.480947] UBI: auto-attach mtd4
[    1.484269] ubi0: default fastmap pool size: 40
[    1.488809] ubi0: default fastmap WL pool size: 20
[    1.493588] ubi0: attaching mtd4
[    2.291485] ubi0: scanning is finished
[    2.306701] ubi0: attached mtd4 (name "ubi", size 110 MiB)
[    2.312192] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    2.319072] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.325848] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.332800] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    2.338798] ubi0: user volume: 5, internal volumes: 1, max. volumes count: 128
[    2.346010] ubi0: max/mean erase counter: 3/1, WL threshold: 4096, image sequence number: 916981975
[    2.355038] ubi0: available PEBs: 0, total reserved PEBs: 880, PEBs reserved for bad PEB handling: 19
[    2.364255] ubi0: background thread "ubi_bgt0d" started, PID 534
[    2.371115] block ubiblock0_2: created from ubi0:2(rootfs)
[    2.376624] ubiblock: device ubiblock0_2 (rootfs) set to be root filesystem
[    2.383676] clk: Disabling unused clocks
[    2.396165] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[    2.403475] Freeing unused kernel memory: 448K
[    2.407994] Run /sbin/init as init process
[    2.412079]   with arguments:
[    2.415033]     /sbin/init
[    2.417740]   with environment:
[    2.420868]     HOME=/
[    2.423215]     TERM=linux
[    2.425909]     boot_from=A
[    2.695296] init: Console is alive
[    2.698906] init: - watchdog -
[    3.149729] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.181495] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    3.191447] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.206463] init: - preinit -
[    3.415951] random: crng init done
[    3.615001] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    3.623554] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    3.653987] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    7.843659] UBIFS (ubi0:3): Mounting in unauthenticated mode
[    7.849433] UBIFS (ubi0:3): background thread "ubifs_bgt0_3" started, PID 676
[    7.912000] UBIFS (ubi0:3): recovery needed
[    8.077775] UBIFS (ubi0:3): recovery completed
[    8.082285] UBIFS (ubi0:3): UBIFS: mounted UBI device 0, volume 3, name "rootfs_data"
[    8.090120] UBIFS (ubi0:3): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[    8.100025] UBIFS (ubi0:3): FS size: 77201408 bytes (73 MiB, 608 LEBs), max 618 LEBs, journal size 3809280 bytes (3 MiB, 30 LEBs)
[    8.111664] UBIFS (ubi0:3): reserved for root: 3646412 bytes (3560 KiB)
[    8.118273] UBIFS (ubi0:3): media format: w5/r0 (latest is w5/r0), UUID 021C2296-8B15-4F8C-9A83-44F1A3DAC691, small LPT model
[    8.133169] mount_root: switching to ubifs overlay
[    8.145785] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[    8.162663] urandom-seed: Seeding with /etc/urandom.seed
[    8.227730] procd: - early -
[    8.230672] procd: - watchdog -
[    8.780034] procd: - watchdog -
[    8.848476] procd: - ubus -
[    8.924092] procd: - init -
Please press Enter to activate this console.
[    9.344179] kmodloader: loading kernel modules from /etc/modules.d/*
[    9.384930] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    9.403690] Loading modules backported from Linux version v6.12.6-0-ge9d65b48ce1a
[    9.411229] Backport generated by backports.git v6.1.110-1-35-g410656ef04d2
[    9.532582] urngd: v1.0.2 started.
[    9.769499] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[    9.769499] 
[   10.029325] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[   10.142009] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[   10.239704] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[   10.337749] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[   10.450085] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   10.464499] PPP generic driver version 2.4.2
[   10.469638] NET: Registered PF_PPPOX protocol family
[   10.477984] kmodloader: done loading kernel modules from /etc/modules.d/*
[   10.787271] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   14.087072] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   14.101327] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   14.110341] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   14.119159] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   14.130546] br-lan: port 1(lan1) entered blocking state
[   14.135779] br-lan: port 1(lan1) entered disabled state
[   14.141096] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   14.147424] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   14.157489] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   14.184278] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   14.197968] br-lan: port 2(lan2) entered blocking state
[   14.203200] br-lan: port 2(lan2) entered disabled state
[   14.208511] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   14.234269] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   14.259570] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   14.271052] br-lan: port 3(lan3) entered blocking state
[   14.276346] br-lan: port 3(lan3) entered disabled state
[   14.281598] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   14.290205] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   14.308450] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   14.316562] br-lan: port 4(lan4) entered blocking state
[   14.321794] br-lan: port 4(lan4) entered disabled state
[   14.327102] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   14.346912] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[   14.371579] mt7530-mdio mdio-bus:1f wan: configuring for phy/gmii link mode



BusyBox v1.36.1 (2025-09-02 18:27:29 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt 24.10-SNAPSHOT, r0+28834-099c643d28
 -----------------------------------------------------
=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------
root@OpenWrt:~# 
```

</p>
</details> 

Related links
--------
- Snapshot PR (main branch): https://github.com/openwrt/openwrt/pull/19368
- Cherry picked from commit: aea6d1bf5eb579614dcc12c3b2c7215b7cd985ac
