### PR TITLE
realtek: Skip auto-MAC assignment for devices with port MACs in DT (+ split in functions)

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -18,137 +18,168 @@ filter_port_list_reverse() {
 	_filter_port_list_ordered "$1" "$2" "-r"
 }
 
+realtek_setup_interfaces()
+{
+	local board="$1"
+	local lan_list="$2"
+
+	ucidef_set_bridge_device switch
+	ucidef_set_interface_lan "$lan_list"
+}
+
+realtek_setup_macs_lan()
+{
+	local lan_list="$1"
+	local lan_mac_start="$2"
+	local lan_mac_end="$3"
+
+	for lan in $lan_list; do
+		ucidef_set_network_device_mac $lan $lan_mac_start
+		[ -z "$lan_mac_end" ] || [ "$lan_mac_start" == "$lan_mac_end" ] && lan_mac_start=$(macaddr_setbit_la $lan_mac_start)
+		lan_mac_start=$(macaddr_add $lan_mac_start 1)
+	done
+}
+
+realtek_setup_macs()
+{
+	local board="$1"
+	local lan_list="$2"
+
+	local lan_mac=""
+	local lan_mac_start=""
+	local lan_mac_end=""
+	local label_mac=""
+
+	case $board in
+	hpe,1920-8g|\
+	hpe,1920-8g-poe-65w|\
+	hpe,1920-8g-poe-180w|\
+	hpe,1920-16g|\
+	hpe,1920-24g|\
+	hpe,1920-24g-poe-180w|\
+	hpe,1920-24g-poe-370w|\
+	hpe,1920-48g|\
+	hpe,1920-48g-poe)
+		label_mac=$(mtd_get_mac_binary factory 0x68)
+		lan_mac=$label_mac
+		mac_count1=$(hexdump -v -n 4 -s 0x110 -e '4 "%d"' $(find_mtd_part factory) 2>/dev/null)
+		mac_count2=$(hexdump -v -n 4 -s 0x114 -e '4 "%d"' $(find_mtd_part factory) 2>/dev/null)
+		lan_mac_start=$(macaddr_add $lan_mac 2)
+		lan_mac_end=$(macaddr_add $lan_mac $((mac_count2-mac_count1)))
+		;;
+	plasmacloud,esx28|\
+	plasmacloud,psx8|\
+	plasmacloud,psx10|\
+	plasmacloud,psx28|\
+	tplink,sg2008p-v1|\
+	tplink,sg2210p-v3|\
+	tplink,sg2452p-v4|\
+	tplink,t1600g-28ts-v3)
+		label_mac=$(get_mac_label)
+		lan_mac="$label_mac"
+		;;
+	tplink,tl-st1008f-v2)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		[ -z "$lan_mac" ] || [ "$lan_mac" = "00:e0:4c:00:00:00" ] && lan_mac=$(macaddr_random)
+		;;
+	xikestor,sks8300-8x)
+		lan_mac=$(mtd_get_mac_binary board-info 0x1f1)
+		;;
+	xikestor,sks8310-8x)
+		lan_mac=$(mtd_get_mac_binary factory 0x80)
+		label_mac="$lan_mac"
+		;;
+	*)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env2 mac_start)
+		lan_mac_end=$(mtd_get_mac_ascii u-boot-env2 mac_end)
+		label_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		[ -z "$lan_mac" ] && lan_mac=$label_mac
+		;;
+	esac
+
+	ucidef_set_interface_macaddr "lan" $lan_mac
+	ucidef_set_bridge_mac "$lan_mac"
+	ucidef_set_network_device_mac eth0 $lan_mac
+
+	[ -z "$lan_mac_start" ] && lan_mac_start=$lan_mac
+	realtek_setup_macs_lan "$lan_list" "$lan_mac_start" "$lan_mac_end"
+
+	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
+}
+
+realtek_setup_poe()
+{
+	local board="$1"
+	local lan_list="$2"
+
+	case $board in
+	d-link,dgs-1210-10mp-f)
+		ucidef_set_poe 130 "$(filter_port_list "$lan_list" "lan9 lan10")"
+		;;
+	d-link,dgs-1210-10p)
+		ucidef_set_poe 65 "$(filter_port_list "$lan_list" "lan9 lan10")"
+		;;
+	d-link,dgs-1210-28mp-f)
+		ucidef_set_poe 370 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
+				lan22 lan21 lan20 lan19 lan18 lan17"
+		;;
+	d-link,dgs-1210-28p-f)
+		ucidef_set_poe 193 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
+				lan22 lan21 lan20 lan19 lan18 lan17"
+		;;
+	engenius,ews2910p-v1|\
+	engenius,ews2910p-v3)
+		ucidef_set_poe 60 "$(filter_port_list "$lan_list" "lan9 lan10")"
+		;;
+	hpe,1920-8g-poe-65w)
+		ucidef_set_poe 65 "$(filter_port_list_reverse "$lan_list" "lan9 lan10")"
+		;;
+	hpe,1920-8g-poe-180w)
+		ucidef_set_poe 180 "$(filter_port_list_reverse "$lan_list" "lan9 lan10")"
+		;;
+	hpe,1920-24g-poe-180w)
+		ucidef_set_poe 180 "$(filter_port_list_reverse "$lan_list" "lan25 lan26 lan27 lan28")"
+		;;
+	hpe,1920-24g-poe-370w)
+		ucidef_set_poe 370 "$(filter_port_list_reverse "$lan_list" "lan25 lan26 lan27 lan28")"
+		;;
+	hpe,1920-48g-poe)
+		ucidef_set_poe 370 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
+				lan22 lan21 lan20 lan19 lan18 lan17 lan32 lan31 lan30 lan29 lan28 lan27 lan26 lan25 lan40 lan39 lan38 lan37
+				lan36 lan35 lan34 lan33 lan48 lan47 lan46 lan45 lan44 lan43 lan42 lan41"
+		;;
+	netgear,gs110tpp-v1)
+		ucidef_set_poe 130 "$(filter_port_list "$lan_list" "lan9 lan10")"
+		;;
+	netgear,gs110tup-v1)
+		ucidef_set_poe 240 "$(filter_port_list "$lan_list" "lan9 lan10")"
+		;;
+	netgear,gs310tp-v1)
+		ucidef_set_poe 55 "$(filter_port_list "$lan_list" "lan9 lan10")"
+		;;
+	zyxel,gs1900-10hp)
+		ucidef_set_poe 77 "$(filter_port_list "$lan_list" "lan9 lan10")"
+		;;
+	zyxel,gs1900-8hp-v1|\
+	zyxel,gs1900-8hp-v2)
+		ucidef_set_poe 70 "$lan_list"
+		;;
+	zyxel,gs1900-24ep)
+		ucidef_set_poe 130 "lan1 lan2 lan3 lan4 lan5 lan6 lan7 lan8 lan9 lan10 lan11 lan12"
+		;;
+	zyxel,gs1900-24hp-v1|\
+	zyxel,gs1900-24hp-v2)
+		ucidef_set_poe 170 "$(filter_port_list "$lan_list" "lan25 lan26")"
+		;;
+	esac
+}
+
 board=$(board_name)
 board_config_update
