### PR TITLE
realtek: pcs: some SerDes mode handling improvements

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -134,7 +134,7 @@ struct rtpcs_ctrl;
 struct rtpcs_serdes {
 	struct rtpcs_ctrl *ctrl;
 	u8 id;
-	enum rtpcs_sds_mode mode;
+	enum rtpcs_sds_mode hw_mode;
 
 	bool rx_pol_inv;
 	bool tx_pol_inv;

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -2708,7 +2708,7 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 	 * For now disable all USXGMII SerDes handling and rely on U-Boot setup.
 	 */
 	if (mode == PHY_INTERFACE_MODE_USXGMII)
-		return -ENOTSUPP;
+		return 0;
 
 	pr_info("%s: set sds %d to mode %d\n", __func__, sds_id, mode);
 	val = rtpcs_sds_read_bits(sds, 0x1F, 0x9, 11, 6);

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -2677,15 +2677,15 @@ static sds_config sds_config_10p3125g_cmu_type1[] = {
 };
 
 static int rtpcs_931x_sds_config_mode(struct rtpcs_serdes *sds,
-				      phy_interface_t mode, int chiptype)
+				      enum rtpcs_sds_mode hw_mode, int chiptype)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 
-	switch (mode) {
-	case PHY_INTERFACE_MODE_NA:
+	switch (hw_mode) {
+	case RTPCS_SDS_MODE_OFF:
 		break;
 
-	case PHY_INTERFACE_MODE_XGMII: /* MII_XSGMII */
+	case RTPCS_SDS_MODE_XSGMII:
 
 		if (chiptype) {
 			/* fifo inv clk */
@@ -2700,7 +2700,12 @@ static int rtpcs_931x_sds_config_mode(struct rtpcs_serdes *sds,
 		rtpcs_sds_write_bits(sds, 0x80, 0xE, 12, 12, 1);
 		break;
 
-	case PHY_INTERFACE_MODE_USXGMII: /* MII_USXGMII_10GSXGMII/10GDXGMII/10GQXGMII: */
+	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GDXGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
+	case RTPCS_SDS_MODE_USXGMII_5GSXGMII:
+	case RTPCS_SDS_MODE_USXGMII_5GDXGMII:
+	case RTPCS_SDS_MODE_USXGMII_2_5GSXGMII:
 		u32 op_code = 0x6003;
 
 		if (chiptype) {
@@ -2742,8 +2747,8 @@ static int rtpcs_931x_sds_config_mode(struct rtpcs_serdes *sds,
 		}
 		break;
 
-	case PHY_INTERFACE_MODE_10GBASER: /* MII_10GR / MII_10GR1000BX_AUTO: */
-					  /* configure 10GR fiber mode=1 */
+	case RTPCS_SDS_MODE_10GBASER: /* 10GR1000BX_AUTO */
+		/* configure 10GR fiber mode=1 */
 		rtpcs_sds_write_bits(sds, 0x1f, 0xb, 1, 1, 1);
 
 		/* init fiber_1g */
@@ -2759,7 +2764,7 @@ static int rtpcs_931x_sds_config_mode(struct rtpcs_serdes *sds,
 		rtpcs_sds_write_bits(sds, 0x1f, 0x7, 10, 4, 0x7f);
 		break;
 
-	case PHY_INTERFACE_MODE_1000BASEX: /* MII_1000BX_FIBER */
+	case RTPCS_SDS_MODE_1000BASEX:
 		rtpcs_sds_write_bits(sds, 0x43, 0x13, 15, 14, 0);
 
 		rtpcs_sds_write_bits(sds, 0x42, 0x0, 12, 12, 1);
@@ -2767,18 +2772,18 @@ static int rtpcs_931x_sds_config_mode(struct rtpcs_serdes *sds,
 		rtpcs_sds_write_bits(sds, 0x42, 0x0, 13, 13, 0);
 		break;
 
-	case PHY_INTERFACE_MODE_SGMII:
+	case RTPCS_SDS_MODE_SGMII:
 		rtpcs_sds_write_bits(sds, 0x24, 0x9, 15, 15, 0);
 
 		/* this was in rtl931x_phylink_mac_config in dsa/rtl83xx/dsa.c before */
 		rtpcs_931x_sds_cmu_band_set(sds, true, 62, PHY_INTERFACE_MODE_SGMII);
 		break;
 
-	case PHY_INTERFACE_MODE_2500BASEX:
+	case RTPCS_SDS_MODE_2500BASEX:
 		rtpcs_sds_write_bits(sds, 0x41, 0x14, 8, 8, 1);
 		break;
 
-	case PHY_INTERFACE_MODE_QSGMII:
+	case RTPCS_SDS_MODE_QSGMII:
 	default:
 		return -ENOTSUPP;
 	}
@@ -2861,7 +2866,7 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 		return -ENOTSUPP;
 	}
 
-	ret = rtpcs_931x_sds_config_mode(sds, mode, chiptype);
+	ret = rtpcs_931x_sds_config_mode(sds, hw_mode, chiptype);
 	if (ret < 0)
 		return ret;
 

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -278,6 +278,43 @@ static struct rtpcs_link *rtpcs_phylink_pcs_to_link(struct phylink_pcs *pcs)
 	return container_of(pcs, struct rtpcs_link, pcs);
 }
 
+__maybe_unused
+static int rtpcs_sds_determine_hw_mode(struct rtpcs_serdes *sds,
+                                       phy_interface_t if_mode,
+                                       enum rtpcs_sds_mode *hw_mode)
+{
+	switch (if_mode) {
+	case PHY_INTERFACE_MODE_NA:
+		*hw_mode = RTPCS_SDS_MODE_OFF;
+		break;
+	case PHY_INTERFACE_MODE_1000BASEX:
+		*hw_mode = RTPCS_SDS_MODE_1000BASEX;
+		break;
+	case PHY_INTERFACE_MODE_2500BASEX:
+		*hw_mode = RTPCS_SDS_MODE_2500BASEX;
+		break;
+	case PHY_INTERFACE_MODE_10GBASER:
+		*hw_mode = RTPCS_SDS_MODE_10GBASER;
+		break;
+	case PHY_INTERFACE_MODE_SGMII:
+		*hw_mode = RTPCS_SDS_MODE_SGMII;
+		break;
+	case PHY_INTERFACE_MODE_QSGMII:
+		*hw_mode = RTPCS_SDS_MODE_QSGMII;
+		break;
+	case PHY_INTERFACE_MODE_USXGMII:
+		/* TODO: set this depending on number of links on SerDes */
+		*hw_mode = RTPCS_SDS_MODE_USXGMII_10GSXGMII;
+		break;
+	default:
+		return -ENOTSUPP;
+	}
+
+	/* TODO: check if the particular SerDes supports the mode */
+
+	return 0;
+}
+
 /* Variant-specific functions */
 
 /* RTL838X */

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -2685,8 +2685,43 @@ static int rtpcs_931x_sds_config_mode(struct rtpcs_serdes *sds,
 	case RTPCS_SDS_MODE_OFF:
 		break;
 
-	case RTPCS_SDS_MODE_XSGMII:
+	case RTPCS_SDS_MODE_1000BASEX:
+		rtpcs_sds_write_bits(sds, 0x43, 0x13, 15, 14, 0);
 
+		rtpcs_sds_write_bits(sds, 0x42, 0x0, 12, 12, 1);
+		rtpcs_sds_write_bits(sds, 0x42, 0x0, 6, 6, 1);
+		rtpcs_sds_write_bits(sds, 0x42, 0x0, 13, 13, 0);
+		break;
+
+	case RTPCS_SDS_MODE_2500BASEX:
+		rtpcs_sds_write_bits(sds, 0x41, 0x14, 8, 8, 1);
+		break;
+
+	case RTPCS_SDS_MODE_10GBASER: /* 10GR1000BX_AUTO */
+		/* configure 10GR fiber mode=1 */
+		rtpcs_sds_write_bits(sds, 0x1f, 0xb, 1, 1, 1);
+
+		/* init fiber_1g */
+		rtpcs_sds_write_bits(sds, 0x43, 0x13, 15, 14, 0);
+
+		rtpcs_sds_write_bits(sds, 0x42, 0x0, 12, 12, 1);
+		rtpcs_sds_write_bits(sds, 0x42, 0x0, 6, 6, 1);
+		rtpcs_sds_write_bits(sds, 0x42, 0x0, 13, 13, 0);
+
+		/* init auto */
+		rtpcs_sds_write_bits(sds, 0x1f, 13, 15, 0, 0x109e);
+		rtpcs_sds_write_bits(sds, 0x1f, 0x6, 14, 10, 0x8);
+		rtpcs_sds_write_bits(sds, 0x1f, 0x7, 10, 4, 0x7f);
+		break;
+
+	case RTPCS_SDS_MODE_SGMII:
+		rtpcs_sds_write_bits(sds, 0x24, 0x9, 15, 15, 0);
+
+		/* this was in rtl931x_phylink_mac_config in dsa/rtl83xx/dsa.c before */
+		rtpcs_931x_sds_cmu_band_set(sds, true, 62, PHY_INTERFACE_MODE_SGMII);
+		break;
+
+	case RTPCS_SDS_MODE_XSGMII:
 		if (chiptype) {
 			/* fifo inv clk */
 			rtpcs_sds_write_bits(sds, 0x41, 0x1, 7, 4, 0xf);
@@ -2745,42 +2780,6 @@ static int rtpcs_931x_sds_config_mode(struct rtpcs_serdes *sds,
 			rtpcs_sds_write(sds, 0x6, 0x1d, 0x0480);
 			rtpcs_sds_write(sds, 0x6, 0xe, 0x0400);
 		}
-		break;
-
-	case RTPCS_SDS_MODE_10GBASER: /* 10GR1000BX_AUTO */
-		/* configure 10GR fiber mode=1 */
-		rtpcs_sds_write_bits(sds, 0x1f, 0xb, 1, 1, 1);
-
-		/* init fiber_1g */
-		rtpcs_sds_write_bits(sds, 0x43, 0x13, 15, 14, 0);
-
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 12, 12, 1);
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 6, 6, 1);
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 13, 13, 0);
-
-		/* init auto */
-		rtpcs_sds_write_bits(sds, 0x1f, 13, 15, 0, 0x109e);
-		rtpcs_sds_write_bits(sds, 0x1f, 0x6, 14, 10, 0x8);
-		rtpcs_sds_write_bits(sds, 0x1f, 0x7, 10, 4, 0x7f);
-		break;
-
-	case RTPCS_SDS_MODE_1000BASEX:
-		rtpcs_sds_write_bits(sds, 0x43, 0x13, 15, 14, 0);
-
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 12, 12, 1);
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 6, 6, 1);
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 13, 13, 0);
-		break;
-
-	case RTPCS_SDS_MODE_SGMII:
-		rtpcs_sds_write_bits(sds, 0x24, 0x9, 15, 15, 0);
-
-		/* this was in rtl931x_phylink_mac_config in dsa/rtl83xx/dsa.c before */
-		rtpcs_931x_sds_cmu_band_set(sds, true, 62, PHY_INTERFACE_MODE_SGMII);
-		break;
-
-	case RTPCS_SDS_MODE_2500BASEX:
-		rtpcs_sds_write_bits(sds, 0x41, 0x14, 8, 8, 1);
 		break;
 
 	case RTPCS_SDS_MODE_QSGMII:

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -2676,6 +2676,17 @@ static sds_config sds_config_10p3125g_cmu_type1[] = {
 	{ 0x2F, 0x0F, 0xA470 }, { 0x2F, 0x10, 0x8000 }, { 0x2F, 0x11, 0x037B }
 };
 
