### PR TITLE
[WIP] realtek: rtl931x: rename SerDes read/write helpers

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
@@ -23,8 +23,11 @@ extern struct rtl83xx_soc_info soc_info;
 extern int rtmdio_930x_read_sds_phy(int sds, int page, int regnum);
 extern int rtmdio_930x_write_sds_phy(int sds, int page, int regnum, u16 val);
 
-extern int rtmdio_931x_read_sds_phy_new(int sds, int page, int regnum);
-extern int rtmdio_931x_write_sds_phy_new(int sds, int page, int regnum, u16 val);
+extern int rtsds_931x_read(int sds, int page, int regnum);
+extern int rtsds_931x_read_field(int sds, int page, int regnum, int end_bit, int start_bit);
+
+extern int rtsds_931x_write(int sds, int page, int regnum, u16 val);
+extern int rtsds_931x_write_field(int sds, int page, int regnum, int end_bit, int start_bit, u16 val);
 
 #define PHY_PAGE_2	2
 #define PHY_PAGE_4	4
@@ -2634,33 +2637,6 @@ int rtl9300_sds_cmu_band_get(int sds)
 	return cmu_band;
 }
 
-static void rtl9310_sds_field_w_new(int sds, u32 page, u32 reg, int end_bit, int start_bit, u32 v)
-{
-	int l = end_bit - start_bit + 1;
-	u32 data = v;
-
-	if (l < 32) {
-		u32 mask = BIT(l) - 1;
-
-		data = rtmdio_931x_read_sds_phy_new(sds, page, reg);
-		data &= ~(mask << start_bit);
-		data |= (v & mask) << start_bit;
-	}
-
-	rtmdio_931x_write_sds_phy_new(sds, page, reg, data);
-}
-
-static u32 rtl9310_sds_field_r_new(int sds, u32 page, u32 reg, int end_bit, int start_bit)
-{
-	int l = end_bit - start_bit + 1;
-	u32 v = rtmdio_931x_read_sds_phy_new(sds, page, reg);
-
-	if (l >= 32)
-		return v;
-
-	return (v >> start_bit) & (BIT(l) - 1);
-}
-
 static void rtl931x_sds_rst(u32 sds)
 {
 	u32 o, v, o_mode;
@@ -2688,21 +2664,21 @@ static void rtl931x_symerr_clear(u32 sds, phy_interface_t mode)
 		break;
 	case PHY_INTERFACE_MODE_XGMII:
 		for (int i = 0; i < 4; ++i) {
-			rtl9310_sds_field_w_new(sds, 0x101, 24,  2, 0, i);
-			rtl9310_sds_field_w_new(sds, 0x101,  3, 15, 8, 0x0);
-			rtl9310_sds_field_w_new(sds, 0x101,  2, 15, 0, 0x0);
+			rtsds_931x_write_field(sds, 0x101, 24,  2, 0, i);
+			rtsds_931x_write_field(sds, 0x101,  3, 15, 8, 0x0);
+			rtsds_931x_write_field(sds, 0x101,  2, 15, 0, 0x0);
 		}
 
 		for (int i = 0; i < 4; ++i) {
-			rtl9310_sds_field_w_new(sds, 0x201, 24,  2, 0, i);
-			rtl9310_sds_field_w_new(sds, 0x201,  3, 15, 8, 0x0);
-			rtl9310_sds_field_w_new(sds, 0x201,  2, 15, 0, 0x0);
+			rtsds_931x_write_field(sds, 0x201, 24,  2, 0, i);
+			rtsds_931x_write_field(sds, 0x201,  3, 15, 8, 0x0);
+			rtsds_931x_write_field(sds, 0x201,  2, 15, 0, 0x0);
 		}
 
-		rtl9310_sds_field_w_new(sds, 0x101, 0, 15, 0, 0x0);
-		rtl9310_sds_field_w_new(sds, 0x101, 1, 15, 8, 0x0);
-		rtl9310_sds_field_w_new(sds, 0x201, 0, 15, 0, 0x0);
-		rtl9310_sds_field_w_new(sds, 0x201, 1, 15, 8, 0x0);
+		rtsds_931x_write_field(sds, 0x101, 0, 15, 0, 0x0);
+		rtsds_931x_write_field(sds, 0x101, 1, 15, 8, 0x0);
+		rtsds_931x_write_field(sds, 0x201, 0, 15, 0, 0x0);
+		rtsds_931x_write_field(sds, 0x201, 1, 15, 8, 0x0);
 		break;
 	default:
 		break;
@@ -2715,7 +2691,7 @@ void rtl931x_sds_fiber_disable(u32 sds)
 {
 	u32 v = 0x3F;
 
-	rtl9310_sds_field_w_new(sds, 0x1F, 0x9, 11, 6, v);
+	rtsds_931x_write_field(sds, 0x1F, 0x9, 11, 6, v);
 }
 
 static void rtl931x_sds_fiber_mode_set(u32 sds, phy_interface_t mode)
@@ -2755,7 +2731,7 @@ static void rtl931x_sds_fiber_mode_set(u32 sds, phy_interface_t mode)
 	}
 
 	pr_info("%s writing analog SerDes Mode value %02x\n", __func__, val);
