### PR TITLE
bcm27xx: package V3D GPU driver

### DIFF
--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -365,6 +365,24 @@ endef
 
 $(eval $(call KernelPackage,drm-dma-helper))
 
+
+define KernelPackage/drm-shmem-helper
+  SUBMENU:=$(VIDEO_MENU)
+  HIDDEN:=1
+  TITLE:=GEM SHMEM helper functions
+  DEPENDS:=@DISPLAY_SUPPORT +kmod-drm-kms-helper
+  KCONFIG:=CONFIG_DRM_GEM_SHMEM_HELPER
+  FILES:=$(LINUX_DIR)/drivers/gpu/drm/drm_shmem_helper.ko
+  AUTOLOAD:=$(call AutoProbe,drm_shmem_helper)
+endef
+
+define KernelPackage/drm-shmem-helper/description
+  GEM SHMEM helper functions.
+endef
+
+$(eval $(call KernelPackage,drm-shmem-helper))
+
+
 define KernelPackage/drm-mipi-dbi
   SUBMENU:=$(VIDEO_MENU)
   HIDDEN:=1
@@ -380,6 +398,25 @@ define KernelPackage/drm-mipi-dbi/description
 endef
 
 $(eval $(call KernelPackage,drm-mipi-dbi))
+
+
+define KernelPackage/drm-sched
+  SUBMENU:=$(VIDEO_MENU)
+  HIDDEN:=1
+  TITLE:=GPU scheduler
+  DEPENDS:=@DISPLAY_SUPPORT +kmod-drm
+  KCONFIG:=CONFIG_DRM_SCHED
+  FILES:=$(LINUX_DIR)/drivers/gpu/drm/scheduler/gpu-sched.ko
+  AUTOLOAD:=$(call AutoProbe,gpu-sched)
+endef
+
+define KernelPackage/drm-sched/description
+  The GPU scheduler provides entities which allow userspace to push jobs
+  into software queues which are then scheduled on a hardware run queue.
+endef
+
+$(eval $(call KernelPackage,drm-sched))
+
 
 define KernelPackage/drm-ttm
   SUBMENU:=$(VIDEO_MENU)

--- a/target/linux/bcm27xx/modules/video.mk
+++ b/target/linux/bcm27xx/modules/video.mk
@@ -93,6 +93,26 @@ endef
 $(eval $(call KernelPackage,codec-bcm2835))
 
 
+define KernelPackage/drm-v3d
+  SUBMENU:=$(VIDEO_MENU)
+  TITLE:=Broadcom V3D Graphics
+  DEPENDS:= \
+    @TARGET_bcm27xx_bcm2711||TARGET_bcm27xx_bcm2712 +kmod-drm \
+    +kmod-drm-shmem-helper +kmod-drm-sched
+  KCONFIG:=CONFIG_DRM_V3D
+  FILES:= \
+    $(LINUX_DIR)/drivers/gpu/drm/v3d/v3d.ko
+  AUTOLOAD:=$(call AutoProbe,v3d)
+endef
+
+define KernelPackage/drm-v3d/description
+  Broadcom V3D 3.x or newer GPUs. SoCs supported include the BCM2711,
+  BCM7268 and BCM7278.
+endef
+
+$(eval $(call KernelPackage,drm-v3d))
+
+
 define KernelPackage/drm-vc4
   SUBMENU:=$(VIDEO_MENU)
   TITLE:=Broadcom VC4 Graphics


### PR DESCRIPTION
Package V3D GPU driver for newer bcm2711 and bcm2712 SoC as module, as well as the required helper modules. This will allow to also package GPU drivers for other targets as modules (instead of having them built-in).