### PR TITLE
iproute2: enable automatic color output by default

### DIFF
--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -172,7 +172,8 @@ CONFIGURE_VARS += \
 
 CONFIGURE_ARGS += \
 	--include_dir="$(TOOLCHAIN_ROOT_DIR)/usr/include" \
-	--libbpf_force=$(LIBBPF_FORCE)
+	--libbpf_force=$(LIBBPF_FORCE) \
+	--color=auto
 
 MAKE_FLAGS += \
 	SHARED_LIBS=$(SHARED_LIBS) \

--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -161,22 +161,23 @@ ifdef CONFIG_PACKAGE_rdma
   HAVE_MNL:=y
 endif
 
-# Disable built-in configure invocation.
-Build/Configure=
-
 TARGET_LDFLAGS += -Wl,--as-needed
 TARGET_CPPFLAGS += -I$(STAGING_DIR)/usr/include/libnl-tiny
 
-MAKE_FLAGS += \
-	KERNEL_INCLUDE="$(TOOLCHAIN_ROOT_DIR)/usr/include" \
-	SHARED_LIBS=$(SHARED_LIBS) \
-	IP_CONFIG_TINY=$(IP_CONFIG_TINY) \
-	BUILD_VARIANT=$(BUILD_VARIANT) \
-	LIBBPF_FORCE=$(LIBBPF_FORCE) \
+CONFIGURE_VARS += \
 	HAVE_ELF=$(HAVE_ELF) \
 	HAVE_MNL=$(HAVE_MNL) \
 	HAVE_CAP=$(HAVE_CAP) \
-	HAVE_TIRPC=n \
+	HAVE_TIRPC=n
+
+CONFIGURE_ARGS += \
+	--include_dir="$(TOOLCHAIN_ROOT_DIR)/usr/include" \
+	--libbpf_force=$(LIBBPF_FORCE)
+
+MAKE_FLAGS += \
+	SHARED_LIBS=$(SHARED_LIBS) \
+	IP_CONFIG_TINY=$(IP_CONFIG_TINY) \
+	BUILD_VARIANT=$(BUILD_VARIANT) \
 	IPT_LIB_DIR=/usr/lib/iptables \
 	XT_LIB_DIR=/usr/lib/iptables \
 	TC_CONFIG_XT=$(TC_CONFIG_XT) \

--- a/package/network/utils/iproute2/Makefile
+++ b/package/network/utils/iproute2/Makefile
@@ -161,10 +161,8 @@ ifdef CONFIG_PACKAGE_rdma
   HAVE_MNL:=y
 endif
 
-define Build/Configure
-	echo "static const char SNAPSHOT[] = \"$(PKG_VERSION)-$(PKG_RELEASE)-openwrt\";" \
-		> $(PKG_BUILD_DIR)/include/SNAPSHOT.h
-endef
+# Disable built-in configure invocation.
+Build/Configure=
 
 TARGET_LDFLAGS += -Wl,--as-needed
 TARGET_CPPFLAGS += -I$(STAGING_DIR)/usr/include/libnl-tiny


### PR DESCRIPTION
I got tired of typing `ip -c ...` and setting up aliases for it.

The first two commits are groundwork.

The last commit actually sets `-color=auto` by default. I'd be willing to write an option to make this configurable, but frankly I have no idea where a suitable place in menuconfig to put said option would be. A per-package option wouldn't really work since it's a configure-time decision, not an install-time decision. It can actually be made to work since we have enough build variants atm, but setting ourselves up to add more build variants just for color output seems... less than ideal.

That being said, I don't think there's really anyone who'd want to turn this off since you don't actually gain any space (color output for iproute2 is and was always compiled in). I might be wrong, but there's only one way to find that out.