### PR TITLE
realtek: fix SFP support on Engenius EWS2910P

### DIFF
--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
@@ -35,16 +35,6 @@
 		};
 	};
 
-	gpio-export {
-		compatible = "gpio-export";
-
-		sff-p9-tx-disable {
-			gpio-export,name = "sff-p9-tx-disable";
-			gpio-export,output = <1>;
-			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
-		};
-	};
-
 	gpio-restart {
 		compatible = "gpio-restart";
 		gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
@@ -76,13 +66,29 @@
 		};
 	};
 
-	i2c1: i2c-gpio-1 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio1 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+	i2c-gpio-shared {
+		compatible = "i2c-gpio-shared";
 		scl-gpios = <&gpio1 31 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
 		#address-cells = <1>;
 		#size-cells = <0>;
+
+		i2c0: i2c@0 {
+			sda-gpios = <&gpio1 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+			i2c-gpio,delay-us = <2>;
+		};
+
+		i2c1: i2c@1 {
+			sda-gpios = <&gpio1 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+			i2c-gpio,delay-us = <2>;
+		};
+	};
+
+	sfp0: sfp-p9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		tx-disable-gpio = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		los-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 12 GPIO_ACTIVE_LOW>;
 	};
 	sfp1: sfp-p10 {
 		compatible = "sff,sfp";
@@ -109,15 +115,6 @@
 			gpios = <1 GPIO_ACTIVE_HIGH>;
 			output-high;
 			line-name = "poe-enable";
-		};
-
-		sff_p9_gpios {
-			gpio-hog;
-			gpios = < 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>,
-				< 11 GPIO_ACTIVE_HIGH>, /* los-gpio */
-				< 12 GPIO_ACTIVE_LOW>;   /* mod-def0-gpio */
-			input;
-			line-name = "sff-p9-gpios";
 		};
 
 		led-controller {
@@ -202,8 +199,15 @@
 		SWITCH_PORT(14, 7, internal)
 		SWITCH_PORT(15, 8, internal)
 
-		/* TODO: fixed link SFP is not right */
-		SWITCH_SFP_PORT(24, 9, 1000base-x)
+		port@24 {
+			reg = <24>;
+			label = "lan9";
+			pcs-handle = <&serdes4>;
+			phy-mode = "1000base-x";
+			phy-handle = <&phy24>;
+			managed = "in-band-status";
+			sfp = <&sfp0>;
+		};
 
 		port@26 {
 			reg = <26>;


### PR DESCRIPTION
EWS2910P has two SFP slots of which only one was fully supported so far. The issue so far was that both SFP slots share the same I2C SCL line but neither the kernel nor any downstream driver was able to deal with this.

Thus, only one SFP slot was completely working (with detection etc.) but the other one had to be enabled manually. Networking was functional in both though.

Since acd7ecc9ed we have a driver which is able to deal with that. Thus, we can fix the SFP support for this device.

**DISCLAIMER: I don't own this device so this change is compile-tested only. Highly appreciated if anyone can test this. But since the changes are quite easy and obvious, it is not expected to break anything.**