-	rtl9310_sds_field_w_new(sds, 0x1F, 0x9, 11, 6, val);
+	rtsds_931x_write_field(sds, 0x1F, 0x9, 11, 6, val);
 
 	return;
 }
@@ -2803,7 +2779,7 @@ static void rtl931x_cmu_type_set(u32 sds, phy_interface_t mode, int chiptype)
 
 /*	case MII_10GR1000BX_AUTO:
 		if (chiptype)
-			rtl9310_sds_field_w_new(sds, 0x24, 0xd, 14, 14, 0);
+			rtsds_931x_write_field(sds, 0x24, 0xd, 14, 14, 0);
 		return; */
 
 	case PHY_INTERFACE_MODE_QSGMII:
@@ -2855,21 +2831,21 @@ static void rtl931x_cmu_type_set(u32 sds, phy_interface_t mode, int chiptype)
 	        __func__, cmu_type, cmu_page, frc_cmu_spd, lane, sds);
 
 	if (cmu_type == 1) {
-		pr_info("%s A CMU page 0x28 0x7 %08x\n", __func__, rtmdio_931x_read_sds_phy_new(sds, 0x28, 0x7));
-		rtl9310_sds_field_w_new(sds, cmu_page, 0x7, 15, 15, 0);
-		pr_info("%s B CMU page 0x28 0x7 %08x\n", __func__, rtmdio_931x_read_sds_phy_new(sds, 0x28, 0x7));
+		pr_info("%s A CMU page 0x28 0x7 %08x\n", __func__, rtsds_931x_read(sds, 0x28, 0x7));
+		rtsds_931x_write_field(sds, cmu_page, 0x7, 15, 15, 0);
+		pr_info("%s B CMU page 0x28 0x7 %08x\n", __func__, rtsds_931x_read(sds, 0x28, 0x7));
 		if (chiptype) {
-			rtl9310_sds_field_w_new(sds, cmu_page, 0xd, 14, 14, 0);
+			rtsds_931x_write_field(sds, cmu_page, 0xd, 14, 14, 0);
 		}
 
-		rtl9310_sds_field_w_new(evenSds, 0x20, 0x12, 3, 2, 0x3);
-		rtl9310_sds_field_w_new(evenSds, 0x20, 0x12, frc_lc_mode_bitnum, frc_lc_mode_bitnum, 1);
-		rtl9310_sds_field_w_new(evenSds, 0x20, 0x12, frc_lc_mode_val_bitnum, frc_lc_mode_val_bitnum, 0);
-		rtl9310_sds_field_w_new(evenSds, 0x20, 0x12, 12, 12, 1);
-		rtl9310_sds_field_w_new(evenSds, 0x20, 0x12, 15, 13, frc_cmu_spd);
+		rtsds_931x_write_field(evenSds, 0x20, 0x12, 3, 2, 0x3);
+		rtsds_931x_write_field(evenSds, 0x20, 0x12, frc_lc_mode_bitnum, frc_lc_mode_bitnum, 1);
+		rtsds_931x_write_field(evenSds, 0x20, 0x12, frc_lc_mode_val_bitnum, frc_lc_mode_val_bitnum, 0);
+		rtsds_931x_write_field(evenSds, 0x20, 0x12, 12, 12, 1);
+		rtsds_931x_write_field(evenSds, 0x20, 0x12, 15, 13, frc_cmu_spd);
 	}
 
