### PR TITLE
[24.10] ipq40xx: add label-mac and led aliases for Linksys WHW01

### DIFF
--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-whw01.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-whw01.dts
@@ -13,7 +13,9 @@
 		ethernet0 = &gmac;
 		serial0 = &blsp1_uart1;
 		led-boot = &led_system_blue;
+		led-failsafe = &led_system_red;
 		led-running = &led_system_blue;
+		led-upgrade = &led_system_red;
 		label-mac-device = &gmac;
 	};
 
@@ -56,7 +58,7 @@
 		reg = <0x62>;
 
 		/* RGB? */
-		led@0 {
+		led_system_red: led@0 {
 			reg = <0>;
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_POWER;

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-whw01.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4018-whw01.dts
@@ -10,11 +10,11 @@
 	compatible = "linksys,whw01";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
 		ethernet0 = &gmac;
 		serial0 = &blsp1_uart1;
 		led-boot = &led_system_blue;
 		led-running = &led_system_blue;
+		label-mac-device = &gmac;
 	};
 
 	chosen {

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -731,6 +731,23 @@ define Device/linksys_mr8300
 endef
 TARGET_DEVICES += linksys_mr8300
 
+define Device/linksys_whw01
+	$(call Device/FitzImage)
+	DEVICE_VENDOR := Linksys
+	DEVICE_MODEL := WHW01
+	KERNEL_SIZE := 6144k
+	IMAGE_SIZE := 75776k
+	NAND_SIZE := 256m
+	SOC := qcom-ipq4018
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
+	IMAGES += factory.bin
+	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=WHW01
+	DEVICE_PACKAGES := uboot-envtools kmod-leds-pca963x
+endef
+TARGET_DEVICES += linksys_whw01
+
 define Device/linksys_whw03
 	$(call Device/FitzImage)
 	DEVICE_VENDOR := Linksys
@@ -762,23 +779,6 @@ define Device/linksys_whw03v2
 	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-leds-pca963x kmod-spi-dev kmod-bluetooth
 endef
 TARGET_DEVICES += linksys_whw03v2
-
-define Device/linksys_whw01
-	$(call Device/FitzImage)
-	DEVICE_VENDOR := Linksys
-	DEVICE_MODEL := WHW01
-	KERNEL_SIZE := 6144k
-	IMAGE_SIZE := 75776k
-	NAND_SIZE := 256m
-	SOC := qcom-ipq4018
-	BLOCKSIZE := 128k
-	PAGESIZE := 2048
-	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
-	IMAGES += factory.bin
-	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=WHW01
-	DEVICE_PACKAGES := uboot-envtools kmod-leds-pca963x
-endef
-TARGET_DEVICES += linksys_whw01
 
 define Device/luma_wrtq-329acn
 	$(call Device/FitImage)


### PR DESCRIPTION
This adds label-mac and led aliases for failsafe and upgrade. Also remove the TODO as the ethernet0 alias is required to get the correct mac assignment.

I'd like to backport these changes, as i want to add support to gluon soon (which is based on the current 24.10 branch). Having at least the label-mac change available will safe some hassle getting the correct label-mac assigned.