### PR TITLE
lantiq: fix partition offsets in arcadyan_arv752dpw device tree

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv752dpw.dts
@@ -176,19 +176,19 @@
 
 			partition@0 {
 				label = "uboot";
-				reg = <0x00000 0x10000>;
+				reg = <0x00000 0x30000>;
 				read-only;
 			};
 
-			partition@10000 {
+			partition@30000 {
 				label = "u-boot-env";
-				reg = <0x10000 0x10000>;
+				reg = <0x30000 0x10000>;
 				read-only;
 			};
 
-			partition@20000 {
+			partition@40000 {
 				label = "firmware";
-				reg = <0x20000 0x7d0000>;
+				reg = <0x40000 0x7b0000>;
 			};
 
 			boardconfig: partition@7f0000 {


### PR DESCRIPTION
The offset and sizes of the uboot, uboot-env and firmware partitions in the arcadyan_arv752dpw device tree are changed to align with the u-boot configuration and actual sizes.

Offset of the u-boot env is `192 * 1024` (0x30000) and u-boot env size is `8 * 1024` (0x2000) according to package/boot/uboot-lantiq/patches/0108-MIPS-add-board-support-for-Arcadyan-ARV752DPW.patch .
The u-boot env offset of 192K fits with the actual u-boot binary size of ~186K. Considering the u-boot env leaves 0x40000 as the next aligned address for the firmware parititon.

Previously:
Writing the firmware image to 0xB0020000, as specified before in the decive tree (and old wiki page) would overwrite a portion of u-boot and brick the device.
Writing the firmware image to 0xB0040000, as specified by kernel_addr in the u-boot config (and new/wip wiki page) would work fine for kernel and initramfs, but fail at detecting the MTD firmware partition, as it is expected at the wrong offset.

I will update the wiki accordingly and create another pull request to get the fix into openwrt-24.10 later.