### PR TITLE
realtek: add support for V3 variant of SG2008P

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/realtek
+++ b/package/boot/uboot-tools/uboot-envtools/files/realtek
@@ -37,6 +37,7 @@ iodata,bsh-g24mb)
 	ubootenv_add_sys_mtd "u-boot-env2" "0x0" "0x3800" "0x10000"
 	;;
 tplink,sg2008p-v1|\
+tplink,sg2008p-v3|\
 tplink,sg2210p-v3|\
 tplink,sg2452p-v4)
 	ubootenv_add_mtd "u-boot-env" "0x0" "0x20000" "0x10000"

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -64,6 +64,7 @@ realtek_setup_macs()
 	netgear,gs308t-v1|\
 	netgear,gs310tp-v1|\
 	tplink,sg2008p-v1|\
+	tplink,sg2008p-v3|\
 	tplink,sg2210p-v3|\
 	tplink,sg2452p-v4|\
 	tplink,t1600g-28ts-v3|\

--- a/target/linux/realtek/base-files/etc/init.d/i2c_poe
+++ b/target/linux/realtek/base-files/etc/init.d/i2c_poe
@@ -1,0 +1,26 @@
+#!/bin/sh /etc/rc.common
+
+START=10
+
+mp3924_auto_mode() {
+	local i2c_addr=0x21
+
+	# Set power limit to 60 Watts.
+	i2cset -y         0 ${i2c_addr?} 0x54 0x00 # PMAX[0]   = 0
+	i2cset -y         0 ${i2c_addr?} 0x55 0x4b # PMAX[1-8] = 0x4b
+	i2cset -y -m 0x04 0 ${i2c_addr?} 0x0f 0x04 # PMAXEN    = 1
+
+	# Set all ports to AUTO mode.
+	i2cset -y         0 ${i2c_addr?} 0x03 0xff # MODE    = AUTO
+	i2cset -y -m 0x0f 0 ${i2c_addr?} 0x0c 0x0f # 2EVNTEN = 1
+	i2cset -y -m 0x0f 0 ${i2c_addr?} 0x07 0x0f # DISEN   = 1
+	i2cset -y         0 ${i2c_addr?} 0x06 0xff # DETEN   = 1, CLSEN = 1
+}
+
+boot() {
+	case $(board_name) in
+	tplink,sg2008p-v3)
+		mp3924_auto_mode
+		;;
+	esac
+}

--- a/target/linux/realtek/base-files/lib/upgrade/platform.sh
+++ b/target/linux/realtek/base-files/lib/upgrade/platform.sh
@@ -36,6 +36,7 @@ platform_do_upgrade() {
 		platform_do_upgrade_dualboot_plasmacloud "$1"
 		;;
 	tplink,sg2008p-v1|\
+	tplink,sg2008p-v3|\
 	tplink,sg2210p-v3)
 		tplink_sg2xxx_fix_mtdparts
 		default_do_upgrade "$1"

--- a/target/linux/realtek/dts/rtl8380_tplink_sg2008p-v3.dts
+++ b/target/linux/realtek/dts/rtl8380_tplink_sg2008p-v3.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl8380_tplink_sg2xxx.dtsi"
+
+/ {
+	compatible = "tplink,sg2008p-v3", "realtek,rtl838x-soc";
+	model = "TP-Link SG2008P v3";
+};
+
+&gpio0 {
+	poe-enable {
+		gpio-hog;
+		gpios = <5 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "poe-enable";
+	};
+};
+
+&tps23861_20 {
+	status = "disabled";
+};
+
+&tps23861_28 {
+	status = "disabled";
+};
+
+&port24 {
+	status = "disabled";
+};
+
+&port26 {
+	status = "disabled";
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -353,6 +353,17 @@ define Device/tplink_sg2008p-v1
 endef
 TARGET_DEVICES += tplink_sg2008p-v1
 
+define Device/tplink_sg2008p-v3
+  SOC := rtl8380
+  KERNEL_SIZE := 6m
+  IMAGE_SIZE := 26m
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := SG2008P
+  DEVICE_VARIANT := v3
+  DEVICE_PACKAGES := i2c-tools
+endef
+TARGET_DEVICES += tplink_sg2008p-v3
+
 define Device/tplink_sg2210p-v3
   SOC := rtl8380
   KERNEL_SIZE := 6m


### PR DESCRIPTION
Add basic support for the TP-Link SG2008P V3 variant. The switch appears to be identical to the V1 variant, except that it uses the MP3924 instead of the TPS23861 PoE chip.

Specifications:
---------------
 * SoC:       Realtek RTL8380M
 * Flash:     32 MiB SPI flash (Vendor varies)
 * RAM:       256 MiB (Vendor varies)
 * Ethernet:  8x 10/100/1000 Mbps with PoE on 4 ports
 * Buttons:   1x "Reset" button on front panel
 * Power:     53.5V DC barrel jack
 * UART:      1x serial header, unpopulated
 * PoE:       1x MPS MP3924 I2C PoE controller

Works:
------
  - (8) RJ-45 ethernet ports
  - Switch functions
  - System LED
  - Basic PoE support (no driver, but a startup script puts the chip into AUTO mode)

Not yet enabled:
----------------
  - PoE, Link/Act, PoE max and System LEDs

Install via web interface:
-------------------------

Not supported at this time.

Install via serial console/tftp:
--------------------------------

The footprints R27 (0201) and R28 (0402) are not populated. To enable serial console, 50 ohm resistors should be soldered -- any value from 0 ohm to 50 ohm will work. R27 can be replaced by a solder bridge.

The u-boot firmware drops to a TP-Link specific "BOOTUTIL" shell at 38400 baud. There is no known way to exit out of this shell, and no way to do anything useful.

Ideally, one would trick the bootloader into flashing the sysupgrade image first. However, if the image exceeds 6MiB in size, it will not work. The sysupgrade image can also be flashed. To install OpenWRT:

Prepare a tftp server with:
 1. server address: 192.168.0.146
 2. the image as: "uImage.img"

Power on device, and stop boot by pressing any key. Once the shell is active:
 1. Ground out the CLK (pin 16) of the ROM (U7)
 2. Select option "3. Start"
 3. Bootloader notes that "The kernel has been damaged!"
 4. Release CLK as sson as bootloader thinks image is corrupted.
 5. Bootloader enters automatic recovery -- details printed on console
 6. Watch as the bootloader flashes and boots OpenWRT.

Blind install via tftp:
-----------------------

This method works when it's not feasible to install a serial header.

Prepare a tftp server with:
 1. server address: 192.168.0.146
 2. the image as: "uImage.img"
 3. Watch network traffic (tcpdump or wireshark works)
 4. Power on the device.
 5. Wait 1-2 seconds then ground out the CLK (pin 16) of the ROM (U7)
 6. When 192.168.0.30 makes tftp requests, release pin 16
 7. Wait 2-3 minutes for device to auto-flash and boot OpenWRT
