### PR TITLE
ath79: cf-ew71-v2: set label-mac-device to eth1

### DIFF
--- a/target/linux/ath79/dts/qca9531_comfast_cf-ew71-v2.dts
+++ b/target/linux/ath79/dts/qca9531_comfast_cf-ew71-v2.dts
@@ -15,6 +15,7 @@
 		led-boot = &led_wan;
 		led-failsafe = &led_wan;
 		led-upgrade = &led_wan;
+		label-mac-device = &eth1;
 	};
 
 	leds {


### PR DESCRIPTION
The EW71v2 has the WAN port configured at eth1.
The printed label-mac is configured on this iface in openwrt.

Should also be backported to 25.12 and 24.10..
