### PR TITLE
[24.10] Backport: mediatek Cudy WBR3000UAX v1 support (factory + ubootmod + ATF)

### DIFF
--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -223,8 +223,8 @@ define Trusted-Firmware-A/mt7981-spim-nand-ddr3
   DDR_TYPE:=ddr3
 endef
 
-define Trusted-Firmware-A/mt7981-cudy-tr3000-v1
-  NAME:=Cudy TR3000 v1 (SPI-NAND via SPIM, DDR3)
+define Trusted-Firmware-A/mt7981-cudy-ddr3
+  NAME:=Cudy (SPI-NAND via SPIM, DDR3)
   BOOT_DEVICE:=spim-nand
   BUILD_SUBTARGET:=filogic
   PLAT:=mt7981
@@ -546,7 +546,7 @@ TFA_TARGETS:= \
 	mt7981-ram-ddr4 \
 	mt7981-emmc-ddr4 \
 	mt7981-spim-nand-ddr4 \
-	mt7981-cudy-tr3000-v1 \
+	mt7981-cudy-ddr3 \
 	mt7986-ram-ddr3 \
 	mt7986-emmc-ddr3 \
 	mt7986-nor-ddr3 \

--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -226,11 +226,12 @@ define Trusted-Firmware-A/mt7981-spim-nand-ddr3
 endef
 
 define Trusted-Firmware-A/mt7981-cudy-ddr3
-  NAME:=Cudy (SPI-NAND via SPIM, DDR3)
+  NAME:=Cudy (SPI-NAND via SPIM, DDR3 1866 MT/s)
   BOOT_DEVICE:=spim-nand
   BUILD_SUBTARGET:=filogic
   PLAT:=mt7981
   DDR_TYPE:=ddr3
+  DDR3_FREQ_1866:=1
   FIP_OFFSET:=0x3c0000
   FIP_SIZE:=0x200000
 endef

--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -29,6 +29,7 @@ define Trusted-Firmware-A/Default
   HIDDEN:=y
   BOOT_DEVICE:=
   DDR3_FLYBY:=
+  DDR3_FREQ_1866:=
   DDR_TYPE:=
   NAND_TYPE:=
   BOARD_QFN:=
@@ -178,6 +179,7 @@ define Trusted-Firmware-A/mt7981-ram-ddr3
   BUILD_SUBTARGET:=filogic
   PLAT:=mt7981
   DDR_TYPE:=ddr3
+  DDR3_FREQ_1866:=1
   RAM_BOOT_UART_DL:=1
   HIDDEN:=
   DEFAULT:=TARGET_mediatek_filogic
@@ -589,6 +591,7 @@ TFA_MAKE_FLAGS += \
 	$(if $(NAND_TYPE),NAND_TYPE=$(NAND_TYPE)) \
 	HAVE_DRAM_OBJ_FILE=yes \
 	$(if $(DDR3_FLYBY),DDR3_FLYBY=1) \
+	$(if $(DDR3_FREQ_1866),DDR3_FREQ_1866=1) \
 	$(if $(DRAM_USE_COMB),DRAM_USE_COMB=1) \
 	$(if $(RAM_BOOT_UART_DL),RAM_BOOT_UART_DL=1) \
 	$(if $(USE_UBI),UBI=1 $(if $(findstring mt7622,$(PLAT)),OVERRIDE_UBI_START_ADDR=0x80000)) \

--- a/package/boot/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-envtools/files/mediatek_filogic
@@ -36,6 +36,7 @@ case "$board" in
 abt,asr3000|\
 cmcc,a10-ubootmod|\
 cudy,tr3000-v1-ubootmod|\
+cudy,wbr3000uax-v1-ubootmod|\
 h3c,magic-nx30-pro|\
 jcg,q30-pro|\
 konka,komi-a31|\

--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -273,9 +273,9 @@ define U-Boot/mt7981_cudy_tr3000-v1
   BUILD_DEVICES:=cudy_tr3000-v1-ubootmod
   UBOOT_CONFIG:=mt7981_cudy_tr3000-v1
   UBOOT_IMAGE:=u-boot.fip
