### PR TITLE
mac80211: use OpenWrt mirror for b43 fw downloads

### DIFF
--- a/package/kernel/mac80211/broadcom.mk
+++ b/package/kernel/mac80211/broadcom.mk
@@ -35,14 +35,6 @@ config-$(CONFIG_PACKAGE_BRCM80211_DEBUG) += BRCMDBG
 config-$(CONFIG_LEDS_TRIGGERS) += B43_LEDS B43LEGACY_LEDS
 
 #Broadcom firmware
-ifneq ($(CONFIG_B43_FW_6_30),)
-  PKG_B43_FWV4_NAME:=broadcom-wl
-  PKG_B43_FWV4_VERSION:=6.30.163.46
-  PKG_B43_FWV4_OBJECT:=$(PKG_B43_FWV4_NAME)-$(PKG_B43_FWV4_VERSION).wl_apsta.o
-  PKG_B43_FWV4_SOURCE:=$(PKG_B43_FWV4_NAME)-$(PKG_B43_FWV4_VERSION).tar.bz2
-  PKG_B43_FWV4_SOURCE_URL:=http://www.lwfinger.com/b43-firmware/
-  PKG_B43_FWV4_HASH:=a07c3b6b277833c7dbe61daa511f908cd66c5e2763eb7a0859abc36cd9335c2d
-else
 ifneq ($(CONFIG_B43_FW_5_10),)
   PKG_B43_FWV4_NAME:=broadcom-wl
   PKG_B43_FWV4_VERSION:=5.10.56.27.3
@@ -64,7 +56,7 @@ ifneq ($(CONFIG_B43_FW_5_100_138),)
   PKG_B43_FWV4_VERSION:=5.100.138
   PKG_B43_FWV4_OBJECT:=$(PKG_B43_FWV4_NAME)-$(PKG_B43_FWV4_VERSION)/linux/wl_apsta.o
   PKG_B43_FWV4_SOURCE:=$(PKG_B43_FWV4_NAME)-$(PKG_B43_FWV4_VERSION).tar.bz2
-  PKG_B43_FWV4_SOURCE_URL:=http://www.lwfinger.com/b43-firmware/
+  PKG_B43_FWV4_SOURCE_URL:=@OPENWRT
   PKG_B43_FWV4_HASH:=f1e7067aac5b62b67b8b6e4c517990277804339ac16065eb13c731ff909ae46f
 else
   PKG_B43_FWV4_NAME:=broadcom-wl
@@ -163,15 +155,6 @@ config PACKAGE_B43_USE_BCMA
 		  This firmware currently gets most of the testing and is needed for some N-PHY devices.
 
 		  If unsure, select the this firmware.
-
-	config B43_FW_6_30
-		bool "Firmware 784.2 from driver 6.30.163.46 (experimental)"
-		help
-		  Newer experimental firmware for BCM43xx devices.
-
-		  This firmware is mostly untested.
-
-		  If unsure, select the "stable" firmware.
 
 	config B43_OPENFIRMWARE
 		bool "Open FirmWare for WiFi networks"
@@ -367,7 +350,7 @@ PKG_BRCMSMAC_FW_NAME:=broadcom-wl
 PKG_BRCMSMAC_FW_VERSION:=5.100.138
 PKG_BRCMSMAC_FW_OBJECT:=$(PKG_BRCMSMAC_FW_NAME)-$(PKG_BRCMSMAC_FW_VERSION)/linux/wl_apsta.o
 PKG_BRCMSMAC_FW_SOURCE:=$(PKG_BRCMSMAC_FW_NAME)-$(PKG_BRCMSMAC_FW_VERSION).tar.bz2
-PKG_BRCMSMAC_FW_SOURCE_URL:=http://www.lwfinger.com/b43-firmware/
+PKG_BRCMSMAC_FW_SOURCE_URL:=@OPENWRT
 PKG_BRCMSMAC_FW_HASH:=f1e7067aac5b62b67b8b6e4c517990277804339ac16065eb13c731ff909ae46f
 
 define Download/brcmsmac


### PR DESCRIPTION
`lwfinger . com` seems drop-catched and now
redirects to potentially unsafe website.

Fixes: https://github.com/openwrt/openwrt/issues/19436

Update: This commit now drops no longer available 6.30 firmware.