### PR TITLE
odhcpd: set procd expected variable for odhcpd update script

### DIFF
--- a/package/network/services/odhcpd/Makefile
+++ b/package/network/services/odhcpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcpd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcpd.git

--- a/package/network/services/odhcpd/files/odhcpd-update
+++ b/package/network/services/odhcpd/files/odhcpd-update
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Make dnsmasq reread hostfile by sending SIGHUP signal
 
+initscript=$0
+
 . /lib/functions/procd.sh
 
 procd_send_signal dnsmasq


### PR DESCRIPTION
Otherwise odhcpd logs:

```
odhcpd[14970]: Sent 113 bytes to xxx%lan@br-lan
BusyBox v1.37.0 (2025-10-10 09:07:48 UTC) multi-call binary.

Usage: basename FILE [SUFFIX] | -a FILE... | -s SUFFIX FILE...

Strip directory path and SUFFIX from FILE

        -a              All arguments are FILEs
        -s SUFFIX       Remove SUFFIX (implies -a)
odhcpd[14970]: Netlink newneigh xxx on lan
```

Apparently procd scripts expect initscript set.

ht @ALphix for finding this.

See https://github.com/openwrt/odhcpd/issues/214#issuecomment-3426798699