### PR TITLE
ramips: add support for Zyxel NWA90AX access point

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -228,8 +228,9 @@ define Build/zytrx-header
 endef
 
 define Build/zyxel-nwa-fit
+	# "77 e1" is NWA90AX
 	$(TOPDIR)/scripts/mkits-zyxel-fit.sh \
-		$@.its $@ "6b e1 6f e1 ff ff ff ff ff ff"
+		$@.its $@ "6b e1 6f e1 77 e1 ff ff ff ff"
 	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
 	@mv $@.new $@
 endef
@@ -3717,6 +3718,8 @@ endef
 define Device/zyxel_nwa50ax
   $(Device/zyxel_nwa-ax)
   DEVICE_MODEL := NWA50AX
+  DEVICE_ALT0_VENDOR := Zyxel
+  DEVICE_ALT0_MODEL := NWA90AX
 endef
 TARGET_DEVICES += zyxel_nwa50ax
 


### PR DESCRIPTION
The NWA90AX is hardware-wise identical to the NWA50AX which is already supported.

The NWA90AX magic model code bytes are `77 E1`, and they are added to the DTS to mark the NWA50AX firmware as being compatible with the 90 model.

Without the compat-models change, uploading the OpenWrt NWA50AX firmware with the official Zyxel web interface yields an error:
> errno: -25007
> errmsg: Firmware content error!

As described on the NWA50AX firmware page[1] on the wiki, the "current image" slot for firmware updates has to be "1". If it is 0, flashing will fail.

[1] https://openwrt.org/toh/zyxel/nwa50ax

Vendor product page:
https://www.zyxel.com/global/en/products/wireless/ax1800-4-stream-wifi-6-dual-radio-nebulaflex-access-point-nwa90ax

Vendor support page stating that the hardware is identical: https://support.zyxel.eu/hc/en-us/articles/4416989548178-Access-Point-NWA50-55AXEE-90AX-110AX-210AX-Differences-in-Hardware-and-Features
> NWA90AX: Identical hardware as in NWA50AX, but with added features
> like Captive portal for Guest access and WPA Enterprise for
> AD/Radius (Credential) authentication.

