### PR TITLE
mvebu: add support for Fortinet FortiWiFi 30E

### DIFF
--- a/target/linux/mvebu/cortexa9/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/cortexa9/base-files/etc/board.d/02_network
@@ -21,6 +21,7 @@ mvebu_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 lan4" "eth2"
 		;;
 	fortinet,fg-30e|\
+	fortinet,fwf-30e|\
 	linksys,wrt1200ac|\
 	linksys,wrt1900ac-v1|\
 	linksys,wrt1900ac-v2|\

--- a/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
@@ -53,6 +53,7 @@ platform_do_upgrade() {
 		legacy_sdcard_do_upgrade "$1"
 		;;
 	fortinet,fg-30e|\
+	fortinet,fwf-30e|\
 	fortinet,fg-50e|\
 	fortinet,fg-51e|\
 	fortinet,fg-52e|\

--- a/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-385-fortinet-fwf-30e.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-385-fortinet-fwf-30e.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "armada-385-fortinet-fg-3xe.dtsi"
+
+
+/ {
+        model = "Fortinet FortiWiFi 30E";
+        compatible = "fortinet,fwf-30e", "marvell,armada385", "marvell,armada380";
+};
+
+&pciec {
+        status = "okay";
+};
+
+&pcie2 {
+        status = "okay";
+};

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -135,6 +135,16 @@ define Device/fortinet_fg-30e
 endef
 TARGET_DEVICES += fortinet_fg-30e
 
+define Device/fortinet_fwf-30e
+  $(Device/fortinet)
+  DEVICE_MODEL := FortiWiFi 30E
+  DEVICE_DTS := armada-385-fortinet-fwf-30e
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | fortigate-header | \
+    gzip-filename FWF30E
+  DEVICE_PACKAGES += kmod-ath9k wpad-basic-mbedtls
+endef
+TARGET_DEVICES += fortinet_fwf-30e
+
 define Device/fortinet_fg-50e
   $(Device/fortinet)
   DEVICE_MODEL := FortiGate 50E


### PR DESCRIPTION
Fortinet FortiWiFi 30E (FWF-30E) is a UTM, based on Armada 385 (88F6820).

Specification:

- SoC          : Marvell Armada 385 88F6820
- RAM          : DDR3 1 GiB (4x Nanya NT5CC256M8IN-D1)
- Flash        : SPI-NOR 128 MiB (Macronix MX66L1G45GMI-10G)
- Ethernet     : 5x 10/100/1000 Mbps
  - Switch     : Marvell 88E6176
- Wireless     : Atheros AR9382 2x2 802.11abgn (mini-PCIe)
- LEDs/Keys    : 16x/1x
- UART         : "CONSOLE" port (RJ-45, RS-232C level)
  - port       : ttyS0
  - settings   : 9600bps 8n1
  - assignment : 1:NC , 2:NC , 3:TXD, 4:GND,
                 5:GND, 6:RXD, 7:NC , 8:NC
  - note       : compatible with Cisco console cable
- HW Monitoring: nuvoTon NCT7802Y
- USB          : 1x USB 3.0
- Power        : 12 VDC, 2 A
  - plug       : Molex 5557-02R

Flash instruction using initramfs image:

 1. Power on FWF-30E and interrupt to show bootmenu
 2. Call "[I]: System information." -> "[S]: Set serial port baudrate." and set baudrate to 9600 bps
 3. Call "[R]: Review TFTP parameters.", check TFTP parameters and connect computer to "Image download port" in the parameters
 4. Prepare TFTP server with the parameters obtained above
 5. Rename OpenWrt initramfs image to "image.out" and put to TFTP directory
 6. Call "[T]: Initiate TFTP firmware transfer." to download initramfs image from TFTP server
 7. Type "r" key when the following message is showed, to boot initramfs image without flashing to spi-nor flash

    "Save as Default firmware/Backup firmware/Run image without saving:[D/B/R]?"

 8. On initramfs image, backup mtd if needed

    minimum:

    - "firmware-info"
    - "kernel"
    - "rootfs"

 9. On initramfs image, upload sysupgrade image to the device and perform sysupgrade
10. Wait ~200 seconds to complete flashing and rebooting. If the device is booted with stock firmware, login to bootmenu and call "[B]: Boot with backup firmware and set as default." to set the first OS image as default and boot it.

Notes:

- Both colors of Bi-color LEDs on the front panel cannot be turned on at the same time.

- "PWR" and "Logo" LEDs are connected to power source directly.

- The following partitions are added for OpenWrt. These partitions are contained in "uboot" partition (0x0-0x1fffff) on stock firmware.

  - "firmware-info"
  - "dtb"
  - "u-boot-env"
  - "board-info"

Image header for bootmenu tftp:

  0x0 - 0xf  : ?
 0x10 - 0x2f : Image Name
 0x30 - 0x17f: ?
0x180 - 0x183: Kernel Offset*
0x184 - 0x187: Kernel Length*
0x188 - 0x18b: RootFS Offset (ext2)*
0x18c - 0x18f: RootFS Length (ext2)*
0x190 - 0x193: DTB Offset
0x194 - 0x197: DTB Length
0x198 - 0x19b: Data Offset (jffs2)
0x19c - 0x19f: Data Length (jffs2)
0x1a0 - 0x1ff: ?

*: required for initramfs image

MAC addresses:

(eth0): 70:4C:A5:xx:xx:42 (board-info, 0xd880 (hex))
WAN   : 70:4C:A5:xx:xx:43
LAN 1 : 70:4C:A5:xx:xx:44
LAN 2 : 70:4C:A5:xx:xx:45
LAN 3 : 70:4C:A5:xx:xx:46
LAN 4 : 70:4C:A5:xx:xx:47

