### PR TITLE
kernel: rtl8261n: Various fixes

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
@@ -61,6 +61,7 @@ static int rtl826xb_probe(struct phy_device *phydev)
 
     priv->phytype = (phydev->drv->phy_id == REALTEK_PHY_ID_RTL8261N) ? (RTK_PHYLIB_RTL8261N) : (RTK_PHYLIB_RTL8264B);
     priv->isBasePort = (phydev->drv->phy_id == REALTEK_PHY_ID_RTL8261N) ? (1) : (((phydev->mdio.addr % 4) == 0) ? (1) : (0));
+    priv->pnswap_rx = device_property_read_bool(dev, "realtek,pnswap-rx");
     priv->pnswap_tx = device_property_read_bool(dev, "realtek,pnswap-tx");
     phydev->priv = priv;
 
@@ -124,6 +125,11 @@ static int rtkphy_config_init(struct phy_device *phydev)
                 printk("[%s,%d] sds link [%s] (0x%X)\n", __FUNCTION__, __LINE__, (readData & BIT(12)) ? "UP" : "DOWN", readData);
             }
           #endif
+
+            if (priv->pnswap_rx)
+                phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,
+                                 REALTEK_SERDES_GLOBAL_CFG,
+                                 REALTEK_HSI_INV);
 
             if (priv->pnswap_tx)
                 phy_set_bits_mmd(phydev, MDIO_MMD_VEND1,

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
@@ -16,7 +16,7 @@
 #define REALTEK_PHY_ID_RTL8264B         0x001CC813
 #define REALTEK_PHY_ID_RTL8264          0x001CCAF2
 
-#define REALTEK_SERDES_GLOBAL_CFG       0x1c
+#define REALTEK_SERDES_GLOBAL_CFG       0xC1
 #define   REALTEK_HSO_INV               BIT(7)
 #define   REALTEK_HSI_INV               BIT(6)
 

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.h
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.h
@@ -51,6 +51,7 @@ struct rtk_phy_priv {
     uint8 isBasePort;
     rt_phy_patch_db_t *patch;
 
+    bool pnswap_rx;
     bool pnswap_tx;
 };
 


### PR DESCRIPTION
Various fixes including:
Correct serdes control register to correct value of 0xC1
Guard Realtek config patch to only run on Realtek target
Add serdes rx pinswap capability.

It is noted that the datasheet claims that the rx pinswap bit is default set to 0x1, but this was found not to be the case in practice.