### PR TITLE
[base-files] modernize sysctl init script

### DIFF
--- a/package/base-files/files/etc/init.d/sysctl
+++ b/package/base-files/files/etc/init.d/sysctl
@@ -4,36 +4,20 @@
 START=11
 
 apply_defaults() {
-	local mem="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
-	local min_free frag_low_thresh frag_high_thresh
+	local min_free mem="$(awk '/^MemTotal:/{print $2}' /proc/meminfo)"
 
-	if [ "$mem" -gt 65536 ]; then # 128M
+	if [ "$mem" -gt 524288 ]; then # 1G
+		min_free=65536
+	elif [ "$mem" -gt 65536 ]; then # 128M
 		min_free=16384
-	elif [ "$mem" -gt 32768 ]; then # 64M
-		min_free=8192
 	else
 		min_free=1024
-		frag_low_thresh=393216
-		frag_high_thresh=524288
 	fi
 
 	sysctl -qw vm.min_free_kbytes="$min_free"
 
-	[ "$frag_low_thresh" ] && sysctl -qw \
-		net.ipv4.ipfrag_low_thresh="$frag_low_thresh" \
-		net.ipv4.ipfrag_high_thresh="$frag_high_thresh" \
-		net.ipv6.ip6frag_low_thresh="$frag_low_thresh" \
-		net.ipv6.ip6frag_high_thresh="$frag_high_thresh" \
-		net.netfilter.nf_conntrack_frag6_low_thresh="$frag_low_thresh" \
-		net.netfilter.nf_conntrack_frag6_high_thresh="$frag_high_thresh"
-
-	# first set default, then all interfaces to avoid races with appearing interfaces
-	if [ -d /proc/sys/net/ipv6/conf ]; then
-		echo 0 > /proc/sys/net/ipv6/conf/default/accept_ra
-		for iface in /proc/sys/net/ipv6/conf/*/accept_ra; do
-			echo 0 > "$iface"
-		done
-	fi
+	# first set default, then each interface to avoid race with appearing interfaces
+	( cd /proc/sys/net/ipv6/conf && echo 0 | tee default/accept_ra */accept_ra ) >/dev/null 2>&1
 }
 
 start() {


### PR DESCRIPTION
Multiple improvements to move along with time
- do not unnecessarily align defrag thresholds, they are conclusively smaller nowadays
- align larger systems with upstream maximum
- shorten accept_ra configuration to one line
- reserve minimal memory possible also on 64M systems as reported in https://github.com/openwrt/openwrt/issues/20946

Fixes: https://github.com/openwrt/openwrt/issues/20946