### PR TITLE
kernel: add quirk for two SFP+ transceivers

### DIFF
--- a/target/linux/generic/backport-6.6/786-v6.10-net-sfp-add-quirk-for-another-multigig-RollBall-tran.patch
+++ b/target/linux/generic/backport-6.6/786-v6.10-net-sfp-add-quirk-for-another-multigig-RollBall-tran.patch
@@ -1,0 +1,30 @@
+From 1c77c721916ae108c2c5865986735bfe92000908 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Beh=C3=BAn?= <kabel@kernel.org>
+Date: Tue, 9 Apr 2024 09:30:16 +0200
+Subject: [PATCH] net: sfp: add quirk for another multigig RollBall transceiver
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add quirk for another RollBall copper transceiver: Turris RTSFP-2.5G,
+containing 2.5g capable RTL8221B PHY.
+
+Signed-off-by: Marek Behún <kabel@kernel.org>
+Signed-off-by: Eric Woudstra <ericwouds@gmail.com>
+
+Reviewed-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/phy/sfp.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -505,6 +505,7 @@ static const struct sfp_quirk sfp_quirks
+ 	SFP_QUIRK_M("OEM", "SFP-2.5G-BX10-U", sfp_quirk_2500basex),
+ 	SFP_QUIRK_F("OEM", "RTSFP-10", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_F("OEM", "RTSFP-10G", sfp_fixup_rollball_cc),
++	SFP_QUIRK_F("Turris", "RTSFP-2.5G", sfp_fixup_rollball),
+ 	SFP_QUIRK_F("Turris", "RTSFP-10", sfp_fixup_rollball),
+ 	SFP_QUIRK_F("Turris", "RTSFP-10G", sfp_fixup_rollball),
+ };

--- a/target/linux/generic/pending-6.12/750-net-sfp-add-quirk-for-FlyPro-10Gbase-T-module.patch
+++ b/target/linux/generic/pending-6.12/750-net-sfp-add-quirk-for-FlyPro-10Gbase-T-module.patch
@@ -1,0 +1,28 @@
+From ddbf0e78a8b20ec18d314d31336a0230fdc9b394 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Sun, 31 Aug 2025 12:59:07 +0200
+Subject: net: sfp: add quirk for FLYPRO copper SFP+ module
+
+Add quirk for a copper SFP that identifies itself as "FLYPRO"
+"SFP-10GT-CS-30M". It uses RollBall protocol to talk to the PHY.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Reviewed-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Link: https://patch.msgid.link/20250831105910.3174-1-olek2@wp.pl
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/sfp.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -474,6 +474,9 @@ static const struct sfp_quirk sfp_quirks
+ 	SFP_QUIRK("ALCATELLUCENT", "3FE46541AA", sfp_quirk_2500basex,
+ 		  sfp_fixup_nokia),
+ 
++	// FLYPRO SFP-10GT-CS-30M uses Rollball protocol to talk to the PHY.
++	SFP_QUIRK_F("FLYPRO", "SFP-10GT-CS-30M", sfp_fixup_rollball),
++
+ 	// Fiberstore SFP-10G-T doesn't identify as copper, uses the Rollball
+ 	// protocol to talk to the PHY and needs 4 sec wait before probing the
+ 	// PHY.

--- a/target/linux/generic/pending-6.6/750-net-sfp-add-quirk-for-FlyPro-10Gbase-T-module.patch
+++ b/target/linux/generic/pending-6.6/750-net-sfp-add-quirk-for-FlyPro-10Gbase-T-module.patch
@@ -1,0 +1,28 @@
+From ddbf0e78a8b20ec18d314d31336a0230fdc9b394 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Sun, 31 Aug 2025 12:59:07 +0200
+Subject: net: sfp: add quirk for FLYPRO copper SFP+ module
+
+Add quirk for a copper SFP that identifies itself as "FLYPRO"
+"SFP-10GT-CS-30M". It uses RollBall protocol to talk to the PHY.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Reviewed-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Link: https://patch.msgid.link/20250831105910.3174-1-olek2@wp.pl
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/sfp.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -459,6 +459,9 @@ static const struct sfp_quirk sfp_quirks
+ 	SFP_QUIRK("ALCATELLUCENT", "3FE46541AA", sfp_quirk_2500basex,
+ 		  sfp_fixup_long_startup),
+ 
++	// FLYPRO SFP-10GT-CS-30M uses Rollball protocol to talk to the PHY.
++	SFP_QUIRK_F("FLYPRO", "SFP-10GT-CS-30M", sfp_fixup_rollball),
++
+ 	// Fiberstore SFP-10G-T doesn't identify as copper, uses the Rollball
+ 	// protocol to talk to the PHY and needs 4 sec wait before probing the
+ 	// PHY.

--- a/target/linux/realtek/patches-6.12/714-net-phy-sfp-add-support-for-SMBus.patch
+++ b/target/linux/realtek/patches-6.12/714-net-phy-sfp-add-support-for-SMBus.patch
@@ -10,7 +10,7 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -691,10 +691,64 @@ static int sfp_i2c_write(struct sfp *sfp
+@@ -694,10 +694,64 @@ static int sfp_i2c_write(struct sfp *sfp
  	return ret == ARRAY_SIZE(msgs) ? len : 0;
  }
  
@@ -77,7 +77,7 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
  
  	sfp->i2c = i2c;
  	sfp->read = sfp_i2c_read;
-@@ -726,6 +780,29 @@ static int sfp_i2c_mdiobus_create(struct
+@@ -729,6 +783,29 @@ static int sfp_i2c_mdiobus_create(struct
  	return 0;
  }
  
@@ -107,7 +107,7 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
  static void sfp_i2c_mdiobus_destroy(struct sfp *sfp)
  {
  	mdiobus_unregister(sfp->i2c_mii);
-@@ -1900,9 +1977,15 @@ static void sfp_sm_fault(struct sfp *sfp
+@@ -1903,9 +1980,15 @@ static void sfp_sm_fault(struct sfp *sfp
  
  static int sfp_sm_add_mdio_bus(struct sfp *sfp)
  {


### PR DESCRIPTION
Backport quirks for two SFP+ modules. Both support the RollBall protocol. The fix for the FLYPRO module is queued in net-next tree.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>