### PR TITLE
econet: en751221: add support for Genexis Platinum 4410

### DIFF
--- a/target/linux/econet/base-files/sbin/en75_chboot
+++ b/target/linux/econet/base-files/sbin/en75_chboot
@@ -102,6 +102,10 @@ switch() {
 
 main() {
     case "$(board_name)" in
+    genexis,platinum-4410)
+        echo "Genexis Platinum 4410 does not support multiboot because of a bootloader bug"
+        exit 1
+        ;;
     tplink,archer-vr1200v-v2)
         # 03fe0000
         part=$(part_named '"reserve"')

--- a/target/linux/econet/dts/en751221_genexis_platinum-4410.dts
+++ b/target/linux/econet/dts/en751221_genexis_platinum-4410.dts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include "en751221.dtsi"
+
+/ {
+	model = "Genexis Platinum 4410";
+	compatible = "genexis,platinum-4410", "econet,en751221";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x4000000>;
+	};
+
+	chosen {
+		stdout-path = "/serial@1fbf0000:115200";
+		linux,usable-memory-range = <0x00020000 0x3fe0000>;
+	};
+};
+
+&nand {
+	status = "okay";
+	econet,bmt;
+	econet,bbt-table-size = <250>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootloader";
+			reg = <0x0 0x40000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_bootloader_ff48: macaddr@ff48 {
+					compatible = "mac-base";
+					reg = <0xff48 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@40000 {
+			label = "romfile";
+			reg = <0x40000 0x40000>;
+		};
+
+		partition@80000 {
+			label = "tclinux";
+			reg = <0x80000 0x1000000>;
+			econet,enable-remap;
+		};
+
+		/* Nested inside of tclinux */
+		partition@480000 {
+			label = "rootfs";
+			reg = <0x480000 0xb80000>;
+			linux,rootfs;
+		};
+
+		partition@1080000 {
+			label = "tclinux_slave";
+			reg = <0x1080000 0x1000000>;
+		};
+
+		partition@2080000 {
+			label = "yaffs";
+			reg = <0x2080000 0x2900000>;
+		};
+
+		partition@4980000 {
+			label = "unknown";
+			reg = <0x4980000 0x24c0000>;
+		};
+
+		partition@6e40000 {
+			label = "reservearea";
+			reg = <0x6e40000 0x1c0000>;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_reserve_140000: eeprom@140000 {
+					reg = <0x140000 0x200>;
+				};
+			};
+		};
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	nvmem-cells = <&macaddr_bootloader_ff48 0>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/econet/image/en751221.mk
+++ b/target/linux/econet/image/en751221.mk
@@ -9,6 +9,15 @@ define Device/en751221_generic
 endef
 TARGET_DEVICES += en751221_generic
 
+define Device/genexis_platinum-4410
+  DEVICE_VENDOR := Genexis
+  DEVICE_MODEL := Platinum 4410
+  DEVICE_DTS := en751221_genexis_platinum-4410
+  IMAGES := tclinux.trx
+  IMAGE/tclinux.trx := append-kernel | lzma | tclinux-trx
+endef
+TARGET_DEVICES += genexis_platinum-4410
+
 define Device/nokia_g240g-e
   DEVICE_VENDOR := Nokia
   DEVICE_MODEL := G-240G-E

--- a/target/linux/generic/pending-6.12/495-mtd-spinand-add-support-for-Dosilicon-DS35xx.patch
+++ b/target/linux/generic/pending-6.12/495-mtd-spinand-add-support-for-Dosilicon-DS35xx.patch
@@ -1,0 +1,145 @@
+From: Ahmed Naseef <naseefkm@gmail.com>
+Subject: [PATCH] mtd: spinand: add support for Dosilicon DS35Q1GA/DS35M1GA
+
+Add support for Dosilicon DS35Q1GA (3.3V) and DS35M1GA (1.8V) SPI NAND.
+
+These are 1Gbit (128MB) devices with:
+  - 2048 byte pages + 64 byte OOB
+  - 64 pages per block, 1024 blocks
+  - On-die 4-bit ECC per 512 byte sector
+
+The 64-byte OOB area is divided into 4 segments of 16 bytes, with each
+segment containing 8 bytes of user data (M2+M1) and 8 bytes of ECC
+parity (R1). This provides 30 bytes of usable OOB space after reserving
+2 bytes for the bad block marker.
+
+Tested on Genexis Platinum 4410 (EcoNet EN751221) by writing known
+patterns to OOB and verifying ECC parity placement in R1 regions.
+
+Datasheet:
+  https://www.dosilicon.com/resources/SPI%20NAND/DS35X1GAXXX_rev08.pdf
+
+Signed-off-by: Ahmed Naseef <naseefkm@gmail.com>
+--- a/drivers/mtd/nand/spi/Makefile
++++ b/drivers/mtd/nand/spi/Makefile
+@@ -1,4 +1,4 @@
+ # SPDX-License-Identifier: GPL-2.0
+-spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fmsh.o foresee.o gigadevice.o
+-spinand-objs += macronix.o micron.o paragon.o skyhigh.o toshiba.o winbond.o xtx.o
++spinand-objs := core.o alliancememory.o ato.o dosilicon.o esmt.o etron.o fmsh.o foresee.o
++spinand-objs += gigadevice.o macronix.o micron.o paragon.o skyhigh.o toshiba.o winbond.o xtx.o
+ obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -1176,6 +1176,7 @@ static const struct nand_ops spinand_ops
+ static const struct spinand_manufacturer *spinand_manufacturers[] = {
+ 	&alliancememory_spinand_manufacturer,
+ 	&ato_spinand_manufacturer,
++	&dosilicon_spinand_manufacturer,
+ 	&esmt_8c_spinand_manufacturer,
+ 	&esmt_c8_spinand_manufacturer,
+ 	&etron_spinand_manufacturer,
+--- /dev/null
++++ b/drivers/mtd/nand/spi/dosilicon.c
+@@ -0,0 +1,91 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Author: Ahmed Naseef <naseefkm@gmail.com>
++ */
++
++#include <linux/device.h>
++#include <linux/kernel.h>
++#include <linux/mtd/spinand.h>
++
++#define SPINAND_MFR_DOSILICON        0xE5
++
++static SPINAND_OP_VARIANTS(read_cache_variants,
++		SPINAND_PAGE_READ_FROM_CACHE_X4_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_X2_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(true, 0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(false, 0, 1, NULL, 0));
++
++static SPINAND_OP_VARIANTS(write_cache_variants,
++		SPINAND_PROG_LOAD_X4(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD(true, 0, NULL, 0));
++
++static SPINAND_OP_VARIANTS(update_cache_variants,
++		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
++		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++
++static int ds35xx_ooblayout_ecc(struct mtd_info *mtd, int section,
++				struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	region->offset = 8 + (section * 16);
++	region->length = 8;
++
++	return 0;
++}
++
++static int ds35xx_ooblayout_free(struct mtd_info *mtd, int section,
++				 struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	if (section == 0) {
++		/* reserve 2 bytes for the BBM */
++		region->offset = 2;
++		region->length = 6;
++	} else {
++		region->offset = section * 16;
++		region->length = 8;
++	}
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops ds35xx_ooblayout = {
++	.ecc = ds35xx_ooblayout_ecc,
++	.free = ds35xx_ooblayout_free,
++};
++
++static const struct spinand_info dosilicon_spinand_table[] = {
++	SPINAND_INFO("DS35Q1GA",
++		SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x71),
++		NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
++		NAND_ECCREQ(4, 512),
++		SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					 &write_cache_variants,
++					 &update_cache_variants),
++		SPINAND_HAS_QE_BIT,
++		SPINAND_ECCINFO(&ds35xx_ooblayout, NULL)),
++	SPINAND_INFO("DS35M1GA",
++		SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x21),
++		NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
++		NAND_ECCREQ(4, 512),
++		SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					 &write_cache_variants,
++					 &update_cache_variants),
++		SPINAND_HAS_QE_BIT,
++		SPINAND_ECCINFO(&ds35xx_ooblayout, NULL)),
++};
++
++static const struct spinand_manufacturer_ops dosilicon_spinand_manuf_ops = {
++};
++
++const struct spinand_manufacturer dosilicon_spinand_manufacturer = {
++	.id = SPINAND_MFR_DOSILICON,
++	.name = "Dosilicon",
++	.chips = dosilicon_spinand_table,
++	.nchips = ARRAY_SIZE(dosilicon_spinand_table),
++	.ops = &dosilicon_spinand_manuf_ops,
++};
+--- a/include/linux/mtd/spinand.h
++++ b/include/linux/mtd/spinand.h
+@@ -262,6 +262,7 @@ struct spinand_manufacturer {
+ /* SPI NAND manufacturers */
+ extern const struct spinand_manufacturer alliancememory_spinand_manufacturer;
+ extern const struct spinand_manufacturer ato_spinand_manufacturer;
++extern const struct spinand_manufacturer dosilicon_spinand_manufacturer;
+ extern const struct spinand_manufacturer esmt_8c_spinand_manufacturer;
+ extern const struct spinand_manufacturer esmt_c8_spinand_manufacturer;
+ extern const struct spinand_manufacturer etron_spinand_manufacturer;

--- a/target/linux/mediatek/patches-6.12/330-snand-mtk-bmt-support.patch
+++ b/target/linux/mediatek/patches-6.12/330-snand-mtk-bmt-support.patch
@@ -8,7 +8,7 @@
  
  static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1596,6 +1597,7 @@ static int spinand_probe(struct spi_mem
+@@ -1597,6 +1598,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -16,7 +16,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1603,6 +1605,7 @@ static int spinand_probe(struct spi_mem
+@@ -1604,6 +1606,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -24,7 +24,7 @@
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1621,6 +1624,7 @@ static int spinand_remove(struct spi_mem
+@@ -1622,6 +1625,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/mediatek/patches-6.12/340-mtd-spinand-Add-support-for-the-Fidelix-FM35X1GA.patch
+++ b/target/linux/mediatek/patches-6.12/340-mtd-spinand-Add-support-for-the-Fidelix-FM35X1GA.patch
@@ -18,13 +18,13 @@ Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>
 +++ b/drivers/mtd/nand/spi/Makefile
 @@ -1,4 +1,4 @@
  # SPDX-License-Identifier: GPL-2.0
--spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fmsh.o foresee.o gigadevice.o
-+spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fidelix.o fmsh.o foresee.o gigadevice.o
- spinand-objs += macronix.o micron.o paragon.o skyhigh.o toshiba.o winbond.o xtx.o
+-spinand-objs := core.o alliancememory.o ato.o dosilicon.o esmt.o etron.o fmsh.o foresee.o
++spinand-objs := core.o alliancememory.o ato.o dosilicon.o esmt.o etron.o fidelix.o fmsh.o foresee.o
+ spinand-objs += gigadevice.o macronix.o micron.o paragon.o skyhigh.o toshiba.o winbond.o xtx.o
  obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1181,6 +1181,7 @@ static const struct spinand_manufacturer
+@@ -1182,6 +1182,7 @@ static const struct spinand_manufacturer
  	&esmt_c8_spinand_manufacturer,
  	&etron_spinand_manufacturer,
  	&fmsh_spinand_manufacturer,
@@ -113,7 +113,7 @@ Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>
 +};
 --- a/include/linux/mtd/spinand.h
 +++ b/include/linux/mtd/spinand.h
-@@ -266,6 +266,7 @@ extern const struct spinand_manufacturer
+@@ -267,6 +267,7 @@ extern const struct spinand_manufacturer
  extern const struct spinand_manufacturer esmt_c8_spinand_manufacturer;
  extern const struct spinand_manufacturer etron_spinand_manufacturer;
  extern const struct spinand_manufacturer fmsh_spinand_manufacturer;

--- a/target/linux/mediatek/patches-6.12/435-drivers-mtd-spinand-Add-calibration-support-for-spin.patch
+++ b/target/linux/mediatek/patches-6.12/435-drivers-mtd-spinand-Add-calibration-support-for-spin.patch
@@ -11,7 +11,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1220,6 +1220,56 @@ static int spinand_manufacturer_match(st
+@@ -1221,6 +1221,56 @@ static int spinand_manufacturer_match(st
  	return -EOPNOTSUPP;
  }
  
@@ -68,7 +68,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
  static int spinand_id_detect(struct spinand_device *spinand)
  {
  	u8 *id = spinand->id.data;
-@@ -1473,6 +1523,10 @@ static int spinand_init(struct spinand_d
+@@ -1474,6 +1524,10 @@ static int spinand_init(struct spinand_d
  	if (!spinand->scratchbuf)
  		return -ENOMEM;
  

--- a/target/linux/mediatek/patches-6.12/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
+++ b/target/linux/mediatek/patches-6.12/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
@@ -12,7 +12,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1261,7 +1261,10 @@ static int spinand_cal_read(void *priv,
+@@ -1262,7 +1262,10 @@ static int spinand_cal_read(void *priv,
  	if (ret)
  		return ret;
  

--- a/target/linux/mediatek/patches-6.12/960-asus-hack-u-boot-ignore-mtdparts.patch
+++ b/target/linux/mediatek/patches-6.12/960-asus-hack-u-boot-ignore-mtdparts.patch
@@ -29,7 +29,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1690,6 +1690,7 @@ static int spinand_remove(struct spi_mem
+@@ -1691,6 +1691,7 @@ static int spinand_remove(struct spi_mem
  
  static const struct spi_device_id spinand_ids[] = {
  	{ .name = "spi-nand" },
@@ -37,7 +37,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	{ /* sentinel */ },
  };
  MODULE_DEVICE_TABLE(spi, spinand_ids);
-@@ -1697,6 +1698,7 @@ MODULE_DEVICE_TABLE(spi, spinand_ids);
+@@ -1698,6 +1699,7 @@ MODULE_DEVICE_TABLE(spi, spinand_ids);
  #ifdef CONFIG_OF
  static const struct of_device_id spinand_of_ids[] = {
  	{ .compatible = "spi-nand" },


### PR DESCRIPTION
 This PR adds support for the Genexis Platinum 4410 GPON router to the econet target, along with necessary kernel and infrastructure


commits:

  - Add SPI NAND support for Dosilicon DS35Q1GA/DS35M1GA flash chips
  - Add configurable BBT table size for en75_bmt driver
  - Add optional model string parameter to tclinux-trx image builder
  - Add device support for Genexis Platinum 4410

  ## Hardware specifications

  **Genexis Platinum 4410:**
  - SoC: EcoNet EN751221
  - RAM: 64 MB
  - Flash: 128 MB SPI NAND (Dosilicon DS35Q1GA)
  - WiFi: 2.4 GHz (MediaTek MT7603)
  - Ethernet: 1 GbE and 1 FE
  - FXS: 1 port
  - Serial: 115200 8N1

  ## Changes

  ### kernel: mtd: spinand: add support for Dosilicon DS35Q1GA/DS35M1GA
  Adds support for Dosilicon DS35Q1GA and DS35M1GA SPI NAND flash chips. 

  ### econet: en75_bmt: add configurable BBT table size
  Different vendor firmware versions use different BBT table sizes. The Genexis Platinum 4410 bootloader expects 250 entries instead of the default 1000. Without this fix, BBT checksum validation fails. Adds `econet,bbt-table-size` DTS property to configure the table size.

  ### econet: tclinux-trx: add optional model string parameter
  Some devices' web UI (including Genexis Platinum 4410) require a specific model string (P4410\n) in the TRX header reserved area, otherwise firmware  updates are rejected. Adds support for passing the model string as a parameter to tclinux-trx.sh.

  ### econet: en751221: add support for Genexis Platinum 4410
  Adds complete device support including DTS, image generation, and chboot script integration.

  ## Installation

  Via OEM web UI:
  1. Login to factory web UI
  2. Navigate to `http://192.168.1.1/cgi-bin/upgrade.asp` (not accessible from web UI menu)
  3. Rename image to `tclinux.bin`
  4. Select tclinux.bin upload type and upload



EDIT: The issue is not load address compatibility, see https://github.com/openwrt/openwrt/pull/21124#issuecomment-3641263742


<del>

### **Open Question: Load Address Compatibility with OEM Bootloader**

###   Background

  This device has a dual-image partition scheme with ping-pong upgrade logic. When users flash OpenWrt via the OEM WebUI, the firmware is written to the slave partition while OEM remains in the master partition.

###   The Problem

  The OEM bootloader has a bug in its dual-image handling logic:

 When booting from slave with a valid OEM image in master, the bootloader:
  - Reads Load address from OEM's TRX header which is in master partition ( which is  0x80002000)
  - But loads and decompresses the kernel from OpenWrt image (in slave partition)
  - OpenWrt is compiled for Load address 0x80020000
  - Result: Address mismatch causes decompression error -- System halted

  Boot log showing the failure:
```
  ==> boot flag = 1
  Decompress to 80002000
  from slave
  Uncompressing [LZMA] ...
  decompression error
  -- System halted
```

  However, when booting openwrt flashed to master, it works correctly.  In this case, the bootloader reads Load address from OpenWrt's TRX header (flashed in master) - both addresses match.

  Analysis

  The OEM firmware uses Load address 0x80002000. OpenWrt currently uses 0x80020000, which causes the mismatch when:
  - OpenWrt is in slave partition
  - OEM is in master partition (valid image)
  - Boot flag = 1 (boot from slave)



  **Question for Maintainers** @cjdelisle 

  Is it acceptable to change the load address as 0x80002000 instead of 0x80020000 for this target?


  If the address change is not acceptable, I will update the installation documentation to only support serial console flashing (which flashes the openwrt to master partition), though this is significantly more difficult for novice users and eliminates the convenience of WebUI-based upgrades.

</del>