### PR TITLE
wifi-scripts: ucode: improve iwinfo output

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/bin/iwinfo
+++ b/package/network/config/wifi-scripts/files-ucode/usr/bin/iwinfo
@@ -6,6 +6,13 @@ import { find_phy } from 'wifi.utils';
 import * as uci from 'uci';
 import * as iwinfo from 'iwinfo';
 
+function normalize_ssid(ssid) {
+	if (!ssid)
+		return 'unknown';
+	return '"' + replace(ssid, /[[:cntrl:]]/g,
+			     function(c) { return '\\x' + hexenc(c); }) + '"'
+}
+
 function print_assoclist(stations) {
 	for (let mac, station in stations) {
 		printf(`${station.mac}  ${station.signal} dBm / ${station.noise} dBm (SNR ${station.snr})  ${station.inactive_time} ms ago\n`);
@@ -44,7 +51,7 @@ function print_info(list) {
 	let padding = '         ';
 
 	for (let bss in list) {
-		printf(`${bss.iface} ESSID: ${bss.ssid === null ? 'unknown' : '"' + bss.ssid + '"'}\n`);
+		printf(`${bss.iface} ESSID: ${normalize_ssid(bss.ssid)}\n`);
 		printf(`${padding}Access Point: ${bss.mac}\n`);
 		printf(`${padding}Mode: ${bss.mode}  Channel: ${bss.channel} (${bss.freq} GHz)  HT Mode: ${bss.htmode}\n`);
 		printf(`${padding}Center Channel 1: ${bss.center_freq1} 2: ${bss.center_freq2}\n`);
@@ -69,7 +76,7 @@ function print_scan(cells) {
 
 	for (let cell in cells) {
 		printf('Cell %02d - Address: %s\n', idx++, cell.bssid);
-		printf('\t  ESSID: %s\n', cell.ssid ? '"' + cell.ssid + '"' : 'unknown');
+		printf('\t  ESSID: %s\n', normalize_ssid(cell.ssid));
 		printf('\t  Mode: %s  Frequency: %s GHz  Band: %s GHz  Channel: %d\n', cell.mode, cell.frequency, cell.band, cell.channel);
 		printf('\t  Signal: %d dBm  Quality: %2d/70\n', cell.dbm, cell.quality);
 

--- a/package/network/config/wifi-scripts/files-ucode/usr/bin/iwinfo
+++ b/package/network/config/wifi-scripts/files-ucode/usr/bin/iwinfo
@@ -69,6 +69,7 @@ function print_scan(cells) {
 
 	for (let cell in cells) {
 		printf('Cell %02d - Address: %s\n', idx++, cell.bssid);
+		printf('\t  ESSID: %s\n', cell.ssid ? '"' + cell.ssid + '"' : 'unknown');
 		printf('\t  Mode: %s  Frequency: %s GHz  Band: %s GHz  Channel: %d\n', cell.mode, cell.frequency, cell.band, cell.channel);
 		printf('\t  Signal: %d dBm  Quality: %2d/70\n', cell.dbm, cell.quality);
 

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/iwinfo.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/iwinfo.uc
@@ -172,29 +172,59 @@ function format_rate(rate) {
 function format_mgmt_key(key) {
 	switch(+key) {
 	case 1:
-	case 11:
-	case 12:
-	case 13:
-	case 14:
-	case 15:
-	case 16:
-	case 17:
 		return '802.1x';
 
 	case 2:
 		return 'WPA PSK';
 
+	case 3:
+		return 'FT 802.1x';
+
 	case 4:
 		return 'FT PSK';
 
-	case 6:
-		return 'WPA PSK2';
+	case 5:
+	case 11: // deprecated 802.1x-suiteB-SHA256
+		return '802.1x-SHA256';
 
-	case 8: 
+	case 6:
+		return 'WPA PSK-SHA256';
+
+	case 8: // SAE with SHA256
+	case 24: // SAE using group-dependent hash
 		return 'SAE';
+
+	case 9: // FT SAE with SHA256
+	case 25: // FT SAE using group-dependent hash
+		return 'FT SAE';
+
+	case 12:
+		return '802.1x-192bit';
+
+	case 13:
+		return 'FT 802.1x-SHA384';
+
+	case 14:
+		return 'FILS-SHA256';
+
+	case 15:
+		return 'FILS-SHA384';
+
+	case 16:
+		return 'FT FILS-SHA256';
+
+	case 17:
+		return 'FT FILS-SHA384';
 
 	case 18:
 		return 'OWE';
+
+	case 19:
+		return 'FT PSK-SHA384';
+
+	case 20:
+		return 'WPA PSK-SHA384';
+
 	}
 
 	return null;


### PR DESCRIPTION
This PR adds an ESSID line to the scan output, which was strangely missing.  While testing this, I encountered some invalid SSIDs showing up and messing with the output, so I added a commit to escape control characters while displaying the SSID.  I chose control characters since they are more bothersome, and don't interfere with UTF8 characters.

While at it, I added some missing AKMs, and made the scan AKM display more detailed as well, by showing the hash function most of the time.  I followed loosely what hostapd does with `wpa_key_mgmt` suites about showing the hash or not.  SHA1 is never shown;  SHA256 is not shown with FT; however, all FILS AKMs show the hash.

Maintainer: @nbd168 


----

If anyone is interested in the invalid SSID display:
I have not looked into what's causing it, but it appears that either the transmitted data is malformed, or the parsing of the received data is failing.  I get similar results with `iw scan`, but since ucode truncates strings with NULL bytes, the full malformed SSID is not shown.  Looking at the hex dump from iw, I clearly see the familiar 802.11 working group OUI 00-0f-ac showing up multiple times.

```
# iw wlan2g scan
```
```
BSS ...
        last seen: 279881.724s [boottime]
        TSF: 207107891607 usec (2d, 09:31:47)
        freq: 2437.0
        beacon interval: 100 TUs
        capability: ESS (0x1c31)
        signal: -94.00 dBm
        last seen: 12640 ms ago
        SSID: <invalid: 61 bytes: 16 06 05 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 4a 0e 14 00 0a 00 2c 01 c8 00 14 00 05 00 19 00 30 14 01 00 00 0f ac 04 01 00 00 0f ac 04 01 00 00 0f ac 02 0c 00>
```
```
# iwinfo wlan2g scan
```
```
Cell 46 - Address: ...
          ESSID: "\x16\x06\x05"
          Mode: Master  Frequency: 2.437 GHz  Band: 2.4 GHz  Channel: 6
          Signal: -95 dBm  Quality: 15/70
          Encryption: NONE
```
