### PR TITLE
mediatek: mt7622: fix 2.5G WAN port on Netgear WAX206

### DIFF
--- a/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
+++ b/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
@@ -208,7 +208,7 @@
 			reg = <7>;
 			reset-gpios = <&pio 101 GPIO_ACTIVE_LOW>;
 			interrupt-parent = <&pio>;
-			interrupts = <52 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <77 IRQ_TYPE_LEVEL_LOW>;
 			reset-assert-us = <100000>;
 			reset-deassert-us = <100000>;
 		};


### PR DESCRIPTION
Since 6b43a52171f5, the PHY is using interrupts instead of polling. It turned out that the interrupt number is wrong and the WAN port doesn't work. This commit fixes this bug.

Fixes: 6b43a52171f5 ("mediatek: mt7622: add the missing phy interrupt-parent for WAX206")
Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>