### PR TITLE
wifi-scripts: ucode: fix setting tx_queue_data2_burst in config

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -303,7 +303,7 @@ function device_htmode_append(config) {
 			config.short_gi_160 = 0;
 		}
 
-		config.tx_queue_data2_burst = '2.0';
+		set_default(config, 'tx_queue_data2_burst', '2.0');
 
 		let vht_capab = phy_capabilities.vht_capa;
 		


### PR DESCRIPTION
Currently we unconditionally set it to 2.0 if 802.11ac and disregard what the user set. This sets it to 2.0 only as a default in case user didn't specify a tx_burst setting.