### PR TITLE
libxml2: Add abi version

### DIFF
--- a/package/libs/libxml2/Makefile
+++ b/package/libs/libxml2/Makefile
@@ -24,6 +24,7 @@ define Package/libxml2
   TITLE:=Gnome XML library
   URL:=http://xmlsoft.org/
   DEPENDS:=+libpthread +zlib $(ICONV_DEPENDS)
+  ABI_VERSION:=16
 endef
 
 define Package/libxml2/description


### PR DESCRIPTION
The version of libxml2 was bumped from  2.13.6 to 2.14.5. Since version 2.14, libxml2 is not binary compatible with older versions. Therefore add an abi version.

From the NEWS file:
Binary compatibility is restricted to versions 2.14 or newer. On ELF systems, the soname was bumped from libxml2.so.2 to libxml2.so.16.

