### PR TITLE
airoha: an7581: enable NPU by default

### DIFF
--- a/target/linux/airoha/an7581/target.mk
+++ b/target/linux/airoha/an7581/target.mk
@@ -5,6 +5,9 @@ CPU_TYPE:=cortex-a53
 KERNELNAME:=Image dtbs
 FEATURES+=pwm source-only
 
+DEFAULT_PACKAGES += \
+	airoha-en7581-npu-firmware
+
 define Target/Description
 	Build firmware images for Airoha an7581 ARM based boards.
 endef

--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -832,7 +832,6 @@
 					<&npu_txbufid>;
 			memory-region-names = "binary", "pkt", "tx-pkt",
 					      "tx-bufid";
-			status = "disabled";
 		};
 
 		eth: ethernet@1fb50000 {


### PR DESCRIPTION
There is no reason not to do this.

Use the following commands to enable hardware offloading:
```
uci set firewall.@defaults[0].flow_offloading='1'
uci set firewall.@defaults[0].flow_offloading_hw='1'
uci commit
```