### PR TITLE
realtek: add support for DGS-1210-52MP

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -101,6 +101,11 @@ d-link,dgs-1210-28p-f)
 	ucidef_set_poe 193 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
 			lan22 lan21 lan20 lan19 lan18 lan17"
 	;;
+d-link,dgs-1210-52mp-f)
+	ucidef_set_poe 370 "lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan32 lan31 
+	      lan30 lan29 lan28 lan27 lan26 lan25 lan24 lan23 lan22 lan21 lan20 lan19 lan18 lan17 lan48 lan47 lan46 lan45
+		  lan44 lan43 lan42 lan41 lan40 lan39 lan38 lan37 lan36 lan35 lan34 lan33"
+	;;
 engenius,ews2910p-v1|\
 engenius,ews2910p-v3)
 	ucidef_set_poe 60 "$(filter_port_list "$lan_list" "lan9 lan10")"

--- a/target/linux/realtek/base-files/etc/uci-defaults/04_dlinkfan
+++ b/target/linux/realtek/base-files/etc/uci-defaults/04_dlinkfan
@@ -7,7 +7,7 @@
 board=$(board_name)
 
 case "$board" in
-d-link,dgs-1210-28p-f|d-link,dgs-1210-28mp-f)
+d-link,dgs-1210-28p-f|d-link,dgs-1210-28mp-f|d-link,dgs-1210-52mp-f)
 	# Enable fan control
 	FAN_CTRL='/sys/class/hwmon/hwmon0'
 	echo 1 > "$FAN_PATH/pwm1_enable"

