### PR TITLE
ipq40xx: cleanup base-files

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -76,12 +76,12 @@ mikrotik,hap-ac3)
 	ucidef_set_led_gpio "poe" "POE" "red:poe" "452" "0"
 	;;
 mikrotik,hap-ac3-lte6-kit)
-        ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
-        ucidef_set_led_netdev "lan1" "LAN1" "green:lan1" "lan1"
-        ucidef_set_led_netdev "lan2" "LAN2" "green:lan2" "lan2"
-        ucidef_set_led_netdev "lan3" "LAN3" "green:lan3" "lan3"
-        ucidef_set_led_netdev "lan4" "LAN4" "green:lan4" "lan4"
-        ;;
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	ucidef_set_led_netdev "lan1" "LAN1" "green:lan1" "lan1"
+	ucidef_set_led_netdev "lan2" "LAN2" "green:lan2" "lan2"
+	ucidef_set_led_netdev "lan3" "LAN3" "green:lan3" "lan3"
+	ucidef_set_led_netdev "lan4" "LAN4" "green:lan4" "lan4"
+	;;
 
 mikrotik,sxtsq-5-ac)
 	ucidef_set_rssimon "wlan0" "200000" "1"

--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -59,6 +59,29 @@ glinet,gl-b1300|\
 mikrotik,lhgg-60ad)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
+meraki,gx20|\
+meraki,z3)
+	ucidef_set_led_netdev "wan_link" "WAN (link)" "green:wan-0" "wan" "link"
+	ucidef_set_led_netdev "wan_act" "WAN (txrx)" "green:wan-1" "wan" "tx rx"
+	ucidef_set_led_netdev "lan1_link" "LAN2 (link)" "green:lan-2" "lan2" "link"
+	ucidef_set_led_netdev "lan1_act" "LAN2 (txrx)" "green:lan-3" "lan2" "tx rx"
+	ucidef_set_led_netdev "lan2_link" "LAN3 (link)" "green:lan-4" "lan3" "link"
+	ucidef_set_led_netdev "lan2_act" "LAN3 (txrx)" "green:lan-5" "lan3" "tx rx"
+	ucidef_set_led_netdev "lan3_link" "LAN4 (link)" "green:lan-6" "lan4" "link"
+	ucidef_set_led_netdev "lan3_act" "LAN4 (txrx)" "green:lan-7" "lan4" "tx rx"
+	ucidef_set_led_netdev "lan4_link" "LAN5 (link)" "green:lan-8" "lan5" "link"
+	ucidef_set_led_netdev "lan4_act" "LAN5 (txrx)" "green:lan-9" "lan5" "tx rx"
+	;;
+meraki,mr30h)
+	ucidef_set_led_netdev "lan1_link" "LAN1 (link)" "green:lan-0" "lan1" "link"
+	ucidef_set_led_netdev "lan1_act" "LAN1 (txrx)" "amber:lan-1" "lan1" "tx rx"
+	ucidef_set_led_netdev "lan2_link" "LAN2 (link)" "green:lan-2" "lan2" "link"
+	ucidef_set_led_netdev "lan2_act" "LAN2 (txrx)" "amber:lan-3" "lan2" "tx rx"
+	ucidef_set_led_netdev "lan3_link" "LAN3 (link)" "green:lan-4" "lan3" "link"
+	ucidef_set_led_netdev "lan3_act" "LAN3 (txrx)" "amber:lan-5" "lan3" "tx rx"
+	ucidef_set_led_netdev "lan4_link" "LAN4 (link)" "green:lan-6" "lan4" "link"
+	ucidef_set_led_netdev "lan4_act" "LAN4 (txrx)" "amber:lan-7" "lan4" "tx rx"
+	;;
 mikrotik,cap-ac)
 	ucidef_set_led_default "power" "POWER" "blue:power" "1"
 	ucidef_set_led_default "user" "USER" "green:user" "0"
@@ -82,7 +105,6 @@ mikrotik,hap-ac3-lte6-kit)
 	ucidef_set_led_netdev "lan3" "LAN3" "green:lan3" "lan3"
 	ucidef_set_led_netdev "lan4" "LAN4" "green:lan4" "lan4"
 	;;
