### PR TITLE
imagebuilder: add ABI suffix to packages when using apk

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -145,6 +145,32 @@ BUILD_PACKAGES:=$(sort $(DEFAULT_PACKAGES) $($(USER_PROFILE)_PACKAGES) kernel)
 BUILD_PACKAGES:=$(filter-out $(filter -%,$(BUILD_PACKAGES)) $(patsubst -%,%,$(filter -%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
 BUILD_PACKAGES:=$(USER_PACKAGES) $(BUILD_PACKAGES)
 BUILD_PACKAGES:=$(filter-out $(filter -%,$(BUILD_PACKAGES)) $(patsubst -%,%,$(filter -%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
+
+ifneq ($(CONFIG_USE_APK),)
+BUILD_PACKAGES+= \
+  "base-files=$(BASE_FILES_VERSION)" \
+  "libc=$(LIBC_VERSION)" \
+  "kernel=$(KERNEL_VERSION)"
+endif
+
+# Get ABI version suffix for a package from an apk index
+#
+# 1: package name
+define GetABISuffix
+$(shell $(APK) query --fields tags --match provides $(1) | grep openwrt:abiversion | awk -F= '{print $$2; exit}')
+endef
+
+# Format packages by adding an ABI version suffix if found
+#
+# 1: list of packages
+define FormatPackages
+$(strip $(foreach pkg,$(strip $(subst ",,$(1))),
+  $(eval pkg_name:=$(firstword $(subst =, ,$(pkg))))
+  $(if $(findstring =,$(pkg)),$(eval pkg_ver:==$(lastword $(subst =, ,$(pkg)))))
+  $(pkg_name)$(call GetABISuffix,$(pkg_name))$(pkg_ver)
+))
+endef
+
 PACKAGES:=
 
 _call_image: staging_dir/host/.prereq-build
@@ -229,10 +255,8 @@ ifeq ($(CONFIG_USE_APK),)
 	$(OPKG) install $(wildcard $(PACKAGE_DIR)/kernel_*.ipk)
 	$(OPKG) install $(BUILD_PACKAGES)
 else
-	$(APK) add --arch $(ARCH_PACKAGES) --no-scripts $(BUILD_PACKAGES) \
-        "base-files=$(BASE_FILES_VERSION)" \
-        "libc=$(LIBC_VERSION)" \
-        "kernel=$(KERNEL_VERSION)"
+	$(eval BUILD_PACKAGES:=$(call FormatPackages,$(BUILD_PACKAGES)))
+	$(APK) add --arch $(ARCH_PACKAGES) --no-scripts $(BUILD_PACKAGES)
 endif
 
 prepare_rootfs: FORCE


### PR DESCRIPTION
When using an image builder (or ASU, or owut), if an apk package with an ABI version doesn't have priority set, it can't be selected by its base name.

Look up the ABI version in apk index and if present, add an ABI suffix to all requested packages.

Before:

```bash
$ make manifest PACKAGES='libustream-openssl -libustream-mbedtls libsqlite3'
ERROR: unable to select packages:
  libsqlite3 (virtual):
    note: please select one of the 'provided by'
          packages explicitly
    provided by: libsqlite3-0
    required by: world[libsqlite3]
  libustream-openssl (virtual):
    note: please select one of the 'provided by'
          packages explicitly
    provided by: libustream-openssl20201210
    required by: world[libustream-openssl]
```

After:

```bash
$ make manifest PACKAGES='libustream-openssl -libustream-mbedtls libsqlite3'
apk-mbedtls - 3.0.2-r1
base-files - 1682~d76c64ad00
bnx2-firmware - 20251125-r1
busybox - 1.37.0-r6
ca-bundle - 20250419-r2
dnsmasq - 2.91-r2
dropbear - 2025.89-r1
e2fsprogs - 1.47.3-r1
firewall4 - 2025.03.17~b6e51575-r1
fstools - 2025.10.03~12858e28-r1
fwtool - 2025.10.03~04cd252e-r1
getrandom - 2025.10.30~6f78fa49-r1
grub2-bios-setup - 2.12-r1
i915-firmware-dmc - 20251125-r1
jansson4 - 2.14.1-r1
jshn - 2025.12.08~7928f171-r1
jsonfilter - 2025.10.04~f4fe702d-r1
kernel - 6.12.63~780c76c9e68ba0964ba865d615ce42f0-r1
kmod-acpi-video - 6.12.63-r1
kmod-amazon-ena - 6.12.63-r1
kmod-amd-xgbe - 6.12.63-r1
kmod-backlight - 6.12.63-r1
kmod-bnx2 - 6.12.63-r1
kmod-button-hotplug - 6.12.63-r3
kmod-crypto-crc32c - 6.12.63-r1
kmod-crypto-hash - 6.12.63-r1
kmod-dma-buf - 6.12.63-r1
kmod-drm - 6.12.63-r1
kmod-drm-buddy - 6.12.63-r1
kmod-drm-display-helper - 6.12.63-r1
kmod-drm-exec - 6.12.63-r1
kmod-drm-i915 - 6.12.63-r1
kmod-drm-kms-helper - 6.12.63-r1
kmod-drm-suballoc-helper - 6.12.63-r1
kmod-drm-ttm - 6.12.63-r1
kmod-drm-ttm-helper - 6.12.63-r1
kmod-dwmac-intel - 6.12.63-r1
kmod-e1000 - 6.12.63-r1
kmod-e1000e - 6.12.63-r1
kmod-fb - 6.12.63-r1
kmod-fb-cfb-copyarea - 6.12.63-r1
kmod-fb-cfb-fillrect - 6.12.63-r1
kmod-fb-cfb-imgblt - 6.12.63-r1
kmod-fb-sys-fops - 6.12.63-r1
kmod-fb-sys-ram - 6.12.63-r1
kmod-forcedeth - 6.12.63-r1
kmod-fs-vfat - 6.12.63-r1
kmod-hwmon-core - 6.12.63-r1
kmod-i2c-algo-bit - 6.12.63-r1
kmod-i2c-core - 6.12.63-r1
kmod-igb - 6.12.63-r1
kmod-igc - 6.12.63-r1
kmod-input-core - 6.12.63-r1
kmod-ixgbe - 6.12.63-r1
kmod-lib-crc-ccitt - 6.12.63-r1
kmod-lib-crc32c - 6.12.63-r1
kmod-libphy - 6.12.63-r1
kmod-mdio - 6.12.63-r1
kmod-mdio-devres - 6.12.63-r1
kmod-mii - 6.12.63-r1
kmod-nf-conntrack - 6.12.63-r1
kmod-nf-conntrack6 - 6.12.63-r1
kmod-nf-flow - 6.12.63-r1
kmod-nf-log - 6.12.63-r1
kmod-nf-log6 - 6.12.63-r1
kmod-nf-nat - 6.12.63-r1
kmod-nf-reject - 6.12.63-r1
kmod-nf-reject6 - 6.12.63-r1
kmod-nfnetlink - 6.12.63-r1
kmod-nft-core - 6.12.63-r1
kmod-nft-fib - 6.12.63-r1
kmod-nft-nat - 6.12.63-r1
kmod-nft-offload - 6.12.63-r1
kmod-nls-base - 6.12.63-r1
kmod-nls-cp437 - 6.12.63-r1
kmod-nls-iso8859-1 - 6.12.63-r1
kmod-nls-utf8 - 6.12.63-r1
kmod-pcs-xpcs - 6.12.63-r1
kmod-phy-realtek - 6.12.63-r1
kmod-phylink - 6.12.63-r1
kmod-ppp - 6.12.63-r1
kmod-pppoe - 6.12.63-r1
kmod-pppox - 6.12.63-r1
kmod-pps - 6.12.63-r1
kmod-ptp - 6.12.63-r1
kmod-r8169 - 6.12.63-r1
kmod-slhc - 6.12.63-r1
kmod-stmmac-core - 6.12.63-r1
kmod-tg3 - 6.12.63-r1
libblkid1 - 2.41.3-r1
libblobmsg-json20251208 - 2025.12.08~7928f171-r1
libc - 1.2.5-r5
libcomerr0 - 1.47.3-r1
libe2p2 - 1.47.3-r1
libext2fs2 - 1.47.3-r1
libf2fs6 - 1.16.0-r4
libgcc1 - 14.3.0-r5
libjson-c5 - 0.18-r1
libjson-script20251208 - 2025.12.08~7928f171-r1
libmbedtls21 - 3.6.5-r1
libmnl0 - 1.0.5-r1
libnftnl11 - 1.3.1-r1
libnl-tiny1 - 2025.12.02~40493a65-r1
libopenssl3 - 3.5.4-r1
libpthread - 1.2.5-r5
librt - 1.2.5-r5
libsmartcols1 - 2.41.3-r1
libsqlite3-0 - 3.51.1-r1
libss2 - 1.47.3-r1
libubox20251208 - 2025.12.08~7928f171-r1
libubus20251202 - 2025.12.02~3cc98db1-r1
libuci20250120 - 2025.12.02~66127cd7-r1
libuclient20201210 - 2025.10.03~dc909ca7-r1
libucode20230711 - 2025.12.01~f7c2b97a-r1
libudebug - 2025.10.21~75f39cd4
libustream-openssl20201210 - 2025.10.03~5a81c108-r1
libuuid1 - 2.41.3-r1
logd - 2025.10.30~6f78fa49-r1
mkf2fs - 1.16.0-r4
mtd - 27
netifd - 2025.10.20~777f5942-r1
nftables-json - 1.1.6-r1
odhcp6c - 2025.12.29~699cc615-r1
odhcpd-ipv6only - 2025.12.18~0779ee28-r1
openwrt-keyring - 2025.12.10~f0670054-r1
partx-utils - 2.41.3-r1
ppp - 2.5.2-r2
ppp-mod-pppoe - 2.5.2-r2
procd - 2025.10.04~3b3501ab-r1
procd-seccomp - 2025.10.04~3b3501ab-r1
procd-ujail - 2025.10.04~3b3501ab-r1
r8169-firmware - 20251125-r1
ubox - 2025.10.30~6f78fa49-r1
ubus - 2025.12.02~3cc98db1-r1
ubusd - 2025.12.02~3cc98db1-r1
uci - 2025.12.02~66127cd7-r1
uclient-fetch - 2025.10.03~dc909ca7-r1
ucode - 2025.12.01~f7c2b97a-r1
ucode-mod-fs - 2025.12.01~f7c2b97a-r1
ucode-mod-ubus - 2025.12.01~f7c2b97a-r1
ucode-mod-uci - 2025.12.01~f7c2b97a-r1
ucode-mod-uloop - 2025.12.01~f7c2b97a-r1
urandom-seed - 3
urngd - 2025.10.03~f17e33d9-r1
usign - 2025.10.03~c4c72b1b-r1
zlib - 1.3.1-r1
```

Tested building images using the 25.12-rc2 x86/64 image builder.

This is addressed on the packaging side by giving packages with an ABI version a priority in:
- #21369

Related:
- #21325

cc: @efahl can you run some checks? I feel like you have a more robust set of test scenarios. Sorry :speak_no_evil: