### PR TITLE
ipq806x: chromium: Pull OnHub caldata directly from VPD

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -6,9 +6,9 @@
 
 board=$(board_name)
 
-dt_base64_extract() {
+base64_extract() {
 	local target_dir="/sys$DEVPATH"
-	local source="$target_dir/../../of_node/qcom,ath10k-calibration-data-base64"
+	local source="$1"
 
 	[ -e "$source" ] || caldata_die "cannot find base64 calibration data: $source"
 	[ -d "$target_dir" ] || \
@@ -30,7 +30,7 @@ case "$FIRMWARE" in
 	case "$board" in
 	asus,onhub |\
 	tplink,onhub)
-		dt_base64_extract
+		base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration0
 		;;
 	meraki,mr52)
 		CI_UBIPART=art
@@ -61,7 +61,7 @@ case "$FIRMWARE" in
 	case "$board" in
 	asus,onhub |\
 	tplink,onhub)
-		dt_base64_extract
+		base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration1
 		;;
 	esac
 	;;
@@ -92,7 +92,7 @@ case "$FIRMWARE" in
 	case "$board" in
 	asus,onhub |\
 	tplink,onhub)
-		dt_base64_extract
+		base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration2
 		;;
 	meraki,mr42)
 		CI_UBIPART=art


### PR DESCRIPTION
Alternative solution to https://github.com/openwrt/openwrt/pull/18989#issuecomment-3417383963 / https://github.com/openwrt/openwrt/pull/20451

I haven't fully tested this yet.

---

The OnHub bootloader tries to patch the calibration directly into the device tree, but it uses constant paths that look like this:

  static const char *dt_path = "soc/pci@%8.8x/pcie@0/ath10k@0,0";

  https://chromium.googlesource.com/chromiumos/platform/depthcharge/+/refs/heads/firmware-storm-6315.B/src/board/storm/wifi_calibration.c#69

These paths have changed in recent kernels, so we need to adapte.

The CONFIG_GOOGLE_VPD kernel module (provided by kmod-google-firmware) is present on OnHub, and provides alternative means to locate this information, in /sys/firmware/vpd/ro/wifi_base64_calibration{0,1,2}. Use that instead.