### PR TITLE
realtek: rtl931x: Add SPI_CTRL0 as pinmux

### DIFF
--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -296,6 +296,36 @@
 		};
 	};
 
+	pinmux@1b00103c {
+		compatible = "pinctrl-single";
+		reg = <0x1b00103c 0x4>;
+
+		pinctrl-single,bit-per-mux;
+		pinctrl-single,register-width = <32>;
+		pinctrl-single,function-mask = <0x1>;
+		#pinctrl-cells = <2>;
+
+		/* 31.25 MHz SPI master clock */
+		pinmux_spi0_31mhz: spi0-31mhz {
+			pinctrl-single,bits = <0x0 0x1800 0x3800>;
+		};
+
+		/* Enable GPIO 8, 9, 10 */
+		pinmux_disable_spi0: disable-spi0 {
+			pinctrl-single,bits = <0x0 0x0 0x400>;
+		};
+
+		/* Enable GPIO 12 */
+		pinmux_disable_spi0_cs1: disable-spi-cs1 {
+			pinctrl-single,bits = <0x0 0x0 0x200>;
+		};
+
+		/* Enable GPIO 11 */
+		pinmux_disable_spi0_cs0: disable-spi-cs0 {
+			pinctrl-single,bits = <0x0 0x0 0x100>;
+		};
+	};
+
 	pinmux@1b001358 {
 		compatible = "pinctrl-single";
 		reg = <0x1b001358 0x4>;

--- a/target/linux/realtek/files-6.12/arch/mips/include/asm/mach-rtl838x/mach-rtl83xx.h
+++ b/target/linux/realtek/files-6.12/arch/mips/include/asm/mach-rtl838x/mach-rtl83xx.h
@@ -105,9 +105,6 @@
 #define RTL9300_FAMILY_ID		(0x9300)
 #define RTL9310_FAMILY_ID		(0x9310)
 
-/* SPI Support */
-#define RTL931X_SPI_CTRL0		(0x103C)
-
 /* Basic SoC Features */
 #define RTL838X_CPU_PORT		28
 #define RTL839X_CPU_PORT		52

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -1519,9 +1519,6 @@ static int rtl931x_chip_init(struct rtl838x_eth_priv *priv)
 	/* Enable ESD auto recovery */
 	sw_w32(0x1, RTL931X_MDX_CTRL_RSVD);
 
-	/* Init SPI, is this for thermal control or what? */
-	sw_w32_mask(0x7 << 11, 0x2 << 11, RTL931X_SPI_CTRL0);
-
 	return 0;
 }
 


### PR DESCRIPTION
The RTL931x has next to its SPI flash controller a SPI master interface. It is connected to

```
* SPI_CS#[1,0]: AH22 , AK22 (aka: GPIO 12, 11)
* SPI_CLK:      AL23 (aka: GPIO 8)
* SPI_MISO:     AM23 (aka: GPIO 9)
* SPI_MOSI:     AL22 (aka: GPIO 10)
```

It is not the same as the SPI flash controller which uses pins:

```
* SPI_CS#[1,0]: B24, A24
* SPI_SCLK:     A23
* SPI_SDI/SIO0: B21
* SPO_SDO_SIO1: B21
* SPI_SIO2:     A22
* SPI_SIO3:     B22
* SPI_RSTN:     B23
```

As shown above, the SPI master controller shares its pin with GPIO 8, 9, 10, 11, 12. In some upcoming devices (like the Plasma Cloud PSX28/ESX28), they will be used for SFP cage signaling. These pins must therefore be switched manually to the GPIO mode.

The SPI_CTRL0 register provides all necessary configuration to enforce the GPIO mode of the pins. And until more requirements (and a correct driver) for the SPI master controller arise, it is therefore possible to use pinctrl-single to configure it using the devicetree.

Previously the ethernet driver did configure the SPI master controller for 31.25 MHz. It is unknown for which kind of device this was originally made and what was actually connected there. But this manual write to the register conflicts potentially with the write of the pinctrl driver to the same register. Luckily, we don't need this SPI speed configuration in the ethernet driver. Still, to allow this device an easy migration, the `spi0-31mhz` configuration was already prepared.

---

prerequisite for #20172