### PR TITLE
airoha: show link rate and duplex

### DIFF
--- a/target/linux/airoha/patches-6.12/611-v7.0-net-airoha-implement-get_link_ksettings.patch
+++ b/target/linux/airoha/patches-6.12/611-v7.0-net-airoha-implement-get_link_ksettings.patch
@@ -1,0 +1,26 @@
+From 50e194b6da721e4fa1fc6ebcf5969803c214929a Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Sat, 10 Jan 2026 18:02:05 +0100
+Subject: [PATCH] net: airoha: implement get_link_ksettings
+
+Implement the .get_link_ksettings to get the rate, duplex, and
+auto-negotiation status.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Tested-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260110170212.570793-1-olek2@wp.pl
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/airoha/airoha_eth.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/net/ethernet/airoha/airoha_eth.c
++++ b/drivers/net/ethernet/airoha/airoha_eth.c
+@@ -2844,6 +2844,7 @@ static const struct ethtool_ops airoha_e
+ 	.get_drvinfo		= airoha_ethtool_get_drvinfo,
+ 	.get_eth_mac_stats      = airoha_ethtool_get_mac_stats,
+ 	.get_rmon_stats		= airoha_ethtool_get_rmon_stats,
++	.get_link_ksettings	= phy_ethtool_get_link_ksettings,
+ 	.get_link		= ethtool_op_get_link,
+ };
+ 


### PR DESCRIPTION
Implement the .get_link_ksettings to get the rate, duplex, and auto-negotiation status.

Link status:
~~~
root@OpenWrt:~# ethtool lan2
Settings for lan2:
        Supported ports: [  ]
        Supported link modes:   100baseT/Half 100baseT/Full
                                1000baseT/Full
                                10000baseT/Full
                                2500baseT/Full
                                5000baseT/Full
        Supported pause frame use: Symmetric Receive-only
        Supports auto-negotiation: Yes
        Supported FEC modes: Not reported
        Advertised link modes:  100baseT/Half 100baseT/Full
                                1000baseT/Full
                                10000baseT/Full
                                2500baseT/Full
                                5000baseT/Full
        Advertised pause frame use: Symmetric Receive-only
        Advertised auto-negotiation: Yes
        Advertised FEC modes: Not reported
        Link partner advertised link modes:  10baseT/Half 10baseT/Full
                                             100baseT/Half 100baseT/Full
                                             1000baseT/Full
        Link partner advertised pause frame use: Symmetric Receive-only
        Link partner advertised auto-negotiation: Yes
        Link partner advertised FEC modes: Not reported
        Speed: 1000Mb/s
        Duplex: Full
        Auto-negotiation: on
        Port: Twisted Pair
        PHYAD: 5
        Transceiver: external
        MDI-X: Unknown
        Link detected: yes
~~~

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>