### PR TITLE
ath79: rb91x_nand: fix some issues in probe

### DIFF
--- a/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
@@ -218,7 +218,7 @@ static void rb91x_nand_read(struct rb91x_nand_drvdata *drvdata,
 
 static int rb91x_nand_dev_ready(struct nand_chip *chip)
 {
-	struct rb91x_nand_drvdata *drvdata = (struct rb91x_nand_drvdata *)(chip->priv);
+	struct rb91x_nand_drvdata *drvdata = chip->priv;
 
 	return gpiod_get_value_cansleep(drvdata->gpio[RB91X_NAND_RDY]);
 }
@@ -263,15 +263,10 @@ static void rb91x_nand_write_buf(struct nand_chip *chip, const u8 *buf, int len)
 	rb91x_nand_write(chip->priv, buf, len);
 }
 
-static void rb91x_nand_release(struct rb91x_nand_drvdata *drvdata)
-{
-	mtd_device_unregister(nand_to_mtd(&drvdata->chip));
-	nand_cleanup(&drvdata->chip);
-}
-
 static int rb91x_nand_probe(struct platform_device *pdev)
 {
 	struct rb91x_nand_drvdata *drvdata;
+	struct nand_chip *nand;
 	struct mtd_info *mtd;
 	int r;
 	struct device *dev = &pdev->dev;
@@ -294,9 +289,13 @@ static int rb91x_nand_probe(struct platform_device *pdev)
 
 	drvdata->gpio = gpios->desc;
 
-	gpiod_direction_input(drvdata->gpio[RB91X_NAND_RDY]);
+	r = gpiod_direction_input(drvdata->gpio[RB91X_NAND_RDY]);
+	if (r)
+		return dev_err_probe(dev, r, "failed to set RDY gpio as input");
 
-	drvdata->ath79_gpio_base = ioremap(AR71XX_GPIO_BASE, AR71XX_GPIO_SIZE);
+	drvdata->ath79_gpio_base = devm_ioremap(dev, AR71XX_GPIO_BASE, AR71XX_GPIO_SIZE);
+	if (!drvdata->ath79_gpio_base)
+		return dev_err_probe(dev, -ENOMEM, "failed to map GPIO registers");
 
 	drvdata->dev = dev;
 
@@ -313,22 +312,20 @@ static int rb91x_nand_probe(struct platform_device *pdev)
 	drvdata->chip.ecc.algo             = NAND_ECC_ALGO_HAMMING;
 	drvdata->chip.options = NAND_NO_SUBPAGE_WRITE;
 
-	r = nand_scan(&drvdata->chip, 1);
-	if (r) {
-		dev_err(dev, "nand_scan() failed: %d\n", r);
-		return r;
-	}
+	nand = &drvdata->chip;
+	r = nand_scan(nand, 1);
+	if (r)
+		return dev_err_probe(dev, r, "nand_scan() failed");
 
-	mtd = nand_to_mtd(&drvdata->chip);
+	mtd = nand_to_mtd(nand);
 	mtd->dev.parent = dev;
 	mtd_set_of_node(mtd, dev->of_node);
-	mtd->owner = THIS_MODULE;
 	if (mtd->writesize == 512)
 		mtd_set_ooblayout(mtd, &rb91x_nand_ecclayout_ops);
 
 	r = mtd_device_register(mtd, NULL, 0);
 	if (r) {
-		rb91x_nand_release(drvdata);
+		nand_cleanup(nand);
 		return dev_err_probe(dev, r, "mtd_device_register() failed");
 	}
 
@@ -338,8 +335,11 @@ static int rb91x_nand_probe(struct platform_device *pdev)
 static void rb91x_nand_remove(struct platform_device *pdev)
 {
 	struct rb91x_nand_drvdata *drvdata = platform_get_drvdata(pdev);
+	struct nand_chip *nand = &drvdata->chip;
+	struct mtd_info *mtd = nand_to_mtd(nand);
 
-	rb91x_nand_release(drvdata);
+	mtd_device_unregister(mtd);
+	nand_cleanup(nand);
 }
 
 static const struct of_device_id rb91x_nand_match[] = {


### PR DESCRIPTION
Add devm for ioremap to proper cleanup.

Test gpiod_direction_input for failure.

Remove rb91x_nand_release and fix wrong usage.