### PR TITLE
odhcp6c: update to Git HEAD (2025-11-04)

### DIFF
--- a/package/network/ipv6/odhcp6c/Makefile
+++ b/package/network/ipv6/odhcp6c/Makefile
@@ -12,17 +12,16 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcp6c.git
-PKG_SOURCE_DATE:=2025-10-21
-PKG_SOURCE_VERSION:=77e1ae21e67f81840024ffe5bb7cf69a8fb0d2f0
-PKG_MIRROR_HASH:=78f1c2342330da5f6bf08a4be89df1d771661966bbff13bd15462035de46837b
+PKG_SOURCE_DATE:=2025-11-04
+PKG_SOURCE_VERSION:=b3e1db42b4dbb5f99705e4d1057ca49b44f4f5ee
+PKG_MIRROR_HASH:=37ddaf182eba190efc091d7b9c963e84dfe0537ce498ad4be1c268bea134782e
 PKG_MAINTAINER:=Hans Dedecker <dedeckeh@gmail.com>
 PKG_LICENSE:=GPL-2.0
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
-CMAKE_OPTIONS += \
-	-DUSE_LIBUBOX=on
+CMAKE_OPTIONS += -DUBUS=1
 
 ifneq ($(CONFIG_PACKAGE_odhcp6c_ext_cer_id),0)
   CMAKE_OPTIONS += -DEXT_CER_ID=$(CONFIG_PACKAGE_odhcp6c_ext_cer_id)
@@ -32,7 +31,7 @@ define Package/odhcp6c
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Embedded DHCPv6-client for OpenWrt
-  DEPENDS:=@IPV6 +libubox
+  DEPENDS:=@IPV6 +libubox +libubus
 endef
 
 define Package/odhcp6c/config


### PR DESCRIPTION
b3e1db42b4db odhcp6c: fix safe interval processing to follow RFC 4862
63461f64d4c1 dhcpv6: always include IA_NA and IA_PD in Request message if requested
1051cabb4da3 dhcpv6: fix incorrect IA type being printed in syslog
c5237eabeb5c odhcp6c: prevent RELEASE at shutdown when -k is set
a01b1ff1e50f odhcp6c: fix client exiting if Renew and Rebind fails
4839bf6d0feb odhcp6c: implement RKAP: Reconfiguration Key Authentication Protocol
52a9a847def4 dhcpv6: fix solicit loop when server has no address available
7b1f67c23de6 ubus: implement ubus methods to force a Renew and Release
2b0e8f2d8541 ubus: implement retransmission configuration via ubus
8d89d373f360 odhcp6c: add failure when -E option is used without ubus support enabled
58f3c9eb1163 odhcp6c: add new argument option to disable script call
1048fc4fb622 reconfigure: move all configuration functions to a new file
93f056d3a1f2 reconfigure: implement DHCP reconfiguration
af669fb23cd3 dhcpv6: implement statistics for DHCPv6
3a1a599fecb7 ubus: implement UBus method to get state data immediately
44c50214997d ubus: emit UBus event on DHCP state changes
33b972bc526a ubus: connect to UBus backend
2f609f248faf odhcp6c: implement asynchronous handling for DHCPv6 State
6466314e7f62 odhcp6c: enable Non-Blocking DHCPv6 Socket
1df65f0caf46 dhcpv6: refactor dhcp_request Function
047c63a8156b dhcpv6: add t1 and t2 transmission
1b5f0c402bbf dscp: add option to set dscp value
96017df54d8f dhcpv6: fix wrong retransmission of DHCPv6 Solicit
b929fc8a1cfd odhcp6c: add a simple build script
adc651ffed55 cmake: make libubox mandatory
5182e2b696ef cmake: drop EXT_PREFIX_CLASS
8d052c52e18d cmake: disable pedantic
f2521b296b21 github: fix CI apt dependencies

https://github.com/openwrt/odhcp6c/compare/77e1ae21e67f...b3e1db42b4db

CC @Alphix @nicopaulb @systemcrash @l-jonas