### PR TITLE
Update vr9_arcadyan_vgv7510kw22.dtsi - it is a WLAN button, not WPS

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
@@ -37,7 +37,7 @@
 			linux,code = <KEY_RESTART>;
 		};
 
-		wps {
+		wlan {
 			label = "wlan";
 			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
@@ -38,9 +38,9 @@
 		};
 
 		wps {
-			label = "wps";
+			label = "wlan";
 			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_WPS_BUTTON>;
+			linux,code = <KEY_RFKILL>;
 		};
 	};
 


### PR DESCRIPTION
The main function and labeling on the router itself is WLAN botton. Not WPS button. Missing the KEY_RFKILL functionality in openwrt because of wrong button function.