### PR TITLE
ath79: add support for NEC Aterm WF1200HP/HP2

### DIFF
--- a/package/boot/uboot-ath79/Makefile
+++ b/package/boot/uboot-ath79/Makefile
@@ -19,10 +19,17 @@ define U-Boot/Default
 endef
 
 define U-Boot/ar9344_nec_aterm
-  NAME:=NEC Aterm series (AR9344)
+  NAME:=NEC Aterm series (AR9344, GbE)
   BUILD_SUBTARGET:= tiny
   BUILD_DEVICES:=nec_wg600hp nec_wr8750n nec_wr9500n
   UBOOT_CONFIG:=nec_ar9344_aterm
+endef
+
+define U-Boot/ar9344_nec_aterm_fe
+  NAME:=NEC Aterm series (AR9344, FE)
+  BUILD_SUBTARGET:= tiny
+  BUILD_DEVICES:=nec_wf1200hp nec_wf1200hp2
+  UBOOT_CONFIG:=nec_ar9344_aterm_fe
 endef
 
 define U-Boot/qca9558_nec_aterm
@@ -32,7 +39,7 @@ define U-Boot/qca9558_nec_aterm
   UBOOT_CONFIG:=nec_qca9558_aterm
 endef
 
-UBOOT_TARGETS := ar9344_nec_aterm qca9558_nec_aterm
+UBOOT_TARGETS := ar9344_nec_aterm ar9344_nec_aterm_fe qca9558_nec_aterm
 
 # don't stage files to bindir, let target/linux/ath79/image/*.mk do that
 define Package/u-boot/install

--- a/package/boot/uboot-ath79/patches/400-ath79-add-support-for-NEC-AR9344-Aterm-series.patch
+++ b/package/boot/uboot-ath79/patches/400-ath79-add-support-for-NEC-AR9344-Aterm-series.patch
@@ -5,19 +5,21 @@ Subject: [PATCH] ath79: add support for NEC AR9344 Aterm series
 
 ---
  arch/mips/dts/Makefile                |  1 +
- arch/mips/dts/nec,ar9344-aterm.dts    | 35 +++++++++++++++
- arch/mips/mach-ath79/Kconfig          |  5 +++
- board/nec/ar9344_aterm/Kconfig        | 30 +++++++++++++
+ arch/mips/dts/nec,ar9344-aterm.dts    | 35 ++++++++++++++
+ arch/mips/mach-ath79/Kconfig          |  5 ++
+ board/nec/ar9344_aterm/Kconfig        | 33 +++++++++++++
  board/nec/ar9344_aterm/Makefile       |  3 ++
- board/nec/ar9344_aterm/ar9344_aterm.c | 59 ++++++++++++++++++++++++++
- configs/nec_ar9344_aterm_defconfig    | 61 +++++++++++++++++++++++++++
- include/configs/nec_ar9344_aterm.h    | 28 ++++++++++++
- 8 files changed, 222 insertions(+)
+ board/nec/ar9344_aterm/ar9344_aterm.c | 70 +++++++++++++++++++++++++++
+ configs/nec_ar9344_aterm_defconfig    | 61 +++++++++++++++++++++++
+ configs/nec_ar9344_aterm_fe_defconfig | 62 ++++++++++++++++++++++++
+ include/configs/nec_ar9344_aterm.h    | 28 +++++++++++
+ 9 files changed, 298 insertions(+)
  create mode 100644 arch/mips/dts/nec,ar9344-aterm.dts
  create mode 100644 board/nec/ar9344_aterm/Kconfig
  create mode 100644 board/nec/ar9344_aterm/Makefile
  create mode 100644 board/nec/ar9344_aterm/ar9344_aterm.c
  create mode 100644 configs/nec_ar9344_aterm_defconfig
+ create mode 100644 configs/nec_ar9344_aterm_fe_defconfig
  create mode 100644 include/configs/nec_ar9344_aterm.h
 
 --- a/arch/mips/dts/Makefile
