### PR TITLE
realtek: rtl930x: split out XGS1250-12 common recipe

### DIFF
--- a/target/linux/realtek/image/common.mk
+++ b/target/linux/realtek/image/common.mk
@@ -92,3 +92,19 @@ define Device/zyxel_gs1900
 	uImage none | \
 	check-size 6976k
 endef
+
+define Device/zyxel_xgs1250-12
+  SOC := rtl9302
+  UIMAGE_MAGIC := 0x93001250
+  ZYXEL_VERS := ABWE
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := XGS1250-12
+  DEVICE_PACKAGES := kmod-hwmon-gpiofan kmod-thermal
+  IMAGE_SIZE := 13312k
+  KERNEL_INITRAMFS := \
+	kernel-bin | \
+	append-dtb | \
+	gzip | \
+	zyxel-vers | \
+	uImage gzip
+endef

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
+include ./common.mk
+
 define Build/xikestor-nosimg
   $(STAGING_DIR_HOST)/bin/nosimg-enc -i $@ -o $@.new
   mv $@.new $@
@@ -114,31 +116,15 @@ define Device/zyxel_xgs1210-12-a1
 endef
 TARGET_DEVICES += zyxel_xgs1210-12-a1
 
-define Device/zyxel_xgs1250-12-common
-  SOC := rtl9302
-  UIMAGE_MAGIC := 0x93001250
-  ZYXEL_VERS := ABWE
-  DEVICE_VENDOR := Zyxel
-  DEVICE_MODEL := XGS1250-12
-  DEVICE_PACKAGES := kmod-hwmon-gpiofan kmod-thermal
-  IMAGE_SIZE := 13312k
-  KERNEL_INITRAMFS := \
-	kernel-bin | \
-	append-dtb | \
-	gzip | \
-	zyxel-vers | \
-	uImage gzip
-endef
-
 define Device/zyxel_xgs1250-12-a1
-  $(Device/zyxel_xgs1250-12-common)
+  $(Device/zyxel_xgs1250-12)
   SUPPORTED_DEVICES += zyxel,xgs1250-12
   DEVICE_VARIANT := A1
 endef
 TARGET_DEVICES += zyxel_xgs1250-12-a1
 
 define Device/zyxel_xgs1250-12-b1
-  $(Device/zyxel_xgs1250-12-common)
+  $(Device/zyxel_xgs1250-12)
   DEVICE_VARIANT := B1
 endef
 TARGET_DEVICES += zyxel_xgs1250-12-b1


### PR DESCRIPTION
Move the common XGS1250-12 recipe to `common.mk`, where the other shared recipes live.

Fixes: 133c91823c (realtek: rtl930x: add XGS1250-12 B1 device)

@hauke Friendly ping.