### PR TITLE
qualcommax: ipq50xx: remove cpufreq scaling

### DIFF
--- a/target/linux/qualcommax/patches-6.12/0912-arm64-dts-qcom-ipq5018-remove-cpufreq-scaling.patch
+++ b/target/linux/qualcommax/patches-6.12/0912-arm64-dts-qcom-ipq5018-remove-cpufreq-scaling.patch
@@ -1,0 +1,28 @@
+From 08910d6f438475bafec40654ff1c3e722d34d809 Mon Sep 17 00:00:00 2001
+From: Robert Senderek <robert.senderek@10g.pl>
+Date: Thu, 25 Dec 2025 12:14:46 +0100
+Subject: [PATCH] arm64: dts: qcom: ipq5018:  remove cpufreq scaling
+
+ipq5018 do not support freq scaling and therefore stuck on 800Mhz
+This patch allows CPU to run with 1.008 Ghz as designed
+
+Signed-off-by: Robert Senderek <robert.senderek@10g.pl>
+---
+ arch/arm64/boot/dts/qcom/ipq5018.dtsi | 6 ------
+ 1 file changed, 6 deletions(-)
+
+--- a/arch/arm64/boot/dts/qcom/ipq5018.dtsi
++++ b/arch/arm64/boot/dts/qcom/ipq5018.dtsi
+@@ -94,12 +94,6 @@
+ 		compatible = "operating-points-v2";
+ 		opp-shared;
+ 
+-		opp-800000000 {
+-			opp-hz = /bits/ 64 <800000000>;
+-			opp-microvolt = <1100000>;
+-			clock-latency-ns = <200000>;
+-		};
+-
+ 		opp-1008000000 {
+ 			opp-hz = /bits/ 64 <1008000000>;
+ 			opp-microvolt = <1100000>;


### PR DESCRIPTION
ipq5018 do not support freq scaling and therefore stuck on 800Mhz.
This patch allows CPU to run with 1.008 Ghz as designed

Downstream qsdk patch:
[arm64: dts: ipq5018: Remove 800 MHz entry from IPQ5018](https://git.codelinaro.org/clo/qsdk/oss/kernel/linux-ipq-5.4/-/commit/572b7d40ab8049ba3d44b4fd21502954ae0632b9)
