### PR TITLE
realtek: dsa: rtl930x: Fix flow control with ingress shaping

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -208,9 +208,13 @@ static int rtldsa_930x_port_rate_police_add(struct dsa_switch *ds, int port,
 	if (ingress) {
 		burst = min_t(u32, act->police.burst, RTL930X_BANDWIDTH_CTRL_INGRESS_BURST_MAX);
 
-		/* set burst high on/off the same to avoid TCP oscillation */
+		/* the linux kernel only provides a single burst value. But the
+		 * realtek HW needs two. And to get flow control correctly
+		 * working, the realtek default ratio of 1:2 seems to work
+		 * reasonable well
+		 */
 		sw_w32(burst, RTL930X_BANDWIDTH_CTRL_INGRESS_BURST_HIGH_ON(port));
-		sw_w32(burst, RTL930X_BANDWIDTH_CTRL_INGRESS_BURST_HIGH_OFF(port));
+		sw_w32(burst / 2, RTL930X_BANDWIDTH_CTRL_INGRESS_BURST_HIGH_OFF(port));
 
 		/* Enable ingress bandwidth flow control to improve TCP throughput and avoid
 		 * the drops behavior of the RTL930x ingress rate limiter which seem to not


### PR DESCRIPTION
Tests with ingress shaping and enabled flow control showed really high packet loss. It seems like the MAC pause frames are not created correctly when both burst high off is set to the same value as burst high on.

By default, RTL930x has set the burst high values to:

* on: 64K
* off: 32K

Using the same 1:2 ratio seems to solve the high packet loss rate during UDP tests.

Fixes: 2e74eb6d93a7 ("realtek: dsa: rtl93xx: Support per port throttling")

---

Here are some logs I got from the packet loss test. Expected were ~0% packet loss:

```
Server cmd: iperf3 -s --bind-dev enp6s0
Client cmd: iperf3 -c 192.168.80.139 --bind-dev enp5s0 -t 15 -i 1 -P 1 -u -b 100M

Iperf server: 
-----------------------------------------------------------
Server listening on 5201 (test #1)
-----------------------------------------------------------
Accepted connection from 192.168.80.138, port 47536
[  5] local 192.168.80.139 port 5201 connected to 192.168.80.138 port 47619
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-1.00   sec  1.22 MBytes  10.2 Mbits/sec  1.256 ms  25/908 (2.8%)  
[  5]   1.00-2.00   sec  1.15 MBytes  9.68 Mbits/sec  1.494 ms  76/912 (8.3%)  
[  5]   2.00-3.00   sec  1.15 MBytes  9.68 Mbits/sec  2.083 ms  125/961 (13%)  
[  5]   3.00-4.00   sec  1.15 MBytes  9.68 Mbits/sec  2.249 ms  175/1011 (17%)  
[  5]   4.00-5.00   sec  1.16 MBytes  9.73 Mbits/sec  0.457 ms  226/1066 (21%)  
[  5]   5.00-6.00   sec  1.15 MBytes  9.69 Mbits/sec  2.314 ms  275/1111 (25%)  
[  5]   6.00-7.00   sec  1.15 MBytes  9.68 Mbits/sec  1.370 ms  326/1162 (28%)  
[  5]   7.00-8.00   sec  1.15 MBytes  9.68 Mbits/sec  1.278 ms  375/1211 (31%)  
[  5]   8.00-9.00   sec  1.16 MBytes  9.70 Mbits/sec  1.494 ms  425/1262 (34%)  
[  5]   9.00-10.00  sec  1.16 MBytes  9.71 Mbits/sec  2.299 ms  477/1315 (36%)  
[  5]  10.00-11.00  sec  1.15 MBytes  9.68 Mbits/sec  2.236 ms  525/1361 (39%)  
[  5]  11.00-12.00  sec  1.15 MBytes  9.68 Mbits/sec  1.057 ms  575/1411 (41%)  
[  5]  12.00-13.00  sec  1.16 MBytes  9.73 Mbits/sec  0.289 ms  629/1469 (43%)  
[  5]  13.00-14.00  sec  1.15 MBytes  9.68 Mbits/sec  1.045 ms  675/1511 (45%)  
[  5]  14.00-15.00  sec  1.15 MBytes  9.68 Mbits/sec  2.344 ms  726/1562 (46%)  
[  5]  15.00-15.04  sec  50.9 KBytes  9.31 Mbits/sec  2.344 ms  32/68 (47%)  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-15.04  sec  17.4 MBytes  9.73 Mbits/sec  2.344 ms  5667/18301 (31%)  receiver

Iperf client: Connecting to host 192.168.80.139, port 5201
[  5] local 192.168.80.138 port 47619 connected to 192.168.80.139 port 5201
[ ID] Interval           Transfer     Bitrate         Total Datagrams
[  5]   0.00-1.00   sec  1.36 MBytes  11.4 Mbits/sec  984  
[  5]   1.00-2.00   sec  1.26 MBytes  10.6 Mbits/sec  912  
[  5]   2.00-3.00   sec  1.33 MBytes  11.2 Mbits/sec  964  
[  5]   3.00-4.00   sec  1.40 MBytes  11.7 Mbits/sec  1013  
[  5]   4.00-5.00   sec  1.47 MBytes  12.4 Mbits/sec  1068  
[  5]   5.00-6.00   sec  1.54 MBytes  12.9 Mbits/sec  1114  
[  5]   6.00-7.00   sec  1.61 MBytes  13.5 Mbits/sec  1163  
[  5]   7.00-8.00   sec  1.68 MBytes  14.1 Mbits/sec  1214  
[  5]   8.00-9.00   sec  1.75 MBytes  14.7 Mbits/sec  1265  
[  5]   9.00-10.00  sec  1.82 MBytes  15.2 Mbits/sec  1316  
[  5]  10.00-11.00  sec  1.88 MBytes  15.8 Mbits/sec  1363  
[  5]  11.00-12.00  sec  1.95 MBytes  16.4 Mbits/sec  1414  
[  5]  12.00-13.00  sec  2.03 MBytes  17.0 Mbits/sec  1471  
[  5]  13.00-14.00  sec  2.09 MBytes  17.5 Mbits/sec  1513  
[  5]  14.00-15.00  sec  2.16 MBytes  18.1 Mbits/sec  1563  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
[  5]   0.00-15.00  sec  25.3 MBytes  14.2 Mbits/sec  0.000 ms  0/18337 (0%)  sender
[  5]   0.00-15.04  sec  17.4 MBytes  9.73 Mbits/sec  2.344 ms  5667/18301 (31%)  receiver

iperf Done.

0: Bitrate: 9680000.0 Bits/sec, Lost: 31.0%

```