### PR TITLE
busybox: enable fractional duration arguments by default

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -189,7 +189,7 @@ config BUSYBOX_DEFAULT_FEATURE_USE_BSS_TAIL
 	default n
 config BUSYBOX_DEFAULT_FLOAT_DURATION
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_RTMINMAX
 	bool
 	default n


### PR DESCRIPTION
Enable the fractional duration arguments busybox option by default.

This allows the use of sub-second intervals on time-related applets:

sleep 0.5

This allows using scripts made for other Linux distributions where fractional duration arguments are usually supported.