### PR TITLE
odhcp6c: fix ip6ifaceid parameter

### DIFF
--- a/package/network/ipv6/odhcp6c/Makefile
+++ b/package/network/ipv6/odhcp6c/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=odhcp6c
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/odhcp6c.git


### PR DESCRIPTION
Commit 87fa17a91e9a started passing ip6ifaceid as a parameter to odhcpd6c, but ip6ifaceid can also contain special values such as "eui64" and "random", which aren't supported since odhcp6c expects an IPv6 address.

Fixes: 87fa17a91e9a ("odhcp6c: change dhcpv6.sh config option "ifaceid" to "ip6ifaceid"")

Closes https://github.com/openwrt/openwrt/issues/20976

CC @dave14305 @hnyman @lleachii @meiser79 @systemcrash 