### PR TITLE
ath79: add support for Linksys LAPAC1200/1750[C]

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -735,6 +735,16 @@ define Build/senao-header
 	&& mv $@.new $@ || rm -f $@
 endef
 
+define Build/sercomm-factory-wrap
+	$(TOPDIR)/scripts/sercomm-factory-wrap.py \
+		--hw-id=$(SERCOMM_HWID) --hw-revision=$(SERCOMM_HWREV) \
+		--function-code=$(SERCOMM_FUNCTION_CODE) \
+		--company-code=$(SERCOMM_COMPANY_CODE) \
+		--kernel-split=$(SERCOMM_KERNEL_SPLIT) \
+		$(1) $@ $@.wrapped \
+	&& mv $@.wrapped $@
+endef
+
 define Build/sysupgrade-tar
 	$(eval dtb=$(call param_get,dtb,$(1)))
 	sh $(TOPDIR)/scripts/sysupgrade-tar.sh \

--- a/scripts/sercomm-factory-wrap.py
+++ b/scripts/sercomm-factory-wrap.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# sercomm-factory-wrap.py: Wraps an input file with factory image header and
+# footer, compatible with certain Sercomm manufactured Linksys devices.
+#
+# Copyright © 2025 Michael Lotz <mmlr@mlotz.ch>
+"""
+
+import argparse
+import binascii
+import codecs
+import struct
+import sys
+
+
+PID_MAGIC = b'sErCoMm'
+PID2_MAGIC = b'\x90\xf7eRcOmM\0\0'
+
+HEADER_SIZE = 256
+HEADER_MAGIC = b'Ser\0'
+HEADER_MAX_IMAGES = 8
+CHECKSUM_BITMAP = 0xff
+
+
+def auto_int(x):
+	return int(x, 0)
+
+
+def pack(structure, endian='<'):
+	form = ''.join([x if x != 's' else f'{len(y)}s' for x, y in structure])
+	return struct.pack(endian + form, *[y for x, y in structure])
+
+
+def padded(data, align, value=b'\xff'):
+	length = len(data)
+	aligned = (length + (align - 1)) // align * align
+	return data + value * (aligned - length)
+
+
+parser = argparse.ArgumentParser(description='This script wraps firmware \
+	images into Sercomm compatible factory update or partition format.')
+
+parser.add_argument('--hw-id', help='Hardware ID as hex string')
+parser.add_argument('--hw-revision', type=auto_int, help='Hardware revision')
+parser.add_argument('--function-code', type=auto_int,
+	help='Device function code')
+parser.add_argument('--company-code', type=auto_int, help='Device company code')
+parser.add_argument('--fw-version', type=auto_int, default=0x0020,
+	help='Firmware version in the format 0xssmn with s=sub, m=major, n=minor')
+parser.add_argument('--kernel-split', type=auto_int,
+	help='Max size of first image')
+parser.add_argument('--no-pid', action='store_true', default=False,
+	help='Do not write initial padding and PID of factory image')
+parser.add_argument('--header-offset', type=auto_int,
+	help='The header offset in the factory image or partition')
+
+parser.add_argument('input')
+parser.add_argument('output')
+
+args = parser.parse_args()
+
+with open(args.input, 'rb') as file:
+	data = file.read()
+
+images = b''
+imageCount = 0
+offset = base = args.header_offset + HEADER_SIZE
+
+parts = [data]
+if args.kernel_split is not None and len(data) > args.kernel_split:
+	parts = [data[:args.kernel_split], data[args.kernel_split:]]
+
+for part in parts:
+	images += pack([
+		('I', offset),
+		('I', len(part)),
+		('I', binascii.crc32(part)),
+		('I', 0), # version
+		('Q', 0xffffffffffffffff) # reserved
+	])
+
+	imageCount += 1
+	offset += len(part)
+
+data = padded(data, 0x1000)
+
+headerStruct = [
+	('s', HEADER_MAGIC),
+	('I', base + len(data)), # pid2 address
+	('I', 0), # header checksum
+	('B', imageCount),
+	('B', CHECKSUM_BITMAP),
+	('H', 0xffff) # reserved
+]
+
+headerStruct[2] = ('I', binascii.crc32(pack(headerStruct)))
+header = padded(pack(headerStruct) + images, HEADER_SIZE)
+
+pid2 = pack([
+	('B', args.hw_revision),
+	('B', args.function_code),
+	('H', args.company_code),
+	('H', args.fw_version),
+	('s', PID2_MAGIC)
+])
+
+with open(args.output, 'wb') as file:
+	if not args.no_pid:
+		pid = pack([
+			('s', PID_MAGIC),
+			('I', 0), # reserved
+			('34s', padded(codecs.decode(args.hw_id, 'hex'), 34, b'\0')),
+			('B', args.hw_revision),
+			('B', args.function_code),
+			('H', args.company_code),
+			('Q', 0), # reserved
+			('H', args.fw_version),
+			('I', 0), # reserved
+			('s', PID_MAGIC)
+		])
+
+		padding = padded(b'\xff', args.header_offset - len(pid))
+
+		file.write(padding)
+		file.write(pid)
+
+	file.write(header)
+	file.write(data)
+	file.write(pid2)

--- a/target/linux/ath79/dts/qca9557_linksys_lapac1200.dts
+++ b/target/linux/ath79/dts/qca9557_linksys_lapac1200.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_linksys_lapac.dtsi"
+
+/ {
+	compatible = "linksys,lapac1200", "qca,qca9557";
+	model = "Linksys LAPAC1200";
+};

--- a/target/linux/ath79/dts/qca9557_linksys_lapac1200c.dts
+++ b/target/linux/ath79/dts/qca9557_linksys_lapac1200c.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_linksys_lapac.dtsi"
+
+/ {
+	compatible = "linksys,lapac1200c", "qca,qca9557";
+	model = "Linksys LAPAC1200C";
+};

--- a/target/linux/ath79/dts/qca9558_linksys_lapac1750.dts
+++ b/target/linux/ath79/dts/qca9558_linksys_lapac1750.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_linksys_lapac.dtsi"
+
+/ {
+	compatible = "linksys,lapac1750", "qca,qca9558";
+	model = "Linksys LAPAC1750";
+};

--- a/target/linux/ath79/dts/qca9558_linksys_lapac1750c.dts
+++ b/target/linux/ath79/dts/qca9558_linksys_lapac1750c.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x_linksys_lapac.dtsi"
+
+/ {
+	compatible = "linksys,lapac1750c", "qca,qca9558";
+	model = "Linksys LAPAC1750C";
+};

--- a/target/linux/ath79/dts/qca955x_linksys_lapac.dtsi
+++ b/target/linux/ath79/dts/qca955x_linksys_lapac.dtsi
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	aliases {
+		label-mac-device = &eth0;
+		led-boot = &led_green;
+		led-failsafe = &led_red;
+		led-upgrade = &led_blue;
+		led-running = &led_blue;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		led_green: green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_blue: blue {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		led_red: red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&fwconcat0 &fwconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "firmware";
+				reg = <0x000000 0xea0000>;
+			};
+
+			partition@10000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "uimage";
+				reg = <0x010000 0xe90000>;
+				openwrt,ih-magic = <IH_MAGIC_OKLI>;
+			};
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_0: macaddr@3ff3a {
+						compatible = "mac-base";
+						reg = <0x3ff3a 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@40000 {
+				label = "u-boot-env";
+				reg = <0x040000 0x010000>;
+				read-only;
+			};
+
+			fwconcat0: partition@50000 {
+				label = "fwconcat0";
+				reg = <0x050000 0x7a0000>;
+			};
+
+			partition@7f0000 {
+				label = "art";
+				reg = <0x7f0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					cal_art_5000: calibration@5000 {
+						reg = <0x5000 0x844>;
+					};
+				};
+			};
+
+			fwconcat1: partition@800000 {
+				label = "fwconcat1";
+				reg = <0x800000 0x700000>;
+			};
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	ar8035: ethernet-phy@0 {
+		reg = <0>;
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_uboot_0 0>;
+	nvmem-cell-names = "mac-address";
+
+	pll-data = <0x03000000 0x80000101 0x80001313>;
+
+	phy-handle = <&ar8035>;
+	phy-mode = "rgmii-rxid";
+
+	gmac-config {
+		device = <&gmac>;
+		rgmii-enabled = <1>;
+		rxdv-delay = <3>;
+		rxd-delay = <3>;
+		txen-delay = <3>;
+		txd-delay = <3>;
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&cal_art_5000>, <&macaddr_uboot_0 2>;
+		nvmem-cell-names = "calibration", "mac-address";
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_uboot_0 1>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -368,7 +368,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan"
 		;;
-	etactica,eg200)
+	etactica,eg200|\
+	linksys,lapac1200|\
+	linksys,lapac1200c|\
+	linksys,lapac1750|\
+	linksys,lapac1750c)
 		ucidef_set_interface_lan "eth0" "dhcp"
 		;;
 	glinet,gl-ar750)

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -12,6 +12,8 @@ DEVICE_VARS += EDIMAX_HEADER_MAGIC EDIMAX_HEADER_MODEL
 DEVICE_VARS += ELECOM_HWID
 DEVICE_VARS += MOXA_MAGIC MOXA_HWID
 DEVICE_VARS += OPENMESH_CE_TYPE ZYXEL_MODEL_STRING
+DEVICE_VARS += SERCOMM_COMPANY_CODE SERCOMM_FUNCTION_CODE
+DEVICE_VARS += SERCOMM_HWID SERCOMM_HWREV SERCOMM_KERNEL_SPLIT
 DEVICE_VARS += SUPPORTED_TELTONIKA_DEVICES
 DEVICE_VARS += SUPPORTED_TELTONIKA_HW_MODS
 
@@ -2025,6 +2027,59 @@ define Device/librerouter_librerouter-v1
   DEVICE_PACKAGES := kmod-usb2
 endef
 TARGET_DEVICES += librerouter_librerouter-v1
+
+define Device/linksys_lapac_common
+  $(Device/loader-okli-uimage)
+  DEVICE_VENDOR := Linksys
+  DEVICE_PACKAGES := -uboot-envtools -swconfig \
+	kmod-ath10k-ct ath10k-firmware-qca988x-ct
+  IMAGE_SIZE := 7100k
+  LOADER_FLASH_OFFS := 0x60000
+  SERCOMM_HWID := 415546955810
+  SERCOMM_HWREV := 1
+  SERCOMM_COMPANY_CODE := 0
+  SERCOMM_KERNEL_SPLIT := 0x12ff00
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma -M 0x4f4b4c49
+  IMAGES += factory.bin
+  IMAGE/default := append-loader-okli-uimage $(1) | pad-to 65280 | \
+	append-kernel | pad-offset $$$$(BLOCKSIZE) 256 | append-rootfs
+  IMAGE/factory.bin := $$(IMAGE/default) | \
+	sercomm-factory-wrap --header-offset=0x10000
+  IMAGE/sysupgrade.bin := $$(IMAGE/default) | \
+	sercomm-factory-wrap --no-pid --header-offset=0x50000 | append-metadata
+endef
+
+define Device/linksys_lapac1200
+  $(Device/linksys_lapac_common)
+  SOC := qca9557
+  DEVICE_MODEL := LAPAC1200
+  SERCOMM_FUNCTION_CODE := 7
+endef
+TARGET_DEVICES += linksys_lapac1200
+
+define Device/linksys_lapac1750
+  $(Device/linksys_lapac_common)
+  SOC := qca9558
+  DEVICE_MODEL := LAPAC1750
+  SERCOMM_FUNCTION_CODE := 7
+endef
+TARGET_DEVICES += linksys_lapac1750
+
+define Device/linksys_lapac1200c
+  $(Device/linksys_lapac_common)
+  SOC := qca9557
+  DEVICE_MODEL := LAPAC1200C
+  SERCOMM_FUNCTION_CODE := 8
+endef
+TARGET_DEVICES += linksys_lapac1200c
+
+define Device/linksys_lapac1750c
+  $(Device/linksys_lapac_common)
+  SOC := qca9558
+  DEVICE_MODEL := LAPAC1750C
+  SERCOMM_FUNCTION_CODE := 8
+endef
+TARGET_DEVICES += linksys_lapac1750c
 
 define Device/longdata_aps256
   SOC := ar9344


### PR DESCRIPTION
Linksys LAPAC1200 and LAPAC1750 are dual band wireless AC access points
with PoE. They use either the QCA9557 or QCA9558 and have a 2x2:2 and
3x3:3 configuration, respectively. The variants with a C suffix are
cloud managed versions that only differ in their software.

Hardware:
* SoC: Qualcomm Atheros QCA9558 (LAPAC1750) or QCA9557 (LAPAC1200)
* RAM: 128GiB 2x EtronTech EM68B16CWQH-25H
* Flash: 16MiB Macronix MX25L12835FMI SPI-NOR
* WLAN 2.4GHz: QCA9558 3x3:3 (LAPAC1750) or 2x2:2 (LAPAC1200)
* WLAN 5GHz: QCA9880 3x3:3 (LAPAC1750) or 2x2:2 (LAPAC1200)
* Ethernet: QCA9558 or QCA9557 with Atheros AR8035 PHY
* Serial Config: 3.3V TTL 115200-8-N-1
* Serial Layout: RX 3.3V (don't connect) TX [GND] --- LEDs
* LEDs: 1x Red, 1x Green, 1x Blue
* Buttons: 1x Reset

MAC addresses:
* Label: LAN, stored in u-boot partition at 0x3ff3a
* 2.4GHz WLAN: LAN + 1
* 5GHz WLAN: LAN + 2

Notes:
The bootloader uses a dual image setup with two slots. OpenWrt can only be
installed in the first slot. Due to limited storage, the flash layout will
consume both slots with mtd-concat and fully replace the stock firmware,
including its log and nvram partitions.

Flashing with Stock Web Interface:
Note: This does not work for the C variants, as they require the firmware
to be GPG signed, use the recovery method below instead.

1. Determine current boot partition by injecting the following command in
   Configuration -> Administration -> SSL Certificate -> Export SSL
   Certificate to TFTP Server -> Destination File (use a dummy server
   address and confirm the upload dialog):

   ' || S=${PWD%u*} && ${S}bin${S}cat ${S}proc${S}cmdline #

2. If the current command line uses "root=31:03", OpenWrt would be written
   to the wrong slot and a stock firmware image [0] needs to be flashed
   first.

3. Once the stock firmware uses "root=31:09", flash the OpenWrt factory
   image.

Unbrick / Revert to Stock / Flash OpenWrt directly:
1. Hold reset button while powering up until the LEDs flash red/blue.
2. Use recovery tool [1] to flash either a stock or OpenWrt factory image.

[0]: https://downloads.linksys.com/downloads/firmware/FW_LAPAC1200_LAPAC1750_1.1.03.000.img
[1]: https://github.com/mmlr/linksys-sercomm-recovery