### PR TITLE
base-files: board_detect: Make robust against power-cuts and address shellcheck warnings

### DIFF
--- a/package/base-files/files/bin/board_detect
+++ b/package/base-files/files/bin/board_detect
@@ -1,14 +1,22 @@
 #!/bin/sh
 
-CFG=$1
+REAL_CFG=$1
 
-[ -n "$CFG" ] || CFG=/etc/board.json
+[ -n "$REAL_CFG" ] || REAL_CFG=/etc/board.json
 
-if [ -d "/etc/board.d/" ] && [ ! -s "$CFG" ]; then
+if [ -d "/etc/board.d/" ] && [ ! -s "$REAL_CFG" ]; then
+	# Use temp file to prevent incomplete file on power-cut, CFG is used by the sourced script to read/write the file
+	CFG="$(dirname "$REAL_CFG")/.$(basename "$REAL_CFG").tmp"
+	rm -f "$CFG" || exit
 	for a in $(ls /etc/board.d/*); do
 		[ -s "$a" ] || continue
 		(. "$a")
 	done
 fi
 
-[ -s "$CFG" ] || return 1
+if [ -s "$CFG" ]; then
+	mv "$CFG" "$REAL_CFG" || exit
+else
+	rm -f "$CFG"
+	exit 1
+fi

--- a/package/base-files/files/bin/board_detect
+++ b/package/base-files/files/bin/board_detect
@@ -4,11 +4,11 @@ CFG=$1
 
 [ -n "$CFG" ] || CFG=/etc/board.json
 
-[ -d "/etc/board.d/" -a ! -s "$CFG" ] && {
+if [ -d "/etc/board.d/" ] && [ ! -s "$CFG" ]; then
 	for a in $(ls /etc/board.d/*); do
-		[ -s $a ] || continue;
-		$(. $a)
+		[ -s "$a" ] || continue
+		(. "$a")
 	done
-}
+fi
 
 [ -s "$CFG" ] || return 1


### PR DESCRIPTION
If board_detect is interrupted by cutting power on first boot,
board.json might only be half-way written and the file will not be
written again correctly on subsequent boards.

Write to a temporary file first, then rename. Since a rename on the same
file system is an atomic operation, it ensures that either no
/etc/board.json or a complete /etc/board.json exists.

Also address shellcheck warnings:

 * SC2166 (warning): Prefer [ p ] && [ q ] as [ p -a q ] is not well
   defined.
 * SC2086 (info): Double quote to prevent globbing and word splitting.
 * SC2091 (warning): Remove surrounding $() to avoid executing output
   (or use eval if intentional).