### PR TITLE
mediatek: filogic: Add support for AsiaRF AP7988-003

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -68,6 +68,7 @@ nradio,c8-668gl)
 	ubootenv_add_mmc "u-boot-env" "" "0x0" "0x80000"
 	;;
 asiarf,ap7986-003|\
+asiarf,ap7988-003|\
 cetron,ct3003|\
 comfast,cf-wr632ax|\
 edgecore,eap111|\

--- a/target/linux/mediatek/dts/mt7988a-asiarf-ap7988-003-mmc.dtso
+++ b/target/linux/mediatek/dts/mt7988a-asiarf-ap7988-003-mmc.dtso
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 AsiaRF Co., Ltd.
+ * Author: Elwin Huang <elwin@asiarf.com>
+ */
+
+/dts-v1/;
+/plugin/;
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "asiarf,ap7988-003", "mediatek,mt7988a";
+
+	fragment@1 {
+		target = <&mmc0>;
+		__overlay__ {
+			pinctrl-names = "default", "state_uhs";
+			pinctrl-0 = <&mmc0_pins_sdcard>;
+			pinctrl-1 = <&mmc0_pins_sdcard>;
+			bus-width = <4>;
+			max-frequency = <50000000>;
+			non-removable;
+			cap-mmc-highspeed;
+			cap-sdio-irq;
+			disable-wp;
+			keep-power-in-suspend;
+			vmmc-supply = <&reg_3p3v>;
+			vqmmc-supply = <&reg_3p3v>;
+			status = "okay";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mm6108_sdio: mm6108_sdio@0 {
+				compatible = "morse,mm610x";
+				reg = <2>;
+				bus-width = <4>;
+				reset-gpios = <&pio 3 GPIO_ACTIVE_HIGH>;
+				power-gpios = <&pio 83 GPIO_ACTIVE_HIGH>,
+					<&pio 82 GPIO_ACTIVE_HIGH>;
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&pio>;
+		__overlay__ {
+			gpio-line-names = "",
+				"", "", "MM_RESET", "", "", // 3
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "MM_WAKE", "MM_BUSY", "", ""; // 82, 83
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7988a-asiarf-ap7988-003-sd.dtso
+++ b/target/linux/mediatek/dts/mt7988a-asiarf-ap7988-003-sd.dtso
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 AsiaRF Co., Ltd.
+ * Author: Elwin Huang <elwin@asiarf.com>
+ */
+
+/dts-v1/;
+/plugin/;
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "asiarf,ap7988-003", "mediatek,mt7988a";
+
+	fragment@1 {
+		target = <&mmc0>;
+		__overlay__ {
+			pinctrl-names = "default", "state_uhs";
+			pinctrl-0 = <&mmc0_pins_sdcard>;
+			pinctrl-1 = <&mmc0_pins_sdcard>;
+			cd-gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+			bus-width = <4>;
+			max-frequency = <50000000>;
+			cap-sd-highspeed;
+			vmmc-supply = <&reg_3p3v>;
+			vqmmc-supply = <&reg_3p3v>;
+			status = "okay";
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7988a-asiarf-ap7988-003-spidev.dtso
+++ b/target/linux/mediatek/dts/mt7988a-asiarf-ap7988-003-spidev.dtso
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 AsiaRF Co., Ltd.
+ * Author: Elwin Huang <elwin@asiarf.com>
+ */
+
+/dts-v1/;
+/plugin/;
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "asiarf,ap7988-003", "mediatek,mt7988a";
+
+	fragment@1 {
+		target = <&spi1>;
+		__overlay__ {
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi1_pins>;
+			status = "okay";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mm6108: mm6108@0 {
+				compatible = "morse,mm610x-spi";
+				reg = <0>; // CE0
+				reset-gpios = <&pio 3 GPIO_ACTIVE_HIGH>; // Reset
+				power-gpios = <&pio 83 GPIO_ACTIVE_HIGH>,
+							<&pio 82 GPIO_ACTIVE_HIGH>; // Wake & Busy
+				spi-irq-gpios = <&pio 52 GPIO_ACTIVE_HIGH>; // Spi_IRQ
+				spi-max-frequency = <48000000>;
+				status = "okay";
+			};
+
+			spidev0: spidev@0 {
+				compatible = "spidev";
+				reg = <0>; /* CE0 */
+				status = "disabled";
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&pio>;
+		__overlay__ {
+			gpio-line-names = "",
+				"", "", "MM_RESET", "", "", // 3
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "", "", "", "",
+				"", "MM_WAKE", "MM_BUSY", "", ""; // 82, 83
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7988a-asiarf-ap7988-003.dts
+++ b/target/linux/mediatek/dts/mt7988a-asiarf-ap7988-003.dts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 AsiaRF Co., Ltd.
+ * Author: Elwin Huang <elwin@asiarf.com>
+ */
+
+/dts-v1/;
+#include "mt7988a-asiarf-ap7988.dtsi"
+
+/ {
+	compatible = "asiarf,ap7988-003", "mediatek,mt7988a";
+	model = "AsaiRF AP7988-003";
+};
+
+&i2c1 {
+	iio@77 {
+		compatible = "infineon,dps310";
+		reg = <0x77>;
+	};
+
+	rtc@68 {
+		compatible = "ti,bq32000";
+		reg = <0x68>;
+	};
+
+	crypto@60 {
+		// ATECC608A
+		reg = <0x60>;
+	};
+};
+
+&serial2 {
+	status = "okay";
+};

--- a/target/linux/mediatek/dts/mt7988a-asiarf-ap7988.dtsi
+++ b/target/linux/mediatek/dts/mt7988a-asiarf-ap7988.dtsi
@@ -1,0 +1,501 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 AsiaRF Co., Ltd.
+ * Author: Elwin Huang <elwin@asiarf.com>
+ */
+
+/dts-v1/;
+#include "mt7988a.dtsi"
+#include <dt-bindings/pinctrl/mt65xx.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/regulator/richtek,rt5190a-regulator.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		serial0 = &serial0;
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "pci=pcie_bus_perf ubi.block=0,fit root=/dev/fit0 rootwait";
+		rootdisk-spim-nand = <&ubi_rootfs>;
+	};
+
+	memory {
+		reg = <0 0x40000000 0 0x40000000>;
+	};
+
+	reg_1p8v: regulator-1p8v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-1.8V";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+		status = "okay";
+
+		led_power_blue: led-1 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 69 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "default-on";
+		};
+
+		led-2 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&pio 70 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "default-on";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&cpu0 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu1 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu2 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu3 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cci {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&eth {
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&mdio_bus {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	clock-frequency = <10500000>;
+
+	/* Aquantia AQR113C */
+	phy8: ethernet-phy@8 {
+		reg = <8>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reset-gpios = <&pio 71 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <221000>;
+		nvmem-cell-names = "firmware";
+		nvmem-cells = <&firmware_factory_200000>;
+	};
+};
+
+&int_2p5g_phy {
+	pinctrl-names = "i2p5gbe-led";
+	pinctrl-0 = <&i2p5gbe_led0_pins>;
+};
+
+&gmac0 {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_ffff4>;
+};
+
+&gmac1 {
+	phy-mode = "internal";
+	phy-connection-type = "internal";
+	phy-handle = <&int_2p5g_phy>;
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_ffffa>;
+};
+
+&gmac2 {
+	phy-mode = "usxgmii";
+	phy-connection-type = "usxgmii";
+	phy = <&phy8>;
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_ffff4>;
+};
+
+&switch {
+	status = "okay";
+
+	ports {
+		port@0 {
+			label = "lan1";
+		};
+
+		port@1 {
+			label = "lan2";
+		};
+
+		port@2 {
+			label = "lan3";
+		};
+
+		port@3 {
+			label = "lan4";
+		};
+	};
+};
+
+&gsw_phy0 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe0_led0_pins>;
+};
+
+&gsw_phy0_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_WHITE>;
+};
+
+&gsw_phy1 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe1_led0_pins>;
+};
+
+&gsw_phy1_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_WHITE>;
+};
+
+&gsw_phy2 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe2_led0_pins>;
+};
+
+&gsw_phy2_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_WHITE>;
+};
+
+&gsw_phy3 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe3_led0_pins>;
+};
+
+&gsw_phy3_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_WHITE>;
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+
+	rt5190a_64: rt5190a@64 {
+		compatible = "richtek,rt5190a";
+		reg = <0x64>;
+		/*interrupts-extended = <&gpio26 0 IRQ_TYPE_LEVEL_LOW>;*/
+		vin2-supply = <&rt5190_buck1>;
+		vin3-supply = <&rt5190_buck1>;
+		vin4-supply = <&rt5190_buck1>;
+
+		regulators {
+			rt5190_buck1: buck1 {
+				regulator-name = "rt5190a-buck1";
+				regulator-min-microvolt = <5090000>;
+				regulator-max-microvolt = <5090000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			buck2 {
+				regulator-name = "vcore";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			rt5190_buck3: buck3 {
+				regulator-name = "vproc";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+			};
+			buck4 {
+				regulator-name = "rt5190a-buck4";
+				regulator-min-microvolt = <850000>;
+				regulator-max-microvolt = <850000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			ldo {
+				regulator-name = "rt5190a-ldo";
+				regulator-min-microvolt = <1200000>;
+				regulator-max-microvolt = <1200000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+		};
+	};
+};
+
+&i2c1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c1_pins>;
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&pcie3 {
+	status = "okay";
+};
+
+&ssusb0 {
+	status = "okay";
+};
+
+&ssusb1 {
+	status = "okay";
+};
+
+&xsphy {
+	status = "okay";
+};
+
+&tphy {
+	status = "okay";
+};
+
+&serial0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&lvts {
+	status = "okay";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x0400000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1e00>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
+					macaddr_factory_a: macaddr@a {
+						reg = <0xa 0x6>;
+					};
+
+					macaddr_factory_2c0: macaddr@2c0 {
+						reg = <0x2c0 0x6>;
+					};
+
+					macaddr_factory_ffff4: macaddr@ffff4 {
+						reg = <0xffff4 0x6>;
+					};
+
+					macaddr_factory_ffffa: macaddr@ffffa {
+						reg = <0xffffa 0x6>;
+					};
+
+					firmware_factory_200000: firmware@200000 {
+						reg = <0x0200000 0x60002>;
+					};
+				};
+			};
+
+			partition@580000 {
+				label = "FIP";
+				reg = <0x580000 0x0200000>;
+			};
+
+			partition@780000 {
+				label = "ubi";
+				reg = <0x780000 0x7080000>;
+				compatible = "linux,ubi";
+
+				volumes {
+					ubi_rootfs: ubi-volume-fit {
+						volname = "fit";
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+
+	mdio0_pins: mdio0-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio0";
+		};
+
+		conf {
+			groups = "mdc_mdio0";
+			drive-strength = <MTK_DRIVE_8mA>;
+		};
+	};
+
+	gbe0_led0_pins: gbe0-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe0_led0";
+		};
+	};
+
+	gbe1_led0_pins: gbe1-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe1_led0";
+		};
+	};
+
+	gbe2_led0_pins: gbe2-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe2_led0";
+		};
+	};
+
+	gbe3_led0_pins: gbe3-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe3_led0";
+		};
+	};
+
+	i2c0_pins: i2c0-g0-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+
+	i2c1_pins: i2c1-g0-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c1_0";
+		};
+	};
+
+	i2c2_1_pins: i2c2-g1-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c2_1";
+		};
+	};
+
+	i2p5gbe_led0_pins: 2p5gbe-led0-pins {
+		mux {
+			function = "led";
+			groups = "2p5gbe_led0";
+		};
+	};
+
+	mmc0_pins_sdcard: mmc0-sdcard-pins {
+		mux {
+			function = "flash";
+			groups = "sdcard";
+		};
+	};
+
+	spi0_flash_pins: spi0-flash-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -41,6 +41,9 @@ mediatek_setup_interfaces()
 	arcadyan,mozart)
 		ucidef_set_interfaces_lan_wan "lan0 eth1" eth2
 		;;
