### PR TITLE
ucode: enable ucode-mod-zlib

### DIFF
--- a/package/utils/ucode/Makefile
+++ b/package/utils/ucode/Makefile
@@ -53,6 +53,7 @@ CMAKE_HOST_OPTIONS += \
 	-DULOOP_SUPPORT=OFF \
 	-DDEBUG_SUPPORT=ON \
 	-DLOG_SUPPORT=OFF \
+	-DZLIB_SUPPORT=ON \
 	-DDIGEST_SUPPORT=OFF
 
 
@@ -187,6 +188,10 @@ $(eval $(call UcodeModule, \
 $(eval $(call UcodeModule, \
 	io, IO_SUPPORT, , \
 	The io module allows direct file descriptor read/write (including non-blocking).))
+
+$(eval $(call UcodeModule, \
+	zlib, ZLIB_SUPPORT, +zlib, \
+	The zlib module allows ucode scripts to de/compress gzip and zlib formats.))
 
 $(eval $(call BuildPackage,libucode))
 $(eval $(call BuildPackage,ucode))


### PR DESCRIPTION
The module exists in ucode and has been present for a while but has not been enabled. It provides the ucode zlib module for handling gzip and zlib compression in ucode scripts.

The package is ~ 5Kb. Installed ~18Kb.