@@ -91,7 +93,7 @@ Subject: [PATCH] ath79: add support for NEC AR9344 Aterm series
  endmenu
 --- /dev/null
 +++ b/board/nec/ar9344_aterm/Kconfig
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,33 @@
 +if BOARD_NEC_AR9344_ATERM
 +
 +config SYS_VENDOR
@@ -121,6 +123,9 @@ Subject: [PATCH] ath79: add support for NEC AR9344 Aterm series
 +config SYS_ICACHE_LINE_SIZE
 +	default 32
 +
++config BOARD_NEC_AR9344_ATERM_FE
++	bool "Aterm devices based on AR9344 with FE ports"
++
 +endif
 --- /dev/null
 +++ b/board/nec/ar9344_aterm/Makefile
@@ -130,7 +135,7 @@ Subject: [PATCH] ath79: add support for NEC AR9344 Aterm series
 +obj-y	= ar9344_aterm.o
 --- /dev/null
 +++ b/board/nec/ar9344_aterm/ar9344_aterm.c
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,70 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Copyright (C) 2024 INAGAKI Hiroshi <musashino.open@gmail.com>
@@ -156,16 +161,27 @@ Subject: [PATCH] ath79: add support for NEC AR9344 Aterm series
 +	writel(0x2, regs + AR934X_GPIO_REG_FUNC);
 +
 +	/* Configure default GPIO OE/SET regs */
++#if defined(CONFIG_BOARD_NEC_AR9344_ATERM_FE)
++	writel(0x39b1f, regs + AR71XX_GPIO_REG_OE);
++	writel(0x040000, regs + AR71XX_GPIO_REG_SET);
++#else
 +	writel(0x3db1f, regs + AR71XX_GPIO_REG_OE);
 +	writel(0x142000, regs + AR71XX_GPIO_REG_SET);
++#endif
 +
 +	/* Configure pin multiplexing */
 +	writel(0x00000000, regs + AR934X_GPIO_REG_OUT_FUNC0);
 +	writel(0x0b0a0900, regs + AR934X_GPIO_REG_OUT_FUNC1);
 +	writel(0x00180000, regs + AR934X_GPIO_REG_OUT_FUNC2);
-+	writel(0x00000000, regs + AR934X_GPIO_REG_OUT_FUNC3);
 +	writel(0x2f2e0000, regs + AR934X_GPIO_REG_OUT_FUNC4);
++
++#if defined(CONFIG_BOARD_NEC_AR9344_ATERM_FE)
++	writel(0x002b2a00, regs + AR934X_GPIO_REG_OUT_FUNC3);
++	writel(0x002c2d00, regs + AR934X_GPIO_REG_OUT_FUNC5);
++#else
++	writel(0x00000000, regs + AR934X_GPIO_REG_OUT_FUNC3);
 +	writel(0x00000000, regs + AR934X_GPIO_REG_OUT_FUNC5);
++#endif
 +}
 +
 +#ifdef CONFIG_DEBUG_UART_BOARD_INIT
@@ -202,6 +218,71 @@ Subject: [PATCH] ath79: add support for NEC AR9344 Aterm series
 +CONFIG_SYS_LOAD_ADDR=0x83000000
 +CONFIG_ARCH_ATH79=y
 +CONFIG_BOARD_NEC_AR9344_ATERM=y
