### PR TITLE
ath79: asus: convert to nvmem for calibration

### DIFF
--- a/target/linux/ath79/dts/qca9531_asus_rp-ac51.dts
+++ b/target/linux/ath79/dts/qca9531_asus_rp-ac51.dts
@@ -55,11 +55,6 @@
 			gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
 		};
 
-		wlan2g {
-			label = "blue:wlan2g";
-			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
-		};
-
 		wlan5g {
 			label = "blue:wlan5g";
 			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
@@ -117,6 +112,10 @@
 						reg = <0x0 0x6>;
 					};
 
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
 					macaddr_art_1002: macaddr@1002 {
 						reg = <0x1002 0x6>;
 					};
@@ -153,5 +152,11 @@
 &wmac {
 	status = "okay";
 
-	qca,no-eeprom;
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <16>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/dts/qca9563_asus_pl-ac56.dts
+++ b/target/linux/ath79/dts/qca9563_asus_pl-ac56.dts
@@ -48,11 +48,6 @@
 			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
 		};
 
-		wlan2g {
-			label = "green:wlan2g";
-			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
-		};
-
 		wlan5g {
 			label = "green:wlan5g";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
@@ -105,6 +100,10 @@
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
 
 					macaddr_art_1002: macaddr@1002 {
 						reg = <0x1002 0x6>;
@@ -168,5 +167,11 @@
 &wmac {
 	status = "okay";
 
-	qca,no-eeprom;
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <19>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/dts/qca9563_asus_rp-ac66.dts
+++ b/target/linux/ath79/dts/qca9563_asus_rp-ac66.dts
@@ -127,6 +127,10 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
 					macaddr_art_1002: macaddr@1002 {
 						reg = <0x1002 0x6>;
 					};
@@ -168,5 +172,6 @@
 &wmac {
 	status = "okay";
 
-	qca,no-eeprom;
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
 };

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -81,12 +81,10 @@ alfa-network,tube-2hq)
 	;;
 asus,pl-ac56)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x3e"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan2g" "wlan1" "link"
 	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan5g" "wlan0" "link"
 	;;
 asus,rp-ac51)
 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan2G" "wlan1" "link"
 	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan5G" "wlan0" "link"
 	;;
 asus,rp-ac66)

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -9,11 +9,6 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath9k-eeprom-ahb-18100000.wmac.bin")
 	case $board in
-	asus,pl-ac56|\
-	asus,rp-ac51|\
-	asus,rp-ac66)
-		caldata_extract "art" 0x1000 0x440
-		;;
 	avm,fritz1750e|\
 	avm,fritz4020|\
 	avm,fritz450e|\


### PR DESCRIPTION
Userspace handling is deprecated.

Also handle 2.4ghz LED in ath9k instead of generic.

ping @therealsummoner 