### PR TITLE
realtek: switch XGS1250-12 to rt-loader

### DIFF
--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -119,12 +119,19 @@ define Device/zyxel_xgs1250-12-common
   DEVICE_MODEL := XGS1250-12
   DEVICE_PACKAGES := kmod-hwmon-gpiofan kmod-thermal
   IMAGE_SIZE := 13312k
+  KERNEL := \
+	kernel-bin | \
+	append-dtb | \
+	rt-compress | \
+	rt-loader | \
+	uImage none
   KERNEL_INITRAMFS := \
 	kernel-bin | \
 	append-dtb | \
-	gzip | \
+	rt-compress | \
 	zyxel-vers | \
-	uImage gzip
+	rt-loader | \
+	uImage none
 endef
 
 define Device/zyxel_xgs1250-12-a1


### PR DESCRIPTION
Switch the XGS1250-12 to rt-loader. Allows us a bit more headroom flash wise and access to more recent compression algorithms.

Both initramfs and sysupgrade image were tested and boot fine.

**Ramdisk log**

<details><summary>Toggle</summary>

```
RTL9300# # bootm
## Booting kernel from Legacy Image at 84f00000 ...
   Image Name:   MIPS OpenWrt Linux-6.12.51
   Created:      2025-10-11  18:15:17 UTC
   Image Type:   MIPS Linux Kernel Image (uncompressed)
   Data Size:    6141787 Bytes = 5.9 MB
   Load Address: 80100000
   Entry Point:  80100000
   Verifying Checksum ... OK
   Loading Kernel Image ... OK
OK

Starting kernel ...


rt-loader
Running on RTL9302B (chip id 6487A) with 128MB
Relocate 6141792 bytes from 0x80100000 to 0x879d0000
Extract image with 6126079 bytes from 0x879d3d5c to 0x80100000 ...
Final kernel size is 24134970 bytes
Booting kernel from 0x80100000 ...

[    0.000000] Linux version 6.12.51 (5800X@crunchbot) (mips-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r30740+9-08cc7e881e) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Sat Oct 11 18:15:17 2025
[    0.000000] SoC Type: Realtek RTL9302B rev B (6487)
[    0.000000] CPU0 revision is: 00019555 (MIPS 34Kc)
[    0.000000] MIPS: machine is Zyxel XGS1250-12 A1 Switch
[    0.000000] earlycon: ns16550a0 at MMIO 0x18002000 (options '115200n8')
[    0.000000] printk: legacy bootconsole [ns16550a0] enabled
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Using appended Device Tree.
[    0.000000] OF: reserved mem: Reserved memory: No reserved-memory node in the DT
[    0.000000] Detected 1 available secondary CPU(s)
[    0.000000] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000]   HighMem  empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000] percpu: Embedded 12 pages/cpu s18096 r8192 d22864 u49152
[    0.000000] pcpu-alloc: s18096 r8192 d22864 u49152 alloc=12*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Kernel command line: earlycon
[    0.000000] Dentry cache hash table entries: 16384 (order: 4, 65536 bytes, linear)
[    0.000000] Inode-cache hash table entries: 8192 (order: 3, 32768 bytes, linear)
[    0.000000] Writing ErrCtl register=00063f50
[    0.000000] Readback ErrCtl register=00063f50
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 32768
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.000000] NR_IRQS: 256
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] Failed to get CPU clock: -2
[    0.000000] CPU frequency from device tree: 800MHz
[    0.000000] clocksource: realtek_otto_timer: mask: 0xfffffff max_cycles: 0xfffffff, max_idle_ns: 38225208801 ns
[    0.000002] sched_clock: 28 bits at 3125kHz, resolution 320ns, wraps every 42949672800ns
[    0.009046] Calibrating delay loop... 531.66 BogoMIPS (lpj=2658304)
[    0.065710] pid_max: default: 32768 minimum: 301
[    0.082103] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.090142] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.111790] rcu: Hierarchical SRCU implementation.
[    0.117026] rcu: 	Max phase no-delay instances is 1000.
[    0.124632] smp: Bringing up secondary CPUs ...
[    0.131406] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.131462] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.131545] CPU1 revision is: 00019555 (MIPS 34Kc)
[    0.208911] Counter synchronization [CPU#0 -> CPU#1]: passed
[    0.236174] smp: Brought up 1 node, 2 CPUs
[    0.242031] Memory: 103932K/131072K available (7411K kernel code, 714K rwdata, 916K rodata, 15592K init, 243K bss, 26324K reserved, 0K cma-reserved, 0K highmem)
[    0.264084] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.274944] futex hash table entries: 512 (order: 2, 16384 bytes, linear)
[    0.289048] pinctrl core: initialized pinctrl subsystem
[    0.297979] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.305046] thermal_sys: Registered thermal governor 'step_wise'
[    0.326464] clocksource: Switched to clocksource realtek_otto_timer
[    0.351503] NET: Registered PF_INET protocol family
[    0.357201] IP idents hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.365983] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.375204] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.383736] TCP established hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.392218] TCP bind hash table entries: 1024 (order: 2, 16384 bytes, linear)
[    0.400140] TCP: Hash tables configured (established 1024 bind 1024)
[    0.407938] MPTCP token hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.416341] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.423583] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.432271] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.456694] workingset: timestamp_bits=14 max_order=15 bucket_order=1
[    0.469566] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.475990] jffs2: version 2.2 (NAND) (SUMMARY) (ZLIB) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.499053] pinctrl-single 1b000200.pinmux: 32 pins, size 4
[    0.505870] pinctrl-single 1b00c600.pinmux: 32 pins, size 4
[    0.513128] pinctrl-single 1b00cc00.pinmux: 32 pins, size 4
[    0.524634] Serial: 8250/16550 driver, 2 ports, IRQ sharing disabled
[    0.534571] printk: legacy console [ttyS0] disabled
[    0.541436] 18002000.uart: ttyS0 at MMIO 0x18002000 (irq = 30, base_baud = 10937500) is a 16550A
[    0.551259] printk: legacy console [ttyS0] enabled
[    0.551259] printk: legacy console [ttyS0] enabled
[    0.562082] printk: legacy bootconsole [ns16550a0] disabled
[    0.562082] printk: legacy bootconsole [ns16550a0] disabled
[    0.629909] brd: module loaded
[    0.636741] 7 fixed-partitions partitions found on MTD device spi0.0
[    0.643923] OF: Bad cell count for /soc/spi@1200/flash@0/partitions
[    0.651066] OF: Bad cell count for /soc/spi@1200/flash@0/partitions
[    0.658484] Creating 7 MTD partitions on "spi0.0":
[    0.663900] 0x000000000000-0x0000000e0000 : "u-boot"
[    0.687232] 0x0000000e0000-0x0000000f0000 : "u-boot-env"
[    0.696107] 0x0000000f0000-0x000000100000 : "u-boot-env2"
[    0.705043] 0x000000100000-0x000000200000 : "jffs"
[    0.713554] 0x000000200000-0x000000300000 : "jffs2"
[    0.722242] 0x000000300000-0x000000fe0000 : "firmware"
[    0.731526] 2 uimage-fw partitions found on MTD device firmware
[    0.738356] Creating 2 MTD partitions on "firmware":
[    0.743957] 0x000000000000-0x0000003b0000 : "kernel"
[    0.752973] 0x0000003b0000-0x000000ce0000 : "rootfs"
[    0.761956] mtd: setting mtd7 (rootfs) as root device
[    0.767910] 1 squashfs-split partitions found on MTD device rootfs
[    0.774873] 0x000000720000-0x000000ce0000 : "rootfs_data"
[    0.784391] 0x000000fe0000-0x000001000000 : "log"
[    0.818819] mdio-rtl-otto 1b000000.switchcore:mdio-controller: probing RTL9300 family mdio bus
[    0.830328] c45_mask: 000e0000
[    1.120617] REALTEK RTL9300 SERDES 1b000000.switchcore:mdio-controller-mii:1b: Detected internal RTL9300 Serdes
[    1.259549] thermal thermal_zone0: Failed to set trips: -34
[    1.397408] thermal thermal_zone1: Failed to set trips: -34
[    1.535229] thermal thermal_zone2: Failed to set trips: -34
[    1.551742] realtek-otto-serdes-mdio 1b000000.switchcore:mdio-serdes: Realtek SerDes mdio bus initialized, 12 SerDes, 64 pages, 32 registers
[    1.566506] realtek-otto-pcs 1b000000.switchcore:pcs: Realtek PCS driver initialized
[    1.575786] Probing RTL838X eth device pdev: 82158a00, dev: 82158a10
[    1.602267] Found SoC ID: 9302: RTL9302B, family 9300
[    1.608133] Using MAC 0000808802488000
[    1.616074] i2c_dev: i2c /dev entries driver
[    1.629355] NET: Registered PF_INET6 protocol family
[    1.642242] Segment Routing with IPv6
[    1.646659] In-situ OAM (IOAM) with IPv6
[    1.651214] NET: Registered PF_PACKET protocol family
[    1.657536] 8021q: 802.1Q VLAN Support v1.8
[    1.709743] sfp sfp-p12: Host maximum power 1.0W
[    1.736966] rtl93xx_setup called
[    1.740647] In rtl83xx_vlan_setup
[    1.744335] UNKNOWN_MC_PMASK: 000000001fffffff
[    2.756503] rtl83xx_enable_phy_polling:          f0000ff
[    2.762801] rtl83xx-switch switch@1b000000: led_set0 has 2 LEDs configured
[    2.770539] rtl83xx-switch switch@1b000000: led_set1 has 4 LEDs configured
[    2.778279] rtl83xx-switch switch@1b000000: led_set2 has 2 LEDs configured
[    2.786160] rtl83xx-switch switch@1b000000: configuring for fixed/internal link mode
[    2.796823] rtl83xx-switch switch@1b000000 lan1 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:00] driver [REALTEK RTL8218D] (irq=POLL)
[    2.815047] rtl83xx-switch switch@1b000000 lan2 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:01] driver [REALTEK RTL8218D] (irq=POLL)
[    2.833235] rtl83xx-switch switch@1b000000 lan3 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:02] driver [REALTEK RTL8218D] (irq=POLL)
[    2.851394] rtl83xx-switch switch@1b000000 lan4 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:03] driver [REALTEK RTL8218D] (irq=POLL)
[    2.869602] rtl83xx-switch switch@1b000000 lan5 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:04] driver [REALTEK RTL8218D] (irq=POLL)
[    2.887987] rtl83xx-switch switch@1b000000 lan6 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:05] driver [REALTEK RTL8218D] (irq=POLL)
[    2.906079] rtl83xx-switch switch@1b000000 lan7 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:06] driver [REALTEK RTL8218D] (irq=POLL)
[    2.924317] rtl83xx-switch switch@1b000000 lan8 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:07] driver [REALTEK RTL8218D] (irq=POLL)
[    2.945411] rtl83xx-switch switch@1b000000: Link is Up - 10Gbps/Full - flow control off
[    2.967311] rtl83xx-switch switch@1b000000 lan9 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:18] driver [Aquantia AQR113C] (irq=POLL)
[    3.007521] rtl83xx-switch switch@1b000000 lan10 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:19] driver [Aquantia AQR113C] (irq=POLL)
[    3.047716] rtl83xx-switch switch@1b000000 lan11 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:1a] driver [Aquantia AQR113C] (irq=POLL)
[    3.068046] rtl838x-eth 1b00a300.ethernet eth0: entered promiscuous mode
[    3.075691] DSA: tree 0 setup
[    3.079148] LINK state irq: 23
[    3.082679] In rtl83xx_setup_qos
[    3.086673] rtl83xx_fib_event_work_do: FIB4 default rule failed
[    3.086670] rtl930x_dbgfs_init called
[    3.097869] clk: Disabling unused clocks
[    3.170716] Freeing unused kernel image (initmem) memory: 15592K
[    3.177492] This architecture does not have kernel memory protection.
[    3.184678] Run /init as init process
[    3.188807]   with arguments:
[    3.192119]     /init
[    3.194637]   with environment:
[    3.198173]     HOME=/
[    3.200808]     TERM=linux
[    3.971276] init: Console is alive
[    3.975515] init: - watchdog -
[    3.995438] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    4.006248] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    4.017905] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    4.037107] init: - preinit -
[    8.186547] random: crng init done
Cannot parse config file '/etc/fw_env.config': No such file or directory
Failed to find NVMEM device
[    9.581668] RESETTING 9300, CPU_PORT 28
[    9.786490] rtl838x-eth 1b00a300.ethernet eth0: configuring for fixed/internal link mode
[    9.795523] In rtl838x_mac_config, mode 1
[    9.800841] rtl83xx-switch switch@1b000000 lan1: configuring for phy/usxgmii link mode
[    9.809749] rtl93xx_phylink_mac_config SDS is 2
[    9.814814] realtek-otto-pcs 1b000000.switchcore:pcs: pcs_config(usxgmii) for port 0 and sds 2 not yet fully implemented
[    9.827462] 8021q: adding VLAN 0 to HW filter on device lan1
[    9.834057] rtl838x-eth 1b00a300.ethernet eth0: Link is Up - 1Gbps/Full - flow control off
[    9.848319] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[    9.855936] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[    9.865841] rtl83xx-switch switch@1b000000: add IPv4 route 10.0.0.254/32 (VLAN 0, MAC 80:88:02:48:80:00)
[    9.876603] rtl83xx-switch switch@1b000000: lower interface lan1 not found
[    9.884272] rtl83xx-switch switch@1b000000: fib_add() failed
[    9.890907] rtl83xx-switch switch@1b000000: add IPv4 route 10.0.0.255/32 (VLAN 0, MAC 80:88:02:48:80:00)
[    9.901595] rtl83xx-switch switch@1b000000: skip loopback/broadcast addresses and default routes
[    9.911512] rtl83xx-switch switch@1b000000: add IPv4 route 10.0.0.0/24 (VLAN 0, MAC 80:88:02:48:80:00)
[    9.921985] rtl83xx-switch switch@1b000000: lower interface lan1 not found
[    9.929710] rtl83xx-switch switch@1b000000: fib_add() failed
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[   11.396550] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   14.042590] rtl83xx-switch switch@1b000000 lan1: Link is Up - 1Gbps/Full - flow control rx/tx
[   14.193467] rtl83xx-switch switch@1b000000: delete IPv4 route 10.0.0.0/24 (VLAN 0, MAC 80:88:02:48:80:00)
[   14.204336] rtl83xx-switch switch@1b000000: no such gateway: 0.0.0.0
[   14.211616] rtl83xx-switch switch@1b000000: fib_del() failed
[   14.218122] rtl83xx-switch switch@1b000000: delete IPv4 route 10.0.0.255/32 (VLAN 0, MAC 80:88:02:48:80:00)
[   14.229146] rtl83xx-switch switch@1b000000: skip loopback/broadcast addresses and default routes
[   14.240379] rtl83xx-switch switch@1b000000 lan1: Link is Down
[   14.247683] rtl83xx-switch switch@1b000000: delete IPv4 route 10.0.0.254/32 (VLAN 0, MAC 80:88:02:48:80:00)
[   14.258720] rtl83xx-switch switch@1b000000: no such gateway: 0.0.0.0
[   14.265813] rtl83xx-switch switch@1b000000: fib_del() failed
[   14.279532] procd: - early -
[   14.283124] procd: - watchdog -
[   14.919568] procd: - watchdog -
[   14.923622] procd: - ubus -
[   15.086325] procd: - init -
Please press Enter to activate this console.
[   15.751555] kmodloader: loading kernel modules from /etc/modules.d/*
[   15.776588] gpio-fan gpio-fan: GPIO fan initialized
[   15.874781] kmodloader: done loading kernel modules from /etc/modules.d/*
[   17.220668] urngd: v1.0.2 started.
[   21.169329] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported



BusyBox v1.37.0 (2025-10-09 18:28:41 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt SNAPSHOT, r31396+10-011ba05fd3
 -----------------------------------------------------
 Hardware: Zyxel XGS1250-12 A1 Switch

=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------

 OpenWrt recently switched to the "apk" package manager!

 OPKG Command           APK Equivalent      Description
 ------------------------------------------------------------------
 opkg install <pkg>     apk add <pkg>       Install a package
 opkg remove <pkg>      apk del <pkg>       Remove a package
 opkg upgrade           apk upgrade         Upgrade all packages
 opkg files <pkg>       apk info -L <pkg>   List package contents
 opkg list-installed    apk info            List installed packages
 opkg update            apk update          Update package lists
 opkg search <pkg>      apk search <pkg>    Search for packages
 ------------------------------------------------------------------

For more https://openwrt.org/docs/guide-user/additional-software/opkg-to-apk-cheatsheet

root@OpenWrt:~# 
```
</details>

