### PR TITLE
realtek: mdio: enhancements for RTL931x

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -13,7 +13,9 @@
 #define RTMDIO_MAX_SMI_BUS			4
 #define RTMDIO_PAGE_SELECT			0x1f
 
-#define RTMDIO_PHY_AQR113C			0x31c31c12
+#define RTMDIO_PHY_AQR113C_A			0x31c31c12
+#define RTMDIO_PHY_AQR113C_B			0x31c31c13
+#define RTMDIO_PHY_AQR813			0x31c31cb2
 #define RTMDIO_PHY_RTL8221B_VB_CG		0x001cc849
 #define RTMDIO_PHY_RTL8221B_VM_CG		0x001cc84a
 #define RTMDIO_PHY_RTL8224			0x001ccad0
@@ -605,7 +607,9 @@ static void rtmdio_get_phy_info(struct mii_bus *bus, int addr, struct rtmdio_phy
 	}
 
 	switch(phyinfo->phy_id) {
-	case RTMDIO_PHY_AQR113C:
+	case RTMDIO_PHY_AQR113C_A:
+	case RTMDIO_PHY_AQR113C_B:
+	case RTMDIO_PHY_AQR813:
 		phyinfo->mac_type = RTMDIO_PHY_MAC_2G_PLUS;
 		phyinfo->poll_duplex = RTMDIO_PHY_POLL_MMD(1, 0x0000, 8);
 		phyinfo->poll_adv_1000 = RTMDIO_PHY_POLL_MMD(7, 0xc400, 15);


### PR DESCRIPTION
This series is a follow-up to #21469 and covers enhancements of the MDIO driver, specifically to improve support of my RTL931x devices.

Reading the PHY ID is enhanced to be more error-proof and the read different MMDs for C45 case because the assumption that MMD_VEND2(31) always works proved wrong. Setting the PHY polling config for RTL931x is implemented, very similar to what RTL930x does.

And more PHY IDs for Aquantia chips are added, AQR813 and another revision of AQR113. I kept it simple for now, just adding the different PHY ID for the AQR113. If we encounter more different revisions in the future, we should probably switch to use PHY IDs with corresponding masks to check against. I'll keep that in mind for later.