### PR TITLE
[pre-6.18] realtek: rename smi-address dts property

### DIFF
--- a/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
+++ b/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
@@ -69,122 +69,122 @@
 	phy0: ethernet-phy@0 {
 		reg = <0>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 0>;
+		realtek,smi-address = <0 0>;
 	};
 	phy1: ethernet-phy@1 {
 		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 1>;
+		realtek,smi-address = <0 1>;
 	};		
 	phy2: ethernet-phy@2 {
 		reg = <2>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 2>;
+		realtek,smi-address = <0 2>;
 	};		
 	phy3: ethernet-phy@3 {
 		reg = <3>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 3>;
+		realtek,smi-address = <0 3>;
 	};		
 	phy4: ethernet-phy@4 {
 		reg = <4>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 4>;
+		realtek,smi-address = <0 4>;
 	};		
 	phy5: ethernet-phy@5 {
 		reg = <5>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 5>;
+		realtek,smi-address = <0 5>;
 	};		
 	phy6: ethernet-phy@6 {
 		reg = <6>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 6>;
+		realtek,smi-address = <0 6>;
 	};		
 	phy7: ethernet-phy@7 {
 		reg = <7>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 7>;
+		realtek,smi-address = <0 7>;
 	};		
 	phy8: ethernet-phy@8 {
 		reg = <8>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 8>;
+		realtek,smi-address = <1 8>;
 	};
 	phy9: ethernet-phy@9 {
 		reg = <9>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 9>;
+		realtek,smi-address = <1 9>;
 	};
 	phy10: ethernet-phy@10 {
 		reg = <10>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 10>;
+		realtek,smi-address = <1 10>;
 	};
 	phy11: ethernet-phy@11 {
 		reg = <11>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 11>;
+		realtek,smi-address = <1 11>;
 	};
 	phy12: ethernet-phy@12 {
 		reg = <12>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 12>;
+		realtek,smi-address = <1 12>;
 	};
 	phy13: ethernet-phy@13 {
 		reg = <13>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 13>;
+		realtek,smi-address = <1 13>;
 	};
 	phy14: ethernet-phy@14 {
 		reg = <14>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 14>;
+		realtek,smi-address = <1 14>;
 	};
 	phy15: ethernet-phy@15 {
 		reg = <15>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 15>;
+		realtek,smi-address = <1 15>;
 	};
 	phy16: ethernet-phy@16 {
 		reg = <16>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <2 16>;
+		realtek,smi-address = <2 16>;
 	};
 	phy17: ethernet-phy@17 {
 		reg = <17>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <2 17>;
+		realtek,smi-address = <2 17>;
 	};		
 	phy18: ethernet-phy@18 {
 		reg = <18>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <2 18>;
+		realtek,smi-address = <2 18>;
 	};		
 	phy19: ethernet-phy@19 {
 		reg = <19>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <2 19>;
+		realtek,smi-address = <2 19>;
 	};		
 	phy20: ethernet-phy@20 {
 		reg = <20>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <2 20>;
+		realtek,smi-address = <2 20>;
 	};		
 	phy21: ethernet-phy@21 {
 		reg = <21>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <2 21>;
+		realtek,smi-address = <2 21>;
 	};		
 	phy22: ethernet-phy@22 {
 		reg = <22>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <2 22>;
+		realtek,smi-address = <2 22>;
 	};		
 	phy23: ethernet-phy@23 {
 		reg = <23>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <2 23>;
+		realtek,smi-address = <2 23>;
 	};	
 };
 

--- a/target/linux/realtek/dts/rtl9302_plasmacloud_common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_plasmacloud_common.dtsi
@@ -138,49 +138,49 @@
 	phy0: ethernet-phy@0 {
 		reg = <0>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 0>;
+		realtek,smi-address = <0 0>;
 	};
 
 	phy1: ethernet-phy@1 {
 		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 1>;
+		realtek,smi-address = <0 1>;
 	};
 
 	phy2: ethernet-phy@2 {
 		reg = <2>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 2>;
+		realtek,smi-address = <0 2>;
 	};
 
 	phy3: ethernet-phy@3 {
 		reg = <3>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 3>;
+		realtek,smi-address = <0 3>;
 	};
 
 	phy8: ethernet-phy@8 {
 		reg = <8>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 4>;
+		realtek,smi-address = <0 4>;
 	};
 
 	phy9: ethernet-phy@9 {
 		reg = <9>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 5>;
+		realtek,smi-address = <0 5>;
 	};
 
 	phy10: ethernet-phy@10 {
 		reg = <10>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 6>;
+		realtek,smi-address = <0 6>;
 	};
 
 	phy11: ethernet-phy@11 {
 		reg = <11>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 7>;
+		realtek,smi-address = <0 7>;
 	};
 };
 

