### PR TITLE
ath79: dts: add address- and size-cells to flash nodes explicitly

### DIFF
--- a/target/linux/ath79/dts/ar1022_iodata_wn-ag300dgr.dts
+++ b/target/linux/ath79/dts/ar1022_iodata_wn-ag300dgr.dts
@@ -105,6 +105,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar1022_sitecom_wlr-7100.dts
+++ b/target/linux/ath79/dts/ar1022_sitecom_wlr-7100.dts
@@ -109,6 +109,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7100_mikrotik_routerboard-4xx.dtsi
+++ b/target/linux/ath79/dts/ar7100_mikrotik_routerboard-4xx.dtsi
@@ -65,7 +65,8 @@
 
 	flash@0 {
 		compatible = "pm25lv512", "jedec,spi-nor";
-
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7161_adtran_bsap1880.dtsi
+++ b/target/linux/ath79/dts/ar7161_adtran_bsap1880.dtsi
@@ -82,6 +82,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-105.dts
@@ -140,6 +140,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7161_aruba_ap-175.dts
+++ b/target/linux/ath79/dts/ar7161_aruba_ap-175.dts
@@ -163,6 +163,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
+++ b/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
@@ -231,6 +231,8 @@
 
 	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		m25p,fast-read;
@@ -238,6 +240,8 @@
 
 	flash1: flash@1 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <1>;
 		spi-max-frequency = <50000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
+++ b/target/linux/ath79/dts/ar7161_dlink_dir-825-b1.dts
@@ -165,6 +165,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7161_jjplus_ja76pf2.dts
+++ b/target/linux/ath79/dts/ar7161_jjplus_ja76pf2.dts
@@ -116,6 +116,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7161_meraki_mr16.dts
+++ b/target/linux/ath79/dts/ar7161_meraki_mr16.dts
@@ -119,6 +119,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -77,6 +77,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/ar7161_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr.dtsi
@@ -173,6 +173,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
+++ b/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
@@ -176,6 +176,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/ar7161_siemens_ws-ap3610.dts
+++ b/target/linux/ath79/dts/ar7161_siemens_ws-ap3610.dts
@@ -105,6 +105,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/ar7161_trendnet_tew-673gru.dts
+++ b/target/linux/ath79/dts/ar7161_trendnet_tew-673gru.dts
@@ -115,6 +115,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7161_ubnt_routerstation.dtsi
+++ b/target/linux/ath79/dts/ar7161_ubnt_routerstation.dtsi
@@ -52,6 +52,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7240_buffalo_whr-g301n.dts
+++ b/target/linux/ath79/dts/ar7240_buffalo_whr-g301n.dts
@@ -103,6 +103,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7240_dlink_dir-615-e4.dts
+++ b/target/linux/ath79/dts/ar7240_dlink_dir-615-e4.dts
@@ -108,6 +108,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <33000000>;
 

--- a/target/linux/ath79/dts/ar7240_netgear_wnr1000-v2.dts
+++ b/target/linux/ath79/dts/ar7240_netgear_wnr1000-v2.dts
@@ -144,6 +144,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
+++ b/target/linux/ath79/dts/ar7240_netgear_wnr612-v2.dtsi
@@ -74,6 +74,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
+++ b/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
@@ -89,6 +89,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 		linux,mtd-name = "ar7240-nor0";

--- a/target/linux/ath79/dts/ar7240_ruckus_zf7025.dts
+++ b/target/linux/ath79/dts/ar7240_ruckus_zf7025.dts
@@ -121,6 +121,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/ar7240_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7240_tplink.dtsi
@@ -67,6 +67,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2000-v3.dts
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2000-v3.dts
@@ -147,6 +147,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7241_netgear_wnr2200.dtsi
+++ b/target/linux/ath79/dts/ar7241_netgear_wnr2200.dtsi
@@ -148,6 +148,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7241_tplink.dtsi
+++ b/target/linux/ath79/dts/ar7241_tplink.dtsi
@@ -52,6 +52,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
+++ b/target/linux/ath79/dts/ar7241_tplink_tl-wr842n-v1.dts
@@ -92,6 +92,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
@@ -33,6 +33,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi-ap.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi-ap.dtsi
@@ -30,6 +30,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
+++ b/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
@@ -102,6 +102,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-bhr.dtsi
@@ -104,12 +104,16 @@
 
 	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 	};
 
 	flash1: flash@1 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <1>;
 		spi-max-frequency = <25000000>;
 	};

--- a/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
+++ b/target/linux/ath79/dts/ar7242_buffalo_wzr-hp-g302h-a1a0.dts
@@ -174,12 +174,16 @@
 
 	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 	};
 
 	flash1: flash@1 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <1>;
 		spi-max-frequency = <25000000>;
 	};

