### PR TITLE
Add KERNEL_FS_ENCRYPTION configuration option

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -795,6 +795,11 @@ config KERNEL_BIG_KEYS
 	bool "Enable large payload keys on kernel keyrings"
 	depends on KERNEL_KEYS
 
+config KERNEL_FS_ENCRYPTION
+	bool "Enable encryption of files and directories"
+	select KERNEL_KEYS
+	default y if !SMALL_FLASH
+
 #
 # CGROUP support symbols
 #


### PR DESCRIPTION
Add kernel configuration option for filesystem encryption (fscrypt). Core support is enabled on !SMALL_FLASH. This appears to be part of the legwork needed to get the`fscrypt` package added in openwrt/packages#25706 working.

This is a draft to solicit feedback. Not yet tested inspired by @Rondom's remarks (please review!)

Note that a couple of architectures have already forcibly enabled this flag.

If OpenWRT moves toward encrypted UCI secrets on UBI in future, the crypto kmods will also need to be compiled into the kernel, but my understanding is that these can remain as modules for the current userspace encryption use case (network file servers etc.)
