### PR TITLE
image: fix race between mkits.sh and mkimage in .itb squashfs generation + improve

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -450,7 +450,8 @@ define Build/fit
 		-c $(if $(DEVICE_DTS_CONFIG),$(DEVICE_DTS_CONFIG),"config-1") \
 		-A $(LINUX_KARCH) -v $(LINUX_VERSION), gen-cpio$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME))))
 	$(call locked,PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage $(if $(findstring external,$(word 3,$(1))),\
-		-E -B 0x1000 $(if $(findstring static,$(word 3,$(1))),-p 0x1000)) -f $@.its $@.new)
+		-E -B 0x1000 $(if $(findstring static,$(word 3,$(1))),-p 0x1000)) -f $@.its $@.new, \
+	  gen-cpio$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME))))
 	@mv $@.new $@
 endef
 

--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -431,27 +431,27 @@ define Build/initrd_compression
 endef
 
 define Build/fit
-	$(call locked, { \
-		$(if $(findstring with-rootfs,$(word 3,$(1))),dd if=$(IMAGE_ROOTFS) of=$(IMAGE_ROOTFS).pagesync bs=4096 conv=sync;) \
-		$(TOPDIR)/scripts/mkits.sh \
-			-D $(DEVICE_NAME) -o $@.its -k $@ \
-			-C $(word 1,$(1)) \
-			$(if $(word 2,$(1)),\
-				$(if $(findstring 11,$(if $(DEVICE_DTS_OVERLAY),1)$(if $(findstring $(KERNEL_BUILD_DIR)/image-,$(word 2,$(1))),,1)), \
-					-d $(KERNEL_BUILD_DIR)/image-$$(basename $(word 2,$(1))), \
-					-d $(word 2,$(1)))) \
-			$(if $(findstring with-rootfs,$(word 3,$(1))),-r $(IMAGE_ROOTFS)) \
-			$(if $(findstring with-initrd,$(word 3,$(1))), \
-				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE), \
-					-i $(KERNEL_BUILD_DIR)/initrd$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME))).cpio$(strip $(call Build/initrd_compression)))) \
-			-a $(KERNEL_LOADADDR) -e $(if $(KERNEL_ENTRY),$(KERNEL_ENTRY),$(KERNEL_LOADADDR)) \
-			$(if $(DEVICE_FDT_NUM),-n $(DEVICE_FDT_NUM)) \
-			$(if $(DEVICE_DTS_DELIMITER),-l $(DEVICE_DTS_DELIMITER)) \
-			$(if $(DEVICE_DTS_LOADADDR),-s $(DEVICE_DTS_LOADADDR)) \
-			$(if $(DEVICE_DTS_OVERLAY),$(foreach dtso,$(DEVICE_DTS_OVERLAY), -O $(dtso):$(KERNEL_BUILD_DIR)/image-$(dtso).dtbo)) \
-			-c $(if $(DEVICE_DTS_CONFIG),$(DEVICE_DTS_CONFIG),"config-1") \
-			-A $(LINUX_KARCH) -v $(LINUX_VERSION) \
-	}, gen-cpio$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME))))
+	$(if $(findstring with-rootfs,$(word 3,$(1))), \
+		$(call locked,dd if=$(IMAGE_ROOTFS) of=$(IMAGE_ROOTFS).pagesync bs=4096 conv=sync, \
+		  gen-cpio$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME)))))
+	$(TOPDIR)/scripts/mkits.sh \
+		-D $(DEVICE_NAME) -o $@.its -k $@ \
+		-C $(word 1,$(1)) \
+		$(if $(word 2,$(1)),\
+			$(if $(findstring 11,$(if $(DEVICE_DTS_OVERLAY),1)$(if $(findstring $(KERNEL_BUILD_DIR)/image-,$(word 2,$(1))),,1)), \
+				-d $(KERNEL_BUILD_DIR)/image-$$(basename $(word 2,$(1))), \
+				-d $(word 2,$(1)))) \
+		$(if $(findstring with-rootfs,$(word 3,$(1))),-r $(IMAGE_ROOTFS)) \
+		$(if $(findstring with-initrd,$(word 3,$(1))), \
+			$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE), \
+				-i $(KERNEL_BUILD_DIR)/initrd$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME))).cpio$(strip $(call Build/initrd_compression)))) \
+		-a $(KERNEL_LOADADDR) -e $(if $(KERNEL_ENTRY),$(KERNEL_ENTRY),$(KERNEL_LOADADDR)) \
+		$(if $(DEVICE_FDT_NUM),-n $(DEVICE_FDT_NUM)) \
+		$(if $(DEVICE_DTS_DELIMITER),-l $(DEVICE_DTS_DELIMITER)) \
+		$(if $(DEVICE_DTS_LOADADDR),-s $(DEVICE_DTS_LOADADDR)) \
+		$(if $(DEVICE_DTS_OVERLAY),$(foreach dtso,$(DEVICE_DTS_OVERLAY), -O $(dtso):$(KERNEL_BUILD_DIR)/image-$(dtso).dtbo)) \
+		-c $(if $(DEVICE_DTS_CONFIG),$(DEVICE_DTS_CONFIG),"config-1") \
+		-A $(LINUX_KARCH) -v $(LINUX_VERSION)
 	$(call locked,PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage $(if $(findstring external,$(word 3,$(1))),\
 		-E -B 0x1000 $(if $(findstring static,$(word 3,$(1))),-p 0x1000)) -f $@.its $@.new, \
 	  gen-cpio$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME))))

