### PR TITLE
mediatek: mt7981: add support for Widelantech WAP430X

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-widelantech-wap430x.dts
+++ b/target/linux/mediatek/dts/mt7981b-widelantech-wap430x.dts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include <dt-bindings/leds/common.h>
+#include "mt7981b.dtsi"
+
+/ {
+	compatible = "widelantech,wap430x", "mediatek,mt7981b";
+	model = "Widelantech WAP430X";
+
+	aliases {
+		label-mac-device = &gmac1;
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		btn-0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0 0x40000000 0 0x10000000>;
+	};
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	status = "okay";
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_24>;
+	};
+};
+
+&pio {
+	spi2_flash_pins: spi2-pins {
+		mux {
+			function = "spi";
+			groups = "spi2", "spi2_wp_hold";
+		};
+	};
+};
+
+&spi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x40000 0x10000>;
+				read-only;
+			};
+
+			partition@50000 {
+				label = "Factory";
+				reg = <0x50000 0xb0000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					// LAN MAC address
+					macaddr_factory_24: macaddr@24 {
+						reg = <0x24 0x6>;
+					};
+
+					// WAN MAC address (not used)
+					/* macaddr@2a {
+						reg = <0x2a 0x6>;
+					}; */
+				};
+			};
+
+			partition@100000 {
+				label = "FIP";
+				reg = <0x100000 0x80000>;
+				read-only;
+			};
+
+			partition@180000 {
+				compatible = "denx,fit";
+				label = "firmware";
+				reg = <0x180000 0xe70000>;
+			};
+
+			partition@ff0000 {
+				label = "opt";
+				reg = <0xff0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory 0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -112,6 +112,7 @@ mediatek_setup_interfaces()
 	openfi,6c|\
 	ubnt,unifi-6-plus|\
 	wavlink,wl-wn573hx3|\
+	widelantech,wap430x|\
 	zyxel,nwa50ax-pro)
 		ucidef_set_interface_lan "eth0"
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -157,9 +157,10 @@ platform_do_upgrade() {
 		;;
 	cudy,re3000-v1|\
 	cudy,wr3000-v1|\
-	yuncore,ax835|\
+	totolink,x6000r|\
 	wavlink,wl-wn573hx3|\
-	totolink,x6000r)
+	widelantech,wap430x|\
+	yuncore,ax835)
 		default_do_upgrade "$1"
 		;;
 	dlink,aquila-pro-ai-m30-a1|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2626,6 +2626,21 @@ define Device/wavlink_wl-wn573hx3
 endef
 TARGET_DEVICES += wavlink_wl-wn573hx3
 
+define Device/widelantech_wap430x
+  DEVICE_VENDOR := Widelantech
+  DEVICE_MODEL := WAP430X
+  DEVICE_ALT1_VENDOR := Widelantech
+  DEVICE_ALT1_MODEL := AX3000AM
+  DEVICE_ALT1_VENDOR := UeeVii
+  DEVICE_ALT1_MODEL := UAP200
+  DEVICE_DTS := mt7981b-widelantech-wap430x
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  IMAGE_SIZE := 14784k
+  SUPPORTED_DEVICES += UAP200 AX3000AM # allow upgrade via GECOOS UART menu
+endef
+TARGET_DEVICES += widelantech_wap430x
+
 define Device/xiaomi_mi-router-ax3000t
   DEVICE_VENDOR := Xiaomi
   DEVICE_MODEL := Mi Router AX3000T


### PR DESCRIPTION
This AX3000 flying saucer-shaped device is sold under a few names:
- Widelantech [WAP430X](http://www.widelantech.com/?m=home&c=View&a=index&aid=131)
- Felicomm (Widelantech's English counterpart)
- UeeVii UAP200 (sold on amazon.com) True name, as marked on the PCB and as appears in the DTS, is WAP430X.

Hardware:
- SoC: Mediatek MT7981B
- RAM: 256MiB DDR3
- ROM: 16MiB NOR flash (Winbond 25Q128JVSQ)
- Wired: one GbE RJ45 port
- Wireless: Mediatek MT7976CN DBDC
- Antennas: Internal (two 2.4 GHz 4.5 dBi, three 5 GHz 6 dBi)
- GPIO: two blue LEDs (status, WLAN), one button (reset)
- Power: DC5521 (12V) or 802.3af PoE (48V 0.3A)
- UART: J500 on PCB [3v3] (Rx) (Tx) (Gnd), 115200n

Original firmware is GECOOS 8.0_2024081000, a fork of OpenWrt 21.02 created by Widelantech. All ports are closed except 443 (web management interface) and 80 (redirects to 443). UART is locked down, but U-Boot bootloader is friendly.

Installation is done via UART (see note below).

Method 1: press any key during boot to enter MTK U-Boot bootloader, then choose option 2 (Upgrade firmware) and upload sysupgrade binary via TFTP (or via Xmodem).

Method 2: put sysupgrade binary on a webserver (http, not https); after GECOOS loads, choose option 4 (固件在线升级 = online firmware upgrade) in the menu and enter the URL to the sysupgrade binary.

Note: GECOOS has a slick web management, and firmware can be uploaded at https://6.6.6.6/#/system/sysupgrade but it's still not clear how to convert the sysupgrade binary to a factory binary accepted by the web interface (WIP).

