### PR TITLE
ipq40xx: rework netgear orbi devices

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -63,6 +63,7 @@ ALLWIFIBOARDS:= \
 	netgear_lbr20 \
 	netgear_rax120v2 \
 	netgear_rbk20 \
+	netgear_rbk40 \
 	netgear_sxk80 \
 	netgear_wax214 \
 	netgear_wax218 \
@@ -242,6 +243,7 @@ $(eval $(call generate-ipq-wifi-package,meraki_z3,Meraki Z3))
 $(eval $(call generate-ipq-wifi-package,netgear_lbr20,Netgear LBR20))
 $(eval $(call generate-ipq-wifi-package,netgear_rax120v2,Netgear RAX120v2))
 $(eval $(call generate-ipq-wifi-package,netgear_rbk20,Netgear RBK20))
+$(eval $(call generate-ipq-wifi-package,netgear_rbk40,Netgear RBK40))
 $(eval $(call generate-ipq-wifi-package,netgear_sxk80,Netgear SXK80))
 $(eval $(call generate-ipq-wifi-package,netgear_wax214,Netgear WAX214))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -244,6 +244,7 @@ ipq40xx_setup_macs()
 		lan_mac=$(cat /sys/firmware/mikrotik/hard_config/mac_base)
 		label_mac="$lan_mac"
 		;;
+	netgear,rbr40|\
 	netgear,rbr50|\
 	netgear,srr60|\
 	pakedge,wr-1)

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -70,14 +70,14 @@ ipq40xx_setup_interfaces()
 	buffalo,wtr-m2133hp|\
 	ezviz,cs-w3-wd1200g-eup|\
 	netgear,rbr40|\
-	netgear,rbs40|\
 	netgear,rbr50|\
-	netgear,rbs50|\
-	netgear,srr60|\
-	netgear,srs60)
+	netgear,srr60)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
-	avm,fritzbox-7530)
+	avm,fritzbox-7530|\
+	netgear,rbs40|\
+	netgear,rbs50|\
+	netgear,srs60)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
 	avm,fritzrepeater-3000|\
@@ -245,9 +245,7 @@ ipq40xx_setup_macs()
 		label_mac="$lan_mac"
 		;;
 	netgear,rbr50|\
-	netgear,rbs50|\
 	netgear,srr60|\
-	netgear,srs60|\
 	pakedge,wr-1)
 		wan_mac=$(macaddr_add $(get_mac_label) 1)
 		;;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi-router.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi-router.dtsi
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019-orbi.dtsi"
+
+&swport1 {
+	status = "okay";
+
+	label = "wan";
+};
+
+&swport2 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport3 {
+	status = "okay";
+
+	label = "lan2";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan3";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi-satellite.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi-satellite.dtsi
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019-orbi.dtsi"
+
+&swport1 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport2 {
+	status = "okay";
+
+	label = "lan2";
+};
+
+&swport3 {
+	status = "okay";
+
+	label = "lan3";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan4";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -288,24 +288,3 @@
 	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
 	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
 };
-
-&pcie_bridge0 {
-	wifi@0,0 {
-		compatible = "qcom,ath10k";
-		reg = <0x00010000 0 0 0 0>;
-		ieee80211-freq-limit = <5470000 5875000>;
-		qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
-	};
-};
-
-&wifi0 {
-	status = "okay";
-
-	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
-};
-
-&wifi1 {
-	status = "okay";
-
-	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
-};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -204,49 +204,65 @@
 		reg = <0x27>;
 
 		led0@0 {
-			label = "rgb:led0";
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <0>;
+			color = <LED_COLOR_ID_WHITE>;
 			reg = <0x0>;
 			linux,default-trigger = "default-on";
 		};
 
 		led1@1 {
-			label = "rgb:led1";
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_WHITE>;
 			reg = <0x1>;
 			linux,default-trigger = "default-on";
 		};
 
 		led2@2 {
-			label = "rgb:led2";
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_WHITE>;
 			reg = <0x2>;
 			linux,default-trigger = "default-on";
 		};
 
 		led3@3 {
-			label = "rgb:led3";
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_WHITE>;
 			reg = <0x3>;
 			linux,default-trigger = "default-on";
 		};
 
 		led4@4 {
-			label = "rgb:led4";
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <4>;
+			color = <LED_COLOR_ID_WHITE>;
 			reg = <0x4>;
 			linux,default-trigger = "default-on";
 		};
 
 		led5@5 {
-			label = "rgb:led5";
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <5>;
+			color = <LED_COLOR_ID_WHITE>;
 			reg = <0x5>;
 			linux,default-trigger = "default-on";
 		};
 
 		led6@6 {
-			label = "rgb:led6";
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <6>;
+			color = <LED_COLOR_ID_WHITE>;
 			reg = <0x6>;
 			linux,default-trigger = "default-on";
 		};
 
 		led7@7 {
-			label = "rgb:led7";
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <7>;
+			color = <LED_COLOR_ID_WHITE>;
 			reg = <0x7>;
 			linux,default-trigger = "default-on";
 		};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-orbi.dtsi
@@ -278,30 +278,6 @@
 	status = "okay";
 };
 
