### PR TITLE
build: apk-related improvements

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -219,6 +219,15 @@ define KernelPackage
     $(call KernelPackage/$(1))
     $(call KernelPackage/$(1)/$(BOARD))
     $(call KernelPackage/$(1)/$(BOARD)/$(SUBTARGET))
+
+    # Add an implicit self-provide. apk can't handle self provides, be it
+    # versioned or virtual, so opt for a prefix and a suffix instead. Package
+    # name without a prefix/suffix is too generic and might conflict with other
+    # packages, e.g. wireguard. This allows several variants to provide the same
+    # virtual package without adding extra provides to the default one, e.g.
+    # r8169 implicitly provides kmod-r8169-any and is marked as default, so
+    # r8125 can explicitly provide @kmod-r8169-any as well.
+    PROVIDES+=@kmod-$(1)-any
   endef
 
   ifdef KernelPackage/$(1)/conffiles
@@ -306,4 +315,3 @@ kernel_patchver_ge=$(call kernel_version_cmp,-ge,$(KERNEL_PATCHVER),$(1))
 kernel_patchver_eq=$(call kernel_version_cmp,-eq,$(KERNEL_PATCHVER),$(1))
 kernel_patchver_le=$(call kernel_version_cmp,-le,$(KERNEL_PATCHVER),$(1))
 kernel_patchver_lt=$(call kernel_version_cmp,-lt,$(KERNEL_PATCHVER),$(1))
-

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -134,9 +134,12 @@ endef
 #
 # - apk doesn't like it when packages specify a redundant provide pointing to
 #   self. Filter it out, but keep virtual self provides, in the form of
-#   @${package_name}-any.
+#   @(kmod-)?${package_name}-any.
 #
 # - Packages implicitly add a virtual @${package_name}-any provide in Package.
+#
+# - kmods implicitly add a virtual @kmod-${package_name}-any provide in
+#   KernelPackage.
 #
 # 1: package name
 # 2: package version

--- a/include/package.mk
+++ b/include/package.mk
@@ -332,6 +332,13 @@ define BuildPackage
   $(eval $(Package/Default))
   $(eval $(Package/$(1)))
 
+  # Add an implicit self-provide. apk can't handle self provides, be it
+  # versioned or virtual, so opt for a suffix instead. This allows several
+  # variants to provide the same virtual package without adding extra provides
+  # to the default one, e.g. wget implicitly provides wget-any and is marked as
+  # default, so wget-ssl can explicitly provide @wget-any as well.
+  PROVIDES+=@$(1)-any
+
 ifdef DESCRIPTION
 $$(error DESCRIPTION:= is obsolete, use Package/PKG_NAME/description)
 endif

--- a/package/kernel/ath10k-ct/Makefile
+++ b/package/kernel/ath10k-ct/Makefile
@@ -34,7 +34,7 @@ define KernelPackage/ath10k-ct
 	$(PKG_BUILD_DIR)/ath10k$(CT_KVER)/ath10k_pci.ko \
 	$(PKG_BUILD_DIR)/ath10k$(CT_KVER)/ath10k_core.ko
   AUTOLOAD:=$(call AutoProbe,ath10k_pci)
-  PROVIDES:=kmod-ath10k
+  PROVIDES:=@kmod-ath10k-any
   VARIANT:=regular
 endef
 

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1207,6 +1207,7 @@ define KernelPackage/r8169
     CONFIG_R8169_LEDS=y
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/realtek/r8169.ko
   AUTOLOAD:=$(call AutoProbe,r8169,1)
+  DEFAULT_VARIANT:=1
 endef
 
 define KernelPackage/r8169/description

--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -265,7 +265,7 @@ This module adds support for wireless adapters based on
 Atheros USB AR9271 and AR7010 family of chipsets.
 endef
 
-define KernelPackage/ath10k
+define KernelPackage/ath10k/Default
   $(call KernelPackage/mac80211/Default)
   TITLE:=Atheros 802.11ac wireless cards support
   URL:=https://wireless.wiki.kernel.org/en/users/drivers/ath10k
