### PR TITLE
mediatek: filogic: gl-mt2500 fix compatibles

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -56,6 +56,7 @@ acer,predator-w6|\
 acer,predator-w6d|\
 acer,vero-w6m|\
 glinet,gl-mt2500|\
+glinet,gl-mt2500-airoha|\
 glinet,gl-mt6000|\
 glinet,gl-x3000|\
 glinet,gl-xe3000|\

--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -5,6 +5,7 @@ set_preinit_iface() {
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
 	glinet,gl-mt2500|\
+	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt3000|\
 	openembed,som7981|\
 	wavlink,wl-wn573hx3)

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v1.dts
@@ -3,6 +3,11 @@
 /dts-v1/;
 #include "mt7981b-glinet-gl-mt2500.dtsi"
 
+/ {
+	model = "GL.iNet GL-MT2500 v1 (MaxLinear PHY)";
+	compatible = "glinet,gl-mt2500", "mediatek,mt7981";
+};
+
 &gmac0 {
 	phy-handle = <&phy5>;
 };

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v2.dts
@@ -3,6 +3,11 @@
 /dts-v1/;
 #include "mt7981b-glinet-gl-mt2500.dtsi"
 
+/ {
+	model = "GL.iNet GL-MT2500 v2 (Airoha PHY)";
+	compatible = "glinet,gl-mt2500-airoha", "mediatek,mt7981";
+};
+
 &gmac0 {
 	phy-handle = <&phy13>;
 };

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dtsi
@@ -5,9 +5,6 @@
 #include <dt-bindings/pinctrl/mt65xx.h>
 
 / {
-	model = "GL.iNet GL-MT2500";
-	compatible = "glinet,gl-mt2500", "mediatek,mt7981";
-
 	aliases {
 		label-mac-device = &gmac0;
 		led-boot = &led_sys_white;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -123,6 +123,7 @@ mediatek_setup_interfaces()
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
 	glinet,gl-mt2500|\
+	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt3000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -124,6 +124,7 @@ platform_do_upgrade() {
 	acer,vero-w6m|\
 	arcadyan,mozart|\
 	glinet,gl-mt2500|\
+	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
@@ -345,6 +346,7 @@ platform_copy_config() {
 	acer,vero-w6m|\
 	arcadyan,mozart|\
 	glinet,gl-mt2500|\
+	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -317,6 +317,11 @@ platform_check_image() {
 
 		return 0
 		;;
+	glinet,gl-mt2500|\
+	glinet,gl-mt2500-airoha)
+		# delegate on fwtool for image checks to allow cross sysupgrades
+		return 0
+		;;
 	*)
 		nand_do_platform_check "$board" "$1"
 		return $?


### PR DESCRIPTION
Alternative fix for https://github.com/openwrt/openwrt/pull/20632 if we want to mantain the two profiles to be "compatible" each other https://github.com/openwrt/openwrt/issues/20566#issuecomment-3591834345. They shared the same compatible in device tree causing some incompatibilities (sysupgrades), assign a unique compatible and model to each variant. https://github.com/openwrt/openwrt/issues/20566#issuecomment-3583555482. This is the minimal change in order to not modify the actual SUPPORTED_DEVICES.

Related PR on the ASU server side: 
- https://github.com/openwrt/asu/pull/1533