### PR TITLE
dropbear: adjust failsafe script

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2025.89
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \

--- a/package/network/services/dropbear/files/dropbear.failsafe
+++ b/package/network/services/dropbear/files/dropbear.failsafe
@@ -32,8 +32,8 @@ failsafe_dropbear () {
 
 		case "${ktype}" in
 		ed25519) _ensurekey "${tkey}" -t ed25519 ;;
-		ecdsa)   _ensurekey "${tkey}" -t ecdsa -s 256 ;;
-		rsa)     _ensurekey "${tkey}" -t rsa   -s 1024 ;;
+		ecdsa)   _ensurekey "${tkey}" -t ecdsa ;;
+		rsa)     _ensurekey "${tkey}" -t rsa ;;
 		*)
 			echo "unknown key type: ${ktype}" >&2
 			continue


### PR DESCRIPTION
- remove size constraint for ECDSA: custom build may include only 384 or 521 bit curves;
- remove size constraint for RSA: default RSA key size is 2048 bits which is sufficient for SSH security recommendations, and previous value of 1024 bits is considered insecure.

Closes #20790.