### PR TITLE
wifi-scripts: carry over roaming defaults from shell script

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -365,7 +365,9 @@ function iface_roaming(config) {
 
 	set_default(config, 'mobility_domain', substr(md5(config.ssid), 0, 4));
 	set_default(config, 'ft_psk_generate_local', config.auth_type == 'psk');
+	set_default(config, 'ft_over_ds', 0);
 	set_default(config, 'ft_iface', config.network_ifname);
+	set_default(config, 'reassociation_deadline', 20000);
 
 	if (!config.ft_psk_generate_local) {
 		if (!config.r0kh || !config.r1kh) {


### PR DESCRIPTION
`ft_over_ds` already defaulted to 0 when the ucode variant was created. `reassociation_deadline` was recently changed to default to 20000 (a7790ce4109).
