### PR TITLE
ath79: fix longdata-aps256 wan port to work in factory bootloader

### DIFF
--- a/target/linux/ath79/dts/ar9344_longdata_aps256.dts
+++ b/target/linux/ath79/dts/ar9344_longdata_aps256.dts
@@ -144,10 +144,6 @@
 
 };
 
-&builtin_switch {
-	/delete-property/ qca,phy4-mii-enable; /* need to delete this to make all 5 FE ports work */
-};
-
 &usb_phy {
 	status = "okay";
 };
@@ -172,7 +168,16 @@
 	gmac-config {
 		device = <&gmac>;
 		switch-phy-swap = <0>;
-		switch-only-mode = <1>;
+		switch-only-mode = <0>;
 	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_art_1002 1>;
+	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -300,7 +300,7 @@ kuwfi,c910)
 	ucidef_set_led_switch "lan2" "LAN2" "white:lan2" "switch0" "0x02"
 	;;
 longdata,aps256)
-	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x20"
+	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
 	ucidef_set_led_switch "lan1" "LAN1" "blue:lan-1" "switch0" "0x04"
 	ucidef_set_led_switch "lan2" "LAN2" "blue:lan-2" "switch0" "0x02"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -419,8 +419,9 @@ ath79_setup_interfaces()
 			"0@eth0" "5:wan" "6@eth1" "4:lan"
 		;;
 	longdata,aps256)
+		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan:2" "2:lan:1" "5:wan"
+			"0@eth0" "1:lan:2" "2:lan:1"
 		;;
 	meraki,mr12)
 		ucidef_set_interface_lan "eth0"


### PR DESCRIPTION
In first commit I successfully bring WAN port into ethernet switch, without realizing that I was using custom bootloader. But if using original bootloader it do not works. WAN port in original bootloader is tied to using its own GMAC.

This fix is made so this firmware will be compatible with orignal bootloader, so the user can directly flash from stock firmware without changing anything.

#https://github.com/openwrt/openwrt/pull/17939#discussion_r1957408493

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
