### PR TITLE
sunxi: image: sync target profiles names with DT compatible

### DIFF
--- a/package/boot/uboot-sunxi/Makefile
+++ b/package/boot/uboot-sunxi/Makefile
@@ -134,17 +134,17 @@ define U-Boot/Mele_M9
   BUILD_DEVICES:=mele_m9
 endef
 
-define U-Boot/OLIMEX_A13_SOM
+define U-Boot/a13-som
   BUILD_SUBTARGET:=cortexa8
   NAME:=Olimex A13 SOM
-  BUILD_DEVICES:=olimex_a13-olimex-som
+  BUILD_DEVICES:=olimex_a13-olinuxino
 endef
 
 define U-Boot/licheepi_nano
   BUILD_SUBTARGET:=arm926ejs
   NAME:=LicheePi Nano
   UENV:=f1c
-  BUILD_DEVICES:=licheepi-nano
+  BUILD_DEVICES:=licheepi_licheepi-nano
 endef
 
 define U-Boot/Linksprite_pcDuino
@@ -268,7 +268,7 @@ define U-Boot/popstick
   BUILD_SUBTARGET:=arm926ejs
   NAME:=PopStick
   UENV:=f1c
-  BUILD_DEVICES:=popstick-v1.1
+  BUILD_DEVICES:=sourceparts_popstick-v1.1
 endef
 
 define U-Boot/libretech_all_h3_cc_h5
@@ -316,16 +316,16 @@ define U-Boot/pine64_plus
   ATF:=a64
 endef
 
-define U-Boot/bananapi_m2_plus_h3
+define U-Boot/bpi_m2_plus_h3
   BUILD_SUBTARGET:=cortexa7
   NAME:=Bananapi M2 Plus H3
-  BUILD_DEVICES:=sinovoip_bananapi-m2-plus
+  BUILD_DEVICES:=sinovoip_bpi-m2-plus
 endef
 
-define U-Boot/Sinovoip_BPI_M3
+define U-Boot/bpi_m3
   BUILD_SUBTARGET:=cortexa7
   NAME:=Bananapi M3
-  BUILD_DEVICES:=sinovoip_bananapi-m3
+  BUILD_DEVICES:=sinovoip_bpi-m3
 endef
 
 define U-Boot/sopine_baseboard
@@ -382,22 +382,22 @@ define U-Boot/orangepi_zero3
   ATF:=h616
 endef
 
-define U-Boot/Bananapi_M2_Ultra
+define U-Boot/bpi_m2_ultra
   BUILD_SUBTARGET:=cortexa7
   NAME:=Bananapi M2 Ultra
-  BUILD_DEVICES:=sinovoip_bananapi-m2-ultra
+  BUILD_DEVICES:=sinovoip_bpi-m2-ultra
 endef
 
-define U-Boot/bananapi_m2_berry
+define U-Boot/bpi_m2_berry
   BUILD_SUBTARGET:=cortexa7
   NAME:=Bananapi M2 Berry
-  BUILD_DEVICES:=sinovoip_bananapi-m2-berry
+  BUILD_DEVICES:=sinovoip_bpi-m2-berry
 endef
 
-define U-Boot/bananapi_p2_zero
+define U-Boot/bpi_p2_zero
   BUILD_SUBTARGET:=cortexa7
   NAME:=Bananapi P2 Zero
-  BUILD_DEVICES:=sinovoip_bananapi-p2-zero
+  BUILD_DEVICES:=sinovoip_bpi-p2-zero
 endef
 
 
@@ -406,24 +406,25 @@ UBOOT_TARGETS := \
 	a64-olinuxino-emmc \
 	A10-OLinuXino-Lime \
 	A13-OLinuXino \
+	a13-som \
 	A20-OLinuXino-Lime \
 	A20-OLinuXino-Lime2 \
 	A20-OLinuXino-Lime2-eMMC \
 	A20-OLinuXino_MICRO \
