### PR TITLE
mpc85xx: p1010: Fix Sophos RED 15w NAND partitions

### DIFF
--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/red-15w-rev1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/red-15w-rev1.dts
@@ -165,23 +165,19 @@
 					read-only;
 				};
 
+				partition@300000 {
+					reg = <0x300000 0x800000>;
+					label = "kernel";
+				};
+
+				partition@b00000 {
+					reg = <0xb00000 0x7500000>;
+					label = "ubi";
+				};
+
 				oem-partition@300000 {
 					reg = <0x300000 0x1900000>;
 					label = "sophos-os1";
-
-					compatible = "fixed-partitions";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					partition@0 {
-						reg = <0x0 0x800000>;
-						label = "kernel";
-					};
-
-					partition@800000 {
-						reg = <0x800000 0x7500000>;
-						label = "ubi";
-					};
 				};
 
 				oem-partition@1c00000 {


### PR DESCRIPTION
When upgrading from an earlier version to OpenWrt 24.10 or later, the UBI rootfs can't be mounted anymore, and the device boot loops.

In addition, the UBI device arbitrarily changes from `/dev/mtd4` to `/dev/mtd5`.

The following error message can be found in the boot log:

```
mtd: partition "ubi" extends beyond the end of device "sophos-os1" -- size truncated to 0x1100000
[...]
UBI: auto-attach mtd5
ubi0: attaching mtd5
ubi0: scanning is finished
ubi0 error: 0xc04e8e58: the layout volume was not found
ubi0 error: 0xc04ecfe8: failed to attach mtd5, error -22
UBI error: cannot attach mtd5
/dev/root: Can't open blockdev
VFS: Cannot open root device "" or unknown-block(0,0): error -6
```

Fix DTS to prevent this, while keeping the previous mtd numbers of the OpenWrt partitions (mtd3 and mtd4), so the original installation instructions will remain valid. Also keep the stock partition definitions (mtd5, mtd6 and mtd7) available, in order to allow backing up the stock firmware and restoring the device back to stock.

Note: In order to be able to boot OpenWrt 24.10 or later, also the boot command has to be changed in U-Boot. This can be done using serial console, either before or after upgrading:

```
setenv bootcmd setenv bootargs console=ttyS0,115200\; nand read 0x1800000 0x300000 0x800000\; bootm 0x1800000
saveenv
```

Previous versions will continue to work with the new boot command.

Fixes: 78d259e7d28d212425164fc64bf0b9d8669d6020