### PR TITLE
realtek: dsa: rtl931x: configure phy ability source

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -614,6 +614,10 @@ static int rtl93xx_setup(struct dsa_switch *ds)
 	}
 	priv->r->traffic_set(priv->cpu_port, BIT_ULL(priv->cpu_port));
 
+	/* Configure how MAC gets PHY ability for each port */
+	if (priv->family_id == RTL9310_FAMILY_ID)
+		rtldsa_931x_config_phy_ability_source(priv);
+
 	if (priv->family_id == RTL9300_FAMILY_ID)
 		rtl930x_print_matrix();
 	else if (priv->family_id == RTL9310_FAMILY_ID)

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -182,6 +182,7 @@ void rtl930x_print_matrix(void);
 /* RTL931x-specific */
 irqreturn_t rtl931x_switch_irq(int irq, void *dev_id);
 void rtl931x_print_matrix(void);
+void rtldsa_931x_config_phy_ability_source(struct rtl838x_switch_priv *priv);
 
 int rtl83xx_lag_add(struct dsa_switch *ds, int group, int port, struct netdev_lag_upper_info *info);
 int rtl83xx_lag_del(struct dsa_switch *ds, int group, int port);


### PR DESCRIPTION
The MAC can get PHY abilities, link status, etc. via different ways. In RTL931x, the corresponding register needs to be setup properly. By default, all ports use out-of-band MDIO polling to retrieve that information. Thus, PHY-backed ports usually work with the default setting.

For SFP ports, there is no MDIO polling available. Instead, the SerDes ability bus needs to be used to retrieve the link information.

So far, the bootloader (e.g. U-boot) had to properly initialize that setting. Instead of relying on that, do that properly during MAC setup.

---

I'm not proud of the style of this. The DSA driver is a mess and needs cleanup with proper separation of the variant-specific parts. But I don't dare to do that right now.
