### PR TITLE
elfutils: add compatibility with new fortify-headers

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=elfutils
 PKG_VERSION:=0.192
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION) \
@@ -87,6 +87,7 @@ TARGET_CFLAGS += \
 	-D_GNU_SOURCE \
 	-Wno-unused-result \
 	-Wno-format-nonliteral \
+	-Wno-error=nonnull-compare \
 	-Wno-error=use-after-free
 
 define Build/InstallDev


### PR DESCRIPTION
Add compatibility with the new fortify-headers 2.3.3 by disabling two warnings.

elfutils throws two different errors with the new fortify-headers 2.3.3 that was committed today by PR #20313 :

`error: this use of "defined" may not be portable [-Werror=expansion-to-defined]`
`error: 'nonnull' argument '__s' compared to NULL [-Werror=nonnull-compare]`

Disable those two warnings.

Compile log extracts:
```
make[3]: Entering directory '/OpenWrt/aarch64/build_dir/target-aarch64_cortex-a53_musl/elfutils-0.192'
make --no-print-directory all-recursive
Making all in config
make[5]: Nothing to be done for 'all'.
Making all in lib
aarch64-openwrt-linux-musl-gcc -D_GNU_SOURCE -DHAVE_CONFIG_H -DLOCALEDIR='"/usr/share/locale"' -I. -I..  -iquote . -I. -I../lib -I.. -I./../libelf -I/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/usr/include -I/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include -I/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include/fortify    -std=gnu99 -Wall -Wshadow -Wformat=2 -Wold-style-definition -Wstrict-prototypes -Wtrampolines -Wlogical-op -Wduplicated-cond -Wnull-dereference -Wimplicit-fallthrough=5 -Wuse-after-free=3 -Werror -Wunused -Wextra -Wstack-usage=262144   -fPIC -Os -pipe -mcpu=cortex-a53 -g3 -fno-caller-saves -fno-plt -fhonour-copts -fmacro-prefix-map=/OpenWrt/aarch64/build_dir/target-aarch64_cortex-a53_musl/elfutils-0.192=elfutils-0.192 -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro   -D_GNU_SOURCE -Wno-unused-result -Wno-format-nonliteral -Wno-error=use-after-free  -c -o xasprintf.o xasprintf.c
In file included from /OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include/fortify/stdio.h:26,
                 from xasprintf.c:34:
/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include/fortify/fortify-headers.h:26:30: error: this use of "defined" may not be portable [-Werror=expansion-to-defined]
   26 | #define __fh_has_builtin(x) (__has_builtin(x) || defined(x))
      |                              ^~~~~~~~~~~~~
/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include/fortify/fortify-headers.h:28:7: note: in expansion of macro '__fh_has_builtin'
   28 | #if ! __fh_has_builtin(__builtin_trap)
      |       ^~~~~~~~~~~~~~~~
/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include/fortify/fortify-headers.h:26:30: error: this use of "defined" may not be portable [-Werror=expansion-to-defined]
   26 | #define __fh_has_builtin(x) (__has_builtin(x) || defined(x))
      |                              ^~~~~~~~~~~~~
/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include/fortify/fortify-headers.h:73:29: note: in expansion of macro '__fh_has_builtin'
   73 | #if _FORTIFY_SOURCE  > 2 && __fh_has_builtin (__builtin_dynamic_object_size)
      |                             ^~~~~~~~~~~~~~~~
/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include/fortify/fortify-headers.h:26:30: error: this use of "defined" may not be portable [-Werror=expansion-to-defined]
   26 | #define __fh_has_builtin(x) (__has_builtin(x) || defined(x))
      |                              ^~~~~~~~~~~~~
/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include/fortify/fortify-headers.h:158:5: note: in expansion of macro '__fh_has_builtin'
  158 | #if __fh_has_builtin (__builtin_mul_overflow_p)
      |     ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[5]: *** [Makefile:511: xasprintf.o] Error 1
make[4]: *** [Makefile:551: all-recursive] Error 1
make[3]: *** [Makefile:467: all] Error 2
make[3]: Leaving directory '/OpenWrt/aarch64/build_dir/target-aarch64_cortex-a53_musl/elfutils-0.192'
make[2]: *** [Makefile:123: /OpenWrt/aarch64/build_dir/target-aarch64_cortex-a53_musl/elfutils-0.192/.built] Error 2
```

```
In file included from xstrndup.c:34:
/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include/fortify/string.h: In function 'mempcpy':
/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include/fortify/string.h:340:13: error: 'nonnull' argument '__d' compared to NULL [-Werror=nonnull-compare]
  340 |         if (!__d || !__s)
      |             ^~~~
/OpenWrt/aarch64/staging_dir/toolchain-aarch64_cortex-a53_gcc-14.3.0_musl/include/fortify/string.h:340:21: error: 'nonnull' argument '__s' compared to NULL [-Werror=nonnull-compare]
  340 |         if (!__d || !__s)
      |                     ^~~~
cc1: all warnings being treated as errors
make[5]: *** [Makefile:511: xstrndup.o] Error 1
```


