### PR TITLE
wifi-scripts: ucode: fix start failed

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -288,8 +288,11 @@ function setup() {
 		wdev_data[v.config.ifname] = config;
 	}
 
-	supplicant.setup(supplicant_data, data);
-	hostapd.setup(data);
+	if (fs.access('/usr/sbin/wpa_supplicant', 'x'))
+		supplicant.setup(supplicant_data, data);
+
+	if (fs.access('/usr/sbin/hostapd', 'x'))
+		hostapd.setup(data);
 
 	system(`ucode /usr/share/hostap/wdev.uc ${data.phy}${data.phy_suffix} set_config '${printf("%J", wdev_data)}' ${join(' ', active_ifnames)}`);
 

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -571,10 +571,11 @@ export function setup(data) {
 		config: has_ap ? file_name : "",
 		prev_config: file_name + '.prev'
 	};
+	system(`ubus wait_for hostapd`);
 	let ret = global.ubus.call('hostapd', 'config_set', msg);
 
 	if (ret)
 		netifd.add_process('/usr/sbin/hostapd', ret.pid, true, true);
-	else if (fs.access('/usr/sbin/hostapd', 'x'))
+	else
 		netifd.setup_failed('HOSTAPD_START_FAILED');
 };

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -270,6 +270,7 @@ export function generate(config_list, data, interface) {
 };
 
 export function setup(config, data) {
+	system(`ubus wait_for wpa_supplicant`);
 	let ret = global.ubus.call('wpa_supplicant', 'config_set', {
 		phy: data.phy,
 		radio: data.config.radio,
@@ -281,7 +282,7 @@ export function setup(config, data) {
 
 	if (ret)
 		netifd.add_process('/usr/sbin/wpa_supplicant', ret.pid, true, true);
-	else if (fs.access('/usr/sbin/wpa_supplicant', 'x'))
+	else
 		netifd.setup_failed('SUPPLICANT_START_FAILED');
 };
 


### PR DESCRIPTION
When using wpad-openssl/wpad-basic-openssl, wpa_supplicant/hostapd may not be ready because of openssl. This cause supplicant.setup and hostapd.setup to be failed. Therefore, wait for wpa_supplicant/hostapd to be ready before supplicant.setup and hostapd.setup.

Run-tested: mediatek/filogic GL-MT3000
fixes: #20361

@nbd168 PTAL...