--- a/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52_common.dtsi
+++ b/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52_common.dtsi
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+&mdio_bus0 {
+	/* External phy RTL8218B #1 */
+	EXTERNAL_PHY(0)
+	EXTERNAL_PHY(1)
+	EXTERNAL_PHY(2)
+	EXTERNAL_PHY(3)
+	EXTERNAL_PHY(4)
+	EXTERNAL_PHY(5)
+	EXTERNAL_PHY(6)
+	EXTERNAL_PHY(7)
+
+	/* External phy RTL8218B #2 */
+	EXTERNAL_PHY(8)
+	EXTERNAL_PHY(9)
+	EXTERNAL_PHY(10)
+	EXTERNAL_PHY(11)
+	EXTERNAL_PHY(12)
+	EXTERNAL_PHY(13)
+	EXTERNAL_PHY(14)
+	EXTERNAL_PHY(15)
+
+	/* External phy RTL8218B #3 */
+	EXTERNAL_PHY(16)
+	EXTERNAL_PHY(17)
+	EXTERNAL_PHY(18)
+	EXTERNAL_PHY(19)
+	EXTERNAL_PHY(20)
+	EXTERNAL_PHY(21)
+	EXTERNAL_PHY(22)
+	EXTERNAL_PHY(23)
+
+	/* External phy RTL8218B #4 */
+	EXTERNAL_PHY(24)
+	EXTERNAL_PHY(25)
+	EXTERNAL_PHY(26)
+	EXTERNAL_PHY(27)
+	EXTERNAL_PHY(28)
+	EXTERNAL_PHY(29)
+	EXTERNAL_PHY(30)
+	EXTERNAL_PHY(31)
+
+	/* External phy RTL8218B #5 */
+	EXTERNAL_PHY(32)
+	EXTERNAL_PHY(33)
+	EXTERNAL_PHY(34)
+	EXTERNAL_PHY(35)
+	EXTERNAL_PHY(36)
+	EXTERNAL_PHY(37)
+	EXTERNAL_PHY(38)
+	EXTERNAL_PHY(39)
+
+	/* External phy RTL8218B #6 */
+	EXTERNAL_PHY(40)
+	EXTERNAL_PHY(41)
+	EXTERNAL_PHY(42)
+	EXTERNAL_PHY(43)
+	EXTERNAL_PHY(44)
+	EXTERNAL_PHY(45)
+	EXTERNAL_PHY(46)
+	EXTERNAL_PHY(47)
+
+	/* External phy RTL8214FC */
+	EXTERNAL_SFP_PHY_FULL(48, 0)
+	EXTERNAL_SFP_PHY_FULL(49, 1)
+	EXTERNAL_SFP_PHY_FULL(50, 2)
+	EXTERNAL_SFP_PHY_FULL(51, 3)
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT(0, 1, qsgmii)
+		SWITCH_PORT(1, 2, qsgmii)
+		SWITCH_PORT(2, 3, qsgmii)
+		SWITCH_PORT(3, 4, qsgmii)
+		SWITCH_PORT(4, 5, qsgmii)
+		SWITCH_PORT(5, 6, qsgmii)
+		SWITCH_PORT(6, 7, qsgmii)
+		SWITCH_PORT(7, 8, qsgmii)
+
+		SWITCH_PORT(8, 9, qsgmii)
+		SWITCH_PORT(9, 10, qsgmii)
+		SWITCH_PORT(10, 11, qsgmii)
+		SWITCH_PORT(11, 12, qsgmii)
+		SWITCH_PORT(12, 13, qsgmii)
+		SWITCH_PORT(13, 14, qsgmii)
+		SWITCH_PORT(14, 15, qsgmii)
+		SWITCH_PORT(15, 16, qsgmii)
+
+		SWITCH_PORT(16, 17, qsgmii)
+		SWITCH_PORT(17, 18, qsgmii)
+		SWITCH_PORT(18, 19, qsgmii)
+		SWITCH_PORT(19, 20, qsgmii)
+		SWITCH_PORT(20, 21, qsgmii)
+		SWITCH_PORT(21, 22, qsgmii)
+		SWITCH_PORT(22, 23, qsgmii)
+		SWITCH_PORT(23, 24, qsgmii)
+
+		SWITCH_PORT(24, 25, qsgmii)
+		SWITCH_PORT(25, 26, qsgmii)
+		SWITCH_PORT(26, 27, qsgmii)
+		SWITCH_PORT(27, 28, qsgmii)
+		SWITCH_PORT(28, 29, qsgmii)
+		SWITCH_PORT(29, 30, qsgmii)
+		SWITCH_PORT(30, 31, qsgmii)
+		SWITCH_PORT(31, 32, qsgmii)
+
+		SWITCH_PORT(32, 33, qsgmii)
+		SWITCH_PORT(33, 34, qsgmii)
+		SWITCH_PORT(34, 35, qsgmii)
+		SWITCH_PORT(35, 36, qsgmii)
+		SWITCH_PORT(36, 37, qsgmii)
+		SWITCH_PORT(37, 38, qsgmii)
+		SWITCH_PORT(38, 39, qsgmii)
+		SWITCH_PORT(39, 40, qsgmii)
+
+		SWITCH_PORT(40, 41, qsgmii)
+		SWITCH_PORT(41, 42, qsgmii)
+		SWITCH_PORT(42, 43, qsgmii)
+		SWITCH_PORT(43, 44, qsgmii)
+		SWITCH_PORT(44, 45, qsgmii)
+		SWITCH_PORT(45, 46, qsgmii)
+		SWITCH_PORT(46, 47, qsgmii)
+		SWITCH_PORT(47, 48, qsgmii)
+
+		SWITCH_PORT(48, 49, qsgmii)
+		SWITCH_PORT(49, 50, qsgmii)
+		SWITCH_PORT(50, 51, qsgmii)
+		SWITCH_PORT(51, 52, qsgmii)
+
+		/* CPU-Port */
+		port@52 {
+			ethernet = <&ethernet0>;
+			reg = <52>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52mp-f.dts
+++ b/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52mp-f.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl839x.dtsi"
+#include "rtl83xx_d-link_dgs-1210_common.dtsi"
+#include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
+#include "rtl83xx_d-link_dgs-1210_gpio_sfp.dtsi"
+#include "rtl8382_d-link_dgs-1210-52_common.dtsi"
+#include "rtl8382_d-link_dgs-1210-52p_common.dtsi"
+
+/ {
+	compatible = "d-link,dgs-1210-52mp-f", "realtek,rtl8393-soc", "realtek,rtl839x-soc";
+	model = "D-Link DGS-1210-52MP F";
+
+};

--- a/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52mp-f.dts
+++ b/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52mp-f.dts
@@ -4,8 +4,8 @@
 #include "rtl83xx_d-link_dgs-1210_common.dtsi"
 #include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
 #include "rtl83xx_d-link_dgs-1210_gpio_sfp.dtsi"
-#include "rtl8382_d-link_dgs-1210-52_common.dtsi"
-#include "rtl8382_d-link_dgs-1210-52p_common.dtsi"
+#include "rtl8393_d-link_dgs-1210-52_common.dtsi"
+#include "rtl8393_d-link_dgs-1210-52p_common.dtsi"
 
 / {
 	compatible = "d-link,dgs-1210-52mp-f", "realtek,rtl8393-soc", "realtek,rtl839x-soc";

--- a/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52p_common.dtsi
+++ b/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52p_common.dtsi
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/ {
+	/* LM63 */
+	i2c-gpio-4 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 32 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 31 GPIO_ACTIVE_HIGH>;
+		i2c-gpio,delay-us = <2>;
+		i2c-gpio,scl-open-drain; /* should be replaced by i2c-gpio,scl-has-no-pullup in kernel 6.6 */
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		lm63@4c {
+			compatible = "national,lm63";
+			reg = <0x4c>;
+		};
+	};
+};
+
+&leds {
+	link_act {
+		label = "green:link_act";
+		gpios = <&gpio1 28 GPIO_ACTIVE_LOW>;
+	};
+
+	poe {
+		label = "green:poe";
+		gpios = <&gpio1 29 GPIO_ACTIVE_LOW>;
+	};
+
+	poe_max {
+		label = "yellow:poe_max";
+		gpios = <&gpio1 27 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&keys {
+	mode {
+		label = "mode";
+		gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+		linux,code = <BTN_0>;
+	};
+};
+
+&uart1 {
+	status = "okay";
+};

--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -9,6 +9,15 @@ define Device/d-link_dgs-1210-52
 endef
 TARGET_DEVICES += d-link_dgs-1210-52
 
+define Device/d-link_dgs-1210-52mp-f
+  $(Device/d-link_dgs-1210)
+  SOC := rtl8393
+  DEVICE_MODEL := DGS-1210-52MP
+  DEVICE_VARIANT := F
+  DEVICE_PACKAGES += realtek-poe kmod-hwmon-lm63
+endef
+TARGET_DEVICES += d-link_dgs-1210-52mp-f
+
 define Device/hpe_1920-48g
   $(Device/hpe_1920)
   SOC := rtl8393


### PR DESCRIPTION
Same hardware underlying as DGS-1210-52 with PoE support
Instructions followed: https://openwrt.org/toh/d-link/dgs-1210-16_g1
This has been developed and tested on device with F1 revision.

Signed-off-by: John Jones <hdcp@dayrep.com>