### PR TITLE
ath79: tiny: use nvmem for engenius devices

### DIFF
--- a/target/linux/ath79/dts/ar7240_engenius_enh202-v1.dts
+++ b/target/linux/ath79/dts/ar7240_engenius_enh202-v1.dts
@@ -62,17 +62,6 @@
 			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
 		};
 	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
 };
 
 &eth0 {
@@ -90,12 +79,16 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,002a";
 		reg = <0x0000 0 0 0 0>;
-		qca,no-eeprom;
-		#gpio-cells = <2>;
-		gpio-controller;
+		nvmem-cells = <&cal_art_1000>;
+		nvmem-cell-names = "calibration";
+
+		led {
+			led-sources = <1>;
+			led-active-low;
+		};
 	};
 };
 
@@ -107,6 +100,10 @@
 
 		macaddr_art_0: macaddr@0 {
 			reg = <0x0 0x6>;
+		};
+
+		cal_art_1000: calibration@1000 {
+			reg = <0x1000 0xeb8>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2000-v3.dts
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2000-v3.dts
@@ -193,6 +193,10 @@
 					macaddr_art_6: macaddr@6 {
 						reg = <0x6 0x6>;
 					};
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x3d8>;
+					};
 				};
 			};
 		};
@@ -219,9 +223,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,002e";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0 1>;
-		nvmem-cell-names = "mac-address";
-		qca,no-eeprom;
+		nvmem-cells = <&cal_art_1000>, <&macaddr_art_0 1>;
+		nvmem-cell-names = "calibration", "mac-address";
 		#gpio-cells = <2>;
 		gpio-controller;
 	};

--- a/target/linux/ath79/dts/ar7242_engenius_eap350-v1.dts
+++ b/target/linux/ath79/dts/ar7242_engenius_eap350-v1.dts
@@ -40,17 +40,6 @@
 			default-state = "on";
 		};
 	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_BLUE>;
-			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
 };
 
 &mdio0 {
@@ -78,14 +67,16 @@
 &pcie {
 	status = "okay";
 
-	ath9k: wifi@0,0 {
+	wifi@0,0 {
 		compatible = "pci168c,002a";
 		reg = <0x0 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0 1>;
-		nvmem-cell-names = "mac-address";
-		qca,no-eeprom;
-		#gpio-cells = <2>;
-		gpio-controller;
+		nvmem-cells = <&cal_art_1000>, <&macaddr_art_0 1>;
+		nvmem-cell-names = "calibration", "mac-address";
+
+		led {
+			led-sources = <1>;
+			led-active-low;
+		};
 	};
 };
 
@@ -99,6 +90,10 @@
 			compatible = "mac-base";
 			reg = <0x0 0x6>;
 			#nvmem-cell-cells = <1>;
+		};
+
+		cal_art_1000: calibration@1000 {
+			reg = <0x1000 0xeb8>;
 		};
 	};
 };

--- a/target/linux/ath79/dts/ar7242_engenius_ecb350-v1.dts
+++ b/target/linux/ath79/dts/ar7242_engenius_ecb350-v1.dts
@@ -40,17 +40,6 @@
 			default-state = "on";
 		};
 	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		wlan {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&ath9k 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
 };
 
 &mdio0 {
@@ -81,11 +70,13 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,002a";
 		reg = <0x0 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_0 (-1)>;
-		nvmem-cell-names = "mac-address";
-		qca,no-eeprom;
-		#gpio-cells = <2>;
-		gpio-controller;
+		nvmem-cells = <&cal_art_1000>, <&macaddr_art_0 (-1)>;
+		nvmem-cell-names = "calibration", "mac-address";
+
+		led {
+			led-sources = <1>;
+			led-active-low;
+		};
 	};
 };
 
@@ -99,6 +90,10 @@
 			compatible = "mac-base";
 			reg = <0x0 0x6>;
 			#nvmem-cell-cells = <1>;
+		};
+
+		cal_art_1000: calibration@1000 {
+			reg = <0x1000 0xeb8>;
 		};
 	};
 };

--- a/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -9,11 +9,6 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
-	engenius,eap350-v1|\
-	engenius,ecb350-v1|\
-	engenius,enh202-v1)
-		caldata_extract "art" 0x1000 0xeb8
-		;;
 	netgear,wnr2000-v3|\
 	ubnt,airrouter|\
 	ubnt,bullet-m-ar7240|\

--- a/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/tiny/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -9,7 +9,6 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath9k-eeprom-pci-0000:00:00.0.bin")
 	case $board in
-	netgear,wnr2000-v3|\
 	ubnt,airrouter|\
 	ubnt,bullet-m-ar7240|\
 	ubnt,bullet-m-ar7241|\


### PR DESCRIPTION
Userspace handling is deprecated.

Also convert custom LED to one handled by ath9k.

ping @robimarko 