### PR TITLE
generic: 6.12: backport fix for mtd parser error handling

### DIFF
--- a/target/linux/generic/backport-6.12/403-v6.19-mtd-mtdpart-ignore-error-ENOENT-from-parsers-on-subp.patch
+++ b/target/linux/generic/backport-6.12/403-v6.19-mtd-mtdpart-ignore-error-ENOENT-from-parsers-on-subp.patch
@@ -1,0 +1,61 @@
+From 64ef5f454e167bb66cf70104f033c3d71e6ef9c0 Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Sun, 9 Nov 2025 12:52:44 +0100
+Subject: [PATCH] mtd: mtdpart: ignore error -ENOENT from parsers on
+ subpartitions
+
+Commit 5c2f7727d437 ("mtd: mtdpart: check for subpartitions parsing
+result") introduced some kind of regression with parser on subpartitions
+where if a parser emits an error then the entire parsing process from the
+upper parser fails and partitions are deleted.
+
+Not checking for error in subpartitions was originally intended as
+special parser can emit error also in the case of the partition not
+correctly init (for example a wiped partition) or special case where the
+partition should be skipped due to some ENV variables externally
+provided (from bootloader for example)
+
+One example case is the TRX partition where, in the context of a wiped
+partition, returns a -ENOENT as the trx_magic is not found in the
+expected TRX header (as the partition is wiped)
+
+To better handle this and still keep some kind of error tracking (for
+example to catch -ENOMEM errors or -EINVAL errors), permit parser on
+subpartition to emit -ENOENT error, print a debug log and skip them
+accordingly.
+
+This results in giving better tracking of the status of the parser
+(instead of returning just 0, dropping any kind of signal that there is
+something wrong with the parser) and to some degree restore the original
+logic of the subpartitions parse.
+
+(worth to notice that some special partition might have all the special
+header present for the parser and declare 0 partition in it, this is why
+it would be wrong to simply return 0 in the case of a special partition
+that is NOT init for the scanning parser)
+
+Cc: stable@vger.kernel.org
+Fixes: 5c2f7727d437 ("mtd: mtdpart: check for subpartitions parsing result")
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+---
+ drivers/mtd/mtdpart.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+--- a/drivers/mtd/mtdpart.c
++++ b/drivers/mtd/mtdpart.c
+@@ -425,9 +425,12 @@ int add_mtd_partitions(struct mtd_info *
+ 
+ 		mtd_add_partition_attrs(child);
+ 
+-		/* Look for subpartitions */
++		/* Look for subpartitions (skip if no maching parser found) */
+ 		ret = parse_mtd_partitions(child, parts[i].types, NULL);
+-		if (ret < 0) {
++		if (ret < 0 && ret == -ENOENT) {
++			pr_debug("Skip parsing subpartitions: %d\n", ret);
++			continue;
++		} else if (ret < 0) {
+ 			pr_err("Failed to parse subpartitions: %d\n", ret);
+ 			goto err_del_partitions;
+ 		}

--- a/target/linux/generic/pending-6.12/400-mtd-mtdsplit-support.patch
+++ b/target/linux/generic/pending-6.12/400-mtd-mtdsplit-support.patch
@@ -229,8 +229,8 @@ Subject: [PATCH] mtd: mtdsplit support
 +		mtd_partition_split(master, child);
  		mtd_add_partition_attrs(child);
  
- 		/* Look for subpartitions */
-@@ -443,31 +588,6 @@ err_del_partitions:
+ 		/* Look for subpartitions (skip if no maching parser found) */
+@@ -446,31 +591,6 @@ err_del_partitions:
  	return ret;
  }
  


### PR DESCRIPTION
Backport a trivial patch that half restore original functionality of MTD parser for subpartition by ignoring if the parser returns -ENOENT.

This fix parsing and booting of some brcm devices.