-
 lan_list=$(ls -1 -v -d /sys/class/net/lan* | xargs -n1 basename | xargs)
-
-ucidef_set_bridge_device switch
-ucidef_set_interface_lan "$lan_list"
-
-lan_mac=""
-lan_mac_start=""
-lan_mac_end=""
-label_mac=""
-case $board in
-hpe,1920-8g|\
-hpe,1920-8g-poe-65w|\
-hpe,1920-8g-poe-180w|\
-hpe,1920-16g|\
-hpe,1920-24g|\
-hpe,1920-24g-poe-180w|\
-hpe,1920-24g-poe-370w|\
-hpe,1920-48g|\
-hpe,1920-48g-poe)
-	label_mac=$(mtd_get_mac_binary factory 0x68)
-	lan_mac=$label_mac
-	mac_count1=$(hexdump -v -n 4 -s 0x110 -e '4 "%d"' $(find_mtd_part factory) 2>/dev/null)
-	mac_count2=$(hexdump -v -n 4 -s 0x114 -e '4 "%d"' $(find_mtd_part factory) 2>/dev/null)
-	lan_mac_start=$(macaddr_add $lan_mac 2)
-	lan_mac_end=$(macaddr_add $lan_mac $((mac_count2-mac_count1)))
-	;;
-plasmacloud,esx28|\
-plasmacloud,psx8|\
-plasmacloud,psx10|\
-plasmacloud,psx28|\
-tplink,sg2008p-v1|\
-tplink,sg2210p-v3|\
-tplink,sg2452p-v4|\
-tplink,t1600g-28ts-v3)
-	label_mac=$(get_mac_label)
-	lan_mac="$label_mac"
-	;;
-tplink,tl-st1008f-v2)
-	lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-	[ -z "$lan_mac" ] || [ "$lan_mac" = "00:e0:4c:00:00:00" ] && lan_mac=$(macaddr_random)
-	;;
-xikestor,sks8300-8x)
-	lan_mac=$(mtd_get_mac_binary board-info 0x1f1)
-	;;
-xikestor,sks8310-8x)
-	lan_mac=$(mtd_get_mac_binary factory 0x80)
-	label_mac="$lan_mac"
-	;;
-*)
-	lan_mac=$(mtd_get_mac_ascii u-boot-env2 mac_start)
-	lan_mac_end=$(mtd_get_mac_ascii u-boot-env2 mac_end)
-	label_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-	[ -z "$lan_mac" ] && lan_mac=$label_mac
-	;;
-esac
-
-ucidef_set_interface_macaddr "lan" $lan_mac
-ucidef_set_bridge_mac "$lan_mac"
-ucidef_set_network_device_mac eth0 $lan_mac
-[ -z "$lan_mac_start" ] && lan_mac_start=$lan_mac
-for lan in $lan_list; do
-	ucidef_set_network_device_mac $lan $lan_mac_start
-	[ -z "$lan_mac_end" ] || [ "$lan_mac_start" == "$lan_mac_end" ] && lan_mac_start=$(macaddr_setbit_la $lan_mac_start)
-	lan_mac_start=$(macaddr_add $lan_mac_start 1)
-done
-[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
-
-case $board in
-d-link,dgs-1210-10mp-f)
-	ucidef_set_poe 130 "$(filter_port_list "$lan_list" "lan9 lan10")"
-	;;
-d-link,dgs-1210-10p)
-	ucidef_set_poe 65 "$(filter_port_list "$lan_list" "lan9 lan10")"
-	;;
-d-link,dgs-1210-28mp-f)
-	ucidef_set_poe 370 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
-			lan22 lan21 lan20 lan19 lan18 lan17"
-	;;
-d-link,dgs-1210-28p-f)
-	ucidef_set_poe 193 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
-			lan22 lan21 lan20 lan19 lan18 lan17"
-	;;
-engenius,ews2910p-v1|\
-engenius,ews2910p-v3)
-	ucidef_set_poe 60 "$(filter_port_list "$lan_list" "lan9 lan10")"
-	;;
-hpe,1920-8g-poe-65w)
-	ucidef_set_poe 65 "$(filter_port_list_reverse "$lan_list" "lan9 lan10")"
-	;;
-hpe,1920-8g-poe-180w)
-	ucidef_set_poe 180 "$(filter_port_list_reverse "$lan_list" "lan9 lan10")"
-	;;
-hpe,1920-24g-poe-180w)
-	ucidef_set_poe 180 "$(filter_port_list_reverse "$lan_list" "lan25 lan26 lan27 lan28")"
-	;;
-hpe,1920-24g-poe-370w)
-	ucidef_set_poe 370 "$(filter_port_list_reverse "$lan_list" "lan25 lan26 lan27 lan28")"
-	;;
-hpe,1920-48g-poe)
-	ucidef_set_poe 370 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
-			lan22 lan21 lan20 lan19 lan18 lan17 lan32 lan31 lan30 lan29 lan28 lan27 lan26 lan25 lan40 lan39 lan38 lan37
-			lan36 lan35 lan34 lan33 lan48 lan47 lan46 lan45 lan44 lan43 lan42 lan41"
-	;;
-netgear,gs110tpp-v1)
-	ucidef_set_poe 130 "$(filter_port_list "$lan_list" "lan9 lan10")"
-	;;
-netgear,gs110tup-v1)
-	ucidef_set_poe 240 "$(filter_port_list "$lan_list" "lan9 lan10")"
-	;;
-netgear,gs310tp-v1)
-	ucidef_set_poe 55 "$(filter_port_list "$lan_list" "lan9 lan10")"
-	;;
-zyxel,gs1900-10hp)
-	ucidef_set_poe 77 "$(filter_port_list "$lan_list" "lan9 lan10")"
-	;;
-zyxel,gs1900-8hp-v1|\
-zyxel,gs1900-8hp-v2)
-	ucidef_set_poe 70 "$lan_list"
-	;;
-zyxel,gs1900-24ep)
-	ucidef_set_poe 130 "lan1 lan2 lan3 lan4 lan5 lan6 lan7 lan8 lan9 lan10 lan11 lan12"
-	;;
-zyxel,gs1900-24hp-v1|\
-zyxel,gs1900-24hp-v2)
-	ucidef_set_poe 170 "$(filter_port_list "$lan_list" "lan25 lan26")"
-	;;
-esac
-
+realtek_setup_interfaces "$board" "$lan_list"
+realtek_setup_macs "$board" "$lan_list"
+realtek_setup_poe "$board" "$lan_list"
 board_config_flush
 
 exit 0

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -70,7 +70,10 @@ realtek_setup_macs()
 	plasmacloud,esx28|\
 	plasmacloud,psx8|\
 	plasmacloud,psx10|\
