### PR TITLE
mac80211: ath11k: fix rssi for ipq5018 and qcn6122

### DIFF
--- a/package/kernel/mac80211/patches/ath11k/947-wifi-ath11k-fix-rssi-station-dump-for-IPQ5018-and-QC.patch
+++ b/package/kernel/mac80211/patches/ath11k/947-wifi-ath11k-fix-rssi-station-dump-for-IPQ5018-and-QC.patch
@@ -1,0 +1,32 @@
+From 8fd48529849310a68500d1d546f246d44697bbed Mon Sep 17 00:00:00 2001
+From: Christian Marangi <ansuelsmth@gmail.com>
+Date: Tue, 25 Nov 2025 14:56:08 +0100
+Subject: [PATCH] wifi: ath11k: fix rssi station dump for IPQ5018 and QCN6122
+
+Commit 031ffa6c2cd3 ("wifi: ath11k: fix rssi station dump not updated in
+QCN9074") didn't account for IPQ5018 and QCN6122 WiFi card that are
+based on QCN9074.
+
+Update the .mpdu_info_get_peerid to use the QCN9074 variant to correctly
+receive consistent RSSI station data.
+
+Reported-by: Scott Mercer <TheRootEd24@gmail.com>
+Suggested-by: Scott Mercer <TheRootEd24@gmail.com>
+Tested-by: Scott Mercer <TheRootEd24@gmail.com>
+Fixes: 031ffa6c2cd3 ("wifi: ath11k: fix rssi station dump not updated in QCN9074")
+Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
+---
+ drivers/net/wireless/ath/ath11k/hw.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/wireless/ath/ath11k/hw.c
++++ b/drivers/net/wireless/ath/ath11k/hw.c
+@@ -1175,7 +1175,7 @@ const struct ath11k_hw_ops ipq5018_ops =
+ 	.rx_desc_get_attention = ath11k_hw_qcn9074_rx_desc_get_attention,
+ 	.reo_setup = ath11k_hw_ipq5018_reo_setup,
+ 	.rx_desc_get_msdu_payload = ath11k_hw_qcn9074_rx_desc_get_msdu_payload,
+-	.mpdu_info_get_peerid = ath11k_hw_ipq8074_mpdu_info_get_peerid,
++	.mpdu_info_get_peerid = ath11k_hw_qcn9074_mpdu_info_get_peerid,
+ 	.rx_desc_mac_addr2_valid = ath11k_hw_ipq9074_rx_desc_mac_addr2_valid,
+ 	.rx_desc_mpdu_start_addr2 = ath11k_hw_ipq9074_rx_desc_mpdu_start_addr2,
+ 	.get_ring_selector = ath11k_hw_ipq8074_get_tcl_ring_selector,


### PR DESCRIPTION
references:
>upstream commit: [031ffa6c2cd305a57ccc6d610f2decd956b2e7f6] 
Subject: [PATCH] wifi: ath11k: fix rssi station dump not updated in QCN9074

symptoms: iw station dump displays default value for avg signal (-95dbm) and signal (0dbm)

As described in the refrenced upstream commit, there was a header change
for HAL_RX_MPDU_START between ipq8074 and qcn9074. This caused wrong peer_id fetch
from msdu in the 9074 and the ipq5018 and subsequently the qcn6122 which uses the
ipq5018 hw_opts.

solution: use the updated qcn9074 mpdu_info_get_peerid implimentation with the new tlv
format, from the referenced upstream commit.
