### PR TITLE
ipq-wifi/ath10k: fix 5GHz radio detection on TP-Link Archer C59 v1

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -78,6 +78,7 @@ ALLWIFIBOARDS:= \
 	tplink_eap623od-hd-v1 \
 	tplink_eap625-outdoor-hd-v1 \
 	tplink_eap660hd-v1 \
+	tplink_archer-c59-v1 \
 	tplink_archer-c6-v2 \
 	tplink_archer-c60-v1 \
 	wallys_dr40x9 \
@@ -250,6 +251,7 @@ $(eval $(call generate-ipq-wifi-package,tplink_eap620hd-v1,TP-Link EAP620 HD v1)
 $(eval $(call generate-ipq-wifi-package,tplink_eap623od-hd-v1,TP-Link EAP623-Outdoor HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap625-outdoor-hd-v1,TP-Link EAP625-Outdoor HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap660hd-v1,TP-Link EAP660 HD v1))
+$(eval $(call generate-ipq-wifi-package,tplink_archer-c59-v1,TP-Link Archer C59 V1))
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c6-v2,TP-Link Archer C6 V2))
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c60-v1,TP-Link Archer C60 V1))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
@@ -37,6 +37,7 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&precal_art_5000>, <&macaddr_info_8 (-1)>;
 		nvmem-cell-names = "pre-calibration", "mac-address";
+		qcom,ath10k-calibration-variant = "TP-Link-Archer-c59-v1";
 	};
 };
 

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -79,7 +79,7 @@ define Device/tplink_archer-c59-v1
   DEVICE_VARIANT := v1
   TPLINK_BOARD_ID := ARCHER-C59-V1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k-ct \
-	ath10k-firmware-qca9888-ct
+	ath10k-firmware-qca9888-ct ipq-wifi-tplink_archer-c59-v1
   SUPPORTED_DEVICES += archer-c59-v1
 endef
 TARGET_DEVICES += tplink_archer-c59-v1


### PR DESCRIPTION

This should fix the 5ghz radio detection on TP-Link Archer C59 v1. Boarddata was extracted from the EU vendor firmware and successfully tested by @matjon.

Requires https://github.com/openwrt/firmware_qca-wireless/pull/108 to be merged first and ipq-wifi to be updated to head.

Fixes: https://github.com/openwrt/openwrt/issues/18223