### PR TITLE
realtek: dsa: avoid use-after-free and unitialized memory access

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -255,7 +255,7 @@ static int rtldsa_bus_c45_write(struct mii_bus *bus, int addr, int devad, int re
 	return mdiobus_c45_write_nested(priv->parent_bus, addr, devad, regnum, val);
 }
 
-static int __init rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
+static int rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 {
 	struct device_node *dn, *phy_node, *pcs_node, *led_node, *np, *mii_np;
 	struct device *dev = priv->dev;
@@ -405,7 +405,7 @@ static int __init rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 	return 0;
 }
 
-static int __init rtl83xx_get_l2aging(struct rtl838x_switch_priv *priv)
+static int rtl83xx_get_l2aging(struct rtl838x_switch_priv *priv)
 {
 	int t = sw_r32(priv->r->l2_ctrl_1);
 
@@ -1391,7 +1391,7 @@ static int rtldsa_ethernet_loaded(struct platform_device *pdev)
 	return ret;
 }
 
-static int __init rtl83xx_sw_probe(struct platform_device *pdev)
+static int rtl83xx_sw_probe(struct platform_device *pdev)
 {
 	struct rtl838x_switch_priv *priv;
 	struct device *dev = &pdev->dev;

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -1647,7 +1647,7 @@ static const struct ethtool_ops rteth_ethtool_ops = {
 	.set_link_ksettings = rteth_set_link_ksettings,
 };
 
-static int __init rtl838x_eth_probe(struct platform_device *pdev)
+static int rtl838x_eth_probe(struct platform_device *pdev)
 {
 	struct net_device *dev;
 	struct device_node *dn = pdev->dev.of_node;

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -1655,7 +1655,7 @@ static int rtl838x_eth_probe(struct platform_device *pdev)
 	const struct rteth_config *matchdata;
 	phy_interface_t phy_mode;
 	struct phylink *phylink;
-	u8 mac_addr[ETH_ALEN];
+	u8 mac_addr[ETH_ALEN] = {0};
 	int err = 0, rxrings, rxringlen;
 	struct ring_b *ring;
 


### PR DESCRIPTION
The realtek target uses some functions marked __init for initialization. However, that means they can only be called once when compiled in and afterwards the memory occupied by them is freed and potentially reused. Some "impossible" (code at a given location can't crash in the way it does) crashes can be caused by this because upon re-execution of those functions, garbage gets executed. Such re-execution can happen for deferred probes or repeated probes.

Additionally, the mac_ addr variable was not zero-initialized, causing weird side effects when the memory contents were a valid MAC address.

Signed-off-by: Carl-Daniel Hailfinger <c-d.hailfinger.devel.2006@gmx.net>