### PR TITLE
mvebu: add missing gpios for regulator node of sdhci1 for GL-MV1000

### DIFF
--- a/target/linux/mvebu/patches-6.12/326-arm64-dts-marvell-add-missing-gpios-to-SD-regulator-.patch
+++ b/target/linux/mvebu/patches-6.12/326-arm64-dts-marvell-add-missing-gpios-to-SD-regulator-.patch
@@ -1,0 +1,30 @@
+From 9a71901c1bd11c1f119754c9f57b8dff7738fb65 Mon Sep 17 00:00:00 2001
+From: Stefan Kalscheuer <stefan@stklcode.de>
+Date: Sun, 30 Nov 2025 13:37:08 +0100
+Subject: [PATCH] arm64: dts: marvell: add missing gpios to SD regulator for
+ GL-MV1000
+
+GL-MV1000 external SD controller is broken because the referenced
+regulator node is missing a required GPIO property:
+
+    "regulator-gpio" was defined without required "gpios" property
+
+Configure GPIO pin 4 active high as it can be found in various vendor
+firmwares, so the regulator is properly defined and the SD controller
+can be initialized.
+
+Signed-off-by: Stefan Kalscheuer <stefan@stklcode.de>
+---
+ arch/arm64/boot/dts/marvell/armada-3720-gl-mv1000.dts | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/arch/arm64/boot/dts/marvell/armada-3720-gl-mv1000.dts
++++ b/arch/arm64/boot/dts/marvell/armada-3720-gl-mv1000.dts
+@@ -33,6 +33,7 @@
+ 		regulator-max-microvolt = <3300000>;
+ 		regulator-boot-on;
+ 
++		gpios = <&gpionb 4 GPIO_ACTIVE_HIGH>;
+ 		gpios-states = <0>;
+ 		states = <1800000 0x1
+ 			3300000 0x0>;


### PR DESCRIPTION
GL-MV1000 external SD controller is broken because the referenced regulator node is missing a required GPIO property:

> "regulator-gpio" was defined without required "gpios" property

Configure GPIO pin 4 active high as it can be found in various vendor firmwares, so the regulator is properly defined and the SD controller can be initialized.

Resolves issue: https://github.com/openwrt/openwrt/issues/20309 (issue is _24.10_, this PR is _main_)

Alternative approach to #20390 / #20378 (that one removes the regulator node)

I do not own such device, the fix is based on the available information. Compile-tested only.
On positive test feedback I would propose this fix upstream.

CC: @zador-blood-stained, @mrkiko

----

**Root cause:**

The node was never properly defined. Likely nobody noticed that, because the SD controller is configured with `no-1-8-v`, so the regulator never actually switches voltage.

Upstream commit [c9764fd](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=c9764fd88bc744592b0604ccb6b6fc1a5f76b4e3) introduces sanity checks for that, so the regulator is no longer initialized and the SD controller broken. This commit was backported to 6.12 and 6.6.97, so it is now broken on _24.10.3_ and _main_.
(analysis done by @zador-blood-stained, see referenced issue)

**References for the proposed GPIO values:**

* https://github.com/gl-inet/uboot-mv1000/blob/master/arch/arm/dts/armada-3720-espressobin.dts#L80
* https://github.com/gl-inet/mv1000-ubuntu-kernel/blob/master/arch/arm64/boot/dts/marvell/armada-3720-community.dts#L188

<details>
<summary>full extracted DTS from GL.iNet firmware 3.218</summary>

