### PR TITLE
[pre-6.18] realtek: replace remove_new with remove

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -1683,8 +1683,8 @@ static const struct of_device_id rtl83xx_switch_of_ids[] = {
 MODULE_DEVICE_TABLE(of, rtl83xx_switch_of_ids);
 
 static struct platform_driver rtl83xx_switch_driver = {
-	.probe = rtl83xx_sw_probe,
-	.remove_new = rtl83xx_sw_remove,
+	.probe  = rtl83xx_sw_probe,
+	.remove = rtl83xx_sw_remove,
 	.driver = {
 		.name = "rtl83xx-switch",
 		.pm = NULL,

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -1836,8 +1836,8 @@ static const struct of_device_id rtl838x_eth_of_ids[] = {
 MODULE_DEVICE_TABLE(of, rtl838x_eth_of_ids);
 
 static struct platform_driver rtl838x_eth_driver = {
-	.probe = rtl838x_eth_probe,
-	.remove_new = rtl838x_eth_remove,
+	.probe  = rtl838x_eth_probe,
+	.remove = rtl838x_eth_remove,
 	.driver = {
 		.name = "rtl838x-eth",
 		.pm = NULL,


### PR DESCRIPTION
Replace remove_new callback in struct platform_driver with remove. This was just meant for a transition period. remove_new is dropped with 6.13.

~This change was missed in 9934c716ed ("treewide: replace remove_new with remove")~

