### PR TITLE
ramips: mt7621: add support for Cudy AP1300 Outdoor v1

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_ap1300-outdoor-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_ap1300-outdoor-v1.dts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "cudy,ap1300-outdoor-v1", "mediatek,mt7621-soc";
+	model = "Cudy AP1300 Outdoor v1";
+	
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;		
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led_sys:status {
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		internet {
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN_ONLINE;
+		};
+
+		lan {
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+		};
+
+		wifi2g {
+			gpios = <&gpio 47 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi5g {
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			linux,default-trigger = "phy1tpt";
+		};	
+	};
+	
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		/* hw_margin_ms seems to be around 30s for this device*/
+		hw_margin_ms = <10000>;
+		always-running;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "debug";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "backup";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "bdinfo";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 1>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@1,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_bdinfo_de00 2>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@4 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "i2c", "jtag";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -728,6 +728,20 @@ define Device/confiabits_mt7621-v1
 endef
 TARGET_DEVICES += confiabits_mt7621-v1
 
+define Device/cudy_ap1300-outdoor-v1
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := AP1300 Outdoor
+  DEVICE_VARIANT := v1
+  IMAGE_SIZE := 15872k
+  UIMAGE_NAME := R39
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+	-uboot-envtools
+  SUPPORTED_DEVICES += R39
+endef
+TARGET_DEVICES += cudy_ap1300-outdoor-v1
+
 define Device/cudy_m1300-v2
   $(Device/dsa-migration)
   IMAGE_SIZE := 15872k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -58,6 +58,9 @@ wifire,s1500-nbn)
 belkin,rt1800)
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan"
 	;;
+cudy,ap1300-outdoor-v1)
+	ucidef_set_led_netdev "lan" "lan" "green:lan" "lan"
+	;;
 confiabits,mt7621-v1|\
 genexis,pulse-ex400|\
 netis,n6)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -42,6 +42,7 @@ ramips_setup_interfaces()
 	arcadyan,we410443|\
 	asus,rp-ac56|\
 	asus,rp-ac87|\
+	cudy,ap1300-outdoor-v1|\
 	dlink,dap-1620-b1|\
 	dlink,dap-x1860-a1|\
 	dlink,dra-1360-a1|\


### PR DESCRIPTION
Commit message:
```
Hardware:
 - SoC: MediaTek MT7621DAT
 - Flash: 16 MiB XM25QH128C
 - RAM: 128 MiB
 - WLAN: 2.4 GHz (MT7603E, 11n), 5 GHz (MediaTek MT7613BEN, 11ac)
 - Ethernet: 1x10/100/1000 Mbps LAN
 - Buttons: 1 Reset button, 1 WPS button
 - LEDs: 5x Green
 - Serial Console: unpopulated header 115200 8n1 (silkscreen on PCB)
 - Power: POE 802.3af (37-57V DC)

MAC addresses:
+---------+-------------------+-----------+
|         | MAC               | Algorithm |
+---------+-------------------+-----------+
| LAN     | 80:af:ca:xx:xx:x0 | label     |
| WLAN 2g | 80:af:ca:xx:xx:x0 | label     |
| WLAN 5g | 82:af:ca:xx:xx:x1 | +1        |
+---------+-------------------+-----------+

Installation:
The factory firmware is locked: you can only work with Cudy signed firmware. Download a intermediate firmware signed by Cudy here: https://www.cudy.com/blogs/faq/openwrt-software-download

After that, login to the router (192.168.10.254, password "admin") and install the intermediate firmware.

If you can reach LuCI or SSH now on the intermediate firmware, just use the sysupgrade image with the 'Keep settings' option turned off.

Special thanks to Daniel de Kock for starting the porting work at #16265.
```

Tested and working:
- Ethernet LAN (including correct MAC)
- Wi-Fi 2.4GHz, 5GHz (including correct MAC)
- 5x LEDs
- Failsafe