### PR TITLE
ath79: fix platform check image mikrotik nor

### DIFF
--- a/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ath79/mikrotik/base-files/lib/upgrade/platform.sh
@@ -6,7 +6,7 @@ REQUIRE_IMAGE_METADATA=1
 
 platform_check_image_mikrotik_nor() {
 	local bootfwver bootfwmajor
-	local bootentry="$(dd bs=10 skip=1 count=1 if="$1" 2>/dev/null | xargs -0)"
+	local bootentry="$(dd bs=10 skip=1 count=1 if="$1" 2>/dev/null | xargs)"
 
 	read -r bootfwver < /sys/firmware/mikrotik/hard_config/booter_version
 	bootfwmajor="${bootfwver%%.*}"


### PR DESCRIPTION
Every attempt to update a device with NOR flash and RouterBOOT v6 resulted in the error: 
> RouterBOOT 6 and earlier requires ELF-in-YAFFS image.

The cause is that xargs do not fully removed whitespace, so the condition `"$bootentry" != "kernel"` always evaluated to true.
`$bootentry` get value:
```shell
dd bs=10 skip=1 count=1 if="openwrt-ath79-mikrotik-mikrotik_routerboard-962uigs-5hact2hnt-squashfs-sysupgrade.bin" 2>/dev/null | xargs -0 | hexdump -C
00000000  6b 65 72 6e 65 6c 20 20  20 0a                    |kernel   .|
0000000a
``` 

Fixed:
```shell
dd bs=10 skip=1 count=1 if="openwrt-ath79-mikrotik-mikrotik_routerboard-962uigs-5hact2hnt-squashfs-sysupgrade.bin" 2>/dev/null | xargs | hexdump -C
00000000  6b 65 72 6e 65 6c 0a                              |kernel.|
00000007
``` 
##
Tested on 962uigs-5hact2hnt
Fixes: #20995 
Releated: https://github.com/openwrt/openwrt/issues/20144