### PR TITLE
realtek: dsa: rtl931x: Sync mgmt recv action code with RTL930x

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -205,7 +205,4 @@ void rtl930x_pie_rule_dump_raw(u32 r[]);
 
 void rtl931x_print_matrix(void);
 
-void rtldsa_930x_set_receive_management_action(int port, rma_ctrl_t type, action_type_t action);
-void rtldsa_931x_set_receive_management_action(int port, rma_ctrl_t type, action_type_t action);
-
 #endif /* _NET_DSA_RTL83XX_H */

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -738,8 +738,8 @@ static void rtl930x_write_mcast_pmask(int idx, u64 portmask)
 	rtl_table_release(q);
 }
 
-void rtldsa_930x_set_receive_management_action(int port, rma_ctrl_t type,
-					       action_type_t action)
+static void rtldsa_930x_set_receive_management_action(int port, rma_ctrl_t type,
+						      action_type_t action)
 {
 	u32 shift;
 	u32 value;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -389,7 +389,8 @@ void rtl931x_print_matrix(void)
 	rtl_table_release(r);
 }
 
-void rtldsa_931x_set_receive_management_action(int port, rma_ctrl_t type, action_type_t action)
+static void rtldsa_931x_set_receive_management_action(int port, rma_ctrl_t type,
+						      action_type_t action)
 {
 	u32 shift;
 	u32 value;


### PR DESCRIPTION
The code for the RTL930x management action configuration was cleaned up significantly for commit 75fe6b2d0b91 ("realtek: rtl930x: Add support for trapping management frames"). Sync these changes to RTL931x to make it easier to extend both implementations.
