### PR TITLE
mediatek: CreatLentem clt-r30b1: Add Livinet Li228 as alt vendor model

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -775,7 +775,9 @@ define Device/creatlentem_clt-r30b1-common
   DEVICE_ALT0_VENDOR := EDUP
   DEVICE_ALT0_MODEL := RT2980
   DEVICE_ALT1_VENDOR := Dragonglass
-  DEVICE_ALT1_MODEL := DXG21
+  DEVICE_ALT1_MODEL := DGX21
+  DEVICE_ALT2_VENDOR := Livinet
+  DEVICE_ALT2_MODEL := Li228
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
   UBINIZE_OPTS := -E 5
@@ -789,6 +791,7 @@ define Device/creatlentem_clt-r30b1-112m
   DEVICE_VARIANT := 112M
   DEVICE_ALT0_VARIANT := 112M
   DEVICE_ALT1_VARIANT := 112M
+  DEVICE_ALT2_VARIANT := 112M
   DEVICE_DTS := mt7981b-creatlentem-clt-r30b1-112m
   SUPPORTED_DEVICES += clt,r30b1 clt,r30b1-112m
   IMAGE_SIZE := 114688k


### PR DESCRIPTION
Add Livinet Li228 as ALT2 - identical device.
Fix typo in ALT1_MODEL: DXG21 -> DGX21

Signed-off-by: Andrii Kuiukoff <andros.ua@gmail.com>