### PR TITLE
[RFP] econet: add LZMA loader with SPI-NAND and BMT support for dual-image boot

### DIFF
--- a/target/linux/econet/base-files/sbin/en75_chboot
+++ b/target/linux/econet/base-files/sbin/en75_chboot
@@ -102,6 +102,14 @@ switch() {
 
 main() {
     case "$(board_name)" in
+    genexis,platinum-4410)
+        part=$(part_named '"reservearea"')
+        offset_blocks=12
+        block_size=$((1024 * 128))
+        code_offset=0
+        code_openwrt=30
+        code_factory=31
+        ;;
     tplink,archer-vr1200v-v2)
         # 03fe0000
         part=$(part_named '"reserve"')

--- a/target/linux/econet/dts/en751221_genexis_platinum-4410.dts
+++ b/target/linux/econet/dts/en751221_genexis_platinum-4410.dts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include "en751221.dtsi"
+
+/ {
+	model = "Genexis Platinum 4410";
+	compatible = "genexis,platinum-4410", "econet,en751221";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x4000000>;
+	};
+
+	chosen {
+		stdout-path = "/serial@1fbf0000:115200";
+		linux,usable-memory-range = <0x00020000 0x3fe0000>;
+	};
+};
+
+&nand {
+	status = "okay";
+	econet,bmt;
+	econet,bbt-table-size = <250>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootloader";
+			reg = <0x0 0x40000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_bootloader_ff48: macaddr@ff48 {
+					compatible = "mac-base";
+					reg = <0xff48 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@40000 {
+			label = "romfile";
+			reg = <0x40000 0x40000>;
+		};
+
+		partition@80000 {
+			label = "tclinux";
+			reg = <0x80000 0x1000000>;
+			econet,enable-remap;
+		};
+
+		/* Nested inside of tclinux
+		 * NOTE: No linux,rootfs marker - root device passed via kernel cmdline
+		 */
+		partition@480000 {
+			label = "rootfs";
+			reg = <0x480000 0xb80000>;
+		};
+
+		partition@1080000 {
+			label = "tclinux_slave";
+			reg = <0x1080000 0x1000000>;
+		};
+
+		/* Nested inside of tclinux_slave */
+		partition@1480000 {
+			label = "rootfs_slave";
+			reg = <0x1480000 0xb80000>;
+		};
+
+		partition@2080000 {
+			label = "yaffs";
+			reg = <0x2080000 0x2900000>;
+		};
+
+		partition@4980000 {
+			label = "unknown";
+			reg = <0x4980000 0x24c0000>;
+		};
+
+		partition@6e40000 {
+			label = "reservearea";
+			reg = <0x6e40000 0x1c0000>;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_reserve_140000: eeprom@140000 {
+					/* MT7592 */
+					reg = <0x140000 0x200>;
+				};
+			};
+		};
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	nvmem-cells = <&macaddr_bootloader_ff48 0>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/econet/image/Makefile
+++ b/target/linux/econet/image/Makefile
@@ -5,10 +5,64 @@ define Target/Description
 	Build firmware images for EcoNet MIPS based boards.
 endef
 
+DEVICE_VARS += LZMA_TEXT_START LOADER_TYPE TCLINUX_MODEL TRX_LOADADDR
+DEVICE_VARS += NAND_BBT_SIZE NAND_OS1_OFFSET NAND_OS2_OFFSET
+DEVICE_VARS += NAND_BOOT_FLAG_OFFSET NAND_BOOT_FLAG_OS1 NAND_BOOT_FLAG_OS2 NAND_BOOT_FLAG_MASK
+DEVICE_VARS += NAND_CMDLINE_OS1 NAND_CMDLINE_OS2
+
+LOADER_TYPE := bin
+LOADADDR := 0x80020000
+TRX_LOADADDR := 80020000
+
+define Build/loader-common
+	rm -rf $@.src
+	$(MAKE) -C lzma-loader \
+		PKG_BUILD_DIR="$@.src" \
+		TARGET_DIR="$(dir $@)" LOADER_NAME="$(notdir $@)" \
+		$(if $(LZMA_TEXT_START),LZMA_TEXT_START=$(LZMA_TEXT_START)) \
+		LOADADDR=$(LOADADDR) \
+		SUBTARGET=$(SUBTARGET) \
+		$(1) compile loader.$(LOADER_TYPE)
+	mv "$@.$(LOADER_TYPE)" "$@"
+	rm -rf $@.src
+endef
+
+define Build/loader-kernel
+	$(call Build/loader-common,LOADER_DATA="$@")
+endef
+
+define Build/loader-spinand-bmt
+	$(call Build/loader-common,NAND_BOOT=1 \
+		$(if $(NAND_BBT_SIZE),MAX_BBT_SIZE=$(NAND_BBT_SIZE)) \
+		$(if $(NAND_OS1_OFFSET),NAND_OS1_OFFSET=$(NAND_OS1_OFFSET)) \
+		$(if $(NAND_OS2_OFFSET),NAND_OS2_OFFSET=$(NAND_OS2_OFFSET)) \
+		$(if $(NAND_BOOT_FLAG_OFFSET),NAND_BOOT_FLAG_OFFSET=$(NAND_BOOT_FLAG_OFFSET)) \
+		$(if $(NAND_BOOT_FLAG_OS1),NAND_BOOT_FLAG_OS1=$(NAND_BOOT_FLAG_OS1)) \
+		$(if $(NAND_BOOT_FLAG_OS2),NAND_BOOT_FLAG_OS2=$(NAND_BOOT_FLAG_OS2)) \
+		$(if $(NAND_BOOT_FLAG_MASK),NAND_BOOT_FLAG_MASK=$(NAND_BOOT_FLAG_MASK)) \
+		$(if $(NAND_CMDLINE_OS1),NAND_CMDLINE_OS1=$(NAND_CMDLINE_OS1)) \
+		$(if $(NAND_CMDLINE_OS2),NAND_CMDLINE_OS2=$(NAND_CMDLINE_OS2)))
+endef
+
 # tclinux-trx is the default format used in the SDK
+# Optional: pass model string via $(1) for reserved header field
+# (supports \n escape). Stock web UI will accept the TRX file if the
+# correct model string is specified here
 define Build/tclinux-trx
-  ./tclinux-trx.sh $@ $(IMAGE_ROOTFS) $(VERSION_DIST)-$(REVISION) > $@.new
+	./tclinux-trx.sh \
+		--kernel $@ \
+		--rootfs $(IMAGE_ROOTFS) \
+		--version $(VERSION_DIST)-$(REVISION) \
+		--loadaddr $(TRX_LOADADDR) \
+		$(if $(1),--model '$(1)') > $@.new
 	mv $@.new $@
+endef
+
+define Device/tclinux-lzma-loader
+  TRX_LOADADDR := 80002000
+  KERNEL := kernel-bin | append-dtb | lzma
+  IMAGES := tclinux.trx
+  IMAGE/tclinux.trx = loader-spinand-bmt | lzma | pad-to 64k | append-kernel | tclinux-trx $$(TCLINUX_MODEL)
 endef
 
 # tclinux bootloader requires LZMA, BUT only provides 7.5MB of space

--- a/target/linux/econet/image/en751221.mk
+++ b/target/linux/econet/image/en751221.mk
@@ -7,6 +7,16 @@ define Device/en751221_generic
 endef
 TARGET_DEVICES += en751221_generic
 
+define Device/genexis_platinum-4410
+  $(Device/tclinux-lzma-loader)
+  DEVICE_VENDOR := Genexis
+  DEVICE_MODEL := Platinum 4410
+  DEVICE_DTS := en751221_genexis_platinum-4410
+  TCLINUX_MODEL := P4410\n
+  NAND_BBT_SIZE := 250
+endef
+TARGET_DEVICES += genexis_platinum-4410
+
 define Device/nokia_g240g-e
   DEVICE_VENDOR := Nokia
   DEVICE_MODEL := G-240G-E

--- a/target/linux/econet/image/lzma-loader/Makefile
+++ b/target/linux/econet/image/lzma-loader/Makefile
@@ -1,0 +1,94 @@
+#
+# Copyright (C) 2011 OpenWrt.org
+# Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+LZMA_TEXT_START	:= 0x80002000
+LOADER		:= loader.bin
+LOADER_NAME	:= $(basename $(notdir $(LOADER)))
+LOADER_DATA 	:=
+TARGET_DIR	:=
+FLASH_START	:=
+FLASH_OFFS	:=
+FLASH_MAX	:=
+BOARD		:=
+PLATFORM	:=
+SUBTARGET	:=
+CACHE_FLAGS    := -DCONFIG_CACHELINE_SIZE=32
+
+# NAND boot configuration (optional, defaults in nand_boot.h)
+NAND_BOOT		:=
+MAX_BBT_SIZE		:=
+NAND_OS1_OFFSET		:=
+NAND_OS2_OFFSET		:=
+NAND_BOOT_FLAG_OFFSET	:=
+NAND_BOOT_FLAG_OS1	:=
+NAND_BOOT_FLAG_OS2	:=
+NAND_BOOT_FLAG_MASK	:=
+NAND_CMDLINE_OS1	:=
+NAND_CMDLINE_OS2	:=
+
+ifeq ($(TARGET_DIR),)
+TARGET_DIR	:= $(KDIR)
+endif
+
+LOADER_BIN	:= $(TARGET_DIR)/$(LOADER_NAME).bin
+LOADER_GZ	:= $(TARGET_DIR)/$(LOADER_NAME).gz
+LOADER_ELF	:= $(TARGET_DIR)/$(LOADER_NAME).elf
+
+PKG_NAME := lzma-loader
+PKG_BUILD_DIR := $(KDIR)/$(PKG_NAME)
+
+.PHONY : loader-compile loader.bin loader.elf loader.gz
+
+$(PKG_BUILD_DIR)/.prepared:
+	mkdir $(PKG_BUILD_DIR)
+	$(CP) ./src/* $(PKG_BUILD_DIR)/
+	touch $@
+
+loader-compile: $(PKG_BUILD_DIR)/.prepared
+	$(MAKE) -C $(PKG_BUILD_DIR) CROSS_COMPILE="$(TARGET_CROSS)" \
+		LZMA_TEXT_START=$(LZMA_TEXT_START) \
+		LOADER_DATA=$(LOADER_DATA) \
+		FLASH_START=$(FLASH_START) \
+		FLASH_OFFS=$(FLASH_OFFS) \
+		FLASH_MAX=$(FLASH_MAX) \
+		BOARD="$(BOARD)" \
+		PLATFORM="$(PLATFORM)" \
+		SUBTARGET="$(SUBTARGET)" \
+		CACHE_FLAGS="$(CACHE_FLAGS)" \
+		NAND_BOOT="$(NAND_BOOT)" \
+		MAX_BBT_SIZE="$(MAX_BBT_SIZE)" \
+		NAND_OS1_OFFSET="$(NAND_OS1_OFFSET)" \
+		NAND_OS2_OFFSET="$(NAND_OS2_OFFSET)" \
+		NAND_BOOT_FLAG_OFFSET="$(NAND_BOOT_FLAG_OFFSET)" \
+		NAND_BOOT_FLAG_OS1="$(NAND_BOOT_FLAG_OS1)" \
+		NAND_BOOT_FLAG_OS2="$(NAND_BOOT_FLAG_OS2)" \
+		NAND_BOOT_FLAG_MASK="$(NAND_BOOT_FLAG_MASK)" \
+		NAND_CMDLINE_OS1="$(NAND_CMDLINE_OS1)" \
+		NAND_CMDLINE_OS2="$(NAND_CMDLINE_OS2)" \
+		clean all
+
+loader.gz: $(PKG_BUILD_DIR)/loader.bin
+	gzip -nc9 $< > $(LOADER_GZ)
+
+loader.elf: $(PKG_BUILD_DIR)/loader.elf
+	$(CP) $< $(LOADER_ELF)
+
+loader.bin: $(PKG_BUILD_DIR)/loader.bin
+	$(CP) $< $(LOADER_BIN)
+
+download:
+prepare: $(PKG_BUILD_DIR)/.prepared
+compile: loader-compile
+
+install:
+
+clean:
+	rm -rf $(PKG_BUILD_DIR)
+

--- a/target/linux/econet/image/lzma-loader/src/LzmaDecode.c
+++ b/target/linux/econet/image/lzma-loader/src/LzmaDecode.c
@@ -1,0 +1,584 @@
+/*
+  LzmaDecode.c
+  LZMA Decoder (optimized for Speed version)
+
+  LZMA SDK 4.40 Copyright (c) 1999-2006 Igor Pavlov (2006-05-01)
+  http://www.7-zip.org/
+
+  LZMA SDK is licensed under two licenses:
+  1) GNU Lesser General Public License (GNU LGPL)
+  2) Common Public License (CPL)
+  It means that you can select one of these two licenses and
+  follow rules of that license.
+
+  SPECIAL EXCEPTION:
+  Igor Pavlov, as the author of this Code, expressly permits you to
+  statically or dynamically link your Code (or bind by name) to the
+  interfaces of this file without subjecting your linked Code to the
+  terms of the CPL or GNU LGPL. Any modifications or additions
+  to this file, however, are subject to the LGPL or CPL terms.
+*/
+
+#include "LzmaDecode.h"
+
+#define kNumTopBits 24
+#define kTopValue ((UInt32)1 << kNumTopBits)
+
+#define kNumBitModelTotalBits 11
+#define kBitModelTotal (1 << kNumBitModelTotalBits)
+#define kNumMoveBits 5
+
+#define RC_READ_BYTE (*Buffer++)
+
+#define RC_INIT2 Code = 0; Range = 0xFFFFFFFF; \
+  { int i; for(i = 0; i < 5; i++) { RC_TEST; Code = (Code << 8) | RC_READ_BYTE; }}
+
+#ifdef _LZMA_IN_CB
+
+#define RC_TEST { if (Buffer == BufferLim) \
+  { SizeT size; int result = InCallback->Read(InCallback, &Buffer, &size); if (result != LZMA_RESULT_OK) return result; \
+  BufferLim = Buffer + size; if (size == 0) return LZMA_RESULT_DATA_ERROR; }}
+
+#define RC_INIT Buffer = BufferLim = 0; RC_INIT2
+
+#else
+
+#define RC_TEST { if (Buffer == BufferLim) return LZMA_RESULT_DATA_ERROR; }
+
+#define RC_INIT(buffer, bufferSize) Buffer = buffer; BufferLim = buffer + bufferSize; RC_INIT2
+
+#endif
+
+#define RC_NORMALIZE if (Range < kTopValue) { RC_TEST; Range <<= 8; Code = (Code << 8) | RC_READ_BYTE; }
+
+#define IfBit0(p) RC_NORMALIZE; bound = (Range >> kNumBitModelTotalBits) * *(p); if (Code < bound)
+#define UpdateBit0(p) Range = bound; *(p) += (kBitModelTotal - *(p)) >> kNumMoveBits;
+#define UpdateBit1(p) Range -= bound; Code -= bound; *(p) -= (*(p)) >> kNumMoveBits;
+
+#define RC_GET_BIT2(p, mi, A0, A1) IfBit0(p) \
+  { UpdateBit0(p); mi <<= 1; A0; } else \
+  { UpdateBit1(p); mi = (mi + mi) + 1; A1; }
+
+#define RC_GET_BIT(p, mi) RC_GET_BIT2(p, mi, ; , ;)
+
+#define RangeDecoderBitTreeDecode(probs, numLevels, res) \
+  { int i = numLevels; res = 1; \
+  do { CProb *p = probs + res; RC_GET_BIT(p, res) } while(--i != 0); \
+  res -= (1 << numLevels); }
+
+
+#define kNumPosBitsMax 4
+#define kNumPosStatesMax (1 << kNumPosBitsMax)
+
+#define kLenNumLowBits 3
+#define kLenNumLowSymbols (1 << kLenNumLowBits)
+#define kLenNumMidBits 3
+#define kLenNumMidSymbols (1 << kLenNumMidBits)
+#define kLenNumHighBits 8
+#define kLenNumHighSymbols (1 << kLenNumHighBits)
+
+#define LenChoice 0
+#define LenChoice2 (LenChoice + 1)
+#define LenLow (LenChoice2 + 1)
+#define LenMid (LenLow + (kNumPosStatesMax << kLenNumLowBits))
+#define LenHigh (LenMid + (kNumPosStatesMax << kLenNumMidBits))
+#define kNumLenProbs (LenHigh + kLenNumHighSymbols)
+
+
+#define kNumStates 12
+#define kNumLitStates 7
+
+#define kStartPosModelIndex 4
+#define kEndPosModelIndex 14
+#define kNumFullDistances (1 << (kEndPosModelIndex >> 1))
+
+#define kNumPosSlotBits 6
+#define kNumLenToPosStates 4
+
+#define kNumAlignBits 4
+#define kAlignTableSize (1 << kNumAlignBits)
+
+#define kMatchMinLen 2
+
+#define IsMatch 0
+#define IsRep (IsMatch + (kNumStates << kNumPosBitsMax))
+#define IsRepG0 (IsRep + kNumStates)
+#define IsRepG1 (IsRepG0 + kNumStates)
+#define IsRepG2 (IsRepG1 + kNumStates)
+#define IsRep0Long (IsRepG2 + kNumStates)
+#define PosSlot (IsRep0Long + (kNumStates << kNumPosBitsMax))
+#define SpecPos (PosSlot + (kNumLenToPosStates << kNumPosSlotBits))
+#define Align (SpecPos + kNumFullDistances - kEndPosModelIndex)
+#define LenCoder (Align + kAlignTableSize)
+#define RepLenCoder (LenCoder + kNumLenProbs)
+#define Literal (RepLenCoder + kNumLenProbs)
+
+#if Literal != LZMA_BASE_SIZE
+StopCompilingDueBUG
+#endif
+
+int LzmaDecodeProperties(CLzmaProperties *propsRes, const unsigned char *propsData, int size)
+{
+  unsigned char prop0;
+  if (size < LZMA_PROPERTIES_SIZE)
+    return LZMA_RESULT_DATA_ERROR;
+  prop0 = propsData[0];
+  if (prop0 >= (9 * 5 * 5))
+    return LZMA_RESULT_DATA_ERROR;
+  {
+    for (propsRes->pb = 0; prop0 >= (9 * 5); propsRes->pb++, prop0 -= (9 * 5));
+    for (propsRes->lp = 0; prop0 >= 9; propsRes->lp++, prop0 -= 9);
+    propsRes->lc = prop0;
+    /*
+    unsigned char remainder = (unsigned char)(prop0 / 9);
+    propsRes->lc = prop0 % 9;
+    propsRes->pb = remainder / 5;
+    propsRes->lp = remainder % 5;
+    */
+  }
+
+  #ifdef _LZMA_OUT_READ
+  {
+    int i;
+    propsRes->DictionarySize = 0;
+    for (i = 0; i < 4; i++)
+      propsRes->DictionarySize += (UInt32)(propsData[1 + i]) << (i * 8);
+    if (propsRes->DictionarySize == 0)
+      propsRes->DictionarySize = 1;
+  }
+  #endif
+  return LZMA_RESULT_OK;
+}
+
+#define kLzmaStreamWasFinishedId (-1)
+
+int LzmaDecode(CLzmaDecoderState *vs,
+    #ifdef _LZMA_IN_CB
+    ILzmaInCallback *InCallback,
+    #else
+    const unsigned char *inStream, SizeT inSize, SizeT *inSizeProcessed,
+    #endif
+    unsigned char *outStream, SizeT outSize, SizeT *outSizeProcessed)
+{
+  CProb *p = vs->Probs;
+  SizeT nowPos = 0;
+  Byte previousByte = 0;
+  UInt32 posStateMask = (1 << (vs->Properties.pb)) - 1;
+  UInt32 literalPosMask = (1 << (vs->Properties.lp)) - 1;
+  int lc = vs->Properties.lc;
+
+  #ifdef _LZMA_OUT_READ
+
+  UInt32 Range = vs->Range;
+  UInt32 Code = vs->Code;
+  #ifdef _LZMA_IN_CB
+  const Byte *Buffer = vs->Buffer;
+  const Byte *BufferLim = vs->BufferLim;
+  #else
+  const Byte *Buffer = inStream;
+  const Byte *BufferLim = inStream + inSize;
+  #endif
+  int state = vs->State;
+  UInt32 rep0 = vs->Reps[0], rep1 = vs->Reps[1], rep2 = vs->Reps[2], rep3 = vs->Reps[3];
+  int len = vs->RemainLen;
+  UInt32 globalPos = vs->GlobalPos;
+  UInt32 distanceLimit = vs->DistanceLimit;
+
+  Byte *dictionary = vs->Dictionary;
+  UInt32 dictionarySize = vs->Properties.DictionarySize;
+  UInt32 dictionaryPos = vs->DictionaryPos;
+
+  Byte tempDictionary[4];
+
+  #ifndef _LZMA_IN_CB
+  *inSizeProcessed = 0;
+  #endif
+  *outSizeProcessed = 0;
+  if (len == kLzmaStreamWasFinishedId)
+    return LZMA_RESULT_OK;
+
+  if (dictionarySize == 0)
+  {
+    dictionary = tempDictionary;
+    dictionarySize = 1;
+    tempDictionary[0] = vs->TempDictionary[0];
+  }
+
+  if (len == kLzmaNeedInitId)
+  {
+    {
+      UInt32 numProbs = Literal + ((UInt32)LZMA_LIT_SIZE << (lc + vs->Properties.lp));
+      UInt32 i;
+      for (i = 0; i < numProbs; i++)
+        p[i] = kBitModelTotal >> 1;
+      rep0 = rep1 = rep2 = rep3 = 1;
+      state = 0;
+      globalPos = 0;
+      distanceLimit = 0;
+      dictionaryPos = 0;
+      dictionary[dictionarySize - 1] = 0;
+      #ifdef _LZMA_IN_CB
+      RC_INIT;
+      #else
+      RC_INIT(inStream, inSize);
+      #endif
+    }
+    len = 0;
+  }
+  while(len != 0 && nowPos < outSize)
+  {
+    UInt32 pos = dictionaryPos - rep0;
+    if (pos >= dictionarySize)
+      pos += dictionarySize;
+    outStream[nowPos++] = dictionary[dictionaryPos] = dictionary[pos];
+    if (++dictionaryPos == dictionarySize)
+      dictionaryPos = 0;
+    len--;
+  }
+  if (dictionaryPos == 0)
+    previousByte = dictionary[dictionarySize - 1];
+  else
+    previousByte = dictionary[dictionaryPos - 1];
+
+  #else /* if !_LZMA_OUT_READ */
+
+  int state = 0;
+  UInt32 rep0 = 1, rep1 = 1, rep2 = 1, rep3 = 1;
+  int len = 0;
+  const Byte *Buffer;
+  const Byte *BufferLim;
+  UInt32 Range;
+  UInt32 Code;
+
+  #ifndef _LZMA_IN_CB
+  *inSizeProcessed = 0;
+  #endif
+  *outSizeProcessed = 0;
+
+  {
+    UInt32 i;
+    UInt32 numProbs = Literal + ((UInt32)LZMA_LIT_SIZE << (lc + vs->Properties.lp));
+    for (i = 0; i < numProbs; i++)
+      p[i] = kBitModelTotal >> 1;
+  }
+
+  #ifdef _LZMA_IN_CB
+  RC_INIT;
+  #else
+  RC_INIT(inStream, inSize);
+  #endif
+
+  #endif /* _LZMA_OUT_READ */
+
+  while(nowPos < outSize)
+  {
+    CProb *prob;
+    UInt32 bound;
+    int posState = (int)(
+        (nowPos
+        #ifdef _LZMA_OUT_READ
+        + globalPos
+        #endif
+        )
+        & posStateMask);
+
+    prob = p + IsMatch + (state << kNumPosBitsMax) + posState;
+    IfBit0(prob)
+    {
+      int symbol = 1;
+      UpdateBit0(prob)
+      prob = p + Literal + (LZMA_LIT_SIZE *
+        (((
+        (nowPos
+        #ifdef _LZMA_OUT_READ
+        + globalPos
+        #endif
+        )
+        & literalPosMask) << lc) + (previousByte >> (8 - lc))));
+
+      if (state >= kNumLitStates)
+      {
+        int matchByte;
+        #ifdef _LZMA_OUT_READ
+        UInt32 pos = dictionaryPos - rep0;
+        if (pos >= dictionarySize)
+          pos += dictionarySize;
+        matchByte = dictionary[pos];
+        #else
+        matchByte = outStream[nowPos - rep0];
+        #endif
+        do
+        {
+          int bit;
+          CProb *probLit;
+          matchByte <<= 1;
+          bit = (matchByte & 0x100);
+          probLit = prob + 0x100 + bit + symbol;
+          RC_GET_BIT2(probLit, symbol, if (bit != 0) break, if (bit == 0) break)
+        }
+        while (symbol < 0x100);
+      }
+      while (symbol < 0x100)
+      {
+        CProb *probLit = prob + symbol;
+        RC_GET_BIT(probLit, symbol)
+      }
+      previousByte = (Byte)symbol;
+
+      outStream[nowPos++] = previousByte;
+      #ifdef _LZMA_OUT_READ
+      if (distanceLimit < dictionarySize)
+        distanceLimit++;
+
+      dictionary[dictionaryPos] = previousByte;
+      if (++dictionaryPos == dictionarySize)
+        dictionaryPos = 0;
+      #endif
+      if (state < 4) state = 0;
+      else if (state < 10) state -= 3;
+      else state -= 6;
+    }
+    else
+    {
+      UpdateBit1(prob);
+      prob = p + IsRep + state;
+      IfBit0(prob)
+      {
+        UpdateBit0(prob);
+        rep3 = rep2;
+        rep2 = rep1;
+        rep1 = rep0;
+        state = state < kNumLitStates ? 0 : 3;
+        prob = p + LenCoder;
+      }
+      else
+      {
+        UpdateBit1(prob);
+        prob = p + IsRepG0 + state;
+        IfBit0(prob)
+        {
+          UpdateBit0(prob);
+          prob = p + IsRep0Long + (state << kNumPosBitsMax) + posState;
+          IfBit0(prob)
+          {
+            #ifdef _LZMA_OUT_READ
+            UInt32 pos;
+            #endif
+            UpdateBit0(prob);
+
+            #ifdef _LZMA_OUT_READ
+            if (distanceLimit == 0)
+            #else
+            if (nowPos == 0)
+            #endif
+              return LZMA_RESULT_DATA_ERROR;
+
+            state = state < kNumLitStates ? 9 : 11;
+            #ifdef _LZMA_OUT_READ
+            pos = dictionaryPos - rep0;
+            if (pos >= dictionarySize)
+              pos += dictionarySize;
+            previousByte = dictionary[pos];
+            dictionary[dictionaryPos] = previousByte;
+            if (++dictionaryPos == dictionarySize)
+              dictionaryPos = 0;
+            #else
+            previousByte = outStream[nowPos - rep0];
+            #endif
+            outStream[nowPos++] = previousByte;
+            #ifdef _LZMA_OUT_READ
+            if (distanceLimit < dictionarySize)
+              distanceLimit++;
+            #endif
+
+            continue;
+          }
+          else
+          {
+            UpdateBit1(prob);
+          }
+        }
+        else
+        {
+          UInt32 distance;
+          UpdateBit1(prob);
+          prob = p + IsRepG1 + state;
+          IfBit0(prob)
+          {
+            UpdateBit0(prob);
+            distance = rep1;
+          }
+          else
+          {
+            UpdateBit1(prob);
+            prob = p + IsRepG2 + state;
+            IfBit0(prob)
+            {
+              UpdateBit0(prob);
+              distance = rep2;
+            }
+            else
+            {
+              UpdateBit1(prob);
+              distance = rep3;
+              rep3 = rep2;
+            }
+            rep2 = rep1;
+          }
+          rep1 = rep0;
+          rep0 = distance;
+        }
+        state = state < kNumLitStates ? 8 : 11;
+        prob = p + RepLenCoder;
+      }
+      {
+        int numBits, offset;
+        CProb *probLen = prob + LenChoice;
+        IfBit0(probLen)
+        {
+          UpdateBit0(probLen);
+          probLen = prob + LenLow + (posState << kLenNumLowBits);
+          offset = 0;
+          numBits = kLenNumLowBits;
+        }
+        else
+        {
+          UpdateBit1(probLen);
+          probLen = prob + LenChoice2;
+          IfBit0(probLen)
+          {
+            UpdateBit0(probLen);
+            probLen = prob + LenMid + (posState << kLenNumMidBits);
+            offset = kLenNumLowSymbols;
+            numBits = kLenNumMidBits;
+          }
+          else
+          {
+            UpdateBit1(probLen);
+            probLen = prob + LenHigh;
+            offset = kLenNumLowSymbols + kLenNumMidSymbols;
+            numBits = kLenNumHighBits;
+          }
+        }
+        RangeDecoderBitTreeDecode(probLen, numBits, len);
+        len += offset;
+      }
+
+      if (state < 4)
+      {
+        int posSlot;
+        state += kNumLitStates;
+        prob = p + PosSlot +
+            ((len < kNumLenToPosStates ? len : kNumLenToPosStates - 1) <<
+            kNumPosSlotBits);
+        RangeDecoderBitTreeDecode(prob, kNumPosSlotBits, posSlot);
+        if (posSlot >= kStartPosModelIndex)
+        {
+          int numDirectBits = ((posSlot >> 1) - 1);
+          rep0 = (2 | ((UInt32)posSlot & 1));
+          if (posSlot < kEndPosModelIndex)
+          {
+            rep0 <<= numDirectBits;
+            prob = p + SpecPos + rep0 - posSlot - 1;
+          }
+          else
+          {
+            numDirectBits -= kNumAlignBits;
+            do
+            {
+              RC_NORMALIZE
+              Range >>= 1;
+              rep0 <<= 1;
+              if (Code >= Range)
+              {
+                Code -= Range;
+                rep0 |= 1;
+              }
+            }
+            while (--numDirectBits != 0);
+            prob = p + Align;
+            rep0 <<= kNumAlignBits;
+            numDirectBits = kNumAlignBits;
+          }
+          {
+            int i = 1;
+            int mi = 1;
+            do
+            {
+              CProb *prob3 = prob + mi;
+              RC_GET_BIT2(prob3, mi, ; , rep0 |= i);
+              i <<= 1;
+            }
+            while(--numDirectBits != 0);
+          }
+        }
+        else
+          rep0 = posSlot;
+        if (++rep0 == (UInt32)(0))
+        {
+          /* it's for stream version */
+          len = kLzmaStreamWasFinishedId;
+          break;
+        }
+      }
+
+      len += kMatchMinLen;
+      #ifdef _LZMA_OUT_READ
+      if (rep0 > distanceLimit)
+      #else
+      if (rep0 > nowPos)
+      #endif
+        return LZMA_RESULT_DATA_ERROR;
+
+      #ifdef _LZMA_OUT_READ
+      if (dictionarySize - distanceLimit > (UInt32)len)
+        distanceLimit += len;
+      else
+        distanceLimit = dictionarySize;
+      #endif
+
+      do
+      {
+        #ifdef _LZMA_OUT_READ
+        UInt32 pos = dictionaryPos - rep0;
+        if (pos >= dictionarySize)
+          pos += dictionarySize;
+        previousByte = dictionary[pos];
+        dictionary[dictionaryPos] = previousByte;
+        if (++dictionaryPos == dictionarySize)
+          dictionaryPos = 0;
+        #else
+        previousByte = outStream[nowPos - rep0];
+        #endif
+        len--;
+        outStream[nowPos++] = previousByte;
+      }
+      while(len != 0 && nowPos < outSize);
+    }
+  }
+  RC_NORMALIZE;
+
+  #ifdef _LZMA_OUT_READ
+  vs->Range = Range;
+  vs->Code = Code;
+  vs->DictionaryPos = dictionaryPos;
+  vs->GlobalPos = globalPos + (UInt32)nowPos;
+  vs->DistanceLimit = distanceLimit;
+  vs->Reps[0] = rep0;
+  vs->Reps[1] = rep1;
+  vs->Reps[2] = rep2;
+  vs->Reps[3] = rep3;
+  vs->State = state;
+  vs->RemainLen = len;
+  vs->TempDictionary[0] = tempDictionary[0];
+  #endif
+
+  #ifdef _LZMA_IN_CB
+  vs->Buffer = Buffer;
+  vs->BufferLim = BufferLim;
+  #else
+  *inSizeProcessed = (SizeT)(Buffer - inStream);
+  #endif
+  *outSizeProcessed = nowPos;
+  return LZMA_RESULT_OK;
+}