--- a/target/linux/realtek/dts/rtl9302_plasmacloud_mcx3.dts
+++ b/target/linux/realtek/dts/rtl9302_plasmacloud_mcx3.dts
@@ -155,13 +155,13 @@
 	phy0: ethernet-phy@0 {
 		reg = <0>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 0>;
+		realtek,smi-address = <0 0>;
 	};
 
 	phy1: ethernet-phy@1 {
 		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 1>;
+		realtek,smi-address = <0 1>;
 	};
 };
 

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-a1.dts
@@ -104,9 +104,9 @@
 };
 
 &phy24 {
-	rtl9300,smi-address = <1 8>;
+	realtek,smi-address = <1 8>;
 };
 
 &phy25 {
-	rtl9300,smi-address = <2 9>;
+	realtek,smi-address = <2 9>;
 };

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-a1.dts
@@ -9,9 +9,9 @@
 };
 
 &phy24 {
-	rtl9300,smi-address = <1 8>;
+	realtek,smi-address = <1 8>;
 };
 
 &phy25 {
-	rtl9300,smi-address = <2 9>;
+	realtek,smi-address = <2 9>;
 };

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-b1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-b1.dts
@@ -9,9 +9,9 @@
 };
 
 &phy24 {
-	rtl9300,smi-address = <1 1>;
+	realtek,smi-address = <1 1>;
 };
 
 &phy25 {
-	rtl9300,smi-address = <2 2>;
+	realtek,smi-address = <2 2>;
 };

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-a1.dts
@@ -13,7 +13,7 @@
 	phy24: ethernet-phy@24 {
 		reg = <24>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 8>;
+		realtek,smi-address = <1 8>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;
@@ -22,7 +22,7 @@
 	phy25: ethernet-phy@25 {
 		reg = <25>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <2 8>;
+		realtek,smi-address = <2 8>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;
@@ -31,7 +31,7 @@
 	phy26: ethernet-phy@26 {
 		reg = <26>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <3 8>;
+		realtek,smi-address = <3 8>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-b1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-b1.dts
@@ -12,7 +12,7 @@
 	phy24: ethernet-phy@24 {
 		reg = <24>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 0>;
+		realtek,smi-address = <1 0>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;
@@ -21,7 +21,7 @@
 	phy25: ethernet-phy@25 {
 		reg = <25>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <2 1>;
+		realtek,smi-address = <2 1>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;
@@ -30,7 +30,7 @@
 	phy26: ethernet-phy@26 {
 		reg = <26>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <3 2>;
+		realtek,smi-address = <3 2>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
@@ -222,44 +222,44 @@
 	phy0: ethernet-phy@0 {
 		reg = <0>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 0>;
+		realtek,smi-address = <0 0>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 	};
 	phy1: ethernet-phy@1 {
 		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 1>;
+		realtek,smi-address = <0 1>;
 	};
 	phy2: ethernet-phy@2 {
 		reg = <2>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 2>;
+		realtek,smi-address = <0 2>;
 	};
 	phy3: ethernet-phy@3 {
 		reg = <3>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 3>;
+		realtek,smi-address = <0 3>;
 	};
 	phy4: ethernet-phy@4 {
 		reg = <4>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 4>;
+		realtek,smi-address = <0 4>;
 	};
 	phy5: ethernet-phy@5 {
 		reg = <5>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 5>;
+		realtek,smi-address = <0 5>;
 	};
 	phy6: ethernet-phy@6 {
 		reg = <6>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 6>;
+		realtek,smi-address = <0 6>;
 	};
 	phy7: ethernet-phy@7 {
 		reg = <7>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 7>;
+		realtek,smi-address = <0 7>;
 	};
 };
 

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
@@ -91,44 +91,44 @@
 	phy0: ethernet-phy@0 {
 		reg = <0>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 0>;
+		realtek,smi-address = <0 0>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 	};
 	phy1: ethernet-phy@1 {
 		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 1>;
+		realtek,smi-address = <0 1>;
 	};
 	phy2: ethernet-phy@2 {
 		reg = <2>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 2>;
+		realtek,smi-address = <0 2>;
 	};
 	phy3: ethernet-phy@3 {
 		reg = <3>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 3>;
+		realtek,smi-address = <0 3>;
 	};
 	phy4: ethernet-phy@4 {
 		reg = <4>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 4>;
+		realtek,smi-address = <0 4>;
 	};
 	phy5: ethernet-phy@5 {
 		reg = <5>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 5>;
+		realtek,smi-address = <0 5>;
 	};
 	phy6: ethernet-phy@6 {
 		reg = <6>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 6>;
+		realtek,smi-address = <0 6>;
 	};
 	phy7: ethernet-phy@7 {
 		reg = <7>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 7>;
+		realtek,smi-address = <0 7>;
 	};
 
 	phy24: ethernet-phy@24 {

--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
@@ -129,49 +129,49 @@
 &mdio_bus0 {
 	phy0: ethernet-phy@0 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 0>;
+		realtek,smi-address = <0 0>;
 		reg = <0>;
 	};
 
 	phy8: ethernet-phy@8 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 1>;
+		realtek,smi-address = <0 1>;
 		reg = <8>;
 	};
 
 	phy16: ethernet-phy@16 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 2>;
+		realtek,smi-address = <0 2>;
 		reg = <16>;
 	};
 
 	phy20: ethernet-phy@20 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 3>;
+		realtek,smi-address = <0 3>;
 		reg = <20>;
 	};
 
 	phy24: ethernet-phy@24 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <3 16>;
+		realtek,smi-address = <3 16>;
 		reg = <24>;
 	};
 
 	phy25: ethernet-phy@25 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <3 17>;
+		realtek,smi-address = <3 17>;
 		reg = <25>;
 	};
 
 	phy26: ethernet-phy@26 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <3 18>;
+		realtek,smi-address = <3 18>;
 		reg = <26>;
 	};
 
 	phy27: ethernet-phy@27 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <3 19>;
