### PR TITLE
[RFT] ipq40xx: dts: convert some SPI cs pins to hardware controlled mode

### DIFF
--- a/target/linux/ipq40xx/dts/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-a42.dts
@@ -122,7 +122,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -139,7 +139,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-cap-ac.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-cap-ac.dts
@@ -137,7 +137,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -155,7 +155,6 @@
 
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		reg = <0>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-cs-w3-wd1200g-eup.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-cs-w3-wd1200g-eup.dts
@@ -121,7 +121,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -138,7 +138,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-dap-2610.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-dap-2610.dts
@@ -82,7 +82,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
@@ -217,7 +216,7 @@
 			bias-disable;
 		};
 		mux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-eap1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-eap1300.dts
@@ -105,12 +105,12 @@
 	spi_0_pins: spi_0_pinmux {
 		pin {
 			function = "blsp_spi0";
-			pins = "gpio54", "gpio55", "gpio56", "gpio57";
+			pins = "gpio55", "gpio56", "gpio57";
 			drive-strength = <12>;
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -127,7 +127,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	m25p80@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-emd1.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-emd1.dts
@@ -99,13 +99,13 @@
 	spi_0_pins: spi_0_pinmux {
 		pin {
 			function = "blsp_spi0";
-			pins = "gpio54", "gpio55", "gpio56", "gpio57";
+			pins = "gpio55", "gpio56", "gpio57";
 			drive-strength = <12>;
 			bias-disable;
 		};
 
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -122,7 +122,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-emr3500.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-emr3500.dts
@@ -97,12 +97,12 @@
 	spi_0_pins: spi_0_pinmux {
 		pin {
 			function = "blsp_spi0";
-			pins = "gpio54", "gpio55", "gpio56", "gpio57";
+			pins = "gpio55", "gpio56", "gpio57";
 			drive-strength = <12>;
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -119,7 +119,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	m25p80@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ens620ext.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ens620ext.dts
@@ -130,7 +130,7 @@
 		};
 
 		mux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -143,7 +143,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ex61x0v2.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ex61x0v2.dtsi
@@ -172,7 +172,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -185,7 +185,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	mx25l12805d@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-fritzbox-4040.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-fritzbox-4040.dts
@@ -131,7 +131,7 @@
 		};
 
 		mux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -154,7 +154,6 @@
 	status = "okay";
 	/delete-property/ dmas;
 	/delete-property/ dma-names;
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-hap-ac2.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-hap-ac2.dts
@@ -125,7 +125,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -150,7 +150,6 @@
 
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		reg = <0>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-magic-2-wifi-next.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-magic-2-wifi-next.dts
@@ -94,7 +94,7 @@
 		};
 
 		mux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -169,7 +169,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-nbg6617.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-nbg6617.dts
@@ -144,7 +144,7 @@
 		};
 
 		mux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -165,7 +165,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-pa1200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-pa1200.dts
@@ -114,7 +114,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -131,7 +131,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-sxtsq-5-ac.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-sxtsq-5-ac.dts
@@ -136,7 +136,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -154,7 +154,6 @@
 
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		reg = <0>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-wap-ac.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-wap-ac.dtsi
@@ -100,7 +100,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -118,7 +118,6 @@
 
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		reg = <0>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-wr-1.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-wr-1.dts
@@ -91,7 +91,6 @@
 &blsp1_spi1 {
 	status = "okay";
 
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 
@@ -330,7 +329,7 @@
 		};
 
 		mux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			bias-disable;
 			drive-strength = <2>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-wre6606.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-wre6606.dts
@@ -132,7 +132,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -149,7 +149,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	mx25l12805d@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-a62.dts
@@ -122,7 +122,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;
@@ -146,7 +146,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac-c1.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac-c1.dts
@@ -22,7 +22,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		reg = <0>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac-c2.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac-c2.dts
@@ -22,7 +22,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		reg = <0>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac.dtsi
@@ -162,7 +162,7 @@
 			bias-disable;
 		};
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-eap2200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-eap2200.dts
@@ -90,7 +90,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
@@ -253,7 +252,7 @@
 			bias-disable;
 		};
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-gl-b2200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-gl-b2200.dts
@@ -128,7 +128,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
@@ -257,7 +256,7 @@
 			pins = "gpio13", "gpio14", "gpio15";
 		};
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 		};
 		pinconf {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-habanero-dvk.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-habanero-dvk.dts
@@ -153,7 +153,7 @@
 		};
 
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;
@@ -210,7 +210,6 @@
 
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-hap-ac3-lte6-kit.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-hap-ac3-lte6-kit.dts
@@ -151,7 +151,7 @@
 		};
 
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;
@@ -184,7 +184,6 @@
 
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		reg = <0>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-hap-ac3.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-hap-ac3.dts
@@ -180,7 +180,7 @@
 		};
 
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;
@@ -221,7 +221,6 @@
 
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		reg = <0>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-le1.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-le1.dts
@@ -86,7 +86,6 @@
 };
 
 &blsp1_spi1 {
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
@@ -255,7 +254,7 @@
 		};
 
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-lhgg-60ad.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-lhgg-60ad.dts
@@ -151,7 +151,7 @@
 		};
 
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			bias-disable;
 			output-high;
