### PR TITLE
siflower: sf21: add CPU_TYPE for RISC-V RVA22U64

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -270,6 +270,7 @@ ifeq ($(DUMP),1)
   ifeq ($(ARCH),riscv64)
     CPU_TYPE ?= generic
     CPU_CFLAGS_generic:=-mabi=lp64d -march=rv64gc
+    CPU_CFLAGS_rva22u64:= -mabi=lp64d -march=rv64gc_zicbom_zicbop_zicboz_zfhmin_zba_zbb_zbs_zkt
   endif
   ifeq ($(ARCH),loongarch64)
     CPU_TYPE ?= generic

--- a/target/linux/siflower/sf21/target.mk
+++ b/target/linux/siflower/sf21/target.mk
@@ -1,4 +1,5 @@
 ARCH:=riscv64
+CPU_TYPE:=rva22u64
 SUBTARGET:=sf21
 BOARDNAME:=Siflower SF21A6826/SF21H8898 based boards
 FEATURES+=fpu nand separate_ramdisk


### PR DESCRIPTION
siflower sf21 boards use Xuantie C908 CPU which supports [RISC-V ISA RVA22U64 Profile](https://github.com/riscv/riscv-profiles/blob/main/src/profiles.adoc#rva22-profiles), including standard extensions Zba, Zbb, Zbs, Zfhmin, Zicbom, Zicbop and Zicboz. By specifying CPU_TYPE as rva22u64, the compiler can generate optimized code for these boards, improving performance in various workloads. And we believe there will be more RISC-V devices adopting this CPU profile in the future.

As `-march=rva22u64` is only available since GCC 15, we manually set the corresponding CPU flags here to ensure compatibility with older GCC versions.

We also see OpenSSL ChaCha20 benefit from these flags:

riscv64_generic:
```console
root@OpenWrt:/tmp# openssl speed -evp chacha20
Doing ChaCha20 ops for 3s on 16 size blocks: 5158997 ChaCha20 ops in 3.00s
Doing ChaCha20 ops for 3s on 64 size blocks: 1908592 ChaCha20 ops in 3.00s
Doing ChaCha20 ops for 3s on 256 size blocks: 514757 ChaCha20 ops in 2.99s
Doing ChaCha20 ops for 3s on 1024 size blocks: 132109 ChaCha20 ops in 3.00s
Doing ChaCha20 ops for 3s on 8192 size blocks: 16637 ChaCha20 ops in 3.00s
Doing ChaCha20 ops for 3s on 16384 size blocks: 8319 ChaCha20 ops in 3.00s
version: 3.5.4
built on: Thu Dec  4 15:35:40 2025 UTC
options: bn(64,64)
compiler: riscv64-openwrt-linux-musl-gcc -fPIC -pthread -Os -pipe -mabi=lp64d -march=rv64gc -fno-caller-saves -fno-plt -fhonour-copts -ffunction-sections -fdata-sections -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -DPIC -fpic -DOPENSSL_USE_NODELETE -DOPENSSL_PIC -DOPENSSL_BUILDING_OPENSSL -DNDEBUG -DOPENSSL_PREFER_CHACHA_OVER_GCM
CPUINFO: N/A
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
ChaCha20         27514.65k    40716.63k    44072.84k    45093.21k    45430.10k    45432.83k
```

riscv64_rva22u64:
```console
root@OpenWrt:~# openssl speed -evp chacha20
Doing ChaCha20 ops for 3s on 16 size blocks: 6309477 ChaCha20 ops in 3.01s
Doing ChaCha20 ops for 3s on 64 size blocks: 2524411 ChaCha20 ops in 3.02s
Doing ChaCha20 ops for 3s on 256 size blocks: 713332 ChaCha20 ops in 3.02s
Doing ChaCha20 ops for 3s on 1024 size blocks: 184886 ChaCha20 ops in 3.01s
Doing ChaCha20 ops for 3s on 8192 size blocks: 23366 ChaCha20 ops in 3.02s
Doing ChaCha20 ops for 3s on 16384 size blocks: 11685 ChaCha20 ops in 3.01s
version: 3.5.4
built on: Sat Dec  6 17:34:36 2025 UTC
options: bn(64,64)
compiler: riscv64-openwrt-linux-musl-gcc -fPIC -pthread -Os -pipe -mabi=lp64d -march=rv64gc_zba_zbb_zbs_zfhmin_zicbom_zicbop_zicboz -fno-caller-saves -fno-plt -fhonour-copts -ffunction-sections -fdata-sections -Wformat -Werror=format-security -fstack-protector -D_FORTIFY_SOURCE=1 -Wl,-z,now -Wl,-z,relro -DPIC -fpic -DOPENSSL_USE_NODELETE -DOPENSSL_PIC -DOPENSSL_BUILDING_OPENSSL -DNDEBUG -DOPENSSL_PREFER_CHACHA_OVER_GCM
CPUINFO: N/A
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
ChaCha20         33538.75k    53497.45k    60467.88k    62898.09k    63382.21k    63603.67k
```