### PR TITLE
ramips: mt76x8: add Teltonika RUT241/RUT200 v5 support

### DIFF
--- a/target/linux/ramips/dts/mt7628an_teltonika_rut241-v5.dts
+++ b/target/linux/ramips/dts/mt7628an_teltonika_rut241-v5.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_teltonika_rut2xx.dtsi"
+
+/ {
+	compatible = "teltonika,rut241-v5", "mediatek,mt7628an-soc";
+	model = "Teltonika RUT200/RUT241 v5";
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_esim_select {
+			gpio-export,name = "esim_select";
+			gpio-export,output = <0>;
+			gpios = <&gpio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_din {
+			gpio-export,name = "digital_input";
+			gpio-export,input = <0>;
+			gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_dout {
+			gpio-export,name = "digital_output";
+			gpio-export,output = <0>;
+			gpios = <&gpio 37 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	tpm: tpm@2e {
+		compatible = "infineon,slb9673";
+		reg = <0x2e>;
+		status = "okay";
+	};
+};

--- a/target/linux/ramips/dts/mt7628an_teltonika_rut2xx.dtsi
+++ b/target/linux/ramips/dts/mt7628an_teltonika_rut2xx.dtsi
@@ -181,7 +181,7 @@
 
 &state_default {
 	gpio {
-		groups = "i2s", "uart1", "p4led_an", "p3led_an", "p2led_an", "p1led_an", "p0led_an", "gpio", "wled_an", "perst", "spi cs1";
+		groups = "i2s", "uart1", "p4led_an", "p3led_an", "p2led_an", "p1led_an", "p0led_an", "gpio", "wled_an", "perst", "spi cs1", "refclk";
 		function = "gpio";
 	};
 };
@@ -190,6 +190,9 @@
 	status = "okay";
 	nvmem-cells = <&eeprom_factory_0>, <&macaddr_config_0 2>;
 	nvmem-cell-names = "eeprom", "mac-address";
+	led {
+		status = "disabled";
+	};
 };
 
 &ethernet {

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1498,30 +1498,41 @@ define Device/zyxel_keenetic-extra-ii
 endef
 TARGET_DEVICES += zyxel_keenetic-extra-ii
 
-define Device/teltonika_rut200
+define Device/teltonika_rut2xx_common
   DEVICE_VENDOR := Teltonika
-  DEVICE_MODEL := RUT200
-  DEVICE_VARIANT := v1-v4
   SUPPORTED_TELTONIKA_DEVICES := teltonika,rut2m
   IMAGE_SIZE := 15424k
   BLOCKSIZE := 64k
-  DEVICE_PACKAGES +=kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-serial-option kmod-usb-net-cdc-ether
+  DEVICE_PACKAGES += uqmi kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-serial-option kmod-usb-net-cdc-ether
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-teltonika-metadata
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+
+define Device/teltonika_rut200
+  $(Device/teltonika_rut2xx_common)
+  DEVICE_MODEL := RUT200
+  DEVICE_VARIANT := v1-v4
+  SUPPORTED_TELTONIKA_HW_MODS := ala440
 endef
 TARGET_DEVICES += teltonika_rut200
 
 define Device/teltonika_rut241
-  DEVICE_VENDOR := Teltonika
+  $(Device/teltonika_rut2xx_common)
   DEVICE_MODEL := RUT241
   DEVICE_VARIANT := v1-v4
-  SUPPORTED_TELTONIKA_DEVICES := teltonika,rut2m
-  IMAGE_SIZE := 15424k
-  BLOCKSIZE := 64k
-  DEVICE_PACKAGES += uqmi kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-serial-option
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-teltonika-metadata
-  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
+  SUPPORTED_TELTONIKA_HW_MODS := ala440
 endef
 TARGET_DEVICES += teltonika_rut241
+
+define Device/teltonika_rut241-v5
+  $(Device/teltonika_rut2xx_common)
+  DEVICE_MODEL := RUT241
+  DEVICE_VARIANT := v5
+  DEVICE_ALT0_VENDOR := Teltonika
+  DEVICE_ALT0_MODEL := RUT200
+  DEVICE_ALT0_VARIANT := v5
+  SUPPORTED_TELTONIKA_HW_MODS := 200v5 241v5 ala440
+  DEVICE_PACKAGES += kmod-i2c-mt7628
+endef
+TARGET_DEVICES += teltonika_rut241-v5

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1528,33 +1528,46 @@ define Device/zyxel_keenetic-extra-ii
 endef
 TARGET_DEVICES += zyxel_keenetic-extra-ii
 
-define Device/teltonika_rut200
+define Device/teltonika_rut2xx_common
   DEVICE_VENDOR := Teltonika
   DEVICE_MODEL := RUT200
   DEVICE_VARIANT := v1-v4
   SUPPORTED_TELTONIKA_DEVICES := teltonika,rut2m
   IMAGE_SIZE := 15424k
   BLOCKSIZE := 64k
-  DEVICE_PACKAGES +=kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-serial-option kmod-usb-net-cdc-ether
+  DEVICE_PACKAGES += uqmi kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-serial-option kmod-usb-net-cdc-ether
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-teltonika-metadata
   IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+
+define Device/teltonika_rut200
+  $(Device/teltonika_rut2xx_common)
+  DEVICE_MODEL := RUT200
+  DEVICE_VARIANT := v1-v4
+  SUPPORTED_TELTONIKA_HW_MODS := ala440
 endef
 TARGET_DEVICES += teltonika_rut200
 
 define Device/teltonika_rut241
-  DEVICE_VENDOR := Teltonika
+  $(Device/teltonika_rut2xx_common)
   DEVICE_MODEL := RUT241
   DEVICE_VARIANT := v1-v4
-  SUPPORTED_TELTONIKA_DEVICES := teltonika,rut2m
-  IMAGE_SIZE := 15424k
-  BLOCKSIZE := 64k
-  DEVICE_PACKAGES += uqmi kmod-mt76x2 kmod-usb2 kmod-usb-ohci kmod-usb-serial-option
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-teltonika-metadata
-  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size | append-metadata
+  SUPPORTED_TELTONIKA_HW_MODS := ala440
 endef
 TARGET_DEVICES += teltonika_rut241
+
+define Device/teltonika_rut241-v5
+  $(Device/teltonika_rut2xx_common)
+  DEVICE_MODEL := RUT241
+  DEVICE_VARIANT := v5
+  DEVICE_ALT0_VENDOR := Teltonika
+  DEVICE_ALT0_MODEL := RUT200
+  DEVICE_ALT0_VARIANT := v5
+  SUPPORTED_TELTONIKA_HW_MODS := 200v5 241v5 ala440
+  DEVICE_PACKAGES += kmod-i2c-mt7628
+endef
+TARGET_DEVICES += teltonika_rut241-v5
 
 define Device/yuncore_1200f
   IMAGE_SIZE := 7872k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -95,7 +95,8 @@ tama,w06)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
 teltonika,rut200|\
-teltonika,rut241)
+teltonika,rut241|\
+teltonika,rut241-v5)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x02"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -102,7 +102,8 @@ tama,w06)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
 teltonika,rut200|\
