### PR TITLE
feeds: revert to git.openwrt.org

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,7 +1,7 @@
-src-git packages https://github.com/openwrt/packages.git
-src-git luci https://github.com/openwrt/luci.git
-src-git routing https://github.com/openwrt/routing.git
-src-git telephony https://github.com/openwrt/telephony.git
+src-git packages https://git.openwrt.org/feed/packages.git
+src-git luci https://git.openwrt.org/project/luci.git
+src-git routing https://git.openwrt.org/feed/routing.git
+src-git telephony https://git.openwrt.org/feed/telephony.git
 src-git video https://github.com/openwrt/video.git
 #src-git targets https://github.com/openwrt/targets.git
 #src-git oldpackages http://git.openwrt.org/packages.git


### PR DESCRIPTION
This reverts the feeds.conf.default to git.openwrt.org

Fixes: 66e6ebbc1ea6c661bcbc85702066e2654da9c26a (microchipsw: drop source-only)

ping @robimarko
