### PR TITLE
ipq40xx: Meraki MR30H enable PoE output when powered by 802.3at

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/init.d/poe_switch
+++ b/target/linux/ipq40xx/base-files/etc/init.d/poe_switch
@@ -1,0 +1,22 @@
+#!/bin/sh /etc/rc.common
+
+START=21
+STOP=10
+
+boot() {
+	case $(board_name) in
+		meraki,mr30h)
+			if [ $(cat /sys/class/gpio/poeaf_det/value) -eq 0 ]; then
+				echo "1" > /sys/class/gpio/pse_en/value
+			fi
+		;;
+	esac
+}
+
+shutdown() {
+	case $(board_name) in
+		meraki,mr30h)
+			echo "0" > /sys/class/gpio/pse_en/value
+		;;
+	esac
+}

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr30h.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4029-mr30h.dts
@@ -79,6 +79,24 @@
 			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
 		};
 	};
+
+        gpio_export {
+                compatible = "gpio-export";
+                #size-cells = <0>;
+
+                pse_en {
+                        gpio-export,name = "pse_en";
+                        gpio-export,output = <1>;
+                        gpios = <&tlmm 28 GPIO_ACTIVE_LOW>;
+                };
+
+                poeaf_det {
+                        gpio-export,name = "poeaf_det";
+                        gpio-export,input = <0>;
+                        gpios = <&tlmm 29 GPIO_ACTIVE_HIGH>;
+                };
+
+        };
 };
 
 &tricolor {


### PR DESCRIPTION
The Meraki MR30H is powered solely by PoE input. When the device is powered by an 802.3at (30W) power source, it can output 803.2af (15W) via port 1.

This commit enables PoE output on port 1 of the Meraki MR30H if the device is powered via 802.3at PoE.

No PoE output is enabled if the device is powered via 802.3af PoE, as there is insufficient power.

Not sure if this is the "correct" way to enable PoE output, but `/etc/board.d/03_gpio_switches` doesn't seem to support logic decisions in configuring GPIO outputs. Additionally, PoE output should only be applied after networking has been brought up, otherwise a PoE powered downstream device may not be able to DHCP.

cc @Leo-PL and @robimarko 