### PR TITLE
include: make APK packing mtime reproducible

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -383,6 +383,9 @@ else
 		exit 1; \
 	fi
 
+	# Touch all files to set mtime to PKG_SOURCE_DATE_EPOCH for reproducible builds
+	find $$(IDIR_$(1)) -exec touch -d "@$(PKG_SOURCE_DATE_EPOCH)" {} \;
+
 	$(FAKEROOT) $(STAGING_DIR_HOST)/bin/apk mkpkg \
 	  --info "name:$(1)$$(ABIV_$(1))" \
 	  --info "version:$(VERSION)" \


### PR DESCRIPTION
APK kindly stores the mtime of each containing file in created packages, breaking reproducibility. As a fix, touch all files of the package with the timestamp of PKGSOURCE_DATE_EPOCH, which contains the timestamp based on the last package modification.

Over at OPKG, something similar is done by setting mtime in the tar command, see the `ipkg-build` script.