### PR TITLE
include: download.mk: do not check PKG_MIRROR_HASH when set to "skip"

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -159,7 +159,7 @@ $(if $(if $(MIRROR), \
 		( $(3) ) \
 		$(if $(filter-out x,$(MIRROR_HASH)), && ( \
 			file_hash="$$$$($(MKHASH) sha256 "$(DL_DIR)/$(FILE)")"; \
-			[ "$$$$file_hash" = "$(MIRROR_HASH)" ] || { \
+			[ "$$$$file_hash" = "$(MIRROR_HASH)" ] || [ "$(MIRROR_HASH)" = "skip" ] || { \
 				echo "Hash mismatch for file $(FILE): expected $(MIRROR_HASH), got $$$$file_hash"; \
 				false; \
 			}; \


### PR DESCRIPTION
In commit 042996b46bd41292ef1fa2d58e3b824a547f4c55 compilation of git repos is made to fail when PKG_MIRROR_HASH is not correct.

It looks like it was forgotten that in openwrt there is a posibility to set the PKG_MIRROR_HASH to "skip". In this case the hash check should not be performed and compilation should continue as expected.

This is especially very usefull when doing local testing and development with git repos.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
