### PR TITLE
Airoha: fix borken patches

### DIFF
--- a/target/linux/airoha/patches-6.12/801-01-net-phy-add-PHY_DETACH_NO_HW_RESET-PHY-flag.patch
+++ b/target/linux/airoha/patches-6.12/801-01-net-phy-add-PHY_DETACH_NO_HW_RESET-PHY-flag.patch
@@ -112,7 +112,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  
  	/* Assert the reset signal */
 -	phy_device_reset(phydev, 1);
-+	if (!(phydev->drv->flags & PHY_DETACH_NO_HW_RESET))
++	if (!phydev->drv || !(phydev->drv->flags & PHY_DETACH_NO_HW_RESET))
 +		phy_device_reset(phydev, 1);
  
  	/*


### PR DESCRIPTION
The pinctrl patch was modified recently, and that broke it.
The side effect was that we crashed in a bug introduced by the PHY_DETACH_NO_HW_RESET patch.
This change fixes both.