+	asiarf,ap7988-003)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 eth2" eth1
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax59u|\
 	asus,zenwifi-bt8|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -80,6 +80,7 @@ platform_do_upgrade() {
 	case "$board" in
 	abt,asr3000|\
 	acer,predator-w6x-ubootmod|\
+	asiarf,ap7988-003|\
 	asus,zenwifi-bt8-ubootmod|\
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -393,6 +393,29 @@ define Device/arcadyan_mozart
 endef
 TARGET_DEVICES += arcadyan_mozart
 
+define Device/asiarf_ap7988-003
+  DEVICE_VENDOR := AsiaRF
+  DEVICE_MODEL := AP7988-003
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS := mt7988a-asiarf-ap7988-003
+  DEVICE_DTS_OVERLAY:= \
+    mt7988a-asiarf-ap7988-003-mmc \
+    mt7988a-asiarf-ap7988-003-sd \
+    mt7988a-asiarf-ap7988-003-spidev
+  DEVICE_PACKAGES := kmod-usb3 fitblk kmod-phy-aquantia mt7988-2p5g-phy-firmware mt7988-wo-firmware
+  DEVICE_DTC_FLAGS := --pad 4096
+  DEVICE_DTS_LOADADDR := 0x45f00000
+  KERNEL_LOADADDR := 0x46000000
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  KERNEL_INITRAMFS_SUFFIX := .itb
+  IMAGES := sysupgrade.itb
+  IMAGE_SIZE := 65536k
+  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
+endef
+TARGET_DEVICES += asiarf_ap7988-003
+
 define Device/asus_rt-ax52
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AX52


### PR DESCRIPTION
WIP
Related PR: #20106

<hr>

**<h1>Specification:</h1>**

- SoC           : MediaTek MT7988A, Quad-core 1.8 GHz ARM Cortex-A73 CPU
- RAM           : DDR4 1 GiB (2x Nanya NT5AD256M16E4-JRI)
- Flash         : SPI-NAND 128 MiB (Macronix MX35LF1GE4AB-Z4I) 
- Ethernet      : 6 ports
  - LAN :
      4x 10/100/1000 Mbps RJ-45 Port
      1x 10/100/1000/2500/5000/10000 Mbps RJ-45 Port (Marvell ARQ113C)
  - WAN :
      1x 10/100/1000/2500 Mbps RJ-45 Port
- LED           : 14x LEDs
    1x Power (Blue, GPIO)
    1x Status (Orange, GPIO)
    2x M.2 AE Key (Orange)
    1x M.2 B Key (Red)
    1x M.2 M Key (Red)
    5x Ethernet LAN activity (White)
    3x Ethernet WAN activity (Green)
- UART          : 1x4 pin header on PCB [J6558]
  - arrangement : 3.3V, TX, RX, GND
  - settings    : 115200, 8n1
- Button        : 2x (Reset, WPS)
- GPS           : 1x (Quectel L76-L)
- WiFi          : 1x
    WiFI HaLow (AsiaRF MM610X-001),
      Switch SDIO/SPI interface by pin jumpers
- Socket        : 
    2x M.2 AE Key (PCIe Gen3)
    1x M.2 B key (USB 3.2)
    1x M.2 M key (PCIe Gen3)
    1x USB-A (USB 3.2)
    1x SIM Card
    1x SD Card
    1x PoE Module
    1x CR2032
- I2C           :
    1x iio (DPS368)
    1x rtc (BQ32002)
    1x crpyto (ATECC608A)
- Power         : 12V DC, 3A

| Interface  | Mac Address | Read Address |
| ------------- | ------------- | ------------- | 
| LAN  | 00:0A:52:xx:xx:xx  | Factory, 0xffff4 |
| WAN   | 00:0A:52:xx:xx:xx  | Factory, 0xffffa |



<h2>Bootlog</h2>
<details>

<summary>Factory Bootlog</summary>

```

F0: 102B 0000
FA: 1042 0000
FA: 1042 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 0600 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
MK: 0000 0000 [0000]
T0: 0000 01AD [0101]
Jump to BL

NOTICE:  BL2: v2.13.0(release):v2.4-rc0-9074-g78a0dfd92
NOTICE:  BL2: Built : 10:46:42, Sep 20 2025
NOTICE:  WDT: Cold boot
NOTICE:  WDT: disabled
NOTICE:  CPU: MT7988
NOTICE:  EMI: Using DDR unknown settings
NOTICE:  EMI: Detected DRAM size: 1024 MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  LVTS: Enable thermal HW reset
WARNING: CASN page may not exist. Try to read parameter page.
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc2
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 2 found in block 960
NOTICE:  Second info table with writecount 2 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.13.0(release):v2.4-rc0-9074-g78a0dfd92
NOTICE:  BL31: Built : 10:46:42, Sep 20 2025


U-Boot 2025.07-g9a25de54e417-dirty (Sep 20 2025 - 10:46:32 +0000)

CPU:   MediaTek MT7988
Model: mt7988-rfb
       (mediatek,mt7988-spim-nand-rfb)
DRAM:  1 GiB
Core:  52 devices, 13 uclasses, devicetree: separate

Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: CASN page check failed
spi-nand: spi_nand spi_nand@0: Fallback to read ID
spi-nand: spi_nand spi_nand@0: Macronix SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 2 found in block 960
Second info table with writecount 2 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11000000
Out:   serial@11000000
Err:   serial@11000000
Net:   MediaTek MT7988 built-in switch
eth0: ethernet@15110100mtk-eth ethernet@15110200: Firmware date code: 2024/10/30, version: 10.0
mtk-eth ethernet@15110200: Firmware loading/trigger ok.
mtk-eth ethernet@15110200: Fail to set LED pins!
, eth1: ethernet@15110200ethernet@15110300 loading firmware version 'v5.6.9 Mediatek Mediatek 23B 100522 05:37:14'
ethernet@15110300 firmware loading done.
, eth2: ethernet@15110300
*** U-Boot Boot Menu ***Press UP/DOWN to move, ENTER to select, ESC to quit1. Startup system (Default)2. Upgrade firmware3. Upgrade ATF BL24. Upgrade ATF FIP5.   Upgrade ATF BL31 only6.   Upgrade bootloader only7. Upgrade single image8. Load image9. Change boot configuration0. ExitHit any key to stop autoboot: 4 Hit any key to stop autoboot: 3 Hit any key to stop autoboot: 2 Hit any key to stop autoboot: 1 ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 112 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 900, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 5/2, WL threshold: 4096, image sequence number: 0
ubi0: available PEBs: 0, total reserved PEBs: 900, PEBs reserved for bad PEB handling: 19
No size specified -> Using max size (10285056)
Read 10285056 bytes from volume fit to 0000000050000000
bootconf: config-1#mt7988a-asiarf-ap7988-003-sd
## Loading kernel (any) from FIT Image at 50000000 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.12.47
     Type:         Kernel Image
     Compression:  gzip compressed
     Data Start:   0x50001000
     Data Size:    6073735 Bytes = 5.8 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x46000000
     Entry Point:  0x46000000
     Hash algo:    crc32
     Hash value:   02dd6e5b
     Hash algo:    sha1
     Hash value:   e43e152c3ec1c52f12fea072b0a476c747a53e8f
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt (any) from FIT Image at 50000000 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt asiarf_ap7988-003 device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x505cc000
     Data Size:    42352 Bytes = 41.4 KiB
     Architecture: AArch64
     Load Address: 0x45f00000
     Hash algo:    crc32
     Hash value:   9b835268
     Hash algo:    sha1
     Hash value:   88d51acf7d585c579f4ad8e7d03dcb8836fe9506
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Loading fdt from 0x505cc000 to 0x45f00000
   Loading Device Tree to 000000007e7ec000, end 000000007e7f9fff ... OK
Working FDT set to 7e7ec000
## Loading fdt (any) from FIT Image at 50000000 ...
   Using 'mt7988a-asiarf-ap7988-003-sd' configuration
   Trying 'fdt-mt7988a-asiarf-ap7988-003-sd' fdt subimage
     Description:  ARM64 OpenWrt asiarf_ap7988-003 device tree overlay mt7988a-asiarf-ap7988-003-sd
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x505d8000
     Data Size:    809 Bytes = 809 Bytes
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   48767d00
     Hash algo:    sha1
     Hash value:   23f5127677cf8b56258230f8c4512b0ad9ec9afa
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x7e7ec000
Working FDT set to 7e7ec000
## Loading loadables (any) from FIT Image at 50000000 ...
   Trying 'rootfs-1' loadables subimage
     Description:  ARM64 OpenWrt asiarf_ap7988-003 rootfs
     Type:         Filesystem Image
     Compression:  uncompressed
     Data Start:   0x505da000
     Data Size:    3964928 Bytes = 3.8 MiB
     Hash algo:    crc32
     Hash value:   bc7f4122
     Hash algo:    sha1
     Hash value:   dde60a5141a021bcf361035557445b3486664716
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Uncompressing Kernel Image to 46000000
   Loading Device Tree to 000000007e7df000, end 000000007e7eb64c ... OK
Working FDT set to 7e7df000
set /chosen/rootdisk to bootrom media: rootdisk-spim-nand (phandle 0x00000056)
FIT volume for fitblk set to 'fit'

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x411fd090]
[    0.000000] Linux version 6.12.47 (elwin@ubuntu-2204) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r31015+46-20d761cf19) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Sat Sep 20 14:43:09 2025
[    0.000000] Machine model: AsaiRF AP7988-003
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004304ffff (320 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x0000000047cc0000..0x0000000047dbffff (1024 KiB) nomap non-reusable wmcpu-reserved@47cc0000
[    0.000000] OF: reserved mem: 0x000000004f600000..0x000000004f63ffff (256 KiB) nomap non-reusable wo-emi@4f600000
[    0.000000] OF: reserved mem: 0x000000004f640000..0x000000004f67ffff (256 KiB) nomap non-reusable wo-emi@4f640000
[    0.000000] OF: reserved mem: 0x000000004f680000..0x000000004f6bffff (256 KiB) nomap non-reusable wo-emi@4f680000
[    0.000000] OF: reserved mem: 0x000000004f700000..0x000000004fefffff (8192 KiB) nomap non-reusable wo-data@4f700000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000007fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004304ffff]
[    0.000000]   node   0: [mem 0x0000000043050000-0x0000000047cbffff]
[    0.000000]   node   0: [mem 0x0000000047cc0000-0x0000000047dbffff]
[    0.000000]   node   0: [mem 0x0000000047dc0000-0x000000004f5fffff]
[    0.000000]   node   0: [mem 0x000000004f600000-0x000000004f6bffff]
[    0.000000]   node   0: [mem 0x000000004f6c0000-0x000000004f6fffff]
[    0.000000]   node   0: [mem 0x000000004f700000-0x000000004fefffff]
[    0.000000]   node   0: [mem 0x000000004ff00000-0x000000007fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000007fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.5
[    0.000000] percpu: Embedded 20 pages/cpu s42520 r8192 d31208 u81920
[    0.000000] pcpu-alloc: s42520 r8192 d31208 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: detected: Spectre-BHB
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: pci=pcie_bus_perf ubi.block=0,fit root=/dev/fit0 rootwait
[    0.000000] Dentry cache hash table entries: 131072 (order: 8, 1048576 bytes, linear)
[    0.000000] Inode-cache hash table entries: 65536 (order: 7, 524288 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 262144
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 1MB
[    0.000000] software IO TLB: area num 4.
[    0.000000] software IO TLB: mapped [mem 0x000000007ea80000-0x000000007eb80000] (1MB)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks Trace: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=4.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 416 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: GICD_CTRL.DS=0, SCR_EL3.FIQ=0
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000001] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000066] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000072] pid_max: default: 32768 minimum: 301
[    0.002140] Mount-cache hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.002147] Mountpoint-cache hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.003673] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.004154] rcu: Hierarchical SRCU implementation.
[    0.004156] rcu: 	Max phase no-delay instances is 1000.
[    0.004249] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.004428] smp: Bringing up secondary CPUs ...
[    0.004653] Detected VIPT I-cache on CPU1
[    0.004694] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.004716] CPU1: Booted secondary processor 0x0000000001 [0x411fd090]
[    0.004998] Detected VIPT I-cache on CPU2
[    0.005020] GICv3: CPU2: found redistributor 2 region 0:0x000000000c0c0000
[    0.005030] CPU2: Booted secondary processor 0x0000000002 [0x411fd090]
[    0.005267] Detected VIPT I-cache on CPU3
[    0.005288] GICv3: CPU3: found redistributor 3 region 0:0x000000000c0e0000
[    0.005298] CPU3: Booted secondary processor 0x0000000003 [0x411fd090]
[    0.005333] smp: Brought up 1 node, 4 CPUs
[    0.005337] SMP: Total of 4 processors activated.
[    0.005339] CPU: All CPU(s) started at EL2
[    0.005342] CPU features: detected: 32-bit EL0 Support
[    0.005344] CPU features: detected: CRC32 instructions
[    0.005372] alternatives: applying system-wide alternatives
[    0.005452] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.005556] Memory: 999392K/1048576K available (9216K kernel code, 976K rwdata, 2736K rodata, 448K init, 300K bss, 45748K reserved, 0K cma-reserved)
[    0.008239] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.008251] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.008296] 29312 pages in range for non-PLT usage
[    0.008298] 520832 pages in range for PLT usage
[    0.009407] pinctrl core: initialized pinctrl subsystem
[    0.010324] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.010582] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.010613] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.010641] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.010913] thermal_sys: Registered thermal governor 'fair_share'
[    0.010916] thermal_sys: Registered thermal governor 'bang_bang'
[    0.010918] thermal_sys: Registered thermal governor 'step_wise'
[    0.010920] thermal_sys: Registered thermal governor 'user_space'
[    0.010957] ASID allocator initialised with 65536 entries
[    0.011447] pstore: Using crash dump compression: deflate
[    0.011454] printk: legacy console [ramoops0] enabled
[    0.011724] pstore: Registered ramoops as persistent store backend
[    0.011729] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.013539] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.016892] /soc/pcie@11290000: Fixed dependency cycle(s) with /soc/pcie@11290000/interrupt-controller
[    0.017012] /soc/pcie@11300000: Fixed dependency cycle(s) with /soc/pcie@11300000/interrupt-controller
[    0.017104] /soc/pcie@11310000: Fixed dependency cycle(s) with /soc/pcie@11310000/interrupt-controller
[    0.027026] cryptd: max_cpu_qlen set to 1000
[    0.028873] SCSI subsystem initialized
[    0.028939] libata version 3.00 loaded.
[    0.029962] clocksource: Switched to clocksource arch_sys_counter
[    0.031691] NET: Registered PF_INET protocol family
[    0.031776] IP idents hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.032840] tcp_listen_portaddr_hash hash table entries: 512 (order: 1, 8192 bytes, linear)
[    0.032858] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.032866] TCP established hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.032900] TCP bind hash table entries: 8192 (order: 6, 262144 bytes, linear)
[    0.033014] TCP: Hash tables configured (established 8192 bind 8192)
[    0.033258] MPTCP token hash table entries: 1024 (order: 2, 24576 bytes, linear)
[    0.033333] UDP hash table entries: 512 (order: 2, 16384 bytes, linear)
[    0.033356] UDP-Lite hash table entries: 512 (order: 2, 16384 bytes, linear)
[    0.033503] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.033532] PCI: CLS 0 bytes, default 64
[    0.034389] workingset: timestamp_bits=46 max_order=18 bucket_order=0
[    0.038182] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.038189] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.070186] mtk-xsphy soc:xs-phy@11e10000: failed to get ref_clk(id-1)
[    0.070751] mtk-pcie-gen3 11290000.pcie: host bridge /soc/pcie@11290000 ranges:
[    0.070769] mtk-pcie-gen3 11290000.pcie: Parsing ranges property...
[    0.070783] mtk-pcie-gen3 11290000.pcie:       IO 0x0028000000..0x00281fffff -> 0x0028000000
[    0.070798] mtk-pcie-gen3 11290000.pcie:      MEM 0x0028200000..0x002fffffff -> 0x0028200000
[    0.070826] /soc/pcie@11290000: Failed to get clk index: 0 ret: -517
[    0.070835] mtk-pcie-gen3 11290000.pcie: failed to get clocks
[    0.070907] mtk-pcie-gen3 11300000.pcie: host bridge /soc/pcie@11300000 ranges:
[    0.070917] mtk-pcie-gen3 11300000.pcie: Parsing ranges property...
[    0.070928] mtk-pcie-gen3 11300000.pcie:       IO 0x0030000000..0x00301fffff -> 0x0030000000
[    0.070938] mtk-pcie-gen3 11300000.pcie:      MEM 0x0030200000..0x0037ffffff -> 0x0030200000
[    0.070956] /soc/pcie@11300000: Failed to get clk index: 0 ret: -517
[    0.070965] mtk-pcie-gen3 11300000.pcie: failed to get clocks
[    0.071046] mtk-pcie-gen3 11310000.pcie: host bridge /soc/pcie@11310000 ranges:
[    0.071056] mtk-pcie-gen3 11310000.pcie: Parsing ranges property...
[    0.071066] mtk-pcie-gen3 11310000.pcie:       IO 0x0038000000..0x00381fffff -> 0x0038000000
[    0.071076] mtk-pcie-gen3 11310000.pcie:      MEM 0x0038200000..0x003fffffff -> 0x0038200000
[    0.071093] /soc/pcie@11310000: Failed to get clk index: 0 ret: -517
[    0.071101] mtk-pcie-gen3 11310000.pcie: failed to get clocks
[    0.075487] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.076236] printk: legacy console [ttyS0] disabled
[    0.096494] 11000000.serial: ttyS0 at MMIO 0x11000000 (irq = 99, base_baud = 2500000) is a ST16650V2
[    0.096532] printk: legacy console [ttyS0] enabled
[    1.118540] 11000200.serial: ttyS1 at MMIO 0x11000200 (irq = 100, base_baud = 2500000) is a ST16650V2
[    1.128503] random: crng init done
[    1.133410] loop: module loaded
[    1.137907] spi-nand spi0.0: Macronix SPI NAND was found.
[    1.143341] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    1.151791] Signature found at block 1023 [0x07fe0000]
[    1.156920] NMBM management region starts at block 960 [0x07800000]
[    1.164208] First info table with writecount 2 found in block 960
[    1.172275] Second info table with writecount 2 found in block 963
[    1.178449] NMBM has been successfully attached
[    1.183121] 5 fixed-partitions partitions found on MTD device spi0.0
[    1.189482] OF: Bad cell count for /soc/spi@11007000/flash@0/partitions
[    1.196106] OF: Bad cell count for /soc/spi@11007000/flash@0/partitions
[    1.202858] Creating 5 MTD partitions on "spi0.0":
[    1.207641] 0x000000000000-0x000000100000 : "BL2"
[    1.213011] 0x000000100000-0x000000180000 : "u-boot-env"
[    1.218641] 0x000000180000-0x000000580000 : "Factory"
[    1.225468] OF: Bad cell count for /soc/spi@11007000/flash@0/partitions
[    1.232203] 0x000000580000-0x000000780000 : "FIP"
[    1.237891] 0x000000780000-0x000007800000 : "ubi"
[    1.289082] ubi0: default fastmap pool size: 45
[    1.293612] ubi0: default fastmap WL pool size: 22
[    1.298393] ubi0: attaching mtd4
[    1.654491] ubi0: scanning is finished
[    1.661813] ubi0 warning: ubi_eba_init: cannot reserve enough PEBs for bad PEB handling, reserved 17, need 19
[    1.672023] ubi0: attached mtd4 (name "ubi", size 112 MiB)
[    1.677500] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    1.684370] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    1.691149] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    1.698098] ubi0: good PEBs: 900, bad PEBs: 0, corrupted PEBs: 0
[    1.704095] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[    1.711307] ubi0: max/mean erase counter: 5/2, WL threshold: 4096, image sequence number: 0
[    1.719644] ubi0: available PEBs: 0, total reserved PEBs: 900, PEBs reserved for bad PEB handling: 17
[    1.728857] ubi0: background thread "ubi_bgt0d" started, PID 242
[    1.729127] block ubiblock0_1: created from ubi0:1(fit)
[    1.861471] i2c_dev: i2c /dev entries driver
[    1.866185] /soc/i2c@11003000/rt5190a@64: Fixed dependency cycle(s) with /soc/i2c@11003000/rt5190a@64/regulators/buck1
[    1.877293] i2c i2c-1: of_i2c: modalias failure on /soc/i2c@11004000/crypto@60
[    1.884521] i2c i2c-1: Failed to create I2C device for /soc/i2c@11004000/crypto@60
[    1.892713] mtk-lvts-thermal 1100a000.lvts: golden temp=60
[    1.899579] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.909899] mtk-msdc 11230000.mmc: Got CD GPIO
[    1.915420] NET: Registered PF_INET6 protocol family
[    1.920825] Segment Routing with IPv6
[    1.924494] In-situ OAM (IOAM) with IPv6
[    1.928434] NET: Registered PF_PACKET protocol family
[    1.933571] 8021q: 802.1Q VLAN Support v1.8
[    1.950505] phy phy-soc:xs-phy@11e10000.3: type_sw - reg 0x194, index 0
[    1.957653] mtk-pcie-gen3 11290000.pcie: host bridge /soc/pcie@11290000 ranges:
[    1.964973] mtk-pcie-gen3 11290000.pcie: Parsing ranges property...
[    1.971240] mtk-pcie-gen3 11290000.pcie:       IO 0x0028000000..0x00281fffff -> 0x0028000000
[    1.979673] mtk-pcie-gen3 11290000.pcie:      MEM 0x0028200000..0x002fffffff -> 0x0028200000
[    2.299979] mtk-pcie-gen3 11290000.pcie: PCIe link down, current LTSSM state: detect.quiet (0x1)
[    2.308785] mtk-pcie-gen3 11290000.pcie: probe with driver mtk-pcie-gen3 failed with error -110
[    2.317760] mtk-pcie-gen3 11300000.pcie: host bridge /soc/pcie@11300000 ranges:
[    2.325077] mtk-pcie-gen3 11300000.pcie: Parsing ranges property...
[    2.331346] mtk-pcie-gen3 11300000.pcie:       IO 0x0030000000..0x00301fffff -> 0x0030000000
[    2.339778] mtk-pcie-gen3 11300000.pcie:      MEM 0x0030200000..0x0037ffffff -> 0x0030200000
[    2.659967] mtk-pcie-gen3 11300000.pcie: PCIe link down, current LTSSM state: detect.quiet (0x1)
[    2.668745] mtk-pcie-gen3 11300000.pcie: probe with driver mtk-pcie-gen3 failed with error -110
[    2.677597] mtk-pcie-gen3 11310000.pcie: host bridge /soc/pcie@11310000 ranges:
[    2.684905] mtk-pcie-gen3 11310000.pcie: Parsing ranges property...
[    2.691170] mtk-pcie-gen3 11310000.pcie:       IO 0x0038000000..0x00381fffff -> 0x0038000000
[    2.699599] mtk-pcie-gen3 11310000.pcie:      MEM 0x0038200000..0x003fffffff -> 0x0038200000
[    3.019964] mtk-pcie-gen3 11310000.pcie: PCIe link down, current LTSSM state: detect.quiet (0x1)
[    3.028743] mtk-pcie-gen3 11310000.pcie: probe with driver mtk-pcie-gen3 failed with error -110
[    3.037963] FIT: Detected U-Boot 2025.07-g9a25de54e417-dirty
[    3.043622] FIT: Selected configuration: "config-1" (OpenWrt asiarf_ap7988-003)
[    3.050933] FIT:           kernel sub-image 0x00001000..0x005cbd86 "kernel-1" (ARM64 OpenWrt Linux-6.12.47) 
[    3.060759] FIT:          flat_dt sub-image 0x005cc000..0x005d656f "fdt-1" (ARM64 OpenWrt asiarf_ap7988-003 device tree blob) 
[    3.072145] FIT:          flat_dt sub-image 0x005d7000..0x005d762b "fdt-mt7988a-asiarf-ap7988-003-mmc" (ARM64 OpenWrt asiarf_ap7988-003 device tree overlay mt7988a-asiarf-ap7988-003-mmc) 
[    3.088826] FIT:          flat_dt sub-image 0x005d8000..0x005d8328 "fdt-mt7988a-asiarf-ap7988-003-sd" (ARM64 OpenWrt asiarf_ap7988-003 device tree overlay mt7988a-asiarf-ap7988-003-sd) 
[    3.105333] FIT:          flat_dt sub-image 0x005d9000..0x005d9561 "fdt-mt7988a-asiarf-ap7988-003-spidev" (ARM64 OpenWrt asiarf_ap7988-003 device tree overlay mt7988a-asiarf-ap7988-003-spidev) 
[    3.122532] FIT:       filesystem sub-image 0x005da000..0x009a1fff "rootfs-1" (ARM64 OpenWrt asiarf_ap7988-003 rootfs) 
[    3.133571] block ubiblock0_1: mapped 1 uImage.FIT filesystem sub-image as /dev/fit0
[    3.262099] mtk_soc_eth 15100000.ethernet: generated random MAC address 20:08:02:00:00:00
[    3.270451] mtk_soc_eth 15100000.ethernet: generated random MAC address 20:08:02:00:00:00
[    3.278787] mtk_soc_eth 15100000.ethernet: generated random MAC address 20:08:02:00:00:00
[    3.634465] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc082400000, irq 105
[    3.644136] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc082400000, irq 105
[    3.653783] mtk_soc_eth 15100000.ethernet eth2: mediatek frame engine at 0xffffffc082400000, irq 105
[    3.745379] mt7530-mmio 15020000.switch: configuring for fixed/internal link mode
[    3.752900] mt7530-mmio 15020000.switch: Link is Up - 10Gbps/Full - flow control rx/tx
[    3.780023] mt7530-mmio 15020000.switch lan1 (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7988 PHY] (irq=114)
[    3.818297] mt7530-mmio 15020000.switch lan2 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7988 PHY] (irq=115)
[    3.856195] mt7530-mmio 15020000.switch lan3 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7988 PHY] (irq=116)
[    3.894562] mt7530-mmio 15020000.switch lan4 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7988 PHY] (irq=117)
[    3.905521] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    3.912232] DSA: tree 0 setup
[    3.915481] clk: Disabling unused clocks
[    3.919842] PM: genpd: Disabling unused power domains
[    3.927563] VFS: Mounted root (squashfs filesystem) readonly on device 259:0.
[    3.934816] Freeing unused kernel memory: 448K
[    3.939287] Run /sbin/init as init process
[    3.943384]   with arguments:
[    3.946341]     /sbin/init
[    3.949036]   with environment:
[    3.952168]     HOME=/
[    3.954518]     TERM=linux
[    4.102281] init: Console is alive
[    4.105792] init: - watchdog -
[    4.270263] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    6.341717] Aquantia AQR113C mdio-bus:08: loading firmware version 'v5.6.9 Mediatek Mediatek 23B 100522 05:37:14' from 'NVMEM'
[   16.184756] init: - preinit -
[   16.388603] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/internal link mode
[   16.396794] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 10Gbps/Full - flow control rx/tx
[   16.411322] mt7530-mmio 15020000.switch lan1: configuring for phy/internal link mode
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[   20.475535] UBIFS (ubi0:2): Mounting in unauthenticated mode
[   20.481276] UBIFS (ubi0:2): background thread "ubifs_bgt0_2" started, PID 860
[   20.500056] UBIFS (ubi0:2): recovery needed
[   20.585609] UBIFS (ubi0:2): recovery completed
[   20.590102] UBIFS (ubi0:2): UBIFS: mounted UBI device 0, volume 2, name "rootfs_data"
[   20.597921] UBIFS (ubi0:2): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[   20.607825] UBIFS (ubi0:2): FS size: 89899008 bytes (85 MiB, 708 LEBs), max 719 LEBs, journal size 4444160 bytes (4 MiB, 35 LEBs)
[   20.619464] UBIFS (ubi0:2): reserved for root: 4246152 bytes (4146 KiB)
[   20.626068] UBIFS (ubi0:2): media format: w5/r0 (latest is w5/r0), UUID 63A582C5-AE23-4FB7-A613-A826759B01AC, small LPT model
[   20.640351] mount_root: switching to ubifs overlay
[   20.648665] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[   20.661853] urandom-seed: Seeding with /etc/urandom.seed
[   20.701068] procd: - early -
[   20.704007] procd: - watchdog -
[   21.224647] procd: - watchdog -
[   21.228904] procd: - ubus -
[   21.583100] procd: - init -
Please press Enter to activate this console.
[   21.854312] kmodloader: loading kernel modules from /etc/modules.d/*
[   21.868428] usbcore: registered new interface driver usbfs
[   21.873962] usbcore: registered new interface driver hub
[   21.879290] usbcore: registered new device driver usb
[   21.884851] gpio_button_hotplug: loading out-of-tree module taints kernel.
[   21.895537] xhci-mtk 11190000.usb: supply vbus not found, using dummy regulator
[   21.903000] xhci-mtk 11190000.usb: supply vusb33 not found, using dummy regulator
[   21.920623] xhci-mtk 11190000.usb: xHCI Host Controller
[   21.925864] xhci-mtk 11190000.usb: new USB bus registered, assigned bus number 1
[   21.933463] xhci-mtk 11190000.usb: hcc params 0x01403f99 hci version 0x110 quirks 0x0000000000200010
[   21.942626] xhci-mtk 11190000.usb: irq 118, io mem 0x11190000
[   21.948453] xhci-mtk 11190000.usb: xHCI Host Controller
[   21.953674] xhci-mtk 11190000.usb: new USB bus registered, assigned bus number 2
[   21.961062] xhci-mtk 11190000.usb: Host supports USB 3.2 Enhanced SuperSpeed
[   21.968621] hub 1-0:1.0: USB hub found
[   21.972385] hub 1-0:1.0: 1 port detected
[   21.976474] usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
[   21.984731] hub 2-0:1.0: USB hub found
[   21.988481] hub 2-0:1.0: 1 port detected
[   21.992702] xhci-mtk 11200000.usb: supply vbus not found, using dummy regulator
[   22.000075] xhci-mtk 11200000.usb: supply vusb33 not found, using dummy regulator
[   22.008385] xhci-mtk 11200000.usb: xHCI Host Controller
[   22.008971] urngd: v1.0.2 started.
[   22.013639] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 3
[   22.016666] xhci-mtk 11200000.usb: hcc params 0x01403f99 hci version 0x110 quirks 0x0000000000200010
[   22.033655] xhci-mtk 11200000.usb: irq 119, io mem 0x11200000
[   22.039484] xhci-mtk 11200000.usb: xHCI Host Controller
[   22.044718] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 4
[   22.052116] xhci-mtk 11200000.usb: Host supports USB 3.2 Enhanced SuperSpeed
[   22.059858] hub 3-0:1.0: USB hub found
[   22.063717] hub 3-0:1.0: 1 port detected
[   22.067875] usb usb4: We don't know the algorithms for LPM for this host, disabling LPM.
[   22.076321] hub 4-0:1.0: USB hub found
[   22.080081] hub 4-0:1.0: 1 port detected
[   22.180696] hwmon hwmon1: temp1_input not attached to any thermal zone
[   22.260600] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[   22.268439] crypto-safexcel 15600000.crypto: EIP197:331(7,1,8,4)-HIA:272(2,5,5),PE:151/450(alg:7fe1fc00)/240/240/450
[   22.279839] crypto-safexcel 15600000.crypto: TRC init: 8704d,48a (32r,128h)
[   22.375821] PPP generic driver version 2.4.2
[   22.380860] NET: Registered PF_PPPOX protocol family
[   22.387538] kmodloader: done loading kernel modules from /etc/modules.d/*
[   24.705970] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   24.733300] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/internal link mode
[   24.741488] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 10Gbps/Full - flow control rx/tx
[   24.743472] mt7530-mmio 15020000.switch lan1: configuring for phy/internal link mode
[   24.758780] br-lan: port 1(lan1) entered blocking state
[   24.764107] br-lan: port 1(lan1) entered disabled state
[   24.769383] mt7530-mmio 15020000.switch lan1: entered allmulticast mode
[   24.776041] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   24.783084] mt7530-mmio 15020000.switch lan1: entered promiscuous mode
[   24.795461] mt7530-mmio 15020000.switch lan2: configuring for phy/internal link mode
[   24.803796] br-lan: port 2(lan2) entered blocking state
[   24.809051] br-lan: port 2(lan2) entered disabled state
[   24.814369] mt7530-mmio 15020000.switch lan2: entered allmulticast mode
[   24.821300] mt7530-mmio 15020000.switch lan2: entered promiscuous mode
[   24.831336] mt7530-mmio 15020000.switch lan3: configuring for phy/internal link mode
[   24.840355] br-lan: port 3(lan3) entered blocking state
[   24.845594] br-lan: port 3(lan3) entered disabled state
[   24.850904] mt7530-mmio 15020000.switch lan3: entered allmulticast mode
[   24.857817] mt7530-mmio 15020000.switch lan3: entered promiscuous mode
[   24.867888] mt7530-mmio 15020000.switch lan4: configuring for phy/internal link mode
[   24.876789] br-lan: port 4(lan4) entered blocking state
[   24.882081] br-lan: port 4(lan4) entered disabled state
[   24.887348] mt7530-mmio 15020000.switch lan4: entered allmulticast mode
[   24.894382] mt7530-mmio 15020000.switch lan4: entered promiscuous mode
[   24.914282] mtk_soc_eth 15100000.ethernet eth2: PHY [mdio-bus:08] driver [Aquantia AQR113C] (irq=POLL)
[   24.923716] mtk_soc_eth 15100000.ethernet eth2: configuring for phy/usxgmii link mode
[   24.951045] br-lan: port 5(eth2) entered blocking state
[   24.956297] br-lan: port 5(eth2) entered disabled state
[   24.961627] mtk_soc_eth 15100000.ethernet eth2: entered allmulticast mode
[   24.968601] mtk_soc_eth 15100000.ethernet eth2: entered promiscuous mode
[   25.022163] MediaTek MT7988 2.5GbE PHY mdio-bus:0f: Firmware date code: 2024/10/30, version: 10.0
[   25.039988] mtk_soc_eth 15100000.ethernet eth1: PHY [mdio-bus:0f] driver [MediaTek MT7988 2.5GbE PHY] (irq=POLL)
[   25.050194] mtk_soc_eth 15100000.ethernet eth1: configuring for phy/internal link mode
[   28.269946] mt7530-mmio 15020000.switch lan3: Link is Up - 1Gbps/Full - flow control rx/tx
[   28.269984] br-lan: port 3(lan3) entered blocking state
[   28.283447] br-lan: port 3(lan3) entered forwarding state



BusyBox v1.37.0 (2025-09-10 04:34:58 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt SNAPSHOT, r31109+6-0203ef3fc9
 -----------------------------------------------------
=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------

 OpenWrt recently switched to the "apk" package manager!

 OPKG Command           APK Equivalent      Description
 ------------------------------------------------------------------
 opkg install <pkg>     apk add <pkg>       Install a package
 opkg remove <pkg>      apk del <pkg>       Remove a package
 opkg upgrade           apk upgrade         Upgrade all packages
 opkg files <pkg>       apk info -L <pkg>   List package contents
 opkg list-installed    apk info            List installed packages
 opkg update            apk update          Update package lists
 opkg search <pkg>      apk search <pkg>    Search for packages
 ------------------------------------------------------------------

For more https://openwrt.org/docs/guide-user/additional-software/opkg-to-apk-cheatsheet

root@OpenWrt:~# 
```
</details>


<h2>How to flash</h2>

**Flash instruction through LuCI:**

This device is flashed OpenWRT base firmware with this target.
The LuCI webpage is integrated in default for upgrading.

**Flash instruction through u-boot:**

1. Prepare the TFTP server on PC.
2. Connect uart to PC, select "2. Upgrade firmware" in u-boot menu.
3. input client IP, server IP, flashed bin file path
4. Wait about 20 seconds to complete flashing

<h2>Links</h2>

[Product link](https://asiarf.com/product/wifi7-enterprise-asymmetric-cryptography-development-platform/)

