### PR TITLE
qualcommax: ipq807x: use ascii-env driver for Linksys MX4200v1

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200.dtsi
@@ -3,6 +3,12 @@
 
 #include "ipq8174-mx4x00.dtsi"
 
+/ {
+	aliases {
+		label-mac-device = &dp2;
+	};
+};
+
 &tlmm {
 	iot_pins: iot-state {
 		recovery-pins {
@@ -238,23 +244,31 @@
 &dp2 {
 	status = "okay";
 	phy-handle = <&qca8075_1>;
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 	label = "wan";
 };
 
 &dp3 {
 	status = "okay";
 	phy-handle = <&qca8075_2>;
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 	label = "lan1";
 };
 
 &dp4 {
 	status = "okay";
 	phy-handle = <&qca8075_3>;
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 	label = "lan2";
 };
 
 &dp5 {
 	status = "okay";
 	phy-handle = <&qca8075_4>;
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 	label = "lan3";
 };

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v1.dts
@@ -9,13 +9,6 @@
 / {
 	model = "Linksys MX4200v1";
 	compatible = "linksys,mx4200v1", "qcom,ipq8074";
-
-	aliases {
-		ethernet1 = &dp2;
-		ethernet2 = &dp3;
-		ethernet3 = &dp4;
-		ethernet4 = &dp5;
-	};
 };
 
 &wifi {

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8174-mx4200v2.dts
@@ -8,30 +8,6 @@
 / {
 	model = "Linksys MX4200v2";
 	compatible = "linksys,mx4200v2", "qcom,ipq8074";
-
-	aliases {
-		label-mac-device = &dp2;
-	};
-};
-
-&dp2 {
-	nvmem-cells = <&hw_mac_addr 0>;
-	nvmem-cell-names = "mac-address";
-};
-
-&dp3 {
-	nvmem-cells = <&hw_mac_addr 0>;
-	nvmem-cell-names = "mac-address";
-};
-
-&dp4 {
-	nvmem-cells = <&hw_mac_addr 0>;
-	nvmem-cell-names = "mac-address";
-};
-
-&dp5 {
-	nvmem-cells = <&hw_mac_addr 0>;
-	nvmem-cell-names = "mac-address";
 };
 
 &wifi {


### PR DESCRIPTION
Just like it has already been changed for v2, use the ascii-eq-delim-env driver to extract the label mac from the devinfo partition.