### PR TITLE
treewide: fixup ath10k nodes

### DIFF
--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
@@ -213,7 +213,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5170000 5350000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-ea8300.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-ea8300.dts
@@ -94,7 +94,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5490000 5835000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
@@ -204,7 +204,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cell-names = "pre-calibration";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-fritzrepeater-3000.dts
@@ -236,8 +236,8 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
-		/* QCA9984 */
+	/* QCA9984 */
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5470000 5875000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-gl-b2200.dts
@@ -337,8 +337,8 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
-		/* Bootlog shows this is a 168c:0056 - QCA 9888v2 */
+	/* Bootlog shows this is a 168c:0056 - QCA 9888v2 */
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5450000 5900000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
@@ -474,7 +474,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5170000 5350000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lhgg-60ad.dts
@@ -231,7 +231,7 @@
 
 &pcie_bridge0 {
 	/* wil6210 802.11ad card */
-	wifi@0,0 {
+	wifi@1,0 {
 		/* wil6210 driver has no compatible */
 		reg = <0x00010000 0 0 0 0>;
 	};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
@@ -244,7 +244,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5170000 5350000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -473,7 +473,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cell-names = "pre-calibration", "mac-address";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
@@ -424,7 +424,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cell-names = "mac-address";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mr8300.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mr8300.dts
@@ -80,7 +80,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5490000 5835000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -314,7 +314,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5470000 5875000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
@@ -193,7 +193,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5170000 5350000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rt-ac42u.dts
@@ -312,7 +312,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-calibration-variant = "ASUS-RT-AC42U";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03.dts
@@ -65,7 +65,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5490000 5835000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03v2.dts
@@ -231,7 +231,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5490000 5835000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-wtr-m2133hp.dts
@@ -235,7 +235,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cell-names = "pre-calibration", "mac-address";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -304,7 +304,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&mac_address 1>, <&cal_factory_9000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr30h.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr30h.dts
@@ -109,9 +109,8 @@
 };
 
 &pcie_bridge0 {
-	wifi2: wifi@0,0 {
+	wifi2: wifi@1,0 {
 		compatible = "qcom,ath10k";
-		status = "okay";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&cal_factory_9000>;
 		nvmem-cell-names = "calibration";

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8062-wg2600hp3.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8062-wg2600hp3.dts
@@ -401,7 +401,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_PRODUCTDATA_12>, <&precal_ART_1000>;
@@ -416,7 +416,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <2400000 2483000>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-ad7200-c2600.dtsi
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-ad7200-c2600.dtsi
@@ -314,7 +314,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_defaultmac_8 (-1)>, <&precal_radio_1000>;
@@ -328,7 +328,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_defaultmac_8 0>, <&precal_radio_5000>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-d7800.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-d7800.dts
@@ -207,7 +207,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_6 1>, <&precal_art_1000>;
@@ -224,7 +224,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_6 2>, <&precal_art_5000>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-eax500.dtsi
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-eax500.dtsi
@@ -55,7 +55,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x10000 0 0 0 0>;
 		nvmem-cells = <&precal_art_1000>;
@@ -68,7 +68,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x10000 0 0 0 0>;
 		nvmem-cells = <&precal_art_5000>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-fap-421e.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-fap-421e.dts
@@ -342,7 +342,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_appsbl_7ff80 8>;
@@ -357,7 +357,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_appsbl_7ff80 16>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-g10.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-g10.dts
@@ -288,7 +288,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-calibration-variant = "ASRock-G10";
@@ -300,7 +300,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-calibration-variant = "ASRock-G10";

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-onhub.dtsi
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-onhub.dtsi
@@ -455,7 +455,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-sa-gpio = <2 3 4 0>;
@@ -468,7 +468,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-sa-gpio = <2 3 4 0>;
@@ -481,7 +481,7 @@
 };
 
 &pcie_bridge2 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 	};

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-r7500v2.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-r7500v2.dts
@@ -210,7 +210,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_6 1>, <&precal_art_1000>;
@@ -227,7 +227,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_6 2>, <&precal_art_5000>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
@@ -288,7 +288,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x10000 0 0 0 0>;
 		nvmem-cells = <&macaddr_eeprom_6 1>;
@@ -301,7 +301,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x10000 0 0 0 0>;
 		nvmem-cells = <&macaddr_eeprom_6 2>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-vr2600v.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-vr2600v.dts
@@ -342,7 +342,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_defaultmac_0 (-1)>, <&precal_ART_1000>;
@@ -356,7 +356,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_defaultmac_0 0>, <&precal_ART_5000>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-wg2600hp.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-wg2600hp.dts
@@ -461,7 +461,7 @@ switch@10 {
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_PRODUCTDATA_12>, <&precal_ART_1000>;
@@ -475,7 +475,7 @@ switch@10 {
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_PRODUCTDATA_c>, <&precal_ART_5000>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-wxr-2533dhp.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-wxr-2533dhp.dts
@@ -522,7 +522,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_ART_1e>, <&precal_ART_1000>;
@@ -536,7 +536,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&macaddr_ART_18>, <&precal_ART_5000>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-ac400i.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-ac400i.dts
@@ -197,7 +197,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-calibration-variant = "Nokia-AC400i";
@@ -213,7 +213,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-calibration-variant = "Nokia-AC400i";

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-nighthawk.dtsi
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-nighthawk.dtsi
@@ -543,7 +543,7 @@
 };
 
 &pcie_bridge0 {
-	wifi0: wifi@0,0 {
+	wifi0: wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 	};
@@ -556,7 +556,7 @@
 };
 
 &pcie_bridge1 {
-	wifi1: wifi@0,0 {
+	wifi1: wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 	};

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-rt4230w-rev6.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-rt4230w-rev6.dts
@@ -581,7 +581,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&precal_ART_1000>;
@@ -598,7 +598,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&precal_ART_5000>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-tr4400-v2.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-tr4400-v2.dts
@@ -479,7 +479,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&precal_ART_1000>, <&macaddr_fw_env_12>;
@@ -496,7 +496,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		nvmem-cells = <&precal_ART_5000>, <&macaddr_fw_env_c>;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-ap3935.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-ap3935.dts
@@ -258,7 +258,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 	};
@@ -272,7 +272,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 	};

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-cryptid-common.dtsi
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-cryptid-common.dtsi
@@ -75,7 +75,7 @@
 };
 
 &pcie_bridge0 {
-	wifi0: wifi@0,0 {
+	wifi0: wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 	};
@@ -86,7 +86,7 @@
 };
 
 &pcie_bridge1 {
-	wifi1: wifi@0,0 {
+	wifi1: wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 	};
@@ -97,7 +97,7 @@
 };
 
 &pcie_bridge2 {
-	wifi2: wifi@0,0 {
+	wifi2: wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 	};

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-ecw5410.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-ecw5410.dts
@@ -230,7 +230,7 @@
 };
 
 &pcie_bridge0 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-calibration-variant = "Edgecore-ECW5410-L";
@@ -246,7 +246,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-calibration-variant = "Edgecore-ECW5410-L";

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-ss-w2-ac2600.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-ss-w2-ac2600.dts
@@ -201,7 +201,7 @@
 };
 
 &pcie_bridge1 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-calibration-variant = "IgniteNet-SS-W2-AC2600";
