### PR TITLE
qualcommax: ipq50xx: Add support for CMCC PZ-L8

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
@@ -8,6 +8,7 @@ touch /etc/config/ubootenv
 board=$(board_name)
 
 case "$board" in
+cmcc,pz-l8|\
 elecom,wrc-x3000gs2|\
 iodata,wn-dax3000gr)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-pz-l8.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-pz-l8.dts
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq5018.dtsi"
+#include "ipq5018-ess.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "CMCC PZ-L8";
+	compatible = "cmcc,pz-l8", "qcom,ipq5018";
+
+	aliases {
+		serial0 = &blsp1_uart1;
+		led-boot = &led_wan;
+		led-failsafe = &led_lan;
+		led-running = &led_wan;
+		led-upgrade = &led_lan;
+		label-mac-device = <&dp1>;
+	};
+
+	chosen {
+		bootargs-append = " root=/dev/ubiblock0_1 swiotlb=1 coherent_pool=2M";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset-button {
+			label = "reset";
+			gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps";
+			gpios = <&tlmm 34 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		led_wan: led-0 {
+			gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			default-state = "off";
+		};
+
+		led_lan: led-1 {
+			gpios = <&tlmm 30 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_LAN;
+		};
+	};
+
+	reserved-memory {
+		q6_mem_regions: q6_mem_regions@4b000000 {
+			no-map;
+			reg = <0x0 0x4b000000 0x0 0x3000000>;
+			status = "disabled";
+		};
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&xo_board_clk {
+	clock-div = <4>;
+	clock-mult = <1>;
+};
+
+&blsp1_uart1 {
+	status = "okay";
+
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qfprom {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	pinctrl-0 = <&qpic_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		nand-ecc-engine = <&qpic_nand>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+
+			partition-art {
+				label = "0:art";
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					hw_mac_addr: mac-address@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
+
+	qcom,port_phyinfo {
+		// MAC0 -> GE Phy --- MDI --- QCA8337 Phy4(Port5)
+		port@0 {
+			port_id = <1>;
+			mdiobus = <&mdio0>;
+			phy_address = <7>;
+		};
+
+		// MAC1 -> Uniphy --- SGMII --- QCA8337 SerDes(Port6)
+		port@1 {
+			port_id = <2>;
+			mdiobus = <&mdio1>;
+			forced-speed = <1000>;
+			forced-duplex = <1>;
+		};
+	};
+};
+
+// MAC0 -> GE Phy
+&dp1 {
+	status = "okay";
+
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+// MAC1 -> SGMII
+&dp2 {
+	status = "okay";
+
+	nvmem-cells = <&hw_mac_addr 1>;
+	nvmem-cell-names = "mac-address";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+// MAC0 -> GE Phy -> QCA8337 Phy4
+&ge_phy {
+	qcom,dac-preset-short-cable;
+};
+
+&mdio1 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio1_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 26 GPIO_ACTIVE_LOW>;
+
+	// QCA8337 Phy0 -> LAN3
+	qca8337_0: ethernet-phy@0 {
+		reg = <0>;
+	};
+
+	// QCA8337 Phy1 -> LAN2
+	qca8337_1: ethernet-phy@1 {
+		reg = <1>;
+	};
+
+	// QCA8337 Phy2 -> LAN1
+	qca8337_2: ethernet-phy@2 {
+		reg = <2>;
+	};
+
+	// QCA8337 Phy3 -> WAN
+	qca8337_3: ethernet-phy@3 {
+		reg = <3>;
+	};
+
+	// QCA8337 Phy4 -> IPQ5018 GE Phy
+	qca8337_4: ethernet-phy@4 {
+		reg = <4>;
+	};
+
+	// QCA8337 switch
+	switch1: ethernet-switch@17 {
+		compatible = "qca,qca8337";
+		reg = <17>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@1 {
+				reg = <1>;
+				label = "lan3";
+				phy-handle = <&qca8337_0>;
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+				phy-handle = <&qca8337_1>;
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan1";
+				phy-handle = <&qca8337_2>;
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "wan";
+				phy-handle = <&qca8337_3>;
+			};
+
+			/*
+			 * WAN cannot work if added
+			 * port@5 {
+			 * 	reg = <5>;
+			 * 	phy-handle = <&qca8337_4>;
+			 * 	phy-mode = "gmii";
+			 * 	ethernet = <&dp1>;
+			 * };
+			 */
+
+			port@6 {
+				reg = <6>;
+				phy-mode = "sgmii";
+				ethernet = <&dp2>;
+				qca,sgmii-enable-pll;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		button-pins {
+			pins = "gpio34", "gpio33";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+	};
+
+	led_pins: led-state {
+		pins = "gpio35", "gpio30";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	mdio1_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio36";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio37";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	qpic_pins: qpic-state {
+		clock-pins {
+			pins = "gpio9";
+			function = "qspi_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		cs-pins {
+			pins = "gpio8";
+			function = "qspi_cs";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		data-pins {
+			pins = "gpio4", "gpio5", "gpio6", "gpio7";
+			function = "qspi_data";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	serial_0_pins: uart0-state {
+		pins = "gpio28", "gpio29";
+		function = "blsp0_uart1";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	switch_reset_pins: switch-reset-state {
+		pins = "gpio26";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+};
+
+/*
+ * ath11k Wi-Fi consumes too large memory spaces and too few spaces are
+ * available for users. To prevent OOM when using LuCI or other softwares,
+ * disable Wi-Fi related peripherals at the moment.
+ */
+&q6v5_wcss {
+	status = "disabled";
+
+	memory-region = <&q6_mem_regions>;
+	firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt",
+			"ath11k/IPQ5018/hw1.0/m3_fw.mdt",
+			"ath11k/QCN6122/hw1.0/m3_fw.mdt";
+
+	/* The QCN6102 radio should map to UPD ID 2. Without       */
+	/* bootargs, the firmware will expect it to be on UPD ID 3 */
+	boot-args = <0x2 4 2 27 0 0>; /* pcie:2, len:4, updid:2, reset:gpio27 */
+
+	// IPQ5018
+	q6_wcss_pd1: pd-1 {
+		firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt";
+
+		resets =
+			<&gcc GCC_WCSSAON_RESET>,
+			<&gcc GCC_WCSS_BCR>,
+			<&gcc GCC_CE_BCR>;
+		reset-names =
+			"wcss_aon_reset",
+			"wcss_reset",
+			"ce_reset";
+
+		clocks =
+			<&gcc GCC_WCSS_AHB_S_CLK>,
+			<&gcc GCC_WCSS_ACMT_CLK>,
+			<&gcc GCC_WCSS_AXI_M_CLK>;
+		clock-names =
+			"gcc_wcss_ahb_s_clk",
+			"gcc_wcss_acmt_clk",
+			"gcc_wcss_axi_m_clk";
+
+		interrupts-extended =
+			<&wcss_smp2p_in 8 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 9 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 12 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 11 IRQ_TYPE_NONE>;
+		interrupt-names =
+			"fatal",
+			"ready",
+			"spawn-ack",
+			"stop-ack";
+
+		qcom,smem-states =
+			<&wcss_smp2p_out 8>,
+			<&wcss_smp2p_out 9>,
+			<&wcss_smp2p_out 10>;
+		qcom,smem-state-names =
+			"shutdown",
+			"stop",
+			"spawn";
+
+		status = "disabled";
+	};
+
+	// QCN6102 5G
+	q6_wcss_pd2: pd-2 {
+		firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt";
+
+		interrupts-extended =
+			<&wcss_smp2p_in 16 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 17 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 20 IRQ_TYPE_NONE>,
+			<&wcss_smp2p_in 19 IRQ_TYPE_NONE>;
+		interrupt-names =
+			"fatal",
+			"ready",
+			"spawn-ack",
+			"stop-ack";
+
+		qcom,smem-states =
+			<&wcss_smp2p_out 16>,
+			<&wcss_smp2p_out 17>,
+			<&wcss_smp2p_out 18>;
+		qcom,smem-state-names =
+			"shutdown",
+			"stop",
+			"spawn";
+
+		status = "disabled";
+	};
+};
+
+&wifi0 {
+	// IPQ5018
+	qcom,rproc = <&q6_wcss_pd1>;
+	qcom,userpd-subsys-name = "q6v5_wcss_userpd1";
+	qcom,ath11k-calibration-variant = "CMCC-PZ-L8";
+	qcom,ath11k-fw-memory-mode = <1>;
+	qcom,bdf-addr = <0x4c400000>;
+
+	ieee80211-freq-limit = <2400000 2483000>;
+
+	status = "disabled";
+};
+
+&wifi1 {
+	// QCN6102 5G
+	qcom,rproc = <&q6_wcss_pd2>;
+	qcom,userpd-subsys-name = "q6v5_wcss_userpd2";
+	qcom,ath11k-calibration-variant = "CMCC-PZ-L8";
+	qcom,ath11k-fw-memory-mode = <1>;
+	qcom,bdf-addr = <0x4d100000>;
+	qcom,m3-dump-addr = <0x4df00000>;
+
+	ieee80211-freq-limit = <5150000 5730000>;
+
+	status = "disabled";
+};

--- a/target/linux/qualcommax/image/ipq50xx.mk
+++ b/target/linux/qualcommax/image/ipq50xx.mk
@@ -18,6 +18,20 @@ define Build/mstc-header
 	rm -f $@.crclen
 endef
 
+define Device/cmcc_pz-l8
+	$(call Device/FitImageLzma)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := CMCC
+	DEVICE_MODEL := PZ-L8
+	DEVICE_DTS_CONFIG := config@mp02.1
+	SOC := ipq5018
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	IMAGE_SIZE := 59392k
+	NAND_SIZE := 128m
+endef
+TARGET_DEVICES += cmcc_pz-l8
+
 define Device/elecom_wrc-x3000gs2
 	$(call Device/FitImageLzma)
 	DEVICE_VENDOR := ELECOM

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/01_leds
@@ -9,6 +9,7 @@ board_config_update
 board=$(board_name)
 
 case "$board" in
+cmcc,pz-l8|\
 elecom,wrc-x3000gs2|\
 iodata,wn-dax3000gr)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan" "tx rx link_10 link_100 link_1000"

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
@@ -15,6 +15,7 @@ ipq50xx_setup_interfaces()
 	glinet,gl-b3000)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
+	cmcc,pz-l8|\
 	linksys,mx2000|\
 	linksys,mx5500|\
 	linksys,spnmx56|\

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
@@ -102,6 +102,7 @@ platform_pre_upgrade() {
 
 platform_do_upgrade() {
 	case "$(board_name)" in
+	cmcc,pz-l8|\
 	elecom,wrc-x3000gs2|\
 	iodata,wn-dax3000gr)
 		local delay


### PR DESCRIPTION
CMCC PZ-L8 is a 2.4/5 GHz band 11ax (Wi-Fi 6) router, based on IPQ5000.

# Specifications

- SoC			: Qualcomm IPQ5000
- RAM			: Integrated 256MiB DDR3L
- Flash			: 128 MiB SPI-NAND (ESMT F50D1G41LB)
- WLAN			: 2.4/5 GHz 2T2R
	- 2.4 GHz		: Qualcomm IPQ5000 (SoC)
	- 5 GHz		: Qualcomm Atheros QCN6102
- Ethernet		: 4x 10/100/1000 Mbps
	- switch		: Qualcomm Atheros QCA8337
- LEDs/Keys (GPIO)	: 2x LEDs, 2x Keys
- UART			: Through-hole on PCB, 4pins in the middle of the black aluminum heat sink
	- assignment	: 3.3V, GND,TX, RX (from left to right)
	- settings	: 115200n8
- Power			: 12 VDC, 1 A

# Flashing Instructions

## SSH Method

1. Enable SSH on the stock firmware
    - Version 501.8 and 501.9: 
        1. Log in to [http://192.168.10.1](http://192.168.10.1) with the password on the sticker
        2. Append "/admin/system/admin" to the URL and press Enter
        3. Delete "Dropbear instance", click "Add instance", then "Save and Apply"
        4. Reboot the router
    - Version 501.11 and 501.12: 
        1. While the router is running the stock firmware, press and hold the reset button for 20-30 seconds
        2. Open [http://192.168.10.1:56781](http://192.168.10.1:56781) and login with username `root` and the password on the sticker
        3. Run `vi /etc/config/dropbear` and delete the line "option enable '0'"
        4. Reboot the router
2. Upload the **factory.ubi** file to router's /tmp directory (using scp or wget) and execute the following commands in the router's shell
    ```sh
    export rootfs=$(cat /proc/mtd | grep rootfs | grep -v _ | cut -d: -f1)
    ubidetach -f -p /dev/${rootfs} 
    ubiformat /dev/${rootfs} -y -f /tmp/factory.ubi
    ```

## U-Boot Method using UBI Image

1. Place the **factory.ubi** file on your TFTP server, enter U-Boot CLI and exec these commands:
    ```
    tftpboot <your_tftp_server_ip>:factory.ubi
    flash rootfs
    reset
    ```

## U-Boot Method using initramfs Image

1. Place the **openwrt-*-initramfs-fit-uImage.itb** file on your TFTP server and rename it to **initramfs.bin**
2. Enable serial console, enter to U-Boot CLI and exec these commands:
    ```
    tftpboot <your_tftp_server_ip>:initramfs.bin
    bootm
    ```
3. Once boot completed, upload the **sysupgrade.bin** file to router's /tmp directory (using scp or wget) and execute the following command in openwrt shell
        ```sh
        sysupgrade -n /tmp/sysupgrade.bin
        ```

# Switching to the Stock Firmware

Please follow the commit https://github.com/openwrt/openwrt/commit/3b7d72bc2ecca2f962319b0a4fb9beb7609a0222

# Partition Layout (Stock Firmware)

0x000000000000-0x000000080000 : "0:SBL1"
0x000000080000-0x000000100000 : "0:MIBIB"
0x000000100000-0x000000140000 : "0:BOOTCONFIG"
0x000000140000-0x000000180000 : "0:BOOTCONFIG1"
0x000000180000-0x000000280000 : "0:QSEE"
0x000000280000-0x000000380000 : "0:QSEE_1"
0x000000380000-0x0000003c0000 : "0:DEVCFG"
0x0000003c0000-0x000000400000 : "0:DEVCFG_1"
0x000000400000-0x000000440000 : "0:CDT"
0x000000440000-0x000000480000 : "0:CDT_1"
0x000000480000-0x000000500000 : "0:APPSBLENV"
0x000000500000-0x000000640000 : "0:APPSBL"
0x000000640000-0x000000780000 : "0:APPSBL_1"
0x000000780000-0x000000880000 : "0:ART"
0x000000880000-0x000000900000 : "0:TRAINING"
0x000000900000-0x000004300000 : "rootfs"
0x000004300000-0x000007d00000 : "rootfs_1"

# Notes

This device is almost the same as ELECOM WRC-X3000GS2, including partition layout and the dual-boot feature.

# Known Issues

- All Wi-Fi related peripherals are disabled in device tree, since 256 MiB RAM is too few for ath11k.
- This device has another version with nand flash FM25SL01, which is not supported at the moment. https://github.com/immortalwrt/immortalwrt/blob/master/target/linux/mediatek/patches-6.12/342-mtd-spinand-Support-fmsh.patch

# MAC Addresses

| Interface | MAC Address          | Location (binary)        |
| --------- | -------------------- | ------------------------ |
| LAN       | A4:39:B6:xx:xx:9D    | (0:ART, 0x00-0x05)       |
| WAN       | A4:39:B6:xx:xx:9E    | (0:ART, 0x06-0x0B)       |
| 2.4 GHz   | A4:39:B6:xx:xx:9F    | (0:ART, 0x0C-0x11)       |
| 5 GHz     | A4:39:B6:xx:xx:A0    | (0:ART, 0x12-0x17)       |
