### PR TITLE
dnsmasq: add support for fast-dns-retry, use-stale-cache and more options

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.92
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.93
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dhcp.conf
+++ b/package/network/services/dnsmasq/files/dhcp.conf
@@ -21,6 +21,7 @@ config dnsmasq
 	#list notinterface	lo
 	#list bogusnxdomain     '64.94.110.11'
 	option localservice	1  # disable to allow DNS requests from non-local subnets
+	option fast_dns_retry	0
 	option ednspacket_max	1232
 	option filter_aaaa	0
 	option filter_a		0

--- a/package/network/services/dnsmasq/files/dhcp.conf
+++ b/package/network/services/dnsmasq/files/dhcp.conf
@@ -22,6 +22,7 @@ config dnsmasq
 	#list bogusnxdomain     '64.94.110.11'
 	option localservice	1  # disable to allow DNS requests from non-local subnets
 	option fast_dns_retry	0
+	option use_stale_cache	0
 	option ednspacket_max	1232
 	option filter_aaaa	0
 	option filter_a		0

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1100,6 +1100,7 @@ dnsmasq_start()
 	append_parm "$cfg" "tftp_root" "--tftp-root"
 	append_parm "$cfg" "dhcp_boot" "--dhcp-boot"
 	append_parm "$cfg" "local_ttl" "--local-ttl"
+	append_parm "$cfg" "neg_ttl" "--neg-ttl"
 	append_parm "$cfg" "max_ttl" "--max-ttl"
 	append_parm "$cfg" "min_cache_ttl" "--min-cache-ttl"
 	append_parm "$cfg" "max_cache_ttl" "--max-cache-ttl"

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1043,6 +1043,18 @@ dnsmasq_start()
 	config_get address_as_local "$cfg" address_as_local 0
 	config_list_foreach "$cfg" "address" append_address "$address_as_local"
 
+	# --fast-dns-retry=[<initial retry delay in ms>[,<time to continue retries in ms>]]
+	local fast_dns_retry fast_dns_retry_param
+	config_get_bool fast_dns_retry "$cfg" fast_dns_retry 0
+	[ "$fast_dns_retry" = "1" ] && {
+		config_get fast_dns_retry_param "$cfg" fast_dns_retry_param
+		if [ -n "$fast_dns_retry_param" ]; then
+			append_parm "$cfg" fast_dns_retry_param "--fast-dns-retry"
+		else
+			append_bool "$cfg" fast_dns_retry "--fast-dns-retry"
+		fi
+	}
+
 	local connmark_allowlist_enable
 	config_get connmark_allowlist_enable "$cfg" connmark_allowlist_enable 0
 	[ "$connmark_allowlist_enable" -gt 0 ] && {

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1055,6 +1055,18 @@ dnsmasq_start()
 		fi
 	}
 
+	# --use-stale-cache[=<max TTL excess in s>]
+	local use_stale_cache stale_cache_param
+	config_get_bool use_stale_cache "$cfg" use_stale_cache 0
+	[ "$use_stale_cache" = "1" ] && {
+		config_get stale_cache_param "$cfg" stale_cache_param
+		if [ -n "$stale_cache_param" ]; then
+			append_parm "$cfg" stale_cache_param "--use-stale-cache"
+		else
+			append_bool "$cfg" use_stale_cache "--use-stale-cache"
+		fi
+	}
+
 	local connmark_allowlist_enable
 	config_get connmark_allowlist_enable "$cfg" connmark_allowlist_enable 0
 	[ "$connmark_allowlist_enable" -gt 0 ] && {

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -987,6 +987,7 @@ dnsmasq_start()
 	append_bool "$cfg" nohosts "--no-hosts"
 	append_bool "$cfg" nonegcache "--no-negcache"
 	append_bool "$cfg" strictorder "--strict-order"
+	append_bool "$cfg" noroundrobin "--no-round-robin"
 	append_bool "$cfg" logqueries "--log-queries=extra"
 	append_bool "$cfg" noresolv "--no-resolv"
 	append_bool "$cfg" localise_queries "--localise-queries"


### PR DESCRIPTION
This is a reworked product of #11738, improved code format.

Added uci support for `fast-dns-retry`, `use-stale-cache`, `neg-ttl` and `no-round-robin`

LuCi and [wiki page](https://openwrt.org/docs/guide-user/base-system/dhcp) may also need updates

@user8446 @hauke