-	pr_info("%s CMU page 0x28 0x7 %08x\n", __func__, rtmdio_931x_read_sds_phy_new(sds, 0x28, 0x7));
+	pr_info("%s CMU page 0x28 0x7 %08x\n", __func__, rtsds_931x_read(sds, 0x28, 0x7));
 	return;
 }
 
@@ -2878,15 +2854,15 @@ static void rtl931x_sds_rx_rst(u32 sds)
 	if (sds < 2)
 		return;
 
-	rtmdio_931x_write_sds_phy_new(sds, 0x2e, 0x12, 0x2740);
-	rtmdio_931x_write_sds_phy_new(sds, 0x2f, 0x0, 0x0);
-	rtmdio_931x_write_sds_phy_new(sds, 0x2f, 0x2, 0x2010);
-	rtmdio_931x_write_sds_phy_new(sds, 0x20, 0x0, 0xc10);
+	rtsds_931x_write(sds, 0x2e, 0x12, 0x2740);
+	rtsds_931x_write(sds, 0x2f, 0x0, 0x0);
+	rtsds_931x_write(sds, 0x2f, 0x2, 0x2010);
+	rtsds_931x_write(sds, 0x20, 0x0, 0xc10);
 
-	rtmdio_931x_write_sds_phy_new(sds, 0x2e, 0x12, 0x27c0);
-	rtmdio_931x_write_sds_phy_new(sds, 0x2f, 0x0, 0xc000);
-	rtmdio_931x_write_sds_phy_new(sds, 0x2f, 0x2, 0x6010);
-	rtmdio_931x_write_sds_phy_new(sds, 0x20, 0x0, 0xc30);
+	rtsds_931x_write(sds, 0x2e, 0x12, 0x27c0);
+	rtsds_931x_write(sds, 0x2f, 0x0, 0xc000);
+	rtsds_931x_write(sds, 0x2f, 0x2, 0x6010);
+	rtsds_931x_write(sds, 0x20, 0x0, 0xc30);
 
 	mdelay(50);
 }
@@ -2972,20 +2948,20 @@ void rtl931x_sds_init(u32 sds, phy_interface_t mode)
 		return;
 
 	pr_info("%s: set sds %d to mode %d\n", __func__, sds, mode);
-	val = rtl9310_sds_field_r_new(sds, 0x1F, 0x9, 11, 6);
+	val = rtsds_931x_read_field(sds, 0x1F, 0x9, 11, 6);
 
 	pr_info("%s: fibermode %08X stored mode 0x%x", __func__,
-			rtmdio_931x_read_sds_phy_new(sds, 0x1f, 0x9), val);
+			rtsds_931x_read(sds, 0x1f, 0x9), val);
 	pr_info("%s: SGMII mode %08X in 0x24 0x9", __func__,
-			rtmdio_931x_read_sds_phy_new(sds, 0x24, 0x9));
+			rtsds_931x_read(sds, 0x24, 0x9));
 	pr_info("%s: CMU mode %08X stored even SDS %d", __func__,
-			rtmdio_931x_read_sds_phy_new(sds & ~1, 0x20, 0x12), sds & ~1);
+			rtsds_931x_read(sds & ~1, 0x20, 0x12), sds & ~1);
 	pr_info("%s: serdes_mode_ctrl %08X", __func__,  RTL931X_SERDES_MODE_CTRL + 4 * (sds >> 2));
