### PR TITLE
mediatek: filogic: Zyxel EX5601-T0 dts fix and cleanup

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -4,11 +4,12 @@
  * Author: Sam.Shih <sam.shih@mediatek.com>
  */
 
-#include "mt7986a.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/leds/common.h>
 #include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986a.dtsi"
 
 / {
 	aliases {
@@ -192,6 +193,9 @@
 		reg = <0>;
 		phy-mode = "2500base-x";
 
+		nvmem-cells = <&macaddr_factory_2a 0>;
+		nvmem-cell-names = "mac-address";
+
 		fixed-link {
 			speed = <2500>;
 			full-duplex;
@@ -204,6 +208,9 @@
 		reg = <1>;
 		phy-mode = "2500base-x";
 		phy = <&phy6>;
+
+		nvmem-cells = <&macaddr_factory_24 0>;
+		nvmem-cell-names = "mac-address";
 	};
 
 	mdio: mdio-bus {
@@ -301,6 +308,8 @@
 	pinctrl-names = "default", "dbdc";
 	pinctrl-0 = <&wf_2g_5g_pins>;
 	pinctrl-1 = <&wf_dbdc_pins>;
+	nvmem-cells = <&eeprom_factory>;
+	nvmem-cell-names = "eeprom";
 };
 
 &crypto {
@@ -367,12 +376,12 @@
 		};
 		conf {
 			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
-			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
-			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
-			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
-			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
-			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
-			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+				"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				"WF1_TOP_CLK", "WF1_TOP_DATA";
 			drive-strength = <MTK_DRIVE_4mA>;
 		};
 	};
@@ -384,12 +393,12 @@
 		};
 		conf {
 			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
-			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
-			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
-			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
-			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
-			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
-			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+				"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				"WF1_TOP_CLK", "WF1_TOP_DATA";
 			drive-strength = <MTK_DRIVE_4mA>;
 		};
 	};

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -304,12 +304,21 @@
 };
 
 &wifi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
 	status = "okay";
 	pinctrl-names = "default", "dbdc";
 	pinctrl-0 = <&wf_2g_5g_pins>;
 	pinctrl-1 = <&wf_dbdc_pins>;
 	nvmem-cells = <&eeprom_factory>;
 	nvmem-cell-names = "eeprom";
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 1>;
+		nvmem-cell-names = "mac-address";
+	};
 };
 
 &crypto {

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -206,6 +206,7 @@
 	gmac1: mac@1 {
 		compatible = "mediatek,eth-mac";
 		reg = <1>;
+		label = "wan";
 		phy-mode = "2500base-x";
 		phy = <&phy6>;
 

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
@@ -5,19 +5,11 @@
  */
 
 /dts-v1/;
-#include "mt7986a.dtsi"
 #include "mt7986a-zyxel-ex5601-t0-common.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
 
 / {
 	model = "Zyxel EX5601-T0 (stock layout)";
 	compatible = "zyxel,ex5601-t0-stock", "mediatek,mt7986a";
-
-	memory@40000000 {
-		device_type = "memory";
-		reg = <0 0x40000000 0 0x20000000>;
-	};
 };
 
 &spi_nand {
@@ -30,18 +22,18 @@
 
 	partition@0 {
 		label = "BL2";
-		reg = <0x00000 0x0100000>;
+		reg = <0x0 0x100000>;
 		read-only;
 	};
 
 	partition@100000 {
 		label = "u-boot-env";
-		reg = <0x0100000 0x0080000>;
+		reg = <0x100000 0x80000>;
 	};
 
 	factory: partition@180000 {
 		label = "Factory";
-		reg = <0x180000 0x0200000>;
+		reg = <0x180000 0x200000>;
 		read-only;
 
 		nvmem-layout {
@@ -54,21 +46,21 @@
 				reg = <0x0 0x1000>;
 			};
 
-			macaddr_factory_0004: macaddr@4 {
+			macaddr_factory_4: macaddr@4 {
 				compatible = "mac-base";
-				reg = <0x0004 0x6>;
+				reg = <0x4 0x6>;
 				#nvmem-cell-cells = <1>;
 			};
 
-			macaddr_factory_0024: macaddr@24 {
+			macaddr_factory_24: macaddr@24 {
 				compatible = "mac-base";
-				reg = <0x0024 0x6>;
+				reg = <0x24 0x6>;
 				#nvmem-cell-cells = <1>;
 			};
 
-			macaddr_factory_002a: macaddr@2a {
+			macaddr_factory_2a: macaddr@2a {
 				compatible = "mac-base";
-				reg = <0x002a 0x6>;
+				reg = <0x2a 0x6>;
 				#nvmem-cell-cells = <1>;
 			};
 		};
@@ -76,13 +68,13 @@
 
 	partition@380000 {
 		label = "FIP";
-		reg = <0x380000 0x01C0000>;
+		reg = <0x380000 0x1c0000>;
 		read-only;
 	};
 
 	partition@540000 {
 		label = "zloader";
-		reg = <0x540000 0x0040000>;
+		reg = <0x540000 0x40000>;
 		read-only;
 	};
 
@@ -99,21 +91,6 @@
 
 	partition@8580000 {
 		label = "zyubi";
-		reg = <0x8580000 0x15A80000>;
+		reg = <0x8580000 0x15a80000>;
 	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_factory_002a 0>;
-	nvmem-cell-names = "mac-address";
-};
-
-&gmac1 {
-	nvmem-cells = <&macaddr_factory_0024 0>;
-	nvmem-cell-names = "mac-address";
-};
-
-&wifi {
-	nvmem-cells = <&eeprom_factory>;
-	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-ubootmod.dts
@@ -75,7 +75,7 @@
 
 	partition@380000 {
 		label = "fip";
-		reg = <0x380000 0x0200000>;
+		reg = <0x380000 0x01c0000>;
 		read-only;
 	};
 

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-ubootmod.dts
@@ -5,19 +5,11 @@
  */
 
 /dts-v1/;
-#include "mt7986a.dtsi"
 #include "mt7986a-zyxel-ex5601-t0-common.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
 
 / {
 	model = "Zyxel EX5601-T0 ubootmod";
 	compatible = "zyxel,ex5601-t0-ubootmod", "mediatek,mt7986a";
-
-	memory@40000000 {
-		device_type = "memory";
-		reg = <0 0x40000000 0 0x20000000>;
-	};
 
 	chosen {
 		bootargs-append = " root=/dev/fit0 rootwait";
@@ -34,13 +26,13 @@
 
 	partition@100000 {
 		label = "u-boot-env";
-		reg = <0x0100000 0x0080000>;
+		reg = <0x100000 0x80000>;
 		read-only;
 	};
 
 	factory: partition@180000 {
-		label = "Factory";
-		reg = <0x180000 0x0200000>;
+		label = "factory";
+		reg = <0x180000 0x200000>;
 		read-only;
 
 		nvmem-layout {
@@ -53,21 +45,21 @@
 				reg = <0x0 0x1000>;
 			};
 
-			macaddr_factory_0004: macaddr@4 {
+			macaddr_factory_4: macaddr@4 {
 				compatible = "mac-base";
-				reg = <0x0004 0x6>;
+				reg = <0x4 0x6>;
 				#nvmem-cell-cells = <1>;
 			};
 
-			macaddr_factory_0024: macaddr@24 {
+			macaddr_factory_24: macaddr@24 {
 				compatible = "mac-base";
-				reg = <0x0024 0x6>;
+				reg = <0x24 0x6>;
 				#nvmem-cell-cells = <1>;
 			};
 
-			macaddr_factory_002a: macaddr@2a {
+			macaddr_factory_2a: macaddr@2a {
 				compatible = "mac-base";
-				reg = <0x002a 0x6>;
+				reg = <0x2a 0x6>;
 				#nvmem-cell-cells = <1>;
 			};
 		};
@@ -75,13 +67,13 @@
 
 	partition@380000 {
 		label = "fip";
-		reg = <0x380000 0x01c0000>;
+		reg = <0x380000 0x1c0000>;
 		read-only;
 	};
 
 	partition@540000 {
 		label = "zloader";
-		reg = <0x540000 0x0040000>;
+		reg = <0x540000 0x40000>;
 		read-only;
 	};
 
@@ -96,19 +88,4 @@
 			};
 		};
 	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_factory_002a 0>;
-	nvmem-cell-names = "mac-address";
-};
-
-&gmac1 {
-	nvmem-cells = <&macaddr_factory_0024 0>;
-	nvmem-cell-names = "mac-address";
-};
-
-&wifi {
-	nvmem-cells = <&eeprom_factory>;
-	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -63,9 +63,7 @@ mediatek_setup_interfaces()
 	ruijie,rg-x60-pro|\
 	unielec,u7981-01*|\
 	zbtlink,zbt-z8102ax|\
-	zbtlink,zbt-z8102ax-v2|\
-	zyxel,ex5601-t0-stock|\
-	zyxel,ex5601-t0-ubootmod)
+	zbtlink,zbt-z8102ax-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
 		;;
 	asus,tuf-ax6000|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -209,11 +209,6 @@ case "$board" in
 	zbtlink,zbt-z8102ax|\
 	zbtlink,zbt-z8102ax-v2|\
 	zbtlink,zbt-z8103ax|\
-	zyxel,ex5601-t0-stock|\
-	zyxel,ex5601-t0-ubootmod)
-		addr=$(mtd_get_mac_binary "Factory" 0x4)
-		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
-		;;
 	wavlink,wl-wn573hx3)
 		addr=$(mtd_get_mac_binary factory 0x04)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr -0x300000) > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
1. Fix incorrect "fip" partition size.
2. Dts cleanup for Zyxel EX5601:
- duplicated code
- trailing zeros and whitespaces
3. Fix 5G MAC address
4. Add label wan and cpu