### PR TITLE
generic: Add package for enabling external (e.g. USB) root FS

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -144,6 +144,18 @@ menu "Global build settings"
 		  Useful for release builds, so that kernel issues can be debugged offline
 		  later.
 
+	config BUILTIN_KMODS
+		bool
+		prompt "Make kernel module packages built-in to the kernel"
+		help
+		  All kernel module packages that are selected for inclusion in the base
+		  image will be compiled directly into the kernel binary. This allows kmods
+		  to be loaded before pre-init so they can be used to mount the root fs.
+		  This increases the size of the kernel image, but decreases the size of the
+		  filesystem. It tends to offer a small net-benefit. Caution: Some (rare)
+		  devices are known to be impossible to reset except by unloading the module
+		  or rebooting. If the module is builtin then it cannot be unloaded.
+
 	menu "Kernel build options"
 
 	source "config/Config-kernel.in"

--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -118,7 +118,7 @@ define Kernel/Configure/Default
 	echo "# CONFIG_KALLSYMS_EXTRA_PASS is not set" >> $(LINUX_DIR)/.config.target
 	echo "# CONFIG_KALLSYMS_ALL is not set" >> $(LINUX_DIR)/.config.target
 	echo "CONFIG_KALLSYMS_UNCOMPRESSED=y" >> $(LINUX_DIR)/.config.target
-	$(SCRIPT_DIR)/package-metadata.pl kconfig $(TMP_DIR)/.packageinfo $(TOPDIR)/.config $(KERNEL_PATCHVER) > $(LINUX_DIR)/.config.override
+	$(SCRIPT_DIR)/package-metadata.pl kconfig $(TMP_DIR)/.packageinfo $(TOPDIR)/.config $(KERNEL_PATCHVER) $(CONFIG_BUILTIN_KMODS) > $(LINUX_DIR)/.config.override
 	$(SCRIPT_DIR)/kconfig.pl 'm+' '+' $(LINUX_DIR)/.config.target /dev/null $(LINUX_DIR)/.config.override > $(LINUX_DIR)/.config.set
 	$(call Kernel/SetNoInitramfs)
 	rm -rf $(KERNEL_BUILD_DIR)/modules

--- a/package/system/extroot/Makefile
+++ b/package/system/extroot/Makefile
@@ -1,0 +1,44 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=extroot
+PKG_RELEASE:=1
+PKG_VERSION:=1.0
+PKG_FLAGS+=nonshared
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/extroot
+  SECTION:=base
+  CATEGORY:=Base system
+  TITLE:=External (e.g. USB) rootfs support
+  DEPENDS:=+sfdisk +e2fsprogs
+endef
+
+define Package/extroot/description
+  Allow the root filesystem overlay to be stored on an external block device such as USB.
+  
+  When the OS boots without any onboard writable storage partition (e.g. JFFS or UBI),
+  it will attempt to partition any qualifying block device it finds. A block device
+  qualifies if it has been overwritten with the exact bytes:
+  'OPENWRT_ROOT_DELETE_ALL_DATA'. After partitioning, the OS will automatically load the
+  disk on boot.
+
+  For this to work, you must include the required filesystem and device drivers as =y and
+  you probably need to set BUILTIN_KMODS so that they will be loaded early enough.
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/extroot/install
+	$(INSTALL_DIR) $(1)/lib/preinit
+	$(INSTALL_BIN) ./files/etc/preinit.d/75_extroot $(1)/lib/preinit/
+
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/block
+	$(INSTALL_BIN) ./files/etc/hotplug.d/block/10-extroot $(1)/etc/hotplug.d/block/
+endef
+
+$(eval $(call BuildPackage,extroot))

--- a/package/system/extroot/files/etc/hotplug.d/block/10-extroot
+++ b/package/system/extroot/files/etc/hotplug.d/block/10-extroot
@@ -1,0 +1,47 @@
+#!/bin/sh
+# /etc/hotplug.d/block/10-extroot
+# Handle "factory reset" disk and rootfs_data partition provisioning
+
+[ "$ACTION" = "add" ] || exit 0
+[ "$SUBSYSTEM" = "block" ] || exit 0
+
+log() {
+    echo "extroot: $*" >/dev/kmsg
+}
+
+# This script only runs if we do not yet have a persistent disk
+grep -q ' /overlay ' /proc/mounts && exit 0
+
+# Case 1: A rootfs partitioned disk appears, this means it was late plugged
+#         and mount_root did not catch it, reboot to give mount_root another chance.
+if [ "$DEVTYPE" = "partition" ] && [ "$PARTNAME" = "rootfs_data" ]; then
+    log "Extroot found on newly connected /dev/$DEVNAME - rebooting to begin using it"
+    reboot -f
+    exit 0;
+fi
+
+# Case 2: A disk appears
+[ "$DEVTYPE" = "disk" ] || exit 0
+
+# Check if it is an ISO9660 (MBR or GPT will have data in the first 32k)
+cmp -s -n 32768 "/dev/$DEVNAME" /dev/zero || exit 0
+
+# Check if it has the OPENWRT_ROOTFS as the volume label
+label=$(dd if="/dev/$DEVNAME" of=/dev/stdout bs=1 skip=32808 count=14 2>/dev/null)
+[ "$label" = 'OPENWRT_ROOTFS' ] || exit 0
+
+log "Extroot volume found on /dev/$DEVNAME, wiping and creating rootfs_data"
+(
+    # Create new GPT with single partition
+    echo ',,L' | sfdisk --wipe always --label gpt "/dev/$DEVNAME"
+
+    # mkfs the new partition
+    mkfs.ext4 -F "/dev/${DEVNAME}1"
+
+    # Label the partition, but only after we have made the FS
+    # to avoid a race with mount_root done
+    sfdisk --part-label "/dev/$DEVNAME" 1 rootfs_data
+
+    log "Rebooting to begin using extroot on /dev/${DEVNAME}1"
+    reboot -f
+) 2>&1 | while read line; do log "$line"; done

