### PR TITLE
build: avoid errors during release candidate kernel packaging

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -213,8 +213,8 @@ define KernelPackage
     SECTION:=kernel
     CATEGORY:=Kernel modules
     DESCRIPTION:=$(DESCRIPTION)
-    EXTRA_DEPENDS:=kernel (=$(LINUX_VERSION)~$(LINUX_VERMAGIC)-r$(LINUX_RELEASE))
-    VERSION:=$(LINUX_VERSION)$(if $(PKG_VERSION),.$(PKG_VERSION))-r$(if $(PKG_RELEASE),$(PKG_RELEASE),$(LINUX_RELEASE))
+    EXTRA_DEPENDS:=kernel (=$(subst -rc,_rc,$(LINUX_VERSION))~$(LINUX_VERMAGIC)-r$(LINUX_RELEASE))
+    VERSION:=$(subst -rc,_rc,$(LINUX_VERSION))$(if $(PKG_VERSION),.$(PKG_VERSION))-r$(if $(PKG_RELEASE),$(PKG_RELEASE),$(LINUX_RELEASE))
     PKGFLAGS:=$(PKGFLAGS)
     $(call KernelPackage/$(1))
     $(call KernelPackage/$(1)/$(BOARD))

--- a/package/Makefile
+++ b/package/Makefile
@@ -105,7 +105,7 @@ ifneq ($(CONFIG_USE_APK),)
 		$$(cat $(TMP_DIR)/apk_install_list) \
 			"base-files=$(shell cat $(TMP_DIR)/base-files.version)" \
 			"libc=$(shell cat $(TMP_DIR)/libc.version)" \
-			"kernel=$(shell cat $(TMP_DIR)/kernel.version)"
+			"kernel=$(subst -rc,_rc,$(shell cat $(TMP_DIR)/kernel.version))"
 
 	rm -rf $(TARGET_DIR)/run
 else

--- a/package/kernel/linux/Makefile
+++ b/package/kernel/linux/Makefile
@@ -53,7 +53,7 @@ define Package/kernel
   CATEGORY:=Kernel
   DEFAULT:=y
   TITLE:=Virtual kernel package
-  VERSION:=$(LINUX_VERSION)~$(LINUX_VERMAGIC)-r$(LINUX_RELEASE)
+  VERSION:=$(subst -rc,_rc,$(LINUX_VERSION))~$(LINUX_VERMAGIC)-r$(LINUX_RELEASE)
   URL:=http://www.kernel.org/
   PKG_FLAGS:=nonshared
 endef


### PR DESCRIPTION
The build system allows to use Linux release candidate kernels (-rcX). For this a target/linux/generic/kernel-6.XY as follows is needed:

```
LINUX_VERSION-6.XY = -rc1
LINUX_KERNEL_HASH-6.XY-rc1 = 18ba6ebd72f46b881e0d73e390b2888b7b43...
```

Sadly the builds fail with a packaging error.

```
fakeroot /home/openwrt/openwrt/openwrt/staging_dir/host/bin/apk mkpkg --info "name:kernel" --info "version:6.15-rc1~c4bf...1f6-r1" 
ERROR: info field 'version' has invalid value: package version is invalid
```

The apk metadata specification reads:

"... Currently the APK version specification is as follows: number{.number}...{letter}{_suffix{number}}...{~hash}{-r#} ... Optionally one or more _suffix{number} components can follow. The list of valid suffixes (and their sorting order) is: alpha, beta, pre, rc, <no suffix>, cvs, svn, git, hg, p."

Given that the kernel uses "-rcX" naming scheme and apk requires "_rcX" instead, simply translate the dash to an underscore for these builds.
