### PR TITLE
airoha: an7581: enable SCU SSR serdes configuration

### DIFF
--- a/target/linux/airoha/patches-6.12/701-soc-airoha-add-support-for-configuring-SCU-SSR-Serde.patch
+++ b/target/linux/airoha/patches-6.12/701-soc-airoha-add-support-for-configuring-SCU-SSR-Serde.patch
@@ -1,0 +1,342 @@
+From d9697c64e0d8ad1b81d23eabd8ca18482e3b3f3d Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Thu, 20 Mar 2025 14:00:27 +0100
+Subject: [PATCH 112/113] soc: airoha: add support for configuring SCU SSR
+ Serdes port
+
+Add support for configuring SCU SSR Serdes port. Airoha AN7581 SoC can
+configure the different Serdes port by toggling bits in the SCU register
+space.
+
+Port Serdes mode are mutually exclusive, force example the USB2 Serdes port
+can either used for USB 3.0 or PCIe 2 port. Enabling USB 3.0 makes the
+PCIe 2 to not work.
+
+The current supported Serdes port are:
+- WiFi 1 and defaults to PCIe0 1 line mode
+- Wifi 2 and defaults to PCIe1 1 line mode
+- USB 1 and defaults to USB 3.0 mode
+- USB 2 and defaults to USB 3.0 mode
+
+WiFi 1, WiFi 2 and USB 1 also support a particular Ethernet mode that
+can toggle between USXGMII or HSGMII mode (USB 1 only to HSGMII)
+Such mode doesn't configure bits as specific Ethernet PCS driver will
+take care of configuring the Serdes mode based on what is required.
+
+This driver is to correctly setup these bits.
+Single driver can't independently set the Serdes port mode as that
+would cause a conflict if someone declare, for example, in DT
+(and enable) PCIe 2 port and USB2 3.0 port.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ MAINTAINERS                               |   2 +
+ drivers/soc/Kconfig                       |   1 +
+ drivers/soc/Makefile                      |   1 +
+ drivers/soc/airoha/Kconfig                |  18 ++
+ drivers/soc/airoha/Makefile               |   3 +
+ drivers/soc/airoha/airoha-scu-ssr.c       | 221 ++++++++++++++++++++++
+ include/linux/soc/airoha/airoha-scu-ssr.h |  23 +++
+ 7 files changed, 269 insertions(+)
+ create mode 100644 drivers/soc/airoha/Kconfig
+ create mode 100644 drivers/soc/airoha/Makefile
+ create mode 100644 drivers/soc/airoha/airoha-scu-ssr.c
+ create mode 100644 include/linux/soc/airoha/airoha-scu-ssr.h
+
+--- a/drivers/soc/Kconfig
++++ b/drivers/soc/Kconfig
+@@ -1,6 +1,7 @@
+ # SPDX-License-Identifier: GPL-2.0-only
+ menu "SOC (System On Chip) specific Drivers"
+ 
++source "drivers/soc/airoha/Kconfig"
+ source "drivers/soc/amlogic/Kconfig"
+ source "drivers/soc/apple/Kconfig"
+ source "drivers/soc/aspeed/Kconfig"
+--- a/drivers/soc/Makefile
++++ b/drivers/soc/Makefile
+@@ -3,6 +3,7 @@
+ # Makefile for the Linux Kernel SOC specific device drivers.
+ #
+ 
++obj-y				+= airoha/
+ obj-y				+= apple/
+ obj-y				+= aspeed/
+ obj-$(CONFIG_ARCH_AT91)		+= atmel/
+--- /dev/null
++++ b/drivers/soc/airoha/Kconfig
+@@ -0,0 +1,18 @@
++# SPDX-License-Identifier: GPL-2.0-only
++
++config AIROHA_SCU_SSR
++	tristate "Airoha SCU SSR Driver"
++	depends on ARCH_AIROHA || COMPILE_TEST
++	depends on OF
++	help
++	  Say 'Y' here to add support for Airoha SCU SSR driver.
++
++	  Airoha SoC pheriperal (like USB/PCIe/Ethernet port) are
++	  selected by toggling specific bit. Serdes Port line
++	  are mutually exclusive such as selecting PCIe port 2
++	  disable support for USB port 2 3.0 mode.
++
++	  This driver is used to configure such bit and expose
++	  an API to read the current status from a user of such
++	  Serdes lines.
++
+--- /dev/null
++++ b/drivers/soc/airoha/Makefile
+@@ -0,0 +1,3 @@
++# SPDX-License-Identifier: GPL-2.0
++
++obj-$(CONFIG_AIROHA_SCU_SSR)		+= airoha-scu-ssr.o
+--- /dev/null
++++ b/drivers/soc/airoha/airoha-scu-ssr.c
+@@ -0,0 +1,221 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Author: Christian Marangi <ansuelsmth@gmail.com>
++ */
++
++#include <dt-bindings/soc/airoha,scu-ssr.h>
++#include <linux/bitfield.h>
++#include <linux/of.h>
++#include <linux/of_platform.h>
++#include <linux/platform_device.h>
++#include <linux/regmap.h>
++#include <linux/soc/airoha/airoha-scu-ssr.h>
++
++#define AIROHA_SCU_PCIC			0x88
++#define   AIROHA_SCU_PCIE_2LANE_MODE	BIT(14)
++
++#define AIROHA_SCU_SSR3			0x94
++#define   AIROHA_SCU_SSUSB_HSGMII_SEL	BIT(29)
++
++#define AIROHA_SCU_SSTR			0x9c
++#define   AIROHA_SCU_PCIE_XSI0_SEL	GENMASK(14, 13)
++#define   AIROHA_SCU_PCIE_XSI0_SEL_PCIE	FIELD_PREP_CONST(AIROHA_SCU_PCIE_XSI0_SEL, 0x0)
++#define   AIROHA_SCU_PCIE_XSI1_SEL	GENMASK(12, 11)
++#define   AIROHA_SCU_PCIE_XSI1_SEL_PCIE	FIELD_PREP_CONST(AIROHA_SCU_PCIE_XSI0_SEL, 0x0)
++#define   AIROHA_SCU_USB_PCIE_SEL	BIT(3)
++
++#define AIROHA_SCU_MAX_SERDES_PORT	4
++
++struct airoha_scu_ssr_priv {
++	struct device *dev;
++	struct regmap *regmap;
++
++	unsigned int serdes_port[AIROHA_SCU_MAX_SERDES_PORT];
++};
++
++static const char * const airoha_scu_serdes_mode_to_str[] = {
++	[AIROHA_SCU_SERDES_MODE_PCIE0_X1] = "pcie0_x1",
++	[AIROHA_SCU_SERDES_MODE_PCIE0_X2] = "pcie0_x2",
++	[AIROHA_SCU_SERDES_MODE_PCIE1_X1] = "pcie1_x1",
++	[AIROHA_SCU_SERDES_MODE_PCIE2_X1] = "pcie2_x1",
++	[AIROHA_SCU_SERDES_MODE_USB3] = "usb3",
++	[AIROHA_SCU_SERDES_MODE_ETHERNET] = "ethernet",
++};
++
++static int airoha_scu_serdes_str_to_mode(const char *serdes_str)
++{
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(airoha_scu_serdes_mode_to_str); i++)
++		if (!strncmp(serdes_str, airoha_scu_serdes_mode_to_str[i],
++			     strlen(airoha_scu_serdes_mode_to_str[i])))
++			return i;
++
++	return -EINVAL;
++}
++
++static int airoha_scu_ssr_apply_modes(struct airoha_scu_ssr_priv *priv)
++{
++	int ret;
++
++	/*
++	 * This is a very bad scenario and needs to be correctly warned
++	 * as it cause PCIe malfunction.
++	 */
++	if ((priv->serdes_port[AIROHA_SCU_SERDES_WIFI1] == AIROHA_SCU_SERDES_MODE_PCIE0_X2 &&
++	     priv->serdes_port[AIROHA_SCU_SERDES_WIFI2] != AIROHA_SCU_SERDES_MODE_PCIE0_X2) ||
++	    (priv->serdes_port[AIROHA_SCU_SERDES_WIFI1] != AIROHA_SCU_SERDES_MODE_PCIE0_X2 &&
++	     priv->serdes_port[AIROHA_SCU_SERDES_WIFI2] == AIROHA_SCU_SERDES_MODE_PCIE0_X2)) {
++		WARN(true, "Wrong Serdes configuration for PCIe0 2 Line mode. Please check DT.\n");
++		return -EINVAL;
++	}
++
++	/* PCS driver takes care of setting the SCU bit for HSGMII or USXGMII */
++	if (priv->serdes_port[AIROHA_SCU_SERDES_WIFI1] == AIROHA_SCU_SERDES_MODE_PCIE0_X1 ||
++	    priv->serdes_port[AIROHA_SCU_SERDES_WIFI1] == AIROHA_SCU_SERDES_MODE_PCIE0_X2) {
++		ret = regmap_update_bits(priv->regmap, AIROHA_SCU_SSTR,
++					 AIROHA_SCU_PCIE_XSI0_SEL,
++					 AIROHA_SCU_PCIE_XSI0_SEL_PCIE);
++		if (ret)
++			return ret;
++	}
++
++	/* PCS driver takes care of setting the SCU bit for HSGMII or USXGMII */
++	if (priv->serdes_port[AIROHA_SCU_SERDES_WIFI2] == AIROHA_SCU_SERDES_MODE_PCIE1_X1 ||
++	    priv->serdes_port[AIROHA_SCU_SERDES_WIFI2] == AIROHA_SCU_SERDES_MODE_PCIE0_X2) {
++		ret = regmap_update_bits(priv->regmap, AIROHA_SCU_SSTR,
++					 AIROHA_SCU_PCIE_XSI1_SEL,
++					 AIROHA_SCU_PCIE_XSI1_SEL_PCIE);
++		if (ret)
++			return ret;
++	}
++
++	/* Toggle PCIe0 2 Line mode if enabled or not */
++	if (priv->serdes_port[AIROHA_SCU_SERDES_WIFI1] == AIROHA_SCU_SERDES_MODE_PCIE0_X2)
++		ret = regmap_set_bits(priv->regmap, AIROHA_SCU_PCIC,
++				      AIROHA_SCU_PCIE_2LANE_MODE);
++	else
++		ret = regmap_clear_bits(priv->regmap, AIROHA_SCU_PCIC,
++					AIROHA_SCU_PCIE_2LANE_MODE);
++	if (ret)
++		return ret;
++
++	if (priv->serdes_port[AIROHA_SCU_SERDES_USB1] == AIROHA_SCU_SERDES_MODE_ETHERNET)
++		ret = regmap_clear_bits(priv->regmap, AIROHA_SCU_SSR3,
++					AIROHA_SCU_SSUSB_HSGMII_SEL);
++	else
++		ret = regmap_set_bits(priv->regmap, AIROHA_SCU_SSR3,
++				      AIROHA_SCU_SSUSB_HSGMII_SEL);
++	if (ret)
++		return ret;
++
++	if (priv->serdes_port[AIROHA_SCU_SERDES_USB2] == AIROHA_SCU_SERDES_MODE_PCIE2_X1)
++		ret = regmap_clear_bits(priv->regmap, AIROHA_SCU_SSTR,
++					AIROHA_SCU_USB_PCIE_SEL);
++	else
++		ret = regmap_set_bits(priv->regmap, AIROHA_SCU_SSTR,
++				      AIROHA_SCU_USB_PCIE_SEL);
++	if (ret)
++		return ret;
++
++	return 0;
++}
++
++static int airoha_scu_ssr_parse_mode(struct device *dev,
++				     struct airoha_scu_ssr_priv *priv,
++				     const char *property_name, unsigned int port,
++				     unsigned int default_mode)
++{
++	const struct airoha_scu_ssr_serdes_info *port_info;
++	const struct airoha_scu_ssr_data *pdata;
++	const char *serdes_mode;
++	int mode, i;
++
++	pdata = dev->platform_data;
++
++	if (of_property_read_string(dev->of_node, property_name,
++				    &serdes_mode)) {
++		priv->serdes_port[port] = default_mode;
++		return 0;
++	}
++
++	mode = airoha_scu_serdes_str_to_mode(serdes_mode);
++	if (mode) {
++		dev_err(dev, "invalid mode %s for %s\n", serdes_mode, property_name);
++		return mode;
++	}
++
++	port_info = &pdata->ports_info[port];
++	for (i = 0; i < port_info->num_modes; i++) {
++		if (port_info->possible_modes[i] == mode) {
++			priv->serdes_port[port] = mode;
++			return 0;
++		}
++	}
++
++	dev_err(dev, "mode %s not supported for %s", serdes_mode, property_name);
++	return -EINVAL;
++}
++
++static int airoha_scu_ssr_probe(struct platform_device *pdev)
++{
++	struct airoha_scu_ssr_priv *priv;
++	struct device *dev = &pdev->dev;
++	int ret;
++
++	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	priv->dev = dev;
++
++	/* Get regmap from MFD */
++	priv->regmap = dev_get_regmap(dev->parent, NULL);
++	if (!priv->regmap)
++		return -EINVAL;
++
++	ret = airoha_scu_ssr_parse_mode(dev, priv, "airoha,serdes-wifi1",
++					AIROHA_SCU_SERDES_WIFI1,
++					AIROHA_SCU_SERDES_MODE_PCIE0_X1);
++	if (ret)
++		return ret;
++
++	ret = airoha_scu_ssr_parse_mode(dev, priv, "airoha,serdes-wifi2",
++					AIROHA_SCU_SERDES_WIFI2,
++					AIROHA_SCU_SERDES_MODE_PCIE1_X1);
++	if (ret)
++		return ret;
++
++	ret = airoha_scu_ssr_parse_mode(dev, priv, "airoha,serdes-usb1",
++					AIROHA_SCU_SERDES_USB1,
++					AIROHA_SCU_SERDES_MODE_USB3);
++	if (ret)
++		return ret;
++
++	ret = airoha_scu_ssr_parse_mode(dev, priv, "airoha,serdes-usb2",
++					AIROHA_SCU_SERDES_USB2,
++					AIROHA_SCU_SERDES_MODE_USB3);
++	if (ret)
++		return ret;
++
++	ret = airoha_scu_ssr_apply_modes(priv);
++	if (ret)
++		return ret;
++
++	platform_set_drvdata(pdev, priv);
++
++	return 0;
++}
++
++static struct platform_driver airoha_scu_ssr_driver = {
++	.probe		= airoha_scu_ssr_probe,
++	.driver		= {
++		.name	= "airoha-scu-ssr",
++	},
++};
++
++module_platform_driver(airoha_scu_ssr_driver);
++
++MODULE_AUTHOR("Christian Marangi <ansuelsmth@gmail.com>");
++MODULE_LICENSE("GPL");
++MODULE_DESCRIPTION("Airoha SCU SSR/STR driver");
+--- /dev/null
++++ b/include/linux/soc/airoha/airoha-scu-ssr.h
+@@ -0,0 +1,23 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef __AIROHA_SCU_SSR__
++#define __AIROHA_SCU_SSR__
++
++enum airoha_scu_serdes_modes {
++	AIROHA_SCU_SERDES_MODE_PCIE0_X1,
++	AIROHA_SCU_SERDES_MODE_PCIE0_X2,
++	AIROHA_SCU_SERDES_MODE_PCIE1_X1,
++	AIROHA_SCU_SERDES_MODE_PCIE2_X1,
++	AIROHA_SCU_SERDES_MODE_USB3,
++	AIROHA_SCU_SERDES_MODE_ETHERNET,
++};
++
++struct airoha_scu_ssr_serdes_info {
++	unsigned int *possible_modes;
++	unsigned int num_modes;
++};
++
++struct airoha_scu_ssr_data {
++	const struct airoha_scu_ssr_serdes_info *ports_info;
++};
++
++#endif

