### PR TITLE
wifi-scripts: ucode: fix hostapd_bss_options

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -502,7 +502,7 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 	}
 
 	/* raw options */
-	for (let raw in config.hostapd_options)
+	for (let raw in config.hostapd_bss_options)
 		append_raw(raw);
 
 	if (config.mlo) {


### PR DESCRIPTION
The raw option inside 'config wifi-iface' is called hostapd_bss_options, not hostapd_options.

---
Maintainer: @nbd168 