--- a/target/linux/econet/image/lzma-loader/src/LzmaDecode.h
+++ b/target/linux/econet/image/lzma-loader/src/LzmaDecode.h
@@ -1,0 +1,113 @@
+/*
+  LzmaDecode.h
+  LZMA Decoder interface
+
+  LZMA SDK 4.40 Copyright (c) 1999-2006 Igor Pavlov (2006-05-01)
+  http://www.7-zip.org/
+
+  LZMA SDK is licensed under two licenses:
+  1) GNU Lesser General Public License (GNU LGPL)
+  2) Common Public License (CPL)
+  It means that you can select one of these two licenses and
+  follow rules of that license.
+
+  SPECIAL EXCEPTION:
+  Igor Pavlov, as the author of this code, expressly permits you to
+  statically or dynamically link your code (or bind by name) to the
+  interfaces of this file without subjecting your linked code to the
+  terms of the CPL or GNU LGPL. Any modifications or additions
+  to this file, however, are subject to the LGPL or CPL terms.
+*/
+
+#ifndef __LZMADECODE_H
+#define __LZMADECODE_H
+
+#include "LzmaTypes.h"
+
+/* #define _LZMA_IN_CB */
+/* Use callback for input data */
+
+/* #define _LZMA_OUT_READ */
+/* Use read function for output data */
+
+/* #define _LZMA_PROB32 */
+/* It can increase speed on some 32-bit CPUs,
+   but memory usage will be doubled in that case */
+
+/* #define _LZMA_LOC_OPT */
+/* Enable local speed optimizations inside code */
+
+#ifdef _LZMA_PROB32
+#define CProb UInt32
+#else
+#define CProb UInt16
+#endif
+
+#define LZMA_RESULT_OK 0
+#define LZMA_RESULT_DATA_ERROR 1
+
+#ifdef _LZMA_IN_CB
+typedef struct _ILzmaInCallback
+{
+  int (*Read)(void *object, const unsigned char **buffer, SizeT *bufferSize);
+} ILzmaInCallback;
+#endif
+
+#define LZMA_BASE_SIZE 1846
+#define LZMA_LIT_SIZE 768
+
+#define LZMA_PROPERTIES_SIZE 5
+
+typedef struct _CLzmaProperties
+{
+  int lc;
+  int lp;
+  int pb;
+  #ifdef _LZMA_OUT_READ
+  UInt32 DictionarySize;
+  #endif
+}CLzmaProperties;
+
+int LzmaDecodeProperties(CLzmaProperties *propsRes, const unsigned char *propsData, int size);
+
+#define LzmaGetNumProbs(Properties) (LZMA_BASE_SIZE + (LZMA_LIT_SIZE << ((Properties)->lc + (Properties)->lp)))
+
+#define kLzmaNeedInitId (-2)
+
+typedef struct _CLzmaDecoderState
+{
+  CLzmaProperties Properties;
+  CProb *Probs;
+
+  #ifdef _LZMA_IN_CB
+  const unsigned char *Buffer;
+  const unsigned char *BufferLim;
+  #endif
+
+  #ifdef _LZMA_OUT_READ
+  unsigned char *Dictionary;
+  UInt32 Range;
+  UInt32 Code;
+  UInt32 DictionaryPos;
+  UInt32 GlobalPos;
+  UInt32 DistanceLimit;
+  UInt32 Reps[4];
+  int State;
+  int RemainLen;
+  unsigned char TempDictionary[4];
+  #endif
+} CLzmaDecoderState;
+
+#ifdef _LZMA_OUT_READ
+#define LzmaDecoderInit(vs) { (vs)->RemainLen = kLzmaNeedInitId; }
+#endif
+
+int LzmaDecode(CLzmaDecoderState *vs,
+    #ifdef _LZMA_IN_CB
+    ILzmaInCallback *inCallback,
+    #else
+    const unsigned char *inStream, SizeT inSize, SizeT *inSizeProcessed,
+    #endif
+    unsigned char *outStream, SizeT outSize, SizeT *outSizeProcessed);
+
+#endif

--- a/target/linux/econet/image/lzma-loader/src/LzmaTypes.h
+++ b/target/linux/econet/image/lzma-loader/src/LzmaTypes.h
@@ -1,0 +1,45 @@
+/*
+LzmaTypes.h
+
+Types for LZMA Decoder
+
+This file written and distributed to public domain by Igor Pavlov.
+This file is part of LZMA SDK 4.40 (2006-05-01)
+*/
+
+#ifndef __LZMATYPES_H
+#define __LZMATYPES_H
+
+#ifndef _7ZIP_BYTE_DEFINED
+#define _7ZIP_BYTE_DEFINED
+typedef unsigned char Byte;
+#endif
+
+#ifndef _7ZIP_UINT16_DEFINED
+#define _7ZIP_UINT16_DEFINED
+typedef unsigned short UInt16;
+#endif
+
+#ifndef _7ZIP_UINT32_DEFINED
+#define _7ZIP_UINT32_DEFINED
+#ifdef _LZMA_UINT32_IS_ULONG
+typedef unsigned long UInt32;
+#else
+typedef unsigned int UInt32;
+#endif
+#endif
+
+/* #define _LZMA_NO_SYSTEM_SIZE_T */
+/* You can use it, if you don't want <stddef.h> */
+
+#ifndef _7ZIP_SIZET_DEFINED
+#define _7ZIP_SIZET_DEFINED
+#ifdef _LZMA_NO_SYSTEM_SIZE_T
+typedef UInt32 SizeT;
+#else
+#include <stddef.h>
+typedef size_t SizeT;
+#endif
+#endif
+
+#endif

--- a/target/linux/econet/image/lzma-loader/src/Makefile
+++ b/target/linux/econet/image/lzma-loader/src/Makefile
@@ -1,0 +1,162 @@
+# Makefile for the LZMA compressed kernel loader for EcoNet based boards
+#
+# Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
+#
+# Some parts of this file was based on the OpenWrt specific lzma-loader
+# for the BCM47xx and ADM5120 based boards:
+#	Copyright (C) 2004 Manuel Novoa III (mjn3@codepoet.org)
+#	Copyright (C) 2005 Mineharu Takahara <mtakahar@yahoo.com>
+#	Copyright (C) 2005 by Oleg I. Vdovikin <oleg@cs.msu.su>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation.
+#
+
+LOADADDR	:=
+LZMA_TEXT_START	:= 0x80002000
+LOADER_DATA	:=
+BOARD		:=
+FLASH_START	:=
+FLASH_OFFS	:=
+FLASH_MAX	:=
+PLATFORM	:=
+SUBTARGET	:=
+CACHE_FLAGS	:=
+
+CC		:= $(CROSS_COMPILE)gcc
+LD		:= $(CROSS_COMPILE)ld
+OBJCOPY		:= $(CROSS_COMPILE)objcopy
+OBJDUMP		:= $(CROSS_COMPILE)objdump
+
+
+BIN_FLAGS	:= -O binary -R .reginfo -R .note -R .comment -R .mdebug \
+		   -R .MIPS.abiflags -S
+
+CFLAGS		= -D__KERNEL__ -Wall -Wstrict-prototypes -Wno-trigraphs -Os \
+		  -fno-strict-aliasing -fno-common -fomit-frame-pointer -G 0 \
+		  -mno-abicalls -fno-pic -ffunction-sections -pipe -mlong-calls \
+		  -fno-common -ffreestanding -fhonour-copts -nostartfiles \
+		  -mabi=32 -march=mips32r2 \
+		  -Wa,-32 -Wa,-march=mips32r2 -Wa,-mips32r2 -Wa,--trap
+CFLAGS		+= -D_LZMA_PROB32
+CFLAGS		+= -flto
+CFLAGS		+= $(CACHE_FLAGS)
+
+ASFLAGS		= $(CFLAGS) -D__ASSEMBLY__
+
+LDFLAGS		= -static -Wl,--gc-sections -Wl,-no-warn-mismatch
+LDFLAGS		+= -Wl,-e,startup -T loader.lds -Wl,-Ttext,$(LZMA_TEXT_START)
+LDFLAGS		+= -flto -fwhole-program -Wl,-z,max-page-size=4096
+
+O_FORMAT 	= $(shell $(OBJDUMP) -i | head -2 | grep elf32)
+
+OBJECTS		:= head.o loader.o cache.o board.o printf.o LzmaDecode.o
+
+# Add NAND boot support objects
+ifneq ($(strip $(NAND_BOOT)),)
+OBJECTS		+= string.o spi_controller.o spi_nand.o bmt.o nand_boot.o
+CFLAGS		+= -DCONFIG_NAND_BOOT=1
+
+# Per-device NAND configuration (all optional, defaults in nand_boot.h)
+# BBT table size (default 1000, Genexis uses 250)
+ifneq ($(strip $(MAX_BBT_SIZE)),)
+CFLAGS		+= -DMAX_BBT_SIZE=$(MAX_BBT_SIZE)
+endif
+# OS1 partition offset (default 0x80000)
+ifneq ($(strip $(NAND_OS1_OFFSET)),)
+CFLAGS		+= -DCONFIG_NAND_OS1_OFFSET=$(NAND_OS1_OFFSET)
+endif
+# OS2 partition offset (default 0x1080000)
+ifneq ($(strip $(NAND_OS2_OFFSET)),)
+CFLAGS		+= -DCONFIG_NAND_OS2_OFFSET=$(NAND_OS2_OFFSET)
+endif
+# Boot flag absolute address (default 0x6FC0000)
+ifneq ($(strip $(NAND_BOOT_FLAG_OFFSET)),)
+CFLAGS		+= -DCONFIG_NAND_BOOT_FLAG_OFFSET=$(NAND_BOOT_FLAG_OFFSET)
+endif
+# Boot flag codes (default "30"/"31" for ASCII '0'/'1')
+ifneq ($(strip $(NAND_BOOT_FLAG_OS1)),)
+CFLAGS		+= -DCONFIG_NAND_BOOT_FLAG_OS1='"$(NAND_BOOT_FLAG_OS1)"'
+endif
+ifneq ($(strip $(NAND_BOOT_FLAG_OS2)),)
+CFLAGS		+= -DCONFIG_NAND_BOOT_FLAG_OS2='"$(NAND_BOOT_FLAG_OS2)"'
+endif
+# Boot flag mask (optional, use 'X' for bits to compare)
+ifneq ($(strip $(NAND_BOOT_FLAG_MASK)),)
+CFLAGS		+= -DCONFIG_NAND_BOOT_FLAG_MASK='"$(NAND_BOOT_FLAG_MASK)"'
+endif
+# Kernel cmdline for OS1 partition (default "root=/dev/mtdblock3")
+ifneq ($(strip $(NAND_CMDLINE_OS1)),)
+CFLAGS		+= -DCONFIG_NAND_CMDLINE_OS1='"$(NAND_CMDLINE_OS1)"'
+endif
+# Kernel cmdline for OS2 partition (default "root=/dev/mtdblock5")
+ifneq ($(strip $(NAND_CMDLINE_OS2)),)
+CFLAGS		+= -DCONFIG_NAND_CMDLINE_OS2='"$(NAND_CMDLINE_OS2)"'
+endif
+endif
+
+ifeq ($(strip $(SUBTARGET)),)
+$(error "Please specify a SUBTARGET!")
+endif
+
+ifeq ($(strip $(SUBTARGET)),en751221)
+CFLAGS	+= -DSOC_EN751221
+endif
+
+ifneq ($(strip $(LOADER_DATA)),)
+OBJECTS		+= data.o
+CFLAGS		+= -DLZMA_WRAPPER=1 -DLOADADDR=$(LOADADDR)
+endif
+
+ifneq ($(strip $(KERNEL_CMDLINE)),)
+CFLAGS		+= -DCONFIG_KERNEL_CMDLINE='"$(KERNEL_CMDLINE)"'
+endif
+
+ifneq ($(strip $(FLASH_START)),)
+CFLAGS		+= -DCONFIG_FLASH_START=$(FLASH_START)
+endif
+
+ifneq ($(strip $(FLASH_OFFS)),)
+CFLAGS		+= -DCONFIG_FLASH_OFFS=$(FLASH_OFFS)
+endif
+
+ifneq ($(strip $(FLASH_MAX)),)
+CFLAGS		+= -DCONFIG_FLASH_MAX=$(FLASH_MAX)
+endif
+
+all: loader.elf
+
+# Don't build dependencies, this may die if $(CC) isn't gcc
+dep:
+
+install:
+
+%.o : %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+%.o : %.S
+	$(CC) $(ASFLAGS) -c -o $@ $<
+
+data.o: $(LOADER_DATA)
+	$(LD) -r -b binary --oformat $(O_FORMAT) -T lzma-data.lds -o $@ $<
+
+loader: $(OBJECTS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJECTS)
+
+loader.bin: loader
+	$(OBJCOPY) $(BIN_FLAGS) $< $@
+
+loader2.o: loader.bin
+	$(LD) -r -b binary --oformat $(O_FORMAT) -o $@ $<
+
+loader.elf: loader2.o
+	$(LD) -e startup -T loader2.lds -Ttext $(LOADADDR) -z max-page-size=4096 -o $@ $<
+
+mrproper: clean
+
+clean:
+	rm -f loader *.elf *.bin *.o
+
+
+

