### PR TITLE
realtek: pcs: rtl931x: SerDes initialization refactoring and fixes

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -2476,6 +2476,15 @@ static int rtpcs_931x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 	return rtpcs_sds_write_bits(sds, 0x1f, 0x9, 11, 6, mode_val);
 }
 
+static int rtpcs_931x_sds_set_mode(struct rtpcs_serdes *sds,
+				   enum rtpcs_sds_mode hw_mode)
+{
+	if (hw_mode == RTPCS_SDS_MODE_XSGMII)
+		return rtpcs_931x_sds_set_mac_mode(sds, hw_mode);
+	else
+		return rtpcs_931x_sds_set_ip_mode(sds, hw_mode);
+}
+
 static void rtpcs_931x_sds_reset(struct rtpcs_serdes *sds)
 {
 	struct rtpcs_ctrl *ctrl = sds->ctrl;
@@ -2951,16 +2960,7 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 
 	rtpcs_931x_sds_power(sds, true);
 
-	if (mode == PHY_INTERFACE_MODE_XGMII ||
-	    mode == PHY_INTERFACE_MODE_QSGMII ||
-	    mode == PHY_INTERFACE_MODE_SGMII ||
-	    mode == PHY_INTERFACE_MODE_USXGMII) {
-		if (mode == PHY_INTERFACE_MODE_XGMII)
-			ret = rtpcs_931x_sds_set_mac_mode(sds, hw_mode);
-		else
-			ret = rtpcs_931x_sds_set_ip_mode(sds, hw_mode);
-	}
-
+	ret = rtpcs_931x_sds_set_mode(sds, hw_mode);
 	if (ret < 0)
 		return ret;
 

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -2384,6 +2384,9 @@ static void rtpcs_931x_sds_mii_mode_set(struct rtpcs_serdes *sds,
 	int shift = ((sds->id & 0x3) << 3);
 
 	switch (mode) {
+	case PHY_INTERFACE_MODE_NA:
+		val = 0x1f;
+		break;
 	case PHY_INTERFACE_MODE_QSGMII:
 		val = 0x6;
 		break;
@@ -2407,12 +2410,6 @@ static void rtpcs_931x_sds_mii_mode_set(struct rtpcs_serdes *sds,
 			  0xff << shift, val << shift);
 }
 
-static void rtpcs_931x_sds_disable(struct rtpcs_serdes *sds)
-{
-	regmap_write(sds->ctrl->map,
-		     RTL931X_SERDES_MODE_CTRL + (sds->id >> 2) * 4, 0x9f);
-}
-
 static void rtpcs_931x_sds_fiber_mode_set(struct rtpcs_serdes *sds,
 					  phy_interface_t mode)
 {
@@ -2420,8 +2417,7 @@ static void rtpcs_931x_sds_fiber_mode_set(struct rtpcs_serdes *sds,
 
 	/* clear symbol error count before changing mode */
 	rtpcs_931x_sds_clear_symerr(sds, mode);
-
-	rtpcs_931x_sds_disable(sds);
+	rtpcs_931x_sds_mii_mode_set(sds, PHY_INTERFACE_MODE_NA);
 
 	switch (mode) {
 	case PHY_INTERFACE_MODE_SGMII:

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -2424,6 +2424,10 @@ static void rtpcs_931x_sds_fiber_mode_set(struct rtpcs_serdes *sds,
 	rtpcs_931x_sds_mii_mode_set(sds, RTPCS_SDS_MODE_OFF);
 
 	switch (hw_mode) {
+	case RTPCS_SDS_MODE_OFF:
+		val = 0x3f;
+		break;
+
 	case RTPCS_SDS_MODE_SGMII:
 		val = 0x5;
 		break;
@@ -2492,14 +2496,6 @@ static void rtpcs_931x_sds_rx_reset(struct rtpcs_serdes *sds)
 	rtpcs_sds_write(sds, 0x20, 0x0, 0xc30);
 
 	mdelay(50);
-}
-
-__always_unused
-static void rtpcs_931x_sds_fiber_disable(struct rtpcs_serdes *sds)
-{
-	u32 v = 0x3F;
-
-	rtpcs_sds_write_bits(sds, 0x1F, 0x9, 11, 6, v);
 }
 
 static int rtpcs_931x_sds_cmu_page_get(phy_interface_t mode)

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -2381,6 +2381,7 @@ static void rtpcs_931x_sds_mii_mode_set(struct rtpcs_serdes *sds,
 					phy_interface_t mode)
 {
 	u32 val;
+	int shift = ((sds->id & 0x3) << 3);
 
 	switch (mode) {
 	case PHY_INTERFACE_MODE_QSGMII:
@@ -2400,10 +2401,10 @@ static void rtpcs_931x_sds_mii_mode_set(struct rtpcs_serdes *sds,
 		return;
 	}
 
-	val |= (1 << 7);
-
-	regmap_write(sds->ctrl->map,
-		     RTL931X_SERDES_MODE_CTRL + 4 * (sds->id >> 2), val);
+	val |= BIT(7); /* force mode bit */
+	regmap_write_bits(sds->ctrl->map,
+			  RTL931X_SERDES_MODE_CTRL + 4 * (sds->id >> 2),
+			  0xff << shift, val << shift);
 }
 
 static void rtpcs_931x_sds_disable(struct rtpcs_serdes *sds)


### PR DESCRIPTION
Fix some issues in RTL931X SerDes initialization. Most importantly, this adopts the patch done by @0xharshal and @ecsv (provided in [1]) to make it work in the PCS driver.

Tested on Zyxel XS1930-10 with following observations:
- 10GBase-LR, 10GBase-SR working fine
- 1000Base-SX working fine
- 1000Base-T (SGMII) fine on 1 of 2 devices
- 10G DAC: still issues with link flapping but works in theory

I left out the USXGMII fixes from the patch because USXGMII (+ XSGMII) initialization needs a lot more love to be properly implemented.

[1] https://github.com/openwrt/openwrt/pull/19579#issuecomment-3371818370