### PR TITLE
econet: New device: Zyxel PMG5617GA

### DIFF
--- a/target/linux/econet/base-files/sbin/en75_chboot
+++ b/target/linux/econet/base-files/sbin/en75_chboot
@@ -124,6 +124,14 @@ main() {
         code_offset=0
         code_openwrt=30000000
         code_factory=31000000
+    elif [ "$machine" = "Zyxel PMG5617GA" ]; then
+        # 00060fff
+        part=$(part_named '"reservearea"')
+        offset_blocks=3
+        block_size=$((1024 * 128))
+        code_offset=4095
+        code_openwrt=30
+        code_factory=31
     else
         echo "Unsupported machine: $machine"
         exit 1

--- a/target/linux/econet/dts/en751221_zyxel_pmg5617ga.dts
+++ b/target/linux/econet/dts/en751221_zyxel_pmg5617ga.dts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include "en751221.dtsi"
+
+/ {
+	model = "Zyxel PMG5617GA";
+	compatible = "tplink,zyxel-pmg5617ga", "econet,en751221";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x8000000>;
+	};
+
+	chosen {
+		stdout-path = "/serial@1fbf0000:115200";
+		linux,usable-memory-range = <0x00020000 0x07fe0000>;
+	};
+};
+
+&nand {
+	status = "okay";
+	econet,bmt;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootloader";
+			reg = <0x0 0x40000>;
+			read-only;
+		};
+
+		partition@40000 {
+			label = "romfile";
+			reg = <0x40000 0x40000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "tclinux";
+			reg = <0x80000 0x3800000>;
+			read-only;
+			econet,enable-remap;
+		};
+
+		/* Nested inside of tclinux */
+		partition@480000 {
+			label = "rootfs";
+			reg = <0x480000 0x3400000>;
+			linux,rootfs;
+			read-only;
+		};
+
+		partition@3880000 {
+			label = "tclinux_alt";
+			reg = <0x3880000 0x0036c0000>;
+		};
+
+		partition@6f40000 {
+			label = "wwan";
+			reg = <0x006f40000 0x000100000>;
+		};
+
+		partition@7040000 {
+			label = "factory_data";
+			reg = <0x007040000 0x000400000>;
+		};
+
+		partition@7440000 {
+			label = "rom-d";
+			reg = <0x007440000 0x000100000>;
+		};
+
+		partition@7540000 {
+			label = "reservearea";
+			reg = <0x007540000 0x000080000>;
+		};
+	};
+};

--- a/target/linux/econet/image/en751221.mk
+++ b/target/linux/econet/image/en751221.mk
@@ -44,3 +44,13 @@ define Device/tplink_archer-vr1200v-v2
     tplink-v2-header -R 0x400000
 endef
 TARGET_DEVICES += tplink_archer-vr1200v-v2
+
+define Device/zyxel_pmg5617ga
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := PMG5617GA
+  DEVICE_DTS := en751221_zyxel_pmg5617ga
+  IMAGES := tclinux.trx
+  IMAGE/tclinux.trx := append-kernel | lzma | tclinux-trx
+  DEVICE_PACKAGES := kmod-usb3
+endef
+TARGET_DEVICES += zyxel_pmg5617ga


### PR DESCRIPTION
This device has one USB2.0 port, plus ethernet, 2x wifi, ethernet, xPON and VoIP. Installation process is documented here: https://openwrt.org/inbox/toh/zyxel/zyxel_pmg5617ga

ZyXEL uses their own modified version of a TRX header, but it transparently supports classical tclinux.trx so we are building classic TRX files to keep the code simple.