### PR TITLE
[24.10]: u-boot: backport swig bugfix

### DIFF
--- a/package/boot/uboot-d1/patches/310-fix-swig-4-3-0-SWIG_AppendOutput-keeps-signature.patch
+++ b/package/boot/uboot-d1/patches/310-fix-swig-4-3-0-SWIG_AppendOutput-keeps-signature.patch
@@ -1,0 +1,57 @@
+From a63456b9191fae2fe49f4b121e025792022e3950 Mon Sep 17 00:00:00 2001
+From: Markus Volk <f_l_k@t-online.de>
+Date: Wed, 30 Oct 2024 06:07:16 +0100
+Subject: [PATCH] scripts/dtc/pylibfdt/libfdt.i_shipped: Use SWIG_AppendOutput
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Swig has changed language specific AppendOutput functions. The helper
+macro SWIG_AppendOutput remains unchanged. Use that instead
+of SWIG_Python_AppendOutput, which would require an extra parameter
+since swig 4.3.0.
+
+/home/flk/poky/build-test/tmp/work/qemux86_64-poky-linux/u-boot/2024.10/git/arch/x86/cpu/u-boot-64.lds
+| scripts/dtc/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_next_node’:
+| scripts/dtc/pylibfdt/libfdt_wrap.c:5581:17: error: too few arguments to function ‘SWIG_Python_AppendOutput’
+|  5581 |     resultobj = SWIG_Python_AppendOutput(resultobj, val);
+|       |                 ^~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Markus Volk <f_l_k@t-online.de>
+Reported-by: Rudi Heitbaum <rudi@heitbaum.com>
+Link: https://github.com/dgibson/dtc/pull/154
+---
+ scripts/dtc/pylibfdt/libfdt.i_shipped | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/dtc/pylibfdt/libfdt.i_shipped b/scripts/dtc/pylibfdt/libfdt.i_shipped
+index 56cc5d48f4f9..e4659489a96a 100644
+--- a/scripts/dtc/pylibfdt/libfdt.i_shipped
++++ b/scripts/dtc/pylibfdt/libfdt.i_shipped
+@@ -1037,7 +1037,7 @@ typedef uint32_t fdt32_t;
+ 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
+ 		buff = PyByteArray_FromStringAndSize(
+ 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
+-		resultobj = SWIG_Python_AppendOutput(resultobj, buff);
++		resultobj = SWIG_AppendOutput(resultobj, buff);
+ 	}
+ }
+ 
+@@ -1076,7 +1076,7 @@ typedef uint32_t fdt32_t;
+ 
+ %typemap(argout) int *depth {
+         PyObject *val = Py_BuildValue("i", *arg$argnum);
+-        resultobj = SWIG_Python_AppendOutput(resultobj, val);
++        resultobj = SWIG_AppendOutput(resultobj, val);
+ }
+ 
+ %apply int *depth { int *depth };
+@@ -1092,7 +1092,7 @@ typedef uint32_t fdt32_t;
+            if (PyTuple_GET_SIZE(resultobj) == 0)
+               resultobj = val;
+            else
+-              resultobj = SWIG_Python_AppendOutput(resultobj, val);
++              resultobj = SWIG_AppendOutput(resultobj, val);
+         }
+ }
+ 

