### PR TITLE
mediatek: filogic: remove erroneous pipe action from BE7200 recipe

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2499,7 +2499,7 @@ define Device/routerich_be7200
   IMAGE/sysupgrade.itb := append-kernel | \
 	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
 	pad-rootfs | append-metadata
-  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-mt7992-firmware | \
+  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-mt7992-firmware \
 	 kmod-regulator-userspace-consumer kmod-usb3
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7987-bl2 spim-nand0


### PR DESCRIPTION
Remove the errorneous pipe action from the BE7200 device package list.

It causes visible errors into config (below) and breaks the buildbot build for filogic:

```
 perus@ub2510:/OpenWrt/aarch64$ make defconfig
 ...
 tmp/.config-target.in:55023:warning: ignoring unsupported character '|'
 tmp/.config-target.in:191877:warning: ignoring unsupported character '|'
 tmp/.config-target.in:191878:warning: ignoring unsupported character '|'
 tmp/.config-target.in:285812:warning: ignoring unsupported character '|'
 tmp/.config-target.in:285815:warning: ignoring unsupported character '|'
 tmp/.config-target.in:285819:warning: ignoring unsupported character '|'
 tmp/.config-target.in:285820:warning: ignoring unsupported character '|'
 #
 # configuration written to .config
 #

 File tmp/.config-target.in:

  55020         select DEFAULT_urandom-seed
  55021         select DEFAULT_urngd
  55022         select DEFAULT_wpad-basic-mbedtls
  55023         select DEFAULT_|
  55024         help
  55025           Build firmware images for Routerich BE7200

```