### PR TITLE
wifi-scripts: update phys after rename_phy_by_name call

### DIFF
--- a/package/network/config/wifi-scripts/files/usr/share/ucode/wifi/utils.uc
+++ b/package/network/config/wifi-scripts/files/usr/share/ucode/wifi/utils.uc
@@ -57,6 +57,11 @@ function rename_phy_by_name(phys, name, rename) {
 		wiphy: idx,
 		wiphy_name: name
 	});
+
+	let prev_idx = index(phys, prev_name);
+	if (prev_idx >= 0)
+		phys[prev_idx] = name;
+
 	return true;
 }
 


### PR DESCRIPTION
This fixes a failed bring up of the radio on bootup if the model defines a rename of phy in its /etc/board.json. This specifically impacts Redmi AX6S and any router that does so in its /etc/board.json. The fix fortunately is simple, just update phy name in phys after rename.

The entry that specifically causes this issue is the following:

{
	<omitted>
	"wlan": {
		"wl0": {
			"path": "platform/18000000.wmac",
			"info": {
				"antenna_rx": 15,
				"antenna_tx": 15,
				"bands": {
					"2G": {
						"ht": true,
						"max_width": 40,
						"modes": [
							"NOHT",
							"HT20",
							"HT40"
						],
						"default_channel": 1
					}
				},
				"radios": [
				]
			}
		},
	...
}

The issue is that after rename, referenced phy in config is going to be wl0 but in phys array it is still phy0; and so it fails to find phy and does not bring up radio.

Fixes: https://github.com/openwrt/openwrt/issues/20250
Fixes: https://github.com/openwrt/openwrt/issues/20339