### PR TITLE
ipq40xx: add support for cradlepoint ibr1700

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -32,6 +32,11 @@ avm,fritzbox-7530)
 	ucidef_set_led_netdev "dsl" "DSL" "green:info" "dsl0"
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
+cradlepoint,ibr1700)
+	ucidef_set_led_wlan "wlan5gaux" "WLAN5GAUX" "blue:5g_4x4" "phy0tpt"
+	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy1tpt"
+	ucidef_set_led_wlan "wlan5g" "WLAN5G" "blue:5g_2x2" "phy2tpt"
+	;;
 edgecore,oap100)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "blue:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "blue:wlan5g" "phy1tpt"

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -82,6 +82,10 @@ ipq40xx_setup_interfaces()
 	compex,wpj428)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
+	cradlepoint,ibr1700)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+		ucidef_set_interface "wwan0" device "/dev/cdc-wdm0" protocol "qmi"
+		;;
 	devolo,magic-2-wifi-next)
 		ucidef_set_interface_lan "lan1 lan2 ghn"
 		;;
@@ -184,6 +188,15 @@ ipq40xx_setup_macs()
 		local tffsdev=$(find_mtd_chardev "nand-tffs")
 		wan_mac=$(/usr/bin/fritz_tffs_nand -b -d $tffsdev -n macdsl)
 		;;
+<<<<<<< HEAD
+=======
+	cilab,meshpoint-one)
+		label_mac=$(mtd_get_mac_binary "ART" 0x1006)
+		;;
+	cradlepoint,ibr1700)
+		label_mac=$(mtd_get_mac_binary "0:ART" 0x1006)
+		;;
+>>>>>>> 6b1fab2299 (ipq40xx: add support for cradlepoint ibr1700 and aer2200)
 	devolo,magic-2-wifi-next)
 		lan_mac=$(mtd_get_mac_ascii APPSBLENV MacAddress0)
 		label_mac=$lan_mac
@@ -253,11 +266,52 @@ ipq40xx_setup_macs()
 	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
 }
 
+
+mtd_get_custdata() {
+	local key="$1"
+
+	part=$(find_mtd_part "0:CUSTDATA")
+	if [ -z "$part" ]; then
+		echo "mtd_get_custdata: partition $mtdname not found!" >&2
+		return
+	fi
+
+	echo -n $(strings "$part" | tr -d ' \t' | sed -n 's/^'"$key"'=//p' | head -n 1)
+}
+
+
+# by default, cradlepoints use the serial for wifi PSK and login password
+# let's replicate this for easier OOBE setup
+
+#TODO: make this a bit more resilient to failure
+cradlepoint_setup()
+{
+	local board="$1"
+
+	case "$board" in
+	cradlepoint,ibr1700)
+		serial=$(mtd_get_custdata "SerialNumber")
+		quasi_uid=$(mtd_get_custdata "MAC0" | cut -c 9-)
+
+		if [ -z "$serial" ] || [ -z "$quasi_uid" ]; then
+			echo "cradlepoint_setup: serial number and/or MAC address were unable to be found! Not configuring root password or wifi..." >&2
+			return
+		fi
+
+		ucidef_set_wireless 2g "OpenWRT-$quasi_uid" sae-mixed "$serial"
+		ucidef_set_wireless 5g "OpenWRT-$quasi_uid-5g" sae-mixed "$serial"
+		ucidef_set_root_password_plain "$serial"
+		;;
+	esac
+}
+
+
 board_config_update
 board=$(board_name)
 ipq40xx_setup_interfaces $board
 ipq40xx_setup_dsl $board
 ipq40xx_setup_macs $board
+cradlepoint_setup $board
 board_config_flush
 
 exit 0

--- a/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
@@ -25,6 +25,25 @@ meraki,gx20|\
 meraki,z3)
 	ucidef_add_gpio_switch "lan5_poe_disable" "LAN5 PoE disable" "540" "0"
 	;;