-	bananapi_m2_plus_h3 \
-	Bananapi \
-	bananapi_m2_berry \
-	bananapi_p2_zero \
-	Bananapi_M2_Ultra \
-	Bananapro \
 	beelink_x2 \
+	bpi_m2_berry \
+	bpi_m2_plus_h3 \
+	bpi_m2_ultra \
+	bpi_m3 \
+	bpi_p2_zero \
+	Bananapi \
+	Bananapro \
 	Cubieboard \
 	Cubieboard2 \
 	Cubietruck \
 	Hummingbird_A31 \
 	Marsboard_A10 \
 	Mele_M9 \
-	OLIMEX_A13_SOM \
 	licheepi_nano \
 	LicheePi_Zero \
 	Linksprite_pcDuino \
@@ -453,7 +454,6 @@ UBOOT_TARGETS := \
 	pangolin \
 	popstick \
 	pine64_plus \
-	Sinovoip_BPI_M3 \
 	sopine_baseboard \
 	orangepi_zero_plus \
 	libretech_all_h3_cc_h5

--- a/target/linux/sunxi/image/arm926ejs.mk
+++ b/target/linux/sunxi/image/arm926ejs.mk
@@ -7,20 +7,21 @@
 
 KERNEL_LOADADDR=0x81000000
 
-define Device/licheepi-nano
+define Device/licheepi_licheepi-nano
   $(call Device/FitImageGzip)
   DEVICE_VENDOR := LicheePi
-  DEVICE_MODEL := Nano
+  DEVICE_MODEL := LicheePi Nano
   DEVICE_PACKAGES := kmod-rtc-sunxi
   SOC := suniv-f1c100s
 endef
-TARGET_DEVICES += licheepi-nano
+TARGET_DEVICES += licheepi_licheepi-nano
 
-define Device/popstick-v1.1
+define Device/sourceparts_popstick-v1.1
   $(call Device/FitImageGzip)
-  DEVICE_VENDOR := PopStick
-  DEVICE_MODEL := v1.1
+  DEVICE_VENDOR := SourceParts
+  DEVICE_MODEL := PopStick
+  DEVICE_VARIANT := v1.1
   DEVICE_PACKAGES := kmod-rtc-sunxi
   SOC := suniv-f1c200s
 endef
-TARGET_DEVICES += popstick-v1.1
+TARGET_DEVICES += sourceparts_popstick-v1.1

--- a/target/linux/sunxi/image/cortexa53.mk
+++ b/target/linux/sunxi/image/cortexa53.mk
@@ -39,7 +39,7 @@ endef
 define Device/friendlyarm_nanopi-neo-plus2
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO Plus2
-  SUPPORTED_DEVICES:=nanopi-neo-plus2
+  SUPPORTED_DEVICES += nanopi-neo-plus2
   $(Device/sun50i-h5)
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo-plus2
@@ -47,7 +47,7 @@ TARGET_DEVICES += friendlyarm_nanopi-neo-plus2
 define Device/friendlyarm_nanopi-neo2
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi NEO2
-  SUPPORTED_DEVICES:=nanopi-neo2
+  SUPPORTED_DEVICES += nanopi-neo2
   $(Device/sun50i-h5)
 endef
 TARGET_DEVICES += friendlyarm_nanopi-neo2
@@ -56,7 +56,7 @@ define Device/friendlyarm_nanopi-r1s-h5
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := Nanopi R1S H5
   DEVICE_PACKAGES := kmod-gpio-button-hotplug kmod-usb-net-rtl8152
-  SUPPORTED_DEVICES:=nanopi-r1s-h5
+  SUPPORTED_DEVICES += nanopi-r1s-h5
   $(Device/sun50i-h5)
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r1s-h5
@@ -109,7 +109,6 @@ define Device/xunlong_orangepi-one-plus
   $(Device/sun50i-h6)
   DEVICE_VENDOR := Xunlong
   DEVICE_MODEL := Orange Pi One Plus
