### PR TITLE
ubox: logread: fix crash on malformed data

### DIFF
--- a/package/system/ubox/patches/001-logread-fix-crash-on-malformed.patch
+++ b/package/system/ubox/patches/001-logread-fix-crash-on-malformed.patch
@@ -1,0 +1,23 @@
+--- a/log/logread.c
++++ b/log/logread.c
+@@ -250,10 +250,19 @@ static int usage(const char *prog)
+ 		int len, cur_len;
+ 
+ 		a = (void*) ustream_get_read_buf(s, &len);
+-		if (len < sizeof(*a))
++		if (len < (int)sizeof(*a))
+ 			break;
+ 
+ 		cur_len = blob_len(a) + sizeof(*a);
++
++		if (cur_len <= sizeof(*a) || cur_len > 4096) {
++			fprintf(stderr,
++				"logread: dropping invalid blob (cur_len=%d, buf=%d)\n",
++				cur_len, len);
++			ustream_consume(s, sizeof(*a));
++			continue;
++		}
++
+ 		if (len < cur_len)
+ 			break;
+ 


### PR DESCRIPTION
Additional checks to prevent crashes due to malformed data.

Fixes crashes observed with ramips/mt7620 and kernel 6.12 when running logread frequently (via cron):
```
[  335.462668] CPU 0 Unable to handle kernel paging request at virtual address 702e1c60, epc == 702e1c60, ra == 80001db0
[  335.473640] Oops[#1]:
[  335.475973] CPU: 0 UID: 0 PID: 3559 Comm: logread Tainted: G           O       6.12.45 #0
[  335.484331] Tainted: [O]=OOT_MODULE
[  335.487887] Hardware name: TP-Link EC220-G5 v2
[  335.492685] $ 0   : 00000000 00000001 81b570e0 809a3cdc
[  335.498048] $ 4   : 00000cc0 00000001 00019e63 82b39300
[  335.503406] $ 8   : 00019e64 00000cc0 00000000 ffffffff
[  335.508763] $12   : 82bb9fa8 00000000 00000000 7ffcdfff
[  335.514121] $16   : 0000001b 77ec9000 77ee0000 68c6a69e
[  335.519479] $20   : 8383fbf8 00000000 55650000 77ee0000
[  335.524838] $24   : 00000003 807a0ea0                  
[  335.530194] $28   : 82e30000 82e31f28 00000000 80001db0
[  335.535553] Hi    : 00009700
[  335.538489] Lo    : 0000a69e
[  335.541426] epc   : 702e1c60 0x702e1c60
[  335.545349] ra    : 80001db0 work_notifysig+0x10/0x18
[  335.550519] Status: 1100f403	KERNEL EXL IE 
[  335.554804] Cause : 50800008 (ExcCode 02)
[  335.558895] BadVA : 702e1c60
[  335.561832] PrId  : 00019650 (MIPS 24KEc)
[  335.565922] Modules linked in: rt2800soc(O) rt2800mmio(O) rt2800lib(O) pppoe ppp_async nft_fib_inet nf_flow_table_inet rt2x00soc(O) rt2x00mmio(O) rt2x00lib(O) pppox ppp_generic nft_reject_ipv6 nft_reject_ipv4 nft_reject_inet nft_reject nft_redir nft_quota nft_numgen nft_nat nft_masq nft_log nft_limit nft_hash nft_flow_offload nft_fib_ipv6 nft_fib_ipv4 nft_fib nft_ct nft_chain_nat nf_tables nf_nat_tftp nf_nat_snmp_basic nf_nat_sip nf_nat_pptp nf_nat_irc nf_nat_h323 nf_nat_amanda nf_nat nf_flow_table nf_conntrack_tftp nf_conntrack_snmp nf_conntrack_sip nf_conntrack_sane nf_conntrack_pptp nf_conntrack_netbios_ns nf_conntrack_irc nf_conntrack_h323 nf_conntrack_broadcast nf_conntrack_amanda nf_conntrack mt76x2e(O) mt76x2_common(O) mt76x02_lib(O) mt76(O) mac80211(O) cfg80211(O) ts_kmp ts_fsm ts_bm slhc nfnetlink nf_reject_ipv6 nf_reject_ipv4 nf_log_syslog nf_defrag_ipv6 nf_defrag_ipv4 libcrc32c crc_ccitt compat(O) asn1_decoder sit tunnel4 ip_tunnel sha512_generic seqiv sha3_generic jitterentropy_rng drbg hmac geniv rng cmac
[  335.566488]  leds_gpio rtl8367b rtl8366_smi gpio_button_hotplug(O) crc32c_generic
[  335.666103] Process logread (pid: 3559, threadinfo=aaef5cd3, task=99f56f6d, tls=77ee9dfc)
[  335.674461] Stack : 00000000 00000000 00000000 00000000 77ee8290 00420030 7fbdb308 00420030
[  335.683036]         00000000 00000001 00000000 00000048 77ec9000 0000001b 00000000 00000000
[  335.691606]         00000000 00000000 81d823d4 ffffffff 7fbdafe0 00000008 00401bc0 00000000
[  335.700178]         0000001b 77ec9000 77ee0000 68c6a69e 8383fbf8 00000000 55650000 77ee0000
[  335.708752]         00000000 77ea66d0 00000001 00000000 77ee8290 7fbdb070 00000000 77e70674
[  335.717324]         ...
[  335.719827] Call Trace:
[  335.719832] 
[  335.723906] 
[  335.725424] Code: (Bad address in epc)
[  335.725424] 
[  335.730755] 
[  335.732418] ---[ end trace 0000000000000000 ]---
[  335.737145] Kernel panic - not syncing: Fatal exception
[  335.742484] Rebooting in 3 seconds..

```
Similarly for the DSA version (https://github.com/openwrt/openwrt/pull/19397/):
```
[  452.171818] CPU 0 Unable to handle kernel paging request at virtual address 702e1534, epc == 702e1534, ra == 80001db0
[  452.182925] Oops[#1]:
[  452.185265] CPU: 0 UID: 0 PID: 4012 Comm: logread Tainted: G           O       6.12.40 #0
[  452.193623] Tainted: [O]=OOT_MODULE
[  452.197179] Hardware name: TP-Link EC220-G5 v2 (DSA)
[  452.202509] $ 0   : 00000000 00000001 81a82040 809d3cdc
[  452.207873] $ 4   : 00000cc0 00000001 000151a4 82a37d80
[  452.213231] $ 8   : 000151a5 00000cc0 00000000 ffffffff
[  452.218589] $12   : 82ffb3a8 00000000 00000000 7ff05fff
[  452.223948] $16   : 0000001b 77e02000 77e19000 6893608b
[  452.229306] $20   : 8383fbf8 00000000 00000000 77e19000
[  452.234664] $24   : 00000003 807cbe88                  
[  452.240021] $28   : 82926000 82927f28 00000000 80001db0
[  452.245380] Hi    : 0000f700
[  452.248317] Lo    : 0000608b
[  452.251254] epc   : 702e1534 0x702e1534
[  452.255177] ra    : 80001db0 work_notifysig+0x10/0x18
[  452.260347] Status: 1100f403KERNEL EXL IE 
[  452.264633] Cause : 50800008 (ExcCode 02)
[  452.268723] BadVA : 702e1534
[  452.271660] PrId  : 00019650 (MIPS 24KEc)
[  452.275750] Modules linked in: rt2800soc(O) rt2800mmio(O) rt2800lib(O) pppoe ppp_async nft_fib_inet nf_flow_table_inet rt2x00soc(O) rt2x00mmio(O) rt2x00lib(O) pppox ppp_generic nft_reject_ipv6 nft_reject_ipv4 nft_reject_inet nft_reject nft_redir nft_quota nft_numgen nft_nat nft_masq nft_log nft_limit nft_hash nft_flow_offload nft_fib_ipv6 nft_fib_ipv4 nft_fib nft_ct nft_chain_nat nf_tables nf_nat_tftp nf_nat_snmp_basic nf_nat_sip nf_nat_pptp nf_nat_irc nf_nat_h323 nf_nat_amanda nf_nat nf_flow_table nf_conntrack_tftp nf_conntrack_snmp nf_conntrack_sip nf_conntrack_sane nf_conntrack_pptp nf_conntrack_netbios_ns nf_conntrack_irc nf_conntrack_h323 nf_conntrack_broadcast nf_conntrack_amanda nf_conntrack mt76x2e(O) mt76x2_common(O) mt76x02_lib(O) mt76(O) mac80211(O) cfg80211(O) ts_kmp ts_fsm ts_bm slhc nfnetlink nf_reject_ipv6 nf_reject_ipv4 nf_log_syslog nf_defrag_ipv6 nf_defrag_ipv4 libcrc32c crc_ccitt compat(O) asn1_decoder i2c_dev sit tunnel4 ip_tunnel sha512_generic seqiv sha3_generic jitterentropy_rng drbg hmac geniv
[  452.276319]  rng cmac leds_gpio tag_rtl8_4 rtl8365mb realtek_dsa dsa_core gpio_button_hotplug(O) realtek hwmon i2c_core phylink crc32c_generic
[  452.381300] Process logread (pid: 4012, threadinfo=115b8766, task=188f5d0f, tls=77e22dfc)
[  452.389660] Stack : 00000000 00000000 00000000 00000000 77e21290 00420030 7fe63e68 00420030
[  452.398236]         00000000 00000001 00000000 00000050 77e02000 0000001b 00000000 00000000
[  452.406808]         00000000 00000000 838343d4 ffffffff 7fe63b40 00000008 00401b40 00000000
[  452.415383]         0000001b 77e02000 77e19000 6893608b 8383fbf8 00000000 00000000 77e19000
[  452.423957]         00000000 77ddf6d0 00000001 00000000 77e21290 7fe63bd0 00000000 77da9674
[  452.432532]         ...
[  452.435035] Call Trace:
[  452.435041] 
[  452.439062] 
[  452.440581] Code: (Bad address in epc)
[  452.440581] 
[  452.445913] 
[  452.450633] ---[ end trace 0000000000000000 ]---
[  452.458093] Kernel panic - not syncing: Fatal exception
[  452.463468] Rebooting in 3 seconds..
```