### PR TITLE
[24.10] ramips: add support for Hongdian H8850 v20

### DIFF
--- a/target/linux/ramips/dts/mt7628an_hongdian_h8850-v20.dts
+++ b/target/linux/ramips/dts/mt7628an_hongdian_h8850-v20.dts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "hongdian,h8850-v20", "mediatek,mt7628an-soc";
+	model = "Hongdian H8850 v20";
+
+	aliases {
+		led-boot = &led_net;
+		led-failsafe = &led_net;
+		led-running = &led_net;
+		led-upgrade = &led_net;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-rf {
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = "rf";
+		};
+
+		led_net: led-net {
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_MOBILE;
+		};
+
+		led-wifi {
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+
+		gpios = <&gpio 0 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <600>;
+		always-running;
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_modem_power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <1>;
+			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&watchdog {
+	status = "disabled";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "i2c", "spi cs1", "gpio", "perst", "refclk", "wdt", "p4led_an", "wled_an";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x30>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -347,6 +347,15 @@ define Device/hongdian_h7920-v40
 endef
 TARGET_DEVICES += hongdian_h7920-v40
 
+define Device/hongdian_h8850-v20
+  IMAGE_SIZE := 16064k
+  DEVICE_VENDOR := Hongdian
+  DEVICE_MODEL := H8850
+  DEVICE_VARIANT := v20
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+endef
+TARGET_DEVICES += hongdian_h8850-v20
+
 define Device/iptime_a3
   IMAGE_SIZE := 7936k
   UIMAGE_NAME := a3

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -117,6 +117,12 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "4:wan" "6@eth0"
 		;;
+	hongdian,h8850-v20|\
+	keenetic,kn-1613|\
+	motorola,mwr03)
+		ucidef_add_switch "switch0" \
+			"1:lan" "2:lan" "3:lan" "0:wan" "6@eth0"
+		;;
 	iptime,a3|\
 	totolink,a3)
 		ucidef_add_switch "switch0" \
@@ -131,11 +137,6 @@ ramips_setup_interfaces()
 	jotale,js76x8-32m)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "6@eth0"
-		;;
-	keenetic,kn-1613|\
-	motorola,mwr03)
-		ucidef_add_switch "switch0" \
-			"1:lan" "2:lan" "3:lan" "0:wan" "6@eth0"
 		;;
 	kroks,kndrt31r19)
 		ucidef_add_switch "switch0" \
@@ -260,6 +261,7 @@ ramips_setup_macs()
 		;;
 	duzun,dm06|\
 	hongdian,h7920-v40|\
+	hongdian,h8850-v20|\
 	netgear,r6020|\
 	netgear,r6080|\
 	netgear,r6120|\

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/03_gpio_switches
@@ -13,6 +13,9 @@ hongdian,h7920-v40)
 	ucidef_add_gpio_switch "modem_enable" "Modem power" "modem_power" "1"
 	ucidef_add_gpio_switch "switch_serial_mode" "Switch RS232 to RS485" "serial_rs485_mode" "0"
 	;;
+hongdian,h8850-v20)
+	ucidef_add_gpio_switch "modem_enable" "Modem power" "modem_power" "1"
+	;;
 esac
 
 board_config_flush


### PR DESCRIPTION
Backport from #20259 

---

This is an industrial 4G router equipped with OpenWrt SNAPSHOT OEM customized version

WARNING: The original firmware device tree is modified from evb boards, and the device tree name is evb board. This submitted device tree is a modified version, which deletes the non-this-device parts and adds GPIO watchdog.

Specification:
- SoC: MediaTek MT7628DAN
- Flash: 16 MB
- RAM: 64 MB
- Power: DC 5V-36V 1.5A
- Ethernet: 1x WAN/LAN, 3x LAN (10/100 Mbps)
- Wireless radio: 802.11n 2.4g-only
- LED: System/Power (PWR): Always Off Modem (NET): GPIO/3 active-low LAN: Always On RF (Modem Signal): GPIO/2 active-low WIFI: GPIO/44 active-low
- Button: WPS / RESET: GPIO/11 active-low
- UART: 1x UART on PCB - 115200 8N1
- GPIO Watchdog: GPIO/0 mode=toggle timeout=1s
- Modem: 1x Built-in modem on board (Power: GPIO/4 active-high)
- SIM Slots: 1x SIM Slots

Issue:
- Factory partition not store mac address on original firmware

Flash instruction:
Using TTL:
1. Connect the board to the computer via TTL.
2. Enter original firmware failsafe mode.
3. Use wget download firmware to board /tmp
4. Use command "mtd -r write openwrt-ramips-mt76x8-hongdian_h8850-v20-squashfs-sysupgrade.bin firmware" to flash

Original Firmware Dump / More details:
https://blog.gov.cooking/archives/research-hongdian-h8850-v20-and-flash.html
