### PR TITLE
kernel: modules: add kmod-pmbus-sensors package

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -493,6 +493,25 @@ endef
 $(eval $(call KernelPackage,pmbus-core))
 
 
+define KernelPackage/pmbus-sensors
+  TITLE:=Generic PMBus devices monitoring support
+  KCONFIG:=CONFIG_SENSORS_PMBUS
+  FILES:=$(LINUX_DIR)/drivers/hwmon/pmbus/pmbus.ko
+  AUTOLOAD:=$(call AutoProbe,pmbus)
+  $(call AddDepends/hwmon,+kmod-pmbus-core)
+endef
+
+define KernelPackage/pmbus-sensors/description
+ Kernel modules for generic PMBus devices,
+including but not limited to ADP4000, BMR310, BMR453,
+BMR454, BMR456, BMR457, BMR458, BMR480, BMR490, BMR491, BMR492,
+MAX20796, MDT040, NCP4200, NCP4208, PDT003, PDT006, PDT012,
+TPS40400, TPS544B20, TPS544B25, TPS544C20, TPS544C25, and UDT020.
+endef
+
+$(eval $(call KernelPackage,pmbus-sensors))
+
+
 define KernelPackage/pmbus-zl6100
   TITLE:=Intersil / Zilker Labs ZL6100 hardware monitoring
   KCONFIG:=CONFIG_SENSORS_ZL6100


### PR DESCRIPTION
Introduce the `kmod-pmbus-sensors` package to provide the generic PMBus hwmon driver (`CONFIG_SENSORS_PMBUS`).

This enables support for a wide range of PMBus-based devices including ADP4000, BMR310, BMR480, DPS460, MAX20796, TPS544B25, and others.