### PR TITLE
firewall: config: add dest addr restrictions for DHCPv6 rules

### DIFF
--- a/package/network/config/firewall/Makefile
+++ b/package/network/config/firewall/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=firewall
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firewall3.git

--- a/package/network/config/firewall/files/firewall.config
+++ b/package/network/config/firewall/files/firewall.config
@@ -59,6 +59,7 @@ config rule
 	option name		Allow-DHCPv6
 	option src		wan
 	option proto		udp
+	option dest_ip		fe80::/10
 	option dest_port	546
 	option family		ipv6
 	option target		ACCEPT


### PR DESCRIPTION
Some ISPs may use a GUA or other non-LLA as the source addr for the DHCPv6 response, but the destination addr is always LLA (fe80::/10).
Therefore, adding a dest addr restriction improves security.
See https://forum.mikrotik.com/t/xfinity-comcast-dhcpv6-configuration-change/156031/10
