### PR TITLE
mediatek: add support for ipTIME AX3000SE

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000se.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000se.dts
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "ipTIME AX3000SE";
+	compatible = "iptime,ax3000se", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		label-mac-device = &wan;
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		button-1 {
+			label = "reset";
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: led-0 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 (3)>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x6E00000>;
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		wan: port@0 {
+			reg = <0>;
+			label = "wan";
+			nvmem-cell-names = "mac-address";
+			nvmem-cells = <&macaddr_factory_4 (1)>;
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan4";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan2";
+		};
+
+		port@4 {
+			reg = <4>;
+			label = "lan1";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 (0)>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 (0)>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -92,6 +92,9 @@ huasifei,wh3000)
 iptime,ax3000q)
 	ucidef_set_led_netdev "wan" "WAN" "amber:wan" "wan" "link tx rx"
 	;;
+iptime,ax3000se)
+	ucidef_set_led_netdev "wlan" "WLAN" "blue:wlan" "phy1-ap0"
+	;;
 iptime,ax3000sm)
 	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -121,6 +121,7 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $addr > /sys${DEVPATH}/macaddress
 		;;
 	iptime,ax3000m|\
+	iptime,ax3000se|\
 	iptime,ax3000sm)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_setbit $addr 26) 25) 27) 28) > \

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1428,6 +1428,26 @@ define Device/iptime_ax3000q
 endef
 TARGET_DEVICES += iptime_ax3000q
 
+define Device/iptime_ax3000se
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := AX3000SE
+  DEVICE_DTS := mt7981b-iptime-ax3000se
+  DEVICE_DTS_DIR := ../dts
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 32768k
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGES := sysupgrade.bin
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3kse
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
+endef
+TARGET_DEVICES += iptime_ax3000se
+
 define Device/iptime_ax3000sm
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := AX3000SM


### PR DESCRIPTION
Specification
-------------
- SoC       : MediaTek MT7981BA dual-core ARM Cortex-A53 1.3GHz
- RAM       : DDR3 256Mbytes, ESMT M15T2G16128A
- Flash     : 128Mbytes NAND Flash, ESMT F50L1G41LB
- WLAN      : MediaTek MT7976CN dual-band Wi-Fi 6
  - 2.4GHz  : b/g/n/ax, MU-MIMO
  - 5GHz    : a/n/ac/ax, MU-MIMO
- Ethernet  : MediaTek MT7531AE
  - LAN     : 10/100/1000 Mbps x4
  - WAN     : 10/100/1000 Mbps x1
- UART      : 1x4 pin header hole on PCB
  - 3.3V, RX, GND, TX (115200, 8N1)
- Buttons   : WPS, Reset
- LEDs      : 7 LEDs
  - 1x CPU (Amber/Blue)
  - 1x Wi-Fi (Amber/Blue)
  - 1x WAN activity (Amber/Blue)
  - 4x LAN activity (Amber/Blue)
- Power     : 12VDC, 1A (Center positive polarity)

Note: The LED color is amber or blue, depending on your router's color (black/white).

MAC address
-----------

| Interface | MAC               | Algorithm |
|-|-|-|
| WLAN 2.4G | B0:38:6C:xx:xx:xx | label     |
| WLAN 5G   | B2:38:6C:4x:xx:xx |           |
| WAN       | B0:38:6C:xx:xx:xx | label + 1 |
| LAN       | B0:38:6C:xx:xx:xx | label + 3 |

The WLAN 2.4G MAC address was found in 'Factory' partition, 0x4

Installation
------------
1. Download the OEM recovery software (ipTIME Firmware Wizard (11ac)) from the manufacturer's website
2. Download the *squashfs-factory.bin file from the OpenWrt website
3. Press a reset button, and power up the router (keep pressing the reset button)
4. Wait more than 10 seconds until the CPU LED stop blinking
5. Connect the router (LAN port) to the PC
6. Run the OEM recovery software and follow the instructions
7. Select the *squashfs-factory.bin file during the router recovery process
8. Wait for the router to boot from *squashfs-factory.bin

Limitation: Triggering the WLAN LED for activity on both phy0 (2.4GHz) and phy1 (5GHz) 
----------
Currently, the UCI doesn't support triggering a single LED for activity on multiple WLAN interfaces. As a temporary workaround, the LED is configured to only indicate activity on `phy1`. If you wish to monitor `phy0` instead, you must change the device from `phy1-ap0` to `phy0-ap0` in the LuCI LED configuration.

Screenshot
--------
<details><summary>OpenWrt Luci Web Interface</summary>
<p>

<img width="812" height="917" alt="openwrt-luci-web-interface" src="https://github.com/user-attachments/assets/72b4f9ad-ffa0-4b32-9c81-c74464a4c2dc" />

</p>
</details> 

Bootlogs
--------
<details><summary>OEM Bootlog</summary>
<p>

