### PR TITLE
tools/dwarves: update to 1.31

### DIFF
--- a/tools/dwarves/Makefile
+++ b/tools/dwarves/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dwarves
-PKG_VERSION:=1.29
+PKG_VERSION:=1.31
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://fedorapeople.org/~acme/dwarves/
-PKG_HASH:=59c597d4e953c714d6f3ff36aeed2ac30cba85c1d7b94d0c87ca91d611d98a56
+PKG_HASH:=0a7f255ccacf8cc7f8cd119099eb327179b4b3c67cb015af646af6d0cb03054d
 
 PKG_MAINTAINER:=Tony Ambardar <itugrok@yahoo.com>
 PKG_LICENSE:=GPL-2.0-only


### PR DESCRIPTION
Release Notes:
- https://github.com/acmel/dwarves/releases/tag/v1.30
- https://github.com/acmel/dwarves/releases/tag/v1.31