-	plasmacloud,psx28|\
+	plasmacloud,psx28)
+		lan_mac_start=skip
+		lan_mac="$(get_mac_label)"
+	;;
 	tplink,sg2008p-v1|\
 	tplink,sg2210p-v3|\
 	tplink,sg2452p-v4|\
@@ -102,7 +105,7 @@ realtek_setup_macs()
 	[ -n "$lan_mac" ] && ucidef_set_network_device_mac eth0 $lan_mac
 
 	[ -z "$lan_mac_start" -a -n "$lan_mac" ] && lan_mac_start=$lan_mac
-	realtek_setup_macs_lan "$lan_list" "$lan_mac_start" "$lan_mac_end"
+	[ "$lan_mac_start" != "skip" ] && realtek_setup_macs_lan "$lan_list" "$lan_mac_start" "$lan_mac_end"
 
 	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
 }

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -97,11 +97,11 @@ realtek_setup_macs()
 		;;
 	esac
 
-	ucidef_set_interface_macaddr "lan" $lan_mac
-	ucidef_set_bridge_mac "$lan_mac"
-	ucidef_set_network_device_mac eth0 $lan_mac
+	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac
+	[ -n "$lan_mac" ] && ucidef_set_bridge_mac "$lan_mac"
+	[ -n "$lan_mac" ] && ucidef_set_network_device_mac eth0 $lan_mac
 
