### PR TITLE
realtek: dts: rearrange mdio-bus for tplink_sg2xxx

### DIFF
--- a/target/linux/realtek/dts/rtl8380_tplink_sg2xxx.dtsi
+++ b/target/linux/realtek/dts/rtl8380_tplink_sg2xxx.dtsi
@@ -134,27 +134,23 @@
 	};
 };
 
+&mdio_bus0 {
+	INTERNAL_PHY(8)
+	INTERNAL_PHY(9)
+	INTERNAL_PHY(10)
+	INTERNAL_PHY(11)
+	INTERNAL_PHY(12)
+	INTERNAL_PHY(13)
+	INTERNAL_PHY(14)
+	INTERNAL_PHY(15)
+
+	INTERNAL_PHY(24)
+	INTERNAL_PHY(26)
+};
+
 &ethernet0 {
 	nvmem-cells = <&factory_macaddr>;
 	nvmem-cell-names = "mac-address";
-
-	mdio: mdio-bus {
-		compatible = "realtek,rtl838x-mdio";
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		INTERNAL_PHY(8)
-		INTERNAL_PHY(9)
-		INTERNAL_PHY(10)
-		INTERNAL_PHY(11)
-		INTERNAL_PHY(12)
-		INTERNAL_PHY(13)
-		INTERNAL_PHY(14)
-		INTERNAL_PHY(15)
-
-		INTERNAL_PHY(24)
-		INTERNAL_PHY(26)
-	};
 };
 
 &switch0 {


### PR DESCRIPTION
This appears to have been missed in #19986.