### PR TITLE
ath79: moxa,awk-1137c: use nvmem for calibration

### DIFF
--- a/target/linux/ath79/dts/ar9344_moxa_awk-1137c.dts
+++ b/target/linux/ath79/dts/ar9344_moxa_awk-1137c.dts
@@ -49,25 +49,17 @@
 
 		led-2 {
 			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_WLAN;
-			function-enumerator = <0>;
-			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
-		};
-
-		led-3 {
-			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WAN;
 			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
 		};
 
-		led-4 {
+		led-3 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_LAN;
 			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 
-		led-5 {
+		led-4 {
 			color = <LED_COLOR_ID_YELLOW>;
 			function = LED_FUNCTION_WLAN;
 			function-enumerator = <1>;
@@ -157,6 +149,16 @@
 				label = "art";
 				reg = <0xfe0000 0x010000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+				};
 			};
 
 			partition@ff0000 {
@@ -174,5 +176,12 @@
 
 &wmac {
 	status = "okay";
-	qca,no-eeprom;
+
+	nvmem-cells = <&cal_art_1000>;
+	nvmem-cell-names = "calibration";
+
+	led {
+		led-sources = <12>;
+		led-active-low;
+	};
 };

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
@@ -15,10 +15,6 @@ case "$FIRMWARE" in
 	avm,fritzdvbc)
 		caldata_extract_reverse "urlader" 0x1541 0x440
 		;;
-	moxa,awk-1137c)
-		caldata_extract "art" 0x1000 0x440
-		ath9k_patch_mac $(mtd_get_mac_ascii u-boot-env mac_addr)
-		;;
 	*)
 		caldata_die "board $board is not supported yet"
 		;;

--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -80,6 +80,10 @@ case "$board" in
 		# which would allow to patch the macaddress
 		macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" $PHYNBR > /sys${DEVPATH}/macaddress
 		;;
+	moxa,awk-1137c)
+		[ "$PHYNBR" -eq 0 ] && \
+			mtd_get_mac_ascii u-boot-env mac_addr > /sys${DEVPATH}/macaddress
+		;;
 	dlink,dir-842-c1|\
 	dlink,dir-842-c2|\
 	dlink,dir-842-c3|\


### PR DESCRIPTION
Userspace handling is deprecated.

Use led-sources for simplicity.