### PR TITLE
wifi-scripts: fix wifi failure on specifying value of DAE client

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -166,7 +166,7 @@ function iface_auth_type(config) {
 
 		if (config.radius_das_client && config.radius_das_secret) {
 			set_default(config, 'radius_das_port', 3799);
-			set_default(config, 'radius_das_client', `${config.radius_das_client} ${config.radius_das_secret}`);
+			config.radius_das_client = config.radius_das_client + ' ' + config.radius_das_secret;
 		}
 
 		set_default(config, 'eapol_version', config.wpa & 1);


### PR DESCRIPTION
The code to be replaced is a glorious no-op. A default value for config.radius_das_client does not need to be assigned. This parameter already has non-empty value: see the enclosing 'if' block.

As a result, the value of config.radius_das_client never gets modified to contain both dae_client and dae_secret. This breaks hostapd.add_iface() that expects config.radius_das_client to contain both dae_client and dae_secret separated by a whitespace.

This patch fixes #21519.
