### PR TITLE
tools/cmake: update to 4.2.0

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=4.1.2
+PKG_VERSION:=4.2.0
 PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
@@ -15,7 +15,7 @@ PKG_CPE_ID:=cpe:/a:kitware:cmake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
 		https://cmake.org/files/v$(PKG_VERSION_MAJOR)/
-PKG_HASH:=643f04182b7ba323ab31f526f785134fb79cba3188a852206ef0473fee282a15
+PKG_HASH:=4104e94657d247c811cb29985405a360b78130b5d51e7f6daceb2447830bd579
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1

--- a/tools/cmake/patches/110-liblzma.patch
+++ b/tools/cmake/patches/110-liblzma.patch
@@ -1,6 +1,6 @@
 --- a/Modules/FindLibLZMA.cmake
 +++ b/Modules/FindLibLZMA.cmake
-@@ -82,7 +82,13 @@ Finding the liblzma library and linking
+@@ -114,7 +114,13 @@ Finding the liblzma library and linking
  cmake_policy(PUSH)
  cmake_policy(SET CMP0159 NEW) # file(STRINGS) with REGEX updates CMAKE_MATCH_<n>
  

--- a/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
+++ b/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
@@ -1,6 +1,6 @@
 --- a/bootstrap
 +++ b/bootstrap
-@@ -1520,7 +1520,10 @@ int main(){ printf("1%c", (char)0x0a); r
+@@ -1521,7 +1521,10 @@ int main(){ printf("1%c", (char)0x0a); r
  ' > "test.c"
  cmake_original_make_flags="${cmake_make_flags}"
  if test "x${cmake_parallel_make}" != "x"; then

--- a/tools/cmake/patches/140-zlib.patch
+++ b/tools/cmake/patches/140-zlib.patch
@@ -1,6 +1,6 @@
 --- a/Modules/FindZLIB.cmake
 +++ b/Modules/FindZLIB.cmake
-@@ -147,10 +147,13 @@ else()
+@@ -160,10 +160,13 @@ else()
    set(ZLIB_NAMES_DEBUG zd zlibd zdlld zlibd1 zlib1d zlibstaticd zlibwapid zlibvcd zlibstatd)
  endif()
  

--- a/tools/cmake/patches/150-zstd-libarchive.patch
+++ b/tools/cmake/patches/150-zstd-libarchive.patch
@@ -1,6 +1,6 @@
 --- a/Utilities/cmlibarchive/CMakeLists.txt
 +++ b/Utilities/cmlibarchive/CMakeLists.txt
-@@ -655,7 +655,7 @@ IF(ENABLE_ZSTD)
+@@ -669,7 +669,7 @@ IF(ENABLE_ZSTD)
      SET(ZSTD_FIND_QUIETLY TRUE)
    ENDIF (ZSTD_INCLUDE_DIR)
  

--- a/tools/cmake/patches/160-disable_xcode_generator.patch
+++ b/tools/cmake/patches/160-disable_xcode_generator.patch
@@ -1,6 +1,6 @@
 --- a/Source/CMakeLists.txt
 +++ b/Source/CMakeLists.txt
-@@ -886,7 +886,7 @@ if(CMake_USE_XCOFF_PARSER)
+@@ -903,7 +903,7 @@ if(CMake_USE_XCOFF_PARSER)
  endif()
  
  # Xcode only works on Apple
@@ -11,7 +11,7 @@
      PRIVATE
 --- a/Source/cmake.cxx
 +++ b/Source/cmake.cxx
-@@ -138,7 +138,7 @@
+@@ -143,7 +143,7 @@
  #  endif
  #endif
  


### PR DESCRIPTION
Update cmake to version 4.2.0
Release notes at https://cmake.org/cmake/help/v4.2/release/4.2.html

Patches refreshed.

Compile-tested for ipq806x/R7800.

cc @hauke 
