### PR TITLE
kernel: r8101: fix build with linux v6.16+

### DIFF
--- a/package/kernel/r8101/Makefile
+++ b/package/kernel/r8101/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8101
 PKG_VERSION:=1.039.00
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8101/releases/download/$(PKG_VERSION)

--- a/package/kernel/r8101/patches/001-r8101-fix-build-with-kernels-6.16.patch
+++ b/package/kernel/r8101/patches/001-r8101-fix-build-with-kernels-6.16.patch
@@ -1,0 +1,67 @@
+From 37bbdad26212b500f80d099e50b635c4ec387510 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Sat, 27 Dec 2025 12:08:47 +0100
+Subject: [PATCH] r8101: fix build with kernels > 6.16
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ src/r8101.h   | 5 +++++
+ src/r8101_n.c | 8 ++++----
+ 2 files changed, 9 insertions(+), 4 deletions(-)
+
+--- a/src/r8101.h
++++ b/src/r8101.h
+@@ -109,6 +109,12 @@ static inline void ether_addr_copy(u8 *d
+ }
+ #endif
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,16,0)
++#define timer_container_of(var, callback_timer, timer_fieldname) \
++	from_timer(var, callback_timer, timer_fieldname)
++#define timer_delete_sync(timer) del_timer_sync(timer)
++#endif
++
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(2,6,15)
+ #define setup_timer(_timer, _function, _data) \
+ do { \
+--- a/src/r8101_n.c
++++ b/src/r8101_n.c
+@@ -10163,7 +10163,7 @@ rtl8101_hw_phy_config(struct net_device
+ 
+ static inline void rtl8101_delete_link_timer(struct net_device *dev, struct timer_list *timer)
+ {
+-        del_timer_sync(timer);
++        timer_delete_sync(timer);
+ }
+ 
+ static inline void rtl8101_request_link_timer(struct net_device *dev)
+@@ -10181,7 +10181,7 @@ static inline void rtl8101_request_link_
+ 
+ static inline void rtl8101_delete_esd_timer(struct net_device *dev, struct timer_list *timer)
+ {
+-        del_timer_sync(timer);
++        timer_delete_sync(timer);
+ }
+ 
+ static inline void rtl8101_request_esd_timer(struct net_device *dev)
+@@ -11600,7 +11600,7 @@ rtl8101_esd_timer(struct timer_list *t)
+         struct rtl8101_private *tp = netdev_priv(dev);
+         struct timer_list *timer = &tp->esd_timer;
+ #else
+-        struct rtl8101_private *tp = from_timer(tp, t, esd_timer);
++        struct rtl8101_private *tp = timer_container_of(tp, t, esd_timer);
+         struct net_device *dev = tp->dev;
+         struct timer_list *timer = t;
+ #endif
+@@ -11776,7 +11776,7 @@ rtl8101_link_timer(struct timer_list *t)
+         struct rtl8101_private *tp = netdev_priv(dev);
+         struct timer_list *timer = &tp->link_timer;
+ #else
+-        struct rtl8101_private *tp = from_timer(tp, t, link_timer);
++        struct rtl8101_private *tp = timer_container_of(tp, t, link_timer);
+         struct net_device *dev = tp->dev;
+         struct timer_list *timer = t;
+ #endif

--- a/package/kernel/r8101/patches/200-r8101-print-link-speed-and-duplex-mode.patch
+++ b/package/kernel/r8101/patches/200-r8101-print-link-speed-and-duplex-mode.patch
@@ -17,7 +17,7 @@ Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
 
 --- a/src/r8101.h
 +++ b/src/r8101.h
-@@ -1162,6 +1162,8 @@ enum RTL8101_register_content {
+@@ -1168,6 +1168,8 @@ enum RTL8101_register_content {
          LinkStatus = 0x02,
          FullDup = 0x01,
  


### PR DESCRIPTION
Fix r8101 module build with kernels >= v6.16.

CC @graysky2 