-
 mikrotik,sxtsq-5-ac)
 	ucidef_set_rssimon "wlan0" "200000" "1"
 	ucidef_set_led_rssi "rssilow" "rssilow" "green:rssilow" "wlan0" "1" "100"
@@ -95,29 +117,6 @@ mobipromo,cm520-79f)
 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "wan"
 	ucidef_set_led_netdev "lan1" "LAN1" "blue:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "LAN2" "blue:lan2" "lan2"
-	;;
-meraki,gx20|\
-meraki,z3)
-	ucidef_set_led_netdev "wan_link" "WAN (link)" "green:wan-0" "wan" "link"
-	ucidef_set_led_netdev "wan_act" "WAN (txrx)" "green:wan-1" "wan" "tx rx"
-	ucidef_set_led_netdev "lan1_link" "LAN2 (link)" "green:lan-2" "lan2" "link"
-	ucidef_set_led_netdev "lan1_act" "LAN2 (txrx)" "green:lan-3" "lan2" "tx rx"
-	ucidef_set_led_netdev "lan2_link" "LAN3 (link)" "green:lan-4" "lan3" "link"
-	ucidef_set_led_netdev "lan2_act" "LAN3 (txrx)" "green:lan-5" "lan3" "tx rx"
-	ucidef_set_led_netdev "lan3_link" "LAN4 (link)" "green:lan-6" "lan4" "link"
-	ucidef_set_led_netdev "lan3_act" "LAN4 (txrx)" "green:lan-7" "lan4" "tx rx"
-	ucidef_set_led_netdev "lan4_link" "LAN5 (link)" "green:lan-8" "lan5" "link"
-	ucidef_set_led_netdev "lan4_act" "LAN5 (txrx)" "green:lan-9" "lan5" "tx rx"
-	;;
-meraki,mr30h)
-	ucidef_set_led_netdev "lan1_link" "LAN1 (link)" "green:lan-0" "lan1" "link"
-	ucidef_set_led_netdev "lan1_act" "LAN1 (txrx)" "amber:lan-1" "lan1" "tx rx"
-	ucidef_set_led_netdev "lan2_link" "LAN2 (link)" "green:lan-2" "lan2" "link"
-	ucidef_set_led_netdev "lan2_act" "LAN2 (txrx)" "amber:lan-3" "lan2" "tx rx"
-	ucidef_set_led_netdev "lan3_link" "LAN3 (link)" "green:lan-4" "lan3" "link"
-	ucidef_set_led_netdev "lan3_act" "LAN3 (txrx)" "amber:lan-5" "lan3" "tx rx"
-	ucidef_set_led_netdev "lan4_link" "LAN4 (link)" "green:lan-6" "lan4" "link"
-	ucidef_set_led_netdev "lan4_act" "LAN4 (txrx)" "amber:lan-7" "lan4" "tx rx"
 	;;
 netgear,ex6100v2|\
 netgear,ex6150v2)

--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -55,7 +55,7 @@ engenius,ens620ext)
 glinet,gl-ap1300)
 	ucidef_set_led_netdev "wan" "WAN" "white:wan" "wan"
 	;;
-glinet,gl-b1300 |\
+glinet,gl-b1300|\
 mikrotik,lhgg-60ad)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
@@ -96,7 +96,7 @@ mobipromo,cm520-79f)
 	ucidef_set_led_netdev "lan1" "LAN1" "blue:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "LAN2" "blue:lan2" "lan2"
 	;;
-meraki,gx20 |\
+meraki,gx20|\
 meraki,z3)
 	ucidef_set_led_netdev "wan_link" "WAN (link)" "green:wan-0" "wan" "link"
 	ucidef_set_led_netdev "wan_act" "WAN (txrx)" "green:wan-1" "wan" "tx rx"
@@ -119,12 +119,12 @@ meraki,mr30h)
 	ucidef_set_led_netdev "lan4_link" "LAN4 (link)" "green:lan-6" "lan4" "link"
 	ucidef_set_led_netdev "lan4_act" "LAN4 (txrx)" "amber:lan-7" "lan4" "tx rx"
 	;;
-netgear,ex6100v2 |\
+netgear,ex6100v2|\
 netgear,ex6150v2)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:router" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:client" "phy1tpt"
 	;;
