### PR TITLE
ipq806x: cleanup base-files

### DIFF
--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -80,11 +80,11 @@ nec,wg2600hp3)
 	ucidef_set_led_netdev "lan4-port-100" "LAN4-PORT-100" "qca8k-0.0:04:green:lan-2" "lan4" "tx rx link_100"
 	ucidef_set_led_netdev "lan4-port-1000" "LAN4-PORT-1000" "qca8k-0.0:04:green:lan-3" "lan4" "tx rx link_1000"
 	;;
-netgear,d7800 |\
-netgear,r7500 |\
-netgear,r7500v2 |\
-netgear,r7800 |\
-netgear,xr450 |\
+netgear,d7800|\
+netgear,r7500|\
+netgear,r7500v2|\
+netgear,r7800|\
+netgear,xr450|\
 netgear,xr500)
 	ucidef_set_led_usbport "usb1" "USB 1" "white:usb1" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "usb2" "USB 2" "white:usb2" "usb3-port1" "usb4-port1"

--- a/target/linux/ipq806x/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq806x/base-files/etc/board.d/01_leds
@@ -29,7 +29,8 @@ compex,wpq864)
 	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "pcie-usb" "PCIe USB" "green:usb-pcie" "usb3-port1"
 	;;
-edgecore,ecw5410)
+edgecore,ecw5410|\
+ignitenet,ss-w2-ac2600)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy1tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy0tpt"
 	;;
@@ -45,10 +46,6 @@ fortinet,fap-421e)
 	ucidef_set_led_wlan "wlan2g" "2.4G" "yellow:2g" "phy1tpt"
 	ucidef_set_led_wlan "wlan5g" "5G" "yellow:5g" "phy0tpt"
 	ucidef_set_led_usbport "usb" "USB" "amber:power" "usb1-port1" "usb2-port1"
-	;;
-ignitenet,ss-w2-ac2600)
-	ucidef_set_led_wlan "wlan2g" "WLAN2G" "green:wlan2g" "phy1tpt"
-	ucidef_set_led_wlan "wlan5g" "WLAN5G" "green:wlan5g" "phy0tpt"
 	;;
 linksys,e8350-v1)
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wifi" "phy0tpt"

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -16,23 +16,23 @@ ipq806x_setup_interfaces()
 		;;
 	askey,rt4230w-rev6|\
 	asrock,g10|\
-	nec,wg2600hp|\
 	buffalo,wxr-2533dhp|\
 	compex,wpq864|\
-	netgear,d7800|\
-	netgear,r7500|\
-	netgear,r7500v2|\
-	qcom,ipq8064-ap148|\
 	linksys,e8350-v1|\
 	linksys,ea7500-v1|\
 	linksys,ea8500|\
+	nec,wg2600hp|\
 	nec,wg2600hp3|\
+	netgear,d7800|\
+	netgear,r7500|\
+	netgear,r7500v2|\
 	netgear,r7800|\
-	netgear,xr500|\
 	netgear,xr450|\
+	netgear,xr500|\
+	qcom,ipq8064-ap148|\
+	tplink,ad7200|\
 	tplink,c2600|\
 	tplink,vr2600v|\
-	tplink,ad7200|\
 	zyxel,nbg6817)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		ucidef_set_network_device_conduit "lan1" "eth1"
@@ -51,12 +51,6 @@ ipq806x_setup_interfaces()
 	extreme,ap3935)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
-	qcom,ipq8064-ap161)
-		ucidef_set_interface_lan "eth1 eth2 lan1 lan2 lan3 lan4" "wan"
-		;;
-	qcom,ipq8064-db149)
-		ucidef_set_interface_lan "eth1 eth2 eth3 lan1 lan2 lan3 lan4" "wan"
-		;;
 	fortinet,fap-421e|\
 	ignitenet,ss-w2-ac2600|\
 	ubnt,unifi-ac-hd)
@@ -67,6 +61,12 @@ ipq806x_setup_interfaces()
 		;;
 	meraki,mr52)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
+		;;
+	qcom,ipq8064-ap161)
+		ucidef_set_interface_lan "eth1 eth2 lan1 lan2 lan3 lan4" "wan"
+		;;
+	qcom,ipq8064-db149)
+		ucidef_set_interface_lan "eth1 eth2 eth3 lan1 lan2 lan3 lan4" "wan"
 		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not intialized"
@@ -79,17 +79,17 @@ ipq806x_setup_macs()
 	local board="$1"
 
 	case "$board" in
