### PR TITLE
kernel: improve support for Fudan Micro SPI-NAND chips

### DIFF
--- a/target/linux/generic/backport-6.12/404-v6.19-mtd-spinand-fmsh-remove-QE-bit-for-FM25S01A-flash.patch
+++ b/target/linux/generic/backport-6.12/404-v6.19-mtd-spinand-fmsh-remove-QE-bit-for-FM25S01A-flash.patch
@@ -1,0 +1,28 @@
+From a1d3bc606bf5c3b3ea811cc2019df6285d75b00f Mon Sep 17 00:00:00 2001
+From: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Date: Mon, 3 Nov 2025 04:01:48 +0300
+Subject: [PATCH] mtd: spinand: fmsh: remove QE bit for FM25S01A flash
+
+According to datasheet (http://eng.fmsh.com/nvm/FM25S01A_ds_eng.pdf)
+there is no QE (Quad Enable) bit for FM25S01A flash, so remove it.
+
+Fixes: 5f284dc15ca86 ("mtd: spinand: add support for FudanMicro FM25S01A")
+Signed-off-by: Mikhail Kshevetskiy <mikhail.kshevetskiy@iopsys.eu>
+Tested-by: Tianling Shen <cnsztl@gmail.com>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+Link: Link: https://lore.kernel.org/linux-mtd/176216634975.908445.2776312239779833518.b4-ty@bootlin.com
+---
+ drivers/mtd/nand/spi/fmsh.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/mtd/nand/spi/fmsh.c
++++ b/drivers/mtd/nand/spi/fmsh.c
+@@ -58,7 +58,7 @@ static const struct spinand_info fmsh_sp
+ 		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
+ 					      &write_cache_variants,
+ 					      &update_cache_variants),
+-		     SPINAND_HAS_QE_BIT,
++		     0,
+ 		     SPINAND_ECCINFO(&fm25s01a_ooblayout, NULL)),
+ };
+ 

--- a/target/linux/generic/pending-6.12/403-mtd-spinand-add-support-for-FudanMicro-FM25S01BI3.patch
+++ b/target/linux/generic/pending-6.12/403-mtd-spinand-add-support-for-FudanMicro-FM25S01BI3.patch
@@ -1,0 +1,117 @@
+To: Miquel Raynal <miquel.raynal@bootlin.com>,
+ Richard Weinberger <richard@nod.at>, Vignesh Raghavendra <vigneshr@ti.com>,
+ Tudor Ambarus <tudor.ambarus@linaro.org>, Mark Brown <broonie@kernel.org>
+Cc: linux-kernel@vger.kernel.org, linux-mtd@lists.infradead.org
+From: Mikhail Zhilkin <csharper2005@gmail.com>
+Subject: [PATCH] mtd: spinand: add support for FudanMicro FM25S01BI3
+
+Add support for FudanMicro FM25S01BI3 SPI NAND.
+
+Link: https://www.fmsh.com/nvm/FM25S01BI3_ds_eng.pdf
+
+Signed-off-by: Mikhail Zhilkin <csharper2005@gmail.com>
+Link: https://lore.kernel.org/linux-mtd/130e0f3f-93e4-47cf-82f0-93ba58a3a670@gmail.com
+---
+ drivers/mtd/nand/spi/fmsh.c | 72 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 72 insertions(+)
+
+--- a/drivers/mtd/nand/spi/fmsh.c
++++ b/drivers/mtd/nand/spi/fmsh.c
+@@ -9,6 +9,13 @@
+ #include <linux/kernel.h>
+ #include <linux/mtd/spinand.h>
+ 
++#define FM25S01BI3_STATUS_ECC_MASK		(7 << 4)
++	#define FM25S01BI3_STATUS_ECC_NO_BITFLIPS	(0 << 4)
++	#define FM25S01BI3_STATUS_ECC_1_3_BITFLIPS	(1 << 4)
++	#define FM25S01BI3_STATUS_ECC_UNCOR_ERROR	(2 << 4)
++	#define FM25S01BI3_STATUS_ECC_4_6_BITFLIPS	(3 << 4)
++	#define FM25S01BI3_STATUS_ECC_7_8_BITFLIPS	(5 << 4)
++
+ #define SPINAND_MFR_FMSH		0xA1
+ 
+ static SPINAND_OP_VARIANTS(read_cache_variants,
+@@ -45,11 +52,66 @@ static int fm25s01a_ooblayout_free(struc
+ 	return 0;
+ }
+ 
++static int fm25s01bi3_ecc_get_status(struct spinand_device *spinand,
++				     u8 status)
++{
++	switch (status & FM25S01BI3_STATUS_ECC_MASK) {
++	case FM25S01BI3_STATUS_ECC_NO_BITFLIPS:
++		return 0;
++
++	case FM25S01BI3_STATUS_ECC_UNCOR_ERROR:
++		return -EBADMSG;
++
++	case FM25S01BI3_STATUS_ECC_1_3_BITFLIPS:
++		return 3;
++
++	case FM25S01BI3_STATUS_ECC_4_6_BITFLIPS:
++		return 6;
++
++	case FM25S01BI3_STATUS_ECC_7_8_BITFLIPS:
++		return 8;
++
++	default:
++		break;
++	}
++
++	return -EINVAL;
++}
++
++static int fm25s01bi3_ooblayout_ecc(struct mtd_info *mtd, int section,
++				    struct mtd_oob_region *region)
++{
++	if (section)
++		return -ERANGE;
++
++	region->offset = 64;
++	region->length = 64;
++
++	return 0;
++}
++
++static int fm25s01bi3_ooblayout_free(struct mtd_info *mtd, int section,
++				     struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	region->offset = (16 * section) + 4;
++	region->length = 12;
++
++	return 0;
++}
++
+ static const struct mtd_ooblayout_ops fm25s01a_ooblayout = {
+ 	.ecc = fm25s01a_ooblayout_ecc,
+ 	.free = fm25s01a_ooblayout_free,
+ };
+ 
++static const struct mtd_ooblayout_ops fm25s01bi3_ooblayout = {
++	.ecc = fm25s01bi3_ooblayout_ecc,
++	.free = fm25s01bi3_ooblayout_free,
++};
++
+ static const struct spinand_info fmsh_spinand_table[] = {
+ 	SPINAND_INFO("FM25S01A",
+ 		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xE4),
+@@ -60,6 +122,16 @@ static const struct spinand_info fmsh_sp
+ 					      &update_cache_variants),
+ 		     0,
+ 		     SPINAND_ECCINFO(&fm25s01a_ooblayout, NULL)),
++	SPINAND_INFO("FM25S01BI3",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xd4),
++		     NAND_MEMORG(1, 2048, 128, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&fm25s01bi3_ooblayout,
++				      fm25s01bi3_ecc_get_status)),
+ };
+ 
+ static const struct spinand_manufacturer_ops fmsh_spinand_manuf_ops = {


### PR DESCRIPTION
Fudan Micro FM25S01A and FM25S01BI3 are the chips that are used in some routers, such as Routerich AX3000 and CMCC RAX3000Me.

Commits:
- kernel: fix QE bit for Fudan Micro FM25S01A SPI-NAND
- kernel: add support for Fudan Micro FM25S01BI3 SPI-NAND
