### PR TITLE
mediatek: add Zyxel NWA90AX PRO model identifier

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -110,7 +110,7 @@ endef
 
 define Build/zyxel-nwa-fit-filogic
 	$(TOPDIR)/scripts/mkits-zyxel-fit-filogic.sh \
-		$@.its $@ "80 e1 ff ff ff ff ff ff ff ff"
+		$@.its $@ "80 e1 81 e1 ff ff ff ff ff ff"
 	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
 	@mv $@.new $@
 endef


### PR DESCRIPTION
Fixes: e34e874a11f0506ff17365819bc101a455dc503e

The NWA90AX Pro diagnostics information reports this model number which is different than the NWA50AX Pro. Otherwise the hardware is the exact same.

```
ZySH system commands output
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
_debug show file /etc/zyxel/ftp/diaglog/.update-fw.log
--------------------------------------------------------------------------------
Upgrade started
Current time: Tue Nov 11 12:43:58 GMT 2025
----- kernel cmdline -----
console=ttyS0,115200n1 earlycon=uart8250,mmio32,0x11002000 loglevel=1 bootVer=V1.08 bootImage=1
------- FW version -------
FIRMWARE_VER=7.00(ACGF.1)
BUILD_DATE=2024-07-09 05:15:52
MODEL_ID=NWA90AX PRO
COMPATIBLE_PRODUCT_MODEL_0=81E1
...
```

Confirmed by inspecting the device tree of the flashed firmware.

```
> binwalk 710ACGF3C0.bin

DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
0             0x0             Flattened device tree, size: 39657996 bytes, version: 17
... Removed ...

> dtc -I dtb -O dts -o DeviceTree 710ACGF3C0.bin

> head DeviceTree 
/dts-v1/;

/ {
        timestamp = <0x6860779e>;
        description = [00];
        compat-models = [81 e1 ff ff ff ff ff ff ff ff];
        fw_version = "7.10(###.3)";

        images {

```

Output after local build

```
>  binwalk openwrt-mediatek-filogic-zyxel_nwa50ax-pro-squashfs-factory.bin

DECIMAL       HEXADECIMAL     DESCRIPTION
--------------------------------------------------------------------------------
0             0x0             Flattened device tree, size: 12060057 bytes, version: 17
224           0xE0            UBI erase count header, version: 1, EC: 0x0, VID header offset: 0x800, data offset: 0x1000

> dtc -f -I dtb -O dts -o fwout openwrt-mediatek-filogic-zyxel_nwa50ax-pro-squashfs-factory.bin
head fwout
/dts-v1/;

/ {
        timestamp = <0x68f513d9>;
        description = "Zyxel FIT (Flattened Image Tree)";
        compat-models = [80 e1 81 e1 ff ff ff ff ff ff];
        fw_version = "9.99(###.1)";
        #address-cells = <0x01>;

        images {
```

Signed-off-by: James Davis <james.l.davis@outlook.com>