### PR TITLE
realtek: dsa: rtl93xx: Implement MSTP state support

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -1542,6 +1542,12 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		return err;
 	}
 
+	priv->msts = devm_kcalloc(priv->dev,
+				  priv->n_mst - 1, sizeof(struct rtldsa_mst),
+				  GFP_KERNEL);
+	if (!priv->msts)
+		return -ENOMEM;
+
 	priv->wq = create_singlethread_workqueue("rtl83xx");
 	if (!priv->wq) {
 		dev_err(dev, "Error creating workqueue: %d\n", err);

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -1501,7 +1501,7 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		 */
 		priv->version = RTL8390_VERSION_A;
 		priv->ds->num_lag_ids = 16;
-		sw_w32(1, RTL930X_ST_CTRL);
+		sw_w32(0, RTL930X_ST_CTRL);
 		priv->l2_bucket_size = 8;
 		priv->n_pie_blocks = 16;
 		priv->port_ignore = 0x3f;
@@ -1521,7 +1521,7 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		 */
 		priv->version = RTL8390_VERSION_A;
 		priv->ds->num_lag_ids = 16;
-		sw_w32(1, RTL931x_ST_CTRL);
+		sw_w32(0, RTL931x_ST_CTRL);
 		priv->l2_bucket_size = 8;
 		priv->n_pie_blocks = 16;
 		priv->port_ignore = 0x3f;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -1467,6 +1467,7 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		rtl8380_get_version(priv);
 		priv->ds->num_lag_ids = 8;
 		priv->l2_bucket_size = 4;
+		priv->n_mst = 64;
 		priv->n_pie_blocks = 12;
 		priv->port_ignore = 0x1f;
 		priv->n_counters = 128;
@@ -1483,6 +1484,7 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		rtl8390_get_version(priv);
 		priv->ds->num_lag_ids = 16;
 		priv->l2_bucket_size = 4;
+		priv->n_mst = 256;
 		priv->n_pie_blocks = 18;
 		priv->port_ignore = 0x3f;
 		priv->n_counters = 1024;
@@ -1503,6 +1505,7 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->ds->num_lag_ids = 16;
 		sw_w32(0, RTL930X_ST_CTRL);
 		priv->l2_bucket_size = 8;
+		priv->n_mst = 64;
 		priv->n_pie_blocks = 16;
 		priv->port_ignore = 0x3f;
 		priv->n_counters = 2048;
@@ -1523,6 +1526,7 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->ds->num_lag_ids = 16;
 		sw_w32(0, RTL931x_ST_CTRL);
 		priv->l2_bucket_size = 8;
+		priv->n_mst = 128;
 		priv->n_pie_blocks = 16;
 		priv->port_ignore = 0x3f;
 		priv->n_counters = 2048;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -1819,6 +1819,10 @@ static int rtl83xx_vlan_del(struct dsa_switch *ds, int port,
 	info.untagged_ports &= (~BIT_ULL(port));
 	info.member_ports &= (~BIT_ULL(port));
 
+	/* VLANs without members are set back (implicitly) to CIST by DSA */
+	if (!info.member_ports)
+		info.fid = 0;
+
 	priv->r->vlan_set_untagged(vlan->vid, info.untagged_ports);
 	pr_debug("Untagged ports, VLAN %d: %llx\n", vlan->vid, info.untagged_ports);
 

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -1830,6 +1830,21 @@ static int rtl83xx_vlan_del(struct dsa_switch *ds, int port,
 	return 0;
 }
 
+static int rtldsa_port_vlan_fast_age(struct dsa_switch *ds, int port, u16 vid)
+{
+	struct rtl838x_switch_priv *priv = ds->priv;
+	int ret;
+
+	if (!priv->r->vlan_port_fast_age)
+		return -EOPNOTSUPP;
+
+	mutex_lock(&priv->reg_mutex);
+	ret = priv->r->vlan_port_fast_age(priv, port, vid);
+	mutex_unlock(&priv->reg_mutex);
+
+	return ret;
+}
+
 static void rtl83xx_setup_l2_uc_entry(struct rtl838x_l2_entry *e, int port, int vid, u64 mac)
 {
 	memset(e, 0, sizeof(*e));
@@ -2680,6 +2695,7 @@ const struct dsa_switch_ops rtl93xx_switch_ops = {
 	.port_vlan_filtering	= rtl83xx_vlan_filtering,
 	.port_vlan_add		= rtl83xx_vlan_add,
 	.port_vlan_del		= rtl83xx_vlan_del,
+	.port_vlan_fast_age	= rtldsa_port_vlan_fast_age,
 
 	.port_fdb_add		= rtl83xx_port_fdb_add,
 	.port_fdb_del		= rtl83xx_port_fdb_del,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -1597,9 +1597,20 @@ static void rtldsa_port_xstp_state_set(struct rtl838x_switch_priv *priv, int por
 void rtl83xx_port_stp_state_set(struct dsa_switch *ds, int port, u8 state)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
+	struct dsa_port *dp = dsa_to_port(ds, port);
+	unsigned int i;
 
 	mutex_lock(&priv->reg_mutex);
 	rtldsa_port_xstp_state_set(priv, port, state, 0);
+
+	if (dp->bridge)
+		goto unlock;
+
+	/* for unbridged ports, also force the same state to the MSTIs */
+	for (i = 1; i < priv->n_mst; i++)
+		rtldsa_port_xstp_state_set(priv, port, state, i);
+
+unlock:
 	mutex_unlock(&priv->reg_mutex);
 }
 

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -781,6 +781,14 @@ struct rtl838x_vlan_info {
 	int l2_tunnel_list_id;
 };
 
+struct rtldsa_mst {
+	/** @msti: MSTI mapped to this slot. 0 == unused */
+	u16 msti;
+
+	/** @refcount: number of vlans currently using this msti, undefined when unused */
+	struct kref refcount;
+};
+
 enum l2_entry_type {
 	L2_INVALID = 0,
 	L2_UNICAST = 1,
@@ -1251,6 +1259,12 @@ struct rtl838x_switch_priv {
 	struct rtl838x_l3_intf *interfaces[MAX_INTERFACES];
 	u16 intf_mtus[MAX_INTF_MTUS];
 	int intf_mtu_count[MAX_INTF_MTUS];
+
+	/**
+	 * @msts: MSTI to HW MST slot allocations. index 0 is for HW slot 1 because CIST is
+	 * not stored in @msts
+	 */
+	struct rtldsa_mst *msts;
 	struct delayed_work counters_work;
 };
 

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1132,6 +1132,7 @@ struct rtl838x_reg {
 	void (*vlan_port_pvidmode_set)(int port, enum pbvlan_type type, enum pbvlan_mode mode);
 	void (*vlan_port_pvid_set)(int port, enum pbvlan_type type, int pvid);
 	void (*vlan_port_keep_tag_set)(int port, bool keep_outer, bool keep_inner);
+	int (*vlan_port_fast_age)(struct rtl838x_switch_priv *priv, int port, u16 vid);
 	void (*set_vlan_igr_filter)(int port, enum igr_filter state);
 	void (*set_vlan_egr_filter)(int port, enum egr_filter state);
 	void (*enable_learning)(int port, bool enable);

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1215,6 +1215,7 @@ struct rtl838x_switch_priv {
 	u64 irq_mask;
 	u32 fib_entries;
 	int l2_bucket_size;
+	u16 n_mst;
 	struct dentry *dbgfs_dir;
 
 	/** @lags_port_members: Port (bit) is part of a specific LAG */


### PR DESCRIPTION
The MSTP support (usually implemented by mstpd) requires from the kernel that a VLAN can associated with an MSTI. At the moment, all these VLANs just get the MSTI 0 harcoded on creation. But the `vlan_tables_read()`+`vlan_tables_write()` helper already allow the modification of the MSTI and only require a minimal hook to expose this functionality.

It is also necessary to adjust the (M)STP states per MSTI and not only per port (or for the CIST). The rtl83xx_port_stp_state_set() function was in theory already capable to modify other MSTIs than CIST - if the MSTI would not have been hardcoded to 0.

The userspace can trigger these modifications using netlink:

* (Re)associating VLANs with an MSTI:

      bridge vlan global set dev <BR> vid <X> msti <Y>

* Setting the port state in a given MSTI:

      bridge mst set dev <PORT> msti <Y> state <Z>

But the HW was configured via  the `ST_CTRL` to always assume the `CIST` (MSTI 0) and ignore any other configuration for VLANs. This must then of course be disabled - which should not be a problem because the VLANs are currently always created with CIST (MSTI 0).

---

Also, the DSA port code is trying to flush associated VLANs whenever the MST  state is changed. This functionality is available on a per port+vid based using the `L2_TBL_FLUSH_CTRL` which is already used for the `.port_fast_age` callbacks.

An implementation specific for the VLAN therefore only required to toggle the VLAN bit and to write the VLAN in the request.

---

To get MSTP working at the end, it is of course also required to run a `MSTP` compatible userspace implementation (which implements `/sbin/bridge-stp`) instead of the old kernel STP implementation from the bridge code. `mstpd` should be used (and it must be checked that `/sys/class/net/switch/bridge/stp_state` is `2` for the userspace STP).

The userspace implementation also requires that the per port transmission work (#20208) and that BPDUs are trapped to the CPU (#20414)

When testing it, it is highly recommended to disable L3 offloading (#20208) to avoid weird offloading problems.