### PR TITLE
mediatek/filogic: add support for Motorcomm PHYs

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -621,6 +621,23 @@ endef
 
 $(eval $(call KernelPackage,phy-aquantia))
 
+
+define KernelPackage/phy-motorcomm
+  SUBMENU:=$(NETWORK_DEVICES_MENU)
+  TITLE:=Motorcomm Ethernet PHYs
+  DEPENDS:=+kmod-libphy
+  KCONFIG:=CONFIG_MOTORCOMM_PHY
+  FILES:=$(LINUX_DIR)/drivers/net/phy/motorcomm.ko
+  AUTOLOAD:=$(call AutoLoad,18,motorcomm,1)
+endef
+
+define KernelPackage/phy-motorcomm/description
+  Supports the Motorcomm 8511/8521/8531/8531S/8821 Ethernet PHYs
+endef
+
+$(eval $(call KernelPackage,phy-motorcomm))
+
+
 define KernelPackage/dsa
   SUBMENU:=$(NETWORK_DEVICES_MENU)
   TITLE:=Distributed Switch Architecture support

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1210,7 +1210,7 @@ define Device/cudy_wr3000h-v1
   IMAGE_SIZE := 65536k
   KERNEL_IN_UBI := 1
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-motorcomm
 endef
 TARGET_DEVICES += cudy_wr3000h-v1
 


### PR DESCRIPTION
There appears to have been a silent change (i.e. no version number change) to some Cudy Filogic based devices (at least WR3000H v1 and M3000 v2 have been reported) replacing RTL8221B PHYs with Motorcomm YT8821 PHYs for the 2.5GBps capable WAN ports and without the Motorcomm PHY driver have no apparent WAN port.  The current DTS sets the WAN port as a generic clause 45 PHY so enable inclusion of the Motorcomm PHY driver; this may be sufficient to get a working LAN port on it's own.  There appears to have been no recent OEM firmware release for potentially affected models so as yet there is no way to tell if DTS changes are required.

If accepted this should be backported to the 25.12 branch as the 6.12 kernel has YT8821 driver support.

Fixes: https://github.com/openwrt/openwrt/issues/21244
Fixes: https://github.com/openwrt/openwrt/issues/21051
       (M3000v2 not officially supported yet but M3000v1 24.10
        images work satisfactorily on M3000v2 devices with
        RTL8221B PHY and available Cudy OEM firmware releases don't
        distinguish between v1 and v2)