### PR TITLE
[24.10] kernel: r8168: add missing flags

### DIFF
--- a/package/kernel/r8168/Makefile
+++ b/package/kernel/r8168/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8168
 PKG_VERSION:=8.055.00
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8168/releases/download/$(PKG_VERSION)
@@ -40,6 +40,7 @@ endif
 
 define Build/Compile
 	+$(KERNEL_MAKE) $(PKG_JOBS) \
+		$(PKG_MAKE_FLAGS) \
 		M="$(PKG_BUILD_DIR)/src" \
 		modules
 endef


### PR DESCRIPTION
Backport 5719d6506467285db424814433e7b6d8779ee9d2 to 24.10