### PR TITLE
[RFC] base-files: sysupgrade: relax check in nand_do_platform_check() to allow SUPPORTED_DEVICES

### DIFF
--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -489,11 +489,7 @@ nand_do_platform_check() {
 
 	local cmd="$(identify_if_gzip "$file")cat"
 	local file_type="$(identify "$file" "$cmd" "")"
-	local control_length=$( ($cmd < "$file" | tar xOf - "sysupgrade-${board_name//,/_}/CONTROL" | wc -c) 2> /dev/null)
-
-	if [ "$control_length" = 0 ]; then
-		control_length=$( ($cmd < "$file" | tar xOf - "sysupgrade-${board_name//_/,}/CONTROL" | wc -c) 2> /dev/null)
-	fi
+	local control_length=$( ($cmd < "$file" | tar xOf - "sysupgrade-*/CONTROL" | wc -c) 2> /dev/null)
 
 	if [ "$control_length" != 0 ]; then
 		nand_verify_tar_file "$file" "$cmd" || return 1


### PR DESCRIPTION
fwtool.sh introduced the SUPPORTED_DEVICES mechanism to validate if an image is compatible with the target device before flashing it.

There seems to be an implicit constraint in the sysupgrade-TAR images's building script which hardcode the "image makefile profile name" (DEVICE_NAME or BOARD_NAME if defined) during the image-building process, but, later on, it is the "board_name()"(dts compatible) what it is checked in "nand_do_platform_check" during sysupgrading on device. That implies
that only one specific dts compatible string (the one which match the profile name) will do a seamless sysupgrade https://github.com/openwrt/openwrt/issues/20566#issuecomment-3583555482

In order to allow the SUPPORTED_DEVICES mechanism to work properly and since fwtool is used for image metadata checks (including the SUPPORTED_DEVICES check for a valid board_name), check only for a valid CONTROL file when verifying the TAR image.

* Unify behavior of all remaining consumers of this function and avoid more platform specific workarounds.
* Before we need to migrate two remaining targets that do not enforce IMAGE METADATA in all devices.

Fixes: https://github.com/openwrt/openwrt/issues/20966
