### PR TITLE
[24.10] ipq806x: Provide wifi pci/pcie path migration script backward from 6.12 to 6.6

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -315,3 +315,10 @@ macaddr_canonicalize() {
 dt_is_enabled() {
 	grep -q okay "/proc/device-tree/$1/status"
 }
+
+get_linux_version() {
+	local ver=$(uname -r)
+	local minor=${ver%\.*}
+
+	printf "%d%02d%03d" ${ver%%\.*} ${minor#*\.} ${ver##*\.} 2>/dev/null
+}

--- a/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# This must run before 10-wifi-detect
+
+[ "${ACTION}" = "add" ] || return
+
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+do_migrate_radio()
+{
+	local config="$1"
+
+	config_get from "$config" path
+
+	to=${from/pci\//pcie\/}
+
+	# Checks if kernel version is less than 6.12.0, if it is and the path is
+	# using the new format, then path should be migrated to the old format.
+	[ "$(get_linux_version)" -lt "612000" ] && to=${from/pcie\//pci\/}
+
+	[ "$from" = "$to" ] && return
+
+	uci set "wireless.${config}.path=${to}"
+	WIRELESS_CHANGED=true
+
+	logger -t wifi-migrate "Updated path of wireless.${config} from '${from}' to '${to}'"
+}
+
+migrate_radio()
+{
+	config_load wireless
+
+	config_foreach do_migrate_radio wifi-device
+}
+
+WIRELESS_CHANGED=false
+
+case "$(board_name)" in
+*)
+	migrate_radio
+	;;
+esac
+
+$WIRELESS_CHANGED && uci commit wireless
+
+exit 0


### PR DESCRIPTION
Backport the wifi pci/pcie path migration script from main/master to provide backward migration capability from 6.12 to 6.6. 
That migration is needed if somebody moves from a main/master development build to a stable 24.10 build.

Simple cherry-picking of a0fe3cf and ae70dbc works.

Run-tested with ipq806x/R7800, between 24.10 and master, both direction.

Reference to discussion in https://github.com/openwrt/openwrt/pull/18989#issuecomment-3518287251

cc @Ansuel 
