### PR TITLE
kernel: add option for USB FunctionFS gadget

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -154,6 +154,24 @@ endef
 
 $(eval $(call KernelPackage,usb-gadget-hid))
 
+define KernelPackage/usb-gadget-fs
+  TITLE:=USB FunctionFS Gadget Support
+  KCONFIG:=CONFIG_USB_FUNCTIONFS \
+    CONFIG_USB_FUNCTIONFS_ETH=n \
+    CONFIG_USB_FUNCTIONFS_RNDIS=n
+  FILES:= \
+	  $(LINUX_DIR)/drivers/usb/gadget/legacy/g_ffs.ko \
+	  $(LINUX_DIR)/drivers/usb/gadget/function/usb_f_fs.ko
+  AUTOLOAD:=$(call AutoLoad,52,usb_f_fs)
+  $(call AddDepends/usbgadget,+kmod-usb-lib-composite +kmod-dma-buf)
+endef
+
+define KernelPackage/usb-gadget-fs/description
+  Kernel support for USB FunctionFS Gadget.
+endef
+
+$(eval $(call KernelPackage,usb-gadget-fs))
+
 define KernelPackage/usb-gadget-ehci-debug
   TITLE:=USB EHCI debug port Gadget support
   KCONFIG:=\


### PR DESCRIPTION
Add menuconfig option 'kmod-usb-gadget-fs' for the USB FunctionFS gadget module

OpenWRT is perfect for USB gadgets that are network-enabled, since it provides everything needed to easily manage the device. Having support for the FunctionFS gadget enables the use of any custom USB devices that does not have a specific module, like Media Transfer Protocol.

I built the patch and can confirm that it works on the Raspberry Pi Zero 2 W.

Also, if this is merged, will the module be automatically included in the offical builds?