### PR TITLE
WIP package: make APK binary reproducible

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git
@@ -14,7 +14,7 @@ PKG_VERSION=3.0.0_pre$(subst -,,$(PKG_SOURCE_DATE))
 PKG_MAINTAINER:=Paul Spooren <mail@aparcar.org>
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=LICENSE
-PKG_INSTALL:=2
+PKG_INSTALL:=1
 
 HOST_BUILD_PREFIX:=$(STAGING_DIR_HOST)
 HOST_BUILD_DEPENDS:=lua/host
@@ -59,6 +59,7 @@ MESON_COMMON_ARGS = \
 	-Dhelp=enabled \
 	-Dlua_version=5.1 \
 	-Ddefault_library=static \
+	-Dprefer_static=true \
 	-Durl_backend=wget \
 	-Dzstd=false \
 	-Dpython=disabled \


### PR DESCRIPTION
Prior to this, APK would include parts of the build path in the binary, making
it unreproducible. By setting `prefer_static` the path is no longer stored.

Example of the unreproducible path:

```
❯ strings usr/bin/apk | grep usr
/Users/user/src/openwrt/openwrt/staging_dir/target-x86_64_musl/usr/lib
/usr/sbin/uvol
PATH=/usr/sbin:/usr/bin:/sbin:/bin
```

After the patch:
```
❯ strings usr/bin/apk | grep usr
/usr/sbin/uvol
PATH=/usr/sbin:/usr/bin:/sbin:/bin
```

This commits make the binary reproducible for both host builds (used in
SDK/ImageBuilder) and also firmware builds.

While at it, set PKG_INSTALL to 1 again, which seems to be a typo from "a6e98a8
apk: add a customfeeds.list configuration file"