--- a/target/linux/econet/image/lzma-loader/src/bmt.c
+++ b/target/linux/econet/image/lzma-loader/src/bmt.c
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * BMT (Bad Block Management Table) driver for EcoNet EN751221 SoC
+ *
+ * Minimal read-only implementation for lzma-loader boot support.
+ * Handles both BBT (factory bad blocks) and BMT (worn blocks).
+ *
+ * Copyright (C) 2025 Ahmed Naseef <naseefkm@gmail.com>
+ */
+
+#include "bmt.h"
+#include "spi_nand.h"
+#include "printf.h"
+#include <string.h>
+
+/* Global BMT context */
+static struct bmt_context bmt_ctx;
+
+/* Working buffers for page reads - sized for maximum supported flash geometry */
+static uint8_t page_buf[SPINAND_MAX_PAGE_SIZE];
+static uint8_t oob_buf[SPINAND_MAX_OOB_SIZE];
+
+/*
+ * Calculate BBT checksum
+ * Checksums version + size + all table entries
+ */
+static uint16_t bbt_calc_checksum(const struct bbt_table *bbt)
+{
+    const uint8_t *data = (const uint8_t *)bbt->table;
+    uint16_t checksum = 0;
+    uint32_t i;
+
+    /* Add header fields */
+    checksum += bbt->header.version;
+    checksum += bbt->header.size;
+
+    /* Add all table data */
+    for (i = 0; i < sizeof(bbt->table); i++) {
+        checksum += data[i];
+    }
+
+    return checksum;
+}
+
+/*
+ * Calculate BMT checksum
+ * Checksums version + size + table entries (up to size count)
+ */
+static uint8_t bmt_calc_checksum(const struct bmt_table *bmt)
+{
+    const uint8_t *data = (const uint8_t *)bmt->table;
+    uint8_t checksum = 0;
+    uint32_t i, table_bytes;
+
+    /* Add header fields */
+    checksum += bmt->header.version;
+    checksum += bmt->header.size;
+
+    /* Add table data (all reserve_block_count entries) */
+    table_bytes = bmt_ctx.reserve_block_count * sizeof(struct bmt_entry);
+    if (table_bytes > sizeof(bmt->table))
+        table_bytes = sizeof(bmt->table);
+
+    for (i = 0; i < table_bytes; i++) {
+        checksum += data[i];
+    }
+
+    return checksum;
+}
+
+/*
+ * Check if a block is bad by reading its OOB marker
+ * Returns: 1 if bad, 0 if good, -1 on read error
+ */
+static int is_block_bad(uint32_t block)
+{
+    uint32_t page;
+    uint8_t marker;
+
+    /* Read first page of block */
+    page = block * bmt_ctx.pages_per_block;
+
+    if (spi_nand_read_page_with_oob(page, page_buf, oob_buf) < 0)
+        return -1;  /* Read error - assume bad */
+
+    /* Check bad block marker (first byte of OOB) */
+    marker = oob_buf[0];
+
+    return (marker != BAD_BLOCK_MARKER_GOOD) ? 1 : 0;
+}
+
+/*
+ * Scan reserve area from end to find good blocks
+ * Calculate reserve area start based on REQUIRED_GOOD_BLOCKS
+ */
+static int bmt_scan_reserve_area(void)
+{
+    uint32_t block;
+    uint32_t good_blocks = 0;
+    uint32_t required_good;
+
+    /* Calculate how many good blocks we need (8% of total) */
+    required_good = (bmt_ctx.total_blocks * RESERVE_PERCENT) / 100;
+
+    printf("BMT: Scanning for reserve area (need %d good blocks)\n", required_good);
+
+    /* Scan from end of flash backwards */
+    for (block = bmt_ctx.total_blocks; block > 0; block--) {
+        int bad = is_block_bad(block - 1);
+
+        if (bad < 0) {
+            /* Read error - skip this block */
+            printf("BMT: Block %d read error, skipping\n", block - 1);
+            continue;
+        }
+
+        if (!bad) {
+            /* Good block found */
+            good_blocks++;
+        }
+
+        /* Once we have enough good blocks, this is the reserve start */
+        if (good_blocks >= required_good) {
+            bmt_ctx.reserve_start_block = block - 1;
+            bmt_ctx.reserve_block_count = bmt_ctx.total_blocks - bmt_ctx.reserve_start_block;
+            printf("BMT: Reserve area: blocks %d-%d (%d blocks, %d good)\n",
+                   bmt_ctx.reserve_start_block,
+                   bmt_ctx.total_blocks - 1,
+                   bmt_ctx.reserve_block_count,
+                   good_blocks);
+            return 0;
+        }
+    }
+
+    printf("BMT: ERROR: Could not find enough good blocks for reserve area\n");
+    return -1;
+}
+
+/*
+ * Load BBT from reserve area
+ * BBT is at the bottom (first good block) of reserve area
+ */
+static int bmt_load_bbt(void)
+{
+    uint32_t block;
+    uint32_t page;
+    const struct bbt_table *bbt;
+    uint16_t checksum;
+
+    printf("BMT: Searching for BBT in reserve area\n");
+
+    /* Scan from start of reserve area upwards */
+    for (block = bmt_ctx.reserve_start_block;
+         block < bmt_ctx.total_blocks;
+         block++) {
+
+        /* Skip bad blocks */
+        if (is_block_bad(block))
+            continue;
+
+        /* Read first page */
+        page = block * bmt_ctx.pages_per_block;
+        if (spi_nand_read_page(page, page_buf) < 0)
+            continue;
+
+        /* Check signature */
+        bbt = (const struct bbt_table *)page_buf;
+        if (memcmp(bbt->header.signature, BBT_SIGNATURE, BBT_SIGNATURE_SIZE) != 0)
+            continue;
+
+        printf("BMT: Found BBT signature at block %d\n", block);
+
+        /* Verify checksum */
+        checksum = bbt_calc_checksum(bbt);
+        if ((bbt->header.checksum & 0xFFFF) != checksum) {
+            printf("BMT: BBT checksum mismatch (expected 0x%04x, got 0x%04x)\n",
+                   (bbt->header.checksum & 0xFFFF), checksum);
+            continue;
+        }
+
+        /* Verify version */
+        if (bbt->header.version != BBT_VERSION) {
+            printf("BMT: BBT version mismatch (expected %d, got %d)\n",
+                   BBT_VERSION, bbt->header.version);
+            continue;
+        }
+
+        /* Valid BBT found - copy to context */
+        memcpy(&bmt_ctx.bbt, bbt, sizeof(bmt_ctx.bbt));
+        bmt_ctx.bbt_block = block;
+
+        printf("BMT: Loaded BBT v%d, %d bad blocks\n",
+               bbt->header.version, bbt->header.size);
+
+        return 0;
+    }
+
+    printf("BMT: WARNING: No valid BBT found, assuming no factory bad blocks\n");
+    /* Initialize empty BBT */
+    memset(&bmt_ctx.bbt, 0xFF, sizeof(bmt_ctx.bbt));
+    memcpy(bmt_ctx.bbt.header.signature, BBT_SIGNATURE, BBT_SIGNATURE_SIZE);
+    bmt_ctx.bbt.header.version = BBT_VERSION;
+    bmt_ctx.bbt.header.size = 0;
+    bmt_ctx.bbt.header.checksum = bbt_calc_checksum(&bmt_ctx.bbt);
+    bmt_ctx.bbt_block = 0;
+
+    return 0;
+}
+
+/*
+ * Load BMT from reserve area
+ * BMT is at the top (last good block) of reserve area
+ */
+static int bmt_load_bmt(void)
+{
+    uint32_t block;
+    uint32_t page;
+    const struct bmt_table *bmt;
+    uint8_t checksum;
+
+    printf("BMT: Searching for BMT in reserve area\n");
+
+    /* Scan from end of flash backwards */
+    for (block = bmt_ctx.total_blocks; block > bmt_ctx.reserve_start_block; block--) {
+
+        /* Skip bad blocks */
+        if (is_block_bad(block - 1))
+            continue;
+
+        /* Read first page */
+        page = (block - 1) * bmt_ctx.pages_per_block;
+        if (spi_nand_read_page(page, page_buf) < 0)
+            continue;
+
+        /* Check signature */
+        bmt = (const struct bmt_table *)page_buf;
+        if (memcmp(bmt->header.signature, BMT_SIGNATURE, BMT_SIGNATURE_SIZE) != 0)
+            continue;
+
+        printf("BMT: Found BMT signature at block %d\n", block - 1);
+
+        /* Verify checksum */
+        checksum = bmt_calc_checksum(bmt);
+        if (bmt->header.checksum != checksum) {
+            printf("BMT: BMT checksum mismatch (expected 0x%02x, got 0x%02x)\n",
+                   bmt->header.checksum, checksum);
+            continue;
+        }
+
+        /* Verify version */
+        if (bmt->header.version != BMT_VERSION) {
+            printf("BMT: BMT version mismatch (expected %d, got %d)\n",
+                   BMT_VERSION, bmt->header.version);
+            continue;
+        }
+
+        /* Valid BMT found - copy to context */
+        memcpy(&bmt_ctx.bmt, bmt, sizeof(bmt_ctx.bmt));
+        bmt_ctx.bmt_block = block - 1;
+
+        printf("BMT: Loaded BMT v%d, %d mappings\n",
+               bmt->header.version, bmt->header.size);
+
+        return 0;
+    }
+
+    printf("BMT: No valid BMT found, assuming no worn blocks\n");
+    /* Initialize empty BMT */
+    memset(&bmt_ctx.bmt, 0xFF, sizeof(bmt_ctx.bmt));
+    memcpy(bmt_ctx.bmt.header.signature, BMT_SIGNATURE, BMT_SIGNATURE_SIZE);
+    bmt_ctx.bmt.header.version = BMT_VERSION;
+    bmt_ctx.bmt.header.size = 0;
+    bmt_ctx.bmt.header.bad_count = 0;
+    bmt_ctx.bmt.header.checksum = bmt_calc_checksum(&bmt_ctx.bmt);
+    bmt_ctx.bmt_block = 0;
+
+    return 0;
+}
+
+/*
+ * Initialize BMT subsystem
+ */
+int bmt_init(uint32_t total_blocks, uint32_t pages_per_block, uint32_t page_size)
+{
+    /* Store geometry */
+    bmt_ctx.total_blocks = total_blocks;
+    bmt_ctx.pages_per_block = pages_per_block;
+    bmt_ctx.page_size = page_size;
+
+    printf("BMT: Initializing (total blocks: %d)\n", total_blocks);
+
+    /* Scan for reserve area */
+    if (bmt_scan_reserve_area() < 0)
+        return -1;
+
+    /* Load BBT */
+    if (bmt_load_bbt() < 0)
+        return -1;
+
+    /* Load BMT */
+    if (bmt_load_bmt() < 0)
+        return -1;
+
+    printf("BMT: Initialization complete\n");
+    printf("  User area: blocks 0-%d\n", bmt_ctx.reserve_start_block - 1);
+    printf("  Reserve area: blocks %d-%d\n",
+           bmt_ctx.reserve_start_block, bmt_ctx.total_blocks - 1);
+    printf("  Factory bad blocks: %d\n", bmt_ctx.bbt.header.size);
+    printf("  Worn block mappings: %d\n", bmt_ctx.bmt.header.size);
+
+    return 0;
+}
+
+/*
+ * Translate logical block through BBT
+ * Factory bad blocks cause all subsequent blocks to shift up by one
+ */
+static int bmt_translate_bbt(uint32_t block)
+{
+    uint32_t i;
+    uint32_t physical = block;
+
+    /* For each factory bad block <= logical block, increment physical block */
+    for (i = 0; i < bmt_ctx.bbt.header.size; i++) {
+        if (bmt_ctx.bbt.table[i] <= physical) {
+            physical++;
+        }
+    }
+
+    /* Ensure we didn't go into reserve area */
+    if (physical >= bmt_ctx.reserve_start_block) {
+        printf("BMT: ERROR: Block %d translates to reserve area (%d)\n",
+               block, physical);
+        return -1;
+    }
+
+    return physical;
+}
+
+/*
+ * Translate logical block through BMT
+ * Worn blocks are remapped to replacement blocks in reserve area
+ */
+static int bmt_translate_bmt(uint32_t block)
+{
+    uint32_t i;
+
+    /* Check if block is mapped */
+    for (i = 0; i < bmt_ctx.bmt.header.size; i++) {
+        if (bmt_ctx.bmt.table[i].from == block) {
+            printf("BMT: Block %d -> %d (mapped)\n",
+                   block, bmt_ctx.bmt.table[i].to);
+            return bmt_ctx.bmt.table[i].to;
+        }
+    }
+
+    /* Not mapped, return original block */
+    return block;
+}
+
+/*
+ * Translate logical block to physical block
+ * Applies both BBT and BMT translations
+ */
+int bmt_translate_block(uint32_t block)
+{
+    int physical;
+
+    /* First translate through BBT (factory bad blocks) */
+    physical = bmt_translate_bbt(block);
+    if (physical < 0)
+        return -1;
+
+    /* Then translate through BMT (worn blocks) */
+    physical = bmt_translate_bmt(physical);
+    if (physical < 0)
+        return -1;
+
+    return physical;
+}
+
+/*
+ * Translate logical page to physical page
+ */
+int bmt_translate_page(uint32_t page)
+{
+    uint32_t block, page_offset;
+    int physical_block;
+
+    /* Extract block and page offset */
+    block = page / bmt_ctx.pages_per_block;
+    page_offset = page % bmt_ctx.pages_per_block;
+
+    /* Translate block */
+    physical_block = bmt_translate_block(block);
+    if (physical_block < 0)
+        return -1;
+
+    /* Reconstruct page number */
+    return (physical_block * bmt_ctx.pages_per_block) + page_offset;
+}
+
+/*
+ * Get BMT context
+ */
+const struct bmt_context *bmt_get_context(void)
+{
+    return &bmt_ctx;
+}

--- a/target/linux/econet/image/lzma-loader/src/bmt.h
+++ b/target/linux/econet/image/lzma-loader/src/bmt.h
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * BMT (Bad Block Management Table) driver for EcoNet EN751221 SoC
+ *
+ * Minimal read-only implementation for lzma-loader boot support.
+ * Handles both BBT (factory bad blocks) and BMT (worn blocks).
+ *
+ * Copyright (C) 2025 Ahmed Naseef <naseefkm@gmail.com>
+ */
+
+#ifndef _BMT_H_
+#define _BMT_H_
+
+#include <stdint.h>
+
+/*
+ * BBT (Bad Block Table) - Factory Bad Blocks
+ *
+ * The BBT contains blocks that were marked bad at the factory.
+ * When a block is in the BBT, all blocks after it are shifted up by one,
+ * so block addresses must be translated through the BBT before using them.
+ *
+ * The BBT is stored at the bottom of the reserve area (first good block).
+ * Signature: "RAWB", Version: 1
+ */
+
+#define BBT_SIGNATURE               "RAWB"
+#define BBT_SIGNATURE_SIZE          4
+#define BBT_VERSION                 1
+
+/* Default 1000, Genexis devices use 250 */
+#ifndef MAX_BBT_SIZE
+#define MAX_BBT_SIZE                1000
+#endif
+
+struct bbt_header {
+    char     signature[4];          /* "RAWB" */
+    uint32_t checksum;              /* 16-bit checksum in lower 16 bits */
+    uint8_t  version;               /* 1 */
+    uint8_t  size;                  /* Number of bad blocks in table */
+    uint8_t  reserved[2];           /* Unused (0xFFFF) */
+} __attribute__((packed));
+
+struct bbt_table {
+    struct bbt_header header;
+    uint16_t table[MAX_BBT_SIZE];   /* Bad block indices (sorted ascending) */
+} __attribute__((packed));
+
+/*
+ * BMT (Block Mapping Table) - Worn Blocks
+ *
+ * The BMT contains mappings from bad blocks (that failed after factory)
+ * to replacement blocks in the reserve area. This allows remapping of
+ * blocks that wear out over time.
+ *
+ * The BMT is stored at the top of the reserve area (last good block).
+ * Signature: "BMT", Version: 1
+ */
+
+#define BMT_SIGNATURE               "BMT"
+#define BMT_SIGNATURE_SIZE          3
+#define BMT_VERSION                 1
+#define MAX_BMT_SIZE                256
+
+struct bmt_header {
+    char    signature[3];           /* "BMT" */
+    uint8_t version;                /* 1 */
+    uint8_t bad_count;              /* Unused */
+    uint8_t size;                   /* Number of mappings in table */
+    uint8_t checksum;               /* Checksum of header + table */
+    uint8_t reserved[13];           /* Unused */
+} __attribute__((packed));
+
+struct bmt_entry {
+    uint16_t from;                  /* Bad block index (logical) */
+    uint16_t to;                    /* Replacement block index (physical, in reserve area) */
+} __attribute__((packed));
+
+struct bmt_table {
+    struct bmt_header header;
+    struct bmt_entry table[MAX_BMT_SIZE];
+} __attribute__((packed));
+
+/*
+ * Reserve Area Configuration
+ *
+ * The reserve area is located at the end of the flash and contains:
+ * - BBT block (at bottom/start of reserve area)
+ * - Free blocks and mapped blocks (middle)
+ * - BMT block (at top/end of reserve area)
+ *
+ * The reserve area size is calculated by counting down from the end
+ * until we have REQUIRED_GOOD_BLOCKS good (non-bad) blocks.
+ * This is typically 8% of the total flash size.
+ */
+
+/* Reserve area = 8% of total blocks */
+#define RESERVE_PERCENT             8
+
+/*
+ * Bad block marker in OOB
+ * - 0x00: Factory bad block
+ * - 0x55: Worn block (marked by BMT system)
+ * - 0xFF: Good block
+ */
+#define BAD_BLOCK_MARKER_FACTORY    0x00
+#define BAD_BLOCK_MARKER_WORN       0x55
+#define BAD_BLOCK_MARKER_GOOD       0xFF
+
+/*
+ * BMT Context
+ *
+ * This structure holds the runtime BMT state including:
+ * - Loaded BBT and BMT tables
+ * - Reserve area boundaries
+ * - Flash geometry
+ */
+struct bmt_context {
+    /* Flash geometry */
+    uint32_t total_blocks;          /* Total blocks in flash */
+    uint32_t pages_per_block;       /* Pages per block */
+    uint32_t page_size;             /* Page size in bytes */
+
+    /* Reserve area */
+    uint32_t reserve_start_block;   /* First block of reserve area */
+    uint32_t reserve_block_count;   /* Number of blocks in reserve */
+
+    /* Loaded tables */
+    struct bbt_table bbt;           /* Factory bad block table */
+    struct bmt_table bmt;           /* Worn block mapping table */
+
+    /* Table block locations */
+    uint32_t bbt_block;             /* Block where BBT is stored */
+    uint32_t bmt_block;             /* Block where BMT is stored */
+};
+
+/*
+ * Function prototypes
+ */
+
+/**
+ * bmt_init - Initialize BMT subsystem
+ * @total_blocks: Total number of blocks in flash
+ * @pages_per_block: Number of pages per block
+ * @page_size: Size of each page in bytes
+ *
+ * Scans the reserve area to find and load BBT and BMT tables.
+ * Calculates reserve area boundaries.
+ *
+ * Returns: 0 on success, -1 on error
+ */
+int bmt_init(uint32_t total_blocks, uint32_t pages_per_block, uint32_t page_size);
+
+/**
+ * bmt_translate_block - Translate logical block to physical block
+ * @block: Logical block number
+ *
+ * Applies both BBT and BMT translations:
+ * 1. First translates through BBT (factory bad blocks)
+ * 2. Then translates through BMT (worn blocks)
+ *
+ * Returns: Physical block number, or -1 if block is in reserve area or invalid
+ */
+int bmt_translate_block(uint32_t block);
+
+/**
+ * bmt_translate_page - Translate logical page to physical page
+ * @page: Logical page number
+ *
+ * Convenience function that translates page address by:
+ * 1. Converting page to block number
+ * 2. Translating block through BMT
+ * 3. Converting back to page number with same page offset
+ *
+ * Returns: Physical page number, or -1 on error
+ */
+int bmt_translate_page(uint32_t page);
+
+/**
+ * bmt_get_context - Get BMT context
+ *
+ * Returns: Pointer to BMT context structure (valid after bmt_init)
+ */
+const struct bmt_context *bmt_get_context(void);
+
+#endif /* _BMT_H_ */