-	[ -z "$lan_mac_start" ] && lan_mac_start=$lan_mac
+	[ -z "$lan_mac_start" -a -n "$lan_mac" ] && lan_mac_start=$lan_mac
 	realtek_setup_macs_lan "$lan_list" "$lan_mac_start" "$lan_mac_end"
 
 	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac


### PR DESCRIPTION
If the devicetree contains the appropriate nodes to configure the MAC addresses for each physical DSA port, then these MAC addresses must be used in OpenWrt and not some automatically generated ones. Otherwise the device often ends up with addresses which are locally administered and not matching the expected port-to-MAC scheme.

Devices which only get the MAC address for eth0 must still auto-generate these MAC addresses until the devicetree was updated to also include the correct ones.

---

On an Plasma Cloud PSX10 without the patch:

```
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1504 qdisc mq state UP qlen 1000
    link/ether 54:9c:27:20:1f:50 brd ff:ff:ff:ff:ff:ff
3: lan1@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master switch state UP qlen 1000
    link/ether 54:9c:27:20:1f:50 brd ff:ff:ff:ff:ff:ff
4: lan2@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 56:9c:27:20:1f:51 brd ff:ff:ff:ff:ff:ff
5: lan3@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 56:9c:27:20:1f:52 brd ff:ff:ff:ff:ff:ff
6: lan4@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 56:9c:27:20:1f:53 brd ff:ff:ff:ff:ff:ff
7: lan5@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 56:9c:27:20:1f:54 brd ff:ff:ff:ff:ff:ff
8: lan6@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 56:9c:27:20:1f:55 brd ff:ff:ff:ff:ff:ff
9: lan7@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 56:9c:27:20:1f:56 brd ff:ff:ff:ff:ff:ff
10: lan8@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 56:9c:27:20:1f:57 brd ff:ff:ff:ff:ff:ff
11: lan9@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 56:9c:27:20:1f:58 brd ff:ff:ff:ff:ff:ff
12: lan10@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 56:9c:27:20:1f:59 brd ff:ff:ff:ff:ff:ff
```

