### PR TITLE
mediatek: add support for AsiaRF AP7622-WH1

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7622
@@ -17,6 +17,9 @@ ubootenv_add_mmc_default() {
 board=$(board_name)
 
 case "$board" in
+asiarf,ap7622-wh1)
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x1000" "0x10000"
+	;;
 dlink,eagle-pro-ai-m32-a1|\
 dlink,eagle-pro-ai-r32-a1)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x2000" "0x2000"

--- a/target/linux/mediatek/dts/mt7622-asiarf-ap7622-wh1.dts
+++ b/target/linux/mediatek/dts/mt7622-asiarf-ap7622-wh1.dts
@@ -1,0 +1,515 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 AsiaRF Co., Ltd
+ * Author: Elwin Huang <elwin@asiarf.com>
+ */
+
+/dts-v1/;
+#include "mt7622.dtsi"
+#include "mt6380.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "AsiaRF AP7622 WH1";
+	compatible = "asiarf,ap7622-wh1", "mediatek,mt7622";
+	
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+	
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8 swiotlb=512";
+	};
+	
+	cpus {
+		cpu@0 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+		
+		cpu@1 {
+			proc-supply = <&mt6380_vcpu_reg>;
+			sram-supply = <&mt6380_vm_reg>;
+		};
+	};
+	
+	mmc1_pwrseq: mmc1_pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		reset-gpios = <&pio 97 GPIO_ACTIVE_LOW>;
+		post-power-on-delay-ms = <200>;
+	};
+	
+	gpio-keys {
+		compatible = "gpio-keys";
+		
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+		
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
+		};
+	};
+	
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;// 512MiB
+		device_type = "memory";
+	};
+	
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+	
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+	
+	gpio-leds {
+		compatible = "gpio-leds";
+		status = "okay";
+		
+		led_power: power {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 101 GPIO_ACTIVE_HIGH>;
+		};
+		
+		wlan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&pio 85 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&bch {
+	status = "okay";
+};
+
+&rtc {
+	status = "disabled";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+	status = "okay";
+	
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		nvmem-cells = <&macaddr_factory_7fff4>;
+		nvmem-cell-names = "mac-address";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+	
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		
+		switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			#interrupt-cells = <1>;
+			interrupt-controller;
+			interrupt-parent = <&pio>;
+			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+			
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				
+				port@0 {
+					reg = <0>;
+					label = "lan1";
+				};
+				
+				port@1 {
+					reg = <1>;
+					label = "lan2";
+				};
+				
+				port@2 {
+					reg = <2>;
+					label = "lan3";
+				};
+				
+				port@3 {
+					reg = <3>;
+					label = "lan4";
+				};
+				
+				port@4 {
+					reg = <4>;
+					label = "wan";
+					nvmem-cells = <&macaddr_factory_7fffa>;
+					nvmem-cell-names = "mac-address";
+				};
+				
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+					
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+		
+	};
+};
+
+&mmc1 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&sd0_pins_default>;
+	pinctrl-1 = <&sd0_pins_uhs>;
+	status = "okay";
+	bus-width = <4>;
+	max-frequency = <50000000>;
+	cap-sd-highspeed;
+	vmmc-supply = <&reg_3p3v>;
+	vqmmc-supply = <&reg_3p3v>;
+	assigned-clocks = <&topckgen CLK_TOP_MSDC30_1_SEL>;
+	assigned-clock-parents = <&topckgen CLK_TOP_UNIV48M>;
+	
+	cap-mmc-highspeed;
+	cap-sdio-irq;
+	non-removable;
+	disable-wp;
+	drv-type = <2>;
+	mmc-pwrseq = <&mmc1_pwrseq>;
+	
+	#address-cells = <1>;
+	#size-cells = <0>;
+	mm6108_sdio@0 {
+		compatible = "morse,mm610x";
+		reset-gpios = <&pio 97 GPIO_ACTIVE_HIGH>;
+		power-gpios = <&pio 98 GPIO_ACTIVE_HIGH>,
+			<&pio 99 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+		reg = <2>;
+		bus-width = <4>;
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	status = "okay";
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_pins>;
+	status = "okay";
+};
+
+&pio {
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio", "rgmii_via_gmac2";
+		};
+	};
+	
+	pcie0_pins: pcie0-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie0_pad_perst",
+			"pcie0_1_waken",
+			"pcie0_1_clkreq";
+		};
+	};
+	
+	pcie1_pins: pcie1-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie1_pad_perst",
+			"pcie1_0_waken",
+			"pcie1_0_clkreq";
+		};
+	};
+	
+	pmic_bus_pins: pmic-bus-pins {
+		mux {
+			function = "pmic";
+			groups = "pmic_bus";
+		};
+	};
+	
+	wled_pins: wled-pins {
+		mux {
+			function = "led";
+			groups = "wled";
+		};
+	};
+	
+	sd0_pins_default: sd0-pins-default {
+		mux {
+			function = "sd";
+			groups = "sd_0";
+		};
+		
+		/* "I2S2_OUT, "I2S4_IN"", "I2S3_IN", "I2S2_IN",
+		*  "I2S4_OUT", "I2S3_OUT" are used as DAT0, DAT1,
+		*  DAT2, DAT3, CMD, CLK for SD respectively.
+		*/
+		conf-cmd-data {
+			pins = "I2S2_OUT", "I2S4_IN", "I2S3_IN",
+			"I2S2_IN","I2S4_OUT";
+			input-enable;
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+		conf-clk {
+			pins = "I2S3_OUT";
+			drive-strength = <12>;
+			bias-pull-down;
+		};
+		conf-cd {
+			pins = "TXD3";
+			bias-pull-up;
+		};
+	};
+	
+	sd0_pins_uhs: sd0-pins-uhs {
+		mux {
+			function = "sd";
+			groups = "sd_0";
+		};
+		
+		conf-cmd-data {
+			pins = "I2S2_OUT", "I2S4_IN", "I2S3_IN",
+			"I2S2_IN","I2S4_OUT";
+			input-enable;
+			bias-pull-up;
+		};
+		
+		conf-clk {
+			pins = "I2S3_OUT";
+			bias-pull-down;
+		};
+	};
+	
+	/* Serial NAND is shared pin with SPI-NOR */
+	serial_nand_pins: serial-nand-pins {
+		mux {
+			function = "flash";
+			groups = "snfi";
+		};
+	};
+	
+	spic0_pins: spic0-pins {
+		mux {
+			function = "spi";
+			groups = "spic0_0";
+		};
+	};
+	
+	spic1_pins: spic1-pins {
+		mux {
+			function = "spi";
+			groups = "spic1_0";
+		};
+	};
+	
+	uart0_pins: uart0-pins {
+		mux {
+			function = "uart";
+			groups = "uart0_0_tx_rx";
+		};
+	};
+	
+	uart2_pins: uart2-pins {
+		mux {
+			function = "uart";
+			groups = "uart2_1_tx_rx";
+		};
+	};
+	
+	watchdog_pins: watchdog-pins {
+		mux {
+			function = "watchdog";
+			groups = "watchdog";
+		};
+	};
+};
+
+&pwrap {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pmic_bus_pins>;
+	status = "okay";
+};
+
+&snfi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&serial_nand_pins>;
+	status = "okay";
+	
+	flash@0 {
+		compatible = "spi-nand";
+		mediatek,bmt-table-size = <0x1000>;
+		mediatek,bmt-v2;
+		nand-ecc-engine = <&snfi>;
+		reg = <0>;
+		spi-rx-bus-width = <4>;
+		spi-tx-bus-width = <4>;
+		
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			
+			partition@0 {
+				label = "Preloader";
+				reg = <0x00000 0x0080000>;
+				read-only;
+			};
+			
+			partition@80000 {
+				label = "ATF";
+				reg = <0x80000 0x0040000>;
+				read-only;
+			};
+			
+			partition@c0000 {
+				label = "Bootloader";
+				reg = <0xc0000 0x0080000>;
+				read-only;
+			};
+			
+			partition@140000 {
+				label = "Config";
+				reg = <0x140000 0x0080000>;
+			};
+			
+			partition@1c0000 {
+				label = "Factory";
+				reg = <0x1c0000 0x0100000>;
+				read-only;
+				
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					factory_eeprom: eeprom@0 {
+						reg = <0x0 0x5000>;
+					};
+					
+					macaddr_factory_7fff4: macaddr@7fff4 {
+						reg = <0x7fff4 0x6>;
+					};
+					
+					macaddr_factory_7fffa: macaddr@7fffa {
+						reg = <0x7fffa 0x6>;
+					};
+				};
+			};
+			
+			partition@2c0000 {
+				label = "firmware";
+				reg = <0x2c0000 0x2000000>;// 32 MiB
+				
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				
+				partition@0 {
+					label = "kernel";
+					reg = <0x0 0x0800000>;
+				};
+				
+				partition@600000 {
+					label = "ubi";
+					reg = <0x800000 0x1800000>;
+				};
+			};
+			
+			partition@22c0000 {
+				label = "User_data";
+				reg = <0x22c0000 0x5300000>;
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spic0_pins>;
+	status = "okay";
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spic1_pins>;
+	status = "okay";
+};
+
+&ssusb {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+	status = "okay";
+};
+
+&u3phy {
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart2_pins>;
+	status = "okay";
+};
+
+&watchdog {
+	pinctrl-names = "default";
+	pinctrl-0 = <&watchdog_pins>;
+	status = "okay";
+};
+
+&wmac {
+	nvmem-cells = <&factory_eeprom>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+};

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -52,6 +52,25 @@ define Build/mt7622-gpt
 	rm $@.tmp
 endef
 
