### PR TITLE
mediatek: add support for Cudy TR3000 new flash chip

### DIFF
--- a/target/linux/mediatek/patches-6.12/999-mtd-spinand-esmt-Add-support-for-F50L1G41LC.patch
+++ b/target/linux/mediatek/patches-6.12/999-mtd-spinand-esmt-Add-support-for-F50L1G41LC.patch
@@ -1,0 +1,58 @@
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -1160,6 +1160,7 @@ static const struct spinand_manufacturer
+ 	&alliancememory_spinand_manufacturer,
+ 	&ato_spinand_manufacturer,
+ 	&esmt_c8_spinand_manufacturer,
++	&esmt_8c_spinand_manufacturer,
+ 	&etron_spinand_manufacturer,
+ 	&fmsh_spinand_manufacturer,
+ 	&fidelix_spinand_manufacturer,
+--- a/drivers/mtd/nand/spi/esmt.c
++++ b/drivers/mtd/nand/spi/esmt.c
+@@ -11,6 +11,7 @@
+ 
+ /* ESMT uses GigaDevice 0xc8 JECDEC ID on some SPI NANDs */
+ #define SPINAND_MFR_ESMT_C8			0xc8
++#define SPINAND_MFR_ESMT_8C			0x8c
+ 
+ static SPINAND_OP_VARIANTS(read_cache_variants,
+ 			   SPINAND_PAGE_READ_FROM_CACHE_X4_OP(0, 1, NULL, 0),
+@@ -113,6 +114,15 @@ static const struct spinand_info esmt_c8
+ 					      &update_cache_variants),
+ 		     0,
+ 		     SPINAND_ECCINFO(&f50l1g41lb_ooblayout, NULL)),
++	SPINAND_INFO("F50L1G41LC",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_ADDR, 0x2C),
++		     NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(1, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     0,
++		     SPINAND_ECCINFO(&f50l1g41lb_ooblayout, NULL)),
+ 	SPINAND_INFO("F50D1G41LB",
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_ADDR, 0x11, 0x7f,
+ 				0x7f, 0x7f),
+@@ -145,3 +155,11 @@ const struct spinand_manufacturer esmt_c
+ 	.nchips = ARRAY_SIZE(esmt_c8_spinand_table),
+ 	.ops = &esmt_spinand_manuf_ops,
+ };
++
++const struct spinand_manufacturer esmt_8c_spinand_manufacturer = {
++	.id = SPINAND_MFR_ESMT_8C,
++	.name = "ESMT",
++	.chips = esmt_c8_spinand_table,
++	.nchips = ARRAY_SIZE(esmt_c8_spinand_table),
++ 	.ops = &esmt_spinand_manuf_ops,
++};
+--- a/include/linux/mtd/spinand.h
++++ b/include/linux/mtd/spinand.h
+@@ -263,6 +263,7 @@ struct spinand_manufacturer {
+ extern const struct spinand_manufacturer alliancememory_spinand_manufacturer;
+ extern const struct spinand_manufacturer ato_spinand_manufacturer;
+ extern const struct spinand_manufacturer esmt_c8_spinand_manufacturer;
++extern const struct spinand_manufacturer esmt_8c_spinand_manufacturer;
+ extern const struct spinand_manufacturer etron_spinand_manufacturer;
+ extern const struct spinand_manufacturer fmsh_spinand_manufacturer;
+ extern const struct spinand_manufacturer fidelix_spinand_manufacturer;


### PR DESCRIPTION
This pull request adds support for the new ESMT F50L1G41LC SPI-NAND flash chip(128MB), which is now being used in recent hardware revisions of the Cudy TR3000 v1 .

According to information provided by Cudy's technical support, newer units shipping with this flash chip are incompatible with the current OpenWrt firmware. Without this patch, OpenWrt will fail to install or boot on these devices.

The manufacturer provided an initial patch to resolve this issue. This commit is a refreshed version of their patch, adapted to apply cleanly to the current main branch and updated to align with OpenWrt's conventions. The change ensures that both the new and old flash chips are supported.

Credit for the original fix goes to the engineering team at Cudy.

The original information provided was as follows: https://github.com/openwrt/openwrt/pull/15214#issuecomment-3514824435

Build-tested for the Cudy TR3000 target.
Runtime-tested on a newer revision of the Cudy TR3000(CN1.0, SN:TR30002544xxx) and confirmed working.

---
This pull request replaces #20783. Following the guidance from @hauke, I'm closing the previous one as I learned that the patch needed to be generated using `make target/linux/refresh`. I've now followed the correct procedure to refresh the patch. Thanks for the guidance!