### PR TITLE
ramips: Fix Hongdian H7920 v40 pinctrl default state and mac address

### DIFF
--- a/target/linux/ramips/dts/mt7628an_hongdian_h7920-v40.dts
+++ b/target/linux/ramips/dts/mt7628an_hongdian_h7920-v40.dts
@@ -140,7 +140,7 @@
 
 &state_default {
 	gpio {
-		groups = "i2s", "gpio", "refclk";
+		groups = "i2s", "i2c", "spi cs1", "gpio", "perst", "refclk", "wdt", "wled_an";
 		function = "gpio";
 	};
 };
@@ -166,6 +166,3 @@
 	status = "okay";
 };
 
-&pcie {
-	status = "okay";
-};

--- a/target/linux/ramips/dts/mt7628an_hongdian_h7920-v40.dts
+++ b/target/linux/ramips/dts/mt7628an_hongdian_h7920-v40.dts
@@ -123,8 +123,8 @@
 						reg = <0x0 0x400>;
 					};
 
-					macaddr_factory_28: macaddr@28 {
-						reg = <0x28 0x6>;
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
 					};
 				};
 			};
@@ -146,7 +146,7 @@
 };
 
 &ethernet {
-	nvmem-cells = <&macaddr_factory_28>;
+	nvmem-cells = <&macaddr_factory_4>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -284,6 +284,7 @@ ramips_setup_macs()
 		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	duzun,dm06|\
+	hongdian,h7920-v40|\
 	netgear,r6020|\
 	netgear,r6080|\
 	netgear,r6120|\
@@ -302,7 +303,6 @@ ramips_setup_macs()
 	totolink,a3)
 		wan_mac=$(mtd_get_mac_binary u-boot 0x1fc40)
 		;;
-	hongdian,h7920-v40|\
 	jotale,js76x8-8m|\
 	jotale,js76x8-16m|\
 	jotale,js76x8-32m|\


### PR DESCRIPTION
According to the MT7628 hardware datasheet:
- GPIO/4 was originally used for I2C, but is now used as the Modem Power.
- GPIO/5 was originally used for I2C, but is now used as the SIM card select. (n/a for this device)
- GPIO/6 was originally used for SPI CS1, but is now used as the Serial mode switch.
- GPIO/36 was originally used for PERST, but is now used as the GPS OE. (n/a for this device)
- GPIO/38 was originally used for WDT, but is now used as the Modem2 Power. (n/a for this device)
- GPIO/44 was used for WLED_AN, but is now controlled by `gpio-leds`.

Corrected pinctrl to ensure it works properly in the future.

---

After extracting the EEPROMs of different devices, only the 0x4 address is unique.

Use the 0x4 address as the LAN address, and the LAN+1 address as the WAN address.