### PR TITLE
openssl: optimize speed for riscv64 by default

### DIFF
--- a/package/libs/openssl/Config.in
+++ b/package/libs/openssl/Config.in
@@ -4,7 +4,7 @@ comment "Build Options"
 
 config OPENSSL_OPTIMIZE_SPEED
 	bool
-	default y if x86_64 || i386
+	default y if x86_64 || i386 || riscv64
 	prompt "Enable optimization for speed instead of size"
 	select OPENSSL_WITH_ASM
 	help


### PR DESCRIPTION
RISC-V is becoming more popular, and it's beneficial to have OpenSSL optimized for speed on riscv64 architectures by default. And many algorithms in OpenSSL currently lack assembly optimizations for riscv64, so optimizing for speed for riscv64 will bring significant performance improvements for C implementations. For example, the performance of ChaCha20 improves dramatically with this change, from 63603.67k to 129428.12k on Bananapi BPI-RV2 with rva22u64 profile.

All existing boards that use riscv64 that support boot from SDCard or at least 128M NAND flash, so the slight increase in binary size is acceptable. And I have tested this change to build with even rva22u64 profile, the libssl.so.3 only increases from 972K to 1.1M, which is acceptable for most use cases.