### PR TITLE
ramips: mt7621: add Teltonika RUTM series support

### DIFF
--- a/target/linux/ramips/dts/mt7621_teltonika_rutm-common.dtsi
+++ b/target/linux/ramips/dts/mt7621_teltonika_rutm-common.dtsi
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	/* NAND flash is devided by half for failover.
+	Bootloader dynamically pass which partition to boot,
+	we can't change CONFIG_MIPS_CMDLINE_FROM_DTB, so
+	cmdline have to be hardcoded to second partition */
+
+	chosen {
+		bootargs = "console=ttyS0,115200n8 ubi.mtd=rutos-b";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x80000 0x10000>;
+				read-only;
+			};
+
+			partition@90000 {
+				label = "config";
+				reg = <0x90000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_0: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@a0000 {
+				label = "bootconfig-a";
+				reg = <0xa0000 0x10000>;
+			};
+
+			partition@b0000 {
+				label = "bootconfig-b";
+				reg = <0xb0000 0x10000>;
+			};
+
+			partition@c0000 {
+				label = "factory";
+				reg = <0xc0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>;
+					};
+				};
+			};
+
+			partition@d0000 {
+				label = "event-log";
+				reg = <0xd0000 0x90000>;
+			};
+
+			partition@400000 {
+				label = "recovery";
+				reg = <0x200000 0xe00000>;
+			};
+		};
+	};
+
+	flash@1 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <1>;
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "rutos-a";
+				reg = <0x00000000 0x08000000>;
+			};
+
+			partition@8000000 {
+				label = "rutos-b";
+				reg = <0x08000000 0x08000000>;
+			};
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_config_0 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+	nvmem-cells = <&macaddr_config_0 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "jtag", "sdhci", "uart2", "uart3";
+		function = "gpio";
+	};
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};

