### PR TITLE
generic: fix typo in swconfig driver patch

### DIFF
--- a/target/linux/generic/hack-6.12/700-swconfig_switch_drivers.patch
+++ b/target/linux/generic/hack-6.12/700-swconfig_switch_drivers.patch
@@ -85,7 +85,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	select SWCONFIG
 +
 +config RTL8367B_PHY
-+	tristate "Driver fot the Realtek RTL8367R-VB switch"
++	tristate "Driver for the Realtek RTL8367R-VB switch"
 +	select SWCONFIG
 +
 +endif # RTL8366_SMI

--- a/target/linux/generic/hack-6.6/700-swconfig_switch_drivers.patch
+++ b/target/linux/generic/hack-6.6/700-swconfig_switch_drivers.patch
@@ -85,7 +85,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	select SWCONFIG
 +
 +config RTL8367B_PHY
-+	tristate "Driver fot the Realtek RTL8367R-VB switch"
++	tristate "Driver for the Realtek RTL8367R-VB switch"
 +	select SWCONFIG
 +
 +endif # RTL8366_SMI


### PR DESCRIPTION
Fix typo in CONFIG_RTL8367B_PHY description.