+cradlepoint,ibr1700)
+	ucidef_add_gpio_switch "pwr_en_int1" "Internal Modem Power" "576" "1"
+	ucidef_add_gpio_switch "pwr_en_usb1" "USB Power" "625" "1"
+	ucidef_add_gpio_switch "pwr_en_mdm1" "Secondary Modem Bay Power" "630" "1"
+	ucidef_add_gpio_switch "2g_antenna_toggle" "2GHz Antenna Switch" "581" "0"
+	
+	# figure out if we are on a snapshot build; if so the mux should default to the header
+	version=$(cat /etc/openwrt_release | grep "DISTRIB_RELEASE" | cut -d "=" -f 2 | tr -d "'")
+
+	if [ $version = "SNAPSHOT" ]; then
+		ucidef_add_gpio_switch "uart_mux" "GPS UART Mux" "549" "0"
+	else
+		ucidef_add_gpio_switch "uart_mux" "GPS UART Mux" "549" "1"
+		# silence kernel logs as it will clog the GPS chip (they are muxed)
+		uci set system.@system[0].kconloglevel=3
+		uci set system.@system[0].conloglevel=3
+
+	fi
+	;;
 mikrotik,cap-ac)
 	ucidef_add_gpio_switch "poe_passtrough" "POE passtrough enable" "514" "0"
 	;;

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -25,6 +25,9 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
+	cradlepoint,ibr1700)
+		caldata_extract "ART" 0x9000 0x2f20
+		;;
 	linksys,ea8300|\
 	linksys,mr8300)
 		caldata_extract "ART" 0x9000 0x2f20
@@ -64,6 +67,12 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
+		;;
+	cradlepoint,ibr1700)
+		caldata_extract "0:ART" 0x1000 0x2f20
+		# HACK: hardcode this to USA (?)
+		# cradlepoint has a lookup table in firmware to patch on the fly
+		caldata_patch_data "0000" 0xc 0x2
 		;;
 	cellc,rtl30vw)
 		caldata_extract "0:ART" 0x1000 0x2f20
@@ -161,6 +170,12 @@ case "$FIRMWARE" in
 		;;
 	cellc,rtl30vw)
 		caldata_extract "0:ART" 0x5000 0x2f20
+		;;
+	cradlepoint,ibr1700)
+		caldata_extract "0:ART" 0x5000 0x2f20
+		# HACK: hardcode this to USA (?)
+		# cradlepoint has a lookup table in firmware to patch on the fly
+		caldata_patch_data "0000" 0xc 0x2
 		;;
 	devolo,magic-2-wifi-next)
 		caldata_extract "ART" 0x5000 0x2f20

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -129,6 +129,26 @@ platform_do_upgrade() {
 	wallys,dr40x9)
 		nand_do_upgrade "$1"
 		;;
