### PR TITLE
mediatek: CMCC RAX3000Me: fix stability issues

### DIFF
--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -201,6 +201,15 @@ define Trusted-Firmware-A/mt7981-emmc-ddr3
   DDR_TYPE:=ddr3
 endef
 
+define Trusted-Firmware-A/mt7981-emmc-ddr3-1866mhz
+  NAME:=MediaTek MT7981 (eMMC, DDR3 1866 MHz)
+  BOOT_DEVICE:=emmc
+  BUILD_SUBTARGET:=filogic
+  PLAT:=mt7981
+  DDR_TYPE:=ddr3
+  DDR3_FREQ_1866:=1
+endef
+
 define Trusted-Firmware-A/mt7981-sdmmc-ddr3
   NAME:=MediaTek MT7981 (SD card, DDR3)
   BOOT_DEVICE:=sdmmc
@@ -223,6 +232,15 @@ define Trusted-Firmware-A/mt7981-spim-nand-ddr3
   BUILD_SUBTARGET:=filogic
   PLAT:=mt7981
   DDR_TYPE:=ddr3
+endef
+
+define Trusted-Firmware-A/mt7981-spim-nand-ddr3-1866mhz
+  NAME:=MediaTek MT7981 (SPI-NAND via SPIM, DDR3 1866 MHz)
+  BOOT_DEVICE:=spim-nand
+  BUILD_SUBTARGET:=filogic
+  PLAT:=mt7981
+  DDR_TYPE:=ddr3
+  DDR3_FREQ_1866:=1
 endef
 
 define Trusted-Firmware-A/mt7981-cudy-tr3000-v1
@@ -559,11 +577,13 @@ TFA_TARGETS:= \
 	mt7622-sdmmc-2ddr \
 	mt7981-ram-ddr3 \
 	mt7981-emmc-ddr3 \
+	mt7981-emmc-ddr3-1866mhz \
 	mt7981-nor-ddr3 \
 	mt7981-nor-ddr4 \
 	mt7981-sdmmc-ddr3 \
 	mt7981-snand-ddr3 \
 	mt7981-spim-nand-ddr3 \
+	mt7981-spim-nand-ddr3-1866mhz \
 	mt7981-spim-nand-ubi-ddr4 \
 	mt7981-ram-ddr4 \
 	mt7981-emmc-ddr4 \

--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -29,6 +29,7 @@ define Trusted-Firmware-A/Default
   HIDDEN:=y
   BOOT_DEVICE:=
   DDR3_FLYBY:=
+  DDR3_FREQ_1866:=
   DDR_TYPE:=
   NAND_TYPE:=
   BOARD_QFN:=
@@ -178,6 +179,7 @@ define Trusted-Firmware-A/mt7981-ram-ddr3
   BUILD_SUBTARGET:=filogic
   PLAT:=mt7981
   DDR_TYPE:=ddr3
+  DDR3_FREQ_1866:=1
   RAM_BOOT_UART_DL:=1
   HIDDEN:=
   DEFAULT:=TARGET_mediatek_filogic
@@ -611,6 +613,7 @@ TFA_MAKE_FLAGS += \
 	$(if $(NAND_TYPE),NAND_TYPE=$(NAND_TYPE)) \
 	HAVE_DRAM_OBJ_FILE=yes \
 	$(if $(DDR3_FLYBY),DDR3_FLYBY=1) \
+	$(if $(DDR3_FREQ_1866),DDR3_FREQ_1866=1) \
 	$(if $(DRAM_USE_COMB),DRAM_USE_COMB=1) \
 	$(if $(RAM_BOOT_UART_DL),RAM_BOOT_UART_DL=1) \
 	$(if $(USE_UBI),UBI=1 $(if $(findstring mt7622,$(PLAT)),OVERRIDE_UBI_START_ADDR=0x80000)) \

--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -252,7 +252,7 @@ define U-Boot/mt7981_cmcc_rax3000m-emmc-ddr3
   BL2_BOOTDEV:=emmc
   BL2_SOC:=mt7981
   BL2_DDRTYPE:=ddr3
-  DEPENDS:=+trusted-firmware-a-mt7981-emmc-ddr3
+  DEPENDS:=+trusted-firmware-a-mt7981-emmc-ddr3-1866mhz
 endef
 
 define U-Boot/mt7981_cmcc_rax3000m-emmc-ddr4
@@ -276,7 +276,7 @@ define U-Boot/mt7981_cmcc_rax3000m-nand-ddr3
   BL2_BOOTDEV:=spim-nand
   BL2_SOC:=mt7981
   BL2_DDRTYPE:=ddr3
-  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr3
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr3-1866mhz
 endef
 
 define U-Boot/mt7981_cmcc_rax3000m-nand-ddr4

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -717,11 +717,11 @@ define Device/cmcc_rax3000m
 	nand-ddr4-bl31-uboot.fip nand-ddr4-preloader.bin
   ARTIFACT/emmc-gpt.bin := mt798x-gpt emmc
   ARTIFACT/emmc-ddr3-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-emmc-ddr3
-  ARTIFACT/emmc-ddr3-preloader.bin  := mt7981-bl2 emmc-ddr3
+  ARTIFACT/emmc-ddr3-preloader.bin  := mt7981-bl2 emmc-ddr3-1866mhz
   ARTIFACT/emmc-ddr4-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-emmc-ddr4
   ARTIFACT/emmc-ddr4-preloader.bin  := mt7981-bl2 emmc-ddr4
   ARTIFACT/nand-ddr3-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-nand-ddr3
-  ARTIFACT/nand-ddr3-preloader.bin  := mt7981-bl2 spim-nand-ddr3
+  ARTIFACT/nand-ddr3-preloader.bin  := mt7981-bl2 spim-nand-ddr3-1866mhz
   ARTIFACT/nand-ddr4-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-nand-ddr4
   ARTIFACT/nand-ddr4-preloader.bin  := mt7981-bl2 spim-nand-ddr4
 endef


### PR DESCRIPTION
This PR fixes stability issues on certain CMCC RAX3000Me devices. Some devices has ddr3 RAM that can't work reliably at 2133 MHz and require special bl2 (1866 MHz RAM freq).

Fixes: https://github.com/openwrt/openwrt/issues/20046