-teltonika,rut241)
+teltonika,rut241|\
+teltonika,rut241-v5)
 	ucidef_set_led_switch "lan" "lan" "green:lan" "switch0" "0x02"
 	ucidef_set_led_switch "wan" "wan" "green:wan" "switch0" "0x01"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -126,7 +126,8 @@ ramips_setup_interfaces()
 	glinet,gl-mt300n-v2|\
 	hongdian,h7920-v40|\
 	teltonika,rut200|\
-	teltonika,rut241)
+	teltonika,rut241|\
+	teltonika,rut241-v5)
 		ucidef_add_switch "switch0" \
 			"1:lan" "0:wan" "6@eth0"
 		;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -360,6 +360,11 @@ ramips_setup_macs()
 	wavlink,wl-wn575a3)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x28)" 1)
 		;;
+	teltonika,rut200|\
+	teltonika,rut241|\
+	teltonika,rut241-v5)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary config 0x0)" 1)
+		;;
 	tplink,archer-c20-v4|\
 	tplink,archer-c50-v3|\
 	tplink,tl-mr3420-v5|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -376,6 +376,11 @@ ramips_setup_macs()
 	wavlink,wl-wn575a3)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x28)" 1)
 		;;
+	teltonika,rut200|\
+	teltonika,rut241|\
+	teltonika,rut241-v5)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary config 0x0)" 1)
+		;;
 	tplink,archer-c20-v4|\
 	tplink,archer-c50-v3|\
 	tplink,tl-mr3420-v5|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
@@ -17,7 +17,8 @@ hongdian,h8850-v20)
 	ucidef_add_gpio_switch "modem_enable" "Modem power" "modem_power" "1"
 	;;
 teltonika,rut200|\
-teltonika,rut241)
+teltonika,rut241|\
+teltonika,rut241-v5)
 	ucidef_add_gpio_switch "digital_output" "Digital output" "digital_output" "0"
 	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "1"
 	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"


### PR DESCRIPTION
Add updated RUT241/RUT200 version 5 hardware support, these routers share same board, just modems differ.
eSIM and TPM added to this revision.

Specifications:
  SoC: MediaTek MT7628AN
  RAM: 128 MB
  Flash: 16MB SPI
  Switch: MediaTek MT7628AN, 2 ports 100 Mbps
  WiFi: MediaTek MT7628AN 2.4 GHz 802.11n
  Modem: MeigLink/Quectel 4G, CAT 4, eSIM
  TPM: Infineon SLB9673

GPIO:
 - 1 button (Reset)
 - 8 LEDs (2G, 3G, 4G, RSSI 1,2,3,4,5)
 - 3 Modem control (power button, reset, eSIM switch)
 - 1 Digital input
 - 1 Digital output

Flashing via OEM WebUI:
1. Download the firmware image *-squashfs-factory.bin
2. Upload firmware image via OEM WebUI firmware update, do not keep settings