**Squashfs log**

<details><summary>Toggle</summary>

```
RTL9300# # boota
## Booting kernel from Legacy Image at 81000000 ...
   Image Name:   MIPS OpenWrt Linux-6.12.51
   Created:      2025-10-11  18:15:17 UTC
   Image Type:   MIPS Linux Kernel Image (uncompressed)
   Data Size:    2815208 Bytes = 2.7 MB
   Load Address: 80100000
   Entry Point:  80100000
   Verifying Checksum ... OK
   Loading Kernel Image ... OK
OK

Starting kernel ...


rt-loader
Running on RTL9302B (chip id 6487A) with 128MB
Relocate 2815216 bytes from 0x80100000 to 0x87d00000
Extract image with 2799500 bytes from 0x87d03d5c to 0x80100000 ...
Final kernel size is 9487674 bytes
Booting kernel from 0x80100000 ...

[    0.000000] Linux version 6.12.51 (5800X@crunchbot) (mips-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r30740+9-08cc7e881e) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Sat Oct 11 18:15:17 2025
[    0.000000] SoC Type: Realtek RTL9302B rev B (6487)
[    0.000000] CPU0 revision is: 00019555 (MIPS 34Kc)
[    0.000000] MIPS: machine is Zyxel XGS1250-12 A1 Switch
[    0.000000] earlycon: ns16550a0 at MMIO 0x18002000 (options '115200n8')
[    0.000000] printk: legacy bootconsole [ns16550a0] enabled
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Using appended Device Tree.
[    0.000000] OF: reserved mem: Reserved memory: No reserved-memory node in the DT
[    0.000000] Detected 1 available secondary CPU(s)
[    0.000000] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000]   HighMem  empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000] percpu: Embedded 12 pages/cpu s18096 r8192 d22864 u49152
[    0.000000] pcpu-alloc: s18096 r8192 d22864 u49152 alloc=12*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Kernel command line: earlycon
[    0.000000] Dentry cache hash table entries: 16384 (order: 4, 65536 bytes, linear)
[    0.000000] Inode-cache hash table entries: 8192 (order: 3, 32768 bytes, linear)
[    0.000000] Writing ErrCtl register=00063f55
[    0.000000] Readback ErrCtl register=00063f55
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 32768
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.000000] NR_IRQS: 256
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] Failed to get CPU clock: -2
[    0.000000] CPU frequency from device tree: 800MHz
[    0.000000] clocksource: realtek_otto_timer: mask: 0xfffffff max_cycles: 0xfffffff, max_idle_ns: 38225208801 ns
[    0.000002] sched_clock: 28 bits at 3125kHz, resolution 320ns, wraps every 42949672800ns
[    0.009046] Calibrating delay loop... 531.66 BogoMIPS (lpj=2658304)
[    0.065711] pid_max: default: 32768 minimum: 301
[    0.082108] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.090151] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.111891] rcu: Hierarchical SRCU implementation.
[    0.117130] rcu: 	Max phase no-delay instances is 1000.
[    0.124750] smp: Bringing up secondary CPUs ...
[    0.131568] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.131625] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.131712] CPU1 revision is: 00019555 (MIPS 34Kc)
[    0.208909] Counter synchronization [CPU#0 -> CPU#1]: passed
[    0.236176] smp: Brought up 1 node, 2 CPUs
[    0.242047] Memory: 118268K/131072K available (7411K kernel code, 714K rwdata, 916K rodata, 1256K init, 243K bss, 11988K reserved, 0K cma-reserved, 0K highmem)
[    0.264012] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.274868] futex hash table entries: 512 (order: 2, 16384 bytes, linear)
[    0.288973] pinctrl core: initialized pinctrl subsystem
[    0.297904] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.304974] thermal_sys: Registered thermal governor 'step_wise'
[    0.326464] clocksource: Switched to clocksource realtek_otto_timer
[    0.351508] NET: Registered PF_INET protocol family
[    0.357213] IP idents hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.366008] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.375232] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.383763] TCP established hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.392246] TCP bind hash table entries: 1024 (order: 2, 16384 bytes, linear)
[    0.400165] TCP: Hash tables configured (established 1024 bind 1024)
[    0.407969] MPTCP token hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.416377] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.423671] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.432342] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.444992] workingset: timestamp_bits=14 max_order=15 bucket_order=1
[    0.455184] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.461642] jffs2: version 2.2 (NAND) (SUMMARY) (ZLIB) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.479575] pinctrl-single 1b000200.pinmux: 32 pins, size 4
[    0.486037] pinctrl-single 1b00c600.pinmux: 32 pins, size 4
[    0.492959] pinctrl-single 1b00cc00.pinmux: 32 pins, size 4
[    0.502153] Serial: 8250/16550 driver, 2 ports, IRQ sharing disabled
[    0.512464] printk: legacy console [ttyS0] disabled
[    0.519202] 18002000.uart: ttyS0 at MMIO 0x18002000 (irq = 30, base_baud = 10937500) is a 16550A
[    0.528926] printk: legacy console [ttyS0] enabled
[    0.528926] printk: legacy console [ttyS0] enabled
[    0.539658] printk: legacy bootconsole [ns16550a0] disabled
[    0.539658] printk: legacy bootconsole [ns16550a0] disabled
[    0.586297] brd: module loaded
[    0.594336] 7 fixed-partitions partitions found on MTD device spi0.0
[    0.601578] OF: Bad cell count for /soc/spi@1200/flash@0/partitions
[    0.608645] OF: Bad cell count for /soc/spi@1200/flash@0/partitions
[    0.615952] Creating 7 MTD partitions on "spi0.0":
[    0.621388] 0x000000000000-0x0000000e0000 : "u-boot"
[    0.627976] 0x0000000e0000-0x0000000f0000 : "u-boot-env"
[    0.634693] 0x0000000f0000-0x000000100000 : "u-boot-env2"
[    0.641838] 0x000000100000-0x000000200000 : "jffs"
[    0.649035] 0x000000200000-0x000000300000 : "jffs2"
[    0.656567] 0x000000300000-0x000000fe0000 : "firmware"
[    0.664475] 2 uimage-fw partitions found on MTD device firmware
[    0.671238] Creating 2 MTD partitions on "firmware":
[    0.676888] 0x000000000000-0x0000002b0000 : "kernel"
[    0.684116] 0x0000002b0000-0x000000ce0000 : "rootfs"
[    0.691975] mtd: setting mtd7 (rootfs) as root device
[    0.697835] 1 squashfs-split partitions found on MTD device rootfs
[    0.704739] 0x000000620000-0x000000ce0000 : "rootfs_data"
[    0.712756] 0x000000fe0000-0x000001000000 : "log"
[    0.739280] mdio-rtl-otto 1b000000.switchcore:mdio-controller: probing RTL9300 family mdio bus
[    0.750631] c45_mask: 000e0000
[    0.805167] REALTEK RTL9300 SERDES 1b000000.switchcore:mdio-controller-mii:1b: Detected internal RTL9300 Serdes
[    0.840800] thermal thermal_zone0: Failed to set trips: -34
[    0.876560] thermal thermal_zone1: Failed to set trips: -34
[    0.912280] thermal thermal_zone2: Failed to set trips: -34
[    0.928724] realtek-otto-serdes-mdio 1b000000.switchcore:mdio-serdes: Realtek SerDes mdio bus initialized, 12 SerDes, 64 pages, 32 registers
[    0.943340] realtek-otto-pcs 1b000000.switchcore:pcs: Realtek PCS driver initialized
[    0.952787] Probing RTL838X eth device pdev: 81959200, dev: 81959210
[    0.979285] Found SoC ID: 9302: RTL9302B, family 9300
[    0.985083] Using MAC 0000808802488000
[    0.992955] i2c_dev: i2c /dev entries driver
[    1.006520] NET: Registered PF_INET6 protocol family
[    1.021280] Segment Routing with IPv6
[    1.025504] In-situ OAM (IOAM) with IPv6
[    1.030187] NET: Registered PF_PACKET protocol family
[    1.037087] 8021q: 802.1Q VLAN Support v1.8
[    1.087408] sfp sfp-p12: Host maximum power 1.0W
[    1.100858] rtl93xx_setup called
[    1.104548] In rtl83xx_vlan_setup
[    1.108345] UNKNOWN_MC_PMASK: 000000001fffffff
[    2.206510] rtl83xx_enable_phy_polling:          f0000ff
[    2.212810] rtl83xx-switch switch@1b000000: led_set0 has 2 LEDs configured
[    2.220546] rtl83xx-switch switch@1b000000: led_set1 has 4 LEDs configured
[    2.228264] rtl83xx-switch switch@1b000000: led_set2 has 2 LEDs configured
[    2.236080] rtl83xx-switch switch@1b000000: configuring for fixed/internal link mode
[    2.246097] rtl83xx-switch switch@1b000000 lan1 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:00] driver [REALTEK RTL8218D] (irq=POLL)
[    2.264259] rtl83xx-switch switch@1b000000 lan2 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:01] driver [REALTEK RTL8218D] (irq=POLL)
[    2.282522] rtl83xx-switch switch@1b000000 lan3 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:02] driver [REALTEK RTL8218D] (irq=POLL)
[    2.300681] rtl83xx-switch switch@1b000000 lan4 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:03] driver [REALTEK RTL8218D] (irq=POLL)
[    2.319661] rtl83xx-switch switch@1b000000 lan5 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:04] driver [REALTEK RTL8218D] (irq=POLL)
[    2.337967] rtl83xx-switch switch@1b000000 lan6 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:05] driver [REALTEK RTL8218D] (irq=POLL)
[    2.356023] rtl83xx-switch switch@1b000000 lan7 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:06] driver [REALTEK RTL8218D] (irq=POLL)
[    2.374232] rtl83xx-switch switch@1b000000 lan8 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:07] driver [REALTEK RTL8218D] (irq=POLL)
[    2.395420] rtl83xx-switch switch@1b000000: Link is Up - 10Gbps/Full - flow control off
[    2.417336] rtl83xx-switch switch@1b000000 lan9 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:18] driver [Aquantia AQR113C] (irq=POLL)
[    2.457465] rtl83xx-switch switch@1b000000 lan10 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:19] driver [Aquantia AQR113C] (irq=POLL)
[    2.496953] rtl83xx-switch switch@1b000000 lan11 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:1a] driver [Aquantia AQR113C] (irq=POLL)
[    2.515393] rtl838x-eth 1b00a300.ethernet eth0: entered promiscuous mode
[    2.523144] DSA: tree 0 setup
[    2.526648] LINK state irq: 23
[    2.530163] In rtl83xx_setup_qos
[    2.533987] rtl930x_dbgfs_init called
[    2.534043] rtl83xx_fib_event_work_do: FIB4 default rule failed
[    2.544913] rtl83xx_fib_event_work_do: FIB4 default rule failed
[    2.551903] clk: Disabling unused clocks
[    2.563299] VFS: Mounted root (squashfs filesystem) readonly on device 31:7.
[    2.576667] Freeing unused kernel image (initmem) memory: 1256K
[    2.583319] This architecture does not have kernel memory protection.
[    2.590553] Run /sbin/init as init process
[    2.595124]   with arguments:
[    2.598478]     /sbin/init
[    2.601505]   with environment:
[    2.604990]     HOME=/
[    2.607654]     TERM=linux
[    3.144631] init: Console is alive
[    3.148954] init: - watchdog -
[    3.518832] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.575463] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    3.587476] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.606336] init: - preinit -
[    8.166562] random: crng init done
Cannot parse config file '/etc/fw_env.config': No such file or directory
Failed to find NVMEM device
[    9.793976] RESETTING 9300, CPU_PORT 28
[    9.998830] rtl838x-eth 1b00a300.ethernet eth0: configuring for fixed/internal link mode
[   10.007864] In rtl838x_mac_config, mode 1
[   10.013147] rtl83xx-switch switch@1b000000 lan1: configuring for phy/usxgmii link mode
[   10.022056] rtl93xx_phylink_mac_config SDS is 2
[   10.027176] realtek-otto-pcs 1b000000.switchcore:pcs: pcs_config(usxgmii) for port 0 and sds 2 not yet fully implemented
[   10.039936] 8021q: adding VLAN 0 to HW filter on device lan1
[   10.046633] rtl838x-eth 1b00a300.ethernet eth0: Link is Up - 1Gbps/Full - flow control off
[   10.048476] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   10.063876] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   10.074019] rtl83xx-switch switch@1b000000: add IPv4 route 10.0.0.254/32 (VLAN 0, MAC 80:88:02:48:80:00)
[   10.084888] rtl83xx-switch switch@1b000000: lower interface lan1 not found
[   10.092697] rtl83xx-switch switch@1b000000: fib_add() failed
[   10.099496] rtl83xx-switch switch@1b000000: add IPv4 route 10.0.0.255/32 (VLAN 0, MAC 80:88:02:48:80:00)
[   10.110347] rtl83xx-switch switch@1b000000: skip loopback/broadcast addresses and default routes
[   10.122093] rtl83xx-switch switch@1b000000: add IPv4 route 10.0.0.0/24 (VLAN 0, MAC 80:88:02:48:80:00)
[   10.132786] rtl83xx-switch switch@1b000000: lower interface lan1 not found
[   10.140697] rtl83xx-switch switch@1b000000: fib_add() failed
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[   11.956544] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   14.202227] rtl83xx-switch switch@1b000000 lan1: Link is Up - 1Gbps/Full - flow control rx/tx
[   14.459942] jffs2_scan_eraseblock(): End of filesystem marker found at 0x10000
[   14.468121] jffs2_build_filesystem(): unlocking the mtd device... 
[   14.468205] done.
[   14.477276] jffs2_build_filesystem(): erasing all blocks after the end marker... 
[   16.281424] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   16.297245] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   16.304670] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   17.796610] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   17.876626] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   43.858086] done.
[   43.860305] jffs2: notice: (822) jffs2_build_xattr_subsystem: complete building xattr subsystem, 0 of xdatum (0 unchecked, 0 orphan) and 0 of xref (0 dead, 0 orphan) found.
[   43.881791] mount_root: overlay filesystem has not been fully initialized yet
[   43.891442] mount_root: switching to jffs2 overlay
[   43.907530] overlayfs: upper fs does not support tmpfile.
- config restore -
[   44.321284] urandom-seed: Seed file not found (/etc/urandom.seed)
[   44.415298] rtl83xx-switch switch@1b000000: delete IPv4 route 10.0.0.0/24 (VLAN 0, MAC 80:88:02:48:80:00)
[   44.426155] rtl83xx-switch switch@1b000000: no such gateway: 0.0.0.0
[   44.433374] rtl83xx-switch switch@1b000000: fib_del() failed
[   44.439874] rtl83xx-switch switch@1b000000: delete IPv4 route 10.0.0.255/32 (VLAN 0, MAC 80:88:02:48:80:00)
[   44.450919] rtl83xx-switch switch@1b000000: skip loopback/broadcast addresses and default routes
[   44.462675] rtl83xx-switch switch@1b000000 lan1: Link is Down
[   44.469450] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   44.476856] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   44.484165] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   44.491600] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   44.498999] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
[   44.507341] rtl83xx-switch switch@1b000000: delete IPv4 route 10.0.0.254/32 (VLAN 0, MAC 80:88:02:48:80:00)
[   44.518387] rtl83xx-switch switch@1b000000: no such gateway: 0.0.0.0
[   44.525603] rtl83xx-switch switch@1b000000: fib_del() failed
[   44.532070] procd: - early -
[   44.532537] procd: - watchdog -
[   45.202503] procd: - watchdog -
[   45.206779] procd: - ubus -
[   45.318557] procd: - init -
Please press Enter to activate this console.
[   46.269530] kmodloader: loading kernel modules from /etc/modules.d/*
[   46.357220] gpio-fan gpio-fan: GPIO fan initialized
[   46.453971] kmodloader: done loading kernel modules from /etc/modules.d/*
[   47.854554] urngd: v1.0.2 started.
[   51.631134] rtl83xx_fib_event: FIB_RULE ADD/DEL for IPv6 not supported
```
</details>
