### PR TITLE
prereq: use staging_dir's compiler

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -237,7 +237,7 @@ endif
 
 $(STAGING_DIR_HOST)/bin/mkhash: $(SCRIPT_DIR)/mkhash.c
 	mkdir -p $(dir $@)
-	$(CC) -O2 -I$(TOPDIR)/tools/include -o $@ $<
+	$(STAGING_DIR_HOST)/bin/gcc -O2 -I$(TOPDIR)/tools/include -o $@ $<
 
 $(STAGING_DIR_HOST)/bin/xxd: $(SCRIPT_DIR)/xxdi.pl
 	$(LN) $< $@

--- a/include/prereq.mk
+++ b/include/prereq.mk
@@ -71,7 +71,7 @@ endef
 # 4: optional link library test (example -lncurses)
 define RequireCHeader
   define Require/$(1)
-    echo 'int main(int argc, char **argv) { $(3); return 0; }' | gcc -include $(1) -x c -o $(TMP_DIR)/a.out - $(4)
+    echo 'int main(int argc, char **argv) { $(3); return 0; }' | $(STAGING_DIR_HOST)/bin/gcc -include $(1) -x c -o $(TMP_DIR)/a.out - $(4)
   endef
 
   $$(eval $$(call Require,$(1),$(2)))


### PR DESCRIPTION
Fixes compilation with missing OS GCC.

ping @hauke @robimarko 