### PR TITLE
realtek: relabel Zyxel GS1900 & XGS1250-12 revisions

### DIFF
--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp-a1.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp-a1.dts
@@ -4,14 +4,10 @@
 #include "rtl8380_zyxel_gs1900_gpio.dtsi"
 
 / {
-	compatible = "zyxel,gs1900-24-v1", "realtek,rtl838x-soc";
-	model = "Zyxel GS1900-24 v1";
+	compatible = "zyxel,gs1900-10hp-a1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-10HP A1 Switch";
 
-	memory@0 {
-		reg = <0x0 0x4000000>;
-	};
-
-	/* i2c of the left SFP cage: port 25 */
+	/* i2c of the left SFP cage: port 9 */
 	i2c0: i2c-gpio-0 {
 		compatible = "i2c-gpio";
 		sda-gpios = <&gpio1 24 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
@@ -21,16 +17,17 @@
 		#size-cells = <0>;
 	};
 
-	sfp0: sfp-p25 {
+	sfp0: sfp-p9 {
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c0>;
 		los-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 26 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
 	};
 
-	/* i2c of the right SFP cage: port 26 */
+	/* i2c of the right SFP cage: port 10 */
 	i2c1: i2c-gpio-1 {
 		compatible = "i2c-gpio";
 		sda-gpios = <&gpio1 30 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
@@ -40,13 +37,14 @@
 		#size-cells = <0>;
 	};
 
-	sfp1: sfp-p26 {
+	sfp1: sfp-p10 {
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c1>;
 		los-gpio = <&gpio1 33 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 28 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 32 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
 	};
 };
 
@@ -55,60 +53,15 @@
 };
 
 &mdio_bus0 {
-	EXTERNAL_PHY(0)
-	EXTERNAL_PHY(1)
-	EXTERNAL_PHY(2)
-	EXTERNAL_PHY(3)
-	EXTERNAL_PHY(4)
-	EXTERNAL_PHY(5)
-	EXTERNAL_PHY(6)
-	EXTERNAL_PHY(7)
-
-	EXTERNAL_PHY(16)
-	EXTERNAL_PHY(17)
-	EXTERNAL_PHY(18)
-	EXTERNAL_PHY(19)
-	EXTERNAL_PHY(20)
-	EXTERNAL_PHY(21)
-	EXTERNAL_PHY(22)
-	EXTERNAL_PHY(23)
-
 	INTERNAL_PHY_SDS(24, 4)
 	INTERNAL_PHY_SDS(26, 5)
 };
 
 &switch0 {
 	ports {
-		SWITCH_PORT(0, 1, qsgmii)
-		SWITCH_PORT(1, 2, qsgmii)
-		SWITCH_PORT(2, 3, qsgmii)
-		SWITCH_PORT(3, 4, qsgmii)
-		SWITCH_PORT(4, 5, qsgmii)
-		SWITCH_PORT(5, 6, qsgmii)
-		SWITCH_PORT(6, 7, qsgmii)
-		SWITCH_PORT(7, 8, qsgmii)
-
-		SWITCH_PORT(8, 9, internal)
-		SWITCH_PORT(9, 10, internal)
-		SWITCH_PORT(10, 11, internal)
-		SWITCH_PORT(11, 12, internal)
-		SWITCH_PORT(12, 13, internal)
-		SWITCH_PORT(13, 14, internal)
-		SWITCH_PORT(14, 15, internal)
-		SWITCH_PORT(15, 16, internal)
-
-		SWITCH_PORT(16, 17, qsgmii)
-		SWITCH_PORT(17, 18, qsgmii)
-		SWITCH_PORT(18, 19, qsgmii)
-		SWITCH_PORT(19, 20, qsgmii)
-		SWITCH_PORT(20, 21, qsgmii)
-		SWITCH_PORT(21, 22, qsgmii)
-		SWITCH_PORT(22, 23, qsgmii)
-		SWITCH_PORT(23, 24, qsgmii)
-
 		port@24 {
 			reg = <24>;
-			label = "lan25";
+			label = "lan9";
 			pcs-handle = <&serdes4>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
@@ -117,7 +70,7 @@
 
 		port@26 {
 			reg = <26>;
-			label = "lan26";
+			label = "lan10";
 			pcs-handle = <&serdes5>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
@@ -126,6 +79,17 @@
 	};
 };
 
-&gpio1 {
-	/delete-node/ poe_enable;
+&thermal_zones {
+	sfp-thermal {
+		polling-delay-passive = <10000>;
+		polling-delay = <10000>;
+		thermal-sensors = <&sfp0>, <&sfp1>;
+		trips {
+			sfp-crit {
+				temperature = <110000>;
+				hysteresis = <1000>;
+				type = "critical";
+			};
+		};
+	};
 };

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8-a1.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8-a1.dts
@@ -4,8 +4,8 @@
 #include "rtl8380_zyxel_gs1900_gpio_emulated.dtsi"
 
 / {
-	compatible = "zyxel,gs1900-8-v1", "realtek,rtl838x-soc";
-	model = "Zyxel GS1900-8 v1 Switch";
+	compatible = "zyxel,gs1900-8-a1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-8 A1 Switch";
 };
 
 &gpio1 {

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8-b1.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8-b1.dts
@@ -4,10 +4,10 @@
 #include "rtl8380_zyxel_gs1900_gpio.dtsi"
 
 / {
-	compatible = "zyxel,gs1900-8hp-v2", "realtek,rtl838x-soc";
-	model = "Zyxel GS1900-8HP v2 Switch";
+	compatible = "zyxel,gs1900-8-b1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-8 B1 Switch";
 };
 
-&uart1 {
-	status = "okay";
+&gpio1 {
+	/delete-node/ poe_enable;
 };

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-a1.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-a1.dts
@@ -4,8 +4,8 @@
 #include "rtl8380_zyxel_gs1900_gpio.dtsi"
 
 / {
-	compatible = "zyxel,gs1900-8hp-v1", "realtek,rtl838x-soc";
-	model = "Zyxel GS1900-8HP v1 Switch";
+	compatible = "zyxel,gs1900-8hp-a1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-8HP A1 Switch";
 };
 
 &uart1 {

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-b1.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-8hp-b1.dts
@@ -4,10 +4,10 @@
 #include "rtl8380_zyxel_gs1900_gpio.dtsi"
 
 / {
-	compatible = "zyxel,gs1900-8-v2", "realtek,rtl838x-soc";
-	model = "Zyxel GS1900-8 v2 Switch";
+	compatible = "zyxel,gs1900-8hp-b1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-8HP B1 Switch";
 };
 
-&gpio1 {
-	/delete-node/ poe_enable;
+&uart1 {
+	status = "okay";
 };

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-16-a1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-16-a1.dts
@@ -4,8 +4,8 @@
 #include "rtl8380_zyxel_gs1900_gpio.dtsi"
 
 / {
-	compatible = "zyxel,gs1900-16", "realtek,rtl838x-soc";
-	model = "Zyxel GS1900-16";
+	compatible = "zyxel,gs1900-16-a1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-16 A1";
 };
 
 &mdio_bus0 {

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24-a1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24-a1.dts
@@ -4,10 +4,14 @@
 #include "rtl8380_zyxel_gs1900_gpio.dtsi"
 
 / {
-	compatible = "zyxel,gs1900-10hp", "realtek,rtl838x-soc";
-	model = "Zyxel GS1900-10HP Switch";
+	compatible = "zyxel,gs1900-24-a1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-24 A1";
 
-	/* i2c of the left SFP cage: port 9 */
+	memory@0 {
+		reg = <0x0 0x4000000>;
+	};
+
+	/* i2c of the left SFP cage: port 25 */
 	i2c0: i2c-gpio-0 {
 		compatible = "i2c-gpio";
 		sda-gpios = <&gpio1 24 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
@@ -17,17 +21,16 @@
 		#size-cells = <0>;
 	};
 
-	sfp0: sfp-p9 {
+	sfp0: sfp-p25 {
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c0>;
 		los-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 26 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 
-	/* i2c of the right SFP cage: port 10 */
+	/* i2c of the right SFP cage: port 26 */
 	i2c1: i2c-gpio-1 {
 		compatible = "i2c-gpio";
 		sda-gpios = <&gpio1 30 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
@@ -37,14 +40,13 @@
 		#size-cells = <0>;
 	};
 
-	sfp1: sfp-p10 {
+	sfp1: sfp-p26 {
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c1>;
 		los-gpio = <&gpio1 33 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 28 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&gpio1 32 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
-		#thermal-sensor-cells = <0>;
 	};
 };
 
@@ -53,15 +55,60 @@
 };
 
 &mdio_bus0 {
+	EXTERNAL_PHY(0)
+	EXTERNAL_PHY(1)
+	EXTERNAL_PHY(2)
+	EXTERNAL_PHY(3)
+	EXTERNAL_PHY(4)
+	EXTERNAL_PHY(5)
+	EXTERNAL_PHY(6)
+	EXTERNAL_PHY(7)
+
+	EXTERNAL_PHY(16)
+	EXTERNAL_PHY(17)
+	EXTERNAL_PHY(18)
+	EXTERNAL_PHY(19)
+	EXTERNAL_PHY(20)
+	EXTERNAL_PHY(21)
+	EXTERNAL_PHY(22)
+	EXTERNAL_PHY(23)
+
 	INTERNAL_PHY_SDS(24, 4)
 	INTERNAL_PHY_SDS(26, 5)
 };
 
 &switch0 {
 	ports {
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, internal)
+		SWITCH_PORT(9, 10, internal)
+		SWITCH_PORT(10, 11, internal)
+		SWITCH_PORT(11, 12, internal)
+		SWITCH_PORT(12, 13, internal)
+		SWITCH_PORT(13, 14, internal)
+		SWITCH_PORT(14, 15, internal)
+		SWITCH_PORT(15, 16, internal)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+
 		port@24 {
 			reg = <24>;
-			label = "lan9";
+			label = "lan25";
 			pcs-handle = <&serdes4>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
@@ -70,7 +117,7 @@
 
 		port@26 {
 			reg = <26>;
-			label = "lan10";
+			label = "lan26";
 			pcs-handle = <&serdes5>;
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
@@ -79,17 +126,6 @@
 	};
 };
 
-&thermal_zones {
-	sfp-thermal {
-		polling-delay-passive = <10000>;
-		polling-delay = <10000>;
-		thermal-sensors = <&sfp0>, <&sfp1>;
-		trips {
-			sfp-crit {
-				temperature = <110000>;
-				hysteresis = <1000>;
-				type = "critical";
-			};
-		};
-	};
+&gpio1 {
+	/delete-node/ poe_enable;
 };

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24e-a1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24e-a1.dts
@@ -4,8 +4,8 @@
 #include "rtl8380_zyxel_gs1900_gpio.dtsi"
 
 / {
-	compatible = "zyxel,gs1900-24e", "realtek,rtl838x-soc";
-	model = "Zyxel GS1900-24E";
+	compatible = "zyxel,gs1900-24e-a1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-24E A1";
 };
 
 &mdio_bus0 {

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24ep-a1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24ep-a1.dts
@@ -4,8 +4,8 @@
 #include "rtl8380_zyxel_gs1900_gpio.dtsi"
 
 / {
-	compatible = "zyxel,gs1900-24ep", "realtek,rtl838x-soc";
-	model = "Zyxel GS1900-24EP Switch";
+	compatible = "zyxel,gs1900-24ep-a1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-24EP A1 Switch";
 };
 
 &uart1 {

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-a1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-a1.dts
@@ -4,8 +4,8 @@
 #include "rtl8380_zyxel_gs1900_gpio.dtsi"
 
 / {
-	compatible = "zyxel,gs1900-24hp-v1", "realtek,rtl838x-soc";
-	model = "Zyxel GS1900-24HP v1";
+	compatible = "zyxel,gs1900-24hp-a1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-24HP A1";
 
 	memory@0 {
 		reg = <0x0 0x4000000>;

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-b1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-b1.dts
@@ -4,8 +4,8 @@
 #include "rtl8380_zyxel_gs1900_gpio.dtsi"
 
 / {
-	compatible = "zyxel,gs1900-24hp-v2", "realtek,rtl838x-soc";
-	model = "Zyxel GS1900-24HP v2 Switch";
+	compatible = "zyxel,gs1900-24hp-b1", "realtek,rtl838x-soc";
+	model = "Zyxel GS1900-24HP B1 Switch";
 
 	/* i2c of the left SFP cage: port 25 */
 	i2c0: i2c-gpio-0 {

--- a/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48-a1.dts
+++ b/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48-a1.dts
@@ -6,8 +6,8 @@
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	compatible = "zyxel,gs1900-48", "realtek,rtl8393-soc";
-	model = "Zyxel GS1900-48";
+	compatible = "zyxel,gs1900-48-a1", "realtek,rtl8393-soc";
+	model = "Zyxel GS1900-48 A1";
 
 	aliases {
 		led-boot = &led_sys;

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-a1.dts
@@ -9,8 +9,8 @@
 #include <dt-bindings/thermal/thermal.h>
 
 / {
-	compatible = "zyxel,xgs1250-12", "realtek,rtl838x-soc";
-	model = "Zyxel XGS1250-12 Switch";
+	compatible = "zyxel,xgs1250-12-a1", "realtek,rtl838x-soc";
+	model = "Zyxel XGS1250-12 A1 Switch";
 
 	aliases {
 		led-boot = &led_pwr_sys;

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -345,105 +345,118 @@ define Device/tplink_t1600g-28ts-v3
 endef
 TARGET_DEVICES += tplink_t1600g-28ts-v3
 
-define Device/zyxel_gs1900-10hp
+define Device/zyxel_gs1900-10hp-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8380
   DEVICE_MODEL := GS1900-10HP
+  DEVICE_VARIANT := A1
   ZYXEL_VERS := AAZI
   DEVICE_PACKAGES += realtek-poe
+  SUPPORTED_DEVICES += zyxel,gs1900-10hp
 endef
-TARGET_DEVICES += zyxel_gs1900-10hp
+TARGET_DEVICES += zyxel_gs1900-10hp-a1
 
-define Device/zyxel_gs1900-16
+define Device/zyxel_gs1900-16-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8382
   DEVICE_MODEL := GS1900-16
+  DEVICE_VARIANT := A1
   ZYXEL_VERS := AAHJ
+  SUPPORTED_DEVICES += zyxel,gs1900-16
 endef
-TARGET_DEVICES += zyxel_gs1900-16
+TARGET_DEVICES += zyxel_gs1900-16-a1
 
-define Device/zyxel_gs1900-8-v1
+define Device/zyxel_gs1900-8-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8380
   DEVICE_MODEL := GS1900-8
-  DEVICE_VARIANT := v1
+  DEVICE_VARIANT := A1
   ZYXEL_VERS := AAHH
-  SUPPORTED_DEVICES += zyxel,gs1900-8
+  SUPPORTED_DEVICES += zyxel,gs1900-8 zyxel,gs1900-8-v1
 endef
-TARGET_DEVICES += zyxel_gs1900-8-v1
+TARGET_DEVICES += zyxel_gs1900-8-a1
 
-define Device/zyxel_gs1900-8-v2
+define Device/zyxel_gs1900-8-b1
   $(Device/zyxel_gs1900)
   SOC := rtl8380
   DEVICE_MODEL := GS1900-8
-  DEVICE_VARIANT := v2
+  DEVICE_VARIANT := B1
   ZYXEL_VERS := AAHH
-  SUPPORTED_DEVICES += zyxel,gs1900-8
+  SUPPORTED_DEVICES += zyxel,gs1900-8 zyxel,gs1900-8-v2
 endef
-TARGET_DEVICES += zyxel_gs1900-8-v2
+TARGET_DEVICES += zyxel_gs1900-8-b1
 
-define Device/zyxel_gs1900-8hp-v1
+define Device/zyxel_gs1900-8hp-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8380
   DEVICE_MODEL := GS1900-8HP
-  DEVICE_VARIANT := v1
+  DEVICE_VARIANT := A1
   ZYXEL_VERS := AAHI
+  SUPPORTED_DEVICES += zyxel,gs1900-8hp-v1
   DEVICE_PACKAGES += realtek-poe
 endef
-TARGET_DEVICES += zyxel_gs1900-8hp-v1
+TARGET_DEVICES += zyxel_gs1900-8hp-a1
 
-define Device/zyxel_gs1900-8hp-v2
+define Device/zyxel_gs1900-8hp-b1
   $(Device/zyxel_gs1900)
   SOC := rtl8380
   DEVICE_MODEL := GS1900-8HP
-  DEVICE_VARIANT := v2
+  DEVICE_VARIANT := B1
   ZYXEL_VERS := AAHI
+  SUPPORTED_DEVICES += zyxel,gs1900-8hp-v2
   DEVICE_PACKAGES += realtek-poe
 endef
-TARGET_DEVICES += zyxel_gs1900-8hp-v2
+TARGET_DEVICES += zyxel_gs1900-8hp-b1
 
-define Device/zyxel_gs1900-24-v1
+define Device/zyxel_gs1900-24-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8382
   DEVICE_MODEL := GS1900-24
-  DEVICE_VARIANT := v1
+  DEVICE_VARIANT := A1
   ZYXEL_VERS := AAHL
+  SUPPORTED_DEVICES += zyxel,gs1900-24-v1
 endef
-TARGET_DEVICES += zyxel_gs1900-24-v1
+TARGET_DEVICES += zyxel_gs1900-24-a1
 
-define Device/zyxel_gs1900-24e
+define Device/zyxel_gs1900-24e-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8382
   DEVICE_MODEL := GS1900-24E
+  DEVICE_VARIANT := A1
   ZYXEL_VERS := AAHK
+  SUPPORTED_DEVICES += zyxel,gs1900-24e
 endef
-TARGET_DEVICES += zyxel_gs1900-24e
+TARGET_DEVICES += zyxel_gs1900-24e-a1
 
-define Device/zyxel_gs1900-24ep
+define Device/zyxel_gs1900-24ep-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8382
   DEVICE_MODEL := GS1900-24EP
+  DEVICE_VARIANT := A1
   ZYXEL_VERS := ABTO
+  SUPPORTED_DEVICES += zyxel,gs1900-24ep
   DEVICE_PACKAGES += realtek-poe
 endef
-TARGET_DEVICES += zyxel_gs1900-24ep
+TARGET_DEVICES += zyxel_gs1900-24ep-a1
 
-define Device/zyxel_gs1900-24hp-v1
+define Device/zyxel_gs1900-24hp-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8382
   DEVICE_MODEL := GS1900-24HP
-  DEVICE_VARIANT := v1
+  DEVICE_VARIANT := A1
   ZYXEL_VERS := AAHM
+  SUPPORTED_DEVICES += zyxel,gs1900-24hp-v1
   DEVICE_PACKAGES += realtek-poe
 endef
-TARGET_DEVICES += zyxel_gs1900-24hp-v1
+TARGET_DEVICES += zyxel_gs1900-24hp-a1
 
-define Device/zyxel_gs1900-24hp-v2
+define Device/zyxel_gs1900-24hp-b1
   $(Device/zyxel_gs1900)
   SOC := rtl8382
   DEVICE_MODEL := GS1900-24HP
-  DEVICE_VARIANT := v2
+  DEVICE_VARIANT := B1
   ZYXEL_VERS := ABTP
+  SUPPORTED_DEVICES += zyxel,gs1900-24hp-v2
   DEVICE_PACKAGES += realtek-poe
 endef
-TARGET_DEVICES += zyxel_gs1900-24hp-v2
+TARGET_DEVICES += zyxel_gs1900-24hp-b1

--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -73,10 +73,12 @@ define Device/tplink_sg2452p-v4
 endef
 TARGET_DEVICES += tplink_sg2452p-v4
 
-define Device/zyxel_gs1900-48
+define Device/zyxel_gs1900-48-a1
   $(Device/zyxel_gs1900)
   SOC := rtl8393
   DEVICE_MODEL := GS1900-48
+  DEVICE_VARIANT := A1
   ZYXEL_VERS := AAHN
+  SUPPORTED_DEVICES += zyxel,gs1900-48
 endef
-TARGET_DEVICES += zyxel_gs1900-48
+TARGET_DEVICES += zyxel_gs1900-48-a1

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -114,13 +114,15 @@ define Device/zyxel_xgs1210-12-a1
 endef
 TARGET_DEVICES += zyxel_xgs1210-12-a1
 
-define Device/zyxel_xgs1250-12
+define Device/zyxel_xgs1250-12-a1
   SOC := rtl9302
   UIMAGE_MAGIC := 0x93001250
   ZYXEL_VERS := ABWE
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := XGS1250-12
+  DEVICE_VARIANT := A1
   DEVICE_PACKAGES := kmod-hwmon-gpiofan kmod-thermal
+  SUPPORTED_DEVICES += zyxel,xgs1250-12
   IMAGE_SIZE := 13312k
   KERNEL_INITRAMFS := \
 	kernel-bin | \
@@ -129,4 +131,4 @@ define Device/zyxel_xgs1250-12
 	zyxel-vers | \
 	uImage gzip
 endef
-TARGET_DEVICES += zyxel_xgs1250-12
+TARGET_DEVICES += zyxel_xgs1250-12-a1


### PR DESCRIPTION
Relabel the Zyxel GS1900 and XGS1250 revisions to follow Zyxel practice. Zyxel uses A1/B1/... instead of v1/v2/.