### PR TITLE
scripts/kernel_bump: adjust commit messages

### DIFF
--- a/scripts/kernel_bump.sh
+++ b/scripts/kernel_bump.sh
@@ -162,14 +162,14 @@ bump_kernel()
 
 	git commit \
 		--signoff \
-		--message "kernel/${platform_name}: Create kernel files for v${target_version} (from v${source_version})" \
+		--message "kernel/${platform_name}: create files for v${target_version} (from v${source_version})" \
 		--message 'This is an automatically generated commit.' \
 		--message 'When doing `git bisect`, consider `git bisect --skip`.'
 
 	git checkout 'HEAD~' "${_target_dir}"
 	git commit \
 		--signoff \
-		--message "kernel/${platform_name}: Restore kernel files for v${source_version}" \
+		--message "kernel/${platform_name}: restore files for v${source_version}" \
 		--message "$(printf "This is an automatically generated commit which aids following Kernel patch\nhistory, as git will see the move and copy as a rename thus defeating the\npurpose.\n\nFor the original discussion see:\nhttps://lists.openwrt.org/pipermail/openwrt-devel/2023-October/041673.html")"
 	git switch "${initial_branch:?Unable to switch back to original branch. Quitting.}"
 	GIT_EDITOR=true git merge --no-ff '__openwrt_kernel_files_mover'


### PR DESCRIPTION
Due to the recent changes with the formality checks `kernel_bump` commit messages no-longer pass them.

Adjust these messages to follow the updated checks:
- start the first word after prefix with lower-case
- reduce the overall subject length by removing the redundant 'kernel'

cc: @namiltd, @oliv3r 