### PR TITLE
mediatek: Fix setting MAC address for some devices

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -215,7 +215,10 @@ case "$board" in
 	routerich,ax3000-ubootmod|\
 	zbtlink,zbt-z8102ax|\
 	zbtlink,zbt-z8102ax-v2|\
-	zbtlink,zbt-z8103ax|\
+	zbtlink,zbt-z8103ax)
+		addr=$(mtd_get_mac_binary "Factory" 0x4)
+		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
+		;;
 	wavlink,wl-wn573hx3)
 		addr=$(mtd_get_mac_binary factory 0x04)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr -0x300000) > /sys${DEVPATH}/macaddress


### PR DESCRIPTION
This fixes a previous commit breaking setting the MAC address for the wifi devices.

Fixes: 9ed4d27fbf90 ("mediatek: filogic: fix 5G MAC address for Zyxel EX5601")