### PR TITLE
kernel: fix dependencies for kmod-gpio-pwm

### DIFF
--- a/package/kernel/linux/modules/gpio.mk
+++ b/package/kernel/linux/modules/gpio.mk
@@ -141,7 +141,7 @@ $(eval $(call KernelPackage,gpio-pcf857x))
 
 define KernelPackage/gpio-pwm
   SUBMENU:=$(GPIO_MENU)
-  DEPENDS:=@GPIO_SUPPORT @PWM_SUPPORT
+  DEPENDS:=@GPIO_SUPPORT @PWM_SUPPORT @!LINUX_6_6
   TITLE:=PWM GPIO support
   KCONFIG:=CONFIG_PWM_GPIO
   FILES:=$(LINUX_DIR)/drivers/pwm/pwm-gpio.ko


### PR DESCRIPTION
gpio pwm driver is only available on kernel 6.11+.

Cc: @robimarko 