### PR TITLE
kernel: of: fix bad cell count error for SPI flash node

### DIFF
--- a/target/linux/ath79/dts/qca9550_dell_apl2x.dtsi
+++ b/target/linux/ath79/dts/qca9550_dell_apl2x.dtsi
@@ -129,8 +129,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <25000000>;
-		#address-cells = <1>;
-		#size-cells = <1>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/bmips/dts/bcm63168-smartrg-sr505n.dts
+++ b/target/linux/bmips/dts/bcm63168-smartrg-sr505n.dts
@@ -61,9 +61,6 @@
 		spi-rx-bus-width = <2>;
 		reg = <0>;
 
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/bmips/dts/bcm6318-comtrend-ar-5315u.dts
+++ b/target/linux/bmips/dts/bcm6318-comtrend-ar-5315u.dts
@@ -77,9 +77,6 @@
 		spi-rx-bus-width = <2>;
 		reg = <0>;
 
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/bmips/dts/bcm6318-tp-link-td-w8968-v3.dts
+++ b/target/linux/bmips/dts/bcm6318-tp-link-td-w8968-v3.dts
@@ -73,9 +73,6 @@
 		spi-rx-bus-width = <2>;
 		reg = <0>;
 
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/bmips/dts/bcm6328-comtrend-ar-5381u.dts
+++ b/target/linux/bmips/dts/bcm6328-comtrend-ar-5381u.dts
@@ -65,9 +65,6 @@
 		spi-rx-bus-width = <2>;
 		reg = <0>;
 
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/bmips/dts/bcm6328-comtrend-ar-5387un.dts
+++ b/target/linux/bmips/dts/bcm6328-comtrend-ar-5387un.dts
@@ -83,9 +83,6 @@
 		spi-rx-bus-width = <2>;
 		reg = <0>;
 
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/bmips/dts/bcm6328-dlink-dsl-2750b-b1.dts
+++ b/target/linux/bmips/dts/bcm6328-dlink-dsl-2750b-b1.dts
@@ -137,9 +137,6 @@
 		spi-rx-bus-width = <2>;
 		reg = <0>;
 
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/bmips/dts/bcm6328-innacomm-w3400v6.dts
+++ b/target/linux/bmips/dts/bcm6328-innacomm-w3400v6.dts
@@ -62,9 +62,6 @@
 		spi-rx-bus-width = <2>;
 		reg = <0>;
 
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/bmips/dts/bcm6328-inteno-xg6846.dts
+++ b/target/linux/bmips/dts/bcm6328-inteno-xg6846.dts
@@ -97,9 +97,6 @@
 		m25p,fast-read;
 		reg = <0>;
 
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/generic/backport-6.12/203-01-v6.13-of-address-Rework-bus-matching-to-avoid-warnings.patch
+++ b/target/linux/generic/backport-6.12/203-01-v6.13-of-address-Rework-bus-matching-to-avoid-warnings.patch
@@ -1,0 +1,61 @@
+From 64ee3cf096ac590e7da2ceac1c390546bff5e240 Mon Sep 17 00:00:00 2001
+From: "Rob Herring (Arm)" <robh@kernel.org>
+Date: Fri, 8 Nov 2024 13:35:48 -0600
+Subject: [PATCH] of/address: Rework bus matching to avoid warnings
+
+With warnings added for deprecated #address-cells/#size-cells handling,
+the DT address handling code causes warnings when used on nodes with no
+address. This happens frequently with calls to of_platform_populate() as
+it is perfectly acceptable to have devices without a 'reg' property. The
+desired behavior is to just silently return an error when retrieving an
+address.
+
+The warnings can be avoided by checking for "#address-cells" presence
+first and checking for an address property before fetching
+"#address-cells" and "#size-cells".
+
+Reported-by: Marek Szyprowski <m.szyprowski@samsung.com>
+Reported-by: Steven Price <steven.price@arm.com>
+Tested-by: Marek Szyprowski <m.szyprowski@samsung.com>
+Link: https://lore.kernel.org/r/20241108193547.2647986-2-robh@kernel.org
+Signed-off-by: Rob Herring (Arm) <robh@kernel.org>
+---
+ drivers/of/address.c | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+--- a/drivers/of/address.c
++++ b/drivers/of/address.c
+@@ -331,7 +331,11 @@ static unsigned int of_bus_isa_get_flags
+ 
+ static int of_bus_default_flags_match(struct device_node *np)
+ {
+-	return of_bus_n_addr_cells(np) == 3;
++	/*
++	 * Check for presence first since of_bus_n_addr_cells() will warn when
++	 * walking parent nodes.
++	 */
++	return of_property_present(np, "#address-cells") && (of_bus_n_addr_cells(np) == 3);
+ }
+ 
+ /*
+@@ -700,16 +704,16 @@ const __be32 *__of_get_address(struct de
+ 	if (strcmp(bus->name, "pci") && (bar_no >= 0))
+ 		return NULL;
+ 
+-	bus->count_cells(dev, &na, &ns);
+-	if (!OF_CHECK_ADDR_COUNT(na))
+-		return NULL;
+-
+ 	/* Get "reg" or "assigned-addresses" property */
+ 	prop = of_get_property(dev, bus->addresses, &psize);
+ 	if (prop == NULL)
+ 		return NULL;
+ 	psize /= 4;
+ 
++	bus->count_cells(dev, &na, &ns);
++	if (!OF_CHECK_ADDR_COUNT(na))
++		return NULL;
++
+ 	onesize = na + ns;
+ 	for (i = 0; psize >= onesize; psize -= onesize, prop += onesize, i++) {
+ 		u32 val = be32_to_cpu(prop[0]);

--- a/target/linux/generic/backport-6.12/203-02-v6.13-of-address-Fix-WARN-when-attempting-translating-non-.patch
+++ b/target/linux/generic/backport-6.12/203-02-v6.13-of-address-Fix-WARN-when-attempting-translating-non-.patch
@@ -1,0 +1,85 @@
+From 6e5773d52f4a2d9c80692245f295069260cff6fc Mon Sep 17 00:00:00 2001
+From: "Rob Herring (Arm)" <robh@kernel.org>
+Date: Fri, 10 Jan 2025 15:50:29 -0600
+Subject: [PATCH] of/address: Fix WARN when attempting translating
+ non-translatable addresses
+
+The recently added WARN() for deprecated #address-cells and #size-cells
+triggered a WARN when of_platform_populate() (which calls
+of_address_to_resource()) is used on nodes with non-translatable
+addresses. This case is expected to return an error.
+
+Rework the bus matching to allow no match and make the default require
+an #address-cells property. That should be safe to do as any platform
+missing #address-cells would have a warning already.
+
+Fixes: 045b14ca5c36 ("of: WARN on deprecated #address-cells/#size-cells handling")
+Tested-by: Sean Anderson <sean.anderson@linux.dev>
+Link: https://lore.kernel.org/r/20250110215030.3637845-2-robh@kernel.org
+Signed-off-by: Rob Herring (Arm) <robh@kernel.org>
+---
+ drivers/of/address.c | 18 +++++++++++++++---
+ 1 file changed, 15 insertions(+), 3 deletions(-)
+
+--- a/drivers/of/address.c
++++ b/drivers/of/address.c
+@@ -338,6 +338,15 @@ static int of_bus_default_flags_match(st
+ 	return of_property_present(np, "#address-cells") && (of_bus_n_addr_cells(np) == 3);
+ }
+ 
++static int of_bus_default_match(struct device_node *np)
++{
++	/*
++	 * Check for presence first since of_bus_n_addr_cells() will warn when
++	 * walking parent nodes.
++	 */
++	return of_property_present(np, "#address-cells");
++}
++
+ /*
+  * Array of bus specific translators
+  */
+@@ -382,7 +391,7 @@ static struct of_bus of_busses[] = {
+ 	{
+ 		.name = "default",
+ 		.addresses = "reg",
+-		.match = NULL,
++		.match = of_bus_default_match,
+ 		.count_cells = of_bus_default_count_cells,
+ 		.map = of_bus_default_map,
+ 		.translate = of_bus_default_translate,
+@@ -397,7 +406,6 @@ static struct of_bus *of_match_bus(struc
+ 	for (i = 0; i < ARRAY_SIZE(of_busses); i++)
+ 		if (!of_busses[i].match || of_busses[i].match(np))
+ 			return &of_busses[i];
+-	BUG();
+ 	return NULL;
+ }
+ 
+@@ -519,6 +527,8 @@ static u64 __of_translate_address(struct
+ 	if (parent == NULL)
+ 		return OF_BAD_ADDR;
+ 	bus = of_match_bus(parent);
++	if (!bus)
++		return OF_BAD_ADDR;
+ 
+ 	/* Count address cells & copy address locally */
+ 	bus->count_cells(dev, &na, &ns);
+@@ -562,6 +572,8 @@ static u64 __of_translate_address(struct
+ 
+ 		/* Get new parent bus and counts */
+ 		pbus = of_match_bus(parent);
++		if (!pbus)
++			return OF_BAD_ADDR;
+ 		pbus->count_cells(dev, &pna, &pns);
+ 		if (!OF_CHECK_COUNTS(pna, pns)) {
+ 			pr_err("Bad cell count for %pOF\n", dev);
+@@ -701,7 +713,7 @@ const __be32 *__of_get_address(struct de
+ 
+ 	/* match the parent's bus type */
+ 	bus = of_match_bus(parent);
+-	if (strcmp(bus->name, "pci") && (bar_no >= 0))
++	if (!bus || (strcmp(bus->name, "pci") && (bar_no >= 0)))
+ 		return NULL;
+ 
+ 	/* Get "reg" or "assigned-addresses" property */

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-a42.dts
@@ -142,8 +142,6 @@
 	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <24000000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-ens620ext.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-ens620ext.dts
@@ -146,8 +146,6 @@
 	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <0>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <24000000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287.dts
@@ -36,8 +36,6 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287plus.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287plus.dts
@@ -36,8 +36,6 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287pro.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-mf287pro.dts
@@ -53,8 +53,6 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-pa1200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-pa1200.dts
@@ -134,8 +134,6 @@
 	cs-gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <24000000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx.dtsi
@@ -155,8 +155,6 @@
 		 * recognition in u-boot.
 		 */
 		compatible = "jedec,spi-nor", "n25q128a11";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx.dtsi
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4018-rutx.dtsi
@@ -271,8 +271,6 @@
 		 * nand recognition in u-boot.
 		 */
 		compatible = "spi-nand", "spinand,mt29f";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <1>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-a62.dts
@@ -149,8 +149,6 @@
 	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <24000000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-eap2200.dts
@@ -93,8 +93,6 @@
 	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <24000000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3-lte6-kit.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-hap-ac3-lte6-kit.dts
@@ -190,9 +190,6 @@
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <10000000>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-le1.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-le1.dts
@@ -93,8 +93,6 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf18a.dts
@@ -152,8 +152,6 @@
 	flash@0 {
 		/* u-boot is looking for "n25q128a11" property */
 		compatible = "jedec,spi-nor", "n25q128a11";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf282plus.dts
@@ -134,8 +134,6 @@
 	flash@0 {
 		/* u-boot is looking for "n25q128a11" property */
 		compatible = "jedec,spi-nor", "n25q128a11";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf286d.dts
@@ -128,8 +128,6 @@
 	flash@0 {
 		/* u-boot is looking for "n25q128a11" property */
 		compatible = "jedec,spi-nor", "n25q128a11";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-mf289f.dts
@@ -137,8 +137,6 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-oap100.dts
@@ -168,8 +168,6 @@
 	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		linux,modalias = "m25p80", "gd25q256";

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-pa2200.dts
@@ -137,8 +137,6 @@
 	cs-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <24000000>;

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
@@ -267,8 +267,6 @@
 		 * nand recognition in u-boot.
 		 */
 		compatible = "spi-nand","spinand,mt29f";
-		#address-cells = <1>;
-		#size-cells = <0>;
 		reg = <1>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-rtl30vw.dts
@@ -193,8 +193,6 @@
 	flash@0 {
 		/*"n25q128a11" is required for proper nand recognition in u-boot. */
 		compatible = "jedec,spi-nor", "n25q128a11";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <24000000>;
 

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-ad7200-c2600.dtsi
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-ad7200-c2600.dtsi
@@ -93,8 +93,6 @@
 
 		flash@0 {
 			compatible = "jedec,spi-nor";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			spi-max-frequency = <50000000>;
 			reg = <0>;
 

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-fap-421e.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-fap-421e.dts
@@ -216,8 +216,6 @@
 
 		flash@0 {
 			compatible = "jedec,spi-nor";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			spi-max-frequency = <50000000>;
 			reg = <0>;
 			m25p,fast-read;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-unifi-ac-hd.dts
@@ -109,8 +109,6 @@
 
 		flash@0 {
 			compatible = "mx25u25635f", "jedec,spi-nor";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			spi-max-frequency = <50000000>;
 			reg = <0>;
 			m25p,fast-read;

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-vr2600v.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8064-vr2600v.dts
@@ -188,8 +188,6 @@
 
 		flash@0 {
 			compatible = "jedec,spi-nor";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			spi-max-frequency = <50000000>;
 			reg = <0>;
 

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-ac400i.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-ac400i.dts
@@ -170,8 +170,6 @@
 
 		m25p80@0 {
 			compatible = "jedec,spi-nor";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			spi-max-frequency = <50000000>;
 			reg = <0>;
 

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-nbg6817.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8065-nbg6817.dts
@@ -223,8 +223,6 @@
 
 		m25p80@0 {
 			compatible = "jedec,spi-nor";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			spi-max-frequency = <51200000>;
 			reg = <0>;
 

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-ecw5410.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-ecw5410.dts
@@ -187,8 +187,6 @@
 
 		m25p80@0 {
 			compatible = "jedec,spi-nor";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			spi-max-frequency = <50000000>;
 			reg = <0>;
 

--- a/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-ss-w2-ac2600.dts
+++ b/target/linux/ipq806x/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq8068-ss-w2-ac2600.dts
@@ -158,8 +158,6 @@
 
 		w25q128@0 {
 			compatible = "jedec,spi-nor";
-			#address-cells = <1>;
-			#size-cells = <1>;
 			spi-max-frequency = <50000000>;
 			reg = <0>;
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7362sl.dts
@@ -32,8 +32,6 @@
 	status = "okay";
 
 	flash@4 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <4>;
 		spi-max-frequency = <1000000>;

--- a/target/linux/mediatek/dts/mt7981a-comfast-cf-e393ax.dts
+++ b/target/linux/mediatek/dts/mt7981a-comfast-cf-e393ax.dts
@@ -133,8 +133,6 @@
 	#size-cells = <0>;
 
 	spi_nand: spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981a-edgecore-eap111.dts
+++ b/target/linux/mediatek/dts/mt7981a-edgecore-eap111.dts
@@ -83,8 +83,6 @@
 	#size-cells = <0>;
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
+++ b/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
@@ -305,8 +305,6 @@
 	status = "okay";
 
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
+++ b/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
@@ -358,8 +358,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
+++ b/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
@@ -99,8 +99,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-abt-asr3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-abt-asr3000.dts
@@ -149,8 +149,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-cetron-ct3003.dts
+++ b/target/linux/mediatek/dts/mt7981b-cetron-ct3003.dts
@@ -100,8 +100,6 @@
 
 	spi_nand@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-cmcc-a10.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-a10.dtsi
@@ -126,8 +126,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-nand.dtso
+++ b/target/linux/mediatek/dts/mt7981b-cmcc-rax3000m-nand.dtso
@@ -66,8 +66,6 @@
 
 			spi_nand@0 {
 				compatible = "spi-nand";
-				#address-cells = <1>;
-				#size-cells = <1>;
 				reg = <0>;
 
 				spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
@@ -135,8 +135,6 @@
 	status = "okay";
 
 	spi_nand: spi-nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-confiabits-mt7981.dts
+++ b/target/linux/mediatek/dts/mt7981b-confiabits-mt7981.dts
@@ -197,8 +197,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-creatlentem-clt-r30b1-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-creatlentem-clt-r30b1-common.dtsi
@@ -110,8 +110,6 @@
 	status = "okay";
 
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-cudy-ap3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-ap3000-v1.dts
@@ -127,8 +127,6 @@
 
 	/* ESMT F50L2G41XA (256M) */
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-cudy-ap3000outdoor-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-ap3000outdoor-v1.dts
@@ -107,8 +107,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
@@ -119,8 +119,6 @@
 
 	spi_nand: spi_nand@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-cudy-re3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-re3000-v1.dts
@@ -118,9 +118,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dtsi
@@ -113,8 +113,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
@@ -72,8 +72,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
@@ -136,9 +136,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-m30-a1.dts
+++ b/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-m30-a1.dts
@@ -138,8 +138,6 @@
 
 	spi_nand@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-elecom-wrc-x3000gs3.dts
+++ b/target/linux/mediatek/dts/mt7981b-elecom-wrc-x3000gs3.dts
@@ -212,8 +212,6 @@
 	spi_nand: spi_nand@0 {
 		compatible = "spi-nand";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
 
 		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;

--- a/target/linux/mediatek/dts/mt7981b-gatonetworks-gdsp.dts
+++ b/target/linux/mediatek/dts/mt7981b-gatonetworks-gdsp.dts
@@ -282,8 +282,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
@@ -138,8 +138,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
@@ -106,8 +106,6 @@
 
 	spi_nand@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-imou-hx21.dts
+++ b/target/linux/mediatek/dts/mt7981b-imou-hx21.dts
@@ -155,8 +155,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
@@ -177,8 +177,6 @@
 	pinctrl-0 = <&nand_pins>;
 
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000q.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000q.dts
@@ -111,8 +111,6 @@
 	status = "okay";
 
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000se.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000se.dts
@@ -96,8 +96,6 @@
 	status = "okay";
 
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000sm.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000sm.dts
@@ -120,8 +120,6 @@
 	status = "okay";
 
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-jcg-q30-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-jcg-q30-pro.dts
@@ -97,8 +97,6 @@
 
 	spi_nand@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
@@ -202,8 +202,6 @@
 
 	/* Winbond W25N01GV SPI NAND (128 MiB) */
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
@@ -218,8 +218,6 @@
 
 	/* Winbond W25N02KV (256M) */
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
@@ -165,8 +165,6 @@
 
 	/* Winbond W25N01GVZEIG (128M) */
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-konka-komi-a31.dts
+++ b/target/linux/mediatek/dts/mt7981b-konka-komi-a31.dts
@@ -142,8 +142,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-mercusys-mr80x-v3.dts
+++ b/target/linux/mediatek/dts/mt7981b-mercusys-mr80x-v3.dts
@@ -162,8 +162,6 @@
 	status = "okay";
 
 	spi_nand: spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-netgear-eax17.dts
+++ b/target/linux/mediatek/dts/mt7981b-netgear-eax17.dts
@@ -150,8 +150,6 @@
 	status = "okay";
 
 	spi_nand_flash: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-netis-nx31.dts
+++ b/target/linux/mediatek/dts/mt7981b-netis-nx31.dts
@@ -123,8 +123,6 @@
 	status = "okay";
 
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-nokia-ea0326gmp.dts
+++ b/target/linux/mediatek/dts/mt7981b-nokia-ea0326gmp.dts
@@ -158,8 +158,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-openembed-som7981.dts
+++ b/target/linux/mediatek/dts/mt7981b-openembed-som7981.dts
@@ -142,8 +142,6 @@
 
 	spi_nand: flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-openfi-6c.dts
+++ b/target/linux/mediatek/dts/mt7981b-openfi-6c.dts
@@ -129,8 +129,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
+++ b/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
@@ -303,8 +303,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
+++ b/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
@@ -354,8 +354,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
+++ b/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
@@ -99,8 +99,6 @@
 
 	spi_nand@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-routerich-ax3000-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-routerich-ax3000-common.dtsi
@@ -152,8 +152,6 @@
 
 	/* ESMT F50L1G41LB (128M) */
 	spi: spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-routerich-ax3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-routerich-ax3000-v1.dts
@@ -167,8 +167,6 @@
 	status = "okay";
 
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-routerich-ax3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-routerich-ax3000.dts
@@ -63,8 +63,6 @@
 
 	/* ESMT F50L1G41LB (128M) */
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-snr-snr-cpe-ax2.dts
+++ b/target/linux/mediatek/dts/mt7981b-snr-snr-cpe-ax2.dts
@@ -132,8 +132,6 @@
 	status = "okay";
 
 	spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-tenbay-wr3000k.dts
+++ b/target/linux/mediatek/dts/mt7981b-tenbay-wr3000k.dts
@@ -146,8 +146,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-totolink-x6000r.dts
+++ b/target/linux/mediatek/dts/mt7981b-totolink-x6000r.dts
@@ -160,9 +160,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-tplink-fr365v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-tplink-fr365v1.dts
@@ -141,8 +141,6 @@
 
 	spi_nand@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-unielec-u7981-01-nand.dts
+++ b/target/linux/mediatek/dts/mt7981b-unielec-u7981-01-nand.dts
@@ -18,8 +18,6 @@
 	pinctrl-0 = <&spi0_flash_pins>;
 	status = "okay";
 	spi_nand: spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-3port-128nand-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-3port-128nand-common.dtsi
@@ -57,9 +57,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn573hx3.dts
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn573hx3.dts
@@ -86,9 +86,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn586x3.dts
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn586x3.dts
@@ -131,9 +131,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
@@ -311,8 +311,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
+++ b/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
@@ -145,9 +145,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
@@ -166,8 +166,6 @@
 
 	spi_nand@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax.dts
@@ -179,8 +179,6 @@
 
 	spi_nand@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dts
@@ -139,8 +139,6 @@
 
 	spi_nand@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
@@ -110,8 +110,6 @@
 	status = "okay";
 
 	spi_nand: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7986a-acelink-ew-7886cax.dts
+++ b/target/linux/mediatek/dts/mt7986a-acelink-ew-7886cax.dts
@@ -158,8 +158,6 @@
 	flash@0 {
 		compatible = "spi-nand";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
 		spi-max-frequency = <52000000>;
 		spi-rx-bus-width = <4>;
 		spi-tx-bus-width = <4>;

--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6x.dtsi
@@ -213,8 +213,6 @@
 
 	spi_nand@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7986a-asiarf-ap7986-003.dts
+++ b/target/linux/mediatek/dts/mt7986a-asiarf-ap7986-003.dts
@@ -307,8 +307,6 @@
 	status = "okay";
 
 	spi_nand@1 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <1>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
+++ b/target/linux/mediatek/dts/mt7986a-bananapi-bpi-r3-mini.dts
@@ -511,8 +511,6 @@
 
 	flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;

--- a/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
+++ b/target/linux/mediatek/dts/mt7986a-dlink-aquila-pro-ai-m60-a1.dts
@@ -210,8 +210,6 @@
 
 	flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;

--- a/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
+++ b/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
@@ -177,8 +177,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
@@ -236,8 +236,6 @@
 
 	flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;

--- a/target/linux/mediatek/dts/mt7986a-netcore-n60.dts
+++ b/target/linux/mediatek/dts/mt7986a-netcore-n60.dts
@@ -181,8 +181,6 @@
 
 	flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;

--- a/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-ruijie-rg-x60-pro.dts
@@ -153,8 +153,6 @@
 
 	flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
@@ -165,8 +165,6 @@
 
 	flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xtr8488.dts
@@ -210,8 +210,6 @@
 
 	flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;

--- a/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
+++ b/target/linux/mediatek/dts/mt7986a-wavlink-wl-wn536ax6-a.dts
@@ -274,8 +274,6 @@
 	/* Macronix SPI NAND (128M) */
 	flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
@@ -134,8 +134,6 @@
 
 	spi_nand_flash: flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-common.dtsi
@@ -166,8 +166,6 @@
 	status = "okay";
 
 	spi_nand: spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mediatek/dts/mt7986b-buffalo-wsr-6000ax8.dts
+++ b/target/linux/mediatek/dts/mt7986b-buffalo-wsr-6000ax8.dts
@@ -267,8 +267,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1-common.dtsi
@@ -216,8 +216,6 @@
 
 	spi_nand_flash: flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;

--- a/target/linux/mediatek/dts/mt7986b-netgear-wax220.dts
+++ b/target/linux/mediatek/dts/mt7986b-netgear-wax220.dts
@@ -180,8 +180,6 @@
 	status = "okay";
 
 	spi_nand_flash: flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <0>;
 

--- a/target/linux/mediatek/dts/mt7986b-tplink-re6000xd.dts
+++ b/target/linux/mediatek/dts/mt7986b-tplink-re6000xd.dts
@@ -231,8 +231,6 @@
 
 	spi_nand_flash: flash@0 {
 		compatible = "spi-nand";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 
 		spi-max-frequency = <20000000>;

--- a/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
+++ b/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
@@ -147,8 +147,6 @@
 	status = "okay";
 
 	spi_nand: spi_nand@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		
 		reg = <0>;

--- a/target/linux/mediatek/files-6.12/arch/arm64/boot/dts/mediatek/mt7981-rfb-spim-nand.dtso
+++ b/target/linux/mediatek/files-6.12/arch/arm64/boot/dts/mediatek/mt7981-rfb-spim-nand.dtso
@@ -18,8 +18,6 @@
 			#size-cells = <0>;
 
 			spi_nand: spi_nand@1 {
-				#address-cells = <1>;
-				#size-cells = <1>;
 				compatible = "spi-nand";
 				reg = <1>;
 				spi-max-frequency = <10000000>;

--- a/target/linux/mediatek/files-6.12/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
+++ b/target/linux/mediatek/files-6.12/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
@@ -10,8 +10,6 @@
 	status = "okay";
 
 	spi_nand: spi_nand@1 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		reg = <1>;
 		spi-max-frequency = <10000000>;

--- a/target/linux/mediatek/files-6.12/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nor.dts
+++ b/target/linux/mediatek/files-6.12/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nor.dts
@@ -10,8 +10,6 @@
 	status = "okay";
 
 	spi_nor: spi_nor@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <52000000>;

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/armada-7040-rb5009.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/armada-7040-rb5009.dts
@@ -120,8 +120,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <20000000>;

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9131-puzzle-m901.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9131-puzzle-m901.dts
@@ -255,8 +255,6 @@
 	      <0x2000000 0x1000000>;    /* CS0 */
 	status = "okay";
 	spi-flash@0 {
-		#address-cells = <0x1>;
-		#size-cells = <0x1>;
 		compatible = "jedec,spi-nor";
 		reg = <0x0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/cn9132-puzzle-m902.dts
@@ -328,8 +328,6 @@
 	      <0x2000000 0x1000000>;    /* CS0 */
 	status = "okay";
 	spi-flash@0 {
-		#address-cells = <0x1>;
-		#size-cells = <0x1>;
 		compatible = "jedec,spi-nor";
 		reg = <0x0>;
 		spi-max-frequency = <40000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
@@ -137,9 +137,6 @@
 	nand@0 {
 		compatible = "spi-nand";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		nand-ecc-engine = <&qpic_nand>;
 		nand-bus-width = <8>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax830.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax830.dts
@@ -300,9 +300,6 @@
 	nand@0 {
 		compatible = "spi-nand";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		nand-ecc-engine = <&qpic_nand>;
 		nand-bus-width = <8>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax830.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax830.dts
@@ -181,8 +181,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <50000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
@@ -300,9 +300,6 @@
 	nand@0 {
 		compatible = "spi-nand";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		nand-ecc-engine = <&qpic_nand>;
 		nand-bus-width = <8>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
@@ -181,8 +181,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <50000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
@@ -219,9 +219,6 @@
 	nand@0 {
 		compatible = "spi-nand";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		nand-ecc-engine = <&qpic_nand>;
 		nand-bus-width = <8>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx-base.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx-base.dtsi
@@ -127,9 +127,6 @@
 	nand@0 {
 		compatible = "spi-nand";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		nand-ecc-engine = <&qpic_nand>;
 		nand-bus-width = <8>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-pz-l8.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-pz-l8.dts
@@ -117,9 +117,6 @@
 	nand@0 {
 		compatible = "spi-nand";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		nand-ecc-engine = <&qpic_nand>;
 		nand-bus-width = <8>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wn-dax3000gr.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wn-dax3000gr.dts
@@ -166,9 +166,6 @@
 	flash@0 {
 		compatible = "spi-nand";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		nand-ecc-engine = <&qpic_nand>;
 
 		/* strength=8 breaks NAND I/O, use 4 instead */

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wrc-x3000gs2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wrc-x3000gs2.dts
@@ -161,9 +161,6 @@
 	flash@0 {
 		compatible = "spi-nand";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		nand-ecc-engine = <&qpic_nand>;
 
 		/* strength=8 breaks NAND I/O, use 4 instead */

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-ap120c-ax.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6000-ap120c-ax.dts
@@ -167,8 +167,6 @@
 	pinctrl-names = "default";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <25000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-mango-dvk.dts
@@ -109,8 +109,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <25000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-xe3-4.dts
@@ -260,8 +260,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		/*
 		 * U-boot looks for "n25q128a11" node,

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-fap650.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6018-fap650.dts
@@ -218,8 +218,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <50000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8070-cax1800.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8070-cax1800.dts
@@ -126,8 +126,6 @@
 	status = "okay";
 
 	m25p80@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <50000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ap8220.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-ap8220.dts
@@ -111,8 +111,6 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-eap102.dts
@@ -103,8 +103,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <50000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-mf269.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8071-mf269.dts
@@ -108,8 +108,6 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-301w.dts
@@ -264,8 +264,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <50000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-ax880.dts
@@ -97,8 +97,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <50000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-haze.dts
@@ -141,8 +141,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <50000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-wpq873.dts
@@ -160,8 +160,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <50000000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-zbt-z800ax.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-zbt-z800ax.dts
@@ -129,8 +129,6 @@
 
 	flash@0 {
 		compatible = "jedec,spi-nor";
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8074-nbg7815.dts
@@ -89,8 +89,6 @@
 	status = "okay";
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		reg = <0>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <50000000>;

--- a/target/linux/qualcommbe/files/arch/arm64/boot/dts/qcom/ipq9570-kiwi-dvk.dts
+++ b/target/linux/qualcommbe/files/arch/arm64/boot/dts/qcom/ipq9570-kiwi-dvk.dts
@@ -62,8 +62,6 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
 		spi-max-frequency = <50000000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_plasmacloud_pax1800-lite.dts
+++ b/target/linux/ramips/dts/mt7621_plasmacloud_pax1800-lite.dts
@@ -144,8 +144,6 @@
 	};
 
 	flash@1 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "spi-nand";
 		spi-max-frequency = <20000000>;
 		reg = <1>;

--- a/target/linux/ramips/dts/mt7621_ruijie_rg-ew1200g-pro-v1.1.dts
+++ b/target/linux/ramips/dts/mt7621_ruijie_rg-ew1200g-pro-v1.1.dts
@@ -48,8 +48,6 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		#address-cells = <1>;
-		#size-cells = <1>;
 		spi-max-frequency = <25000000>;
 
 		partitions {

--- a/target/linux/siflower/dts/sf19a2890_evb.dts
+++ b/target/linux/siflower/dts/sf19a2890_evb.dts
@@ -87,9 +87,6 @@
 		reg = <0>;
 		spi-max-frequency = <30000000>;
 
-		#address-cells = <1>;
-		#size-cells = <1>;
-
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;

--- a/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2-nand.dts
+++ b/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2-nand.dts
@@ -17,8 +17,6 @@
 		spi-max-frequency = <35000000>;
 		spi-tx-bus-width = <2>;
 		spi-rx-bus-width = <2>;
-		#address-cells = <1>;
-		#size-cells = <1>;
 
 	        partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2-nor.dts
+++ b/target/linux/siflower/dts/sf21h8898_bananapi_bpi-rv2-nor.dts
@@ -60,8 +60,6 @@
 		spi-max-frequency = <35000000>;
 		spi-tx-bus-width = <2>;
 		spi-rx-bus-width = <2>;
-		#address-cells = <1>;
-		#size-cells = <1>;
 
 	        partitions {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
This patchset silences some noisy dts false warnings:
```
[    0.616266] OF: Bad cell count for /spi@1100d000/flash@0/partitions
[    0.622551] OF: Bad cell count for /spi@1100d000/flash@0/partitions
``` 
Closes: https://github.com/openwrt/openwrt/issues/14701