### PR TITLE
mediatek: ap7622-wh1: Enable bluetooth interface

### DIFF
--- a/target/linux/mediatek/dts/mt7622-asiarf-ap7622-wh1.dts
+++ b/target/linux/mediatek/dts/mt7622-asiarf-ap7622-wh1.dts
@@ -108,6 +108,10 @@
 	status = "okay";
 };
 
+&btif {
+	status = "okay";
+};
+
 &rtc {
 	status = "disabled";
 };


### PR DESCRIPTION
This device is supported for mt7622 bluetooth. Enable it in dts.