### PR TITLE
wifi-scripts: allow sae_password_file to be configured

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -322,7 +322,7 @@ hostapd_common_add_bss_config() {
 
 	config_add_string 'key1:wepkey' 'key2:wepkey' 'key3:wepkey' 'key4:wepkey' 'password:wpakey'
 
-	config_add_string wpa_psk_file
+	config_add_string wpa_psk_file sae_password_file
 
 	config_add_int multi_ap
 


### PR DESCRIPTION
Adds missing config_add_string for sae_password_file.

Fixes: 65a1c666f2 ("hostapd: add SAE support for wifi-station and optimize PSK file creation")
Fixes: https://github.com/openwrt/openwrt/issues/19717