### PR TITLE
base-files: correct global DHCP DUID generation

### DIFF
--- a/package/base-files/files/etc/uci-defaults/14_network-generate-clientid
+++ b/package/base-files/files/etc/uci-defaults/14_network-generate-clientid
@@ -2,7 +2,7 @@
 
 uci -q batch <<-EOF >/dev/null
 	# DUID-UUID - RFC6355
-	set network.globals.dhcp_default_duid="$(hexdump -vn 16 -e '"0004" 2/2 "%x"' /dev/urandom)"
+	set network.globals.dhcp_default_duid="$(printf '%s%s' '0004' $(cat /proc/sys/kernel/random/uuid | sed -e 's/-//g'))"
 	commit network
 EOF
 


### PR DESCRIPTION
The old command generates an often incorrect variable length UUID instead of a fixed 16-octet hex string.

Ref: https://datatracker.ietf.org/doc/html/rfc8415#section-11.5
