### PR TITLE
ath79: glinet_gl-ar150: add I2C GPIO support in DTS

### DIFF
--- a/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
+++ b/target/linux/ath79/dts/ar9330_glinet_gl-ar150.dts
@@ -63,6 +63,12 @@
 		};
 	};
 
+	i2c {
+		compatible = "i2c-gpio";
+    	sda-gpios = <&gpio 1 GPIO_ACTIVE_HIGH>;
+    	scl-gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+	};
+
 	reg_power_usb: regulator {
 		compatible = "regulator-fixed";
 		regulator-name = "power_usb";


### PR DESCRIPTION
This patch adds an I2C bus based on the i2c-gpio driver to the GL.iNet GL-AR150 device tree. The device uses GPIO pins 1 and 17 configured as SDA and SCL to support external I2C peripherals such as the DS1307 RTC.

The configuration has been tested on real hardware with a DS1307 RTC module connected to GPIOs 1/17. The RTC is correctly detected and `hwclock` works as expected.