### PR TITLE
ramips: use whole flash on Asus RT-AX53U

### DIFF
--- a/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
+++ b/target/linux/ramips/dts/mt7621_asus_rt-ax53u.dts
@@ -63,8 +63,7 @@
 
 	mediatek,nmbm;
 	mediatek,bmt-remap-range =
-		<0x000000 0x7e0000>,
-		<0x35e0000 0x7800000>;
+		<0x000000 0x7e0000>;
 
 	partitions {
 		compatible = "fixed-partitions";
@@ -124,7 +123,7 @@
 
 		partition@3e0000 {
 			label = "firmware";
-			reg = <0x3e0000 0x3200000>;
+			reg = <0x3e0000 0x7420000>;
 
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
@@ -137,18 +136,8 @@
 
 			partition@400000 {
 				label = "ubi";
-				reg = <0x400000 0x2e00000>;
+				reg = <0x400000 0x7020000>;
 			};
-		};
-
-		partition@35e0000 {
-			label = "firmware2";
-			reg = <0x35e0000 0x3200000>;
-		};
-
-		partition@67e0000 {
-			label = "jffs2";
-			reg = <0x67e0000 0x1020000>;
 		};
 
 		/* Last 8M are reserved for NMBM management (bad blocks) */

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -474,6 +474,10 @@ define Device/asus_rt-ax53u
   DEVICE_MODEL := RT-AX53U
   DEVICE_ALT0_VENDOR := ASUS
   DEVICE_ALT0_MODEL := RT-AX1800U
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Partition table has been changed. \
+	Follow instructions in the OpenWRT Wiki to migrate to the new layout: \
+	https://openwrt.org/toh/asus/rt-ax53u
   IMAGE_SIZE := 51200k
   IMAGES += factory.bin
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
@@ -8,6 +8,7 @@
 board_config_update
 
 case "$(board_name)" in
+	asus,rt-ax53u|\
 	ubnt,edgerouter-x|\
 	ubnt,edgerouter-x-sfp|\
 	iptime,ax2004m)


### PR DESCRIPTION
The Asus RT-AX53U router has a 128MB flash, but currently only around 62MB of it are used with OpenWRT. The rest consists of an alternative Asus firmware image (`firmware2`) and Asus firmware configuration (`jffs2`). These two partitions are useless with OpenWRT (even for restoring the original Asus firmware), so remove them and increase the size of the `firmware` and `ubi` partitions accordingly. This gives more space for the user.

Remove an entry from the NMBM remap list to avoid conflicts with UBI.

There are two good ways to flash the modified firmware:

1. TFTP the image to the router. This does not require opening the case and can even be done easily with the ASUS Firmware Restoration utility (available on the ASUS website):

   1. Connect LAN1 on the router with an Ethernet cable.
   2. Set computer's static IP to 192.168.1.10.
   3. Remove power; while pressing the RESET button apply power to the router.
   4. TFTP (as client) the initramfs-kernel image to the router on 192.168.1.1.
   5. Wait a while, use the squashfs-sysupgrade image to sysupgrade in the usual way.

   Sysupgrade in the last step will format the UBI partition anew and
   remove any old signatures.

2. Do:

       mtd erase firmware2
       mtd erase jffs2
       sysupgrade --force openwrt-ramips-mt7621-asus_rt-ax53u-squashfs-sysupgrade.bin
       <reboot>
       # if preserving configuration with sysupgrade
       uci set system.@system[0].compat_version='2.0'
       uci commit
       # once again:
       sysupgrade openwrt-ramips-mt7621-asus_rt-ax53u-squashfs-sysupgrade.bin

   Erasing `firmware2` and `jffs2` is necessary to remove any old UBI signatures (there would be some remnants if the user had flashed a patched firmware and then downgraded). These old UBI signatures would cause UBI attach failures - likely with a message like:

       bad image sequence number %d in PEB %d, expected %d

   After the first sysupgrade UBI will automatically expand to the new space, but the UBIFS for `rootfs_data` will not automatically claim the newly available blocks. This space will be claimed during the second sysupgrade, when `rootfs_data` is removed and created again.

   This is a similar approach to commit 983a753f389e - see https://github.com/openwrt/openwrt/pull/14791 .

   The second upgrade method allows keeping the OpenWRT configuration.

Because of the need to erase the partitions manually with step 2 (in some cases), increase `DEVICE_COMPAT_VERSION` to 2.0.

I have been running OpenWRT with modifications similar to this patch since 23.05 and have done numerous trials while testing it.

Previous PRs:
- https://github.com/openwrt/openwrt/pull/10502 
- https://github.com/openwrt/openwrt/pull/10685 
- https://github.com/openwrt/openwrt/pull/12741

Fixes: 8c00fd9b4519 ("ramips: add support for ASUS RT-AX53U")

Co-developed-by: Cristian Toader <37828991+tlc76@users.noreply.github.com>

Co-developed-by: Gábor Poczkodi <gabest11@gmail.com>

Co-developed-by: Kimmo Vuorinen <kimmo.vuorinen@gmail.com>