### PR TITLE
siflower: sf21 device tree fix

### DIFF
--- a/target/linux/siflower/dts/sf21.dtsi
+++ b/target/linux/siflower/dts/sf21.dtsi
@@ -655,6 +655,7 @@
 			#size-cells = <0>;
 			pinctrl-names = "default";
 			pinctrl-0 = <&i2c1_pins>;
+			resets = <&i2crst 1>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
`i2c1` node was missing `resets`, so the driver would not recognize it (after setting `status="okay"`):
```
i2c_designware c101000.i2c: Unknown Synopsys component type: 0x00000000
```

With this fix, I2C pins on BPi-RV2 26-pin GPIO header are usable. I tested this with a DS3231 RTC module.