+	cradlepoint,ibr1700)
+		# check for renaming the data partition
+		# parted doesn't exist in the ramfs
+		# mmcp4_part=$(cat /sys/class/block/mmcblk0p4/uevent | grep PARTNAME | tr -d 'PARTNAME=')
+
+		# if [ "$mmcp4_part" = "Filesystem" ]; then
+		# 	parted /dev/mmcblk0 name 4 rootfs_data
+		# fi
+
+		CI_KERNPART="0:HLOS"
+		CI_ROOTPART="rootfs"
+		CI_DATAPART="rootfs_data"
+		emmc_do_upgrade "$1"
+		;;
+	glinet,gl-b2200)
+		CI_KERNPART="0:HLOS"
+		CI_ROOTPART="rootfs"
+		CI_DATAPART="rootfs_data"
+		emmc_do_upgrade "$1"
+		;;
 	alfa-network,ap120c-ac)
 		part="$(awk -F 'ubi.mtd=' '{printf $2}' /proc/cmdline | sed -e 's/ .*$//')"
 		if [ "$part" = "rootfs1" ]; then

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-brulk-common.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-brulk-common.dtsi
@@ -1,0 +1,581 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* Copyright (c) 2025, Natalie Moore <natalie@natalielucy.dev> */
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/thermal/thermal.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	/* Common device tree fragments for both IBR1700 (Hulk) and AER2200 (Bruce) */
+	aliases {
+		//TODO: unresolved comment by @achterin
+		led-failsafe = &led_attn_red;
+		led-upgrade = &led_attn_red;
+		label-mac-device = &gmac;
+	};
+
+	chosen {
+		bootargs-append = " root=/dev/mmcblk0p2";
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>;
+	};
+
+	soc {
+		counter@4a1000 {
+			compatible = "qcom,qca-gcnt";
+			reg = <0x4a1000 0x4>;
+		};
+		
+		tcsr@194b000 {
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 59 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+
+		sim_door_detect {
+			gpio-export,name = "sim_door_detect";
+			gpio-export,input = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
+		};
+
+		pwr_off_toggle {
+			gpio-export,name = "pwr_off_toggle";
+			gpio-export,output = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 42 GPIO_ACTIVE_HIGH>;
+		};
+
+		pwr_en_int1 {
+			gpio-export,name = "pwr_en_int1";
+			gpio-export,output = <1>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 64 GPIO_ACTIVE_HIGH>;
+		};
+
+		pwr_off_latch {
+			gpio-export,name = "pwr_off_latch";
+			gpio-export,output = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&expander1 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		pwr_en_usb1 {
+			gpio-export,name = "pwr_en_usb1";
+			gpio-export,output = <1>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&expander1 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		pwr_en_mdm1 {
+			gpio-export,name = "pwr_en_mdm1";
+			gpio-export,output = <1>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&expander1 18 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_ext_modem_red: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&tlmm 66 GPIO_ACTIVE_LOW>;
+			label = "red:ext_modem";
+		};
+
+		led_ext_modem_green: led-1 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 67 GPIO_ACTIVE_LOW>;
+			label = "green:ext_modem";
+		};
+
+		led_wwan_white: led-2 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&tlmm 68 GPIO_ACTIVE_LOW>;
+			label = "white:wwan";
+		};
+
+		led_ss_0_blue: led-7 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&expander1 0 GPIO_ACTIVE_LOW>;
+			label = "blue:ss_0";
+		};
+
+		led_ss_1_blue: led-8 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&expander1 1 GPIO_ACTIVE_LOW>;
+			label = "blue:ss_1";
+		};
+
+		led_ss_2_blue: led-9 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&expander1 2 GPIO_ACTIVE_LOW>;
+			label = "blue:ss_2";
+		};
+
+		led_ss_3_blue: led-10 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&expander1 3 GPIO_ACTIVE_LOW>;
+			label = "blue:ss_3";
+		};
+
+		led_attn_red: led-11 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&expander1 4 GPIO_ACTIVE_LOW>;
+			label = "red:attn";
+		};
+
+		led_gps_blue: led-12 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&expander1 5 GPIO_ACTIVE_LOW>;
+			label = "blue:gps";
+		};
+
+		led_2g_green: led-13 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&expander1 6 GPIO_ACTIVE_LOW>;
+			label = "green:wlan2g";
+		};
+
+		led_5g_blue: led-14 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&tlmm 61 GPIO_ACTIVE_LOW>;
+			label = "blue:wlan5g";
+		};
+
+		led_int_modem_red: led-15 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&expander1 15 GPIO_ACTIVE_LOW>;
+			label = "red:int_modem";
+		};
+
+		led_int_modem_green: led-16 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&expander1 14 GPIO_ACTIVE_LOW>;
+			label = "green:int_modem";
+		};
+	};
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_uart1 {
+		status = "okay";
+		pinctrl-0 = <&serial_0_pins>;
+		pinctrl-names = "default";
+};
+
+&blsp1_uart2 {
+		status = "okay";
+		pinctrl-0 = <&serial_1_pins>;
+		pinctrl-names = "default";
+};
+
+&blsp1_spi1 {
+	status = "okay";
+
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	cs-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <24000000>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition0@0 {
+				label = "0:SBL1";
+				reg = <0x00000000 0x00040000>;
+				read-only;
+			};
+
+			partition1@40000 {
+				label = "0:MIBIB";
+				reg = <0x00040000 0x00020000>;
+				read-only;
+			};
+
+			partition2@60000 {
+				label = "0:QSEE";
+				reg = <0x00060000 0x00060000>;
+				read-only;
+			};
+
+			partition3@c0000 {
+				label = "0:CDT";
+				reg = <0x000c0000 0x00010000>;
+				read-only;
+			};
+
+			partition4@d0000 {
+				label = "0:DDRPARAMS";
+				reg = <0x000d0000 0x00010000>;
+				read-only;
+			};
+
+			partition5@e0000 {
+				label = "0:APPSBLENV"; /* uboot env */
+				reg = <0x000e0000 0x00010000>;
+				read-only;
+			};
+
+			partition6@f0000 {
+				label = "0:APPSBL"; /* uboot */
+				reg = <0x000f0000 0x00080000>;
+				read-only;
+			};
+
+			partition7@170000 {
+				label = "0:ART";
+				reg = <0x00170000 0x00010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_lan: mac-address@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_wan: mac-address@6 {
+						reg = <0x6 0x6>;
+					};
+
+					precal_art_1000: precal@1000 {
+						reg = <0x1000 0x2f20>;
+					};
+
+					precal_art_5000: precal@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+
+					precal_art_9000: precal@9000 {
+						reg = <0x9000 0x2f20>;
+					};
+				};
+			};
+
+			partition8@180000 {
+				label = "0:CUSTDATA";
+				reg = <0x00180000 0x00010000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&blsp1_i2c3 {
+	pinctrl-0 = <&i2c_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	expander1: gpio@35 {
+		compatible = "ti,tca6424";
+		gpio-controller;
+		#gpio-cells = <2>;
+		interrupts = <0x12>;
+		interrupt-parent = <&tlmm>;
+		reg = <0x23>;
+	};
+
+	therm: temperature-sensor@77 {
+		compatible = "gmt,g781";
+		reg = <0x4d>;
+		#thermal-sensor-cells = <1>;
+		status = "ok";
+	};
+};
+
+
+&cryptobam {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+		mux_2 {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		pin {
+			function = "blsp_spi0";
+			pins = "gpio13", "gpio14", "gpio15";
+			drive-strength = <12>;
+			bias-disable;
+		};
+		pin_cs {
+			function = "gpio";
+			pins = "gpio12";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+
+	i2c_0_pins: i2c_0_pinmux {
+		mux {
+			pins = "gpio20", "gpio21";
+			function = "blsp_i2c0";
+			drive-open-drain;
+		};
+	};
+
+
+	serial_0_pins: serial_0_pinmux {
+		mux {
+			pins = "gpio16", "gpio17";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	serial_1_pins: serial_1_pinmux {
+		mux {
+			/* RS-232 port supports flow control */
+			pins = "gpio8", "gpio9", "gpio10", "gpio11";
+			function = "blsp_uart1";
+			bias-disable;
+		};
+	};
+
+	sd_pins: sd_pins {
+		pinmux {
+			function = "sdio";
+			pins = "gpio23", "gpio24", "gpio25", "gpio26",
+				"gpio28", "gpio29", "gpio30", "gpio31";
+			drive-strength = <10>;
+		};
+		pinmux_sd_clk {
+			function = "sdio";
+			pins = "gpio27";
+			drive-strength = <16>;
+		};
+		pinmux_sd7 {
+			function = "sdio";
+			pins = "gpio32";
+			drive-strength = <10>;
+			bias-disable;
+		};
+	};
+};
+
+&vqmmc {
+	status = "okay";
+};
+
+&sdhci {
+	status = "okay";
+
+	pinctrl-0 = <&sd_pins>;
+	pinctrl-names = "default";
+	vqmmc-supply = <&vqmmc>;
+	non-removable;
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 47 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
+};
+
+&ethphy0 {
+	reg = <0x08>;
+};
+
+&ethphy1 {
+	reg = <0x09>;
+};
+
+&ethphy2 {
+	reg = <0x0a>;
+};
+
+&ethphy3 {
+	reg = <0x0b>;
+};
+
+&ethphy4 {
+	reg = <0x0c>;
+};
+
+&psgmiiphy {
+	reg = <0x0d>;
+};
+
+&gmac {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_wan>;
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport1 {
+	status = "okay";
+	label = "wan";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_wan>;
+};
+
+&swport2 {
+	status = "okay";
+	label = "lan4";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_lan>;
+};
+
+&swport3 {
+	status = "okay";
+	label = "lan3";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_lan>;
+};
+
+&swport4 {
+	status = "okay";
+	label = "lan2";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_lan>;
+};
+
+&swport5 {
+	status = "okay";
+	label = "lan1";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_lan>;
+};
+
+&usb2 {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&wifi0 {
+	status = "okay";
+};
+
+&wifi1 {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+	perst-gpio = <&tlmm 38 GPIO_ACTIVE_LOW>;
+};
+
+&pcie_bridge0 {
+	ext_wifi: wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x00010000 0 0 0 0>;
+		ieee80211-freq-limit = <5470000 5875000>;
+		status = "disabled";
+	};
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-ibr1700.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-ibr1700.dts
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* Copyright (c) 2025, Natalie Moore <natalie@natalielucy.dev> */
+
+#include "qcom-ipq4029-brulk-common.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	/* Codename Hulk */
+	model = "Cradlepoint IBR1700";
+	compatible = "cradlepoint,ibr1700";
+
+	gpio_export {
+		2g_antenna_toggle {
+			gpio-export,name = "2g_antenna_toggle";
+			gpio-export,output = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 69 GPIO_ACTIVE_HIGH>;
+		};
+
+		conn_ign_sense {
+			gpio-export,name = "conn_ign_sense";
+			gpio-export,input = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 19 GPIO_ACTIVE_LOW>;
+		};
+
+		conn_output {
+			gpio-export,name = "conn_output";
+			gpio-export,output = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&expander1 7 GPIO_ACTIVE_HIGH>;
+		};
+
+		sata_ign_sense {
+			gpio-export,name = "sata_ign_sense";
+			gpio-export,input = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 53 GPIO_ACTIVE_LOW>;
+		};
+
+		/* GPS + RS-232 + GPIO riser card */
+		riser_mux {
+			gpio-export,name = "riser_mux";
+			gpio-export,output = <0>;	/* 0 = console; 1 = GPS */
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 37 GPIO_ACTIVE_HIGH>;
+		};
+
+		riser_flipflop_d {
+			gpio-export,name = "riser_flipflop_d";
+			gpio-export,output = <0>;
+			gpio-export,direction_may_change = <1>;
+			gpios = <&expander1 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		riser_pwr_clk {
+			gpio-export,name = "riser_pwr_clk";
+			gpio-export,output = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 50 GPIO_ACTIVE_HIGH>;
+		};
+
+		riser_bias_clk {
+			gpio-export,name = "riser_bias_clk";
+			gpio-export,output = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 48 GPIO_ACTIVE_HIGH>;
+		};
+
+		riser_gps_boot_mode {
+			gpio-export,name = "riser_gps_boot_mode";
+			gpio-export,output = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 63 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		led_5g_right_blue: led-3 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&tlmm 33 GPIO_ACTIVE_HIGH>;
+			label = "blue:5g_2x2";
+		};
+
+		led_2g_right_green: led-4 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 34 GPIO_ACTIVE_HIGH>;
+			label = "green:2g_2x2";
+		};
+
+		led_5g_left_blue: led-5 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&tlmm 36 GPIO_ACTIVE_HIGH>;
+			label = "blue:5g_4x4";
+		};
+
+		led_2g_left_green: led-6 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 56 GPIO_ACTIVE_HIGH>;
+			label = "green:2g_4x4";
+		};
+	};
+};
+
+&blsp1_i2c3 {
+	adc: adc@49 {
+		compatible = "ads7924";
+		reg = <0x49>;
+		status = "okay";
+	};
+};
+
+&ext_wifi {
+	status = "okay";
+};

--- a/target/linux/ipq40xx/image/cradlepoint-kernel-packing.py
+++ b/target/linux/ipq40xx/image/cradlepoint-kernel-packing.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import zlib
+import sys
+import os
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        print('Usage: {} <input-gzip> <output-gzip> <input-squashfs>'.format(sys.argv[0]))
+        sys.exit(1)
+    
+    input_gzip_path = sys.argv[1]
+    output_gzip_path = sys.argv[2]
+    rootfs_file_path = sys.argv[3]
+    
+    with (open(rootfs_file_path, 'r+b') as r):
+        rootfs = r.read()
+        curr_len = len(rootfs)
+
+        # pad out squashfs image
+        fs_needed_len = (4096 - (curr_len) % 0x1000)
+        fs_pad = b'\x00' * fs_needed_len
+
+        r.seek(0, os.SEEK_END)
+        r.write(fs_pad)
+        
+        fs_len = curr_len + fs_needed_len
+
+        # seek back to the beginning, and re-read into RAM
+        r.seek(0)
+        new_rootfs = r.read()
+    
+    fs_chksum = zlib.crc32(new_rootfs).to_bytes(4, "little")
+
+    # footer should start on a 4-byte-aligned boundary
+    kern_len = os.path.getsize(input_gzip_path)
+    needed_padding = 4 - ((kern_len) % 4)
+    front_padding = b'\xaa' * needed_padding
+    
+    footer = front_padding + b'\x00\x00\x00\x00\x27\x05\x19\x58' + fs_chksum + fs_len.to_bytes(4, "little") + b'\x00\x00\x00\x00'
+
+    with (open(input_gzip_path, 'rb') as i):
+        in_file = i.read()
+    
+    with (open(output_gzip_path, 'wb') as o):
+        o.write(in_file)
+        o.write(footer)

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -10,6 +10,16 @@ define Build/netgear-fit-padding
 	mv $@.new $@
 endef
 
+define Build/copy-vmlinux
+	cp $(KDIR)/vmlinux $@
+endef
+
+define Build/cradlepoint-kernel-packing
+	./cradlepoint-kernel-packing.py $@ $@.new $(IMAGE_ROOTFS)
+	rm $@
+	mv $@.new $@
+endef
+
 define Device/FitImage
 	KERNEL_SUFFIX := -uImage.itb
 	KERNEL = kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
@@ -368,6 +378,33 @@ define Device/compex_wpj428
 	DEFAULT := n
 endef
 TARGET_DEVICES += compex_wpj428
+
+define Cradlepoint/base_pkgs
+	DEVICE_PACKAGES += kmod-gpio-pca953x \
+	kmod-usb-acm kmod-usb-net kmod-usb-net-cdc-qmi kmod-usb-serial kmod-usb-serial-option
+endef
+
+# Base defs for IBR1700 and AER2200
+define Device/cradlepoint_brulk
+	$(call Device/FitImage)
+	$(call Cradlepoint/base_pkgs)
+	DEVICE_VENDOR := Cradlepoint
+	SOC := qcom-ipq4029
+	DEVICE_DTS_CONFIG := config@ap.dk04.1-c3
+	FILESYSTEMS := squashfs
+	BLOCKSIZE := 32k
+	IMAGE_SIZE := 65536k
+	KERNEL_SIZE := 8192k
+	IMAGES += sysupgrade.bin
+	IMAGE/sysupgrade.bin = copy-vmlinux | gzip | cradlepoint-kernel-packing | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb | sysupgrade-tar kernel=$$$$@ | append-metadata
+	DEVICE_PACKAGES += kmod-mmc ath10k-firmware-qca9984 kmod-spi-dev kmod-hwmon-lm90 parted mkf2fs e2fsprogs kmod-fs-f2fs
+endef
+
+define Device/cradlepoint_ibr1700
+	$(call Device/cradlepoint_brulk)
+	DEVICE_MODEL := IBR1700
+endef
+TARGET_DEVICES += cradlepoint_ibr1700
 
 define Device/devolo_magic-2-wifi-next
 	$(call Device/FitzImage)


### PR DESCRIPTION
This commit adds initial support for the Cradlepoint IBR1700 and AER2200 devices. Both are built on a similar PCB and can use common device tree options.

Most testing has been performed on the IBR1700, and all peripherals (Ethernet, all 3 WiFi radios, GPS, cellular, USB, LEDs, etc.) are working at this time.

At this time, permanent installation requires renaming the /dev/mmcblk0p4 partition to "rootfs_data". This is initially named "Filesystem". This will be automated in a future commit.