### PR TITLE
ramips: esw_rt3050: fix uninitialized variable build error

### DIFF
--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/esw_rt3050.c
@@ -1464,13 +1464,13 @@ int rt3050_esw_init(struct fe_priv *priv)
 	const __be32 *rgmii;
 	int ret;
 
-	if (!pdev)
-		return -ENODEV;
-
 	if (!of_device_is_compatible(np, ralink_esw_match->compatible))
 		return -EINVAL;
 
 	pdev = of_find_device_by_node(np);
+	if (!pdev)
+		return -ENODEV;
+
 	esw = platform_get_drvdata(pdev);
 	if (!esw) {
 		put_device(&pdev->dev);


### PR DESCRIPTION
This patch fixes the following build error:

drivers/net/ethernet/ralink/esw_rt3050.c: In function 'rt3050_esw_init': drivers/net/ethernet/ralink/esw_rt3050.c:1467:12: error: 'pdev' is used uninitialized [-Werror=uninitialized]
 1467 |         if (!pdev)
      |            ^
drivers/net/ethernet/ralink/esw_rt3050.c:1461:33: note: 'pdev' was declared here
 1461 |         struct platform_device *pdev;
      |                                 ^~~~

Fixes: 4ffd5aa239c1 ("treewide: fix coccinelle checks")
