### PR TITLE
treewide: dts: typo disbled and disable

### DIFF
--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -520,7 +520,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			status = "disable";
+			status = "disabled";
 		};
 
 		i2c1: i2c1@1fbf8100 {
@@ -534,7 +534,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			status = "disable";
+			status = "disabled";
 		};
 
 		snfi: spi@1fa10000 {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
@@ -560,7 +560,7 @@
 	 * although the pcie1 phy probes successfully, the controller is unable
 	 * to bring it up. So let's disable it until a solution is found.
 	 */
-	status = "disbled";
+	status = "disabled";
 
 	perst-gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
 


### PR DESCRIPTION
No functional changes intended.

Fixes warning:
~~~
/linux/arch/arm64/boot/dts/airoha/en7581-gemtek-w1700k.dtb: i2c1@1fbf8100 (mediatek,mt7621-i2c): status: 'oneOf' conditional failed, one must be fixed:
	['disable'] is not of type 'object'
	'disable' is not one of ['okay', 'disabled', 'reserved', 'fail', 'fail-needs-probe']
	from schema $id: http://devicetree.org/schemas/dt-core.yaml#
~~~

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>