--- a/target/linux/ath79/dts/ar7242_meraki_mr12.dts
+++ b/target/linux/ath79/dts/ar7242_meraki_mr12.dts
@@ -119,6 +119,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
+++ b/target/linux/ath79/dts/ar7242_tplink_tl-wr2543-v1.dts
@@ -97,6 +97,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/ar7242_ubnt_sw.dtsi
+++ b/target/linux/ath79/dts/ar7242_ubnt_sw.dtsi
@@ -68,6 +68,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar724x_senao_loader-4k.dtsi
+++ b/target/linux/ath79/dts/ar724x_senao_loader-4k.dtsi
@@ -28,6 +28,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <20000000>;
 

--- a/target/linux/ath79/dts/ar724x_senao_loader-64k.dtsi
+++ b/target/linux/ath79/dts/ar724x_senao_loader-64k.dtsi
@@ -28,6 +28,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <20000000>;
 

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wa901nd-v2.dts
@@ -63,6 +63,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr1043nd-v1.dts
@@ -89,6 +89,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v2.dts
+++ b/target/linux/ath79/dts/ar9132_tplink_tl-wr941-v2.dts
@@ -112,6 +112,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9330_dlink_dir-505.dts
+++ b/target/linux/ath79/dts/ar9330_dlink_dir-505.dts
@@ -93,6 +93,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <50000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
+++ b/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
@@ -89,6 +89,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <50000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9330_openmesh_om2p.dtsi
+++ b/target/linux/ath79/dts/ar9330_openmesh_om2p.dtsi
@@ -86,6 +86,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9330_pqi_air-pen.dts
+++ b/target/linux/ath79/dts/ar9330_pqi_air-pen.dts
@@ -66,6 +66,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <50000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9330_ziking_cpe46b.dts
+++ b/target/linux/ath79/dts/ar9330_ziking_cpe46b.dts
@@ -51,6 +51,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <50000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9331_8dev_carambola2.dts
+++ b/target/linux/ath79/dts/ar9331_8dev_carambola2.dts
@@ -64,6 +64,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <50000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9331_alfa-network_ap121f.dtsi
+++ b/target/linux/ath79/dts/ar9331_alfa-network_ap121f.dtsi
@@ -79,6 +79,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/ar9331_arduino_yun.dts
+++ b/target/linux/ath79/dts/ar9331_arduino_yun.dts
@@ -141,6 +141,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/ar9331_embeddedwireless_dorin.dts
+++ b/target/linux/ath79/dts/ar9331_embeddedwireless_dorin.dts
@@ -58,6 +58,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <50000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9331_etactica_eg200.dts
+++ b/target/linux/ath79/dts/ar9331_etactica_eg200.dts
@@ -85,6 +85,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <50000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9331_glinet_6408.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_6408.dts
@@ -16,6 +16,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9331_glinet_6416.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_6416.dts
@@ -16,6 +16,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9331_glinet_gl-mifi.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_gl-mifi.dts
@@ -88,6 +88,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <33000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9331_glinet_gl-usb150.dts
+++ b/target/linux/ath79/dts/ar9331_glinet_gl-usb150.dts
@@ -82,6 +82,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <33000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9331_hak5_lan-turtle.dtsi
+++ b/target/linux/ath79/dts/ar9331_hak5_lan-turtle.dtsi
@@ -53,6 +53,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/ar9331_hak5_wifi-pineapple-nano.dts
+++ b/target/linux/ath79/dts/ar9331_hak5_wifi-pineapple-nano.dts
@@ -78,6 +78,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/ar9331_hiwifi_hc6361.dts
+++ b/target/linux/ath79/dts/ar9331_hiwifi_hc6361.dts
@@ -64,6 +64,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9331_onion_omega.dts
+++ b/target/linux/ath79/dts/ar9331_onion_omega.dts
@@ -87,6 +87,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <25000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9331_pisen_ts-d084.dts
+++ b/target/linux/ath79/dts/ar9331_pisen_ts-d084.dts
@@ -43,6 +43,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
+++ b/target/linux/ath79/dts/ar9331_pisen_wmm003n.dts
@@ -51,6 +51,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
+++ b/target/linux/ath79/dts/ar9331_teltonika_rut230-v1.dts
@@ -123,6 +123,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <30000000>;
 

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3020-v1.dts
@@ -105,6 +105,8 @@
 	/* Spansion S25FL032PIF SPI flash */
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <50000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-mr3040-v2.dts
@@ -99,6 +99,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <50000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr703n_tl-mr10u.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr703n_tl-mr10u.dtsi
@@ -48,6 +48,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-8m.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr710n-8m.dtsi
@@ -13,6 +13,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
+++ b/target/linux/ath79/dts/ar9331_tplink_tl-wr741nd-v4.dtsi
@@ -92,6 +92,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9341_openmesh_om2p-hs.dtsi
+++ b/target/linux/ath79/dts/ar9341_openmesh_om2p-hs.dtsi
@@ -96,6 +96,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
+++ b/target/linux/ath79/dts/ar9341_pcs_cr3000.dts
@@ -92,6 +92,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9341_pisen_wmb001n.dts
+++ b/target/linux/ath79/dts/ar9341_pisen_wmb001n.dts
@@ -135,6 +135,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-mr3420-v2.dts
@@ -55,6 +55,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wa.dtsi
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wa.dtsi
@@ -20,6 +20,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr841-v8.dts
@@ -35,6 +35,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr842n-v2.dts
@@ -56,6 +56,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9341_tplink_tl-wr941nd-v5.dts
+++ b/target/linux/ath79/dts/ar9341_tplink_tl-wr941nd-v5.dts
@@ -45,6 +45,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
+++ b/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
@@ -54,6 +54,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9342_mikrotik_routerboard-911g.dtsi
+++ b/target/linux/ath79/dts/ar9342_mikrotik_routerboard-911g.dtsi
@@ -155,6 +155,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/ar9342_ubnt_aircube-ac.dts
+++ b/target/linux/ath79/dts/ar9342_ubnt_aircube-ac.dts
@@ -26,6 +26,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9342_ubnt_wa.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_wa.dtsi
@@ -41,6 +41,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -30,6 +30,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9342_zyxel_nwa11xx.dtsi
+++ b/target/linux/ath79/dts/ar9342_zyxel_nwa11xx.dtsi
@@ -46,6 +46,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/ar9344_aerohive_hiveap-121.dts
+++ b/target/linux/ath79/dts/ar9344_aerohive_hiveap-121.dts
@@ -119,6 +119,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
+++ b/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
@@ -112,6 +112,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/ar9344_atheros_db120.dts
+++ b/target/linux/ath79/dts/ar9344_atheros_db120.dts
@@ -81,6 +81,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_comfast_cf-e120a-v3.dts
+++ b/target/linux/ath79/dts/ar9344_comfast_cf-e120a-v3.dts
@@ -86,6 +86,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_compex_wpj344-16m.dts
+++ b/target/linux/ath79/dts/ar9344_compex_wpj344-16m.dts
@@ -68,6 +68,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_devolo_dlan_wifi.dtsi
+++ b/target/linux/ath79/dts/ar9344_devolo_dlan_wifi.dtsi
@@ -76,6 +76,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
+++ b/target/linux/ath79/dts/ar9344_dlink_dir-8x5.dtsi
@@ -72,6 +72,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_embeddedwireless_balin.dts
+++ b/target/linux/ath79/dts/ar9344_embeddedwireless_balin.dts
@@ -52,6 +52,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/ar9344_enterasys_ws-ap3705i.dts
+++ b/target/linux/ath79/dts/ar9344_enterasys_ws-ap3705i.dts
@@ -112,6 +112,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 
@@ -183,6 +185,8 @@
 
 	flash@1 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <1>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_huawei_ap6010dn.dts
