### PR TITLE
odhcpd: update to Git HEAD (2025-10-02)

### DIFF
--- a/package/network/services/odhcpd/Makefile
+++ b/package/network/services/odhcpd/Makefile
@@ -12,9 +12,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcpd.git
-PKG_MIRROR_HASH:=4745093b58a221252fd092a40f2902e2a45a8ec972bcaa8592602f20acf26aa2
-PKG_SOURCE_DATE:=2025-09-27
-PKG_SOURCE_VERSION:=bc9f9d93d4d6b8feb7b19235d7f0371480fc679d
+PKG_MIRROR_HASH:=1ad44323f7803fdb5d1b2492d47e4b4b0fbc3d4c7c171b270422b10535c2a284
+PKG_SOURCE_DATE:=2025-10-02
+PKG_SOURCE_VERSION:=b14cf98c914d8582f18c7b263814797366fa185d
 
 PKG_MAINTAINER:=Hans Dedecker <dedeckeh@gmail.com>
 PKG_LICENSE:=GPL-2.0
@@ -29,7 +29,7 @@ define Package/odhcpd/default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=OpenWrt DHCPv6(-PD)/RA Server & Relay
-  DEPENDS:=+libubox +libuci +libubus +libnl-tiny
+  DEPENDS:=+libjson-c +libubox +libuci +libubus +libnl-tiny
 endef
 
 define Package/odhcpd/default/description

--- a/package/network/services/odhcpd/files/odhcpd.defaults
+++ b/package/network/services/odhcpd/files/odhcpd.defaults
@@ -1,5 +1,14 @@
 #!/bin/sh
-uci -q get dhcp.odhcpd && exit 0
+
+if [ -n "$(uci -q get dhcp.odhcpd)" ]; then
+	if [ -z "$(uci -q get dhcp.odhcpd.piofolder)" ]; then
+		uci set dhcp.odhcpd.piofolder=/tmp/odhcpd-piofolder
+		uci commit dhcp
+	fi
+
+	exit 0
+fi
+
 touch /etc/config/dhcp
 
 . /usr/share/libubox/jshn.sh
@@ -42,6 +51,7 @@ set dhcp.odhcpd.maindhcp=$ODHCPDONLY
 set dhcp.odhcpd.leasefile=/tmp/hosts/odhcpd
 set dhcp.odhcpd.leasetrigger=/usr/sbin/odhcpd-update
 set dhcp.odhcpd.loglevel=4
+set dhcp.odhcpd.piofolder=/tmp/odhcpd-piofolder
 set dhcp.lan.dhcpv4=$V4MODE
 set dhcp.lan.dhcpv6=$V6MODE
 set dhcp.lan.ra=$V6MODE


### PR DESCRIPTION
b14cf98 router: log “Sending a RA on lan” at LOG_DEBUG
c2810fe odhcpd: update cmake file
8c2c065 odhcpd: convert README to markdown
3b96480 odhcpd: allow the use of an alternative cfg file
7328bfe odhcpd: remove confusing #defines
cdb9e5b odhcpd: improve RFC9096 § 3.5 SLAAC compliance

RFC9096 § 3.5 SLAAC compliance introduces a new config option (odhcpd piofolder), which may wear out the flash under certain conditions (for example: ISPs with dynamic IPv6 prefixes which disconnect the clients every X hours).
Therefore, setting "dhcp.odhcpd.piofolder" to persistent storage in the router flash is not advisable and should be set to other kinds of persistent storage such as USBs, SDs, NVMEs...
In order to prevent wearing out the router flash it's set to ephemeral storage by default (tmp):
`uci set dhcp.odhcpd.piofolder="/tmp/odhcpd-piofolder"`

CC @dedeckeh @Alphix @systemcrash @biergaizi @efahl @GoetzGoerisch