### PR TITLE
wifi-scripts: ucode: fix bug moving to empty wifi-station config

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -307,9 +307,6 @@ function iface_vlan(interface, config, vlans) {
 }
 
 function iface_wpa_stations(config, stas) {
-	if (!length(stas))
-		return;
-
 	let path = `/var/run/hostapd-${config.ifname}.psk`;
 
 	let file = fs.open(path, 'w');
@@ -326,9 +323,6 @@ function iface_wpa_stations(config, stas) {
 }
 
 function iface_sae_stations(config, stas) {
-	if (!length(stas))
-		return;
-
 	let path = `/var/run/hostapd-${config.ifname}.sae`;
 
 	let file = fs.open(path, 'w');


### PR DESCRIPTION
When transitioning from a config with one or more wifi-stations, to a configuration that has no wifi-station; the file would not be empty/reset and the old wifi-station entries would remain.

This is because iface_wpa_stations and iface_sae_stations return early if there are no wifi-stations present, which is an incorrect behavior as it causes the file to actually have old entries.

'sae_password_file' and 'wpa_psk_file' are also set by default inside of iface_auth_type to same path as the one used by wifi-station, so it is indeed going to be set in the config and would contain the old entries.

This happens with reload and wifi restart. So the only solution would be to manually remove the file.