### PR TITLE
mac80211: initial support for linux 6.18

### DIFF
--- a/package/kernel/mac80211/patches/ath9k/548-ath9k_enable_gpio_chip.patch
+++ b/package/kernel/mac80211/patches/ath9k/548-ath9k_enable_gpio_chip.patch
@@ -32,7 +32,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #ifdef CPTCFG_ATH9K_DEBUGFS
 --- a/drivers/net/wireless/ath/ath9k/gpio.c
 +++ b/drivers/net/wireless/ath/ath9k/gpio.c
-@@ -16,12 +16,120 @@
+@@ -16,12 +16,129 @@
  
  #include "ath9k.h"
  
@@ -85,12 +85,21 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +}
 +
 +/* gpio_chip handler : set GPIO pin to value */
++#if LINUX_VERSION_IS_LESS(6,16,0)
 +static void ath9k_gpio_pin_set(struct gpio_chip *chip, unsigned offset,
 +			       int value)
++#else
++static int ath9k_gpio_pin_set(struct gpio_chip *chip, unsigned offset,
++			       int value)
++#endif
 +{
 +	struct ath_softc *sc = gpiochip_get_data(chip);
 +
 +	ath9k_hw_set_gpio(sc->sc_ah, offset, value);
++
++#if LINUX_VERSION_IS_GEQ(6,16,0)
++	return 0;
++#endif
 +}
 +
 +/* register GPIO chip */
