### PR TITLE
econet: refresh patches 6.12

### DIFF
--- a/target/linux/econet/patches-6.12/010-v6.16-MAINTAINERS-Add-entry-for-newly-added-EcoNet-platfor.patch
+++ b/target/linux/econet/patches-6.12/010-v6.16-MAINTAINERS-Add-entry-for-newly-added-EcoNet-platfor.patch
@@ -17,7 +17,7 @@ Signed-off-by: Thomas Bogendoerfer <tsbogend@alpha.franken.de>
 
 --- a/MAINTAINERS
 +++ b/MAINTAINERS
-@@ -8019,6 +8019,18 @@ W:	https://linuxtv.org
+@@ -8025,6 +8025,18 @@ W:	https://linuxtv.org
  Q:	http://patchwork.linuxtv.org/project/linux-media/list/
  F:	drivers/media/dvb-frontends/ec100*
  

--- a/target/linux/econet/patches-6.12/901-nand-enable-en75-bbt.patch
+++ b/target/linux/econet/patches-6.12/901-nand-enable-en75-bbt.patch
@@ -14,9 +14,9 @@ Signed-off-by: Caleb James DeLisle <cjd@cjdns.fr>
  obj-$(CONFIG_MTD_NAND_ECC_MEDIATEK) += ecc-mtk.o
 -obj-$(CONFIG_MTD_NAND_MTK_BMT)	+= mtk_bmt.o mtk_bmt_v2.o mtk_bmt_bbt.o mtk_bmt_nmbm.o
 +obj-$(CONFIG_MTD_NAND_MTK_BMT)	+= mtk_bmt.o mtk_bmt_v2.o mtk_bmt_bbt.o mtk_bmt_nmbm.o en75_bmt.o
- ifeq ($(CONFIG_SPI_QPIC_SNAND),y)
  obj-$(CONFIG_SPI_QPIC_SNAND) += qpic_common.o
- else
+ obj-$(CONFIG_MTD_NAND_QCOM) += qpic_common.o
+ obj-y	+= onenand/
 --- a/drivers/mtd/nand/mtk_bmt.h
 +++ b/drivers/mtd/nand/mtk_bmt.h
 @@ -77,6 +77,7 @@ extern struct bmt_desc bmtd;


### PR DESCRIPTION
Manually rebased:
econet/patches-6.12/901-nand-enable-en75-bbt.patch

Fixes:
 5230157a165 kernel: QCOM SPI NAND: backport multiple fixes

