### PR TITLE
package/libs/gettext-full: fix license

### DIFF
--- a/package/libs/gettext-full/Makefile
+++ b/package/libs/gettext-full/Makefile
@@ -18,7 +18,8 @@ PKG_BUILD_DIR:=$(BUILD_DIR)/gettext-$(PKG_VERSION)
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/gettext-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
-PKG_LICENSE:=GPL-3.0-or-later
+PKG_LICENSE:=LGPL-2.1-or-later
+PKG_LICENSE_FILES:=gettext-runtime/intl/COPYING.LIB
 PKG_CPE_ID:=cpe:/a:gnu:gettext
 
 PKG_INSTALL:=1


### PR DESCRIPTION
gettext-full only provides `libintl` which is not licensed under `GPL-3.0.-or-later` but under `LGPL-2.1-or-later` as stated in `gettext-runtime/intl/COPYING.LIB`

Fixes: c10d97484a43375a0446dafc8cb4072e26502f37 (Add more license tags with SPDX identifiers)
