### PR TITLE
ramips: add support for AsiaRF AP7621-004 Rev. 3

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -30,6 +30,7 @@ alfa-network,ax1800rm|\
 allnet,all0256n-4m|\
 allnet,all0256n-8m|\
 allnet,all5002|\
+asiarf,ap7621-004-v3|\
 yuncore,ax820)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
 	;;

--- a/target/linux/ramips/dts/mt7621_asiarf_ap7621-004-v3.dts
+++ b/target/linux/ramips/dts/mt7621_asiarf_ap7621-004-v3.dts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+/ {
+	compatible = "asiarf,ap7621-004-v3", "mediatek,mt7621-soc";
+	model = "AsiaRF AP7621-004 v3";
+
+	keys {
+		compatible = "gpio-keys";
+		
+		wps {
+			label = "wps";
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&sdhci {
+	status = "okay";
+	non-removable;
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_factory_e000: macaddr@e000 {
+						reg = <0xe000 0x6>;
+					};
+
+					macaddr_factory_e006: macaddr@e006 {
+						reg = <0xe006 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+				compatible = "denx,uimage";
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&gmac0 {
+	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_e000>;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cell-names = "mac-address";
+			nvmem-cells = <&macaddr_factory_e006>;
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+	
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "jtag";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -366,6 +366,17 @@ define Device/asiarf_ap7621-001
 endef
 TARGET_DEVICES += asiarf_ap7621-001
 
+define Device/asiarf_ap7621-004-v3
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := AsiaRF
+  DEVICE_MODEL := AP7621-004
+  DEVICE_VARIANT := v3
+  IMAGE_SIZE := 16000k
+  DEVICE_PACKAGES := kmod-mmc-mtk kmod-usb3
+endef
+TARGET_DEVICES += asiarf_ap7621-004-v3
+
 define Device/asiarf_ap7621-nv1
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)


### PR DESCRIPTION
**<h1>Specification:</h1>**

- SoC           : MediaTek MT7621AT, dual-core 880 MHz MIPS CPU
- RAM           : DDR3 512 MB (Micron MT41K256M16TW-107)
- Flash         : SPI-NOR 16 MB (MACRONIX MX25L12835FM2I-10G)
- Ethernet      : 5 port GbE Switch
  - LAN : 
      3x RJ-45 Port
      1x PHD Connector (2x5 pin, pitch 2.0 mm)
  - WAN :
      1x RJ-45 Port
- LED           : 8x LEDs
    1x Power (Blue)
    2x MiniPCIe (Orange)
    1x M.2 B Key (Red)
    4x Ethernet activity (White)
- UART          : 1x4 pin header on PCB [J1]
  - arrangement : 3.3V, TX, RX, GND
  - settings    : 57600, 8n1
- Button        : 2x (Reset, WPS)
- USB           : 1x USB 2.0
- Socket       : 
    2x MiniPCIe (PCIe Gen2)
    1x M.2 B key (PCIe Gen2 + USB 3.0)
    1x MicroSD
    1x SIM Card
- Power         : 12V DC, 1A (DC Jack or Molex KK 254)


| Interface  | Mac Address | Read Address |
| ------------- | ------------- | ------------- | 
| LAN  | 00:0A:52:xx:xx:xx  | Factory, 0xe000 |
| WAN  | 00:0A:52:xx:xx:xx  | Factory, 0xe006 |


<h2>Bootlog</h2>
<details>

<summary>Factory Bootlog</summary>

```
U-Boot SPL 2018.09 (Aug 22 2024 - 10:47:19 +0800)
Trying to boot from NOR


U-Boot 2018.09 (Aug 22 2024 - 10:47:19 +0800)

CPU:   MediaTek MT7621AT ver 1, eco 3
Clocks: CPU: 880MHz, DDR: 1200MHz, Bus: 220MHz, XTAL: 40MHz
Model: MediaTek MT7621 reference board
DRAM:  448 MiB
Loading Environment from SPI Flash... SF: Detected mx25l12805 with page size 256 Bytes, erase size 64 KiB, total 16 MiB
*** Warning - bad CRC, using default environment

In:    uartlite0@1e000c00
Out:   uartlite0@1e000c00
Err:   uartlite0@1e000c00
Net:   
Warning: eth@1e100000 (eth0) using random MAC address - 16:8c:52:b2:08:9e
eth0: eth@1e100000
Hit any key to stop autoboot:  0 
  *** U-Boot Boot Menu ***  Press UP/DOWN to move, ENTER to select     1. Startup system (Default)     2. Upgrade firmware     3. Upgrade bootloader     4. Upgrade bootloader (advanced mode)     5. Load image     0. U-Boot console  Hit any key to stop autoboot:  3  2  1  0 ## Booting kernel from Legacy Image at bfc50000 ...
   Image Name:   MIPS OpenWrt Linux-6.12.44
   Image Type:   MIPS Linux Kernel Image (uncompressed)
   Data Size:    3404928 Bytes = 3.2 MiB
   Load Address: 80001000
   Entry Point:  80001000
   Verifying Checksum ... OK
   Loading Kernel Image ... OK


OpenWrt kernel loader for MIPS based SoC
Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
Decompressing kernel... done!
Starting kernel at 80001000...

[    0.000000] Linux version 6.12.44 (elwin@elwin-B760M-DS3H-AX) (mipsel-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r30942-bd831560cf) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Tue Sep  2 22:59:58 2025
[    0.000000] SoC Type: MediaTek MT7621 ver:1 eco:3
[    0.000000] printk: legacy bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 0001992f (MIPS 1004Kc)
[    0.000000] MIPS: machine is AsiaRF AP7621-004 v3
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] VPE topology {2,2} total 4
[    0.000000] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.000000] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000001fffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x000000001bffffff]
[    0.000000]   node   0: [mem 0x0000000020000000-0x0000000023ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x0000000023ffffff]
[    0.000000] On node 0, zone Normal: 16384 pages in unavailable ranges
[    0.000000] OF: reserved mem: Reserved memory: No reserved-memory node in the DT
[    0.000000] percpu: Embedded 13 pages/cpu s22768 r8192 d22288 u53248
[    0.000000] Kernel command line: console=ttyS0,57600 rootfstype=squashfs,jffs2
[    0.000000] Dentry cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
[    0.000000] Writing ErrCtl register=000422a4
[    0.000000] Readback ErrCtl register=000422a4
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 114688
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks Trace: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=4.
[    0.000000] NR_IRQS: 256
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] clocksource: GIC: mask: 0xffffffffffffffff max_cycles: 0xcaf478abb4, max_idle_ns: 440795247997 ns
[    0.000005] sched_clock: 64 bits at 880MHz, resolution 1ns, wraps every 4398046511103ns
[    0.015978] Calibrating delay loop... 586.13 BogoMIPS (lpj=2930688)
[    0.088248] pid_max: default: 32768 minimum: 301
[    0.107623] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.122042] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.147909] rcu: Hierarchical SRCU implementation.
[    0.157316] rcu: 	Max phase no-delay instances is 1000.
[    0.168245] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.185085] smp: Bringing up secondary CPUs ...
[    0.195031] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.195071] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.195094] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.195147] CPU1 revision is: 0001992f (MIPS 1004Kc)
[    0.256873] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.256903] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.256916] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.256951] CPU2 revision is: 0001992f (MIPS 1004Kc)
[    0.316879] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.316909] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.316921] MIPS secondary cache 256kB, 8-way, linesize 32 bytes.
[    0.316959] CPU3 revision is: 0001992f (MIPS 1004Kc)
[    0.375984] smp: Brought up 1 node, 4 CPUs
[    0.535933] Memory: 439224K/458752K available (8394K kernel code, 647K rwdata, 1788K rodata, 1256K init, 226K bss, 17604K reserved, 0K cma-reserved)
[    0.567588] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.587097] futex hash table entries: 1024 (order: 3, 32768 bytes, linear)
[    0.606429] pinctrl core: initialized pinctrl subsystem
[    0.620172] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.635044] /pinctrl: Fixed dependency cycle(s) with /pinctrl/pinctrl0
[    0.667504] clocksource: Switched to clocksource GIC
[    0.687088] NET: Registered PF_INET protocol family
[    0.697013] IP idents hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.712734] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.729303] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.744658] TCP established hash table entries: 4096 (order: 2, 16384 bytes, linear)
[    0.760096] TCP bind hash table entries: 4096 (order: 4, 65536 bytes, linear)
[    0.774512] TCP: Hash tables configured (established 4096 bind 4096)
[    0.788240] MPTCP token hash table entries: 512 (order: 1, 8192 bytes, linear)
[    0.802935] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.815883] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.830763] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.842013] PCI: CLS 0 bytes, default 32
[    0.853381] workingset: timestamp_bits=14 max_order=17 bucket_order=3
[    0.869133] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.880616] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.907855] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.919348] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.930806] mt7621_gpio 1e000600.gpio: registering 32 gpios
[    0.942501] mt7621-pci 1e140000.pcie: host bridge /pcie@1e140000 ranges:
[    0.955753] mt7621-pci 1e140000.pcie:   No bus range found for /pcie@1e140000, using [bus 00-ff]
[    0.973262] mt7621-pci 1e140000.pcie:      MEM 0x0060000000..0x006fffffff -> 0x0060000000
[    0.989444] mt7621-pci 1e140000.pcie:       IO 0x001e160000..0x001e16ffff -> 0x0000000000
[    1.327518] mt7621-pci 1e140000.pcie: pcie0 no card, disable it (RST & CLK)
[    1.341297] mt7621-pci 1e140000.pcie: pcie1 no card, disable it (RST & CLK)
[    1.355103] mt7621-pci 1e140000.pcie: pcie2 no card, disable it (RST & CLK)
[    1.368922] mt7621-pci 1e140000.pcie: nothing connected in virtual bridges
[    1.384403] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    1.399784] printk: legacy console [ttyS0] disabled
[    1.410383] 1e000c00.uartlite: ttyS0 at MMIO 0x1e000c00 (irq = 18, base_baud = 3125000) is a 16550A
[    1.428386] printk: legacy console [ttyS0] enabled
[    1.428386] printk: legacy console [ttyS0] enabled
[    1.447317] printk: legacy bootconsole [early0] disabled
[    1.447317] printk: legacy bootconsole [early0] disabled
[    1.473688] spi-mt7621 1e000b00.spi: sys_freq: 220000000
[    1.485840] 8 fixed-partitions partitions found on MTD device spi0.0
[    1.498643] OF: Bad cell count for /palmbus@1e000000/spi@b00/flash@0/partitions
[    1.513261] OF: Bad cell count for /palmbus@1e000000/spi@b00/flash@0/partitions
[    1.528151] Creating 8 MTD partitions on "spi0.0":
[    1.537751] 0x000000000000-0x000000030000 : "u-boot"
[    1.549228] 0x000000030000-0x000000032000 : "u-boot-env"
[    1.560977] 0x000000032000-0x000000036000 : "2860"
[    1.571752] 0x000000036000-0x000000038000 : "rtdev"
[    1.582578] 0x000000038000-0x000000040000 : "Reserve"
[    1.593818] 0x000000040000-0x000000050000 : "factory"
[    1.605095] OF: Bad cell count for /palmbus@1e000000/spi@b00/flash@0/partitions
[    1.620126] 0x000000050000-0x000000ff0000 : "firmware"
[    1.631562] 2 uimage-fw partitions found on MTD device firmware
[    1.643459] Creating 2 MTD partitions on "firmware":
[    1.653379] 0x000000000000-0x00000033f4c0 : "kernel"
[    1.663285] mtd: partition "kernel" doesn't end on an erase/write block -- force read-only
[    1.680886] 0x00000033f4c0-0x000000fa0000 : "rootfs"
[    1.690876] mtd: partition "rootfs" doesn't start on an erase/write block boundary -- force read-only
[    1.710173] mtd: setting mtd8 (rootfs) as root device
[    1.720414] 1 squashfs-split partitions found on MTD device rootfs
[    1.732751] 0x000000660000-0x000000fa0000 : "rootfs_data"
[    1.744701] 0x000000ff0000-0x000001000000 : "nvram"
[    1.879165] mtk_soc_eth 1e100000.ethernet: generated random MAC address 20:08:02:00:00:00
[    1.897197] mt7530-mdio mdio-bus:1f: MT7530 adapts as multi-chip module
[    1.910493] mt7530-mdio mdio-bus:1f: supply core not found, using dummy regulator
[    1.925701] mt7530-mdio mdio-bus:1f: supply io not found, using dummy regulator
[    1.948703] mtk_soc_eth 1e100000.ethernet eth0: mediatek frame engine at 0xbe100000, irq 19
[    1.967227] i2c_dev: i2c /dev entries driver
[    1.979580] NET: Registered PF_INET6 protocol family
[    1.993072] Segment Routing with IPv6
[    2.000546] In-situ OAM (IOAM) with IPv6
[    2.008582] NET: Registered PF_PACKET protocol family
[    2.019132] 8021q: 802.1Q VLAN Support v1.8
[    2.055811] mt7530-mdio mdio-bus:1f: MT7530 adapts as multi-chip module
[    2.069128] mt7530-mdio mdio-bus:1f: supply core not found, using dummy regulator
[    2.084372] mt7530-mdio mdio-bus:1f: supply io not found, using dummy regulator
[    2.125136] mt7530-mdio mdio-bus:1f: configuring for fixed/rgmii link mode
[    2.140759] mt7530-mdio mdio-bus:1f wan (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7530 PHY] (irq=21)
[    2.163671] mt7530-mdio mdio-bus:1f: Link is Up - 1Gbps/Full - flow control rx/tx
[    2.168590] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7530 PHY] (irq=22)
[    2.201926] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7530 PHY] (irq=23)
[    2.225151] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7530 PHY] (irq=24)
[    2.248563] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:04] driver [MediaTek MT7530 PHY] (irq=25)
[    2.271291] mtk_soc_eth 1e100000.ethernet eth0: entered promiscuous mode
[    2.284877] DSA: tree 0 setup
[    2.291826] clk: Disabling unused clocks
[    2.305952] VFS: Mounted root (squashfs filesystem) readonly on device 31:8.
[    2.324081] Freeing unused kernel image (initmem) memory: 1256K
[    2.335963] This architecture does not have kernel memory protection.
[    2.348808] Run /sbin/init as init process
[    2.843669] init: Console is alive
[    2.850953] init: - watchdog -
[    3.481118] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.633467] usbcore: registered new interface driver usbfs
[    3.644631] usbcore: registered new interface driver hub
[    3.655445] usbcore: registered new device driver usb
[    3.667274] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    3.693869] xhci-mtk 1e1c0000.xhci: xHCI Host Controller
[    3.704686] xhci-mtk 1e1c0000.xhci: new USB bus registered, assigned bus number 1
[    3.724792] xhci-mtk 1e1c0000.xhci: hcc params 0x01401198 hci version 0x96 quirks 0x0000000000280010
[    3.743156] xhci-mtk 1e1c0000.xhci: irq 28, io mem 0x1e1c0000
[    3.754926] xhci-mtk 1e1c0000.xhci: xHCI Host Controller
[    3.765563] xhci-mtk 1e1c0000.xhci: new USB bus registered, assigned bus number 2
[    3.780493] xhci-mtk 1e1c0000.xhci: Host supports USB 3.0 SuperSpeed
[    3.794296] hub 1-0:1.0: USB hub found
[    3.801979] hub 1-0:1.0: 2 ports detected
[    3.811250] usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
[    3.828511] hub 2-0:1.0: USB hub found
[    3.836101] hub 2-0:1.0: 1 port detected
[    3.863171] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.883919] init: - preinit -
[    7.677545] random: crng init done
[    8.072952] mtk_soc_eth 1e100000.ethernet eth0: configuring for fixed/rgmii link mode
[    8.093487] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[    8.107713] mtk_soc_eth 1e100000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[   12.318422] jffs2: notice: (561) jffs2_build_xattr_subsystem: complete building xattr subsystem, 8 of xdatum (0 unchecked, 2 orphan) and 9 of xref (2 dead, 0 orphan) found.
[   12.351360] mount_root: switching to jffs2 overlay
[   12.365033] overlayfs: upper fs does not support tmpfile.
[   12.384014] urandom-seed: Seeding with /etc/urandom.seed
[   12.488060] procd: - early -
[   12.494041] procd: - watchdog -
[   13.094307] procd: - watchdog -
[   13.224146] procd: - ubus -
[   13.386448] procd: - init -
Please press Enter to activate this console.
[   14.110032] kmodloader: loading kernel modules from /etc/modules.d/*
[   14.255353] mtk-eip93 1e004000.crypto: EIP93 Crypto Engine Initialized.
[   14.350082] PPP generic driver version 2.4.2
[   14.360628] NET: Registered PF_PPPOX protocol family
[   14.377875] kmodloader: done loading kernel modules from /etc/modules.d/*
[   15.148471] urngd: v1.0.2 started.
[   21.618662] mtk_soc_eth 1e100000.ethernet eth0: Link is Down
[   21.654424] mtk_soc_eth 1e100000.ethernet eth0: configuring for fixed/rgmii link mode
[   21.670802] mtk_soc_eth 1e100000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
[   21.694779] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   21.710824] br-lan: port 1(lan1) entered blocking state
[   21.721532] br-lan: port 1(lan1) entered disabled state
[   21.732187] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   21.744882] mtk_soc_eth 1e100000.ethernet eth0: entered allmulticast mode
[   21.761752] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   21.802735] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   21.819462] br-lan: port 2(lan2) entered blocking state
[   21.830100] br-lan: port 2(lan2) entered disabled state
[   21.840984] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   21.855823] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   21.881786] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   21.897752] br-lan: port 3(lan3) entered blocking state
[   21.908409] br-lan: port 3(lan3) entered disabled state
[   21.919087] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   21.934341] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   21.963742] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   21.979843] br-lan: port 4(lan4) entered blocking state
[   21.990460] br-lan: port 4(lan4) entered disabled state
[   22.001243] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   22.017811] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[   22.050483] mt7530-mdio mdio-bus:1f wan: configuring for phy/gmii link mode



BusyBox v1.37.0 (2025-09-02 22:59:58 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt SNAPSHOT, r30942-bd831560cf
 -----------------------------------------------------
=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------

 OpenWrt recently switched to the "apk" package manager!

 OPKG Command           APK Equivalent      Description
 ------------------------------------------------------------------
 opkg install <pkg>     apk add <pkg>       Install a package
 opkg remove <pkg>      apk del <pkg>       Remove a package
 opkg upgrade           apk upgrade         Upgrade all packages
 opkg files <pkg>       apk info -L <pkg>   List package contents
 opkg list-installed    apk info            List installed packages
 opkg update            apk update          Update package lists
 opkg search <pkg>      apk search <pkg>    Search for packages
 ------------------------------------------------------------------

For more https://openwrt.org/docs/guide-user/additional-software/opkg-to-apk-cheatsheet

root@OpenWrt:~# 
```
</details>


<h2>How to flash</h2>

**Flash instruction through LuCI:**

This device is flashed OpenWRT base firmware with this target.
The LuCI webpage is integrated in default for upgrading.

**Flash instruction through u-boot:**

1. Prepare the TFTP server on PC.
2. Connect uart to PC, select "2. Upgrade firmware" in u-boot menu.
3. Select "0 - TFTP client (Default)", input client IP, server IP, flashed bin file path
4. Wait about 60 seconds to complete flashing