### PR TITLE
kernel: rtl8261n: add support for Serdes TX swap

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.h
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.h
@@ -8,6 +8,8 @@
 #define __RTK_PHYLIB_H
 
 #if defined(RTK_PHYDRV_IN_LINUX)
+  #include <linux/types.h>
+
   #include "type.h"
   #include "rtk_phylib_def.h"
 #else
@@ -48,6 +50,8 @@ struct rtk_phy_priv {
     rtk_phylib_phy_t phytype;
     uint8 isBasePort;
     rt_phy_patch_db_t *patch;
+
+    bool pnswap_tx;
 };
 
 #if defined(RTK_PHYDRV_IN_LINUX)


### PR DESCRIPTION
Add support for swapping the Serdes TX line on RTL8261N PHYs. This is used on an Arcadyan Mozart board where the Serdes TX is swapped on the PHY (instead of on the Soc) to permit support of SFP module by using toggling the integrated MUX.

The register are saddly fully undocumented and the default value of MMD 0x1e 0xc1 is 0x200 so it's particular difficult to reverse any kind of logic on the applied register.
