### PR TITLE
kernel: modules: add PWM GPIO module

### DIFF
--- a/package/kernel/linux/modules/gpio.mk
+++ b/package/kernel/linux/modules/gpio.mk
@@ -137,3 +137,20 @@ define KernelPackage/gpio-pcf857x/description
 endef
 
 $(eval $(call KernelPackage,gpio-pcf857x))
+
+
+define KernelPackage/gpio-pwm
+  SUBMENU:=$(GPIO_MENU)
+  DEPENDS:=@GPIO_SUPPORT @PWM_SUPPORT
+  TITLE:=PWM GPIO support
+  KCONFIG:=CONFIG_PWM_GPIO
+  FILES:=$(LINUX_DIR)/drivers/pwm/pwm-gpio.ko
+  AUTOLOAD:=$(call AutoProbe,pwm-gpio)
+endef
+
+define KernelPackage/gpio-pwm/description
+ Generic PWM framework driver for software PWM toggling a GPIO pin from
+ kernel high-resolution timers.
+endef
+
+$(eval $(call KernelPackage,gpio-pwm))


### PR DESCRIPTION
Package the generic kernel PWM GPIO driver as a module to avoid the need to build it into the kernel.
