### PR TITLE
realtek: rtl930x: Add support for Plasma Cloud MCX3 Media Converter

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -68,6 +68,7 @@ realtek_setup_macs()
 		lan_mac_end=$(macaddr_add $lan_mac $((mac_count2-mac_count1)))
 		;;
 	plasmacloud,esx28|\
+	plasmacloud,mcx3|\
 	plasmacloud,psx8|\
 	plasmacloud,psx10|\
 	plasmacloud,psx28)

--- a/target/linux/realtek/base-files/lib/upgrade/platform.sh
+++ b/target/linux/realtek/base-files/lib/upgrade/platform.sh
@@ -28,6 +28,7 @@ platform_do_upgrade() {
 
 	case "$board" in
 	plasmacloud,esx28|\
+	plasmacloud,mcx3|\
 	plasmacloud,psx8|\
 	plasmacloud,psx10|\
 	plasmacloud,psx28)

--- a/target/linux/realtek/base-files/lib/upgrade/upgrade_dualboot_plasmacloud.sh
+++ b/target/linux/realtek/base-files/lib/upgrade/upgrade_dualboot_plasmacloud.sh
@@ -4,6 +4,7 @@ set_boot_part() {
 	local board=$(board_name)
 
 	case "$board" in
+	plasmacloud,mcx3|\
 	plasmacloud,psx8|\
 	plasmacloud,psx10)
 		if [ "$part_num" = "1" ]; then
@@ -70,6 +71,7 @@ platform_do_upgrade_dualboot_plasmacloud() {
 	# identify "inactive" slot id based on the expected partition id
 	# of the primary ("firmware1") slot
 	case "$(board_name)" in
+	plasmacloud,mcx3|\
 	plasmacloud,psx8|\
 	plasmacloud,psx10)
 		primary_firmware_mtd=3

--- a/target/linux/realtek/dts/rtl9302_plasmacloud_mcx3.dts
+++ b/target/linux/realtek/dts/rtl9302_plasmacloud_mcx3.dts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "plasmacloud,mcx3", "realtek,rtl9302-soc";
+	model = "Plasma Cloud MCX3";
+
+	chosen {
+		/* get active mtdparts from u-boot */
+		/delete-property/ bootargs;
+	};
+
+	aliases {
+		led-boot = &led_power;
+		led-running = &led_power;
+		led-failsafe = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet0;
+	};
+
+	memory@0 {
+		reg = <0x0 0x10000000>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		mode {
+			label = "reset";
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	i2c0: i2c-gpio0 {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sda-gpios = <&gpio0 9 GPIO_ACTIVE_HIGH>;
+		scl-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+
+		i2c-gpio,delay-us = <5>;	/* ~100 kHz */
+	};
+
+
+	sfp0: sfp-lan3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>;
+
+		led_power: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	led_set@0 {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G |
+			     RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G |
+			     RTL93XX_LED_SET_100M | RTL93XX_LED_SET_10M |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x10000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_ubootenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0xf0000 0x10000>;
+			};
+
+			partition@100000 {
+				label = "firmware1";
+				reg = <0x100000 0xf80000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x93000000>;
+			};
+
+			partition@1080000 {
+				label = "firmware2";
+				reg = <0x1080000 0xf80000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <0x93000000>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_bus0 {
+	/* External RTL8224 PHY */
+	phy0: ethernet-phy@0 {
+		reg = <0>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <0 0>;
+	};
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		rtl9300,smi-address = <0 1>;
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_SDS(0, 2, 2, 10g-qxgmii)
+		SWITCH_PORT_SDS(1, 1, 2, 10g-qxgmii)
+
+		port@26 {
+			reg = <26>;
+			label = "lan3";
+			pcs-handle = <&serdes8>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp0>;
+			led-set = <0>;
+			managed = "in-band-status";
+
+			nvmem-cells = <&macaddr_ubootenv_ethaddr 3>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		/* CPU-port */
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&port0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 2>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port1 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 1>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -30,6 +30,12 @@ define Device/plasmacloud-common
   IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
 endef
 
+define Device/plasmacloud_mcx3
+  $(Device/plasmacloud-common)
+  DEVICE_MODEL := MCX3
+endef
+TARGET_DEVICES += plasmacloud_mcx3
+
 define Device/plasmacloud_psx8
   $(Device/plasmacloud-common)
   DEVICE_MODEL := PSX8


### PR DESCRIPTION
The Plasma Cloud MCX3 Media Converter is a 3 port multi-GBit switch with 2x 10/100/1000/2500BaseT Ethernet ports and 1x SFP+ module slot.

Hardware:

- RTL9302C SoC
- Macronix MX25L25645G (32MB flash)
- Winbond W632GU6rB-11 (256MB DDR3 SDRAM)
- RTL8224 4x 10m/100m/1/2.5 Gigabit PHY
- IC+ IP802AR POE+ PSE controller

The media converter is powered by 54 Volts 1.2A barrel connector. The internal TTL serial connector can be used to access the terminal. Pins from 1:

```
TX RX (unused) GND
```

Serial connection is via 115200 baud, 8N1.

A reset button is accessible through a hole next to the SFP+ module slot.

Installation
------------

* The device can be flashed by using sysupgrade command. Either from the original vendor firmware or using an initramfs (see "Debug")
* Connect serial as per the layout above. Connection parameters: 115200 8N1
* The image must be copied using scp to /tmp of the device

      scp openwrt-realtek-rtl930x-plasmacloud_mcx3-squashfs-sysupgrade.bin root@[IP address of the device]:/tmp/

* start sysupgrade without saving the original vendor configuration

      sysupgrade -n /tmp/openwrt-realtek-rtl930x-plasmacloud_mcx3-squashfs-sysupgrade.bin

Installation via u-boot
-----------------------

If you have an TFTP server connected to the switch, it is possible to directly install the device using the factory image from u-boot

    # setup networking and IP of TFP server
    rtk network on
    setenv ipaddr 10.100.100.99
    setenv serverip 10.100.100.20

    # get factory image
    tftp 0x84000000 factory.bin

    # erase firmware partitions
    sf probe 0
    sf erase 0x100000 0x01f00000

    # write firmware to both partitions
    sf write ${fileaddr} 0x100000 ${filesize}
    sf write ${fileaddr} 0x1080000 ${filesize}

    # adjust the boot commands
    setenv bootargs "mtdparts=spi0.0:896k(u-boot),64k(u-boot-env),64k(u-boot-env2),15872k(inactive),15872k(firmware2)"
    setenv bootcmd "rtk init; bootm 0xb5080000"

    # restart
    reset

Debug
-----

* Connect serial as per the layout above. Connection parameters: 115200 8N1.
* A tftp server is required, tftpd-hpa works well.
* Power the device, at U-Boot start rapidly hit Esc key to stop autoboot
* Enable network:

      rtk network on

* Change ip address of device:

      setenv ipaddr 192.168.1.6

* Download initramfs from TFTP server:

      tftpboot 0x84000000 192.168.1.111:openwrt-realtek-rtl930x-plasmacloud_mcx3-initramfs-kernel.bin

* Boot loaded file:

      bootm 0x84000000