### PR TITLE
wifi-scripts: set extended_key_id for psk-like APs

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -339,6 +339,11 @@
 			"description": "WPS UPnP interface",
 			"type": "boolean"
 		},
+		"extended_key_id": {
+			"description": "Rekey PTK using Extended Key ID",
+			"type": "number",
+			"enum": [ 0, 1, 2 ]
+		},
 		"fils": {
 			"description": "Enable FILS",
 			"type": "boolean"

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -144,6 +144,9 @@ function iface_auth_type(config) {
 			set_default(config, 'sae_password_file', `/var/run/hostapd-${config.ifname}.sae`);
 			touch_file(config.sae_password_file);
 		}
+
+		set_default(config, 'extended_key_id', 1);
+
 		break;
 
 	case 'eap':
@@ -184,7 +187,7 @@ function iface_auth_type(config) {
 		'macaddr_acl', 'wpa_psk_radius', 'wpa_psk', 'wpa_passphrase', 'wpa_psk_file',
 		'eapol_version', 'dynamic_vlan', 'radius_request_cui', 'eap_reauth_period',
 		'radius_das_client', 'radius_das_port', 'own_ip_addr', 'dynamic_own_ip_addr',
-		'wpa_disable_eapol_key_retries', 'auth_algs', 'wpa', 'wpa_pairwise',
+		'wpa_disable_eapol_key_retries', 'auth_algs', 'wpa', 'wpa_pairwise', 'extended_key_id',
 		'erp_domain', 'fils_realm', 'erp_send_reauth_start', 'fils_cache_id'
 	]);
 }

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -550,7 +550,7 @@ hostapd_set_bss_options() {
 	local wep_rekey wpa_group_rekey wpa_pair_rekey wpa_master_rekey wpa_key_mgmt
 
 	json_get_vars \
-		wep_rekey wpa_group_rekey wpa_pair_rekey wpa_master_rekey wpa_strict_rekey \
+		wep_rekey wpa_group_rekey wpa_pair_rekey wpa_master_rekey wpa_strict_rekey extended_key_id \
 		wpa_disable_eapol_key_retries tdls_prohibit \
 		maxassoc max_inactivity disassoc_low_ack isolate auth_cache \
 		wps_pushbutton wps_label ext_registrar wps_pbc_in_m1 wps_ap_setup_locked \
@@ -674,6 +674,8 @@ hostapd_set_bss_options() {
 			wps_not_configured=1
 		;;
 		psk|sae|psk-sae)
+			set_default extended_key_id 1
+
 			json_get_vars key wpa_psk_file sae_password_file
 			if [ "$ppsk" -ne 0 ]; then
 				json_get_vars auth_secret auth_port
@@ -804,6 +806,7 @@ hostapd_set_bss_options() {
 	append bss_conf "auth_algs=${auth_algs:-1}" "$N"
 	append bss_conf "wpa=$wpa" "$N"
 	[ -n "$wpa_pairwise" ] && append bss_conf "wpa_pairwise=$wpa_pairwise" "$N"
+	[ -n "$extended_key_id" ] && append bss_conf "extended_key_id=$extended_key_id" "$N"
 
 	set_default wps_pushbutton 0
 	set_default wps_label 0


### PR DESCRIPTION
From the commit adding it in hostapd:

    Extended Key ID allows to rekey pairwise keys without the otherwise
    unavoidable MPDU losses on a busy link. The standard is fully backward
    compatible, allowing an AP to serve STAs with and without Extended Key
    ID support in the same BSS.