### PR TITLE
firewall3: fix dubious rule syntax in config

### DIFF
--- a/package/network/config/firewall/files/firewall.config
+++ b/package/network/config/firewall/files/firewall.config
@@ -132,14 +132,14 @@ config rule
 # note that traceroute uses a fixed port range, and depends on getting
 # back ICMP Unreachables.  if we're operating in DROP mode, it won't
 # work so we explicitly REJECT packets on these ports.
-config rule
-	option name		Support-UDP-Traceroute
-	option src		wan
-	option dest_port	33434:33689
-	option proto		udp
-	option family		ipv4
-	option target		REJECT
-	option enabled		0
+#config rule
+#	option name		Support-UDP-Traceroute
+#	option src		wan
+#	option dest_port	33434-33689
+#	option proto		udp
+#	option family		ipv4
+#	option target		REJECT
+#	option enabled		0
 
 # include a file with users custom iptables rules
 config include


### PR DESCRIPTION
Fix non-default rule syntax and comment it out.
Systems with UDP traceroute are long gone
Besides default behaviour is to reject by default and it works without 
extra rule

Fixes: #21063