### PR TITLE
kernel: rtl8261n: allow selection as package

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -525,6 +525,22 @@ endef
 $(eval $(call KernelPackage,phy-realtek))
 
 
+define KernelPackage/phy-rtl8261n
+   SUBMENU:=$(NETWORK_DEVICES_MENU)
+   TITLE:=Realtek RTL8261N NBASE-T PHY driver
+   KCONFIG:=CONFIG_RTL8261N_PHY
+   DEPENDS:=+kmod-libphy
+   FILES:=$(LINUX_DIR)/drivers/net/phy/rtl8261n/rtl8261n.ko
+   AUTOLOAD:=$(call AutoLoad,18,rtl8261n,1)
+endef
+
+define KernelPackage/phy-rtl8261n/description
+   Supports the Realtek 8261N NBASE-T PHY.
+endef
+
+$(eval $(call KernelPackage,phy-rtl8261n))
+
+
 define KernelPackage/phy-smsc
    SUBMENU:=$(NETWORK_DEVICES_MENU)
    TITLE:=SMSC PHY driver

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/Makefile
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/Makefile
@@ -1,11 +1,11 @@
 
-obj-$(CONFIG_RTL8261N_PHY) += rtl8621n.o
+obj-$(CONFIG_RTL8261N_PHY) += rtl8261n.o
 
-rtl8621n-objs += phy_patch.o
-rtl8621n-objs += phy_rtl826xb_patch.o
-rtl8621n-objs += rtk_osal.o
-rtl8621n-objs += rtk_phy.o
-rtl8621n-objs += rtk_phylib.o
-rtl8621n-objs += rtk_phylib_rtl826xb.o
+rtl8261n-objs += phy_patch.o
+rtl8261n-objs += phy_rtl826xb_patch.o
+rtl8261n-objs += rtk_osal.o
+rtl8261n-objs += rtk_phy.o
+rtl8261n-objs += rtk_phylib.o
+rtl8261n-objs += rtk_phylib_rtl826xb.o
 
 ccflags-y += -Werror -DRTK_PHYDRV_IN_LINUX


### PR DESCRIPTION
Previously, devices would have to select `CONFIG_RTL8261N_PHY=Y` in the whole target's kernel config. Now that this driver is becoming usable for devices other than Realtek switches, allow packaging this driver separately.

Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>