### PR TITLE
loongarch64: switch to Linux kernel 6.12 by default

### DIFF
--- a/target/linux/loongarch64/Makefile
+++ b/target/linux/loongarch64/Makefile
@@ -10,8 +10,7 @@ BOARDNAME:=Loongson LoongArch
 FEATURES:=audio display ext4 pcie boot-part rootfs-part rtc usb targz
 SUBTARGETS:=generic
 
-KERNEL_PATCHVER:=6.6
-KERNEL_TESTING_PATCHVER:=6.12
+KERNEL_PATCHVER:=6.12
 
 KERNELNAME:=vmlinuz.efi dtbs
 


### PR DESCRIPTION
Use Linux kernel version 6.12 by default for loongarch64 target.
