### PR TITLE
build: parsing "git log" breaks with gpg signature verification

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -238,7 +238,7 @@ define DownloadMethod/rawgit
 	[ \! -d $(SUBDIR) ] && \
 	git clone $(OPTS) $(URL) $(SUBDIR) && \
 	(cd $(SUBDIR) && git checkout $(SOURCE_VERSION)) && \
-	export TAR_TIMESTAMP=`cd $(SUBDIR) && git log -1 --format='@%ct'` && \
+	export TAR_TIMESTAMP=`cd $(SUBDIR) && git log -1 --no-show-signature --format='@%ct'` && \
 	echo "Generating formal git archive (apply .gitattributes rules)" && \
 	(cd $(SUBDIR) && git config core.abbrev 8 && \
 	git archive --format=tar HEAD --output=../$(SUBDIR).tar.git) && \

--- a/rules.mk
+++ b/rules.mk
@@ -514,9 +514,9 @@ ext=$(word $(words $(subst ., ,$(1))),$(subst ., ,$(1)))
 ##
 define commitcount
 $(shell \
-  if git log -1 >/dev/null 2>/dev/null; then \
+  if git log -1 --no-show-signature >/dev/null 2>/dev/null; then \
     if [ -n "$(1)" ]; then \
-      last_bump="$$(git log --pretty=format:'%h %s' . | \
+      last_bump="$$(git log --no-show-signature --pretty=format:'%h %s' . | \
         grep -m 1 -e ': [uU]pdate to ' -e ': [bB]ump to ' | \
         cut -f 1 -d ' ')"; \
     fi; \

--- a/scripts/getver.sh
+++ b/scripts/getver.sh
@@ -43,7 +43,7 @@ try_git() {
 			REV="${UPSTREAM_REV}+$((REV - UPSTREAM_REV))"
 		fi
 
-		REV="${REV:+r$REV-$(git log -n 1 --format="%h" $UPSTREAM_BASE)}"
+		REV="${REV:+r$REV-$(git log -n 1 --no-show-signature --format="%h" $UPSTREAM_BASE)}"
 
 		;;
 	esac

--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -65,7 +65,7 @@ endif
 ifdef CONFIG_BUILDBOT
 ifneq ($(wildcard $(TOPDIR)/.git),)
   $(TOOLCHAIN_DIR)/stamp/.ver_check: $(TMP_DIR)/.build
-	cd "$(TOPDIR)"; git log --format=%h -1 toolchain > $(TMP_DIR)/.ver_check
+	cd "$(TOPDIR)"; git log --no-show-signature --format=%h -1 toolchain > $(TMP_DIR)/.ver_check
 	cmp -s $(TMP_DIR)/.ver_check $@ || { \
 		rm -rf $(BUILD_DIR) $(STAGING_DIR) $(TOOLCHAIN_DIR) $(BUILD_DIR_TOOLCHAIN); \
 		mkdir -p $(TOOLCHAIN_DIR)/stamp; \


### PR DESCRIPTION
This has been stuck in patchwork for quite a while:

https://patchwork.ozlabs.org/project/openwrt/patch/mailman.57525.1739297147.1089.openwrt-devel@lists.openwrt.org/

So let's try here instead. I'm a bit tired of having to carry it locally. The fix should be a no-brainer which doesn't hurt anyone...

Note that the problem can't be entirely worked around by modifying the local openwrt repo configuration, since the global setting still is applied to the feeds.


Parsing "git log" is fragile.  The actual output depends on both global and local configuration files. Enabling "log.showSignature" makes "git log" prefix signed commits with multiple lines of gpg verify output, regardless of the configured log format.

Add "--no-show-signature" to "git log" commands to work around this particular issue.