--- a/target/linux/ramips/dts/mt7621_teltonika_rutm11.dts
+++ b/target/linux/ramips/dts/mt7621_teltonika_rutm11.dts
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_teltonika_rutm-common.dtsi"
+
+/ {
+	compatible = "teltonika,rutm11", "mediatek,mt7621-soc";
+	model = "Teltonika RUTM11";
+
+	gpio_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <1>;
+
+		gpio_hc595: gpio_hc595@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <2>;
+			spi-max-frequency = <10000000>;
+			enable-gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_modem_reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <0>;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_modem_power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <0>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_sim_select {
+			gpio-export,name = "sim_select";
+			gpio-export,output = <0>;
+			gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		wan_sim1 {
+			function = "wan-sim1";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 41 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_sim2 {
+			function = "wan-sim2";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 43 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_eth {
+			function = "wan-eth";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 45 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_wifi {
+			function = "wan-wifi";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi_2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		2G {
+			function = "2G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		3G {
+			function = "3G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 9 GPIO_ACTIVE_HIGH>;
+		};
+
+		4G {
+			function = "4G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi1 {
+			function = "rssi-1";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi2 {
+			function = "rssi-2";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi3 {
+			function = "rssi-3";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi4 {
+			function = "rssi-4";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi5 {
+			function = "rssi-5";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan1-g {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <1>;
+			gpios = <&gpio_hc595 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:00:1Gbps";
+		};
+
+		lan1-y {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_AMBER>;
+			function-enumerator = <1>;
+			gpios = <&gpio_hc595 4 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:00:100Mbps";
+		};
+
+		lan2-g {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <2>;
+			gpios = <&gpio_hc595 1 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:01:1Gbps";
+		};
+
+		lan2-y {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_AMBER>;
+			function-enumerator = <2>;
+			gpios = <&gpio_hc595 5 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:01:100Mbps";
+		};
+
+		lan3-g {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <3>;
+			gpios = <&gpio_hc595 2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:02:1Gbps";
+		};
+
+		lan3-y {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_AMBER>;
+			function-enumerator = <3>;
+			gpios = <&gpio_hc595 6 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:02:100Mbps";
+		};
+
+		wan-g {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:04:1Gbps";
+		};
+
+		wan-y {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio_hc595 7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:04:100Mbps";
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_config_0 2>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_config_0 3>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_teltonika_rutm30.dts
+++ b/target/linux/ramips/dts/mt7621_teltonika_rutm30.dts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_teltonika_rutm-common.dtsi"
+
+/ {
+	compatible = "teltonika,rutm30", "mediatek,mt7621-soc";
+	model = "Teltonika RUTM30/RUTM31";
+
+	gpio_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <1>;
+
+		gpio_hc595: gpio_hc595@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <2>;
+			spi-max-frequency = <10000000>;
+			enable-gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_modem_reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <0>;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_modem_power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <0>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_esim_select {
+			gpio-export,name = "esim_select";
+			gpio-export,output = <0>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_tpm_enable {
+			gpio-export,name = "tpm_enable";
+			gpio-export,output = <1>;
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		gsm_red {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		gsm_green {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		gsm_blue {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_red {
+			label = "red:rssi";
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_green {
+			label = "green:rssi";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 48 GPIO_ACTIVE_LOW>;
+		};
+
+		rssi_blue {
+			label = "blue:rssi";
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+		};
+
+		lan-g {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 43 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:01:1Gbps";
+		};
+
+		lan-y {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:01:100Mbps";
+		};
+
+		wan-g {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 41 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:00:1Gbps";
+		};
+
+		wan-y {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio 45 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:00:100Mbps";
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+
+	tpm: tpm@2e {
+		compatible = "infineon,slb9673";
+		reg = <0x2e>;
+		status = "okay";
+	};
+};
+
+&gmac1 {
+	phy-handle = <&ethphy0>;
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		led {
+			status = "disabled";
+		};
+
+		band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_config_0 2>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_config_0 3>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_teltonika_rutm50.dts
+++ b/target/linux/ramips/dts/mt7621_teltonika_rutm50.dts
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_teltonika_rutm-common.dtsi"
+
+/ {
+	compatible = "teltonika,rutm50", "mediatek,mt7621-soc";
+	model = "Teltonika RUTM50/RUTM51";
+
+	gpio_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 9 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio 11 GPIO_ACTIVE_HIGH>;
+		num-chipselects = <1>;
+
+		gpio_hc595: gpio_hc595@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <2>;
+			spi-max-frequency = <10000000>;
+			enable-gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_modem_reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <0>;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_modem_power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <0>;
+			gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		wan_sim1 {
+			function = "wan-sim1";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 41 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_sim2 {
+			function = "wan-sim2";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 43 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_eth {
+			function = "wan-eth";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 45 GPIO_ACTIVE_HIGH>;
+		};
+
+		wan_wifi {
+			function = "wan-wifi";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 42 GPIO_ACTIVE_HIGH>;
+		};
+
+		wifi_2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 10 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi_5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 11 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		3G {
+			function = "3G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		4G {
+			function = "4G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		5G {
+			function = "5G";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi1 {
+			function = "rssi-1";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 47 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi2 {
+			function = "rssi-2";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 48 GPIO_ACTIVE_HIGH>;
+		};
+
+		rssi3 {
+			function = "rssi-3";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 46 GPIO_ACTIVE_HIGH>;
+		};
+
+		lan1-g {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:00:1Gbps";
+		};
+
+		lan1-y {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio_hc595 5 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:00:100Mbps";
+		};
+
+		lan2-g {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 1 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:01:1Gbps";
+		};
+
+		lan2-y {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio_hc595 6 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:01:100Mbps";
+		};
+
+		lan3-g {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:02:1Gbps";
+		};
+
+		lan3-y {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio_hc595 7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:02:100Mbps";
+		};
+
+		lan4-g {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 3 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:03:1Gbps";
+		};
+
+		lan4-y {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio_hc595 8 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:03:100Mbps";
+		};
+
+		wan-g {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_hc595 4 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:04:1Gbps";
+		};
+
+		wan-y {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&gpio_hc595 9 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "mt7530-0:04:100Mbps";
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_config_0 2>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_config_0 3>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2881,6 +2881,15 @@ define Device/teltonika_rutm50
 endef
 TARGET_DEVICES += teltonika_rutm50
 
+define Device/teltonika_rutm30
+  $(Device/teltonika_rutm_common)
+  DEVICE_MODEL := RUTM30
+  DEVICE_ALT0_VENDOR := Teltonika
+  DEVICE_ALT0_MODEL := RUTM31
+  DEVICE_PACKAGES += kmod-usb-net-qmi-wwan kmod-usb-net-cdc-ncm
+endef
+TARGET_DEVICES += teltonika_rutm30
+
 define Device/thunder_timecloud
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -8,6 +8,8 @@ include ./common-tp-link.mk
 DEFAULT_SOC := mt7621
 
 DEVICE_VARS += BUFFALO_TRX_MAGIC ELECOM_HWNAME LINKSYS_HWNAME DLINK_HWID
+DEVICE_VARS += SUPPORTED_TELTONIKA_DEVICES
+DEVICE_VARS += SUPPORTED_TELTONIKA_HW_MODS
 
 define Image/Prepare
 	# For UBI we want only one extra block
@@ -2855,6 +2857,29 @@ define Device/tenbay_t-mb5eu-v01
   SUPPORTED_DEVICES += mt7621-dm2-t-mb5eu-v01-nor
 endef
 TARGET_DEVICES += tenbay_t-mb5eu-v01
+
+define Device/teltonika_rutm_common
+  $(Device/nand)
+  DEVICE_VENDOR := Teltonika
+  SUPPORTED_TELTONIKA_DEVICES := teltonika,rutm
+  SUPPORTED_TELTONIKA_HW_MODS := W25N02KV
+  KERNEL_IN_UBI := 1
+  FILESYSTEMS := squashfs
+  IMAGE_SIZE := 147456k
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 kmod-usb-serial-option \
+	kmod-gpio-nxp-74hc164 kmod-spi-gpio -uboot-envtools
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size | append-teltonika-metadata
+endef
+
+define Device/teltonika_rutm50
+  $(Device/teltonika_rutm_common)
+  DEVICE_MODEL := RUTM50
+  DEVICE_ALT0_VENDOR := Teltonika
+  DEVICE_ALT0_MODEL := RUTM51
+  DEVICE_PACKAGES += kmod-usb-net-qmi-wwan kmod-usb-net-cdc-ncm
+endef
+TARGET_DEVICES += teltonika_rutm50
 
 define Device/thunder_timecloud
   $(Device/dsa-migration)

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2890,6 +2890,13 @@ define Device/teltonika_rutm30
 endef
 TARGET_DEVICES += teltonika_rutm30
 
+define Device/teltonika_rutm11
+  $(Device/teltonika_rutm_common)
+  DEVICE_MODEL := RUTM11
+  DEVICE_PACKAGES += kmod-usb-net-qmi-wwan kmod-usb-net-cdc-mbim
+endef
+TARGET_DEVICES += teltonika_rutm11
+
 define Device/thunder_timecloud
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -87,6 +87,7 @@ ramips_setup_interfaces()
 	maginon,mc-1200ac|\
 	meig,slt866|\
 	openfi,5pro|\
+	teltonika,rutm30|\
 	wavlink,ws-wn572hp3-4g|\
 	winstars,ws-wn583a6|\
 	yuncore,ax820|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -26,6 +26,7 @@ ramips_setup_interfaces()
 	netgear,wax202|\
 	sim,simax1800t|\
 	sim,simax1800u|\
+	teltonika,rutm11|\
 	tplink,mr600-v2-eu|\
 	xiaomi,mi-router-3-pro|\
 	xiaomi,mi-router-ac2100|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -12,6 +12,10 @@ mikrotik,routerboard-760igs)
 telco-electronics,x1)
 	ucidef_add_gpio_switch "modem_reset" "Modem Reset" "528"
 	;;
+teltonika,rutm50)
+	ucidef_add_gpio_switch "modem_power" "Modem power button" "modem_power" "1"
+	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
+	;;
 tozed,zlt-s12-pro)
 	ucidef_add_gpio_switch "lt72_power" "Power LTE modem" "lt72_power" "1"
 	;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -12,6 +12,7 @@ mikrotik,routerboard-760igs)
 telco-electronics,x1)
 	ucidef_add_gpio_switch "modem_reset" "Modem Reset" "528"
 	;;
+teltonika,rutm11|\
 teltonika,rutm30|\
 teltonika,rutm50)
 	ucidef_add_gpio_switch "modem_power" "Modem power button" "modem_power" "1"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/03_gpio_switches
@@ -12,6 +12,7 @@ mikrotik,routerboard-760igs)
 telco-electronics,x1)
 	ucidef_add_gpio_switch "modem_reset" "Modem Reset" "528"
 	;;
+teltonika,rutm30|\
 teltonika,rutm50)
 	ucidef_add_gpio_switch "modem_power" "Modem power button" "modem_power" "1"
 	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -49,6 +49,7 @@ boot() {
 		[ $(printf %d $(fw_printenv -n Image1Stable)) -gt 0 ] || fw_setenv Image1Stable 1
 		[ $(printf %d $(fw_printenv -n Image1Try)) -gt 0 ] && fw_setenv Image1Try 0
 		;;
+	teltonika,rutm30|\
 	teltonika,rutm50)
 		#Bootloader expect successfull startup value after update, we need to write success value to bootconfig partition
 		#otherwise bootloader will fallback to previous root partition

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -49,5 +49,27 @@ boot() {
 		[ $(printf %d $(fw_printenv -n Image1Stable)) -gt 0 ] || fw_setenv Image1Stable 1
 		[ $(printf %d $(fw_printenv -n Image1Try)) -gt 0 ] && fw_setenv Image1Try 0
 		;;
+	teltonika,rutm50)
+		#Bootloader expect successfull startup value after update, we need to write success value to bootconfig partition
+		#otherwise bootloader will fallback to previous root partition
+		. /lib/functions.sh
+		local PART="$(cmdline_get_var ubi.mtd)"
+		local MTD_INDEX=$(find_mtd_index bootconfig-a)
+
+		case "$PART" in
+		rutos-a)
+			[ "$(md5sum /dev/mtd$MTD_INDEX | awk '{print $1}')" = "adc4a78e76efc6b4afdc41925e4017c6" ] || {
+				logger -t "bootcount" "saving new failsafe boot config in /dev/mtd$MTD_INDEX bootconfig-a partition rutos-a"
+				echo -ne "\xe1\xb0\xba\xba\x01\x00\xf9\x01\xf8\x01\xf0\x00\x3d\xd4\xfb\x95" | mtd -e bootconfig-a write - bootconfig-a
+			}
+			;;
+		rutos-b)
+			[ "$(md5sum /dev/mtd$MTD_INDEX | awk '{print $1}')" = "2904b3476604ef153d1925acdde062e8" ] || {
+				logger -t "bootcount" "saving new failsafe boot config in /dev/mtd$MTD_INDEX bootconfig-a partition rutos-b"
+				echo -ne "\xe1\xb0\xba\xba\x01\x01\xf7\x01\xf8\x00\xf0\x00\xce\xd4\x44\x08" | mtd -e bootconfig-a write - bootconfig-a
+				}
+			;;
+		esac
+		;;
 	esac
 }

--- a/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
+++ b/target/linux/ramips/mt7621/base-files/etc/init.d/bootcount
@@ -49,6 +49,7 @@ boot() {
 		[ $(printf %d $(fw_printenv -n Image1Stable)) -gt 0 ] || fw_setenv Image1Stable 1
 		[ $(printf %d $(fw_printenv -n Image1Try)) -gt 0 ] && fw_setenv Image1Try 0
 		;;
+	teltonika,rutm11|\
 	teltonika,rutm30|\
 	teltonika,rutm50)
 		#Bootloader expect successfull startup value after update, we need to write success value to bootconfig partition

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -230,6 +230,7 @@ platform_do_upgrade() {
 		zyxel_mstc_upgrade_prepare
 		nand_do_upgrade "$1"
 		;;
+	teltonika,rutm11|\
 	teltonika,rutm30|\
 	teltonika,rutm50)
 		CI_UBIPART="$(cmdline_get_var ubi.mtd)"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -230,6 +230,7 @@ platform_do_upgrade() {
 		zyxel_mstc_upgrade_prepare
 		nand_do_upgrade "$1"
 		;;
+	teltonika,rutm30|\
 	teltonika,rutm50)
 		CI_UBIPART="$(cmdline_get_var ubi.mtd)"
 		nand_do_upgrade "$1"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -230,6 +230,10 @@ platform_do_upgrade() {
 		zyxel_mstc_upgrade_prepare
 		nand_do_upgrade "$1"
 		;;
+	teltonika,rutm50)
+		CI_UBIPART="$(cmdline_get_var ubi.mtd)"
+		nand_do_upgrade "$1"
+		;;
 	*)
 		default_do_upgrade "$1"
 		;;


### PR DESCRIPTION
Teltonika RUTM series are industrial mobile routers in different variations:
 - RUTM50/RUTM51: 5x 1Gbps Ethernet ports, 5G modem, dual band wifi.
 - RUTM30/RUTM31: 2x 1Gbps Ethernet ports, 5G modem, dual band wifi.
 - RUTM11: 4x 1Gbps Ethernet ports, 4G CAT6 modem, dual band wifi.

## Common specifications:
- MediaTek MT7921AT SoC
- 256 MB RAM
- 16MB SPI NOR Flash
- 256MB NAND (split in half for firmware fallback)
- 10/100/1000 Mbps Ethernet, with passive PoE support on LAN1
- WLAN      : MediaTek dual-band WiFi 5
  - 2.4 GHz : b/g/n, MIMO 2x2
  - 5 GHz   : n/ac, MIMO 2x2
- Mobile modem
- 1x Digital input
- 1x Digital output
- 2x SIM slots

Installation
------------
Notice: update OEM firmware to 7.19 or later, earlier versions will
fail to flash openwrt factory firmware.

1. Check from which partition the device is currently running from

  $ cat /proc/bootconfig/chosen

  In case this output reads rutos-b, install a software update from
  Teltonika first. After upgrade completion, check this file now reads
  rutos-a before continuing.

2. Download the *-squashfs-factory.bin firmware image
3. Flash firmware image via WEB interface

## To revert back to OEM firmware:
https://wiki.teltonika-networks.com/view/Bootloader_menu

### Mobile connection establishment depends on modem model, detailed instructions for every device in commit message.