### PR TITLE
gitattributes: automatically convert dts file CRLF line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 * -text
 *.patch whitespace=-indent-with-non-tab,-space-before-tab,-tab-in-indent,-trailing-space
+*.dts text eol=lf
+*.dts[io] text eol=lf


### PR DESCRIPTION
It seems that some developers prefer to use the Windows OS to add new device support. Add new attributes for device tree files so that the CRLF line endings can be automatically normalized to LF.
