### PR TITLE
qualcommax: ipq5018: pz-l8: enable PHY-to-PHY CPU link

### DIFF
--- a/target/linux/qualcommax/dts/ipq5018-pz-l8.dts
+++ b/target/linux/qualcommax/dts/ipq5018-pz-l8.dts
@@ -232,6 +232,18 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
+			port@0 {
+				reg = <0>;
+				phy-mode = "sgmii";
+				ethernet = <&dp2>;
+				qca,sgmii-enable-pll;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+
 			port@1 {
 				reg = <1>;
 				label = "lan3";
@@ -256,26 +268,11 @@
 				phy-handle = <&qca8337_3>;
 			};
 
-			/*
-			 * WAN cannot work if added
-			 * port@5 {
-			 * 	reg = <5>;
-			 * 	phy-handle = <&qca8337_4>;
-			 * 	phy-mode = "gmii";
-			 * 	ethernet = <&dp1>;
-			 * };
-			 */
-
-			port@6 {
-				reg = <6>;
-				phy-mode = "sgmii";
-				ethernet = <&dp2>;
-				qca,sgmii-enable-pll;
-
-				fixed-link {
-					speed = <1000>;
-					full-duplex;
-				};
+			port@5 {
+				reg = <5>;
+				phy-handle = <&qca8337_4>;
+				phy-mode = "gmii";
+				ethernet = <&dp1>;
 			};
 		};
 	};

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
@@ -17,7 +17,6 @@ ipq50xx_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
 	cmcc,mr3000d-ci|\
-	cmcc,pz-l8|\
 	linksys,mx2000|\
 	linksys,mx5500|\
 	linksys,spnmx56|\
@@ -28,6 +27,13 @@ ipq50xx_setup_interfaces()
 	yuncore,ax830|\
 	yuncore,ax850)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
+		;;
+	cmcc,pz-l8)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
+		ucidef_set_network_device_conduit "lan1" "eth1"
+		ucidef_set_network_device_conduit "lan2" "eth1"
+		ucidef_set_network_device_conduit "lan3" "eth1"
+		ucidef_set_network_device_conduit "wan" "eth0"
 		;;
 	esac
 }

--- a/target/linux/qualcommax/patches-6.12/0752-net-dsa-qca8k-support-PHY-to-PHY-CPU-link.patch
+++ b/target/linux/qualcommax/patches-6.12/0752-net-dsa-qca8k-support-PHY-to-PHY-CPU-link.patch
@@ -1,7 +1,7 @@
-From 8a56ac86c2eed13024413aa23a6cda85613d60f9 Mon Sep 17 00:00:00 2001
+From e82cfa658fc4a0429b3d159d0e1bedb6b5cc6d38 Mon Sep 17 00:00:00 2001
 From: Ziyang Huang <hzyitc@outlook.com>
 Date: Sat, 18 Jan 2025 16:18:40 +0800
-Subject: [PATCH 1/2] net: dsa: qca8k: support PHY-to-PHY CPU link
+Subject: [PATCH 1/3] net: dsa: qca8k: support PHY-to-PHY CPU link
 
 PHY-to-PHY CPU link is a common/demo design in IPQ50xx platform, since it only has a SGMII/SGMII+ link and a MDI link.
 
@@ -9,8 +9,8 @@ For DSA, CPU tag is the only requirement. Fortunately, qca8337 can enable it on 
 
 Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
 ---
- drivers/net/dsa/qca/qca8k-8xxx.c | 12 +++++++-----
- 1 file changed, 7 insertions(+), 5 deletions(-)
+ drivers/net/dsa/qca/qca8k-8xxx.c | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
 
 --- a/drivers/net/dsa/qca/qca8k-8xxx.c
 +++ b/drivers/net/dsa/qca/qca8k-8xxx.c
@@ -46,4 +46,13 @@ Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
 +
  	return -EINVAL;
  }
+ 
+@@ -1950,7 +1952,7 @@ qca8k_setup(struct dsa_switch *ds)
+ 
+ 	cpu_port = qca8k_find_cpu_port(ds);
+ 	if (cpu_port < 0) {
+-		dev_err(priv->dev, "No cpu port configured in both cpu port0 and port6");
++		dev_err(priv->dev, "No cpu port configured");
+ 		return cpu_port;
+ 	}
  

