### PR TITLE
siflower: bpi-rv2 device tree fix

### DIFF
--- a/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2.dtsi
+++ b/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2.dtsi
@@ -122,7 +122,7 @@
 };
 
 &mdio0 {
-	reset-gpios = <&gpio 30 GPIO_ACTIVE_LOW>;
+	reset-gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
 	reset-delay-us = <10000>;
 	reset-post-delay-us = <100000>;
 


### PR DESCRIPTION
As per [schematics](https://forum.openwrt.org/uploads/default/optimized/3X/3/3/33c6e212111be33203a15550dfbf8c1622a422e9_2_690x301.png), GPIO 30 is incorrect to use as the reset pin for the QSGMII PHY SF23P1240; the correct one is GPIO 22.

See also here:
https://forum.openwrt.org/t/kernel-6-12-testing-needed-at91-bcm47xx-bcm4908-bcm53xx-qoriq-siflower-and-zynq-targets/242857/28

Cc: @LGA1150 @981213