### PR TITLE
mediatek: update Bananapi BPi-R4 Lite support

### DIFF
--- a/target/linux/mediatek/dts/mt7987.dtsi
+++ b/target/linux/mediatek/dts/mt7987.dtsi
@@ -13,7 +13,6 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/thermal/thermal.h>
 #include <dt-bindings/reset/mediatek,mt7987-resets.h>
-#include <dt-bindings/regulator/richtek,rt5190a-regulator.h>
 
 /* TOPRGU resets */
 #define MT7987_TOPRGU_SGMII0_GRST		1
@@ -45,7 +44,6 @@
 		optee {
 			method = "smc";
 			compatible = "linaro,optee-tz";
-			status = "okay";
 		};
 	};
 
@@ -237,7 +235,7 @@
 
 	fan: pwm-fan {
 		compatible = "pwm-fan";
-		cooling-levels = <0 128 255>;
+		cooling-levels = <0 128 192 255>;
 		#cooling-cells = <2>;
 		#thermal-sensor-cells = <1>;
 		status = "disabled";
@@ -1001,9 +999,6 @@
 				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
-			};
-			slot1: pcie@0,0 {
-				reg = <0x0000 0 0 0 0>;
 			};
 		};
 

--- a/target/linux/mediatek/dts/mt7987.dtsi
+++ b/target/linux/mediatek/dts/mt7987.dtsi
@@ -858,9 +858,10 @@
 				      "dma_ck";
 			#address-cells = <2>;
 			#size-cells = <2>;
-			phys = <&tphyu2port0 PHY_TYPE_USB2>;
+			mediatek,u3p-dis-msk = <0x0>;
+			phys = <&tphyu2port0 PHY_TYPE_USB2>,
+			       <&tphyu3port0 PHY_TYPE_USB3>;
 			usb2-lpm-disable;
-			mediatek,u3p-dis-msk=<1>;
 			status = "disabled";
 		};
 

