### PR TITLE
dropbear: make it possible to configure port forwarding configuration

### DIFF
--- a/package/network/services/dropbear/files/dropbear.config
+++ b/package/network/services/dropbear/files/dropbear.config
@@ -5,3 +5,5 @@ config dropbear main
 	option RootPasswordAuth 'on'
 	option Port         '22'
 #	option BannerFile   '/etc/banner'
+#	option LocalPortForward 'off'
+#	option RemotePortForward 'off'

--- a/package/network/services/dropbear/files/dropbear.init
+++ b/package/network/services/dropbear/files/dropbear.init
@@ -178,6 +178,8 @@ validate_section_dropbear()
 		'IdleTimeout:uinteger:0' \
 		'MaxAuthTries:uinteger:3' \
 		'RecvWindowSize:uinteger:0' \
+		'LocalPortForward:bool:1' \
+		'RemotePortForward:bool:1' \
 		'mdns:bool:1'
 }
 
@@ -317,6 +319,8 @@ dropbear_instance()
 	fi
 	[ "${PasswordAuth}" -eq 0 ] && procd_append_param command -s
 	[ "${GatewayPorts}" -eq 1 ] && procd_append_param command -a
+	[ "${LocalPortForward}" -eq 0 ] && procd_append_param command -j
+	[ "${RemotePortForward}" -eq 0 ] && procd_append_param command -k
 	[ -n "${ForceCommand}" ] && procd_append_param command -c "${ForceCommand}"
 	[ "${RootPasswordAuth}" -eq 0 ] && procd_append_param command -g
 	[ "${RootLogin}" -eq 0 ] && procd_append_param command -w


### PR DESCRIPTION
Currently its only possible to disable port forwarding only for specific keys, via the OpenSSH-style restriction in `authorized_keys` file.

In some use cases it might be feasible to disable such features globally on service level, so lets add new LocalPortForward and RemotePortForward config knobs.