### PR TITLE
mvebu: gl-mv1000: add devicetree patch for sdhci1

### DIFF
--- a/target/linux/mvebu/patches-6.12/326-arm64-dts-marvell-glinet-mv1000-fix-sdhci1.patch
+++ b/target/linux/mvebu/patches-6.12/326-arm64-dts-marvell-glinet-mv1000-fix-sdhci1.patch
@@ -1,0 +1,53 @@
+From 5f20749c2dbbbc0f4f3c5bd1c4067388ab760960 Mon Sep 17 00:00:00 2001
+From: Mikhail Zadorozhnyi <zador.blood.stained+git@protonmail.com>
+Date: Sat, 11 Oct 2025 20:22:07 +0300
+Subject: [PATCH] arm64: dts: marvell: fix sdhci1 controller for gl-mv1000
+
+GL-MV1000 external SD controller was broken by a recent kernel update
+due to a mistake in Device Tree: "regulator-gpio" was defined without
+required "gpios" property.
+
+Since "no-1-8-v" property is also defined for this controller
+a switchable vqmmc-supply regulator performs no function - a fixed 3.3V
+IO voltage will always be used.
+
+This regulator definition was probably added by mistake from a Device
+Tree from another device.
+
+Remove incomplete vcc_sd_reg1 regulator definition to fix this issue.
+
+Signed-off-by: Mikhail Zadorozhnyi <zador.blood.stained+git@protonmail.com>
+---
+ .../boot/dts/marvell/armada-3720-gl-mv1000.dts     | 14 --------------
+ 1 file changed, 14 deletions(-)
+
+--- a/arch/arm64/boot/dts/marvell/armada-3720-gl-mv1000.dts
++++ b/arch/arm64/boot/dts/marvell/armada-3720-gl-mv1000.dts
+@@ -26,19 +26,6 @@
+ 		reg = <0x00000000 0x00000000 0x00000000 0x20000000>;
+ 	};
+ 
+-	vcc_sd_reg1: regulator {
+-		compatible = "regulator-gpio";
+-		regulator-name = "vcc_sd1";
+-		regulator-min-microvolt = <1800000>;
+-		regulator-max-microvolt = <3300000>;
+-		regulator-boot-on;
+-
+-		gpios-states = <0>;
+-		states = <1800000 0x1
+-			3300000 0x0>;
+-		enable-active-high;
+-	};
+-
+ 	keys {
+ 		compatible = "gpio-keys";
+ 
+@@ -135,7 +122,6 @@
+ 	cd-gpios = <&gpionb 17 GPIO_ACTIVE_LOW>;
+ 	marvell,pad-type = "sd";
+ 	no-1-8-v;
+-	vqmmc-supply = <&vcc_sd_reg1>;
+ 	status = "okay";
+ };
+ 


### PR DESCRIPTION
GL-MV1000 external SD controller was broken by a recent kernel update 
due to a mistake in Device Tree: "regulator-gpio" was defined without 
required "gpios" property.

Removing this regulator definition from the device tree fixes this issue
without any side effects so far.

"main" branch uses upstream devicetree for this device, so add a kernel
patch for the "mvebu" kernel family.

Relevant discussions:
https://github.com/openwrt/openwrt/issues/20309
https://github.com/openwrt/openwrt/pull/20378