### PR TITLE
libusb: update to 1.0.29

### DIFF
--- a/package/libs/libusb/Makefile
+++ b/package/libs/libusb/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libusb
-PKG_VERSION:=1.0.27
+PKG_VERSION:=1.0.29
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/libusb/libusb/releases/download/v$(PKG_VERSION)
-PKG_HASH:=ffaa41d741a8a3bee244ac8e54a72ea05bf2879663c098c82fc5757853441575
+PKG_HASH:=5977fc950f8d1395ccea9bd48c06b3f808fd3c2c961b44b0c2e6e29fc3a70a85
 
 PKG_MAINTAINER:= Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=LGPL-2.1-or-later


### PR DESCRIPTION
Release Notes:
- https://github.com/libusb/libusb/releases/tag/v1.0.29
- https://github.com/libusb/libusb/releases/tag/v1.0.28
