### PR TITLE
realtek: pcs: fix RTL930x 10GBASE-R PLL and SerDes initialization

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -725,13 +725,15 @@ static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds,
 
 	/*
 	 * A SerDes clock can either be taken from the low speed ring PLL or the high speed
-	 * LC PLL. As it is unclear if disabling PLLs has any positive or negative effect,
-	 * always activate both.
+	 * LC PLL. Initialize CMU reset control bits to enable subsequent CMU toggle.
 	 */
 
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 0, 0xf);
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, pbit + 1, pbit, pll);
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, sbit + 3, sbit, speed);
+
+	/* Initialize CMU reset control bits for subsequent toggle in clock ready loop */
+	rtpcs_sds_write_bits(even_sds, 0x21, 0x0b, 3, 0, 0xf);
 
 	return 0;
 }

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -101,6 +101,10 @@
 #define RTSDS_930X_PLL_LC		0x3
 #define RTSDS_930X_PLL_RING		0x1
 
+/* LEQ/DFE media type configuration (0x2e:0x16[3:2]) */
+#define RTSDS_930X_MEDIA_DAC			0x1	/* Direct Attach Copper cable */
+#define RTSDS_930X_MEDIA_FIBER			0x2	/* Fiber or PHY-based connection */
+
 /* Registers of the internal SerDes of the 9310 */
 #define RTL931X_SERDES_MODE_CTRL		(0x13cc)
 #define RTL931X_PS_SERDES_OFF_MODE_CTRL_ADDR	(0x13F4)
@@ -1553,17 +1557,13 @@ static void rtpcs_930x_sds_do_rx_calibration_1(struct rtpcs_serdes *sds,
 
 	pr_info("start_1.1.5 LEQ and DFE setting\n");
 
-	/* TODO: make this work for DAC cables of different lengths */
-	/* For a 10GBit serdes wit Fibre, SDS 8 or 9 */
-	if (phy_mode == PHY_INTERFACE_MODE_10GBASER ||
-	    phy_mode == PHY_INTERFACE_MODE_1000BASEX ||
-	    phy_mode == PHY_INTERFACE_MODE_SGMII)
-		rtpcs_sds_write_bits(sds, 0x2e, 0x16,  3,  2, 0x02);
-	else
-		pr_err("%s not PHY-based or SerDes, implement DAC!\n", __func__);
-
-	/* No serdes, check for Aquantia PHYs */
-	rtpcs_sds_write_bits(sds, 0x2e, 0x16,  3,  2, 0x02);
+	/*
+	 * Configure LEQ/DFE based on media type:
+	 * 0x1 = DAC (Direct Attach Copper) cable on SDS 8/9
+	 * 0x2 = Fiber or PHY-based connection
+	 * TODO: DAC detection not implemented, always use fiber/PHY setting
+	 */
+	rtpcs_sds_write_bits(sds, 0x2e, 0x16,  3,  2, RTSDS_930X_MEDIA_FIBER);
 
 	rtpcs_sds_write_bits(sds, 0x2e, 0x0f,  6,  0, 0x5f);
 	rtpcs_sds_write_bits(sds, 0x2f, 0x05,  7,  2, 0x1f);


### PR DESCRIPTION
This patch series fixes 10GBASE-R link establishment issues on RTL930x SoCs by aligning the PLL and SerDes initialization sequence with the Realtek SDK.

Fixes: #20609

The main issues addressed:

1. Missing analog CMU reset control initialization (0x21:0x0b)
2. Incorrect PLL selection logic for 10G speeds
3. Incomplete LEQ/DFE configuration with duplicate writes

Changes:

* Initialize CMU reset control bits (0x21:0x0b[3:0]=0xf) before PLL configuration
* Ensure 10GBASE-R always uses LC PLL, with proper neighbor reconfiguration
* Fix LEQ/DFE media type configuration by removing ineffective condition check

Tested on RTL9303 with 10GBASE-R SFP+ module.

Reference: Realtek SDK dal_longan_sds.c

* https://github.com/plappermaul/realtek-doc/blob/main/sources/rtk-dms1250/src/dal/longan/dal_longan_sds.c
* https://github.com/plappermaul/realtek-doc/blob/main/sources/rtk-xgs1210/src/dal/longan/dal_longan_sds.c