### PR TITLE
realtek: dsa: Link aggregation cleanup

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -452,21 +452,6 @@ int rtl83xx_lag_add(struct dsa_switch *ds, int group, int port, struct netdev_la
 	u32 algomsk = 0;
 	u32 algoidx = 0;
 
-	if (info->tx_type != NETDEV_LAG_TX_TYPE_HASH) {
-		pr_err("%s: Only mode LACP 802.3ad (4) allowed.\n", __func__);
-		return -EINVAL;
-	}
-
-	if (group >= priv->ds->num_lag_ids) {
-		pr_err("%s: LAG %d invalid.\n", __func__, group);
-		return -EINVAL;
-	}
-
-	if (port >= priv->cpu_port) {
-		pr_err("%s: Port %d invalid.\n", __func__, port);
-		return -EINVAL;
-	}
-
 	for (i = 0; i < priv->ds->num_lag_ids; i++) {
 		if (priv->lags_port_members[i] & BIT_ULL(port))
 			break;
@@ -515,11 +500,6 @@ int rtl83xx_lag_del(struct dsa_switch *ds, int group, int port)
 
 	if (group >= priv->ds->num_lag_ids) {
 		pr_err("%s: LAG %d invalid.\n", __func__, group);
-		return -EINVAL;
-	}
-
-	if (port >= priv->cpu_port) {
-		pr_err("%s: Port %d invalid.\n", __func__, port);
 		return -EINVAL;
 	}
 

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -457,7 +457,7 @@ int rtl83xx_lag_add(struct dsa_switch *ds, int group, int port, struct netdev_la
 		return -EINVAL;
 	}
 
-	if (group >= priv->n_lags) {
+	if (group >= priv->ds->num_lag_ids) {
 		pr_err("%s: LAG %d invalid.\n", __func__, group);
 		return -EINVAL;
 	}
@@ -467,11 +467,11 @@ int rtl83xx_lag_add(struct dsa_switch *ds, int group, int port, struct netdev_la
 		return -EINVAL;
 	}
 
-	for (i = 0; i < priv->n_lags; i++) {
+	for (i = 0; i < priv->ds->num_lag_ids; i++) {
 		if (priv->lags_port_members[i] & BIT_ULL(port))
 			break;
 	}
-	if (i != priv->n_lags) {
+	if (i != priv->ds->num_lag_ids) {
 		pr_err("%s: Port %d already member of LAG %d.\n", __func__, port, i);
 		return -ENOSPC;
 	}
@@ -513,7 +513,7 @@ int rtl83xx_lag_del(struct dsa_switch *ds, int group, int port)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 
-	if (group >= priv->n_lags) {
+	if (group >= priv->ds->num_lag_ids) {
 		pr_err("%s: LAG %d invalid.\n", __func__, group);
 		return -EINVAL;
 	}
@@ -702,7 +702,7 @@ static int rtl83xx_handle_changeupper(struct rtl838x_switch_priv *priv,
 
 	mutex_lock(&priv->reg_mutex);
 
-	for (i = 0; i < priv->n_lags; i++) {
+	for (i = 0; i < priv->ds->num_lag_ids; i++) {
 		if ((!priv->lag_devs[i]) || (priv->lag_devs[i] == upper))
 			break;
 	}
@@ -1563,7 +1563,7 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->ds->num_ports = 29;
 		priv->fib_entries = 8192;
 		rtl8380_get_version(priv);
-		priv->n_lags = 8;
+		priv->ds->num_lag_ids = 8;
 		priv->l2_bucket_size = 4;
 		priv->n_pie_blocks = 12;
 		priv->port_ignore = 0x1f;
@@ -1579,7 +1579,7 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->ds->num_ports = 53;
 		priv->fib_entries = 16384;
 		rtl8390_get_version(priv);
-		priv->n_lags = 16;
+		priv->ds->num_lag_ids = 16;
 		priv->l2_bucket_size = 4;
 		priv->n_pie_blocks = 18;
 		priv->port_ignore = 0x3f;
@@ -1598,7 +1598,7 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		 * be constructed. For now, just set it to a static 'A'
 		 */
 		priv->version = RTL8390_VERSION_A;
-		priv->n_lags = 16;
+		priv->ds->num_lag_ids = 16;
 		sw_w32(1, RTL930X_ST_CTRL);
 		priv->l2_bucket_size = 8;
 		priv->n_pie_blocks = 16;
@@ -1618,7 +1618,7 @@ static int __init rtl83xx_sw_probe(struct platform_device *pdev)
 		 * be constructed. For now, just set it to a static 'A'
 		 */
 		priv->version = RTL8390_VERSION_A;
-		priv->n_lags = 16;
+		priv->ds->num_lag_ids = 16;
 		sw_w32(1, RTL931x_ST_CTRL);
 		priv->l2_bucket_size = 8;
 		priv->n_pie_blocks = 16;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/debugfs.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/debugfs.c
@@ -613,7 +613,7 @@ void rtl838x_dbgfs_init(struct rtl838x_switch_priv *priv)
 	debugfs_create_u8("id", 0444, port_dir, &priv->cpu_port);
 
 	/* Create entries for LAGs */
-	for (int i = 0; i < priv->n_lags; i++) {
+	for (int i = 0; i < priv->ds->num_lag_ids; i++) {
 		snprintf(lag_name, sizeof(lag_name), "lag.%02d", i);
 		if (priv->family_id == RTL8380_FAMILY_ID)
 			debugfs_create_x32(lag_name, 0644, rtl838x_dir,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -2407,7 +2407,7 @@ static int rtl83xx_port_lag_join(struct dsa_switch *ds,
 
 	mutex_lock(&priv->reg_mutex);
 
-	for (i = 0; i < priv->n_lags; i++) {
+	for (i = 0; i < priv->ds->num_lag_ids; i++) {
 		if ((!priv->lag_devs[i]) || (priv->lag_devs[i] == lag.dev))
 			break;
 	}
@@ -2446,7 +2446,7 @@ static int rtl83xx_port_lag_leave(struct dsa_switch *ds, int port,
 	struct rtl838x_switch_priv *priv = ds->priv;
 
 	mutex_lock(&priv->reg_mutex);
-	for (i = 0; i < priv->n_lags; i++) {
+	for (i = 0; i < priv->ds->num_lag_ids; i++) {
 		if (priv->lags_port_members[i] & BIT_ULL(port)) {
 			group = i;
 			break;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1164,7 +1164,6 @@ struct rtl838x_switch_priv {
 	u32 fib_entries;
 	int l2_bucket_size;
 	struct dentry *dbgfs_dir;
-	int n_lags;
 	u64 lags_port_members[MAX_LAGS];
 	struct net_device *lag_devs[MAX_LAGS];
 	u32 lag_primary[MAX_LAGS];

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1174,10 +1174,10 @@ struct rtl838x_switch_priv {
 	u32 lag_primary[MAX_LAGS];
 
 	/**
-	 * @is_lagmember: Port is part of any LAG but not the first/primary
-	 * port which needs to be added in the port matrix
+	 * @lag_non_primary: Port (bit) is part of any LAG but not the
+	 * first/primary port which needs to be added in the port matrix
 	 */
-	u32 is_lagmember[57];
+	u64 lag_non_primary;
 
 	/** @lagmembers: Port (bit) is part of any LAG */
 	u64 lagmembers;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1164,9 +1164,22 @@ struct rtl838x_switch_priv {
 	u32 fib_entries;
 	int l2_bucket_size;
 	struct dentry *dbgfs_dir;
+
+	/** @lags_port_members: Port (bit) is part of a specific LAG */
 	u64 lags_port_members[MAX_LAGS];
+
+	/** @lag_primary: port of a LAG is primary (repesenting) and is added to
+	 * the port matrix
+	 */
 	u32 lag_primary[MAX_LAGS];
+
+	/**
+	 * @is_lagmember: Port is part of any LAG but not the first/primary
+	 * port which needs to be added in the port matrix
+	 */
 	u32 is_lagmember[57];
+
+	/** @lagmembers: Port (bit) is part of any LAG */
 	u64 lagmembers;
 	struct workqueue_struct *wq;
 	struct notifier_block ne_nb;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1165,7 +1165,6 @@ struct rtl838x_switch_priv {
 	int l2_bucket_size;
 	struct dentry *dbgfs_dir;
 	u64 lags_port_members[MAX_LAGS];
-	struct net_device *lag_devs[MAX_LAGS];
 	u32 lag_primary[MAX_LAGS];
 	u32 is_lagmember[57];
 	u64 lagmembers;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1170,7 +1170,6 @@ struct rtl838x_switch_priv {
 	u32 is_lagmember[57];
 	u64 lagmembers;
 	struct workqueue_struct *wq;
-	struct notifier_block nb;  /* TODO: change to different name */
 	struct notifier_block ne_nb;
 	struct notifier_block fib_nb;
 	bool eee_enabled;


### PR DESCRIPTION
Before adding the support for Link Aggregation on RTL930x + RTL931x, it would be good to first have the already existing code cleaned up a little bit in a smaller PR. At the moment lets deal with:

* DSA lag callbacks are not working because `dsa_lag_id` always returns an error
* there is an old version of the LAG configuration code which skips DSA and waits for
  - having two different ways to receive the configuration events complicates everything and makes it more error prone
* some checks are duplicated between the DSA callbacks and the `common.c` functions
* the code reimplemented the LAG ID allocation which is already present in the shared DSA code
* names of the lag variables in `rtl838x_switch_priv` are confusing - they need some documentation and maybe renaming
  - if anyone has some other suggestions for names, please feel free to propose them here