### PR TITLE
wifi-scripts: fix wdev fallback for mesh interfaces

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -294,7 +294,15 @@ function setup() {
 	if (fs.access('/usr/sbin/hostapd', 'x'))
 		hostapd.setup(data);
 
-	system(`ucode /usr/share/hostap/wdev.uc ${data.phy}${data.phy_suffix} set_config '${printf("%J", wdev_data)}' ${join(' ', active_ifnames)}`);
+	for (let ifname in active_ifnames) {
+		if (!wdev_data[ifname])
+			continue;
+
+		let if_config = {
+			[ifname]: wdev_data[ifname]
+		};
+		system(`ucode /usr/share/hostap/wdev.uc ${data.phy}${data.phy_suffix} set_config '${if_config}'`);
+	}
 
 	if (length(supplicant_data) > 0)
 		supplicant.start(data);

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -605,11 +605,8 @@
 			"type": "boolean"
 		},
 		"mcast_rate": {
-			"description": "Allowed multicast rates",
-			"type": "array",
-			"items": {
-				"type": "number"
-			}
+			"description": "Allowed multicast rate",
+			"type": "number"
 		},
 		"mesh_auto_open_plinks": {
 			"type": "boolean"


### PR DESCRIPTION
The previous wdev.uc invocation failed for mesh interfaces. Rewrite it as a loop so the mesh interface is created correctly when no wpa_supplicant mesh support is installed.


Mesh interface is created but stays down:
```
100: wlan5-mesh: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch0 state DOWN mode DEFAULT group default qlen 1000
    link/ether 4e:8f:5a:b9:83:83 brd ff:ff:ff:ff:ff:ff
```