### PR TITLE
rockchip: add support for HINLINK H28K

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -174,6 +174,13 @@ define U-Boot/rk3528/Default
   TPL:=rk3528_ddr_1056MHz_v1.11.bin
 endef
 
+define U-Boot/generic-rk3528
+  $(U-Boot/rk3528/Default)
+  NAME:=Generic RK3528
+  BUILD_DEVICES:= \
+    hinlink_opc-h28k
+endef
+
 define U-Boot/radxa-e20c-rk3528
   $(U-Boot/rk3528/Default)
   NAME:=E20C
@@ -420,6 +427,7 @@ UBOOT_TARGETS := \
   rock64-rk3328 \
   rock-pi-e-rk3328 \
   rock-pi-e-v3-rk3328 \
+  generic-rk3528 \
   radxa-e20c-rk3528 \
   rock-2-rk3528 \
   nanopi-r3s-rk3566 \

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
@@ -44,6 +44,10 @@ radxa,e52c)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "lan"
 	;;
+hinlink,opc-h28k)
+	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
+	ucidef_set_led_netdev "lan" "LAN" "amber:lan" "eth0"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -23,6 +23,7 @@ rockchip_setup_interfaces()
 	friendlyarm,nanopc-t6|\
 	friendlyarm,nanopi-r5c|\
 	friendlyarm,nanopi-r76s|\
+	hinlink,opc-h28k|\
 	lunzn,fastrhino-r66s|\
 	radxa,e20c|\
 	radxa,e25|\
@@ -99,6 +100,14 @@ rockchip_setup_macs()
 	friendlyarm,nanopi-r4s-enterprise)
 		wan_mac=$(get_mac_binary "/sys/bus/i2c/devices/2-0051/eeprom" 0xfa)
 		lan_mac=$(macaddr_setbit_la "$wan_mac")
+		;;
+	hinlink,opc-h28k)
+		for mmcdev in /sys/devices/platform/soc/ffbf0000.mmc/mmc_host/*/*/block/*; do
+			mmcdev=${mmcdev##*/}
+			wan_mac=$(macaddr_generate_from_mmc_cid $mmcdev)
+			lan_mac=$(macaddr_add "$wan_mac" 1)
+			break
+		done
 		;;
 	xunlong,orangepi-r1-plus|\
 	xunlong,orangepi-r1-plus-lts)

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -32,6 +32,7 @@ case "$(board_name)" in
 armsom,sige7|\
 friendlyarm,nanopi-r3s|\
 friendlyarm,nanopi-r5c|\
+hinlink,opc-h28k|\
 linkease,easepi-r1|\
 lunzn,fastrhino-r66s|\
 radxa,e20c|\

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -180,6 +180,18 @@ define Device/friendlyarm_nanopi-r76s
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r76s
 
+define Device/hinlink_opc-h28k
+  $(Device/rk3528)
+  DEVICE_VENDOR := HINLINK
+  DEVICE_MODEL := OPC-H28K
+  DEVICE_ALT0_VENDOR := LinkStar
+  DEVICE_ALT0_MODEL := H28K
+  DEVICE_DTS := rk3528-opc-h28k
+  UBOOT_DEVICE_NAME := generic-rk3528
+  DEVICE_PACKAGES := kmod-r8169
+endef
+TARGET_DEVICES += hinlink_opc-h28k
+
 define Device/linkease_easepi-r1
   $(Device/rk3568)
   DEVICE_VENDOR := LinkEase

