### PR TITLE
rockchip: make NIC name predictable for Radxa E52C/ROCK 5 ITX/ROCK 5T

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
@@ -15,7 +15,6 @@ friendlyarm,nanopi-r3s|\
 friendlyarm,nanopi-r4s|\
 friendlyarm,nanopi-r4s-enterprise|\
 friendlyarm,nanopi-r6c|\
-radxa,e52c|\
 xunlong,orangepi-r1-plus|\
 xunlong,orangepi-r1-plus-lts)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth0"
@@ -39,6 +38,10 @@ friendlyarm,nanopi-r6s)
 friendlyarm,nanopi-r76s)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
+	;;
+radxa,e52c)
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "lan"
 	;;
 esac
 

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -15,7 +15,6 @@ rockchip_setup_interfaces()
 	friendlyarm,nanopi-r4s|\
 	friendlyarm,nanopi-r4s-enterprise|\
 	friendlyarm,nanopi-r6c|\
-	radxa,e52c|\
 	radxa,rockpi-e|\
 	xunlong,orangepi-r1-plus|\
 	xunlong,orangepi-r1-plus-lts)
@@ -26,9 +25,7 @@ rockchip_setup_interfaces()
 	friendlyarm,nanopi-r76s|\
 	lunzn,fastrhino-r66s|\
 	radxa,e25|\
-	radxa,rock-3b|\
-	radxa,rock-5-itx|\
-	radxa,rock-5t)
+	radxa,rock-3b)
 		ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
 		;;
 	friendlyarm,nanopi-r5s)
@@ -36,6 +33,21 @@ rockchip_setup_interfaces()
 		;;
 	friendlyarm,nanopi-r6s)
 		ucidef_set_interfaces_lan_wan 'eth0 eth2' 'eth1'
+		;;
+	radxa,e52c)
+		ucidef_set_network_device_path 'wan' 'platform/a40c00000.pcie/pci0003:30/0003:30:00.0/0003:31:00.0'
+		ucidef_set_network_device_path 'lan' 'platform/a41000000.pcie/pci0004:40/0004:40:00.0/0004:41:00.0'
+		ucidef_set_interfaces_lan_wan 'lan' 'wan'
+		;;
+	radxa,rock-5-itx)
+		ucidef_set_network_device_path 'eth0' 'platform/a40c00000.pcie/pci0003:30/0003:30:00.0/0003:31:00.0'
+		ucidef_set_network_device_path 'eth1' 'platform/a41000000.pcie/pci0004:40/0004:40:00.0/0004:41:00.0'
+		ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
+		;;
+	radxa,rock-5t)
+		ucidef_set_network_device_path 'eth1' 'platform/a40c00000.pcie/pci0003:30/0003:30:00.0/0003:31:00.0'
+		ucidef_set_network_device_path 'eth0' 'platform/a41000000.pcie/pci0004:40/0004:40:00.0/0004:41:00.0'
+		ucidef_set_interfaces_lan_wan 'eth0' 'eth1'
 		;;
 	sinovoip,rk3568-bpi-r2pro)
 		ucidef_set_interfaces_lan_wan 'lan0 lan1 lan2 lan3' 'eth0'

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -225,6 +225,8 @@ define Device/radxa_e52c
   UBOOT_DEVICE_NAME := generic-rk3588
   DEVICE_DTS := rk3582-radxa-e52c
   DEVICE_PACKAGES := blkdiscard kmod-r8169
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Network interface names have been changed
 endef
 TARGET_DEVICES += radxa_e52c
 


### PR DESCRIPTION
The probe order for PCIe buses and devices is non-deterministic, making the names eth0 and eth1 unpredictable (they may be swapped).

This patch fixes the names by referencing the device path using `ucidef_set_network_device_path`.

The mapping between silkscreen labels on the board/case and OpenWrt interface names is as follows:

- E52C
  LAN: lan
  WAN: wan

- ROCK 5 ITX
  RJ45 1: eth0
  RJ45 2: eth1

- ROCK 5T
  RJ45_1: eth0
  RJ45_2: eth1

For Radxa E52C, this breaks compatibility of the network config; therefore, set DEVICE_COMPAT_VERSION to `1.1`.

Fixes: d16d2765bd ("rockchip: add support for Radxa E52C")
Fixes: 0839345211 ("rockchip: add support for Radxa ROCK 5 ITX/ITX+")
Fixes: 4a78af9876 ("rockchip: add support for Radxa ROCK 5T")
Link: https://github.com/openwrt/openwrt/issues/20202