### PR TITLE
package: too many package files are removed when cleaning or compilin…

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -358,9 +358,9 @@ $(_endef)
     $(PKG_INFO_DIR)/$(1).provides $$(PACK_$(1)): $(STAMP_BUILT) $(INCLUDE_DIR)/package-pack.mk
 	rm -rf $$(IDIR_$(1))
 ifeq ($$(CONFIG_USE_APK),)
-	$$(call remove_ipkg_files,$(1),$$(call opkg_package_files,$(call gen_package_wildcard,$(1))))
+	$$(call remove_ipkg_files,$(1),$$(call opkg_package_files,$(call gen_package_wildcard,$(1)$(if $(VERSION),_$(VERSION)))))
 else
-	$$(call remove_ipkg_files,$(1),$$(call apk_package_files,$(call gen_package_wildcard,$(1))))
+	$$(call remove_ipkg_files,$(1),$$(call apk_package_files,$(call gen_package_wildcard,$(1)$(if $(VERSION),-$(VERSION)))))
 endif
 	mkdir -p $(PACKAGE_DIR) $$(IDIR_$(1)) $(PKG_INFO_DIR)
 	$(call Package/$(1)/install,$$(IDIR_$(1)))
@@ -528,9 +528,9 @@ endif
 
     $(1)-clean:
 ifeq ($(CONFIG_USE_APK),)
-	$$(call remove_ipkg_files,$(1),$$(call opkg_package_files,$(call gen_package_wildcard,$(1))))
+	$$(call remove_ipkg_files,$(1),$$(call opkg_package_files,$(call gen_package_wildcard,$(1)$(if $(VERSION),_$(VERSION)))))
 else
-	$$(call remove_ipkg_files,$(1),$$(call apk_package_files,$(call gen_package_wildcard,$(1))))
+	$$(call remove_ipkg_files,$(1),$$(call apk_package_files,$(call gen_package_wildcard,$(1)$(if $(VERSION),-$(VERSION)))))
 endif
 
 


### PR DESCRIPTION
 Suppose that we have two packages with similar naming:
  
  - libhello
  - libhello_world
  
  When libhello gets cleaned or compiled, the corresponding apk (or ipk) file in
  bin/packages/<arch>/ is removed.
  
  In include/package-pack.mk, a wildcard is generated for this package
  matching libhello_*.apk. This means that the libhello_world apk is also
  removed.
  
  This is unwanted behaviour, since non-related packages can be deleted
  this way, leading to build errors in the package/install step like
  missing dependency issues.
  
  To solve this, append version information to the wildcard, if available.
  E.g.
  
  libhello_v1.0.0
  libhello_world_v1.0.0
  
  This prevents the wrong file from being removed.
  
  Signed-off-by: Matthias Franck <matthias.franck@softathome.com>