### PR TITLE
mediatek-filogic: assign WAN netdev trigger to blue:wan LED for cudy wr3000e

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000e-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000e-v1.dts
@@ -39,7 +39,7 @@
 		};
 
 		led-wan {
-			function = LED_FUNCTION_WAN_ONLINE;
+			function = LED_FUNCTION_WAN;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
 		};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -61,7 +61,8 @@ cudy,re3000-v1|\
 wavlink,wl-wn573hx3)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0" "link tx rx"
 	;;
-cudy,wr3000-v1)
+cudy,wr3000-v1|\
+cudy,wr3000e-v1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	;;
 cudy,wr3000h-v1|\


### PR DESCRIPTION
Without this definition WAN LED won`t get triggered.
- rename LED blue:wan-online to blue:wan
- assign wan netdev trigger to blue:wan