### PR TITLE
wifi-scripts: add missing default value to na_mcast_to_ucast

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -1157,11 +1157,14 @@ hostapd_set_bss_options() {
 	if [ "$multicast_to_unicast_all" -gt 0 ]; then
 		append bss_conf "multicast_to_unicast=$multicast_to_unicast_all" "$N"
 	fi
+
 	set_default proxy_arp 0
+	set_default na_mcast_to_ucast 0
 	if [ "$proxy_arp" -gt 0 ]; then
 		append bss_conf "proxy_arp=$proxy_arp" "$N"
 		set_default na_mcast_to_ucast 1
 	fi
+
 	if [ "$na_mcast_to_ucast" -gt 0 ]; then
 		append bss_conf "na_mcast_to_ucast=$na_mcast_to_ucast" "$N"
 	fi


### PR DESCRIPTION
Add missing default value for na_mcast_to_ucast.
Silences the following msg: daemon.notice: netifd: radio1 (xxxx): sh: out of range

Commit: https://github.com/openwrt/openwrt/commit/bcdb29f78f5ee7a7f21c272f8273f1186028e78f
