### PR TITLE
mpc85xx: fix failsafe iface selection for mpc85xx boards

### DIFF
--- a/target/linux/mpc85xx/base-files/lib/preinit/05_set_preinit_iface_mpc85xx
+++ b/target/linux/mpc85xx/base-files/lib/preinit/05_set_preinit_iface_mpc85xx
@@ -4,6 +4,17 @@
 
 mpc85xx_set_preinit_iface() {
 	case $(board_name) in
+	aerohive,br200-wp|\
+	ocedo,panda|\
+	tplink,tl-wdr4900-v1)
+		ifname=lan1
+		;;
+	aerohive,hiveap-330|\
+	enterasys,ws-ap3715i|\
+	watchguard,firebox-t10|\
+	watchguard,firebox-t15)
+		ifname=eth1
+		;;
 	watchguard,xtm330)
 		ifname=port1
 		;;


### PR DESCRIPTION
Some mpc85xx boards still boot with failsafe configured on a non-LAN interface. Align the preinit interface with the first DSA port or the interface that LAN is connected to.

This makes failsafe reachable on devices where the default selection does not map to the primary LAN port.