### PR TITLE
econet: Make eth0 a wan interface

### DIFF
--- a/target/linux/econet/base-files/etc/board.d/02_network
+++ b/target/linux/econet/base-files/etc/board.d/02_network
@@ -1,0 +1,11 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+. /lib/functions/uci-defaults.sh
+. /lib/functions/system.sh
+
+board_config_update
+
+ucidef_set_interface_wan "eth0"
+
+board_config_flush


### PR DESCRIPTION
The internal ethernet device on EcoNet boards is not yet supported but with USB support, we can now use a USB ethernet dongle to get internet working for testing and development purposes.

Make the device register eth0 as a wan interface so that networking will work.

---

I'm sorry to make a PR for something so trivial, but it's useful for the people who are playing with EcoNet currently, and I need to get the branch off of my desk so I can start working on PCI.