### PR TITLE
realtek: support Teltonika TSW202

### DIFF
--- a/target/linux/realtek/dts/rtl8380_teltonika_tsw202.dts
+++ b/target/linux/realtek/dts/rtl8380_teltonika_tsw202.dts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl838x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "teltonika,tsw202", "realtek,rtl838x-soc";
+	model = "Teltonika TSW202 Switch";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x8000000>;
+	};
+
+	/* i2c of the left SFP cage: port 9 */
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		mod-def0-gpio = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio =  <&gpio0 10 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c of the right SFP cage: port 10 */
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 14 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		mod-def0-gpio = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c for poe */
+	i2c2: i2c-gpio-2 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 5 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "u-boot-env";
+				reg = <0x80000 0x10000>;
+				read-only;
+			};
+
+			partition@90000 {
+				label = "config";
+				reg = <0x90000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_config_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
+			};
+
+			partition@a0000 {
+				label = "firmware";
+				reg = <0xa0000 0xf60000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+			};
+		};
+	};
+};
+
+&uart1 {
+	status = "okay";
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_config_0 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_bus0 {
+	PHY_C22(8, 8)
+	PHY_C22(9, 9)
+	PHY_C22(10, 10)
+	PHY_C22(11, 11)
+	PHY_C22(12, 12)
+	PHY_C22(13, 13)
+	PHY_C22(14, 14)
+	PHY_C22(15, 15)
+};
+
+&switch0 {
+	ethernet-ports {
+
+		SWITCH_PORT(8, 1, internal)
+		SWITCH_PORT(9, 2, internal)
+		SWITCH_PORT(10, 3, internal)
+		SWITCH_PORT(11, 4, internal)
+		SWITCH_PORT(12, 5, internal)
+		SWITCH_PORT(13, 6, internal)
+		SWITCH_PORT(14, 7, internal)
+		SWITCH_PORT(15, 8, internal)
+		SWITCH_PORT_SFP(24,  9, 4, 0, 0)
+		SWITCH_PORT_SFP(26, 10, 5, 0, 1)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+
+	};
+};

--- a/target/linux/realtek/image/rtl838x.mk
+++ b/target/linux/realtek/image/rtl838x.mk
@@ -326,6 +326,22 @@ define Device/panasonic_m8eg-pn28080k
 endef
 TARGET_DEVICES += panasonic_m8eg-pn28080k
 
+define Device/teltonika_tsw202
+  SOC := rtl8380
+  IMAGE_SIZE := 15168k
+  DEVICE_VENDOR := Teltonika
+  DEVICE_MODEL := TSW202
+  IMAGE/sysupgrade.bin := \
+  	append-kernel | \
+	pad-to 64k | \
+	append-rootfs | \
+	pad-rootfs | \
+	check-size | \
+	append-metadata
+  SUPPORTED_DEVICES := teltonika,tsw202
+endef
+TARGET_DEVICES += teltonika_tsw202
+
 define Device/tplink_sg2008p-v1
   SOC := rtl8380
   KERNEL_SIZE := 6m


### PR DESCRIPTION
Add support for TSW202 PoE switch. This is an RTL8380 based switch with two SFP slots, and 8 PoE 802.3af one every RJ-45 port.

The max budget is 240W.
The vendor firmware configures the PSE
with a per-port budget of 30.0W.

Specifications:
---------------
* SoC:       Realtek RTL8380M
* Flash:     16 MiB SPI NOR W25Q80RV, 8Mb_Serial_Flash, low_power
* RAM:       128 MiB Winbond W631GG8NB 151
* Ethernet:  8x 10/100/1000 Mbps with PoE
             2x SFP slots
* Buttons:   1 "Reset" button on front panel
* Power:     48V-54V DC barrel jack
* UART:      1 serial header with terminal on the back side.
             With ground, rx, tx, and 3.3V
* PoE:       2 XS2184
* LED:       2 i2c SL74HC164

Works:
------
  - (8) RJ-45 ethernet ports
  - (2) SFP with ethernet or fiber
  - Switch functions
  - LEDs and buttons
  - Power-over-Ethernet

Install via web interface:
-------------------------

The openwrt firmware will not accept and flash the sysupgrade image.

It is recommended to flash with sysupgrade -n -f over ssh.

For POE the xs2184-tsw202 package must be installed.

Dokumantation, Bootlogs, and Fotos can be found on

https://git.f2a.space/patrick/openwrt-24.10-tsw202/-/wikis/home
