### PR TITLE
package-metadata.pl: provides/depends fixes

### DIFF
--- a/scripts/package-metadata.pl
+++ b/scripts/package-metadata.pl
@@ -205,7 +205,15 @@ sub mconf_depends {
 			# thus if FOO depends on other config options, these dependencies
 			# will not be checked. To fix this, we simply emit all of FOO's
 			# depends here as well.
-			$package{$depend} and push @t_depends, [ $package{$depend}->{depends}, $condition ];
+			#
+			# When there are multiple variants, don't propagate the variant
+			# selection condition to the transitive dependencies - that
+			# creates circular deps
+			if ($vdep && @{$vdep} > 1) {
+				$package{$depend} and push @t_depends, [ $package{$depend}->{depends}, $parent_condition ];
+			} else {
+				$package{$depend} and push @t_depends, [ $package{$depend}->{depends}, $condition ];
+			}
 
 			$m = "select";
 			next if $only_dep;

--- a/scripts/package-metadata.pl
+++ b/scripts/package-metadata.pl
@@ -545,6 +545,7 @@ sub gen_package_auxiliary() {
 		my @depends = sort keys %depends;
 		if (@depends > 0) {
 			foreach my $n (@{$pkg->{provides}}) {
+				next if $package{$n} && $package{$n}->{name} eq $n && $package{$n} != $pkg;
 				print "Package/$n/depends = @depends\n";
 			}
 		}


### PR DESCRIPTION
Two small fixes to `scripts/package-metadata.pl` to improve the handling of transitive dependencies and for packages which `PROVIDE` something which is also covered by a real package (see the individual commit messages).