### PR TITLE
ipq40xx: use NVMEM-on-UBI  for ASUS Lyra and introduce label mac

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -9,11 +9,6 @@ board=$(board_name)
 case "$FIRMWARE" in
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case "$board" in
-	asus,map-ac2200)
-		caldata_extract_ubi "Factory" 0x9000 0x2f20
-		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
-			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
-		;;
 	asus,rt-ac42u)
 		caldata_extract_ubi "Factory" 0x9000 0x2f20
 		;;
@@ -48,7 +43,6 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-ahb-a000000.wifi.bin")
 	case "$board" in
-	asus,map-ac2200|\
 	asus,rt-ac42u)
 		caldata_extract_ubi "Factory" 0x1000 0x2f20
 		;;
@@ -143,9 +137,6 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-ahb-a800000.wifi.bin")
 	case "$board" in
-	asus,map-ac2200)
-		caldata_extract_ubi "Factory" 0x5000 0x2f20
-		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
 		;;

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -2,11 +2,6 @@
 
 preinit_set_mac_address() {
 	case $(board_name) in
-	asus,map-ac2200)
-		base_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
-		ip link set dev eth0 address $(macaddr_add "$base_mac" 1)
-		ip link set dev eth1 address $(macaddr_add "$base_mac" 3)
-		;;
 	asus,rt-ac42u)
 		base_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
 		ip link set dev eth0 address $base_mac

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
@@ -15,9 +15,8 @@
 		led-failsafe = &led_red0;
 		led-running = &led_blue0;
 		led-upgrade = &led_red0;
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		ethernet1 = &swport4;
+		label-mac-device = &wifi0;
 	};
 
 	soc {
@@ -117,9 +116,42 @@
 			};
 
 			partition@400000 {
-				label = "ubi";
+				compatible = "linux,ubi";
 				reg = <0x400000 0x7c00000>;
+				label = "ubi";
+
+				volumes {
+					ubi_factory: ubi-volume-factory {
+						volname = "Factory";
+					};
+				};
 			};
+		};
+	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		precal_factory_1000: precal@1000 {
+			reg = <0x1000 0x2f20>;
+		};
+
+		macaddr_factory_1006: macaddr@1006 {
+			compatible = "mac-base";
+			reg = <0x1006 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+
+		precal_factory_5000: precal@5000 {
+			reg = <0x5000 0x2f20>;
+		};
+
+		precal_factory_9000: precal@9000 {
+			reg = <0x9000 0x2f20>;
 		};
 	};
 };
@@ -192,11 +224,15 @@
 
 &wifi0 {
 	status = "okay";
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_factory_1000>;
 	qcom,ath10k-calibration-variant = "ASUS-MAP-AC2200";
 };
 
 &wifi1 {
 	status = "okay";
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_factory_5000>;
 	qcom,ath10k-calibration-variant = "ASUS-MAP-AC2200";
 	ieee80211-freq-limit = <5470000 5875000>;
 };
@@ -212,7 +248,10 @@
 		compatible = "qcom,ath10k";
 		reg = <0x00010000 0 0 0 0>;
 		ieee80211-freq-limit = <5170000 5350000>;
+		nvmem-cell-names = "pre-calibration";
+		nvmem-cells = <&precal_factory_9000>;
 		qcom,ath10k-calibration-variant = "ASUS-MAP-AC2200";
+		status = "okay";
 	};
 };
 
@@ -340,6 +379,8 @@
 
 &gmac {
 	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_1006 1>;
 };
 
 &switch {
@@ -348,6 +389,8 @@
 
 &swport4 {
 	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_1006 3>;
 
 	label = "wan";
 };


### PR DESCRIPTION
Inspired by the PR #14729 I tried to get this working on a Lyra and stumbled upon the TODO marker which was not needed. In addition to the changes needed to use the MAC adresses stored in the UBI partition I also introduced the label-mac-device as it is bound to the first wifi chip instead of one of the ethernet ports. This simplifies the usage for gluon later on.