### PR TITLE
kernel: add kmod-hwmon-adt7470

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -63,6 +63,21 @@ endef
 $(eval $(call KernelPackage,hwmon-adt7410))
 
 
+define KernelPackage/hwmon-adt7470
+  TITLE:=ADT7470 monitoring support
+  KCONFIG:=CONFIG_SENSORS_ADT7470
+  FILES:=$(LINUX_DIR)/drivers/hwmon/adt7470.ko
+  AUTOLOAD:=$(call AutoProbe,adt7470)
+  $(call AddDepends/hwmon,+kmod-i2c-core +kmod-regmap-i2c)
+endef
+
+define KernelPackage/hwmon-adt7470/description
+ Kernel module for ADT7470 thermal monitor chip
+endef
+
+$(eval $(call KernelPackage,hwmon-adt7470))
+
+
 define KernelPackage/hwmon-adt7475
   TITLE:=ADT7473/7475/7476/7490 monitoring support
   KCONFIG:=CONFIG_SENSORS_ADT7475


### PR DESCRIPTION
This driver supports the ADT7470 thermal monitoring chip, which is used in the ECS4100-12PH switch.

Fixes: fa9f92595197 ("realtek/rtl839x: Edgecore ECS4100-12PH support")