--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -431,24 +431,27 @@ define Build/initrd_compression
 endef
 
 define Build/fit
-	$(call locked,$(TOPDIR)/scripts/mkits.sh \
-		-D $(DEVICE_NAME) -o $@.its -k $@ \
-		-C $(word 1,$(1)) \
-		$(if $(word 2,$(1)),\
-			$(if $(findstring 11,$(if $(DEVICE_DTS_OVERLAY),1)$(if $(findstring $(KERNEL_BUILD_DIR)/image-,$(word 2,$(1))),,1)), \
-				-d $(KERNEL_BUILD_DIR)/image-$$(basename $(word 2,$(1))), \
-				-d $(word 2,$(1)))) \
-		$(if $(findstring with-rootfs,$(word 3,$(1))),-r $(IMAGE_ROOTFS)) \
-		$(if $(findstring with-initrd,$(word 3,$(1))), \
-			$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE), \
-				-i $(KERNEL_BUILD_DIR)/initrd$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME))).cpio$(strip $(call Build/initrd_compression)))) \
-		-a $(KERNEL_LOADADDR) -e $(if $(KERNEL_ENTRY),$(KERNEL_ENTRY),$(KERNEL_LOADADDR)) \
-		$(if $(DEVICE_FDT_NUM),-n $(DEVICE_FDT_NUM)) \
-		$(if $(DEVICE_DTS_DELIMITER),-l $(DEVICE_DTS_DELIMITER)) \
-		$(if $(DEVICE_DTS_LOADADDR),-s $(DEVICE_DTS_LOADADDR)) \
-		$(if $(DEVICE_DTS_OVERLAY),$(foreach dtso,$(DEVICE_DTS_OVERLAY), -O $(dtso):$(KERNEL_BUILD_DIR)/image-$(dtso).dtbo)) \
-		-c $(if $(DEVICE_DTS_CONFIG),$(DEVICE_DTS_CONFIG),"config-1") \
-		-A $(LINUX_KARCH) -v $(LINUX_VERSION), gen-cpio$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME))))
+	$(call locked, { \
+		$(if $(findstring with-rootfs,$(word 3,$(1))),dd if=$(IMAGE_ROOTFS) of=$(IMAGE_ROOTFS).pagesync bs=4096 conv=sync;) \
+		$(TOPDIR)/scripts/mkits.sh \
+			-D $(DEVICE_NAME) -o $@.its -k $@ \
+			-C $(word 1,$(1)) \
+			$(if $(word 2,$(1)),\
+				$(if $(findstring 11,$(if $(DEVICE_DTS_OVERLAY),1)$(if $(findstring $(KERNEL_BUILD_DIR)/image-,$(word 2,$(1))),,1)), \
+					-d $(KERNEL_BUILD_DIR)/image-$$(basename $(word 2,$(1))), \
+					-d $(word 2,$(1)))) \
+			$(if $(findstring with-rootfs,$(word 3,$(1))),-r $(IMAGE_ROOTFS)) \
+			$(if $(findstring with-initrd,$(word 3,$(1))), \
+				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE), \
+					-i $(KERNEL_BUILD_DIR)/initrd$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME))).cpio$(strip $(call Build/initrd_compression)))) \
+			-a $(KERNEL_LOADADDR) -e $(if $(KERNEL_ENTRY),$(KERNEL_ENTRY),$(KERNEL_LOADADDR)) \
+			$(if $(DEVICE_FDT_NUM),-n $(DEVICE_FDT_NUM)) \
+			$(if $(DEVICE_DTS_DELIMITER),-l $(DEVICE_DTS_DELIMITER)) \
+			$(if $(DEVICE_DTS_LOADADDR),-s $(DEVICE_DTS_LOADADDR)) \
+			$(if $(DEVICE_DTS_OVERLAY),$(foreach dtso,$(DEVICE_DTS_OVERLAY), -O $(dtso):$(KERNEL_BUILD_DIR)/image-$(dtso).dtbo)) \
+			-c $(if $(DEVICE_DTS_CONFIG),$(DEVICE_DTS_CONFIG),"config-1") \
+			-A $(LINUX_KARCH) -v $(LINUX_VERSION) \
+	}, gen-cpio$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME))))
 	$(call locked,PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage $(if $(findstring external,$(word 3,$(1))),\
 		-E -B 0x1000 $(if $(findstring static,$(word 3,$(1))),-p 0x1000)) -f $@.its $@.new, \
 	  gen-cpio$(if $(TARGET_PER_DEVICE_ROOTFS),.$(ROOTFS_ID/$(DEVICE_NAME))))

