### PR TITLE
toolchain: fortify-headers: Fix build of some packages

### DIFF
--- a/toolchain/fortify-headers/patches/011-Check-if-FORTIFY_USE_NATIVE_CHK-is-defined.patch
+++ b/toolchain/fortify-headers/patches/011-Check-if-FORTIFY_USE_NATIVE_CHK-is-defined.patch
@@ -1,0 +1,261 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sun, 26 Oct 2025 17:38:41 +0100
+Subject: Check if FORTIFY_USE_NATIVE_CHK is defined
+
+The previews code tried to get the value defined for
+FORTIFY_USE_NATIVE_CHK and this resulted in some build errors like
+this:
+```
+/include/fortify/stdio.h: In function 'vsnprintf':
+/include/fortify/stdio.h:155:49: error: "FORTIFY_USE_NATIVE_CHK" is not defined, evaluates to 0 [-Werror=undef]
+  155 | #if __has_builtin(__builtin___vsnprintf_chk) && FORTIFY_USE_NATIVE_CHK
+      |                                                 ^~~~~~~~~~~~~~~~~~~~~~
+```
+
+Check if it is defined instead.
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ include/stdio.h  | 20 ++++++++++----------
+ include/string.h | 32 ++++++++++++++++----------------
+ 2 files changed, 26 insertions(+), 26 deletions(-)
+
+--- a/include/stdio.h
++++ b/include/stdio.h
+@@ -152,7 +152,7 @@ __diagnose_as_builtin(__builtin_vsnprint
+ _FORTIFY_FN(vsnprintf) int vsnprintf(char * _FORTIFY_POS0 __s, size_t __n,
+                                      const char *__f, __builtin_va_list __v)
+ {
+-#if __has_builtin(__builtin___vsnprintf_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___vsnprintf_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___vsnprintf_chk(__s, __n, _FORTIFY_SOURCE, __fh_bos(__s, 0), __f, __v);
+ #else
+ 	__fh_size_t __b = __fh_bos(__s, 0);
+@@ -172,7 +172,7 @@ __diagnose_as_builtin(__builtin_vsprintf
+ _FORTIFY_FN(vsprintf) int vsprintf(char * _FORTIFY_POS0 __s, const char *__f,
+                                    __builtin_va_list __v)
+ {
+-#if __has_builtin(__builtin___vsprintf_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___vsprintf_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___vsprintf_chk(__s, _FORTIFY_SOURCE, __fh_bos(__s, 0), __f, __v);
+ #else
+ 	__fh_size_t __b = __fh_bos(__s, 0);
+@@ -200,7 +200,7 @@ __diagnose_as_builtin(__builtin_vfprintf
+ #endif
+ _FORTIFY_FN(vfprintf) int vfprintf(FILE * __s, const char *__f, __builtin_va_list __v)
+ {
+-#if __has_builtin(__builtin___vfprintf_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___vfprintf_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___vfprintf_chk(__s, _FORTIFY_SOURCE, __f, __v);
+ #else
+ 	return __orig_vfprintf(__s, __f, __v);
+@@ -214,7 +214,7 @@ __diagnose_as_builtin(__builtin_vprintf,
+ #endif
+ _FORTIFY_FN(vprintf) int vprintf(const char *__f, __builtin_va_list __v)
+ {
+-#if __has_builtin(__builtin___vprintf_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___vprintf_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___vprintf_chk(_FORTIFY_SOURCE, __f, __v);
+ #else
+ 	return __orig_vprintf(__f, __v);
+@@ -228,7 +228,7 @@ __diagnose_as_builtin(__builtin_vasprint
+ #endif
+ _FORTIFY_FN(vasprintf) int vasprintf(char **strp, const char *fmt, __builtin_va_list ap)
+ {
+-#if __has_builtin(__builtin___vasprintf_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___vasprintf_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___vasprintf_chk(_FORTIFY_SOURCE, strp, fmt, ap);
+ #else
+ 	int ret = __orig_vasprintf(strp, fmt, ap);
+@@ -275,7 +275,7 @@ __fh_format(printf, 3, 4)
+ _FORTIFY_FN(snprintf) int snprintf(char *__s, size_t __n,
+                                     const char *__f, ...)
+ {
+-#if __has_builtin(__builtin___snprintf_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___snprintf_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___snprintf_chk(__s, __n, _FORTIFY_SOURCE, __fh_bos(__s, 0), __f, __builtin_va_arg_pack());
+ #else
+ 	__fh_size_t __b = __fh_bos(__s, 0);
+@@ -291,7 +291,7 @@ __fh_format(printf, 2, 3)
+ __fh_access(read_only, 2)
+ _FORTIFY_FN(sprintf) int sprintf(char *__s, const char *__f, ...)
+ {
+-#if __has_builtin(__builtin___sprintf_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___sprintf_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___sprintf_chk(__s, _FORTIFY_SOURCE, __fh_bos(__s, 0), __f, __builtin_va_arg_pack());
+ #else
+ 	__fh_size_t __b = __fh_bos(__s, 0);
+@@ -312,7 +312,7 @@ __fh_format(printf, 1, 2)
+ __fh_access(read_only, 1)
+ _FORTIFY_FN(printf) int printf(const char *__f, ...)
+ {
+-#if __has_builtin(__builtin___printf_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___printf_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___printf_chk(_FORTIFY_SOURCE, __f, __builtin_va_arg_pack());
+ #else
+ 	return __orig_printf(__f, __builtin_va_arg_pack());
+@@ -326,7 +326,7 @@ __diagnose_as_builtin(__builtin_fprintf,
+ #endif
+ _FORTIFY_FN(fprintf) int fprintf(FILE *__s, const char *__f, ...)
+ {
+-#if __has_builtin(__builtin___fprintf_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___fprintf_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___fprintf_chk(_FORTIFY_SOURCE, __s, __f, __builtin_va_arg_pack());
+ #else
+ 	return __orig_fprintf(__s, __f, __builtin_va_arg_pack());
+@@ -343,7 +343,7 @@ __diagnose_as_builtin(__builtin_asprintf
+ #endif
+ _FORTIFY_FN(asprintf) int asprintf(char **strp, const char *fmt, ...)
+ {
+-#if __has_builtin(__builtin___asprintf_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___asprintf_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___asprintf_chk(_FORTIFY_SOURCE, strp, fmt, __builtin_va_arg_pack());
+ #else
+ 	int ret = __orig_asprintf(strp, fmt, __builtin_va_arg_pack());
+--- a/include/string.h
++++ b/include/string.h
+@@ -48,7 +48,7 @@ _FORTIFY_FN(memcpy) void *memcpy(void *
+                                  const void * _FORTIFY_POS0 __os, size_t __n)
+ __error_if((__fh_bos(__od, 0) < __n), "'memcpy' called with `n` bigger than the size of `d`.")
+ {
+-#if __has_builtin(__builtin___memcpy_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___memcpy_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___memcpy_chk(__od, __os, __n, __fh_bos(__od, 0));
+ #else
+ #if defined FORTIFY_PEDANTIC_CHECKS
+@@ -75,7 +75,7 @@ __diagnose_as_builtin(__builtin_memmove,
+ _FORTIFY_FN(memmove) void *memmove(void * _FORTIFY_POS0 __d,
+                                    const void * _FORTIFY_POS0 __s, size_t __n)
+ {
+-#if __has_builtin(__builtin___memmove_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___memmove_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___memmove_chk(__d, __s, __n, __fh_bos(__d, 0));
+ #else
+ #if defined FORTIFY_PEDANTIC_CHECKS
+@@ -99,7 +99,7 @@ __diagnose_as_builtin(__builtin_memset,
+ _FORTIFY_FN(memset) void *memset(void * _FORTIFY_POS0 __d, int __c, size_t __n)
+ __warning_if(__c != 0 && __n == 0, "'memset' will set `0` bytes; did you invert the arguments?")
+ {
+-#if __has_builtin(__builtin___memset_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___memset_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___memset_chk(__d, __c, __n, __fh_bos(__d, 0));
+ #else
+ #if defined FORTIFY_PEDANTIC_CHECKS
+@@ -121,7 +121,7 @@ __diagnose_as_builtin(__builtin_memchr,
+ #endif
+ _FORTIFY_FN(memchr) void *memchr(const void * _FORTIFY_POS0 __d, int __c, size_t __n)
+ {
+-#if __has_builtin(__builtin___memchr_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___memchr_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___memchr_chk(__d, __c, __n, __fh_bos(__d, 0));
+ #else
+ #if defined FORTIFY_PEDANTIC_CHECKS
+@@ -142,7 +142,7 @@ _FORTIFY_FN(memchr) void *memchr(const v
+ __fh_access(read_only, 1, 2)
+ _FORTIFY_FN(strchr) char *strchr(const char * _FORTIFY_POS0 __s, int __c)
+ {
+-#if __has_builtin(__builtin___strchr_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___strchr_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___strchr_chk(__s, __c, __fh_bos(__s, 0));
+ #else
+ 	__fh_size_t __b = __fh_bos(__s, 0);
+@@ -157,7 +157,7 @@ _FORTIFY_FN(strchr) char *strchr(const c
+ __fh_access(read_only, 1, 2)
+ _FORTIFY_FN(strrchr) char *strrchr(const char * _FORTIFY_POS0 __s, int __c)
+ {
+-#if __has_builtin(__builtin___strrchr_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___strrchr_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___strrchr_chk(__s, __c, __fh_bos(__s, 0));
+ #else
+ 	__fh_size_t __b = __fh_bos(__s, 0);
+@@ -181,7 +181,7 @@ __diagnose_as_builtin(__builtin_stpcpy,
+ #endif
+ _FORTIFY_FN(stpcpy) char *stpcpy(char * _FORTIFY_POS0 __d, const char *__s)
+ {
+-#if __has_builtin(__builtin___stpcpy_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___stpcpy_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___stpcpy_chk(__d, __s, __fh_bos(__d, 0));
+ #else
+ 	__fh_size_t __n = strlen(__s) + 1;
+@@ -205,7 +205,7 @@ __diagnose_as_builtin(__builtin_stpncpy,
+ _FORTIFY_FN(stpncpy) char *stpncpy(char * _FORTIFY_POS0 __d, const char *__s,
+                                    size_t __n)
+ {
+-#if __has_builtin(__builtin___stpncpy_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___stpncpy_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___stpncpy_chk(__d, __s, __n, __fh_bos(__d, 0));
+ #else
+ 	// If the length strlen(src) is smaller than n, the remaining
+@@ -227,7 +227,7 @@ __diagnose_as_builtin(__builtin_strcat,
+ #endif
+ _FORTIFY_FN(strcat) char *strcat(char * _FORTIFY_POS0 __d, const char *__s)
+ {
+-#if __has_builtin(__builtin___strcat_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___strcat_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___strcat_chk(__d, __s, __fh_bos(__d, 0));
+ #else
+ 	__fh_size_t __b = __fh_bos(__d, 0);
+@@ -245,7 +245,7 @@ __diagnose_as_builtin(__builtin_strcpy,
+ #endif
+ _FORTIFY_FN(strcpy) char *strcpy(char * _FORTIFY_POS0 __d, const char *__s)
+ {
+-#if __has_builtin(__builtin___strcpy_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___strcpy_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___strcpy_chk(__d, __s, __fh_bos(__d, 0));
+ #else
+ 	__fh_size_t __n = strlen(__s) + 1;
+@@ -266,7 +266,7 @@ __diagnose_as_builtin(__builtin_strlen,
+ #endif
+ _FORTIFY_FN(strlen) size_t strlen(const char * _FORTIFY_POS0 __s)
+ {
+-#if __has_builtin(__builtin___strlen_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___strlen_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___strlen_chk(__s, __fh_bos(__s, 0));
+ #else
+ 	__fh_size_t ret = __orig_strlen(__s);
+@@ -284,7 +284,7 @@ __diagnose_as_builtin(__builtin_strncat,
+ _FORTIFY_FN(strncat) char *strncat(char * _FORTIFY_POS0 __d, const char *__s,
+                                    size_t __n)
+ {
+-#if __has_builtin(__builtin___strncat_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___strncat_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___strncat_chk(__d, __s, __n, __fh_bos(__d, 0));
+ #else
+ #if 0 // strlen(__s) isn't guaranteed to be valid.
+@@ -311,7 +311,7 @@ __diagnose_as_builtin(__builtin_strncpy,
+ _FORTIFY_FN(strncpy) char *strncpy(char * _FORTIFY_POS0 __d,
+                                    const char *__s, size_t __n)
+ {
+-#if __has_builtin(__builtin___strncpy_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___strncpy_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___strncpy_chk(__d, __s, __n, __fh_bos(__d, 0));
+ #else
+ 	// If the length of src is less than n, strncpy() writes additional
+@@ -334,7 +334,7 @@ __diagnose_as_builtin(__builtin_mempcpy,
+ _FORTIFY_FN(mempcpy) void *mempcpy(void * _FORTIFY_POS0 __d,
+                                    const void * _FORTIFY_POS0 __s, size_t __n)
+ {
+-#if __has_builtin(__builtin___mempcpy_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___mempcpy_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___mempcpy_chk(__d, __s, __n, __fh_bos(__d, 0));
+ #else
+ 	if (!__d || !__s)
+@@ -361,7 +361,7 @@ __diagnose_as_builtin(__builtin_strlcat,
+ _FORTIFY_FN(strlcat) size_t strlcat(char * _FORTIFY_POS0 __d,
+                                     const char *__s, size_t __n)
+ {
+-#if __has_builtin(__builtin___strlcat_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___strlcat_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___strlcat_chk(__d, __s, __n, __fh_bos(__d, 0));
+ #else
+ 	__fh_size_t __b = __fh_bos(__d, 0);
+@@ -380,7 +380,7 @@ __diagnose_as_builtin(__builtin_strlcpy,
+ _FORTIFY_FN(strlcpy) size_t strlcpy(char * _FORTIFY_POS0 __d,
+                                     const char *__s, size_t __n)
+ {
+-#if __has_builtin(__builtin___strlcpy_chk) && FORTIFY_USE_NATIVE_CHK
++#if __has_builtin(__builtin___strlcpy_chk) && defined(FORTIFY_USE_NATIVE_CHK)
+ 	return __builtin___strlcpy_chk(__d, __s, __n, __fh_bos(__d, 0));
+ #else
+ 	__fh_size_t __b = __fh_bos(__d, 0);

--- a/toolchain/fortify-headers/patches/012-poll-Check-if-_REDIR_TIME64-is-defined.patch
+++ b/toolchain/fortify-headers/patches/012-poll-Check-if-_REDIR_TIME64-is-defined.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sun, 26 Oct 2025 23:15:30 +0100
+Subject: poll: Check if _REDIR_TIME64 is defined
+
+Treat _REDIR_TIME64 being undefined like being set to 0.
+
+This fixes the following compile error in strace:
+```
+In file included from pathtrace.c:12:
+/include/fortify/poll.h:46:30: error: "_REDIR_TIME64" is not defined, evaluates to 0 [-Werror=undef]
+   46 | #if defined(_GNU_SOURCE) && !_REDIR_TIME64
+      |                              ^~~~~~~~~~~~~
+cc1: all warnings being treated as errors
+```
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ include/poll.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/include/poll.h
++++ b/include/poll.h
+@@ -43,7 +43,7 @@ _FORTIFY_FN(poll) int poll(struct pollfd
+ 	return __orig_poll(__f, __n, __s);
+ }
+ 
+-#if defined(_GNU_SOURCE) && !_REDIR_TIME64
++#if defined(_GNU_SOURCE) && (!defined(_REDIR_TIME64) || !_REDIR_TIME64)
+ #undef ppoll
+ #if __has_builtin(__builtin_ppoll)
+ __diagnose_as_builtin(__builtin_ppoll, 1, 2, 3, 4)

--- a/toolchain/fortify-headers/patches/013-fortify-headers-Remove-__fh_has_builtin.patch
+++ b/toolchain/fortify-headers/patches/013-fortify-headers-Remove-__fh_has_builtin.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sun, 26 Oct 2025 23:16:01 +0100
+Subject: fortify-headers: Remove __fh_has_builtin()
+
+GCC complains about the `defined` usage here. Just call `__has_builtin` directly.
+
+This fixes the following compile error when compiling strace:
+```
+In file included from /home/hauke/openwrt/openwrt/staging_dir/toolchain-aarch64_generic_gcc-14.3.0_musl/include/fortify/stdlib.h:27,
+                 from number_set.c:14:
+/home/hauke/openwrt/openwrt/staging_dir/toolchain-aarch64_generic_gcc-14.3.0_musl/include/fortify/fortify-headers.h:26:30: error: this use of "defined" may not be portable [-Werror=expansion-to-defined]
+   26 | #define __fh_has_builtin(x) (__has_builtin(x) || defined(x))
+      |                              ^~~~~~~~~~~~~
+/home/hauke/openwrt/openwrt/staging_dir/toolchain-aarch64_generic_gcc-14.3.0_musl/include/fortify/fortify-headers.h:28:7: note: in expansion of macro '__fh_has_builtin'
+   28 | #if ! __fh_has_builtin(__builtin_trap)
+      |       ^~~~~~~~~~~~~~~~
+/home/hauke/openwrt/openwrt/staging_dir/toolchain-aarch64_generic_gcc-14.3.0_musl/include/fortify/fortify-headers.h:26:30: error: this use of "defined" may not be portable [-Werror=expansion-to-defined]
+   26 | #define __fh_has_builtin(x) (__has_builtin(x) || defined(x))
+      |                              ^~~~~~~~~~~~~
+/home/hauke/openwrt/openwrt/staging_dir/toolchain-aarch64_generic_gcc-14.3.0_musl/include/fortify/fortify-headers.h:73:29: note: in expansion of macro '__fh_has_builtin'
+   73 | #if _FORTIFY_SOURCE  > 2 && __fh_has_builtin (__builtin_dynamic_object_size)
+      |                             ^~~~~~~~~~~~~~~~
+/home/hauke/openwrt/openwrt/staging_dir/toolchain-aarch64_generic_gcc-14.3.0_musl/include/fortify/fortify-headers.h:26:30: error: this use of "defined" may not be portable [-Werror=expansion-to-defined]
+   26 | #define __fh_has_builtin(x) (__has_builtin(x) || defined(x))
+      |                              ^~~~~~~~~~~~~
+/home/hauke/openwrt/openwrt/staging_dir/toolchain-aarch64_generic_gcc-14.3.0_musl/include/fortify/fortify-headers.h:158:5: note: in expansion of macro '__fh_has_builtin'
+  158 | #if __fh_has_builtin (__builtin_mul_overflow_p)
+      |     ^~~~~~~~~~~~~~~~
+cc1: all warnings being treated as errors
+```
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ include/fortify-headers.h | 14 +++-----------
+ 1 file changed, 3 insertions(+), 11 deletions(-)
+
+--- a/include/fortify-headers.h
++++ b/include/fortify-headers.h
+@@ -21,21 +21,13 @@
+ #error a compiler with __has_builtin support is required
+ #endif
+ 
+-// https://clang.llvm.org/docs/LanguageExtensions.html#has-builtin
+-// > __has_builtin should not be used to detect support for a builtin macro; use #ifdef instead.
+-#define __fh_has_builtin(x) (__has_builtin(x) || defined(x))
+-
+-#if ! __fh_has_builtin(__builtin_trap)
+-#define __builtin_trap abort
+-#endif
+-
+ #if _FORTIFY_SOURCE > 3
+ #warning _FORTIFY_SOURCE > 3 is treated as 3
+ #endif
+ 
+ #ifdef __clang__
+ 
+-#if _FORTIFY_SOURCE  > 2 && __fh_has_builtin (__builtin_dynamic_object_size) && __has_attribute(pass_dynamic_object_size)
++#if _FORTIFY_SOURCE  > 2 && __has_builtin (__builtin_dynamic_object_size) && __has_attribute(pass_dynamic_object_size)
+ #define _FORTIFY_POSN(n) const __attribute__((pass_dynamic_object_size(n)))
+ #else
+ #define _FORTIFY_POSN(n) const __attribute__((pass_object_size(n)))
+@@ -70,7 +62,7 @@
+ #define _FORTIFY_FN(fn) _FORTIFY_FNB(fn); _FORTIFY_INLINE
+ 
+ /* Use __builtin_dynamic_object_size with _FORTIFY_SOURCE>2, if available.  */
+-#if _FORTIFY_SOURCE  > 2 && __fh_has_builtin (__builtin_dynamic_object_size)
++#if _FORTIFY_SOURCE  > 2 && __has_builtin (__builtin_dynamic_object_size)
+ /* 
+  * See:
+  * - https://gcc.gnu.org/onlinedocs/gcc/Object-Size-Checking.html
+@@ -155,7 +147,7 @@
+  * - https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html
+  * - https://clang.llvm.org/docs/LanguageExtensions.html#checked-arithmetic-builtins
+  */
+-#if __fh_has_builtin (__builtin_mul_overflow_p)
++#if __has_builtin (__builtin_mul_overflow_p)
+ #define __bmo(x, y) (x != 0 && __builtin_mul_overflow_p(x, y, (__typeof__ ((x) + (y))) 0))
+ #else /* !__builtin_mul_overflow_p */
+ #define __bmo(x, y) (x != 0 && (x * y) / x != y)


### PR DESCRIPTION
Fix some warnings and compile errors generated by the new fortify-headers when compiling some applications like strace.

Fixes: 6268692bd2bf ("toolchain: fortify-headers: Update to version 2.3.3")

I created a PR with these changes upstream: https://github.com/jvoisin/fortify-headers/pull/74