### PR TITLE
package: uboot-qoriq: fix T4240RDB u-boot selection

### DIFF
--- a/package/boot/uboot-qoriq/Makefile
+++ b/package/boot/uboot-qoriq/Makefile
@@ -36,12 +36,14 @@ endef
 
 define U-Boot/fsl_T4240RDB-nor
   NAME:=NXP T4240RDB NOR Boot
+  BUILD_DEVICES:=fsl_T4240RDB
   UBOOT_CONFIG:=T4240RDB
   UBOOT_IMAGE:=u-boot-dtb.bin
 endef
 
 define U-Boot/fsl_T4240RDB-sdboot
   NAME:=NXP T4240RDB SD Card Boot
+  BUILD_DEVICES:=fsl_T4240RDB
   UBOOT_CONFIG:=T4240RDB_SDCARD
   UBOOT_IMAGE:=u-boot-with-spl-pbl.bin
 endef

--- a/target/linux/qoriq/image/generic.mk
+++ b/target/linux/qoriq/image/generic.mk
@@ -4,7 +4,7 @@ define Device/fsl_T4240RDB
   DEVICE_DTS_DIR := $(DTS_DIR)/fsl
   DEVICE_PACKAGES := \
     kmod-eeprom-at24 kmod-gpio-button-hotplug kmod-hwmon-w83793 kmod-leds-gpio \
-	  kmod-ptp-qoriq kmod-rtc-ds1374 u-boot-fsl_T4240RDB-nor u-boot-fsl_T4240RDB-sdboot
+	  kmod-ptp-qoriq kmod-rtc-ds1374
   FILESYSTEMS := squashfs
   KERNEL := kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGES := factory-nor.bin.gz sdcard.img.gz rcw.bin sysupgrade.bin


### PR DESCRIPTION
Mark T4240RDB u-boot variants as device-built and avoid installing them into rootfs.

Without this buildbot crashes during package install with:

````
ERROR: unable to select packages:

  u-boot-fsl_T4240RDB-nor (no such package):

    required by: world[u-boot-fsl_T4240RDB-nor]

  u-boot-fsl_T4240RDB-sdboot (no such package):

    required by: world[u-boot-fsl_T4240RDB-sdboot]
````

Fixes: c5d3d5fe28f7 ("package: u-boot: initial support for qoriq arch")
