### PR TITLE
realtek/rtl839x: Edgecore ECS4100-12PH support

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -51,6 +51,14 @@ realtek_setup_macs()
 	local label_mac=""
 
 	case $board in
+	edgecore,ecs4100-12ph|\
+	tplink,sg2008p-v1|\
+	tplink,sg2210p-v3|\
+	tplink,sg2452p-v4|\
+	tplink,t1600g-28ts-v3)
+		label_mac=$(get_mac_label)
+		lan_mac="$label_mac"
+		;;
 	hpe,1920-8g|\
 	hpe,1920-8g-poe-65w|\
 	hpe,1920-8g-poe-180w|\
@@ -75,13 +83,6 @@ realtek_setup_macs()
 		lan_mac_start=skip
 		lan_mac="$(get_mac_label)"
 	;;
-	tplink,sg2008p-v1|\
-	tplink,sg2210p-v3|\
-	tplink,sg2452p-v4|\
-	tplink,t1600g-28ts-v3)
-		label_mac=$(get_mac_label)
-		lan_mac="$label_mac"
-		;;
 	tplink,tl-st1008f-v2|\
 	zyxel,xgs1010-12-a1)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
@@ -132,6 +133,10 @@ realtek_setup_poe()
 		ucidef_set_poe 193 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
 				lan22 lan21 lan20 lan19 lan18 lan17"
 		;;
+	edgecore,ecs4100-12ph|\
+	netgear,gs110tpp-v1)
+		ucidef_set_poe 130 "$(filter_port_list "$lan_list" "lan9 lan10")"
+		;;
 	engenius,ews2910p-v1|\
 	engenius,ews2910p-v3)
 		ucidef_set_poe 60 "$(filter_port_list "$lan_list" "lan9 lan10")"
@@ -152,9 +157,6 @@ realtek_setup_poe()
 		ucidef_set_poe 370 "lan8 lan7 lan6 lan5 lan4 lan3 lan2 lan1 lan16 lan15 lan14 lan13 lan12 lan11 lan10 lan9 lan24 lan23
 				lan22 lan21 lan20 lan19 lan18 lan17 lan32 lan31 lan30 lan29 lan28 lan27 lan26 lan25 lan40 lan39 lan38 lan37
 				lan36 lan35 lan34 lan33 lan48 lan47 lan46 lan45 lan44 lan43 lan42 lan41"
-		;;
-	netgear,gs110tpp-v1)
-		ucidef_set_poe 130 "$(filter_port_list "$lan_list" "lan9 lan10")"
 		;;
 	netgear,gs110tup-v1)
 		ucidef_set_poe 240 "$(filter_port_list "$lan_list" "lan9 lan10")"