@@ -215,7 +215,7 @@
 };
 
 &pcie_bridge2 {
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		qcom,ath10k-calibration-variant = "IgniteNet-SS-W2-AC2600";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
@@ -529,13 +529,9 @@
 	perst-gpios = <&tlmm 15 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
-		wifi@0,0 {
-			status = "okay";
-
-			/* QCN9074: ath11k lacks DT compatible for PCI cards */
+		wifi@1,0 {
 			compatible = "pci17cb,1104";
 			reg = <0x00010000 0 0 0 0>;
-
 			qcom,ath11k-calibration-variant = "Xiaomi-AX6000";
 		};
 	};
@@ -555,12 +551,9 @@
 	perst-gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
-		wifi@0,0 {
-			status = "okay";
-
+		wifi@1,0 {
 			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
-
 			qcom,ath10k-calibration-variant = "Xiaomi-AX6000";
 			nvmem-cell-names = "calibration";
 			nvmem-cells = <&caldata_qca9889>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mr5500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mr5500.dts
@@ -308,13 +308,9 @@
 	perst-gpios = <&tlmm 15 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
-		wifi@0,0 {
-			status = "okay";
-
-			/* QCN9074: ath11k lacks DT compatible for PCI cards */
+		wifi@1,0 {
 			compatible = "pci17cb,1104";
 			reg = <0x00010000 0 0 0 0>;
-
 			qcom,ath11k-calibration-variant = "Linksys-MR5500";
 		};
 	};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx5500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx5500.dts
@@ -155,13 +155,9 @@
 	perst-gpios = <&tlmm 15 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
-		wifi@0,0 {
-			status = "okay";
-
-			/* QCN9074: ath11k lacks DT compatible for PCI cards */
+		wifi@1,0 {
 			compatible = "pci17cb,1104";
 			reg = <0x00010000 0 0 0 0>;
-
 			qcom,ath11k-calibration-variant = "Linksys-MX5500";
 		};
 	};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-spnmx56.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-spnmx56.dts
@@ -166,13 +166,9 @@
 	perst-gpios = <&tlmm 15 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
-		wifi@0,0 {
-			status = "okay";
-
-			/* QCN9074: ath11k lacks DT compatible for PCI cards */
+		wifi@1,0 {
 			compatible = "pci17cb,1104";
 			reg = <0x00010000 0 0 0 0>;
-
 			qcom,ath11k-calibration-variant = "Linksys-SPNMX56";
 		};
 	};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
@@ -156,13 +156,9 @@
 	perst-gpios = <&tlmm 60 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
-		wifi@0,0 {
-			status = "okay";
-
-			/* ath11k has no DT compatible for PCI cards */
+		wifi@1,0 {
 			compatible = "pci17cb,1104";
 			reg = <0x00010000 0 0 0 0>;
-
 			qcom,ath11k-fw-memory-mode = <0>;
 			qcom,ath11k-calibration-variant = "CambiumNetworks-XE34";
 		};

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-mr7500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-mr7500.dts
@@ -523,9 +523,7 @@
 	status = "okay";
 
 	pcie@0 {
-		wifi@0,0 {
-			status = "okay";
-			/* ath11k has no DT compatible for PCI cards */
+		wifi@1,0 {
 			compatible = "pci17cb,1104";
 			reg = <0x00010000 0 0 0 0>;
 			qcom,ath11k-calibration-variant = "Linksys-MR7500";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ax3600.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ax3600.dts
@@ -51,9 +51,7 @@
 	perst-gpios = <&tlmm 52 GPIO_ACTIVE_HIGH>;
 
 	pcie@0 {
-		wifi0: wifi@0,0 {
-			status = "okay";
-
+		wifi@1,0 {
 			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax9000.dts
@@ -536,13 +536,9 @@
 	perst-gpios = <&tlmm 58 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
-		wifi@0,0 {
-			status = "okay";
-
-			/* ath11k has no DT compatible for PCI cards */
+		wifi@1,0 {
 			compatible = "pci17cb,1104";
 			reg = <0x00010000 0 0 0 0>;
-
 			qcom,ath11k-calibration-variant = "Xiaomi-AX9000";
 		};
 	};
@@ -558,12 +554,9 @@
 	perst-gpios = <&tlmm 62 GPIO_ACTIVE_HIGH>;
 
 	pcie@0 {
-		wifi@0,0 {
-			status = "okay";
-
+		wifi@1,0 {
 			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
-
 			qcom,ath10k-calibration-variant = "Xiaomi-AX9000";
 			nvmem-cell-names = "calibration";
 			nvmem-cells = <&caldata_qca9889>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
@@ -290,10 +290,7 @@
 	perst-gpios = <&tlmm 61 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
-		wifi@0,0 {
-			status = "okay";
-
-			/* ath11k has no DT compatible for PCI cards */
+		wifi@1,0 {
 			compatible = "pci17cb,1104";
 			reg = <0x00010000 0 0 0 0>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
@@ -523,9 +523,7 @@
 	perst-gpios = <&tlmm 58 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
-		wifi0: wifi@0,0 {
-			status = "okay";
-
+		wifi@1,0 {
 			compatible = "qcom,ath10k";
 			reg = <0x00010000 0 0 0 0>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx8500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx8500.dts
@@ -517,10 +517,7 @@
 	perst-gpios = <&tlmm 61 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
-		wifi@0,0 {
-			status = "okay";
-
-			/* ath11k has no DT compatible for PCI cards */
+		wifi@1,0 {
 			compatible = "pci17cb,1104";
 			reg = <0x00010000 0 0 0 0>;
 

--- a/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
+++ b/target/linux/ramips/dts/rt3662_asus_rt-n56u.dts
@@ -148,7 +148,7 @@
 &pci1 {
 	status = "okay";
 
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "pci1814,3091";
 		reg = <0x10000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;

--- a/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
+++ b/target/linux/ramips/dts/rt3662_edimax_br-6475nd.dts
@@ -184,7 +184,7 @@
 &pci1 {
 	status = "okay";
 
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "pci0,0";
 		reg = <0x10000 0 0 0 0>;
 		ralink,5ghz = <0>;

--- a/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
+++ b/target/linux/ramips/dts/rt3662_engenius_esr600h.dts
@@ -162,7 +162,7 @@
 &pci1 {
 	status = "okay";
 
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "pci1814,3091";
 		reg = <0x10000 0 0 0 0>;
 		ralink,5ghz = <0>;

--- a/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
+++ b/target/linux/ramips/dts/rt3662_samsung_cy-swr1100.dts
@@ -150,7 +150,7 @@
 &pci1 {
 	status = "okay";
 
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "pci1814,3091";
 		reg = <0x10000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_2000>;

--- a/target/linux/ramips/dts/rt3883_belkin_f9k1109v1.dts
+++ b/target/linux/ramips/dts/rt3883_belkin_f9k1109v1.dts
@@ -113,7 +113,7 @@
 &pci1 {
 	status = "okay";
 
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "pci1814,3091";
 		reg = <0x10000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;

--- a/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
+++ b/target/linux/ramips/dts/rt3883_sitecom_wlr-6000.dts
@@ -180,7 +180,7 @@
 &pci1 {
 	status = "okay";
 
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "pci1814,3091";
 		reg = <0x10000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_8000>;

--- a/target/linux/ramips/dts/rt3883_trendnet_tew-692gr.dts
+++ b/target/linux/ramips/dts/rt3883_trendnet_tew-692gr.dts
@@ -150,7 +150,7 @@
 &pci1 {
 	status = "okay";
 
-	wifi@0,0 {
+	wifi@1,0 {
 		compatible = "pci0,0";
 		reg = < 0x10000 0 0 0 0 >;
 		ralink,2ghz = <0>;


### PR DESCRIPTION
Use compatible before reg for consistency.

Also fixup the wifi node name for some qualcomm platforms where the slot
is 1 instead of 0.

ping @computersforpeace 

Can you verify the onhub commit to be correct? lspci should be enough.