### PR TITLE
treewide: reset-gpio to reset-gpios

### DIFF
--- a/target/linux/ath79/dts/ar9344_aerohive_hiveap-121.dts
+++ b/target/linux/ath79/dts/ar9344_aerohive_hiveap-121.dts
@@ -74,21 +74,21 @@
 
 	gpio_ext_lna0 {
 		gpio-hog;
-		gpios = <20 0>;
+		gpios = <20 GPIO_ACTIVE_HIGH>;
 		output-low;
 		line-name = "hiveap-121:ext:lna0";
 	};
 
 	gpio_ext_lna1 {
 		gpio-hog;
-		gpios = <19 0>;
+		gpios = <19 GPIO_ACTIVE_HIGH>;
 		output-low;
 		line-name = "hiveap-121:ext:lna1";
 	};
 
 	gpio_usb_power {
 		gpio-hog;
-		gpios = <15 0>;
+		gpios = <15 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "hiveap-121:power:usb";
 	};

--- a/target/linux/ath79/dts/ar9344_nec_aterm.dtsi
+++ b/target/linux/ath79/dts/ar9344_nec_aterm.dtsi
@@ -129,7 +129,7 @@
 		regulator-name = "usb-vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 20 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-always-on;
 	};

--- a/target/linux/ath79/dts/ar9344_qihoo_c301.dts
+++ b/target/linux/ath79/dts/ar9344_qihoo_c301.dts
@@ -82,14 +82,14 @@
 &gpio {
 	gpio_ext_lna0 {
 		gpio-hog;
-		gpios = <14 0>;
+		gpios = <14 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "c301:ext:lna0";
 	};
 
 	gpio_ext_lna1 {
 		gpio-hog;
-		gpios = <15 0>;
+		gpios = <15 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "c301:ext:lna1";
 	};

--- a/target/linux/ath79/dts/ar9344_wd_mynet-n600.dts
+++ b/target/linux/ath79/dts/ar9344_wd_mynet-n600.dts
@@ -60,14 +60,14 @@
 &gpio {
 	gpio_ext_lna0 {
 		gpio-hog;
-		gpios = <14 0>;
+		gpios = <14 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "ext:lna0";
 	};
 
 	gpio_ext_lna1 {
 		gpio-hog;
-		gpios = <15 0>;
+		gpios = <15 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "ext:lna1";
 	};

--- a/target/linux/ath79/dts/ar9344_wd_mynet-n750.dts
+++ b/target/linux/ath79/dts/ar9344_wd_mynet-n750.dts
@@ -59,14 +59,14 @@
 &gpio {
 	gpio_ext_lna0 {
 		gpio-hog;
-		gpios = <15 0>;
+		gpios = <15 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "ext:lna0";
 	};
 
 	gpio_ext_lna1 {
 		gpio-hog;
-		gpios = <18 0>;
+		gpios = <18 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "ext:lna1";
 	};

--- a/target/linux/ath79/dts/qca955x_zyxel_nbg6x16.dtsi
+++ b/target/linux/ath79/dts/qca955x_zyxel_nbg6x16.dtsi
@@ -36,7 +36,7 @@
 &gpio {
 	gpio_usb_power: usb_power {
 		gpio-hog;
-		gpios = <16 0>;
+		gpios = <16 GPIO_ACTIVE_HIGH>;
 		output-high;
 	};
 };

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx.dtsi
@@ -52,7 +52,7 @@
 
 			reset {
 				label = "reset";
-				gpios = <&tlmm 4 1>;
+				gpios = <&tlmm 4 GPIO_ACTIVE_LOW>;
 				linux,code = <KEY_RESTART>;
 			};
 		};
@@ -141,7 +141,7 @@
 &blsp1_spi1 {
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
-	cs-gpios = <&tlmm 54 0>, <&tlmm 63 0>;
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>, <&tlmm 63 GPIO_ACTIVE_HIGH>;
 	num-cs = <2>;
 	status = "okay";
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx.dtsi
@@ -300,7 +300,7 @@
 	status = "okay";
 	pinctrl-0 = <&mdio_pins>;
 	pinctrl-names = "default";
-	phy-reset-gpio = <&tlmm 62 0>;
+	phy-reset-gpios = <&tlmm 62 GPIO_ACTIVE_HIGH>;
 };
 
 &usb3_ss_phy {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-whw01.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-whw01.dts
@@ -216,7 +216,7 @@
 	status = "okay";
 	pinctrl-0 = <&mdio_pins>;
 	pinctrl-names = "default";
-	phy-reset-gpio = <&tlmm 62 GPIO_ACTIVE_HIGH>;
+	phy-reset-gpios = <&tlmm 62 GPIO_ACTIVE_HIGH>;
 };
 
 &tlmm {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
@@ -210,7 +210,7 @@
 
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
@@ -211,7 +211,7 @@
 &pcie0 {
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
@@ -201,7 +201,7 @@
 
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
@@ -202,7 +202,7 @@
 &pcie0 {
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
@@ -311,7 +311,7 @@
 	status = "okay";
 
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzbox-7530.dts
@@ -310,7 +310,7 @@
 	compatible = "qcom,pcie-ipq4019-lantiq-hack";
 	status = "okay";
 
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
@@ -231,7 +231,7 @@
 &pcie0 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 35 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
@@ -232,7 +232,7 @@
 	status = "okay";
 
 	perst-gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
@@ -333,7 +333,7 @@
 &pcie0 {
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
@@ -332,7 +332,7 @@
 
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
@@ -319,7 +319,7 @@
 &pcie0 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-habanero-dvk.dts
@@ -320,7 +320,7 @@
 	status = "okay";
 
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &mdio {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
@@ -226,7 +226,7 @@
 
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 42 GPIO_ACTIVE_HIGH>;
+	perst-gpios = <&tlmm 42 GPIO_ACTIVE_HIGH>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
@@ -204,7 +204,7 @@
 &pcie0 {
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
@@ -203,7 +203,7 @@
 
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -470,7 +470,7 @@
 &pcie0 {
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 40 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 40 GPIO_ACTIVE_LOW>;
 	clkreq-gpio = <&tlmm 39 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -471,7 +471,7 @@
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpios = <&tlmm 40 GPIO_ACTIVE_LOW>;
-	clkreq-gpio = <&tlmm 39 GPIO_ACTIVE_LOW>;
+	clkreq-gpios = <&tlmm 39 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -469,7 +469,7 @@
 //* This node is used for 5Ghz on QCA9982 */
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 40 GPIO_ACTIVE_LOW>;
 	clkreq-gpio = <&tlmm 39 GPIO_ACTIVE_LOW>;
 };

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
@@ -421,7 +421,7 @@
 &pcie0 {
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 40 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 40 GPIO_ACTIVE_LOW>;
 	clkreq-gpio = <&tlmm 39 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
@@ -420,7 +420,7 @@
 /* This node is used only on AT1 version for 5Ghz on QCA9984 */
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 40 GPIO_ACTIVE_LOW>;
 	clkreq-gpio = <&tlmm 39 GPIO_ACTIVE_LOW>;
 };

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
@@ -422,7 +422,7 @@
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpios = <&tlmm 40 GPIO_ACTIVE_LOW>;
-	clkreq-gpio = <&tlmm 39 GPIO_ACTIVE_LOW>;
+	clkreq-gpios = <&tlmm 39 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-ncp-hg100-cellular.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-ncp-hg100-cellular.dts
@@ -330,7 +330,7 @@
 		compatible = "ti,lp55231";
 		reg = <0x32>;
 		clock-mode = /bits/ 8 <0>;
-		enable-gpio = <&tlmm 1 GPIO_ACTIVE_HIGH>;
+		enable-gpios = <&tlmm 1 GPIO_ACTIVE_HIGH>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -309,7 +309,7 @@
 &pcie0 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -310,7 +310,7 @@
 	status = "okay";
 
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
@@ -190,7 +190,7 @@
 
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
@@ -191,7 +191,7 @@
 &pcie0 {
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
@@ -208,7 +208,7 @@
 	status = "okay";
 	pinctrl-names = "default";
 	pinctrl-0 = <&pcie_pins>;
-	perst-gpio = <&tlmm 4 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 4 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 40 GPIO_ACTIVE_HIGH>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-r619ac.dtsi
@@ -209,7 +209,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&pcie_pins>;
 	perst-gpios = <&tlmm 4 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 40 GPIO_ACTIVE_HIGH>;
+	wake-gpios = <&tlmm 40 GPIO_ACTIVE_HIGH>;
 };
 
 &qpic_bam {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
@@ -308,7 +308,7 @@
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
-	clkreq-gpio = <&tlmm 39 GPIO_ACTIVE_LOW>;
+	clkreq-gpios = <&tlmm 39 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
@@ -307,7 +307,7 @@
 &pcie0 {
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 	clkreq-gpio = <&tlmm 39 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
@@ -306,7 +306,7 @@
 
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 	clkreq-gpio = <&tlmm 39 GPIO_ACTIVE_LOW>;
 };

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
@@ -206,7 +206,7 @@
 	status = "okay";
 
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &qpic_bam {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-xx8300.dtsi
@@ -205,7 +205,7 @@
 &pcie0 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -274,7 +274,7 @@
 
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -275,7 +275,7 @@
 &pcie0 {
 	status = "okay";
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 50 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_bridge0 {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr33.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr33.dts
@@ -9,5 +9,5 @@
 };
 
 &tricolor {
-	enable-gpio = <&tlmm 48 GPIO_ACTIVE_HIGH>;
+	enable-gpios = <&tlmm 48 GPIO_ACTIVE_HIGH>;
 };

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr74.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr74.dts
@@ -9,5 +9,5 @@
 };
 
 &tricolor {
-	enable-gpio = <&tlmm 14 GPIO_ACTIVE_LOW>;
+	enable-gpios = <&tlmm 14 GPIO_ACTIVE_LOW>;
 };

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq40x9-dr40x9.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq40x9-dr40x9.dts
@@ -331,7 +331,7 @@
 &pcie0 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpio = <&tlmm 40 GPIO_ACTIVE_LOW>;
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq40x9-dr40x9.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq40x9-dr40x9.dts
@@ -332,7 +332,7 @@
 	status = "okay";
 
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
-	wake-gpio = <&tlmm 40 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 40 GPIO_ACTIVE_LOW>;
 };
 
 &vqmmc {

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-onhub.dtsi
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-onhub.dtsi
@@ -405,7 +405,7 @@
 		pinctrl-0 = <&spi_pins>;
 		pinctrl-names = "default";
 
-		cs-gpios = <&qcom_pinmux 20 0>;
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
 
 		flash: flash@0 {
 			compatible = "jedec,spi-nor";

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
@@ -100,7 +100,7 @@
 
 		pinctrl-0 = <&spi_pins>;
 		pinctrl-names = "default";
-		cs-gpios = <&qcom_pinmux 20 0>;
+		cs-gpios = <&qcom_pinmux 20 GPIO_ACTIVE_HIGH>;
 
 		flash@0 {
 			compatible = "mx25u25635f", "jedec,spi-nor";

--- a/target/linux/kirkwood/files/arch/arm/boot/dts/marvell/kirkwood-dns320l.dts
+++ b/target/linux/kirkwood/files/arch/arm/boot/dts/marvell/kirkwood-dns320l.dts
@@ -57,13 +57,13 @@
 		button@1 {
 			label = "Reset push button";
 			linux,code = <KEY_RESTART>;
-			gpios = <&gpio0 28 1>;
+			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
 		};
 
 		button@2 {
 			label = "USB unmount button";
 			linux,code = <KEY_EJECTCD>;
-			gpios = <&gpio0 27 1>;
+			gpios = <&gpio0 27 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -127,7 +127,7 @@
 			enable-active-high;
 			regulator-always-on;
 			regulator-boot-on;
-			gpios = <&gpio0 24 0>;
+			gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv452cqw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv452cqw.dts
@@ -105,7 +105,7 @@
 		};
 		voice {
 			label = "blue:sprache";
-			gpios = <&gpiomm 4 1>;
+			gpios = <&gpiomm 4 GPIO_ACTIVE_LOW>;
 		};
 		led_usb: usb {
 			function = LED_FUNCTION_USB;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon.dtsi
@@ -172,7 +172,8 @@
 			reg = <0x200000 0x10000>;
 			interrupt-parent = <&icu0>;
 			interrupts = <18 19 20 21>;
-			gpios = <&gpio1 7 0 &gpio1 8 0>;
+			gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>,
+				<&gpio1 8 GPIO_ACTIVE_HIGH>;
 			pinctrl-names = "default";
 			pinctrl-0 = <&i2c_pins>;
 			clocks = <&clock_sys1 14>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98021.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/falcon_lantiq_easy98021.dts
@@ -36,7 +36,7 @@
 			<&gpio0 2 GPIO_ACTIVE_HIGH>,
 			<0>; /* no CS */
 		gpio-names = "di", "do", "clk", "cs";
-		reset-gpio = <&gpio3 24 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&gpio3 24 GPIO_ACTIVE_HIGH>;
 	};
 
 	pinctrl {

--- a/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-ax3200-a1.dtsi
+++ b/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-ax3200-a1.dtsi
@@ -84,7 +84,7 @@
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;
 			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
-			reset-gpios = <&pio 54 0>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7622-linksys-e8450.dtsi
+++ b/target/linux/mediatek/dts/mt7622-linksys-e8450.dtsi
@@ -146,7 +146,7 @@
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;
 			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
-			reset-gpios = <&pio 54 0>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dtsi
@@ -34,7 +34,7 @@
 		compatible = "ubnt,ledbar";
 		reg = <0x30>;
 
-		enable-gpio = <&pio 59 GPIO_ACTIVE_LOW>;
+		enable-gpios = <&pio 59 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&pio 60 GPIO_ACTIVE_LOW>;
 
 		red {

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dtsi
@@ -35,7 +35,7 @@
 		reg = <0x30>;
 
 		enable-gpio = <&pio 59 GPIO_ACTIVE_LOW>;
-		reset-gpio = <&pio 60 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&pio 60 GPIO_ACTIVE_LOW>;
 
 		red {
 			label = "red";

--- a/target/linux/mediatek/dts/mt7629-iptime-a6004mx.dts
+++ b/target/linux/mediatek/dts/mt7629-iptime-a6004mx.dts
@@ -130,7 +130,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 28 0>;
+			reset-gpios = <&pio 28 GPIO_ACTIVE_HIGH>;
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7629-linksys-ea7500-v3.dts
+++ b/target/linux/mediatek/dts/mt7629-linksys-ea7500-v3.dts
@@ -108,7 +108,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 28 0>;
+			reset-gpios = <&pio 28 GPIO_ACTIVE_HIGH>;
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-asus-rt-ax52.dts
+++ b/target/linux/mediatek/dts/mt7981b-asus-rt-ax52.dts
@@ -122,7 +122,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 39 0>;
+			reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7981b-gatonetworks-gdsp.dts
+++ b/target/linux/mediatek/dts/mt7981b-gatonetworks-gdsp.dts
@@ -170,7 +170,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 39 0>;
+			reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-openfi-6c.dts
+++ b/target/linux/mediatek/dts/mt7981b-openfi-6c.dts
@@ -98,7 +98,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&pio 8 GPIO_ACTIVE_LOW>;
+		gpios = <&pio 8 GPIO_ACTIVE_LOW>;
 		regulator-boot-on;
 	};
 };

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -434,7 +434,7 @@
 		spi-cpol = <1>;
 		channel_count = <1>;
 		debug_level = <4>;       /* 1 = TRC, 2 = DBG, 4 = ERR */
-		reset_gpio = <&pio 25 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 25 GPIO_ACTIVE_HIGH>;
 		ig,enable-spi = <1>;     /* 1: Enable, 0: Disable */
 	};
 };

--- a/target/linux/mediatek/files-6.12/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dtsi
+++ b/target/linux/mediatek/files-6.12/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dtsi
@@ -302,7 +302,7 @@
 		spi-cpol = <1>;
 		channel_count = <1>;
 		debug_level = <4>;       /* 1 = TRC, 2 = DBG, 4 = ERR */
-		reset_gpio = <&pio 7 0>;
+		reset-gpios = <&pio 7 GPIO_ACTIVE_HIGH>;
 		ig,enable-spi = <1>;     /* 1: Enable, 0: Disable */
 	};
 };

--- a/target/linux/mediatek/files-6.12/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dtsi
+++ b/target/linux/mediatek/files-6.12/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dtsi
@@ -5,6 +5,7 @@
  */
 
 /dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pinctrl/mt65xx.h>
 #include "mt7986a.dtsi"
 
@@ -92,7 +93,7 @@
 		compatible = "ethernet-phy-id67c9.de0a";
 		reg = <5>;
 
-		reset-gpios = <&pio 6 1>;
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
 		reset-deassert-us = <20000>;
 	};
 
@@ -104,7 +105,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 0>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-385-wd_cloud-mirror-gen2.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-385-wd_cloud-mirror-gen2.dts
@@ -264,7 +264,7 @@
 		regulator-max-microvolt = <5000000>;
 		enable-active-high;
 		regulator-always-on;
-		gpio = <&gpio0 26 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
 	};
 
 	reg_usb3_1_vbus: usb3-vbus1 {
@@ -276,7 +276,7 @@
 		regulator-max-microvolt = <5000000>;
 		enable-active-high;
 		regulator-always-on;
-		gpio = <&gpio0 27 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio0 27 GPIO_ACTIVE_HIGH>;
 	};
 
 	reg_sata0: pwr-sata0 {
@@ -286,7 +286,7 @@
 		regulator-max-microvolt = <12000000>;
 		enable-active-high;
 		regulator-boot-on;
-		gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio1 23 GPIO_ACTIVE_HIGH>;
 	};
 
 	reg_5v_sata0: v5-sata0 {
@@ -312,7 +312,7 @@
 		regulator-max-microvolt = <12000000>;
 		enable-active-high;
 		regulator-boot-on;
-		gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 	};
 
 	reg_5v_sata1: v5-sata1 {

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/armada-7040-rb5009.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/armada-7040-rb5009.dts
@@ -34,7 +34,7 @@
 		regulator-name = "usb3_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&cp0_gpio2 23 GPIO_ACTIVE_HIGH>;
+		gpios = <&cp0_gpio2 23 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 
@@ -43,7 +43,7 @@
 		regulator-name = "LED-power";
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
-		gpio = <&cp0_gpio2 27 GPIO_ACTIVE_HIGH>;
+		gpios = <&cp0_gpio2 27 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 	};

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6130_cisco_vedge1000.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn6130_cisco_vedge1000.dts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 /include/ "octeon_3xxx.dtsi"
+#include <dt-bindings/gpio/gpio.h>
 
 / {
 	compatible = "cisco,vedge1000", "cavium,cn6130";
@@ -168,8 +169,8 @@
 				reg = <0x00>;
 				voltage-ranges = <0xce4 0xce4>;
 				max-frequency = <0x3197500>;
-				wp-gpios = <&gpio 0x02 0x00>;
-				cd-gpios = <&gpio 0x03 0x01>;
+				wp-gpios = <&gpio 0x02 GPIO_ACTIVE_HIGH>;
+				cd-gpios = <&gpio 0x03 GPIO_ACTIVE_LOW>;
 				cavium,bus-max-width = <0x04>;
 			};
 		};

--- a/target/linux/pistachio/patches-6.12/902-MIPS-DTS-img-marduk-Add-Cascoda-CA8210-6LoWPAN.patch
+++ b/target/linux/pistachio/patches-6.12/902-MIPS-DTS-img-marduk-Add-Cascoda-CA8210-6LoWPAN.patch
@@ -30,7 +30,7 @@ Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
 +		reg = <0>;
 +		spi-max-frequency = <4000000>;
 +		spi-cpol;
-+		reset-gpio = <&gpio0 12 GPIO_ACTIVE_HIGH>;
++		reset-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 +		irq-gpio = <&gpio2 12 GPIO_ACTIVE_HIGH>;
 +		extclock-enable;
 +		extclock-freq = <16000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
@@ -51,37 +51,37 @@
 		led_wlan_green: wlan-green {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WLAN;
-			gpio = <&tlmm 23 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 23 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_system_blue: system-blue {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_POWER;
-			gpio = <&tlmm 24 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_system_yellow: system-yellow {
 			color = <LED_COLOR_ID_YELLOW>;
 			function = LED_FUNCTION_POWER;
-			gpio = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_net_blue: net-blue {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_WAN_ONLINE;
-			gpio = <&tlmm 26 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 26 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_net_yellow: net-yellow {
 			color = <LED_COLOR_ID_YELLOW>;
 			function = LED_FUNCTION_WAN;
-			gpio = <&tlmm 27 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 27 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_phy_green: phy-green {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_LAN;
-			gpio = <&tlmm 28 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 28 GPIO_ACTIVE_HIGH>;
 		};
 	};
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
@@ -46,13 +46,13 @@
 		led_system_blue: system-blue {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_STATUS;
-			gpio = <&tlmm 24 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_status_white: status-white {
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_STATUS;
-			gpio = <&tlmm 23 GPIO_ACTIVE_HIGH>;
+			gpios = <&tlmm 23 GPIO_ACTIVE_HIGH>;
 		};
 	};
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mr5500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mr5500.dts
@@ -24,7 +24,7 @@
 		regulator-min-microvolt = <500000>;
 		regulator-max-microvolt = <500000>;
 		regulator-name = "fixed_5p0";
-		gpio = <&tlmm 17 GPIO_ACTIVE_LOW>;
+		gpios = <&tlmm 17 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-gl-axt1800.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-gl-axt1800.dts
@@ -27,7 +27,7 @@
 		regulator-name = "vcc_fan";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&tlmm 29 GPIO_ACTIVE_HIGH>;
+		gpios = <&tlmm 29 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 	};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-glinet.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-glinet.dtsi
@@ -61,7 +61,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&tlmm 0 GPIO_ACTIVE_HIGH>;
+		gpios = <&tlmm 0 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 	};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-mr7350.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-mr7350.dts
@@ -60,7 +60,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&tlmm 61 GPIO_ACTIVE_LOW>;
+		gpios = <&tlmm 61 GPIO_ACTIVE_LOW>;
 		regulator-boot-on;
 	};
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
@@ -338,7 +338,7 @@
 
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 60 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 60 GPIO_ACTIVE_LOW>;
 };
 
 &wifi {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
@@ -48,13 +48,13 @@
 		led_status_white: status-white {
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_STATUS;
-			gpio = <&tlmm 56 GPIO_ACTIVE_LOW>;
+			gpios = <&tlmm 56 GPIO_ACTIVE_LOW>;
 		};
 
 		led_status_amber: status-amber {
 			color = <LED_COLOR_ID_AMBER>;
 			function = LED_FUNCTION_STATUS;
-			gpio = <&tlmm 35 GPIO_ACTIVE_LOW>;
+			gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -66,7 +66,7 @@
 
 		startup-delay-us = <200>;
 
-		gpio = <&tlmm 66 GPIO_ACTIVE_HIGH>;
+		gpios = <&tlmm 66 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 
 		pinctrl-names = "default";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
@@ -153,7 +153,7 @@
 
 &pcie0 {
 	status = "okay";
-	perst-gpio = <&tlmm 60 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 60 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
 		wifi@0,0 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-mr7500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-mr7500.dts
@@ -97,7 +97,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&tlmm 25 GPIO_ACTIVE_LOW>;
+		gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ax3600.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ax3600.dts
@@ -48,7 +48,7 @@
 &pcie0 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 52 GPIO_ACTIVE_HIGH>;
+	perst-gpios = <&tlmm 52 GPIO_ACTIVE_HIGH>;
 
 	pcie@0 {
 		wifi0: wifi@0,0 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-aw1000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-aw1000.dts
@@ -160,7 +160,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&tlmm 9 GPIO_ACTIVE_LOW>;
+		gpios = <&tlmm 9 GPIO_ACTIVE_LOW>;
 		regulator-boot-on;
 	};
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
@@ -533,7 +533,7 @@
 &pcie0 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 58 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 58 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
 		wifi@0,0 {
@@ -555,7 +555,7 @@
 &pcie1 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 62 GPIO_ACTIVE_HIGH>;
+	perst-gpios = <&tlmm 62 GPIO_ACTIVE_HIGH>;
 
 	pcie@0 {
 		wifi@0,0 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
@@ -280,7 +280,7 @@
 &pcie0 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 58 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 58 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_qmp1 {
@@ -290,7 +290,7 @@
 &pcie1 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 61 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 61 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
 		wifi@0,0 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
@@ -520,7 +520,7 @@
 &pcie1 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 58 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 58 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
 		wifi0: wifi@0,0 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx8500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx8500.dts
@@ -514,7 +514,7 @@
 &pcie0 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 61 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 61 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
 		wifi@0,0 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
@@ -450,7 +450,7 @@
 &pcie0 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 58 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 58 GPIO_ACTIVE_LOW>;
 };
 
 &pcie_qmp1 {
@@ -460,7 +460,7 @@
 &pcie1 {
 	status = "okay";
 
-	perst-gpio = <&tlmm 62 GPIO_ACTIVE_HIGH>;
+	perst-gpios = <&tlmm 62 GPIO_ACTIVE_HIGH>;
 };
 
 &wifi {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rt-ax89x.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-rt-ax89x.dts
@@ -146,7 +146,7 @@
 		regulator-name = "usb0_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&tlmm 30 GPIO_ACTIVE_HIGH>;
+		gpios = <&tlmm 30 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 	};
@@ -156,7 +156,7 @@
 		regulator-name = "usb1_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&tlmm 31 GPIO_ACTIVE_HIGH>;
+		gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-boot-on;
 	};

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-flexhd.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-flexhd.dts
@@ -169,7 +169,7 @@
 		compatible = "ubnt,ledbar";
 		reg = <0x30>;
 
-		enable-gpio = <&gpio 44 GPIO_ACTIVE_HIGH>;
+		enable-gpios = <&gpio 44 GPIO_ACTIVE_HIGH>;
 		reset-gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
 		led-count = <8>;
 

--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-flexhd.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-flexhd.dts
@@ -170,7 +170,7 @@
 		reg = <0x30>;
 
 		enable-gpio = <&gpio 44 GPIO_ACTIVE_HIGH>;
-		reset-gpio = <&gpio 41 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
 		led-count = <8>;
 
 		red {

--- a/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2.dtsi
+++ b/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2.dtsi
@@ -19,7 +19,7 @@
 		regulator-name = "usb_vbus";
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
-		gpio = <&gpio 37 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 37 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 	};
 
@@ -28,7 +28,7 @@
 		regulator-name = "m2keyb_pwren";
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
-		gpio = <&gpio 38 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio 38 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
 		regulator-always-on;
 	};


### PR DESCRIPTION
The former is deprecated. Fixes dtc warning.