### PR TITLE
[25.12] netifd: use stable IAID for DHCPv4

### DIFF
--- a/package/base-files/files/lib/functions/network.sh
+++ b/package/base-files/files/lib/functions/network.sh
@@ -24,6 +24,17 @@ __network_ifstatus() {
 	eval "$__tmp"
 }
 
+# determine the IAID of the given logical interface
+# 1: destination variable
+# 2: interface
+network_generate_iface_iaid() {
+	local __iaid
+
+	__iaid=$(printf '%s' "$2" | md5sum | cut -c 1-8)
+
+	export "$1=$__iaid"
+}
+
 # determine first IPv4 address of given logical interface
 # 1: destination variable
 # 2: interface

--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=netifd
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/netifd.git

--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -3,6 +3,7 @@
 [ -x /sbin/udhcpc ] || exit 0
 
 . /lib/functions.sh
+. /lib/functions/network.sh
 . ../netifd-proto.sh
 . /lib/config/uci.sh
 init_proto "$@"
@@ -37,11 +38,11 @@ proto_dhcp_get_default_clientid() {
 
 	local iface="$1"
 	local duid
-	local iaid="0"
+	local iaid
 
-        [ -e "/sys/class/net/$iface/ifindex" ] && iaid="$(cat "/sys/class/net/$iface/ifindex")"
-        duid="$(uci_get network @globals[0] dhcp_default_duid)"
-        [ -n "$duid" ] && printf "ff%08x%s" "$iaid" "$duid"
+	network_generate_iface_iaid iaid "$iface"
+	duid="$(uci_get network @globals[0] dhcp_default_duid)"
+	[ -n "$duid" ] && printf "ff%s%s" "$iaid" "$duid"
 }
 
 proto_dhcp_setup() {


### PR DESCRIPTION
Backport of https://github.com/openwrt/openwrt/pull/21489

---

Commit https://github.com/openwrt/openwrt/commit/9151c7015ed2116b92a82b27c122310f1a91a426 introduced support for the global DHCP DUID to generate a RFC4361-style client identifier.
However, the IAID introduced in those changes is based on ifindex, which is subject to changes and causes issues on environments requiring a stable IAID.

This commit switches the IAID to a stable one based on the same algorithm used in odhcp6c:
https://github.com/openwrt/odhcp6c/commit/9a4d6fe802d21e4fc1b84f7d55b5c3c23e71d6ba

Fixes: https://github.com/openwrt/openwrt/commit/9151c7015ed2116b92a82b27c122310f1a91a426 ("netifd: use the global DHCP DUID for DHCPv4")