### PR TITLE
mediatek/filogic: fix Cudy WR3000H ethernet port order

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
@@ -118,22 +118,22 @@
 
 		port@0 {
 			reg = <0>;
-			label = "lan1";
+			label = "lan4";
 		};
 
 		port@1 {
 			reg = <1>;
-			label = "lan2";
+			label = "lan3";
 		};
 
 		port@2 {
 			reg = <2>;
-			label = "lan3";
+			label = "lan2";
 		};
 
 		port@3 {
 			reg = <3>;
-			label = "lan4";
+			label = "lan1";
 		};
 
 		port@6 {


### PR DESCRIPTION
The ports are physically labelled in reverse order on the device. This patch aligns logical names with physical ones.
LED order on front of device is correct after this patch.
    
Fixes: 9d66b8b312fb6a4087244ee3ee10e1ba1623df81

Please backport to 24.10 once merged.