### PR TITLE
dropbear: add UCI option IdleTimeout

### DIFF
--- a/package/network/services/dropbear/files/dropbear.init
+++ b/package/network/services/dropbear/files/dropbear.init
@@ -300,6 +300,7 @@ dropbear_instance()
 	local pid_file="/var/run/${NAME}.${1}.pid"
 
 	procd_open_instance
+	config_get IdleTimeout "$section" IdleTimeout
 	procd_set_param command "$PROG" -F -P "$pid_file"
 	if [ -n "${iface}" ] ; then
 		# if ${iface} is non-empty then ${ndev} is non-empty too


### PR DESCRIPTION
Problem: IdleTimeout variable isn’t populated from UCI; -I is never applied.
• Change: Read IdleTimeout from /etc/config/dropbear via config_get in procd_start_instance(); pass -I accordingly.
• Usage example: 
option IdleTimeout '900' 
option IdleTimeout '0'
• Link: (https://github.com/openwrt/openwrt/issues/20992)
• Signed-off-by: Present in commit.

