### PR TITLE
linux-firmware: update to 20251021

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
-PKG_VERSION:=20251011
+PKG_VERSION:=20251021
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=b6c9a9c112b88417d985b87d6521b677fa2fa0d5d7ee5219c76dc8ca66945ad3
+PKG_HASH:=fa6130988ecd7968602938c77dd6f8d2dace4e03ba0da4c0e9624dfed657e6cf
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
    % git log --no-merges --pretty=oneline --abbrev-commit 20251011...20251021
    b0b775e5ad10 Revert "linux-firmware: update firmware for MT7922 WiFi device"
    d06442f2b6f5 QCA: Update Bluetooth WCN6856 firmware 2.1.0-00653 to 2.1.0-00659
    9440754a997a iwlwifi: add Bz/Fm and gl FW for core98-161 release
    f2fbfd22d9d1 iwlwifi: update Bz/Hr and Bz/Gf firmwares for core98-161 release
    dda8b9b09a1c iwlwifi: update ty/So/Ma firmwares for core98-161 release
    822db3708dbc iwlwifi: update cc/Qu/QuZ firmwares for core98-161 release
    edc9bbecf0fe intel: qat: Fix missing link
    80bca4b3d75e amdgpu: DMCUB updates for various ASICs
    7a1a266e22f1 nvidia: add generic bootloader for GSP-enabled systems
    2121082a8884 linux-firmware: qcom: sync audioreach firmwares from v1.0.0 build
    4ba7ff78711b qcom: vpu: rename firmware binaries
    15cb201918e5 Intel IPU7: Update product signed firmware binary
    10de40e2bb55 i915: Xe2LPD DMC v2.29
    4bda88bd3a9f i915: Xe3LPD DMC v2.32
    afae3516d1d8 i915: Xe3LPD_3002 DMC v2.27
    bcce0efb5c4a WHENCE: nvidia: rearrange GSP-RM firmware lines
    a96c15581a53 linux-firmware: Add ISH firmware file for Intel Pather Lake platform
    55d8d2fa006b linux-firmware: Update firmware file for Intel Magnetar core
    890cad9f8387 linux-firmware: Update firmware file for Intel BlazarU core
    7bbab634ede0 linux-firmware: Update firmware file for Intel BlazarI core

Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: x86/64-glibc