### PR TITLE
realtek: dts: add pcs-handle to switch ports

### DIFF
--- a/target/linux/realtek/dts/rtl8380_d-link_dgs-1210-10mp-f.dts
+++ b/target/linux/realtek/dts/rtl8380_d-link_dgs-1210-10mp-f.dts
@@ -106,6 +106,7 @@
 		port@24 {
 			reg = <24>;
 			label = "lan9";
+			pcs-handle = <&serdes4>;
 			phy-handle = <&phy24>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
@@ -115,6 +116,7 @@
 		port@26 {
 			reg = <26>;
 			label = "lan10";
+			pcs-handle = <&serdes5>;
 			phy-handle = <&phy26>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";

--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
@@ -202,11 +202,13 @@
 		SWITCH_PORT(14, 7, internal)
 		SWITCH_PORT(15, 8, internal)
 
+		/* TODO: fixed link SFP is not right */
 		SWITCH_SFP_PORT(24, 9, 1000base-x)
 
 		port@26 {
 			reg = <26>;
 			label = "lan10";
+			pcs-handle = <&serdes5>;
 			phy-mode = "1000base-x";
 			phy-handle = <&phy26>;
 			managed = "in-band-status";

--- a/target/linux/realtek/dts/rtl8380_hpe_1920-8g.dtsi
+++ b/target/linux/realtek/dts/rtl8380_hpe_1920-8g.dtsi
@@ -88,6 +88,7 @@
 		port@24 {
 			reg = <24>;
 			label = "lan9";
+			pcs-handle = <&serdes4>;
 			phy-handle = <&phy24>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
@@ -97,6 +98,7 @@
 		port@26 {
 			reg = <26>;
 			label = "lan10";
+			pcs-handle = <&serdes5>;
 			phy-handle = <&phy26>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";

--- a/target/linux/realtek/dts/rtl8380_linksys_lgs310c.dts
+++ b/target/linux/realtek/dts/rtl8380_linksys_lgs310c.dts
@@ -178,6 +178,7 @@
 		port@24 {
 			reg = <24>;
 			label = "lan9";
+			pcs-handle = <&serdes4>;
 			phy-handle = <&phy24>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
@@ -187,6 +188,7 @@
 		port@26 {
 			reg = <26>;
 			label = "lan10";
+			pcs-handle = <&serdes5>;
 			phy-handle = <&phy26>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";

--- a/target/linux/realtek/dts/rtl8380_netgear_gs110tup-v1.dts
+++ b/target/linux/realtek/dts/rtl8380_netgear_gs110tup-v1.dts
@@ -53,6 +53,7 @@
 &switch0 {
 	ports {
 		SWITCH_PORT(16, 9, qsgmii)
+		/* TODO: fixed link SFP is not right */
 		SWITCH_SFP_PORT(24, 10, rgmii-id)
 	};
 };

--- a/target/linux/realtek/dts/rtl8380_netgear_gs310tp-v1.dts
+++ b/target/linux/realtek/dts/rtl8380_netgear_gs310tp-v1.dts
@@ -56,6 +56,7 @@
 
 &switch0 {
 	ports {
+		/* TODO: fixed link SFP is not right */
 		SWITCH_SFP_PORT(24, 9, 1000base-x)
 		SWITCH_SFP_PORT(26, 10, 1000base-x)
 	};

--- a/target/linux/realtek/dts/rtl8380_panasonic_m8eg-pn28080k.dts
+++ b/target/linux/realtek/dts/rtl8380_panasonic_m8eg-pn28080k.dts
@@ -104,8 +104,9 @@
 		port@24 {
 			reg = <24>;
 			label = "lan9";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes4>;
 			phy-handle = <&phy24>;
+			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp0>;
 		};

--- a/target/linux/realtek/dts/rtl8380_tplink_sg2xxx.dtsi
+++ b/target/linux/realtek/dts/rtl8380_tplink_sg2xxx.dtsi
@@ -171,6 +171,7 @@
 		SWITCH_PORT(9, 7, internal)
 		SWITCH_PORT(8, 8, internal)
 
+		/* TODO: fixed link SFP is not right */
 		SWITCH_SFP_PORT(24, 9, 1000base-x)
 		SWITCH_SFP_PORT(26, 10, 1000base-x)
 

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp.dts
@@ -62,6 +62,7 @@
 		port@24 {
 			reg = <24>;
 			label = "lan9";
+			pcs-handle = <&serdes4>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp0>;
@@ -70,6 +71,7 @@
 		port@26 {
 			reg = <26>;
 			label = "lan10";
+			pcs-handle = <&serdes5>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp1>;

--- a/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-10p.dts
+++ b/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-10p.dts
@@ -105,6 +105,7 @@
 		port@24 {
 			reg = <24>;
 			label = "lan9";
+			pcs-handle = <&serdes4>;
 			phy-handle = <&phy24>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
@@ -114,6 +115,7 @@
 		port@26 {
 			reg = <26>;
 			label = "lan10";
+			pcs-handle = <&serdes5>;
 			phy-handle = <&phy26>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";

--- a/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-26.dts
+++ b/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-26.dts
@@ -112,6 +112,7 @@
 		port@24 {
 			reg = <24>;
 			label = "lan25";
+			pcs-handle = <&serdes4>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp0>;
@@ -120,6 +121,7 @@
 		port@26 {
 			reg = <26>;
 			label = "lan26";
+			pcs-handle = <&serdes5>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp1>;

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24-v1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24-v1.dts
@@ -109,6 +109,7 @@
 		port@24 {
 			reg = <24>;
 			label = "lan25";
+			pcs-handle = <&serdes4>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp0>;
@@ -117,6 +118,7 @@
 		port@26 {
 			reg = <26>;
 			label = "lan26";
+			pcs-handle = <&serdes5>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp1>;

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-v1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-v1.dts
@@ -109,6 +109,7 @@
 		port@24 {
 			reg = <24>;
 			label = "lan25";
+			pcs-handle = <&serdes4>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp0>;
@@ -117,6 +118,7 @@
 		port@26 {
 			reg = <26>;
 			label = "lan26";
+			pcs-handle = <&serdes5>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp1>;

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-v2.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-v2.dts
@@ -106,6 +106,7 @@
 		port@24 {
 			reg = <24>;
 			label = "lan25";
+			pcs-handle = <&serdes4>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp0>;
@@ -114,6 +115,7 @@
 		port@26 {
 			reg = <26>;
 			label = "lan26";
+			pcs-handle = <&serdes5>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp1>;

--- a/target/linux/realtek/dts/rtl8393_netgear_gs750e.dts
+++ b/target/linux/realtek/dts/rtl8393_netgear_gs750e.dts
@@ -230,7 +230,7 @@
 		SWITCH_PORT(46, 47, qsgmii)
 		SWITCH_PORT(47, 48, qsgmii)
 
-		/* SFP cages */
+		/* TODO: fixed link SFP is not right */
 		SWITCH_SFP_PORT(48, 49, sgmii)
 		SWITCH_SFP_PORT(49, 50, sgmii)
 

--- a/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48.dts
+++ b/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48.dts
@@ -273,6 +273,7 @@
 		port@48 {
 			reg = <48>;
 			label = "lan49";
+			pcs-handle = <&serdes12>;
 			phy-mode = "1000base-x";
 			phy-handle = <&phy48>;
 			managed = "in-band-status";
@@ -282,6 +283,7 @@
 		port@49 {
 			reg = <49>;
 			label = "lan50";
+			pcs-handle = <&serdes13>;
 			phy-mode = "1000base-x";
 			phy-handle = <&phy49>;
 			managed = "in-band-status";

--- a/target/linux/realtek/dts/rtl9302_plasmacloud_psx10.dts
+++ b/target/linux/realtek/dts/rtl9302_plasmacloud_psx10.dts
@@ -45,8 +45,9 @@
 		port@26 {
 			reg = <26>;
 			label = "lan9";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes8>;
 			phy-handle = <&phy26>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp0>;
 			led-set = <0>;
 			managed = "in-band-status";
@@ -58,8 +59,9 @@
 		port@27 {
 			reg = <27>;
 			label = "lan10";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes9>;
 			phy-handle = <&phy27>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp1>;
 			led-set = <0>;
 			managed = "in-band-status";

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-a1.dts
@@ -33,15 +33,17 @@
 		port@24 {
 			reg = <24>;
 			label = "lan9";
-			phy-mode = "2500base-x";
+			pcs-handle = <&serdes6>;
 			phy-handle = <&phy24>;
+			phy-mode = "2500base-x";
 			led-set = <1>;
 		};
 		port@25 {
 			reg = <25>;
 			label = "lan10";
-			phy-mode = "2500base-x";
+			pcs-handle = <&serdes7>;
 			phy-handle = <&phy25>;
+			phy-mode = "2500base-x";
 			led-set = <1>;
 		};
 	};

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-common.dtsi
@@ -204,6 +204,7 @@
 		port@0 {
 			reg = <0>;
 			label = "lan1";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy0>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -211,6 +212,7 @@
 		port@1 {
 			reg = <1>;
 			label = "lan2";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy1>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -218,6 +220,7 @@
 		port@2 {
 			reg = <2>;
 			label = "lan3";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy2>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -225,6 +228,7 @@
 		port@3 {
 			reg = <3>;
 			label = "lan4";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy3>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -232,6 +236,7 @@
 		port@4 {
 			reg = <4>;
 			label = "lan5";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy4>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -239,6 +244,7 @@
 		port@5 {
 			reg = <5>;
 			label = "lan6";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy5>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -246,6 +252,7 @@
 		port@6 {
 			reg = <6>;
 			label = "lan7";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy6>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -253,6 +260,7 @@
 		port@7 {
 			reg = <7>;
 			label = "lan8";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy7>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -261,8 +269,9 @@
 		port@26 {
 			reg = <26>;
 			label = "lan11";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes8>;
 			phy-handle = <&phy26>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp0>;
 			led-set = <2>;
 			managed = "in-band-status";
@@ -271,8 +280,9 @@
 		port@27 {
 			reg = <27>;
 			label = "lan12";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes9>;
 			phy-handle = <&phy27>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp1>;
 			led-set = <2>;
 			managed = "in-band-status";

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12.dts
@@ -308,6 +308,7 @@
 		port@0 {
 			reg = <0>;
 			label = "lan1";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy0>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -315,6 +316,7 @@
 		port@1 {
 			reg = <1>;
 			label = "lan2";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy1>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -322,6 +324,7 @@
 		port@2 {
 			reg = <2>;
 			label = "lan3";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy2>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -329,6 +332,7 @@
 		port@3 {
 			reg = <3>;
 			label = "lan4";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy3>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -336,6 +340,7 @@
 		port@4 {
 			reg = <4>;
 			label = "lan5";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy4>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -343,6 +348,7 @@
 		port@5 {
 			reg = <5>;
 			label = "lan6";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy5>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -350,6 +356,7 @@
 		port@6 {
 			reg = <6>;
 			label = "lan7";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy6>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -357,6 +364,7 @@
 		port@7 {
 			reg = <7>;
 			label = "lan8";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy7>;
 			phy-mode = "usxgmii";
 			led-set = <0>;
@@ -365,30 +373,34 @@
 		port@24 {
 			reg = <24>;
 			label = "lan9";
-			phy-mode = "usxgmii";
+			pcs-handle = <&serdes6>;
 			phy-handle = <&phy24>;
+			phy-mode = "usxgmii";
 			led-set = <1>;
 		};
 		port@25 {
 			reg = <25>;
 			label = "lan10";
-			phy-mode = "usxgmii";
+			pcs-handle = <&serdes7>;
 			phy-handle = <&phy25>;
+			phy-mode = "usxgmii";
 			led-set = <1>;
 		};
 		port@26 {
 			reg = <26>;
 			label = "lan11";
-			phy-mode = "usxgmii";
+			pcs-handle = <&serdes8>;
 			phy-handle = <&phy26>;
+			phy-mode = "usxgmii";
 			led-set = <1>;
 		};
 
 		port@27 {
 			reg = <27>;
 			label = "lan12";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes9>;
 			phy-handle = <&phy27>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp0>;
 			led-set = <2>;
 			managed = "in-band-status";

--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
@@ -192,64 +192,72 @@
 		port@0 {
 			reg = <0>;
 			label = "lan1";
-			phy-mode = "usxgmii";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy0>;
+			phy-mode = "usxgmii";
 			led-set = <0>;
 		};
 
 		port@8 {
 			reg = <8>;
 			label = "lan2";
-			phy-mode = "usxgmii";
+			pcs-handle = <&serdes3>;
 			phy-handle = <&phy8>;
+			phy-mode = "usxgmii";
 			led-set = <0>;
 		};
 
 		port@16 {
 			reg = <16>;
 			label = "lan3";
-			phy-mode = "usxgmii";
+			pcs-handle = <&serdes4>;
 			phy-handle = <&phy16>;
+			phy-mode = "usxgmii";
 			led-set = <0>;
 		};
 
 		port@20 {
 			reg = <20>;
 			label = "lan4";
-			phy-mode = "usxgmii";
+			pcs-handle = <&serdes5>;
 			phy-handle = <&phy20>;
+			phy-mode = "usxgmii";
 			led-set = <0>;
 		};
 
 		port@24 {
 			reg = <24>;
 			label = "lan5";
-			phy-mode = "usxgmii";
+			pcs-handle = <&serdes6>;
 			phy-handle = <&phy24>;
+			phy-mode = "usxgmii";
 			led-set = <0>;
 		};
 
 		port@25 {
 			reg = <25>;
 			label = "lan6";
-			phy-mode = "usxgmii";
+			pcs-handle = <&serdes7>;
 			phy-handle = <&phy25>;
+			phy-mode = "usxgmii";
 			led-set = <0>;
 		};
 
 		port@26 {
 			reg = <26>;
 			label = "lan7";
-			phy-mode = "usxgmii";
+			pcs-handle = <&serdes8>;
 			phy-handle = <&phy26>;
+			phy-mode = "usxgmii";
 			led-set = <0>;
 		};
 
 		port@27 {
 			reg = <27>;
 			label = "lan8";
-			phy-mode = "usxgmii";
+			pcs-handle = <&serdes9>;
 			phy-handle = <&phy27>;
+			phy-mode = "usxgmii";
 			led-set = <0>;
 		};
 

--- a/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f-v2.dts
+++ b/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f-v2.dts
@@ -251,8 +251,9 @@
 		port@0 {
 			reg = <0>;
 			label = "lan1";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy0>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp0>;
 			managed = "in-band-status";
 			led-set = <0>;
@@ -261,8 +262,9 @@
 		port@8 {
 			reg = <8>;
 			label = "lan2";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes3>;
 			phy-handle = <&phy8>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp1>;
 			managed = "in-band-status";
 			led-set = <0>;
@@ -271,8 +273,9 @@
 		port@10 {
 			reg = <16>;
 			label = "lan3";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes4>;
 			phy-handle = <&phy16>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp2>;
 			managed = "in-band-status";
 			led-set = <0>;
@@ -281,8 +284,9 @@
 		port@14 {
 			reg = <20>;
 			label = "lan4";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes5>;
 			phy-handle = <&phy20>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp3>;
 			managed = "in-band-status";
 			led-set = <0>;
@@ -291,8 +295,9 @@
 		port@18 {
 			reg = <24>;
 			label = "lan5";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes6>;
 			phy-handle = <&phy24>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp4>;
 			managed = "in-band-status";
 			led-set = <0>;
@@ -301,8 +306,9 @@
 		port@19 {
 			reg = <25>;
 			label = "lan6";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes7>;
 			phy-handle = <&phy25>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp5>;
 			managed = "in-band-status";
 			led-set = <0>;
@@ -311,8 +317,9 @@
 		port@1a {
 			reg = <26>;
 			label = "lan7";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes8>;
 			phy-handle = <&phy26>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp6>;
 			managed = "in-band-status";
 			led-set = <0>;
@@ -321,8 +328,9 @@
 		port@1b {
 			reg = <27>;
 			label = "lan8";
-			phy-mode = "1000base-x";
+			pcs-handle = <&serdes9>;
 			phy-handle = <&phy27>;
+			phy-mode = "1000base-x";
 			sfp = <&sfp7>;
 			managed = "in-band-status";
 			led-set = <0>;

--- a/target/linux/realtek/dts/rtl9303_vimin_vm-s100-0800ms.dts
+++ b/target/linux/realtek/dts/rtl9303_vimin_vm-s100-0800ms.dts
@@ -240,6 +240,7 @@
 		port@0 {
 			reg = <0>;
 			label = "lan1";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy0>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp0>;
@@ -250,6 +251,7 @@
 		port@8 {
 			reg = <8>;
 			label = "lan2";
+			pcs-handle = <&serdes3>;
 			phy-handle = <&phy8>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp1>;
@@ -260,6 +262,7 @@
 		port@10 {
 			reg = <16>;
 			label = "lan3";
+			pcs-handle = <&serdes4>;
 			phy-handle = <&phy16>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp2>;
@@ -270,6 +273,7 @@
 		port@14 {
 			reg = <20>;
 			label = "lan4";
+			pcs-handle = <&serdes5>;
 			phy-handle = <&phy20>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp3>;
@@ -280,6 +284,7 @@
 		port@18 {
 			reg = <24>;
 			label = "lan5";
+			pcs-handle = <&serdes6>;
 			phy-handle = <&phy24>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp4>;
@@ -290,6 +295,7 @@
 		port@19 {
 			reg = <25>;
 			label = "lan6";
+			pcs-handle = <&serdes7>;
 			phy-handle = <&phy25>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp5>;
@@ -300,6 +306,7 @@
 		port@1a {
 			reg = <26>;
 			label = "lan7";
+			pcs-handle = <&serdes8>;
 			phy-handle = <&phy26>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp6>;
@@ -310,6 +317,7 @@
 		port@1b {
 			reg = <27>;
 			label = "lan8";
+			pcs-handle = <&serdes9>;
 			phy-handle = <&phy27>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp7>;

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
@@ -262,6 +262,7 @@
 		port@0 {
 			reg = <0>;
 			label = "lan1";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy0>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp0>;
@@ -272,6 +273,7 @@
 		port@8 {
 			reg = <8>;
 			label = "lan2";
+			pcs-handle = <&serdes3>;
 			phy-handle = <&phy8>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp1>;
@@ -282,6 +284,7 @@
 		port@10 {
 			reg = <16>;
 			label = "lan3";
+			pcs-handle = <&serdes4>;
 			phy-handle = <&phy16>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp2>;
@@ -292,6 +295,7 @@
 		port@14 {
 			reg = <20>;
 			label = "lan4";
+			pcs-handle = <&serdes5>;
 			phy-handle = <&phy20>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp3>;
@@ -302,6 +306,7 @@
 		port@18 {
 			reg = <24>;
 			label = "lan5";
+			pcs-handle = <&serdes6>;
 			phy-handle = <&phy24>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp4>;
@@ -312,6 +317,7 @@
 		port@19 {
 			reg = <25>;
 			label = "lan6";
+			pcs-handle = <&serdes7>;
 			phy-handle = <&phy25>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp5>;
@@ -322,6 +328,7 @@
 		port@1a {
 			reg = <26>;
 			label = "lan7";
+			pcs-handle = <&serdes8>;
 			phy-handle = <&phy26>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp6>;
@@ -332,6 +339,7 @@
 		port@1b {
 			reg = <27>;
 			label = "lan8";
+			pcs-handle = <&serdes9>;
 			phy-handle = <&phy27>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp7>;

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
@@ -259,6 +259,7 @@
 		port@0 {
 			reg = <0>;
 			label = "lan1";
+			pcs-handle = <&serdes2>;
 			phy-handle = <&phy0>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp0>;
@@ -269,6 +270,7 @@
 		port@8 {
 			reg = <8>;
 			label = "lan2";
+			pcs-handle = <&serdes3>;
 			phy-handle = <&phy8>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp1>;
@@ -279,6 +281,7 @@
 		port@10 {
 			reg = <16>;
 			label = "lan3";
+			pcs-handle = <&serdes4>;
 			phy-handle = <&phy16>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp2>;
@@ -289,6 +292,7 @@
 		port@14 {
 			reg = <20>;
 			label = "lan4";
+			pcs-handle = <&serdes5>;
 			phy-handle = <&phy20>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp3>;
@@ -299,6 +303,7 @@
 		port@18 {
 			reg = <24>;
 			label = "lan5";
+			pcs-handle = <&serdes6>;
 			phy-handle = <&phy24>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp4>;
@@ -309,6 +314,7 @@
 		port@19 {
 			reg = <25>;
 			label = "lan6";
+			pcs-handle = <&serdes7>;
 			phy-handle = <&phy25>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp5>;
@@ -319,6 +325,7 @@
 		port@1a {
 			reg = <26>;
 			label = "lan7";
+			pcs-handle = <&serdes8>;
 			phy-handle = <&phy26>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp6>;
@@ -329,6 +336,7 @@
 		port@1b {
 			reg = <27>;
 			label = "lan8";
+			pcs-handle = <&serdes9>;
 			phy-handle = <&phy27>;
 			phy-mode = "1000base-x";
 			sfp = <&sfp7>;


### PR DESCRIPTION
For all switch ports where the assigned SerDes is known, add the new pcs-handle to the dts. Leave the existing <sds> assignments to the PHYs as is because the driver has not yet been updated.