### PR TITLE
[25.12] mediatek: add support for Routerich BE7200 

### DIFF
--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -440,6 +440,14 @@ define Trusted-Firmware-A/mt7987-sdmmc-ddr4-4bg
   DDR4_4BG_MODE:=1
 endef
 
+define Trusted-Firmware-A/mt7987-spim-nand0
+  NAME:=MediaTek MT7987 (SPI-NAND via SPIM)
+  BOOT_DEVICE:=spim-nand
+  BUILD_SUBTARGET:=filogic
+  PLAT:=mt7987
+  SPIM_CTRL:=0
+endef
+
 define Trusted-Firmware-A/mt7987-spim-nand0-ubi-comb
   NAME:=MediaTek MT7987 (SPI-NAND via SPIM, UBI)
   BOOT_DEVICE:=spim-nand
@@ -685,6 +693,7 @@ TFA_TARGETS:= \
 	mt7987-nor-comb \
 	mt7987-sdmmc-comb \
 	mt7987-sdmmc-ddr4-4bg \
+	mt7987-spim-nand0 \
 	mt7987-spim-nand0-ubi-comb \
 	mt7987-spim-nand2-ubi-comb \
 	mt7987-ram-comb \

--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -881,6 +881,17 @@ define U-Boot/mt7987_bananapi_bpi-r4-lite-nor
   FIP_COMPRESS:=1
 endef
 
+define U-Boot/mt7987_routerich_be7200
+  NAME:=Routerich BE7200
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=routerich_be7200
+  UBOOT_CONFIG:=mt7987a_routerich_be7200
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand0
+  BL2_SOC:=mt7987
+  DEPENDS:=+trusted-firmware-a-mt7987-spim-nand0
+endef
+
 define U-Boot/mt7988_arcadyan_mozart
   NAME:=Arcadyan Mozart
   BUILD_SUBTARGET:=filogic
@@ -1152,6 +1163,7 @@ UBOOT_TARGETS := \
 	mt7987_rfb-emmc \
 	mt7987_rfb-sd \
 	mt7987_rfb-spim-nand \
+	mt7987_routerich_be7200 \
 	mt7988_arcadyan_mozart \
 	mt7988_asus_zenwifi-bt8 \
 	mt7988_bananapi_bpi-r4-emmc \

