### PR TITLE
ipq806x: restore recent changes made to 6.6 dts files

### DIFF
--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-eax500.dtsi
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-eax500.dtsi
@@ -53,22 +53,36 @@
 
 	max-link-speed = <1>;
 
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&precal_art_1000>;
-		nvmem-cell-names = "pre-calibration";
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+			nvmem-cells = <&precal_art_1000>;
+			nvmem-cell-names = "pre-calibration";
+		};
 	};
 };
 
 &pcie1 {
 	status = "okay";
 
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&precal_art_5000>;
-		nvmem-cell-names = "pre-calibration";
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+			nvmem-cells = <&precal_art_5000>;
+			nvmem-cell-names = "pre-calibration";
+		};
 	};
 };
 

--- a/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
+++ b/target/linux/ipq806x/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
@@ -283,22 +283,38 @@
 &pcie0 {
 	status = "okay";
 
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_eeprom_6 1>;
-		nvmem-cell-names = "mac-address";
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_eeprom_6 1>;
+			nvmem-cell-names = "mac-address";
+		};
 	};
 };
 
 &pcie1 {
 	status = "okay";
 
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_eeprom_6 2>;
-		nvmem-cell-names = "mac-address";
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi@1,0 {
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+
+			nvmem-cells = <&macaddr_eeprom_6 2>;
+			nvmem-cell-names = "mac-address";
+		};
 	};
 };
 


### PR DESCRIPTION
a33d59f7af8f (2025-10-14) restored dts files for kernel 6.6 to `files-6.6` after the preceding 15fa59c41f0d moved `files-6.6` to `files-6.12` to be used by the new testing kernel, 6.12. This restoration omitted 1a3f05eb2b8e (2025-10-08), which fixed important aspects of the wifi device definitions in `qcom-ipq8064-eax500.dtsi` and `qcom-ipq8064-unifi-ac-hd.dts`.

The 1a3f05eb2b8e fix persisted into the 6.12 dts files. This change now restores it for 6.6. Note that ipq806x is currently using kernel 6.6 for most purposes, as 6.12 is only in testing status for this target.

This change was prepared with `git diff a33d59f7af8f:target/linux/ipq806x/files-6.6 15fa59c41f0d^:target/linux/ipq806x/files-6.6`. This identified c186d17fa518 (2025-10-08) as another change that was not present in the restored `files-6.6`, but it has since been superseded by 2a709d108e80 (2025-10-20), so no action is necessary to restore it. There were no diffs present between these revisions in `config-6.6` or `patches-6.6`, which were also moved and restored in the 6.12 bring-up.

Cc: @DragonBluep (https://github.com/openwrt/openwrt/pull/18989)
Cc: @neheb (https://github.com/openwrt/openwrt/pull/20325)