### PR TITLE
[24.10] mvebu: gl-mv1000: fix sdhci1 controller

### DIFF
--- a/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/armada-3720-gl-mv1000.dts
+++ b/target/linux/mvebu/files-6.6/arch/arm64/boot/dts/marvell/armada-3720-gl-mv1000.dts
@@ -26,19 +26,6 @@
 		reg = <0x00000000 0x00000000 0x00000000 0x20000000>;
 	};
 
-	vcc_sd_reg1: regulator {
-		compatible = "regulator-gpio";
-		regulator-name = "vcc_sd1";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <3300000>;
-		regulator-boot-on;
-
-		gpios-states = <0>;
-		states = <1800000 0x1
-			3300000 0x0>;
-		enable-active-high;
-	};
-
 	keys {
 		compatible = "gpio-keys";
 
@@ -149,7 +136,6 @@
 	cd-gpios = <&gpionb 17 GPIO_ACTIVE_LOW>;
 	marvell,pad-type = "sd";
 	no-1-8-v;
-	vqmmc-supply = <&vcc_sd_reg1>;
 	status = "okay";
 };
 


### PR DESCRIPTION
GL-MV1000 external SD controller was broken by a recent kernel update between OpenWRT releases 24.10.2 and 24.10.3 due to a mistake in Device Tree: "regulator-gpio" was defined without required "gpios" property.

Since "no-1-8-v" property is also defined for this controller a switchable vqmmc-supply regulator performs no function - a fixed 3.3V IO voltage will always be used.

This regulator definition was probably added by mistake from a Device Tree from another device.

Remove incomplete vcc_sd_reg1 regulator definition to fix this issue.

Issue discussion for reference: openwrt/openwrt#20309