### PR TITLE
base-files,netifd,odhcp6c: generate/use a global DUID for DHCP

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -44,14 +44,15 @@ generate_static_network() {
 		set network.loopback.device='lo'
 		set network.loopback.proto='static'
 		add_list network.loopback.ipaddr='127.0.0.1/8'
+		delete network.globals
+		set network.globals='globals'
+		set network.globals.dhcp_default_duid='auto'
 	EOF
-		[ -e /proc/sys/net/ipv6 ] && {
-			uci -q batch <<-EOF
-				delete network.globals
-				set network.globals='globals'
-				set network.globals.ula_prefix='auto'
-			EOF
-		}
+	[ -e /proc/sys/net/ipv6 ] && {
+		uci -q batch <<-EOF
+			set network.globals.ula_prefix='auto'
+		EOF
+	}
 
 	if json_is_a dsl object; then
 		json_select dsl

--- a/package/base-files/files/etc/uci-defaults/14_network-generate-clientid
+++ b/package/base-files/files/etc/uci-defaults/14_network-generate-clientid
@@ -1,0 +1,9 @@
+[ "$(uci -q get network.globals.dhcp_default_duid)" != "auto" ] && exit 0
+
+uci -q batch <<-EOF >/dev/null
+	# DUID-UUID - RFC6355
+	set network.globals.dhcp_default_duid="$(hexdump -vn 16 -e '"0004" 2/2 "%x"' /dev/urandom)"
+	commit network
+EOF
+
+exit 0

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -2,6 +2,7 @@
 
 . /lib/functions.sh
 . ../netifd-proto.sh
+. /lib/config/uci.sh
 init_proto "$@"
 
 proto_dhcpv6_init_config() {
@@ -66,6 +67,7 @@ proto_dhcpv6_setup() {
 	[ -z "$reqprefix" -o "$reqprefix" = "auto" ] && reqprefix=0
 	[ "$reqprefix" != "no" ] && append opts "-P$reqprefix"
 
+	[ -z "$clientid" ] && clientid="$(uci_get network @globals[0] dhcp_default_duid)"
 	[ -n "$clientid" ] && append opts "-c$clientid"
 
 	[ "$defaultreqopts" = "0" ] && append opts "-R"


### PR DESCRIPTION
odhcp6c already supports custom DUIDS on a per-interface basis.  When no client
identifier has been set, odhcp6c will generate one on the basis of the MAC
address of the given interface.

The same problem exists in odhcpd, which also generates server-side DUIDs on a
per-interface basis.

This is contrary to how DUIDs are meant to be used, as the client identifier
will vary from interface to interface, while it is meant to remain stable for a
given host, no matter how the network hardware changes (see [RFC8415, §11](https://datatracker.ietf.org/doc/html/rfc8415#section-11)).

Currently, a DUID-UUID style clientid is generated. This is mostly meant as an
RFC, and we might consider using a different kind of DUID instead (DUID-LLT,
DUID-EN).

In the subsequent patches, `udhcpc` (DHCPv4 client) and `odhcp6c` (DHCPv6 client)
are amended so that they use use the global DUID if available.

One drawback is that this will typically change the DUID used on existing
OpenWrt devices when upgrading to a new release. However, that seems unavoidable
and is a one-time pain in order to have stable DUIDs (and in many cases, it
shouldn't cause any issues).