### PR TITLE
realtek: rtl93xx: Trap BPDU management frames

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -529,6 +529,7 @@ static int rtl93xx_setup(struct dsa_switch *ds)
 
 	rtl83xx_vlan_setup(priv);
 
+	rtldsa_setup_bpdu_traps(priv);
 	rtldsa_setup_lldp_traps(priv);
 
 	ds->configure_vlan_while_not_filtering = true;


### PR DESCRIPTION
BPDU frames like STP must be processed by each switch (bridge) which supports STP. It must not be forwarded to avoid confusing the STP state of other STP participants. It is essential to be an active participant of STP. The software bridge automatically takes care of forwarding the BPDUs to other ports when STP is disabled and the hardware switch should not interfere.

It is important to only be used together with the fixed port transmission (#19802) to avoid incorrectly reflected STP BPDUs (by the software bridge) when STP is disabled.

It is also highly recommended to also disable L3 offloading (with #20208) when playing around with STP+VLANs. The current implementation in RTL930x is slightly problematic and results in various unexpected behaviors.