### PR TITLE
openssl: rework CFLAGS handling on compilation

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -356,34 +356,31 @@ OPENSSL_TARGET:=linux-$(call qstrip,$(CONFIG_ARCH))-openwrt
 
 STAMP_CONFIGURED := $(STAMP_CONFIGURED)_$(shell echo $(OPENSSL_OPTIONS) | $(MKHASH) md5)
 
+TARGET_CFLAGS += $(FPIC)
+
 define Build/Configure
 	(cd $(PKG_BUILD_DIR); \
+		CFLAGS="$(TARGET_CFLAGS)" \
+		CPPFLAGS="$(TARGET_CPPFLAGS)" \
+		LDFLAGS="$(TARGET_LDFLAGS)" \
 		./Configure $(OPENSSL_TARGET) \
 			--prefix=/usr \
 			--libdir=lib \
 			--openssldir=/etc/ssl \
 			--cross-compile-prefix="$(TARGET_CROSS)" \
-			$(TARGET_CFLAGS) \
-			$(TARGET_CPPFLAGS) \
-			$(TARGET_LDFLAGS) \
 			$(OPENSSL_OPTIONS) && \
 		{ [ -f $(STAMP_CONFIGURED) ] || make clean; } \
 	)
 endef
 
-TARGET_CFLAGS += $(FPIC)
-
 define Build/Compile
 	+$(MAKE) $(PKG_JOBS) -C $(PKG_BUILD_DIR) \
 		CC="$(TARGET_CC)" \
 		SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
-		OPENWRT_OPTIMIZATION_FLAGS="$(TARGET_CFLAGS)" \
-		$(OPENSSL_MAKEFLAGS) \
 		all
 	$(MAKE) -C $(PKG_BUILD_DIR) \
 		CC="$(TARGET_CC)" \
 		DESTDIR="$(PKG_INSTALL_DIR)" \
-		$(OPENSSL_MAKEFLAGS) \
 		install_sw install_ssldirs
 endef
 

--- a/package/libs/openssl/patches/110-openwrt_targets.patch
+++ b/package/libs/openssl/patches/110-openwrt_targets.patch
@@ -9,63 +9,59 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
 --- /dev/null
 +++ b/Configurations/25-openwrt.conf
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,55 @@
 +## Openwrt "CONFIG_ARCH" matching targets.
 +
 +# The targets need to end in '-openwrt' for the AFALG patch to work
 +
 +my %targets = (
-+    "openwrt" => {
-+	template	=> 1,
-+	CFLAGS		=> add("\$(OPENWRT_OPTIMIZATION_FLAGS)"),
-+    },
 +    "linux-aarch64-openwrt" => {
-+        inherit_from    => [ "linux-aarch64", "openwrt" ],
++        inherit_from    => [ "linux-aarch64" ],
 +    },
 +    "linux-arc-openwrt" => {
-+        inherit_from    => [ "linux-latomic", "openwrt" ],
++        inherit_from    => [ "linux-latomic" ],
 +    },
 +    "linux-arm-openwrt" => {
-+        inherit_from    => [ "linux-armv4", "openwrt" ],
++        inherit_from    => [ "linux-armv4" ],
 +    },
 +    "linux-armeb-openwrt" => {
-+        inherit_from    => [ "linux-armv4", "openwrt" ],
++        inherit_from    => [ "linux-armv4" ],
 +    },
 +    "linux-i386-openwrt" => {
-+        inherit_from    => [ "linux-x86", "openwrt" ],
++        inherit_from    => [ "linux-x86" ],
 +    },
 +    "linux-loongarch64-openwrt" => {
-+        inherit_from    => [ "linux64-loongarch64", "openwrt" ],
++        inherit_from    => [ "linux64-loongarch64" ],
 +    },
 +    "linux-mips-openwrt" => {
-+        inherit_from    => [ "linux-mips32", "openwrt" ],
++        inherit_from    => [ "linux-mips32" ],
 +    },
 +    "linux-mips64-openwrt" => {
-+        inherit_from    => [ "linux64-mips64", "openwrt" ],
++        inherit_from    => [ "linux64-mips64" ],
 +    },
 +    "linux-mips64el-openwrt" => {
-+        inherit_from    => [ "linux64-mips64", "openwrt" ],
++        inherit_from    => [ "linux64-mips64" ],
 +    },
 +    "linux-mipsel-openwrt" => {
-+        inherit_from    => [ "linux-mips32", "openwrt" ],
++        inherit_from    => [ "linux-mips32" ],
 +    },
 +    "linux-powerpc-openwrt" => {
-+        inherit_from    => [ "linux-ppc", "openwrt" ],
++        inherit_from    => [ "linux-ppc" ],
 +    },
 +    "linux-powerpc64-openwrt" => {
-+        inherit_from    => [ "linux-ppc64", "openwrt" ],
++        inherit_from    => [ "linux-ppc64" ],
 +        perlasm_scheme  => "linux64v2",
 +    },
 +    "linux-riscv64-openwrt" => {
-+        inherit_from    => [ "linux-generic64", "openwrt" ],
++        inherit_from    => [ "linux-generic64" ],
 +        perlasm_scheme   => "linux64",
 +    },
 +    "linux-x86_64-openwrt" => {
-+        inherit_from    => [ "linux-x86_64", "openwrt" ],
++        inherit_from    => [ "linux-x86_64" ],
 +    },
 +
 +### Basic default option
 +    "linux-generic32-openwrt" => {
-+        inherit_from    => [ "linux-generic32", "openwrt" ],
++        inherit_from    => [ "linux-generic32" ],
 +    },
 +);


### PR DESCRIPTION
This mainly improve the CFLAGS handling on compilation of OpenSSL.

The CFLAGS are currently passed 2 times generating compilation warning due to -fhonour-copts passed 2 times.

This can be improved by passing the CFLAGS as env to the OpenSSL Configure tool.

For consistency we do the same for CPPFLAGS and LDFLAGS.

This permits to drop redundant flags in the Compile phase and from the .conf file.

---

@cotequeiroz can you check this simple pr?