### PR TITLE
realtek: rt-loader: allow arbitrary kernel load address

### DIFF
--- a/target/linux/realtek/image/Makefile
+++ b/target/linux/realtek/image/Makefile
@@ -30,6 +30,13 @@ define Build/rt-loader
 	mv "$@.new" "$@"
 endef
 
+define Build/rt-loader-no-uimage
+        $(MAKE) all clean -C rt-loader CROSS_COMPILE="$(TARGET_CROSS)" \
+                KERNEL_ADDR="$(KERNEL_LOADADDR)" KERNEL_IMG_IN="$@" \
+                KERNEL_IMG_OUT="$@.new" BUILD_DIR="$@.build"
+        mv "$@.new" "$@"
+endef
+
 define Build/zyxel-vers
        ( echo VERS;\
        for hw in $(ZYXEL_VERS); do\

--- a/target/linux/realtek/image/rt-loader/Makefile
+++ b/target/linux/realtek/image/rt-loader/Makefile
@@ -7,9 +7,15 @@
 #
 # KERNEL_IMG_IN:	The filename of an LZMA compressed kernel. If given the loader
 #			and the kernel will be concatenated (piggy back loading).
-# FLASH_ADDR:		The kernel address in the ROM. If given, the loeader will be
+# FLASH_ADDR:		The kernel address in the ROM. If given, the loader will be
 #			created standalone and search a LZMA compressed uImage on the
 #			target device starting from this address.
+# KERNEL_ADDR:		The to-be-used kernel load address to which rt-loader will load
+# 			the kernel and execute it. If not given, rt-loader will use its
+# 			initial run address for this (which is the uImage load address
+# 			when using U-boot images) For non-uImage, this uses an arbitrary
+# 			load address which is independent of rt-loader's initial run
+# 			address.
 # KERNEL_IMG_OUT:	The filename of the kernel image with the rt-loader prepended.
 #			If not given it will be created as image.bin into the BUILD_DIR.
 # BUILD_DIR:		The temporary build dir. If not given it will be set to "build".
@@ -26,6 +32,12 @@
 #	    KERNEL_IMG_IN="$@" KERNEL_IMG_OUT="$@.new" BUILD_DIR="$@.build"
 #   mv "$@.new" "$@"
 # endef
+#
+# define Build/rt-loader-non-uImage
+#   $(MAKE) all clean -C rt-loader CROSS_COMPILE="$(TARGET_CROSS)" \
+#           KERNEL_ADDR="$(KERNEL_LOADADDR)" KERNEL_IMG_IN="$@" \
+#           KERNEL_IMG_OUT="$@.new" BUILD_DIR="$@.build"
+#   mv "$@.new" "$@"
 #
 # define Build/rt-loader-standalone
 #   $(MAKE) all clean -C rt-loader CROSS_COMPILE="$(TARGET_CROSS)" \
@@ -48,9 +60,13 @@
 #   KERNEL/rt-loader := rt-loader-standalone
 #   KERNEL := kernel-bin | append-dtb | rt-compress | uImage lzma
 # endef
+#
 
 FLASH_ADDR_NONE	:= 0x0
 FLASH_ADDR	?= $(FLASH_ADDR_NONE)
+
+KERNEL_ADDR_NONE := 0x0
+KERNEL_ADDR 	?= $(KERNEL_ADDR_NONE)
 
 CC		:= $(CROSS_COMPILE)gcc
 LD		:= $(CROSS_COMPILE)ld
@@ -59,6 +75,7 @@ OBJDUMP		:= $(CROSS_COMPILE)objdump
 
 CFLAGS		= -fpic -mabicalls -O2 -fno-builtin-printf -Iinclude
 CFLAGS		+= -DFLASH_ADDR=$(FLASH_ADDR)
+CFLAGS		+= -DKERNEL_ADDR=$(KERNEL_ADDR)
 
 ASFLAGS		= -fpic -msoft-float -Iinclude
 

--- a/target/linux/realtek/image/rt-loader/src/main.c
+++ b/target/linux/realtek/image/rt-loader/src/main.c
@@ -168,6 +168,7 @@ void main(unsigned long reg_a0, unsigned long reg_a1,
 	  unsigned long reg_a2, unsigned long reg_a3)
 {
 	void *flash_start = (void *)FLASH_ADDR; /* from makefile */
+	void *kernel_addr = (void *)KERNEL_ADDR; /* from makefile */
 	entry_func_t fn;
 
 	/*
@@ -188,6 +189,8 @@ void main(unsigned long reg_a0, unsigned long reg_a1,
 	 */
 	if (flash_start)
 		load_kernel(flash_start);
+	else if (kernel_addr)
+		_kernel_load_addr = kernel_addr;
 
 	/*
 	 * Finally extract the attached kernel image to the load address. This is


### PR DESCRIPTION
This allows me to RAM-boot on Zyxel XS1930 devices. Using the default setup where   
```
<kernel load address> == <rt-loader initial run address> == 0x80100000
```
doesn't work because BootExt presumably uses some RAM in that area. Switching to `0x80300000` (based on the memory map) works fine but would require to change the kernel load address. This cannot just be done with changing `KERNEL_LOADADDR` but would require e.g. changing `arch/mips/rtl83xx/Platform` (and probably more).

Log with this change:
```
XS1930-12F> ATUP80300000,5133213
...
OK
XS1930-12F> ATGO80300000
rt-loader
Running on RTL9313 (chip id 6567A) with 256MB
Relocate 5133216 bytes from 0x80300000 to 0x8fac0000
Extract image with 5117505 bytes from 0x8fac3d5c to 0x80100000 ...
Final kernel size is 19602473 bytes
Booting kernel from 0x80100000 ...

<kernel boots>
```

This is probably only needed for RAM-boot/Initramfs image. Loading from flash, which is needed here too for full support, can use the standalone variant of rt-loader.