### PR TITLE
libunwind: enable build for riscv64 and update it to 1.8.3

### DIFF
--- a/package/libs/libunwind/Makefile
+++ b/package/libs/libunwind/Makefile
@@ -13,7 +13,7 @@ PKG_VERSION:=1.8.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
+PKG_SOURCE_URL:=https://github.com/libunwind/libunwind/releases/download/v$(PKG_VERSION)/
 PKG_HASH:=be30d910e67f58d82e753231f1357f326a1a088acf126b21ff77e60aab19b90b
 
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>

--- a/package/libs/libunwind/Makefile
+++ b/package/libs/libunwind/Makefile
@@ -32,7 +32,7 @@ define Package/libunwind
   CATEGORY:=Libraries
   TITLE:=The libunwind project
   URL:=http://www.nongnu.org/libunwind/
-  DEPENDS:=@((mips||mipsel||mips64||powerpc64||x86_64||arm||aarch64||loongarch64)||(USE_GLIBC&&(powerpc||i386))) +zlib
+  DEPENDS:=@!(USE_MUSL&&(powerpc)) +zlib
   ABI_VERSION:=8
 endef
 

--- a/package/libs/libunwind/Makefile
+++ b/package/libs/libunwind/Makefile
@@ -9,12 +9,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libunwind
-PKG_VERSION:=1.8.1
+PKG_VERSION:=1.8.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/$(PKG_NAME)/$(PKG_NAME)/releases/download/v$(PKG_VERSION)/
-PKG_HASH:=ddf0e32dd5fafe5283198d37e4bf9decf7ba1770b6e7e006c33e6df79e6a6157
+PKG_HASH:=be30d910e67f58d82e753231f1357f326a1a088acf126b21ff77e60aab19b90b
 
 PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>
 PKG_LICENSE:=X11


### PR DESCRIPTION
Unfortunately, I do not have riscv64 device, so it would be really nice, if someone might test it.
Partially Fixes: https://github.com/openwrt/openwrt/issues/20191

While at it, update it to version 1.8.3