### PR TITLE
base-files: fix default_postinst clearing luci cache

### DIFF
--- a/package/base-files/files/lib/functions.sh
+++ b/package/base-files/files/lib/functions.sh
@@ -382,7 +382,7 @@ default_postinst() {
 			uci commit
 		fi
 
-		rm -f /tmp/luci-indexcache
+		rm -f /tmp/luci-indexcache.*
 	fi
 
 	if [ -f "$root/usr/lib/opkg/info/${pkgname}.postinst-pkg" ]; then


### PR DESCRIPTION
The path to the LuCI index cache file has changed to
/tmp/luci-indexcache.*.json since OpenWrt 22.03.

Update functions.sh to align with luci.mk.

@jow- 