-qxwlan,e2600ac-c1 |\
+qxwlan,e2600ac-c1|\
 qxwlan,e2600ac-c2)
 	ucidef_set_led_wlan "wlan2g" "WLAN0" "green:wlan0" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN1" "green:wlan1" "phy1tpt"
@@ -134,7 +134,7 @@ sony,ncp-hg100-cellular)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	ucidef_set_led_netdev "wwan" "WWAN" "green:wan-4" "wwan0"
 	;;
-zyxel,nbg6617 |\
+zyxel,nbg6617|\
 zyxel,wre6606)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy1tpt"

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -71,9 +71,7 @@ ipq40xx_setup_interfaces()
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
 	avm,fritzrepeater-3000|\
-	cellc,rtl30vw)
-		ucidef_set_interface_lan "lan1 lan2"
-		;;
+	cellc,rtl30vw|\
 	compex,wpj428)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
@@ -175,7 +173,8 @@ ipq40xx_setup_macs()
 	local label_mac=""
 
 	case "$board" in
-	8dev,habanero-dvk)
+	8dev,habanero-dvk|\
+	cilab,meshpoint-one)
 		label_mac=$(mtd_get_mac_binary "ART" 0x1006)
 		;;
 	asus,rt-ac42u)
@@ -184,9 +183,6 @@ ipq40xx_setup_macs()
 	avm,fritzbox-7530)
 		local tffsdev=$(find_mtd_chardev "nand-tffs")
 		wan_mac=$(/usr/bin/fritz_tffs_nand -b -d $tffsdev -n macdsl)
-		;;
-	cilab,meshpoint-one)
-		label_mac=$(mtd_get_mac_binary "ART" 0x1006)
 		;;
 	devolo,magic-2-wifi-next)
 		lan_mac=$(mtd_get_mac_ascii APPSBLENV MacAddress0)

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -29,10 +29,6 @@ ipq40xx_setup_interfaces()
 	zyxel,nbg6617)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;
-	meraki,gx20|\
-	meraki,z3)
-		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
-		;;
 	8dev,jalapeno|\
 	alfa-network,ap120c-ac|\
 	asus,map-ac2200|\
@@ -67,6 +63,17 @@ ipq40xx_setup_interfaces()
 	zte,mf282plus)
 		ucidef_set_interface_lan "lan"
 		;;
+	aruba,ap-303h|\
+	buffalo,wtr-m2133hp|\
+	ezviz,cs-w3-wd1200g-eup|\
+	netgear,rbr40|\
+	netgear,rbs40|\
+	netgear,rbr50|\
+	netgear,rbs50|\
+	netgear,srr60|\
+	netgear,srs60)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
+		;;
 	avm,fritzbox-7530)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
@@ -90,21 +97,21 @@ ipq40xx_setup_interfaces()
 	mobipromo,cm520-79f)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
+	meraki,gx20|\
+	meraki,z3)
+		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
+		;;
+	meraki,mr30h)
+		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
+		;;
 	mikrotik,wap-ac|\
 	mikrotik,wap-ac-lte|\
 	mikrotik,wap-r-ac)
 		ucidef_set_interface_lan "sw-eth1 sw-eth2"
 		;;
-	aruba,ap-303h|\
-	buffalo,wtr-m2133hp|\
-	ezviz,cs-w3-wd1200g-eup|\
-	netgear,rbr40|\
-	netgear,rbs40|\
-	netgear,rbr50|\
-	netgear,rbs50|\
-	netgear,srr60|\
-	netgear,srs60)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
+	netgear,lbr20)
+		ucidef_set_interface_lan "lan1 lan2"
+		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
 		;;
 	openmesh,a42|\
 	openmesh,a62)
@@ -131,13 +138,6 @@ ipq40xx_setup_interfaces()
 	zte,mf287pro)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
-		;;
-	netgear,lbr20)
-		ucidef_set_interface_lan "lan1 lan2"
-		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
-		;;
-	meraki,mr30h)
-		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
 		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -221,7 +221,7 @@ ipq40xx_setup_macs()
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		;;
 	linksys,ea6350v3|\
-	linksys,ea8300  |\
+	linksys,ea8300|\
 	linksys,mr8300)
 		wan_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