--- a/package/boot/uboot-mediatek/patches/467-add-routerich-be7200.patch
+++ b/package/boot/uboot-mediatek/patches/467-add-routerich-be7200.patch
@@ -1,0 +1,373 @@
+--- /dev/null
++++ b/configs/mt7987a_routerich_be7200_defconfig
+@@ -0,0 +1,133 @@
++CONFIG_ARM=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7987a-routerich_be7200"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7987=y
++CONFIG_CPU_ARMV8=y
++CONFIG_SYS_BOOTM_LEN=0x6000000
++CONFIG_SYS_LOAD_ADDR=0x48000000
++CONFIG_PRE_CON_BUF_ADDR=0x4007ef00
++CONFIG_DEBUG_UART_BASE=0x11000000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_DEFAULT_FDT_FILE="mt7987a-routerich_be7200"
++CONFIG_SYS_CBSIZE=512
++CONFIG_SYS_PBSIZE=1049
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7987> "
++# CONFIG_BOOTM_NETBSD is not set
++# CONFIG_BOOTM_PLAN9 is not set
++# CONFIG_BOOTM_RTEMS is not set
++# CONFIG_BOOTM_VXWORKS is not set
++# CONFIG_CMD_BOOTEFI_BOOTMGR is not set
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_CPU=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_PWM=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_I2C=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_PCI=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_LINK_LOCAL=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_FAT=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_FS_UUID=y
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++# CONFIG_CMD_XIMG is not set
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_REDUNDANT=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/routerich_be7200_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_NETMASK=y
++CONFIG_NETMASK="255.255.255.0"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_DM_I2C=y
++CONFIG_SYS_I2C_MTK=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_PHY_ETHERNET_ID=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PHY=y
++CONFIG_PHY_MTK_TPHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7987=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_DM_PWM=y
++CONFIG_PWM_MTK=y
++CONFIG_SCSI=y
++CONFIG_DM_SERIAL=y
++CONFIG_SERIAL_RX_BUFFER=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_MTK=y
++CONFIG_USB_STORAGE=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/defenvs/routerich_be7200_env
+@@ -0,0 +1,57 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x48000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootcmd=run check_buttons ; if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
++bootconf=config-1
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-routerich_be7200-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-routerich_be7200-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-routerich_be7200-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-routerich_be7200-squashfs-sysupgrade.itb
++bootled_status=blue:status
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_production ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_recovery ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_6=[31mLoad BL31+U-Boot FIP via TFTP then write to NAND.[0m=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=[31mLoad BL2 preloader via TFTP then write to NAND.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_first=if button reset ; then led $bootled_status on ; run boot_default ; fi ; bootmenu
++boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
++boot_production=led $bootled_status on ; run ubi_read_production && bootm $loadaddr#$bootconf ; led bootled_status off
++boot_recovery=led $bootled_status on ; run ubi_read_recovery && bootm $loadaddr#$bootconf ; led bootled_status off
++boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
++boot_tftp_forever=led $bootled_status on ; while true ; do run boot_tftp ; sleep 1 ; done
++boot_tftp_production=tftpboot $loadaddr $bootfile_upg && env exists replacevol && iminfo $loadaddr && run ubi_write_production ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run ubi_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run mtd_write_fip && run reset_factory
++boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run mtd_write_bl2
++check_buttons=if button reset ; then run boot_tftp ; fi
++ethaddr_factory=mtd read Factory 0x40080000 0x0 0x20000 && env readmem -b ethaddr 0x40080004 0x6 ; setenv ethaddr_factory
++part_default=production
++part_recovery=recovery
++reset_factory=ubi part ubi ; mw $loadaddr 0x0 0x800 ; ubi write $loadaddr ubootenv 0x800 ; ubi write $loadaddr ubootenv2 0x800
++mtd_write_fip=mtd erase FIP && mtd write FIP $loadaddr
++mtd_write_bl2=mtd erase BL2 && mtd write BL2 $loadaddr
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x100000 dynamic || run ubi_format ; ubi check ubootenv2 || ubi create ubootenv2 0x100000 dynamic || run ubi_format
++ubi_format=ubi detach ; mtd erase ubi && ubi part ubi ; reset
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run ethaddr_factory ; run _switch_to_menu ; run _init_env ; run boot_first
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"
+--- /dev/null
++++ b/arch/arm/dts/mt7987a-routerich_be7200.dts
+@@ -0,0 +1,77 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) 2025
++ * Author: Mikhail Zhilkin <csharper2005@gmail.com>
++ */
++
++/dts-v1/;
++#include "mt7987a.dtsi"
++#include <dt-bindings/input/input.h>
++
++/ {
++	model = "Routerich BE7200";
++	compatible = "routerich,be7200",
++		     "mediatek,mt7987";
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		button-0 {
++			label = "mesh";
++			linux,code = <KEY_WPS_BUTTON>;
++			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
++			debounce-interval = <10>;
++		};
++
++		button-1 {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
++			debounce-interval = <10>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-0 {
++			label = "blue:status";
++			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
++		};
++
++		led-1 {
++			label = "blue:wlan5g";
++			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
++		};
++
++		led-2 {
++			label = "blue:mesh";
++			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
++		};
++
++		led-3 {
++			label = "red:wan";
++			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
++		};
++
++		led-4 {
++			label = "blue:wan";
++			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
++		};
++
++		led-5 {
++			label = "blue:lan3";
++			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
++		};
++
++		led-6 {
++			label = "blue:lan2";
++			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
++		};
++
++		led-7 {
++			label = "blue:lan1";
++			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -1138,6 +1138,7 @@ dtb-$(CONFIG_ARCH_MEDIATEK) += \
+ 	mt7986b-emmc-rfb.dtb \
+ 	mt7987a-emmc-rfb.dtb \
+ 	mt7987a-rfb.dtb \
++	mt7987a-routerich_be7200.dtb \
+ 	mt7987a-sd-rfb.dtb \
+ 	mt7988-rfb.dtb \
+ 	mt7988-sd-rfb.dtb \
+--- /dev/null
++++ b/arch/arm/dts/mt7987a-routerich_be7200-u-boot.dtsi
+@@ -0,0 +1,84 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) 2025
++ * Author: Mikhail Zhilkin <csharper2005@gmail.com>
++ */
++
++#include "mt7987a-u-boot.dtsi"
++#include "mt7987-netsys-u-boot.dtsi"
++
++/ {
++	model = "Routerich BE7200";
++	compatible = "routerich,be7200",
++		     "mediatek,mt7987";
++};
++
++&eth0 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&mdio0_pins>;
++	phy-mode = "2500base-x";
++	mediatek,switch = "auto";
++	reset-gpios = <&pio 42 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++		pause;
++	};
++};
++
++&spi0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi0_flash_pins>;
++	#address-cells = <1>;
++	#size-cells = <0>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++		spi-rx-bus-width = <4>;
++		spi-tx-bus-width = <4>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "BL2";
++				reg = <0x0 0x100000>;
++			};
++
++			partition@100000 {
++				label = "u-boot-env (unused)";
++				reg = <0x100000 0x80000>;
++			};
++
++			partition@180000 {
++				label = "Factory";
++				reg = <0x180000 0x400000>;
++			};
++
++			partition@580000 {
++				label = "FIP";
++				reg = <0x580000 0x200000>;
++			};
++
++			partition@780000 {
++				label = "ubi";
++				reg = <0x780000 0x1f880000>;
++				compatible = "linux,ubi";
++			};
++		};
++	};
++};

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -42,6 +42,7 @@ nokia,ea0326gmp|\
 openwrt,one|\
 qihoo,360t7|\
 routerich,ax3000-ubootmod|\
