### PR TITLE
build: remove iwinfo dependency

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -595,7 +595,6 @@ define Device/Check/Common
       _PROFILE_SET :=
     endif
   endif
-  DEVICE_PACKAGES += $$(call extra_packages,$$(DEVICE_PACKAGES))
   ifdef TARGET_PER_DEVICE_ROOTFS
     $$(eval $$(call merge_packages,_PACKAGES,$$(DEVICE_PACKAGES) $$(call DEVICE_EXTRA_PACKAGES,$(1))))
     ROOTFS_ID/$(1) := $$(if $$(_PROFILE_SET),$$(call mkfs_packages_id,$$(_PACKAGES)))

--- a/include/target.mk
+++ b/include/target.mk
@@ -105,13 +105,6 @@ DEFAULT_PACKAGES += $(DEFAULT_PACKAGES.$(DEVICE_TYPE))
 ##
 filter_packages = $(filter-out -% $(patsubst -%,%,$(filter -%,$(1))),$(1))
 
-##@
-# @brief Append extra package dependencies.
-#
-# @param 1: Package list.
-##
-extra_packages = $(if $(filter wpad wpad-% nas,$(1)),iwinfo)
-
 define ProfileDefault
   NAME:=
   PRIORITY:=
@@ -128,7 +121,7 @@ define Profile
 	echo "Target-Profile: $(1)"; \
 	$(if $(PRIORITY), echo "Target-Profile-Priority: $(PRIORITY)"; ) \
 	echo "Target-Profile-Name: $(NAME)"; \
-	echo "Target-Profile-Packages: $(PACKAGES) $(call extra_packages,$(DEFAULT_PACKAGES) $(PACKAGES))"; \
+	echo "Target-Profile-Packages: $(PACKAGES)"; \
 	echo "Target-Profile-Description:"; \
 	echo "$$$$$$$$$(call shvar,Profile/$(1)/Description)"; \
 	echo "@@"; \
@@ -386,7 +379,7 @@ define BuildTargets/DumpCurrent
 	 echo "$$$$DESCRIPTION"; \
 	 echo '@@'; \
 	 $(if $(DEFAULT_PROFILE),echo 'Target-Default-Profile: $(DEFAULT_PROFILE)';) \
-	 echo 'Default-Packages: $(DEFAULT_PACKAGES) $(call extra_packages,$(DEFAULT_PACKAGES))'; \
+	 echo 'Default-Packages: $(DEFAULT_PACKAGES)'; \
 	 $(DUMPINFO)
 	$(if $(CUR_SUBTARGET),$(SUBMAKE) -r --no-print-directory -C image -s DUMP=1 SUBTARGET=$(CUR_SUBTARGET))
 	$(if $(SUBTARGET),,@$(foreach SUBTARGET,$(SUBTARGETS),$(SUBMAKE) --no-print-directory -s DUMP=1 SUBTARGET=$(SUBTARGET); ))


### PR DESCRIPTION
Do not always try to include iwinfo in the images when wpa supplicant or Broadcom nas is also included. iwinfo is incompatible with current default configuration.

iwinfo is only build when CONFIG_WIFI_SCRIPTS_UCODE is not set. If CONFIG_WIFI_SCRIPTS_UCODE is not set kmod-cfg80211 depends on iwinfo, so it should be included in all images with wifi drivers.

The CONFIG_WIFI_SCRIPTS_UCODE option was recently changed to be active by default.

This should fix the current buildbot build failures.

This reverts commit 6435b8bb27ea ("build: include iwinfo by default
if nas or wpad(-mini) is selected")

Fixes: 04e9929c47e9 ("wifi-scripts: enable ucode scripts by default")
