### PR TITLE
firewall3: remove unreachable rules

### DIFF
--- a/package/network/config/firewall/files/firewall.config
+++ b/package/network/config/firewall/files/firewall.config
@@ -82,7 +82,6 @@ config rule
 	option src		wan
 	option proto	icmp
 	list icmp_type		echo-request
-	list icmp_type		echo-reply
 	list icmp_type		destination-unreachable
 	list icmp_type		packet-too-big
 	list icmp_type		time-exceeded
@@ -103,7 +102,6 @@ config rule
 	option dest		*
 	option proto		icmp
 	list icmp_type		echo-request
-	list icmp_type		echo-reply
 	list icmp_type		destination-unreachable
 	list icmp_type		packet-too-big
 	list icmp_type		time-exceeded
@@ -114,18 +112,20 @@ config rule
 	option target		ACCEPT
 
 config rule
-	option name		Allow-IPSec-ESP
+	option name		Allow-IPv6-IPSec-ESP
 	option src		wan
 	option dest		lan
 	option proto		esp
+	option family		ipv6
 	option target		ACCEPT
 
 config rule
-	option name		Allow-ISAKMP
+	option name		Allow-IPv6-ISAKMP
 	option src		wan
 	option dest		lan
 	option dest_port	500
 	option proto		udp
+	option family		ipv6
 	option target		ACCEPT
 
 # allow interoperability with traceroute classic


### PR DESCRIPTION
Do not accept unsolicited ICMP echo reply. It is implied by conntrack state from request already. cf https://github.com/openwrt/firewall4/pull/44 Also exemplified by ipv4 ping rule

Limit peer-to-peer ipsec to ipv6 only as stated in original "ipv6 cpe requirements" cf https://github.com/openwrt/firewall4/pull/65
