### PR TITLE
libpcre2: Default enable JIT support for aarch64

### DIFF
--- a/package/libs/pcre2/Config.in
+++ b/package/libs/pcre2/Config.in
@@ -1,7 +1,7 @@
 config PCRE2_JIT_ENABLED
 	bool
 	depends on PACKAGE_libpcre2 && (aarch64 || aarch64_be || arm || i386 || i686 || x86_64 || mips || mipsel || mips64 || mips64el || powerpc || powerpc64 || powerpcle || sparc)
-	default y if (arm || i686 || x86_64)
+	default y if (aarch64 || arm || i686 || x86_64)
 	prompt "Enable JIT compiler support"
 	help
 		Enable JIT (Just-In-Time) compiler support.


### PR DESCRIPTION
JIT support in pcre2 allows for extra performance for regex operations in applications that support it. As outlined in
https://pcre.org/current/doc/html/pcre2jit.html#SEC2 64-bit ARM is supported.

I tested this on an GL.Inet MT6000 which is an aarch64 device and to my knowledge everything works as expected. The primary application I tested this on was haproxy, which makes use pcre for several operations.

If there are no known downsides or known breakages I suggest to default-enable this feature for aarch64.