+static int rtpcs_931x_sds_config_fiber_1g(struct rtpcs_serdes *sds)
+{
+	rtpcs_sds_write_bits(sds, 0x43, 0x12, 15, 14, 0x0);
+
+	rtpcs_sds_write_bits(sds, 0x42, 0x0, 12, 12, 0x1);
+	rtpcs_sds_write_bits(sds, 0x42, 0x0, 6, 6, 0x1);
+	rtpcs_sds_write_bits(sds, 0x42, 0x0, 13, 13, 0x0);
+
+	return 0;
+}
+
 static int rtpcs_931x_sds_config_mode(struct rtpcs_serdes *sds,
 				      enum rtpcs_sds_mode hw_mode, int chiptype)
 {
@@ -2686,11 +2697,7 @@ static int rtpcs_931x_sds_config_mode(struct rtpcs_serdes *sds,
 		break;
 
 	case RTPCS_SDS_MODE_1000BASEX:
-		rtpcs_sds_write_bits(sds, 0x43, 0x13, 15, 14, 0);
-
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 12, 12, 1);
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 6, 6, 1);
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 13, 13, 0);
+		rtpcs_931x_sds_config_fiber_1g(sds);
 		break;
 
 	case RTPCS_SDS_MODE_2500BASEX:
@@ -2701,12 +2708,7 @@ static int rtpcs_931x_sds_config_mode(struct rtpcs_serdes *sds,
 		/* configure 10GR fiber mode=1 */
 		rtpcs_sds_write_bits(sds, 0x1f, 0xb, 1, 1, 1);
 
-		/* init fiber_1g */
-		rtpcs_sds_write_bits(sds, 0x43, 0x13, 15, 14, 0);
-
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 12, 12, 1);
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 6, 6, 1);
-		rtpcs_sds_write_bits(sds, 0x42, 0x0, 13, 13, 0);
+		rtpcs_931x_sds_config_fiber_1g(sds);
 
 		/* init auto */
 		rtpcs_sds_write_bits(sds, 0x1f, 13, 15, 0, 0x109e);


### PR DESCRIPTION
This includes various cleanups, improvements and fixes for the RTL931X SerDes setup, most notably making use of previously introduced groundwork to improve the quality and clarity of the code.

Note: the diff of commit c896e4670329a3e51df7b1424920f69c4cb02fcc sadly looks quite weird and may be hard to review, though it's just a code move.