### PR TITLE
uboot-rockchip: add u-boot device tree back for Radxa ROCK 4D

### DIFF
--- a/package/boot/uboot-rockchip/patches/108-board-rockchip-Add-Radxa-ROCK-4D.patch
+++ b/package/boot/uboot-rockchip/patches/108-board-rockchip-Add-Radxa-ROCK-4D.patch
@@ -196,6 +196,19 @@ v2: Add comment about the reset-gpios prop rename
  &usb_drd1_dwc3 {
  	dr_mode = "host";
  	status = "okay";
+--- /dev/null
++++ b/arch/arm/dts/rk3576-rock-4d-u-boot.dtsi
+@@ -0,0 +1,10 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++#include "rk3576-u-boot.dtsi"
++
++&sfc0 {
++	flash@0 {
++		bootph-pre-ram;
++		bootph-some-ram;
++	};
++};
 --- a/arch/arm/mach-rockchip/rk3576/MAINTAINERS
 +++ b/arch/arm/mach-rockchip/rk3576/MAINTAINERS
 @@ -4,6 +4,12 @@ S:	Maintained


### PR DESCRIPTION
This was removed by mistake.

Fixes: 292cca0e5c72 ("uboot-rockchip: Update to 2025.10")
