### PR TITLE
ipq806x: fix wifi node addresses

### DIFF
--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-eax500.dtsi
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-eax500.dtsi
@@ -53,22 +53,36 @@
 
 	max-link-speed = <1>;
 
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&precal_art_1000>;
-		nvmem-cell-names = "pre-calibration";
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+			nvmem-cells = <&precal_art_1000>;
+			nvmem-cell-names = "pre-calibration";
+		};
 	};
 };
 
 &pcie1 {
 	status = "okay";
 
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&precal_art_5000>;
-		nvmem-cell-names = "pre-calibration";
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+			nvmem-cells = <&precal_art_5000>;
+			nvmem-cell-names = "pre-calibration";
+		};
 	};
 };
 

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
@@ -283,22 +283,38 @@
 &pcie0 {
 	status = "okay";
 
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_eeprom_6 1>;
-		nvmem-cell-names = "mac-address";
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_eeprom_6 1>;
+			nvmem-cell-names = "mac-address";
+		};
 	};
 };
 
 &pcie1 {
 	status = "okay";
 
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_eeprom_6 2>;
-		nvmem-cell-names = "mac-address";
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_eeprom_6 2>;
+			nvmem-cell-names = "mac-address";
+		};
 	};
 };
 


### PR DESCRIPTION
In the conversion to nvmem of eax500 and unifi-ac-hd, the address was set to 0 as is the case with most platforms, but not this one.

Matches every other device in ipq806x.

Fixes: 148f82ad4525 ("ipq806x: use nvmem for wifi mac")

ping @hauke @robimarko 