### PR TITLE
iptables: update to 1.8.11

### DIFF
--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -9,12 +9,12 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=iptables
-PKG_VERSION:=1.8.10
-PKG_RELEASE:=2
+PKG_VERSION:=1.8.11
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://netfilter.org/projects/iptables/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=5cc255c189356e317d070755ce9371eb63a1b783c34498fb8c30264f3cc59c9c
+PKG_HASH:=d87303d55ef8c92bcad4dd3f978b26d272013642b029425775f5bad1009fe7b2
 
 PKG_FIXUP:=autoreconf
 PKG_FLAGS:=nonshared

--- a/package/network/utils/iptables/patches/010-add-set-dscpmark-support.patch
+++ b/package/network/utils/iptables/patches/010-add-set-dscpmark-support.patch
@@ -25,7 +25,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  #include <xtables.h>
  #include <linux/netfilter/xt_CONNMARK.h>
  
-@@ -49,6 +50,7 @@ enum {
+@@ -44,6 +45,7 @@ enum {
  	O_CTMASK,
  	O_NFMASK,
  	O_MASK,
@@ -33,7 +33,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  	F_SET_MARK         = 1 << O_SET_MARK,
  	F_SAVE_MARK        = 1 << O_SAVE_MARK,
  	F_RESTORE_MARK     = 1 << O_RESTORE_MARK,
-@@ -61,8 +63,10 @@ enum {
+@@ -56,8 +58,10 @@ enum {
  	F_CTMASK           = 1 << O_CTMASK,
  	F_NFMASK           = 1 << O_NFMASK,
  	F_MASK             = 1 << O_MASK,
@@ -45,7 +45,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  };
  
  static const char *const xt_connmark_shift_ops[] = {
-@@ -114,6 +118,8 @@ static const struct xt_option_entry conn
+@@ -109,6 +113,8 @@ static const struct xt_option_entry conn
  	 .excl = F_MASK, .flags = XTOPT_PUT, XTOPT_POINTER(s, nfmask)},
  	{.name = "mask", .id = O_MASK, .type = XTTYPE_UINT32,
  	 .excl = F_CTMASK | F_NFMASK},
@@ -54,7 +54,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  	XTOPT_TABLEEND,
  };
  #undef s
-@@ -148,6 +154,38 @@ static const struct xt_option_entry conn
+@@ -143,6 +149,38 @@ static const struct xt_option_entry conn
  };
  #undef s
  
@@ -93,7 +93,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  static void connmark_tg_help(void)
  {
  	printf(
-@@ -175,6 +213,15 @@ static void connmark_tg_help_v2(void)
+@@ -170,6 +208,15 @@ static void connmark_tg_help_v2(void)
  );
  }
  
@@ -109,7 +109,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  static void connmark_tg_init(struct xt_entry_target *target)
  {
  	struct xt_connmark_tginfo1 *info = (void *)target->data;
-@@ -199,6 +246,16 @@ static void connmark_tg_init_v2(struct x
+@@ -194,6 +241,16 @@ static void connmark_tg_init_v2(struct x
  	info->shift_bits = 0;
  }
  
@@ -126,7 +126,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  static void CONNMARK_parse(struct xt_option_call *cb)
  {
  	struct xt_connmark_target_info *markinfo = cb->data;
-@@ -253,6 +310,23 @@ static void connmark_tg_parse(struct xt_
+@@ -248,6 +305,23 @@ static void connmark_tg_parse(struct xt_
  		info->ctmark = cb->val.u32;
  		info->ctmask = 0;
  		break;
@@ -150,7 +150,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  	case O_SAVE_MARK:
  		info->mode = XT_CONNMARK_SAVE;
  		break;
-@@ -320,6 +394,78 @@ static void connmark_tg_parse_v2(struct
+@@ -315,6 +389,78 @@ static void connmark_tg_parse_v2(struct
  	}
  }
  
@@ -229,7 +229,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  static void connmark_tg_check(struct xt_fcheck_call *cb)
  {
  	if (!(cb->xflags & F_OP_ANY))
-@@ -463,6 +609,65 @@ connmark_tg_print_v2(const void *ip, con
+@@ -458,6 +604,65 @@ connmark_tg_print_v2(const void *ip, con
  	}
  }
  
@@ -295,7 +295,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  static void CONNMARK_save(const void *ip, const struct xt_entry_target *target)
  {
  	const struct xt_connmark_target_info *markinfo =
-@@ -548,6 +753,38 @@ connmark_tg_save_v2(const void *ip, cons
+@@ -543,6 +748,38 @@ connmark_tg_save_v2(const void *ip, cons
  	}
  }
  
@@ -334,7 +334,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  static int connmark_tg_xlate(struct xt_xlate *xl,
  			     const struct xt_xlate_tg_params *params)
  {
-@@ -644,6 +881,66 @@ static int connmark_tg_xlate_v2(struct x
+@@ -639,6 +876,66 @@ static int connmark_tg_xlate_v2(struct x
  
  	return 1;
  }
@@ -401,7 +401,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  static struct xtables_target connmark_tg_reg[] = {
  	{
  		.family        = NFPROTO_UNSPEC,
-@@ -692,6 +989,22 @@ static struct xtables_target connmark_tg
+@@ -687,6 +984,22 @@ static struct xtables_target connmark_tg
  		.x6_options    = connmark_tg_opts_v2,
  		.xlate         = connmark_tg_xlate_v2,
  	},
@@ -426,8 +426,8 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  void _init(void)
 --- a/include/linux/netfilter/xt_connmark.h
 +++ b/include/linux/netfilter/xt_connmark.h
-@@ -18,6 +18,11 @@ enum {
- 	XT_CONNMARK_RESTORE
+@@ -19,6 +19,11 @@ enum {
+ 	D_SHIFT_RIGHT,
  };
  
 +enum {
@@ -438,7 +438,7 @@ Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
  struct xt_connmark_tginfo1 {
  	__u32 ctmark, ctmask, nfmask;
  	__u8 mode;
-@@ -28,6 +33,11 @@ struct xt_connmark_tginfo2 {
+@@ -29,6 +34,11 @@ struct xt_connmark_tginfo2 {
  	__u8 shift_dir, shift_bits, mode;
  };
  

--- a/package/network/utils/iptables/patches/101-remove-check-already.patch
+++ b/package/network/utils/iptables/patches/101-remove-check-already.patch
@@ -1,6 +1,6 @@
 --- a/libxtables/xtables.c
 +++ b/libxtables/xtables.c
-@@ -1095,12 +1095,6 @@ void xtables_register_match(struct xtabl
+@@ -1100,12 +1100,6 @@ void xtables_register_match(struct xtabl
  	struct xtables_match **pos;
  	bool seen_myself = false;
  
@@ -13,7 +13,7 @@
  	if (me->version == NULL) {
  		fprintf(stderr, "%s: match %s<%u> is missing a version\n",
  		        xt_params->program_name, me->name, me->revision);
-@@ -1279,12 +1273,6 @@ void xtables_register_target(struct xtab
+@@ -1294,12 +1288,6 @@ void xtables_register_target(struct xtab
  	struct xtables_target **pos;
  	bool seen_myself = false;
  

--- a/package/network/utils/iptables/patches/102-iptables-disable-modprobe.patch
+++ b/package/network/utils/iptables/patches/102-iptables-disable-modprobe.patch
@@ -1,6 +1,6 @@
 --- a/libxtables/xtables.c
 +++ b/libxtables/xtables.c
-@@ -475,7 +475,7 @@ char *xtables_strdup(const char *s)
+@@ -474,7 +474,7 @@ char *xtables_strdup(const char *s)
  	return dup;
  }
  
@@ -9,7 +9,7 @@
  {
  	int procfile;
  	char *ret;
-@@ -505,6 +505,7 @@ static char *get_modprobe(void)
+@@ -504,6 +504,7 @@ static char *get_modprobe(void)
  
  int xtables_insmod(const char *modname, const char *modprobe, bool quiet)
  {
@@ -17,7 +17,7 @@
  	char *buf = NULL;
  	char *argv[4];
  	int status;
-@@ -539,6 +540,7 @@ int xtables_insmod(const char *modname,
+@@ -538,6 +539,7 @@ int xtables_insmod(const char *modname,
  	free(buf);
  	if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
  		return 0;

--- a/package/network/utils/iptables/patches/200-configurable_builtin.patch
+++ b/package/network/utils/iptables/patches/200-configurable_builtin.patch
@@ -1,6 +1,6 @@
 --- a/extensions/GNUmakefile.in
 +++ b/extensions/GNUmakefile.in
-@@ -50,11 +50,31 @@ pfb_build_mod := $(filter-out @blacklist
+@@ -65,11 +65,31 @@ pfb_build_mod := $(filter-out @blacklist
  pfa_build_mod := $(filter-out @blacklist_modules@ @blacklist_a_modules@,${pfa_build_mod})
  pf4_build_mod := $(filter-out @blacklist_modules@ @blacklist_4_modules@,${pf4_build_mod})
  pf6_build_mod := $(filter-out @blacklist_modules@ @blacklist_6_modules@,${pf6_build_mod})
@@ -37,7 +37,7 @@
  pfx_solibs    := $(patsubst %,libxt_%.so,${pfx_build_mod})
  pfb_solibs    := $(patsubst %,libebt_%.so,${pfb_build_mod})
  pfa_solibs    := $(patsubst %,libarpt_%.so,${pfa_build_mod})
-@@ -68,14 +88,14 @@ pfx_symlink_files := $(patsubst %,libxt_
+@@ -83,14 +103,14 @@ pfx_symlink_files := $(patsubst %,libxt_
  #
  targets := libext.a libext4.a libext6.a libext_ebt.a libext_arpt.a matches.man targets.man
  targets_install :=
@@ -60,9 +60,9 @@
  
  .SECONDARY:
  
-@@ -170,11 +190,11 @@ libext4.a: initext4.o ${libext4_objs}
+@@ -185,11 +205,11 @@ libext4.a: initext4.o ${libext4_objs}
  libext6.a: initext6.o ${libext6_objs}
- 	${AM_VERBOSE_AR} ${AR} crs $@ $^;
+ 	${AM_V_AR} ${AR} crs $@ $^;
  
 -initext_func  := $(addprefix xt_,${pfx_build_mod})
 -initextb_func := $(addprefix ebt_,${pfb_build_mod})

--- a/package/network/utils/iptables/patches/600-shared-libext.patch
+++ b/package/network/utils/iptables/patches/600-shared-libext.patch
@@ -1,6 +1,6 @@
 --- a/extensions/GNUmakefile.in
 +++ b/extensions/GNUmakefile.in
-@@ -86,7 +86,7 @@ pfx_symlink_files := $(patsubst %,libxt_
+@@ -101,7 +101,7 @@ pfx_symlink_files := $(patsubst %,libxt_
  #
  # Building blocks
  #
@@ -9,52 +9,52 @@
  targets_install :=
  libext_objs := ${pfx_objs}
  libext_ebt_objs := ${pfb_objs}
-@@ -133,7 +133,7 @@ clean:
+@@ -148,7 +148,7 @@ clean:
  distclean: clean
  
  init%.o: init%.c
--	${AM_VERBOSE_CC} ${CC} ${AM_CPPFLAGS} ${AM_DEPFLAGS} ${AM_CFLAGS} -D_INIT=$*_init ${CFLAGS} -o $@ -c $<;
-+	${AM_VERBOSE_CC} ${CC} ${AM_CPPFLAGS} ${AM_DEPFLAGS} ${AM_CFLAGS} -D_INIT=$*_init  -DPIC -fPIC ${CFLAGS} -o $@ -c $<;
+-	${AM_V_CC} ${CC} ${AM_CPPFLAGS} ${AM_DEPFLAGS} ${AM_CFLAGS} -D_INIT=$*_init ${CFLAGS} -o $@ -c $<;
++	${AM_V_CC} ${CC} ${AM_CPPFLAGS} ${AM_DEPFLAGS} ${AM_CFLAGS} -D_INIT=$*_init -DPIC -fPIC ${CFLAGS} -o $@ -c $<;
  
  -include .*.d
  
-@@ -173,22 +173,22 @@ xt_connlabel_LIBADD = @libnetfilter_conn
+@@ -188,22 +188,22 @@ xt_connlabel_LIBADD = @libnetfilter_conn
  #	handling code in the Makefiles.
  #
  lib%.o: ${srcdir}/lib%.c
--	${AM_VERBOSE_CC} ${CC} ${AM_CPPFLAGS} ${AM_DEPFLAGS} ${AM_CFLAGS} -DNO_SHARED_LIBS=1 -D_INIT=lib$*_init ${CFLAGS} -o $@ -c $<;
-+	${AM_VERBOSE_CC} ${CC} ${AM_CPPFLAGS} ${AM_DEPFLAGS} ${AM_CFLAGS} -DNO_SHARED_LIBS=1 -D_INIT=lib$*_init -DPIC -fPIC ${CFLAGS} -o $@ -c $<;
+-	${AM_V_CC} ${CC} ${AM_CPPFLAGS} ${AM_DEPFLAGS} ${AM_CFLAGS} -DNO_SHARED_LIBS=1 -D_INIT=lib$*_init ${CFLAGS} -o $@ -c $<;
++	${AM_V_CC} ${CC} ${AM_CPPFLAGS} ${AM_DEPFLAGS} ${AM_CFLAGS} -DNO_SHARED_LIBS=1 -D_INIT=lib$*_init -DPIC -fPIC ${CFLAGS} -o $@ -c $<;
  
 -libext.a: initext.o ${libext_objs}
--	${AM_VERBOSE_AR} ${AR} crs $@ $^;
+-	${AM_V_AR} ${AR} crs $@ $^;
 +libiptext.so: initext.o ${libext_objs}
-+	${AM_VERBOSE_CCLD} ${CCLD} ${AM_LDFLAGS} -shared ${LDFLAGS} -o $@ $^ -L../libxtables/.libs -lxtables $(foreach obj,$^,${$(patsubst lib%.o,%,$(obj))_LIBADD});
++	${AM_V_CCLD} ${CCLD} ${AM_LDFLAGS} -shared ${LDFLAGS} -o $@ $^ -L../libxtables/.libs -lxtables $(foreach obj,$^,${$(patsubst lib%.o,%,$(obj))_LIBADD});
  
 -libext_ebt.a: initextb.o ${libext_ebt_objs}
--	${AM_VERBOSE_AR} ${AR} crs $@ $^;
+-	${AM_V_AR} ${AR} crs $@ $^;
 +libiptext_ebt.so: initextb.o ${libext_ebt_objs}
-+	${AM_VERBOSE_CCLD} ${CCLD} ${AM_LDFLAGS} -shared ${LDFLAGS} -o $@ $^ -L../libxtables/.libs -lxtables $(foreach obj,$^,${$(patsubst lib%.o,%,$(obj))_LIBADD});
++	${AM_V_CCLD} ${CCLD} ${AM_LDFLAGS} -shared ${LDFLAGS} -o $@ $^ -L../libxtables/.libs -lxtables $(foreach obj,$^,${$(patsubst lib%.o,%,$(obj))_LIBADD});
  
 -libext_arpt.a: initexta.o ${libext_arpt_objs}
--	${AM_VERBOSE_AR} ${AR} crs $@ $^;
+-	${AM_V_AR} ${AR} crs $@ $^;
 +libiptext_arpt.so: initexta.o ${libext_arpt_objs}
-+	${AM_VERBOSE_CCLD} ${CCLD} ${AM_LDFLAGS} -shared ${LDFLAGS} -o $@ $^ -L../libxtables/.libs -lxtables $(foreach obj,$^,${$(patsubst lib%.o,%,$(obj))_LIBADD});
++	${AM_V_CCLD} ${CCLD} ${AM_LDFLAGS} -shared ${LDFLAGS} -o $@ $^ -L../libxtables/.libs -lxtables $(foreach obj,$^,${$(patsubst lib%.o,%,$(obj))_LIBADD});
  
 -libext4.a: initext4.o ${libext4_objs}
--	${AM_VERBOSE_AR} ${AR} crs $@ $^;
+-	${AM_V_AR} ${AR} crs $@ $^;
 +libiptext4.so: initext4.o ${libext4_objs}
-+	${AM_VERBOSE_CCLD} ${CCLD} ${AM_LDFLAGS} -shared ${LDFLAGS} -o $@ $^ -L../libxtables/.libs -lxtables $(foreach obj,$^,${$(patsubst lib%.o,%,$(obj))_LIBADD});
++	${AM_V_CCLD} ${CCLD} ${AM_LDFLAGS} -shared ${LDFLAGS} -o $@ $^ -L../libxtables/.libs -lxtables $(foreach obj,$^,${$(patsubst lib%.o,%,$(obj))_LIBADD});
  
 -libext6.a: initext6.o ${libext6_objs}
--	${AM_VERBOSE_AR} ${AR} crs $@ $^;
+-	${AM_V_AR} ${AR} crs $@ $^;
 +libiptext6.so: initext6.o ${libext6_objs}
-+	${AM_VERBOSE_CCLD} ${CCLD} ${AM_LDFLAGS} -shared ${LDFLAGS} -o $@ $^ -L../libxtables/.libs -lxtables $(foreach obj,$^,${$(patsubst lib%.o,%,$(obj))_LIBADD});
++	${AM_V_CCLD} ${CCLD} ${AM_LDFLAGS} -shared ${LDFLAGS} -o $@ $^ -L../libxtables/.libs -lxtables $(foreach obj,$^,${$(patsubst lib%.o,%,$(obj))_LIBADD});
  
  initext_func  := $(addprefix xt_,${pfx_build_static})
  initextb_func := $(addprefix ebt_,${pfb_build_static})
 --- a/iptables/Makefile.am
 +++ b/iptables/Makefile.am
-@@ -7,7 +7,7 @@ AM_LDFLAGS       = ${regular_LDFLAGS}
+@@ -14,7 +14,7 @@ AM_LDFLAGS       = ${regular_LDFLAGS}
  BUILT_SOURCES =
  
  common_sources = iptables-xml.c xtables-multi.h xshared.c xshared.h
@@ -63,7 +63,7 @@
  common_cflags  = ${AM_CFLAGS}
  if ENABLE_STATIC
  common_cflags += -DALL_INCLUSIVE
-@@ -17,15 +17,18 @@ xtables_legacy_multi_SOURCES  = ${common
+@@ -24,15 +24,18 @@ xtables_legacy_multi_SOURCES  = ${common
  				iptables-restore.c iptables-save.c
  xtables_legacy_multi_CFLAGS   = ${common_cflags}
  xtables_legacy_multi_LDADD    = ${common_ldadd}
@@ -84,7 +84,7 @@
  endif
  
  # iptables using nf_tables api
-@@ -33,12 +36,9 @@ if ENABLE_NFTABLES
+@@ -40,12 +43,9 @@ if ENABLE_NFTABLES
  xtables_nft_multi_SOURCES  = ${common_sources} xtables-nft-multi.c
  xtables_nft_multi_CFLAGS   = ${common_cflags}
  xtables_nft_multi_LDADD    = ${common_ldadd} \

--- a/package/network/utils/iptables/patches/700-disable-legacy-revisions.patch
+++ b/package/network/utils/iptables/patches/700-disable-legacy-revisions.patch
@@ -1,6 +1,6 @@
 --- a/extensions/libxt_conntrack.c
 +++ b/extensions/libxt_conntrack.c
-@@ -1385,6 +1385,7 @@ static int conntrack3_mt6_xlate(struct x
+@@ -1359,6 +1359,7 @@ static int conntrack3_mt6_xlate(struct x
  }
  
  static struct xtables_match conntrack_mt_reg[] = {
@@ -8,7 +8,7 @@
  	{
  		.version       = XTABLES_VERSION,
  		.name          = "conntrack",
-@@ -1460,6 +1461,7 @@ static struct xtables_match conntrack_mt
+@@ -1434,6 +1435,7 @@ static struct xtables_match conntrack_mt
  		.alias	       = conntrack_print_name_alias,
  		.x6_options    = conntrack2_mt_opts,
  	},
@@ -16,7 +16,7 @@
  	{
  		.version       = XTABLES_VERSION,
  		.name          = "conntrack",
-@@ -1492,6 +1494,7 @@ static struct xtables_match conntrack_mt
+@@ -1466,6 +1468,7 @@ static struct xtables_match conntrack_mt
  		.x6_options    = conntrack3_mt_opts,
  		.xlate	       = conntrack3_mt6_xlate,
  	},
@@ -24,7 +24,7 @@
  	{
  		.family        = NFPROTO_UNSPEC,
  		.name          = "state",
-@@ -1522,6 +1525,8 @@ static struct xtables_match conntrack_mt
+@@ -1496,6 +1499,8 @@ static struct xtables_match conntrack_mt
  		.x6_parse      = state_ct23_parse,
  		.x6_options    = state_opts,
  	},
@@ -33,7 +33,7 @@
  	{
  		.family        = NFPROTO_UNSPEC,
  		.name          = "state",
-@@ -1551,6 +1556,7 @@ static struct xtables_match conntrack_mt
+@@ -1525,6 +1530,7 @@ static struct xtables_match conntrack_mt
  		.x6_parse      = state_parse,
  		.x6_options    = state_opts,
  	},


### PR DESCRIPTION
Release Notes:
https://www.netfilter.org/projects/iptables/files/changes-iptables-1.8.11.txt

Manually Refreshed:
- 600-shared-libext.patch

Automatic Refresh:
- 010-add-set-dscpmark-support.patch
- 101-remove-check-already.patch
- 102-iptables-disable-modprobe.patch
- 200-configurable_builtin.patch
- 700-disable-legacy-revisions.patch
