### PR TITLE
package-defaults: use REAL GNU target name for configure host

### DIFF
--- a/include/package-defaults.mk
+++ b/include/package-defaults.mk
@@ -78,7 +78,7 @@ endif
 CONFIGURE_PREFIX:=/usr
 CONFIGURE_ARGS = \
 		--target=$(GNU_TARGET_NAME) \
-		--host=$(GNU_TARGET_NAME) \
+		--host=$(REAL_GNU_TARGET_NAME) \
 		--build=$(GNU_HOST_NAME) \
 		--disable-dependency-tracking \
 		--program-prefix="" \


### PR DESCRIPTION
It seems that using an half filled GNU target name results in that autocompleted with the -gnu part.

This imply on some package that we are using glibc instead of MUSL.

Use the REAL GNU target name for configure host value to give better info to the configure scripts.

---

@mcprat @hnyman Interesting finding?
