### PR TITLE
mediatek: filogic: fix supported_devices list for gl-mt2500

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1379,7 +1379,7 @@ define Device/glinet_gl-mt2500
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTS_LOADADDR := 0x47000000
   DEVICE_PACKAGES := -wpad-basic-mbedtls e2fsprogs f2fsck mkf2fs kmod-usb3
-  SUPPORTED_DEVICES += glinet,mt2500-emmc glinet,gl-mt2500-airoha
+  SUPPORTED_DEVICES += glinet,mt2500-emmc
   IMAGES := sysupgrade.bin factory.bin
   IMAGE/factory.bin := append-kernel | pad-to 32M | append-rootfs
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
@@ -1397,7 +1397,7 @@ define Device/glinet_gl-mt2500-airoha
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTS_LOADADDR := 0x47000000
   DEVICE_PACKAGES := -wpad-basic-mbedtls e2fsprogs f2fsck mkf2fs kmod-usb3 kmod-phy-airoha-en8811h airoha-en8811h-firmware
-  SUPPORTED_DEVICES += glinet,mt2500-emmc glinet,gl-mt2500
+  SUPPORTED_DEVICES += glinet,mt2500-emmc
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
 endef


### PR DESCRIPTION
The SUPPORTED_DEVICES sets for both Maxlinear (dts v1) and Airoha (dts v2) devices were identical, so sysupgrade was unable to detect when an incorrect image was being installed.  This causeed "soft bricking" of devices when a v1 image was installed on a v2 device, and vice versa.

Fix this by making the supported_devices distinct for each device version, and add a version-specific id so that you can identify which DTS was used to generate which image without digging through the makefiles.

Fixes: https://github.com/openwrt/openwrt/issues/20566
Fixes: https://github.com/openwrt/asu/issues/1525

