### PR TITLE
treewide: constify mdio_bus

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
@@ -310,7 +310,7 @@ static struct phy_driver rtk_phy_drivers[] = {
 module_phy_driver(rtk_phy_drivers);
 
 
-static struct mdio_device_id __maybe_unused rtk_phy_tbl[] = {
+static const struct mdio_device_id __maybe_unused rtk_phy_tbl[] = {
     { PHY_ID_MATCH_EXACT(REALTEK_PHY_ID_RTL8261N) },
     { PHY_ID_MATCH_EXACT(REALTEK_PHY_ID_RTL8264B) },
     { PHY_ID_MATCH_EXACT(REALTEK_PHY_ID_RTL8264) },

--- a/target/linux/mediatek/files-6.12/drivers/net/phy/air_an8855.c
+++ b/target/linux/mediatek/files-6.12/drivers/net/phy/air_an8855.c
@@ -255,7 +255,7 @@ static struct phy_driver an8855_driver[] = {
 
 module_phy_driver(an8855_driver);
 
-static struct mdio_device_id __maybe_unused an8855_tbl[] = {
+static const struct mdio_device_id __maybe_unused an8855_tbl[] = {
 	{ PHY_ID_MATCH_EXACT(AN8855_PHY_ID) },
 	{ }
 };

--- a/target/linux/mediatek/files/drivers/net/phy/en8801sc.c
+++ b/target/linux/mediatek/files/drivers/net/phy/en8801sc.c
@@ -1109,7 +1109,7 @@ static struct phy_driver Airoha_driver[] = {
 
 module_phy_driver(Airoha_driver);
 
-static struct mdio_device_id __maybe_unused Airoha_tbl[] = {
+static const struct mdio_device_id __maybe_unused Airoha_tbl[] = {
 	{ EN8801SC_PHY_ID, 0x0ffffff0 },
 	{ }
 };

--- a/target/linux/mediatek/patches-6.12/701-net-phy-mediatek-add-driver-for-built-in-2.5G-ethern.patch
+++ b/target/linux/mediatek/patches-6.12/701-net-phy-mediatek-add-driver-for-built-in-2.5G-ethern.patch
@@ -386,7 +386,7 @@ Signed-off-by: Sky Huang <skylake.huang@mediatek.com>
 +
 +module_phy_driver(mtk_2p5gephy_driver);
 +
-+static struct mdio_device_id __maybe_unused mtk_2p5ge_phy_tbl[] = {
++static const struct mdio_device_id __maybe_unused mtk_2p5ge_phy_tbl[] = {
 +	{ PHY_ID_MATCH_VENDOR(0x00339c00) },
 +	{ }
 +};

--- a/target/linux/realtek/files-6.12/drivers/net/phy/realtek/realtek_multiport.c
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/realtek/realtek_multiport.c
@@ -695,7 +695,7 @@ static struct phy_driver rtl83xx_phy_driver[] = {
 
 module_phy_driver(rtl83xx_phy_driver);
 
-static struct mdio_device_id __maybe_unused rtl83xx_tbl[] = {
+static const struct mdio_device_id __maybe_unused rtl83xx_tbl[] = {
 	{ PHY_ID_MATCH_MODEL(PHY_ID_RTL8214_OR_8218) },
 	{ }
 };

--- a/target/linux/siflower/files-6.12/drivers/net/phy/siflower.c
+++ b/target/linux/siflower/files-6.12/drivers/net/phy/siflower.c
@@ -865,7 +865,7 @@ static struct phy_driver sf_phy_drivers[] = {
 /* for linux 4.x */
 module_phy_driver(sf_phy_drivers);
 
-static struct mdio_device_id __maybe_unused siflower_phy_tbl[] = {
+static const struct mdio_device_id __maybe_unused siflower_phy_tbl[] = {
 	{ SF1211F_PHY_ID, SIFLOWER_PHY_ID_MASK },
 	{ SF1240_PHY_ID, SIFLOWER_PHY_ID_MASK },
 	{},


### PR DESCRIPTION
In generic, there's a backport from 6.14 that makes this change. Do so in downstream locations as well.