### PR TITLE
include: do not prepend kernel version if PKG_VERSION is available

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -216,9 +216,9 @@ define KernelPackage
     EXTRA_DEPENDS:=kernel (=$(LINUX_VERSION)~$(LINUX_VERMAGIC)-r$(LINUX_RELEASE))
     ifneq ($(PKG_VERSION),)
       ifneq ($(PKG_RELEASE),)
-        VERSION:=$(LINUX_VERSION).$(PKG_VERSION)-r$(PKG_RELEASE)
+        VERSION:=$(PKG_VERSION)-r$(PKG_RELEASE)
       else
-        VERSION:=$(LINUX_VERSION).$(PKG_VERSION)-r$(LINUX_RELEASE)
+        VERSION:=$(PKG_VERSION)-r$(LINUX_RELEASE)
       endif
     else
       ifneq ($(PKG_RELEASE),)

--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -214,7 +214,19 @@ define KernelPackage
     CATEGORY:=Kernel modules
     DESCRIPTION:=$(DESCRIPTION)
     EXTRA_DEPENDS:=kernel (=$(LINUX_VERSION)~$(LINUX_VERMAGIC)-r$(LINUX_RELEASE))
-    VERSION:=$(LINUX_VERSION)$(if $(PKG_VERSION),.$(PKG_VERSION))-r$(if $(PKG_RELEASE),$(PKG_RELEASE),$(LINUX_RELEASE))
+    ifneq ($(PKG_VERSION),)
+      ifneq ($(PKG_RELEASE),)
+        VERSION:=$(LINUX_VERSION).$(PKG_VERSION)-r$(PKG_RELEASE)
+      else
+        VERSION:=$(LINUX_VERSION).$(PKG_VERSION)-r$(LINUX_RELEASE)
+      endif
+    else
+      ifneq ($(PKG_RELEASE),)
+        VERSION:=$(LINUX_VERSION)-r$(PKG_RELEASE)
+      else
+        VERSION:=$(LINUX_VERSION)-r$(LINUX_RELEASE)
+       endif
+    endif
     PKGFLAGS:=$(PKGFLAGS)
     $(call KernelPackage/$(1))
     $(call KernelPackage/$(1)/$(BOARD))


### PR DESCRIPTION
include: do not prepend kernel version if PKG_VERSION is available

External kernel modules that have their own version string variable
'PKG_VERSION' set, are additional prefixed with the current version string
of the Linux kernel.

 For the 'kmod-ath10k' module, which is installed via backports, the
 following version string applies for 'openwrt-24.10'.

kmod-ath10k:
6.6.109.2024.07.30~ac71b14d-r2

This commit removes the kernel prefix version string if the package has set
 its own 'PKG_VERSION'. This results in the following new version string
for 'kmod-ath10k'.

 kmod-ath10k:
 2024.07.30~ac71b14d-r2