### PR TITLE
binutils: update to 2.45.1

### DIFF
--- a/package/devel/binutils/Makefile
+++ b/package/devel/binutils/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=binutils
-PKG_VERSION:=2.42
+PKG_VERSION:=2.45.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@GNU/binutils
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_VERSION:=$(PKG_VERSION)
-PKG_HASH:=f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800
+PKG_HASH:=5fe101e6fe9d18fdec95962d81ed670fdee5f37e3f48f0bef87bddf862513aa5
 
 PKG_FIXUP:=patch-libtool
 PKG_LIBTOOL_PATHS:=. gas bfd opcodes gprof gprofng binutils ld libiberty gold intl libctf libsframe

--- a/package/devel/binutils/patches/001-replace-attribute_const.patch
+++ b/package/devel/binutils/patches/001-replace-attribute_const.patch
@@ -17,9 +17,9 @@ unwind.c:490:3: note: in expansion of macro 'FILL_CONTEXT'
 ----------------------
 --- a/gprofng/common/cpuid.c
 +++ b/gprofng/common/cpuid.c
-@@ -23,7 +23,7 @@
- #elif defined(__aarch64__)
+@@ -25,7 +25,7 @@
  #define ATTRIBUTE_UNUSED __attribute__((unused))
+ #endif
  
 -static inline uint_t __attribute_const__
 +static inline uint_t __attribute__((__const__))
@@ -28,7 +28,7 @@ unwind.c:490:3: note: in expansion of macro 'FILL_CONTEXT'
  	     unsigned int *ecx ATTRIBUTE_UNUSED, unsigned int *edx ATTRIBUTE_UNUSED)
 --- a/gprofng/libcollector/unwind.c
 +++ b/gprofng/libcollector/unwind.c
-@@ -237,7 +237,7 @@ typedef uint64_t __u64;
+@@ -236,7 +236,7 @@ typedef uint64_t __u64;
  
  #define FILL_CONTEXT(context) \
      { CALL_UTIL (getcontext) (context);  \
@@ -36,8 +36,8 @@ unwind.c:490:3: note: in expansion of macro 'FILL_CONTEXT'
 +      context->uc_mcontext.sp = (uint64_t) __builtin_frame_address(0); \
      }
  
- #endif /* ARCH() */
-@@ -4583,11 +4583,11 @@ stack_unwind (char *buf, int size, void
+ #elif ARCH(RISCV)
+@@ -4588,11 +4588,11 @@ stack_unwind (char *buf, int size, void
    if (buf && bptr && eptr && context && size + mode > 0)
      getByteInstruction ((unsigned char *) eptr);
    int ind = 0;
@@ -54,7 +54,7 @@ unwind.c:490:3: note: in expansion of macro 'FILL_CONTEXT'
    unsigned long tbgn = 0;
    unsigned long tend = 0;
  
-@@ -4598,7 +4598,7 @@ stack_unwind (char *buf, int size, void
+@@ -4603,7 +4603,7 @@ stack_unwind (char *buf, int size, void
      {
        stack_base = sp + 0x100000;
        if (stack_base < sp)  // overflow
@@ -63,7 +63,7 @@ unwind.c:490:3: note: in expansion of macro 'FILL_CONTEXT'
      }
    DprintfT (SP_DUMP_UNWIND,
      "unwind.c:%d stack_unwind %2d pc=0x%llx  sp=0x%llx  stack_base=0x%llx\n",
-@@ -4629,17 +4629,17 @@ stack_unwind (char *buf, int size, void
+@@ -4634,17 +4634,17 @@ stack_unwind (char *buf, int size, void
  		      __LINE__, (unsigned long) sp);
  	    break;
  	  }


### PR DESCRIPTION
Patches automatically refreshed.

Release Notes:
- 2.45.1: https://sourceware.org/pipermail/binutils/2025-November/145592.html
- 2.45.0: https://lists.gnu.org/archive/html/info-gnu/2025-07/msg00009.html
- 2.44.0: https://lists.gnu.org/archive/html/info-gnu/2025-02/msg00001.html
- 2.43.0: https://lists.gnu.org/archive/html/info-gnu/2024-08/msg00001.html
