### PR TITLE
ramips: sim_simax1800t: switch to wpad-openssl

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2738,6 +2738,7 @@ define Device/sim_simax1800t
   $(Device/haier-sim_wr1800k)
   DEVICE_VENDOR := SIM
   DEVICE_MODEL := SIMAX1800T
+  DEVICE_PACKAGES += -wpad-basic-mbedtls wpad-openssl
 endef
 TARGET_DEVICES += sim_simax1800t
 


### PR DESCRIPTION
 Without this package, enabling 802.11v causes the driver/hostapd to crash or fail initialization.

The device has sufficient storage space to accommodate the larger wpad-openssl package.and it fixes this issue which has previously been attributed to the mediatek driver incorrectly.