### PR TITLE
ath79: add support for Waveshare WS-431E

### DIFF
--- a/target/linux/ath79/dts/qca9533_waveshare_ws431e.dts
+++ b/target/linux/ath79/dts/qca9533_waveshare_ws431e.dts
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/input/input.h>
+#include "qca9533_qca_ap143.dtsi"
+
+/ {
+	model = "Waveshare WS-431E";
+	compatible = "waveshare,ws431e", "qca,ap143-16m", "qca,qca9533";
+
+	/* External watchdog on GPIO 3 */
+	ext_wdt: watchdog@0 {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio 3 GPIO_ACTIVE_HIGH>; /* GPIO 3 -> 515 */
+		hw_algo = "toggle";
+		hw_margin_ms = <30000>;
+		always-running;
+	};
+
+	/* OKLI virtual firmware partition spanning the vendor split */
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x0>;
+				label = "firmware";
+				compatible = "openwrt,uimage", "denx,uimage";
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+			};
+		};
+	};
+
+	/* LEDs: override AP143 layout with actual WS-431E wiring */
+	leds {
+		/* disable generic AP143 LEDs */
+		wan {
+			status = "disabled";
+		};
+
+		wlan {
+			status = "disabled";
+		};
+
+		wps {
+			status = "disabled";
+		};
+
+		lan4 {
+			status = "disabled";
+		};
+
+		lan3 {
+			status = "disabled";
+		};
+
+		lan2 {
+			status = "disabled";
+		};
+
+		lan1 {
+			status = "disabled";
+		};
+
+		/* 0 -> red:sys (2G+4G) */
+		led_sys_red: sys_red {
+			label = "red:sys";
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "none";
+		};
+
+		/* 1 -> blue:sys (3G+4G) */
+		led_sys_blue: sys_blue {
+			label = "blue:sys";
+			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "none";
+		};
+
+		/* 2 -> green:4g-low */
+		led_4g_low: lte_low {
+			label = "green:4g-low";
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "none";
+		};
+
+		/* 4 -> green:wan (WAN activity) */
+		led_wan: wan_led {
+			label = "green:wan";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "netdev";
+			trigger-sources = <&eth1>;
+		};
+
+
+		/* 14 -> green:4g-high */
+		led_4g_high: lte_high {
+			label = "green:4g-high";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "none";
+		};
+
+		/* 15 -> green:lan2 (switch0 portmask 0x04) */
+		led_lan2: lan2_led {
+			label = "green:lan2";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "switch0";
+			switch0-mask = <0x04>;
+			switch0-mode = "tx rx";
+		};
+
+		/* 16 -> green:lan1 (switch0 portmask 0x02) */
+		led_lan1: lan1_led {
+			label = "green:lan1";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "switch0";
+			switch0-mask = <0x02>;
+			switch0-mode = "tx rx";
+		};
+	};
+
+	/* Keys: single reset button on GPIO 17 */
+	keys {
+		compatible = "gpio-keys";
+
+		/* disable inherited WPS from AP143 */
+		wps {
+			status = "disabled";
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+			debounce-interval = <600>;
+		};
+	};
+};
+
+&partitions {
+	fwconcat0: partition@50000 {
+		label = "fwconcat0";
+		reg = <0x050000 0xe30000>;
+	};
+
+	partition@e80000 {
+		label = "loader";
+		reg = <0xe80000 0x10000>;
+	};
+
+	fwconcat1: partition@e90000 {
+		label = "fwconcat1";
+		reg = <0xe90000 0x160000>;
+	};
+
+	partition@ff0000 {
+		label = "art";
+		reg = <0xff0000 0x010000>;
+		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_art_0: macaddr@0 {
+				reg = <0x0 0x6>;
+			};
+
+			macaddr_art_6: macaddr@6 {
+				reg = <0x6 0x6>;
+			};
+
+			cal_art_1000: calibration@1000 {
+				reg = <0x1000 0x440>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wmac {
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <12>;
+		led-active-low;
+	};
+};
+
+&wdt {
+	status = "disabled";
+};
+
+/* GPIO hog to power the internal Quectel LTE modem */
+&gpio {
+	modem_enable: modem-enable {
+		gpio-hog;
+		gpios = <11 GPIO_ACTIVE_LOW>; /* GPIO 11 -> modem power */
+		output-high; /* modem enabled by default */
+		line-name = "modem-enable";
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -523,6 +523,16 @@ ubnt,uk-ultra)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "white:rssi2" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "white:rssi3" "wlan0" "76" "100"
 	;;
+waveshare,ws431e)
+	ucidef_set_led_default "sys_red"   "SYS Red"   "red:sys"         "0"
+	ucidef_set_led_default "sys_blue"  "SYS Blue"  "blue:sys"        "0"
+	ucidef_set_led_default "4g_low"    "4G low"    "green:4g-low"    "0"
+	ucidef_set_led_default "4g_high"   "4G high"   "green:4g-high"   "0"
+	ucidef_set_led_netdev  "wan"  "WAN"  "green:wan"  "eth1"   "link tx rx"
+	ucidef_set_led_switch  "lan1" "LAN1" "green:lan1" "switch0" "0x02"
+	ucidef_set_led_switch  "lan2" "LAN2" "green:lan2" "switch0" "0x04"
+	ucidef_set_led_wlan    "wlan" "WLAN" "green:wlan" "phy0tpt"
+        ;;
 wallys,dr531)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	ucidef_set_led_switch "wan" "WAN" "green:wan" "switch0" "0x2"
@@ -560,6 +570,7 @@ zbtlink,zbt-wd323)
 zyxel,nwa1100-nh)
 	ucidef_set_led_netdev "lan_data" "LAN_DATA" "amber:lan" "eth0" "tx rx"
 	ucidef_set_led_netdev "lan_link" "LAN_LINK" "green:lan" "eth0" "link"
