### PR TITLE
mediatek: add support for Elecom WRC-X6000QS

### DIFF
--- a/target/linux/mediatek/dts/mt7986b-elecom-wrc-x6000qs.dts
+++ b/target/linux/mediatek/dts/mt7986b-elecom-wrc-x6000qs.dts
@@ -1,0 +1,472 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986b.dtsi"
+
+/ {
+	model = "ELECOM WRC-X6000QS";
+	compatible = "elecom,wrc-x6000qs", "mediatek,mt7986b";
+
+	aliases {
+		serial0 = &uart0;
+
+		label-mac-device = &gmac0;
+		led-boot = &led_power_g;
+		led-failsafe = &led_power_r;
+		led-running = &led_power_g;
+		led-upgrade = &led_power_g;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wps_r: led-0 {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_power_r: led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 22 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_g: led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_b: led-3 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_w: led-4 {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		led_2g_r: led-5 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_2g_g: led-6 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led_2g_w: led-7 {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_5g_r: led-8 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_5g_g: led-9 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led_5g_w: led-10 {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		switch-ap {
+			label = "ap";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		button-reset {
+			label = "reset";
+			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&pio 16 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+			linux,input-type = <EV_SW>;
+		};
+
+		switch-router {
+			label = "router";
+			gpios = <&pio 19 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable;
+		};
+	};
+
+	wf_2g_5g_pins: wf-2g-5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				"WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_factory_2a>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		status = "okay";
+		phy-mode = "2500base-x";
+		phy-handle = <&phy5>;
+
+		nvmem-cells = <&macaddr_factory_24>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <600>;
+		reset-post-delay-us = <20000>;
+
+		phy5: phy@5 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <5>;
+			max-speed = <2500>;
+
+			leds {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				led@0 {
+					reg = <0>;
+					color = <LED_COLOR_ID_WHITE>;
+					function = LED_FUNCTION_WAN;
+				};
+			};
+		};
+
+		switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "lan1";
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan2";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan3";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan4";
+				};
+
+				port@6 {
+					reg = <6>;
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+    pinctrl-names = "default";
+    pinctrl-0 = <&spi_flash_pins>;
+	num-cs = <2>;
+	cs-gpios = <0>, <0>;
+
+	flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+
+		spi-max-frequency = <20000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+		mediatek,bmt-remap-range =
+		<0x0000000 0x5a0000>, /*     BL2 - Fwheader  (5.625 MiB) */
+		<0x37a0000 0x3a0000>, /*  Config - Fwheader2 (3.625 MiB) */
+		<0x6d40000 0x840000>; /* Config2 - Backup    (8.25 MiB) */
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "Ubootenv";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: mac-address@4 {
+						reg = <0x4 0x6>;
+					};
+
+					macaddr_factory_a: mac-address@a {
+						reg = <0xa 0x6>;
+					};
+
+					macaddr_factory_24: mac-address@24 {
+						reg = <0x24 0x6>;
+					};
+
+					macaddr_factory_2a: mac-address@2a {
+						reg = <0x2a 0x6>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "Fwheader";
+				reg = <0x580000 0x20000>;
+				read-only;
+			};
+
+			partition@5a0000 {
+				compatible = "mstc,boot";
+				label = "firmware1";
+				reg = <0x5a0000 0x3200000>;
+				mstc,bootnum = <1>;
+				mstc,persist = <&mtd_persist>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label-base = "ubi";
+					reg = <0x0 0x3200000>;
+				};
+			};
+
+			partition@37a0000 {
+				label = "Config";
+				reg = <0x37a0000 0x380000>;
+				read-only;
+			};
+
+			partition@3b20000 {
+				label = "Fwheader_2";
+				reg = <0x3b20000 0x20000>;
+				read-only;
+			};
+
+			partition@3b40000 {
+				compatible = "mstc,boot";
+				label = "firmware2";
+				reg = <0x3b40000 0x3200000>;
+				mstc,bootnum = <2>;
+				mstc,persist = <&mtd_persist>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label-base = "ubi";
+					reg = <0x0 0x3200000>;
+				};
+			};
+
+			partition@6d40000 {
+				label = "Config_2";
+				reg = <0x6d40000 0x380000>;
+				read-only;
+			};
+
+			mtd_persist: partition@70c0000 {
+				label = "persist";
+				reg = <0x70c0000 0x100000>;
+			};
+
+			partition@71c0000 {
+				label = "Mrd";
+				reg = <0x71c0000 0x40000>;
+				read-only;
+			};
+
+			partition@7200000 {
+				label = "Backup";
+				reg = <0x7200000 0x380000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_a>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -87,6 +87,9 @@ cudy,wbr3000uax-v1-ubootmod)
 elecom,wrc-x3000gs3)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
 	;;
+elecom,wrc-x6000qs)
+	ucidef_set_led_netdev "wan" "wan" "mdio-bus:05:white:wan" "eth1" "link tx rx"
+	;;
 glinet,gl-x3000|\
 glinet,gl-xe3000)
 	ucidef_set_led_default "power" "POWER" "green:power" "1"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -60,6 +60,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;
 	asus,tuf-ax4200|\
