### PR TITLE
scripts,ipkg-build: Fix error message for invalid package name

### DIFF
--- a/scripts/ipkg-build
+++ b/scripts/ipkg-build
@@ -45,7 +45,7 @@ pkg_appears_sane() {
 	arch="$(required_field Architecture)"
 
 	if echo "$pkg" | grep '[^a-zA-Z0-9_.+-]'; then
-		echo "*** Error: Package name $name contains illegal characters, (other than [a-z0-9.+-])" >&2
+		echo "*** Error: Package name '$pkg' contains illegal characters, (other than [a-z0-9.+-])" >&2
 		PKG_ERROR=1;
 	fi
 


### PR DESCRIPTION
Use the correct variable ($pkg instead of $name) in the error message.