### PR TITLE
mbedtls: update to 4.0.0

### DIFF
--- a/package/libs/mbedtls/Config.in
+++ b/package/libs/mbedtls/Config.in
@@ -4,10 +4,6 @@ comment "Option details in source code: include/mbedtls/mbedtls_config.h"
 
 comment "Ciphers - unselect old or less-used ciphers to reduce binary size"
 
-config MBEDTLS_AES_C
-	bool "MBEDTLS_AES_C"
-	default y
-
 config MBEDTLS_ARIA_C
 	bool "MBEDTLS_ARIA_C"
 	default n
@@ -19,18 +15,6 @@ config MBEDTLS_CAMELLIA_C
 config MBEDTLS_CCM_C
 	bool "MBEDTLS_CCM_C"
 	default n
-
-config MBEDTLS_CMAC_C
-	bool "MBEDTLS_CMAC_C (old but used by hostapd)"
-	default y
-
-config MBEDTLS_DES_C
-	bool "MBEDTLS_DES_C (old but used by hostapd)"
-	default y
-
-config MBEDTLS_GCM_C
-	bool "MBEDTLS_GCM_C"
-	default y
 
 config MBEDTLS_NIST_KW_C
 	bool "MBEDTLS_NIST_KW_C (old but used by hostapd)"
@@ -98,18 +82,6 @@ config MBEDTLS_ECP_DP_SECP224R1_ENABLED
 	bool "MBEDTLS_ECP_DP_SECP224R1_ENABLED"
 	default n
 
-config MBEDTLS_ECP_DP_SECP256R1_ENABLED
-	bool "MBEDTLS_ECP_DP_SECP256R1_ENABLED"
-	default y
-
-config MBEDTLS_ECP_DP_SECP384R1_ENABLED
-	bool "MBEDTLS_ECP_DP_SECP384R1_ENABLED"
-	default y
-
-config MBEDTLS_ECP_DP_SECP521R1_ENABLED
-	bool "MBEDTLS_ECP_DP_SECP521R1_ENABLED"
-	default y
-
 config MBEDTLS_ECP_DP_SECP192K1_ENABLED
 	bool "MBEDTLS_ECP_DP_SECP192K1_ENABLED"
 	default n
@@ -117,10 +89,6 @@ config MBEDTLS_ECP_DP_SECP192K1_ENABLED
 config MBEDTLS_ECP_DP_SECP224K1_ENABLED
 	bool "MBEDTLS_ECP_DP_SECP224K1_ENABLED"
 	default n
-
-config MBEDTLS_ECP_DP_SECP256K1_ENABLED
-	bool "MBEDTLS_ECP_DP_SECP256K1_ENABLED"
-	default y
 
 config MBEDTLS_ECP_DP_BP256R1_ENABLED
 	bool "MBEDTLS_ECP_DP_BP256R1_ENABLED"
@@ -133,10 +101,6 @@ config MBEDTLS_ECP_DP_BP384R1_ENABLED
 config MBEDTLS_ECP_DP_BP512R1_ENABLED
 	bool "MBEDTLS_ECP_DP_BP512R1_ENABLED"
 	default n
-
-config MBEDTLS_ECP_DP_CURVE25519_ENABLED
-	bool "MBEDTLS_ECP_DP_CURVE25519_ENABLED"
-	default y
 
 config MBEDTLS_ECP_DP_CURVE448_ENABLED
 	bool "MBEDTLS_ECP_DP_CURVE448_ENABLED"
@@ -154,10 +118,6 @@ config MBEDTLS_CIPHER_MODE_XTS
 
 config MBEDTLS_DEBUG_C
 	bool "MBEDTLS_DEBUG_C"
-	default n
-
-config MBEDTLS_HKDF_C
-	bool "MBEDTLS_HKDF_C"
 	default n
 
 config MBEDTLS_PLATFORM_C
@@ -197,7 +157,6 @@ config MBEDTLS_SSL_PROTO_TLS1_2
 config MBEDTLS_SSL_PROTO_TLS1_3
 	bool "MBEDTLS_SSL_PROTO_TLS1_3"
 	select MBEDTLS_PSA_CRYPTO_CLIENT
-	select MBEDTLS_HKDF_C
 	default y
 
 config MBEDTLS_SSL_TLS1_3_COMPATIBILITY_MODE
@@ -221,10 +180,6 @@ config MBEDTLS_SSL_TLS1_3_KEY_EXCHANGE_MODE_PSK_EPHEMERAL_ENABLED
 	default y
 
 comment "Build Options"
-
-config MBEDTLS_ENTROPY_FORCE_SHA256
-	bool "MBEDTLS_ENTROPY_FORCE_SHA256"
-	default y
 
 config MBEDTLS_SSL_RENEGOTIATION
 	bool "MBEDTLS_SSL_RENEGOTIATION"

