### PR TITLE
mac80211: Compile fixes

### DIFF
--- a/package/kernel/mac80211/intel.mk
+++ b/package/kernel/mac80211/intel.mk
@@ -6,7 +6,7 @@ config-$(CONFIG_PACKAGE_IWLWIFI_DEBUGFS)+= IWLWIFI_DEBUGFS
 
 define KernelPackage/iwlwifi
   $(call KernelPackage/mac80211/Default)
-  DEPENDS:= +kmod-mac80211 +kmod-ptp @PCI_SUPPORT +@DRIVER_11AC_SUPPORT +@DRIVER_11AX_SUPPORT
+  DEPENDS:= +kmod-mac80211 +kmod-ptp @PCI_SUPPORT +@DRIVER_11AC_SUPPORT +@DRIVER_11AX_SUPPORT +@DRIVER_11BE_SUPPORT
   TITLE:=Intel AGN Wireless support
   FILES:= \
 	$(PKG_BUILD_DIR)/drivers/net/wireless/intel/iwlwifi/iwlwifi.ko \

--- a/package/kernel/mac80211/patches/build/020-intel-mld-compile.patch
+++ b/package/kernel/mac80211/patches/build/020-intel-mld-compile.patch
@@ -1,0 +1,54 @@
+Fix Intel mld thermal compilation
+
+Do the same changes done also in iwlwifi/mvm/tt.c in the iwlwifi/mld/thermal.c file.
+
+This fixes the compilation.
+
+--- a/drivers/net/wireless/intel/iwlwifi/mld/thermal.c
++++ b/drivers/net/wireless/intel/iwlwifi/mld/thermal.c
+@@ -209,9 +209,15 @@ unlock:
+ 	return ret;
+ }
+ 
++#if LINUX_VERSION_IS_GEQ(6,11,0)
+ static int iwl_mld_tzone_set_trip_temp(struct thermal_zone_device *device,
+ 				       const struct thermal_trip *trip,
+ 				       int temp)
++#else
++static int iwl_mld_tzone_set_trip_temp(struct thermal_zone_device *device,
++				       int trip,
++				       int temp)
++#endif
+ {
+ 	struct iwl_mld *mld = thermal_zone_device_priv(device);
+ 	int ret;
+@@ -248,18 +254,29 @@ static void iwl_mld_thermal_zone_registe
+ 		[0 ... IWL_MAX_DTS_TRIPS - 1] = {
+ 			.temperature = THERMAL_TEMP_INVALID,
+ 			.type = THERMAL_TRIP_PASSIVE,
++#if LINUX_VERSION_IS_GEQ(6,9,0)
+ 			.flags = THERMAL_TRIP_FLAG_RW_TEMP,
++#endif
+ 		},
+ 	};
+ 
+ 	BUILD_BUG_ON(ARRAY_SIZE(name) >= THERMAL_NAME_LENGTH);
+ 
+ 	sprintf(name, "iwlwifi_%u", atomic_inc_return(&counter) & 0xFF);
++#if LINUX_VERSION_IS_GEQ(6,9,0)
+ 	mld->tzone =
+ 		thermal_zone_device_register_with_trips(name, trips,
+ 							IWL_MAX_DTS_TRIPS,
+ 							mld, &tzone_ops,
+ 							NULL, 0, 0);
++#else
++	mld->tzone =
++		thermal_zone_device_register_with_trips(name, trips,
++							IWL_MAX_DTS_TRIPS, 0,
++							mld, &tzone_ops,
++							NULL, 0, 0);
++#endif
++
+ 	if (IS_ERR(mld->tzone)) {
+ 		IWL_DEBUG_TEMP(mld,
+ 			       "Failed to register to thermal zone (err = %ld)\n",

--- a/package/kernel/mac80211/patches/rt2x00/602-04-wifi-rt2x00-Support-EEPROM-swap-binding.patch
+++ b/package/kernel/mac80211/patches/rt2x00/602-04-wifi-rt2x00-Support-EEPROM-swap-binding.patch
@@ -32,7 +32,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 +
  static int rt2800lib_read_eeprom_mtd(struct rt2x00_dev *rt2x00dev)
  {
- 	int ret = -EINVAL;
+ 	struct device_node *np = rt2x00dev->dev->of_node, *mtd_np = NULL;
 @@ -65,6 +78,8 @@ static int rt2800lib_read_eeprom_mtd(str
  		return ret;
  	}

--- a/package/kernel/mac80211/patches/rt2x00/602-05-wifi-rt2x00-support-loading-eeprom-from-NVMEM-cells.patch
+++ b/package/kernel/mac80211/patches/rt2x00/602-05-wifi-rt2x00-support-loading-eeprom-from-NVMEM-cells.patch
@@ -41,7 +41,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 +#if IS_ENABLED(CONFIG_MTD)
  static int rt2800lib_read_eeprom_mtd(struct rt2x00_dev *rt2x00dev)
  {
- 	int ret = -EINVAL;
+ 	struct device_node *np = rt2x00dev->dev->of_node, *mtd_np = NULL;
 @@ -86,6 +87,40 @@ static int rt2800lib_read_eeprom_mtd(str
  }
  #endif


### PR DESCRIPTION
Multiple independent fixes for mac80211.

This fixes iwlwifi compilation.