### PR TITLE
mediatek: filogic: add support for TP-LINK BE450

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -127,7 +127,8 @@ smartrg,sdg-8733a|\
 smartrg,sdg-8734)
 	ubootenv_add_mmc "u-boot-env" "mmcblk0" "0x0" "0x8000" "0x8000"
 	;;
-tplink,archer-ax80-v1)
+tplink,archer-ax80-v1|\
+tplink,be450)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000" "8"
 	;;
 ubnt,unifi-6-plus)

--- a/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
+++ b/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include "mt7988a.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+#include <dt-bindings/regulator/richtek,rt5190a-regulator.h>
+
+/ {
+	model = "TP-Link BE450";
+	compatible = "tplink,be450", "mediatek,mt7988d";
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	aliases {
+		serial0 = &serial0;
+		label-mac-device = &gmac0;
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	memory@40000000 {
+		reg = <0x0 0x40000000 0x0 0x40000000>;
+		device_type = "memory";
+	};
+
+	cpus {
+		/delete-node/ cpu@3;
+	};
+
+	reg_1p8v: regulator-1p8v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-1.8V";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-names = "default";
+		pinctrl-0 = <&button_pins>;
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			gpios = <&pio 21 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_WAN;
+		};
+
+		led-1 {
+			gpios = <&pio 28 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+		};
+
+		led-2 {
+			gpios = <&pio 29 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+		};
+
+		led_status: led-3 {
+			gpios = <&pio 30 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			panic-indicator;
+		};
+
+		led-4 {
+			gpios = <&pio 31 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+		};
+
+		led-5 {
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WPS;
+		};
+
+		led-6 {
+			gpios = <&pio 57 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+		};
+
+		led-7 {
+			gpios = <&pio 68 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+		};		
+	};
+};
+
+&cpu0 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu1 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu2 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cci {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		
+		reg = <0>;
+
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+		spi-cal-addrlen = <5>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
+		spi-cal-datalen = <7>;
+		spi-cal-enable;
+		spi-cal-mode = "read-data";		
+
+		spi-max-frequency = <52000000>;
+		spi-rx-bus-width = <4>;
+		spi-tx-bus-width = <4>;
+
+		partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x0 0x200000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "u-boot-env";
+				reg = <0x200000 0x100000>;
+			};
+
+			partition@300000 {
+				label = "ubi0";
+				reg = <0x300000 0x3200000>;
+			};
+
+			partition@3500000 {
+				label = "ubi1";
+				reg = <0x3500000 0x3200000>;
+				read-only;
+			};
+
+			partition@6700000 {
+				label = "userconfig";
+				reg = <0x6700000 0x800000>;
+				read-only;
+			};
+
+			partition@6f00000 {
+				label = "tp_data";
+				reg = <0x6f00000 0x800000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio0_pins>;
+	status = "okay";
+};
+
+&gmac0 {
+	status = "okay";
+};
+
+&gmac1 {
+	phy-mode = "internal";
+	phy-connection-type = "internal";
+	phy = <&int_2p5g_phy>;
+	status = "okay";
+};
+
+&gmac2 {
+	phy-mode = "usxgmii";
+	phy-connection-type = "usxgmii";
+	phy = <&phy0>;
+	status = "okay";
+};
+
+&gsw_phy3 {
+	status = "disabled";
+};
+
+&mdio_bus {
+	phy0: ethernet-phy@0 {
+		/* RTL8261N */
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <0>;
+
+		reset-gpios = <&pio 3 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+	};
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+
+	rt5190a_64: rt5190a@64 {
+		compatible = "richtek,rt5190a";
+		reg = <0x64>;
+		/*interrupts-extended = <&gpio26 0 IRQ_TYPE_LEVEL_LOW>;*/
+		vin2-supply = <&rt5190_buck1>;
+		vin3-supply = <&rt5190_buck1>;
+		vin4-supply = <&rt5190_buck1>;
+
+		regulators {
+			rt5190_buck1: buck1 {
+				regulator-name = "rt5190a-buck1";
+				regulator-min-microvolt = <5090000>;
+				regulator-max-microvolt = <5090000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			buck2 {
+				regulator-name = "vcore";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			rt5190_buck3: buck3 {
+				regulator-name = "vproc";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+			};
+
+			buck4 {
+				regulator-name = "rt5190a-buck4";
+				regulator-min-microvolt = <850000>;
+				regulator-max-microvolt = <850000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			ldo {
+				regulator-name = "rt5190a-ldo";
+				regulator-min-microvolt = <1200000>;
+				regulator-max-microvolt = <1200000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+		};
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_1_pins>;
+	reset-gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		mt7996@0,0 {
+			reg = <0x0000 0 0 0 0>;
+		};
+	};
+};
+
+&pio {
+	button_pins: button-pins {
+		pins = "GPIO_RESET", "GPIO_WPS";
+		bias-disable; /* bias-disable */
+	};
+
+	mdio0_pins: mdio0-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio0";
+		};
+
+		conf {
+			groups = "mdc_mdio0";
+			drive-strength = <MTK_DRIVE_8mA>;
+		};
+	};
+
+	i2c0_pins: i2c0-pins-g0 {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+
+	pcie0_1_pins: pcie0-pins-g1 {
+		mux {
+			function = "pcie";
+			groups = "pcie_2l_0_pereset", "pcie_clk_req_n0_0";
+		};
+	};
+
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+
+	enable-usb-power {
+        gpio-hog;
+        gpios = <32 GPIO_ACTIVE_HIGH>;
+        output-high;
+        line-name = "USB power";
+    };
+};
+
+&ssusb1 {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+
+	ports {
+		port@0 {
+			label = "lan3";
+		};
+
+		port@1 {
+			label = "lan2";
+		};
+
+		port@2 {
+			label = "lan1";
+		};
+
+		port@3 {
+			status = "disabled";
+		};
+	};
+};
+
+&tphy {
+	status = "okay";
+};
+
+&serial0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -214,6 +214,11 @@ teltonika,rutc50)
 totolink,x6000r)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
 	;;
+tplink,be450)
+	ucidef_set_led_netdev "br-lan" "lan" "blue:lan" "br-lan" "link tx rx"
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan-2ghz" "phy0.0-ap0"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan-5ghz" "phy0.1-ap0"
+	;;
 tplink,fr365-v1)
 	ucidef_set_led_netdev "port2-green-act" "port-2" "green:port2_act" "port2" "link tx rx"
 	ucidef_set_led_netdev "port1-green-act" "port-1" "green:sfp" "port1" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -159,6 +159,9 @@ mediatek_setup_interfaces()
 	tplink,archer-ax80-v1)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" eth1
 		;;