--- a/target/linux/econet/image/lzma-loader/src/board.c
+++ b/target/linux/econet/image/lzma-loader/src/board.c
@@ -1,0 +1,55 @@
+/*
+ * Arch specific code for EcoNet based boards
+ *
+ * Copyright (C) 2013 John Crispin <blogic@openwrt.org>
+ * Copyright (C) 2018 Tobias Schramm <tobleminer@gmail.com>
+ * Copyright (C) 2023 Antonio Vázquez <antoniovazquezblanco@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+
+#define KSEG0			0x80000000
+#define KSEG1			0xa0000000
+
+#define _ATYPE_ 		__PTRDIFF_TYPE__
+#define _ATYPE32_		int
+
+#define _ACAST32_		(_ATYPE_)(_ATYPE32_)
+
+#define CPHYSADDR(a)		((_ACAST32_(a)) & 0x1fffffff)
+
+#define KSEG0ADDR(a)		(CPHYSADDR(a) | KSEG0)
+#define KSEG1ADDR(a)		(CPHYSADDR(a) | KSEG1)
+
+#define UART_LSR_THRE		0x20
+
+#if defined(SOC_EN751221)
+/* ns16550 compatible, reg-io-width=4, reg-shift=2 */
+#define UART_BASE			KSEG1ADDR(0x1fbf0000)
+#define UART_THR			(UART_BASE + 0x00)
+#define UART_LSR			(UART_BASE + 0x14)
+#define UART_LSR_MASK			UART_LSR_THRE
+#else
+#error "Unsupported SOC..."
+#endif
+
+// Helper functions
+#define READREG(r)		(*(volatile uint32_t *)(r))
+#define WRITEREG(r,v)	(*(volatile uint32_t *)(r)) = v
+
+
+void board_init(void)
+{
+}
+
+void board_putc(int ch)
+{
+	while ((READREG(UART_LSR) & UART_LSR_MASK) == 0);
+	WRITEREG(UART_THR, ch);
+	while ((READREG(UART_LSR) & UART_LSR_MASK) == 0);
+}

--- a/target/linux/econet/image/lzma-loader/src/cache.c
+++ b/target/linux/econet/image/lzma-loader/src/cache.c
@@ -1,0 +1,43 @@
+/*
+ * LZMA compressed kernel loader for Atheros AR7XXX/AR9XXX based boards
+ *
+ * Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
+ *
+ * The cache manipulation routine has been taken from the U-Boot project.
+ *	(C) Copyright 2003
+ *	Wolfgang Denk, DENX Software Engineering, <wd@denx.de>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ */
+
+#include "cache.h"
+#include "cacheops.h"
+#include "config.h"
+
+#define cache_op(op,addr)						\
+	__asm__ __volatile__(						\
+	"	.set	push					\n"	\
+	"	.set	noreorder				\n"	\
+	"	.set	mips3\n\t				\n"	\
+	"	cache	%0, %1					\n"	\
+	"	.set	pop					\n"	\
+	:								\
+	: "i" (op), "R" (*(unsigned char *)(addr)))
+
+void flush_cache(unsigned long start_addr, unsigned long size)
+{
+	unsigned long lsize = CONFIG_CACHELINE_SIZE;
+	unsigned long addr = start_addr & ~(lsize - 1);
+	unsigned long aend = (start_addr + size - 1) & ~(lsize - 1);
+
+	while (1) {
+		cache_op(Hit_Writeback_Inv_D, addr);
+		cache_op(Hit_Invalidate_I, addr);
+		if (addr == aend)
+			break;
+		addr += lsize;
+	}
+}

--- a/target/linux/econet/image/lzma-loader/src/cache.h
+++ b/target/linux/econet/image/lzma-loader/src/cache.h
@@ -1,0 +1,17 @@
+/*
+ * LZMA compressed kernel loader for Atheros AR7XXX/AR9XXX based boards
+ *
+ * Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ */
+
+#ifndef __CACHE_H
+#define __CACHE_H
+
+void flush_cache(unsigned long start_addr, unsigned long size);
+
+#endif /* __CACHE_H */

--- a/target/linux/econet/image/lzma-loader/src/cacheops.h
+++ b/target/linux/econet/image/lzma-loader/src/cacheops.h
@@ -1,0 +1,85 @@
+/*
+ * Cache operations for the cache instruction.
+ *
+ * This file is subject to the terms and conditions of the GNU General Public
+ * License.  See the file "COPYING" in the main directory of this archive
+ * for more details.
+ *
+ * (C) Copyright 1996, 97, 99, 2002, 03 Ralf Baechle
+ * (C) Copyright 1999 Silicon Graphics, Inc.
+ */
+#ifndef	__ASM_CACHEOPS_H
+#define	__ASM_CACHEOPS_H
+
+/*
+ * Cache Operations available on all MIPS processors with R4000-style caches
+ */
+#define Index_Invalidate_I      0x00
+#define Index_Writeback_Inv_D   0x01
+#define Index_Load_Tag_I	0x04
+#define Index_Load_Tag_D	0x05
+#define Index_Store_Tag_I	0x08
+#define Index_Store_Tag_D	0x09
+#if defined(CONFIG_CPU_LOONGSON2)
+#define Hit_Invalidate_I	0x00
+#else
+#define Hit_Invalidate_I	0x10
+#endif
+#define Hit_Invalidate_D	0x11
+#define Hit_Writeback_Inv_D	0x15
+
+/*
+ * R4000-specific cacheops
+ */
+#define Create_Dirty_Excl_D	0x0d
+#define Fill			0x14
+#define Hit_Writeback_I		0x18
+#define Hit_Writeback_D		0x19
+
+/*
+ * R4000SC and R4400SC-specific cacheops
+ */
+#define Index_Invalidate_SI     0x02
+#define Index_Writeback_Inv_SD  0x03
+#define Index_Load_Tag_SI	0x06
+#define Index_Load_Tag_SD	0x07
+#define Index_Store_Tag_SI	0x0A
+#define Index_Store_Tag_SD	0x0B
+#define Create_Dirty_Excl_SD	0x0f
+#define Hit_Invalidate_SI	0x12
+#define Hit_Invalidate_SD	0x13
+#define Hit_Writeback_Inv_SD	0x17
+#define Hit_Writeback_SD	0x1b
+#define Hit_Set_Virtual_SI	0x1e
+#define Hit_Set_Virtual_SD	0x1f
+
+/*
+ * R5000-specific cacheops
+ */
+#define R5K_Page_Invalidate_S	0x17
+
+/*
+ * RM7000-specific cacheops
+ */
+#define Page_Invalidate_T	0x16
+
+/*
+ * R10000-specific cacheops
+ *
+ * Cacheops 0x02, 0x06, 0x0a, 0x0c-0x0e, 0x16, 0x1a and 0x1e are unused.
+ * Most of the _S cacheops are identical to the R4000SC _SD cacheops.
+ */
+#define Index_Writeback_Inv_S	0x03
+#define Index_Load_Tag_S	0x07
+#define Index_Store_Tag_S	0x0B
+#define Hit_Invalidate_S	0x13
+#define Cache_Barrier		0x14
+#define Hit_Writeback_Inv_S	0x17
+#define Index_Load_Data_I	0x18
+#define Index_Load_Data_D	0x19
+#define Index_Load_Data_S	0x1b
+#define Index_Store_Data_I	0x1c
+#define Index_Store_Data_D	0x1d
+#define Index_Store_Data_S	0x1f
+
+#endif	/* __ASM_CACHEOPS_H */

--- a/target/linux/econet/image/lzma-loader/src/config.h
+++ b/target/linux/econet/image/lzma-loader/src/config.h
@@ -1,0 +1,27 @@
+/*
+ * LZMA compressed kernel loader for Atheros AR7XXX/AR9XXX based boards
+ *
+ * Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ */
+
+#ifndef _CONFIG_H_
+#define _CONFIG_H_
+
+#ifndef CONFIG_FLASH_OFFS
+#define CONFIG_FLASH_OFFS	0
+#endif
+
+#ifndef CONFIG_FLASH_MAX
+#define CONFIG_FLASH_MAX	0
+#endif
+
+#ifndef CONFIG_FLASH_STEP
+#define CONFIG_FLASH_STEP	0x1000
+#endif
+
+#endif /* _CONFIG_H_ */

--- a/target/linux/econet/image/lzma-loader/src/cp0regdef.h
+++ b/target/linux/econet/image/lzma-loader/src/cp0regdef.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 1994, 1995, 1996, 1997, 2000, 2001 by Ralf Baechle
+ *
+ * Copyright (C) 2001, Monta Vista Software
+ * Author: jsun@mvista.com or jsun@junsun.net
+ */
+#ifndef _cp0regdef_h_
+#define _cp0regdef_h_
+
+#define CP0_INDEX $0
+#define CP0_RANDOM $1
+#define CP0_ENTRYLO0 $2
+#define CP0_ENTRYLO1 $3
+#define CP0_CONTEXT $4
+#define CP0_PAGEMASK $5
+#define CP0_WIRED $6
+#define CP0_BADVADDR $8
+#define CP0_COUNT $9
+#define CP0_ENTRYHI $10
+#define CP0_COMPARE $11
+#define CP0_STATUS $12
+#define CP0_CAUSE $13
+#define CP0_EPC $14
+#define CP0_PRID $15
+#define CP0_CONFIG $16
+#define CP0_LLADDR $17
+#define CP0_WATCHLO $18
+#define CP0_WATCHHI $19
+#define CP0_XCONTEXT $20
+#define CP0_FRAMEMASK $21
+#define CP0_DIAGNOSTIC $22
+#define CP0_PERFORMANCE $25
+#define CP0_ECC $26
+#define CP0_CACHEERR $27
+#define CP0_TAGLO $28
+#define CP0_TAGHI $29
+#define CP0_ERROREPC $30
+
+#endif

--- a/target/linux/econet/image/lzma-loader/src/head.S
+++ b/target/linux/econet/image/lzma-loader/src/head.S
@@ -1,0 +1,121 @@
+/*
+ * LZMA compressed kernel loader for Atheros AR7XXX/AR9XXX based boards
+ *
+ * Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
+ *
+ * Some parts of this code was based on the OpenWrt specific lzma-loader
+ * for the BCM47xx and ADM5120 based boards:
+ *	Copyright (C) 2004 Manuel Novoa III (mjn3@codepoet.org)
+ *	Copyright (C) 2005 by Oleg I. Vdovikin <oleg@cs.msu.su>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ */
+
+#include <asm/asm.h>
+#include <asm/regdef.h>
+#include "cp0regdef.h"
+#include "cacheops.h"
+#include "config.h"
+
+#define KSEG0		0x80000000
+
+	.macro	ehb
+	sll     zero, 3
+	.endm
+
+	.text
+
+LEAF(startup)
+	.set noreorder
+	.set mips32
+
+	mtc0	zero, CP0_WATCHLO	# clear watch registers
+	mtc0	zero, CP0_WATCHHI
+	mtc0	zero, CP0_CAUSE		# clear before writing status register
+
+	mfc0	t0, CP0_STATUS
+	li	t1, 0x1000001f
+	or	t0, t1
+	xori	t0, 0x1f
+	mtc0	t0, CP0_STATUS
+	ehb
+
+	mtc0	zero, CP0_COUNT
+	mtc0	zero, CP0_COMPARE
+	ehb
+
+	la	t0, __reloc_label	# get linked address of label
+	bal	__reloc_label		# branch and link to label to
+	nop				# get actual address
+__reloc_label:
+	subu	t0, ra, t0		# get reloc_delta
+
+	beqz	t0, __reloc_done         # if delta is 0 we are in the right place
+	nop
+
+	/* Copy our code to the right place */
+	la	t1, _code_start		# get linked address of _code_start
+	la	t2, _code_end		# get linked address of _code_end
+	addu	t0, t0, t1		# calculate actual address of _code_start
+
+__reloc_copy:
+	lw	t3, 0(t0)
+	sw	t3, 0(t1)
+	add	t1, 4
+	blt	t1, t2, __reloc_copy
+	add	t0, 4
+
+	/* flush cache */
+	la	t0, _code_start
+	la	t1, _code_end
+
+	li	t2, ~(CONFIG_CACHELINE_SIZE - 1)
+	and	t0, t2
+	and	t1, t2
+	li	t2, CONFIG_CACHELINE_SIZE
+
+	b	__flush_check
+	nop
+
+__flush_line:
+	cache	Hit_Writeback_Inv_D, 0(t0)
+	cache	Hit_Invalidate_I, 0(t0)
+	add	t0, t2
+
+__flush_check:
+	bne	t0, t1, __flush_line
+	nop
+
+	sync
+
+__reloc_done:
+
+	/* clear bss */
+	la	t0, _bss_start
+	la	t1, _bss_end
+	b	__bss_check
+	nop
+
+__bss_fill:
+	sw	zero, 0(t0)
+	addi	t0, 4
+
+__bss_check:
+	bne	t0, t1, __bss_fill
+	nop
+
+	/* Setup new "C" stack */
+	la	sp, _stack
+
+	/* reserve stack space for a0-a3 registers */
+	subu	sp, 16
+
+	/* jump to the decompressor routine */
+	la	t0, loader_main
+	jr	t0
+	nop
+
+	.set reorder
+END(startup)

--- a/target/linux/econet/image/lzma-loader/src/loader.c
+++ b/target/linux/econet/image/lzma-loader/src/loader.c
@@ -1,0 +1,282 @@
+/*
+ * LZMA compressed kernel loader for Atheros AR7XXX/AR9XXX based boards
+ *
+ * Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>
+ *
+ * Some parts of this code was based on the OpenWrt specific lzma-loader
+ * for the BCM47xx and ADM5120 based boards:
+ *	Copyright (C) 2004 Manuel Novoa III (mjn3@codepoet.org)
+ *	Copyright (C) 2005 Mineharu Takahara <mtakahar@yahoo.com>
+ *	Copyright (C) 2005 by Oleg I. Vdovikin <oleg@cs.msu.su>
+ *
+ * The image_header structure has been taken from the U-Boot project.
+ *	(C) Copyright 2008 Semihalf
+ *	(C) Copyright 2000-2005
+ *	Wolfgang Denk, DENX Software Engineering, wd@denx.de.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "config.h"
+#include "cache.h"
+#include "printf.h"
+#include "LzmaDecode.h"
+
+#ifdef CONFIG_NAND_BOOT
+#include "nand_boot.h"
+#endif
+
+#define KSEG0			0x80000000
+#define KSEG1			0xa0000000
+
+#define KSEG1ADDR(a)		((((unsigned)(a)) & 0x1fffffffU) | KSEG1)
+
+#undef LZMA_DEBUG
+
+#ifdef LZMA_DEBUG
+#  define DBG(f, a...)	printf(f, ## a)
+#else
+#  define DBG(f, a...)	do {} while (0)
+#endif
+
+#define IH_MAGIC_OKLI		0x4f4b4c49	/* 'OKLI' */
+
+#define IH_NMLEN		32	/* Image Name Length		*/
+
+typedef struct image_header {
+	uint32_t	ih_magic;	/* Image Header Magic Number	*/
+	uint32_t	ih_hcrc;	/* Image Header CRC Checksum	*/
+	uint32_t	ih_time;	/* Image Creation Timestamp	*/
+	uint32_t	ih_size;	/* Image Data Size		*/
+	uint32_t	ih_load;	/* Data	 Load  Address		*/
+	uint32_t	ih_ep;		/* Entry Point Address		*/
+	uint32_t	ih_dcrc;	/* Image Data CRC Checksum	*/
+	uint8_t		ih_os;		/* Operating System		*/
+	uint8_t		ih_arch;	/* CPU architecture		*/
+	uint8_t		ih_type;	/* Image Type			*/
+	uint8_t		ih_comp;	/* Compression Type		*/
+	uint8_t		ih_name[IH_NMLEN];	/* Image Name		*/
+} image_header_t;
+
+/* beyond the image end, size not known in advance */
+extern unsigned char workspace[];
+extern void board_init(void);
+
+static CLzmaDecoderState lzma_state;
+unsigned char *lzma_data;
+unsigned long lzma_datasize;
+static unsigned long lzma_outsize;
+unsigned long kernel_la;
+
+#ifdef CONFIG_KERNEL_CMDLINE
+#define kernel_argc	2
+static const char kernel_cmdline[] = CONFIG_KERNEL_CMDLINE;
+static const char *kernel_argv[] = {
+	NULL,
+	kernel_cmdline,
+	NULL,
+};
+#endif /* CONFIG_KERNEL_CMDLINE */
+
+void halt(void)
+{
+	printf("\nSystem halted!\n");
+	for(;;);
+}
+
+static __inline__ unsigned long get_be32(void *buf)
+{
+	unsigned char *p = buf;
+
+	return (((unsigned long) p[0] << 24) +
+	        ((unsigned long) p[1] << 16) +
+	        ((unsigned long) p[2] << 8) +
+	        (unsigned long) p[3]);
+}
+
+static __inline__ unsigned char lzma_get_byte(void)
+{
+	unsigned char c;
+
+	lzma_datasize--;
+	c = *lzma_data++;
+
+	return c;
+}
+
+static int lzma_init_props(void)
+{
+	unsigned char props[LZMA_PROPERTIES_SIZE];
+	int res;
+	int i;
+
+	/* read lzma properties */
+	for (i = 0; i < LZMA_PROPERTIES_SIZE; i++)
+		props[i] = lzma_get_byte();
+
+	/* read the lower half of uncompressed size in the header */
+	lzma_outsize = ((SizeT) lzma_get_byte()) +
+		       ((SizeT) lzma_get_byte() << 8) +
+		       ((SizeT) lzma_get_byte() << 16) +
+		       ((SizeT) lzma_get_byte() << 24);
+
+	/* skip rest of the header (upper half of uncompressed size) */
+	for (i = 0; i < 4; i++)
+		lzma_get_byte();
+
+	res = LzmaDecodeProperties(&lzma_state.Properties, props,
+					LZMA_PROPERTIES_SIZE);
+	return res;
+}
+
+static int lzma_decompress(unsigned char *outStream)
+{
+	SizeT ip, op;
+	int ret;
+
+	lzma_state.Probs = (CProb *) workspace;
+
+	ret = LzmaDecode(&lzma_state, lzma_data, lzma_datasize, &ip, outStream,
+			 lzma_outsize, &op);
+
+	if (ret != LZMA_RESULT_OK) {
+		int i;
+
+		DBG("LzmaDecode error %d at %08x, osize:%d ip:%d op:%d\n",
+		    ret, lzma_data + ip, lzma_outsize, ip, op);
+
+		for (i = 0; i < 16; i++)
+			DBG("%02x ", lzma_data[ip + i]);
+
+		DBG("\n");
+	}
+
+	return ret;
+}
+
+#ifndef CONFIG_NAND_BOOT
+#if (LZMA_WRAPPER)
+static void lzma_init_data(void)
+{
+	extern unsigned char _lzma_data_start[];
+	extern unsigned char _lzma_data_end[];
+
+	kernel_la = LOADADDR;
+	lzma_data = _lzma_data_start;
+	lzma_datasize = _lzma_data_end - _lzma_data_start;
+}
+#else
+static void lzma_init_data(void)
+{
+	struct image_header *hdr = NULL;
+	unsigned char *flash_base;
+	unsigned long flash_ofs;
+	unsigned long kernel_ofs;
+	unsigned long kernel_size;
+
+	flash_base = (unsigned char *) KSEG1ADDR(CONFIG_FLASH_START);
+
+	printf("Looking for OpenWrt image... ");
+
+	for (flash_ofs = CONFIG_FLASH_OFFS;
+	     flash_ofs <= (CONFIG_FLASH_OFFS + CONFIG_FLASH_MAX);
+	     flash_ofs += CONFIG_FLASH_STEP) {
+		unsigned long magic;
+		unsigned char *p;
+
+		p = flash_base + flash_ofs;
+		magic = get_be32(p);
+		if (magic == IH_MAGIC_OKLI) {
+			hdr = (struct image_header *) p;
+			break;
+		}
+	}
+
+	if (hdr == NULL) {
+		printf("not found!\n");
+		halt();
+	}
+
+	printf("found at 0x%08x\n", flash_base + flash_ofs);
+
+	kernel_ofs = sizeof(struct image_header);
+	kernel_size = get_be32(&hdr->ih_size);
+	kernel_la = get_be32(&hdr->ih_load);
+
+	lzma_data = flash_base + flash_ofs + kernel_ofs;
+	lzma_datasize = kernel_size;
+}
+#endif /* (LZMA_WRAPPER) */
+#endif /* !CONFIG_NAND_BOOT */
+
+void loader_main(unsigned long reg_a0, unsigned long reg_a1,
+		 unsigned long reg_a2, unsigned long reg_a3)
+{
+	void (*kernel_entry) (unsigned long, unsigned long, unsigned long,
+			      unsigned long);
+	int res;
+
+	board_init();
+
+	printf("\n\nOpenWrt kernel loader for MIPS based SoC\n");
+	printf("Copyright (C) 2011 Gabor Juhos <juhosg@openwrt.org>\n");
+
+#ifdef CONFIG_NAND_BOOT
+	printf("NAND boot mode enabled\n");
+	nand_init_data();
+#else
+	lzma_init_data();
+#endif
+
+	res = lzma_init_props();
+	if (res != LZMA_RESULT_OK) {
+		printf("Incorrect LZMA stream properties!\n");
+		halt();
+	}
+
+	printf("Decompressing kernel... ");
+
+	res = lzma_decompress((unsigned char *) kernel_la);
+	if (res != LZMA_RESULT_OK) {
+		printf("failed, ");
+		switch (res) {
+		case LZMA_RESULT_DATA_ERROR:
+			printf("data error!\n");
+			break;
+		default:
+			printf("unknown error %d!\n", res);
+		}
+		halt();
+	} else {
+		printf("done!\n");
+	}
+
+	flush_cache(kernel_la, lzma_outsize);
+
+	printf("Starting kernel at %08x...\n\n", kernel_la);
+
+#ifdef CONFIG_NAND_BOOT
+	/* For NAND boot, use static const command line selected by boot flag */
+	reg_a0 = 2;  /* argc */
+	reg_a1 = (unsigned long) nand_get_kernel_argv();
+	reg_a2 = 0;
+	reg_a3 = 0;
+	printf("DEBUG: Passing to kernel: a0=%d, a1=0x%08x, argv[1]='%s'\n",
+	       (int)reg_a0, (unsigned int)reg_a1,
+	       ((const char **)reg_a1)[1] ? ((const char **)reg_a1)[1] : "(null)");
+#elif defined(CONFIG_KERNEL_CMDLINE)
+	reg_a0 = kernel_argc;
+	reg_a1 = (unsigned long) kernel_argv;
+	reg_a2 = 0;
+	reg_a3 = 0;
+#endif
+
+	kernel_entry = (void *) kernel_la;
+	kernel_entry(reg_a0, reg_a1, reg_a2, reg_a3);
+}

