### PR TITLE
[24.10] mediatek: add support for ipTIME AX7800M-6E

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
+++ b/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
@@ -149,7 +149,7 @@
 				   "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
 				   "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
 				   "WF1_TOP_CLK", "WF1_TOP_DATA";
-			drive-strength = <4>;
+			drive-strength = <MTK_DRIVE_4mA>;
 		};
 	};
 
@@ -166,7 +166,7 @@
 				   "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
 				   "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
 				   "WF1_TOP_CLK", "WF1_TOP_DATA";
-			drive-strength = <4>;
+			drive-strength = <MTK_DRIVE_4mA>;
 		};
 	};
 };

--- a/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
+++ b/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	model = "ipTIME AX7800M-6E";
+	compatible = "iptime,ax7800m-6e", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+		label-mac-device = &gmac1;
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		button-1 {
+			label = "reset";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+
+		switch-0 {
+			label = "rfkill";
+			gpios = <&pio 15 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RFKILL>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 22 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "default-on";
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_cpu: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&pio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-4 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_6GHZ;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-5 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy2tpt";
+		};
+	};
+
+	gpio-fan {
+		compatible = "gpio-fan";
+		gpios = <&pio 19 GPIO_ACTIVE_HIGH
+				 &pio 18 GPIO_ACTIVE_HIGH>;
+		/* We don't know the exact rpm, just use dummy values here. */
+		gpio-fan,speed-map = <0 0>, <1 1>, <2 2>;
+		#cooling-cells = <2>;
+	};
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+	pcie_pins: pcie-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_pereset";
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				   "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				   "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				   "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				   "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				   "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				   "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+
+	wf_dbdc_pins: wf-dbdc-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_dbdc";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				   "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				   "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				   "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				   "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				   "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				   "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					eeprom_factory_a0000: eeprom@a0000 {
+						reg = <0xa0000 0x1000>;
+					};
+
+					macaddr_factory_a0004: macaddr@a0004 {
+						compatible = "mac-base";
+						reg = <0xa0004 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x6e00000>;
+			};
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_a0004 (3)>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy6>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_a0004 (1)>;
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <50000>;
+		reset-post-delay-us = <20000>;
+	};
+};
+
+&mdio {
+	phy6: phy@6 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <6>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_BLUE>;
+				function = LED_FUNCTION_WAN;
+			};
+		};
+	};
+
+	switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <10000>;
+
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan4";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan3";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan1";
+			};
+
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	pinctrl-names = "default", "dbdc";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+	pinctrl-1 = <&wf_dbdc_pins>;
+	status = "okay";
+};
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie_pins>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <0x03>;
+		#size-cells = <0x02>;
+
+		wifi@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			nvmem-cells = <&eeprom_factory_a0000>;
+			nvmem-cell-names = "eeprom";
+
+			band@0 {
+				reg = <0>;
+				nvmem-cells = <&macaddr_factory_a0004 (0)>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@1 {
+				reg = <1>;
+				nvmem-cells = <&macaddr_factory_a0004 (0)>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@2 {
+				reg = <2>;
+				nvmem-cells = <&macaddr_factory_4 (0)>;
+				nvmem-cell-names = "mac-address";
+			};
+		};
+	};
+};
+
+&pcie_phy {
+	status = "okay";
+};
+
+&trng {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&ssusb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -71,6 +71,9 @@ iptime,ax3000q)
 iptime,ax3000sm)
 	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
 	;;
+iptime,ax7800m-6e)
+	ucidef_set_led_netdev "wan" "wan" "mdio-bus:06:blue:wan" "eth1" "link tx rx"
+	;;
 mercusys,mr80x-v3)
 	ucidef_set_led_netdev "lan1" "lan-1" "green:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan-2" "green:lan-2" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -48,6 +48,7 @@ mediatek_setup_interfaces()
 		;;
 	asus,tuf-ax4200|\
 	iptime,ax3000sm|\
+	iptime,ax7800m-6e|\
 	jdcloud,re-cp-03|\
 	mediatek,mt7981-rfb|\
 	netcore,n60|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -118,6 +118,12 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_setbit $addr 26) 25) 27) 28) > \
 			/sys${DEVPATH}/macaddress
 		;;
+	iptime,ax7800m-6e)
+		addr1=$(mtd_get_mac_binary "Factory" 0xa0004)
+		addr2=$(mtd_get_mac_binary "Factory" 0x4)
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $addr1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "2" ] && macaddr_setbit_la $addr2 > /sys${DEVPATH}/macaddress
+		;;
 	jcg,q30-pro|\
 	netcore,n60)
 		# Originally, phy1 is phy0 mac with LA bit set. However, this would conflict

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1131,6 +1131,25 @@ define Device/iptime_ax3000sm
 endef
 TARGET_DEVICES += iptime_ax3000sm
 