+define Device/asiarf_ap7622-wh1
+  DEVICE_VENDOR := AsiaRF
+  DEVICE_MODEL := AP7622-WH1
+  DEVICE_DTS := mt7622-asiarf-ap7622-wh1
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-ata-ahci-mtk kmod-btmtkuart kmod-usb3
+  BOARD_NAME := asiarf,ap7622-wh1
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 8192k
+  IMAGE_SIZE := 32768k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+          append-ubi | check-size
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += asiarf_ap7622-wh1
+
 define Device/smartrg_sdg-841-t6
   DEVICE_VENDOR := Adtran
   DEVICE_DTS_DIR := ../dts


### PR DESCRIPTION
**<h1>Specification:</h1>**

- SoC           : MediaTek MT7622A, dual-core 1.35 Ghz ARM Cortex-A53 CPU
- RAM           : DDR3 512 MiB (Nanya NT5CC256M16ER-EKI)
- Flash         : SPI-NAND 128 MiB (Winbond W25N01GVZEIG)
- Ethernet      : 5 port Switch
  - LAN : 
      4x 10/100/1000 Mbps RJ-45 Port
  - WAN :
      1x 10/100/1000 Mbps RJ-45 Port
- LED           : 10x LEDs
    1x Power (Blue, GPIO)
    1x WiFi (Green, GPIO)
    2x MiniPCIe (Orange)
    1x M.2 B Key (Red)
    5x Ethernet activity (White)
