### PR TITLE
[24.10] qualcommax: ipq807x: Add ability to perform upgrade on current partition and remove OEM UBI volume for Linksys MX devices

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -20,6 +20,7 @@ CONF_IMAGE=
 CONF_BACKUP_LIST=0
 CONF_BACKUP=
 CONF_RESTORE=
+USE_CURR_PART=0
 NEED_IMAGE=
 HELP=0
 TEST=0
@@ -50,6 +51,7 @@ while [ -n "$1" ]; do
 		-r|--restore-backup) CONF_RESTORE="$2" NEED_IMAGE=1; shift;;
 		-l|--list-backup) CONF_BACKUP_LIST=1;;
 		-f) CONF_IMAGE="$2"; shift;;
+		-s) USE_CURR_PART=1;;
 		-F|--force) export FORCE=1;;
 		-T|--test) TEST=1;;
 		-h|--help) HELP=1; break;;
@@ -79,6 +81,7 @@ upgrade-option:
 	-p           do not attempt to restore the partition table after flash.
 	-k           include in backup a list of current installed packages at
 	             $INSTALLED_PACKAGES
+	-s           stay on current partition (for dual firmware devices)
 	-T | --test
 	             Verify image and config .tar.gz but do not actually flash.
 	-F | --force
@@ -416,6 +419,7 @@ else
 	json_add_string command "$COMMAND"
 	json_add_object options
 	json_add_int save_partitions "$SAVE_PARTITIONS"
+	[ $USE_CURR_PART -eq 1 ] && json_add_boolean use_curr_part 1
 	json_close_object
 
 	ubus call system sysupgrade "$(json_dump)"

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -109,6 +109,8 @@ tplink_do_upgrade() {
 }
 
 linksys_mx_do_upgrade() {
+	local setenv_script="/tmp/fw_env_upgrade"
+
 	CI_UBIPART="rootfs"
 	boot_part="$(fw_printenv -n boot_part)"
 	if [ -n "$UPGRADE_OPT_USE_CURR_PART" ]; then
@@ -118,15 +120,30 @@ linksys_mx_do_upgrade() {
 		fi
 	else
 		if [ "$boot_part" -eq "1" ]; then
-			fw_setenv boot_part 2
+			echo "boot_part 2" >> $setenv_script
 			CI_KERNPART="alt_kernel"
 			CI_UBIPART="alt_rootfs"
 		else
-			fw_setenv boot_part 1
+			echo "boot_part 1" >> $setenv_script
 		fi
 	fi
-	fw_setenv boot_part_ready 3
-	fw_setenv auto_recovery yes
+
+	boot_part_ready="$(fw_printenv -n boot_part_ready)"
+	if [ "$boot_part_ready" -ne "3" ]; then
+		echo "boot_part_ready 3" >> $setenv_script
+	fi
+
+	auto_recovery="$(fw_printenv -n auto_recovery)"
+	if [ "$auto_recovery" != "yes" ]; then
+		echo "auto_recovery yes" >> $setenv_script
+	fi
+
+	if [ -f "$setenv_script" ]; then
+		fw_setenv -s $setenv_script || {
+			echo "failed to update U-Boot environment"
+			return 1
+		}
+	fi
 	nand_do_upgrade "$1"
 }
 

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -108,6 +108,28 @@ tplink_do_upgrade() {
 	nand_do_upgrade "$1"
 }
 
+linksys_mx_do_upgrade() {
+	CI_UBIPART="rootfs"
+	boot_part="$(fw_printenv -n boot_part)"
+	if [ -n "$UPGRADE_OPT_USE_CURR_PART" ]; then
+		if [ "$boot_part" -eq "2" ]; then
+			CI_KERNPART="alt_kernel"
+			CI_UBIPART="alt_rootfs"
+		fi
+	else
+		if [ "$boot_part" -eq "1" ]; then
+			fw_setenv boot_part 2
+			CI_KERNPART="alt_kernel"
+			CI_UBIPART="alt_rootfs"
+		else
+			fw_setenv boot_part 1
+		fi
+	fi
+	fw_setenv boot_part_ready 3
+	fw_setenv auto_recovery yes
+	nand_do_upgrade "$1"
+}
+
 platform_check_image() {
 	return 0;
 }
@@ -176,18 +198,7 @@ platform_do_upgrade() {
 	linksys,mx4300|\
 	linksys,mx5300|\
 	linksys,mx8500)
-		boot_part="$(fw_printenv -n boot_part)"
-		if [ "$boot_part" -eq "1" ]; then
-			fw_setenv boot_part 2
-			CI_KERNPART="alt_kernel"
-			CI_UBIPART="alt_rootfs"
-		else
-			fw_setenv boot_part 1
-			CI_UBIPART="rootfs"
-		fi
-		fw_setenv boot_part_ready 3
-		fw_setenv auto_recovery yes
-		nand_do_upgrade "$1"
+		linksys_mx_do_upgrade "$1"
 		;;
 	prpl,haze|\
 	qnap,301w)

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -212,9 +212,13 @@ platform_do_upgrade() {
 		;;
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
-	linksys,mx4300|\
+	linksys,mx4300)
+		remove_oem_ubi_volume squashfs
+		linksys_mx_do_upgrade "$1"
+		;;
 	linksys,mx5300|\
 	linksys,mx8500)
+		remove_oem_ubi_volume ubifs
 		linksys_mx_do_upgrade "$1"
 		;;
 	prpl,haze|\

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -108,7 +108,7 @@ tplink_do_upgrade() {
 	nand_do_upgrade "$1"
 }
 
-linksys_mx_do_upgrade() {
+linksys_mx_pre_upgrade() {
 	local setenv_script="/tmp/fw_env_upgrade"
 
 	CI_UBIPART="rootfs"
@@ -144,7 +144,6 @@ linksys_mx_do_upgrade() {
 			return 1
 		}
 	fi
-	nand_do_upgrade "$1"
 }
 
 platform_check_image() {
@@ -213,13 +212,15 @@ platform_do_upgrade() {
 	linksys,mx4200v1|\
 	linksys,mx4200v2|\
 	linksys,mx4300)
+		linksys_mx_pre_upgrade "$1"
 		remove_oem_ubi_volume squashfs
-		linksys_mx_do_upgrade "$1"
+		nand_do_upgrade "$1"
 		;;
 	linksys,mx5300|\
 	linksys,mx8500)
+		linksys_mx_pre_upgrade "$1"
 		remove_oem_ubi_volume ubifs
-		linksys_mx_do_upgrade "$1"
+		nand_do_upgrade "$1"
 		;;
 	prpl,haze|\
 	qnap,301w)


### PR DESCRIPTION
Dual firmware devices like Linksys MX4200, MX4300, MX5300 and MX8500 use separate rootfs partition.
This option helps to keep all configuration during upgrade.

1. Add new sysupgrade option to be able to perform upgrade on current partition for dual firmware devices:
  `-s           stay on current partition (for dual firmware devices)`

2. Update u-boot env variables only when changes are made.

3. Use `remove_oem_ubi_volume` function to remove OEM UBI volume before upgrade.
This allows to upgrade even if we have OEM firmware on the second partition.

Fixes:
- https://github.com/openwrt/openwrt/issues/17681
- https://github.com/openwrt/openwrt/issues/17871