### PR TITLE
treewide: remove obsolete packet steering defaults

### DIFF
--- a/target/linux/bcm53xx/base-files/etc/uci-defaults/05_packet_steering
+++ b/target/linux/bcm53xx/base-files/etc/uci-defaults/05_packet_steering
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: GPL-2.0-only
-
-uci set network.@globals[0].packet_steering="1"

--- a/target/linux/ramips/mt7621/base-files/etc/uci-defaults/01_enable_packet_steering
+++ b/target/linux/ramips/mt7621/base-files/etc/uci-defaults/01_enable_packet_steering
@@ -1,5 +1,0 @@
-uci -q get network.globals.packet_steering > /dev/null || {
-	uci set network.globals='globals'
-	uci set network.globals.packet_steering=1
-	uci commit network
-}


### PR DESCRIPTION
Packet steering defaults to 1 (Enable) on clean install[1]. No need to set it again.

[1] https://github.com/openwrt/luci/commit/d889c27b4bc77c18b83548a60412b1b418d77439#diff-56df

The following may no longer be needed or need to be adapted for the new packet-steering.uc:

1. [target/linux/bcm4908/base-files/usr/libexec/platform/packet-steering.sh](https://github.com/openwrt/openwrt/blob/46532c9bcb1902dc016806dd3199d16dc2fd33b4/target/linux/bcm4908/base-files/usr/libexec/platform/packet-steering.sh#L3)
2. [target/linux/bcm53xx/base-files/usr/libexec/platform/packet-steering.sh](https://github.com/openwrt/openwrt/blob/46532c9bcb1902dc016806dd3199d16dc2fd33b4/target/linux/bcm53xx/base-files/usr/libexec/platform/packet-steering.sh#L3)