### PR TITLE
realtek: add support for XikeStor SKS8300-8T

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -63,6 +63,7 @@ tplink,tl-st1008f-v2)
 xikestor,sks8300-8x)
 	lan_mac=$(mtd_get_mac_binary board-info 0x1f1)
 	;;
+xikestor,sks8300-8t|\
 xikestor,sks8310-8x)
 	lan_mac=$(mtd_get_mac_binary factory 0x80)
 	label_mac="$lan_mac"

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl930x.dtsi"
+#include "macros.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "xikestor,sks8300-8t", "realtek,rtl9303-soc";
+	model = "XikeStor SKS8300-8T";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* first 256 MiB */
+					<0x20000000 0x10000000>; /* remaining 256 MiB */
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			(RTL93XX_LED_SET_1G | RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_5G |
+				RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)>;
+	};
+};
+
+&mdio_aux {
+	status = "okay";
+
+	gpio1: gpio@0 {
+		compatible = "realtek,rtl8231";
+		reg = <0>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio1 0 0 37>;
+		status = "okay";
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c@0 {
+		reg = <0>;
+		clock-frequency = <100000>;
+
+		temp_sensor: temp-sensor@48 {
+			compatible = "national,lm75";
+			reg = <0x48>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x1c0000>;
+				read-only;
+			};
+
+			partition@1c0000 {
+				label = "u-boot-env";
+				reg = <0x1c0000 0x10000>;
+			};
+
+			partition@1d0000 {
+				label = "sysinfo";
+				reg = <0x1d0000 0x10000>;
+				read-only;
+			};
+
+			partition@1e0000 {
+				label = "factory";
+				reg = <0x1e0000 0x10000>;
+				read-only;
+			};
+
+			partition@1f0000 {
+				label = "sysdata";
+				reg = <0x1f0000 0x10000>;
+			};
+
+			partition@200000 {
+				label = "jffs2_filesystem";
+				reg = <0x200000 0xa00000>;
+			};
+
+			partition@c00000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0xc00000 0x1400000>;
+				openwrt,ih-magic = <0x93000000>;
+				openwrt,offset = <0x10>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	mdio: mdio-bus {
+		compatible = "realtek,rtl838x-mdio";
+		regmap = <&ethernet0>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy0: ethernet-phy@0 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <0>;
+			sds = <2>;
+			rtl9300,smi-address = <0 0>;
+		};
+
+		phy8: ethernet-phy@8 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <8>;
+			sds = <3>;
+			rtl9300,smi-address = <0 1>;
+		};
+
+		phy16: ethernet-phy@16 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <16>;
+			sds = <4>;
+			rtl9300,smi-address = <0 2>;
+		};
+
+		phy20: ethernet-phy@20 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <20>;
+			sds = <5>;
+			rtl9300,smi-address = <0 3>;
+		};
+
+		phy24: ethernet-phy@24 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <24>;
+			sds = <6>;
+			rtl9300,smi-address = <1 0>;
+		};
+
+		phy25: ethernet-phy@25 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <25>;
+			sds = <7>;
+			rtl9300,smi-address = <1 1>;
+		};
+
+		phy26: ethernet-phy@26 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <26>;
+			sds = <8>;
+			rtl9300,smi-address = <1 2>;
+		};
+
+		phy27: ethernet-phy@27 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <27>;
+			sds = <9>;
+			rtl9300,smi-address = <1 3>;
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			phy-handle = <&phy0>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+
+		port@8 {
+			reg = <8>;
+			label = "lan2";
+			phy-handle = <&phy8>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+
+		port@16 {
+			reg = <16>;
+			label = "lan3";
+			phy-handle = <&phy16>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+
+		port@20 {
+			reg = <20>;
+			label = "lan4";
+			phy-handle = <&phy20>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+
+		port@24 {
+			reg = <24>;
+			label = "lan5";
+			phy-handle = <&phy24>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+
+		port@25 {
+			reg = <25>;
+			label = "lan6";
+			phy-handle = <&phy25>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+
+		port@26 {
+			reg = <26>;
+			label = "lan7";
+			phy-handle = <&phy26>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+
+		port@27 {
+			reg = <27>;
+			label = "lan8";
+			phy-handle = <&phy27>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -63,6 +63,24 @@ define Device/vimin_vm-s100-0800ms
 endef
 TARGET_DEVICES += vimin_vm-s100-0800ms
 
+define Device/xikestor_sks8300-8t
+  SOC := rtl9303
+  UIMAGE_MAGIC := 0x93000000
+  DEVICE_VENDOR := XikeStor
+  DEVICE_MODEL := SKS8300-8T
+  IMAGE_SIZE := 20480k
+  $(Device/kernel-lzma)
+  IMAGE/sysupgrade.bin := \
+    pad-extra 16 | \
+    append-kernel | \
+    pad-to 64k | \
+    append-rootfs | \
+    pad-rootfs | \
+    check-size | \
+    append-metadata
+endef
+TARGET_DEVICES += xikestor_sks8300-8t
+
 define Device/xikestor_sks8300-8x
   SOC := rtl9303
   DEVICE_VENDOR := XikeStor


### PR DESCRIPTION
XikeStor SKS8300-8T is a 8 ports Multi-Gig switch, based on the RTL9303.

Specifications:

- SoC              : Realtek RTL9303
- RAM             : DDR3 512 MiB
- Flash             : SPI-NOR 32 MiB (Macronix)
- CPU              : 800MHz
- Ethernet        : 8× TG/2.5G/5G/10G Base-T RJ45 ports (RTL8261BE)
- LEDs/Keys (GPIO) : 1x/1x
- UART             : "Console" port on the front panel
  - type           : RS-232C
  - connector      : RJ-45
  - settings       : 115200 8N1
- Power            : 12 VDC, 4A
- Temperature sensor: LM75
- Dimensions    : (L×W×H)  207×136×35 mm
- Weight           : 2.3 kg

Flash instruction using initramfs image:

 1. Prepare TFTP server & connect to serial port.
 2. Connect your computer to one of the RJ45 ports on SKS8300-8T 
 3. Power on SKS8300-8T and interrupt autoboot with Shift + A.
 4. Use Shift + Q to drop from vendor CLI to U-Boot CLI.
 6. Set the boot command to enable network on boot.
	> setenv bootcmd 'rtk network on; boota'
 7. Save environment variable
	> saveenv
 8. Enable networking within U-Boot.
	> rtk network on
 9. Set switch IP and TFTP server IP (optional, adjust to your setup).
       > setenv ipaddr <ip>
       > setenv serverip <ip>
 10. Download initramfs image from TFTP server.
       > tftpboot 0x81000000 <image name>
 11. Boot with the downloaded image.
       > bootm 0x81000000 
 12. With rambooted OpenWrt, backup the stock firmware if needed.
 13. Copy sysupgrade image to the device.
 14. Perform sysupgrade with the sysupgrade image.
 15. After reboot, you should have functional OpenWrt.

Reverting to stock firmware:

 1. Download latest firmware from XikeStor and upload to your device.
 1. Write firmware with 'sysupgrade -F'.
 2. After reboot, stock firmware should boot automatically.

U-Boot environment variables:
```yaml
RTL9300# # printenv
baudrate=115200
boardmodel=RTL9303_8X8261BE_V1
bootcmd=boota
bootdelay=3
ethact=rtl9300#0
ethaddr=00:E0:4C:00:00:00
fileaddr=81000000
filesize=B30621
ipaddr=10.42.0.2
ledModeInitSkip=0
serverip=10.42.0.1
stderr=serial
stdin=serial
stdout=serial

Environment size: 274/65532 bytes
```

Stock firmware SPI partition + CPU info:
```yaml
/www_wayos # cat /proc/mtd
dev:    size   erasesize  name
mtd0: 001c0000 00010000 "LOADER"
mtd1: 00010000 00010000 "BDINFO"
mtd2: 00010000 00010000 "SYSINFO"
mtd3: 00010000 00010000 "JFFS2 FACTORYDATA"
mtd4: 00010000 00010000 "JFFS2 SYSDATA"
mtd5: 00a00000 00010000 "JFFS2 FILESYSTEM"
mtd6: 01400000 00010000 "RUNTIME"
mtd7: 02000000 00010000 "RUNTIME2"
/www_wayos # cat /proc/cpuinfo
system type             : RTL9300
machine                 : RTL9300
processor               : 0
cpu model               : MIPS 34Kc V5.5
BogoMIPS                : 530.41
wait instruction        : yes
microsecond timers      : yes
tlb_entries             : 32
extra interrupt vector  : yes
hardware watchpoint     : no
isa                     : mips1 mips32r2
ASEs implemented        : mips16
shadow register sets    : 1
kscratch registers      : 0
package                 : 0
core                    : 0
```

Signed-off-by: Samy Younsi <kame@duck.com>