### PR TITLE
ath79: buffalo: use nvmem for calibration

### DIFF
--- a/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
+++ b/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
@@ -165,6 +165,14 @@
 						reg = <0x520c 0x6>;
 						#nvmem-cell-cells = <1>;
 					};
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0xeb8>;
+					};
+
+					cal_art_5000: calibration@5000 {
+						reg = <0x5000 0xeb8>;
+					};
 				};
 			};
 
@@ -201,7 +209,8 @@
 	ath9k0: wifi@11,0 {
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
-		qca,no-eeprom;
+		nvmem-cells = <&cal_art_1000>;
+		nvmem-cell-names = "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
 	};
@@ -209,7 +218,8 @@
 	ath9k1: wifi@12,0 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
-		qca,no-eeprom;
+		nvmem-cells = <&cal_art_5000>;
+		nvmem-cell-names = "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
 	};

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g450h.dts
@@ -74,9 +74,8 @@
 	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_1002>;
-		nvmem-cell-names = "mac-address";
-		qca,no-eeprom;
+		nvmem-cells = <&cal_art_1000>;
+		nvmem-cell-names = "calibration";
 		#gpio-cells = <2>;
 		gpio-controller;
 		qca,tx-gain-buffalo;
@@ -88,6 +87,10 @@
 		compatible = "fixed-layout";
 		#address-cells = <1>;
 		#size-cells = <1>;
+
+		cal_art_1000: calibration@1000 {
+			reg = <0x1000 0x440>;
+		};
 
 		macaddr_art_1002: macaddr@1002 {
 			reg = <0x1002 0x6>;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -47,9 +47,6 @@ case "$FIRMWARE" in
 	avm,fritz300e)
 		caldata_extract_reverse "urloader" 0x1541 0x440
 		;;
-	buffalo,wzr-hp-g450h)
-		caldata_extract "art" 0x1000 0x440
-		;;
 	enterasys,ws-ap3705i)
 		caldata_extract "calibrate" 0x5000 0x440
 		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env0 RADIOADDR0)
@@ -72,10 +69,6 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:11.0.bin")
 	case $board in
-	buffalo,wzr-600dhp|\
-	buffalo,wzr-hp-ag300h)
-		caldata_extract "art" 0x1000 0xeb8
-		;;
 	meraki,mr16)
 		caldata_extract "art" 0x11000 0xeb8
 		;;
@@ -86,10 +79,6 @@ case "$FIRMWARE" in
 	;;
 "ath9k-eeprom-pci-0000:00:12.0.bin")
 	case $board in
-	buffalo,wzr-600dhp|\
-	buffalo,wzr-hp-ag300h)
-		caldata_extract "art" 0x5000 0xeb8
-		;;
 	meraki,mr16)
 		caldata_extract "art" 0x15000 0xeb8
 		;;


### PR DESCRIPTION
Userspace handling is deprecated.