### PR TITLE
airoha: adjust and default the loadaddr

### DIFF
--- a/target/linux/airoha/image/Makefile
+++ b/target/linux/airoha/image/Makefile
@@ -1,6 +1,10 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
+loadaddr-$(CONFIG_TARGET_airoha_an7581) := 0x80200000
+loadaddr-$(CONFIG_TARGET_airoha_an7583) := 0x80200000
+loadaddr-$(CONFIG_TARGET_airoha_en7523) := 0x80200000
+
 # default all platform image(fit) build
 define Device/Default
   PROFILES = Default $$(DEVICE_NAME)
@@ -9,6 +13,7 @@ define Device/Default
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL_INITRAMFS = kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_LOADADDR = $(loadaddr-y)
   FILESYSTEMS := squashfs
   DEVICE_DTS = $$(SOC)-$(lastword $(subst _, ,$(1)))
   DEVICE_DTS_DIR := ../dts

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -25,7 +25,6 @@ define Device/airoha_an7581-evb
   DEVICE_PACKAGES := kmod-leds-pwm kmod-i2c-an7581 kmod-pwm-airoha kmod-input-gpio-keys-polled
   DEVICE_DTS := an7581-evb
   DEVICE_DTS_CONFIG := config@1
-  KERNEL_LOADADDR := 0x80088000
   IMAGE/sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | append-metadata
   ARTIFACT/preloader.bin := an7581-preloader rfb
   ARTIFACT/bl31-uboot.fip := an7581-bl31-uboot rfb

--- a/target/linux/airoha/image/en7523.mk
+++ b/target/linux/airoha/image/en7523.mk
@@ -1,5 +1,3 @@
-KERNEL_LOADADDR := 0x80208000
-
 define Target/Description
 	Build firmware images for Airoha EN7523 ARM based boards.
 endef


### PR DESCRIPTION
Similar to e92b153e99 ("mediatek: introduce KERNEL_LOADADDR to Device/Default template"), let's move the default loadaddr to Device/Default.

What's more, use 0x80200000 instead of the SDK default value 0x80088000 to avoid the following error which may overwrite TZ memory and cause crash:
```
    [    0.000000] [Firmware Bug]: Kernel image misaligned at boot, please fix your bootloader!
    [    0.000000] OF: reserved mem: Reserved memory: failed to reserve memory for node 'atf@80000000': base 0x0000000080000000, size 2 MiB
```

Only test on AN7581, but should be work on all subtarget.