### PR TITLE
[openwrt-24.10] Improve support for Radxa's RK358x-based boards

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -280,6 +280,13 @@ define U-Boot/rk358x/Default
   TPL:=rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin
 endef
 
+define U-Boot/generic-rk3588
+  $(U-Boot/rk358x/Default)
+  NAME:=Generic RK358x board
+  BUILD_DEVICES:= \
+    radxa_rock-5b-plus
+endef
+
 # RK3588 boards
 
 define U-Boot/nanopc-t6-rk3588
@@ -356,6 +363,7 @@ UBOOT_TARGETS := \
   radxa-e25-rk3568 \
   rock-3a-rk3568 \
   rock-3b-rk3568 \
+  generic-rk3588 \
   nanopc-t6-rk3588 \
   rock5b-rk3588 \
   sige7-rk3588 \

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -297,6 +297,13 @@ define U-Boot/nanopc-t6-rk3588
     friendlyarm_nanopc-t6
 endef
 
+define U-Boot/rock-5-itx-rk3588
+  $(U-Boot/rk358x/Default)
+  NAME:=ROCK 5 ITX/ITX+
+  BUILD_DEVICES:= \
+    radxa_rock-5-itx
+endef
+
 define U-Boot/rock5b-rk3588
   $(U-Boot/rk358x/Default)
   NAME:=ROCK 5B
@@ -366,6 +373,7 @@ UBOOT_TARGETS := \
   rock-3b-rk3568 \
   generic-rk3588 \
   nanopc-t6-rk3588 \
+  rock-5-itx-rk3588 \
   rock5b-rk3588 \
   sige7-rk3588 \
   nanopi-r6c-rk3588s \

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -342,6 +342,13 @@ define U-Boot/rock5a-rk3588s
     radxa_rock-5a
 endef
 
+define U-Boot/rock-5c-rk3588s
+  $(U-Boot/rk358x/Default)
+  NAME:=ROCK 5C/5C Lite
+  BUILD_DEVICES:= \
+    radxa_rock-5c
+endef
+
 UBOOT_TARGETS := \
   nanopc-t4-rk3399 \
   nanopi-r4s-rk3399 \
@@ -378,7 +385,8 @@ UBOOT_TARGETS := \
   sige7-rk3588 \
   nanopi-r6c-rk3588s \
   nanopi-r6s-rk3588s \
-  rock5a-rk3588s
+  rock5a-rk3588s \
+  rock-5c-rk3588s
 
 UBOOT_CONFIGURE_VARS += USE_PRIVATE_LIBGCC=yes
 

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -271,31 +271,33 @@ define U-Boot/rock-3b-rk3568
 endef
 
 
-# RK3588 boards
+# RK358x boards
 
-define U-Boot/rk3588/Default
+define U-Boot/rk358x/Default
   BUILD_SUBTARGET:=armv8
   DEPENDS:=+PACKAGE_u-boot-$(1):trusted-firmware-a-rk3588
   ATF:=rk3588_bl31_v1.45.elf
   TPL:=rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.16.bin
 endef
 
+# RK3588 boards
+
 define U-Boot/nanopc-t6-rk3588
-  $(U-Boot/rk3588/Default)
+  $(U-Boot/rk358x/Default)
   NAME:=NanoPC T6
   BUILD_DEVICES:= \
     friendlyarm_nanopc-t6
 endef
 
 define U-Boot/rock5b-rk3588
-  $(U-Boot/rk3588/Default)
+  $(U-Boot/rk358x/Default)
   NAME:=ROCK 5B
   BUILD_DEVICES:= \
     radxa_rock-5b
 endef
 
 define U-Boot/sige7-rk3588
-  $(U-Boot/rk3588/Default)
+  $(U-Boot/rk358x/Default)
   NAME:=Sige7
   BUILD_DEVICES:= \
     armsom_sige7
@@ -305,21 +307,21 @@ endef
 # RK3588S boards
 
 define U-Boot/nanopi-r6c-rk3588s
-  $(U-Boot/rk3588/Default)
+  $(U-Boot/rk358x/Default)
   NAME:=NanoPi R6C
   BUILD_DEVICES:= \
     friendlyarm_nanopi-r6c
 endef
 
 define U-Boot/nanopi-r6s-rk3588s
-  $(U-Boot/rk3588/Default)
+  $(U-Boot/rk358x/Default)
   NAME:=NanoPi R6S
   BUILD_DEVICES:= \
     friendlyarm_nanopi-r6s
 endef
 
 define U-Boot/rock5a-rk3588s
-  $(U-Boot/rk3588/Default)
+  $(U-Boot/rk358x/Default)
   NAME:=ROCK 5A
   BUILD_DEVICES:= \
     radxa_rock-5a

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -284,7 +284,8 @@ define U-Boot/generic-rk3588
   $(U-Boot/rk358x/Default)
   NAME:=Generic RK358x board
   BUILD_DEVICES:= \
-    radxa_rock-5b-plus
+    radxa_rock-5b-plus \
+    radxa_rock-5t
 endef
 
 # RK3588 boards

--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -284,6 +284,7 @@ define U-Boot/generic-rk3588
   $(U-Boot/rk358x/Default)
   NAME:=Generic RK358x board
   BUILD_DEVICES:= \
+    radxa_e52c \
     radxa_rock-5b-plus \
     radxa_rock-5t
 endef

--- a/package/boot/uboot-rockchip/patches/004-rockchip-rk3588-Implement-checkboard-to-print-SoC-variant.patch
+++ b/package/boot/uboot-rockchip/patches/004-rockchip-rk3588-Implement-checkboard-to-print-SoC-variant.patch
@@ -1,0 +1,113 @@
+From 1c2ffcd5e622031fa1c05335d0db839de14bf0e9 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 10 Nov 2024 00:56:16 +0000
+Subject: [PATCH] rockchip: rk3588: Implement checkboard() to print SoC variant
+
+Implement checkboard() to print current SoC model used by a board,
+e.g. one of:
+
+  SoC:   RK3582
+  SoC:   RK3588
+  SoC:   RK3588J
+  SoC:   RK3588S
+  SoC:   RK3588S2
+
+when U-Boot proper is running.
+
+  U-Boot 2025.01-rc1 (Nov 10 2024 - 00:31:29 +0000)
+
+  Model: Generic RK3588S/RK3588
+  SoC:   RK3588S2
+  DRAM:  8 GiB
+
+Information about the SoC model and variant is read from OTP.
+
+Also update rk3588s-u-boot.dtsi to include OTP in U-Boot pre-reloc phase,
+where checkboard() is called.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+Tested-by: FUKAUMI Naoki <naoki@radxa.com>
+Reviewed-by: Kever Yang <kever.yang@rock-chips.com>
+---
+ arch/arm/dts/rk3588s-u-boot.dtsi       |  4 ++
+ arch/arm/mach-rockchip/rk3588/rk3588.c | 52 ++++++++++++++++++++++++++
+ 2 files changed, 56 insertions(+)
+
+--- a/arch/arm/dts/rk3588s-u-boot.dtsi
++++ b/arch/arm/dts/rk3588s-u-boot.dtsi
+@@ -69,6 +69,10 @@
+ 	bootph-all;
+ };
+ 
++&otp {
++	bootph-some-ram;
++};
++
+ &pcfg_pull_down {
+ 	bootph-all;
+ };
+--- a/arch/arm/mach-rockchip/rk3588/rk3588.c
++++ b/arch/arm/mach-rockchip/rk3588/rk3588.c
+@@ -4,6 +4,10 @@
+  * Copyright (c) 2022 Edgeble AI Technologies Pvt. Ltd.
+  */
+ 
++#define LOG_CATEGORY LOGC_ARCH
++
++#include <dm.h>
++#include <misc.h>
+ #include <spl.h>
+ #include <asm/armv8/mmu.h>
+ #include <asm/arch-rockchip/bootrom.h>
+@@ -178,3 +182,51 @@ int arch_cpu_init(void)
+ 	return 0;
+ }
+ #endif
++
++#define RK3588_OTP_CPU_CODE_OFFSET		0x02
++#define RK3588_OTP_SPECIFICATION_OFFSET		0x06
++
++int checkboard(void)
++{
++	u8 cpu_code[2], specification, package;
++	struct udevice *dev;
++	char suffix[3];
++	int ret;
++
++	if (!IS_ENABLED(CONFIG_ROCKCHIP_OTP) || !CONFIG_IS_ENABLED(MISC))
++		return 0;
++
++	ret = uclass_get_device_by_driver(UCLASS_MISC,
++					  DM_DRIVER_GET(rockchip_otp), &dev);
++	if (ret) {
++		log_debug("Could not find otp device, ret=%d\n", ret);
++		return 0;
++	}
++
++	/* cpu-code: SoC model, e.g. 0x35 0x82 or 0x35 0x88 */
++	ret = misc_read(dev, RK3588_OTP_CPU_CODE_OFFSET, cpu_code, 2);
++	if (ret < 0) {
++		log_debug("Could not read cpu-code, ret=%d\n", ret);
++		return 0;
++	}
++
++	/* specification: SoC variant, e.g. 0xA for RK3588J and 0x13 for RK3588S */
++	ret = misc_read(dev, RK3588_OTP_SPECIFICATION_OFFSET, &specification, 1);
++	if (ret < 0) {
++		log_debug("Could not read specification, ret=%d\n", ret);
++		return 0;
++	}
++	/* package: likely SoC variant revision, 0x2 for RK3588S2 */
++	package = specification >> 5;
++	specification &= 0x1f;
++
++	/* for RK3588J i.e. '@' + 0xA = 'J' */
++	suffix[0] = specification > 1 ? '@' + specification : '\0';
++	/* for RK3588S2 i.e. '0' + 0x2 = '2' */
++	suffix[1] = package > 1 ? '0' + package : '\0';
++	suffix[2] = '\0';
++
++	printf("SoC:   RK%02x%02x%s\n", cpu_code[0], cpu_code[1], suffix);
++
++	return 0;
++}

--- a/package/boot/uboot-rockchip/patches/005-arm64-dts-rockchip-add-Radxa-ROCK-5C.patch
+++ b/package/boot/uboot-rockchip/patches/005-arm64-dts-rockchip-add-Radxa-ROCK-5C.patch
@@ -1,0 +1,920 @@
+From a0dd3480a7dc028b23ab640eacb652c5b0cf2b77 Mon Sep 17 00:00:00 2001
+From: FUKAUMI Naoki <naoki@radxa.com>
+Date: Sat, 4 Jan 2025 01:57:03 +0000
+Subject: [PATCH] arm64: dts: rockchip: add Radxa ROCK 5C
+
+Radxa ROCK 5C is a 8K computer for everything[1] using the Rockchip
+RK3588S2 chip:
+
+- Rockchip RK3588S2
+- Quad A76 and Quad A55 CPU
+- 6 TOPS NPU
+- up to 32GB LPDDR4x RAM
+- eMMC / SPI flash connector
+- Micro SD Card slot
+- Gigabit ethernet port (supports PoE with add-on PoE HAT)
+- WiFi6 / BT5.4
+- 1x USB 3.0 Type-A HOST port
+- 1x USB 3.0 Type-A OTG port
+- 2x USB 2.0 Type-A HOST port
+- 1x USB Type-C 5V power port
+
+[1] https://radxa.com/products/rock5/5c
+
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+Link: https://lore.kernel.org/r/20241021090548.1052-2-naoki@radxa.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+[ upstream commit: 3ddf5cdb77e6efd6fe9b70f36dec935e324a3cd2 ]
+
+(cherry picked from commit f80689fcef4b9b07a97b629b4075cc1a4c21a68e)
+Reviewed-by: Kever Yang <kever.yang@rock-chips.com>
+---
+ .../src/arm64/rockchip/rk3588s-rock-5c.dts    | 920 ++++++++++++++++++
+ 1 file changed, 920 insertions(+)
+ create mode 100644 dts/upstream/src/arm64/rockchip/rk3588s-rock-5c.dts
+
+--- /dev/null
++++ b/dts/upstream/src/arm64/rockchip/rk3588s-rock-5c.dts
+@@ -0,0 +1,881 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2024 Radxa Computer (Shenzhen) Co., Ltd.
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/soc/rockchip,vop2.h>
++#include "rk3588s.dtsi"
++
++/ {
++	model = "Radxa ROCK 5C";
++	compatible = "radxa,rock-5c", "rockchip,rk3588s";
++
++	aliases {
++		ethernet0 = &gmac1;
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc;
++	};
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	analog-sound {
++		compatible = "audio-graph-card";
++		label = "rk3588-es8316";
++		dais = <&i2s0_8ch_p0>;
++		routing = "MIC2", "Mic Jack",
++			  "Headphones", "HPOL",
++			  "Headphones", "HPOR";
++		widgets = "Microphone", "Mic Jack",
++			  "Headphone", "Headphones";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&led_pins>;
++
++		led-0 {
++			color = <LED_COLOR_ID_GREEN>;
++			default-state = "on";
++			function = LED_FUNCTION_POWER;
++			gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_HIGH>;
++		};
++
++		led-1 {
++			color = <LED_COLOR_ID_BLUE>;
++			default-state = "on";
++			function = LED_FUNCTION_HEARTBEAT;
++			gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	fan {
++		compatible = "pwm-fan";
++		#cooling-cells = <2>;
++		cooling-levels = <0 64 128 192 255>;
++		fan-supply = <&vcc_5v0>;
++		pwms = <&pwm3 0 10000 0>;
++	};
++
++	pcie2x1l2_3v3: regulator-pcie2x1l2-3v3 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pow_en>;
++		regulator-name = "pcie2x1l2_3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc5v_dcin: regulator-vcc5v-dcin {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v_dcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc5v0_usb_host: regulator-vcc5v0-usb-host {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 RK_PB5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb_host_pwren_h>;
++		regulator-name = "vcc5v0_usb_host";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc5v0_usb_otg0: regulator-vcc5v0-usb-otg0 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb_otg_pwren_h>;
++		regulator-name = "vcc5v0_usb_otg0";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc_1v1_nldo_s3: regulator-vcc-1v1-nldo-s3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_1v1_nldo_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1100000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc_3v3_pmu: regulator-vcc-3v3-pmu {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_3v3_pmu";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
++	vcc_3v3_s0: regulator-vcc-3v3-s0 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_3v3_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_1v8_s0>;
++	};
++
++	vcc_5v0: regulator-vcc-5v0 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_5v0_pwren_h>;
++		regulator-name = "vcc_5v0";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc_sysin: regulator-vcc-sysin {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sysin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v_dcin>;
++	};
++
++	vcca: regulator-vcca {
++		compatible = "regulator-fixed";
++		regulator-name = "vcca";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <4000000>;
++		regulator-max-microvolt = <4000000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vdd_3v3: regulator-vdd-3v3 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb_wifi_pwr>;
++		regulator-name = "vdd_3v3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++};
++
++&combphy0_ps {
++	status = "okay";
++};
++
++&combphy2_psu {
++	status = "okay";
++};
++
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b1 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b2 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_b3 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l1 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l2 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l3 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&gmac1 {
++	phy-handle = <&rgmii_phy1>;
++	phy-mode = "rgmii-id";
++	phy-supply = <&vcc_3v3_s0>;
++	pinctrl-0 = <&gmac1_miim
++		     &gmac1_tx_bus2
++		     &gmac1_rx_bus2
++		     &gmac1_rgmii_clk
++		     &gmac1_rgmii_bus
++		     &gmac1_clkinout>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	status = "okay";
++};
++
++&hdptxphy_hdmi0 {
++	status = "okay";
++};
++
++&i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c0m2_xfer>;
++	status = "okay";
++
++	vdd_cpu_big0_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big0_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc_sysin>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_cpu_big1_s0: regulator@43 {
++		compatible = "rockchip,rk8603", "rockchip,rk8602";
++		reg = <0x43>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big1_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc_sysin>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	eeprom@50 {
++		compatible = "belling,bl24c16a", "atmel,24c16";
++		reg = <0x50>;
++		pagesize = <16>;
++		vcc-supply = <&vcc_3v3_pmu>;
++	};
++};
++
++&i2c2 {
++	status = "okay";
++
++	vdd_npu_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_npu_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <950000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc_sysin>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c5m2_xfer>;
++	status = "okay";
++
++	rtc@51 {
++		compatible = "haoyu,hym8563";
++		reg = <0x51>;
++		#clock-cells = <0>;
++		clock-output-names = "rtcic_32kout";
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&rtc_int_l>;
++	};
++};
++
++&i2c7 {
++	status = "okay";
++
++	audio-codec@11 {
++		compatible = "everest,es8316";
++		reg = <0x11>;
++		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
++		assigned-clock-rates = <12288000>;
++		clocks = <&cru I2S0_8CH_MCLKOUT>;
++		clock-names = "mclk";
++		#sound-dai-cells = <0>;
++
++		port {
++			es8316_p0_0: endpoint {
++				remote-endpoint = <&i2s0_8ch_p0_0>;
++			};
++		};
++	};
++};
++
++&i2s0_8ch {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s0_lrck
++		     &i2s0_mclk
++		     &i2s0_sclk
++		     &i2s0_sdi0
++		     &i2s0_sdo0>;
++	status = "okay";
++
++	i2s0_8ch_p0: port {
++		i2s0_8ch_p0_0: endpoint {
++			dai-format = "i2s";
++			mclk-fs = <256>;
++			remote-endpoint = <&es8316_p0_0>;
++		};
++	};
++};
++
++&mdio1 {
++	rgmii_phy1: ethernet-phy@1 {
++		compatible = "ethernet-phy-id001c.c916";
++		reg = <1>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&gmac1_rstn>;
++		reset-assert-us = <20000>;
++		reset-deassert-us = <100000>;
++		reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
++	};
++};
++
++&pcie2x1l2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie20x1_2_perstn_m0>;
++	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&pcie2x1l2_3v3>;
++	status = "okay";
++};
++
++&pinctrl {
++	leds {
++		led_pins: led-pins {
++			rockchip,pins = <3 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>,
++					<3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	mdio {
++		gmac1_rstn: gmac1-rstn {
++			rockchip,pins = <3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie {
++		pcie20x1_2_perstn_m0: pcie20x1-2-perstn-m0 {
++			rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pow_en: pow-en {
++			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	rtc {
++		rtc_int_l: rtc-int-l {
++			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb {
++		usb_host_pwren_h: usb-host-pwren-h {
++			rockchip,pins = <4 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		usb_otg_pwren_h: usb-otg-pwren-h {
++			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		usb_wifi_pwr: usb-wifi-pwr {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		vcc_5v0_pwren_h: vcc-5v0-pwren-h {
++			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&pwm3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm3m1_pins>;
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&vcca_1v8_s0>;
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	no-sdio;
++	no-sd;
++	non-removable;
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	no-sdio;
++	no-mmc;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_3v3_s3>;
++	vqmmc-supply = <&vccio_sd_s0>;
++	status = "okay";
++};
++
++&sfc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspim0_pins>;
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <104000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++	};
++};
++
++&spi2 {
++	status = "okay";
++	assigned-clocks = <&cru CLK_SPI2>;
++	assigned-clock-rates = <200000000>;
++	num-cs = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
++
++	pmic@0 {
++		compatible = "rockchip,rk806";
++		reg = <0>;
++		gpio-controller;
++		#gpio-cells = <2>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
++			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++		spi-max-frequency = <1000000>;
++		system-power-controller;
++
++		vcc1-supply = <&vcc_sysin>;
++		vcc2-supply = <&vcc_sysin>;
++		vcc3-supply = <&vcc_sysin>;
++		vcc4-supply = <&vcc_sysin>;
++		vcc5-supply = <&vcc_sysin>;
++		vcc6-supply = <&vcc_sysin>;
++		vcc7-supply = <&vcc_sysin>;
++		vcc8-supply = <&vcc_sysin>;
++		vcc9-supply = <&vcc_sysin>;
++		vcc10-supply = <&vcc_sysin>;
++		vcc11-supply = <&vcc_2v0_pldo_s3>;
++		vcc12-supply = <&vcc_sysin>;
++		vcc13-supply = <&vcc_1v1_nldo_s3>;
++		vcc14-supply = <&vcc_1v1_nldo_s3>;
++		vcca-supply = <&vcca>;
++
++		rk806_dvs1_null: dvs1-null-pins {
++			pins = "gpio_pwrctrl1";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs2_null: dvs2-null-pins {
++			pins = "gpio_pwrctrl2";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs3_null: dvs3-null-pins {
++			pins = "gpio_pwrctrl3";
++			function = "pin_fun0";
++		};
++
++		regulators {
++			vdd_gpu_s0: dcdc-reg1 {
++				regulator-name = "vdd_gpu_s0";
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-enable-ramp-delay = <400>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_lit_s0: dcdc-reg2 {
++				regulator-name = "vdd_cpu_lit_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_logic_s0: dcdc-reg3 {
++				regulator-name = "vdd_logic_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_vdenc_s0: dcdc-reg4 {
++				regulator-name = "vdd_vdenc_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_ddr_s0: dcdc-reg5 {
++				regulator-name = "vdd_ddr_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <900000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdd2_ddr_s3: dcdc-reg6 {
++				regulator-name = "vdd2_ddr_s3";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_2v0_pldo_s3: dcdc-reg7 {
++				regulator-name = "vdd_2v0_pldo_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <2000000>;
++				regulator-max-microvolt = <2000000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <2000000>;
++				};
++			};
++
++			vcc_3v3_s3: dcdc-reg8 {
++				regulator-name = "vcc_3v3_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vddq_ddr_s0: dcdc-reg9 {
++				regulator-name = "vddq_ddr_s0";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc1v8_pmu_ddr_s3: dcdc-reg10 {
++				regulator-name = "vcc1v8_pmu_ddr_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc_1v8_s0: pldo-reg1 {
++				regulator-name = "vcc_1v8_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcca_1v8_s0: pldo-reg2 {
++				regulator-name = "vcca_1v8_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdda_1v2_s0: pldo-reg3 {
++				regulator-name = "vdda_1v2_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcca_3v3_s0: pldo-reg4 {
++				regulator-name = "vcca_3v3_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vccio_sd_s0: pldo-reg5 {
++				regulator-name = "vccio_sd_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			pldo6_s3: pldo-reg6 {
++				regulator-name = "pldo6_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_0v75_s3: nldo-reg1 {
++				regulator-name = "vdd_0v75_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdda_ddr_pll_s0: nldo-reg2 {
++				regulator-name = "vdda_ddr_pll_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdda_0v75_s0: nldo-reg3 {
++				regulator-name = "vdda_0v75_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdda_0v85_s0: nldo-reg4 {
++				regulator-name = "vdda_0v85_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v75_s0: nldo-reg5 {
++				regulator-name = "vdd_0v75_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++};
++
++&tsadc {
++	status = "okay";
++};
++
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	phy-supply = <&vcc5v0_usb_otg0>;
++	status = "okay";
++};
++
++&u2phy2 {
++	status = "okay";
++};
++
++&u2phy2_host {
++	/* connected to USB hub, which is powered by vcc_5v0 */
++	phy-supply = <&vcc_5v0>;
++	status = "okay";
++};
++
++&u2phy3 {
++	status = "okay";
++};
++
++&u2phy3_host {
++	phy-supply = <&vcc5v0_usb_host>;
++	status = "okay";
++};
++
++&uart2 {
++	pinctrl-0 = <&uart2m0_xfer>;
++	status = "okay";
++};
++
++&usbdp_phy0 {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_xhci {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usb_host2_xhci {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};

--- a/package/boot/uboot-rockchip/patches/006-rockchip-Add-support-for-Radxa-ROCK-5C.patch
+++ b/package/boot/uboot-rockchip/patches/006-rockchip-Add-support-for-Radxa-ROCK-5C.patch
@@ -1,0 +1,217 @@
+From e1661639d976d382fed73323b2c62874a25ab0e6 Mon Sep 17 00:00:00 2001
+From: FUKAUMI Naoki <naoki@radxa.com>
+Date: Sat, 4 Jan 2025 01:57:04 +0000
+Subject: [PATCH] rockchip: Add support for Radxa ROCK 5C
+
+Radxa ROCK 5C[1] is a Rockchip RK3588S2 based single board computer.
+
+[1] https://radxa.com/products/rock5/5c
+
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+Reviewed-by: Kever Yang <kever.yang@rock-chips.com>
+---
+ arch/arm/dts/rk3588s-rock-5c-u-boot.dtsi | 11 ++++
+ arch/arm/mach-rockchip/rk3588/Kconfig    | 21 ++++++
+ board/radxa/rock-5c-rk3588s/Kconfig      | 12 ++++
+ board/radxa/rock-5c-rk3588s/MAINTAINERS  |  7 ++
+ configs/rock-5c-rk3588s_defconfig        | 84 ++++++++++++++++++++++++
+ doc/board/rockchip/rockchip.rst          |  1 +
+ include/configs/rock-5c-rk3588s.h        | 15 +++++
+ 7 files changed, 151 insertions(+)
+ create mode 100644 arch/arm/dts/rk3588s-rock-5c-u-boot.dtsi
+ create mode 100644 board/radxa/rock-5c-rk3588s/Kconfig
+ create mode 100644 board/radxa/rock-5c-rk3588s/MAINTAINERS
+ create mode 100644 configs/rock-5c-rk3588s_defconfig
+ create mode 100644 include/configs/rock-5c-rk3588s.h
+
+--- /dev/null
++++ b/arch/arm/dts/rk3588s-rock-5c-u-boot.dtsi
+@@ -0,0 +1,11 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2024-2025 Radxa Computer (Shenzhen) Co., Ltd.
++ */
++
++#include "rk3588s-u-boot.dtsi"
++
++&sdhci {
++	cap-mmc-highspeed;
++	mmc-hs200-1_8v;
++};
+--- a/arch/arm/mach-rockchip/rk3588/Kconfig
++++ b/arch/arm/mach-rockchip/rk3588/Kconfig
+@@ -236,6 +236,26 @@ config TARGET_ROCK_5_ITX_RK3588
+ 	  Front-panel connectors for audio and case-power, -leds
+ 	  Powered by either 12V, ATX power-supply or PoE
+ 
++config TARGET_ROCK_5C_RK3588S
++	bool "Radxa ROCK 5C RK3588S2 board"
++	select BOARD_LATE_INIT
++	help
++	  Radxa ROCK 5C is a Rockchip RK3588S2 based single board computer.
++
++	  Specification:
++
++	  Quad A76 and Quad A55 CPU
++	  6 TOPS NPU
++	  up to 32GB LPDDR4x RAM
++	  eMMC / SPI flash connector
++	  Micro SD Card slot
++	  Gigabit ethernet port (supports PoE with add-on PoE HAT)
++	  WiFi6 / BT5.4
++	  1x USB 3.0 Type-A HOST port
++	  1x USB 3.0 Type-A OTG port
++	  2x USB 2.0 Type-A HOST port
++	  1x USB Type-C 5V power port
++
+ config TARGET_SIGE7_RK3588
+ 	bool "ArmSoM Sige7 RK3588 board"
+ 	select BOARD_LATE_INIT
+@@ -372,6 +392,7 @@ source "board/turing/turing-rk1-rk3588/K
+ source "board/radxa/rock5a-rk3588s/Kconfig"
+ source "board/radxa/rock5b-rk3588/Kconfig"
+ source "board/radxa/rock-5-itx-rk3588/Kconfig"
++source "board/radxa/rock-5c-rk3588s/Kconfig"
+ source "board/rockchip/evb_rk3588/Kconfig"
+ source "board/rockchip/toybrick_rk3588/Kconfig"
+ source "board/theobroma-systems/jaguar_rk3588/Kconfig"
+--- /dev/null
++++ b/board/radxa/rock-5c-rk3588s/Kconfig
+@@ -0,0 +1,12 @@
++if TARGET_ROCK_5C_RK3588S
++
++config SYS_BOARD
++	default "rock-5c-rk3588s"
++
++config SYS_VENDOR
++	default "radxa"
++
++config SYS_CONFIG_NAME
++	default "rock-5c-rk3588s"
++
++endif
+--- /dev/null
++++ b/board/radxa/rock-5c-rk3588s/MAINTAINERS
+@@ -0,0 +1,7 @@
++ROCK-5C-RK3588S
++M:	FUKAUMI Naoki <naoki@radxa.com>
++S:	Maintained
++F:	arch/arm/dts/rk3588s-rock-5c-u-boot.dtsi
++F:	board/radxa/rock-5c-rk3588s/
++F:	configs/rock-5c-rk3588s_defconfig
++F:	include/configs/rock-5c-rk3588s.h
+--- /dev/null
++++ b/configs/rock-5c-rk3588s_defconfig
+@@ -0,0 +1,84 @@
++CONFIG_ARM=y
++CONFIG_SKIP_LOWLEVEL_INIT=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_COUNTER_FREQUENCY=24000000
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_DEFAULT_DEVICE_TREE="rockchip/rk3588s-rock-5c"
++CONFIG_ROCKCHIP_RK3588=y
++CONFIG_SPL_SERIAL=y
++CONFIG_TARGET_ROCK_5C_RK3588S=y
++CONFIG_SYS_LOAD_ADDR=0xc00800
++CONFIG_DEBUG_UART_BASE=0xFEB50000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_PCI=y
++CONFIG_DEBUG_UART=y
++CONFIG_AHCI=y
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_FIT_SIGNATURE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3588s-rock-5c.dtb"
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_SPL_MAX_SIZE=0x40000
++CONFIG_SPL_PAD_TO=0x7f8000
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_ATF=y
++CONFIG_CMD_ADC=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_REGULATOR=y
++# CONFIG_SPL_DOS_PARTITION is not set
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_OF_LIVE=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_SPL_DM_SEQ_ALIAS=y
++CONFIG_SPL_REGMAP=y
++CONFIG_SPL_SYSCON=y
++CONFIG_SCSI_AHCI=y
++CONFIG_AHCI_PCI=y
++CONFIG_SPL_CLK=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_LED=y
++CONFIG_LED_GPIO=y
++CONFIG_MISC=y
++CONFIG_SUPPORT_EMMC_RPMB=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_SDMA=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_PHY_REALTEK=y
++CONFIG_DWC_ETH_QOS=y
++CONFIG_DWC_ETH_QOS_ROCKCHIP=y
++CONFIG_RTL8169=y
++CONFIG_NVME_PCI=y
++CONFIG_PCIE_DW_ROCKCHIP=y
++CONFIG_PHY_ROCKCHIP_INNO_USB2=y
++CONFIG_PHY_ROCKCHIP_NANENG_COMBOPHY=y
++CONFIG_PHY_ROCKCHIP_USBDP=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_SPL_RAM=y
++CONFIG_SCSI=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYS_NS16550_MEM32=y
++CONFIG_ROCKCHIP_SPI=y
++CONFIG_SYSRESET=y
++CONFIG_SYSRESET_PSCI=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC3=y
++CONFIG_USB_DWC3_GENERIC=y
++CONFIG_ERRNO_STR=y
+--- a/doc/board/rockchip/rockchip.rst
++++ b/doc/board/rockchip/rockchip.rst
+@@ -138,6 +138,7 @@ List of mainline supported Rockchip boar
+      - Radxa ROCK 5 ITX (rock-5-itx-rk3588)
+      - Radxa ROCK 5A (rock5a-rk3588s)
+      - Radxa ROCK 5B (rock5b-rk3588)
++     - Radxa ROCK 5C (rock-5c-rk3588s)
+      - Rockchip Toybrick TB-RK3588X (toybrick-rk3588)
+      - Theobroma Systems RK3588-SBC Jaguar (jaguar-rk3588)
+      - Theobroma Systems SOM-RK3588-Q7 - Tiger (tiger-rk3588)
+--- /dev/null
++++ b/include/configs/rock-5c-rk3588s.h
+@@ -0,0 +1,15 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (c) 2024-2025 Radxa Computer (Shenzhen) Co., Ltd.
++ */
++
++#ifndef __ROCK_5C_RK3588S_H
++#define __ROCK_5C_RK3588S_H
++
++#define ROCKCHIP_DEVICE_SETTINGS \
++		"stdout=serial,vidconsole\0" \
++		"stderr=serial,vidconsole\0"
++
++#include <configs/rk3588_common.h>
++
++#endif /* __ROCK_5C_RK3588S_H */

--- a/package/boot/uboot-rockchip/patches/110-rockchip-Add-initial-RK3582-support.patch
+++ b/package/boot/uboot-rockchip/patches/110-rockchip-Add-initial-RK3582-support.patch
@@ -1,0 +1,245 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 10 Aug 2025 22:26:29 +0000
+Subject: rockchip: Add initial RK3582 support
+
+The RK3582 SoC is a variant of the RK3588S with some IP blocks disabled.
+What blocks are disabled/non-working is indicated by ip-state in OTP.
+
+This add initial support for RK3582 by using ft_system_setup() to mark
+any cpu and/or vdec/venc node with status=fail as indicated by ip-state.
+
+This apply same policy as vendor U-Boot for RK3582, i.e. two big cpu
+cores and one vdec/venc core is always failed/disabled.
+
+Enable Kconfig option OF_SYSTEM_SETUP in board defconfig to make use of
+the required DT fixups for RK3582 board variants.
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+
+--- a/arch/arm/mach-rockchip/rk3588/rk3588.c
++++ b/arch/arm/mach-rockchip/rk3588/rk3588.c
+@@ -7,6 +7,7 @@
+ #define LOG_CATEGORY LOGC_ARCH
+ 
+ #include <dm.h>
++#include <fdt_support.h>
+ #include <misc.h>
+ #include <spl.h>
+ #include <asm/armv8/mmu.h>
+@@ -185,6 +186,15 @@ int arch_cpu_init(void)
+ 
+ #define RK3588_OTP_CPU_CODE_OFFSET		0x02
+ #define RK3588_OTP_SPECIFICATION_OFFSET		0x06
++#define RK3588_OTP_IP_STATE_OFFSET		0x1d
++
++#define FAIL_CPU_CLUSTER0		GENMASK(3, 0)
++#define FAIL_CPU_CLUSTER1		GENMASK(5, 4)
++#define FAIL_CPU_CLUSTER2		GENMASK(7, 6)
++#define FAIL_RKVDEC0			BIT(6)
++#define FAIL_RKVDEC1			BIT(7)
++#define FAIL_RKVENC0			BIT(0)
++#define FAIL_RKVENC1			BIT(2)
+ 
+ int checkboard(void)
+ {
+@@ -230,3 +240,199 @@ int checkboard(void)
+ 
+ 	return 0;
+ }
++
++static int fdt_path_del_node(void *fdt, const char *path)
++{
++	int nodeoffset;
++
++	nodeoffset = fdt_path_offset(fdt, path);
++	if (nodeoffset < 0)
++		return nodeoffset;
++
++	return fdt_del_node(fdt, nodeoffset);
++}
++
++static int fdt_path_set_name(void *fdt, const char *path, const char *name)
++{
++	int nodeoffset;
++
++	nodeoffset = fdt_path_offset(fdt, path);
++	if (nodeoffset < 0)
++		return nodeoffset;
++
++	return fdt_set_name(fdt, nodeoffset, name);
++}
++
++/*
++ * RK3582 is a variant of the RK3588S with some IP blocks disabled. What blocks
++ * are disabled/non-working is indicated by ip-state in OTP. ft_system_setup()
++ * is used to mark any cpu and/or vdec/venc node with status=fail as indicated
++ * by ip-state. Apply same policy as vendor U-Boot for RK3582, i.e. two big cpu
++ * cores and one vdec/venc core is always failed. Enable OF_SYSTEM_SETUP to make
++ * use of the required DT fixups for RK3582 board variants.
++ */
++int ft_system_setup(void *blob, struct bd_info *bd)
++{
++	static const char * const cpu_node_names[] = {
++		"cpu@0", "cpu@100", "cpu@200", "cpu@300",
++		"cpu@400", "cpu@500", "cpu@600", "cpu@700",
++	};
++	int parent, node, i, comp_len, len, ret;
++	bool cluster1_removed = false;
++	u8 cpu_code[2], ip_state[3];
++	struct udevice *dev;
++	char soc_comp[16];
++	const char *comp;
++	void *data;
++
++	if (!IS_ENABLED(CONFIG_OF_SYSTEM_SETUP))
++		return 0;
++
++	if (!IS_ENABLED(CONFIG_ROCKCHIP_OTP) || !CONFIG_IS_ENABLED(MISC))
++		return -ENOSYS;
++
++	ret = uclass_get_device_by_driver(UCLASS_MISC,
++					  DM_DRIVER_GET(rockchip_otp), &dev);
++	if (ret) {
++		log_debug("Could not find otp device, ret=%d\n", ret);
++		return ret;
++	}
++
++	/* cpu-code: SoC model, e.g. 0x35 0x82 or 0x35 0x88 */
++	ret = misc_read(dev, RK3588_OTP_CPU_CODE_OFFSET, cpu_code, 2);
++	if (ret < 0) {
++		log_debug("Could not read cpu-code, ret=%d\n", ret);
++		return ret;
++	}
++
++	log_debug("cpu-code: %02x %02x\n", cpu_code[0], cpu_code[1]);
++
++	/* only fail cores on rk3582/rk3583 */
++	if (!(cpu_code[0] == 0x35 && cpu_code[1] == 0x82) &&
++	    !(cpu_code[0] == 0x35 && cpu_code[1] == 0x83))
++		return 0;
++
++	ret = misc_read(dev, RK3588_OTP_IP_STATE_OFFSET, &ip_state, 3);
++	if (ret < 0) {
++		log_err("Could not read ip-state, ret=%d\n", ret);
++		return ret;
++	}
++
++	log_debug("ip-state: %02x %02x %02x (otp)\n",
++		  ip_state[0], ip_state[1], ip_state[2]);
++
++	/* policy: fail entire big core cluster when one or more core is bad */
++	if (ip_state[0] & FAIL_CPU_CLUSTER1)
++		ip_state[0] |= FAIL_CPU_CLUSTER1;
++	if (ip_state[0] & FAIL_CPU_CLUSTER2)
++		ip_state[0] |= FAIL_CPU_CLUSTER2;
++
++	/* policy: always fail one big core cluster on rk3582/rk3583 */
++	if (!(ip_state[0] & (FAIL_CPU_CLUSTER1 | FAIL_CPU_CLUSTER2)))
++		ip_state[0] |= FAIL_CPU_CLUSTER2;
++
++	/* policy: always fail one rkvdec core on rk3582/rk3583 */
++	if (!(ip_state[1] & (FAIL_RKVDEC0 | FAIL_RKVDEC1)))
++		ip_state[1] |= FAIL_RKVDEC1;
++
++	/* policy: always fail one rkvenc core on rk3582/rk3583 */
++	if (!(ip_state[2] & (FAIL_RKVENC0 | FAIL_RKVENC1)))
++		ip_state[2] |= FAIL_RKVENC1;
++
++	log_debug("ip-state: %02x %02x %02x (policy)\n",
++		  ip_state[0], ip_state[1], ip_state[2]);
++
++	/* cpu cluster1: ip_state[0]: bit4~5 */
++	if ((ip_state[0] & FAIL_CPU_CLUSTER1) == FAIL_CPU_CLUSTER1) {
++		log_debug("remove cpu-map cluster1\n");
++		fdt_path_del_node(blob, "/cpus/cpu-map/cluster1");
++		cluster1_removed = true;
++	}
++
++	/* cpu cluster2: ip_state[0]: bit6~7 */
++	if ((ip_state[0] & FAIL_CPU_CLUSTER2) == FAIL_CPU_CLUSTER2) {
++		log_debug("remove cpu-map cluster2\n");
++		fdt_path_del_node(blob, "/cpus/cpu-map/cluster2");
++	} else if (cluster1_removed) {
++		/* cluster nodes must be named in a continuous series */
++		log_debug("rename cpu-map cluster2\n");
++		fdt_path_set_name(blob, "/cpus/cpu-map/cluster2", "cluster1");
++	}
++
++	/* rkvdec: ip_state[1]: bit6,7 */
++	if (ip_state[1] & FAIL_RKVDEC0) {
++		log_debug("fail rkvdec0\n");
++		fdt_status_fail_by_pathf(blob, "/video-codec@fdc38100");
++		fdt_status_fail_by_pathf(blob, "/iommu@fdc38700");
++	}
++	if (ip_state[1] & FAIL_RKVDEC1) {
++		log_debug("fail rkvdec1\n");
++		fdt_status_fail_by_pathf(blob, "/video-codec@fdc40100");
++		fdt_status_fail_by_pathf(blob, "/iommu@fdc40700");
++	}
++
++	/* rkvenc: ip_state[2]: bit0,2 */
++	if (ip_state[2] & FAIL_RKVENC0) {
++		log_debug("fail rkvenc0\n");
++		fdt_status_fail_by_pathf(blob, "/video-codec@fdbd0000");
++		fdt_status_fail_by_pathf(blob, "/iommu@fdbdf000");
++	}
++	if (ip_state[2] & FAIL_RKVENC1) {
++		log_debug("fail rkvenc1\n");
++		fdt_status_fail_by_pathf(blob, "/video-codec@fdbe0000");
++		fdt_status_fail_by_pathf(blob, "/iommu@fdbef000");
++	}
++
++	parent = fdt_path_offset(blob, "/cpus");
++	if (parent < 0) {
++		log_err("Could not find /cpus, parent=%d\n", parent);
++		return parent;
++	}
++
++	/* cpu: ip_state[0]: bit0~7 */
++	for (i = 0; i < 8; i++) {
++		/* fail any bad cpu core */
++		if (!(ip_state[0] & BIT(i)))
++			continue;
++
++		node = fdt_subnode_offset(blob, parent, cpu_node_names[i]);
++		if (node >= 0) {
++			log_debug("fail cpu %s\n", cpu_node_names[i]);
++			fdt_status_fail(blob, node);
++		} else {
++			log_err("Could not find %s, node=%d\n",
++				cpu_node_names[i], node);
++			return node;
++		}
++	}
++
++	node = fdt_path_offset(blob, "/");
++	if (node < 0) {
++		log_err("Could not find /, node=%d\n", node);
++		return node;
++	}
++
++	snprintf(soc_comp, sizeof(soc_comp), "rockchip,rk35%x", cpu_code[1]);
++
++	for (i = 0, comp_len = 0;
++	     (comp = fdt_stringlist_get(blob, node, "compatible", i, &len));
++	     i++) {
++		/* stop at soc compatible */
++		if (!strcmp(comp, soc_comp) ||
++		    !strcmp(comp, "rockchip,rk3588s") ||
++		    !strcmp(comp, "rockchip,rk3588"))
++			break;
++
++		log_debug("compatible[%d]: %s\n", i, comp);
++		comp_len += len + 1;
++	}
++
++	/* truncate to only include board compatible */
++	fdt_setprop_placeholder(blob, node, "compatible", comp_len, &data);
++
++	/* append soc compatible */
++	fdt_appendprop_string(blob, node, "compatible", soc_comp);
++	fdt_appendprop_string(blob, node, "compatible", "rockchip,rk3588s");
++
++	return 0;
++}

--- a/package/boot/uboot-rockchip/patches/111-rockchip-rk3588-generic-Enable-support-for-RK3582.patch
+++ b/package/boot/uboot-rockchip/patches/111-rockchip-rk3588-generic-Enable-support-for-RK3582.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 10 Aug 2025 22:26:30 +0000
+Subject: rockchip: rk3588-generic: Enable support for RK3582
+
+Add Kconfig option OF_SYSTEM_SETUP=y to support booting boards with a
+RK3582 SoC. CPU and GPU cores are failed based on ip-state and policy.
+
+Tested on a ROCK 5C Lite v1.1:
+
+  cpu-code: 35 82
+  ip-state: 10 00 00 (otp)
+  ip-state: 30 80 04 (policy)
+  remove cpu-map cluster1
+  rename cpu-map cluster2
+  fail rkvdec1
+  fail rkvenc1
+  fail cpu cpu@400
+  fail cpu cpu@500
+
+and on a Radxa E52C:
+
+  cpu-code: 35 82
+  ip-state: 00 04 00 (otp)
+  ip-state: c0 84 04 (policy)
+  remove cpu-map cluster2
+  fail rkvdec1
+  fail rkvenc1
+  fail cpu cpu@600
+  fail cpu cpu@700
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+
+--- a/arch/arm/dts/rk3588-generic.dts
++++ b/arch/arm/dts/rk3588-generic.dts
+@@ -1,13 +1,13 @@
+ // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+ /*
+- * Minimal generic DT for RK3588S/RK3588 with eMMC, SD-card and USB OTG enabled
++ * Minimal generic DT for RK3582/RK3588S/RK3588 with eMMC, SD-card and USB OTG enabled
+  */
+ 
+ /dts-v1/;
+ #include "rk3588s.dtsi"
+ 
+ / {
+-	model = "Generic RK3588S/RK3588";
++	model = "Generic RK3582/RK3588S/RK3588";
+ 	compatible = "rockchip,rk3588";
+ 
+ 	aliases {
+--- a/configs/generic-rk3588_defconfig
++++ b/configs/generic-rk3588_defconfig
+@@ -16,6 +16,7 @@ CONFIG_SPL_FIT_SIGNATURE=y
+ CONFIG_SPL_LOAD_FIT=y
+ # CONFIG_BOOTMETH_VBE is not set
+ CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_DEFAULT_FDT_FILE="rockchip/rk3588-generic.dtb"
+ # CONFIG_DISPLAY_CPUINFO is not set
+ CONFIG_DISPLAY_BOARDINFO_LATE=y
+--- a/doc/board/rockchip/rockchip.rst
++++ b/doc/board/rockchip/rockchip.rst
+@@ -132,7 +132,7 @@ List of mainline supported Rockchip boar
+      - FriendlyElec NanoPC-T6 (nanopc-t6-rk3588)
+      - FriendlyElec NanoPi R6C (nanopi-r6c-rk3588s)
+      - FriendlyElec NanoPi R6S (nanopi-r6s-rk3588s)
+-     - Generic RK3588S/RK3588 (generic-rk3588)
++     - Generic RK3582/RK3588S/RK3588 (generic-rk3588)
+      - Indiedroid Nova (nova-rk3588s)
+      - Pine64 QuartzPro64 (quartzpro64-rk3588)
+      - Radxa ROCK 5 ITX (rock-5-itx-rk3588)

--- a/package/boot/uboot-rockchip/patches/112-rockchip-rk3588s-rock-5c-Add-support-for-ROCK-5C-Lit.patch
+++ b/package/boot/uboot-rockchip/patches/112-rockchip-rk3588s-rock-5c-Add-support-for-ROCK-5C-Lit.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jonas Karlman <jonas@kwiboo.se>
+Date: Sun, 10 Aug 2025 22:26:31 +0000
+Subject: rockchip: rk3588s-rock-5c: Add support for ROCK 5C Lite variant
+
+Add Kconfig option OF_SYSTEM_SETUP=y to support booting ROCK 5C Lite
+boards with a RK3582 SoC. CPU and GPU cores are failed based on ip-state
+and policy.
+
+Tested on a ROCK 5C Lite v1.1:
+
+  cpu-code: 35 82
+  ip-state: 00 80 00 (otp)
+  ip-state: c0 80 04 (policy)
+  remove cpu-map cluster2
+  fail rkvdec1
+  fail rkvenc1
+  fail cpu cpu@600
+  fail cpu cpu@700
+
+Signed-off-by: Jonas Karlman <jonas@kwiboo.se>
+
+--- a/configs/rock-5c-rk3588s_defconfig
++++ b/configs/rock-5c-rk3588s_defconfig
+@@ -18,6 +18,7 @@ CONFIG_FIT_VERBOSE=y
+ CONFIG_SPL_FIT_SIGNATURE=y
+ CONFIG_SPL_LOAD_FIT=y
+ CONFIG_LEGACY_IMAGE_FORMAT=y
++CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_DEFAULT_FDT_FILE="rockchip/rk3588s-rock-5c.dtb"
+ # CONFIG_DISPLAY_CPUINFO is not set
+ CONFIG_SPL_MAX_SIZE=0x40000

--- a/target/linux/generic/backport-6.6/801-01-v6.13-dt-bindings-clocks-add-binding-for-gated-fixed-clock.patch
+++ b/target/linux/generic/backport-6.6/801-01-v6.13-dt-bindings-clocks-add-binding-for-gated-fixed-clock.patch
@@ -1,0 +1,82 @@
+From a4a7cbe36623ffaabbae413c0eacf40d033db71f Mon Sep 17 00:00:00 2001
+From: Heiko Stuebner <heiko@sntech.de>
+Date: Fri, 6 Sep 2024 10:25:07 +0200
+Subject: dt-bindings: clocks: add binding for gated-fixed-clocks
+
+In contrast to fixed clocks that are described as ungateable, boards
+sometimes use additional oscillators for things like PCIe reference
+clocks, that need actual supplies to get enabled and enable-gpios to be
+toggled for them to work.
+
+This adds a binding for such oscillators that are not configurable
+themself, but need to handle supplies for them to work.
+
+In schematics they often can be seen as
+
+         ----------------
+Enable - | 100MHz,3.3V, | - VDD
+         |    3225      |
+   GND - |              | - OUT
+         ----------------
+
+or similar. The enable pin might be separate but can also just be tied
+to the vdd supply, hence it is optional in the binding.
+
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+Reviewed-by: Rob Herring (Arm) <robh@kernel.org>
+Reviewed-by: Conor Dooley <conor.dooley@microchip.com>
+Link: https://lore.kernel.org/r/20240906082511.2963890-2-heiko@sntech.de
+Signed-off-by: Stephen Boyd <sboyd@kernel.org>
+
+--- /dev/null
++++ b/Documentation/devicetree/bindings/clock/gated-fixed-clock.yaml
+@@ -0,0 +1,49 @@
++# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++%YAML 1.2
++---
++$id: http://devicetree.org/schemas/clock/gated-fixed-clock.yaml#
++$schema: http://devicetree.org/meta-schemas/core.yaml#
++
++title: Gated Fixed clock
++
++maintainers:
++  - Heiko Stuebner <heiko@sntech.de>
++
++properties:
++  compatible:
++    const: gated-fixed-clock
++
++  "#clock-cells":
++    const: 0
++
++  clock-frequency: true
++
++  clock-output-names:
++    maxItems: 1
++
++  enable-gpios:
++    description:
++      Contains a single GPIO specifier for the GPIO that enables and disables
++      the oscillator.
++    maxItems: 1
++
++  vdd-supply:
++    description: handle of the regulator that provides the supply voltage
++
++required:
++  - compatible
++  - "#clock-cells"
++  - clock-frequency
++  - vdd-supply
++
++additionalProperties: false
++
++examples:
++  - |
++    clock-1000000000 {
++      compatible = "gated-fixed-clock";
++      #clock-cells = <0>;
++      clock-frequency = <1000000000>;
++      vdd-supply = <&reg_vdd>;
++    };
++...

--- a/target/linux/generic/backport-6.6/801-02-v6.13-clk-clk-gpio-update-documentation-for-gpio-gate-cloc.patch
+++ b/target/linux/generic/backport-6.6/801-02-v6.13-clk-clk-gpio-update-documentation-for-gpio-gate-cloc.patch
@@ -1,0 +1,27 @@
+From 6cb137c7e99f8307f1f0fcccb1896f2d3b0651d3 Mon Sep 17 00:00:00 2001
+From: Heiko Stuebner <heiko@sntech.de>
+Date: Fri, 6 Sep 2024 10:25:08 +0200
+Subject: clk: clk-gpio: update documentation for gpio-gate clock
+
+The main documentation block seems to be from a time before the driver
+handled sleeping and non-sleeping gpios and with that change it seems
+updating the doc was overlooked. So do that now.
+
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+Link: https://lore.kernel.org/r/20240906082511.2963890-3-heiko@sntech.de
+Signed-off-by: Stephen Boyd <sboyd@kernel.org>
+
+--- a/drivers/clk/clk-gpio.c
++++ b/drivers/clk/clk-gpio.c
+@@ -22,8 +22,9 @@
+  * DOC: basic gpio gated clock which can be enabled and disabled
+  *      with gpio output
+  * Traits of this clock:
+- * prepare - clk_(un)prepare only ensures parent is (un)prepared
+- * enable - clk_enable and clk_disable are functional & control gpio
++ * prepare - clk_(un)prepare are functional and control a gpio that can sleep
++ * enable - clk_enable and clk_disable are functional & control
++ *          non-sleeping gpio
+  * rate - inherits rate from parent.  No clk_set_rate support
+  * parent - fixed parent.  No clk_set_parent support
+  */

--- a/target/linux/generic/backport-6.6/801-03-v6.13-clk-clk-gpio-use-dev_err_probe-for-gpio-get-failure.patch
+++ b/target/linux/generic/backport-6.6/801-03-v6.13-clk-clk-gpio-use-dev_err_probe-for-gpio-get-failure.patch
@@ -1,0 +1,44 @@
+From 36abe81d9c3fa200a57ef2363e93a2991e387e19 Mon Sep 17 00:00:00 2001
+From: Heiko Stuebner <heiko@sntech.de>
+Date: Fri, 6 Sep 2024 10:25:09 +0200
+Subject: clk: clk-gpio: use dev_err_probe for gpio-get failure
+
+This is a real driver and dev_err_probe will hide the distinction between
+EPROBE_DEFER and other errors automatically, so there is no need to
+open-code this.
+
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+Link: https://lore.kernel.org/r/20240906082511.2963890-4-heiko@sntech.de
+Signed-off-by: Stephen Boyd <sboyd@kernel.org>
+
+--- a/drivers/clk/clk-gpio.c
++++ b/drivers/clk/clk-gpio.c
+@@ -200,7 +200,6 @@ static int gpio_clk_driver_probe(struct
+ 	struct gpio_desc *gpiod;
+ 	struct clk_hw *hw;
+ 	bool is_mux;
+-	int ret;
+ 
+ 	is_mux = of_device_is_compatible(node, "gpio-mux-clock");
+ 
+@@ -212,17 +211,9 @@ static int gpio_clk_driver_probe(struct
+ 
+ 	gpio_name = is_mux ? "select" : "enable";
+ 	gpiod = devm_gpiod_get(dev, gpio_name, GPIOD_OUT_LOW);
+-	if (IS_ERR(gpiod)) {
+-		ret = PTR_ERR(gpiod);
+-		if (ret == -EPROBE_DEFER)
+-			pr_debug("%pOFn: %s: GPIOs not yet available, retry later\n",
+-					node, __func__);
+-		else
+-			pr_err("%pOFn: %s: Can't get '%s' named GPIO property\n",
+-					node, __func__,
+-					gpio_name);
+-		return ret;
+-	}
++	if (IS_ERR(gpiod))
++		return dev_err_probe(dev, PTR_ERR(gpiod),
++				     "Can't get '%s' named GPIO property\n", gpio_name);
+ 
+ 	if (is_mux)
+ 		hw = clk_hw_register_gpio_mux(dev, gpiod);

--- a/target/linux/generic/backport-6.6/801-04-v6.13-clk-clk-gpio-add-driver-for-gated-fixed-clocks.patch
+++ b/target/linux/generic/backport-6.6/801-04-v6.13-clk-clk-gpio-add-driver-for-gated-fixed-clocks.patch
@@ -1,0 +1,229 @@
+From 4940071d962827467f7297be3b874c96186ca0b7 Mon Sep 17 00:00:00 2001
+From: Heiko Stuebner <heiko@sntech.de>
+Date: Fri, 6 Sep 2024 10:25:10 +0200
+Subject: clk: clk-gpio: add driver for gated-fixed-clocks
+
+In contrast to fixed clocks that are described as ungateable, boards
+sometimes use additional oscillators for things like PCIe reference
+clocks, that need actual supplies to get enabled and enable-gpios to be
+toggled for them to work.
+
+This adds a driver for those generic gated-fixed-clocks
+that can show up in schematics looking like
+
+         ----------------
+Enable - | 100MHz,3.3V, | - VDD
+         |    3225      |
+   GND - |              | - OUT
+         ----------------
+
+The new driver gets grouped together with the existing gpio-gate and
+gpio-mux, as it for one re-uses a lot of the gpio-gate functions
+and also in its core it's just another gpio-controlled clock, just
+with a fixed rate and a regulator-supply added in.
+
+The regulator-API provides function stubs for the !CONFIG_REGULATOR case,
+so no special handling is necessary.
+
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+Link: https://lore.kernel.org/r/20240906082511.2963890-5-heiko@sntech.de
+Signed-off-by: Stephen Boyd <sboyd@kernel.org>
+
+--- a/drivers/clk/clk-gpio.c
++++ b/drivers/clk/clk-gpio.c
+@@ -17,6 +17,7 @@
+ #include <linux/device.h>
+ #include <linux/of.h>
+ #include <linux/platform_device.h>
++#include <linux/regulator/consumer.h>
+ 
+ /**
+  * DOC: basic gpio gated clock which can be enabled and disabled
+@@ -239,3 +240,187 @@ static struct platform_driver gpio_clk_d
+ 	},
+ };
+ builtin_platform_driver(gpio_clk_driver);
++
++/**
++ * DOC: gated fixed clock, controlled with a gpio output and a regulator
++ * Traits of this clock:
++ * prepare - clk_prepare and clk_unprepare are function & control regulator
++ *           optionally a gpio that can sleep
++ * enable - clk_enable and clk_disable are functional & control gpio
++ * rate - rate is fixed and set on clock registration
++ * parent - fixed clock is a root clock and has no parent
++ */
++
++/**
++ * struct clk_gated_fixed - Gateable fixed rate clock
++ * @clk_gpio:	instance of clk_gpio for gate-gpio
++ * @supply:	supply regulator
++ * @rate:	fixed rate
++ */
++struct clk_gated_fixed {
++	struct clk_gpio clk_gpio;
++	struct regulator *supply;
++	unsigned long rate;
++};
++
++#define to_clk_gated_fixed(_clk_gpio) container_of(_clk_gpio, struct clk_gated_fixed, clk_gpio)
++
++static unsigned long clk_gated_fixed_recalc_rate(struct clk_hw *hw,
++						 unsigned long parent_rate)
++{
++	return to_clk_gated_fixed(to_clk_gpio(hw))->rate;
++}
++
++static int clk_gated_fixed_prepare(struct clk_hw *hw)
++{
++	struct clk_gated_fixed *clk = to_clk_gated_fixed(to_clk_gpio(hw));
++
++	if (!clk->supply)
++		return 0;
++
++	return regulator_enable(clk->supply);
++}
++
++static void clk_gated_fixed_unprepare(struct clk_hw *hw)
++{
++	struct clk_gated_fixed *clk = to_clk_gated_fixed(to_clk_gpio(hw));
++
++	if (!clk->supply)
++		return;
++
++	regulator_disable(clk->supply);
++}
++
++static int clk_gated_fixed_is_prepared(struct clk_hw *hw)
++{
++	struct clk_gated_fixed *clk = to_clk_gated_fixed(to_clk_gpio(hw));
++
++	if (!clk->supply)
++		return true;
++
++	return regulator_is_enabled(clk->supply);
++}
++
++/*
++ * Fixed gated clock with non-sleeping gpio.
++ *
++ * Prepare operation turns on the supply regulator
++ * and the enable operation switches the enable-gpio.
++ */
++static const struct clk_ops clk_gated_fixed_ops = {
++	.prepare = clk_gated_fixed_prepare,
++	.unprepare = clk_gated_fixed_unprepare,
++	.is_prepared = clk_gated_fixed_is_prepared,
++	.enable = clk_gpio_gate_enable,
++	.disable = clk_gpio_gate_disable,
++	.is_enabled = clk_gpio_gate_is_enabled,
++	.recalc_rate = clk_gated_fixed_recalc_rate,
++};
++
++static int clk_sleeping_gated_fixed_prepare(struct clk_hw *hw)
++{
++	int ret;
++
++	ret = clk_gated_fixed_prepare(hw);
++	if (ret)
++		return ret;
++
++	ret = clk_sleeping_gpio_gate_prepare(hw);
++	if (ret)
++		clk_gated_fixed_unprepare(hw);
++
++	return ret;
++}
++
++static void clk_sleeping_gated_fixed_unprepare(struct clk_hw *hw)
++{
++	clk_gated_fixed_unprepare(hw);
++	clk_sleeping_gpio_gate_unprepare(hw);
++}
++
++/*
++ * Fixed gated clock with non-sleeping gpio.
++ *
++ * Enabling the supply regulator and switching the enable-gpio happens
++ * both in the prepare step.
++ * is_prepared only needs to check the gpio state, as toggling the
++ * gpio is the last step when preparing.
++ */
++static const struct clk_ops clk_sleeping_gated_fixed_ops = {
++	.prepare = clk_sleeping_gated_fixed_prepare,
++	.unprepare = clk_sleeping_gated_fixed_unprepare,
++	.is_prepared = clk_sleeping_gpio_gate_is_prepared,
++	.recalc_rate = clk_gated_fixed_recalc_rate,
++};
++
++static int clk_gated_fixed_probe(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct clk_gated_fixed *clk;
++	const struct clk_ops *ops;
++	const char *clk_name;
++	u32 rate;
++	int ret;
++
++	clk = devm_kzalloc(dev, sizeof(*clk), GFP_KERNEL);
++	if (!clk)
++		return -ENOMEM;
++
++	ret = device_property_read_u32(dev, "clock-frequency", &rate);
++	if (ret)
++		return dev_err_probe(dev, ret, "Failed to get clock-frequency\n");
++	clk->rate = rate;
++
++	ret = device_property_read_string(dev, "clock-output-names", &clk_name);
++	if (ret)
++		clk_name = fwnode_get_name(dev->fwnode);
++
++	clk->supply = devm_regulator_get_optional(dev, "vdd");
++	if (IS_ERR(clk->supply)) {
++		if (PTR_ERR(clk->supply) != -ENODEV)
++			return dev_err_probe(dev, PTR_ERR(clk->supply),
++					     "Failed to get regulator\n");
++		clk->supply = NULL;
++	}
++
++	clk->clk_gpio.gpiod = devm_gpiod_get_optional(dev, "enable",
++						      GPIOD_OUT_LOW);
++	if (IS_ERR(clk->clk_gpio.gpiod))
++		return dev_err_probe(dev, PTR_ERR(clk->clk_gpio.gpiod),
++				     "Failed to get gpio\n");
++
++	if (gpiod_cansleep(clk->clk_gpio.gpiod))
++		ops = &clk_sleeping_gated_fixed_ops;
++	else
++		ops = &clk_gated_fixed_ops;
++
++	clk->clk_gpio.hw.init = CLK_HW_INIT_NO_PARENT(clk_name, ops, 0);
++
++	/* register the clock */
++	ret = devm_clk_hw_register(dev, &clk->clk_gpio.hw);
++	if (ret)
++		return dev_err_probe(dev, ret,
++				     "Failed to register clock\n");
++
++	ret = devm_of_clk_add_hw_provider(dev, of_clk_hw_simple_get,
++					  &clk->clk_gpio.hw);
++	if (ret)
++		return dev_err_probe(dev, ret,
++				     "Failed to register clock provider\n");
++
++	return 0;
++}
++
++static const struct of_device_id gated_fixed_clk_match_table[] = {
++	{ .compatible = "gated-fixed-clock" },
++	{ /* sentinel */ }
++};
++
++static struct platform_driver gated_fixed_clk_driver = {
++	.probe		= clk_gated_fixed_probe,
++	.driver		= {
++		.name	= "gated-fixed-clk",
++		.of_match_table = gated_fixed_clk_match_table,
++	},
++};
++builtin_platform_driver(gated_fixed_clk_driver);

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
@@ -15,6 +15,7 @@ friendlyarm,nanopi-r3s|\
 friendlyarm,nanopi-r4s|\
 friendlyarm,nanopi-r4s-enterprise|\
 friendlyarm,nanopi-r6c|\
+radxa,e52c|\
 xunlong,orangepi-r1-plus|\
 xunlong,orangepi-r1-plus-lts)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
@@ -15,7 +15,6 @@ friendlyarm,nanopi-r3s|\
 friendlyarm,nanopi-r4s|\
 friendlyarm,nanopi-r4s-enterprise|\
 friendlyarm,nanopi-r6c|\
-radxa,e52c|\
 xunlong,orangepi-r1-plus|\
 xunlong,orangepi-r1-plus-lts)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
@@ -35,6 +34,10 @@ friendlyarm,nanopi-r6s)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_netdev "lan1" "LAN1" "green:lan-1" "eth2"
 	ucidef_set_led_netdev "lan2" "LAN2" "green:lan-2" "eth0"
+	;;
+radxa,e52c)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "lan"
 	;;
 esac
 

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -15,6 +15,7 @@ rockchip_setup_interfaces()
 	friendlyarm,nanopi-r4s|\
 	friendlyarm,nanopi-r4s-enterprise|\
 	friendlyarm,nanopi-r6c|\
+	radxa,e52c|\
 	radxa,rockpi-e|\
 	xunlong,orangepi-r1-plus|\
 	xunlong,orangepi-r1-plus-lts)

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -24,7 +24,8 @@ rockchip_setup_interfaces()
 	friendlyarm,nanopi-r5c|\
 	lunzn,fastrhino-r66s|\
 	radxa,e25|\
-	radxa,rock-3b)
+	radxa,rock-3b|\
+	radxa,rock-5t)
 		ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
 		;;
 	friendlyarm,nanopi-r5s)

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -25,6 +25,7 @@ rockchip_setup_interfaces()
 	lunzn,fastrhino-r66s|\
 	radxa,e25|\
 	radxa,rock-3b|\
+	radxa,rock-5-itx|\
 	radxa,rock-5t)
 		ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
 		;;

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -15,7 +15,6 @@ rockchip_setup_interfaces()
 	friendlyarm,nanopi-r4s|\
 	friendlyarm,nanopi-r4s-enterprise|\
 	friendlyarm,nanopi-r6c|\
-	radxa,e52c|\
 	radxa,rockpi-e|\
 	xunlong,orangepi-r1-plus|\
 	xunlong,orangepi-r1-plus-lts)
@@ -25,9 +24,7 @@ rockchip_setup_interfaces()
 	friendlyarm,nanopi-r5c|\
 	lunzn,fastrhino-r66s|\
 	radxa,e25|\
-	radxa,rock-3b|\
-	radxa,rock-5-itx|\
-	radxa,rock-5t)
+	radxa,rock-3b)
 		ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
 		;;
 	friendlyarm,nanopi-r5s)
@@ -40,6 +37,21 @@ rockchip_setup_interfaces()
 		ucidef_set_network_device_path eth2 'platform/3c0400000.pcie/pci0001:10/0001:10:00.0/0001:11:00.0'
 		ucidef_set_network_device_path eth3 'platform/3c0000000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0'
 		ucidef_set_interfaces_lan_wan 'eth1 eth2 eth3' 'eth0'
+		;;
+	radxa,e52c)
+		ucidef_set_network_device_path 'wan' 'platform/a40c00000.pcie/pci0003:30/0003:30:00.0/0003:31:00.0'
+		ucidef_set_network_device_path 'lan' 'platform/a41000000.pcie/pci0004:40/0004:40:00.0/0004:41:00.0'
+		ucidef_set_interfaces_lan_wan 'lan' 'wan'
+		;;
+	radxa,rock-5-itx)
+		ucidef_set_network_device_path 'eth0' 'platform/a40c00000.pcie/pci0003:30/0003:30:00.0/0003:31:00.0'
+		ucidef_set_network_device_path 'eth1' 'platform/a41000000.pcie/pci0004:40/0004:40:00.0/0004:41:00.0'
+		ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
+		;;
+	radxa,rock-5t)
+		ucidef_set_network_device_path 'eth1' 'platform/a40c00000.pcie/pci0003:30/0003:30:00.0/0003:31:00.0'
+		ucidef_set_network_device_path 'eth0' 'platform/a41000000.pcie/pci0004:40/0004:40:00.0/0004:41:00.0'
+		ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
 		;;
 	sinovoip,rk3568-bpi-r2pro)
 		ucidef_set_interfaces_lan_wan 'lan0 lan1 lan2 lan3' 'eth0'

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/05_compat-version
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/05_compat-version
@@ -1,0 +1,15 @@
+. /lib/functions.sh
+. /lib/functions/uci-defaults.sh
+
+board="$(board_name)"
+board_config_update
+
+case "$board" in
+radxa,e52c)
+	ucidef_set_compat_version "1.1"
+	;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -52,6 +52,7 @@ friendlyarm,nanopi-r4s|\
 friendlyarm,nanopi-r4s-enterprise|\
 friendlyarm,nanopi-r6c|\
 friendlyarm,nanopc-t6|\
+radxa,e52c|\
 radxa,rock-5-itx|\
 radxa,rock-5t)
 	set_interface_core 10 "eth0"

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -52,6 +52,7 @@ friendlyarm,nanopi-r4s|\
 friendlyarm,nanopi-r4s-enterprise|\
 friendlyarm,nanopi-r6c|\
 friendlyarm,nanopc-t6|\
+radxa,rock-5-itx|\
 radxa,rock-5t)
 	set_interface_core 10 "eth0"
 	set_interface_core 20 "eth1"

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -52,7 +52,6 @@ friendlyarm,nanopi-r4s|\
 friendlyarm,nanopi-r4s-enterprise|\
 friendlyarm,nanopi-r6c|\
 friendlyarm,nanopc-t6|\
-radxa,e52c|\
 radxa,rock-5-itx|\
 radxa,rock-5t)
 	set_interface_core 10 "eth0"
@@ -72,6 +71,10 @@ radxa,rock-5a|\
 radxa,rock-5c)
 	set_interface_core 10 "eth1"
 	set_interface_core 20 "eth2"
+	;;
+radxa,e52c)
+	set_interface_core 10 "lan"
+	set_interface_core 20 "wan"
 	;;
 esac
 

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -65,5 +65,9 @@ friendlyarm,nanopi-r6s)
 	set_interface_core 20 "eth1"
 	set_interface_core 40 "eth2"
 	;;
+radxa,rock-5a)
+	set_interface_core 10 "eth1"
+	set_interface_core 20 "eth2"
+	;;
 esac
 

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -67,7 +67,8 @@ friendlyarm,nanopi-r6s)
 	set_interface_core 20 "eth1"
 	set_interface_core 40 "eth2"
 	;;
-radxa,rock-5a)
+radxa,rock-5a|\
+radxa,rock-5c)
 	set_interface_core 10 "eth1"
 	set_interface_core 20 "eth2"
 	;;

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -51,7 +51,8 @@ xunlong,orangepi-r1-plus-lts)
 friendlyarm,nanopi-r4s|\
 friendlyarm,nanopi-r4s-enterprise|\
 friendlyarm,nanopi-r6c|\
-friendlyarm,nanopc-t6)
+friendlyarm,nanopc-t6|\
+radxa,rock-5t)
 	set_interface_core 10 "eth0"
 	set_interface_core 20 "eth1"
 	;;

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -174,6 +174,16 @@ define Device/radxa_e25
 endef
 TARGET_DEVICES += radxa_e25
 
+define Device/radxa_e52c
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := E52C
+  SOC := rk3582
+  UBOOT_DEVICE_NAME := generic-rk3588
+  DEVICE_DTS := rockchip/rk3582-radxa-e52c
+  DEVICE_PACKAGES := blkdiscard kmod-r8169
+endef
+TARGET_DEVICES += radxa_e52c
+
 define Device/radxa_rock-3a
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK 3A

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -181,6 +181,8 @@ define Device/radxa_e52c
   UBOOT_DEVICE_NAME := generic-rk3588
   DEVICE_DTS := rockchip/rk3582-radxa-e52c
   DEVICE_PACKAGES := blkdiscard kmod-r8169
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Network interface names have been changed
 endef
 TARGET_DEVICES += radxa_e52c
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -213,6 +213,14 @@ define Device/radxa_rock-4se
 endef
 TARGET_DEVICES += radxa_rock-4se
 
+define Device/radxa_rock-5-itx
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := ROCK 5 ITX/ITX+
+  SOC := rk3588
+  DEVICE_PACKAGES := blkdiscard block-mount kmod-ata-ahci kmod-hwmon-pwmfan kmod-nvme kmod-r8169 kmod-rtw89-8852be wpad-basic-mbedtls
+endef
+TARGET_DEVICES += radxa_rock-5-itx
+
 define Device/radxa_rock-5a
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK 5A

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -249,6 +249,14 @@ define Device/radxa_rock-5b-plus
 endef
 TARGET_DEVICES += radxa_rock-5b-plus
 
+define Device/radxa_rock-5c
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := ROCK 5C/5C Lite
+  SOC := rk3588s
+  DEVICE_PACKAGES := blkdiscard block-mount kmod-ata-ahci kmod-hwmon-pwmfan kmod-nvme kmod-r8169
+endef
+TARGET_DEVICES += radxa_rock-5c
+
 define Device/radxa_rock-5t
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK 5T

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -231,6 +231,16 @@ define Device/radxa_rock-5b
 endef
 TARGET_DEVICES += radxa_rock-5b
 
+define Device/radxa_rock-5b-plus
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := ROCK 5B+
+  SOC := rk3588
+  UBOOT_DEVICE_NAME := generic-rk3588
+  DEVICE_DTS := rockchip/rk3588-rock-5b-plus
+  DEVICE_PACKAGES := blkdiscard block-mount kmod-hwmon-pwmfan kmod-nvme kmod-r8169 kmod-rtw89-8852be wpad-basic-mbedtls
+endef
+TARGET_DEVICES += radxa_rock-5b-plus
+
 define Device/radxa_rock-pi-4a
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK Pi 4A

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -218,7 +218,7 @@ define Device/radxa_rock-5a
   DEVICE_MODEL := ROCK 5A
   SOC := rk3588s
   UBOOT_DEVICE_NAME := rock5a-rk3588s
-  DEVICE_PACKAGES := kmod-hwmon-pwmfan
+  DEVICE_PACKAGES := blkdiscard block-mount kmod-ata-ahci kmod-hwmon-pwmfan kmod-nvme kmod-r8169 kmod-rtw89-8852be wpad-basic-mbedtls
 endef
 TARGET_DEVICES += radxa_rock-5a
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -227,7 +227,7 @@ define Device/radxa_rock-5b
   DEVICE_MODEL := ROCK 5B
   SOC := rk3588
   UBOOT_DEVICE_NAME := rock5b-rk3588
-  DEVICE_PACKAGES := kmod-r8169 kmod-hwmon-pwmfan
+  DEVICE_PACKAGES := blkdiscard block-mount kmod-hwmon-pwmfan kmod-nvme kmod-r8169 kmod-rtw89-8852be wpad-basic-mbedtls
 endef
 TARGET_DEVICES += radxa_rock-5b
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -241,6 +241,16 @@ define Device/radxa_rock-5b-plus
 endef
 TARGET_DEVICES += radxa_rock-5b-plus
 
+define Device/radxa_rock-5t
+  DEVICE_VENDOR := Radxa
+  DEVICE_MODEL := ROCK 5T
+  SOC := rk3588
+  UBOOT_DEVICE_NAME := generic-rk3588
+  DEVICE_DTS := rockchip/rk3588-rock-5t
+  DEVICE_PACKAGES := blkdiscard block-mount iwlwifi-firmware-ax210 kmod-hwmon-pwmfan kmod-iwlwifi kmod-nvme kmod-r8169 wpad-basic-mbedtls
+endef
+TARGET_DEVICES += radxa_rock-5t
+
 define Device/radxa_rock-pi-4a
   DEVICE_VENDOR := Radxa
   DEVICE_MODEL := ROCK Pi 4A

--- a/target/linux/rockchip/patches-6.6/030-24-v6.8-dt-bindings-rockchip-vop2-Add-more-endpoint-definition.patch
+++ b/target/linux/rockchip/patches-6.6/030-24-v6.8-dt-bindings-rockchip-vop2-Add-more-endpoint-definition.patch
@@ -1,0 +1,28 @@
+From dc7226acacc6502291446f9e33cf96246ec49a30 Mon Sep 17 00:00:00 2001
+From: Andy Yan <andy.yan@rock-chips.com>
+Date: Mon, 11 Dec 2023 19:59:07 +0800
+Subject: [PATCH] dt-bindings: rockchip,vop2: Add more endpoint definition
+
+There are 2 HDMI, 2 DP, 2 eDP on rk3588, so add
+corresponding endpoint definition for it.
+
+Signed-off-by: Andy Yan <andy.yan@rock-chips.com>
+Acked-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+Link: https://patchwork.freedesktop.org/patch/msgid/20231211115907.1785377-1-andyshrk@163.com
+---
+ include/dt-bindings/soc/rockchip,vop2.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/include/dt-bindings/soc/rockchip,vop2.h
++++ b/include/dt-bindings/soc/rockchip,vop2.h
+@@ -10,5 +10,9 @@
+ #define ROCKCHIP_VOP2_EP_LVDS0	5
+ #define ROCKCHIP_VOP2_EP_MIPI1	6
+ #define ROCKCHIP_VOP2_EP_LVDS1	7
++#define ROCKCHIP_VOP2_EP_HDMI1	8
++#define ROCKCHIP_VOP2_EP_EDP1	9
++#define ROCKCHIP_VOP2_EP_DP0	10
++#define ROCKCHIP_VOP2_EP_DP1	11
+ 
+ #endif /* __DT_BINDINGS_ROCKCHIP_VOP2_H */

--- a/target/linux/rockchip/patches-6.6/050-28-v6.12-arm64-dts-rockchip-rk3588s-fix-sdio-pins-to-pull-up.patch
+++ b/target/linux/rockchip/patches-6.6/050-28-v6.12-arm64-dts-rockchip-rk3588s-fix-sdio-pins-to-pull-up.patch
@@ -1,0 +1,39 @@
+From bd60cae2932cd123d867bf93bdadc4bf545fcdce Mon Sep 17 00:00:00 2001
+From: Alex Zhao <zzc@rock-chips.com>
+Date: Thu, 29 Aug 2024 15:45:15 -0500
+Subject: [PATCH] arm64: dts: rockchip: rk3588s fix sdio pins to pull up
+
+The sdio requires the cmd and data pins to pull up by soc.
+
+Signed-off-by: Alex Zhao <zzc@rock-chips.com>
+[adapted to pinctrl filename change]
+Signed-off-by: Chris Morgan <macromorgan@hotmail.com>
+Link: https://lore.kernel.org/r/20240829204517.398669-2-macroalpha82@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-base-pinctrl.dtsi | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base-pinctrl.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base-pinctrl.dtsi
+@@ -2449,15 +2449,15 @@
+ 				/* sdio_clk_m1 */
+ 				<3 RK_PA5 2 &pcfg_pull_none>,
+ 				/* sdio_cmd_m1 */
+-				<3 RK_PA4 2 &pcfg_pull_none>,
++				<3 RK_PA4 2 &pcfg_pull_up>,
+ 				/* sdio_d0_m1 */
+-				<3 RK_PA0 2 &pcfg_pull_none>,
++				<3 RK_PA0 2 &pcfg_pull_up>,
+ 				/* sdio_d1_m1 */
+-				<3 RK_PA1 2 &pcfg_pull_none>,
++				<3 RK_PA1 2 &pcfg_pull_up>,
+ 				/* sdio_d2_m1 */
+-				<3 RK_PA2 2 &pcfg_pull_none>,
++				<3 RK_PA2 2 &pcfg_pull_up>,
+ 				/* sdio_d3_m1 */
+-				<3 RK_PA3 2 &pcfg_pull_none>;
++				<3 RK_PA3 2 &pcfg_pull_up>;
+ 		};
+ 	};
+ 

--- a/target/linux/rockchip/patches-6.6/050-29-v6.12-arm64-dts-rockchip-Move-L3-cache-outside-CPUs-in-RK3588-S.patch
+++ b/target/linux/rockchip/patches-6.6/050-29-v6.12-arm64-dts-rockchip-Move-L3-cache-outside-CPUs-in-RK3588-S.patch
@@ -1,0 +1,57 @@
+From df5f6f2f62b9b50cef78f32909485b00fc7cf7f2 Mon Sep 17 00:00:00 2001
+From: Dragan Simic <dsimic@manjaro.org>
+Date: Thu, 26 Sep 2024 12:29:13 +0200
+Subject: [PATCH] arm64: dts: rockchip: Move L3 cache outside CPUs in RK3588(S)
+ SoC dtsi
+
+Move the "l3_cache" node outside the "cpus" node in the base dtsi file for
+Rockchip RK3588(S) SoCs.  The A55 and A76 CPU cores in these SoCs belong to
+the ARM DynamIQ IP core lineup, which places the L3 cache outside the CPUs
+and into the DynamIQ Shared Unit (DSU). [1]  Thus, moving the L3 cache DT
+node one level higher in the DT improves the way the physical topology of
+the RK3588(S) SoCs is represented in the SoC dtsi files.
+
+While there, add a comment that explains it briefly, to save curious readers
+from the need to reference the repository log for a clarification.
+
+[1] ARM DynamIQ Shared Unit revision r4p0 TRM, version 0400-02
+
+Fixes: c9211fa2602b ("arm64: dts: rockchip: Add base DT for rk3588 SoC")
+Helped-by: Robin Murphy <robin.murphy@arm.com>
+Signed-off-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/84264d0713fb51ae2b9b731e28fc14681beea853.1727345965.git.dsimic@manjaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-base.dtsi | 20 +++++++++++--------
+ 1 file changed, 12 insertions(+), 8 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -337,15 +337,19 @@
+ 			cache-unified;
+ 			next-level-cache = <&l3_cache>;
+ 		};
++	};
+ 
+-		l3_cache: l3-cache {
+-			compatible = "cache";
+-			cache-size = <3145728>;
+-			cache-line-size = <64>;
+-			cache-sets = <4096>;
+-			cache-level = <3>;
+-			cache-unified;
+-		};
++	/*
++	 * The L3 cache belongs to the DynamIQ Shared Unit (DSU),
++	 * so it's represented here, outside the "cpus" node
++	 */
++	l3_cache: l3-cache {
++		compatible = "cache";
++		cache-size = <3145728>;
++		cache-line-size = <64>;
++		cache-sets = <4096>;
++		cache-level = <3>;
++		cache-unified;
+ 	};
+ 
+ 	display_subsystem: display-subsystem {

--- a/target/linux/rockchip/patches-6.6/050-30-v6.13-arm64-dts-rockchip-Add-HDMI0-node-to-rk3588.patch
+++ b/target/linux/rockchip/patches-6.6/050-30-v6.13-arm64-dts-rockchip-Add-HDMI0-node-to-rk3588.patch
@@ -1,0 +1,61 @@
+From d7bb71e69f58c1b3665a9f926bf8d3855111bf8e Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Sat, 19 Oct 2024 13:12:10 +0300
+Subject: arm64: dts: rockchip: Add HDMI0 node to rk3588
+
+Add support for the HDMI0 output port found on RK3588 SoC.
+
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Link: https://lore.kernel.org/r/20241019-rk3588-hdmi0-dt-v2-1-466cd80e8ff9@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -1258,6 +1258,47 @@
+ 		status = "disabled";
+ 	};
+ 
++	hdmi0: hdmi@fde80000 {
++		compatible = "rockchip,rk3588-dw-hdmi-qp";
++		reg = <0x0 0xfde80000 0x0 0x20000>;
++		clocks = <&cru PCLK_HDMITX0>,
++			 <&cru CLK_HDMITX0_EARC>,
++			 <&cru CLK_HDMITX0_REF>,
++			 <&cru MCLK_I2S5_8CH_TX>,
++			 <&cru CLK_HDMIHDP0>,
++			 <&cru HCLK_VO1>;
++		clock-names = "pclk", "earc", "ref", "aud", "hdp", "hclk_vo1";
++		interrupts = <GIC_SPI 169 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 170 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 171 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 172 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 360 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupt-names = "avp", "cec", "earc", "main", "hpd";
++		phys = <&hdptxphy_hdmi0>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&hdmim0_tx0_cec &hdmim0_tx0_hpd
++			     &hdmim0_tx0_scl &hdmim0_tx0_sda>;
++		power-domains = <&power RK3588_PD_VO1>;
++		resets = <&cru SRST_HDMITX0_REF>, <&cru SRST_HDMIHDP0>;
++		reset-names = "ref", "hdp";
++		rockchip,grf = <&sys_grf>;
++		rockchip,vo-grf = <&vo1_grf>;
++		status = "disabled";
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			hdmi0_in: port@0 {
++				reg = <0>;
++			};
++
++			hdmi0_out: port@1 {
++				reg = <1>;
++			};
++		};
++	};
++
+ 	qos_gpu_m0: qos@fdf35000 {
+ 		compatible = "rockchip,rk3588-qos", "syscon";
+ 		reg = <0x0 0xfdf35000 0x0 0x20>;

--- a/target/linux/rockchip/patches-6.6/050-31-v6.14-arm64-dts-rockchip-Fix-broken-tsadc-pinctrl-names-for.patch
+++ b/target/linux/rockchip/patches-6.6/050-31-v6.14-arm64-dts-rockchip-Fix-broken-tsadc-pinctrl-names-for.patch
@@ -1,0 +1,39 @@
+From 5c8f9a05336cf5cadbd57ad461621b386aadb762 Mon Sep 17 00:00:00 2001
+From: Alexander Shiyan <eagle.alexander923@gmail.com>
+Date: Thu, 30 Jan 2025 08:38:49 +0300
+Subject: [PATCH] arm64: dts: rockchip: Fix broken tsadc pinctrl names for
+ rk3588
+
+The tsadc driver does not handle pinctrl "gpio" and "otpout".
+Let's use the correct pinctrl names "default" and "sleep".
+Additionally, Alexey Charkov's testing [1] has established that
+it is necessary for pinctrl state to reference the &tsadc_shut_org
+configuration rather than &tsadc_shut for the driver to function correctly.
+
+[1] https://lkml.org/lkml/2025/1/24/966
+
+Fixes: 32641b8ab1a5 ("arm64: dts: rockchip: add rk3588 thermal sensor")
+Cc: stable@vger.kernel.org
+Reviewed-by: Dragan Simic <dsimic@manjaro.org>
+Signed-off-by: Alexander Shiyan <eagle.alexander923@gmail.com>
+Link: https://lore.kernel.org/r/20250130053849.4902-1-eagle.alexander923@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-base.dtsi | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -2555,9 +2555,9 @@
+ 		rockchip,hw-tshut-temp = <120000>;
+ 		rockchip,hw-tshut-mode = <0>; /* tshut mode 0:CRU 1:GPIO */
+ 		rockchip,hw-tshut-polarity = <0>; /* tshut polarity 0:LOW 1:HIGH */
+-		pinctrl-0 = <&tsadc_gpio_func>;
+-		pinctrl-1 = <&tsadc_shut>;
+-		pinctrl-names = "gpio", "otpout";
++		pinctrl-0 = <&tsadc_shut_org>;
++		pinctrl-1 = <&tsadc_gpio_func>;
++		pinctrl-names = "default", "sleep";
+ 		#thermal-sensor-cells = <1>;
+ 		status = "disabled";
+ 	};

--- a/target/linux/rockchip/patches-6.6/050-32-v6.14-arm64-dts-rockchip-adjust-SMMU-interrupt-type-on-rk3588.patch
+++ b/target/linux/rockchip/patches-6.6/050-32-v6.14-arm64-dts-rockchip-adjust-SMMU-interrupt-type-on-rk3588.patch
@@ -1,0 +1,52 @@
+From 8546cfd08aa4b982acd2357403a1f15495d622ec Mon Sep 17 00:00:00 2001
+From: Patrick Wildt <patrick@blueri.se>
+Date: Mon, 10 Feb 2025 22:37:29 +0100
+Subject: [PATCH] arm64: dts: rockchip: adjust SMMU interrupt type on rk3588
+
+The SMMU architecture requires wired interrupts to be edge triggered,
+which does not align with the DT description for the RK3588.  This leads
+to interrupt storms, as the SMMU continues to hold the pin high and only
+pulls it down for a short amount when issuing an IRQ.  Update the DT
+description to be in line with the spec and perceived reality.
+
+Signed-off-by: Patrick Wildt <patrick@blueri.se>
+Fixes: cd81d3a0695c ("arm64: dts: rockchip: add rk3588 pcie and php IOMMUs")
+Reviewed-by: Niklas Cassel <cassel@kernel.org>
+Link: https://lore.kernel.org/r/Z6pxme2Chmf3d3uK@windev.fritz.box
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-base.dtsi | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -549,10 +549,10 @@
+ 	mmu600_pcie: iommu@fc900000 {
+ 		compatible = "arm,smmu-v3";
+ 		reg = <0x0 0xfc900000 0x0 0x200000>;
+-		interrupts = <GIC_SPI 369 IRQ_TYPE_LEVEL_HIGH 0>,
+-			     <GIC_SPI 371 IRQ_TYPE_LEVEL_HIGH 0>,
+-			     <GIC_SPI 374 IRQ_TYPE_LEVEL_HIGH 0>,
+-			     <GIC_SPI 367 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupts = <GIC_SPI 369 IRQ_TYPE_EDGE_RISING 0>,
++			     <GIC_SPI 371 IRQ_TYPE_EDGE_RISING 0>,
++			     <GIC_SPI 374 IRQ_TYPE_EDGE_RISING 0>,
++			     <GIC_SPI 367 IRQ_TYPE_EDGE_RISING 0>;
+ 		interrupt-names = "eventq", "gerror", "priq", "cmdq-sync";
+ 		#iommu-cells = <1>;
+ 		status = "disabled";
+@@ -561,10 +561,10 @@
+ 	mmu600_php: iommu@fcb00000 {
+ 		compatible = "arm,smmu-v3";
+ 		reg = <0x0 0xfcb00000 0x0 0x200000>;
+-		interrupts = <GIC_SPI 381 IRQ_TYPE_LEVEL_HIGH 0>,
+-			     <GIC_SPI 383 IRQ_TYPE_LEVEL_HIGH 0>,
+-			     <GIC_SPI 386 IRQ_TYPE_LEVEL_HIGH 0>,
+-			     <GIC_SPI 379 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupts = <GIC_SPI 381 IRQ_TYPE_EDGE_RISING 0>,
++			     <GIC_SPI 383 IRQ_TYPE_EDGE_RISING 0>,
++			     <GIC_SPI 386 IRQ_TYPE_EDGE_RISING 0>,
++			     <GIC_SPI 379 IRQ_TYPE_EDGE_RISING 0>;
+ 		interrupt-names = "eventq", "gerror", "priq", "cmdq-sync";
+ 		#iommu-cells = <1>;
+ 		status = "disabled";

--- a/target/linux/rockchip/patches-6.6/050-33-v6.15-arm64-dts-rockchip-Use-dma-noncoherent-in-base-RK358.patch
+++ b/target/linux/rockchip/patches-6.6/050-33-v6.15-arm64-dts-rockchip-Use-dma-noncoherent-in-base-RK358.patch
@@ -1,0 +1,51 @@
+From 33b561eb66f1e271f2899e103c857d20425076f4 Mon Sep 17 00:00:00 2001
+From: Dragan Simic <dsimic@manjaro.org>
+Date: Wed, 8 Jan 2025 05:26:45 +0100
+Subject: arm64: dts: rockchip: Use "dma-noncoherent" in base RK3588 SoC dtsi
+
+The preferred way to denote hardware with non-coherent DMA is to use the
+"dma-noncoherent" DT property, at both the GIC redistributor and the GIC ITS
+levels, [1] instead of relying on the compatibles to handle hardware errata,
+in this case the Rockchip 3588001 errata. [2]
+
+Let's have the preferred way employed in the base Rockchip RK3588 SoC dtsi,
+which also goes along with adding initial support for the Rockchip RK3582 SoC
+variant, with its separate compatible. [2][3]
+
+[1] Documentation/devicetree/bindings/interrupt-controller/arm,gic-v3.yaml
+[2] https://lore.kernel.org/linux-rockchip/86msgoozqa.wl-maz@kernel.org/
+[3] https://lore.kernel.org/linux-rockchip/20241222030355.2246-4-naoki@radxa.com/
+
+Cc: Marc Zyngier <maz@kernel.org>
+Cc: FUKAUMI Naoki <naoki@radxa.com>
+Acked-by: Marc Zyngier <maz@kernel.org>
+Signed-off-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/fa1a672dae3644bb3caa58f03216d0ca349db88b.1736279094.git.dsimic@manjaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -1909,6 +1909,7 @@
+ 		      <0x0 0xfe680000 0 0x100000>; /* GICR */
+ 		interrupts = <GIC_PPI 9 IRQ_TYPE_LEVEL_HIGH 0>;
+ 		interrupt-controller;
++		dma-noncoherent;
+ 		mbi-alias = <0x0 0xfe610000>;
+ 		mbi-ranges = <424 56>;
+ 		msi-controller;
+@@ -1920,6 +1921,7 @@
+ 		its0: msi-controller@fe640000 {
+ 			compatible = "arm,gic-v3-its";
+ 			reg = <0x0 0xfe640000 0x0 0x20000>;
++			dma-noncoherent;
+ 			msi-controller;
+ 			#msi-cells = <1>;
+ 		};
+@@ -1927,6 +1929,7 @@
+ 		its1: msi-controller@fe660000 {
+ 			compatible = "arm,gic-v3-its";
+ 			reg = <0x0 0xfe660000 0x0 0x20000>;
++			dma-noncoherent;
+ 			msi-controller;
+ 			#msi-cells = <1>;
+ 		};

--- a/target/linux/rockchip/patches-6.6/050-34-v6.15-arm64-dts-rockchip-Enable-HDMI0-PHY-clk-provider-on-.patch
+++ b/target/linux/rockchip/patches-6.6/050-34-v6.15-arm64-dts-rockchip-Enable-HDMI0-PHY-clk-provider-on-.patch
@@ -1,0 +1,28 @@
+From d0f17738778c12be629ba77ff00c43c3e9eb8428 Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Tue, 4 Feb 2025 14:40:07 +0200
+Subject: arm64: dts: rockchip: Enable HDMI0 PHY clk provider on RK3588
+
+Since commit c4b09c562086 ("phy: phy-rockchip-samsung-hdptx: Add clock
+provider support"), the HDMI PHY PLL can be used as an alternative and
+more accurate pixel clock source for VOP2 to improve display modes
+handling on RK3588 SoC.
+
+Add the missing #clock-cells property to allow using the clock provider
+functionality of HDMI0 PHY.
+
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Tested-by: FUKAUMI Naoki <naoki@radxa.com>
+Link: https://lore.kernel.org/r/20250204-vop2-hdmi0-disp-modes-v3-4-d71c6a196e58@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -2702,6 +2702,7 @@
+ 		reg = <0x0 0xfed60000 0x0 0x2000>;
+ 		clocks = <&cru CLK_USB2PHY_HDPTXRXPHY_REF>, <&cru PCLK_HDPTX0>;
+ 		clock-names = "ref", "apb";
++		#clock-cells = <0>;
+ 		#phy-cells = <0>;
+ 		resets = <&cru SRST_HDPTX0>, <&cru SRST_P_HDPTX0>,
+ 			 <&cru SRST_HDPTX0_INIT>, <&cru SRST_HDPTX0_CMN>,

--- a/target/linux/rockchip/patches-6.6/050-35-v6.15-arm64-dts-rockchip-Add-HDMI0-PHY-PLL-clock-source-to.patch
+++ b/target/linux/rockchip/patches-6.6/050-35-v6.15-arm64-dts-rockchip-Add-HDMI0-PHY-PLL-clock-source-to.patch
@@ -1,0 +1,38 @@
+From eb4262203d7d85eb7b6f2696816db272e41f5464 Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Tue, 4 Feb 2025 14:40:08 +0200
+Subject: arm64: dts: rockchip: Add HDMI0 PHY PLL clock source to VOP2 on
+ RK3588
+
+VOP2 on RK3588 is able to use the HDMI PHY PLL as an alternative and
+more accurate pixel clock source to improve handling of display modes up
+to 4K@60Hz on video ports 0, 1 and 2.
+
+For now only HDMI0 output is supported, hence add the related PLL clock.
+
+Tested-by: FUKAUMI Naoki <naoki@radxa.com>
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Link: https://lore.kernel.org/r/20250204-vop2-hdmi0-disp-modes-v3-5-d71c6a196e58@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -1150,14 +1150,16 @@
+ 			 <&cru DCLK_VOP1>,
+ 			 <&cru DCLK_VOP2>,
+ 			 <&cru DCLK_VOP3>,
+-			 <&cru PCLK_VOP_ROOT>;
++			 <&cru PCLK_VOP_ROOT>,
++			 <&hdptxphy_hdmi0>;
+ 		clock-names = "aclk",
+ 			      "hclk",
+ 			      "dclk_vp0",
+ 			      "dclk_vp1",
+ 			      "dclk_vp2",
+ 			      "dclk_vp3",
+-			      "pclk_vop";
++			      "pclk_vop",
++			      "pll_hdmiphy0";
+ 		iommus = <&vop_mmu>;
+ 		power-domains = <&power RK3588_PD_VOP>;
+ 		rockchip,grf = <&sys_grf>;

--- a/target/linux/rockchip/patches-6.6/050-36-v6.15-arm64-dts-rockchip-Add-PHY-node-for-HDMI1-TX-port-on.patch
+++ b/target/linux/rockchip/patches-6.6/050-36-v6.15-arm64-dts-rockchip-Add-PHY-node-for-HDMI1-TX-port-on.patch
@@ -1,0 +1,52 @@
+From ea97212a0f66b7bd71c23c12f781f1770dd6fcff Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Wed, 11 Dec 2024 01:06:15 +0200
+Subject: arm64: dts: rockchip: Add PHY node for HDMI1 TX port on RK3588
+
+In preparation to enable the second HDMI output port found on RK3588
+SoC, add the related PHY node.  This requires a GRF, hence add the
+dependent node as well.
+
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Tested-by: Jagan Teki <jagan@edgeble.ai> # edgeble-6tops-modules
+Tested-by: Alexandre ARNOUD <aarnoud@me.com>
+Link: https://lore.kernel.org/r/20241211-rk3588-hdmi1-v2-2-02cdca22ff68@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
+@@ -67,6 +67,11 @@
+ 		};
+ 	};
+ 
++	hdptxphy1_grf: syscon@fd5e4000 {
++		compatible = "rockchip,rk3588-hdptxphy-grf", "syscon";
++		reg = <0x0 0xfd5e4000 0x0 0x100>;
++	};
++
+ 	i2s8_8ch: i2s@fddc8000 {
+ 		compatible = "rockchip,rk3588-i2s-tdm";
+ 		reg = <0x0 0xfddc8000 0x0 0x1000>;
+@@ -360,6 +365,22 @@
+ 		};
+ 	};
+ 
++	hdptxphy1: phy@fed70000 {
++		compatible = "rockchip,rk3588-hdptx-phy";
++		reg = <0x0 0xfed70000 0x0 0x2000>;
++		clocks = <&cru CLK_USB2PHY_HDPTXRXPHY_REF>, <&cru PCLK_HDPTX1>;
++		clock-names = "ref", "apb";
++		#phy-cells = <0>;
++		resets = <&cru SRST_HDPTX1>, <&cru SRST_P_HDPTX1>,
++			 <&cru SRST_HDPTX1_INIT>, <&cru SRST_HDPTX1_CMN>,
++			 <&cru SRST_HDPTX1_LANE>, <&cru SRST_HDPTX1_ROPLL>,
++			 <&cru SRST_HDPTX1_LCPLL>;
++		reset-names = "phy", "apb", "init", "cmn", "lane", "ropll",
++			      "lcpll";
++		rockchip,grf = <&hdptxphy1_grf>;
++		status = "disabled";
++	};
++
+ 	usbdp_phy1: phy@fed90000 {
+ 		compatible = "rockchip,rk3588-usbdp-phy";
+ 		reg = <0x0 0xfed90000 0x0 0x10000>;

--- a/target/linux/rockchip/patches-6.6/050-37-v6.15-arm64-dts-rockchip-Fix-label-name-of-hdptxphy-for-RK.patch
+++ b/target/linux/rockchip/patches-6.6/050-37-v6.15-arm64-dts-rockchip-Fix-label-name-of-hdptxphy-for-RK.patch
@@ -1,0 +1,44 @@
+From 2efdb041019fd6c58abefba3eb6fdc4d659e576c Mon Sep 17 00:00:00 2001
+From: Damon Ding <damon.ding@rock-chips.com>
+Date: Thu, 6 Feb 2025 11:03:30 +0800
+Subject: arm64: dts: rockchip: Fix label name of hdptxphy for RK3588
+
+The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP
+and eDP Link. Therefore, it is better to name it hdptxphy0 other than
+hdptxphy_hdmi0, which will be referenced by both hdmi0 and edp0 nodes.
+
+Signed-off-by: Damon Ding <damon.ding@rock-chips.com>
+Link: https://lore.kernel.org/r/20250206030330.680424-3-damon.ding@rock-chips.com
+[added armsom-sige7, where hdmi-support was added recently and also
+ the hdptxphy0-as-dclk source I just added]
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -1151,7 +1151,7 @@
+ 			 <&cru DCLK_VOP2>,
+ 			 <&cru DCLK_VOP3>,
+ 			 <&cru PCLK_VOP_ROOT>,
+-			 <&hdptxphy_hdmi0>;
++			 <&hdptxphy0>;
+ 		clock-names = "aclk",
+ 			      "hclk",
+ 			      "dclk_vp0",
+@@ -1276,7 +1276,7 @@
+ 			     <GIC_SPI 172 IRQ_TYPE_LEVEL_HIGH 0>,
+ 			     <GIC_SPI 360 IRQ_TYPE_LEVEL_HIGH 0>;
+ 		interrupt-names = "avp", "cec", "earc", "main", "hpd";
+-		phys = <&hdptxphy_hdmi0>;
++		phys = <&hdptxphy0>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&hdmim0_tx0_cec &hdmim0_tx0_hpd
+ 			     &hdmim0_tx0_scl &hdmim0_tx0_sda>;
+@@ -2699,7 +2699,7 @@
+ 		#dma-cells = <1>;
+ 	};
+ 
+-	hdptxphy_hdmi0: phy@fed60000 {
++	hdptxphy0: phy@fed60000 {
+ 		compatible = "rockchip,rk3588-hdptx-phy";
+ 		reg = <0x0 0xfed60000 0x0 0x2000>;
+ 		clocks = <&cru CLK_USB2PHY_HDPTXRXPHY_REF>, <&cru PCLK_HDPTX0>;

--- a/target/linux/rockchip/patches-6.6/050-38-v6.15-arm64-dts-rockchip-Add-HDMI1-node-on-RK3588.patch
+++ b/target/linux/rockchip/patches-6.6/050-38-v6.15-arm64-dts-rockchip-Add-HDMI1-node-on-RK3588.patch
@@ -1,0 +1,63 @@
+From bed6964e779b5853de042da14320edf9f79506fe Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Wed, 11 Dec 2024 01:06:16 +0200
+Subject: arm64: dts: rockchip: Add HDMI1 node on RK3588
+
+Add support for the second HDMI TX port found on RK3588 SoC.
+
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Tested-by: Jagan Teki <jagan@edgeble.ai> # edgeble-6tops-modules
+Tested-by: Alexandre ARNOUD <aarnoud@me.com>
+Link: https://lore.kernel.org/r/20241211-rk3588-hdmi1-v2-3-02cdca22ff68@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
+@@ -140,6 +140,47 @@
+ 		status = "disabled";
+ 	};
+ 
++	hdmi1: hdmi@fdea0000 {
++		compatible = "rockchip,rk3588-dw-hdmi-qp";
++		reg = <0x0 0xfdea0000 0x0 0x20000>;
++		clocks = <&cru PCLK_HDMITX1>,
++			 <&cru CLK_HDMITX1_EARC>,
++			 <&cru CLK_HDMITX1_REF>,
++			 <&cru MCLK_I2S6_8CH_TX>,
++			 <&cru CLK_HDMIHDP1>,
++			 <&cru HCLK_VO1>;
++		clock-names = "pclk", "earc", "ref", "aud", "hdp", "hclk_vo1";
++		interrupts = <GIC_SPI 173 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 174 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 175 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 176 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 361 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupt-names = "avp", "cec", "earc", "main", "hpd";
++		phys = <&hdptxphy1>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&hdmim2_tx1_cec &hdmim0_tx1_hpd
++			     &hdmim1_tx1_scl &hdmim1_tx1_sda>;
++		power-domains = <&power RK3588_PD_VO1>;
++		resets = <&cru SRST_HDMITX1_REF>, <&cru SRST_HDMIHDP1>;
++		reset-names = "ref", "hdp";
++		rockchip,grf = <&sys_grf>;
++		rockchip,vo-grf = <&vo1_grf>;
++		status = "disabled";
++
++		ports {
++			#address-cells = <1>;
++			#size-cells = <0>;
++
++			hdmi1_in: port@0 {
++				reg = <0>;
++			};
++
++			hdmi1_out: port@1 {
++				reg = <1>;
++			};
++		};
++	};
++
+ 	pcie3x4: pcie@fe150000 {
+ 		compatible = "rockchip,rk3588-pcie", "rockchip,rk3568-pcie";
+ 		#address-cells = <3>;

--- a/target/linux/rockchip/patches-6.6/050-39-v6.15-arm64-dts-rockchip-Enable-HDMI1-PHY-clk-provider-on-.patch
+++ b/target/linux/rockchip/patches-6.6/050-39-v6.15-arm64-dts-rockchip-Enable-HDMI1-PHY-clk-provider-on-.patch
@@ -1,0 +1,27 @@
+From aadaa27956e3430217d9e6b8af5880e39b05b961 Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Sun, 23 Feb 2025 11:31:39 +0200
+Subject: arm64: dts: rockchip: Enable HDMI1 PHY clk provider on RK3588
+
+Since commit c4b09c562086 ("phy: phy-rockchip-samsung-hdptx: Add clock
+provider support"), the HDMI PHY PLL can be used as an alternative and
+more accurate pixel clock source for VOP2 to improve display modes
+handling on RK3588 SoC.
+
+Add the missing #clock-cells property to allow using the clock provider
+functionality of HDMI1 PHY.
+
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Link: https://lore.kernel.org/r/20250223-vop2-hdmi1-disp-modes-v2-3-f4cec5e06fbe@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
+@@ -411,6 +411,7 @@
+ 		reg = <0x0 0xfed70000 0x0 0x2000>;
+ 		clocks = <&cru CLK_USB2PHY_HDPTXRXPHY_REF>, <&cru PCLK_HDPTX1>;
+ 		clock-names = "ref", "apb";
++		#clock-cells = <0>;
+ 		#phy-cells = <0>;
+ 		resets = <&cru SRST_HDPTX1>, <&cru SRST_P_HDPTX1>,
+ 			 <&cru SRST_HDPTX1_INIT>, <&cru SRST_HDPTX1_CMN>,

--- a/target/linux/rockchip/patches-6.6/050-40-v6.15-arm64-dts-rockchip-Add-HDMI1-PHY-PLL-clock-source-to.patch
+++ b/target/linux/rockchip/patches-6.6/050-40-v6.15-arm64-dts-rockchip-Add-HDMI1-PHY-PLL-clock-source-to.patch
@@ -1,0 +1,48 @@
+From b2e668a60ed866ba960acb5310d1fb6bf81d154f Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Sun, 23 Feb 2025 11:31:40 +0200
+Subject: arm64: dts: rockchip: Add HDMI1 PHY PLL clock source to VOP2 on
+ RK3588
+
+VOP2 on RK3588 is able to use the HDMI PHY PLL as an alternative and
+more accurate pixel clock source to improve handling of display modes up
+to 4K@60Hz on video ports 0, 1 and 2.
+
+The HDMI1 PHY PLL clock source cannot be added directly to vop node in
+rk3588-base.dtsi, along with the HDMI0 related one, because HDMI1 is an
+optional feature and its PHY node belongs to a separate (extra) DT file.
+
+Therefore, add the HDMI1 PHY PLL clock source to VOP2 by overwriting its
+clocks & clock-names properties in the extra DT file.
+
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Link: https://lore.kernel.org/r/20250223-vop2-hdmi1-disp-modes-v2-4-f4cec5e06fbe@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
+@@ -474,3 +474,24 @@
+ 		status = "disabled";
+ 	};
+ };
++
++&vop {
++	clocks = <&cru ACLK_VOP>,
++		 <&cru HCLK_VOP>,
++		 <&cru DCLK_VOP0>,
++		 <&cru DCLK_VOP1>,
++		 <&cru DCLK_VOP2>,
++		 <&cru DCLK_VOP3>,
++		 <&cru PCLK_VOP_ROOT>,
++		 <&hdptxphy0>,
++		 <&hdptxphy1>;
++	clock-names = "aclk",
++		      "hclk",
++		      "dclk_vp0",
++		      "dclk_vp1",
++		      "dclk_vp2",
++		      "dclk_vp3",
++		      "pclk_vop",
++		      "pll_hdmiphy0",
++		      "pll_hdmiphy1";
++};

--- a/target/linux/rockchip/patches-6.6/050-41-v6.15-arm64-dts-rockchip-Add-rng-node-to-RK3588.patch
+++ b/target/linux/rockchip/patches-6.6/050-41-v6.15-arm64-dts-rockchip-Add-rng-node-to-RK3588.patch
@@ -17,7 +17,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
 
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-@@ -1763,6 +1763,14 @@
+@@ -1810,6 +1810,14 @@
  		status = "disabled";
  	};
  

--- a/target/linux/rockchip/patches-6.6/050-42-v6.15-arm64-dts-rockchip-Add-HDMI-audio-outputs-for-rk3588.patch
+++ b/target/linux/rockchip/patches-6.6/050-42-v6.15-arm64-dts-rockchip-Add-HDMI-audio-outputs-for-rk3588.patch
@@ -1,0 +1,91 @@
+From b8c6c136971c0e9750eec89f367529b2854d3a3c Mon Sep 17 00:00:00 2001
+From: Detlev Casanova <detlev.casanova@collabora.com>
+Date: Mon, 17 Feb 2025 16:47:41 -0500
+Subject: arm64: dts: rockchip: Add HDMI audio outputs for rk3588
+
+For hdmi0_sound, use the simple-audio-card driver with the hdmi0 QP node
+as CODEC and the i2s5 device as CPU.
+
+Similarly for hdmi1_sound, the CODEC is the hdmi1 node and the CPU is
+i2s6, but only added in the rk3588-extra.dtsi device tree as the second
+TX HDMI port is not available on base versions of the SoC.
+
+The simple-audio-card,mclk-fs value is set to 128 as it is done in
+the downstream driver.
+
+The #sound-dai-cells value is set to 0 in the hdmi0 and hdmi1 nodes so
+that they can be used as audio codec nodes.
+
+Tested-by: Quentin Schulz <quentin.schulz@cherry.de> # RK3588 Tiger Haikou
+Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
+Fixes: 419d1918105e ("ASoC: simple-card-utils: use __free(device_node) for device node")
+Signed-off-by: Kuninori Morimoto <kuninori.morimoto.gx@renesas.com>
+Link: https://lore.kernel.org/r/20250217215641.372723-3-detlev.casanova@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -382,6 +382,22 @@
+ 		};
+ 	};
+ 
++	hdmi0_sound: hdmi0-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,name = "hdmi0";
++		status = "disabled";
++
++		simple-audio-card,codec {
++			sound-dai = <&hdmi0>;
++		};
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s5_8ch>;
++		};
++	};
++
+ 	pmu-a55 {
+ 		compatible = "arm,cortex-a55-pmu";
+ 		interrupts = <GIC_PPI 7 IRQ_TYPE_LEVEL_HIGH &ppi_partition0>;
+@@ -1285,6 +1301,7 @@
+ 		reset-names = "ref", "hdp";
+ 		rockchip,grf = <&sys_grf>;
+ 		rockchip,vo-grf = <&vo1_grf>;
++		#sound-dai-cells = <0>;
+ 		status = "disabled";
+ 
+ 		ports {
+--- a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
+@@ -7,6 +7,22 @@
+ #include "rk3588-extra-pinctrl.dtsi"
+ 
+ / {
++	hdmi1_sound: hdmi1-sound {
++		compatible = "simple-audio-card";
++		simple-audio-card,format = "i2s";
++		simple-audio-card,mclk-fs = <128>;
++		simple-audio-card,name = "hdmi1";
++		status = "disabled";
++
++		simple-audio-card,codec {
++			sound-dai = <&hdmi1>;
++		};
++
++		simple-audio-card,cpu {
++			sound-dai = <&i2s6_8ch>;
++		};
++	};
++
+ 	usb_host1_xhci: usb@fc400000 {
+ 		compatible = "rockchip,rk3588-dwc3", "snps,dwc3";
+ 		reg = <0x0 0xfc400000 0x0 0x400000>;
+@@ -165,6 +181,7 @@
+ 		reset-names = "ref", "hdp";
+ 		rockchip,grf = <&sys_grf>;
+ 		rockchip,vo-grf = <&vo1_grf>;
++		#sound-dai-cells = <0>;
+ 		status = "disabled";
+ 
+ 		ports {

--- a/target/linux/rockchip/patches-6.6/050-43-v6.15-arm64-dts-rockchip-Add-device-tree-support-for-HDMI-.patch
+++ b/target/linux/rockchip/patches-6.6/050-43-v6.15-arm64-dts-rockchip-Add-device-tree-support-for-HDMI-.patch
@@ -1,0 +1,88 @@
+From 0327238991ba2d1de25e1116b1c064f433e45b8d Mon Sep 17 00:00:00 2001
+From: Shreeya Patel <shreeya.patel@collabora.com>
+Date: Fri, 7 Mar 2025 12:18:56 +0300
+Subject: arm64: dts: rockchip: Add device tree support for HDMI RX Controller
+
+Add device tree support for Synopsys DesignWare HDMI RX
+Controller.
+
+Reviewed-by: Dmitry Osipenko <dmitry.osipenko@collabora.com>
+Tested-by: Dmitry Osipenko <dmitry.osipenko@collabora.com>
+Co-developed-by: Dingxian Wen <shawn.wen@rock-chips.com>
+Signed-off-by: Dingxian Wen <shawn.wen@rock-chips.com>
+Signed-off-by: Shreeya Patel <shreeya.patel@collabora.com>
+Signed-off-by: Dmitry Osipenko <dmitry.osipenko@collabora.com>
+Link: https://lore.kernel.org/r/20250307091857.646581-2-dmitry.osipenko@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-extra.dtsi
+@@ -23,6 +23,30 @@
+ 		};
+ 	};
+ 
++	reserved-memory {
++		#address-cells = <2>;
++		#size-cells = <2>;
++		ranges;
++
++		/*
++		 * The 4k HDMI capture controller works only with 32bit
++		 * phys addresses and doesn't support IOMMU. HDMI RX CMA
++		 * must be reserved below 4GB.
++		 * The size of 160MB was determined as follows:
++		 * (3840 * 2160 pixels) * (4 bytes/pixel) * (2 frames/buffer) / 10^6 = 66MB
++		 * To ensure sufficient support for practical use-cases,
++		 * we doubled the 66MB value.
++		 */
++		hdmi_receiver_cma: hdmi-receiver-cma {
++			compatible = "shared-dma-pool";
++			alloc-ranges = <0x0 0x0 0x0 0xffffffff>;
++			size = <0x0 (160 * 0x100000)>; /* 160MiB */
++			alignment = <0x0 0x40000>; /* 64K */
++			no-map;
++			status = "disabled";
++		};
++	};
++
+ 	usb_host1_xhci: usb@fc400000 {
+ 		compatible = "rockchip,rk3588-dwc3", "snps,dwc3";
+ 		reg = <0x0 0xfc400000 0x0 0x400000>;
+@@ -198,6 +222,37 @@
+ 		};
+ 	};
+ 
++	hdmi_receiver: hdmi_receiver@fdee0000 {
++		compatible = "rockchip,rk3588-hdmirx-ctrler", "snps,dw-hdmi-rx";
++		reg = <0x0 0xfdee0000 0x0 0x6000>;
++		interrupts = <GIC_SPI 177 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 178 IRQ_TYPE_LEVEL_HIGH 0>,
++			     <GIC_SPI 179 IRQ_TYPE_LEVEL_HIGH 0>;
++		interrupt-names = "cec", "hdmi", "dma";
++		clocks = <&cru ACLK_HDMIRX>,
++			 <&cru CLK_HDMIRX_AUD>,
++			 <&cru CLK_CR_PARA>,
++			 <&cru PCLK_HDMIRX>,
++			 <&cru CLK_HDMIRX_REF>,
++			 <&cru PCLK_S_HDMIRX>,
++			 <&cru HCLK_VO1>;
++		clock-names = "aclk",
++			      "audio",
++			      "cr_para",
++			      "pclk",
++			      "ref",
++			      "hclk_s_hdmirx",
++			      "hclk_vo1";
++		memory-region = <&hdmi_receiver_cma>;
++		power-domains = <&power RK3588_PD_VO1>;
++		resets = <&cru SRST_A_HDMIRX>, <&cru SRST_P_HDMIRX>,
++			 <&cru SRST_HDMIRX_REF>, <&cru SRST_A_HDMIRX_BIU>;
++		reset-names = "axi", "apb", "ref", "biu";
++		rockchip,grf = <&sys_grf>;
++		rockchip,vo1-grf = <&vo1_grf>;
++		status = "disabled";
++	};
++
+ 	pcie3x4: pcie@fe150000 {
+ 		compatible = "rockchip,rk3588-pcie", "rockchip,rk3568-pcie";
+ 		#address-cells = <3>;

--- a/target/linux/rockchip/patches-6.6/050-44-v6.15-arm64-dts-rockchip-Add-GPU-power-domain-regulator-de.patch
+++ b/target/linux/rockchip/patches-6.6/050-44-v6.15-arm64-dts-rockchip-Add-GPU-power-domain-regulator-de.patch
@@ -1,0 +1,46 @@
+From f94500eb7328b35f3d0927635b1aba26c85ea4b0 Mon Sep 17 00:00:00 2001
+From: Sebastian Reichel <sebastian.reichel@collabora.com>
+Date: Thu, 20 Feb 2025 19:58:11 +0100
+Subject: arm64: dts: rockchip: Add GPU power domain regulator dependency for
+ RK3588
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Enabling the GPU power domain requires that the GPU regulator is
+enabled. The regulator is enabled at boot time, but gets disabled
+automatically when there are no users.
+
+This means the system might run into a failure state hanging the
+whole system for the following use cases:
+
+ * if the GPU driver is being probed late (e.g. build as a
+   module and firmware is not in initramfs), the regulator
+   might already have been disabled. In that case the power
+   domain is enabled before the regulator.
+ * unbinding the GPU driver will disable the PM domain and
+   the regulator. When the driver is bound again, the PM
+   domain will be enabled before the regulator and error
+   appears.
+
+Avoid this by adding an explicit regulator dependency to the
+power domain.
+
+Tested-by: Heiko Stuebner <heiko@sntech.de>
+Reported-by: Adrián Martínez Larumbe <adrian.larumbe@collabora.com>
+Tested-by: Adrian Larumbe <adrian.larumbe@collabora.com> # On Rock 5B
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Link: https://lore.kernel.org/r/20250220-rk3588-gpu-pwr-domain-regulator-v6-8-a4f9c24e5b81@kernel.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -881,7 +881,7 @@
+ 				};
+ 			};
+ 			/* These power domains are grouped by VD_GPU */
+-			power-domain@RK3588_PD_GPU {
++			pd_gpu: power-domain@RK3588_PD_GPU {
+ 				reg = <RK3588_PD_GPU>;
+ 				clocks = <&cru CLK_GPU>,
+ 					 <&cru CLK_GPU_COREGROUP>,

--- a/target/linux/rockchip/patches-6.6/050-45-v6.15-arm64-dts-rockchip-change-rng-reset-id-back-to-its-c.patch
+++ b/target/linux/rockchip/patches-6.6/050-45-v6.15-arm64-dts-rockchip-change-rng-reset-id-back-to-its-c.patch
@@ -14,7 +14,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
 
 --- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
 +++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
-@@ -1768,7 +1768,7 @@
+@@ -1832,7 +1832,7 @@
  		reg = <0x0 0xfe378000 0x0 0x200>;
  		interrupts = <GIC_SPI 400 IRQ_TYPE_LEVEL_HIGH 0>;
  		clocks = <&scmi_clk SCMI_HCLK_SECURE_NS>;

--- a/target/linux/rockchip/patches-6.6/050-46-v6.16-arm64-dts-rockchip-Move-SHMEM-memory-to-reserved-memory-o.patch
+++ b/target/linux/rockchip/patches-6.6/050-46-v6.16-arm64-dts-rockchip-Move-SHMEM-memory-to-reserved-memory-o.patch
@@ -1,0 +1,43 @@
+From 8ecd096d018be8a6bd3bd930f3a41a85db66a67d Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Tue, 1 Apr 2025 17:00:09 +0800
+Subject: [PATCH] arm64: dts: rockchip: Move SHMEM memory to reserved memory on
+ rk3588
+
+0x0 to 0xf0000000 are SDRAM memory areas where 0x10f000 is located.
+So move the SHMEM memory of arm_scmi to the reserved memory node.
+
+Fixes: c9211fa2602b ("arm64: dts: rockchip: Add base DT for rk3588 SoC")
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+Link: https://lore.kernel.org/r/20250401090009.733771-2-amadeus@jmu.edu.cn
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-base.dtsi | 15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base.dtsi
+@@ -444,16 +444,15 @@
+ 		#clock-cells = <0>;
+ 	};
+ 
+-	pmu_sram: sram@10f000 {
+-		compatible = "mmio-sram";
+-		reg = <0x0 0x0010f000 0x0 0x100>;
+-		ranges = <0 0x0 0x0010f000 0x100>;
+-		#address-cells = <1>;
+-		#size-cells = <1>;
++	reserved-memory {
++		#address-cells = <2>;
++		#size-cells = <2>;
++		ranges;
+ 
+-		scmi_shmem: sram@0 {
++		scmi_shmem: shmem@10f000 {
+ 			compatible = "arm,scmi-shmem";
+-			reg = <0x0 0x100>;
++			reg = <0x0 0x0010f000 0x0 0x100>;
++			no-map;
+ 		};
+ 	};
+ 

--- a/target/linux/rockchip/patches-6.6/051-05-v6.13-arm64-dts-rockchip-Split-up-RK3588-s-PCIe-pinctrls.patch
+++ b/target/linux/rockchip/patches-6.6/051-05-v6.13-arm64-dts-rockchip-Split-up-RK3588-s-PCIe-pinctrls.patch
@@ -1,0 +1,444 @@
+From 4294e32111781b3de4d73b944cbd1bc1662a9a7a Mon Sep 17 00:00:00 2001
+From: Sam Edwards <cfsworks@gmail.com>
+Date: Wed, 11 Sep 2024 19:50:30 -0700
+Subject: arm64: dts: rockchip: Split up RK3588's PCIe pinctrls
+
+These pinctrls manage the low-speed PCIe signals:
+- CLKREQ#: An output on the RK3588 (both RC or EP modes), used to
+  request that external clock-generation circuitry provide a clock.
+- PERST#: An input on the RK3588 in EP mode, used to detect a reset
+  signal from the RC. In RC mode, the hardware does not use this signal:
+  Linux itself generates it by putting the pin in GPIO mode.
+- WAKE#: In EP mode, this is an output; in RC mode, this is an input.
+
+Each of these signals serves a distinct purpose, and more importantly,
+PERST# should not be muxed when the RK3588 is in the RC role. Bundling
+them together in pinctrl groups prevents proper use: indeed, almost none
+of the current board-specific .dts files make any use of them.
+(Exception: Rock 5A recently had a patch land that misuses _pins; this
+ patch corrects that.)
+
+However, on some RK3588 boards, the PCIe 3 controller will indefinitely
+stall the boot if CLKREQ# is not muxed (details in the next patch).
+This patch unbundles the signals to allow them to be used.
+
+Signed-off-by: Sam Edwards <CFSworks@gmail.com>
+Link: https://lore.kernel.org/r/20240912025034.180233-2-CFSworks@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-base-pinctrl.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-base-pinctrl.dtsi
+@@ -1612,23 +1612,43 @@
+ 
+ 	pcie20x1 {
+ 		/omit-if-no-ref/
+-		pcie20x1m0_pins: pcie20x1m0-pins {
++		pcie20x1m0_clkreqn: pcie20x1m0-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie20x1_2_clkreqn_m0 */
+-				<3 RK_PC7 4 &pcfg_pull_none>,
++				<3 RK_PC7 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie20x1m0_perstn: pcie20x1m0-perstn {
++			rockchip,pins =
+ 				/* pcie20x1_2_perstn_m0 */
+-				<3 RK_PD1 4 &pcfg_pull_none>,
++				<3 RK_PD1 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie20x1m0_waken: pcie20x1m0-waken {
++			rockchip,pins =
+ 				/* pcie20x1_2_waken_m0 */
+ 				<3 RK_PD0 4 &pcfg_pull_none>;
+ 		};
+ 
+ 		/omit-if-no-ref/
+-		pcie20x1m1_pins: pcie20x1m1-pins {
++		pcie20x1m1_clkreqn: pcie20x1m1-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie20x1_2_clkreqn_m1 */
+-				<4 RK_PB7 4 &pcfg_pull_none>,
++				<4 RK_PB7 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie20x1m1_perstn: pcie20x1m1-perstn {
++			rockchip,pins =
+ 				/* pcie20x1_2_perstn_m1 */
+-				<4 RK_PC1 4 &pcfg_pull_none>,
++				<4 RK_PC1 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie20x1m1_waken: pcie20x1m1-waken {
++			rockchip,pins =
+ 				/* pcie20x1_2_waken_m1 */
+ 				<4 RK_PC0 4 &pcfg_pull_none>;
+ 		};
+@@ -1654,52 +1674,127 @@
+ 
+ 	pcie30x1 {
+ 		/omit-if-no-ref/
+-		pcie30x1m0_pins: pcie30x1m0-pins {
++		pcie30x1m0_0_clkreqn: pcie30x1m0-0-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie30x1_0_clkreqn_m0 */
+-				<0 RK_PC0 12 &pcfg_pull_none>,
++				<0 RK_PC0 12 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m0_0_perstn: pcie30x1m0-0-perstn {
++			rockchip,pins =
+ 				/* pcie30x1_0_perstn_m0 */
+-				<0 RK_PC5 12 &pcfg_pull_none>,
++				<0 RK_PC5 12 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m0_0_waken: pcie30x1m0-0-waken {
++			rockchip,pins =
+ 				/* pcie30x1_0_waken_m0 */
+-				<0 RK_PC4 12 &pcfg_pull_none>,
++				<0 RK_PC4 12 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m0_1_clkreqn: pcie30x1m0-1-clkreqn {
++			rockchip,pins =
+ 				/* pcie30x1_1_clkreqn_m0 */
+-				<0 RK_PB5 12 &pcfg_pull_none>,
++				<0 RK_PB5 12 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m0_1_perstn: pcie30x1m0-1-perstn {
++			rockchip,pins =
+ 				/* pcie30x1_1_perstn_m0 */
+-				<0 RK_PB7 12 &pcfg_pull_none>,
++				<0 RK_PB7 12 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m0_1_waken: pcie30x1m0-1-waken {
++			rockchip,pins =
+ 				/* pcie30x1_1_waken_m0 */
+ 				<0 RK_PB6 12 &pcfg_pull_none>;
+ 		};
+ 
+ 		/omit-if-no-ref/
+-		pcie30x1m1_pins: pcie30x1m1-pins {
++		pcie30x1m1_0_clkreqn: pcie30x1m1-0-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie30x1_0_clkreqn_m1 */
+-				<4 RK_PA3 4 &pcfg_pull_none>,
++				<4 RK_PA3 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m1_0_perstn: pcie30x1m1-0-perstn {
++			rockchip,pins =
+ 				/* pcie30x1_0_perstn_m1 */
+-				<4 RK_PA5 4 &pcfg_pull_none>,
++				<4 RK_PA5 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m1_0_waken: pcie30x1m1-0-waken {
++			rockchip,pins =
+ 				/* pcie30x1_0_waken_m1 */
+-				<4 RK_PA4 4 &pcfg_pull_none>,
++				<4 RK_PA4 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m1_1_clkreqn: pcie30x1m1-1-clkreqn {
++			rockchip,pins =
+ 				/* pcie30x1_1_clkreqn_m1 */
+-				<4 RK_PA0 4 &pcfg_pull_none>,
++				<4 RK_PA0 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m1_1_perstn: pcie30x1m1-1-perstn {
++			rockchip,pins =
+ 				/* pcie30x1_1_perstn_m1 */
+-				<4 RK_PA2 4 &pcfg_pull_none>,
++				<4 RK_PA2 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m1_1_waken: pcie30x1m1-1-waken {
++			rockchip,pins =
+ 				/* pcie30x1_1_waken_m1 */
+ 				<4 RK_PA1 4 &pcfg_pull_none>;
+ 		};
+ 
+ 		/omit-if-no-ref/
+-		pcie30x1m2_pins: pcie30x1m2-pins {
++		pcie30x1m2_0_clkreqn: pcie30x1m2-0-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie30x1_0_clkreqn_m2 */
+-				<1 RK_PB5 4 &pcfg_pull_none>,
++				<1 RK_PB5 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m2_0_perstn: pcie30x1m2-0-perstn {
++			rockchip,pins =
+ 				/* pcie30x1_0_perstn_m2 */
+-				<1 RK_PB4 4 &pcfg_pull_none>,
++				<1 RK_PB4 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m2_0_waken: pcie30x1m2-0-waken {
++			rockchip,pins =
+ 				/* pcie30x1_0_waken_m2 */
+-				<1 RK_PB3 4 &pcfg_pull_none>,
++				<1 RK_PB3 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m2_1_clkreqn: pcie30x1m2-1-clkreqn {
++			rockchip,pins =
+ 				/* pcie30x1_1_clkreqn_m2 */
+-				<1 RK_PA0 4 &pcfg_pull_none>,
++				<1 RK_PA0 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m2_1_perstn: pcie30x1m2-1-perstn {
++			rockchip,pins =
+ 				/* pcie30x1_1_perstn_m2 */
+-				<1 RK_PA7 4 &pcfg_pull_none>,
++				<1 RK_PA7 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x1m2_1_waken: pcie30x1m2-1-waken {
++			rockchip,pins =
+ 				/* pcie30x1_1_waken_m2 */
+ 				<1 RK_PA1 4 &pcfg_pull_none>;
+ 		};
+@@ -1721,45 +1816,85 @@
+ 
+ 	pcie30x2 {
+ 		/omit-if-no-ref/
+-		pcie30x2m0_pins: pcie30x2m0-pins {
++		pcie30x2m0_clkreqn: pcie30x2m0-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie30x2_clkreqn_m0 */
+-				<0 RK_PD1 12 &pcfg_pull_none>,
++				<0 RK_PD1 12 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x2m0_perstn: pcie30x2m0-perstn {
++			rockchip,pins =
+ 				/* pcie30x2_perstn_m0 */
+-				<0 RK_PD4 12 &pcfg_pull_none>,
++				<0 RK_PD4 12 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x2m0_waken: pcie30x2m0-waken {
++			rockchip,pins =
+ 				/* pcie30x2_waken_m0 */
+ 				<0 RK_PD2 12 &pcfg_pull_none>;
+ 		};
+ 
+ 		/omit-if-no-ref/
+-		pcie30x2m1_pins: pcie30x2m1-pins {
++		pcie30x2m1_clkreqn: pcie30x2m1-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie30x2_clkreqn_m1 */
+-				<4 RK_PA6 4 &pcfg_pull_none>,
++				<4 RK_PA6 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x2m1_perstn: pcie30x2m1-perstn {
++			rockchip,pins =
+ 				/* pcie30x2_perstn_m1 */
+-				<4 RK_PB0 4 &pcfg_pull_none>,
++				<4 RK_PB0 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x2m1_waken: pcie30x2m1-waken {
++			rockchip,pins =
+ 				/* pcie30x2_waken_m1 */
+ 				<4 RK_PA7 4 &pcfg_pull_none>;
+ 		};
+ 
+ 		/omit-if-no-ref/
+-		pcie30x2m2_pins: pcie30x2m2-pins {
++		pcie30x2m2_clkreqn: pcie30x2m2-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie30x2_clkreqn_m2 */
+-				<3 RK_PD2 4 &pcfg_pull_none>,
++				<3 RK_PD2 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x2m2_perstn: pcie30x2m2-perstn {
++			rockchip,pins =
+ 				/* pcie30x2_perstn_m2 */
+-				<3 RK_PD4 4 &pcfg_pull_none>,
++				<3 RK_PD4 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x2m2_waken: pcie30x2m2-waken {
++			rockchip,pins =
+ 				/* pcie30x2_waken_m2 */
+ 				<3 RK_PD3 4 &pcfg_pull_none>;
+ 		};
+ 
+ 		/omit-if-no-ref/
+-		pcie30x2m3_pins: pcie30x2m3-pins {
++		pcie30x2m3_clkreqn: pcie30x2m3-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie30x2_clkreqn_m3 */
+-				<1 RK_PD7 4 &pcfg_pull_none>,
++				<1 RK_PD7 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x2m3_perstn: pcie30x2m3-perstn {
++			rockchip,pins =
+ 				/* pcie30x2_perstn_m3 */
+-				<1 RK_PB7 4 &pcfg_pull_none>,
++				<1 RK_PB7 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x2m3_waken: pcie30x2m3-waken {
++			rockchip,pins =
+ 				/* pcie30x2_waken_m3 */
+ 				<1 RK_PB6 4 &pcfg_pull_none>;
+ 		};
+@@ -1774,45 +1909,85 @@
+ 
+ 	pcie30x4 {
+ 		/omit-if-no-ref/
+-		pcie30x4m0_pins: pcie30x4m0-pins {
++		pcie30x4m0_clkreqn: pcie30x4m0-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie30x4_clkreqn_m0 */
+-				<0 RK_PC6 12 &pcfg_pull_none>,
++				<0 RK_PC6 12 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x4m0_perstn: pcie30x4m0-perstn {
++			rockchip,pins =
+ 				/* pcie30x4_perstn_m0 */
+-				<0 RK_PD0 12 &pcfg_pull_none>,
++				<0 RK_PD0 12 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x4m0_waken: pcie30x4m0-waken {
++			rockchip,pins =
+ 				/* pcie30x4_waken_m0 */
+ 				<0 RK_PC7 12 &pcfg_pull_none>;
+ 		};
+ 
+ 		/omit-if-no-ref/
+-		pcie30x4m1_pins: pcie30x4m1-pins {
++		pcie30x4m1_clkreqn: pcie30x4m1-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie30x4_clkreqn_m1 */
+-				<4 RK_PB4 4 &pcfg_pull_none>,
++				<4 RK_PB4 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x4m1_perstn: pcie30x4m1-perstn {
++			rockchip,pins =
+ 				/* pcie30x4_perstn_m1 */
+-				<4 RK_PB6 4 &pcfg_pull_none>,
++				<4 RK_PB6 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x4m1_waken: pcie30x4m1-waken {
++			rockchip,pins =
+ 				/* pcie30x4_waken_m1 */
+ 				<4 RK_PB5 4 &pcfg_pull_none>;
+ 		};
+ 
+ 		/omit-if-no-ref/
+-		pcie30x4m2_pins: pcie30x4m2-pins {
++		pcie30x4m2_clkreqn: pcie30x4m2-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie30x4_clkreqn_m2 */
+-				<3 RK_PC4 4 &pcfg_pull_none>,
++				<3 RK_PC4 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x4m2_perstn: pcie30x4m2-perstn {
++			rockchip,pins =
+ 				/* pcie30x4_perstn_m2 */
+-				<3 RK_PC6 4 &pcfg_pull_none>,
++				<3 RK_PC6 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x4m2_waken: pcie30x4m2-waken {
++			rockchip,pins =
+ 				/* pcie30x4_waken_m2 */
+ 				<3 RK_PC5 4 &pcfg_pull_none>;
+ 		};
+ 
+ 		/omit-if-no-ref/
+-		pcie30x4m3_pins: pcie30x4m3-pins {
++		pcie30x4m3_clkreqn: pcie30x4m3-clkreqn {
+ 			rockchip,pins =
+ 				/* pcie30x4_clkreqn_m3 */
+-				<1 RK_PB0 4 &pcfg_pull_none>,
++				<1 RK_PB0 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x4m3_perstn: pcie30x4m3-perstn {
++			rockchip,pins =
+ 				/* pcie30x4_perstn_m3 */
+-				<1 RK_PB2 4 &pcfg_pull_none>,
++				<1 RK_PB2 4 &pcfg_pull_none>;
++		};
++
++		/omit-if-no-ref/
++		pcie30x4m3_waken: pcie30x4m3-waken {
++			rockchip,pins =
+ 				/* pcie30x4_waken_m3 */
+ 				<1 RK_PB1 4 &pcfg_pull_none>;
+ 		};
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+@@ -310,7 +310,7 @@
+ };
+ 
+ &pcie2x1l2 {
+-	pinctrl-0 = <&pcie20x1m0_pins>;
++	pinctrl-0 = <&pcie2_reset>, <&pcie20x1m0_clkreqn>, <&pcie20x1m0_waken>;
+ 	pinctrl-names = "default";
+ 	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
+ 	vpcie3v3-supply = <&vcc3v3_wf>;
+@@ -328,6 +328,10 @@
+ 		pow_en: pow-en {
+ 			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
++
++		pcie2_reset: pcie2-reset {
++			rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
+ 	};
+ 
+ 	power {

--- a/target/linux/rockchip/patches-6.6/051-06-v6.13-arm64-dts-rockchip-add-and-enable-gpu-node-for-Radxa.patch
+++ b/target/linux/rockchip/patches-6.6/051-06-v6.13-arm64-dts-rockchip-add-and-enable-gpu-node-for-Radxa.patch
@@ -1,0 +1,25 @@
+From a98053d098c4ad91a45a3a55604d9574dfc6ffdb Mon Sep 17 00:00:00 2001
+From: FUKAUMI Naoki <naoki@radxa.com>
+Date: Sat, 19 Oct 2024 02:50:08 +0000
+Subject: arm64: dts: rockchip: add and enable gpu node for Radxa ROCK 5A
+
+add gpu node to make it usable on Radxa ROCK 5A.
+
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+Link: https://lore.kernel.org/r/20241019025008.852-1-naoki@radxa.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+@@ -165,6 +165,11 @@
+ 	cpu-supply = <&vdd_cpu_lit_s0>;
+ };
+ 
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	status = "okay";
++};
++
+ &i2c0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c0m2_xfer>;

--- a/target/linux/rockchip/patches-6.6/051-07-v6.13-arm64-dts-rockchip-Enable-HDMI0-on-rock-5a.patch
+++ b/target/linux/rockchip/patches-6.6/051-07-v6.13-arm64-dts-rockchip-Enable-HDMI0-on-rock-5a.patch
@@ -1,0 +1,90 @@
+From f57a8daf6bbd8e71f16693ad6d8421cb881c7fe0 Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Tue, 22 Oct 2024 19:04:42 +0300
+Subject: arm64: dts: rockchip: Enable HDMI0 on rock-5a
+
+Add the necessary DT changes to enable HDMI0 on Radxa ROCK 5A.
+
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Link: https://lore.kernel.org/r/20241022-rk3588-hdmi0-dt-v3-1-3cc981e89afb@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+@@ -5,6 +5,7 @@
+ #include <dt-bindings/gpio/gpio.h>
+ #include <dt-bindings/leds/common.h>
+ #include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/soc/rockchip,vop2.h>
+ #include "rk3588s.dtsi"
+ 
+ / {
+@@ -34,6 +35,17 @@
+ 		stdout-path = "serial2:1500000n8";
+ 	};
+ 
++	hdmi0-con {
++		compatible = "hdmi-connector";
++		type = "d";
++
++		port {
++			hdmi0_con_in: endpoint {
++				remote-endpoint = <&hdmi0_out_con>;
++			};
++		};
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 		pinctrl-names = "default";
+@@ -301,6 +313,31 @@
+ 	status = "okay";
+ };
+ 
++&hdmi0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&hdmim0_tx0_cec
++		     &hdmim1_tx0_hpd
++		     &hdmim0_tx0_scl
++		     &hdmim0_tx0_sda>;
++	status = "okay";
++};
++
++&hdmi0_in {
++	hdmi0_in_vp0: endpoint {
++		remote-endpoint = <&vp0_out_hdmi0>;
++	};
++};
++
++&hdmi0_out {
++	hdmi0_out_con: endpoint {
++		remote-endpoint = <&hdmi0_con_in>;
++	};
++};
++
++&hdptxphy_hdmi0 {
++	status = "okay";
++};
++
+ &mdio1 {
+ 	rgmii_phy1: ethernet-phy@1 {
+ 		/* RTL8211F */
+@@ -813,3 +850,18 @@
+ &usb_host2_xhci {
+ 	status = "okay";
+ };
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vp0 {
++	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
++		remote-endpoint = <&hdmi0_in_vp0>;
++	};
++};

--- a/target/linux/rockchip/patches-6.6/051-08-v6.13-arm64-dts-rockchip-adapt-regulator-nodenames-to-pref.patch
+++ b/target/linux/rockchip/patches-6.6/051-08-v6.13-arm64-dts-rockchip-adapt-regulator-nodenames-to-pref.patch
@@ -1,0 +1,72 @@
+From 5c96e63301978f4657c9082c55a066763c8db7b1 Mon Sep 17 00:00:00 2001
+From: Johan Jonker <jbx6244@gmail.com>
+Date: Sat, 5 Oct 2024 22:40:12 +0200
+Subject: arm64: dts: rockchip: adapt regulator nodenames to preferred form
+
+The preferred nodename for fixed-regulators has changed to
+pattern: '^regulator(-[0-9]+v[0-9]+|-[0-9a-z-]+)?$'
+
+Fix all Rockchip DT regulator nodenames.
+
+Signed-off-by: Johan Jonker <jbx6244@gmail.com>
+Link: https://lore.kernel.org/r/0ae40493-93e9-40cd-9ca9-990ae064f21a@gmail.com
+[adapted rebased on top of a number of other changes and included
+ neu6a-wifi + wolfvision-pf5-io-expander overlays]
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+@@ -67,7 +67,7 @@
+ 		#cooling-cells = <2>;
+ 	};
+ 
+-	vcc12v_dcin: vcc12v-dcin-regulator {
++	vcc12v_dcin: regulator-vcc12v-dcin {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc12v_dcin";
+ 		regulator-always-on;
+@@ -76,7 +76,7 @@
+ 		regulator-max-microvolt = <12000000>;
+ 	};
+ 
+-	vcc3v3_wf: vcc3v3-wf-regulator {
++	vcc3v3_wf: regulator-vcc3v3-wf {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc3v3_wf";
+ 		regulator-min-microvolt = <3300000>;
+@@ -88,7 +88,7 @@
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+-	vcc5v0_host: vcc5v0-host-regulator {
++	vcc5v0_host: regulator-vcc5v0-host {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_host";
+ 		regulator-boot-on;
+@@ -102,7 +102,7 @@
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+-	vcc5v0_sys: vcc5v0-sys-regulator {
++	vcc5v0_sys: regulator-vcc5v0-sys {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_sys";
+ 		regulator-always-on;
+@@ -112,7 +112,7 @@
+ 		vin-supply = <&vcc12v_dcin>;
+ 	};
+ 
+-	vcc_5v0: vcc-5v0-regulator {
++	vcc_5v0: regulator-vcc-5v0 {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc_5v0";
+ 		regulator-min-microvolt = <5000000>;
+@@ -126,7 +126,7 @@
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+-	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3-regulator {
++	vcc_1v1_nldo_s3: regulator-vcc-1v1-nldo-s3 {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc_1v1_nldo_s3";
+ 		regulator-always-on;

--- a/target/linux/rockchip/patches-6.6/051-09-v6.15-arm64-dts-rockchip-Fix-label-name-of-hdptxphy-for-RK.patch
+++ b/target/linux/rockchip/patches-6.6/051-09-v6.15-arm64-dts-rockchip-Fix-label-name-of-hdptxphy-for-RK.patch
@@ -1,0 +1,26 @@
+From 2efdb041019fd6c58abefba3eb6fdc4d659e576c Mon Sep 17 00:00:00 2001
+From: Damon Ding <damon.ding@rock-chips.com>
+Date: Thu, 6 Feb 2025 11:03:30 +0800
+Subject: arm64: dts: rockchip: Fix label name of hdptxphy for RK3588
+
+The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP
+and eDP Link. Therefore, it is better to name it hdptxphy0 other than
+hdptxphy_hdmi0, which will be referenced by both hdmi0 and edp0 nodes.
+
+Signed-off-by: Damon Ding <damon.ding@rock-chips.com>
+Link: https://lore.kernel.org/r/20250206030330.680424-3-damon.ding@rock-chips.com
+[added armsom-sige7, where hdmi-support was added recently and also
+ the hdptxphy0-as-dclk source I just added]
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+@@ -334,7 +334,7 @@
+ 	};
+ };
+ 
+-&hdptxphy_hdmi0 {
++&hdptxphy0 {
+ 	status = "okay";
+ };
+ 

--- a/target/linux/rockchip/patches-6.6/051-10-v6.15-arm64-dts-rockchip-Add-GPU-power-domain-regulator-de.patch
+++ b/target/linux/rockchip/patches-6.6/051-10-v6.15-arm64-dts-rockchip-Add-GPU-power-domain-regulator-de.patch
@@ -1,0 +1,48 @@
+From f94500eb7328b35f3d0927635b1aba26c85ea4b0 Mon Sep 17 00:00:00 2001
+From: Sebastian Reichel <sebastian.reichel@collabora.com>
+Date: Thu, 20 Feb 2025 19:58:11 +0100
+Subject: arm64: dts: rockchip: Add GPU power domain regulator dependency for
+ RK3588
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Enabling the GPU power domain requires that the GPU regulator is
+enabled. The regulator is enabled at boot time, but gets disabled
+automatically when there are no users.
+
+This means the system might run into a failure state hanging the
+whole system for the following use cases:
+
+ * if the GPU driver is being probed late (e.g. build as a
+   module and firmware is not in initramfs), the regulator
+   might already have been disabled. In that case the power
+   domain is enabled before the regulator.
+ * unbinding the GPU driver will disable the PM domain and
+   the regulator. When the driver is bound again, the PM
+   domain will be enabled before the regulator and error
+   appears.
+
+Avoid this by adding an explicit regulator dependency to the
+power domain.
+
+Tested-by: Heiko Stuebner <heiko@sntech.de>
+Reported-by: Adrián Martínez Larumbe <adrian.larumbe@collabora.com>
+Tested-by: Adrian Larumbe <adrian.larumbe@collabora.com> # On Rock 5B
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Link: https://lore.kernel.org/r/20250220-rk3588-gpu-pwr-domain-regulator-v6-8-a4f9c24e5b81@kernel.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+@@ -359,6 +359,10 @@
+ 	status = "okay";
+ };
+ 
++&pd_gpu {
++	domain-supply = <&vdd_gpu_s0>;
++};
++
+ &pinctrl {
+ 	leds {
+ 		io_led: io-led {

--- a/target/linux/rockchip/patches-6.6/052-13-v6.10-arm64-dts-rockchip-Correct-the-model-names-for-Radxa-ROCK.patch
+++ b/target/linux/rockchip/patches-6.6/052-13-v6.10-arm64-dts-rockchip-Correct-the-model-names-for-Radxa-ROCK.patch
@@ -32,7 +32,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  	aliases {
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
-@@ -8,7 +8,7 @@
+@@ -9,7 +9,7 @@
  #include "rk3588s.dtsi"
  
  / {

--- a/target/linux/rockchip/patches-6.6/052-16-v6.11-arm64-dts-rockchip-add-rfkill-node-for-M-2-Key-E-Bluetoot.patch
+++ b/target/linux/rockchip/patches-6.6/052-16-v6.11-arm64-dts-rockchip-add-rfkill-node-for-M-2-Key-E-Bluetoot.patch
@@ -1,0 +1,37 @@
+From 1d3ac84d6a960baa50da4163160ae82f8dc74af6 Mon Sep 17 00:00:00 2001
+From: Alexey Charkov <alchark@gmail.com>
+Date: Fri, 17 May 2024 16:25:08 +0400
+Subject: [PATCH] arm64: dts: rockchip: add rfkill node for M.2 Key E Bluetooth
+ on Rock 5B
+
+By default the BT WAKE signal inside the M.2 key E connector on Radxa
+Rock 5B is driven low, which results in the Bluetooth function being
+disabled even if the inserted M.2 card supports it. Expose this signal
+as an RFKILL device so that it can be enabled by the userspace.
+
+Tested with an Intel AX210 card, which connects a Bluetooth device over
+the USB 2.0 bus.
+
+Signed-off-by: Alexey Charkov <alchark@gmail.com>
+Link: https://lore.kernel.org/r/20240517122509.4626-1-alchark@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -65,6 +65,13 @@
+ 		shutdown-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+ 	};
+ 
++	rfkill-bt {
++		compatible = "rfkill-gpio";
++		label = "rfkill-m2-bt";
++		radio-type = "bluetooth";
++		shutdown-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
++	};
++
+ 	vcc3v3_pcie2x1l0: vcc3v3-pcie2x1l0-regulator {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;

--- a/target/linux/rockchip/patches-6.6/052-17-v6.12-arm64-dts-rockchip-Start-cooling-maps-numbering-from-zero.patch
+++ b/target/linux/rockchip/patches-6.6/052-17-v6.12-arm64-dts-rockchip-Start-cooling-maps-numbering-from-zero.patch
@@ -1,0 +1,36 @@
+From 6be82067254cba14f7b9ca00613bdb7caac9501f Mon Sep 17 00:00:00 2001
+From: Dragan Simic <dsimic@manjaro.org>
+Date: Sat, 21 Sep 2024 23:39:05 +0200
+Subject: [PATCH] arm64: dts: rockchip: Start cooling maps numbering from zero
+ on ROCK 5B
+
+The package cooling maps for the Radxa ROCK 5B were mistakenly named map1
+and map2.  Their numbering should start from zero instead, because there are
+no package cooling maps defined in the parent RK3588 SoC dtsi file, so let's
+rename these cooling maps to map0 and map1.
+
+Fixes: 4a152231b050 ("arm64: dts: rockchip: enable automatic fan control on Rock 5B")
+Signed-off-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/335ecd5841ab55f333e17bb391d0e1264fac257b.1726954592.git.dsimic@manjaro.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -304,12 +304,12 @@
+ 	};
+ 
+ 	cooling-maps {
+-		map1 {
++		map0 {
+ 			trip = <&package_fan0>;
+ 			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
+ 		};
+ 
+-		map2 {
++		map1 {
+ 			trip = <&package_fan1>;
+ 			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
+ 		};

--- a/target/linux/rockchip/patches-6.6/052-18-v6.13-arm64-dts-rockchip-Enable-HDMI0-on-rock-5b.patch
+++ b/target/linux/rockchip/patches-6.6/052-18-v6.13-arm64-dts-rockchip-Enable-HDMI0-on-rock-5b.patch
@@ -1,0 +1,86 @@
+From c8152f79c2dd8039e14073be76fdbce8760175da Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Sat, 19 Oct 2024 13:12:11 +0300
+Subject: arm64: dts: rockchip: Enable HDMI0 on rock-5b
+
+Add the necessary DT changes to enable HDMI0 on Radxa ROCK 5B.
+
+Tested-by: FUKAUMI Naoki <naoki@radxa.com>
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Link: https://lore.kernel.org/r/20241019-rk3588-hdmi0-dt-v2-2-466cd80e8ff9@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -4,6 +4,7 @@
+ 
+ #include <dt-bindings/gpio/gpio.h>
+ #include <dt-bindings/leds/common.h>
++#include <dt-bindings/soc/rockchip,vop2.h>
+ #include "rk3588.dtsi"
+ 
+ / {
+@@ -37,6 +38,17 @@
+ 		pinctrl-0 = <&hp_detect>;
+ 	};
+ 
++	hdmi0-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi0_con_in: endpoint {
++				remote-endpoint = <&hdmi0_out_con>;
++			};
++		};
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 		pinctrl-names = "default";
+@@ -192,6 +204,26 @@
+ 	status = "okay";
+ };
+ 
++&hdmi0 {
++	status = "okay";
++};
++
++&hdmi0_in {
++	hdmi0_in_vp0: endpoint {
++		remote-endpoint = <&vp0_out_hdmi0>;
++	};
++};
++
++&hdmi0_out {
++	hdmi0_out_con: endpoint {
++		remote-endpoint = <&hdmi0_con_in>;
++	};
++};
++
++&hdptxphy_hdmi0 {
++	status = "okay";
++};
++
+ &i2c0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c0m2_xfer>;
+@@ -854,3 +886,18 @@
+ &usb_host2_xhci {
+ 	status = "okay";
+ };
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vp0 {
++	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
++		remote-endpoint = <&hdmi0_in_vp0>;
++	};
++};

--- a/target/linux/rockchip/patches-6.6/052-19-v6.13-arm64-dts-rockchip-adapt-regulator-nodenames-to-pref.patch
+++ b/target/linux/rockchip/patches-6.6/052-19-v6.13-arm64-dts-rockchip-adapt-regulator-nodenames-to-pref.patch
@@ -1,0 +1,72 @@
+From 5c96e63301978f4657c9082c55a066763c8db7b1 Mon Sep 17 00:00:00 2001
+From: Johan Jonker <jbx6244@gmail.com>
+Date: Sat, 5 Oct 2024 22:40:12 +0200
+Subject: arm64: dts: rockchip: adapt regulator nodenames to preferred form
+
+The preferred nodename for fixed-regulators has changed to
+pattern: '^regulator(-[0-9]+v[0-9]+|-[0-9a-z-]+)?$'
+
+Fix all Rockchip DT regulator nodenames.
+
+Signed-off-by: Johan Jonker <jbx6244@gmail.com>
+Link: https://lore.kernel.org/r/0ae40493-93e9-40cd-9ca9-990ae064f21a@gmail.com
+[adapted rebased on top of a number of other changes and included
+ neu6a-wifi + wolfvision-pf5-io-expander overlays]
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -84,7 +84,7 @@
+ 		shutdown-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
+ 	};
+ 
+-	vcc3v3_pcie2x1l0: vcc3v3-pcie2x1l0-regulator {
++	vcc3v3_pcie2x1l0: regulator-vcc3v3-pcie2x1l0 {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+ 		gpios = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
+@@ -99,7 +99,7 @@
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+-	vcc3v3_pcie2x1l2: vcc3v3-pcie2x1l2-regulator {
++	vcc3v3_pcie2x1l2: regulator-vcc3v3-pcie2x1l2 {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc3v3_pcie2x1l2";
+ 		regulator-min-microvolt = <3300000>;
+@@ -108,7 +108,7 @@
+ 		vin-supply = <&vcc_3v3_s3>;
+ 	};
+ 
+-	vcc3v3_pcie30: vcc3v3-pcie30-regulator {
++	vcc3v3_pcie30: regulator-vcc3v3-pcie30 {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+ 		gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
+@@ -121,7 +121,7 @@
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+-	vcc5v0_host: vcc5v0-host-regulator {
++	vcc5v0_host: regulator-vcc5v0-host {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_host";
+ 		regulator-boot-on;
+@@ -135,7 +135,7 @@
+ 		vin-supply = <&vcc5v0_sys>;
+ 	};
+ 
+-	vcc5v0_sys: vcc5v0-sys-regulator {
++	vcc5v0_sys: regulator-vcc5v0-sys {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc5v0_sys";
+ 		regulator-always-on;
+@@ -144,7 +144,7 @@
+ 		regulator-max-microvolt = <5000000>;
+ 	};
+ 
+-	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3-regulator {
++	vcc_1v1_nldo_s3: regulator-vcc-1v1-nldo-s3 {
+ 		compatible = "regulator-fixed";
+ 		regulator-name = "vcc_1v1_nldo_s3";
+ 		regulator-always-on;

--- a/target/linux/rockchip/patches-6.6/052-20-v6.13-arm64-dts-rockchip-rename-rfkill-label-for-Radxa-ROC.patch
+++ b/target/linux/rockchip/patches-6.6/052-20-v6.13-arm64-dts-rockchip-rename-rfkill-label-for-Radxa-ROC.patch
@@ -1,0 +1,30 @@
+From 2ddd93481bce86c6a46223f45accdb3b149a43e4 Mon Sep 17 00:00:00 2001
+From: FUKAUMI Naoki <naoki@radxa.com>
+Date: Thu, 28 Nov 2024 12:06:30 +0000
+Subject: arm64: dts: rockchip: rename rfkill label for Radxa ROCK 5B
+
+on ROCK 5B, there is no PCIe slot, instead there is a M.2 slot.
+rfkill pin is not exclusive to PCIe devices, there is SDIO Wi-Fi
+devices.
+
+rename rfkill label from "rfkill-pcie-wlan" to "rfkill-m2-wlan", it
+matches with rfkill-bt.
+
+Fixes: 82d40b141a4c ("arm64: dts: rockchip: add rfkill node for M.2 Key E WiFi on rock-5b")
+Reviewed-by: Dragan Simic <dsimic@manjaro.org>
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+Fixes: 82d40b141a4c ("arm64: dts: rockchip: add rfkill node for M.2 Key  E WiFi on rock-5b")
+Link: https://lore.kernel.org/r/20241128120631.37458-1-naoki@radxa.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -72,7 +72,7 @@
+ 
+ 	rfkill {
+ 		compatible = "rfkill-gpio";
+-		label = "rfkill-pcie-wlan";
++		label = "rfkill-m2-wlan";
+ 		radio-type = "wlan";
+ 		shutdown-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+ 	};

--- a/target/linux/rockchip/patches-6.6/052-21-v6.15-arm64-dts-rockchip-Fix-label-name-of-hdptxphy-for-RK.patch
+++ b/target/linux/rockchip/patches-6.6/052-21-v6.15-arm64-dts-rockchip-Fix-label-name-of-hdptxphy-for-RK.patch
@@ -1,0 +1,26 @@
+From 2efdb041019fd6c58abefba3eb6fdc4d659e576c Mon Sep 17 00:00:00 2001
+From: Damon Ding <damon.ding@rock-chips.com>
+Date: Thu, 6 Feb 2025 11:03:30 +0800
+Subject: arm64: dts: rockchip: Fix label name of hdptxphy for RK3588
+
+The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP
+and eDP Link. Therefore, it is better to name it hdptxphy0 other than
+hdptxphy_hdmi0, which will be referenced by both hdmi0 and edp0 nodes.
+
+Signed-off-by: Damon Ding <damon.ding@rock-chips.com>
+Link: https://lore.kernel.org/r/20250206030330.680424-3-damon.ding@rock-chips.com
+[added armsom-sige7, where hdmi-support was added recently and also
+ the hdptxphy0-as-dclk source I just added]
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -220,7 +220,7 @@
+ 	};
+ };
+ 
+-&hdptxphy_hdmi0 {
++&hdptxphy0 {
+ 	status = "okay";
+ };
+ 

--- a/target/linux/rockchip/patches-6.6/052-22-v6.15-arm64-dts-rockchip-Enable-HDMI1-on-rock-5b.patch
+++ b/target/linux/rockchip/patches-6.6/052-22-v6.15-arm64-dts-rockchip-Enable-HDMI1-on-rock-5b.patch
@@ -1,0 +1,94 @@
+From 77cea7ca13680e14119a3b9635c7ef16cd7ee44e Mon Sep 17 00:00:00 2001
+From: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Date: Wed, 11 Dec 2024 01:06:17 +0200
+Subject: arm64: dts: rockchip: Enable HDMI1 on rock-5b
+
+Add the necessary DT changes to enable the second HDMI output port on
+Radxa ROCK 5B.
+
+While at it, switch the position of &vop_mmu and @vop to maintain the
+alphabetical order.
+
+Signed-off-by: Cristian Ciocaltea <cristian.ciocaltea@collabora.com>
+Tested-by: Alexandre ARNOUD <aarnoud@me.com>
+Link: https://lore.kernel.org/r/20241211-rk3588-hdmi1-v2-4-02cdca22ff68@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -49,6 +49,17 @@
+ 		};
+ 	};
+ 
++	hdmi1-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi1_con_in: endpoint {
++				remote-endpoint = <&hdmi1_out_con>;
++			};
++		};
++	};
++
+ 	leds {
+ 		compatible = "gpio-leds";
+ 		pinctrl-names = "default";
+@@ -220,10 +231,32 @@
+ 	};
+ };
+ 
++&hdmi1 {
++	pinctrl-0 = <&hdmim0_tx1_cec &hdmim0_tx1_hpd
++		     &hdmim1_tx1_scl &hdmim1_tx1_sda>;
++	status = "okay";
++};
++
++&hdmi1_in {
++	hdmi1_in_vp1: endpoint {
++		remote-endpoint = <&vp1_out_hdmi1>;
++	};
++};
++
++&hdmi1_out {
++	hdmi1_out_con: endpoint {
++		remote-endpoint = <&hdmi1_con_in>;
++	};
++};
++
+ &hdptxphy0 {
+ 	status = "okay";
+ };
+ 
++&hdptxphy1 {
++	status = "okay";
++};
++
+ &i2c0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c0m2_xfer>;
+@@ -887,11 +920,11 @@
+ 	status = "okay";
+ };
+ 
+-&vop_mmu {
++&vop {
+ 	status = "okay";
+ };
+ 
+-&vop {
++&vop_mmu {
+ 	status = "okay";
+ };
+ 
+@@ -901,3 +934,10 @@
+ 		remote-endpoint = <&hdmi0_in_vp0>;
+ 	};
+ };
++
++&vp1 {
++	vp1_out_hdmi1: endpoint@ROCKCHIP_VOP2_EP_HDMI1 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI1>;
++		remote-endpoint = <&hdmi1_in_vp1>;
++	};
++};

--- a/target/linux/rockchip/patches-6.6/052-23-v6.15-arm64-dts-rockchip-Enable-HDMI-audio-outputs-for-Roc.patch
+++ b/target/linux/rockchip/patches-6.6/052-23-v6.15-arm64-dts-rockchip-Enable-HDMI-audio-outputs-for-Roc.patch
@@ -1,0 +1,54 @@
+From 97aa62ed1e970bf8aa9f57e87c946a95fa3d5bef Mon Sep 17 00:00:00 2001
+From: Detlev Casanova <detlev.casanova@collabora.com>
+Date: Mon, 17 Feb 2025 16:47:42 -0500
+Subject: arm64: dts: rockchip: Enable HDMI audio outputs for Rock 5B
+
+HDMI audio is available on the Rock 5B HDMI TX ports.
+Enable it for both ports.
+
+Reviewed-by: Quentin Schulz <quentin.schulz@cherry.de>
+Signed-off-by: Detlev Casanova <detlev.casanova@collabora.com>
+Fixes: 419d1918105e ("ASoC: simple-card-utils: use __free(device_node) for device node")
+Signed-off-by: Kuninori Morimoto <kuninori.morimoto.gx@renesas.com>
+Link: https://lore.kernel.org/r/20250217215641.372723-4-detlev.casanova@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -231,6 +231,10 @@
+ 	};
+ };
+ 
++&hdmi0_sound {
++	status = "okay";
++};
++
+ &hdmi1 {
+ 	pinctrl-0 = <&hdmim0_tx1_cec &hdmim0_tx1_hpd
+ 		     &hdmim1_tx1_scl &hdmim1_tx1_sda>;
+@@ -249,6 +253,10 @@
+ 	};
+ };
+ 
++&hdmi1_sound {
++	status = "okay";
++};
++
+ &hdptxphy0 {
+ 	status = "okay";
+ };
+@@ -351,6 +359,14 @@
+ 	};
+ };
+ 
++&i2s5_8ch {
++	status = "okay";
++};
++
++&i2s6_8ch {
++	status = "okay";
++};
++
+ &package_thermal {
+ 	polling-delay = <1000>;
+ 

--- a/target/linux/rockchip/patches-6.6/052-24-v6.15-arm64-dts-rockchip-Add-GPU-power-domain-regulator-de.patch
+++ b/target/linux/rockchip/patches-6.6/052-24-v6.15-arm64-dts-rockchip-Add-GPU-power-domain-regulator-de.patch
@@ -1,0 +1,48 @@
+From f94500eb7328b35f3d0927635b1aba26c85ea4b0 Mon Sep 17 00:00:00 2001
+From: Sebastian Reichel <sebastian.reichel@collabora.com>
+Date: Thu, 20 Feb 2025 19:58:11 +0100
+Subject: arm64: dts: rockchip: Add GPU power domain regulator dependency for
+ RK3588
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Enabling the GPU power domain requires that the GPU regulator is
+enabled. The regulator is enabled at boot time, but gets disabled
+automatically when there are no users.
+
+This means the system might run into a failure state hanging the
+whole system for the following use cases:
+
+ * if the GPU driver is being probed late (e.g. build as a
+   module and firmware is not in initramfs), the regulator
+   might already have been disabled. In that case the power
+   domain is enabled before the regulator.
+ * unbinding the GPU driver will disable the PM domain and
+   the regulator. When the driver is bound again, the PM
+   domain will be enabled before the regulator and error
+   appears.
+
+Avoid this by adding an explicit regulator dependency to the
+power domain.
+
+Tested-by: Heiko Stuebner <heiko@sntech.de>
+Reported-by: Adrián Martínez Larumbe <adrian.larumbe@collabora.com>
+Tested-by: Adrian Larumbe <adrian.larumbe@collabora.com> # On Rock 5B
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Link: https://lore.kernel.org/r/20250220-rk3588-gpu-pwr-domain-regulator-v6-8-a4f9c24e5b81@kernel.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -425,6 +425,10 @@
+ 	status = "okay";
+ };
+ 
++&pd_gpu {
++	domain-supply = <&vdd_gpu_s0>;
++};
++
+ &pinctrl {
+ 	hym8563 {
+ 		hym8563_int: hym8563-int {

--- a/target/linux/rockchip/patches-6.6/052-25-v6.15-arm64-dts-rockchip-Enable-HDMI-receiver-on-rock-5b.patch
+++ b/target/linux/rockchip/patches-6.6/052-25-v6.15-arm64-dts-rockchip-Enable-HDMI-receiver-on-rock-5b.patch
@@ -1,0 +1,47 @@
+From c62d8fdb27391ee72bfdf53328463813997844f1 Mon Sep 17 00:00:00 2001
+From: Sebastian Reichel <sebastian.reichel@collabora.com>
+Date: Fri, 7 Mar 2025 12:18:57 +0300
+Subject: arm64: dts: rockchip: Enable HDMI receiver on rock-5b
+
+The Rock 5B has a Micro HDMI port, which can be used for receiving
+HDMI data. This enables support for it.
+
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Signed-off-by: Shreeya Patel <shreeya.patel@collabora.com>
+Signed-off-by: Dmitry Osipenko <dmitry.osipenko@collabora.com>
+Link: https://lore.kernel.org/r/20250307091857.646581-3-dmitry.osipenko@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -257,6 +257,17 @@
+ 	status = "okay";
+ };
+ 
++&hdmi_receiver_cma {
++	status = "okay";
++};
++
++&hdmi_receiver {
++	hpd-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
++	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_hpd>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
+ &hdptxphy0 {
+ 	status = "okay";
+ };
+@@ -430,6 +441,12 @@
+ };
+ 
+ &pinctrl {
++	hdmirx {
++		hdmirx_hpd: hdmirx-5v-detection {
++			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	hym8563 {
+ 		hym8563_int: hym8563-int {
+ 			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;

--- a/target/linux/rockchip/patches-6.6/052-26-v6.16-arm64-dts-rockchip-Add-vcc-supply-to-SPI-flash-on-rk.patch
+++ b/target/linux/rockchip/patches-6.6/052-26-v6.16-arm64-dts-rockchip-Add-vcc-supply-to-SPI-flash-on-rk.patch
@@ -1,0 +1,28 @@
+From 425af91c58023a8924cc2330384e040d388adc4e Mon Sep 17 00:00:00 2001
+From: Diederik de Haas <didi.debian@cknow.org>
+Date: Fri, 25 Apr 2025 10:44:44 +0200
+Subject: arm64: dts: rockchip: Add vcc-supply to SPI flash on rk3588-rock-5b
+
+The Radxa Rock 5B component placement document identifies the SPI Nor
+Flash chip as 'U4300' which is described on page 25 of the Schematic
+v1.45. There we can see that the VCC connector is connected to the
+VCC_3V3_S3 power source.
+
+This fixes the following warning:
+
+  spi-nor spi5.0: supply vcc not found, using dummy regulator
+
+Signed-off-by: Diederik de Haas <didi.debian@cknow.org>
+Link: https://lore.kernel.org/r/20250425092601.56549-5-didi.debian@cknow.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -562,6 +562,7 @@
+ 		spi-max-frequency = <104000000>;
+ 		spi-rx-bus-width = <4>;
+ 		spi-tx-bus-width = <1>;
++		vcc-supply = <&vcc_3v3_s3>;
+ 	};
+ };
+ 

--- a/target/linux/rockchip/patches-6.6/052-27-v6.16-arm64-dts-rockchip-move-rock-5b-to-include-file.patch
+++ b/target/linux/rockchip/patches-6.6/052-27-v6.16-arm64-dts-rockchip-move-rock-5b-to-include-file.patch
@@ -1,0 +1,1940 @@
+From aadfbdcf7e1e7f3892e0e4bdcc3c9c7c9adfb723 Mon Sep 17 00:00:00 2001
+From: Sebastian Reichel <sebastian.reichel@collabora.com>
+Date: Thu, 8 May 2025 19:48:50 +0200
+Subject: arm64: dts: rockchip: move rock 5b to include file
+
+Radxa released some more boards, which are based on the original
+Rock 5B. Move its board description into an include file to avoid
+unnecessary duplication.
+
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Link: https://lore.kernel.org/r/20250508-rock5bp-for-upstream-v2-1-677033cc1ac2@kernel.org
+Link: https://lore.kernel.org/r/20250508-rock5bp-for-upstream-v2-2-677033cc1ac2@kernel.org
+
+[The original submission was split into two elements, renaming the file
+ and then moving some nodes around. This was done to make review easier
+ due to the diff being smaller. This commit is a squash of both of them
+ to facilitate bisectability and was also intended by the original author]
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -2,532 +2,11 @@
+ 
+ /dts-v1/;
+ 
+-#include <dt-bindings/gpio/gpio.h>
+-#include <dt-bindings/leds/common.h>
+-#include <dt-bindings/soc/rockchip,vop2.h>
+-#include "rk3588.dtsi"
++#include "rk3588-rock-5b.dtsi"
+ 
+ / {
+ 	model = "Radxa ROCK 5B";
+ 	compatible = "radxa,rock-5b", "rockchip,rk3588";
+-
+-	aliases {
+-		mmc0 = &sdhci;
+-		mmc1 = &sdmmc;
+-		mmc2 = &sdio;
+-	};
+-
+-	chosen {
+-		stdout-path = "serial2:1500000n8";
+-	};
+-
+-	analog-sound {
+-		compatible = "audio-graph-card";
+-		label = "rk3588-es8316";
+-
+-		widgets = "Microphone", "Mic Jack",
+-			  "Headphone", "Headphones";
+-
+-		routing = "MIC2", "Mic Jack",
+-			  "Headphones", "HPOL",
+-			  "Headphones", "HPOR";
+-
+-		dais = <&i2s0_8ch_p0>;
+-		hp-det-gpio = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&hp_detect>;
+-	};
+-
+-	hdmi0-con {
+-		compatible = "hdmi-connector";
+-		type = "a";
+-
+-		port {
+-			hdmi0_con_in: endpoint {
+-				remote-endpoint = <&hdmi0_out_con>;
+-			};
+-		};
+-	};
+-
+-	hdmi1-con {
+-		compatible = "hdmi-connector";
+-		type = "a";
+-
+-		port {
+-			hdmi1_con_in: endpoint {
+-				remote-endpoint = <&hdmi1_out_con>;
+-			};
+-		};
+-	};
+-
+-	leds {
+-		compatible = "gpio-leds";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&led_rgb_b>;
+-
+-		led_rgb_b {
+-			function = LED_FUNCTION_STATUS;
+-			color = <LED_COLOR_ID_BLUE>;
+-			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+-		};
+-	};
+-
+-	fan: pwm-fan {
+-		compatible = "pwm-fan";
+-		cooling-levels = <0 120 150 180 210 240 255>;
+-		fan-supply = <&vcc5v0_sys>;
+-		pwms = <&pwm1 0 50000 0>;
+-		#cooling-cells = <2>;
+-	};
+-
+-	rfkill {
+-		compatible = "rfkill-gpio";
+-		label = "rfkill-m2-wlan";
+-		radio-type = "wlan";
+-		shutdown-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+-	};
+-
+-	rfkill-bt {
+-		compatible = "rfkill-gpio";
+-		label = "rfkill-m2-bt";
+-		radio-type = "bluetooth";
+-		shutdown-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
+-	};
+-
+-	vcc3v3_pcie2x1l0: regulator-vcc3v3-pcie2x1l0 {
+-		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpios = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pcie2_0_vcc3v3_en>;
+-		regulator-name = "vcc3v3_pcie2x1l0";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		startup-delay-us = <50000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+-	vcc3v3_pcie2x1l2: regulator-vcc3v3-pcie2x1l2 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc3v3_pcie2x1l2";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		startup-delay-us = <5000>;
+-		vin-supply = <&vcc_3v3_s3>;
+-	};
+-
+-	vcc3v3_pcie30: regulator-vcc3v3-pcie30 {
+-		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pcie3_vcc3v3_en>;
+-		regulator-name = "vcc3v3_pcie30";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		startup-delay-us = <5000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+-	vcc5v0_host: regulator-vcc5v0-host {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_host";
+-		regulator-boot-on;
+-		regulator-always-on;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-		enable-active-high;
+-		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&vcc5v0_host_en>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+-	vcc5v0_sys: regulator-vcc5v0-sys {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_sys";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-	};
+-
+-	vcc_1v1_nldo_s3: regulator-vcc-1v1-nldo-s3 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc_1v1_nldo_s3";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <1100000>;
+-		regulator-max-microvolt = <1100000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-};
+-
+-&combphy0_ps {
+-	status = "okay";
+-};
+-
+-&combphy1_ps {
+-	status = "okay";
+-};
+-
+-&combphy2_psu {
+-	status = "okay";
+-};
+-
+-&cpu_b0 {
+-	cpu-supply = <&vdd_cpu_big0_s0>;
+-};
+-
+-&cpu_b1 {
+-	cpu-supply = <&vdd_cpu_big0_s0>;
+-};
+-
+-&cpu_b2 {
+-	cpu-supply = <&vdd_cpu_big1_s0>;
+-};
+-
+-&cpu_b3 {
+-	cpu-supply = <&vdd_cpu_big1_s0>;
+-};
+-
+-&cpu_l0 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&cpu_l1 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&cpu_l2 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&cpu_l3 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&gpu {
+-	mali-supply = <&vdd_gpu_s0>;
+-	status = "okay";
+-};
+-
+-&hdmi0 {
+-	status = "okay";
+-};
+-
+-&hdmi0_in {
+-	hdmi0_in_vp0: endpoint {
+-		remote-endpoint = <&vp0_out_hdmi0>;
+-	};
+-};
+-
+-&hdmi0_out {
+-	hdmi0_out_con: endpoint {
+-		remote-endpoint = <&hdmi0_con_in>;
+-	};
+-};
+-
+-&hdmi0_sound {
+-	status = "okay";
+-};
+-
+-&hdmi1 {
+-	pinctrl-0 = <&hdmim0_tx1_cec &hdmim0_tx1_hpd
+-		     &hdmim1_tx1_scl &hdmim1_tx1_sda>;
+-	status = "okay";
+-};
+-
+-&hdmi1_in {
+-	hdmi1_in_vp1: endpoint {
+-		remote-endpoint = <&vp1_out_hdmi1>;
+-	};
+-};
+-
+-&hdmi1_out {
+-	hdmi1_out_con: endpoint {
+-		remote-endpoint = <&hdmi1_con_in>;
+-	};
+-};
+-
+-&hdmi1_sound {
+-	status = "okay";
+-};
+-
+-&hdmi_receiver_cma {
+-	status = "okay";
+-};
+-
+-&hdmi_receiver {
+-	hpd-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
+-	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_hpd>;
+-	pinctrl-names = "default";
+-	status = "okay";
+-};
+-
+-&hdptxphy0 {
+-	status = "okay";
+-};
+-
+-&hdptxphy1 {
+-	status = "okay";
+-};
+-
+-&i2c0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&i2c0m2_xfer>;
+-	status = "okay";
+-
+-	vdd_cpu_big0_s0: regulator@42 {
+-		compatible = "rockchip,rk8602";
+-		reg = <0x42>;
+-		fcs,suspend-voltage-selector = <1>;
+-		regulator-name = "vdd_cpu_big0_s0";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <550000>;
+-		regulator-max-microvolt = <1050000>;
+-		regulator-ramp-delay = <2300>;
+-		vin-supply = <&vcc5v0_sys>;
+-
+-		regulator-state-mem {
+-			regulator-off-in-suspend;
+-		};
+-	};
+-
+-	vdd_cpu_big1_s0: regulator@43 {
+-		compatible = "rockchip,rk8603", "rockchip,rk8602";
+-		reg = <0x43>;
+-		fcs,suspend-voltage-selector = <1>;
+-		regulator-name = "vdd_cpu_big1_s0";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <550000>;
+-		regulator-max-microvolt = <1050000>;
+-		regulator-ramp-delay = <2300>;
+-		vin-supply = <&vcc5v0_sys>;
+-
+-		regulator-state-mem {
+-			regulator-off-in-suspend;
+-		};
+-	};
+-};
+-
+-&i2c6 {
+-	status = "okay";
+-
+-	hym8563: rtc@51 {
+-		compatible = "haoyu,hym8563";
+-		reg = <0x51>;
+-		#clock-cells = <0>;
+-		clock-output-names = "hym8563";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&hym8563_int>;
+-		interrupt-parent = <&gpio0>;
+-		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
+-		wakeup-source;
+-	};
+-};
+-
+-&i2c7 {
+-	status = "okay";
+-
+-	es8316: audio-codec@11 {
+-		compatible = "everest,es8316";
+-		reg = <0x11>;
+-		clocks = <&cru I2S0_8CH_MCLKOUT>;
+-		clock-names = "mclk";
+-		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
+-		assigned-clock-rates = <12288000>;
+-		#sound-dai-cells = <0>;
+-
+-		port {
+-			es8316_p0_0: endpoint {
+-				remote-endpoint = <&i2s0_8ch_p0_0>;
+-			};
+-		};
+-	};
+-};
+-
+-&i2s0_8ch {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&i2s0_lrck
+-		     &i2s0_mclk
+-		     &i2s0_sclk
+-		     &i2s0_sdi0
+-		     &i2s0_sdo0>;
+-	status = "okay";
+-
+-	i2s0_8ch_p0: port {
+-		i2s0_8ch_p0_0: endpoint {
+-			dai-format = "i2s";
+-			mclk-fs = <256>;
+-			remote-endpoint = <&es8316_p0_0>;
+-		};
+-	};
+-};
+-
+-&i2s5_8ch {
+-	status = "okay";
+-};
+-
+-&i2s6_8ch {
+-	status = "okay";
+-};
+-
+-&package_thermal {
+-	polling-delay = <1000>;
+-
+-	trips {
+-		package_fan0: package-fan0 {
+-			temperature = <55000>;
+-			hysteresis = <2000>;
+-			type = "active";
+-		};
+-
+-		package_fan1: package-fan1 {
+-			temperature = <65000>;
+-			hysteresis = <2000>;
+-			type = "active";
+-		};
+-	};
+-
+-	cooling-maps {
+-		map0 {
+-			trip = <&package_fan0>;
+-			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
+-		};
+-
+-		map1 {
+-			trip = <&package_fan1>;
+-			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
+-		};
+-	};
+-};
+-
+-&pcie2x1l0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pcie2_0_rst>;
+-	reset-gpios = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc3v3_pcie2x1l0>;
+-	status = "okay";
+-};
+-
+-&pcie2x1l2 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pcie2_2_rst>;
+-	reset-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc3v3_pcie2x1l2>;
+-	status = "okay";
+-};
+-
+-&pcie30phy {
+-	status = "okay";
+-};
+-
+-&pcie3x4 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pcie3_rst>;
+-	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc3v3_pcie30>;
+-	status = "okay";
+-};
+-
+-&pd_gpu {
+-	domain-supply = <&vdd_gpu_s0>;
+-};
+-
+-&pinctrl {
+-	hdmirx {
+-		hdmirx_hpd: hdmirx-5v-detection {
+-			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	hym8563 {
+-		hym8563_int: hym8563-int {
+-			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	leds {
+-		led_rgb_b: led-rgb-b {
+-			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	sound {
+-		hp_detect: hp-detect {
+-			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	pcie2 {
+-		pcie2_0_rst: pcie2-0-rst {
+-			rockchip,pins = <4 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		pcie2_0_vcc3v3_en: pcie2-0-vcc-en {
+-			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		pcie2_2_rst: pcie2-2-rst {
+-			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	pcie3 {
+-		pcie3_rst: pcie3-rst {
+-			rockchip,pins = <4 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		pcie3_vcc3v3_en: pcie3-vcc3v3-en {
+-			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	usb {
+-		vcc5v0_host_en: vcc5v0-host-en {
+-			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-};
+-
+-&pwm1 {
+-	status = "okay";
+-};
+-
+-&saradc {
+-	vref-supply = <&avcc_1v8_s0>;
+-	status = "okay";
+-};
+-
+-&sdhci {
+-	bus-width = <8>;
+-	no-sdio;
+-	no-sd;
+-	non-removable;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
+-	status = "okay";
+-};
+-
+-&sdmmc {
+-	max-frequency = <200000000>;
+-	no-sdio;
+-	no-mmc;
+-	bus-width = <4>;
+-	cap-mmc-highspeed;
+-	cap-sd-highspeed;
+-	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+-	disable-wp;
+-	sd-uhs-sdr104;
+-	vmmc-supply = <&vcc_3v3_s3>;
+-	vqmmc-supply = <&vccio_sd_s0>;
+-	status = "okay";
+ };
+ 
+ &sdio {
+@@ -551,431 +30,23 @@
+ 	status = "okay";
+ };
+ 
+-&sfc {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&fspim2_pins>;
+-	status = "okay";
+-
+-	flash@0 {
+-		compatible = "jedec,spi-nor";
+-		reg = <0>;
+-		spi-max-frequency = <104000000>;
+-		spi-rx-bus-width = <4>;
+-		spi-tx-bus-width = <1>;
+-		vcc-supply = <&vcc_3v3_s3>;
+-	};
+-};
+-
+ &uart6 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&uart6m1_xfer &uart6m1_ctsn &uart6m1_rtsn>;
+ 	status = "okay";
+ };
+ 
+-&spi2 {
+-	status = "okay";
+-	assigned-clocks = <&cru CLK_SPI2>;
+-	assigned-clock-rates = <200000000>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
+-	num-cs = <1>;
+-
+-	pmic@0 {
+-		compatible = "rockchip,rk806";
+-		spi-max-frequency = <1000000>;
+-		reg = <0x0>;
+-
+-		interrupt-parent = <&gpio0>;
+-		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
+-
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
+-			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
+-
+-		system-power-controller;
+-
+-		vcc1-supply = <&vcc5v0_sys>;
+-		vcc2-supply = <&vcc5v0_sys>;
+-		vcc3-supply = <&vcc5v0_sys>;
+-		vcc4-supply = <&vcc5v0_sys>;
+-		vcc5-supply = <&vcc5v0_sys>;
+-		vcc6-supply = <&vcc5v0_sys>;
+-		vcc7-supply = <&vcc5v0_sys>;
+-		vcc8-supply = <&vcc5v0_sys>;
+-		vcc9-supply = <&vcc5v0_sys>;
+-		vcc10-supply = <&vcc5v0_sys>;
+-		vcc11-supply = <&vcc_2v0_pldo_s3>;
+-		vcc12-supply = <&vcc5v0_sys>;
+-		vcc13-supply = <&vcc_1v1_nldo_s3>;
+-		vcc14-supply = <&vcc_1v1_nldo_s3>;
+-		vcca-supply = <&vcc5v0_sys>;
+-
+-		gpio-controller;
+-		#gpio-cells = <2>;
+-
+-		rk806_dvs1_null: dvs1-null-pins {
+-			pins = "gpio_pwrctrl1";
+-			function = "pin_fun0";
+-		};
+-
+-		rk806_dvs2_null: dvs2-null-pins {
+-			pins = "gpio_pwrctrl2";
+-			function = "pin_fun0";
+-		};
+-
+-		rk806_dvs3_null: dvs3-null-pins {
+-			pins = "gpio_pwrctrl3";
+-			function = "pin_fun0";
+-		};
+-
+-		regulators {
+-			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
+-				regulator-boot-on;
+-				regulator-min-microvolt = <550000>;
+-				regulator-max-microvolt = <950000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_gpu_s0";
+-				regulator-enable-ramp-delay = <400>;
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: dcdc-reg2 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <550000>;
+-				regulator-max-microvolt = <950000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_cpu_lit_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_log_s0: dcdc-reg3 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <675000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_log_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <750000>;
+-				};
+-			};
+-
+-			vdd_vdenc_s0: vdd_vdenc_mem_s0: dcdc-reg4 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <550000>;
+-				regulator-max-microvolt = <950000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_vdenc_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_ddr_s0: dcdc-reg5 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <675000>;
+-				regulator-max-microvolt = <900000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_ddr_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <850000>;
+-				};
+-			};
+-
+-			vdd2_ddr_s3: dcdc-reg6 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-name = "vdd2_ddr_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-				};
+-			};
+-
+-			vcc_2v0_pldo_s3: dcdc-reg7 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <2000000>;
+-				regulator-max-microvolt = <2000000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_2v0_pldo_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <2000000>;
+-				};
+-			};
+-
+-			vcc_3v3_s3: dcdc-reg8 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <3300000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-name = "vcc_3v3_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
+-				};
+-			};
+-
+-			vddq_ddr_s0: dcdc-reg9 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-name = "vddq_ddr_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vcc_1v8_s3: dcdc-reg10 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "vcc_1v8_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <1800000>;
+-				};
+-			};
+-
+-			avcc_1v8_s0: pldo-reg1 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "avcc_1v8_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vcc_1v8_s0: pldo-reg2 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "vcc_1v8_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <1800000>;
+-				};
+-			};
+-
+-			avdd_1v2_s0: pldo-reg3 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1200000>;
+-				regulator-max-microvolt = <1200000>;
+-				regulator-name = "avdd_1v2_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vcc_3v3_s0: pldo-reg4 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <3300000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vcc_3v3_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vccio_sd_s0: pldo-reg5 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vccio_sd_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			pldo6_s3: pldo-reg6 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "pldo6_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <1800000>;
+-				};
+-			};
+-
+-			vdd_0v75_s3: nldo-reg1 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <750000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-name = "vdd_0v75_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <750000>;
+-				};
+-			};
+-
+-			vdd_ddr_pll_s0: nldo-reg2 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <850000>;
+-				regulator-max-microvolt = <850000>;
+-				regulator-name = "vdd_ddr_pll_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <850000>;
+-				};
+-			};
+-
+-			avdd_0v75_s0: nldo-reg3 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <750000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-name = "avdd_0v75_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_0v85_s0: nldo-reg4 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <850000>;
+-				regulator-max-microvolt = <850000>;
+-				regulator-name = "vdd_0v85_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_0v75_s0: nldo-reg5 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <750000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-name = "vdd_0v75_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
++&pinctrl {
++	usb {
++		vcc5v0_host_en: vcc5v0-host-en {
++			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ };
+ 
+-&uart2 {
+-	pinctrl-0 = <&uart2m0_xfer>;
+-	status = "okay";
+-};
+-
+-&u2phy1 {
+-	status = "okay";
+-};
+-
+-&u2phy1_otg {
+-	status = "okay";
+-};
+-
+-&u2phy2 {
+-	status = "okay";
+-};
+-
+-&u2phy2_host {
+-	/* connected to USB hub, which is powered by vcc5v0_sys */
+-	phy-supply = <&vcc5v0_sys>;
+-	status = "okay";
+-};
+-
+-&u2phy3 {
+-	status = "okay";
+-};
+-
+-&u2phy3_host {
+-	phy-supply = <&vcc5v0_host>;
+-	status = "okay";
+-};
+-
+-&usbdp_phy1 {
+-	status = "okay";
+-};
+-
+-&usb_host0_ehci {
+-	status = "okay";
+-};
+-
+-&usb_host0_ohci {
+-	status = "okay";
+-};
+-
+-&usb_host1_ehci {
+-	status = "okay";
+-};
+-
+-&usb_host1_ohci {
+-	status = "okay";
+-};
+-
+-&usb_host1_xhci {
+-	dr_mode = "host";
+-	status = "okay";
+-};
+-
+-&usb_host2_xhci {
+-	status = "okay";
+-};
+-
+-&vop {
+-	status = "okay";
+-};
+-
+-&vop_mmu {
+-	status = "okay";
+-};
+-
+-&vp0 {
+-	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
+-		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
+-		remote-endpoint = <&hdmi0_in_vp0>;
+-	};
+-};
+-
+-&vp1 {
+-	vp1_out_hdmi1: endpoint@ROCKCHIP_VOP2_EP_HDMI1 {
+-		reg = <ROCKCHIP_VOP2_EP_HDMI1>;
+-		remote-endpoint = <&hdmi1_in_vp1>;
+-	};
++&vcc5v0_host {
++	enable-active-high;
++	gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&vcc5v0_host_en>;
+ };
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dtsi
+@@ -0,0 +1,941 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/soc/rockchip,vop2.h>
++#include "rk3588.dtsi"
++
++/ {
++	aliases {
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc;
++		mmc2 = &sdio;
++	};
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	analog-sound {
++		compatible = "audio-graph-card";
++		label = "rk3588-es8316";
++
++		widgets = "Microphone", "Mic Jack",
++			  "Headphone", "Headphones";
++
++		routing = "MIC2", "Mic Jack",
++			  "Headphones", "HPOL",
++			  "Headphones", "HPOR";
++
++		dais = <&i2s0_8ch_p0>;
++		hp-det-gpio = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&hp_detect>;
++	};
++
++	hdmi0-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi0_con_in: endpoint {
++				remote-endpoint = <&hdmi0_out_con>;
++			};
++		};
++	};
++
++	hdmi1-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi1_con_in: endpoint {
++				remote-endpoint = <&hdmi1_out_con>;
++			};
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&led_rgb_b>;
++
++		led_rgb_b {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_BLUE>;
++			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		cooling-levels = <0 120 150 180 210 240 255>;
++		fan-supply = <&vcc5v0_sys>;
++		pwms = <&pwm1 0 50000 0>;
++		#cooling-cells = <2>;
++	};
++
++	rfkill {
++		compatible = "rfkill-gpio";
++		label = "rfkill-m2-wlan";
++		radio-type = "wlan";
++		shutdown-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++	};
++
++	rfkill-bt {
++		compatible = "rfkill-gpio";
++		label = "rfkill-m2-bt";
++		radio-type = "bluetooth";
++		shutdown-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
++	};
++
++	vcc3v3_pcie2x1l0: regulator-vcc3v3-pcie2x1l0 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie2_0_vcc3v3_en>;
++		regulator-name = "vcc3v3_pcie2x1l0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <50000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc3v3_pcie2x1l2: regulator-vcc3v3-pcie2x1l2 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie2x1l2";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <5000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
++	vcc3v3_pcie30: regulator-vcc3v3-pcie30 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie3_vcc3v3_en>;
++		regulator-name = "vcc3v3_pcie30";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <5000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc5v0_host: regulator-vcc5v0-host {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_host";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc5v0_sys: regulator-vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_1v1_nldo_s3: regulator-vcc-1v1-nldo-s3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_1v1_nldo_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1100000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&combphy0_ps {
++	status = "okay";
++};
++
++&combphy1_ps {
++	status = "okay";
++};
++
++&combphy2_psu {
++	status = "okay";
++};
++
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b1 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b2 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_b3 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l1 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l2 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l3 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	status = "okay";
++};
++
++&hdmi0 {
++	status = "okay";
++};
++
++&hdmi0_in {
++	hdmi0_in_vp0: endpoint {
++		remote-endpoint = <&vp0_out_hdmi0>;
++	};
++};
++
++&hdmi0_out {
++	hdmi0_out_con: endpoint {
++		remote-endpoint = <&hdmi0_con_in>;
++	};
++};
++
++&hdmi0_sound {
++	status = "okay";
++};
++
++&hdmi1 {
++	pinctrl-0 = <&hdmim0_tx1_cec &hdmim0_tx1_hpd
++		     &hdmim1_tx1_scl &hdmim1_tx1_sda>;
++	status = "okay";
++};
++
++&hdmi1_in {
++	hdmi1_in_vp1: endpoint {
++		remote-endpoint = <&vp1_out_hdmi1>;
++	};
++};
++
++&hdmi1_out {
++	hdmi1_out_con: endpoint {
++		remote-endpoint = <&hdmi1_con_in>;
++	};
++};
++
++&hdmi1_sound {
++	status = "okay";
++};
++
++&hdmi_receiver_cma {
++	status = "okay";
++};
++
++&hdmi_receiver {
++	hpd-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
++	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_hpd>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&hdptxphy0 {
++	status = "okay";
++};
++
++&hdptxphy1 {
++	status = "okay";
++};
++
++&i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c0m2_xfer>;
++	status = "okay";
++
++	vdd_cpu_big0_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big0_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc5v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_cpu_big1_s0: regulator@43 {
++		compatible = "rockchip,rk8603", "rockchip,rk8602";
++		reg = <0x43>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big1_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc5v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c6 {
++	status = "okay";
++
++	hym8563: rtc@51 {
++		compatible = "haoyu,hym8563";
++		reg = <0x51>;
++		#clock-cells = <0>;
++		clock-output-names = "hym8563";
++		pinctrl-names = "default";
++		pinctrl-0 = <&hym8563_int>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
++		wakeup-source;
++	};
++};
++
++&i2c7 {
++	status = "okay";
++
++	es8316: audio-codec@11 {
++		compatible = "everest,es8316";
++		reg = <0x11>;
++		clocks = <&cru I2S0_8CH_MCLKOUT>;
++		clock-names = "mclk";
++		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
++		assigned-clock-rates = <12288000>;
++		#sound-dai-cells = <0>;
++
++		port {
++			es8316_p0_0: endpoint {
++				remote-endpoint = <&i2s0_8ch_p0_0>;
++			};
++		};
++	};
++};
++
++&i2s0_8ch {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s0_lrck
++		     &i2s0_mclk
++		     &i2s0_sclk
++		     &i2s0_sdi0
++		     &i2s0_sdo0>;
++	status = "okay";
++
++	i2s0_8ch_p0: port {
++		i2s0_8ch_p0_0: endpoint {
++			dai-format = "i2s";
++			mclk-fs = <256>;
++			remote-endpoint = <&es8316_p0_0>;
++		};
++	};
++};
++
++&i2s5_8ch {
++	status = "okay";
++};
++
++&i2s6_8ch {
++	status = "okay";
++};
++
++&package_thermal {
++	polling-delay = <1000>;
++
++	trips {
++		package_fan0: package-fan0 {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		package_fan1: package-fan1 {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map0 {
++			trip = <&package_fan0>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map1 {
++			trip = <&package_fan1>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&pcie2x1l0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie2_0_rst>;
++	reset-gpios = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie2x1l0>;
++	status = "okay";
++};
++
++&pcie2x1l2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie2_2_rst>;
++	reset-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie2x1l2>;
++	status = "okay";
++};
++
++&pcie30phy {
++	status = "okay";
++};
++
++&pcie3x4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie3_rst>;
++	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++};
++
++&pd_gpu {
++	domain-supply = <&vdd_gpu_s0>;
++};
++
++&pinctrl {
++	hdmirx {
++		hdmirx_hpd: hdmirx-5v-detection {
++			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	hym8563 {
++		hym8563_int: hym8563-int {
++			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	leds {
++		led_rgb_b: led-rgb-b {
++			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	sound {
++		hp_detect: hp-detect {
++			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie2 {
++		pcie2_0_rst: pcie2-0-rst {
++			rockchip,pins = <4 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie2_0_vcc3v3_en: pcie2-0-vcc-en {
++			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie2_2_rst: pcie2-2-rst {
++			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie3 {
++		pcie3_rst: pcie3-rst {
++			rockchip,pins = <4 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie3_vcc3v3_en: pcie3-vcc3v3-en {
++			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&pwm1 {
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&avcc_1v8_s0>;
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	no-sdio;
++	no-sd;
++	non-removable;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	status = "okay";
++};
++
++&sdmmc {
++	max-frequency = <200000000>;
++	no-sdio;
++	no-mmc;
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
++	disable-wp;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_3v3_s3>;
++	vqmmc-supply = <&vccio_sd_s0>;
++	status = "okay";
++};
++
++&sfc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspim2_pins>;
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <104000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++		vcc-supply = <&vcc_3v3_s3>;
++	};
++};
++
++&spi2 {
++	status = "okay";
++	assigned-clocks = <&cru CLK_SPI2>;
++	assigned-clock-rates = <200000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
++	num-cs = <1>;
++
++	pmic@0 {
++		compatible = "rockchip,rk806";
++		spi-max-frequency = <1000000>;
++		reg = <0x0>;
++
++		interrupt-parent = <&gpio0>;
++		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
++			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++
++		system-power-controller;
++
++		vcc1-supply = <&vcc5v0_sys>;
++		vcc2-supply = <&vcc5v0_sys>;
++		vcc3-supply = <&vcc5v0_sys>;
++		vcc4-supply = <&vcc5v0_sys>;
++		vcc5-supply = <&vcc5v0_sys>;
++		vcc6-supply = <&vcc5v0_sys>;
++		vcc7-supply = <&vcc5v0_sys>;
++		vcc8-supply = <&vcc5v0_sys>;
++		vcc9-supply = <&vcc5v0_sys>;
++		vcc10-supply = <&vcc5v0_sys>;
++		vcc11-supply = <&vcc_2v0_pldo_s3>;
++		vcc12-supply = <&vcc5v0_sys>;
++		vcc13-supply = <&vcc_1v1_nldo_s3>;
++		vcc14-supply = <&vcc_1v1_nldo_s3>;
++		vcca-supply = <&vcc5v0_sys>;
++
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		rk806_dvs1_null: dvs1-null-pins {
++			pins = "gpio_pwrctrl1";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs2_null: dvs2-null-pins {
++			pins = "gpio_pwrctrl2";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs3_null: dvs3-null-pins {
++			pins = "gpio_pwrctrl3";
++			function = "pin_fun0";
++		};
++
++		regulators {
++			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_gpu_s0";
++				regulator-enable-ramp-delay = <400>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: dcdc-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_cpu_lit_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_log_s0: dcdc-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_log_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_vdenc_s0: vdd_vdenc_mem_s0: dcdc-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_vdenc_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_ddr_s0: dcdc-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <900000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_ddr_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdd2_ddr_s3: dcdc-reg6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vdd2_ddr_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_2v0_pldo_s3: dcdc-reg7 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <2000000>;
++				regulator-max-microvolt = <2000000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_2v0_pldo_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <2000000>;
++				};
++			};
++
++			vcc_3v3_s3: dcdc-reg8 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc_3v3_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vddq_ddr_s0: dcdc-reg9 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vddq_ddr_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s3: dcdc-reg10 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avcc_1v8_s0: pldo-reg1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "avcc_1v8_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s0: pldo-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avdd_1v2_s0: pldo-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++				regulator-name = "avdd_1v2_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_3v3_s0: pldo-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vcc_3v3_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vccio_sd_s0: pldo-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vccio_sd_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			pldo6_s3: pldo-reg6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "pldo6_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_0v75_s3: nldo-reg1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_ddr_pll_s0: nldo-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_ddr_pll_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			avdd_0v75_s0: nldo-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "avdd_0v75_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v85_s0: nldo-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_0v85_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v75_s0: nldo-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++};
++
++&uart2 {
++	pinctrl-0 = <&uart2m0_xfer>;
++	status = "okay";
++};
++
++&u2phy1 {
++	status = "okay";
++};
++
++&u2phy1_otg {
++	status = "okay";
++};
++
++&u2phy2 {
++	status = "okay";
++};
++
++&u2phy2_host {
++	/* connected to USB hub, which is powered by vcc5v0_sys */
++	phy-supply = <&vcc5v0_sys>;
++	status = "okay";
++};
++
++&u2phy3 {
++	status = "okay";
++};
++
++&u2phy3_host {
++	phy-supply = <&vcc5v0_host>;
++	status = "okay";
++};
++
++&usbdp_phy1 {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usb_host1_xhci {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usb_host2_xhci {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vp0 {
++	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
++		remote-endpoint = <&hdmi0_in_vp0>;
++	};
++};
++
++&vp1 {
++	vp1_out_hdmi1: endpoint@ROCKCHIP_VOP2_EP_HDMI1 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI1>;
++		remote-endpoint = <&hdmi1_in_vp1>;
++	};
++};

--- a/target/linux/rockchip/patches-6.6/052-28-v6.16-arm64-dts-rockchip-add-Rock-5B.patch
+++ b/target/linux/rockchip/patches-6.6/052-28-v6.16-arm64-dts-rockchip-add-Rock-5B.patch
@@ -1,0 +1,149 @@
+From 376cb9696298df2028afb620a9dc6c4b10a18605 Mon Sep 17 00:00:00 2001
+From: Sebastian Reichel <sebastian.reichel@collabora.com>
+Date: Thu, 8 May 2025 19:48:53 +0200
+Subject: arm64: dts: rockchip: add Rock 5B+
+
+Add ROCK 5B+, which is an improved version of the ROCK 5B with the
+following changes:
+
+ * Memory LPDDR4X -> LPDDR5
+ * HDMI input connector size
+ * eMMC socket -> onboard
+ * M.2 E-Key is replaced by onboard RTL8852BE WLAN/BT
+ * M.2 M-Key 1x4 lanes is replaced by 2x2 lanes
+ * Added M.2 B-Key for USB connected WWAN modules (untested)
+ * Add second camera port (not yet supported in upstream Linux)
+ * Add dedicated USB-C port for device power (no impact in DT;
+   the existing port has not been changed and the new port is
+   handled by CH224D standalone chip)
+
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Link: https://lore.kernel.org/r/20250508-rock5bp-for-upstream-v2-4-677033cc1ac2@kernel.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -108,6 +108,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-ed
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-evb1-v10.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-nanopc-t6.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5b.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5b-plus.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-indiedroid-nova.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-khadas-edge2.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-rock-5a.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
+@@ -0,0 +1,113 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include "rk3588-rock-5b.dtsi"
++
++/ {
++	model = "Radxa ROCK 5B+";
++	compatible = "radxa,rock-5b-plus", "rockchip,rk3588";
++
++	rfkill-wwan {
++		compatible = "rfkill-gpio";
++		label = "rfkill-m2-wwan";
++		radio-type = "wwan";
++		shutdown-gpios = <&gpio3 RK_PA6 GPIO_ACTIVE_HIGH>;
++	};
++
++	vcc3v3_4g: regulator-vcc3v3-4g {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
++		/* pinctrl for the GPIO is requested by vcc3v3_pcie2x1l0 */
++		regulator-name = "vcc3v3_4g";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <50000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc3v3_wwan_pwr: regulator-vcc3v3-wwan {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <&gpio2 RK_PB1 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&wwan_power_en>;
++		regulator-name = "vcc3v3_wwan_pwr";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc3v3_4g>;
++	};
++};
++
++&gpio0 {
++	wwan-disable2-n-hog {
++		gpios = <RK_PB2 GPIO_ACTIVE_LOW>;
++		output-low;
++		line-name = "M.2 B-key W_DISABLE2#";
++		gpio-hog;
++	};
++};
++
++&gpio2 {
++	wwan-reset-n-hog {
++		gpios = <RK_PB3 GPIO_ACTIVE_LOW>;
++		output-low;
++		line-name = "M.2 B-key RESET#";
++		gpio-hog;
++	};
++
++	wwan-wake-n-hog {
++		gpios = <RK_PB2 GPIO_ACTIVE_LOW>;
++		input;
++		line-name = "M.2 B-key WoWWAN#";
++		gpio-hog;
++	};
++};
++
++&pcie30phy {
++	data-lanes = <1 1 2 2>;
++};
++
++&pcie3x2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie3x2_rst>;
++	reset-gpios = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++};
++
++&pcie3x4 {
++	num-lanes = <2>;
++};
++
++&pinctrl {
++	wwan {
++		wwan_power_en: wwan-pwr-en {
++			rockchip,pins = <2 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie3 {
++		pcie3x2_rst: pcie3x2-rst {
++			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb {
++		vcc5v0_host_en: vcc5v0-host-en {
++			rockchip,pins = <1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&vcc5v0_host {
++	enable-active-high;
++	gpio = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&vcc5v0_host_en>;
++};

--- a/target/linux/rockchip/patches-6.6/052-29-v6.17-arm64-dts-rockchip-rename-rk3588-rock-5b.dtsi.patch
+++ b/target/linux/rockchip/patches-6.6/052-29-v6.17-arm64-dts-rockchip-rename-rk3588-rock-5b.dtsi.patch
@@ -1,0 +1,1926 @@
+From 8b76abf78321ea3361c01e849c8dc3a6793c05d6 Mon Sep 17 00:00:00 2001
+From: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
+Date: Tue, 20 May 2025 20:50:09 +0200
+Subject: arm64: dts: rockchip: rename rk3588-rock-5b.dtsi
+
+As subsequent patches will add ROCK 5T support, rename the .dtsi file to
+reflect that it's shared between ROCK 5B, ROCK 5B+ and ROCK 5T.
+
+This is done separately from moving the 5B and 5B+ only nodes to a
+common tree so that the history stays bisectable and the diff easily
+reviewable.
+
+Signed-off-by: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
+Link: https://lore.kernel.org/r/20250520-add-rock5t-v2-2-1f1971850a20@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
+@@ -2,7 +2,7 @@
+ 
+ /dts-v1/;
+ 
+-#include "rk3588-rock-5b.dtsi"
++#include "rk3588-rock-5b-5bp-5t.dtsi"
+ 
+ / {
+ 	model = "Radxa ROCK 5B+";
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -2,7 +2,7 @@
+ 
+ /dts-v1/;
+ 
+-#include "rk3588-rock-5b.dtsi"
++#include "rk3588-rock-5b-5bp-5t.dtsi"
+ 
+ / {
+ 	model = "Radxa ROCK 5B";
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
+@@ -0,0 +1,941 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/soc/rockchip,vop2.h>
++#include "rk3588.dtsi"
++
++/ {
++	aliases {
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc;
++		mmc2 = &sdio;
++	};
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	analog-sound {
++		compatible = "audio-graph-card";
++		label = "rk3588-es8316";
++
++		widgets = "Microphone", "Mic Jack",
++			  "Headphone", "Headphones";
++
++		routing = "MIC2", "Mic Jack",
++			  "Headphones", "HPOL",
++			  "Headphones", "HPOR";
++
++		dais = <&i2s0_8ch_p0>;
++		hp-det-gpio = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&hp_detect>;
++	};
++
++	hdmi0-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi0_con_in: endpoint {
++				remote-endpoint = <&hdmi0_out_con>;
++			};
++		};
++	};
++
++	hdmi1-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi1_con_in: endpoint {
++				remote-endpoint = <&hdmi1_out_con>;
++			};
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&led_rgb_b>;
++
++		led_rgb_b {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_BLUE>;
++			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		cooling-levels = <0 120 150 180 210 240 255>;
++		fan-supply = <&vcc5v0_sys>;
++		pwms = <&pwm1 0 50000 0>;
++		#cooling-cells = <2>;
++	};
++
++	rfkill {
++		compatible = "rfkill-gpio";
++		label = "rfkill-m2-wlan";
++		radio-type = "wlan";
++		shutdown-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++	};
++
++	rfkill-bt {
++		compatible = "rfkill-gpio";
++		label = "rfkill-m2-bt";
++		radio-type = "bluetooth";
++		shutdown-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
++	};
++
++	vcc3v3_pcie2x1l0: regulator-vcc3v3-pcie2x1l0 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie2_0_vcc3v3_en>;
++		regulator-name = "vcc3v3_pcie2x1l0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <50000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc3v3_pcie2x1l2: regulator-vcc3v3-pcie2x1l2 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie2x1l2";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <5000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
++	vcc3v3_pcie30: regulator-vcc3v3-pcie30 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie3_vcc3v3_en>;
++		regulator-name = "vcc3v3_pcie30";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <5000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc5v0_host: regulator-vcc5v0-host {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_host";
++		regulator-boot-on;
++		regulator-always-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc5v0_sys: regulator-vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_1v1_nldo_s3: regulator-vcc-1v1-nldo-s3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_1v1_nldo_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1100000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&combphy0_ps {
++	status = "okay";
++};
++
++&combphy1_ps {
++	status = "okay";
++};
++
++&combphy2_psu {
++	status = "okay";
++};
++
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b1 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b2 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_b3 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l1 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l2 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l3 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	status = "okay";
++};
++
++&hdmi0 {
++	status = "okay";
++};
++
++&hdmi0_in {
++	hdmi0_in_vp0: endpoint {
++		remote-endpoint = <&vp0_out_hdmi0>;
++	};
++};
++
++&hdmi0_out {
++	hdmi0_out_con: endpoint {
++		remote-endpoint = <&hdmi0_con_in>;
++	};
++};
++
++&hdmi0_sound {
++	status = "okay";
++};
++
++&hdmi1 {
++	pinctrl-0 = <&hdmim0_tx1_cec &hdmim0_tx1_hpd
++		     &hdmim1_tx1_scl &hdmim1_tx1_sda>;
++	status = "okay";
++};
++
++&hdmi1_in {
++	hdmi1_in_vp1: endpoint {
++		remote-endpoint = <&vp1_out_hdmi1>;
++	};
++};
++
++&hdmi1_out {
++	hdmi1_out_con: endpoint {
++		remote-endpoint = <&hdmi1_con_in>;
++	};
++};
++
++&hdmi1_sound {
++	status = "okay";
++};
++
++&hdmi_receiver_cma {
++	status = "okay";
++};
++
++&hdmi_receiver {
++	hpd-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
++	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_hpd>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&hdptxphy0 {
++	status = "okay";
++};
++
++&hdptxphy1 {
++	status = "okay";
++};
++
++&i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c0m2_xfer>;
++	status = "okay";
++
++	vdd_cpu_big0_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big0_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc5v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_cpu_big1_s0: regulator@43 {
++		compatible = "rockchip,rk8603", "rockchip,rk8602";
++		reg = <0x43>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big1_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc5v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c6 {
++	status = "okay";
++
++	hym8563: rtc@51 {
++		compatible = "haoyu,hym8563";
++		reg = <0x51>;
++		#clock-cells = <0>;
++		clock-output-names = "hym8563";
++		pinctrl-names = "default";
++		pinctrl-0 = <&hym8563_int>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
++		wakeup-source;
++	};
++};
++
++&i2c7 {
++	status = "okay";
++
++	es8316: audio-codec@11 {
++		compatible = "everest,es8316";
++		reg = <0x11>;
++		clocks = <&cru I2S0_8CH_MCLKOUT>;
++		clock-names = "mclk";
++		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
++		assigned-clock-rates = <12288000>;
++		#sound-dai-cells = <0>;
++
++		port {
++			es8316_p0_0: endpoint {
++				remote-endpoint = <&i2s0_8ch_p0_0>;
++			};
++		};
++	};
++};
++
++&i2s0_8ch {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s0_lrck
++		     &i2s0_mclk
++		     &i2s0_sclk
++		     &i2s0_sdi0
++		     &i2s0_sdo0>;
++	status = "okay";
++
++	i2s0_8ch_p0: port {
++		i2s0_8ch_p0_0: endpoint {
++			dai-format = "i2s";
++			mclk-fs = <256>;
++			remote-endpoint = <&es8316_p0_0>;
++		};
++	};
++};
++
++&i2s5_8ch {
++	status = "okay";
++};
++
++&i2s6_8ch {
++	status = "okay";
++};
++
++&package_thermal {
++	polling-delay = <1000>;
++
++	trips {
++		package_fan0: package-fan0 {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		package_fan1: package-fan1 {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map0 {
++			trip = <&package_fan0>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map1 {
++			trip = <&package_fan1>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&pcie2x1l0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie2_0_rst>;
++	reset-gpios = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie2x1l0>;
++	status = "okay";
++};
++
++&pcie2x1l2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie2_2_rst>;
++	reset-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie2x1l2>;
++	status = "okay";
++};
++
++&pcie30phy {
++	status = "okay";
++};
++
++&pcie3x4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie3_rst>;
++	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++};
++
++&pd_gpu {
++	domain-supply = <&vdd_gpu_s0>;
++};
++
++&pinctrl {
++	hdmirx {
++		hdmirx_hpd: hdmirx-5v-detection {
++			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	hym8563 {
++		hym8563_int: hym8563-int {
++			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	leds {
++		led_rgb_b: led-rgb-b {
++			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	sound {
++		hp_detect: hp-detect {
++			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie2 {
++		pcie2_0_rst: pcie2-0-rst {
++			rockchip,pins = <4 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie2_0_vcc3v3_en: pcie2-0-vcc-en {
++			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie2_2_rst: pcie2-2-rst {
++			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie3 {
++		pcie3_rst: pcie3-rst {
++			rockchip,pins = <4 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie3_vcc3v3_en: pcie3-vcc3v3-en {
++			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&pwm1 {
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&avcc_1v8_s0>;
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	no-sdio;
++	no-sd;
++	non-removable;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	status = "okay";
++};
++
++&sdmmc {
++	max-frequency = <200000000>;
++	no-sdio;
++	no-mmc;
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
++	disable-wp;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_3v3_s3>;
++	vqmmc-supply = <&vccio_sd_s0>;
++	status = "okay";
++};
++
++&sfc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspim2_pins>;
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <104000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++		vcc-supply = <&vcc_3v3_s3>;
++	};
++};
++
++&spi2 {
++	status = "okay";
++	assigned-clocks = <&cru CLK_SPI2>;
++	assigned-clock-rates = <200000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
++	num-cs = <1>;
++
++	pmic@0 {
++		compatible = "rockchip,rk806";
++		spi-max-frequency = <1000000>;
++		reg = <0x0>;
++
++		interrupt-parent = <&gpio0>;
++		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
++			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++
++		system-power-controller;
++
++		vcc1-supply = <&vcc5v0_sys>;
++		vcc2-supply = <&vcc5v0_sys>;
++		vcc3-supply = <&vcc5v0_sys>;
++		vcc4-supply = <&vcc5v0_sys>;
++		vcc5-supply = <&vcc5v0_sys>;
++		vcc6-supply = <&vcc5v0_sys>;
++		vcc7-supply = <&vcc5v0_sys>;
++		vcc8-supply = <&vcc5v0_sys>;
++		vcc9-supply = <&vcc5v0_sys>;
++		vcc10-supply = <&vcc5v0_sys>;
++		vcc11-supply = <&vcc_2v0_pldo_s3>;
++		vcc12-supply = <&vcc5v0_sys>;
++		vcc13-supply = <&vcc_1v1_nldo_s3>;
++		vcc14-supply = <&vcc_1v1_nldo_s3>;
++		vcca-supply = <&vcc5v0_sys>;
++
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		rk806_dvs1_null: dvs1-null-pins {
++			pins = "gpio_pwrctrl1";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs2_null: dvs2-null-pins {
++			pins = "gpio_pwrctrl2";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs3_null: dvs3-null-pins {
++			pins = "gpio_pwrctrl3";
++			function = "pin_fun0";
++		};
++
++		regulators {
++			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_gpu_s0";
++				regulator-enable-ramp-delay = <400>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: dcdc-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_cpu_lit_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_log_s0: dcdc-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_log_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_vdenc_s0: vdd_vdenc_mem_s0: dcdc-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_vdenc_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_ddr_s0: dcdc-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <900000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_ddr_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdd2_ddr_s3: dcdc-reg6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vdd2_ddr_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_2v0_pldo_s3: dcdc-reg7 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <2000000>;
++				regulator-max-microvolt = <2000000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_2v0_pldo_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <2000000>;
++				};
++			};
++
++			vcc_3v3_s3: dcdc-reg8 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc_3v3_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vddq_ddr_s0: dcdc-reg9 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vddq_ddr_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s3: dcdc-reg10 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avcc_1v8_s0: pldo-reg1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "avcc_1v8_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s0: pldo-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avdd_1v2_s0: pldo-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++				regulator-name = "avdd_1v2_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_3v3_s0: pldo-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vcc_3v3_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vccio_sd_s0: pldo-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vccio_sd_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			pldo6_s3: pldo-reg6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "pldo6_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_0v75_s3: nldo-reg1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_ddr_pll_s0: nldo-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_ddr_pll_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			avdd_0v75_s0: nldo-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "avdd_0v75_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v85_s0: nldo-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_0v85_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v75_s0: nldo-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++};
++
++&uart2 {
++	pinctrl-0 = <&uart2m0_xfer>;
++	status = "okay";
++};
++
++&u2phy1 {
++	status = "okay";
++};
++
++&u2phy1_otg {
++	status = "okay";
++};
++
++&u2phy2 {
++	status = "okay";
++};
++
++&u2phy2_host {
++	/* connected to USB hub, which is powered by vcc5v0_sys */
++	phy-supply = <&vcc5v0_sys>;
++	status = "okay";
++};
++
++&u2phy3 {
++	status = "okay";
++};
++
++&u2phy3_host {
++	phy-supply = <&vcc5v0_host>;
++	status = "okay";
++};
++
++&usbdp_phy1 {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usb_host1_xhci {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usb_host2_xhci {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vp0 {
++	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
++		remote-endpoint = <&hdmi0_in_vp0>;
++	};
++};
++
++&vp1 {
++	vp1_out_hdmi1: endpoint@ROCKCHIP_VOP2_EP_HDMI1 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI1>;
++		remote-endpoint = <&hdmi1_in_vp1>;
++	};
++};
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dtsi
++++ /dev/null
+@@ -1,941 +0,0 @@
+-// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+-
+-/dts-v1/;
+-
+-#include <dt-bindings/gpio/gpio.h>
+-#include <dt-bindings/leds/common.h>
+-#include <dt-bindings/soc/rockchip,vop2.h>
+-#include "rk3588.dtsi"
+-
+-/ {
+-	aliases {
+-		mmc0 = &sdhci;
+-		mmc1 = &sdmmc;
+-		mmc2 = &sdio;
+-	};
+-
+-	chosen {
+-		stdout-path = "serial2:1500000n8";
+-	};
+-
+-	analog-sound {
+-		compatible = "audio-graph-card";
+-		label = "rk3588-es8316";
+-
+-		widgets = "Microphone", "Mic Jack",
+-			  "Headphone", "Headphones";
+-
+-		routing = "MIC2", "Mic Jack",
+-			  "Headphones", "HPOL",
+-			  "Headphones", "HPOR";
+-
+-		dais = <&i2s0_8ch_p0>;
+-		hp-det-gpio = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&hp_detect>;
+-	};
+-
+-	hdmi0-con {
+-		compatible = "hdmi-connector";
+-		type = "a";
+-
+-		port {
+-			hdmi0_con_in: endpoint {
+-				remote-endpoint = <&hdmi0_out_con>;
+-			};
+-		};
+-	};
+-
+-	hdmi1-con {
+-		compatible = "hdmi-connector";
+-		type = "a";
+-
+-		port {
+-			hdmi1_con_in: endpoint {
+-				remote-endpoint = <&hdmi1_out_con>;
+-			};
+-		};
+-	};
+-
+-	leds {
+-		compatible = "gpio-leds";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&led_rgb_b>;
+-
+-		led_rgb_b {
+-			function = LED_FUNCTION_STATUS;
+-			color = <LED_COLOR_ID_BLUE>;
+-			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+-		};
+-	};
+-
+-	fan: pwm-fan {
+-		compatible = "pwm-fan";
+-		cooling-levels = <0 120 150 180 210 240 255>;
+-		fan-supply = <&vcc5v0_sys>;
+-		pwms = <&pwm1 0 50000 0>;
+-		#cooling-cells = <2>;
+-	};
+-
+-	rfkill {
+-		compatible = "rfkill-gpio";
+-		label = "rfkill-m2-wlan";
+-		radio-type = "wlan";
+-		shutdown-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+-	};
+-
+-	rfkill-bt {
+-		compatible = "rfkill-gpio";
+-		label = "rfkill-m2-bt";
+-		radio-type = "bluetooth";
+-		shutdown-gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
+-	};
+-
+-	vcc3v3_pcie2x1l0: regulator-vcc3v3-pcie2x1l0 {
+-		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpios = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pcie2_0_vcc3v3_en>;
+-		regulator-name = "vcc3v3_pcie2x1l0";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		startup-delay-us = <50000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+-	vcc3v3_pcie2x1l2: regulator-vcc3v3-pcie2x1l2 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc3v3_pcie2x1l2";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		startup-delay-us = <5000>;
+-		vin-supply = <&vcc_3v3_s3>;
+-	};
+-
+-	vcc3v3_pcie30: regulator-vcc3v3-pcie30 {
+-		compatible = "regulator-fixed";
+-		enable-active-high;
+-		gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pcie3_vcc3v3_en>;
+-		regulator-name = "vcc3v3_pcie30";
+-		regulator-min-microvolt = <3300000>;
+-		regulator-max-microvolt = <3300000>;
+-		startup-delay-us = <5000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+-	vcc5v0_host: regulator-vcc5v0-host {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_host";
+-		regulator-boot-on;
+-		regulator-always-on;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-
+-	vcc5v0_sys: regulator-vcc5v0-sys {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc5v0_sys";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <5000000>;
+-		regulator-max-microvolt = <5000000>;
+-	};
+-
+-	vcc_1v1_nldo_s3: regulator-vcc-1v1-nldo-s3 {
+-		compatible = "regulator-fixed";
+-		regulator-name = "vcc_1v1_nldo_s3";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <1100000>;
+-		regulator-max-microvolt = <1100000>;
+-		vin-supply = <&vcc5v0_sys>;
+-	};
+-};
+-
+-&combphy0_ps {
+-	status = "okay";
+-};
+-
+-&combphy1_ps {
+-	status = "okay";
+-};
+-
+-&combphy2_psu {
+-	status = "okay";
+-};
+-
+-&cpu_b0 {
+-	cpu-supply = <&vdd_cpu_big0_s0>;
+-};
+-
+-&cpu_b1 {
+-	cpu-supply = <&vdd_cpu_big0_s0>;
+-};
+-
+-&cpu_b2 {
+-	cpu-supply = <&vdd_cpu_big1_s0>;
+-};
+-
+-&cpu_b3 {
+-	cpu-supply = <&vdd_cpu_big1_s0>;
+-};
+-
+-&cpu_l0 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&cpu_l1 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&cpu_l2 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&cpu_l3 {
+-	cpu-supply = <&vdd_cpu_lit_s0>;
+-};
+-
+-&gpu {
+-	mali-supply = <&vdd_gpu_s0>;
+-	status = "okay";
+-};
+-
+-&hdmi0 {
+-	status = "okay";
+-};
+-
+-&hdmi0_in {
+-	hdmi0_in_vp0: endpoint {
+-		remote-endpoint = <&vp0_out_hdmi0>;
+-	};
+-};
+-
+-&hdmi0_out {
+-	hdmi0_out_con: endpoint {
+-		remote-endpoint = <&hdmi0_con_in>;
+-	};
+-};
+-
+-&hdmi0_sound {
+-	status = "okay";
+-};
+-
+-&hdmi1 {
+-	pinctrl-0 = <&hdmim0_tx1_cec &hdmim0_tx1_hpd
+-		     &hdmim1_tx1_scl &hdmim1_tx1_sda>;
+-	status = "okay";
+-};
+-
+-&hdmi1_in {
+-	hdmi1_in_vp1: endpoint {
+-		remote-endpoint = <&vp1_out_hdmi1>;
+-	};
+-};
+-
+-&hdmi1_out {
+-	hdmi1_out_con: endpoint {
+-		remote-endpoint = <&hdmi1_con_in>;
+-	};
+-};
+-
+-&hdmi1_sound {
+-	status = "okay";
+-};
+-
+-&hdmi_receiver_cma {
+-	status = "okay";
+-};
+-
+-&hdmi_receiver {
+-	hpd-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
+-	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_hpd>;
+-	pinctrl-names = "default";
+-	status = "okay";
+-};
+-
+-&hdptxphy0 {
+-	status = "okay";
+-};
+-
+-&hdptxphy1 {
+-	status = "okay";
+-};
+-
+-&i2c0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&i2c0m2_xfer>;
+-	status = "okay";
+-
+-	vdd_cpu_big0_s0: regulator@42 {
+-		compatible = "rockchip,rk8602";
+-		reg = <0x42>;
+-		fcs,suspend-voltage-selector = <1>;
+-		regulator-name = "vdd_cpu_big0_s0";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <550000>;
+-		regulator-max-microvolt = <1050000>;
+-		regulator-ramp-delay = <2300>;
+-		vin-supply = <&vcc5v0_sys>;
+-
+-		regulator-state-mem {
+-			regulator-off-in-suspend;
+-		};
+-	};
+-
+-	vdd_cpu_big1_s0: regulator@43 {
+-		compatible = "rockchip,rk8603", "rockchip,rk8602";
+-		reg = <0x43>;
+-		fcs,suspend-voltage-selector = <1>;
+-		regulator-name = "vdd_cpu_big1_s0";
+-		regulator-always-on;
+-		regulator-boot-on;
+-		regulator-min-microvolt = <550000>;
+-		regulator-max-microvolt = <1050000>;
+-		regulator-ramp-delay = <2300>;
+-		vin-supply = <&vcc5v0_sys>;
+-
+-		regulator-state-mem {
+-			regulator-off-in-suspend;
+-		};
+-	};
+-};
+-
+-&i2c6 {
+-	status = "okay";
+-
+-	hym8563: rtc@51 {
+-		compatible = "haoyu,hym8563";
+-		reg = <0x51>;
+-		#clock-cells = <0>;
+-		clock-output-names = "hym8563";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&hym8563_int>;
+-		interrupt-parent = <&gpio0>;
+-		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
+-		wakeup-source;
+-	};
+-};
+-
+-&i2c7 {
+-	status = "okay";
+-
+-	es8316: audio-codec@11 {
+-		compatible = "everest,es8316";
+-		reg = <0x11>;
+-		clocks = <&cru I2S0_8CH_MCLKOUT>;
+-		clock-names = "mclk";
+-		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
+-		assigned-clock-rates = <12288000>;
+-		#sound-dai-cells = <0>;
+-
+-		port {
+-			es8316_p0_0: endpoint {
+-				remote-endpoint = <&i2s0_8ch_p0_0>;
+-			};
+-		};
+-	};
+-};
+-
+-&i2s0_8ch {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&i2s0_lrck
+-		     &i2s0_mclk
+-		     &i2s0_sclk
+-		     &i2s0_sdi0
+-		     &i2s0_sdo0>;
+-	status = "okay";
+-
+-	i2s0_8ch_p0: port {
+-		i2s0_8ch_p0_0: endpoint {
+-			dai-format = "i2s";
+-			mclk-fs = <256>;
+-			remote-endpoint = <&es8316_p0_0>;
+-		};
+-	};
+-};
+-
+-&i2s5_8ch {
+-	status = "okay";
+-};
+-
+-&i2s6_8ch {
+-	status = "okay";
+-};
+-
+-&package_thermal {
+-	polling-delay = <1000>;
+-
+-	trips {
+-		package_fan0: package-fan0 {
+-			temperature = <55000>;
+-			hysteresis = <2000>;
+-			type = "active";
+-		};
+-
+-		package_fan1: package-fan1 {
+-			temperature = <65000>;
+-			hysteresis = <2000>;
+-			type = "active";
+-		};
+-	};
+-
+-	cooling-maps {
+-		map0 {
+-			trip = <&package_fan0>;
+-			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
+-		};
+-
+-		map1 {
+-			trip = <&package_fan1>;
+-			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
+-		};
+-	};
+-};
+-
+-&pcie2x1l0 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pcie2_0_rst>;
+-	reset-gpios = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc3v3_pcie2x1l0>;
+-	status = "okay";
+-};
+-
+-&pcie2x1l2 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pcie2_2_rst>;
+-	reset-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc3v3_pcie2x1l2>;
+-	status = "okay";
+-};
+-
+-&pcie30phy {
+-	status = "okay";
+-};
+-
+-&pcie3x4 {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&pcie3_rst>;
+-	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
+-	vpcie3v3-supply = <&vcc3v3_pcie30>;
+-	status = "okay";
+-};
+-
+-&pd_gpu {
+-	domain-supply = <&vdd_gpu_s0>;
+-};
+-
+-&pinctrl {
+-	hdmirx {
+-		hdmirx_hpd: hdmirx-5v-detection {
+-			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	hym8563 {
+-		hym8563_int: hym8563-int {
+-			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	leds {
+-		led_rgb_b: led-rgb-b {
+-			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	sound {
+-		hp_detect: hp-detect {
+-			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	pcie2 {
+-		pcie2_0_rst: pcie2-0-rst {
+-			rockchip,pins = <4 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		pcie2_0_vcc3v3_en: pcie2-0-vcc-en {
+-			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		pcie2_2_rst: pcie2-2-rst {
+-			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	pcie3 {
+-		pcie3_rst: pcie3-rst {
+-			rockchip,pins = <4 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+-		pcie3_vcc3v3_en: pcie3-vcc3v3-en {
+-			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-};
+-
+-&pwm1 {
+-	status = "okay";
+-};
+-
+-&saradc {
+-	vref-supply = <&avcc_1v8_s0>;
+-	status = "okay";
+-};
+-
+-&sdhci {
+-	bus-width = <8>;
+-	no-sdio;
+-	no-sd;
+-	non-removable;
+-	mmc-hs400-1_8v;
+-	mmc-hs400-enhanced-strobe;
+-	status = "okay";
+-};
+-
+-&sdmmc {
+-	max-frequency = <200000000>;
+-	no-sdio;
+-	no-mmc;
+-	bus-width = <4>;
+-	cap-mmc-highspeed;
+-	cap-sd-highspeed;
+-	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
+-	disable-wp;
+-	sd-uhs-sdr104;
+-	vmmc-supply = <&vcc_3v3_s3>;
+-	vqmmc-supply = <&vccio_sd_s0>;
+-	status = "okay";
+-};
+-
+-&sfc {
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&fspim2_pins>;
+-	status = "okay";
+-
+-	flash@0 {
+-		compatible = "jedec,spi-nor";
+-		reg = <0>;
+-		spi-max-frequency = <104000000>;
+-		spi-rx-bus-width = <4>;
+-		spi-tx-bus-width = <1>;
+-		vcc-supply = <&vcc_3v3_s3>;
+-	};
+-};
+-
+-&spi2 {
+-	status = "okay";
+-	assigned-clocks = <&cru CLK_SPI2>;
+-	assigned-clock-rates = <200000000>;
+-	pinctrl-names = "default";
+-	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
+-	num-cs = <1>;
+-
+-	pmic@0 {
+-		compatible = "rockchip,rk806";
+-		spi-max-frequency = <1000000>;
+-		reg = <0x0>;
+-
+-		interrupt-parent = <&gpio0>;
+-		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
+-
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
+-			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
+-
+-		system-power-controller;
+-
+-		vcc1-supply = <&vcc5v0_sys>;
+-		vcc2-supply = <&vcc5v0_sys>;
+-		vcc3-supply = <&vcc5v0_sys>;
+-		vcc4-supply = <&vcc5v0_sys>;
+-		vcc5-supply = <&vcc5v0_sys>;
+-		vcc6-supply = <&vcc5v0_sys>;
+-		vcc7-supply = <&vcc5v0_sys>;
+-		vcc8-supply = <&vcc5v0_sys>;
+-		vcc9-supply = <&vcc5v0_sys>;
+-		vcc10-supply = <&vcc5v0_sys>;
+-		vcc11-supply = <&vcc_2v0_pldo_s3>;
+-		vcc12-supply = <&vcc5v0_sys>;
+-		vcc13-supply = <&vcc_1v1_nldo_s3>;
+-		vcc14-supply = <&vcc_1v1_nldo_s3>;
+-		vcca-supply = <&vcc5v0_sys>;
+-
+-		gpio-controller;
+-		#gpio-cells = <2>;
+-
+-		rk806_dvs1_null: dvs1-null-pins {
+-			pins = "gpio_pwrctrl1";
+-			function = "pin_fun0";
+-		};
+-
+-		rk806_dvs2_null: dvs2-null-pins {
+-			pins = "gpio_pwrctrl2";
+-			function = "pin_fun0";
+-		};
+-
+-		rk806_dvs3_null: dvs3-null-pins {
+-			pins = "gpio_pwrctrl3";
+-			function = "pin_fun0";
+-		};
+-
+-		regulators {
+-			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
+-				regulator-boot-on;
+-				regulator-min-microvolt = <550000>;
+-				regulator-max-microvolt = <950000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_gpu_s0";
+-				regulator-enable-ramp-delay = <400>;
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: dcdc-reg2 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <550000>;
+-				regulator-max-microvolt = <950000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_cpu_lit_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_log_s0: dcdc-reg3 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <675000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_log_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <750000>;
+-				};
+-			};
+-
+-			vdd_vdenc_s0: vdd_vdenc_mem_s0: dcdc-reg4 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <550000>;
+-				regulator-max-microvolt = <950000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_vdenc_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_ddr_s0: dcdc-reg5 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <675000>;
+-				regulator-max-microvolt = <900000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_ddr_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <850000>;
+-				};
+-			};
+-
+-			vdd2_ddr_s3: dcdc-reg6 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-name = "vdd2_ddr_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-				};
+-			};
+-
+-			vcc_2v0_pldo_s3: dcdc-reg7 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <2000000>;
+-				regulator-max-microvolt = <2000000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vdd_2v0_pldo_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <2000000>;
+-				};
+-			};
+-
+-			vcc_3v3_s3: dcdc-reg8 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <3300000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-name = "vcc_3v3_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <3300000>;
+-				};
+-			};
+-
+-			vddq_ddr_s0: dcdc-reg9 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-name = "vddq_ddr_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vcc_1v8_s3: dcdc-reg10 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "vcc_1v8_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <1800000>;
+-				};
+-			};
+-
+-			avcc_1v8_s0: pldo-reg1 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "avcc_1v8_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vcc_1v8_s0: pldo-reg2 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "vcc_1v8_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <1800000>;
+-				};
+-			};
+-
+-			avdd_1v2_s0: pldo-reg3 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1200000>;
+-				regulator-max-microvolt = <1200000>;
+-				regulator-name = "avdd_1v2_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vcc_3v3_s0: pldo-reg4 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <3300000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vcc_3v3_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vccio_sd_s0: pldo-reg5 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <3300000>;
+-				regulator-ramp-delay = <12500>;
+-				regulator-name = "vccio_sd_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			pldo6_s3: pldo-reg6 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <1800000>;
+-				regulator-max-microvolt = <1800000>;
+-				regulator-name = "pldo6_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <1800000>;
+-				};
+-			};
+-
+-			vdd_0v75_s3: nldo-reg1 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <750000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-name = "vdd_0v75_s3";
+-
+-				regulator-state-mem {
+-					regulator-on-in-suspend;
+-					regulator-suspend-microvolt = <750000>;
+-				};
+-			};
+-
+-			vdd_ddr_pll_s0: nldo-reg2 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <850000>;
+-				regulator-max-microvolt = <850000>;
+-				regulator-name = "vdd_ddr_pll_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-					regulator-suspend-microvolt = <850000>;
+-				};
+-			};
+-
+-			avdd_0v75_s0: nldo-reg3 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <750000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-name = "avdd_0v75_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_0v85_s0: nldo-reg4 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <850000>;
+-				regulator-max-microvolt = <850000>;
+-				regulator-name = "vdd_0v85_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-
+-			vdd_0v75_s0: nldo-reg5 {
+-				regulator-always-on;
+-				regulator-boot-on;
+-				regulator-min-microvolt = <750000>;
+-				regulator-max-microvolt = <750000>;
+-				regulator-name = "vdd_0v75_s0";
+-
+-				regulator-state-mem {
+-					regulator-off-in-suspend;
+-				};
+-			};
+-		};
+-	};
+-};
+-
+-&uart2 {
+-	pinctrl-0 = <&uart2m0_xfer>;
+-	status = "okay";
+-};
+-
+-&u2phy1 {
+-	status = "okay";
+-};
+-
+-&u2phy1_otg {
+-	status = "okay";
+-};
+-
+-&u2phy2 {
+-	status = "okay";
+-};
+-
+-&u2phy2_host {
+-	/* connected to USB hub, which is powered by vcc5v0_sys */
+-	phy-supply = <&vcc5v0_sys>;
+-	status = "okay";
+-};
+-
+-&u2phy3 {
+-	status = "okay";
+-};
+-
+-&u2phy3_host {
+-	phy-supply = <&vcc5v0_host>;
+-	status = "okay";
+-};
+-
+-&usbdp_phy1 {
+-	status = "okay";
+-};
+-
+-&usb_host0_ehci {
+-	status = "okay";
+-};
+-
+-&usb_host0_ohci {
+-	status = "okay";
+-};
+-
+-&usb_host1_ehci {
+-	status = "okay";
+-};
+-
+-&usb_host1_ohci {
+-	status = "okay";
+-};
+-
+-&usb_host1_xhci {
+-	dr_mode = "host";
+-	status = "okay";
+-};
+-
+-&usb_host2_xhci {
+-	status = "okay";
+-};
+-
+-&vop {
+-	status = "okay";
+-};
+-
+-&vop_mmu {
+-	status = "okay";
+-};
+-
+-&vp0 {
+-	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
+-		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
+-		remote-endpoint = <&hdmi0_in_vp0>;
+-	};
+-};
+-
+-&vp1 {
+-	vp1_out_hdmi1: endpoint@ROCKCHIP_VOP2_EP_HDMI1 {
+-		reg = <ROCKCHIP_VOP2_EP_HDMI1>;
+-		remote-endpoint = <&hdmi1_in_vp1>;
+-	};
+-};

--- a/target/linux/rockchip/patches-6.6/052-30-v6.17-arm64-dts-rockchip-move-common-ROCK-5B-nodes-into-ow.patch
+++ b/target/linux/rockchip/patches-6.6/052-30-v6.17-arm64-dts-rockchip-move-common-ROCK-5B-nodes-into-ow.patch
@@ -1,0 +1,265 @@
+From 988035f152709549a095b12fcdcb3cf26cbad63f Mon Sep 17 00:00:00 2001
+From: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
+Date: Tue, 20 May 2025 20:50:10 +0200
+Subject: arm64: dts: rockchip: move common ROCK 5B/+ nodes into own tree
+
+A few device tree nodes are shared between ROCK 5B and ROCK 5B+ that are
+not shared with ROCK 5T.
+
+Move them into their own device tree include.
+
+Signed-off-by: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
+Link: https://lore.kernel.org/r/20250520-add-rock5t-v2-3-1f1971850a20@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
+@@ -18,23 +18,6 @@
+ 		stdout-path = "serial2:1500000n8";
+ 	};
+ 
+-	analog-sound {
+-		compatible = "audio-graph-card";
+-		label = "rk3588-es8316";
+-
+-		widgets = "Microphone", "Mic Jack",
+-			  "Headphone", "Headphones";
+-
+-		routing = "MIC2", "Mic Jack",
+-			  "Headphones", "HPOL",
+-			  "Headphones", "HPOR";
+-
+-		dais = <&i2s0_8ch_p0>;
+-		hp-det-gpio = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&hp_detect>;
+-	};
+-
+ 	hdmi0-con {
+ 		compatible = "hdmi-connector";
+ 		type = "a";
+@@ -57,19 +40,6 @@
+ 		};
+ 	};
+ 
+-	leds {
+-		compatible = "gpio-leds";
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&led_rgb_b>;
+-
+-		led_rgb_b {
+-			function = LED_FUNCTION_STATUS;
+-			color = <LED_COLOR_ID_BLUE>;
+-			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+-		};
+-	};
+-
+ 	fan: pwm-fan {
+ 		compatible = "pwm-fan";
+ 		cooling-levels = <0 120 150 180 210 240 255>;
+@@ -78,13 +48,6 @@
+ 		#cooling-cells = <2>;
+ 	};
+ 
+-	rfkill {
+-		compatible = "rfkill-gpio";
+-		label = "rfkill-m2-wlan";
+-		radio-type = "wlan";
+-		shutdown-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+-	};
+-
+ 	rfkill-bt {
+ 		compatible = "rfkill-gpio";
+ 		label = "rfkill-m2-bt";
+@@ -95,9 +58,6 @@
+ 	vcc3v3_pcie2x1l0: regulator-vcc3v3-pcie2x1l0 {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+-		gpios = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
+-		pinctrl-names = "default";
+-		pinctrl-0 = <&pcie2_0_vcc3v3_en>;
+ 		regulator-name = "vcc3v3_pcie2x1l0";
+ 		regulator-always-on;
+ 		regulator-boot-on;
+@@ -105,6 +65,7 @@
+ 		regulator-max-microvolt = <3300000>;
+ 		startup-delay-us = <50000>;
+ 		vin-supply = <&vcc5v0_sys>;
++		status = "disabled";
+ 	};
+ 
+ 	vcc3v3_pcie2x1l2: regulator-vcc3v3-pcie2x1l2 {
+@@ -255,10 +216,8 @@
+ };
+ 
+ &hdmi_receiver {
+-	hpd-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
+ 	pinctrl-0 = <&hdmim1_rx_cec &hdmim1_rx_hpdin &hdmim1_rx_scl &hdmim1_rx_sda &hdmirx_hpd>;
+ 	pinctrl-names = "default";
+-	status = "okay";
+ };
+ 
+ &hdptxphy0 {
+@@ -434,39 +393,17 @@
+ };
+ 
+ &pinctrl {
+-	hdmirx {
+-		hdmirx_hpd: hdmirx-5v-detection {
+-			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+ 	hym8563 {
+ 		hym8563_int: hym8563-int {
+ 			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
+ 
+-	leds {
+-		led_rgb_b: led-rgb-b {
+-			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+-	sound {
+-		hp_detect: hp-detect {
+-			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-	};
+-
+ 	pcie2 {
+ 		pcie2_0_rst: pcie2-0-rst {
+ 			rockchip,pins = <4 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 
+-		pcie2_0_vcc3v3_en: pcie2-0-vcc-en {
+-			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
+-		};
+-
+ 		pcie2_2_rst: pcie2-2-rst {
+ 			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+@@ -914,10 +851,6 @@
+ 	status = "okay";
+ };
+ 
+-&usb_host2_xhci {
+-	status = "okay";
+-};
+-
+ &vop {
+ 	status = "okay";
+ };
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
+@@ -2,7 +2,7 @@
+ 
+ /dts-v1/;
+ 
+-#include "rk3588-rock-5b-5bp-5t.dtsi"
++#include "rk3588-rock-5b.dtsi"
+ 
+ / {
+ 	model = "Radxa ROCK 5B+";
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+@@ -2,7 +2,7 @@
+ 
+ /dts-v1/;
+ 
+-#include "rk3588-rock-5b-5bp-5t.dtsi"
++#include "rk3588-rock-5b.dtsi"
+ 
+ / {
+ 	model = "Radxa ROCK 5B";
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dtsi
+@@ -0,0 +1,86 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include "rk3588-rock-5b-5bp-5t.dtsi"
++
++/ {
++	analog-sound {
++		compatible = "audio-graph-card";
++		label = "rk3588-es8316";
++
++		widgets = "Microphone", "Mic Jack",
++			  "Headphone", "Headphones";
++
++		routing = "MIC2", "Mic Jack",
++			  "Headphones", "HPOL",
++			  "Headphones", "HPOR";
++
++		dais = <&i2s0_8ch_p0>;
++		hp-det-gpio = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&hp_detect>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&led_rgb_b>;
++
++		led_rgb_b {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_BLUE>;
++			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	rfkill {
++		compatible = "rfkill-gpio";
++		label = "rfkill-m2-wlan";
++		radio-type = "wlan";
++		shutdown-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++	};
++};
++
++&hdmi_receiver {
++	hpd-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
++&pinctrl {
++	hdmirx {
++		hdmirx_hpd: hdmirx-5v-detection {
++			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	leds {
++		led_rgb_b: led-rgb-b {
++			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie2 {
++		pcie2_0_vcc3v3_en: pcie2-0-vcc-en {
++			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	sound {
++		hp_detect: hp-detect {
++			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&usb_host2_xhci {
++	status = "okay";
++};
++
++&vcc3v3_pcie2x1l0 {
++	gpios = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie2_0_vcc3v3_en>;
++	status = "okay";
++};

--- a/target/linux/rockchip/patches-6.6/052-31-v6.17-arm64-dts-rockchip-add-ROCK-5T-device-tree.patch
+++ b/target/linux/rockchip/patches-6.6/052-31-v6.17-arm64-dts-rockchip-add-ROCK-5T-device-tree.patch
@@ -1,0 +1,134 @@
+From 0ea651de9b79a17cbe410a69399877805c136b76 Mon Sep 17 00:00:00 2001
+From: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
+Date: Tue, 20 May 2025 20:50:11 +0200
+Subject: arm64: dts: rockchip: add ROCK 5T device tree
+
+The RADXA ROCK 5T is a single board computer quite similar to the ROCK
+5B+, except it has one more PCIe-to-Ethernet controller (at the expense
+of a USB3 port) and a barrel jack for power input instead. Some pins are
+shuffled around as well.
+
+Add a device tree for it.
+
+Signed-off-by: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
+Link: https://lore.kernel.org/r/20250520-add-rock5t-v2-4-1f1971850a20@collabora.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -109,6 +109,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-ev
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-nanopc-t6.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5b.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5b-plus.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5t.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-indiedroid-nova.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-khadas-edge2.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-rock-5a.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
+@@ -0,0 +1,105 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++
++#include "rk3588-rock-5b-5bp-5t.dtsi"
++
++/ {
++	model = "Radxa ROCK 5T";
++	compatible = "radxa,rock-5t", "rockchip,rk3588";
++
++	analog-sound {
++		compatible = "audio-graph-card";
++		label = "rk3588-es8316";
++
++		widgets = "Microphone", "Mic Jack",
++		"Headphone", "Headphones";
++
++		routing = "MIC2", "Mic Jack",
++		"Headphones", "HPOL",
++		"Headphones", "HPOR";
++
++		dais = <&i2s0_8ch_p0>;
++		hp-det-gpio = <&gpio4 RK_PC3 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&hp_detect>;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&led_rgb_b>;
++
++		led_rgb_b {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_BLUE>;
++			gpios = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	rfkill {
++		compatible = "rfkill-gpio";
++		label = "rfkill-m2-wlan";
++		radio-type = "wlan";
++		shutdown-gpios = <&gpio1 RK_PB0 GPIO_ACTIVE_HIGH>;
++	};
++
++	vcc3v3_pcie2x1l1: regulator-vcc3v3-pcie2x1l2 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_pcie2x1l1";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <5000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++};
++
++&hdmi_receiver {
++	hpd-gpios = <&gpio2 RK_PB7 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
++&pcie2x1l1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie2_1_rst>;
++	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie2x1l1>;
++	status = "okay";
++};
++
++&pinctrl {
++	hdmirx {
++		hdmirx_hpd: hdmirx-5v-detection {
++			rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	leds {
++		led_rgb_b: led-rgb-b {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie2 {
++		pcie2_1_rst: pcie2-1-rst {
++			rockchip,pins = <4 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++		pcie2_0_vcc3v3_en: pcie2-0-vcc-en {
++			rockchip,pins = <2 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	sound {
++		hp_detect: hp-detect {
++			rockchip,pins = <4 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&vcc3v3_pcie2x1l0 {
++	gpios = <&gpio2 RK_PC0 GPIO_ACTIVE_HIGH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie2_0_vcc3v3_en>;
++	status = "okay";
++};

--- a/target/linux/rockchip/patches-6.6/052-32-v6.17-arm64-dts-rockchip-fix-USB-on-RADXA-ROCK-5T.patch
+++ b/target/linux/rockchip/patches-6.6/052-32-v6.17-arm64-dts-rockchip-fix-USB-on-RADXA-ROCK-5T.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
+Date: Mon, 25 Aug 2025 09:27:08 +0200
+Subject: arm64: dts: rockchip: fix USB on RADXA ROCK 5T
+
+The RADXA ROCK 5T board uses the same GPIO pin for controlling the USB
+host port regulator. This control pin was mistakenly left out of the
+ROCK 5T device tree.
+
+Reported-by: FUKAUMI Naoki <naoki@radxa.com>
+Closes: https://libera.catirclogs.org/linux-rockchip/2025-08-25#38609886;
+Fixes: 0ea651de9b79 ("arm64: dts: rockchip: add ROCK 5T device tree")
+Signed-off-by: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
+@@ -95,6 +95,12 @@
+ 			rockchip,pins = <4 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
+ 		};
+ 	};
++
++	usb {
++		vcc5v0_host_en: vcc5v0-host-en {
++			rockchip,pins = <1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
+ };
+ 
+ &vcc3v3_pcie2x1l0 {
+@@ -103,3 +109,10 @@
+ 	pinctrl-0 = <&pcie2_0_vcc3v3_en>;
+ 	status = "okay";
+ };
++
++&vcc5v0_host {
++	enable-active-high;
++	gpio = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&vcc5v0_host_en>;
++};

--- a/target/linux/rockchip/patches-6.6/052-33-v6.17-arm64-dts-rockchip-fix-second-M.2-slot-on-ROCK-5T.patch
+++ b/target/linux/rockchip/patches-6.6/052-33-v6.17-arm64-dts-rockchip-fix-second-M.2-slot-on-ROCK-5T.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
+Date: Tue, 26 Aug 2025 10:08:36 +0200
+Subject: arm64: dts: rockchip: fix second M.2 slot on ROCK 5T
+
+The Radxa ROCK 5T has two M.2 slots, much like the Radxa Rock 5B+. As it
+stands, the board won't be able to use PCIe3 if the second M.2 slot is
+in use.
+
+Fix this by adding the necessary node enablement and data-lanes property
+to the ROCK 5T device tree, mirroring what's in the ROCK 5B+ device
+tree.
+
+Reported-by: FUKAUMI Naoki <naoki@radxa.com>
+Closes: https://libera.catirclogs.org/linux-rockchip/2025-08-25#38610630;
+Fixes: 0ea651de9b79 ("arm64: dts: rockchip: add ROCK 5T device tree")
+Signed-off-by: Nicolas Frattaroli <nicolas.frattaroli@collabora.com>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
+@@ -68,6 +68,22 @@
+ 	status = "okay";
+ };
+ 
++&pcie30phy {
++	data-lanes = <1 1 2 2>;
++};
++
++&pcie3x2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie3x2_rst>;
++	reset-gpios = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_pcie30>;
++	status = "okay";
++};
++
++&pcie3x4 {
++	num-lanes = <2>;
++};
++
+ &pinctrl {
+ 	hdmirx {
+ 		hdmirx_hpd: hdmirx-5v-detection {
+@@ -90,6 +106,12 @@
+ 		};
+ 	};
+ 
++	pcie3 {
++		pcie3x2_rst: pcie3x2-rst {
++			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	sound {
+ 		hp_detect: hp-detect {
+ 			rockchip,pins = <4 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;

--- a/target/linux/rockchip/patches-6.6/053-v6.9-arm64-dts-rockchip-Add-support-for-NanoPi-R6S.patch
+++ b/target/linux/rockchip/patches-6.6/053-v6.9-arm64-dts-rockchip-Add-support-for-NanoPi-R6S.patch
@@ -17,8 +17,8 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
 
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -110,4 +110,5 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-na
- dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5b.dtb
+@@ -112,4 +112,5 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-ro
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5t.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-indiedroid-nova.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-khadas-edge2.dtb
 +dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-nanopi-r6s.dtb

--- a/target/linux/rockchip/patches-6.6/054-v6.9-arm64-dts-rockchip-Add-support-for-NanoPi-R6C.patch
+++ b/target/linux/rockchip/patches-6.6/054-v6.9-arm64-dts-rockchip-Add-support-for-NanoPi-R6C.patch
@@ -17,7 +17,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
 
 --- a/arch/arm64/boot/dts/rockchip/Makefile
 +++ b/arch/arm64/boot/dts/rockchip/Makefile
-@@ -111,4 +111,5 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-ro
+@@ -113,4 +113,5 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-ro
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-indiedroid-nova.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-khadas-edge2.dtb
  dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-nanopi-r6s.dtb

--- a/target/linux/rockchip/patches-6.6/056-02-v6.11-arm64-dts-rockchip-enable-thermal-management-on-all-RK358.patch
+++ b/target/linux/rockchip/patches-6.6/056-02-v6.11-arm64-dts-rockchip-enable-thermal-management-on-all-RK358.patch
@@ -51,9 +51,9 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  &u2phy2 {
  	status = "okay";
  };
---- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
-@@ -787,6 +787,10 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
+@@ -794,6 +794,10 @@
  	};
  };
  

--- a/target/linux/rockchip/patches-6.6/056-02-v6.11-arm64-dts-rockchip-enable-thermal-management-on-all-RK358.patch
+++ b/target/linux/rockchip/patches-6.6/056-02-v6.11-arm64-dts-rockchip-enable-thermal-management-on-all-RK358.patch
@@ -66,7 +66,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  	status = "okay";
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
-@@ -742,6 +742,10 @@
+@@ -746,6 +746,10 @@
  	};
  };
  

--- a/target/linux/rockchip/patches-6.6/056-02-v6.11-arm64-dts-rockchip-enable-thermal-management-on-all-RK358.patch
+++ b/target/linux/rockchip/patches-6.6/056-02-v6.11-arm64-dts-rockchip-enable-thermal-management-on-all-RK358.patch
@@ -66,7 +66,7 @@ Signed-off-by: Heiko Stuebner <heiko@sntech.de>
  	status = "okay";
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
-@@ -746,6 +746,10 @@
+@@ -792,6 +792,10 @@
  	};
  };
  

--- a/target/linux/rockchip/patches-6.6/057-01-v6.11-arm64-dts-rockchip-add-ROCK-5-ITX-board.patch
+++ b/target/linux/rockchip/patches-6.6/057-01-v6.11-arm64-dts-rockchip-add-ROCK-5-ITX-board.patch
@@ -1,0 +1,1222 @@
+From 31390eb8ffbf2b6be7d789708ec08b635d7a3eb8 Mon Sep 17 00:00:00 2001
+From: Heiko Stuebner <heiko@sntech.de>
+Date: Thu, 4 Jul 2024 17:38:15 +0200
+Subject: [PATCH] arm64: dts: rockchip: add ROCK 5 ITX board
+
+The ROCK 5 ITX as the name suggests is made in the ITX form factor and
+actually built in a form to be used in a regular case even providing
+connectors for regular front-panel io.
+
+It can be powered either by 12V, ATX power-supply or PoE.
+
+Notable peripherals are the 4 SATA ports, M.2 M-Key slot, M.2 E-key slot,
+2*2.5Gb PCIe-connected Ethernet NICs.
+
+As of yet unsupported display options consist of 2*HDMI, DP via USB-c,
+eDP + 2*DSI via PCB connectors.
+
+USB ports are 4*USB3 + 2*USB2 on the back panel and 2-port front-panel
+connector.
+
+Schematics for the board can be found on
+- https://dl.radxa.com/rock5/5itx/radxa_rock_5_itx_X1100_schematic.pdf
+- https://dl.radxa.com/rock5/5itx/v1110/radxa_rock_5itx_v1110_schematic.pdf
+
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+Link: https://lore.kernel.org/r/20240704153815.837392-3-heiko@sntech.de
+---
+ arch/arm64/boot/dts/rockchip/Makefile         |    1 +
+ .../boot/dts/rockchip/rk3588-rock-5-itx.dts   | 1177 +++++++++++++++++
+ 2 files changed, 1178 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -108,6 +108,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-ed
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-edgeble-neu6b-io.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-evb1-v10.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-nanopc-t6.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5-itx.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5b.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5b-plus.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-rock-5t.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+@@ -0,0 +1,1177 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2024 Radxa Limited
++ * Copyright (c) 2024 Heiko Stuebner <heiko@sntech.de>
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/pwm/pwm.h>
++#include "dt-bindings/usb/pd.h"
++#include "rk3588.dtsi"
++
++/ {
++	model = "Radxa ROCK 5 ITX";
++	compatible = "radxa,rock-5-itx", "rockchip,rk3588";
++
++	aliases {
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc;
++		mmc2 = &sdio;
++	};
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	adc_keys: adc-keys {
++		compatible = "adc-keys";
++		io-channels = <&saradc 0>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <1800000>;
++		poll-interval = <100>;
++
++		button-maskrom {
++			label = "Mask Rom";
++			linux,code = <KEY_SETUP>;
++			press-threshold-microvolt = <1750>;
++		};
++	};
++
++	analog-sound {
++		compatible = "audio-graph-card";
++		label = "rk3588-es8316";
++		dais = <&i2s0_8ch_p0>;
++		hp-det-gpio = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&hp_detect>;
++		routing = "MIC2", "Mic Jack",
++			  "Headphones", "HPOL",
++			  "Headphones", "HPOR";
++		widgets = "Microphone", "Mic Jack",
++			  "Headphone", "Headphones";
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&led_pins>;
++
++		power-led1 {
++			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "default-on";
++		};
++
++		hdd-led2 {
++			gpios = <&gpio0 RK_PC0 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "disk-activity";
++		};
++	};
++
++	fan0: pwm-fan {
++		compatible = "pwm-fan";
++		#cooling-cells = <2>;
++		cooling-levels = <0 64 128 192 255>;
++		fan-supply = <&vcc12v_dcin>;
++		pwms = <&pwm14 0 10000 0>;
++	};
++
++	/* M.2 E-KEY */
++	sdio_pwrseq: sdio-pwrseq {
++		compatible = "mmc-pwrseq-simple";
++		clocks = <&hym8563>;
++		clock-names = "ext_clock";
++		pinctrl-names = "default";
++		pinctrl-0 = <&wifi_enable_h>;
++		reset-gpios = <&gpio0 RK_PC4 GPIO_ACTIVE_LOW>;
++	};
++
++	typec_vin: regulator-typec-vin {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio1 RK_PB6 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vbus5v0_typec_en>;
++		regulator-name = "typec_vin";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc12v_dcin: regulator-vcc12v-dcin {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc12v_dcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <12000000>;
++		regulator-max-microvolt = <12000000>;
++	};
++
++	vcc33_io64: regulator-vcc33-io64 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc33_io64";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc3v3_ekey: regulator-vcc3v3-ekey {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <&gpio1 RK_PD2 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&ekey_en>;
++		regulator-name = "vcc3v3_ekey";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <50000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc3v3_lan: vcc3v3_lan_phy2: regulator-vcc3v3-lan {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_lan";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
++	vcc3v3_mkey: regulator-vcc3v3-mkey {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pcie30x4_pwren_h>;
++		regulator-name = "vcc3v3_mkey";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		startup-delay-us = <5000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc3v3_sys: regulator-vcc3v3-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc3v3_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc5v0_sys: regulator-vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc12v_dcin>;
++	};
++
++	vcc5v0_usb20: vcc5v0_usb12: vcc5v0_usb34: regulator-vcc5v0-usb {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb_host_pwren_h>;
++		regulator-name = "vcc5v0_usb";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc_1v1_nldo_s3: regulator-vcc-1v1-nldo-s3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_1v1_nldo_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1100000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++};
++
++&combphy0_ps {
++	status = "okay";
++};
++
++&combphy1_ps {
++	status = "okay";
++};
++
++&combphy2_psu {
++	status = "okay";
++};
++
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b1 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b2 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_b3 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l1 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l2 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l3 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	status = "okay";
++};
++
++&i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c0m2_xfer>;
++	status = "okay";
++
++	vdd_cpu_big0_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big0_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc5v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_cpu_big1_s0: regulator@43 {
++		compatible = "rockchip,rk8603", "rockchip,rk8602";
++		reg = <0x43>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big1_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc5v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c1m2_xfer>;
++	status = "okay";
++
++	vdd_npu_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_npu_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <950000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc5v0_sys>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++/* CAM0 connector */
++&i2c3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c3m0_xfer>;
++};
++
++/* M.2 E-key */
++&i2c4 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c4m1_xfer>;
++};
++
++/* RTC and LCD0 connector */
++&i2c6 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c6m0_xfer>;
++	status = "okay";
++
++	hym8563: rtc@51 {
++		compatible = "haoyu,hym8563";
++		reg = <0x51>;
++		#clock-cells = <0>;
++		clock-output-names = "wifi_32kout";
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&rtc_int>;
++	};
++};
++
++/* Audio codec and CAM1 connector */
++&i2c7 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c7m0_xfer>;
++	status = "okay";
++
++	es8316: audio-codec@11 {
++		compatible = "everest,es8316";
++		reg = <0x11>;
++		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
++		assigned-clock-rates = <12288000>;
++		clocks = <&cru I2S0_8CH_MCLKOUT>;
++		clock-names = "mclk";
++		#sound-dai-cells = <0>;
++
++		port {
++			es8316_p0_0: endpoint {
++				remote-endpoint = <&i2s0_8ch_p0_0>;
++			};
++		};
++	};
++};
++
++/* FUSB302 and LCD1 connector */
++&i2c8 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c8m4_xfer>;
++	status = "okay";
++
++	usbc0: usb-typec@22 {
++		compatible = "fcs,fusb302";
++		reg = <0x22>;
++		interrupt-parent = <&gpio3>;
++		interrupts = <RK_PB4 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usbc0_int>;
++		vbus-supply = <&typec_vin>;
++
++		usb_con: connector {
++			compatible = "usb-c-connector";
++			data-role = "dual";
++			label = "USB-C";
++			power-role = "source";
++			source-pdos =
++				<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
++
++			ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				port@0 {
++					reg = <0>;
++
++					usbc0_orien_sw: endpoint {
++						remote-endpoint = <&usbdp_phy0_orientation_switch>;
++					};
++				};
++
++				port@1 {
++					reg = <1>;
++
++					usbc0_role_sw: endpoint {
++						remote-endpoint = <&dwc3_0_role_switch>;
++					};
++				};
++
++				port@2 {
++					reg = <2>;
++
++					dp_altmode_mux: endpoint {
++						remote-endpoint = <&usbdp_phy0_dp_altmode_mux>;
++					};
++				};
++			};
++		};
++	};
++};
++
++&i2c8m4_xfer {
++	rockchip,pins =
++		/* i2c8_scl_m4 */
++		<3 RK_PC2 9 &pcfg_pull_up_drv_level_6>,
++		/* i2c8_sda_m4 */
++		<3 RK_PC3 9 &pcfg_pull_up_drv_level_6>;
++};
++
++&i2s0_8ch {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s0_lrck
++		     &i2s0_mclk
++		     &i2s0_sclk
++		     &i2s0_sdi0
++		     &i2s0_sdo0>;
++	status = "okay";
++
++	i2s0_8ch_p0: port {
++		i2s0_8ch_p0_0: endpoint {
++			dai-format = "i2s";
++			mclk-fs = <256>;
++			remote-endpoint = <&es8316_p0_0>;
++		};
++	};
++};
++
++&package_thermal {
++	polling-delay = <1000>;
++
++	trips {
++		package_fan0: package-fan0 {
++			hysteresis = <2000>;
++			temperature = <50000>;
++			type = "active";
++		};
++
++		package_fan1: package-fan1 {
++			hysteresis = <2000>;
++			temperature = <65000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map0 {
++			cooling-device = <&fan0 THERMAL_NO_LIMIT 1>;
++			trip = <&package_fan0>;
++		};
++		map1 {
++			cooling-device = <&fan0 2 THERMAL_NO_LIMIT>;
++			trip = <&package_fan1>;
++		};
++	};
++};
++
++/* M.2 E-key */
++&pcie2x1l0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie30x1_0_perstn_m1_l>;
++	reset-gpios = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_ekey>;
++	status = "okay";
++};
++
++/* RTL8125B_1 */
++&pcie2x1l1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie30x1_1_perstn>;
++	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_lan>;
++	status = "okay";
++};
++
++/* RTL8125B_2 */
++&pcie2x1l2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie20x1_2_perstn>;
++	reset-gpios = <&gpio3 RK_PB0 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_lan_phy2>;
++	status = "okay";
++};
++
++&pcie30phy {
++	data-lanes = <1 1 2 2>;
++	/* separate clock lines from the clock generator to phy and devices */
++	rockchip,rx-common-refclk-mode = <0 0 0 0>;
++	status = "okay";
++};
++
++/* ASMedia ASM1164 Sata controller */
++&pcie3x2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie30x2_perstn_m1_l>;
++	reset-gpios = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc33_io64>;
++	status = "okay";
++};
++
++/* M.2 M.key */
++&pcie3x4 {
++	num-lanes = <2>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie30x4_perstn_m1_l>;
++	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc3v3_mkey>;
++	status = "okay";
++};
++
++&pinctrl {
++	hym8563 {
++		rtc_int: rtc-int {
++			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	leds {
++		led_pins: led-pins {
++			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>,
++					<0 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie {
++		pcie20x1_2_perstn: pcie20x1-2-perstn {
++			rockchip,pins = <3 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie30x1_0_perstn_m1_l: pcie30x1-0-perstn-m1-l {
++			rockchip,pins = <4 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie30x1_1_perstn: pcie30x1-1-perstn {
++			rockchip,pins = <4 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie30x2_perstn_m1_l: pcie30x2-perstn-m1-l {
++			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie30x4_perstn_m1_l: pcie30x4-perstn-m1-l {
++			rockchip,pins = <4 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		ekey_en: ekey-en {
++			rockchip,pins = <1 RK_PD2 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++
++		pcie30x4_pwren_h: pcie30x4-pwren-h {
++			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	sound {
++		hp_detect: hp-detect {
++			rockchip,pins = <1 RK_PD5 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	usb {
++		usb_host_pwren_h: usb-host-pwren-h {
++			rockchip,pins = <3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		vcc5v0_otg_en: vcc5v0-otg-en {
++			rockchip,pins = <2 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		gl3523_reset: rl3523-reset {
++			rockchip,pins = <3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb-typec {
++		usbc0_int: usbc0-int {
++			rockchip,pins = <3 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++
++		vbus5v0_typec_en: vbus5v0-typec-en {
++			rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	hdmirx {
++		hdmirx_det: hdmirx-det {
++			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	sdio-pwrseq {
++		wifi_enable_h: wifi-enable-h {
++			rockchip,pins = <0 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	wireless-wlan {
++		wifi_host_wake_irq: wifi-host-wake-irq {
++			rockchip,pins = <0 RK_PB2 RK_FUNC_GPIO &pcfg_pull_down>;
++		};
++	};
++
++	bt {
++		bt_enable_h: bt-enable-h {
++			rockchip,pins = <2 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_host_wake_l: bt-host-wake-l {
++			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		bt_wake_l: bt-wake-l {
++			rockchip,pins = <4 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	dp {
++		dp1_hpd: dp1-hpd {
++			rockchip,pins = <3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&pwm14 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm14m1_pins>;
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&avcc_1v8_s0>;
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	max-frequency = <200000000>;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	mmc-hs200-1_8v;
++	no-sdio;
++	no-sd;
++	non-removable;
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	max-frequency = <200000000>;
++	no-sdio;
++	no-mmc;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc_bus4 &sdmmc_clk &sdmmc_cmd &sdmmc_det>;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_3v3_s3>;
++	vqmmc-supply = <&vccio_sd_s0>;
++	status = "okay";
++};
++
++/* M.2 E-KEY */
++&sdio {
++	broken-cd;
++	bus-width = <4>;
++	cap-sdio-irq;
++	keep-power-in-suspend;
++	max-frequency = <150000000>;
++	mmc-pwrseq = <&sdio_pwrseq>;
++	no-sd;
++	no-mmc;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdiom0_pins>;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc3v3_ekey>;
++	status = "okay";
++};
++
++&sfc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspim2_pins>;
++	status = "okay";
++
++	spi_flash: flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0x0>;
++		spi-max-frequency = <50000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++	};
++};
++
++&spi2 {
++	status = "okay";
++	assigned-clocks = <&cru CLK_SPI2>;
++	assigned-clock-rates = <200000000>;
++	num-cs = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
++
++	pmic@0 {
++		compatible = "rockchip,rk806";
++		reg = <0x0>;
++		gpio-controller;
++		#gpio-cells = <2>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
++			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++		spi-max-frequency = <1000000>;
++		system-power-controller;
++
++		vcc1-supply = <&vcc5v0_sys>;
++		vcc2-supply = <&vcc5v0_sys>;
++		vcc3-supply = <&vcc5v0_sys>;
++		vcc4-supply = <&vcc5v0_sys>;
++		vcc5-supply = <&vcc5v0_sys>;
++		vcc6-supply = <&vcc5v0_sys>;
++		vcc7-supply = <&vcc5v0_sys>;
++		vcc8-supply = <&vcc5v0_sys>;
++		vcc9-supply = <&vcc5v0_sys>;
++		vcc10-supply = <&vcc5v0_sys>;
++		vcc11-supply = <&vcc_2v0_pldo_s3>;
++		vcc12-supply = <&vcc5v0_sys>;
++		vcc13-supply = <&vcc_1v1_nldo_s3>;
++		vcc14-supply = <&vcc_1v1_nldo_s3>;
++		vcca-supply = <&vcc5v0_sys>;
++
++		rk806_dvs1_null: dvs1-null-pins {
++			pins = "gpio_pwrctrl1";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs2_null: dvs2-null-pins {
++			pins = "gpio_pwrctrl2";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs3_null: dvs3-null-pins {
++			pins = "gpio_pwrctrl3";
++			function = "pin_fun0";
++		};
++
++		regulators {
++			vdd_gpu_s0: vdd_gpu_mem_s0: dcdc-reg1 {
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_gpu_s0";
++				regulator-enable-ramp-delay = <400>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_lit_s0: vdd_cpu_lit_mem_s0: dcdc-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_cpu_lit_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_log_s0: dcdc-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_log_s0";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_vdenc_s0: vdd_vdenc_mem_s0: dcdc-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_vdenc_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_ddr_s0: dcdc-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <900000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_ddr_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdd2_ddr_s3: dcdc-reg6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vdd2_ddr_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_2v0_pldo_s3: dcdc-reg7 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <2000000>;
++				regulator-max-microvolt = <2000000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vdd_2v0_pldo_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <2000000>;
++				};
++			};
++
++			vcc_3v3_s3: dcdc-reg8 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-name = "vcc_3v3_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vddq_ddr_s0: dcdc-reg9 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-name = "vddq_ddr_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s3: dcdc-reg10 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avcc_1v8_s0: pldo-reg1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "avcc_1v8_s0";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc_1v8_s0: pldo-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "vcc_1v8_s0";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			avdd_1v2_s0: pldo-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++				regulator-name = "avdd_1v2_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_3v3_s0: pldo-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vcc_3v3_s0";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vccio_sd_s0: pldo-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++				regulator-ramp-delay = <12500>;
++				regulator-name = "vccio_sd_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			pldo6_s3: pldo-reg6 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++				regulator-name = "pldo6_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_0v75_s3: nldo-reg1 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s3";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_ddr_pll_s0: nldo-reg2 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_ddr_pll_s0";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			avdd_0v75_s0: nldo-reg3 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "avdd_0v75_s0";
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v85_s0: nldo-reg4 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++				regulator-name = "vdd_0v85_s0";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <837500>;
++				};
++			};
++
++			vdd_0v75_s0: nldo-reg5 {
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++				regulator-name = "vdd_0v75_s0";
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++		};
++	};
++};
++
++&tsadc {
++	status = "okay";
++};
++
++&uart2 {
++	pinctrl-0 = <&uart2m0_xfer>;
++	status = "okay";
++};
++
++/* Connected to M.2 E-key */
++&uart6 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart6m1_xfer &uart6m1_ctsn &uart6m1_rtsn>;
++	status = "okay";
++};
++
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	status = "okay";
++};
++
++&u2phy1 {
++	status = "okay";
++};
++
++&u2phy1_otg {
++	/* connected to USB3 hub, which is powered by vcc5v0_usb12 */
++	phy-supply = <&vcc5v0_usb12>;
++	status = "okay";
++};
++
++&u2phy2 {
++	status = "okay";
++};
++
++&u2phy2_host {
++	/* connected to USB2 hub, which is powered by vcc5v0_usb20 */
++	phy-supply = <&vcc5v0_usb20>;
++	status = "okay";
++};
++
++&u2phy3 {
++	status = "okay";
++};
++
++&u2phy3_host {
++	phy-supply = <&vcc5v0_usb20>;
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usb_host0_xhci {
++	usb-role-switch;
++	status = "okay";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		dwc3_0_role_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_role_sw>;
++		};
++	};
++};
++
++&usb_host1_xhci {
++	dr_mode = "host";
++	#address-cells = <1>;
++	#size-cells = <0>;
++	status = "okay";
++
++	/* 2.0 hub on port 1 */
++	hub_2_0: hub@1 {
++		compatible = "usb5e3,610";
++		reg = <1>;
++		peer-hub = <&hub_3_0>;
++		vdd-supply = <&vcc_3v3_s3>;
++	};
++
++	/* 3.0 hub on port 4 */
++	hub_3_0: hub@2 {
++		compatible = "usb5e3,620";
++		reg = <2>;
++		peer-hub = <&hub_2_0>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&gl3523_reset>;
++		reset-gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_LOW>;
++		vdd-supply = <&vcc_3v3_s3>;
++	};
++};
++
++&usbdp_phy0 {
++	mode-switch;
++	orientation-switch;
++	sbu1-dc-gpios = <&gpio4 RK_PB7 GPIO_ACTIVE_HIGH>;
++	sbu2-dc-gpios = <&gpio4 RK_PC0 GPIO_ACTIVE_HIGH>;
++	status = "okay";
++
++	port {
++		#address-cells = <1>;
++		#size-cells = <0>;
++		usbdp_phy0_orientation_switch: endpoint@0 {
++			reg = <0>;
++			remote-endpoint = <&usbc0_orien_sw>;
++		};
++
++		usbdp_phy0_dp_altmode_mux: endpoint@1 {
++			reg = <1>;
++			remote-endpoint = <&dp_altmode_mux>;
++		};
++	};
++};
++
++&usbdp_phy1 {
++	rockchip,dp-lane-mux = <2 3>;
++	status = "okay";
++};

--- a/target/linux/rockchip/patches-6.6/057-02-v6.13-arm64-dts-rockchip-fix-the-pcie-refclock-oscillator-.patch
+++ b/target/linux/rockchip/patches-6.6/057-02-v6.13-arm64-dts-rockchip-fix-the-pcie-refclock-oscillator-.patch
@@ -1,0 +1,94 @@
+From e684f02492f99d6f6f037a35a613607339cf8e8f Mon Sep 17 00:00:00 2001
+From: Heiko Stuebner <heiko@sntech.de>
+Date: Fri, 6 Sep 2024 10:25:11 +0200
+Subject: arm64: dts: rockchip: fix the pcie refclock oscillator on Rock 5 ITX
+
+The Rock 5 ITX uses two PCIe controllers to drive both a M.2 slot and its
+SATA controller with 2 lanes each. The supply for the refclk oscillator is
+the same that supplies the M.2 slot, but the SATA controller port is
+supplied by a different rail.
+
+This leads to the effect that if the PCIe30x4 controller for the M.2
+probes first, everything works normally. But if the PCIe30x2 controller
+that is connected to the SATA controller probes first, it will hang on
+the first DBI read as nothing will have enabled the refclock before.
+
+Fix this by describing the clock generator with its supplies so that
+both controllers can reference it as needed.
+
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+Link: https://lore.kernel.org/r/20240906082511.2963890-6-heiko@sntech.de
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+@@ -72,6 +72,15 @@
+ 		};
+ 	};
+ 
++	/* Unnamed gated oscillator: 100MHz,3.3V,3225 */
++	pcie30_port0_refclk: pcie30_port1_refclk: pcie-oscillator {
++		compatible = "gated-fixed-clock";
++		#clock-cells = <0>;
++		clock-frequency = <100000000>;
++		clock-output-names = "pcie30_refclk";
++		vdd-supply = <&vcc3v3_pi6c_05>;
++	};
++
+ 	fan0: pwm-fan {
+ 		compatible = "pwm-fan";
+ 		#cooling-cells = <2>;
+@@ -146,13 +155,14 @@
+ 		vin-supply = <&vcc_3v3_s3>;
+ 	};
+ 
+-	vcc3v3_mkey: regulator-vcc3v3-mkey {
++	/* The PCIE30x4_PWREN_H controls two regulators */
++	vcc3v3_mkey: vcc3v3_pi6c_05: regulator-vcc3v3-pi6c-05 {
+ 		compatible = "regulator-fixed";
+ 		enable-active-high;
+ 		gpios = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&pcie30x4_pwren_h>;
+-		regulator-name = "vcc3v3_mkey";
++		regulator-name = "vcc3v3_pi6c_05";
+ 		regulator-min-microvolt = <3300000>;
+ 		regulator-max-microvolt = <3300000>;
+ 		startup-delay-us = <5000>;
+@@ -513,6 +523,18 @@
+ 
+ /* ASMedia ASM1164 Sata controller */
+ &pcie3x2 {
++	/*
++	 * The board has a "pcie_refclk" oscillator that needs enabling,
++	 * so add it to the list of clocks.
++	 */
++	clocks = <&cru ACLK_PCIE_2L_MSTR>, <&cru ACLK_PCIE_2L_SLV>,
++		 <&cru ACLK_PCIE_2L_DBI>, <&cru PCLK_PCIE_2L>,
++		 <&cru CLK_PCIE_AUX1>, <&cru CLK_PCIE2L_PIPE>,
++		 <&pcie30_port1_refclk>;
++	clock-names = "aclk_mst", "aclk_slv",
++		      "aclk_dbi", "pclk",
++		      "aux", "pipe",
++		      "ref";
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie30x2_perstn_m1_l>;
+ 	reset-gpios = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
+@@ -522,6 +544,18 @@
+ 
+ /* M.2 M.key */
+ &pcie3x4 {
++	/*
++	 * The board has a "pcie_refclk" oscillator that needs enabling,
++	 * so add it to the list of clocks.
++	 */
++	clocks = <&cru ACLK_PCIE_4L_MSTR>, <&cru ACLK_PCIE_4L_SLV>,
++		 <&cru ACLK_PCIE_4L_DBI>, <&cru PCLK_PCIE_4L>,
++		 <&cru CLK_PCIE_AUX0>, <&cru CLK_PCIE4L_PIPE>,
++		 <&pcie30_port0_refclk>;
++	clock-names = "aclk_mst", "aclk_slv",
++		      "aclk_dbi", "pclk",
++		      "aux", "pipe",
++		      "ref";
+ 	num-lanes = <2>;
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie30x4_perstn_m1_l>;

--- a/target/linux/rockchip/patches-6.6/057-03-v6.14-arm64-dts-rockchip-slow-down-emmc-freq-for-rock-5-it.patch
+++ b/target/linux/rockchip/patches-6.6/057-03-v6.14-arm64-dts-rockchip-slow-down-emmc-freq-for-rock-5-it.patch
@@ -1,0 +1,35 @@
+From b36402e4a0772d1b3da06a4f5fbd1cfe4d6f1cc0 Mon Sep 17 00:00:00 2001
+From: Jianfeng Liu <liujianfeng1994@gmail.com>
+Date: Fri, 28 Feb 2025 22:33:08 +0800
+Subject: arm64: dts: rockchip: slow down emmc freq for rock 5 itx
+
+The current max-frequency 200000000 of emmc is not stable. When doing
+heavy write there will be I/O Error. After setting max-frequency to
+150000000 the emmc is stable under write.
+
+Also remove property mmc-hs200-1_8v because we are already running at
+HS400 mode.
+
+Tested with fio command:
+fio -filename=./test_randread -direct=1 -iodepth 1 -thread \
+-rw=randwrite -ioengine=psync -bs=16k -size=1G -numjobs=10 \
+-runtime=600 -group_reporting -name=mytest
+
+Signed-off-by: Jianfeng Liu <liujianfeng1994@gmail.com>
+Link: https://lore.kernel.org/r/20250228143341.70244-1-liujianfeng1994@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+@@ -690,10 +690,9 @@
+ 
+ &sdhci {
+ 	bus-width = <8>;
+-	max-frequency = <200000000>;
++	max-frequency = <150000000>;
+ 	mmc-hs400-1_8v;
+ 	mmc-hs400-enhanced-strobe;
+-	mmc-hs200-1_8v;
+ 	no-sdio;
+ 	no-sd;
+ 	non-removable;

--- a/target/linux/rockchip/patches-6.6/057-04-v6.15-arm64-dts-rockchip-add-hdmi1-support-to-ROCK-5-ITX.patch
+++ b/target/linux/rockchip/patches-6.6/057-04-v6.15-arm64-dts-rockchip-add-hdmi1-support-to-ROCK-5-ITX.patch
@@ -1,0 +1,87 @@
+From 3eac9319af62dbc56d1f06fcb240e4a092fa5b2f Mon Sep 17 00:00:00 2001
+From: Jianfeng Liu <liujianfeng1994@gmail.com>
+Date: Tue, 25 Feb 2025 11:08:48 +0800
+Subject: arm64: dts: rockchip: add hdmi1 support to ROCK 5 ITX
+
+Enable the HDMI port next to ethernet port.
+
+Signed-off-by: Jianfeng Liu <liujianfeng1994@gmail.com>
+Link: https://lore.kernel.org/r/20250225030904.2813023-1-liujianfeng1994@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+@@ -11,6 +11,7 @@
+ #include <dt-bindings/leds/common.h>
+ #include <dt-bindings/pinctrl/rockchip.h>
+ #include <dt-bindings/pwm/pwm.h>
++#include <dt-bindings/soc/rockchip,vop2.h>
+ #include "dt-bindings/usb/pd.h"
+ #include "rk3588.dtsi"
+ 
+@@ -72,6 +73,17 @@
+ 		};
+ 	};
+ 
++	hdmi1-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi1_con_in: endpoint {
++				remote-endpoint = <&hdmi1_out_con>;
++			};
++		};
++	};
++
+ 	/* Unnamed gated oscillator: 100MHz,3.3V,3225 */
+ 	pcie30_port0_refclk: pcie30_port1_refclk: pcie-oscillator {
+ 		compatible = "gated-fixed-clock";
+@@ -261,6 +273,28 @@
+ 	status = "okay";
+ };
+ 
++&hdmi1 {
++	pinctrl-0 = <&hdmim0_tx1_cec &hdmim0_tx1_hpd
++		     &hdmim1_tx1_scl &hdmim1_tx1_sda>;
++	status = "okay";
++};
++
++&hdmi1_in {
++	hdmi1_in_vp1: endpoint {
++		remote-endpoint = <&vp1_out_hdmi1>;
++	};
++};
++
++&hdmi1_out {
++	hdmi1_out_con: endpoint {
++		remote-endpoint = <&hdmi1_con_in>;
++	};
++};
++
++&hdptxphy1 {
++	status = "okay";
++};
++
+ &i2c0 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&i2c0m2_xfer>;
+@@ -1208,3 +1242,18 @@
+ 	rockchip,dp-lane-mux = <2 3>;
+ 	status = "okay";
+ };
++
++&vop {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vp1 {
++	vp1_out_hdmi1: endpoint@ROCKCHIP_VOP2_EP_HDMI1 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI1>;
++		remote-endpoint = <&hdmi1_in_vp1>;
++	};
++};

--- a/target/linux/rockchip/patches-6.6/057-05-v6.15-arm64-dts-rockchip-Add-GPU-power-domain-regulator-de.patch
+++ b/target/linux/rockchip/patches-6.6/057-05-v6.15-arm64-dts-rockchip-Add-GPU-power-domain-regulator-de.patch
@@ -1,0 +1,48 @@
+From f94500eb7328b35f3d0927635b1aba26c85ea4b0 Mon Sep 17 00:00:00 2001
+From: Sebastian Reichel <sebastian.reichel@collabora.com>
+Date: Thu, 20 Feb 2025 19:58:11 +0100
+Subject: arm64: dts: rockchip: Add GPU power domain regulator dependency for
+ RK3588
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Enabling the GPU power domain requires that the GPU regulator is
+enabled. The regulator is enabled at boot time, but gets disabled
+automatically when there are no users.
+
+This means the system might run into a failure state hanging the
+whole system for the following use cases:
+
+ * if the GPU driver is being probed late (e.g. build as a
+   module and firmware is not in initramfs), the regulator
+   might already have been disabled. In that case the power
+   domain is enabled before the regulator.
+ * unbinding the GPU driver will disable the PM domain and
+   the regulator. When the driver is bound again, the PM
+   domain will be enabled before the regulator and error
+   appears.
+
+Avoid this by adding an explicit regulator dependency to the
+power domain.
+
+Tested-by: Heiko Stuebner <heiko@sntech.de>
+Reported-by: Adrián Martínez Larumbe <adrian.larumbe@collabora.com>
+Tested-by: Adrian Larumbe <adrian.larumbe@collabora.com> # On Rock 5B
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Link: https://lore.kernel.org/r/20250220-rk3588-gpu-pwr-domain-regulator-v6-8-a4f9c24e5b81@kernel.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+@@ -598,6 +598,10 @@
+ 	status = "okay";
+ };
+ 
++&pd_gpu {
++	domain-supply = <&vdd_gpu_s0>;
++};
++
+ &pinctrl {
+ 	hym8563 {
+ 		rtc_int: rtc-int {

--- a/target/linux/rockchip/patches-6.6/058-01-v6.13-arm64-dts-rockchip-add-Radxa-ROCK-5C.patch
+++ b/target/linux/rockchip/patches-6.6/058-01-v6.13-arm64-dts-rockchip-add-Radxa-ROCK-5C.patch
@@ -1,0 +1,957 @@
+From 3ddf5cdb77e6efd6fe9b70f36dec935e324a3cd2 Mon Sep 17 00:00:00 2001
+From: FUKAUMI Naoki <naoki@radxa.com>
+Date: Mon, 21 Oct 2024 09:05:47 +0000
+Subject: arm64: dts: rockchip: add Radxa ROCK 5C
+
+Radxa ROCK 5C is a 8K computer for everything[1] using the Rockchip
+RK3588S2 chip:
+
+- Rockchip RK3588S2
+- Quad A76 and Quad A55 CPU
+- 6 TOPS NPU
+- up to 32GB LPDDR4x RAM
+- eMMC / SPI flash connector
+- Micro SD Card slot
+- Gigabit ethernet port (supports PoE with add-on PoE HAT)
+- WiFi6 / BT5.4
+- 1x USB 3.0 Type-A HOST port
+- 1x USB 3.0 Type-A OTG port
+- 2x USB 2.0 Type-A HOST port
+- 1x USB Type-C 5V power port
+
+[1] https://radxa.com/products/rock5/5c
+
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+Link: https://lore.kernel.org/r/20241021090548.1052-2-naoki@radxa.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -117,3 +117,4 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-k
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-nanopi-r6s.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-nanopi-r6c.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-rock-5a.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-rock-5c.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
+@@ -0,0 +1,920 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2024 Radxa Computer (Shenzhen) Co., Ltd.
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/soc/rockchip,vop2.h>
++#include "rk3588s.dtsi"
++
++/ {
++	model = "Radxa ROCK 5C";
++	compatible = "radxa,rock-5c", "rockchip,rk3588s";
++
++	aliases {
++		ethernet0 = &gmac1;
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc;
++	};
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	analog-sound {
++		compatible = "audio-graph-card";
++		label = "rk3588-es8316";
++		dais = <&i2s0_8ch_p0>;
++		routing = "MIC2", "Mic Jack",
++			  "Headphones", "HPOL",
++			  "Headphones", "HPOR";
++		widgets = "Microphone", "Mic Jack",
++			  "Headphone", "Headphones";
++	};
++
++	hdmi0-con {
++		compatible = "hdmi-connector";
++		type = "a";
++
++		port {
++			hdmi0_con_in: endpoint {
++				remote-endpoint = <&hdmi0_out_con>;
++			};
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&led_pins>;
++
++		led-0 {
++			color = <LED_COLOR_ID_GREEN>;
++			default-state = "on";
++			function = LED_FUNCTION_POWER;
++			gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_HIGH>;
++		};
++
++		led-1 {
++			color = <LED_COLOR_ID_BLUE>;
++			default-state = "on";
++			function = LED_FUNCTION_HEARTBEAT;
++			gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	fan {
++		compatible = "pwm-fan";
++		#cooling-cells = <2>;
++		cooling-levels = <0 64 128 192 255>;
++		fan-supply = <&vcc_5v0>;
++		pwms = <&pwm3 0 10000 0>;
++	};
++
++	pcie2x1l2_3v3: regulator-pcie2x1l2-3v3 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pow_en>;
++		regulator-name = "pcie2x1l2_3v3";
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc5v_dcin: regulator-vcc5v-dcin {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v_dcin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc5v0_usb_host: regulator-vcc5v0-usb-host {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 RK_PB5 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb_host_pwren_h>;
++		regulator-name = "vcc5v0_usb_host";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc5v0_usb_otg0: regulator-vcc5v0-usb-otg0 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb_otg_pwren_h>;
++		regulator-name = "vcc5v0_usb_otg0";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc_1v1_nldo_s3: regulator-vcc-1v1-nldo-s3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_1v1_nldo_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1100000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc_3v3_pmu: regulator-vcc-3v3-pmu {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_3v3_pmu";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
++	vcc_3v3_s0: regulator-vcc-3v3-s0 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_3v3_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_1v8_s0>;
++	};
++
++	vcc_5v0: regulator-vcc-5v0 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_5v0_pwren_h>;
++		regulator-name = "vcc_5v0";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc_sysin: regulator-vcc-sysin {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sysin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc5v_dcin>;
++	};
++
++	vcca: regulator-vcca {
++		compatible = "regulator-fixed";
++		regulator-name = "vcca";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <4000000>;
++		regulator-max-microvolt = <4000000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vdd_3v3: regulator-vdd-3v3 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb_wifi_pwr>;
++		regulator-name = "vdd_3v3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++};
++
++&combphy0_ps {
++	status = "okay";
++};
++
++&combphy2_psu {
++	status = "okay";
++};
++
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b1 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b2 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_b3 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l1 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l2 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l3 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&gmac1 {
++	phy-handle = <&rgmii_phy1>;
++	phy-mode = "rgmii-id";
++	phy-supply = <&vcc_3v3_s0>;
++	pinctrl-0 = <&gmac1_miim
++		     &gmac1_tx_bus2
++		     &gmac1_rx_bus2
++		     &gmac1_rgmii_clk
++		     &gmac1_rgmii_bus
++		     &gmac1_clkinout>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&gpu {
++	mali-supply = <&vdd_gpu_s0>;
++	status = "okay";
++};
++
++&hdmi0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&hdmim0_tx0_cec
++		     &hdmim1_tx0_hpd
++		     &hdmim0_tx0_scl
++		     &hdmim0_tx0_sda>;
++	status = "okay";
++};
++
++&hdmi0_in {
++	hdmi0_in_vp0: endpoint {
++		remote-endpoint = <&vp0_out_hdmi0>;
++	};
++};
++
++&hdmi0_out {
++	hdmi0_out_con: endpoint {
++		remote-endpoint = <&hdmi0_con_in>;
++	};
++};
++
++&hdptxphy_hdmi0 {
++	status = "okay";
++};
++
++&i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c0m2_xfer>;
++	status = "okay";
++
++	vdd_cpu_big0_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big0_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc_sysin>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_cpu_big1_s0: regulator@43 {
++		compatible = "rockchip,rk8603", "rockchip,rk8602";
++		reg = <0x43>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big1_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc_sysin>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	eeprom@50 {
++		compatible = "belling,bl24c16a", "atmel,24c16";
++		reg = <0x50>;
++		pagesize = <16>;
++		vcc-supply = <&vcc_3v3_pmu>;
++	};
++};
++
++&i2c2 {
++	status = "okay";
++
++	vdd_npu_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_npu_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <950000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc_sysin>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c5m2_xfer>;
++	status = "okay";
++
++	rtc@51 {
++		compatible = "haoyu,hym8563";
++		reg = <0x51>;
++		#clock-cells = <0>;
++		clock-output-names = "rtcic_32kout";
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&rtc_int_l>;
++	};
++};
++
++&i2c7 {
++	status = "okay";
++
++	audio-codec@11 {
++		compatible = "everest,es8316";
++		reg = <0x11>;
++		assigned-clocks = <&cru I2S0_8CH_MCLKOUT>;
++		assigned-clock-rates = <12288000>;
++		clocks = <&cru I2S0_8CH_MCLKOUT>;
++		clock-names = "mclk";
++		#sound-dai-cells = <0>;
++
++		port {
++			es8316_p0_0: endpoint {
++				remote-endpoint = <&i2s0_8ch_p0_0>;
++			};
++		};
++	};
++};
++
++&i2s0_8ch {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2s0_lrck
++		     &i2s0_mclk
++		     &i2s0_sclk
++		     &i2s0_sdi0
++		     &i2s0_sdo0>;
++	status = "okay";
++
++	i2s0_8ch_p0: port {
++		i2s0_8ch_p0_0: endpoint {
++			dai-format = "i2s";
++			mclk-fs = <256>;
++			remote-endpoint = <&es8316_p0_0>;
++		};
++	};
++};
++
++&mdio1 {
++	rgmii_phy1: ethernet-phy@1 {
++		compatible = "ethernet-phy-id001c.c916";
++		reg = <1>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&gmac1_rstn>;
++		reset-assert-us = <20000>;
++		reset-deassert-us = <100000>;
++		reset-gpios = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
++	};
++};
++
++&pcie2x1l2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie20x1_2_perstn_m0>;
++	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&pcie2x1l2_3v3>;
++	status = "okay";
++};
++
++&pinctrl {
++	leds {
++		led_pins: led-pins {
++			rockchip,pins = <3 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>,
++					<3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	mdio {
++		gmac1_rstn: gmac1-rstn {
++			rockchip,pins = <3 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie {
++		pcie20x1_2_perstn_m0: pcie20x1-2-perstn-m0 {
++			rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pow_en: pow-en {
++			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	rtc {
++		rtc_int_l: rtc-int-l {
++			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb {
++		usb_host_pwren_h: usb-host-pwren-h {
++			rockchip,pins = <4 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		usb_otg_pwren_h: usb-otg-pwren-h {
++			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		usb_wifi_pwr: usb-wifi-pwr {
++			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		vcc_5v0_pwren_h: vcc-5v0-pwren-h {
++			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&pwm3 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm3m1_pins>;
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&vcca_1v8_s0>;
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	no-sdio;
++	no-sd;
++	non-removable;
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	disable-wp;
++	no-sdio;
++	no-mmc;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_3v3_s3>;
++	vqmmc-supply = <&vccio_sd_s0>;
++	status = "okay";
++};
++
++&sfc {
++	pinctrl-names = "default";
++	pinctrl-0 = <&fspim0_pins>;
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <104000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <1>;
++	};
++};
++
++&spi2 {
++	status = "okay";
++	assigned-clocks = <&cru CLK_SPI2>;
++	assigned-clock-rates = <200000000>;
++	num-cs = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
++
++	pmic@0 {
++		compatible = "rockchip,rk806";
++		reg = <0>;
++		gpio-controller;
++		#gpio-cells = <2>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
++			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++		spi-max-frequency = <1000000>;
++		system-power-controller;
++
++		vcc1-supply = <&vcc_sysin>;
++		vcc2-supply = <&vcc_sysin>;
++		vcc3-supply = <&vcc_sysin>;
++		vcc4-supply = <&vcc_sysin>;
++		vcc5-supply = <&vcc_sysin>;
++		vcc6-supply = <&vcc_sysin>;
++		vcc7-supply = <&vcc_sysin>;
++		vcc8-supply = <&vcc_sysin>;
++		vcc9-supply = <&vcc_sysin>;
++		vcc10-supply = <&vcc_sysin>;
++		vcc11-supply = <&vcc_2v0_pldo_s3>;
++		vcc12-supply = <&vcc_sysin>;
++		vcc13-supply = <&vcc_1v1_nldo_s3>;
++		vcc14-supply = <&vcc_1v1_nldo_s3>;
++		vcca-supply = <&vcca>;
++
++		rk806_dvs1_null: dvs1-null-pins {
++			pins = "gpio_pwrctrl1";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs2_null: dvs2-null-pins {
++			pins = "gpio_pwrctrl2";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs3_null: dvs3-null-pins {
++			pins = "gpio_pwrctrl3";
++			function = "pin_fun0";
++		};
++
++		regulators {
++			vdd_gpu_s0: dcdc-reg1 {
++				regulator-name = "vdd_gpu_s0";
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-enable-ramp-delay = <400>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_lit_s0: dcdc-reg2 {
++				regulator-name = "vdd_cpu_lit_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_logic_s0: dcdc-reg3 {
++				regulator-name = "vdd_logic_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_vdenc_s0: dcdc-reg4 {
++				regulator-name = "vdd_vdenc_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_ddr_s0: dcdc-reg5 {
++				regulator-name = "vdd_ddr_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <900000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdd2_ddr_s3: dcdc-reg6 {
++				regulator-name = "vdd2_ddr_s3";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_2v0_pldo_s3: dcdc-reg7 {
++				regulator-name = "vdd_2v0_pldo_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <2000000>;
++				regulator-max-microvolt = <2000000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <2000000>;
++				};
++			};
++
++			vcc_3v3_s3: dcdc-reg8 {
++				regulator-name = "vcc_3v3_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vddq_ddr_s0: dcdc-reg9 {
++				regulator-name = "vddq_ddr_s0";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc1v8_pmu_ddr_s3: dcdc-reg10 {
++				regulator-name = "vcc1v8_pmu_ddr_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc_1v8_s0: pldo-reg1 {
++				regulator-name = "vcc_1v8_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcca_1v8_s0: pldo-reg2 {
++				regulator-name = "vcca_1v8_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdda_1v2_s0: pldo-reg3 {
++				regulator-name = "vdda_1v2_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcca_3v3_s0: pldo-reg4 {
++				regulator-name = "vcca_3v3_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vccio_sd_s0: pldo-reg5 {
++				regulator-name = "vccio_sd_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			pldo6_s3: pldo-reg6 {
++				regulator-name = "pldo6_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_0v75_s3: nldo-reg1 {
++				regulator-name = "vdd_0v75_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdda_ddr_pll_s0: nldo-reg2 {
++				regulator-name = "vdda_ddr_pll_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdda_0v75_s0: nldo-reg3 {
++				regulator-name = "vdda_0v75_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdda_0v85_s0: nldo-reg4 {
++				regulator-name = "vdda_0v85_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v75_s0: nldo-reg5 {
++				regulator-name = "vdd_0v75_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++};
++
++&tsadc {
++	status = "okay";
++};
++
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	phy-supply = <&vcc5v0_usb_otg0>;
++	status = "okay";
++};
++
++&u2phy2 {
++	status = "okay";
++};
++
++&u2phy2_host {
++	/* connected to USB hub, which is powered by vcc_5v0 */
++	phy-supply = <&vcc_5v0>;
++	status = "okay";
++};
++
++&u2phy3 {
++	status = "okay";
++};
++
++&u2phy3_host {
++	phy-supply = <&vcc5v0_usb_host>;
++	status = "okay";
++};
++
++&uart2 {
++	pinctrl-0 = <&uart2m0_xfer>;
++	status = "okay";
++};
++
++&usbdp_phy0 {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_xhci {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usb_host1_ehci {
++	status = "okay";
++};
++
++&usb_host1_ohci {
++	status = "okay";
++};
++
++&usb_host2_xhci {
++	status = "okay";
++};
++
++&vop_mmu {
++	status = "okay";
++};
++
++&vop {
++	status = "okay";
++};
++
++&vp0 {
++	vp0_out_hdmi0: endpoint@ROCKCHIP_VOP2_EP_HDMI0 {
++		reg = <ROCKCHIP_VOP2_EP_HDMI0>;
++		remote-endpoint = <&hdmi0_in_vp0>;
++	};
++};

--- a/target/linux/rockchip/patches-6.6/058-02-v6.15-arm64-dts-rockchip-Add-finer-grained-PWM-states-for-.patch
+++ b/target/linux/rockchip/patches-6.6/058-02-v6.15-arm64-dts-rockchip-Add-finer-grained-PWM-states-for-.patch
@@ -1,0 +1,34 @@
+From 6ed35e6ff556626734c400fff5a636b38b91fe19 Mon Sep 17 00:00:00 2001
+From: Alexey Charkov <alchark@gmail.com>
+Date: Mon, 20 Jan 2025 23:22:46 +0400
+Subject: arm64: dts: rockchip: Add finer-grained PWM states for the fan on
+ Rock 5C
+
+Radxa Heatsink 6540B, which is the official cooling accessory for the
+Rock 5C board, includes a small 5V fan, which in my testing spins up
+reliably at a PWM setting of 24 (out of 255). It is also quite loud
+at the current minimum setting of 64, and noticeably less so at 24.
+
+Introduce two intermediate PWM states at the lower end of the fan's
+operating range to enable better balance between noise and cooling.
+
+Note further that, in my testing, having the fan run at 44 is enough
+to keep the system from thermal throttling with sustained 100% load
+on its 8 CPU cores (in 22C ambient temperature and no case)
+
+Signed-off-by: Alexey Charkov <alchark@gmail.com>
+Acked-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/20250120-rock-5c-fan-v1-1-5fb8446c981b@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
+@@ -71,7 +71,7 @@
+ 	fan {
+ 		compatible = "pwm-fan";
+ 		#cooling-cells = <2>;
+-		cooling-levels = <0 64 128 192 255>;
++		cooling-levels = <0 24 44 64 128 192 255>;
+ 		fan-supply = <&vcc_5v0>;
+ 		pwms = <&pwm3 0 10000 0>;
+ 	};

--- a/target/linux/rockchip/patches-6.6/058-03-v6.15-arm64-dts-rockchip-Enable-automatic-fan-control-on-R.patch
+++ b/target/linux/rockchip/patches-6.6/058-03-v6.15-arm64-dts-rockchip-Enable-automatic-fan-control-on-R.patch
@@ -1,0 +1,62 @@
+From cd5681e63fb9887bd05d4ef59151d6a6b39c9d33 Mon Sep 17 00:00:00 2001
+From: Alexey Charkov <alchark@gmail.com>
+Date: Mon, 20 Jan 2025 23:22:47 +0400
+Subject: arm64: dts: rockchip: Enable automatic fan control on Radxa Rock 5C
+
+Add the necessary cooling map to enable the kernel's thermal subsystem
+to manage the fan speed automatically depending on the overall SoC
+package temperature on Radxa Rock 5C
+
+Signed-off-by: Alexey Charkov <alchark@gmail.com>
+Reviewed-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/20250120-rock-5c-fan-v1-2-5fb8446c981b@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
+@@ -68,7 +68,7 @@
+ 		};
+ 	};
+ 
+-	fan {
++	fan: fan {
+ 		compatible = "pwm-fan";
+ 		#cooling-cells = <2>;
+ 		cooling-levels = <0 24 44 64 128 192 255>;
+@@ -417,6 +417,36 @@
+ 	};
+ };
+ 
++&package_thermal {
++	polling-delay = <1000>;
++
++	trips {
++		package_fan0: package-fan0 {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		package_fan1: package-fan1 {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map0 {
++			trip = <&package_fan0>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map1 {
++			trip = <&package_fan1>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
+ &pcie2x1l2 {
+ 	pinctrl-names = "default";
+ 	pinctrl-0 = <&pcie20x1_2_perstn_m0>;

--- a/target/linux/rockchip/patches-6.6/058-04-v6.15-arm64-dts-rockchip-Fix-label-name-of-hdptxphy-for-RK.patch
+++ b/target/linux/rockchip/patches-6.6/058-04-v6.15-arm64-dts-rockchip-Fix-label-name-of-hdptxphy-for-RK.patch
@@ -1,0 +1,26 @@
+From 2efdb041019fd6c58abefba3eb6fdc4d659e576c Mon Sep 17 00:00:00 2001
+From: Damon Ding <damon.ding@rock-chips.com>
+Date: Thu, 6 Feb 2025 11:03:30 +0800
+Subject: arm64: dts: rockchip: Fix label name of hdptxphy for RK3588
+
+The hdptxphy is a combo transmit-PHY for HDMI2.1 TMDS Link, FRL Link, DP
+and eDP Link. Therefore, it is better to name it hdptxphy0 other than
+hdptxphy_hdmi0, which will be referenced by both hdmi0 and edp0 nodes.
+
+Signed-off-by: Damon Ding <damon.ding@rock-chips.com>
+Link: https://lore.kernel.org/r/20250206030330.680424-3-damon.ding@rock-chips.com
+[added armsom-sige7, where hdmi-support was added recently and also
+ the hdptxphy0-as-dclk source I just added]
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
+@@ -278,7 +278,7 @@
+ 	};
+ };
+ 
+-&hdptxphy_hdmi0 {
++&hdptxphy0 {
+ 	status = "okay";
+ };
+ 

--- a/target/linux/rockchip/patches-6.6/058-05-v6.15-arm64-dts-rockchip-switch-Rock-5C-to-PMIC-based-TSHU.patch
+++ b/target/linux/rockchip/patches-6.6/058-05-v6.15-arm64-dts-rockchip-switch-Rock-5C-to-PMIC-based-TSHU.patch
@@ -1,0 +1,36 @@
+From 52cababc9c1914ebf50929bfb9a67c8f74cd60ab Mon Sep 17 00:00:00 2001
+From: Alexey Charkov <alchark@gmail.com>
+Date: Tue, 4 Feb 2025 13:02:28 +0400
+Subject: arm64: dts: rockchip: switch Rock 5C to PMIC-based TSHUT reset
+
+Radxa Rock 5C supports both CRU-based (default) and PMIC-based reset
+upon thermal runaway conditions. The former resets the SoC by internally
+poking the CRU from TSADC, while the latter power-cycles the whole board
+by pulling the PMIC reset line low in case of uncontrolled overheating.
+
+Switch to a PMIC-based reset, as the more 'thorough' of the two.
+
+Tested by temporarily setting rockchip,hw-tshut-temp to 65C to simulate
+overheating - this causes the board to reset when any of the on-chip
+temperature sensors surpasses the tshut temperature.
+
+Requires Alexander's patch [1] fixing TSADC pinctrl assignment
+
+[1] https://lore.kernel.org/r/20250130053849.4902-1-eagle.alexander923@gmail.com
+
+Signed-off-by: Alexey Charkov <alchark@gmail.com>
+Reviewed-by: Dragan Simic <dsimic@manjaro.org>
+Link: https://lore.kernel.org/r/20250204-rock-5c-tshut-v1-1-33301e4eef64@gmail.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
+@@ -873,6 +873,8 @@
+ };
+ 
+ &tsadc {
++	rockchip,hw-tshut-mode = <1>; /* tshut mode 0:CRU 1:GPIO */
++	rockchip,hw-tshut-polarity = <0>; /* tshut polarity 0:LOW 1:HIGH */
+ 	status = "okay";
+ };
+ 

--- a/target/linux/rockchip/patches-6.6/058-06-v6.15-arm64-dts-rockchip-Add-GPU-power-domain-regulator-de.patch
+++ b/target/linux/rockchip/patches-6.6/058-06-v6.15-arm64-dts-rockchip-Add-GPU-power-domain-regulator-de.patch
@@ -1,0 +1,48 @@
+From f94500eb7328b35f3d0927635b1aba26c85ea4b0 Mon Sep 17 00:00:00 2001
+From: Sebastian Reichel <sebastian.reichel@collabora.com>
+Date: Thu, 20 Feb 2025 19:58:11 +0100
+Subject: arm64: dts: rockchip: Add GPU power domain regulator dependency for
+ RK3588
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Enabling the GPU power domain requires that the GPU regulator is
+enabled. The regulator is enabled at boot time, but gets disabled
+automatically when there are no users.
+
+This means the system might run into a failure state hanging the
+whole system for the following use cases:
+
+ * if the GPU driver is being probed late (e.g. build as a
+   module and firmware is not in initramfs), the regulator
+   might already have been disabled. In that case the power
+   domain is enabled before the regulator.
+ * unbinding the GPU driver will disable the PM domain and
+   the regulator. When the driver is bound again, the PM
+   domain will be enabled before the regulator and error
+   appears.
+
+Avoid this by adding an explicit regulator dependency to the
+power domain.
+
+Tested-by: Heiko Stuebner <heiko@sntech.de>
+Reported-by: Adrián Martínez Larumbe <adrian.larumbe@collabora.com>
+Tested-by: Adrian Larumbe <adrian.larumbe@collabora.com> # On Rock 5B
+Signed-off-by: Sebastian Reichel <sebastian.reichel@collabora.com>
+Link: https://lore.kernel.org/r/20250220-rk3588-gpu-pwr-domain-regulator-v6-8-a4f9c24e5b81@kernel.org
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
+@@ -455,6 +455,10 @@
+ 	status = "okay";
+ };
+ 
++&pd_gpu {
++	domain-supply = <&vdd_gpu_s0>;
++};
++
+ &pinctrl {
+ 	leds {
+ 		led_pins: led-pins {

--- a/target/linux/rockchip/patches-6.6/059-v6.14-arm64-dts-rockchip-Add-Radxa-E52C.patch
+++ b/target/linux/rockchip/patches-6.6/059-v6.14-arm64-dts-rockchip-Add-Radxa-E52C.patch
@@ -1,0 +1,780 @@
+From 9be4171219b659a8f0fa0a7913af2c6ab20c714e Mon Sep 17 00:00:00 2001
+From: FUKAUMI Naoki <naoki@radxa.com>
+Date: Thu, 26 Dec 2024 02:46:30 +0000
+Subject: arm64: dts: rockchip: Add Radxa E52C
+
+Radxa E52C[1] is a compact network computer based on the Rockchip
+RK3582 SoC:
+
+- Dual Cortex-A76 and quad Cortex-A55 CPU
+- 5TOPS NPU
+- 2GB/4GB/8GB LPDDR4 RAM
+- 16GB/32GB/64GB on-board eMMC
+- microSD card slot
+- USB 3.0 Type-A HOST port
+- USB Type-C debug port
+- USB Type-C power port (5V only)
+- 2x 2.5GbE ports
+
+[1] https://radxa.com/products/network-computer/e52c
+
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
+Link: https://lore.kernel.org/r/20241226024630.13702-3-naoki@radxa.com
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -103,6 +103,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-ra
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-roc-pc.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-rock-3a.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-rock-3b.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3582-radxa-e52c.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-armsom-sige7.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-edgeble-neu6a-io.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-edgeble-neu6b-io.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3582-radxa-e52c.dts
+@@ -0,0 +1,743 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2024 Radxa Computer (Shenzhen) Co., Ltd.
++ */
++
++/dts-v1/;
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++#include <dt-bindings/pwm/pwm.h>
++#include "rk3588s.dtsi"
++
++/ {
++	model = "Radxa E52C";
++	compatible = "radxa,e52c", "rockchip,rk3582", "rockchip,rk3588s";
++
++	aliases {
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc;
++	};
++
++	chosen {
++		stdout-path = "serial2:1500000n8";
++	};
++
++	keys-0 {
++		compatible = "adc-keys";
++		io-channels = <&saradc 0>;
++		io-channel-names = "buttons";
++		keyup-threshold-microvolt = <18000>;
++		poll-interval = <100>;
++
++		button-0 {
++			label = "Maskrom";
++			linux,code = <KEY_VENDOR>;
++			press-threshold-microvolt = <0>;
++		};
++	};
++
++	keys-1 {
++		compatible = "gpio-keys";
++		pinctrl-names = "default";
++		pinctrl-0 = <&btn_0>;
++
++		button-1 {
++			label = "User";
++			gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_LOW>;
++			linux,code = <BTN_0>;
++			wakeup-source;
++		};
++	};
++
++	leds-0 {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&led_0>;
++
++		led-0 {
++			color = <LED_COLOR_ID_GREEN>;
++			default-state = "on";
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++		};
++	};
++
++	leds-1 {
++		compatible = "pwm-leds";
++
++		led-1 {
++			color = <LED_COLOR_ID_GREEN>;
++			default-state = "on";
++			function = LED_FUNCTION_LAN;
++			linux,default-trigger = "netdev";
++			pwms = <&pwm14 0 1000000 PWM_POLARITY_INVERTED>;
++			max-brightness = <255>;
++		};
++
++		led-2 {
++			color = <LED_COLOR_ID_GREEN>;
++			default-state = "on";
++			function = LED_FUNCTION_WAN;
++			linux,default-trigger = "netdev";
++			pwms = <&pwm11 0 1000000 PWM_POLARITY_INVERTED>;
++			max-brightness = <255>;
++		};
++	};
++
++	vcc_1v1_nldo_s3: regulator-1v1 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_1v1_nldo_s3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1100000>;
++		regulator-max-microvolt = <1100000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc_3v3_pmu: regulator-3v3-0 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_3v3_pmu";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
++	vcc_3v3_s0: regulator-3v3-1 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_3v3_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_3v3_s3>;
++	};
++
++	vcca: regulator-4v0 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcca";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <4000000>;
++		regulator-max-microvolt = <4000000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc5v0_usb_otg0: regulator-5v0-0 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio0 RK_PD4 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&usb_otg_pwren_h>;
++		regulator-name = "vcc5v0_usb_otg0";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc_5v0: regulator-5v0-1 {
++		compatible = "regulator-fixed";
++		enable-active-high;
++		gpio = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&vcc_5v0_pwren_h>;
++		regulator-name = "vcc_5v0";
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++		vin-supply = <&vcc_sysin>;
++	};
++
++	vcc_sysin: regulator-5v0-2 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_sysin";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++};
++
++&combphy0_ps {
++	status = "okay";
++};
++
++&combphy2_psu {
++	status = "okay";
++};
++
++/*
++ * In the Rockchip RK3582 SoC, some CPU cores end up disabled
++ * and unused because they're marked in the efuses as defective.
++ * The disabling in the DT is performed by the boot loader.
++ */
++&cpu_b0 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b1 {
++	cpu-supply = <&vdd_cpu_big0_s0>;
++};
++
++&cpu_b2 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_b3 {
++	cpu-supply = <&vdd_cpu_big1_s0>;
++};
++
++&cpu_l0 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l1 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l2 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&cpu_l3 {
++	cpu-supply = <&vdd_cpu_lit_s0>;
++};
++
++&i2c0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c0m2_xfer>;
++	status = "okay";
++
++	vdd_cpu_big0_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big0_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc_sysin>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	vdd_cpu_big1_s0: regulator@43 {
++		compatible = "rockchip,rk8603", "rockchip,rk8602";
++		reg = <0x43>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_cpu_big1_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <1050000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc_sysin>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++
++	eeprom@50 {
++		compatible = "belling,bl24c16a", "atmel,24c16";
++		reg = <0x50>;
++		pagesize = <16>;
++		vcc-supply = <&vcc_3v3_pmu>;
++	};
++};
++
++&i2c2 {
++	status = "okay";
++
++	vdd_npu_s0: regulator@42 {
++		compatible = "rockchip,rk8602";
++		reg = <0x42>;
++		fcs,suspend-voltage-selector = <1>;
++		regulator-name = "vdd_npu_s0";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <550000>;
++		regulator-max-microvolt = <950000>;
++		regulator-ramp-delay = <2300>;
++		vin-supply = <&vcc_sysin>;
++
++		regulator-state-mem {
++			regulator-off-in-suspend;
++		};
++	};
++};
++
++&i2c5 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&i2c5m2_xfer>;
++	status = "okay";
++
++	rtc@51 {
++		compatible = "haoyu,hym8563";
++		reg = <0x51>;
++		#clock-cells = <0>;
++		clock-output-names = "rtcic_32kout";
++		interrupt-parent = <&gpio0>;
++		interrupts = <RK_PB0 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&rtc_int_l>;
++		wakeup-source;
++	};
++};
++
++&pcie2x1l1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie20x1_1_perstn_m1>;
++	reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc_3v3_s3>;
++	status = "okay";
++};
++
++&pcie2x1l2 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pcie20x1_2_perstn_m0>;
++	reset-gpios = <&gpio3 RK_PD1 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc_3v3_s3>;
++	status = "okay";
++};
++
++&pinctrl {
++	keys {
++		btn_0: button-0 {
++			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	leds {
++		led_0: led-0 {
++			rockchip,pins = <3 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie {
++		pcie20x1_1_perstn_m1: pcie-1 {
++			rockchip,pins = <4 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		pcie20x1_2_perstn_m0: pcie-2 {
++			rockchip,pins = <3 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	regulators {
++		vcc_5v0_pwren_h: regulator-5v0-1 {
++			rockchip,pins = <4 RK_PA3 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	rtc {
++		rtc_int_l: rtc-0 {
++			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	usb {
++		usb_otg_pwren_h: regulator-5v0-0 {
++			rockchip,pins = <0 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++};
++
++&pwm11 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm11m1_pins>;
++	status = "okay";
++};
++
++&pwm14 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&pwm14m1_pins>;
++	status = "okay";
++};
++
++&saradc {
++	vref-supply = <&vcca_1v8_s0>;
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	mmc-hs400-1_8v;
++	mmc-hs400-enhanced-strobe;
++	no-sd;
++	no-sdio;
++	non-removable;
++	vmmc-supply = <&vcc_3v3_s0>;
++	vqmmc-supply = <&vcc_1v8_s3>;
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-sd-highspeed;
++	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
++	disable-wp;
++	no-sdio;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc_3v3_s3>;
++	vqmmc-supply = <&vccio_sd_s0>;
++	status = "okay";
++};
++
++&spi2 {
++	status = "okay";
++	assigned-clocks = <&cru CLK_SPI2>;
++	assigned-clock-rates = <200000000>;
++	num-cs = <1>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;
++
++	pmic@0 {
++		compatible = "rockchip,rk806";
++		reg = <0>;
++		gpio-controller;
++		#gpio-cells = <2>;
++		interrupt-parent = <&gpio0>;
++		interrupts = <7 IRQ_TYPE_LEVEL_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&pmic_pins>, <&rk806_dvs1_null>,
++			    <&rk806_dvs2_null>, <&rk806_dvs3_null>;
++		spi-max-frequency = <1000000>;
++		system-power-controller;
++
++		vcc1-supply = <&vcc_sysin>;
++		vcc2-supply = <&vcc_sysin>;
++		vcc3-supply = <&vcc_sysin>;
++		vcc4-supply = <&vcc_sysin>;
++		vcc5-supply = <&vcc_sysin>;
++		vcc6-supply = <&vcc_sysin>;
++		vcc7-supply = <&vcc_sysin>;
++		vcc8-supply = <&vcc_sysin>;
++		vcc9-supply = <&vcc_sysin>;
++		vcc10-supply = <&vcc_sysin>;
++		vcc11-supply = <&vcc_2v0_pldo_s3>;
++		vcc12-supply = <&vcc_sysin>;
++		vcc13-supply = <&vcc_1v1_nldo_s3>;
++		vcc14-supply = <&vcc_1v1_nldo_s3>;
++		vcca-supply = <&vcca>;
++
++		rk806_dvs1_null: dvs1-null-pins {
++			pins = "gpio_pwrctrl1";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs2_null: dvs2-null-pins {
++			pins = "gpio_pwrctrl2";
++			function = "pin_fun0";
++		};
++
++		rk806_dvs3_null: dvs3-null-pins {
++			pins = "gpio_pwrctrl3";
++			function = "pin_fun0";
++		};
++
++		regulators {
++			vdd_gpu_s0: dcdc-reg1 {
++				regulator-name = "vdd_gpu_s0";
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++				regulator-enable-ramp-delay = <400>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_cpu_lit_s0: dcdc-reg2 {
++				regulator-name = "vdd_cpu_lit_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_logic_s0: dcdc-reg3 {
++				regulator-name = "vdd_logic_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <750000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdd_vdenc_s0: dcdc-reg4 {
++				regulator-name = "vdd_vdenc_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <550000>;
++				regulator-max-microvolt = <950000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_ddr_s0: dcdc-reg5 {
++				regulator-name = "vdd_ddr_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <675000>;
++				regulator-max-microvolt = <900000>;
++				regulator-ramp-delay = <12500>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdd2_ddr_s3: dcdc-reg6 {
++				regulator-name = "vdd2_ddr_s3";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++				};
++			};
++
++			vcc_2v0_pldo_s3: dcdc-reg7 {
++				regulator-name = "vcc_2v0_pldo_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <2000000>;
++				regulator-max-microvolt = <2000000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <2000000>;
++				};
++			};
++
++			vcc_3v3_s3: dcdc-reg8 {
++				regulator-name = "vcc_3v3_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vddq_ddr_s0: dcdc-reg9 {
++				regulator-name = "vddq_ddr_s0";
++				regulator-always-on;
++				regulator-boot-on;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcc_1v8_s3: dcdc-reg10 {
++				regulator-name = "vcc_1v8_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcc_1v8_s0: pldo-reg1 {
++				regulator-name = "vcc_1v8_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vcca_1v8_s0: pldo-reg2 {
++				regulator-name = "vcca_1v8_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdda_1v2_s0: pldo-reg3 {
++				regulator-name = "vdda_1v2_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1200000>;
++				regulator-max-microvolt = <1200000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vcca_3v3_s0: pldo-reg4 {
++				regulator-name = "vcca_3v3_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <3300000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <3300000>;
++				};
++			};
++
++			vccio_sd_s0: pldo-reg5 {
++				regulator-name = "vccio_sd_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <3300000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			pldo6_s3: pldo-reg6 {
++				regulator-name = "pldo6_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <1800000>;
++				regulator-max-microvolt = <1800000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <1800000>;
++				};
++			};
++
++			vdd_0v75_s3: nldo-reg1 {
++				regulator-name = "vdd_0v75_s3";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdda_ddr_pll_s0: nldo-reg2 {
++				regulator-name = "vdda_ddr_pll_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <850000>;
++				};
++			};
++
++			vdda_0v75_s0: nldo-reg3 {
++				regulator-name = "vdda_0v75_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++
++				regulator-state-mem {
++					regulator-on-in-suspend;
++					regulator-suspend-microvolt = <750000>;
++				};
++			};
++
++			vdda_0v85_s0: nldo-reg4 {
++				regulator-name = "vdda_0v85_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <850000>;
++				regulator-max-microvolt = <850000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++
++			vdd_0v75_s0: nldo-reg5 {
++				regulator-name = "vdd_0v75_s0";
++				regulator-always-on;
++				regulator-boot-on;
++				regulator-min-microvolt = <750000>;
++				regulator-max-microvolt = <750000>;
++
++				regulator-state-mem {
++					regulator-off-in-suspend;
++				};
++			};
++		};
++	};
++};
++
++&tsadc {
++	status = "okay";
++};
++
++&u2phy0 {
++	status = "okay";
++};
++
++&u2phy0_otg {
++	phy-supply = <&vcc5v0_usb_otg0>;
++	status = "okay";
++};
++
++&uart2 {
++	pinctrl-0 = <&uart2m0_xfer>;
++	status = "okay";
++};
++
++&usb_host0_xhci {
++	dr_mode = "host";
++	status = "okay";
++};
++
++&usbdp_phy0 {
++	status = "okay";
++};

--- a/target/linux/rockchip/patches-6.6/116-arm64-dts-rockchip-Update-LED-properties-for-Radxa-Ro.patch
+++ b/target/linux/rockchip/patches-6.6/116-arm64-dts-rockchip-Update-LED-properties-for-Radxa-Ro.patch
@@ -11,28 +11,49 @@ Signed-off-by: Tianling Shen <cnsztl@gmail.com>
 
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
-@@ -14,6 +14,11 @@
+@@ -15,6 +15,11 @@
  	aliases {
  		mmc0 = &sdhci;
  		mmc1 = &sdmmc;
 +
-+		led-boot = &status_led;
-+		led-failsafe = &status_led;
-+		led-running = &status_led;
-+		led-upgrade = &status_led;
++		led-boot = &led_green;
++		led-failsafe = &led_green;
++		led-running = &led_green;
++		led-upgrade = &led_green;
  	};
  
  	analog-sound {
-@@ -39,11 +44,10 @@
+@@ -49,13 +54,19 @@
+ 	leds {
+ 		compatible = "gpio-leds";
  		pinctrl-names = "default";
- 		pinctrl-0 = <&io_led>;
+-		pinctrl-0 = <&io_led>;
++		pinctrl-0 = <&leds>;
++
++		led_green: led-0 {
++			color = <LED_COLOR_ID_GREEN>;
++			default-state = "on";
++			function = LED_FUNCTION_POWER;
++			gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_HIGH>;
++		};
  
--		io-led {
-+		status_led: io-led {
+ 		io-led {
  			color = <LED_COLOR_ID_BLUE>;
  			function = LED_FUNCTION_STATUS;
  			gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
 -			linux,default-trigger = "heartbeat";
+ 		};
+ 	};
+ 
+@@ -365,8 +376,9 @@
+ 
+ &pinctrl {
+ 	leds {
+-		io_led: io-led {
+-			rockchip,pins = <3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
++		leds: leds {
++			rockchip,pins = <3 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>,
++					<3 RK_PD5 RK_FUNC_GPIO &pcfg_pull_none>;
  		};
  	};
  

--- a/target/linux/rockchip/patches-6.6/117-arm64-dts-rockchip-lower-mmc-speed-for-Radxa-Rock-5A.patch
+++ b/target/linux/rockchip/patches-6.6/117-arm64-dts-rockchip-lower-mmc-speed-for-Radxa-Rock-5A.patch
@@ -15,7 +15,7 @@ Signed-off-by: Tianling Shen <cnsztl@gmail.com>
 
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
-@@ -409,7 +409,7 @@
+@@ -463,7 +463,7 @@
  	max-frequency = <150000000>;
  	no-sdio;
  	no-mmc;

--- a/target/linux/rockchip/patches-6.6/117-arm64-dts-rockchip-lower-mmc-speed-for-Radxa-Rock-5A.patch
+++ b/target/linux/rockchip/patches-6.6/117-arm64-dts-rockchip-lower-mmc-speed-for-Radxa-Rock-5A.patch
@@ -15,7 +15,7 @@ Signed-off-by: Tianling Shen <cnsztl@gmail.com>
 
 --- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
-@@ -405,7 +405,7 @@
+@@ -409,7 +409,7 @@
  	max-frequency = <150000000>;
  	no-sdio;
  	no-mmc;

--- a/target/linux/rockchip/patches-6.6/118-arm64-dts-rockchip-Update-LED-properties-for-Radxa-Ro.patch
+++ b/target/linux/rockchip/patches-6.6/118-arm64-dts-rockchip-Update-LED-properties-for-Radxa-Ro.patch
@@ -2,37 +2,56 @@ From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Tianling Shen <cnsztl@gmail.com>
 Date: Mon Aug 05 16:14:33 2024 +0800
 Subject: [PATCH] arm64: dts: rockchip: Update LED properties for Radxa
- Rock 5B
+ Rock 5B/5B+/5T
 
 Add OpenWrt's LED aliases for showing system status.
 
 Signed-off-by: Tianling Shen <cnsztl@gmail.com>
+Signed-off-by: FUKAUMI Naoki <naoki@radxa.com>
 ---
 
---- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
-@@ -14,6 +14,11 @@
- 		mmc0 = &sdhci;
- 		mmc1 = &sdmmc;
- 		mmc2 = &sdio;
-+
-+		led-boot = &status_led;
-+		led-failsafe = &status_led;
-+		led-running = &status_led;
-+		led-upgrade = &status_led;
- 	};
- 
- 	chosen {
-@@ -42,11 +47,10 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dtsi
+@@ -27,11 +27,11 @@
  		pinctrl-names = "default";
  		pinctrl-0 = <&led_rgb_b>;
  
 -		led_rgb_b {
-+		status_led: led_rgb_b {
++		led_blue: led_rgb_b {
  			function = LED_FUNCTION_STATUS;
  			color = <LED_COLOR_ID_BLUE>;
++			default-state = "on";
  			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
 -			linux,default-trigger = "heartbeat";
  		};
  	};
  
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
+@@ -30,11 +30,11 @@
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&led_rgb_b>;
+ 
+-		led_rgb_b {
++		led_blue: led_rgb_b {
+ 			function = LED_FUNCTION_STATUS;
+ 			color = <LED_COLOR_ID_BLUE>;
++			default-state = "on";
+ 			gpios = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+ 		};
+ 	};
+ 
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
+@@ -12,6 +12,10 @@
+ 		mmc0 = &sdhci;
+ 		mmc1 = &sdmmc;
+ 		mmc2 = &sdio;
++		led-boot = &led_blue;
++		led-failsafe = &led_blue;
++		led-running = &led_blue;
++		led-upgrade = &led_blue;
+ 	};
+ 
+ 	chosen {

--- a/target/linux/rockchip/patches-6.6/119-arm64-dts-rockchip-lower-mmc-speed-for-Radxa-Rock-5B.patch
+++ b/target/linux/rockchip/patches-6.6/119-arm64-dts-rockchip-lower-mmc-speed-for-Radxa-Rock-5B.patch
@@ -13,9 +13,9 @@ To be on the safe side, lower the speed to workaround.
 Signed-off-by: Tianling Shen <cnsztl@gmail.com>
 ---
 
---- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
-+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
-@@ -419,7 +419,7 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-5bp-5t.dtsi
+@@ -452,7 +452,7 @@
  	cap-sd-highspeed;
  	cd-gpios = <&gpio0 RK_PA4 GPIO_ACTIVE_LOW>;
  	disable-wp;

--- a/target/linux/rockchip/patches-6.6/131-arm64-dts-rockchip-Update-LED-properties-for-Radxa-ROCK-5-ITX.patch
+++ b/target/linux/rockchip/patches-6.6/131-arm64-dts-rockchip-Update-LED-properties-for-Radxa-ROCK-5-ITX.patch
@@ -1,0 +1,30 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+@@ -23,6 +23,10 @@
+ 		mmc0 = &sdhci;
+ 		mmc1 = &sdmmc;
+ 		mmc2 = &sdio;
++		led-boot = &power_led;
++		led-failsafe = &power_led;
++		led-running = &power_led;
++		led-upgrade = &power_led;
+ 	};
+ 
+ 	chosen {
+@@ -62,12 +66,14 @@
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&led_pins>;
+ 
+-		power-led1 {
++		power_led: power-led1 {
++			default-state = "on";
++			function = LED_FUNCTION_POWER;
+ 			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "default-on";
+ 		};
+ 
+ 		hdd-led2 {
++			function = LED_FUNCTION_DISK;
+ 			gpios = <&gpio0 RK_PC0 GPIO_ACTIVE_HIGH>;
+ 			linux,default-trigger = "disk-activity";
+ 		};

--- a/target/linux/rockchip/patches-6.6/132-arm64-dts-rockchip-Update-LED-properties-for-Radxa-ROCK-5C.patch
+++ b/target/linux/rockchip/patches-6.6/132-arm64-dts-rockchip-Update-LED-properties-for-Radxa-ROCK-5C.patch
@@ -1,0 +1,33 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
+@@ -19,6 +19,10 @@
+ 		ethernet0 = &gmac1;
+ 		mmc0 = &sdhci;
+ 		mmc1 = &sdmmc;
++		led-boot = &led_green;
++		led-failsafe = &led_green;
++		led-running = &led_green;
++		led-upgrade = &led_green;
+ 	};
+ 
+ 	chosen {
+@@ -52,7 +56,7 @@
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&led_pins>;
+ 
+-		led-0 {
++		led_green: led-0 {
+ 			color = <LED_COLOR_ID_GREEN>;
+ 			default-state = "on";
+ 			function = LED_FUNCTION_POWER;
+@@ -61,10 +65,8 @@
+ 
+ 		led-1 {
+ 			color = <LED_COLOR_ID_BLUE>;
+-			default-state = "on";
+ 			function = LED_FUNCTION_HEARTBEAT;
+ 			gpios = <&gpio3 RK_PD5 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+ 		};
+ 	};
+ 

--- a/target/linux/rockchip/patches-6.6/133-arm64-dts-rockchip-Update-LED-properties-for-Radxa-E52C.patch
+++ b/target/linux/rockchip/patches-6.6/133-arm64-dts-rockchip-Update-LED-properties-for-Radxa-E52C.patch
@@ -1,0 +1,43 @@
+--- a/arch/arm64/boot/dts/rockchip/rk3582-radxa-e52c.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3582-radxa-e52c.dts
+@@ -19,6 +19,10 @@
+ 	aliases {
+ 		mmc0 = &sdhci;
+ 		mmc1 = &sdmmc;
++		led-boot = &led_green;
++		led-failsafe = &led_green;
++		led-running = &led_green;
++		led-upgrade = &led_green;
+ 	};
+ 
+ 	chosen {
+@@ -57,12 +61,11 @@
+ 		pinctrl-names = "default";
+ 		pinctrl-0 = <&led_0>;
+ 
+-		led-0 {
++		led_green: led-0 {
+ 			color = <LED_COLOR_ID_GREEN>;
+ 			default-state = "on";
+ 			function = LED_FUNCTION_STATUS;
+ 			gpios = <&gpio3 RK_PC4 GPIO_ACTIVE_HIGH>;
+-			linux,default-trigger = "heartbeat";
+ 		};
+ 	};
+ 
+@@ -71,7 +74,6 @@
+ 
+ 		led-1 {
+ 			color = <LED_COLOR_ID_GREEN>;
+-			default-state = "on";
+ 			function = LED_FUNCTION_LAN;
+ 			linux,default-trigger = "netdev";
+ 			pwms = <&pwm14 0 1000000 PWM_POLARITY_INVERTED>;
+@@ -80,7 +82,6 @@
+ 
+ 		led-2 {
+ 			color = <LED_COLOR_ID_GREEN>;
+-			default-state = "on";
+ 			function = LED_FUNCTION_WAN;
+ 			linux,default-trigger = "netdev";
+ 			pwms = <&pwm11 0 1000000 PWM_POLARITY_INVERTED>;


### PR DESCRIPTION
This is a backport of PR #19867.
Run tested on ROCK 5C Lite (RK3582).

Cc: @RadxaNaoki 

---

Improve support for the following Radxa RK358x-based boards:

* Radxa ROCK 5A
* Radxa ROCK 5B
* Radxa ROCK 5B+ (new)
* Radxa ROCK 5T (new)
* Radxa ROCK 5 ITX/ITX+ (new)
* Radxa ROCK 5C/5C Lite (new)
* Radxa E52C (new)
