### PR TITLE
rockchip: make NIC name predictable for LinkEase EasePi R1

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -35,6 +35,8 @@ rockchip_setup_interfaces()
 		ucidef_set_interfaces_lan_wan 'eth0 eth2' 'eth1'
 		;;
 	linkease,easepi-r1)
+		ucidef_set_network_device_path eth2 'platform/3c0400000.pcie/pci0001:10/0001:10:00.0/0001:11:00.0'
+		ucidef_set_network_device_path eth3 'platform/3c0000000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0'
 		ucidef_set_interfaces_lan_wan 'eth1 eth2 eth3' 'eth0'
 		;;
 	radxa,e52c)


### PR DESCRIPTION
The probe order for PCIe buses and devices is non-deterministic, making the names eth2 and eth3 unpredictable (they may be swapped).

This patch fixes the names by referencing the device path using `ucidef_set_network_device_path`.

This patch ensures that the OpenWrt interface name matches the case label.

Fixes: 8ca4caacd039 ("rockchip: Add support for RK3568 LinkEase EasePi R1")
Signed-off-by: Liangbin Lian <jjm2473@gmail.com>
