### PR TITLE
mediatek: filogic: fix led setup on zyxel-ex5601-t0

### DIFF
--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -245,9 +245,9 @@ zbtlink,zbt-z8103ax)
 zyxel,ex5601-t0-stock|\
 zyxel,ex5601-t0-ubootmod)
 	ucidef_set_led_netdev "lan1" "LAN1" "mdio-bus:05:green:lan" "lan1" "link tx rx"
-	ucidef_set_led_netdev "wan" "2.5G-WAN" "mdio-bus:06:green:wan" "eth1" "link_2500"
+	ucidef_set_led_netdev "wan" "2.5G-WAN" "mdio-bus:06:green:wan" "wan" "link_2500"
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link tx rx"
-	ucidef_set_led_netdev "internet" "INTERNET" "green:inet" "eth1" "link tx rx"
+	ucidef_set_led_netdev "internet" "INTERNET" "green:inet" "wan" "link tx rx"
 	ucidef_set_led_netdev "wifi-24g" "WIFI-2.4G" "green:wifi24g" "phy0-ap0" "link tx rx"
 	ucidef_set_led_netdev "wifi-5g" "WIFI-5G" "green:wifi5g" "phy1-ap0" "link tx rx"
 	;;


### PR DESCRIPTION
Fixes device led setup