--- a/package/boot/uboot-mediatek/patches/002-scripts-dtc-pylibfdt-libfdt-i_shipped-Use-SWIG_AppendOutp.patch
+++ b/package/boot/uboot-mediatek/patches/002-scripts-dtc-pylibfdt-libfdt-i_shipped-Use-SWIG_AppendOutp.patch
@@ -1,0 +1,55 @@
+From a63456b9191fae2fe49f4b121e025792022e3950 Mon Sep 17 00:00:00 2001
+From: Markus Volk <f_l_k@t-online.de>
+Date: Wed, 30 Oct 2024 06:07:16 +0100
+Subject: [PATCH] scripts/dtc/pylibfdt/libfdt.i_shipped: Use SWIG_AppendOutput
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Swig has changed language specific AppendOutput functions. The helper
+macro SWIG_AppendOutput remains unchanged. Use that instead
+of SWIG_Python_AppendOutput, which would require an extra parameter
+since swig 4.3.0.
+
+/home/flk/poky/build-test/tmp/work/qemux86_64-poky-linux/u-boot/2024.10/git/arch/x86/cpu/u-boot-64.lds
+| scripts/dtc/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_next_node’:
+| scripts/dtc/pylibfdt/libfdt_wrap.c:5581:17: error: too few arguments to function ‘SWIG_Python_AppendOutput’
+|  5581 |     resultobj = SWIG_Python_AppendOutput(resultobj, val);
+|       |                 ^~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Markus Volk <f_l_k@t-online.de>
+Reported-by: Rudi Heitbaum <rudi@heitbaum.com>
+Link: https://github.com/dgibson/dtc/pull/154
+---
+ scripts/dtc/pylibfdt/libfdt.i_shipped | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/scripts/dtc/pylibfdt/libfdt.i_shipped
++++ b/scripts/dtc/pylibfdt/libfdt.i_shipped
+@@ -1037,7 +1037,7 @@ typedef uint32_t fdt32_t;
+ 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
+ 		buff = PyByteArray_FromStringAndSize(
+ 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
+-		resultobj = SWIG_Python_AppendOutput(resultobj, buff);
++		resultobj = SWIG_AppendOutput(resultobj, buff);
+ 	}
+ }
+ 
+@@ -1076,7 +1076,7 @@ typedef uint32_t fdt32_t;
+ 
+ %typemap(argout) int *depth {
+         PyObject *val = Py_BuildValue("i", *arg$argnum);
+-        resultobj = SWIG_Python_AppendOutput(resultobj, val);
++        resultobj = SWIG_AppendOutput(resultobj, val);
+ }
+ 
+ %apply int *depth { int *depth };
+@@ -1092,7 +1092,7 @@ typedef uint32_t fdt32_t;
+            if (PyTuple_GET_SIZE(resultobj) == 0)
+               resultobj = val;
+            else
+-              resultobj = SWIG_Python_AppendOutput(resultobj, val);
++              resultobj = SWIG_AppendOutput(resultobj, val);
+         }
+ }
+ 

--- a/package/boot/uboot-sifiveu/patches/002-scripts-dtc-pylibfdt-libfdt-i_shipped-Use-SWIG_AppendOutp.patch
+++ b/package/boot/uboot-sifiveu/patches/002-scripts-dtc-pylibfdt-libfdt-i_shipped-Use-SWIG_AppendOutp.patch
@@ -1,0 +1,55 @@
+From a63456b9191fae2fe49f4b121e025792022e3950 Mon Sep 17 00:00:00 2001
+From: Markus Volk <f_l_k@t-online.de>
+Date: Wed, 30 Oct 2024 06:07:16 +0100
+Subject: [PATCH] scripts/dtc/pylibfdt/libfdt.i_shipped: Use SWIG_AppendOutput
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Swig has changed language specific AppendOutput functions. The helper
+macro SWIG_AppendOutput remains unchanged. Use that instead
+of SWIG_Python_AppendOutput, which would require an extra parameter
+since swig 4.3.0.
+
+/home/flk/poky/build-test/tmp/work/qemux86_64-poky-linux/u-boot/2024.10/git/arch/x86/cpu/u-boot-64.lds
+| scripts/dtc/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_next_node’:
+| scripts/dtc/pylibfdt/libfdt_wrap.c:5581:17: error: too few arguments to function ‘SWIG_Python_AppendOutput’
+|  5581 |     resultobj = SWIG_Python_AppendOutput(resultobj, val);
+|       |                 ^~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Markus Volk <f_l_k@t-online.de>
+Reported-by: Rudi Heitbaum <rudi@heitbaum.com>
+Link: https://github.com/dgibson/dtc/pull/154
+---
+ scripts/dtc/pylibfdt/libfdt.i_shipped | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/scripts/dtc/pylibfdt/libfdt.i_shipped
++++ b/scripts/dtc/pylibfdt/libfdt.i_shipped
+@@ -1037,7 +1037,7 @@ typedef uint32_t fdt32_t;
+ 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
+ 		buff = PyByteArray_FromStringAndSize(
+ 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
+-		resultobj = SWIG_Python_AppendOutput(resultobj, buff);
++		resultobj = SWIG_AppendOutput(resultobj, buff);
+ 	}
+ }
+ 
+@@ -1076,7 +1076,7 @@ typedef uint32_t fdt32_t;
+ 
+ %typemap(argout) int *depth {
+         PyObject *val = Py_BuildValue("i", *arg$argnum);
+-        resultobj = SWIG_Python_AppendOutput(resultobj, val);
++        resultobj = SWIG_AppendOutput(resultobj, val);
+ }
+ 
+ %apply int *depth { int *depth };
+@@ -1092,7 +1092,7 @@ typedef uint32_t fdt32_t;
+            if (PyTuple_GET_SIZE(resultobj) == 0)
+               resultobj = val;
+            else
+-              resultobj = SWIG_Python_AppendOutput(resultobj, val);
++              resultobj = SWIG_AppendOutput(resultobj, val);
+         }
+ }
+ 


