### PR TITLE
qualcommbe: ipq95xx: add alta route10 support

### DIFF
--- a/target/linux/qualcommbe/files/arch/arm64/boot/dts/qcom/ipq9574-route10.dts
+++ b/target/linux/qualcommbe/files/arch/arm64/boot/dts/qcom/ipq9574-route10.dts
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+
+/dts-v1/;
+
+#include "ipq9574.dtsi"
+
+#include <dt-bindings/clock/qcom,ipq-cmn-pll.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/clock/qcom,qca8k-nsscc.h>
+#include <dt-bindings/net/qcom,qca808x.h>
+#include <dt-bindings/reset/qcom,qca8k-nsscc.h>
+
+/ {
+	model = "Alta Labs Route10";
+	compatible = "alta,route10", "qcom,ipq9574";
+
+	aliases {
+		serial0 = &blsp1_uart2;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	qca8k_uniphy1_rx312p5m: qca8k-uniphy1-rx312p5m {
+		compatible = "fixed-clock";
+		clock-frequency = <312500000>;
+		#clock-cells = <0>;
+	};
+
+	qca8k_uniphy1_tx312p5m: qca8k-uniphy1-tx312p5m {
+		compatible = "fixed-clock";
+		clock-frequency = <312500000>;
+		#clock-cells = <0>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&sfp_leds>;
+		pinctrl-names = "default";
+
+		led-0 {
+			color = <LED_COLOR_ID_WHITE>;
+			label = "led10g_p5";
+			gpios = <&tlmm 61 GPIO_ACTIVE_LOW>;
+		};
+	
+		led-2 {
+			color = <LED_COLOR_ID_WHITE>;
+			label = "led10g_p6";
+			gpios = <&tlmm 62 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_BLUE>;
+			label = "led1g_p5";
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+		};
+	
+		led-4 {
+			color = <LED_COLOR_ID_BLUE>;
+			label = "led1g_p6";
+			gpios = <&tlmm 64 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	sfp0: sfp-0 {
+		compatible = "sff,sfp";
+		pinctrl-0 = <&sfp_0_pins>;
+		pinctrl-names = "default";
+		i2c-bus = <&blsp1_i2c4>;
+		los-gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpios = <&tlmm 28 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp1: sfp-1 {
+		compatible = "sff,sfp";
+		pinctrl-0 = <&sfp_1_pins>;
+		pinctrl-names = "default";
+		i2c-bus = <&blsp1_i2c1>;
+		los-gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpios = <&tlmm 23 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&blsp1_i2c4{
+	pinctrl-0 = <&blsp4_i2c_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp1_i2c1 {
+	pinctrl-0 = <&blsp1_i2c1_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	
+	lp5562@30 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "ti,lp5562";
+		reg = <0x30>;
+		clock-mode = /bits/8 <2>;
+
+		led@0 {
+			reg = <0>;
+			chan-name = "red";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			color = <LED_COLOR_ID_RED>;
+		};
+	
+		led@1 {
+			reg = <1>;
+			chan-name = "green";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		led@2 {
+			reg = <2>;
+			chan-name = "blue";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		led@3 {
+			reg = <3>;
+			chan-name = "white";
+			led-cur = /bits/ 8 <0x20>;
+			max-cur = /bits/ 8 <0x60>;
+			color = <LED_COLOR_ID_WHITE>;
+		};
+	};
+};
+
+&blsp1_uart2 {
+	pinctrl-0 = <&blsp1_uart2_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&sdhc_1 {
+	bus-width = <8>;
+	max-frequency = <384000000>;
+	mmc-ddr-1_8v;
+	mmc-hs200-1_8v;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+	pinctrl-0 = <&emmc_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&qcom_ppe {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@1 {
+			reg = <1>;
+			phy-mode = "qsgmii";
+			label = "wan0";
+			phy-handle = <&phy0>;
+			pcs-handle = <&pcsuniphy0_ch0>;
+			clocks = <&nsscc NSS_CC_PORT1_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT1_RX_CLK>,
+				 <&nsscc NSS_CC_PORT1_TX_CLK>;
+			clock-names = "port_mac",
+				"port_rx",
+				"port_tx";
+			resets = <&nsscc PORT1_MAC_ARES>,
+				 <&nsscc PORT1_RX_ARES>,
+				 <&nsscc PORT1_TX_ARES>;
+			reset-names = "port_mac",
+				"port_rx",
+				"port_tx";
+		};
+		port@2 {
+			reg = <2>;
+			phy-mode = "qsgmii";
+			label = "lan1";
+			phy-handle = <&phy1>;
+			pcs-handle = <&pcsuniphy0_ch1>;
+			clocks = <&nsscc NSS_CC_PORT2_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT2_RX_CLK>,
+				 <&nsscc NSS_CC_PORT2_TX_CLK>;
+			clock-names = "port_mac",
+				"port_rx",
+				"port_tx";
+			resets = <&nsscc PORT2_MAC_ARES>,
+				 <&nsscc PORT2_RX_ARES>,
+				 <&nsscc PORT2_TX_ARES>;
+			reset-names = "port_mac",
+				"port_rx",
+				"port_tx";
+		};
+		port@3 {
+			reg = <3>;
+			phy-mode = "qsgmii";
+			label = "lan2";
+			phy-handle = <&phy2>;
+			pcs-handle = <&pcsuniphy0_ch2>;
+			clocks = <&nsscc NSS_CC_PORT3_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT3_RX_CLK>,
+				 <&nsscc NSS_CC_PORT3_TX_CLK>;
+			clock-names = "port_mac",
+				"port_rx",
+				"port_tx";
+			resets = <&nsscc PORT3_MAC_ARES>,
+				 <&nsscc PORT3_RX_ARES>,
+				 <&nsscc PORT3_TX_ARES>;
+			reset-names = "port_mac",
+				"port_rx",
+				"port_tx";
+		};
+		port@4 {
+			reg = <4>;
+			phy-mode = "qsgmii";
+			label = "lan3";
+			phy-handle = <&phy3>;
+			pcs-handle = <&pcsuniphy0_ch3>;
+			clocks = <&nsscc NSS_CC_PORT4_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT4_RX_CLK>,
+				 <&nsscc NSS_CC_PORT4_TX_CLK>;
+			clock-names = "port_mac",
+				"port_rx",
+				"port_tx";
+			resets = <&nsscc PORT4_MAC_ARES>,
+				 <&nsscc PORT4_RX_ARES>,
+				 <&nsscc PORT4_TX_ARES>;
+			reset-names = "port_mac",
+				"port_rx",
+				"port_tx";
+		};
+
+		port@5 {
+			reg = <5>;
+			phy-mode = "10gbase-r";
+			managed = "in-band-status";
+			label = "wan1";
+			sfp = <&sfp0>;
+			pcs-handle = <&pcsuniphy1_ch0>;
+			local-mac-address = [00 00 00 00 00 00];
+			clocks = <&nsscc NSS_CC_PORT5_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT5_RX_CLK>,
+				 <&nsscc NSS_CC_PORT5_TX_CLK>;
+			clock-names = "port_mac",
+				"port_rx",
+				"port_tx";
+			resets = <&nsscc PORT5_MAC_ARES>,
+				 <&nsscc PORT5_RX_ARES>,
+				<&nsscc PORT5_TX_ARES>;
+			reset-names = "port_mac",
+				"port_rx",
+				"port_tx";
+		};
+
+		port@6 {
+			reg = <6>;
+			phy-mode = "10gbase-r";
+			managed = "in-band-status";
+			label = "lan4";
+			sfp = <&sfp1>;
+			pcs-handle = <&pcsuniphy2_ch0>;
+			local-mac-address = [00 00 00 00 00 00];
+			clocks = <&nsscc NSS_CC_PORT6_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT6_RX_CLK>,
+				 <&nsscc NSS_CC_PORT6_TX_CLK>;
+			clock-names = "port_mac",
+				"port_rx",
+				"port_tx";
+			resets = <&nsscc PORT6_MAC_ARES>,
+				 <&nsscc PORT6_RX_ARES>,
+				 <&nsscc PORT6_TX_ARES>;
+			reset-names = "port_mac",
+				"port_rx",
+				"port_tx";
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	phy-reset-gpio = <&tlmm 60 0>;
+	
+	qca8k_nsscc: clock-controller@18 {
+		compatible = "qcom,qca8084-nsscc";
+			reg = <0x18>;
+			clocks = <&cmn_pll ETH0_50MHZ_CLK>,
+				<0>,
+				<0>,
+				<0>,
+				<0>,
+				<&qca8k_uniphy1_rx312p5m>,
+				<&qca8k_uniphy1_tx312p5m>;
+			#clock-cells = <1>;
+			#reset-cells = <1>;
+			#power-domain-cells = <1>;
+	};
+
+	ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "qcom,qca8084-package";
+		reg = <0>;
+		clocks = <&qca8k_nsscc NSS_CC_APB_BRIDGE_CLK>,
+			 <&qca8k_nsscc NSS_CC_AHB_CLK>,
+			 <&qca8k_nsscc NSS_CC_SEC_CTRL_AHB_CLK>,
+			 <&qca8k_nsscc NSS_CC_TLMM_CLK>,
+			 <&qca8k_nsscc NSS_CC_TLMM_AHB_CLK>,
+			 <&qca8k_nsscc NSS_CC_CNOC_AHB_CLK>,
+			 <&qca8k_nsscc NSS_CC_MDIO_AHB_CLK>;
+		clock-names = "apb_bridge",
+			"ahb",
+			"sec_ctrl_ahb",
+			"tlmm",
+			"tlmm_ahb",
+			"cnoc_ahb",
+			"mdio_ahb";
+		resets = <&qca8k_nsscc NSS_CC_GEPHY_FULL_ARES>;
+		com,phy-addr-fixup = <1 2 3 4 5 6 7>;
+
+		qcom,package-mode = <QCA808X_PCS1_10G_QXGMII_PCS0_UNUNSED>;
+
+		phy0: ethernet-phy@1 {
+			compatible = "ethernet-phy-id004d.d101", "ethernet-phy-ieee802.3-c22";
+			reg = <1>;
+			clocks = <&qca8k_nsscc NSS_CC_GEPHY0_SYS_CLK>;
+			resets = <&qca8k_nsscc NSS_CC_GEPHY0_SYS_ARES>;
+		};
+
+		phy1: ethernet-phy@2 {
+			compatible = "ethernet-phy-id004d.d101", "ethernet-phy-ieee802.3-c22";
+			reg = <2>;
+			clocks = <&qca8k_nsscc NSS_CC_GEPHY1_SYS_CLK>;
+			resets = <&qca8k_nsscc NSS_CC_GEPHY1_SYS_ARES>;
+		};
+
+		phy2: ethernet-phy@3 {
+			compatible = "ethernet-phy-id004d.d101", "ethernet-phy-ieee802.3-c22";
+			reg = <3>;
+			clocks = <&qca8k_nsscc NSS_CC_GEPHY2_SYS_CLK>;
+			resets = <&qca8k_nsscc NSS_CC_GEPHY2_SYS_ARES>;
+		};
+
+		phy3: ethernet-phy@4 {
+			compatible = "ethernet-phy-id004d.d101", "ethernet-phy-ieee802.3-c22";
+			reg = <4>;
+			clocks = <&qca8k_nsscc NSS_CC_GEPHY3_SYS_CLK>;
+			resets = <&qca8k_nsscc NSS_CC_GEPHY3_SYS_ARES>;
+		};
+	};
+};
+
+&rpm_requests {
+	regulators {
+		compatible = "qcom,rpm-mp5496-regulators";
+
+		ipq9574_s1: s1 {
+			regulator-min-microvolt = <725000>;
+			regulator-max-microvolt = <1075000>;
+		};
+
+		mp5496_l2: l2 {
+			regulator-min-microvolt = <850000>;
+			regulator-max-microvolt = <850000>;
+			regulator-always-on;
+			regulator-boot-on;
+		};
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&tlmm {
+	blsp1_i2c1_pins: blsp1-i2c1-pins {
+		pins = "gpio36", "gpio37";
+		function = "blsp1_i2c";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	blsp4_i2c_pins: blsp4-i2c-pins {
+		pins = "gpio50", "gpio51";
+		function = "blsp4_i2c";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	blsp1_uart2_pins: blsp1_uart2_pinmux {
+		pins = "gpio34", "gpio35";
+		function = "blsp2_uart";
+		drive-strength = <8>;
+		bias-disable;
+	};
+	
+	emmc_pins: emmc_pins {
+		clk-pins {
+			pins = "gpio5";
+			function = "sdc_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+		cmd-pins {
+			pins = "gpio4";
+			function = "sdc_cmd";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+		data-pins {
+			pins = "gpio0", "gpio1", "gpio2",
+				"gpio3", "gpio6", "gpio7",
+				"gpio8", "gpio9";
+			function = "sdc_data";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+		rclk-pins {
+			pins = "gpio10";
+			function = "sdc_rclk";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+	};
+	
+	sfp_leds: sfp_leds_pinmux {
+		led_en {
+			pins = "gpio43";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-pull-down;
+			output-low;
+		};
+
+		sfp_10g_p5 {
+			pins = "gpio61";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		sfp_10g_p6 {
+			pins = "gpio62";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		sfp_1g_p5 {
+			pins = "gpio63";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+		
+		sfp_1g_p6 {
+			pins = "gpio64";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	sfp_0_pins: sfp_0_pinmux {
+		tx_disable_p5 {
+			pins = "gpio28";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+
+		los_gpio_p5 {
+			pins = "gpio31";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+	
+	sfp_1_pins: sfp_1_pinmux {
+		tx_disable_p6 {
+			pins = "gpio23";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+
+		los_gpio_p6 {
+			pins = "gpio25";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+};
+
+/*
+ * The bootstrap pins for the board select the XO clock frequency,
+ * which automatically enables the right dividers to ensure the
+ * reference clock output from WiFi is 48 MHZ.
+ */
+&ref_48mhz_clk {
+	clock-div = <1>;
+	clock-mult = <1>;
+};
+
+/*
+ * The frequency of xo_board_clk is fixed to 24 MHZ, which is routed
+ * from WiFi output clock 48 MHZ divided by 2.
+ */
+&xo_board_clk {
+	clock-div = <2>;
+	clock-mult = <1>;
+};
+
+&xo_clk {
+	clock-frequency = <48000000>;
+};

--- a/target/linux/qualcommbe/image/ipq95xx.mk
+++ b/target/linux/qualcommbe/image/ipq95xx.mk
@@ -10,6 +10,16 @@ define Device/8devices_kiwi-dvk
 endef
 TARGET_DEVICES += 8devices_kiwi-dvk
 
+define Device/alta_route10
+	$(call Device/FitImage)
+	$(call Device/EmmcImage)
+	DEVICE_VENDOR := Alta Labs
+	DEVICE_MODEL := Route10
+	SOC := ipq9574
+	DEVICE_PACKAGES := f2fsck mkf2fs kmod-sfp
+endef
+TARGET_DEVICES += alta_route10
+
 define Device/qcom_rdp433
 	$(call Device/FitImageLzma)
 	DEVICE_VENDOR := Qualcomm Technologies, Inc.

--- a/target/linux/qualcommbe/ipq95xx/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommbe/ipq95xx/base-files/etc/board.d/01_leds
@@ -1,0 +1,19 @@
+
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+board=$(board_name)
+
+case "$board" in
+alta,route10)
+	ucidef_set_led_netdev "wan1-link-1g" "WAN-SFP-PORT-LINK-1G" "led1g_p6" "wan1" "link"
+	ucidef_set_led_netdev "wan1-link-10g" "WAN-SFP-PORT-LINK" "led10g_p6" "wan1" "tx rx"
+	ucidef_set_led_netdev "lan4-link-1g" "LAN-SFP-PORT-LINK-1G" "led1g_p5" "lan4" "link"
+	ucidef_set_led_netdev "lan4-link-10g" "LAN-SFP-PORT-LINK" "led10g_p5" "lan4" "tx rx"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/qualcommbe/ipq95xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommbe/ipq95xx/base-files/etc/board.d/02_network
@@ -14,6 +14,9 @@ ipq95xx_setup_interfaces()
 	8devices,kiwi-dvk)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
+	alta,route10)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan0 wan1"
+		;;
 	qcom,ipq9574-ap-al02-c7)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "wan"
 		;;

--- a/target/linux/qualcommbe/ipq95xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommbe/ipq95xx/base-files/lib/upgrade/platform.sh
@@ -9,7 +9,8 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
-	8devices,kiwi-dvk)
+	8devices,kiwi-dvk|\
+	alta,route10)
 		CI_KERNPART="0:HLOS"
 		CI_ROOTPART="rootfs"
 		emmc_do_upgrade "$1"


### PR DESCRIPTION
**Specifications:**
  SoC:      Qualcomm IPQ9574
  RAM:      1 GiB DDR4
  Flash:    4 GiB eMMC
  PCS0:     QCA8084 PHY in QXGMII mode (4 x 2.5G Ports)
  PCS1:     10G SFP+ cage
  PCS2:     10G SFP+ cage
  Button:   Reset
  UART :    3.3v header on PCB

**Overview**
This is a simple router with no wifi connectivity, 4x2.5G ports via a QCA8084 and 2x10G SFP+ ports), it looks to be a good candidate for use as a retail dev board because it has a pre populated UART header on the PCB and both u-boot and stock firmware serial consoles are unlocked.

**What Works :**
- Both SFP ports work at 10G
- QCA8084 PHY enumerates all ports (*however no traffic is seen see note below*)
- eMMC
- Serial
- logo LED is enabled via uboot
- PPE engine seems we are waiting for more patches to enable flow offloading ? (this limits network routing to aprox 800Mbps)
- SFP+ LED's

**Not Working :** 
- POE (this may never work due to obscure PoE chip)

**QCA8084**
Looks like the support for this switch / phy is incomplete in openwrt, but this is resolved in the PR : https://github.com/openwrt/openwrt/pull/18930 (however the IPQ5424 PR breaks the SFP+ port detection)

**tftp boot instructions**
```
    $ tftpb 192.168.10.1:openwrt-qualcommbe-ipq95xx-alta_route10-initramfs-uImage.itb
    $ bootm
```

**install from initramfs**
`    $ sysupgrade openwrt-qualcommbe-ipq95xx-alta_route10-squashfs-sysupgrade.bin`

**Boot logs**
```
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x411fd090]
[    0.000000] Linux version 6.12.44 (shane@wasp) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r30963-79d3db7447) 15
[    0.000000] Machine model: Alta-Route10
[    0.000000] OF: reserved mem: 0x000000004a100000..0x000000004a4fffff (4096 KiB) nomap non-reusable bootloader@4a100000
[    0.000000] OF: reserved mem: 0x000000004a500000..0x000000004a5fffff (1024 KiB) nomap non-reusable sbl@4a500000
[    0.000000] OF: reserved mem: 0x000000004a600000..0x000000004a9fffff (4096 KiB) nomap non-reusable tz@4a600000
[    0.000000] OF: reserved mem: 0x000000004aa00000..0x000000004aafffff (1024 KiB) nomap non-reusable smem@4aa00000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000007fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x000000004a0fffff]
[    0.000000]   node   0: [mem 0x000000004a100000-0x000000004aafffff]
[    0.000000]   node   0: [mem 0x000000004ab00000-0x000000007fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000007fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.0 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.0
[    0.000000] percpu: Embedded 20 pages/cpu s43224 r8192 d30504 u81920
[    0.000000] pcpu-alloc: s43224 r8192 d30504 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: Spectre-v2
[    0.000000] CPU features: detected: Spectre-v4
[    0.000000] CPU features: detected: Spectre-BHB
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: console=ttyMSM0 rootwait root=/dev/mmcblk0p27
[    0.000000] Dentry cache hash table entries: 131072 (order: 8, 1048576 bytes, linear)
[    0.000000] Inode-cache hash table entries: 65536 (order: 7, 524288 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 262144
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 1MB
[    0.000000] software IO TLB: area num 4.
[    0.000000] software IO TLB: mapped [mem 0x000000007ea80000-0x000000007eb80000] (1MB)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000]  Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks Trace: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=4.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv2m: range[mem 0x0b00c000-0x0b00cffc], SPI[640:671]
[    0.000000] GICv2m: range[mem 0x0b00d000-0x0b00dffc], SPI[672:703]
[    0.000000] GICv2m: range[mem 0x0b00e000-0x0b00effc], SPI[704:735]
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 and mmio timer(s) running at 24.00MHz (virt/virt).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x588fe9dc0, max_idle_ns: 440795202592 ns
[    0.000000] sched_clock: 56 bits at 24MHz, resolution 41ns, wraps every 4398046511097ns
[    0.000056] Calibrating delay loop (skipped), value calculated using timer frequency.. 48.00 BogoMIPS (lpj=240000)
[    0.000065] pid_max: default: 32768 minimum: 301
[    0.003953] Mount-cache hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.003963] Mountpoint-cache hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.007358] rcu: Hierarchical SRCU implementation.
[    0.007361] rcu:     Max phase no-delay instances is 1000.
[    0.007548] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.007806] smp: Bringing up secondary CPUs ...
[    0.009271] Detected VIPT I-cache on CPU1
[    0.009361] CPU1: Booted secondary processor 0x0000000001 [0x411fd090]
[    0.011038] Detected VIPT I-cache on CPU2
[    0.011126] CPU2: Booted secondary processor 0x0000000002 [0x411fd090]
[    0.012761] Detected VIPT I-cache on CPU3
[    0.012846] CPU3: Booted secondary processor 0x0000000003 [0x411fd090]
[    0.012948] smp: Brought up 1 node, 4 CPUs
[    0.012955] SMP: Total of 4 processors activated.
[    0.012959] CPU: All CPU(s) started at EL1
[    0.012962] CPU features: detected: 32-bit EL0 Support
[    0.012966] CPU features: detected: CRC32 instructions
[    0.013009] alternatives: applying system-wide alternatives
[    0.013126] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.013320] Memory: 979508K/1048576K available (9088K kernel code, 1002K rwdata, 2980K rodata, 20288K init, 286K bss, 6)
[    0.017504] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.017519] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.017574] 24304 pages in range for non-PLT usage
[    0.017578] 515824 pages in range for PLT usage
[    0.019362] pinctrl core: initialized pinctrl subsystem
[    0.020954] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.021342] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.021398] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.021450] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.021690] thermal_sys: Registered thermal governor 'step_wise'
[    0.021730] cpuidle: using governor menu
[    0.021854] ASID allocator initialised with 65536 entries
[    0.024965] /soc@0/interrupt-controller@b000000: Fixed dependency cycle(s) with /soc@0/interrupt-controller@b000000
[    0.053714] SCSI subsystem initialized
[    0.053850] usbcore: registered new interface driver usbfs
[    0.053886] usbcore: registered new interface driver hub
[    0.053908] usbcore: registered new device driver usb
[    0.054603] qcom_scm: convention: smc arm 64
[    0.059872] s1: Bringing 0uV into 725000-725000uV
[    0.060005] qcom_rpm_smd_regulator remoteproc:glink-edge:rpm-requests:regulators: Supply for s1 (s1) resolved to itself
[    0.060102] l2: Bringing 0uV into 850000-850000uV
[    0.060286] clocksource: Switched to clocksource arch_sys_counter
[    0.063260] NET: Registered PF_INET protocol family
[    0.063369] IP idents hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.065361] tcp_listen_portaddr_hash hash table entries: 512 (order: 1, 8192 bytes, linear)
[    0.065377] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.065388] TCP established hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.065443] TCP bind hash table entries: 8192 (order: 6, 262144 bytes, linear)
[    0.065635] TCP: Hash tables configured (established 8192 bind 8192)
[    0.066014] MPTCP token hash table entries: 1024 (order: 2, 24576 bytes, linear)
[    0.066146] UDP hash table entries: 512 (order: 2, 16384 bytes, linear)
[    0.066174] UDP-Lite hash table entries: 512 (order: 2, 16384 bytes, linear)
[    0.066525] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.066554] PCI: CLS 0 bytes, default 64
[    0.071474] workingset: timestamp_bits=46 max_order=18 bucket_order=0
[    0.071924] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.071929] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.095704] Serial: 8250/16550 driver, 2 ports, IRQ sharing disabled
[    0.096458] msm_serial 78b1000.serial: msm_serial: detected port #0
[    0.096535] msm_serial 78b1000.serial: uartclk = 1843199
[    0.096833] 78b1000.serial: ttyMSM0 at MMIO 0x78b1000 (irq = 20, base_baud = 115199) is a MSM
[    0.096892] msm_serial: console setup on port #0
[    0.096924] printk: legacy console [ttyMSM0] enabled
[    0.815315] msm_serial: driver initialized
[    0.823182] loop: module loaded
[    0.867250] i2c_dev: i2c /dev entries driver
[    0.867445] i2c_qup 78b6000.i2c: using default clock-frequency 100000
[    0.871254] i2c_qup 78b9000.i2c: using default clock-frequency 100000
[    0.881437] sdhci: Secure Digital Host Controller Interface driver
[    0.883338] sdhci: Copyright(c) Pierre Ossman
[    0.889412] sdhci-pltfm: SDHCI platform and OF driver helper
[    0.894828] mmc0: CQHCI version 5.10
[    0.896485] NET: Registered PF_INET6 protocol family
[    0.904145] Segment Routing with IPv6
[    0.908109] In-situ OAM (IOAM) with IPv6
[    0.911703] NET: Registered PF_PACKET protocol family
[    0.915742] 8021q: 802.1Q VLAN Support v1.8
[    0.932895] mmc0: SDHCI controller on 7804000.mmc [7804000.mmc] using ADMA 64-bit
[    0.932936] sdhci_msm 7804000.mmc: mmc0: CQE init: success
[    0.952527] cpufreq: cpufreq_online: CPU0: Running at unlisted initial frequency: 799999 KHz, changing to: 936000 KHz
[    0.953422] clk: Disabling unused clocks
[    0.971450] ------------[ cut here ]------------
[    0.971464] nss_cc_mdio_ahb_clk status stuck at 'on'
[    0.971478] WARNING: CPU: 2 PID: 1 at drivers/clk/qcom/clk-branch.c:87 clk_branch_toggle+0x168/0x180
[    0.980066] Modules linked in:
[    0.989176] CPU: 2 UID: 0 PID: 1 Comm: swapper/0 Not tainted 6.12.44 #0
[    0.992042] Hardware name: Alta-Route10 (DT)
[    0.998551] pstate: 60400005 (nZCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[    1.003066] pc : clk_branch_toggle+0x168/0x180
[    1.009749] lr : clk_branch_toggle+0x168/0x180
[    1.014262] sp : ffffffc082133cc0
[    1.018688] x29: ffffffc082133cc0 x28: 0000000000000000 x27: 0000000000000000
[    1.022078] x26: 0000000000000000 x25: 0000000000000000 x24: ffffffc080b41228
[    1.029195] x23: 0000000000000000 x22: 0000000000000000 x21: ffffffc0804cbea8
[    1.036313] x20: ffffffc08206bc78 x19: 0000000000000000 x18: ffffffc081fdb878
[    1.043431] x17: ffffffc082070ee0 x16: 00000000ebf8ae67 x15: 0000000000000088
[    1.050549] x14: 0000000000000088 x13: 00000000ffffffea x12: ffffffc082033820
[    1.057668] x11: ffffffc081fdb878 x10: ffffffc082033878 x9 : 0000000000000001
[    1.064786] x8 : 0000000000000001 x7 : 0000000000017fe8 x6 : c0000000ffffefff
[    1.071903] x5 : 0000000000057fa8 x4 : 0000000000000000 x3 : ffffffc082133aa0
[    1.079022] x2 : ffffffc081fdb7a0 x1 : ffffffc081fdb7a0 x0 : 0000000000000028
[    1.086140] Call trace:
[    1.093253]  clk_branch_toggle+0x168/0x180
[    1.095512]  clk_branch2_disable+0x1c/0x30
[    1.099678]  clk_unprepare_unused_subtree+0xb0/0xc0
[    1.103760]  clk_unprepare_unused_subtree+0x2c/0xc0
[    1.108534]  clk_unprepare_unused_subtree+0x2c/0xc0
[    1.113395]  clk_disable_unused+0xa8/0xf0
[    1.118255]  do_one_initcall+0x50/0x210
[    1.122422]  kernel_init_freeable+0x23c/0x298
[    1.126068]  kernel_init+0x20/0x120
[    1.130580]  ret_from_fork+0x10/0x20
[    1.133880] ---[ end trace 0000000000000000 ]---
[    1.146658] ------------[ cut here ]------------
[    1.146669] nss_cc_cnoc_ahb_clk status stuck at 'on'
[    1.146678] WARNING: CPU: 2 PID: 1 at drivers/clk/qcom/clk-branch.c:87 clk_branch_toggle+0x168/0x180
[    1.155271] Modules linked in:
[    1.164380] CPU: 2 UID: 0 PID: 1 Comm: swapper/0 Tainted: G        W          6.12.44 #0
[    1.167250] Tainted: [W]=WARN
[    1.175490] Hardware name: Alta-Route10 (DT)
[    1.178356] pstate: 60400005 (nZCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[    1.182698] pc : clk_branch_toggle+0x168/0x180
[    1.189381] lr : clk_branch_toggle+0x168/0x180
[    1.193895] sp : ffffffc082133cc0
[    1.198321] x29: ffffffc082133cc0 x28: 0000000000000000 x27: 0000000000000000
[    1.201709] x26: 0000000000000000 x25: 0000000000000000 x24: ffffffc080b41240
[    1.208827] x23: 0000000000000000 x22: 0000000000000000 x21: ffffffc0804cbea8
[    1.215946] x20: ffffffc08206bcc0 x19: 0000000000000000 x18: ffffffc081fdb878
[    1.223063] x17: ffffffc082070ee0 x16: 0000000000000000 x15: 00000000000000a8
[    1.230182] x14: 00000000000000a8 x13: 00000000ffffffea x12: ffffffc082033820
[    1.237299] x11: ffffffc081fdb878 x10: ffffffc082033878 x9 : 0000000000000001
[    1.244418] x8 : 0000000000000001 x7 : 0000000000017fe8 x6 : c0000000ffffefff
[    1.251536] x5 : 0000000000057fa8 x4 : 0000000000000000 x3 : ffffffc082133aa0
[    1.258654] x2 : ffffffc081fdb7a0 x1 : ffffffc081fdb7a0 x0 : 0000000000000028
[    1.265772] Call trace:
[    1.272885]  clk_branch_toggle+0x168/0x180
[    1.275143]  clk_branch2_disable+0x1c/0x30
[    1.279310]  clk_unprepare_unused_subtree+0xb0/0xc0
[    1.283392]  clk_unprepare_unused_subtree+0x2c/0xc0
[    1.288165]  clk_unprepare_unused_subtree+0x2c/0xc0
[    1.293026]  clk_disable_unused+0xa8/0xf0
[    1.297887]  do_one_initcall+0x50/0x210
[    1.302053]  kernel_init_freeable+0x23c/0x298
[    1.305699]  kernel_init+0x20/0x120
[    1.310212]  ret_from_fork+0x10/0x20
[    1.313511] ---[ end trace 0000000000000000 ]---
[    1.326540] ------------[ cut here ]------------
[    1.326548] nss_cc_ahb_clk status stuck at 'on'
[    1.326556] WARNING: CPU: 2 PID: 1 at drivers/clk/qcom/clk-branch.c:87 clk_branch_toggle+0x168/0x180
[    1.334455] Modules linked in:
[    1.343824] CPU: 2 UID: 0 PID: 1 Comm: swapper/0 Tainted: G        W          6.12.44 #0
[    1.346694] Tainted: [W]=WARN
[    1.354936] Hardware name: Alta-Route10 (DT)
[    1.357801] pstate: 60400005 (nZCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[    1.362144] pc : clk_branch_toggle+0x168/0x180
[    1.368825] lr : clk_branch_toggle+0x168/0x180
[    1.373339] sp : ffffffc082133cc0
[    1.377765] x29: ffffffc082133cc0 x28: 0000000000000000 x27: 0000000000000000
[    1.381155] x26: 0000000000000000 x25: 0000000000000000 x24: ffffffc080b41298
[    1.388272] x23: 0000000000000000 x22: 0000000000000000 x21: ffffffc0804cbea8
[    1.395391] x20: ffffffc08206bde0 x19: 0000000000000000 x18: ffffffc081fdb878
[    1.402508] x17: ffffffc082070ee0 x16: 0000000000000000 x15: 00000000000000c9
[    1.409626] x14: 00000000000000c9 x13: 00000000ffffffea x12: ffffffc082033820
[    1.416744] x11: ffffffc081fdb878 x10: ffffffc082033878 x9 : 0000000000000001
[    1.423862] x8 : 0000000000000001 x7 : 0000000000017fe8 x6 : c0000000ffffefff
[    1.430980] x5 : 0000000000057fa8 x4 : 0000000000000000 x3 : ffffffc082133aa0
[    1.438098] x2 : ffffffc081fdb7a0 x1 : ffffffc081fdb7a0 x0 : 0000000000000023
[    1.445217] Call trace:
[    1.452331]  clk_branch_toggle+0x168/0x180
[    1.454589]  clk_branch2_disable+0x1c/0x30
[    1.458755]  clk_unprepare_unused_subtree+0xb0/0xc0
[    1.462837]  clk_unprepare_unused_subtree+0x2c/0xc0
[    1.467611]  clk_unprepare_unused_subtree+0x2c/0xc0
[    1.472471]  clk_disable_unused+0xa8/0xf0
[    1.477332]  do_one_initcall+0x50/0x210
[    1.481498]  kernel_init_freeable+0x23c/0x298
[    1.485145]  kernel_init+0x20/0x120
[    1.489658]  ret_from_fork+0x10/0x20
[    1.492957] ---[ end trace 0000000000000000 ]---
[    1.503599] Freeing unused kernel memory: 20288K
[    1.503651] Run /init as init process
[    1.507269]   with arguments:
[    1.507270]     /init
[    1.507272]   with environment:
[    1.507273]     HOME=/
[    1.507274]     TERM=linux
[    1.532823] mmc0: Command Queue Engine enabled
[    1.532851] mmc0: new HS400 Enhanced strobe MMC card at address 0001
[    1.536511] mmcblk0: mmc0:0001 4FTE4R 3.64 GiB
[    1.543537] Alternate GPT is invalid, using primary GPT.
[    1.546938]  mmcblk0: p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 p16 p17 p18 p19 p20 p21 p22 p23 p24 p25 p26 p29
[    1.553287] mmcblk0boot0: mmc0:0001 4FTE4R 4.00 MiB
[    1.564127] init: Console is alive
[    1.564188] mmcblk0boot1: mmc0:0001 4FTE4R 4.00 MiB
[    1.568602] init: - watchdog -
[    1.572163] mmcblk0rpmb: mmc0:0001 4FTE4R 512 KiB, chardev (247:0)
[    1.578940] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    1.593746] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    1.598844] lp5562 0-0030: probe with driver lp5562 failed with error -22
[    1.599825] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    1.607224] init: - preinit -
[    8.120263] random: crng init done
[   12.010305] qcom,gcc-ipq9574 1800000.clock-controller: sync_state() pending due to 3a000000.ethernet
[   12.010340] qcom,nsscc-ipq9574 39b00000.clock-controller: sync_state() pending due to 3a000000.ethernet
[   12.018502] qcom,gcc-ipq9574 1800000.clock-controller: sync_state() pending due to 7a00000.ethernet-pcs
[   12.027629] qcom,nsscc-ipq9574 39b00000.clock-controller: sync_state() pending due to 7a00000.ethernet-pcs
[   12.037000] qcom,gcc-ipq9574 1800000.clock-controller: sync_state() pending due to 7a10000.ethernet-pcs
[   12.046719] qcom,nsscc-ipq9574 39b00000.clock-controller: sync_state() pending due to 7a10000.ethernet-pcs
[   12.056007] qcom,gcc-ipq9574 1800000.clock-controller: sync_state() pending due to 7a20000.ethernet-pcs
[   12.065734] qcom,nsscc-ipq9574 39b00000.clock-controller: sync_state() pending due to 7a20000.ethernet-pcs
[   12.188352] procd: - early -
[   12.188409] procd: - watchdog -
[   12.701785] procd: - watchdog -
[   12.701941] procd: - ubus -
[   12.754715] procd: - init -
[   12.825610] kmodloader: loading kernel modules from /etc/modules.d/*
[   12.851419] dummy# (dummy): netif_napi_add_weight() called with weight 128
[   12.852039] qcom_ppe 3a000000.ethernet: EDMA configuration successful
[   12.857254] qcom_ppe 3a000000.ethernet wan0 (uninitialized): GMAC1 Using random MAC address - c6:32:6d:33:3d:1b
[   12.862164] urngd: v1.0.2 started.
[   12.931767] qcom_ppe 3a000000.ethernet wan0 (uninitialized): PHY [90000.mdio-1:01] driver [Qualcomm QCA8081] (irq=POLL)
[   12.932238] qcom_ppe 3a000000.ethernet lan1 (uninitialized): GMAC2 Using random MAC address - 6a:2d:6f:83:fc:cd
[   13.012200] qcom_ppe 3a000000.ethernet lan1 (uninitialized): PHY [90000.mdio-1:02] driver [Qualcomm QCA8081] (irq=POLL)
[   13.012911] qcom_ppe 3a000000.ethernet lan2 (uninitialized): GMAC3 Using random MAC address - 92:20:7a:a4:fd:e9
[   13.092108] qcom_ppe 3a000000.ethernet lan2 (uninitialized): PHY [90000.mdio-1:03] driver [Qualcomm QCA8081] (irq=POLL)
[   13.092790] qcom_ppe 3a000000.ethernet lan3 (uninitialized): GMAC4 Using random MAC address - d6:ab:6e:17:92:8c
[   13.172105] qcom_ppe 3a000000.ethernet lan3 (uninitialized): PHY [90000.mdio-1:04] driver [Qualcomm QCA8081] (irq=POLL)
[   13.172809] qcom_ppe 3a000000.ethernet wan1 (uninitialized): GMAC5 Using random MAC address - aa:d0:54:f0:6a:f8
[   13.182249] qcom_ppe 3a000000.ethernet lan4 (uninitialized): GMAC6 Using random MAC address - 56:25:04:82:4e:12
[   13.193566] sfp sfp-0: Host maximum power 1.0W
[   13.202009] sfp sfp-0: No tx_disable pin: SFP modules will always be emitting.
[   13.206628] sfp sfp-1: Host maximum power 1.0W
[   13.213681] sfp sfp-1: No tx_disable pin: SFP modules will always be emitting.
[   13.228156] PPP generic driver version 2.4.2
[   13.228542] NET: Registered PF_PPPOX protocol family
[   13.232856] kmodloader: done loading kernel modules from /etc/modules.d/*
[   13.520802] sfp sfp-0: module OEM              SFP+-T30         rev 1    sn C202411240469    dc 241121  
[   13.550715] hwmon hwmon13: temp1_input not attached to any thermal zone
[   14.510488] sfp sfp-1: please wait, module slow to respond
[   15.289109] qcom_ppe 3a000000.ethernet lan1: configuring for phy/qsgmii link mode
[   15.488103] br-lan: port 1(lan1) entered blocking state
[   15.488135] br-lan: port 1(lan1) entered disabled state
[   15.492169] qcom_ppe 3a000000.ethernet lan1: entered allmulticast mode
[   15.497513] qcom_ppe 3a000000.ethernet lan1: entered promiscuous mode
[   15.508538] qcom_ppe 3a000000.ethernet lan2: configuring for phy/qsgmii link mode
[   15.671325] br-lan: port 2(lan2) entered blocking state
[   15.671357] br-lan: port 2(lan2) entered disabled state
[   15.675368] qcom_ppe 3a000000.ethernet lan2: entered allmulticast mode
[   15.680749] qcom_ppe 3a000000.ethernet lan2: entered promiscuous mode
[   15.689526] qcom_ppe 3a000000.ethernet lan3: configuring for phy/qsgmii link mode
[   15.730305] qcom_ppe 3a000000.ethernet lan2: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   15.897572] br-lan: port 2(lan2) entered blocking state
[   15.897596] br-lan: port 2(lan2) entered forwarding state
[   15.901808] br-lan: port 3(lan3) entered blocking state
[   15.907147] br-lan: port 3(lan3) entered disabled state
[   15.912211] qcom_ppe 3a000000.ethernet lan3: entered allmulticast mode
[   15.917553] qcom_ppe 3a000000.ethernet lan3: entered promiscuous mode
[   15.925731] qcom_ppe 3a000000.ethernet lan4: configuring for inband/10gbase-r link mode
[   15.976596] br-lan: port 4(lan4) entered blocking state
[   15.976619] br-lan: port 4(lan4) entered disabled state
[   15.980651] qcom_ppe 3a000000.ethernet lan4: entered allmulticast mode
[   15.985995] qcom_ppe 3a000000.ethernet lan4: entered promiscuous mode
[   15.995965] qcom_ppe 3a000000.ethernet wan0: configuring for phy/qsgmii link mode
[   16.151059] br-wan: port 1(wan0) entered blocking state
[   16.151091] br-wan: port 1(wan0) entered disabled state
[   16.155105] qcom_ppe 3a000000.ethernet wan0: entered allmulticast mode
[   16.160523] qcom_ppe 3a000000.ethernet wan0: entered promiscuous mode
[   16.169718] qcom_ppe 3a000000.ethernet wan1: configuring for inband/10gbase-r link mode
[   16.217118] br-wan: port 2(wan1) entered blocking state
[   16.217147] br-wan: port 2(wan1) entered disabled state
[   16.221184] qcom_ppe 3a000000.ethernet wan1: entered allmulticast mode
[   16.226496] qcom_ppe 3a000000.ethernet wan1: entered promiscuous mode
[   16.390303] ipq9574_pcs 7a10000.ethernet-pcs: PCS link up fail for interface 10gbase-r
[   16.390353] qcom_ppe 3a000000.ethernet wan1: Link is Up - 10Gbps/Full - flow control rx/tx
[   16.390381] br-wan: port 2(wan1) entered blocking state
[   16.405356] br-wan: port 2(wan1) entered forwarding state
[   69.930394] sfp sfp-1: failed to read EEPROM: -ENXIO
```

**ip link**
```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: wan0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq master br-wan state DOWN qlen 1000
    link/ether 0e:da:64:89:47:67 brd ff:ff:ff:ff:ff:ff
3: lan1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq master br-lan state DOWN qlen 1000
    link/ether f6:bd:5b:40:8d:4b brd ff:ff:ff:ff:ff:ff
4: lan2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master br-lan state UP qlen 1000
    link/ether 66:2e:84:79:67:a2 brd ff:ff:ff:ff:ff:ff
5: lan3: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq master br-lan state DOWN qlen 1000
    link/ether de:b7:59:3d:78:8b brd ff:ff:ff:ff:ff:ff
6: wan1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master br-wan state UP qlen 1000
    link/ether 3e:22:de:be:52:16 brd ff:ff:ff:ff:ff:ff
7: lan4: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc mq master br-lan state DOWN qlen 1000
    link/ether 3a:f6:58:89:6a:1b brd ff:ff:ff:ff:ff:ff
8: br-lan: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP qlen 1000
    link/ether f6:bd:5b:40:8d:4b brd ff:ff:ff:ff:ff:ff
9: br-wan: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP qlen 1000
    link/ether 0e:da:64:89:47:67 brd ff:ff:ff:ff:ff:ff
```

**ethtool (sfp+)**
```
Settings for wan1:
        Supported ports: [ FIBRE ]
        Supported link modes:   10000baseSR/Full
        Supported pause frame use: Symmetric Receive-only
        Supports auto-negotiation: Yes
        Supported FEC modes: Not reported
        Advertised link modes:  10000baseSR/Full
        Advertised pause frame use: Symmetric Receive-only
        Advertised auto-negotiation: Yes
        Advertised FEC modes: Not reported
        Speed: 10000Mb/s
        Duplex: Full
        Auto-negotiation: on
        Port: FIBRE
        PHYAD: 0
        Transceiver: internal
        Link detected: yes
```

**ethtool (2.5G port)**
```
Settings for lan2:
        Supported ports: [  ]
        Supported link modes:   10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
                                1000baseT/Full
        Supported pause frame use: Symmetric Receive-only
        Supports auto-negotiation: Yes
        Supported FEC modes: Not reported
        Advertised link modes:  10baseT/Half 10baseT/Full
                                100baseT/Half 100baseT/Full
                                1000baseT/Full
        Advertised pause frame use: Symmetric Receive-only
        Advertised auto-negotiation: Yes
        Advertised FEC modes: Not reported
        Link partner advertised link modes:  10baseT/Half 10baseT/Full
                                             100baseT/Half 100baseT/Full
                                             1000baseT/Full
        Link partner advertised pause frame use: Symmetric Receive-only
        Link partner advertised auto-negotiation: Yes
        Link partner advertised FEC modes: Not reported
        Speed: 2500Mb/s
        Duplex: Full
        Auto-negotiation: on
        master-slave cfg: preferred master
        master-slave status: master
        Port: Twisted Pair
        PHYAD: 3
        Transceiver: external
        MDI-X: on (auto)
        Link detected: yes

```

