### PR TITLE
rockchip: add Lunzn FastRhino R66S support

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -219,6 +219,13 @@ define U-Boot/bpi-r2-pro-rk3568
     sinovoip_bpi-r2-pro
 endef
 
+define U-Boot/fastrhino-r66s-rk3568
+  $(U-Boot/rk3568/Default)
+  NAME:=FastRhino R66S
+  BUILD_DEVICES:= \
+    lunzn_fastrhino-r66s
+endef
+
 define U-Boot/nanopi-r5c-rk3568
   $(U-Boot/rk3568/Default)
   NAME:=NanoPi R5C
@@ -360,6 +367,7 @@ UBOOT_TARGETS := \
   radxa-zero-3-rk3566 \
   rock-3c-rk3566 \
   bpi-r2-pro-rk3568 \
+  fastrhino-r66s-rk3568 \
   nanopi-r5c-rk3568 \
   nanopi-r5s-rk3568 \
   radxa-e25-rk3568 \

--- a/package/boot/uboot-rockchip/patches/100-board-rockchip-add-Lunzn-FastRhino-R66S.patch
+++ b/package/boot/uboot-rockchip/patches/100-board-rockchip-add-Lunzn-FastRhino-R66S.patch
@@ -1,0 +1,124 @@
+From 03610008ce31b7a780b7864a0a916d945b7234ba Mon Sep 17 00:00:00 2001
+From: Tianling Shen <cnsztl@gmail.com>
+Date: Mon, 8 Sep 2025 19:29:55 +0800
+Subject: [PATCH] board: rockchip: add Lunzn FastRhino R66S
+
+Lunzn Fastrhino R66S is a high-performance mini router.
+
+Specification:
+- Rockchip RK3568
+- 1/2GB LPDDR4 RAM
+- SD card slot
+- 2x USB 3.0 Port
+- 2x 2500 Base-T (PCIe, r8125b)
+- 12v DC Jack
+
+Signed-off-by: Tianling Shen <cnsztl@gmail.com>
+---
+ .../arm/dts/rk3568-fastrhino-r66s-u-boot.dtsi |  3 +
+ board/rockchip/evb_rk3568/MAINTAINERS         |  7 ++
+ configs/fastrhino-r66s-rk3568_defconfig       | 64 +++++++++++++++++++
+ doc/board/rockchip/rockchip.rst               |  1 +
+ 4 files changed, 75 insertions(+)
+ create mode 100644 arch/arm/dts/rk3568-fastrhino-r66s-u-boot.dtsi
+ create mode 100644 configs/fastrhino-r66s-rk3568_defconfig
+
+--- /dev/null
++++ b/arch/arm/dts/rk3568-fastrhino-r66s-u-boot.dtsi
+@@ -0,0 +1,3 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++#include "rk356x-u-boot.dtsi"
+--- a/board/rockchip/evb_rk3568/MAINTAINERS
++++ b/board/rockchip/evb_rk3568/MAINTAINERS
+@@ -14,6 +14,13 @@ F:	configs/evb-rk3568_defconfig
+ F:	arch/arm/dts/rk3568-evb-u-boot.dtsi
+ F:	arch/arm/dts/rk3568-evb.dts
+ 
++FASTRHINO-R66S-RK3568
++M:	Tianling Shen <cnsztl@gmail.com>
++R:	Jonas Karlman <jonas@kwiboo.se>
++S:	Maintained
++F:	configs/fastrhino-r66s-rk3568_defconfig
++F:	arch/arm/dts/rk3568-fastrhino-r66s-u-boot.dtsi
++
+ GENERIC-RK3568
+ M:	Jonas Karlman <jonas@kwiboo.se>
+ S:	Maintained
+--- /dev/null
++++ b/configs/fastrhino-r66s-rk3568_defconfig
+@@ -0,0 +1,64 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_COUNTER_FREQUENCY=24000000
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3568-fastrhino-r66s"
++CONFIG_ROCKCHIP_RK3568=y
++CONFIG_SPL_SERIAL=y
++CONFIG_SYS_LOAD_ADDR=0xc00800
++CONFIG_DEBUG_UART_BASE=0xFE660000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_PCI=y
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_FIT_SIGNATURE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3568-fastrhino-r66s.dtb"
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++CONFIG_SPL_MAX_SIZE=0x40000
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_ATF=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_I2C=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_PMIC=y
++CONFIG_CMD_REGULATOR=y
++# CONFIG_SPL_DOS_PARTITION is not set
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_SPL_DM_SEQ_ALIAS=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SPL_SYSCON=y
++CONFIG_SPL_CLK=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MISC=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_RTL8169=y
++CONFIG_PCIE_DW_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_NANENG_COMBOPHY=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_SPL_RAM=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_ERRNO_STR=y
+--- a/doc/board/rockchip/rockchip.rst
++++ b/doc/board/rockchip/rockchip.rst
+@@ -128,6 +128,7 @@ List of mainline supported Rockchip boar
+      - FriendlyElec NanoPi R5S (nanopi-r5s-rk3568)
+      - Generic RK3566/RK3568 (generic-rk3568)
+      - Hardkernel ODROID-M1 (odroid-m1-rk3568)
++     - Lunzn FastRhino R66S (fastrhino-r66s-rk3568)
+      - QNAP TS-433 (qnap-ts433-rk3568)
+      - Radxa E25 Carrier Board (radxa-e25-rk3568)
+      - Radxa ROCK 3A (rock-3a-rk3568)

