### PR TITLE
net: dsa: mt7530/mt7531: fix reset GPIO polarity

### DIFF
--- a/target/linux/mediatek/dts/mt7622-asiarf-ap7622-wh1.dts
+++ b/target/linux/mediatek/dts/mt7622-asiarf-ap7622-wh1.dts
@@ -146,7 +146,7 @@
 			interrupt-controller;
 			interrupt-parent = <&pio>;
 			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
-			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_LOW>;
 			
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-3200ax4s.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-3200ax4s.dts
@@ -43,7 +43,7 @@
 	switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 54 GPIO_ACTIVE_LOW>;
 
 		ports {
 			#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7622-elecom-wrc-x3200gst3.dts
+++ b/target/linux/mediatek/dts/mt7622-elecom-wrc-x3200gst3.dts
@@ -218,7 +218,7 @@
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;
 			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
-			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_LOW>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
+++ b/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
@@ -154,7 +154,7 @@
 			interrupt-controller;
 			interrupt-parent = <&pio>;
 			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
-			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_LOW>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7622-ruijie-rg-ew3200.dtsi
+++ b/target/linux/mediatek/dts/mt7622-ruijie-rg-ew3200.dtsi
@@ -101,7 +101,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_LOW>;
 			interrupt-controller;
 			#interrupt-cells = <2>;
 			interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
+++ b/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
@@ -172,7 +172,7 @@
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;
 			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
-			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 54 GPIO_ACTIVE_LOW>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7981a-comfast-cf-e393ax.dts
+++ b/target/linux/mediatek/dts/mt7981a-comfast-cf-e393ax.dts
@@ -95,7 +95,7 @@
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;
 		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
+++ b/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
@@ -218,7 +218,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-abt-asr3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-abt-asr3000.dts
@@ -114,7 +114,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-cetron-ct3003.dts
+++ b/target/linux/mediatek/dts/mt7981b-cetron-ct3003.dts
@@ -85,7 +85,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-cmcc-a10.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-a10.dtsi
@@ -91,7 +91,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m.dts
@@ -99,7 +99,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-confiabits-mt7981.dts
+++ b/target/linux/mediatek/dts/mt7981b-confiabits-mt7981.dts
@@ -144,7 +144,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7981b-creatlentem-clt-r30b1-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-creatlentem-clt-r30b1-common.dtsi
@@ -96,7 +96,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-cudy-re3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-re3000-v1.dts
@@ -104,7 +104,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
@@ -58,7 +58,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
@@ -120,7 +120,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-m30-a1.dts
+++ b/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-m30-a1.dts
@@ -89,7 +89,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 
 		ports {
 			#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7981b-elecom-wrc-x3000gs3.dts
+++ b/target/linux/mediatek/dts/mt7981b-elecom-wrc-x3000gs3.dts
@@ -142,7 +142,7 @@
 	switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 
 		ports {
 			#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
@@ -91,7 +91,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
@@ -129,7 +129,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 
 		ports {
 			#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000q.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000q.dts
@@ -97,7 +97,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <0x1f>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000sm.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000sm.dts
@@ -106,7 +106,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <0x1f>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-jcg-q30-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-jcg-q30-pro.dts
@@ -82,7 +82,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
@@ -133,7 +133,7 @@
 	switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <0x1f>;
-		reset-gpios = <&pio 22 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 22 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
@@ -148,7 +148,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <0x1f>;
-		reset-gpios = <&pio 22 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 22 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-mercusys-mr80x-v3.dts
+++ b/target/linux/mediatek/dts/mt7981b-mercusys-mr80x-v3.dts
@@ -118,7 +118,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7981b-netis-nx31.dts
+++ b/target/linux/mediatek/dts/mt7981b-netis-nx31.dts
@@ -109,7 +109,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <0x1f>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-nokia-ea0326gmp.dts
+++ b/target/linux/mediatek/dts/mt7981b-nokia-ea0326gmp.dts
@@ -123,7 +123,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-nradio-c8-668gl.dts
+++ b/target/linux/mediatek/dts/mt7981b-nradio-c8-668gl.dts
@@ -201,7 +201,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
+++ b/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
@@ -84,7 +84,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-routerich-ax3000-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-routerich-ax3000-common.dtsi
@@ -137,7 +137,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <0x1f>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-routerich-ax3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-routerich-ax3000-v1.dts
@@ -153,7 +153,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <0x1f>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-routerich-ax3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-routerich-ax3000.dts
@@ -48,7 +48,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <0x1f>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-snr-snr-cpe-ax2.dts
+++ b/target/linux/mediatek/dts/mt7981b-snr-snr-cpe-ax2.dts
@@ -118,7 +118,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <0x1f>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-tenbay-wr3000k.dts
+++ b/target/linux/mediatek/dts/mt7981b-tenbay-wr3000k.dts
@@ -91,7 +91,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-totolink-x6000r.dts
+++ b/target/linux/mediatek/dts/mt7981b-totolink-x6000r.dts
@@ -108,7 +108,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-tplink-fr365v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-tplink-fr365v1.dts
@@ -126,7 +126,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-unielec-u7981-01.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-unielec-u7981-01.dtsi
@@ -62,7 +62,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-3port-128nand-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-3port-128nand-common.dtsi
@@ -168,7 +168,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn586x3.dts
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn586x3.dts
@@ -111,7 +111,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
@@ -78,7 +78,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
+++ b/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
@@ -101,7 +101,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
@@ -151,7 +151,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax.dts
@@ -164,7 +164,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dts
@@ -124,7 +124,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dts
@@ -101,7 +101,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986a-acer-w6-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-acer-w6-common.dtsi
@@ -283,7 +283,7 @@
 		switch: switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986a-asiarf-ap7986-003.dts
+++ b/target/linux/mediatek/dts/mt7986a-asiarf-ap7986-003.dts
@@ -145,7 +145,7 @@
 			interrupt-controller;
 			interrupt-parent = <&pio>;
 			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
-			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986a-asus-rt-ax59u.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-rt-ax59u.dts
@@ -110,7 +110,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax4200.dts
@@ -153,7 +153,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -180,7 +180,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
+++ b/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
@@ -96,7 +96,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986a-glinet-gl-mt6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-glinet-gl-mt6000.dts
@@ -133,7 +133,7 @@
 		switch: switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 18 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 18 GPIO_ACTIVE_LOW>;
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
+++ b/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
@@ -305,7 +305,7 @@
 	switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <0x1f>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 		reset-assert-us = <10000>;
 		reset-deassert-us = <10000>;
 

--- a/target/linux/mediatek/dts/mt7986a-jdcloud-re-cp-03.dts
+++ b/target/linux/mediatek/dts/mt7986a-jdcloud-re-cp-03.dts
@@ -143,7 +143,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
@@ -180,7 +180,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986a-netcore-n60.dts
+++ b/target/linux/mediatek/dts/mt7986a-netcore-n60.dts
@@ -127,7 +127,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
@@ -93,7 +93,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986a-smartrg-SDG-8612.dts
+++ b/target/linux/mediatek/dts/mt7986a-smartrg-SDG-8612.dts
@@ -27,7 +27,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 
 		ports {
 			#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986a-smartrg-SDG-8614.dts
+++ b/target/linux/mediatek/dts/mt7986a-smartrg-SDG-8614.dts
@@ -75,7 +75,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 
 		ports {
 			#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-archer-ax80-v1.dts
@@ -129,7 +129,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
@@ -150,7 +150,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
@@ -149,7 +149,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 6 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
@@ -76,7 +76,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -256,7 +256,7 @@
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 
 			ports {
 				#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5700-telenor.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5700-telenor.dts
@@ -204,7 +204,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 		interrupt-controller;
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;

--- a/target/linux/mediatek/dts/mt7986b-buffalo-wsr-6000ax8.dts
+++ b/target/linux/mediatek/dts/mt7986b-buffalo-wsr-6000ax8.dts
@@ -164,7 +164,7 @@
 		switch: switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
-			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 
 			interrupt-controller;
 			#interrupt-cells = <1>;

--- a/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1-common.dtsi
@@ -132,7 +132,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7986b-tplink-re6000xd.dts
+++ b/target/linux/mediatek/dts/mt7986b-tplink-re6000xd.dts
@@ -151,7 +151,7 @@
 	switch: switch@1f {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
 	};
 };
 

--- a/target/linux/mediatek/patches-6.12/996-net-dsa-mt7530-reset.patch
+++ b/target/linux/mediatek/patches-6.12/996-net-dsa-mt7530-reset.patch
@@ -1,0 +1,103 @@
+--- a/arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7622-bananapi-bpi-r64.dts
+@@ -161,7 +161,7 @@
+ 			interrupt-controller;
+ 			#interrupt-cells = <1>;
+ 			interrupts-extended = <&pio 53 IRQ_TYPE_LEVEL_HIGH>;
+-			reset-gpios = <&pio 54 0>;
++			reset-gpios = <&pio 54 1>;
+ 
+ 			ports {
+ 				#address-cells = <1>;
+--- a/arch/arm64/boot/dts/mediatek/mt7622-rfb1.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7622-rfb1.dts
+@@ -132,7 +132,7 @@
+ 		switch@1f {
+ 			compatible = "mediatek,mt7531";
+ 			reg = <31>;
+-			reset-gpios = <&pio 54 0>;
++			reset-gpios = <&pio 54 1>;
+ 
+ 			ports {
+ 				#address-cells = <1>;
+--- a/arch/arm64/boot/dts/mediatek/mt7981-rfb.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7981-rfb.dts
+@@ -89,7 +89,7 @@
+ 		#interrupt-cells = <1>;
+ 		interrupt-parent = <&pio>;
+ 		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
++		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+ 	};
+ };
+ 
+--- a/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7986a-bananapi-bpi-r3.dts
+@@ -211,7 +211,7 @@
+ 		interrupt-controller;
+ 		#interrupt-cells = <1>;
+ 		interrupts-extended = <&pio 66 IRQ_TYPE_LEVEL_HIGH>;
+-		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
++		reset-gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+ 	};
+ };
+ 
+--- a/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dts
+@@ -87,7 +87,7 @@
+ 	switch: switch@0 {
+ 		compatible = "mediatek,mt7531";
+ 		reg = <31>;
+-		reset-gpios = <&pio 5 0>;
++		reset-gpios = <&pio 5 1>;
+ 	};
+ };
+ 
+--- a/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7986a-rfb.dtsi
+@@ -104,7 +104,7 @@
+ 	switch: switch@1f {
+ 		compatible = "mediatek,mt7531";
+ 		reg = <31>;
+-		reset-gpios = <&pio 5 0>;
++		reset-gpios = <&pio 5 1>;
+ 	};
+ };
+ 
+--- a/arch/arm64/boot/dts/mediatek/mt7986b-rfb.dts
++++ b/arch/arm64/boot/dts/mediatek/mt7986b-rfb.dts
+@@ -64,7 +64,7 @@
+ 		switch@0 {
+ 			compatible = "mediatek,mt7531";
+ 			reg = <31>;
+-			reset-gpios = <&pio 5 0>;
++			reset-gpios = <&pio 5 1>;
+ 
+ 			ports {
+ 				#address-cells = <1>;
+--- a/drivers/net/dsa/mt7530.c
++++ b/drivers/net/dsa/mt7530.c
+@@ -2380,9 +2380,9 @@ mt7530_setup(struct dsa_switch *ds)
+ 		usleep_range(5000, 5100);
+ 		reset_control_deassert(priv->rstc);
+ 	} else {
+-		gpiod_set_value_cansleep(priv->reset, 0);
+-		usleep_range(5000, 5100);
+ 		gpiod_set_value_cansleep(priv->reset, 1);
++		usleep_range(5000, 5100);
++		gpiod_set_value_cansleep(priv->reset, 0);
+ 	}
+ 
+ 	/* Waiting for MT7530 got to stable */
+@@ -2613,9 +2613,9 @@ mt7531_setup(struct dsa_switch *ds)
+ 		usleep_range(5000, 5100);
+ 		reset_control_deassert(priv->rstc);
+ 	} else {
+-		gpiod_set_value_cansleep(priv->reset, 0);
+-		usleep_range(5000, 5100);
+ 		gpiod_set_value_cansleep(priv->reset, 1);
++		usleep_range(5000, 5100);
++		gpiod_set_value_cansleep(priv->reset, 0);
+ 	}
+ 
+ 	/* Waiting for MT7530 got to stable */


### PR DESCRIPTION
The MT7531 switch chip uses an active-low RESET_N pin (low = assert reset, high = release).
Current DTS files and driver code treat the reset GPIO as active-high, which results in inverted behavior.

Fix this by:
- Updating DTS and DTSI files to use `reset-gpios = <&pio XX GPIO_ACTIVE_LOW>;`
- Adjusting mt7530 driver code so that reset sequence drives the GPIO low to assert reset, then high to release.

This ensures proper reset timing and stable bring-up of the MT7531 switch.
