### PR TITLE
ath79: fix build of big images for TP-Link RE355 v1, RE450 v1 and RE4…

### DIFF
--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -9,6 +9,7 @@ define Device/tplink_rex5x-v1
   DEVICE_COMPAT_VERSION := 2.0
   DEVICE_COMPAT_MESSAGE := Partition layout has changed compared to older versions by utilizing unused flash. \
     Upgrade via sysupgrade mechanism (-F) will only work if flashed image still fits to the size of old partition (6016 KiB).
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 
 define Device/tplink_re355-v1
@@ -40,6 +41,7 @@ define Device/tplink_re450-v2
   DEVICE_COMPAT_VERSION := 2.0
   DEVICE_COMPAT_MESSAGE := Partition layout has changed compared to older versions by utilizing unused flash. \
     Upgrade via sysupgrade mechanism (-F) will only work if flashed image still fits to the size of old partition (6016 KiB).
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size | append-metadata
   TPLINK_BOARD_ID := RE450-V2
   LOADER_TYPE := elf
 endef


### PR DESCRIPTION
Dear @achterin, @ambassador86 and other OpenWrt Maintainers,

After merge of https://github.com/openwrt/openwrt/pull/20709 I noticed, that https://mirror-03.infra.openwrt.org/snapshots/targets/ath79/tiny/ still does not contain the build for RE450.

I analyzed the problem and noticed, that only builds which fits into original size can be build and if the image is larger, it fails with the following error: "`WARNING: Image file .../openwrt/build_dir/ target-mips_24kc_musl/linux-ath79_tiny/tmp/
openwrt-ath79-tiny-tplink_re450-v1-squashfs-sysupgrade.bin is too big: > 7864320`".

This error is quite misleading as the image is smaller than 7864320. The reason for this error is that default tplink-safeloader has hardcoded factory partition structure and fails to generate any file.

Rather then fixing tplink-safeloader I followed approach from commit ebd5e5fb5359 ("ramips: switched TP-Link RE305 v1 to new partition layout") and switched away from "`tplink-safeloader sysupgrade`".

I did not include "`IMAGES := sysupgrade.bin`", because with tiny target it is still possible to locally build even factory image.

Fixes commit e768731dc8e9 ("ath79: switch TP-Link RE355 v1, RE450 v1 and RE450 v2 to mtd-concat").

I am sorry, that I did not get it right first time. Please check this fix and if you find my analysis correct, please merge it to both main and ideally also to openwrt-25.12.

Best regards,
Radek Dostál