### PR TITLE
generic: mtdsplit_seil: return 0 instead of -ENODEV

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_seil.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_seil.c
@@ -112,7 +112,7 @@ static int mtdsplit_parse_seil_fw(struct mtd_info *master,
 	u64 id;
 
 	if (!seil_bootdev_is_active(np))
-		return -ENODEV;
+		return 0;
 
 	ret = of_property_read_u64(np, "iij,seil-id", &id);
 	if (ret) {
@@ -137,7 +137,7 @@ static int mtdsplit_parse_seil_fw(struct mtd_info *master,
 	if (be64_to_cpu(header.id) != id ||
 	    be32_to_cpu(header.vfmt) != SEIL_VFMT) {
 		pr_debug("no valid seil image found in \"%s\"\n", master->name);
-		ret = -ENODEV;
+		ret = 0;
 		goto err_free_parts;
 	}
 
@@ -154,7 +154,7 @@ static int mtdsplit_parse_seil_fw(struct mtd_info *master,
 	if (ret || (master->size - rootfs_offset) == 0) {
 		pr_debug("no rootfs after seil image in \"%s\"\n",
 			 master->name);
-		ret = -ENODEV;
+		ret = 0;
 		goto err_free_parts;
 	}
 


### PR DESCRIPTION
Return 0 if the current mtd is inactive or no valid header/rootfs found, instead of -ENODEV.
Linux Kernel 6.7 and later versions handle all errors returned by mtd parsers, including -ENODEV as error. So '0' needs to be returned if no child partitions were not parsed.

current snapshot:

```
[    1.378316] 5 fixed-partitions partitions found on MTD device spi1.0
[    1.384801] OF: Bad cell count for /soc/spi@10680/flash@0/partitions
[    1.391196] OF: Bad cell count for /soc/spi@10680/flash@0/partitions
[    1.397766] OF: Bad cell count for /soc/spi@10680/flash@0/partitions
[    1.404181] OF: Bad cell count for /soc/spi@10680/flash@0/partitions
[    1.410661] Creating 5 MTD partitions on "spi1.0":
[    1.415492] 0x000000000000-0x000000100000 : "bootloader"
[    1.421668] 0x000000100000-0x000000110000 : "bootloader-env"
[    1.427942] 0x000000110000-0x000000200000 : "board_info"
[    1.433819] OF: Bad cell count for /soc/spi@10680/flash@0/partitions
[    1.440336] 0x000000200000-0x000001100000 : "firmware"
[    1.551382] Failed to parse subpartitions: -19
[    1.555882] Deleting MTD partitions on "spi1.0":
[    1.560515] Deleting bootloader MTD partition
[    1.564905] ------------[ cut here ]------------
[    1.569537] WARNING: CPU: 0 PID: 1 at block/genhd.c:668 del_mtd_blktrans_dev+0x30/0x110
[    1.577593] Modules linked in:
[    1.580664] CPU: 0 UID: 0 PID: 1 Comm: swapper/0 Not tainted 6.12.57 #0
[    1.580674] Hardware name: Marvell Armada 380/385 (Device Tree)
[    1.580679] Call trace: 
[    1.580686]  unwind_backtrace from show_stack+0x10/0x14
[    1.580704]  show_stack from dump_stack_lvl+0x50/0x64
[    1.580721]  dump_stack_lvl from __warn+0x7c/0xd4
[    1.580739]  __warn from warn_slowpath_fmt+0x158/0x15c
[    1.580753]  warn_slowpath_fmt from del_mtd_blktrans_dev+0x30/0x110
[    1.580770]  del_mtd_blktrans_dev from blktrans_notify_remove+0x6c/0x84
[    1.580786]  blktrans_notify_remove from del_mtd_device+0x50/0xc8
[    1.580801]  del_mtd_device from __del_mtd_partitions+0x7c/0xb8
[    1.580814]  __del_mtd_partitions from del_mtd_partitions+0x40/0x58
[    1.580827]  del_mtd_partitions from add_mtd_partitions+0xa4/0x1e8
[    1.580842]  add_mtd_partitions from parse_mtd_partitions+0x3d8/0x49c
[    1.580856]  parse_mtd_partitions from mtd_device_parse_register+0xe8/0x32c
[    1.580869]  mtd_device_parse_register from spi_nor_probe+0x258/0x2a8
[    1.580890]  spi_nor_probe from really_probe+0xc8/0x2cc
[    1.580908]  really_probe from driver_probe_device+0x38/0xe4
[    1.580921]  driver_probe_device from __device_attach_driver+0x94/0xc4
[    1.580933]  __device_attach_driver from bus_for_each_drv+0x78/0xa4
[    1.580945]  bus_for_each_drv from __device_attach+0xd8/0x140
[    1.580956]  __device_attach from bus_probe_device+0x88/0x8c
[    1.580968]  bus_probe_device from device_add+0x4f8/0x74c
[    1.580977]  device_add from __spi_add_device+0x140/0x1c0
[    1.580991]  __spi_add_device from spi_register_controller+0x898/0xbe4
[    1.581002]  spi_register_controller from orion_spi_probe+0x270/0x34c
[    1.581017]  orion_spi_probe from platform_probe+0x48/0x84
[    1.581035]  platform_probe from really_probe+0xc8/0x2cc
[    1.581049]  really_probe from driver_probe_device+0x38/0xe4
[    1.581061]  driver_probe_device from __driver_attach+0x90/0x140
[    1.581074]  __driver_attach from bus_for_each_dev+0x60/0x94
[    1.581084]  bus_for_each_dev from bus_add_driver+0xd0/0x1fc
[    1.581094]  bus_add_driver from driver_register+0x80/0x11c
[    1.581106]  driver_register from do_one_initcall+0x48/0x27c
[    1.581121]  do_one_initcall from kernel_init_freeable+0x230/0x284
[    1.581139]  kernel_init_freeable from kernel_init+0x1c/0x12c
[    1.581158]  kernel_init from ret_from_fork+0x14/0x38
[    1.581170] Exception stack(0xc2837fb0 to 0xc2837ff8)
[    1.581177] 7fa0:                                     00000000 00000000 00000000 00000000
[    1.581185] 7fc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    1.581191] 7fe0: 00000000 00000000 00000000 00000000 00000013 00000000
[    1.581196] ---[ end trace 0000000000000000 ]---
[    1.828037] Deleting bootloader-env MTD partition
[    1.833002] Deleting board_info MTD partition
[    1.837603] Deleting firmware MTD partition
```

fixed:

```
[    1.369276] 5 fixed-partitions partitions found on MTD device spi1.0
[    1.375746] OF: Bad cell count for /soc/spi@10680/flash@0/partitions
[    1.382142] OF: Bad cell count for /soc/spi@10680/flash@0/partitions
[    1.388732] OF: Bad cell count for /soc/spi@10680/flash@0/partitions
[    1.395123] OF: Bad cell count for /soc/spi@10680/flash@0/partitions
[    1.401636] Creating 5 MTD partitions on "spi1.0":
[    1.406473] 0x000000000000-0x000000100000 : "bootloader"
[    1.412601] 0x000000100000-0x000000110000 : "bootloader-env"
[    1.418900] 0x000000110000-0x000000200000 : "board_info"
[    1.424682] OF: Bad cell count for /soc/spi@10680/flash@0/partitions
[    1.431231] 0x000000200000-0x000001100000 : "firmware"
[    1.542571] 0x000001100000-0x000002000000 : "rescue"
[    1.654720] 2 seil-fw partitions found on MTD device rescue
[    1.660337] Creating 2 MTD partitions on "rescue":
[    1.665155] 0x000000000000-0x0000003a0000 : "kernel"
[    1.670606] 0x0000003a0000-0x000000f00000 : "rootfs"
[    1.676068] mtd: setting mtd6 (rootfs) as root device
[    1.681244] 1 squashfs-split partitions found on MTD device rootfs
[    1.687469] 0x0000006f0000-0x000000f00000 : "rootfs_data"
```