### PR TITLE
ramips: add support for ipTIME AX2002MESH

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -78,6 +78,7 @@ elecom,wrc-x1800gs|\
 h3c,tx1800-plus|\
 h3c,tx1801-plus|\
 h3c,tx1806|\
+iptime,ax2002m|\
 iptime,ax2004m|\
 jcg,q20|\
 linksys,e7350|\

--- a/target/linux/ramips/dts/mt7621_iptime_ax2002m.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_ax2002m.dts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "iptime,ax2002m", "mediatek,mt7621-soc";
+	model = "ipTIME AX2002MESH";
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: led-0 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+	mediatek,bmt-remap-range = <0x000000 0x580000>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x80000>;
+		};
+
+		partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					compatible = "mac-base";
+					reg = <0x4 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+
+				precal_factory_e10: precal@e10 {
+					reg = <0xe10 0x19c10>;
+				};
+			};
+		};
+
+		partition@180000 {
+			label = "firmware";
+			reg = <0x180000 0x7680000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7280000>;
+			};
+		};
+
+		/* last 8 MiB is reserved for NMBM bad block table */
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4 3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_4 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
+		nvmem-cell-names = "eeprom", "precal";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1864,6 +1864,27 @@ define Device/iptime_a8004t
 endef
 TARGET_DEVICES += iptime_a8004t
 
+define Device/iptime_ax2002m
+  $(Device/nand)
+  IMAGE_SIZE := 121344k
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+ifeq ($(IB),)
+  ARTIFACTS := initramfs-factory.bin
+  ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | \
+	check-size | iptime-crc32 ax2002m
+endif
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := AX2002MESH
+  DEVICE_PACKAGES := kmod-mt7915-firmware
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := NMBM has been newly enabled, and its flash block \
+	mapping might be incompatible with existing installation. \
+	New installation with factory image via recovery mode is recommended.
+endef
+TARGET_DEVICES += iptime_ax2002m
+
 define Device/iptime_ax2004m
   $(Device/nand)
   IMAGE_SIZE := 121344k

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -101,6 +101,7 @@ ramips_setup_interfaces()
 	glinet,gl-mt1300|\
 	iodata,wn-deax1800gr|\
 	iptime,a3002mesh|\
+	iptime,ax2002m|\
 	jcg,q20|\
 	jdcloud,re-sp-01b|\
 	lenovo,newifi-d1|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
@@ -10,6 +10,7 @@ board_config_update
 case "$(board_name)" in
 	ubnt,edgerouter-x|\
 	ubnt,edgerouter-x-sfp|\
+	iptime,ax2002m|\
 	iptime,ax2004m)
 		ucidef_set_compat_version "2.0"
 		;;

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -97,6 +97,7 @@ case "$board" in
 			macaddr_setbit_la "$(macaddr_add $hw_mac_addr 3)" > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && echo -n "$hw_mac_addr" > /sys${DEVPATH}/macaddress
 		;;
+	iptime,ax2002m|\
 	iptime,ax2004m)
 		if [ "$PHYNBR" = "1" ]; then
 			hw_mac_addr="$(mtd_get_mac_binary factory 0x4)"

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -45,6 +45,7 @@ platform_do_upgrade() {
 			fw_setenv --lock / bootImage 0 || exit 1
 		fi
 		;;
+	iptime,ax2002m|\
 	iptime,ax2004m)
 		if [ "$(fw_printenv -n boot_from 2>/dev/null)" != "firmware1" ]; then
 			fw_setenv boot_from firmware1 || exit 1
@@ -105,6 +106,7 @@ platform_do_upgrade() {
 	gemtek,wvrtm-127acn|\
 	gemtek,wvrtm-130acn|\
 	iptime,a3004t|\
+	iptime,ax2002m|\
 	iptime,ax2004m|\
 	iptime,t5004|\
 	jcg,q20|\


### PR DESCRIPTION
ipTIME AX2002MESH is an 802.11ax (Wi-Fi 6) router based on MediaTek MT7621 SoC.
It has similar board design as ipTIME AX2004M[^1][^2][^3].

## Specifications
- SoC: MediaTek MT7621, MIPS 1004Kc, 880 MHz
- RAM: 128 MiB
- Flash: NAND 128 MiB (ESMT PSU1GA30DT)
- WLAN: MediaTek MT7915E
  - 2.4 GHz: ax/b/g/n
  - 5 GHz: ac/ax/n
- Ethernet:
  - LAN: MediaTek MT7530, 2x 1GbE
  - WAN: MediaTek SoC built-in, 1x 1GbE
- UART: J4 header, 115200 8N1
  - Pinout: [3V3] [TX] [RX] [GND]
- Button: Reset
- LEDs: 6 LEDs
  - 1x CPU (Amber)
  - 1x WLAN 5GHz (Amber)
  - 1x WLAN 2.4GHz (Amber)
  - 2x LAN (Amber)
  - 1x WAN (Amber)
- Power: DC 12V/1A

## MAC addresses
| Interface | MAC               | Algorithm                 |
|:----------|:-----------------:|:--------------------------|
| WLAN 2.4G | 58:86:94:XX:XX:34 | label                     |
| WAN       | 58:86:94:XX:XX:35 | label + 1                 |
| LAN       | 58:86:94:XX:XX:37 | label + 3                 |
| WLAN 5G   | 5A:86:94:XX:XX:37 | label + 3 with LA bit set |
> The WLAN 2.4G MAC address (label) is stored in factory partition, 0x4

## Installation
- Stock web interface:
  1. Flash the **initramfs-factory** image through the web page.
  2. Boot into OpenWrt and perform sysupgrade with **sysupgrade** image.
- Recovery mode:
  1. Turn on the device and press the Reset button more than 10 seconds to enter recovery mode.
  2. Access the recovery web interface at 192.168.0.1/24 and flash the **initramfs-factory** image.
  3. Boot into OpenWrt and perform sysupgrade with **sysupgrade** image.

## Related links
- openwrt/firmware-utils#55

[^1]: 37753f34ac68fbd70730aa37a6b8b94ad3215d85 ("ramips: add support for ipTIME AX2004M")
[^2]: 85a8f58483b223951515219ca9b21c31c36f87c8 ("ramips: add factory image for ipTIME AX2004M")
[^3]: 7e04a611bc798c27a0dc584959d2c2bdf64da05f ("ramips: add NMBM support for ipTIME AX2004M")