### PR TITLE
mediatek: enable ramoops (pstore) for MT6000 by default

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1141,7 +1141,7 @@ define Device/glinet_gl-mt6000
   DEVICE_MODEL := GL-MT6000
   DEVICE_DTS := mt7986a-glinet-gl-mt6000
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := e2fsprogs f2fsck mkf2fs kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  DEVICE_PACKAGES := e2fsprogs f2fsck mkf2fs kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-ramoops
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to 32M | append-rootfs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata


### PR DESCRIPTION
Enable ramoops pstore kernel crash debug functionality in MT6000 by default by adding kmod-ramoops to device packages.

Short kernel crash log dump files can be seen in `/sys/fs/pstore/` and they can be cleared by deleting the files or by hard power-off.

-------

Similar ramoops/pstore is enabled in several popular routers (like R7800, E8450/RT3200), so enable it also for MT6000 by default.

Support for ramoops exists both in mediatek/filogic and in uboot-mediatek (which is not really needed for this router, but even that reserves the memory area needed for the functionality).

Run-tested with MT6000:

```
root@router6000:~# ls /sys/fs/pstore/
root@router6000:~# echo c > /proc/sysrq-trigger

- - - reboot after the triggered crash - - -

root@router6000:~# ls /sys/fs/pstore/
dmesg-ramoops-0
root@router6000:~# cat /sys/fs/pstore/dmesg-ramoops-0
Panic#1 Part1
...
<6>[425216.153914] br-lan: port 1(lan1) entered forwarding state
<6>[428855.331921] sysrq: Trigger a crash
<0>[428855.335418] Kernel panic - not syncing: sysrq triggered crash
<2>[428855.341231] SMP: stopping secondary CPUs
<0>[428855.345226] Kernel Offset: disabled
<0>[428855.348784] CPU features: 0x00,00000000,00000000,4200400b
<0>[428855.354252] Memory Limit: none
```
