### PR TITLE
wifi-scripts: bump reassociation_deadline default to 20000

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -916,7 +916,7 @@
 			"type": "number",
 			"minimum": 1000,
 			"maximum": 65535,
-			"default": 1000
+			"default": 20000
 		},
 		"request_cui": {
 			"type": "alias",

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -920,7 +920,7 @@ hostapd_set_bss_options() {
 
 			set_default mobility_domain "$(echo "$ssid" | md5sum | head -c 4)"
 			set_default ft_over_ds 0
-			set_default reassociation_deadline 1000
+			set_default reassociation_deadline 20000
 
 			case "$auth_type" in
 				psk)


### PR DESCRIPTION
Most users on forums face a broken 802.11r setup when having a very simple 802.11r config (i.e., just ieee80211r enabled).

In most cases, simply bumping reassociation_deadline to 20000 fixes their problems and allows 802.11r to just work.

Reassociation Deadline is already set to 20 seconds on Cisco equipment by default[1] which is why this value has been chosen.

It is also mentioned on the OpenWRT Wiki as a value that should be changed in order for 802.11r to work on Apple devices. I think it would be better to change the defaults instead so users don't have to do much work for a working setup.

[1]: https://www.cisco.com/c/en/us/td/docs/wireless/controller/technotes/80211r-ft/b-80211r-dg.html

Fixes: https://github.com/openwrt/openwrt/issues/7907