### PR TITLE
wifi-scripts: don't set wpa_pairwise for wpa=0

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -16,10 +16,11 @@ export function parse_encryption(config, dev_config) {
 			config.wpa = v;
 			break;
 		}
-	if (!config.wpa)
-		config.wpa_pairwise = null;
 
-	config.wpa_pairwise = (config.hw_mode == 'ad') ? 'GCMP' : 'CCMP';
+	config.wpa_pairwise = null;
+	if (config.wpa)
+		config.wpa_pairwise = (config.hw_mode == 'ad') ? 'GCMP' : 'CCMP';
+
 	config.auth_type = encryption[0] ?? 'none';
 
 	let wpa3_pairwise = config.wpa_pairwise;


### PR DESCRIPTION
Without this patch, the

```
if (!config.wpa)
		config.wpa_pairwise = null;
```

is overwritten immediately.