### PR TITLE
target: add BTREE_SUPPORT target capability

### DIFF
--- a/target/Config.in
+++ b/target/Config.in
@@ -26,6 +26,9 @@ config PCI_SUPPORT
 	select AUDIO_SUPPORT
 	bool
 
+config BTREE_SUPPORT
+	bool
+
 config PCIE_SUPPORT
 	bool
 


### PR DESCRIPTION
Add a BTREE_SUPPORT capability to describe targets whose kernels provide BTREE support, allowing packages to express a hard dependency without making kernel config assumptions.

This is needed to merge before https://github.com/openwrt/telephony/pull/930