### PR TITLE
base-files: commit and sync before removing defaults script.

### DIFF
--- a/package/base-files/files/etc/init.d/boot
+++ b/package/base-files/files/etc/init.d/boot
@@ -10,10 +10,13 @@ uci_apply_defaults() {
 	cd /etc/uci-defaults || return 0
 	files="$(ls)"
 	[ -z "$files" ] && return 0
+	applied=""
 	for file in $files; do
-		( . "./$(basename $file)" ) && rm -f "$file"
+		( . "./$(basename $file)" ) && applied="$applied $file"
 	done
 	uci commit
+	sync
+	rm -f $applied
 }
 
 boot() {


### PR DESCRIPTION
Improve the resilence against power failures during boot-up by trying to sync the file system before
removing the script. The order of the operations are important.