### PR TITLE
realtek: rtl838x: fix regression in enable_phy_polling

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -58,11 +58,11 @@ static void rtl83xx_enable_phy_polling(struct rtl838x_switch_priv *priv)
 	pr_info("%s: %16llx\n", __func__, v);
 	priv->r->set_port_reg_le(v, priv->r->smi_poll_ctrl);
 
-	/* PHY update complete, there is no global PHY polling enable bit on the 9300 */
+	/* PHY update complete, there is no global PHY polling enable bit on the 93xx */
 	if (priv->family_id == RTL8390_FAMILY_ID)
 		sw_w32_mask(0, BIT(7), RTL839X_SMI_GLB_CTRL);
-	else if(priv->family_id == RTL9300_FAMILY_ID)
-		sw_w32_mask(0, 0x8000, RTL838X_SMI_GLB_CTRL);
+	else if(priv->family_id == RTL8380_FAMILY_ID)
+		sw_w32_mask(0, BIT(15), RTL838X_SMI_GLB_CTRL);
 }
 
 const struct rtldsa_mib_list_item rtldsa_838x_mib_list[] = {


### PR DESCRIPTION
Fix regression from back when support for RTL930x was added.
While at it replace 0x8000 by BIT(15).

Fixes: 27029277f98ddd0006175bdc5beec8b0b150f187

____________________________

It would be good if anyone with more knowledge about the platform could confirm, that this is actually a regression.
My knowledge about the realtek target itself is still miniscule.
I stumbled across this while refactoring `family_id`s

Should I also edit the code comment so it reflects 93xx instead of 9300? Is there a global PHY polling enable bit on the RTL9310?