### PR TITLE
base-files: fix setting brightness on 'smart' LEDs

### DIFF
--- a/package/base-files/files/etc/init.d/led
+++ b/package/base-files/files/etc/init.d/led
@@ -103,6 +103,10 @@ load_led() {
 		}
 		printf "\n" >> /var/run/led.state
 
+		# in most LEDs with i.e. 8-bit brightness, brightness should be set for all triggers
+		[ $(cat /sys/class/leds/${sysfs}/max_brightness) -gt 1 ] &&
+			default=1
+
 		[ "$default" = 0 ] &&
 			echo 0 >/sys/class/leds/${sysfs}/brightness
 


### PR DESCRIPTION
This is very much up for debate.

Until now the default behaviour has been to set LED brightness to `0` regardless of the trigger unless `option default '1'` is specified.

However I looked at multiple LED triggers in Linux and all of those either use initial brightness to determine blink brightness (maximum if set to `0`) or they ignore it altogether.

What are the cases where we actually need to explicitly set brightness to `0` before setting a trigger?

This implementation by default preserves the configured brightness only for LEDs with 'non-binary' brightness (usually RGB LEDs). That's really the only case where it's noticeable because they use the maximum brightness if  `option default '1'` is not specified.

If this won't cause issues in general, it might be worth it to implicitly preserve configured brightness for other LEDs as well, and maybe add a different option that would set brightness to `0` only if truly needed.

What do you think?

Thanks for your feedback