### PR TITLE
tools: mtd-utils: fix patch 110 for musl missing execinfo-h

### DIFF
--- a/tools/mtd-utils/patches/110-portability.patch
+++ b/tools/mtd-utils/patches/110-portability.patch
@@ -50,16 +50,20 @@
  #define UBI_VERSION 1
 --- a/ubifs-utils/common/compiler_attributes.h
 +++ b/ubifs-utils/common/compiler_attributes.h
-@@ -1,6 +1,8 @@
+@@ -1,6 +1,12 @@
  #ifndef __COMPILER_ATTRIBUTES_H__
  #define __COMPILER_ATTRIBUTES_H__
  
++#if HAVE_EXECINFO_H
 +#include <execinfo.h>
++#else
++#include "libmissing.h"
++#endif
 +
  #if __has_attribute(__fallthrough__)
  #define fallthrough	__attribute__((__fallthrough__))
  #else
-@@ -11,6 +13,7 @@
+@@ -11,6 +17,7 @@
  #define __unused	__attribute__((__unused__))
  #define __const		__attribute__((__const__))
  #define __must_check    __attribute__((__warn_unused_result__))


### PR DESCRIPTION
This patch 110-portability.patch is introducing the same header that the other patch
001-ubifs-utils-link-libmissing.a-in-case-execinfo.h-isn.patch
is guarding against missing in musl libc. We need to
mimic that.

While building in an alpine container you gets this.
```
/workdir/staging_dir/host/bin/gcc -std=gnu23  -O2 -I/workdir/staging_dir/host/include  -L/workdir/staging_dir/host/lib -o ubinize ubi-utils/ubinize.o libubi.a libubigen.a libmtd.a libiniparser.a
/workdir/staging_dir/host/bin/gcc -std=gnu23 -DHAVE_CONFIG_H -I. -I./include  -Wall -Wextra -Wunused -Wmissing-prototypes -Wmissing-declarations -Wwrite-strings -Wjump-misses-init -Wuninitialized -Winit-self -Wlogical-op -Wunused-but-set-parameter -Wunused-but-set-variable -Wunused-parameter -Wunused-result -Wunused-variable -Wduplicated-cond -Wduplicated-branches -Wrestrict -Wnull-dereference -Wno-shadow -Wno-sign-compare -D_GNU_SOURCE -std=gnu99 -I./include -include ./include/config.h -DWITH_ZLIB    -DWITH_LZMA   -I/workdir/staging_dir/host/include   -I/workdir/staging_dir/host/include/uuid -pthread  -I./ubi-utils/include -I./ubifs-utils/common -I ./ubifs-utils/libubifs -I/workdir/staging_dir/host/include  -O2 -I/workdir/staging_dir/host/include -c -o ubifs-utils/common/mkfs_ubifs-bitops.o `test -f 'ubifs-utils/common/bitops.c' || echo './'`ubifs-utils/common/bitops.c
In file included from ./ubifs-utils/common/linux_types.h:10,
                 from ./ubifs-utils/libubifs/ubifs.h:17,
                 from ubifs-utils/common/defs.h:21,
                 from ubifs-utils/common/bitops.c:7:
./ubifs-utils/common/compiler_attributes.h:4:10: fatal error: execinfo.h: No such file or directory
    4 | #include <execinfo.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```