+routerich,be7200|\
 snr,snr-cpe-ax2|\
 tplink,tl-xdr4288|\
 tplink,tl-xdr6086|\

--- a/target/linux/mediatek/dts/mt7987a-routerich-be7200.dts
+++ b/target/linux/mediatek/dts/mt7987a-routerich-be7200.dts
@@ -1,0 +1,480 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Author: Mikhail Zhilkin <csharper2005@gmail.com>
+ */
+
+/dts-v1/;
+#include "mt7987a.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Routerich BE7200";
+	compatible = "routerich,be7200",
+		     "mediatek,mt7987a",
+		     "mediatek,mt7987";
+
+	aliases {
+		label-mac-device = &gmac1;
+
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+
+		serial0 = &uart0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n1 \
+			    earlycon=uart8250,mmio32,0x11000000 \
+			    pci=pcie_bus_perf";
+		rootdisk = <&ubi_fit>;
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "mesh";
+			/* Reassigned to RF_KILL */
+			linux,code = <KEY_RFKILL>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+
+		button-1 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: led-0 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = "mesh";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 8 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-4 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led-6 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led-7 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	memory@40000000 {
+		reg = <0x0 0x40000000 0x0 0x40000000>;
+		device_type = "memory";
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-max-microvolt = <3300000>;
+		regulator-min-microvolt = <3300000>;
+		regulator-name = "fixed-3.3V";
+	};
+
+	reg_usb_5v: regulator-usb-5v {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&pio 14 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+		regulator-max-microvolt = <5000000>;
+		regulator-min-microvolt = <5000000>;
+		regulator-name = "usb-5v";
+	};
+
+	usb-power {
+		compatible = "regulator-output";
+		vout-supply = <&reg_usb_5v>;
+	};
+};
+
+&gmac0 {
+	phy-mode = "2500base-x";
+	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_4 (-1)>;
+
+	fixed-link {
+		speed = <2500>;
+		full-duplex;
+		pause;
+	};
+};
+
+&gmac1 {
+	openwrt,netdev-name = "wan";
+	phy-mode = "internal";
+	phy-handle = <&phy15>;
+	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_factory_4 (-2)>;
+};
+
+&mdio {
+	an8855: mfd@1 {
+		compatible = "airoha,an8855-mfd";
+		reg = <1>;
+	};
+
+	phy15: phy@15 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <15>;
+
+		pinctrl-0 = <&i2p5gbe_led0_pins>;
+		pinctrl-names = "i2p5gbe-led";
+	};
+};
+
+&an8855 {
+	efuse {
+		compatible = "airoha,an8855-efuse";
+		#nvmem-cell-cells = <0>;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			shift_sel_port0_tx_a: shift-sel-port0-tx-a@c {
+				reg = <0xc 0x4>;
+			};
+
+			shift_sel_port0_tx_b: shift-sel-port0-tx-b@10 {
+				reg = <0x10 0x4>;
+			};
+
+			shift_sel_port0_tx_c: shift-sel-port0-tx-c@14 {
+				reg = <0x14 0x4>;
+			};
+
+			shift_sel_port0_tx_d: shift-sel-port0-tx-d@18 {
+				reg = <0x18 0x4>;
+			};
+
+			shift_sel_port1_tx_a: shift-sel-port1-tx-a@1c {
+				reg = <0x1c 0x4>;
+			};
+
+			shift_sel_port1_tx_b: shift-sel-port1-tx-b@20 {
+				reg = <0x20 0x4>;
+			};
+
+			shift_sel_port1_tx_c: shift-sel-port1-tx-c@24 {
+				reg = <0x24 0x4>;
+			};
+
+			shift_sel_port1_tx_d: shift-sel-port1-tx-d@28 {
+				reg = <0x28 0x4>;
+			};
+
+			shift_sel_port2_tx_a: shift-sel-port2-tx-a@2c {
+				reg = <0x2c 0x4>;
+			};
+
+			shift_sel_port2_tx_b: shift-sel-port2-tx-b@30 {
+				reg = <0x30 0x4>;
+			};
+
+			shift_sel_port2_tx_c: shift-sel-port2-tx-c@34 {
+				reg = <0x34 0x4>;
+			};
+
+			shift_sel_port2_tx_d: shift-sel-port2-tx-d@38 {
+				reg = <0x38 0x4>;
+			};
+		};
+	};
+
+	ethernet-switch {
+		compatible = "airoha,an8855-switch";
+		reset-gpios = <&pio 42 GPIO_ACTIVE_HIGH>;
+		airoha,ext-surge;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan1";
+				phy-mode = "internal";
+				phy-handle = <&internal_phy1>;
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan2";
+				phy-mode = "internal";
+				phy-handle = <&internal_phy2>;
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan3";
+				phy-mode = "internal";
+				phy-handle = <&internal_phy3>;
+			};
+
+			port@5 {
+				reg = <5>;
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+
+	mdio {
+		compatible = "airoha,an8855-mdio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		internal_phy1: phy@1 {
+			reg = <1>;
+
+			nvmem-cells = <&shift_sel_port0_tx_a>,
+					<&shift_sel_port0_tx_b>,
+					<&shift_sel_port0_tx_c>,
+					<&shift_sel_port0_tx_d>;
+			nvmem-cell-names = "tx_a", "tx_b", "tx_c", "tx_d";
+		};
+
+		internal_phy2: phy@2 {
+			reg = <2>;
+
+			nvmem-cells = <&shift_sel_port1_tx_a>,
+					<&shift_sel_port1_tx_b>,
+					<&shift_sel_port1_tx_c>,
+					<&shift_sel_port1_tx_d>;
+			nvmem-cell-names = "tx_a", "tx_b", "tx_c", "tx_d";
+		};
+
+		internal_phy3: phy@3 {
+			reg = <3>;
+
+			nvmem-cells = <&shift_sel_port2_tx_a>,
+					<&shift_sel_port2_tx_b>,
+					<&shift_sel_port2_tx_c>,
+					<&shift_sel_port2_tx_d>;
+			nvmem-cell-names = "tx_a", "tx_b", "tx_c", "tx_d";
+		};
+	};
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	reset-gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		mt7992@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			ieee80211-freq-limit = <2400000 2500000>,
+					       <5170000 5835000>;
+
+			band@0 {
+				reg = <0>;
+				nvmem-cells = <&macaddr_factory_4 (0)>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@1 {
+				reg = <1>;
+				nvmem-cells = <&macaddr_factory_4 (1)>;
+				nvmem-cell-names = "mac-address";
+			};
+		};
+	};
+};
+
+&pcie1 {
+	status = "disabled";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env (stock bootloader)";
+				reg = <0x100000 0x80000>;
+				read-only;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x400000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1e00>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@580000 {
+				label = "FIP";
+				reg = <0x580000 0x200000>;
+				read-only;
+			};
+
+			partition@780000 {
+				label = "ubi";
+				reg = <0x780000 0x1f880000>;
+				compatible = "linux,ubi";
+
+				volumes {
+					ubi_env: ubi-volume-ubootenv {
+						volname = "ubootenv";
+					};
+
+					ubi_env2: ubi-volume-ubootenv2 {
+						volname = "ubootenv2";
+					};
+
+					ubi_fit: ubi-volume-fit {
+						volname = "fit";
+					};
+				};
+			};
+		};
+	};
+};
+
+&ssusb {
+	status = "okay";
+
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_usb_5v>;
+};
+
+&tphyu3port0 {
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+
+	status = "okay";
+};
+
+&ubi_env {
+	nvmem-layout {
+		compatible = "u-boot,env-redundant-bool-layout";
+	};
+};
+
+&ubi_env2 {
+	nvmem-layout {
+		compatible = "u-boot,env-redundant-bool-layout";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -205,6 +205,14 @@ routerich,ax3000-v1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
 	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "eth1" "link"
 	;;
+routerich,be7200)
+	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link tx rx"
+	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-2" "lan2" "link tx rx"
+	ucidef_set_led_netdev "lan-3" "lan-3" "blue:lan-3" "lan3" "link tx rx"
+	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
+	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
+	ucidef_set_led_netdev "wlan5g" "wlan-5ghz" "blue:wlan-5ghz" "phy0.1-ap0" "link tx rx"
+	;;
 smartrg,sdg-8612)
 	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:amber:lan" "lan4" "link_10 link_100"
 	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-0" "lan4" "link_1000"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -56,6 +56,7 @@ mediatek_setup_interfaces()
 	qihoo,360t7|\
 	routerich,ax3000|\
 	routerich,ax3000-ubootmod|\
