### PR TITLE
treewide: add explicit default variant part 2

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -544,6 +544,7 @@ define Package/eapol-test
   $(call Package/eapol-test/Default,$(1))
   TITLE+= (built-in full)
   VARIANT:=supplicant-full-internal
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/eapol-test-openssl

--- a/package/network/utils/ethtool/Makefile
+++ b/package/network/utils/ethtool/Makefile
@@ -26,24 +26,25 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/ethtool
+define Package/ethtool/Default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Display or change ethernet card settings
   URL:=https://www.kernel.org/pub/software/network/ethtool/
+endef
+
+define Package/ethtool
+$(call Package/ethtool/Default)
   VARIANT:=tiny
-  CONFLICTS:=ethtool-full
   DEFAULT_VARIANT:=1
 endef
 
 define Package/ethtool-full
-  $(Package/ethtool)
+$(call Package/ethtool/Default)
   TITLE += (full)
   VARIANT:=full
   PROVIDES:=ethtool
   DEPENDS:=+libmnl
-  CONFLICTS:=
-  DEFAULT_VARIANT:=
 endef
 
 define Package/ethtool/description

--- a/package/network/utils/iw/Makefile
+++ b/package/network/utils/iw/Makefile
@@ -23,17 +23,22 @@ PKG_BUILD_FLAGS:=gc-sections lto
 
 include $(INCLUDE_DIR)/package.mk
 
-define Package/iw
+define Package/iw/Default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=cfg80211 interface configuration utility
   URL:=https://wireless.kernel.org/en/latest/en/users/documentation/iw.html
   DEPENDS:= +libnl-tiny
+endef
+
+define Package/iw
+$(call Package/iw/Default)
   VARIANT:=tiny
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/iw-full
-  $(Package/iw)
+$(call Package/iw/Default)
   TITLE += (full version)
   VARIANT:=full
   PROVIDES:=iw


### PR DESCRIPTION
Add 'DEFAULT_VARIANT' to two packages, 'iw' and 'eapol-test', that were missed in the first pass.  Refactor 'iw' and 'ethtool' package definitions to be consistent with the pattern used in most other packages.

Fixes: https://github.com/openwrt/openwrt/commit/f4fdb996
Fixes: https://github.com/openwrt/openwrt/commit/7a78dc4a

@hauke @robimarko 