### PR TITLE
realtek: rt-loader: fix chip revision printout.

### DIFF
--- a/target/linux/realtek/image/rt-loader/src/board.c
+++ b/target/linux/realtek/image/rt-loader/src/board.c
@@ -91,10 +91,12 @@ found:
 	val = ioread32(reg + 4);
 	chip_id = val & 0xffff;
 
-	if (model_id < 0x9300)
-		chip_version = val >> 16 & 0x1f;
+	if (model_id < 0x8390)
+		chip_version = (val >> 16) & 0x1f;
+	else if (model_id < 0x9300)
+		chip_version = ((val >> 16) & 0x1f) + 1;
 	else
-		chip_version = val >> 28 & 0x0f;
+		chip_version = ((val >> 28) & 0x0f) + 1;
 
 	snprintf(buffer, len, "RTL%04X%c (chip id %04x%c)",
 		 model_id, model_version ? model_version + 64 : 0,


### PR DESCRIPTION
There is currently a mismatch in the detection of the chip type.
rt-loader and the kernel give different revisions. E.g.

```
rt-loader: Running on RTL9313 (chip id 6567A) with 256MB
kernel: Realtek RTL9313 rev B (6567) SoC with 256 MB
```

Realtek internal version numbering is

- for RTL838x: 1=A, 2=B, ...
- for others: 0=A, 1=B, ...

rt-loader does not differentiate that. Adapt the calculation to
give a consistent picture.