### PR TITLE
ipq40xx: meraki: convert to nvmem for calibration

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -7,15 +7,6 @@
 board=$(board_name)
 
 case "$FIRMWARE" in
-"ath10k/cal-pci-0000:01:00.0.bin")
-	case "$board" in
-	meraki,mr33 |\
-	meraki,mr74)
-		caldata_extract_ubi "ART" 0x9000 0x844
-		caldata_valid "4408" || caldata_extract "ART" 0x9000 0x844
-		;;
-	esac
-	;;
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case "$board" in
 	asus,map-ac2200)
@@ -111,11 +102,6 @@ case "$FIRMWARE" in
 		caldata_extract_mmc "0:ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		;;
-	meraki,mr33 |\
-	meraki,mr74)
-		caldata_extract_ubi "ART" 0x1000 0x2f20
-		caldata_valid "202f" || caldata_extract "ART" 0x1000 0x2f20
-		;;
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\
 	mikrotik,hap-ac3 |\
@@ -209,11 +195,6 @@ case "$FIRMWARE" in
 	linksys,whw03)
 		caldata_extract_mmc "0:ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
-		;;
-	meraki,mr33 |\
-	meraki,mr74)
-		caldata_extract_ubi "ART" 0x5000 0x2f20
-		caldata_valid "202f" || caldata_extract "ART" 0x5000 0x2f20
 		;;
 	mikrotik,cap-ac |\
 	mikrotik,hap-ac2 |\

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-insect-common.dtsi
@@ -267,7 +267,32 @@
 				 * confuse the u-boot and it might not
 				 * find the kernel partition anymore.
 				 */
+				volumes {
+					ubi_art: ubi-volume-art {
+						volname = "ART";
+					};
+				};
 			};
+		};
+	};
+};
+
+&ubi_art {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		precal_factory_1000: precal@1000 {
+			reg = <0x1000 0x2f20>;
+		};
+
+		precal_factory_5000: precal@5000 {
+			reg = <0x5000 0x2f20>;
+		};
+
+		cal_factory_9000: cal@9000 {
+			reg = <0x9000 0x844>;
 		};
 	};
 };
@@ -282,8 +307,8 @@
 	wifi@0,0 {
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
-		nvmem-cells = <&mac_address 1>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&mac_address 1>, <&cal_factory_9000>;
+		nvmem-cell-names = "mac-address", "calibration";
 	};
 };
 
@@ -385,16 +410,14 @@
 
 &wifi0 {
 	status = "okay";
-	qcom,ath10k-calibration-variant = "Meraki-MR33";
-	nvmem-cells = <&mac_address 2>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&mac_address 2>, <&precal_factory_1000>;
+	nvmem-cell-names = "mac-address", "pre-calibration";
 };
 
 &wifi1 {
 	status = "okay";
-	qcom,ath10k-calibration-variant = "Meraki-MR33";
-	nvmem-cells = <&mac_address 3>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&mac_address 3>, <&precal_factory_5000>;
+	nvmem-cell-names = "mac-address", "pre-calibration";
 };
 
 &mdio {

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr33.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr33.dts
@@ -11,3 +11,11 @@
 &tricolor {
 	enable-gpios = <&tlmm 48 GPIO_ACTIVE_HIGH>;
 };
+
+&wifi0 {
+	qcom,ath10k-calibration-variant = "Meraki-MR33";
+};
+
+&wifi1 {
+	qcom,ath10k-calibration-variant = "Meraki-MR33";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr74.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr74.dts
@@ -11,3 +11,11 @@
 &tricolor {
 	enable-gpios = <&tlmm 14 GPIO_ACTIVE_LOW>;
 };
+
+&wifi0 {
+	qcom,ath10k-calibration-variant = "Meraki-MR33";
+};
+
+&wifi1 {
+	qcom,ath10k-calibration-variant = "Meraki-MR33";
+};


### PR DESCRIPTION
This commit changes the Meraki MR33 and MR74 device trees to use nvmem for ART calibration.

There is also some device tree clean-up, to align with the work done for the MR30H/Z3/GX20 support.

The WiFi BDF variant was moved from `insect-common.dtsi` to the respective device files in preparation for additional Meraki insect-family devices being added.