++CONFIG_SYS_MIPS_TIMER_FREQ=280000000
++CONFIG_MIPS_RELOCATION_TABLE_SIZE=0x4000
++# CONFIG_LOCALVERSION_AUTO is not set
++CONFIG_TIMESTAMP=y
++CONFIG_BOOTDELAY=3
++# CONFIG_ARCH_FIXUP_FDT_MEMORY is not set
++CONFIG_USE_BOOTARGS=y
++CONFIG_BOOTARGS="console=ttyS0,115200"
++CONFIG_USE_BOOTCOMMAND=y
++CONFIG_BOOTCOMMAND="bootm 0x9f040000"
++# CONFIG_DISPLAY_BOARDINFO is not set
++CONFIG_BOARD_EARLY_INIT_F=y
++CONFIG_SYS_MALLOC_BOOTPARAMS=y
++# CONFIG_CMDLINE_EDITING is not set
++# CONFIG_AUTO_COMPLETE is not set
++# CONFIG_SYS_LONGHELP is not set
++CONFIG_SYS_MAXARGS=32
++# CONFIG_SYS_XTRACE is not set
++# CONFIG_CMD_BDI is not set
++# CONFIG_CMD_CONSOLE is not set
++# CONFIG_BOOTM_PLAN9 is not set
++# CONFIG_BOOTM_RTEMS is not set
++# CONFIG_BOOTM_VXWORKS is not set
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_FDT is not set
++# CONFIG_CMD_RUN is not set
++# CONFIG_CMD_XIMG is not set
++# CONFIG_CMD_EXPORTENV is not set
++# CONFIG_CMD_IMPORTENV is not set
++# CONFIG_CMD_EDITENV is not set
++# CONFIG_CMD_SAVEENV is not set
++# CONFIG_CMD_ENV_EXISTS is not set
++# CONFIG_CMD_CRC32 is not set
++# CONFIG_CMD_DM is not set
++# CONFIG_CMD_LOADS is not set
++# CONFIG_CMD_ECHO is not set
++# CONFIG_CMD_ITEST is not set
++# CONFIG_CMD_SOURCE is not set
++# CONFIG_CMD_SETEXPR is not set
++# CONFIG_CMD_SLEEP is not set
++# CONFIG_ISO_PARTITION is not set
++# CONFIG_OF_TAG_MIGRATE is not set
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_NO_NET=y
++CONFIG_CLK=y
++# CONFIG_GPIO is not set
++# CONFIG_I2C is not set
++# CONFIG_INPUT is not set
++# CONFIG_POWER is not set
++CONFIG_DM_SERIAL=y
++CONFIG_SYS_NS16550=y
++# CONFIG_GZIP is not set
+--- /dev/null
++++ b/configs/nec_ar9344_aterm_fe_defconfig
+@@ -0,0 +1,62 @@
++CONFIG_MIPS=y
++CONFIG_SYS_MALLOC_LEN=0x40000
++CONFIG_HAS_CUSTOM_SYS_INIT_SP_ADDR=y
++CONFIG_CUSTOM_SYS_INIT_SP_ADDR=0xbd007fff
++CONFIG_ENV_SIZE=0x1000
++CONFIG_DEFAULT_DEVICE_TREE="nec,ar9344-aterm"
++CONFIG_SYS_LOAD_ADDR=0x83000000
++CONFIG_ARCH_ATH79=y
++CONFIG_BOARD_NEC_AR9344_ATERM=y
++CONFIG_BOARD_NEC_AR9344_ATERM_FE=y
 +CONFIG_SYS_MIPS_TIMER_FREQ=280000000
 +CONFIG_MIPS_RELOCATION_TABLE_SIZE=0x4000
 +# CONFIG_LOCALVERSION_AUTO is not set

