### PR TITLE
ci: add pull-requests: write permission to formal workflow

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build:


### PR DESCRIPTION
Add pull-requests: write to .github/workflows/formal.yml because the reusable workflow openwrt/actions-shared-workflows/formal.yml requires that permission to post/minimize comments on pull requests. Without this the workflow is rejected with a validation error.

Fixes:
 Invalid workflow file: .github/workflows/formal.yml#L10
The workflow is not valid. .github/workflows/formal.yml (Line: 10, Col: 3): Error calling workflow 'openwrt/actions-shared-workflows/.github/workflows/formal.yml@main'. The workflow is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.