+++ b/target/linux/ath79/dts/ar9344_huawei_ap6010dn.dts
@@ -84,6 +84,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_longdata_aps256.dts
+++ b/target/linux/ath79/dts/ar9344_longdata_aps256.dts
@@ -83,6 +83,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <33000000>;
 

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-16m-nor.dtsi
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-16m-nor.dtsi
@@ -5,6 +5,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-2011uias-2hnd.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-2011uias-2hnd.dts
@@ -133,6 +133,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951x-2hnd.dtsi
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-951x-2hnd.dtsi
@@ -44,6 +44,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_mikrotik_routerboard-sxt-5nd-r2.dts
+++ b/target/linux/ath79/dts/ar9344_mikrotik_routerboard-sxt-5nd-r2.dts
@@ -43,6 +43,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/ar9344_moxa_awk-1137c.dts
+++ b/target/linux/ath79/dts/ar9344_moxa_awk-1137c.dts
@@ -86,6 +86,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/ar9344_nec_aterm.dtsi
+++ b/target/linux/ath79/dts/ar9344_nec_aterm.dtsi
@@ -144,6 +144,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
+++ b/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
@@ -73,6 +73,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
+++ b/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
@@ -34,6 +34,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
@@ -116,6 +116,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/ar9344_openmesh_om5p.dts
+++ b/target/linux/ath79/dts/ar9344_openmesh_om5p.dts
@@ -99,6 +99,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/ar9344_pcs_cap324.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cap324.dts
@@ -84,6 +84,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
+++ b/target/linux/ath79/dts/ar9344_pcs_cr5000.dts
@@ -73,6 +73,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_qihoo_c301.dts
+++ b/target/linux/ath79/dts/ar9344_qihoo_c301.dts
@@ -108,6 +108,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 
@@ -181,6 +183,8 @@
 
 	flash@1 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <1>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_qxwlan_e750x.dtsi