--- a/target/linux/ath79/dts/ar9344_nec_wf1200.dtsi
+++ b/target/linux/ath79/dts/ar9344_nec_wf1200.dtsi
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "ar9344.dtsi"
+
+/ {
+	aliases {
+		label-mac-device = &eth0;
+	};
+
+	chosen {
+		/*
+		 * don't specify bootargs property in DeviceTree to
+		 * enable a console with a default baudrate (9600)
+		 * or passed console= parameter from the bootloader
+		 */
+		/delete-property/ bootargs;
+		stdout-path = &uart;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-wps {
+			label = "wps";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		switch-bridge {
+			label = "br";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			debounce-interval = <60>;
+		};
+
+		switch-coverter {
+			label = "cnv";
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			debounce-interval = <60>;
+		};
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	/* all LEDs are connected to ath10k chip (QCA9882) */
+};
+
+&ref {
+	clock-frequency = <40000000>;
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <25000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/*
+			 * since the OEM bootloader requires unknown
+			 * filesystem on firmware area, needs to be
+			 * replaced to u-boot before OpenWrt installation
+			 */
+			partition@0 {
+				label = "bootloader";
+				reg = <0x000000 0x020000>;
+			};
+
+			/* not compatible with u-boot */
+			partition@20000 {
+				label = "config";
+				reg = <0x020000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_0: mac-address@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_config_6: mac-address@6 {
+						reg = <0x6 0x6>;
+					};
+
+					macaddr_config_c: mac-address@c {
+						reg = <0xc 0x6>;
+					};
+
+					macaddr_config_12: mac-address@12 {
+						reg = <0x12 0x6>;
+					};
+				};
+			};
+
+			partition@30000 {
+				label = "art";
+				reg = <0x030000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					cal_art_5000: calibration@5000 {
+						reg = <0x5000 0x844>;
+					};
+				};
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x040000 0x7c0000>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	phy-handle = <&swphy4>;
+
+	nvmem-cells = <&macaddr_config_c>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_config_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0000 0 0 0 0>;
+
+		nvmem-cells = <&cal_art_5000>, <&macaddr_config_12>;
+		nvmem-cell-names = "calibration", "mac-address";
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&cal_art_1000>, <&macaddr_config_0>;
+	nvmem-cell-names = "calibration", "mac-address";
+};

--- a/target/linux/ath79/dts/ar9344_nec_wf1200hp.dts
+++ b/target/linux/ath79/dts/ar9344_nec_wf1200hp.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_nec_wf1200.dtsi"
+
+/ {
+	compatible = "nec,wf1200hp", "qca,ar9344";
+	model = "NEC Aterm WF1200HP";
+};

--- a/target/linux/ath79/dts/ar9344_nec_wf1200hp2.dts
+++ b/target/linux/ath79/dts/ar9344_nec_wf1200hp2.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9344_nec_wf1200.dtsi"
+
+/ {
+	compatible = "nec,wf1200hp2", "qca,ar9344";
+	model = "NEC Aterm WF1200HP2";
+};

--- a/target/linux/ath79/image/lzma-loader/src/board.c
+++ b/target/linux/ath79/image/lzma-loader/src/board.c
@@ -219,7 +219,8 @@ static inline void huawei_ap_init(void)
 static inline void huawei_ap_init(void) {}
 #endif
 
-#if defined(CONFIG_BOARD_NEC_WG1400HP) || \
+#if defined(CONFIG_BOARD_NEC_WF1200HP) || \
+    defined(CONFIG_BOARD_NEC_WG1400HP) || \
     defined(CONFIG_BOARD_NEC_WG1800HP) || \
     defined(CONFIG_BOARD_NEC_WG1800HP2) || \
     defined(CONFIG_BOARD_NEC_WG2200HP) || \
@@ -262,7 +263,8 @@ static inline void nec_aterm_reset_common(void)
 }
 #endif
 
-#if defined(CONFIG_BOARD_NEC_WG600HP) || \
+#if defined(CONFIG_BOARD_NEC_WF1200HP) || \
+    defined(CONFIG_BOARD_NEC_WG600HP) || \
     defined(CONFIG_BOARD_NEC_WR8750N) || \
     defined(CONFIG_BOARD_NEC_WR9500N)
 

--- a/target/linux/ath79/image/lzma-loader/src/board.c
+++ b/target/linux/ath79/image/lzma-loader/src/board.c
@@ -220,6 +220,7 @@ static inline void huawei_ap_init(void) {}
 #endif
 
 #if defined(CONFIG_BOARD_NEC_WF1200HP) || \