--- a/package/boot/uboot-rockchip/patches/111-rockchip-rk3588-generic-Enable-support-for-RK3582.patch
+++ b/package/boot/uboot-rockchip/patches/111-rockchip-rk3588-generic-Enable-support-for-RK3582.patch
@@ -61,7 +61,7 @@ Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
  CONFIG_SPL_MAX_SIZE=0x40000
 --- a/doc/board/rockchip/rockchip.rst
 +++ b/doc/board/rockchip/rockchip.rst
-@@ -145,7 +145,7 @@ List of mainline supported Rockchip boar
+@@ -146,7 +146,7 @@ List of mainline supported Rockchip boar
       - FriendlyElec NanoPC-T6 (nanopc-t6-rk3588)
       - FriendlyElec NanoPi R6C (nanopi-r6c-rk3588s)
       - FriendlyElec NanoPi R6S (nanopi-r6s-rk3588s)

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -23,6 +23,7 @@ rockchip_setup_interfaces()
 		;;
 	friendlyarm,nanopc-t6|\
 	friendlyarm,nanopi-r5c|\
+	lunzn,fastrhino-r66s|\
 	radxa,e25|\
 	radxa,rock-3b|\
 	radxa,rock-5-itx|\
@@ -55,7 +56,8 @@ rockchip_setup_macs()
 	armsom,sige7|\
 	friendlyarm,nanopc-t6|\
 	friendlyarm,nanopi-r2c|\
-	friendlyarm,nanopi-r2s)
+	friendlyarm,nanopi-r2s|\
+	lunzn,fastrhino-r66s)
 		wan_mac=$(macaddr_generate_from_mmc_cid mmcblk0)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -32,6 +32,7 @@ case "$(board_name)" in
 armsom,sige7|\
 friendlyarm,nanopi-r3s|\
 friendlyarm,nanopi-r5c|\
+lunzn,fastrhino-r66s|\
 radxa,e25|\
 sinovoip,rk3568-bpi-r2pro)
 	set_interface_core 2 "eth0"

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -124,6 +124,14 @@ define Device/friendlyarm_nanopi-r6s
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r6s
 
+define Device/lunzn_fastrhino-r66s
+  DEVICE_VENDOR := Lunzn
+  DEVICE_MODEL := FastRhino R66S
+  SOC := rk3568
+  DEVICE_PACKAGES := kmod-r8169
+endef
+TARGET_DEVICES += lunzn_fastrhino-r66s
+
 define Device/pine64_rock64
   DEVICE_VENDOR := Pine64
   DEVICE_MODEL := Rock64

--- a/target/linux/rockchip/patches-6.12/133-arm64-dts-rockchip-Update-LED-properties-for-Lunzn-Fastrh.patch
+++ b/target/linux/rockchip/patches-6.12/133-arm64-dts-rockchip-Update-LED-properties-for-Lunzn-Fastrh.patch
@@ -1,0 +1,24 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3568-fastrhino-r66s.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3568-fastrhino-r66s.dtsi
+@@ -9,6 +9,13 @@
+ #include "rk3568.dtsi"
+ 
+ / {
++	aliases {
++		led-boot = &status_led;
++		led-failsafe = &status_led;
++		led-running = &status_led;
++		led-upgrade = &status_led;
++	};
++
+ 	chosen: chosen {
+ 		stdout-path = "serial2:1500000n8";
+ 	};
+@@ -35,7 +42,6 @@
+ 			color = <LED_COLOR_ID_BLUE>;
+ 			function = LED_FUNCTION_STATUS;
+ 			gpios = <&gpio0 RK_PC0 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+ 		};
+ 	};
+ 


### PR DESCRIPTION
Hardware
--------
RockChip RK3568 ARM64 (4 cores)
1/2GB LPDDR4 RAM
2x 2500 Base-T (PCIe, r8125b)
1 LED (Power)
1 Button (Reset)
Micro-SD Slot
2x USB 3.0 Port
12V DC Jack

Installation
------------
Uncompress the OpenWrt sysupgrade and write it to a micro SD card using
dd.

The patch for U-Boot has been sent to upstream:
https://lore.kernel.org/u-boot/20250908113218.4102764-1-cnsztl@gmail.com/