### PR TITLE
realtek: dsa: Fix rate control initialization

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
@@ -553,13 +553,14 @@ void __init rtl83xx_setup_qos(struct rtl838x_switch_priv *priv)
 
 	pr_info("In %s\n", __func__);
 
-	if (priv->family_id == RTL8380_FAMILY_ID)
+	switch (priv->family_id) {
+	case RTL8380_FAMILY_ID:
 		rtl838x_config_qos();
-	else if (priv->family_id == RTL8390_FAMILY_ID)
-		rtl839x_config_qos();
-
-	if (priv->family_id == RTL8380_FAMILY_ID)
 		rtl838x_rate_control_init(priv);
-	else if (priv->family_id == RTL8390_FAMILY_ID)
+		break;
+	case RTL8390_FAMILY_ID:
+		rtl839x_config_qos();
 		rtl839x_rate_control_init(priv);
+		break;
+	}
 }

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
@@ -554,9 +554,9 @@ void __init rtl83xx_setup_qos(struct rtl838x_switch_priv *priv)
 	pr_info("In %s\n", __func__);
 
 	if (priv->family_id == RTL8380_FAMILY_ID)
-		return rtl838x_config_qos();
+		rtl838x_config_qos();
 	else if (priv->family_id == RTL8390_FAMILY_ID)
-		return rtl839x_config_qos();
+		rtl839x_config_qos();
 
 	if (priv->family_id == RTL8380_FAMILY_ID)
 		rtl838x_rate_control_init(priv);


### PR DESCRIPTION
The `rtl838x_rate_control_init()` and `rtl839x_rate_control_init()` functions were never called because the `rtl83xx_setup_qos()` always returned after the QoS configuration

Fixes: dc9cc0d3e2a1 ("realtek: add QoS and rate control")

---

***WARNING*** I don't have any device for testing. This was just noticed while reading the code.

Btw. these are void functions -  so no return value to return or check