with the patch:

```
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1504 qdisc mq state UP qlen 1000
    link/ether 54:9c:27:20:1f:50 brd ff:ff:ff:ff:ff:ff
3: lan1@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master switch state UP qlen 1000
    link/ether 54:9c:27:20:1f:51 brd ff:ff:ff:ff:ff:ff
4: lan2@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 54:9c:27:20:1f:52 brd ff:ff:ff:ff:ff:ff
5: lan3@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 54:9c:27:20:1f:53 brd ff:ff:ff:ff:ff:ff
6: lan4@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 54:9c:27:20:1f:54 brd ff:ff:ff:ff:ff:ff
7: lan5@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 54:9c:27:20:1f:55 brd ff:ff:ff:ff:ff:ff
8: lan6@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 54:9c:27:20:1f:56 brd ff:ff:ff:ff:ff:ff
9: lan7@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 54:9c:27:20:1f:57 brd ff:ff:ff:ff:ff:ff
10: lan8@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 54:9c:27:20:1f:58 brd ff:ff:ff:ff:ff:ff
11: lan9@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 54:9c:27:20:1f:59 brd ff:ff:ff:ff:ff:ff
12: lan10@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 54:9c:27:20:1f:5a brd ff:ff:ff:ff:ff:ff
```

difference:


```diff
--- <unnamed>
+++ <unnamed>
@@ -1,22 +1,22 @@
 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1504 qdisc mq state UP qlen 1000
     link/ether 54:9c:27:20:1f:50 brd ff:ff:ff:ff:ff:ff
 3: lan1@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master switch state UP qlen 1000
-    link/ether 54:9c:27:20:1f:50 brd ff:ff:ff:ff:ff:ff
+    link/ether 54:9c:27:20:1f:51 brd ff:ff:ff:ff:ff:ff
 4: lan2@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
-    link/ether 56:9c:27:20:1f:51 brd ff:ff:ff:ff:ff:ff
+    link/ether 54:9c:27:20:1f:52 brd ff:ff:ff:ff:ff:ff
 5: lan3@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
-    link/ether 56:9c:27:20:1f:52 brd ff:ff:ff:ff:ff:ff
+    link/ether 54:9c:27:20:1f:53 brd ff:ff:ff:ff:ff:ff
 6: lan4@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
-    link/ether 56:9c:27:20:1f:53 brd ff:ff:ff:ff:ff:ff
+    link/ether 54:9c:27:20:1f:54 brd ff:ff:ff:ff:ff:ff
 7: lan5@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
-    link/ether 56:9c:27:20:1f:54 brd ff:ff:ff:ff:ff:ff
+    link/ether 54:9c:27:20:1f:55 brd ff:ff:ff:ff:ff:ff
 8: lan6@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
-    link/ether 56:9c:27:20:1f:55 brd ff:ff:ff:ff:ff:ff
+    link/ether 54:9c:27:20:1f:56 brd ff:ff:ff:ff:ff:ff
 9: lan7@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
-    link/ether 56:9c:27:20:1f:56 brd ff:ff:ff:ff:ff:ff
+    link/ether 54:9c:27:20:1f:57 brd ff:ff:ff:ff:ff:ff
 10: lan8@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
-    link/ether 56:9c:27:20:1f:57 brd ff:ff:ff:ff:ff:ff
+    link/ether 54:9c:27:20:1f:58 brd ff:ff:ff:ff:ff:ff
 11: lan9@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
-    link/ether 56:9c:27:20:1f:58 brd ff:ff:ff:ff:ff:ff
+    link/ether 54:9c:27:20:1f:59 brd ff:ff:ff:ff:ff:ff
 12: lan10@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
-    link/ether 56:9c:27:20:1f:59 brd ff:ff:ff:ff:ff:ff
+    link/ether 54:9c:27:20:1f:5a brd ff:ff:ff:ff:ff:ff
```

---

To actually make the behavior modifying change simpler to read, two cleanup commits were added in front. The first one might look scary but it isn't. 99% of the diff is just from the function identation. `--ignore-all-space` in git makes it lot more readable. The "Hide whitespace" option for the github diff viewer does the same