### PR TITLE
libtraceevent: update to 1.8.6

### DIFF
--- a/package/libs/libtraceevent/Makefile
+++ b/package/libs/libtraceevent/Makefile
@@ -1,12 +1,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libtraceevent
-PKG_VERSION:=1.8.4
+PKG_VERSION:=1.8.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/snapshot/
-PKG_HASH:=dc456d4d2bf4b4cd4d0c737d3374a8093f9e5ca18c1d7fc2279a4bf41e613121
+PKG_HASH:=812547d2f7b248485c183be2799b7041038ee44183000705609754b128c84c6f
 
 PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
 


### PR DESCRIPTION
Update to latest release.
