### PR TITLE
mediatek: add support for Cudy WBR3000UAX v1

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7981b-cudy-wbr3000uax-v1.dtsi"
+
+/ {
+	model = "Cudy WBR3000UAX v1";
+	compatible = "cudy,wbr3000uax-v1", "mediatek,mt7981";
+};
+
+&spi_nand {
+	spi-cal-enable;
+	spi-cal-mode = "read-data";
+	spi-cal-datalen = <7>;
+	spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
+	spi-cal-addrlen = <5>;
+	spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};
+
+&ubi {
+	reg = <0x5c0000 0x4000000>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dtsi
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include "mt7981b-cudy-wr3000-nand.dtsi"
+
+/ {
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_status;
+		led-failsafe = &led_warning;
+		led-running = &led_status;
+		led-upgrade = &led_warning;
+		serial0 = &uart0;
+	};
+	
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: led_power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_internet {
+			function = LED_FUNCTION_WAN_ONLINE;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+		
+		led_warning: led_fault {
+			function = LED_FUNCTION_FAULT;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wps {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_wifi2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_wifi5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	usb_vbus: regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "usb-vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+		regulator-boot-on;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "wan";
+
+			nvmem-cell-names = "mac-address";
+			nvmem-cells = <&macaddr_bdinfo_de00 1>;
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan1";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan3";
+		};
+
+		port@4 {
+			reg = <4>;
+			label = "lan4";
+		};
+
+		port@6 {
+			reg = <6>;
+			label = "cpu";
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&usb_vbus>;
+	mediatek,u3p-dis-msk = <0x00>;
+	phys = <&u2port0 PHY_TYPE_USB2>,
+	       <&u3port0 PHY_TYPE_USB3>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
@@ -146,7 +146,7 @@
 				read-only;
 			};
 
-			partition@5c0000 {
+			ubi: partition@5c0000 {
 				label = "ubi";
 				reg = <0x5c0000 0x4000000>;
 				compatible = "linux,ubi";

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -75,6 +75,10 @@ cudy,wr3000p-v1)
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan" "link tx rx"
 	ucidef_set_led_netdev "internet" "internet" "white:wan-online" "wan" "link"
 	;;
+cudy,wbr3000uax-v1)
+	ucidef_set_led_netdev "LAN" "LAN" "blue:lan" "br-lan" "link tx rx"
+	ucidef_set_led_netdev "WAN" "WAN" "blue:wan" "wan" "link tx rx"
+	;;
 elecom,wrc-x3000gs3)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -89,6 +89,7 @@ case "$board" in
 	cudy,tr3000-256mb-v1|\
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
+	cudy,wbr3000uax-v1|\
 	cudy,wr3000e-v1|\
 	cudy,wr3000s-v1|\
 	cudy,wr3000h-v1|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1200,6 +1200,23 @@ define Device/cudy_wr3000p-v1
 endef
 TARGET_DEVICES += cudy_wr3000p-v1
 
+define Device/cudy_wbr3000uax-v1
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := WBR3000UAX
+  DEVICE_VARIANT := v1
+  DEVICE_DTS := mt7981b-cudy-wbr3000uax-v1
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES += R120
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_IN_UBI := 1
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+endef
+TARGET_DEVICES += cudy_wbr3000uax-v1
+
 define Device/dlink_aquila-pro-ai-m30-a1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := AQUILA PRO AI M30


### PR DESCRIPTION
mediatek: add support for Cudy WBR3000UAX v1

Another OEM variation of a Cudy WR3000 series device made for Russian market.

Hardware:
 - SoC: MediaTek MT7981B
 - CPU: 2x 1.3 GHz Cortex-A53
 - Flash: 128 MiB GigaDevice SPI NAND. Flash Model: F50L1G41LB, ID: C801
 - RAM: DDR3, 512 MiB
 - WLAN: 2.4 GHz, 5 GHz (MediaTek MT7976CN, 802.11ax)
 - 1x WAN MT7531 (JXD 2531Z) 10/100/1000 Mbps
 - 4x LAN 2x MT7530 (JXD 2529S) 10/100/1000 Mbps
 - USB 3.0 port
 - Buttons: Reset, WPS
 - 8x LEDs: 2x Red, 6x Blue
 - Serial console: no need to solder, just open the case and unskrew the radiator, TX-RX, RX-TX, GND-GND, VCC do not connect, 115200 8n1
 - Power: 12 VDC, 1.5 A

MAC addresses:
WAN `80:AF:CA:xx:xx:x1` label+1
LAN `80:AF:CA:xx:xx:x0` label
WLAN 2g `80:AF:CA:xx:xx:x0`  label
WLAN 5g `82:AF:CA:xx:xx:x1` label+1

Based on a factory layout with only 64mb partition for easier transition from factory to OpenWrt for users if the "intermediate" RSA signed firmware will be provided by Cudy.

**Installation**
The installation must be done via UART & TFTP by disassembling the router. On other occasions Cudy has distributed intermediate firmware and dts to make installation easier, but since this router is OEM special WB order for local RU market there is a possibility they will not provide it.

**Install using UART & TFTP**
1. Connect to UART.
2. Since the factory BL is locked and the boot process can not be stopped, you have to use mtkuartboot, hold reset, engage the power, boot into your payloaded bl2 & fip.
3. Connect to LAN and set your IP to 192.168.1.254.
4. Configure a TFTP server to serve openwrt-mediatek-filogic-cudy_wbr3000uax-v1-initramfs-kernel.bin file.
5. Run these steps in u-boot using the name of your file:

```
setenv bootfile openwrt-mediatek-filogic-cudy_wbr3000uax-v1-initramfs-kernel.bin
setenv ipaddr 192.168.1.1
setenv serverip 192.168.1.254
tftpboot
bootm
```

6. Router will boot into OpenWrt initramfs recovery, just open your browser `192.168.1.1` and sysupgrade with the `Keep settings` option turned off.