### PR TITLE
leds.mk: fix leds-group-multicolor name

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -24,22 +24,22 @@ $(eval $(call KernelPackage,leds-gpio))
 
 LED_TRIGGER_DIR=$(LINUX_DIR)/drivers/leds/trigger
 
-define KernelPackage/led-group-multi-color
+define KernelPackage/leds-group-multicolor
   SUBMENU:=$(LEDS_MENU)
-  TITLE:=LEDs group multi-color support
+  TITLE:=LEDs group multicolor support
   KCONFIG:=CONFIG_LEDS_GROUP_MULTICOLOR
   FILES:=$(LINUX_DIR)/drivers/leds/rgb/leds-group-multicolor.ko
-  AUTOLOAD:=$(call AutoProbe,led-group-multi-color)
+  AUTOLOAD:=$(call AutoProbe,leds-group-multicolor)
 endef
 
-define KernelPackage/led-group-multi-color/description
+define KernelPackage/leds-group-multicolor/description
  This option enables support for monochrome LEDs that are grouped
  into multicolor LEDs which is useful in the case where LEDs of
  different colors are physically grouped in a single multi-color LED
  and driven by a controller that does not have multi-color support.
 endef
 
-$(eval $(call KernelPackage,led-group-multi-color))
+$(eval $(call KernelPackage,leds-group-multicolor))
 
 define KernelPackage/ledtrig-activity
   SUBMENU:=$(LEDS_MENU)


### PR DESCRIPTION
Fix package name and AUTOLOAD parameter to match the actual kernel module name (leds-group-multicolor), enabling proper auto-loading at boot.