### PR TITLE
[24.10] mediatek: add kmod-usb3 to default package set of WR3000P

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -891,7 +891,7 @@ define Device/cudy_wr3000p-v1
   IMAGE_SIZE := 65536k
   KERNEL_IN_UBI := 1
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
 endef
 TARGET_DEVICES += cudy_wr3000p-v1
 


### PR DESCRIPTION
Backport for 24.10.
Include XHCI USB drivers on the Cudy WR3000P v1 router, the drivers are required to be able to use the USB port for USD devices.

Fixes: https://github.com/openwrt/openwrt/issues/21231