### PR TITLE
[25.12] wifi-scripts: ucode: fix wpa_supplicant mesh

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -4,6 +4,9 @@ import { append_value, log } from 'wifi.common';
 import * as fs from 'fs';
 
 export function parse_encryption(config, dev_config) {
+	if (!config.encryption)
+		return;
+
 	let encryption = split(config.encryption, '+', 2);
 
 	config.wpa = 0;


### PR DESCRIPTION
Mesh interfaces may not define an encryption setting. This results in a ucode runtime error when parse_encryption() is called:
  Reference error: left-hand side expression is null
  In parse_encryption(), file /usr/share/ucode/wifi/iface.uc, line 20, byte 32:
    called from function setup_sta (/usr/share/ucode/wifi/supplicant.uc:59:31)
    called from function generate (/usr/share/ucode/wifi/supplicant.uc:243:41)
    called from function setup (./mac80211.sh:254:61)
    called from anonymous function (./mac80211.sh:342:14)
   `    config.auth_type = encryption[0] ?? 'none';`
    Near here ------------------------^

Link: https://github.com/openwrt/openwrt/pull/21293

(cherry picked from commit 00e6c18a930df22e2734c3bc5d9b1cca1e538e6b)
