### PR TITLE
base-files: always generate default DUID

### DIFF
--- a/package/base-files/files/etc/uci-defaults/14_network-generate-duid
+++ b/package/base-files/files/etc/uci-defaults/14_network-generate-duid
@@ -1,4 +1,4 @@
-[ "$(uci -q get network.globals.dhcp_default_duid)" != "auto" ] && exit 0
+[ "$(uci -q get network.globals.dhcp_default_duid || echo "auto")" != "auto" ] && exit 0
 
 uci -q batch <<-EOF >/dev/null
 	# DUID-UUID - RFC6355


### PR DESCRIPTION
The previous logic was copied from 12_network-generate-ula, but fails to account for upgrades where the "auto" value isn't set (it is set by base-files/files/bin/config_generate). Fix this to always set the default duid if it isn't set.

Also, rename the file to better reflect what it does.

Closes: https://github.com/openwrt/openwrt/issues/21029