### PR TITLE
netifd: add options for udhcp client 

### DIFF
--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -26,6 +26,8 @@ proto_dhcp_init_config() {
 	proto_config_add_string mtu6rd
 	proto_config_add_string customroutes
 	proto_config_add_boolean classlessroute
+	proto_config_add_int 'retryinterval:uinteger'
+	proto_config_add_int 'numdiscoverpackets:uinteger'
 }
 
 proto_dhcp_add_sendopts() {
@@ -48,8 +50,8 @@ proto_dhcp_setup() {
 	local config="$1"
 	local iface="$2"
 
-	local ipaddr hostname clientid vendorid broadcast norelease reqopts defaultreqopts iface6rd sendopts delegate zone6rd zone mtu6rd customroutes classlessroute
-	json_get_vars ipaddr hostname clientid vendorid broadcast norelease reqopts defaultreqopts iface6rd delegate zone6rd zone mtu6rd customroutes classlessroute
+	local ipaddr hostname clientid vendorid broadcast norelease reqopts defaultreqopts iface6rd sendopts delegate zone6rd zone mtu6rd customroutes classlessroute retryinterval numdiscoverpackets
+	json_get_vars ipaddr hostname clientid vendorid broadcast norelease reqopts defaultreqopts iface6rd delegate zone6rd zone mtu6rd customroutes classlessroute retryinterval numdiscoverpackets
 
 	local opt dhcpopts
 	for opt in $reqopts; do
@@ -80,7 +82,7 @@ proto_dhcp_setup() {
 	proto_run_command "$config" udhcpc \
 		-p /var/run/udhcpc-$iface.pid \
 		-s /lib/netifd/dhcp.script \
-		-f -t 0 -i "$iface" \
+		-f -t "${numdiscoverpackets:-0}" -T "${retryinterval:-3}" -i "$iface" \
 		${ipaddr:+-r ${ipaddr/\/*/}} \
 		${hostname:+-x "hostname:$hostname"} \
 		${vendorid:+-V "$vendorid"} \


### PR DESCRIPTION
This PR adds two new configuration options to the DHCP protocol handler to provide more control over DHCP client behavior:

- retryinterval: Sets the interval (in seconds) between DHCP discover/request packets (udhcpc -T option). Default: 3 seconds.
- numdiscoverpackets: Sets the maximum number of DHCP discover packets to send before giving up (udhcpc -t option). Default: 0 (infinite retries).
