### PR TITLE
prereq-build: delete redundant Python version checks

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -187,23 +187,9 @@ $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 	perl --version | grep "perl.*v5"))
 
 $(eval $(call SetupHostCommand,python,Please install Python >= 3.8, \
-	python3.14 -V 2>&1 | grep 'Python 3', \
-	python3.13 -V 2>&1 | grep 'Python 3', \
-	python3.12 -V 2>&1 | grep 'Python 3', \
-	python3.11 -V 2>&1 | grep 'Python 3', \
-	python3.10 -V 2>&1 | grep 'Python 3', \
-	python3.9 -V 2>&1 | grep 'Python 3', \
-	python3.8 -V 2>&1 | grep 'Python 3', \
 	python3 -V 2>&1 | grep -E 'Python 3\.([8-9]|[0-9][0-9])\.?'))
 
 $(eval $(call SetupHostCommand,python3,Please install Python >= 3.8, \
-	python3.14 -V 2>&1 | grep 'Python 3', \
-	python3.13 -V 2>&1 | grep 'Python 3', \
-	python3.12 -V 2>&1 | grep 'Python 3', \
-	python3.11 -V 2>&1 | grep 'Python 3', \
-	python3.10 -V 2>&1 | grep 'Python 3', \
-	python3.9 -V 2>&1 | grep 'Python 3', \
-	python3.8 -V 2>&1 | grep 'Python 3', \
 	python3 -V 2>&1 | grep -E 'Python 3\.([8-9]|[0-9][0-9])\.?'))
 
 $(eval $(call TestHostCommand,python3-distutils, \


### PR DESCRIPTION
Since commit https://github.com/openwrt/openwrt/commit/a9e8eec221874e5840d659aed3f68850ff1d9982 all future Python versions until 3.99 are supported and there is no need for manually adding each one.
