### PR TITLE
package: ethtool: specify just one default variant

### DIFF
--- a/package/network/utils/ethtool/Makefile
+++ b/package/network/utils/ethtool/Makefile
@@ -43,6 +43,7 @@ define Package/ethtool-full
   PROVIDES:=ethtool
   DEPENDS:=+libmnl
   CONFLICTS:=
+  DEFAULT_VARIANT:=
 endef
 
 define Package/ethtool/description


### PR DESCRIPTION
Inadvertently defining 'DEFAULT_VARIANT' on both ethool and ethtool-full variants resulted in

    $ make defconfig
    tmp/.config-package.in:121615:error: recursive dependency detected!
    tmp/.config-package.in:121615:  symbol PACKAGE_ethtool-full is selected by PACKAGE_ethtool
    tmp/.config-package.in:121605:  symbol PACKAGE_ethtool depends on PACKAGE_ethtool-full

Fix this by simply undefining 'DEFAULT_VARIANT' on the ethtool-full variant, which is ugly, but expedient.

Fixes: https://github.com/openwrt/openwrt/commit/f4fdb996