### PR TITLE
ramips: add support for Cudy C200P

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_c200p.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_c200p.dts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "cudy,c200p", "mediatek,mt7621-soc";
+	model = "Cudy C200P";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 10 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1000>;
+		always-running;
+	};
+	
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		pse {
+			gpio-export,name = "pse";
+			gpio-export,output = <1>;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_green: led-status-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led-poe-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&reg_vbus {
+	/delete-property/ regulator-always-on;
+	gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+	enable-active-high;
+};
+
+&i2c {
+	status = "okay";
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfa0000>;
+			};
+
+			partition@ff0000 {
+				label = "bdinfo";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart2", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_bdinfo_de00 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan5";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan2";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -806,6 +806,16 @@ define Device/cudy_r700
 endef
 TARGET_DEVICES += cudy_r700
 
+define Device/cudy_c200p
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := C200P
+  IMAGE_SIZE := 15872k
+  UIMAGE_NAME := R74
+  DEVICE_PACKAGES := -uboot-envtools -wpad-basic-mbedtls kmod-usb3
+endef
+TARGET_DEVICES += cudy_c200p
+
 define Device/cudy_x6-v1
   $(Device/dsa-migration)
   IMAGE_SIZE := 32256k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -119,6 +119,10 @@ ramips_setup_interfaces()
 		uci add_list firewall.@zone[1].network='eth_data'
 		uci add_list firewall.@zone[1].network='eth_om'
 		;;
+	cudy,c200p|\
+	mikrotik,routerboard-750gr3)
+		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
+		;;
 	dlink,covr-x1860-a1)
 		ucidef_set_interfaces_lan_wan "ethernet" "internet"
 		;;
@@ -136,9 +140,6 @@ ramips_setup_interfaces()
 		;;
 	gnubee,gb-pc2)
 		ucidef_set_interface_lan "ethblack ethblue ethyellow"
-		;;
-	mikrotik,routerboard-750gr3)
-		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
 		;;
 	mikrotik,routerboard-760igs)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan sfp"


### PR DESCRIPTION
This patch adds support for Cudy C200P.

Specifications:

    SoC: MediaTek MT7621AT
    RAM: 256 MB (DDR3)
    Flash: 16 MB (NOR)
    POE Chip: IP804AR

Interfaces:

    Switch: 1 WAN, 4 LAN (Gigabit)
    Gigabit RJ45 PoE Ports on 2~5
    Max Power on a Single PoE Ports 	30W
    PoE Ports : The PoE ports comply with IEEE 802.3at/af standards.
    Ports: 1 USB-A 3.0 Ports

LED:

    System
    PoE Max Status
    Link/ACT/PoE Status of Each PoE Port

Physical Buttons:

 	Reset Button

Power Input:

 	DC Jack

Power Methods:

    DC: 54V 1.11A
    802.3at/af PoE
    Passive PoE: 24/48V

Max Power Consumption (W):

    Total: 60W
    PoE: 55W
    PoE (when USB Device is plugged in): 50W
    No PoE: 5W

Installation:

To install OpenWRT, you need the intermediate firmware from Cudy. (U-boot is locked). After installing the intermediate firmware, you can install OpenWRT via sysupgrade.

Recovery:

TFTP available.
1. Place the recovery.bin in the serving directory of your TFTP server.
2. Set your IP to 192.168.1.88/24.
3. Press the “Reset” button of Cudy router and hold it. Before the Cudy router is powered on and before TFTP start to download the firmware, don't release the “Reset” button.
4. Power on the Cudy router.
5. You can release the reset button only when TFTP starts downloading firmware.
6. When the SYSTEM LED turns solid green, the upgrade is complete.

Serial:

1. Serial connection parameters: 115200 / 8N1
2. Serial connection voltage: 3.3V

PoE is not supported at the time of PR. The IP804R chip is not yet supported by OpenWRT.
