### PR TITLE
mediatek: backport various pinctrl fixes

### DIFF
--- a/package/boot/uboot-mediatek/patches/001-pinctrl-mediatek-MT7981-fix-GPIO9-register-map.patch
+++ b/package/boot/uboot-mediatek/patches/001-pinctrl-mediatek-MT7981-fix-GPIO9-register-map.patch
@@ -1,0 +1,75 @@
+From a1d1fc8d8c8699d80e1b9ab3214752e5882d3740 Mon Sep 17 00:00:00 2001
+From: Shiji Yang <yangshiji66@outlook.com>
+Date: Sat, 3 Jan 2026 16:42:39 +0800
+Subject: [PATCH] pinctrl: mediatek: MT7981: fix GPIO9 register map
+
+Ported from the Mediatek SDK. The upstream Linux kernel also has the
+same register map as the SDK.
+
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ drivers/pinctrl/mediatek/pinctrl-mt7981.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7981.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7981.c
+@@ -103,8 +103,8 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(6, 6, 4, 0x20, 0x10, 3, 1),
+ 	PIN_FIELD_BASE(7, 7, 4, 0x20, 0x10, 0, 1),
+ 	PIN_FIELD_BASE(8, 8, 4, 0x20, 0x10, 4, 1),
+-	PIN_FIELD_BASE(9, 9, 4, 0x20, 0x10, 9, 1),
+ 
++	PIN_FIELD_BASE(9, 9, 5, 0x20, 0x10, 9, 1),
+ 	PIN_FIELD_BASE(10, 10, 5, 0x20, 0x10, 8, 1),
+ 	PIN_FIELD_BASE(11, 11, 5, 0x40, 0x10, 10, 1),
+ 	PIN_FIELD_BASE(12, 12, 5, 0x20, 0x10, 7, 1),
+@@ -172,8 +172,8 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(6, 6, 4, 0x80, 0x10, 3, 1),
+ 	PIN_FIELD_BASE(7, 7, 4, 0x80, 0x10, 0, 1),
+ 	PIN_FIELD_BASE(8, 8, 4, 0x80, 0x10, 4, 1),
+-	PIN_FIELD_BASE(9, 9, 4, 0x80, 0x10, 9, 1),
+ 
++	PIN_FIELD_BASE(9, 9, 5, 0x90, 0x10, 9, 1),
+ 	PIN_FIELD_BASE(10, 10, 5, 0x90, 0x10, 8, 1),
+ 	PIN_FIELD_BASE(11, 11, 5, 0x90, 0x10, 10, 1),
+ 	PIN_FIELD_BASE(12, 12, 5, 0x90, 0x10, 7, 1),
+@@ -285,8 +285,8 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(6, 6, 4, 0x00, 0x10, 9, 3),
+ 	PIN_FIELD_BASE(7, 7, 4, 0x00, 0x10, 0, 3),
+ 	PIN_FIELD_BASE(8, 8, 4, 0x00, 0x10, 12, 3),
+-	PIN_FIELD_BASE(9, 9, 4, 0x00, 0x10, 27, 3),
+ 
++	PIN_FIELD_BASE(9, 9, 5, 0x00, 0x10, 27, 3),
+ 	PIN_FIELD_BASE(10, 10, 5, 0x00, 0x10, 24, 3),
+ 	PIN_FIELD_BASE(11, 11, 5, 0x00, 0x10, 0, 3),
+ 	PIN_FIELD_BASE(12, 12, 5, 0x00, 0x10, 21, 3),
+@@ -354,8 +354,8 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(6, 6, 4, 0x30, 0x10, 3, 1),
+ 	PIN_FIELD_BASE(7, 7, 4, 0x30, 0x10, 0, 1),
+ 	PIN_FIELD_BASE(8, 8, 4, 0x30, 0x10, 4, 1),
+-	PIN_FIELD_BASE(9, 9, 4, 0x30, 0x10, 9, 1),
+ 
++	PIN_FIELD_BASE(9, 9, 5, 0x30, 0x10, 9, 1),
+ 	PIN_FIELD_BASE(10, 10, 5, 0x30, 0x10, 8, 1),
+ 	PIN_FIELD_BASE(11, 11, 5, 0x30, 0x10, 10, 1),
+ 	PIN_FIELD_BASE(12, 12, 5, 0x30, 0x10, 7, 1),
+@@ -404,8 +404,8 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(6, 6, 4, 0x40, 0x10, 3, 1),
+ 	PIN_FIELD_BASE(7, 7, 4, 0x40, 0x10, 0, 1),
+ 	PIN_FIELD_BASE(8, 8, 4, 0x40, 0x10, 4, 1),
+-	PIN_FIELD_BASE(9, 9, 4, 0x40, 0x10, 9, 1),
+ 
++	PIN_FIELD_BASE(9, 9, 5, 0x40, 0x10, 9, 1),
+ 	PIN_FIELD_BASE(10, 10, 5, 0x40, 0x10, 8, 1),
+ 	PIN_FIELD_BASE(11, 11, 5, 0x40, 0x10, 10, 1),
+ 	PIN_FIELD_BASE(12, 12, 5, 0x40, 0x10, 7, 1),
+@@ -454,8 +454,8 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(6, 6, 4, 0x50, 0x10, 3, 1),
+ 	PIN_FIELD_BASE(7, 7, 4, 0x50, 0x10, 0, 1),
+ 	PIN_FIELD_BASE(8, 8, 4, 0x50, 0x10, 4, 1),
+-	PIN_FIELD_BASE(9, 9, 4, 0x50, 0x10, 9, 1),
+ 
++	PIN_FIELD_BASE(9, 9, 5, 0x50, 0x10, 9, 1),
+ 	PIN_FIELD_BASE(10, 10, 5, 0x50, 0x10, 8, 1),
+ 	PIN_FIELD_BASE(11, 11, 5, 0x50, 0x10, 10, 1),
+ 	PIN_FIELD_BASE(12, 12, 5, 0x50, 0x10, 7, 1),