--- a/target/linux/econet/image/lzma-loader/src/loader.lds
+++ b/target/linux/econet/image/lzma-loader/src/loader.lds
@@ -1,0 +1,35 @@
+OUTPUT_ARCH(mips)
+SECTIONS {
+	.text : {
+		_code_start = .;
+		*(.text)
+		*(.text.*)
+		*(.rodata)
+		*(.rodata.*)
+		*(.data.lzma)
+	}
+
+	. = ALIGN(32);
+	.data : {
+		*(.data)
+		*(.data.*)
+		. = . + 524288;		/* workaround for buggy bootloaders */
+	}
+
+	. = ALIGN(32);
+	_code_end = .;
+
+	_bss_start = .;
+	.bss : {
+		*(.bss)
+		*(.bss.*)
+	}
+
+	. = ALIGN(32);
+	_bss_end = .;
+
+	. = . + 8192;
+	_stack = .;
+
+	workspace = .;
+}

--- a/target/linux/econet/image/lzma-loader/src/loader2.lds
+++ b/target/linux/econet/image/lzma-loader/src/loader2.lds
@@ -1,0 +1,10 @@
+OUTPUT_ARCH(mips)
+SECTIONS {
+	.text : {
+		startup = .;
+		*(.text)
+		*(.text.*)
+		*(.data)
+		*(.data.*)
+	}
+}

--- a/target/linux/econet/image/lzma-loader/src/lzma-data.lds
+++ b/target/linux/econet/image/lzma-loader/src/lzma-data.lds
@@ -1,0 +1,8 @@
+OUTPUT_ARCH(mips)
+SECTIONS {
+	.data.lzma : {
+		_lzma_data_start = .;
+		*(.data)
+		_lzma_data_end = .;
+	}
+}

--- a/target/linux/econet/image/lzma-loader/src/nand_boot.c
+++ b/target/linux/econet/image/lzma-loader/src/nand_boot.c
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * NAND boot support for EcoNet EN751221 SoC
+ *
+ * Implements dual-image boot from SPI-NAND flash with BMT translation.
+ * Selects OS1 or OS2 partition based on boot flag and loads kernel.
+ *
+ * Copyright (C) 2025 Ahmed Naseef <naseefkm@gmail.com>
+ */
+
+#include "nand_boot.h"
+#include "spi_nand.h"
+#include "bmt.h"
+#include "printf.h"
+#include <string.h>
+
+/* External symbols from loader.c */
+extern unsigned long kernel_la;
+extern unsigned char *lzma_data;
+extern unsigned long lzma_datasize;
+extern void halt(void);
+
+/* Kernel data buffer - will hold compressed kernel read from NAND */
+static unsigned char kernel_buffer[4 * 1024 * 1024];  /* 4MB buffer for compressed kernel */
+
+/* Page buffer for NAND reads - sized for maximum supported flash geometry */
+static uint8_t page_buf[SPINAND_MAX_PAGE_SIZE];
+
+/* Kernel command line strings (from config, in .rodata section) */
+static const char cmdline_os1[] = CONFIG_NAND_CMDLINE_OS1;
+static const char cmdline_os2[] = CONFIG_NAND_CMDLINE_OS2;
+
+/* Kernel argv arrays (static const, like CONFIG_KERNEL_CMDLINE) */
+static const char *const argv_os1[] = {
+	NULL,
+	cmdline_os1,
+	NULL,
+};
+
+static const char *const argv_os2[] = {
+	NULL,
+	cmdline_os2,
+	NULL,
+};
+
+/* Selected boot partition (0=OS1, 1=OS2) */
+static int boot_partition = 0;
+
+/*
+ * Parse hex string to byte array
+ * Hex string format: "30" or "0000000101000002" (pairs of hex digits)
+ * Returns number of bytes parsed
+ */
+static int hex_to_bytes(const char *hex_str, uint8_t *bytes, int max_bytes)
+{
+    int len = 0;
+    int i;
+
+    if (hex_str == NULL)
+        return 0;
+
+    for (i = 0; hex_str[i] && hex_str[i+1] && len < max_bytes; i += 2, len++) {
+        unsigned int byte;
+        char hex_pair[3] = { hex_str[i], hex_str[i+1], '\0' };
+
+        /* Simple hex parser */
+        byte = 0;
+        if (hex_pair[0] >= '0' && hex_pair[0] <= '9')
+            byte = (hex_pair[0] - '0') << 4;
+        else if (hex_pair[0] >= 'a' && hex_pair[0] <= 'f')
+            byte = (hex_pair[0] - 'a' + 10) << 4;
+        else if (hex_pair[0] >= 'A' && hex_pair[0] <= 'F')
+            byte = (hex_pair[0] - 'A' + 10) << 4;
+
+        if (hex_pair[1] >= '0' && hex_pair[1] <= '9')
+            byte |= (hex_pair[1] - '0');
+        else if (hex_pair[1] >= 'a' && hex_pair[1] <= 'f')
+            byte |= (hex_pair[1] - 'a' + 10);
+        else if (hex_pair[1] >= 'A' && hex_pair[1] <= 'F')
+            byte |= (hex_pair[1] - 'A' + 10);
+
+        bytes[len] = byte;
+    }
+
+    return len;
+}
+
+/*
+ * Apply mask to byte array
+ * Mask uses 'X' for bits to keep, '0' for bits to ignore
+ * Example: mask "0X" keeps second nibble of each byte
+ */
+static void apply_mask(uint8_t *data, const char *mask, int len)
+{
+    int i, j;
+
+    if (mask == NULL)
+        return;
+
+    for (i = 0; i < len && mask[i*2] && mask[i*2+1]; i++) {
+        uint8_t byte_mask = 0;
+
+        /* Check each nibble of the mask */
+        for (j = 0; j < 2; j++) {
+            char c = mask[i*2 + j];
+            if (c == 'X' || c == 'x') {
+                byte_mask |= (0xF << ((1-j) * 4));
+            }
+            /* '0' or any other char means mask out that nibble */
+        }
+
+        data[i] &= byte_mask;
+    }
+}
+
+/*
+ * Read boot flag from NAND flash
+ * Returns: 0 for OS1 partition, 1 for OS2 partition
+ */
+static int get_boot_flag(void)
+{
+    const struct spinand_info *info = spi_nand_get_info();
+    uint32_t page_size = info->page_size;
+    uint32_t page = CONFIG_NAND_BOOT_FLAG_OFFSET / page_size;
+    uint32_t offset = CONFIG_NAND_BOOT_FLAG_OFFSET % page_size;
+    uint8_t flag_bytes[32];  /* Max 32 bytes for boot flag */
+    uint8_t os1_code[32];
+    uint8_t os2_code[32];
+    int flag_len, os1_len, os2_len;
+    int i;
+
+    /* Read page containing boot flag */
+    if (spi_nand_read_page(page, page_buf) < 0) {
+        printf("ERROR: Failed to read boot flag page\n");
+        return 0;  /* Default to OS1 partition */
+    }
+
+    /* Parse expected boot flag codes */
+    os1_len = hex_to_bytes(CONFIG_NAND_BOOT_FLAG_OS1, os1_code, sizeof(os1_code));
+    os2_len = hex_to_bytes(CONFIG_NAND_BOOT_FLAG_OS2, os2_code, sizeof(os2_code));
+
+    if (os1_len == 0 || os2_len == 0 || os1_len != os2_len) {
+        printf("ERROR: Invalid boot flag configuration\n");
+        return 0;
+    }
+
+    flag_len = os1_len;
+
+    /* Extract boot flag from page */
+    for (i = 0; i < flag_len; i++) {
+        flag_bytes[i] = page_buf[offset + i];
+    }
+
+    /* Apply mask if configured */
+    if (CONFIG_NAND_BOOT_FLAG_MASK != NULL) {
+        apply_mask(flag_bytes, CONFIG_NAND_BOOT_FLAG_MASK, flag_len);
+        apply_mask(os1_code, CONFIG_NAND_BOOT_FLAG_MASK, flag_len);
+        apply_mask(os2_code, CONFIG_NAND_BOOT_FLAG_MASK, flag_len);
+    }
+
+    /* Compare against OS1 code */
+    if (memcmp(flag_bytes, os1_code, flag_len) == 0) {
+        printf("Boot flag: OS1 (");
+        for (i = 0; i < flag_len; i++)
+            printf("%02x", page_buf[offset + i]);
+        printf(")\n");
+        return 0;  /* OS1 partition */
+    }
+
+    /* Compare against OS2 code */
+    if (memcmp(flag_bytes, os2_code, flag_len) == 0) {
+        printf("Boot flag: OS2 (");
+        for (i = 0; i < flag_len; i++)
+            printf("%02x", page_buf[offset + i]);
+        printf(")\n");
+        return 1;  /* OS2 partition */
+    }
+
+    /* Unknown flag value */
+    printf("WARNING: Unknown boot flag (");
+    for (i = 0; i < flag_len; i++)
+        printf("%02x", page_buf[offset + i]);
+    printf("), defaulting to OS1\n");
+    return 0;  /* Default to OS1 partition */
+}
+
+/*
+ * Select partition offset based on boot flag
+ * Returns: Byte offset of selected partition
+ */
+static uint32_t select_partition(void)
+{
+    boot_partition = get_boot_flag();
+
+    if (boot_partition == 0) {
+        printf("Boot flag: 0 (OS1 partition)\n");
+        printf("Kernel cmdline: %s\n", CONFIG_NAND_CMDLINE_OS1);
+        return CONFIG_NAND_OS1_OFFSET;
+    } else {
+        printf("Boot flag: 1 (OS2 partition)\n");
+        printf("Kernel cmdline: %s\n", CONFIG_NAND_CMDLINE_OS2);
+        return CONFIG_NAND_OS2_OFFSET;
+    }
+}
+
+/*
+ * Get kernel argv based on selected boot partition
+ * Returns pointer to static const argv array
+ */
+const char **nand_get_kernel_argv(void)
+{
+    if (boot_partition == 0) {
+        return (const char **)argv_os1;
+    } else {
+        return (const char **)argv_os2;
+    }
+}
+
+/*
+ * Read data from NAND with BMT translation
+ *
+ * Reads len bytes from NAND starting at byte offset, applying BMT
+ * translation for bad block handling. Reads are done page-by-page.
+ *
+ * Returns: Number of bytes read, or -1 on error
+ */
+static int nand_read_with_bmt(uint32_t offset, uint8_t *buf, uint32_t len)
+{
+    const struct spinand_info *info = spi_nand_get_info();
+    uint32_t page_size = info->page_size;
+    uint32_t bytes_read = 0;
+    uint32_t page, page_offset;
+    uint32_t copy_len;
+    int physical_page;
+
+    while (bytes_read < len) {
+        /* Calculate page and offset within page */
+        page = offset / page_size;
+        page_offset = offset % page_size;
+
+        /* Translate page through BMT */
+        physical_page = bmt_translate_page(page);
+        if (physical_page < 0) {
+            printf("NAND: BMT translation failed for page %d\n", page);
+            return -1;
+        }
+
+        /* Read page from NAND */
+        if (spi_nand_read_page(physical_page, page_buf) < 0) {
+            printf("NAND: Read failed for page %d (physical %d)\n",
+                   page, physical_page);
+            return -1;
+        }
+
+        /* Copy relevant portion to output buffer */
+        copy_len = page_size - page_offset;
+        if (copy_len > len - bytes_read)
+            copy_len = len - bytes_read;
+
+        memcpy(buf + bytes_read, page_buf + page_offset, copy_len);
+
+        bytes_read += copy_len;
+        offset += copy_len;
+    }
+
+    return bytes_read;
+}
+
+/*
+ * Read and validate TRX header from partition
+ *
+ * Returns: 0 on success, -1 on error
+ */
+static int nand_read_trx_header(uint32_t partition_offset, struct trx_header *hdr)
+{
+    /* Read TRX header */
+    if (nand_read_with_bmt(partition_offset, (uint8_t *)hdr, sizeof(*hdr)) < 0) {
+        printf("NAND: Failed to read TRX header\n");
+        return -1;
+    }
+
+    /* Validate magic */
+    if (hdr->magic != TRX_MAGIC) {
+        printf("NAND: Invalid TRX magic: 0x%08x (expected 0x%08x)\n",
+               hdr->magic, TRX_MAGIC);
+        return -1;
+    }
+
+    /* Validate header length */
+    if (hdr->header_len != TRX_HEADER_SIZE) {
+        printf("NAND: Invalid TRX header length: %d (expected %d)\n",
+               hdr->header_len, TRX_HEADER_SIZE);
+        return -1;
+    }
+
+    printf("TRX Header:\n");
+    printf("  Magic: 0x%08x\n", hdr->magic);
+    printf("  Total length: %d bytes\n", hdr->total_len);
+    printf("  Kernel length: %d bytes\n", hdr->kernel_len);
+    printf("  Rootfs length: %d bytes\n", hdr->rootfs_len);
+    printf("  Load address: 0x%08x\n", hdr->load_addr);
+    printf("  Model: %.32s\n", hdr->model);
+    printf("  Version: %.32s\n", hdr->version);
+
+    return 0;
+}
+
+/*
+ * Read compressed kernel data from NAND
+ *
+ * Returns: Number of bytes read, or -1 on error
+ */
+static int nand_read_kernel(uint32_t kernel_offset, uint32_t kernel_len)
+{
+    printf("Reading compressed kernel from NAND...\n");
+    printf("  Offset: 0x%08x\n", kernel_offset);
+    printf("  Length: %d bytes\n", kernel_len);
+
+    /* Sanity check kernel size */
+    if (kernel_len == 0 || kernel_len > sizeof(kernel_buffer)) {
+        printf("NAND: Invalid kernel length: %d\n", kernel_len);
+        return -1;
+    }
+
+    /* Read kernel data */
+    if (nand_read_with_bmt(kernel_offset, kernel_buffer, kernel_len) < 0) {
+        printf("NAND: Failed to read kernel data\n");
+        return -1;
+    }
+
+    printf("Kernel data loaded to buffer at 0x%08x\n", (uint32_t)kernel_buffer);
+
+    return kernel_len;
+}
+
+/*
+ * Main NAND boot initialization
+ *
+ * This replaces lzma_init_data() for NAND-based boot.
+ * Sets up kernel_la, lzma_data, and lzma_datasize for LZMA decompression.
+ */
+void nand_init_data(void)
+{
+    const struct spinand_info *flash_info;
+    struct trx_header hdr;
+    uint32_t partition_offset;
+    uint32_t kernel_offset;
+
+    printf("\n=== NAND Boot Initialization ===\n");
+
+    /* Initialize SPI-NAND controller and flash */
+    printf("\nInitializing SPI-NAND flash...\n");
+    if (spi_nand_init() < 0) {
+        printf("ERROR: SPI-NAND initialization failed!\n");
+        halt();
+    }
+
+    flash_info = spi_nand_get_info();
+    printf("Flash: %d blocks, %d KB per block\n",
+           flash_info->total_blocks,
+           (flash_info->page_size * flash_info->pages_per_block) / 1024);
+
+    /* Initialize BMT (Bad Block Management) */
+    printf("\nInitializing BMT...\n");
+    if (bmt_init(flash_info->total_blocks,
+                 flash_info->pages_per_block,
+                 flash_info->page_size) < 0) {
+        printf("ERROR: BMT initialization failed!\n");
+        halt();
+    }
+
+    /* Select partition based on boot flag */
+    printf("\nSelecting boot partition...\n");
+    partition_offset = select_partition();
+    printf("Partition offset: 0x%08x\n", partition_offset);
+
+    /* Read and validate TRX header */
+    printf("\nReading TRX header...\n");
+    if (nand_read_trx_header(partition_offset, &hdr) < 0) {
+        printf("ERROR: Failed to read TRX header!\n");
+        halt();
+    }
+
+    /* Calculate kernel offset (after TRX header + NAND loader) */
+    kernel_offset = partition_offset + KERNEL_OFFSET;
+
+    /* Read compressed kernel into buffer */
+    printf("\n");
+    if (nand_read_kernel(kernel_offset, hdr.kernel_len) < 0) {
+        printf("ERROR: Failed to read kernel!\n");
+        halt();
+    }
+
+    /* Set up LZMA decompression parameters */
+    /* Use fixed kernel load address 0x80020000 instead of TRX header value */
+    /* to avoid overwriting NAND loader running at 0x80002000 */
+    kernel_la = 0x80020000;
+    lzma_data = kernel_buffer;
+    lzma_datasize = hdr.kernel_len;
+
+    printf("\n=== NAND Boot Ready ===\n");
+    printf("Kernel will be decompressed to 0x%08x\n", kernel_la);
+    printf("Compressed size: %d bytes\n", lzma_datasize);
+    printf("\n");
+}