+		realtek,smi-address = <3 19>;
 		reg = <27>;
 	};
 };

--- a/target/linux/realtek/dts/rtl9311_linksys_lgs352c.dts
+++ b/target/linux/realtek/dts/rtl9311_linksys_lgs352c.dts
@@ -83,242 +83,242 @@
 	phy0: ethernet-phy@0 {
 		reg = <0>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 0>;
+		realtek,smi-address = <0 0>;
 	};
 	phy1: ethernet-phy@1 {
 		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 1>;
+		realtek,smi-address = <0 1>;
 	};
 	phy2: ethernet-phy@2 {
 		reg = <2>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 2>;
+		realtek,smi-address = <0 2>;
 	};
 	phy3: ethernet-phy@3 {
 		reg = <3>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 3>;
+		realtek,smi-address = <0 3>;
 	};
 	phy4: ethernet-phy@4 {
 		reg = <4>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 4>;
+		realtek,smi-address = <0 4>;
 	};
 	phy5: ethernet-phy@5 {
 		reg = <5>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 5>;
+		realtek,smi-address = <0 5>;
 	};
 	phy6: ethernet-phy@6 {
 		reg = <6>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 6>;
+		realtek,smi-address = <0 6>;
 	};
 	phy7: ethernet-phy@7 {
 		reg = <7>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 7>;
+		realtek,smi-address = <0 7>;
 	};
 	phy8: ethernet-phy@8 {
 		reg = <8>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 8>;
+		realtek,smi-address = <0 8>;
 	};
 	phy9: ethernet-phy@9 {
 		reg = <9>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 9>;
+		realtek,smi-address = <0 9>;
 	};
 	phy10: ethernet-phy@10 {
 		reg = <10>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 10>;
+		realtek,smi-address = <0 10>;
 	};
 	phy11: ethernet-phy@11 {
 		reg = <11>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 11>;
+		realtek,smi-address = <0 11>;
 	};
 	phy12: ethernet-phy@12 {
 		reg = <12>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 12>;
+		realtek,smi-address = <0 12>;
 	};
 	phy13: ethernet-phy@13 {
 		reg = <13>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 13>;
+		realtek,smi-address = <0 13>;
 	};
 	phy14: ethernet-phy@14 {
 		reg = <14>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 14>;
+		realtek,smi-address = <0 14>;
 	};
 	phy15: ethernet-phy@15 {
 		reg = <15>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 15>;
+		realtek,smi-address = <0 15>;
 	};
 	phy16: ethernet-phy@16 {
 		reg = <16>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 16>;
+		realtek,smi-address = <0 16>;
 	};
 	phy17: ethernet-phy@17 {
 		reg = <17>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 17>;
+		realtek,smi-address = <0 17>;
 	};
 	phy18: ethernet-phy@18 {
 		reg = <18>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 18>;
+		realtek,smi-address = <0 18>;
 	};
 	phy19: ethernet-phy@19 {
 		reg = <19>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 19>;
+		realtek,smi-address = <0 19>;
 	};
 	phy20: ethernet-phy@20 {
 		reg = <20>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 20>;
+		realtek,smi-address = <0 20>;
 	};
 	phy21: ethernet-phy@21 {
 		reg = <21>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 21>;
+		realtek,smi-address = <0 21>;
 	};
 	phy22: ethernet-phy@22 {
 		reg = <22>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 22>;
+		realtek,smi-address = <0 22>;
 	};
 	phy23: ethernet-phy@23 {
 		reg = <23>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <0 23>;
+		realtek,smi-address = <0 23>;
 	};
 	phy24: ethernet-phy@24 {
 		reg = <24>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 0>;
+		realtek,smi-address = <1 0>;
 	};
 	phy25: ethernet-phy@25 {
 		reg = <25>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 1>;
+		realtek,smi-address = <1 1>;
 	};
 	phy26: ethernet-phy@26 {
 		reg = <26>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 2>;
+		realtek,smi-address = <1 2>;
 	};
 	phy27: ethernet-phy@27 {
 		reg = <27>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 3>;
+		realtek,smi-address = <1 3>;
 	};
 	phy28: ethernet-phy@28 {
 		reg = <28>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 4>;
+		realtek,smi-address = <1 4>;
 	};
 	phy29: ethernet-phy@29 {
 		reg = <29>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 5>;
+		realtek,smi-address = <1 5>;
 	};
 	phy30: ethernet-phy@30 {
 		reg = <30>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 6>;
+		realtek,smi-address = <1 6>;
 	};
 	phy31: ethernet-phy@31 {
 		reg = <31>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 7>;
+		realtek,smi-address = <1 7>;
 	};
 	phy32: ethernet-phy@32 {
 		reg = <32>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 8>;
+		realtek,smi-address = <1 8>;
 	};
 	phy33: ethernet-phy@33 {
 		reg = <33>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 9>;
+		realtek,smi-address = <1 9>;
 	};
 	phy34: ethernet-phy@34 {
 		reg = <34>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 10>;
+		realtek,smi-address = <1 10>;
 	};
 	phy35: ethernet-phy@35 {
 		reg = <35>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 11>;
+		realtek,smi-address = <1 11>;
 	};
 	phy36: ethernet-phy@36 {
 		reg = <36>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 12>;
+		realtek,smi-address = <1 12>;
 	};
 	phy37: ethernet-phy@37 {
 		reg = <37>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 13>;
+		realtek,smi-address = <1 13>;
 	};
 	phy38: ethernet-phy@38 {
 		reg = <38>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 14>;
+		realtek,smi-address = <1 14>;
 	};
 	phy39: ethernet-phy@39 {
 		reg = <39>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 15>;
+		realtek,smi-address = <1 15>;
 	};
 	phy40: ethernet-phy@40 {
 		reg = <40>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 16>;
+		realtek,smi-address = <1 16>;
 	};
 	phy41: ethernet-phy@41 {
 		reg = <41>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 17>;
+		realtek,smi-address = <1 17>;
 	};
 	phy42: ethernet-phy@42 {
 		reg = <42>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 18>;
+		realtek,smi-address = <1 18>;
 	};
 	phy43: ethernet-phy@43 {
 		reg = <43>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 19>;
+		realtek,smi-address = <1 19>;
 	};
 	phy44: ethernet-phy@44 {
 		reg = <44>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 20>;
+		realtek,smi-address = <1 20>;
 	};
 	phy45: ethernet-phy@45 {
 		reg = <45>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 21>;
+		realtek,smi-address = <1 21>;
 	};
 	phy46: ethernet-phy@46 {
 		reg = <46>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 22>;
+		realtek,smi-address = <1 22>;
 	};
 	phy47: ethernet-phy@47 {
 		reg = <47>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		rtl9300,smi-address = <1 23>;
+		realtek,smi-address = <1 23>;
 	};
 };
 