+++ b/target/linux/ath79/dts/ar9344_qxwlan_e750x.dtsi
@@ -63,6 +63,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_samsung_wam250.dts
+++ b/target/linux/ath79/dts/ar9344_samsung_wam250.dts
@@ -104,6 +104,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/ar9344_teltonika_rut9xx.dtsi
+++ b/target/linux/ath79/dts/ar9344_teltonika_rut9xx.dtsi
@@ -61,6 +61,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_tplink_cpe.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_cpe.dtsi
@@ -31,6 +31,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wdrxxxx.dtsi
@@ -71,6 +71,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <33000000>;
 

--- a/target/linux/ath79/dts/ar9344_tplink_tl-wr841hp-v2.dts
+++ b/target/linux/ath79/dts/ar9344_tplink_tl-wr841hp-v2.dts
@@ -87,6 +87,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_ubnt_unifi-ap-pro.dts
+++ b/target/linux/ath79/dts/ar9344_ubnt_unifi-ap-pro.dts
@@ -51,6 +51,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/ar9344_wd_mynet-nxxx.dtsi
+++ b/target/linux/ath79/dts/ar9344_wd_mynet-nxxx.dtsi
@@ -20,6 +20,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_wd_mynet-wifi-rangeextender.dts
+++ b/target/linux/ath79/dts/ar9344_wd_mynet-wifi-rangeextender.dts
@@ -89,6 +89,8 @@
 
 	flash@0 {
 		compatible = /* "s25fl064k", */ "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
+++ b/target/linux/ath79/dts/ar9344_winchannel_wb2000.dts
@@ -73,6 +73,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
+++ b/target/linux/ath79/dts/ar9344_zbtlink_zbt-wd323.dts
@@ -107,6 +107,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		spi-max-frequency = <22000000>;
 		reg = <0>;
 

--- a/target/linux/ath79/dts/ar934x_ruckus_zf73xx.dtsi
+++ b/target/linux/ath79/dts/ar934x_ruckus_zf73xx.dtsi
@@ -84,6 +84,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/ar934x_senao_loader.dtsi
+++ b/target/linux/ath79/dts/ar934x_senao_loader.dtsi
@@ -32,6 +32,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/arxxxx_fortinet_loader.dtsi
+++ b/target/linux/ath79/dts/arxxxx_fortinet_loader.dtsi
@@ -28,6 +28,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca9531_8dev_carambola3.dts
+++ b/target/linux/ath79/dts/qca9531_8dev_carambola3.dts
@@ -47,6 +47,8 @@
 	/* Winbond W25Q256 SPI flash */
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <45000000>;
 

--- a/target/linux/ath79/dts/qca9531_8dev_lima.dts
+++ b/target/linux/ath79/dts/qca9531_8dev_lima.dts
@@ -38,6 +38,8 @@
 	/* Winbond W25Q256 SPI flash */
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <45000000>;
 

--- a/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
+++ b/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
@@ -86,6 +86,8 @@
 	/* Winbond W25Q256 SPI flash */
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
+++ b/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
@@ -61,6 +61,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/qca9531_asus_rp-ac51.dts
+++ b/target/linux/ath79/dts/qca9531_asus_rp-ac51.dts
@@ -78,6 +78,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e130n-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e130n-v2.dts
@@ -79,6 +79,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e313ac.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e313ac.dts
@@ -79,6 +79,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e314n-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e314n-v2.dts
@@ -94,6 +94,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e355ac-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e355ac-v2.dts
@@ -94,6 +94,8 @@
 
 	flash@0 {
 		compatible = "winbond,w25q128", "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e5.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e5.dts
@@ -78,6 +78,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-e560ac.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-e560ac.dts
@@ -88,6 +88,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-ew71-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-ew71-v2.dts
@@ -73,6 +73,8 @@
 
 	flash@0 {
 		compatible = "winbond,w25q128", "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-ew72.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-ew72.dts
@@ -80,6 +80,8 @@
 
 	flash@0 {
 		compatible = "winbond,w25q128", "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_comfast_cf-wr752ac-v1.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-wr752ac-v1.dts
@@ -78,6 +78,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_compex_wpj531-16m.dts
+++ b/target/linux/ath79/dts/qca9531_compex_wpj531-16m.dts
@@ -71,6 +71,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_dlink_dch-g020-a1.dts
+++ b/target/linux/ath79/dts/qca9531_dlink_dch-g020-a1.dts
@@ -96,6 +96,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9531_engenius_ews511ap.dts
+++ b/target/linux/ath79/dts/qca9531_engenius_ews511ap.dts
@@ -98,6 +98,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar300m.dtsi
@@ -90,6 +90,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-ar750.dts
@@ -92,6 +92,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_glinet_gl-e750.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-e750.dts
@@ -67,6 +67,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_glinet_gl-s200.dtsi
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-s200.dtsi
@@ -111,6 +111,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_glinet_gl-x300b.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-x300b.dts
@@ -87,6 +87,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_glinet_gl-x750.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-x750.dts
@@ -82,6 +82,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dts
+++ b/target/linux/ath79/dts/qca9531_glinet_gl-xe300.dts
@@ -89,6 +89,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts
+++ b/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts
@@ -67,6 +67,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9531_letv_lba-047-ch.dts
+++ b/target/linux/ath79/dts/qca9531_letv_lba-047-ch.dts
@@ -75,6 +75,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <30000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
+++ b/target/linux/ath79/dts/qca9531_qxwlan_e600g.dtsi
@@ -65,6 +65,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_telco_t1.dts
+++ b/target/linux/ath79/dts/qca9531_telco_t1.dts
@@ -82,6 +82,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_teltonika_rut300.dts
+++ b/target/linux/ath79/dts/qca9531_teltonika_rut300.dts
@@ -67,6 +67,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_archer-d50-v1.dts
@@ -98,6 +98,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <10000000>;
 

--- a/target/linux/ath79/dts/qca9531_tplink_tl-mr3420-v3.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-mr3420-v3.dts
@@ -142,6 +142,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_tplink_tl-mr6400-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-mr6400-v1.dts
@@ -100,6 +100,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_tplink_tl-wr902ac-v1.dts
+++ b/target/linux/ath79/dts/qca9531_tplink_tl-wr902ac-v1.dts
@@ -106,6 +106,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9531_wallys_dr531.dts
+++ b/target/linux/ath79/dts/qca9531_wallys_dr531.dts
@@ -101,6 +101,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/qca9531_yuncore_a770.dts
+++ b/target/linux/ath79/dts/qca9531_yuncore_a770.dts
@@ -63,6 +63,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_comfast_cf-e110n-v2.dts
+++ b/target/linux/ath79/dts/qca9533_comfast_cf-e110n-v2.dts
@@ -98,6 +98,8 @@
 
 	flash@0 {
 		compatible = "winbond,w25q128", "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_dlink_dap-13xx.dtsi
+++ b/target/linux/ath79/dts/qca9533_dlink_dap-13xx.dtsi
@@ -73,6 +73,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9533_kuwfi_c910.dts
+++ b/target/linux/ath79/dts/qca9533_kuwfi_c910.dts
@@ -96,6 +96,8 @@
 
 	flash@0 {
 		compatible = "winbond,w25q128", "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_mikrotik_routerboard-16m.dtsi
+++ b/target/linux/ath79/dts/qca9533_mikrotik_routerboard-16m.dtsi
@@ -27,6 +27,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca9533_openmesh_om2p-v4.dtsi
+++ b/target/linux/ath79/dts/qca9533_openmesh_om2p-v4.dtsi
@@ -86,6 +86,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_plasmacloud_pa300.dtsi
+++ b/target/linux/ath79/dts/qca9533_plasmacloud_pa300.dtsi
@@ -68,6 +68,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_qca_ap143.dtsi
+++ b/target/linux/ath79/dts/qca9533_qca_ap143.dtsi
@@ -75,6 +75,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_tplink_cpexxx.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_cpexxx.dtsi
@@ -54,6 +54,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wa801nd.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wa801nd.dtsi
@@ -71,6 +71,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wa850re-v2.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wa850re-v2.dts
@@ -99,6 +99,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr802n.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr802n.dtsi
@@ -39,6 +39,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841.dtsi
@@ -77,6 +77,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr841hp-v3.dts
@@ -102,6 +102,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_tplink_tl-wr842n-v3.dts
+++ b/target/linux/ath79/dts/qca9533_tplink_tl-wr842n-v3.dts
@@ -113,6 +113,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_ubnt_aircube-isp.dts
+++ b/target/linux/ath79/dts/qca9533_ubnt_aircube-isp.dts
@@ -30,6 +30,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_yuncore_a930.dts
+++ b/target/linux/ath79/dts/qca9533_yuncore_a930.dts
@@ -50,6 +50,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9533_yuncore_cpe830.dts
+++ b/target/linux/ath79/dts/qca9533_yuncore_cpe830.dts
@@ -76,6 +76,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca953x_dlink_dap-2xxx.dtsi
+++ b/target/linux/ath79/dts/qca953x_dlink_dap-2xxx.dtsi
@@ -10,6 +10,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca953x_tplink_tl-wr810n.dtsi
+++ b/target/linux/ath79/dts/qca953x_tplink_tl-wr810n.dtsi
@@ -56,6 +56,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9550_airtight_c-75.dts
+++ b/target/linux/ath79/dts/qca9550_airtight_c-75.dts
@@ -120,6 +120,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 
@@ -178,6 +180,8 @@
 
 	flash@1 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <1>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9550_huawei_ap5030dn.dts
+++ b/target/linux/ath79/dts/qca9550_huawei_ap5030dn.dts
@@ -84,6 +84,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9556_avm_fritz-repeater.dtsi
+++ b/target/linux/ath79/dts/qca9556_avm_fritz-repeater.dtsi
@@ -22,6 +22,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
+++ b/target/linux/ath79/dts/qca9556_mikrotik_routerboard-wap-g-5hact2hnd.dts
@@ -61,6 +61,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca9557_buffalo_bhr-4grv2.dts
+++ b/target/linux/ath79/dts/qca9557_buffalo_bhr-4grv2.dts
@@ -68,6 +68,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9557_dongwon_dw02-412h.dtsi
+++ b/target/linux/ath79/dts/qca9557_dongwon_dw02-412h.dtsi
@@ -51,6 +51,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9557_extreme-networks_ws-ap3805i.dts
+++ b/target/linux/ath79/dts/qca9557_extreme-networks_ws-ap3805i.dts
@@ -116,6 +116,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/qca9557_fortinet_fap-221-c.dts
+++ b/target/linux/ath79/dts/qca9557_fortinet_fap-221-c.dts
@@ -121,6 +121,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
+++ b/target/linux/ath79/dts/qca9557_iodata_wn-ac-dgr.dtsi
@@ -88,6 +88,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9557_ruckus_r500.dts
+++ b/target/linux/ath79/dts/qca9557_ruckus_r500.dts
@@ -188,6 +188,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9557_sophos_ap15.dtsi
+++ b/target/linux/ath79/dts/qca9557_sophos_ap15.dtsi
@@ -42,6 +42,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9557_zyxel_nbg6616.dts
+++ b/target/linux/ath79/dts/qca9557_zyxel_nbg6616.dts
@@ -68,6 +68,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_aruba_ap-115.dts
+++ b/target/linux/ath79/dts/qca9558_aruba_ap-115.dts
@@ -132,6 +132,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_belkin_f9x-v2.dtsi
+++ b/target/linux/ath79/dts/qca9558_belkin_f9x-v2.dtsi
@@ -115,6 +115,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/qca9558_buffalo_wzr-450hp2.dts
+++ b/target/linux/ath79/dts/qca9558_buffalo_wzr-450hp2.dts
@@ -66,6 +66,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_comfast_cf-e380ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-e380ac-v2.dts
@@ -68,6 +68,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac-v1.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac-v1.dts
@@ -21,6 +21,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-wr650ac-v2.dts
@@ -23,6 +23,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_compex_wpj558-16m.dts
+++ b/target/linux/ath79/dts/qca9558_compex_wpj558-16m.dts
@@ -63,6 +63,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/qca9558_devolo_dvl1xxx.dtsi
+++ b/target/linux/ath79/dts/qca9558_devolo_dvl1xxx.dtsi
@@ -52,6 +52,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_dlink_dir-629-a1.dts
+++ b/target/linux/ath79/dts/qca9558_dlink_dir-629-a1.dts
@@ -86,6 +86,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <30000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/qca9558_domywifi_dw33d.dts
+++ b/target/linux/ath79/dts/qca9558_domywifi_dw33d.dts
@@ -96,6 +96,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_jjplus_jwap230.dts
+++ b/target/linux/ath79/dts/qca9558_jjplus_jwap230.dts
@@ -53,6 +53,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
+++ b/target/linux/ath79/dts/qca9558_librerouter_librerouter-v1.dts
@@ -102,6 +102,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_mikrotik_routerboard-92x.dtsi
+++ b/target/linux/ath79/dts/qca9558_mikrotik_routerboard-92x.dtsi
@@ -112,6 +112,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_mikrotik_routerboard-96x.dtsi
+++ b/target/linux/ath79/dts/qca9558_mikrotik_routerboard-96x.dtsi
@@ -76,6 +76,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca9558_nec_aterm.dtsi
+++ b/target/linux/ath79/dts/qca9558_nec_aterm.dtsi
@@ -188,6 +188,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_netgear_ex7300.dts
+++ b/target/linux/ath79/dts/qca9558_netgear_ex7300.dts
@@ -140,6 +140,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_ocedo_koala.dts
+++ b/target/linux/ath79/dts/qca9558_ocedo_koala.dts
@@ -73,6 +73,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9558_ocedo_ursus.dts
+++ b/target/linux/ath79/dts/qca9558_ocedo_ursus.dts
@@ -42,6 +42,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
+++ b/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
@@ -74,6 +74,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca9558_openmesh_mr.dtsi
+++ b/target/linux/ath79/dts/qca9558_openmesh_mr.dtsi
@@ -83,6 +83,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v1.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v1.dts
@@ -93,6 +93,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v2.dts
@@ -127,6 +127,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_qxwlan_e558.dtsi
+++ b/target/linux/ath79/dts/qca9558_qxwlan_e558.dtsi
@@ -67,6 +67,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_sitecom_wlr-8100.dts
+++ b/target/linux/ath79/dts/qca9558_sitecom_wlr-8100.dts
@@ -67,6 +67,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_sophos_ap.dtsi
+++ b/target/linux/ath79/dts/qca9558_sophos_ap.dtsi
@@ -88,6 +88,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-c.dtsi
@@ -102,6 +102,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_tplink_archer-d7-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-d7-v1.dts
@@ -25,6 +25,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_tplink_archer-d7b-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_archer-d7b-v1.dts
@@ -25,6 +25,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_tplink_re350k-v1.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_re350k-v1.dts
@@ -131,6 +131,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_tplink_rex5x.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_rex5x.dtsi
@@ -116,6 +116,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wdr4900-v2.dts
@@ -111,6 +111,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr1043nd.dtsi
@@ -88,6 +88,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <33400000>;
 

--- a/target/linux/ath79/dts/qca9558_tplink_tl-wr941n-v7-cn.dts
+++ b/target/linux/ath79/dts/qca9558_tplink_tl-wr941n-v7-cn.dts
@@ -64,6 +64,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_trendnet_tew-823dru.dts
+++ b/target/linux/ath79/dts/qca9558_trendnet_tew-823dru.dts
@@ -99,6 +99,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9558_zyxel_nbg6716.dts
+++ b/target/linux/ath79/dts/qca9558_zyxel_nbg6716.dts
@@ -89,6 +89,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca955x_dlink_dap-2xxx.dtsi
+++ b/target/linux/ath79/dts/qca955x_dlink_dap-2xxx.dtsi
@@ -10,6 +10,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca955x_elecom_wab.dtsi
+++ b/target/linux/ath79/dts/qca955x_elecom_wab.dtsi
@@ -154,6 +154,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca955x_engenius_ecb1xxx.dtsi
+++ b/target/linux/ath79/dts/qca955x_engenius_ecb1xxx.dtsi
@@ -54,6 +54,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca955x_senao_loader.dtsi
+++ b/target/linux/ath79/dts/qca955x_senao_loader.dtsi
@@ -44,6 +44,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca955x_senao_router-dual.dtsi
+++ b/target/linux/ath79/dts/qca955x_senao_router-dual.dtsi
@@ -56,6 +56,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca955x_ubnt_xc.dtsi
+++ b/target/linux/ath79/dts/qca955x_ubnt_xc.dtsi
@@ -21,6 +21,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_avm_fritz4020.dts
+++ b/target/linux/ath79/dts/qca9561_avm_fritz4020.dts
@@ -105,6 +105,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_nec_wf1200cr.dts
+++ b/target/linux/ath79/dts/qca9561_nec_wf1200cr.dts
@@ -66,6 +66,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c25-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c25-v1.dts
@@ -121,6 +121,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c58-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c58-v1.dts
@@ -25,6 +25,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c59-v1.dts
@@ -46,6 +46,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c59-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c59-v2.dts
@@ -42,6 +42,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c60-v1.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c60-v1.dts
@@ -42,6 +42,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c60-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c60-v2.dts
@@ -42,6 +42,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_tplink_archer-c60-v3.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_archer-c60-v3.dts
@@ -35,6 +35,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_tplink_eap225-wall-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_eap225-wall-v2.dts
@@ -75,6 +75,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_tplink_tl-wdr6500-v2.dts
+++ b/target/linux/ath79/dts/qca9561_tplink_tl-wdr6500-v2.dts
@@ -70,6 +70,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9561_xiaomi_mi-router-4q.dts
+++ b/target/linux/ath79/dts/qca9561_xiaomi_mi-router-4q.dts
@@ -57,6 +57,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_asus_pl-ac56.dts
+++ b/target/linux/ath79/dts/qca9563_asus_pl-ac56.dts
@@ -71,6 +71,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9563_asus_rp-ac66.dts
+++ b/target/linux/ath79/dts/qca9563_asus_rp-ac66.dts
@@ -97,6 +97,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9563_comfast_cf-e375ac.dts
+++ b/target/linux/ath79/dts/qca9563_comfast_cf-e375ac.dts
@@ -76,6 +76,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_compex_wpj563.dts
+++ b/target/linux/ath79/dts/qca9563_compex_wpj563.dts
@@ -67,6 +67,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_dlink_covr.dtsi
+++ b/target/linux/ath79/dts/qca9563_dlink_covr.dtsi
@@ -49,6 +49,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9563_dlink_dap-1720-a1.dts
+++ b/target/linux/ath79/dts/qca9563_dlink_dap-1720-a1.dts
@@ -89,6 +89,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_dlink_dir-842-c.dtsi
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-842-c.dtsi
@@ -56,6 +56,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9563_dlink_dir-8x9-a1.dtsi
+++ b/target/linux/ath79/dts/qca9563_dlink_dir-8x9-a1.dtsi
@@ -42,6 +42,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_elecom_wrc-ghbk2-i.dtsi
+++ b/target/linux/ath79/dts/qca9563_elecom_wrc-ghbk2-i.dtsi
@@ -56,6 +56,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_glinet_gl-ar750s.dtsi
+++ b/target/linux/ath79/dts/qca9563_glinet_gl-ar750s.dtsi
@@ -74,6 +74,8 @@
 
 	flash_nor: flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_glinet_gl-x1200.dtsi
+++ b/target/linux/ath79/dts/qca9563_glinet_gl-x1200.dtsi
@@ -71,6 +71,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_kuwfi_n650.dts
+++ b/target/linux/ath79/dts/qca9563_kuwfi_n650.dts
@@ -70,6 +70,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_nec_wg1200cr.dts
+++ b/target/linux/ath79/dts/qca9563_nec_wg1200cr.dts
@@ -75,6 +75,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_nec_wg800hp.dts
+++ b/target/linux/ath79/dts/qca9563_nec_wg800hp.dts
@@ -100,6 +100,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/qca9563_netgear_wndr.dtsi
@@ -119,6 +119,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_phicomm_k2t.dts
+++ b/target/linux/ath79/dts/qca9563_phicomm_k2t.dts
@@ -66,6 +66,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_qxwlan_e1700ac.dtsi
+++ b/target/linux/ath79/dts/qca9563_qxwlan_e1700ac.dtsi
@@ -67,6 +67,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
+++ b/target/linux/ath79/dts/qca9563_rosinson_wr818.dts
@@ -48,6 +48,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c2-v3.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c2-v3.dts
@@ -101,6 +101,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2-us.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2-us.dts
@@ -97,6 +97,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c6-v2.dts
@@ -98,6 +98,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-c7-v4.dts
@@ -179,6 +179,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_archer-x7-v5.dtsi
@@ -121,6 +121,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_cpe710.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_cpe710.dtsi
@@ -59,6 +59,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_deco-m4r-v1.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_deco-m4r-v1.dts
@@ -84,6 +84,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_deco-s4-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_deco-s4-v2.dts
@@ -84,6 +84,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_eap245-v3.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_eap245-v3.dts
@@ -64,6 +64,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_eap2x5-1port.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_eap2x5-1port.dtsi
@@ -31,6 +31,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_re450.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_re450.dtsi
@@ -116,6 +116,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wa1201-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wa1201-v2.dts
@@ -117,6 +117,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630.dtsi
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wpa8630.dtsi
@@ -90,6 +90,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n-v5.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043n-v5.dts
@@ -16,6 +16,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wr1043nd-v4.dts
@@ -28,6 +28,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_ubnt_amplifi-router-hd.dts
+++ b/target/linux/ath79/dts/qca9563_ubnt_amplifi-router-hd.dts
@@ -41,6 +41,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
+++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
@@ -55,6 +55,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_xiaomi_aiot-ac2350.dts
+++ b/target/linux/ath79/dts/qca9563_xiaomi_aiot-ac2350.dts
@@ -77,6 +77,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/ath79/dts/qca9563_yuncore_xd4200.dtsi
+++ b/target/linux/ath79/dts/qca9563_yuncore_xd4200.dtsi
@@ -67,6 +67,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qca9563_zte_mf28x.dtsi
+++ b/target/linux/ath79/dts/qca9563_zte_mf28x.dtsi
@@ -62,6 +62,8 @@
 
 	boot_flash: flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qcn5502_asus.dtsi
+++ b/target/linux/ath79/dts/qcn5502_asus.dtsi
@@ -59,6 +59,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/qcn5502_netgear_ex7300-v2.dts
+++ b/target/linux/ath79/dts/qcn5502_netgear_ex7300-v2.dts
@@ -133,6 +133,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/qcn5502_tplink_archer-a9-v6.dts
+++ b/target/linux/ath79/dts/qcn5502_tplink_archer-a9-v6.dts
@@ -128,6 +128,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 		m25p,fast-read;

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wr941hp-v1.dts
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wr941hp-v1.dts
@@ -102,6 +102,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 

--- a/target/linux/ath79/dts/tp9343_tplink_tl-wx.dtsi
+++ b/target/linux/ath79/dts/tp9343_tplink_tl-wx.dtsi
@@ -16,6 +16,8 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <25000000>;
 


### PR DESCRIPTION
Defining the implicitly inherited address and size cells on the `flash` nodes makes them a proper container for fixed `partitions` and silences warnings like this:

    OF: Bad cell count for /ahb/spi@1f000000/flash@0/partitions

The warning is harmless, but silencing it this way should not hurt either.

Build and run-tested on a Ubiquiti airCube AC (_ar9342_ubnt_aircube-ac.dts_) with Kernel 6.12.55
I assume it is safe to add those values to all SPI NOR flash nodes.

----

Related issues:
* #14701