### PR TITLE
uboot-tools + tools/mkimage: update to version 2025.10

### DIFF
--- a/package/boot/uboot-tools/Makefile
+++ b/package/boot/uboot-tools/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_DISTNAME:=u-boot
-PKG_VERSION:=2025.07
+PKG_VERSION:=2025.10
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_DISTNAME)-$(PKG_VERSION).tar.bz2
@@ -10,7 +10,7 @@ PKG_SOURCE_URL:= \
 	https://mirror.cyberbits.eu/u-boot \
 	ftp://ftp.denx.de/pub/u-boot
 PKG_URL:=http://www.denx.de/wiki/U-Boot
-PKG_HASH:=0f933f6c5a426895bf306e93e6ac53c60870e4b54cda56d95211bec99e63bec7
+PKG_HASH:=b4f032848e56cc8f213ad59f9132c084dbbb632bc29176d024e58220e0efdf4a
 PKG_SOURCE_SUBDIR:=$(PKG_DISTNAME)-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_DISTNAME)-$(PKG_VERSION)
 

--- a/package/boot/uboot-tools/patches/013-tools-fit_check_sign-all-image-types.patch
+++ b/package/boot/uboot-tools/patches/013-tools-fit_check_sign-all-image-types.patch
@@ -1,6 +1,6 @@
 --- a/boot/bootm.c
 +++ b/boot/bootm.c
-@@ -1232,20 +1232,18 @@ static int bootm_host_load_image(const v
+@@ -1245,20 +1245,18 @@ static int bootm_host_load_image(const v
  
  int bootm_host_load_images(const void *fit, int cfg_noffset)
  {

--- a/package/boot/uboot-tools/patches/014-tools-fit_check_sign-no-decompress.patch
+++ b/package/boot/uboot-tools/patches/014-tools-fit_check_sign-no-decompress.patch
@@ -1,6 +1,6 @@
 --- a/boot/bootm.c
 +++ b/boot/bootm.c
-@@ -1191,10 +1191,6 @@ static int bootm_host_load_image(const v
+@@ -1204,10 +1204,6 @@ static int bootm_host_load_image(const v
  	ulong data, len;
  	struct bootm_headers images;
  	int noffset;
@@ -11,7 +11,7 @@
  	int ret;
  
  	fit_uname_config = fdt_get_name(fit, cfg_noffset, NULL);
-@@ -1206,26 +1202,6 @@ static int bootm_host_load_image(const v
+@@ -1219,26 +1215,6 @@ static int bootm_host_load_image(const v
  		FIT_LOAD_IGNORED, &data, &len);
  	if (noffset < 0)
  		return noffset;

--- a/tools/mkimage/Makefile
+++ b/tools/mkimage/Makefile
@@ -7,14 +7,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mkimage
-PKG_VERSION:=2025.07
+PKG_VERSION:=2025.10
 
 PKG_SOURCE:=u-boot-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
 	https://mirror.cyberbits.eu/u-boot \
 	https://ftp.denx.de/pub/u-boot \
 	ftp://ftp.denx.de/pub/u-boot
-PKG_HASH:=0f933f6c5a426895bf306e93e6ac53c60870e4b54cda56d95211bec99e63bec7
+PKG_HASH:=b4f032848e56cc8f213ad59f9132c084dbbb632bc29176d024e58220e0efdf4a
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/u-boot-$(PKG_VERSION)
 


### PR DESCRIPTION
Update both host and target package to the latest stable version.
All patches automatically refreshed.

Build and run tested on x86/64 host for mvebu/cortexa9 (Turris Omnia)