@@ -276,7 +276,12 @@ define KernelPackage/ath10k
 	$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath10k/ath10k_pci.ko
   AUTOLOAD:=$(call AutoProbe,ath10k_core ath10k_pci)
   MODPARAMS.ath10k_core:=frame_mode=2
+endef
+
+define KernelPackage/ath10k
+  $(call KernelPackage/ath10k/Default)
   VARIANT:=regular
+  DEFAULT_VARIANT:=1
 endef
 
 define KernelPackage/ath10k/description
@@ -299,9 +304,10 @@ define KernelPackage/ath10k/config
 endef
 
 define KernelPackage/ath10k-smallbuffers
-  $(call KernelPackage/ath10k)
+  $(call KernelPackage/ath10k/Default)
   TITLE+= (small buffers for low-RAM devices)
   VARIANT:=smallbuffers
+  PROVIDES:=@kmod-ath10k-any
 endef
 
 define KernelPackage/ath11k

--- a/package/kernel/r8101/Makefile
+++ b/package/kernel/r8101/Makefile
@@ -21,7 +21,7 @@ define KernelPackage/r8101
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8101.ko
   AUTOLOAD:=$(call AutoProbe,r8101,1)
-  PROVIDES:=kmod-r8169
+  PROVIDES:=@kmod-r8169-any
 endef
 
 define Build/Compile

--- a/package/kernel/r8125/Makefile
+++ b/package/kernel/r8125/Makefile
@@ -21,7 +21,7 @@ define KernelPackage/r8125
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8125.ko
   AUTOLOAD:=$(call AutoProbe,r8125,1)
-  PROVIDES:=kmod-r8169
+  PROVIDES:=@kmod-r8169-any
   VARIANT:=regular
   PKG_MAKE_FLAGS += CONFIG_ASPM=n
 endef

--- a/package/kernel/r8126/Makefile
+++ b/package/kernel/r8126/Makefile
@@ -21,7 +21,7 @@ define KernelPackage/r8126
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8126.ko
   AUTOLOAD:=$(call AutoProbe,r8126,1)
-  PROVIDES:=kmod-r8169
+  PROVIDES:=@kmod-r8169-any
   VARIANT:=regular
 endef
 

--- a/package/kernel/r8127/Makefile
+++ b/package/kernel/r8127/Makefile
@@ -21,7 +21,7 @@ define KernelPackage/r8127
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8127.ko
   AUTOLOAD:=$(call AutoProbe,r8127,1)
-  PROVIDES:=kmod-r8169
+  PROVIDES:=@kmod-r8169-any
   VARIANT:=regular
 endef
 

--- a/package/kernel/r8168/Makefile
+++ b/package/kernel/r8168/Makefile
@@ -21,7 +21,7 @@ define KernelPackage/r8168
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8168.ko
   AUTOLOAD:=$(call AutoProbe,r8168,1)
-  PROVIDES:=kmod-r8169
+  PROVIDES:=@kmod-r8169-any
   VARIANT:=regular
 endef
 

--- a/package/kernel/rtl8812au-ct/Makefile
+++ b/package/kernel/rtl8812au-ct/Makefile
@@ -28,7 +28,7 @@ define KernelPackage/rtl8812au-ct
   FILES:=\
 	$(PKG_BUILD_DIR)/rtl8812au.ko
   AUTOLOAD:=$(call AutoProbe,rtl8812au)
-  PROVIDES:=kmod-rtl8812au
+  PROVIDES:=@kmod-rtl8812au-any
 endef
 
 NOSTDINC_FLAGS := \

--- a/package/system/ca-certificates/Makefile
+++ b/package/system/ca-certificates/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ca-certificates
 PKG_VERSION:=20250419
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MAINTAINER:=
 
 PKG_LICENSE:=GPL-2.0-or-later MPL-2.0
@@ -24,12 +24,14 @@ include $(INCLUDE_DIR)/package.mk
 TAR_OPTIONS+= --strip-components 1
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
+# ca-certs is deprecated and new packages should use ca-certificates-any if
+# they don't need a specific package
 define Package/ca-certificates
   SECTION:=base
   CATEGORY:=Base system
   TITLE:=System CA certificates
   PKGARCH:=all
