### PR TITLE
mediatek: filogic: add support for Kebidumei AX3000-U22

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-kebidumei-ax3000-u22.dts
+++ b/target/linux/mediatek/dts/mt7981b-kebidumei-ax3000-u22.dts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "Kebidumei AX3000-U22";
+	compatible = "kebidumei,ax3000-u22", "mediatek,mt7981b";
+
+	aliases {
+		label-mac-device = &gmac1;
+
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x10000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-1 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-3 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	status = "okay";
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cells = <&macaddr_factory_e000 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&spi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bl2";
+				reg = <0x00000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "factory";
+				reg = <0x50000 0xb0000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_e000: macaddr@e000 {
+						compatible = "mac-base";
+						reg = <0xe000 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+				};
+			};
+
+			partition@100000 {
+				label = "fip";
+				reg = <0x100000 0x80000>;
+				read-only;
+			};
+
+			partition@180000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0x180000 0xe80000>;
+			};
+		};
+	};
+};
+
+&pio {
+	spi2_flash_pins: spi2-pins {
+		mux {
+			function = "spi";
+			groups = "spi2", "spi2_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -58,6 +58,7 @@ bananapi,bpi-r4-lite)
 	ucidef_set_led_netdev "sfp0" "sfp0" "green:sfp" "sfp0" "link tx rx"
 	;;
 cudy,re3000-v1|\
+kebidumei,ax3000-u22|\
 wavlink,wl-wn573hx3)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0" "link tx rx"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -107,6 +107,7 @@ mediatek_setup_interfaces()
 	cudy,ap3000outdoor-v1|\
 	cudy,ap3000-v1|\
 	cudy,re3000-v1|\
+	kebidumei,ax3000-u22|\
 	netgear,eax17|\
 	netgear,wax220|\
 	openfi,6c|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -157,6 +157,7 @@ platform_do_upgrade() {
 		;;
 	cudy,re3000-v1|\
 	cudy,wr3000-v1|\
+	kebidumei,ax3000-u22|\
 	totolink,x6000r|\
 	wavlink,wl-wn573hx3|\
 	widelantech,wap430x|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1616,6 +1616,21 @@ define Device/jdcloud_re-cp-03
 endef
 TARGET_DEVICES += jdcloud_re-cp-03
 
+define Device/kebidumei_ax3000-u22
+  DEVICE_VENDOR := Kebidumei
+  DEVICE_MODEL := AX3000-U22
+  DEVICE_DTS := mt7981b-kebidumei-ax3000-u22
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x43f00000
+  IMAGE_SIZE := 14848k
+  KERNEL_LOADADDR := 0x44000000
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-nor-rfb
+endef
+TARGET_DEVICES += kebidumei_ax3000-u22
+
 define Device/keenetic_kn-1812-common
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7992-firmware kmod-usb3 \


### PR DESCRIPTION
![Kebidumei AX3000-U22](https://openwrt.org/_media/media/kebidumei_ax3000-u22.png)

Kebidumei AX3000-U22 is one of many clones of the same range extender that can be found on Aliexpress or other Chinese portals.

The easiest way to identify this model is by searching for "AX3000 Repeater" and picking the device that looks like mine [0].

Specification:
  - SoC:     MediaTek MT7981B (1.3 GHz)
  - RAM:     256 MB
  - Flash:   16 MB SPI NOR
  - Ports:   1 x 1 GbE
  - Antenna: 6 (2 fake)
  - WiFi:    MediaTek dual-band WiFi 6
    - 2.4 GHz: b/g/n/ax, MIMO 2x2
    - 5 GHz:   a/n/ac/ax, MIMO 2x2
  - Buttons: Reset & WPS
  - LEDs:    Ethernet (green), Status (red, green, blue)
  - Power:   110–240 V AC (internal PSU, board uses 12 V DC)
  - Serial:  unmarked connector on PCB
           [1: Vcc, 2: RX, 3: TX, 4: GND]

Install via OEM web UI:
1. Use reset button to perform factory reset.
2. Connect PC to LAN port and obtain DHCP address.
3. Upload the sysupgrade image via OEM firmware upgrade page, e.g. http://192.168.18.1/upgrade.html
4. After reboot, hold reset button to clear leftover vendor config.

Install via serial:
1. Connect serial console (115200 8N1).
2. Enter the console.
3. Backup mtd4 partition if you want to restore OEM FW later.
4. Download image.
5. Run 'sysupgrade -n'.

Revert to stock:
1. Run sysupgrade without keeping config using mtd4 backup.

[0] https://openwrt.org/_media/media/kebidumei_ax3000-u22.png

---


Decompiled original dts:

```c
/dts-v1/;

/ {
	#address-cells = <0x02>;
	#size-cells = <0x02>;
	compatible = "mediatek,mt7981-spim-nor-rfb";
	interrupt-parent = <0x01>;
	model = "MediaTek MT7981 RFB";

	adc@1100d000 {
		#io-channel-cells = <0x01>;
		clock-names = "main\032k";
		clocks = <0x02 0x2f 0x02 0x30>;
		compatible = "mediatek,mt7981-auxadc\0mediatek,mt7622-auxadc";
		phandle = <0x04>;
		reg = <0x00 0x1100d000 0x00 0x1000>;
	};

	ap2woccif@151A5000 {
		compatible = "mediatek,ap2woccif";
		interrupt-parent = <0x01>;
		interrupts = <0x00 0xd3 0x04 0x00 0xd4 0x04>;
		reg = <0x00 0x151a5000 0x00 0x1000 0x00 0x151ad000 0x00 0x1000>;
	};

	apmixedsys@1001E000 {
		#clock-cells = <0x01>;
		compatible = "mediatek,mt7981-apmixedsys\0syscon";
		phandle = <0x05>;
		reg = <0x00 0x1001e000 0x00 0x1000>;
	};

	audio-controller@11210000 {
		assigned-clock-parents = <0x08 0x10 0x08 0x12 0x08 0x10 0x08 0x12>;
		assigned-clocks = <0x08 0x65 0x08 0x66 0x08 0x67 0x08 0x68>;
		clock-names = "aud_bus_ck\0aud_26m_ck\0aud_l_ck\0aud_aud_ck\0aud_eg2_ck\0aud_sel";
		clocks = <0x02 0x12 0x02 0x13 0x02 0x14 0x02 0x15 0x02 0x16 0x08 0x65>;
		compatible = "mediatek,mt79xx-audio";
		interrupts = <0x00 0x6a 0x04>;
		reg = <0x00 0x11210000 0x00 0x9000>;
		status = "disabled";
	};

	chosen {
		bootargs = "console=ttyS0,115200n1 loglevel=8  \t\t\t\tearlycon=uart8250,mmio32,0x11002000";
	};

	clkitg {
		compatible = "simple-bus";

		bring-up {
			clock-names = "0\01\02\03\04\05\06\07\08\09\010\011\012\013\014\015\016\017\018\019\020\021\022\023\024\025\026\027\028\029\030\031\032\033\034\035\036\037\038\039\040\041\042\043\044\045\046\047\048\049\050\051\052\053\054\055\056\057\058\059\060\061\062\063\064\065\066\067\068\069\070\071\072\073\074\075\076\077\078\079\080\081\082\083\084\085\086\087\088\089\090\091\092\093\094\095\096\097\098\099\0100\0101\0102\0103\0104\0105\0106\0107\0108\0109\0110\0111\0112\0113\0114\0115\0116\0117\0118\0119\0120\0121\0122\0123\0124\0125\0126\0127\0128\0129\0130\0131\0132\0133\0134\0135\0136\0137\0138\0139\0140\0141\0142\0143\0144\0145\0146\0147\0148\0149\0150\0151\0152\0153\0154\0155\0156\0157\0158\0159\0160\0161\0162\0163\0164\0165\0166\0167\0168\0169\0170\0171\0172\0173\0174\0175\0176\0177\0178\0179\0180\0181\0182\0183";
			clocks = <0x05 0x00 0x05 0x01 0x05 0x02 0x05 0x03 0x05 0x04 0x05 0x05 0x05 0x06 0x05 0x07 0x09 0x00 0x1d 0x09 0x02 0x09 0x03 0x09 0x04 0x1d 0x09 0x06 0x09 0x07 0x1d 0x1d 0x1d 0x1d 0x09 0x0c 0x09 0x0d 0x09 0x0e 0x09 0x0f 0x09 0x10 0x09 0x11 0x1d 0x1d 0x1d 0x1d 0x1d 0x09 0x17 0x09 0x18 0x09 0x1a 0x09 0x1b 0x09 0x1c 0x09 0x1d 0x09 0x1e 0x09 0x1f 0x09 0x20 0x09 0x21 0x1d 0x09 0x23 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x02 0x0b 0x1d 0x1d 0x1d 0x1d 0x02 0x11 0x1d 0x1d 0x1d 0x1d 0x1d 0x02 0x17 0x1d 0x02 0x19 0x02 0x1a 0x02 0x1b 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x1d 0x02 0x2a 0x02 0x2b 0x02 0x2c 0x02 0x2d 0x02 0x2e 0x1d 0x1d 0x02 0x31 0x02 0x32 0x02 0x33 0x02 0x34 0x02 0x35 0x02 0x36 0x02 0x37 0x1d 0x1d 0x1d 0x08 0x01 0x1d 0x08 0x05 0x08 0x06 0x08 0x07 0x08 0x04 0x08 0x09 0x08 0x0c 0x08 0x0f 0x08 0x10 0x08 0x12 0x08 0x14 0x08 0x15 0x08 0x16 0x08 0x17 0x08 0x19 0x08 0x1a 0x1d 0x08 0x1d 0x08 0x1e 0x08 0x21 0x1d 0x08 0x24 0x08 0x25 0x1d 0x08 0x29 0x08 0x26 0x08 0x2b 0x08 0x2a 0x1d 0x08 0x31 0x1d 0x1d 0x1d 0x08 0x56 0x08 0x37 0x08 0x3d 0x08 0x3e 0x08 0x3f 0x08 0x45 0x08 0x41 0x08 0x46 0x08 0x47 0x08 0x48 0x08 0x49 0x08 0x4a 0x08 0x3a 0x1d 0x1d 0x1d 0x1d 0x08 0x52 0x1d 0x1d 0x1d 0x08 0x56 0x08 0x57 0x08 0x58 0x08 0x59 0x08 0x5a 0x08 0x5b 0x08 0x5c 0x08 0x5d 0x08 0x5e 0x08 0x5f 0x1d 0x1d 0x08 0x62 0x08 0x5e 0x1d 0x08 0x64 0x08 0x56 0x08 0x69 0x08 0x6a 0x08 0x6b 0x08 0x6c>;
			compatible = "mediatek,clk-bring-up";
		};
	};

	consys@10000000 {
		compatible = "mediatek,mt7981-consys";
		memory-region = <0x17>;
		reg = <0x00 0x10000000 0x00 0x8600000>;
	};

	cpus {
		#address-cells = <0x01>;
		#size-cells = <0x00>;

		cpu@0 {
			compatible = "arm,cortex-a53";
			device_type = "cpu";
			enable-method = "psci";
			reg = <0x00>;
		};

		cpu@1 {
			compatible = "arm,cortex-a53";
			device_type = "cpu";
			enable-method = "psci";
			reg = <0x01>;
		};
	};

	crypto@10320000 {
		assigned-clock-parents = <0x08 0x15>;
		assigned-clocks = <0x08 0x63>;
		clock-names = "top_eip97_ck";
		clocks = <0x08 0x42>;
		compatible = "inside-secure,safexcel-eip97";
		interrupt-names = "ring0\0ring1\0ring2\0ring3";
		interrupts = <0x00 0x74 0x04 0x00 0x75 0x04 0x00 0x76 0x04 0x00 0x77 0x04>;
		reg = <0x00 0x10320000 0x00 0x40000>;
	};

	dummy_gpt_clk {
		#clock-cells = <0x00>;
		clock-frequency = <0x1312d00>;
		compatible = "fixed-clock";
	};

	dummy_system_clk {
		#clock-cells = <0x00>;
		clock-frequency = <0x2625a00>;
		compatible = "fixed-clock";
		phandle = <0x19>;
	};

	efuse@11f20000 {
		#address-cells = <0x01>;
		#size-cells = <0x01>;
		compatible = "mediatek,efuse";
		reg = <0x00 0x11f20000 0x00 0x1000>;

		calib@274 {
			phandle = <0x06>;
			reg = <0x274 0x0c>;
		};

		calib@8dc {
			phandle = <0x13>;
			reg = <0x8dc 0x10>;
		};

		usb3-intr@8c9 {
			bits = <0x02 0x06>;
			phandle = <0x1a>;
			reg = <0x8c9 0x01>;
		};

		usb3-rx-imp@8c8 {
			bits = <0x00 0x05>;
			phandle = <0x1b>;
			reg = <0x8c8 0x01>;
		};

		usb3-tx-imp@8c8 {
			bits = <0x05 0x05>;
			phandle = <0x1c>;
			reg = <0x8c8 0x02>;
		};
	};

	ethernet@15100000 {
		#address-cells = <0x01>;
		#reset-cells = <0x01>;
		#size-cells = <0x00>;
		assigned-clock-parents = <0x08 0x1b 0x08 0x22>;
		assigned-clocks = <0x08 0x60 0x08 0x61>;
		clock-names = "fe\0gp2\0gp1\0wocpu0\0sgmii_tx250m\0sgmii_rx250m\0sgmii_cdr_ref\0sgmii_cdr_fb\0sgmii2_tx250m\0sgmii2_rx250m\0sgmii2_cdr_ref\0sgmii2_cdr_fb";
		clocks = <0x0d 0x00 0x0d 0x01 0x0d 0x02 0x0d 0x03 0x0e 0x00 0x0e 0x01 0x0e 0x02 0x0e 0x03 0x0f 0x00 0x0f 0x01 0x0f 0x02 0x0f 0x03>;
		compatible = "mediatek,mt7981-eth";
		interrupts = <0x00 0xbd 0x04 0x00 0xbe 0x04 0x00 0xbf 0x04 0x00 0xc0 0x04 0x00 0xc4 0x04 0x00 0xc5 0x04 0x00 0xc6 0x04 0x00 0xc7 0x04>;
		mediatek,ethsys = <0x0d>;
		mediatek,infracfg = <0x10>;
		mediatek,sgmiisys = <0x0e 0x0f>;
		reg = <0x00 0x15100000 0x00 0x80000>;
		status = "okay";

		mac@0 {
			compatible = "mediatek,eth-mac";
			mtd-mac-address = <0x11 0xe000>;
			phandle = <0x14>;
			phy-mode = "2500base-x";
			reg = <0x00>;

			fixed-link {
				full-duplex;
				pause;
				speed = <0x9c4>;
			};
		};

		mac@1 {
			compatible = "mediatek,eth-mac";
			mtd-mac-address = <0x11 0xe006>;
			phy-handle = <0x12>;
			phy-mode = "gmii";
			reg = <0x01>;
		};

		mdio-bus {
			#address-cells = <0x01>;
			#size-cells = <0x00>;

			ethernet-phy@0 {
				compatible = "ethernet-phy-id03a2.9461";
				nvmem-cell-names = "phy-cal-data";
				nvmem-cells = <0x13>;
				phandle = <0x12>;
				phy-mode = "gmii";
				reg = <0x00>;
			};

			switch@0 {
				compatible = "mediatek,mt7531";
				reg = <0x1f>;
				reset-gpios = <0x0c 0x27 0x00>;

				ports {
					#address-cells = <0x01>;
					#size-cells = <0x00>;

					port@0 {
						label = "lan1";
						reg = <0x00>;
					};

					port@1 {
						label = "lan2";
						reg = <0x01>;
					};

					port@2 {
						label = "lan3";
						reg = <0x02>;
					};

					port@3 {
						label = "lan4";
						reg = <0x03>;
					};

					port@6 {
						ethernet = <0x14>;
						label = "cpu";
						phy-mode = "2500base-x";
						reg = <0x06>;

						fixed-link {
							full-duplex;
							pause;
							speed = <0x9c4>;
						};
					};
				};
			};
		};
	};

	gpio-keys {
		compatible = "gpio-keys";

		reset {
			gpios = <0x0c 0x01 0x01>;
			label = "reset";
			linux,code = <0x198>;
		};

		wps {
			gpios = <0x0c 0x00 0x00>;
			label = "wps";
			linux,code = <0x211>;
		};
	};

	hnat@15000000 {
		compatible = "mediatek,mtk-hnat_v4";
		mtketh-lan = "lan";
		mtketh-max-gmac = <0x02>;
		mtketh-wan = "eth1";
		reg = <0x00 0x15100000 0x00 0x80000>;
		reset-names = "mtketh";
		resets = <0x0d 0x00>;
		status = "okay";
	};

	i2c@11007000 {
		#address-cells = <0x01>;
		#size-cells = <0x00>;
		clock-div = <0x01>;
		clock-names = "main\0dma";
		clocks = <0x02 0x1d 0x02 0x19>;
		compatible = "mediatek,mt7981-i2c";
		interrupts = <0x00 0x88 0x04>;
		reg = <0x00 0x11007000 0x00 0x1000 0x00 0x10217080 0x00 0x80>;
		status = "disabled";
	};

	ice_debug {
		clock-names = "ice_dbg";
		clocks = <0x02 0x18>;
		compatible = "mediatek,mt7981-ice_debug\0mediatek,mt2701-ice_debug";
	};

	infracfg@10001040 {
		#clock-cells = <0x01>;
		compatible = "mediatek,mt7981-infracfg\0syscon";
		phandle = <0x09>;
		reg = <0x00 0x10001068 0x00 0x1000>;
	};

	infracfg_ao@10001000 {
		#clock-cells = <0x01>;
		compatible = "mediatek,mt7981-infracfg_ao\0syscon";
		phandle = <0x02>;
		reg = <0x00 0x10001000 0x00 0x68>;
	};

	interrupt-controller@c000000 {
		#interrupt-cells = <0x03>;
		compatible = "arm,gic-v3";
		interrupt-controller;
		interrupt-parent = <0x01>;
		interrupts = <0x01 0x09 0x04>;
		phandle = <0x01>;
		reg = <0x00 0xc000000 0x00 0x40000 0x00 0xc080000 0x00 0x200000>;
	};

	leds {
		compatible = "gpio-leds";

		ethwan {
			gpios = <0x0c 0x06 0x01>;
			label = "bfros:pio:ethwan";
		};

		led1 {
			gpios = <0x0c 0x08 0x00>;
			label = "bfros:pio:red";
		};

		led2 {
			gpios = <0x0c 0x23 0x01>;
			label = "bfros:pio:blue";
		};

		led3 {
			gpios = <0x0c 0x22 0x01>;
			label = "bfros:pio:green";
		};
	};

	memory {
		reg = <0x00 0x40000000 0x00 0x10000000>;
	};

	mmc@11230000 {
		assigned-clock-parents = <0x08 0x02 0x08 0x1c>;
		assigned-clocks = <0x08 0x54 0x08 0x55>;
		clock-names = "source\0hclk\0source_cg";
		clocks = <0x08 0x33 0x08 0x34 0x02 0x2b>;
		compatible = "mediatek,mt7986-mmc\0mediatek,mt7981-mmc";
		interrupts = <0x00 0x8f 0x04>;
		reg = <0x00 0x11230000 0x00 0x1000 0x00 0x11c20000 0x00 0x1000>;
		status = "disabled";
	};

	oscillator@0 {
		#clock-cells = <0x00>;
		clock-frequency = <0x2625a00>;
		clock-output-names = "clkxtal";
		compatible = "fixed-clock";
		phandle = <0x1d>;
	};

	pcie@11280000 {
		#address-cells = <0x03>;
		#interrupt-cells = <0x01>;
		#size-cells = <0x02>;
		bus-range = <0x00 0xff>;
		clocks = <0x02 0x38 0x02 0x39 0x02 0x3a 0x02 0x3b>;
		compatible = "mediatek,mt7981-pcie\0mediatek,mt7986-pcie";
		device_type = "pci";
		interrupt-map = <0x00 0x00 0x00 0x01 0x0b 0x00 0x00 0x00 0x00 0x02 0x0b 0x01 0x00 0x00 0x00 0x03 0x0b 0x02 0x00 0x00 0x00 0x04 0x0b 0x03>;
		interrupt-map-mask = <0x00 0x00 0x00 0x07>;
		interrupts = <0x00 0xa8 0x04>;
		phy-names = "pcie-phy";
		phys = <0x0a 0x02>;
		ranges = <0x82000000 0x00 0x20000000 0x00 0x20000000 0x00 0x10000000>;
		reg = <0x00 0x11280000 0x00 0x4000>;
		reg-names = "pcie-mac";
		status = "disabled";

		interrupt-controller {
			#address-cells = <0x00>;
			#interrupt-cells = <0x01>;
			interrupt-controller;
			phandle = <0x0b>;
		};
	};

	pinctrl@11d00000 {
		#gpio-cells = <0x02>;
		#interrupt-cells = <0x02>;
		compatible = "mediatek,mt7981-pinctrl";
		gpio-controller;
		gpio-ranges = <0x0c 0x00 0x00 0x38>;
		interrupt-controller;
		interrupt-parent = <0x01>;
		interrupts = <0x00 0xe1 0x04>;
		phandle = <0x0c>;
		reg = <0x00 0x11d00000 0x00 0x1000 0x00 0x11c00000 0x00 0x1000 0x00 0x11c10000 0x00 0x1000 0x00 0x11d20000 0x00 0x1000 0x00 0x11e00000 0x00 0x1000 0x00 0x11e20000 0x00 0x1000 0x00 0x11f00000 0x00 0x1000 0x00 0x11f10000 0x00 0x1000 0x00 0x1000b000 0x00 0x1000>;
		reg-names = "gpio_base\0iocfg_rt_base\0iocfg_rm_base\0iocfg_rb_base\0iocfg_lb_base\0iocfg_bl_base\0iocfg_tm_base\0iocfg_tl_base\0eint";

		spi1-pins {
			phandle = <0x15>;

			mux {
				function = "spi";
				groups = "spi1_1";
			};
		};

		spi2-pins {
			phandle = <0x16>;

			conf-pd {
				bias-pull-down = <0x67>;
				drive-strength = <0x08>;
				pins = "SPI2_CLK\0SPI2_MOSI\0SPI2_MISO";
			};

			conf-pu {
				bias-pull-up = <0x67>;
				drive-strength = <0x08>;
				pins = "SPI2_CS\0SPI2_HOLD\0SPI2_WP";
			};

			mux {
				function = "spi";
				groups = "spi2\0spi2_wp_hold";
			};
		};
	};

	psci {
		compatible = "arm,psci-0.2";
		method = "smc";
	};

	pwm@10048000 {
		#pwm-cells = <0x02>;
		clock-names = "top\0main\0pwm1\0pwm2\0pwm3";
		clocks = <0x02 0x0d 0x02 0x0c 0x02 0x0e 0x02 0x0f 0x02 0x10>;
		compatible = "mediatek,mt7981-pwm";
		reg = <0x00 0x10048000 0x00 0x1000>;
	};

	regulator-3p3v {
		compatible = "regulator-fixed";
		regulator-always-on;
		regulator-boot-on;
		regulator-max-microvolt = <0x325aa0>;
		regulator-min-microvolt = <0x325aa0>;
		regulator-name = "fixed-3.3V";
	};

	reserved-memory {
		#address-cells = <0x02>;
		#size-cells = <0x02>;
		ranges;

		secmon@43000000 {
			no-map;
			reg = <0x00 0x43000000 0x00 0x80000>;
		};

		wmcpu-reserved@47C80000 {
			compatible = "mediatek,wmcpu-reserved";
			no-map;
			phandle = <0x17>;
			reg = <0x00 0x47c80000 0x00 0x100000>;
		};

		wocpu0_emi@47D80000 {
			compatible = "mediatek,wocpu0_emi";
			no-map;
			reg = <0x00 0x47d80000 0x00 0x40000>;
			shared = <0x00>;
		};

		wocpu_data@47DC0000 {
			compatible = "mediatek,wocpu_data";
			no-map;
			reg = <0x00 0x47dc0000 0x00 0x240000>;
			shared = <0x01>;
		};
	};

	serial@11002000 {
		assigned-clock-parents = <0x08 0x00 0x09 0x01>;
		assigned-clocks = <0x08 0x50 0x02 0x00>;
		clocks = <0x02 0x1e>;
		compatible = "mediatek,mt6577-uart";
		interrupts = <0x00 0x7b 0x04>;
		reg = <0x00 0x11002000 0x00 0x400>;
		status = "okay";
	};

	serial@11003000 {
		assigned-clock-parents = <0x08 0x00 0x09 0x01>;
		assigned-clocks = <0x08 0x50 0x02 0x01>;
		clocks = <0x02 0x1f>;
		compatible = "mediatek,mt6577-uart";
		interrupts = <0x00 0x7c 0x04>;
		reg = <0x00 0x11003000 0x00 0x400>;
		status = "disabled";
	};

	serial@11004000 {
		assigned-clock-parents = <0x08 0x00 0x09 0x01>;
		assigned-clocks = <0x08 0x50 0x02 0x02>;
		clocks = <0x02 0x20>;
		compatible = "mediatek,mt6577-uart";
		interrupts = <0x00 0x7d 0x04>;
		reg = <0x00 0x11004000 0x00 0x400>;
		status = "disabled";
	};

	snfi@11005000 {
		#address-cells = <0x01>;
		#size-cells = <0x00>;
		assigned-clock-parents = <0x08 0x06 0x08 0x06>;
		assigned-clocks = <0x08 0x4d 0x08 0x4c>;
		clock-names = "pad_clk\0nfi_clk\0nfi_hclk";
		clocks = <0x02 0x24 0x02 0x23 0x02 0x25>;
		compatible = "mediatek,mt7986-snand";
		interrupts = <0x00 0x79 0x04>;
		reg = <0x00 0x11005000 0x00 0x1000 0x00 0x11006000 0x00 0x1000>;
		reg-names = "nfi\0ecc";
		status = "disabled";
	};

	spi@11009000 {
		clock-names = "parent-clk\0sel-clk\0spi-clk\0spi-hclk";
		clocks = <0x08 0x02 0x08 0x4e 0x02 0x21 0x02 0x22>;
		compatible = "mediatek,ipm-spi-quad";
		interrupts = <0x00 0x8e 0x04>;
		pinctrl-0 = <0x16>;
		pinctrl-names = "default";
		reg = <0x00 0x11009000 0x00 0x100>;
		status = "okay";

		spi_nor@0 {
			#address-cells = <0x01>;
			#size-cells = <0x01>;
			compatible = "jedec,spi-nor";
			reg = <0x00>;
			spi-cal-addr = <0x00>;
			spi-cal-addrlen = <0x01>;
			spi-cal-data = [53 46 5f 42 4f 4f 54];
			spi-cal-datalen = <0x07>;
			spi-cal-enable;
			spi-cal-mode = "read-data";
			spi-max-frequency = <0x3197500>;
			spi-rx-bus-width = <0x04>;
			spi-tx-bus-width = <0x04>;

			partition@00000 {
				label = "BL2";
				reg = <0x00 0x40000>;
			};

			partition@100000 {
				label = "FIP";
				reg = <0x100000 0x80000>;
			};

			partition@180000 {
				label = "firmware";
				reg = <0x180000 0xe80000>;
			};

			partition@40000 {
				label = "u-boot-env";
				reg = <0x40000 0x10000>;
			};

			partition@50000 {
				label = "Factory";
				phandle = <0x11>;
				reg = <0x50000 0xb0000>;
			};
		};
	};

	spi@1100a000 {
		clock-names = "parent-clk\0sel-clk\0spi-clk\0spi-hclk";
		clocks = <0x08 0x02 0x08 0x4e 0x02 0x26 0x02 0x28>;
		compatible = "mediatek,ipm-spi-quad";
		interrupts = <0x00 0x8c 0x04>;
		reg = <0x00 0x1100a000 0x00 0x100>;
		status = "disabled";
	};

	spi@1100b000 {
		clock-names = "parent-clk\0sel-clk\0spi-clk\0spi-hclk";
		clocks = <0x08 0x02 0x08 0x4f 0x02 0x27 0x02 0x29>;
		compatible = "mediatek,ipm-spi-single";
		interrupts = <0x00 0x8d 0x04>;
		pinctrl-0 = <0x15>;
		pinctrl-names = "default";
		reg = <0x00 0x1100b000 0x00 0x100>;
		status = "disabled";
	};

	syscon@10060000 {
		#clock-cells = <0x01>;
		compatible = "mediatek,mt7981-sgmiisys_0\0syscon";
		phandle = <0x0e>;
		pn_swap;
		reg = <0x00 0x10060000 0x00 0x1000>;
	};

	syscon@10070000 {
		#clock-cells = <0x01>;
		compatible = "mediatek,mt7981-sgmiisys_1\0syscon";
		phandle = <0x0f>;
		reg = <0x00 0x10070000 0x00 0x1000>;
	};

	syscon@15000000 {
		#address-cells = <0x01>;
		#clock-cells = <0x01>;
		#reset-cells = <0x01>;
		#size-cells = <0x01>;
		compatible = "mediatek,mt7981-ethsys\0syscon";
		phandle = <0x0d>;
		reg = <0x00 0x15000000 0x00 0x1000>;

		reset-controller {
			#reset-cells = <0x01>;
			compatible = "ti,syscon-reset";
			phandle = <0x07>;
			ti,reset-bits = <0x34 0x04 0x34 0x04 0x34 0x04 0x28>;
		};
	};

	thermal-zones {

		cpu-thermal {
			polling-delay = <0x3e8>;
			polling-delay-passive = <0x3e8>;
			thermal-sensors = <0x03 0x00>;
		};
	};

	thermal@1100c800 {
		#thermal-sensor-cells = <0x01>;
		clock-names = "therm\0auxadc\0adc_32k";
		clocks = <0x02 0x1c 0x02 0x2f 0x02 0x30>;
		compatible = "mediatek,mt7981-thermal";
		interrupts = <0x00 0x8a 0x04>;
		mediatek,apmixedsys = <0x05>;
		mediatek,auxadc = <0x04>;
		nvmem-cell-names = "calibration-data";
		nvmem-cells = <0x06>;
		phandle = <0x03>;
		reg = <0x00 0x1100c800 0x00 0x800>;
	};

	timer {
		clock-frequency = <0xc65d40>;
		compatible = "arm,armv8-timer";
		interrupt-parent = <0x01>;
		interrupts = <0x01 0x0d 0x08 0x01 0x0e 0x08 0x01 0x0b 0x08 0x01 0x0a 0x08>;
	};

	topckgen@1001B000 {
		#clock-cells = <0x01>;
		compatible = "mediatek,mt7981-topckgen\0syscon";
		phandle = <0x08>;
		reg = <0x00 0x1001b000 0x00 0x1000>;
	};

	topmisc@11d10000 {
		#clock-cells = <0x01>;
		compatible = "mediatek,mt7981-topmisc\0syscon";
		phandle = <0x10>;
		reg = <0x00 0x11d10000 0x00 0x10000>;
	};

	trng@1020f000 {
		compatible = "mediatek,mt7981-rng";
	};

	usb-phy@11e10000 {
		#address-cells = <0x02>;
		#size-cells = <0x02>;
		compatible = "mediatek,mt7986\0mediatek,generic-tphy-v2";
		ranges;
		status = "okay";

		usb-phy@11e10000 {
			#phy-cells = <0x01>;
			clock-names = "ref";
			clocks = <0x19>;
			phandle = <0x18>;
			reg = <0x00 0x11e10000 0x00 0x700>;
			status = "okay";
		};

		usb-phy@11e10700 {
			#phy-cells = <0x01>;
			clock-names = "ref";
			clocks = <0x19>;
			mediatek,syscon-type = <0x10 0x218 0x00>;
			nvmem-cell-names = "intr\0rx_imp\0tx_imp";
			nvmem-cells = <0x1a 0x1b 0x1c>;
			phandle = <0x0a>;
			reg = <0x00 0x11e10700 0x00 0x900>;
			status = "okay";
		};
	};

	watchdog@1001c000 {
		#reset-cells = <0x01>;
		compatible = "mediatek,mt7622-wdt\0mediatek,mt6589-wdt";
		interrupts = <0x00 0x6e 0x04>;
		reg = <0x00 0x1001c000 0x00 0x1000>;
		status = "okay";
	};

	wbsys@18000000 {
		chip_id = <0x7981>;
		compatible = "mediatek,wbsys";
		interrupts = <0x00 0xd5 0x04 0x00 0xd6 0x04 0x00 0xd7 0x04 0x00 0xd8 0x04>;
		reg = <0x00 0x18000000 0x00 0x1000000>;
	};

	wdma@15104800 {
		compatible = "mediatek,wed-wdma";
		reg = <0x00 0x15104800 0x00 0x400 0x00 0x15104c00 0x00 0x400>;
	};

	wed@15010000 {
		compatible = "mediatek,wed";
		dy_txbm_budget = <0x08>;
		dy_txbm_enable = "true";
		interrupt-parent = <0x01>;
		interrupts = <0x00 0xcd 0x04 0x00 0xce 0x04>;
		pci_slot_map = <0x00 0x01>;
		reg = <0x00 0x15010000 0x00 0x1000 0x00 0x15011000 0x00 0x1000>;
		status = "okay";
		txbm_init_sz = <0x08>;
		txbm_max_sz = <0x20>;
		wed_num = <0x02>;
	};

	wed_pcie@10003000 {
		compatible = "mediatek,wed_pcie";
		reg = <0x00 0x10003000 0x00 0x10>;
	};

	wocpu0_ilm@151E0000 {
		compatible = "mediatek,wocpu0_ilm";
		reg = <0x00 0x151e0000 0x00 0x8000>;
	};

	wocpu_boot@15194000 {
		compatible = "mediatek,wocpu_boot";
		reg = <0x00 0x15194000 0x00 0x1000>;
	};

	wocpu_dlm@151E8000 {
		compatible = "mediatek,wocpu_dlm";
		reg = <0x00 0x151e8000 0x00 0x2000 0x00 0x151f8000 0x00 0x2000>;
		reset-names = "wocpu_rst";
		resets = <0x07 0x00>;
	};

	xhci@11200000 {
		#address-cells = <0x02>;
		#size-cells = <0x02>;
		clock-names = "sys_ck\0xhci_ck\0ref_ck\0mcu_ck\0dma_ck";
		clocks = <0x19 0x19 0x19 0x19 0x19>;
		compatible = "mediatek,mt7986-xhci\0mediatek,mtk-xhci";
		interrupts = <0x00 0xad 0x04>;
		mediatek,u3p-dis-msk = <0x01>;
		phys = <0x18 0x03>;
		reg = <0x00 0x11200000 0x00 0x2e00 0x00 0x11203e00 0x00 0x100>;
		reg-names = "mac\0ippc";
		status = "okay";
	};
};

```