### PR TITLE
realtek: phy: RTL8214FC initialization

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
@@ -904,9 +904,19 @@ static int rtl8218b_config_init(struct phy_device *phydev)
 	phy_modify_paged(phydev, RTL821X_MAC_SDS_PAGE(0, 1), 0x14, 0, BIT(3));
 	/* magic CMU setting for stable connectivity of first MAC serdes */
 	phy_write_paged(phydev, 0x462, 0x15, 0x6e58);
+	/* magic setting for rate select 10G full */
+	phy_write_paged(phydev, 0x464, 0x15, 0x202a);
+	/* magic setting for variable gain amplifier */
+	phy_modify_paged(phydev, 0x464, 0x12, 0, 0x1f80);
+	/* magic setting for equalizer of second MAC serdes */
+	phy_write_paged(phydev, RTL821X_MAC_SDS_PAGE(1, 8), 0x12, 0x2020);
+	/* unknown magic for second MAC serdes */
+	phy_write_paged(phydev, RTL821X_MAC_SDS_PAGE(1, 9), 0x11, 0xc014);
 	rtl8218b_cmu_reset(phydev, 0);
 
 	for (int sds = 0; sds < 2; sds++) {
+		/* disable ring PLL for serdes 2+3 */
+		phy_modify_paged(phydev, RTL821X_MAC_SDS_PAGE(sds + 1, 8), 0x11, BIT(15), 0);
 		/* force negative clock edge */
 		phy_modify_paged(phydev, RTL821X_MAC_SDS_PAGE(sds, 0), 0x17, 0, BIT(14));
 		rtl8218b_cmu_reset(phydev, 5 + sds);

--- a/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
+++ b/target/linux/realtek/files-6.12/drivers/net/phy/rtl83xx-phy.c
@@ -453,12 +453,11 @@ static bool __rtl8214fc_media_is_fibre(struct phy_device *phydev)
 
 static bool rtl8214fc_media_is_fibre(struct phy_device *phydev)
 {
-	struct mii_bus *bus = phydev->mdio.bus;
 	int ret;
 
-	mutex_lock(&bus->mdio_lock);
+	phy_lock_mdio_bus(phydev);
 	ret = __rtl8214fc_media_is_fibre(phydev);
-	mutex_unlock(&bus->mdio_lock);
+	phy_unlock_mdio_bus(phydev);
 
 	return ret;
 }


### PR DESCRIPTION
This series makes RTL8214FC on non-U-Boot RTL839x devices work. Depends on https://github.com/openwrt/openwrt/pull/21360