### PR TITLE
build: handle --root feeds script feature

### DIFF
--- a/include/package-defaults.mk
+++ b/include/package-defaults.mk
@@ -20,7 +20,7 @@ define Package/Default
   PROVIDES:=
   EXTRA_DEPENDS:=
   MAINTAINER:=$(PKG_MAINTAINER)
-  SOURCE:=$(patsubst $(TOPDIR)/%,%,$(patsubst $(TOPDIR)/package/%,feeds/base/%,$(CURDIR)))
+  SOURCE:=$(patsubst $(TOPDIR)/%,%,$(if $(__pkg_source_makefile),$(__pkg_source_makefile),$(CURDIR)))
   ifneq ($(PKG_VERSION),)
     ifneq ($(PKG_RELEASE),)
       VERSION:=$(PKG_VERSION)-r$(PKG_RELEASE)


### PR DESCRIPTION
Rework the package SOURCE entry handling to account for the --root feeds script feature.

Move the SOURCE entry string manipulation logic outside package-defaults.mk in package.mk and limit only to non DUMP scenario to not pollute the .mk too much.

Restructure the previous logic and add a new additional condition. If we detect the package comes from a feed, replace any feed path that have the _root prefix to the feed name with the non-root variant (the feeds script create a symbolic link to it) and point the package SOURCE entry to what the symbolic link points to.

Example:
Feed link: feeds/base_root/package -> feeds/base
Package: feeds/base_root/package/system/uci -> feeds/base/system/uci