### PR TITLE
ucode: minor patch adjustment

### DIFF
--- a/package/utils/ucode/patches/130-ubus-complete-pending-requests-when-disconnecting-lo.patch
+++ b/package/utils/ucode/patches/130-ubus-complete-pending-requests-when-disconnecting-lo.patch
@@ -23,7 +23,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
      add_definitions(-DHAVE_NEW_UBUS_STATUS_CODES)
    endif()
 +  if(HAVE_UBUS_FLUSH_REQUESTS)
-+    add_definitions(-DHAVE_UBUS_FLUSH_REQUESTS)
++    target_compile_definitions(ubus_lib PRIVATE HAVE_UBUS_FLUSH_REQUESTS)
 +  endif()
    if (HAVE_UBUS_NEW_OBJ_CB)
      target_compile_definitions(ubus_lib PUBLIC HAVE_UBUS_NEW_OBJ_CB)


### PR DESCRIPTION
improves bf46d119a275 "ucode-mod-ubus: complete pending requests when disconnecting locally" by providing definition only for ubus module and not bothering others.