### PR TITLE
wifi-scripts: ucode: create wpa_psk_file and sae_password_file when needed

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -135,11 +135,15 @@ function iface_auth_type(config) {
 			 netifd.setup_failed('INVALID_WPA_PSK');
 		}
 
-		set_default(config, 'wpa_psk_file', `/var/run/hostapd-${config.ifname}.psk`);
-		touch_file(config.wpa_psk_file);
+		if (config.auth_type in [ 'psk', 'psk-sae' ]) {
+			set_default(config, 'wpa_psk_file', `/var/run/hostapd-${config.ifname}.psk`);
+			touch_file(config.wpa_psk_file);
+		}
 
-		set_default(config, 'sae_password_file', `/var/run/hostapd-${config.ifname}.sae`);
-		touch_file(config.sae_password_file);
+		if (config.auth_type in [ 'sae', 'psk-sae' ]) {
+			set_default(config, 'sae_password_file', `/var/run/hostapd-${config.ifname}.sae`);
+			touch_file(config.sae_password_file);
+		}
 		break;
 
 	case 'eap':
@@ -464,9 +468,6 @@ function iface_interworking(config) {
 export function generate(interface, data, config, vlans, stas, phy_features) {
 	config.ctrl_interface = '/var/run/hostapd';
 
-	iface_wpa_stations(config, stas);
-	iface_sae_stations(config, stas);
-
 	config.start_disabled = data.ap_start_disabled;
 	iface_setup(config);
 
@@ -477,6 +478,11 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 		if (config.auth_type == 'eap-eap2')
 			config.auth_type = 'eap2';
 	}
+
+	if (config.auth_type in [ 'psk', 'psk-sae' ])
+		iface_wpa_stations(config, stas);
+	if (config.auth_type in [ 'sae', 'psk-sae' ])
+		iface_sae_stations(config, stas);
 
 	iface_auth_type(config);
 


### PR DESCRIPTION
This handles the case when 'wpad' or 'wpad-mini' package is used which is missing WPA3 support. This makes it impossible to use ucode wifi-scripts on such APs as it will raise an error:

   daemon.err hostapd: Line 87: unknown configuration item 'sae_password_file'

This also achieves parity with what is currently happening with old wifi-scripts. The behavior now matches.

Fixes: https://github.com/openwrt/openwrt/issues/20781