--- a/package/libs/mbedtls/Makefile
+++ b/package/libs/mbedtls/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mbedtls
-PKG_VERSION:=3.6.5
+PKG_VERSION:=4.0.0
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL=https://github.com/Mbed-TLS/$(PKG_NAME)/releases/download/$(PKG_NAME)-$(PKG_VERSION)
-PKG_HASH:=4a11f1777bb95bf4ad96721cac945a26e04bf19f57d905f241fe77ebeddf46d8
+PKG_HASH:=2f3a47f7b3a541ddef450e4867eeecb7ce2ef7776093f3a11d6d43ead6bf2827
 
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=LICENSE
@@ -23,26 +23,17 @@ PKG_CPE_ID:=cpe:/a:arm:mbed_tls
 MBEDTLS_BUILD_OPTS_CURVES= \
   CONFIG_MBEDTLS_ECP_DP_SECP192R1_ENABLED \
   CONFIG_MBEDTLS_ECP_DP_SECP224R1_ENABLED \
-  CONFIG_MBEDTLS_ECP_DP_SECP256R1_ENABLED \
-  CONFIG_MBEDTLS_ECP_DP_SECP384R1_ENABLED \
-  CONFIG_MBEDTLS_ECP_DP_SECP521R1_ENABLED \
   CONFIG_MBEDTLS_ECP_DP_SECP192K1_ENABLED \
   CONFIG_MBEDTLS_ECP_DP_SECP224K1_ENABLED \
-  CONFIG_MBEDTLS_ECP_DP_SECP256K1_ENABLED \
   CONFIG_MBEDTLS_ECP_DP_BP256R1_ENABLED \
   CONFIG_MBEDTLS_ECP_DP_BP384R1_ENABLED \
   CONFIG_MBEDTLS_ECP_DP_BP512R1_ENABLED \
-  CONFIG_MBEDTLS_ECP_DP_CURVE25519_ENABLED \
   CONFIG_MBEDTLS_ECP_DP_CURVE448_ENABLED
 
 MBEDTLS_BUILD_OPTS_CIPHERS= \
-  CONFIG_MBEDTLS_AES_C \
   CONFIG_MBEDTLS_ARIA_C \
   CONFIG_MBEDTLS_CAMELLIA_C \
   CONFIG_MBEDTLS_CCM_C \
-  CONFIG_MBEDTLS_CMAC_C \
-  CONFIG_MBEDTLS_DES_C \
-  CONFIG_MBEDTLS_GCM_C \
   CONFIG_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED \
   CONFIG_MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED \
   CONFIG_MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED \
@@ -67,8 +58,6 @@ MBEDTLS_BUILD_OPTS= \
   CONFIG_MBEDTLS_CIPHER_MODE_OFB \
   CONFIG_MBEDTLS_CIPHER_MODE_XTS \
   CONFIG_MBEDTLS_DEBUG_C \
-  CONFIG_MBEDTLS_ENTROPY_FORCE_SHA256 \
-  CONFIG_MBEDTLS_HKDF_C \
   CONFIG_MBEDTLS_PLATFORM_C \
   CONFIG_MBEDTLS_SELF_TEST \
   CONFIG_MBEDTLS_SSL_RENEGOTIATION \
@@ -111,23 +100,9 @@ define Package/libmbedtls/config
 	source "$(SOURCE)/Config.in"
 endef
 
-define Package/mbedtls-util
-$(call Package/mbedtls/Default)
-  SECTION:=utils
-  CATEGORY:=Utilities
-  TITLE+= (utilities)
-  DEPENDS:=+libmbedtls
-endef
-
 define Package/libmbedtls/description
 $(call Package/mbedtls/Default/description)
 This package contains the mbedtls library.
-endef
-
-define Package/mbedtls-util/description
-$(call Package/mbedtls/Default/description)
-This package contains mbedtls helper programs for private key and
-CSR generation (gen_key, cert_req)
 endef
 
 TARGET_CFLAGS := $(filter-out -O%,$(TARGET_CFLAGS)) -Wno-unterminated-string-initialization
@@ -171,11 +146,4 @@ define Package/libmbedtls/install
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/lib*.so.* $(1)/usr/lib/
 endef
 
-define Package/mbedtls-util/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/gen_key $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/cert_req $(1)/usr/bin/
-endef
-
 $(eval $(call BuildPackage,libmbedtls))
-$(eval $(call BuildPackage,mbedtls-util))

