### PR TITLE
bmips: support sagemcom f@st4353

### DIFF
--- a/target/linux/bmips/bcm63268/base-files/etc/board.d/01_leds
+++ b/target/linux/bmips/bcm63268/base-files/etc/board.d/01_leds
@@ -27,6 +27,10 @@ sagem,fast-3864-op)
 	ucidef_set_led_netdev "wan_link" "WAN_LINK" "amber:wan" "wan" "link"
 	ucidef_set_led_netdev "wan_act" "WAN_ACT" "green:wan" "wan" "rx tx"
 	;;
+sagem,fast-4353-cfe-spi-nor |\
+sagem,fast-4353-uboot-nand)
+	ucidef_set_led_netdev "wan_link" "WAN_LINK" "amber:wan" "wan" "link"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/bmips/bcm63268/base-files/etc/board.d/02_network
+++ b/target/linux/bmips/bcm63268/base-files/etc/board.d/02_network
@@ -8,6 +8,8 @@ case "$(board_name)" in
 actiontec,t1200h |\
 comtrend,vg-8050 |\
 sagem,fast-3864-op |\
+sagem,fast-4353-cfe-spi-nor |\
+sagem,fast-4353-uboot-nand |\
 sercomm,shg2500)
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 	;;

--- a/target/linux/bmips/dts/bcm63167-sagem-fast-4353-cfe-spi-nor.dts
+++ b/target/linux/bmips/dts/bcm63167-sagem-fast-4353-cfe-spi-nor.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm63167-sagem-fast-4353.dtsi"
+
+/ {
+	model = "Sagemcom F@ST 4353";
+	compatible = "sagem,fast-4353-cfe-spi-nor", "sagem,fast-4353", "brcm,bcm63167", "brcm,bcm63268";
+};

--- a/target/linux/bmips/dts/bcm63167-sagem-fast-4353-uboot-nand.dts
+++ b/target/linux/bmips/dts/bcm63167-sagem-fast-4353-uboot-nand.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm63167-sagem-fast-4353.dtsi"
+
+/ {
+	model = "Sagemcom F@ST 4353";
+	compatible = "sagem,fast-4353-uboot-nand", "sagem,fast-4353", "brcm,bcm63167", "brcm,bcm63268";
+};

