### PR TITLE
mediatek-filogic: fix IPv4 address missing on interface in failsafe mode for cudy ap3000-v1

### DIFF
--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -11,6 +11,7 @@ set_preinit_iface() {
 		ip link set eth1 up
 		ifname=eth1
 		;;
+	cudy,ap3000-v1|\
 	cudy,ap3000outdoor-v1|\
 	cudy,re3000-v1|\
 	ubnt,unifi-6-lr|\


### PR DESCRIPTION
Cudy AP3000-v1 does not work correctly in failsafe mode because the address 192.168.1.1 is missing on the eth0 interface. It is reachable via it's IPv6 link-local address however.
This commit fixes the issue so the failsafe mode works as intended.

I did test this in the openwrt-24.10 branch and can confirm it is also working in 24.10. Please cherry-pick this for 24.10 if possible.