### PR TITLE
odhcp6c: add dynamic interface option for creating '4in6' protos in 'dhcpv6'

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -165,7 +165,7 @@ setup_interface () {
 
 	[ -n "$ZONE" ] || ZONE=$(fw3 -q network $INTERFACE 2>/dev/null)
 
-	if [ "$IFACE_MAP" != 0 -a -n "$MAPTYPE" -a -n "$MAPRULE" ]; then
+	if [ "$IFACE_MAP" != 0 ] && [ -n "$MAPTYPE" ] && [ -n "$MAPRULE" ]; then
 		[ -z "$IFACE_MAP" -o "$IFACE_MAP" = 1 ] && IFACE_MAP=${INTERFACE}_4
 		json_init
 		json_add_string name "$IFACE_MAP"
@@ -182,7 +182,7 @@ setup_interface () {
 		[ -n "$IFACE_MAP_DELEGATE" ] && json_add_boolean delegate "$IFACE_MAP_DELEGATE"
 		json_close_object
 		ubus call network add_dynamic "$(json_dump)"
-	elif [ -n "$AFTR" -a "$IFACE_DSLITE" != 0 -a -f /lib/netifd/proto/dslite.sh ]; then
+	elif [ -n "$AFTR" ] && [ "$IFACE_DSLITE" != 0 ] && [ -f /lib/netifd/proto/dslite.sh ]; then
 		[ -z "$IFACE_DSLITE" -o "$IFACE_DSLITE" = 1 ] && IFACE_DSLITE=${INTERFACE}_4
 		json_init
 		json_add_string name "$IFACE_DSLITE"
@@ -197,7 +197,7 @@ setup_interface () {
 		[ -n "$IFACE_DSLITE_DELEGATE" ] && json_add_boolean delegate "$IFACE_DSLITE_DELEGATE"
 		json_close_object
 		ubus call network add_dynamic "$(json_dump)"
-	elif [ "$IFACE_464XLAT" != 0 -a -f /lib/netifd/proto/464xlat.sh ]; then
+	elif [ "$IFACE_464XLAT" != 0 ] && [ -f /lib/netifd/proto/464xlat.sh ]; then
 		[ -z "$IFACE_464XLAT" -o "$IFACE_464XLAT" = 1 ] && IFACE_464XLAT=${INTERFACE}_4
 		json_init
 		json_add_string name "$IFACE_464XLAT"

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -149,6 +149,11 @@ setup_interface () {
 
 	proto_send_update "$INTERFACE"
 
+	# If the flag '$DYNAMIC' is set to '0' (default=1), then the dynamic
+	# interfaces for the proto 'map', 'dslite' or '464xlat' are not
+	# created, even if the requirements are met.
+	[ "$DYNAMIC" = 0 ] && return
+
 	MAPTYPE=""
 	MAPRULE=""
 

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -57,11 +57,28 @@ proto_dhcpv6_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local reqaddress reqprefix clientid reqopts defaultreqopts noslaaconly forceprefix extendprefix norelease noserverunicast noclientfqdn noacceptreconfig ip6prefix ip6prefixes iface_dslite iface_map iface_464xlat ip6ifaceid userclass vendorclass sendopts delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite encaplimit_map skpriority soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff verbose mtu_dslite
-	json_get_vars reqaddress reqprefix clientid reqopts defaultreqopts noslaaconly forceprefix extendprefix norelease noserverunicast noclientfqdn noacceptreconfig iface_dslite iface_map iface_464xlat ip6ifaceid userclass vendorclass delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite encaplimit_map skpriority soltimeout fakeroutes sourcefilter keep_ra_dnslifetime ra_holdoff verbose mtu_dslite
+	local reqaddress reqprefix clientid reqopts defaultreqopts
+	local noslaaconly forceprefix extendprefix norelease
+	local noserverunicast noclientfqdn noacceptreconfig iface_dslite
+	local iface_map iface_464xlat ip6ifaceid userclass vendorclass
+	local delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite
+	local encaplimit_map skpriority soltimeout fakeroutes sourcefilter
+	local keep_ra_dnslifetime ra_holdoff verbose mtu_dslite
+
+	local ip6prefix ip6prefixes
+
+	json_get_vars reqaddress reqprefix clientid reqopts defaultreqopts
+	json_get_vars noslaaconly forceprefix extendprefix norelease
+	json_get_vars noserverunicast noclientfqdn noacceptreconfig iface_dslite
+	json_get_vars iface_map iface_464xlat ip6ifaceid userclass vendorclass
+	json_get_vars delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite
+	json_get_vars encaplimit_map skpriority soltimeout fakeroutes sourcefilter
+	json_get_vars keep_ra_dnslifetime ra_holdoff verbose mtu_dslite
+
 	json_for_each_item proto_dhcpv6_add_prefix ip6prefix ip6prefixes
 
 	# Configure
+	local sendopts
 	local opts=""
 	[ -n "$reqaddress" ] && append opts "-N$reqaddress"
 

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -43,6 +43,7 @@ proto_dhcpv6_init_config() {
 	proto_config_add_boolean keep_ra_dnslifetime
 	proto_config_add_int "ra_holdoff"
 	proto_config_add_boolean verbose
+	proto_config_add_boolean dynamic
 }
 
 proto_dhcpv6_add_prefix() {
@@ -63,7 +64,7 @@ proto_dhcpv6_setup() {
 	local iface_map iface_464xlat ip6ifaceid userclass vendorclass
 	local delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite
 	local encaplimit_map skpriority soltimeout fakeroutes sourcefilter
-	local keep_ra_dnslifetime ra_holdoff verbose mtu_dslite
+	local keep_ra_dnslifetime ra_holdoff verbose mtu_dslite dynamic
 
 	local ip6prefix ip6prefixes
 
@@ -73,7 +74,7 @@ proto_dhcpv6_setup() {
 	json_get_vars iface_map iface_464xlat ip6ifaceid userclass vendorclass
 	json_get_vars delegate zone_dslite zone_map zone_464xlat zone encaplimit_dslite
 	json_get_vars encaplimit_map skpriority soltimeout fakeroutes sourcefilter
-	json_get_vars keep_ra_dnslifetime ra_holdoff verbose mtu_dslite
+	json_get_vars keep_ra_dnslifetime ra_holdoff verbose mtu_dslite dynamic
 
 	json_for_each_item proto_dhcpv6_add_prefix ip6prefix ip6prefixes
 
@@ -153,6 +154,12 @@ proto_dhcpv6_setup() {
 	[ "$fakeroutes" != "0" ] && proto_export "FAKE_ROUTES=1"
 	[ "$sourcefilter" = "0" ] && proto_export "NOSOURCEFILTER=1"
 	[ "$extendprefix" = "1" ] && proto_export "EXTENDPREFIX=1"
+
+	if [ "$dynamic" = 0 ]; then
+		proto_export "DYNAMIC=0"
+	else
+		proto_export "DYNAMIC=1"
+	fi
 
 	proto_export "INTERFACE=$config"
 	proto_run_command "$config" odhcp6c \


### PR DESCRIPTION
The last change was quite a while ago, so I'm not sure if @dedeckeh is the right reviewer, as he hasn't been active for a long time.

Changes:

odhcp6c: use && in if statement on dynamic interfaces
odhcp6c: cleanup variable definitions
odhcp6c: add new option to start 4in6 protos as dynamic interface

This PR replaces #19936
