### PR TITLE
[pre-6.18] realtek: prom.c initialization fixes.

### DIFF
--- a/target/linux/realtek/files-6.12/arch/mips/include/asm/mach-rtl838x/mach-rtl83xx.h
+++ b/target/linux/realtek/files-6.12/arch/mips/include/asm/mach-rtl838x/mach-rtl83xx.h
@@ -48,8 +48,8 @@ struct rtl83xx_soc_info {
 	unsigned int revision;
 	unsigned int cpu;
 	bool testchip;
-	unsigned char *compatible;
 	int cpu_port;
+	int memory_size;
 };
 
 #endif /* _MACH_RTL838X_H_ */

--- a/target/linux/realtek/files-6.12/arch/mips/rtl838x/prom.c
+++ b/target/linux/realtek/files-6.12/arch/mips/rtl838x/prom.c
@@ -20,13 +20,13 @@
 struct rtl83xx_soc_info soc_info;
 const void *fdt;
 
-static char soc_name[16];
-static char rtl83xx_system_type[48];
+static char rtl_soc_name[16];
+static char rtl_system_type[48];
 
 #ifdef CONFIG_MIPS_MT_SMP
 
 extern const struct plat_smp_ops vsmp_smp_ops;
-static struct plat_smp_ops rtlops;
+static struct plat_smp_ops rtl_smp_ops;
 
 static void rtlsmp_init_secondary(void)
 {
@@ -62,10 +62,10 @@ static int rtlsmp_register(void)
 	if (!cpu_has_mipsmt)
 		return 1;
 
-	rtlops = vsmp_smp_ops;
-	rtlops.init_secondary = rtlsmp_init_secondary;
-	rtlops.smp_finish = rtlsmp_finish;
-	register_smp_ops(&rtlops);
+	rtl_smp_ops = vsmp_smp_ops;
+	rtl_smp_ops.init_secondary = rtlsmp_init_secondary;
+	rtl_smp_ops.smp_finish = rtlsmp_finish;
+	register_smp_ops(&rtl_smp_ops);
 
 	return 0;
 }
@@ -99,7 +99,7 @@ void __init device_tree_init(void)
 
 const char *get_system_type(void)
 {
-	return rtl83xx_system_type;
+	return rtl_system_type;
 }
 
 static void __init rtl838x_read_details(u32 model)
@@ -206,13 +206,13 @@ static void __init parse_model(u32 model)
 	if (val > 0 && val <= 26)
 		suffix = 'A' + (val - 1);
 
-	snprintf(soc_name, sizeof(soc_name), "RTL%04X%c",
+	snprintf(rtl_soc_name, sizeof(rtl_soc_name), "RTL%04X%c",
 		 soc_info.id, suffix);
 
-	soc_info.name = soc_name;
+	soc_info.name = rtl_soc_name;
 }
 
-static void __init rtl83xx_set_system_type(void)
+static void __init set_system_type(void)
 {
 	char revision = '?';
 	char *es = "";
@@ -223,7 +223,7 @@ static void __init rtl83xx_set_system_type(void)
 	if (soc_info.testchip)
 		es = " ES";
 
-	snprintf(rtl83xx_system_type, sizeof(rtl83xx_system_type),
+	snprintf(rtl_system_type, sizeof(rtl_system_type),
 		 "Realtek %s%s rev %c (%04X)",
 		 soc_info.name, es, revision, soc_info.cpu);
 }
@@ -233,7 +233,7 @@ void __init prom_init(void)
 	u32 model = read_model();
 
 	parse_model(model);
-	rtl83xx_set_system_type();
+	set_system_type();
 
 	pr_info("SoC Type: %s\n", get_system_type());
 

--- a/target/linux/realtek/files-6.12/arch/mips/rtl838x/prom.c
+++ b/target/linux/realtek/files-6.12/arch/mips/rtl838x/prom.c
@@ -187,6 +187,7 @@ static u32 __init read_model(void)
 	if ((id >= 0x8380 && id <= 0x8382) || id == 0x8330 || id == 0x8332) {
 		soc_info.id = id;
 		soc_info.family = RTL8380_FAMILY_ID;
+		soc_info.cpu_port = RTL838X_CPU_PORT;
 		rtl838x_read_details(model);
 		return model;
 	}
@@ -196,6 +197,7 @@ static u32 __init read_model(void)
 	if ((id >= 0x8391 && id <= 0x8396) || (id >= 0x8351 && id <= 0x8353)) {
 		soc_info.id = id;
 		soc_info.family = RTL8390_FAMILY_ID;
+		soc_info.cpu_port = RTL839X_CPU_PORT;
 		rtl839x_read_details(model);
 		return model;
 	}
@@ -205,11 +207,13 @@ static u32 __init read_model(void)
 	if (id >= 0x9301 && id <= 0x9303) {
 		soc_info.id = id;
 		soc_info.family = RTL9300_FAMILY_ID;
+		soc_info.cpu_port = RTL930X_CPU_PORT;
 		rtl93xx_read_details(model);
 		return model;
 	} else if (id >= 0x9311 && id <= 0x9313) {
 		soc_info.id = id;
 		soc_info.family = RTL9310_FAMILY_ID;
+		soc_info.cpu_port = RTL931X_CPU_PORT;
 		rtl93xx_read_details(model);
 		return model;
 	}


### PR DESCRIPTION
This series fixes several shortcomings in prom.c. Especially boot stalls on RLT930x devices with kernel 6.18 and more than 256 MB memory.