### PR TITLE
realtek: Add PoE support for the D-link DGS-1210-52XX series

### DIFF
--- a/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52p_common.dtsi
+++ b/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52p_common.dtsi
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/ {
+	/* LM63 */
+	i2c-gpio-4 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 32 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 31 GPIO_ACTIVE_HIGH>;
+		i2c-gpio,delay-us = <2>;
+		i2c-gpio,scl-open-drain; /* should be replaced by i2c-gpio,scl-has-no-pullup in kernel 6.6 */
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		lm63@4c {
+			compatible = "national,lm63";
+			reg = <0x4c>;
+		};
+	};
+};
+
+&leds {
+	link_act {
+		label = "green:link_act";
+		gpios = <&gpio1 28 GPIO_ACTIVE_LOW>;
+	};
+
+	poe {
+		label = "green:poe";
+		gpios = <&gpio1 29 GPIO_ACTIVE_LOW>;
+	};
+
+	poe_max {
+		label = "yellow:poe_max";
+		gpios = <&gpio1 27 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&keys {
+	mode {
+		label = "mode";
+		gpios = <&gpio1 30 GPIO_ACTIVE_LOW>;
+		linux,code = <BTN_0>;
+	};
+};
+
+&uart1 {
+	status = "okay";
+};


### PR DESCRIPTION
This adds PoE support for the D-link DGS-1210-52XX series so that we can add support for other DGS-1210-52XX revisions such as the DGS-1210-52MP which there will be a separate commit for.

Relating common files created here: https://github.com/openwrt/openwrt/pull/20534

Signed-off-by: John Jones [hdcp@dayrep.com](mailto:hdcp@dayrep.com)
