### PR TITLE
uboot-mediatek: fix build variant for mt7981_cmcc_rax3000m-{emmc,nand}-ddr3

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -249,9 +249,8 @@ define U-Boot/mt7981_cmcc_rax3000m-emmc-ddr3
   BUILD_DEVICES:=cmcc_rax3000m
   UBOOT_CONFIG:=mt7981_cmcc_rax3000m-emmc
   UBOOT_IMAGE:=u-boot.fip
-  BL2_BOOTDEV:=emmc
+  BL2_BOOTDEV:=emmc-ddr3-1866mhz
   BL2_SOC:=mt7981
-  BL2_DDRTYPE:=ddr3
   DEPENDS:=+trusted-firmware-a-mt7981-emmc-ddr3-1866mhz
 endef
 
@@ -273,9 +272,8 @@ define U-Boot/mt7981_cmcc_rax3000m-nand-ddr3
   BUILD_DEVICES:=cmcc_rax3000m
   UBOOT_CONFIG:=mt7981_cmcc_rax3000m-nand
   UBOOT_IMAGE:=u-boot.fip
-  BL2_BOOTDEV:=spim-nand
+  BL2_BOOTDEV:=spim-nand-ddr3-1866mhz
   BL2_SOC:=mt7981
-  BL2_DDRTYPE:=ddr3
   DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr3-1866mhz
 endef
 


### PR DESCRIPTION
Fixes: 028050d

