### PR TITLE
mediatek: dts: rework mt7981b.dtsi

### DIFF
--- a/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
+++ b/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
@@ -173,8 +173,6 @@
 };
 
 &eth {
-	pinctrl-names = "default";
-	pinctrl-0 = <&gbe_led0_pins>, <&gbe_led1_pins>;
 	status = "okay";
 
 	gmac0: mac@0 {
@@ -200,6 +198,11 @@
 		nvmem-cells = <&macaddr_config_0 1>;
 		nvmem-cell-names = "mac-address";
 	};
+};
+
+&int_gbe_phy {
+	pinctrl-names = "default";
+	pinctrl-0 = <&gbe_led0_pins>, <&gbe_led1_pins>;
 };
 
 &int_gbe_phy_led0{
@@ -447,6 +450,20 @@
 };
 
 &pio {
+	gbe_led0_pins: gbe-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe_led0";
+		};
+	};
+
+	gbe_led1_pins: gbe-led1-pins {
+		mux {
+			function = "led";
+			groups = "gbe_led1";
+		};
+	};
+
 	spi0_flash_pins: spi0-pins {
 		mux {
 			function = "spi";

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
@@ -94,7 +94,7 @@
 
 &eth {
 	pinctrl-names = "default";
-	pinctrl-0 = <&mdio_pins &gbe_led0_pins>;
+	pinctrl-0 = <&mdio_pins>;
 
 	status = "okay";
 

--- a/target/linux/mediatek/dts/mt7981b-totolink-x6000r.dts
+++ b/target/linux/mediatek/dts/mt7981b-totolink-x6000r.dts
@@ -74,7 +74,7 @@
 
 &eth {
 	pinctrl-names = "default";
-	pinctrl-0 = <&mdio_pins &gbe_led0_pins &gbe_led1_pins>;
+	pinctrl-0 = <&mdio_pins>;
 	status = "okay";
 
 	gmac0: mac@0 {

--- a/target/linux/mediatek/dts/mt7981b-unielec-u7981-01.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-unielec-u7981-01.dtsi
@@ -33,7 +33,7 @@
 
 &eth {
 	pinctrl-names = "default";
-	pinctrl-0 = <&mdio_pins &gbe_led0_pins &gbe_led1_pins>;
+	pinctrl-0 = <&mdio_pins>;
 	status = "okay";
 
 	gmac0: mac@0 {

--- a/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
+++ b/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
@@ -304,7 +304,7 @@ working:
  		};
  
  		efuse@11f20000 {
-@@ -211,17 +387,318 @@
+@@ -211,17 +387,296 @@
  			reg = <0 0x11f20000 0 0x1000>;
  			#address-cells = <1>;
  			#size-cells = <1>;
@@ -431,21 +431,6 @@ working:
 +					};
 +				};
 +			};
-+		};
-+
-+		wdma: wdma@15104800 {
-+			compatible = "mediatek,wed-wdma";
-+			reg = <0 0x15104800 0 0x400>,
-+			      <0 0x15104c00 0 0x400>;
-+		};
-+
-+		ap2woccif: ap2woccif@151a5000 {
-+			compatible = "mediatek,ap2woccif";
-+			reg = <0 0x151a5000 0 0x1000>,
-+			      <0 0x151ad000 0 0x1000>;
-+			interrupt-parent = <&gic>;
-+			interrupts = <GIC_SPI 211 IRQ_TYPE_LEVEL_HIGH>,
-+				     <GIC_SPI 212 IRQ_TYPE_LEVEL_HIGH>;
 +		};
 +
 +		wo_dlm0: syscon@151e8000 {
@@ -611,13 +596,6 @@ working:
 +			status = "disabled";
 +		};
 +
-+		ice: ice_debug {
-+			compatible = "mediatek,mt7981-ice_debug",
-+				   "mediatek,mt2701-ice_debug";
-+			clocks = <&infracfg CLK_INFRA_DBG_CK>;
-+			clock-names = "ice_dbg";
-+		};
-+
 +		wifi: wifi@18000000 {
  			compatible = "mediatek,mt7981-wmac";
 +			pinctrl-0 = <&wifi_dbdc_pins>;
@@ -625,7 +603,7 @@ working:
  			reg = <0 0x18000000 0 0x1000000>,
  			      <0 0x10003000 0 0x1000>,
  			      <0 0x11d10000 0 0x1000>;
-@@ -234,6 +711,67 @@
+@@ -234,6 +689,67 @@
  			clock-names = "mcu", "ap2conn";
  			resets = <&watchdog MT7986_TOPRGU_CONSYS_SW_RST>;
  			reset-names = "consys";
@@ -693,7 +671,7 @@ working:
  		};
  	};
  
-@@ -245,4 +783,8 @@
+@@ -245,4 +761,8 @@
  			     <GIC_PPI 11 IRQ_TYPE_LEVEL_LOW>,
  			     <GIC_PPI 10 IRQ_TYPE_LEVEL_LOW>;
  	};

--- a/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
+++ b/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
@@ -304,7 +304,7 @@ working:
  		};
  
  		efuse@11f20000 {
-@@ -211,17 +387,296 @@
+@@ -211,17 +387,300 @@
  			reg = <0 0x11f20000 0 0x1000>;
  			#address-cells = <1>;
  			#size-cells = <1>;
@@ -564,6 +564,10 @@ working:
 +				clock-names = "ref";
 +				#phy-cells = <1>;
 +				mediatek,syscon-type = <&topmisc 0x218 0>;
++				nvmem-cells = <&comb_intr_p0>,
++					      <&comb_rx_imp_p0>,
++					      <&comb_tx_imp_p0>;
++				nvmem-cell-names = "intr", "rx_imp", "tx_imp";
 +				status = "okay";
 +			};
 +		};