+    defined(CONFIG_BOARD_NEC_WF1200HP2) || \
     defined(CONFIG_BOARD_NEC_WG1400HP) || \
     defined(CONFIG_BOARD_NEC_WG1800HP) || \
     defined(CONFIG_BOARD_NEC_WG1800HP2) || \
@@ -264,6 +265,7 @@ static inline void nec_aterm_reset_common(void)
 #endif
 
 #if defined(CONFIG_BOARD_NEC_WF1200HP) || \
+    defined(CONFIG_BOARD_NEC_WF1200HP2) || \
     defined(CONFIG_BOARD_NEC_WG600HP) || \
     defined(CONFIG_BOARD_NEC_WR8750N) || \
     defined(CONFIG_BOARD_NEC_WR9500N)

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -134,6 +134,19 @@ define Device/nec_wf1200hp
 endef
 TARGET_DEVICES += nec_wf1200hp
 
+define Device/nec_wf1200hp2
+  DEVICE_MODEL := Aterm WF1200HP2
+  SOC := ar9344
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7936k
+  NEC_FW_TYPE := H053
+  $(Device/nec-netbsd-aterm)
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct \
+	-uboot-envtools
+  UBOOT_PATH := $$(STAGING_DIR_IMAGE)/$$(SOC)_nec_aterm_fe-u-boot.bin
+endef
+TARGET_DEVICES += nec_wf1200hp2
+
 define Device/nec_wg600hp
   DEVICE_MODEL := Aterm WG600HP
   SOC := ar9344

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -121,6 +121,19 @@ define Device/engenius_enh202-v1
 endef
 TARGET_DEVICES += engenius_enh202-v1
 
+define Device/nec_wf1200hp
+  DEVICE_MODEL := Aterm WF1200HP
+  SOC := ar9344
+  BLOCKSIZE := 4k
+  IMAGE_SIZE := 7936k
+  NEC_FW_TYPE := H047
+  $(Device/nec-netbsd-aterm)
+  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct \
+	-uboot-envtools
+  UBOOT_PATH := $$(STAGING_DIR_IMAGE)/$$(SOC)_nec_aterm_fe-u-boot.bin
+endef
+TARGET_DEVICES += nec_wf1200hp
+
 define Device/nec_wg600hp
   DEVICE_MODEL := Aterm WG600HP
   SOC := ar9344

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -72,6 +72,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "4:lan:1"
 		;;
+	nec,wf1200hp)
+		ucidef_set_interface_wan "eth1"
+		ucidef_add_switch "switch0" \
+			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1"
+		;;
 	nec,wg600hp|\
 	nec,wr8750n|\
 	nec,wr9500n|\

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -72,7 +72,8 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth1" "4:lan:1"
 		;;
-	nec,wf1200hp)
+	nec,wf1200hp|\
+	nec,wf1200hp2)
 		ucidef_set_interface_wan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "2:lan:3" "3:lan:2" "4:lan:1"

--- a/target/linux/ath79/tiny/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/tiny/base-files/lib/upgrade/platform.sh
@@ -12,6 +12,7 @@ platform_check_image() {
 	local board=$(board_name)
 
 	case "$board" in
+	nec,wf1200hp|\
 	nec,wg600hp|\
 	nec,wr8750n|\
 	nec,wr9500n)

--- a/target/linux/ath79/tiny/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/tiny/base-files/lib/upgrade/platform.sh
@@ -13,6 +13,7 @@ platform_check_image() {
 
 	case "$board" in
 	nec,wf1200hp|\
+	nec,wf1200hp2|\
 	nec,wg600hp|\
 	nec,wr8750n|\
 	nec,wr9500n)


### PR DESCRIPTION
This PR adds support for NEC Aterm WF1200HP and WF1200HP2 using the internal FE switch instead of the external GbE switch.