### PR TITLE
mediatek: add support for trng on mt7988a

### DIFF
--- a/target/linux/mediatek/patches-6.12/965-dts-mt7988a-add-trng-support.patch
+++ b/target/linux/mediatek/patches-6.12/965-dts-mt7988a-add-trng-support.patch
@@ -1,0 +1,14 @@
+diff --git a/arch/arm64/boot/dts/mediatek/mt7988a.dtsi b/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
+index aa728331e876..9da783f6412c 100644
+--- a/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
+@@ -221,4 +221,8 @@ timer {
+ 			     <GIC_PPI 11 IRQ_TYPE_LEVEL_LOW>,
+ 			     <GIC_PPI 10 IRQ_TYPE_LEVEL_LOW>;
+ 	};
++
++	trng {
++		compatible = "mediatek,mt7988-rng";
++	};
+ };
+


### PR DESCRIPTION
Add support for trng on mt7988a.

Tested on Banana Pi BPI-R4.

