### PR TITLE
mediatek/filogic: fix Totolink X6000R sysupgrade failed

### DIFF
--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -154,7 +154,8 @@ platform_do_upgrade() {
 	cudy,re3000-v1|\
 	cudy,wr3000-v1|\
 	yuncore,ax835|\
-	wavlink,wl-wn573hx3)
+	wavlink,wl-wn573hx3|\
+	totolink,x6000r)
 		default_do_upgrade "$1"
 		;;
 	dlink,aquila-pro-ai-m30-a1|\


### PR DESCRIPTION
This will fix sysupgrade for Totolink X6000R as it using NOR path with `default_do_upgrade "$1"` instead of NAND `nand_do_upgrade "$1"`

Error log:
```Sun Aug 10 21:47:57 UTC 2025 upgrade: Performing system upgrade...
[   64.678747] ubi0: default fastmap pool size: 8
[   64.683193] ubi0: default fastmap WL pool size: 4
[   64.687917] ubi0: attaching mtd6
[   64.691135] ubi0: MTD device 6 is write-protected, attach in read-only mode
[   64.706147] ubi0: scanning is finished
[   64.709924] ubi0 error: ubi_read_volume_table: the layout volume was not found
[   64.717187] ubi0 error: ubi_attach_mtd_dev: failed to attach mtd6, error -22
ubiattach: error!: cannot attach mtd6
           error 22 (Invalid argument)
ubiformat: error!: cannot open "[   64.734595] ubi0: default fastmap pool size: 8
/dev/mtd6"
    [   64.739975] ubi0: default fastmap WL pool size: 4
       error 13 [   64.746037] ubi0: attaching mtd6
(Permission deni[   64.750644] ubi0: MTD device 6 is write-protected, attach in read-only mode
ed)
[   64.767016] ubi0: scanning is finished
[   64.770764] ubi0 error: ubi_read_volume_table: the layout volume was not found
[   64.778016] ubi0 error: ubi_attach_mtd_dev: failed to attach mtd6, error -22
ubiattach: error!: cannot attach mtd6
           error 22 (Invalid argument)
cannot attach ubi mtd partition rootfs
sysupgrade failed
```