--- a/target/linux/rockchip/patches-6.12/170-arm64-dts-rockchip-Add-HINLINK-H28K.patch
+++ b/target/linux/rockchip/patches-6.12/170-arm64-dts-rockchip-Add-HINLINK-H28K.patch
@@ -1,0 +1,312 @@
+From 96f060507d280a5b1b424b739f2b4a1b9e0344d2 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Fri, 9 Jan 2026 21:42:23 +0000
+Subject: [PATCH] arm64: dts: rockchip: Add HINLINK H28K
+
+The HINLINK H28K is a single board computer based on the Rockchip
+RK3528A SoC.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+---
+ .../boot/dts/rockchip/rk3528-opc-h28k.dts     | 295 ++++++++++++++++++
+ 1 file changed, 295 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3528-opc-h28k.dts
+
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3528-opc-h28k.dts
+@@ -0,0 +1,295 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++
++/dts-v1/;
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/pinctrl/rockchip.h>
++
++#include "rk3528.dtsi"
++
++/ {
++	model = "HINLINK OPC-H28K Board";
++	compatible = "hinlink,opc-h28k", "rockchip,rk3528";
++
++	aliases {
++		mmc0 = &sdhci;
++		mmc1 = &sdmmc;
++		ethernet0 = &gmac1;
++
++		led-boot = &led_work;
++		led-failsafe = &led_work;
++		led-running = &led_work;
++		led-upgrade = &led_work;
++	};
++
++	chosen {
++		stdout-path = "serial0:1500000n8";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++		pinctrl-names = "default";
++		pinctrl-0 = <&lan_led_en>, <&wan_led_en>, <&work_led_en>;
++
++		lan {
++			color = <LED_COLOR_ID_AMBER>;
++			function = LED_FUNCTION_LAN;
++			gpios = <&gpio4 RK_PC1 GPIO_ACTIVE_LOW>;
++		};
++
++		wan {
++			color = <LED_COLOR_ID_BLUE>;
++			function = LED_FUNCTION_WAN;
++			gpios = <&gpio4 RK_PC0 GPIO_ACTIVE_LOW>;
++		};
++
++		led_work: work {
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_STATUS;
++			gpios = <&gpio4 RK_PB7 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	vcc5v0_sys: vcc5v0-sys {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc5v0_sys";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <5000000>;
++		regulator-max-microvolt = <5000000>;
++	};
++
++	vcc_3v3: vcc-3v3 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_3v3";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc_1v8: vcc-1v8 {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_1v8";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <1800000>;
++		vin-supply = <&vcc_3v3>;
++	};
++
++	vcc3v3_sd: vcc3v3-sd {
++		compatible = "regulator-fixed";
++		gpio = <&gpio4 RK_PA1 GPIO_ACTIVE_LOW>;
++		regulator-name = "vcc3v3_sd";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		vin-supply = <&vcc_3v3>;
++	};
++
++	vccio_sd: vccio-sd {
++		compatible = "regulator-gpio";
++		gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
++		regulator-name = "vccio_sd";
++		regulator-min-microvolt = <1800000>;
++		regulator-max-microvolt = <3300000>;
++		states = <1800000 0x0>, <3300000 0x1>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vcc_ddr: vcc-ddr {
++		compatible = "regulator-fixed";
++		regulator-name = "vcc_ddr";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <1200000>;
++		regulator-max-microvolt = <1200000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vdd_0v9: vdd-0v9 {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_0v9";
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-min-microvolt = <900000>;
++		regulator-max-microvolt = <900000>;
++		vin-supply = <&vcc5v0_sys>;
++	};
++
++	vdd_arm: vdd-arm {
++		compatible = "pwm-regulator";
++		pwms = <&pwm1 0 5000 1>;
++		pwm-supply = <&vcc5v0_sys>;
++		regulator-name = "vdd_arm";
++		regulator-min-microvolt = <746000>;
++		regulator-max-microvolt = <1201000>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-settling-time-up-us = <250>;
++	};
++
++	vdd_logic: vdd-logic {
++		compatible = "pwm-regulator";
++		pwms = <&pwm2 0 5000 1>;
++		pwm-supply = <&vcc5v0_sys>;
++		regulator-name = "vdd_logic";
++		regulator-min-microvolt = <705000>;
++		regulator-max-microvolt = <1006000>;
++		regulator-always-on;
++		regulator-boot-on;
++		regulator-settling-time-up-us = <250>;
++	};
++};
++
++&combphy {
++	status = "okay";
++};
++
++&cpu0 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu1 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu2 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&cpu3 {
++	cpu-supply = <&vdd_arm>;
++};
++
++&gmac1 {
++	clock_in_out = "output";
++	pinctrl-names = "default";
++	pinctrl-0 = <&rgmii_miim
++		     &rgmii_tx_bus2
++		     &rgmii_rx_bus2
++		     &rgmii_rgmii_clk
++		     &rgmii_rgmii_bus>;
++	phy-handle = <&rgmii_phy>;
++	phy-mode = "rgmii-id";
++	phy-supply = <&vcc_3v3>;
++	snps,reset-active-low;
++	snps,reset-delays-us = <0 20000 100000>;
++	snps,reset-gpio = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
++	status = "okay";
++};
++
++&gpu {
++	mali-supply = <&vdd_logic>;
++	status = "okay";
++};
++
++&mdio1 {
++	rgmii_phy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <0x1>;
++		realtek,led-data = <0x6d60>;
++	};
++};
++
++&pcie {
++	pinctrl-names = "default";
++	pinctrl-0 = <&rtl8111_isolate>;
++	reset-gpios = <&gpio4 RK_PA3 GPIO_ACTIVE_HIGH>;
++	vpcie3v3-supply = <&vcc_3v3>;
++	status = "okay";
++
++	bridge@0,0 {
++		reg = <0x00000000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++		ranges;
++
++		ethernet@0,0 {
++			compatible = "pci10ec,8168";
++			reg = <0x000000 0 0 0 0>;
++			realtek,led-data = <0xf70>;
++		};
++	};
++};
++
++&pinctrl {
++	leds {
++		lan_led_en: lan-led-en {
++			rockchip,pins = <4 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		wan_led_en: wan-led-en {
++			rockchip,pins = <4 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++
++		work_led_en: led-work-en {
++			rockchip,pins = <4 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
++	pcie {
++		rtl8111_isolate: rtl8111-isolate {
++			rockchip,pins = <4 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
++		};
++	};
++};
++
++&pwm1 {
++	status = "okay";
++};
++
++&pwm2 {
++	status = "okay";
++};
++
++&sdhci {
++	bus-width = <8>;
++	mmc-hs200-1_8v;
++	max-frequency = <200000000>;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_bus8 &emmc_clk &emmc_cmd &emmc_strb>;
++	vmmc-supply = <&vcc_3v3>;
++	vqmmc-supply = <&vcc_1v8>;
++	status = "okay";
++};
++
++&sdmmc {
++	bus-width = <4>;
++	cap-sd-highspeed;
++	disable-wp;
++	max-frequency = <150000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&sdmmc_bus4 &sdmmc_clk &sdmmc_cmd &sdmmc_det>;
++	rockchip,default-sample-phase = <90>;
++	sd-uhs-sdr104;
++	vmmc-supply = <&vcc3v3_sd>;
++	vqmmc-supply = <&vccio_sd>;
++	status = "okay";
++};
++
++&tsadc {
++	status = "okay";
++};
++
++&uart0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&uart0m0_xfer>;
++	status = "okay";
++};
++
++&usb2phy {
++	status = "okay";
++};
++
++&usb_host0_ehci {
++	status = "okay";
++};
++
++&usb_host0_ohci {
++	status = "okay";
++};


### PR DESCRIPTION
(partially based on @coolsnowwolf work)
A very small RockChip SBC with 2x Gigabit Ethernet. Also known as LinkStar H28K, distributed by SeeedStudio.

Hardware
--------
SoC: RockChip RK3528A ARM64 (4 cores)
RAM: 1/2/4GB LPDDR4 RAM
LEDs: 3x LED (lan, wan, status)
Buttons: 1x Reset button
Storage: 8GB eMMC on-board
         Micro-SD Slot
Ethernet: 1x RTL8211F RGMII PHY
          1x RTL8111H PCIe MAC/PHY
USB: 1x USB 2.0
Serial: using SBU1 and SBU2 pins of the USB-C connector for RX and TX
        1.8V TTL level, 1500000 baud, 8N1
Power: USB-C (5V 2A/12V 1A PD)

See also
https://www.hinlink.cn/121.html
https://wiki.seeedstudio.com/H28K_Datasheet/

Installation
------------
Uncompress the OpenWrt sysupgrade and write it to a micro SD card or internal eMMC using dd.