### PR TITLE
ipq40xx: fix unit-address of Netgear LBR20 ubi partition

### DIFF
--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-lbr20.dts
@@ -394,7 +394,7 @@
 				reg = <0x0a600000 0x00700000>;
 			};
 
-			partition@a9c0000 {
+			partition@ad00000 {
 				label = "ubi";
 				reg = <0x0ad00000 0x05300000>;
 			};


### PR DESCRIPTION
The unit-address of the ubi partition was @a9c0000 but the partition actually starts at offset 0x0ad00000. Ideally they should match, so align them.