### PR TITLE
wifi-scripts: ucode: fix RRM defaults

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -424,8 +424,7 @@
 		},
 		"ieee80211k": {
 			"description": "Enables Radio Resource Measurement (802.11k) support",
-			"type": "boolean",
-			"default": true
+			"type": "boolean"
 		},
 		"ieee80211r": {
 			"description": "Enables fast BSS transition (802.11r) support.",
@@ -929,18 +928,15 @@
 		},
 		"rrm_beacon_report": {
 			"description": "Enable beacon report via radio measurements",
-			"type": "boolean",
-			"default": true
+			"type": "boolean"
 		},
 		"rrm_neighbor_report": {
 			"description": "Enable neighbor report via radio measurements",
-			"type": "boolean",
-			"default": true
+			"type": "boolean"
 		},
 		"rnr": {
 			"description": "Enable reduced neighbor reporting",
-			"type": "boolean",
-			"default": true
+			"type": "boolean"
 		},
 		"roaming_consortium": {
 			"description": "Roaming Consortium List",


### PR DESCRIPTION
They are being default enabled unconditionally when they should depend on 802.11k. 802.11k should not be enabled by default either as it can cause issues with certain older drivers and is useless without a userspace program like usteer or DAWN.

If users want to enable 802.11k they will enable it when they set such programs up.

Another inconsistency with rnr was dealt with so that it is not default enabled. This is also not done with old wifi-scripts and is generally unexpected and surprising behavior.

Moreoever, this introduces an inconsistency between old shell wifi-scripts and ucode version. Old wifi-scripts does not do this.