--- a/target/linux/mediatek/dts/mt7987a-bananapi-bpi-r4-lite.dts
+++ b/target/linux/mediatek/dts/mt7987a-bananapi-bpi-r4-lite.dts
@@ -244,10 +244,23 @@
 	};
 };
 
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	status = "okay";
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_pins>;
+	status = "disabled";
+};
+
 &ssusb {
 	mediatek,u3p-dis-msk=<0>;
 	phys = <&tphyu2port0 PHY_TYPE_USB2>,
 	       <&tphyu3port0 PHY_TYPE_USB3>;
+	status = "okay";
 
 	/*
 	 * VIA VL817 USB3.1/USB2.0 hub
@@ -310,6 +323,12 @@
 };
 
 &tphyu3port0 {
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
 	status = "okay";
 };
 

--- a/target/linux/mediatek/dts/mt7987a-bananapi-bpi-r4-lite.dts
+++ b/target/linux/mediatek/dts/mt7987a-bananapi-bpi-r4-lite.dts
@@ -257,9 +257,6 @@
 };
 
 &ssusb {
-	mediatek,u3p-dis-msk=<0>;
-	phys = <&tphyu2port0 PHY_TYPE_USB2>,
-	       <&tphyu3port0 PHY_TYPE_USB3>;
 	status = "okay";
 
 	/*

--- a/target/linux/mediatek/dts/mt7987a-bananapi-bpi-r4-lite.dts
+++ b/target/linux/mediatek/dts/mt7987a-bananapi-bpi-r4-lite.dts
@@ -11,7 +11,7 @@
 #include "mt7987a-bananapi-bpi-r4-lite-mikrobus.dtsi"
 
 / {
-	model = "Bananapi BPI-R4-LITE";
+	model = "BananaPi BPI-R4 Lite";
 	compatible = "bananapi,bpi-r4-lite",
 		     "mediatek,mt7987a", "mediatek,mt7987";
 
@@ -23,10 +23,10 @@
 		i2c2 = &imux1_sfp;
 		i2c3 = &imux2_MikroBus;
 		i2c4 = &imux3;
-		led-boot = &sys_led_blue;
-		led-failsafe = &sys_led_blue;
-		led-running = &sys_led_blue;
-		led-upgrade = &sys_led_blue;
+		led-boot = &act_led;
+		led-failsafe = &act_led;
+		led-running = &act_led;
+		led-upgrade = &act_led;
 		serial0 = &uart0;
 	};
 
@@ -58,24 +58,22 @@
 		compatible = "gpio-leds";
 
 		sfp-led {
-			gpios = <&pca9555 11 GPIO_ACTIVE_LOW>;
 			function = "sfp";
 			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pca9555 11 GPIO_ACTIVE_LOW>;
 		};
 	};
 
 	pwm-leds {
 		compatible = "pwm-leds";
-		status = "okay";
 
 		/* ACT LED on bpi-r4-lite */
-		sys_led_blue: sys-led {
+		act_led: act-led {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_STATUS;
-			pwms = <&pwm 0 50000>;
+			pwms = <&pwm 0 50000 0>;
 			max-brightness = <255>;
-			active-high;
-			linux,default-trigger = "default-on";
+			default-state = "on";
 		};
 	};
 
@@ -106,22 +104,19 @@
 		regulator-min-microvolt = <5000000>;
 		regulator-max-microvolt = <5000000>;
 		gpio = <&pca9555 9 GPIO_ACTIVE_HIGH>;
-	};
-
-	usb-vbus-regulator {
-		compatible = "regulator-output";
-		vout-supply = <&reg_usb_5v>;
+		enable-active-high;
 	};
 };
 
 &fan {
-	pwms = <&pwm 2 50000>;
+	pwms = <&pwm 2 50000 0>;
 	status = "okay";
 };
 
 &gmac0 {
 	phy-mode = "2500base-x";
 	status = "okay";
+
 	fixed-link {
 		speed = <2500>;
 		full-duplex;
@@ -130,27 +125,10 @@
 };
 
 &gmac1 {
+	openwrt,netdev-name = "wan";
 	phy-mode = "internal";
 	phy-handle = <&phy15>;
 	status = "okay";
-};
-
-&pwm {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pwm_pins>;
-	status = "okay";
-};
-
-&pwm_pins {
-	mux {
-		/*
-		 * - pwm0   : PWM0@PIN13
-		 * - pwm1_0 : PWM@PIN7  (share with JTAG)
-		 * - pwm2_0 : PWM2@PIN12 (share with PCM)
-		 */
-		function = "pwm";
-		groups = "pwm0", "pwm1_0", "pwm2_0";
-	};
 };
 
 &i2c0 {
@@ -161,6 +139,7 @@
 	pca9545@70 {
 		compatible = "nxp,pca9545";
 		reg = <0x70>;
+		vdd-supply = <&reg_3p3v>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 
@@ -180,6 +159,7 @@
 				address-bits = <8>;
 				page-size = <8>;
 				size = <256>;
+				vcc-supply = <&reg_3p3v>;
 			};
 		};
 
@@ -202,18 +182,19 @@
 
 			pca9555: i2c-gpio-expander@20 {
 				compatible = "nxp,pca9555";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <2>;
 				interrupt-controller;
 				interrupt-parent = <&pio>;
 				interrupts = <2 IRQ_TYPE_LEVEL_LOW>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				reg = <0x20>;
+				vcc-supply = <&reg_3p3v>;
 			};
 
-			wifi_eeprom@50 {
+			/* on the Wi-Fi card */
+			eeprom@50 {
 				compatible = "atmel,24c02";
 				reg = <0x50>;
-				wp-gpios = <&pca9555 10 GPIO_ACTIVE_LOW>;
 				address-bits = <8>;
 				page-size = <8>;
 				size = <256>;
@@ -225,14 +206,13 @@
 &mdio {
 	/* built-in 2.5G Ethernet PHY */
 	phy15: phy@15 {
-		pinctrl-names = "i2p5gbe-led";
-		pinctrl-0 = <&i2p5gbe_led0_pins>;
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <15>;
-		phy-mode = "internal";
+		pinctrl-names = "i2p5gbe-led";
+		pinctrl-0 = <&i2p5gbe_led0_pins>;
 	};
 
-	switch31: switch@31 {
+	switch: switch@31 {
 		compatible = "mediatek,mt7531";
 		reg = <31>;
 		reset-gpios = <&pio 42 GPIO_ACTIVE_HIGH>;
@@ -240,7 +220,6 @@
 		#interrupt-cells = <1>;
 		interrupt-parent = <&pio>;
 		interrupts = <41 IRQ_TYPE_LEVEL_HIGH>;
-		status = "okay";
 	};
 };
 
@@ -256,7 +235,33 @@
 	status = "disabled";
 };
 
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_pins>;
+	status = "okay";
+};
+
+&pwm_pins {
+	mux {
+		/*
+		 * - pwm0   : PWM0@PIN13
+		 * - pwm1_0 : PWM@PIN7  (share with JTAG)
+		 * - pwm2_0 : PWM2@PIN12 (share with PCM)
+		 */
+		function = "pwm";
+		groups = "pwm0", "pwm1_0", "pwm2_0";
+	};
+};
+
+&spi2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi2_flash_pins>;
+	status = "okay";
+};
+
 &ssusb {
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_usb_5v>;
 	status = "okay";
 
 	/*
@@ -271,37 +276,38 @@
 	// reset-gpios = <&pca9555 8 GPIO_ACTIVE_HIGH>;
 };
 
-&switch31 {
+&switch {
 	ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 
 		port@0 {
 			reg = <0>;
-			label = "lan0";
+			label = "lan1";
 		};
 
 		port@1 {
 			reg = <1>;
-			label = "lan1";
+			label = "lan2";
 		};
 
 		port@2 {
 			reg = <2>;
-			label = "lan2";
+			label = "lan3";
 		};
 
 		port@3 {
 			reg = <3>;
-			label = "lan3";
+			label = "lan4";
 		};
 
 		port@5 {
 			reg = <5>;
-			label = "sfp0";
-			phy-mode = "2500base-x";
+			label = "sfp";
 			sfp = <&sfp>;
+			phy-mode = "2500base-x";
 			managed = "in-band-status";
+			openwrt,netdev-name = "sfp-lan";
 		};
 
 		port@6 {
@@ -326,12 +332,5 @@
 &uart0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&uart0_pins>;
-	status = "okay";
-};
-
-&spi2 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&spi2_flash_pins>;
-
 	status = "okay";
 };

--- a/target/linux/mediatek/dts/mt7987a-rfb-eth2-usb.dtso
+++ b/target/linux/mediatek/dts/mt7987a-rfb-eth2-usb.dtso
@@ -16,10 +16,8 @@
 	fragment@1 {
 		target-path = "/soc/usb@11200000";
 		__overlay__ {
-			phys = <&tphyu2port0 PHY_TYPE_USB2>,
-			       <&tphyu3port0 PHY_TYPE_USB3>;
-			mediatek,u3p-dis-msk=<0>;
+			mediatek,u3p-dis-msk = <0x1>;
+			phys = <&tphyu2port0 PHY_TYPE_USB2>;
 		};
 	};
 };
-

--- a/target/linux/mediatek/dts/mt7987a-rfb.dts
+++ b/target/linux/mediatek/dts/mt7987a-rfb.dts
@@ -81,7 +81,39 @@
 	};
 };
 
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+};
+
 &fan {
 	pwms = <&pwm 0 50000 0>;
 	status = "disabled";
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	status = "okay";
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_pins>;
+	status = "disabled";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&ssusb {
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
 };

--- a/target/linux/mediatek/dts/mt7987a.dtsi
+++ b/target/linux/mediatek/dts/mt7987a.dtsi
@@ -14,16 +14,9 @@
 	memory {
 		reg = <0 0x40000000 0 0x10000000>;
 	};
-
 };
 
 &boottrap {
-	status = "okay";
-};
-
-&i2c0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&i2c0_pins>;
 	status = "okay";
 };
 
@@ -35,36 +28,10 @@
 	status = "okay";
 };
 
-&pcie0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pcie0_pins>;
-	status = "okay";
-};
-
-&pcie1 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pcie1_pins>;
-	status = "disabled";
-};
-
-&pwm {
-	status = "okay";
-};
-
 &trng {
 	status = "okay";
 };
 
-&uart0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&uart0_pins>;
-	status = "okay";
-};
-
 &watchdog {
-	status = "okay";
-};
-
-&ssusb {
 	status = "okay";
 };

--- a/target/linux/mediatek/dts/mt7987b.dtsi
+++ b/target/linux/mediatek/dts/mt7987b.dtsi
@@ -6,7 +6,6 @@
 
 /dts-v1/;
 #include "mt7987a.dtsi"
-#include "mt7987-netsys-eth2-usb.dtsi"
 
 / {
 	compatible = "mediatek,mt7987b", "mediatek,mt7987";
@@ -28,4 +27,12 @@
 					 <&cpu1 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
 		};
 	};
+};
+
+&lvts {
+	status = "okay";
+};
+
+&trng {
+	status = "okay";
 };

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -94,7 +94,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 sfp-lan" "wan sfp-wan"
 		;;
 	bananapi,bpi-r4-lite)
-		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 sfp0" "eth1"
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp-lan" wan
 		;;
 	bananapi,bpi-r4-2g5|\
 	bananapi,bpi-r4-poe)
@@ -206,7 +206,8 @@ mediatek_setup_macs()
 		;;
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\
-	bananapi,bpi-r4)
+	bananapi,bpi-r4|\
+	bananapi,bpi-r4-lite)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
 		;;
 	h3c,magic-nx30-pro)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -668,9 +668,8 @@ define Device/bananapi_bpi-r4-lite
   DEVICE_DTC_FLAGS := --pad 4096
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTS_LOADADDR := 0x4ff00000
-  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-eeprom-at24 \
-		     kmod-gpio-pca953x kmod-i2c-mux-pca954x kmod-rtc-pcf8563 \
-		     kmod-sfp e2fsprogs mkf2fs
+  DEVICE_PACKAGES := kmod-eeprom-at24 kmod-gpio-pca953x kmod-i2c-mux-pca954x \
+		     kmod-rtc-pcf8563 kmod-sfp kmod-usb3 e2fsprogs mkf2fs mt7987-2p5g-phy-firmware
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   KERNEL_IN_UBI := 1


### PR DESCRIPTION
Fixed bug/warning reports when running on BPi-R4 Lite:
```
[    2.868654] xhci-mtk 11200000.usb: supply vbus not found, using dummy regulator
[    2.876087] xhci-mtk 11200000.usb: supply vusb33 not found, using dummy regulator
[    9.026739] pca954x 0-0070: supply vdd not found, using dummy regulator
[    9.063146] pca953x 4-0020: supply vcc not found, using dummy regulator
[    9.127124] at24 1-0057: supply vcc not found, using dummy regulator
[    9.141353] at24 4-0050: supply vcc not found, using dummy regulator
[    9.220612] thermal thermal_zone0: binding cdev pwm-fan to trip 3 failed: -22
```
Update network port names based on the [shell image](https://docs.banana-pi.org/bpi-r4_lite/banana_pi_bpi-r4_lite_case_1.png)

The wp-gpios in eeprom has been temporarily removed, it should be active high?
And it was placed in the wrong position. (Connect to 1-0057 instead of 4-0050)