### PR TITLE
ipq806x: add missing semicolons for 10_fix_wifi_mac

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -20,6 +20,7 @@ case "$board" in
 	linksys,ea7500-v1 |\
 	linksys,ea8500)
 		macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) $(($PHYNBR + 1)) > /sys${DEVPATH}/macaddress
+		;;
 esac
 
 OPATH=${DEVPATH##/devices/platform/}


### PR DESCRIPTION
Fix the syntax issue.

Fixes: 148f82ad4525 ("ipq806x: use nvmem for wifi mac")
