### PR TITLE
realtek: rtl930x: add XGS1250-12 B1 device

### DIFF
--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-b1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-b1.dts
@@ -4,16 +4,15 @@
 #include "rtl9302_zyxel_xgs1250-12-common.dtsi"
 
 / {
-	compatible = "zyxel,xgs1250-12-a1", "realtek,rtl838x-soc";
-	model = "Zyxel XGS1250-12 A1 Switch";
+	compatible = "zyxel,xgs1250-12-b1", "realtek,rtl838x-soc";
+	model = "Zyxel XGS1250-12 B1 Switch";
 };
 
 &mdio_bus0 {
-	/* External Aquantia 113C PHYs */
 	phy24: ethernet-phy@24 {
 		reg = <24>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 8>;
+		rtl9300,smi-address = <1 0>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;
@@ -22,7 +21,7 @@
 	phy25: ethernet-phy@25 {
 		reg = <25>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <2 8>;
+		rtl9300,smi-address = <2 1>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;
@@ -31,7 +30,7 @@
 	phy26: ethernet-phy@26 {
 		reg = <26>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <3 8>;
+		rtl9300,smi-address = <3 2>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/thermal/thermal.h>
+
+/ {
+	aliases {
+		led-boot = &led_pwr_sys;
+		led-failsafe = &led_pwr_sys;
+		led-running = &led_pwr_sys;
+		led-upgrade = &led_pwr_sys;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		mode {
+			label = "reset";
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>;
+
+		led_pwr_sys: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	sfp0: sfp-p12 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio0 17 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 15 GPIO_ACTIVE_HIGH>;
+	};
+
+	led_set: led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		led_set0 = <0x0a20 0x0b80>; // LED set 0: 1000Mbps,  10/100Mbps
+		led_set1 = <0x0a0b 0x0a28 0x0a82 0x0a0b>; // LED set 1: (10G, 5G, 2.5G) (2.5G, 1G)
+							  // (5G, 10/100) (10G, 5G, 2.5G)
+		led_set2 = <0x0a20 0x0a01>; // LED set 2: 1000MBit, 10GBit
+	};
+
+	thermal-zones {
+		phy24-thermal {
+			/* Poll every 10 seconds */
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy24>;
+
+			trips {
+				phy24_trip0: phy24-trip0 {
+					/* At 80 degrees turn on fan */
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+
+				phy24_trip1: phy24-trip1 {
+					/* At 108 degrees phys exceed spec */
+					temperature = <108000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&phy24_trip0>;
+					cooling-device = <&chassis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+
+		phy25-thermal {
+			/* Poll every 10 seconds */
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy25>;
+
+			trips {
+				phy25_trip0: phy25-trip0 {
+					/* At 80 degrees turn on fan */
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+
+				phy25_trip1: phy25-trip1 {
+					/* At 108 degrees phys exceed spec */
+					temperature = <108000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&phy25_trip0>;
+					cooling-device = <&chassis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+
+		phy26-thermal {
+			/* Poll every 10 seconds */
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy26>;
+
+			trips {
+				phy26_trip0: phy26-trip0 {
+					/* At 80 degrees turn on fan */
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+
+				phy26_trip1: phy26-trip1 {
+					/* At 108 degrees phys exceed spec */
+					temperature = <108000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&phy26_trip0>;
+					cooling-device = <&chassis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+
+	/* YEN SUN TECHNOLOGY FD122510LL-N fan */
+	chassis_fan: gpio-fan {
+		compatible = "gpio-fan";
+		gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		gpio-fan,speed-map = <0    0
+				      7000 1>;
+		#cooling-cells = <2>;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	/* i2c of the SFP+ cage; port 12 */
+	i2c0: i2c@1 {
+		reg = <1>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x10000>;
+			};
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0xf0000 0x10000>;
+				read-only;
+			};
+			partition@100000 {
+				label = "jffs";
+				reg = <0x100000 0x100000>;
+			};
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x200000 0x100000>;
+			};
+			partition@b300000 {
+				label = "firmware";
+				reg = <0x300000 0xce0000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x93001250>;
+			};
+			partition@fe0000 {
+				label = "log";
+				reg = <0xfe0000 0x20000>;
+			};
+		};
+	};
+};
+
+&mdio_bus0 {
+	/* External RTL8218D or RTL8218E PHY */
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		rtl9300,smi-address = <0 0>;
+		// Disabled because we do not know how to bring up again
+		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+	};
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		rtl9300,smi-address = <0 1>;
+	};
+	phy2: ethernet-phy@2 {
+		reg = <2>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		rtl9300,smi-address = <0 2>;
+	};
+	phy3: ethernet-phy@3 {
+		reg = <3>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		rtl9300,smi-address = <0 3>;
+	};
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		rtl9300,smi-address = <0 4>;
+	};
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		rtl9300,smi-address = <0 5>;
+	};
+	phy6: ethernet-phy@6 {
+		reg = <6>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		rtl9300,smi-address = <0 6>;
+	};
+	phy7: ethernet-phy@7 {
+		reg = <7>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+		rtl9300,smi-address = <0 7>;
+	};
+
+	INTERNAL_PHY(27)
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			pcs-handle = <&serdes2>;
+			phy-handle = <&phy0>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+			pcs-handle = <&serdes2>;
+			phy-handle = <&phy1>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+			pcs-handle = <&serdes2>;
+			phy-handle = <&phy2>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+			pcs-handle = <&serdes2>;
+			phy-handle = <&phy3>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@4 {
+			reg = <4>;
+			label = "lan5";
+			pcs-handle = <&serdes2>;
+			phy-handle = <&phy4>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@5 {
+			reg = <5>;
+			label = "lan6";
+			pcs-handle = <&serdes2>;
+			phy-handle = <&phy5>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@6 {
+			reg = <6>;
+			label = "lan7";
+			pcs-handle = <&serdes2>;
+			phy-handle = <&phy6>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+		port@7 {
+			reg = <7>;
+			label = "lan8";
+			pcs-handle = <&serdes2>;
+			phy-handle = <&phy7>;
+			phy-mode = "usxgmii";
+			led-set = <0>;
+		};
+
+		port@24 {
+			reg = <24>;
+			label = "lan9";
+			pcs-handle = <&serdes6>;
+			phy-handle = <&phy24>;
+			phy-mode = "usxgmii";
+			led-set = <1>;
+		};
+		port@25 {
+			reg = <25>;
+			label = "lan10";
+			pcs-handle = <&serdes7>;
+			phy-handle = <&phy25>;
+			phy-mode = "usxgmii";
+			led-set = <1>;
+		};
+		port@26 {
+			reg = <26>;
+			label = "lan11";
+			pcs-handle = <&serdes8>;
+			phy-handle = <&phy26>;
+			phy-mode = "usxgmii";
+			led-set = <1>;
+		};
+
+		port@27 {
+			reg = <27>;
+			label = "lan12";
+			pcs-handle = <&serdes9>;
+			phy-handle = <&phy27>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp0>;
+			led-set = <2>;
+			managed = "in-band-status";
+		};
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -114,15 +114,13 @@ define Device/zyxel_xgs1210-12-a1
 endef
 TARGET_DEVICES += zyxel_xgs1210-12-a1
 
-define Device/zyxel_xgs1250-12-a1
+define Device/zyxel_xgs1250-12-common
   SOC := rtl9302
   UIMAGE_MAGIC := 0x93001250
   ZYXEL_VERS := ABWE
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := XGS1250-12
-  DEVICE_VARIANT := A1
   DEVICE_PACKAGES := kmod-hwmon-gpiofan kmod-thermal
-  SUPPORTED_DEVICES += zyxel,xgs1250-12
   IMAGE_SIZE := 13312k
   KERNEL_INITRAMFS := \
 	kernel-bin | \
@@ -131,4 +129,16 @@ define Device/zyxel_xgs1250-12-a1
 	zyxel-vers | \
 	uImage gzip
 endef
+
+define Device/zyxel_xgs1250-12-a1
+  $(Device/zyxel_xgs1250-12-common)
+  SUPPORTED_DEVICES += zyxel,xgs1250-12
+  DEVICE_VARIANT := A1
+endef
 TARGET_DEVICES += zyxel_xgs1250-12-a1
+
+define Device/zyxel_xgs1250-12-b1
+  $(Device/zyxel_xgs1250-12-common)
+  DEVICE_VARIANT := B1
+endef
+TARGET_DEVICES += zyxel_xgs1250-12-b1


### PR DESCRIPTION
The A1 and B1 devices are largely the same. The differences seem to be:
- RTL8218D (A1) vs RTL8218E (B1) PHY for the eight 1 Gbps TP ports
- Aquantia (A1) vs RTL8261N (B1) PHY for the three 10 Gbps TP ports

RTL8218D/E share the same driver and support was added already by commit c8c187f0f0 ("realtek: add support for RTL8218E").

The RTL8261N is also already supported but it's located at different addresses compared to the A1 device. This requires the device tree to be split. As a result, the devices are require different images.

I found the smi addresses on the forum:
https://forum.openwrt.org/t/support-for-rtl838x-based-managed-switches/57875/3622 And I can conform on my B1 device that this is working.