+	tplink,be450)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 eth2" eth1
+		;;
 	tplink,re6000xd)
 		ucidef_set_interface_lan "lan1 lan2 eth1"
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -35,6 +35,14 @@ case "$FIRMWARE" in
 		;;
 	esac
 	;;
+"mediatek/mt7996/mt7992_eeprom.bin")
+	case "$board" in
+	tplink,be450)
+		ln -sf /tmp/tp_data/MT7992_EEPROM.bin \
+			/lib/firmware/$FIRMWARE
+		;;
+	esac
+	;;
 *)
 	exit 1
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -156,6 +156,7 @@ case "$board" in
 		;;
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
+	tplink,be450|\
 	tplink,re6000xd)
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -16,6 +16,7 @@ preinit_mount_cfg_part() {
 	mercusys,mr80x-v3|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
+	tplink,be450|\
 	tplink,re6000xd)
 		mount_ubi_part "tp_data" "tp_data"
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -43,6 +43,11 @@ preinit_set_mac_address() {
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		ip link set dev eth1 address "$(macaddr_add $addr 1)"
 		;;
+	tplink,be450)
+		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
+		ip link set dev eth1 address "$(macaddr_add $addr 1)"
+		ip link set dev eth2 address "$(macaddr_add $addr 2)"
+		;;
 	tplink,fr365-v1)
 		lan_mac=$(strings /dev/mtd11 | grep 'option macaddr' | awk -F"'" '{print $2}')
 		wan_mac="$(macaddr_add $lan_mac 1)"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -182,6 +182,7 @@ platform_do_upgrade() {
 	mercusys,mr80x-v3|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
+	tplink,be450|\
 	tplink,re6000xd)
 		CI_UBIPART="ubi0"
 		nand_do_upgrade "$1"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2234,6 +2234,21 @@ define Device/tplink_archer-ax80-v1
 endef
 TARGET_DEVICES += tplink_archer-ax80-v1
 
+define Device/tplink_be450
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := BE450
+  DEVICE_DTS := mt7988d-tplink-be450
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7992-firmware kmod-usb3 \
+	    mt7988-2p5g-phy-firmware mt7988-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 51200k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += tplink_be450
+
 define Device/tplink_re6000xd
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := RE6000XD


### PR DESCRIPTION
mediatek: filogic: add support for TP-LINK BE450
This commit adds support for TP-LINK BE450.

Device specification
--------------------
SoC Type:   MediaTek MT7988D, Cortex-A73, 64-bit
RAM:           512MB
Flash:          SPI NAND GigaDevice (128 MiB)
Ethernet:    MediaTek MT7531AE (3 Ports) + 2.5GbE (internal MT7988 phy) + 10GbE (RTL8261N)

WLAN:         MT7992
WLAN 2g:    MediaTek MT7975N, b/g/n/ax/be, MIMO 4x4
WLAN 5g:    MediaTek MT7979N, a/n/ac/ax/be, MIMO 4x4
LEDs:           8 LEDs, 1 status blue, 2x WIFI blue, 2x Internet
	             blue/orange, 1 LAN blue, 1 usb blue, 1 wps blue, gpio-controlled
Button:       2 (Reset, WPS)
USB port:   Yes
Power:        12 VDC, 2 A
Connector:  Barrel
Bootloader: Main U-Boot - U-Boot 2023.10-rc4. Additionally, ubi0
                      partition contain "seconduboot" (also U-Boot 2023.10-rc4)

Serial console (UART), unpopulated, located near the power connector
---------------------
```
heatsink
|   |
|   |
|   |     +----+-----+------+-------+               +-----------------+
|   |     | TX |  RX |  GND | +3.3V |               | power connector |
+---+     +----+-----+------+-------+               +-----------------+
                                  |
                Don't connect ----+
```
Disassemble: rm the 2 screws at the bottom and the one at the backside.
             un-clip the case starting at the edge above the LEDs.

Installation (UART)
-------------------
1. Place OpenWrt initramfs image on tftp server with IP 192.168.1.2
2. Attach UART, switch on the router and interrupt the boot process by
   pressing 'Ctrl-C'
3. Load and run OpenWrt initramfs image:
      tftpboot 0x50000000 openwrt-mediatek-filogic-tplink_be450-initramfs-kernel.bin && bootm 0x50000000
4. Run 'sysupgrade -n' with the sysupgrade OpenWrt image

Note: 

the 10GbE (RTL8261N) is only working if reverting this Realtek target specific commit:
https://github.com/openwrt/openwrt/commit/b77fa45d1278443d534919598c0301719fed2784

The second ubi partition (ubi1) is empty and there is no known
dual-partition mechanism, neither in u-boot nor in the stock firmware.

NMBM is not used.

Not Working: WED, if activated, MT7992 isn't recognized any more.

Signed-off-by: Dirk Buchwalder <buchwalder@posteo.de>