-		linksys,e8350-v1|\
-		zyxel,nbg6817)
-			hw_mac_addr=$(mtd_get_mac_ascii 0:appsblenv ethaddr)
-			ucidef_set_interface_macaddr "lan" "$(macaddr_add $hw_mac_addr 2)"
-			ucidef_set_interface_macaddr "wan" "$(macaddr_add $hw_mac_addr 3)"
+	asrock,g10)
+		hw_mac_addr=$(mtd_get_mac_ascii hwconfig HW.LAN.MAC.Address)
+		ucidef_set_interface_macaddr "lan" "$hw_mac_addr"
+		hw_mac_addr=$(mtd_get_mac_ascii hwconfig HW.WAN.MAC.Address)
+		ucidef_set_interface_macaddr "wan" "$(macaddr_add $hw_mac_addr 1)"
 		;;
-		asrock,g10)
-			hw_mac_addr=$(mtd_get_mac_ascii hwconfig HW.LAN.MAC.Address)
-			ucidef_set_interface_macaddr "lan" "$hw_mac_addr"
-			hw_mac_addr=$(mtd_get_mac_ascii hwconfig HW.WAN.MAC.Address)
-			ucidef_set_interface_macaddr "wan" "$(macaddr_add $hw_mac_addr 1)"
+	linksys,e8350-v1|\
+	zyxel,nbg6817)
+		hw_mac_addr=$(mtd_get_mac_ascii 0:appsblenv ethaddr)
+		ucidef_set_interface_macaddr "lan" "$(macaddr_add $hw_mac_addr 2)"
+		ucidef_set_interface_macaddr "wan" "$(macaddr_add $hw_mac_addr 3)"
 		;;
 	esac
 }

--- a/target/linux/ipq806x/base-files/etc/board.d/02_network
+++ b/target/linux/ipq806x/base-files/etc/board.d/02_network
@@ -14,25 +14,25 @@ ipq806x_setup_interfaces()
 	arris,tr4400-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth2"
 		;;
-	askey,rt4230w-rev6 |\
-	asrock,g10 |\
-	nec,wg2600hp |\
-	buffalo,wxr-2533dhp |\
-	compex,wpq864 |\
-	netgear,d7800 |\
-	netgear,r7500 |\
-	netgear,r7500v2 |\
-	qcom,ipq8064-ap148 |\
-	linksys,e8350-v1 |\
-	linksys,ea7500-v1 |\
-	linksys,ea8500 |\
-	nec,wg2600hp3 |\
-	netgear,r7800 |\
-	netgear,xr500 |\
-	netgear,xr450 |\
-	tplink,c2600 |\
-	tplink,vr2600v |\
-	tplink,ad7200 |\
+	askey,rt4230w-rev6|\
+	asrock,g10|\
+	nec,wg2600hp|\
+	buffalo,wxr-2533dhp|\
+	compex,wpq864|\
+	netgear,d7800|\
+	netgear,r7500|\
+	netgear,r7500v2|\
+	qcom,ipq8064-ap148|\
+	linksys,e8350-v1|\
+	linksys,ea7500-v1|\
+	linksys,ea8500|\
+	nec,wg2600hp3|\
+	netgear,r7800|\
+	netgear,xr500|\
+	netgear,xr450|\
+	tplink,c2600|\
+	tplink,vr2600v|\
+	tplink,ad7200|\
 	zyxel,nbg6817)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		ucidef_set_network_device_conduit "lan1" "eth1"
@@ -41,13 +41,13 @@ ipq806x_setup_interfaces()
 		ucidef_set_network_device_conduit "lan4" "eth1"
 		ucidef_set_network_device_conduit "wan" "eth0"
 		;;
-	asus,onhub |\
+	asus,onhub|\
 	tplink,onhub)
 		ucidef_set_interfaces_lan_wan "lan1" "wan"
 		ucidef_set_network_device_conduit "lan1" "eth1"
 		ucidef_set_network_device_conduit "wan" "eth0"
 		;;
-	edgecore,ecw5410 |\
+	edgecore,ecw5410|\
 	extreme,ap3935)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
 		;;
@@ -57,8 +57,8 @@ ipq806x_setup_interfaces()
 	qcom,ipq8064-db149)
 		ucidef_set_interface_lan "eth1 eth2 eth3 lan1 lan2 lan3 lan4" "wan"
 		;;
-	fortinet,fap-421e |\
-	ignitenet,ss-w2-ac2600 |\
+	fortinet,fap-421e|\
+	ignitenet,ss-w2-ac2600|\
 	ubnt,unifi-ac-hd)
 		ucidef_set_interface_lan "eth0 eth1"
 		;;
@@ -79,7 +79,7 @@ ipq806x_setup_macs()
 	local board="$1"
 
 	case "$board" in
-		linksys,e8350-v1 |\
+		linksys,e8350-v1|\
 		zyxel,nbg6817)
 			hw_mac_addr=$(mtd_get_mac_ascii 0:appsblenv ethaddr)
 			ucidef_set_interface_macaddr "lan" "$(macaddr_add $hw_mac_addr 2)"