--- a/package/libs/mbedtls/patches/100-fix-gcc14-build.patch
+++ b/package/libs/mbedtls/patches/100-fix-gcc14-build.patch
@@ -1,11 +1,11 @@
---- a/library/common.h
-+++ b/library/common.h
+--- a/tf-psa-crypto/core/tf_psa_crypto_common.h
++++ b/tf-psa-crypto/core/tf_psa_crypto_common.h
 @@ -199,7 +199,7 @@ static inline void mbedtls_xor(unsigned
          uint8x16_t x = veorq_u8(v1, v2);
          vst1q_u8(r + i, x);
      }
 -#if defined(__IAR_SYSTEMS_ICC__)
-+#if defined(__IAR_SYSTEMS_ICC__) || (defined(MBEDTLS_COMPILER_IS_GCC) && MBEDTLS_GCC_VERSION >= 140100)
++#if defined(__IAR_SYSTEMS_ICC__) || defined(MBEDTLS_COMPILER_IS_GCC)
      /* This if statement helps some compilers (e.g., IAR) optimise out the byte-by-byte tail case
       * where n is a constant multiple of 16.
       * For other compilers (e.g. recent gcc and clang) it makes no difference if n is a compile-time

--- a/package/libs/mbedtls/patches/101-remove-test.patch
+++ b/package/libs/mbedtls/patches/101-remove-test.patch
@@ -1,16 +1,13 @@
 --- a/programs/CMakeLists.txt
 +++ b/programs/CMakeLists.txt
-@@ -3,14 +3,10 @@ add_custom_target(${programs_target})
+@@ -1,11 +1,6 @@
+ set(programs_target "${MBEDTLS_TARGET_PREFIX}programs")
+ add_custom_target(${programs_target})
  
- add_subdirectory(aes)
- add_subdirectory(cipher)
 -if (NOT WIN32)
 -    add_subdirectory(fuzz)
 -endif()
- add_subdirectory(hash)
- add_subdirectory(pkey)
- add_subdirectory(psa)
- add_subdirectory(random)
+-
  add_subdirectory(ssl)
 -add_subdirectory(test)
  add_subdirectory(util)


### PR DESCRIPTION
Release Notes:
https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-4.0.0

There is an error:
```
In function 'mbedtls_xor',
    inlined from 'ctr_drbg_update_internal' at /home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/drivers/builtin/src/ctr_drbg.c:373:5:
/home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/core/tf_psa_crypto_common.h:235:17: error: array subscript 48 is outside array bounds of 'unsigned char[48]' [-Werror=array-bounds=]
  235 |         r[i] = a[i] ^ b[i];
      |                ~^~~
/home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/drivers/builtin/src/ctr_drbg.c: In function 'ctr_drbg_update_internal':
/home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/drivers/builtin/src/ctr_drbg.c:336:19: note: at offset 48 into object 'tmp' of size 48
  336 |     unsigned char tmp[MBEDTLS_CTR_DRBG_SEEDLEN];
      |                   ^~~
In function 'mbedtls_xor',
    inlined from 'ctr_drbg_update_internal' at /home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/drivers/builtin/src/ctr_drbg.c:373:5:
/home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/core/tf_psa_crypto_common.h:235:24: error: array subscript 48 is outside array bounds of 'const unsigned char[48]' [-Werror=array-bounds=]
  235 |         r[i] = a[i] ^ b[i];
      |                       ~^~~
/home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/drivers/builtin/src/ctr_drbg.c: In function 'ctr_drbg_update_internal':
/home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/drivers/builtin/src/ctr_drbg.c:334:57: note: at offset 48 into object 'data' of size [0, 48]
  334 |                                     const unsigned char data[MBEDTLS_CTR_DRBG_SEEDLEN])
      |                                     ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'mbedtls_xor',
    inlined from 'ctr_drbg_update_internal' at /home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/drivers/builtin/src/ctr_drbg.c:373:5:
/home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/core/tf_psa_crypto_common.h:235:14: error: array subscript 48 is outside array bounds of 'unsigned char[48]' [-Werror=array-bounds=]
  235 |         r[i] = a[i] ^ b[i];
      |         ~~~~~^~~~~~~~~~~~~
/home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/drivers/builtin/src/ctr_drbg.c: In function 'ctr_drbg_update_internal':
/home/nick/openwrt/build_dir/target-aarch64_cortex-a53_musl/mbedtls-4.0.0/tf-psa-crypto/drivers/builtin/src/ctr_drbg.c:336:19: note: at offset 48 into object 'tmp' of size 48
  336 |     unsigned char tmp[MBEDTLS_CTR_DRBG_SEEDLEN];
      |                   ^~~
At top level:
```

Same error as here: https://github.com/Mbed-TLS/mbedtls/issues/9003 However, the [mentioned patch](https://github.com/Mbed-TLS/mbedtls/issues/9003#issuecomment-3515264388) fixes it.