### PR TITLE
[25.12] Backport: netifd: dhcp: suppress udhcpc default vendor class if specified in se…

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/netifd.git


### PR DESCRIPTION
This is backport of https://github.com/openwrt/openwrt/pull/21450 into 25.12. Cherry-picked only, no changes done.


cherry picked from commit 89d982d723f027a5650d9e55726c87a1ba46b4dd