### PR TITLE
[24.10] CI: fix formal workflow permissions

### DIFF
--- a/.github/workflows/formal.yml
+++ b/.github/workflows/formal.yml
@@ -5,8 +5,14 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build:
     name: Test Formalities
     uses: openwrt/actions-shared-workflows/.github/workflows/formal.yml@main
+    # with:
+    #   # Post formality check summaries to the PR.
+    #   # Repo's permissions need to be updated for actions to modify PRs:
+    #   # https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment
+    #   post_comment: true


### PR DESCRIPTION
Fix formality check permissions that are needed to post optional summaries back to the PR.

Link: https://github.com/openwrt/actions-shared-workflows/pull/64
Link: https://github.com/openwrt/openwrt/pull/20930

cc: @robimarko 