### PR TITLE
[24.10] mediatek: Huasifei WH3000 Pro wifi fix

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1042,7 +1042,7 @@ define Device/huasifei_wh3000-pro
   DEVICE_MODEL := WH3000 Pro
   DEVICE_DTS := mt7981b-huasifei-wh3000-pro
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7981-firmware mt7981-wo-firmware kmod-hwmon-pwmfan kmod-usb3 f2fsck mkf2fs
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-hwmon-pwmfan kmod-usb3 f2fsck mkf2fs
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k


### PR DESCRIPTION
typo forgot to add `kmod-mt7915e`

Fixes: db1de8d21fd7 ("mediatek: add Huasifei WH3000 Pro support")

Link: https://github.com/openwrt/openwrt/pull/19825

(cherry picked from commit 194466d52afda73c68f9c8581685e6065b43891e)

Signed-off-by: Fil Dunsky [filipp.dunsky@gmail.com](mailto:filipp.dunsky@gmail.com)
