### PR TITLE
mediatek: filogic: NWA50AX Pro use NVMEM for EEPROM/WiFI macaddr

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
@@ -71,7 +71,7 @@
 
 		phy-handle = <&phy0>;
 
-		nvmem-cells = <&macaddr_mrd_1fff8>;
+		nvmem-cells = <&macaddr_mrd_1fff8 0>;
 		nvmem-cell-names = "mac-address";
 	};
 };
@@ -162,10 +162,6 @@
 					precal_factory_1010:precal@1010 {
 						reg = <0x1010 0x6f010>;
 					};
-
-					macaddr: macaddr@a {
-						reg = <0xa 0x6>;
-					};
 				};
 			};
 
@@ -220,7 +216,9 @@
 					#size-cells = <1>;
 
 					macaddr_mrd_1fff8: macaddr@1fff8 {
+						compatible = "mac-base";
 						reg = <0x1fff8 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -247,5 +245,19 @@
 &wifi {
 	nvmem-cells = <&eeprom_factory_0>, <&precal_factory_1010>;
 	nvmem-cell-names = "eeprom", "precal";
+	#address-cells = <1>;
+	#size-cells = <0>;
 	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_mrd_1fff8 1>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_mrd_1fff8 2>;
+		nvmem-cell-names = "mac-address";
+	};
 };

--- a/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
@@ -155,6 +155,14 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					eeprom_factory_0:eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					precal_factory_1010:precal@1010 {
+						reg = <0x1010 0x6f010>;
+					};
+
 					macaddr: macaddr@a {
 						reg = <0xa 0x6>;
 					};
@@ -237,7 +245,7 @@
 };
 
 &wifi {
+	nvmem-cells = <&eeprom_factory_0>, <&precal_factory_1010>;
+	nvmem-cell-names = "eeprom", "precal";
 	status = "okay";
-
-	mediatek,mtd-eeprom = <&factory 0x0>;
 };

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -218,9 +218,4 @@ case "$board" in
 		addr=$(mtd_get_mac_binary factory 0x04)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr -0x300000) > /sys${DEVPATH}/macaddress
 		;;
-	zyxel,nwa50ax-pro)
-		hw_mac_addr="$(mtd_get_mac_binary mrd 0x1fff8)"
-		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
-		;;
 esac


### PR DESCRIPTION
Convert NWA50AX Pro to use NVMEM framework for EEPROM and wifi macaddr.

Also remove unused macaddr@a.

Note: ~~Currently precal for mt7981 has incorrect size and offset so skipping it in this PR.
Will add it after the mt76 fix gets accepted in upstream.~~
Now merged https://github.com/openwrt/openwrt/commit/e401229918fdbd37eedf53db52e3ba022652831e
DTS updated

ping @blocktrron 