### PR TITLE
realtek: add support for XikeStor SKS8300-8T

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -88,6 +88,10 @@ realtek_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		[ -z "$lan_mac" ] || [ "$lan_mac" = "00:e0:4c:00:00:00" ] && lan_mac=$(macaddr_random)
 		;;
+	xikestor,sks8300-8t)
+		lan_mac="$(get_mac_label)"
+		label_mac="$lan_mac"
+		;;
 	xikestor,sks8300-8x)
 		lan_mac=$(mtd_get_mac_binary board-info 0x1f1)
 		;;

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "xikestor,sks8300-8t", "realtek,rtl9303-soc";
+	model = "XikeStor SKS8300-8T";
+
+	aliases {
+		label-mac-device = &ethernet0;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* first 256 MiB */
+		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		led_set0 = <(RTL93XX_LED_SET_10M | RTL93XX_LED_SET_100M |
+			     RTL93XX_LED_SET_1G | RTL93XX_LED_SET_2P5G |
+			     RTL93XX_LED_SET_5G | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT)>;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c@0 {
+		reg = <0>;
+
+		temperature_sensor: temperature-sensor@48 {
+			compatible = "national,lm75";
+			reg = <0x48>;
+			#thermal-sensor-cells = <0>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x1c0000>;
+				read-only;
+			};
+
+			partition@1c0000 {
+				label = "u-boot-env";
+				reg = <0x1c0000 0x10000>;
+			};
+
+			partition@1d0000 {
+				label = "sysinfo";
+				reg = <0x1d0000 0x10000>;
+				read-only;
+			};
+
+			partition@1e0000 {
+				label = "factory";
+				reg = <0x1e0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					factory_macaddr: macaddr@80 {
+						reg = <0x80 0x6>;
+					};
+				};
+			};
+
+			partition@1f0000 {
+				label = "sysdata";
+				reg = <0x1f0000 0x10000>;
+			};
+
+			partition@200000 {
+				label = "jffs2_filesystem";
+				reg = <0x200000 0xa00000>;
+			};
+
+			partition@c00000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0xc00000 0x1400000>;
+				openwrt,ih-magic = <0x93000000>;
+				openwrt,offset = <0x10>;
+			};
+		};
+	};
+};
+
+&mdio_bus0 {
+	phy0: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <0>;
+	};
+
+	phy8: ethernet-phy@8 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <8>;
+		realtek,smi-address = <1>;
+	};
+
+	phy16: ethernet-phy@16 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <16>;
+		realtek,smi-address = <2>;
+	};
+
+	phy20: ethernet-phy@20 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <20>;
+		realtek,smi-address = <3>;
+	};
+};
+
+&mdio_bus1 {
+	phy24: ethernet-phy@24 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <24>;
+		realtek,smi-address = <0>;
+	};
+
+	phy25: ethernet-phy@25 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <25>;
+		realtek,smi-address = <1>;
+	};
+
+	phy26: ethernet-phy@26 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <26>;
+		realtek,smi-address = <2>;
+	};
+
+	phy27: ethernet-phy@27 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <27>;
+		realtek,smi-address = <3>;
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&factory_macaddr>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_SDS(0, 1, 2, usxgmii)
+		SWITCH_PORT_SDS(8, 2, 3, usxgmii)
+		SWITCH_PORT_SDS(16, 3, 4, usxgmii)
+		SWITCH_PORT_SDS(20, 4, 5, usxgmii)
+		SWITCH_PORT_SDS(24, 5, 6, usxgmii)
+		SWITCH_PORT_SDS(25, 6, 7, usxgmii)
+		SWITCH_PORT_SDS(26, 7, 8, usxgmii)
+		SWITCH_PORT_SDS(27, 8, 9, usxgmii)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&thermal_zones {
+	sys-thermal {
+		polling-delay-passive = <1000>;
+		polling-delay = <1000>;
+		thermal-sensors = <&temperature_sensor>;
+		trips {
+			sys-crit {
+				temperature = <70000>;
+				hysteresis = <2000>;
+				type = "critical";
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -71,6 +71,25 @@ define Device/vimin_vm-s100-0800ms
 endef
 TARGET_DEVICES += vimin_vm-s100-0800ms
 
+define Device/xikestor_sks8300-8t
+  SOC := rtl9303
+  UIMAGE_MAGIC := 0x93000000
+  DEVICE_VENDOR := XikeStor
+  DEVICE_MODEL := SKS8300-8T
+  DEVICE_PACKAGES := kmod-hwmon-lm75
+  IMAGE_SIZE := 20480k
+  $(Device/kernel-lzma)
+  IMAGE/sysupgrade.bin := \
+    pad-extra 16 | \
+    append-kernel | \
+    pad-to 64k | \
+    append-rootfs | \
+    pad-rootfs | \
+    check-size | \
+    append-metadata
+endef
+TARGET_DEVICES += xikestor_sks8300-8t
+
 define Device/xikestor_sks8300-8x
   SOC := rtl9303
   DEVICE_VENDOR := XikeStor


### PR DESCRIPTION
XikeStor SKS8300-8T is a 8 ports Multi-Gig switch, based on the RTL9303.

Specifications:

- SoC                : Realtek RTL9303
- RAM                : DDR3 512 MiB
- Flash              : SPI-NOR 32 MiB (Macronix)
- CPU                : 800MHz
- Ethernet           : 8× 1G/2.5G/5G/10G Base-T RJ45 ports (RTL8261N)
- Keys (GPIO)        : 1x
- UART               : "Console" port on the front panel
  - type             : RS-232C
  - connector        : RJ-45
  - settings         : 115200 8N1
- Power              : 12 VDC, 4A
- Temperature sensor : LM75 or compatible
- Fan controller     : SensyLink CTF2302

Flash instruction using initramfs image:

 1. Prepare TFTP server & connect to serial port.
 2. Connect your computer to one of the RJ45 ports on SKS8300-8T
 3. Power on SKS8300-8T and interrupt autoboot with Shift + A.
 4. Use Shift + Q to drop from vendor CLI to U-Boot CLI.
 5. Set the boot command to enable network on boot.
       > setenv bootcmd 'mw.l 0x8401da94 0; rtk network on; boota'
 6. Set switch IP and TFTP server IP (optional, adjust to your setup).
       > setenv ipaddr <ip>
       > setenv serverip <ip>
 7. Download initramfs image from TFTP server.
       > tftpboot 0x83000000 <image name>
 8. Boot with the downloaded image.
       > bootm 0x83000000
 9. With rambooted OpenWrt, backup the stock firmware if needed.
10. Copy sysupgrade image to the device.
11. Perform sysupgrade with the sysupgrade image.
12. After reboot, you should have functional OpenWrt.

In OpenWrt, it is necessary to execute "rtk network on" to enable full networking functionality. However, the internal U-Boot initialization (which shares logic with "rtk network init" initializing MAC only and configures the fan controller) sets a flag at memory address 0x8401da94. Once this flag is set, any subsequent calls to "rtk network on" are blocked. To bypass this, resetting 0x8401da94 to 0 by step 5, ensuring that the network can be properly initialized later. This specific address was confirmed in U-Boot 2011.12.(3.6.11.55242) (Jan 06 2025 - 14:39:46) by decompiling the function that references the "rtk_mac_init" string.

Reverting to stock firmware:

1. Connect to serial port.
2. Power on SKS8300-8T and interrupt autoboot with Shift + A.
3. Use Shift + Q to drop from vendor CLI to U-Boot CLI.
4. Set the boot command to the firmware default.
       > setenv bootcmd boota
5. Enable network.
       > rtk network on
6. Boot OpenWrt.
       > boota
7. Download latest firmware from XikeStor and upload to your device.
8. Write firmware with 'sysupgrade -F'.
9. After reboot, stock firmware should boot automatically.

---
This is based on the PR https://github.com/openwrt/openwrt/pull/19994