### PR TITLE
packages: ethtool: restore CONFLICTS

### DIFF
--- a/package/network/utils/ethtool/Makefile
+++ b/package/network/utils/ethtool/Makefile
@@ -36,6 +36,7 @@ endef
 define Package/ethtool
 $(call Package/ethtool/Default)
   VARIANT:=tiny
+  CONFLICTS:=ethtool-full
   DEFAULT_VARIANT:=1
 endef
 


### PR DESCRIPTION
Inadvertent removal of 'CONFLICTS' breaks kconfig selection. Restore it.

Fixes: https://github.com/efahl/openwrt/commit/ded99c2984


@robimarko 