```
/dts-v1/;

/ {
	model = "GL.inet GL-MV1000";
	compatible = "gl-mv1000", "marvell,armada3720";
	interrupt-parent = <0x01>;
	#address-cells = <0x02>;
	#size-cells = <0x02>;

	aliases {
		ethernet0 = "/soc/internal-regs@d0000000/ethernet@30000";
		serial0 = "/soc/internal-regs@d0000000/serial@12000";
	};

	cpus {
		#address-cells = <0x01>;
		#size-cells = <0x00>;

		cpu@0 {
			device_type = "cpu";
			compatible = "arm,cortex-a53", "arm,armv8";
			reg = <0x00>;
			clocks = <0x02 0x10>;
			enable-method = "psci";
		};

		cpu@1 {
			device_type = "cpu";
			compatible = "arm,cortex-a53", "arm,armv8";
			reg = <0x01>;
			clocks = <0x02 0x10>;
			enable-method = "psci";
		};
	};

	psci {
		compatible = "arm,psci-0.2";
		method = "smc";
	};

	timer {
		compatible = "arm,armv8-timer";
		interrupts = <0x01 0x0d 0x04 0x01 0x0e 0x04 0x01 0x0b 0x04 0x01 0x0a 0x04>;
	};

	pmu {
		compatible = "arm,armv8-pmuv3";
		interrupts = <0x01 0x07 0x04>;
	};

	soc {
		compatible = "simple-bus";
		#address-cells = <0x02>;
		#size-cells = <0x02>;
		ranges;

		internal-regs@d0000000 {
			#address-cells = <0x01>;
			#size-cells = <0x01>;
			compatible = "simple-bus";
			ranges = <0x00 0x00 0xd0000000 0x2000000>;

			spi@10600 {
				compatible = "marvell,armada-3700-spi";
				#address-cells = <0x01>;
				#size-cells = <0x00>;
				reg = <0x10600 0xa00>;
				clocks = <0x02 0x07>;
				interrupts = <0x00 0x00 0x04>;
				num-cs = <0x04>;
				status = "okay";

				flash@0 {
					reg = <0x00>;
					compatible = "jedec,spi-nor";
					spi-max-frequency = <0x632ea00>;
					m25p,fast-read;

					partitions {
						compatible = "fixed-partitions";
						#address-cells = <0x01>;
						#size-cells = <0x01>;

						partition@0 {
							label = "u-boot";
							reg = <0x00 0xf0000>;
						};

						partition@f0000 {
							label = "u-boot-env";
							reg = <0xf0000 0x8000>;
						};

						partition@f8000 {
							label = "factory";
							reg = <0xf8000 0x8000>;
							linux,phandle = <0x08>;
							phandle = <0x08>;
						};
					};
				};
			};

			i2c@11000 {
				compatible = "marvell,armada-3700-i2c";
				reg = <0x11000 0x24>;
				#address-cells = <0x01>;
				#size-cells = <0x00>;
				clocks = <0x02 0x0a>;
				interrupts = <0x00 0x01 0x04>;
				mrvl,i2c-fast-mode;
				status = "disabled";
			};

			i2c@11080 {
				compatible = "marvell,armada-3700-i2c";
				reg = <0x11080 0x24>;
				#address-cells = <0x01>;
				#size-cells = <0x00>;
				clocks = <0x02 0x09>;
				interrupts = <0x00 0x02 0x04>;
				mrvl,i2c-fast-mode;
				status = "disabled";
			};

			serial@12000 {
				compatible = "marvell,armada-3700-uart";
				reg = <0x12000 0x200>;
				clocks = <0x03>;
				interrupts = <0x00 0x0b 0x04>;
				status = "okay";
			};

			nb-periph-clk@13000 {
				compatible = "marvell,armada-3700-periph-clock-nb";
				reg = <0x13000 0x100>;
				clocks = <0x04 0x00 0x04 0x01 0x04 0x02 0x04 0x03 0x03>;
				#clock-cells = <0x01>;
				linux,phandle = <0x02>;
				phandle = <0x02>;
			};

			sb-periph-clk@18000 {
				compatible = "marvell,armada-3700-periph-clock-sb";
				reg = <0x18000 0x100>;
				clocks = <0x04 0x00 0x04 0x01 0x04 0x02 0x04 0x03 0x03>;
				#clock-cells = <0x01>;
				linux,phandle = <0x07>;
				phandle = <0x07>;
			};

			tbg@13200 {
				compatible = "marvell,armada-3700-tbg-clock";
				reg = <0x13200 0x100>;
				clocks = <0x03>;
				#clock-cells = <0x01>;
				linux,phandle = <0x04>;
				phandle = <0x04>;
			};

			pinctrl@13800 {
				compatible = "marvell,armada3710-nb-pinctrl", "syscon", "simple-mfd";
				reg = <0x13800 0x100 0x13c00 0x20>;
				linux,phandle = <0x05>;
				phandle = <0x05>;

				gpio {
					#gpio-cells = <0x02>;
					gpio-ranges = <0x05 0x00 0x00 0x24>;
					gpio-controller;
					interrupts = <0x00 0x33 0x04 0x00 0x34 0x04 0x00 0x35 0x04 0x00 0x36 0x04 0x00 0x37 0x04 0x00 0x38 0x04 0x00 0x39 0x04 0x00 0x3a 0x04 0x00 0x98 0x04 0x00 0x99 0x04 0x00 0x9a 0x04 0x00 0x9b 0x04>;
					linux,phandle = <0x0d>;
					phandle = <0x0d>;
				};

				xtal-clk {
					compatible = "marvell,armada-3700-xtal-clock";
					clock-output-names = "xtal";
					#clock-cells = <0x00>;
					linux,phandle = <0x03>;
					phandle = <0x03>;
				};

				spi-quad-pins {
					groups = "spi_quad";
					function = "spi";
				};

				i2c1-pins {
					groups = "i2c1";
					function = "i2c";
				};

				i2c2-pins {
					groups = "i2c2";
					function = "i2c";
				};

				uart1-pins {
					groups = "uart1";
					function = "uart";
				};

				uart2-pins {
					groups = "uart2";
					function = "uart";
				};

				mmc-pins {
					groups = "emmc_nb";
					function = "emmc";
					linux,phandle = <0x10>;
					phandle = <0x10>;
				};
			};

			syscon@14000 {
				compatible = "marvell,armada-3700-nb-pm", "syscon";
				reg = <0x14000 0x60>;
			};

			pinctrl@18800 {
				compatible = "marvell,armada3710-sb-pinctrl", "syscon", "simple-mfd";
				reg = <0x18800 0x100 0x18c00 0x20>;
				linux,phandle = <0x06>;
				phandle = <0x06>;

				gpio {
					#gpio-cells = <0x02>;
					gpio-ranges = <0x06 0x00 0x00 0x1e>;
					gpio-controller;
					interrupts = <0x00 0xa0 0x04 0x00 0x9f 0x04 0x00 0x9e 0x04 0x00 0x9d 0x04 0x00 0x9c 0x04>;
				};

				mii-pins {
					groups = "rgmii";
					function = "mii";
				};

				sdio-pins {
					groups = "sdio_sb";
					function = "sdio";
					linux,phandle = <0x0f>;
					phandle = <0x0f>;
				};
			};

			ethernet@30000 {
				compatible = "marvell,armada-3700-neta";
				reg = <0x30000 0x4000>;
				interrupts = <0x00 0x2a 0x04>;
				clocks = <0x07 0x08>;
				status = "okay";
				mtd-mac-address = <0x08 0x00>;
				phy-mode = "rgmii-id";
				linux,phandle = <0x09>;
				phandle = <0x09>;

				fixed-link {
					speed = <0x3e8>;
					full-duplex;
				};
			};

			mdio@32004 {
				#address-cells = <0x01>;
				#size-cells = <0x00>;
				compatible = "marvell,orion-mdio";
				reg = <0x32004 0x04>;

				switch0@1 {
					compatible = "marvell,mv88e6085";
					#address-cells = <0x01>;
					#size-cells = <0x00>;
					reg = <0x01>;
					dsa,member = <0x00 0x00>;

					ports {
						#address-cells = <0x01>;
						#size-cells = <0x00>;

						port@0 {
							reg = <0x00>;
							label = "cpu";
							ethernet = <0x09>;
						};

						port@1 {
							reg = <0x01>;
							label = "wan";
							phy-handle = <0x0a>;
						};

						port@2 {
							reg = <0x02>;
							label = "lan0";
							phy-handle = <0x0b>;
						};

						port@3 {
							reg = <0x03>;
							label = "lan1";
							phy-handle = <0x0c>;
						};
					};

					mdio {
						#address-cells = <0x01>;
						#size-cells = <0x00>;

						switch0phy0@11 {
							reg = <0x11>;
							linux,phandle = <0x0a>;
							phandle = <0x0a>;
						};

						switch0phy1@12 {
							reg = <0x12>;
							linux,phandle = <0x0b>;
							phandle = <0x0b>;
						};

						switch0phy2@13 {
							reg = <0x13>;
							linux,phandle = <0x0c>;
							phandle = <0x0c>;
						};
					};
				};
			};

			ethernet@40000 {
				compatible = "marvell,armada-3700-neta";
				reg = <0x40000 0x4000>;
				interrupts = <0x00 0x2d 0x04>;
				clocks = <0x07 0x07>;
				status = "disabled";
			};

			usb@58000 {
				compatible = "marvell,armada3700-xhci", "generic-xhci";
				reg = <0x58000 0x4000>;
				interrupts = <0x00 0x03 0x04>;
				clocks = <0x07 0x0c>;
				status = "okay";
			};

			usb@5e000 {
				compatible = "marvell,armada-3700-ehci";
				reg = <0x5e000 0x2000>;
				interrupts = <0x00 0x11 0x04>;
				status = "okay";
			};

			u3d@50000 {
				compatible = "marvell,armada3700-u3d";
				reg = <0x50000 0x2000>;
				interrupts = <0x00 0x0f 0x04>;
				clocks = <0x07 0x0c>;
				status = "okay";
			};

			udc@54100 {
				compatible = "marvell,mv-udc";
				reg = <0x54100 0x2000>;
				interrupts = <0x00 0x0f 0x04>;
				clocks = <0x07 0x0c>;
				status = "okay";
			};

			xor@60900 {
				compatible = "marvell,armada-3700-xor";
				reg = <0x60900 0x100 0x60b00 0x100>;

				xor10 {
					interrupts = <0x00 0x2f 0x04>;
				};

				xor11 {
					interrupts = <0x00 0x30 0x04>;
				};
			};

			sdhci@d0000 {
				compatible = "marvell,armada-3700-sdhci", "marvell,sdhci-xenon";
				reg = <0xd0000 0x300 0x1e808 0x04>;
				interrupts = <0x00 0x19 0x04>;
				clocks = <0x02 0x00>;
				clock-names = "core";
				status = "okay";
				wp-inverted;
				bus-width = <0x04>;
				cd-gpios = <0x0d 0x11 0x01>;
				marvell,pad-type = "sd";
				no-1-8-v;
				vqmmc-supply = <0x0e>;
				pinctrl-names = "default";
				pinctrl-0 = <0x0f>;
			};

			sdhci@d8000 {
				compatible = "marvell,armada-3700-sdhci", "marvell,sdhci-xenon";
				reg = <0xd8000 0x300 0x17808 0x04>;
				interrupts = <0x00 0x1a 0x04>;
				clocks = <0x02 0x00>;
				clock-names = "core";
				status = "okay";
				bus-width = <0x08>;
				mmc-ddr-1_8v;
				mmc-hs400-1_8v;
				non-removable;
				no-sd;
				no-sdio;
				marvell,pad-type = "fixed-1-8v";
				pinctrl-names = "default";
				pinctrl-0 = <0x10>;
			};

			sata@e0000 {
				compatible = "marvell,armada-3700-ahci";
				reg = <0xe0000 0x2000>;
				interrupts = <0x00 0x1b 0x04>;
				status = "disabled";
			};

			interrupt-controller@1d00000 {
				compatible = "arm,gic-v3";
				#interrupt-cells = <0x03>;
				interrupt-controller;
				reg = <0x1d00000 0x10000 0x1d40000 0x40000 0x1d80000 0x2000 0x1d90000 0x2000 0x1da0000 0x20000>;
				interrupts = <0x01 0x09 0x04>;
				linux,phandle = <0x01>;
				phandle = <0x01>;
			};
		};

		pcie@d0070000 {
			compatible = "marvell,armada-3700-pcie";
			device_type = "pci";
			status = "disabled";
			reg = <0x00 0xd0070000 0x00 0x20000>;
			#address-cells = <0x03>;
			#size-cells = <0x02>;
			bus-range = <0x00 0xff>;
			interrupts = <0x00 0x1d 0x04>;
			#interrupt-cells = <0x01>;
			msi-parent = <0x11>;
			msi-controller;
			ranges = <0x82000000 0x00 0xe8000000 0x00 0xe8000000 0x00 0x1000000 0x81000000 0x00 0xe9000000 0x00 0xe9000000 0x00 0x10000>;
			interrupt-map-mask = <0x00 0x00 0x00 0x07>;
			interrupt-map = <0x00 0x00 0x00 0x01 0x12 0x00 0x00 0x00 0x00 0x02 0x12 0x01 0x00 0x00 0x00 0x03 0x12 0x02 0x00 0x00 0x00 0x04 0x12 0x03>;
			linux,phandle = <0x11>;
			phandle = <0x11>;

			interrupt-controller {
				interrupt-controller;
				#interrupt-cells = <0x01>;
				linux,phandle = <0x12>;
				phandle = <0x12>;
			};
		};
	};

	chosen {
		stdout-path = "serial0:115200n8";
	};

	memory@0 {
		device_type = "memory";
		reg = <0x00 0x00 0x00 0x20000000>;
	};

	regulator {
		compatible = "regulator-gpio";
		regulator-name = "vcc_sd1";
		regulator-min-microvolt = <0x1b7740>;
		regulator-max-microvolt = <0x325aa0>;
		regulator-boot-on;
		gpios = <0x0d 0x04 0x00>;
		gpios-states = <0x00>;
		states = <0x1b7740 0x01 0x325aa0 0x00>;
		enable-active-high;
		linux,phandle = <0x0e>;
		phandle = <0x0e>;
	};

	leds {
		compatible = "gpio-leds";

		led@487 {
			label = "gl-mv1000:green:vpn";
			gpios = <0x0d 0x0b 0x01>;
			default-state = "off";
		};

		led@488 {
			label = "gl-mv1000:green:wifi";
			gpios = <0x0d 0x0c 0x01>;
			default-state = "off";
		};

		led@489 {
			label = "gl-mv1000:green:power";
			gpios = <0x0d 0x0d 0x01>;
			default-state = "on";
		};
	};
};
```
</details>
