### PR TITLE
mediatek: rtl8367s: modernize gpio API

### DIFF
--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
@@ -22,7 +22,7 @@
 		compatible = "mediatek,rtk-gsw";
 		mediatek,ethsys = <&ethsys>;
 		mediatek,mdio = <&mdio>;
-		mediatek,reset-pin = <&pio 54 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 54 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7622-elecom-wrc-2533gent.dts
+++ b/target/linux/mediatek/dts/mt7622-elecom-wrc-2533gent.dts
@@ -161,7 +161,7 @@
 		compatible = "mediatek,rtk-gsw";
 		mediatek,ethsys = <&ethsys>;
 		mediatek,mdio = <&mdio>;
-		mediatek,reset-pin = <&pio 54 0>;
+		reset-gpios = <&pio 54 GPIO_ACTIVE_LOW>;
 		status = "okay";
 	};
 };

--- a/target/linux/mediatek/dts/mt7622-totolink-a8000ru.dts
+++ b/target/linux/mediatek/dts/mt7622-totolink-a8000ru.dts
@@ -95,7 +95,7 @@
 		compatible = "mediatek,rtk-gsw";
 		mediatek,ethsys = <&ethsys>;
 		mediatek,mdio = <&mdio>;
-		mediatek,reset-pin = <&pio 54 0>;
+		reset-gpios = <&pio 54 GPIO_ACTIVE_LOW>;
 		status = "okay";
 	};
 };


### PR DESCRIPTION
Upstream is strongly considering removing of_gpio.h. As of this commit, 3 upstream drivers remain with actual usage.

Get ahead of upstream and use the GPIOD API before the OF one goes away.

Rework to remove mediatek,reset-pin in favor of the standard reset-gpios.

ping @dangowrt 