### PR TITLE
realtek: dsa: Add non-primary LAG ports to port matrix

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -1378,11 +1378,6 @@ static int rtldsa_port_enable(struct dsa_switch *ds, int port, struct phy_device
 	/* add port to switch mask of CPU_PORT */
 	priv->r->traffic_enable(priv->cpu_port, port);
 
-	if (priv->lag_non_primary & BIT_ULL(port)) {
-		pr_debug("%s: %d is lag slave. ignore\n", __func__, port);
-		return 0;
-	}
-
 	/* add all other ports in the same bridge to switch mask of port */
 	priv->r->traffic_set(port, priv->ports[port].pm);
 
@@ -1479,9 +1474,6 @@ static void rtldsa_update_port_member(struct rtl838x_switch_priv *priv, int port
 		if (!dsa_port_offloads_bridge_dev(other_dp, bridge_dev))
 			continue;
 
-		if (join && priv->lag_non_primary & BIT_ULL(other_port))
-			continue;
-
 		isolated = p->isolated && other_p->isolated;
 
 		if (join && !isolated) {
@@ -1507,11 +1499,6 @@ static int rtldsa_port_bridge_join(struct dsa_switch *ds, int port, struct dsa_b
 	struct rtl838x_switch_priv *priv = ds->priv;
 
 	pr_debug("%s %x: %d", __func__, (u32)priv, port);
-
-	if (priv->lag_non_primary & BIT_ULL(port)) {
-		pr_debug("%s: %d is lag slave. ignore\n", __func__, port);
-		return 0;
-	}
 
 	/* reset to default flags for new net_bridge_port */
 	priv->ports[port].isolated = false;


### PR DESCRIPTION
If ports of a RTL93xx switch are not added to a port matrix then they are not used for the link aggregation. As result, communication will then just break on non-primary interfaces.

This can be reproduced in balanced-xor and 802.3ad bandwidth mode.

---

I don't have any RTL83xx based switches. Maybe it is the opposite for them and you really don't want to have them added. Just as reference, this is how I set it up on my PC:

```
port1=enp0s31f6
port2=enxc84d44212bca

nmcli  dev set "$port1" managed no
nmcli  dev set "$port2" managed no

sudo modprobe bonding
ip link del dev bond0

ethtool -s "$port1" speed 1000 duplex full autoneg off
ethtool -s "$port2" speed 1000 duplex full autoneg off

ip link add dev bond0 type bond
ip link set bond0 type bond mode balance-xor xmit_hash_policy layer2+3

ip link set dev "$port1" down
ip link set dev "$port2" down
sleep 3
ip link set dev "$port1" master bond0
ip link set dev "$port2" master bond0

ip link set dev "$port1" up
ip link set dev "$port2" up
ip link set dev bond0 up

ip a add 192.168.42.1/24 dev bond0
ip a add 192.168.42.2/24 dev bond0

iperf3 -s --bind 192.168.42.1 &
iperf3 -s --bind 192.168.42.2 &
```

The switch was configured via:

```
port1=lan1
port2=lan8

ip link del dev bond0

ip link add dev bond0 type bond
ip link set bond0 type bond mode balance-xor xmit_hash_policy layer2+3

ip link set dev "$port1" down
ip link set dev "$port2" down
sleep 3
ip link set dev "$port1" master bond0
ip link set dev "$port2" master bond0

ip link set dev "$port1" up
ip link set dev "$port2" up
ip link set dev bond0 up

ip link set master switch dev bond0
```

There was then another PC connected via 2.5GB to lan4:

```
sudo ip link set up dev enp68s0
sudo ip addr add 192.168.42.3/24 dev enp68s0

# actually in two different terminals
iperf3 -c 192.168.42.1 -t 3600 -i 1 &
iperf3 -c 192.168.42.2 -t 3600 -i 1 &
```


The RTL93xx specific HW setup will be published later. At the moment, I am more interested in "what are the RTL83xx requirements". If RTL83xx is not working at all at the moment, then you might also want to check #20707

---

For 802.3ad, the line

```
ip link set bond0 type bond mode balance-xor xmit_hash_policy layer2+3
```

as was replaced everywhere with:

```
ip link set bond0 type bond mode 802.3ad lacp_rate fast ad_select bandwidth
```