### PR TITLE
wifi-scripts: add missing na_mcast_to_ucast default when proxy_arp is disabled

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -1160,9 +1160,9 @@ hostapd_set_bss_options() {
 		append bss_conf "multicast_to_unicast=$multicast_to_unicast_all" "$N"
 	fi
 	set_default proxy_arp 0
+	set_default na_mcast_to_ucast "$proxy_arp"
 	if [ "$proxy_arp" -gt 0 ]; then
 		append bss_conf "proxy_arp=$proxy_arp" "$N"
-		set_default na_mcast_to_ucast 1
 	fi
 	if [ "$na_mcast_to_ucast" -gt 0 ]; then
 		append bss_conf "na_mcast_to_ucast=$na_mcast_to_ucast" "$N"


### PR DESCRIPTION
Adds missing default value for na_mcast_to_ucast when proxy_arp is not enabled in order to silence the following msg:

   daemon.notice: netifd: radio1 (xxxx): sh: out of range

Fixes: bcdb29f78f5 ("wifi-scripts: add na_mcast_to_ucast option")
Reported-by: Antony Kolitsos <zeusomighty@hotmail.com>