### PR TITLE
odhcpd: update opts

### DIFF
--- a/package/network/services/odhcpd/Makefile
+++ b/package/network/services/odhcpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcpd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcpd.git

--- a/package/network/services/odhcpd/Makefile
+++ b/package/network/services/odhcpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcpd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcpd.git

--- a/package/network/services/odhcpd/Makefile
+++ b/package/network/services/odhcpd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcpd
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcpd.git
@@ -19,7 +19,6 @@ PKG_SOURCE_VERSION:=d44af6dd8f4e1dd0d858ae19419057ab4f319310
 PKG_MAINTAINER:=Hans Dedecker <dedeckeh@gmail.com>
 PKG_LICENSE:=GPL-2.0
 
-PKG_CONFIG_DEPENDS:=CONFIG_PACKAGE_odhcpd_$(BUILD_VARIANT)_ext_cer_id
 PKG_ASLR_PIE_REGULAR:=1
 
 include $(INCLUDE_DIR)/package.mk
@@ -38,27 +37,14 @@ define Package/odhcpd/default/description
  requirements for IPv6 home routers.
 endef
 
-define Package/odhcpd/default/config
-menu "Configuration"
-	depends on PACKAGE_$(1)
-
-config PACKAGE_odhcpd_$(2)_ext_cer_id
-	int
-	default 0
-	prompt "CER-ID Extension ID (0 = disabled)"
-endmenu
-endef
-
 define Package/odhcpd
-  $(call Package/odhcpd/default)
+  $(Package/odhcpd/default)
   TITLE += and DHCPv4 server
   VARIANT:=full
 endef
 
-Package/odhcpd/config=$(call Package/odhcpd/default/config,odhcpd,full)
-
 define Package/odhcpd/description
- $(call Package/odhcpd/default/description)
+ $(Package/odhcpd/default/description)
 
  This is a variant providing server services for DHCPv4, RA, stateless and
  stateful DHCPv6,  prefix delegation and can be used to relay RA, DHCPv6 and
@@ -67,15 +53,13 @@ define Package/odhcpd/description
 endef
 
 define Package/odhcpd-ipv6only
-  $(call Package/odhcpd/default)
+  $(Package/odhcpd/default)
   VARIANT:=ipv6only
   DEPENDS+= @IPV6
 endef
 
-Package/odhcpd-ipv6only/config=$(call Package/odhcpd/default/config,odhcpd-ipv6only,ipv6only)
-
 define Package/odhcpd-ipv6only/description
- $(call Package/odhcpd/default/description)
+ $(Package/odhcpd/default/description)
 
  This is a variant providing server services for RA, stateless and stateful
  DHCPv6,  prefix delegation and can be used to relay RA, DHCPv6 and NDP between
@@ -86,10 +70,6 @@ CMAKE_OPTIONS += -DUBUS=1
 
 ifeq ($(BUILD_VARIANT),full)
   CMAKE_OPTIONS += -DDHCPV4_SUPPORT=1
-endif
-
-ifneq ($(CONFIG_PACKAGE_odhcpd_$(BUILD_VARIANT)_ext_cer_id),0)
-  CMAKE_OPTIONS += -DEXT_CER_ID=$(CONFIG_PACKAGE_odhcpd_$(BUILD_VARIANT)_ext_cer_id)
 endif
 
 define Package/odhcpd/install

--- a/package/network/services/odhcpd/Makefile
+++ b/package/network/services/odhcpd/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2015 OpenWrt.org
+# Copyright (C) 2013-2025 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcpd
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcpd.git
@@ -27,7 +27,6 @@ include $(INCLUDE_DIR)/cmake.mk
 define Package/odhcpd/default
   SECTION:=net
   CATEGORY:=Network
-  TITLE:=OpenWrt DHCPv6(-PD)/RA Server & Relay
   DEPENDS:=+libjson-c +libubox +libuci +libubus +libnl-tiny
 endef
 
@@ -39,31 +38,31 @@ endef
 
 define Package/odhcpd
   $(Package/odhcpd/default)
-  TITLE += and DHCPv4 server
+  TITLE:=OpenWrt DHCPv4/DHCPv6/NDP/RA server
   VARIANT:=full
 endef
 
 define Package/odhcpd/description
  $(Package/odhcpd/default/description)
 
- This is a variant providing server services for DHCPv4, RA, stateless and
- stateful DHCPv6,  prefix delegation and can be used to relay RA, DHCPv6 and
- NDP between routed (non-bridged) interfaces in case no delegated prefixes
- are available.
+ This is a variant with support for RA, DHCPv4 and DHCPv6. It can also be used
+ to relay RA, DHCPv6 and NDP messages between routed (non-bridged) interfaces
+ in case no delegated prefixes are available.
 endef
 
 define Package/odhcpd-ipv6only
   $(Package/odhcpd/default)
+  TITLE:=OpenWrt DHCPv6/NDP/RA server (without DHCPv4)
   VARIANT:=ipv6only
-  DEPENDS+= @IPV6
+  DEPENDS+=@IPV6
 endef
 
 define Package/odhcpd-ipv6only/description
  $(Package/odhcpd/default/description)
 
- This is a variant providing server services for RA, stateless and stateful
- DHCPv6,  prefix delegation and can be used to relay RA, DHCPv6 and NDP between
- routed (non-bridged) interfaces in case no delegated prefixes are available.
+ This is a variant with support for RA and DHCPv6. It can also be used to
+ relay RA, DHCPv6 and NDP messages between routed (non-bridged) interfaces
+ in case no delegated prefixes are available.
 endef
 
 CMAKE_OPTIONS += -DUBUS=1

--- a/package/network/services/odhcpd/files/odhcpd.defaults
+++ b/package/network/services/odhcpd/files/odhcpd.defaults
@@ -1,11 +1,20 @@
 #!/bin/sh
 
 if [ -n "$(uci -q get dhcp.odhcpd)" ]; then
+	local commit
+	commit=0
+
 	if [ -z "$(uci -q get dhcp.odhcpd.piofolder)" ]; then
 		uci set dhcp.odhcpd.piofolder=/tmp/odhcpd-piofolder
-		uci commit dhcp
+		commit=1
 	fi
 
+	if [ -n "$(uci -q get dhcp.odhcpd.legacy)" ]; then
+		uci delete dhcp.odhcpd.legacy
+		commit=1
+	fi
+
+	[ "$commit" -eq 1 ] && uci commit dhcp
 	exit 0
 fi
 
@@ -34,7 +43,7 @@ case "$protocol" in
 	;;
 esac
 
-uci get dhcp.lan 1>/dev/null 2>/dev/null || {
+uci -q get dhcp.lan || {
 uci batch <<EOF
 set dhcp.lan=dhcp
 set dhcp.lan.interface='lan'

--- a/package/network/services/odhcpd/files/odhcpd.init
+++ b/package/network/services/odhcpd/files/odhcpd.init
@@ -17,6 +17,5 @@ reload_service() {
 
 service_triggers()
 {
-	procd_add_reload_trigger "dhcp"
+	procd_add_reload_trigger "dhcp" "network" "system"
 }
-


### PR DESCRIPTION
This PR removes some of the options that have been removed in `odhcpd` from the Makefiles, and also updates the defaults to reflect recent changes.

Haven't build-tested it yet, so draft for now.