### PR TITLE
wifi-scripts: detect PKCS#12/PFX keys and skip appending client_cert

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -1306,6 +1306,25 @@ wpa_supplicant_set_fixed_freq() {
 	esac
 }
 
+append_cert_key_config() {
+    local cert="$1"        # client_cert or client_cert2
+    local priv_key="$2"    # private_key or private_key2
+    local priv_pwd="$3"    # private_key_passwd or private_key2_passwd
+
+    if [ -n "$priv_key" ]; then
+        case "$priv_key" in
+            *".p12"|*".pfx")
+                # PKCS#12/PFX contains both cert+key, so skip client_cert
+                ;;
+            *)
+                append network_data "client_cert=\"$cert\"" "$N$T"
+                ;;
+        esac
+        append network_data "private_key=\"$priv_key\"" "$N$T"
+        append network_data "private_key_passwd=\"$priv_pwd\"" "$N$T"
+    fi
+}
+
 wpa_supplicant_add_network() {
 	local ifname="$1"
 	local freq="$2"
@@ -1434,9 +1453,7 @@ wpa_supplicant_add_network() {
 			case "$eap_type" in
 				tls)
 					json_get_vars client_cert priv_key priv_key_pwd
-					append network_data "client_cert=\"$client_cert\"" "$N$T"
-					append network_data "private_key=\"$priv_key\"" "$N$T"
-					append network_data "private_key_passwd=\"$priv_key_pwd\"" "$N$T"
+					append_cert_key_config "$client_cert" "$priv_key" "$priv_key_pwd"
 
 					json_get_vars subject_match
 					[ -n "$subject_match" ] && append network_data "subject_match=\"$subject_match\"" "$N$T"
@@ -1478,9 +1495,7 @@ wpa_supplicant_add_network() {
 						else
 							[ -n "$ca_cert2" ] && append network_data "ca_cert2=\"$ca_cert2\"" "$N$T"
 						fi
-						append network_data "client_cert2=\"$client_cert2\"" "$N$T"
-						append network_data "private_key2=\"$priv_key2\"" "$N$T"
-						append network_data "private_key2_passwd=\"$priv_key2_pwd\"" "$N$T"
+						append_cert_key_config "$client_cert" "$priv_key" "$priv_key_pwd"
 					else
 						append network_data "password=\"$password\"" "$N$T"
 					fi


### PR DESCRIPTION
When both a PKCS#12/PFX file and a separate client certificate are provided, the configuration becomes invalid or ambiguous.

.p12/.pfx bundle already contains both the private key and the client certificate (and often the CA chain), so appending client_cert alongside it is redundant at best and can cause failures during parsing or TLS negotiation.
The same rule applies to Phase 1 (outer TLS) and Phase 2 (inner TLS): if we incorrectly append a client certificate in addition to a .p12/.pfx, authentication may fail or the wrong certificate could be selected. To avoid this, the new helper explicitly detects .p12/.pfx files and skips adding the client_cert line, ensuring correct and consistent behavior across both phases.

**Error logs in case of both .p12 private key and client cert are configured.**

```
Mon Mar 18 16:36:30 2024 daemon.notice wpa_supplicant[21735]: phy0-sta0: CTRL-EVENT-EAP-STARTED EAP authentication started
Mon Mar 18 16:36:30 2024 daemon.notice wpa_supplicant[21735]: phy0-sta0: CTRL-EVENT-EAP-PROPOSED-METHOD vendor=0 method=13
Mon Mar 18 16:36:30 2024 daemon.notice wpa_supplicant[21735]: OpenSSL: pending error: error:80000002:system library::No such file or directory
Mon Mar 18 16:36:30 2024 daemon.notice wpa_supplicant[21735]: OpenSSL: pending error: error:10080002:BIO routines::system lib
Mon Mar 18 16:36:30 2024 daemon.notice wpa_supplicant[21735]: OpenSSL: pending error: error:0A080002:SSL routines::system lib
Mon Mar 18 16:36:30 2024 daemon.notice wpa_supplicant[21735]: TLS: Failed to set TLS connection parameters
Mon Mar 18 16:36:30 2024 daemon.notice wpa_supplicant[21735]: EAP-TLS: Failed to initialize SSL.
Mon Mar 18 16:36:30 2024 daemon.notice wpa_supplicant[21735]: phy0-sta0: EAP: Failed to initialize EAP method: vendor 0 method 13 (TLS)
Mon Mar 18 16:36:30 2024 daemon.notice wpa_supplicant[21735]: phy0-sta0: CTRL-EVENT-EAP-FAILURE EAP authentication failed
Mon Mar 18 16:36:30 2024 daemon.notice netifd: Network device 'phy0-sta0' link is down
Mon Mar 18 16:36:30 2024 daemon.notice netifd: Interface 'wwan' has link connectivity loss
Mon Mar 18 16:36:30 2024 kern.info kernel: [ 5251.345598] phy0-sta0: deauthenticated from b8:d8:12:68:04:e0 (Reason: 23=IEEE8021X_FAILED)
Mon Mar 18 16:36:30 2024 daemon.notice wpa_supplicant[21735]: phy0-sta0: CTRL-EVENT-DISCONNECTED bssid=b8:d8:12:68:04:e0 reason=23
Mon Mar 18 16:36:30 2024 daemon.notice wpa_supplicant[21735]: phy0-sta0: CTRL-EVENT-SSID-TEMP-DISABLED id=4 ssid="Test_wpa3_mtk" auth_failures=1 duration=10 reason=AUTH_FAILED
```
**Error Configuration:**

```
`root@ekh03-680869:~# cat /var/run/wpa_supplicant-phy0-sta0.conf

network={
        scan_ssid=1
        ssid="Test_wpa3"
        key_mgmt=WPA-EAP-SHA256
        ca_cert="/etc/luci-uploads/ca.pem"
        identity="user"
        client_cert=""
        private_key="/etc/luci-uploads/client.p12"
        private_key_passwd="password"
        eap=TLS
        proto=RSN
        ieee80211w=2
        beacon_int=100
}
`
```
**Wpa-supplicant config file snippet:**
```

`private_key: File path to client private key file (PEM/DER/PFX)
#	When PKCS#12/PFX file (.p12/.pfx) is used, client_cert should be
#	commented out. Both the private key and certificate will be read from
#	the PKCS#12 file in this case.`
```