### PR TITLE
wifi-scripts: iface should be optional in wifi-station definition

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
@@ -214,22 +214,24 @@ function config_init(uci)
 	}
 
 	for (let name, data in sections.station) {
-		if (!data.iface || !vifs[data.iface])
-			continue;
-
-		for (let vif in vifs[data.iface]) {
-			let dev = devices[vif.device];
-			let handler = handlers[vif.device];
-			if (!dev || !handler)
+		for (let iface, iface_vifs in vifs) {
+			if (data.iface && data.iface != iface)
 				continue;
 
-			let config = parse_attribute_list(data, handler.station);
+			for (let vif in iface_vifs) {
+				let dev = devices[vif.device];
+				let handler = handlers[vif.device];
+				if (!dev || !handler)
+					continue;
 
-			let sta = {
-				name,
-				config
-			};
-			push(vif.sta, sta);
+				let config = parse_attribute_list(data, handler.station);
+
+				let sta = {
+					name,
+					config
+				};
+				push(vif.sta, sta);
+			}
 		}
 	}
 


### PR DESCRIPTION
Similar to "wifi-scripts: iface should be optional in wifi-vlan definition" (98435a3), wifi-station iface should also be optional. By default, it is supposed to match all interfaces if omitted.

Fixes: https://github.com/openwrt/openwrt/issues/20705