### PR TITLE
realtek: rt-loader: add piggy-backed uimage support

### DIFF
--- a/target/linux/realtek/image/rt-loader/src/main.c
+++ b/target/linux/realtek/image/rt-loader/src/main.c
@@ -128,19 +128,15 @@ void *decompress(void *out, void *in, int len)
 	return out;
 }
 
-void search_image(void **flash_addr, int *flash_size, void **load_addr)
+void search_image(void **image_addr, int *image_size, void **load_addr)
 {
-	unsigned char *addr = *flash_addr;
-	unsigned int image_size = 0;
-	unsigned int *maxaddr;
+	unsigned char *addr = *image_addr;
 
-	printf("Searching for uImage starting at 0x%08x ...\n", addr);
-
-	*flash_addr = NULL;
-	for (int i = 0; i < 256 * 1024; i += 4, addr += 4) {
+	*image_addr = NULL;
+	for (int i = 0; i < 256 * 1024; i += 1, addr += 1) {
 		if (is_uimage(addr)) {
-			*flash_addr = addr;
-			*flash_size = *(int *)(addr + 12);
+			*image_addr = addr;
+			*image_size = *(int *)(addr + 12);
 			*load_addr = *(void **)(addr + 16);
 			_kernel_comp_type = addr[31];
 			break;
@@ -151,6 +147,8 @@ void search_image(void **flash_addr, int *flash_size, void **load_addr)
 void load_kernel(void *flash_start)
 {
 	void *flash_addr = flash_start;
+
+	printf("Searching for uImage starting at 0x%08x ...\n", flash_addr);
 
 	search_image(&flash_addr, &_kernel_data_size, &_kernel_load_addr);
 	_kernel_data_addr = _my_load_addr - _kernel_data_size - 1024;

--- a/target/linux/realtek/image/rt-loader/src/main.c
+++ b/target/linux/realtek/image/rt-loader/src/main.c
@@ -144,10 +144,14 @@ void search_image(void **image_addr, int *image_size, void **load_addr)
 	}
 }
 
-void load_kernel(void *flash_start)
+void load_uimage_from_flash(void *flash_start)
 {
 	void *flash_addr = flash_start;
 
+	/*
+	 * Loader has been started standalone. So no piggy backed kernel. Search
+	 * flash for kernel uImage and copy it to memory before the loader.
+	 */
 	printf("Searching for uImage starting at 0x%08x ...\n", flash_addr);
 
 	search_image(&flash_addr, &_kernel_data_size, &_kernel_load_addr);
@@ -186,11 +190,11 @@ void main(unsigned long reg_a0, unsigned long reg_a1,
 	}
 
 	/*
-	 * Check if we have been started standalone. So no piggy backed kernel.
-	 * Search flash for kernel uImage and copy it to memory before the loader.
+	 * Usually the loader expects a piggy-backed lzma compressed kernel stream.
+	 * Evaluate alternative configurations for kernel loading and decompression.
 	 */
 	if (flash_start)
-		load_kernel(flash_start);
+		load_uimage_from_flash(flash_start);
 	else if (kernel_addr)
 		_kernel_load_addr = kernel_addr;
 


### PR DESCRIPTION
rt-loader currently assumes an append lzma compressed data stream that is decompressed to the initial load address of itself. This PR adds support for appended uimages. For non-UBoot devices this allows dynamically loadable "initramfs" images with the following recipe:

```
define Device/rt-loader-uimage
	KERNEL/rt-compress := kernel-bin | append-dtb | rt-compress
	KERNEL := $$(KERNEL/rt-compress) | rt-loader | uImage none
	KERNEL_INITRAMFS := $$(KERNEL/rt-compress) | uImage lzma | rt-loader
endef
```