### PR TITLE
rtl8101/rtl8168: fix CFLAGS with linux 6.15+

### DIFF
--- a/package/kernel/r8101/Makefile
+++ b/package/kernel/r8101/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8101
 PKG_VERSION:=1.039.00
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8101/releases/download/$(PKG_VERSION)

--- a/package/kernel/r8101/patches/002-Makefile-fix-CFLAGS-with-linux-6.15.patch
+++ b/package/kernel/r8101/patches/002-Makefile-fix-CFLAGS-with-linux-6.15.patch
@@ -1,0 +1,26 @@
+From 1bb099396afa88077b93bfdbd4d20dbdacea36eb Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Tue, 30 Dec 2025 14:38:03 +0100
+Subject: [PATCH] Makefile: fix CFLAGS with linux 6.15+
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Ensure EXTRA_CFLAGS are taken into account.
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ src/Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -64,6 +64,8 @@ ifneq ($(KERNELRELEASE),)
+ 	ifeq ($(CONFIG_CTAP_SHORT_OFF), y)
+ 		EXTRA_CFLAGS += -DCONFIG_CTAP_SHORT_OFF
+ 	endif
++
++	ccflags-y += $(EXTRA_CFLAGS)
+ else
+ 	BASEDIR := /lib/modules/$(shell uname -r)
+ 	KERNELDIR ?= $(BASEDIR)/build

--- a/package/kernel/r8168/Makefile
+++ b/package/kernel/r8168/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=r8168
 PKG_VERSION:=8.055.00
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://github.com/openwrt/rtl8168/releases/download/$(PKG_VERSION)

--- a/package/kernel/r8168/patches/002-Makefile-fix-CFLAGS-with-linux-6.15.patch
+++ b/package/kernel/r8168/patches/002-Makefile-fix-CFLAGS-with-linux-6.15.patch
@@ -1,0 +1,26 @@
+From b5a3eaec6a4ba859602a286fcb5034cf3f25fc55 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=81lvaro=20Fern=C3=A1ndez=20Rojas?= <noltari@gmail.com>
+Date: Tue, 30 Dec 2025 14:35:03 +0100
+Subject: [PATCH] Makefile: fix CFLAGS with linux 6.15+
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Ensure EXTRA_CFLAGS are taken into account.
+
+Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>
+---
+ src/Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -121,6 +121,8 @@ ifneq ($(KERNELRELEASE),)
+ 	ifeq ($(ENABLE_GIGA_LITE), y)
+ 		EXTRA_CFLAGS += -DENABLE_GIGA_LITE
+ 	endif
++
++	ccflags-y += $(EXTRA_CFLAGS)
+ else
+ 	BASEDIR := /lib/modules/$(shell uname -r)
+ 	KERNELDIR ?= $(BASEDIR)/build


### PR DESCRIPTION
- kernel: r8101: fix CFLAGS with linux 6.15+
- kernel: r8168: fix CFLAGS with linux 6.15+