### PR TITLE
mediatek: filogic: use nvmem for Unifi 6 Plus WiFi mac

### DIFF
--- a/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
+++ b/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
@@ -128,7 +128,9 @@
 					};
 
 					macaddr_eeprom_6: macaddr@6 {
+						compatible = "mac-base";
 						reg = <0x6 0x6>;
+						#nvmem-cell-cells = <1>;
 					};
 				};
 			};
@@ -169,5 +171,19 @@
 };
 
 &wifi {
+	#address-cells = <1>;
+	#size-cells = <0>;
 	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_eeprom_6 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_eeprom_6 1>;
+		nvmem-cell-names = "mac-address";
+	};
 };

--- a/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
+++ b/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
@@ -153,6 +153,33 @@
 	vmmc-supply = <&reg_3p3v>;
 	non-removable;
 	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+
+			partitions {
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem: nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory_0: eeprom@0 {
+							reg = <0x0 0x1000>;
+						};
+					};
+				};
+			};
+		};
+	};
 };
 
 &eth {
@@ -171,6 +198,8 @@
 };
 
 &wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";

--- a/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
+++ b/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
@@ -175,6 +175,9 @@
 						eeprom_factory_0: eeprom@0 {
 							reg = <0x0 0x1000>;
 						};
+						precal_factory_1010: precal@1010 {
+							reg = <0x1010 0x6f010>;
+					};
 					};
 				};
 			};
@@ -198,8 +201,8 @@
 };
 
 &wifi {
-	nvmem-cells = <&eeprom_factory_0>;
-	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>, <&precal_factory_1010>;
+	nvmem-cell-names = "eeprom", "precal";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -16,9 +16,6 @@ case "$FIRMWARE" in
 	tplink,fr365-v1)
 		ln -sf /tmp/wlan/radio /lib/firmware/$FIRMWARE
 		;;
-	ubnt,unifi-6-plus)
-		caldata_extract_mmc "factory" 0x0 0x1000
-		;;
 	esac
 	;;
 "mediatek/mt7986_eeprom_mt7975_dual.bin")

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -206,11 +206,6 @@ case "$board" in
 	tplink,tl-xtr8488)
 		[ "$PHYNBR" = "1" ] && get_mac_label > /sys${DEVPATH}/macaddress
 		;;
-	ubnt,unifi-6-plus)
-		addr=$(mtd_get_mac_binary EEPROM 0x6)
-		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
-		;;
 	routerich,ax3000|\
 	routerich,ax3000-ubootmod|\
 	zbtlink,zbt-z8102ax|\


### PR DESCRIPTION
Avoids the occasional lost race, where VAPs are created before the hotplug script has updated the phy mac address.

Run tested