### PR TITLE
wifi-scripts: add missing 802.11be type in hwmodelist

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/iwinfo.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/iwinfo.uc
@@ -316,7 +316,7 @@ function dbm2quality(dbm) {
 }
 
 function hwmodelist(name) {
-	const mode = { 'HT*': 'n', 'VHT*': 'ac', 'HE*': 'ax' };
+	const mode = { 'HT*': 'n', 'VHT*': 'ac', 'HE*': 'ax', 'EHT*': 'be' };
 	let iface = ifaces[name];
 	let phy = board_data.wlan?.['phy' + iface.wiphy];
 	if (!phy || !iface.radio?.band)


### PR DESCRIPTION
Add EHT* check so that the hwmode will display 802.11be capability correctly.



<details>
<summary>example</summary>

```
phy0.0-ap0 ESSID: "OpenWrt2g"
         Access Point: 02:0a:52:0c:e3:16
         Mode: Master  Channel: 1 (2.412 GHz)  HT Mode: EHT20
         Center Channel 1: 1 2: unknown
         Tx-Power: 20 dBm  Link Quality: 70/70
         Signal: 0 dBm  Noise: -86 dBm
         Bit Rate: unknown
         Encryption: none
         Type: nl80211  HW Mode(s): 802.11be/ax/n/g/b
         Hardware: 0x14c3:0x7992 0x14c3:0x7992 [MediaTek MT7992E]
         TX power offset: none
         Channel offset: none
         Supports VAPs: yes  PHY name: phy0

phy0.1-ap0 ESSID: "OpenWrt5g"
         Access Point: 00:0a:52:0c:e3:26
         Mode: Master  Channel: 36 (5.180 GHz)  HT Mode: EHT80
         Center Channel 1: 42 2: unknown
         Tx-Power: 20 dBm  Link Quality: 70/70
         Signal: 0 dBm  Noise: -91 dBm
         Bit Rate: unknown
         Encryption: none
         Type: nl80211  HW Mode(s): 802.11be/ax/ac/n
         Hardware: 0x14c3:0x7992 0x14c3:0x7992 [MediaTek MT7992E]
         TX power offset: none
         Channel offset: none
         Supports VAPs: yes  PHY name: phy0
```


</details>