--- a/package/system/extroot/files/etc/preinit.d/75_extroot
+++ b/package/system/extroot/files/etc/preinit.d/75_extroot
@@ -1,0 +1,28 @@
+# If we're using an external root device (e.g. USB) we may
+# need to create the device node for it because procd has
+# not started yet and we need it for 80_mount_root.
+do_extroot_mknod() {
+    for blk in /sys/class/block/*/*/uevent; do
+        if ! grep -q 'PARTNAME=rootfs_data' "$blk"; then
+            continue
+        fi
+		local devname="$(basename "$(dirname "$blk")")"
+        if [ -b "/dev/$devname" ]; then
+			continue
+        fi
+		local devpath="/sys/class/block/$devname/dev"
+		if [ -f "$devpath" ]; then
+			local major=$(cut -d: -f1 "$devpath")
+			local minor=$(cut -d: -f2 "$devpath")
+			mknod "/dev/$devname" b "$major" "$minor"
+		fi
+		if [ -x /usr/sbin/fsck.ext4 ]; then
+			if ! /usr/sbin/fsck.ext4 -p "/dev/${devname}"; then
+				echo "$devname has errors, not mounting, please run fsck.ext4 manually"
+				rm "/dev/$devname"
+			fi
+		fi
+    done
+}
+
+[ "$INITRAMFS" = "1" ] || boot_hook_add preinit_main do_extroot_mknod

