### PR TITLE
build: add docker file for local compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Usage:
+# docker run --interactive --rm --tty --ulimit 'nofile=1024:262144' \
+#   --volume "$(pwd):/workdir" --workdir '/workdir' buildbot:debian /bin/bash
+
+# Primary (used) stage - Debian
+# docker build --rm --target debian -t buildbot:debian .
+FROM debian:trixie-slim AS debian
+LABEL maintainer="xiaobo <peterwillcn@gmail.com>"
+
+ENV GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
+WORKDIR /workdir
+
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests --yes \
+    build-essential clang flex bison g++ gawk device-tree-compiler \
+    gcc-multilib g++-multilib gettext git libncurses-dev libssl-dev \
+    rsync swig unzip zlib1g-dev zstd file wget upx-ucl ca-certificates \
+    python3-dev python3-pyelftools python3-setuptools elfutils libelf-dev quilt && \
+  rm -rf /var/lib/apt/lists/* && \
+  useradd -m -s /bin/bash -U buildbot
+
+USER buildbot
+
+# Experimental (unused/default) stage - Alpine
+# docker build --rm --target alpine -t buildbot:alpine .
+FROM alpine:3.22 AS alpine
+LABEL maintainer="xiaobo <peterwillcn@gmail.com>"
+
+ENV GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
+WORKDIR /workdir
+
+RUN apk update && apk add --no-cache \
+    argp-standalone asciidoc autoconf automake bash bc binutils bzip2 build-base \
+    cdrkit coreutils diffutils elfutils-dev e2fsprogs-dev findutils flex g++ \
+    gawk gcc gettext git grep gzip intltool libtool libxslt linux-headers lzo-dev \
+    make musl-fts-dev musl-libintl musl-obstack-dev ncurses-dev openssl-dev patch \
+    perl pkgconfig py3-distutils-extra py3-elftools py3-setuptools python3-dev \
+    sed rsync swig tar unzip util-linux wget zlib-dev bsd-compat-headers && \
+  addgroup buildbot && \
+  adduser -s /bin/bash -G buildbot -D buildbot
+
+USER buildbot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Usage:
+# docker run --interactive --rm --tty --ulimit 'nofile=1024:262144' \
+#   --volume "$(pwd):/workdir" --workdir '/workdir' buildbot:debian /bin/bash
+
+# Primary (used) stage - Debian
+# docker build --rm --target debian -t buildbot:debian .
+FROM debian:trixie-slim AS debian
+LABEL maintainer="xiaobo <peterwillcn@gmail.com>"
+
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests --yes \
+    build-essential clang flex bison g++ gawk device-tree-compiler \
+    gcc-multilib g++-multilib gettext git libncurses-dev libssl-dev \
+    rsync swig unzip zlib1g-dev zstd file wget upx-ucl ca-certificates \
+    python3-dev python3-pyelftools python3-setuptools elfutils libelf-dev quilt && \
+  rm -rf /var/lib/apt/lists/* && \
+  useradd -m -s /bin/bash -U buildbot
+
+WORKDIR /workdir
+USER buildbot
+
+# Experimental (unused/default) stage - Alpine
+# docker build --rm --target alpine -t buildbot:alpine .
+FROM alpine:3.23 AS alpine
+LABEL maintainer="xiaobo <peterwillcn@gmail.com>"
+
+RUN apk update && apk add --no-cache \
+    argp-standalone asciidoc autoconf automake bash bc binutils bzip2 build-base \
+    cdrkit coreutils diffutils elfutils-dev e2fsprogs-dev findutils flex g++ \
+    gawk gcc gettext git grep gzip intltool libtool libxslt linux-headers lzo-dev \
+    make musl-fts-dev musl-libintl musl-obstack-dev ncurses-dev openssl-dev patch \
+    perl pkgconfig py3-distutils-extra py3-elftools py3-setuptools python3-dev \
+    sed rsync swig tar unzip util-linux wget zlib-dev bsd-compat-headers quilt && \
+  addgroup buildbot && \
+  adduser -s /bin/bash -G buildbot -D buildbot
+
+WORKDIR /workdir
+USER buildbot

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+# docker compose run --rm buildbot
+
+services:
+  buildbot:
+    build: .
+    image: buildbot:debian
+    container_name: openwrt
+    user: "${UID:-1000}:${GID:-1000}"
+    stdin_open: true
+    tty: true
+    working_dir: /workdir
+    ulimits:
+      nofile:
+        soft: 1024
+        hard: 262144
+    volumes:
+      - .:/workdir:rw


### PR DESCRIPTION
1. **Solves the problem of inconsistent compilation environments**
Compilation dependencies and versions vary significantly across different host systems (e.g., Ubuntu, CentOS, macOS). Manual environment setup often leads to errors like *command not found*, *version incompatibility*, or *permission denied*. This container provides a **unified, clean, and trouble-free compilation environment**—launching it on any machine ensures an identical development setup, eliminating environment-related issues entirely.

2. **Meets the need for full compilation and in-depth customization**
Unlike official SDK containers that only support building based on pre-packaged SDKs, this container offers a **clean-slate environment from scratch**, enabling developers to:
   - Modify OpenWrt kernel source code and customize kernel versions or parameters
   - Add proprietary drivers for custom hardware to support niche devices
   - Perform in-depth pruning of system components to create ultra-lightweight firmware images
   - Customize the root file system and partition layout to meet specific use case requirements

Build:
```
docker build --rm --target debian -t buildbot:debian .
# docker build --rm --target alpine -t buildbot:alpine .
```

Usage:
```
docker-compose up 

or 

docker run --interactive --rm --tty --ulimit 'nofile=1024:262144' \
   --volume "$(pwd):/workdir" --workdir '/workdir' buildbot:debian /bin/bash
```
Ping @jonasjelonek 
https://github.com/openwrt/openwrt/pull/23911 
https://github.com/openwrt/openwrt/commit/4e2920fc0885d766519295cf7d3b84af589d7489