### PR TITLE
build: use base variant as fallback

### DIFF
--- a/scripts/json_add_image_info.py
+++ b/scripts/json_add_image_info.py
@@ -23,8 +23,12 @@ def get_titles():
     for prefix in ["", "ALT0_", "ALT1_", "ALT2_", "ALT3_", "ALT4_", "ALT5_"]:
         title = {}
         for var in ["vendor", "model", "variant"]:
-            if getenv("DEVICE_{}{}".format(prefix, var.upper())):
-                title[var] = getenv("DEVICE_{}{}".format(prefix, var.upper()))
+            value = getenv("DEVICE_{}{}".format(prefix, var.upper()))
+            if not value and prefix != "" and var == "variant":
+                value = getenv("DEVICE_VARIANT")
+
+            if value:
+                title[var] = value
 
         if title:
             titles.append(title)


### PR DESCRIPTION
Some alt targets missing variant info, this makes it impossible to distinguish some targets by means other than their target id, so use the base variant as fallback.

exmaple target: https://github.com/openwrt/openwrt/blob/67af946dd739f9077c266b6d208b96c6ae06f181/target/linux/mediatek/image/filogic.mk#L2842-L2849
