### PR TITLE
ksmbd: revert upstream limit repeated connection

### DIFF
--- a/target/linux/generic/hack-6.12/940-Revert-ksmbd-extend-the-connection-limiting-mechanism-to-ipv6.patch
+++ b/target/linux/generic/hack-6.12/940-Revert-ksmbd-extend-the-connection-limiting-mechanism-to-ipv6.patch
@@ -1,0 +1,83 @@
+From 7220ecc26a9a8e6766eb9ec7cd90fbba048ce7b3 Mon Sep 17 00:00:00 2001
+From: Andrea Pesaresi <andreapesaresi82@gmail.com>
+Date: Tue, 30 Sep 2025 19:35:36 +0200
+Subject: Revert "ksmbd: extend the connection limiting mechanism to support
+ IPv6"
+
+This reverts commit d9e157fcfebc126cd19b2333a6417a840c24e529.
+---
+ fs/smb/server/connection.h    |  7 +------
+ fs/smb/server/transport_tcp.c | 26 +++-----------------------
+ 2 files changed, 4 insertions(+), 29 deletions(-)
+
+--- a/fs/smb/server/connection.h
++++ b/fs/smb/server/connection.h
+@@ -46,12 +46,7 @@ struct ksmbd_conn {
+ 	struct mutex			srv_mutex;
+ 	int				status;
+ 	unsigned int			cli_cap;
+-	union {
+-		__be32			inet_addr;
+-#if IS_ENABLED(CONFIG_IPV6)
+-		u8			inet6_addr[16];
+-#endif
+-	};
++	__be32				inet_addr;
+ 	char				*request_buf;
+ 	struct ksmbd_transport		*transport;
+ 	struct nls_table		*local_nls;
+--- a/fs/smb/server/transport_tcp.c
++++ b/fs/smb/server/transport_tcp.c
+@@ -87,14 +87,7 @@ static struct tcp_transport *alloc_trans
+ 		return NULL;
+ 	}
+ 
+-#if IS_ENABLED(CONFIG_IPV6)
+-	if (client_sk->sk->sk_family == AF_INET6)
+-		memcpy(&conn->inet6_addr, &client_sk->sk->sk_v6_daddr, 16);
+-	else
+-		conn->inet_addr = inet_sk(client_sk->sk)->inet_daddr;
+-#else
+ 	conn->inet_addr = inet_sk(client_sk->sk)->inet_daddr;
+-#endif
+ 	conn->transport = KSMBD_TRANS(t);
+ 	KSMBD_TRANS(t)->conn = conn;
+ 	KSMBD_TRANS(t)->ops = &ksmbd_tcp_transport_ops;
+@@ -238,6 +231,7 @@ static int ksmbd_kthread_fn(void *p)
+ {
+ 	struct socket *client_sk = NULL;
+ 	struct interface *iface = (struct interface *)p;
++	struct inet_sock *csk_inet;
+ 	struct ksmbd_conn *conn;
+ 	int ret;
+ 
+@@ -260,27 +254,13 @@ static int ksmbd_kthread_fn(void *p)
+ 		/*
+ 		 * Limits repeated connections from clients with the same IP.
+ 		 */
++		csk_inet = inet_sk(client_sk->sk);
+ 		down_read(&conn_list_lock);
+ 		list_for_each_entry(conn, &conn_list, conns_list)
+-#if IS_ENABLED(CONFIG_IPV6)
+-			if (client_sk->sk->sk_family == AF_INET6) {
+-				if (memcmp(&client_sk->sk->sk_v6_daddr,
+-					   &conn->inet6_addr, 16) == 0) {
+-					ret = -EAGAIN;
+-					break;
+-				}
+-			} else if (inet_sk(client_sk->sk)->inet_daddr ==
+-				 conn->inet_addr) {
++			if (csk_inet->inet_daddr == conn->inet_addr) {
+ 				ret = -EAGAIN;
+ 				break;
+ 			}
+-#else
+-			if (inet_sk(client_sk->sk)->inet_daddr ==
+-			    conn->inet_addr) {
+-				ret = -EAGAIN;
+-				break;
+-			}
+-#endif
+ 		up_read(&conn_list_lock);
+ 		if (ret == -EAGAIN)
+ 			continue;

--- a/target/linux/generic/hack-6.12/941-Revert-ksmbd-limit-repeated-connections-from-clients.patch
+++ b/target/linux/generic/hack-6.12/941-Revert-ksmbd-limit-repeated-connections-from-clients.patch
@@ -1,0 +1,62 @@
+From 575b789e36cf4bfa85ba5b649673ede9b4c7b5d0 Mon Sep 17 00:00:00 2001
+From: Andrea Pesaresi <andreapesaresi82@gmail.com>
+Date: Tue, 30 Sep 2025 22:36:12 +0200
+Subject: Revert "ksmbd: limit repeated connections from clients with the same
+ IP"
+
+This reverts commit fa1c47af4ff641cf9197ecdb1f8240cbb30389c1.
+---
+ fs/smb/server/connection.h    |  1 -
+ fs/smb/server/transport_tcp.c | 17 -----------------
+ 2 files changed, 18 deletions(-)
+
+--- a/fs/smb/server/connection.h
++++ b/fs/smb/server/connection.h
+@@ -46,7 +46,6 @@ struct ksmbd_conn {
+ 	struct mutex			srv_mutex;
+ 	int				status;
+ 	unsigned int			cli_cap;
+-	__be32				inet_addr;
+ 	char				*request_buf;
+ 	struct ksmbd_transport		*transport;
+ 	struct nls_table		*local_nls;
+--- a/fs/smb/server/transport_tcp.c
++++ b/fs/smb/server/transport_tcp.c
+@@ -87,7 +87,6 @@ static struct tcp_transport *alloc_trans
+ 		return NULL;
+ 	}
+ 
+-	conn->inet_addr = inet_sk(client_sk->sk)->inet_daddr;
+ 	conn->transport = KSMBD_TRANS(t);
+ 	KSMBD_TRANS(t)->conn = conn;
+ 	KSMBD_TRANS(t)->ops = &ksmbd_tcp_transport_ops;
+@@ -231,8 +230,6 @@ static int ksmbd_kthread_fn(void *p)
+ {
+ 	struct socket *client_sk = NULL;
+ 	struct interface *iface = (struct interface *)p;
+-	struct inet_sock *csk_inet;
+-	struct ksmbd_conn *conn;
+ 	int ret;
+ 
+ 	while (!kthread_should_stop()) {
+@@ -251,20 +248,6 @@ static int ksmbd_kthread_fn(void *p)
+ 			continue;
+ 		}
+ 
+-		/*
+-		 * Limits repeated connections from clients with the same IP.
+-		 */
+-		csk_inet = inet_sk(client_sk->sk);
+-		down_read(&conn_list_lock);
+-		list_for_each_entry(conn, &conn_list, conns_list)
+-			if (csk_inet->inet_daddr == conn->inet_addr) {
+-				ret = -EAGAIN;
+-				break;
+-			}
+-		up_read(&conn_list_lock);
+-		if (ret == -EAGAIN)
+-			continue;
+-
+ 		if (server_conf.max_connections &&
+ 		    atomic_inc_return(&active_num_conn) >= server_conf.max_connections) {
+ 			pr_info_ratelimited("Limit the maximum number of connections(%u)\n",

--- a/target/linux/generic/hack-6.6/940-Revert-ksmbd-extend-the-connection-limiting-mechanism-to-ipv6.patch
+++ b/target/linux/generic/hack-6.6/940-Revert-ksmbd-extend-the-connection-limiting-mechanism-to-ipv6.patch
@@ -1,0 +1,83 @@
+From a2002bb6f1b1dee2b1f3b1839f2d677c9a05fabc Mon Sep 17 00:00:00 2001
+From: Andrea Pesaresi <andreapesaresi82@gmail.com>
+Date: Tue, 30 Sep 2025 22:43:30 +0200
+Subject: Revert "ksmbd: extend the connection limiting mechanism to support
+ IPv6"
+
+This reverts commit d9e157fcfebc126cd19b2333a6417a840c24e529.
+---
+ fs/smb/server/connection.h    |  7 +------
+ fs/smb/server/transport_tcp.c | 26 +++-----------------------
+ 2 files changed, 4 insertions(+), 29 deletions(-)
+
+--- a/fs/smb/server/connection.h
++++ b/fs/smb/server/connection.h
+@@ -46,12 +46,7 @@ struct ksmbd_conn {
+ 	struct mutex			srv_mutex;
+ 	int				status;
+ 	unsigned int			cli_cap;
+-	union {
+-		__be32			inet_addr;
+-#if IS_ENABLED(CONFIG_IPV6)
+-		u8			inet6_addr[16];
+-#endif
+-	};
++	__be32				inet_addr;
+ 	char				*request_buf;
+ 	struct ksmbd_transport		*transport;
+ 	struct nls_table		*local_nls;
+--- a/fs/smb/server/transport_tcp.c
++++ b/fs/smb/server/transport_tcp.c
+@@ -87,14 +87,7 @@ static struct tcp_transport *alloc_trans
+ 		return NULL;
+ 	}
+ 
+-#if IS_ENABLED(CONFIG_IPV6)
+-	if (client_sk->sk->sk_family == AF_INET6)
+-		memcpy(&conn->inet6_addr, &client_sk->sk->sk_v6_daddr, 16);
+-	else
+-		conn->inet_addr = inet_sk(client_sk->sk)->inet_daddr;
+-#else
+ 	conn->inet_addr = inet_sk(client_sk->sk)->inet_daddr;
+-#endif
+ 	conn->transport = KSMBD_TRANS(t);
+ 	KSMBD_TRANS(t)->conn = conn;
+ 	KSMBD_TRANS(t)->ops = &ksmbd_tcp_transport_ops;
+@@ -238,6 +231,7 @@ static int ksmbd_kthread_fn(void *p)
+ {
+ 	struct socket *client_sk = NULL;
+ 	struct interface *iface = (struct interface *)p;
++	struct inet_sock *csk_inet;
+ 	struct ksmbd_conn *conn;
+ 	int ret;
+ 
+@@ -260,27 +254,13 @@ static int ksmbd_kthread_fn(void *p)
+ 		/*
+ 		 * Limits repeated connections from clients with the same IP.
+ 		 */
++		csk_inet = inet_sk(client_sk->sk);
+ 		down_read(&conn_list_lock);
+ 		list_for_each_entry(conn, &conn_list, conns_list)
+-#if IS_ENABLED(CONFIG_IPV6)
+-			if (client_sk->sk->sk_family == AF_INET6) {
+-				if (memcmp(&client_sk->sk->sk_v6_daddr,
+-					   &conn->inet6_addr, 16) == 0) {
+-					ret = -EAGAIN;
+-					break;
+-				}
+-			} else if (inet_sk(client_sk->sk)->inet_daddr ==
+-				 conn->inet_addr) {
++			if (csk_inet->inet_daddr == conn->inet_addr) {
+ 				ret = -EAGAIN;
+ 				break;
+ 			}
+-#else
+-			if (inet_sk(client_sk->sk)->inet_daddr ==
+-			    conn->inet_addr) {
+-				ret = -EAGAIN;
+-				break;
+-			}
+-#endif
+ 		up_read(&conn_list_lock);
+ 		if (ret == -EAGAIN)
+ 			continue;

--- a/target/linux/generic/hack-6.6/941-Revert-ksmbd-limit-repeated-connections-from-clients.patch
+++ b/target/linux/generic/hack-6.6/941-Revert-ksmbd-limit-repeated-connections-from-clients.patch
@@ -1,0 +1,62 @@
+From 7fe1a46e2d0bf2f4ca9da286be95c46c21111c0c Mon Sep 17 00:00:00 2001
+From: Andrea Pesaresi <andreapesaresi82@gmail.com>
+Date: Tue, 30 Sep 2025 22:44:36 +0200
+Subject: Revert "ksmbd: limit repeated connections from clients with the same
+ IP"
+
+This reverts commit fa1c47af4ff641cf9197ecdb1f8240cbb30389c1.
+---
+ fs/smb/server/connection.h    |  1 -
+ fs/smb/server/transport_tcp.c | 17 -----------------
+ 2 files changed, 18 deletions(-)
+
+--- a/fs/smb/server/connection.h
++++ b/fs/smb/server/connection.h
+@@ -46,7 +46,6 @@ struct ksmbd_conn {
+ 	struct mutex			srv_mutex;
+ 	int				status;
+ 	unsigned int			cli_cap;
+-	__be32				inet_addr;
+ 	char				*request_buf;
+ 	struct ksmbd_transport		*transport;
+ 	struct nls_table		*local_nls;
+--- a/fs/smb/server/transport_tcp.c
++++ b/fs/smb/server/transport_tcp.c
+@@ -87,7 +87,6 @@ static struct tcp_transport *alloc_trans
+ 		return NULL;
+ 	}
+ 
+-	conn->inet_addr = inet_sk(client_sk->sk)->inet_daddr;
+ 	conn->transport = KSMBD_TRANS(t);
+ 	KSMBD_TRANS(t)->conn = conn;
+ 	KSMBD_TRANS(t)->ops = &ksmbd_tcp_transport_ops;
+@@ -231,8 +230,6 @@ static int ksmbd_kthread_fn(void *p)
+ {
+ 	struct socket *client_sk = NULL;
+ 	struct interface *iface = (struct interface *)p;
+-	struct inet_sock *csk_inet;
+-	struct ksmbd_conn *conn;
+ 	int ret;
+ 
+ 	while (!kthread_should_stop()) {
+@@ -251,20 +248,6 @@ static int ksmbd_kthread_fn(void *p)
+ 			continue;
+ 		}
+ 
+-		/*
+-		 * Limits repeated connections from clients with the same IP.
+-		 */
+-		csk_inet = inet_sk(client_sk->sk);
+-		down_read(&conn_list_lock);
+-		list_for_each_entry(conn, &conn_list, conns_list)
+-			if (csk_inet->inet_daddr == conn->inet_addr) {
+-				ret = -EAGAIN;
+-				break;
+-			}
+-		up_read(&conn_list_lock);
+-		if (ret == -EAGAIN)
+-			continue;
+-
+ 		if (server_conf.max_connections &&
+ 		    atomic_inc_return(&active_num_conn) >= server_conf.max_connections) {
+ 			pr_info_ratelimited("Limit the maximum number of connections(%u)\n",


### PR DESCRIPTION
This is a pull request to revert two upstream commit on ksmbd.
Description:
these two related upstream commit [this](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/fs/smb?h=linux-6.6.y&id=fa1c47af4ff641cf9197ecdb1f8240cbb30389c1) and the extended for ipv6 [this](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/fs/smb?h=linux-6.6.y&id=d9e157fcfebc126cd19b2333a6417a840c24e529) cause a regression.
The issue is:
if you try to open a connection on nautilus by a simple double click on share name the connection hangs and get refused until ksmbd service is restarted, this is caused by two attempt with same IP. So, when you do a double click on share name Nautilus try to connect two times, and ksmbd refusing it. An issue is opened [here](https://github.com/namjaejeon/ksmbd/issues/512) at the moment.
Until we don't have a fix upstream I suggest to revert these two commits.
