### PR TITLE
Fix missing compression propery for initrd images in FIT

### DIFF
--- a/scripts/mkits.sh
+++ b/scripts/mkits.sh
@@ -128,6 +128,7 @@ if [ -n "${INITRD}" ]; then
 			type = \"ramdisk\";
 			arch = \"${ARCH}\";
 			os = \"linux\";
+			compression = \"none\";
 			hash${REFERENCE_CHAR}1 {
 				algo = \"crc32\";
 			};


### PR DESCRIPTION
Add the compression property to maximize compatibility with legacy software

Older U-Boot tools return -EINVAL instead of IH_COMP_NONE, resulting in a warning like

 WARNING: 'compression' nodes for ramdisks are deprecated, please fix your .its file!
 Can't get image compression!

and an eventual signature validation error in case of signed images.

I hit this issue while trying to create an OpenWrt image that could be installed from Zyxel's firmware on a newer device. Their sysupgrade script requires a signature node and runs fit_check_sign on the.  It doesn't actually require a signature though...
But it fails anyway with initramfs kernels because their old fit_check_sign defaults to -EINVAL when the compression property is missing. 

(using an initramfs kernel is useful here since I don't agree with their choice of root partition)