### PR TITLE
rockchip: make use of OpenWrt compiled dtbs

### DIFF
--- a/target/linux/rockchip/image/Makefile
+++ b/target/linux/rockchip/image/Makefile
@@ -46,7 +46,7 @@ endef
 ### Devices ###
 define Device/Default
   PROFILES := Default
-  KERNEL = kernel-bin | lzma | fit lzma $$(DTS_DIR)/$$(DEVICE_DTS).dtb
+  KERNEL = kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   BOOT_SCRIPT :=
   IMAGES := sysupgrade.img.gz
   IMAGE/sysupgrade.img.gz = boot-common | boot-script $$(BOOT_SCRIPT) | pine64-img | gzip | append-metadata


### PR DESCRIPTION
OpenWrt buildroot will compile all dtbs defined in target to `$(KDIR)/image-$(DEVICE_DTS).dtb`,
so make use of it to allow us debug and use external dtbs easier without patching kernel Makefile.

This also fixes commit 5c724939c396 which forgot to update DTS_DIR in KERNEL variable.