### PR TITLE
[24.10] ipq40xx: use NVMEM-on-UBI  for ASUS Lyra and introduce label mac

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -18,11 +18,6 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-pci-0000:01:00.0.bin")
 	case "$board" in
-	asus,map-ac2200)
-		caldata_extract_ubi "Factory" 0x9000 0x2f20
-		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
-			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
-		;;
 	asus,rt-ac42u)
 		caldata_extract_ubi "Factory" 0x9000 0x2f20
 		;;
@@ -57,7 +52,6 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-ahb-a000000.wifi.bin")
 	case "$board" in
-	asus,map-ac2200|\
 	asus,rt-ac42u)
 		caldata_extract_ubi "Factory" 0x1000 0x2f20
 		;;
@@ -157,9 +151,6 @@ case "$FIRMWARE" in
 	;;
 "ath10k/pre-cal-ahb-a800000.wifi.bin")
 	case "$board" in
-	asus,map-ac2200)
-		caldata_extract_ubi "Factory" 0x5000 0x2f20
-		;;
 	avm,fritzbox-4040)
 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
 		;;

--- a/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
+++ b/target/linux/ipq40xx/base-files/lib/preinit/05_set_iface_mac_ipq40xx.sh
@@ -2,11 +2,6 @@
 
 preinit_set_mac_address() {
 	case $(board_name) in
-	asus,map-ac2200)
-		base_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
-		ip link set dev eth0 address $(macaddr_add "$base_mac" 1)
-		ip link set dev eth1 address $(macaddr_add "$base_mac" 3)
-		;;
 	asus,rt-ac42u)
 		base_mac=$(mtd_get_mac_binary_ubi Factory 0x1006)
 		ip link set dev eth0 address $base_mac

--- a/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
+++ b/target/linux/ipq40xx/files-6.6/arch/arm/boot/dts/qcom/qcom-ipq4019-map-ac2200.dts
@@ -15,9 +15,8 @@
 		led-failsafe = &led_red0;
 		led-running = &led_blue0;
 		led-upgrade = &led_red0;
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		ethernet1 = &swport4;
+		label-mac-device = &wifi0;
 	};
 
 	soc {
@@ -117,9 +116,41 @@
 			};
 
 			partition@400000 {
+				compatible = "linux,ubi";
 				label = "ubi";
 				reg = <0x400000 0x7c00000>;
+				volumes {
+					ubi_factory: ubi-volume-factory {
+						volname = "Factory";
+					};
+				};
 			};
+		};
+	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		precal_factory_1000: precal@1000 {
+			reg = <0x1000 0x2f20>;
+		};
+
+		macaddr_factory_1006: macaddr@1006 {
+			compatible = "mac-base";
+			reg = <0x1006 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+
+		precal_factory_5000: precal@5000 {
+			reg = <0x5000 0x2f20>;
+		};
+
+		precal_factory_9000: precal@9000 {
+			reg = <0x9000 0x2f20>;
 		};
 	};
 };
@@ -192,11 +223,15 @@
 
 &wifi0 {
 	status = "okay";
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_factory_1000>;
 	qcom,ath10k-calibration-variant = "ASUS-MAP-AC2200";
 };
 
 &wifi1 {
 	status = "okay";
+	nvmem-cell-names = "pre-calibration";
+	nvmem-cells = <&precal_factory_5000>;
 	qcom,ath10k-calibration-variant = "ASUS-MAP-AC2200";
 	ieee80211-freq-limit = <5470000 5875000>;
 };
@@ -218,6 +253,8 @@
 			reg = <0x00010000 0 0 0 0>;
 			qcom,ath10k-calibration-variant = "ASUS-MAP-AC2200";
 			ieee80211-freq-limit = <5170000 5350000>;
+			nvmem-cell-names = "pre-calibration";
+			nvmem-cells = <&precal_factory_9000>;
 		};
 	};
 };
@@ -346,6 +383,8 @@
 
 &gmac {
 	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_1006 1>;
 };
 
 &switch {
@@ -354,6 +393,8 @@
 
 &swport4 {
 	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_1006 3>;
 
 	label = "wan";
 };


### PR DESCRIPTION
After getting this merged into main in https://github.com/openwrt/openwrt/pull/20612 I tried to backport this change also to 24.10 to use this change also in downstream project. The test was successful.