+
 esac
 
 board_config_flush

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -3249,6 +3249,24 @@ define Device/watchguard_ap300
 endef
 TARGET_DEVICES += watchguard_ap300
 
+define Device/waveshare_ws431e
+  $(Device/qca_ap143)
+  DEVICE_VENDOR := Waveshare
+  DEVICE_MODEL := WS-431E
+  DEVICE_DTS := qca9533_waveshare_ws431e
+  DEVICE_PACKAGES += \
+	kmod-ath9k wpad-basic-mbedtls \
+	kmod-gpio-button-hotplug kmod-gpio-wdt \
+	kmod-leds-gpio kmod-ledtrig-default-on kmod-ledtrig-timer \
+	kmod-usb2 kmod-usb-ohci \
+	kmod-usb-net kmod-usb-net-qmi-wwan cdc-wdm \
+	kmod-usb-serial-option kmod-usb-serial-wwan uqmi
+  IMAGES += sysupgrade.bin
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
+  KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | loader-kernel | uImage none
+endef
+TARGET_DEVICES += waveshare_ws431e
+
 define Device/wd_mynet-n600
   $(Device/seama)
   SOC := ar9344


### PR DESCRIPTION
This PR adds full support for the Waveshare WS-431E, an LTE router based on the Qualcomm Atheros QCA9533 (AP143) platform.
Support includes Ethernet, WiFi, LTE/QMI modem, GPIO-controlled modem power, LEDs, reset button, and the vendor split-flash layout via OKLI.

---

## Hardware Overview

| Component   | Details |
|------------|---------|
| **SoC**    | Qualcomm Atheros QCA9533 @ 650 MHz |
| **RAM**    | 128 MiB |
| **Flash**  | 16 MiB SPI-NOR, vendor split layout |
| **WiFi**   | 2.4 GHz 802.11b/g/n (ath9k) |
| **Ethernet** | 1× WAN (eth1), 2× LAN (switch ports) |
| **LTE Modem** | Internal Quectel USB modem (QMI), power via GPIO 11 |
| **Buttons** | Reset (GPIO 17) |
| **LEDs** | sys-red, sys-blue, 4g-low, 4g-high, wan, wlan, lan1, lan2 |

---

## Flash Layout

The vendor firmware uses a two-piece kernel+rootfs layout.  
OpenWrt uses an **OKLI virtual firmware partition** backed by:

- `fwconcat0 @ 0x050000–0xE80000`
- `fwconcat1 @ 0xE90000–0xFF0000`

This allows OpenWrt to embed a standard sysupgrade image.

---

## Installation Notes

Serial console access is required.  
Interrupt U-Boot and load the initramfs image using:

```bash
setenv ipaddr 192.168.1.1
setenv serverip 192.168.1.2
tftpboot 0x81000000 openwrt-ath79-generic-waveshare_ws431e-initramfs-kernel.bin
bootm 0x81000000
```

**Note:**  
On the tested unit, the image was successfully booted from address **0x81000000**.  
If `bootm` reports a “bad magic number” at a different address, please check the
U-Boot environment (e.g. `printenv loadaddr`) and adjust the `tftpboot` address
accordingly.

Flashing via the stock firmware web UI has **not been tested** and may reject images due to size and OKLI header.

---

## GPIO Notes

- **GPIO 11** — powers the internal LTE modem (`gpio-hog`, `output-high`)
- **GPIO 17** — reset button  
- Inherited AP143 LEDs/WPS button are **disabled**
- All WS-431E LED mappings are provided in DTS and in `board.d/01_leds`

---

## Runtime Testing

Tested and working:

- ✔ LTE/QMI modem, power control and connectivity  
- ✔ Reset button functionality  
- ✔ All LEDs (WAN, LAN1/2, WLAN, SYS, LTE)  
- ✔ Ethernet switch, LAN/WAN ports  
- ✔ WiFi (ath9k)  
- ✔ Sysupgrade  
- ✔ OKLI firmware layout  
- ✔ Clean boot with no DTS warnings  

---

Please let me know if additional logs, boot dumps, or documentation would be useful.
