### PR TITLE
net: phy: sfp: add quirk for H-COM SPP425H-GAB4 XGS-PON module

### DIFF
--- a/target/linux/mediatek/patches-6.12/999-net-phy-sfp-add-quirk-hcom-xgpon.patch
+++ b/target/linux/mediatek/patches-6.12/999-net-phy-sfp-add-quirk-hcom-xgpon.patch
@@ -1,0 +1,37 @@
+From 170347513+brudalevante@users.noreply.github.com Sat Sep 27 21:04:53 2025
+From: brudalevante <170347513+brudalevante@users.noreply.github.com>
+Date: Sat, 27 Sep 2025 21:04:53 +0200
+Subject: [PATCH] net: phy: sfp: add quirk for H-COM SPP425H-GAB4 XGS-PON module
+
+Add quirk for the H-COM SPP425H-GAB4 XGS-PON SFP+ module to use sfp_fixup_halny_gsfp.
+This module requires the fixup for correct operation.
+
+The module identifiers are based on working EEPROM and ethtool output.
+
+Tested and confirmed working with the actual module.
+
+Signed-off-by: brudalevante <170347513+brudalevante@users.noreply.github.com>
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -486,14 +486,20 @@
+ 	// OEM SFP-GE-T is a 1000Base-T module with broken TX_FAULT indicator
+ 	SFP_QUIRK_F("OEM", "SFP-GE-T", sfp_fixup_ignore_tx_fault),
+ 
++	// H-COM SPP425H-GAB4 XGS-PON module (SFP+)
++	SFP_QUIRK_F("H-COM", "SPP425H-GAB4", sfp_fixup_halny_gsfp),
++
++	SFP_QUIRK_F("ETU", "ESP-T5-R", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_F("OEM", "SFP-10G-T", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_M("OEM", "SFP-2.5G-T", sfp_quirk_oem_2_5g),
+ 	SFP_QUIRK_M("OEM", "SFP-2.5G-BX10-D", sfp_quirk_2500basex),
+ 	SFP_QUIRK_M("OEM", "SFP-2.5G-BX10-U", sfp_quirk_2500basex),
+ 	SFP_QUIRK_F("OEM", "RTSFP-10", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_F("OEM", "RTSFP-10G", sfp_fixup_rollball_cc),
++	SFP_QUIRK_F("OEM", "TNBYV02-C0X-C3", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_F("Turris", "RTSFP-10", sfp_fixup_rollball),
+ 	SFP_QUIRK_F("Turris", "RTSFP-10G", sfp_fixup_rollball),
++	SFP_QUIRK_F("JESS-LINK", "P60000BBC001-1", sfp_fixup_rollball),
+ };
+ 
+ static size_t sfp_strlen(const char *str, size_t maxlen)


### PR DESCRIPTION
This patch adds a quirk for the H-COM SPP425H-GAB4 XGS-PON SFP+ module, making it use sfp_fixup_halny_gsfp for proper operation.

Tested and confirmed working with the actual module.

Signed-off-by: brudalevante <170347513+brudalevante@users.noreply.github.com>