--- a/target/linux/realtek/dts/rtl9312_plasmacloud_common.dtsi
+++ b/target/linux/realtek/dts/rtl9312_plasmacloud_common.dtsi
@@ -243,145 +243,145 @@
 	phy0: ethernet-phy@0 {
 		reg = <0>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 0>;
+		realtek,smi-address = <0 0>;
 	};
 
 	phy1: ethernet-phy@1 {
 		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 1>;
+		realtek,smi-address = <0 1>;
 	};
 
 	phy4: ethernet-phy@4 {
 		reg = <4>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 2>;
+		realtek,smi-address = <0 2>;
 	};
 
 	phy5: ethernet-phy@5 {
 		reg = <5>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 3>;
+		realtek,smi-address = <0 3>;
 	};
 
 	phy8: ethernet-phy@8 {
 		reg = <8>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 4>;
+		realtek,smi-address = <0 4>;
 	};
 
 	phy9: ethernet-phy@9 {
 		reg = <9>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 5>;
+		realtek,smi-address = <0 5>;
 	};
 
 	phy12: ethernet-phy@12 {
 		reg = <12>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 6>;
+		realtek,smi-address = <0 6>;
 	};
 
 	phy13: ethernet-phy@13 {
 		reg = <13>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 7>;
+		realtek,smi-address = <0 7>;
 	};
 
 	phy16: ethernet-phy@16 {
 		reg = <16>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 8>;
+		realtek,smi-address = <0 8>;
 	};
 
 	phy17: ethernet-phy@17 {
 		reg = <17>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 9>;
+		realtek,smi-address = <0 9>;
 	};
 
 	phy20: ethernet-phy@20 {
 		reg = <20>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 10>;
+		realtek,smi-address = <0 10>;
 	};
 
 	phy21: ethernet-phy@21 {
 		reg = <21>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <0 11>;
+		realtek,smi-address = <0 11>;
 	};
 
 	phy24: ethernet-phy@24 {
 		reg = <24>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 12>;
+		realtek,smi-address = <1 12>;
 	};
 
 	phy25: ethernet-phy@25 {
 		reg = <25>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 13>;
+		realtek,smi-address = <1 13>;
 	};
 
 	phy28: ethernet-phy@28 {
 		reg = <28>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 14>;
+		realtek,smi-address = <1 14>;
 	};
 
 	phy29: ethernet-phy@29 {
 		reg = <29>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 15>;
+		realtek,smi-address = <1 15>;
 	};
 
 	phy32: ethernet-phy@32 {
 		reg = <32>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 16>;
+		realtek,smi-address = <1 16>;
 	};
 
 	phy33: ethernet-phy@33 {
 		reg = <33>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 17>;
+		realtek,smi-address = <1 17>;
 	};
 
 	phy36: ethernet-phy@36 {
 		reg = <36>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 18>;
+		realtek,smi-address = <1 18>;
 	};
 
 	phy37: ethernet-phy@37 {
 		reg = <37>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 19>;
+		realtek,smi-address = <1 19>;
 	};
 
 	phy40: ethernet-phy@40 {
 		reg = <40>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 20>;
+		realtek,smi-address = <1 20>;
 	};
 
 	phy41: ethernet-phy@41 {
 		reg = <41>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 21>;
+		realtek,smi-address = <1 21>;
 	};
 
 	phy44: ethernet-phy@44 {
 		reg = <44>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 22>;
+		realtek,smi-address = <1 22>;
 	};
 
 	phy45: ethernet-phy@45 {
 		reg = <45>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		rtl9300,smi-address = <1 23>;
+		realtek,smi-address = <1 23>;
 	};
 };
 

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -1429,7 +1429,7 @@ static int rtmdio_probe(struct platform_device *pdev)
 			return -ENODEV;
 		}
 
-		if (of_property_read_u32_array(dn, "rtl9300,smi-address", &smi_addr[0], 2)) {
+		if (of_property_read_u32_array(dn, "realtek,smi-address", &smi_addr[0], 2)) {
 			priv->smi_bus[pn] = 0;
 			priv->smi_addr[pn] = pn;
 		} else {


### PR DESCRIPTION
The rtl9300,smi-address property was first developed for the RTL930x targets. So it got a device specific prefix. Nowadays it is used for RTL931x targets too. Convert it to our gerneric realtek prefix.

`find ./realtek -type f -exec sed -i 's/rtl9300,smi-address/realtek,smi-address/g' {} +`
