### PR TITLE
ramips: add support for EDUP EP-RT2960S

### DIFF
--- a/target/linux/ramips/dts/mt7621_edup_ep-rt2960s.dts
+++ b/target/linux/ramips/dts/mt7621_edup_ep-rt2960s.dts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_haier-sim_wr1800k.dtsi"
+
+/ {
+	compatible = "edup,ep-rt2960s", "mediatek,mt7621-soc";
+	model = "EDUP EP-RT2960S";
+
+	keys {
+		reset {
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		led_status_blue: led-0 {
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-2 {
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_3fff4 0>;
+};
+
+&gmac1 {
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_3fff4 (-3)>;
+};
+
+&nvmem_layout {
+	macaddr_factory_3fff4: macaddr@3fff4 {
+		compatible = "mac-base";
+		reg = <0x3fff4 0x6>;
+		#nvmem-cell-cells = <1>;
+	};
+};

--- a/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
+++ b/target/linux/ramips/dts/mt7621_haier-sim_wr1800k.dtsi
@@ -95,7 +95,7 @@
 			reg = <0x0100000 0x0080000>;
 			read-only;
 
-			nvmem-layout {
+			nvmem_layout: nvmem-layout {
 				compatible = "fixed-layout";
 				#address-cells = <1>;
 				#size-cells = <1>;

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1188,6 +1188,13 @@ define Device/edimax_rg21s
 endef
 TARGET_DEVICES += edimax_rg21s
 
+define Device/edup_ep-rt2960s
+  $(Device/haier-sim_wr1800k)
+  DEVICE_VENDOR := EDUP
+  DEVICE_MODEL := EP-RT2960S
+endef
+TARGET_DEVICES += edup_ep-rt2960s
+
 define Device/elecom_wrc-gs
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -13,6 +13,7 @@ ramips_setup_interfaces()
 	buffalo,wsr-2533dhpl2|\
 	buffalo,wsr-2533dhpls|\
 	confiabits,mt7621-v1|\
+	edup,ep-rt2960s|\
 	gehua,ghl-r-001|\
 	h3c,tx1800-plus|\
 	h3c,tx1801-plus|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -78,6 +78,7 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo -n ${addr:0:9}'1'${addr:10:7} > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && echo -n ${addr:0:9}'7'${addr:10:7} > /sys${DEVPATH}/macaddress
 		;;
+	edup,ep-rt2960s|\
 	haier,har-20s2u1|\
 	jcg,y2|\
 	sim,simax1800t|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -92,6 +92,7 @@ platform_do_upgrade() {
 	dlink,dir-3040-a1|\
 	dlink,dir-3060-a1|\
 	dlink,dir-853-a3|\
+	edup,ep-rt2960s|\
 	elecom,wmc-x1800gst|\
 	elecom,wsc-x1800gs|\
 	etisalat,s3|\


### PR DESCRIPTION
```
ramips: add support for EDUP EP-RT2960S
EDUP EP-RT2960S has the similar hardware design as the SIMAX1800T.
The main difference is the arrangement of the GPIO pins
and the location of the MAC address.

Specification
-------------
- SoC       : Mediatek MT7621
- RAM       : 256 MiB DDR3
- Flash     : 128 MiB NAND Flash
- WLAN      : Mediatek MT7905 DBDC
  - 2.4 GHz : 2x2 MIMO WiFi6
  - 5 GHz   : 2x2 MIMO WiFi6
- Ethernet  : MT7621 built-in 10/100/1000 Mbps 1x WAN; 3x LAN
- UART      : 3.3V, 115200n8
- Buttons   : 1x RESET; 1x WPS/MESH
- LEDs      : 1x Multi-Color(Blue;Green;Red)
- Power     : DC 12V1A
- CMIIT ID  : 2022AP7163
- TFTP IP   :
  - server  : 192.168.1.254
  - router  : 192.168.1.28

TFTP Installation(recommend)
------------
1. Set local tftp server IP "192.168.1.254" and NetMask "255.255.255.0".
2. Rename initramfs-kernel.bin to "factory.bin" and put it in the root
   directory of the tftp server. tftpd64 is a good choice for Windows.
3. Remove all Ethernet cables and WiFi connections from the PC, except
   for the one connected to the EDUP EP-RT2960S. Start the TFTP server, plug
   in the power adapter and wait for the OpenWrt system to boot.
4. Backup "firmware" partition and rename it to "firmware.bin". We need
   it to back to the stock firmware.
5. Use "fw_printenv" command to list envs. If "firmware_select=2" is
   observed then set u-boot env variable via command:
   `fw_setenv firmware_select 1`
6. Apply sysupgrade.bin in OpenWrt LuCI.

Web UI Installation
------------
1. Apply update by uploading initramfs-factory.bin to the web UI.
2. Use "fw_printenv" command to list envs. If "firmware_select=2" is
   observed then set u-boot env variable via command:
   `fw_setenv firmware_select 1`
3. Apply squashfs-sysupgrade.bin in OpenWrt LuCI.

Return to Stock Firmware
----------------------------
  Restore the backup firmware partition in the installation step 4.

MAC addresses
-------------
+---------+-------------------+
|         | MAC example       |
+---------+-------------------+
| LABEL   | 24:D5:1C:xx:xx:xx |
| LAN     | 24:D5:1C:xx:xx:xx |
| WAN     | 24:D5:1C:xx:xx:xx |
| WLAN2G  | 24:D5:1C:xx:xx:xx |
| WLAN5G  | 26:D5:1C:xx:xx:xx |
+---------+-------------------+

Tips:
-----------
  User can use `TFTP Installation` method to recover a brick device.

```