### PR TITLE
odhcp6c: update to Git HEAD (2025-11-14)

### DIFF
--- a/package/network/ipv6/odhcp6c/Makefile
+++ b/package/network/ipv6/odhcp6c/Makefile
@@ -12,9 +12,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcp6c.git
-PKG_SOURCE_DATE:=2025-11-09
-PKG_SOURCE_VERSION:=e5690c1f13ed3605ece68d870abb3c4a2f09d571
-PKG_MIRROR_HASH:=4dbf3980f8ac72f92f68c5dbac7179c28aab0e012a53162e0defbbf5959a9389
+PKG_SOURCE_DATE:=2025-11-14
+PKG_SOURCE_VERSION:=cbc8ff0e62261a5681dab1aa6d0e503545178354
+PKG_MIRROR_HASH:=3c3b73c9b74c45900128d91ad443d4411a5ba3f9246b97a562d9acaf7a9f01f3
 PKG_MAINTAINER:=Hans Dedecker <dedeckeh@gmail.com>
 PKG_LICENSE:=GPL-2.0
 
@@ -23,22 +23,11 @@ include $(INCLUDE_DIR)/cmake.mk
 
 CMAKE_OPTIONS += -DUBUS=1
 
-ifneq ($(CONFIG_PACKAGE_odhcp6c_ext_cer_id),0)
-  CMAKE_OPTIONS += -DEXT_CER_ID=$(CONFIG_PACKAGE_odhcp6c_ext_cer_id)
-endif
-
 define Package/odhcp6c
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Embedded DHCPv6-client for OpenWrt
   DEPENDS:=@IPV6 +libubox +libubus
-endef
-
-define Package/odhcp6c/config
-  config PACKAGE_odhcp6c_ext_cer_id
-    int "CER-ID Extension ID (0 = disabled)"
-    depends on PACKAGE_odhcp6c
-    default 0
 endef
 
 define Package/odhcp6c/conffiles

--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -142,7 +142,6 @@ setup_interface () {
 	done
 
 	proto_add_data
-	[ -n "$CER" ] && json_add_string cer "$CER"
 	[ -n "$PASSTHRU" ] && json_add_string passthru "$PASSTHRU"
 	[ -n "$ZONE" ] && json_add_string zone "$ZONE"
 	proto_close_data


### PR DESCRIPTION
cbc8ff0e6226 github: ci: add powerpc arch
8eba02233133 github: ci: add cmake build and source directories
5f3104ea17ae github: ci: disable json-c tests
27ff42cd40f9 scripts: devel-build: disable json-c tests
e0a9d02b52d1 dhcpv6: DHCPV6_OPT_INFO_REFRESH contains a 4 byte option
5a02da9c1200 dhcpv6: use compile time resolved sizeof(struct in6_addr) for IPv6 values
cf203ceb3fc8 dhcpv6: set a static define for DUID max length
3627e85d1540 dhcpv6: set static defines for DHCPv6 option header size
ecb9a0243e77 odhcp6c: RFC comments
c284c587d37d all: spell fixes
1259a32d7e4d dhcpv6: dhcpv6_handle_reply switch case handling
227280a37853 dhcpv6: dhcpv6_handle_advert; migrate if blocks to switch case
b253f8907e72 dhcpv6: migrate to switch case for dhcpv6_handle_reply
61a54db802cb dhcpv6: migrate to switch case for dhcpv6_handle_reply
49c64bbe00ba all: drop CER_ID
16ce83075b2e dhcpv6: refactor u8 and u16 to u32 to avoid boolean coercion

https://github.com/openwrt/odhcp6c/compare/e5690c1f13ed...cbc8ff0e6226

Options related to homenet (EXT_CER_ID) have been removed, so drop them from the package.

CC @Alphix @systemcrash