### PR TITLE
package/libs/elfutils: fix license

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION) \
 PKG_HASH:=616099beae24aba11f9b63d86ca6cc8d566d968b802391334c91df54eab416b4
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
-PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE:=GPL-2.0-or-later OR LGPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING COPYING-GPLV2 COPYING-LGPLV3
 PKG_CPE_ID:=cpe:/a:elfutils_project:elfutils
 


### PR DESCRIPTION
elfutils libraries are not licensed under `GPL-3.0-or-later`, they are dual licensed: `GPL-2.0-or-later OR LGPL-3.0-or-later` as clearly stated in source files as well as on https://sourceware.org/elfutils:

> The libraries and backends are dual GPLv2+/LGPLv3+. The utilities are GPLv3+.

Fixes: b98fb7664639a814f3dba309eaf38b62be137bb8 (elfutils: import package from packages.git)