--- a/package/boot/uboot-mediatek/patches/002-pinctrl-mediatek-set-MT798x-rev-as-MTK_PINCTRL_V1.patch
+++ b/package/boot/uboot-mediatek/patches/002-pinctrl-mediatek-set-MT798x-rev-as-MTK_PINCTRL_V1.patch
@@ -1,0 +1,56 @@
+From b681f2be8cc81de83fdd4c56cdb35755ca0409eb Mon Sep 17 00:00:00 2001
+From: Shiji Yang <yangshiji66@outlook.com>
+Date: Sat, 31 Jan 2026 10:33:50 +0800
+Subject: [PATCH] pinctrl: mediatek: set MT798x rev as MTK_PINCTRL_V1
+
+The MT798x series SoCs have IES regiter definitions. They should
+belong to the pinctrl v1 revision.
+
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ drivers/pinctrl/mediatek/pinctrl-mt7981.c | 1 +
+ drivers/pinctrl/mediatek/pinctrl-mt7986.c | 1 +
+ drivers/pinctrl/mediatek/pinctrl-mt7987.c | 1 +
+ drivers/pinctrl/mediatek/pinctrl-mt7988.c | 1 +
+ 4 files changed, 4 insertions(+)
+
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7981.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7981.c
+@@ -1070,6 +1070,7 @@ static const struct mtk_pinctrl_soc mt79
+ 	.gpio_mode = 0,
+ 	.base_names = mt7981_pinctrl_register_base_names,
+ 	.nbase_names = ARRAY_SIZE(mt7981_pinctrl_register_base_names),
++	.rev = MTK_PINCTRL_V1,
+ 	.base_calc = 1,
+ };
+ 
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7986.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7986.c
+@@ -755,6 +755,7 @@ static const struct mtk_pinctrl_soc mt79
+ 	.gpio_mode = 0,
+ 	.base_names = mt7986_pinctrl_register_base_names,
+ 	.nbase_names = ARRAY_SIZE(mt7986_pinctrl_register_base_names),
++	.rev = MTK_PINCTRL_V1,
+ 	.base_calc = 1,
+ };
+ 
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7987.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7987.c
+@@ -712,6 +712,7 @@ static const struct mtk_pinctrl_soc mt79
+ 	.gpio_mode = 0,
+ 	.base_names = mt7987_pinctrl_register_base_names,
+ 	.nbase_names = ARRAY_SIZE(mt7987_pinctrl_register_base_names),
++	.rev = MTK_PINCTRL_V1,
+ 	.base_calc = 1,
+ };
+ 
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7988.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7988.c
+@@ -1250,6 +1250,7 @@ static const struct mtk_pinctrl_soc mt79
+ 	.gpio_mode = 0,
+ 	.base_names = mt7988_pinctrl_register_base_names,
+ 	.nbase_names = ARRAY_SIZE(mt7988_pinctrl_register_base_names),
++	.rev = MTK_PINCTRL_V1,
+ 	.base_calc = 1,
+ };
+ 

