### PR TITLE
common.sh: replace logic to find boot device

### DIFF
--- a/package/base-files/files/lib/upgrade/common.sh
+++ b/package/base-files/files/lib/upgrade/common.sh
@@ -226,13 +226,13 @@ export_bootdevice() {
 
 export_partdevice() {
 	local var="$1" offset="$2"
-	local uevent line MAJOR MINOR DEVNAME DEVTYPE
+	local uevent line MAJOR MINOR DEVNAME DEVTYPE PARTN
 
 	for uevent in /sys/class/block/*/uevent; do
 		while read line; do
 			export -n "$line"
 		done < "$uevent"
-		if [ "$BOOTDEV_MAJOR" = "$MAJOR" -a $(($BOOTDEV_MINOR + $offset)) = "$MINOR" -a -b "/dev/$DEVNAME" ]; then
+		if [ "$BOOTDEV_MAJOR" = "$MAJOR" ] && [ "$PARTN" = "$offset" ] && [ -b "/dev/$DEVNAME" ]; then
 			export "$var=$DEVNAME"
 			return 0
 		fi


### PR DESCRIPTION
Replace minor number arithmetic with sysfs partition lookup in export_partdevice function.

The original logic used BOOTDEV_MINOR + offset to find partitions, but device enumeration can create non-sequential minor numbers causing the wrong partition to be selected which can lead to an entire disk experiencing 100% data loss[1a,b].

Replace with direct sysfs partition number lookup to reliably identify the correct partition regardless of enumeration order.

1a. https://github.com/openwrt/openwrt/pull/18962#issuecomment-2922429004
1b. https://forum.openwrt.org/t/flashing-a-custom-image-deleted-contents-of-data-ssd-replacing-it-with-the-kernel-partition-why/238753/