+define Device/iptime_ax7800m-6e
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := AX7800M-6E
+  DEVICE_DTS := mt7986a-iptime-ax7800m-6e
+  DEVICE_DTS_DIR := ../dts
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 32768k
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax7800m
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7916-firmware kmod-mt7986-firmware mt7986-wo-firmware kmod-hwmon-gpiofan
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += iptime_ax7800m-6e
+
 define Device/jcg_q30-pro
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := Q30 PRO


### PR DESCRIPTION
Specification
-------------
- SoC       : MediaTek MT7986AV quad-core ARM Cortex-A53 2GHz
- RAM       : DDR4 512Mbytes, Nanya Technology NT5AD256M16E4
- Flash     : 128Mbytes NAND Flash, ESMT F50L1G41LB
- WLAN      : MediaTek MT7976DAN, MediaTek MT7916AN, MediaTek MT7976AN
  - 2.4GHz  : b/g/n/ax, Multi User MIMO
  - 5GHz    : a/n/ac/ax, Multi User MIMO
  - 6GHz    : ax, Multi User MIMO
- Ethernet  : 10/100/1000 Mbps x4, LAN (MediaTek MT7531AE)
              10/100/1000/2500 Mbps x1, WAN (MaxLinear GPY211C0VC)
- UART      : 1x4 pin header on PCB
  - [J1] 3.3V, TX, RX, GND (115200, 8N1)
- Buttons   : WPS, Reset
- Switches  : Rfkill Slide Switch
- USB       : 1x USB 3.0 (MediaTek MT7986AV peripheral)
- FAN       : 1x Fan (off - slow -fast)
- LEDs      :  11 LEDs
  - 1x Power (Blue)
  - 1x CPU (Blue)
  - 1x Wi-Fi 6GHz (Blue)
  - 1x Wi-Fi 5GHz (Blue)
  - 1x Wi-Fi 2.4GHz (Blue)
  - 4x LAN activity (Blue)
  - 1x WAN activity (Blue)
  - 1x USB 3.0 (Blue)
- Power     : 12VDC, 3.5A (Center positive polarity)

MAC address
-----------

| Interface | MAC               | Algorithm              |
|-|-|-|
| WLAN 2.4G | 58:86:94:xx:xx:xx | label1                 |
| WLAN 5G   | 5A:86:94:xx:xx:xx | label2 with LA Bit set |
| WLAN 6G   | 5A:86:94:xx:xx:xx | label1 with LA Bit set |
| WAN       | 58:86:94:xx:xx:xx | label1 + 1             |
| LAN       | 58:86:94:xx:xx:xx | label1 + 3             |

The WLAN 2.4G MAC address (label1) was found in 'Factory' partition, 0xA0004
The WLAN 5G MAC address (label2) was found in 'Factory' partition, 0x4

Installation
------------
1. Download the OEM recovery software (ipTIME Firmware Wizard (11ac)) from the manufacturer's website
2. Download the *squashfs-factory.bin file from the OpenWrt website
3. Press a reset button, and power up the router(keep pressing the reset button)
4. Wait more than 10 seconds until the CPU LED stop blinking
5. Connect the router (LAN port) to the PC
6. Run the OEM recovery software and follow the instructions
7. Select the *squashfs-factory.bin file during the router recovery process
8. Wait for the router to boot from *squashfs-factory.bin

Note: The router will automatically reboot if no file is uploaded within 55 seconds.

Fan Control
------------
The fan speed is controlled by writing a value from 0 to 2 to the `fan1_target` file.

```
cd /sys/devices/platform/gpio-fan/hwmon/hwmon2

echo '0' > fan1_target // off
echo '1' > fan1_target // slow
echo '2' > fan1_target // fast
```

Limitation: Enabling Wi-Fi 6E
----------
Wi-Fi 6E (6GHz) does not work out of the box on LuCI. After installation, you need to configure a few settings in the `radio1` and `default_radio1` sections of the `/etc/config/wireless`. Once you have made these changes, you can enable and use Wi-Fi 6E.

In the `radio1` section, you need to add three common options:
- band: must be set to `6g`
- country: a valid country code for the 6GHz band
- channel: a preferrend scanning channel (PSC) for 6GHz

In the `default_radio1` section, you need to add the SSID and key:
- ssid: The public name of your Wi-Fi network
- key: The Wi-Fi password
- encryption: must be set to either `sae` for WPA3 or `owe` for OWE (open network)

Example:

```
config wifi-device 'radio1'
        ...
        option band '6g'
        option country 'KR'
        option channel '37'
        ...

config wifi-iface 'default_radio1'
        ...
        option ssid 'my_wifi_6e_name'
        option key 'my_strong_password1234'
        option encryption 'sae'
        ...
```

Note: A list of all the 6GHz PSC channels:

```
5, 21, 37, 53, 69, 85, 101, 117, 133, 149, 165, 181, 197, 213, and 229
```

Limitation: Maximum Transmit Power (Wi-Fi 6E)
----------
The maximum transmit power is currently broken. In the drop-down menu, you can only choose between "driver default" and "255 dBm (2147493647 mW)". There is currently no workaround for the issue. Please leave the maximum transmit power set to "driver default".