### PR TITLE
mediatek: filogic: increase flash speed on ASUS TUF AX6000

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
+++ b/target/linux/mediatek/dts/mt7986a-asus-tuf-ax6000.dts
@@ -252,7 +252,7 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 


### PR DESCRIPTION
This commit increases the SPI bus frequency from 20 to 52 MHz. Reduces boot time by 2s. Below is a performance comparison.

Before:
root@OpenWrt:~# dd if=/dev/mtd1 of=/dev/null bs=10M count=1 status=progress 10485760 bytes (10 MB, 10 MiB) copied, 1.68404 s, 6.2 MB/s

After:
root@OpenWrt:~# dd if=/dev/mtd1 of=/dev/null bs=10M count=1 status=progress 10485760 bytes (10 MB, 10 MiB) copied, 0.819222 s, 12.8 MB/s

Taken from PR #18752 as each device should be tested individually, so I have created a separate PR for this.

Signed-off-by: Sky Huang <SkyLake.Huang@mediatek.com>
Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>

