### PR TITLE
rockchip: add `"compat_version": "1.1"` for Radxa E52C

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/board.d/05_compat-version
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/05_compat-version
@@ -1,0 +1,15 @@
+. /lib/functions.sh
+. /lib/functions/uci-defaults.sh
+
+board="$(board_name)"
+board_config_update
+
+case "$board" in
+radxa,e52c)
+	ucidef_set_compat_version "1.1"
+	;;
+esac
+
+board_config_flush
+
+exit 0


### PR DESCRIPTION
This is something I missed in https://github.com/openwrt/openwrt/pull/20608

Fixes: 1f1db75432 ("rockchip: make NIC name predictable for Radxa E52C/ROCK 5 ITX/ROCK 5T")

This should be backported to openwrt-25.12 ASAP.