### PR TITLE
bcm53xx: image: sync targets names with DT compatible

### DIFF
--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -345,39 +345,41 @@ define Device/luxul
   IMAGE/lxl := append-ubi | trx-nand | luxul-lxl
 endef
 
-define Device/luxul_abr-4500
+define Device/luxul_abr-4500-v1
   $(Device/luxul)
   DEVICE_MODEL := ABR-4500
   DEVICE_PACKAGES := $(USB3_PACKAGES)
+  DEVICE_DTS := bcm47094-luxul-abr-4500
   LUXUL_BOARD := ABR-4500
 endef
-TARGET_DEVICES += luxul_abr-4500
+TARGET_DEVICES += luxul_abr-4500-v1
 
-define Device/luxul_xap-1610
+define Device/luxul_xap-1610-v1
   $(Device/luxul)
   DEVICE_MODEL := XAP-1610
   DEVICE_PACKAGES := $(BRCMFMAC_4366C0)
+  DEVICE_DTS := bcm47094-luxul-xap-1610
   IMAGE/lxl := append-rootfs | trx-serial | luxul-lxl
   LUXUL_BOARD := XAP-1610
 endef
-TARGET_DEVICES += luxul_xap-1610
+TARGET_DEVICES += luxul_xap-1610-v1
 
-define Device/luxul_xbr-4500
+define Device/luxul_xbr-4500-v1
   $(Device/luxul)
   DEVICE_MODEL := XBR-4500
   DEVICE_PACKAGES := $(USB3_PACKAGES)
+  DEVICE_DTS := bcm47094-luxul-xbr-4500
   LUXUL_BOARD := XBR-4500
 endef
-TARGET_DEVICES += luxul_xbr-4500
+TARGET_DEVICES += luxul_xbr-4500-v1
 
-define Device/luxul_xwr-3150
+define Device/luxul_xwr-3150-v1
   $(Device/luxul)
   DEVICE_MODEL := XWR-3150
   DEVICE_PACKAGES := $(BRCMFMAC_4366C0) $(USB3_PACKAGES)
-  DEVICE_DTS := bcm47094-luxul-xwr-3150-v1
   LUXUL_BOARD := XWR-3150
 endef
-TARGET_DEVICES += luxul_xwr-3150
+TARGET_DEVICES += luxul_xwr-3150-v1
 
 define Device/meraki_mr26
   DEVICE_VENDOR := Meraki
@@ -464,13 +466,14 @@ define Device/netgear
   NETGEAR_REGION := 1
 endef
 
-define Device/netgear_r6250
+define Device/netgear_r6250-v1
   DEVICE_MODEL := R6250
   DEVICE_PACKAGES := $(B43) $(USB3_PACKAGES)
+  DEVICE_DTS := bcm4708-netgear-r6250
   $(Device/netgear)
   NETGEAR_BOARD_ID := U12H245T00_NETGEAR
 endef
-TARGET_DEVICES += netgear_r6250
+TARGET_DEVICES += netgear_r6250-v1
 
 define Device/netgear_r6300-v2
   DEVICE_MODEL := R6300


### PR DESCRIPTION
Some devices profile names and *.dts files are named without suffix "-v1" but the DT compatible has the suffix. (xwr-3150 exception)
https://github.com/openwrt/openwrt/blob/09e7b24ceb5d9310334c4f88327dc6d58052e7fd/target/linux/bcm53xx/image/Makefile#L348-L354 https://github.com/gregkh/linux/blob/3f9f0252130e7dd60d41be0802bf58f6471c691d/arch/arm/boot/dts/broadcom/bcm47094-luxul-abr-4500.dts

This breaks ASU sysupgrades since the default SUPPORTED_DEVICES is the makefile image profile target and it does not match the actual DT compatible sent by the ASU client.

This is not breaking sysupgrade because the platform implementation does not depends on DEVICE_NAME(not use sysupgrade-TAR). And the board_name() checks are done against the correct DT compatible. https://github.com/openwrt/openwrt/blob/09e7b24ceb5d9310334c4f88327dc6d58052e7fd/target/linux/bcm53xx/base-files/lib/upgrade/platform.sh#L36-L62

Fixes: https://github.com/openwrt/asu/issues/560
Fixes: https://github.com/openwrt/asu/issues/560#issuecomment-2083236275
Fixes: https://github.com/openwrt/asu/issues/1108
Fixes: https://forum.openwrt.org/t/luci-attended-sysupgrade-support-thread/230552/243
Fixes: c459a6bf482f5afc4746a4a108a143e9194cd59d "bcm53xx: add support for Luxul FullMAC WiFi devices"
Fixes: 1d47f81581bcd476487e5b29314602167a843b99 "bcm53xx: build images for Luxul ABR-4500 and XBR-4500 routers"