### PR TITLE
build: restore opkg-related provides logic

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -324,7 +324,12 @@ endif
       Package/$(1)/DEPENDS := $$(call mergelist,$$(Package/$(1)/DEPENDS))
     endif
 
-    Package/$(1)/PROVIDES := $$(call FormatProvides,$(1),$(VERSION),$(PROVIDES),$(ALTERNATIVES))
+    ifeq ($(CONFIG_USE_APK),)
+      Package/$(1)/PROVIDES := $$(patsubst @%,%,$(PROVIDES))
+      Package/$(1)/PROVIDES := $$(filter-out $(1)$$(ABIV_$(1)),$$(Package/$(1)/PROVIDES)$$(if $$(ABIV_$(1)), $(1) $$(foreach provide,$$(Package/$(1)/PROVIDES),$$(provide)$$(ABIV_$(1)))))
+    else
+      Package/$(1)/PROVIDES := $$(call FormatProvides,$(1),$(VERSION),$(PROVIDES),$(ALTERNATIVES))
+    endif
 
 $(_define) Package/$(1)/CONTROL
 Package: $(1)$$(ABIV_$(1))


### PR DESCRIPTION
Re-add opkg provides logic to `CONTROL` when `USE_APK` is not set and remove virtual provider prefix.

The opkg side is completely untested as I don't have the resources to rebuild everything just for opkg. I expect the users reporting opkg issues with the main branch to provide feedback.

Fixes: cefbf11 ("build: refactor provides logic")
Fixes: https://github.com/openwrt/openwrt/issues/21372
Fixes: https://github.com/openwrt/openwrt/issues/21382
Fixes: https://github.com/openwrt/openwrt/issues/21402

cc: @robimarko 