### PR TITLE
treewide: add default variant to packages for better apk support

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -51,6 +51,7 @@ endef
 define Package/dnsmasq
 $(call Package/dnsmasq/Default)
   VARIANT:=nodhcpv6
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/dnsmasq-dhcpv6

--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -248,6 +248,7 @@ $(call Package/hostapd/Default,$(1))
   TITLE+= (WPA-PSK, 11r and 11w)
   VARIANT:=basic-mbedtls
   DEPENDS+=+PACKAGE_hostapd-basic-mbedtls:libmbedtls
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/hostapd-basic-mbedtls/description

--- a/package/network/utils/ethtool/Makefile
+++ b/package/network/utils/ethtool/Makefile
@@ -33,6 +33,7 @@ define Package/ethtool
   URL:=http://www.kernel.org/pub/software/network/ethtool/
   VARIANT:=tiny
   CONFLICTS:=ethtool-full
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/ethtool-full

--- a/package/system/procd/Makefile
+++ b/package/system/procd/Makefile
@@ -50,6 +50,7 @@ define Package/procd
   $(call Package/procd/Default)
   VARIANT:=default
   CONFLICTS:=procd-selinux
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/procd-selinux

--- a/package/system/ucert/Makefile
+++ b/package/system/ucert/Makefile
@@ -31,23 +31,25 @@ HOST_BUILD_DEPENDS:=libubox/host libjson-c/host usign/host
 HOST_BUILD_PREFIX:=$(STAGING_DIR_HOST)
 PKG_BUILD_DEPENDS:=ucert/host
 
-define Package/ucert-full
-  SECTION:=base
-  CATEGORY:=Base system
-  DEPENDS:=+usign +libubox +libjson-c +libblobmsg-json
-  TITLE:=OpenWrt certificate generation and verification utility
-  PROVIDES:=ucert
-  VARIANT:=full
-endef
-
-define Package/ucert
+define Package/ucert/Default
   SECTION:=base
   CATEGORY:=Base system
   DEPENDS:=+usign +libubox
+endef
+
+define Package/ucert
+$(call Package/ucert/Default)
   TITLE:=OpenWrt certificate verification utility
-  PROVIDES:=ucert
-  CONFLICTS:=ucert-full
   VARIANT:=tiny
+  DEFAULT_VARIANT:=1
+endef
+
+define Package/ucert-full
+$(call Package/ucert/Default)
+  TITLE:=OpenWrt certificate generation and verification utility
+  DEPENDS+=+libjson-c +libblobmsg-json
+  VARIANT:=full
+  PROVIDES:=ucert
 endef
 
 ifeq ($(BUILD_VARIANT),full)

--- a/package/utils/busybox/Makefile
+++ b/package/utils/busybox/Makefile
@@ -56,6 +56,7 @@ define Package/busybox
   $(call Package/busybox/Default)
   CONFLICTS:=busybox-selinux
   VARIANT:=default
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/busybox-selinux

--- a/package/utils/f2fs-tools/Makefile
+++ b/package/utils/f2fs-tools/Makefile
@@ -48,6 +48,7 @@ define Package/mkf2fs
   $(Package/f2fs-tools/Default)
   TITLE:=Utility for creating a Flash-Friendly File System (F2FS)
   CONFLICTS:=mkf2fs-selinux
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/mkf2fs-selinux
@@ -87,6 +88,7 @@ define Package/libf2fs
   ABI_VERSION:=6
   CONFLICTS:=libf2fs-selinux
   VARIANT:=default
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/libf2fs-selinux


### PR DESCRIPTION
Some packages with variants did not specify the default among the alternatives, so were left without any apk 'provider_priority' for that package.  This caused the apk solver to select the wrong variant, silently changing the requested package list.

Notable among these were busybox, procd and the hostapd/wpad suite. This behavior presented in the imagebuilders when creating the image as follows, silently replacing packages even when explicitly requested:

    $ make image PACKAGES=busybox
    ...
    ( 14/148) Installing busybox-selinux (1.37.0-r6)
    ...

We add 'DEFAULT_VARIANT:=1' to the packages that were missing one, providing apk with sufficient information to choose the correct package.

See link below for further examples and discussion.

Link: https://github.com/openwrt/openwrt/pull/21288#issuecomment-3704101422

