### PR TITLE
mediatek: filogic: Add support for AsiaRF AP7988-002

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -68,6 +68,7 @@ nradio,c8-668gl)
 	ubootenv_add_mmc "u-boot-env" "" "0x0" "0x80000"
 	;;
 asiarf,ap7986-003|\
+asiarf,ap7988-002|\
 cetron,ct3003|\
 comfast,cf-wr632ax|\
 edgecore,eap111|\

--- a/target/linux/mediatek/dts/mt7988a-asiarf-ap7988-002.dts
+++ b/target/linux/mediatek/dts/mt7988a-asiarf-ap7988-002.dts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 AsiaRF Co., Ltd.
+ * Author: Elwin Huang <elwin@asiarf.com>
+ */
+
+/dts-v1/;
+#include "mt7988a-asiarf-ap7988.dtsi"
+
+/ {
+	compatible = "asiarf,ap7988-002", "mediatek,mt7988a";
+	model = "AsaiRF AP7988-002";
+};
+
+&i2c1 {
+	iio@77 {
+		compatible = "infineon,dps310";
+		reg = <0x77>;
+	};
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_sdcard>;
+	pinctrl-1 = <&mmc0_pins_sdcard>;
+	cd-gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+	bus-width = <4>;
+	max-frequency = <50000000>;
+	cap-sd-highspeed;
+	vmmc-supply = <&reg_3p3v>;
+	vqmmc-supply = <&reg_3p3v>;
+	status = "okay";
+};
+
+&serial1 {
+	status = "okay";
+};
+
+&pcie0 {
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		/* BE19000 */
+		mt7996@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+			ieee80211-freq-limit = <2400000 2500000>, <5170000 5835000>, <5945000 7125000>;
+
+			band@0 {
+				/* 2.4 GHz */
+				reg = <0>;
+				nvmem-cells = <&macaddr_factory_4>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@1 {
+				/* 5 GHz */
+				reg = <1>;
+				nvmem-cells = <&macaddr_factory_a>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@2 {
+				/* 6 GHz */
+				reg = <2>;
+				nvmem-cells = <&macaddr_factory_2c0>;
+				nvmem-cell-names = "mac-address";
+			};
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7988a-asiarf-ap7988.dtsi
+++ b/target/linux/mediatek/dts/mt7988a-asiarf-ap7988.dtsi
@@ -1,0 +1,501 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 AsiaRF Co., Ltd.
+ * Author: Elwin Huang <elwin@asiarf.com>
+ */
+
+/dts-v1/;
+#include "mt7988a.dtsi"
+#include <dt-bindings/pinctrl/mt65xx.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/regulator/richtek,rt5190a-regulator.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		serial0 = &serial0;
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "pci=pcie_bus_perf ubi.block=0,fit root=/dev/fit0 rootwait";
+		rootdisk-spim-nand = <&ubi_rootfs>;
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+
+	reg_1p8v: regulator-1p8v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-1.8V";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		status = "okay";
+
+		led_power_blue: led-1 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 69 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "default-on";
+		};
+
+		led-2 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&pio 70 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "default-on";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&cpu0 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu1 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu2 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu3 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cci {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&eth {
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&mdio_bus {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <10500000>;
+
+	/* Aquantia AQR113C */
+	phy8: ethernet-phy@8 {
+		reg = <8>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reset-gpios = <&pio 71 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <221000>;
+		nvmem-cell-names = "firmware";
+		nvmem-cells = <&firmware_factory_200000>;
+	};
+};
+
+&int_2p5g_phy {
+	pinctrl-names = "i2p5gbe-led";
+	pinctrl-0 = <&i2p5gbe_led0_pins>;
+};
+
+&gmac0 {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_ffff4>;
+};
+
+&gmac1 {
+	phy-mode = "internal";
+	phy-connection-type = "internal";
+	phy-handle = <&int_2p5g_phy>;
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_ffffa>;
+};
+
+&gmac2 {
+	phy-mode = "usxgmii";
+	phy-connection-type = "usxgmii";
+	phy = <&phy8>;
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_ffff4>;
+};
+
+&switch {
+	status = "okay";
+
+	ports {
+		port@0 {
+			label = "lan1";
+		};
+
+		port@1 {
+			label = "lan2";
+		};
+
+		port@2 {
+			label = "lan3";
+		};
+
+		port@3 {
+			label = "lan4";
+		};
+	};
+};
+
+&gsw_phy0 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe0_led0_pins>;
+};
+
+&gsw_phy0_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_WHITE>;
+};
+
+&gsw_phy1 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe1_led0_pins>;
+};
+
+&gsw_phy1_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_WHITE>;
+};
+
+&gsw_phy2 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe2_led0_pins>;
+};
+
+&gsw_phy2_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_WHITE>;
+};
+
+&gsw_phy3 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe3_led0_pins>;
+};
+
+&gsw_phy3_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_WHITE>;
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+
+	rt5190a_64: rt5190a@64 {
+		compatible = "richtek,rt5190a";
+		reg = <0x64>;
+		/*interrupts-extended = <&gpio26 0 IRQ_TYPE_LEVEL_LOW>;*/
+		vin2-supply = <&rt5190_buck1>;
+		vin3-supply = <&rt5190_buck1>;
+		vin4-supply = <&rt5190_buck1>;
+
+		regulators {
+			rt5190_buck1: buck1 {
+				regulator-name = "rt5190a-buck1";
+				regulator-min-microvolt = <5090000>;
+				regulator-max-microvolt = <5090000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			buck2 {
+				regulator-name = "vcore";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			rt5190_buck3: buck3 {
+				regulator-name = "vproc";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+			};
+			buck4 {
+				regulator-name = "rt5190a-buck4";
+				regulator-min-microvolt = <850000>;
+				regulator-max-microvolt = <850000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			ldo {
+				regulator-name = "rt5190a-ldo";
+				regulator-min-microvolt = <1200000>;
+				regulator-max-microvolt = <1200000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+		};
+	};
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c1_pins>;
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&pcie3 {
+	status = "okay";
+};
+
+&ssusb0 {
+	status = "okay";
+};
+
+&ssusb1 {
+	status = "okay";
+};
+
+&xsphy {
+	status = "okay";
+};
+
+&tphy {
+	status = "okay";
+};
+
+&serial0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&lvts {
+	status = "okay";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x0400000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1e00>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
+					macaddr_factory_a: macaddr@a {
+						reg = <0xa 0x6>;
+					};
+
+					macaddr_factory_2c0: macaddr@2c0 {
+						reg = <0x2c0 0x6>;
+					};
+
+					macaddr_factory_ffff4: macaddr@ffff4 {
+						reg = <0xffff4 0x6>;
+					};
+
+					macaddr_factory_ffffa: macaddr@ffffa {
+						reg = <0xffffa 0x6>;
+					};
+
+					firmware_factory_200000: firmware@200000 {
+						reg = <0x0200000 0x60002>;
+					};
+				};
+			};
+
+			partition@580000 {
+				label = "FIP";
+				reg = <0x580000 0x0200000>;
+			};
+
+			partition@780000 {
+				label = "ubi";
+				reg = <0x780000 0x7080000>;
+				compatible = "linux,ubi";
+
+				volumes {
+					ubi_rootfs: ubi-volume-fit {
+						volname = "fit";
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+
+	mdio0_pins: mdio0-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio0";
+		};
+
+		conf {
+			groups = "mdc_mdio0";
+			drive-strength = <MTK_DRIVE_8mA>;
+		};
+	};
+
+	gbe0_led0_pins: gbe0-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe0_led0";
+		};
+	};
+
+	gbe1_led0_pins: gbe1-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe1_led0";
+		};
+	};
+
+	gbe2_led0_pins: gbe2-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe2_led0";
+		};
+	};
+
+	gbe3_led0_pins: gbe3-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe3_led0";
+		};
+	};
+
+	i2c0_pins: i2c0-g0-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+
+	i2c1_pins: i2c1-g0-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c1_0";
+		};
+	};
+
+	i2c2_1_pins: i2c2-g1-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c2_1";
+		};
+	};
+
+	i2p5gbe_led0_pins: 2p5gbe-led0-pins {
+		mux {
+			function = "led";
+			groups = "2p5gbe_led0";
+		};
+	};
+
+	mmc0_pins_sdcard: mmc0-sdcard-pins {
+		mux {
+			function = "flash";
+			groups = "sdcard";
+		};
+	};
+
+	spi0_flash_pins: spi0-flash-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -41,6 +41,9 @@ mediatek_setup_interfaces()
 	arcadyan,mozart)
 		ucidef_set_interfaces_lan_wan "lan0 eth1" eth2
 		;;
