### PR TITLE
realtek: rtl930x: add TP-Link TL-ST5008

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -54,7 +54,8 @@ plasmacloud,psx28|\
 tplink,sg2008p-v1|\
 tplink,sg2210p-v3|\
 tplink,sg2452p-v4|\
-tplink,t1600g-28ts-v3)
+tplink,t1600g-28ts-v3|\
+tplink,tl-st5008)
 	label_mac=$(get_mac_label)
 	lan_mac="$label_mac"
 	;;

--- a/target/linux/realtek/dts/rtl9303_tplink_tl-st5008.dts
+++ b/target/linux/realtek/dts/rtl9303_tplink_tl-st5008.dts
@@ -1,0 +1,516 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/thermal/thermal.h>
+
+/ {
+	compatible = "tplink,tl-st5008", "realtek,rtl930x-soc";
+	model = "TP-Link TL-ST5008";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* first 256 MiB */
+		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+	};
+
+	aliases {
+		led-boot = &led_sys_red;
+		led-failsafe = &led_master_yellow;
+		led-running = &led_sys_green;
+		led-upgrade = &led_stack;
+		label-mac-device = &ethernet0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-mode {
+			label = "mode";
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
+			debounce-interval = <50>;
+			linux,code = <BTN_0>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>, <&pinmux_enable_usb_led>;
+
+		led_master_green: led-master-green {
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		led_master_yellow: led-master-yellow {
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_YELLOW>;
+		};
+
+		led_stack: led-stack {
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		led_sys_red: led-system-red {
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_BOOT;
+		};
+
+		led_sys_green: led-system-green {
+			gpios = <&gpio0 17 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+
+		led_set0 = <(RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			     (RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			     (RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT)>;
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1200>;
+		always-running;
+	};
+
+	thermal-zones {
+		phy0-thermal {
+			/* Poll every 10 seconds */
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy0>;
+
+			trips {
+				phy0_trip0: phy0-trip0 {
+					/* At 80 degrees turn on fan */
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+
+				phy0-trip1 {
+					/* At 108 degrees phys exceed spec */
+					temperature = <108000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&phy0_trip0>;
+					cooling-device = <&chassis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+
+		phy8-thermal {
+			/* Poll every 10 seconds */
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy8>;
+
+			trips {
+				phy8_trip0: phy8-trip0 {
+					/* At 80 degrees turn on fan */
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+
+				phy8-trip1 {
+					/* At 108 degrees phys exceed spec */
+					temperature = <108000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&phy8_trip0>;
+					cooling-device = <&chassis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+
+		phy16-thermal {
+			/* Poll every 10 seconds */
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy16>;
+
+			trips {
+				phy16_trip0: phy16-trip0 {
+					/* At 80 degrees turn on fan */
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+
+				phy16-trip1 {
+					/* At 108 degrees phys exceed spec */
+					temperature = <108000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&phy16_trip0>;
+					cooling-device = <&chassis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+
+		phy20-thermal {
+			/* Poll every 10 seconds */
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy20>;
+
+			trips {
+				phy20_trip0: phy20-trip0 {
+					/* At 80 degrees turn on fan */
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+
+				phy20-trip1 {
+					/* At 108 degrees phys exceed spec */
+					temperature = <108000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&phy20_trip0>;
+					cooling-device = <&chassis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+
+		phy24-thermal {
+			/* Poll every 10 seconds */
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy24>;
+
+			trips {
+				phy24_trip0: phy24-trip0 {
+					/* At 80 degrees turn on fan */
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+
+				phy24-trip1 {
+					/* At 108 degrees phys exceed spec */
+					temperature = <108000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&phy24_trip0>;
+					cooling-device = <&chassis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+
+		phy25-thermal {
+			/* Poll every 10 seconds */
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy25>;
+
+			trips {
+				phy25_trip0: phy25-trip0 {
+					/* At 80 degrees turn on fan */
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+
+				phy25-trip1 {
+					/* At 108 degrees phys exceed spec */
+					temperature = <108000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&phy25_trip0>;
+					cooling-device = <&chassis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+
+		phy26-thermal {
+			/* Poll every 10 seconds */
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy26>;
+
+			trips {
+				phy26_trip0: phy26-trip0 {
+					/* At 80 degrees turn on fan */
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+
+				phy26-trip1 {
+					/* At 108 degrees phys exceed spec */
+					temperature = <108000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&phy26_trip0>;
+					cooling-device = <&chassis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+
+		phy27-thermal {
+			/* Poll every 10 seconds */
+			polling-delay-passive = <10000>;
+			polling-delay = <10000>;
+			thermal-sensors = <&phy27>;
+
+			trips {
+				phy27_trip0: phy27-trip0 {
+					/* At 80 degrees turn on fan */
+					temperature = <80000>;
+					hysteresis = <1000>;
+					type = "active";
+				};
+
+				phy27-trip1 {
+					/* At 108 degrees phys exceed spec */
+					temperature = <108000>;
+					hysteresis = <5000>;
+					type = "critical";
+				};
+			};
+
+			cooling-maps {
+				map {
+					trip = <&phy27_trip0>;
+					cooling-device = <&chassis_fan THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+				};
+			};
+		};
+	};
+
+	chassis_fan: gpio-fan {
+		compatible = "gpio-fan";
+		gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>, <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		alarm-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		gpio-fan,speed-map = <0 0>, <1 1>, <2 2>, <3 3>;
+		#cooling-cells = <2>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <100000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x20000>;
+			};
+
+			partition@100000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x100000 0x1e00000>;
+				openwrt,ih-magic = <0x93030000>;
+			};
+
+			partition@1f00000 {
+				label = "para";
+				reg = <0x1f00000 0x100000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					factory_macaddr: macaddr@fdff4 {
+						reg = <0xfdff4 0x6>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&factory_macaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_bus0 {
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <0 0>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	phy8: ethernet-phy@8 {
+		reg = <8>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <0 1>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	phy16: ethernet-phy@16 {
+		reg = <16>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <1 2>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	phy20: ethernet-phy@20 {
+		reg = <20>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <1 3>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	phy24: ethernet-phy@24 {
+		reg = <24>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <2 4>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	phy25: ethernet-phy@25 {
+		reg = <25>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <2 5>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	phy26: ethernet-phy@26 {
+		reg = <26>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <3 6>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	phy27: ethernet-phy@27 {
+		reg = <27>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <3 7>;
+		#thermal-sensor-cells = <0>;
+	};
+};
+
+&serdes2 {
+	realtek,pnswap-tx;
+};
+
+&serdes3 {
+	realtek,pnswap-rx;
+};
+
+&serdes4 {
+	realtek,pnswap-tx;
+};
+
+&serdes5 {
+	realtek,pnswap-rx;
+};
+
+&serdes6 {
+	realtek,pnswap-tx;
+};
+
+&serdes7 {
+	realtek,pnswap-rx;
+};
+
+&serdes8 {
+	realtek,pnswap-tx;
+};
+
+&serdes9 {
+	realtek,pnswap-rx;
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_SDS(0, 1, 2, usxgmii)
+		SWITCH_PORT_SDS(8, 2, 3, usxgmii)
+		SWITCH_PORT_SDS(16, 3, 4, usxgmii)
+		SWITCH_PORT_SDS(20, 4, 5, usxgmii)
+		SWITCH_PORT_SDS(24, 5, 6, usxgmii)
+		SWITCH_PORT_SDS(25, 6, 7, usxgmii)
+		SWITCH_PORT_SDS(26, 7, 8, usxgmii)
+		SWITCH_PORT_SDS(27, 8, 9, usxgmii)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -382,6 +382,14 @@ static int __init rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 				return -ENODEV;
 			}
 		}
+		
+		if (pcs_node) {
+			priv->ports[pn].swap_rx_polarity = of_property_read_bool(pcs_node, "realtek,pnswap-rx");
+			priv->ports[pn].swap_tx_polarity = of_property_read_bool(pcs_node, "realtek,pnswap-tx");
+		} else {
+			priv->ports[pn].swap_rx_polarity = false;
+			priv->ports[pn].swap_tx_polarity = false;
+		}
 
 		/* Check for the integrated SerDes of the RTL8380M first */
 		if (of_property_read_bool(phy_node, "phy-is-integrated")

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -759,7 +759,9 @@ static void rtl93xx_phylink_mac_config(struct dsa_switch *ds, int port,
 	     state->interface == PHY_INTERFACE_MODE_SGMII ||
 	     state->interface == PHY_INTERFACE_MODE_2500BASEX ||
 	     state->interface == PHY_INTERFACE_MODE_10GBASER))
-		rtl9300_serdes_setup(port, sds_num, state->interface);
+		rtl9300_serdes_setup(port, sds_num, state->interface,
+				     priv->ports[port].swap_rx_polarity,
+				     priv->ports[port].swap_tx_polarity);
 }
 
 static void rtl83xx_phylink_mac_link_down(struct dsa_switch *ds, int port,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -691,6 +691,8 @@ struct rtl838x_port {
 	int sds_num;
 	int led_set;
 	int leds_on_this_port;
+	bool swap_rx_polarity:1;
+	bool swap_tx_polarity:1;
 	struct rtldsa_counter_state counters;
 	const struct dsa_port *dp;
 };

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -179,7 +179,8 @@ irqreturn_t rtldsa_930x_switch_irq(int irq, void *dev_id);
 irqreturn_t rtl839x_switch_irq(int irq, void *dev_id);
 void rtl930x_vlan_profile_dump(int index);
 int rtl9300_sds_power(int mac, int val);
-extern int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode);
+extern int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode,
+				bool swap_rx_polarity, bool swap_tx_polarity);
 void rtl930x_print_matrix(void);
 
 /* RTL931x-specific */

--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
@@ -2355,7 +2355,8 @@ static int rtl9300_sds_10g_idle(int sds_num);
 static void rtsds_930x_patch_serdes(int sds, phy_interface_t mode);
 
 #define RTL930X_MAC_FORCE_MODE_CTRL		(0xCA1C)
-int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode)
+int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode,
+			 bool swap_rx_polarity, bool swap_tx_polarity)
 {
 	int calib_tries = 0;
 
@@ -2378,7 +2379,7 @@ int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode)
 	pr_info("%s: Configuring RTL9300 SERDES %d\n", __func__, sds_num);
 
 	/* Configure link to MAC */
-	rtl9300_serdes_mac_link_config(sds_num, true, true);	/* MAC Construct */
+	rtl9300_serdes_mac_link_config(sds_num, !swap_tx_polarity, !swap_rx_polarity);	/* MAC Construct */
 
 	/* Re-Enable MAC */
 	sw_w32_mask(1, 0, RTL930X_MAC_FORCE_MODE_CTRL + 4 * port);

--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.h
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.h
@@ -59,7 +59,8 @@ struct __attribute__ ((__packed__)) fw_header {
 #define RTL931X_PS_SERDES_OFF_MODE_CTRL_ADDR	(0x13F4)
 #define RTL931X_MAC_SERDES_MODE_CTRL(sds)	(0x136C + (((sds) << 2)))
 
-int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode);
+int rtl9300_serdes_setup(int port, int sds_num, phy_interface_t phy_mode,
+			 bool swap_rx_polarity, bool swap_tx_polarity);
 
 int rtl931x_sds_cmu_band_get(int sds, phy_interface_t mode);
 void rtl931x_sds_init(u32 sds, phy_interface_t mode);

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -53,6 +53,17 @@ define Device/tplink_tl-st1008f-v2
 endef
 TARGET_DEVICES += tplink_tl-st1008f-v2
 
+define Device/tplink_tl-st5008
+  SOC := rtl9303
+  UIMAGE_MAGIC := 0x93030000
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := TL-ST5008
+  DEVICE_PACKAGES := kmod-hwmon-gpiofan kmod-thermal
+  IMAGE_SIZE := 30720k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += tplink_tl-st5008
+
 define Device/vimin_vm-s100-0800ms
   SOC := rtl9303
   UIMAGE_MAGIC := 0x93000000


### PR DESCRIPTION
To run openwrt you need to install a patched uboot.
Luckily there's a bug in the uboot tftp update implementation that can be exploited to do just that.
Will be documented on the wiki.

Depends: https://github.com/openwrt/openwrt/pull/20450