--- a/scripts/package-metadata.pl
+++ b/scripts/package-metadata.pl
@@ -57,11 +57,12 @@ sub gen_kconfig_overrides() {
 	my $pkginfo = shift @ARGV;
 	my $cfgfile = shift @ARGV;
 	my $patchver = shift @ARGV;
+	my $builtin = shift(@ARGV) eq 'y';
 
 	# parameter 2: build system config
 	open FILE, "<$cfgfile" or return;
 	while (<FILE>) {
-		/^(CONFIG_.+?)=(.+)$/ and $config{$1} = 1;
+		/^(CONFIG_.+?)=(.+)$/ and $config{$1} = $2;
 	}
 	close FILE;
 
@@ -78,6 +79,8 @@ sub gen_kconfig_overrides() {
 					$config = $1;
 					$override = 1;
 					$val = $2;
+				} elsif ($builtin and $config{"CONFIG_PACKAGE_$package"} eq 'y') {
+					$val = 'y';
 				}
 				if ($config{"CONFIG_PACKAGE_$package"} and ($config ne 'n')) {
 					next if $kconfig{$config} eq 'y';
@@ -812,18 +815,18 @@ sub parse_command() {
 	}
 	die <<EOF
 Available Commands:
-	$0 mk [file]					Package metadata in makefile format
-	$0 config [file] 				Package metadata in Kconfig format
-	$0 kconfig [file] [config] [patchver]	Kernel config overrides
-	$0 source [file] 				Package source file information
-	$0 pkgaux [file]				Package auxiliary variables in makefile format
-	$0 pkgmanifestjson [file]			Package manifests in JSON format
-	$0 imgcyclonedxsbom <file> [manifest]	Image package manifest in CycloneDX SBOM JSON format
-	$0 pkgcyclonedxsbom <file>			Package manifest in CycloneDX SBOM JSON format
-	$0 license [file] 				Package license information
-	$0 licensefull [file] 			Package license information (full list)
-	$0 usergroup [file]				Package usergroup allocation list
-	$0 version_filter [patchver] [list...]	Filter list of version tagged strings
+	$0 mk [file]						Package metadata in makefile format
+	$0 config [file] 					Package metadata in Kconfig format
+	$0 kconfig [file] [config] [patchver] [builtin]	Kernel config overrides
+	$0 source [file] 					Package source file information
+	$0 pkgaux [file]					Package auxiliary variables in makefile format
+	$0 pkgmanifestjson [file]				Package manifests in JSON format
+	$0 imgcyclonedxsbom <file> [manifest]		Image package manifest in CycloneDX SBOM JSON format
+	$0 pkgcyclonedxsbom <file>				Package manifest in CycloneDX SBOM JSON format
+	$0 license [file] 					Package license information
+	$0 licensefull [file] 				Package license information (full list)
+	$0 usergroup [file]					Package usergroup allocation list
+	$0 version_filter [patchver] [list...]		Filter list of version tagged strings
 
 Options:
 	--ignore <name>				Ignore the source package <name>


### PR DESCRIPTION
Hello,

I want to use this pull req to begin a conversation about external rootfs and how it aligns with the goals and direction of the project.

I will describe what this does, and then indicate my questions:

1. New config symbol BUILTIN_KMODS which makes kmod packages kernel builtins unless they explicitly specify otherwise.

QUESTION1: Do we feel like this aligns with project objectives? If this is seen as a can of worms then the entire idea is mostly dead in the water.

2. Ensure that a /dev/sdX1 block device exists at preinit time for any partition with a "rootfs_data" label. This makes mount_root work with hotplug devices.

QUESTION2: Is this something which should be implemented in fstools and run regardless of configuration?

3. In case a "rootfs_data" partition is found, scan it with fsck.ext4 before mount_root, and delete the /dev/sdX1 device if it fails. This adds a check and makes booting possible even if the partition is bad.

QUESTION3: Is this something which should be in fstools and run for everyone? Should we always scan ext4 if we see one and fsck.ext4 exists?

4. If no rootfs_data is mounted and one is plugged in later (hotplug)
then reboot so that it will be loaded properly. This handles a race
condition where mount_root happens before USB is fully loaded. This
has been seen in cases with a bad USB stick which does not always
initialize on the first try and sometimes requires a USB reset. This
may cause a boot-loop if the OS loads the drivers too late (e.g. a
late-loading .ko file), but this is a bad build, and looping can be
stopped by removing the disk.

5. If no rootfs_data is mounted and a disk is plugged in that
contains an ISO9660 with the volume label "OPENWRT_ROOTFS", this
disk will be re-partitioned to GPT and an ext4 rootfs_data filesystem
created. You can create such an iso with the following commands:

```bash
mkdir ./iso_image
echo 'OpenWRT rootfs marker image' > ./iso_image/readme.txt
genisoimage -V "OPENWRT_ROOTFS" -o openwrt_rootfs.iso ./iso_image/
```

QUESTION4: Does this overall generally seem like a direction we want to take? Is f2fs a much better choice than ext4?

Here is what a boot looks like with a fresh USB stick containing the marker ISO:

```

Decompress to 80020000 free_mem_ptr=80950000 free_mem_ptr_end=807B0000
from main
Uncompressing [LZMA] ...  done.
zimage at:     800233C0 803838F0

Uncompressing Linux at load address 81000000

Copy device tree to address  81B316C0

Now, booting the kernel...

[    0.000000] Linux version 6.12.45 (user@cjd-dev) (mips-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r29925+8-cc5421128e) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Tue Sep 16 12:15:00 2025
[    0.000000] ISPRAM0: PA=1c000000,Size=00010000,enabled
[    0.000000] printk: legacy bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 00019558 (MIPS 34Kc)
[    0.000000] MIPS: machine is SmartFiber XP8421-B
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] OF: reserved mem: Reserved memory: No reserved-memory node in the DT
[    0.000000] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, VIPT, cache aliases, linesize 32 bytes
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000001bffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x000000001bffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000001bffffff]
[    0.000000] percpu: Embedded 12 pages/cpu s18096 r8192 d22864 u49152
[    0.000000] Kernel command line: 
[    0.000000] Dentry cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
[    0.000000] Writing ErrCtl register=00008008
[    0.000000] Readback ErrCtl register=00008008
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 114688
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=2 to nr_cpu_ids=1.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
[    0.000000] RCU Tasks Trace: Setting shift to 0 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=1.
[    0.000000] NR_IRQS: 256
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] clocksource: timer: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 9556302233 ns
[    0.000002] sched_clock: 32 bits at 200MHz, resolution 5ns, wraps every 10737418237ns
[    0.008524] timer: using 200.000 MHz high precision timer
[    0.014607] Calibrating delay loop... 597.60 BogoMIPS (lpj=2988032)
[    0.081317] pid_max: default: 32768 minimum: 301
[    0.096077] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.104067] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.122778] rcu: Hierarchical SRCU implementation.
[    0.128034] rcu: 	Max phase no-delay instances is 1000.
[    0.134863] smp: Bringing up secondary CPUs ...
[    0.139837] smp: Brought up 1 node, 1 CPU
[    0.144310] Memory: 440488K/458752K available (8856K kernel code, 645K rwdata, 1744K rodata, 1288K init, 235K bss, 17268K reserved, 0K cma-reserved)
[    0.161908] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.172786] futex hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.188388] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.205418] SCSI subsystem initialized
[    0.209754] usbcore: registered new interface driver usbfs
[    0.215822] usbcore: registered new interface driver hub
[    0.221845] usbcore: registered new device driver usb
[    0.229063] clocksource: Switched to clocksource timer
[    0.244485] NET: Registered PF_INET protocol family
[    0.250133] IP idents hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.259452] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.268589] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.277168] TCP established hash table entries: 4096 (order: 2, 16384 bytes, linear)
[    0.285686] TCP bind hash table entries: 4096 (order: 4, 65536 bytes, linear)
[    0.293771] TCP: Hash tables configured (established 4096 bind 4096)
[    0.301398] MPTCP token hash table entries: 512 (order: 1, 8192 bytes, linear)
[    0.309740] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.316862] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.325485] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.335826] workingset: timestamp_bits=14 max_order=17 bucket_order=3
[    0.358629] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.369471] Serial: 8250/16550 driver, 2 ports, IRQ sharing disabled
[    0.377610] printk: legacy console [ttyS0] disabled
[    0.383622] 1fbf0000.serial: ttyS0 at MMIO 0x1fbf0000 (irq = 8, base_baud = 115200) is a 16550
[    0.393231] printk: legacy console [ttyS0] enabled
[    0.393231] printk: legacy console [ttyS0] enabled
[    0.403243] printk: legacy bootconsole [early0] disabled
[    0.403243] printk: legacy bootconsole [early0] disabled
[    0.425066] spi-nand spi0.0: GigaDevice SPI NAND was found.
[    0.430826] spi-nand spi0.0: 256 MiB, block size: 128 KiB, page size: 2048, OOB size: 128
[    0.440292] en75_bmt: found BMT in block 2047
[    0.527765] en75_bmt: found BBT in block 1885
[    0.532220] en75_bmt: BBT & BMT found
[    0.535885] en75_bmt: blocks: total: 2048, user: 1884, factory_bad: 1, worn: 0 reserve: 163
[    0.544256]  - BBT factory bad block: 1023
[    0.548350] en75_bmt: 235 MiB usable space
[    0.549073] 9 fixed-partitions partitions found on MTD device spi0.0
[    0.559658] Creating 9 MTD partitions on "spi0.0":
[    0.564461] 0x000000000000-0x000000040000 : "bootloader"
[    0.571893] 0x000000040000-0x000000080000 : "romfile"
[    0.578614] 0x000000080000-0x000001480000 : "tclinux"
[    0.608133] 0x000000480000-0x000001400000 : "rootfs"
[    0.614777] mtd: setting mtd3 (rootfs) as root device
[    0.620544] 1 squashfs-split partitions found on MTD device rootfs
[    0.626766] 0x0000007a0000-0x000001400000 : "rootfs_data"
[    0.633709] 0x000001480000-0x000002880000 : "tclinux_alt"
[    0.663408] 0x000002880000-0x000004880000 : "openjdk"
[    0.706307] 0x000004880000-0x00000d980000 : "ubifs"
[    0.877040] 0x00000d980000-0x00000de40000 : "unknown"
[    0.889149] 0x00000de40000-0x00000e000000 : "reservearea"
[    0.903437] PPP generic driver version 2.4.2
[    0.907877] NET: Registered PF_PPPOX protocol family
[    0.913118] usbcore: registered new device driver r8152-cfgselector
[    0.919574] usbcore: registered new interface driver r8152
[    0.925469] xhci-mtk 1fb90000.usb: xHCI Host Controller
[    0.930846] xhci-mtk 1fb90000.usb: new USB bus registered, assigned bus number 1
[    0.944604] xhci-mtk 1fb90000.usb: hcc params 0x01401198 hci version 0x96 quirks 0x0000000000280810
[    0.953932] xhci-mtk 1fb90000.usb: irq 17, io mem 0x1fb90000
[    0.959969] xhci-mtk 1fb90000.usb: xHCI Host Controller
[    0.965240] xhci-mtk 1fb90000.usb: new USB bus registered, assigned bus number 2
[    0.972721] xhci-mtk 1fb90000.usb: Host supports USB 3.0 SuperSpeed
[    0.980559] hub 1-0:1.0: USB hub found
[    0.984838] hub 1-0:1.0: 2 ports detected
[    0.991886] hub 2-0:1.0: USB hub found
[    0.996203] hub 2-0:1.0: 1 port detected
[    1.001526] usbcore: registered new interface driver usb-storage
[    1.012052] NET: Registered PF_INET6 protocol family
[    1.022339] Segment Routing with IPv6
[    1.026123] In-situ OAM (IOAM) with IPv6
[    1.030453] NET: Registered PF_PACKET protocol family
[    1.035601] 8021q: 802.1Q VLAN Support v1.8
[    1.087145] clk: Disabling unused clocks
[    1.092073] mtdblock: MTD device 'rootfs' is NAND, please consider using UBI block devices instead.
[    1.103298] mtdblock: MTD device 'rootfs' is NAND, please consider using UBI block devices instead.
[    1.114639] mtdblock: MTD device 'rootfs' is NAND, please consider using UBI block devices instead.
[    1.125638] mtdblock: MTD device 'rootfs' is NAND, please consider using UBI block devices instead.
[    1.146232] VFS: Mounted root (squashfs filesystem) readonly on device 31:3.
[    1.156978] Freeing unused kernel image (initmem) memory: 1288K
[    1.163049] This architecture does not have kernel memory protection.
[    1.169560] Run /sbin/init as init process
[    1.510852] usb 1-1: new high-speed USB device number 2 using xhci-mtk
[    1.695109] usb-storage 1-1:1.0: USB Mass Storage device detected
[    1.707201] scsi host0: usb-storage 1-1:1.0
[    1.979688] init: Console is alive
[    2.019254] usb 1-2: new high-speed USB device number 3 using xhci-mtk
[    2.100217] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    2.128267] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    2.146382] init: - preinit -
[    2.185378] hub 1-2:1.0: USB hub found
[    2.190368] hub 1-2:1.0: 4 ports detected
[    2.569439] usb 1-2.1: new high-speed USB device number 4 using xhci-mtk
[    2.762471] scsi 0:0:0:0: Direct-Access     Generic  Flash Disk       8.07 PQ: 0 ANSI: 4
[    2.786100] sd 0:0:0:0: [sda] 64430080 512-byte logical blocks: (33.0 GB/30.7 GiB)
[    2.796139] sd 0:0:0:0: [sda] Write Protect is off
[    2.803451] sd 0:0:0:0: [sda] Write cache: disabled, read cache: enabled, doesn't support DPO or FUA
[    2.867184] r8152-cfgselector 1-2.1: reset high-speed USB device number 4 using xhci-mtk
[    2.924822] sd 0:0:0:0: [sda] Attached SCSI removable disk
[    4.339798] r8152 1-2.1:1.0 eth0: v1.12.13
[    4.398770] random: crng init done
[    4.479054] usb 1-2.4: new high-speed USB device number 5 using xhci-mtk
[    4.761077] usb-storage 1-2.4:1.0: USB Mass Storage device detected
[    4.769486] scsi host1: usb-storage 1-2.4:1.0
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    5.818963] scsi 1:0:0:0: Direct-Access     Multi    Flash Reader     1.00 PQ: 0 ANSI: 0
[    5.868898] sd 1:0:0:0: [sdb] Media removed, stopped polling
[    5.875262] sd 1:0:0:0: [sdb] Attached SCSI removable disk
[    7.048999] r8152 1-2.1:1.0 eth0: carrier on
[    9.303466] mount_root: no usable overlay filesystem found, using tmpfs overlay
[    9.315737] urandom-seed: Seed file not found (/etc/urandom.seed)
[    9.923832] procd: - early -
[   10.204534] mtdblock: MTD device 'rootfs_data' is NAND, please consider using UBI block devices instead.
[   10.271449] mtdblock: MTD device 'tclinux' is NAND, please consider using UBI block devices instead.
[   10.490940] mtdblock: MTD device 'bootloader' is NAND, please consider using UBI block devices instead.
[   10.557959] mtdblock: MTD device 'reservearea' is NAND, please consider using UBI block devices instead.
[   10.625527] mtdblock: MTD device 'ubifs' is NAND, please consider using UBI block devices instead.
[   10.692241] mtdblock: MTD device 'tclinux_alt' is NAND, please consider using UBI block devices instead.
[   10.816944] mtdblock: MTD device 'romfile' is NAND, please consider using UBI block devices instead.
[   10.951083] procd: - ubus -
[   11.051391] extroot: Extroot volume found on /dev/sda, wiping and creating rootfs_data
[   11.365113] procd: - init -
Please press Enter to activate this console.
[   12.713006] extroot: Checking that no-one is using this disk right now ... OK
[   12.742962] extroot: 
[   12.745907] extroot: The device contains 'iso9660' signature and it may be removed by a write command. See sfdisk(8) man page and --wipe option for more details.
[   12.815793] extroot: 
[   12.818485] extroot: Disk /dev/sda: 30.72 GiB, 32988200960 bytes, 64430080 sectors
[   12.859486] extroot: Disk model: Flash Disk
[   12.864025] extroot: Units: sectors of 1 * 512 = 512 bytes
[   12.905067] extroot: Sector size (logical/physical): 512 bytes / 512 bytes
[   12.940108] extroot: I/O size (minimum/optimal): 512 bytes / 512 bytes
[   12.946845] extroot: 
[   12.984081] extroot: >>> Created a new GPT disklabel (GUID: FC745DF1-CA89-4580-A659-E7DB32A423A3).
[   13.035666] extroot: The device contains 'iso9660' signature and it may be removed by a write command. See sfdisk(8) man page and --wipe option for more details.
[   13.449069] extroot: 
[   13.451924] extroot: /dev/sda1: Created a new partition 1 of type 'Linux filesystem' and of size 30.7 GiB.
[   13.499507] extroot: Partition #1 contains a ext4 signature.
[   13.529483] kmodloader: loading kernel modules from /etc/modules.d/*
[   13.670815] kmodloader: done loading kernel modules from /etc/modules.d/*
[   14.929482] urngd: v1.0.2 started.
[   17.499200]  sda: sda1
[   17.504877] extroot: /dev/sda2: Done.
[   17.526086] extroot: 
[   17.551183] extroot: New situation:
[   17.602022] extroot: Disklabel type: gpt
[   17.606375] extroot: Disk identifier: FC745DF1-CA89-4580-A659-E7DB32A423A3
[   17.627615] extroot: 
[   17.681861] extroot: Device     Start      End  Sectors  Size Type
[   17.688455] extroot: /dev/sda1   2048 64428031 64425984 30.7G Linux filesystem
[   17.713318] extroot: 
[   17.757647] extroot: The partition table has been altered.
[   17.888930] extroot: Calling ioctl() to re-read partition table.
[   17.895222] extroot: Syncing disks.
[   18.062797] extroot: mke2fs 1.47.2 (1-Jan-2025)
[   18.270281] extroot: Creating filesystem with 8053248 4k blocks and 2015232 inodes
[   18.278422] extroot: Filesystem UUID: 41c6a8b1-4da1-45df-b6cf-011edc9aeb71
[   18.307017] extroot: Superblock backups stored on blocks:
[   18.348953] extroot: 32768, 98304, 163840, 229376, 294912, 819200, 884736, 1605632, 2654208,
[   18.357688] extroot: 4096000, 7962624
[   18.374782] extroot: 
[   18.420142] extroot: Allocating group tables:   0/246       done
[   18.427856] extroot: Writing inode tables:   0/246       done
[   70.848864] br-lan: port 1(eth0) entered blocking state
[   70.854140] br-lan: port 1(eth0) entered disabled state
[   70.859559] r8152 1-2.1:1.0 eth0: entered allmulticast mode
[   70.865487] r8152 1-2.1:1.0 eth0: entered promiscuous mode
[   70.888958] r8152 1-2.1:1.0 eth0: Promiscuous mode enabled
[   70.949102] br-lan: port 1(eth0) entered blocking state
[   70.954385] br-lan: port 1(eth0) entered forwarding state
[   71.059713] br-lan: port 1(eth0) entered disabled state
[   73.699181] r8152 1-2.1:1.0 eth0: Promiscuous mode enabled
[   73.719091] r8152 1-2.1:1.0 eth0: carrier on
[   73.778977] br-lan: port 1(eth0) entered blocking state
[   73.784255] br-lan: port 1(eth0) entered forwarding state
[   74.259205] extroot: Creating journal (32768 blocks): done
[  143.835431] extroot: Writing superblocks and filesystem accounting information:   0/246       done
[  143.849492] extroot: 
[  145.151068] extroot: Partition name changed from '' to 'rootfs_data'.
[  148.879208]  sda: sda1
[  148.886670] extroot: 
[  148.890469] extroot: Rebooting to begin using extroot on /dev/sda1
[  148.898251] extroot: The partition table has been altered.
[  148.907132] extroot: Calling ioctl() to re-read partition table.
[  148.920846] extroot: Syncing disks.
[  148.924725] reboot: Restarting system
BGA IC
Xtal:1
DDR3 init.
DRAMC init done. 
Calculate size.
DRAM size=512MB
Set new TRFC.
ddr-1066


7512DRAMC V1.2.2 (0)



EN751221 at Thu Oct 10 16:51:39 EDT 2024 version 1.1 free bootbase

Memory size 512MB

Set SPI Clock to 50 Mhz
spi_nand_probe: mfr_id=0xc8, dev_id=0xd2
Using Flash ECC.
Detected SPI NAND Flash : _SPI_NAND_DEVICE_ID_GD5F2GQ4UB, Flash Size=0x10000000
bmt pool size: 163 
BMT & BBT Init Success 

Press any key in 5 secs to enter boot command mode..
....................................................................................................



==> boot flag = 0Decompress to 80020000 free_mem_ptr=80950000 free_mem_ptr_end=807B0000
from main
Uncompressing [LZMA] ...  done.
zimage at:     800233C0 803838F0

Uncompressing Linux at load address 81000000

Copy device tree to address  81B316C0

Now, booting the kernel...

[    0.000000] Linux version 6.12.45 (user@cjd-dev) (mips-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r29925+8-cc5421128e) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Tue Sep 16 12:15:00 2025
[    0.000000] ISPRAM0: PA=1c000000,Size=00010000,enabled
[    0.000000] printk: legacy bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 00019558 (MIPS 34Kc)
[    0.000000] MIPS: machine is SmartFiber XP8421-B
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] OF: reserved mem: Reserved memory: No reserved-memory node in the DT
[    0.000000] Primary instruction cache 64kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, VIPT, cache aliases, linesize 32 bytes
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000001bffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x000000001bffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000001bffffff]
[    0.000000] percpu: Embedded 12 pages/cpu s18096 r8192 d22864 u49152
[    0.000000] Kernel command line: 
[    0.000000] Dentry cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
[    0.000000] Writing ErrCtl register=00008008
[    0.000000] Readback ErrCtl register=00008008
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 114688
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=1, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=2 to nr_cpu_ids=1.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=1
[    0.000000] RCU Tasks Trace: Setting shift to 0 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=1.
[    0.000000] NR_IRQS: 256
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] clocksource: timer: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 9556302233 ns
[    0.000002] sched_clock: 32 bits at 200MHz, resolution 5ns, wraps every 10737418237ns
[    0.008524] timer: using 200.000 MHz high precision timer
[    0.014608] Calibrating delay loop... 597.60 BogoMIPS (lpj=2988032)
[    0.081317] pid_max: default: 32768 minimum: 301
[    0.096076] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.104066] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.122729] rcu: Hierarchical SRCU implementation.
[    0.127981] rcu: 	Max phase no-delay instances is 1000.
[    0.134812] smp: Bringing up secondary CPUs ...
[    0.139793] smp: Brought up 1 node, 1 CPU
[    0.144269] Memory: 440488K/458752K available (8856K kernel code, 645K rwdata, 1744K rodata, 1288K init, 235K bss, 17268K reserved, 0K cma-reserved)
[    0.161866] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.172751] futex hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.188368] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.205388] SCSI subsystem initialized
[    0.209727] usbcore: registered new interface driver usbfs
[    0.215796] usbcore: registered new interface driver hub
[    0.221819] usbcore: registered new device driver usb
[    0.229018] clocksource: Switched to clocksource timer
[    0.244443] NET: Registered PF_INET protocol family
[    0.250091] IP idents hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.259408] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.268545] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.277127] TCP established hash table entries: 4096 (order: 2, 16384 bytes, linear)
[    0.285640] TCP bind hash table entries: 4096 (order: 4, 65536 bytes, linear)
[    0.293727] TCP: Hash tables configured (established 4096 bind 4096)
[    0.301355] MPTCP token hash table entries: 512 (order: 1, 8192 bytes, linear)
[    0.309696] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.316818] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.325441] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.335789] workingset: timestamp_bits=14 max_order=17 bucket_order=3
[    0.358632] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.369458] Serial: 8250/16550 driver, 2 ports, IRQ sharing disabled
[    0.377585] printk: legacy console [ttyS0] disabled
[    0.383591] 1fbf0000.serial: ttyS0 at MMIO 0x1fbf0000 (irq = 8, base_baud = 115200) is a 16550
[    0.393204] printk: legacy console [ttyS0] enabled
[    0.393204] printk: legacy console [ttyS0] enabled
[    0.403217] printk: legacy bootconsole [early0] disabled
[    0.403217] printk: legacy bootconsole [early0] disabled
[    0.425177] spi-nand spi0.0: GigaDevice SPI NAND was found.
[    0.430932] spi-nand spi0.0: 256 MiB, block size: 128 KiB, page size: 2048, OOB size: 128
[    0.440399] en75_bmt: found BMT in block 2047
[    0.528285] en75_bmt: found BBT in block 1885
[    0.532741] en75_bmt: BBT & BMT found
[    0.536406] en75_bmt: blocks: total: 2048, user: 1884, factory_bad: 1, worn: 0 reserve: 163
[    0.544778]  - BBT factory bad block: 1023
[    0.548888] en75_bmt: 235 MiB usable space
[    0.549520] 9 fixed-partitions partitions found on MTD device spi0.0
[    0.560118] Creating 9 MTD partitions on "spi0.0":
[    0.564922] 0x000000000000-0x000000040000 : "bootloader"
[    0.572356] 0x000000040000-0x000000080000 : "romfile"
[    0.579260] 0x000000080000-0x000001480000 : "tclinux"
[    0.608623] 0x000000480000-0x000001400000 : "rootfs"
[    0.615302] mtd: setting mtd3 (rootfs) as root device
[    0.621069] 1 squashfs-split partitions found on MTD device rootfs
[    0.627286] 0x0000007a0000-0x000001400000 : "rootfs_data"
[    0.634291] 0x000001480000-0x000002880000 : "tclinux_alt"
[    0.664114] 0x000002880000-0x000004880000 : "openjdk"
[    0.707131] 0x000004880000-0x00000d980000 : "ubifs"
[    0.877729] 0x00000d980000-0x00000de40000 : "unknown"
[    0.889796] 0x00000de40000-0x00000e000000 : "reservearea"
[    0.904001] PPP generic driver version 2.4.2
[    0.908440] NET: Registered PF_PPPOX protocol family
[    0.913687] usbcore: registered new device driver r8152-cfgselector
[    0.920147] usbcore: registered new interface driver r8152
[    0.926043] xhci-mtk 1fb90000.usb: xHCI Host Controller
[    0.931429] xhci-mtk 1fb90000.usb: new USB bus registered, assigned bus number 1
[    0.944970] xhci-mtk 1fb90000.usb: hcc params 0x01401198 hci version 0x96 quirks 0x0000000000280810
[    0.954241] xhci-mtk 1fb90000.usb: irq 17, io mem 0x1fb90000
[    0.960268] xhci-mtk 1fb90000.usb: xHCI Host Controller
[    0.965534] xhci-mtk 1fb90000.usb: new USB bus registered, assigned bus number 2
[    0.973014] xhci-mtk 1fb90000.usb: Host supports USB 3.0 SuperSpeed
[    0.980855] hub 1-0:1.0: USB hub found
[    0.985125] hub 1-0:1.0: 2 ports detected
[    0.992179] hub 2-0:1.0: USB hub found
[    0.996493] hub 2-0:1.0: 1 port detected
[    1.001798] usbcore: registered new interface driver usb-storage
[    1.012364] NET: Registered PF_INET6 protocol family
[    1.022657] Segment Routing with IPv6
[    1.026436] In-situ OAM (IOAM) with IPv6
[    1.030760] NET: Registered PF_PACKET protocol family
[    1.035914] 8021q: 802.1Q VLAN Support v1.8
[    1.087788] clk: Disabling unused clocks
[    1.092723] mtdblock: MTD device 'rootfs' is NAND, please consider using UBI block devices instead.
[    1.103889] mtdblock: MTD device 'rootfs' is NAND, please consider using UBI block devices instead.
[    1.115267] mtdblock: MTD device 'rootfs' is NAND, please consider using UBI block devices instead.
[    1.126239] mtdblock: MTD device 'rootfs' is NAND, please consider using UBI block devices instead.
[    1.146880] VFS: Mounted root (squashfs filesystem) readonly on device 31:3.
[    1.157627] Freeing unused kernel image (initmem) memory: 1288K
[    1.163700] This architecture does not have kernel memory protection.
[    1.170210] Run /sbin/init as init process
[    1.511929] usb 1-1: new high-speed USB device number 2 using xhci-mtk
[    1.698852] usb-storage 1-1:1.0: USB Mass Storage device detected
[    1.711011] scsi host0: usb-storage 1-1:1.0
[    1.981382] init: Console is alive
[    2.018782] usb 1-2: new high-speed USB device number 3 using xhci-mtk
[    2.101589] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    2.130052] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    2.148046] init: - preinit -
[    2.185388] hub 1-2:1.0: USB hub found
[    2.190435] hub 1-2:1.0: 4 ports detected
[    2.572383] usb 1-2.1: new high-speed USB device number 4 using xhci-mtk
[    2.763498] scsi 0:0:0:0: Direct-Access     Generic  Flash Disk       8.07 PQ: 0 ANSI: 4
[    2.859090] r8152-cfgselector 1-2.1: reset high-speed USB device number 4 using xhci-mtk
[    2.879031] sd 0:0:0:0: [sda] 64430080 512-byte logical blocks: (33.0 GB/30.7 GiB)
[    2.898920] sd 0:0:0:0: [sda] Write Protect is off
[    2.911622] sd 0:0:0:0: [sda] Write cache: disabled, read cache: enabled, doesn't support DPO or FUA
[    3.288126]  sda: sda1
[    3.293364] sd 0:0:0:0: [sda] Attached SCSI removable disk
[    4.149733] r8152 1-2.1:1.0 eth0: v1.12.13
[    4.288752] usb 1-2.4: new high-speed USB device number 5 using xhci-mtk
[    4.338737] random: crng init done
[    4.580987] usb-storage 1-2.4:1.0: USB Mass Storage device detected
[    4.589417] scsi host1: usb-storage 1-2.4:1.0
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    5.658898] scsi 1:0:0:0: Direct-Access     Multi    Flash Reader     1.00 PQ: 0 ANSI: 0
[    5.708854] sd 1:0:0:0: [sdb] Media removed, stopped polling
[    5.715194] sd 1:0:0:0: [sdb] Attached SCSI removable disk
[    6.868780] r8152 1-2.1:1.0 eth0: carrier on
/dev/sda1: clean, 12/2015232 files, 172078/8053248 blocks
[   26.943009] EXT4-fs (sda1): mounted filesystem 41c6a8b1-4da1-45df-b6cf-011edc9aeb71 r/w with ordered data mode. Quota mode: disabled.
[   27.009949] mount_root: overlay filesystem has not been fully initialized yet
[   27.099430] mount_root: switching to ext4 overlay
[   27.192110] urandom-seed: Seed file not found (/etc/urandom.seed)
[   27.803877] procd: - early -
[   28.485146] procd: - ubus -
[   28.660841] procd: - init -
Please press Enter to activate this console.
[   30.122021] kmodloader: loading kernel modules from /etc/modules.d/*
[   30.260141] kmodloader: done loading kernel modules from /etc/modules.d/*
[   31.569263] urngd: v1.0.2 started.
[   98.878760] br-lan: port 1(eth0) entered blocking state
[   98.884036] br-lan: port 1(eth0) entered disabled state
[   98.889379] r8152 1-2.1:1.0 eth0: entered allmulticast mode
[   98.895266] r8152 1-2.1:1.0 eth0: entered promiscuous mode
[   98.908912] r8152 1-2.1:1.0 eth0: Promiscuous mode enabled
[   98.968885] br-lan: port 1(eth0) entered blocking state
[   98.974170] br-lan: port 1(eth0) entered forwarding state
[   99.169499] br-lan: port 1(eth0) entered disabled state
[  101.849013] r8152 1-2.1:1.0 eth0: Promiscuous mode enabled
[  101.868917] r8152 1-2.1:1.0 eth0: carrier on
[  101.928756] br-lan: port 1(eth0) entered blocking state
[  101.934038] br-lan: port 1(eth0) entered forwarding state
```