-  SUNXI_DTS_DIR := allwinner/
 endef
 TARGET_DEVICES += xunlong_orangepi-one-plus
 

--- a/target/linux/sunxi/image/cortexa7.mk
+++ b/target/linux/sunxi/image/cortexa7.mk
@@ -92,27 +92,29 @@ define Device/lemaker_bananapi
 endef
 TARGET_DEVICES += lemaker_bananapi
 
-define Device/sinovoip_bananapi-m2-berry
+define Device/sinovoip_bpi-m2-berry
   $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Berry
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
 	cypress-firmware-43430-sdio wpad-basic-mbedtls
-  SUPPORTED_DEVICES:=lemaker,bananapi-m2-berry
+  SUPPORTED_DEVICES += lemaker,bananapi-m2-berry
   SOC := sun8i-v40
+  SUNXI_DTS := $$(SUNXI_DTS_DIR)$$(SOC)-bananapi-m2-berry
 endef
-TARGET_DEVICES += sinovoip_bananapi-m2-berry
+TARGET_DEVICES += sinovoip_bpi-m2-berry
 
-define Device/sinovoip_bananapi-m2-ultra
+define Device/sinovoip_bpi-m2-ultra
   $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2 Ultra
   DEVICE_PACKAGES:=kmod-ata-sunxi kmod-brcmfmac \
 	brcmfmac-firmware-43430a0-sdio wpad-basic-mbedtls
-  SUPPORTED_DEVICES:=lemaker,bananapi-m2-ultra
+  SUPPORTED_DEVICES += lemaker,bananapi-m2-ultra
   SOC := sun8i-r40
+  SUNXI_DTS := $$(SUNXI_DTS_DIR)$$(SOC)-bananapi-m2-ultra
 endef
-TARGET_DEVICES += sinovoip_bananapi-m2-ultra
+TARGET_DEVICES += sinovoip_bpi-m2-ultra
 
 define Device/lemaker_bananapro
   $(call Device/FitImageGzip)
@@ -217,35 +219,38 @@ define Device/roofull_beelink-x2
 endef
 TARGET_DEVICES += roofull_beelink-x2
 
-define Device/sinovoip_bananapi-m2-plus
+define Device/sinovoip_bpi-m2-plus
   $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M2+
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
 	brcmfmac-firmware-43430a0-sdio wpad-basic-mbedtls
   SOC := sun8i-h3
+  SUNXI_DTS := $$(SUNXI_DTS_DIR)$$(SOC)-bananapi-m2-plus
 endef
-TARGET_DEVICES += sinovoip_bananapi-m2-plus
+TARGET_DEVICES += sinovoip_bpi-m2-plus
 
-define Device/sinovoip_bananapi-m3
+define Device/sinovoip_bpi-m3
   $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi M3
   DEVICE_PACKAGES:=kmod-rtc-sunxi kmod-leds-gpio kmod-rtc-ac100 \
 	kmod-brcmfmac cypress-firmware-43430-sdio wpad-basic-mbedtls
   SOC := sun8i-a83t
+  SUNXI_DTS := $$(SUNXI_DTS_DIR)$$(SOC)-bananapi-m3
 endef
-TARGET_DEVICES += sinovoip_bananapi-m3
+TARGET_DEVICES += sinovoip_bpi-m3
 
-define Device/sinovoip_bananapi-p2-zero
+define Device/sinovoip_bpi-p2-zero
   $(call Device/FitImageGzip)
   DEVICE_VENDOR := Sinovoip
   DEVICE_MODEL := Banana Pi P2 Zero
   DEVICE_PACKAGES:=kmod-leds-gpio kmod-brcmfmac \
 	cypress-firmware-43430-sdio wpad-basic-mbedtls
   SOC := sun8i-h2-plus
+  SUNXI_DTS := $$(SUNXI_DTS_DIR)$$(SOC)-bananapi-p2-zero
 endef
-TARGET_DEVICES += sinovoip_bananapi-p2-zero
+TARGET_DEVICES += sinovoip_bpi-p2-zero
 
 define Device/xunlong_orangepi-one
   $(call Device/FitImageGzip)