--- a/package/boot/uboot-mediatek/patches/110-pinctrl-mediatek-MT7981-some-register-map-fixes.patch
+++ b/package/boot/uboot-mediatek/patches/110-pinctrl-mediatek-MT7981-some-register-map-fixes.patch
@@ -1,0 +1,76 @@
+From 2b4d8df6054acb13cae20889c40102c93df2edd6 Mon Sep 17 00:00:00 2001
+From: developer <developer@mediatek.com>
+Date: Tue, 6 Jan 2026 19:52:11 +0800
+Subject: [PATCH] pinctrl: mediatek: MT7981: some register map fixes
+
+Fix mt7981 pinctrl setting mistake including:
+1) Wrong pinctrl bits length
+2) Wrong pinctrl register offset
+
+Link: https://git01.mediatek.com/plugins/gitiles/openwrt/feeds/mtk-openwrt-feeds/+/52579dd19e62df5aff784462e133e14bfe4a7726
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ drivers/pinctrl/mediatek/pinctrl-mt7981.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7981.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7981.c
+@@ -106,7 +106,7 @@ static const struct mtk_pin_field_calc m
+ 
+ 	PIN_FIELD_BASE(9, 9, 5, 0x20, 0x10, 9, 1),
+ 	PIN_FIELD_BASE(10, 10, 5, 0x20, 0x10, 8, 1),
+-	PIN_FIELD_BASE(11, 11, 5, 0x40, 0x10, 10, 1),
++	PIN_FIELD_BASE(11, 11, 5, 0x20, 0x10, 10, 1),
+ 	PIN_FIELD_BASE(12, 12, 5, 0x20, 0x10, 7, 1),
+ 	PIN_FIELD_BASE(13, 13, 5, 0x20, 0x10, 11, 1),
+ 
+@@ -215,7 +215,7 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(41, 41, 7, 0x70, 0x10, 0, 1),
+ 	PIN_FIELD_BASE(42, 42, 7, 0x70, 0x10, 9, 1),
+ 	PIN_FIELD_BASE(43, 43, 7, 0x70, 0x10, 7, 1),
+-	PIN_FIELD_BASE(44, 44, 7, 0x30, 0x10, 8, 1),
++	PIN_FIELD_BASE(44, 44, 7, 0x70, 0x10, 8, 1),
+ 	PIN_FIELD_BASE(45, 45, 7, 0x70, 0x10, 3, 1),
+ 	PIN_FIELD_BASE(46, 46, 7, 0x70, 0x10, 4, 1),
+ 	PIN_FIELD_BASE(47, 47, 7, 0x70, 0x10, 5, 1),
+@@ -279,8 +279,8 @@ static const struct mtk_pin_field_calc m
+ 
+ 	PIN_FIELD_BASE(2, 2, 5, 0x00, 0x10, 18, 3),
+ 
+-	PIN_FIELD_BASE(3, 3, 4, 0x00, 0x10, 18, 1),
+-	PIN_FIELD_BASE(4, 4, 4, 0x00, 0x10, 6, 1),
++	PIN_FIELD_BASE(3, 3, 4, 0x00, 0x10, 18, 3),
++	PIN_FIELD_BASE(4, 4, 4, 0x00, 0x10, 6, 3),
+ 	PIN_FIELD_BASE(5, 5, 4, 0x00, 0x10, 3, 3),
+ 	PIN_FIELD_BASE(6, 6, 4, 0x00, 0x10, 9, 3),
+ 	PIN_FIELD_BASE(7, 7, 4, 0x00, 0x10, 0, 3),
+@@ -288,9 +288,9 @@ static const struct mtk_pin_field_calc m
+ 
+ 	PIN_FIELD_BASE(9, 9, 5, 0x00, 0x10, 27, 3),
+ 	PIN_FIELD_BASE(10, 10, 5, 0x00, 0x10, 24, 3),
+-	PIN_FIELD_BASE(11, 11, 5, 0x00, 0x10, 0, 3),
++	PIN_FIELD_BASE(11, 11, 5, 0x10, 0x10, 0, 3),
+ 	PIN_FIELD_BASE(12, 12, 5, 0x00, 0x10, 21, 3),
+-	PIN_FIELD_BASE(13, 13, 5, 0x00, 0x10, 3, 3),
++	PIN_FIELD_BASE(13, 13, 5, 0x10, 0x10, 3, 3),
+ 
+ 	PIN_FIELD_BASE(14, 14, 4, 0x00, 0x10, 27, 3),
+ 
+@@ -302,7 +302,7 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(20, 20, 2, 0x00, 0x10, 9, 3),
+ 	PIN_FIELD_BASE(21, 21, 2, 0x00, 0x10, 18, 3),
+ 	PIN_FIELD_BASE(22, 22, 2, 0x00, 0x10, 21, 3),
+-	PIN_FIELD_BASE(23, 23, 2, 0x00, 0x10, 0, 3),
++	PIN_FIELD_BASE(23, 23, 2, 0x10, 0x10, 0, 3),
+ 	PIN_FIELD_BASE(24, 24, 2, 0x00, 0x10, 27, 3),
+ 	PIN_FIELD_BASE(25, 25, 2, 0x00, 0x10, 24, 3),
+ 
+@@ -368,7 +368,7 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(17, 17, 2, 0x30, 0x10, 5, 1),
+ 	PIN_FIELD_BASE(18, 18, 2, 0x30, 0x10, 4, 1),
+ 	PIN_FIELD_BASE(19, 19, 2, 0x30, 0x10, 2, 1),
+-	PIN_FIELD_BASE(20, 20, 2, 0x90, 0x10, 3, 1),
++	PIN_FIELD_BASE(20, 20, 2, 0x30, 0x10, 3, 1),
+ 	PIN_FIELD_BASE(21, 21, 2, 0x30, 0x10, 6, 1),
+ 	PIN_FIELD_BASE(22, 22, 2, 0x30, 0x10, 7, 1),
+ 	PIN_FIELD_BASE(23, 23, 2, 0x30, 0x10, 10, 1),

