### PR TITLE
realtek: pcs: prepare SerDes PHY --> PCS transition

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -78,6 +78,7 @@ struct rtpcs_config {
 	int mac_tx_pause_sts;
 	const struct phylink_pcs_ops *pcs_ops;
 	int (*set_autoneg)(struct rtpcs_ctrl *ctrl, int sds, unsigned int neg_mode);
+	int (*setup_serdes)(struct rtpcs_ctrl *ctrl, int sds, phy_interface_t mode);
 };
 
 static int rtpcs_sds_to_mmd(int sds_page, int sds_regnum)
@@ -253,6 +254,12 @@ static int rtpcs_pcs_config(struct phylink_pcs *pcs, unsigned int neg_mode,
 		 phy_modes(interface), link->port, link->sds);
 
 	mutex_lock(&ctrl->lock);
+
+	if (ctrl->cfg->setup_serdes) {
+		ret = ctrl->cfg->setup_serdes(ctrl, link->sds, interface);
+		if (ret < 0)
+			goto out;
+	}
 
 	if (ctrl->cfg->set_autoneg) {
 		ret = ctrl->cfg->set_autoneg(ctrl, link->sds, neg_mode);


### PR DESCRIPTION
This is a first PR from my side in a planned series to continue bringing structure into our Realtek drivers. So let's start with something small first.

This add some helpers and a callback needed for the next steps of transitioning all SerDes configuration from the PHY driver to the PCS driver.

---

There's still a lot of work ahead of us to make the big picture layed out in https://github.com/openwrt/openwrt/pull/20292#issuecomment-3367927780 reality.

My rough plan on this during the next PRs is:
1. Move SerDes configuration code currently located in DSA/PHY driver over to the PCS driver while keeping the status-quo (i.e. how they are implemented, that it works)
  - RTL931X first (because it's not much code and apparently easy)
  - RTL930X next
  - RTL83XX at last
2. Implement architectural changes in the PCS driver and the SerDes setup routines (more on that later)
3. Actually improve the SerDes setup itself, e.g. fixing outstanding issues on RTL931X.
