### PR TITLE
airoha: add support for Gemtek W1701K

### DIFF
--- a/package/kernel/mt76/patches/900-wifi-mt76-mt7996-fix-eeprom-valid.patch
+++ b/package/kernel/mt76/patches/900-wifi-mt76-mt7996-fix-eeprom-valid.patch
@@ -1,0 +1,24 @@
+--- a/mt7996/init.c
++++ b/mt7996/init.c
+@@ -1138,7 +1138,7 @@ static int mt7996_variant_fem_init(struct mt7996_dev *dev)
+ 		adie_idx = (val & MT_PAD_GPIO_ADIE_SINGLE) ? 0 : 1;
+ 		adie_comb = u32_get_bits(val, MT_PAD_GPIO_ADIE_COMB_7992);
+ 	} else {
+-		adie_idx = 0;
++		adie_idx = 1;
+ 		adie_comb = u32_get_bits(val, MT_PAD_GPIO_ADIE_COMB);
+ 	}
+ 
+@@ -1164,6 +1164,12 @@ static int mt7996_variant_fem_init(struct mt7996_dev *dev)
+ 	else
+ 		dev->var.fem = MT7996_FEM_EXT;
+ 
++	dev_info(dev->mt76.dev,
++		 "ADIE ID: 0x%04x, VER: 0x%04x, COMB: %d, FEM type: %s\n",
++		 adie_id, adie_ver, adie_comb,
++		 dev->var.fem == MT7996_FEM_INT ? "internal" :
++		 dev->var.fem == MT7996_FEM_MIX ? "mixed" : "external");
++
+ 	return 0;
+ }
+ 

--- a/target/linux/airoha/an7581/base-files/etc/board.d/02_network
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/02_network
@@ -17,6 +17,9 @@ an7581_setup_interfaces()
 	gemtek,w1700k-ubi)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;
+	gemtek,w1701k)
+		ucidef_set_interfaces_lan_wan "eth2" "eth1"
+		;;
 	nokia,valyrian)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 10g" "wan"
 		;;

