### PR TITLE
kernel: modules: fix mlxreg dependency to avoid deferred probe

### DIFF
--- a/package/kernel/linux/modules/other.mk
+++ b/package/kernel/linux/modules/other.mk
@@ -155,7 +155,9 @@ $(eval $(call KernelPackage,mlx_wdt))
 define KernelPackage/mlxreg
   SUBMENU:=$(OTHER_MENU)
   TITLE:=Mellanox platform register access
-  DEPENDS:=@TARGET_x86 +kmod-i2c-mux-mlxcpld
+  DEPENDS:=@TARGET_x86 \
+	+kmod-i2c-mux-mlxcpld \
+	+kmod-i2c-mux-reg
   KCONFIG:= \
 	CONFIG_MELLANOX_PLATFORM=y \
 	CONFIG_MLX_PLATFORM \


### PR DESCRIPTION
The `mlxreg-hotplug` platform driver was failing to probe due to a missing I²C multiplexer dependency.
Previously, only `kmod-i2c-mux-mlxcpld` was declared, but `mlxreg` also requires `kmod-i2c-mux-reg` to initialize its I²C mux functionality.

Without this dependency, the driver probe was deferred:
```
[   24.902331] platform mlxreg-hotplug: deferred probe pending: (reason unknown)
```

<br>

With `kmod-i2c-mux-reg` added, the probe succeeds and the expected multiplexed I²C buses are registered:
```
[   15.793884] i2c i2c-1: Added multiplexed i2c bus 2
[   15.799391] i2c i2c-1: Added multiplexed i2c bus 3
[   15.804830] i2c i2c-1: Added multiplexed i2c bus 4
...
```