### PR TITLE
wifi-scripts: ucode: improve formatting of expected throughput

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/bin/iwinfo
+++ b/package/network/config/wifi-scripts/files-ucode/usr/bin/iwinfo
@@ -25,7 +25,8 @@ function print_assoclist(stations) {
 				printf(', %s', flags);
 			printf('%10d Pkts.\n', bitrate.packets);
 		}
-		printf(`\texpected throughput: ${station.expected_throughput}\n\n`);
+		let expected_throughput = station.expected_throughput;
+		printf(`\texpected throughput: ${expected_throughput == 'unknown' ? 'unknown' : expected_throughput + ' MBit/s'}\n\n`);
 	}
 }
 

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/iwinfo.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/iwinfo.uc
@@ -169,6 +169,10 @@ function format_rate(rate) {
 	return rate ? sprintf('%.01f', rate / 10.0) : 'unknown';
 }
 
+function format_expected_throughput(rate) {
+	return rate ? sprintf('%.01f', rate / 1000.0) : 'unknown';
+}
+
 function format_mgmt_key(key) {
 	switch(+key) {
 	case 1:
@@ -352,7 +356,7 @@ export function assoclist(dev) {
 				packets: station.sta_info.tx_packets ?? 0,
 				flags: assoc_flags(station.sta_info.tx_bitrate ?? {}),
 			},
-			expected_throughput: station.sta_info.expected_throughput ?? 'unknown',
+			expected_throughput: format_expected_throughput(station.sta_info.expected_throughput ?? 0),
 		};
 		ret[sta.mac] = sta;
 	}


### PR DESCRIPTION
Convert to MBit/s like all other fields and specify the unit. Most users probably aren't aware that this is in kilobits/s.