- UART          : 1x4 pin header on PCB [J19]
  - arrangement : 3.3V, TX, RX, GND
  - settings    : 115200, 8n1
- Button        : 2x (Reset, WPS)
- GPS           : 1x (Quectel L76-L)
- WiFi          : 2x
    WiFi 4 (MediaTek MT7622A)
    WiFI HaLow (AsiaRF MM610X-001)
- BT            : BT 4.2/BLE 5.0 (MediaTek MT7622A)
- Socket        : 
    2x MiniPCIe (PCIe Gen2 + USB 2.0) with extra SPI interface (NI)
    1x M.2 B key (USB 3.0)
    1x SIM Card
    1x USB-A (USB 2.0)
- Power         : 12V DC, 1A

| Interface  | Mac Address | Read Address |
| ------------- | ------------- | ------------- | 
| WLAN  | 00:0A:52:xx:xx:xx  | Factory, 0x6 |
| LAN  | 00:0A:52:xx:xx:xx  | Factory, 0x7fff4 |
| WAN  | 00:0A:52:xx:xx:xx  | Factory, 0x7fffa |

**Note:** To use SPI interface on mPCIe slot, weld 4x 0402 0R resistors on [R832-835] or [R960-963]
mPCIe mapping:
    45# - SPI_CLK
    47# - SPI_MISO
    49# - SPI_MOSI
    51# - SPI_CSN

<h2>Bootlog</h2>
<details>

<summary>Factory Bootlog</summary>

