### PR TITLE
projectsmirrors: switch to HTTPS and drop some mirrors

### DIFF
--- a/scripts/projectsmirrors.json
+++ b/scripts/projectsmirrors.json
@@ -47,15 +47,12 @@
 	"@KERNEL": [
 		"https://cdn.kernel.org/pub",
 		"https://mirrors.mit.edu/kernel",
-		"http://ftp.nara.wide.ad.jp/pub/kernel.org",
-		"http://www.ring.gr.jp/archives/linux/kernel.org",
 		"https://www.mirrorservice.org/sites/ftp.kernel.org/pub",
 		"https://mirrors.ustc.edu.cn/kernel.org"
 	],
 	"@GNOME": [
 		"https://download.gnome.org/sources",
-		"https://mirror.csclub.uwaterloo.ca/gnome/sources",
-		"http://ftp.nara.wide.ad.jp/pub/X11/GNOME/sources"
+		"https://mirror.csclub.uwaterloo.ca/gnome/sources"
 	],
 	"@OPENWRT": [
 		"https://sources.cdn.openwrt.org",

--- a/scripts/projectsmirrors.json
+++ b/scripts/projectsmirrors.json
@@ -18,7 +18,7 @@
 		"https://mirror.navercorp.com/apache",
 		"https://ftp.jaist.ac.jp/pub/apache",
 		"https://apache.cs.utah.edu",
-		"http://apache.mirrors.ovh.net/ftp.apache.org/dist",
+		"https://apache.mirrors.ovh.net/ftp.apache.org/dist",
 		"https://mirrors.tuna.tsinghua.edu.cn/apache",
 		"https://mirrors.ustc.edu.cn/apache"
 	],


### PR DESCRIPTION
### Removed
- `www.ring.gr.jp`: only supports insecure plain HTTP, and unstable
- `ftp.nara.wide.ad.jp`: only supports insecure plain HTTP

### Updated
- `apache.mirrors.ovh.net`: switch to HTTPS