### PR TITLE
kernel: add missing cpe id for linux

### DIFF
--- a/package/kernel/linux/Makefile
+++ b/package/kernel/linux/Makefile
@@ -18,6 +18,7 @@ SCAN_DEPS=modules/*.mk $(SUBTARGET_MODULES) $(TOPDIR)/include/netfilter.mk
 
 PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING
+PKG_CPE_ID:=cpe:/o:linux:linux_kernel
 
 export SHELL:=/bin/sh
 .ONESHELL:


### PR DESCRIPTION
No 'PKG_CPE_ID' is stored for the kernel package Makefile. This commit adds this.