### PR TITLE
mediatek: filogic: add Huasifei WS1610 support

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-huasifei-ws1610.dts
+++ b/target/linux/mediatek/dts/mt7981b-huasifei-ws1610.dts
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "Huasifei WS1610";
+	compatible = "huasifei,ws1610", "mediatek,mt7981";
+
+	aliases {
+		led-boot = &led_sim1;
+		led-failsafe = &led_sim2;
+		led-running = &led_sim1;
+		led-upgrade = &led_sim1;
+		label-mac-device = &gmac0;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_4g: led-4g {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <1>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_5g: led-5g {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <2>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan: led-lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led_wifi: led-wifi {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sim1: led-sim1 {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <3>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led_sim2: led-sim2 {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_GREEN>;
+			function-enumerator = <4>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		/*
+		 * GPIO5 controls the modem 5V rail: low = rail off, high = rail on.
+		 * GPIO4 is a modem control line, separate from the 5V rail;
+		 * asserting it can reset/hold the module.
+		 */
+		gpio_modem_power {
+			gpio-export,name = "modem_power";
+			gpio-export,output = <1>;
+			gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		gpio_modem_reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <0>;
+			gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	/* Port labeled 2.5G LAN/WAN */
+	gmac0: mac@0 {
+		label = "wan";
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		phy-handle = <&rtl8221b_phy>;
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 0>;
+	};
+
+	/* Port labeled LAN */
+	gmac1: mac@1 {
+		label = "lan";
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 1>;
+	};
+};
+
+&mdio_bus {
+	rtl8221b_phy: ethernet-phy@6 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <6>;
+		reset-assert-us = <100000>;
+		reset-deassert-us = <100000>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+		interrupts = <38 IRQ_TYPE_LEVEL_LOW>;
+		interrupt-parent = <&pio>;
+		realtek,aldps-enable;
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0000000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x0180000 0x0200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x0380000 0x0200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "woem";
+				reg = <0x0580000 0x00a0000>;
+			};
+
+			partition@620000 {
+				label = "ubi";
+				reg = <0x0620000 0x07000000>;
+			};
+
+			partition@7620000 {
+				label = "ubi2";
+				reg = <0x07620000 0x07000000>;
+			};
+
+			partition@e620000 {
+				label = "wtinfo";
+				reg = <0x0e620000 0x00060000>;
+				read-only;
+			};
+
+			partition@e680000 {
+				label = "nvram";
+				reg = <0x0e680000 0x00060000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&xhci {
+	phys = <&u2port0 PHY_TYPE_USB2>,
+	       <&u3port0 PHY_TYPE_USB3>;
+	mediatek,u3p-dis-msk = <0x0>;
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 2>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 3>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -118,6 +118,10 @@ glinet,gl-xe3000)
 huasifei,wh3000)
 	ucidef_set_led_netdev "wan" "WAN" "red:wan" "eth1" "link tx rx"
 	;;
+huasifei,ws1610)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "lan" "link tx rx"
+	ucidef_set_led_netdev "wifi" "WIFI" "green:wlan" "phy1-ap0"
+	;;
 iptime,ax3000q)
 	ucidef_set_led_netdev "wan" "WAN" "amber:wan" "wan" "link tx rx"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -164,7 +164,8 @@ mediatek_setup_interfaces()
 	smartrg,sdg-8622|\
 	smartrg,sdg-8632|\
 	smartrg,sdg-8733a|\
-	yuncore,ax835)
+	yuncore,ax835|\
+	huasifei,ws1610)
 		ucidef_set_interfaces_lan_wan lan wan
 		;;
 	keenetic,kn-1812|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -109,6 +109,92 @@ update_oem_ubi_volume() {
 	ubiupdatevol "/dev/$ubidev" -s "$oem_volume_size" "$oem_volume_data"
 }
 
+ws1610_get_boot_slot()
+{
+	local tmp
+	local val
+
+	tmp="$(mktemp -t ws1610-woem.XXXXXX)" || return 1
+	mtd -l 0x20000 dump woem >"$tmp" || {
+		rm -f "$tmp"
+		return 1
+	}
+
+	val="$(dd if="$tmp" bs=1 count=4 2>/dev/null)"
+	[ "$val" = "WTUP" ] || {
+		echo "invalid WS1610 woem header: $val" >&2
+		rm -f "$tmp"
+		return 1
+	}
+
+	val="$(dd if="$tmp" bs=1 skip=4 count=1 2>/dev/null | hexdump -v -e '1/1 "%02x"')"
+	rm -f "$tmp"
+
+	case "$val" in
+	00)
+		echo "ubi"
+		;;
+	01)
+		echo "ubi2"
+		;;
+	*)
+		echo "invalid WS1610 slot selector: $val" >&2
+		return 1
+		;;
+	esac
+}
+
+ws1610_set_boot_slot()
+{
+	local target="$1"
+	local tmp
+	local val
+	local byte
+
+	case "$target" in
+	ubi)
+		byte='\000'
+		;;
+	ubi2)
+		byte='\001'
+		;;
+	*)
+		echo "invalid WS1610 target slot: $target" >&2
+		return 1
+		;;
+	esac
+
+	tmp="$(mktemp -t ws1610-woem.XXXXXX)" || return 1
+	mtd -l 0x20000 dump woem >"$tmp" || {
+		rm -f "$tmp"
+		return 1
+	}
+
+	val="$(dd if="$tmp" bs=1 count=4 2>/dev/null)"
+	[ "$val" = "WTUP" ] || {
+		echo "invalid WS1610 woem header: $val" >&2
+		rm -f "$tmp"
+		return 1
+	}
+
+	printf '%b' "$byte" | dd of="$tmp" bs=1 seek=4 conv=notrunc 2>/dev/null || {
+		rm -f "$tmp"
+		return 1
+	}
+
+	mtd unlock woem >/dev/null 2>&1 || {
+		rm -f "$tmp"
+		return 1
+	}
+
+	mtd write "$tmp" woem || {
+		rm -f "$tmp"
+		return 1
+	}
+
+	rm -f "$tmp"
+}
+
 platform_do_upgrade() {
 	local board=$(board_name)
 
@@ -212,6 +298,38 @@ platform_do_upgrade() {
 	huasifei,wh3000-pro-nand)
 		CI_UBIPART="ubi"
 		nand_do_upgrade "$1"
+		;;
+	huasifei,ws1610)
+		local current_slot target_slot
+
+		current_slot="$(ws1610_get_boot_slot)" || nand_do_upgrade_failed
+
+		case "$current_slot" in
+		ubi)
+			target_slot="ubi2"
+			;;
+		ubi2)
+			target_slot="ubi"
+			;;
+		*)
+			echo "failed to determine current WS1610 boot slot" >&2
+			nand_do_upgrade_failed
+			;;
+		esac
+
+		echo "Current slot: $current_slot"
+		echo "Upgrading inactive slot: $target_slot"
+
+		CI_UBIPART="$target_slot"
+		nand_do_flash_file "$1" || nand_do_upgrade_failed
+
+		if nand_do_restore_config && sync && ws1610_set_boot_slot "$target_slot" && sync; then
+			echo "sysupgrade successful"
+			umount -a
+			reboot -f
+		fi
+
+		nand_do_upgrade_failed
 		;;
 	cudy,re3000-v1|\
 	cudy,wr3000-v1|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1822,6 +1822,26 @@ define Device/huasifei_wh3000-pro-nand
 endef
 TARGET_DEVICES += huasifei_wh3000-pro-nand
 