@@ -166,7 +166,6 @@
 &blsp1_spi1 {
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 	status = "okay";
 
 	m25p80@0 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf18a.dts
@@ -147,7 +147,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		/* u-boot is looking for "n25q128a11" property */
@@ -428,7 +427,7 @@
 		};
 
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf282plus.dts
@@ -129,7 +129,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		/* u-boot is looking for "n25q128a11" property */
@@ -401,7 +400,7 @@
 		};
 
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf286d.dts
@@ -123,7 +123,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		/* u-boot is looking for "n25q128a11" property */
@@ -409,7 +408,7 @@
 		};
 
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-oap100.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-oap100.dts
@@ -117,7 +117,7 @@
 		};
 
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;
@@ -165,7 +165,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-pa2200.dts
@@ -117,7 +117,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;
@@ -134,7 +134,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-u4019-32m.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-u4019-32m.dts
@@ -13,7 +13,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		reg = <0>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-u4019.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-u4019.dtsi
@@ -128,7 +128,7 @@
 		};
 
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-wifi.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-wifi.dts
@@ -176,7 +176,7 @@
 			pins = "gpio13", "gpio14","gpio15";
 		};
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 		};
 		pinconf {
@@ -396,7 +396,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-x1pro.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-x1pro.dts
@@ -15,7 +15,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		reg = <0>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-x1pro.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-x1pro.dtsi
@@ -129,7 +129,7 @@
 		};
 
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;

--- a/target/linux/ipq40xx/dts/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4028-wpj428.dts
@@ -143,7 +143,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 			drive-strength = <2>;
 			bias-disable;
@@ -160,7 +160,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	m25p80@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-ap-303.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-ap-303.dts
@@ -63,7 +63,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-ap-365.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-ap-365.dts
@@ -84,7 +84,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-aruba-glenmorangie.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-aruba-glenmorangie.dtsi
@@ -142,7 +142,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-gl-b1300.dts
@@ -130,7 +130,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	mx25l25635f@0 {
 		compatible = "jedec,spi-nor";
@@ -244,7 +243,7 @@
 			pins = "gpio55", "gpio56", "gpio57";
 		};
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio54";
 		};
 		pinconf {

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-gl-s1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-gl-s1300.dts
@@ -126,7 +126,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
@@ -265,7 +264,7 @@
 			pins = "gpio13", "gpio14", "gpio15";
 		};
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 		};
 		pinconf {

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-ws-ap3915i.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-ws-ap3915i.dts
@@ -158,7 +158,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;
@@ -189,7 +189,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-ws-ap391x.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-ws-ap391x.dts
@@ -233,7 +233,7 @@
 			bias-disable;
 		};
 		pin_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;
@@ -264,7 +264,6 @@
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
 	status = "okay";
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";

--- a/target/linux/ipq40xx/dts/qcom-ipq40x9-dr40x9.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq40x9-dr40x9.dts
@@ -127,7 +127,7 @@
 			bias-disable;
 		};
 		pinmux_cs {
-			function = "gpio";
+			function = "blsp_spi0";
 			pins = "gpio12";
 			drive-strength = <2>;
 			bias-disable;
@@ -182,8 +182,6 @@
 
 	pinctrl-0 = <&spi_0_pins>;
 	pinctrl-names = "default";
-
-	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
 		compatible = "jedec,spi-nor";


### PR DESCRIPTION
On ipq40xx platform, the GPIO12 and GPIO54 can be muxed as SPI0 hardware chip select pin. Compared to the GPIO software control, the hardware controlled cs can save some CPU resources, and its internal dedicated hardware circuit may also include some signal and timing optimization.

This PR does require some testing and feedback. GPIO12 should work as expected, I've tested it on WIA3300-20.

IPQ4019:
<img width="492" height="64" alt="image" src="https://github.com/user-attachments/assets/8ecb62f2-5d9c-4e09-95fe-3628a37900d8" />
IPQ4018:
<img width="492" height="43" alt="image" src="https://github.com/user-attachments/assets/575f1337-3529-437e-a6e1-e067f05b51af" />