### PR TITLE
apk: packages names hell

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -218,6 +218,15 @@ define KernelPackage
     $(call KernelPackage/$(1))
     $(call KernelPackage/$(1)/$(BOARD))
     $(call KernelPackage/$(1)/$(BOARD)/$(SUBTARGET))
+
+    # Add an implicit self-provide. apk can't handle self provides, be it
+    # versioned or virtual, so opt for a prefix and a suffix instead. Package
+    # name without a prefix/suffix is too generic and might conflict with other
+    # packages, e.g. wireguard. This allows several variants to provide the same
+    # virtual package without adding extra provides to the default one, e.g.
+    # r8169 implicitly provides kmod-r8169-any and is marked as default, so
+    # r8125 can explicitly provide @kmod-r8169-any as well.
+    PROVIDES+=@kmod-$(1)-any
   endef
 
   ifdef KernelPackage/$(1)/conffiles

--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -218,15 +218,6 @@ define KernelPackage
     $(call KernelPackage/$(1))
     $(call KernelPackage/$(1)/$(BOARD))
     $(call KernelPackage/$(1)/$(BOARD)/$(SUBTARGET))
-
-    # Add an implicit self-provide. apk can't handle self provides, be it
-    # versioned or virtual, so opt for a prefix and a suffix instead. Package
-    # name without a prefix/suffix is too generic and might conflict with other
-    # packages, e.g. wireguard. This allows several variants to provide the same
-    # virtual package without adding extra provides to the default one, e.g.
-    # r8169 implicitly provides kmod-r8169-any and is marked as default, so
-    # r8125 can explicitly provide @kmod-r8169-any as well.
-    PROVIDES+=@kmod-$(1)-any
   endef
 
   ifdef KernelPackage/$(1)/conffiles

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -461,7 +461,7 @@ else
 	    $(1)$$(ABIV_$(1))[conflict]=$(VERSION) \
 	    $(if $(CONFLICTS),$(foreach conflict,$(CONFLICTS), $(conflict)$$(ABIV_$(1))[conflict]=0.0.0)) \
 	    )" \
-	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100",$(if $(PROVIDES),--info "provider-priority:1")) \
+	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100",$(if $(findstring kernel/linux,$(SOURCE)),--info "provider-priority:50",--info "provider-priority:1")) \
 	  $$(APK_SCRIPTS_$(1)) \
 	  --info "depends:$$(foreach depends,$$(subst $$(comma),$$(space),$$(subst $$(space),,$$(subst $$(paren_right),,$$(subst $$(paren_left),,$$(Package/$(1)/DEPENDS))))),$$(depends))" \
 	  --files "$$(IDIR_$(1))" \

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -245,29 +245,6 @@ $(strip
 )
 endef
 
