### PR TITLE
qualcommax: ipq50xx: match QDSK ports unit address with port id

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax6000.dts
@@ -298,7 +298,7 @@
 
 	qcom,port_phyinfo {
 		// MAC0 -> GE Phy --- MDI --- QCA8337 Switch
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
@@ -306,7 +306,7 @@
 		};
 
 		// MAC1 -> Uniphy --- SGMII --- QCA8081
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			mdiobus = <&mdio1>;
 			phy_address = <8>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax830.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax830.dts
@@ -82,14 +82,14 @@
 
 	qcom,port_phyinfo {
 		// MAC0 -> GE Phy
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
 		};
 
 		// MAC1 -> Uniphy --- SGMII --- QCA8081
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			mdiobus = <&mdio1>;
 			phy_address = <28>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-ax850.dts
@@ -81,14 +81,14 @@
 
 	qcom,port_phyinfo {
 		// MAC0 -> GE Phy
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
 		};
 
 		// MAC1 -> Uniphy --- SGMII --- QCA8081
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			mdiobus = <&mdio1>;
 			phy_address = <28>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-gl-b3000.dts
@@ -64,14 +64,14 @@
 
 	qcom,port_phyinfo {
 		// MAC0 -> GE Phy -> QCA8337 Phy2
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
 		};
 
 		// MAC1 ---SGMII---> QCA8337 SerDes
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			forced-speed = <1000>;
 			forced-duplex = <1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mr5500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mr5500.dts
@@ -55,14 +55,14 @@
 
 	qcom,port_phyinfo {
 		// MAC0 -> GE Phy
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
 		};
 
 		// MAC1 ---SGMII---> QCA8337 SerDes
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			forced-speed = <1000>;
 			forced-duplex = <1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx2000.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx2000.dts
@@ -36,14 +36,14 @@
 
 	qcom,port_phyinfo {
 		// MAC0 -> GE Phy -> QCA8337 Phy4
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
 		};
 
 		// MAC1 ---SGMII---> QCA8337 SerDes
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			forced-speed = <1000>;
 			forced-duplex = <1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx5500.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx5500.dts
@@ -35,14 +35,14 @@
 
 	qcom,port_phyinfo {
 		// MAC0 -> GE Phy -> QCA8337 Phy4
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
 		};
 
 		// MAC1 ---SGMII---> QCA8337 SerDes
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			forced-speed = <1000>;
 			forced-duplex = <1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx6200.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-mx6200.dts
@@ -39,14 +39,14 @@
 
 	qcom,port_phyinfo {
 		// MAC0 -> GE Phy -> MDI --> RJ45
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
 		};
 
 		// MAC1 ---SGMII---> MaxLinear PHY -> RJ45
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			mdiobus = <&mdio1>;
 			phy_address = <15>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-pz-l8.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-pz-l8.dts
@@ -143,14 +143,14 @@
 
 	qcom,port_phyinfo {
 		// MAC0 -> GE Phy --- MDI --- QCA8337 Phy4(Port5)
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
 		};
 
 		// MAC1 -> Uniphy --- SGMII --- QCA8337 SerDes(Port6)
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			mdiobus = <&mdio1>;
 			forced-speed = <1000>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-scr50axe.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-scr50axe.dts
@@ -140,13 +140,13 @@
 
 	qcom,port_phyinfo {
 
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
 		};
 
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			forced-speed = <1000>;
 			forced-duplex = <1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-spnmx56.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-spnmx56.dts
@@ -38,7 +38,7 @@
 
 	qcom,port_phyinfo {
 		// MAC0 -> GE Phy --- MDI --- QCA8337 Switch
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
@@ -46,7 +46,7 @@
 		};
 
 		// MAC1 -> Uniphy --- SGMII --- QCA8081
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			mdiobus = <&mdio1>;
 			phy_address = <28>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wn-dax3000gr.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wn-dax3000gr.dts
@@ -200,13 +200,13 @@
 	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
 
 	qcom,port_phyinfo {
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
 		};
 
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			forced-speed = <1000>;
 			forced-duplex = <1>;

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wrc-x3000gs2.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq5018-wrc-x3000gs2.dts
@@ -194,13 +194,13 @@
 	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
 
 	qcom,port_phyinfo {
-		port@0 {
+		port@1 {
 			port_id = <1>;
 			mdiobus = <&mdio0>;
 			phy_address = <7>;
 		};
 
-		port@1 {
+		port@2 {
 			port_id = <2>;
 			forced-speed = <1000>;
 			forced-duplex = <1>;


### PR DESCRIPTION
Match the unit address of both QSDK switch ports with the node's port_id
property. Purely cleanup, no functional change.