### PR TITLE
realtek: add support for DGS-1210-52MP

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -130,6 +130,11 @@ realtek_setup_poe()
 		ucidef_set_poe 193 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
 				lan22 lan21 lan20 lan19 lan18 lan17"
 		;;
+d-link,dgs-1210-52mp-f)
+	ucidef_set_poe 370 "lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan32 lan31 
+	      lan30 lan29 lan28 lan27 lan26 lan25 lan24 lan23 lan22 lan21 lan20 lan19 lan18 lan17 lan48 lan47 lan46 lan45
+		  lan44 lan43 lan42 lan41 lan40 lan39 lan38 lan37 lan36 lan35 lan34 lan33"
+		;;
 	engenius,ews2910p-v1|\
 	engenius,ews2910p-v3)
 		ucidef_set_poe 60 "$(filter_port_list "$lan_list" "lan9 lan10")"

--- a/target/linux/realtek/base-files/etc/uci-defaults/04_dlinkfan
+++ b/target/linux/realtek/base-files/etc/uci-defaults/04_dlinkfan
@@ -7,7 +7,7 @@
 board=$(board_name)
 
 case "$board" in
-d-link,dgs-1210-28p-f|d-link,dgs-1210-28mp-f)
+d-link,dgs-1210-28p-f|d-link,dgs-1210-28mp-f|d-link,dgs-1210-52mp-f)
 	# Enable fan control
 	FAN_CTRL='/sys/class/hwmon/hwmon0'
 	echo 1 > "$FAN_PATH/pwm1_enable"

--- a/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52mp-f.dts
+++ b/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52mp-f.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "rtl839x.dtsi"
+#include "rtl83xx_d-link_dgs-1210_common.dtsi"
+#include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
+#include "rtl83xx_d-link_dgs-1210_gpio_sfp.dtsi"
+#include "rtl8382_d-link_dgs-1210-52_common.dtsi"
+#include "rtl8382_d-link_dgs-1210-52p_common.dtsi"
+
+/ {
+	compatible = "d-link,dgs-1210-52mp-f", "realtek,rtl8393-soc", "realtek,rtl839x-soc";
+	model = "D-Link DGS-1210-52MP F";
+
+};

--- a/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52mp-f.dts
+++ b/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52mp-f.dts
@@ -4,8 +4,8 @@
 #include "rtl83xx_d-link_dgs-1210_common.dtsi"
 #include "rtl83xx_d-link_dgs-1210_gpio.dtsi"
 #include "rtl83xx_d-link_dgs-1210_gpio_sfp.dtsi"
-#include "rtl8382_d-link_dgs-1210-52_common.dtsi"
-#include "rtl8382_d-link_dgs-1210-52p_common.dtsi"
+#include "rtl8393_d-link_dgs-1210-52_common.dtsi"
+#include "rtl8393_d-link_dgs-1210-52p_common.dtsi"
 
 / {
 	compatible = "d-link,dgs-1210-52mp-f", "realtek,rtl8393-soc", "realtek,rtl839x-soc";

--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -9,6 +9,15 @@ define Device/d-link_dgs-1210-52
 endef
 TARGET_DEVICES += d-link_dgs-1210-52
 
+define Device/d-link_dgs-1210-52mp-f
+  $(Device/d-link_dgs-1210)
+  SOC := rtl8393
+  DEVICE_MODEL := DGS-1210-52MP
+  DEVICE_VARIANT := F
+  DEVICE_PACKAGES += realtek-poe kmod-hwmon-lm63
+endef
+TARGET_DEVICES += d-link_dgs-1210-52mp-f
+
 define Device/hpe_1920-48g
   $(Device/hpe_1920)
   SOC := rtl8393


### PR DESCRIPTION
Hardware Specification
----------------------

D-Link DGS-1210-52MP rev. F1 is a switch with 48 Ethernet ports and 4
combo ports, all ports Gbit capable. It is based on a RTL8393 SoC @ 700MHz,
DRAM 128MB and 32MB flash. 48 Ethernet ports are 802.3af/at PoE capable
with a total PoE power budget of 370W.

Installation using OEM upgrade
------------------------------

1. Make sure you are running OEM firmware in image2 slot (logged as admin):
   - > config firmware image_id 2 boot_up
   - > reboot
2. Install squashfs-factory_image1.bin to image1 using (logged as admin):
   - > download firmware_fromTFTP <tftpserver> factory_image1.bin
   - > config firmware image_id 1 boot_up
   - > reboot

Installation using serial interface
-----------------------------------

1. Press Escape key during `Hit Esc key to stop autoboot` prompt
2. Press CTRL+C keys to get into real U-Boot prompt
3. Init network with `rtk network on` command
4. Load image with `tftpboot 0x8f000000 openwrt-realtek-rtl839x-d-link_dgs-1210-52mp-f-initramfs-kernel.bin` command
5. Boot the image with `bootm` command

Once booted the initramfs, install the squashfs-sysupgrade.bin as a normal OpenWrt system.
Dual-boot with stock firmware using writable u-boot-env
-------------------------------------------------------

From stock to OpenWRT / boot image 1 (CLI as admin):
   - > config firmware image_id 1 boot_up
   - > reboot

From OpenWRT to stock / boot image 2: (shell as root)
   - # fw_setenv bootcmd 'run addargs ; bootm 0xb4e80000'
   - # fw_setenv image '/dev/mtdblock7'
   - # reboot

Additional details on this device series can be found here: https://openwrt.org/toh/d-link/dgs-1210-16_g1
This has been developed and tested on device with F1 revision.

Common files added here: https://github.com/openwrt/openwrt/pull/20534
PoE support added here: https://github.com/openwrt/openwrt/pull/20535

Signed-off-by: John Jones hdcp@dayrep.com