### PR TITLE
ath79: iodata: set eth MAC in dts

### DIFF
--- a/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
+++ b/target/linux/ath79/dts/ar9342_iodata_etg3-r.dts
@@ -71,6 +71,14 @@
 			partition@40000 {
 				label = "u-boot-env";
 				reg = <0x040000 0x010000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_uboot_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@50000 {
@@ -125,6 +133,9 @@
 
 	phy-mode = "rgmii";
 	phy-handle = <&phy0>;
+
+	nvmem-cells = <&macaddr_uboot_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
 
 	gmac-config {
 		device = <&gmac>;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -742,8 +742,7 @@ ath79_setup_macs()
 		label_mac=$(mtd_get_mac_binary u-boot 0x1fc00)
 		;;
 	iodata,etg3-r)
-		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-		wan_mac=$(macaddr_add "$lan_mac" -1)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" -1)
 		label_mac=$wan_mac
 		;;
 	iodata,wn-ac1167dgr|\

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -729,8 +729,7 @@ ath79_setup_macs()
 		label_mac=$(mtd_get_mac_binary u-boot 0x1fc00)
 		;;
 	iodata,etg3-r)
-		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-		wan_mac=$(macaddr_add "$lan_mac" -1)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" -1)
 		label_mac=$wan_mac
 		;;
 	iodata,wn-ac1167dgr|\


### PR DESCRIPTION
Userspace handling is deprecated. WAN stuff needs to remain as no DSA yet.