### PR TITLE
mediatek: flogic: platform.sh fix typo

### DIFF
--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -102,7 +102,7 @@ platform_do_upgrade() {
 	netcore,n60-pro|\
 	qihoo,360t7|\
 	routerich,ax3000-ubootmod|\
- 	snr,snr-cpe-ax2|\
+	snr,snr-cpe-ax2|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088|\


### PR DESCRIPTION
Fixes:
https://github.com/openwrt/openwrt/commit/726bb8e0e2fca96a160b3abbbf8e18227749cc27 ("mediatek: filogic: add support for SNR-CPE-AX2")

