### PR TITLE
treewide: remove of_gpio.h

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -25,8 +25,8 @@
 #include <linux/input.h>
 #include <linux/interrupt.h>
 #include <linux/platform_device.h>
-#include <linux/of_gpio.h>
 #include <linux/of_irq.h>
+#include <linux/gpio.h>
 #include <linux/gpio_keys.h>
 #include <linux/gpio/consumer.h>
 

--- a/package/kernel/ubnt-ledbar/src/leds-ubnt-ledbar.c
+++ b/package/kernel/ubnt-ledbar/src/leds-ubnt-ledbar.c
@@ -7,7 +7,6 @@
 #include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/of.h>
-#include <linux/of_gpio.h>
 #include <linux/gpio/consumer.h>
 
 /**

--- a/target/linux/ath79/files/drivers/gpio/gpio-latch-mikrotik.c
+++ b/target/linux/ath79/files/drivers/gpio/gpio-latch-mikrotik.c
@@ -13,7 +13,6 @@
 #include <linux/gpio/driver.h>
 #include <linux/platform_device.h>
 #include <linux/of_platform.h>
-#include <linux/of_gpio.h>
 
 #define GPIO_LATCH_DRIVER_NAME  "gpio-latch-mikrotik"
 #define GPIO_LATCH_LINES 9

--- a/target/linux/ath79/files/drivers/gpio/gpio-rb91x-key.c
+++ b/target/linux/ath79/files/drivers/gpio/gpio-rb91x-key.c
@@ -20,7 +20,6 @@
 #include <linux/gpio/driver.h>
 #include <linux/platform_device.h>
 #include <linux/of_platform.h>
-#include <linux/of_gpio.h>
 #include <linux/delay.h>
 
 #define GPIO_RB91X_KEY_DRIVER_NAME  "gpio-rb91x-key"

--- a/target/linux/ath79/patches-6.12/700-phy-add-ath79-usb-phys.patch
+++ b/target/linux/ath79/patches-6.12/700-phy-add-ath79-usb-phys.patch
@@ -51,7 +51,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
  obj-$(CONFIG_PHY_LPC18XX_USB_OTG)	+= phy-lpc18xx-usb-otg.o
 --- /dev/null
 +++ b/drivers/phy/phy-ar7100-usb.c
-@@ -0,0 +1,117 @@
+@@ -0,0 +1,115 @@
 +/*
 + * Copyright (C) 2018 John Crispin <john@phrozen.org>
 + *
@@ -66,7 +66,6 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +#include <linux/phy/phy.h>
 +#include <linux/delay.h>
 +#include <linux/reset.h>
-+#include <linux/of_gpio.h>
 +
 +#include <asm/mach-ath79/ath79.h>
 +#include <asm/mach-ath79/ar71xx_regs.h>
@@ -77,7 +76,6 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +	struct reset_control	*rst_ohci_dll;
 +	void __iomem		*io_base;
 +	struct phy		*phy;
-+	int			gpio;
 +};
 +
 +static int ar7100_usb_phy_power_off(struct phy *phy)
@@ -171,7 +169,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +MODULE_LICENSE("GPL");
 --- /dev/null
 +++ b/drivers/phy/phy-ar7200-usb.c
-@@ -0,0 +1,111 @@
+@@ -0,0 +1,109 @@
 +/*
 + * Copyright (C) 2015 Alban Bedel <albeu@free.fr>
 + *
@@ -185,14 +183,12 @@ Signed-off-by: John Crispin <john@phrozen.org>
 +#include <linux/platform_device.h>
 +#include <linux/phy/phy.h>
 +#include <linux/reset.h>
-+#include <linux/of_gpio.h>
 +
 +struct ar7200_usb_phy {
 +	struct reset_control	*rst_phy;
 +	struct reset_control	*rst_phy_analog;
 +	struct reset_control	*suspend_override;
 +	struct phy		*phy;
-+	int			gpio;
 +};
 +
 +static int ar7200_usb_phy_power_on(struct phy *phy)

--- a/target/linux/bmips/files/drivers/pci/controller/pci-bcm6348.c
+++ b/target/linux/bmips/files/drivers/pci/controller/pci-bcm6348.c
@@ -15,7 +15,6 @@
 #include <linux/mm.h>
 #include <linux/module.h>
 #include <linux/of_address.h>
-#include <linux/of_gpio.h>
 #include <linux/of_irq.h>
 #include <linux/of_pci.h>
 #include <linux/of_platform.h>

--- a/target/linux/bmips/files/drivers/pci/controller/pcie-bcm6318.c
+++ b/target/linux/bmips/files/drivers/pci/controller/pcie-bcm6318.c
@@ -13,7 +13,6 @@
 #include <linux/kernel.h>
 #include <linux/mm.h>
 #include <linux/module.h>
-#include <linux/of_gpio.h>
 #include <linux/of_irq.h>
 #include <linux/of_pci.h>
 #include <linux/of_platform.h>

--- a/target/linux/bmips/files/drivers/pci/controller/pcie-bcm6328.c
+++ b/target/linux/bmips/files/drivers/pci/controller/pcie-bcm6328.c
@@ -14,7 +14,6 @@
 #include <linux/mfd/syscon.h>
 #include <linux/mm.h>
 #include <linux/module.h>
-#include <linux/of_gpio.h>
 #include <linux/of_irq.h>
 #include <linux/of_pci.h>
 #include <linux/of_platform.h>

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -32,7 +32,6 @@
 #include <linux/bug.h>
 #include <linux/netfilter.h>
 #include <net/netfilter/nf_flow_table.h>
-#include <linux/of_gpio.h>
 #include <linux/gpio.h>
 #include <linux/gpio/consumer.h>
 

--- a/target/linux/siflower/files-6.6/drivers/pci/controller/dwc/pcie-sf21.c
+++ b/target/linux/siflower/files-6.6/drivers/pci/controller/dwc/pcie-sf21.c
@@ -13,7 +13,6 @@
 #include <linux/kernel.h>
 #include <linux/mfd/syscon.h>
 #include <linux/module.h>
-#include <linux/of_gpio.h>
 #include <linux/of_device.h>
 #include <linux/of_address.h>
 #include <linux/pci.h>


### PR DESCRIPTION
of_gpio.h is deprecated in upstream Linux and may be removed soon. Get ahead of things and remove it. Most of these drivers already use the gpiod API.