### PR TITLE
mediatek: filogic: add support for AsiaRF AP7986-003

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -85,6 +85,7 @@ comfast,cf-e393ax|\
 iptime,ax3000m)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x80000"
 	;;
+asiarf,ap7986-003|\
 cetron,ct3003|\
 edgecore,eap111|\
 netgear,wax220|\

--- a/target/linux/mediatek/dts/mt7986a-asiarf-ap7986-003.dts
+++ b/target/linux/mediatek/dts/mt7986a-asiarf-ap7986-003.dts
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 AsiaRF Co., Ltd
+ * Author: Elwin Huang <elwin@asiarf.com>
+ */
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+#include "mt7986a.dtsi"
+
+/ {
+	model = "AsiaRF AP7986-003";
+	compatible = "asiarf,ap7986-003", "mediatek,mt7986a-rfb";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	pwm-leds {
+		compatible = "pwm-leds";
+
+		led_status_green: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			pwms = <&pwm 0 10000>;
+			active-low;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_DEBUG;
+			pwms = <&pwm 1 10000>;
+			linux,default-trigger = "pattern";
+			led-pattern = <0 1000 255 1000>;
+			active-low;
+		};
+	};
+
+	reg_1p8v: regulator-1p8v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-1.8V";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		nvmem-cells = <&macaddr_factory_24>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-handle = <&phy6>;
+		phy-mode = "2500base-x";
+		nvmem-cells = <&macaddr_factory_2a>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		phy6: phy@6 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <6>;
+
+			reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+			reset-deassert-us = <20000>;
+			#interrupt-cells = <1>;
+			interrupt-controller;
+			interrupt-parent = <&pio>;
+			interrupts = <46 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+		switch: switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			#interrupt-cells = <1>;
+			interrupt-controller;
+			interrupt-parent = <&pio>;
+			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "lan1";
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan2";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan3";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan4";
+				};
+
+				port@4 {
+					reg = <4>;
+					label = "lan5";
+				};
+
+				port@6 {
+					reg = <6>;
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&wifi {
+	pinctrl-names = "default", "dbdc";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+	pinctrl-1 = <&wf_dbdc_pins>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+};
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie_pins>;
+	status = "okay";
+};
+
+&pcie_phy {
+	status = "okay";
+};
+
+&pio {
+	pcie_pins: pcie-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_clk", "pcie_wake", "pcie_pereset";
+		};
+	};
+	
+	pwm_pins: pwm-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm0", "pwm1_0";
+		};
+	};
+
+	spic1_pins: spi-pins-23-to-26 {
+		mux {
+			function = "spi";
+			groups = "spi1_1";
+		};
+	};
+
+	spic2_pins: spi-flash-pins-29-to-32 {
+		mux {
+			function = "spi";
+			groups = "spi1_2";
+		};
+	};
+
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable;	/* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable;	/* bias-disable */
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				   "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				   "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				   "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				   "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				   "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				   "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+
+	wf_dbdc_pins: wf_dbdc-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_dbdc";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				   "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				   "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				   "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				   "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				   "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				   "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+
+	i2c_pins: i2c-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c";
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+
+	spi_nand@1 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <1>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x0180000 0x0200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_24: macaddr@24 {
+						reg = <0x24 0x6>;
+					};
+
+					macaddr_factory_2a: macaddr@2a {
+						reg = <0x2a 0x6>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x0380000 0x0200000>;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x0580000 0x4000000>; // 64MB
+			};
+
+			partition@4580000 {
+				label = "User_data";
+				reg = <0x4580000 0x3280000>;
+			};
+		};
+	};
+};
+
+&spi1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spic1_pins &spic2_pins>;
+	cs-gpios = <&pio 26 GPIO_ACTIVE_LOW>, <&pio 32 GPIO_ACTIVE_LOW>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	status = "okay";
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c_pins>;
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&ssusb {
+	phys = <&u3port0 PHY_TYPE_USB3>,
+		<&u2port1 PHY_TYPE_USB2>;
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&trng {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_pins>;
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -68,6 +68,7 @@ mediatek_setup_interfaces()
 	zbtlink,zbt-z8102ax-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
 		;;
+	asiarf,ap7986-003|\
 	asus,tuf-ax6000|\
 	glinet,gl-mt6000|\
 	tplink,tl-xdr4288|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -225,6 +225,24 @@ define Device/acer_vero-w6m
 endef
 TARGET_DEVICES += acer_vero-w6m
 
+define Device/asiarf_ap7986-003
+  DEVICE_VENDOR := AsiaRF
+  DEVICE_MODEL := AP7986 003
+  DEVICE_DTS := mt7986a-asiarf-ap7986-003
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_IN_UBI := 1
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+endef
+TARGET_DEVICES += asiarf_ap7986-003
+
 define Device/adtran_smartrg
   DEVICE_VENDOR := Adtran
   DEVICE_DTS_DIR := ../dts


### PR DESCRIPTION
**<h1>Specification:</h1>**

- SoC           : MediaTek MT7986AV, Quad-core 2.0 GHz ARM Cortex-A53 CPU
- RAM           : DDR3 512 MiB (Micron MT41K256M16TW-107)
- Flash         : SPI-NAND 128 MiB (Winbound W25N01GVZEIG) 
- Ethernet      : 6 ports
  - LAN :
      5x 10/100/1000 Mbps RJ-45 Port
  - WAN :
      1x 10/100/1000/2500 Mbps RJ-45 Port (MaxLinear GPY211B1VC-LN8A)
- LED           : 19x LEDs (Green)
    1x  Power
    1x  Status (PWM-LED)
    1x  Debug (PWM-LED)
    2x  WiFi activity
    10x Ethernet LAN activity
    4x  Ethernet WAN activity
- UART          : 1x4 pin header on PCB [J1]
  - arrangement : 3.3V, RX, TX, GND
  - settings    : 115200, 8n1
- Button        : 3x (Reset, WPS, Power)
- WiFi          : 2x
    WiFi 6 2.4 Ghz + 5 Ghz (Mediatek MT7975N+MT7975PN)
- Socket        : 
    1x Raspberry header 13x2
    1x JTAG 10x2
    1x USB-A (USB 3.0)
- Power         : 12V DC, 3A

| Interface  | Mac Address | Read Address |
| ------------- | ------------- | ------------- | 
| WLAN  | 00:0A:52:xx:xx:xx  | Factory, 0x6 |
| LAN  | 00:0A:52:xx:xx:xx  | Factory, 0x24 |
| WAN  | 00:0A:52:xx:xx:xx  | Factory, 0x2a |



<h2>Bootlog</h2>
<details>

<summary>Factory Bootlog</summary>

```

F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 021E [010F]
Jump to BL

NOTICE:  BL2: v2.5(release):19b34200e
NOTICE:  BL2: Built : 15:24:47, Aug  3 2021
NOTICE:  WDT: disabled
NOTICE:  CPU: MT7986 (2000MHz)
NOTICE:  EMI: Using DDR3 settings
NOTICE:  EMI: Detected DRAM size: 512MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  Recognized SPI-NAND ID: 0xef 0xaa 0x21
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.5(release):19b34200e
NOTICE:  BL31: Built : 15:24:51, Aug  3 2021


U-Boot 2021.10-rc1-g6fbac8585d (Aug 03 2021 - 15:22:15 +0800)

CPU:   MediaTek MT7986
Model: mt7986-rfb
DRAM:  512 MiB
WDT:   Not found!

Initializing NMBM ...
spi-nand: spi_nand spi_nand@1: Winbond SPI NAND was found.
spi-nand: spi_nand spi_nand@1: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 2 found in block 960
Second info table with writecount 2 found in block 963
NMBM has been successfully attached 

MMC:   mmc@11230000: 0
Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   
Warning: ethernet@15100000 (eth0) using random MAC address - 86:06:f6:c9:6b:d1
eth0: ethernet@15100000
  *** U-Boot Boot Menu ***  Press UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit     1. Startup system (Default)     2. Upgrade firmware     3. Upgrade ATF BL2     4. Upgrade ATF FIP     5. Upgrade single image     6. Load image     0. U-Boot console  Hit any key to stop autoboot:  4  3  2  1  0 ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 64 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 512, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 2/0, WL threshold: 4096, image sequence number: 1758100390
ubi0: available PEBs: 0, total reserved PEBs: 512, PEBs reserved for bad PEB handling: 19
Reading from volume 'kernel' to 0x46000000, size 0x0 ... OK
## Loading kernel from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.12.45
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x460000e8
     Data Size:    4451894 Bytes = 4.2 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x48000000
     Entry Point:  0x48000000
     Hash algo:    crc32
     Hash value:   d551f5fd
     Hash algo:    sha1
     Hash value:   d1f24417ce3dc1b67a38feab870ff0743329c5d9
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt asiarf_ap7986-003 device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x4643f064
     Data Size:    21812 Bytes = 21.3 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   f6ba51f5
     Hash algo:    sha1
     Hash value:   8a4a4beeb4b8c1e6d3d9a599fe18f7a642253f31
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x4643f064
   Uncompressing Kernel Image
   Loading Device Tree to 000000005fff7000, end 000000005ffff533 ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.12.45 (elwin@ubuntu-2204) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r31015+46-20d761cf19) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Wed Sep 17 09:13:10 2025
[    0.000000] Machine model: AsiaRF AP7986-003
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004303ffff (256 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x000000004fc00000..0x000000004fcfffff (1024 KiB) nomap non-reusable wmcpu-reserved@4fc00000
[    0.000000] OF: reserved mem: 0x000000004fd00000..0x000000004fd3ffff (256 KiB) nomap non-reusable wo-emi@4fd00000
[    0.000000] OF: reserved mem: 0x000000004fd40000..0x000000004fd7ffff (256 KiB) nomap non-reusable wo-emi@4fd40000
[    0.000000] OF: reserved mem: 0x000000004fd80000..0x000000004ffbffff (2304 KiB) nomap non-reusable wo-data@4fd80000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000005fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004303ffff]
[    0.000000]   node   0: [mem 0x0000000043040000-0x000000004fbfffff]
[    0.000000]   node   0: [mem 0x000000004fc00000-0x000000004ffbffff]
[    0.000000]   node   0: [mem 0x000000004ffc0000-0x000000005fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000005fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 20 pages/cpu s42520 r8192 d31208 u81920
[    0.000000] pcpu-alloc: s42520 r8192 d31208 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: 
[    0.000000] Dentry cache hash table entries: 65536 (order: 7, 524288 bytes, linear)
[    0.000000] Inode-cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 131072
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[    0.000000] software IO TLB: area num 4.
[    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 1MB
[    0.000000] software IO TLB: mapped [mem 0x000000005f480000-0x000000005f580000] (1MB)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks Trace: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=4.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: GICD_CTRL.DS=0, SCR_EL3.FIQ=0
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000062] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000069] pid_max: default: 32768 minimum: 301
[    0.002098] Mount-cache hash table entries: 1024 (order: 1, 8192 bytes, linear)
[    0.002106] Mountpoint-cache hash table entries: 1024 (order: 1, 8192 bytes, linear)
[    0.003697] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.004312] rcu: Hierarchical SRCU implementation.
[    0.004314] rcu: 	Max phase no-delay instances is 1000.
[    0.004436] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.004657] smp: Bringing up secondary CPUs ...
[    0.004920] Detected VIPT I-cache on CPU1
[    0.004958] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.004983] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.005306] Detected VIPT I-cache on CPU2
[    0.005332] GICv3: CPU2: found redistributor 2 region 0:0x000000000c0c0000
[    0.005345] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
[    0.005668] Detected VIPT I-cache on CPU3
[    0.005686] GICv3: CPU3: found redistributor 3 region 0:0x000000000c0e0000
[    0.005697] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
[    0.005732] smp: Brought up 1 node, 4 CPUs
[    0.005735] SMP: Total of 4 processors activated.
[    0.005737] CPU: All CPU(s) started at EL2
[    0.005739] CPU features: detected: 32-bit EL0 Support
[    0.005741] CPU features: detected: CRC32 instructions
[    0.005763] alternatives: applying system-wide alternatives
[    0.005871] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.005986] Memory: 491904K/524288K available (9216K kernel code, 976K rwdata, 2736K rodata, 448K init, 300K bss, 29460K reserved, 0K cma-reserved)
[    0.008091] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.008104] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.008172] 29312 pages in range for non-PLT usage
[    0.008175] 520832 pages in range for PLT usage
[    0.009153] pinctrl core: initialized pinctrl subsystem
[    0.010075] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.010306] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.010326] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.010341] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.010635] thermal_sys: Registered thermal governor 'fair_share'
[    0.010638] thermal_sys: Registered thermal governor 'bang_bang'
[    0.010640] thermal_sys: Registered thermal governor 'step_wise'
[    0.010642] thermal_sys: Registered thermal governor 'user_space'
[    0.010666] ASID allocator initialised with 65536 entries
[    0.011142] pstore: Using crash dump compression: deflate
[    0.011146] pstore: Registered ramoops as persistent store backend
[    0.011148] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.012216] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.015335] /soc/pcie@11280000: Fixed dependency cycle(s) with /soc/pcie@11280000/interrupt-controller
[    0.024000] cryptd: max_cpu_qlen set to 1000
[    0.025907] SCSI subsystem initialized
[    0.026020] libata version 3.00 loaded.
[    0.027101] clocksource: Switched to clocksource arch_sys_counter
[    0.028691] NET: Registered PF_INET protocol family
[    0.028773] IP idents hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.029548] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.029557] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.029563] TCP established hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.029584] TCP bind hash table entries: 4096 (order: 5, 131072 bytes, linear)
[    0.029676] TCP: Hash tables configured (established 4096 bind 4096)
[    0.029912] MPTCP token hash table entries: 512 (order: 1, 12288 bytes, linear)
[    0.029984] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.029995] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.030207] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.030228] PCI: CLS 0 bytes, default 64
[    0.031216] workingset: timestamp_bits=46 max_order=17 bucket_order=0
[    0.034527] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.034531] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.071967] mtk-pcie-gen3 11280000.pcie: host bridge /soc/pcie@11280000 ranges:
[    0.071985] mtk-pcie-gen3 11280000.pcie: Parsing ranges property...
[    0.071993] mtk-pcie-gen3 11280000.pcie:      MEM 0x0020000000..0x002fffffff -> 0x0020000000
[    0.072098] /soc/pcie@11280000: Failed to get clk index: 0 ret: -517
[    0.072106] mtk-pcie-gen3 11280000.pcie: failed to get clocks
[    0.074927] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.075803] printk: legacy console [ttyS0] disabled
[    0.096102] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 116, base_baud = 2500000) is a ST16650V2
[    0.096138] printk: legacy console [ttyS0] enabled
[    0.935011] mtk_rng 1020f000.rng: registered RNG driver
[    0.942996] loop: module loaded
[    0.948036] spi-nand spi0.1: Winbond SPI NAND was found.
[    0.953344] spi-nand spi0.1: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.961837] Signature found at block 1023 [0x07fe0000]
[    0.966958] NMBM management region starts at block 960 [0x07800000]
[    0.974082] First info table with writecount 2 found in block 960
[    0.982607] Second info table with writecount 2 found in block 963
[    0.988789] NMBM has been successfully attached
[    0.993477] 6 fixed-partitions partitions found on MTD device spi0.1
[    0.999845] Creating 6 MTD partitions on "spi0.1":
[    1.004619] 0x000000000000-0x000000100000 : "BL2"
[    1.010380] 0x000000100000-0x000000180000 : "u-boot-env"
[    1.016233] 0x000000180000-0x000000380000 : "Factory"
[    1.023068] 0x000000380000-0x000000580000 : "FIP"
[    1.029365] 0x000000580000-0x000004580000 : "ubi"
[    1.076324] 0x000004580000-0x000007800000 : "User_data"
[    1.277897] Maxlinear Ethernet GPY211B mdio-bus:06: Firmware Version: 7.48 (0x8730)
[    1.290491] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081680000, irq 120
[    1.300293] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc081680000, irq 120
[    1.310011] i2c_dev: i2c /dev entries driver
[    1.315551] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.324314] NET: Registered PF_INET6 protocol family
[    1.330099] Segment Routing with IPv6
[    1.333775] In-situ OAM (IOAM) with IPv6
[    1.337732] NET: Registered PF_PACKET protocol family
[    1.342856] 8021q: 802.1Q VLAN Support v1.8
[    1.362073] mtk-pcie-gen3 11280000.pcie: host bridge /soc/pcie@11280000 ranges:
[    1.369415] mtk-pcie-gen3 11280000.pcie: Parsing ranges property...
[    1.375669] mtk-pcie-gen3 11280000.pcie:      MEM 0x0020000000..0x002fffffff -> 0x0020000000
[    1.384141] debugfs: File 'type' in directory 'phy-soc:t-phy@11c00000.0' already present!
[    1.392317] debugfs: File 'efuse' in directory 'phy-soc:t-phy@11c00000.0' already present!
[    1.400571] debugfs: File 'intr' in directory 'phy-soc:t-phy@11c00000.0' already present!
[    1.408728] debugfs: File 'tx-imp' in directory 'phy-soc:t-phy@11c00000.0' already present!
[    1.417054] debugfs: File 'rx-imp' in directory 'phy-soc:t-phy@11c00000.0' already present!
[    1.737111] mtk-pcie-gen3 11280000.pcie: PCIe link down, current LTSSM state: detect.quiet (0x0)
[    1.745917] mtk-pcie-gen3 11280000.pcie: probe with driver mtk-pcie-gen3 failed with error -110
[    1.793205] mt7530-mdio mdio-bus:1f: no interrupt support
[    1.815531] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.824492] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.834198] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=POLL)
[    1.855282] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=POLL)
[    1.876070] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=POLL)
[    1.896844] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=POLL)
[    1.917614] mt7530-mdio mdio-bus:1f lan5 (uninitialized): PHY [mt7530-0:04] driver [MediaTek MT7531 PHY] (irq=POLL)
[    1.928678] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.935380] DSA: tree 0 setup
[    1.938711] UBI: auto-attach mtd4
[    1.942028] ubi0: default fastmap pool size: 25
[    1.946541] ubi0: default fastmap WL pool size: 12
[    1.951323] ubi0: attaching mtd4
[    2.180206] ubi0: scanning is finished
[    2.187867] ubi0 warning: ubi_eba_init: cannot reserve enough PEBs for bad PEB handling, reserved 17, need 19
[    2.198141] ubi0: attached mtd4 (name "ubi", size 64 MiB)
[    2.203528] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    2.210388] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.217158] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.224098] ubi0: good PEBs: 512, bad PEBs: 0, corrupted PEBs: 0
[    2.230088] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[    2.237290] ubi0: max/mean erase counter: 2/0, WL threshold: 4096, image sequence number: 1758100390
[    2.246397] ubi0: available PEBs: 0, total reserved PEBs: 512, PEBs reserved for bad PEB handling: 17
[    2.255599] ubi0: background thread "ubi_bgt0d" started, PID 613
[    2.256247] block ubiblock0_1: created from ubi0:1(rootfs)
[    2.267064] ubiblock: device ubiblock0_1 (rootfs) set to be root filesystem
[    2.274091] clk: Disabling unused clocks
[    2.278228] PM: genpd: Disabling unused power domains
[    2.286978] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[    2.294312] Freeing unused kernel memory: 448K
[    2.298789] Run /sbin/init as init process
[    2.302870]   with arguments:
[    2.305821]     /sbin/init
[    2.308521]   with environment:
[    2.311646]     HOME=/
[    2.313990]     TERM=linux
[    2.446789] init: Console is alive
[    2.450326] init: - watchdog -
[    2.747017] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    2.763301] usbcore: registered new interface driver usbfs
[    2.768846] usbcore: registered new interface driver hub
[    2.774178] usbcore: registered new device driver usb
[    2.779809] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    2.791597] xhci-mtk 11200000.usb: xHCI Host Controller
[    2.796829] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 1
[    2.807224] xhci-mtk 11200000.usb: hcc params 0x01403f99 hci version 0x110 quirks 0x0000000000200010
[    2.816368] xhci-mtk 11200000.usb: irq 124, io mem 0x11200000
[    2.822199] xhci-mtk 11200000.usb: xHCI Host Controller
[    2.827415] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 2
[    2.834793] xhci-mtk 11200000.usb: Host supports USB 3.2 Enhanced SuperSpeed
[    2.842146] hub 1-0:1.0: USB hub found
[    2.845896] hub 1-0:1.0: 2 ports detected
[    2.850142] usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
[    2.858583] hub 2-0:1.0: USB hub found
[    2.862334] hub 2-0:1.0: 1 port detected
[    2.869422] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    2.886853] init: - preinit -
[    3.112952] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    3.121560] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    3.139883] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    6.727102] random: crng init done
[    7.388816] UBIFS (ubi0:2): Mounting in unauthenticated mode
[    7.394553] UBIFS (ubi0:2): background thread "ubifs_bgt0_2" started, PID 760
[    7.415838] UBIFS (ubi0:2): recovery needed
[    7.494809] UBIFS (ubi0:2): recovery completed
[    7.499309] UBIFS (ubi0:2): UBIFS: mounted UBI device 0, volume 2, name "rootfs_data"
[    7.507124] UBIFS (ubi0:2): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[    7.517014] UBIFS (ubi0:2): FS size: 49647616 bytes (47 MiB, 391 LEBs), max 401 LEBs, journal size 2539520 bytes (2 MiB, 20 LEBs)
[    7.528655] UBIFS (ubi0:2): reserved for root: 2344978 bytes (2290 KiB)
[    7.535252] UBIFS (ubi0:2): media format: w5/r0 (latest is w5/r0), UUID 01E01F8B-E944-4E30-B861-C5DF02F3BA6C, small LPT model
[    7.548120] mount_root: switching to ubifs overlay
[    7.557550] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[    7.570733] urandom-seed: Seeding with /etc/urandom.seed
[    7.617974] procd: - early -
[    7.620901] procd: - watchdog -
[    8.161875] procd: - watchdog -
[    8.169362] procd: - ubus -
[    8.323880] procd: - init -
Please press Enter to activate this console.
[    8.535439] kmodloader: loading kernel modules from /etc/modules.d/*
[    8.556128] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    8.570293] Loading modules backported from Linux version v6.16-0-g038d61fd6422
[    8.577623] Backport generated by backports.git v6.1.145-1-47-g6194bf852a3e
[    8.668750] urngd: v1.0.2 started.
[    9.017717] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823160739a
[    9.017717] 
[    9.148595] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823160804
[    9.228605] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823160840
[    9.334655] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[    9.388526] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[    9.529357] PPP generic driver version 2.4.2
[    9.534536] NET: Registered PF_PPPOX protocol family
[    9.542158] kmodloader: done loading kernel modules from /etc/modules.d/*
[   11.545903] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   11.569505] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   11.578138] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   11.584625] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   11.598013] br-lan: port 1(lan1) entered blocking state
[   11.603246] br-lan: port 1(lan1) entered disabled state
[   11.608526] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   11.614790] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   11.624277] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   11.639086] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   11.649792] br-lan: port 2(lan2) entered blocking state
[   11.655028] br-lan: port 2(lan2) entered disabled state
[   11.660320] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   11.668365] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   11.682421] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   11.693196] br-lan: port 3(lan3) entered blocking state
[   11.698508] br-lan: port 3(lan3) entered disabled state
[   11.703766] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   11.711980] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   11.726090] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   11.736860] br-lan: port 4(lan4) entered blocking state
[   11.742159] br-lan: port 4(lan4) entered disabled state
[   11.747459] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   11.755993] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[   11.769852] mt7530-mdio mdio-bus:1f lan5: configuring for phy/gmii link mode
[   11.780501] br-lan: port 5(lan5) entered blocking state
[   11.785714] br-lan: port 5(lan5) entered disabled state
[   11.791070] mt7530-mdio mdio-bus:1f lan5: entered allmulticast mode
[   11.799655] mt7530-mdio mdio-bus:1f lan5: entered promiscuous mode
[   11.813571] mtk_soc_eth 15100000.ethernet eth1: PHY [mdio-bus:06] driver [Maxlinear Ethernet GPY211B] (irq=POLL)
[   11.823808] mtk_soc_eth 15100000.ethernet eth1: configuring for phy/2500base-x link mode
[   14.968808] mtk_soc_eth 15100000.ethernet eth1: Link is Up - 1Gbps/Full - flow control rx/tx
[   15.934188] mt7530-mdio mdio-bus:1f lan5: Link is Up - 1Gbps/Full - flow control rx/tx
[   15.934210] br-lan: port 5(lan5) entered blocking state
[   15.947317] br-lan: port 5(lan5) entered forwarding state



BusyBox v1.37.0 (2025-09-12 10:05:46 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt SNAPSHOT, r31076+2-57fcb37401
 -----------------------------------------------------
=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------

 OpenWrt recently switched to the "apk" package manager!

 OPKG Command           APK Equivalent      Description
 ------------------------------------------------------------------
 opkg install <pkg>     apk add <pkg>       Install a package
 opkg remove <pkg>      apk del <pkg>       Remove a package
 opkg upgrade           apk upgrade         Upgrade all packages
 opkg files <pkg>       apk info -L <pkg>   List package contents
 opkg list-installed    apk info            List installed packages
 opkg update            apk update          Update package lists
 opkg search <pkg>      apk search <pkg>    Search for packages
 ------------------------------------------------------------------

For more https://openwrt.org/docs/guide-user/additional-software/opkg-to-apk-cheatsheet

root@OpenWrt:~# 
```
</details>


<h2>How to flash</h2>

**Flash instruction through LuCI:**

This device is flashed OpenWRT base firmware with this target.
The LuCI webpage is integrated in default for upgrading.

**Flash instruction through u-boot:**

1. Prepare the TFTP server on PC.
2. Connect uart to PC, select "2. Upgrade firmware" in u-boot menu.
3. Select "0 - TFTP client (Default)", input client IP, server IP, IP netmask, flashed bin file path
4. Wait about 20 seconds to complete flashing

<h2>Links</h2>

[Product link](https://asiarf.com/product/wi-fi-6e-development-platform-dp7986/)