### PR TITLE
libnl: fix when building with LTO

### DIFF
--- a/package/libs/libnl/Makefile
+++ b/package/libs/libnl/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libnl
 PKG_VERSION:=3.12.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/thom311/libnl/releases/download/libnl$(subst .,_,$(PKG_VERSION))
@@ -93,6 +93,7 @@ define Package/libnl/description
 endef
 
 TARGET_CFLAGS += $(FPIC)
+TARGET_LDFLAGS += $(FPIC)
 
 CONFIGURE_ARGS += \
 	--disable-debug


### PR DESCRIPTION
When I built with the following, my build ended in relink errors. Adding $(FPIC) to LDFLAGS fixes it.

```
CONFIG_USE_GLIBC=y
CONFIG_USE_LTO=y
CONFIG_USE_MOLD=y
```
Note that I am building against 6.18.2 currently, I do not know if this is related.