### PR TITLE
build: Add !USE_APK dependency to CLEAN_IPKG to prevent build errors

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -108,6 +108,7 @@ menu "Global build settings"
 	config CLEAN_IPKG
 		bool
 		prompt "Remove ipkg/opkg status data files in final images"
+		depends on !USE_APK
 		help
 		  This removes all ipkg/opkg status data files from the target directory
 		  before building the root filesystem.


### PR DESCRIPTION
When USE_APK is enabled, APK replaces opkg/ipkg, leading to a build failure when CLEAN_IPKG is also selected. 

> openwrt/build_dir/target-aarch64_cortex-a53_musl/root-mediatek/usr/lib/opkg/status > openwrt/build_dir/target-aarch64_cortex-a53_musl/root-mediatek/usr/lib/opkg/status.new
> bash: line 1: openwrt/build_dir/target-aarch64_cortex-a53_musl/root-mediatek/usr/lib/opkg/status.new: No such file or directory

Add 'depends on !USE_APK' to CLEAN_IPKG to ensure this option is only selectable when opkg/ipkg is the active package manager.