+	routerich,be7200|\
 	tenbay,wr3000k)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -109,6 +109,7 @@ platform_do_upgrade() {
 	netcore,n60-pro|\
 	qihoo,360t7|\
 	routerich,ax3000-ubootmod|\
+	routerich,be7200|\
 	snr,snr-cpe-ax2|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2462,6 +2462,34 @@ define Device/routerich_ax3000-v1
 endef
 TARGET_DEVICES += routerich_ax3000-v1
 
+define Device/routerich_be7200
+  DEVICE_VENDOR := Routerich
+  DEVICE_MODEL := BE7200
+  DEVICE_DTS := mt7987a-routerich-be7200
+  DEVICE_DTS_DIR := ../dts
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL_LOADADDR := 0x40000000
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
+	pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
+	pad-rootfs | append-metadata
+  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-mt7992-firmware | \
+	 kmod-regulator-userspace-consumer kmod-usb3
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+  ARTIFACT/preloader.bin := mt7987-bl2 spim-nand0
+  ARTIFACT/bl31-uboot.fip := mt7987-bl31-uboot routerich_be7200
+endef
+TARGET_DEVICES += routerich_be7200
+
 define Device/ruijie_rg-x60-pro
   DEVICE_VENDOR := Ruijie
   DEVICE_MODEL := RG-X60 Pro

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2482,7 +2482,7 @@ define Device/routerich_be7200
   IMAGE/sysupgrade.itb := append-kernel | \
 	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
 	pad-rootfs | append-metadata
-  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-mt7992-firmware | \
+  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-mt7992-firmware \
 	 kmod-regulator-userspace-consumer kmod-usb3
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7987-bl2 spim-nand0


### PR DESCRIPTION
This PR backports support for Routerich BE7200 router to the 25.12 branch.

```
Specification
-------------
- SoC       : MediaTek MT7987A Quad-core ARM Cortex-A53 2.0 GHz
- RAM       : 1024 MiB DDR4
- Flash     : SPI-NAND 512 MiB (Giga Device)
- WLAN      : MediaTek MT7992E, WiFi 7
  - 2.4 GHz : b/g/n/ax, MIMO 4x4
  - 5 GHz   : a/n/ac/ax, MIMO 4x4
- Ethernet  : 10/100/1000 Mbps x3 (LAN, Airoha AN8855AE)
              10/100/1000/2500 Mbps x1 (WAN, SoC internal phy)
- USB       : 3.0 x1
- Buttons   : Mesh, Reset
- LEDs      : 1x Status (blue), gpio-controlled
              1x WiFi (blue), gpio-controlled
              1x mesh (blue), gpio-controlled
              3x LAN activity (blue), gpio-controlled
              1x WAN activity (blue), gpio-controlled
              1x WAN no-link (red), gpio-controlled
- Power     : 12 VDC, 1.5 A
```

P.S. Erroneous pipe action in `filogic.mk` is removed.