### PR TITLE
treewide: replace remove_new with remove

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -681,7 +681,7 @@ static void gpio_keys_remove(struct platform_device *pdev)
 
 static struct platform_driver gpio_keys_driver = {
 	.probe	= gpio_keys_probe,
-	.remove_new = gpio_keys_remove,
+	.remove = gpio_keys_remove,
 	.driver	= {
 		.name	= "gpio-keys",
 		.of_match_table = of_match_ptr(gpio_keys_of_match),
@@ -690,7 +690,7 @@ static struct platform_driver gpio_keys_driver = {
 
 static struct platform_driver gpio_keys_polled_driver = {
 	.probe	= gpio_keys_polled_probe,
-	.remove_new = gpio_keys_remove,
+	.remove = gpio_keys_remove,
 	.driver	= {
 		.name	= "gpio-keys-polled",
 		.of_match_table = of_match_ptr(gpio_keys_polled_of_match),

--- a/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
+++ b/package/kernel/lantiq/ltq-adsl-mei/src/drv_mei_cpe.c
@@ -2808,8 +2808,8 @@ static const struct of_device_id ltq_mei_match[] = {
 };
 
 static struct platform_driver ltq_mei_driver = {
-	.probe = ltq_mei_probe,
-	.remove_new = ltq_mei_remove,
+	.probe  = ltq_mei_probe,
+	.remove = ltq_mei_remove,
 	.driver = {
 		.name = "lantiq,mei-xway",
 		.of_match_table = ltq_mei_match,

--- a/package/kernel/lantiq/ltq-adsl/patches/120-platform.patch
+++ b/package/kernel/lantiq/ltq-adsl/patches/120-platform.patch
@@ -55,8 +55,8 @@
 +MODULE_DEVICE_TABLE(of, ltq_adsl_match);
 +
 +static struct platform_driver ltq_adsl_driver = {
-+	.probe = ltq_adsl_probe,
-+	.remove_new = ltq_adsl_remove,
++	.probe  = ltq_adsl_probe,
++	.remove = ltq_adsl_remove,
 +	.driver = {
 +		.name = "adsl",
 +		.of_match_table = ltq_adsl_match,

--- a/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
+++ b/package/kernel/lantiq/ltq-atm/src/ltq_atm.c
@@ -1884,8 +1884,8 @@ static void ltq_atm_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver ltq_atm_driver = {
-	.probe = ltq_atm_probe,
-	.remove_new = ltq_atm_remove,
+	.probe  = ltq_atm_probe,
+	.remove = ltq_atm_remove,
 	.driver = {
 		.name = "atm",
 		.of_match_table = ltq_atm_match,

--- a/package/kernel/lantiq/ltq-deu/src/ifxmips_deu.c
+++ b/package/kernel/lantiq/ltq-deu/src/ifxmips_deu.c
@@ -190,8 +190,8 @@ MODULE_DEVICE_TABLE(of, ltq_deu_match);
 
 
 static struct platform_driver ltq_deu_driver = {
-	.probe = ltq_deu_probe,
-	.remove_new = ltq_deu_remove,
+	.probe  = ltq_deu_probe,
+	.remove = ltq_deu_remove,
 	.driver = {
 		.name = "deu",
 		.of_match_table = ltq_deu_match,

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
@@ -499,7 +499,7 @@ static int ptm_ioctl(struct net_device *dev, struct ifreq *ifr, void __user *dat
     case IFX_PTM_MIB_FRAME_GET:
         {
             PTM_FRAME_MIB_T tmp = {0};
-    
+
             tmp.RxCorrect   = WAN_MIB_TABLE[ndev].wrx_correct_pdu;
             tmp.TC_CrcError = WAN_MIB_TABLE[ndev].wrx_tccrc_err_pdu;
             tmp.RxDropped   = WAN_MIB_TABLE[ndev].wrx_nodesc_drop_pdu + WAN_MIB_TABLE[ndev].wrx_len_violation_drop_pdu;
@@ -1632,8 +1632,8 @@ static void ltq_ptm_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver ltq_ptm_driver = {
-       .probe = ltq_ptm_probe,
-       .remove_new = ltq_ptm_remove,
+       .probe  = ltq_ptm_probe,
+       .remove = ltq_ptm_remove,
        .driver = {
                .name = "ptm",
                .of_match_table = ltq_ptm_match,

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
@@ -1166,8 +1166,8 @@ static int __init queue_gamma_map_setup(char *line)
 }
 #endif
 static struct platform_driver ltq_ptm_driver = {
-	.probe = ltq_ptm_probe,
-	.remove_new = ltq_ptm_remove,
+	.probe  = ltq_ptm_probe,
+	.remove = ltq_ptm_remove,
 	.driver = {
 		.name = "ptm",
 		.of_match_table = ltq_ptm_match,

--- a/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/133-convert-platform-driver-.remove-to-.remove_new.patch
+++ b/package/kernel/lantiq/ltq-vdsl-vr11-mei/patches/133-convert-platform-driver-.remove-to-.remove_new.patch
@@ -32,12 +32,3 @@ Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
  }
  
  static const struct of_device_id ltq_dsl_cpe_mei_match[] = {
-@@ -2267,7 +2266,7 @@ static struct platform_driver ltq_dsl_cp
-       .owner          = THIS_MODULE,
-       .of_match_table = ltq_dsl_cpe_mei_match,
-    },
--   .remove = ltq_dsl_cpe_mei_remove,
-+   .remove_new = ltq_dsl_cpe_mei_remove,
- };
- 
- static int ltq_dsl_cpe_mei_reboot_notifier(struct notifier_block *nb,

--- a/package/kernel/lantiq/ltq-vdsl-vr9-mei/patches/405-convert-platform-driver-.remove-to-.remove_new.patch
+++ b/package/kernel/lantiq/ltq-vdsl-vr9-mei/patches/405-convert-platform-driver-.remove-to-.remove_new.patch
@@ -30,12 +30,3 @@ Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
  }
  
  static const struct of_device_id ltq_dsl_cpe_mei_match[] = {
-@@ -2070,7 +2069,7 @@ static struct platform_driver ltq_dsl_cp
-       .owner          = THIS_MODULE,
-       .of_match_table = ltq_dsl_cpe_mei_match,
-    },
--   .remove = __exit_p(ltq_dsl_cpe_mei_remove),
-+   .remove_new = __exit_p(ltq_dsl_cpe_mei_remove),
- };
- 
- static int __init ltq_dsl_cpe_mei_probe(struct platform_device *pdev)

--- a/package/kernel/ubootenv-nvram/src/ubootenv-nvram.c
+++ b/package/kernel/ubootenv-nvram/src/ubootenv-nvram.c
@@ -141,8 +141,8 @@ static void ubootenv_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver ubootenv_driver = {
-	.probe = ubootenv_probe,
-	.remove_new = ubootenv_remove,
+	.probe  = ubootenv_probe,
+	.remove = ubootenv_remove,
 	.driver = {
 		.name           = NAME,
 		.of_match_table = of_ubootenv_match,

--- a/target/linux/ath79/files/drivers/mtd/nand/raw/ar934x_nand.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/ar934x_nand.c
@@ -1470,8 +1470,8 @@ static const struct of_device_id ar934x_nfc_match[] = {
 MODULE_DEVICE_TABLE(of, ar934x_nfc_match);
 
 static struct platform_driver ar934x_nfc_driver = {
-	.probe		= ar934x_nfc_probe,
-	.remove_new	= ar934x_nfc_remove,
+	.probe	= ar934x_nfc_probe,
+	.remove	= ar934x_nfc_remove,
 	.driver = {
 		.name	= AR934X_NFC_DRIVER_NAME,
 		.of_match_table = ar934x_nfc_match,

--- a/target/linux/ath79/files/drivers/mtd/nand/raw/nand_rb4xx.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/nand_rb4xx.c
@@ -223,8 +223,8 @@ static void rb4xx_nand_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver rb4xx_nand_driver = {
-	.probe = rb4xx_nand_probe,
-	.remove_new = rb4xx_nand_remove,
+	.probe  = rb4xx_nand_probe,
+	.remove = rb4xx_nand_remove,
 	.driver = {
 		.name = "rb4xx-nand",
 	},

--- a/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
+++ b/target/linux/ath79/files/drivers/mtd/nand/raw/rb91x_nand.c
@@ -351,7 +351,7 @@ MODULE_DEVICE_TABLE(of, rb91x_nand_match);
 
 static struct platform_driver rb91x_nand_driver = {
 	.probe	= rb91x_nand_probe,
-	.remove_new	= rb91x_nand_remove,
+	.remove	= rb91x_nand_remove,
 	.driver	= {
 		.name	= "rb91x-nand",
 		.of_match_table = rb91x_nand_match,

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_legacy_mdio.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_legacy_mdio.c
@@ -237,8 +237,8 @@ static const struct of_device_id ag71xx_mdio_match[] = {
 };
 
 static struct platform_driver ag71xx_mdio_driver = {
-	.probe		= ag71xx_mdio_probe,
-	.remove_new	= ag71xx_mdio_remove,
+	.probe	= ag71xx_mdio_probe,
+	.remove	= ag71xx_mdio_remove,
 	.driver = {
 		.name	 = "ag71xx-legacy-mdio",
 		.of_match_table = ag71xx_mdio_match,

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -1762,8 +1762,8 @@ static const struct of_device_id ag71xx_match[] = {
 };
 
 static struct platform_driver ag71xx_driver = {
-	.probe		= ag71xx_probe,
-	.remove_new	= ag71xx_remove,
+	.probe	= ag71xx_probe,
+	.remove	= ag71xx_remove,
 	.driver = {
 		.name	= AG71XX_DRV_NAME,
 		.of_match_table = ag71xx_match,

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6348-enet.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6348-enet.c
@@ -1704,7 +1704,7 @@ static struct platform_driver bcm6348_emac_driver = {
 		.of_match_table = bcm6348_emac_of_match,
 	},
 	.probe	= bcm6348_emac_probe,
-	.remove_new	= bcm6348_emac_remove,
+	.remove	= bcm6348_emac_remove,
 };
 
 int bcm6348_iudma_drivers_register(struct platform_device *pdev)

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6368-enetsw.c
@@ -1136,7 +1136,7 @@ static struct platform_driver bcm6368_enetsw_driver = {
 		.of_match_table = bcm6368_enetsw_of_match,
 	},
 	.probe	= bcm6368_enetsw_probe,
-	.remove_new	= bcm6368_enetsw_remove,
+	.remove	= bcm6368_enetsw_remove,
 };
 module_platform_driver(bcm6368_enetsw_driver);
 

--- a/target/linux/generic/files/drivers/net/phy/adm6996.c
+++ b/target/linux/generic/files/drivers/net/phy/adm6996.c
@@ -1208,8 +1208,8 @@ static void adm6996_gpio_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver adm6996_gpio_driver = {
-	.probe = adm6996_gpio_probe,
-	.remove_new = adm6996_gpio_remove,
+	.probe  = adm6996_gpio_probe,
+	.remove = adm6996_gpio_remove,
 	.driver = {
 		.name = "adm6996_gpio",
 	},

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_mmap.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_mmap.c
@@ -226,8 +226,8 @@ static void b53_mmap_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver b53_mmap_driver = {
-	.probe = b53_mmap_probe,
-	.remove_new = b53_mmap_remove,
+	.probe  = b53_mmap_probe,
+	.remove = b53_mmap_remove,
 	.driver = {
 		.name = "b53-switch",
 	},

--- a/target/linux/generic/files/drivers/net/phy/b53/b53_srab.c
+++ b/target/linux/generic/files/drivers/net/phy/b53/b53_srab.c
@@ -363,8 +363,8 @@ static void b53_srab_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver b53_srab_driver = {
-	.probe = b53_srab_probe,
-	.remove_new = b53_srab_remove,
+	.probe  = b53_srab_probe,
+	.remove = b53_srab_remove,
 	.driver = {
 		.name = "b53-srab-switch",
 	},

--- a/target/linux/generic/files/drivers/net/phy/rtl8366rb.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366rb.c
@@ -1498,7 +1498,7 @@ static struct platform_driver rtl8366rb_driver = {
 		.of_match_table = rtl8366rb_match,
 	},
 	.probe		= rtl8366rb_probe,
-	.remove_new		= rtl8366rb_remove,
+	.remove		= rtl8366rb_remove,
 };
 
 static int __init rtl8366rb_module_init(void)

--- a/target/linux/generic/files/drivers/net/phy/rtl8366s.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8366s.c
@@ -1274,8 +1274,8 @@ static struct platform_driver rtl8366s_driver = {
 		.name		= RTL8366S_DRIVER_NAME,
 		.of_match_table = rtl8366s_match,
 	},
-	.probe		= rtl8366s_probe,
-	.remove_new	= rtl8366s_remove,
+	.probe	= rtl8366s_probe,
+	.remove	= rtl8366s_remove,
 };
 
 static int __init rtl8366s_module_init(void)

--- a/target/linux/generic/files/drivers/net/phy/rtl8367.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367.c
@@ -1811,9 +1811,9 @@ static struct platform_driver rtl8367_driver = {
 		.name		= RTL8367_DRIVER_NAME,
 		.of_match_table = rtl8367_match,
 	},
-	.probe		= rtl8367_probe,
-	.remove_new	= rtl8367_remove,
-	.shutdown	= rtl8367_shutdown,
+	.probe	  = rtl8367_probe,
+	.remove	  = rtl8367_remove,
+	.shutdown = rtl8367_shutdown,
 };
 
 static int __init rtl8367_module_init(void)

--- a/target/linux/generic/files/drivers/net/phy/rtl8367b.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8367b.c
@@ -1609,9 +1609,9 @@ static struct platform_driver rtl8367b_driver = {
 		.name		= RTL8367B_DRIVER_NAME,
 		.of_match_table = rtl8367b_match,
 	},
-	.probe		= rtl8367b_probe,
-	.remove_new	= rtl8367b_remove,
-	.shutdown	= rtl8367b_shutdown,
+	.probe	  = rtl8367b_probe,
+	.remove	  = rtl8367b_remove,
+	.shutdown = rtl8367b_shutdown,
 };
 
 module_platform_driver(rtl8367b_driver);

--- a/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s_mdio.c
+++ b/target/linux/mediatek/files/drivers/net/phy/rtk/rtl8367s_mdio.c
@@ -281,8 +281,8 @@ static void rtk_gsw_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver gsw_driver = {
-	.probe = rtk_gsw_probe,
-	.remove_new = rtk_gsw_remove,
+	.probe  = rtk_gsw_probe,
+	.remove = rtk_gsw_remove,
 	.driver = {
 		.name = "rtk-gsw",
 		.of_match_table = rtk_gsw_match,

--- a/target/linux/ramips/files/drivers/dma/mediatek/hsdma-mt7621.c
+++ b/target/linux/ramips/files/drivers/dma/mediatek/hsdma-mt7621.c
@@ -744,8 +744,8 @@ static void mtk_hsdma_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver mtk_hsdma_driver = {
-	.probe = mtk_hsdma_probe,
-	.remove_new = mtk_hsdma_remove,
+	.probe  = mtk_hsdma_probe,
+	.remove = mtk_hsdma_remove,
 	.driver = {
 		.name = KBUILD_MODNAME,
 		.of_match_table = mtk_hsdma_of_match,

--- a/target/linux/ramips/files/drivers/dma/ralink-gdma.c
+++ b/target/linux/ramips/files/drivers/dma/ralink-gdma.c
@@ -900,8 +900,8 @@ static void gdma_dma_remove(struct platform_device *pdev)
 }
 
 static struct platform_driver gdma_dma_driver = {
-	.probe = gdma_dma_probe,
-	.remove_new = gdma_dma_remove,
+	.probe  = gdma_dma_probe,
+	.remove = gdma_dma_remove,
 	.driver = {
 		.name = "gdma-rt2880",
 		.of_match_table = gdma_of_match_table,

--- a/target/linux/ramips/files/drivers/mmc/host/mtk-mmc/sd.c
+++ b/target/linux/ramips/files/drivers/mmc/host/mtk-mmc/sd.c
@@ -2410,7 +2410,7 @@ MODULE_DEVICE_TABLE(of, mt7620_sdhci_match);
 
 static struct platform_driver mt_msdc_driver = {
 	.probe   = msdc_drv_probe,
-	.remove_new  = msdc_drv_remove,
+	.remove  = msdc_drv_remove,
 #ifdef CONFIG_PM
 	.suspend = msdc_drv_suspend,
 	.resume  = msdc_drv_resume,

--- a/target/linux/ramips/files/drivers/mtd/nand/raw/mt7621_nand.c
+++ b/target/linux/ramips/files/drivers/mtd/nand/raw/mt7621_nand.c
@@ -1330,8 +1330,8 @@ static const struct of_device_id mt7621_nfc_id_table[] = {
 MODULE_DEVICE_TABLE(of, match);
 
 static struct platform_driver mt7621_nfc_driver = {
-	.probe = mt7621_nfc_probe,
-	.remove_new = mt7621_nfc_remove,
+	.probe  = mt7621_nfc_probe,
+	.remove = mt7621_nfc_remove,
 	.driver = {
 		.name = MT7621_NFC_NAME,
 		.of_match_table = mt7621_nfc_id_table,


### PR DESCRIPTION
Preparation for kernel 6.18. It removes the former.

ping @namiltd @graysky2