--- a/target/linux/econet/image/lzma-loader/src/nand_boot.h
+++ b/target/linux/econet/image/lzma-loader/src/nand_boot.h
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * NAND boot support for EcoNet EN751221 SoC
+ *
+ * Defines partition layout, TRX header structure, and boot parameters
+ * for dual-image (OS1/OS2) boot support.
+ *
+ * Copyright (C) 2025 Ahmed Naseef <naseefkm@gmail.com>
+ */
+
+#ifndef _NAND_BOOT_H_
+#define _NAND_BOOT_H_
+
+#include <stdint.h>
+
+/*
+ * Partition Layout
+ *
+ * These offsets are device-specific and can be overridden via Makefile:
+ *   NAND_OS1_OFFSET        - OS1 firmware partition offset
+ *   NAND_OS2_OFFSET        - OS2 firmware partition offset
+ *   NAND_BOOT_FLAG_OFFSET  - Boot flag absolute address
+ *   NAND_CMDLINE_OS1       - Kernel cmdline for OS1 partition
+ *   NAND_CMDLINE_OS2       - Kernel cmdline for OS2 partition
+ *
+ * Default layout (Genexis Platinum 4410):
+ * - bootloader @ 0x000000 (256KB)   - Stock bootloader
+ * - romfile @ 0x040000 (256KB)      - Configuration
+ * - tclinux (OS1) @ 0x080000 (16MB) - Primary firmware image
+ * - tclinux_slave (OS2) @ 0x1080000 (16MB) - Secondary firmware image
+ * - reservearea @ 0x6E40000          - BMT tables and reserve blocks
+ */
+
+/* OS1 firmware partition offset - override with CONFIG_NAND_OS1_OFFSET */
+#ifndef CONFIG_NAND_OS1_OFFSET
+#define CONFIG_NAND_OS1_OFFSET      0x00080000
+#endif
+
+/* OS2 firmware partition offset - override with CONFIG_NAND_OS2_OFFSET */
+#ifndef CONFIG_NAND_OS2_OFFSET
+#define CONFIG_NAND_OS2_OFFSET      0x01080000
+#endif
+
+/*
+ * Boot Flag Location and Format
+ *
+ * The boot flag is stored at a fixed absolute address (device-specific).
+ * Different devices use different flag formats:
+ *
+ * Override with:
+ *   CONFIG_NAND_BOOT_FLAG_OFFSET - Absolute byte address in NAND
+ *   CONFIG_NAND_BOOT_FLAG_OS1    - Hex string for OS1 code (e.g., "30")
+ *   CONFIG_NAND_BOOT_FLAG_OS2    - Hex string for OS2 code (e.g., "31")
+ *   CONFIG_NAND_BOOT_FLAG_MASK   - Optional mask string (use 'X' for bits to compare)
+ *
+ * Examples:
+ *   Platinum 4410:   OS1="30", OS2="31" (1 byte, ASCII)
+ *   TP-Link VR1200v: OS1="0000000101000002", OS2="0000000101010003" (8 bytes)
+ *   Nokia G-240G-E:  OS1="000000000000000000000001000000010000000000000000",
+ *                    OS2="000000000000000100000001000000010000000000000000" (24 bytes)
+ *                    MASK="000000000000000X00000000000000000000000000000000"
+ *   SmartFiber:      OS1="30000000", OS2="31000000" (4 bytes, little-endian)
+ *   Zyxel PMG5617GA: OS1="30", OS2="31" (1 byte at offset 4095)
+ *
+ * Default: 0x6FC0000 (reservearea + 12 blocks * 128KB on Genexis)
+ */
+#ifndef CONFIG_NAND_BOOT_FLAG_OFFSET
+#define CONFIG_NAND_BOOT_FLAG_OFFSET  0x6FC0000
+#endif
+
+/* Default boot flag codes (Platinum 4410 format: single ASCII byte) */
+#ifndef CONFIG_NAND_BOOT_FLAG_OS1
+#define CONFIG_NAND_BOOT_FLAG_OS1     "30"
+#endif
+
+#ifndef CONFIG_NAND_BOOT_FLAG_OS2
+#define CONFIG_NAND_BOOT_FLAG_OS2     "31"
+#endif
+
+/* Optional mask - use 'X' to mark bits to compare, '0' to ignore */
+#ifndef CONFIG_NAND_BOOT_FLAG_MASK
+#define CONFIG_NAND_BOOT_FLAG_MASK    NULL
+#endif
+
+/*
+ * Kernel Command Line
+ *
+ * Root device varies by partition layout. Override with:
+ *   CONFIG_NAND_CMDLINE_OS1  - cmdline when booting from OS1
+ *   CONFIG_NAND_CMDLINE_OS2  - cmdline when booting from OS2
+ */
+#ifndef CONFIG_NAND_CMDLINE_OS1
+#define CONFIG_NAND_CMDLINE_OS1     "root=/dev/mtdblock3"
+#endif
+
+#ifndef CONFIG_NAND_CMDLINE_OS2
+#define CONFIG_NAND_CMDLINE_OS2     "root=/dev/mtdblock5"
+#endif
+
+/*
+ * TRX Header Structure
+ *
+ * EcoNet uses a custom TRX header format with "HDR2" magic.
+ * The header is 256 bytes and contains kernel/rootfs sizes and load address.
+ *
+ * Layout (NAND boot variant):
+ * - TRX Header (256 bytes at offset 0x000)
+ * - LZMA compressed NAND loader (padded to 64KB at offset 0x100)
+ * - LZMA compressed kernel (at offset 0x10100)
+ * - Squashfs rootfs
+ */
+
+#define TRX_MAGIC                   0x32524448  /* "HDR2" little-endian */
+#define TRX_HEADER_SIZE             256
+#define NAND_LOADER_SIZE            (64 * 1024) /* NAND loader padded to 64KB */
+#define KERNEL_OFFSET               (TRX_HEADER_SIZE + NAND_LOADER_SIZE) /* 0x10100 */
+
+struct trx_header {
+    uint32_t magic;                 /* "HDR2" (0x32524448) */
+    uint32_t header_len;            /* Header length (256) */
+    uint32_t total_len;             /* Total image size */
+    uint32_t crc32;                 /* CRC32 of content */
+    char     version[32];           /* Firmware version string */
+    char     customer_ver[32];      /* Customer version string */
+    uint32_t kernel_len;            /* Kernel size (compressed) */
+    uint32_t rootfs_len;            /* Rootfs size */
+    uint32_t romfile_len;           /* Romfile size (usually 0) */
+    char     model[32];             /* Model name */
+    uint32_t load_addr;             /* Kernel load address (0x80020000) */
+    char     reserved[128];         /* Reserved space */
+} __attribute__((packed));
+
+/*
+ * Memory Layout
+ *
+ * The loader operates with the following memory layout:
+ *
+ * 0x80000000 - 0x8001FFFF: Loader code + stack (~128KB)
+ * 0x80020000 - .........: Kernel decompression target (from TRX load_addr)
+ * Workspace: After loader code, used for LZMA decoder state
+ *
+ * The loader reads compressed kernel data from NAND through BMT translation,
+ * decompresses it to the load address specified in TRX header, and jumps to it.
+ */
+
+/*
+ * Function prototypes
+ */
+
+/**
+ * nand_init_data - Initialize NAND boot data
+ *
+ * Replacement for lzma_init_data() in NAND boot mode.
+ * This function:
+ * 1. Initializes SPI-NAND controller and BMT
+ * 2. Reads boot flag to select OS1 or OS2 partition
+ * 3. Reads and validates TRX header from selected partition
+ * 4. Sets up LZMA decompression parameters (kernel_la, lzma_data, lzma_datasize)
+ * 5. Sets up kernel command line with correct root device
+ *
+ * After this function returns, the loader proceeds with LZMA decompression
+ * as usual.
+ */
+void nand_init_data(void);
+
+/**
+ * Get kernel command line arguments for NAND boot
+ *
+ * Returns pointer to argv array based on boot flag:
+ * - OS1 partition: argv with root=/dev/mtdblock3
+ * - OS2 partition: argv with root=/dev/mtdblock5
+ *
+ * Format matches CONFIG_KERNEL_CMDLINE: argc=2, argv={NULL, cmdline, NULL}
+ */
+const char **nand_get_kernel_argv(void);
+
+#endif /* _NAND_BOOT_H_ */

--- a/target/linux/econet/image/lzma-loader/src/printf.c
+++ b/target/linux/econet/image/lzma-loader/src/printf.c
@@ -1,0 +1,350 @@
+/*
+ * Copyright (C) 2001 MontaVista Software Inc.
+ * Author: Jun Sun, jsun@mvista.com or jsun@junsun.net
+ *
+ * This program is free software; you can redistribute  it and/or modify it
+ * under  the terms of  the GNU General  Public License as published by the
+ * Free Software Foundation;  either version 2 of the  License, or (at your
+ * option) any later version.
+ *
+ */
+
+#include	"printf.h"
+
+extern void board_putc(int ch);
+
+/* this is the maximum width for a variable */
+#define		LP_MAX_BUF	256
+
+/* macros */
+#define		IsDigit(x)	( ((x) >= '0') && ((x) <= '9') )
+#define		Ctod(x)		( (x) - '0')
+
+/* forward declaration */
+static int PrintChar(char *, char, int, int);
+static int PrintString(char *, char *, int, int);
+static int PrintNum(char *, unsigned long, int, int, int, int, char, int);
+
+/* private variable */
+static const char theFatalMsg[] = "fatal error in lp_Print!";
+
+/* -*-
+ * A low level printf() function.
+ */
+static void
+lp_Print(void (*output)(void *, char *, int),
+	 void * arg,
+	 char *fmt,
+	 va_list ap)
+{
+
+#define 	OUTPUT(arg, s, l)  \
+  { if (((l) < 0) || ((l) > LP_MAX_BUF)) { \
+       (*output)(arg, (char*)theFatalMsg, sizeof(theFatalMsg)-1); for(;;); \
+    } else { \
+      (*output)(arg, s, l); \
+    } \
+  }
+
+    char buf[LP_MAX_BUF];
+
+    char c;
+    char *s;
+    long int num;
+
+    int longFlag;
+    int negFlag;
+    int width;
+    int prec;
+    int ladjust;
+    char padc;
+
+    int length;
+
+    for(;;) {
+	{
+	    /* scan for the next '%' */
+	    char *fmtStart = fmt;
+	    while ( (*fmt != '\0') && (*fmt != '%')) {
+		fmt ++;
+	    }
+
+	    /* flush the string found so far */
+	    OUTPUT(arg, fmtStart, fmt-fmtStart);
+
+	    /* are we hitting the end? */
+	    if (*fmt == '\0') break;
+	}
+
+	/* we found a '%' */
+	fmt ++;
+
+	/* check for long */
+	if (*fmt == 'l') {
+	    longFlag = 1;
+	    fmt ++;
+	} else {
+	    longFlag = 0;
+	}
+
+	/* check for other prefixes */
+	width = 0;
+	prec = -1;
+	ladjust = 0;
+	padc = ' ';
+
+	if (*fmt == '-') {
+	    ladjust = 1;
+	    fmt ++;
+	}
+
+	if (*fmt == '0') {
+	    padc = '0';
+	    fmt++;
+	}
+
+	if (IsDigit(*fmt)) {
+	    while (IsDigit(*fmt)) {
+		width = 10 * width + Ctod(*fmt++);
+	    }
+	}
+
+	if (*fmt == '.') {
+	    fmt ++;
+	    if (IsDigit(*fmt)) {
+		prec = 0;
+		while (IsDigit(*fmt)) {
+		    prec = prec*10 + Ctod(*fmt++);
+		}
+	    }
+	}
+
+
+	/* check format flag */
+	negFlag = 0;
+	switch (*fmt) {
+	 case 'b':
+	    if (longFlag) {
+		num = va_arg(ap, long int);
+	    } else {
+		num = va_arg(ap, int);
+	    }
+	    length = PrintNum(buf, num, 2, 0, width, ladjust, padc, 0);
+	    OUTPUT(arg, buf, length);
+	    break;
+
+	 case 'd':
+	 case 'D':
+	    if (longFlag) {
+		num = va_arg(ap, long int);
+	    } else {
+		num = va_arg(ap, int);
+	    }
+	    if (num < 0) {
+		num = - num;
+		negFlag = 1;
+	    }
+	    length = PrintNum(buf, num, 10, negFlag, width, ladjust, padc, 0);
+	    OUTPUT(arg, buf, length);
+	    break;
+
+	 case 'o':
+	 case 'O':
+	    if (longFlag) {
+		num = va_arg(ap, long int);
+	    } else {
+		num = va_arg(ap, int);
+	    }
+	    length = PrintNum(buf, num, 8, 0, width, ladjust, padc, 0);
+	    OUTPUT(arg, buf, length);
+	    break;
+
+	 case 'u':
+	 case 'U':
+	    if (longFlag) {
+		num = va_arg(ap, long int);
+	    } else {
+		num = va_arg(ap, int);
+	    }
+	    length = PrintNum(buf, num, 10, 0, width, ladjust, padc, 0);
+	    OUTPUT(arg, buf, length);
+	    break;
+
+	 case 'x':
+	    if (longFlag) {
+		num = va_arg(ap, long int);
+	    } else {
+		num = va_arg(ap, int);
+	    }
+	    length = PrintNum(buf, num, 16, 0, width, ladjust, padc, 0);
+	    OUTPUT(arg, buf, length);
+	    break;
+
+	 case 'X':
+	    if (longFlag) {
+		num = va_arg(ap, long int);
+	    } else {
+		num = va_arg(ap, int);
+	    }
+	    length = PrintNum(buf, num, 16, 0, width, ladjust, padc, 1);
+	    OUTPUT(arg, buf, length);
+	    break;
+
+	 case 'c':
+	    c = (char)va_arg(ap, int);
+	    length = PrintChar(buf, c, width, ladjust);
+	    OUTPUT(arg, buf, length);
+	    break;
+
+	 case 's':
+	    s = (char*)va_arg(ap, char *);
+	    length = PrintString(buf, s, width, ladjust);
+	    OUTPUT(arg, buf, length);
+	    break;
+
+	 case '\0':
+	    fmt --;
+	    break;
+
+	 default:
+	    /* output this char as it is */
+	    OUTPUT(arg, fmt, 1);
+	}	/* switch (*fmt) */
+
+	fmt ++;
+    }		/* for(;;) */
+
+    /* special termination call */
+    OUTPUT(arg, "\0", 1);
+}
+
+
+/* --------------- local help functions --------------------- */
+static int
+PrintChar(char * buf, char c, int length, int ladjust)
+{
+    int i;
+
+    if (length < 1) length = 1;
+    if (ladjust) {
+	*buf = c;
+	for (i=1; i< length; i++) buf[i] = ' ';
+    } else {
+	for (i=0; i< length-1; i++) buf[i] = ' ';
+	buf[length - 1] = c;
+    }
+    return length;
+}
+
+static int
+PrintString(char * buf, char* s, int length, int ladjust)
+{
+    int i;
+    int len=0;
+    char* s1 = s;
+    while (*s1++) len++;
+    if (length < len) length = len;
+
+    if (ladjust) {
+	for (i=0; i< len; i++) buf[i] = s[i];
+	for (i=len; i< length; i++) buf[i] = ' ';
+    } else {
+	for (i=0; i< length-len; i++) buf[i] = ' ';
+	for (i=length-len; i < length; i++) buf[i] = s[i-length+len];
+    }
+    return length;
+}
+
+static int
+PrintNum(char * buf, unsigned long u, int base, int negFlag,
+	 int length, int ladjust, char padc, int upcase)
+{
+    /* algorithm :
+     *  1. prints the number from left to right in reverse form.
+     *  2. fill the remaining spaces with padc if length is longer than
+     *     the actual length
+     *     TRICKY : if left adjusted, no "0" padding.
+     *		    if negtive, insert  "0" padding between "0" and number.
+     *  3. if (!ladjust) we reverse the whole string including paddings
+     *  4. otherwise we only reverse the actual string representing the num.
+     */
+
+    int actualLength =0;
+    char *p = buf;
+    int i;
+
+    do {
+	int tmp = u %base;
+	if (tmp <= 9) {
+	    *p++ = '0' + tmp;
+	} else if (upcase) {
+	    *p++ = 'A' + tmp - 10;
+	} else {
+	    *p++ = 'a' + tmp - 10;
+	}
+	u /= base;
+    } while (u != 0);
+
+    if (negFlag) {
+	*p++ = '-';
+    }
+
+    /* figure out actual length and adjust the maximum length */
+    actualLength = p - buf;
+    if (length < actualLength) length = actualLength;
+
+    /* add padding */
+    if (ladjust) {
+	padc = ' ';
+    }
+    if (negFlag && !ladjust && (padc == '0')) {
+	for (i = actualLength-1; i< length-1; i++) buf[i] = padc;
+	buf[length -1] = '-';
+    } else {
+	for (i = actualLength; i< length; i++) buf[i] = padc;
+    }
+
+
+    /* prepare to reverse the string */
+    {
+	int begin = 0;
+	int end;
+	if (ladjust) {
+	    end = actualLength - 1;
+	} else {
+	    end = length -1;
+	}
+
+	while (end > begin) {
+	    char tmp = buf[begin];
+	    buf[begin] = buf[end];
+	    buf[end] = tmp;
+	    begin ++;
+	    end --;
+	}
+    }
+
+    /* adjust the string pointer */
+    return length;
+}
+
+static void printf_output(void *arg, char *s, int l)
+{
+    int i;
+
+    // special termination call
+    if ((l==1) && (s[0] == '\0')) return;
+
+    for (i=0; i< l; i++) {
+	board_putc(s[i]);
+	if (s[i] == '\n') board_putc('\r');
+    }
+}
+
+void printf(char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    lp_Print(printf_output, 0, fmt, ap);
+    va_end(ap);
+}

--- a/target/linux/econet/image/lzma-loader/src/printf.h
+++ b/target/linux/econet/image/lzma-loader/src/printf.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2001 MontaVista Software Inc.
+ * Author: Jun Sun, jsun@mvista.com or jsun@junsun.net
+ *
+ * This program is free software; you can redistribute  it and/or modify it
+ * under  the terms of  the GNU General  Public License as published by the
+ * Free Software Foundation;  either version 2 of the  License, or (at your
+ * option) any later version.
+ *
+ */
+
+#ifndef _printf_h_
+#define _printf_h_
+
+#include <stdarg.h>
+void printf(char *fmt, ...);
+
+#endif /* _printf_h_ */

--- a/target/linux/econet/image/lzma-loader/src/spi_controller.c
+++ b/target/linux/econet/image/lzma-loader/src/spi_controller.c
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * SPI Controller driver for EcoNet EN751221 SoC
+ *
+ * Minimal implementation for lzma-loader SPI-NAND boot support.
+ *
+ * Copyright (C) 2025 Ahmed Naseef <naseefkm@gmail.com>
+ */
+
+#include "spi_controller.h"
+
+/*
+ * Internal helper: Set operation FIFO command
+ *
+ * Queues an operation to the SPI controller's command FIFO.
+ * The controller processes these commands to generate SPI bus activity.
+ *
+ * @op_cmd: Operation code (SPI_OP_*)
+ * @op_len: Number of bytes/cycles for this operation (1-511)
+ */
+static void spi_set_opfifo(uint8_t op_cmd, uint32_t op_len)
+{
+    uint32_t cmd;
+
+    /* Build command word: (opcode << 9) | length */
+    cmd = ((op_cmd & SPI_OP_CMD_MASK) << SPI_OP_CMD_SHIFT) |
+          (op_len & SPI_OP_LEN_MASK);
+
+    /* Write command to OPFIFO data register */
+    writel(cmd, SPI_REG_OPFIFO_WDATA);
+
+    /* Wait until OPFIFO has room */
+    while (readl(SPI_REG_OPFIFO_FULL))
+        ;
+
+    /* Trigger write from WDATA register to OPFIFO */
+    writel(1, SPI_REG_OPFIFO_WR);
+
+    /* Wait until OPFIFO is empty (command processed) */
+    while (!readl(SPI_REG_OPFIFO_EMPTY))
+        ;
+}
+
+/*
+ * Internal helper: Write bytes to data FIFO
+ *
+ * Queues data bytes to the SPI controller's data FIFO for transmission.
+ * Must be called after setting up the corresponding output operation.
+ *
+ * @buf: Data buffer to write
+ * @len: Number of bytes to write
+ */
+static void spi_write_dfifo(const uint8_t *buf, uint32_t len)
+{
+    uint32_t i;
+
+    for (i = 0; i < len; i++) {
+        /* Wait until DFIFO has room */
+        while (readl(SPI_REG_DFIFO_FULL))
+            ;
+
+        /* Write data byte */
+        writel(buf[i] & SPI_DFIFO_MASK, SPI_REG_DFIFO_WDATA);
+
+        /* Wait for byte to be accepted */
+        while (readl(SPI_REG_DFIFO_FULL))
+            ;
+    }
+}
+
+/*
+ * Internal helper: Read bytes from data FIFO
+ *
+ * Reads data bytes from the SPI controller's data FIFO.
+ * Must be called after setting up the corresponding input operation.
+ *
+ * @buf: Buffer to store read data
+ * @len: Number of bytes to read
+ */
+static void spi_read_dfifo(uint8_t *buf, uint32_t len)
+{
+    uint32_t i;
+
+    for (i = 0; i < len; i++) {
+        /* Wait until DFIFO has data */
+        while (readl(SPI_REG_DFIFO_EMPTY))
+            ;
+
+        /* Read data byte */
+        buf[i] = readl(SPI_REG_DFIFO_RDATA) & SPI_DFIFO_MASK;
+
+        /* Advance to next byte */
+        writel(1, SPI_REG_DFIFO_RD);
+    }
+}
+
+/*
+ * Initialize SPI controller in manual mode
+ */
+void spi_controller_init(void)
+{
+    /* Disable read idle state (stops auto-read mode) */
+    writel(SPI_VAL_READ_IDLE_DISABLE, SPI_REG_READ_IDLE_EN);
+
+    /* Wait for read controller FSM to reach idle state */
+    while (readl(SPI_REG_RDCTL_FSM))
+        ;
+
+    /* Switch from auto mode to manual mode */
+    writel(SPI_VAL_MTX_MODE_MANUAL, SPI_REG_MTX_MODE_TOG);
+
+    /* Enable manual mode */
+    writel(SPI_VAL_MANUAL_ENABLE, SPI_REG_MANUAL_EN);
+}
+
+/*
+ * Assert chip select (active low)
+ *
+ * Note: CSL is called twice as a timing workaround for the hardware.
+ */
+void spi_cs_low(void)
+{
+    spi_set_opfifo(SPI_OP_CSL, 1);
+    spi_set_opfifo(SPI_OP_CSL, 1);
+}
+
+/*
+ * Deassert chip select
+ *
+ * Note: 5 clock cycles are added after CSH for timing margin.
+ */
+void spi_cs_high(void)
+{
+    spi_set_opfifo(SPI_OP_CSH, 1);
+    spi_set_opfifo(SPI_OP_CK, 5);
+}
+
+/*
+ * Write a single byte to SPI bus
+ */
+void spi_write_byte(uint8_t data)
+{
+    spi_set_opfifo(SPI_OP_OUTS, 1);
+    spi_write_dfifo(&data, 1);
+}
+
+/*
+ * Write multiple bytes to SPI bus
+ *
+ * Handles chunking for transfers larger than the hardware
+ * maximum of 511 bytes per operation.
+ */
+void spi_write_nbyte(const uint8_t *buf, uint32_t len)
+{
+    uint32_t chunk_len;
+    uint32_t offset = 0;
+
+    while (len > 0) {
+        /* Limit to maximum transfer size */
+        chunk_len = (len > SPI_OP_LEN_MAX) ? SPI_OP_LEN_MAX : len;
+
+        /* Set up output operation */
+        spi_set_opfifo(SPI_OP_OUTS, chunk_len);
+
+        /* Write data to DFIFO */
+        spi_write_dfifo(buf + offset, chunk_len);
+
+        offset += chunk_len;
+        len -= chunk_len;
+    }
+}
+
+/*
+ * Read multiple bytes from SPI bus
+ *
+ * Handles chunking for transfers larger than the hardware
+ * maximum of 511 bytes per operation.
+ */
+void spi_read_nbyte(uint8_t *buf, uint32_t len)
+{
+    uint32_t chunk_len;
+    uint32_t offset = 0;
+
+    while (len > 0) {
+        /* Limit to maximum transfer size */
+        chunk_len = (len > SPI_OP_LEN_MAX) ? SPI_OP_LEN_MAX : len;
+
+        /* Set up input operation */
+        spi_set_opfifo(SPI_OP_INS, chunk_len);
+
+        /* Read data from DFIFO */
+        spi_read_dfifo(buf + offset, chunk_len);
+
+        offset += chunk_len;
+        len -= chunk_len;
+    }
+}

