### PR TITLE
ath79: fix MAC addresses on MikroTik RB962UiGS-5HacT2HnT

### DIFF
--- a/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/mikrotik/base-files/etc/board.d/02_network
@@ -84,7 +84,8 @@ ath79_setup_macs()
 		;;
 	mikrotik,routerboard-2011uias-2hnd|\
 	mikrotik,routerboard-921gs-5hpacd-15s|\
-	mikrotik,routerboard-922uags-5hpacd)
+	mikrotik,routerboard-922uags-5hpacd|\
+	mikrotik,routerboard-962uigs-5hact2hnt)
 		label_mac="$mac_base"
 		lan_mac="$mac_base"
 		wan_mac=$(macaddr_add $mac_base 1)


### PR DESCRIPTION
The MikroTik RouterBOARD 962UiGS-5HacT2HnT (hAP ac) currently comes up with random MAC addresses. Assign the MAC addresses from hard_config for LAN and WAN ports.

Fixes: c2140e32ce ("ath79: add support for MikroTik RouterBOARD 962UiGS-5HacT2HnT (hAP ac)")

@rmounce