### PR TITLE
kernel: mtdsplit_fit: always return 0 when partition can't be split

### DIFF
--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_fit.c
@@ -210,7 +210,7 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 
 	of_property_read_string(np, "openwrt,cmdline-match", &cmdline_match);
 	if (cmdline_match && !strstr(saved_command_line, cmdline_match))
-		return -ENODEV;
+		return 0;
 
 	of_property_read_u32(np, "openwrt,fit-offset", &offset_start);
 
@@ -222,12 +222,12 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 		if (ret) {
 			pr_err("read error in \"%s\" at offset 0x%llx\n",
 			       mtd->name, (unsigned long long) offset);
-			return ret;
+			return 0;
 		}
 
 		if (retlen != hdr_len) {
 			pr_err("short read in \"%s\"\n", mtd->name);
-			return -EIO;
+			return 0;
 		}
 
 		/* Check the magic - see if this is a FIT image */
@@ -247,7 +247,7 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 	if (fit_size == 0) {
 		pr_err("FIT image in \"%s\" at offset %llx has null size\n",
 		       mtd->name, (unsigned long long) fit_offset);
-		return -ENODEV;
+		return 0;
 	}
 
 	/*
@@ -267,14 +267,14 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 		if (ret) {
 			pr_info("no rootfs found after FIT image in \"%s\"\n",
 				mtd->name);
-			return ret;
+			return 0;
 		}
 
 		rootfs_size = mtd->size - rootfs_offset;
 
 		parts = kzalloc(2 * sizeof(*parts), GFP_KERNEL);
 		if (!parts)
-			return -ENOMEM;
+			return 0;
 
 		parts[0].name = KERNEL_PART_NAME;
 		parts[0].offset = fit_offset;
@@ -297,14 +297,14 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 		if (ret) {
 			pr_err("read error in \"%s\" at offset 0x%llx\n",
 			       mtd->name, (unsigned long long) offset);
-			return ret;
+			return 0;
 		}
 
 		images_noffset = fdt_path_offset(fit, FIT_IMAGES_PATH);
 		if (images_noffset < 0) {
 			pr_err("Can't find images parent node '%s' (%s)\n",
 			FIT_IMAGES_PATH, fdt_strerror(images_noffset));
-			return -ENODEV;
+			return 0;
 		}
 
 		for (ndepth = 0,
@@ -324,7 +324,7 @@ mtdsplit_fit_parse(struct mtd_info *mtd,
 
 		parts = kzalloc(sizeof(*parts), GFP_KERNEL);
 		if (!parts)
-			return -ENOMEM;
+			return 0;
 
 		parts[0].name = ROOTFS_SPLIT_NAME;
 		parts[0].offset = fit_offset + mtd_roundup_to_eb(max_size, mtd);


### PR DESCRIPTION
If parse_fn() callback returns any error code, the entire MTD partition table will be destroyed. Returning "0" indicates that the partition should not be split. This patch fixes the kernel warning when running the initramfs image but there is no image in firmware partition:

```
[    1.554246] no rootfs found after FIT image in "firmware"
[    1.559686] Failed to parse subpartitions: -19
[    1.564120] Deleting MTD partitions on "spi0.0":
[    1.568743] Deleting bl2 MTD partition
[    1.572507] ------------[ cut here ]------------
[    1.577110] WARNING: CPU: 0 PID: 1 at del_gendisk+0x260/0x2c4
[    1.582855] Modules linked in:
[    1.585902] CPU: 0 UID: 0 PID: 1 Comm: swapper/0 Not tainted 6.12.57 #0
[    1.592505] Hardware name: AiroPi AX3 (DT)
[    1.596589] pstate: 60400005 (nZCv daif +PAN -UAO -TCO -DIT -SSBS BTYPE=--)
[    1.603538] pc : del_gendisk+0x260/0x2c4
[    1.607452] lr : del_gendisk+0x1c/0x2c4
[    1.611280] sp : ffffffc080dab460
[    1.614583] x29: ffffffc080dab460 x28: ffffffc080d75140 x27: 0000000000000004
[    1.621711] x26: 0000000000000000 x25: 0000000000000000 x24: ffffffc080b3f3d0
[    1.628838] x23: ffffffc080cf3d78 x22: ffffffc080cf3da8 x21: ffffff80009b8780
[    1.635966] x20: ffffffc080cf3e10 x19: ffffff80009d7400 x18: ffffffc080c5ebd8
[    1.643093] x17: ffffffc080cf00f0 x16: 000000009d594d00 x15: 0000000000000088
[    1.650221] x14: 0000000000000088 x13: 00000000ffffffea x12: ffffffc080cb6b80
[    1.657348] x11: 0000000000000040 x10: ffffffc080cf3820 x9 : ffffffc080cf3818
[    1.664475] x8 : ffffff8000420dd8 x7 : 0000000000000000 x6 : 0000000000000000
[    1.671601] x5 : ffffff8000420db0 x4 : ffffff8000420dd8 x3 : 0000000000000000
[    1.678728] x2 : 0000000000000000 x1 : 0000000000000000 x0 : 0000000000000004
[    1.685855] Call trace:
[    1.688290]  del_gendisk+0x260/0x2c4
[    1.691858]  del_mtd_blktrans_dev+0x30/0x144
[    1.696120]  mtdblock_remove_dev+0xc/0x20
[    1.700119]  blktrans_notify_remove+0x88/0xc4
[    1.704464]  del_mtd_device+0x58/0xdc
[    1.708120]  __del_mtd_partitions+0x98/0xe0
[    1.712296]  del_mtd_partitions+0x50/0x70
[    1.716299]  add_mtd_partitions+0x94/0x1e0
[    1.720388]  parse_mtd_partitions+0x3d0/0x4d4
[    1.724736]  mtd_device_parse_register+0x170/0x36c
[    1.729518]  spi_nor_probe+0x250/0x2cc
[    1.733261]  spi_mem_probe+0x68/0xa0
[    1.736828]  spi_probe+0x80/0xe0
[    1.740051]  really_probe+0xb8/0x2a4
[    1.743617]  __driver_probe_device+0x74/0x118
[    1.747962]  driver_probe_device+0x3c/0xe0
[    1.752049]  __device_attach_driver+0xac/0xe8
[    1.756394]  bus_for_each_drv+0x6c/0xb0
[    1.760224]  __device_attach+0x98/0x178
[    1.764049]  device_initial_probe+0x10/0x18
[    1.768223]  bus_probe_device+0xa0/0xa4
[    1.772051]  device_add+0x540/0x724
[    1.775531]  __spi_add_device+0x13c/0x1f8
[    1.779532]  of_register_spi_device+0x44c/0x720
[    1.784051]  spi_register_controller+0x4cc/0x6c0
[    1.788658]  devm_spi_register_controller+0x48/0xa0
[    1.793525]  mtk_spi_probe+0x420/0x720
[    1.797266]  platform_probe+0x64/0xcc
[    1.800920]  really_probe+0xb8/0x2a4
[    1.804485]  __driver_probe_device+0x74/0x118
[    1.808831]  driver_probe_device+0x3c/0xe0
[    1.812916]  __driver_attach+0x88/0x154
[    1.816741]  bus_for_each_dev+0x60/0xa0
[    1.820569]  driver_attach+0x20/0x28
[    1.824138]  bus_add_driver+0xdc/0x208
[    1.827880]  driver_register+0x64/0x114
[    1.831705]  __platform_driver_register+0x20/0x30
[    1.836399]  mtk_spi_driver_init+0x18/0x20
[    1.840486]  do_one_initcall+0x4c/0x1f8
[    1.844313]  kernel_init_freeable+0x238/0x290
[    1.848661]  kernel_init+0x1c/0x120
[    1.852141]  ret_from_fork+0x10/0x20
[    1.855707] ---[ end trace 0000000000000000 ]---
[    1.860731] Deleting u-boot-env MTD partition
[    1.865431] Deleting factory MTD partition
[    1.869907] Deleting fip MTD partition
[    1.874003] Deleting firmware MTD partition
```

Ref:
https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/drivers/mtd/mtdpart.c?h=linux-6.12.y&id=5c2f7727d437cd42033d13ebc8b3d74b9fe65712