--- a/target/linux/realtek/dts/rtl8393_edgecore_ecs4100-12ph.dts
+++ b/target/linux/realtek/dts/rtl8393_edgecore_ecs4100-12ph.dts
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl839x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "edgecore,ecs4100-12ph", "realtek,rtl839x-soc";
+	model = "Edgecore ECS4100-12PH Switch";
+
+	aliases {
+		label-mac-device = &ethernet0;
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	leds {
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>;
+		compatible = "gpio-leds";
+
+		led_sys: sys {
+			label = "green:sys";
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <&gpio1 26 GPIO_ACTIVE_LOW>;
+	};
+
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 8 GPIO_ACTIVE_LOW>;
+	};
+
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 2 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 3 GPIO_ACTIVE_LOW>;
+	};
+
+	i2c2: i2c-gpio-2 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp2: sfp-p11 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 24 GPIO_ACTIVE_LOW>;
+	};
+
+	i2c3: i2c-gpio-3 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 12 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp3: sfp-p12 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
+	};
+
+	i2c4: i2c-gpio-4 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 29 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 30 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		lm75b@48 {
+			compatible = "nxp,lm75a";
+			reg = <0x48>;
+		};
+
+		eeprom@56 {
+			compatible = "atmel,24c32";
+			reg = <0x56>;
+		};
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1200>;
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_factory>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gpio0 {
+	poe_enable {
+		gpio-hog;
+		gpios = <16 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+
+	poe_reset {
+		gpio-hog;
+		gpios = <18 GPIO_ACTIVE_HIGH>;
+		output-high;
+	};
+};
+
+&mdio_aux {
+	status = "okay";
+
+	gpio1: expander@3 {
+		compatible = "realtek,rtl8231";
+		reg = <3>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio1 0 0 37>;
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+};
+
+&mdio_bus0 {
+	reset-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <2000>;
+	reset-post-delay-us = <140000>;
+
+	/* External phy RTL8218B */
+	EXTERNAL_PHY(0)
+	EXTERNAL_PHY(1)
+	EXTERNAL_PHY(2)
+	EXTERNAL_PHY(3)
+	EXTERNAL_PHY(4)
+	EXTERNAL_PHY(5)
+	EXTERNAL_PHY(6)
+	EXTERNAL_PHY(7)
+
+	/* External phy RTL8214FC */
+	EXTERNAL_SFP_PHY_FULL(48, 0)
+	EXTERNAL_SFP_PHY_FULL(49, 1)
+	EXTERNAL_SFP_PHY_FULL(50, 2)
+	EXTERNAL_SFP_PHY_FULL(51, 3)
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+			partition@100000 {
+				compatible = "u-boot,env";
+				label = "u-boot-env";
+				reg = <0x100000 0x20000>;
+			};
+			partition@120000 {
+				label = "empty";
+				reg = <0x120000 0x60000>;
+				read-only;
+			};
+			partition@180000 {
+				label = "para";
+				reg = <0x180000 0x20000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_factory: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+				};
+			};
+			partition@200000 {
+				label = "firmware";
+				reg = <0x200000 0xdf0000>;
+				compatible = "openwrt,uimage", "denx,uimage";
+			};
+			partition@ff0000 {
+				label = "certificates";
+				reg = <0xff0000 0x10000>;
+			};
+		};
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_SDS(0, 1, 0, qsgmii)
+		SWITCH_PORT_SDS(1, 2, 0, qsgmii)
+		SWITCH_PORT_SDS(2, 3, 0, qsgmii)
+		SWITCH_PORT_SDS(3, 4, 0, qsgmii)
+		SWITCH_PORT_SDS(4, 5, 1, qsgmii)
+		SWITCH_PORT_SDS(5, 6, 1, qsgmii)
+		SWITCH_PORT_SDS(6, 7, 1, qsgmii)
+		SWITCH_PORT_SDS(7, 8, 1, qsgmii)
+
+		SWITCH_PORT_SDS(48, 9, 12, qsgmii)
+		SWITCH_PORT_SDS(49, 10, 12, qsgmii)
+		SWITCH_PORT_SDS(50, 11, 12, qsgmii)
+		SWITCH_PORT_SDS(51, 12, 12, qsgmii)
+
+		port@52 {
+			ethernet = <&ethernet0>;
+			reg = <52>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&uart1 {
+	status = "okay";
+};

--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -9,6 +9,21 @@ define Device/d-link_dgs-1210-52
 endef
 TARGET_DEVICES += d-link_dgs-1210-52
 
+define Device/edgecore_ecs4100-12ph
+  $(Device/uimage-rt-loader)
+  SOC := rtl8393
+  DEVICE_VENDOR := Edgecore
+  DEVICE_MODEL := ECS4100-12PH
+  IMAGE_SIZE := 14336k
+  DEVICE_PACKAGES := \
+	kmod-eeprom-at24 \
+	kmod-hwmon-adt7470 \
+	kmod-hwmon-lm75 \
+	kmod-thermal \
+	realtek-poe
+endef
+TARGET_DEVICES += edgecore_ecs4100-12ph
+
 define Device/hpe_1920-48g
   $(Device/hpe_1920)
   SOC := rtl8393


### PR DESCRIPTION
Add support for the Edgecore ECS4100-12PH, an 8-port PoE Gigabit Ethernet switch with 2 combo RJ45/SFP and 2 SFP ports.

Hardware:
* SoC: RTL8392M
* RAM: 256MiB
* Flash: 32MiB SPI-NOR
* Ethernet:
  * 8x GbE RJ45 PoE (external RTL8218B)
  * 2x GbE RJ45 / SFP combo
  * 2x SFP
* Console: RJ45 RS232 port on front panel
* PoE: Nuvoton M0516 + 2x Broadcom BCM59121 PSE

Installation via bootloader:
* open serial console (baud rate 115200)
* interrupt boot process by pressing any key during boot
* boot the OpenWrt initramfs: # rtk network on # tftpboot 0x8f000000 /tftpboot/openwrt-realtek-rtl839x-edgecore_ecs4100-12ph-initramfs-kernel.bin # bootm
* copy openwrt-realtek-rtl839x-edgecore_ecs4100-12ph-squashfs-sysupgrade.bin to /tmp and use sysupgrade to install it: # sysupgrade /tmp/openwrt-realtek-rtl839x-edgecore_ecs4100-12ph-squashfs-sysupgrade.bin

---

Thanks to the great work of @plappermaul and others, I was able to remove my WIP hacks to make the SFP and combo ports work, and this is finally ready to merge.

All ports have been successfully tested, including the SFP and combo ports, both with copper and SFP.

Changes since [v1](https://lists.openwrt.org/pipermail/openwrt-devel/2024-April/042569.html):

    * reduce u-boot-env parition to 128k
    * add "para" partition which contains the label MAC address
      analog to TP-Link SG2452P v4 and few others
    * add "empty" partition in between u-boot-env and para partitions
    * use nvmem-layout for MAC address
    * fix indentation in DTS
    * replace edgecore,reboot with gpio-restart and use active-low
    * remove adt7470@2f node, the adt7470 driver has no OF support
    * remove chosen node, it is not needed
    * remove ext-io@e4 node, we don't have a rtl8390-eio driver
    * remove gpio-fan node, the fan is connected to an adt7470
    * use EXTERNAL_PHY macro for phy 0-7
    * add leds node with the gpio-leds driver
    * enable uart1 for Nuvoton M0516 (PoE)
    * fix PoE UCI defaults
    * set phy-mode for PHY at address 48-51 to qsgmii
    * add reset-gpios to mdio node
    * add to DEVICE_PACKAGES:
      * kmod-eeprom-at24
      * kmod-hwmon-adt7470
      * kmod-hwmon-lm75
      * kmod-thermal
      * realtek-poe
    * switch rtl8231 driver
    * use EXTERNAL_SFP_PHY_FULL macros for SFP PHYs
    * move PHYs under mdio_bus0
    * use rt-loader to fix booting larger kernel image
    * add comments about external PHYs in DTS
    * change CPU port mode to internal
    * add pcs-handle to combo and SFP ports and remove in-band-status
    * add device to realtek_setup_macs in /etc/board.d/02_network
    * add u-boot,env compatible to u-boot-env partition to silence this error in preinit during boot:
        Cannot parse config file '/etc/fw_env.config': No such file or directory
        Failed to find NVMEM device
    * remove device from package/boot/uboot-tools/uboot-envtools/files/realtek, no longer needed with u-boot,env compatible in dts
    * use SWITCH_PORT_SDS for lan1-lan8
