### PR TITLE
linux-firmware: intel: kick BE200 wifi firmware

### DIFF
--- a/package/firmware/linux-firmware/intel.mk
+++ b/package/firmware/linux-firmware/intel.mk
@@ -219,7 +219,7 @@ $(eval $(call BuildPackage,iwlwifi-firmware-ax411))
 Package/iwlwifi-firmware-be200 = $(call Package/firmware-default,Intel BE200 firmware)
 define Package/iwlwifi-firmware-be200/install
 	$(INSTALL_DIR) $(1)/lib/firmware
-	$(INSTALL_DATA) $(PKG_BUILD_DIR)/intel/iwlwifi/iwlwifi-gl-c0-fm-c0-98.ucode $(1)/lib/firmware
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/intel/iwlwifi/iwlwifi-gl-c0-fm-c0-101.ucode $(1)/lib/firmware
 	$(INSTALL_DATA) $(PKG_BUILD_DIR)/intel/iwlwifi/iwlwifi-gl-c0-fm-c0.pnvm $(1)/lib/firmware
 endef
 $(eval $(call BuildPackage,iwlwifi-firmware-be200))


### PR DESCRIPTION
latest backports require newer firmware version