@@ -230,7 +230,7 @@ ipq40xx_setup_macs()
 		wan_mac=$(mmc_get_mac_ascii devinfo hw_mac_addr)
 		lan_mac="$wan_mac"
 		;;
-	mikrotik,cap-ac |\
+	mikrotik,cap-ac|\
 	mikrotik,hap-ac2|\
 	mikrotik,hap-ac3|\
 	mikrotik,hap-ac3-lte6-kit)

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -256,7 +256,7 @@ case "$FIRMWARE" in
 	mikrotik,cap-ac|\
 	mikrotik,hap-ac2|\
 	mikrotik,hap-ac3|\
-        mikrotik,hap-ac3-lte6-kit|\
+	mikrotik,hap-ac3-lte6-kit|\
 	mikrotik,sxtsq-5-ac|\
 	mikrotik,wap-ac|\
 	mikrotik,wap-ac-lte|\

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -25,7 +25,7 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x212 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
-	linksys,ea8300 |\
+	linksys,ea8300|\
 	linksys,mr8300)
 		caldata_extract "ART" 0x9000 0x2f20
 		# OEM assigns 4 sequential MACs
@@ -55,8 +55,8 @@ case "$FIRMWARE" in
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
 		;;
-	avm,fritzbox-7530 |\
-	avm,fritzrepeater-1200 |\
+	avm,fritzbox-7530|\
+	avm,fritzrepeater-1200|\
 	avm,fritzrepeater-3000)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader0") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader0") || \
@@ -88,12 +88,12 @@ case "$FIRMWARE" in
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) 2)
 		;;
-	extreme-networks,ws-ap3915i |\
+	extreme-networks,ws-ap3915i|\
 	extreme-networks,ws-ap391x)
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(mtd_get_mac_ascii CFG1 RADIOADDR0)
 		;;
-	linksys,ea8300 |\
+	linksys,ea8300|\
 	linksys,mr8300)
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
@@ -102,12 +102,12 @@ case "$FIRMWARE" in
 		caldata_extract_mmc "0:ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		;;
-	mikrotik,cap-ac |\
-	mikrotik,hap-ac2 |\
-	mikrotik,hap-ac3 |\
-	mikrotik,hap-ac3-lte6-kit |\
-	mikrotik,wap-ac |\
-	mikrotik,wap-ac-lte |\
+	mikrotik,cap-ac|\
+	mikrotik,hap-ac2|\
+	mikrotik,hap-ac3|\
+	mikrotik,hap-ac3-lte6-kit|\
+	mikrotik,wap-ac|\
+	mikrotik,wap-ac-lte|\
 	mikrotik,wap-r-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x0 0x2f20 ) || \
@@ -134,7 +134,7 @@ case "$FIRMWARE" in
 	sony,ncp-hg100-cellular)
 		caldata_extract_mmc "0:ART" 0x1000 0x2f20
 		;;
-	zyxel,nbg6617 |\
+	zyxel,nbg6617|\
 	zyxel,wre6606)
 		caldata_extract "ART" 0x1000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
@@ -149,8 +149,8 @@ case "$FIRMWARE" in
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
 		;;
-	avm,fritzbox-7530 |\
-	avm,fritzrepeater-1200 |\
+	avm,fritzbox-7530|\
+	avm,fritzrepeater-1200|\
 	avm,fritzrepeater-3000)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader0") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader0") || \
@@ -182,12 +182,12 @@ case "$FIRMWARE" in
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) 3)
 		;;
-	extreme-networks,ws-ap3915i |\
+	extreme-networks,ws-ap3915i|\
 	extreme-networks,ws-ap391x)
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(mtd_get_mac_ascii CFG1 RADIOADDR1)
 		;;
-	linksys,ea8300 |\
+	linksys,ea8300|\
 	linksys,mr8300)
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 3)
@@ -196,13 +196,13 @@ case "$FIRMWARE" in
 		caldata_extract_mmc "0:ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add "$(cat /sys/class/net/eth0/address)" 2)
 		;;
