### PR TITLE
mediatek: add support for WAVLINK WL-WN536AX6 Rev a

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
+++ b/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
@@ -1,0 +1,385 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	compatible = "wavlink,wl-wn536ax6-a", "mediatek,mt7986a";
+	model = "WAVLINK WL-WN536AX6 Rev a";
+
+	aliases {
+		serial0 = &uart0;
+		label-mac-device = &wifi;
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		pair {
+			label = "pair";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		turbo {
+			label = "turbo";
+			linux,code = <BTN_MISC>;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_blue: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 31 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&pio 32 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	reg_1p8v: regulator-1p8v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-1.8V";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	/* LAN */
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_hw_44e 0>;
+
+		fixed-link {
+			full-duplex;
+			pause;
+			speed = <2500>;
+		};
+	};
+
+	/* WAN */
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy6>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_hw_44e 1>;
+	};
+
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* MaxLinear GPY211C 2.5G PHY */
+		phy6: phy@6 {
+			/*
+			 * Force the ID here as the PHY only reports it's
+			 * (C45) ID correctly after a reset (before resetting
+			 * it reports 0xfffffff, which causes only the genphy
+			 * driver to match).
+			 */
+			compatible = "ethernet-phy-id67c9.de10";
+			reg = <6>;
+			reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+			reset-assert-us = <600>;
+			reset-deassert-us = <20000>;
+			phy-mode = "2500base-x";
+		};
+
+		switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "lan4";
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan3";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan2";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan1";
+				};
+
+				port@6 {
+					reg = <6>;
+					label = "cpu";
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+			drive-strength = <MTK_DRIVE_8mA>;
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+			drive-strength = <MTK_DRIVE_8mA>;
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+					"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+					"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+					"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+					"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+					"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+					"WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+
+	wf_dbdc_pins: wf_dbdc-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_dbdc";
+		};
+
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	/* Macronix SPI NAND (128M) */
+	flash@0 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x4000000>;
+			};
+
+			partition@7580000 {
+				label = "HW";
+				reg = <0x4580000 0x80000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_hw_44e: macaddr@44e {
+						compatible = "mac-base";
+						reg = <0x44e 0x11>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&ssusb {
+	status = "okay";
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&trng {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	pinctrl-names = "default", "dbdc";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+	pinctrl-1 = <&wf_dbdc_pins>;
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -233,6 +233,10 @@ tplink,re6000xd)
 	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-1" "lan2" "link tx rx"
 	ucidef_set_led_netdev "eth1" "lan-3" "blue:lan-2" "eth1" "link tx rx"
 	;;
+wavlink,wl-wn536ax6-a)
+	ucidef_set_led_netdev "wifi" "wifi" "blue:wlan" "phy1-ap0" "link"
+	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
+	;;
 wavlink,wl-wn551x3)
         ucidef_set_led_netdev "lan-1" "lan-1" "green:lan-1" "lan1" "link tx rx"
         ucidef_set_led_netdev "lan-2" "lan-2" "green:lan-2" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -68,6 +68,7 @@ mediatek_setup_interfaces()
 	nradio,c8-668gl|\
 	ruijie,rg-x60-pro|\
 	unielec,u7981-01*|\
+	wavlink,wl-wn536ax6-a|\
 	zbtlink,zbt-z8102ax|\
 	zbtlink,zbt-z8102ax-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2451,6 +2451,24 @@ define Device/unielec_u7981-01-nand
 endef
 TARGET_DEVICES += unielec_u7981-01-nand
 
+define Device/wavlink_wl-wn536ax6-a
+  DEVICE_VENDOR := WAVLINK
+  DEVICE_MODEL := WL-WN536AX6
+  DEVICE_VARIANT := Rev a
+  DEVICE_DTS := mt7986a-wavlink-wl-wn536ax6-a
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_INITRAMFS_SUFFIX := .itb
+  KERNEL_IN_UBI := 1
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += wavlink_wl-wn536ax6-a
+
 define Device/wavlink_wl-wn551x3
   DEVICE_VENDOR := WAVLINK
   DEVICE_MODEL := WL-WN551X3


### PR DESCRIPTION
Product name: Wavlink WL-WN536AX6 Rev a "Mighty LX2"
Product link: https://www.wavlink.com/en_us/product/WL-WN536AX6.html

Specifications:
SOC: MT7986AV
RAM: 512MB DDR4
Flash: 128MB SPI NAND
Ports: 4 LAN (1G) & 1 WAN (2.5G)
WIFI: MT7976PN + MT7975N
LEDs: 8 (STATUS, WIFI, WAN, LAN1, LAN2, LAN3, LAN4, PWR)
USB: 1 (3.0)

MAC table, same as stock firmware:
LAN: 80:3F:5D:xx:xx:x1 partition "hw" at 0x44e (ASCII)
WAN: 80:3F:5D:xx:xx:x2 partition "hw" at 0x460 (ASCII)
2G: 80:3F:5D:xx:xx:x3
5G: 80:3F:5D:xx:xx:x4

* Installation with OEM WebUI:

Note: Make sure PC is connected on LAN1 port. The OEM firmware has an unknown root password and settings are kept after upgrading firmware. Therefore, a customized Openwrt firmware is needed to remove the root password on startup, by adding `passwd -d root` to /etc/init.d/bootcount. The WebUI does a filename check so the customized firmware is named accordingly.

1. Download modified firmware file `WAVLINK_WN536AX6-A_M36AX6_V250320-WO-437baca-modified.bin` from https://github.com/ses1er/firmware-misc/tree/main/wavlink/wl-wn536ax6a
2. Log into WebUI on default IP: http://192.168.20.1
3. Browse to More (top menu) -> System -> Firmware Upgrade.
4. Under `Local Upgrade` section, check the device to be upgraded and upload downloaded modified firmware. Click `UPLOAD FILE`, then `APPLY`
5. Wait about 2 minutes (ignore progress bar), and browse to http://192.168.20.1. You should see LUCI login page. Username is root and no password.
6. Browse to `System -> Backup/Flash Firmware`, click on `Flash Image`, click `Browse` and locate `openwrt-mediatek-filogic-wavlink_wl-wn536ax6a-squashfs-sysupgrade.bin` file.
7. Uncheck `Keep settings and retain the current configuration` and click `Continue`.
8.  Router will now be set to IP 192.168.1.1 which is the Openwrt default.

* Installation with UART:

Note: Having UART connected while cold booting the device will result in a kernel panic when initializing wifi. I've found this workaround:
1. Power off the device and ensure UART is not connected to PC.
2. Power up the device, when lights come on, plug in UART.
3. Warm boots and soft restarts will not cause kernel panic for the duration of device being powered on. Repeat steps for subsequent cold boots.

Installation:
1. Configure TFTP server with IP 192.168.1.66. Copy `openwrt-mediatek-filogic-wavlink_wl-wn536ax6-a-initramfs.itb` to TFTP root.
2. Interrupt boot by pressing 0.
3. Run the following in Uboot console: `setenv serverip 192.168.1.66; setenv ipaddr 192.168.1.1; tftpboot 0x46000000 openwrt-mediatek-filogic-wavlink_wl-wn536ax6-a-initramfs.itb; bootm`
4. Transfer `openwrt-mediatek-filogic-wavlink_wl-wn536ax6-a-squashfs-sysupgrade.bin` to device: (`scp -O openwrt-mediatek-filogic-wavlink_wl-wn536ax6a-squashfs-sysupgrade.bin root@192.168.1.1:/tmp/`)
5. Run the following on device: `sysupgrade -n /tmp/openwrt-mediatek-filogic-wavlink_wl-wn536ax6-a-squashfs-sysupgrade.bin`

OEM firmware's DTS file: https://gist.github.com/ses1er/51b6cbd59609f3f733ef6efe01cc39e6

### Limitation

Since this device has 1 WLAN LED and 2 radios, you'd need to pick which radio controls the LED.
With #19903, either/both radios can activate the LED and provides an OEM experience to the device.