--- a/target/linux/econet/image/lzma-loader/src/spi_controller.h
+++ b/target/linux/econet/image/lzma-loader/src/spi_controller.h
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * SPI Controller driver for EcoNet EN751221 SoC
+ *
+ * Register definitions and function prototypes for SPI controller access.
+ *
+ * Copyright (C) 2025 Ahmed Naseef <naseefkm@gmail.com>
+ */
+
+#ifndef _SPI_CONTROLLER_H_
+#define _SPI_CONTROLLER_H_
+
+#include <stdint.h>
+
+/*
+ * Memory-mapped I/O accessors
+ */
+#define readl(addr)         (*(volatile uint32_t *)(addr))
+#define writel(val, addr)   (*(volatile uint32_t *)(addr) = (val))
+
+/*
+ * SPI Controller Register Definitions
+ * Base address: 0xBFA10000 (KSEG1 mapped)
+ */
+#define SPI_CONTROLLER_BASE             0xBFA10000
+
+/* Control registers */
+#define SPI_REG_READ_MODE               (SPI_CONTROLLER_BASE + 0x0000)
+#define SPI_REG_READ_IDLE_EN            (SPI_CONTROLLER_BASE + 0x0004)
+#define SPI_REG_SIDLY                   (SPI_CONTROLLER_BASE + 0x0008)
+#define SPI_REG_CSHEXT                  (SPI_CONTROLLER_BASE + 0x000C)
+#define SPI_REG_CSLEXT                  (SPI_CONTROLLER_BASE + 0x0010)
+#define SPI_REG_MTX_MODE_TOG            (SPI_CONTROLLER_BASE + 0x0014)
+#define SPI_REG_RDCTL_FSM               (SPI_CONTROLLER_BASE + 0x0018)
+#define SPI_REG_MACMUX_SEL              (SPI_CONTROLLER_BASE + 0x001C)
+#define SPI_REG_MANUAL_EN               (SPI_CONTROLLER_BASE + 0x0020)
+
+/* Operation FIFO registers */
+#define SPI_REG_OPFIFO_EMPTY            (SPI_CONTROLLER_BASE + 0x0024)
+#define SPI_REG_OPFIFO_WDATA            (SPI_CONTROLLER_BASE + 0x0028)
+#define SPI_REG_OPFIFO_FULL             (SPI_CONTROLLER_BASE + 0x002C)
+#define SPI_REG_OPFIFO_WR               (SPI_CONTROLLER_BASE + 0x0030)
+
+/* Data FIFO registers */
+#define SPI_REG_DFIFO_FULL              (SPI_CONTROLLER_BASE + 0x0034)
+#define SPI_REG_DFIFO_WDATA             (SPI_CONTROLLER_BASE + 0x0038)
+#define SPI_REG_DFIFO_EMPTY             (SPI_CONTROLLER_BASE + 0x003C)
+#define SPI_REG_DFIFO_RD                (SPI_CONTROLLER_BASE + 0x0040)
+#define SPI_REG_DFIFO_RDATA             (SPI_CONTROLLER_BASE + 0x0044)
+
+/* Misc registers */
+#define SPI_REG_DUMMY                   (SPI_CONTROLLER_BASE + 0x0080)
+#define SPI_REG_PROBE_SEL               (SPI_CONTROLLER_BASE + 0x0088)
+#define SPI_REG_INTERRUPT               (SPI_CONTROLLER_BASE + 0x0090)
+#define SPI_REG_INTERRUPT_EN            (SPI_CONTROLLER_BASE + 0x0094)
+#define SPI_REG_SI_CK_SEL               (SPI_CONTROLLER_BASE + 0x009C)
+
+/*
+ * Operation codes for OPFIFO
+ * Format: (opcode << 9) | length
+ */
+#define SPI_OP_CSH                      0x00    /* Chip select high */
+#define SPI_OP_CSL                      0x01    /* Chip select low */
+#define SPI_OP_CK                       0x02    /* Clock cycles */
+#define SPI_OP_OUTS                     0x08    /* Output single */
+#define SPI_OP_OUTD                     0x09    /* Output dual */
+#define SPI_OP_OUTQ                     0x0A    /* Output quad */
+#define SPI_OP_INS                      0x0C    /* Input single */
+#define SPI_OP_INS0                     0x0D    /* Input single (variant) */
+#define SPI_OP_IND                      0x0E    /* Input dual */
+#define SPI_OP_INQ                      0x0F    /* Input quad */
+#define SPI_OP_OS2IS                    0x10    /* Output single, switch to input single */
+#define SPI_OP_OS2ID                    0x11    /* Output single, switch to input dual */
+#define SPI_OP_OS2IQ                    0x12    /* Output single, switch to input quad */
+#define SPI_OP_OD2IS                    0x13    /* Output dual, switch to input single */
+#define SPI_OP_OD2ID                    0x14    /* Output dual, switch to input dual */
+#define SPI_OP_OD2IQ                    0x15    /* Output dual, switch to input quad */
+#define SPI_OP_OQ2IS                    0x16    /* Output quad, switch to input single */
+#define SPI_OP_OQ2ID                    0x17    /* Output quad, switch to input dual */
+#define SPI_OP_OQ2IQ                    0x18    /* Output quad, switch to input quad */
+#define SPI_OP_OSNIS                    0x19    /* Output single, no input switch */
+#define SPI_OP_ODNID                    0x1A    /* Output dual, no input dual */
+
+/* Operation code field masks and shifts */
+#define SPI_OP_CMD_MASK                 0x1F
+#define SPI_OP_CMD_SHIFT                9
+#define SPI_OP_LEN_MASK                 0x1FF
+#define SPI_OP_LEN_MAX                  0x1FF   /* Max 511 bytes per operation */
+
+/* Data FIFO mask */
+#define SPI_DFIFO_MASK                  0xFF
+
+/* Manual mode values */
+#define SPI_VAL_READ_IDLE_DISABLE       0x00
+#define SPI_VAL_MTX_MODE_MANUAL         0x09
+#define SPI_VAL_MANUAL_ENABLE           0x01
+
+/*
+ * Function prototypes
+ */
+
+/**
+ * spi_controller_init - Initialize SPI controller in manual mode
+ *
+ * Disables auto-read mode and enables manual mode for direct
+ * SPI bus access. Must be called before any SPI operations.
+ */
+void spi_controller_init(void);
+
+/**
+ * spi_cs_low - Assert chip select (active low)
+ *
+ * Pulls the SPI chip select line low to begin a transaction.
+ */
+void spi_cs_low(void);
+
+/**
+ * spi_cs_high - Deassert chip select
+ *
+ * Pulls the SPI chip select line high to end a transaction.
+ * Also generates additional clock cycles for timing.
+ */
+void spi_cs_high(void);
+
+/**
+ * spi_write_byte - Write a single byte to SPI bus
+ * @data: Byte to write
+ *
+ * Writes one byte using single-speed SPI.
+ */
+void spi_write_byte(uint8_t data);
+
+/**
+ * spi_write_nbyte - Write multiple bytes to SPI bus
+ * @buf: Buffer containing data to write
+ * @len: Number of bytes to write
+ *
+ * Writes up to len bytes using single-speed SPI.
+ * Handles chunking for transfers larger than 511 bytes.
+ */
+void spi_write_nbyte(const uint8_t *buf, uint32_t len);
+
+/**
+ * spi_read_nbyte - Read multiple bytes from SPI bus
+ * @buf: Buffer to store read data
+ * @len: Number of bytes to read
+ *
+ * Reads len bytes using single-speed SPI.
+ * Handles chunking for transfers larger than 511 bytes.
+ */
+void spi_read_nbyte(uint8_t *buf, uint32_t len);
+
+#endif /* _SPI_CONTROLLER_H_ */

--- a/target/linux/econet/image/lzma-loader/src/spi_nand.c
+++ b/target/linux/econet/image/lzma-loader/src/spi_nand.c
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * SPI-NAND Flash driver for EcoNet EN751221 SoC
+ *
+ * Minimal read-only implementation for lzma-loader boot support.
+ * Supports Dosilicon, MXIC, and Toshiba SPI-NAND chips.
+ *
+ * Copyright (C) 2025 Ahmed Naseef <naseefkm@gmail.com>
+ */
+
+#include "spi_nand.h"
+#include "spi_controller.h"
+#include "printf.h"
+
+/* Global flash information */
+static struct spinand_info flash_info;
+
+/*
+ * Supported SPI-NAND device table
+ *
+ * Note: dummy_bytes indicates number of dummy bytes for READ_FROM_CACHE (0x03):
+ *   - 1 = append dummy byte (Dosilicon and most chips)
+ *   - 0 = no dummy byte (uncommon, check datasheet)
+ */
+static const struct spinand_device supported_devices[] = {
+    /* Dosilicon (used in Platinum 4410) */
+    { 0xE5, 0x71, "Dosilicon DS35Q1GA", 2048, 64, 64, 1024, 1 },
+    { 0xE5, 0x21, "Dosilicon DS35M1GA", 2048, 64, 64, 1024, 1 },
+
+    /* MXIC (Macronix) */
+    { 0xC2, 0x12, "MXIC MX35LF1GE4AB", 2048, 64, 64, 1024, 1 },
+
+    /* Toshiba */
+    { 0x98, 0xCB, "Toshiba TC58CVG1S3H", 2048, 64, 64, 2048, 1 },
+
+    /* Terminator */
+    { 0, 0, NULL, 0, 0, 0, 0, 0 }
+};
+
+/* Simple delay for wait loops */
+static void udelay(uint32_t us)
+{
+    volatile uint32_t i;
+    /* Rough delay - assumes ~200MHz CPU */
+    for (i = 0; i < us * 50; i++)
+        ;
+}
+
+/*
+ * Read manufacturer and device ID
+ */
+int spi_nand_read_id(uint8_t *mfr_id, uint8_t *dev_id)
+{
+    uint8_t cmd[2] = { SPINAND_CMD_READ_ID, 0x00 };
+    uint8_t id[2];
+
+    /* CS low */
+    spi_cs_low();
+
+    /* Send READ_ID command + address byte */
+    spi_write_nbyte(cmd, 2);
+
+    /* Read manufacturer ID and device ID */
+    spi_read_nbyte(id, 2);
+
+    /* CS high */
+    spi_cs_high();
+
+    *mfr_id = id[0];
+    *dev_id = id[1];
+
+    return 0;
+}
+
+/*
+ * Read feature register
+ */
+int spi_nand_get_feature(uint8_t reg, uint8_t *val)
+{
+    uint8_t cmd[2] = { SPINAND_CMD_GET_FEATURE, reg };
+
+    /* CS low */
+    spi_cs_low();
+
+    /* Send GET_FEATURE command + register address */
+    spi_write_nbyte(cmd, 2);
+
+    /* Read register value */
+    spi_read_nbyte(val, 1);
+
+    /* CS high */
+    spi_cs_high();
+
+    return 0;
+}
+
+/*
+ * Wait for flash to become ready (OIP bit clears)
+ */
+int spi_nand_wait_ready(uint32_t timeout_ms)
+{
+    uint8_t status;
+    uint32_t timeout;
+
+    /* Convert ms to loop iterations (rough estimate) */
+    timeout = timeout_ms * 100;
+
+    do {
+        if (spi_nand_get_feature(SPINAND_REG_STATUS, &status) < 0)
+            return -1;
+
+        if (!(status & SPINAND_STATUS_OIP))
+            return 0;  /* Ready */
+
+        udelay(10);
+    } while (--timeout > 0);
+
+    return -1;  /* Timeout */
+}
+
+/*
+ * Load page into flash chip's internal cache
+ */
+static int spi_nand_page_read_to_cache(uint32_t page)
+{
+    uint8_t cmd[4];
+
+    /* Build PAGE_READ command with row address */
+    cmd[0] = SPINAND_CMD_PAGE_READ;
+    cmd[1] = (page >> 16) & 0xFF;  /* Row address byte 2 */
+    cmd[2] = (page >> 8) & 0xFF;   /* Row address byte 1 */
+    cmd[3] = page & 0xFF;          /* Row address byte 0 */
+
+    /* CS low */
+    spi_cs_low();
+
+    /* Send command */
+    spi_write_nbyte(cmd, 4);
+
+    /* CS high */
+    spi_cs_high();
+
+    return 0;
+}
+
+/*
+ * Read data from flash chip's internal cache
+ */
+static int spi_nand_read_from_cache(uint16_t column, uint8_t *buf, uint32_t len)
+{
+    uint8_t cmd[4];
+
+    /* Build READ_FROM_CACHE command */
+    cmd[0] = SPINAND_CMD_READ_FROM_CACHE;
+    cmd[1] = (column >> 8) & 0xFF;  /* Column address high */
+    cmd[2] = column & 0xFF;         /* Column address low */
+    cmd[3] = 0x00;                  /* Dummy byte (required by Dosilicon) */
+
+    /* CS low */
+    spi_cs_low();
+
+    /* Send command + address + dummy */
+    spi_write_nbyte(cmd, 4);
+
+    /* Read data */
+    spi_read_nbyte(buf, len);
+
+    /* CS high */
+    spi_cs_high();
+
+    return 0;
+}
+
+/*
+ * Read a complete page (data only)
+ */
+int spi_nand_read_page(uint32_t page, uint8_t *buf)
+{
+    /* Step 1: Load page into cache */
+    if (spi_nand_page_read_to_cache(page) < 0)
+        return -1;
+
+    /* Step 2: Wait for page load to complete */
+    if (spi_nand_wait_ready(100) < 0)  /* 100ms timeout */
+        return -1;
+
+    /* Step 3: Read from cache (data area only, column 0 to page_size) */
+    if (spi_nand_read_from_cache(0, buf, flash_info.page_size) < 0)
+        return -1;
+
+    return 0;
+}
+
+/*
+ * Read a complete page including OOB
+ */
+int spi_nand_read_page_with_oob(uint32_t page, uint8_t *buf, uint8_t *oob)
+{
+    /* Step 1: Load page into cache */
+    if (spi_nand_page_read_to_cache(page) < 0)
+        return -1;
+
+    /* Step 2: Wait for page load to complete */
+    if (spi_nand_wait_ready(100) < 0)
+        return -1;
+
+    /* Step 3: Read main data from cache */
+    if (spi_nand_read_from_cache(0, buf, flash_info.page_size) < 0)
+        return -1;
+
+    /* Step 4: Read OOB data from cache */
+    if (spi_nand_read_from_cache(flash_info.page_size, oob, flash_info.oob_size) < 0)
+        return -1;
+
+    return 0;
+}
+
+/*
+ * Initialize SPI-NAND flash
+ */
+int spi_nand_init(void)
+{
+    uint8_t mfr_id, dev_id;
+    const struct spinand_device *device = NULL;
+    int i;
+
+    /* Initialize SPI controller first */
+    spi_controller_init();
+
+    /* Read flash ID */
+    if (spi_nand_read_id(&mfr_id, &dev_id) < 0) {
+        printf("SPI-NAND: Failed to read ID\n");
+        return -1;
+    }
+
+    printf("SPI-NAND: ID %02x:%02x\n", mfr_id, dev_id);
+
+    /* Search device table */
+    for (i = 0; supported_devices[i].name != NULL; i++) {
+        if (supported_devices[i].mfr_id == mfr_id &&
+            supported_devices[i].dev_id == dev_id) {
+            device = &supported_devices[i];
+            break;
+        }
+    }
+
+    if (device == NULL) {
+        printf("SPI-NAND: Unsupported chip %02x:%02x\n", mfr_id, dev_id);
+        printf("SPI-NAND: Add entry to supported_devices[] table\n");
+        return -1;
+    }
+
+    /* Initialize flash info structure from device table */
+    flash_info.mfr_id = mfr_id;
+    flash_info.dev_id = dev_id;
+    flash_info.page_size = device->page_size;
+    flash_info.oob_size = device->oob_size;
+    flash_info.pages_per_block = device->pages_per_block;
+    flash_info.total_blocks = device->total_blocks;
+
+    printf("SPI-NAND: %s\n", device->name);
+    printf("  Capacity: %d MB (%d blocks)\n",
+           (device->page_size * device->pages_per_block * device->total_blocks) / (1024 * 1024),
+           device->total_blocks);
+    printf("  Page: %d bytes, OOB: %d bytes\n",
+           device->page_size, device->oob_size);
+    printf("  Block: %d KB (%d pages)\n",
+           (device->page_size * device->pages_per_block) / 1024,
+           device->pages_per_block);
+
+    return 0;
+}
+
+/*
+ * Get flash information
+ */
+const struct spinand_info *spi_nand_get_info(void)
+{
+    return &flash_info;
+}
+
+/*
+ * Helper: Convert block number to first page number
+ */
+uint32_t spi_nand_block_to_page(uint32_t block)
+{
+    return block * flash_info.pages_per_block;
+}
+
+/*
+ * Helper: Convert page number to block number
+ */
+uint32_t spi_nand_page_to_block(uint32_t page)
+{
+    return page / flash_info.pages_per_block;
+}
+
+/*
+ * Helper: Convert byte address to page number
+ */
+uint32_t spi_nand_addr_to_page(uint32_t addr)
+{
+    return addr / flash_info.page_size;
+}
+
+/*
+ * Helper: Get offset within page
+ */
+uint32_t spi_nand_addr_to_offset(uint32_t addr)
+{
+    return addr % flash_info.page_size;
+}

--- a/target/linux/econet/image/lzma-loader/src/spi_nand.c
+++ b/target/linux/econet/image/lzma-loader/src/spi_nand.c
@@ -3,7 +3,7 @@
  * SPI-NAND Flash driver for EcoNet EN751221 SoC
  *
  * Minimal read-only implementation for lzma-loader boot support.
- * Supports Dosilicon, MXIC, and Toshiba SPI-NAND chips.
+ * Supports Dosilicon, MXIC, Toshiba, and Winbond SPI-NAND chips.
  *
  * Copyright (C) 2025 Ahmed Naseef <naseefkm@gmail.com>
  */
