### PR TITLE
ath79: fix label-mac-device for wmac

### DIFF
--- a/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
+++ b/target/linux/ath79/dts/ar7242_avm_fritz300e.dts
@@ -15,7 +15,6 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
-		label-mac-device = &ath9k;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/ar9331_alfa-network_ap121f.dtsi
+++ b/target/linux/ath79/dts/ar9331_alfa-network_ap121f.dtsi
@@ -109,6 +109,10 @@
 					macaddr_art_0: macaddr@0 {
 						reg = <0x0 0x6>;
 					};
+
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
 				};
 			};
 
@@ -132,8 +136,8 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002>;
+	nvmem-cell-names = "calibration", "mac-address";
 
 	led {
 		led-sources = <0>;

--- a/target/linux/ath79/dts/ar9331_hak5_wifi-pineapple-nano.dts
+++ b/target/linux/ath79/dts/ar9331_hak5_wifi-pineapple-nano.dts
@@ -116,6 +116,10 @@
 					cal_art_1000: calibration@1000 {
 						reg = <0x1000 0x440>;
 					};
+
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
 				};
 			};
 		};
@@ -135,6 +139,6 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002>;
+	nvmem-cell-names = "calibration", "mac-address";
 };

--- a/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
+++ b/target/linux/ath79/dts/ar9342_ubnt_xw.dtsi
@@ -79,6 +79,10 @@
 					calibration_art_1000: calibration@1000 {
 						reg = <0x1000 0x440>;
 					};
+
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
 				};
 			};
 		};
@@ -88,8 +92,8 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&calibration_art_1000>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&calibration_art_1000>, <&macaddr_art_1002>;
+	nvmem-cell-names = "calibration", "mac-address";
 };
 
 &eth0 {

--- a/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
+++ b/target/linux/ath79/dts/ar9344_alfa-network_n5q.dts
@@ -146,6 +146,10 @@
 					macaddr_art_6: macaddr@6 {
 						reg = <0x6 0x6>;
 					};
+
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
 				};
 			};
 
@@ -165,8 +169,8 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002>;
+	nvmem-cell-names = "calibration", "mac-address";
 
 	led {
 		led-sources = <12>;

--- a/target/linux/ath79/dts/ar9344_longdata_aps256.dts
+++ b/target/linux/ath79/dts/ar9344_longdata_aps256.dts
@@ -129,8 +129,8 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002 0>;
+	nvmem-cell-names = "calibration", "mac-address";
 
 	led {
 		led-sources = <13>;

--- a/target/linux/ath79/dts/ar9344_moxa_awk-1137c.dts
+++ b/target/linux/ath79/dts/ar9344_moxa_awk-1137c.dts
@@ -15,7 +15,6 @@
 		led-failsafe = &led_status_red;
 		led-running = &led_status_green;
 		led-upgrade = &led_status_red;
-		label-mac-device = &eth1;
 	};
 
 	keys {

--- a/target/linux/ath79/dts/qca9531_8dev_carambola3.dts
+++ b/target/linux/ath79/dts/qca9531_8dev_carambola3.dts
@@ -87,6 +87,10 @@
 					cal_art_1000: calibration@1000 {
 						reg = <0x1000 0x440>;
 					};
+
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
 				};
 			};
 
@@ -127,6 +131,6 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002>;
+	nvmem-cell-names = "calibration", "mac-address";
 };

--- a/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
+++ b/target/linux/ath79/dts/qca9531_alcatel_hh40v.dts
@@ -132,6 +132,10 @@
 					macaddr_art_6: macaddr@6 {
 						reg = <0x6 0x6>;
 					};
+
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
 				};
 			};
 		};
@@ -162,8 +166,8 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002>;
+	nvmem-cell-names = "calibration", "mac-address";
 
 	led {
 		led-sources = <0>;

--- a/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
+++ b/target/linux/ath79/dts/qca9531_alfa-network_r36a.dtsi
@@ -127,6 +127,6 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002 0>;
+	nvmem-cell-names = "calibration", "mac-address";
 };

--- a/target/linux/ath79/dts/qca9533_ubnt_aircube-isp.dts
+++ b/target/linux/ath79/dts/qca9533_ubnt_aircube-isp.dts
@@ -83,6 +83,10 @@
 					cal_art_1000: calibration@1000 {
 						reg = <0x1000 0x440>;
 					};
+
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
 				};
 			};
 		};
@@ -110,6 +114,6 @@
 &wmac {
 	status = "okay";
 
-	nvmem-cells = <&cal_art_1000>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002>;
+	nvmem-cell-names = "calibration", "mac-address";
 };

--- a/target/linux/ath79/dts/qca9558_comfast_cf-e380ac-v2.dts
+++ b/target/linux/ath79/dts/qca9558_comfast_cf-e380ac-v2.dts
@@ -11,7 +11,7 @@
 	model = "COMFAST CF-E380AC";
 
 	aliases {
-		label-mac-device = &eth1;
+		label-mac-device = &eth0;
 		led-boot = &led_lan;
 		led-failsafe = &led_lan;
 		led-upgrade = &led_lan;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -634,16 +634,6 @@ ath79_setup_macs()
 		lan_mac=$(mtd_get_mac_binary "Board data" 2)
 		label_mac=$lan_mac
 		;;
-	alfa-network,ap121f|\
-	alfa-network,ap121fe|\
-	alfa-network,n2q|\
-	alfa-network,n5q|\
-	alfa-network,pi-wifi4|\
-	alfa-network,r36a|\
-	alfa-network,tube-2hq|\
-	alfa-network,wifi-camppro-nano-duo)
-		label_mac=$(mtd_get_mac_binary art 0x1002)
-		;;
 	arduino,yun)
 		base_mac=$(mtd_get_mac_binary art 0x1002)
 		lan_mac=$(macaddr_setbit $base_mac 29)


### PR DESCRIPTION
It appears 683-of_net-add-mac-address-to-of-tree.patch relies on the
mac-address nvmem property being present. wmac itself doesn't need it as
it takes it from the eeprom but label-mac-device needs it.

Relevant: https://github.com/openwrt/openwrt/pull/17329#discussion_r1903182626