### PR TITLE
qualcommax: ipq50xx: fix various dtc warnings

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
@@ -393,6 +393,9 @@
 		reg = <17>;
 
 		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
 			port@1 {
 				reg = <1>;
 				label = "lan1";

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax830.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax830.dts
@@ -287,10 +287,6 @@
 	pinctrl-names = "default";
 	status = "okay";
 
-	partitions {
-		status = "disabled";
-	};
-
 	nand@0 {
 		compatible = "spi-nand";
 		reg = <0>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
@@ -286,10 +286,6 @@
 	pinctrl-names = "default";
 	status = "okay";
 
-	partitions {
-		status = "disabled";
-	};
-
 	nand@0 {
 		compatible = "spi-nand";
 		reg = <0>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx-base.dtsi
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx-base.dtsi
@@ -113,10 +113,6 @@
 	pinctrl-names = "default";
 	status = "okay";
 
-	partitions {
-		status = "disabled";
-	};
-
 	nand@0 {
 		compatible = "spi-nand";
 		reg = <0>;


### PR DESCRIPTION
qualcommax: ipq50xx: fix qca8337 dtc warnings for Xiaomi AX6000

Add missing address-cells and size-cells properties under the switch's
ports node to fix a multitude of below build warnings:

Warning (reg_format): /soc@0/mdio@90000/ethernet-switch@11/ports/port@1:reg: property has invalid length (4 bytes) (#address-cells == 2, #size-cells == 1)
Warning (avoid_default_addr_size): /soc@0/mdio@90000/ethernet-switch@11/ports/port@1: Relying on default #address-cells value

Signed-off-by: George Moussalem <george.moussalem@outlook.com>

qualcommax: ipq50xx: remove disabled partitions node

Although the bootloader tries to 'fixup' the qpic nand node, it actually
can't find it as the node was renamed to spi based on the new driver
architecture. The added benefit is that it also silences build warning:

Warning (spi_bus_reg): /soc@0/spi@79b0000/partitions: missing or empty reg property

Signed-off-by: George Moussalem <george.moussalem@outlook.com>
---
Node rename:

old node name: qpic-nand@79b0000
new node name: spi@79b0000

Bootloader logs:

   Booting using the fdt blob at 0x44d3fc78
   Uncompressing Kernel Image ... OK
   Loading Device Tree to 4a3f6000, end 4a3ff805 ... OK
fdt_fixup_qpic: QPIC: unable to find node '/soc/qpic-nand@79b0000'
parse_fdt_fixup: unable to find node '/soc/qpic-nand@79b0000/'