-  BL2_BOOTDEV:=cudy-tr3000-v1
+  BL2_BOOTDEV:=cudy-ddr3
   BL2_SOC:=mt7981
-  DEPENDS:=+trusted-firmware-a-mt7981-cudy-tr3000-v1
+  DEPENDS:=+trusted-firmware-a-mt7981-cudy-ddr3
 endef
 
 define U-Boot/mt7981_glinet_gl-x3000

--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -278,6 +278,17 @@ define U-Boot/mt7981_cudy_tr3000-v1
   DEPENDS:=+trusted-firmware-a-mt7981-cudy-ddr3
 endef
 
+define U-Boot/mt7981_cudy_wbr3000uax-v1
+  NAME:=Cudy WBR3000UAX v1
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=cudy_wbr3000uax-v1-ubootmod
+  UBOOT_CONFIG:=mt7981_cudy_wbr3000uax-v1
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=cudy-ddr3
+  BL2_SOC:=mt7981
+  DEPENDS:=+trusted-firmware-a-mt7981-cudy-ddr3
+endef
+
 define U-Boot/mt7981_glinet_gl-x3000
   NAME:=GL.iNet GL-X3000
   BUILD_SUBTARGET:=filogic
@@ -883,6 +894,7 @@ UBOOT_TARGETS := \
 	mt7981_cmcc_rax3000m-emmc \
 	mt7981_cmcc_rax3000m-nand \
 	mt7981_cudy_tr3000-v1 \
+	mt7981_cudy_wbr3000uax-v1 \
 	mt7981_gatonetworks_gdsp \
 	mt7981_glinet_gl-x3000 \
 	mt7981_glinet_gl-xe3000 \

