### PR TITLE
wifi-scripts: use stationary_ap conf for AX mode

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -385,6 +385,11 @@ function device_htmode_append(config) {
 			config.he_oper_centr_freq_seg0_idx = config.vht_oper_centr_freq_seg0_idx;
 		}
 
+		if (config.band == "6g") {
+			config.stationary_ap = true;
+			append_vars(config, [ 'he_6ghz_reg_pwr_type', ]);
+		}
+
 		if (config.he_bss_color_enabled) {
 			if (config.he_spr_non_srg_obss_pd_max_offset)
 				config.he_spr_sr_control |= 1 << 2;
@@ -425,11 +430,6 @@ function device_htmode_append(config) {
 
 		if (config.hw_mode == 'a')
 			append_vars(config, [ 'eht_oper_chwidth', 'eht_oper_centr_freq_seg0_idx' ]);
-
-		if (config.band == "6g") {
-			config.stationary_ap = true;
-			append_vars(config, [ 'he_6ghz_reg_pwr_type', ]);
-		}
 	}
 
 	append_vars(config, [ 'tx_queue_data2_burst', 'stationary_ap' ]);


### PR DESCRIPTION
Use stationary_ap configuration for 6GHz AX AP (not only BE).
This change fixes the 6GHz network not visible issue for QCN9024.