### PR TITLE
mediatek: filogic: TP-Link Archer AX80 v1 (EU) support

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -134,6 +134,7 @@ teltonika,rutc50)
 	ubootenv_add_mtd "u-boot-env" "0x0" "0x10000" "0x10000"
 	;;
 tplink,archer-ax80-v1|\
+tplink,archer-ax80-v1-eu|\
 tplink,be450)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000" "8"
 	;;

--- a/target/linux/mediatek/dts/mt7986b-tplink-archer-ax80-v1-eu.dts
+++ b/target/linux/mediatek/dts/mt7986b-tplink-archer-ax80-v1-eu.dts
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986b.dtsi"
+
+/ {
+	compatible = "tplink,archer-ax80-v1-eu", "mediatek,mt7986b";
+	model = "TP-Link Archer AX80 v1 (EU)";
+	
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+	
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+	
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+	
+	leds {
+		compatible = "gpio-leds";
+		
+		led_power: power {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+		
+		wlan2g {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tpt";
+		};
+		
+		wlan5g {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+		
+		internet_white {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WAN_ONLINE;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+		
+		internet_orange {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 19 GPIO_ACTIVE_LOW>;
+		};
+		
+		lan {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_LAN;
+			gpios = <&pio 16 GPIO_ACTIVE_HIGH>;
+		};
+		
+		usb {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_DISK;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&ssusb>;
+			linux,default-trigger = "usbport";
+		};
+		
+		wps {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&pio 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+	
+	keys {
+		compatible = "gpio-keys";
+		
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+		
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		};
+		
+		wifi {
+			label = "wlan";
+			linux,code = <KEY_WLAN>;
+			gpios = <&pio 20 GPIO_ACTIVE_LOW>;
+		};
+	};
+	
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+	
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&auxadc {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+	
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+		};
+	};
+	
+	mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy6>;
+	};
+	
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reset-delay-us = <1500000>;
+		reset-post-delay-us = <1000000>;		
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		phy6: phy@6 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <6>;
+		};
+		
+		switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+			
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				port@0 {
+					reg = <1>;
+					label = "lan0";
+				};
+				port@1 {
+					reg = <2>;
+					label = "lan1";
+				};
+				port@2 {
+					reg = <3>;
+					label = "lan2";
+				};
+				port@3 {
+					reg = <4>;
+					label = "lan3";
+				};
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+					};
+				};
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+	
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			
+			partition@0 {
+				label = "boot";
+				reg = <0x0 0x200000>;
+				read-only;
+			};
+			
+			partition@200000 {
+				label = "u-boot-env";
+				reg = <0x200000 0x100000>;
+			};
+			
+			partition@300000 {
+				label = "ubi0";
+				reg = <0x300000 0x3200000>;
+			};
+			
+			partition@3500000 {
+				label = "ubi1";
+				reg = <0x3500000 0x3200000>;
+			};
+			
+			partition@6700000 {
+				label = "userconfig";
+				reg = <0x6700000 0x800000>;
+			};
+			
+			partition@6f00000 {
+				label = "tp_data";
+				reg = <0x6f00000 0x400000>;
+				read-only;
+			};
+			
+			partition@7300000 {
+				label = "mali_data";
+				reg = <0x7300000 0x800000>;
+			};
+		};
+	};
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable; /* bias-disable */
+		};
+	};
+	
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			"WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&ssusb {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -248,6 +248,9 @@ teltonika,rutc50)
 totolink,x6000r)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
 	;;
+tplink,archer-ax80-v1-eu)
+	ucidef_set_led_netdev "lan" "LAN" "white:lan" "br-lan" "link tx rx"
+	;;
 tplink,be450)
 	ucidef_set_led_netdev "br-lan" "lan" "blue:lan" "br-lan" "link tx rx"
 	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan-2ghz" "phy0.0-ap0"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -173,7 +173,8 @@ mediatek_setup_interfaces()
 	wavlink,wl-wn586x3b)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" eth1
 		;;
-	tplink,archer-ax80-v1)
+	tplink,archer-ax80-v1|\
+	tplink,archer-ax80-v1-eu)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" eth1
 		;;
 	tplink,be450)
@@ -236,6 +237,7 @@ mediatek_setup_macs()
 		;;
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
+	tplink,archer-ax80-v1-eu|\
 	tplink,re6000xd)
 		label_mac=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		lan_mac=$label_mac

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -22,6 +22,7 @@ case "$FIRMWARE" in
 "mediatek/mt7986_eeprom_mt7975_dual.bin")
 	case "$board" in
 	mercusys,mr90x-v1|\
+	tplink,archer-ax80-v1-eu|\
 	tplink,re6000xd)
 		ln -sf /tmp/tp_data/MT7986_EEPROM.bin \
 			/lib/firmware/$FIRMWARE

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -159,6 +159,7 @@ case "$board" in
 		;;
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
+	tplink,archer-ax80-v1-eu|\
 	tplink,be450|\
 	tplink,re6000xd)
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -17,6 +17,7 @@ preinit_mount_cfg_part() {
 	mercusys,mr85x|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
+	tplink,archer-ax80-v1-eu|\
 	tplink,be450|\
 	tplink,re6000xd)
 		mount_ubi_part "tp_data" "tp_data"

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -40,6 +40,7 @@ preinit_set_mac_address() {
 		;;
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
+	tplink,archer-ax80-v1-eu|\
 	tplink,re6000xd)
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		ip link set dev eth1 address "$(macaddr_add $addr 1)"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -189,6 +189,7 @@ platform_do_upgrade() {
 	mercusys,mr85x|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
+	tplink,archer-ax80-v1-eu|\
 	tplink,be450|\
 	tplink,re6000xd)
 		CI_UBIPART="ubi0"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2476,7 +2476,8 @@ TARGET_DEVICES += totolink_x6000r
 
 define Device/tplink_archer-ax80-v1
   DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := Archer AX80V1