@@ -603,7 +607,7 @@ working:
  			reg = <0 0x18000000 0 0x1000000>,
  			      <0 0x10003000 0 0x1000>,
  			      <0 0x11d10000 0 0x1000>;
-@@ -234,6 +689,67 @@
+@@ -234,6 +693,67 @@
  			clock-names = "mcu", "ap2conn";
  			resets = <&watchdog MT7986_TOPRGU_CONSYS_SW_RST>;
  			reset-names = "consys";
@@ -671,7 +675,7 @@ working:
  		};
  	};
  
-@@ -245,4 +761,8 @@
+@@ -245,4 +765,8 @@
  			     <GIC_PPI 11 IRQ_TYPE_LEVEL_LOW>,
  			     <GIC_PPI 10 IRQ_TYPE_LEVEL_LOW>;
  	};

--- a/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
+++ b/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
@@ -304,7 +304,7 @@ working:
  		};
  
  		efuse@11f20000 {
-@@ -211,17 +387,300 @@
+@@ -211,17 +387,301 @@
  			reg = <0 0x11f20000 0 0x1000>;
  			#address-cells = <1>;
  			#size-cells = <1>;
@@ -395,6 +395,7 @@ working:
 +			mediatek,sgmiisys = <&sgmiisys0>, <&sgmiisys1>;
 +			mediatek,infracfg = <&topmisc>;
 +			mediatek,wed = <&wed>;
++			mediatek,wed-pcie = <&wed_pcie>;
 +			status = "disabled";
 +
 +			mdio_bus: mdio-bus {
@@ -510,7 +511,7 @@ working:
 +		};
 +
 +		wed_pcie: wed_pcie@10003000 {
-+			compatible = "mediatek,wed_pcie";
++			compatible = "mediatek,wed_pcie", "syscon";
 +			reg = <0 0x10003000 0 0x10>;
 +		};
 +
@@ -607,7 +608,7 @@ working:
  			reg = <0 0x18000000 0 0x1000000>,
  			      <0 0x10003000 0 0x1000>,
  			      <0 0x11d10000 0 0x1000>;
-@@ -234,6 +693,67 @@
+@@ -234,6 +694,67 @@
  			clock-names = "mcu", "ap2conn";
  			resets = <&watchdog MT7986_TOPRGU_CONSYS_SW_RST>;
  			reset-names = "consys";
@@ -675,7 +676,7 @@ working:
  		};
  	};
  
-@@ -245,4 +765,8 @@
+@@ -245,4 +766,8 @@
  			     <GIC_PPI 11 IRQ_TYPE_LEVEL_LOW>,
  			     <GIC_PPI 10 IRQ_TYPE_LEVEL_LOW>;
  	};

--- a/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
+++ b/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
@@ -254,7 +254,7 @@ working:
  		pio: pinctrl@11d00000 {
  			compatible = "mediatek,mt7981-pinctrl";
  			reg = <0 0x11d00000 0 0x1000>,
-@@ -204,6 +337,49 @@
+@@ -204,6 +337,35 @@
  			gpio-controller;
  			#gpio-cells = <2>;
  			#interrupt-cells = <2>;
@@ -287,24 +287,10 @@ working:
 +					drive-strength = <MTK_DRIVE_4mA>;
 +				};
 +			};
-+
-+			gbe_led0_pins: gbe-led0-pins {
-+				mux {
-+					function = "led";
-+					groups = "gbe_led0";
-+				};
-+			};
-+
-+			gbe_led1_pins: gbe-led1-pins {
-+				mux {
-+					function = "led";
-+					groups = "gbe_led1";
-+				};
-+			};
  		};
  
  		efuse@11f20000 {
-@@ -211,17 +387,301 @@
+@@ -211,17 +373,297 @@
  			reg = <0 0x11f20000 0 0x1000>;
  			#address-cells = <1>;
  			#size-cells = <1>;
@@ -417,16 +403,12 @@ working:
 +						int_gbe_phy_led0: int-gbe-phy-led0@0 {
 +							reg = <0>;
 +							function = LED_FUNCTION_LAN;
-+							pinctrl-0 = <&gbe_led0_pins>;
-+							pinctrl-names = "default";
 +							status = "disabled";
 +						};
 +
 +						int_gbe_phy_led1: int-gbe-phy-led1@1 {
 +							reg = <1>;
 +							function = LED_FUNCTION_LAN;
-+							pinctrl-0 = <&gbe_led1_pins>;
-+							pinctrl-names = "default";
 +							status = "disabled";
 +						};
 +					};
