### PR TITLE
realtek: phy: save register for RTL8214FC fibre check

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
@@ -436,14 +436,16 @@ static bool __rtl8214fc_media_is_fibre(struct phy_device *phydev)
 	struct phy_device *basephy = get_base_phy(phydev);
 	static int regs[] = {16, 19, 20, 21};
 	int reg = regs[phydev->mdio.addr & 3];
-	int oldpage, val;
+	int oldpage, oldxpage, val;
 
-	/* The fiber status is a package "global" in the first phy. */
 	oldpage = __phy_read(basephy, RTL8XXX_PAGE_SELECT);
-	__phy_write(basephy, RTL821XINT_MEDIA_PAGE_SELECT, RTL821X_MEDIA_PAGE_INTERNAL);
+	oldxpage = __phy_read(basephy, RTL821XEXT_MEDIA_PAGE_SELECT);
+
+	__phy_write(basephy, RTL821XEXT_MEDIA_PAGE_SELECT, RTL821X_MEDIA_PAGE_INTERNAL);
 	__phy_write(basephy, RTL8XXX_PAGE_SELECT, RTL821X_PAGE_PORT);
 	val = __phy_read(basephy, reg);
-	__phy_write(basephy, RTL821XINT_MEDIA_PAGE_SELECT, RTL821X_MEDIA_PAGE_AUTO);
+
+	__phy_write(basephy, RTL821XEXT_MEDIA_PAGE_SELECT, oldxpage);
 	__phy_write(basephy, RTL8XXX_PAGE_SELECT, oldpage);
 
 	return !(val & BMCR_PDOWN);


### PR DESCRIPTION
Reading the fibre status of a RTL8214FC needs access to the page register (31) and the extended page register (30). At the end of the function the extended page register is overwritten with zero. This is independent from the previous content. This makes use of mdio tools for the first port of the RTL821FC hard, as register 30 is overwritten every second during the periodic status checks. Restore the content of the register after the fibre check.