-	pr_info("%s CMU page 0x24 0x7 %08x\n", __func__, rtmdio_931x_read_sds_phy_new(sds, 0x24, 0x7));
-	pr_info("%s CMU page 0x26 0x7 %08x\n", __func__, rtmdio_931x_read_sds_phy_new(sds, 0x26, 0x7));
-	pr_info("%s CMU page 0x28 0x7 %08x\n", __func__, rtmdio_931x_read_sds_phy_new(sds, 0x28, 0x7));
-	pr_info("%s XSG page 0x0 0xe %08x\n", __func__, rtmdio_931x_read_sds_phy_new(sds, 0x100, 0xe));
-	pr_info("%s XSG2 page 0x0 0xe %08x\n", __func__, rtmdio_931x_read_sds_phy_new(sds, 0x200, 0xe));
+	pr_info("%s CMU page 0x24 0x7 %08x\n", __func__, rtsds_931x_read(sds, 0x24, 0x7));
+	pr_info("%s CMU page 0x26 0x7 %08x\n", __func__, rtsds_931x_read(sds, 0x26, 0x7));
+	pr_info("%s CMU page 0x28 0x7 %08x\n", __func__, rtsds_931x_read(sds, 0x28, 0x7));
+	pr_info("%s XSG page 0x0 0xe %08x\n", __func__, rtsds_931x_read(sds, 0x100, 0xe));
+	pr_info("%s XSG2 page 0x0 0xe %08x\n", __func__, rtsds_931x_read(sds, 0x200, 0xe));
 
 	model_info = sw_r32(RTL93XX_MODEL_NAME_INFO);
 	if ((model_info >> 4) & 0x1) {
@@ -2996,7 +2972,7 @@ void rtl931x_sds_init(u32 sds, phy_interface_t mode)
 	}
 
 	pr_info("%s: 2.5gbit %08X", __func__,
-	        rtmdio_931x_read_sds_phy_new(sds, 0x101, 0x14));
+	        rtsds_931x_read(sds, 0x101, 0x14));
 
 	pr_info("%s: RTL931X_PS_SERDES_OFF_MODE_CTRL_ADDR 0x%08X\n", __func__, sw_r32(RTL931X_PS_SERDES_OFF_MODE_CTRL_ADDR));
 	ori = sw_r32(RTL931X_PS_SERDES_OFF_MODE_CTRL_ADDR);
@@ -3011,16 +2987,16 @@ void rtl931x_sds_init(u32 sds, phy_interface_t mode)
 
 		if (chiptype) {
 			/* fifo inv clk */
-			rtl9310_sds_field_w_new(sds, 0x101, 0x1, 7, 4, 0xf);
-			rtl9310_sds_field_w_new(sds, 0x101, 0x1, 3, 0, 0xf);
+			rtsds_931x_write_field(sds, 0x101, 0x1, 7, 4, 0xf);
+			rtsds_931x_write_field(sds, 0x101, 0x1, 3, 0, 0xf);
 
-			rtl9310_sds_field_w_new(sds, 0x201, 0x1, 7, 4, 0xf);
-			rtl9310_sds_field_w_new(sds, 0x201, 0x1, 3, 0, 0xf);
+			rtsds_931x_write_field(sds, 0x201, 0x1, 7, 4, 0xf);
+			rtsds_931x_write_field(sds, 0x201, 0x1, 3, 0, 0xf);
 
 		}
 
-		rtl9310_sds_field_w_new(sds, 0x100, 0xE, 12, 12, 1);
-		rtl9310_sds_field_w_new(sds, 0x200, 0xE, 12, 12, 1);
+		rtsds_931x_write_field(sds, 0x100, 0xE, 12, 12, 1);
+		rtsds_931x_write_field(sds, 0x200, 0xE, 12, 12, 1);
 		break;
 
 	case PHY_INTERFACE_MODE_USXGMII: /* MII_USXGMII_10GSXGMII/10GDXGMII/10GQXGMII: */
