### PR TITLE
refpolicy: update to 2.20250923

### DIFF
--- a/package/system/refpolicy/Makefile
+++ b/package/system/refpolicy/Makefile
@@ -6,12 +6,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=refpolicy
-PKG_VERSION:=2.20200229
-PKG_RELEASE:=3
+PKG_VERSION:=2.20250923
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
-PKG_SOURCE_URL:=https://github.com/SELinuxProject/refpolicy/releases/download/RELEASE_2_20200229
-PKG_HASH:=dec854512ed00cd057408f330c2cea4de7a4405f7a147458f59c994bf578e4b0
+PKG_SOURCE_URL:=https://github.com/SELinuxProject/refpolicy/releases/download/RELEASE_2_20250923
+PKG_HASH:=e5b435c934048d01ca4415a1f2670a51e113f26f5d01ad4227c98fbe8dea8d5b
 PKG_INSTALL:=1
 PKG_BUILD_DEPENDS:=checkpolicy/host policycoreutils/host
 

--- a/package/system/refpolicy/patches/100-no-docs.patch
+++ b/package/system/refpolicy/patches/100-no-docs.patch
@@ -1,10 +1,8 @@
 --- a/Makefile
 +++ b/Makefile
-@@ -648,6 +648,6 @@ ifneq ($(generated_fc),)
+@@ -729,4 +729,4 @@ ifneq ($(generated_fc),)
  endif
  endif
  
--.PHONY: install-src install-appconfig install-headers generate xml conf html bare tags
-+.PHONY: install-src install-appconfig install-headers generate conf bare tags
- .SUFFIXES:
- .SUFFIXES: .c
+-.PHONY: install-src install-appconfig install-headers install-udica-templates build-interface-db generate xml conf html bare tags
++.PHONY: install-src install-appconfig install-headers install-udica-templates build-interface-db generate conf bare tags


### PR DESCRIPTION
Changelog:
  Notable Changes
  - Several updates and fixes for systemd
  - Add new permissions and policy capabilities
  - Drop reiserfs support (it was removed in kernel 6.13)

  New Modules
  - bubblewrap
  - incus
  - kanidm
  - seatd
  - opensnitch

Refresh patch:
- 100-no-docs.patch
