### PR TITLE
x86: improve bootable ISO compatibility

### DIFF
--- a/target/linux/x86/Makefile
+++ b/target/linux/x86/Makefile
@@ -25,7 +25,7 @@ $(eval $(call BuildTarget))
 
 $(eval $(call $(if $(CONFIG_ISO_IMAGES),SetupHostCommand,Ignore),mkisofs, \
 	Please install mkisofs. , \
-	mkisofs -v 2>&1 , \
-	genisoimage -v 2>&1 | grep genisoimage, \
-	xorrisofs -v 2>&1 | grep xorriso \
+	mkisofs --version 2>&1 | grep mkisofs, \
+	genisoimage --version 2>&1 | grep genisoimage, \
+	xorrisofs --version 2>&1 | grep xorriso \
 ))

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -119,8 +119,13 @@ define Build/iso
 			$(STAGING_DIR_IMAGE)/grub2/iso-boot$(if $(CONFIG_x86_64),x64,ia32).efi \
 			::/efi/boot/boot$(if $(CONFIG_x86_64),x64,ia32).efi
 	)
-	mkisofs -R -b boot/grub/eltorito.img -no-emul-boot -boot-info-table \
-		$(if $(filter $(1),efi),-boot-load-size 4 -c boot.cat -eltorito-alt-boot -b boot/grub/isoboot.img -no-emul-boot) \
+	mkisofs -R -c boot.cat \
+		-b boot/grub/eltorito.img -no-emul-boot -boot-load-size 4 -boot-info-table \
+		$(if $(filter $(1),efi),-eltorito-alt-boot \
+		$(if $(findstring genisoimage,$(realpath $(STAGING_DIR_HOST)/bin/mkisofs)),\
+			-e,\
+			-eltorito-platform efi -b) \
+		boot/grub/isoboot.img -no-emul-boot) \
 		-o $@ $@.boot $(TARGET_DIR)
 endef
 

--- a/target/linux/x86/image/Makefile
+++ b/target/linux/x86/image/Makefile
@@ -119,7 +119,7 @@ define Build/iso
 			$(STAGING_DIR_IMAGE)/grub2/iso-boot$(if $(CONFIG_x86_64),x64,ia32).efi \
 			::/efi/boot/boot$(if $(CONFIG_x86_64),x64,ia32).efi
 	)
