### PR TITLE
mpc85xx: HPE MSM460 add HPE MSM466 alias

### DIFF
--- a/target/linux/mpc85xx/image/p1020.mk
+++ b/target/linux/mpc85xx/image/p1020.mk
@@ -96,6 +96,8 @@ define Device/hpe_msm460
   DEVICE_MODEL := MSM460
   DEVICE_ALT0_VENDOR := Hewlett-Packard
   DEVICE_ALT0_MODEL := MSM430
+  DEVICE_ALT1_VENDOR := Hewlett-Packard
+  DEVICE_ALT1_MODEL := MSM466
   KERNEL = kernel-bin | fit none $(KDIR)/image-$$(DEVICE_DTS).dtb
   KERNEL_NAME := zImage.la3000000
   KERNEL_ENTRY := 0x3000000


### PR DESCRIPTION
Define MSM466 as alternative name, to explicitly show the device is supported using existing image (MSM460).  The only difference between the MSM460 and MSM466 is that the MSM466 has external antenna.

Signed-off-by: Raylynn Knight <rayknight@me.com>