--- a/target/linux/airoha/patches-6.12/702-clk-en7523-define-and-register-SoC-SCU-SSR-driver-fo.patch
+++ b/target/linux/airoha/patches-6.12/702-clk-en7523-define-and-register-SoC-SCU-SSR-driver-fo.patch
@@ -1,0 +1,210 @@
+From a07fe509d2709e54b1dfb195b6b4c8f92024e98e Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Thu, 20 Mar 2025 14:00:28 +0100
+Subject: [PATCH] clk: en7523: define and register SoC SCU SSR driver for
+ EN7581
+
+Define all the possible interface modes and register the SoC SCU SSR
+platform driver for EN7581.
+
+Failing to register the SCU SSR driver is not a critical error (example
+the SoC driver is not enable) but will prevent PCIe or USB port to
+function correctly.
+
+Reference to the SSR pdev are stored in the new en7523 priv struct.
+
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/clk/clk-en7523.c       | 99 ++++++++++++++++++++++++++++++++--
+ include/linux/clk/clk-en7523.h | 10 ++++
+ 2 files changed, 106 insertions(+), 3 deletions(-)
+ create mode 100644 include/linux/clk/clk-en7523.h
+
+--- a/drivers/clk/clk-en7523.c
++++ b/drivers/clk/clk-en7523.c
+@@ -3,6 +3,7 @@
+ #include <linux/bitfield.h>
+ #include <linux/delay.h>
+ #include <linux/clk-provider.h>
++#include <linux/clk/clk-en7523.h>
+ #include <linux/io.h>
+ #include <linux/mfd/syscon.h>
+ #include <linux/of_platform.h>
+@@ -10,10 +11,12 @@
+ #include <linux/property.h>
+ #include <linux/regmap.h>
+ #include <linux/reset-controller.h>
++#include <linux/soc/airoha/airoha-scu-ssr.h>
+ #include <dt-bindings/clock/en7523-clk.h>
+ #include <dt-bindings/reset/airoha,en7523-reset.h>
+ #include <dt-bindings/reset/airoha,en7581-reset.h>
+ #include <dt-bindings/reset/airoha,an7583-reset.h>
++#include <dt-bindings/soc/airoha,scu-ssr.h>
+ 
+ #define RST_NR_PER_BANK			32
+ 
+@@ -92,6 +95,7 @@ struct en_clk_soc_data {
+ 	const struct clk_ops pcie_ops;
+ 	int (*hw_init)(struct platform_device *pdev,
+ 		       const struct en_clk_soc_data *soc_data,
++		       struct en_clk_priv *priv,
+ 		       struct clk_hw_onecell_data *clk_data);
+ };
+ 
+@@ -558,6 +562,51 @@ static const u16 en7581_rst_map[] = {
+ 	[EN7581_XPON_MAC_RST]		= RST_NR_PER_BANK + 31,
+ };
+ 
++static unsigned int an7581_serdes_wifi1_possible_modes[] = {
++	AIROHA_SCU_SERDES_MODE_PCIE0_X1,
++	AIROHA_SCU_SERDES_MODE_PCIE0_X2,
++	AIROHA_SCU_SERDES_MODE_ETHERNET,
++};
++
++static unsigned int an7581_serdes_wifi2_possible_modes[] = {
++	AIROHA_SCU_SERDES_MODE_PCIE1_X1,
++	AIROHA_SCU_SERDES_MODE_PCIE0_X2,
++	AIROHA_SCU_SERDES_MODE_ETHERNET,
++};
++
++static unsigned int an7581_serdes_usb1_possible_modes[] = {
++	AIROHA_SCU_SERDES_MODE_USB3,
++	AIROHA_SCU_SERDES_MODE_ETHERNET,
++};
++
++static unsigned int an7581_serdes_usb2_possible_modes[] = {
++	AIROHA_SCU_SERDES_MODE_PCIE2_X1,
++	AIROHA_SCU_SERDES_MODE_ETHERNET,
++};
++
++static const struct airoha_scu_ssr_serdes_info an7581_ports_info[] = {
++	[AIROHA_SCU_SERDES_WIFI1] = {
++		.possible_modes = an7581_serdes_wifi1_possible_modes,
++		.num_modes = ARRAY_SIZE(an7581_serdes_wifi1_possible_modes),
++	},
++	[AIROHA_SCU_SERDES_WIFI2] = {
++		.possible_modes = an7581_serdes_wifi2_possible_modes,
++		.num_modes = ARRAY_SIZE(an7581_serdes_wifi2_possible_modes),
++	},
++	[AIROHA_SCU_SERDES_USB1] = {
++		.possible_modes = an7581_serdes_usb1_possible_modes,
++		.num_modes = ARRAY_SIZE(an7581_serdes_usb1_possible_modes),
++	},
++	[AIROHA_SCU_SERDES_USB2] = {
++		.possible_modes = an7581_serdes_usb2_possible_modes,
++		.num_modes = ARRAY_SIZE(an7581_serdes_usb2_possible_modes),
++	},
++};
++
++static const struct airoha_scu_ssr_data an7581_scu_ssr_data = {
++	.ports_info = an7581_ports_info,
++};
++
+ static const u16 an7583_rst_map[] = {
+ 	/* RST_CTRL2 */
+ 	[AN7583_XPON_PHY_RST]		= 0,
+@@ -989,6 +1038,7 @@ static const struct regmap_config en7523
+ 
+ static int en7523_clk_hw_init(struct platform_device *pdev,
+ 			      const struct en_clk_soc_data *soc_data,
++			      struct en_clk_priv *priv,
+ 			      struct clk_hw_onecell_data *clk_data)
+ {
+ 	void __iomem *base, *np_base;
+@@ -1098,8 +1148,33 @@ static int en7581_reset_register(struct
+ 	return devm_reset_controller_register(dev, &rst_data->rcdev);
+ }
+ 
++static void en7581_clk_register_ssr(struct platform_device *pdev,
++				    struct en_clk_priv *priv)
++{
++	struct platform_device_info pinfo = { };
++	struct platform_device *ssr_pdev;
++
++	pinfo.name = "airoha-scu-ssr";
++	pinfo.parent = &pdev->dev;
++	pinfo.id = PLATFORM_DEVID_AUTO;
++	pinfo.fwnode = of_fwnode_handle(pdev->dev.of_node);
++	pinfo.of_node_reused = true;
++	pinfo.data = &an7581_scu_ssr_data;
++	pinfo.size_data = sizeof(an7581_scu_ssr_data);
++
++	ssr_pdev = platform_device_register_data(&pdev->dev, "airoha-scu-ssr",
++						 PLATFORM_DEVID_AUTO,
++						 &an7581_scu_ssr_data,
++						 sizeof(an7581_scu_ssr_data));
++	if (IS_ERR(ssr_pdev))
++		dev_err_probe(&pdev->dev, PTR_ERR(ssr_pdev), "failed to register SCU SSR driver.\n");
++
++	priv->ssr_pdev = ssr_pdev;
++}
++
+ static int en7581_clk_hw_init(struct platform_device *pdev,
+ 			      const struct en_clk_soc_data *soc_data,
++			      struct en_clk_priv *priv,
+ 			      struct clk_hw_onecell_data *clk_data)
+ {
+ 	struct device *dev = &pdev->dev;
+@@ -1132,12 +1207,15 @@ static int en7581_clk_hw_init(struct pla
+ 	regmap_update_bits(clk_map, REG_NP_SCU_PCIC, REG_PCIE_CTRL,
+ 			   FIELD_PREP(REG_PCIE_CTRL, 3));
+ 
++	en7581_clk_register_ssr(pdev, priv);
++
+ 	return en7581_reset_register(&pdev->dev, clk_map, en7581_rst_map,
+ 				     ARRAY_SIZE(en7581_rst_map));
+ }
+ 
+ static int an7583_clk_hw_init(struct platform_device *pdev,
+ 			      const struct en_clk_soc_data *soc_data,
++			      struct en_clk_priv *priv,
+ 			      struct clk_hw_onecell_data *clk_data)
+ {
+ 	struct device *dev = &pdev->dev;
+@@ -1175,10 +1253,15 @@ static int en7523_clk_probe(struct platf
+ 	const struct en_clk_soc_data *soc_data;
+ 	struct clk_hw_onecell_data *clk_data;
+ 	struct device *dev = &pdev->dev;
++	struct en_clk_priv *priv;
+ 	int err;
+ 
+ 	soc_data = device_get_match_data(dev);
+ 
++	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
+ 	clk_data = devm_kzalloc(dev,
+ 				struct_size(clk_data, hws,
+ 					    soc_data->num_clocks),
+@@ -1187,7 +1270,7 @@ static int en7523_clk_probe(struct platf
+ 		return -ENOMEM;
+ 
+ 	clk_data->num = soc_data->num_clocks;
+-	err = soc_data->hw_init(pdev, soc_data, clk_data);
++	err = soc_data->hw_init(pdev, soc_data, priv, clk_data);
+ 	if (err)
+ 		return err;
+ 
+@@ -1203,6 +1286,8 @@ static int en7523_clk_probe(struct platf
+ 			return err;
+ 	}
+ 
++	platform_set_drvdata(pdev, priv);
++
+ 	return 0;
+ }
+ 
+--- /dev/null
++++ b/include/linux/clk/clk-en7523.h
+@@ -0,0 +1,10 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++
++#ifndef __LINUX_CLK_EN7523_H_
++#define __LINUX_CLK_EN7523_H_
++
++struct en_clk_priv {
++	struct platform_device *ssr_pdev;
++};
++
++#endif

--- a/target/linux/airoha/patches-6.12/703-clk-en7523-pass-of-handle-to-scu-ssr.patch
+++ b/target/linux/airoha/patches-6.12/703-clk-en7523-pass-of-handle-to-scu-ssr.patch
@@ -1,0 +1,28 @@
+From 014c83c7200b2d7deb5e4de4ba6a0a310a386a95 Mon Sep 17 00:00:00 2001
+From: Kenneth Kasilag <kenneth@kasilag.me>
+Date: Thu, 25 Sep 2025 00:04:38 +0000
+Subject: [PATCH] airoha: an7581: pass SCU OF handle to SCU SSR driver
+
+Use `platform_device_register_full` instead of `platform_device_register_data`
+in `drivers/clk/clk-en7523.c` to properly pass the SCU OF handle to the child
+driver (airoha-scu-ssr).
+
+Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
+---
+ drivers/clk/clk-en7523.c    | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+--- a/drivers/clk/clk-en7523.c
++++ b/drivers/clk/clk-en7523.c
+@@ -1103,10 +1103,7 @@ static void en7581_clk_register_ssr(stru
+ 	pinfo.data = &an7581_scu_ssr_data;
+ 	pinfo.size_data = sizeof(an7581_scu_ssr_data);
+ 
+-	ssr_pdev = platform_device_register_data(&pdev->dev, "airoha-scu-ssr",
+-						 PLATFORM_DEVID_AUTO,
+-						 &an7581_scu_ssr_data,
+-						 sizeof(an7581_scu_ssr_data));
++	ssr_pdev = platform_device_register_full(&pinfo);
+ 	if (IS_ERR(ssr_pdev))
+ 		dev_err_probe(&pdev->dev, PTR_ERR(ssr_pdev), "failed to register SCU SSR driver.\n");
+ 

--- a/target/linux/airoha/patches-6.12/704-PCI-mediatek-gen3-require-SCU-SSR.patch
+++ b/target/linux/airoha/patches-6.12/704-PCI-mediatek-gen3-require-SCU-SSR.patch
@@ -1,0 +1,58 @@
+From ce6c41d7d229359a253a1ddd7ffd52dc606c3e26 Mon Sep 17 00:00:00 2001
+From: Kenneth Kasilag <kenneth@kasilag.me>
+Date: Thu, 25 Sep 2025 00:53:57 +0000
+Subject: [PATCH] PCI: mediatek-gen3: require SCU SSR for airoha
+
+For the airoha platform, defer probe until SCU SSR has finished initializing.
+This resolves a race condition where mediatek-gen3 starts the PCIe lanes
+before SerDes configuration completes.
+
+Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
+---
+ drivers/pci/controller/pcie-mediatek-gen3.c      | 28 ++++++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+), 0 deletions(-)
+
+--- a/drivers/pci/controller/pcie-mediatek-gen3.c
++++ b/drivers/pci/controller/pcie-mediatek-gen3.c
+@@ -1110,6 +1110,10 @@ static int mtk_pcie_probe(struct platfor
+ 	struct mtk_gen3_pcie *pcie;
+ 	struct pci_host_bridge *host;
+ 	int err;
++#ifdef CONFIG_AIROHA_SCU_SSR
++	struct device *ssr_dev;
++	struct device_link *link;
++#endif
+ 
+ 	host = devm_pci_alloc_host_bridge(dev, sizeof(*pcie));
+ 	if (!host)
+@@ -1121,6 +1125,30 @@ static int mtk_pcie_probe(struct platfor
+ 	pcie->soc = device_get_match_data(dev);
+ 	platform_set_drvdata(pdev, pcie);
+ 
++#ifdef CONFIG_AIROHA_SCU_SSR
++	/* Ensure SCU SSR driver is initialized before PCIe */
++	ssr_dev = bus_find_device_by_name(&platform_bus_type, NULL, "airoha-scu-ssr.0.auto");
++	if (!ssr_dev) {
++		dev_info(dev, "SCU SSR device not found, deferring probe\n");
++		return -EPROBE_DEFER;
++	}
++
++	/* Check if the SSR driver has finished its probe */
++	if (!dev_get_drvdata(ssr_dev)) {
++		dev_info(dev, "SCU SSR driver not ready, deferring probe\n");
++		put_device(ssr_dev); /* Clean up before deferring */
++		return -EPROBE_DEFER;
++	}
++
++	/* Link to the device now that we know it's ready */
++	link = device_link_add(dev, ssr_dev, DL_FLAG_STATELESS | DL_FLAG_PM_RUNTIME);
++	put_device(ssr_dev); /* Clean up our reference */
++	if (!link) {
++		dev_err(dev, "failed to create device link to SCU SSR\n");
++		return -ENOMEM;
++	}
++#endif
++
+ 	err = mtk_pcie_setup(pcie);
+ 	if (err)
+ 		return err;

--- a/target/linux/airoha/patches-6.12/705-soc-airoha-fix-mode-validation.patch
+++ b/target/linux/airoha/patches-6.12/705-soc-airoha-fix-mode-validation.patch
@@ -1,0 +1,27 @@
+From 9efd5d5bff0e69dd7ffa9b10a7e89c5a086704fe Mon Sep 17 00:00:00 2001
+From: Kenneth Kasilag <kenneth@kasilag.me>
+Date: Thu, 25 Sep 2025 01:43:31 +0000
+Subject: [PATCH] soc: airoha: airoha-scu-ssr: fix serdes mode validation
+
+The modes in the array `airoha_scu_serdes_mode_to_str` will be converted
+by `airoha_scu_serdes_str_to_mode` to an `int` value, however all non-zero
+values are treated as invalid.
+
+Revise program logic to reject invalid modes (less than 0).
+
+Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
+---
+ drivers/soc/airoha/airoha-scu-ssr.c       | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/soc/airoha/airoha-scu-ssr.c
++++ b/drivers/soc/airoha/airoha-scu-ssr.c
+@@ -140,7 +140,7 @@ static int airoha_scu_ssr_parse_mode(str
+ 	}
+ 
+ 	mode = airoha_scu_serdes_str_to_mode(serdes_mode);
+-	if (mode) {
++	if (mode < 0) {
+ 		dev_err(dev, "invalid mode %s for %s\n", serdes_mode, property_name);
+ 		return mode;
+ 	}


### PR DESCRIPTION
These patches add the `airoha-scu-ssr` driver to configure SerDes on AN7581. On startup, the AN7581 configures the SerDes ports as follows:

```
AIROHA_SCU_SERDES_WIFI1 = pcie0_x1
AIROHA_SCU_SERDES_WIFI2 = pcie1_x1
AIROHA_SCU_SERDES_USB1  = usb1
AIROHA_SCU_SERDES_USB2  = usb2
```

On certain devices such as the Gemtek W1700K, the SerDes ports should be configured such that WIFI1 and WIFI2 serve a 2-lane PCIe Gen3 port, and USB2 the another PCIe lane to the MT7996 card to allow the `hif2` offload to function.

To demonstrate the above example requires DTS configuration as follows:
```
scuclk: clock-controller@1fb00000 {
	compatible = "airoha,en7581-scu";
	reg = <0x0 0x1fb00000 0x0 0x970>;

	airoha,serdes-wifi1 = "pcie0_x2";
	airoha,serdes-wifi2 = "pcie0_x2";
	airoha,serdes-usb2 = "pcie2_x1";

	#clock-cells = <1>;
	#reset-cells = <1>;
};
```

Supersedes: #17844  
Depends: #20137 
Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>