### PR TITLE
ath79: add back mistakenly removed label

### DIFF
--- a/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
+++ b/target/linux/ath79/dts/ar9344_openmesh_mr600.dtsi
@@ -138,7 +138,7 @@
 &pcie {
 	status = "okay";
 
-	wifi@0,0 {
+	ath9k: wifi@0,0 {
 		compatible = "pci168c,0030";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&macaddr_art_0 8>, <&calibration_art_5000>;


### PR DESCRIPTION
Fixes: 592d4e6 ("ath79: mr600-v1: use led-sources for ath9k")

ping @hauke 