### PR TITLE
kernel: rockchip: backport 6.17 pcie driver

### DIFF
--- a/target/linux/rockchip/patches-6.12/036-06-v6.17-phy-rockchip-pcie-Enable-all-four-lanes-if-required.patch
+++ b/target/linux/rockchip/patches-6.12/036-06-v6.17-phy-rockchip-pcie-Enable-all-four-lanes-if-required.patch
@@ -1,0 +1,50 @@
+From c3fe7071e196e25789ecf90dbc9e8491a98884d7 Mon Sep 17 00:00:00 2001
+From: Valmantas Paliksa <walmis@gmail.com>
+Date: Mon, 30 Jun 2025 19:25:14 -0300
+Subject: [PATCH] phy: rockchip-pcie: Enable all four lanes if required
+
+Current code enables only Lane 0 because pwr_cnt will be incremented on
+first call to the function. Let's reorder the enablement code to enable
+all 4 lanes through GRF.
+
+Reviewed-by: Neil Armstrong <neil.armstrong@linaro.org>
+Reviewed-by: Robin Murphy <robin.murphy@arm.com>
+
+Signed-off-by: Valmantas Paliksa <walmis@gmail.com>
+Signed-off-by: Geraldo Nascimento <geraldogabriel@gmail.com>
+Reviewed-by: Robin Murphy <robin.murphy@arm.com>
+Reviewed-by: Neil Armstrong <neil.armstrong@linaro.org>
+Link: https://lore.kernel.org/r/16b610aab34e069fd31d9f57260c10df2a968f80.1751322015.git.geraldogabriel@gmail.com
+Signed-off-by: Vinod Koul <vkoul@kernel.org>
+---
+ drivers/phy/rockchip/phy-rockchip-pcie.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+--- a/drivers/phy/rockchip/phy-rockchip-pcie.c
++++ b/drivers/phy/rockchip/phy-rockchip-pcie.c
+@@ -165,6 +165,12 @@ static int rockchip_pcie_phy_power_on(st
+ 
+ 	mutex_lock(&rk_phy->pcie_mutex);
+ 
++	regmap_write(rk_phy->reg_base,
++		     rk_phy->phy_data->pcie_laneoff,
++		     HIWORD_UPDATE(!PHY_LANE_IDLE_OFF,
++				   PHY_LANE_IDLE_MASK,
++				   PHY_LANE_IDLE_A_SHIFT + inst->index));
++
+ 	if (rk_phy->pwr_cnt++)
+ 		goto err_out;
+ 
+@@ -179,12 +185,6 @@ static int rockchip_pcie_phy_power_on(st
+ 				   PHY_CFG_ADDR_MASK,
+ 				   PHY_CFG_ADDR_SHIFT));
+ 
+-	regmap_write(rk_phy->reg_base,
+-		     rk_phy->phy_data->pcie_laneoff,
+-		     HIWORD_UPDATE(!PHY_LANE_IDLE_OFF,
+-				   PHY_LANE_IDLE_MASK,
+-				   PHY_LANE_IDLE_A_SHIFT + inst->index));
+-
+ 	/*
+ 	 * No documented timeout value for phy operation below,
+ 	 * so we make it large enough here. And we use loop-break


### PR DESCRIPTION
This patch resolves the LAN port not initializing on the FriendlyElec NanoPI R4S, especially during warm reboots.

Upstream commit patch is based on:
https://github.com/torvalds/linux/commit/c3fe7071e196e25789ecf90dbc9e8491a98884d7

I've experienced the LAN port failing to initialize from a cold boot and after a reboot. Other users have reported this issue on https://forum.openwrt.org/t/nanopi-r4s-rk3399-is-a-great-new-openwrt-device/79143. The NanoPI R4S has its LAN port connected to the RK3399 via PCIE. Since the PCIE lanes don't initialize correctly after reboot, the LAN port doesn't initialize.

This patch was originally included in https://github.com/openwrt/openwrt/pull/18078, based on https://github.com/armbian/build/pull/7572 (original patch prior to upstream inclusion).

Several users have tested custom builds with this patch included with success.