### PR TITLE
wifi-scripts: fix broken match all case for wifi-vlan

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless-device.uc
@@ -488,7 +488,11 @@ function wdev_set_data(wdev, vif, vlan, data)
 		cur_type = "vlan";
 	}
 
-	wdev.handler_data[cur.name] = {
+	let key = cur.name;
+	if (cur_type == "vlan")
+		key = vif.name + "/" + vlan.name;
+
+	wdev.handler_data[key] = {
 		...cur,
 		...data,
 		type: cur_type,
@@ -545,9 +549,13 @@ function hotplug(name, add)
 	}
 }
 
-function get_status_data(wdev, vif)
+function get_status_data(wdev, vif, parent_vif)
 {
-	let hdata = wdev.handler_data[vif.name];
+	let key = vif.name;
+	if (parent_vif)
+		key = parent_vif.name + "/" + vif.name;
+
+	let hdata = wdev.handler_data[key];
 	let data = {
 		section: vif.name,
 		config: vif.config
@@ -561,7 +569,7 @@ function get_status_vlans(wdev, vif)
 {
 	let vlans = [];
 	for (let vlan in vif.vlan)
-		push(vlans, get_status_data(wdev, vlan));
+		push(vlans, get_status_data(wdev, vlan, vif));
 	return vlans;
 }
 

--- a/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
+++ b/package/network/config/wifi-scripts/files/lib/netifd/wireless.uc
@@ -192,8 +192,9 @@ function config_init(uci)
 	}
 
 	for (let name, data in sections.vlan) {
+		let ifaces = parse_array(data.iface);
 		for (let iface, iface_vifs in vifs) {
-			if (data.iface && data.iface != iface)
+			if (length(ifaces) && index(ifaces, iface) < 0)
 				continue;
 
 			for (let vif in iface_vifs) {
@@ -214,8 +215,9 @@ function config_init(uci)
 	}
 
 	for (let name, data in sections.station) {
+		let ifaces = parse_array(data.iface);
 		for (let iface, iface_vifs in vifs) {
-			if (data.iface && data.iface != iface)
+			if (length(ifaces) && index(ifaces, iface) < 0)
 				continue;
 
 			for (let vif in iface_vifs) {


### PR DESCRIPTION
## wifi-scripts: fix broken match all case for wifi-vlan 

When iface is omitted, wifi-vlan will apply to all interfaces.
However, netifd.set_vlan call is not successful as it assumes
that every wifi-vlan section corresponds to one VIF.

For this reason in the wifi-vlan case (cur_type == "vlan")
we create a composite key in the form `${vif.name}/${vlan.name}`
allowing the same vlan section to correspond to multiple VAPs.
`/` was decided as a delimiter as it is an invalid character
for a network interface name and UCI identifier; so it is
impossible for it to cause conflicts.

It was verified that the `ubus call network.wireless status`
works as expected with this change. Moreover, wifi-station
is not susceptible to this problem.

This also means that it is now possible for wifi-vlan
to support `list` iface similar to old shell-based wifi-scripts.
This will be done in a follow-up commit.

Fixes: https://github.com/openwrt/openwrt/commit/98435a37a7139aa4bc1d494f7cc3cbdf2b9be597 ("wifi-scripts: iface should be optional in wifi-vlan definition")

## wifi-scripts: add support for using list for iface in wifi-station/vlan

This is a trivial change to allow users to use 'list' on iface.
Old wifi-scripts already implements this, so this just ensures
that shell-based and ucode wifi-scripts are on-par with each other.