### PR TITLE
realtek: mdio-serdes: use correct device table identifier

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto-serdes.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto-serdes.c
@@ -528,7 +528,7 @@ static const struct of_device_id rtsds_of_match[] = {
 	},
 	{ /* sentinel */ }
 };
-MODULE_DEVICE_TABLE(of, rtsds_mdio_of_match);
+MODULE_DEVICE_TABLE(of, rtsds_of_match);
 
 static struct platform_driver rtsds_mdio_driver = {
 	.driver = {


### PR DESCRIPTION
Use the correct identifier 'rtsds_of_match' instead of 'rtsds_mdio_of_match' because the latter doesn't exist.

This doesn't cause an error for 6.12. However, with 6.18 the implementation of MODULE_DEVICE_TABLE has changed to use 'static' and 'used' [1] instead of 'extern' and 'unused' [2].

[1] https://github.com/torvalds/linux/blob/7d0a66e4bb9081d75c82ec4957c50034cb0ea449/include/linux/module.h#L260
[2] https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/include/linux/module.h#L249
