### PR TITLE
ath79: tiny: tplink: add nvmem and fix

### DIFF
--- a/target/linux/ath79/dts/ar7241_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7241_tplink.dtsi
@@ -84,7 +84,7 @@
 				label = "firmware";
 			};
 
-			partition@3f0000 {
+			art_part: partition@3f0000 {
 				reg = <0x3f0000 0x10000>;
 				label = "art";
 				read-only;
@@ -95,15 +95,6 @@
 
 &pcie {
 	status = "okay";
-
-	ath9k: wifi@0,0 {
-		reg = <0x0000 0 0 0 0>;
-		#gpio-cells = <2>;
-		gpio-controller;
-		qca,no-eeprom;
-		nvmem-cells = <&macaddr_uboot_1fc00 0>;
-		nvmem-cell-names = "mac-address";
-	};
 };
 
 &eth0 {		/* WAN interface, initialized last as eth1 */

--- a/target/linux/ath79/dts/ar7241_tplink_tl-mr3220-v1.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-mr3220-v1.dts
@@ -7,15 +7,30 @@
 / {
 	compatible = "tplink,tl-mr3220-v1", "qca,ar7241";
 	model = "TP-Link TL-MR3220 v1";
+};
 
-	ath9k-leds {
-		compatible = "gpio-leds";
+&art_part {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
+		cal_art_1000: calibration@1000 {
+			reg = <0x1000 0x200>;
+		};
+	};
+};
+
+&pcie {
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,002b";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&cal_art_1000>, <&macaddr_uboot_1fc00 0>;
+		nvmem-cell-names = "calibration", "mac-address";
+
+		led {
+			led-sources = <1>;
+			led-active-low;
 		};
 	};
 };

--- a/target/linux/ath79/dts/ar7241_tplink_tl-mr3420-v1.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-mr3420-v1.dts
@@ -7,15 +7,30 @@
 / {
 	compatible = "tplink,tl-mr3420-v1", "qca,ar7241";
 	model = "TP-Link TL-MR3420 v1";
+};
 
-	ath9k-leds {
-		compatible = "gpio-leds";
+&art_part {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
+		cal_art_1000: calibration@1000 {
+			reg = <0x1000 0x3d8>;
+		};
+	};
+};
+
+&pcie {
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,002e";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&cal_art_1000>, <&macaddr_uboot_1fc00 0>;
+		nvmem-cell-names = "calibration", "mac-address";
+
+		led {
+			led-sources = <0>;
+			led-active-low;
 		};
 	};
 };

--- a/target/linux/ath79/dts/ar7241_tplink_tl-wr841-v7.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-wr841-v7.dts
@@ -7,15 +7,30 @@
 / {
 	compatible = "tplink,tl-wr841-v7", "qca,ar7241";
 	model = "TP-Link TL-WR841N/ND v7";
+};
 
-	ath9k-leds {
-		compatible = "gpio-leds";
+&art_part {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&ath9k 0 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
+		cal_art_1000: calibration@1000 {
+			reg = <0x1000 0x3d8>;
+		};
+	};
+};
+
+&pcie {
+	ath9k: wifi@0,0 {
+		compatible = "pci168c,002e";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&cal_art_1000>, <&macaddr_uboot_1fc00 0>;
+		nvmem-cell-names = "calibration", "mac-address";
+
+		led {
+			led-sources = <0>;
+			led-active-low;
 		};
 	};
 };

--- a/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -20,9 +20,6 @@ case "$FIRMWARE" in
 		ath9k_patch_mac_crc $(mtd_get_mac_ascii "nvram" "lan_mac") 0x10c
 		;;
 	netgear,wnr2000-v3|\
-	tplink,tl-mr3220-v1|\
-	tplink,tl-mr3420-v1|\
-	tplink,tl-wr841-v7|\
 	ubnt,airrouter|\
 	ubnt,bullet-m-ar7240|\
 	ubnt,bullet-m-ar7241|\


### PR DESCRIPTION
Despite having the same tplink.dtsi file, there are differences in wifi

Move wifi nodes out of dtsi to make it clear what the chipset is and what calibration size should be used.

While at it, change to use led-sources to simplify LED setup.

ping @hauke 