### PR TITLE
realtek: dsa: rtl931x: Fix port L2 table flushing

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -1709,15 +1709,20 @@ void rtl83xx_fast_age(struct dsa_switch *ds, int port)
 	mutex_unlock(&priv->reg_mutex);
 }
 
-static void rtl931x_fast_age(struct dsa_switch *ds, int port)
+static void rtldsa_931x_fast_age(struct dsa_switch *ds, int port)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
+	u32 val;
 
-	pr_info("%s port %d\n", __func__, port);
 	mutex_lock(&priv->reg_mutex);
-	sw_w32(port << 11, RTL931X_L2_TBL_FLUSH_CTRL + 4);
 
-	sw_w32(BIT(24) | BIT(28), RTL931X_L2_TBL_FLUSH_CTRL);
+	sw_w32(0, RTL931X_L2_TBL_FLUSH_CTRL + 4);
+
+	val = 0;
+	val |= port << 11;
+	val |= BIT(24); /* compare port id */
+	val |= BIT(28); /* status - trigger flush */
+	sw_w32(val, RTL931X_L2_TBL_FLUSH_CTRL);
 
 	do { } while (sw_r32(RTL931X_L2_TBL_FLUSH_CTRL) & BIT (28));
 
@@ -1729,7 +1734,7 @@ static void rtl930x_fast_age(struct dsa_switch *ds, int port)
 	struct rtl838x_switch_priv *priv = ds->priv;
 
 	if (priv->family_id == RTL9310_FAMILY_ID)
-		return rtl931x_fast_age(ds, port);
+		return rtldsa_931x_fast_age(ds, port);
 
 	pr_debug("FAST AGE port %d\n", port);
 	mutex_lock(&priv->reg_mutex);


### PR DESCRIPTION
The DSA driver must flush the HW FDB when a port changes from learning/forwarding to disabled/blocking/listening.

But the implementation for RTL931x was writing the port information starting at bit 11 (bit 11 of the second 32-bit L2_TBL_FLUSH_CTRL register). But this offset is the AGG_VID and not the port. The actual position is 43 (bit 11 of the first register).

As result, the FDB was always only flushed for the port 0 and not for the selected port.

Fixes: 9ed609705481 ("realtek: Add HW support for RTL931X for PIE, L2 and STP aging")

---

Some references:

* https://svanheule.net/realtek/mango/register/l2_tbl_flush_ctrl
* https://github.com/plappermaul/realtek-doc/blob/main/sources/rtk-dms1250/system/include/private/drv/swcore/swcore_rtl9310.h

      #define RTL9310_L2_TBL_FLUSH_CTRL_ADDR                                                                         (0xCD9C)
        #define RTL9310_L2_TBL_FLUSH_CTRL_STS_OFFSET                                                                 (60)
        #define RTL9310_L2_TBL_FLUSH_CTRL_STS_MASK                                                                   (0x1 << RTL9310_L2_TBL_FLUSH_CTRL_STS_OFFSET)
        #define RTL9310_L2_TBL_FLUSH_CTRL_ACT_OFFSET                                                                 (59)
        #define RTL9310_L2_TBL_FLUSH_CTRL_ACT_MASK                                                                   (0x1 << RTL9310_L2_TBL_FLUSH_CTRL_ACT_OFFSET)
        #define RTL9310_L2_TBL_FLUSH_CTRL_FVID_CMP_OFFSET                                                            (58)
        #define RTL9310_L2_TBL_FLUSH_CTRL_FVID_CMP_MASK                                                              (0x1 << RTL9310_L2_TBL_FLUSH_CTRL_FVID_CMP_OFFSET)
        #define RTL9310_L2_TBL_FLUSH_CTRL_AGG_VID_CMP_OFFSET                                                         (57)
        #define RTL9310_L2_TBL_FLUSH_CTRL_AGG_VID_CMP_MASK                                                           (0x1 << RTL9310_L2_TBL_FLUSH_CTRL_AGG_VID_CMP_OFFSET)
        #define RTL9310_L2_TBL_FLUSH_CTRL_PORT_CMP_OFFSET                                                            (56)
        #define RTL9310_L2_TBL_FLUSH_CTRL_PORT_CMP_MASK                                                              (0x1 << RTL9310_L2_TBL_FLUSH_CTRL_PORT_CMP_OFFSET)
        #define RTL9310_L2_TBL_FLUSH_CTRL_ENTRY_TYPE_OFFSET                                                          (54)
        #define RTL9310_L2_TBL_FLUSH_CTRL_ENTRY_TYPE_MASK                                                            (0x3 << RTL9310_L2_TBL_FLUSH_CTRL_ENTRY_TYPE_OFFSET)
        #define RTL9310_L2_TBL_FLUSH_CTRL_PORT_ID_OFFSET                                                             (43)
        #define RTL9310_L2_TBL_FLUSH_CTRL_PORT_ID_MASK                                                               (0x7FF << RTL9310_L2_TBL_FLUSH_CTRL_PORT_ID_OFFSET)
        #define RTL9310_L2_TBL_FLUSH_CTRL_REPLACING_PORT_ID_OFFSET                                                   (32)
        #define RTL9310_L2_TBL_FLUSH_CTRL_REPLACING_PORT_ID_MASK                                                     (0x7FF << RTL9310_L2_TBL_FLUSH_CTRL_REPLACING_PORT_ID_OFFSET)
        #define RTL9310_L2_TBL_FLUSH_CTRL_FVID_OFFSET                                                                (20)
        #define RTL9310_L2_TBL_FLUSH_CTRL_FVID_MASK                                                                  (0xFFF << RTL9310_L2_TBL_FLUSH_CTRL_FVID_OFFSET)
        #define RTL9310_L2_TBL_FLUSH_CTRL_AGG_VID_OFFSET                                                             (0)
        #define RTL9310_L2_TBL_FLUSH_CTRL_AGG_VID_MASK                                                               (0xFFFFF << RTL9310_L2_TBL_FLUSH_CTRL_AGG_VID_OFFSET)

* https://github.com/plappermaul/realtek-doc/blob/main/sources/rtk-xgs1210/system/include/private/drv/swcore/swcore_rtl9310.h