### PR TITLE
uci-defaults: migrate time zonename on upgrade

### DIFF
--- a/package/base-files/files/etc/uci-defaults/15_migrate-time-zonename
+++ b/package/base-files/files/etc/uci-defaults/15_migrate-time-zonename
@@ -1,0 +1,6 @@
+zonename="$(uci -q get system.@system[0].zonename)"
+case "$zonename" in
+        *[[:space:]]*) uci set system.@system[0].zonename="${zonename// /_}" ;;
+esac
+
+exit 0


### PR DESCRIPTION
Timezone names no longer allow spaces, so older installations upgrading to new will have their timezone reset to UTC.

For example, on 24.10:
  $ uci get system.@system[0].zonename
  America/Los Angeles

After upgrade to 25.12:
  $ uci get system.@system[0].zonename
  UTC

Add a migration script to edit zonename on first boot.

Link: https://github.com/openwrt/luci/issues/8203
Link: https://forum.openwrt.org/t/openwrt-25-12-0-rc1-release-candidate/244364/98