### PR TITLE
uboot-mvebu: update to version 2025.10

### DIFF
--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -8,10 +8,10 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
-PKG_VERSION:=2025.07
+PKG_VERSION:=2025.10
 PKG_RELEASE:=1
 
-PKG_HASH:=0f933f6c5a426895bf306e93e6ac53c60870e4b54cda56d95211bec99e63bec7
+PKG_HASH:=b4f032848e56cc8f213ad59f9132c084dbbb632bc29176d024e58220e0efdf4a
 
 include $(INCLUDE_DIR)/u-boot.mk
 include $(INCLUDE_DIR)/package.mk

--- a/package/boot/uboot-mvebu/patches/101-net-mvpp2-fix-10GBase-R-support.patch
+++ b/package/boot/uboot-mvebu/patches/101-net-mvpp2-fix-10GBase-R-support.patch
@@ -18,7 +18,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/drivers/net/mvpp2.c
 +++ b/drivers/net/mvpp2.c
-@@ -3254,6 +3254,76 @@ static int gop_gpcs_reset(struct mvpp2_p
+@@ -3253,6 +3253,76 @@ static int gop_gpcs_reset(struct mvpp2_p
  	return 0;
  }
  
@@ -95,7 +95,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
  static int gop_mpcs_mode(struct mvpp2_port *port)
  {
  	u32 val;
-@@ -3396,7 +3466,10 @@ static int gop_port_init(struct mvpp2_po
+@@ -3395,7 +3465,10 @@ static int gop_port_init(struct mvpp2_po
  		num_of_act_lanes = 2;
  		mac_num = 0;
  		/* configure PCS */

--- a/package/boot/uboot-mvebu/patches/102-arm-mvebu-add-support-for-MikroTik-RB5009UG-S-IN.patch
+++ b/package/boot/uboot-mvebu/patches/102-arm-mvebu-add-support-for-MikroTik-RB5009UG-S-IN.patch
@@ -31,7 +31,7 @@ Signed-off-by: Robert Marko <robimarko@gmail.com>
 
 --- a/arch/arm/dts/Makefile
 +++ b/arch/arm/dts/Makefile
-@@ -172,6 +172,7 @@ dtb-$(CONFIG_ARCH_MVEBU) +=			\
+@@ -177,6 +177,7 @@ dtb-$(CONFIG_ARCH_MVEBU) +=			\
  	armada-3720-uDPU.dtb			\
  	armada-7040-db-nand.dtb			\
  	armada-7040-db.dtb			\


### PR DESCRIPTION
Update package to the latest stable version.
All patches automatically refreshed.

Build and run tested on mvebu/cortexa9 (Turris Omnia)