### PR TITLE
rockchip: minor fixes for LinkEase EasePi R1 and Radxa E52C

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -53,7 +53,6 @@ friendlyarm,nanopi-r4s-enterprise|\
 friendlyarm,nanopi-r6c|\
 friendlyarm,nanopi-r76s|\
 friendlyarm,nanopc-t6|\
-radxa,e52c|\
 radxa,rock-5-itx|\
 radxa,rock-5t)
 	set_interface_core 10 "eth0"
@@ -73,6 +72,10 @@ radxa,rock-5a|\
 radxa,rock-5c)
 	set_interface_core 10 "eth1"
 	set_interface_core 20 "eth2"
+	;;
+radxa,e52c)
+	set_interface_core 10 "lan"
+	set_interface_core 20 "wan"
 	;;
 esac
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -176,9 +176,9 @@ endef
 TARGET_DEVICES += friendlyarm_nanopi-r76s
 
 define Device/linkease_easepi-r1
+  $(Device/rk3568)
   DEVICE_VENDOR := LinkEase
   DEVICE_MODEL := EasePi R1
-  SOC := rk3568
   UBOOT_DEVICE_NAME := generic-rk3568
   DEVICE_PACKAGES := blkdiscard block-mount kmod-button-hotplug kmod-nvme kmod-r8169
 endef


### PR DESCRIPTION
- rockchip: fix assign IRQ SMP affinity for Radxa E52C
- rockchip: add missing KERNEL_LOADADDR for LinkEase EasePi R1