### PR TITLE
mvebu: add support for Netgear ReadyNAS 102

### DIFF
--- a/h --force origin fresh-start:openwrt-rn102
+++ b/h --force origin fresh-start:openwrt-rn102
@@ -1,0 +1,38 @@
+[33mcommit a8e15494e38b74b04b93e603c70174be29416bfd[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mfresh-start[m[33m)[m
+Author: Rylee Dunn <ryleedunn111@gmail.com>
+Date:   Tue Dec 16 14:33:27 2025 -0500
+
+    mvebu: add support for Netgear ReadyNAS 102
+    
+    The Netgear ReadyNAS 102 is a 2-bay NAS based on the Marvell
+    Armada 370 SoC.
+    
+    Specification:
+    - SoC: Marvell Armada 370 (88F6707) @ 1.2 GHz
+    - RAM: 512 MB DDR3
+    - Flash: 128 MB NAND (Samsung K9F1G08U0D)
+    - Storage: 2x SATA 3.0 (Marvell 88SE9170 via PCIe)
+    - Network: 1x Gigabit Ethernet (Marvell NETA)
+    - USB: 2x USB 3.0 (Rear), 1x USB 2.0 (Front)
+    
+    Installation:
+    1. Connect via Serial Console (115200 8N1).
+    2. Interrupt U-Boot and TFTP boot the initramfs image.
+    3. Use sysupgrade to install the squashfs-sysupgrade.bin image.
+    
+    Verified working:
+    - Booting (Kernel 6.12)
+    - Ethernet (with correct MAC address from u-boot-env)
+    - SATA Ports (both bays detected via AHCI)
+    - USB 3.0 Ports
+    - LEDs and Buttons
+    - Sysupgrade (NAND/UBI preservation)
+    
+    Signed-off-by: Rylee Dunn <ryleedunn111@gmail.com>
+
+ target/linux/mvebu/cortexa9/base-files/etc/board.d/01_leds                  |  4 [32m++++[m
+ target/linux/mvebu/cortexa9/base-files/etc/board.d/02_network               |  9 [32m+++++++++[m
+ target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh              |  5 [32m+++++[m
+ target/linux/mvebu/image/cortexa9.mk                                        | 14 [32m++++++++++++++[m
+ target/linux/mvebu/patches-6.12/901-armada-370-rn102-fix-ubi-bootargs.patch | 10 [32m++++++++++[m
+ 5 files changed, 42 insertions(+)

--- a/target/linux/mvebu/cortexa9/base-files/etc/board.d/01_leds
+++ b/target/linux/mvebu/cortexa9/base-files/etc/board.d/01_leds
@@ -54,6 +54,10 @@ linksys,wrt32x)
 	ucidef_set_led_usbport "usb2" "USB 2" "pca963x:venom:blue:usb3_1" "usb2-port1" "usb3-port1"
 	ucidef_set_led_usbport "usb2_ss" "USB 2 SS" "pca963x:venom:blue:usb3_2" "usb3-port1"
 	;;
+netgear,readynas-102)
+	ucidef_set_led_netdev "activity" "Activity" "rn102:blue:pwr" "eth0"
+	ucidef_set_led_default "backup" "Backup" "rn102:blue:backup" "0"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/mvebu/cortexa9/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/cortexa9/base-files/etc/board.d/02_network
@@ -49,6 +49,9 @@ mvebu_setup_interfaces()
 	marvell,axp-gp)
 		ucidef_set_interface_lan "eth0 eth1 eth2 eth3"
 		;;
+	netgear,readynas-102)
+		ucidef_set_interface_lan "eth0" "dhcp"
+		;;
 	solidrun,clearfog-base-a1)
 		# eth0 is standalone ethernet
 		# eth1 is standalone ethernet
@@ -95,6 +98,12 @@ mvebu_setup_macs()
 		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		lan_mac=$label_mac
 		wan_mac=$label_mac
+		;;
+	netgear,readynas-102)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		if [ -z "$lan_mac" ]; then
+		lan_mac=$(mtd_get_mac_ascii u-boot-env eth1addr)
+		fi
 		;;
 	wd,cloud-mirror-gen2)
 		# mac address is on ubi "config" or ubi "reserve2" in text file.

--- a/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
@@ -87,6 +87,11 @@ platform_do_upgrade() {
 	linksys,wrt32x)
 		platform_do_upgrade_linksys "$1"
 		;;
+	netgear,readynas-102)
+		CI_UBIPART="ubifs"
+		CI_KERNPART="uImage"
+		nand_do_upgrade "$1"
+		;;
 	*)
 		default_do_upgrade "$1"
 		;;

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -398,6 +398,19 @@ define Device/marvell_axp-gp
 endef
 TARGET_DEVICES += marvell_axp-gp
 
+define Device/netgear_rn102
+  $(Device/NAND-128K)
+  DEVICE_VENDOR := Netgear
+  DEVICE_MODEL := ReadyNAS 102
+  DEVICE_DTS := armada-370-netgear-rn102
+  KERNEL := kernel-bin | append-dtb | uImage none
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  SUPPORTED_DEVICES := netgear,readynas-102
+  DEVICE_PACKAGES := kmod-usb3 kmod-r8169 uboot-envtools kmod-ata-ahci block-mount
+endef
+TARGET_DEVICES += netgear_rn102
+
 define Device/plathome_openblocks-ax3-4
   DEVICE_VENDOR := Plat'Home
   DEVICE_MODEL := OpenBlocks AX3

--- a/target/linux/mvebu/patches-6.12/901-armada-370-rn102-fix-ubi-bootargs.patch
+++ b/target/linux/mvebu/patches-6.12/901-armada-370-rn102-fix-ubi-bootargs.patch
@@ -1,0 +1,10 @@
+--- a/arch/arm/boot/dts/marvell/armada-370-netgear-rn102.dts
++++ b/arch/arm/boot/dts/marvell/armada-370-netgear-rn102.dts
+@@ -17,6 +17,7 @@
+ 
+ 	chosen {
+ 		stdout-path = "serial0:115200n8";
++		bootargs = "console=ttyS0,115200 ubi.mtd=4 root=ubi0:rootfs rootfstype=squashfs ";
+ 	};
+ 
+ 	memory@0 {


### PR DESCRIPTION
The Netgear ReadyNAS 102 is a 2-bay NAS based on the Marvell Armada 370 SoC.

Specification:
- SoC: Marvell Armada 370 (88F6707) @ 1.2 GHz
- RAM: 512 MB DDR3
- Flash: 128 MB NAND (Samsung K9F1G08U0D)
- Storage: 2x SATA 3.0 (Marvell 88SE9170 via PCIe)
- Network: 1x Gigabit Ethernet (Marvell NETA)
- USB: 2x USB 3.0 (Rear), 1x USB 2.0 (Front)

Installation:
1. Connect via Serial Console (115200 8N1).
2. Interrupt U-Boot and TFTP boot the initramfs image.
3. Use sysupgrade to install the squashfs-sysupgrade.bin image.

Verified working:
- Booting (Kernel 6.12)
- Ethernet (with correct MAC address from u-boot-env)
- SATA Ports (both bays detected via AHCI)
- USB 3.0 Ports
- LEDs and Buttons
- Sysupgrade (NAND/UBI preservation)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
