### PR TITLE
wifi-scripts: wdev.uc: fix mesh mode frequency handling

### DIFF
--- a/package/network/config/wifi-scripts/files/usr/share/hostap/wdev.uc
+++ b/package/network/config/wifi-scripts/files/usr/share/hostap/wdev.uc
@@ -44,7 +44,12 @@ function iface_start(wdev)
 				push(cmd, key, wdev[key]);
 		system(cmd);
 	} else if (wdev.mode == "mesh") {
-		let cmd = [ "iw", "dev", ifname, "mesh", "join", wdev.ssid, "freq", wdev.freq, htmode ];
+		let cmd = [ "iw", "dev", ifname, "mesh", "join", wdev.ssid ];
+		if (wdev.freq) {
+			push(cmd, "freq", wdev.freq);
+			if (htmode && htmode != "NOHT")
+				push(cmd, htmode);
+		}
 		for (let key in [ "basic-rates", "mcast-rate", "beacon-interval" ])
 			if (wdev[key])
 				push(cmd, key, wdev[key]);


### PR DESCRIPTION
Mesh mode interface creation fails when the freq parameter is empty or
undefined. Unlike adhoc mode which checks if freq exists before using it,
mesh mode blindly constructs the iw command with freq parameter, resulting
in invalid syntax like:

```
iw dev mesh0 mesh join ssid freq  NOHT
```

This causes the mesh interface to be created without joining the mesh
network, leaving it in a DOWN state with no channel assigned.

**Fix:**
1. Add freq validation check similar to adhoc mode
2. Make freq and htmode optional in the mesh join command

**Tested on:**
- Xiaomi AX3000T (MediaTek MT7981)
- OpenWrt One (MediaTek MT7981)
- Both routers tested in parallel as mesh peers
- OpenWrt 6.6.119, 802.11s mesh on 5GHz (Channel 36, HE80)

Discovered while testing custom L3 mesh routing protocol with mesh_fwding=0.

Signed-off-by: Valent Turkovic <valent@meshpointone.com>