### PR TITLE
toplevel.mk: use relative path for feeds/base symlink

### DIFF
--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -78,7 +78,7 @@ _ignore = $(foreach p,$(IGNORE_PACKAGES),--ignore $(p))
 prepare-tmpinfo: FORCE
 	@+$(MAKE) -r -s $(STAGING_DIR_HOST)/.prereq-build $(PREP_MK)
 	mkdir -p tmp/info feeds
-	[ -e $(TOPDIR)/feeds/base ] || ln -sf $(TOPDIR)/package $(TOPDIR)/feeds/base
+	[ -e $(TOPDIR)/feeds/base ] || ln -sf ../package $(TOPDIR)/feeds/base
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="packageinfo" SCAN_DIR="package" SCAN_NAME="package" SCAN_DEPTH=5 SCAN_EXTRA=""
 	$(_SINGLE)$(NO_TRACE_MAKE) -j1 -r -s -f include/scan.mk SCAN_TARGET="targetinfo" SCAN_DIR="target/linux" SCAN_NAME="target" SCAN_DEPTH=3 SCAN_EXTRA="" SCAN_MAKEOPTS="TARGET_BUILD=1"
 	for type in package target; do \


### PR DESCRIPTION
Currently, feeds/base is created as an absolute symlink to $(TOPDIR)/package.
If the OpenWrt source tree is copied to another location for building (while keeping the old tree), the symlink will still point to the package directory in the old tree.
Using a relative symlink ensures that feeds/base always points to the package directory within the current OpenWrt source tree, improving portability and avoiding incorrect links.
