### PR TITLE
realtek: dts: fix Zyxel GS1920 port section

### DIFF
--- a/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24hp-v1.dts
+++ b/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24hp-v1.dts
@@ -253,6 +253,9 @@
 
 &switch0 {
 	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		SWITCH_PORT_SDS(0, 1, 0, qsgmii)
 		SWITCH_PORT_SDS(1, 2, 0, qsgmii)
 		SWITCH_PORT_SDS(2, 3, 0, qsgmii)


### PR DESCRIPTION
For the GS1920 the build system throws errors like

```
../dts/rtl8392_zyxel_gs1920-24hp-v1.dts:256.19-29: 
Warning (reg_format): /switch@1b000000/ports/port@0:reg: 
property has invalid length (4 bytes)
(#address-cells == 2, #size-cells == 1)
```

The dts misses the address and size properties for the ports section. Fix that.

Fixes: 2a55846 ("realtek: add support for ZyXEL GS1920-24HPv1")