```
F0: 102B 0000
F6: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 0000 0041 [0000]
G0: 0190 0000
T0: 0000 0364 [000F]
Jump to BL

UNIVPLL_CON0 = 0xFE000000!!!
mt_pll_init: Set pll frequency for 25M crystal
RAM_CONSOLE preloader last status: 0x0 0x0 0x0 0x0 0x0 0x0 
[PMIC_WRAP]wrap_init pass,the return value=0.
[pmic_init] Preloader Start..................
[pmic_init] MT6380 CHIP Code, reg_val = 0, 1:E2  0:E3
[pmic_init] Done...................
Chip part number:7622A
MT7622 Version: 1.2.7, (iPA) 
SSC OFF
mt_pll_post_init: mt_get_cpu_freq = 1350000Khz
mt_pll_post_init: mt_get_mem_freq = 1600000Khz
mt_pll_post_init: mt_get_bus_freq = 1119920Khz
[PLFM] Init I2C: OK(0)

[BLDR] Build Time: 20180503-103334
==== Dump RGU Reg ========
RGU MODE:     14
RGU LENGTH:   FFE0
RGU STA:      40000000
RGU INTERVAL: FFF
RGU SWSYSRST: 8000
==== Dump RGU Reg End ====
RGU: g_rgu_satus:2
 mtk_wdt_mode_config  mode value=10, tmp:22000010
PL RGU RST: ??
SW reset with bypass power key flag
Find bypass powerkey flag
WDT NONRST=0x20000000
WDT IRQ_EN=0x340003
RGU mtk_wdt_init:MTK_WDT_DEBUG_CTL(590200F3)
[EMI] MDL number = 2
[EMI] DRAMC calibration start

[EMI] DRAMC calibration end

[EMI]rank size auto detect
[EMI]rank0 size: 0x20000000
[MEM] complex R/W mem test pass
RAM_CONSOLE wdt status (0x2)=0x2
[SNF] [Cheng] ECC Control (1: Enable, 0: Disable) : 0

[SNF] Unlock all blocks ...

[SNF] Lock register(before). lock:0x0 

[SNF] Lock register (after) new lock: 0

[BBT] BMT.v2 is found at 0x3FF
[SNF] Unlock all blocks ...

[SNF] Lock register(before). lock:0x0 

[SNF] Lock register (after) new lock: 0

[PLFM] Init Boot Device: OK(0)

[PART] blksz: 2048B
[PART] [0x0000000000000000-0x000000000007FFFF] "PRELOADER" (256 blocks) 
[PART] [0x0000000000080000-0x00000000000BFFFF] "tee1" (128 blocks) 
[PART] [0x00000000000C0000-0x000000000013FFFF] "lk" (256 blocks) 

Device APC domain init setup:

Domain Setup (0x0)
Domain Setup (0x0)
Device APC domain after setup:
Domain Setup (0x0)
Domain Setup (0x0)
Bad_Block_Table init, sizeof(Bad_Block_Table)= 8192 
[PART] Image with part header
[PART] name : U-Boot
[PART] addr : 41E00000h mode : -1
[PART] size : 337496
[PART] magic: 58881688h

[PART] load "lk" from 0x00000000000C0200 (dev) to 0x41E00000 (mem) [SUCCESS]
[PART] load speed: 10298KB/s, 337496 bytes, 32ms
load lk (ret=0)
[PART] Image with part header
[PART] name : atf
[PART] addr : FFFFFFFFh mode : -1
[PART] size : 57936
[PART] magic: 58881688h

[PART] load "tee1" from 0x0000000000080200 (dev) to 0x43000DC0 (mem) [SUCCESS]
[PART] load speed: 9429KB/s, 57936 bytes, 6ms
load tee1 (ret=0)
[BLDR] bldr load tee part ret=0x0, addr=0x43001000
[BLDR] boot part. not found
[BLDR] part_load_images ret=0x0
[BLDR] Others, jump to ATF

[BLDR] jump to 0x41E00000
[BLDR] <0x41E00000>=0xEA00000F
[BLDR] <0x41E00004>=0xE59FF014


U-Boot 2014.04-rc1 (Apr 19 2024 - 06:52:33)

auto detection g_total_rank_size = 0x1F000000
DRAM:  496 MiB
NAND:  Recognize SNAND: ID [ef aa 21 ], Device Name [Winbond 1Gb], Page Size [2048]B Spare Size [64]B Total Size [128]MB
[mtk_snand] probe successfully!
[BBT] BMT.v2 is found at 0x3ff
128 MiB
In:    serial
Out:   serial
Err:   serial
Net:   mtk_eth
Uip activated
  *** U-Boot SPI NAND ***  Press UP/DOWN to move or Press 1~9,a~b to choose, ENTER to select     1. System Load Linux to SDRAM via TFTP.     2. System Load Linux Kernel then write to Flash via TFTP.     3. Boot system code via Flash.     4. System Load U-Boot then write to Flash via TFTP.     5. System Load U-Boot then write to Flash via Serial.     6. System Load ATF then write to Flash via TFTP.     7. System Load Preloader then write to Flash via TFTP.     8. System Load ROM header then write to Flash via TFTP.     9. System Load CTP then write to Flash via TFTP.     a. System Load CTP then Boot to CTP (via Flash).     b. System Load SingleImage then write to Flash via TFTP.     U-Boot console  Hit any key to stop autoboot:  3  2  1  0 
NAND read: device 0 offset 0x2c0000, size 0x2000
 8192 bytes read: OK
[do_read_image_blks] This is a FIT image,img_size = 0x44d620
[do_read_image_blks] img_blks = 0x89b
[do_read_image_blks] img_align_size = 0x44d800

NAND read: device 0 offset 0x2c0000, size 0x44d800
 4511744 bytes read: OK
bootm flag=0, states=70f
## Loading kernel from FIT Image at 4007ff28 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.12.44
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x40080010
     Data Size:    4477611 Bytes = 4.3 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x44000000
     Entry Point:  0x44000000
     Hash algo:    crc32
     Hash value:   a9329cce
     Hash algo:    sha1
     Hash value:   5e474e365897ca8a815265b0b717adc2a147ebfc
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 4007ff28 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt asiarf_ap7622-wh1 device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x404c5400
     Data Size:    31742 Bytes = 31 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   7209ddf0
     Hash algo:    sha1
     Hash value:   f1ec5d1520a507f79bef2681dc3c34d2cf379977
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x404c5400
   Uncompressing Kernel Image ... OK
   Loading Device Tree to 5cf4c000, end 5cf56bfd ... OK

Starting kernel ...

[ATF][     5.526851]save kernel info
[ATF][     5.529788]Kernel_EL2
[ATF][     5.532458]Kernel is 64Bit
[ATF][     5.535547]pc=0x44000000, r0=0x5cf4c000, r1=0x0
INFO:    BL3-1: Preparing for EL3 exit to normal world, Kernel
INFO:    BL3-1: Next image address = 0x44000000
INFO:    BL3-1: Next image spsr = 0x3c9
[ATF][     5.553245]el3_exit
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.12.44 (elwin@elwin-B760M-DS3H-AX) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r30959-b4294bc980) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Thu Sep  4 21:50:17 2025
[    0.000000] Machine model: AsiaRF AP7622 WH1
[    0.000000] earlycon: uart8250 at MMIO32 0x0000000011002000 (options '')
[    0.000000] printk: legacy bootconsole [uart8250] enabled
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004302ffff (192 KiB) nomap non-reusable secmon@43000000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000005fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004302ffff]
[    0.000000]   node   0: [mem 0x0000000043030000-0x000000005fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000005fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv0.2 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: Trusted OS migration not required
[    0.000000] percpu: Embedded 20 pages/cpu s42520 r8192 d31208 u81920
[    0.000000] pcpu-alloc: s42520 r8192 d31208 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] CPU features: detected: ARM erratum 843419
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8 swiotlb=512
[    0.000000] Dentry cache hash table entries: 65536 (order: 7, 524288 bytes, linear)
[    0.000000] Inode-cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 131072
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: area num 2.
[    0.000000] software IO TLB: mapped [mem 0x000000005f4c0000-0x000000005f5c0000] (1MB)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GIC: Using split EOI/Deactivate mode
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 12.50MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2e2049cda, max_idle_ns: 440795202628 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 80ns, wraps every 4398046511080ns
[    0.008277] Calibrating delay loop (skipped), value calculated using timer frequency.. 25.00 BogoMIPS (lpj=125000)
[    0.018676] pid_max: default: 32768 minimum: 301
[    0.026156] Mount-cache hash table entries: 1024 (order: 1, 8192 bytes, linear)
[    0.033502] Mountpoint-cache hash table entries: 1024 (order: 1, 8192 bytes, linear)
[    0.044239] rcu: Hierarchical SRCU implementation.
[    0.049053] rcu: 	Max phase no-delay instances is 1000.
[    0.054472] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.062815] smp: Bringing up secondary CPUs ...
[    0.067769] Detected VIPT I-cache on CPU1
[    0.067851] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.067927] smp: Brought up 1 node, 2 CPUs
[    0.082610] SMP: Total of 2 processors activated.
[    0.087327] CPU: All CPU(s) started at EL2
[    0.091436] CPU features: detected: 32-bit EL0 Support
[    0.096590] CPU features: detected: CRC32 instructions
[    0.101770] alternatives: applying system-wide alternatives
[    0.107497] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.115998] Memory: 496920K/524288K available (9344K kernel code, 924K rwdata, 2712K rodata, 448K init, 306K bss, 25528K reserved, 0K cma-reserved)
[    0.133179] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.143087] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.149965] 29296 pages in range for non-PLT usage
[    0.149969] 520816 pages in range for PLT usage
[    0.156241] pinctrl core: initialized pinctrl subsystem
[    0.167164] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.173385] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.180495] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.188284] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.196659] thermal_sys: Registered thermal governor 'fair_share'
[    0.196664] thermal_sys: Registered thermal governor 'bang_bang'
[    0.202776] thermal_sys: Registered thermal governor 'step_wise'
[    0.208810] thermal_sys: Registered thermal governor 'user_space'
[    0.214900] ASID allocator initialised with 65536 entries
[    0.226806] pstore: Using crash dump compression: deflate
[    0.232233] pstore: Registered ramoops as persistent store backend
[    0.238433] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.251535] /pcie@1a143000: Fixed dependency cycle(s) with /pcie@1a143000/interrupt-controller
[    0.260538] /pcie@1a145000: Fixed dependency cycle(s) with /pcie@1a145000/interrupt-controller
[    0.281610] cryptd: max_cpu_qlen set to 1000
[    0.288386] SCSI subsystem initialized
[    0.292455] libata version 3.00 loaded.
[    0.297697] clocksource: Switched to clocksource arch_sys_counter
[    0.306041] NET: Registered PF_INET protocol family
[    0.311062] IP idents hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.319487] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.327886] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.335663] TCP established hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.343466] TCP bind hash table entries: 4096 (order: 5, 131072 bytes, linear)
[    0.350820] TCP: Hash tables configured (established 4096 bind 4096)
[    0.357497] MPTCP token hash table entries: 512 (order: 1, 12288 bytes, linear)
[    0.364939] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.371508] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.378680] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.384379] PCI: CLS 0 bytes, default 64
[    0.389321] workingset: timestamp_bits=46 max_order=17 bucket_order=0
[    0.400665] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.406520] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.480452] mt-pmic-pwrap 10001000.pwrap: unexpected interrupt int=0x1
[    0.493698] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.501237] printk: legacy console [ttyS0] disabled
[    0.526518] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 118, base_baud = 1562500) is a ST16650V2
[    0.535837] printk: legacy console [ttyS0] enabled
[    0.535837] printk: legacy console [ttyS0] enabled
[    0.545428] printk: legacy bootconsole [uart8250] disabled
[    0.545428] printk: legacy bootconsole [uart8250] disabled
[    0.577492] 11004000.serial: ttyS1 at MMIO 0x11004000 (irq = 119, base_baud = 1562500) is a ST16650V2
[    0.587827] mtk_rng 1020f000.rng: registered RNG driver
[    0.588058] random: crng init done
[    0.599347] loop: module loaded
[    0.602953] mtk-ecc 1100e000.ecc: probed
[    0.609607] spi-nand spi2.0: Winbond SPI NAND was found.
[    0.614929] spi-nand spi2.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.623128] mtk-snand 1100d000.spi: ECC strength: 4 bits per 512 bytes
[    0.630996] [BBT] BMT.v2 is found at 0x3ff
[    0.635241] 7 fixed-partitions partitions found on MTD device spi2.0
[    0.641620] OF: Bad cell count for /spi@1100d000/flash@0/partitions
[    0.648015] OF: Bad cell count for /spi@1100d000/flash@0/partitions
[    0.654465] Creating 7 MTD partitions on "spi2.0":
[    0.659274] 0x000000000000-0x000000080000 : "Preloader"
[    0.665374] 0x000000080000-0x0000000c0000 : "ATF"
[    0.670590] 0x0000000c0000-0x000000140000 : "Bootloader"
[    0.676642] 0x000000140000-0x0000001c0000 : "Config"
[    0.682369] 0x0000001c0000-0x0000002c0000 : "Factory"
[    0.688761] OF: Bad cell count for /spi@1100d000/flash@0/partitions
[    0.695198] 0x0000002c0000-0x0000022c0000 : "firmware"
[    0.734456] 2 fixed-partitions partitions found on MTD device firmware
[    0.740990] Creating 2 MTD partitions on "firmware":
[    0.745949] 0x000000000000-0x000000800000 : "kernel"
[    0.751296] 0x000000800000-0x000002000000 : "ubi"
[    0.756278] 0x0000022c0000-0x0000075c0000 : "User_data"
[    0.971499] mtk_soc_eth 1b100000.ethernet eth0: mediatek frame engine at 0xffffffc081360000, irq 126
[    0.981353] i2c_dev: i2c /dev entries driver
[    0.986946] mtk-wdt 10212000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    0.996809] NET: Registered PF_INET6 protocol family
[    0.996910] mtk-msdc 11240000.mmc: allocated mmc-pwrseq
[    1.008337] Segment Routing with IPv6
[    1.012030] In-situ OAM (IOAM) with IPv6
[    1.015989] NET: Registered PF_PACKET protocol family
[    1.021252] 8021q: 802.1Q VLAN Support v1.8
[    1.047300] mtk-pcie 1a143000.pcie: host bridge /pcie@1a143000 ranges:
[    1.053906] mtk-pcie 1a143000.pcie: Parsing ranges property...
[    1.059752] mtk-pcie 1a143000.pcie:      MEM 0x0020000000..0x0027ffffff -> 0x0020000000
[    1.241539] mtk-msdc 11240000.mmc: msdc_track_cmd_data: cmd=52 arg=00000C00; host->error=0x00000002
[    1.251196] mtk-msdc 11240000.mmc: msdc_track_cmd_data: cmd=52 arg=80000C08; host->error=0x00000002
[    1.277044] mmc0: new high speed SDIO card at address 0001
[    1.387736] mtk-pcie 1a143000.pcie: Port0 link down
[    1.392983] mtk-pcie 1a143000.pcie: PCI host bridge to bus 0000:00
[    1.399187] pci_bus 0000:00: root bus resource [bus 00-ff]
[    1.404671] pci_bus 0000:00: root bus resource [mem 0x20000000-0x27ffffff]
[    1.411552] pci_bus 0000:00: scanning bus
[    1.416973] pci_bus 0000:00: fixups for bus
[    1.421156] pci_bus 0000:00: bus scan returning with max=00
[    1.426726] pci_bus 0000:00: resource 4 [mem 0x20000000-0x27ffffff]
[    1.433453] mtk-pcie 1a145000.pcie: host bridge /pcie@1a145000 ranges:
[    1.440005] mtk-pcie 1a145000.pcie: Parsing ranges property...
[    1.445836] mtk-pcie 1a145000.pcie:      MEM 0x0028000000..0x002fffffff -> 0x0028000000
[    1.767746] mtk-pcie 1a145000.pcie: Port1 link down
[    1.772802] mtk-pcie 1a145000.pcie: PCI host bridge to bus 0001:00
[    1.779007] pci_bus 0001:00: root bus resource [bus 00-ff]
[    1.784495] pci_bus 0001:00: root bus resource [mem 0x28000000-0x2fffffff]
[    1.791373] pci_bus 0001:00: scanning bus
[    1.796552] pci_bus 0001:00: fixups for bus
[    1.800734] pci_bus 0001:00: bus scan returning with max=00
[    1.806304] pci_bus 0001:00: resource 4 [mem 0x28000000-0x2fffffff]
[    1.813205] mtk_hsdma 1b007000.dma-controller: MediaTek HSDMA driver registered
[    1.881492] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.890788] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.904129] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=133)
[    1.928962] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=134)
[    1.953441] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=135)
[    1.977908] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=136)
[    2.002590] mt7530-mdio mdio-bus:1f wan (uninitialized): PHY [mt7530-0:04] driver [MediaTek MT7531 PHY] (irq=137)
[    2.013701] mtk_soc_eth 1b100000.ethernet eth0: entered promiscuous mode
[    2.020434] DSA: tree 0 setup
[    2.023754] UBI: auto-attach mtd7
[    2.027071] ubi0: default fastmap pool size: 8
[    2.031563] ubi0: default fastmap WL pool size: 4
[    2.036260] ubi0: attaching mtd7
[    2.158451] ubi0: scanning is finished
[    2.166435] ubi0: attached mtd7 (name "ubi", size 24 MiB)
[    2.171884] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    2.178772] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.185558] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.192526] ubi0: good PEBs: 192, bad PEBs: 0, corrupted PEBs: 0
[    2.198539] ubi0: user volume: 2, internal volumes: 1, max. volumes count: 128
[    2.205759] ubi0: max/mean erase counter: 2/0, WL threshold: 4096, image sequence number: 1757022617
[    2.214897] ubi0: available PEBs: 0, total reserved PEBs: 192, PEBs reserved for bad PEB handling: 19
[    2.224144] ubi0: background thread "ubi_bgt0d" started, PID 643
[    2.230650] block ubiblock0_0: created from ubi0:0(rootfs)
[    2.236131] ubiblock: device ubiblock0_0 (rootfs) set to be root filesystem
[    2.243222] clk: Disabling unused clocks
[    2.247425] PM: genpd: Disabling unused power domains
[    2.255996] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[    2.263364] Freeing unused kernel memory: 448K
[    2.267849] Run /sbin/init as init process
[    2.271937]   with arguments:
[    2.274895]     /sbin/init
[    2.277592]   with environment:
[    2.280733]     HOME=/
[    2.283084]     TERM=linux
[    2.464576] init: Console is alive
[    2.468116] init: - watchdog -
[    3.000617] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.030773] usbcore: registered new interface driver usbfs
[    3.036300] usbcore: registered new interface driver hub
[    3.041687] usbcore: registered new device driver usb
[    3.047477] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    3.063331] xhci-mtk 1a0c0000.usb: xHCI Host Controller
[    3.068616] xhci-mtk 1a0c0000.usb: new USB bus registered, assigned bus number 1
[    3.077679] xhci-mtk 1a0c0000.usb: hcc params 0x01403198 hci version 0x96 quirks 0x0000000000200010
[    3.086770] xhci-mtk 1a0c0000.usb: irq 138, io mem 0x1a0c0000
[    3.092634] xhci-mtk 1a0c0000.usb: xHCI Host Controller
[    3.097876] xhci-mtk 1a0c0000.usb: new USB bus registered, assigned bus number 2
[    3.105272] xhci-mtk 1a0c0000.usb: Host supports USB 3.0 SuperSpeed
[    3.111966] hub 1-0:1.0: USB hub found
[    3.115732] hub 1-0:1.0: 2 ports detected
[    3.120061] usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
[    3.128486] hub 2-0:1.0: USB hub found
[    3.132248] hub 2-0:1.0: 1 port detected
[    3.141138] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.157590] init: - preinit -
[    3.432265] mtk_soc_eth 1b100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    3.440921] mtk_soc_eth 1b100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    3.456664] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to [    3.537788] usb 1-2: new high-speed USB device number 2 using xhci-mtk
select the debug level
[    3.689053] hub 1-2:1.0: USB hub found
[    3.692949] hub 1-2:1.0: 4 ports detected
[    7.702942] UBIFS (ubi0:1): Mounting in unauthenticated mode
[    7.708755] UBIFS (ubi0:1): background thread "ubifs_bgt0_1" started, PID 778
[    7.734014] UBIFS (ubi0:1): recovery needed
[    7.801231] UBIFS (ubi0:1): recovery completed
[    7.805762] UBIFS (ubi0:1): UBIFS: mounted UBI device 0, volume 1, name "rootfs_data"
[    7.813623] UBIFS (ubi0:1): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[    7.823550] UBIFS (ubi0:1): FS size: 13586432 bytes (12 MiB, 107 LEBs), max 117 LEBs, journal size 1015809 bytes (0 MiB, 6 LEBs)
[    7.835135] UBIFS (ubi0:1): reserved for root: 641720 bytes (626 KiB)
[    7.841584] UBIFS (ubi0:1): media format: w5/r0 (latest is w5/r0), UUID 659CCEAE-E01E-4B89-B5B3-F7BA4811A7C2, small LPT model
[    7.855177] mount_root: switching to ubifs overlay
[    7.863385] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[    7.876709] urandom-seed: Seeding with /etc/urandom.seed
[    7.936792] procd: - early -
[    7.939873] procd: - watchdog -
[    8.495317] procd: - watchdog -
[    8.499547] procd: - ubus -
[    8.654731] procd: - init -
Please press Enter to activate this console.
[    8.984129] kmodloader: loading kernel modules from /etc/modules.d/*
[    9.004716] hid: raw HID events driver (C) Jiri Kosina
[    9.022820] Bluetooth: Core ver 2.22
[    9.026500] NET: Registered PF_BLUETOOTH protocol family
[    9.031850] Bluetooth: HCI device and connection manager initialized
[    9.038218] Bluetooth: HCI socket layer initialized
[    9.043091] Bluetooth: L2CAP socket layer initialized
[    9.048161] Bluetooth: SCO socket layer initialized
[    9.054541] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
[    9.059953] Bluetooth: BNEP filters: protocol multicast
[    9.065180] Bluetooth: BNEP socket layer initialized
[    9.072582] Loading modules backported from Linux version v6.16-0-g038d61fd6422
[    9.079932] Backport generated by backports.git v6.1.145-1-47-g6194bf852a3e
[    9.088511] Bluetooth: HIDP (Human Interface Emulation) ver 1.2
[    9.094453] Bluetooth: HIDP socket layer initialized
[    9.106467] Bluetooth: RFCOMM TTY layer initialized
[    9.111403] Bluetooth: RFCOMM socket layer initialized
[    9.116550] Bluetooth: RFCOMM ver 1.11
[    9.198066] mt7622-wmac 18000000.wmac: registering led 'mt76-phy0'
[    9.230883] urngd: v1.0.2 started.
[    9.308263] ieee80211 phy0: Selected rate control algorithm 'minstrel_ht'
[    9.385709] PPP generic driver version 2.4.2
[    9.408606] NET: Registered PF_PPPOX protocol family
[    9.413765] mt7622-wmac 18000000.wmac: HW/SW Version: 0x8a108a10, Build Time: 20190801210006a
[    9.413765] 
[    9.436471] kmodloader: done loading kernel modules from /etc/modules.d/*
[    9.538157] mt7622-wmac 18000000.wmac: N9 Firmware Version: _reserved_, Build Time: 20220630094834
[   12.554580] mtk_soc_eth 1b100000.ethernet eth0: Link is Down
[   12.569722] mtk_soc_eth 1b100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   12.578625] mtk_soc_eth 1b100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   12.590503] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   12.601626] br-lan: port 1(lan1) entered blocking state
[   12.606866] br-lan: port 1(lan1) entered disabled state
[   12.612207] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   12.618498] mtk_soc_eth 1b100000.ethernet eth0: entered allmulticast mode
[   12.628270] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   12.643069] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   12.654124] br-lan: port 2(lan2) entered blocking state
[   12.659389] br-lan: port 2(lan2) entered disabled state
[   12.664641] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   12.672548] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   12.686646] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   12.697353] br-lan: port 3(lan3) entered blocking state
[   12.702589] br-lan: port 3(lan3) entered disabled state
[   12.707842] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   12.715904] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   12.729901] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   12.740598] br-lan: port 4(lan4) entered blocking state
[   12.745822] br-lan: port 4(lan4) entered disabled state
[   12.751083] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   12.759336] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode



BusyBox v1.37.0 (2025-09-04 21:50:17 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt SNAPSHOT, r30959-b4294bc980
 -----------------------------------------------------
=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------

 OpenWrt recently switched to the "apk" package manager!

 OPKG Command           APK Equivalent      Description
 ------------------------------------------------------------------
 opkg install <pkg>     apk add <pkg>       Install a package
 opkg remove <pkg>      apk del <pkg>       Remove a package
 opkg upgrade           apk upgrade         Upgrade all packages
 opkg files <pkg>       apk info -L <pkg>   List package contents
 opkg list-installed    apk info            List installed packages
 opkg update            apk update          Update package lists
 opkg search <pkg>      apk search <pkg>    Search for packages
 ------------------------------------------------------------------

For more https://openwrt.org/docs/guide-user/additional-software/opkg-to-apk-cheatsheet

root@OpenWrt:~# 
```
</details>


<h2>How to flash</h2>

**Flash instruction through LuCI:**

This device is flashed OpenWRT base firmware with this target.
The LuCI webpage is integrated in default for upgrading.

**Flash instruction through u-boot:**

1. Prepare the TFTP server on PC.
2. Connect uart to PC, select "2. System Load Linux Kernel then write to Flash via TFTP." in u-boot menu.
3. input flashed bin file path, server IP, client IP
4. Wait about 20 seconds to complete flashing

<h2>Links</h2>

[Product link](https://asiarf.com/product/enterprise-lte-wi-fi-6-halow-lora-router/)
