### PR TITLE
[24.10] mpc85xx: p1010: Use zImage loader for Watchguard Firebox T10

### DIFF
--- a/target/linux/mpc85xx/image/p1010.mk
+++ b/target/linux/mpc85xx/image/p1010.mk
@@ -78,7 +78,12 @@ define Device/watchguard_firebox-t10
   DEVICE_VENDOR := Watchguard
   DEVICE_MODEL := Firebox T10
   DEVICE_PACKAGES := kmod-rtc-s35390a kmod-eeprom-at24
+  # This boot loader doesn't reliably boot an uncompressed image,
+  # therefore resort to gzipping the already compressed zImage
   KERNEL = kernel-bin | gzip | fit gzip $(KDIR)/image-$$(DEVICE_DTS).dtb
+  KERNEL_NAME := zImage.la3000000
+  KERNEL_ENTRY := 0x3000000
+  KERNEL_LOADADDR := 0x3000000
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef

--- a/target/linux/mpc85xx/p1010/target.mk
+++ b/target/linux/mpc85xx/p1010/target.mk
@@ -1,5 +1,5 @@
 BOARDNAME:=P1010
-KERNEL_IMAGES:=simpleImage.br200-wp simpleImage.tl-wdr4900-v1 simpleImage.ws-ap3715i
+KERNEL_IMAGES:=simpleImage.br200-wp simpleImage.tl-wdr4900-v1 simpleImage.ws-ap3715i zImage.la3000000
 
 define Target/Description
 	Build firmware images for P1010 based boards.

--- a/target/linux/mpc85xx/patches-6.6/108-powerpc-85xx-firebox-t10-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/108-powerpc-85xx-firebox-t10-support.patch
@@ -1,6 +1,6 @@
 --- a/arch/powerpc/platforms/85xx/Kconfig
 +++ b/arch/powerpc/platforms/85xx/Kconfig
-@@ -83,6 +83,16 @@ config WS_AP3825I
+@@ -83,6 +83,17 @@ config WS_AP3825I
  	  This board is a Concurrent Dual-Band wireless access point with a
  	  Freescale P1020 SoC.
  
@@ -9,6 +9,7 @@
 +	select DEFAULT_UIMAGE
 +	select ARCH_REQUIRE_GPIOLIB
 +	select GPIO_MPC8XXX
++	select PPC_ZIMAGE_LA3000000
 +	help
 +	  This option enables support for the Watchguard Firebox T10 board.
 +	  This board is a VPN Gateway-Router with a

--- a/target/linux/mpc85xx/patches-6.6/111-powerpc-85xx-hpe-msm-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/111-powerpc-85xx-hpe-msm-support.patch
@@ -1,6 +1,6 @@
 --- a/arch/powerpc/platforms/85xx/Kconfig
 +++ b/arch/powerpc/platforms/85xx/Kconfig
-@@ -114,6 +114,18 @@ config FIREBOX_T10
+@@ -115,6 +115,18 @@ config FIREBOX_T10
  	  This board is a VPN Gateway-Router with a
  	  Freescale P1010 SoC.
  


### PR DESCRIPTION
Partial backport of #16776 (fix only, no new device support).

Since kernel 6.1, the Watchguard Firebox T10 can't boot anymore due to increased kernel size.

This PR introduces the zImage loader from 7d768a9 to boot the kernel. This is required, since the U-Boot version used in this device appears to have a hard limit of 16MB for the kernel size it can handle. The current kernel size is around 17MB, though, due to kernel page alignment required for memory protection.