### PR TITLE
target: add dumbap DEVICE_TYPE

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -39,6 +39,11 @@ DEFAULT_PACKAGES:=\
 ##
 DEFAULT_PACKAGES.basic:=
 ##@
+# @brief Default packages for @DEVICE_TYPE dumbap.
+##
+DEFAULT_PACKAGES.dumbap:=\
+	odhcp6c
+##@
 # @brief Default packages for @DEVICE_TYPE nas.
 ##
 DEFAULT_PACKAGES.nas:=\


### PR DESCRIPTION
On a dumb AP, having a static IP and DHCP server enabled by default is not a great user experience. If the user's subnet is the same as our default static IP, there is a good chance our IP will conflict with the user's default gateway. If the user's subnet is different, existing clients might be assigned an IP by our DHCP server, resulting in the client losing connectivity. Additionally, the user will have to configure a static IP in a different range to be able to login to the AP and change the IP configuration. All of this can be avoided by shipping images for dump APs without dnsmasq and odhcpd, and defaulting the only interface in such AP to request an IP via DHCP, as many OEM firmwares do.

Add a new DEVICE_TYPE dumbap that only includes odhcp6c on top of DEFAULT_PACKAGES.basic. An IPv4 DHCP client (udhcpc) is enabled by default in busybox.