### PR TITLE
ppp: update deprecated cpe

### DIFF
--- a/package/network/services/ppp/Makefile
+++ b/package/network/services/ppp/Makefile
@@ -20,7 +20,7 @@ PKG_SOURCE_VERSION:=9f612dc02c34509f062ed63b60bcc7e937e25178
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 PKG_LICENSE:=BSD-4-Clause
-PKG_CPE_ID:=cpe:/a:samba:ppp
+PKG_CPE_ID:=cpe:/a:point-to-point_protocol_project:point-to-point_protocol
 
 PKG_ASLR_PIE_REGULAR:=1
 PKG_BUILD_DEPENDS:=libpcap


### PR DESCRIPTION
The CPE 'samba:ppp' added in OpenWRT commit [1], has been deprecated in favour of 'point-to-point_protocol_project:point-to-point_protocol' (see [2]).

[1] c61a239514 add PKG_CPE_ID ids to package and tools
[2] https://nvd.nist.gov/products/cpe/detail/1224B76D-6BB3-4088-9F42-23AC04A764F2
