### PR TITLE
ipq40xx: add device alias for Linksys VLP01

### DIFF
--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-whw01.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-whw01.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	model = "Linksys WHW01";
+	model = "Linksys WHW01 / VLP01";
 	compatible = "linksys,whw01";
 
 	aliases {

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -727,6 +727,8 @@ define Device/linksys_whw01
 	$(call Device/FitzImage)
 	DEVICE_VENDOR := Linksys
 	DEVICE_MODEL := WHW01
+	DEVICE_ALT0_VENDOR := Linksys
+	DEVICE_ALT0_MODEL := VLP01
 	KERNEL_SIZE := 6144k
 	IMAGE_SIZE := 75776k
 	NAND_SIZE := 256m


### PR DESCRIPTION
Both devices, the Linksys WHW01 and the VLP01, are essentially the same device. Even Linksys provides only one image for both devices which uses the WHW01 identifier in the image header.

The changes were run tested on an actual unit.
