### PR TITLE
airoha: add missing Kconfig entry on 6.12

### DIFF
--- a/target/linux/airoha/patches-6.12/105-uart-add-en7523-support.patch
+++ b/target/linux/airoha/patches-6.12/105-uart-add-en7523-support.patch
@@ -135,6 +135,25 @@
  	/*
  	 * LCR DLAB must be set to enable 64-byte FIFO mode. If the FCR
  	 * is written without DLAB set, this mode will be disabled.
+--- a/drivers/tty/serial/8250/Kconfig
++++ b/drivers/tty/serial/8250/Kconfig
+@@ -355,6 +355,16 @@ config SERIAL_8250_ACORN
+ 	  system, say Y to this option.  The driver can handle 1, 2, or 3 port
+ 	  cards.  If unsure, say N.
+ 
++config SERIAL_8250_AIROHA
++	tristate "Airoha UART support"
++	depends on (ARCH_AIROHA || COMPILE_TEST) && OF && SERIAL_8250
++	help
++	  Selecting this option enables an Airoha SoC specific baud rate
++	  calculation routine on an otherwise 16550 compatible UART hardware.
++
++	  If you have an Airoha based board and want to use the serial port,
++	  say Y to this option. If unsure, say N.
++
+ config SERIAL_8250_BCM2835AUX
+ 	tristate "BCM2835 auxiliar mini UART support"
+ 	depends on ARCH_BCM2835 || COMPILE_TEST
 --- a/drivers/tty/serial/8250/Makefile
 +++ b/drivers/tty/serial/8250/Makefile
 @@ -20,6 +20,7 @@ obj-$(CONFIG_SERIAL_8250_CONSOLE)	+= 825


### PR DESCRIPTION
This commit adds the missing Kconfig entry. It was accidentally omitted previously.

Fixes: 440b85f5b102 ("airoha: an7581: enable uart baudrate control")
Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
