### PR TITLE
libunistring: disable pthread_rwlockattr_setkind_np on musl

### DIFF
--- a/package/libs/libunistring/patches/0000-fix-pthread-rwlockattr-test.patch
+++ b/package/libs/libunistring/patches/0000-fix-pthread-rwlockattr-test.patch
@@ -1,0 +1,20 @@
+--- a/tests/pthread-rwlock.c
++++ b/tests/pthread-rwlock.c
+@@ -49,7 +49,7 @@ pthread_rwlockattr_destroy (_GL_UNUSED p
+   return 0;
+ }
+ 
+-#elif PTHREAD_RWLOCK_BAD_WAITQUEUE
++#elif 0
+ 
+ /* Override pthread_rwlockattr_init, to use the kind PREFER_WRITER_NONRECURSIVE
+    (or possibly PREFER_WRITER) instead of the kind DEFAULT.  */
+@@ -388,7 +388,7 @@ pthread_rwlock_destroy (pthread_rwlock_t
+ 
+ # else
+ 
+-#  if PTHREAD_RWLOCK_BAD_WAITQUEUE
++#  if 0
+ 
+ /* Override pthread_rwlock_init, to use the kind PREFER_WRITER_NONRECURSIVE
+    (or possibly PREFER_WRITER) instead of the default, when no


### PR DESCRIPTION
On the buildbots the pthread-rwlock tests fail:
```
pthread-rwlock.c:65:9: error: implicit declaration of function 'pthread_rwlockattr_setkind_np'; did you mean 'pthread_rwlockattr_setpshared'? [-Wimplicit-function-declaration]
   65 |   err = pthread_rwlockattr_setkind_np (attr,
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         pthread_rwlockattr_setpshared
pthread-rwlock.c:66:40: error: 'PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP' undeclared (first use in this function)
   66 |                                        PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
      |                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pthread-rwlock.c:66:40: note: each undeclared identifier is reported only once for each function it appears in
pthread-rwlock.c: In function 'rpl_pthread_rwlock_init':
pthread-rwlock.c:412:44: error: 'PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP' undeclared (first use in this function)
  412 |                                            PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
      |                                            ^~~~~~~
```
Add a patch disabling these testcases.
