### PR TITLE
wifi-scripts: ucode: add missing config.auth_type assignment for psk2

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -41,8 +41,9 @@ export function parse_encryption(config, dev_config) {
 		break;
 
 	case 'psk':
+	case 'psk2':
 	case 'psk-mixed':
-		config.auth_type = "psk";
+		config.auth_type = 'psk';
 		wpa3_pairwise = null;
 		break;
 
@@ -60,10 +61,6 @@ export function parse_encryption(config, dev_config) {
 	case 'wpa2':
 	case 'wpa-mixed':
 		config.auth_type = 'eap';
-		wpa3_pairwise = null;
-		break;
-
-	case 'psk2':
 		wpa3_pairwise = null;
 		break;
 


### PR DESCRIPTION
This ends up breaking wifi-station and wifi-vlan as it depends on config.auth_type being either psk or psk-sae. When set to psk2, this would be unset causing that feature to not work.

See discussion in https://github.com/openwrt/openwrt/issues/20705#issuecomment-3568446006