### PR TITLE
package: generate sha256sums by default

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -169,6 +169,7 @@ ifdef CONFIG_JSON_CYCLONEDX_SBOM
 	); done
 endif
 endif
+	$(call sha256sums,$(OUTPUT_DIR)/packages/$(ARCH_PACKAGES),1)
 
 $(curdir)/flags-install:= -j1
 


### PR DESCRIPTION
Right now the sha256sums are only created for the targets/ folder (i.e. firmware images) and only the buildbot generates those sha256sums. Instead, let the build system create the sha256sums directly.