### PR TITLE
wifi-scripts: fix race in wireless interface creation

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -288,12 +288,6 @@ function setup() {
 		wdev_data[v.config.ifname] = config;
 	}
 
-	if (fs.access('/usr/sbin/wpa_supplicant', 'x'))
-		supplicant.setup(supplicant_data, data);
-
-	if (fs.access('/usr/sbin/hostapd', 'x'))
-		hostapd.setup(data);
-
 	for (let ifname in active_ifnames) {
 		if (!wdev_data[ifname])
 			continue;
@@ -303,6 +297,12 @@ function setup() {
 		};
 		system(`ucode /usr/share/hostap/wdev.uc ${data.phy}${data.phy_suffix} set_config '${if_config}'`);
 	}
+
+	if (fs.access('/usr/sbin/wpa_supplicant', 'x'))
+		supplicant.setup(supplicant_data, data);
+
+	if (fs.access('/usr/sbin/hostapd', 'x'))
+		hostapd.setup(data);
 
 	if (length(supplicant_data) > 0)
 		supplicant.start(data);


### PR DESCRIPTION
When wdev interfaces and hostapd interfaces are mixed, race conditions can occur. Sometimes all interfaces are started correctly, sometimes only the wdev interface and some of the hostapd interfaces, and sometimes only the wdev interface.

Fix this by creating the wdev interfaces first, before processing wpa_supplicant or hostapd interfaces.
