### PR TITLE
strace: use bundled kernel headers

### DIFF
--- a/package/devel/strace/Makefile
+++ b/package/devel/strace/Makefile
@@ -10,7 +10,7 @@ include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=strace
 PKG_VERSION:=6.18
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=https://strace.io/files/$(PKG_VERSION)
@@ -30,8 +30,6 @@ PKG_CONFIG_DEPENDS := \
 
 include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/nls.mk
-
-HOST_CFLAGS += -I$(LINUX_DIR)/user_headers/include
 
 CONFIGURE_VARS+= \
 	LDFLAGS_FOR_BUILD="$(HOST_LDFLAGS)" \
@@ -72,6 +70,7 @@ CONFIGURE_ARGS += \
 	--with-libdw=$(if $(CONFIG_STRACE_LIBDW),yes,no) \
 	--with-libunwind=$(if $(CONFIG_STRACE_LIBUNWIND),yes,no) \
 	--enable-mpers=no \
+	--enable-bundled=yes \
 	--without-libselinux
 
 MAKE_FLAGS := \


### PR DESCRIPTION
Build against the bundled kernel headers instead of using the current kernel ones. This ensures strace is using the kernel headers it is written against, and not a random one that may contain breaking uapi changes (which happen from time to time).

Fixes build against 6.18 final and recent LTS/stable kernels that got minor uapi breakages (rename of a 6.18 introduced #define and a struct field).