### PR TITLE
[24.10]: kernel: ksmbd: add max ip connection parameter 

### DIFF
--- a/target/linux/generic/backport-6.6/540-v6.12-ksmbd-browse-interfaces-list-on-FSCTL_QUERY_INTERFACE_INFO.patch
+++ b/target/linux/generic/backport-6.6/540-v6.12-ksmbd-browse-interfaces-list-on-FSCTL_QUERY_INTERFACE_INFO.patch
@@ -1,0 +1,35 @@
+From 0fc403192dcc8def1f6284959141608ac4c86699 Mon Sep 17 00:00:00 2001
+From: Namjae Jeon <linkinjeon@kernel.org>
+Date: Fri, 10 Jan 2025 13:37:05 +0900
+Subject: ksmbd: browse interfaces list on FSCTL_QUERY_INTERFACE_INFO IOCTL
+
+[ Upstream commit b2d99376c5d61eb60ffdb6c503e4b6c8f9712ddd ]
+
+ksmbd.mount will give each interfaces list and bind_interfaces_only flags
+to ksmbd server. Previously, the interfaces list was sent only
+when bind_interfaces_only was enabled.
+ksmbd server browse only interfaces list given from ksmbd.conf on
+FSCTL_QUERY_INTERFACE_INFO IOCTL.
+
+Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>
+Signed-off-by: Steve French <stfrench@microsoft.com>
+Stable-dep-of: 21a4e47578d4 ("ksmbd: fix use-after-free in __smb2_lease_break_noti()")
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ fs/smb/server/ksmbd_netlink.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+(limited to 'fs/smb/server/ksmbd_netlink.h')
+
+--- a/fs/smb/server/ksmbd_netlink.h
++++ b/fs/smb/server/ksmbd_netlink.h
+@@ -108,7 +108,8 @@ struct ksmbd_startup_request {
+ 	__u32	smb2_max_credits;	/* MAX credits */
+ 	__u32	smbd_max_io_size;	/* smbd read write size */
+ 	__u32	max_connections;	/* Number of maximum simultaneous connections */
+-	__u32	reserved[126];		/* Reserved room */
++	__s8	bind_interfaces_only;
++	__s8	reserved[503];		/* Reserved room */
+ 	__u32	ifc_list_sz;		/* interfaces list size */
+ 	__s8	____payload[];
+ };

