### PR TITLE
kernel: sound: add support for MIDI 2.0 and UMP

### DIFF
--- a/package/kernel/linux/modules/sound.mk
+++ b/package/kernel/linux/modules/sound.mk
@@ -604,3 +604,55 @@ define KernelPackage/sound-hda-intel/description
 endef
 
 $(eval $(call KernelPackage,sound-hda-intel))
+
+
+define KernelPackage/sound-midi2
+  TITLE:=MIDI 2.0 and UMP Support
+  KCONFIG:= \
+	CONFIG_SND_UMP=y  \
+	CONFIG_SND_UMP_LEGACY_RAWMIDI=y
+  FILES:=$(LINUX_DIR)/sound/core/snd-ump.ko
+  AUTOLOAD:=$(call AutoProbe,snd-ump)
+  $(call AddDepends/sound)
+endef
+
+define KernelPackage/sound-midi2/description
+ Kernel module for MIDI 2.0: sequencer, rawmidi, and USB-MIDI 2.0 support.
+endef
+
+$(eval $(call KernelPackage,sound-midi2))
+
+define KernelPackage/sound-midi2-seq
+  TITLE:=MIDI 2.0 and UMP Support for Sequencer
+  KCONFIG:= \
+	CONFIG_SND_SEQ_UMP=y \
+	CONFIG_SND_SEQ_UMP_CLIENT=y
+  DEPENDS:=+kmod-sound-midi2 +kmod-sound-seq
+  $(call AddDepends/sound)
+endef
+
+$(eval $(call KernelPackage,sound-midi2-seq))
+
+
+define KernelPackage/sound-midi2-usb
+  TITLE:=MIDI 2.0 and UMP Support for USB-MIDI
+  KCONFIG:=CONFIG_SND_USB_AUDIO_MIDI_V2=y
+  DEPENDS:=+kmod-sound-midi2 +kmod-usb-audio
+  $(call AddDepends/sound)
+endef
+
+$(eval $(call KernelPackage,sound-midi2-usb))
+
+
+define KernelPackage/sound-dynamic-minors
+  TITLE:=Support more than 8 audio and MIDI devices
+  KCONFIG:=CONFIG_SND_DYNAMIC_MINORS=y
+  $(call AddDepends/sound)
+endef
+
+define KernelPackage/sound-dynamic-minors/description
+ Kernel module for dynamic minor device support.
+ Required for using more than 8 audio and MIDI devices.
+endef
+
+$(eval $(call KernelPackage,sound-dynamic-minors))

--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -616,7 +616,7 @@ define KernelPackage/usb-audio
 	CONFIG_SND_USB_AUDIO
   $(call AddDepends/usb)
   $(call AddDepends/sound)
-  DEPENDS+=+kmod-media-controller
+  DEPENDS+=+kmod-media-controller +PACKAGE_kmod-sound-midi2-usb:kmod-sound-midi2
   FILES:= \
 	$(LINUX_DIR)/sound/usb/snd-usbmidi-lib.ko \
 	$(LINUX_DIR)/sound/usb/snd-usb-audio.ko


### PR DESCRIPTION
I'm proposing these new Packages / build options:
* sound-midi2: enable MIDI 2.0 / UMP in ALSA MIDI
* sound-midi2-seq: enable MIDI 2.0 / UMP in ALSA sequencer
* sound-midi2-usb: enable USB MIDI 2.0 support
* sound-dynamic-minors: enable dynamic device minors, allowing more than 8 MIDI devices

More info about ALSA MIDI 2.0 kernel implementation: https://docs.kernel.org/6.12/sound/designs/midi-2.0.html
More info about MIDI 2.0: https://midi.org/midi-2-0