+  DEVICE_MODEL := Archer AX80
+  DEVICE_VARIANT := v1
   DEVICE_DTS := mt7986a-tplink-archer-ax80-v1
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-leds-lp5523 kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
@@ -2487,6 +2488,21 @@ define Device/tplink_archer-ax80-v1
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += tplink_archer-ax80-v1
+
+define Device/tplink_archer-ax80-v1-eu
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := Archer AX80
+  DEVICE_VARIANT := v1 (EU)
+  DEVICE_DTS := mt7986b-tplink-archer-ax80-v1-eu
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 51200k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += tplink_archer-ax80-v1-eu
 
 define Device/tplink_be450
   DEVICE_VENDOR := TP-Link


### PR DESCRIPTION
Mediatek Filogic: add TP-Link Archer AX80 EU support
As of 7th November 2025, the device is ready finally! I expect reviewers to check this out @achterin  @musashino205 

Thanks to collaborators @HateTM and @mantikafasi we made it! 
Everything works! Reset button also works! Just that, small caveat on LED's. It will be fixed soon. Or if someone volunteers to fix the LED's.

### Device specification
SoC Type:   MediaTek MT7986B, Cortex-A53, 64-bit 1.6GHz Quad Core
RAM:        ESMT M15T4G16256 (512MB)
Flash:      ESMT F50L1G41LB (128 MB)
Ethernet:   MediaTek MT7531AE + 2.5GbE MaxLinear GPY211C0VC (SLNW8)
Ethernet:   1x2.5Gbe (WAN/LAN 2.5Gbps), 4xGbE (WAN/LAN 1Gbps, LAN1, LAN2, LAN3)
WLAN 2g:    MediaTek MT7975
WLAN 5g:    MediaTek MT7975
LEDs:       All White(probably)

Buttons:    4 (Reset,ledswitch,wps,wlan),
USB ports:  1 (USB 3.0)
Power:      12 VDC, 2.0 A
Connector:  Barrel
Bootloader: Main U-Boot - U-Boot 2022.01-rc4. Additionally, both UBI
            slots contain "seconduboot" (also U-Boot 2022.01-rc4)
Serial console (UART)
```
                            V
+-------+-------+-------+-------+
| +3.3V |  GND  |  TX   |  RX   |
+---+---+-------+-------+-------+
    |
    +--- Don't connect

CPU BLOCK HERE                               LEDS ARE HERE
```

Installation (UART)
Note: There might be methods without UART possible soon.
Place OpenWrt initramfs image on tftp server with IP 192.168.1.2

Attach UART, switch on the router and interrupt the boot process by pressing 'Ctrl-C'

Load and run OpenWrt initramfs image:

```
      tftpboot initramfs-kernel.bin
      bootm

```
!!Attention!! is very important! After entering OpenWrt, please set / update the environment variables:

```
fw_setenv bootargs "ubi.mtd=ubi0 console=ttyS0,115200n1 loglevel=8 earlycon=uart8250,mmio32,0x11002000 init=/etc/preinit"
fw_setenv mtdids "spi-nand0=spi-nand0"
fw_setenv mtdparts "spi-nand0:2M(boot),1M(u-boot-env),50M(ubi0),50M(ubi1),8M(userconfig),4M(tp_data),8M(mali_data)"
fw_setenv tp_boot_idx 0
```

Run 'sysupgrade -n' with the sysupgrade OpenWrt image from console or Luci WebUI.

Recovery

Press Reset button and power on the router
Navigate to U-Boot recovery web server (192.168.1.1) and upload the OEM firmware

Stock layout

0x000000000000-0x000000200000 : "boot"
0x000000200000-0x000000300000 : "u-boot-env"
0x000000300000-0x000003500000 : "ubi0"
0x000003500000-0x000006700000 : "ubi1"
0x000006700000-0x000006f00000 : "userconfig"
0x000006f00000-0x000007300000 : "tp_data"
0x000007300000-0x000007B00000 : "mali_data"

ubi0/ubi1 format
U-Boot at boot checks that all volumes are in place:

+-------------------------------+
| Volume Name: uboot   Vol ID: 0|
| Volume Name: kernel  Vol ID: 1|
| Volume Name: rootfs  Vol ID: 2|
+-------------------------------+
MAC addresses
+---------+-------------------+-----------+
| label   | 00:eb:xx:xx:xx:be | label     |
| LAN     | 00:eb:xx:xx:xx:be | label     |
| WAN     | 00:eb:xx:xx:xx:bf | label+1   |
| WLAN 2g | 00:eb:xx:xx:xx:be | label     |
| WLAN 5g | 00:eb:xx:xx:xx:bd | label-1   |
+---------+-------------------+-----------+
label MAC address was found in UBI partition "tp_data", file "default-mac".
OEM wireless eeprom is also there (file "MT7986_EEPROM.bin").


<img width="1767" height="985" alt="Ekran Görüntüsü 2025-11-09 00-27-53" src="https://github.com/user-attachments/assets/a3202cd9-ab31-42c6-bef4-c9651e65fbbd" />
