### PR TITLE
mediatek/filogic: add Keenetic KN-1812/Netcraze NC-1812 support

### DIFF
--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dts
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+#include "mt7988d-keenetic-kn-1812.dtsi"
+
+/ {
+	model = "Keenetic KN-1812";
+	compatible = "keenetic,kn-1812", "mediatek,mt7988d";
+};

--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
@@ -1,0 +1,610 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7988a.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+#include <dt-bindings/regulator/richtek,rt5190a-regulator.h>
+
+/ {
+	aliases {
+		serial0 = &serial0;
+		label-mac-device = &gmac1;
+		led-boot = &power_led;
+		led-failsafe = &power_led;
+		led-running = &power_led;
+		led-upgrade = &power_led;
+	};
+
+	chosen {
+		stdout-path = &serial0;
+		bootargs = "console=ttyS0,115200n1 pci=pcie_bus_perf";
+	};
+
+	memory@40000000 {
+		reg = <0x0 0x40000000 0x0 0x40000000>;
+		device_type = "memory";
+	};
+
+	cpus {
+		/delete-node/ cpu@3;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-fn1 {
+			label = "fn1";
+			linux,code = <BTN_0>;
+			gpios = <&pio 29 GPIO_ACTIVE_LOW>;
+		};
+
+		button-fn2 {
+			label = "fn2";
+			linux,code = <BTN_1>;
+			gpios = <&pio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 60 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 61 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		/* fn1 */
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <0>;
+			gpios = <&pio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		/* fn2 */
+		led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_INDICATOR;
+			function-enumerator = <1>;
+			gpios = <&pio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		/* wifi */
+		led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&pio 47 GPIO_ACTIVE_LOW>;
+		};
+
+		/* internet */
+		led-3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN_ONLINE;
+			gpios = <&pio 48 GPIO_ACTIVE_LOW>;
+		};
+
+		/* power */
+		power_led: led-4 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 50 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		/* usb2.0 hub GL850G */
+		usbhub {
+			gpio-export,name = "usbhub";
+			gpio-export,output = <1>;
+			gpios = <&pio 34 GPIO_ACTIVE_HIGH>;
+		};
+
+		/* USB2.0 */
+		usb1power {
+			gpio-export,name = "usb1power";
+			gpio-export,output = <1>;
+			gpios = <&pio 44 GPIO_ACTIVE_HIGH>;
+		};
+
+		/* USB3.2 Gen1 */
+		usb2power {
+			gpio-export,name = "usb2power";
+			gpio-export,output = <1>;
+			gpios = <&pio 45 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &storage1 &firmware2 &storage2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x600000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x600000 0x0>;
+			};
+		};
+	};
+};
+
+/* configure uart */
+&serial0 {
+	status = "okay";
+};
+
+/* configure spi-nand */
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	/* Winbond W25N02KV (256M) */
+	spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-rx-bus-width = <4>;
+		spi-tx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* bl2 */
+			partition@0 {
+				label = "preloader";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			/* fip */
+			partition@80000 {
+				label = "u-boot";
+				reg = <0x80000 0x200000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "u-config";
+				reg = <0x280000 0x80000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "rf-eeprom";
+				reg = <0x300000 0x400000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1e00>;
+					};
+
+					/* lan mac */
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
+					/* 5Ghz mac */
+					macaddr_factory_a: macaddr@a {
+						reg = <0xa 0x6>;
+					};
+
+					/* lan5 mac */
+					macaddr_factory_fffee: macaddr@fffee {
+						reg = <0xfffee 0x6>;
+					};
+
+					/* wan mac */
+					macaddr_factory_ffffa: macaddr@ffffa {
+						reg = <0xffffa 0x6>;
+					};
+				};
+			};
+
+			firmware1: partition@700000 {
+				label = "firmware_1";
+				reg = <0x700000 0x3800000>;
+			};
+
+			partition@3f00000 {
+				label = "config_1";
+				reg = <0x3f00000 0x80000>;
+				read-only;
+			};
+
+			partition@3f80000 {
+				label = "dump";
+				reg = <0x3f80000 0x80000>;
+				read-only;
+			};
+
+			storage1: partition@4000000 {
+				label = "storage_a";
+				reg = <0x4000000 0x3800000>;
+			};
+
+			partition@7800000 {
+				label = "u-state";
+				reg = <0x7800000 0x80000>;
+				read-only;
+			};
+
+			partition@7a80000 {
+				label = "u-config_res";
+				reg = <0x7a80000 0x80000>;
+				read-only;
+			};
+
+			partition@7b00000 {
+				label = "rf-eeprom_res";
+				reg = <0x7b00000 0x400000>;
+				read-only;
+			};
+
+			firmware2: partition@7f00000 {
+				label = "firmware_2";
+				reg = <0x7f00000 0x3800000>;
+			};
+
+			partition@b700000 {
+				label = "config_2";
+				reg = <0xb700000 0x80000>;
+				read-only;
+			};
+
+			storage2: partition@b780000 {
+				label = "storage_b";
+				reg = <0xb780000 0x3880000>;
+			};
+		};
+	};
+};
+
+/* configure switch */
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+};
+
+/* lan1 */
+&gsw_port0 {
+	label = "lan1";
+};
+
+&gsw_phy0 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe0_led0_pins>;
+};
+
+&gsw_phy0_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+};
+
+/* lan2 */
+&gsw_port1 {
+	label = "lan2";
+};
+
+&gsw_phy1 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe1_led0_pins>;
+};
+
+&gsw_phy1_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+};
+
+/* lan3 */
+&gsw_port2 {
+	label = "lan3";
+};
+
+&gsw_phy2 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe2_led0_pins>;
+};
+
+&gsw_phy2_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+};
+
+/* lan4 */
+&gsw_port3 {
+	label = "lan4";
+};
+
+&gsw_phy3 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe3_led0_pins>;
+};
+
+&gsw_phy3_led0 {
+	status = "okay";
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_GREEN>;
+};
+
+/* configure wan */
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_ffffa>;
+	nvmem-cell-names = "mac-address";
+	label = "wan";
+	phy-mode = "internal";
+	phy-connection-type = "internal";
+	phy = <&int_2p5g_phy>;
+	status = "okay";
+};
+
+&int_2p5g_phy {
+	pinctrl-names = "i2p5gbe-led";
+	pinctrl-0 = <&i2p5gbe_led0_pins>;
+};
+
+&i2p5gbe_led0 {
+	color = <LED_COLOR_ID_GREEN>;
+	function = LED_FUNCTION_WAN;
+	status = "okay";
+};
+
+/* configure lan5 */
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio0_pins>;
+	status = "okay";
+};
+
+&mdio_bus {
+	phy27: ethernet-phy@1b {
+		/* RTL8261BE */
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <0x1b>;
+
+		reset-gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+	};
+};
+
+&gmac2 {
+	nvmem-cells = <&macaddr_factory_fffee>;
+	nvmem-cell-names = "mac-address";
+	label = "lan5";
+	phy-mode = "usxgmii";
+	phy-connection-type = "usxgmii";
+	phy = <&phy27>;
+	status = "okay";
+};
+
+/* configure power supply */
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+
+	rt5190a_64: rt5190a@64 {
+		compatible = "richtek,rt5190a";
+		reg = <0x64>;
+
+		vin2-supply = <&rt5190_buck1>;
+		vin3-supply = <&rt5190_buck1>;
+		vin4-supply = <&rt5190_buck1>;
+
+		regulators {
+			rt5190_buck1: buck1 {
+				regulator-name = "rt5190a-buck1";
+				regulator-min-microvolt = <5090000>;
+				regulator-max-microvolt = <5090000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			buck2 {
+				regulator-name = "vcore";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			rt5190_buck3: buck3 {
+				regulator-name = "vproc";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+			};
+
+			buck4 {
+				regulator-name = "rt5190a-buck4";
+				regulator-min-microvolt = <850000>;
+				regulator-max-microvolt = <850000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+
+			ldo {
+				regulator-name = "rt5190a-ldo";
+				regulator-min-microvolt = <1200000>;
+				regulator-max-microvolt = <1200000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+		};
+	};
+};
+
+&cpu0 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu1 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu2 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cci {
+	proc-supply = <&rt5190_buck3>;
+};
+
+/* configure wifi chip */
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_1_pins>;
+	wifi-reset-gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+	wifi-reset-msleep = <100>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		mt7996@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+			ieee80211-freq-limit = <2400000 2500000>, <5170000 5835000>;
+
+			band@0 {
+				/* 2.4 GHz */
+				reg = <0>;
+				nvmem-cells = <&macaddr_factory_4>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@1 {
+				/* 5 GHz */
+				reg = <1>;
+				nvmem-cells = <&macaddr_factory_a>;
+				nvmem-cell-names = "mac-address";
+			};
+		};
+	};
+};
+
+/* configure pinmux settings */
+&pio {
+	mdio0_pins: mdio0-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio0";
+		};
+
+		conf {
+			groups = "mdc_mdio0";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+
+	gbe0_led0_pins: gbe0-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe0_led0";
+		};
+	};
+
+	gbe1_led0_pins: gbe1-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe1_led0";
+		};
+	};
+
+	gbe2_led0_pins: gbe2-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe2_led0";
+		};
+	};
+
+	gbe3_led0_pins: gbe3-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe3_led0";
+		};
+	};
+
+	i2p5gbe_led0_pins: 2p5gbe-led0-pins {
+		mux {
+			function = "led";
+			groups = "2p5gbe_led0";
+		};
+	};
+
+	i2c0_pins: i2c0-pins-g0 {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+
+	pcie0_1_pins: pcie0-pins-g1 {
+		mux {
+			function = "pcie";
+			groups = "pcie_2l_0_pereset", "pcie_clk_req_n0_0";
+		};
+	};
+
+	spi0_flash_pins: spi0-flash-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+};
+
+/* configure usb */
+&ssusb1 {
+	status = "okay";
+};
+
+&tphy {
+	status = "okay";
+};

