### PR TITLE
Remove obsolete CONFIG_EXT4_ENCRYPTION from fs.mk

### DIFF
--- a/package/kernel/linux/modules/fs.mk
+++ b/package/kernel/linux/modules/fs.mk
@@ -243,7 +243,6 @@ define KernelPackage/fs-ext4
     +kmod-crypto-crc32c
   KCONFIG:= \
 	CONFIG_EXT4_FS \
-	CONFIG_EXT4_ENCRYPTION=n \
 	CONFIG_JBD2
   FILES:= \
 	$(LINUX_DIR)/fs/ext4/ext4.ko \


### PR DESCRIPTION
This kernel config flag doesn't appear in modern kernel sources. Noticed while drafting #20591.