--- a/target/linux/ipq806x/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ipq806x/base-files/etc/board.d/05_compat-version
@@ -9,33 +9,33 @@
 board_config_update
 
 case "$(board_name)" in
-	arris,tr4400-v2 |\
-	askey,rt4230w-rev6 |\
-	asrock,g10 |\
-	buffalo,wxr-2533dhp |\
-	compex,wpq864 |\
-	fortinet,fap-421e |\
-	nec,wg2600hp |\
-	nec,wg2600hp3 |\
-	netgear,d7800 |\
-	netgear,r7500 |\
-	netgear,r7500v2 |\
-	netgear,r7800 |\
-	netgear,xr450 |\
-	netgear,xr500 |\
-	nokia,ac400i |\
-	qcom,ipq8064-ap148 |\
-	qcom,ipq8064-ap161 |\
-	qcom,ipq8064-db149 |\
-	tplink,ad7200 |\
-	tplink,c2600 |\
-	tplink,vr2600v |\
-	zyxel,nbg6817 |\
-	asus,onhub |\
+	arris,tr4400-v2|\
+	askey,rt4230w-rev6|\
+	asrock,g10|\
+	buffalo,wxr-2533dhp|\
+	compex,wpq864|\
+	fortinet,fap-421e|\
+	nec,wg2600hp|\
+	nec,wg2600hp3|\
+	netgear,d7800|\
+	netgear,r7500|\
+	netgear,r7500v2|\
+	netgear,r7800|\
+	netgear,xr450|\
+	netgear,xr500|\
+	nokia,ac400i|\
+	qcom,ipq8064-ap148|\
+	qcom,ipq8064-ap161|\
+	qcom,ipq8064-db149|\
+	tplink,ad7200|\
+	tplink,c2600|\
+	tplink,vr2600v|\
+	zyxel,nbg6817|\
+	asus,onhub|\
 	tplink,onhub)
 		ucidef_set_compat_version "1.1"
 		;;
-	linksys,ea7500-v1 |\
+	linksys,ea7500-v1|\
 	linksys,ea8500)
 		ucidef_set_compat_version "2.1"
 		;;

--- a/target/linux/ipq806x/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ipq806x/base-files/etc/board.d/05_compat-version
@@ -12,6 +12,7 @@ case "$(board_name)" in
 	arris,tr4400-v2|\
 	askey,rt4230w-rev6|\
 	asrock,g10|\
+	asus,onhub|\
 	buffalo,wxr-2533dhp|\
 	compex,wpq864|\
 	fortinet,fap-421e|\
@@ -29,10 +30,9 @@ case "$(board_name)" in
 	qcom,ipq8064-db149|\
 	tplink,ad7200|\
 	tplink,c2600|\
+	tplink,onhub|\
 	tplink,vr2600v|\
-	zyxel,nbg6817|\
-	asus,onhub|\
-	tplink,onhub)
+	zyxel,nbg6817)
 		ucidef_set_compat_version "1.1"
 		;;
 	linksys,ea7500-v1|\

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -28,7 +28,7 @@ base64_extract() {
 case "$FIRMWARE" in
 "ath10k/cal-pci-0000:01:00.0.bin")
 	case "$board" in
-	asus,onhub |\
+	asus,onhub|\
 	tplink,onhub)
 		base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration0
 		;;
@@ -59,7 +59,7 @@ case "$FIRMWARE" in
 	;;
 "ath10k/cal-pci-0001:01:00.0.bin")
 	case "$board" in
-	asus,onhub |\
+	asus,onhub|\
 	tplink,onhub)
 		base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration1
 		;;
@@ -73,7 +73,7 @@ case "$FIRMWARE" in
 	edgecore,ecw5410)
 		caldata_extract "0:art" 0x1000 0x2f20
 		;;
-	meraki,mr42 |\
+	meraki,mr42|\
 	meraki,mr52)
 		CI_UBIPART=art
 		caldata_extract_ubi "ART" 0x5000 0x2f20
@@ -90,7 +90,7 @@ case "$FIRMWARE" in
 	;;
 "ath10k/cal-pci-0002:01:00.0.bin")
 	case "$board" in
-	asus,onhub |\
+	asus,onhub|\
 	tplink,onhub)
 		base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration2
 		;;

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -17,7 +17,7 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && echo $(mtd_get_mac_ascii CFG1 RADIOADDR0) > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && echo $(mtd_get_mac_ascii CFG1 RADIOADDR1) > /sys${DEVPATH}/macaddress
 		;;
-	linksys,ea7500-v1 |\
+	linksys,ea7500-v1|\
 	linksys,ea8500)
 		macaddr_add $(mtd_get_mac_ascii devinfo hw_mac_addr) $(($PHYNBR + 1)) > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/ipq806x/base-files/etc/init.d/bootcount
