### PR TITLE
realtek: rtl838x: fix lan9 on Netgear GS110TUP

### DIFF
--- a/target/linux/realtek/dts/rtl8380_netgear_gs110tup-v1.dts
+++ b/target/linux/realtek/dts/rtl8380_netgear_gs110tup-v1.dts
@@ -47,24 +47,19 @@
 
 &mdio_bus0 {
 	EXTERNAL_PHY(16)
-	EXTERNAL_PHY(24)
 };
 
 &switch0 {
 	ports {
-		SWITCH_PORT(16, 9, qsgmii)
+		SWITCH_PORT_SDS(16, 9, 2, qsgmii)
 
-		/* TODO: fixed link SFP is not right */
-		port24: port@24 {
+		port@24 {
 			reg = <24>;
-			label = SWITCH_PORT_LABEL(10);
+			label = "lan10";
 			pcs-handle = <&serdes4>;
-			phy-handle = <&phy24>;
 			phy-mode = "1000base-x";
-			fixed-link {
-				speed = <1000>;
-				full-duplex;
-			};
+			managed = "in-band-status";
+			/* i2c and gpios not yet identified */
 		};
 	};
 };


### PR DESCRIPTION
The GS110TUP's lan9 port is connected via a QSGMII PHY to SERDES 2, and therefore should use the SWITCH_PORT_SDS macro instead of SWITCH_PORT. This was missed in e956adfe because the GS110TUP layout is somewhat confusing and not well documented.

Also add some comments to the GS110TUP DTS to clarify the port layout.

Discussion here: https://github.com/openwrt/openwrt/issues/21324 - I've tested this on my GS110TUP and it
restores lan9's functionality.