-	mikrotik,cap-ac |\
-	mikrotik,hap-ac2 |\
-	mikrotik,hap-ac3 |\
-	mikrotik,hap-ac3-lte6-kit |\
-	mikrotik,sxtsq-5-ac |\
-	mikrotik,wap-ac |\
-	mikrotik,wap-ac-lte |\
+	mikrotik,cap-ac|\
+	mikrotik,hap-ac2|\
+	mikrotik,hap-ac3|\
+	mikrotik,hap-ac3-lte6-kit|\
+	mikrotik,sxtsq-5-ac|\
+	mikrotik,wap-ac|\
+	mikrotik,wap-ac-lte|\
 	mikrotik,wap-r-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x8000 0x2f20 ) || \
@@ -229,7 +229,7 @@ case "$FIRMWARE" in
 	sony,ncp-hg100-cellular)
 		caldata_extract_mmc "0:ART" 0x5000 0x2f20
 		;;
-	zyxel,nbg6617 |\
+	zyxel,nbg6617|\
 	zyxel,wre6606)
 		caldata_extract "ART" 0x5000 0x2f20
 		ath10k_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
@@ -238,12 +238,12 @@ case "$FIRMWARE" in
 	;;
 "ath10k/QCA4019/hw1.0/board-ahb-a000000.wifi.bin")
 	case "$board" in
-	mikrotik,cap-ac |\
-	mikrotik,hap-ac2 |\
-	mikrotik,hap-ac3 |\
-	mikrotik,hap-ac3-lte6-kit |\
-	mikrotik,wap-ac |\
-	mikrotik,wap-ac-lte |\
+	mikrotik,cap-ac|\
+	mikrotik,hap-ac2|\
+	mikrotik,hap-ac3|\
+	mikrotik,hap-ac3-lte6-kit|\
+	mikrotik,wap-ac|\
+	mikrotik,wap-ac-lte|\
 	mikrotik,wap-r-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0x2f20 0x2f20 ) || \
@@ -253,13 +253,13 @@ case "$FIRMWARE" in
 	;;
 "ath10k/QCA4019/hw1.0/board-ahb-a800000.wifi.bin")
 	case "$board" in
-	mikrotik,cap-ac |\
-	mikrotik,hap-ac2 |\
-	mikrotik,hap-ac3 |\
-        mikrotik,hap-ac3-lte6-kit |\
-	mikrotik,sxtsq-5-ac |\
-	mikrotik,wap-ac |\
-	mikrotik,wap-ac-lte |\
+	mikrotik,cap-ac|\
+	mikrotik,hap-ac2|\
+	mikrotik,hap-ac3|\
+        mikrotik,hap-ac3-lte6-kit|\
+	mikrotik,sxtsq-5-ac|\
+	mikrotik,wap-ac|\
+	mikrotik,wap-ac-lte|\
 	mikrotik,wap-r-ac)
 		wlan_data="/sys/firmware/mikrotik/hard_config/wlan_data"
 		( [ -f "$wlan_data" ] && caldata_sysfsload_from_file "$wlan_data" 0xaf20 0x2f20 ) || \

--- a/target/linux/ipq40xx/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/ipq40xx/base-files/etc/uci-defaults/05_fix-compat-version
@@ -1,10 +1,10 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
+ezviz,cs-w3-wd1200g-eup|\
 linksys,ea6350v3|\
 linksys,ea8300|\
-linksys,mr8300|\
-ezviz,cs-w3-wd1200g-eup)
+linksys,mr8300)
 	uci set system.@system[0].compat_version="2.0"
 	uci commit system
 	;;

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -113,6 +113,7 @@ platform_do_upgrade() {
 	avm,fritzrepeater-3000|\
 	buffalo,wtr-m2133hp|\
 	cilab,meshpoint-one|\
+	compex,wpj419|\
 	edgecore,ecw5211|\
 	edgecore,oap100|\
 	engenius,eap2200|\
@@ -145,10 +146,7 @@ platform_do_upgrade() {
 		fi
 		nand_do_upgrade "$1"
 		;;
-	asus,map-ac2200)
-		CI_KERNPART="linux"
-		nand_do_upgrade "$1"
-		;;
+	asus,map-ac2200|\
 	asus,rt-ac42u|\
 	asus,rt-ac58u)
 		CI_KERNPART="linux"
@@ -157,9 +155,6 @@ platform_do_upgrade() {
 	cellc,rtl30vw)
 		CI_UBIPART="ubifs"
 		askey_do_upgrade "$1"