+	asiarf,ap7988-002)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 eth2" eth1
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax59u|\
 	asus,zenwifi-bt8|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -80,6 +80,7 @@ platform_do_upgrade() {
 	case "$board" in
 	abt,asr3000|\
 	acer,predator-w6x-ubootmod|\
+	asiarf,ap7988-002|\
 	asus,zenwifi-bt8-ubootmod|\
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -393,6 +393,25 @@ define Device/arcadyan_mozart
 endef
 TARGET_DEVICES += arcadyan_mozart
 
+define Device/asiarf_ap7988-002
+  DEVICE_VENDOR := AsiaRF
+  DEVICE_MODEL := AP7988-002
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS := mt7988a-asiarf-ap7988-002
+  DEVICE_PACKAGES := kmod-usb3 fitblk kmod-mt7996-firmware kmod-phy-aquantia mt7988-2p5g-phy-firmware mt7988-wo-firmware
+  DEVICE_DTC_FLAGS := --pad 4096
+  DEVICE_DTS_LOADADDR := 0x45f00000
+  KERNEL_LOADADDR := 0x46000000
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  KERNEL_INITRAMFS_SUFFIX := .itb
+  IMAGES := sysupgrade.itb
+  IMAGE_SIZE := 65536k
+  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
+endef
+TARGET_DEVICES += asiarf_ap7988-002
+
 define Device/asus_rt-ax52
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AX52


### PR DESCRIPTION
WIP
Related PR: #20107

<hr>

**<h1>Specification:</h1>**

- SoC           : MediaTek MT7988A, Quad-core 1.8 GHz ARM Cortex-A73 CPU
- RAM           : DDR4 1 GiB (2x Nanya NT5AD256M16E4-JRI)
- Flash         : SPI-NAND 128 MiB (Macronix MX35LF1GE4AB-Z4I) 
- Ethernet      : 6 ports
  - LAN :
      4x 10/100/1000 Mbps RJ-45 Port
      1x 10/100/1000/2500/5000/10000 Mbps RJ-45 Port (Marvell ARQ113C)
  - WAN :
      1x 10/100/1000/2500 Mbps RJ-45 Port
- LED           : 15x LEDs
    1x Power (Blue, GPIO)
    1x Status (Orange, GPIO)
    3x Wi-Fi (Orange)
    1x M.2 B Key (Red)
    1x M.2 M Key (Red)
    5x Ethernet LAN activity (White)
    3x Ethernet WAN activity (Green)
- UART          : 1x4 pin header on PCB [J6538]
  - arrangement : 3.3V, TX, RX, GND
  - settings    : 115200, 8n1
- Button        : 2x (Reset, WPS)
- GPS           : 1x (Quectel L76-L)
- WiFi          : 3x 
    WiFi 7 2.4/5/6 Ghz (Mediatek MT7996AV, BE19000)
- Socket        :
    1x M.2 B key (USB 3.2)
    1x M.2 M key (PCIe Gen3)
    1x USB-A (USB 3.2)
    1x SIM Card
    1x SD Card
- I2C           :
    1x iio (DPS368)
- Power         : 12V DC, 5A


| Interface  | Mac Address | Read Address |
| ------------- | ------------- | ------------- | 
| WLAN Band1 | 00:0A:52:xx:xx:xx  | Factory, 0x4 |
| WLAN Band2 | 00:0A:52:xx:xx:xx  | Factory, 0xa |
| WLAN Band3 | 00:0A:52:xx:xx:xx  | Factory, 0x2c0 |
| LAN  | 00:0A:52:xx:xx:xx  | Factory, 0xffff4 |
| WAN   | 00:0A:52:xx:xx:xx  | Factory, 0xffffa |



<h2>Bootlog</h2>
<details>

<summary>Factory Bootlog</summary>

```


F0: 102B 0000
FA: 1042 0000
FA: 1042 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 0600 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
MK: 0000 0000 [0000]
T0: 0000 01AD [0101]
Jump to BL

NOTICE:  BL2: v2.13.0(release):v2.4-rc0-9074-g78a0dfd92
NOTICE:  BL2: Built : 10:46:42, Sep 20 2025
NOTICE:  WDT: Cold boot
NOTICE:  WDT: disabled
NOTICE:  CPU: MT7988
NOTICE:  EMI: Using DDR unknown settings
NOTICE:  EMI: Detected DRAM size: 1024 MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  LVTS: Enable thermal HW reset
WARNING: CASN page may not exist. Try to read parameter page.
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc2
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 2 found in block 962
NOTICE:  Second info table with writecount 2 found in block 965
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.9(release):
NOTICE:  BL31: Built : 18:12:07, Oct 13 2023


U-Boot 2025.07-g9a25de54e417-dirty (Sep 20 2025 - 10:46:32 +0000)

CPU:   MediaTek MT7988
Model: mt7988-rfb
       (mediatek,mt7988-spim-nand-rfb)
DRAM:  1 GiB
Core:  52 devices, 13 uclasses, devicetree: separate

Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: CASN page check failed
spi-nand: spi_nand spi_nand@0: Fallback to read ID
spi-nand: spi_nand spi_nand@0: Macronix SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 2 found in block 962
Second info table with writecount 2 found in block 965
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11000000
Out:   serial@11000000
Err:   serial@11000000
Net:   MediaTek MT7988 built-in switch
eth0: ethernet@15110100mtk-eth ethernet@15110200: Firmware date code: 2024/10/30, version: 10.0
mtk-eth ethernet@15110200: Firmware loading/trigger ok.
mtk-eth ethernet@15110200: Fail to set LED pins!
, eth1: ethernet@15110200ethernet@15110300 loading firmware version 'v5.6.9 Mediatek Mediatek 23B 100522 05:37:14'
ethernet@15110300 firmware loading done.
, eth2: ethernet@15110300
*** U-Boot Boot Menu ***Press UP/DOWN to move, ENTER to select, ESC to quit1. Startup system (Default)2. Upgrade firmware3. Upgrade ATF BL24. Upgrade ATF FIP5.   Upgrade ATF BL31 only6.   Upgrade bootloader only7. Upgrade single image8. Load image9. Change boot configuration0. ExitHit any key to stop autoboot: 4 Hit any key to stop autoboot: 3 Hit any key to stop autoboot: 2 Hit any key to stop autoboot: 1 ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 112 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 900, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 2, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 16/11, WL threshold: 4096, image sequence number: 0
ubi0: available PEBs: 0, total reserved PEBs: 900, PEBs reserved for bad PEB handling: 19
No size specified -> Using max size (22855680)
Read 22855680 bytes from volume fit to 0000000050000000
## Loading kernel (any) from FIT Image at 50000000 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.12.68
     Type:         Kernel Image
     Compression:  gzip compressed
     Data Start:   0x50001000
     Data Size:    6097576 Bytes = 5.8 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x46000000
     Entry Point:  0x46000000
     Hash algo:    crc32
     Hash value:   a67d2742
     Hash algo:    sha1
     Hash value:   93687709d86df7ebf839f4b1fa1a98acb7c328b3
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt (any) from FIT Image at 50000000 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt asiarf_ap7988-002 device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x505d2000
     Data Size:    42982 Bytes = 42 KiB
     Architecture: AArch64
     Load Address: 0x45f00000
     Hash algo:    crc32
     Hash value:   efadb951
     Hash algo:    sha1
     Hash value:   d374a610a8c04d4b624a5dc3eb4bdf5a8a779587
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Loading fdt from 0x505d2000 to 0x45f00000
   Booting using the fdt blob at 0x45f00000
Working FDT set to 45f00000
## Loading loadables (any) from FIT Image at 50000000 ...
   Trying 'rootfs-1' loadables subimage
     Description:  ARM64 OpenWrt asiarf_ap7988-002 rootfs
     Type:         Filesystem Image
     Compression:  uncompressed
     Data Start:   0x505dd000
     Data Size:    16515072 Bytes = 15.8 MiB
     Hash algo:    crc32
     Hash value:   39474a37
     Hash algo:    sha1
     Hash value:   756946553c0262ae61791c29a6e3cb9a879cb371
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Uncompressing Kernel Image to 46000000
   Loading Device Tree to 000000007e7ec000, end 000000007e7f97e5 ... OK
Working FDT set to 7e7ec000
set /chosen/rootdisk to bootrom media: rootdisk-spim-nand (phandle 0x0000005c)
FIT volume for fitblk set to 'fit'

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x411fd090]
[    0.000000] Linux version 6.12.68 (elwin@ubuntu-2204) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r31132+1237-6b681fd285) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Thu Feb  5 06:32:20 2026
[    0.000000] Machine model: AsaiRF AP7988-002
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004304ffff (320 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x0000000047cc0000..0x0000000047dbffff (1024 KiB) nomap non-reusable wmcpu-reserved@47cc0000
[    0.000000] OF: reserved mem: 0x000000004f600000..0x000000004f63ffff (256 KiB) nomap non-reusable wo-emi@4f600000
[    0.000000] OF: reserved mem: 0x000000004f640000..0x000000004f67ffff (256 KiB) nomap non-reusable wo-emi@4f640000
[    0.000000] OF: reserved mem: 0x000000004f680000..0x000000004f6bffff (256 KiB) nomap non-reusable wo-emi@4f680000
[    0.000000] OF: reserved mem: 0x000000004f700000..0x000000004fefffff (8192 KiB) nomap non-reusable wo-data@4f700000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000007fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004304ffff]
[    0.000000]   node   0: [mem 0x0000000043050000-0x0000000047cbffff]
[    0.000000]   node   0: [mem 0x0000000047cc0000-0x0000000047dbffff]
[    0.000000]   node   0: [mem 0x0000000047dc0000-0x000000004f5fffff]
[    0.000000]   node   0: [mem 0x000000004f600000-0x000000004f6bffff]
[    0.000000]   node   0: [mem 0x000000004f6c0000-0x000000004f6fffff]
[    0.000000]   node   0: [mem 0x000000004f700000-0x000000004fefffff]
[    0.000000]   node   0: [mem 0x000000004ff00000-0x000000007fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000007fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.4
[    0.000000] percpu: Embedded 20 pages/cpu s42520 r8192 d31208 u81920
[    0.000000] pcpu-alloc: s42520 r8192 d31208 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: detected: Spectre-BHB
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: pci=pcie_bus_perf ubi.block=0,fit root=/dev/fit0 rootwait
[    0.000000] Dentry cache hash table entries: 131072 (order: 8, 1048576 bytes, linear)
[    0.000000] Inode-cache hash table entries: 65536 (order: 7, 524288 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 262144
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 1MB
[    0.000000] software IO TLB: area num 4.
[    0.000000] software IO TLB: mapped [mem 0x000000007ea80000-0x000000007eb80000] (1MB)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks Trace: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=4.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 416 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: GICD_CTRL.DS=0, SCR_EL3.FIQ=0
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000063] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000070] pid_max: default: 32768 minimum: 301
[    0.002137] Mount-cache hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.002144] Mountpoint-cache hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.003670] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.004147] rcu: Hierarchical SRCU implementation.
[    0.004149] rcu: 	Max phase no-delay instances is 1000.
[    0.004242] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.004421] smp: Bringing up secondary CPUs ...
[    0.004651] Detected VIPT I-cache on CPU1
[    0.004692] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.004714] CPU1: Booted secondary processor 0x0000000001 [0x411fd090]
[    0.005001] Detected VIPT I-cache on CPU2
[    0.005022] GICv3: CPU2: found redistributor 2 region 0:0x000000000c0c0000
[    0.005032] CPU2: Booted secondary processor 0x0000000002 [0x411fd090]
[    0.005280] Detected VIPT I-cache on CPU3
[    0.005303] GICv3: CPU3: found redistributor 3 region 0:0x000000000c0e0000
[    0.005313] CPU3: Booted secondary processor 0x0000000003 [0x411fd090]
[    0.005348] smp: Brought up 1 node, 4 CPUs
[    0.005353] SMP: Total of 4 processors activated.
[    0.005355] CPU: All CPU(s) started at EL2
[    0.005357] CPU features: detected: 32-bit EL0 Support
[    0.005360] CPU features: detected: CRC32 instructions
[    0.005387] alternatives: applying system-wide alternatives
[    0.005469] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.005586] Memory: 999196K/1048576K available (9280K kernel code, 984K rwdata, 2764K rodata, 448K init, 300K bss, 45940K reserved, 0K cma-reserved)
[    0.008327] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.008338] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.008390] 29280 pages in range for non-PLT usage
[    0.008393] 520800 pages in range for PLT usage
[    0.009501] pinctrl core: initialized pinctrl subsystem
[    0.010414] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.010678] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.010709] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.010736] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.011000] thermal_sys: Registered thermal governor 'fair_share'
[    0.011002] thermal_sys: Registered thermal governor 'bang_bang'
[    0.011004] thermal_sys: Registered thermal governor 'step_wise'
[    0.011006] thermal_sys: Registered thermal governor 'user_space'
[    0.011044] ASID allocator initialised with 65536 entries
[    0.011534] pstore: Using crash dump compression: deflate
[    0.011540] printk: legacy console [ramoops0] enabled
[    0.011812] pstore: Registered ramoops as persistent store backend
[    0.011817] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.013647] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.017050] /soc/pcie@11290000: Fixed dependency cycle(s) with /soc/pcie@11290000/interrupt-controller
[    0.017163] /soc/pcie@11300000: Fixed dependency cycle(s) with /soc/pcie@11300000/interrupt-controller
[    0.017268] /soc/pcie@11310000: Fixed dependency cycle(s) with /soc/pcie@11310000/interrupt-controller
[    0.027156] cryptd: max_cpu_qlen set to 1000
[    0.028875] SCSI subsystem initialized
[    0.028970] libata version 3.00 loaded.
[    0.030028] clocksource: Switched to clocksource arch_sys_counter
[    0.031734] NET: Registered PF_INET protocol family
[    0.031821] IP idents hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.032892] tcp_listen_portaddr_hash hash table entries: 512 (order: 1, 8192 bytes, linear)
[    0.032906] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.032915] TCP established hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.032948] TCP bind hash table entries: 8192 (order: 6, 262144 bytes, linear)
[    0.033058] TCP: Hash tables configured (established 8192 bind 8192)
[    0.033297] MPTCP token hash table entries: 1024 (order: 3, 24576 bytes, linear)
[    0.033373] UDP hash table entries: 512 (order: 2, 16384 bytes, linear)
[    0.033391] UDP-Lite hash table entries: 512 (order: 2, 16384 bytes, linear)
[    0.033531] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.033565] PCI: CLS 0 bytes, default 64
[    0.034329] workingset: timestamp_bits=46 max_order=18 bucket_order=0
[    0.038221] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.038230] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.070265] mtk-xsphy soc:xs-phy@11e10000: failed to get ref_clk(id-1)
[    0.070820] mtk-pcie-gen3 11290000.pcie: host bridge /soc/pcie@11290000 ranges:
[    0.070837] mtk-pcie-gen3 11290000.pcie: Parsing ranges property...
[    0.070854] mtk-pcie-gen3 11290000.pcie:       IO 0x0028000000..0x00281fffff -> 0x0028000000
[    0.070875] mtk-pcie-gen3 11290000.pcie:      MEM 0x0028200000..0x002fffffff -> 0x0028200000
[    0.070910] /soc/pcie@11290000: Failed to get clk index: 0 ret: -517
[    0.070920] mtk-pcie-gen3 11290000.pcie: failed to get clocks
[    0.070993] mtk-pcie-gen3 11300000.pcie: host bridge /soc/pcie@11300000 ranges:
[    0.071004] mtk-pcie-gen3 11300000.pcie: Parsing ranges property...
[    0.071017] mtk-pcie-gen3 11300000.pcie:       IO 0x0030000000..0x00301fffff -> 0x0030000000
[    0.071027] mtk-pcie-gen3 11300000.pcie:      MEM 0x0030200000..0x0037ffffff -> 0x0030200000
[    0.071046] /soc/pcie@11300000: Failed to get clk index: 0 ret: -517
[    0.071054] mtk-pcie-gen3 11300000.pcie: failed to get clocks
[    0.071139] mtk-pcie-gen3 11310000.pcie: host bridge /soc/pcie@11310000 ranges:
[    0.071148] mtk-pcie-gen3 11310000.pcie: Parsing ranges property...
[    0.071160] mtk-pcie-gen3 11310000.pcie:       IO 0x0038000000..0x00381fffff -> 0x0038000000
[    0.071171] mtk-pcie-gen3 11310000.pcie:      MEM 0x0038200000..0x003fffffff -> 0x0038200000
[    0.071189] /soc/pcie@11310000: Failed to get clk index: 0 ret: -517
[    0.071197] mtk-pcie-gen3 11310000.pcie: failed to get clocks
[    0.075747] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.076496] printk: legacy console [ttyS0] disabled
[    0.096745] 11000000.serial: ttyS0 at MMIO 0x11000000 (irq = 99, base_baud = 2500000) is a ST16650V2
[    0.096784] printk: legacy console [ttyS0] enabled
[    1.119061] 11000100.serial: ttyS1 at MMIO 0x11000100 (irq = 100, base_baud = 2500000) is a ST16650V2
[    1.128976] random: crng init done
[    1.133907] loop: module loaded
[    1.138446] spi-nand spi0.0: Macronix SPI NAND was found.
[    1.143888] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    1.152315] Signature found at block 1023 [0x07fe0000]
[    1.157444] NMBM management region starts at block 960 [0x07800000]
[    1.165823] First info table with writecount 2 found in block 962
[    1.173955] Second info table with writecount 2 found in block 965
[    1.180147] NMBM has been successfully attached
[    1.184799] 5 fixed-partitions partitions found on MTD device spi0.0
[    1.191329] Creating 5 MTD partitions on "spi0.0":
[    1.196111] 0x000000000000-0x000000100000 : "BL2"
[    1.201501] 0x000000100000-0x000000180000 : "u-boot-env"
[    1.207182] 0x000000180000-0x000000580000 : "Factory"
[    1.214011] 0x000000580000-0x000000780000 : "FIP"
[    1.219580] 0x000000780000-0x000007800000 : "ubi"
[    1.273085] ubi0: default fastmap pool size: 45
[    1.277608] ubi0: default fastmap WL pool size: 22
[    1.282395] ubi0: attaching mtd4
[    1.616774] ubi0: scanning is finished
[    1.624079] ubi0 warning: ubi_eba_init: cannot reserve enough PEBs for bad PEB handling, reserved 17, need 19
[    1.634263] ubi0: attached mtd4 (name "ubi", size 112 MiB)
[    1.639739] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    1.646608] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    1.653386] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    1.660336] ubi0: good PEBs: 900, bad PEBs: 0, corrupted PEBs: 0
[    1.666330] ubi0: user volume: 2, internal volumes: 1, max. volumes count: 128
[    1.673541] ubi0: max/mean erase counter: 16/11, WL threshold: 4096, image sequence number: 0
[    1.682054] ubi0: available PEBs: 0, total reserved PEBs: 900, PEBs reserved for bad PEB handling: 17
[    1.691267] ubi0: background thread "ubi_bgt0d" started, PID 240
[    1.691521] block ubiblock0_0: created from ubi0:0(fit)
[    1.821599] i2c_dev: i2c /dev entries driver
[    1.826321] /soc/i2c@11003000/rt5190a@64: Fixed dependency cycle(s) with /soc/i2c@11003000/rt5190a@64/regulators/buck1
[    1.838002] mtk-lvts-thermal 1100a000.lvts: golden temp=60
[    1.844939] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.853520] mtk-msdc 11230000.mmc: Got CD GPIO
[    1.853702] NET: Registered PF_INET6 protocol family
[    1.863426] Segment Routing with IPv6
[    1.867097] In-situ OAM (IOAM) with IPv6
[    1.871047] NET: Registered PF_PACKET protocol family
[    1.876142] 8021q: 802.1Q VLAN Support v1.8
[    1.893147] phy phy-soc:xs-phy@11e10000.3: type_sw - reg 0x194, index 0
[    1.900361] mtk-pcie-gen3 11290000.pcie: host bridge /soc/pcie@11290000 ranges:
[    1.907675] mtk-pcie-gen3 11290000.pcie: Parsing ranges property...
[    1.913964] mtk-pcie-gen3 11290000.pcie:       IO 0x0028000000..0x00281fffff -> 0x0028000000
[    1.922411] mtk-pcie-gen3 11290000.pcie:      MEM 0x0028200000..0x002fffffff -> 0x0028200000
[    2.248935] mtk-pcie-gen3 11290000.pcie: set IO trans window[0]: cpu_addr = 0x28000000, pci_addr = 0x28000000, size = 0x200000
[    2.260340] mtk-pcie-gen3 11290000.pcie: set MEM trans window[1]: cpu_addr = 0x28200000, pci_addr = 0x28200000, size = 0x200000
[    2.271809] mtk-pcie-gen3 11290000.pcie: set MEM trans window[2]: cpu_addr = 0x28400000, pci_addr = 0x28400000, size = 0x400000
[    2.283274] mtk-pcie-gen3 11290000.pcie: set MEM trans window[3]: cpu_addr = 0x28800000, pci_addr = 0x28800000, size = 0x800000
[    2.294738] mtk-pcie-gen3 11290000.pcie: set MEM trans window[4]: cpu_addr = 0x29000000, pci_addr = 0x29000000, size = 0x1000000
[    2.306289] mtk-pcie-gen3 11290000.pcie: set MEM trans window[5]: cpu_addr = 0x2a000000, pci_addr = 0x2a000000, size = 0x2000000
[    2.317839] mtk-pcie-gen3 11290000.pcie: set MEM trans window[6]: cpu_addr = 0x2c000000, pci_addr = 0x2c000000, size = 0x4000000
[    2.329691] mtk-pcie-gen3 11290000.pcie: PCI host bridge to bus 0002:00
[    2.336307] pci_bus 0002:00: root bus resource [bus 00-ff]
[    2.341789] pci_bus 0002:00: root bus resource [io  0x0000-0x1fffff] (bus address [0x28000000-0x281fffff])
[    2.351436] pci_bus 0002:00: root bus resource [mem 0x28200000-0x2fffffff]
[    2.358299] pci_bus 0002:00: scanning bus
[    2.362329] pci 0002:00:00.0: [14c3:7988] type 01 class 0x060400 PCIe Root Port
[    2.369638] pci 0002:00:00.0: BAR 0 [mem 0x00000000-0x00007fff 64bit]
[    2.376080] pci 0002:00:00.0: PCI bridge to [bus 00]
[    2.381040] pci 0002:00:00.0:   bridge window [io  0x0000-0x0fff]
[    2.387124] pci 0002:00:00.0:   bridge window [mem 0x00000000-0x000fffff]
[    2.393914] pci 0002:00:00.0:   bridge window [mem 0x00000000-0x000fffff 64bit pref]
[    2.401705] pci 0002:00:00.0: PME# supported from D0 D3hot D3cold
[    2.407789] pci 0002:00:00.0: PME# disabled
[    2.413025] pci_bus 0002:00: fixups for bus
[    2.417200] pci 0002:00:00.0: scanning [bus 00-00] behind bridge, pass 0
[    2.423895] pci 0002:00:00.0: bridge configuration invalid ([bus 00-00]), reconfiguring
[    2.431897] pci 0002:00:00.0: scanning [bus 00-00] behind bridge, pass 1
[    2.438629] pci_bus 0002:01: scanning bus
[    2.442660] pci 0002:01:00.0: [1e95:100e] type 00 class 0x010802 PCIe Endpoint
[    2.449892] pci 0002:01:00.0: BAR 0 [mem 0x00000000-0x00003fff 64bit]
[    2.456357] pci 0002:01:00.0: BAR 5 [mem 0x00000000-0x00001fff]
[    2.462428] pci 0002:01:00.0: 7.876 Gb/s available PCIe bandwidth, limited by 8.0 GT/s PCIe x1 link at 0002:00:00.0 (capable of 31.504 Gb/s with 8.0 GT/s PCIe x4 link)
[    2.490069] pci_bus 0002:01: fixups for bus
[    2.494245] pci_bus 0002:01: bus scan returning with max=01
[    2.499807] pci_bus 0002:01: busn_res: [bus 01-ff] end is updated to 01
[    2.506425] pci_bus 0002:00: bus scan returning with max=01
[    2.512003] pci 0002:00:00.0: bridge window [mem 0x28200000-0x282fffff]: assigned
[    2.519475] pci 0002:00:00.0: BAR 0 [mem 0x28300000-0x28307fff 64bit]: assigned
[    2.526783] pci 0002:01:00.0: BAR 0 [mem 0x28200000-0x28203fff 64bit]: assigned
[    2.534095] pci 0002:01:00.0: BAR 5 [mem 0x28204000-0x28205fff]: assigned
[    2.540877] pci 0002:00:00.0: PCI bridge to [bus 01]
[    2.545833] pci 0002:00:00.0:   bridge window [mem 0x28200000-0x282fffff]
[    2.552615] pci_bus 0002:00: resource 4 [io  0x0000-0x1fffff]
[    2.558350] pci_bus 0002:00: resource 5 [mem 0x28200000-0x2fffffff]
[    2.564608] pci_bus 0002:01: resource 1 [mem 0x28200000-0x282fffff]
[    2.570873] pci 0002:00:00.0: Max Payload Size set to  256/ 256 (was  128), Max Read Rq  256
[    2.579314] pci 0002:01:00.0: Max Payload Size set to  256/ 512 (was  128), Max Read Rq  256
[    2.587843] pcieport 0002:00:00.0: assign IRQ: got 114
[    2.592981] pcieport 0002:00:00.0: enabling device (0000 -> 0002)
[    2.599072] pcieport 0002:00:00.0: enabling bus mastering
[    2.604825] mtk-pcie-gen3 11290000.pcie: msi#0x0 address_hi 0x0 address_lo 0x11290c00 data 0
[    2.613264] mtk-pcie-gen3 11290000.pcie: msi#0x1 address_hi 0x0 address_lo 0x11290c00 data 1
[    2.621693] mtk-pcie-gen3 11290000.pcie: msi#0x2 address_hi 0x0 address_lo 0x11290c00 data 2
[    2.630120] mtk-pcie-gen3 11290000.pcie: msi#0x3 address_hi 0x0 address_lo 0x11290c00 data 3
[    2.638545] mtk-pcie-gen3 11290000.pcie: msi#0x4 address_hi 0x0 address_lo 0x11290c00 data 4
[    2.646971] mtk-pcie-gen3 11290000.pcie: msi#0x5 address_hi 0x0 address_lo 0x11290c00 data 5
[    2.655400] mtk-pcie-gen3 11290000.pcie: msi#0x6 address_hi 0x0 address_lo 0x11290c00 data 6
[    2.663827] mtk-pcie-gen3 11290000.pcie: msi#0x7 address_hi 0x0 address_lo 0x11290c00 data 7
[    2.672254] mtk-pcie-gen3 11290000.pcie: msi#0x8 address_hi 0x0 address_lo 0x11290c00 data 8
[    2.680680] mtk-pcie-gen3 11290000.pcie: msi#0x9 address_hi 0x0 address_lo 0x11290c00 data 9
[    2.689104] mtk-pcie-gen3 11290000.pcie: msi#0xa address_hi 0x0 address_lo 0x11290c00 data 10
[    2.697617] mtk-pcie-gen3 11290000.pcie: msi#0xb address_hi 0x0 address_lo 0x11290c00 data 11
[    2.706130] mtk-pcie-gen3 11290000.pcie: msi#0xc address_hi 0x0 address_lo 0x11290c00 data 12
[    2.714643] mtk-pcie-gen3 11290000.pcie: msi#0xd address_hi 0x0 address_lo 0x11290c00 data 13
[    2.723158] mtk-pcie-gen3 11290000.pcie: msi#0xe address_hi 0x0 address_lo 0x11290c00 data 14
[    2.731672] mtk-pcie-gen3 11290000.pcie: msi#0xf address_hi 0x0 address_lo 0x11290c00 data 15
[    2.740185] mtk-pcie-gen3 11290000.pcie: msi#0x10 address_hi 0x0 address_lo 0x11290c00 data 16
[    2.748782] mtk-pcie-gen3 11290000.pcie: msi#0x11 address_hi 0x0 address_lo 0x11290c00 data 17
[    2.757382] mtk-pcie-gen3 11290000.pcie: msi#0x12 address_hi 0x0 address_lo 0x11290c00 data 18
[    2.765982] mtk-pcie-gen3 11290000.pcie: msi#0x13 address_hi 0x0 address_lo 0x11290c00 data 19
[    2.774584] mtk-pcie-gen3 11290000.pcie: msi#0x14 address_hi 0x0 address_lo 0x11290c00 data 20
[    2.783184] mtk-pcie-gen3 11290000.pcie: msi#0x15 address_hi 0x0 address_lo 0x11290c00 data 21
[    2.791784] mtk-pcie-gen3 11290000.pcie: msi#0x16 address_hi 0x0 address_lo 0x11290c00 data 22
[    2.800383] mtk-pcie-gen3 11290000.pcie: msi#0x17 address_hi 0x0 address_lo 0x11290c00 data 23
[    2.808981] mtk-pcie-gen3 11290000.pcie: msi#0x18 address_hi 0x0 address_lo 0x11290c00 data 24
[    2.817580] mtk-pcie-gen3 11290000.pcie: msi#0x19 address_hi 0x0 address_lo 0x11290c00 data 25
[    2.826180] mtk-pcie-gen3 11290000.pcie: msi#0x1a address_hi 0x0 address_lo 0x11290c00 data 26
[    2.834781] mtk-pcie-gen3 11290000.pcie: msi#0x1b address_hi 0x0 address_lo 0x11290c00 data 27
[    2.843381] mtk-pcie-gen3 11290000.pcie: msi#0x1c address_hi 0x0 address_lo 0x11290c00 data 28
[    2.851981] mtk-pcie-gen3 11290000.pcie: msi#0x1d address_hi 0x0 address_lo 0x11290c00 data 29
[    2.860581] mtk-pcie-gen3 11290000.pcie: msi#0x1e address_hi 0x0 address_lo 0x11290c00 data 30
[    2.869178] mtk-pcie-gen3 11290000.pcie: msi#0x1f address_hi 0x0 address_lo 0x11290c00 data 31
[    2.878177] mtk-pcie-gen3 11290000.pcie: msi#0x0 address_hi 0x0 address_lo 0x11290c00 data 0
[    2.886680] pcieport 0002:00:00.0: PME: Signaling with IRQ 115
[    2.892628] pcieport 0002:00:00.0: AER: enabled with IRQ 115
[    2.898313] pcieport 0002:00:00.0: save config 0x00: 0x798814c3
[    2.904230] pcieport 0002:00:00.0: save config 0x04: 0x00100406
[    2.910143] pcieport 0002:00:00.0: save config 0x08: 0x06040001
[    2.916051] pcieport 0002:00:00.0: save config 0x0c: 0x00010000
[    2.921962] pcieport 0002:00:00.0: save config 0x10: 0x28300004
[    2.927870] pcieport 0002:00:00.0: save config 0x14: 0x00000000
[    2.933781] pcieport 0002:00:00.0: save config 0x18: 0x00010100
[    2.939688] pcieport 0002:00:00.0: save config 0x1c: 0x000001f1
[    2.945600] pcieport 0002:00:00.0: save config 0x20: 0x28202820
[    2.951511] pcieport 0002:00:00.0: save config 0x24: 0x0001fff1
[    2.957418] pcieport 0002:00:00.0: save config 0x28: 0x00000000
[    2.963328] pcieport 0002:00:00.0: save config 0x2c: 0x00000000
[    2.969237] pcieport 0002:00:00.0: save config 0x30: 0x00000000
[    2.975147] pcieport 0002:00:00.0: save config 0x34: 0x00000080
[    2.981057] pcieport 0002:00:00.0: save config 0x38: 0x00000000
[    2.986965] pcieport 0002:00:00.0: save config 0x3c: 0x00020172
[    2.993158] mtk-pcie-gen3 11300000.pcie: host bridge /soc/pcie@11300000 ranges:
[    3.000469] mtk-pcie-gen3 11300000.pcie: Parsing ranges property...
[    3.006737] mtk-pcie-gen3 11300000.pcie:       IO 0x0030000000..0x00301fffff -> 0x0030000000
[    3.015177] mtk-pcie-gen3 11300000.pcie:      MEM 0x0030200000..0x0037ffffff -> 0x0030200000
[    3.243840] mtk-pcie-gen3 11300000.pcie: set IO trans window[0]: cpu_addr = 0x30000000, pci_addr = 0x30000000, size = 0x200000
[    3.255225] mtk-pcie-gen3 11300000.pcie: set MEM trans window[1]: cpu_addr = 0x30200000, pci_addr = 0x30200000, size = 0x200000
[    3.266691] mtk-pcie-gen3 11300000.pcie: set MEM trans window[2]: cpu_addr = 0x30400000, pci_addr = 0x30400000, size = 0x400000
[    3.278156] mtk-pcie-gen3 11300000.pcie: set MEM trans window[3]: cpu_addr = 0x30800000, pci_addr = 0x30800000, size = 0x800000
[    3.289620] mtk-pcie-gen3 11300000.pcie: set MEM trans window[4]: cpu_addr = 0x31000000, pci_addr = 0x31000000, size = 0x1000000
[    3.301172] mtk-pcie-gen3 11300000.pcie: set MEM trans window[5]: cpu_addr = 0x32000000, pci_addr = 0x32000000, size = 0x2000000
[    3.312723] mtk-pcie-gen3 11300000.pcie: set MEM trans window[6]: cpu_addr = 0x34000000, pci_addr = 0x34000000, size = 0x4000000
[    3.324404] mtk-pcie-gen3 11300000.pcie: PCI host bridge to bus 0000:00
[    3.331018] pci_bus 0000:00: root bus resource [bus 00-ff]
[    3.336496] pci_bus 0000:00: root bus resource [io  0x200000-0x3fffff] (bus address [0x30000000-0x301fffff])
[    3.346312] pci_bus 0000:00: root bus resource [mem 0x30200000-0x37ffffff]
[    3.353183] pci_bus 0000:00: scanning bus
[    3.357243] pci 0000:00:00.0: [14c3:7988] type 01 class 0x060400 PCIe Root Port
[    3.364556] pci 0000:00:00.0: BAR 0 [mem 0x00000000-0x00007fff 64bit]
[    3.370995] pci 0000:00:00.0: PCI bridge to [bus 00]
[    3.375952] pci 0000:00:00.0:   bridge window [io  0x0000-0x0fff]
[    3.382037] pci 0000:00:00.0:   bridge window [mem 0x00000000-0x000fffff]
[    3.388818] pci 0000:00:00.0:   bridge window [mem 0x00000000-0x000fffff 64bit pref]
[    3.396607] pci 0000:00:00.0: PME# supported from D0 D3hot D3cold
[    3.402694] pci 0000:00:00.0: PME# disabled
[    3.407985] pci_bus 0000:00: fixups for bus
[    3.412169] pci 0000:00:00.0: scanning [bus 00-00] behind bridge, pass 0
[    3.418860] pci 0000:00:00.0: bridge configuration invalid ([bus 00-00]), reconfiguring
[    3.426858] pci 0000:00:00.0: scanning [bus 00-00] behind bridge, pass 1
[    3.433608] pci_bus 0000:01: scanning bus
[    3.437653] pci 0000:01:00.0: [14c3:7990] type 00 class 0x028000 PCIe Endpoint
[    3.444890] pci 0000:01:00.0: BAR 0 [mem 0x00000000-0x001fffff 64bit pref]
[    3.451771] pci 0000:01:00.0: BAR 2 [mem 0x00000000-0x00007fff 64bit]
[    3.458312] pci 0000:01:00.0: PME# supported from D0 D3hot D3cold
[    3.464401] pci 0000:01:00.0: PME# disabled
[    3.480065] pci_bus 0000:01: fixups for bus
[    3.484239] pci_bus 0000:01: bus scan returning with max=01
[    3.489801] pci_bus 0000:01: busn_res: [bus 01-ff] end is updated to 01
[    3.496414] pci_bus 0000:00: bus scan returning with max=01
[    3.501989] pci 0000:00:00.0: bridge window [mem 0x30200000-0x303fffff 64bit pref]: assigned
[    3.510420] pci 0000:00:00.0: bridge window [mem 0x30400000-0x304fffff]: assigned
[    3.517891] pci 0000:00:00.0: BAR 0 [mem 0x30500000-0x30507fff 64bit]: assigned
[    3.525200] pci 0000:01:00.0: BAR 0 [mem 0x30200000-0x303fffff 64bit pref]: assigned
[    3.532947] pci 0000:01:00.0: BAR 2 [mem 0x30400000-0x30407fff 64bit]: assigned
[    3.540256] pci 0000:00:00.0: PCI bridge to [bus 01]
[    3.545212] pci 0000:00:00.0:   bridge window [mem 0x30400000-0x304fffff]
[    3.551994] pci 0000:00:00.0:   bridge window [mem 0x30200000-0x303fffff 64bit pref]
[    3.559727] pci_bus 0000:00: resource 4 [io  0x200000-0x3fffff]
[    3.565637] pci_bus 0000:00: resource 5 [mem 0x30200000-0x37ffffff]
[    3.571897] pci_bus 0000:01: resource 1 [mem 0x30400000-0x304fffff]
[    3.578152] pci_bus 0000:01: resource 2 [mem 0x30200000-0x303fffff 64bit pref]
[    3.585376] pci 0000:00:00.0: Max Payload Size set to  256/ 256 (was  128), Max Read Rq  256
[    3.593820] pci 0000:01:00.0: Max Payload Size set to  256/ 256 (was  128), Max Read Rq  256
[    3.602328] pcieport 0000:00:00.0: assign IRQ: got 117
[    3.607460] pcieport 0000:00:00.0: enabling device (0000 -> 0002)
[    3.613558] pcieport 0000:00:00.0: enabling bus mastering
[    3.619297] mtk-pcie-gen3 11300000.pcie: msi#0x0 address_hi 0x0 address_lo 0x11300c00 data 0
[    3.627733] mtk-pcie-gen3 11300000.pcie: msi#0x1 address_hi 0x0 address_lo 0x11300c00 data 1
[    3.636166] mtk-pcie-gen3 11300000.pcie: msi#0x2 address_hi 0x0 address_lo 0x11300c00 data 2
[    3.644593] mtk-pcie-gen3 11300000.pcie: msi#0x3 address_hi 0x0 address_lo 0x11300c00 data 3
[    3.653022] mtk-pcie-gen3 11300000.pcie: msi#0x4 address_hi 0x0 address_lo 0x11300c00 data 4
[    3.661449] mtk-pcie-gen3 11300000.pcie: msi#0x5 address_hi 0x0 address_lo 0x11300c00 data 5
[    3.669874] mtk-pcie-gen3 11300000.pcie: msi#0x6 address_hi 0x0 address_lo 0x11300c00 data 6
[    3.678302] mtk-pcie-gen3 11300000.pcie: msi#0x7 address_hi 0x0 address_lo 0x11300c00 data 7
[    3.686730] mtk-pcie-gen3 11300000.pcie: msi#0x8 address_hi 0x0 address_lo 0x11300c00 data 8
[    3.695159] mtk-pcie-gen3 11300000.pcie: msi#0x9 address_hi 0x0 address_lo 0x11300c00 data 9
[    3.703585] mtk-pcie-gen3 11300000.pcie: msi#0xa address_hi 0x0 address_lo 0x11300c00 data 10
[    3.712101] mtk-pcie-gen3 11300000.pcie: msi#0xb address_hi 0x0 address_lo 0x11300c00 data 11
[    3.720617] mtk-pcie-gen3 11300000.pcie: msi#0xc address_hi 0x0 address_lo 0x11300c00 data 12
[    3.729127] mtk-pcie-gen3 11300000.pcie: msi#0xd address_hi 0x0 address_lo 0x11300c00 data 13
[    3.737643] mtk-pcie-gen3 11300000.pcie: msi#0xe address_hi 0x0 address_lo 0x11300c00 data 14
[    3.746157] mtk-pcie-gen3 11300000.pcie: msi#0xf address_hi 0x0 address_lo 0x11300c00 data 15
[    3.754672] mtk-pcie-gen3 11300000.pcie: msi#0x10 address_hi 0x0 address_lo 0x11300c00 data 16
[    3.763272] mtk-pcie-gen3 11300000.pcie: msi#0x11 address_hi 0x0 address_lo 0x11300c00 data 17
[    3.771875] mtk-pcie-gen3 11300000.pcie: msi#0x12 address_hi 0x0 address_lo 0x11300c00 data 18
[    3.780475] mtk-pcie-gen3 11300000.pcie: msi#0x13 address_hi 0x0 address_lo 0x11300c00 data 19
[    3.789072] mtk-pcie-gen3 11300000.pcie: msi#0x14 address_hi 0x0 address_lo 0x11300c00 data 20
[    3.797674] mtk-pcie-gen3 11300000.pcie: msi#0x15 address_hi 0x0 address_lo 0x11300c00 data 21
[    3.806275] mtk-pcie-gen3 11300000.pcie: msi#0x16 address_hi 0x0 address_lo 0x11300c00 data 22
[    3.814877] mtk-pcie-gen3 11300000.pcie: msi#0x17 address_hi 0x0 address_lo 0x11300c00 data 23
[    3.823477] mtk-pcie-gen3 11300000.pcie: msi#0x18 address_hi 0x0 address_lo 0x11300c00 data 24
[    3.832079] mtk-pcie-gen3 11300000.pcie: msi#0x19 address_hi 0x0 address_lo 0x11300c00 data 25
[    3.840681] mtk-pcie-gen3 11300000.pcie: msi#0x1a address_hi 0x0 address_lo 0x11300c00 data 26
[    3.849278] mtk-pcie-gen3 11300000.pcie: msi#0x1b address_hi 0x0 address_lo 0x11300c00 data 27
[    3.857880] mtk-pcie-gen3 11300000.pcie: msi#0x1c address_hi 0x0 address_lo 0x11300c00 data 28
[    3.866480] mtk-pcie-gen3 11300000.pcie: msi#0x1d address_hi 0x0 address_lo 0x11300c00 data 29
[    3.875083] mtk-pcie-gen3 11300000.pcie: msi#0x1e address_hi 0x0 address_lo 0x11300c00 data 30
[    3.883683] mtk-pcie-gen3 11300000.pcie: msi#0x1f address_hi 0x0 address_lo 0x11300c00 data 31
[    3.892678] mtk-pcie-gen3 11300000.pcie: msi#0x0 address_hi 0x0 address_lo 0x11300c00 data 0
[    3.901182] pcieport 0000:00:00.0: PME: Signaling with IRQ 118
[    3.907126] pcieport 0000:00:00.0: AER: enabled with IRQ 118
[    3.912821] pcieport 0000:00:00.0: save config 0x00: 0x798814c3
[    3.918731] pcieport 0000:00:00.0: save config 0x04: 0x00100406
[    3.924645] pcieport 0000:00:00.0: save config 0x08: 0x06040001
[    3.930556] pcieport 0000:00:00.0: save config 0x0c: 0x00010000
[    3.936464] pcieport 0000:00:00.0: save config 0x10: 0x30500004
[    3.942374] pcieport 0000:00:00.0: save config 0x14: 0x00000000
[    3.948281] pcieport 0000:00:00.0: save config 0x18: 0x00010100
[    3.954191] pcieport 0000:00:00.0: save config 0x1c: 0x000001f1
[    3.960103] pcieport 0000:00:00.0: save config 0x20: 0x30403040
[    3.966011] pcieport 0000:00:00.0: save config 0x24: 0x30313021
[    3.971921] pcieport 0000:00:00.0: save config 0x28: 0x00000000
[    3.977829] pcieport 0000:00:00.0: save config 0x2c: 0x00000000
[    3.983739] pcieport 0000:00:00.0: save config 0x30: 0x00000000
[    3.989648] pcieport 0000:00:00.0: save config 0x34: 0x00000080
[    3.995558] pcieport 0000:00:00.0: save config 0x38: 0x00000000
[    4.001469] pcieport 0000:00:00.0: save config 0x3c: 0x00020175
[    4.007680] mtk-pcie-gen3 11310000.pcie: host bridge /soc/pcie@11310000 ranges:
[    4.014990] mtk-pcie-gen3 11310000.pcie: Parsing ranges property...
[    4.021260] mtk-pcie-gen3 11310000.pcie:       IO 0x0038000000..0x00381fffff -> 0x0038000000
[    4.029693] mtk-pcie-gen3 11310000.pcie:      MEM 0x0038200000..0x003fffffff -> 0x0038200000
[    4.254098] mtk-pcie-gen3 11310000.pcie: set IO trans window[0]: cpu_addr = 0x38000000, pci_addr = 0x38000000, size = 0x200000
[    4.265486] mtk-pcie-gen3 11310000.pcie: set MEM trans window[1]: cpu_addr = 0x38200000, pci_addr = 0x38200000, size = 0x200000
[    4.276951] mtk-pcie-gen3 11310000.pcie: set MEM trans window[2]: cpu_addr = 0x38400000, pci_addr = 0x38400000, size = 0x400000
[    4.288417] mtk-pcie-gen3 11310000.pcie: set MEM trans window[3]: cpu_addr = 0x38800000, pci_addr = 0x38800000, size = 0x800000
[    4.299881] mtk-pcie-gen3 11310000.pcie: set MEM trans window[4]: cpu_addr = 0x39000000, pci_addr = 0x39000000, size = 0x1000000
[    4.311431] mtk-pcie-gen3 11310000.pcie: set MEM trans window[5]: cpu_addr = 0x3a000000, pci_addr = 0x3a000000, size = 0x2000000
[    4.322982] mtk-pcie-gen3 11310000.pcie: set MEM trans window[6]: cpu_addr = 0x3c000000, pci_addr = 0x3c000000, size = 0x4000000
[    4.334662] mtk-pcie-gen3 11310000.pcie: PCI host bridge to bus 0001:00
[    4.341277] pci_bus 0001:00: root bus resource [bus 00-ff]
[    4.346754] pci_bus 0001:00: root bus resource [io  0x400000-0x5fffff] (bus address [0x38000000-0x381fffff])
[    4.356570] pci_bus 0001:00: root bus resource [mem 0x38200000-0x3fffffff]
[    4.363437] pci_bus 0001:00: scanning bus
[    4.367461] pci 0001:00:00.0: [14c3:7988] type 01 class 0x060400 PCIe Root Port
[    4.374773] pci 0001:00:00.0: BAR 0 [mem 0x00000000-0x00007fff 64bit]
[    4.381213] pci 0001:00:00.0: PCI bridge to [bus 00]
[    4.386170] pci 0001:00:00.0:   bridge window [io  0x0000-0x0fff]
[    4.392257] pci 0001:00:00.0:   bridge window [mem 0x00000000-0x000fffff]
[    4.399039] pci 0001:00:00.0:   bridge window [mem 0x00000000-0x000fffff 64bit pref]
[    4.406828] pci 0001:00:00.0: PME# supported from D0 D3hot D3cold
[    4.412914] pci 0001:00:00.0: PME# disabled
[    4.418182] pci_bus 0001:00: fixups for bus
[    4.422362] pci 0001:00:00.0: scanning [bus 00-00] behind bridge, pass 0
[    4.429052] pci 0001:00:00.0: bridge configuration invalid ([bus 00-00]), reconfiguring
[    4.437050] pci 0001:00:00.0: scanning [bus 00-00] behind bridge, pass 1
[    4.443788] pci_bus 0001:01: scanning bus
[    4.447812] pci 0001:01:00.0: [14c3:7991] type 00 class 0x028000 PCIe Endpoint
[    4.455047] pci 0001:01:00.0: BAR 0 [mem 0x00000000-0x001fffff 64bit pref]
[    4.461926] pci 0001:01:00.0: BAR 2 [mem 0x00000000-0x00007fff 64bit]
[    4.468468] pci 0001:01:00.0: PME# supported from D0 D3hot D3cold
[    4.474555] pci 0001:01:00.0: PME# disabled
[    4.490066] pci_bus 0001:01: fixups for bus
[    4.494239] pci_bus 0001:01: bus scan returning with max=01
[    4.499801] pci_bus 0001:01: busn_res: [bus 01-ff] end is updated to 01
[    4.506414] pci_bus 0001:00: bus scan returning with max=01
[    4.511991] pci 0001:00:00.0: bridge window [mem 0x38200000-0x383fffff 64bit pref]: assigned
[    4.520420] pci 0001:00:00.0: bridge window [mem 0x38400000-0x384fffff]: assigned
[    4.527889] pci 0001:00:00.0: BAR 0 [mem 0x38500000-0x38507fff 64bit]: assigned
[    4.535195] pci 0001:01:00.0: BAR 0 [mem 0x38200000-0x383fffff 64bit pref]: assigned
[    4.542938] pci 0001:01:00.0: BAR 2 [mem 0x38400000-0x38407fff 64bit]: assigned
[    4.550247] pci 0001:00:00.0: PCI bridge to [bus 01]
[    4.555203] pci 0001:00:00.0:   bridge window [mem 0x38400000-0x384fffff]
[    4.561982] pci 0001:00:00.0:   bridge window [mem 0x38200000-0x383fffff 64bit pref]
[    4.569714] pci_bus 0001:00: resource 4 [io  0x400000-0x5fffff]
[    4.575626] pci_bus 0001:00: resource 5 [mem 0x38200000-0x3fffffff]
[    4.581884] pci_bus 0001:01: resource 1 [mem 0x38400000-0x384fffff]
[    4.588138] pci_bus 0001:01: resource 2 [mem 0x38200000-0x383fffff 64bit pref]
[    4.595359] pci 0001:00:00.0: Max Payload Size set to  256/ 256 (was  128), Max Read Rq  256
[    4.603805] pci 0001:01:00.0: Max Payload Size set to  256/ 256 (was  128), Max Read Rq  256
[    4.612332] pcieport 0001:00:00.0: assign IRQ: got 120
[    4.617465] pcieport 0001:00:00.0: enabling device (0000 -> 0002)
[    4.623559] pcieport 0001:00:00.0: enabling bus mastering
[    4.629293] mtk-pcie-gen3 11310000.pcie: msi#0x0 address_hi 0x0 address_lo 0x11310c00 data 0
[    4.637731] mtk-pcie-gen3 11310000.pcie: msi#0x1 address_hi 0x0 address_lo 0x11310c00 data 1
[    4.646161] mtk-pcie-gen3 11310000.pcie: msi#0x2 address_hi 0x0 address_lo 0x11310c00 data 2
[    4.654588] mtk-pcie-gen3 11310000.pcie: msi#0x3 address_hi 0x0 address_lo 0x11310c00 data 3
[    4.663015] mtk-pcie-gen3 11310000.pcie: msi#0x4 address_hi 0x0 address_lo 0x11310c00 data 4
[    4.671442] mtk-pcie-gen3 11310000.pcie: msi#0x5 address_hi 0x0 address_lo 0x11310c00 data 5
[    4.679866] mtk-pcie-gen3 11310000.pcie: msi#0x6 address_hi 0x0 address_lo 0x11310c00 data 6
[    4.688292] mtk-pcie-gen3 11310000.pcie: msi#0x7 address_hi 0x0 address_lo 0x11310c00 data 7
[    4.696719] mtk-pcie-gen3 11310000.pcie: msi#0x8 address_hi 0x0 address_lo 0x11310c00 data 8
[    4.705145] mtk-pcie-gen3 11310000.pcie: msi#0x9 address_hi 0x0 address_lo 0x11310c00 data 9
[    4.713572] mtk-pcie-gen3 11310000.pcie: msi#0xa address_hi 0x0 address_lo 0x11310c00 data 10
[    4.722084] mtk-pcie-gen3 11310000.pcie: msi#0xb address_hi 0x0 address_lo 0x11310c00 data 11
[    4.730600] mtk-pcie-gen3 11310000.pcie: msi#0xc address_hi 0x0 address_lo 0x11310c00 data 12
[    4.739111] mtk-pcie-gen3 11310000.pcie: msi#0xd address_hi 0x0 address_lo 0x11310c00 data 13
[    4.747624] mtk-pcie-gen3 11310000.pcie: msi#0xe address_hi 0x0 address_lo 0x11310c00 data 14
[    4.756138] mtk-pcie-gen3 11310000.pcie: msi#0xf address_hi 0x0 address_lo 0x11310c00 data 15
[    4.764652] mtk-pcie-gen3 11310000.pcie: msi#0x10 address_hi 0x0 address_lo 0x11310c00 data 16
[    4.773252] mtk-pcie-gen3 11310000.pcie: msi#0x11 address_hi 0x0 address_lo 0x11310c00 data 17
[    4.781851] mtk-pcie-gen3 11310000.pcie: msi#0x12 address_hi 0x0 address_lo 0x11310c00 data 18
[    4.790452] mtk-pcie-gen3 11310000.pcie: msi#0x13 address_hi 0x0 address_lo 0x11310c00 data 19
[    4.799049] mtk-pcie-gen3 11310000.pcie: msi#0x14 address_hi 0x0 address_lo 0x11310c00 data 20
[    4.807649] mtk-pcie-gen3 11310000.pcie: msi#0x15 address_hi 0x0 address_lo 0x11310c00 data 21
[    4.816249] mtk-pcie-gen3 11310000.pcie: msi#0x16 address_hi 0x0 address_lo 0x11310c00 data 22
[    4.824849] mtk-pcie-gen3 11310000.pcie: msi#0x17 address_hi 0x0 address_lo 0x11310c00 data 23
[    4.833449] mtk-pcie-gen3 11310000.pcie: msi#0x18 address_hi 0x0 address_lo 0x11310c00 data 24
[    4.842049] mtk-pcie-gen3 11310000.pcie: msi#0x19 address_hi 0x0 address_lo 0x11310c00 data 25
[    4.850650] mtk-pcie-gen3 11310000.pcie: msi#0x1a address_hi 0x0 address_lo 0x11310c00 data 26
[    4.859247] mtk-pcie-gen3 11310000.pcie: msi#0x1b address_hi 0x0 address_lo 0x11310c00 data 27
[    4.867847] mtk-pcie-gen3 11310000.pcie: msi#0x1c address_hi 0x0 address_lo 0x11310c00 data 28
[    4.876448] mtk-pcie-gen3 11310000.pcie: msi#0x1d address_hi 0x0 address_lo 0x11310c00 data 29
[    4.885048] mtk-pcie-gen3 11310000.pcie: msi#0x1e address_hi 0x0 address_lo 0x11310c00 data 30
[    4.893648] mtk-pcie-gen3 11310000.pcie: msi#0x1f address_hi 0x0 address_lo 0x11310c00 data 31
[    4.902629] mtk-pcie-gen3 11310000.pcie: msi#0x0 address_hi 0x0 address_lo 0x11310c00 data 0
[    4.911128] pcieport 0001:00:00.0: PME: Signaling with IRQ 121
[    4.917076] pcieport 0001:00:00.0: AER: enabled with IRQ 121
[    4.922769] pcieport 0001:00:00.0: save config 0x00: 0x798814c3
[    4.928679] pcieport 0001:00:00.0: save config 0x04: 0x00100406
[    4.934592] pcieport 0001:00:00.0: save config 0x08: 0x06040001
[    4.940503] pcieport 0001:00:00.0: save config 0x0c: 0x00010000
[    4.946411] pcieport 0001:00:00.0: save config 0x10: 0x38500004
[    4.952327] pcieport 0001:00:00.0: save config 0x14: 0x00000000
[    4.958236] pcieport 0001:00:00.0: save config 0x18: 0x00010100
[    4.964147] pcieport 0001:00:00.0: save config 0x1c: 0x000001f1
[    4.970061] pcieport 0001:00:00.0: save config 0x20: 0x38403840
[    4.975969] pcieport 0001:00:00.0: save config 0x24: 0x38313821
[    4.981880] pcieport 0001:00:00.0: save config 0x28: 0x00000000
[    4.987787] pcieport 0001:00:00.0: save config 0x2c: 0x00000000
[    4.993698] pcieport 0001:00:00.0: save config 0x30: 0x00000000
[    4.999606] pcieport 0001:00:00.0: save config 0x34: 0x00000080
[    5.005517] pcieport 0001:00:00.0: save config 0x38: 0x00000000
[    5.011428] pcieport 0001:00:00.0: save config 0x3c: 0x00020178
[    5.017989] FIT: Detected U-Boot 2025.07-g9a25de54e417-dirty
[    5.023656] FIT: Selected configuration: "config-1" (OpenWrt asiarf_ap7988-002)
[    5.030965] FIT:           kernel sub-image 0x00001000..0x005d1aa7 "kernel-1" (ARM64 OpenWrt Linux-6.12.68) 
[    5.040788] FIT:          flat_dt sub-image 0x005d2000..0x005dc7e5 "fdt-1" (ARM64 OpenWrt asiarf_ap7988-002 device tree blob) 
[    5.052171] FIT:       filesystem sub-image 0x005dd000..0x0159cfff "rootfs-1" (ARM64 OpenWrt asiarf_ap7988-002 rootfs) 
[    5.063203] block ubiblock0_0: mapped 1 uImage.FIT filesystem sub-image as /dev/fit0
[    5.554534] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc082400000, irq 105
[    5.564198] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc082400000, irq 105
[    5.573812] mtk_soc_eth 15100000.ethernet eth2: mediatek frame engine at 0xffffffc082400000, irq 105
[    5.672553] mt7530-mmio 15020000.switch: configuring for fixed/internal link mode
[    5.680069] mt7530-mmio 15020000.switch: Link is Up - 10Gbps/Full - flow control rx/tx
[    5.707405] mt7530-mmio 15020000.switch lan1 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7988 PHY] (irq=123)
[    5.746191] mt7530-mmio 15020000.switch lan2 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7988 PHY] (irq=124)
[    5.785038] mt7530-mmio 15020000.switch lan3 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7988 PHY] (irq=125)
[    5.823843] mt7530-mmio 15020000.switch lan4 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7988 PHY] (irq=126)
[    5.834809] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    5.841521] DSA: tree 0 setup
[    5.844766] clk: Disabling unused clocks
[    5.849115] PM: genpd: Disabling unused power domains
[    5.857056] VFS: Mounted root (squashfs filesystem) readonly on device 259:0.
[    5.864309] Freeing unused kernel memory: 448K
[    5.868782] Run /sbin/init as init process
[    5.872880]   with arguments:
[    5.875837]     /sbin/init
[    5.878534]   with environment:
[    5.881667]     HOME=/
[    5.884016]     TERM=linux
[    6.019876] init: Console is alive
[    6.023389] init: - watchdog -
[    6.424785] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    8.491981] Aquantia AQR113C mdio-bus:08: loading firmware version 'v5.6.9 Mediatek Mediatek 23B 100522 05:37:14' from 'NVMEM'
[   13.307747] hwmon hwmon1: temp1_input not attached to any thermal zone
[   13.318513] usbcore: registered new interface driver usbfs
[   13.324043] usbcore: registered new interface driver hub
[   13.329368] usbcore: registered new device driver usb
[   13.368202] SGI XFS with ACLs, security attributes, no debug enabled
[   13.375897] gpio_button_hotplug: loading out-of-tree module taints kernel.
[   13.386574] nvme 0002:01:00.0: assign IRQ: got 114
[   13.391550] nvme nvme0: pci function 0002:01:00.0
[   13.396252] nvme 0002:01:00.0: enabling device (0000 -> 0002)
[   13.402015] nvme 0002:01:00.0: enabling bus mastering
[   13.407124] mtk-pcie-gen3 11290000.pcie: msi#0x1 address_hi 0x0 address_lo 0x11290c00 data 1
[   13.415583] nvme 0002:01:00.0: save config 0x00: 0x100e1e95
[   13.421153] nvme 0002:01:00.0: save config 0x04: 0x00100406
[   13.426715] nvme 0002:01:00.0: save config 0x08: 0x01080201
[   13.432285] nvme 0002:01:00.0: save config 0x0c: 0x00000000
[   13.437847] nvme 0002:01:00.0: save config 0x10: 0x28200004
[   13.443412] nvme 0002:01:00.0: save config 0x14: 0x00000000
[   13.448974] nvme 0002:01:00.0: save config 0x18: 0x00000000
[   13.454539] nvme 0002:01:00.0: save config 0x1c: 0x00000000
[   13.460107] nvme 0002:01:00.0: save config 0x20: 0x00000000
[   13.465669] nvme 0002:01:00.0: save config 0x24: 0x28204000
[   13.471234] nvme 0002:01:00.0: save config 0x28: 0x00000000
[   13.476796] nvme 0002:01:00.0: save config 0x2c: 0x100e1e95
[   13.482360] nvme 0002:01:00.0: save config 0x30: 0x00000000
[   13.487920] nvme 0002:01:00.0: save config 0x34: 0x00000040
[   13.493485] nvme 0002:01:00.0: save config 0x38: 0x00000000
[   13.499046] nvme 0002:01:00.0: save config 0x3c: 0x00000172
[   13.658591] hwmon hwmon2: temp1_input not attached to any thermal zone
[   13.675637] nvme nvme0: allocated 64 MiB host memory buffer.
[   13.711475] mtk-pcie-gen3 11290000.pcie: msi#0x1 address_hi 0x0 address_lo 0x11290c00 data 1
[   13.719924] mtk-pcie-gen3 11290000.pcie: msi#0x2 address_hi 0x0 address_lo 0x11290c00 data 2
[   13.728390] mtk-pcie-gen3 11290000.pcie: msi#0x3 address_hi 0x0 address_lo 0x11290c00 data 3
[   13.736836] mtk-pcie-gen3 11290000.pcie: msi#0x4 address_hi 0x0 address_lo 0x11290c00 data 4
[   13.745286] mtk-pcie-gen3 11290000.pcie: msi#0x5 address_hi 0x0 address_lo 0x11290c00 data 5
[   13.757566] nvme nvme0: 4/0/0 default/read/poll queues
[   13.776930]  nvme0n1:
[   13.782295] xhci-mtk 11190000.usb: supply vbus not found, using dummy regulator
[   13.789685] xhci-mtk 11190000.usb: supply vusb33 not found, using dummy regulator
[   13.797511] xhci-mtk 11190000.usb: xHCI Host Controller
[   13.802746] xhci-mtk 11190000.usb: new USB bus registered, assigned bus number 1
[   13.810346] xhci-mtk 11190000.usb: hcc params 0x01403f99 hci version 0x110 quirks 0x0000000000200010
[   13.819499] xhci-mtk 11190000.usb: irq 132, io mem 0x11190000
[   13.825313] xhci-mtk 11190000.usb: xHCI Host Controller
[   13.830551] xhci-mtk 11190000.usb: new USB bus registered, assigned bus number 2
[   13.837938] xhci-mtk 11190000.usb: Host supports USB 3.2 Enhanced SuperSpeed
[   13.845323] hub 1-0:1.0: USB hub found
[   13.849077] hub 1-0:1.0: 1 port detected
[   13.853164] usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
[   13.861411] hub 2-0:1.0: USB hub found
[   13.865160] hub 2-0:1.0: 1 port detected
[   13.869324] xhci-mtk 11200000.usb: supply vbus not found, using dummy regulator
[   13.876687] xhci-mtk 11200000.usb: supply vusb33 not found, using dummy regulator
[   13.884605] xhci-mtk 11200000.usb: xHCI Host Controller
[   13.889829] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 3
[   13.900280] xhci-mtk 11200000.usb: hcc params 0x01403f99 hci version 0x110 quirks 0x0000000000200010
[   13.909428] xhci-mtk 11200000.usb: irq 133, io mem 0x11200000
[   13.915230] xhci-mtk 11200000.usb: xHCI Host Controller
[   13.920449] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 4
[   13.927835] xhci-mtk 11200000.usb: Host supports USB 3.2 Enhanced SuperSpeed
[   13.935082] hub 3-0:1.0: USB hub found
[   13.938833] hub 3-0:1.0: 1 port detected
[   13.942904] usb usb4: We don't know the algorithms for LPM for this host, disabling LPM.
[   13.951154] hub 4-0:1.0: USB hub found
[   13.954902] hub 4-0:1.0: 1 port detected
[   14.061545] usbcore: registered new interface driver usb-storage
[   14.068231] usbcore: registered new interface driver uas
[   14.073682] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[   14.087852] init: - preinit -
[   14.331239] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/internal link mode
[   14.339418] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 10Gbps/Full - flow control rx/tx
[   14.351715] mt7530-mmio 15020000.switch lan1: configuring for phy/internal link mode
[   14.380091] usb 3-1: new high-speed USB device number 2 using xhci-mtk
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[   14.530787] usb 3-1: config 1 has an invalid interface number: 8 but max is 6
[   14.537933] usb 3-1: config 1 has an invalid interface number: 9 but max is 6
[   14.545067] usb 3-1: config 1 has an invalid interface number: 9 but max is 6
[   14.552200] usb 3-1: config 1 has an invalid interface number: 12 but max is 6
[   14.559410] usb 3-1: config 1 has no interface number 4
[   14.564627] usb 3-1: config 1 has no interface number 5
[   14.569841] usb 3-1: config 1 has no interface number 6
[   18.597409] mount_root: loading kmods from internal overlay
[   18.611316] kmodloader: loading kernel modules from //etc/modules-boot.d/*
[   18.619399] kmodloader: done loading kernel modules from //etc/modules-boot.d/*
[   18.800465] block: attempting to load /tmp/overlay/upper/etc/config/fstab
[   18.808160] block: unable to load configuration (fstab: Entry not found)
[   18.814909] block: attempting to load /tmp/overlay/etc/config/fstab
[   18.821226] block: unable to load configuration (fstab: Entry not found)
[   18.827950] block: attempting to load /etc/config/fstab
[   18.835379] block: unable to load configuration (fstab: Entry not found)
[   18.842197] block: no usable configuration
[   18.847943] UBIFS (ubi0:1): Mounting in unauthenticated mode
[   18.853669] UBIFS (ubi0:1): background thread "ubifs_bgt0_1" started, PID 1017
[   18.872345] UBIFS (ubi0:1): recovery needed
[   18.947676] UBIFS (ubi0:1): recovery completed
[   18.952154] UBIFS (ubi0:1): UBIFS: mounted UBI device 0, volume 1, name "rootfs_data"
[   18.959976] UBIFS (ubi0:1): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[   18.969881] UBIFS (ubi0:1): FS size: 87105536 bytes (83 MiB, 686 LEBs), max 697 LEBs, journal size 4317184 bytes (4 MiB, 34 LEBs)
[   18.981524] UBIFS (ubi0:1): reserved for root: 4114209 bytes (4017 KiB)
[   18.988128] UBIFS (ubi0:1): media format: w5/r0 (latest is w5/r0), UUID B91B28BF-60BE-46B3-8454-6FF856FF45D0, small LPT model
[   18.999916] block: attempting to load /tmp/ubifs_cfg/upper/etc/config/fstab
[   19.009503] block: extroot: not configured
[   19.013692] UBIFS (ubi0:1): un-mount UBI device 0
[   19.018395] UBIFS (ubi0:1): background thread "ubifs_bgt0_1" stops
[   19.026970] UBIFS (ubi0:1): Mounting in unauthenticated mode
[   19.032713] UBIFS (ubi0:1): background thread "ubifs_bgt0_1" started, PID 1020
[   19.069427] UBIFS (ubi0:1): UBIFS: mounted UBI device 0, volume 1, name "rootfs_data"
[   19.077266] UBIFS (ubi0:1): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[   19.087171] UBIFS (ubi0:1): FS size: 87105536 bytes (83 MiB, 686 LEBs), max 697 LEBs, journal size 4317184 bytes (4 MiB, 34 LEBs)
[   19.098810] UBIFS (ubi0:1): reserved for root: 4114209 bytes (4017 KiB)
[   19.105416] UBIFS (ubi0:1): media format: w5/r0 (latest is w5/r0), UUID B91B28BF-60BE-46B3-8454-6FF856FF45D0, small LPT model
[   19.185503] block: attempting to load /tmp/overlay/upper/etc/config/fstab
[   19.194791] block: extroot: not configured
[   19.199984] block: attempting to load /tmp/ubifs_cfg/upper/etc/config/fstab
[   19.207104] block: extroot: not configured
[   19.212377] mount_root: switching to ubifs overlay
[   19.221442] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[   19.234108] urandom-seed: Seeding with /etc/urandom.seed
[   19.262905] procd: - early -
[   19.265844] procd: - watchdog -
[   19.802373] procd: - watchdog -
[   19.812450] procd: - ubus -
[   19.966865] procd: - init -
Please press Enter to activate this console.
[   20.210096] kmodloader: loading kernel modules from /etc/modules.d/*
[   20.237762] crypto-safexcel 15600000.crypto: EIP197:331(7,1,8,4)-HIA:272(2,5,5),PE:151/450(alg:7fe1fc00)/240/240/450
[   20.249151] crypto-safexcel 15600000.crypto: TRC init: 8704d,48a (32r,128h)
[   20.289813] urngd: v1.0.2 started.
[   20.373386] usbcore: registered new interface driver cdc_wdm
[   20.379403] Loading modules backported from Linux version v6.18.7-0-g5dfbc5357
[   20.386625] Backport generated by backports.git c8a37ce
[   20.408238] usbcore: registered new interface driver ums-alauda
[   20.414663] usbcore: registered new interface driver ums-cypress
[   20.421150] usbcore: registered new interface driver ums-datafab
[   20.427570] usbcore: registered new interface driver ums-freecom
[   20.434028] usbcore: registered new interface driver ums-isd200
[   20.440382] usbcore: registered new interface driver ums-jumpshot
[   20.446874] usbcore: registered new interface driver ums-karma
[   20.453237] usbcore: registered new interface driver ums-sddr09
[   20.459592] usbcore: registered new interface driver ums-sddr55
[   20.465979] usbcore: registered new interface driver ums-usbat
[   20.473368] usbcore: registered new interface driver ax88179_178a
[   20.479892] usbcore: registered new interface driver cdc_eem
[   20.486077] usbcore: registered new interface driver cdc_ether
[   20.492642] usbcore: registered new interface driver cdc_ncm
[   20.543496] mt7996e_hif 0001:01:00.0: assign IRQ: got 120
[   20.548918] mt7996e_hif 0001:01:00.0: enabling device (0000 -> 0002)
[   20.555314] mt7996e_hif 0001:01:00.0: enabling bus mastering
[   20.561094] mt7996e 0000:01:00.0: assign IRQ: got 117
[   20.566143] mt7996e 0000:01:00.0: enabling device (0000 -> 0002)
[   20.572163] mt7996e 0000:01:00.0: enabling bus mastering
[   20.630107] mtk-pcie-gen3 11300000.pcie: msi#0x1 address_hi 0x0 address_lo 0x11300c00 data 1
[   20.638626] mtk-pcie-gen3 11310000.pcie: msi#0x1 address_hi 0x0 address_lo 0x11310c00 data 1
[   20.690952] mt7996e 0000:01:00.0: HW/SW Version: 0x8a108a10, Build Time: 20250904202927a
[   20.690952] 
[   20.913840] mt7996e 0000:01:00.0: WM Firmware Version: ____000000, Build Time: 20250904202924
[   20.976422] mt7996e 0000:01:00.0: DSP Firmware Version: ____000000, Build Time: 20250904202814
[   21.033142] mt7996e 0000:01:00.0: WA Firmware Version: ____000000, Build Time: 20250904202837
[   21.364527] PPP generic driver version 2.4.2
[   21.369714] NET: Registered PF_PPPOX protocol family
[   21.375865] usbcore: registered new interface driver qmi_wwan
[   21.382650] usbcore: registered new interface driver rndis_host
[   21.886625] cdc_mbim 3-1:1.8: setting rx_max = 16384
[   21.891930] cdc_mbim 3-1:1.8: cdc-wdm0: USB WDM device
[   21.897545] cdc_mbim 3-1:1.8 wwan0: register 'cdc_mbim' at usb-11200000.usb-1, CDC MBIM, f6:aa:10:87:0e:59
[   21.907362] usbcore: registered new interface driver cdc_mbim
[   21.916837] kmodloader: done loading kernel modules from /etc/modules.d/*
[   23.649738] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   23.677126] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/internal link mode
[   23.685327] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 10Gbps/Full - flow control rx/tx
[   23.687490] mt7530-mmio 15020000.switch lan1: configuring for phy/internal link mode
[   23.702913] br-lan: port 1(lan1) entered blocking state
[   23.708158] br-lan: port 1(lan1) entered disabled state
[   23.713490] mt7530-mmio 15020000.switch lan1: entered allmulticast mode
[   23.720138] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   23.727168] mt7530-mmio 15020000.switch lan1: entered promiscuous mode
[   23.739035] mt7530-mmio 15020000.switch lan2: configuring for phy/internal link mode
[   23.747631] br-lan: port 2(lan2) entered blocking state
[   23.752923] br-lan: port 2(lan2) entered disabled state
[   23.758192] mt7530-mmio 15020000.switch lan2: entered allmulticast mode
[   23.765112] mt7530-mmio 15020000.switch lan2: entered promiscuous mode
[   23.775215] mt7530-mmio 15020000.switch lan3: configuring for phy/internal link mode
[   23.783785] br-lan: port 3(lan3) entered blocking state
[   23.789028] br-lan: port 3(lan3) entered disabled state
[   23.794327] mt7530-mmio 15020000.switch lan3: entered allmulticast mode
[   23.801228] mt7530-mmio 15020000.switch lan3: entered promiscuous mode
[   23.810965] mt7530-mmio 15020000.switch lan4: configuring for phy/internal link mode
[   23.819494] br-lan: port 4(lan4) entered blocking state
[   23.824814] br-lan: port 4(lan4) entered disabled state
[   23.830132] mt7530-mmio 15020000.switch lan4: entered allmulticast mode
[   23.837420] mt7530-mmio 15020000.switch lan4: entered promiscuous mode
[   23.855367] mtk_soc_eth 15100000.ethernet eth2: PHY [mdio-bus:08] driver [Aquantia AQR113C] (irq=POLL)
[   23.864817] mtk_soc_eth 15100000.ethernet eth2: configuring for phy/usxgmii link mode
[   23.890895] br-lan: port 5(eth2) entered blocking state
[   23.896145] br-lan: port 5(eth2) entered disabled state
[   23.901463] mtk_soc_eth 15100000.ethernet eth2: entered allmulticast mode
[   23.908934] mtk_soc_eth 15100000.ethernet eth2: entered promiscuous mode
[   23.964523] MediaTek MT7988 2.5GbE PHY mdio-bus:0f: Firmware date code: 2024/10/30, version: 10.0
[   23.981838] mtk_soc_eth 15100000.ethernet eth1: PHY [mdio-bus:0f] driver [MediaTek MT7988 2.5GbE PHY] (irq=POLL)
[   23.992093] mtk_soc_eth 15100000.ethernet eth1: configuring for phy/internal link mode
[   27.857525] mt7530-mmio 15020000.switch lan2: Link is Up - 1Gbps/Full - flow control rx/tx
[   38.799852] br-lan: port 2(lan2) entered blocking state
[   38.805117] br-lan: port 2(lan2) entered forwarding state



BusyBox v1.37.0 (2026-01-02 17:07:02 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt SNAPSHOT, r32903-9d2c91d661
 -----------------------------------------------------

 === WARNING! =====================================
 There is no root password defined on this device!
 Use the "passwd" command to set up a new password
 in order to prevent unauthorized SSH logins.
 --------------------------------------------------


 OpenWrt recently switched to the "apk" package manager!

 OPKG Command           APK Equivalent      Description
 ------------------------------------------------------------------
 opkg install <pkg>     apk add <pkg>       Install a package
 opkg remove <pkg>      apk del <pkg>       Remove a package
 opkg upgrade           apk upgrade         Upgrade all packages
 opkg files <pkg>       apk info -L <pkg>   List package contents
 opkg list-installed    apk info            List installed packages
 opkg update            apk update          Update package lists
 opkg search <pkg>      apk search <pkg>    Search for packages
 ------------------------------------------------------------------

For more information visit:
https://openwrt.org/docs/guide-user/additional-software/opkg-to-apk-cheatsheet

root@OpenWrt:~# 
```
</details>


<h2>How to flash</h2>

**Flash instruction through LuCI:**

This device is flashed OpenWRT base firmware with this target.
The LuCI webpage is integrated in default for upgrading.

**Flash instruction through u-boot:**

1. Prepare the TFTP server on PC.
2. Connect uart to PC, select "2. Upgrade firmware" in u-boot menu.
3. input client IP, server IP, flashed bin file path
4. Wait about 20 seconds to complete flashing

<h2>Links</h2>

[Product link](https://asiarf.com/product/wi-fi-7-be19000-development-platform-ap7988-002/)

