### PR TITLE
[25.12] treewide: APK provides-related backports

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -191,6 +191,7 @@ endif
     $(STAGING_DIR_ROOT)/stamp/.$(1)_installed: $(PKG_BUILD_DIR)/.pkgdir/$(1).installed
 	mkdir -p $(STAGING_DIR_ROOT)/stamp
 	$(if $(ABI_VERSION),echo '$(ABI_VERSION)' | cmp -s - $(PKG_INFO_DIR)/$(1).version || { \
+		mkdir -p $(PKG_INFO_DIR); \
 		echo '$(ABI_VERSION)' > $(PKG_INFO_DIR)/$(1).version; \
 		$(foreach pkg,$(filter-out $(1),$(PROVIDES)), \
 			cp $(PKG_INFO_DIR)/$(1).version $(PKG_INFO_DIR)/$(pkg).version; \

--- a/package/libs/toolchain/Makefile
+++ b/package/libs/toolchain/Makefile
@@ -781,8 +781,9 @@ else
 
 endif
 
-$(eval $(call BuildPackage,libc))
 $(eval $(call BuildPackage,libgcc))
+# libc depends on knowing libgcc's ABI, so it needs to be evaluated first
+$(eval $(call BuildPackage,libc))
 $(eval $(call BuildPackage,libatomic))
 $(eval $(call BuildPackage,libquadmath))
 $(eval $(call BuildPackage,libstdcpp))


### PR DESCRIPTION
Backport #20819 and #21265 to 25.12.

Depends on:
- https://github.com/openwrt/openwrt/pull/21265
- https://github.com/openwrt/packages/pull/28155
- https://github.com/openwrt/packages/pull/28145
- https://github.com/openwrt/packages/pull/28158

Related:
- https://github.com/openwrt/openwrt/issues/21257