### PR TITLE
realtek: rtl93xx: Send per port packets on physical port

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -133,7 +133,7 @@ static void rtl930x_create_tx_header(struct p_hdr *h, unsigned int dest_port, in
 	h->cpu_tag[0] = 0x8000;  /* CPU tag marker */
 
 	h->cpu_tag[1] = FIELD_PREP(RTL93XX_CPU_TAG1_FWD_MASK,
-				   RTL93XX_CPU_TAG1_FWD_LOGICAL);
+				   RTL93XX_CPU_TAG1_FWD_PHYSICAL);
 	h->cpu_tag[1] |= FIELD_PREP(RTL93XX_CPU_TAG1_IGNORE_STP_MASK, 1);
 	h->cpu_tag[2] = 0;
 	h->cpu_tag[3] = 0;
@@ -152,7 +152,7 @@ static void rtl931x_create_tx_header(struct p_hdr *h, unsigned int dest_port, in
 	h->cpu_tag[0] = 0x8000;  /* CPU tag marker */
 
 	h->cpu_tag[1] = FIELD_PREP(RTL93XX_CPU_TAG1_FWD_MASK,
-				   RTL93XX_CPU_TAG1_FWD_LOGICAL);
+				   RTL93XX_CPU_TAG1_FWD_PHYSICAL);
 	h->cpu_tag[1] |= FIELD_PREP(RTL93XX_CPU_TAG1_IGNORE_STP_MASK, 1);
 	h->cpu_tag[2] = 0;
 	h->cpu_tag[3] = 0;


### PR DESCRIPTION
If link aggregation with LACP is activated, we must send out the LACP packets on the physical port and not on a logic port. Otherwise, the per port packets might be (re-balanced) between the different ports in a link aggregation group.

Such rebalancing breaks 802.3ad and will leave ports in a churned state.