-# Get apk provider priority
-#
-# - if a package is marked as a default variant, set it to 100.
-#
-# - if a package has an ABI version defined, set it to 10.
-#   The enables packages with an ABI version to be installed by their base name
-#   instead of a name and an ABI version, e.g.:
-#   libfoo3, where 3 is the ABI version can be installed by just libfoo.
-#   This affects manual installation only, as the dependency resolution takes
-#   care of ABI versions.
-#
-# - otherwise return nothing, i.e. package will have the default priority 0.
-#
-# 1: Default variant
-# 2: ABI version
-define GetProviderPriority
-$(strip
-  $(if $(1),100,
-    $(if $(2),10)
-  )
-)
-endef
-
 ifneq ($(PKG_NAME),toolchain)
   define CheckDependencies
 	@( \
@@ -407,7 +384,6 @@ endif
       Package/$(1)/PROVIDES := $$(filter-out $(1)$$(ABIV_$(1)),$$(Package/$(1)/PROVIDES)$$(if $$(ABIV_$(1)), $(1) $$(foreach provide,$$(Package/$(1)/PROVIDES),$$(provide)$$(ABIV_$(1)))))
     else
       Package/$(1)/PROVIDES := $$(call FormatProvides,$(1),$(VERSION),$(ABI_VERSION),$(PROVIDES))
-      Package/$(1)/PRIORITY := $$(call GetProviderPriority,$(DEFAULT_VARIANT),$(ABI_VERSION))
     endif
 
 $(_define) Package/$(1)/CONTROL
@@ -601,7 +577,7 @@ else
 	  --info "url:$(URL)" \
 	  --info "maintainer:$(MAINTAINER)" \
 	  $$(if $$(Package/$(1)/PROVIDES),--info "provides:$$(Package/$(1)/PROVIDES)") \
-	  $$(if $$(Package/$(1)/PRIORITY),--info "provider-priority:$$(Package/$(1)/PRIORITY)") \
+	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100") \
 	  $$(APK_SCRIPTS_$(1)) \
 	  --info "depends:$$(foreach depends,$$(subst $$(comma),$$(space),$$(subst $$(space),,$$(subst $$(paren_right),,$$(subst $$(paren_left),,$$(Package/$(1)/DEPENDS))))),$$(depends))" \
 	  --files "$$(IDIR_$(1))" \

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -453,13 +453,14 @@ else
 	  --info "origin:$(SOURCE)" \
 	  --info "url:$(URL)" \
 	  --info "maintainer:$(MAINTAINER)" \
-	  --info "provides:$$(if $$(ABIV_$(1)), \
-	    $(1) $(foreach provide,$(PROVIDES), $(provide)$$(ABIV_$(1))=$(VERSION)), \
-	    $(if $(ALTERNATIVES), \
-	      $(PROVIDES), \
-	      $(foreach provide,$(PROVIDES), $(provide)=$(VERSION)) \
+	  --info "provides:$(strip \
+	    $$(if $$(ABIV_$(1)), \
+	      $(1)$(foreach provide,$(PROVIDES), $(provide) $(provide)$(call FormatABISuffix,$(provide),$(ABI_VERSION))=$(VERSION)), \
+	      $(foreach provide,$(filter-out $(1),$(PROVIDES)), $(provide)) \
 	    ) \
-	  )" \
+	    $(1)$$(ABIV_$(1))[conflict]=$(VERSION) \
+	    $(if $(CONFLICTS),$(foreach conflict,$(CONFLICTS), $(conflict)$$(ABIV_$(1))[conflict]=0.0.0)) \
+	    )" \
 	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100",$(if $(PROVIDES),--info "provider-priority:1")) \
 	  $$(APK_SCRIPTS_$(1)) \
 	  --info "depends:$$(foreach depends,$$(subst $$(comma),$$(space),$$(subst $$(space),,$$(subst $$(paren_right),,$$(subst $$(paren_left),,$$(Package/$(1)/DEPENDS))))),$$(depends))" \

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -130,22 +130,11 @@ endef
 # Format provide and add ABI and version if it's not a virtual provide marked
 # with an @.
 #
-# Same as for the base package name, if ABI version is set, provide both
-# unversioned provide and one with ABI version and version.
-#
 # 1: provide name
 # 2: provide version
-# 3: (optional) ABI version
+# 3: (optional) ABI preformatted by FormatABISuffix
 define AddProvide
-$(strip
-  $(if $(filter @%,$(1)),
-    $(patsubst @%,%,$(1)),
-    $(if $(3),
-      $(1) $(1)$(call FormatABISuffix,$(1),$(3))=$(2),
-      $(1)=$(2)
-    )
-  )
-)
+$(if $(filter @%,$(1)),$(patsubst @%,%,$(1)),$(1)$(3)=$(2))
 endef
 
 # Remove virtual provides prefix and self. apk doesn't like it when packages
@@ -169,14 +158,9 @@ endef
 #     at the same time
 #   - additionally provide `${package_name}` so multiple packages can be looked
 #     up by its base name
-#   - for each `provides`:
-#     - provide `${provide}${ABI_version}=${package_version}`
-#       this implies that only one version of a provide can be installed at the
-#       same time
-#     - if a `provide` ends in a number, the `ABI_version` will be prefixed with
-#       a - sign, e.g.: provide1-0
-#     - additionally provide `${provide}` so multiple packages can be looked up
-#       by its base name
+#   - for each `provides`, provide `${provide}${ABI_version}=${package_version}`
+#     this implies that only one version of a provide can be installed at the
+#     same time
 #
 # - else if ABI version is _not_ defined
 #   - package is named `${package_name}`
@@ -229,17 +213,16 @@ endef
 #
 # 1: package name
 # 2: package version
-# 3: ABI version
-# 4: list of provides
+# 3: list of provides
 define FormatProvides
 $(strip
-  $(if $(call FormatABISuffix,$(1),$(3)),
+  $(if $(ABIV_$(1)),
     $(1) $(foreach provide,
-      $(filter-out $(1),$(4)),
-      $(call AddProvide,$(provide),$(2),$(3))
+      $(filter-out $(1),$(3)),
+      $(call AddProvide,$(provide),$(2),$(ABIV_$(1)))
     ),
     $(foreach provide,
-      $(filter-out $(1),$(4)),
+      $(filter-out $(1),$(3)),
       $(call AddProvide,$(provide),$(2))
     )
   )
@@ -384,7 +367,7 @@ endif
       Package/$(1)/PROVIDES := $$(patsubst @%,%,$(PROVIDES))
       Package/$(1)/PROVIDES := $$(filter-out $(1)$$(ABIV_$(1)),$$(Package/$(1)/PROVIDES)$$(if $$(ABIV_$(1)), $(1) $$(foreach provide,$$(Package/$(1)/PROVIDES),$$(provide)$$(ABIV_$(1)))))
     else
-      Package/$(1)/PROVIDES := $$(call FormatProvides,$(1),$(VERSION),$(ABI_VERSION),$(PROVIDES))
+      Package/$(1)/PROVIDES := $$(call FormatProvides,$(1),$(VERSION),$(PROVIDES))
     endif
 
 $(_define) Package/$(1)/CONTROL

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -344,12 +344,7 @@ endif
       Package/$(1)/DEPENDS := $$(call mergelist,$$(Package/$(1)/DEPENDS))
     endif
 
-    ifeq ($(CONFIG_USE_APK),)
-      Package/$(1)/PROVIDES := $$(patsubst @%,%,$(PROVIDES))
-      Package/$(1)/PROVIDES := $$(filter-out $(1)$$(ABIV_$(1)),$$(Package/$(1)/PROVIDES)$$(if $$(ABIV_$(1)), $(1) $$(foreach provide,$$(Package/$(1)/PROVIDES),$$(provide)$$(ABIV_$(1)))))
-    else
-      Package/$(1)/PROVIDES := $$(call FormatProvides,$(1),$(VERSION),$(PROVIDES),$(ALTERNATIVES))
-    endif
+    Package/$(1)/PROVIDES := $$(call FormatProvides,$(1),$(VERSION),$(PROVIDES),$(ALTERNATIVES))
 
 $(_define) Package/$(1)/CONTROL
 Package: $(1)$$(ABIV_$(1))

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -127,25 +127,6 @@ $(strip
 )
 endef
 
-# Format provide and add ABI and version if it's not a virtual provide marked
-# with an @.
-#
-# 1: provide name
-# 2: provide version
-# 3: (optional) ABI preformatted by FormatABISuffix
-define AddProvide
-$(if $(filter @%,$(1)),$(patsubst @%,%,$(1)),$(1)$(3)=$(2))
-endef
-
-# Remove virtual provides prefix and self. apk doesn't like it when packages
-# specify a redundant provide pointing to self.
-#
-# 1: package name
-# 2: list of provides
-define SanitizeProvides
-$(filter-out $(1),$(patsubst @%,%,$(2)))
-endef
-
 # Format provides both for apk and control
 #
 # - If ABI version is defined:
@@ -176,33 +157,16 @@ endef
 #       this implies that only one version of a provide can be installed at the
 #       same time
 #
-# - Both with and without an ABI, if a provide starts with an @, treat it as a
-#   virtual provide, that doesn't own the name by not appending version.
-#   Multiple packages with the same virtual provides can be installed
-#   side-by-side.
-#
-# - apk doesn't like it when packages specify a redundant provide pointing to
-#   self. Filter it out, but keep virtual self provides, in the form of
-#   @${package_name}-any.
-#
-# - Packages implicitly add a virtual @${package_name}-any provide in Package.
-#
 # 1: package name
 # 2: package version
 # 3: list of provides
 # 4: list of alternatives
 define FormatProvides
 $(strip $(if $(ABIV_$(1)), \
-  $(1) $(foreach provide, \
-    $(filter-out $(1),$(3)), \
-    $(call AddProvide,$(provide),$(2),$(ABIV_$(1))) \
-  ), \
+  $(1) $(foreach provide,$(3), $(provide)$(ABIV_$(1))=$(2)), \
   $(if $(4), \
-    $(filter-out $(1),$(3)), \
-    $(foreach provide, \
-      $(filter-out $(1),$(3)), \
-      $(call AddProvide,$(provide),$(2)) \
-    ) \
+    $(3), \
+    $(foreach provide,$(3), $(provide)=$(2)) \
   ) \
 ))
 endef
@@ -322,7 +286,7 @@ endif
 	$(if $(ABI_VERSION),echo '$(ABI_VERSION)' | cmp -s - $(PKG_INFO_DIR)/$(1).version || { \
 		mkdir -p $(PKG_INFO_DIR); \
 		echo '$(ABI_VERSION)' > $(PKG_INFO_DIR)/$(1).version; \
-		$(foreach pkg,$(call SanitizeProvides,$(1),$(PROVIDES)), \
+		$(foreach pkg,$(filter-out $(1),$(PROVIDES)), \
 			cp $(PKG_INFO_DIR)/$(1).version $(PKG_INFO_DIR)/$(pkg).version; \
 		) \
 	} )
@@ -392,7 +356,7 @@ endif
 			fi; \
 		done; $(Package/$(1)/extra_provides) \
 	) | sort -u > $(PKG_INFO_DIR)/$(1).provides
-	$(if $(PROVIDES),@for pkg in $(call SanitizeProvides,$(1),$(PROVIDES)); do cp $(PKG_INFO_DIR)/$(1).provides $(PKG_INFO_DIR)/$$$$pkg.provides; done)
+	$(if $(PROVIDES),@for pkg in $(filter-out $(1),$(PROVIDES)); do cp $(PKG_INFO_DIR)/$(1).provides $(PKG_INFO_DIR)/$$$$pkg.provides; done)
 	$(CheckDependencies)
 
 	$(RSTRIP) $$(IDIR_$(1))

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -195,9 +195,10 @@ endef
 #   self. Filter it out, but keep virtual self provides, in the form of
 #   @(kmod-)?${package_name}-any.
 #
-# - Packages implicitly add a virtual @${package_name}-any provide in Package,
-#   which implies that kmods, which are also packages, will have a virtual
-#   @kmod-${package_name}-any provide.
+# - Packages implicitly add a virtual @${package_name}-any provide in Package.
+#
+# - kmods implicitly add a virtual @kmod-${package_name}-any provide in
+#   KernelPackage.
 #
 # - Aside from the two aforementioned implicit provides, packages are expected
 #   to manage their provides themselves.

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -542,7 +542,7 @@ else
 	  --info "url:$(URL)" \
 	  --info "maintainer:$(MAINTAINER)" \
 	  $$(if $$(Package/$(1)/PROVIDES),--info "provides:$$(Package/$(1)/PROVIDES)") \
-	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100") \
+	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100",$(if $(PROVIDES),--info "provider-priority:1")) \
 	  $$(APK_SCRIPTS_$(1)) \
 	  --info "depends:$$(foreach depends,$$(subst $$(comma),$$(space),$$(subst $$(space),,$$(subst $$(paren_right),,$$(subst $$(paren_left),,$$(Package/$(1)/DEPENDS))))),$$(depends))" \
 	  --files "$$(IDIR_$(1))" \

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -167,8 +167,14 @@ endef
 #   - package implicitly provides `${package_name}=${package_version}`
 #     this implies that only one version of a package can be installed at the
 #     same time
-#   - for each `provides`, provide `${provide}=${package_version}` this implies
-#     that only one version of a provide can be installed at the same time
+#   - if `alternatives` is defined
+#     - for each `provides`, provide `${provide}`
+#       this implies that multiple versions of a provide can be installed at the
+#       same time
+#   - else if `alternatives` is _not_ defined
+#     - for each `provides`, provide `${provide}=${package_version}`
+#       this implies that only one version of a provide can be installed at the
+#       same time
 #
 # - Both with and without an ABI, if a provide starts with an @, treat it as a
 #   virtual provide, that doesn't own the name by not appending version.
@@ -184,49 +190,24 @@ endef
 # - kmods implicitly add a virtual @kmod-${package_name}-any provide in
 #   KernelPackage.
 #
-# - Aside from the two aforementioned implicit provides, packages are expected
-#   to manage their provides themselves.
-#
-# - When multiple variants inside the same package have the same provide, a
-#   default variant must be set using DEFAULT_VARIANT:=1.
-#
-# - Cross-package provides must be virtual and a default variant must be set. If
-#   different packages provide the same versioned (i.e. non-virtual) provide the
-#   package with a higher version will be preferred, which results in unintended
-#   behavior, because the order might change with package updates.
-#
-#   Example:
-#   - both uclient-fetch and wget provide wget
-#   - wget doesn't have a default variant called wget that would provide an
-#     implicit @wget-any
-#     - add wget to PROVIDES for both wget-ssl and wget-nossl variants so they
-#       can't be installed at the same time
-#     - add @wget-any to both packages so packages outside of wget can provide
-#       it
-#   - uclient-fetch has only one variant
-#     - add @wget-any to PROVIDES
-#     - mark uclient-fetch as the default variant using DEFAULT_VARIANT:=1
-#   - switch wget consumer that don't depend on a specific version like apk to
-#     depend on @wget-any
-#
-# - Alternatives don't affect the packaging.
-#
 # 1: package name
 # 2: package version
 # 3: list of provides
+# 4: list of alternatives
 define FormatProvides
-$(strip
-  $(if $(ABIV_$(1)),
-    $(1) $(foreach provide,
-      $(filter-out $(1),$(3)),
-      $(call AddProvide,$(provide),$(2),$(ABIV_$(1)))
-    ),
-    $(foreach provide,
-      $(filter-out $(1),$(3)),
-      $(call AddProvide,$(provide),$(2))
-    )
-  )
-)
+$(strip $(if $(ABIV_$(1)), \
+  $(1) $(foreach provide, \
+    $(filter-out $(1),$(3)), \
+    $(call AddProvide,$(provide),$(2),$(ABIV_$(1))) \
+  ), \
+  $(if $(4), \
+    $(filter-out $(1),$(3)), \
+    $(foreach provide, \
+      $(filter-out $(1),$(3)), \
+      $(call AddProvide,$(provide),$(2)) \
+    ) \
+  ) \
+))
 endef
 
 ifneq ($(PKG_NAME),toolchain)
@@ -367,7 +348,7 @@ endif
       Package/$(1)/PROVIDES := $$(patsubst @%,%,$(PROVIDES))
       Package/$(1)/PROVIDES := $$(filter-out $(1)$$(ABIV_$(1)),$$(Package/$(1)/PROVIDES)$$(if $$(ABIV_$(1)), $(1) $$(foreach provide,$$(Package/$(1)/PROVIDES),$$(provide)$$(ABIV_$(1)))))
     else
-      Package/$(1)/PROVIDES := $$(call FormatProvides,$(1),$(VERSION),$(PROVIDES))
+      Package/$(1)/PROVIDES := $$(call FormatProvides,$(1),$(VERSION),$(PROVIDES),$(ALTERNATIVES))
     endif
 
 $(_define) Package/$(1)/CONTROL

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -92,38 +92,38 @@ endef
 # 1: list of dependencies
 # 2: list of extra dependencies
 define FormatDepends
-$(strip
-  $(eval _COMMA_SEP := __COMMA_SEP__)
-  $(eval _SPACE_SEP := __SPACE_SEP__)
-  $(eval _DEPENDS := $(1))
-  $(eval _EXTRA_DEPENDS_ABI := )
-  $(eval _DEP_ITEMS := $(subst $(_COMMA_SEP),$(space),$(subst $(space),$(_SPACE_SEP),$(subst $(comma),$(_COMMA_SEP),$(2)))))
-
-  $(foreach dep,$(_DEP_ITEMS),
-    $(eval _EXTRA_DEP := )
-    $(eval _CUR_DEP := $(subst $(_SPACE_SEP),$(space),$(strip $(dep))))
-    $(eval _PKG_NAME := $(word 1,$(_CUR_DEP)))
-    $(if $(findstring $(paren_left), $(_PKG_NAME)),
-      $(error "Unsupported extra dependency format: no space before '(': $(_CUR_DEP)"))
-    )
-    $(eval _ABI_SUFFIX := $(call GetABISuffix,$(_PKG_NAME)))
-    $(eval _PKG_NAME_ABI := $(_PKG_NAME)$(_ABI_SUFFIX))
-    $(eval _VERSION_CONSTRAINT := $(word 2,$(_CUR_DEP)))
-    $(if $(_VERSION_CONSTRAINT),
-      $(eval _EXTRA_DEP := $(_PKG_NAME_ABI) $(_VERSION_CONSTRAINT)),
-      $(error "Extra dependencies must have version constraints. $(_PKG_NAME) seems to be unversioned.")
-    )
-    $(if $(and $(_EXTRA_DEPENDS_ABI),$(_EXTRA_DEP)),
-      $(eval _EXTRA_DEPENDS_ABI := $(_EXTRA_DEPENDS_ABI)$(comma)$(_EXTRA_DEP)),
-      $(eval _EXTRA_DEPENDS_ABI := $(_EXTRA_DEP))
-    )
-    $(if $(_DEPENDS),
-      $(eval _DEPENDS := $(filter-out $(_PKG_NAME_ABI),$(_DEPENDS)))
-    )
-  )
-
-  $(eval _DEPENDS := $(call mergelist,$(_DEPENDS)))
-  $(_EXTRA_DEPENDS_ABI)$(if $(_DEPENDS),$(comma) $(_DEPENDS))
+$(strip \
+  $(eval _COMMA_SEP := __COMMA_SEP__) \
+  $(eval _SPACE_SEP := __SPACE_SEP__) \
+  $(eval _DEPENDS := $(1)) \
+  $(eval _EXTRA_DEPENDS_ABI := ) \
+  $(eval _DEP_ITEMS := $(subst $(_COMMA_SEP),$(space),$(subst $(space),$(_SPACE_SEP),$(subst $(comma),$(_COMMA_SEP),$(2))))) \
+ \
+  $(foreach dep,$(_DEP_ITEMS), \
+    $(eval _EXTRA_DEP := ) \
+    $(eval _CUR_DEP := $(subst $(_SPACE_SEP),$(space),$(strip $(dep)))) \
+    $(eval _PKG_NAME := $(word 1,$(_CUR_DEP))) \
+    $(if $(findstring $(paren_left), $(_PKG_NAME)), \
+      $(error "Unsupported extra dependency format: no space before '(': $(_CUR_DEP)")) \
+    ) \
+    $(eval _ABI_SUFFIX := $(call GetABISuffix,$(_PKG_NAME))) \
+    $(eval _PKG_NAME_ABI := $(_PKG_NAME)$(_ABI_SUFFIX)) \
+    $(eval _VERSION_CONSTRAINT := $(word 2,$(_CUR_DEP))) \
+    $(if $(_VERSION_CONSTRAINT), \
+      $(eval _EXTRA_DEP := $(_PKG_NAME_ABI) $(_VERSION_CONSTRAINT)), \
+      $(error "Extra dependencies must have version constraints. $(_PKG_NAME) seems to be unversioned.") \
+    ) \
+    $(if $(and $(_EXTRA_DEPENDS_ABI),$(_EXTRA_DEP)), \
+      $(eval _EXTRA_DEPENDS_ABI := $(_EXTRA_DEPENDS_ABI)$(comma)$(_EXTRA_DEP)), \
+      $(eval _EXTRA_DEPENDS_ABI := $(_EXTRA_DEP)) \
+    ) \
+    $(if $(_DEPENDS), \
+      $(eval _DEPENDS := $(filter-out $(_PKG_NAME_ABI),$(_DEPENDS))) \
+    ) \
+  ) \
+ \
+  $(eval _DEPENDS := $(call mergelist,$(_DEPENDS))) \
+  $(_EXTRA_DEPENDS_ABI)$(if $(_DEPENDS),$(comma) $(_DEPENDS)) \
 )
 endef
 

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -183,12 +183,9 @@ endef
 #
 # - apk doesn't like it when packages specify a redundant provide pointing to
 #   self. Filter it out, but keep virtual self provides, in the form of
-#   @(kmod-)?${package_name}-any.
+#   @${package_name}-any.
 #
 # - Packages implicitly add a virtual @${package_name}-any provide in Package.
-#
-# - kmods implicitly add a virtual @kmod-${package_name}-any provide in
-#   KernelPackage.
 #
 # 1: package name
 # 2: package version

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -127,50 +127,6 @@ $(strip
 )
 endef
 
-# Format provides both for apk and control
-#
-# - If ABI version is defined:
-#   - package is named `${package_name}${ABI_version}`
-#     if a `package_name` ends in a number, the `ABI_version` will be prefixed
-#     with a - sign, e.g.: libsqlite3-0
-#   - package implicitly provides
-#     `${package_name}${ABI_version}=${package_version}`
-#     this implies that only one version of a package per ABI can be installed
-#     at the same time
-#   - additionally provide `${package_name}` so multiple packages can be looked
-#     up by its base name
-#   - for each `provides`, provide `${provide}${ABI_version}=${package_version}`
-#     this implies that only one version of a provide can be installed at the
-#     same time
-#
-# - else if ABI version is _not_ defined
-#   - package is named `${package_name}`
-#   - package implicitly provides `${package_name}=${package_version}`
-#     this implies that only one version of a package can be installed at the
-#     same time
-#   - if `alternatives` is defined
-#     - for each `provides`, provide `${provide}`
-#       this implies that multiple versions of a provide can be installed at the
-#       same time
-#   - else if `alternatives` is _not_ defined
-#     - for each `provides`, provide `${provide}=${package_version}`
-#       this implies that only one version of a provide can be installed at the
-#       same time
-#
-# 1: package name
-# 2: package version
-# 3: list of provides
-# 4: list of alternatives
-define FormatProvides
-$(strip $(if $(ABIV_$(1)), \
-  $(1) $(foreach provide,$(3), $(provide)$(ABIV_$(1))=$(2)), \
-  $(if $(4), \
-    $(3), \
-    $(foreach provide,$(3), $(provide)=$(2)) \
-  ) \
-))
-endef
-
 ifneq ($(PKG_NAME),toolchain)
   define CheckDependencies
 	@( \
@@ -305,14 +261,14 @@ endif
       Package/$(1)/DEPENDS := $$(call mergelist,$$(Package/$(1)/DEPENDS))
     endif
 
-    Package/$(1)/PROVIDES := $$(call FormatProvides,$(1),$(VERSION),$(PROVIDES),$(ALTERNATIVES))
+    $$(info $(1) fused dependencies: $$(Package/$(1)/DEPENDS))
 
 $(_define) Package/$(1)/CONTROL
 Package: $(1)$$(ABIV_$(1))
 Version: $(VERSION)
 $$(call addfield,Depends,$$(Package/$(1)/DEPENDS)
 )$$(call addfield,Conflicts,$$(call mergelist,$(CONFLICTS))
-)$$(call addfield,Provides,$$(call mergelist,$$(Package/$(1)/PROVIDES))
+)$$(call addfield,Provides,$$(call mergelist,$$(filter-out $(1)$$(ABIV_$(1)),$(PROVIDES)$$(if $$(ABIV_$(1)), $(1) $(foreach provide,$(PROVIDES),$(provide)$$(ABIV_$(1))))))
 )$$(call addfield,Alternatives,$$(call mergelist,$(ALTERNATIVES))
 )$$(call addfield,Source,$(SOURCE)
 )$$(call addfield,SourceName,$(PKG_NAME)
@@ -497,7 +453,13 @@ else
 	  --info "origin:$(SOURCE)" \
 	  --info "url:$(URL)" \
 	  --info "maintainer:$(MAINTAINER)" \
-	  $$(if $$(Package/$(1)/PROVIDES),--info "provides:$$(Package/$(1)/PROVIDES)") \
+	  --info "provides:$$(if $$(ABIV_$(1)), \
+	    $(1) $(foreach provide,$(PROVIDES), $(provide)$$(ABIV_$(1))=$(VERSION)), \
+	    $(if $(ALTERNATIVES), \
+	      $(PROVIDES), \
+	      $(foreach provide,$(PROVIDES), $(provide)=$(VERSION)) \
+	    ) \
+	  )" \
 	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100",$(if $(PROVIDES),--info "provider-priority:1")) \
 	  $$(APK_SCRIPTS_$(1)) \
 	  --info "depends:$$(foreach depends,$$(subst $$(comma),$$(space),$$(subst $$(space),,$$(subst $$(paren_right),,$$(subst $$(paren_left),,$$(Package/$(1)/DEPENDS))))),$$(depends))" \

--- a/include/package.mk
+++ b/include/package.mk
@@ -337,7 +337,7 @@ define BuildPackage
   # variants to provide the same virtual package without adding extra provides
   # to the default one, e.g. wget implicitly provides wget-any and is marked as
   # default, so wget-ssl can explicitly provide @wget-any as well.
-  $(eval PROVIDES:=$(strip @$(1)-any $(PROVIDES)))
+  PROVIDES+=@$(1)-any
 
 ifndef Package/$(1)/description
 define Package/$(1)/description

--- a/include/package.mk
+++ b/include/package.mk
@@ -332,13 +332,6 @@ define BuildPackage
   $(eval $(Package/Default))
   $(eval $(Package/$(1)))
 
-  # Add an implicit self-provide. apk can't handle self provides, be it
-  # versioned or virtual, so opt for a suffix instead. This allows several
-  # variants to provide the same virtual package without adding extra provides
-  # to the default one, e.g. wget implicitly provides wget-any and is marked as
-  # default, so wget-ssl can explicitly provide @wget-any as well.
-  PROVIDES+=@$(1)-any
-
 ifndef Package/$(1)/description
 define Package/$(1)/description
 	$(TITLE)

--- a/package/kernel/ath10k-ct/Makefile
+++ b/package/kernel/ath10k-ct/Makefile
@@ -34,7 +34,7 @@ define KernelPackage/ath10k-ct
 	$(PKG_BUILD_DIR)/ath10k$(CT_KVER)/ath10k_pci.ko \
 	$(PKG_BUILD_DIR)/ath10k$(CT_KVER)/ath10k_core.ko
   AUTOLOAD:=$(call AutoProbe,ath10k_pci)
-  PROVIDES:=@kmod-ath10k-any
+  PROVIDES:=kmod-ath10k
   VARIANT:=regular
 endef
 

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1224,7 +1224,6 @@ define KernelPackage/r8169
     CONFIG_R8169_LEDS=y
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/realtek/r8169.ko
   AUTOLOAD:=$(call AutoProbe,r8169,1)
-  DEFAULT_VARIANT:=1
 endef
 
 define KernelPackage/r8169/description

--- a/package/kernel/mac80211/ath.mk
+++ b/package/kernel/mac80211/ath.mk
@@ -265,7 +265,7 @@ This module adds support for wireless adapters based on
 Atheros USB AR9271 and AR7010 family of chipsets.
 endef
 
-define KernelPackage/ath10k/Default
+define KernelPackage/ath10k
   $(call KernelPackage/mac80211/Default)
   TITLE:=Atheros 802.11ac wireless cards support
   URL:=https://wireless.wiki.kernel.org/en/users/drivers/ath10k
@@ -276,12 +276,7 @@ define KernelPackage/ath10k/Default
 	$(PKG_BUILD_DIR)/drivers/net/wireless/ath/ath10k/ath10k_pci.ko
   AUTOLOAD:=$(call AutoProbe,ath10k_core ath10k_pci)
   MODPARAMS.ath10k_core:=frame_mode=2
-endef
-
-define KernelPackage/ath10k
-  $(call KernelPackage/ath10k/Default)
   VARIANT:=regular
-  DEFAULT_VARIANT:=1
 endef
 
 define KernelPackage/ath10k/description
@@ -304,10 +299,9 @@ define KernelPackage/ath10k/config
 endef
 
 define KernelPackage/ath10k-smallbuffers
-  $(call KernelPackage/ath10k/Default)
+  $(call KernelPackage/ath10k)
   TITLE+= (small buffers for low-RAM devices)
   VARIANT:=smallbuffers
-  PROVIDES:=@kmod-ath10k-any
 endef
 
 define KernelPackage/ath11k

--- a/package/kernel/r8101/Makefile
+++ b/package/kernel/r8101/Makefile
@@ -21,7 +21,7 @@ define KernelPackage/r8101
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8101.ko
   AUTOLOAD:=$(call AutoProbe,r8101,1)
-  PROVIDES:=@kmod-r8169-any
+  PROVIDES:=kmod-r8169
 endef
 
 define Build/Compile

--- a/package/kernel/r8125/Makefile
+++ b/package/kernel/r8125/Makefile
@@ -21,7 +21,7 @@ define KernelPackage/r8125
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8125.ko
   AUTOLOAD:=$(call AutoProbe,r8125,1)
-  PROVIDES:=@kmod-r8169-any
+  PROVIDES:=kmod-r8169
   VARIANT:=regular
   PKG_MAKE_FLAGS += CONFIG_ASPM=n
 endef

--- a/package/kernel/r8126/Makefile
+++ b/package/kernel/r8126/Makefile
@@ -21,7 +21,7 @@ define KernelPackage/r8126
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8126.ko
   AUTOLOAD:=$(call AutoProbe,r8126,1)
-  PROVIDES:=@kmod-r8169-any
+  PROVIDES:=kmod-r8169
   VARIANT:=regular
 endef
 

--- a/package/kernel/r8127/Makefile
+++ b/package/kernel/r8127/Makefile
@@ -21,7 +21,7 @@ define KernelPackage/r8127
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8127.ko
   AUTOLOAD:=$(call AutoProbe,r8127,1)
-  PROVIDES:=@kmod-r8169-any
+  PROVIDES:=kmod-r8169
   VARIANT:=regular
 endef
 

--- a/package/kernel/r8168/Makefile
+++ b/package/kernel/r8168/Makefile
@@ -21,7 +21,7 @@ define KernelPackage/r8168
   DEPENDS:=@PCI_SUPPORT +kmod-libphy
   FILES:=$(PKG_BUILD_DIR)/src/r8168.ko
   AUTOLOAD:=$(call AutoProbe,r8168,1)
-  PROVIDES:=@kmod-r8169-any
+  PROVIDES:=kmod-r8169
   VARIANT:=regular
 endef
 

--- a/package/kernel/rtl8812au-ct/Makefile
+++ b/package/kernel/rtl8812au-ct/Makefile
@@ -28,7 +28,7 @@ define KernelPackage/rtl8812au-ct
   FILES:=\
 	$(PKG_BUILD_DIR)/rtl8812au.ko
   AUTOLOAD:=$(call AutoProbe,rtl8812au)
-  PROVIDES:=@kmod-rtl8812au-any
+  PROVIDES:=kmod-rtl8812au
 endef
 
 NOSTDINC_FLAGS := \

--- a/package/libs/uclient/Makefile
+++ b/package/libs/uclient/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uclient
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uclient.git
@@ -34,8 +34,7 @@ define Package/uclient-fetch
   CATEGORY:=Network
   TITLE:=Tiny wget replacement using libuclient
   ALTERNATIVES:=200:/usr/bin/wget:/bin/uclient-fetch
-  DEFAULT_VARIANT:=1
-  PROVIDES:=@wget-any
+  PROVIDES:=wget
   DEPENDS:=+libuclient
 endef
 

--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git
@@ -26,7 +26,7 @@ define Package/apk/default
   SECTION:=base
   CATEGORY:=Base system
   TITLE:=apk package manager
-  DEPENDS:=+zlib +wget-any
+  DEPENDS:=+zlib +wget
   URL:=$(PKG_SOURCE_URL)
   PROVIDES:=apk
 endef

--- a/package/system/ca-certificates/Makefile
+++ b/package/system/ca-certificates/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ca-certificates
 PKG_VERSION:=20250419
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_MAINTAINER:=
 
 PKG_LICENSE:=GPL-2.0-or-later MPL-2.0
@@ -24,14 +24,12 @@ include $(INCLUDE_DIR)/package.mk
 TAR_OPTIONS+= --strip-components 1
 TAR_CMD=$(HOST_TAR) -C $(1) $(TAR_OPTIONS)
 
-# ca-certs is deprecated and new packages should use ca-certificates-any if
-# they don't need a specific package
 define Package/ca-certificates
   SECTION:=base
   CATEGORY:=Base system
   TITLE:=System CA certificates
   PKGARCH:=all
-  PROVIDES:=@ca-certs
+  PROVIDES:=ca-certs
 endef
 
 define Package/ca-bundle
@@ -39,7 +37,7 @@ define Package/ca-bundle
   CATEGORY:=Base system
   TITLE:=System CA certificates as a bundle
   PKGARCH:=all
-  PROVIDES:=@ca-certs @ca-certificates-any
+  PROVIDES:=ca-certs
 endef
 
 define Build/Install

--- a/scripts/metadata.pm
+++ b/scripts/metadata.pm
@@ -263,9 +263,6 @@ sub parse_package_metadata($) {
 		/^Default: \s*(.+)\s*$/ and $pkg->{default} = $1;
 		/^Provides: \s*(.+)\s*$/ and do {
 			my @vpkg = split /\s+/, $1;
-			foreach (@vpkg) {
-				s/^@//;
-			}
 			@{$pkg->{provides}} = ($pkg->{name}, @vpkg);
 			foreach my $vpkg (@vpkg) {
 				next if ($vpkg eq $pkg->{name});

--- a/scripts/package-metadata.pl
+++ b/scripts/package-metadata.pl
@@ -255,52 +255,6 @@ sub mconf_conflicts {
 	return $res;
 }
 
-sub add_implicit_provides_conflicts {
-	foreach my $provide (keys %vpackage) {
-		next if $provide =~ /-any$/;
-
-		my $providers = $vpackage{$provide};
-		next unless $providers && @$providers > 1;
-
-		my $default_pkg;
-		my @non_defaults;
-
-		foreach my $pkg (@$providers) {
-			next if $pkg->{buildonly};
-			if ($pkg->{variant_default}) {
-				$default_pkg = $pkg;
-			} else {
-				push @non_defaults, $pkg;
-			}
-		}
-
-		next unless $default_pkg && @non_defaults;
-
-		my %existing_conflicts;
-		if ($default_pkg->{conflicts}) {
-			%existing_conflicts = map { $_ => 1 } @{$default_pkg->{conflicts}};
-		}
-
-		foreach my $non_default (@non_defaults) {
-			next if $existing_conflicts{$non_default->{name}};
-
-			my $already_conflicts = 0;
-			if ($non_default->{conflicts}) {
-				foreach my $c (@{$non_default->{conflicts}}) {
-					if ($c eq $default_pkg->{name}) {
-						$already_conflicts = 1;
-						last;
-					}
-				}
-			}
-			next if $already_conflicts;
-
-			$default_pkg->{conflicts} ||= [];
-			push @{$default_pkg->{conflicts}}, $non_default->{name};
-		}
-	}
-}
-
 sub print_package_config_category($) {
 	my $cat = shift;
 	my %menus;
@@ -396,7 +350,6 @@ sub print_package_overrides() {
 
 sub gen_package_config() {
 	parse_package_metadata($ARGV[0]) or exit 1;
-	add_implicit_provides_conflicts();
 	print "menuconfig IMAGEOPT\n\tbool \"Image configuration\"\n\tdefault n\n";
 	print "source \"package/*/image-config.in\"\n";
 	if (scalar glob "package/feeds/*/*/image-config.in") {


### PR DESCRIPTION
Instead of arguing I will try to enumerate and explain what happens in each kind of the exposed/reported issues reported, in the commit's description I give more details.

> "apk"'s package selection logic for a given name will look for packages
> names and provides names and select the provider package following this
> logic:
> - Virtual names:
> If the provider-priority is the same for several providers the apk
> internal logic will select the provider in alphabetically order
> (provider's package name)[2][3].
> - Non-virtual(Versioned names):
> If the names are versioned apk will select the package with higher
> version but if the version is the exactly the same, apk will also use
> provider-priority to select the package, or the lower provider's package
> name in lexicographical order if the provider-priority is also the same.
> - Hybrid(Virtual name and versioned name):
> apk will select the package with versioned provider.

- `ca-bundle` and `ca-certificates` (ca-certs):
`ca-certs` is a virtual name(no VARIANTs defined) and both providers have the same provider-priority -> allowed side-by-side installation and ca-bundle will be selected because of lexicographical package name order

- in-kernel `kmod-r8169` and and `kmod-r81XX `out-kernel kernel packages: kmod-r8169 Will be selected because is the only provider providing a versioned kmod-r8169 name. kmod-* variants provide a virtual name so the versioned name has higher priority.
- The same for `kmod-ath10k` and variants
- `kmod-rtl8812au-ct`, here, it is the only provider of `kmod-rtl8812au` and as all packages has a provider-priority:1 it will be
selected by apk.

- dnsmasq and variants, jq, iw, ethtool and other similar packages with VARIANTs: ~apk will select the correct default variant because of lexicographical package
names order. VARIANTs provides a versioned(for conflict between variants) name(default variant name) so all providers
are versioned, all of them have the same version(same makefile package source) and if not DEFAULT_VARIANT=1 is defined they all will have the same provider-priority so apk will select the provider in lexicographical order by package name. (When DEFAULT_VARIANT is defined apk will select that provider).~ apk will select the correct default variant because other providers just provides a virtual name(non-versioned) and apk will select the versioned one.

- ALTERNATIVES cases: All provider will provide a virtual name so all of them can be installed side-by-side (even VARIANT are meant to be installed side-by-side since they not install conflictive file(overwrites) (i.e. uclient-fetch, wget-ssl, wget-nossl) with the actual code if you make "apk add wget" apk will not install anything since uclient-fetch is installed and it provides the virtual name "wget" but if uclient-fetch was not installed apk will select it because lexicographical order(uclient-fetch < wget-nossl < wget-ssl).
If you make "apk add gnu-wget" apk will install wget-nossl for the same reason.
*This case is a good example where DEFAULT_VARIANT does not fit because, there could be a DEFAULT_VARIANT defined in both uclient and wget makefiles and it will lost the meaning but ALTERNATIVES priority will fit very well(TO-DO) (although the default lexicographical order seem to match the desired order in this case again).

*We are overloading DEFAULT_VARIANT since it has nothing to do with packaging, in principle, since it was just meant for kconfig and to define the building directory VARIANT used for subpackages that do not define a VARIANT explicitly while the makefile they belong to define VARIANTS. Because of this the DEFAULT_VARIANT semantic only matches the provider-priority semantic when the VARIANT comes from a common package makefile.

~*Notice by georgesapkin, the ABI case need some love for the cases where the package name/provides ends in a number (i.e. sqlite3-0)?~ fixed.

EDIT: V2: Remove redundant conflicts definition, Use a new "namespace" to define explicit conflicts through versioned provides names (name[conflict]=version) to avoid affecting the "default" namespace, add a suffix "[conflict]" to indicate this special namespace.
All packages provides a "name[conflict]=version" and later the conflicts defined in CONFLICTS field are added as "name[conflict]=0.0.0" provides.

For me, the key question is if we need the addition of the new flag "@ -any" in provides or not, with all the new information gathered by @GeorgeSapkin and @efahl and everyone else what it seemed imposible now seems posible but I could be wrong so let's break this to check it. Regards.

Here you can check a cleaner diff https://github.com/map-b/openwrt/commits/apk-packages-name-PR-v2

------------------------------------
Despite the appeareance, this is only reverting the addition of the new flag and changes to PROVIDES semantic, that is:
- https://github.com/openwrt/openwrt/pull/21288
and
- https://github.com/openwrt/openwrt/pull/21369
  Except commits:
  - https://github.com/openwrt/openwrt/commit/779fa7ff6caa509d5df3827342162fdb07093cee ("build: refactor dependency formatting")
  - https://github.com/openwrt/openwrt/commit/8cc2743c4865607b67f9b4b2ecacb62e242abb20 ("elfutils: drop libelf1 provide")
  - https://github.com/openwrt/openwrt/commit/1dec4683f6a91cb0734e97186738b0ea413bb356 ("build: remove redundant shebang from apk lifecycle scripts")
   
Fixes: https://github.com/openwrt/openwrt/commit/18029977f65e11bafaad501399ad42a66d3baa10 ("build: fix apk packaging and ABI-versioning")