--- a/target/linux/airoha/dts/an7581-gemtek.dtsi
+++ b/target/linux/airoha/dts/an7581-gemtek.dtsi
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include "an7581.dtsi"
+
+/ {
+	aliases {
+		serial0 = &uart1;
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		key-restart {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&en7581_pinctrl 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		led_status_green: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 17 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 19 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_white: led-2 {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 20 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-3 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 29 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&en7581_pinctrl {
+	gpio-ranges = <&en7581_pinctrl 0 13 47>;
+
+	mdio_pins: mdio-pins {
+		mux {
+			function = "mdio";
+			groups = "mdio";
+		};
+
+		conf {
+			pins = "gpio2";
+			output-high;
+		};
+	};
+
+	pcie0_rst_pins: pcie0-rst-pins {
+		conf {
+			pins = "pcie_reset0";
+			drive-open-drain = <1>;
+		};
+	};
+
+	pcie2_rst_pins: pcie2-rst-pins {
+		conf {
+			pins = "pcie_reset2";
+			drive-open-drain = <1>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+};
+
+&gdm1 {
+	status = "okay";
+};
+
+&gdm2 {
+	status = "okay";
+};
+
+&gdm4 {
+	status = "okay";
+};
+
+&i2c0 {
+	status = "okay";
+
+	/* NCT7511Y */
+	hwmon@2e {
+		compatible = "nuvoton,nct7802";
+		reg = <0x2e>;
+	};
+};
+
+&npu {
+	firmware-name = "airoha/en7581_MT7996_npu_rv32.bin",
+			"airoha/en7581_MT7996_npu_data.bin";
+	status = "okay";
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_rst_pins>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		device_type = "pci";
+
+		wifi: wifi@0,0 {
+			reg = <0x0000 0 0 0 0>;
+
+			airoha,eth = <&eth>;
+			airoha,npu = <&npu>;
+		};
+	};
+};
+
+&pcie2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie2_rst_pins>;
+	status = "okay";
+
+	pcie@2,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		device_type = "pci";
+
+		wifi@0,0 {
+			reg = <0x0000 0 0 0 0>;
+
+			airoha,eth = <&eth>;
+			airoha,npu = <&npu>;
+		};
+	};
+};
+
+&snfi {
+	status = "okay";
+};
+
+&switch {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+	status = "okay";
+};

--- a/target/linux/airoha/dts/an7581-w1700k-ubi.dts
+++ b/target/linux/airoha/dts/an7581-w1700k-ubi.dts
@@ -2,125 +2,49 @@
 
 /dts-v1/;
 
-#include <dt-bindings/leds/common.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include "an7581.dtsi"
+#include "an7581-gemtek.dtsi"
 
 / {
 	model = "Gemtek W1700K (OpenWrt U-Boot layout)";
 	compatible = "gemtek,w1700k-ubi", "airoha,an7581", "airoha,en7581";
 
-	aliases {
-		serial0 = &uart1;
-		led-boot = &led_status_red;
-		led-failsafe = &led_status_blue;
-		led-upgrade = &led_status_blue;
-		led-running = &led_status_green;
-	};
-
 	chosen {
 		rootdisk = <&ubi_rootfs>;
 		bootargs = "console=ttyS0,115200 earlycon ubi.block=0,fit root=/dev/fit0 rootwait";
-		stdout-path = "serial0:115200n8";
+	};
+};
+
+&leds {
+	led-4 {
+		color = <LED_COLOR_ID_GREEN>;
+		function = LED_FUNCTION_LAN;
+		function-enumerator = <3>;
+		gpios = <&en7581_pinctrl 9 GPIO_ACTIVE_LOW>;
 	};
 
-	keys {
-		compatible = "gpio-keys";
-
-		key-restart {
-			label = "reset";
-			gpios = <&en7581_pinctrl 0 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
+	led-5 {
+		color = <LED_COLOR_ID_YELLOW>;
+		function = LED_FUNCTION_LAN;
+		function-enumerator = <3>;
+		gpios = <&en7581_pinctrl 10 GPIO_ACTIVE_LOW>;
 	};
 
-	leds {
-		compatible = "gpio-leds";
+	led-6 {
+		color = <LED_COLOR_ID_GREEN>;
+		function = LED_FUNCTION_LAN;
+		function-enumerator = <4>;
+		gpios = <&en7581_pinctrl 27 GPIO_ACTIVE_LOW>;
+	};
 
-		led_status_green: led-0 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&en7581_pinctrl 17 GPIO_ACTIVE_LOW>;
-		};
-
-		led_status_blue: led-1 {
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&en7581_pinctrl 19 GPIO_ACTIVE_LOW>;
-		};
-
-		led_status_red: led-2 {
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&en7581_pinctrl 29 GPIO_ACTIVE_LOW>;
-		};
-
-		led_status_white: led-3 {
-			color = <LED_COLOR_ID_WHITE>;
-			function = LED_FUNCTION_STATUS;
-			gpios = <&en7581_pinctrl 20 GPIO_ACTIVE_LOW>;
-		};
-
-		led-4 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_LAN;
-			function-enumerator = <3>;
-			gpios = <&en7581_pinctrl 9 GPIO_ACTIVE_LOW>;
-		};
-
-		led-5 {
-			color = <LED_COLOR_ID_YELLOW>;
-			function = LED_FUNCTION_LAN;
-			function-enumerator = <3>;
-			gpios = <&en7581_pinctrl 10 GPIO_ACTIVE_LOW>;
-		};
-
-		led-6 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_LAN;
-			function-enumerator = <4>;
-			gpios = <&en7581_pinctrl 27 GPIO_ACTIVE_LOW>;
-		};
-
-		led-7 {
-			color = <LED_COLOR_ID_YELLOW>;
-			function = LED_FUNCTION_LAN;
-			function-enumerator = <4>;
-			gpios = <&en7581_pinctrl 28 GPIO_ACTIVE_LOW>;
-		};
+	led-7 {
+		color = <LED_COLOR_ID_YELLOW>;
+		function = LED_FUNCTION_LAN;
+		function-enumerator = <4>;
+		gpios = <&en7581_pinctrl 28 GPIO_ACTIVE_LOW>;
 	};
 };
 
 &en7581_pinctrl {
-	gpio-ranges = <&en7581_pinctrl 0 13 47>;
-
-	mdio_pins: mdio-pins {
-		mux {
-			function = "mdio";
-			groups = "mdio";
-		};
-
-		conf {
-			pins = "gpio2";
-			output-high;
-		};
-	};
-
-	pcie0_rst_pins: pcie0-rst-pins {
-		conf {
-			pins = "pcie_reset0";
-			drive-open-drain = <1>;
-		};
-	};
-
-	pcie2_rst_pins: pcie2-rst-pins {
-		conf {
-			pins = "pcie_reset2";
-			drive-open-drain = <1>;
-		};
-	};
-
 	/* W1700K does not use the built-in LED controller. Instead, it uses GPIO.
 	 * The driver fails to probe without gswpX_led0_pins defined, so put a dummy
 	 * here.
@@ -155,13 +79,10 @@
 	};
 };
 
-&snfi {
-	status = "okay";
-};
-
 &spi_nand {
 	#address-cells = <1>;
 	#size-cells = <1>;
+
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
@@ -218,133 +139,7 @@
 	};
 };
 
-&ubi_factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		eeprom: eeprom@0 {
-			reg = <0x0 0x1e00>;
-		};
-
-		wan_mac: macaddr@5000 {
-			reg = <0x5000 0x6>;
-		};
-
-		lan_mac: macaddr@6000 {
-			compatible = "mac-base";
-			reg = <0x6000 0x6>;
-			#nvmem-cell-cells = <1>;
-		};
-	};
-};
-
-&i2c0 {
-	status = "okay";
-
-	hwmon@2e {
-		compatible = "nuvoton,nct7802";
-		reg = <0x2e>;
-	};
-};
-
-&pcie0 {
-	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&pcie0_rst_pins>;
-	pcie@0,0 {
-		reg = <0x0000 0 0 0 0>;
-		device_type = "pci";
-		#address-cells = <3>;
-		#size-cells = <2>;
-
-		mt7996@0,0 {
-			reg = <0x0000 0 0 0 0>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			nvmem-cells = <&eeprom>;
-			nvmem-cell-names = "eeprom";
-			airoha,npu = <&npu>;
-			airoha,eth = <&eth>;
-
-			band@0 {
-				/* 2.4 GHz */
-				reg = <0>;
-				nvmem-cells = <&lan_mac 1>;
-				nvmem-cell-names = "mac-address";
-			};
-
-			band@1 {
-				/* 5 GHz */
-				reg = <1>;
-				nvmem-cells = <&lan_mac 2>;
-				nvmem-cell-names = "mac-address";
-			};
-
-			band@2 {
-				/* 6 GHz */
-				reg = <2>;
-				nvmem-cells = <&lan_mac 3>;
-				nvmem-cell-names = "mac-address";
-			};
-		};
-	};
-};
-
-&pcie2 {
-	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&pcie2_rst_pins>;
-};
-
-&npu {
-	firmware-name = "airoha/en7581_MT7996_npu_rv32.bin",
-		"airoha/en7581_MT7996_npu_data.bin";
-	status = "okay";
-};
-
-&eth {
-	status = "okay";
-};
-
-&gdm1 {
-	status = "okay";
-
-	nvmem-cells = <&lan_mac 0>;
-	nvmem-cell-names = "mac-address";
-};
-
-&gdm2 {
-	status = "okay";
-
-	phy-handle = <&phy8>;
-	phy-mode = "usxgmii";
-
-	nvmem-cells = <&wan_mac 0>;
-	nvmem-cell-names = "mac-address";
-	openwrt,netdev-name = "wan";
-};
-
-&gdm4 {
-	status = "okay";
-
-	phy-handle = <&phy5>;
-	phy-mode = "usxgmii";
-
-	nvmem-cells = <&lan_mac 0>;
-	nvmem-cell-names = "mac-address";
-	openwrt,netdev-name = "lan2";
-};
-
 &switch {
-	status = "okay";
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&mdio_pins>;
-
 	mdio {
 		phy5: ethernet-phy@5 {
 			compatible = "ethernet-phy-ieee802.3-c45";
@@ -370,6 +165,51 @@
 			realtek,pnswap-rx;
 		};
 	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		eeprom: eeprom@0 {
+			reg = <0x0 0x1e00>;
+		};
+
+		wan_mac: macaddr@5000 {
+			reg = <0x5000 0x6>;
+		};
+
+		lan_mac: macaddr@6000 {
+			compatible = "mac-base";
+			reg = <0x6000 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+	};
+};
+
+&gdm1 {
+	nvmem-cells = <&lan_mac 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gdm2 {
+	phy-handle = <&phy8>;
+	phy-mode = "usxgmii";
+
+	nvmem-cells = <&wan_mac 0>;
+	nvmem-cell-names = "mac-address";
+	openwrt,netdev-name = "wan";
+};
+
+&gdm4 {
+	phy-handle = <&phy5>;
+	phy-mode = "usxgmii";
+
+	nvmem-cells = <&lan_mac 0>;
+	nvmem-cell-names = "mac-address";
+	openwrt,netdev-name = "lan2";
 };
 
 &gsw_phy1 {
@@ -404,4 +244,9 @@
 	status = "okay";
 	pinctrl-names = "default";
 	pinctrl-0 = <&hsuart_pins>;
+};
+
+&wifi {
+	nvmem-cells = <&eeprom>, <&lan_mac 1>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };

--- a/target/linux/airoha/dts/an7581-w1701k.dts
+++ b/target/linux/airoha/dts/an7581-w1701k.dts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "an7581-gemtek.dtsi"
+
+/ {
+	model = "Gemtek W1701K";
+	compatible = "gemtek,w1701k", "airoha,an7581", "airoha,en7581";
+
+	chosen {
+		bootargs = "console=ttyS0,115200 earlycon";
+	};
+};
+
+&gdm1 {
+	nvmem-cells = <&lan_mac 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gdm2 {
+	phy-handle = <&phy15>;
+	phy-mode = "2500base-x";
+
+	nvmem-cells = <&wan_mac 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gdm4 {
+	phy-handle = <&phy14>;
+	phy-mode = "2500base-x";
+
+	nvmem-cells = <&lan_mac 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	phy14: ethernet-phy@14 {
+		reg = <14>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <20000>;
+		reset-gpios = <&en7581_pinctrl 46 GPIO_ACTIVE_LOW>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				default-state = "keep";
+			};
+
+			led@1 {
+				reg = <1>;
+				color = <LED_COLOR_ID_AMBER>;
+				function = LED_FUNCTION_LAN;
+				default-state = "keep";
+			};
+		};
+	};
+
+	phy15: ethernet-phy@15 {
+		reg = <15>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <20000>;
+		reset-gpios = <&en7581_pinctrl 27 GPIO_ACTIVE_LOW>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_WAN;
+				default-state = "keep";
+			};
+
+			led@1 {
+				reg = <1>;
+				color = <LED_COLOR_ID_AMBER>;
+				function = LED_FUNCTION_WAN;
+				default-state = "keep";
+			};
+		};
+	};
+};
+
+&spi_nand {
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootloader";
+			reg = <0x00000000 0x00200000>;
+			read-only;
+		};
+
+		partition@200000 {
+			label = "uenv";
+			reg = <0x00200000 0x00200000>;
+		};
+
+		dsd: partition@400000 {
+			label = "dsd";
+			reg = <0x00400000 0x00200000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "ascii-eq-delim-env";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				lan_mac: lan_mac {
+					compatible = "mac-base";
+					#nvmem-cell-cells = <1>;
+				};
+
+				wan_mac: wan_mac {
+					compatible = "mac-base";
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@600000 {
+			label = "kernel";
+			reg = <0x00600000 0x01000000>;
+		};
+
+		partition@1600000 {
+			label = "rootfs";
+			reg = <0x01600000 0x1e800000>;
+			compatible = "linux,ubi";
+		};
+
+		/* reserved for bad block table */
+		reserved@1fe00000 {
+			label = "reserved";
+			reg = <0x1fe00000 0x00200000>;
+			read-only;
+		};
+	};
+};
+
+&wifi {
+	mediatek,mtd-eeprom = <&dsd 0x5000>;
+	nvmem-cells = <&lan_mac 1>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -105,6 +105,21 @@ define Device/gemtek_w1700k-ubi
 endef
 TARGET_DEVICES += gemtek_w1700k-ubi
 
+define Device/gemtek_w1701k
+  $(call Device/FitImageLzma)
+  DEVICE_VENDOR := Gemtek
+  DEVICE_MODEL := W1701K
+  DEVICE_ALT0_VENDOR := Quantum Fiber
+  DEVICE_ALT0_MODEL := W1701K
+  DEVICE_PACKAGES := airoha-en7581-mt7996-npu-firmware \
+		     kmod-hwmon-nct7802 kmod-i2c-an7581 \
+		     kmod-mt7996-firmware kmod-phy-airoha-en8811h \
+		     wpad-basic-mbedtls
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  SOC := an7581
+endef
+TARGET_DEVICES += gemtek_w1701k
+
 define Device/nokia_valyrian
   DEVICE_VENDOR := Nokia
   DEVICE_MODEL := Valyrian


### PR DESCRIPTION
Hardware specification:
```
SoC:     Airoha AN7581
RAM:     2GB DDR4 2666MHz
Flash:   512MB W25N04KV
ETH:     2x 2.5G EN8811H
WLAN:    MT7996AV BE19000
WLAN1:   MT7975N 2.4GHz 4x4
WLAN2:   MT7977BN 5GHz 4x5
WLAN3:   MT7977AN 6GHz 4x5
PWM FAN: Nuvoton NCT7511Y
Power:   100-240V AC 1.2A
Button:  Reset
```

Flash instructions:
  1. Download the initramfs image, rename it to
     initramfs.itb, host it with the tftp server.
  2. Connect to the router through the right Lan port,
     set a static ip of your PC. (ip 192.168.0.205)
  3. Interrupt U-Boot and run these commands:
```
setenv bootflag 0
setenv one flash read 0x600000 0x1000000 \$loadaddr
setenv two "; bootm"
setenv bootcmd "$one$two"
setenv one
setenv two
saveenv
```
  4. Reboot and interrupt U-Boot again, then run:
```
tftpboot 0x89000000 initramfs.itb
bootm
```
  5. After openwrt boots up, use scp or luci web
     to upload sysupgrade.bin to upgrade.

Note:
  1. Flash partition is based on pr #17869.
  2. Flash instructions is based on pr #17869.