### PR TITLE
[24.10] build: stricter hash validation on download

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -159,7 +159,7 @@ $(if $(if $(MIRROR), \
 		( $(3) ) \
 		$(if $(filter-out x,$(MIRROR_HASH)), && ( \
 			file_hash="$$$$($(MKHASH) sha256 "$(DL_DIR)/$(FILE)")"; \
-			[ "$$$$file_hash" = "$(MIRROR_HASH)" ] || { \
+			[ "$$$$file_hash" = "$(MIRROR_HASH)" ] || [ "$(MIRROR_HASH)" = "skip" ] || { \
 				echo "Hash mismatch for file $(FILE): expected $(MIRROR_HASH), got $$$$file_hash"; \
 				false; \
 			}; \

--- a/include/download.mk
+++ b/include/download.mk
@@ -163,7 +163,7 @@ $(if $(if $(MIRROR), \
 				echo "Hash mismatch for file $(FILE): expected $(MIRROR_HASH), got $$$$file_hash"; \
 				false; \
 			}; \
-		)),
+		)), \
 	$(3)) \
 $(if $(filter check,$(1)), \
 	$(call check_hash,$(FILE),$(MIRROR_HASH),$(2)MIRROR_$(call hash_var,$(MIRROR_MD5SUM))) \


### PR DESCRIPTION
Check the hash after packing the checkout and fail the build if it does not match.
(cherry picked and requested from commit 042996b46bd41292ef1fa2d58e3b824a547f4c55)