### PR TITLE
mvebu: add depends for Turris MOX boards

### DIFF
--- a/target/linux/mvebu/image/cortexa53.mk
+++ b/target/linux/mvebu/image/cortexa53.mk
@@ -2,7 +2,11 @@ define Device/cznic_turris-mox
   $(call Device/Default-arm64)
   DEVICE_VENDOR := CZ.NIC
   DEVICE_MODEL := Turris MOX
-  DEVICE_PACKAGES := kmod-usb2 kmod-gpio-button-hotplug kmod-rtc-ds1307 kmod-i2c-pxa
+  DEVICE_PACKAGES += kmod-usb2 kmod-usb3 \
+    kmod-rtc-ds1307 kmod-i2c-pxa kmod-dsa kmod-dsa-mv88e6xxx kmod-sfp \
+    kmod-phy-marvell kmod-phy-marvell-10g kmod-ath10k ath10k-board-qca988x \
+    ath10k-firmware-qca988x kmod-mt7915e kmod-mt7915-firmware mwlwifi-firmware-88w8997 \
+    wpad-basic-mbedtls
   SOC := armada-3720
   BOOT_SCRIPT := turris-mox
 endef


### PR DESCRIPTION
An extension of https://github.com/openwrt/openwrt/pull/20356

Add dependencies for Turris MOX board modules directly as DEVICE_PACKAGES. (So that users don't have to add them manually.)

The device uses an SD card for primary storage so space shouldn't be an issue.