@@ -608,7 +590,7 @@ working:
  			reg = <0 0x18000000 0 0x1000000>,
  			      <0 0x10003000 0 0x1000>,
  			      <0 0x11d10000 0 0x1000>;
-@@ -234,6 +694,67 @@
+@@ -234,6 +676,67 @@
  			clock-names = "mcu", "ap2conn";
  			resets = <&watchdog MT7986_TOPRGU_CONSYS_SW_RST>;
  			reset-names = "consys";
@@ -676,7 +658,7 @@ working:
  		};
  	};
  
-@@ -245,4 +766,8 @@
+@@ -245,4 +748,8 @@
  			     <GIC_PPI 11 IRQ_TYPE_LEVEL_LOW>,
  			     <GIC_PPI 10 IRQ_TYPE_LEVEL_LOW>;
  	};

--- a/target/linux/mediatek/patches-6.12/187-arm64-dts-mediatek-fix-mt7981-spim-clock.patch
+++ b/target/linux/mediatek/patches-6.12/187-arm64-dts-mediatek-fix-mt7981-spim-clock.patch
@@ -1,0 +1,53 @@
+From 0c74ae06ed6b6c9627712a74ecee4e61bbd4092d Mon Sep 17 00:00:00 2001
+From: developer <developer@mediatek.com>
+Date: Mon, 19 Jan 2026 21:42:29 +0800
+Subject: [PATCH] arm64: dts: mediatek: fix mt7981 spim clock
+
+1) Add spi0/1/2 clock parent setting
+2) Fix spi1 clock_sel to CLK_TOP_SPIM_MST_SEL
+
+Link: https://git01.mediatek.com/plugins/gitiles/openwrt/feeds/mtk-openwrt-feeds/+/836034ca0baad57e4c287a62ccc5677c60be0e18
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ arch/arm64/boot/dts/mediatek/mt7981b.dtsi | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7981b.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7981b.dtsi
+@@ -248,6 +248,10 @@
+ 				 <&topckgen CLK_TOP_SPI_SEL>,
+ 				 <&infracfg CLK_INFRA_SPI2_CK>,
+ 				 <&infracfg CLK_INFRA_SPI2_HCK_CK>;
++			assigned-clocks = <&topckgen CLK_TOP_SPI_SEL>,
++					  <&infracfg CLK_INFRA_SPI2_SEL>;
++			assigned-clock-parents = <&topckgen CLK_TOP_CB_M_D2>,
++						 <&topckgen CLK_TOP_SPI_SEL>;
+ 			clock-names = "parent-clk", "sel-clk", "spi-clk", "hclk";
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;
+@@ -262,6 +266,10 @@
+ 				 <&topckgen CLK_TOP_SPI_SEL>,
+ 				 <&infracfg CLK_INFRA_SPI0_CK>,
+ 				 <&infracfg CLK_INFRA_SPI0_HCK_CK>;
++			assigned-clocks = <&topckgen CLK_TOP_SPI_SEL>,
++					  <&infracfg CLK_INFRA_SPI0_SEL>;
++			assigned-clock-parents = <&topckgen CLK_TOP_CB_M_D2>,
++						 <&topckgen CLK_TOP_SPI_SEL>;
+ 			clock-names = "parent-clk", "sel-clk", "spi-clk", "hclk";
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;
+@@ -273,9 +281,13 @@
+ 			reg = <0 0x1100b000 0 0x1000>;
+ 			interrupts = <GIC_SPI 141 IRQ_TYPE_LEVEL_HIGH>;
+ 			clocks = <&topckgen CLK_TOP_CB_M_D2>,
+-				 <&topckgen CLK_TOP_SPI_SEL>,
++				 <&topckgen CLK_TOP_SPIM_MST_SEL>,
+ 				 <&infracfg CLK_INFRA_SPI1_CK>,
+ 				 <&infracfg CLK_INFRA_SPI1_HCK_CK>;
++			assigned-clocks = <&topckgen CLK_TOP_SPIM_MST_SEL>,
++					  <&infracfg CLK_INFRA_SPI1_SEL>;
++			assigned-clock-parents = <&topckgen CLK_TOP_CB_M_D2>,
++						 <&topckgen CLK_TOP_SPIM_MST_SEL>;
+ 			clock-names = "parent-clk", "sel-clk", "spi-clk", "hclk";
+ 			#address-cells = <1>;
+ 			#size-cells = <0>;


### PR DESCRIPTION
These stuffs were copied from the vendor SDK. There are currently no drivers compatible with them. The pending upstream patches did not include them either.