### PR TITLE
toolchain: fix libgcc ABI for libc

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -191,6 +191,7 @@ endif
     $(STAGING_DIR_ROOT)/stamp/.$(1)_installed: $(PKG_BUILD_DIR)/.pkgdir/$(1).installed
 	mkdir -p $(STAGING_DIR_ROOT)/stamp
 	$(if $(ABI_VERSION),echo '$(ABI_VERSION)' | cmp -s - $(PKG_INFO_DIR)/$(1).version || { \
+		mkdir -p $(PKG_INFO_DIR); \
 		echo '$(ABI_VERSION)' > $(PKG_INFO_DIR)/$(1).version; \
 		$(foreach pkg,$(filter-out $(1),$(PROVIDES)), \
 			cp $(PKG_INFO_DIR)/$(1).version $(PKG_INFO_DIR)/$(pkg).version; \

--- a/package/libs/toolchain/Makefile
+++ b/package/libs/toolchain/Makefile
@@ -781,8 +781,9 @@ else
 
 endif
 
-$(eval $(call BuildPackage,libc))
 $(eval $(call BuildPackage,libgcc))
+# libc depends on knowing libgcc's ABI, so it needs to be evaluated first
+$(eval $(call BuildPackage,libc))
 $(eval $(call BuildPackage,libatomic))
 $(eval $(call BuildPackage,libquadmath))
 $(eval $(call BuildPackage,libstdcpp))


### PR DESCRIPTION
libc depends on knowing libgcc's ABI, so it needs to be evaluated first. Otherwise libc will depend on an ABI-less libgcc causing the rest of the toolchain to fail.

```bash
Building package index...
ERROR: unable to select packages:
  libgcc (virtual):
    note: please select one of the 'provided by'
          packages explicitly
    provided by: libgcc1
    required by: world[libgcc]
```

Before:

```bash
libc fused dependencies: libgcc
libgcc fused dependencies:
libatomic fused dependencies: libgcc1
```

After:

```bash
libgcc fused dependencies:
libc fused dependencies: libgcc1
libatomic fused dependencies: libgcc1
```

If the first built package has an ABI, `PKG_INFO_DIR` might not exist, so ensure it does.

cc: @efahl, @robimarko

Related:
- https://github.com/openwrt/openwrt/pull/20819#issuecomment-3687689487