### PR TITLE
mediatek: filogic: add factory image for TUF-AX4200

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -415,6 +415,16 @@ define Device/asus_tuf-ax4200
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+ifeq ($(IB),)
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+ifeq ($(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE),)
+  # The default boot command of the bootloader does not load the ramdisk from the FIT image
+  ARTIFACTS := initramfs.trx
+  ARTIFACT/initramfs.trx := append-image-stage initramfs-kernel.bin | \
+	uImage none | asus-trx -v 3 -n $$(DEVICE_MODEL)
+endif
+endif
+endif
 endef
 TARGET_DEVICES += asus_tuf-ax4200
 


### PR DESCRIPTION
The initramfs.trx image can be flashed from the web interface of factory firmware.

Unfortunately, the bootloader doesn't seem to load the ramdisk from the FIT image when loading from flash. This means that the image only works when built with `TARGET_ROOTFS_INITRAMFS_SEPARATE` disabled.

Requiring a manual build of course limits the usefulness of the factory image. Maybe someone has a better solution for this? For now, I have marked the pull request as a draft.

This is likely the reason why #19623 didn't work. Also relevant for #20809.