### PR TITLE
airoha: support openwrt,netdev-name for renaming interfaces

### DIFF
--- a/target/linux/airoha/base-files/lib/preinit/04_set_netdev_label
+++ b/target/linux/airoha/base-files/lib/preinit/04_set_netdev_label
@@ -1,0 +1,15 @@
+set_netdev_labels() {
+	local dir
+	local label
+	local netdev
+
+	for dir in /sys/class/net/*; do
+		[ -r "$dir/of_node/openwrt,netdev-name" ] || continue
+		read -r label < "$dir/of_node/openwrt,netdev-name"
+		netdev="${dir##*/}"
+		[ "$netdev" = "$label" ] && continue
+		ip link set "$netdev" name "$label"
+	done
+}
+
+boot_hook_add preinit_main set_netdev_labels


### PR DESCRIPTION
Add support to the airoha target for the OpenWrt-specific DT property `openwrt,netdev-name`.
In particular, this is for interfaces under non-DSA `airoha_eth` interfaces.

This will avoid conflicts with upstream code[1]; and maintain forward compatibility with OpenWrt configurations if/when `airoha_eth` becomes a full DSA driver.

[1] https://lore.kernel.org/netdev/20240709124503.pubki5nwjfbedhhy@skbuf/

Borrowed from d4d6c48 (mediatek: filogic: support openwrt,netdev-name for renaming interfaces)

Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>