### PR TITLE
[24.10] mold: dont allow on MacOS

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -176,6 +176,7 @@ menu "Global build settings"
 	config MOLD
 		depends on (aarch64 || arm || i386 || i686 || m68k || powerpc || powerpc64 || sh4 || x86_64)
 		depends on !GCC_USE_VERSION_11
+		depends on !HOST_OS_MACOS
 		def_bool $(shell, ./config/check-hostcxx.sh 10 2 12)
 
 	config USE_MOLD


### PR DESCRIPTION
Mold does not really work on MacOS, when attempting to use it for example for ubus:
mold: get_self_path is not supportedcollect2: error: ld returned 1 exit status

Which was introduced by [1] so it seems that MacOS is not supported, so lets make it non selectable when MacOS is the host.

[1] https://github.com/rui314/mold/commit/f9a37e9dd43681758bbc5647ba9e596ec4ea9f33

Link: https://github.com/openwrt/openwrt/pull/18575

(cherry picked from commit 3c65dc367827bc06bd45f7eb375c59192deb0a75)