### PR TITLE
bcm47xx: fix no previous prototype error

### DIFF
--- a/target/linux/bcm47xx/patches-6.6/980-no-previous-protoype-fixes.patch
+++ b/target/linux/bcm47xx/patches-6.6/980-no-previous-protoype-fixes.patch
@@ -1,0 +1,22 @@
+--- a/drivers/bcma/driver_chipcommon_sflash.c
++++ b/drivers/bcma/driver_chipcommon_sflash.c
+@@ -93,7 +93,7 @@ static void bcma_sflash_cmd(struct bcma_
+ 	bcma_err(cc->core->bus, "SFLASH control command failed (timeout)!\n");
+ }
+ 
+-const struct bcma_sflash_tbl_e *bcma_sflash_shrink_flash(u32 id)
++static const struct bcma_sflash_tbl_e *bcma_sflash_shrink_flash(u32 id)
+ {
+ 	enum bcm47xx_board board = bcm47xx_board_get();
+ 	const struct bcma_sflash_tbl_e *e;
+--- a/drivers/firmware/broadcom/cfe_env.c
++++ b/drivers/firmware/broadcom/cfe_env.c
+@@ -21,6 +21,8 @@
+ static char _nvdata[NVRAM_SIZE];
+ static char _valuestr[256];
+ 
++char *cfe_env_get(unsigned char *nv_buf, const char *name);
++
+ /*
+  * TLV types.  These codes are used in the "type-length-value"
+  * encoding of the items stored in the NVRAM device (flash or EEPROM)

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
@@ -227,7 +227,7 @@ static void b53_set_vlan_entry(struct b53_device *dev, u16 vid, u16 members,
 	}
 }
 
-void b53_set_forwarding(struct b53_device *dev, int enable)
+static void b53_set_forwarding(struct b53_device *dev, int enable)
 {
 	u8 mgmt;
 

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_mdio.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_mdio.c
@@ -400,7 +400,7 @@ static struct phy_driver b53_phy_driver_id3 = {
 	.read_status	= b53_phy_read_status,
 };
 
-int __init b53_phy_driver_register(void)
+static int __init b53_phy_driver_register(void)
 {
 	int ret;
 
@@ -422,7 +422,7 @@ err1:
 	return ret;
 }
 
-void __exit b53_phy_driver_unregister(void)
+static void __exit b53_phy_driver_unregister(void)
 {
 	phy_driver_unregister(&b53_phy_driver_id3);
 	phy_driver_unregister(&b53_phy_driver_id2);

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_phy_fixup.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_phy_fixup.c
@@ -47,7 +47,7 @@ static int b53_phy_fixup(struct phy_device *dev)
 	return 0;
 }
 
-int __init b53_phy_fixup_register(void)
+static int __init b53_phy_fixup_register(void)
 {
 	return phy_register_fixup_for_id(PHY_ANY_ID, b53_phy_fixup);
 }


### PR DESCRIPTION
Make functions in b53 static and add kernel patch to fix prototype build errors
