### PR TITLE
wifi-scripts: restore noscan handling for sta/adhoc/mesh

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -232,7 +232,7 @@ function setup() {
 		case 'adhoc':
 		case 'mesh':
 			if (mode != "ap")
-				data.config.noscan = true;
+				set_default(data.config, 'noscan', true);
 			validate('iface', v.config);
 			iface.prepare(v.config, data.phy + data.phy_suffix, data.config.num_global_macaddr, data.config.macaddr_base);
 			netifd.set_vif(k, v.config.ifname);

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -34,6 +34,9 @@ function set_fixed_freq(data, config) {
 
 	if (wildcard(data.htmode, 'VHT*'))
 		set_default(config, 'vht', 1);
+
+	if (config.mode in [ 'sta', 'adhoc', 'mesh' ])
+		set_default(config, 'noscan', true);
 }
 
 export function ratestr(rate) {

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -36,6 +36,9 @@ function set_fixed_freq(data, config) {
 
 	if (wildcard(data.htmode, 'VHT*'))
 		set_default(config, 'vht', 1);
+
+	if (config.mode in [ 'sta', 'adhoc', 'mesh' ])
+		set_default(config, 'noscan', true);
 }
 
 export function ratestr(rate) {


### PR DESCRIPTION
The mac80211 shell implementation explicitly enabled noscan for station, adhoc and mesh interfaces when operating on a fixed frequency:

  for_each_interface "sta adhoc mesh" mac80211_set_noscan

During the migration from the shell scripts to ucode, this logic was not carried over into supplicant.uc. As a result, wpa_supplicant would continue to perform scans even when fixed_freq is set, preventing reliable HT40/HE40 operation on 2.4 GHz and causing mesh links to fall back to 20 MHz.

Restore the original behavior by setting noscan when fixed_freq is enabled for sta, adhoc and mesh modes. This matches the legacy mac80211.sh behavior and ensures correct channel width operation for fixed-frequency links.

No functional change for non-fixed-frequency configurations.