### PR TITLE
apk: avoid silent file overwrites between packages sharing the same origin field

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -597,7 +597,7 @@ else
 	  --info "description:$$(call description_escape,$$(strip $$(Package/$(1)/description)))" \
 	  $(if $(findstring all,$(PKGARCH)),--info "arch:noarch",--info "arch:$(PKGARCH)") \
 	  --info "license:$(LICENSE)" \
-	  --info "origin:$(SOURCE)" \
+	  --info "origin:$(SOURCE)/$(1)" \
 	  --info "url:$(URL)" \
 	  --info "maintainer:$(MAINTAINER)" \
 	  $$(if $$(Package/$(1)/PROVIDES),--info "provides:$$(Package/$(1)/PROVIDES)") \


### PR DESCRIPTION
Actually "apk" allow silent files overwrites between packages sharing the "--info origin" field, that is for example, all packages implementing VARIANTs which are precisely those with highest posible file conflicts [^1].

We are preventing this at the package level conflicts restrictions, but in some cases like packages using ALTERNATIVES mechanism would not catch those file conflicts as it allow to install packages whitin the same VARIANT(same "origin") side-by-side.  And more cases without VARIANTs (ca-certs, v2ray-*, etc.)

This is a feature of the "apk" package manager to allow old packages be replaced but since "apk" also offers the field "replaces" which allow these overwrites explicitly [^2], modify the "origin" field appending the package name in order to make this field unique in all cases and get back the expected behavior since opkg times.

[^1]: apk docs https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/master/doc/apk-package.5.scd?#L127
[^2]: apk docs "replaces" https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/master/doc/apk-package.5.scd?#L217

Fixes: https://github.com/openwrt/openwrt/issues/20802#issuecomment-3539469449
