### PR TITLE
qualcommax: ipq50xx: fix XO board clock rate for Yuncore AX850

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
@@ -147,7 +147,8 @@
 };
 
 &xo_board_clk {
-	clock-frequency = <24000000>;
+	clock-div = <4>;
+	clock-mult = <1>;
 };
 
 &blsp1_uart1 {


### PR DESCRIPTION
Commit 468975a985ab changed the XO board clock definition from a fixed clock to a fixed rate clock in the dtsi.

As such, boards must use clock dividers and multipliers to calculate the clock rate based on the referenced parent clock.

Fixes: 5d2994a73e20 ("qualcommax: ipq50xx: Add support for Yuncore AX850")