-		;;
-	compex,wpj419)
-		nand_do_upgrade "$1"
 		;;
 	google,wifi)
 		export_bootdevice

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -129,12 +129,6 @@ platform_do_upgrade() {
 	wallys,dr40x9)
 		nand_do_upgrade "$1"
 		;;
-	glinet,gl-b2200)
-		CI_KERNPART="0:HLOS"
-		CI_ROOTPART="rootfs"
-		CI_DATAPART="rootfs_data"
-		emmc_do_upgrade "$1"
-		;;
 	alfa-network,ap120c-ac)
 		part="$(awk -F 'ubi.mtd=' '{printf $2}' /proc/cmdline | sed -e 's/ .*$//')"
 		if [ "$part" = "rootfs1" ]; then
@@ -156,6 +150,12 @@ platform_do_upgrade() {
 		CI_UBIPART="ubifs"
 		askey_do_upgrade "$1"
 		;;
+	glinet,gl-b2200)
+		CI_KERNPART="0:HLOS"
+		CI_ROOTPART="rootfs"
+		CI_DATAPART="rootfs_data"
+		emmc_do_upgrade "$1"
+		;;
 	google,wifi)
 		export_bootdevice
 		export_partdevice CI_ROOTDEV 0
@@ -173,18 +173,18 @@ platform_do_upgrade() {
 	linksys,whw03)
 		platform_do_upgrade_linksys_emmc "$1"
 		;;
-	meraki,mr30h|\
-	meraki,mr33|\
-	meraki,mr74)
-		CI_KERNPART="part.safe"
-		nand_do_upgrade "$1"
-		;;
 	meraki,gx20|\
 	meraki,z3)
 		# DO NOT set CI_KERNPART to part.safe,
 		# that is used for chain-loading an unlocked u-boot
 		# if part.safe is overwritten, then u-boot is lost!
 		CI_KERNPART="part.old"
+		nand_do_upgrade "$1"
+		;;
+	meraki,mr30h|\
+	meraki,mr33|\
+	meraki,mr74)
+		CI_KERNPART="part.safe"
 		nand_do_upgrade "$1"
 		;;
 	mikrotik,cap-ac|\

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -6,7 +6,7 @@ RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
 platform_check_image() {
 	case "$(board_name)" in
-	asus,rt-ac42u |\
+	asus,rt-ac42u|\
 	asus,rt-ac58u)
 		local ubidev=$(nand_find_ubi $CI_UBIPART)
 		local asus_root=$(nand_find_volume $ubidev jffs2)
@@ -25,12 +25,12 @@ Once this is done. Retry.
 EOF
 		return 1
 		;;
-	zte,mf18a |\
+	zte,mf18a|\
 	zte,mf282plus|\
-	zte,mf286d |\
+	zte,mf286d|\
 	zte,mf287|\
-	zte,mf287plus |\
-	zte,mf287pro |\
+	zte,mf287plus|\
+	zte,mf287pro|\
 	zte,mf289f)
 		CI_UBIPART="rootfs"
 		local mtdnum="$( find_mtd_index $CI_UBIPART )"
@@ -104,27 +104,27 @@ platform_do_upgrade_mikrotik_nand() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
-	8dev,jalapeno |\
-	aruba,ap-303 |\
-	aruba,ap-303h |\
-	aruba,ap-365 |\
-	avm,fritzbox-7530 |\
-	avm,fritzrepeater-1200 |\
-	avm,fritzrepeater-3000 |\
-	buffalo,wtr-m2133hp |\
-	cilab,meshpoint-one |\
-	edgecore,ecw5211 |\
-	edgecore,oap100 |\
-	engenius,eap2200 |\
-	glinet,gl-a1300 |\
-	glinet,gl-ap1300 |\
-	luma,wrtq-329acn |\
-	mobipromo,cm520-79f |\
-	netgear,lbr20 |\
-	netgear,wac510 |\
-	p2w,r619ac-64m |\
-	p2w,r619ac-128m |\
-	qxwlan,e2600ac-c2 |\
+	8dev,jalapeno|\
+	aruba,ap-303|\
+	aruba,ap-303h|\
+	aruba,ap-365|\
+	avm,fritzbox-7530|\
+	avm,fritzrepeater-1200|\
+	avm,fritzrepeater-3000|\
+	buffalo,wtr-m2133hp|\
+	cilab,meshpoint-one|\
+	edgecore,ecw5211|\
+	edgecore,oap100|\
+	engenius,eap2200|\
+	glinet,gl-a1300|\
+	glinet,gl-ap1300|\
+	luma,wrtq-329acn|\
+	mobipromo,cm520-79f|\
+	netgear,lbr20|\
+	netgear,wac510|\
+	p2w,r619ac-64m|\
+	p2w,r619ac-128m|\
+	qxwlan,e2600ac-c2|\
 	wallys,dr40x9)
 		nand_do_upgrade "$1"
 		;;
