### PR TITLE
toolchain: Default lib{pthread,rt} to y if USE_MUSL

### DIFF
--- a/package/libs/toolchain/Makefile
+++ b/package/libs/toolchain/Makefile
@@ -292,6 +292,7 @@ endef
 define Package/libpthread
 $(call Package/libc/Default)
   TITLE:=POSIX thread library
+  DEFAULT:=y if USE_MUSL
 endef
 
 define Package/libpthread/config
@@ -345,6 +346,7 @@ define Package/librt
 $(call Package/libc/Default)
   TITLE:=POSIX.1b RealTime extension library
   DEPENDS:=+libpthread
+  DEFAULT:=y if USE_MUSL
 endef
 
 define Package/librt/config


### PR DESCRIPTION
These are empty packages because the functionality is part of the musl libc itself. Enabling them by default avoids dependency errors when attempting to install an ipkg that depends on one of these libraries on a base build that didn't have them enabled.