### PR TITLE
realtek: dsa: rtl839x: implement LED configuration

### DIFF
--- a/target/linux/realtek/dts/macros.dtsi
+++ b/target/linux/realtek/dts/macros.dtsi
@@ -64,6 +64,24 @@
 	};
 
 // LED Set mode definitions
+#define RTL839X_LED_LINK_ACT		(0)
+#define RTL839X_LED_LINK		(1)
+#define RTL839X_LED_ACT			(2)
+#define RTL839X_LED_ACT_RX		(3)
+#define RTL839X_LED_ACT_TX		(4)
+#define RTL839X_LED_DUPLEX_MODE		(6)
+#define RTL839X_LED_LINK_1G		(7)
+#define RTL839X_LED_LINK_100M		(8)
+#define RTL839X_LED_LINK_10M		(9)
+#define RTL839X_LED_LINK_ACT_1G		(10)
+#define RTL839X_LED_LINK_ACT_100M	(11)
+#define RTL839X_LED_LINK_ACT_10M	(12)
+#define RTL839X_LED_LINK_ACT_1G_100M	(13)
+#define RTL839X_LED_LINK_ACT_1G_10M	(14)
+#define RTL839X_LED_LINK_ACT_100M_10M	(15)
+#define RTL839X_LED_LINK_ACT_10G	(21)
+#define RTL839X_LED_DISABLED		(31)
+
 #define RTL93XX_LED_SET_NONE        (0)
 #define RTL93XX_LED_SET_10G         (1 << 0)
 #define RTL93XX_LED_SET_5G          (1 << 1)

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -350,11 +350,11 @@ static int __init rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 		if (interface == PHY_INTERFACE_MODE_10GBASER)
 			priv->ports[pn].is10G = true;
 
+		if (of_property_read_u32(dn, "led-set", &led_set))
+			led_set = 0;
+		priv->ports[pn].led_set = led_set;
 		priv->ports[pn].leds_on_this_port = 0;
 		if (led_node) {
-			if (of_property_read_u32(dn, "led-set", &led_set))
-				led_set = 0;
-			priv->ports[pn].led_set = led_set;
 			sprintf(led_set_str, "led_set%d", led_set);
 			priv->ports[pn].leds_on_this_port = of_property_count_u32_elems(led_node, led_set_str);
 			if (priv->ports[pn].leds_on_this_port > 4) {

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -580,6 +580,9 @@ static int rtl83xx_setup(struct dsa_switch *ds)
 	msleep(1000);
 	priv->r->pie_init(priv);
 
+	if (priv->r->led_init)
+		priv->r->led_init(priv);
+
 	return 0;
 }
 

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -670,6 +670,15 @@ typedef enum {
 #define RTL930X_L3_IP_ROUTE_CTRL		0xab44
 
 /* Port LED Control */
+#define RTL839X_MAX_LEDS_PER_PORT		3
+#define RTL839X_LED_SET_2_3_CTRL		(0x00e8)
+#define RTL839X_LED_SET_0_1_CTRL		(0x00ec)
+#define RTL839X_LED_PORT_COPR_SET_SEL_CTRL(p)	(0x00f0 + (((p >> 4) << 2)))
+#define RTL839X_LED_PORT_FIB_SET_SEL_CTRL(p)	(0x0100 + (((p >> 4) << 2)))
+#define RTL839X_LED_PORT_COPR_MASK_CTRL		(0x0110)
+#define RTL839X_LED_PORT_FIB_MASK_CTRL		(0x0118)
+#define RTL839X_LED_PORT_COMBO_MASK_CTRL	(0x0120)
+
 #define RTL930X_LED_PORT_NUM_CTRL(p)		(0xCC04 + (((p >> 4) << 2)))
 #define RTL930X_LED_SET0_0_CTRL			(0xCC28)
 #define RTL930X_LED_PORT_COPR_SET_SEL_CTRL(p)	(0xCC2C + (((p >> 4) << 2)))


### PR DESCRIPTION
While waiting for other stuff to settle, something out of the row ...

Our LED implementation in the DSA driver is far from optimal but instead of letting this rot in my local tree until I find the time to refactor the LED stuff, better push that out to have the functionality.

---

LED configuration in RTL839X works similar as in RTL93XX with configurable LED sets which ports are assigned to. There are just some limitations e.g. only 3 LEDs per set are supported and the number of LEDs per port is global for all ports.

Take the implementation from RTL931X and adjust it accordingly (except for forced port mask support). Also add constants to 'macros.dtsi' to avoid having magic values in DTS.

In the DTS, configuring this may look like:

    led-set {
        compatible = "realtek,rtl8390-leds";
        active-low;

        realtek,leds-per-port = <2>;
        realtek,ignore-port-mask = <0x00 0xf000000>;

        led_set0 = <RTL839X_LED_LINK_ACT_1G RTL839X_LED_LINK_ACT_100M_10M>;
    };

EDIT: The purpose of the `realtek,ignore-port-mask` is for the RTL8214FC which afaik controls the LEDs for the combo ports.