### PR TITLE
airoha: an7581: add switch ports interrups

### DIFF
--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -929,7 +929,7 @@
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			interrupt-parent = <&gic>;
-			interrupts = <GIC_SPI 209 IRQ_TYPE_LEVEL_HIGH>;
+			interrupts = <GIC_SPI 31 IRQ_TYPE_LEVEL_HIGH>;
 
 			status = "disabled";
 
@@ -988,6 +988,7 @@
 				gsw_phy1: ethernet-phy@9 {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <9>;
+					interrupts = <1>;
 					phy-mode = "internal";
 					status = "disabled";
 
@@ -1010,6 +1011,7 @@
 				gsw_phy2: ethernet-phy@a {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <10>;
+					interrupts = <2>;
 					phy-mode = "internal";
 					status = "disabled";
 
@@ -1032,6 +1034,7 @@
 				gsw_phy3: ethernet-phy@b {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <11>;
+					interrupts = <3>;
 					phy-mode = "internal";
 					status = "disabled";
 
@@ -1054,6 +1057,7 @@
 				gsw_phy4: ethernet-phy@c {
 					compatible = "ethernet-phy-ieee802.3-c22";
 					reg = <12>;
+					interrupts = <4>;
 					phy-mode = "internal";
 					status = "disabled";
 

--- a/target/linux/airoha/patches-6.12/610-v7.0-net-phy-mediatek-enable-interrupts-on-AN7581.patch
+++ b/target/linux/airoha/patches-6.12/610-v7.0-net-phy-mediatek-enable-interrupts-on-AN7581.patch
@@ -1,0 +1,27 @@
+From 2e229771543b2b20e1fe29da00df80c917469449 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Fri, 2 Jan 2026 12:30:06 +0100
+Subject: [PATCH] net: phy: mediatek: enable interrupts on AN7581
+
+Interrupts work just like on MT7988.
+
+Suggested-by: Benjamin Larsson <benjamin.larsson@genexis.eu>
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Link: https://patch.msgid.link/20260102113222.3519900-1-olek2@wp.pl
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/mediatek/mtk-ge-soc.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/net/phy/mediatek/mtk-ge-soc.c
++++ b/drivers/net/phy/mediatek/mtk-ge-soc.c
+@@ -1492,6 +1492,8 @@ static struct phy_driver mtk_socphy_driv
+ 	{
+ 		PHY_ID_MATCH_EXACT(MTK_GPHY_ID_AN7581),
+ 		.name		= "Airoha AN7581 PHY",
++		.config_intr	= genphy_no_config_intr,
++		.handle_interrupt = genphy_handle_interrupt_no_ack,
+ 		.probe		= an7581_phy_probe,
+ 		.led_blink_set	= mt798x_phy_led_blink_set,
+ 		.led_brightness_set = mt798x_phy_led_brightness_set,


### PR DESCRIPTION
The MT7531 has an incorrect interrupt number described in the DTS. This commit also adds PHY interrupts. They work the same as on the MT7988.

Tested on Gemtek W1700k.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