--- a/target/linux/mediatek/patches-6.12/070-v7.0-pinctrl-mediatek-enable-ies_present-flag-for-MT798x.patch
+++ b/target/linux/mediatek/patches-6.12/070-v7.0-pinctrl-mediatek-enable-ies_present-flag-for-MT798x.patch
@@ -1,0 +1,59 @@
+From 6da9f0cc2717158857f8b8b9369523d0d6770c07 Mon Sep 17 00:00:00 2001
+From: Shiji Yang <yangshiji66@outlook.com>
+Date: Sat, 17 Jan 2026 11:04:37 +0800
+Subject: [PATCH] pinctrl: mediatek: enable ies_present flag for MT798x
+
+The MT798x series SoCs have IES regiter definitions. I think we
+must enable the ies_present flag to correctly configure the pin
+input mode.
+
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+Signed-off-by: Linus Walleij <linusw@kernel.org>
+---
+ drivers/pinctrl/mediatek/pinctrl-mt7981.c | 2 +-
+ drivers/pinctrl/mediatek/pinctrl-mt7986.c | 4 ++--
+ drivers/pinctrl/mediatek/pinctrl-mt7988.c | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7981.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7981.c
+@@ -1019,7 +1019,7 @@ static struct mtk_pin_soc mt7981_data =
+ 	.nfuncs = ARRAY_SIZE(mt7981_functions),
+ 	.eint_hw = &mt7981_eint_hw,
+ 	.gpio_m = 0,
+-	.ies_present = false,
++	.ies_present = true,
+ 	.base_names = mt7981_pinctrl_register_base_names,
+ 	.nbase_names = ARRAY_SIZE(mt7981_pinctrl_register_base_names),
+ 	.bias_disable_set = mtk_pinconf_bias_disable_set,
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7986.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7986.c
+@@ -919,7 +919,7 @@ static struct mtk_pin_soc mt7986a_data =
+ 	.nfuncs = ARRAY_SIZE(mt7986_functions),
+ 	.eint_hw = &mt7986a_eint_hw,
+ 	.gpio_m = 0,
+-	.ies_present = false,
++	.ies_present = true,
+ 	.base_names = mt7986_pinctrl_register_base_names,
+ 	.nbase_names = ARRAY_SIZE(mt7986_pinctrl_register_base_names),
+ 	.bias_disable_set = mtk_pinconf_bias_disable_set,
+@@ -945,7 +945,7 @@ static struct mtk_pin_soc mt7986b_data =
+ 	.nfuncs = ARRAY_SIZE(mt7986_functions),
+ 	.eint_hw = &mt7986b_eint_hw,
+ 	.gpio_m = 0,
+-	.ies_present = false,
++	.ies_present = true,
+ 	.base_names = mt7986_pinctrl_register_base_names,
+ 	.nbase_names = ARRAY_SIZE(mt7986_pinctrl_register_base_names),
+ 	.bias_disable_set = mtk_pinconf_bias_disable_set,
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7988.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7988.c
+@@ -1515,7 +1515,7 @@ static const struct mtk_pin_soc mt7988_d
+ 	.nfuncs = ARRAY_SIZE(mt7988_functions),
+ 	.eint_hw = &mt7988_eint_hw,
+ 	.gpio_m = 0,
+-	.ies_present = false,
++	.ies_present = true,
+ 	.base_names = mt7988_pinctrl_register_base_names,
+ 	.nbase_names = ARRAY_SIZE(mt7988_pinctrl_register_base_names),
+ 	.bias_disable_set = mtk_pinconf_bias_disable_set,

