### PR TITLE
treewide: use _scoped for loop

### DIFF
--- a/package/kernel/leds-gca230718/src/leds-gca230718.c
+++ b/package/kernel/leds-gca230718/src/leds-gca230718.c
@@ -122,30 +122,27 @@ static int gca230718_probe(struct i2c_client *client)
 
 	i2c_set_clientdata(client, priv);
 
-	struct device_node *ledNode;
-	for_each_child_of_node(client->dev.of_node, ledNode) {
+	device_for_each_child_node_scoped(client->dev, ledNode) {
+		const char *lname = fwnode_get_name(ledNode);
 		u32 regValue = 0;
-		if (of_property_read_u32(ledNode, "reg", &regValue))
-			pr_info("Missing entry \"reg\" in node %s\n",
-				ledNode->name);
+		if (fwnode_property_read_u32(ledNode, "reg", &regValue))
+			pr_info("Missing entry \"reg\" in node %s\n", lname);
 		else if (regValue >= GCA230718_MAX_LEDS)
 			pr_info("Invalid entry \"reg\" in node %s (%u)\n",
-				ledNode->name, regValue);
+				lname, regValue);
 		else {
 			struct led_classdev *ledClassDev =
 				&(priv->leds[regValue].ledClassDev);
 			struct led_init_data init_data = {};
 
 			priv->leds[regValue].client = client;
-			init_data.fwnode = of_fwnode_handle(ledNode);
+			init_data.fwnode = fwnode_handle_get(ledNode);
 
 			pr_info("Creating LED for node %s: reg=%u\n",
-				ledNode->name, regValue);
+				lname, regValue);
 
-			ledClassDev->name =
-				of_get_property(ledNode, "label", NULL);
-			if (!ledClassDev->name)
-				ledClassDev->name = ledNode->name;
+			ledClassDev->name = lname;
+			fwnode_property_read_string(ledNode, "label", &ledClassDev->name);
 
 			ledClassDev->brightness = LED_OFF;
 			ledClassDev->max_brightness = LED_FULL;

--- a/package/kernel/leds-ws2812b/src/leds-ws2812b.c
+++ b/package/kernel/leds-ws2812b/src/leds-ws2812b.c
@@ -106,7 +106,6 @@ static int ws2812b_probe(struct spi_device *spi)
 	struct device *dev = &spi->dev;
 	int cur_led = 0;
 	struct ws2812b_priv *priv;
-	struct fwnode_handle *led_node;
 	int num_leds, i, cnt, ret;
 
 	num_leds = device_get_child_node_count(dev);
@@ -131,9 +130,9 @@ static int ws2812b_probe(struct spi_device *spi)
 	priv->num_leds = num_leds;
 	priv->spi = spi;
 
-	device_for_each_child_node(dev, led_node) {
+	device_for_each_child_node_scoped(dev, led_node) {
 		struct led_init_data init_data = {
-			.fwnode = led_node,
+			.fwnode = fwnode_handle_get(led_node),
 		};
 		/* WS2812B LEDs usually come with GRB color */
 		u32 color_idx[WS2812B_NUM_COLORS] = {

--- a/target/linux/bmips/files/drivers/leds/leds-sercomm-msp430.c
+++ b/target/linux/bmips/files/drivers/leds/leds-sercomm-msp430.c
@@ -327,14 +327,13 @@ static int msp430_leds_probe(struct spi_device *spi)
 {
 	struct device *dev = &spi->dev;
 	struct device_node *np = dev_of_node(dev);
-	struct device_node *child;
 	int rc;
 
 	rc = msp430_check_workmode(spi);
 	if (rc)
 		return rc;
 
-	for_each_available_child_of_node(np, child) {
+	for_each_available_child_of_node_scoped(np, child) {
 		u32 reg;
 
 		if (of_property_read_u32(child, "reg", &reg))
@@ -347,10 +346,8 @@ static int msp430_leds_probe(struct spi_device *spi)
 		}
 
 		rc = msp430_led_probe(spi, child, reg);
-		if (rc < 0) {
-			of_node_put(child);
+		if (rc < 0)
 			return rc;
-		}
 	}
 
 	return 0;

--- a/target/linux/econet/files/drivers/mtd/nand/en75_bmt.c
+++ b/target/linux/econet/files/drivers/mtd/nand/en75_bmt.c
@@ -1249,10 +1249,9 @@ static int w_init(struct en75_bmt_m *ctx, struct device_node *np)
 		add_remap_range(ctx, 0, ctx->reserve_area_begin);
 	} else {
 		struct device_node *parts_np;
-		struct device_node *part_np;
 
 		parts_np = of_get_child_by_name(np, "partitions");
-		for_each_child_of_node(parts_np, part_np) {
+		for_each_child_of_node_scoped(parts_np, part_np) {
 			u32 start;
 			u32 size;
 			const __be32 *reg;

--- a/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_mstc_boot.c
+++ b/target/linux/generic/files/drivers/mtd/mtdsplit/mtdsplit_mstc_boot.c
@@ -175,7 +175,6 @@ mstcboot_parse_fixed_parts(struct mtd_info *mtd,
 			   int active, u32 bootnum_dt)
 {
 	struct device_node *np = mtd_get_of_node(mtd);
-	struct device_node *child;
 	struct mtd_partition *parts;
 	int ret, nr_parts, index = 0;
 
@@ -189,7 +188,7 @@ mstcboot_parse_fixed_parts(struct mtd_info *mtd,
 	if (!parts)
 		return -ENOMEM;
 
-	for_each_child_of_node(np, child) {
+	for_each_child_of_node_scoped(np, child) {
 		u32 reg[2];
 		if (of_n_addr_cells(child) != 1 ||
 		    of_n_size_cells(child) != 1)
@@ -219,7 +218,6 @@ mstcboot_parse_fixed_parts(struct mtd_info *mtd,
 		parts[index].size = reg[1];
 		index++;
 	}
-	of_node_put(child);
 
 	if (ret)
 		kfree(parts);

--- a/target/linux/generic/files/drivers/mtd/parsers/routerbootpart.c
+++ b/target/linux/generic/files/drivers/mtd/parsers/routerbootpart.c
@@ -229,7 +229,7 @@ static int routerboot_partitions_parse(struct mtd_info *master,
 
 	/* First count the subnodes */
 	np = 0;
-	for_each_child_of_node(rbpart_node,  pp)
+	for_each_child_of_node_scoped(rbpart_node, pp)
 		np++;
 
 	if (!np)
@@ -244,7 +244,7 @@ static int routerboot_partitions_parse(struct mtd_info *master,
 
 	np = 0;
 	master_ofs = 0;
-	for_each_child_of_node(rbpart_node, pp) {
+	for_each_child_of_node_scoped(rbpart_node, pp) {
 		const __be32 *reg, *sz;
 		size_t offset, size;
 		int i, len, a_cells, s_cells;
@@ -342,7 +342,6 @@ static int routerboot_partitions_parse(struct mtd_info *master,
 rbpart_fail:
 	pr_err("%s: error parsing routerboot partition %pOF (%pOF)\n",
 	       master->name, pp, rbpart_node);
-	of_node_put(pp);
 	kfree(parts);
 	return -EINVAL;
 }

--- a/target/linux/generic/files/drivers/net/phy/ar8327.c
+++ b/target/linux/generic/files/drivers/net/phy/ar8327.c
@@ -413,7 +413,7 @@ ar8327_hw_config_of(struct ar8xxx_priv *priv, struct device_node *np)
 	const __be32 *paddr;
 	int len;
 	int i;
-	struct device_node *leds, *child;
+	struct device_node *leds;
 
 	paddr = of_get_property(np, "qca,ar8327-initvals", &len);
 	if (!paddr || len < (2 * sizeof(*paddr)))
@@ -450,7 +450,7 @@ ar8327_hw_config_of(struct ar8xxx_priv *priv, struct device_node *np)
 	if (!data->leds)
 		return -ENOMEM;
 
-	for_each_available_child_of_node(leds, child) {
+	for_each_available_child_of_node_scoped(leds, child) {
 		u32 reg = 0, mode = 0;
 		struct ar8327_led_info info;
 		int ret;

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_common.c
@@ -488,12 +488,12 @@ static void b53_switch_reset_gpio(struct b53_device *dev)
 
 static int b53_configure_ports_of(struct b53_device *dev)
 {
-	struct device_node *dn, *pn;
+	struct device_node *dn;
 	u32 port_num;
 
 	dn = of_get_child_by_name(dev_of_node(dev->dev), "ports");
 
-	for_each_available_child_of_node(dn, pn) {
+	for_each_available_child_of_node_scoped(dn, pn) {
 		struct device_node *fixed_link;
 
 		if (of_property_read_u32(pn, "reg", &port_num))
@@ -1479,7 +1479,7 @@ static const struct b53_chip_data b53_switch_chips[] = {
 
 static int b53_switch_init_of(struct b53_device *dev)
 {
-	struct device_node *dn, *pn;
+	struct device_node *dn;
 	const char *alias;
 	u32 port_num;
 	u16 ports = 0;
@@ -1488,7 +1488,7 @@ static int b53_switch_init_of(struct b53_device *dev)
 	if (!dn)
 		return -EINVAL;
 
-	for_each_available_child_of_node(dn, pn) {
+	for_each_available_child_of_node_scoped(dn, pn) {
 		const char *label;
 		int len;
 

--- a/target/linux/generic/files/drivers/net/phy/swconfig.c
+++ b/target/linux/generic/files/drivers/net/phy/swconfig.c
@@ -1060,12 +1060,10 @@ static struct genl_family switch_fam = {
 static void
 of_switch_load_portmap(struct switch_dev *dev)
 {
-	struct device_node *port;
-
 	if (!dev->of_node)
 		return;
 
-	for_each_child_of_node(dev->of_node, port) {
+	for_each_child_of_node_scoped(dev->of_node, port) {
 		const __be32 *prop;
 		const char *segment;
 		int size, phys;

--- a/target/linux/ipq40xx/patches-6.12/706-net-dsa-qca8k-add-IPQ4019-built-in-switch-support.patch
+++ b/target/linux/ipq40xx/patches-6.12/706-net-dsa-qca8k-add-IPQ4019-built-in-switch-support.patch
@@ -557,7 +557,7 @@ Signed-off-by: Robert Marko <robert.marko@sartura.hr>
 +qca8k_do_dsa_sw_ports_self_test(struct qca8k_priv *priv, int parallel_test)
 +{
 +	struct device_node *dn = priv->dev->of_node;
-+	struct device_node *ports, *port;
++	struct device_node *ports;
 +	struct device_node *phy_dn;
 +	struct phy_device *phy;
 +	int reg, err = 0, test_phase;
@@ -575,7 +575,7 @@ Signed-off-by: Robert Marko <robert.marko@sartura.hr>
 +			if (err)
 +				goto error;
 +		}
-+		for_each_available_child_of_node(ports, port) {
++		for_each_available_child_of_node_scoped(ports, port) {
 +			err = of_property_read_u32(port, "reg", &reg);
 +			if (err)
 +				goto error;

--- a/target/linux/mediatek/files/drivers/leds/leds-smartrg-system.c
+++ b/target/linux/mediatek/files/drivers/leds/leds-smartrg-system.c
@@ -161,7 +161,7 @@ static int
 
 srg_led_probe(struct i2c_client *client)
 {
-	struct device_node *np = client->dev.of_node, *child;
+	struct device_node *np = client->dev.of_node;
 	struct srg_led_ctrl *sysled_ctrl;
 	int err;
 
@@ -177,7 +177,7 @@ srg_led_probe(struct i2c_client *client)
 
 	i2c_set_clientdata(client, sysled_ctrl);
 
-	for_each_available_child_of_node(np, child) {
+	for_each_available_child_of_node_scoped(np, child) {
 		if (srg_led_init_led(sysled_ctrl, child))
 			continue;
 

--- a/target/linux/mvebu/patches-6.12/903-drivers-hwmon-Add-the-IEI-WT61P803-PUZZLE-HWMON-driv.patch
+++ b/target/linux/mvebu/patches-6.12/903-drivers-hwmon-Add-the-IEI-WT61P803-PUZZLE-HWMON-driv.patch
@@ -53,7 +53,7 @@ Cc: Robert Marko <robert.marko@sartura.hr>
  obj-$(CONFIG_SENSORS_IBMPOWERNV)+= ibmpowernv.o
 --- /dev/null
 +++ b/drivers/hwmon/iei-wt61p803-puzzle-hwmon.c
-@@ -0,0 +1,444 @@
+@@ -0,0 +1,442 @@
 +// SPDX-License-Identifier: GPL-2.0-only
 +/* IEI WT61P803 PUZZLE MCU HWMON Driver
 + *
@@ -444,7 +444,6 @@ Cc: Robert Marko <robert.marko@sartura.hr>
 +	struct device *dev = &pdev->dev;
 +	struct iei_wt61p803_puzzle *mcu = dev_get_drvdata(dev->parent);
 +	struct iei_wt61p803_puzzle_hwmon *mcu_hwmon;
-+	struct fwnode_handle *child;
 +	struct device *hwmon_dev;
 +	int ret;
 +
@@ -467,11 +466,10 @@ Cc: Robert Marko <robert.marko@sartura.hr>
 +
 +	/* Control fans via PWM lines via Linux Kernel */
 +	if (IS_ENABLED(CONFIG_THERMAL)) {
-+		device_for_each_child_node(dev, child) {
++		device_for_each_child_node_scoped(dev, child) {
 +			ret = iei_wt61p803_puzzle_enable_thermal_cooling_dev(dev, child, mcu_hwmon);
 +			if (ret) {
 +				dev_err(dev, "Enabling the PWM fan failed\n");
-+				fwnode_handle_put(child);
 +				return ret;
 +			}
 +		}

--- a/target/linux/mvebu/patches-6.12/910-drivers-leds-wt61p803-puzzle-improvements.patch
+++ b/target/linux/mvebu/patches-6.12/910-drivers-leds-wt61p803-puzzle-improvements.patch
@@ -47,7 +47,7 @@
  
  	ret = iei_wt61p803_puzzle_write_command(priv->mcu, led_power_cmd,
  						sizeof(led_power_cmd),
-@@ -90,39 +106,168 @@ static enum led_brightness iei_wt61p803_
+@@ -90,39 +106,166 @@ static enum led_brightness iei_wt61p803_
  	return led_state;
  }
  
@@ -143,7 +143,6 @@
  {
  	struct device *dev = &pdev->dev;
 +	struct device_node *np = dev_of_node(dev);
-+	struct device_node *child;
  	struct iei_wt61p803_puzzle *mcu = dev_get_drvdata(dev->parent);
  	struct iei_wt61p803_puzzle_led *priv;
 -	struct led_init_data init_data = {};
@@ -170,7 +169,7 @@
 -	priv->cdev.brightness_set_blocking = iei_wt61p803_puzzle_led_brightness_set_blocking;
 -	priv->cdev.brightness_get = iei_wt61p803_puzzle_led_brightness_get;
 -	priv->cdev.max_brightness = 1;
-+	for_each_available_child_of_node(np, child) {
++	for_each_available_child_of_node_scoped(np, child) {
 +		struct led_init_data init_data = {};
  
 -	ret = devm_led_classdev_register_ext(dev, &priv->cdev, &init_data);
@@ -207,7 +206,7 @@
 +		priv->id = reg;
 +		priv->led_power_state = 1;
 +		priv->blinking = 0;
-+		init_data.fwnode = of_fwnode_handle(child);
++		init_data.fwnode = of_fwnode_handle(of_node_get(child));
 +
 +		priv->cdev.brightness_set_blocking = iei_wt61p803_puzzle_led_brightness_set_blocking;
 +		priv->cdev.brightness_get = iei_wt61p803_puzzle_led_brightness_get;
@@ -234,7 +233,6 @@
  
 -	fwnode_handle_put(child);
 +put_child_node:
-+	of_node_put(child);
  	return ret;
  }
  

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/gsw_mt7620.c
@@ -203,7 +203,7 @@ MODULE_DEVICE_TABLE(of, mediatek_gsw_match);
 int mtk_gsw_init(struct fe_priv *priv)
 {
 	struct device_node *eth_node = priv->dev->of_node;
-	struct device_node *phy_node, *mdiobus_node;
+	struct device_node *mdiobus_node;
 	struct device_node *np = priv->switch_np;
 	struct platform_device *pdev;
 	struct mt7620_gsw *gsw;
@@ -225,7 +225,7 @@ int mtk_gsw_init(struct fe_priv *priv)
 
 	mdiobus_node = of_get_child_by_name(eth_node, "mdio-bus");
 	if (mdiobus_node) {
-		for_each_child_of_node(mdiobus_node, phy_node) {
+		for_each_child_of_node_scoped(mdiobus_node, phy_node) {
 			id = of_get_property(phy_node, "reg", NULL);
 			if (id && (be32_to_cpu(*id) == 0x1f))
 				gsw->ephy_disable = true;

--- a/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
+++ b/target/linux/ramips/files/drivers/net/ethernet/ralink/mtk_eth_soc.c
@@ -1354,7 +1354,6 @@ static void fe_reset_phy(struct fe_priv *priv)
 static int __init fe_init(struct net_device *dev)
 {
 	struct fe_priv *priv = netdev_priv(dev);
-	struct device_node *port;
 	int err;
 
 	fe_reset_fe(priv);
@@ -1372,7 +1371,7 @@ static int __init fe_init(struct net_device *dev)
 		return err;
 
 	if (priv->soc->port_init)
-		for_each_child_of_node(priv->dev->of_node, port)
+		for_each_child_of_node_scoped(priv->dev->of_node, port)
 			if (of_device_is_compatible(port, "mediatek,eth-port") &&
 			    of_device_is_available(port))
 				priv->soc->port_init(priv, port);

--- a/target/linux/realtek/files-6.18/drivers/i2c/busses/i2c-gpio-shared.c
+++ b/target/linux/realtek/files-6.18/drivers/i2c/busses/i2c-gpio-shared.c
@@ -82,7 +82,6 @@ static void gpio_shared_post_xfer(struct i2c_adapter *adap)
 static int gpio_shared_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
-	struct fwnode_handle *child;
 	struct gpio_shared_ctx *ctx;
 	int msecs, ret, bus_num = -1;
 
@@ -100,7 +99,7 @@ static int gpio_shared_probe(struct platform_device *pdev)
 	if (device_get_child_node_count(dev) > GPIO_SHARED_MAX_BUS)
 		return dev_err_probe(dev, -EINVAL, "Too many channels\n");
 
-	device_for_each_child_node(dev, child) {
+	device_for_each_child_node_scoped(dev, child) {
 		struct gpio_shared_bus *bus = &ctx->bus[++bus_num];
 		struct i2c_adapter *adap = &bus->adap;
 		struct i2c_algo_bit_data *bit_data = &bus->bit_data;
@@ -108,7 +107,6 @@ static int gpio_shared_probe(struct platform_device *pdev)
 		bus->sda = devm_fwnode_gpiod_get(dev, child, "sda", GPIOD_OUT_HIGH_OPEN_DRAIN,
 						 fwnode_get_name(child));
 		if (IS_ERR(bus->sda)) {
-			fwnode_handle_put(child);
 			dev_err(dev, "SDA node for bus %d not found\n", bus_num);
 			continue;
 		}

--- a/target/linux/siflower/files-6.12/drivers/phy/siflower/phy-sf21-pcie.c
+++ b/target/linux/siflower/files-6.12/drivers/phy/siflower/phy-sf21-pcie.c
@@ -214,7 +214,6 @@ static int sf21_pcie_phy_probe(struct platform_device *pdev)
 	struct sf21_pcie_phy *p_phy;
 	struct phy_provider *provider;
 	struct phy *phy;
-	struct device_node *child;
 	int num_insts = 0;
 	u32 reg_idx, num_lanes, lvds_idx;
 	int ret;
@@ -253,7 +252,7 @@ static int sf21_pcie_phy_probe(struct platform_device *pdev)
 	regmap_clear_bits(p_phy->pcie_regmap, PCIE_SYSM_INIT,
 			PCIE_L1_RSTN | PCIE_L0_RSTN | PCIE_PHY_RSTN);
 
-	for_each_available_child_of_node(pdev->dev.of_node, child) {
+	for_each_available_child_of_node_scoped(pdev->dev.of_node, child) {
 		ret = of_property_read_u32(child, "reg", &reg_idx);
 		if (ret)
 			return dev_err_probe(


### PR DESCRIPTION
Avoids refcount problems and slightly simplifies code.