### PR TITLE
package: xcrypt: add missing PKG_NAME

### DIFF
--- a/package/libs/xcrypt/libcrypt-compat/Makefile
+++ b/package/libs/xcrypt/libcrypt-compat/Makefile
@@ -1,6 +1,7 @@
 include $(TOPDIR)/rules.mk
 include ../libxcrypt-common.mk
 
+PKG_NAME:=libcrypt-compat
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/libcrypt-compat/$(PKG_SOURCE_NAME)-$(PKG_VERSION)

--- a/package/libs/xcrypt/libxcrypt/Makefile
+++ b/package/libs/xcrypt/libxcrypt/Makefile
@@ -1,6 +1,7 @@
 include $(TOPDIR)/rules.mk
 include ../libxcrypt-common.mk
 
+PKG_NAME:=libxcrypt
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_SOURCE_NAME)-$(PKG_VERSION)


### PR DESCRIPTION
PKG_NAME was lost during package migration from "packages" feed to "main" feed.