### PR TITLE
build: Let CLEAN_IPKG with USE_APK drop apk status

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -107,10 +107,9 @@ menu "Global build settings"
 
 	config CLEAN_IPKG
 		bool
-		prompt "Remove ipkg/opkg status data files in final images"
-		depends on !USE_APK
+		prompt "Remove ipkg/opkg/apk status data files in final images"
 		help
-		  This removes all ipkg/opkg status data files from the target directory
+		  This removes all ipkg/opkg/apk status data files from the target directory
 		  before building the root filesystem.
 
 	config IPK_FILES_CHECKSUMS

--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -54,7 +54,13 @@ apk = \
 TARGET_DIR_ORIG := $(TARGET_ROOTFS_DIR)/root.orig-$(BOARD)
 
 ifdef CONFIG_CLEAN_IPKG
-  define clean_ipkg
+  ifdef CONFIG_USE_APK
+    define clean_ipkg
+	-find $(1)/lib/apk/packages -type f -and -not -name '*.conffiles_static' -delete
+	-rm -rf $(1)/etc/apk $(1)/lib/apk/db
+    endef
+  else
+    define clean_ipkg
 	-find $(1)/usr/lib/opkg/info -type f -and -not -name '*.control' -delete
 	-sed -i -ne '/^Require-User: /p' $(1)/usr/lib/opkg/info/*.control
 	awk ' \
@@ -65,7 +71,8 @@ ifdef CONFIG_CLEAN_IPKG
 	' $(1)/usr/lib/opkg/status >$(1)/usr/lib/opkg/status.new
 	mv $(1)/usr/lib/opkg/status.new $(1)/usr/lib/opkg/status
 	-find $(1)/usr/lib/opkg -empty -delete
-  endef
+    endef
+  endif
 endif
 
 define prepare_rootfs


### PR DESCRIPTION
Instead of dropping this space saving feature, it is adapted for apk.

With my (heavily configured) qualcommax_ipq807x dynalink_dl-wrx36:
```
$ pwd
…/openwrt/build_dir/target-aarch64_cortex-a53_musl/root-qualcommax $ du -sh etc/apk lib/apk # without CLEAN_IPKG
32K     etc/apk
1.9M    lib/apk
$ du -sh lib/apk # with patched CLEAN_IPKG
du: cannot access 'etc/apk': No such file or directory
136K    lib/apk
```
In the resulting squashfs-sysupgrade.bin image this still amounts to roughly ~120kB of a size difference. Not much, but given some space-saving options provide less savings this seems like an easy way to save space as on space-constraint systems apk is probably not installed to begin with (which my current system is not, but the previous was).

I am using this since APK is default (as I did before with opkg), but my images configure themselves on first boot and I never keep config on upgrade, so this part is entirely untested – and was hence hoping for someone else to come forward and pick it up…

The config name is reused as it effected opkg even if it was named ipkg before and someone who wants to drop those status files probably makes no difference between opkg/ipkg/apk used internally in the build.

References: 929a460bfa6ad8e894db97e4d6ca267cf848e3a2