@@ -155,7 +164,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static void ath_fill_led_pin(struct ath_softc *sc)
  {
  	struct ath_hw *ah = sc->sc_ah;
-@@ -79,6 +187,12 @@ static int ath_add_led(struct ath_softc
+@@ -79,6 +196,12 @@ static int ath_add_led(struct ath_softc
  	else
  		ath9k_hw_set_gpio(sc->sc_ah, gpio->gpio, gpio->active_low);
  
@@ -168,7 +177,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	return 0;
  }
  
-@@ -117,16 +231,23 @@ void ath_deinit_leds(struct ath_softc *s
+@@ -117,16 +240,23 @@ void ath_deinit_leds(struct ath_softc *s
  
  	while (!list_empty(&sc->leds)) {
  		led = list_first_entry(&sc->leds, struct ath_led, list);
@@ -192,7 +201,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	char led_name[32];
  	const char *trigger;
  
-@@ -135,6 +256,15 @@ void ath_init_leds(struct ath_softc *sc)
+@@ -135,6 +265,15 @@ void ath_init_leds(struct ath_softc *sc)
  	if (AR_SREV_9100(sc->sc_ah))
  		return;
  

--- a/package/kernel/mac80211/patches/build/400-restore-old-debugfs_fops.patch
+++ b/package/kernel/mac80211/patches/build/400-restore-old-debugfs_fops.patch
@@ -1,64 +1,81 @@
 --- a/drivers/net/wireless/ath/carl9170/debug.c
 +++ b/drivers/net/wireless/ath/carl9170/debug.c
-@@ -54,6 +54,7 @@ struct carl9170_debugfs_fops {
+@@ -54,6 +54,9 @@ struct carl9170_debugfs_fops {
  	char *(*read)(struct ar9170 *ar, char *buf, size_t bufsize,
  		      ssize_t *len);
  	ssize_t (*write)(struct ar9170 *aru, const char *buf, size_t size);
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	const struct file_operations fops;
++#endif
  
  	enum carl9170_device_state req_dev_state;
  };
-@@ -61,7 +62,7 @@ struct carl9170_debugfs_fops {
+@@ -61,7 +64,11 @@ struct carl9170_debugfs_fops {
  static ssize_t carl9170_debugfs_read(struct file *file, char __user *userbuf,
  				     size_t count, loff_t *ppos)
  {
--	const struct carl9170_debugfs_fops *dfops;
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	struct carl9170_debugfs_fops *dfops;
++#else
+ 	const struct carl9170_debugfs_fops *dfops;
++#endif
  	struct ar9170 *ar;
  	char *buf = NULL, *res_buf = NULL;
  	ssize_t ret = 0;
-@@ -74,7 +75,8 @@ static ssize_t carl9170_debugfs_read(str
+@@ -74,7 +81,12 @@ static ssize_t carl9170_debugfs_read(str
  
  	if (!ar)
  		return -ENODEV;
--	dfops = debugfs_get_aux(file);
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	dfops = container_of(debugfs_real_fops(file),
 +			     struct carl9170_debugfs_fops, fops);
++#else
+ 	dfops = debugfs_get_aux(file);
++#endif
  
  	if (!dfops->read)
  		return -ENOSYS;
-@@ -111,7 +113,7 @@ out_free:
+@@ -111,7 +123,11 @@ out_free:
  static ssize_t carl9170_debugfs_write(struct file *file,
  	const char __user *userbuf, size_t count, loff_t *ppos)
  {
--	const struct carl9170_debugfs_fops *dfops;
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	struct carl9170_debugfs_fops *dfops;
++#else
+ 	const struct carl9170_debugfs_fops *dfops;
++#endif
  	struct ar9170 *ar;
  	char *buf = NULL;
  	int err = 0;
-@@ -126,7 +128,8 @@ static ssize_t carl9170_debugfs_write(st
+@@ -126,7 +142,12 @@ static ssize_t carl9170_debugfs_write(st
  
  	if (!ar)
  		return -ENODEV;
--	dfops = debugfs_get_aux(file);
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	dfops = container_of(debugfs_real_fops(file),
 +			     struct carl9170_debugfs_fops, fops);
++#else
+ 	dfops = debugfs_get_aux(file);
++#endif
  
  	if (!dfops->write)
  		return -ENOSYS;
-@@ -162,11 +165,6 @@ out_free:
+@@ -162,11 +183,14 @@ out_free:
  	return err;
  }
  
--static struct debugfs_short_fops debugfs_fops = {
--	.read	= carl9170_debugfs_read,
--	.write	= carl9170_debugfs_write,
--};
--
++#if LINUX_VERSION_IS_GEQ(6,14,0)
+ static struct debugfs_short_fops debugfs_fops = {
+ 	.read	= carl9170_debugfs_read,
+ 	.write	= carl9170_debugfs_write,
+ };
++#endif
+ 
++#if LINUX_VERSION_IS_LESS(6,14,0)
  #define __DEBUGFS_DECLARE_FILE(name, _read, _write, _read_bufsize,	\
  			       _attr, _dstate)				\
  static const struct carl9170_debugfs_fops carl_debugfs_##name ##_ops = {\
-@@ -175,6 +173,12 @@ static const struct carl9170_debugfs_fop
+@@ -175,7 +199,24 @@ static const struct carl9170_debugfs_fop
  	.write = _write,						\
  	.attr = _attr,							\
  	.req_dev_state = _dstate,					\
@@ -69,79 +86,113 @@
 +		.owner	= THIS_MODULE					\
 +	},								\
  }
++#else
++#define __DEBUGFS_DECLARE_FILE(name, _read, _write, _read_bufsize,	\
++			       _attr, _dstate)				\
++static const struct carl9170_debugfs_fops carl_debugfs_##name ##_ops = {\
++	.read_bufsize = _read_bufsize,					\
++	.read = _read,							\
++	.write = _write,						\
++	.attr = _attr,							\
++	.req_dev_state = _dstate,					\
++}
++#endif
  
  #define DEBUGFS_DECLARE_FILE(name, _read, _write, _read_bufsize, _attr)	\
-@@ -812,9 +816,9 @@ void carl9170_debugfs_register(struct ar
+ 	__DEBUGFS_DECLARE_FILE(name, _read, _write, _read_bufsize,	\
+@@ -811,10 +852,17 @@ void carl9170_debugfs_register(struct ar
+ 	ar->debug_dir = debugfs_create_dir(KBUILD_MODNAME,
  		ar->hw->wiphy->debugfsdir);
  
- #define DEBUGFS_ADD(name)						\
--	debugfs_create_file_aux(#name, carl_debugfs_##name ##_ops.attr,	\
--			    ar->debug_dir, ar, &carl_debugfs_##name ## _ops, \
--			    &debugfs_fops)
++#if LINUX_VERSION_IS_LESS(6,14,0)
++#define DEBUGFS_ADD(name)						\
 +	debugfs_create_file(#name, carl_debugfs_##name ##_ops.attr,	\
 +			    ar->debug_dir, ar,				\
 +			    &carl_debugfs_##name ## _ops.fops)
++#else
+ #define DEBUGFS_ADD(name)						\
+ 	debugfs_create_file_aux(#name, carl_debugfs_##name ##_ops.attr,	\
+ 			    ar->debug_dir, ar, &carl_debugfs_##name ## _ops, \
+ 			    &debugfs_fops)
++#endif
  
  	DEBUGFS_ADD(usb_tx_anch_urbs);
  	DEBUGFS_ADD(usb_rx_pool_urbs);
 --- a/drivers/net/wireless/broadcom/b43/debugfs.c
 +++ b/drivers/net/wireless/broadcom/b43/debugfs.c
-@@ -30,6 +30,7 @@ static struct dentry *rootdir;
+@@ -30,6 +30,9 @@ static struct dentry *rootdir;
  struct b43_debugfs_fops {
  	ssize_t (*read)(struct b43_wldev *dev, char *buf, size_t bufsize);
  	int (*write)(struct b43_wldev *dev, const char *buf, size_t count);
++#if LINUX_VERSION_IS_GEQ(6,14,0)
 +	struct file_operations fops;
++#endif
  	/* Offset of struct b43_dfs_file in struct b43_dfsentry */
  	size_t file_struct_offset;
  };
-@@ -490,7 +491,7 @@ static ssize_t b43_debugfs_read(struct f
+@@ -490,7 +493,11 @@ static ssize_t b43_debugfs_read(struct f
  				size_t count, loff_t *ppos)
  {
  	struct b43_wldev *dev;
--	const struct b43_debugfs_fops *dfops;
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	struct b43_debugfs_fops *dfops;
++#else
+ 	const struct b43_debugfs_fops *dfops;
++#endif
  	struct b43_dfs_file *dfile;
  	ssize_t ret;
  	char *buf;
-@@ -510,7 +511,8 @@ static ssize_t b43_debugfs_read(struct f
+@@ -510,7 +517,12 @@ static ssize_t b43_debugfs_read(struct f
  		goto out_unlock;
  	}
  
--	dfops = debugfs_get_aux(file);
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	dfops = container_of(debugfs_real_fops(file),
 +			     struct b43_debugfs_fops, fops);
++#else
+ 	dfops = debugfs_get_aux(file);
++#endif
  	if (!dfops->read) {
  		err = -ENOSYS;
  		goto out_unlock;
-@@ -553,7 +555,7 @@ static ssize_t b43_debugfs_write(struct
+@@ -553,7 +565,11 @@ static ssize_t b43_debugfs_write(struct
  				 size_t count, loff_t *ppos)
  {
  	struct b43_wldev *dev;
--	const struct b43_debugfs_fops *dfops;
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	struct b43_debugfs_fops *dfops;
++#else
+ 	const struct b43_debugfs_fops *dfops;
++#endif
  	char *buf;
  	int err = 0;
  
-@@ -571,7 +573,8 @@ static ssize_t b43_debugfs_write(struct
+@@ -571,7 +587,12 @@ static ssize_t b43_debugfs_write(struct
  		goto out_unlock;
  	}
  
--	dfops = debugfs_get_aux(file);
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	dfops = container_of(debugfs_real_fops(file),
 +			     struct b43_debugfs_fops, fops);
++#else
+ 	dfops = debugfs_get_aux(file);
++#endif
  	if (!dfops->write) {
  		err = -ENOSYS;
  		goto out_unlock;
-@@ -599,16 +602,16 @@ out_unlock:
+@@ -599,19 +620,37 @@ out_unlock:
  }
  
  
--static struct debugfs_short_fops debugfs_ops = {
--	.read	= b43_debugfs_read,
--	.write	= b43_debugfs_write,
--	.llseek = generic_file_llseek,
--};
--
++#if LINUX_VERSION_IS_GEQ(6,14,0)
+ static struct debugfs_short_fops debugfs_ops = {
+ 	.read	= b43_debugfs_read,
+ 	.write	= b43_debugfs_write,
+ 	.llseek = generic_file_llseek,
+ };
++#endif
+ 
++#if LINUX_VERSION_IS_LESS(6,14,0)
  #define B43_DEBUGFS_FOPS(name, _read, _write)			\
  	static struct b43_debugfs_fops fops_##name = {		\
  		.read	= _read,				\
@@ -155,76 +206,115 @@
  		.file_struct_offset = offsetof(struct b43_dfsentry, \
  					       file_##name),	\
  	}
-@@ -700,9 +703,9 @@ void b43_debugfs_add_device(struct b43_w
++#else
++#define B43_DEBUGFS_FOPS(name, _read, _write)			\
++	static struct b43_debugfs_fops fops_##name = {		\
++		.read	= _read,				\
++		.write	= _write,				\
++		.file_struct_offset = offsetof(struct b43_dfsentry, \
++					       file_##name),	\
++	}
++#endif
  
+ B43_DEBUGFS_FOPS(shm16read, shm16read__read_file, shm16read__write_file);
+ B43_DEBUGFS_FOPS(shm16write, NULL, shm16write__write_file);
+@@ -698,12 +737,21 @@ void b43_debugfs_add_device(struct b43_w
+ 	e->shm32read_routing_next = 0xFFFFFFFF; /* invalid routing */
+ 	e->shm32read_addr_next = 0xFFFFFFFF; /* invalid address */
+ 
++#if LINUX_VERSION_IS_LESS(6,14,0)
++#define ADD_FILE(name, mode)	\
++	do {							\
++		debugfs_create_file(__stringify(name),		\
++				mode, e->subdir, dev,		\
++				&fops_##name.fops);		\
++	} while (0)
++#else
  #define ADD_FILE(name, mode)	\
  	do {							\
--		debugfs_create_file_aux(__stringify(name),	\
-+		debugfs_create_file(__stringify(name),		\
+ 		debugfs_create_file_aux(__stringify(name),	\
  				mode, e->subdir, dev,		\
--				&fops_##name, &debugfs_ops);	\
-+				&fops_##name.fops);		\
+ 				&fops_##name, &debugfs_ops);	\
  	} while (0)
++#endif
  
  
+ 	ADD_FILE(shm16read, 0600);
 --- a/drivers/net/wireless/broadcom/b43legacy/debugfs.c
 +++ b/drivers/net/wireless/broadcom/b43legacy/debugfs.c
-@@ -31,6 +31,7 @@ static struct dentry *rootdir;
+@@ -31,6 +31,9 @@ static struct dentry *rootdir;
  struct b43legacy_debugfs_fops {
  	ssize_t (*read)(struct b43legacy_wldev *dev, char *buf, size_t bufsize);
  	int (*write)(struct b43legacy_wldev *dev, const char *buf, size_t count);
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	struct file_operations fops;
++#endif
  	/* Offset of struct b43legacy_dfs_file in struct b43legacy_dfsentry */
  	size_t file_struct_offset;
  	/* Take wl->irq_lock before calling read/write? */
-@@ -187,7 +188,7 @@ static ssize_t b43legacy_debugfs_read(st
+@@ -187,7 +190,11 @@ static ssize_t b43legacy_debugfs_read(st
  				size_t count, loff_t *ppos)
  {
  	struct b43legacy_wldev *dev;
--	const struct b43legacy_debugfs_fops *dfops;
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	struct b43legacy_debugfs_fops *dfops;
++#else
+ 	const struct b43legacy_debugfs_fops *dfops;
++#endif
  	struct b43legacy_dfs_file *dfile;
  	ssize_t ret;
  	char *buf;
-@@ -207,7 +208,8 @@ static ssize_t b43legacy_debugfs_read(st
+@@ -207,7 +214,12 @@ static ssize_t b43legacy_debugfs_read(st
  		goto out_unlock;
  	}
  
--	dfops = debugfs_get_aux(file);
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	dfops = container_of(debugfs_real_fops(file),
 +			     struct b43legacy_debugfs_fops, fops);
++#else
+ 	dfops = debugfs_get_aux(file);
++#endif
  	if (!dfops->read) {
  		err = -ENOSYS;
  		goto out_unlock;
-@@ -255,7 +257,7 @@ static ssize_t b43legacy_debugfs_write(s
+@@ -255,7 +267,11 @@ static ssize_t b43legacy_debugfs_write(s
  				 size_t count, loff_t *ppos)
  {
  	struct b43legacy_wldev *dev;
--	const struct b43legacy_debugfs_fops *dfops;
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	struct b43legacy_debugfs_fops *dfops;
++#else
+ 	const struct b43legacy_debugfs_fops *dfops;
++#endif
  	char *buf;
  	int err = 0;
  
-@@ -273,7 +275,8 @@ static ssize_t b43legacy_debugfs_write(s
+@@ -273,7 +289,12 @@ static ssize_t b43legacy_debugfs_write(s
  		goto out_unlock;
  	}
  
--	dfops = debugfs_get_aux(file);
++#if LINUX_VERSION_IS_LESS(6,14,0)
 +	dfops = container_of(debugfs_real_fops(file),
 +			     struct b43legacy_debugfs_fops, fops);
++#else
+ 	dfops = debugfs_get_aux(file);
++#endif
  	if (!dfops->write) {
  		err = -ENOSYS;
  		goto out_unlock;
-@@ -305,16 +308,17 @@ out_unlock:
+@@ -305,20 +326,39 @@ out_unlock:
  	return err ? err : count;
  }
  
--static struct debugfs_short_fops debugfs_ops = {
--	.read	= b43legacy_debugfs_read,
--	.write	= b43legacy_debugfs_write,
--	.llseek = generic_file_llseek
--};
++#if LINUX_VERSION_IS_GEQ(6,14,0)
+ static struct debugfs_short_fops debugfs_ops = {
+ 	.read	= b43legacy_debugfs_read,
+ 	.write	= b43legacy_debugfs_write,
+ 	.llseek = generic_file_llseek
+ };
++#endif
  
++#if LINUX_VERSION_IS_LESS(6,14,0)
  #define B43legacy_DEBUGFS_FOPS(name, _read, _write, _take_irqlock)	\
  	static struct b43legacy_debugfs_fops fops_##name = {		\
  		.read	= _read,				\
@@ -238,15 +328,39 @@
  		.file_struct_offset = offsetof(struct b43legacy_dfsentry, \
  					       file_##name),	\
  		.take_irqlock	= _take_irqlock,		\
-@@ -382,9 +386,9 @@ void b43legacy_debugfs_add_device(struct
+ 	}
++#else
++#define B43legacy_DEBUGFS_FOPS(name, _read, _write, _take_irqlock)	\
++	static struct b43legacy_debugfs_fops fops_##name = {		\
++		.read	= _read,				\
++		.write	= _write,				\
++		.file_struct_offset = offsetof(struct b43legacy_dfsentry, \
++					       file_##name),	\
++		.take_irqlock	= _take_irqlock,		\
++	}
++#endif
  
+ B43legacy_DEBUGFS_FOPS(tsf, tsf_read_file, tsf_write_file, 1);
+ B43legacy_DEBUGFS_FOPS(ucode_regs, ucode_regs_read_file, NULL, 1);
+@@ -380,12 +420,21 @@ void b43legacy_debugfs_add_device(struct
+ 	snprintf(devdir, sizeof(devdir), "%s", wiphy_name(dev->wl->hw->wiphy));
+ 	e->subdir = debugfs_create_dir(devdir, rootdir);
+ 
++#if LINUX_VERSION_IS_LESS(6,14,0)
++#define ADD_FILE(name, mode)	\
++	do {							\
++		debugfs_create_file(__stringify(name), mode,	\
++				    e->subdir, dev,		\
++				    &fops_##name.fops);		\
++	} while (0)
++#else
  #define ADD_FILE(name, mode)	\
  	do {							\
--		debugfs_create_file_aux(__stringify(name), mode,	\
-+		debugfs_create_file(__stringify(name), mode,	\
+ 		debugfs_create_file_aux(__stringify(name), mode,	\
  				    e->subdir, dev,		\
--				    &fops_##name, &debugfs_ops);	\
-+				    &fops_##name.fops);		\
+ 				    &fops_##name, &debugfs_ops);	\
  	} while (0)
++#endif
  
  
+ 	ADD_FILE(tsf, 0600);


### PR DESCRIPTION
mac80211: backports: fix ath9k/ath11k compatibility with Linux 6.18+

Linux 6.18 introduces several API removals and signature changes that break
builds of ath9k and ath11k in the mac80211 backports tree. This patchset
restores compatibility while preserving support for older kernels used by
OpenWrt and other downstreams.