--- a/target/linux/sunxi/image/cortexa8.mk
+++ b/target/linux/sunxi/image/cortexa8.mk
@@ -43,21 +43,12 @@ define Device/olimex_a10-olinuxino-lime
 endef
 TARGET_DEVICES += olimex_a10-olinuxino-lime
 
-define Device/olimex_a13-olimex-som
-  $(call Device/FitImageGzip)
-  DEVICE_VENDOR := Olimex
-  DEVICE_MODEL := A13-SOM
-  DEVICE_PACKAGES:=kmod-rtl8192cu
-  SUPPORTED_DEVICES:=olimex,a13-olinuxino
-  SOC := sun5i-a13
-  SUNXI_DTS := $$(SUNXI_DTS_DIR)sun5i-a13-olinuxino
-endef
-TARGET_DEVICES += olimex_a13-olimex-som
-
 define Device/olimex_a13-olinuxino
   $(call Device/FitImageGzip)
   DEVICE_VENDOR := Olimex
   DEVICE_MODEL := A13-OLinuXino
+  DEVICE_ALT0_VENDOR := Olimex
+  DEVICE_ALT0_MODEL := A13-SOM
   DEVICE_PACKAGES:=kmod-rtl8192cu
   SOC := sun5i
 endef


### PR DESCRIPTION
Following up with errors reported in the ASU repo, these bananapi cases do not match the DT compatible "bpi", sync with dts sources [^1]. Also some profiles were overwriting SUPPORTED_DEVICES.
Sysupgrade would be failing in SUPPORTED_DEVICES check since the DT compatible(/tmp/sysinfo/board_name) is not in SUPPORTED_DEVICES. This should also fix errors when using ASU sysupgrade clients.
- Sync profile makefile target names with DT compatibles.
- Fix overwrites of SUPPORTED_DEVICES instead of appending.
- Adapt the uboot-sunxi profiles accordingly. 

*bpi-p2-zero dts is still not upstream.

V2:
- Include fixes for arm926ejs(ARM926EJ-S) subtarget (LicheePi Nano and
PopStick v1.1) (profile rename for correct default SUPPORTED_DEVICES)

Fixes: https://forum.openwrt.org/t/luci-attended-sysupgrade-support-thread/230552/246
Fixes: https://github.com/openwrt/asu/issues/486
Fixes: https://github.com/openwrt/asu/issues/524
Fixes: 9aa66b8ce730aebff76d353392151708a897a3a0 "sunxi: add support for Banana Pi M2 Berry"
Fixes: d5f615bf2a0434c15d13943b566d46f25da579bb "sunxi: add support for Sinovoip Banana Pi M2 Plus"
Fixes: 3819c1638a9d300840d0f869628891f9696be112 "sunxi: Add support for Banana Pi M2 Ultra"
Fixes: 6bf8193b25a147abfe3720104e63af890c1ca2b8 "sunxi: add support for Bananapi P2 Zero"
Fixes: 80edfaf675364835e6d2e17d97ebec6afc6b2103 "sunxi: add support for Banana Pi M3"
Fixes: 3c24a1d423a6052b101c00cb7d94e70d72702639 "sunxi: add support for NanoPi NEO Plus2 board"
Fixes: a689307c970e37c247c6452ba3963be8b109eb4f "sunxi: build image/uboot for the NanoPi NEO2"
Fixes: fde68cb80941a60be93ece75e808b5b407d11cc8 "sunxi: add support for FriendlyARM NanoPi R1S H5"
Fixes: 3ec468ff4fa3106d459ae58ec4bc4833715118c6 "sunxi: add F1C100 (arm926ej-s) support"

[^1]: Upstream dts souces https://elixir.bootlin.com/linux/v6.12.60/source/arch/arm64/boot/dts/allwinner - https://elixir.bootlin.com/linux/v6.12.60/source/arch/arm/boot/dts/allwinner