### PR TITLE
mbedtls: update to 3.6.5

### DIFF
--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=3.6.4
+PKG_VERSION:=3.6.5
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL=https://github.com/Mbed-TLS/$(PKG_NAME)/releases/download/$(PKG_NAME)-$(PKG_VERSION)
-PKG_HASH:=ec35b18a6c593cf98c3e30db8b98ff93e8940a8c4e690e66b41dfc011d678110
+PKG_HASH:=4a11f1777bb95bf4ad96721cac945a26e04bf19f57d905f241fe77ebeddf46d8
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE


### PR DESCRIPTION
This release includes fixes for security issues.

Mbed TLS 3.6 is a long-term support (LTS) branch. It will be supported with bug-fixes and security fixes until at least March 2027.

The two issues fixed were timing side channels:
* Padding oracle through timing of cipher error reporting (CVE-2025-59438) [1]
* Side channel in RSA key generation and operations (SSBleed, M-Step) (CVE-2025-54764) [2]

Bug fixes:
* Fix potential CMake parallel build failure when building both the static and shared libraries.
* Fix a build error or incorrect TLS session lifetime on platforms where mbedtls_time_t is not time_t.

[1]: https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-10-invalid-padding-error/
[2]: https://mbed-tls.readthedocs.io/en/latest/security-advisories/mbedtls-security-advisory-2025-10-ssbleed-mstep/

Full release announcement:
https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.5

Build-tested: mediatek/filogic, aarch64_cortex-a53, ath79/generic, mips_24kc
Tested: Build image with openvpn-mbedtls, libcurl with mbedtls, uencrypt-mbedtls, libustream-mbedtls, wpad-basic-mbedtls. Built other wpad/hostapd/wpa-supplicant packages using mbedtls as packages.

Runtime tested: ath79/generic, mips_24kc (TL-WDR4300 v1)
Tested: HTTPS connection to uhttpd using libustream-mbedtls. Connect as client to network with wpad-mbedtls. Create account and issue certificate using uacme with mbedtls as crypto backend.