### PR TITLE
wifi-scripts: allow disabling automatic wifi-iface generation via board.json

### DIFF
--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -689,6 +689,16 @@ ucidef_set_country() {
 	json_select ..
 }
 
+ucidef_set_wireless_generate_ifaces() {
+	local generate="$1"
+
+	json_select_object wlan
+		json_select_object defaults
+			json_add_boolean generate_ifaces "$generate"
+		json_select ..
+	json_select ..
+}
+
 ucidef_set_wireless_mac_count() {
 	local band="$1"
 	local mac_count="$2"

--- a/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
+++ b/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
@@ -78,12 +78,18 @@ for (let phy_name, phy in board.wlan) {
 
 		band_name = lc(band_name);
 
+		let generate_ifaces = true;
 		let country, defaults, num_global_macaddr;
 		if (board.wlan.defaults) {
 			defaults = board.wlan.defaults.ssids?.[band_name]?.ssid ? board.wlan.defaults.ssids?.[band_name] : board.wlan.defaults.ssids?.all;
 			country = board.wlan.defaults.country;
 			if (!country && band_name != '2g')
 				defaults = null;
+
+			generate_ifaces = board.wlan.defaults.generate_ifaces !== false;
+			if (!generate_ifaces)
+				defaults = null;
+
 			num_global_macaddr = board.wlan.defaults.ssids?.[band_name]?.mac_count;
 		}
 
@@ -100,7 +106,10 @@ set ${s}.country='${country || ''}'
 set ${s}.num_global_macaddr='${num_global_macaddr || ''}'
 set ${s}.disabled='${defaults ? 0 : 1}'
 
-set ${si}=wifi-iface
+`);
+
+		if (generate_ifaces){
+			print(`set ${si}=wifi-iface
 set ${si}.device='${name}'
 set ${si}.network='lan'
 set ${si}.mode='ap'
@@ -109,6 +118,7 @@ set ${si}.encryption='${defaults?.encryption || "none"}'
 set ${si}.key='${defaults?.key || ""}'
 
 `);
+		}
 		config[name] = {};
 		commit = true;
 	}


### PR DESCRIPTION
Currently, for every wifi device a corresponding wifi-device and wifi-iface section is created.
This PR adds the ability to disable automatic wifi-iface generation through board.json.

Can you have a look at this, please, @blogic 