-  PROVIDES:=ca-certs
+  PROVIDES:=@ca-certs
 endef
 
 define Package/ca-bundle
@@ -37,7 +39,7 @@ define Package/ca-bundle
   CATEGORY:=Base system
   TITLE:=System CA certificates as a bundle
   PKGARCH:=all
-  PROVIDES:=ca-certs
+  PROVIDES:=@ca-certs @ca-certificates-any
 endef
 
 define Build/Install

--- a/scripts/metadata.pm
+++ b/scripts/metadata.pm
@@ -263,6 +263,9 @@ sub parse_package_metadata($) {
 		/^Default: \s*(.+)\s*$/ and $pkg->{default} = $1;
 		/^Provides: \s*(.+)\s*$/ and do {
 			my @vpkg = split /\s+/, $1;
+			foreach (@vpkg) {
+				s/^@//;
+			}
 			@{$pkg->{provides}} = ($pkg->{name}, @vpkg);
 			foreach my $vpkg (@vpkg) {
 				next if ($vpkg eq $pkg->{name});


### PR DESCRIPTION
Allow defining virtual provides using the `PROVIDES` field by prefixing them with an `@`, e.g.:

```
PROVIDES:=@ca-certs
```

Virtual provides don't own the provided name and multiple packages with the same virtual provides can be installed side-by-side. Packages must still take care not to override each other's files.

Add an implicit self-provide to packages. apk can't handle self provides, be it versioned or virtual, so opt for a suffix instead. This allows several variants to provide the same virtual package without adding extra provides to the default one, e.g. `wget` implicitly provides `wget-any` and is marked as default, so `wget-ssl` can explicitly provide `@wget-any` as well.

Add an implicit self-provide to kmods using a prefix and a suffix. Package name without a prefix/suffix is too generic and might conflict with other packages, e.g. `wireguard`. This allows several variants to provide the same virtual package without adding extra provides to the default one, e.g. `r8169` implicitly provides `kmod-r8169-any` and is marked as default, so `r8125` can explicitly provide `@kmod-r8169-any` as well.

The actual symbol that marks virtual provides is not important. I chose @ for _alias_.

Edit: @ is kind of overloaded as it already means something else in `DEPENDS`.

> [!IMPORTANT]
>
> Cross-package provides must be virtual and a default variant must be set.

Refactor provides logic into a helper define and use it for both apk and control (which was still using the older logic). Document the behavior. It looks excessive but I think we should have this somewhere outside of commit messages.

Filter out virtual provides when generating metadata.

Filter out virtual provides prefix and self provide where appropriate.

Remove unnecessary logging.

Adjust packages to uses the new virtual provides:

- Switch ca-certs provides to use the new virtual provides semantic that enables ca-bundle and ca-certificates to be installed side-by-side. Provide the new format virtual `ca-certificates-any` in ca-bundle.
- Switch ath10k and related kmods to use the new virtual kmod provides semantic and mark ath10k as the default variant.
- Switch r8169 and related kmods to use the new virtual kmod provides semantic and mark r8169 as the default variant.
- Switch rtl8812au-ct to use the new virtual kmod provides semantic.

Tested:
- building and installing ca-bundle and ca-certificates side-by-side
- building and installing stubby that depends on the virtual ca-certs
- building and installing libsqlite3 that has an ABI and sqlite3-cli that depends on it
- building x86/64 generic image and testing in QEMU
- defining a provides in a library with an ABI
- build config can still be generated with ca-bundle and ca-certificates selected at the same time (this might need more testing)

The alternatives check might not be necessary anymore and could be replaced with the new virtual semantic in the long run, but is there for compatibility reasons.

> [!CAUTION]
>
> This was neither tested with, nor is intended to be backported to opkg.

Fixes: https://github.com/openwrt/openwrt/issues/21257

cc: @efahl, @robimarko and maybe @mstorchak 

'Tis the holiday season over here, so I probably overlooked something obvious. I think this needs a good look before this gets merged. I will update the wiki to document the recent DEPENDS, EXTRA_DEPENDS and PROVIDES changes at some point, unless somebody else gets to it first.