### PR TITLE
build: depend on tools/zstd for download

### DIFF
--- a/include/toplevel.mk
+++ b/include/toplevel.mk
@@ -201,7 +201,7 @@ else
   DOWNLOAD_DIRS = package/download
 endif
 
-download: .config FORCE $(if $(wildcard $(STAGING_DIR_HOST)/bin/flock),,tools/flock/compile)
+download: .config FORCE $(if $(wildcard $(STAGING_DIR_HOST)/bin/flock),,tools/flock/compile) $(if $(wildcard $(STAGING_DIR_HOST)/bin/zstd),,tools/zstd/compile)
 	@+$(foreach dir,$(DOWNLOAD_DIRS),$(SUBMAKE) $(dir);)
 
 clean dirclean: .config


### PR DESCRIPTION
Downloading packages from git requires zstd to compress their tarballs.
Make sure that zstd from host tools is compiled when running make
download. Otherwise, either a random version from the host is used which
will lead to hash mismatches, or the download would fail because zstd is
not present.