-&swport1 {
-	status = "okay";
-
-	label = "wan";
-};
-
-&swport2 {
-	status = "okay";
-
-	label = "lan1";
-};
-
-&swport3 {
-	status = "okay";
-
-	label = "lan2";
-};
-
-&swport4 {
-	status = "okay";
-
-	label = "lan3";
-};
-
 &ethphy4 {
 	status = "disabled";
 };

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr40.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr40.dts
@@ -10,3 +10,24 @@
 		bootargs = "root=/dev/mmcblk0p20 blkdevparts=mmcblk0:512K@17K(0:SBL1)ro,512K(0:BOOTCONFIG)ro,512K(0:QSEE)ro,512K(0:QSEE_ALT)ro,256K(0:CDT)ro,256K(0:CDT_ALT)ro,256K(0:DDRPARAMS)ro,256K(0:APPSBLENV)ro,1M(0:APPSBL)ro,1M(0:APPSBL_ALT)ro,256K(0:ART)ro,256K(ARTMTD)ro,2M(language)ro,256K(config)ro,256K(pot)ro,256K(traffic_meter)ro,256K(pot_bak)ro,256K(traffic_meter.bak)ro,3840K(kernel),31488K(rootfs),35328K@9233K(firmware),256K(mtdoops)ro,1457651200(reserved)ro,-(unallocated) rootfstype=squashfs,ext4 rootwait";
 	};
 };
+
+&pcie_bridge0 {
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x00010000 0 0 0 0>;
+		ieee80211-freq-limit = <5170000 5350000>;
+		qcom,ath10k-calibration-variant = "Netgear-RBK40";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-RBK40";
+};
+
+&wifi1 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-RBK40";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr40.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr40.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "qcom-ipq4019-orbi.dtsi"
+#include "qcom-ipq4019-orbi-router.dtsi"
 
 / {
 	model = "NETGEAR RBR40";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr50.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr50.dts
@@ -26,3 +26,24 @@
 &usb2 {
 	status = "okay";
 };
+
+&pcie_bridge0 {
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x00010000 0 0 0 0>;
+		ieee80211-freq-limit = <5470000 5875000>;
+		qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};
+
+&wifi1 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr50.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbr50.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "qcom-ipq4019-orbi.dtsi"
+#include "qcom-ipq4019-orbi-router.dtsi"
 
 / {
 	model = "NETGEAR RBR50";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs40.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs40.dts
@@ -10,3 +10,24 @@
 		bootargs = "root=/dev/mmcblk0p20 blkdevparts=mmcblk0:512K@17K(0:SBL1)ro,512K(0:BOOTCONFIG)ro,512K(0:QSEE)ro,512K(0:QSEE_ALT)ro,256K(0:CDT)ro,256K(0:CDT_ALT)ro,256K(0:DDRPARAMS)ro,256K(0:APPSBLENV)ro,1M(0:APPSBL)ro,1M(0:APPSBL_ALT)ro,256K(0:ART)ro,256K(ARTMTD)ro,2M(language)ro,256K(config)ro,256K(pot)ro,256K(traffic_meter)ro,256K(pot_bak)ro,256K(traffic_meter.bak)ro,3840K(kernel),31488K(rootfs),35328K@9233K(firmware),256K(mtdoops)ro,1457651200(reserved)ro,-(unallocated) rootfstype=squashfs,ext4 rootwait";
 	};
 };
