### PR TITLE
airoha: backport kernel part of WiFi MT76 offload patch

### DIFF
--- a/target/linux/airoha/patches-6.12/111-v6.19-wifi-mt76-Introduce-the-NPU-generic-layer.patch
+++ b/target/linux/airoha/patches-6.12/111-v6.19-wifi-mt76-Introduce-the-NPU-generic-layer.patch
@@ -1,0 +1,39 @@
+From 62f1347fa5bf6e6c9c054aedb9e87e7205fa12ac Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Fri, 17 Oct 2025 10:50:32 +0200
+Subject: [PATCH] wifi: mt76: Introduce the NPU generic layer
+
+Add the NPU generic layer in mt76 module. NPU will be used to enable
+traffic forward offloading between the MT76 NIC and the Airoha ethernet one
+available on the Airoha EN7581 SoC using Netfilter Flowtable APIs.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20251017-mt76-npu-devel-v2-4-ddaa90901723@kernel.org
+Signed-off-by: Felix Fietkau <nbd@nbd.name>
+---
+ drivers/net/wireless/mediatek/mt76/Kconfig    |   4 +
+ drivers/net/wireless/mediatek/mt76/Makefile   |   1 +
+ drivers/net/wireless/mediatek/mt76/dma.c      |  41 +-
+ drivers/net/wireless/mediatek/mt76/dma.h      |  36 ++
+ drivers/net/wireless/mediatek/mt76/mac80211.c |   6 +-
+ drivers/net/wireless/mediatek/mt76/mt76.h     | 135 +++++
+ drivers/net/wireless/mediatek/mt76/npu.c      | 494 ++++++++++++++++++
+ include/linux/soc/airoha/airoha_offload.h     |   1 +
+ 8 files changed, 711 insertions(+), 7 deletions(-)
+ create mode 100644 drivers/net/wireless/mediatek/mt76/npu.c
+
+diff --git a/include/linux/soc/airoha/airoha_offload.h b/include/linux/soc/airoha/airoha_offload.h
+index 6f66eb339b3f..4d23cbb7d407 100644
+--- a/include/linux/soc/airoha/airoha_offload.h
++++ b/include/linux/soc/airoha/airoha_offload.h
+@@ -6,6 +6,7 @@
+ #ifndef AIROHA_OFFLOAD_H
+ #define AIROHA_OFFLOAD_H
+ 
++#include <linux/skbuff.h>
+ #include <linux/spinlock.h>
+ #include <linux/workqueue.h>
+ 
+-- 
+2.51.0
+


### PR DESCRIPTION
Backport the kernel parf of the WiFi MT76 offload patch. This is needed
as we have a dedicated package that only have mt76 related changes.

Add missing include in airoha_offload.h in order to enable MT76 NPU
offloading (and fix compilation error)
