### PR TITLE
realtek: Add support for Zyxel XGS1210 Rev B1 and switch to rt-loader

### DIFF
--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-b1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-b1.dts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl9302_zyxel_xgs1210-12-common.dtsi"
+
+/ {
+	compatible = "zyxel,xgs1210-12-b1", "realtek,rtl838x-soc";
+	model = "Zyxel XGS1210-12 B1 Switch";
+};
+
+&mdio_bus0 {
+	phy24: ethernet-phy@24 {
+		reg = <24>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <1 1>;
+		// Disabled because we do not know how to bring up again
+		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+	};
+
+	phy25: ethernet-phy@25 {
+		reg = <25>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <2 2>;
+		// Disabled because we do not know how to bring up again
+		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@24 {
+			reg = <24>;
+			label = "lan9";
+			pcs-handle = <&serdes6>;
+			phy-handle = <&phy24>;
+			phy-mode = "2500base-x";
+			led-set = <1>;
+		};
+		port@25 {
+			reg = <25>;
+			label = "lan10";
+			pcs-handle = <&serdes7>;
+			phy-handle = <&phy25>;
+			phy-mode = "2500base-x";
+			led-set = <1>;
+		};
+	};
+};

--- a/target/linux/realtek/image/common.mk
+++ b/target/linux/realtek/image/common.mk
@@ -92,3 +92,25 @@ define Device/zyxel_gs1900
 	uImage none | \
 	check-size 6976k
 endef
+
+define Device/zyxel_xgs1210-12
+  SOC := rtl9302
+  UIMAGE_MAGIC := 0x93001210
+  ZYXEL_VERS := ABTY
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := XGS1210-12
+  IMAGE_SIZE := 13312k
+  KERNEL := \
+        kernel-bin | \
+        append-dtb | \
+        rt-compress | \
+        rt-loader | \
+        uImage none
+  KERNEL_INITRAMFS := \
+        kernel-bin | \
+        append-dtb | \
+        rt-compress | \
+        zyxel-vers | \
+        rt-loader | \
+        uImage none
+endef

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
+include ./common.mk
+
 define Build/xikestor-nosimg
   $(STAGING_DIR_HOST)/bin/nosimg-enc -i $@ -o $@.new
   mv $@.new $@
@@ -97,22 +99,17 @@ endef
 TARGET_DEVICES += xikestor_sks8310-8x
 
 define Device/zyxel_xgs1210-12-a1
-  SOC := rtl9302
+  $(Device/zyxel_xgs1210-12)
   SUPPORTED_DEVICES += zyxel,xgs1210-12
-  UIMAGE_MAGIC := 0x93001210
-  ZYXEL_VERS := ABTY
-  DEVICE_VENDOR := Zyxel
-  DEVICE_MODEL := XGS1210-12
   DEVICE_VARIANT := A1
-  IMAGE_SIZE := 13312k
-  KERNEL_INITRAMFS := \
-        kernel-bin | \
-        append-dtb | \
-        gzip | \
-        zyxel-vers | \
-        uImage gzip
 endef
 TARGET_DEVICES += zyxel_xgs1210-12-a1
+
+define Device/zyxel_xgs1210-12-b1
+  $(Device/zyxel_xgs1210-12)
+  DEVICE_VARIANT := B1
+endef
+TARGET_DEVICES += zyxel_xgs1210-12-b1
 
 define Device/zyxel_xgs1250-12-common
   SOC := rtl9302


### PR DESCRIPTION
This is just like Rev A1 except for different PHYs on the 2.5gbps ports (lan9 and lan10)

Both revisions of xgs1210-12 are also switched to use rt-loader to avoid problems due to overwriting the compressed image in memory when flashing with the oem firmware (and also to save flash space with respect to gzip compression)

Currently the 2.5gbps ports ONLY work at 2.5gbps.  If connected to a 1gbps peer, link appears to work correctly but no traffic flows.

Partly (mostly) addresses https://github.com/openwrt/openwrt/issues/19640