### PR TITLE
[24.10] ramips: add support for Cudy R700

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_r700.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_r700.dts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "cudy,r700", "mediatek,mt7621-soc";
+	model = "Cudy R700";
+
+	aliases {
+		led-boot = &led_internet_blue;
+		led-failsafe = &led_internet_blue;
+		led-running = &led_internet_blue;
+		led-upgrade = &led_internet_blue;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_internet_blue: internet_blue {
+			label = "blue:internet";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		internet_red {
+			label = "red:internet";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		lan1 {
+			label = "green:lan1";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2 {
+			label = "green:lan2";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		lan3 {
+			label = "green:lan3";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		lan4 {
+			label = "green:lan4";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "debug";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "backup";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "bdinfo";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "jtag", "uart3", "wdt";
+		function = "gpio";
+	};
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_bdinfo_de00 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7621_cudy_r700.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_r700.dts
@@ -11,10 +11,9 @@
 	model = "Cudy R700";
 
 	aliases {
-		led-boot = &led_internet_blue;
-		led-failsafe = &led_internet_blue;
-		led-running = &led_internet_blue;
-		led-upgrade = &led_internet_blue;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
 		label-mac-device = &gmac0;
 	};
 
@@ -27,7 +26,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};
@@ -35,40 +34,10 @@
 	leds {
 		compatible = "gpio-leds";
 
-		led_internet_blue: internet_blue {
-			label = "blue:internet";
-			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
-		};
-
-		internet_red {
-			label = "red:internet";
-			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
-		};
-
-		wan {
-			function = LED_FUNCTION_WAN;
+		led_status_green: led-status-green {
 			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
 			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
-		};
-
-		lan1 {
-			label = "green:lan1";
-			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
-		};
-
-		lan2 {
-			label = "green:lan2";
-			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
-		};
-
-		lan3 {
-			label = "green:lan3";
-			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
-		};
-
-		lan4 {
-			label = "green:lan4";
-			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
 		};
 	};
 };
@@ -107,38 +76,12 @@
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					eeprom_factory_0: eeprom@0 {
-						reg = <0x0 0x400>;
-					};
-
-					eeprom_factory_8000: eeprom@8000 {
-						reg = <0x8000 0x4da8>;
-					};
-				};
 			};
 
 			partition@50000 {
 				compatible = "denx,uimage";
 				label = "firmware";
-				reg = <0x50000 0xf80000>;
-			};
-
-			partition@fd0000 {
-				label = "debug";
-				reg = <0xfd0000 0x10000>;
-				read-only;
-			};
-
-			partition@fe0000 {
-				label = "backup";
-				reg = <0xfe0000 0x10000>;
-				read-only;
+				reg = <0x50000 0xfa0000>;
 			};
 
 			partition@ff0000 {
@@ -178,16 +121,20 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
 &switch0 {
 	ports {
 		port@0 {
 			status = "okay";
-			label = "lan1";
+			label = "lan5";
 		};
 
 		port@1 {
 			status = "okay";
-			label = "lan2";
+			label = "lan4";
 		};
 
 		port@2 {
@@ -197,7 +144,7 @@
 
 		port@3 {
 			status = "okay";
-			label = "lan4";
+			label = "lan2";
 		};
 	};
 };

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -795,6 +795,16 @@ define Device/cudy_wr2100
 endef
 TARGET_DEVICES += cudy_wr2100
 
+define Device/cudy_r700
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := R700
+  IMAGE_SIZE := 15872k
+  UIMAGE_NAME := R29
+  DEVICE_PACKAGES := -uboot-envtools
+endef
+TARGET_DEVICES += cudy_r700
+
 define Device/cudy_x6-v1
   $(Device/dsa-migration)
   IMAGE_SIZE := 32256k

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -801,7 +801,7 @@ define Device/cudy_r700
   DEVICE_MODEL := R700
   IMAGE_SIZE := 15872k
   UIMAGE_NAME := R29
-  DEVICE_PACKAGES := -uboot-envtools
+  DEVICE_PACKAGES := -uboot-envtools -wpad-basic-mbedtls
 endef
 TARGET_DEVICES += cudy_r700
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -66,7 +66,6 @@ genexis,pulse-ex400|\
 netis,n6)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
 	;;
-cudy,r700|\
 cudy,wr2100)
 	ucidef_set_led_netdev "lan1" "lan1" "green:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "lan2" "green:lan2" "lan2"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -66,6 +66,7 @@ genexis,pulse-ex400|\
 netis,n6)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
 	;;
+cudy,r700|\
 cudy,wr2100)
 	ucidef_set_led_netdev "lan1" "lan1" "green:lan1" "lan1"
 	ucidef_set_led_netdev "lan2" "lan2" "green:lan2" "lan2"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -116,6 +116,7 @@ ramips_setup_interfaces()
 		uci add_list firewall.@zone[1].network='eth_om'
 		;;
 	cudy,c200p|\
+	cudy,r700|\
 	mikrotik,routerboard-750gr3)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan"
 		;;


### PR DESCRIPTION
Backport Cudy device R700 to 24.10.

Original commit: https://github.com/openwrt/openwrt/commit/75403dd1d05bea1b65349ebb9f8b7deb40b9c802
PR fixed some bugs: https://github.com/openwrt/openwrt/pull/20756

Specifications:

    SoC: MT7621
    CPU: 880 MHz
    Flash: 16 MB NOR Flash
    RAM: 128 MB DDR
    Ethernet: 5x Gbit ports

LED:

    Power
    System
    Speed/Link/ACT of Ethernet Port

Physical Buttons:

 	Reset Button

Power Input:

 	DC Jack (12V 1A)

Installation:

    To install OpenWRT, you need the intermediate firmware from Cudy.
    After installing the intermediate firmware, you can install OpenWRT via sysupgrade.

Recovery:

    TFTP available.
    1. Place the recovery.bin in the serving directory of your TFTP server.
    2. Set your IP to 192.168.1.88/24.
    3. Press the “Reset” button of Cudy router and hold it. Before the Cudy router is powered on and before TFTP start to download the firmware, don't release the “Reset” button.
    4. Power on the Cudy router.
    5. You can release the reset button only when TFTP starts downloading firmware.
    6. When the SYSTEM LED turns solid green, the upgrade is complete.


