### PR TITLE
rules.mk: do not set CCACHE_NOHASHDIR

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -349,7 +349,6 @@ ifneq ($(CONFIG_CCACHE),)
   TARGET_CXX:= ccache $(TARGET_CXX)
   HOSTCC:= ccache $(HOSTCC)
   HOSTCXX:= ccache $(HOSTCXX)
-  export CCACHE_NOHASHDIR:=true
   export CCACHE_NOCOMPRESS:=true
   export CCACHE_BASEDIR:=$(TOPDIR)
   export CCACHE_DIR:=$(if $(call qstrip,$(CONFIG_CCACHE_DIR)),$(call qstrip,$(CONFIG_CCACHE_DIR)),$(TOPDIR)/.ccache)


### PR DESCRIPTION
Not hashing CWD is potentially unsafe since it involves deliberately poisoning the cache in certain situations in exchange for performance gain. It can lead to debug information pointing out either no longer existing or much worse incorrect source files, possibly leading developers onto a false track and wasting a lot of time.

If one wishes to save build time by sharing the cache between multiple source trees, this can be achieved safely by enabling reproducible debug information, like this:

CONFIG_CCACHE_DIR="$(HOME)/.ccache"
CONFIG_REPRODUCIBLE_DEBUG_INFO=y

Note that CWD hashing gets disabled implicitly when reproducible debug information is enabled. The CCACHE_NOHASHDIR option is only for disabling CWD hashing in cases where it is not safe to do so.
