### PR TITLE
ipq40xx: add support for Netgear RBR20/RBS20

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/ipq40xx
@@ -54,7 +54,8 @@ aruba,ap-365)
 	ubootenv_add_uci_config "/dev/mtd8" "0x0" "0x10000" "0x10000"
 	;;
 buffalo,wtr-m2133hp|\
-netgear,lbr20)
+netgear,lbr20|\
+netgear,rbr20)
 	ubootenv_add_uci_config "/dev/mtd8" "0x0" "0x40000" "0x20000"
 	;;
 linksys,ea6350v3)

--- a/package/boot/uboot-tools/uboot-envtools/files/ipq40xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/ipq40xx
@@ -55,7 +55,8 @@ aruba,ap-365)
 	;;
 buffalo,wtr-m2133hp|\
 netgear,lbr20|\
-netgear,rbr20)
+netgear,rbr20|\
+netgear,rbs20)
 	ubootenv_add_uci_config "/dev/mtd8" "0x0" "0x40000" "0x20000"
 	;;
 linksys,ea6350v3)

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -61,6 +61,7 @@ ALLWIFIBOARDS:= \
 	meraki_z3 \
 	netgear_lbr20 \
 	netgear_rax120v2 \
+	netgear_rbk20 \
 	netgear_sxk80 \
 	netgear_wax214 \
 	netgear_wax218 \
@@ -237,6 +238,7 @@ $(eval $(call generate-ipq-wifi-package,meraki_mr30h,Meraki MR30H))
 $(eval $(call generate-ipq-wifi-package,meraki_z3,Meraki Z3))
 $(eval $(call generate-ipq-wifi-package,netgear_lbr20,Netgear LBR20))
 $(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))
+$(eval $(call generate-ipq-wifi-package,netgear_rbk20,Netgear RBK20))
 $(eval $(call generate-ipq-wifi-package,netgear_sxk80,Netgear SXK80))
 $(eval $(call generate-ipq-wifi-package,netgear_wax214,Netgear WAX214))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -42,6 +42,7 @@ ipq40xx_setup_interfaces()
 	linksys,whw03v2|\
 	luma,wrtq-329acn|\
 	mikrotik,cap-ac|\
+	netgear,rbr20|\
 	netgear,wac510|\
 	sony,ncp-hg100-cellular|\
 	wallys,dr40x9|\

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -81,7 +81,8 @@ ipq40xx_setup_interfaces()
 		;;
 	avm,fritzrepeater-3000|\
 	cellc,rtl30vw|\
