### PR TITLE
tools/libdeflate: update to 1.25

### DIFF
--- a/tools/libdeflate/Makefile
+++ b/tools/libdeflate/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libdeflate
-PKG_VERSION:=1.24
+PKG_VERSION:=1.25
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/ebiggers/libdeflate/releases/download/v$(PKG_VERSION)
-PKG_HASH:=a0dda1c4b804742066db07b9510876edd09cc0ca06cdc32c5dfe1b2016a26463
+PKG_HASH:=fed5cd22f00f30cc4c2e5329f94e2b8a901df9fa45ee255cb70e2b0b42344477
 
 include $(INCLUDE_DIR)/host-build.mk
 


### PR DESCRIPTION
Changelog:
- Update to v1.25 (2025-10-31): no fixes or improvements, only the build harness maintenance.