--- a/package/boot/uboot-mediatek/patches/449-add-cudy_wbr3000uax-v1.patch
+++ b/package/boot/uboot-mediatek/patches/449-add-cudy_wbr3000uax-v1.patch
@@ -1,0 +1,354 @@
+--- /dev/null
++++ b/configs/mt7981_cudy_wbr3000uax-v1_defconfig
+@@ -0,0 +1,107 @@
++CONFIG_ARM=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981-cudy-wbr3000uax-v1"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7981=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_DEFAULT_FDT_FILE="mediatek/mt7981-cudy-wbr3000uax-v1.dtb"
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_CPU=y
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_LINK_LOCAL=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_USE_DEFAULT_ENV_FILE=y
++CONFIG_DEFAULT_ENV_FILE="defenvs/cudy_wbr3000uax-v1_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_RAM=y
++CONFIG_DM_SERIAL=y
++CONFIG_SERIAL_RX_BUFFER=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/arch/arm/dts/mt7981-cudy-wbr3000uax-v1.dts
+@@ -0,0 +1,184 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++
++/dts-v1/;
++#include "mt7981.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/linux-event-codes.h>
++
++/ {
++	#address-cells = <1>;
++	#size-cells = <1>;
++	model = "Cudy WBR3000UAX v1";
++	compatible = "mediatek,mt7981", "mediatek,mt7981-rfb";
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x20000000>;
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		button-reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
++		};
++
++		button-wps {
++			label = "wps";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++
++		led_status: led_power {
++			label = "blue:power";
++			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
++		};
++
++		led_wan_blue {
++			label = "blue:wan";
++			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
++		};
++
++		led_wan_red {
++			label = "red:wan";
++			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
++		};
++
++		led_lan {
++			label = "blue:lan";
++			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
++		};
++
++		led_wps_blue {
++			label = "blue:wps";
++			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
++		};
++
++		led_wps_red {
++			label = "red:wps";
++			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
++		};
++
++		led_wifi2g {
++			label = "blue:wifi2g";
++			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
++		};
++
++		led_wifi5g {
++			label = "blue:wifi5g";
++			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&eth {
++	status = "okay";
++	mediatek,gmac-id = <0>;
++	phy-mode = "2500base-x";
++	mediatek,switch = "mt7531";
++	reset-gpios = <&gpio 39 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++	};
++};
++
++&pinctrl {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
++		};
++
++		conf-pd {
++			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
++			drive-strength = <MTK_DRIVE_8mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "bl2";
++				reg = <0x0 0x100000>;
++			};
++
++			partition@100000 {
++				label = "u-boot-env";
++				reg = <0x100000 0x80000>;
++			};
++
++			partition@180000 {
++				label = "factory";
++				reg = <0x180000 0x200000>;
++			};
++
++			partition@380000 {
++				label = "bdinfo";
++				reg = <0x380000 0x40000>;
++			};
++
++			partition@3c0000 {
++				label = "fip";
++				reg = <0x3c0000 0x200000>;
++			};
++
++			partition@5c0000 {
++				label = "ubi";
++				reg = <0x5c0000 0x7a40000>;
++				compatible = "linux,ubi";
++			};
++		};
++	};
++};
++
++&uart0 {
++	mediatek,force-highspeed;
++	status = "okay";
++};
++
++&watchdog {
++	status = "disabled";
++};
+--- /dev/null
++++ b/defenvs/cudy_wbr3000uax-v1_env
+@@ -0,0 +1,54 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootcmd=if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
++bootconf=config-1
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-cudy_wbr3000uax-v1-ubootmod-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-cudy_wbr3000uax-v1-ubootmod-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-cudy_wbr3000uax-v1-ubootmod-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-cudy_wbr3000uax-v1-ubootmod-squashfs-sysupgrade.itb
++bootled_pwr=blue:power
++bootled_rec=red:wan
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_production ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_recovery ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_6=[31mLoad BL31+U-Boot FIP via TFTP then write to NAND.[0m=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=[31mLoad BL2 preloader via TFTP then write to NAND.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_first=if button reset ; then led $bootled_rec on ; run boot_tftp_recovery ; setenv flag_recover 1 ; run boot_default ; fi ; bootmenu
++boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
++boot_production=led $bootled_pwr on ; run ubi_read_production && bootm $loadaddr#$bootconf ; led $bootled_pwr off
++boot_recovery=led $bootled_rec on ; run ubi_read_recovery && bootm $loadaddr#$bootconf ; led $bootled_rec off
++boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
++boot_tftp_forever=led $bootled_rec on ; while true ; do run boot_tftp_recovery ; sleep 1 ; done
++boot_tftp_production=tftpboot $loadaddr $bootfile_upg && env exists replacevol && iminfo $loadaddr && run ubi_write_production ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run ubi_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run mtd_write_fip && run reset_factory
++boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run mtd_write_bl2
++reset_factory=ubi part ubi ; mw $loadaddr 0x0 0x800 ; ubi write $loadaddr ubootenv 0x800 ; ubi write $loadaddr ubootenv2 0x800
++mtd_write_fip=mtd erase fip && mtd write fip $loadaddr
++mtd_write_bl2=mtd erase bl2 && mtd write bl2 $loadaddr
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x100000 dynamic || run ubi_format ; ubi check ubootenv2 || ubi create ubootenv2 0x100000 dynamic || run ubi_format
++ubi_format=ubi detach ; mtd erase ubi && ubi part ubi ; reset
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run _switch_to_menu ; run _init_env ; run boot_first
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"

--- a/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1-ubootmod.dts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7981b-cudy-wbr3000uax-v1.dtsi"
+
+/ {
+	model = "Cudy WBR3000UAX v1 (OpenWrt U-Boot layout)";
+	compatible = "cudy,wbr3000uax-v1-ubootmod", "mediatek,mt7981";
+
+	chosen {
+		bootargs = "root=/dev/fit0 rootwait";
+		rootdisk = <&ubi_rootdisk>;
+	};
+};
+
+&ubi {
+	reg = <0x5c0000 0x7a40000>;
+
+	volumes {
+		ubi_rootdisk: ubi-volume-fit {
+			volname = "fit";
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7981b-cudy-wbr3000uax-v1.dtsi"
+
+/ {
+	model = "Cudy WBR3000UAX v1";
+	compatible = "cudy,wbr3000uax-v1", "mediatek,mt7981";
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dts
@@ -7,3 +7,9 @@
 	model = "Cudy WBR3000UAX v1";
 	compatible = "cudy,wbr3000uax-v1", "mediatek,mt7981";
 };
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dtsi
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include "mt7981b-cudy-wr3000-nand.dtsi"
+
+/ {
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_status;
+		led-failsafe = &led_warning;
+		led-running = &led_status;
+		led-upgrade = &led_warning;
+		serial0 = &uart0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: led_power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_internet {
+			function = LED_FUNCTION_WAN_ONLINE;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_warning: led_fault {
+			function = LED_FUNCTION_FAULT;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wps {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_wifi5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	usb_vbus: regulator-usb {
+		compatible = "regulator-fixed";
+		regulator-name = "usb-vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&pio 35 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "wan";
+
+			nvmem-cell-names = "mac-address";
+			nvmem-cells = <&macaddr_bdinfo_de00 1>;
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan1";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan3";
+		};
+
+		port@4 {
+			reg = <4>;
+			label = "lan4";
+		};
+
+		port@6 {
+			reg = <6>;
+			label = "cpu";
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
@@ -148,7 +148,7 @@
 				read-only;
 			};
 
-			partition@5c0000 {
+			ubi: partition@5c0000 {
 				label = "ubi";
 				reg = <0x5c0000 0x4000000>;
 				compatible = "linux,ubi";

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
@@ -87,9 +87,6 @@
 
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
-		mediatek,nmbm;
-		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000e-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000e-v1.dts
@@ -118,3 +118,9 @@
 		};
 	};
 };
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
@@ -155,3 +155,8 @@
 	};
 };
 
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000p-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000p-v1.dts
@@ -151,3 +151,9 @@
 &usb_phy {
 	status = "okay";
 };
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000s-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000s-v1.dts
@@ -101,3 +101,9 @@
 		};
 	};
 };
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -55,6 +55,13 @@ cudy,wr3000p-v1)
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan" "link tx rx"
 	ucidef_set_led_netdev "internet" "internet" "white:wan-online" "wan" "link"
 	;;
+cudy,wbr3000uax-v1)
+	ucidef_set_led_default "internet_off" "internet_off" "red:fault" "1"
+	ucidef_set_led_netdev "internet" "internet" "blue:wan-online" "wan" "link"
+	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "tx rx"
+	ucidef_set_led_default "lan_off" "lan_off" "red:wps" "1"
+	ucidef_set_led_netdev "lan" "lan" "blue:lan" "br-lan" "link tx rx"
+	;;
 glinet,gl-x3000|\
 glinet,gl-xe3000)
 	ucidef_set_led_default "power" "POWER" "green:power" "1"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -55,7 +55,8 @@ cudy,wr3000p-v1)
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan" "link tx rx"
 	ucidef_set_led_netdev "internet" "internet" "white:wan-online" "wan" "link"
 	;;
