### PR TITLE
target/sdk: include tools/hv for Hyper-V guest tools

### DIFF
--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -90,6 +90,7 @@ KERNEL_FILES := $(patsubst $(TOPDIR)/%,%,$(wildcard $(addprefix $(LINUX_DIR)/,$(
 #
 USERSPACE_UTILS_FILES := \
 	tools/build \
+	tools/hv \
 	tools/leds \
 	tools/power/cpupower \
 	tools/scripts \


### PR DESCRIPTION
Add tools/hv to USERSPACE_UTILS_FILES so that Hyper-V Integration Services tools (hv_kvp_daemon, hv_vss_daemon, hv_fcopy_uio_daemon) are available in the SDK for building package hv-tools.

This change enables SDK users to build packages that depend on kernel userspace tools from tools/hv directory, similar to how tools/usb/usbip is currently supported.

Ref: https://github.com/openwrt/packages/pull/24871