### PR TITLE
Add support for wpa_supplicant bgscan feature

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -165,6 +165,25 @@
 		"basic_rate": {
 			"type": "array"
 		},
+		"bgscan_simple": {
+			"description": "Background Scan for stronger APs",
+			"type": "boolean"
+		},
+		"bgscan_simple_short_itv": {
+			"description": "Scan interval when RSSI with current AP is below treshold",
+			"type": "number",
+			"default": 30
+		},
+		"bgscan_simple_long_itv": {
+			"description": "Scan interval when RSSI with current AP is over treshold",
+			"type": "number",
+			"default": 3600
+		},
+		"bgscan_simple_rssi_thd": {
+			"description": "RSSI treshold to consider for short or long scanning intervals",
+			"type": "number",
+			"default": -70
+		},
 		"bss_load_update_period": {
 			"description": "BSS Load update period (in BUs)",
 			"type": "number",

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -73,6 +73,7 @@ function setup_sta(data, config) {
 	set_default(config, 'multi_ap', 0);
 	set_default(config, 'multi_profile', 1);
 	set_default(config, 'default_disabled', 0);
+	set_default(config, 'bgscan_simple', 0);
 
 	config.scan_ssid = 1;
 
@@ -170,6 +171,10 @@ function setup_sta(data, config) {
 
 	config.key_mgmt ??= 'NONE';
 
+	if (config.bgscan_simple) {
+		config.bgscan = `"simple:${config.bgscan_simple_short_itv}:${bgscan_simple_rssi_thd}:${bgscan_simple_long_itv}"`;
+	}
+
 	config.basic_rate = ratelist(config.basic_rate);
 	config.mcast_rate = ratestr(config.mcast_rate);
 
@@ -183,7 +188,8 @@ function setup_sta(data, config) {
 		'bssid_blacklist', 'bssid_whitelist', 'erp', 'ca_cert', 'identity',
 		'anonymous_identity', 'client_cert', 'private_key', 'private_key_passwd',
 		'subject_match', 'altsubject_match', 'domain_match', 'domain_suffix_match',
-		'ca_cert2', 'client_cert2', 'private_key2', 'private_key2_passwd', 'password'
+		'ca_cert2', 'client_cert2', 'private_key2', 'private_key2_passwd', 'password',
+		'bgscan'
 	]);
 }
 

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -402,6 +402,12 @@ hostapd_common_add_bss_config() {
 
 	config_add_boolean apup
 	config_add_string apup_peer_ifname_prefix
+
+	config_add_boolean bgscan_simple
+	config_add_int \
+		bgscan_simple_short_itv \
+		bgscan_simple_long_itv \
+		bgscan_simple_rssi_thd
 }
 
 hostapd_set_vlan_file() {
@@ -1324,7 +1330,8 @@ wpa_supplicant_add_network() {
 		mcast_rate \
 		ieee80211w ieee80211r fils ocv \
 		multi_ap \
-		default_disabled
+		default_disabled \
+		bgscan_simple
 
 	json_get_values basic_rate_list basic_rate
 
@@ -1343,6 +1350,7 @@ wpa_supplicant_add_network() {
 	set_default multi_ap 0
 	set_default sae_pwe 2
 	set_default default_disabled 0
+	set_default bgscan_simple 0
 
 	local key_mgmt='NONE'
 	local network_data=
@@ -1618,6 +1626,21 @@ wpa_supplicant_add_network() {
 		local mc_rate=
 		wpa_supplicant_add_rate mc_rate "$mcast_rate"
 		append network_data "mcast_rate=$mc_rate" "$N$T"
+	}
+
+	[ "$bgscan_simple" = 1 ] && {
+		local bgscan_simple_short_itv \
+			bgscan_simple_long_itv \
+			bgscan_simple_rssi_thd
+		json_get_vars \
+			bgscan_simple_short_itv \
+			bgscan_simple_long_itv \
+			bgscan_simple_rssi_thd
+		set_default bgscan_simple_short_itv   30
+		set_default bgscan_simple_long_itv  3600
+		set_default bgscan_simple_rssi_thd   -70
+
+		append network_data "bgscan=\"simple:$bgscan_simple_short_itv:$bgscan_simple_rssi_thd:$bgscan_simple_long_itv\"" "$N$T"
 	}
 
 	if [ "$key_mgmt" = "WPS" ]; then

--- a/package/network/services/hostapd/files/wpa_supplicant-basic.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-basic.config
@@ -527,9 +527,9 @@ CONFIG_GETRANDOM=y
 #
 # Enabling directly a module will enable autoscan support.
 # For exponential module:
-#CONFIG_AUTOSCAN_EXPONENTIAL=y
+CONFIG_AUTOSCAN_EXPONENTIAL=y
 # For periodic module:
-#CONFIG_AUTOSCAN_PERIODIC=y
+CONFIG_AUTOSCAN_PERIODIC=y
 
 # Password (and passphrase, etc.) backend for external storage
 # These optional mechanisms can be used to add support for storing passwords
@@ -600,7 +600,7 @@ CONFIG_GETRANDOM=y
 # operations for roaming within an ESS (same SSID). See the bgscan parameter in
 # the wpa_supplicant.conf file for more details.
 # Periodic background scans based on signal strength
-#CONFIG_BGSCAN_SIMPLE=y
+CONFIG_BGSCAN_SIMPLE=y
 # Learn channels used by the network and try to avoid bgscans on other
 # channels (experimental)
 #CONFIG_BGSCAN_LEARN=y

--- a/package/network/services/hostapd/files/wpa_supplicant-full.config
+++ b/package/network/services/hostapd/files/wpa_supplicant-full.config
@@ -527,9 +527,9 @@ CONFIG_HS20=y
 #
 # Enabling directly a module will enable autoscan support.
 # For exponential module:
-#CONFIG_AUTOSCAN_EXPONENTIAL=y
+CONFIG_AUTOSCAN_EXPONENTIAL=y
 # For periodic module:
-#CONFIG_AUTOSCAN_PERIODIC=y
+CONFIG_AUTOSCAN_PERIODIC=y
 
 # Password (and passphrase, etc.) backend for external storage
 # These optional mechanisms can be used to add support for storing passwords
@@ -600,7 +600,7 @@ CONFIG_IBSS_RSN=y
 # operations for roaming within an ESS (same SSID). See the bgscan parameter in
 # the wpa_supplicant.conf file for more details.
 # Periodic background scans based on signal strength
-#CONFIG_BGSCAN_SIMPLE=y
+CONFIG_BGSCAN_SIMPLE=y
 # Learn channels used by the network and try to avoid bgscans on other
 # channels (experimental)
 #CONFIG_BGSCAN_LEARN=y


### PR DESCRIPTION
Allow a wifi client (station mode) in OpenWRT to use the bgscan feature to connect to stronger access points when they become available.

Background scans are a feature to allow scanning for other APs while being connected.  A moving client will re-connect to another AP when the scan results in a better candidate.  Currently only the simple strategy is enabled and and configurable, it works based on a signal strength treshold and scanning intervals below and above this treshold.

https://git.w1.fi/cgit/hostap/tree/wpa_supplicant/wpa_supplicant.conf?id=1a94c04bd30abbdd8baa315c239294b5b8111e28#n1054