--- a/target/linux/mediatek/patches-6.12/119-pinctrl-mediatek-MT7981-some-register-map-fixes.patch
+++ b/target/linux/mediatek/patches-6.12/119-pinctrl-mediatek-MT7981-some-register-map-fixes.patch
@@ -1,0 +1,76 @@
+From 2b4d8df6054acb13cae20889c40102c93df2edd6 Mon Sep 17 00:00:00 2001
+From: developer <developer@mediatek.com>
+Date: Tue, 6 Jan 2026 19:52:11 +0800
+Subject: [PATCH] pinctrl: mediatek: MT7981: some register map fixes
+
+Fix mt7981 pinctrl setting mistake including:
+1) Wrong pinctrl bits length
+2) Wrong pinctrl register offset
+
+Link: https://git01.mediatek.com/plugins/gitiles/openwrt/feeds/mtk-openwrt-feeds/+/52579dd19e62df5aff784462e133e14bfe4a7726
+Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
+---
+ drivers/pinctrl/mediatek/pinctrl-mt7981.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+--- a/drivers/pinctrl/mediatek/pinctrl-mt7981.c
++++ b/drivers/pinctrl/mediatek/pinctrl-mt7981.c
+@@ -48,7 +48,7 @@ static const struct mtk_pin_field_calc m
+ 
+ 	PIN_FIELD_BASE(9, 9, 5, 0x20, 0x10, 9, 1),
+ 	PIN_FIELD_BASE(10, 10, 5, 0x20, 0x10, 8, 1),
+-	PIN_FIELD_BASE(11, 11, 5, 0x40, 0x10, 10, 1),
++	PIN_FIELD_BASE(11, 11, 5, 0x20, 0x10, 10, 1),
+ 	PIN_FIELD_BASE(12, 12, 5, 0x20, 0x10, 7, 1),
+ 	PIN_FIELD_BASE(13, 13, 5, 0x20, 0x10, 11, 1),
+ 
+@@ -157,7 +157,7 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(41, 41, 7, 0x70, 0x10, 0, 1),
+ 	PIN_FIELD_BASE(42, 42, 7, 0x70, 0x10, 9, 1),
+ 	PIN_FIELD_BASE(43, 43, 7, 0x70, 0x10, 7, 1),
+-	PIN_FIELD_BASE(44, 44, 7, 0x30, 0x10, 8, 1),
++	PIN_FIELD_BASE(44, 44, 7, 0x70, 0x10, 8, 1),
+ 	PIN_FIELD_BASE(45, 45, 7, 0x70, 0x10, 3, 1),
+ 	PIN_FIELD_BASE(46, 46, 7, 0x70, 0x10, 4, 1),
+ 	PIN_FIELD_BASE(47, 47, 7, 0x70, 0x10, 5, 1),
+@@ -221,8 +221,8 @@ static const struct mtk_pin_field_calc m
+ 
+ 	PIN_FIELD_BASE(2, 2, 5, 0x00, 0x10, 18, 3),
+ 
+-	PIN_FIELD_BASE(3, 3, 4, 0x00, 0x10, 18, 1),
+-	PIN_FIELD_BASE(4, 4, 4, 0x00, 0x10, 6, 1),
++	PIN_FIELD_BASE(3, 3, 4, 0x00, 0x10, 18, 3),
++	PIN_FIELD_BASE(4, 4, 4, 0x00, 0x10, 6, 3),
+ 	PIN_FIELD_BASE(5, 5, 4, 0x00, 0x10, 3, 3),
+ 	PIN_FIELD_BASE(6, 6, 4, 0x00, 0x10, 9, 3),
+ 	PIN_FIELD_BASE(7, 7, 4, 0x00, 0x10, 0, 3),
+@@ -230,9 +230,9 @@ static const struct mtk_pin_field_calc m
+ 
+ 	PIN_FIELD_BASE(9, 9, 5, 0x00, 0x10, 27, 3),
+ 	PIN_FIELD_BASE(10, 10, 5, 0x00, 0x10, 24, 3),
+-	PIN_FIELD_BASE(11, 11, 5, 0x00, 0x10, 0, 3),
++	PIN_FIELD_BASE(11, 11, 5, 0x10, 0x10, 0, 3),
+ 	PIN_FIELD_BASE(12, 12, 5, 0x00, 0x10, 21, 3),
+-	PIN_FIELD_BASE(13, 13, 5, 0x00, 0x10, 3, 3),
++	PIN_FIELD_BASE(13, 13, 5, 0x10, 0x10, 3, 3),
+ 
+ 	PIN_FIELD_BASE(14, 14, 4, 0x00, 0x10, 27, 3),
+ 
+@@ -244,7 +244,7 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(20, 20, 2, 0x00, 0x10, 9, 3),
+ 	PIN_FIELD_BASE(21, 21, 2, 0x00, 0x10, 18, 3),
+ 	PIN_FIELD_BASE(22, 22, 2, 0x00, 0x10, 21, 3),
+-	PIN_FIELD_BASE(23, 23, 2, 0x00, 0x10, 0, 3),
++	PIN_FIELD_BASE(23, 23, 2, 0x10, 0x10, 0, 3),
+ 	PIN_FIELD_BASE(24, 24, 2, 0x00, 0x10, 27, 3),
+ 	PIN_FIELD_BASE(25, 25, 2, 0x00, 0x10, 24, 3),
+ 
+@@ -310,7 +310,7 @@ static const struct mtk_pin_field_calc m
+ 	PIN_FIELD_BASE(17, 17, 2, 0x30, 0x10, 5, 1),
+ 	PIN_FIELD_BASE(18, 18, 2, 0x30, 0x10, 4, 1),
+ 	PIN_FIELD_BASE(19, 19, 2, 0x30, 0x10, 2, 1),
+-	PIN_FIELD_BASE(20, 20, 2, 0x90, 0x10, 3, 1),
++	PIN_FIELD_BASE(20, 20, 2, 0x30, 0x10, 3, 1),
+ 	PIN_FIELD_BASE(21, 21, 2, 0x30, 0x10, 6, 1),
+ 	PIN_FIELD_BASE(22, 22, 2, 0x30, 0x10, 7, 1),
+ 	PIN_FIELD_BASE(23, 23, 2, 0x30, 0x10, 10, 1),

--- a/target/linux/mediatek/patches-6.12/360-pinctrl-mediatek-add-mt7987-pinctrl-support.patch
+++ b/target/linux/mediatek/patches-6.12/360-pinctrl-mediatek-add-mt7987-pinctrl-support.patch
@@ -750,7 +750,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	.nfuncs = ARRAY_SIZE(mt7987_functions),
 +	.eint_hw = &mt7987_eint_hw,
 +	.gpio_m = 0,
-+	.ies_present = false,
++	.ies_present = true,
 +	.base_names = mt7987_pinctrl_register_base_names,
 +	.nbase_names = ARRAY_SIZE(mt7987_pinctrl_register_base_names),
 +	.bias_disable_set = mtk_pinconf_bias_disable_set,


### PR DESCRIPTION
Port mt7981 pinctrl register offset and bits length fixes from the Mediatek SDK to address the pinctrl issue.

Report: https://lore.kernel.org/linux-mediatek/OS7PR01MB13834E7D3E265DAFD58CEFF92BCB8A@OS7PR01MB13834.jpnprd01.prod.outlook.com/