### PR TITLE
realtek: fix dts warnings.

### DIFF
--- a/target/linux/realtek/dts/rtl838x.dtsi
+++ b/target/linux/realtek/dts/rtl838x.dtsi
@@ -202,6 +202,8 @@
 	switchcore@1b000000 {
 		compatible = "syscon", "simple-mfd";
 		reg = <0x1b000000 0x10000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		mdio_ctrl: mdio-controller {
 			compatible = "realtek,rtl8380-mdio", "realtek,otto-mdio";

--- a/target/linux/realtek/dts/rtl839x.dtsi
+++ b/target/linux/realtek/dts/rtl839x.dtsi
@@ -210,6 +210,8 @@
 	switchcore@1b000000 {
 		compatible = "syscon", "simple-mfd";
 		reg = <0x1b000000 0x10000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		mdio_ctrl: mdio-controller {
 			compatible = "realtek,rtl8392-mdio", "realtek,otto-mdio";

--- a/target/linux/realtek/dts/rtl930x.dtsi
+++ b/target/linux/realtek/dts/rtl930x.dtsi
@@ -160,6 +160,8 @@
 	switchcore@1b000000 {
 		compatible = "syscon", "simple-mfd";
 		reg = <0x1b000000 0x10000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		i2c_mst1: i2c@36c {
 			compatible = "realtek,rtl9301-i2c";

--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -190,6 +190,8 @@
 	switchcore@1b000000 {
 		compatible = "syscon", "simple-mfd";
 		reg = <0x1b000000 0x10000>;
+		#address-cells = <1>;
+		#size-cells = <1>;
 
 		i2c_mst1: i2c@100c {
 			compatible = "realtek,rtl9310-i2c";


### PR DESCRIPTION
Currently following warnings are given

dts/rtl930x.dtsi:166.4-23: Warning (reg_format):
/switchcore@1b000000/i2c@36c:reg: property has invalid length (8 bytes) (#address-cells == 2, #size-cells == 1)

Obviously default address-cells size is fixed to 64 bit. Align with upstream and override address size to 32 bit.