### PR TITLE
Tp re450 mtd concat

### DIFF
--- a/target/linux/ath79/dts/qca9558_tplink_rex5x.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_rex5x.dtsi
@@ -162,7 +162,7 @@
 
 			partition@630000 {
 				label = "config";
-				reg = <0x630000 0x1c0000>;
+				reg = <0x630000 0x020000>;
 				read-only;
 			};
 

--- a/target/linux/ath79/dts/qca9558_tplink_rex5x.dtsi
+++ b/target/linux/ath79/dts/qca9558_tplink_rex5x.dtsi
@@ -98,6 +98,21 @@
 			reset-gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0>, <&fwconcat1>;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			partition@0 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
 };
 
 &pcie0 {
@@ -130,9 +145,8 @@
 				read-only;
 			};
 
-			partition@20000 {
-				compatible = "tplink,firmware";
-				label = "firmware";
+			fwconcat0: partition@20000 {
+				label = "fwconcat0";
 				reg = <0x020000 0x5e0000>;
 			};
 
@@ -164,6 +178,11 @@
 				label = "config";
 				reg = <0x630000 0x020000>;
 				read-only;
+			};
+
+			fwconcat1: partition@650000 {
+				label = "fwconcat1";
+				reg = <0x650000 0x1a0000>;
 			};
 
 			partition@7f0000 {

--- a/target/linux/ath79/dts/qca9563_tplink_re450-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_re450-v2.dts
@@ -9,6 +9,21 @@
 	aliases {
 		label-mac-device = &eth0;
 	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0>, <&fwconcat1>;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			partition@0 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x0 0x0>;
+			};
+		};
+	};
 };
 
 &partitions {
@@ -18,9 +33,8 @@
 		read-only;
 	};
 
-	partition@20000 {
-		compatible = "tplink,firmware";
-		label = "firmware";
+	fwconcat0: partition@20000 {
+		compatible = "fwconcat0";
 		reg = <0x020000 0x5e0000>;
 	};
 
@@ -52,6 +66,11 @@
 		label = "config";
 		reg = <0x630000 0x020000>;
 		read-only;
+	};
+
+	fwconcat1: partition@650000 {
+		label = "fwconcat1";
+		reg = <0x650000 0x1a0000>;
 	};
 
 	partition@7f0000 {

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -9,7 +9,6 @@ define Device/tplink_rex5x-v1
   DEVICE_COMPAT_VERSION := 2.0
   DEVICE_COMPAT_MESSAGE := Partition layout has changed compared to older versions by utilizing unused flash. \
     Upgrade via sysupgrade mechanism (-F) will only work if flashed image still fits to the size of old partition (6016 KiB).
-  DEFAULT := n
 endef
 
 define Device/tplink_re355-v1
@@ -43,7 +42,6 @@ define Device/tplink_re450-v2
     Upgrade via sysupgrade mechanism (-F) will only work if flashed image still fits to the size of old partition (6016 KiB).
   TPLINK_BOARD_ID := RE450-V2
   LOADER_TYPE := elf
-  DEFAULT := n
 endef
 TARGET_DEVICES += tplink_re450-v2
 

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -3,8 +3,12 @@ include ./common-tp-link.mk
 define Device/tplink_rex5x-v1
   $(Device/tplink-safeloader)
   SOC := qca9558
-  IMAGE_SIZE := 6016k
+  IMAGE_SIZE := 7680k
+  KERNEL_SIZE := 6016k
   DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Partition layout has changed compared to older versions by utilizing unused flash. \
+    Upgrade via sysupgrade mechanism (-F) will only work if flashed image still fits to the size of old partition (6016 KiB).
   DEFAULT := n
 endef
 
@@ -29,10 +33,14 @@ TARGET_DEVICES += tplink_re450-v1
 define Device/tplink_re450-v2
   $(Device/tplink-safeloader)
   SOC := qca9563
-  IMAGE_SIZE := 6016k
+  IMAGE_SIZE := 7680k
+  KERNEL_SIZE := 6016k
   DEVICE_MODEL := RE450
   DEVICE_VARIANT := v2
   DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Partition layout has changed compared to older versions by utilizing unused flash. \
+    Upgrade via sysupgrade mechanism (-F) will only work if flashed image still fits to the size of old partition (6016 KiB).
   TPLINK_BOARD_ID := RE450-V2
   LOADER_TYPE := elf
   DEFAULT := n

--- a/target/linux/ath79/tiny/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/05_compat-version
@@ -13,6 +13,11 @@ case "$(board_name)" in
 	tplink,tl-wpa8630p-v2.1-eu)
 		ucidef_set_compat_version "2.0"
 		;;
+	tplink,re355-v1|\
+	tplink,re450-v1|\
+	tplink,re450-v2)
+		ucidef_set_compat_version "2.0"
+		;;
 esac
 
 board_config_flush


### PR DESCRIPTION
Dear OpenWrt maintainters,

I followed up on https://forum.openwrt.org/t/tp-link-re355-v1-and-re450-v1-v2-moved-to-tiny-builds/241895 and implemented mtd-concat support for RE355 v1, RE450 v1 and RE450 v2.

Both RE450 v1 and R450 v2 compile. I tested it on my RE450 v1 and it works as expected. @ivanddiaz do you mind checking it also on RE450 v2. It should be fairly straight forward.

I am happy to reduce the subject lines to less than 50 characters, but I noticed that you are not enforcing this rule too much, so
I rather kept them descriptive.

Looking forward to your feedback.

Best regards,
Radek Dostál