### PR TITLE
treewide: drop CVS support

### DIFF
--- a/include/download.mk
+++ b/include/download.mk
@@ -34,11 +34,9 @@ $(strip \
       $(if $(filter @OPENWRT @APACHE/% @DEBIAN/% @GITHUB/% @GNOME/% @GNU/% @KERNEL/% @SF/% @SAVANNAH/% ftp://% http://% https://% file://%,$(1)),default, \
         $(if $(filter git://%,$(1)),$(call dl_method_git,$(1),$(2)), \
           $(if $(filter svn://%,$(1)),svn, \
-            $(if $(filter cvs://%,$(1)),cvs, \
-              $(if $(filter hg://%,$(1)),hg, \
-                $(if $(filter sftp://%,$(1)),bzr, \
-                  unknown \
-                ) \
+            $(if $(filter hg://%,$(1)),hg, \
+              $(if $(filter sftp://%,$(1)),bzr, \
+                unknown \
               ) \
             ) \
           ) \
@@ -49,7 +47,7 @@ $(strip \
 )
 endef
 
-# code for creating tarballs from cvs/svn/git/bzr/hg/darcs checkouts - useful for mirror support
+# code for creating tarballs from svn/git/bzr/hg/darcs checkouts - useful for mirror support
 dl_pack/bz2=bzip2 -c > $(1)
 dl_pack/gz=gzip -nc > $(1)
 dl_pack/xz=xz -zc -7e > $(1)
@@ -171,21 +169,6 @@ $(if $(filter check,$(1)), \
 )
 endef
 
-define DownloadMethod/cvs
-	$(call wrap_mirror,$(1),$(2), \
-		echo "Checking out files from the cvs repository..."; \
-		mkdir -p $(TMP_DIR)/dl && \
-		cd $(TMP_DIR)/dl && \
-		rm -rf $(SUBDIR) && \
-		[ \! -d $(SUBDIR) ] && \
-		cvs -d $(URL) export $(SOURCE_VERSION) $(SUBDIR) && \
-		echo "Packing checkout..." && \
-		$(call dl_tar_pack,$(TMP_DIR)/dl/$(FILE),$(SUBDIR)) && \
-		mv $(TMP_DIR)/dl/$(FILE) $(DL_DIR)/ && \
-		rm -rf $(SUBDIR); \
-	)
-endef
-
 define DownloadMethod/svn
 	$(call wrap_mirror,$(1),$(2), \
 		echo "Checking out files from the svn repository..."; \
@@ -305,7 +288,6 @@ define DownloadMethod/darcs
 	)
 endef
 
-Validate/cvs=SOURCE_VERSION SUBDIR
 Validate/svn=SOURCE_VERSION SUBDIR
 Validate/git=SOURCE_VERSION SUBDIR
 Validate/bzr=SOURCE_VERSION SUBDIR

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -450,7 +450,7 @@ endif
 	$(call Package/$(1)/install,$$(IDIR_$(1)))
 	$(if $(Package/$(1)/install-overlay),mkdir -p $(PACKAGE_DIR) $$(IDIR_$(1))/rootfs-overlay)
 	$(call Package/$(1)/install-overlay,$$(IDIR_$(1))/rootfs-overlay)
-	-find $$(IDIR_$(1)) -name 'CVS' -o -name '.svn' -o -name '.#*' -o -name '*~'| $(XARGS) rm -rf
+	-find $$(IDIR_$(1)) -name '.svn' -o -name '.#*' -o -name '*~'| $(XARGS) rm -rf
 	@( \
 		find $$(IDIR_$(1)) -name lib\*.so\* -or -name \*.ko | awk -F/ '{ print $$$$NF }'; \
 		for file in $$(patsubst %,$(PKG_INFO_DIR)/%.provides,$$(IDEPEND_$(1))); do \

--- a/include/rootfs.mk
+++ b/include/rootfs.mk
@@ -113,7 +113,7 @@ define prepare_rootfs
 		done || true \
 	)
 
-	@-find $(1) -name CVS -o -name .svn -o -name .git -o -name '.#*' | $(XARGS) rm -rf
+	@-find $(1) -name .svn -o -name .git -o -name '.#*' | $(XARGS) rm -rf
 	rm -rf \
 		$(1)/boot \
 		$(1)/tmp/* \

--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -130,7 +130,7 @@ endif
 	$(SED) 's,^# LIBC_VERSION:=.*,LIBC_VERSION:=$(shell cat $(STAGING_DIR)/libc.version),g' $(PKG_BUILD_DIR)/include/version.mk
 	$(SED) 's,^# KERNEL_VERSION:=.*,KERNEL_VERSION:=$(shell cat $(STAGING_DIR)/kernel.version),g' $(PKG_BUILD_DIR)/include/version.mk
 	$(SED) '/LINUX_VERMAGIC:=/ { s,unknown,$(LINUX_VERMAGIC),g }' $(PKG_BUILD_DIR)/include/kernel.mk
-	find $(PKG_BUILD_DIR) -name CVS -o -name .git -o -name .svn \
+	find $(PKG_BUILD_DIR) -name .git -o -name .svn \
 	  | $(XARGS) rm -rf
 	$(INSTALL_DIR) $(IB_IDIR)
 	-$(CP) $(STAGING_DIR_IMAGE)/* $(IB_IDIR)/

--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -183,7 +183,6 @@ $(BIN_DIR)/$(SDK_NAME).tar.zst: clean
 	$(SED) '/LINUX_VERMAGIC:=/ { s,unknown,$(LINUX_VERMAGIC),g }' $(SDK_BUILD_DIR)/include/kernel.mk
 	find $(SDK_BUILD_DIR) -name .git | $(XARGS) rm -rf
 	find $(SDK_BUILD_DIR) -name .svn | $(XARGS) rm -rf
-	find $(SDK_BUILD_DIR) -name CVS | $(XARGS) rm -rf
 	-make -C $(SDK_BUILD_DIR)/scripts/config clean
 
 	(cd $(BUILD_DIR); \


### PR DESCRIPTION
We have no CVS-managed package in official repositories.
This commit drops obsolete SCM system support.