```
F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 024F [010F]
Jump to BL

NOTICE:  BL2: v2.7(release):openwrt_update_for_driver_7672_update-16-ge17ac657ee
NOTICE:  BL2: Built : 15:47:59, Mar 20 2025
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a083f1 000003ff 00100000 00000000
1001d040 | 00000000 00000000 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0x8 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 620, worse bit 1, min window 76
Window Sum 588, worse bit 8, min window 72
Window Sum 394, worse bit 2, min window 46
Window Sum 312, worse bit 9, min window 36
Window Sum 404, worse bit 2, min window 48
Window Sum 330, worse bit 9, min window 38
Window Sum 408, worse bit 3, min window 48
Window Sum 414, worse bit 2, min window 48
Window Sum 334, worse bit 9, min window 38
Window Sum 422, worse bit 2, min window 50
Window Sum 348, worse bit 15, min window 40
Window Sum 356, worse bit 11, min window 42
Window Sum 428, worse bit 3, min window 50
Window Sum 358, worse bit 9, min window 42
Window Sum 370, worse bit 9, min window 44
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc8
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 0 found in block 960
NOTICE:  Second info table with writecount 0 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):openwrt_update_for_driver_7672_update-16-ge17ac657ee
NOTICE:  BL31: Built : 15:48:01, Mar 20 2025
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Mar 20 2025 - 15:47:14 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: GigaDevice SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 0 found in block 960
Second info table with writecount 0 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[?25h[2J[1;1H----------------------------> Turned on LEDS: 9
Check RST button - wait 1 second

ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 110 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 2/0, WL threshold: 4096, image sequence number: 193594469
ubi0: available PEBs: 428, total reserved PEBs: 452, PEBs reserved for bad PEB handling: 19
Reading from volume 'kernel' to 0x46000000, size 0x0 ... OK
## Loading kernel from FIT Image at 46000000 ...
   Using 'config@1' configuration
   Trying 'kernel@1' kernel subimage
     Description:  ARM64 OpenWrt Linux-5.4.246
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x460000e8
     Data Size:    3389947 Bytes = 3.2 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x48080000
     Entry Point:  0x48080000
     Hash algo:    crc32
     Hash value:   a051e482
     Hash algo:    sha1
     Hash value:   d59d1b3fb51d0892eb343d0af5cde85d95d348fe
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 46000000 ...
   Using 'config@1' configuration
   Trying 'fdt@1' fdt subimage
     Description:  ARM64 OpenWrt image-mt7981-spim-nand-ax3000q device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x4633bc34
     Data Size:    18374 Bytes = 17.9 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   c26e478a
     Hash algo:    sha1
     Hash value:   f41e66b6d7c8bb8989903eaea23fef2b3b8edf91
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x4633bc34
   Uncompressing Kernel Image
   Loading Device Tree to 000000004f7f1000, end 000000004f7f87c5 ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 5.4.246 (ipTIME@5497c1999d3d) (gcc version 8.4.0 (OpenWrt GCC 8.4.0 r16908-b4f139f8d1)) #0 SMP Wed Feb 5 07:52:24 2025
[    0.000000] Machine model: ipTIME AX3000Q
[    0.000000] On node 0 totalpages: 64512
[    0.000000]   DMA32 zone: 1024 pages used for memmap
[    0.000000]   DMA32 zone: 0 pages reserved
[    0.000000]   DMA32 zone: 64512 pages, LIFO batch:15
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.0
[    0.000000] percpu: Embedded 20 pages/cpu s43672 r8192 d30056 u81920
[    0.000000] pcpu-alloc: s43672 r8192 d30056 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 63488
[    0.000000] Kernel command line: console=ttyS0,115200 boot_from=A
[    0.000000] get_boot_firmware_name(66) boot_from=rootfs
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 230152K/258048K available (7038K kernel code, 494K rwdata, 1996K rodata, 448K init, 296K bss, 27896K reserved, 0K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	CONFIG_RCU_FANOUT set to non-default value of 32.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] GICv3: Distributor has no Range Selector support
[    0.000000] GICv3: 16 PPIs implemented
[    0.000000] GICv3: no VLPI support, no direct LPI support
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000003] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000140] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=52000)
[    0.000147] pid_max: default: 32768 minimum: 301
[    0.000216] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.000221] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.000951] ASID allocator initialised with 65536 entries
[    0.001009] rcu: Hierarchical SRCU implementation.
[    0.001296] smp: Bringing up secondary CPUs ...
[    0.001582] Detected VIPT I-cache on CPU1
[    0.001602] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.001624] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.001685] smp: Brought up 1 node, 2 CPUs
[    0.001693] SMP: Total of 2 processors activated.
[    0.001698] CPU features: detected: 32-bit EL0 Support
[    0.001702] CPU features: detected: CRC32 instructions
[    0.001803] CPU: All CPU(s) started at EL2
[    0.001813] alternatives: patching kernel code
[    0.002321] devtmpfs: initialized
[    0.004224] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.004239] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.004322] pinctrl core: initialized pinctrl subsystem
[    0.004969] NET: Registered protocol family 16
[    0.005172] DMA: preallocated 256 KiB pool for atomic allocations
[    0.019512] cryptd: max_cpu_qlen set to 1000
[    0.021245] SCSI subsystem initialized
[    0.021431] libata version 3.00 loaded.
[    0.021604] usbcore: registered new interface driver usbfs
[    0.021632] usbcore: registered new interface driver hub
[    0.021666] usbcore: registered new device driver usb
[    0.022589] Bluetooth: Core ver 2.22
[    0.022633] NET: Registered protocol family 31
[    0.022636] Bluetooth: HCI device and connection manager initialized
[    0.022644] Bluetooth: HCI socket layer initialized
[    0.022653] Bluetooth: L2CAP socket layer initialized
[    0.022663] Bluetooth: SCO socket layer initialized
[    0.022914] rbus 18000000.wbsys: PCI host bridge to bus 0000:00
[    0.022924] pci_bus 0000:00: root bus resource [mem 0x18000000-0x18ffffff]
[    0.022930] pci_bus 0000:00: root bus resource [bus 00-ff]
[    0.022936] pci_bus 0000:00: scanning bus
[    0.022953] pci 0000:00:00.0: [14c3:7981] type 00 class 0x000280
[    0.022968] pci 0000:00:00.0: reg 0x10: [mem 0x18000000-0x1800000f 64bit]
[    0.022974] pci 0000:00:00.0: reg 0x18: [mem 0x00000000-0x0000000f]
[    0.022981] pci 0000:00:00.0: reg 0x1c: [mem 0x00000000-0x0000000f]
[    0.022987] pci 0000:00:00.0: reg 0x20: [mem 0x00000000-0x0000000f]
[    0.022993] pci 0000:00:00.0: reg 0x24: [mem 0x00000000-0x0000000f]
[    0.023834] pci_bus 0000:00: fixups for bus
[    0.023841] pci_bus 0000:00: bus scan returning with max=00
[    0.024258] clocksource: Switched to clocksource arch_sys_counter
[    0.025206] thermal_sys: Registered thermal governor 'fair_share'
[    0.025211] thermal_sys: Registered thermal governor 'bang_bang'
[    0.025221] thermal_sys: Registered thermal governor 'step_wise'
[    0.025224] thermal_sys: Registered thermal governor 'user_space'
[    0.025228] thermal_sys: Registered thermal governor 'power_allocator'
[    0.025444] NET: Registered protocol family 2
[    0.025544] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.025908] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.025926] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.025945] TCP bind hash table entries: 2048 (order: 3, 32768 bytes, linear)
[    0.025971] TCP: Hash tables configured (established 2048 bind 2048)
[    0.026042] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.026058] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.026164] NET: Registered protocol family 1
[    0.026194] PCI: CLS 0 bytes, default 64
[    0.026849] workingset: timestamp_bits=62 max_order=16 bucket_order=0
[    0.029219] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.029228] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.041707] phy phy-usb-phy@11e10000.1: type_sw - reg 0x218, index 0
[    0.052317] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.053212] printk: console [ttyS0] disabled
[    0.073345] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 12, base_baud = 2500000) is a ST16650V2
[    0.714816] printk: console [ttyS0] enabled
[    0.719682] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.728216] loop: module loaded
[    0.731477] mediatek,mt2701-ice_debug ice_debug: get dbg_sel clock fail: -2
[    0.738455] mediatek,mt2701-ice_debug: probe of ice_debug failed with error -2
[    0.746542] mt7981-pinctrl 11d00000.pinctrl: pin_config_set op failed for pin 19
[    0.753937] mtk-spi 1100a000.spi: Error applying setting, reverse things back
[    0.761561] spi-nand spi0.0: Failed to calibrate SPI-NAND (err = -22)
[    0.768099] spi-nand spi0.0: GigaDevice SPI NAND was found.
[    0.773671] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.784380] [mtk_hw_init] reset_lock:0, force:0
[    0.788948] [mtk_hw_init] execute fe cold reset
[    0.804488] mtk_soc_eth 15100000.ethernet: MDC is running on 2500000 Hz
[    0.831758] mtk_soc_eth 15100000.ethernet: generated random MAC address ce:be:50:3f:61:c2
[    0.840249] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc011900000, irq 79
[    0.849327] mtk_soc_eth 15100000.ethernet: generated random MAC address 16:e0:22:f3:a8:33
[    0.857762] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc011900000, irq 79
[    0.866808] (unnamed net_device) (dummy): netif_napi_add() called with weight 256
[    0.874563] usbcore: registered new interface driver usblp
[    0.880175] usbcore: registered new interface driver uas
[    0.885534] usbcore: registered new interface driver usb-storage
[    0.891637] i2c /dev entries driver
[    0.896126] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    0.904272] device-mapper: ioctl: 4.41.0-ioctl (2019-09-16) initialised: dm-devel@redhat.com
[    0.912861] Bluetooth: HCI UART driver ver 2.3
[    0.917311] Bluetooth: HCI UART protocol H4 registered
[    0.922450] Bluetooth: HCI UART protocol BCSP registered
[    0.927841] Bluetooth: HCI UART protocol Broadcom registered
[    0.933513] Bluetooth: HCI UART protocol QCA registered
[    0.939237] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    0.953955] Twin IP Module Init
[    0.957121] --> Init Smart QoS Monitor
[    0.961165] NET: Registered protocol family 10
[    0.966241] Segment Routing with IPv6
[    0.969955] NET: Registered protocol family 17
[    0.974430] Bridge firewalling registered
[    0.978513] 8021q: 802.1Q VLAN Support v1.8
[    0.992155] nmbm nmbm_spim_nand: Signature found at block 1023 [0x07fe0000]
[    1.000028] nmbm nmbm_spim_nand: First info table with writecount 0 found in block 960
[    1.010638] nmbm nmbm_spim_nand: Second info table with writecount 0 found in block 963
[    1.018638] nmbm nmbm_spim_nand: NMBM has been successfully attached 
[    1.025231] 5 fixed-partitions partitions found on MTD device nmbm_spim_nand
[    1.032275] Creating 5 MTD partitions on "nmbm_spim_nand":
[    1.037761] 0x000000000000-0x000000100000 : "BL2"
[    1.043082] 0x000000100000-0x000000180000 : "u-boot-env"
[    1.048941] 0x000000180000-0x000000380000 : "Factory"
[    1.054531] 0x000000380000-0x000000580000 : "FIP"
[    1.059812] 0x000000580000-0x000007380000 : "ubi"
[    1.291039] mt7530 mdio-bus:1f lan0 (uninitialized): PHY [dsa-0.0:00] driver [MediaTek MT7531 PHY]
[    1.309702] mt7530 mdio-bus:1f lan1 (uninitialized): PHY [dsa-0.0:01] driver [MediaTek MT7531 PHY]
[    1.328345] mt7530 mdio-bus:1f lan2 (uninitialized): PHY [dsa-0.0:02] driver [MediaTek MT7531 PHY]
[    1.346986] mt7530 mdio-bus:1f lan3 (uninitialized): PHY [dsa-0.0:03] driver [MediaTek MT7531 PHY]
[    1.365623] mt7530 mdio-bus:1f lan4 (uninitialized): PHY [dsa-0.0:04] driver [MediaTek MT7531 PHY]
[    1.375200] mt7530 mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.382271] DSA: tree 0 setup
[    1.382523] mt7530 mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.385232] mt7530-nl: genl_register_family_with_ops 
[    1.397911] UBI: auto-attach mtd5
[    1.401251] ubi0: attaching mtd5
[    1.761123] ubi0: scanning is finished
[    1.770498] ubi0: attached mtd5 (name "ubi", size 110 MiB)
[    1.775985] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    1.782853] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    1.789630] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    1.796580] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    1.802575] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[    1.809785] ubi0: max/mean erase counter: 2/0, WL threshold: 4096, image sequence number: 193594469
[    1.818816] ubi0: available PEBs: 428, total reserved PEBs: 452, PEBs reserved for bad PEB handling: 19
[    1.828202] ubi0: background thread "ubi_bgt0d" started, PID 732
[    1.828944] block ubiblock0_2: created from ubi0:2(rootfs)
[    1.839695] ubiblock: device ubiblock0_2 (rootfs) set to be root filesystem
[    1.846648] hctosys: unable to open rtc device (rtc0)
[    1.854809] VFS: Mounted root (squashfs filesystem) readonly on device 253:0.
[    1.864545] devtmpfs: mounted
[    1.867738] Freeing unused kernel memory: 448K
[    1.888220] Run /sbin/init as init process
Start inittime
---> init fs


Checking Uboot Env ---> [ OK : ax3kse ]


check_and_install_mtk_eeprom:Check EEPROM (wl_mode:0) -> [ OK ]
check_and_install_mtk_eeprom:Check EEPROM (wl_mode:1) -> [ OK ]
---> init elog
---> init dump_core
---> init version
Product ID:ax3kse Version:15.104
---> init sys
Install Module Failed: nf_conntrack_netlink.ko
 
---> init sysctl
---> init restore_config
	--> Restoring Config...
		--> 1st Config - Default
		 -- Default account : Do macfmt conversion admin/admin
		 -- mgmt access - credential patched : admin /  admin
		 -- patched (login --> removed)
		 -- patched (password --> removed)
rm: can't remove '/data/etc/econf/elog/*': No such file or directory
---> init restore_session
---> init nfrule
---> init servd
---> init config
rm: can't remove '/etc/snmp*': No such file or directory
---> init ftm
---> init tz
---> init gpio
  ---> gpio.init end
---> init mac
    =================================================================
    press magic key to change default setting ...
    LAN MAC : B0:38:6C:6E:8D:73
    WAN MAC : B0:38:6C:6E:8D:71
---> init bridge
---> init wireless
  ---> wl.preinit
		--->Pre-Interface up/down:ra0
	Scanning best channel for wl_mode:0 --->[ 2 ]
	--> set_profile WL_MODE:0
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b0.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b0.dat
	--> set_profile WL_MODE:1
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b1.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b1.dat
set 0x7d3 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d3=0x82
set 0x7d4 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d4=0x82
No need to scan for wl_mode:0 (channel:2) is already found
	--> set_profile WL_MODE:0
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b0.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b0.dat
	--> set_profile WL_MODE:1
		Profile:/etc/wireless/mediatek/mt7981.dbdc.b1.dat
		Default Profile:/default/etc/wireless/mediatek/mt7981.dbdc.b1.dat
set 0x7d3 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d3=0x82
set 0x7d4 = 0x82
si_run_regulation_cmd -> mtke2p 2g 0x7d4=0x82
---> init iptables
  ---> NAT:enabled
---> init lan
---> init wan
---> init dns
---> init resume_lan
---> init iptables_chain
  --> br-lan multicast_router=2
---> init dos
Reload macvlan
---> init connctrl
  ---> init_connctrl
---> init disable_switch
---> init switch
  ---> IPTV mode: 2
---> init macvlan
Reload macvlan
route: SIOCDELRT: No such process
---> init enable_switch
---> init port_mirroring
---> init port_config
---> init stacache
---> init portcache
---> init optimization
Optimize CPU : wireless
---> init resume_wan
---> init route
---> init services
killall: gpioctld: no process killed
Reload macvlan
killall: apcpd: no process killed
  ---> init_connctrl
---> Initialize HostName
killall: httpd: no process killed
---> Start station cache timer
---> set_hwnat: hwnat:1
Install mtk nat module
insmod: can't insert '/lib/modules/5.4.246/mtkhnat.ko': File exists
rtcs:initial:304,interval:21600
rtcs:initial:1550,interval:21600
killall: snmpd: no process killed
killall: snmptrapd: no process killed
Terminated
Stop MTK 8021x Daemon for ra0.
Stop MTK 8021x Daemon for rax0.
killall: inotifywait: no process killed
killall: saved: no process killed
---> init easymesh
End inittime
Setting up watches.  Beware: since -r was given, this may take a while!
Watches established.
Stopping strongSwan IPsec failed: starter is not running
helper_timer_handler:Start wl_helper
[1970/01/01 09:00:42.691648]:(info):(3950)reg_pwr:pwr-cache is flushed:2.40
[1970/01/01 09:00:42.691848]:(info):(3950)reg_pwr:update power:2g -> KR:100%
[1970/01/01 09:00:42.700362]:(info):(3950)wl_set_txpower:reg_pwr:band:2g, Channel:2/40, Power:60 %
[1970/01/01 09:00:42.701229]:(info):(3950)reg_pwr:pwr-cache is flushed:36.160
[1970/01/01 09:00:42.701403]:(info):(3950)reg_pwr:update power:5g -> KR:100%
killall: dhcpd.helper: no process killed
[1970/01/01 09:00:42.715576]:(info):(3950)wl_set_txpower:reg_pwr:band:5g, Channel:36/160, Power:40 %
timer helper_timer has not finished yet
```

