### PR TITLE
wifi-scripts: ucode: fix airtime_mode with hostapd-mini

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -483,7 +483,8 @@ function generate(config) {
 	append_vars(config, [ 'noscan' ]);
 
 	/* airtime */
-	append_vars(config, [ 'airtime_mode' ]);
+	if (config.airtime_mode)
+		append_vars(config, [ 'airtime_mode' ]);
 
 	/* assoc/thresholds */
 	append_vars(config, [ 'rssi_reject_assoc_rssi', 'rssi_ignore_probe_request', 'iface_max_num_sta', 'no_probe_resp_if_max_sta' ]);


### PR DESCRIPTION
Currently wifi-scripts ucode appends airtime_mode to hostapd config file unconditionally.
However this breaks bringing up interface with hostapd-mini because the mini variant doesn't support airtime policy.

Fix this by changing the script to append airtime_mode only when airtime_mode is set to greater than zero value in /etc/config/wireless.

Fixes: #20136
Fixes: #20314