--- a/scripts/mkits.sh
+++ b/scripts/mkits.sh
@@ -82,6 +82,11 @@ if [ -z "${ARCH}" ] || [ -z "${COMPRESS}" ] || [ -z "${LOAD_ADDR}" ] || \
 	usage
 fi
 
+if [ -n "${ROOTFS}" ] && [ ! -f "${ROOTFS}".pagesync ]; then
+	echo "Missing .pagesync blob for RootFS blob '${ROOTFS}'"
+	exit 1
+fi
+
 ARCH_UPPER=$(echo "$ARCH" | tr '[:lower:]' '[:upper:]')
 
 if [ -n "${COMPATIBLE}" ]; then
@@ -136,7 +141,6 @@ fi
 
 
 if [ -n "${ROOTFS}" ]; then
-	dd if="${ROOTFS}" of="${ROOTFS}.pagesync" bs=4096 conv=sync
 	ROOTFS_NODE="
 		rootfs${REFERENCE_CHAR}$ROOTFSNUM {
 			description = \"${ARCH_UPPER} OpenWrt ${DEVICE} rootfs\";


### PR DESCRIPTION
With further investigation it was found a race in generating .itb images
that include a RootFS caused by the mkits.sh and the mkimage.

Due to the fact that mkits.sh generates a .pagesync image of the passed
rootfs, it can happen that, concurrently, mkimage can be called at the
same time mkits.sh is creating another .pagesync for the same rootfs.

This cause mkimage to use an half made rootfs.pagesync creating a
corrupted image.

To address this, also protect the mkimage with the same lock used for
mkits.sh preventing any kind of concurrent usage/generation of the
rootfs.pagesync blob

It's expected the mkits.sh script to generate only the relevant DTS
entry and have all the blob already prepared to use for mkimage.

This is not the case for the RootFS case where the script generates a
.pagesync with the dd command.

To better handle this, drop the dd command and instead error out if the
.pagesync blob is not found if RootFS is used.

Adapt the generic fit build in image-commands.mk to call the dd for
.pagesync right before mkits.sh.

As mkits.sh only generates the relevant DTS for mkimage and is
specific for the building image, we can move it outside the locked
section as it doesn't do any operation that can be used concurrently by
others.

This won't have any real impact but clean the code making it clear what
needs to be protected and what can be executed concurrently.