### PR TITLE
wifi-scripts: hostapd.sh: hostapd_(bss_)options

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -268,10 +268,7 @@ hostapd_prepare_device_config() {
 	set_default stationary_ap 1
 	append base_cfg "stationary_ap=$stationary_ap" "$N"
 
-	json_get_values opts hostapd_options
-	for val in $opts; do
-		append base_cfg "$val" "$N"
-	done
+	json_for_each_item hostapd_append_generic_option hostapd_options base_cfg
 
 	cat > "$config" <<EOF
 driver=$driver
@@ -480,6 +477,47 @@ hostapd_set_sae() {
 		*) return ;;
 	esac
 	for_each_station hostapd_set_sae_file ${ifname}
+}
+
+# hostapd_get_option <var> <option>
+hostapd_get_option() {
+	eval "local _cfg=\"\$N\$$1\$N\""
+	local _val="${_cfg##*$N$2=}"
+	[ "$_val" != "$_cfg" ] && echo -n "${_val%%$N*}"
+}
+
+# hostapd_override_option <var> <option>
+hostapd_override_option() {
+	eval "$1=\"\$N\${$1}\""
+	eval "$1=\"\${$1//\$N\$2=/\$N#\$2=}\""
+	eval "$1=\"\${$1#\$N}\""
+}
+
+hostapd_append_generic_option() {
+	local line="$1"
+	local var="$3"
+
+	case "$line" in
+		\#*)
+			append "$var" "$line" "$N"
+		;;
+		*:=*)
+			local opt="${line%%:=*}" val="${line#*:=}"
+			hostapd_override_option "$var" "$opt"
+			[ -n "$val" ] && append "$var" "$opt=$val" "$N"
+		;;
+		*+=*)
+			local opt="${line%%+=*}" val="${line#*+=}"
+			if [ -n "$val" ]; then
+				val="$(hostapd_get_option "$var" "$opt")$val"
+				hostapd_override_option "$var" "$opt"
+				append "$var" "$opt=$val" "$N"
+			fi
+		;;
+		*)
+			append "$var" "$line" "$N"
+		;;
+	esac
 }
 
 append_iw_roaming_consortium() {
@@ -1219,10 +1257,7 @@ hostapd_set_bss_options() {
 		[ -n "$dpp_netaccesskey" ] && append bss_conf "dpp_netaccesskey=$dpp_netaccesskey" "$N"
 	}
 
-	json_get_values opts hostapd_bss_options
-	for val in $opts; do
-		append bss_conf "$val" "$N"
-	done
+	json_for_each_item hostapd_append_generic_option hostapd_bss_options bss_conf
 
 	append "$var" "$bss_conf" "$N"
 	return 0


### PR DESCRIPTION
Fix processing of hostapd_(bss_)options values that contain whitespace by using json_for_each_item. Currently these are erroneously output as separate lines.

Also add support for overriding or amending script-generated settings. Lines of the form "<option>:=<value>" override / replace any previous lines for the same option, and "<option>+=<value>" appends to the value.

Overriding with ":=" is useful for options that hostapd processes in a cumulative way (and to make the generated configuration less confusing even in cases where it doesn't). Appending with "+=" is useful for options where hostapd only considers the last value that was set. For example 802.1X can be added to the list of enabled AKMs via "wpa_key_mgmt+= WPA-EAP".
