### PR TITLE
Disable deprecated openssl protocols

### DIFF
--- a/package/libs/openssl/Config.in
+++ b/package/libs/openssl/Config.in
@@ -76,6 +76,33 @@ config OPENSSL_WITH_ERROR_MESSAGES
 
 comment "Protocol Support"
 
+config OPENSSL_WITH_SSL3
+	bool
+	default n
+	prompt "Enable support for SSLv3"
+	help
+		SSLv3 has been deprecated. This option aims to provide
+		support for earlier versions of the standard for compatibility.
+		You should enable this option only if you need it.
+
+config OPENSSL_WITH_TLS10
+	bool
+	default n
+	prompt "Enable support for TLS 1"
+	help
+		TLS v1 (1.0) has been deprecated. This option aims to provide
+		support for earlier versions of the standard for compatibility.
+		You should enable this option only if you need it.
+
+config OPENSSL_WITH_TLS11
+	bool
+	default n
+	prompt "Enable support for TLS 1.1"
+	help
+		TLS v1.1 has been deprecated. This option aims to provide
+		support for earlier versions of the standard for compatibility.
+		You should enable this option only if you need it.
+
 config OPENSSL_WITH_TLS13
 	bool
 	default y

--- a/package/libs/openssl/Config.in
+++ b/package/libs/openssl/Config.in
@@ -103,6 +103,26 @@ config OPENSSL_WITH_TLS11
 		support for earlier versions of the standard for compatibility.
 		You should enable this option only if you need it.
 
+config OPENSSL_WITH_TLS12
+	bool
+	default y
+	prompt "Enable support for TLS 1.2"
+	help
+		TLS 1.2 is a widely deployed and secure version of the TLS
+		protocol and remains required for compatibility with many
+		existing servers, clients, and embedded systems.
+
+		While TLS 1.3 is preferred when available, TLS 1.2 support
+		is still necessary for interoperability, including in
+		environments where TLS 1.3 is not yet supported or enabled.
+
+		Disabling TLS 1.2 removes protocol support entirely and may
+		cause TLS connections to fail when communicating with peers
+		that do not support TLS 1.3.
+
+		This option should only be disabled in controlled environments
+		where all communicating endpoints are known to support TLS 1.3.
+
 config OPENSSL_WITH_TLS13
 	bool
 	default y

--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.5.4
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_BUILD_PARALLEL:=1
@@ -240,6 +240,18 @@ endif
 
 ifndef CONFIG_OPENSSL_WITH_ERROR_MESSAGES
   OPENSSL_OPTIONS += no-err
+endif
+
+ifndef CONFIG_OPENSSL_WITH_SSL3
+  OPENSSL_OPTIONS += no-ssl3 no-ssl3-method
+endif
+
+ifndef CONFIG_OPENSSL_WITH_TLS10
+  OPENSSL_OPTIONS += no-tls1 no-tls1-method
+endif
+
+ifndef CONFIG_OPENSSL_WITH_TLS11
+  OPENSSL_OPTIONS += no-tls1_1 no-tls1_1-method
 endif
 
 ifndef CONFIG_OPENSSL_WITH_TLS13

--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
 PKG_VERSION:=3.5.4
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_BUILD_PARALLEL:=1
@@ -252,6 +252,10 @@ endif
 
 ifndef CONFIG_OPENSSL_WITH_TLS11
   OPENSSL_OPTIONS += no-tls1_1 no-tls1_1-method
+endif
+
+ifndef CONFIG_OPENSSL_WITH_TLS12
+  OPENSSL_OPTIONS += no-tls1_2 no-tls1_2-method
 endif
 
 ifndef CONFIG_OPENSSL_WITH_TLS13


### PR DESCRIPTION
SSLv3, TLSv1 and TLSv1.1 have been deprecated since 2021. They should
thus be disabled by default in openssl builds, and be enabled when needed.

This change introduces a new parameter per protocol, to enable them. If
not enabled, the protocol will be disabled by default.
