### PR TITLE
buildsystem: enable SIGNED_PACKAGES option only if packaging backend is not APK

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -58,11 +58,13 @@ menu "Global build settings"
 
 	config SIGNED_PACKAGES
 		bool "Cryptographically signed package lists"
+		depends on !USE_APK
 		default y
 
 	config SIGNATURE_CHECK
 		bool "Enable signature checking in opkg"
-		default SIGNED_PACKAGES
+		default y if SIGNED_PACKAGES
+		default y if USE_APK
 
 	config DOWNLOAD_CHECK_CERTIFICATE
 		bool "Enable TLS certificate verification during package download"

--- a/target/sdk/files/Config.in
+++ b/target/sdk/files/Config.in
@@ -16,6 +16,7 @@ menu "Global build settings"
 
 	config SIGNED_PACKAGES
 		bool "Cryptographically sign package lists"
+		depends on !USE_APK
 		default y
 
 	comment "General build options"


### PR DESCRIPTION
@aparcar

The config option 'CONFIG_SIGNED_PACKAGES' is only useful and can only be used if packaging backend is 'opkg' and not 'apk'. By adding the option ‘!USE_APK' in 'Config.in' (SDK) and 'Config-build.in' (buildsystem) disbales this option.
