### PR TITLE
ramips: mt76x8: fix 02_network typo

### DIFF
--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -11,7 +11,7 @@ ramips_setup_interfaces()
 	7links,wlr-1230|\
 	7links,wlr-1240|\
 	alfa-network,awusfree1|\
-	creality,wb-01|\	
+	creality,wb-01|\
 	d-team,pbr-d1|\
 	dlink,dap-1325-a1|\
 	glinet,microuter-n300|\


### PR DESCRIPTION
Remove unnecessary tab which breaks 02_network script with syntax error.

`/bin/board_detect: /etc/board.d/02_network: line 15: syntax error: unexpected newline (expecting ")")`