### PR TITLE
netifd: dhcp: suppress udhcpc default vendor class if specified in sendopts

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/netifd.git


### PR DESCRIPTION
## netifd: Support hex Option 60 via sendopts while maintaining backward compatibility

### Motivation

This PR provides an alternative solution to #21247, addressing the same IPTV authentication issues but with better backward compatibility and a cleaner implementation.

### Problem Statement

When connecting to ISP IPTV services via IPoE, two issues arise:

1. **Non-ASCII Option 60 values**: Some ISPs require DHCP Option 60 (Vendor Class Identifier) to contain raw hexadecimal data that doesn't translate to printable ASCII characters.
2. **Duplicate Option 60**: **The current implementation  of udhcpc** sends both the user-specified vendorid and udhcpc's default version string, causing authentication failures with some ISP DHCP servers.

### Solution

This implementation allows users to send hexadecimal Option 60 values via the existing [sendopts]

configuration option, while automatically providing an empty `-V ""` placeholder to prevent udhcpc from sending its default vendor class.

The solution intelligently detects Option 60 in **all supported udhcpc formats**:
- **Hexadecimal**: `0x3c`, `0X3C`, `0x003c` (case-insensitive with optional leading zeros)
- **Decimal**: `60`
- **Named**: `vendor`

**Key advantages over #21247:**

- ✅ **Full backward compatibility**: Existing `vendorid` configurations continue to work unchanged
- ✅ **Cleaner implementation**: Uses existing [sendopts] mechanism instead of modifying vendorid behavior
- ✅ **More flexible**: Users can choose between ASCII vendorid or hex sendopts based on their needs
- ✅ **Comprehensive format support**: Detects Option 60 in all three formats supported by udhcpc

### Changes

Modified [package/network/config/netifd/files/lib/netifd/proto/dhcp.sh]

- Added detection for Option 60 in `$dhcpopts` (populated by sendopts) supporting all udhcpc formats
- When Option 60 is detected via sendopts (in any format), automatically provide `-V ""` to suppress udhcpc's default vendor class
- When no Option 60 is present in sendopts, use the traditional `vendorid` parameter if configured

### Usage Examples

#### For IPTV with hex Option 60 (new functionality):
```bash
# Method 1: Hexadecimal format (recommended for non-ASCII values)
uci set network.iptv=interface
uci set network.iptv.proto='dhcp'
uci set network.iptv.device='eth1'
uci add_list network.iptv.sendopts='0x3c:48575443'  # Hex vendor class
uci commit network
ifup iptv

# Method 2: Decimal format
uci add_list network.iptv.sendopts='60:48575443'

# Method 3: Named format with ASCII value
uci add_list network.iptv.sendopts='vendor:48575443'
```

#### For traditional ASCII vendorid (backward compatible):
```bash
uci set network.wan.vendorid='HWTC'
uci commit network
ifup wan
```

#### Combined example with multiple options:
```bash
uci set network.iptv=interface
uci set network.iptv.proto='dhcp'
uci set network.iptv.device='eth1'
uci add_list network.iptv.sendopts='0x3c:48575443'  # Option 60: Vendor Class
uci add_list network.iptv.sendopts='0x7d:0000000000'  # Option 125: Vendor-Specific Info
uci commit network
ifup iptv
```

### Testing

Tested with:
- ✅ Existing configurations using ASCII vendorid
- ✅ Configurations without vendorid set

<img width="1549" height="45" alt="image" src="https://github.com/user-attachments/assets/8282140f-77b4-4e2d-bb4a-777deb7663c9" />

- ✅ All three Option 60 formats: hex (`0x3c`), decimal (`60`), and named (`vendor`)
<img width="1906" height="69" alt="image" src="https://github.com/user-attachments/assets/524c3204-72aa-4aaf-9a15-a26432bc666d" />
<img width="1863" height="45" alt="image" src="https://github.com/user-attachments/assets/4d8fd0bf-e60c-4003-99f9-8c35f1ba152b" />

-  ✅ Wireshark verified with only one Option 60
<img width="1266" height="727" alt="image" src="https://github.com/user-attachments/assets/f323858f-6c00-4f13-b2fa-7f5a727b7e10" />


### Technical Details

**udhcpc Option Format Support:**

BusyBox udhcpc's `-x` parameter accepts three formats for specifying DHCP options:
1. Hexadecimal: `-x 0x3c:value` (Option number in hex)
2. Decimal: `-x 60:value` (Option number in decimal)
3. Named: `-x vendor:value` (Predefined option name)

### References

- Closes #21242
- Alternative to #21247
- Related discussion: https://v2ex.com/t/896669


