### PR TITLE
package: do not sign individual APK packages

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -408,8 +408,7 @@ else
 	  $$(APK_SCRIPTS_$(1)) \
 	  --info "depends:$$(foreach depends,$$(subst $$(comma),$$(space),$$(subst $$(space),,$$(subst $$(paren_right),,$$(subst $$(paren_left),,$$(Package/$(1)/DEPENDS))))),$$(depends))" \
 	  --files "$$(IDIR_$(1))" \
-	  --output "$$(PACK_$(1))" \
-	  --sign "$(BUILD_KEY_APK_SEC)"
+	  --output "$$(PACK_$(1))"
 endif
 
 	@[ -f $$(PACK_$(1)) ]

--- a/package/Makefile
+++ b/package/Makefile
@@ -70,7 +70,8 @@ ifneq ($(CONFIG_USE_APK),)
 	(cd $(PACKAGE_DIR_ALL) && $(STAGING_DIR_HOST)/bin/apk mkndx \
 			--root $(TOPDIR) \
 			--keys-dir $(TOPDIR) \
-			--sign $(BUILD_KEY_APK_SEC) \
+			--allow-untrusted \
+			$(if $(CONFIG_SIGNED_PACKAGES),--sign $(BUILD_KEY_APK_SEC),) \
 			--output packages.adb \
 			*.apk; \
 	)
@@ -100,6 +101,7 @@ ifneq ($(CONFIG_USE_APK),)
 	    $(foreach pkg,$(shell cat $(PACKAGE_INSTALL_FILES) 2>/dev/null),$(pkg)$(call GetABISuffix,$(pkg))))
 	$(call apk,$(TARGET_DIR)) add --no-cache --initdb --no-scripts --arch $(ARCH_PACKAGES) \
 		--repositories-file /dev/null --repository file://$(PACKAGE_DIR_ALL)/packages.adb \
+		$(if $(CONFIG_SIGNED_PACKAGES),,--allow-untrusted) \
 		$$(cat $(TMP_DIR)/apk_install_list) \
 			"base-files=$(shell cat $(TMP_DIR)/base-files.version)" \
 			"libc=$(shell cat $(TMP_DIR)/libc.version)" \
@@ -133,7 +135,8 @@ ifneq ($(CONFIG_USE_APK),)
 		$(STAGING_DIR_HOST)/bin/apk mkndx \
 			--root $(TOPDIR) \
 			--keys-dir $(TOPDIR) \
-			--sign $(BUILD_KEY_APK_SEC) \
+			--allow-untrusted \
+			$(if $(CONFIG_SIGNED_PACKAGES),--sign $(BUILD_KEY_APK_SEC),) \
 			--output packages.adb \
 			*.apk; \
 		$(STAGING_DIR_HOST)/bin/apk adbdump --format json packages.adb | \


### PR DESCRIPTION
APK, unlike OPKG, can sign individual packages and not just indexes. Since OpenWrt uses a distributed build infrastructure and only the build master owns the private keys, signing of individual buildworkers doesn't work. Right now, each buildworker creates a temporary build key to sign packages, then transmits the package index to the buildmaster for a signature.

As a result, all individual packages contain a nonsensical signature, making them harder to reproduce. This commit removes the individual package signing.

Since APK requires signatures per default, explicitly allow installation of unsigned packages during the build process.

The config option here is for historical reasons misleading, SIGNED_PACKAGES refers to the package index, not the individual packages.