--- a/target/linux/mediatek/dts/mt7988d-netcraze-nc-1812.dts
+++ b/target/linux/mediatek/dts/mt7988d-netcraze-nc-1812.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+#include "mt7988d-keenetic-kn-1812.dtsi"
+
+/ {
+	model = "Netcraze NC-1812";
+	compatible = "netcraze,nc-1812", "mediatek,mt7988d";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -103,6 +103,12 @@ iptime,ax3000sm)
 iptime,ax7800m-6e)
 	ucidef_set_led_netdev "wan" "wan" "mdio-bus:06:blue:wan" "eth1" "link tx rx"
 	;;
+keenetic,kn-1812|\
+netcraze,nc-1812)
+	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:indicator-1" "phy0.0-ap0"
+	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan" "phy0.1-ap0"
+	ucidef_set_led_netdev "internet" "internet" "green:wan-online" "wan" "link"
+	;;
 mercusys,mr80x-v3)
 	ucidef_set_led_netdev "lan1" "lan-1" "green:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan-2" "green:lan-2" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -141,6 +141,10 @@ mediatek_setup_interfaces()
 	yuncore,ax835)
 		ucidef_set_interfaces_lan_wan lan wan
 		;;
+	keenetic,kn-1812|\
+	netcraze,nc-1812)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "wan"
+		;;
 	mediatek,mt7986a-rfb)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan6" "eth1 wan"
 		;;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1616,6 +1616,32 @@ define Device/jdcloud_re-cp-03
 endef
 TARGET_DEVICES += jdcloud_re-cp-03
 
