### PR TITLE
kernel: add kmods for vsockets over virtio

### DIFF
--- a/package/kernel/linux/modules/virt.mk
+++ b/package/kernel/linux/modules/virt.mk
@@ -139,3 +139,59 @@ define KernelPackage/vhost-net
 endef
 
 $(eval $(call KernelPackage,vhost-net))
+
+
+define KernelPackage/vsock
+  SUBMENU:=Virtualization
+  TITLE:=Virtual Socket Protocol
+  KCONFIG:= \
+	CONFIG_VSOCKETS \
+	CONFIG_VSOCKETS_LOOPBACK=n \
+	CONFIG_HYPERV_VSOCKETS=n
+  FILES:=$(LINUX_DIR)/net/vmw_vsock/vsock.ko
+  AUTOLOAD:=$(call AutoProbe,vsock)
+endef
+
+define KernelPackage/vsock/description
+  Kernel support support for the Virtual Socket Protocol.
+  Often used when running in a VM to communicate with the hypervisor.
+  Additionally needs a hypervisor-specific transport driver.
+endef
+
+$(eval $(call KernelPackage,vsock))
+
+
+define KernelPackage/vsock-virtio-common
+  SUBMENU:=Virtualization
+  TITLE:=Module used by other drivers to access Virtio Virtual Sockets
+  DEPENDS:=+kmod-vsock
+  KCONFIG:=CONFIG_VIRTIO_VSOCKETS_COMMON
+  FILES:=$(LINUX_DIR)/net/vmw_vsock/vmw_vsock_virtio_transport_common.ko
+  AUTOLOAD:=$(call AutoProbe,vmw_vsock_virtio_transport_common)
+  HIDDEN:=1
+endef
+
+$(eval $(call KernelPackage,vsock-virtio-common))
+
+
+define KernelPackage/vsock-virtio
+  SUBMENU:=Virtualization
+  TITLE:=Virtio transport driver for Virtual Sockets
+  DEPENDS:= @VIRTIO_SUPPORT +kmod-vsock +kmod-vsock-virtio-common
+  KCONFIG:=CONFIG_VIRTIO_VSOCKETS
+  FILES:=$(LINUX_DIR)/net/vmw_vsock/vmw_vsock_virtio_transport.ko
+  AUTOLOAD:=$(call AutoProbe,vmw_vsock_virtio_transport)
+endef
+
+define KernelPackage/vsock-virtio/description
+  Kernel support for Virtual Sockets over virtio.
+  Enable this transport if you plan to run OpenWRT in a virtual machine and the
+  hypervisor supports Virtual Sockets over virtio (Incus for example).
+
+  Usually needed by "guest agents" to function, as it provides a communication
+  channel between the guest os and the hypervisor.
+
+  The module will be called vmw_vsock_virtio_transport.
+endef
+
+$(eval $(call KernelPackage,vsock-virtio))


### PR DESCRIPTION
This PR adds kmod packages for the following kernel modules:
- `vsock`
- `vmw_vsock_virtio_transport`
- `vmw_vsock_virtio_transport_common`

These are needed for some guest agents to communicate with the hypervisor when running OpenWRT as a guest in a VM.
Right now, this mainly concerns [Incus](https://linuxcontainers.org/incus/introduction/), but these modules are in no way specific to Incus, rather to virtio, which is also used by other hypervisors.

Note that this has been attempted before in [this pull request](https://github.com/openwrt/openwrt/pull/19654), but that seems to have run into a dead end because of the proposal to have the modules built-in. While these pr's ultimately have the same objective, there is no code-reuse.

See also [this thread](https://forum.openwrt.org/t/vsock-ko-kernel-module-needed-aarch64-x86-64-targets/) on the forum.

Looking forward to hear from you!