### PR TITLE
[24.10] mediatek: filogic: add ASUS RT-AX52 factory-initramfs image generation

### DIFF
--- a/target/linux/mediatek/image/Makefile
+++ b/target/linux/mediatek/image/Makefile
@@ -33,6 +33,11 @@ define Device/Default
 	pad-rootfs | append-metadata
 endef
 
+define Build/asus-trx
+	$(STAGING_DIR_HOST)/bin/asusuimage $(wordlist 1,$(words $(1)),$(1)) -i $@ -o $@.new
+	mv $@.new $@
+endef
+
 include $(SUBTARGET).mk
 
 define Image/Build

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -270,6 +270,9 @@ define Device/asus_rt-ax52
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  ARTIFACTS := initramfs.trx
+  ARTIFACT/initramfs.trx := append-image-stage initramfs-kernel.bin | \
+	uImage none | asus-trx -v 3 -n $$(DEVICE_MODEL)
 endef
 TARGET_DEVICES += asus_rt-ax52
 


### PR DESCRIPTION
This adds the required image receipt to generate a vendor ui compatible initramfs-factory image, that can be used to flash the final sysupgrade image.

This is already included in main and was omitted when backporting the patch to 24.10.

As the commit massage mentions this image in the install instructions and it enables users to easily flash these devices without opening the case and soldering a uart header, it would be beneficially to backport the initramfs-factory generation as well.
