### PR TITLE
[24.10] ramips: add support for D-Link DIR-2660 A2

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -960,6 +960,9 @@ define Device/dlink_dir-2660-a1
   $(Device/dlink_dir_nand_128m)
   DEVICE_MODEL := DIR-2660
   DEVICE_VARIANT := A1
+  DEVICE_ALT0_VENDOR := D-Link
+  DEVICE_ALT0_MODEL := DIR-2660
+  DEVICE_ALT0_VARIANT := A2
 endef
 TARGET_DEVICES += dlink_dir-2660-a1
 


### PR DESCRIPTION
Backport D-link DIR-2660 A2 device to 24.10


This patch adds support for D-Link DIR-2660 A2.
Based on the commit: https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=b5dd746cbb1aaf91f4b68e9f3eda97413550d904,

Both devices look identical, except for the A1/A2 designation. You can safely install the A1 firmware for the A2 – I've been testing it for several months as a DUMB AP – without any problems.

Specifications:
* SoC: MediaTek MT7621AT
* RAM: 256 MB (DDR3)
* Flash: 128 MB (NAND)
* WiFi: MediaTek MT7615N (x2)
* Switch: 1 WAN, 4 LAN (Gigabit)
* Ports: 1 USB 2.0, 1 USB 3.0
* Buttons: Reset, WPS
* LEDs: Power (white/orange), Internet (white/orange), WiFi 2.4G (white), WiFi 5G (white), USB 3.0 (white), USB 2.0 (white)

Notes:
* WiFi 2.4G and WiFi 5G LEDs are wired directly to the wireless chips

Installation:
* D-Link Recovery GUI: power down the router, press and hold the reset button, then re-plug it. Keep the reset button pressed until the power LED starts flashing orange, manually assign a static IP address under the 192.168.0.xxx subnet (e.g. 192.168.0.2) and go to http://192.168.0.1

* Some modern browsers may have problems flashing via the Recovery GUI, if that occurs consider uploading the firmware through cURL:

    curl -v -i -F "firmware=@file.bin" 192.168.0.1


Link: https://github.com/openwrt/openwrt/pull/20020