### PR TITLE
mediatek: fix ubi size for zbtlink zbt z8102ax v2

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
@@ -39,7 +39,7 @@
 			linux,code = <KEY_WPS_BUTTON>;
 			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
 		};
-		
+
 	};
 
 	leds {
@@ -56,20 +56,20 @@
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
 		};
-		
+
 		led_status_blue: blue {
 			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_STATUS;
 		};
-		
+
 		led_status_5g1: 5g1 {
 			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_USB;
 			function-enumerator = <0>;
 		};
-		
+
 		led_status_5g2: 5g2 {
 			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
 			color = <LED_COLOR_ID_BLUE>;
@@ -136,7 +136,7 @@
 			pause;
 		};
 	};
-	
+
 	gmac1: mac@1 {
 		compatible = "mediatek,eth-mac";
 		reg = <1>;
@@ -208,7 +208,7 @@
 
 			nand_rootfs: partition@580000 {
 				label = "ubi";
-				reg = <0x0580000 0x7220000>;
+				reg = <0x0580000 0x7280000>;
 			};
 		};
 	};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
@@ -8,12 +8,11 @@ case "$(board_name)" in
 	bananapi,bpi-r3)
 		ucidef_set_compat_version "1.3"
 		;;
-	routerich,ax3000)
-		ucidef_set_compat_version "1.1"
-		;;
 	bananapi,bpi-r4|\
 	bananapi,bpi-r4-2g5|\
-	bananapi,bpi-r4-poe)
+	bananapi,bpi-r4-poe|\
+	routerich,ax3000|\
+	zbtlink,zbt-z8102ax-v2)
 		ucidef_set_compat_version "1.1"
 		;;
 esac

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2689,6 +2689,8 @@ define Device/zbtlink_zbt-z8102ax-v2
   IMAGES += factory.bin
   IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Partition layout has been changed to fit the bootloader
 endef
 TARGET_DEVICES += zbtlink_zbt-z8102ax-v2
 


### PR DESCRIPTION
According to the factory uboot and firmware[^1], the ubi size is set
to 512 MiB (0x20000000) and it exceeds the size of the flash, after
that the uboot and kernel resizes it to 114.5 MiB (0x7280000) instead
of 114.125 MiB (0x7220000). The mismatch of the ubi size causes
kernel fails to read ubi volumes and throws panic.

Trim whilespaces while at it.

[^1]: https://github.com/immortalwrt/immortalwrt/issues/2123#issuecomment-3523744128
