### PR TITLE
realtek: add support for RTL8218E

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
@@ -3263,7 +3263,7 @@ static int rtl8218b_int_phy_probe(struct phy_device *phydev)
 	return 0;
 }
 
-static int rtl8218d_phy_probe(struct phy_device *phydev)
+static int rtl8218x_phy_probe(struct phy_device *phydev)
 {
 	int base_addr = phydev->mdio.addr & ~7;
 
@@ -3445,7 +3445,20 @@ static struct phy_driver rtl83xx_phy_driver[] = {
 		.name		= "REALTEK RTL8218D",
 		.config_init	= rtl821x_config_init,
 		.features	= PHY_GBIT_FEATURES,
-		.probe		= rtl8218d_phy_probe,
+		.probe		= rtl8218x_phy_probe,
+		.read_mmd	= rtl821x_read_mmd,
+		.read_page	= rtl821x_read_page,
+		.resume		= genphy_resume,
+		.suspend	= genphy_suspend,
+		.write_mmd	= rtl821x_write_mmd,
+		.write_page	= rtl821x_write_page,
+	},
+	{
+		PHY_ID_MATCH_EXACT(PHY_ID_RTL8218E),
+		.name		= "REALTEK RTL8218E",
+		.config_init	= rtl821x_config_init,
+		.features	= PHY_GBIT_FEATURES,
+		.probe		= rtl8218x_phy_probe,
 		.read_mmd	= rtl821x_read_mmd,
 		.read_page	= rtl821x_read_page,
 		.resume		= genphy_resume,

--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.h
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.h
@@ -23,6 +23,7 @@ struct __attribute__ ((__packed__)) fw_header {
 #define PHY_ID_RTL8218B_E			0x001cc980
 #define PHY_ID_RTL8214_OR_8218			0x001cc981
 #define PHY_ID_RTL8218D				0x001cc983
+#define PHY_ID_RTL8218E				0x001cc984
 #define PHY_ID_RTL8218B_I			0x001cca40
 #define PHY_ID_RTL8390_GENERIC			0x001ccab0
 #define PHY_ID_RTL8393_I			0x001c8393


### PR DESCRIPTION
Continuation of https://github.com/openwrt/openwrt/pull/18362 since the author doesn't seem to respond. I have this device and the patch is useful.

ZyXEL XGS1250-12 Rev.B1 has RTL8218E compared to RTL8218D in Rev.A1 but both of them seem very similar and pin compatible. Therefore they can share the same phy_driver callbacks.

PHY identifier is set based on the datasheet from
  https://github.com/plappermaul/realtek-doc/blob/main/RTL8218E-CG_Datasheet.pdf


