### PR TITLE
bmips: use led-sources for ath9k

### DIFF
--- a/target/linux/bmips/dts/bcm6328-dlink-dsl-2750b-b1.dts
+++ b/target/linux/bmips/dts/bcm6328-dlink-dsl-2750b-b1.dts
@@ -48,17 +48,6 @@
 			linux,default-trigger = "usbport";
 		};
 	};
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		led-8 {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&ath9k 8 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
 };
 
 &leds {
@@ -205,15 +194,16 @@
 		device_type = "pci";
 		ranges;
 
-		ath9k: wifi@0,0 {
+		wifi@0,0 {
 			compatible = "pci168c,002e";
 			reg = <0 0 0 0 0>;
 
 			nvmem-cells = <&macaddr_cfe_6a0 1>, <&cal_data_1000>;
 			nvmem-cell-names = "mac-address", "calibration";
 
-			#gpio-cells = <2>;
-			gpio-controller;
+			led {
+				led-sources = <8>;
+			};
 		};
 	};
 };

--- a/target/linux/bmips/dts/bcm6358-huawei-hg556a-a.dts
+++ b/target/linux/bmips/dts/bcm6358-huawei-hg556a-a.dts
@@ -5,17 +5,6 @@
 / {
 	model = "Huawei EchoLife HG556a (version A)";
 	compatible = "huawei,hg556a-a", "brcm,bcm6358";
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		led-2 {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_RED>;
-			gpios = <&ath9k 2 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
 };
 
 &gpio_keys {
@@ -58,7 +47,7 @@
 &pci {
 	status = "okay";
 
-	ath9k: wifi@1,0 {
+	wifi@1,0 {
 		compatible = "pci168c,ff1d";
 		reg = <0x0800 0 0 0 0>;
 
@@ -67,7 +56,8 @@
 		nvmem-cells = <&macaddr_cfe_6a0 1>;
 		nvmem-cell-names = "mac-address";
 
-		#gpio-cells = <2>;
-		gpio-controller;
+		led {
+			led-sources = <2>;
+		};
 	};
 };

--- a/target/linux/bmips/dts/bcm6358-huawei-hg556a-b.dts
+++ b/target/linux/bmips/dts/bcm6358-huawei-hg556a-b.dts
@@ -5,17 +5,6 @@
 / {
 	model = "Huawei EchoLife HG556a (version B)";
 	compatible = "huawei,hg556a-b", "brcm,bcm6358";
-
-	ath9k-leds {
-		compatible = "gpio-leds";
-
-		led-2 {
-			function = LED_FUNCTION_WLAN;
-			color = <LED_COLOR_ID_RED>;
-			gpios = <&ath9k 2 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy0tpt";
-		};
-	};
 };
 
 &gpio_keys {
@@ -58,7 +47,7 @@
 &pci {
 	status = "okay";
 
-	ath9k: wifi@1,0 {
+	wifi@1,0 {
 		compatible = "pci168c,0029";
 		reg = <0x0800 0 0 0 0>;
 
@@ -67,7 +56,8 @@
 		nvmem-cells = <&macaddr_cfe_6a0 1>;
 		nvmem-cell-names = "mac-address";
 
-		#gpio-cells = <2>;
-		gpio-controller;
+		led {
+			led-sources = <2>;
+		};
 	};
 };

--- a/target/linux/bmips/dts/bcm6358-huawei-hg556a-c.dts
+++ b/target/linux/bmips/dts/bcm6358-huawei-hg556a-c.dts
@@ -38,16 +38,26 @@
 	};
 };
 
+&cal_data {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		cal_data_1fe00: calibration@1fe00 {
+			reg = <0x1fe00 0x200>;
+		};
+	};
+};
+
 &pci {
 	status = "okay";
 
 	wifi@1,0 {
-		compatible = "pci0,0";
+		compatible = "pci1814,3062";
 		reg = <0x0800 0 0 0 0>;
 
-		ralink,mtd-eeprom = <&cal_data 0x1fe00>;
-
-		nvmem-cells = <&macaddr_cfe_6a0 1>;
-		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&cal_data_1fe00>, <&macaddr_cfe_6a0 1>;
+		nvmem-cell-names = "calibration", "mac-address";
 	};
 };


### PR DESCRIPTION
Avoids having to create a custom LED for wifi.

ping @Noltari 