### PR TITLE
realtek: pcs: extend SerDes hardware mode handling

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -110,6 +110,7 @@ enum rtpcs_sds_mode {
 	RTPCS_SDS_MODE_OFF = 0,
 
 	/* fiber modes */
+	RTPCS_SDS_MODE_100BASEX,
 	RTPCS_SDS_MODE_1000BASEX,
 	RTPCS_SDS_MODE_2500BASEX,
 	RTPCS_SDS_MODE_10GBASER,
@@ -286,6 +287,9 @@ static int rtpcs_sds_determine_hw_mode(struct rtpcs_serdes *sds,
 	case PHY_INTERFACE_MODE_NA:
 		*hw_mode = RTPCS_SDS_MODE_OFF;
 		break;
+	case PHY_INTERFACE_MODE_100BASEX:
+		*hw_mode = RTPCS_SDS_MODE_100BASEX;
+		break;
 	case PHY_INTERFACE_MODE_1000BASEX:
 		*hw_mode = RTPCS_SDS_MODE_1000BASEX;
 		break;
@@ -304,6 +308,9 @@ static int rtpcs_sds_determine_hw_mode(struct rtpcs_serdes *sds,
 	case PHY_INTERFACE_MODE_USXGMII:
 		/* TODO: set this depending on number of links on SerDes */
 		*hw_mode = RTPCS_SDS_MODE_USXGMII_10GSXGMII;
+		break;
+	case PHY_INTERFACE_MODE_10G_QXGMII:
+		*hw_mode = RTPCS_SDS_MODE_USXGMII_10GQXGMII;
 		break;
 	default:
 		return -ENOTSUPP;

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -285,6 +285,8 @@ static int rtpcs_sds_determine_hw_mode(struct rtpcs_serdes *sds,
                                        phy_interface_t if_mode,
                                        enum rtpcs_sds_mode *hw_mode)
 {
+	u8 n_links = sds->num_of_links;
+
 	switch (if_mode) {
 	case PHY_INTERFACE_MODE_NA:
 		*hw_mode = RTPCS_SDS_MODE_OFF;
@@ -308,8 +310,15 @@ static int rtpcs_sds_determine_hw_mode(struct rtpcs_serdes *sds,
 		*hw_mode = RTPCS_SDS_MODE_QSGMII;
 		break;
 	case PHY_INTERFACE_MODE_USXGMII:
-		/* TODO: set this depending on number of links on SerDes */
-		*hw_mode = RTPCS_SDS_MODE_USXGMII_10GSXGMII;
+		if (n_links == 1)
+			*hw_mode = RTPCS_SDS_MODE_USXGMII_10GSXGMII;
+		else if (n_links == 2)
+			*hw_mode = RTPCS_SDS_MODE_USXGMII_10GDXGMII;
+		else if (n_links <= 4)
+			*hw_mode = RTPCS_SDS_MODE_USXGMII_10GQXGMII;
+		else if (n_links <= 8)
+			*hw_mode = RTPCS_SDS_MODE_XSGMII;
+
 		break;
 	case PHY_INTERFACE_MODE_10G_QXGMII:
 		*hw_mode = RTPCS_SDS_MODE_USXGMII_10GQXGMII;

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -287,6 +287,12 @@ static int rtpcs_sds_determine_hw_mode(struct rtpcs_serdes *sds,
 {
 	u8 n_links = sds->num_of_links;
 
+	/* turn off SerDes when there are no links */
+	if (!n_links) {
+		*hw_mode = RTPCS_SDS_MODE_OFF;
+		return 0;
+	}
+
 	switch (if_mode) {
 	case PHY_INTERFACE_MODE_NA:
 		*hw_mode = RTPCS_SDS_MODE_OFF;


### PR DESCRIPTION
This series extends the SerDes hardware mode handling capabilities of the PCS driver. To be precise, it adds keeping track of the number of links attached to a SerDes which is crucial for supporting modes like XSGMII under the umbrella of "USXGMII".

A new field for each SerDes is added and increment when a link is registered. The generic mode mapper (which maps from kernel's interface modes to the SerDes hardware modes) is extended to differentiate USXGMII for different numbers of links. Finally, disabling USXGMII setup for RTL931x is softened ... single-port 10G USXGMII seems to work fine and thus, we can configure it. Other modes (10G-QXGMII + XSGMII) stay disabled.

While at adding the missing 10G-QXGMII case in the generic mode mapper, also add missing 100Base-X mode in this mapper and the enum. Thus, 100Base-X can potentially supported by all variants then.

This **shouldn't** break the existing RTL931x devices which rely on skipping the USXGMII setup for now.