### PR TITLE
arm-trusted-firmware-mediatek: add Cudy DDR3 target

### DIFF
--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -262,8 +262,8 @@ define Trusted-Firmware-A/mt7981-spim-nand-ubi-ddr4
   USE_UBI:=1
 endef
 
-define Trusted-Firmware-A/mt7981-cudy-tr3000-v1
-  NAME:=Cudy TR3000 v1 (SPI-NAND via SPIM, DDR3)
+define Trusted-Firmware-A/mt7981-cudy-ddr3
+  NAME:=Cudy (SPI-NAND via SPIM, DDR3)
   BOOT_DEVICE:=spim-nand
   BUILD_SUBTARGET:=filogic
   PLAT:=mt7981
@@ -664,7 +664,7 @@ TFA_TARGETS:= \
 	mt7981-emmc-ddr4 \
 	mt7981-sdmmc-ddr4 \
 	mt7981-spim-nand-ddr4 \
-	mt7981-cudy-tr3000-v1 \
+	mt7981-cudy-ddr3 \
 	mt7986-ram-ddr3 \
 	mt7986-emmc-ddr3 \
 	mt7986-nor-ddr3 \

--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -311,7 +311,7 @@ define U-Boot/mt7981_cudy_tr3000-v1
   UBOOT_IMAGE:=u-boot.fip
   BL2_BOOTDEV:=cudy-tr3000-v1
   BL2_SOC:=mt7981
-  DEPENDS:=+trusted-firmware-a-mt7981-cudy-tr3000-v1
+  DEPENDS:=+trusted-firmware-a-mt7981-cudy-ddr3
 endef
 
 define U-Boot/mt7981_glinet_gl-mt2500


### PR DESCRIPTION
Since there are many similar devices from Cudy (TR3000 / WR3000E / WR3000P / WR3000S / WR3000H / WBR3000UAX) this will allow to create OpenWrt U-Boot layout for all of them using same DDR3 target.

Tested-by: 4pda users
Signed-off-by: Fil Dunsky <filipp.dunsky@gmail.com>