### PR TITLE
mediatek: use dt-bindings drive strength macros for ipTIME AX7800M-6E

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
+++ b/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
@@ -149,7 +149,7 @@
 				   "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
 				   "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
 				   "WF1_TOP_CLK", "WF1_TOP_DATA";
-			drive-strength = <4>;
+			drive-strength = <MTK_DRIVE_4mA>;
 		};
 	};
 
@@ -166,7 +166,7 @@
 				   "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
 				   "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
 				   "WF1_TOP_CLK", "WF1_TOP_DATA";
-			drive-strength = <4>;
+			drive-strength = <MTK_DRIVE_4mA>;
 		};
 	};
 };


### PR DESCRIPTION
Replace hardcoded numbers with the dt-bindings drive strength macros defined in `dt-bindings/pinctrl/mt65xx.h`.
