### PR TITLE
lua5.3: Add TARGET_LDFLAGS to MYLDFLAGS

### DIFF
--- a/package/utils/lua5.3/Makefile
+++ b/package/utils/lua5.3/Makefile
@@ -86,6 +86,7 @@ define Build/Compile
 		RANLIB="$(TARGET_CROSS)ranlib" \
 		INSTALL_ROOT=/usr \
 		CFLAGS="$(TARGET_CPPFLAGS) $(TARGET_CFLAGS)" \
+		MYLDFLAGS="$(TARGET_LDFLAGS)" \
 		PKG_VERSION=$(PKG_VERSION) \
 		linux
 	rm -rf $(PKG_INSTALL_DIR)


### PR DESCRIPTION
Add TARGET_LDFLAGS to MYLDFLAGS make sure that the required flags are used during the compilation.
