### PR TITLE
qualcommax: ipq5018: glinet-gl-b3000: fix dts nvmem macs

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
@@ -88,7 +88,7 @@
 // MAC1 ---SGMII---> QCA8337 SerDes
 &dp2 {
 	status = "okay";
-	nvmem-cells = <&macaddr_dp2>;
+	nvmem-cells = <&macaddr_dp2 0>;
 	nvmem-cell-names = "mac-address";
 
 	fixed-link {
@@ -229,11 +229,8 @@
 			compatible = "qcom,smem-part";
 
 			partition-0-art {
-				compatible = "fixed-partitions";
-				label = "0:ART";
+				label = "0:art";
 				read-only;
-				#address-cells = <1>;
-				#size-cells = <1>;
 
 				nvmem-layout {
 					compatible = "fixed-layout";
@@ -243,7 +240,7 @@
 					macaddr_dp2: macaddr@0 {
 						compatible = "mac-base";
 						#nvmem-cell-cells = <1>;
-						reg = <0x0 0x6>;
+						reg = <0x6 0x6>;
 					};
 				};
 			};


### PR DESCRIPTION
After the latest updates to the nvmem the macs on my board stopped working. All macs displayed the same. After some investigation, it seems  the offset <0x0 0x6> ( from the oem dts)  was incorrect. 

```
 root@OpenWrt:~# cat /proc/mtd                                                                                                                       
dev:    size   erasesize  name                                                                                                                      
mtd0: 00080000 00020000 "0:sbl1"                                                                                                                    
mtd1: 00080000 00020000 "0:mibib"                                                                                                                   
mtd2: 00040000 00020000 "0:bootconfig"                                                                                                              
mtd3: 00100000 00020000 "0:qsee"                                                                                                                    
mtd4: 00040000 00020000 "0:devcfg"                                                                                                                  
mtd5: 00040000 00020000 "0:cdt"                                                                                                                     
mtd6: 00080000 00020000 "0:appsblenv"                                                                                                               
mtd7: 00140000 00020000 "0:appsbl"                                                                                                                  
mtd8: 00100000 00020000 "0:art"                                                                                                                     
mtd9: 00080000 00020000 "0:training"                                                                                                                
mtd10: 00200000 00020000 "cfg"                                                                                                                      
mtd11: 07800000 00020000 "rootfs"

root@OpenWrt:~# hexdump /sys/bus/nvmem/devices/mtd8/nvmem                                                                                        
0000000 ffff ffff ffff 8394 a4c4 21a7 ffff ffff                                                                                                     
0000010 686f 6134 3237 ff31 ffff ffff ffff ffff 
```

As can been seen above, the correct loc/off should be  <0x6 0x6>.   

Tested with proposed changes and confirmed working 