+define Device/keenetic_kn-1812-common
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7992-firmware kmod-usb3 \
+		mt7988-2p5g-phy-firmware mt7988-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 6144k
+  IMAGE_SIZE := 229888k
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
+	append-squashfs4-fakeroot
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size | zyimage -d $$(ZYIMAGE_ID) -v "$$(DEVICE_MODEL)"
+endef
+
+define Device/keenetic_kn-1812
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-1812
+  DEVICE_DTS := mt7988d-keenetic-kn-1812
+  ZYIMAGE_ID := 0x801812
+  $(call Device/keenetic_kn-1812-common)
+endef
+TARGET_DEVICES += keenetic_kn-1812
+
 define Device/keenetic_kn-3711
   DEVICE_VENDOR := Keenetic
   DEVICE_MODEL := KN-3711
@@ -2029,6 +2055,15 @@ define Device/netcore_n60-pro
   ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot netcore_n60-pro
 endef
 TARGET_DEVICES += netcore_n60-pro
+
+define Device/netcraze_nc-1812
+  DEVICE_VENDOR := Netcraze
+  DEVICE_MODEL := NC-1812
+  DEVICE_DTS := mt7988d-netcraze-nc-1812
+  ZYIMAGE_ID := 0xC01812
+  $(call Device/keenetic_kn-1812-common)
+endef
+TARGET_DEVICES += netcraze_nc-1812
 
 define Device/netgear_eax17
   DEVICE_VENDOR := NETGEAR

