### PR TITLE
ipq40xx: Netgear LBR20 fixes

### DIFF
--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
@@ -15,10 +15,10 @@
 	};
 
 	aliases {
-		led-boot = &led_backlight_white;
-		led-failsafe = &led_status_green;
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_red;
 		led-running = &led_status_green;
-		led-upgrade = &led_status_red;
+		led-upgrade = &led_status_blue;
 		label-mac-device = &gmac;
 	};
 
@@ -41,17 +41,18 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_status_green: led-status-green {
-			function = LED_FUNCTION_STATUS;
+		led-0 {
+			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_GREEN>;
 			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
-			default-state = "keep";
+			default-state = "on";
 		};
 
-		led_status_red: led-status-red {
-			function = LED_FUNCTION_STATUS;
+		led-1 {
+			function = LED_FUNCTION_POWER;
 			color = <LED_COLOR_ID_RED>;
 			gpios = <&tlmm 23 GPIO_ACTIVE_LOW>;
+			panic-indicator;
 		};
 	};
 
@@ -81,7 +82,6 @@
 			gpio-export,output = <1>;
 			gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
 		};
-
 	};
 
 	soc {
@@ -111,7 +111,6 @@
 			reg = <0x1957000 0x100>;
 			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
 		};
-
 	};
 };
 
@@ -184,7 +183,7 @@
 
 	nand_pins: nand-pins {
 		pullups {
-			pins =	"gpio52", "gpio53", "gpio58", "gpio59";
+			pins = "gpio52", "gpio53", "gpio58", "gpio59";
 			function = "qpic";
 			bias-pull-up;
 		};
@@ -298,7 +297,6 @@
 					precal_art_9000: precal@9000 {
 						reg = <0x9000 0x2f20>;
 					};
-
 				};
 			};
 
@@ -347,7 +345,6 @@
 						reg = <0x12 0x6>;
 						#nvmem-cell-cells = <1>;
 					};
-
 				};
 			};
 
@@ -401,7 +398,6 @@
 				label = "ubi";
 				reg = <0x0ad00000 0x05300000>;
 			};
-
 		};
 	};
 };
@@ -415,34 +411,29 @@
 		compatible = "ti,tlc59108"; /* really is tlc59208f */
 		reg = <0x27>;
 
-		led_backlight_green: led-backlight-green {
-			function = LED_FUNCTION_BACKLIGHT;
+		led_status_green: led-0 {
+			function = LED_FUNCTION_STATUS;
 			color = <LED_COLOR_ID_GREEN>;
 			reg = <0x0>;
-			linux,default-trigger = "default-off";
 		};
 
-		led_backlight_red: led-backlight-red {
-			function = LED_FUNCTION_BACKLIGHT;
+		led_status_red: led-1 {
+			function = LED_FUNCTION_STATUS;
 			color = <LED_COLOR_ID_RED>;
 			reg = <0x1>;
-			linux,default-trigger = "default-off";
 		};
 
-		led_backlight_blue: led-backlight-blue {
-			function = LED_FUNCTION_BACKLIGHT;
+		led_status_blue: led-2 {
+			function = LED_FUNCTION_STATUS;
 			color = <LED_COLOR_ID_BLUE>;
 			reg = <0x2>;
-			linux,default-trigger = "default-off";
 		};
 
-		led_backlight_white: led-backlight-white {
-			function = LED_FUNCTION_BACKLIGHT;
+		led_status_white: led-3 {
+			function = LED_FUNCTION_STATUS;
 			color = <LED_COLOR_ID_WHITE>;
 			reg = <0x3>;
-			linux,default-trigger = "default-off";
 		};
-
 	};
 };
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
@@ -15,8 +15,6 @@
 	};
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_backlight_white;
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -882,7 +882,9 @@ define Device/netgear_orbi
 endef
 
 define Device/netgear_lbr20
-	$(call Device/netgear_orbi)
+	$(call Device/DniImage)
+	SOC := qcom-ipq4019
+	DEVICE_VENDOR := NETGEAR
 	DEVICE_MODEL := LBR20
 	NETGEAR_BOARD_ID := LBR20
 	NETGEAR_HW_ID := 29766182+0+256+512+2x2+2x2+2x2+1


### PR DESCRIPTION
This series fixes several issues I've found when I was fiddling with a similar unit (RBR20) and used this one as a template due to the hardware they share.
The main issue was, that using sysupgrade currently results in a bricked unit. Also the led behavior is now in line with other Orbi devices - they use the multi-color LEDs on the top to display the device status and the LEDs on the back are only used as panic indicator.
Remove the ethernet0 alias as well as setting the label mac to gmac0 will set the correct mac to the switch anyway.