</p>
</details> 

<details><summary>OpenWrt Bootlog</summary>
<p>

```
F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 024F [010F]
Jump to BL

NOTICE:  BL2: v2.7(release):openwrt_update_for_driver_7672_update-16-ge17ac657ee
NOTICE:  BL2: Built : 15:47:59, Mar 20 2025
NOTICE:  WDT: disabled
NOTICE:  EMI: Using DDR3 settings

dump toprgu registers data: 
1001c000 | 00000000 0000ffe0 00000000 00000000
1001c010 | 00000fff 00000000 00f00000 00000000
1001c020 | 00000000 00000000 00000000 00000000
1001c030 | 003c0003 003c0003 00000000 00000000
1001c040 | 00000000 00000000 00000000 00000000
1001c050 | 00000000 00000000 00000000 00000000
1001c060 | 00000000 00000000 00000000 00000000
1001c070 | 00000000 00000000 00000000 00000000
1001c080 | 00000000 00000000 00000000 00000000

dump drm registers data: 
1001d000 | 00000000 00000000 00000000 00000000
1001d010 | 00000000 00000000 00000000 00000000
1001d020 | 00000000 00000000 00000000 00000000
1001d030 | 00a083f1 000003ff 00100000 00000000
1001d040 | 00000000 00000000 00020303 000000ff
1001d050 | 00000000 00000000 00000000 00000000
1001d060 | 00000002 00000000 00000000 00000000
drm: 500 = 0x8 
[DDR Reserve] ddr reserve mode not be enabled yet
DDR RESERVE Success 0
[EMI] ComboMCP not ready, using default setting
BYTE_swap:0 
BYTE_swap:0 
Window Sum 596, worse bit 1, min window 72
Window Sum 584, worse bit 8, min window 72
Window Sum 416, worse bit 1, min window 50
Window Sum 350, worse bit 8, min window 42
Window Sum 424, worse bit 2, min window 50
Window Sum 354, worse bit 9, min window 42
Window Sum 428, worse bit 2, min window 50
Window Sum 364, worse bit 15, min window 42
Window Sum 430, worse bit 2, min window 50
Window Sum 374, worse bit 9, min window 44
Window Sum 436, worse bit 2, min window 52
Window Sum 386, worse bit 9, min window 46
Window Sum 438, worse bit 3, min window 52
NOTICE:  EMI: Detected DRAM size: 256MB
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI_NAND parses attributes from parameter page.
NOTICE:  SPI_NAND Detected ID 0xc8
NOTICE:  Page size 2048, Block size 131072, size 134217728
NOTICE:  Initializing NMBM ...
NOTICE:  Signature found at block 1023 [0x07fe0000]
NOTICE:  First info table with writecount 0 found in block 960
NOTICE:  Second info table with writecount 0 found in block 963
NOTICE:  NMBM has been successfully attached in read-only mode
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.7(release):openwrt_update_for_driver_7672_update-16-ge17ac657ee
NOTICE:  BL31: Built : 15:48:01, Mar 20 2025
NOTICE:  Hello BL31!!!


U-Boot 2022.07-rc3 (Mar 20 2025 - 15:47:14 +0900)

CPU:   MediaTek MT7981
Model: mt7981-rfb
DRAM:  256 MiB
Core:  36 devices, 16 uclasses, devicetree: embed
7[r[999;999H[6n8
Initializing NMBM ...
spi-nand: spi_nand spi_nand@0: GigaDevice SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
Could not find a valid device for nmbm0
Signature found at block 1023 [0x07fe0000]
First info table with writecount 0 found in block 960
Second info table with writecount 0 found in block 963
NMBM has been successfully attached 

Loading Environment from MTD... OK
In:    serial@11002000
Out:   serial@11002000
Err:   serial@11002000
Net:   eth0: ethernet@15100000
[?25l[2J[1;1H[1;1H[2K[2;3H*** U-Boot Boot Menu ***[0K[3;1H[2K[12;1H[2K[13;3HPress UP/DOWN to move, ENTER to select, ESC/CTRL+C to quit[0K[14;1H[2K[4;7H[7m1. Startup system (Default)[0m[5;7H2. Upgrade firmware[6;7H3. Upgrade ATF BL2[7;7H4. Upgrade ATF FIP[8;7H5. Upgrade single image[9;7H6. Load image[10;7H0. U-Boot console[12;3HHit any key to stop autoboot: 1 [12;1H[2K[?25h[2J[1;1H----------------------------> Turned on LEDS: 9
Check RST button - wait 1 second

ubi0: attaching mtd6
ubi0: scanning is finished
ubi0: attached mtd6 (name "ubi", size 110 MiB)
ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
ubi0: max/mean erase counter: 2/1, WL threshold: 4096, image sequence number: 193594469
ubi0: available PEBs: 516, total reserved PEBs: 364, PEBs reserved for bad PEB handling: 19
Reading from volume 'kernel' to 0x46000000, size 0x0 ... OK
## Loading kernel from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'kernel-1' kernel subimage
     Description:  ARM64 OpenWrt Linux-6.12.57
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x460000e8
     Data Size:    4456390 Bytes = 4.2 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x48000000
     Entry Point:  0x48000000
     Hash algo:    crc32
     Hash value:   efcecbee
     Hash algo:    sha1
     Hash value:   ab4f804e945fad2f0c9415a5ca3782ef6de3608b
   Verifying Hash Integrity ... crc32+ sha1+ OK
## Loading fdt from FIT Image at 46000000 ...
   Using 'config-1' configuration
   Trying 'fdt-1' fdt subimage
     Description:  ARM64 OpenWrt iptime_ax3000se device tree blob
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x464401f0
     Data Size:    22395 Bytes = 21.9 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   6066cd9e
     Hash algo:    sha1
     Hash value:   f21b7b4aca7e019d67f942511edb4145ee324c43
   Verifying Hash Integrity ... crc32+ sha1+ OK
   Booting using the fdt blob at 0x464401f0
   Uncompressing Kernel Image
   Loading Device Tree to 000000004f7f0000, end 000000004f7f877a ... OK

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.12.57 (nyanko@DevBox) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r0+31789-57a1b6abf5) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Thu Nov 13 10:52:43 2025
[    0.000000] Machine model: ipTIME AX3000SE
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004302ffff (192 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x0000000047c80000..0x0000000047d7ffff (1024 KiB) nomap non-reusable wmcpu-reserved@47c80000
[    0.000000] OF: reserved mem: 0x0000000047d80000..0x0000000047dbffff (256 KiB) nomap non-reusable wo-emi@47d80000
[    0.000000] OF: reserved mem: 0x0000000047dc0000..0x0000000047ffffff (2304 KiB) nomap non-reusable wo-data@47dc0000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004302ffff]
[    0.000000]   node   0: [mem 0x0000000043030000-0x0000000047c7ffff]
[    0.000000]   node   0: [mem 0x0000000047c80000-0x0000000047ffffff]
[    0.000000]   node   0: [mem 0x0000000048000000-0x000000004fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000004fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 20 pages/cpu s42520 r8192 d31208 u81920
[    0.000000] pcpu-alloc: s42520 r8192 d31208 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: console=ttyS0,115200 boot_from=A
[    0.000000] Unknown kernel command line parameters "boot_from=A", will be passed to user space.
[    0.000000] Dentry cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 65536
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[    0.000000] software IO TLB: area num 2.
[    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 0MB
[    0.000000] software IO TLB: mapped [mem 0x000000004fe4b000-0x000000004fecb000] (0MB)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=4 to nr_cpu_ids=2.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=2
[    0.000000] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: GICD_CTRL.DS=0, SCR_EL3.FIQ=0
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000074] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000083] pid_max: default: 32768 minimum: 301
[    0.003062] Mount-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.003070] Mountpoint-cache hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.005203] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.006036] rcu: Hierarchical SRCU implementation.
[    0.006043] rcu: 	Max phase no-delay instances is 1000.
[    0.006240] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.006474] smp: Bringing up secondary CPUs ...
[    0.006834] Detected VIPT I-cache on CPU1
[    0.006883] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.006913] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.006995] smp: Brought up 1 node, 2 CPUs
[    0.007001] SMP: Total of 2 processors activated.
[    0.007003] CPU: All CPU(s) started at EL2
[    0.007006] CPU features: detected: 32-bit EL0 Support
[    0.007009] CPU features: detected: CRC32 instructions
[    0.007039] alternatives: applying system-wide alternatives
[    0.007169] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.007283] Memory: 236920K/262144K available (9216K kernel code, 982K rwdata, 2756K rodata, 448K init, 298K bss, 23596K reserved, 0K cma-reserved)
[    0.010361] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.010377] futex hash table entries: 512 (order: 3, 32768 bytes, linear)
[    0.010434] 29296 pages in range for non-PLT usage
[    0.010437] 520816 pages in range for PLT usage
[    0.011943] pinctrl core: initialized pinctrl subsystem
[    0.013234] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.013575] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.013601] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.013620] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.013998] thermal_sys: Registered thermal governor 'fair_share'
[    0.014002] thermal_sys: Registered thermal governor 'bang_bang'
[    0.014005] thermal_sys: Registered thermal governor 'step_wise'
[    0.014007] thermal_sys: Registered thermal governor 'user_space'
[    0.014067] ASID allocator initialised with 65536 entries
[    0.014717] pstore: Using crash dump compression: deflate
[    0.014723] pstore: Registered ramoops as persistent store backend
[    0.014726] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.016214] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.032350] cryptd: max_cpu_qlen set to 1000
[    0.034685] SCSI subsystem initialized
[    0.034844] libata version 3.00 loaded.
[    0.036483] clocksource: Switched to clocksource arch_sys_counter
[    0.038799] NET: Registered PF_INET protocol family
[    0.038897] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.039938] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.039953] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.039962] TCP established hash table entries: 2048 (order: 2, 16384 bytes, linear)
[    0.039981] TCP bind hash table entries: 2048 (order: 4, 65536 bytes, linear)
[    0.040085] TCP: Hash tables configured (established 2048 bind 2048)
[    0.040396] MPTCP token hash table entries: 256 (order: 0, 6144 bytes, linear)
[    0.040496] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.040512] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.040722] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.040755] PCI: CLS 0 bytes, default 64
[    0.042077] workingset: timestamp_bits=46 max_order=16 bucket_order=0
[    0.047081] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.047090] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.114201] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.115430] printk: legacy console [ttyS0] disabled
[    0.135833] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 72, base_baud = 2500000) is a ST16650V2
[    0.135878] printk: legacy console [ttyS0] enabled
[    0.910226] random: crng init done
[    0.916644] loop: module loaded
[    0.922660] spi-nand spi0.0: calibration result: 0x3
[    0.927887] spi-nand spi0.0: ESMT SPI NAND was found.
[    0.932930] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.941700] Signature found at block 1023 [0x07fe0000]
[    0.946854] NMBM management region starts at block 960 [0x07800000]
[    0.955479] First info table with writecount 0 found in block 960
[    0.967430] Second info table with writecount 0 found in block 963
[    0.973612] NMBM has been successfully attached
[    0.978369] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.984721] Creating 5 MTD partitions on "spi0.0":
[    0.989519] 0x000000000000-0x000000100000 : "BL2"
[    0.995411] 0x000000100000-0x000000180000 : "u-boot-env"
[    1.001560] 0x000000180000-0x000000380000 : "Factory"
[    1.008890] 0x000000380000-0x000000580000 : "FIP"
[    1.015624] 0x000000580000-0x000007380000 : "ubi"
[    1.224621] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081400000, irq 75
[    1.234410] i2c_dev: i2c /dev entries driver
[    1.240411] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.249153] NET: Registered PF_INET6 protocol family
[    1.254936] Segment Routing with IPv6
[    1.258643] In-situ OAM (IOAM) with IPv6
[    1.262604] NET: Registered PF_PACKET protocol family
[    1.267974] 8021q: 802.1Q VLAN Support v1.8
[    1.349979] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.358714] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.376434] mt7530-mdio mdio-bus:1f wan (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=79)
[    1.397505] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=80)
[    1.418562] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=81)
[    1.439514] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=82)
[    1.460446] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:04] driver [MediaTek MT7531 PHY] (irq=83)
[    1.471690] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.478446] DSA: tree 0 setup
[    1.482120] UBI: auto-attach mtd4
[    1.485441] ubi0: default fastmap pool size: 40
[    1.489971] ubi0: default fastmap WL pool size: 20
[    1.494751] ubi0: attaching mtd4
[    2.338857] ubi0: scanning is finished
[    2.353700] ubi0: attached mtd4 (name "ubi", size 110 MiB)
[    2.359212] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    2.366075] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.372855] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.379808] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    2.385801] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[    2.393014] ubi0: max/mean erase counter: 2/1, WL threshold: 4096, image sequence number: 193594469
[    2.402048] ubi0: available PEBs: 514, total reserved PEBs: 366, PEBs reserved for bad PEB handling: 19
[    2.411440] ubi0: background thread "ubi_bgt0d" started, PID 560
[    2.412390] block ubiblock0_2: created from ubi0:2(rootfs)
[    2.422941] ubiblock: device ubiblock0_2 (rootfs) set to be root filesystem
[    2.429998] clk: Disabling unused clocks
[    2.434180] PM: genpd: Disabling unused power domains
[    2.447078] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[    2.454411] Freeing unused kernel memory: 448K
[    2.458917] Run /sbin/init as init process
[    2.463003]   with arguments:
[    2.465958]     /sbin/init
[    2.468664]   with environment:
[    2.471793]     HOME=/
[    2.474141]     TERM=linux
[    2.476869]     boot_from=A
[    2.736501] init: Console is alive
[    2.740053] init: - watchdog -
[    3.185069] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.201320] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    3.211324] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.227693] init: - preinit -
[    3.592090] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    3.600717] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    3.625390] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[    4.962924] mt7530-mdio mdio-bus:1f lan1: Link is Up - 1Gbps/Full - flow control rx/tx
[    7.835491] UBIFS (ubi0:0): Mounting in unauthenticated mode
[    7.841263] UBIFS (ubi0:0): background thread "ubifs_bgt0_0" started, PID 676
[    7.896757] UBIFS (ubi0:0): recovery needed
[    8.065005] UBIFS (ubi0:0): recovery completed
[    8.069531] UBIFS (ubi0:0): UBIFS: mounted UBI device 0, volume 0, name "rootfs_data"
[    8.077368] UBIFS (ubi0:0): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[    8.087277] UBIFS (ubi0:0): FS size: 32378880 bytes (30 MiB, 255 LEBs), max 265 LEBs, journal size 1650688 bytes (1 MiB, 13 LEBs)
[    8.098923] UBIFS (ubi0:0): reserved for root: 1529334 bytes (1493 KiB)
[    8.105527] UBIFS (ubi0:0): media format: w5/r0 (latest is w5/r0), UUID 759E228C-5519-40A6-9D66-61531AF5CCC3, small LPT model
[    8.122292] mount_root: switching to ubifs overlay
[    8.133709] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[    8.151655] urandom-seed: Seeding with /etc/urandom.seed
[    8.213711] mt7530-mdio mdio-bus:1f lan1: Link is Down
[    8.222967] procd: - early -
[    8.225912] procd: - watchdog -
[    8.779559] procd: - watchdog -
[    8.790868] procd: - ubus -
[    8.871120] procd: - init -
Please press Enter to activate this console.
[    9.244319] kmodloader: loading kernel modules from /etc/modules.d/*
[    9.275490] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    9.292434] Loading modules backported from Linux version v6.16-0-g038d61fd6422
[    9.299796] Backport generated by backports.git v6.1.145-1-47-g6194bf852a3e
[    9.431650] urngd: v1.0.2 started.
[    9.627962] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823161240a
[    9.627962] 
[    9.866663] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823161304
[    9.979038] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823161841
[   10.077850] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[   10.131192] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[   10.219943] PPP generic driver version 2.4.2
[   10.225320] NET: Registered PF_PPPOX protocol family
[   10.235749] kmodloader: done loading kernel modules from /etc/modules.d/*
[   10.327994] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   10.590706] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   13.678539] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   13.695950] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   13.704836] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   13.720837] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   13.732318] br-lan: port 1(lan1) entered blocking state
[   13.737613] br-lan: port 1(lan1) entered disabled state
[   13.742889] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   13.749175] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   13.758486] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   13.779493] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   13.797465] br-lan: port 2(lan2) entered blocking state
[   13.802702] br-lan: port 2(lan2) entered disabled state
[   13.808026] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   13.817903] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   13.833646] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   13.844503] br-lan: port 3(lan3) entered blocking state
[   13.849820] br-lan: port 3(lan3) entered disabled state
[   13.855081] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   13.863361] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   13.880062] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   13.891564] br-lan: port 4(lan4) entered blocking state
[   13.896842] br-lan: port 4(lan4) entered disabled state
[   13.902097] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   13.910604] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[   13.932195] mt7530-mdio mdio-bus:1f wan: configuring for phy/gmii link mode
[   17.086788] mt7530-mdio mdio-bus:1f lan1: Link is Up - 1Gbps/Full - flow control rx/tx
[   17.086818] br-lan: port 1(lan1) entered blocking state
[   17.099945] br-lan: port 1(lan1) entered forwarding state
[   17.112284] mt7530-mdio mdio-bus:1f wan: Link is Up - 1Gbps/Full - flow control rx/tx



BusyBox v1.37.0 (2025-11-13 10:52:43 UTC) built-in shell (ash)

  _______                     ________        __
 |       |.-----.-----.-----.|  |  |  |.----.|  |_
 |   -   ||  _  |  -__|     ||  |  |  ||   _||   _|
 |_______||   __|_____|__|__||________||__|  |____|
          |__| W I R E L E S S   F R E E D O M
 -----------------------------------------------------
 OpenWrt SNAPSHOT, r0+31789-57a1b6abf5
 -----------------------------------------------------
=== WARNING! =====================================
There is no root password defined on this device!
Use the "passwd" command to set up a new password
in order to prevent unauthorized SSH logins.
--------------------------------------------------

 OpenWrt recently switched to the "apk" package manager!

 OPKG Command           APK Equivalent      Description
 ------------------------------------------------------------------
 opkg install <pkg>     apk add <pkg>       Install a package
 opkg remove <pkg>      apk del <pkg>       Remove a package
 opkg upgrade           apk upgrade         Upgrade all packages
 opkg files <pkg>       apk info -L <pkg>   List package contents
 opkg list-installed    apk info            List installed packages
 opkg update            apk update          Update package lists
 opkg search <pkg>      apk search <pkg>    Search for packages
 ------------------------------------------------------------------

For more https://openwrt.org/docs/guide-user/additional-software/opkg-to-apk-cheatsheet

root@OpenWrt:~# 
```

</p>
</details> 
