### PR TITLE
ipq806x: chromium: fix broken WiFi on 6.12 kernel

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
@@ -37,6 +37,10 @@ migrate_radio()
 WIRELESS_CHANGED=false
 
 case "$(board_name)" in
+asus,onhub |\
+tplink,onhub)
+	exit 0
+	;;
 *)
 	migrate_radio
 	;;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-onhub.dtsi
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-onhub.dtsi
@@ -450,40 +450,213 @@
 	};
 };
 
-&pcie0 {
-	status = "okay";
-};
+&soc {
+	/*
+	 * The Chrome OnHub bootloader will patch the ath10k calibration data properties
+	 * "qcom,ath10k-calibration-data-base64" into "pci@1b{5,7,9}00000/pcie@0/ath10k@0,0" nodes.
+	 */
 
-&pcie_bridge0 {
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x00010000 0 0 0 0>;
-		qcom,ath10k-sa-gpio = <2 3 4 0>;
-		qcom,ath10k-sa-gpio-func = <5 5 5 0>;
+	/delete-node/ pcie@1b500000;
+	/delete-node/ pcie@1b700000;
+	/delete-node/ pcie@1b900000;
+
+	pci@1b500000 {
+		compatible = "qcom,pcie-ipq8064";
+		reg = <0x1b500000 0x1000
+		       0x1b502000 0x80
+		       0x1b600000 0x100
+		       0x0ff00000 0x100000>;
+		reg-names = "dbi", "elbi", "parf", "config";
+		device_type = "pci";
+		linux,pci-domain = <0>;
+		bus-range = <0x00 0xff>;
+		num-lanes = <1>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		ranges = <0x81000000 0x0 0x00000000 0x0fe00000 0x0 0x00010000   /* I/O */
+			  0x82000000 0x0 0x08000000 0x08000000 0x0 0x07e00000>; /* MEM */
+
+		interrupts = <GIC_SPI 35 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "msi";
+		#interrupt-cells = <1>;
+		interrupt-map-mask = <0 0 0 0x7>;
+		interrupt-map = <0 0 0 1 &intc 0 36 IRQ_TYPE_LEVEL_HIGH>, /* int_a */
+				<0 0 0 2 &intc 0 37 IRQ_TYPE_LEVEL_HIGH>, /* int_b */
+				<0 0 0 3 &intc 0 38 IRQ_TYPE_LEVEL_HIGH>, /* int_c */
+				<0 0 0 4 &intc 0 39 IRQ_TYPE_LEVEL_HIGH>; /* int_d */
+
+		clocks = <&gcc PCIE_A_CLK>,
+			 <&gcc PCIE_H_CLK>,
+			 <&gcc PCIE_PHY_CLK>,
+			 <&gcc PCIE_AUX_CLK>,
+			 <&gcc PCIE_ALT_REF_CLK>;
+		clock-names = "core", "iface", "phy", "aux", "ref";
+
+		assigned-clocks = <&gcc PCIE_ALT_REF_CLK>;
+		assigned-clock-rates = <100000000>;
+
+		resets = <&gcc PCIE_ACLK_RESET>,
+			 <&gcc PCIE_HCLK_RESET>,
+			 <&gcc PCIE_POR_RESET>,
+			 <&gcc PCIE_PCI_RESET>,
+			 <&gcc PCIE_PHY_RESET>,
+			 <&gcc PCIE_EXT_RESET>;
+		reset-names = "axi", "ahb", "por", "pci", "phy", "ext";
+
+		pinctrl-0 = <&pcie0_pins>;
+		pinctrl-names = "default";
+
+		perst-gpios = <&qcom_pinmux 3 GPIO_ACTIVE_LOW>;
+
+		pcie@0 {
+			device_type = "pci";
+			reg = <0x0 0x0 0x0 0x0 0x0>;
+			bus-range = <0x01 0xff>;
+
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+
+			ath10k@0,0 {
+				compatible = "qcom,ath10k";
+				reg = <0x00010000 0 0 0 0>;
+				qcom,ath10k-sa-gpio = <2 3 4 0>;
+				qcom,ath10k-sa-gpio-func = <5 5 5 0>;
+			};
+		};
 	};
-};
 
-&pcie1 {
-	status = "okay";
-};
+	pci@1b700000 {
+		compatible = "qcom,pcie-ipq8064";
+		reg = <0x1b700000 0x1000
+		       0x1b702000 0x80
+		       0x1b800000 0x100
+		       0x31f00000 0x100000>;
+		reg-names = "dbi", "elbi", "parf", "config";
+		device_type = "pci";
+		linux,pci-domain = <1>;
+		bus-range = <0x00 0xff>;
+		num-lanes = <1>;
+		#address-cells = <3>;
+		#size-cells = <2>;
 
-&pcie_bridge1 {
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x00010000 0 0 0 0>;
-		qcom,ath10k-sa-gpio = <2 3 4 0>;
-		qcom,ath10k-sa-gpio-func = <5 5 5 0>;
+		ranges = <0x81000000 0x0 0x00000000 0x31e00000 0x0 0x00010000   /* I/O */
+			  0x82000000 0x0 0x2e000000 0x2e000000 0x0 0x03e00000>; /* MEM */
+
+		interrupts = <GIC_SPI 57 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "msi";
+		#interrupt-cells = <1>;
+		interrupt-map-mask = <0 0 0 0x7>;
+		interrupt-map = <0 0 0 1 &intc 0 58 IRQ_TYPE_LEVEL_HIGH>, /* int_a */
+				<0 0 0 2 &intc 0 59 IRQ_TYPE_LEVEL_HIGH>, /* int_b */
+				<0 0 0 3 &intc 0 60 IRQ_TYPE_LEVEL_HIGH>, /* int_c */
+				<0 0 0 4 &intc 0 61 IRQ_TYPE_LEVEL_HIGH>; /* int_d */
+
+		clocks = <&gcc PCIE_1_A_CLK>,
+			 <&gcc PCIE_1_H_CLK>,
+			 <&gcc PCIE_1_PHY_CLK>,
+			 <&gcc PCIE_1_AUX_CLK>,
+			 <&gcc PCIE_1_ALT_REF_CLK>;
+		clock-names = "core", "iface", "phy", "aux", "ref";
+
+		assigned-clocks = <&gcc PCIE_1_ALT_REF_CLK>;
+		assigned-clock-rates = <100000000>;
+
+		resets = <&gcc PCIE_1_ACLK_RESET>,
+			 <&gcc PCIE_1_HCLK_RESET>,
+			 <&gcc PCIE_1_POR_RESET>,
+			 <&gcc PCIE_1_PCI_RESET>,
+			 <&gcc PCIE_1_PHY_RESET>,
+			 <&gcc PCIE_1_EXT_RESET>;
+		reset-names = "axi", "ahb", "por", "pci", "phy", "ext";
+
+		pinctrl-0 = <&pcie1_pins>;
+		pinctrl-names = "default";
+
+		perst-gpios = <&qcom_pinmux 48 GPIO_ACTIVE_LOW>;
+
+		pcie@0 {
+			device_type = "pci";
+			reg = <0x0 0x0 0x0 0x0 0x0>;
+			bus-range = <0x01 0xff>;
+
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+
+			ath10k@0,0 {
+				compatible = "qcom,ath10k";
+				reg = <0x00010000 0 0 0 0>;
+				qcom,ath10k-sa-gpio = <2 3 4 0>;
+				qcom,ath10k-sa-gpio-func = <5 5 5 0>;
+			};
+		};
 	};
-};
 
-&pcie2 {
-	status = "okay";
-};
+	pci@1b900000 {
+		compatible = "qcom,pcie-ipq8064";
+		reg = <0x1b900000 0x1000
+		       0x1b902000 0x80
+		       0x1ba00000 0x100
+		       0x35f00000 0x100000>;
+		reg-names = "dbi", "elbi", "parf", "config";
+		device_type = "pci";
+		linux,pci-domain = <2>;
+		bus-range = <0x00 0xff>;
+		num-lanes = <1>;
+		#address-cells = <3>;
+		#size-cells = <2>;
 
-&pcie_bridge2 {
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x00010000 0 0 0 0>;
+		ranges = <0x81000000 0x0 0x00000000 0x35e00000 0x0 0x00010000   /* I/O */
+			  0x82000000 0x0 0x32000000 0x32000000 0x0 0x03e00000>; /* MEM */
+
+		interrupts = <GIC_SPI 71 IRQ_TYPE_LEVEL_HIGH>;
+		interrupt-names = "msi";
+		#interrupt-cells = <1>;
+		interrupt-map-mask = <0 0 0 0x7>;
+		interrupt-map = <0 0 0 1 &intc 0 72 IRQ_TYPE_LEVEL_HIGH>, /* int_a */
+				<0 0 0 2 &intc 0 73 IRQ_TYPE_LEVEL_HIGH>, /* int_b */
+				<0 0 0 3 &intc 0 74 IRQ_TYPE_LEVEL_HIGH>, /* int_c */
+				<0 0 0 4 &intc 0 75 IRQ_TYPE_LEVEL_HIGH>; /* int_d */
+
+		clocks = <&gcc PCIE_2_A_CLK>,
+			 <&gcc PCIE_2_H_CLK>,
+			 <&gcc PCIE_2_PHY_CLK>,
+			 <&gcc PCIE_2_AUX_CLK>,
+			 <&gcc PCIE_2_ALT_REF_CLK>;
+		clock-names = "core", "iface", "phy", "aux", "ref";
+
+		assigned-clocks = <&gcc PCIE_2_ALT_REF_CLK>;
+		assigned-clock-rates = <100000000>;
+
+		resets = <&gcc PCIE_2_ACLK_RESET>,
+			 <&gcc PCIE_2_HCLK_RESET>,
+			 <&gcc PCIE_2_POR_RESET>,
+			 <&gcc PCIE_2_PCI_RESET>,
+			 <&gcc PCIE_2_PHY_RESET>,
+			 <&gcc PCIE_2_EXT_RESET>;
+		reset-names = "axi", "ahb", "por", "pci", "phy", "ext";
+
+		pinctrl-0 = <&pcie2_pins>;
+		pinctrl-names = "default";
+
+		perst-gpios = <&qcom_pinmux 63 GPIO_ACTIVE_LOW>;
+
+		pcie@0 {
+			device_type = "pci";
+			reg = <0x0 0x0 0x0 0x0 0x0>;
+			bus-range = <0x01 0xff>;
+
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+
+			ath10k@0,0 {
+				compatible = "qcom,ath10k";
+				reg = <0x00010000 0 0 0 0>;
+			};
+		};
 	};
 };
 


### PR DESCRIPTION
The ath10k WiFi calibration data of these chromium devices are patched by the bootloader. However, the ipq806x dts PCIe node names have been renamed since 6.12 kernel. Hence, the calibration data can't be merged into the correct paths anymore. Restore the old PCIe device node names to address this issue.

Report: https://github.com/openwrt/openwrt/pull/18989#issuecomment-3417383963

cc @dadogroove