### PR TITLE
firewall4: remove unused dependency

### DIFF
--- a/package/network/config/firewall4/Makefile
+++ b/package/network/config/firewall4/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=firewall4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firewall4.git
@@ -22,9 +22,7 @@ define Package/firewall4
   CATEGORY:=Base system
   TITLE:=OpenWrt 4th gen firewall
   DEPENDS:= \
-	+kmod-nft-core +kmod-nft-fib +kmod-nft-offload \
-	+kmod-nft-nat \
-	+nftables-json \
+	+kmod-nft-core +kmod-nft-offload +kmod-nft-nat +nftables-json \
 	+ucode +ucode-mod-fs +ucode-mod-ubus +ucode-mod-uci
   EXTRA_DEPENDS:=ucode (>=2022.03.22)
   PROVIDES:=uci-firewall


### PR DESCRIPTION
Remove unused nftables fib kmod dependency, taking 25kB on disk 50kB in mem
Not used by any community package either
Tested blacklisting kmods from v22 to week old snapshots on varied platforms.
User includes containing fib match (eg rp filter reimplementation or splitting forward from input before conntrack) will need the module added.
iptables-translate -m addrtype and -m rpfilter idem
