### PR TITLE
mediatek: add missing eeprom for ipTIME AX3000M

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
@@ -217,6 +217,10 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
 					macaddr_factory_4: macaddr@4 {
 						compatible = "mac-base";
 						reg = <0x4 0x6>;
@@ -249,6 +253,8 @@
 
 &wifi {
 	status = "okay";
+	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
 
 	band@0 {
 		reg = <0>;


### PR DESCRIPTION
This change fixes the eeprom load failure while on boot

before dmesg:
```
[    9.852498] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[   10.037690] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[   10.132308] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[   10.230534] mt798x-wmac 18000000.wifi: eeprom load fail, use default bin
```

after:
```
[    9.643273] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[    9.829599] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[    9.925153] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[   10.022737] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[   10.119266] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
...
```