### PR TITLE
ath79: Fix syntax error in 10_fix_wifi_mac

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -60,7 +60,6 @@ case "$board" in
 	extreme-networks,ws-ap3805i)
 		[ "$PHYNBR" -eq 0 ] && \
 			mtd_get_mac_ascii cfg1 RADIOADDR0 > /sys${DEVPATH}/macaddress
-		;;
 		[ "$PHYNBR" -eq 1 ] && \
 			mtd_get_mac_ascii cfg1 RADIOADDR1 > /sys${DEVPATH}/macaddress
 		;;
@@ -71,7 +70,6 @@ case "$board" in
 		# which would allow to patch the macaddress
 		[ "$PHYNBR" -eq 0 ] && \
 			macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" 1 > /sys${DEVPATH}/macaddress
-		;;
 		[ "$PHYNBR" -eq 1 ] && \
 			macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" 0 > /sys${DEVPATH}/macaddress
 		;;


### PR DESCRIPTION
This typo makes the script fail with:
-ash: /etc/hotplug.d/ieee80211/10_fix_wifi_mac: line 66: syntax error: unexpected word (expecting ")")

which ultimately prevents the mac address for certain devices wireless cards being set correctly