### PR TITLE
[openwrt-24.10] mediatek: filogic: fix for new GL.iNet GL-MT2500/GL-MT2500A hardware revision

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v1.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7981b-glinet-gl-mt2500.dtsi"
+
+&gmac0 {
+	phy-handle = <&phy5>;
+};
+
+&mdio_bus {
+	phy5: ethernet-phy@5 {
+		reg = <5>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v2.dts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7981b-glinet-gl-mt2500.dtsi"
+
+&gmac0 {
+	phy-handle = <&phy13>;
+};
+
+&mdio_bus {
+	phy13: ethernet-phy@13 {
+		reg = <13>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dtsi
@@ -108,7 +108,6 @@
 		reg = <0>;
 
 		phy-mode = "2500base-x";
-		phy-handle = <&phy5>;
 	};
 
 	gmac1: mac@1 {
@@ -125,11 +124,6 @@
 	reset-gpios = <&pio 14 GPIO_ACTIVE_LOW>;
 	reset-delay-us = <600>;
 	reset-post-delay-us = <20000>;
-
-	phy5: ethernet-phy@5 {
-		reg = <5>;
-		compatible = "ethernet-phy-ieee802.3-c45";
-	};
 };
 
 &usb_phy {

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -927,15 +927,30 @@ TARGET_DEVICES += gatonetworks_gdsp
 define Device/glinet_gl-mt2500
   DEVICE_VENDOR := GL.iNet
   DEVICE_MODEL := GL-MT2500
-  DEVICE_DTS := mt7981b-glinet-gl-mt2500
+  DEVICE_VARIANT := MaxLinear PHY
+  DEVICE_DTS := mt7981b-glinet-gl-mt2500-v1
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTS_LOADADDR := 0x47000000
   DEVICE_PACKAGES := -wpad-basic-mbedtls e2fsprogs f2fsck mkf2fs kmod-usb3
-  SUPPORTED_DEVICES += glinet,mt2500-emmc
+  SUPPORTED_DEVICES += glinet,mt2500-emmc glinet,gl-mt2500-airoha
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
 endef
 TARGET_DEVICES += glinet_gl-mt2500
+
+define Device/glinet_gl-mt2500-airoha
+  DEVICE_VENDOR := GL.iNet
+  DEVICE_MODEL := GL-MT2500
+  DEVICE_VARIANT := Airoha PHY
+  DEVICE_DTS := mt7981b-glinet-gl-mt2500-v2
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  DEVICE_PACKAGES := -wpad-basic-mbedtls e2fsprogs f2fsck mkf2fs kmod-usb3 kmod-phy-airoha-en8811h airoha-en8811h-firmware
+  SUPPORTED_DEVICES += glinet,mt2500-emmc glinet,gl-mt2500
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
+endef
+TARGET_DEVICES += glinet_gl-mt2500-airoha
 
 define Device/glinet_gl-mt3000
   DEVICE_VENDOR := GL.iNet


### PR DESCRIPTION
GL.iNet shipped a hardware change of the WAN PHY going from the MaxLinear GPY211C to the Airoha EN8811H.

Cherry picked from commit 8d30e07180367cdeb4affd79adead6e1025355c9.