### PR TITLE
netifd: Allow hex input for vendorid and remove additional option 60 packet for DHCP

### DIFF
--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -83,7 +83,7 @@ proto_dhcp_setup() {
 		-f -t 0 -i "$iface" \
 		${ipaddr:+-r ${ipaddr/\/*/}} \
 		${hostname:+-x "hostname:$hostname"} \
-		${vendorid:+-V "$vendorid"} \
+		${vendorid:+-V '' "-x 0x3c:$vendorid"} \
 		$clientid $defaultreqopts $broadcast $norelease $dhcpopts
 }
 


### PR DESCRIPTION
The current implementation of DHCP causes 2 problems when trying to get IP from IPTV upstream.

1. Sometimes option 60 translates to non ASCII characters, so it would be preferable to allow user to input hex codes instead of ASCII.
2. The current implementation would send udhcp version as an additional option 60 packet which causes authentication to fail.

This change omits the additional packet with udhcp version, and uses hex as input as opposed to plain ASCII. 

Closes https://github.com/openwrt/openwrt/issues/21242