--- a/target/linux/mediatek/patches-6.12/966-pcie-mediatek-gen3-Add-WIFI-HW-reset-flow.patch
+++ b/target/linux/mediatek/patches-6.12/966-pcie-mediatek-gen3-Add-WIFI-HW-reset-flow.patch
@@ -1,0 +1,88 @@
+From f566462daef92eb0074013e32d0332116fc3a2eb Mon Sep 17 00:00:00 2001
+From: Jianguo Zhang <jianguo.zhang@mediatek.com>
+Date: Tue, 14 Oct 2025 16:00:03 +0800
+Subject: [PATCH] pcie: mediatek-gen3: Add WIFI HW reset flow
+
+[Description]
+Add WIFI HW reset before PCIe host detects EP device for reboot.
+
+[Release-log]
+NA
+
+Signed-off-by: Jianguo Zhang <jianguo.zhang@mediatek.com>
+---
+ drivers/pci/controller/pcie-mediatek-gen3.c | 29 +++++++++++++++++++++
+ 1 file changed, 29 insertions(+)
+
+--- a/drivers/pci/controller/pcie-mediatek-gen3.c
++++ b/drivers/pci/controller/pcie-mediatek-gen3.c
+@@ -10,6 +10,8 @@
+ #include <linux/clk.h>
+ #include <linux/clk-provider.h>
+ #include <linux/delay.h>
++#include <linux/gpio.h>
++#include <linux/gpio/consumer.h>
+ #include <linux/iopoll.h>
+ #include <linux/irq.h>
+ #include <linux/irqchip/chained_irq.h>
+@@ -18,6 +20,7 @@
+ #include <linux/module.h>
+ #include <linux/msi.h>
+ #include <linux/of_device.h>
++#include <linux/of_gpio.h>
+ #include <linux/of_pci.h>
+ #include <linux/pci.h>
+ #include <linux/phy/phy.h>
+@@ -160,6 +163,8 @@ struct mtk_msi_set {
+  * @phy: PHY controller block
+  * @clks: PCIe clocks
+  * @num_clks: PCIe clocks count for this port
++ * @wifi_reset: reset pin for WIFI chip
++ * @wifi_reset_delay_ms: delay time for WIFI chip reset
+  * @irq: PCIe controller interrupt number
+  * @saved_irq_state: IRQ enable state saved at suspend time
+  * @irq_lock: lock protecting IRQ register access
+@@ -181,6 +186,9 @@ struct mtk_gen3_pcie {
+ 	struct clk_bulk_data *clks;
+ 	int num_clks;
+ 
++	struct gpio_desc *wifi_reset;
++	u32 wifi_reset_delay_ms;
++
+ 	int irq;
+ 	u32 saved_irq_state;
+ 	raw_spinlock_t irq_lock;
+@@ -402,6 +410,12 @@ static int mtk_pcie_startup_port(struct
+ 	val |= PCIE_DISABLE_DVFSRC_VLT_REQ;
+ 	writel_relaxed(val, pcie->base + PCIE_MISC_CTRL_REG);
+ 
++	if (pcie->wifi_reset) {
++		gpiod_set_value_cansleep(pcie->wifi_reset, 1);
++		msleep(pcie->wifi_reset_delay_ms);
++		gpiod_set_value_cansleep(pcie->wifi_reset, 0);
++	}
++
+ 	/* Assert all reset signals */
+ 	val = readl_relaxed(pcie->base + PCIE_RST_CTRL_REG);
+ 	val |= PCIE_MAC_RSTB | PCIE_PHY_RSTB | PCIE_BRG_RSTB | PCIE_PE_RSTB;
+@@ -864,6 +878,20 @@ static int mtk_pcie_parse_port(struct mt
+ 		return pcie->num_clks;
+ 	}
+ 
++	ret = of_property_read_u32(dev->of_node, "wifi-reset-msleep",
++				   &pcie->wifi_reset_delay_ms);
++	if (!ret) {
++		pcie->wifi_reset = devm_gpiod_get_optional(dev, "wifi-reset",
++							   GPIOD_OUT_LOW);
++		if (IS_ERR(pcie->wifi_reset)) {
++			ret = PTR_ERR(pcie->wifi_reset);
++			if (ret != -EPROBE_DEFER)
++				dev_err(dev,
++					"failed to request WIFI reset gpio\n");
++			return ret;
++		}
++	}
++
+ 	return 0;
+ }
+ 


### PR DESCRIPTION
Device specification
--------------------
SoC Type:   MediaTek MT7988D, Cortex-A73, 64-bit
RAM:        1024MB DDR4 Micron MT40A512M16TB-062E:R
Flash:      SPI NAND Winbond W25N02KV (256 MiB)
Ethernet:   4x1GbE (internal MT7988 built-in) + 2.5GbE (internal MT7988 phy) + 10GbE (RTL8261BE)

WLAN:       MT7992AV
WLAN 2g:    MediaTek MT7975N, b/g/n/ax/be, MIMO 4x4
WLAN 5g:    MediaTek MT7977B, a/n/ac/ax/be, MIMO 4x4
LEDs:       5 LEDs, 1 power green, 1 internet green,
		2x fn green, 1 wlan, gpio-controlled
Button:     4 (Reset, WPS, FN1, FN2)
USB port:   Yes, 1xUSB3.2 and 1xUSB2.0 (via GL850G)
Power:      12 VDC, 3 A

Notes:
 * The device supports dual boot mode
 * Fn2 led reassigned to wlan 2.4

Flash instruction:
The only way to flash OpenWrt image is to use tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.1.2/24 and tftp server.
2. a) Keenetic
      Rename "openwrt-mediatek-filogic-keenetic_kn-1812-squashfs-factory.bin"
      to "KN-1812_recovery.bin" and place it in tftp server directory.
   b) Netcraze
      Rename "openwrt-mediatek-filogic-netcraze_nc-1812-squashfs-factory.bin"
      to "NC-1812_recovery.bin" and place it in tftp server directory.
3. Connect PC with ethernet port, press the reset button, power up
   the device and keep button pressed until status led start blinking.
4. Device will download file from server, write it to flash and reboot.

P.S.  I added several patches from the MTK SDK. Without them, the Wi-Fi chip wasn't detected, and there's no way to reduce the processor frequency at high temperatures.