### PR TITLE
realtek: Zyxel relabel fixup

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/realtek
+++ b/package/boot/uboot-tools/uboot-envtools/files/realtek
@@ -17,17 +17,17 @@ d-link,dgs-1210-10p|\
 d-link,dgs-1210-16|\
 d-link,dgs-1210-20|\
 d-link,dgs-1210-28|\
-zyxel,gs1900-8|\
-zyxel,gs1900-8hp-v1|\
-zyxel,gs1900-8hp-v2|\
-zyxel,gs1900-10hp|\
-zyxel,gs1900-16|\
-zyxel,gs1900-24-v1|\
-zyxel,gs1900-24e|\
-zyxel,gs1900-24ep|\
-zyxel,gs1900-24hp-v1|\
-zyxel,gs1900-24hp-v2|\
-zyxel,gs1900-48)
+zyxel,gs1900-8-a1|\
+zyxel,gs1900-8hp-a1|\
+zyxel,gs1900-8hp-b1|\
+zyxel,gs1900-10hp-a1|\
+zyxel,gs1900-16-a1|\
+zyxel,gs1900-24-a1|\
+zyxel,gs1900-24e-a1|\
+zyxel,gs1900-24ep-a1|\
+zyxel,gs1900-24hp-a1|\
+zyxel,gs1900-24hp-b1|\
+zyxel,gs1900-48-a1)
 	ubootenv_add_mtd "u-boot-env" "0x0" "0x400" "0x10000"
 	ubootenv_add_sys_mtd "u-boot-env2" "0x0" "0x1000" "0x10000"
 	;;

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -160,18 +160,18 @@ realtek_setup_poe()
 	netgear,gs310tp-v1)
 		ucidef_set_poe 55 "$(filter_port_list "$lan_list" "lan9 lan10")"
 		;;
-	zyxel,gs1900-10hp)
+	zyxel,gs1900-10hp-a1)
 		ucidef_set_poe 77 "$(filter_port_list "$lan_list" "lan9 lan10")"
 		;;
-	zyxel,gs1900-8hp-v1|\
-	zyxel,gs1900-8hp-v2)
+	zyxel,gs1900-8hp-a1|\
+	zyxel,gs1900-8hp-b1)
 		ucidef_set_poe 70 "$lan_list"
 		;;
-	zyxel,gs1900-24ep)
+	zyxel,gs1900-24ep-a1)
 		ucidef_set_poe 130 "lan1 lan2 lan3 lan4 lan5 lan6 lan7 lan8 lan9 lan10 lan11 lan12"
 		;;
-	zyxel,gs1900-24hp-v1|\
-	zyxel,gs1900-24hp-v2)
+	zyxel,gs1900-24hp-a1|\
+	zyxel,gs1900-24hp-b1)
 		ucidef_set_poe 170 "$(filter_port_list "$lan_list" "lan25 lan26")"
 		;;
 	esac

--- a/target/linux/realtek/base-files/etc/board.d/05_compat-version
+++ b/target/linux/realtek/base-files/etc/board.d/05_compat-version
@@ -13,18 +13,18 @@ case "$(board_name)" in
 	hpe,1920-24g-poe-370w)
 		ucidef_set_compat_version "1.1"
 	;;
-	zyxel,gs1900-8-v1 | \
-	zyxel,gs1900-8-v2 | \
-	zyxel,gs1900-8hp-v1 | \
-	zyxel,gs1900-8hp-v2 | \
-	zyxel,gs1900-10hp | \
-	zyxel,gs1900-16 | \
-	zyxel,gs1900-24e | \
-	zyxel,gs1900-24ep | \
-	zyxel,gs1900-24hp-v1 | \
-	zyxel,gs1900-24hp-v2 | \
-	zyxel,gs1900-24-v1 | \
-	zyxel,gs1900-48)
+	zyxel,gs1900-8-a1 | \
+	zyxel,gs1900-8-b1 | \
+	zyxel,gs1900-8hp-a1 | \
+	zyxel,gs1900-8hp-b1 | \
+	zyxel,gs1900-10hp-a1 | \
+	zyxel,gs1900-16-a1 | \
+	zyxel,gs1900-24e-a1 | \
+	zyxel,gs1900-24ep-a1 | \
+	zyxel,gs1900-24hp-a1 | \
+	zyxel,gs1900-24hp-b1 | \
+	zyxel,gs1900-24-a1 | \
+	zyxel,gs1900-48-a1)
 		ucidef_set_compat_version "2.0"
         ;;
 esac


### PR DESCRIPTION
This PR fixes the botched Zyxel relabel in d205878ede and 46cf10771a.

@GoetzGoerisch If you could take a look once more, I grepped the tree but no lingering v1/v2 references other than the desired SUPPORTED_DEVICES values.

Thanks!