### PR TITLE
openssl: update to 3.5.4

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.5.3
+PKG_VERSION:=3.5.4
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -21,7 +21,7 @@ PKG_SOURCE_URL:= \
 	https://www.openssl.org/source/old/$(PKG_BASE)/ \
 	https://github.com/openssl/openssl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 
-PKG_HASH:=c9489d2abcf943cdc8329a57092331c598a402938054dc3a22218aea8a8ec3bf
+PKG_HASH:=967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt


### PR DESCRIPTION
release is Moderate.

This release incorporates the following bug fixes and mitigations:

Fix Out-of-bounds read & write in RFC 3211 KEK Unwrap. (CVE-2025-9230)

Fix Timing side-channel in SM2 algorithm on 64 bit ARM. (CVE-2025-9231)

Fix Out-of-bounds read in HTTP client no_proxy handling. (CVE-2025-9232)

Reverted the synthesised OPENSSL_VERSION_NUMBER change for the release builds, as it broke some exiting applications that relied on the previous 3.x semantics, as documented in OpenSSL_version(3).

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc