### PR TITLE
kernel: fix build of kmod-udptunnel4 and kmod-udptunnel6

### DIFF
--- a/target/linux/generic/hack-6.12/249-udp-tunnel-selection.patch
+++ b/target/linux/generic/hack-6.12/249-udp-tunnel-selection.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andy Chiang <AndyChiang_git@outlook.com>
+Date: Thu, 20 Nov 2025 20:37:53 +0700
+Subject: [PATCH] kernel: fix build of kmod-udptunnel4 and kmod-udptunnel6
+
+This fixes the following errors:
+```
+make[4]: Entering directory '/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.12.57'
+  MODPOST /home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/Module.symvers
+ERROR: modpost: "udp_tunnel6_xmit_skb" [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/ovpn-dco-v2.ko] undefined!
+ERROR: modpost: "setup_udp_tunnel_sock" [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/ovpn-dco-v2.ko] undefined!
+ERROR: modpost: "udp_tunnel_xmit_skb" [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/ovpn-dco-v2.ko] undefined!
+make[6]: *** [scripts/Makefile.modpost:145: /home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/Module.symvers] Error 1
+make[5]: *** [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.12.57/Makefile:1897: modpost] Error 2
+make[4]: *** [Makefile:224: __sub-make] Error 2
+```
+
+ref https://github.com/openwrt/openwrt/commit/1d15a96b29dcd0947690951a7c36aead79a27129
+fixes: https://github.com/openwrt/packages/issues/22998
+
+Signed-off-by: Andy Chiang <AndyChiang_git@outlook.com>
+---
+ net/ipv4/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/net/ipv4/Kconfig
++++ b/net/ipv4/Kconfig
+@@ -315,7 +315,7 @@ config NET_IPVTI
+ 	  on top.
+ 
+ config NET_UDP_TUNNEL
+-	tristate
++	tristate "IP: UDP tunneling support"
+ 	select NET_IP_TUNNEL
+ 	default n
+ 

--- a/target/linux/generic/hack-6.6/249-udp-tunnel-selection.patch
+++ b/target/linux/generic/hack-6.6/249-udp-tunnel-selection.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andy Chiang <AndyChiang_git@outlook.com>
+Date: Thu, 20 Nov 2025 20:37:53 +0700
+Subject: [PATCH] kernel: fix build of kmod-udptunnel4 and kmod-udptunnel6
+
+This fixes the following errors:
+```
+make[4]: Entering directory '/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.12.57'
+  MODPOST /home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/Module.symvers
+ERROR: modpost: "udp_tunnel6_xmit_skb" [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/ovpn-dco-v2.ko] undefined!
+ERROR: modpost: "setup_udp_tunnel_sock" [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/ovpn-dco-v2.ko] undefined!
+ERROR: modpost: "udp_tunnel_xmit_skb" [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/ovpn-dco-v2.ko] undefined!
+make[6]: *** [scripts/Makefile.modpost:145: /home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/Module.symvers] Error 1
+make[5]: *** [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.12.57/Makefile:1897: modpost] Error 2
+make[4]: *** [Makefile:224: __sub-make] Error 2
+```
+
+ref https://github.com/openwrt/openwrt/commit/1d15a96b29dcd0947690951a7c36aead79a27129
+fixes: https://github.com/openwrt/packages/issues/22998
+
+Signed-off-by: Andy Chiang <AndyChiang_git@outlook.com>
+---
+ net/ipv4/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/net/ipv4/Kconfig
++++ b/net/ipv4/Kconfig
+@@ -315,7 +315,7 @@ config NET_IPVTI
+ 	  on top.
+ 
+ config NET_UDP_TUNNEL
+-	tristate
++	tristate "IP: UDP tunneling support"
+ 	select NET_IP_TUNNEL
+ 	default n
+ 


### PR DESCRIPTION
This fixes the following errors:
```
make[4]: Entering directory '/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.12.57'
  MODPOST /home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/Module.symvers
ERROR: modpost: "udp_tunnel6_xmit_skb" [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/ovpn-dco-v2.ko] undefined!
ERROR: modpost: "setup_udp_tunnel_sock" [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/ovpn-dco-v2.ko] undefined!
ERROR: modpost: "udp_tunnel_xmit_skb" [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/ovpn-dco-v2.ko] undefined!
make[6]: *** [scripts/Makefile.modpost:145: /home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/ovpn-dco-0.2.20250801/drivers/net/ovpn-dco/Module.symvers] Error 1
make[5]: *** [/home/runner/work/OP/OP/openwrt/build_dir/target-aarch64_cortex-a53_musl/linux-mediatek_filogic/linux-6.12.57/Makefile:1897: modpost] Error 2
make[4]: *** [Makefile:224: __sub-make] Error 2
```

ref 1d15a96b29dc
fixes: openwrt/packages#22998
