### PR TITLE
image: build ext4 rootfs with mke2fs instead of make_ext4fs

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -325,6 +325,7 @@ define Image/mkfs/ext4
 		$(if $(CONFIG_TARGET_EXT4_JOURNAL),,-J) \
 		$(if $(SOURCE_DATE_EPOCH),-T $(SOURCE_DATE_EPOCH)) \
 		$@ $(call mkfs_target_dir,$(1))/
+		$(STAGING_DIR_HOST)/bin/e2fsck -fy $@ || true
 endef
 
 # Don't use the mkfs.erofs builtin $SOURCE_DATE_EPOCH behavior


### PR DESCRIPTION

    image: build ext4 rootfs with mke2fs instead of make_ext4fs
    
    make_ext4fs writes filesystems that are inconsistent: both free block
    and inode counts are wrong plus the padding at the end of the inode
    bitmap is left unset, so anything that checks the image reports errors
    and modifies it.
    
    - Build the rootfs with mke2fs -d instead, which gets both of these right
    - The call runs under fakeroot with the tree chowned to root:root, since
      mke2fs -d would otherwise copy uid/gid off the build host
    - Pin the filesystem UUID and dir hash seed to IMG_PART_DISKGUID for
      reproduciblity.
    - Run e2fsck -fn afterwards to flag any regression in the build log.