@@ -3028,73 +3004,73 @@ void rtl931x_sds_init(u32 sds, phy_interface_t mode)
 		u32 evenSds;
 
 		if (chiptype) {
-			rtl9310_sds_field_w_new(sds, 0x6, 0x2, 12, 12, 1);
+			rtsds_931x_write_field(sds, 0x6, 0x2, 12, 12, 1);
 
 			for (int i = 0; i < sizeof(sds_config_10p3125g_type1) / sizeof(sds_config); ++i) {
-				rtmdio_931x_write_sds_phy_new(sds, sds_config_10p3125g_type1[i].page - 0x4, sds_config_10p3125g_type1[i].reg, sds_config_10p3125g_type1[i].data);
+				rtsds_931x_write(sds, sds_config_10p3125g_type1[i].page - 0x4, sds_config_10p3125g_type1[i].reg, sds_config_10p3125g_type1[i].data);
 			}
 
 			evenSds = sds & ~1;
 
 			for (int i = 0; i < sizeof(sds_config_10p3125g_cmu_type1) / sizeof(sds_config); ++i) {
-				rtmdio_931x_write_sds_phy_new(evenSds,
+				rtsds_931x_write(evenSds,
 				                      sds_config_10p3125g_cmu_type1[i].page - 0x4, sds_config_10p3125g_cmu_type1[i].reg, sds_config_10p3125g_cmu_type1[i].data);
 			}
 
-			rtl9310_sds_field_w_new(sds, 0x6, 0x2, 12, 12, 0);
+			rtsds_931x_write_field(sds, 0x6, 0x2, 12, 12, 0);
 		} else {
 
-			rtl9310_sds_field_w_new(sds, 0x2e, 0xd, 6, 0, 0x0);
-			rtl9310_sds_field_w_new(sds, 0x2e, 0xd, 7, 7, 0x1);
+			rtsds_931x_write_field(sds, 0x2e, 0xd, 6, 0, 0x0);
+			rtsds_931x_write_field(sds, 0x2e, 0xd, 7, 7, 0x1);
 
-			rtl9310_sds_field_w_new(sds, 0x2e, 0x1c, 5, 0, 0x1E);
-			rtl9310_sds_field_w_new(sds, 0x2e, 0x1d, 11, 0, 0x00);
-			rtl9310_sds_field_w_new(sds, 0x2e, 0x1f, 11, 0, 0x00);
-			rtl9310_sds_field_w_new(sds, 0x2f, 0x0, 11, 0, 0x00);
-			rtl9310_sds_field_w_new(sds, 0x2f, 0x1, 11, 0, 0x00);
+			rtsds_931x_write_field(sds, 0x2e, 0x1c, 5, 0, 0x1E);
+			rtsds_931x_write_field(sds, 0x2e, 0x1d, 11, 0, 0x00);
+			rtsds_931x_write_field(sds, 0x2e, 0x1f, 11, 0, 0x00);
+			rtsds_931x_write_field(sds, 0x2f, 0x0, 11, 0, 0x00);
+			rtsds_931x_write_field(sds, 0x2f, 0x1, 11, 0, 0x00);
 
-			rtl9310_sds_field_w_new(sds, 0x2e, 0xf, 12, 6, 0x7F);
-			rtmdio_931x_write_sds_phy_new(sds, 0x2f, 0x12, 0xaaa);
+			rtsds_931x_write_field(sds, 0x2e, 0xf, 12, 6, 0x7F);
+			rtsds_931x_write(sds, 0x2f, 0x12, 0xaaa);
 
 			rtl931x_sds_rx_rst(sds);
 
-			rtmdio_931x_write_sds_phy_new(sds, 0x7, 0x10, op_code);
-			rtmdio_931x_write_sds_phy_new(sds, 0x6, 0x1d, 0x0480);
-			rtmdio_931x_write_sds_phy_new(sds, 0x6, 0xe, 0x0400);
+			rtsds_931x_write(sds, 0x7, 0x10, op_code);
+			rtsds_931x_write(sds, 0x6, 0x1d, 0x0480);
+			rtsds_931x_write(sds, 0x6, 0xe, 0x0400);
 		}
 		break;
 
 	case PHY_INTERFACE_MODE_10GBASER: /* MII_10GR / MII_10GR1000BX_AUTO: */
 	                                  /* configure 10GR fiber mode=1 */
-		rtl9310_sds_field_w_new(sds, 0x1f, 0xb, 1, 1, 1);
+		rtsds_931x_write_field(sds, 0x1f, 0xb, 1, 1, 1);
 
 		/* init fiber_1g */
-		rtl9310_sds_field_w_new(sds, 0x103, 0x13, 15, 14, 0);
+		rtsds_931x_write_field(sds, 0x103, 0x13, 15, 14, 0);
 
-		rtl9310_sds_field_w_new(sds, 0x102, 0x0, 12, 12, 1);
-		rtl9310_sds_field_w_new(sds, 0x102, 0x0, 6, 6, 1);
-		rtl9310_sds_field_w_new(sds, 0x102, 0x0, 13, 13, 0);
+		rtsds_931x_write_field(sds, 0x102, 0x0, 12, 12, 1);
+		rtsds_931x_write_field(sds, 0x102, 0x0, 6, 6, 1);
+		rtsds_931x_write_field(sds, 0x102, 0x0, 13, 13, 0);
 
 		/* init auto */
-		rtl9310_sds_field_w_new(sds, 0x1f, 13, 15, 0, 0x109e);
-		rtl9310_sds_field_w_new(sds, 0x1f, 0x6, 14, 10, 0x8);
-		rtl9310_sds_field_w_new(sds, 0x1f, 0x7, 10, 4, 0x7f);
+		rtsds_931x_write_field(sds, 0x1f, 13, 15, 0, 0x109e);
+		rtsds_931x_write_field(sds, 0x1f, 0x6, 14, 10, 0x8);
+		rtsds_931x_write_field(sds, 0x1f, 0x7, 10, 4, 0x7f);
 		break;
 
 	case PHY_INTERFACE_MODE_1000BASEX: /* MII_1000BX_FIBER */
-		rtl9310_sds_field_w_new(sds, 0x103, 0x13, 15, 14, 0);
+		rtsds_931x_write_field(sds, 0x103, 0x13, 15, 14, 0);
 
-		rtl9310_sds_field_w_new(sds, 0x102, 0x0, 12, 12, 1);
-		rtl9310_sds_field_w_new(sds, 0x102, 0x0, 6, 6, 1);
-		rtl9310_sds_field_w_new(sds, 0x102, 0x0, 13, 13, 0);
+		rtsds_931x_write_field(sds, 0x102, 0x0, 12, 12, 1);
+		rtsds_931x_write_field(sds, 0x102, 0x0, 6, 6, 1);
+		rtsds_931x_write_field(sds, 0x102, 0x0, 13, 13, 0);
 		break;
 
 	case PHY_INTERFACE_MODE_SGMII:
-		rtl9310_sds_field_w_new(sds, 0x24, 0x9, 15, 15, 0);
+		rtsds_931x_write_field(sds, 0x24, 0x9, 15, 15, 0);
 		break;
 
 	case PHY_INTERFACE_MODE_2500BASEX:
-		rtl9310_sds_field_w_new(sds, 0x101, 0x14, 8, 8, 1);
+		rtsds_931x_write_field(sds, 0x101, 0x14, 8, 8, 1);
 		break;
 
 	case PHY_INTERFACE_MODE_QSGMII:
@@ -3108,16 +3084,16 @@ void rtl931x_sds_init(u32 sds, phy_interface_t mode)
 
 	if (sds >= 2 && sds <= 13) {
 		if (chiptype)
-			rtmdio_931x_write_sds_phy_new(sds, 0x2E, 0x1, board_sds_tx_type1[sds - 2]);
+			rtsds_931x_write(sds, 0x2E, 0x1, board_sds_tx_type1[sds - 2]);
 		else {
 			val = 0xa0000;
 			sw_w32(val, RTL93XX_CHIP_INFO);
 			val = sw_r32(RTL93XX_CHIP_INFO);
 			if (val & BIT(28)) /* consider 9311 etc. RTL9313_CHIP_ID == HWP_CHIP_ID(unit)) */
 			{
-				rtmdio_931x_write_sds_phy_new(sds, 0x2E, 0x1, board_sds_tx2[sds - 2]);
+				rtsds_931x_write(sds, 0x2E, 0x1, board_sds_tx2[sds - 2]);
 			} else {
-				rtmdio_931x_write_sds_phy_new(sds, 0x2E, 0x1, board_sds_tx[sds - 2]);
+				rtsds_931x_write(sds, 0x2E, 0x1, board_sds_tx[sds - 2]);
 			}
 			val = 0;
 			sw_w32(val, RTL93XX_CHIP_INFO);
@@ -3148,14 +3124,14 @@ int rtl931x_sds_cmu_band_set(int sds, bool enable, u32 band, phy_interface_t mod
 	page += 1;
 
 	if (enable) {
-		rtl9310_sds_field_w_new(sds, page, 0x7, 13, 13, 0);
-		rtl9310_sds_field_w_new(sds, page, 0x7, 11, 11, 0);
+		rtsds_931x_write_field(sds, page, 0x7, 13, 13, 0);
+		rtsds_931x_write_field(sds, page, 0x7, 11, 11, 0);
 	} else {
-		rtl9310_sds_field_w_new(sds, page, 0x7, 13, 13, 0);
-		rtl9310_sds_field_w_new(sds, page, 0x7, 11, 11, 0);
+		rtsds_931x_write_field(sds, page, 0x7, 13, 13, 0);
+		rtsds_931x_write_field(sds, page, 0x7, 11, 11, 0);
 	}
 
-	rtl9310_sds_field_w_new(sds, page, 0x7, 4, 0, band);
+	rtsds_931x_write_field(sds, page, 0x7, 4, 0, band);
 
 	rtl931x_sds_rst(sds);
 
@@ -3169,10 +3145,10 @@ int rtl931x_sds_cmu_band_get(int sds, phy_interface_t mode)
 
 	sds -= (sds % 2);
 	page += 1;
-	rtmdio_931x_write_sds_phy_new(sds, 0x1f, 0x02, 73);
+	rtsds_931x_write(sds, 0x1f, 0x02, 73);
 
-	rtl9310_sds_field_w_new(sds, page, 0x5, 15, 15, 1);
-	band = rtl9310_sds_field_r_new(sds, 0x1f, 0x15, 8, 3);
+	rtsds_931x_write_field(sds, page, 0x5, 15, 15, 1);
+	band = rtsds_931x_read_field(sds, 0x1f, 0x15, 8, 3);
 	pr_info("%s band is: %d\n", __func__, band);
 
 	return band;
@@ -3183,15 +3159,15 @@ int rtl931x_link_sts_get(u32 sds)
 {
 	u32 sts, sts1, latch_sts, latch_sts1;
 	if (0){
-		sts = rtl9310_sds_field_r_new(sds, 0x101, 29, 8, 0);
-		sts1 = rtl9310_sds_field_r_new(sds, 0x201, 29, 8, 0);
-		latch_sts = rtl9310_sds_field_r_new(sds, 0x101, 30, 8, 0);
-		latch_sts1 = rtl9310_sds_field_r_new(sds, 0x201, 30, 8, 0);
+		sts = rtsds_931x_read_field(sds, 0x101, 29, 8, 0);
+		sts1 = rtsds_931x_read_field(sds, 0x201, 29, 8, 0);
+		latch_sts = rtsds_931x_read_field(sds, 0x101, 30, 8, 0);
+		latch_sts1 = rtsds_931x_read_field(sds, 0x201, 30, 8, 0);
 	} else {
-		sts = rtl9310_sds_field_r_new(sds, 0x5, 0, 12, 12);
-		latch_sts = rtl9310_sds_field_r_new(sds, 0x4, 1, 2, 2);
-		latch_sts1 = rtl9310_sds_field_r_new(sds, 0x102, 1, 2, 2);
-		sts1 = rtl9310_sds_field_r_new(sds, 0x102, 1, 2, 2);
+		sts = rtsds_931x_read_field(sds, 0x5, 0, 12, 12);
+		latch_sts = rtsds_931x_read_field(sds, 0x4, 1, 2, 2);
+		latch_sts1 = rtsds_931x_read_field(sds, 0x102, 1, 2, 2);
+		sts1 = rtsds_931x_read_field(sds, 0x102, 1, 2, 2);
 	}
 
 	pr_info("%s: serdes %d sts %d, sts1 %d, latch_sts %d, latch_sts1 %d\n", __func__,


### PR DESCRIPTION
During SerDes rework the helper functions were temporarily renamed to ..._new(). Fix the leftovers and drop the _new appendix.
