### PR TITLE
udebug: update to Git HEAD (2025-10-21)

### DIFF
--- a/package/libs/udebug/Makefile
+++ b/package/libs/udebug/Makefile
@@ -11,9 +11,9 @@ PKG_NAME:=udebug
 CMAKE_INSTALL:=1
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/udebug.git
-PKG_MIRROR_HASH:=d198d95f83f0d2c17ea30039db85a4bd50360886b0963e227d2d879406b79c27
-PKG_SOURCE_DATE:=2025-09-28
-PKG_SOURCE_VERSION:=5327524e715332daaebf6b04c155d2880d230979
+PKG_MIRROR_HASH:=eb40871f2259e17b6e3ee2c01930a6faffb5e0a7db7589827a9e1efda267726f
+PKG_SOURCE_DATE:=2025-10-21
+PKG_SOURCE_VERSION:=75f39cd4a8067a6f0503c2f1c83c6b1af733a6f2
 PKG_ABI_VERSION:=$(call abi_version_str,$(PKG_SOURCE_DATE))
 
 PKG_LICENSE:=GPL-2.0
@@ -73,7 +73,7 @@ endef
 
 define Package/udebug-cli/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/udebug-cli $(1)/usr/sbin/udebug
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/udebug $(1)/usr/sbin/udebug
 endef
 
 $(eval $(call BuildPackage,libudebug))


### PR DESCRIPTION
8c967bce23ae CMakeLists.txt: rename udebug-cli to udebug on installation
75f39cd4a806 add debian package support