@@ -149,7 +149,7 @@ platform_do_upgrade() {
 		CI_KERNPART="linux"
 		nand_do_upgrade "$1"
 		;;
-	asus,rt-ac42u |\
+	asus,rt-ac42u|\
 	asus,rt-ac58u)
 		CI_KERNPART="linux"
 		nand_do_upgrade "$1"
@@ -168,18 +168,18 @@ platform_do_upgrade() {
 		CI_ROOTPART="rootfs"
 		emmc_do_upgrade "$1"
 		;;
-	linksys,ea6350v3 |\
-	linksys,ea8300 |\
-	linksys,mr8300 |\
-	linksys,whw01 |\
+	linksys,ea6350v3|\
+	linksys,ea8300|\
+	linksys,mr8300|\
+	linksys,whw01|\
 	linksys,whw03v2)
 		platform_do_upgrade_linksys "$1"
 		;;
 	linksys,whw03)
 		platform_do_upgrade_linksys_emmc "$1"
 		;;
-	meraki,mr30h |\
-	meraki,mr33 |\
+	meraki,mr30h|\
+	meraki,mr33|\
 	meraki,mr74)
 		CI_KERNPART="part.safe"
 		nand_do_upgrade "$1"
@@ -208,15 +208,15 @@ platform_do_upgrade() {
 		;;
 	netgear,rbr40|\
 	netgear,rbs40|\
-	netgear,rbr50 |\
-	netgear,rbs50 |\
-	netgear,srr60 |\
+	netgear,rbr50|\
+	netgear,rbs50|\
+	netgear,srr60|\
 	netgear,srs60)
 		platform_do_upgrade_netgear_orbi_upgrade "$1"
 		;;
-	openmesh,a42 |\
-	openmesh,a62 |\
-	plasmacloud,pa1200 |\
+	openmesh,a42|\
+	openmesh,a62|\
+	plasmacloud,pa1200|\
 	plasmacloud,pa2200)
 		PART_NAME="inactive"
 		platform_do_upgrade_dualboot_datachk "$1"
@@ -224,14 +224,14 @@ platform_do_upgrade() {
 	sony,ncp-hg100-cellular)
 		sony_emmc_do_upgrade "$1"
 		;;
-	teltonika,rutx10 |\
-	teltonika,rutx50 |\
-	zte,mf18a |\
-	zte,mf282plus |\
-	zte,mf286d |\
-	zte,mf287 |\
-	zte,mf287plus |\
-	zte,mf287pro |\
+	teltonika,rutx10|\
+	teltonika,rutx50|\
+	zte,mf18a|\
+	zte,mf282plus|\
+	zte,mf286d|\
+	zte,mf287|\
+	zte,mf287plus|\
+	zte,mf287pro|\
 	zte,mf289f)
 		CI_UBIPART="rootfs"
 		nand_do_upgrade "$1"
@@ -247,8 +247,8 @@ platform_do_upgrade() {
 
 platform_copy_config() {
 	case "$(board_name)" in
-	glinet,gl-b2200 |\
-	google,wifi |\
+	glinet,gl-b2200|\
+	google,wifi|\
 	linksys,whw03)
 		emmc_copy_config
 		;;


### PR DESCRIPTION
While working on some ipq40xx devices I've notices some small imperfections related to the formatting and sorting of base-files. So I've tried to cleanup some of the errors I found.
These changes should be harmless and introduce no functional change. It just merges some duplicated cases, removes whitespaces and fixes the sorting.
