### PR TITLE
wifi-scripts: ucode: fix wifi-vlan "network" option not working

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -288,7 +288,7 @@ function iface_vlan(interface, config, vlans) {
 		if (vlan.config.name && vlan.config.vid) {
 			let ifname = `${config.ifname}-${vlan.config.name}`;
 			file.write(`${vlan.config.vid} ${ifname}\n`);
-			netifd.set_vlan(interface, k, ifname);
+			netifd.set_vlan(interface, ifname, k);
 		}
 	file.close();
 


### PR DESCRIPTION
The call to netifd.set_vlan(...) had an incorrect argument order. It should be (interface, ifname, vlan) not
(interface, vlan, ifname). This prevented wifi-vlan's "network" option from working as netifd was not able to find the wifi-vlan section.

Fixes: https://github.com/openwrt/openwrt/issues/20705
Fixes: https://github.com/openwrt/openwrt/issues/20911