### PR TITLE
dnsmasq: Fix dnsmasq-full not compliing with ipset

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -112,7 +112,7 @@ define Package/dnsmasq-full/config
 		default y
 	config PACKAGE_dnsmasq_full_ipset
 		bool "Build with IPset support."
-		default n
+		default y
 	config PACKAGE_dnsmasq_full_nftset
 		bool "Build with Nftset support."
 		default y


### PR DESCRIPTION
dnsmasq-full compiled without ipset is a serious bug, breaking working configuration files, crashing dnsmasq, and making the whole network fail by losing DHCP.

If it needs a f-word for you to take it seriously, I can send it right away.