### PR TITLE
realtek: remove DSA internal PCS functions

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -261,11 +261,6 @@ static inline int rtl838x_l2_port_new_sa_fwd(int p)
 	return RTL838X_L2_PORT_NEW_SA_FWD(p);
 }
 
-static inline int rtl838x_mac_link_spd_sts(int p)
-{
-	return RTL838X_MAC_LINK_SPD_STS(p);
-}
-
 inline static int rtl838x_trk_mbr_ctr(int group)
 {
 	return RTL838X_TRK_MBR_CTR + (group << 2);
@@ -1706,11 +1701,6 @@ const struct rtl838x_reg rtl838x_reg = {
 	.mir_ctrl = RTL838X_MIR_CTRL,
 	.mir_dpm = RTL838X_MIR_DPM_CTRL,
 	.mir_spm = RTL838X_MIR_SPM_CTRL,
-	.mac_link_sts = RTL838X_MAC_LINK_STS,
-	.mac_link_dup_sts = RTL838X_MAC_LINK_DUP_STS,
-	.mac_link_spd_sts = rtl838x_mac_link_spd_sts,
-	.mac_rx_pause_sts = RTL838X_MAC_RX_PAUSE_STS,
-	.mac_tx_pause_sts = RTL838X_MAC_TX_PAUSE_STS,
 	.read_l2_entry_using_hash = rtl838x_read_l2_entry_using_hash,
 	.write_l2_entry_using_hash = rtl838x_write_l2_entry_using_hash,
 	.read_cam = rtl838x_read_cam,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -123,24 +123,6 @@
 #define RTL839X_MAC_LINK_STS			(0x0390)
 #define RTL930X_MAC_LINK_STS			(0xCB10)
 #define RTL931X_MAC_LINK_STS			(0x0EC0)
-#define RTL838X_MAC_LINK_SPD_STS(p)		(0xa190 + (((p >> 4) << 2)))
-#define RTL839X_MAC_LINK_SPD_STS(p)		(0x03a0 + (((p >> 4) << 2)))
-#define RTL930X_MAC_LINK_SPD_STS(p)		(0xCB18 + (((p >> 3) << 2)))
-#define RTL931X_MAC_LINK_SPD_STS		(0x0ED0)
-#define RTL838X_MAC_LINK_DUP_STS		(0xa19c)
-#define RTL839X_MAC_LINK_DUP_STS		(0x03b0)
-#define RTL930X_MAC_LINK_DUP_STS		(0xCB28)
-#define RTL931X_MAC_LINK_DUP_STS		(0x0EF0)
-#define RTL838X_MAC_TX_PAUSE_STS		(0xa1a0)
-#define RTL839X_MAC_TX_PAUSE_STS		(0x03b8)
-#define RTL930X_MAC_TX_PAUSE_STS		(0xCB2C)
-#define RTL931X_MAC_TX_PAUSE_STS		(0x0EF8)
-#define RTL838X_MAC_RX_PAUSE_STS		(0xa1a4)
-#define RTL839X_MAC_RX_PAUSE_STS		(0x03c0)
-#define RTL930X_MAC_RX_PAUSE_STS		(0xCB30)
-#define RTL931X_MAC_RX_PAUSE_STS		(0x0F00)
-#define RTL930X_MAC_LINK_MEDIA_STS		(0xCB14)
-#define RTL931X_MAC_LINK_MEDIA_STS		(0x0EC8)
 
 /* MAC link state bits */
 #define RTL_SPEED_10				0
@@ -702,12 +684,6 @@ struct rtl838x_port {
 	const struct dsa_port *dp;
 };
 
-struct rtl838x_pcs {
-	struct phylink_pcs pcs;
-	struct rtl838x_switch_priv *priv;
-	int port;
-};
-
 struct rtl838x_vlan_info {
 	u64 untagged_ports;
 	u64 member_ports;
@@ -1073,11 +1049,6 @@ struct rtl838x_reg {
 	int mir_ctrl;
 	int mir_dpm;
 	int mir_spm;
-	int mac_link_sts;
-	int mac_link_dup_sts;
-	int  (*mac_link_spd_sts)(int port);
-	int mac_rx_pause_sts;
-	int mac_tx_pause_sts;
 	u64 (*read_l2_entry_using_hash)(u32 hash, u32 position, struct rtl838x_l2_entry *e);
 	void (*write_l2_entry_using_hash)(u32 hash, u32 pos, struct rtl838x_l2_entry *e);
 	u64 (*read_cam)(int idx, struct rtl838x_l2_entry *e);
@@ -1126,7 +1097,7 @@ struct rtl838x_switch_priv {
 	u16 family_id;
 	char version;
 	struct rtl838x_port ports[57];
-	struct rtl838x_pcs pcs[57];
+	struct phylink_pcs *pcs[57];
 	struct mutex reg_mutex;		/* Mutex for individual register manipulations */
 	struct mutex pie_mutex;		/* Mutex for Packet Inspection Engine */
 	int link_state_irq;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -293,11 +293,6 @@ static inline int rtl839x_l2_port_new_sa_fwd(int p)
 	return RTL839X_L2_PORT_NEW_SA_FWD(p);
 }
 
-static inline int rtl839x_mac_link_spd_sts(int p)
-{
-	return RTL839X_MAC_LINK_SPD_STS(p);
-}
-
 static inline int rtl839x_trk_mbr_ctr(int group)
 {
 	return RTL839X_TRK_MBR_CTR + (group << 3);
@@ -1686,11 +1681,6 @@ const struct rtl838x_reg rtl839x_reg = {
 	.mir_ctrl = RTL839X_MIR_CTRL,
 	.mir_dpm = RTL839X_MIR_DPM_CTRL,
 	.mir_spm = RTL839X_MIR_SPM_CTRL,
-	.mac_link_sts = RTL839X_MAC_LINK_STS,
-	.mac_link_dup_sts = RTL839X_MAC_LINK_DUP_STS,
-	.mac_link_spd_sts = rtl839x_mac_link_spd_sts,
-	.mac_rx_pause_sts = RTL839X_MAC_RX_PAUSE_STS,
-	.mac_tx_pause_sts = RTL839X_MAC_TX_PAUSE_STS,
 	.read_l2_entry_using_hash = rtl839x_read_l2_entry_using_hash,
 	.write_l2_entry_using_hash = rtl839x_write_l2_entry_using_hash,
 	.read_cam = rtl839x_read_cam,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -350,11 +350,6 @@ static inline int rtl930x_mac_port_ctrl(int p)
 	return RTL930X_MAC_L2_PORT_CTRL(p);
 }
 
-static inline int rtl930x_mac_link_spd_sts(int p)
-{
-	return RTL930X_MAC_LINK_SPD_STS(p);
-}
-
 static u64 rtl930x_l2_hash_seed(u64 mac, u32 vid)
 {
 	u64 v = vid;
@@ -2454,11 +2449,6 @@ const struct rtl838x_reg rtl930x_reg = {
 	.mir_ctrl = RTL930X_MIR_CTRL,
 	.mir_dpm = RTL930X_MIR_DPM_CTRL,
 	.mir_spm = RTL930X_MIR_SPM_CTRL,
-	.mac_link_sts = RTL930X_MAC_LINK_STS,
-	.mac_link_dup_sts = RTL930X_MAC_LINK_DUP_STS,
-	.mac_link_spd_sts = rtl930x_mac_link_spd_sts,
-	.mac_rx_pause_sts = RTL930X_MAC_RX_PAUSE_STS,
-	.mac_tx_pause_sts = RTL930X_MAC_TX_PAUSE_STS,
 	.read_l2_entry_using_hash = rtl930x_read_l2_entry_using_hash,
 	.write_l2_entry_using_hash = rtl930x_write_l2_entry_using_hash,
 	.read_cam = rtl930x_read_cam,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -265,11 +265,6 @@ static inline int rtl931x_mac_force_mode_ctrl(int p)
 	return RTL931X_MAC_FORCE_MODE_CTRL + (p << 2);
 }
 
-static inline int rtl931x_mac_link_spd_sts(int p)
-{
-	return RTL931X_MAC_LINK_SPD_STS + (((p >> 3) << 2));
-}
-
 static inline int rtl931x_mac_port_ctrl(int p)
 {
 	return RTL931X_MAC_L2_PORT_CTRL + (p << 7);
@@ -1557,11 +1552,6 @@ const struct rtl838x_reg rtl931x_reg = {
 	.mir_ctrl = RTL931X_MIR_CTRL,
 	.mir_dpm = RTL931X_MIR_DPM_CTRL,
 	.mir_spm = RTL931X_MIR_SPM_CTRL,
-	.mac_link_sts = RTL931X_MAC_LINK_STS,
-	.mac_link_dup_sts = RTL931X_MAC_LINK_DUP_STS,
-	.mac_link_spd_sts = rtl931x_mac_link_spd_sts,
-	.mac_rx_pause_sts = RTL931X_MAC_RX_PAUSE_STS,
-	.mac_tx_pause_sts = RTL931X_MAC_TX_PAUSE_STS,
 	.read_l2_entry_using_hash = rtl931x_read_l2_entry_using_hash,
 	.write_l2_entry_using_hash = rtl931x_write_l2_entry_using_hash,
 	.read_cam = rtl931x_read_cam,

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -272,6 +272,7 @@ struct phylink_pcs *rtpcs_create(struct device *dev, struct device_node *np, int
 	link->port = port;
 	link->sds = sds;
 	link->pcs.ops = ctrl->cfg->pcs_ops;
+	link->pcs.neg_mode = true;
 
 	ctrl->link[port] = link;
 


### PR DESCRIPTION
Now that there is a dedicated PCS driver remove the old functions from the DSA driver and make use of the new ones.