+	elecom,wrc-x6000qs|\
 	iptime,ax3000sm|\
 	iptime,ax7800m-6e|\
 	jdcloud,re-cp-03|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -172,7 +172,8 @@ platform_do_upgrade() {
 		fw_setenv sw_tryactive 0
 		nand_do_upgrade "$1"
 		;;
-	elecom,wrc-x3000gs3)
+	elecom,wrc-x3000gs3|\
+	elecom,wrc-x6000qs)
 		local bootnum="$(mstc_rw_bootnum)"
 		case "$bootnum" in
 		1|2)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1343,6 +1343,25 @@ define Device/elecom_wrc-x3000gs3
 endef
 TARGET_DEVICES += elecom_wrc-x3000gs3
 
+define Device/elecom_wrc-x6000qs
+  DEVICE_VENDOR := ELECOM
+  DEVICE_MODEL := WRC-X6000QS
+  DEVICE_DTS := mt7986b-elecom-wrc-x6000qs
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  KERNEL_IN_UBI := 1
+  IMAGE_SIZE := 51200k
+  IMAGES := sysupgrade.bin factory.bin
+  IMAGE/factory.bin := sysupgrade-tar | mstc-header 5.04(XZQ.0)b90 COMD | \
+	elecom-product-header WRC-X6000QS
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+endef
+TARGET_DEVICES += elecom_wrc-x6000qs
+
 define Device/gatonetworks_gdsp
   DEVICE_VENDOR := GatoNetworks
   DEVICE_MODEL := gdsp


### PR DESCRIPTION
mediatek: add support for Elecom WRC-X6000QS

Elecom WRC-X6000QS is a 4804Mbps 4xMIMO 2.4/5 GHz 11ax (Wi-Fi 6) router
with 2.5Gbps WAN, based on MT7986b

Specification:

- SoC             : MediaTek MT7986B
- RAM             : DDR3 512 MiB
- Flash           : Winbond 128MiB SPI NAND
- WLAN            : 2.4/5 GHz 4T4R (MediaTek MT7986)
- Ethernet        : 5x 10/100/1000 Mbps
  - wan           : Maxlinear Ethernet GPY211C
  - lan           : MediaTek MT7531
- LEDs/Keys (GPIO): 11x/4x
- UART            : through-hole on PCB (J1)
  - assignment    : 3.3V, TX, RX, NC, GND from tri-angle marking
  - settings      : 115200n8
- Power           : 12 VDC, 2 A

Flash layout:
dev:  offset     size        name
mtd0: 0x00000000 0x00100000 "BL2"
mtd1: 0x00100000 0x00080000 "Ubootenv"
mtd2: 0x00180000 0x00200000 "Factory"
mtd3: 0x00380000 0x00200000 "FIP"
mtd4: 0x00580000 0x00020000 "Fwheader"
mtd5: 0x005a0000 0x03200000 "ubi"
mtd6: 0x037a0000 0x00380000 "Config"
mtd7: 0x03b20000 0x00020000 "Fwheader_2"
mtd8: 0x03b40000 0x03200000 "ubi_2"
mtd9: 0x06d40000 0x00380000 "Config_2"
mtd10: 0x070c0000 0x00100000 "persist"
mtd11: 0x071c0000 0x00040000 "Mrd"
mtd12: 0x07200000 0x00380000 "Backup"

UBI layout:
name:       size:
kernel      0x00364000  dynamic
rootfs      0x00FFC000  dynamic
rootfs_data 0x01A47000  dynamic

Flash instruction using factory.bin image:

1. Boot WRC-X6000QS in router mode normally
2. Access to the WebUI ("http://192.168.2.1/") on the device         
   -> その他設定 (Other settings)
   -> フォームウェア更新 (Update firmware)
   -> ローカルファイル指定 (Specify local file)
3. Select the OpenWrt factory.bin image and click apply ("適用") button
4. Wait ~120 seconds to complete flashing

Switching to the stock firmware:

1. Load the elecom.sh script
   . /lib/upgrade/elecom.sh

2. Check the current index of firmware partition
   mstc_rw_bootnum

3. Set the bootnum to opposite value between 1 and 2
   mstc_rw_bootnum value

   example:
   - step2 returned "1": mstc_rw_bootnum 2
   - step2 returned "2": mstc_rw_bootnum 1

4. Reboot, to stock FW

5. Flash the stock FW to fuly revert back to original.

Note 1: With the stock firmware, it will flash to another partition and
  toggle boot to that partition when any firmware is flashed.
  For example when booting on ubi, the new firmware will be flashed
  to ubi_2 and the router will boot from ubi_2 afterwards.
  The 5th byte of the Persist partition is the boot value (0x01 or 0x02).

  During my tests, it never switched to another boot partition if the
  firmware failed boot. So if openwrt doesn't boot,
  UART might be required to recover.

Note 2: bootmenu_delay=0 is set from factory so uboot menu is hidden.

Signed-off-by: Yuhei Amemiya <minihui@me.com>
