### PR TITLE
readline: add $(FPIC) to LDFLAGS

### DIFF
--- a/package/libs/readline/Makefile
+++ b/package/libs/readline/Makefile
@@ -57,7 +57,10 @@ CONFIGURE_VARS += \
 	bash_cv_termcap_lib=libncursesw
 
 TARGET_CFLAGS += $(FPIC)
-HOST_CFLAGS += $(FPIC)
+TARGET_LDFLAGS += $(FPIC)
+
+HOST_CFLAGS += $(HOST_FPIC)
+HOST_LDFLAGS += $(HOST_FPIC)
 
 define Build/InstallDev
 	$(INSTALL_DIR) $(1)/usr/include


### PR DESCRIPTION
Ensure -fPIC is passed during the linking stage to fix LTO build failures (relocation errors) on MIPS and other architectures.

Build tested on: tplink_tl-wr842n-v3

Fixes: #20436