### PR TITLE
kernel: qca8k: fix host FDB on multi-CPU

### DIFF
--- a/target/linux/generic/pending-6.12/711-04-net-dsa-qca8k-merge-host-fdb-for-multi-cpu.patch
+++ b/target/linux/generic/pending-6.12/711-04-net-dsa-qca8k-merge-host-fdb-for-multi-cpu.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kevin Staley <glaciertablet@gmail.com>
+Date: Mon, 29 Dec 2025 00:00:00 +0000
+Subject: [PATCH] net: dsa: qca8k: merge host FDB for multi-CPU setups
+
+In multi-CPU-port setups, DSA may install the same host FDB entry on
+multiple upstream-facing ports when bridged user ports use different
+conduits. qca8k_port_fdb_add currently overwrites any existing entry for
+the same {MAC, VID}, so the last CPU port wins and host reachability can
+break for ports serviced by the other CPU port (e.g. Netgear R7800 when
+wan is bridged into br-lan).
+
+Use the existing search-and-insert/delete helpers for CPU and DSA ports
+so the destination port mask is merged instead of replaced.
+
+Fixes: openwrt/openwrt#17891
+Signed-off-by: Kevin Staley <glaciertablet@gmail.com>
+---
+ drivers/net/dsa/qca/qca8k-common.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+--- a/drivers/net/dsa/qca/qca8k-common.c
++++ b/drivers/net/dsa/qca/qca8k-common.c
+@@ -836,6 +836,13 @@ int qca8k_port_fdb_add(struct dsa_switch
+ 	struct qca8k_priv *priv = ds->priv;
+ 	u16 port_mask = BIT(port);
+ 
++	if (!vid)
++		vid = QCA8K_PORT_VID_DEF;
++
++	if (dsa_is_cpu_port(ds, port) || dsa_is_dsa_port(ds, port))
++		return qca8k_fdb_search_and_insert(priv, BIT(port), addr, vid,
++						   QCA8K_ATU_STATUS_STATIC);
++
+ 	return qca8k_port_fdb_insert(priv, addr, port_mask, vid);
+ }
+ 
+@@ -849,6 +856,9 @@ int qca8k_port_fdb_del(struct dsa_switch
+ 	if (!vid)
+ 		vid = QCA8K_PORT_VID_DEF;
+ 
++	if (dsa_is_cpu_port(ds, port) || dsa_is_dsa_port(ds, port))
++		return qca8k_fdb_search_and_del(priv, BIT(port), addr, vid);
++
+ 	return qca8k_fdb_del(priv, addr, port_mask, vid);
+ }
+ 


### PR DESCRIPTION
Fix bridged-AP use-cases on qca8k multi-CPU-port boards (e.g. Netgear R7800) when WAN is added to br-lan.

When ports in the same bridge are serviced by different CPU ports (different conduits), DSA installs the bridge MAC as a host FDB entry on each dedicated CPU/DSA port. qca8k's port_fdb_add overwrites an existing {MAC,VID} entry instead of merging the destination port mask, so the last CPU port wins and the host becomes reachable only from one side.

Add a kernel 6.12 pending patch that merges CPU/DSA-port FDB adds/dels via qca8k_fdb_search_and_insert()/qca8k_fdb_search_and_del().

Fixes: openwrt/openwrt#17891

Testing: patch applies cleanly; not hardware-tested.