+
+&pcie_bridge0 {
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x00010000 0 0 0 0>;
+		ieee80211-freq-limit = <5170000 5350000>;
+		qcom,ath10k-calibration-variant = "Netgear-RBK40";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-RBK40";
+};
+
+&wifi1 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-RBK40";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs40.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs40.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "qcom-ipq4019-orbi.dtsi"
+#include "qcom-ipq4019-orbi-satellite.dtsi"
 
 / {
 	model = "NETGEAR RBS40";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs50.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs50.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "qcom-ipq4019-orbi.dtsi"
+#include "qcom-ipq4019-orbi-satellite.dtsi"
 
 / {
 	model = "NETGEAR RBS50";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs50.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rbs50.dts
@@ -26,3 +26,24 @@
 &usb2 {
 	status = "okay";
 };
+
+&pcie_bridge0 {
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x00010000 0 0 0 0>;
+		ieee80211-freq-limit = <5470000 5875000>;
+		qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};
+
+&wifi1 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-srr60.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-srr60.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "qcom-ipq4019-orbi.dtsi"
+#include "qcom-ipq4019-orbi-router.dtsi"
 
 / {
 	model = "NETGEAR SRR60";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-srr60.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-srr60.dts
@@ -10,3 +10,24 @@
 		bootargs = "root=/dev/mmcblk0p20 blkdevparts=mmcblk0:512K@17K(0:SBL1)ro,512K(0:BOOTCONFIG)ro,512K(0:QSEE)ro,512K(0:QSEE_1)ro,256K(0:CDT)ro,256K(0:CDT_1)ro,512K(0:BOOTCONFIG1)ro,256K(0:APPSBLENV)ro,1M(0:APPSBL)ro,1M(0:APPSBL_1)ro,256K(0:ART)ro,256K(ARTMTD)ro,2M(language)ro,256K(config)ro,256K(pot)ro,256K(traffic_meter)ro,256K(pot_bak)ro,256K(traffic_meter.bak)ro,3840K(kernel),31488K(rootfs),35328K@9233K(firmware),256K(mtdoops)ro,64K(cert)ro,3840K(kernel-2)ro,31488K(rootfs-2)ro,35328K@44881K(firmware-2)ro,5M(device_table)ro,17M(cp_file)ro,102737K(reserved)ro,-(unallocated) rootfstype=squashfs,ext4 rootwait";
 	};
 };
+
+&pcie_bridge0 {
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x00010000 0 0 0 0>;
+		ieee80211-freq-limit = <5470000 5875000>;
+		qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};
+
+&wifi1 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-srs60.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-srs60.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "qcom-ipq4019-orbi.dtsi"
+#include "qcom-ipq4019-orbi-satellite.dtsi"
 
 / {
 	model = "NETGEAR SRS60";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-srs60.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-srs60.dts
@@ -10,3 +10,24 @@
 		bootargs = "root=/dev/mmcblk0p20 blkdevparts=mmcblk0:512K@17K(0:SBL1)ro,512K(0:BOOTCONFIG)ro,512K(0:QSEE)ro,512K(0:QSEE_1)ro,256K(0:CDT)ro,256K(0:CDT_1)ro,512K(0:BOOTCONFIG1)ro,256K(0:APPSBLENV)ro,1M(0:APPSBL)ro,1M(0:APPSBL_1)ro,256K(0:ART)ro,256K(ARTMTD)ro,2M(language)ro,256K(config)ro,256K(pot)ro,256K(traffic_meter)ro,256K(pot_bak)ro,256K(traffic_meter.bak)ro,3840K(kernel),31488K(rootfs),35328K@9233K(firmware),256K(mtdoops)ro,64K(cert)ro,3840K(kernel-2)ro,31488K(rootfs-2)ro,35328K@44881K(firmware-2)ro,5M(device_table)ro,17M(cp_file)ro,102737K(reserved)ro,-(unallocated) rootfstype=squashfs,ext4 rootwait";
 	};
 };
+
+&pcie_bridge0 {
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x00010000 0 0 0 0>;
+		ieee80211-freq-limit = <5470000 5875000>;
+		qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};
+
+&wifi1 {
+	status = "okay";
+
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -904,7 +904,7 @@ define Device/netgear_orbi
 		append-rootfs | pad-rootfs | netgear-dni
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-to 64k | \
 		sysupgrade-tar rootfs=$$$$@ | append-metadata
-	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct e2fsprogs kmod-fs-ext4 losetup
+	DEVICE_PACKAGES := e2fsprogs kmod-fs-ext4 losetup
 endef
 
 define Device/netgear_lbr20
@@ -967,6 +967,7 @@ define Device/netgear_rbx40
 	KERNEL_SIZE := 3932160
 	ROOTFS_SIZE := 32243712
 	IMAGE_SIZE := 36175872
+	DEVICE_PACKAGES += ipq-wifi-netgear_rbk40 ath10k-firmware-qca9888-ct
 endef
 
 define Device/netgear_rbr40
@@ -991,6 +992,7 @@ define Device/netgear_rbx50
 	KERNEL_SIZE := 3932160
 	ROOTFS_SIZE := 32243712
 	IMAGE_SIZE := 36175872
+	DEVICE_PACKAGES += ath10k-firmware-qca9984-ct
 endef
 
 define Device/netgear_rbr50
@@ -1015,6 +1017,7 @@ define Device/netgear_srx60
 	KERNEL_SIZE := 3932160
 	ROOTFS_SIZE := 32243712
 	IMAGE_SIZE := 36175872
+	DEVICE_PACKAGES += ath10k-firmware-qca9984-ct
 endef
 
 define Device/netgear_srr60


### PR DESCRIPTION
This reworks several issues i found with the already supported Netgear Orbi devices, mainly the RBR40/RBS40.

At first a new dtsi layer is introduced to distinguish between router and satellite units. The reason for that is that the network configuration for satellites is currently wrong as they do not have a designated WAN port - instead all ports are labeled "Ethernet".
Next, the led node config was converted to function and color - and changed from RGB to white. The reason for that is that these LEDs are white by default and the color part is controlled by individual GPIOs.

Now to the RBx40 specific changes:
First change is simple and just fixes the WAN MAC for RBR40 - i guess the line in `ipq40xx_setup_macs()` was simply forgotten.
After that I've also fixed the 2nd 5ghz wifi, as the RBx40 devices use QCA9886 instead of QCA9984 like their bigger siblings. They also use different boardfiles for the IPQ4019 chip in their vendor image, so I've added overrides to the ipq-wifi package (https://github.com/openwrt/firmware_qca-wireless/pull/115) and changed the package selection.