### PR TITLE
mvebu: add support for Netgear ReadyNAS 102

### DIFF
--- a/target/linux/mvebu/cortexa9/base-files/etc/board.d/01_leds
+++ b/target/linux/mvebu/cortexa9/base-files/etc/board.d/01_leds
@@ -54,6 +54,10 @@ linksys,wrt32x)
 	ucidef_set_led_usbport "usb2" "USB 2" "pca963x:venom:blue:usb3_1" "usb2-port1" "usb3-port1"
 	ucidef_set_led_usbport "usb2_ss" "USB 2 SS" "pca963x:venom:blue:usb3_2" "usb3-port1"
 	;;
+netgear,readynas-102)
+	ucidef_set_led_netdev "activity" "Activity" "rn102:blue:pwr" "eth0"
+	ucidef_set_led_default "backup" "Backup" "rn102:blue:backup" "0"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mvebu/cortexa9/base-files/lib/upgrade/platform.sh
@@ -87,6 +87,11 @@ platform_do_upgrade() {
 	linksys,wrt32x)
 		platform_do_upgrade_linksys "$1"
 		;;
+	netgear,readynas-102)
+		CI_UBIPART="ubifs"
+		CI_KERNPART="uImage"
+		nand_do_upgrade "$1"
+		;;
 	*)
 		default_do_upgrade "$1"
 		;;

--- a/target/linux/mvebu/image/cortexa9.mk
+++ b/target/linux/mvebu/image/cortexa9.mk
@@ -398,6 +398,19 @@ define Device/marvell_axp-gp
 endef
 TARGET_DEVICES += marvell_axp-gp
 
+define Device/netgear_rn102
+  $(Device/NAND-128K)
+  DEVICE_VENDOR := Netgear
+  DEVICE_MODEL := ReadyNAS 102
+  DEVICE_DTS := armada-370-netgear-rn102
+  KERNEL := kernel-bin | append-dtb | uImage none
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  SUPPORTED_DEVICES := netgear,readynas-102
+  DEVICE_PACKAGES := kmod-usb3 kmod-r8169 kmod-ata-ahci block-mount
+endef
+TARGET_DEVICES += netgear_rn102
+
 define Device/plathome_openblocks-ax3-4
   DEVICE_VENDOR := Plat'Home
   DEVICE_MODEL := OpenBlocks AX3

--- a/target/linux/mvebu/patches-6.12/901-armada-370-rn102-support.patch
+++ b/target/linux/mvebu/patches-6.12/901-armada-370-rn102-support.patch
@@ -1,0 +1,53 @@
+Index: linux-6.12.60/arch/arm/boot/dts/marvell/armada-370-netgear-rn102.dts
+===================================================================
+--- linux-6.12.60.orig/arch/arm/boot/dts/marvell/armada-370-netgear-rn102.dts
++++ linux-6.12.60/arch/arm/boot/dts/marvell/armada-370-netgear-rn102.dts
+@@ -15,8 +15,18 @@
+ 	model = "NETGEAR ReadyNAS 102";
+ 	compatible = "netgear,readynas-102", "marvell,armada370", "marvell,armada-370-xp";
+ 
++	aliases {
++		ethernet0 = &eth0;
++		label-mac-device = &eth0;
++		led-boot = &led_power;
++		led-failsafe = &led_power;
++		led-running = &led_power;
++		led-upgrade = &led_power;
++	};
++
+ 	chosen {
+ 		stdout-path = "serial0:115200n8";
++		bootargs = "console=ttyS0,115200";
+ 	};
+ 
+ 	memory@0 {
+@@ -52,6 +62,9 @@
+ 				status = "okay";
+ 				phy = <&phy0>;
+ 				phy-mode = "rgmii-id";
++
++				nvmem-cells = <&ethaddr>;
++				nvmem-cell-names = "mac-address";
+ 			};
+ 
+ 			usb@50000 {
+@@ -100,7 +113,7 @@
+ 			     &backup_led_pin>;
+ 		pinctrl-names = "default";
+ 
+-		blue-power-led {
++		led_power: blue-power-led {
+ 			label = "rn102:blue:pwr";
+ 			gpios = <&gpio1 25 GPIO_ACTIVE_LOW>;
+ 			default-state = "keep";
+@@ -254,6 +267,10 @@
+ 				label = "u-boot-env";
+ 				reg = <0x180000 0x20000>;    /* 128KB */
+ 				read-only;
++
++				nvmem-layout {
++					compatible = "u-boot,env";
++				};
+ 			};
+ 
+ 			partition@200000 {


### PR DESCRIPTION
The Netgear ReadyNAS 102 is a 2-bay NAS based on the Marvell Armada 370 SoC.

Specification:
- SoC: Marvell Armada 370 (88F6707) @ 1.2 GHz
- RAM: 512 MB DDR3
- Flash: 128 MB NAND (Samsung K9F1G08U0D)
- Storage: 2x SATA 3.0 (Marvell 88SE9170 via PCIe)
- Network: 1x Gigabit Ethernet (Marvell NETA)
- USB: 2x USB 3.0 (Rear), 1x USB 2.0 (Front)

Installation:
1. Connect via Serial Console (115200 8N1).
2. Interrupt U-Boot and TFTP boot the initramfs image.
3. Use sysupgrade to install the squashfs-sysupgrade.bin image.

Verified working:
- Booting (Kernel 6.12)
- Ethernet (with correct MAC address from u-boot-env)
- SATA Ports (both bays detected via AHCI)
- USB 3.0 Ports
- LEDs and Buttons
- Sysupgrade (NAND/UBI preservation)