@@ -32,6 +32,9 @@ static const struct spinand_device supported_devices[] = {
 
     /* Toshiba */
     { 0x98, 0xCB, "Toshiba TC58CVG1S3H", 2048, 64, 64, 2048, 1 },
+
+    /* Winbond */
+    { 0xEF, 0xAA, "Winbond W25N01GV", 2048, 64, 64, 1024, 1 },
 
     /* Terminator */
     { 0, 0, NULL, 0, 0, 0, 0, 0 }

--- a/target/linux/econet/image/lzma-loader/src/spi_nand.h
+++ b/target/linux/econet/image/lzma-loader/src/spi_nand.h
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * SPI-NAND Flash driver for EcoNet EN751221 SoC
+ *
+ * Minimal read-only implementation for lzma-loader boot support.
+ *
+ * Copyright (C) 2025 Ahmed Naseef <naseefkm@gmail.com>
+ */
+
+#ifndef _SPI_NAND_H_
+#define _SPI_NAND_H_
+
+#include <stdint.h>
+
+/* NULL definition for bootloader environment */
+#ifndef NULL
+#define NULL 0
+#endif
+
+/*
+ * Maximum supported flash geometry
+ *
+ * These values define the maximum supported page and OOB sizes across all
+ * SPI-NAND chips this driver may support. Used for static buffer allocation.
+ */
+#define SPINAND_MAX_PAGE_SIZE           4096
+#define SPINAND_MAX_OOB_SIZE            256
+
+/*
+ * SPI-NAND Command Set
+ */
+#define SPINAND_CMD_READ_ID                 0x9F
+#define SPINAND_CMD_GET_FEATURE             0x0F
+#define SPINAND_CMD_SET_FEATURE             0x1F
+#define SPINAND_CMD_PAGE_READ               0x13    /* Load page into cache */
+#define SPINAND_CMD_READ_FROM_CACHE         0x03    /* Read from cache (single) */
+#define SPINAND_CMD_READ_FROM_CACHE_X2      0x3B    /* Read from cache (dual) */
+#define SPINAND_CMD_READ_FROM_CACHE_X4      0x6B    /* Read from cache (quad) */
+
+/* Feature register addresses */
+#define SPINAND_REG_PROTECTION              0xA0
+#define SPINAND_REG_FEATURE                 0xB0
+#define SPINAND_REG_STATUS                  0xC0
+
+/* Status register bits */
+#define SPINAND_STATUS_OIP                  0x01    /* Operation In Progress */
+#define SPINAND_STATUS_WEL                  0x02    /* Write Enable Latch */
+#define SPINAND_STATUS_E_FAIL               0x04    /* Erase failed */
+#define SPINAND_STATUS_P_FAIL               0x08    /* Program failed */
+#define SPINAND_STATUS_ECC_MASK             0x30    /* ECC status mask */
+#define SPINAND_STATUS_ECC_SHIFT            4
+
+/* ECC status values */
+#define SPINAND_ECC_NO_ERROR                0x00
+#define SPINAND_ECC_CORRECTED               0x01
+#define SPINAND_ECC_UNCORRECTABLE           0x02
+
+/*
+ * Flash information structure
+ */
+struct spinand_info {
+    uint8_t  mfr_id;                /* Manufacturer ID */
+    uint8_t  dev_id;                /* Device ID */
+    uint32_t page_size;             /* Page size in bytes */
+    uint32_t oob_size;              /* OOB/spare size in bytes */
+    uint32_t pages_per_block;       /* Pages per block */
+    uint32_t total_blocks;          /* Total number of blocks */
+};
+
+/*
+ * Device table entry for supported SPI-NAND chips
+ */
+struct spinand_device {
+    uint8_t  mfr_id;                /* Manufacturer ID */
+    uint8_t  dev_id;                /* Device ID */
+    const char *name;               /* Human-readable chip name */
+    uint32_t page_size;             /* Page size in bytes */
+    uint32_t oob_size;              /* OOB/spare size in bytes */
+    uint32_t pages_per_block;       /* Pages per block */
+    uint32_t total_blocks;          /* Total number of blocks */
+    uint8_t  dummy_bytes;           /* Dummy bytes for READ_FROM_CACHE command */
+};
+
+/*
+ * Function prototypes
+ */
+
+/**
+ * spi_nand_init - Initialize and probe SPI-NAND flash
+ *
+ * Reads flash ID and verifies it's a supported Dosilicon chip.
+ * Stores flash geometry in global structure for later use.
+ *
+ * Returns: 0 on success, -1 on error
+ */
+int spi_nand_init(void);
+
+/**
+ * spi_nand_read_id - Read manufacturer and device ID
+ * @mfr_id: Pointer to store manufacturer ID
+ * @dev_id: Pointer to store device ID
+ *
+ * Returns: 0 on success, -1 on error
+ */
+int spi_nand_read_id(uint8_t *mfr_id, uint8_t *dev_id);
+
+/**
+ * spi_nand_get_feature - Read feature register
+ * @reg: Register address (SPINAND_REG_*)
+ * @val: Pointer to store register value
+ *
+ * Returns: 0 on success, -1 on error
+ */
+int spi_nand_get_feature(uint8_t reg, uint8_t *val);
+
+/**
+ * spi_nand_wait_ready - Wait for flash operation to complete
+ * @timeout_ms: Maximum time to wait in milliseconds
+ *
+ * Polls the OIP (Operation In Progress) bit until it clears
+ * or timeout occurs.
+ *
+ * Returns: 0 on success, -1 on timeout
+ */
+int spi_nand_wait_ready(uint32_t timeout_ms);
+
+/**
+ * spi_nand_read_page - Read a page from flash
+ * @page: Page number to read
+ * @buf: Buffer to store page data (must be SPINAND_PAGE_SIZE bytes)
+ *
+ * Loads the specified page into the flash chip's internal cache,
+ * then reads it out. Does not include OOB data.
+ *
+ * Returns: 0 on success, -1 on error
+ */
+int spi_nand_read_page(uint32_t page, uint8_t *buf);
+
+/**
+ * spi_nand_read_page_with_oob - Read a page including OOB
+ * @page: Page number to read
+ * @buf: Buffer to store page data (must be SPINAND_PAGE_SIZE bytes)
+ * @oob: Buffer to store OOB data (must be SPINAND_OOB_SIZE bytes)
+ *
+ * Reads both main data and OOB/spare area.
+ *
+ * Returns: 0 on success, -1 on error
+ */
+int spi_nand_read_page_with_oob(uint32_t page, uint8_t *buf, uint8_t *oob);
+
+/**
+ * spi_nand_block_to_page - Convert block number to first page number
+ * @block: Block number
+ *
+ * Note: Requires spi_nand_init() to be called first
+ * Returns: Page number of first page in block
+ */
+uint32_t spi_nand_block_to_page(uint32_t block);
+
+/**
+ * spi_nand_page_to_block - Convert page number to block number
+ * @page: Page number
+ *
+ * Note: Requires spi_nand_init() to be called first
+ * Returns: Block number containing the page
+ */
+uint32_t spi_nand_page_to_block(uint32_t page);
+
+/**
+ * spi_nand_addr_to_page - Convert byte address to page number
+ * @addr: Byte address
+ *
+ * Note: Requires spi_nand_init() to be called first
+ * Returns: Page number containing the address
+ */
+uint32_t spi_nand_addr_to_page(uint32_t addr);
+
+/**
+ * spi_nand_addr_to_offset - Get offset within page
+ * @addr: Byte address
+ *
+ * Note: Requires spi_nand_init() to be called first
+ * Returns: Offset within the page
+ */
+uint32_t spi_nand_addr_to_offset(uint32_t addr);
+
+/**
+ * spi_nand_get_info - Get flash information structure
+ *
+ * Returns: Pointer to flash info structure (valid after spi_nand_init)
+ */
+const struct spinand_info *spi_nand_get_info(void);
+
+#endif /* _SPI_NAND_H_ */

--- a/target/linux/econet/image/lzma-loader/src/string.c
+++ b/target/linux/econet/image/lzma-loader/src/string.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * Minimal string functions for lzma-loader
+ *
+ * Provides memcpy, memcmp, and memset for freestanding environment.
+ *
+ * Copyright (C) 2025 Ahmed Naseef <naseefkm@gmail.com>
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+void *memcpy(void *dest, const void *src, size_t n)
+{
+	uint8_t *d = dest;
+	const uint8_t *s = src;
+
+	while (n--)
+		*d++ = *s++;
+
+	return dest;
+}
+
+void *memset(void *s, int c, size_t n)
+{
+	uint8_t *p = s;
+
+	while (n--)
+		*p++ = (uint8_t)c;
+
+	return s;
+}
+
+int memcmp(const void *s1, const void *s2, size_t n)
+{
+	const uint8_t *p1 = s1;
+	const uint8_t *p2 = s2;
+
+	while (n--) {
+		if (*p1 != *p2)
+			return *p1 - *p2;
+		p1++;
+		p2++;
+	}
+
+	return 0;
+}

--- a/target/linux/econet/patches-6.12/012-mips-econet-add-fw_init_cmdline-support.patch
+++ b/target/linux/econet/patches-6.12/012-mips-econet-add-fw_init_cmdline-support.patch
@@ -1,0 +1,30 @@
+From: Ahmed Naseef <naseefkm@gmail.com>
+Subject: mips: econet: add fw_init_cmdline() support
+
+Add support for reading kernel command line from bootloader arguments.
+This enables the bootloader to pass arguments via fw_arg0 (argc) and
+fw_arg1 (argv), which are then parsed by fw_init_cmdline().
+
+This is needed for dual-image NAND boot support where the LZMA loader
+needs to pass the correct root device (root=/dev/mtdblockN) dynamically
+based on which partition (MAIN or SLAVE) is being booted.
+
+Signed-off-by: Ahmed Naseef <naseefkm@gmail.com>
+--- a/arch/mips/econet/init.c
++++ b/arch/mips/econet/init.c
+@@ -16,6 +16,7 @@
+ #include <asm/prom.h>
+ #include <asm/smp-ops.h>
+ #include <asm/reboot.h>
++#include <asm/fw/fw.h>
+
+ #define CR_AHB_RSTCR		((void __iomem *)CKSEG1ADDR(0x1fb00040))
+ #define RESET			BIT(31)
+@@ -31,6 +32,7 @@ static void hw_reset(char *command)
+ /* 1. Bring up early printk. */
+ void __init prom_init(void)
+ {
++	fw_init_cmdline();
+ 	setup_8250_early_printk_port(UART_BASE, UART_REG_SHIFT, 0);
+ 	_machine_restart = hw_reset;
+ }

--- a/target/linux/generic/pending-6.12/495-mtd-spinand-add-support-for-Dosilicon-DS35xx.patch
+++ b/target/linux/generic/pending-6.12/495-mtd-spinand-add-support-for-Dosilicon-DS35xx.patch
@@ -1,0 +1,145 @@
+From: Ahmed Naseef <naseefkm@gmail.com>
+Subject: [PATCH] mtd: spinand: add support for Dosilicon DS35Q1GA/DS35M1GA
+
+Add support for Dosilicon DS35Q1GA (3.3V) and DS35M1GA (1.8V) SPI NAND.
+
+These are 1Gbit (128MB) devices with:
+  - 2048 byte pages + 64 byte OOB
+  - 64 pages per block, 1024 blocks
+  - On-die 4-bit ECC per 512 byte sector
+
+The 64-byte OOB area is divided into 4 segments of 16 bytes, with each
+segment containing 8 bytes of user data (M2+M1) and 8 bytes of ECC
+parity (R1). This provides 30 bytes of usable OOB space after reserving
+2 bytes for the bad block marker.
+
+Tested on Genexis Platinum 4410 (EcoNet EN751221) by writing known
+patterns to OOB and verifying ECC parity placement in R1 regions.
+
+Datasheet:
+  https://www.dosilicon.com/resources/SPI%20NAND/DS35X1GAXXX_rev08.pdf
+
+Signed-off-by: Ahmed Naseef <naseefkm@gmail.com>
+--- a/drivers/mtd/nand/spi/Makefile
++++ b/drivers/mtd/nand/spi/Makefile
+@@ -1,4 +1,4 @@
+ # SPDX-License-Identifier: GPL-2.0
+-spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fmsh.o foresee.o gigadevice.o
+-spinand-objs += macronix.o micron.o paragon.o toshiba.o winbond.o xtx.o
++spinand-objs := core.o alliancememory.o ato.o dosilicon.o esmt.o etron.o fmsh.o foresee.o
++spinand-objs += gigadevice.o macronix.o micron.o paragon.o toshiba.o winbond.o xtx.o
+ obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -1158,6 +1158,7 @@ static const struct nand_ops spinand_ops
+ static const struct spinand_manufacturer *spinand_manufacturers[] = {
+ 	&alliancememory_spinand_manufacturer,
+ 	&ato_spinand_manufacturer,
++	&dosilicon_spinand_manufacturer,
+ 	&esmt_8c_spinand_manufacturer,
+ 	&esmt_c8_spinand_manufacturer,
+ 	&etron_spinand_manufacturer,
+--- /dev/null
++++ b/drivers/mtd/nand/spi/dosilicon.c
+@@ -0,0 +1,91 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Author: Ahmed Naseef <naseefkm@gmail.com>
++ */
++
++#include <linux/device.h>
++#include <linux/kernel.h>
++#include <linux/mtd/spinand.h>
++
++#define SPINAND_MFR_DOSILICON        0xE5
++
++static SPINAND_OP_VARIANTS(read_cache_variants,
++		SPINAND_PAGE_READ_FROM_CACHE_X4_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_X2_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(true, 0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(false, 0, 1, NULL, 0));
++
++static SPINAND_OP_VARIANTS(write_cache_variants,
++		SPINAND_PROG_LOAD_X4(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD(true, 0, NULL, 0));
++
++static SPINAND_OP_VARIANTS(update_cache_variants,
++		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
++		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++
++static int ds35xx_ooblayout_ecc(struct mtd_info *mtd, int section,
++				struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	region->offset = 8 + (section * 16);
++	region->length = 8;
++
++	return 0;
++}
++
++static int ds35xx_ooblayout_free(struct mtd_info *mtd, int section,
++				 struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	if (section == 0) {
++		/* reserve 2 bytes for the BBM */
++		region->offset = 2;
++		region->length = 6;
++	} else {
++		region->offset = section * 16;
++		region->length = 8;
++	}
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops ds35xx_ooblayout = {
++	.ecc = ds35xx_ooblayout_ecc,
++	.free = ds35xx_ooblayout_free,
++};
++
++static const struct spinand_info dosilicon_spinand_table[] = {
++	SPINAND_INFO("DS35Q1GA",
++		SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x71),
++		NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
++		NAND_ECCREQ(4, 512),
++		SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					 &write_cache_variants,
++					 &update_cache_variants),
++		SPINAND_HAS_QE_BIT,
++		SPINAND_ECCINFO(&ds35xx_ooblayout, NULL)),
++	SPINAND_INFO("DS35M1GA",
++		SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x21),
++		NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
++		NAND_ECCREQ(4, 512),
++		SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					 &write_cache_variants,
++					 &update_cache_variants),
++		SPINAND_HAS_QE_BIT,
++		SPINAND_ECCINFO(&ds35xx_ooblayout, NULL)),
++};
++
++static const struct spinand_manufacturer_ops dosilicon_spinand_manuf_ops = {
++};
++
++const struct spinand_manufacturer dosilicon_spinand_manufacturer = {
++	.id = SPINAND_MFR_DOSILICON,
++	.name = "Dosilicon",
++	.chips = dosilicon_spinand_table,
++	.nchips = ARRAY_SIZE(dosilicon_spinand_table),
++	.ops = &dosilicon_spinand_manuf_ops,
++};
+--- a/include/linux/mtd/spinand.h
++++ b/include/linux/mtd/spinand.h
+@@ -262,6 +262,7 @@ struct spinand_manufacturer {
+ /* SPI NAND manufacturers */
+ extern const struct spinand_manufacturer alliancememory_spinand_manufacturer;
+ extern const struct spinand_manufacturer ato_spinand_manufacturer;
++extern const struct spinand_manufacturer dosilicon_spinand_manufacturer;
+ extern const struct spinand_manufacturer esmt_8c_spinand_manufacturer;
+ extern const struct spinand_manufacturer esmt_c8_spinand_manufacturer;
+ extern const struct spinand_manufacturer etron_spinand_manufacturer;


### PR DESCRIPTION
## Problem Statement

  The OEM bootloader on EcoNet EN751221 devices ( alteaslt in Genexis Platinum 4410)  has a critical bug in dual-image boot implementations:

  When booting from the OS2 (slave) partition with `boot_flag=1`, the bootloader:
  1. Reads the TRX header from the **MAIN (OS1)** partition to get `kernel_len`
  2. Allocates memory based on this size
  3. But loads the kernel from the **SLAVE** partition

  This causes boot failure when the two kernels differ in size with below error
  
```
  Press any key in 3 secs to enter boot command mode.
............................................................


==> boot flag = 1Decompress to 80002000 free_mem_ptr=80950000 free_mem_ptr_end=807B0000
from slave
Uncompressing [LZMA] ...

decompression error

 -- System halted
```

see #21124 for more info

  ## Solution: NAND Loader with BMT Support

  This series adds a small (~10KB) intermediate loader that:
  1. Gets loaded by the OEM bootloader 
  2. Initializes SPI-NAND controller and BMT (Bad Block Management)
  3. Reads the boot flag to select OS1/OS2 partition
  4. Loads the correct kernel from NAND with BMT translation
  5. Decompresses and boots the kernel with correct root device in cmdline

  ## Boot Flow

  ### Without NAND Loader
  OEM Bootloader
      ↓ reads TRX header, gets load_addr=0x80020000
      ↓ decompresses LZMA(Kernel) to 0x80020000
      ↓ jumps to 0x80020000
  Kernel runs

  ### With NAND Loader (Dual-Image Support)
  OEM Bootloader
      ↓ reads TRX header from MAIN partition
      ↓ gets load_addr=0x80002000, kernel_len=
      ↓ decompresses LZMA(NAND Loader) to 0x80002000
      ↓ jumps to 0x80002000
  NAND Loader
      ↓ initializes SPI-NAND controller
      ↓ initializes BMT (scans BBT/BMT tables from reserve area)
      ↓ reads boot flag from NAND (offset configurable)
      ↓ selects OS1 or OS2 partition based on 
      ↓ reads TRX header from SELECTED partition
      ↓ reads compressed kernel from NAND with BMT translation
      ↓ sets kernel cmdline for the rootfs based on select parition
      ↓ decompresses kernel to 0x80020000
      ↓ jumps to 0x80020000
  Kernel runs with correct root device

  ## TRX Image Structure

  ### Before
```
  ┌────────────────────────────────────┐ 0x000000
  │ TRX Header (256 bytes)             │
  │   magic: "HDR2"                    │
  │   kernel_len:     │
  │   load_addr: 0x80020000            │
  ├────────────────────────────────────┤ 0x000100
  │ LZMA(Kernel)                       │
  │                     │
  ├────────────────────────────────────┤ aligned to 4MB
  │ SquashFS Rootfs                    │
  └────────────────────────────────────┘
```

  ### NAND Loader TRX (Dual-Image Devices)
```
  ┌────────────────────────────────────┐ 0x000000
  │ TRX Header (256 bytes)             │
  │   magic: "HDR2"                    │
  │   kernel_len:                      │ ← CRITICAL: Total of loader+kernel
  │   load_addr: 0x80002000            │ ← Loader runs here
  ├────────────────────────────────────┤ 0x000100
  │ LZMA(NAND Loader) - padded to 64KB │
  │   Loader code: <10   KB            │
  │   Padding:       to 64KB           │
  ├────────────────────────────────────┤ 0x010100
  │ LZMA(Kernel)                       │
  │                                    │
  ├────────────────────────────────────┤ aligned to 4MB
  │ SquashFS Rootfs                    │
  └────────────────────────────────────┘
```

  **IMPORTANT**: The `kernel_len` field in the TRX header contains the **total size** of
  LZMA(NAND Loader) + LZMA(Kernel). This ensures the OEM bootloader allocates enough
  memory to load the entire compressed image when switching between OS1/OS2 partitions,
  regardless of which partition the TRX header is read from.

  
  ### SPI-NAND Flash Support
  - Supports Dosilicon DS35Q1GA/DS35M1GA (Platinum 4410)
  - Supports MXIC MX35LF1GE4AB (0xC2:0x12)
  - Supports Toshiba TC58CVG1S3H (0x98:0xCB)
  - Easy to add more chips via device table

  ### BMT (Bad Block Management Table)
  - Compatible with OEM bootloader BMT format
  - Automatic block translation during reads

  ### Configurable Boot Flag Format
  Different devices use different boot flag formats. The loader supports:

  **Simple ASCII (1 byte)**:
  - Platinum 4410: `0x30`/`0x31` at reservearea+12 blocks
  - Zyxel PMG5617GA: `0x30`/`0x31` at offset 0x00060FFF

  **Multi-byte codes**:
  - TP-Link VR1200v-v2: 8 bytes `0000000101000002`/`0000000101010003`
  - SmartFiber XP8421-B: 4 bytes `30000000`/`31000000`

  **Masked comparison** (Nokia G-240G-E):
  - 24-byte boot flag with bit mask support
  - Mask format: 'X' = compare bit, '0' = ignore bit

  Configuration example:
  ```makefile
  define Device/your_device
    $(Device/tclinux-lzma-loader)
    NAND_BOOT_FLAG_OFFSET := 0x6FC0000
    NAND_BOOT_FLAG_OS1 := 30
    NAND_BOOT_FLAG_OS2 := 31
    NAND_CMDLINE_OS1 := root=/dev/mtdblock3
    NAND_CMDLINE_OS2 := root=/dev/mtdblock5
  endef
```
 ### Why Other Devices Need This

  Even for devices without the bootloader bug, this loader enables:

  1. Correct root device selection: When booting from OS2, the kernel needs
  root=/dev/mtdblock5 instead of mtdblock3. The OEM bootloader doesn't
  change cmdline based on boot_flag, so without this loader, OS2 would try
  to mount OS1's rootfs.
  2. Kernel independence: Each partition can have completely different
  kernel sizes without causing boot failures.


  Configuration Options

  - TCLINUX_MODEL: Model string for TRX header (e.g., "P4410\n")
  - NAND_BBT_SIZE: Max BBT entries (default: 1000, Genexis: 250)
  - NAND_OS1_OFFSET: OS1 partition offset (default: 0x00080000)
  - NAND_OS2_OFFSET: OS2 partition offset (default: 0x01080000)
  - NAND_BOOT_FLAG_OFFSET: Boot flag address (default: 0x6FC0000)
  - NAND_BOOT_FLAG_OS1: OS1 code hex string (default: "30")
  - NAND_BOOT_FLAG_OS2: OS2 code hex string (default: "31")
  - NAND_BOOT_FLAG_MASK: Optional bit mask (default: none)
  - NAND_CMDLINE_OS1: Kernel cmdline for OS1 (default: "root=/dev/mtdblock3")
  - NAND_CMDLINE_OS2: Kernel cmdline for OS2 (default: "root=/dev/mtdblock5")