### PR TITLE
kernel: 6.12: refresh patches for airoha/econet on 6.12.45

### DIFF
--- a/target/linux/airoha/patches-6.12/017-v6.13-net-airoha-Implement-BQL-support.patch
+++ b/target/linux/airoha/patches-6.12/017-v6.13-net-airoha-Implement-BQL-support.patch
@@ -16,7 +16,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/mediatek/airoha_eth.c
 +++ b/drivers/net/ethernet/mediatek/airoha_eth.c
-@@ -1710,9 +1710,11 @@ static int airoha_qdma_tx_napi_poll(stru
+@@ -1709,9 +1709,11 @@ static int airoha_qdma_tx_napi_poll(stru
  			WRITE_ONCE(desc->msg1, 0);
  
  			if (skb) {
@@ -29,7 +29,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  				if (netif_tx_queue_stopped(txq) &&
  				    q->ndesc - q->queued >= q->free_thr)
  					netif_tx_wake_queue(txq);
-@@ -2488,7 +2490,9 @@ static netdev_tx_t airoha_dev_xmit(struc
+@@ -2499,7 +2501,9 @@ static netdev_tx_t airoha_dev_xmit(struc
  	q->queued += i;
  
  	skb_tx_timestamp(skb);

--- a/target/linux/airoha/patches-6.12/031-01-v6.13-net-airoha-Read-completion-queue-data-in-airoha_qdma.patch
+++ b/target/linux/airoha/patches-6.12/031-01-v6.13-net-airoha-Read-completion-queue-data-in-airoha_qdma.patch
@@ -31,7 +31,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  };
  
  struct airoha_hw_stats {
-@@ -1656,25 +1654,31 @@ static int airoha_qdma_init_rx(struct ai
+@@ -1655,25 +1653,31 @@ static int airoha_qdma_init_rx(struct ai
  static int airoha_qdma_tx_napi_poll(struct napi_struct *napi, int budget)
  {
  	struct airoha_tx_irq_queue *irq_q;
@@ -69,7 +69,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		done++;
  
  		last = FIELD_GET(IRQ_DESC_IDX_MASK, val);
-@@ -2026,20 +2030,11 @@ static irqreturn_t airoha_irq_handler(in
+@@ -2025,20 +2029,11 @@ static irqreturn_t airoha_irq_handler(in
  
  	if (intr[0] & INT_TX_MASK) {
  		for (i = 0; i < ARRAY_SIZE(qdma->q_tx_irq); i++) {

--- a/target/linux/airoha/patches-6.12/031-02-v6.13-net-airoha-Simplify-Tx-napi-logic.patch
+++ b/target/linux/airoha/patches-6.12/031-02-v6.13-net-airoha-Simplify-Tx-napi-logic.patch
@@ -17,7 +17,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/mediatek/airoha_eth.c
 +++ b/drivers/net/ethernet/mediatek/airoha_eth.c
-@@ -1670,8 +1670,12 @@ static int airoha_qdma_tx_napi_poll(stru
+@@ -1669,8 +1669,12 @@ static int airoha_qdma_tx_napi_poll(stru
  	irq_queued = FIELD_GET(IRQ_ENTRY_LEN_MASK, status);
  
  	while (irq_queued > 0 && done < budget) {
@@ -31,7 +31,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  		if (val == 0xff)
  			break;
-@@ -1681,9 +1685,7 @@ static int airoha_qdma_tx_napi_poll(stru
+@@ -1680,9 +1684,7 @@ static int airoha_qdma_tx_napi_poll(stru
  		irq_queued--;
  		done++;
  
@@ -41,7 +41,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		if (qid >= ARRAY_SIZE(qdma->q_tx))
  			continue;
  
-@@ -1691,46 +1693,53 @@ static int airoha_qdma_tx_napi_poll(stru
+@@ -1690,46 +1692,53 @@ static int airoha_qdma_tx_napi_poll(stru
  		if (!q->ndesc)
  			continue;
  

--- a/target/linux/airoha/patches-6.12/032-v6.13-watchdog-Add-support-for-Airoha-EN7851-watchdog.patch
+++ b/target/linux/airoha/patches-6.12/032-v6.13-watchdog-Add-support-for-Airoha-EN7851-watchdog.patch
@@ -21,7 +21,7 @@ Signed-off-by: Wim Van Sebroeck <wim@linux-watchdog.org>
 
 --- a/drivers/watchdog/Kconfig
 +++ b/drivers/watchdog/Kconfig
-@@ -372,6 +372,14 @@ config SL28CPLD_WATCHDOG
+@@ -408,6 +408,14 @@ config SL28CPLD_WATCHDOG
  
  # ARM Architecture
  

--- a/target/linux/airoha/patches-6.12/033-05-v6.13-clk-en7523-move-en7581_reset_register-in-en7581_clk_.patch
+++ b/target/linux/airoha/patches-6.12/033-05-v6.13-clk-en7523-move-en7581_reset_register-in-en7581_clk_.patch
@@ -29,7 +29,7 @@ Signed-off-by: Stephen Boyd <sboyd@kernel.org>
  	int (*hw_init)(struct platform_device *pdev,
  		       struct clk_hw_onecell_data *clk_data);
  };
-@@ -595,32 +590,6 @@ static void en7581_register_clocks(struc
+@@ -596,32 +591,6 @@ static void en7581_register_clocks(struc
  	clk_data->num = EN7523_NUM_CLOCKS;
  }
  
@@ -62,7 +62,7 @@ Signed-off-by: Stephen Boyd <sboyd@kernel.org>
  static int en7523_reset_update(struct reset_controller_dev *rcdev,
  			       unsigned long id, bool assert)
  {
-@@ -670,23 +639,18 @@ static int en7523_reset_xlate(struct res
+@@ -671,23 +640,18 @@ static int en7523_reset_xlate(struct res
  	return rst_data->idx_map[reset_spec->args[0]];
  }
  
@@ -88,7 +88,7 @@ Signed-off-by: Stephen Boyd <sboyd@kernel.org>
  	base = devm_platform_ioremap_resource(pdev, 1);
  	if (IS_ERR(base))
  		return PTR_ERR(base);
-@@ -695,13 +659,13 @@ static int en7523_reset_register(struct
+@@ -696,13 +660,13 @@ static int en7523_reset_register(struct
  	if (!rst_data)
  		return -ENOMEM;
  
@@ -106,7 +106,7 @@ Signed-off-by: Stephen Boyd <sboyd@kernel.org>
  	rst_data->rcdev.of_node = dev->of_node;
  	rst_data->rcdev.of_reset_n_cells = 1;
  	rst_data->rcdev.owner = THIS_MODULE;
-@@ -710,6 +674,32 @@ static int en7523_reset_register(struct
+@@ -711,6 +675,32 @@ static int en7523_reset_register(struct
  	return devm_reset_controller_register(dev, &rst_data->rcdev);
  }
  
@@ -139,7 +139,7 @@ Signed-off-by: Stephen Boyd <sboyd@kernel.org>
  static int en7523_clk_probe(struct platform_device *pdev)
  {
  	struct device_node *node = pdev->dev.of_node;
-@@ -728,19 +718,7 @@ static int en7523_clk_probe(struct platf
+@@ -729,19 +719,7 @@ static int en7523_clk_probe(struct platf
  	if (r)
  		return r;
  
@@ -160,7 +160,7 @@ Signed-off-by: Stephen Boyd <sboyd@kernel.org>
  }
  
  static const struct en_clk_soc_data en7523_data = {
-@@ -758,11 +736,6 @@ static const struct en_clk_soc_data en75
+@@ -759,11 +737,6 @@ static const struct en_clk_soc_data en75
  		.enable = en7581_pci_enable,
  		.disable = en7581_pci_disable,
  	},

--- a/target/linux/airoha/patches-6.12/033-06-v6.13-clk-en7523-map-io-region-in-a-single-block.patch
+++ b/target/linux/airoha/patches-6.12/033-06-v6.13-clk-en7523-map-io-region-in-a-single-block.patch
@@ -27,7 +27,7 @@ Signed-off-by: Stephen Boyd <sboyd@kernel.org>
  
  struct en_clk_desc {
  	int id;
-@@ -645,15 +645,9 @@ static const struct reset_control_ops en
+@@ -646,15 +646,9 @@ static const struct reset_control_ops en
  	.status = en7523_reset_status,
  };
  
@@ -44,7 +44,7 @@ Signed-off-by: Stephen Boyd <sboyd@kernel.org>
  
  	rst_data = devm_kzalloc(dev, sizeof(*rst_data), GFP_KERNEL);
  	if (!rst_data)
-@@ -677,27 +671,27 @@ static int en7581_reset_register(struct
+@@ -678,27 +672,27 @@ static int en7581_reset_register(struct
  static int en7581_clk_hw_init(struct platform_device *pdev,
  			      struct clk_hw_onecell_data *clk_data)
  {

--- a/target/linux/airoha/patches-6.12/034-01-v6.13-pinctrl-airoha-Add-support-for-EN7581-SoC.patch
+++ b/target/linux/airoha/patches-6.12/034-01-v6.13-pinctrl-airoha-Add-support-for-EN7581-SoC.patch
@@ -27,11 +27,9 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  4 files changed, 2994 insertions(+), 1 deletion(-)
  create mode 100644 drivers/pinctrl/mediatek/pinctrl-airoha.c
 
-diff --git a/MAINTAINERS b/MAINTAINERS
-index 67634f0ea30e13..38ccb620cc2497 100644
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -18232,6 +18232,13 @@ F:	drivers/pinctrl/
+@@ -18191,6 +18191,13 @@ F:	drivers/pinctrl/
  F:	include/dt-bindings/pinctrl/
  F:	include/linux/pinctrl/
  
@@ -45,8 +43,6 @@ index 67634f0ea30e13..38ccb620cc2497 100644
  PIN CONTROLLER - AMD
  M:	Basavaraj Natikar <Basavaraj.Natikar@amd.com>
  M:	Shyam Sundar S K <Shyam-sundar.S-k@amd.com>
-diff --git a/drivers/pinctrl/mediatek/Kconfig b/drivers/pinctrl/mediatek/Kconfig
-index 7af287252834a4..a417a031659c65 100644
 --- a/drivers/pinctrl/mediatek/Kconfig
 +++ b/drivers/pinctrl/mediatek/Kconfig
 @@ -1,6 +1,6 @@
@@ -79,11 +75,9 @@ index 7af287252834a4..a417a031659c65 100644
  config PINCTRL_MT2712
  	bool "MediaTek MT2712 pin control"
  	depends on OF
-diff --git a/drivers/pinctrl/mediatek/Makefile b/drivers/pinctrl/mediatek/Makefile
-index 680f7e8526e00a..1405d434218ea1 100644
 --- a/drivers/pinctrl/mediatek/Makefile
 +++ b/drivers/pinctrl/mediatek/Makefile
-@@ -8,6 +8,7 @@ obj-$(CONFIG_PINCTRL_MTK_MOORE)		+= pinctrl-moore.o
+@@ -8,6 +8,7 @@ obj-$(CONFIG_PINCTRL_MTK_MOORE)		+= pinc
  obj-$(CONFIG_PINCTRL_MTK_PARIS)		+= pinctrl-paris.o
  
  # SoC Drivers
@@ -91,9 +85,6 @@ index 680f7e8526e00a..1405d434218ea1 100644
  obj-$(CONFIG_PINCTRL_MT7620)		+= pinctrl-mt7620.o
  obj-$(CONFIG_PINCTRL_MT7621)		+= pinctrl-mt7621.o
  obj-$(CONFIG_PINCTRL_MT76X8)		+= pinctrl-mt76x8.o
-diff --git a/drivers/pinctrl/mediatek/pinctrl-airoha.c b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-new file mode 100644
-index 00000000000000..7692e6d9b87105
 --- /dev/null
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
 @@ -0,0 +1,2970 @@

--- a/target/linux/airoha/patches-6.12/034-02-v6.13-pinctrl-airoha-Use-unsigned-long-for-bit-search.patch
+++ b/target/linux/airoha/patches-6.12/034-02-v6.13-pinctrl-airoha-Use-unsigned-long-for-bit-search.patch
@@ -36,11 +36,9 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  drivers/pinctrl/mediatek/pinctrl-airoha.c | 9 +++++----
  1 file changed, 5 insertions(+), 4 deletions(-)
 
-diff --git a/drivers/pinctrl/mediatek/pinctrl-airoha.c b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-index 7692e6d9b87105..547a798b71c8ae 100644
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-@@ -2384,15 +2384,16 @@ static irqreturn_t airoha_irq_handler(int irq, void *data)
+@@ -2384,15 +2384,16 @@ static irqreturn_t airoha_irq_handler(in
  
  	for (i = 0; i < ARRAY_SIZE(irq_status_regs); i++) {
  		struct gpio_irq_chip *girq = &pinctrl->gpiochip.chip.irq;

--- a/target/linux/airoha/patches-6.12/038-01-v6.14-net-airoha-Enable-Tx-drop-capability-for-each-Tx-DMA.patch
+++ b/target/linux/airoha/patches-6.12/038-01-v6.14-net-airoha-Enable-Tx-drop-capability-for-each-Tx-DMA.patch
@@ -14,7 +14,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/drivers/net/ethernet/mediatek/airoha_eth.c
 +++ b/drivers/net/ethernet/mediatek/airoha_eth.c
-@@ -1790,6 +1790,10 @@ static int airoha_qdma_init_tx_queue(str
+@@ -1789,6 +1789,10 @@ static int airoha_qdma_init_tx_queue(str
  		WRITE_ONCE(q->desc[i].ctrl, cpu_to_le32(val));
  	}
  

--- a/target/linux/airoha/patches-6.12/038-02-v6.14-net-airoha-Introduce-ndo_select_queue-callback.patch
+++ b/target/linux/airoha/patches-6.12/038-02-v6.14-net-airoha-Introduce-ndo_select_queue-callback.patch
@@ -29,7 +29,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  #define AIROHA_NUM_TX_RING		32
  #define AIROHA_NUM_RX_RING		32
  #define AIROHA_FE_MC_MAX_VLAN_TABLE	64
-@@ -2422,21 +2424,44 @@ static void airoha_dev_get_stats64(struc
+@@ -2421,21 +2423,44 @@ static void airoha_dev_get_stats64(struc
  	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
  }
  
@@ -76,7 +76,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	if (skb->ip_summed == CHECKSUM_PARTIAL)
  		msg0 |= FIELD_PREP(QDMA_ETH_TXMSG_TCO_MASK, 1) |
  			FIELD_PREP(QDMA_ETH_TXMSG_UCO_MASK, 1) |
-@@ -2610,6 +2635,7 @@ static const struct net_device_ops airoh
+@@ -2609,6 +2634,7 @@ static const struct net_device_ops airoh
  	.ndo_init		= airoha_dev_init,
  	.ndo_open		= airoha_dev_open,
  	.ndo_stop		= airoha_dev_stop,

--- a/target/linux/airoha/patches-6.12/038-03-v6.14-net-airoha-Add-sched-ETS-offload-support.patch
+++ b/target/linux/airoha/patches-6.12/038-03-v6.14-net-airoha-Add-sched-ETS-offload-support.patch
@@ -100,7 +100,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  };
  
  struct airoha_eth {
-@@ -1962,6 +2003,27 @@ static void airoha_qdma_init_qos(struct
+@@ -1961,6 +2002,27 @@ static void airoha_qdma_init_qos(struct
  			FIELD_PREP(SLA_SLOW_TICK_RATIO_MASK, 40));
  }
  
@@ -128,7 +128,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  static int airoha_qdma_hw_init(struct airoha_qdma *qdma)
  {
  	int i;
-@@ -2012,6 +2074,7 @@ static int airoha_qdma_hw_init(struct ai
+@@ -2011,6 +2073,7 @@ static int airoha_qdma_hw_init(struct ai
  
  	airoha_qdma_set(qdma, REG_TXQ_CNGST_CFG,
  			TXQ_CNGST_DROP_EN | TXQ_CNGST_DEI_DROP_EN);
@@ -136,7 +136,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  
  	return 0;
  }
-@@ -2631,6 +2694,135 @@ airoha_ethtool_get_rmon_stats(struct net
+@@ -2630,6 +2693,135 @@ airoha_ethtool_get_rmon_stats(struct net
  	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
  }
  
@@ -272,7 +272,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  static const struct net_device_ops airoha_netdev_ops = {
  	.ndo_init		= airoha_dev_init,
  	.ndo_open		= airoha_dev_open,
-@@ -2639,6 +2831,7 @@ static const struct net_device_ops airoh
+@@ -2638,6 +2830,7 @@ static const struct net_device_ops airoh
  	.ndo_start_xmit		= airoha_dev_xmit,
  	.ndo_get_stats64        = airoha_dev_get_stats64,
  	.ndo_set_mac_address	= airoha_dev_set_macaddr,
@@ -280,7 +280,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  };
  
  static const struct ethtool_ops airoha_ethtool_ops = {
-@@ -2688,7 +2881,8 @@ static int airoha_alloc_gdm_port(struct
+@@ -2687,7 +2880,8 @@ static int airoha_alloc_gdm_port(struct
  	dev->watchdog_timeo = 5 * HZ;
  	dev->hw_features = NETIF_F_IP_CSUM | NETIF_F_RXCSUM |
  			   NETIF_F_TSO6 | NETIF_F_IPV6_CSUM |

--- a/target/linux/airoha/patches-6.12/038-04-v6.14-net-airoha-Add-sched-HTB-offload-support.patch
+++ b/target/linux/airoha/patches-6.12/038-04-v6.14-net-airoha-Add-sched-HTB-offload-support.patch
@@ -94,7 +94,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	/* qos stats counters */
  	u64 cpu_tx_packets;
  	u64 fwd_tx_packets;
-@@ -2810,6 +2851,243 @@ static int airoha_tc_setup_qdisc_ets(str
+@@ -2809,6 +2850,243 @@ static int airoha_tc_setup_qdisc_ets(str
  	}
  }
  
@@ -338,7 +338,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  static int airoha_dev_tc_setup(struct net_device *dev, enum tc_setup_type type,
  			       void *type_data)
  {
-@@ -2818,6 +3096,8 @@ static int airoha_dev_tc_setup(struct ne
+@@ -2817,6 +3095,8 @@ static int airoha_dev_tc_setup(struct ne
  	switch (type) {
  	case TC_SETUP_QDISC_ETS:
  		return airoha_tc_setup_qdisc_ets(port, type_data);
@@ -347,7 +347,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	default:
  		return -EOPNOTSUPP;
  	}
-@@ -2868,7 +3148,8 @@ static int airoha_alloc_gdm_port(struct
+@@ -2867,7 +3147,8 @@ static int airoha_alloc_gdm_port(struct
  	}
  
  	dev = devm_alloc_etherdev_mqs(eth->dev, sizeof(*port),
@@ -357,7 +357,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	if (!dev) {
  		dev_err(eth->dev, "alloc_etherdev failed\n");
  		return -ENOMEM;
-@@ -2888,6 +3169,11 @@ static int airoha_alloc_gdm_port(struct
+@@ -2887,6 +3168,11 @@ static int airoha_alloc_gdm_port(struct
  	dev->irq = qdma->irq;
  	SET_NETDEV_DEV(dev, eth->dev);
  

--- a/target/linux/airoha/patches-6.12/039-v6.14-cpufreq-airoha-Add-EN7581-CPUFreq-SMCCC-driver.patch
+++ b/target/linux/airoha/patches-6.12/039-v6.14-cpufreq-airoha-Add-EN7581-CPUFreq-SMCCC-driver.patch
@@ -25,7 +25,7 @@ Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>
 
 --- a/drivers/cpufreq/Kconfig.arm
 +++ b/drivers/cpufreq/Kconfig.arm
-@@ -41,6 +41,14 @@ config ARM_ALLWINNER_SUN50I_CPUFREQ_NVME
+@@ -15,6 +15,14 @@ config ARM_ALLWINNER_SUN50I_CPUFREQ_NVME
  	  To compile this driver as a module, choose M here: the
  	  module will be called sun50i-cpufreq-nvmem.
  
@@ -228,5 +228,5 @@ Signed-off-by: Viresh Kumar <viresh.kumar@linaro.org>
 +	{ .compatible = "airoha,en7581", },
 +
  	{ .compatible = "allwinner,sun50i-h6", },
- 
- 	{ .compatible = "apple,arm-platform", },
+ 	{ .compatible = "allwinner,sun50i-h616", },
+ 	{ .compatible = "allwinner,sun50i-h618", },

--- a/target/linux/airoha/patches-6.12/039-v6.14-net-airoha-Enforce-ETS-Qdisc-priomap.patch
+++ b/target/linux/airoha/patches-6.12/039-v6.14-net-airoha-Enforce-ETS-Qdisc-priomap.patch
@@ -20,7 +20,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/mediatek/airoha_eth.c
 +++ b/drivers/net/ethernet/mediatek/airoha_eth.c
-@@ -2786,7 +2786,7 @@ static int airoha_qdma_set_tx_ets_sched(
+@@ -2785,7 +2785,7 @@ static int airoha_qdma_set_tx_ets_sched(
  	struct tc_ets_qopt_offload_replace_params *p = &opt->replace_params;
  	enum tx_sched_mode mode = TC_SCH_SP;
  	u16 w[AIROHA_NUM_QOS_QUEUES] = {};
@@ -29,7 +29,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  	if (p->bands > AIROHA_NUM_QOS_QUEUES)
  		return -EINVAL;
-@@ -2800,7 +2800,20 @@ static int airoha_qdma_set_tx_ets_sched(
+@@ -2799,7 +2799,20 @@ static int airoha_qdma_set_tx_ets_sched(
  	if (nstrict == AIROHA_NUM_QOS_QUEUES - 1)
  		return -EINVAL;
  

--- a/target/linux/airoha/patches-6.12/042-01-v6.14-PCI-mediatek-gen3-Rely-on-clk_bulk_prepare_enable-in.patch
+++ b/target/linux/airoha/patches-6.12/042-01-v6.14-PCI-mediatek-gen3-Rely-on-clk_bulk_prepare_enable-in.patch
@@ -21,7 +21,7 @@ Reviewed-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
 
 --- a/drivers/pci/controller/pcie-mediatek-gen3.c
 +++ b/drivers/pci/controller/pcie-mediatek-gen3.c
-@@ -907,12 +907,6 @@ static int mtk_pcie_en7581_power_up(stru
+@@ -900,12 +900,6 @@ static int mtk_pcie_en7581_power_up(stru
  	pm_runtime_enable(dev);
  	pm_runtime_get_sync(dev);
  
@@ -34,7 +34,7 @@ Reviewed-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
  	val = FIELD_PREP(PCIE_VAL_LN0_DOWNSTREAM, 0x47) |
  	      FIELD_PREP(PCIE_VAL_LN1_DOWNSTREAM, 0x47) |
  	      FIELD_PREP(PCIE_VAL_LN0_UPSTREAM, 0x41) |
-@@ -925,17 +919,15 @@ static int mtk_pcie_en7581_power_up(stru
+@@ -918,17 +912,15 @@ static int mtk_pcie_en7581_power_up(stru
  	      FIELD_PREP(PCIE_K_FINETUNE_MAX, 0xf);
  	writel_relaxed(val, pcie->base + PCIE_PIPE4_PIE8_REG);
  

--- a/target/linux/airoha/patches-6.12/042-02-v6.14-PCI-mediatek-gen3-Move-reset-assert-callbacks-in-.po.patch
+++ b/target/linux/airoha/patches-6.12/042-02-v6.14-PCI-mediatek-gen3-Move-reset-assert-callbacks-in-.po.patch
@@ -36,7 +36,7 @@ Reviewed-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
  /* Time in ms needed to complete PCIe reset on EN7581 SoC */
  #define PCIE_EN7581_RESET_TIME_MS	100
  
-@@ -875,9 +877,14 @@ static int mtk_pcie_en7581_power_up(stru
+@@ -868,9 +870,14 @@ static int mtk_pcie_en7581_power_up(stru
  	u32 val;
  
  	/*
@@ -53,7 +53,7 @@ Reviewed-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
  	mdelay(PCIE_EN7581_RESET_TIME_MS);
  
  	err = phy_init(pcie->phy);
-@@ -944,6 +951,15 @@ static int mtk_pcie_power_up(struct mtk_
+@@ -937,6 +944,15 @@ static int mtk_pcie_power_up(struct mtk_
  	struct device *dev = pcie->dev;
  	int err;
  
@@ -69,7 +69,7 @@ Reviewed-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
  	/* PHY power on and enable pipe clock */
  	err = reset_control_bulk_deassert(pcie->soc->phy_resets.num_resets, pcie->phy_resets);
  	if (err) {
-@@ -1016,14 +1032,6 @@ static int mtk_pcie_setup(struct mtk_gen
+@@ -1009,14 +1025,6 @@ static int mtk_pcie_setup(struct mtk_gen
  	 * counter since the bulk is shared.
  	 */
  	reset_control_bulk_deassert(pcie->soc->phy_resets.num_resets, pcie->phy_resets);

--- a/target/linux/airoha/patches-6.12/042-03-v6.14-PCI-mediatek-gen3-Add-comment-about-initialization-o.patch
+++ b/target/linux/airoha/patches-6.12/042-03-v6.14-PCI-mediatek-gen3-Add-comment-about-initialization-o.patch
@@ -22,7 +22,7 @@ Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com
 
 --- a/drivers/pci/controller/pcie-mediatek-gen3.c
 +++ b/drivers/pci/controller/pcie-mediatek-gen3.c
-@@ -887,6 +887,10 @@ static int mtk_pcie_en7581_power_up(stru
+@@ -880,6 +880,10 @@ static int mtk_pcie_en7581_power_up(stru
  	/* Wait for the time needed to complete the reset lines assert. */
  	mdelay(PCIE_EN7581_RESET_TIME_MS);
  

--- a/target/linux/airoha/patches-6.12/042-04-v6.14-PCI-mediatek-gen3-Move-reset-delay-in-mtk_pcie_en758.patch
+++ b/target/linux/airoha/patches-6.12/042-04-v6.14-PCI-mediatek-gen3-Move-reset-delay-in-mtk_pcie_en758.patch
@@ -43,7 +43,7 @@ Acked-by: Stephen Boyd <sboyd@kernel.org>
  }
 --- a/drivers/pci/controller/pcie-mediatek-gen3.c
 +++ b/drivers/pci/controller/pcie-mediatek-gen3.c
-@@ -936,6 +936,13 @@ static int mtk_pcie_en7581_power_up(stru
+@@ -929,6 +929,13 @@ static int mtk_pcie_en7581_power_up(stru
  		goto err_clk_prepare_enable;
  	}
  

--- a/target/linux/airoha/patches-6.12/042-05-v6.14-PCI-mediatek-gen3-Rely-on-msleep-in-mtk_pcie_en7581_.patch
+++ b/target/linux/airoha/patches-6.12/042-05-v6.14-PCI-mediatek-gen3-Rely-on-msleep-in-mtk_pcie_en7581_.patch
@@ -21,7 +21,7 @@ Reviewed-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
 
 --- a/drivers/pci/controller/pcie-mediatek-gen3.c
 +++ b/drivers/pci/controller/pcie-mediatek-gen3.c
-@@ -885,7 +885,7 @@ static int mtk_pcie_en7581_power_up(stru
+@@ -878,7 +878,7 @@ static int mtk_pcie_en7581_power_up(stru
  	reset_control_assert(pcie->mac_reset);
  
  	/* Wait for the time needed to complete the reset lines assert. */
@@ -30,7 +30,7 @@ Reviewed-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
  
  	/*
  	 * Unlike the other MediaTek Gen3 controllers, the Airoha EN7581
-@@ -913,7 +913,7 @@ static int mtk_pcie_en7581_power_up(stru
+@@ -906,7 +906,7 @@ static int mtk_pcie_en7581_power_up(stru
  	 * Wait for the time needed to complete the bulk de-assert above.
  	 * This time is specific for EN7581 SoC.
  	 */

--- a/target/linux/airoha/patches-6.12/042-06-v6.14-PCI-mediatek-gen3-Avoid-PCIe-resetting-via-PERST-for.patch
+++ b/target/linux/airoha/patches-6.12/042-06-v6.14-PCI-mediatek-gen3-Avoid-PCIe-resetting-via-PERST-for.patch
@@ -101,7 +101,7 @@ Signed-off-by: Krzysztof Wilczyński <kwilczynski@kernel.org>
  
  	/* Check if the link is up or not */
  	err = readl_poll_timeout(pcie->base + PCIE_LINK_STATUS_REG, val,
-@@ -1178,10 +1198,12 @@ static int mtk_pcie_suspend_noirq(struct
+@@ -1171,10 +1191,12 @@ static int mtk_pcie_suspend_noirq(struct
  		return err;
  	}
  
@@ -118,7 +118,7 @@ Signed-off-by: Krzysztof Wilczyński <kwilczynski@kernel.org>
  
  	dev_dbg(pcie->dev, "entered L2 states successfully");
  
-@@ -1232,6 +1254,7 @@ static const struct mtk_gen3_pcie_pdata
+@@ -1225,6 +1247,7 @@ static const struct mtk_gen3_pcie_pdata
  		.id[2] = "phy-lane2",
  		.num_resets = 3,
  	},

--- a/target/linux/airoha/patches-6.12/043-v6.15-PCI-mediatek-gen3-Remove-leftover-mac_reset-assert-f.patch
+++ b/target/linux/airoha/patches-6.12/043-v6.15-PCI-mediatek-gen3-Remove-leftover-mac_reset-assert-f.patch
@@ -24,7 +24,7 @@ Signed-off-by: Krzysztof Wilczyński <kwilczynski@kernel.org>
 
 --- a/drivers/pci/controller/pcie-mediatek-gen3.c
 +++ b/drivers/pci/controller/pcie-mediatek-gen3.c
-@@ -902,7 +902,6 @@ static int mtk_pcie_en7581_power_up(stru
+@@ -895,7 +895,6 @@ static int mtk_pcie_en7581_power_up(stru
  	 */
  	reset_control_bulk_assert(pcie->soc->phy_resets.num_resets,
  				  pcie->phy_resets);

--- a/target/linux/airoha/patches-6.12/044-v6.15-PCI-mediatek-gen3-Configure-PBUS_CSR-registers-for-E.patch
+++ b/target/linux/airoha/patches-6.12/044-v6.15-PCI-mediatek-gen3-Configure-PBUS_CSR-registers-for-E.patch
@@ -37,7 +37,7 @@ Signed-off-by: Krzysztof Wilczyński <kwilczynski@kernel.org>
  #include <linux/reset.h>
  
  #include "../pci.h"
-@@ -892,9 +894,13 @@ static int mtk_pcie_parse_port(struct mt
+@@ -885,9 +887,13 @@ static int mtk_pcie_parse_port(struct mt
  
  static int mtk_pcie_en7581_power_up(struct mtk_gen3_pcie *pcie)
  {
@@ -52,7 +52,7 @@ Signed-off-by: Krzysztof Wilczyński <kwilczynski@kernel.org>
  
  	/*
  	 * The controller may have been left out of reset by the bootloader
-@@ -907,6 +913,26 @@ static int mtk_pcie_en7581_power_up(stru
+@@ -900,6 +906,26 @@ static int mtk_pcie_en7581_power_up(stru
  	msleep(PCIE_EN7581_RESET_TIME_MS);
  
  	/*

--- a/target/linux/airoha/patches-6.12/046-v6.15-net-airoha-Fix-TSO-support-for-header-cloned-skbs.patch
+++ b/target/linux/airoha/patches-6.12/046-v6.15-net-airoha-Fix-TSO-support-for-header-cloned-skbs.patch
@@ -24,7 +24,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/mediatek/airoha_eth.c
 +++ b/drivers/net/ethernet/mediatek/airoha_eth.c
-@@ -2549,11 +2549,10 @@ static u16 airoha_dev_select_queue(struc
+@@ -2548,11 +2548,10 @@ static u16 airoha_dev_select_queue(struc
  static netdev_tx_t airoha_dev_xmit(struct sk_buff *skb,
  				   struct net_device *dev)
  {
@@ -37,7 +37,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	struct netdev_queue *txq;
  	struct airoha_queue *q;
  	void *data = skb->data;
-@@ -2576,8 +2575,9 @@ static netdev_tx_t airoha_dev_xmit(struc
+@@ -2575,8 +2574,9 @@ static netdev_tx_t airoha_dev_xmit(struc
  		if (skb_cow_head(skb, 0))
  			goto error;
  
@@ -49,7 +49,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  			tcp_hdr(skb)->check = (__force __sum16)csum;
  			msg0 |= FIELD_PREP(QDMA_ETH_TXMSG_TSO_MASK, 1);
-@@ -2606,7 +2606,7 @@ static netdev_tx_t airoha_dev_xmit(struc
+@@ -2605,7 +2605,7 @@ static netdev_tx_t airoha_dev_xmit(struc
  	for (i = 0; i < nr_frags; i++) {
  		struct airoha_qdma_desc *desc = &q->desc[index];
  		struct airoha_queue_entry *e = &q->entry[index];

--- a/target/linux/airoha/patches-6.12/047-v6.13-net-airoha-Reset-BQL-stopping-the-netdevice.patch
+++ b/target/linux/airoha/patches-6.12/047-v6.13-net-airoha-Reset-BQL-stopping-the-netdevice.patch
@@ -16,7 +16,7 @@ Signed-off-by: Andrew Lunn <andrew@lunn.ch>
 
 --- a/drivers/net/ethernet/mediatek/airoha_eth.c
 +++ b/drivers/net/ethernet/mediatek/airoha_eth.c
-@@ -2469,7 +2469,7 @@ static int airoha_dev_stop(struct net_de
+@@ -2468,7 +2468,7 @@ static int airoha_dev_stop(struct net_de
  {
  	struct airoha_gdm_port *port = netdev_priv(dev);
  	struct airoha_qdma *qdma = port->qdma;
@@ -25,7 +25,7 @@ Signed-off-by: Andrew Lunn <andrew@lunn.ch>
  
  	netif_tx_disable(dev);
  	err = airoha_set_gdm_ports(qdma->eth, false);
-@@ -2480,6 +2480,14 @@ static int airoha_dev_stop(struct net_de
+@@ -2479,6 +2479,14 @@ static int airoha_dev_stop(struct net_de
  			  GLOBAL_CFG_TX_DMA_EN_MASK |
  			  GLOBAL_CFG_RX_DMA_EN_MASK);
  

--- a/target/linux/airoha/patches-6.12/048-01-v6.15-net-airoha-Move-airoha_eth-driver-in-a-dedicated-fol.patch
+++ b/target/linux/airoha/patches-6.12/048-01-v6.15-net-airoha-Move-airoha_eth-driver-in-a-dedicated-fol.patch
@@ -26,7 +26,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/drivers/net/ethernet/Kconfig
 +++ b/drivers/net/ethernet/Kconfig
-@@ -23,6 +23,8 @@ source "drivers/net/ethernet/actions/Kco
+@@ -20,6 +20,8 @@ source "drivers/net/ethernet/actions/Kco
  source "drivers/net/ethernet/adaptec/Kconfig"
  source "drivers/net/ethernet/aeroflex/Kconfig"
  source "drivers/net/ethernet/agere/Kconfig"

--- a/target/linux/airoha/patches-6.12/048-05-v6.15-net-airoha-Move-DSA-tag-in-DMA-descriptor.patch
+++ b/target/linux/airoha/patches-6.12/048-05-v6.15-net-airoha-Move-DSA-tag-in-DMA-descriptor.patch
@@ -74,7 +74,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  		napi_gro_receive(&q->napi, skb);
  
  		done++;
-@@ -1637,25 +1656,76 @@ static u16 airoha_dev_select_queue(struc
+@@ -1636,25 +1655,76 @@ static u16 airoha_dev_select_queue(struc
  	return queue < dev->num_tx_queues ? queue : 0;
  }
  
@@ -155,7 +155,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	if (skb->ip_summed == CHECKSUM_PARTIAL)
  		msg0 |= FIELD_PREP(QDMA_ETH_TXMSG_TCO_MASK, 1) |
  			FIELD_PREP(QDMA_ETH_TXMSG_UCO_MASK, 1) |
-@@ -1686,6 +1756,8 @@ static netdev_tx_t airoha_dev_xmit(struc
+@@ -1685,6 +1755,8 @@ static netdev_tx_t airoha_dev_xmit(struc
  	spin_lock_bh(&q->lock);
  
  	txq = netdev_get_tx_queue(dev, qid);
@@ -164,7 +164,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	if (q->queued + nr_frags > q->ndesc) {
  		/* not enough space in the queue */
  		netif_tx_stop_queue(txq);
-@@ -1693,7 +1765,10 @@ static netdev_tx_t airoha_dev_xmit(struc
+@@ -1692,7 +1764,10 @@ static netdev_tx_t airoha_dev_xmit(struc
  		return NETDEV_TX_BUSY;
  	}
  
@@ -175,7 +175,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	for (i = 0; i < nr_frags; i++) {
  		struct airoha_qdma_desc *desc = &q->desc[index];
  		struct airoha_queue_entry *e = &q->entry[index];
-@@ -2224,6 +2299,37 @@ static const struct ethtool_ops airoha_e
+@@ -2223,6 +2298,37 @@ static const struct ethtool_ops airoha_e
  	.get_rmon_stats		= airoha_ethtool_get_rmon_stats,
  };
  
@@ -213,7 +213,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  static int airoha_alloc_gdm_port(struct airoha_eth *eth, struct device_node *np)
  {
  	const __be32 *id_ptr = of_get_property(np, "reg", NULL);
-@@ -2296,6 +2402,10 @@ static int airoha_alloc_gdm_port(struct
+@@ -2295,6 +2401,10 @@ static int airoha_alloc_gdm_port(struct
  	port->id = id;
  	eth->ports[index] = port;
  
@@ -224,7 +224,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	return register_netdev(dev);
  }
  
-@@ -2388,8 +2498,10 @@ error_hw_cleanup:
+@@ -2387,8 +2497,10 @@ error_hw_cleanup:
  	for (i = 0; i < ARRAY_SIZE(eth->ports); i++) {
  		struct airoha_gdm_port *port = eth->ports[i];
  
@@ -236,7 +236,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	}
  	free_netdev(eth->napi_dev);
  	platform_set_drvdata(pdev, NULL);
-@@ -2415,6 +2527,7 @@ static void airoha_remove(struct platfor
+@@ -2414,6 +2526,7 @@ static void airoha_remove(struct platfor
  
  		airoha_dev_stop(port->dev);
  		unregister_netdev(port->dev);

--- a/target/linux/airoha/patches-6.12/048-07-v6.15-net-airoha-Enable-support-for-multiple-net_devices.patch
+++ b/target/linux/airoha/patches-6.12/048-07-v6.15-net-airoha-Enable-support-for-multiple-net_devices.patch
@@ -25,7 +25,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1563,6 +1563,7 @@ static int airoha_dev_open(struct net_de
+@@ -1562,6 +1562,7 @@ static int airoha_dev_open(struct net_de
  	airoha_qdma_set(qdma, REG_QDMA_GLOBAL_CFG,
  			GLOBAL_CFG_TX_DMA_EN_MASK |
  			GLOBAL_CFG_RX_DMA_EN_MASK);
@@ -33,7 +33,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  
  	return 0;
  }
-@@ -1578,16 +1579,20 @@ static int airoha_dev_stop(struct net_de
+@@ -1577,16 +1578,20 @@ static int airoha_dev_stop(struct net_de
  	if (err)
  		return err;
  
@@ -62,7 +62,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	}
  
  	return 0;
-@@ -2330,13 +2335,14 @@ static void airoha_metadata_dst_free(str
+@@ -2329,13 +2334,14 @@ static void airoha_metadata_dst_free(str
  	}
  }
  
@@ -79,7 +79,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	u32 id;
  
  	if (!id_ptr) {
-@@ -2345,14 +2351,14 @@ static int airoha_alloc_gdm_port(struct
+@@ -2344,14 +2350,14 @@ static int airoha_alloc_gdm_port(struct
  	}
  
  	id = be32_to_cpup(id_ptr);
@@ -96,7 +96,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  		dev_err(eth->dev, "duplicate gdm port id: %d\n", id);
  		return -EINVAL;
  	}
-@@ -2400,7 +2406,7 @@ static int airoha_alloc_gdm_port(struct
+@@ -2399,7 +2405,7 @@ static int airoha_alloc_gdm_port(struct
  	port->qdma = qdma;
  	port->dev = dev;
  	port->id = id;
@@ -105,7 +105,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  
  	err = airoha_metadata_dst_alloc(port);
  	if (err)
-@@ -2472,6 +2478,7 @@ static int airoha_probe(struct platform_
+@@ -2471,6 +2477,7 @@ static int airoha_probe(struct platform_
  	for (i = 0; i < ARRAY_SIZE(eth->qdma); i++)
  		airoha_qdma_start_napi(&eth->qdma[i]);
  
@@ -113,7 +113,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	for_each_child_of_node(pdev->dev.of_node, np) {
  		if (!of_device_is_compatible(np, "airoha,eth-mac"))
  			continue;
-@@ -2479,7 +2486,7 @@ static int airoha_probe(struct platform_
+@@ -2478,7 +2485,7 @@ static int airoha_probe(struct platform_
  		if (!of_device_is_available(np))
  			continue;
  

--- a/target/linux/airoha/patches-6.12/048-08-v6.15-net-airoha-Move-REG_GDM_FWD_CFG-initialization-in-ai.patch
+++ b/target/linux/airoha/patches-6.12/048-08-v6.15-net-airoha-Move-REG_GDM_FWD_CFG-initialization-in-ai.patch
@@ -63,7 +63,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  		airoha_fe_rmw(eth, REG_GDM_LEN_CFG(p),
  			      GDM_SHORT_LEN_MASK | GDM_LONG_LEN_MASK,
  			      FIELD_PREP(GDM_SHORT_LEN_MASK, 60) |
-@@ -1615,8 +1606,11 @@ static int airoha_dev_set_macaddr(struct
+@@ -1614,8 +1605,11 @@ static int airoha_dev_set_macaddr(struct
  static int airoha_dev_init(struct net_device *dev)
  {
  	struct airoha_gdm_port *port = netdev_priv(dev);

--- a/target/linux/airoha/patches-6.12/048-09-v6.15-net-airoha-Rename-airoha_set_gdm_port_fwd_cfg-in-air.patch
+++ b/target/linux/airoha/patches-6.12/048-09-v6.15-net-airoha-Rename-airoha_set_gdm_port_fwd_cfg-in-air.patch
@@ -83,7 +83,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  static void airoha_fe_maccr_init(struct airoha_eth *eth)
  {
  	int p;
-@@ -1540,7 +1513,7 @@ static int airoha_dev_open(struct net_de
+@@ -1539,7 +1512,7 @@ static int airoha_dev_open(struct net_de
  	int err;
  
  	netif_tx_start_all_queues(dev);
@@ -92,7 +92,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	if (err)
  		return err;
  
-@@ -1566,7 +1539,7 @@ static int airoha_dev_stop(struct net_de
+@@ -1565,7 +1538,7 @@ static int airoha_dev_stop(struct net_de
  	int i, err;
  
  	netif_tx_disable(dev);

--- a/target/linux/airoha/patches-6.12/048-13-v6.15-net-airoha-Introduce-flowtable-offload-support.patch
+++ b/target/linux/airoha/patches-6.12/048-13-v6.15-net-airoha-Introduce-flowtable-offload-support.patch
@@ -76,7 +76,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  		napi_gro_receive(&q->napi, skb);
  
  		done++;
-@@ -1302,6 +1311,10 @@ static int airoha_hw_init(struct platfor
+@@ -1301,6 +1310,10 @@ static int airoha_hw_init(struct platfor
  			return err;
  	}
  
@@ -87,7 +87,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	set_bit(DEV_STATE_INITIALIZED, &eth->state);
  
  	return 0;
-@@ -2166,6 +2179,47 @@ static int airoha_tc_htb_alloc_leaf_queu
+@@ -2165,6 +2178,47 @@ static int airoha_tc_htb_alloc_leaf_queu
  	return 0;
  }
  
@@ -135,7 +135,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  static void airoha_tc_remove_htb_queue(struct airoha_gdm_port *port, int queue)
  {
  	struct net_device *dev = port->dev;
-@@ -2249,6 +2303,9 @@ static int airoha_dev_tc_setup(struct ne
+@@ -2248,6 +2302,9 @@ static int airoha_dev_tc_setup(struct ne
  		return airoha_tc_setup_qdisc_ets(port, type_data);
  	case TC_SETUP_QDISC_HTB:
  		return airoha_tc_setup_qdisc_htb(port, type_data);
@@ -145,7 +145,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	default:
  		return -EOPNOTSUPP;
  	}
-@@ -2505,6 +2562,7 @@ static void airoha_remove(struct platfor
+@@ -2504,6 +2561,7 @@ static void airoha_remove(struct platfor
  	}
  	free_netdev(eth->napi_dev);
  

--- a/target/linux/airoha/patches-6.12/048-14-v6.15-net-airoha-Add-loopback-support-for-GDM2.patch
+++ b/target/linux/airoha/patches-6.12/048-14-v6.15-net-airoha-Add-loopback-support-for-GDM2.patch
@@ -18,7 +18,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1589,14 +1589,81 @@ static int airoha_dev_set_macaddr(struct
+@@ -1588,14 +1588,81 @@ static int airoha_dev_set_macaddr(struct
  	return 0;
  }
  

--- a/target/linux/airoha/patches-6.12/049-01-v6.16-thermal-drivers-Add-support-for-Airoha-EN7581-therma.patch
+++ b/target/linux/airoha/patches-6.12/049-01-v6.16-thermal-drivers-Add-support-for-Airoha-EN7581-therma.patch
@@ -30,7 +30,7 @@ Signed-off-by: Daniel Lezcano <daniel.lezcano@linaro.org>
 
 --- a/drivers/thermal/Kconfig
 +++ b/drivers/thermal/Kconfig
-@@ -317,6 +317,15 @@ config QORIQ_THERMAL
+@@ -318,6 +318,15 @@ config QORIQ_THERMAL
  	  cpufreq is used as the cooling device to throttle CPUs when the
  	  passive trip is crossed.
  
@@ -48,7 +48,7 @@ Signed-off-by: Daniel Lezcano <daniel.lezcano@linaro.org>
  	depends on PLAT_SPEAR || COMPILE_TEST
 --- a/drivers/thermal/Makefile
 +++ b/drivers/thermal/Makefile
-@@ -34,6 +34,7 @@ obj-$(CONFIG_K3_THERMAL)	+= k3_bandgap.o
+@@ -35,6 +35,7 @@ obj-$(CONFIG_K3_THERMAL)	+= k3_bandgap.o
  # platform thermal drivers
  obj-y				+= broadcom/
  obj-$(CONFIG_THERMAL_MMIO)		+= thermal_mmio.o

--- a/target/linux/airoha/patches-6.12/051-v6.15-pinctrl-airoha-fix-wrong-PHY-LED-mapping-and-PHY2-LE.patch
+++ b/target/linux/airoha/patches-6.12/051-v6.15-pinctrl-airoha-fix-wrong-PHY-LED-mapping-and-PHY2-LE.patch
@@ -36,7 +36,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  #include <linux/bits.h>
  #include <linux/cleanup.h>
  #include <linux/gpio/driver.h>
-@@ -106,39 +107,19 @@
+@@ -112,39 +113,19 @@
  #define REG_LAN_LED1_MAPPING			0x0280
  
  #define LAN4_LED_MAPPING_MASK			GENMASK(18, 16)
@@ -81,7 +81,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  
  /* CONF */
  #define REG_I2C_SDA_E2				0x001c
-@@ -1470,8 +1451,8 @@ static const struct airoha_pinctrl_func_
+@@ -1476,8 +1457,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -92,7 +92,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1485,8 +1466,8 @@ static const struct airoha_pinctrl_func_
+@@ -1491,8 +1472,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -103,7 +103,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1500,8 +1481,8 @@ static const struct airoha_pinctrl_func_
+@@ -1506,8 +1487,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -114,7 +114,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1515,8 +1496,8 @@ static const struct airoha_pinctrl_func_
+@@ -1521,8 +1502,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -125,7 +125,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	},
-@@ -1534,8 +1515,8 @@ static const struct airoha_pinctrl_func_
+@@ -1540,8 +1521,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -136,7 +136,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1549,8 +1530,8 @@ static const struct airoha_pinctrl_func_
+@@ -1555,8 +1536,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -147,7 +147,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1564,8 +1545,8 @@ static const struct airoha_pinctrl_func_
+@@ -1570,8 +1551,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -158,7 +158,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1579,8 +1560,8 @@ static const struct airoha_pinctrl_func_
+@@ -1585,8 +1566,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -169,7 +169,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	},
-@@ -1598,8 +1579,8 @@ static const struct airoha_pinctrl_func_
+@@ -1604,8 +1585,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -180,7 +180,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1613,8 +1594,8 @@ static const struct airoha_pinctrl_func_
+@@ -1619,8 +1600,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -191,7 +191,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1628,8 +1609,8 @@ static const struct airoha_pinctrl_func_
+@@ -1634,8 +1615,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -202,7 +202,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1643,8 +1624,8 @@ static const struct airoha_pinctrl_func_
+@@ -1649,8 +1630,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -213,7 +213,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	},
-@@ -1662,8 +1643,8 @@ static const struct airoha_pinctrl_func_
+@@ -1668,8 +1649,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -224,7 +224,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1677,8 +1658,8 @@ static const struct airoha_pinctrl_func_
+@@ -1683,8 +1664,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -235,7 +235,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1692,8 +1673,8 @@ static const struct airoha_pinctrl_func_
+@@ -1698,8 +1679,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -246,7 +246,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1707,8 +1688,8 @@ static const struct airoha_pinctrl_func_
+@@ -1713,8 +1694,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED0_MAPPING,
@@ -257,7 +257,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	},
-@@ -1726,8 +1707,8 @@ static const struct airoha_pinctrl_func_
+@@ -1732,8 +1713,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -268,7 +268,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1741,8 +1722,8 @@ static const struct airoha_pinctrl_func_
+@@ -1747,8 +1728,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -279,7 +279,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1756,8 +1737,8 @@ static const struct airoha_pinctrl_func_
+@@ -1762,8 +1743,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -290,7 +290,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1771,8 +1752,8 @@ static const struct airoha_pinctrl_func_
+@@ -1777,8 +1758,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -301,7 +301,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	},
-@@ -1790,8 +1771,8 @@ static const struct airoha_pinctrl_func_
+@@ -1796,8 +1777,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -312,7 +312,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1805,8 +1786,8 @@ static const struct airoha_pinctrl_func_
+@@ -1811,8 +1792,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -323,7 +323,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1820,8 +1801,8 @@ static const struct airoha_pinctrl_func_
+@@ -1826,8 +1807,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -334,7 +334,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1835,8 +1816,8 @@ static const struct airoha_pinctrl_func_
+@@ -1841,8 +1822,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -345,7 +345,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	},
-@@ -1854,8 +1835,8 @@ static const struct airoha_pinctrl_func_
+@@ -1860,8 +1841,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -356,7 +356,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1869,8 +1850,8 @@ static const struct airoha_pinctrl_func_
+@@ -1875,8 +1856,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -367,7 +367,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1884,8 +1865,8 @@ static const struct airoha_pinctrl_func_
+@@ -1890,8 +1871,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -378,7 +378,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1899,8 +1880,8 @@ static const struct airoha_pinctrl_func_
+@@ -1905,8 +1886,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -389,7 +389,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	},
-@@ -1918,8 +1899,8 @@ static const struct airoha_pinctrl_func_
+@@ -1924,8 +1905,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -400,7 +400,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1933,8 +1914,8 @@ static const struct airoha_pinctrl_func_
+@@ -1939,8 +1920,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -411,7 +411,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1948,8 +1929,8 @@ static const struct airoha_pinctrl_func_
+@@ -1954,8 +1935,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,
@@ -422,7 +422,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		},
  		.regmap_size = 2,
  	}, {
-@@ -1963,8 +1944,8 @@ static const struct airoha_pinctrl_func_
+@@ -1969,8 +1950,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
  			REG_LAN_LED1_MAPPING,

--- a/target/linux/airoha/patches-6.12/060-v6.16-02-net-phy-mediatek-add-Airoha-PHY-ID-to-SoC-driver.patch
+++ b/target/linux/airoha/patches-6.12/060-v6.16-02-net-phy-mediatek-add-Airoha-PHY-ID-to-SoC-driver.patch
@@ -21,8 +21,8 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/phy/mediatek/mtk-ge-soc.c
 +++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
-@@ -1405,6 +1408,53 @@ static int mt7981_phy_probe(struct phy_d
- 	return mt798x_phy_calibration(phydev);
+@@ -1454,6 +1454,53 @@ static int an7581_phy_led_polarity_set(s
+ 			      MTK_PHY_LED_ON_POLARITY, val);
  }
  
 +static int an7581_phy_probe(struct phy_device *phydev)
@@ -75,12 +75,10 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static struct phy_driver mtk_socphy_driver[] = {
  	{
  		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_MT7981),
-@@ -1440,6 +1490,17 @@ static struct phy_driver mtk_socphy_driv
- 		.led_hw_control_set = mt798x_phy_led_hw_control_set,
- 		.led_hw_control_get = mt798x_phy_led_hw_control_get,
+@@ -1491,6 +1538,17 @@ static struct phy_driver mtk_socphy_driv
  	},
-+	{
-+		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_AN7581),
+ 	{
+ 		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_AN7581),
 +		.name		= "Airoha AN7581 PHY",
 +		.probe		= an7581_phy_probe,
 +		.led_blink_set	= mt798x_phy_led_blink_set,
@@ -90,6 +88,8 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 +		.led_hw_control_get = mt798x_phy_led_hw_control_get,
 +		.led_polarity_set = an7581_phy_led_polarity_set,
 +	},
- };
- 
- module_phy_driver(mtk_socphy_driver); 
++	{
++		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_AN7581),
+ 		.name		= "Airoha AN7581 PHY",
+ 		.probe		= an7581_phy_probe,
+ 		.led_blink_set	= mt798x_phy_led_blink_set,

--- a/target/linux/airoha/patches-6.12/063-01-v6.15-net-airoha-Move-min-max-packet-len-configuration-in-.patch
+++ b/target/linux/airoha/patches-6.12/063-01-v6.15-net-airoha-Move-min-max-packet-len-configuration-in-.patch
@@ -34,7 +34,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  	airoha_fe_rmw(eth, REG_CDM1_VLAN_CTRL, CDM1_VLAN_MASK,
  		      FIELD_PREP(CDM1_VLAN_MASK, 0x8100));
-@@ -1521,9 +1516,9 @@ static void airoha_update_hw_stats(struc
+@@ -1520,9 +1515,9 @@ static void airoha_update_hw_stats(struc
  
  static int airoha_dev_open(struct net_device *dev)
  {
@@ -45,7 +45,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  	netif_tx_start_all_queues(dev);
  	err = airoha_set_vip_for_gdm_port(port, true);
-@@ -1537,6 +1532,11 @@ static int airoha_dev_open(struct net_de
+@@ -1536,6 +1531,11 @@ static int airoha_dev_open(struct net_de
  		airoha_fe_clear(qdma->eth, REG_GDM_INGRESS_CFG(port->id),
  				GDM_STAG_EN_MASK);
  

--- a/target/linux/airoha/patches-6.12/063-02-v6.15-net-airoha-Enable-Rx-Scatter-Gather.patch
+++ b/target/linux/airoha/patches-6.12/063-02-v6.15-net-airoha-Enable-Rx-Scatter-Gather.patch
@@ -124,7 +124,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	}
  	airoha_qdma_fill_rx_queue(q);
  
-@@ -763,6 +779,7 @@ static int airoha_qdma_init_rx_queue(str
+@@ -762,6 +778,7 @@ static int airoha_qdma_init_rx_queue(str
  			FIELD_PREP(RX_RING_THR_MASK, thr));
  	airoha_qdma_rmw(qdma, REG_RX_DMA_IDX(qid), RX_RING_DMA_IDX_MASK,
  			FIELD_PREP(RX_RING_DMA_IDX_MASK, q->head));
@@ -132,7 +132,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  	airoha_qdma_fill_rx_queue(q);
  
-@@ -1162,7 +1179,6 @@ static int airoha_qdma_hw_init(struct ai
+@@ -1161,7 +1178,6 @@ static int airoha_qdma_hw_init(struct ai
  	}
  
  	airoha_qdma_wr(qdma, REG_QDMA_GLOBAL_CFG,

--- a/target/linux/airoha/patches-6.12/063-03-v6.15-net-airoha-Introduce-airoha_dev_change_mtu-callback.patch
+++ b/target/linux/airoha/patches-6.12/063-03-v6.15-net-airoha-Introduce-airoha_dev_change_mtu-callback.patch
@@ -16,7 +16,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1706,6 +1706,20 @@ static void airoha_dev_get_stats64(struc
+@@ -1705,6 +1705,20 @@ static void airoha_dev_get_stats64(struc
  	} while (u64_stats_fetch_retry(&port->stats.syncp, start));
  }
  
@@ -37,7 +37,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static u16 airoha_dev_select_queue(struct net_device *dev, struct sk_buff *skb,
  				   struct net_device *sb_dev)
  {
-@@ -2398,6 +2412,7 @@ static const struct net_device_ops airoh
+@@ -2397,6 +2411,7 @@ static const struct net_device_ops airoh
  	.ndo_init		= airoha_dev_init,
  	.ndo_open		= airoha_dev_open,
  	.ndo_stop		= airoha_dev_stop,

--- a/target/linux/airoha/patches-6.12/063-06-v6.15-net-airoha-Enable-TSO-Scatter-Gather-for-LAN-port.patch
+++ b/target/linux/airoha/patches-6.12/063-06-v6.15-net-airoha-Enable-TSO-Scatter-Gather-for-LAN-port.patch
@@ -17,7 +17,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2503,6 +2503,7 @@ static int airoha_alloc_gdm_port(struct
+@@ -2502,6 +2502,7 @@ static int airoha_alloc_gdm_port(struct
  			   NETIF_F_SG | NETIF_F_TSO |
  			   NETIF_F_HW_TC;
  	dev->features |= dev->hw_features;

--- a/target/linux/airoha/patches-6.12/064-v6.15-net-airoha-Fix-dev-dsa_ptr-check-in-airoha_get_dsa_t.patch
+++ b/target/linux/airoha/patches-6.12/064-v6.15-net-airoha-Fix-dev-dsa_ptr-check-in-airoha_get_dsa_t.patch
@@ -25,7 +25,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1742,18 +1742,13 @@ static u32 airoha_get_dsa_tag(struct sk_
+@@ -1741,18 +1741,13 @@ static u32 airoha_get_dsa_tag(struct sk_
  {
  #if IS_ENABLED(CONFIG_NET_DSA)
  	struct ethhdr *ehdr;

--- a/target/linux/airoha/patches-6.12/066-01-v6.15-net-airoha-Fix-qid-report-in-airoha_tc_get_htb_get_l.patch
+++ b/target/linux/airoha/patches-6.12/066-01-v6.15-net-airoha-Fix-qid-report-in-airoha_tc_get_htb_get_l.patch
@@ -66,7 +66,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2356,7 +2356,7 @@ static int airoha_tc_get_htb_get_leaf_qu
+@@ -2355,7 +2355,7 @@ static int airoha_tc_get_htb_get_leaf_qu
  		return -EINVAL;
  	}
  

--- a/target/linux/airoha/patches-6.12/066-02-v6.15-net-airoha-Fix-ETS-priomap-validation.patch
+++ b/target/linux/airoha/patches-6.12/066-02-v6.15-net-airoha-Fix-ETS-priomap-validation.patch
@@ -22,7 +22,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2029,7 +2029,7 @@ static int airoha_qdma_set_tx_ets_sched(
+@@ -2028,7 +2028,7 @@ static int airoha_qdma_set_tx_ets_sched(
  	struct tc_ets_qopt_offload_replace_params *p = &opt->replace_params;
  	enum tx_sched_mode mode = TC_SCH_SP;
  	u16 w[AIROHA_NUM_QOS_QUEUES] = {};
@@ -31,7 +31,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  	if (p->bands > AIROHA_NUM_QOS_QUEUES)
  		return -EINVAL;
-@@ -2047,17 +2047,17 @@ static int airoha_qdma_set_tx_ets_sched(
+@@ -2046,17 +2046,17 @@ static int airoha_qdma_set_tx_ets_sched(
  	 * lowest priorities with respect to SP ones.
  	 * e.g: WRR0, WRR1, .., WRRm, SP0, SP1, .., SPn
  	 */

--- a/target/linux/airoha/patches-6.12/067-v6.15-net-airoha-Validate-egress-gdm-port-in-airoha_ppe_fo.patch
+++ b/target/linux/airoha/patches-6.12/067-v6.15-net-airoha-Validate-egress-gdm-port-in-airoha_ppe_fo.patch
@@ -35,7 +35,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2452,6 +2452,19 @@ static void airoha_metadata_dst_free(str
+@@ -2451,6 +2451,19 @@ static void airoha_metadata_dst_free(str
  	}
  }
  

--- a/target/linux/airoha/patches-6.12/069-v6.16-net-airoha-Add-matchall-filter-offload-support.patch
+++ b/target/linux/airoha/patches-6.12/069-v6.16-net-airoha-Add-matchall-filter-offload-support.patch
@@ -55,7 +55,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  	/* enable 1:N vlan action, init vlan table */
  	airoha_fe_set(eth, REG_MC_VLAN_EN, MC_VLAN_EN_MASK);
  
-@@ -1632,7 +1651,6 @@ static void airhoha_set_gdm2_loopback(st
+@@ -1631,7 +1650,6 @@ static void airhoha_set_gdm2_loopback(st
  
  	if (port->id == 3) {
  		/* FIXME: handle XSI_PCE1_PORT */
@@ -63,7 +63,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  		airoha_fe_rmw(eth, REG_FE_WAN_PORT,
  			      WAN1_EN_MASK | WAN1_MASK | WAN0_MASK,
  			      FIELD_PREP(WAN0_MASK, HSGMII_LAN_PCIE0_SRCPORT));
-@@ -2107,6 +2125,125 @@ static int airoha_tc_setup_qdisc_ets(str
+@@ -2106,6 +2124,125 @@ static int airoha_tc_setup_qdisc_ets(str
  	}
  }
  
@@ -189,7 +189,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  static int airoha_qdma_get_trtcm_param(struct airoha_qdma *qdma, int channel,
  				       u32 addr, enum trtcm_param_type param,
  				       enum trtcm_mode_type mode,
-@@ -2271,10 +2408,142 @@ static int airoha_tc_htb_alloc_leaf_queu
+@@ -2270,10 +2407,142 @@ static int airoha_tc_htb_alloc_leaf_queu
  	return 0;
  }
  

--- a/target/linux/airoha/patches-6.12/070-01-v6.16-net-airoha-Introduce-airoha_irq_bank-struct.patch
+++ b/target/linux/airoha/patches-6.12/070-01-v6.16-net-airoha-Introduce-airoha_irq_bank-struct.patch
@@ -93,7 +93,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  				       RX_DONE_INT_MASK);
  
  	return done;
-@@ -945,7 +949,7 @@ unlock:
+@@ -944,7 +948,7 @@ unlock:
  	}
  
  	if (done < budget && napi_complete(napi))
@@ -102,7 +102,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  				       TX_DONE_INT_MASK(id));
  
  	return done;
-@@ -1176,13 +1180,16 @@ static int airoha_qdma_hw_init(struct ai
+@@ -1175,13 +1179,16 @@ static int airoha_qdma_hw_init(struct ai
  	int i;
  
  	/* clear pending irqs */
@@ -123,7 +123,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  	/* setup irq binding */
  	for (i = 0; i < ARRAY_SIZE(qdma->q_tx); i++) {
-@@ -1227,13 +1234,14 @@ static int airoha_qdma_hw_init(struct ai
+@@ -1226,13 +1233,14 @@ static int airoha_qdma_hw_init(struct ai
  
  static irqreturn_t airoha_irq_handler(int irq, void *dev_instance)
  {
@@ -142,7 +142,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		airoha_qdma_wr(qdma, REG_INT_STATUS(i), intr[i]);
  	}
  
-@@ -1241,7 +1249,7 @@ static irqreturn_t airoha_irq_handler(in
+@@ -1240,7 +1248,7 @@ static irqreturn_t airoha_irq_handler(in
  		return IRQ_NONE;
  
  	if (intr[1] & RX_DONE_INT_MASK) {
@@ -151,7 +151,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  					RX_DONE_INT_MASK);
  
  		for (i = 0; i < ARRAY_SIZE(qdma->q_rx); i++) {
-@@ -1258,7 +1266,7 @@ static irqreturn_t airoha_irq_handler(in
+@@ -1257,7 +1265,7 @@ static irqreturn_t airoha_irq_handler(in
  			if (!(intr[0] & TX_DONE_INT_MASK(i)))
  				continue;
  
@@ -160,7 +160,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  						TX_DONE_INT_MASK(i));
  			napi_schedule(&qdma->q_tx_irq[i].napi);
  		}
-@@ -1267,6 +1275,39 @@ static irqreturn_t airoha_irq_handler(in
+@@ -1266,6 +1274,39 @@ static irqreturn_t airoha_irq_handler(in
  	return IRQ_HANDLED;
  }
  
@@ -200,7 +200,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  static int airoha_qdma_init(struct platform_device *pdev,
  			    struct airoha_eth *eth,
  			    struct airoha_qdma *qdma)
-@@ -1274,9 +1315,7 @@ static int airoha_qdma_init(struct platf
+@@ -1273,9 +1314,7 @@ static int airoha_qdma_init(struct platf
  	int err, id = qdma - &eth->qdma[0];
  	const char *res;
  
@@ -210,7 +210,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	res = devm_kasprintf(eth->dev, GFP_KERNEL, "qdma%d", id);
  	if (!res)
  		return -ENOMEM;
-@@ -1286,12 +1325,7 @@ static int airoha_qdma_init(struct platf
+@@ -1285,12 +1324,7 @@ static int airoha_qdma_init(struct platf
  		return dev_err_probe(eth->dev, PTR_ERR(qdma->regs),
  				     "failed to iomap qdma%d regs\n", id);
  
@@ -224,7 +224,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	if (err)
  		return err;
  
-@@ -2782,7 +2816,7 @@ static int airoha_alloc_gdm_port(struct
+@@ -2781,7 +2815,7 @@ static int airoha_alloc_gdm_port(struct
  	dev->features |= dev->hw_features;
  	dev->vlan_features = dev->hw_features;
  	dev->dev.of_node = np;

--- a/target/linux/airoha/patches-6.12/070-02-v6.16-net-airoha-Enable-multiple-IRQ-lines-support-in-airo.patch
+++ b/target/linux/airoha/patches-6.12/070-02-v6.16-net-airoha-Enable-multiple-IRQ-lines-support-in-airo.patch
@@ -58,7 +58,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  	return done;
  }
-@@ -1179,17 +1189,24 @@ static int airoha_qdma_hw_init(struct ai
+@@ -1178,17 +1188,24 @@ static int airoha_qdma_hw_init(struct ai
  {
  	int i;
  
@@ -91,7 +91,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  
  	/* setup irq binding */
  	for (i = 0; i < ARRAY_SIZE(qdma->q_tx); i++) {
-@@ -1236,6 +1253,7 @@ static irqreturn_t airoha_irq_handler(in
+@@ -1235,6 +1252,7 @@ static irqreturn_t airoha_irq_handler(in
  {
  	struct airoha_irq_bank *irq_bank = dev_instance;
  	struct airoha_qdma *qdma = irq_bank->qdma;
@@ -99,7 +99,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	u32 intr[ARRAY_SIZE(irq_bank->irqmask)];
  	int i;
  
-@@ -1248,17 +1266,24 @@ static irqreturn_t airoha_irq_handler(in
+@@ -1247,17 +1265,24 @@ static irqreturn_t airoha_irq_handler(in
  	if (!test_bit(DEV_STATE_INITIALIZED, &qdma->eth->state))
  		return IRQ_NONE;
  

--- a/target/linux/airoha/patches-6.12/074-01-v6.16-net-airoha-Do-not-store-hfwd-references-in-airoha_qd.patch
+++ b/target/linux/airoha/patches-6.12/074-01-v6.16-net-airoha-Do-not-store-hfwd-references-in-airoha_qd.patch
@@ -20,7 +20,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1078,17 +1078,13 @@ static int airoha_qdma_init_hfwd_queues(
+@@ -1077,17 +1077,13 @@ static int airoha_qdma_init_hfwd_queues(
  	int size;
  
  	size = HW_DSCP_NUM * sizeof(struct airoha_qdma_fwd_desc);

--- a/target/linux/airoha/patches-6.12/074-02-v6.16-net-airoha-Add-the-capability-to-allocate-hwfd-buffe.patch
+++ b/target/linux/airoha/patches-6.12/074-02-v6.16-net-airoha-Add-the-capability-to-allocate-hwfd-buffe.patch
@@ -27,7 +27,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  #include <linux/platform_device.h>
  #include <linux/tcp.h>
  #include <linux/u64_stats_sync.h>
-@@ -1073,9 +1074,11 @@ static void airoha_qdma_cleanup_tx_queue
+@@ -1072,9 +1073,11 @@ static void airoha_qdma_cleanup_tx_queue
  static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
  {
  	struct airoha_eth *eth = qdma->eth;
@@ -40,7 +40,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  
  	size = HW_DSCP_NUM * sizeof(struct airoha_qdma_fwd_desc);
  	if (!dmam_alloc_coherent(eth->dev, size, &dma_addr, GFP_KERNEL))
-@@ -1083,10 +1086,34 @@ static int airoha_qdma_init_hfwd_queues(
+@@ -1082,10 +1085,34 @@ static int airoha_qdma_init_hfwd_queues(
  
  	airoha_qdma_wr(qdma, REG_FWD_DSCP_BASE, dma_addr);
  

--- a/target/linux/airoha/patches-6.12/074-03-v6.16-net-airoha-Add-the-capability-to-allocate-hfwd-descr.patch
+++ b/target/linux/airoha/patches-6.12/074-03-v6.16-net-airoha-Add-the-capability-to-allocate-hfwd-descr.patch
@@ -38,7 +38,7 @@ Signed-off-by: Paolo Abeni <pabeni@redhat.com>
  static void airoha_set_macaddr(struct airoha_gdm_port *port, const u8 *addr)
  {
  	struct airoha_eth *eth = port->qdma->eth;
-@@ -1125,7 +1116,7 @@ static int airoha_qdma_init_hfwd_queues(
+@@ -1124,7 +1115,7 @@ static int airoha_qdma_init_hfwd_queues(
  			LMGR_INIT_START | LMGR_SRAM_MODE_MASK |
  			HW_FWD_DESC_NUM_MASK,
  			FIELD_PREP(HW_FWD_DESC_NUM_MASK, HW_DSCP_NUM) |

--- a/target/linux/airoha/patches-6.12/075-v6.16-net-airoha-Fix-an-error-handling-path-in-airoha_allo.patch
+++ b/target/linux/airoha/patches-6.12/075-v6.16-net-airoha-Fix-an-error-handling-path-in-airoha_allo.patch
@@ -23,7 +23,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2881,7 +2881,15 @@ static int airoha_alloc_gdm_port(struct
+@@ -2880,7 +2880,15 @@ static int airoha_alloc_gdm_port(struct
  	if (err)
  		return err;
  

--- a/target/linux/airoha/patches-6.12/080-01-v6.16-net-airoha-Compute-number-of-descriptors-according-t.patch
+++ b/target/linux/airoha/patches-6.12/080-01-v6.16-net-airoha-Compute-number-of-descriptors-according-t.patch
@@ -19,7 +19,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1066,19 +1066,13 @@ static void airoha_qdma_cleanup_tx_queue
+@@ -1065,19 +1065,13 @@ static void airoha_qdma_cleanup_tx_queue
  
  static int airoha_qdma_init_hfwd_queues(struct airoha_qdma *qdma)
  {
@@ -40,7 +40,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	name = devm_kasprintf(eth->dev, GFP_KERNEL, "qdma%d-buf", id);
  	if (!name)
  		return -ENOMEM;
-@@ -1100,8 +1094,12 @@ static int airoha_qdma_init_hfwd_queues(
+@@ -1099,8 +1093,12 @@ static int airoha_qdma_init_hfwd_queues(
  		rmem = of_reserved_mem_lookup(np);
  		of_node_put(np);
  		dma_addr = rmem->base;
@@ -54,7 +54,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		if (!dmam_alloc_coherent(eth->dev, size, &dma_addr,
  					 GFP_KERNEL))
  			return -ENOMEM;
-@@ -1109,6 +1107,11 @@ static int airoha_qdma_init_hfwd_queues(
+@@ -1108,6 +1106,11 @@ static int airoha_qdma_init_hfwd_queues(
  
  	airoha_qdma_wr(qdma, REG_FWD_BUF_BASE, dma_addr);
  
@@ -66,7 +66,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	airoha_qdma_rmw(qdma, REG_HW_FWD_DSCP_CFG,
  			HW_FWD_DSCP_PAYLOAD_SIZE_MASK,
  			FIELD_PREP(HW_FWD_DSCP_PAYLOAD_SIZE_MASK, 0));
-@@ -1117,7 +1120,7 @@ static int airoha_qdma_init_hfwd_queues(
+@@ -1116,7 +1119,7 @@ static int airoha_qdma_init_hfwd_queues(
  	airoha_qdma_rmw(qdma, REG_LMGR_INIT_CFG,
  			LMGR_INIT_START | LMGR_SRAM_MODE_MASK |
  			HW_FWD_DESC_NUM_MASK,

--- a/target/linux/airoha/patches-6.12/080-02-v6.16-net-airoha-Differentiate-hwfd-buffer-size-for-QDMA0-.patch
+++ b/target/linux/airoha/patches-6.12/080-02-v6.16-net-airoha-Differentiate-hwfd-buffer-size-for-QDMA0-.patch
@@ -21,7 +21,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -1069,14 +1069,15 @@ static int airoha_qdma_init_hfwd_queues(
+@@ -1068,14 +1068,15 @@ static int airoha_qdma_init_hfwd_queues(
  	int size, index, num_desc = HW_DSCP_NUM;
  	struct airoha_eth *eth = qdma->eth;
  	int id = qdma - &eth->qdma[0];
@@ -38,7 +38,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  	index = of_property_match_string(eth->dev->of_node,
  					 "memory-region-names", name);
  	if (index >= 0) {
-@@ -1097,9 +1098,9 @@ static int airoha_qdma_init_hfwd_queues(
+@@ -1096,9 +1097,9 @@ static int airoha_qdma_init_hfwd_queues(
  		/* Compute the number of hw descriptors according to the
  		 * reserved memory size and the payload buffer size
  		 */
@@ -50,7 +50,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
  		if (!dmam_alloc_coherent(eth->dev, size, &dma_addr,
  					 GFP_KERNEL))
  			return -ENOMEM;
-@@ -1112,9 +1113,10 @@ static int airoha_qdma_init_hfwd_queues(
+@@ -1111,9 +1112,10 @@ static int airoha_qdma_init_hfwd_queues(
  		return -ENOMEM;
  
  	airoha_qdma_wr(qdma, REG_FWD_DSCP_BASE, dma_addr);

--- a/target/linux/airoha/patches-6.12/083-01-v6.13-resource-Add-resource-set-range-and-size-helpers.patch
+++ b/target/linux/airoha/patches-6.12/083-01-v6.13-resource-Add-resource-set-range-and-size-helpers.patch
@@ -32,7 +32,7 @@ Reviewed-by: Jonathan Cameron <Jonathan.Cameron@huawei.com>
 
 --- a/include/linux/ioport.h
 +++ b/include/linux/ioport.h
-@@ -216,6 +216,38 @@ struct resource *lookup_resource(struct
+@@ -249,6 +249,38 @@ struct resource *lookup_resource(struct
  int adjust_resource(struct resource *res, resource_size_t start,
  		    resource_size_t size);
  resource_size_t resource_alignment(struct resource *res);

--- a/target/linux/airoha/patches-6.12/083-02-v6.16-of-reserved_mem-Add-functions-to-parse-memory-region.patch
+++ b/target/linux/airoha/patches-6.12/083-02-v6.16-of-reserved_mem-Add-functions-to-parse-memory-region.patch
@@ -29,7 +29,7 @@ Signed-off-by: Rob Herring (Arm) <robh@kernel.org>
  #include <linux/libfdt.h>
  #include <linux/of.h>
  #include <linux/of_fdt.h>
-@@ -514,3 +515,82 @@ struct reserved_mem *of_reserved_mem_loo
+@@ -694,3 +695,82 @@ struct reserved_mem *of_reserved_mem_loo
  	return NULL;
  }
  EXPORT_SYMBOL_GPL(of_reserved_mem_lookup);
@@ -122,7 +122,7 @@ Signed-off-by: Rob Herring (Arm) <robh@kernel.org>
  
  struct reserved_mem {
  	const char			*name;
-@@ -40,6 +41,12 @@ int of_reserved_mem_device_init_by_name(
+@@ -39,6 +40,12 @@ int of_reserved_mem_device_init_by_name(
  void of_reserved_mem_device_release(struct device *dev);
  
  struct reserved_mem *of_reserved_mem_lookup(struct device_node *np);
@@ -135,7 +135,7 @@ Signed-off-by: Rob Herring (Arm) <robh@kernel.org>
  #else
  
  #define RESERVEDMEM_OF_DECLARE(name, compat, init)			\
-@@ -64,6 +71,25 @@ static inline struct reserved_mem *of_re
+@@ -63,6 +70,25 @@ static inline struct reserved_mem *of_re
  {
  	return NULL;
  }

--- a/target/linux/airoha/patches-6.12/086-02-v6.18-net-airoha-Add-airoha_ppe_dev-struct-definition.patch
+++ b/target/linux/airoha/patches-6.12/086-02-v6.18-net-airoha-Add-airoha_ppe_dev-struct-definition.patch
@@ -24,7 +24,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2602,13 +2602,15 @@ static int airoha_dev_setup_tc_block_cb(
+@@ -2601,13 +2601,15 @@ static int airoha_dev_setup_tc_block_cb(
  					void *type_data, void *cb_priv)
  {
  	struct net_device *dev = cb_priv;

--- a/target/linux/airoha/patches-6.12/087-v6.17-pinctrl-airoha-Fix-return-value-in-pinconf-callbacks.patch
+++ b/target/linux/airoha/patches-6.12/087-v6.17-pinctrl-airoha-Fix-return-value-in-pinconf-callbacks.patch
@@ -17,7 +17,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
 
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-@@ -2696,7 +2696,7 @@ static int airoha_pinconf_get(struct pin
+@@ -2697,7 +2697,7 @@ static int airoha_pinconf_get(struct pin
  		arg = 1;
  		break;
  	default:
@@ -26,7 +26,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  	}
  
  	*config = pinconf_to_config_packed(param, arg);
-@@ -2790,7 +2790,7 @@ static int airoha_pinconf_set(struct pin
+@@ -2791,7 +2791,7 @@ static int airoha_pinconf_set(struct pin
  			break;
  		}
  		default:
@@ -35,7 +35,7 @@ Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
  		}
  	}
  
-@@ -2807,10 +2807,10 @@ static int airoha_pinconf_group_get(stru
+@@ -2808,10 +2808,10 @@ static int airoha_pinconf_group_get(stru
  		if (airoha_pinconf_get(pctrl_dev,
  				       airoha_pinctrl_groups[group].pins[i],
  				       config))

--- a/target/linux/airoha/patches-6.12/089-v6.14-net-airoha-Fix-channel-configuration-for-ETS-Qdisc.patch
+++ b/target/linux/airoha/patches-6.12/089-v6.14-net-airoha-Fix-channel-configuration-for-ETS-Qdisc.patch
@@ -18,7 +18,7 @@ Signed-off-by: Jakub Kicinski <kuba@kernel.org>
 
 --- a/drivers/net/ethernet/airoha/airoha_eth.c
 +++ b/drivers/net/ethernet/airoha/airoha_eth.c
-@@ -2184,11 +2184,14 @@ static int airoha_qdma_get_tx_ets_stats(
+@@ -2183,11 +2183,14 @@ static int airoha_qdma_get_tx_ets_stats(
  static int airoha_tc_setup_qdisc_ets(struct airoha_gdm_port *port,
  				     struct tc_ets_qopt_offload *opt)
  {

--- a/target/linux/airoha/patches-6.12/091-01-v6.18-pinctrl-airoha-fix-wrong-PHY-LED-mux-value-for-LED1-.patch
+++ b/target/linux/airoha/patches-6.12/091-01-v6.18-pinctrl-airoha-fix-wrong-PHY-LED-mux-value-for-LED1-.patch
@@ -22,7 +22,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-@@ -1746,8 +1746,8 @@ static const struct airoha_pinctrl_func_
+@@ -1752,8 +1752,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[0] = {
  			AIROHA_FUNC_MUX,
  			REG_GPIO_2ND_I2C_MODE,
@@ -33,7 +33,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		},
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
-@@ -1810,8 +1810,8 @@ static const struct airoha_pinctrl_func_
+@@ -1816,8 +1816,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[0] = {
  			AIROHA_FUNC_MUX,
  			REG_GPIO_2ND_I2C_MODE,
@@ -44,7 +44,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		},
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
-@@ -1874,8 +1874,8 @@ static const struct airoha_pinctrl_func_
+@@ -1880,8 +1880,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[0] = {
  			AIROHA_FUNC_MUX,
  			REG_GPIO_2ND_I2C_MODE,
@@ -55,7 +55,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  		},
  		.regmap[1] = {
  			AIROHA_FUNC_MUX,
-@@ -1938,8 +1938,8 @@ static const struct airoha_pinctrl_func_
+@@ -1944,8 +1944,8 @@ static const struct airoha_pinctrl_func_
  		.regmap[0] = {
  			AIROHA_FUNC_MUX,
  			REG_GPIO_2ND_I2C_MODE,

--- a/target/linux/airoha/patches-6.12/091-02-v6.18-pinctrl-airoha-fix-wrong-MDIO-function-bitmaks.patch
+++ b/target/linux/airoha/patches-6.12/091-02-v6.18-pinctrl-airoha-fix-wrong-MDIO-function-bitmaks.patch
@@ -23,7 +23,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/drivers/pinctrl/mediatek/pinctrl-airoha.c
 +++ b/drivers/pinctrl/mediatek/pinctrl-airoha.c
-@@ -102,6 +102,9 @@
+@@ -108,6 +108,9 @@
  #define JTAG_UDI_EN_MASK			BIT(4)
  #define JTAG_DFD_EN_MASK			BIT(3)
  
@@ -33,7 +33,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  /* LED MAP */
  #define REG_LAN_LED0_MAPPING			0x027c
  #define REG_LAN_LED1_MAPPING			0x0280
-@@ -713,16 +716,16 @@ static const struct airoha_pinctrl_func_
+@@ -719,16 +722,16 @@ static const struct airoha_pinctrl_func_
  		.name = "mdio",
  		.regmap[0] = {
  			AIROHA_FUNC_MUX,

--- a/target/linux/airoha/patches-6.12/105-uart-add-en7523-support.patch
+++ b/target/linux/airoha/patches-6.12/105-uart-add-en7523-support.patch
@@ -97,7 +97,7 @@
 +EXPORT_SYMBOL_GPL(en7523_set_uart_baud_rate);
 --- a/drivers/tty/serial/8250/8250_of.c
 +++ b/drivers/tty/serial/8250/8250_of.c
-@@ -338,6 +338,7 @@ static const struct of_device_id of_plat
+@@ -341,6 +341,7 @@ static const struct of_device_id of_plat
  	{ .compatible = "ti,da830-uart", .data = (void *)PORT_DA830, },
  	{ .compatible = "nuvoton,wpcm450-uart", .data = (void *)PORT_NPCM, },
  	{ .compatible = "nuvoton,npcm750-uart", .data = (void *)PORT_NPCM, },
@@ -107,7 +107,7 @@
  MODULE_DEVICE_TABLE(of, of_platform_serial_table);
 --- a/drivers/tty/serial/8250/8250_port.c
 +++ b/drivers/tty/serial/8250/8250_port.c
-@@ -330,6 +330,14 @@ static const struct serial8250_config ua
+@@ -319,6 +319,14 @@ static const struct serial8250_config ua
  		.rxtrig_bytes	= {1, 8, 16, 30},
  		.flags		= UART_CAP_FIFO | UART_CAP_AFE,
  	},
@@ -122,7 +122,7 @@
  };
  
  /* Uart divisor latch read */
-@@ -2888,6 +2896,12 @@ serial8250_do_set_termios(struct uart_po
+@@ -2835,6 +2843,12 @@ serial8250_do_set_termios(struct uart_po
  
  	serial8250_set_divisor(port, baud, quot, frac);
  
@@ -137,7 +137,7 @@
  	 * is written without DLAB set, this mode will be disabled.
 --- a/drivers/tty/serial/8250/Makefile
 +++ b/drivers/tty/serial/8250/Makefile
-@@ -20,6 +20,7 @@
+@@ -20,6 +20,7 @@ obj-$(CONFIG_SERIAL_8250_CONSOLE)	+= 825
  
  obj-$(CONFIG_SERIAL_8250_ACCENT)	+= 8250_accent.o
  obj-$(CONFIG_SERIAL_8250_ACORN)		+= 8250_acorn.o
@@ -147,7 +147,7 @@
  obj-$(CONFIG_SERIAL_8250_BCM7271)	+= 8250_bcm7271.o
 --- a/include/uapi/linux/serial_reg.h
 +++ b/include/uapi/linux/serial_reg.h
-@@ -382,5 +382,17 @@
+@@ -383,5 +383,17 @@
  #define UART_ALTR_EN_TXFIFO_LW	0x01	/* Enable the TX FIFO Low Watermark */
  #define UART_ALTR_TX_LOW	0x41	/* Tx FIFO Low Watermark */
  
@@ -167,7 +167,7 @@
  
 --- a/include/uapi/linux/serial_core.h
 +++ b/include/uapi/linux/serial_core.h
-@@ -45,6 +45,7 @@
+@@ -31,6 +31,7 @@
  #define PORT_ALTR_16550_F128 28 /* Altera 16550 UART with 128 FIFOs */
  #define PORT_RT2880	29	/* Ralink RT2880 internal UART */
  #define PORT_16550A_FSL64 30	/* Freescale 16550 UART with 64 FIFOs */
@@ -179,7 +179,7 @@
 +++ b/include/linux/serial_8250.h
 @@ -195,6 +195,7 @@ void serial8250_do_set_mctrl(struct uart
  void serial8250_do_set_divisor(struct uart_port *port, unsigned int baud,
- 			       unsigned int quot, unsigned int quot_frac);
+ 			       unsigned int quot);
  int fsl8250_handle_irq(struct uart_port *port);
 +int en7523_set_uart_baud_rate(struct uart_port *port, unsigned int baud);
  int serial8250_handle_irq(struct uart_port *port, unsigned int iir);

--- a/target/linux/airoha/patches-6.12/108-pwm-airoha-Add-support-for-EN7581-SoC.patch
+++ b/target/linux/airoha/patches-6.12/108-pwm-airoha-Add-support-for-EN7581-SoC.patch
@@ -140,8 +140,6 @@ Changes in v2:
  3 files changed, 548 insertions(+)
  create mode 100644 drivers/pwm/pwm-airoha.c
 
-diff --git a/drivers/pwm/Kconfig b/drivers/pwm/Kconfig
-index c866ed388da9..113ca01f319f 100644
 --- a/drivers/pwm/Kconfig
 +++ b/drivers/pwm/Kconfig
 @@ -54,6 +54,17 @@ config PWM_ADP5585
@@ -162,8 +160,6 @@ index c866ed388da9..113ca01f319f 100644
  config PWM_APPLE
  	tristate "Apple SoC PWM support"
  	depends on ARCH_APPLE || COMPILE_TEST
-diff --git a/drivers/pwm/Makefile b/drivers/pwm/Makefile
-index 5c782af8f49b..cd3e6de2e44a 100644
 --- a/drivers/pwm/Makefile
 +++ b/drivers/pwm/Makefile
 @@ -2,6 +2,7 @@
@@ -174,9 +170,6 @@ index 5c782af8f49b..cd3e6de2e44a 100644
  obj-$(CONFIG_PWM_APPLE)		+= pwm-apple.o
  obj-$(CONFIG_PWM_ATMEL)		+= pwm-atmel.o
  obj-$(CONFIG_PWM_ATMEL_HLCDC_PWM)	+= pwm-atmel-hlcdc.o
-diff --git a/drivers/pwm/pwm-airoha.c b/drivers/pwm/pwm-airoha.c
-new file mode 100644
-index 000000000000..eaf946a53c81
 --- /dev/null
 +++ b/drivers/pwm/pwm-airoha.c
 @@ -0,0 +1,536 @@

--- a/target/linux/airoha/patches-6.12/201-crypto-Add-Mediatek-EIP-93-crypto-engine-support.patch
+++ b/target/linux/airoha/patches-6.12/201-crypto-Add-Mediatek-EIP-93-crypto-engine-support.patch
@@ -59,7 +59,7 @@ Changes v2:
 
 --- a/drivers/crypto/Kconfig
 +++ b/drivers/crypto/Kconfig
-@@ -796,5 +796,6 @@ config CRYPTO_DEV_SA2UL
+@@ -851,5 +851,6 @@ config CRYPTO_DEV_SA2UL
  
  source "drivers/crypto/aspeed/Kconfig"
  source "drivers/crypto/starfive/Kconfig"
@@ -68,7 +68,7 @@ Changes v2:
  endif # CRYPTO_HW
 --- a/drivers/crypto/Makefile
 +++ b/drivers/crypto/Makefile
-@@ -51,3 +51,4 @@ obj-y += hisilicon/
+@@ -52,3 +52,4 @@ obj-y += hisilicon/
  obj-$(CONFIG_CRYPTO_DEV_AMLOGIC_GXL) += amlogic/
  obj-y += intel/
  obj-y += starfive/

--- a/target/linux/airoha/patches-6.12/300-spi-Add-support-for-the-Airoha-EN7523-SoC-SPI-contro.patch
+++ b/target/linux/airoha/patches-6.12/300-spi-Add-support-for-the-Airoha-EN7523-SoC-SPI-contro.patch
@@ -1,6 +1,6 @@
 --- a/drivers/spi/Kconfig
 +++ b/drivers/spi/Kconfig
-@@ -363,6 +363,12 @@ config SPI_DLN2
+@@ -370,6 +370,12 @@ config SPI_DLN2
  	 This driver can also be built as a module.  If so, the module
  	 will be called spi-dln2.
  
@@ -15,7 +15,7 @@
  	depends on ARCH_EP93XX || COMPILE_TEST
 --- a/drivers/spi/Makefile
 +++ b/drivers/spi/Makefile
-@@ -51,6 +51,7 @@ obj-$(CONFIG_SPI_DW_BT1)		+= spi-dw-bt1.
+@@ -52,6 +52,7 @@ obj-$(CONFIG_SPI_DW_BT1)		+= spi-dw-bt1.
  obj-$(CONFIG_SPI_DW_MMIO)		+= spi-dw-mmio.o
  obj-$(CONFIG_SPI_DW_PCI)		+= spi-dw-pci.o
  obj-$(CONFIG_SPI_EP93XX)		+= spi-ep93xx.o

--- a/target/linux/airoha/patches-6.12/901-snand-mtk-bmt-support.patch
+++ b/target/linux/airoha/patches-6.12/901-snand-mtk-bmt-support.patch
@@ -8,7 +8,7 @@
  
  static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1352,6 +1353,7 @@ static int spinand_probe(struct spi_mem
+@@ -1530,6 +1531,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -16,7 +16,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1359,6 +1361,7 @@ static int spinand_probe(struct spi_mem
+@@ -1537,6 +1539,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -24,7 +24,7 @@
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1377,6 +1380,7 @@ static int spinand_remove(struct spi_mem
+@@ -1555,6 +1558,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/econet/patches-6.12/002-v6.16-irqchip-Add-EcoNet-EN751221-INTC.patch
+++ b/target/linux/econet/patches-6.12/002-v6.16-irqchip-Add-EcoNet-EN751221-INTC.patch
@@ -17,7 +17,7 @@ Link: https://lore.kernel.org/all/20250330170306.2584136-4-cjd@cjdns.fr
 
 --- a/drivers/irqchip/Kconfig
 +++ b/drivers/irqchip/Kconfig
-@@ -147,6 +147,11 @@ config DW_APB_ICTL
+@@ -148,6 +148,11 @@ config DW_APB_ICTL
  	select GENERIC_IRQ_CHIP
  	select IRQ_DOMAIN_HIERARCHY
  

--- a/target/linux/econet/patches-6.12/008-v6.16-dt-bindings-vendor-prefixes-Add-SmartFiber.patch
+++ b/target/linux/econet/patches-6.12/008-v6.16-dt-bindings-vendor-prefixes-Add-SmartFiber.patch
@@ -18,7 +18,7 @@ Signed-off-by: Thomas Bogendoerfer <tsbogend@alpha.franken.de>
 
 --- a/Documentation/devicetree/bindings/vendor-prefixes.yaml
 +++ b/Documentation/devicetree/bindings/vendor-prefixes.yaml
-@@ -1368,6 +1368,8 @@ patternProperties:
+@@ -1370,6 +1370,8 @@ patternProperties:
      description: SKOV A/S
    "^skyworks,.*":
      description: Skyworks Solutions, Inc.

--- a/target/linux/econet/patches-6.12/902-snand-mtk-bmt-support.patch
+++ b/target/linux/econet/patches-6.12/902-snand-mtk-bmt-support.patch
@@ -8,7 +8,7 @@
  
  static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1525,6 +1526,7 @@ static int spinand_probe(struct spi_mem
+@@ -1530,6 +1531,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -16,7 +16,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1532,6 +1534,7 @@ static int spinand_probe(struct spi_mem
+@@ -1537,6 +1539,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -24,7 +24,7 @@
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1550,6 +1553,7 @@ static int spinand_remove(struct spi_mem
+@@ -1555,6 +1558,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  


### PR DESCRIPTION
Refresh patches 6.12 for airoha and econet

Fixes: 122135b964 ("airoha: an7581: add support for kernel 6.12")
Fixes: 73d0f92460 ("kernel: Add new platform EcoNet MIPS")