-	compex,wpj428)
+	compex,wpj428|\
+	netgear,rbs20)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
 	devolo,magic-2-wifi-next)

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -123,6 +123,7 @@ platform_do_upgrade() {
 	luma,wrtq-329acn|\
 	mobipromo,cm520-79f|\
 	netgear,lbr20|\
+	netgear,rbr20|\
 	netgear,wac510|\
 	p2w,r619ac-64m|\
 	p2w,r619ac-128m|\

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -124,6 +124,7 @@ platform_do_upgrade() {
 	mobipromo,cm520-79f|\
 	netgear,lbr20|\
 	netgear,rbr20|\
+	netgear,rbs20|\
 	netgear,wac510|\
 	p2w,r619ac-64m|\
 	p2w,r619ac-128m|\

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr20.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr20.dts
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Netgear RBR20";
+	compatible = "netgear,rbr20";
+
+	chosen {
+		bootargs-append = "ubi.mtd=ubi root=/dev/ubiblock0_0";
+	};
+
+	aliases {
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+		label-mac-device = &gmac;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&tlmm 32 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 22 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led-1 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&tlmm 23 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		led_status_green: led-2 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: led-3 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_blue: led-4 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&tlmm 26 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_white: led-5 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&tlmm 27 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	soc {
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			status = "okay";
+
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+};
+
+&prng {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio-pinmux {
+		mux_mdio {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_mdc {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	serial_pins: serial-pinmux {
+		function = "blsp_uart0";
+		pins = "gpio16", "gpio17";
+		bias-disable;
+	};
+
+	nand_pins: nand-pins {
+		pullups {
+			pins = "gpio53", "gpio58", "gpio59";
+			function = "qpic";
+			bias-pull-up;
+		};
+
+		pulldowns {
+			pins = "gpio54", "gpio55", "gpio56",
+				"gpio57", "gpio60", "gpio61",
+				"gpio62", "gpio63", "gpio64",
+				"gpio65", "gpio66", "gpio67",
+				"gpio68", "gpio69";
+			function = "qpic";
+			bias-pull-down;
+		};
+	};
+};
+
+&nand {
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	nand@0 {
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x00000000 0x00100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "0:MIBIB";
+				reg = <0x00100000 0x00100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "0:BOOTCONFIG";
+				reg = <0x00200000 0x00100000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "0:QSEE";
+				reg = <0x00300000 0x00100000>;
+				read-only;
+			};
+
+			partition@400000 {
+				label = "0:QSEE_1";
+				reg = <0x00400000 0x00100000>;
+				read-only;
+			};
+
+			partition@500000 {
+				label = "0:CDT";
+				reg = <0x00500000 0x00080000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "0:CDT_1";
+				reg = <0x00580000 0x00080000>;
+				read-only;
+			};
+
+			partition@600000 {
+				label = "0:BOOTCONFIG1";
+				reg = <0x00600000 0x00080000>;
+				read-only;
+			};
+
+			partition@680000 {
+				label = "0:APPSBLENV";
+				reg = <0x00680000 0x00080000>;
+			};
+
+			partition@700000 {
+				label = "0:APPSBL";
+				reg = <0x00700000 0x00200000>;
+				read-only;
+			};
+
+			partition@900000 {
+				label = "0:APPSBL_1";
+				reg = <0x00900000 0x00200000>;
+				read-only;
+			};
+
+			partition@b00000 {
+				label = "0:ART";
+				reg = <0x00b00000 0x00080000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					precal_art_1000: precal@1000 {
+						reg = <0x1000 0x2f20>;
+					};
+
+					precal_art_5000: precal@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+
+					precal_art_9000: precal@9000 {
+						reg = <0x9000 0x2f20>;
+					};
+				};
+			};
+
+			partition@b80000 {
+				label = "0:ART.bak";
+				reg = <0x00b80000 0x00080000>;
+				read-only;
+			};
+
+			partition@c00000 {
+				label = "config";
+				reg = <0x00c00000 0x00100000>;
+				read-only;
+			};
+
+			partition@d00000 {
+				label = "boarddata1";
+				reg = <0x00d00000 0x00080000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					mac_address_lan: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wan: macaddr@6 {
+						compatible = "mac-base";
+						reg = <0x6 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wlan_5g: macaddr@c {
+						compatible = "mac-base";
+						reg = <0xc 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wlan_2nd5g: macaddr@12 {
+						compatible = "mac-base";
+						reg = <0x12 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@d80000 {
+				label = "boarddata2";
+				reg = <0x00d80000 0x00040000>;
+				read-only;
+			};
+
+			partition@dc0000 {
+				label = "pot";
+				reg = <0x00dc0000 0x00100000>;
+				read-only;
+			};
+
+			partition@ec0000 {
+				label = "boarddata1.bak";
+				reg = <0x00ec0000 0x00080000>;
+				read-only;
+			};
+
+			partition@f40000 {
+				label = "boarddata2.bak";
+				reg = <0x00f40000 0x00040000>;
+				read-only;
+			};
+
+			partition@f80000 {
+				label = "language";
+				reg = <0x00f80000 0x00300000>;
+				read-only;
+			};
+
+			partition@1280000 {
+				label = "cert";
+				reg = <0x01280000 0x00080000>;
+				read-only;
+			};
+
+			partition@1300000 {
+				label = "ntgrdata";
+				reg = <0x01300000 0x09300000>;
+			};
+
+			partition@a600000 {
+				label = "kernel";
+				reg = <0x0a600000 0x00700000>;
+			};
+
+			partition@ad00000 {
+				label = "ubi";
+				reg = <0x0ad00000 0x05300000>;
+			};
+		};
+	};
+};
+
+&blsp1_i2c3 {
+	status = "okay";
+
+	led-controller@27 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "ti,tlc59108"; /* really is tlc59208f */
+		reg = <0x27>;
+
+		led0@0 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <0>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x0>;
+			linux,default-trigger = "default-on";
+		};
+
+		led1@1 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x1>;
+			linux,default-trigger = "default-on";
+		};
+
+		led2@2 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x2>;
+			linux,default-trigger = "default-on";
+		};
+
+		led3@3 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x3>;
+			linux,default-trigger = "default-on";
+		};
+	};
+};
+
+&blsp1_uart1 {
+	status = "okay";
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&mac_address_lan 0>;
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "wan";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&mac_address_wan 0>;
+};
+
+&swport5 {
+	status = "okay";
+
+	label = "lan";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+};
+
+&pcie_bridge0 {
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x00010000 0 0 0 0>;
+		ieee80211-freq-limit = <5170000 5350000>;
+		nvmem-cell-names = "pre-calibration", "mac-address";
+		nvmem-cells = <&precal_art_9000>, <&mac_address_wlan_2nd5g 0>;
+		qcom,ath10k-calibration-variant = "Netgear-RBK20";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_1000>, <&mac_address_lan 0>;
+	qcom,ath10k-calibration-variant = "Netgear-RBK20";
+};
+
+&wifi1 {
+	status = "okay";
+	ieee80211-freq-limit = <5470000 5815000>;
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_5000>, <&mac_address_wlan_5g 0>;
+	qcom,ath10k-calibration-variant = "Netgear-RBK20";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs20.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs20.dts
@@ -3,8 +3,8 @@
 #include "qcom-ipq4019-rbx20.dtsi"
 
 / {
-	model = "Netgear RBR20";
-	compatible = "netgear,rbr20";
+	model = "Netgear RBS20";
+	compatible = "netgear,rbs20";
 };
 
 &nand {
@@ -135,12 +135,6 @@
 						#nvmem-cell-cells = <1>;
 					};
 
-					mac_address_wan: macaddr@6 {
-						compatible = "mac-base";
-						reg = <0x6 0x6>;
-						#nvmem-cell-cells = <1>;
-					};
-
 					mac_address_wlan_5g: macaddr@c {
 						compatible = "mac-base";
 						reg = <0xc 0x6>;
@@ -186,24 +180,18 @@
 			};
 
 			partition@1280000 {
-				label = "cert";
-				reg = <0x01280000 0x00080000>;
-				read-only;
-			};
-
-			partition@1300000 {
 				label = "ntgrdata";
-				reg = <0x01300000 0x09300000>;
+				reg = <0x01280000 0x01e00000>;
 			};
 
-			partition@a600000 {
+			partition@3080000 {
 				label = "kernel";
-				reg = <0x0a600000 0x00700000>;
+				reg = <0x03080000 0x00700000>;
 			};
 
-			partition@ad00000 {
+			partition@3780000 {
 				label = "ubi";
-				reg = <0x0ad00000 0x05300000>;
+				reg = <0x03780000 0x04880000>;
 			};
 		};
 	};
@@ -212,13 +200,11 @@
 &swport4 {
 	status = "okay";
 
-	label = "wan";
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&mac_address_wan 0>;
+	label = "lan1";
 };
 
 &swport5 {
 	status = "okay";
 
-	label = "lan";
+	label = "lan2";
 };

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbx20.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbx20.dtsi
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	chosen {
+		bootargs-append = "ubi.mtd=ubi root=/dev/ubiblock0_0";
+	};
+
+	aliases {
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+		label-mac-device = &gmac;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&tlmm 32 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 22 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led-1 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&tlmm 23 GPIO_ACTIVE_HIGH>;
+			panic-indicator;
+		};
+
+		led_status_green: led-2 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: led-3 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_blue: led-4 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&tlmm 26 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_white: led-5 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&tlmm 27 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	soc {
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			status = "okay";
+
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+};
+
+&prng {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio-pinmux {
+		mux_mdio {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_mdc {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	serial_pins: serial-pinmux {
+		function = "blsp_uart0";
+		pins = "gpio16", "gpio17";
+		bias-disable;
+	};
+
+	nand_pins: nand-pins {
+		pullups {
+			pins = "gpio53", "gpio58", "gpio59";
+			function = "qpic";
+			bias-pull-up;
+		};
+
+		pulldowns {
+			pins = "gpio54", "gpio55", "gpio56",
+				"gpio57", "gpio60", "gpio61",
+				"gpio62", "gpio63", "gpio64",
+				"gpio65", "gpio66", "gpio67",
+				"gpio68", "gpio69";
+			function = "qpic";
+			bias-pull-down;
+		};
+	};
+};
+
+&blsp1_i2c3 {
+	status = "okay";
+
+	led-controller@27 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "ti,tlc59108"; /* really is tlc59208f */
+		reg = <0x27>;
+
+		led0@0 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <0>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x0>;
+			linux,default-trigger = "default-on";
+		};
+
+		led1@1 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x1>;
+			linux,default-trigger = "default-on";
+		};
+
+		led2@2 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x2>;
+			linux,default-trigger = "default-on";
+		};
+
+		led3@3 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x3>;
+			linux,default-trigger = "default-on";
+		};
+	};
+};
+
+&blsp1_uart1 {
+	status = "okay";
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&gmac {
+	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&mac_address_lan 0>;
+};
+
+&switch {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+};
+
+&pcie_bridge0 {
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x00010000 0 0 0 0>;
+		ieee80211-freq-limit = <5170000 5350000>;
+		nvmem-cell-names = "pre-calibration", "mac-address";
+		nvmem-cells = <&precal_art_9000>, <&mac_address_wlan_2nd5g 0>;
+		qcom,ath10k-calibration-variant = "Netgear-RBK20";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_1000>, <&mac_address_lan 0>;
+	qcom,ath10k-calibration-variant = "Netgear-RBK20";
+};
+
+&wifi1 {
+	status = "okay";
+	ieee80211-freq-limit = <5470000 5815000>;
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_5000>, <&mac_address_wlan_5g 0>;
+	qcom,ath10k-calibration-variant = "Netgear-RBK20";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -911,13 +911,10 @@ define Device/netgear_lbr20
 endef
 TARGET_DEVICES += netgear_lbr20
 
-define Device/netgear_rbr20
+define Device/netgear_rbx20
 	$(call Device/DniImage)
 	SOC := qcom-ipq4019
 	DEVICE_VENDOR := NETGEAR
-	DEVICE_MODEL := RBR20
-	NETGEAR_BOARD_ID := RBR20
-	NETGEAR_HW_ID := 29765641+0+256+512+2x2+2x2+2x2
 	KERNEL_SIZE := 7340032
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
@@ -930,7 +927,22 @@ define Device/netgear_rbr20
 		append-metadata
 	DEVICE_PACKAGES := ipq-wifi-netgear_rbk20 ath10k-firmware-qca9888-ct
 endef
+
+define Device/netgear_rbr20
+	$(call Device/netgear_rbx20)
+	DEVICE_MODEL := RBR20
+	NETGEAR_BOARD_ID := RBR20
+	NETGEAR_HW_ID := 29765641+0+256+512+2x2+2x2+2x2
+endef
 TARGET_DEVICES += netgear_rbr20
+
+define Device/netgear_rbs20
+	$(call Device/netgear_rbx20)
+	DEVICE_MODEL := RBS20
+	NETGEAR_BOARD_ID := RBS20
+	NETGEAR_HW_ID := 29765641+0+128+512+2x2+2x2+2x2
+endef
+TARGET_DEVICES += netgear_rbs20
 
 define Device/netgear_rbx40
 	$(call Device/netgear_orbi)

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -911,6 +911,27 @@ define Device/netgear_lbr20
 endef
 TARGET_DEVICES += netgear_lbr20
 
+define Device/netgear_rbr20
+	$(call Device/DniImage)
+	SOC := qcom-ipq4019
+	DEVICE_VENDOR := NETGEAR
+	DEVICE_MODEL := RBR20
+	NETGEAR_BOARD_ID := RBR20
+	NETGEAR_HW_ID := 29765641+0+256+512+2x2+2x2+2x2
+	KERNEL_SIZE := 7340032
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	UBINIZE_OPTS := -E 5
+	IMAGE/factory.img := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
+		append-uImage-fakehdr filesystem | pad-to $$$$(KERNEL_SIZE) | \
+		append-ubi | netgear-dni
+	IMAGE/sysupgrade.bin := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
+		append-uImage-fakehdr filesystem | sysupgrade-tar kernel=$$$$@ | \
+		append-metadata
+	DEVICE_PACKAGES := ipq-wifi-netgear_rbk20 ath10k-firmware-qca9888-ct
+endef
+TARGET_DEVICES += netgear_rbr20
+
 define Device/netgear_rbx40
 	$(call Device/netgear_orbi)
 	NETGEAR_HW_ID := 29765515+0+4096+512+2x2+2x2+2x2


### PR DESCRIPTION
RBR20
-----

This device shares a lot of similarities with the LBR20 - the RBR20 just misses the LTE modem and its formfactor is alot smaller. Other than that the LED configuration matches other RBR devices but the RBR20 has less LEDs than its larger counterparts.

Hardware
--------
SOC:    Qualcomm IPQ4019
FLASH:	256MB (Winbond W29N02GVSIAF)
RAM:  	512MB (Nanya NT5CC256M16EP-EK)
WIFI:   Qualcomm IPQ4019
        Qualcomm Atheros QCA9886
ETH:	1x WAN, 1x LAN
LED:	5 (4 RGB at top, 1 RG at back)
BTN:	WPS, Reset
UART:	115200 8N1 (dotted Pin = VCC) VCC-TX-RX-GND

MAC addresses
-------------
LAN	Label MAC (stored in boarddata1 offset 0x0)
WAN	LAN + 1 (stored in boarddata1 offset 0x6)
2.4G	LAN
5GLow	LAN + 3 (stored in boarddata1 offset 0xc)
5GUpper LAN + 2 (stored in boarddata1 offset 0x12)

Installation
------------
Either use the vendor ui upgrade method or nmrpflash to install the factory image.

RBS20
-----

This device has only half the flash and ram of the RBR20. It also has
two lan ports instead of wan and lan.

Hardware
--------
SOC:    Qualcomm IPQ4019
FLASH:  128MB (Winbond W29N01HVSINF)
RAM:    256MB (Winbond W632GU6MB-12)
WIFI:   Qualcomm IPQ4019
        Qualcomm Atheros QCA9886
ETH:    2x LAN
LED:    5 (4 RGB at top, 1 RG at back)
BTN:    WPS, Reset
UART:   115200 8N1 (dotted Pin = VCC) VCC-TX-RX-GND

MAC addresses
-------------
LAN     Label MAC (stored in boarddata1 offset 0x0)
2.4G    LAN
5GLow   LAN + 3 (stored in boarddata1 offset 0xc)
5GUpper LAN + 2 (stored in boarddata1 offset 0x12)

Installation
------------
Either use the vendor ui upgrade method or nmrpflash to install the
factory image.