### PR TITLE
cryptodev-linux: add backport to build for 6.18

### DIFF
--- a/package/kernel/cryptodev-linux/Makefile
+++ b/package/kernel/cryptodev-linux/Makefile
@@ -11,7 +11,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=cryptodev-linux
 PKG_VERSION:=1.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://codeload.github.com/$(PKG_NAME)/$(PKG_NAME)/tar.gz/$(PKG_NAME)-$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/package/kernel/cryptodev-linux/patches/002-Fix-build-for-Linux-6.18-rc1.patch
+++ b/package/kernel/cryptodev-linux/patches/002-Fix-build-for-Linux-6.18-rc1.patch
@@ -1,0 +1,49 @@
+From 08644db02d43478f802755903212f5ee506af73b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joan=20Bruguera=20Mic=C3=B3?= <joanbrugueram@gmail.com>
+Date: Sat, 6 Sep 2025 20:36:38 +0000
+Subject: [PATCH] Fix build for Linux 6.18-rc1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It's no longer required to use nth_page() when iterating pages within a
+single scatterlist entry.
+
+Note I believe this code path in `sg_advance` is currently unreachable:
+It is only called from `get_userbuf_srtp`, passing in a scatterlist
+copied from one created by `__get_userbuf`, which only generates
+entries such that `sg->offset + sg->length <= PAGE_SIZE`.
+On the other hand, this code path in `sg_advance` requires that
+`sg->offset + sg->length > sg->offset + consumed >= PAGE_SIZE`.
+
+See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f8f03eb5f0f91fddc9bb8563c7e82bd7d3ba1dd0
+          https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ce00897b94bc5c62fab962625efcf1ab824d3688
+
+Signed-off-by: Joan Bruguera Micó <joanbrugueram@gmail.com>
+---
+ util.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/util.c
++++ b/util.c
+@@ -21,6 +21,7 @@
+ 
+ #include <crypto/scatterwalk.h>
+ #include <linux/scatterlist.h>
++#include <linux/version.h>
+ #include "util.h"
+ 
+ /* These were taken from Maxim Levitsky's patch to lkml.
+@@ -44,8 +45,12 @@ struct scatterlist *sg_advance(struct sc
+ 	sg->length -= consumed;
+ 
+ 	if (sg->offset >= PAGE_SIZE) {
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0))
++		struct page *page = sg_page(sg) + (sg->offset / PAGE_SIZE);
++#else
+ 		struct page *page =
+ 			nth_page(sg_page(sg), sg->offset / PAGE_SIZE);
++#endif
+ 		sg_set_page(sg, page, sg->length, sg->offset % PAGE_SIZE);
+ 	}
+ 


### PR DESCRIPTION
Add https://github.com/cryptodev-linux/cryptodev-linux/commit/08644db02d43478f802755903212f5ee506af73b to allow builds against the 6.18 series of kernels.