--- a/target/linux/generic/backport-6.6/541-v6.18-ksmbd-add-max-ip-connections-parameter.patch
+++ b/target/linux/generic/backport-6.6/541-v6.18-ksmbd-add-max-ip-connections-parameter.patch
@@ -1,0 +1,119 @@
+From d8b6dc9256762293048bf122fc11c4e612d0ef5d Mon Sep 17 00:00:00 2001
+From: Namjae Jeon <linkinjeon@kernel.org>
+Date: Wed, 1 Oct 2025 09:25:35 +0900
+Subject: ksmbd: add max ip connections parameter
+
+This parameter set the maximum number of connections per ip address.
+The default is 8.
+
+Cc: stable@vger.kernel.org
+Fixes: c0d41112f1a5 ("ksmbd: extend the connection limiting mechanism to support IPv6")
+Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>
+Signed-off-by: Steve French <stfrench@microsoft.com>
+---
+ fs/smb/server/ksmbd_netlink.h |  5 +++--
+ fs/smb/server/server.h        |  1 +
+ fs/smb/server/transport_ipc.c |  3 +++
+ fs/smb/server/transport_tcp.c | 27 ++++++++++++++++-----------
+ 4 files changed, 23 insertions(+), 13 deletions(-)
+
+(limited to 'fs/smb')
+
+--- a/fs/smb/server/ksmbd_netlink.h
++++ b/fs/smb/server/ksmbd_netlink.h
+@@ -109,10 +109,11 @@ struct ksmbd_startup_request {
+ 	__u32	smbd_max_io_size;	/* smbd read write size */
+ 	__u32	max_connections;	/* Number of maximum simultaneous connections */
+ 	__s8	bind_interfaces_only;
+-	__s8	reserved[503];		/* Reserved room */
++	__u32	max_ip_connections;	/* Number of maximum connection per ip address */
++	__s8	reserved[499];		/* Reserved room */
+ 	__u32	ifc_list_sz;		/* interfaces list size */
+ 	__s8	____payload[];
+-};
++} __packed;
+ 
+ #define KSMBD_STARTUP_CONFIG_INTERFACES(s)	((s)->____payload)
+ 
+--- a/fs/smb/server/server.h
++++ b/fs/smb/server/server.h
+@@ -43,6 +43,7 @@ struct ksmbd_server_config {
+ 	unsigned int		auth_mechs;
+ 	unsigned int		max_connections;
+ 	unsigned int		max_inflight_req;
++	unsigned int		max_ip_connections;
+ 
+ 	char			*conf[SERVER_CONF_WORK_GROUP + 1];
+ };
+--- a/fs/smb/server/transport_ipc.c
++++ b/fs/smb/server/transport_ipc.c
+@@ -321,6 +321,9 @@ static int ipc_server_config_on_startup(
+ 	if (req->max_connections)
+ 		server_conf.max_connections = req->max_connections;
+ 
++	if (req->max_ip_connections)
++		server_conf.max_ip_connections = req->max_ip_connections;
++
+ 	ret = ksmbd_set_netbios_name(req->netbios_name);
+ 	ret |= ksmbd_set_server_string(req->server_string);
+ 	ret |= ksmbd_set_work_group(req->work_group);
+--- a/fs/smb/server/transport_tcp.c
++++ b/fs/smb/server/transport_tcp.c
+@@ -240,6 +240,7 @@ static int ksmbd_kthread_fn(void *p)
+ 	struct interface *iface = (struct interface *)p;
+ 	struct ksmbd_conn *conn;
+ 	int ret;
++	unsigned int max_ip_conns;
+ 
+ 	while (!kthread_should_stop()) {
+ 		mutex_lock(&iface->sock_release_lock);
+@@ -257,34 +258,38 @@ static int ksmbd_kthread_fn(void *p)
+ 			continue;
+ 		}
+ 
++		if (!server_conf.max_ip_connections)
++			goto skip_max_ip_conns_limit;
++
+ 		/*
+ 		 * Limits repeated connections from clients with the same IP.
+ 		 */
++		max_ip_conns = 0;
+ 		down_read(&conn_list_lock);
+-		list_for_each_entry(conn, &conn_list, conns_list)
++		list_for_each_entry(conn, &conn_list, conns_list) {
+ #if IS_ENABLED(CONFIG_IPV6)
+ 			if (client_sk->sk->sk_family == AF_INET6) {
+ 				if (memcmp(&client_sk->sk->sk_v6_daddr,
+-					   &conn->inet6_addr, 16) == 0) {
+-					ret = -EAGAIN;
+-					break;
+-				}
++					   &conn->inet6_addr, 16) == 0)
++					max_ip_conns++;
+ 			} else if (inet_sk(client_sk->sk)->inet_daddr ==
+-				 conn->inet_addr) {
+-				ret = -EAGAIN;
+-				break;
+-			}
++				 conn->inet_addr)
++				max_ip_conns++;
+ #else
+ 			if (inet_sk(client_sk->sk)->inet_daddr ==
+-			    conn->inet_addr) {
++			    conn->inet_addr)
++				max_ip_conns++;
++#endif
++			if (server_conf.max_ip_connections <= max_ip_conns) {
+ 				ret = -EAGAIN;
+ 				break;
+ 			}
+-#endif
++		}
+ 		up_read(&conn_list_lock);
+ 		if (ret == -EAGAIN)
+ 			continue;
+ 
++skip_max_ip_conns_limit:
+ 		if (server_conf.max_connections &&
+ 		    atomic_inc_return(&active_num_conn) >= server_conf.max_connections) {
+ 			pr_info_ratelimited("Limit the maximum number of connections(%u)\n",


### PR DESCRIPTION
 * kernel: ksmbd: browse-interfaces-list-on-FSCTL_QUERY_INTERFACE_INFO
    
    backport from kernel 6.12
    
    ksmbd.mount will give each interfaces list and bind_interfaces_only flags
    to ksmbd server. Previously, the interfaces list was sent only
    when bind_interfaces_only was enabled.
    ksmbd server browse only interfaces list given from ksmbd.conf on
    FSCTL_QUERY_INTERFACE_INFO IOCTL.
    

 * kernel: ksmbd: add max ip connection parameter
    
    With this patch is set the maximum number of connections per ip address instead of no control.
    The default is 8.
    