### PR TITLE
econet: Add Nokia G-240G-E and EN751221 recovery image

### DIFF
--- a/target/linux/econet/base-files/sbin/en75_chboot
+++ b/target/linux/econet/base-files/sbin/en75_chboot
@@ -9,6 +9,7 @@ block_size=
 code_openwrt=
 code_factory=
 code_offset=
+read_mask=
 
 read_nand() {
     dd "if=$part" "of=$file" "bs=$block_size" "skip=$offset_blocks" count=1 2>/dev/null
@@ -29,6 +30,24 @@ part_named() {
     echo "/dev/$pn"
 }
 
+mask() {
+    if [ -z "$2" ]; then
+        echo "$1"
+        return
+    fi
+    echo "$1 $2" | awk '{
+        a=$1; b=$2;
+        res="";
+        for(i=1;i<=length(a);i++){
+            abit=substr(a,i,1);
+            bbit=substr(b,i,1);
+            if(bbit=="X") res=res""abit;
+            else res=res"0";
+        }
+        print res;
+    }'
+}
+
 to_hex() {
     hexdump -v -e '1/1 "%02x"'
 }
@@ -38,16 +57,19 @@ from_hex() {
 }
 
 check() {
-    stored_code=$(dd \
+    local stored_code=$(dd \
         "if=$part" \
         bs=1 \
         skip=$((offset_blocks * block_size + code_offset)) \
         count=$((${#code_openwrt} / 2)) \
             2>/dev/null | to_hex
     )
-    if [ "$stored_code" = "$code_openwrt" ]; then
+    stored_code=$(mask "$stored_code" "$read_mask")
+    local code_owrt=$(mask "$code_openwrt" "$read_mask")
+    local code_fact=$(mask "$code_factory" "$read_mask")
+    if [ "$stored_code" = "$code_owrt" ]; then
         echo "Current boot flag set to OS A (OpenWrt)"
-    elif [ "$stored_code" = "$code_factory" ]; then
+    elif [ "$stored_code" = "$code_fact" ]; then
         echo "Current boot flag set to OS B (Factory)"
     else
         echo "Current boot flag unknown: $stored_code"
@@ -86,6 +108,14 @@ main() {
         code_offset=0
         code_openwrt=0000000101000002
         code_factory=0000000101010003
+    elif [ "$machine" = "Nokia G-240G-E" ]; then
+        part=$(part_named '"flag"')
+        offset_blocks=0
+        block_size=$((1024 * 128))
+        code_offset=0
+        code_openwrt=000000000000000000000001000000010000000000000000
+        code_factory=000000000000000100000001000000010000000000000000
+           read_mask=000000000000000X00000000000000000000000000000000
     elif [ "$machine" = "SmartFiber XP8421-B" ]; then
         # 0dfc0000
         part=$(part_named '"reservearea"')

--- a/target/linux/econet/dts/en751221_generic.dts
+++ b/target/linux/econet/dts/en751221_generic.dts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+
+#include "en751221.dtsi"
+
+/ {
+	model = "Generic EN751221";
+	compatible = "econet,en751221";
+
+	memory@0 {
+		// We hope at least 64MB will be available on every device
+		device_type = "memory";
+		reg = <0x00000000 0x4000000>;
+	};
+
+	chosen {
+		stdout-path = "/serial@1fbf0000:115200";
+		linux,usable-memory-range = <0x00020000 0x3fe0000>;
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@1 {
+			// We don't know how big the flash is
+			// Put 1GB and let it truncate
+			label = "all_flash";
+			reg = <0x0 0x40000000>;
+			read-only;
+		};
+
+		partition@2 {
+			// We don't know how big the bootloader
+			// is, but when we're doing testing, lets
+			// make sure nobody touches anything below 4MB
+			label = "bootloader";
+			reg = <0x0 0x00400000>;
+			read-only;
+		};
+
+		partition@3 {
+			label = "rest_of_flash";
+			reg = <0x00400000 0x40000000>;
+		};
+	};
+};

--- a/target/linux/econet/dts/en751221_nokia_g240g-e.dts
+++ b/target/linux/econet/dts/en751221_nokia_g240g-e.dts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include "en751221.dtsi"
+
+/ {
+	model = "Nokia G-240G-E";
+	compatible = "nokia,g240g-e", "econet,en751221";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>;
+	};
+
+	chosen {
+		stdout-path = "/serial@1fbf0000:115200";
+		linux,usable-memory-range = <0x00020000 0x0ffe0000>;
+	};
+};
+
+&nand {
+	status = "okay";
+	econet,bmt;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootloader";
+			reg = <0x00000000 0x00040000>;
+			read-only;
+		};
+
+		partition@40000 {
+			// Unused
+			label = "romfile";
+			reg = <0x00040000 0x00040000>;
+		};
+
+		partition@80000 {
+			// trx - OpenWRT kernel is 4MB, factory is 3MB
+			label = "kernel";
+			reg = <0x00080000 0x00400000>;
+		};
+
+		partition@380000 {
+			// squashfs
+			label = "rootfs";
+			reg = <0x00480000 0x01F00000>;
+			linux,rootfs;
+		};
+
+		partition@2280000 {
+			// trx
+			label = "kernel_slave";
+			reg = <0x02280000 0x00300000>;
+		};
+
+		partition@2580000 {
+			// squashfs
+			label = "rootfs_slave";
+			reg = <0x02580000 0x01F00000>;
+		};
+
+		partition@4480000 {
+			// trx
+			label = "kernel_oflt";
+			reg = <0x04480000 0x00300000>;
+		};
+
+		partition@4780000 {
+			// squashfs
+			label = "rootfs_oflt";
+			reg = <0x04780000 0x00C00000>;
+		};
+
+		partition@5380000 {
+			// UBI
+			label = "config";
+			reg = <0x05380000 0x00800000>;
+		};
+
+		partition@5b80000 {
+			// UBI
+			label = "log";
+			reg = <0x05b80000 0x00C00000>;
+		};
+
+		partition@6780000 {
+			// UBI / unused
+			label = "extfs";
+			reg = <0x06780000 0x00600000>;
+		};
+
+		partition@6d80000 {
+			// binary
+			label = "bosa";
+			reg = <0x06d80000 0x00040000>;
+		};
+
+		partition@6dc0000 {
+			label = "flag";
+			reg = <0x06dc0000 0x00040000>;
+		};
+
+		partition@6e00000 {
+			label = "flagback";
+			reg = <0x06e00000 0x00040000>;
+		};
+
+		partition@6e40000 {
+			label = "ri";
+			reg = <0x06e40000 0x00040000>;
+		};
+
+		partition@6e80000 {
+			label = "riback";
+			reg = <0x06e80000 0x00040000>;
+		};
+	};
+};

--- a/target/linux/econet/image/en751221.mk
+++ b/target/linux/econet/image/en751221.mk
@@ -1,3 +1,22 @@
+define Device/en751221_generic
+  DEVICE_VENDOR := EN751221 Family
+  DEVICE_MODEL := Initramfs Image
+  DEVICE_TITLE := EN751221 Initramfs Image
+  DEVICE_DESCRIPTION := In-memory build for testing and recovery of EN751221 SoCs
+  DEVICE_DTS := en751221_generic
+endef
+TARGET_DEVICES += en751221_generic
+
+define Device/nokia_g240g-e
+  DEVICE_VENDOR := Nokia
+  DEVICE_MODEL := G-240G-E
+  DEVICE_DTS := en751221_nokia_g240g-e
+  IMAGES := tclinux.trx
+  IMAGE/tclinux.trx := append-kernel | lzma | tclinux-trx
+  DEVICE_PACKAGES := kmod-usb3
+endef
+TARGET_DEVICES += nokia_g240g-e
+
 define Device/smartfiber_xp8421-b
   DEVICE_VENDOR := SmartFiber
   DEVICE_MODEL := XP8421-B


### PR DESCRIPTION
The Nokia G-240G-E is an xPON device with an EN7526G, 256M of memory and 128M of flash. It has 1 USB2 port as well as phone and ethernet but no wifi. Flashing instructions are per the typical process using xmodem in the bootloader. This and other things are described here: https://openwrt.org/inbox/toh/bt/g-240g-e_1

In addition, a generic image is offered, this image can be loaded into memory from within the bootloader and launched directly. It is recommended on the wiki of G-240G-E and other EcoNet devices to be used for backing up the flash before flashing OpenWRT.