### PR TITLE
kernel: add kernel.org tarball signature verification

### DIFF
--- a/include/kernel-version.mk
+++ b/include/kernel-version.mk
@@ -49,3 +49,6 @@ KERNEL_PATCHVER ?= $(KERNEL)
 # disable the md5sum check for unknown kernel versions
 LINUX_KERNEL_HASH:=$(LINUX_KERNEL_HASH-$(strip $(LINUX_VERSION)))
 LINUX_KERNEL_HASH?=x
+
+# enable kernel signature verification for all targets
+KERNEL_VERIFY_SIG:=1

--- a/scripts/verify-kernel-tar-signature.sh
+++ b/scripts/verify-kernel-tar-signature.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Usage: verify-kernel-tar-signature.sh <tarball> <signfile>
+
+set -eu
+
+tarball="$1"
+signfile="$2"
+
+case "$tarball" in
+  *.tar.xz)  decomp="xz -cd"    ;;
+  *.tar.gz)  decomp="gzip -cd"  ;;
+  *.tar.bz2) decomp="bzip2 -cd" ;;
+  *.tar.zst) decomp="zstd -cd"  ;;
+  *)
+    echo "Unsupported kernel tarball format: $tarball" >&2
+    exit 1
+    ;;
+esac
+
+$decomp "$tarball" | gpg --verify "$signfile" -
+


### PR DESCRIPTION
Introduce support for verifying upstream kernel source tarballs using kernel.org stream signatures. This adds the corresponding .tar.sign file to the kernel source downloads and performs signature verification during `Kernel/Prepare`, before unpacking the tarball.

This ensures that kernel sources are authenticated prior to applying OpenWrt patches or performing any build steps, and causes the build to fail early if the signature is missing or invalid.

Changes:
 - download `linux-$(VERSION).tar.sign` alongside the kernel tarball
 - add a verification hook to `Kernel/Prepare`
 - abort the build on signature verification failure

This improves supply‑chain integrity for all targets without altering the existing kernel workflow.