-	mkisofs -R -c boot.cat \
+	mkisofs -R -uid 0 -gid 0 -c boot.cat \
 		-b boot/grub/eltorito.img -no-emul-boot -boot-load-size 4 -boot-info-table \
 		$(if $(filter $(1),efi),-eltorito-alt-boot \
 		$(if $(findstring genisoimage,$(realpath $(STAGING_DIR_HOST)/bin/mkisofs)),\


### PR DESCRIPTION
Set the BIOS boot image size to 4 sectors even when it is the only boot image.  Some BIOS implementations consider boot records with larger sizes to be invalid.

Set the UEFI boot image platform to EFI (0xEF).  Some UEFI implementations only consider boot images marked for EFI.  Some BIOS implementations, when given a choice between multiple boot images with platform 0, display a prompt asking the user to choose an image and do not proceed with booting until it is answered.  If the UEFI image is marked for EFI, these BIOSes can boot the BIOS boot image unattended.

The -c option causes the boot catalog to appear as a file in the ISO filesystem. This option is not required for booting, but having a name for the boot catalog is convenient for debugging El Torito boot.  Use the -c option for both the BIOS-only and combined images.

---

I had both of the BIOS boot problems on an MSI MS-7309 motherboard with American Megatrends AMI BIOS v02.59.  This system won't boot from USB, and I don't want to "waste" a hard drive on a tiny OpenWRT installation, so I'm using the image builder to build bootable ISOs with configuration and booting from the DVD drive.  (Using the image builder also makes it easy to keep my configuration in version control and allows for A/B upgrades by alternating between two DVD-RWs.)

[UEFI spec section 13.3.2.1](https://uefi.org/specs/UEFI/2.11/13_Protocols_Media_Access.html#iso-9660-and-el-torito) defines the 0xEF platform identifier.  QEMU with OVMF don't need this PR to boot in UEFI because the [OVMF El Torito parsing code](https://github.com/tianocore/edk2/blob/master/MdeModulePkg/Universal/Disk/PartitionDxe/ElTorito.c) doesn't check the platform identifier.  On the other hand, there's [an issue in the OVMF repo](https://github.com/tianocore/edk2/issues/10952) where the developers say it's necessary.  I don't know if [other UEFI implementations](https://en.wikipedia.org/wiki/UEFI#Implementations) need it or not.

---

[dumpet](https://github.com/rhboot/dumpet) output from before this PR:
```
[jbosboom@promenade dumpet]$ ./dumpet -i openwrt-24.10.4-x86-64-generic-image.iso 
Validation Entry:
	Header Indicator: 0x01 (Validation Entry)
	PlatformId: 0x00 (80x86)
	ID: ""
	Checksum: 0x55aa
	Key bytes: 0x55aa
Boot Catalog Default Entry:
	Entry is bootable
	Boot Media emulation type: no emulation
	Media load segment: 0x0 (0000:7c00)
	System type: 0 (0x00)
	Load Sectors: 308 (0x0134)
	Load LBA: 1308 (0x0000051c)
[jbosboom@promenade dumpet]$ ./dumpet -i openwrt-24.10.4-x86-64-generic-image-efi.iso 
Validation Entry:
	Header Indicator: 0x01 (Validation Entry)
	PlatformId: 0x00 (80x86)
	ID: ""
	Checksum: 0x55aa
	Key bytes: 0x55aa
Boot Catalog Default Entry:
	Entry is bootable
	Boot Media emulation type: no emulation
	Media load segment: 0x0 (0000:7c00)
	System type: 0 (0x00)
	Load Sectors: 4 (0x0004)
	Load LBA: 1308 (0x0000051c)
Section Header Entry:
	Header Indicator: 0x91 (Final Section Header Entry)
	PlatformId: 0x00 (80x86)
	Section Entries: 1
	ID: ""
Boot Catalog Section Entry:
	Entry is bootable
	Boot Media emulation type: no emulation
	Media load segment: 0x07c0
	System type: 0 (0x00)
	Load Sectors: 2880 (0x0b40)
	Load LBA: 1385 (0x00000569)
```

dumpet output after this PR:
```
[jbosboom@promenade dumpet]$ ./dumpet -i openwrt-24.10.4-x86-64-generic-image.iso
Validation Entry:
	Header Indicator: 0x01 (Validation Entry)
	PlatformId: 0x00 (80x86)
	ID: ""
	Checksum: 0x55aa
	Key bytes: 0x55aa
Boot Catalog Default Entry:
	Entry is bootable
	Boot Media emulation type: no emulation
	Media load segment: 0x0 (0000:7c00)
	System type: 0 (0x00)
	Load Sectors: 4 (0x0004)
	Load LBA: 1308 (0x0000051c)
[jbosboom@promenade dumpet]$ ./dumpet -i openwrt-24.10.4-x86-64-generic-image-efi.iso
Validation Entry:
	Header Indicator: 0x01 (Validation Entry)
	PlatformId: 0x00 (80x86)
	ID: ""
	Checksum: 0x55aa
	Key bytes: 0x55aa
Boot Catalog Default Entry:
	Entry is bootable
	Boot Media emulation type: no emulation
	Media load segment: 0x0 (0000:7c00)
	System type: 0 (0x00)
	Load Sectors: 4 (0x0004)
	Load LBA: 1308 (0x0000051c)
Section Header Entry:
	Header Indicator: 0x91 (Final Section Header Entry)
	PlatformId: 0xef (EFI)
	Section Entries: 1
	ID: ""
Boot Catalog Section Entry:
	Entry is bootable
	Boot Media emulation type: no emulation
	Media load address: 0 (0x0000)
	System type: 0 (0x00)
	Load Sectors: 2880 (0x0b40)
	Load LBA: 1385 (0x00000569)
```

Note the BIOS boot entry now has "Load Sectors: 4" in both ISOs and the section header in the combined ISO has "PlatformId: 0xef".