### PR TITLE
treewide: add linux,rootfs to rootfs labeled partitions

### DIFF
--- a/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
@@ -73,6 +73,7 @@
 				partition@300000 {
 					label = "rootfs";
 					reg = <0x300000 0xc60000>;
+					linux,rootfs;
 				};
 			};
 

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
@@ -74,6 +74,7 @@
 				partition@300000 {
 					label = "rootfs";
 					reg = <0x300000 0xc60000>;
+					linux,rootfs;
 				};
 			};
 

--- a/target/linux/ath79/dts/ar9344_ubnt_unifi-ap-pro.dts
+++ b/target/linux/ath79/dts/ar9344_ubnt_unifi-ap-pro.dts
@@ -91,6 +91,7 @@
 				partition@300000 {
 					label = "rootfs";
 					reg = <0x300000 0xc60000>;
+					linux,rootfs;
 				};
 			};
 

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ea6350v3.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ea6350v3.dts
@@ -271,6 +271,7 @@
 			rootfs@500000 {
 				label = "rootfs";
 				reg = <0x00500000 0x02300000>;
+				linux,rootfs;
 			};
 			alt_kernel@2800000 {
 				label = "alt_kernel";

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-ecw5211.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-ecw5211.dts
@@ -246,6 +246,7 @@
 			partition@0 {
 				label = "rootfs";
 				reg = <0x00000000 0x04000000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-mf287.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-mf287.dts
@@ -167,6 +167,7 @@
 			partition@1300000 {
 				label = "rootfs";
 				reg = <0x1300000 0x2200000>;
+				linux,rootfs;
 			};
 
 			partition@3500000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-mf287plus.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-mf287plus.dts
@@ -167,6 +167,7 @@
 			partition@1300000 {
 				label = "rootfs";
 				reg = <0x1300000 0x2200000>;
+				linux,rootfs;
 			};
 
 			partition@3500000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-mf287pro.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-mf287pro.dts
@@ -199,6 +199,7 @@
 			partition@1800000 {
 				label = "rootfs";
 				reg = <0x1800000 0x1d00000>;
+				linux,rootfs;
 			};
 
 			partition@3500000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-nbg6617.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-nbg6617.dts
@@ -252,6 +252,7 @@
 			partition13@7a0000 {
 				label = "rootfs";
 				reg = <0x007a0000 0x01860000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-rutx.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-rutx.dtsi
@@ -287,6 +287,7 @@
 			partition@8000000 {
 				label = "rootfs";
 				reg = <0x08000000 0x08000000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-wac510.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-wac510.dts
@@ -308,6 +308,7 @@
 			partition@0 {
 				label = "rootfs";
 				reg = <0x00000000 0x03800000>;
+				linux,rootfs;
 			};
 
 			partition@3800000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-whw01.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-whw01.dts
@@ -181,6 +181,7 @@
 			partition@600000 {
 				label = "rootfs";
 				reg = <0x0600000 0x4a00000>;
+				linux,rootfs;
 			};
 
 			partition@5000000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf18a.dts
@@ -345,6 +345,7 @@
 			partition@1800000 {
 				label = "rootfs";
 				reg = <0x1800000 0x1d00000>;
+				linux,rootfs;
 			};
 
 			partition@3500000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf18a.dts
@@ -344,6 +344,7 @@
 			partition@1800000 {
 				label = "rootfs";
 				reg = <0x1800000 0x1d00000>;
+				linux,rootfs;
 			};
 
 			partition@3500000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf282plus.dts
@@ -308,6 +308,7 @@
 			partition@1800000 {
 				label = "rootfs";
 				reg = <0x1800000 0x1d00000>;
+				linux,rootfs;
 			};
 
 			partition@3500000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf282plus.dts
@@ -307,6 +307,7 @@
 			partition@1800000 {
 				label = "rootfs";
 				reg = <0x1800000 0x1d00000>;
+				linux,rootfs;
 			};
 
 			partition@3500000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf286d.dts
@@ -302,6 +302,7 @@
 			partition@1800000 {
 				label = "rootfs";
 				reg = <0x1800000 0x1d00000>;
+				linux,rootfs;
 			};
 
 			partition@3500000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf286d.dts
@@ -301,6 +301,7 @@
 			partition@1800000 {
 				label = "rootfs";
 				reg = <0x1800000 0x1d00000>;
+				linux,rootfs;
 			};
 
 			partition@3500000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf289f.dts
@@ -285,6 +285,7 @@
 			partition@1800000 {
 				label = "rootfs";
 				reg = <0x1800000 0x1d00000>;
+				linux,rootfs;
 			};
 
 			partition@3500000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf289f.dts
@@ -283,6 +283,7 @@
 			partition@1800000 {
 				label = "rootfs";
 				reg = <0x1800000 0x1d00000>;
+				linux,rootfs;
 			};
 
 			partition@3500000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-oap100.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-oap100.dts
@@ -250,6 +250,7 @@
 			partition@0 {
 				label = "rootfs";
 				reg = <0x00000000 0x4000000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-rtl30vw.dts
@@ -283,6 +283,7 @@
 			partition@400000 {
 				label = "rootfs";
 				reg = <0x400000 0x2000000>;
+				linux,rootfs;
 			};
 
 			partition@2400000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-rtl30vw.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-rtl30vw.dts
@@ -297,6 +297,7 @@
 			partition@400000 {
 				label = "rootfs";
 				reg = <0x400000 0x2000000>;
+				linux,rootfs;
 			};
 
 			partition@2400000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-whw03v2.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-whw03v2.dts
@@ -175,6 +175,7 @@
 			partition@d00000 {
 				label = "rootfs";
 				reg = <0xd00000 0x9b00000>;
+				linux,rootfs;
 			};
 
 			partition@a800000 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-xx8300.dtsi
@@ -196,6 +196,7 @@
 			partition@c80000 {
 				label = "rootfs";
 				reg = <0xc80000 0x5300000>;
+				linux,rootfs;
 			};
 
 			partition@5f80000 {

--- a/target/linux/ipq806x/dts/qcom-ipq8064-ad7200-c2600.dtsi
+++ b/target/linux/ipq806x/dts/qcom-ipq8064-ad7200-c2600.dtsi
@@ -189,6 +189,7 @@
 				partition@5f0000 {
 					label = "rootfs";
 					reg = <0x5f0000 0x1900000>;
+					linux,rootfs;
 				};
 
 				defaultmac: partition@1ef0000 {

--- a/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
@@ -326,6 +326,7 @@
 			rootfs@0 {
 				label = "rootfs";
 				reg = <0x0000000 0x4000000>;
+				linux,rootfs;
 			};
 
 			rootfs_1@4000000 {

--- a/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8065-ac400i.dts
@@ -365,6 +365,7 @@
 			rootfs@0 {
 				label = "rootfs";
 				reg = <0x0000000 0x4000000>;
+				linux,rootfs;
 			};
 
 			rootfs_1@4000000 {

--- a/target/linux/lantiq/dts/danube_lantiq_easy50712.dts
+++ b/target/linux/lantiq/dts/danube_lantiq_easy50712.dts
@@ -59,6 +59,7 @@
 			partition@400000 {
 				label = "rootfs";
 				reg = <0x400000 0x400000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/br200-wp.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/br200-wp.dts
@@ -67,6 +67,7 @@
 				partition@80000 {
 					reg = <0x80000 0x27c0000>;
 					label = "rootfs";
+					linux,rootfs;
 				};
 
 				partition@2840000 {

--- a/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-xxe.dtsi
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-385-fortinet-fg-xxe.dtsi
@@ -310,6 +310,7 @@
 			partition@800000 {
 				reg = <0x800000 0x1800000>;
 				label = "rootfs";
+				linux,rootfs;
 			};
 
 			partition@2000000 {

--- a/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-385-nas1dual.dts
+++ b/target/linux/mvebu/files/arch/arm/boot/dts/marvell/armada-385-nas1dual.dts
@@ -281,6 +281,7 @@
 				partition@600000 {
 					reg = <0x00600000 0x038c0000>;
 					label = "rootfs";
+					linux,rootfs;
 				};
 			};
 

--- a/target/linux/qualcommax/dts/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/dts/ipq5018-ax6000.dts
@@ -268,6 +268,7 @@
 			partition@2e80000 {
 				label = "rootfs";
 				reg = <0x02e80000 0x5180000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/qualcommax/dts/ipq5018-ax830.dts
+++ b/target/linux/qualcommax/dts/ipq5018-ax830.dts
@@ -311,6 +311,7 @@
 			partition@3e80000 {
 				label = "rootfs";
 				reg = <0x3e80000 0x3e00000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/qualcommax/dts/ipq5018-ax850.dts
+++ b/target/linux/qualcommax/dts/ipq5018-ax850.dts
@@ -310,6 +310,7 @@
 			partition@3e80000 {
 				label = "rootfs";
 				reg = <0x3e80000 0x3e00000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/qualcommax/dts/ipq6000-gl-ax1800.dts
+++ b/target/linux/qualcommax/dts/ipq6000-gl-ax1800.dts
@@ -17,6 +17,7 @@
 	partition@a00000 {
 		label = "rootfs";
 		reg = <0x0a00000 0x7300000>;
+		linux,rootfs;
 	};
 };
 

--- a/target/linux/qualcommax/dts/ipq6000-gl-axt1800.dts
+++ b/target/linux/qualcommax/dts/ipq6000-gl-axt1800.dts
@@ -111,6 +111,7 @@
 	partition@a00000 {
 		label = "rootfs";
 		reg = <0x0a00000 0x7280000>;
+		linux,rootfs;
 	};
 
 	partition@7c80000 {

--- a/target/linux/qualcommax/dts/ipq6010-xe3-4.dts
+++ b/target/linux/qualcommax/dts/ipq6010-xe3-4.dts
@@ -415,6 +415,7 @@
 			partition@0 {
 				label = "rootfs";
 				reg = <0x0 0x6000000>;
+				linux,rootfs;
 			};
 
 			partition@6000000 {

--- a/target/linux/qualcommax/dts/ipq6018-fap650.dts
+++ b/target/linux/qualcommax/dts/ipq6018-fap650.dts
@@ -328,6 +328,7 @@
 			partition@0 {
 				label = "rootfs";
 				reg = <0x00000000 0x03c00000>;
+				linux,rootfs;
 			};
 
 			partition@3c00000 {

--- a/target/linux/qualcommax/dts/ipq8070-cax1800.dts
+++ b/target/linux/qualcommax/dts/ipq8070-cax1800.dts
@@ -114,6 +114,7 @@
 			partition@0 {
 				label = "rootfs";
 				reg = <0x0000000 0x3400000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/qualcommax/dts/ipq8071-ax3600.dtsi
+++ b/target/linux/qualcommax/dts/ipq8071-ax3600.dtsi
@@ -201,6 +201,7 @@
 			rootfs: partition@2dc0000 {
 				label = "rootfs";
 				reg = <0x2dc0000 0xd240000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/qualcommax/dts/ipq8071-mf269.dts
+++ b/target/linux/qualcommax/dts/ipq8071-mf269.dts
@@ -360,6 +360,7 @@
 			partition@5fc0000 {
 				label = "rootfs";
 				reg = <0x5fc0000 0x9a00000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/qualcommax/dts/ipq8072-ax880.dts
+++ b/target/linux/qualcommax/dts/ipq8072-ax880.dts
@@ -292,6 +292,7 @@
 			rootfs: partition@3c00000 {
 				label = "rootfs";
 				reg = <0x3c00000 0x3400000>;
+				linux,rootfs;
 			};
 
 			partition@7000000 {

--- a/target/linux/qualcommax/dts/ipq8072-ax9000.dts
+++ b/target/linux/qualcommax/dts/ipq8072-ax9000.dts
@@ -338,6 +338,7 @@
 			partition@4980000 {
 				label = "rootfs";
 				reg = <0x4980000 0xb680000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/qualcommax/dts/ipq8072-mx5300.dts
+++ b/target/linux/qualcommax/dts/ipq8072-mx5300.dts
@@ -307,6 +307,7 @@
 			partition@1680000 {
 				label = "rootfs";
 				reg = <0x1680000 0x9000000>;
+				linux,rootfs;
 			};
 
 			partition@a680000 {

--- a/target/linux/qualcommax/dts/ipq8072-mx8500.dts
+++ b/target/linux/qualcommax/dts/ipq8072-mx8500.dts
@@ -276,6 +276,7 @@
 			partition@1680000 {
 				label = "rootfs";
 				reg = <0x1680000 0x9000000>;
+				linux,rootfs;
 			};
 
 			partition@a680000 {

--- a/target/linux/qualcommax/dts/ipq8072-wpq873.dts
+++ b/target/linux/qualcommax/dts/ipq8072-wpq873.dts
@@ -302,6 +302,7 @@
 			partition@0 {
 				label = "rootfs";
 				reg = <0x0000000 0x3400000>;
+				linux,rootfs;
 			};
 
 			partition@3400000 {

--- a/target/linux/qualcommax/dts/ipq8072-zbt-z800ax.dts
+++ b/target/linux/qualcommax/dts/ipq8072-zbt-z800ax.dts
@@ -292,6 +292,7 @@
 			partition@0 {
 				label = "rootfs";
 				reg = <0x0000000 0x3400000>;
+				linux,rootfs;
 			};
 
 			partition@3400000 {

--- a/target/linux/qualcommax/dts/ipq8074-rax120v2.dts
+++ b/target/linux/qualcommax/dts/ipq8074-rax120v2.dts
@@ -489,6 +489,7 @@
 			partition@e8800000 {
 				label = "rootfs";
 				reg = <0xe880000 0x11780000>;
+				linux,rootfs;
 			};
 		};
 	};

--- a/target/linux/qualcommax/dts/ipq8074-sxk80.dtsi
+++ b/target/linux/qualcommax/dts/ipq8074-sxk80.dtsi
@@ -397,6 +397,7 @@
 			partition@1fa0000 {
 				label = "rootfs";
 				reg = <0x1fa0000 0x66e0000>;
+				linux,rootfs;
 			};
 
 			partition@8680000 {

--- a/target/linux/qualcommax/dts/ipq807x-nwax10ax.dtsi
+++ b/target/linux/qualcommax/dts/ipq807x-nwax10ax.dtsi
@@ -294,6 +294,7 @@
 		partition@0 {
 			reg = <0x00 0x3c00000>;
 			label = "rootfs";
+			linux,rootfs;
 		};
 
 		partition@3c00000 {

--- a/target/linux/qualcommax/dts/ipq8174-mx4200.dtsi
+++ b/target/linux/qualcommax/dts/ipq8174-mx4200.dtsi
@@ -202,6 +202,7 @@
 			partition@1680000 {
 				label = "rootfs";
 				reg = <0x1680000 0x9000000>;
+				linux,rootfs;
 			};
 
 			partition@a680000 {

--- a/target/linux/qualcommax/dts/ipq8174-mx4300.dts
+++ b/target/linux/qualcommax/dts/ipq8174-mx4300.dts
@@ -198,6 +198,7 @@
 			partition@1a40000 {
 				label = "rootfs";
 				reg = <0x1a40000 0xa740000>;
+				linux,rootfs;
 			};
 
 			partition@c180000 {

--- a/target/linux/qualcommbe/patches-6.12/0304-arm64-dts-qcom-ipq9574-add-QPIC-SPI-NAND-default-par.patch
+++ b/target/linux/qualcommbe/patches-6.12/0304-arm64-dts-qcom-ipq9574-add-QPIC-SPI-NAND-default-par.patch
@@ -13,7 +13,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq9574-rdp-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq9574-rdp-common.dtsi
-@@ -189,6 +189,34 @@
+@@ -189,6 +189,35 @@
  		nand-ecc-engine = <&qpic_nand>;
  		nand-ecc-strength = <4>;
  		nand-ecc-step-size = <512>;
@@ -38,6 +38,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 +			partition@c0000 {
 +				label = "rootfs";
 +				reg = <0xc0000 0x3c00000>;
++				linux,rootfs;
 +			};
 +
 +			partition@3cc0000 {

--- a/target/linux/qualcommbe/patches-6.18/0347-arm64-dts-qcom-ipq9574-add-QPIC-SPI-NAND-default-par.patch
+++ b/target/linux/qualcommbe/patches-6.18/0347-arm64-dts-qcom-ipq9574-add-QPIC-SPI-NAND-default-par.patch
@@ -13,7 +13,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 
 --- a/arch/arm64/boot/dts/qcom/ipq9574-rdp-common.dtsi
 +++ b/arch/arm64/boot/dts/qcom/ipq9574-rdp-common.dtsi
-@@ -189,6 +189,34 @@
+@@ -189,6 +189,35 @@
  		nand-ecc-engine = <&qpic_nand>;
  		nand-ecc-strength = <4>;
  		nand-ecc-step-size = <512>;
@@ -38,6 +38,7 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
 +			partition@c0000 {
 +				label = "rootfs";
 +				reg = <0xc0000 0x3c00000>;
++				linux,rootfs;
 +			};
 +
 +			partition@3cc0000 {

--- a/target/linux/ramips/dts/mt7621_arcadyan_we410443.dts
+++ b/target/linux/ramips/dts/mt7621_arcadyan_we410443.dts
@@ -122,6 +122,7 @@
 				partition@400000 {
 					label = "rootfs";
 					reg = <0x440000 0x1b20000>;
+					linux,rootfs;
 				};
 			};
 

--- a/target/linux/ramips/dts/mt7621_arcadyan_we420223-99.dts
+++ b/target/linux/ramips/dts/mt7621_arcadyan_we420223-99.dts
@@ -145,6 +145,7 @@
 			partition@490000 {
 				label = "rootfs";
 				reg = <0x490000 0x1b20000>;
+				linux,rootfs;
 			};
 
 			partition@1000000 {

--- a/target/linux/ramips/dts/mt7621_mediatek_mt7621-eval-board.dts
+++ b/target/linux/ramips/dts/mt7621_mediatek_mt7621-eval-board.dts
@@ -31,6 +31,7 @@
 		partition@140000 {
 			label = "rootfs";
 			reg = <0x140000 0xec0000>;
+			linux,rootfs;
 		};
 	};
 };

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks7300-4x4t.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks7300-4x4t.dts
@@ -225,6 +225,7 @@
 				partition@800000 {
 					label = "rootfs";
 					reg = <0x800000 0x1380000>;
+					linux,rootfs;
 				};
 			};
 		};

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
@@ -248,6 +248,7 @@
 				partition@800000 {
 					label = "rootfs";
 					reg = <0x800000 0x1600000>;
+					linux,rootfs;
 				};
 			};
 		};

--- a/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
+++ b/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
@@ -339,6 +339,7 @@
 				partition@800000 {
 					label = "rootfs";
 					reg = <0x800000 0x1600000>;
+					linux,rootfs;
 				};
 			};
 		};


### PR DESCRIPTION
A step towards removing hack/420-mtd-support-OpenWrt-s-MTD_ROOTFS_ROOT_DEV.patch

ping @Ansuel 