### PR TITLE
libbpf: update to 1.6.2

### DIFF
--- a/package/libs/libbpf/Makefile
+++ b/package/libs/libbpf/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libbpf
-PKG_VERSION:=1.5.0
+PKG_VERSION:=1.6.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://github.com/libbpf/libbpf
-PKG_MIRROR_HASH:=7699fcfa89bf0f6e756c4555fbd3fdb8cbcfcc770e5944aebdd0e9244031f022
+PKG_MIRROR_HASH:=9620f45b4fc0ee5e0f43502634fe48fbcb34ab49d2553b7275fa92f7e02d3dc7
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_ABI_VERSION:=$(firstword $(subst .,$(space),$(PKG_VERSION)))

--- a/package/libs/libbpf/patches/100-bpf_tc_classid.patch
+++ b/package/libs/libbpf/patches/100-bpf_tc_classid.patch
@@ -1,6 +1,6 @@
 --- a/src/libbpf.h
 +++ b/src/libbpf.h
-@@ -1291,9 +1291,10 @@ struct bpf_tc_opts {
+@@ -1332,9 +1332,10 @@ struct bpf_tc_opts {
  	__u32 prog_id;
  	__u32 handle;
  	__u32 priority;
@@ -14,7 +14,7 @@
  LIBBPF_API int bpf_tc_hook_destroy(struct bpf_tc_hook *hook);
 --- a/src/netlink.c
 +++ b/src/netlink.c
-@@ -673,6 +673,8 @@ static int __get_tc_info(void *cookie, s
+@@ -687,6 +687,8 @@ static int __get_tc_info(void *cookie, s
  	OPTS_SET(info->opts, prog_id, libbpf_nla_getattr_u32(tbb[TCA_BPF_ID]));
  	OPTS_SET(info->opts, handle, tc->tcm_handle);
  	OPTS_SET(info->opts, priority, TC_H_MAJ(tc->tcm_info) >> 16);
@@ -23,7 +23,7 @@
  
  	info->processed = true;
  	return unicast ? NL_NEXT : NL_DONE;
-@@ -717,7 +719,7 @@ static int tc_add_fd_and_name(struct lib
+@@ -731,7 +733,7 @@ static int tc_add_fd_and_name(struct lib
  
  int bpf_tc_attach(const struct bpf_tc_hook *hook, struct bpf_tc_opts *opts)
  {
@@ -32,7 +32,7 @@
  	int ret, ifindex, attach_point, prog_fd;
  	struct bpf_cb_ctx info = {};
  	struct libbpf_nla_req req;
-@@ -737,6 +739,7 @@ int bpf_tc_attach(const struct bpf_tc_ho
+@@ -751,6 +753,7 @@ int bpf_tc_attach(const struct bpf_tc_ho
  	prog_fd      = OPTS_GET(opts, prog_fd, 0);
  	prog_id      = OPTS_GET(opts, prog_id, 0);
  	flags        = OPTS_GET(opts, flags, 0);
@@ -40,7 +40,7 @@
  
  	if (ifindex <= 0 || !prog_fd || prog_id)
  		return libbpf_err(-EINVAL);
-@@ -776,6 +779,11 @@ int bpf_tc_attach(const struct bpf_tc_ho
+@@ -790,6 +793,11 @@ int bpf_tc_attach(const struct bpf_tc_ho
  	ret = nlattr_add(&req, TCA_BPF_FLAGS, &bpf_flags, sizeof(bpf_flags));
  	if (ret < 0)
  		return libbpf_err(ret);


### PR DESCRIPTION
Release Notes:
- 1.6.2: https://github.com/libbpf/libbpf/releases/tag/v1.6.2
- 1.6.1: https://github.com/libbpf/libbpf/releases/tag/v1.6.1
- 1.6.0: https://github.com/libbpf/libbpf/releases/tag/v1.6.0
- 1.5.1: https://github.com/libbpf/libbpf/releases/tag/v1.5.1
