### PR TITLE
hostapd: warn if log level is being cut off

### DIFF
--- a/package/network/services/hostapd/patches/410-limit_debug_messages.patch
+++ b/package/network/services/hostapd/patches/410-limit_debug_messages.patch
@@ -213,3 +213,87 @@ Subject: [PATCH] hostapd: add configurable debug message minimum priority to
  
  /**
   * wpa_msg_global - Global printf for ctrl_iface monitors
+--- a/hostapd/ctrl_iface.c
++++ b/hostapd/ctrl_iface.c
+@@ -3203,6 +3203,16 @@ static int hostapd_ctrl_iface_log_level(
+ 		int level = str_to_debug_level(cmd);
+ 		if (level < 0)
+ 			return -1;
++
++#ifdef CONFIG_MSG_MIN_PRIORITY
++		if (wpa_debug_level < CONFIG_MSG_MIN_PRIORITY) {
++			wpa_printf(MSG_WARNING, "refusing to set wpa_debug_level (%d)"
++				" below compile-time limit: %d",
++				wpa_debug_level, CONFIG_MSG_MIN_PRIORITY);
++			return -1;
++		}
++#endif
++
+ 		wpa_debug_level = level;
+ 	}
+ 
+--- a/hostapd/main.c
++++ b/hostapd/main.c
+@@ -950,6 +950,13 @@ int main(int argc, char *argv[])
+ 		}
+ 	}
+ 
++#ifdef CONFIG_MSG_MIN_PRIORITY
++	if (wpa_debug_level < CONFIG_MSG_MIN_PRIORITY) {
++		wpa_printf(MSG_WARNING, "clamping wpa_debug_level (%d) to compile-time limit: %d", wpa_debug_level, CONFIG_MSG_MIN_PRIORITY);
++		wpa_debug_level = CONFIG_MSG_MIN_PRIORITY;
++	}
++#endif
++
+ 	if (optind == argc && interfaces.global_iface_path == NULL &&
+ 	    num_bss_configs == 0)
+ 		usage();
+--- a/hostapd/radius.c
++++ b/hostapd/radius.c
+@@ -640,6 +640,11 @@ int radius_main(int argc, char **argv)
+ 			break;
+ 		case 'l':
+ 			wpa_debug_level = atoi(optarg);
++
++#ifdef CONFIG_MSG_MIN_PRIORITY
++	if (wpa_debug_level < CONFIG_MSG_MIN_PRIORITY)
++		wpa_printf(MSG_WARNING, "wpa_debug_level (%d) below compile-time limit: %d", wpa_debug_level, CONFIG_MSG_MIN_PRIORITY);
++#endif
+ 			break;
+ 		case 'C':
+ 			config.tls.ca_cert = optarg;
+--- a/wpa_supplicant/ctrl_iface.c
++++ b/wpa_supplicant/ctrl_iface.c
+@@ -2765,6 +2765,16 @@ static int wpa_supplicant_ctrl_iface_log
+ 		int level = str_to_debug_level(cmd);
+ 		if (level < 0)
+ 			return -1;
++
++#ifdef CONFIG_MSG_MIN_PRIORITY
++		if (wpa_debug_level < CONFIG_MSG_MIN_PRIORITY) {
++			wpa_printf(MSG_WARNING, "refusing to set wpa_debug_level (%d)"
++				" below compile-time limit: %d",
++				wpa_debug_level, CONFIG_MSG_MIN_PRIORITY);
++			return -1;
++		}
++#endif
++
+ 		wpa_debug_level = level;
+ 	}
+ 
+--- a/wpa_supplicant/main.c
++++ b/wpa_supplicant/main.c
+@@ -344,6 +344,13 @@ int main(int argc, char *argv[])
+ 		}
+ 	}
+ 
++#ifdef CONFIG_MSG_MIN_PRIORITY
++	if (wpa_debug_level < CONFIG_MSG_MIN_PRIORITY) {
++		wpa_printf(MSG_WARNING, "clamping wpa_debug_level (%d) to compile-time limit: %d", wpa_debug_level, CONFIG_MSG_MIN_PRIORITY);
++		wpa_debug_level = CONFIG_MSG_MIN_PRIORITY;
++	}
++#endif
++
+ 	exitcode = 0;
+ 	global = wpa_supplicant_init(&params);
+ 	if (global == NULL) {

--- a/package/network/services/hostapd/patches/601-ucode_support.patch
+++ b/package/network/services/hostapd/patches/601-ucode_support.patch
@@ -132,7 +132,7 @@ as adding/removing interfaces.
  ifdef CONFIG_CODE_COVERAGE
 --- a/hostapd/ctrl_iface.c
 +++ b/hostapd/ctrl_iface.c
-@@ -6061,6 +6061,7 @@ try_again:
+@@ -6071,6 +6071,7 @@ try_again:
  		return -1;
  	}
  
@@ -140,7 +140,7 @@ as adding/removing interfaces.
  	wpa_msg_register_cb(hostapd_ctrl_iface_msg_cb);
  
  	return 0;
-@@ -6162,6 +6163,7 @@ fail:
+@@ -6172,6 +6173,7 @@ fail:
  	os_free(fname);
  
  	interface->global_ctrl_sock = s;
@@ -150,7 +150,7 @@ as adding/removing interfaces.
  
 --- a/hostapd/main.c
 +++ b/hostapd/main.c
-@@ -1074,6 +1074,7 @@ int main(int argc, char *argv[])
+@@ -1081,6 +1081,7 @@ int main(int argc, char *argv[])
  	}
  
  	hostapd_global_ctrl_iface_init(&interfaces);
@@ -158,7 +158,7 @@ as adding/removing interfaces.
  
  	if (hostapd_global_run(&interfaces, daemonize, pid_file)) {
  		wpa_printf(MSG_ERROR, "Failed to start eloop");
-@@ -1083,6 +1084,7 @@ int main(int argc, char *argv[])
+@@ -1090,6 +1091,7 @@ int main(int argc, char *argv[])
  	ret = 0;
  
   out:


### PR DESCRIPTION
Openwrt allows "cutting off" wpa_debug_level in order to reduce the size of the binary. At runtime, wpa_debug_level can still be set to values below this threshold. Inform users when that happens.

This affects only the functions in wpa_debug.h. The settings related to the 'logger' aren't affected.