### PR DESCRIPTION
When building on current Debian stable (13), which has a newer swig version, the build process fails. This was previously described in #20620, and in this PR's commit messages.

Some of the commits exist on main (`sifiveu` https://github.com/openwrt/openwrt/commit/a9da3daa74e884080213395376be4ff2b74a7bc2 and `d1` https://github.com/openwrt/openwrt/commit/367b214b68c30334cf88c42a9def640fbd4f1a9f), but have not been backported to 24.10, which still has these issues.

I've also added the same patch for `uboot-mediatek`, which has the same error for target `ramips-mt7621` (`mt7621_zbtlink_zbt-wg3526-16m`). That commit is not on main, as `uboot-mediatek` was bumped early to u-boot 25.01 (https://github.com/openwrt/openwrt/commit/10b16d932869aed6e69d932e18df18d27f432ee9), before this patch could've been added.

An example of this patch being removed in a u-boot 25.01 bump is uboot-rockchip: https://github.com/openwrt/openwrt/commit/92814fec77fe24a68ab4a2acbf3ac245163c6090

<details>
<summary>error log for uboot-mediatek</summary>

```console
...
scripts/dtc/pylibfdt/libfdt_wrap.c: In function ‘_wrap_fdt_get_property_w’:
scripts/dtc/pylibfdt/libfdt_wrap.c:6767:19: error: too few arguments to function ‘SWIG_Python_AppendOutput’
 6767 |       resultobj = SWIG_Python_AppendOutput(resultobj, buff);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
scripts/dtc/pylibfdt/libfdt_wrap.c:1262:1: note: declared here
 1262 | SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~
error: command '/home/user/openwrt/staging_dir/host/bin/gcc' failed with exit code 1
make[6]: *** [scripts/dtc/pylibfdt/Makefile:33: rebuild] Error 1
make[5]: *** [scripts/Makefile.build:397: scripts/dtc/pylibfdt] Error 2
make[4]: *** [Makefile:2055: scripts_dtc] Error 2
make[4]: Leaving directory '/home/user/openwrt/build_dir/target-mipsel_24kc_musl/u-boot-mt7621_zbtlink_zbt-wg3526-16m/u-boot-2024.10'
make[3]: *** [Makefile:993: /home/user/openwrt/build_dir/target-mipsel_24kc_musl/u-boot-mt7621_zbtlink_zbt-wg3526-16m/u-boot-2024.10/.built] Error 2
make[3]: Leaving directory '/home/user/openwrt/package/boot/uboot-mediatek'
time: package/boot/uboot-mediatek/mt7621_zbtlink_zbt-wg3526-16m/compile#2.38#0.64#2.91
    ERROR: package/boot/uboot-mediatek failed to build (build variant: mt7621_zbtlink_zbt-wg3526-16m).
...
```

</details>