--- a/target/linux/qualcommax/patches-6.12/0754-net-dsa-qca8k-use-correct-CPU-port-when-having-multi.patch
+++ b/target/linux/qualcommax/patches-6.12/0754-net-dsa-qca8k-use-correct-CPU-port-when-having-multi.patch
@@ -1,0 +1,90 @@
+From 08740093ef69e94613f19323f3abc55cb5d6863d Mon Sep 17 00:00:00 2001
+From: Ziyang Huang <hzyitc@outlook.com>
+Date: Wed, 14 Jan 2026 23:38:30 +0800
+Subject: [PATCH 2/3] net: dsa: qca8k: use correct CPU port when having multi
+ CPU ports
+
+DSA framework call dsa_tree_setup_cpu_ports() to find a default CPU port.
+If .preferred_default_local_cpu_port() isn't implemented, it will use the
+first CPU port, which is different from qca8k_find_cpu_port().
+
+Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
+---
+ drivers/net/dsa/qca/qca8k-8xxx.c | 38 ++++++--------------------------
+ 1 file changed, 7 insertions(+), 31 deletions(-)
+
+--- a/drivers/net/dsa/qca/qca8k-8xxx.c
++++ b/drivers/net/dsa/qca/qca8k-8xxx.c
+@@ -1087,24 +1087,6 @@ qca8k_setup_mac_pwr_sel(struct qca8k_pri
+ 	return ret;
+ }
+ 
+-static int qca8k_find_cpu_port(struct dsa_switch *ds)
+-{
+-	int i;
+-
+-	if (dsa_is_cpu_port(ds, 0))
+-		return 0;
+-
+-	if (dsa_is_cpu_port(ds, 6))
+-		return 6;
+-
+-	/* PHY-to-PHY link */
+-	for (i = 1; i <= 5; i++)
+-		if (dsa_is_cpu_port(ds, i))
+-			return i;
+-
+-	return -EINVAL;
+-}
+-
+ static int
+ qca8k_setup_of_pws_reg(struct qca8k_priv *priv)
+ {
+@@ -1947,15 +1929,9 @@ qca8k_setup(struct dsa_switch *ds)
+ {
+ 	struct qca8k_priv *priv = ds->priv;
+ 	struct dsa_port *dp;
+-	int cpu_port, ret;
++	int ret;
+ 	u32 mask;
+ 
+-	cpu_port = qca8k_find_cpu_port(ds);
+-	if (cpu_port < 0) {
+-		dev_err(priv->dev, "No cpu port configured");
+-		return cpu_port;
+-	}
+-
+ 	/* Parse CPU port config to be later used in phy_link mac_config */
+ 	ret = qca8k_parse_port_config(priv);
+ 	if (ret)
+@@ -2040,17 +2016,12 @@ qca8k_setup(struct dsa_switch *ds)
+ 	if (ret)
+ 		return ret;
+ 
+-	/* CPU port gets connected to all user ports of the switch */
+-	ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(cpu_port),
+-			QCA8K_PORT_LOOKUP_MEMBER, dsa_user_ports(ds));
+-	if (ret)
+-		return ret;
+-
+ 	/* Setup connection between CPU port & user ports
+ 	 * Individual user ports get connected to CPU port only
+ 	 */
+ 	dsa_switch_for_each_user_port(dp, ds) {
+ 		u8 port = dp->index;
++		u8 cpu_port = dp->cpu_dp->index;
+ 
+ 		ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(port),
+ 				QCA8K_PORT_LOOKUP_MEMBER,
+@@ -2058,6 +2029,11 @@ qca8k_setup(struct dsa_switch *ds)
+ 		if (ret)
+ 			return ret;
+ 
++		ret = qca8k_rmw(priv, QCA8K_PORT_LOOKUP_CTRL(cpu_port),
++				BIT(port), BIT(port));
++		if (ret)
++			return ret;
++
+ 		/* For port based vlans to work we need to set the
+ 		 * default egress vid
+ 		 */

--- a/target/linux/qualcommax/patches-6.12/0755-net-dsa-qca8k-implement-ds-ops-preferred_default_loc.patch
+++ b/target/linux/qualcommax/patches-6.12/0755-net-dsa-qca8k-implement-ds-ops-preferred_default_loc.patch
@@ -1,0 +1,40 @@
+From a572f1020159294fe980606996e7e3af5fa7ba9a Mon Sep 17 00:00:00 2001
+From: Ziyang Huang <hzyitc@outlook.com>
+Date: Wed, 14 Jan 2026 23:38:30 +0800
+Subject: [PATCH 3/3] net: dsa: qca8k: implement
+ ds->ops->preferred_default_local_cpu_port()
+
+Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
+---
+ drivers/net/dsa/qca/qca8k-8xxx.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+--- a/drivers/net/dsa/qca/qca8k-8xxx.c
++++ b/drivers/net/dsa/qca/qca8k-8xxx.c
+@@ -1733,6 +1733,18 @@ qca8k_get_tag_protocol(struct dsa_switch
+ 	return DSA_TAG_PROTO_QCA;
+ }
+ 
++static struct dsa_port *
++qca8k_preferred_default_local_cpu_port(struct dsa_switch *ds)
++{
++	if (dsa_is_cpu_port(ds, 0))
++		return dsa_to_port(ds, 0);
++
++	if (dsa_is_cpu_port(ds, 6))
++		return dsa_to_port(ds, 6);
++
++	return NULL;
++}
++
+ static int qca8k_port_change_master(struct dsa_switch *ds, int port,
+ 				    struct net_device *master,
+ 				    struct netlink_ext_ack *extack)
+@@ -2133,6 +2145,7 @@ static const struct dsa_switch_ops qca8k
+ 	.get_phy_flags		= qca8k_get_phy_flags,
+ 	.port_lag_join		= qca8xxx_port_lag_join,
+ 	.port_lag_leave		= qca8xxx_port_lag_leave,
++	.preferred_default_local_cpu_port = qca8k_preferred_default_local_cpu_port,
+ 	.port_change_conduit	= qca8k_port_change_master,
+ 	.conduit_state_change	= qca8k_conduit_change,
+ 	.connect_tag_protocol	= qca8k_connect_tag_protocol,


### PR DESCRIPTION
For the following topology, we need to enable dual CPU link for 2Gbps:

```
 _______________________         _______________________
|        IPQ5018        |       |        QCA8337        |
| +------+   +--------+ |       | +--------+   +------+ |
| | MAC0 |---| GE Phy |-+--MDI--+-|  Phy4  |---| MAC5 | |
| +------+   +--------+ |       | +--------+   +------+ |
| +------+   +--------+ |       | +--------+   +------+ |
| | MAC1 |---| Uniphy |-+-SGMII-+-| SerDes |---| MAC0 | |
| +------+   +--------+ |       | +--------+   +------+ |
|_______________________|       |_______________________|
```