--- a/target/linux/bmips/dts/bcm63167-sagem-fast-4353.dtsi
+++ b/target/linux/bmips/dts/bcm63167-sagem-fast-4353.dtsi
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "bcm63268.dtsi"
+
+/ {
+	aliases {
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+
+		led-dsl = &led_dsl_green;
+		led-internet = &led_internet_green;
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 35 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		wlan {
+			label = "wlan";
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WLAN>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&ehci {
+	status = "okay";
+};
+
+&ethernet {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_cferom_6a0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&leds {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_leds>;
+
+	led@0 {
+		reg = <0>;
+		function = LED_FUNCTION_WAN;
+		color = <LED_COLOR_ID_AMBER>;
+		active-low;
+	};
+
+	led_internet_green: led@8 {
+		reg = <8>;
+		label = "green:internet";
+		active-low;
+	};
+
+	led@9 {
+		reg = <9>;
+		label = "green:lan";
+		active-low;
+	};
+
+	wan_green@12 {
+		/* GPHY0 Act */
+		reg = <12>;
+		brcm,hardware-controlled;
+	};
+
+	led@13 {
+		reg = <13>;
+		label = "red:internet";
+	};
+
+	led@15 {
+		reg = <15>;
+		function = LED_FUNCTION_WPS;
+		color = <LED_COLOR_ID_GREEN>;
+		active-low;
+	};
+
+	led@17 {
+		reg = <17>;
+		function = LED_FUNCTION_WLAN;
+		color = <LED_COLOR_ID_GREEN>;
+	};
+
+	led_dsl_green: led@18 {
+		reg = <18>;
+		label = "green:sync";
+		active-low;
+	};
+
+	led_power_green: led@20 {
+		reg = <20>;
+		function = LED_FUNCTION_POWER;
+		color = <LED_COLOR_ID_GREEN>;
+		active-low;
+	};
+
+	led_power_red: led@21 {
+		reg = <21>;
+		function = LED_FUNCTION_POWER;
+		color = <LED_COLOR_ID_RED>;
+		panic-indicator;
+	};
+};
+
+&pinctrl {
+	pinctrl_leds: leds {
+		function = "led";
+		pins = "gpio0",  "gpio8",  "gpio9", "gpio12",
+		       "gpio13", "gpio15", "gpio17", "gpio18",
+		       "gpio20", "gpio21";
+	};
+};
+
+&mdio_ext {
+	switch@1e {
+		compatible = "brcm,bcm53125";
+		reg = <0x1e>;
+
+		dsa,member = <1 0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan1";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan2";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan4";
+			};
+
+			port@8 {
+				reg = <8>;
+
+				phy-mode = "rgmii";
+				ethernet = <&switch0port4>;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+					asym-pause;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&nflash {
+	status = "okay";
+
+	nandcs@0 {
+		compatible = "brcm,nandcs";
+		reg = <0>;
+		nand-ecc-step-size = <512>;
+		nand-ecc-strength = <4>;
+		nand-on-flash-bbt;
+		brcm,nand-oob-sector-size = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			nand_bcmfs:partition@0 {
+				label = "bcmfs";
+				reg = <0x00000000 0x00020000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_cferom_6a0: macaddr@6a0 {
+						reg = <0x6a0 0x6>;
+					};
+				};
+			};
+
+			nand_bcmfs_update:partition@20000 {
+				label = "bcmfs_update";
+				reg = <0x00020000 0x000a0000>;
+				read-only;
+			};
+
+			nand_ubi:partition@c0000 {
+				label = "ubi";
+				reg = <0x000c0000 0x0fa40000>;
+				read-only;
+			};
+
+			nand_data:partition@fb00000 {
+				label = "stock_data";
+				reg = <0x0fb00000 0x0400000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ohci {
+	status = "okay";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&switch0 {
+	dsa,member = <0 0>;
+
+	ports {
+		port@3 {
+			reg = <3>;
+			label = "wan";
+
+			phy-handle = <&phy4>;
+		};
+
+		switch0port4: port@4 {
+			reg = <4>;
+			label = "extsw";
+
+			phy-mode = "rgmii";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usbh {
+	status = "okay";
+};
+
+&hsspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <16666667>;
+		spi-tx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "cfe";
+				reg = <0x000000 0x030000>;
+			};
+
+			partition@30000 {
+				compatible = "brcm,bcm963xx-imagetag";
+				label = "firmware";
+				reg = <0x030000 0xfd0000>;
+			};
+		};
+	};
+};

--- a/target/linux/bmips/image/Makefile
+++ b/target/linux/bmips/image/Makefile
@@ -85,10 +85,17 @@ define Image/FileSystemStrip
 $(firstword $(subst +,$(space),$(subst root.,,$(notdir $(1)))))
 endef
 
+# CFE_LOADADDR: the memory address where CFE unzips the compressed firmware to
+# CFE_ENTRY: the memory address to jump to, after CFE loads the firmware into the memory
+# By default, the tag version will be set to 6, and `imagetag` only supports version 6.
+# There are many tag versions, each has its own format.
+# But in almost all cases, only the first 138 bytes matter (e.g. addresses, signatures).
+# To specify a tag version, use `CFE_EXTRAS += --tag-version=7`.
 define Build/cfe-bin
 	$(STAGING_DIR_HOST)/bin/imagetag -i $(IMAGE_KERNEL) -f $(IMAGE_ROOTFS) \
 		--output $@ --boardid $(CFE_BOARD_ID) --chipid $(CHIP_ID) \
-		--entry $(LOADER_ENTRY) --load-addr $(LOADER_ENTRY) \
+		--load-addr $(if $(CFE_LOADADDR),$(CFE_LOADADDR),$(LOADER_ENTRY)) \
+		--entry $(if $(CFE_ENTRY),$(CFE_ENTRY),$(LOADER_ENTRY)) \
 		--info1 "$(call ModelNameLimit16,$(DEVICE_NAME))" \
 		--info2 "$(call Image/FileSystemStrip,$(IMAGE_ROOTFS))" \
 		$(call rootfspad/$(call Image/FileSystemStrip,$(IMAGE_ROOTFS))) \

--- a/target/linux/bmips/image/bcm63268.mk
+++ b/target/linux/bmips/image/bcm63268.mk
@@ -78,6 +78,44 @@ define Device/sagem_fast-3864-op
 endef
 TARGET_DEVICES += sagem_fast-3864-op
 
+define Device/sagem_fast-4353-uboot-nand
+# The stock uboot does not work with gzip if the image size is greater than 8mb
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | libdeflate-gzip | uImage gzip
+#  KERNEL_INITRAMFS := kernel-bin | append-dtb | uImage none
+  KERNEL_INITRAMFS_SUFFIX := .bin
+  DEVICE_VENDOR := Sagemcom
+  DEVICE_MODEL := F@ST 4353
+  DEVICE_VARIANT := U-Boot NAND Flash
+  CHIP_ID := 63268
+  SOC := bcm63167
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  SUBPAGESIZE := 512
+  VID_HDR_OFFSET := 2048
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    kmod-leds-bcm6328
+endef
+TARGET_DEVICES += sagem_fast-4353-uboot-nand
+
+define Device/sagem_fast-4353-cfe-spi-nor
+  $(Device/bcm63xx-cfe-legacy)
+  DEVICE_VENDOR := Sagemcom
+  DEVICE_MODEL := F@ST 4353
+  DEVICE_VARIANT := CFE Spi Nor Flash
+  CHIP_ID := 63268
+  SOC := bcm63167
+  CFE_BOARD_ID := 963268SV2_EXTSW
+  CFE_EXTRAS += --tag-version=7
+  CFE_LOADADDR := 0x80000000
+  CFE_ENTRY := 0x80010000
+  FLASH_MB := 16
+  BLOCKSIZE := 0x10000
+  IMAGE_OFFSET := 0x30000
+  DEVICE_PACKAGES += $(USB2_PACKAGES) \
+    kmod-leds-bcm6328
+endef
+TARGET_DEVICES += sagem_fast-4353-cfe-spi-nor
+
 define Device/sercomm_h500-s-lowi
   $(Device/sercomm-nand)
   DEVICE_VENDOR := Sercomm


### PR DESCRIPTION
This DSL modem was supplied by Belong Australia to FTTP customers Branded as "Belong 4353 modem" on its label

Specifications:
* SoC: BCM63167
* RAM: 256MiB
* NAND: 256MiB
* Ethernet: 4x1000M LAN, 1x 1000M WAN
* Serial interface: on board but not populated, 3.3V, 115200, 8N1
* 2.4G Wifi (Built-in)
* 5G Wifi (Broadcom BCM43602, PCIe 14E4:AA52)

What works:
* Everything except WLAN and DSL
* RAM boot over stock U-Boot, requires hacking the stock firmware: https://forum.openwrt.org/t/openwrt-support-for-belong-4353/71866/11
* Install to SPI Flash and boot from CFE, requires soldering
* RAM boot from CFE installed to the SPI Flash

Notes:
* Use DSA for VLAN and switches
* NO FAP support, no hardware NAT acceleration
* SPI Flash known to work: GD25Q128
* BCM43602 is found on the PCIe bus, but doesn't work as expected

__Special thanks to @danitool, who provided much support in getting CFE to work on the SPI Flash__

OpenWrt Wiki: https://openwrt.org/inbox/toh/sagem/f_st4353
Prebuilt OpenWrt 24.10 and CFE firmwares are available here: https://github.com/rikka0w0/openwrt/releases/tag/fast4353-24.10