+define Device/huasifei_ws1610
+  DEVICE_VENDOR := Huasifei
+  DEVICE_MODEL := WS1610
+  DEVICE_DTS := mt7981b-huasifei-ws1610
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 \
+	kmod-usb-net-qmi-wwan kmod-usb-net-cdc-ether kmod-usb-net-cdc-ncm \
+	kmod-usb-serial-option kmod-usbmon mdio-tools uqmi
+  SUPPORTED_DEVICES := huasifei,ws1610
+  KERNEL_IN_UBI := 1
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 114688k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += huasifei_ws1610
+
 define Device/imou_hx21
   DEVICE_VENDOR := Imou
   DEVICE_MODEL := HX21


### PR DESCRIPTION
mediatek: filogic: add support for Huasifei WS1610

Add support for the Huasifei WS1610 router

Specifications:
- MediaTek MT7981B
- 1 GiB DDR4 RAM
- 256 MiB SPI-NAND with NMBM
- MT7976CN 2.4/5 GHz 802.11ax wireless
- 2.5 GbE WAN via RTL8221B
- 1 GbE LAN via internal PHY
- M.2 and PCIe slots intended for USB modem use
- 2x nano-SIM slots
- LEDs: wifi, lan, sim1, sim2, 4g, 5g
- Reset button

MAC addresses (NVMEM):
- Base MAC located at factory partition offset 0x4
- wan: Base + 0
- lan: Base + 1
- 2.4 GHz: Base + 2
- 5 GHz: Base + 3

Flash layout:
```
  - bl2:        0x00000000 - 0x00100000
  - u-boot-env: 0x00100000 - 0x00180000  unused
  - factory:    0x00180000 - 0x00380000
  - fip:        0x00380000 - 0x00580000
  - woem:       0x00580000 - 0x00620000  boot slot selector
  - ubi:        0x00620000 - 0x07620000  slot A
  - ubi2:       0x07620000 - 0x0e620000  slot B
  - wtinfo:     0x0e620000 - 0x0e680000
  - nvram:      0x0e680000 - 0x0e6e0000
```

The device uses a vendor A/B UBI layout with two rootfs partitions,
ubi and ubi2. The active slot is selected through metadata stored in
the woem partition. This commit includes support for upgrading the
inactive slot and switching the active slot after a successful sysupgrade.

Active slot can be changed by modifying byte 4 in the woem
partition. The selector values are:

- 0x00: ubi
- 0x01: ubi2

Manual active slot selection in U-Boot:

  Read and inspect woem:

    mtd read woem 0x46000000 0x0 0x20000
    md.b 0x46000000 0x10

  Select ubi:

    mw.b 0x46000000+4 0x00
    mtd write woem 0x46000000 0x0 0x20000

  Select ubi2:

    mw.b 0x46000000+4 0x01
    mtd write woem 0x46000000 0x0 0x20000

Flashing from factory firmware:

1. Check the current boot slot:

     dmesg | grep -E "ubi0: attached mtd"

   Also check the selector byte in woem:

   - 0x00: ubi
   - 0x01: ubi2

2. If the device is booted from ubi, switch to ubi2 first by using one
   of the following methods:

   - flash the stock firmware once more
   - run the vendor command:

       wtoem -r

   - manually edit the woem metadata from U-Boot

3. Verify that the device is booted from ubi2.
4. Copy the OpenWrt factory image to /tmp.
5. Flash OpenWrt:

     sysupgrade -n -F /tmp/factory.bin

Flashing from ubi will soft-brick the device and require U-Boot
recovery.

Installation via U-Boot recovery:

1. Connect to the serial console.
2. Power on the device.
3. Enter the boot menu before the timeout expires.
4. Select "2. Upgrade firmware".
5. Select YMODEM.
6. Send the OpenWrt factory image.
7. U-Boot writes both slots and reboots.

Signed-off-by: Georg Seema <georgseema@gmail.com>