### PR TITLE
realtek: fix Linksys LGS328C dts memory definition

### DIFF
--- a/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
+++ b/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
@@ -7,6 +7,12 @@
 / {
 	compatible = "linksys,lgs328c", "realtek,rtl9301-soc";
 	model = "Linksys LGS328C";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* 256 MiB lowmem */
+		      <0x20000000 0x10000000>; /* 256 MiB highmem */
+	};
 };
 
 &i2c_mst1 {

--- a/target/linux/realtek/dts/rtl9311_linksys_lgs352c.dts
+++ b/target/linux/realtek/dts/rtl9311_linksys_lgs352c.dts
@@ -7,6 +7,12 @@
 / {
 	compatible = "linksys,lgs352c", "realtek,rtl9311-soc";
 	model = "Linksys LGS352C";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* 256 MiB lowmem */
+		      <0x90000000 0x10000000>; /* 256 MiB highmem */
+	};
 };
 
 &i2c_mst1 {

--- a/target/linux/realtek/dts/rtl93xx_linksys_lgs3xxc_nand_common.dtsi
+++ b/target/linux/realtek/dts/rtl93xx_linksys_lgs3xxc_nand_common.dtsi
@@ -43,12 +43,6 @@
 		};
 	};
 
-	memory@0 {
-		device_type = "memory";
-		reg = <0x00000000 0x10000000>, /* 256 MiB lowmem */
-		      <0x90000000 0x10000000>; /* 256 MiB highmem */
-	};
-
 	sfp0: sfp-p49 {
 		compatible = "sff,sfp";
 		los-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;


### PR DESCRIPTION
RTL930x devices have highmem starting address at 0x20000000. The Linksys LGS328 highmem definition is wrongly shared with the larger LGS352C RTL931x model and starts at 0x90000000. Fix it by splitting the definition.

Fixes: 853d73f ("realtek: add support for Linksys LGS328C")