### PR TITLE
build: Add support for linking with DT_RELR

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -383,6 +383,15 @@ menu "Global build settings"
 			bool "Full"
 	endchoice
 
+	config PKG_DT_RELR
+		bool "Link with relative relocations (RELR)"
+		depends on (aarch64 || i386 || loongarch64 || x86_64)
+		default y
+		help
+		  Link all applications with -Wl,-z,pack-relative-relocs.
+		  This will reduce the size of many applications.
+		  This is only supported on a limited number of architectures.
+
 	config TARGET_ROOTFS_SECURITY_LABELS
 		bool
 		select KERNEL_SQUASHFS_XATTR

--- a/include/hardening.mk
+++ b/include/hardening.mk
@@ -8,6 +8,7 @@ PKG_ASLR_PIE_REGULAR ?= 0
 PKG_SSP ?= 1
 PKG_FORTIFY_SOURCE ?= 1
 PKG_RELRO ?= 1
+PKG_DT_RELR ?= 1
 
 ifdef CONFIG_PKG_CHECK_FORMAT_SECURITY
   ifeq ($(strip $(PKG_CHECK_FORMAT_SECURITY)),1)
@@ -66,6 +67,13 @@ ifdef CONFIG_PKG_RELRO_FULL
   ifeq ($(strip $(PKG_RELRO)),1)
     TARGET_CFLAGS += -Wl,-z,now -Wl,-z,relro
     TARGET_LDFLAGS += -znow -zrelro
+  endif
+endif
+
+ifdef CONFIG_PKG_DT_RELR
+  ifeq ($(strip $(PKG_DT_RELR)),1)
+    TARGET_CFLAGS += -Wl,-z,pack-relative-relocs
+    TARGET_LDFLAGS += -zpack-relative-relocs
   endif
 endif
 


### PR DESCRIPTION
This adds the -Wl,-z,pack-relative-relocs linking options. This reduces the size of some binaries.

This is only supported on i386, x86_64, aarch64 and loongarch64 in binutils. This feature is not support for MIPS.

musl libc supports it since version 1.2.4 .
glibc supports it since version 2.36.
binutils ld supports it since version 2.38 for x86 and since version 2.43 for LoongArch.

---

I will do some more testing and measure how much memory we can save with this setting. 
Maybe we can active this also by default.
It looks like we are not providing LDFLAGS to all linker operations, I will look into this for the main packages.

You can check like this if the flag s working:
```
[hauke@hauke-p14s openwrt]$ readelf -d staging_dir/target-aarch64_generic_musl/root-armsr/usr/lib/libucode.so.20230711 |grep RELR
 0x0000000000000024 (RELR)               0x4230
 0x0000000000000023 (RELRSZ)             136 (bytes)
 0x0000000000000025 (RELRENT)            8 (bytes)
```

See here for more details: https://maskray.me/blog/2021-10-31-relative-relocations-and-relr
Arch Linux RFC is here: https://rfc.archlinux.page/0023-pack-relative-relocs/