### PR TITLE
base-files: upgrade: nand: add rootfs volume ID support

### DIFF
--- a/package/base-files/files/lib/upgrade/nand.sh
+++ b/package/base-files/files/lib/upgrade/nand.sh
@@ -243,7 +243,11 @@ nand_upgrade_prepare_ubi() {
 		else
 			rootfs_size_param="-s $rootfs_length"
 		fi
-		if ! ubimkvol /dev/$root_ubidev -N "$CI_ROOTPART" $rootfs_size_param; then
+		local vol_id="${CI_ROOT_UBI_VOL_ID}"
+		if [ -n "$vol_id" ]; then
+			vol_id="-n $vol_id"
+		fi
+		if ! ubimkvol /dev/$root_ubidev -N "$CI_ROOTPART" $rootfs_size_param $vol_id; then
 			echo "cannot create rootfs volume"
 			return 1;
 		fi


### PR DESCRIPTION
I am currently trying hard to get around all quirks and annoyances in a vendor modified U-Boot.  The vendor has implemented a dual firmware scheme using a number of duplicate volumes (kernel, rootfs, ++) inside the same ubi device.

Going a bit back and forth, I have now ended up with a scheme where I use whichever one of the vendors two kernel volumes we happened to hit on install, but with an OpenWrt specific squashfs rootfs volume (I know this would have been .easier using ubifs - maybe I should?).  To make that fly I have this command line:

`bootargs = "root=/dev/ubiblock0_42 ubi.block=0,openwrt rootwait"
`
setting
```
CI_ROOTPART="openwrt"
CI_ROOT_UBI_VOL_ID=42
```
in platform_do_upgrade() to get the feature implemented by this patch. 
`
Still not sure this is a good idea, but wanted to post it here for feedback anyway.
