### PR TITLE
toolchain: fortify-headers: fix __fh_overlap() build error

### DIFF
--- a/toolchain/fortify-headers/patches/014-fortify-headers-fix-__fh_overlap-build-error.patch
+++ b/toolchain/fortify-headers/patches/014-fortify-headers-fix-__fh_overlap-build-error.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andy Chiang <AndyChiang_git@outlook.com>
+Date: Tue, 28 Oct 2025 14:34:29 +0700
+Subject: [PATCH] fortify-headers: fix __fh_overlap() build error
+
+This fixes the following compile error when compiling dtc:
+```
+../../../../staging_dir/toolchain-x86_64_gcc-15.2.0_musl/include/fortify/string.h: In function 'memcpy':
+../../../../staging_dir/toolchain-x86_64_gcc-15.2.0_musl/include/fortify/fortify-headers.h:136:31: error: cast discards 'const' qualifier from pointer target type [-Werror=cast-qual]
+```
+
+Signed-off-by: Andy Chiang <AndyChiang_git@outlook.com>
+---
+ include/fortify-headers.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- a/include/fortify-headers.h
++++ b/include/fortify-headers.h
+@@ -133,8 +133,8 @@
+  * since gcc seems to like to generate code that relies on dst == src */
+ #define __fh_overlap(a, len_a, b, len_b) \
+ 	( \
+-		((char*)(a) < (char*)(b) && (char*)(b) < ((char*)(a) + (__fh_size_t)(len_a))) \
+-	     || ((char*)(b) < (char*)(a) && (char*)(a) < ((char*)(b) + (__fh_size_t)(len_b))) \
++		((const char*)(a) < (const char*)(b) && (const char*)(b) < ((const char*)(a) + (__fh_size_t)(len_a))) \
++	     || ((const char*)(b) < (const char*)(a) && (const char*)(a) < ((const char*)(b) + (__fh_size_t)(len_b))) \
+         )
+ 
+ /*


### PR DESCRIPTION
This fixes the following compile error when compiling dtc:
```
../../../../staging_dir/toolchain-x86_64_gcc-15.2.0_musl/include/fortify/string.h: In function 'memcpy':
../../../../staging_dir/toolchain-x86_64_gcc-15.2.0_musl/include/fortify/fortify-headers.h:136:31: error: cast discards 'const' qualifier from pointer target type [-Werror=cast-qual]
```

See:
https://github.com/openwrt/openwrt/commit/6268692bd2bf25a5105c074648f7c899624ecfd7#commitcomment-168867998
https://github.com/openwrt/openwrt/commit/096739a93d16fa8a923d3f80e1a9c570be5d38d2#commitcomment-168865302
https://github.com/openwrt/openwrt/actions/runs/18831304277/job/53723163525?pr=20562
https://github.com/openwrt/openwrt/actions/runs/18866296497/job/53834525684


