### PR TITLE
ramips: mt7621: add support for D-Link DIR-X1860 B1 / DIR-X1550 A1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-x1860-b1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-x1860-b1.dts
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "dlink,dir-x1860-b1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-X1860 B1 / DIR-X1550 A1";
+
+	aliases {
+		label-mac-device = &ethernet;
+		led-boot = &status_orange;
+		led-failsafe = &status_orange;
+		led-running = &status_white;
+		led-upgrade = &status_orange;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		status_white: power {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		status_orange: status_orange {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		wan_white {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "mt7530-0:04:link";
+		};
+
+		wan_orange {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
+				};
+			};
+		};
+
+		partition@180000 {
+			label = "config2";
+			reg = <0x180000 0x40000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_config2_10: macaddr@10 {
+					compatible = "mac-base";
+					reg = <0x10 0x11>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@1c0000 {
+			label = "kernel";
+			reg = <0x1c0000 0x800000>;
+		};
+
+		fwconcat0: partition@9c0000 {
+			label = "fwconcat0";
+			reg = <0x9c0000 0x2000000>;
+		};
+
+		partition@29c0000 {
+			label = "kernel2";
+			reg = <0x29c0000 0x800000>;
+			read-only;
+		};
+
+		fwconcat1: partition@31c0000 {
+			label = "fwconcat1";
+			reg = <0x31c0000 0x2a00000>;
+		};
+
+		partition@5bc0000 {
+			label = "private";
+			reg = <0x5bc0000 0x1400000>;
+			read-only;
+		};
+
+		partition@6fc0000 {
+			label = "mydlink";
+			reg = <0x6fc0000 0x600000>;
+			read-only;
+		};
+
+		partition@75c0000 {
+			label = "myconfig";
+			reg = <0x75c0000 0xa00000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
+		mediatek,disable-radar-background;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_config2_10 1>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_config2_10 2>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_config2_10 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+	nvmem-cells = <&macaddr_config2_10 3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1093,6 +1093,30 @@ define Device/dlink_dir-882-r1
 endef
 TARGET_DEVICES += dlink_dir-882-r1
 
+define Device/dlink_dir-x1860-b1
+  $(Device/nand)
+  KERNEL_SIZE := 8192k
+  IMAGE_SIZE := 40960k
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DIR-X1860
+  DEVICE_VARIANT := B1
+  DEVICE_ALT0_VENDOR := D-Link
+  DEVICE_ALT0_MODEL := DIR-X1550
+  DEVICE_ALT0_VARIANT := A1
+  DEVICE_PACKAGES := kmod-mt7915-firmware
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
+	append-squashfs4-fakeroot
+  IMAGES += factory.bin recovery.bin
+  IMAGE/recovery.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin) | \
+	append-dlink-covr-metadata $$(DEVICE_MODEL) | \
+	dlink-sge-image $$(DEVICE_MODEL)-$$(DEVICE_VARIANT)
+endef
+TARGET_DEVICES += dlink_dir-x1860-b1
+
 define Device/dlink_dra-1360-a1
   $(Device/dlink_dxx-1xx0-x1)
   DEVICE_MODEL := DRA-1360

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -13,6 +13,7 @@ ramips_setup_interfaces()
 	buffalo,wsr-2533dhpl2|\
 	buffalo,wsr-2533dhpls|\
 	confiabits,mt7621-v1|\
+	dlink,dir-x1860-b1|\
 	gehua,ghl-r-001|\
 	h3c,tx1800-plus|\
 	h3c,tx1801-plus|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -84,7 +84,7 @@ platform_do_upgrade() {
 	dlink,covr-x1860-a1|\
 	dlink,dap-x1860-a1|\
 	dlink,dir-1960-a1|\
-        dlink,dir-2055-a1|\
+	dlink,dir-2055-a1|\
 	dlink,dir-2150-a1|\
 	dlink,dir-2150-r1|\
 	dlink,dir-2640-a1|\
@@ -92,6 +92,7 @@ platform_do_upgrade() {
 	dlink,dir-3040-a1|\
 	dlink,dir-3060-a1|\
 	dlink,dir-853-a3|\
+	dlink,dir-x1860-b1|\
 	elecom,wmc-x1800gst|\
 	elecom,wsc-x1800gs|\
 	etisalat,s3|\


### PR DESCRIPTION
Both devices seem to be completely identical and D-Link doesnt even mention the DIR-X1550 A1 in the GPL source. Furthermore the supported devices header also just contains DIR-X1860 B1. The cherry on top is the FCC filing, which features the manual for DIR-X1550 A1 but the label info for DIR-X1860 B1. I guess someone at D-Link was just as confused as me.

Hardware
--------
SOC:    MediaTek MT7621AT
FLASH:  128MB (Spansion S34ML01G200TF100)
RAM:    256MB (Winbond W632GU6NB-12)
WIFI:   MediaTek MT7915DAN + MT7975DN DBDC 2x2 802.11ax
ETH:	1x WAN, 3x LAN
LED:	6 (4 GPIO controllable, 2 WIFI hardwired)
BTN:	WPS, Reset
UART:	115200 8N1 (Pinout silkscreened) - ignore VCC

MAC addresses
-------------
LAN	Label MAC (stored in config2 partition as ASCII (entry
	factory_mac=xx:xx:xx:xx:xx:xx))
WAN	LAN + 3
2.4G	LAN + 1
5G	LAN + 2

Installation
------------
Vendor UI
---------
1. Browse to http://192.168.0.1 and login.
2. Navigate to "Management" -> "Upgrade".
3. Press the "Select File" button and upload openwrt-ramips-mt7621-dlink_dir-x1860-b1-squashfs-factory.bin
4. Confirm the security questions, wait for a reboot and enjoy OpenWrt.

Recovery UI
-----------
1. Set your IP address to 192.168.0.101, subnet 255.255.255.0.
2. Power on the device while holding reset.
3. Release reset once the status led starts to blink orange.
4. Open a chrome- or firefox based browser and browse to https://192.168.0.1
5. Upload openwrt-ramips-mt7621-dlink_dir-x1860-b1-squashfs-recovery.bin wait for a reboot and enjoy OpenWrt.

Back to stock
-------------
1. Set your IP address to 192.168.0.101, subnet 255.255.255.0.
2. Power on the device while holding reset.
3. Release reset once the status led starts to blink orange.
4. Open a chrome- or firefox based browser and browse to https://192.168.0.1
5. Upload a decrypted vendor image, wait for a reboot and regret your decision.

Decrypt vendor image
--------------------
1. Download dlink-sge-image.c and dlink-sge-image.h from the firmware-utils openwrt repository.
2. Compile a binary from the downloaded file e.g. gcc dlink-sge-image.c -lcrypto -o dlink-sge-image
3. Run ./dlink-sge-image DIR-X1860-B1 <vendor_image> <decrypted_image> -d