-cudy,wbr3000uax-v1)
+cudy,wbr3000uax-v1|\
+cudy,wbr3000uax-v1-ubootmod)
 	ucidef_set_led_default "internet_off" "internet_off" "red:fault" "1"
 	ucidef_set_led_netdev "internet" "internet" "blue:wan-online" "wan" "link"
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -83,6 +83,7 @@ case "$board" in
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
 	cudy,wbr3000uax-v1|\
+	cudy,wbr3000uax-v1-ubootmod|\
 	cudy,wr3000e-v1|\
 	cudy,wr3000s-v1|\
 	cudy,wr3000h-v1|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -82,6 +82,7 @@ case "$board" in
 	cudy,tr3000-256mb-v1|\
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
+	cudy,wbr3000uax-v1|\
 	cudy,wr3000e-v1|\
 	cudy,wr3000s-v1|\
 	cudy,wr3000h-v1|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -74,6 +74,7 @@ platform_do_upgrade() {
 	cmcc,a10-ubootmod|\
 	cmcc,rax3000m|\
 	cudy,tr3000-v1-ubootmod|\
+	cudy,wbr3000uax-v1-ubootmod|\
 	gatonetworks,gdsp|\
 	h3c,magic-nx30-pro|\
 	jcg,q30-pro|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -895,6 +895,23 @@ define Device/cudy_wr3000p-v1
 endef
 TARGET_DEVICES += cudy_wr3000p-v1
 
+define Device/cudy_wbr3000uax-v1
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := WBR3000UAX
+  DEVICE_VARIANT := v1
+  DEVICE_DTS := mt7981b-cudy-wbr3000uax-v1
+  DEVICE_DTS_DIR := ../dts
+  SUPPORTED_DEVICES += R120
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_IN_UBI := 1
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+endef
+TARGET_DEVICES += cudy_wbr3000uax-v1
+
 define Device/dlink_aquila-pro-ai-m30-a1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := AQUILA PRO AI M30

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -803,7 +803,7 @@ define Device/cudy_tr3000-v1-ubootmod
   IMAGE/sysupgrade.itb := append-kernel | \
 	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 cudy-tr3000-v1
+  ARTIFACT/preloader.bin := mt7981-bl2 cudy-ddr3
   ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot cudy_tr3000-v1
 endef
 TARGET_DEVICES += cudy_tr3000-v1-ubootmod

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -912,6 +912,31 @@ define Device/cudy_wbr3000uax-v1
 endef
 TARGET_DEVICES += cudy_wbr3000uax-v1
 
+define Device/cudy_wbr3000uax-v1-ubootmod
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := WBR3000UAX
+  DEVICE_VARIANT := v1 (OpenWrt U-Boot layout)
+  DEVICE_DTS := mt7981b-cudy-wbr3000uax-v1-ubootmod
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+  ARTIFACT/preloader.bin := mt7981-bl2 cudy-ddr3
+  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot cudy_wbr3000uax-v1
+endef
+TARGET_DEVICES += cudy_wbr3000uax-v1-ubootmod
+
 define Device/dlink_aquila-pro-ai-m30-a1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := AQUILA PRO AI M30


### PR DESCRIPTION
This PR adds support for the Cudy WBR3000UAX v1 device with factory layout + OpenWrt (U-Boot layout).

The changes are split into 6 commits:

1. Add a common Cudy DDR3 ATF target (former Cudy TR3000 target).
2. Add support for the factory flash layout.
3. Add support for the ubootmod flash layout.
4. Fix wrong nmbm configuration on ubootmod builds of nand Cudy routers.
5. Reduce mt7981-ram-ddr3 frequency to 1866 MHz (dependency for 6, adds DDR3_FREQ_1866 plumbing).
6. Reduce Cudy DDR3 ATF target ram speed to 1866 MT/s.

This structure allows reuse of the ATF target for other similar Cudy devices.

Signed-off-by: Fil Dunsky <filipp.dunsky@gmail.com>

(cherry picked from commits https://github.com/openwrt/openwrt/commit/f4c9ab659191b19af21a861defb6f9408c9aac44 | https://github.com/openwrt/openwrt/commit/d7d6faf26f39b59d22c38d09321e0d345fbec950 | https://github.com/openwrt/openwrt/commit/15df98f3b54d9ce0d3a7c7b238e1c7b4814a15d6 | https://github.com/openwrt/openwrt/commit/ed4015375355570984a77de151d6bc2baf58a6ed | https://github.com/openwrt/openwrt/commit/b8c427f4867d5f843743d6835821307f29d256ab | https://github.com/openwrt/openwrt/commit/05f37579ad11e9304a9e204e1292fc746a04eb03)
