### PR TITLE
selinux-policy: update to 2.8.4

### DIFF
--- a/package/system/selinux-policy/Makefile
+++ b/package/system/selinux-policy/Makefile
@@ -8,8 +8,8 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=selinux-policy
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://git.defensec.nl/selinux-policy.git
-PKG_VERSION:=2.8.3
-PKG_MIRROR_HASH:=accbb1c7bebfbe48d46ac4060d12a06434ed28d6834b0fb4e22d25d329b277ef
+PKG_VERSION:=2.8.4
+PKG_MIRROR_HASH:=5ee24ac072414bb2a8a93cefeeb827a11123d7a61313d4389fce554ef2fb94ce
 PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=secilc/host policycoreutils/host
 


### PR DESCRIPTION
Changelog:
73e77ae odhcpd anticipate per link configuration
c353698 various
8465968 iwinfo: ucode
9d9f12c various
2f41f9b various
70bb8bc various loose ends
6e817d4 netifd odhcpd wifi
69558b8 addresses various surfaced policy issues
9eb2dae README update
0a710e3 README
6fffaf6 pidfs: fsuse task seclabelfs
b051c6d makefile reproducible

ping @kcinimod-defensec 