+++ b/target/linux/ipq806x/base-files/etc/init.d/bootcount
@@ -9,14 +9,14 @@ boot() {
 	asrock,g10)
 		asrock_bootconfig_mangle "bootcheck" && reboot
 		;;
-	edgecore,ecw5410 |\
+	edgecore,ecw5410|\
 	ignitenet,ss-w2-ac2600)
 		fw_setenv bootcount 0
 		;;
 	extreme,ap3935)
 		fw_setenv WATCHDOG_COUNT 0x00000000
 		;;
-	linksys,ea7500-v1 |\
+	linksys,ea7500-v1|\
 	linksys,ea8500)
 		mtd resetbc s_env || true
 		;;

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -30,6 +30,15 @@ platform_do_upgrade() {
 		asrock_upgrade_prepare
 		nand_do_upgrade "$1"
 		;;
+	asus,onhub|\
+	tplink,onhub)
+		export_bootdevice
+		export_partdevice CI_ROOTDEV 0
+		CI_KERNPART="kernel"
+		CI_ROOTPART="rootfs"
+		CI_DATAPART="rootfs_data"
+		emmc_do_upgrade "$1"
+		;;
 	buffalo,wxr-2533dhp)
 		buffalo_upgrade_prepare_ubi
 		CI_ROOTPART="ubi_rootfs"
@@ -66,15 +75,6 @@ platform_do_upgrade() {
 		PART_NAME="os-image:rootfs"
 		MTD_CONFIG_ARGS="-s 0x200000"
 		default_do_upgrade "$1"
-		;;
-	asus,onhub|\
-	tplink,onhub)
-		export_bootdevice
-		export_partdevice CI_ROOTDEV 0
-		CI_KERNPART="kernel"
-		CI_ROOTPART="rootfs"
-		CI_DATAPART="rootfs_data"
-		emmc_do_upgrade "$1"
 		;;
 	tplink,vr2600v)
 		MTD_CONFIG_ARGS="-s 0x200000"

--- a/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq806x/base-files/lib/upgrade/platform.sh
@@ -10,19 +10,19 @@ platform_check_image() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
-	arris,tr4400-v2 |\
-	askey,rt4230w-rev6 |\
+	arris,tr4400-v2|\
+	askey,rt4230w-rev6|\
 	compex,wpq864|\
 	fortinet,fap-421e|\
 	linksys,e8350-v1|\
-	netgear,d7800 |\
-	netgear,r7500 |\
-	netgear,r7500v2 |\
-	netgear,r7800 |\
-	netgear,xr450 |\
-	netgear,xr500 |\
-	nokia,ac400i |\
-	qcom,ipq8064-ap148 |\
+	netgear,d7800|\
+	netgear,r7500|\
+	netgear,r7500v2|\
+	netgear,r7800|\
+	netgear,xr450|\
+	netgear,xr500|\
+	nokia,ac400i|\
+	qcom,ipq8064-ap148|\
 	qcom,ipq8064-ap161)
 		nand_do_upgrade "$1"
 		;;
@@ -35,7 +35,7 @@ platform_do_upgrade() {
 		CI_ROOTPART="ubi_rootfs"
 		nand_do_upgrade "$1"
 		;;
-	edgecore,ecw5410 |\
+	edgecore,ecw5410|\
 	ignitenet,ss-w2-ac2600)
 		part="$(awk -F 'ubi.mtd=' '{printf $2}' /proc/cmdline | sed -e 's/ .*$//')"
 		if [ "$part" = "rootfs1" ]; then
@@ -52,22 +52,22 @@ platform_do_upgrade() {
 		CI_KERNPART="PriImg"
 		nand_do_upgrade "$1"
 		;;
-	linksys,ea7500-v1 |\
+	linksys,ea7500-v1|\
 	linksys,ea8500)
 		platform_do_upgrade_linksys "$1"
 		;;
-	meraki,mr42 |\
+	meraki,mr42|\
 	meraki,mr52)
 		CI_KERNPART="bootkernel2"
 		nand_do_upgrade "$1"
 		;;
-	tplink,ad7200 |\
+	tplink,ad7200|\
 	tplink,c2600)
 		PART_NAME="os-image:rootfs"
 		MTD_CONFIG_ARGS="-s 0x200000"
 		default_do_upgrade "$1"
 		;;
-	asus,onhub |\
+	asus,onhub|\
 	tplink,onhub)
 		export_bootdevice
 		export_partdevice CI_ROOTDEV 0
@@ -91,7 +91,7 @@ platform_do_upgrade() {
 
 platform_copy_config() {
 	case "$(board_name)" in
-	asus,onhub |\
+	asus,onhub|\
 	tplink,onhub)
 		emmc_copy_config
 		;;


### PR DESCRIPTION
Same basic cleanup I've done recently for the ipq40xx target.
These changes should be harmless and introduce no functional change. It just merges some duplicated cases, removes whitespaces and fixes the sorting.
