### PR TITLE
ramips: Add TP-Link MR6400 v7

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_16m.dtsi
+++ b/target/linux/ramips/dts/mt7628an_tplink_16m.dtsi
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	aliases {
+		label-mac-device = &ethernet;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x20000 0xfa0000>;
+			};
+
+			partition@fc0000 {
+				label = "config";
+				reg = <0xfc0000 0x10000>;
+				read-only;
+			};
+
+			factory: partition@fd0000 {
+				label = "factory";
+				reg = <0xfd0000 0x30000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_factory_f100: macaddr@f100 {
+						compatible = "mac-base";
+						reg = <0xf100 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					eeprom_factory_20000: eeprom@20000 {
+						reg = <0x20000 0x400>;
+					};
+
+					eeprom_factory_28000: eeprom@28000 {
+						reg = <0x28000 0x200>;
+					};
+				};
+			};
+		};
+	};
+};

--- a/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v7.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_tl-mr6400-v7.dts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include <dt-bindings/leds/common.h>
+
+#include "mt7628an_tplink_16m.dtsi"
+
+/ {
+	compatible = "tplink,tl-mr6400-v7", "mediatek,mt7628an-soc";
+	model = "TP-Link TL-MR6400 v7";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		signal1 {
+			label = "white:signal1";
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			label = "white:signal2";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			label = "white:signal3";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "p0led_an", "p1led_an", "p2led_an", "p3led_an", "p4led_an", "uart1", "wdt";
+		function = "gpio";
+	};
+};
+
+&esw {
+	mediatek,portmap = <0x37>;
+	mediatek,portdisable = <0x30>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_factory_1f100 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_1f100 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_factory_1f100: macaddr@1f100 {
+			compatible = "mac-base";
+			reg = <0x1f100 0x6>;
+			#nvmem-cell-cells = <1>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1053,6 +1053,22 @@ define Device/tplink_tl-mr6400-v5
 endef
 TARGET_DEVICES += tplink_tl-mr6400-v5
 
+define Device/tplink_tl-mr6400-v7
+  $(Device/tplink-v2)
+  IMAGE_SIZE := 15872k
+  DEVICE_MODEL := TL-MR6400
+  DEVICE_VARIANT := v7
+  TPLINK_FLASHLAYOUT := 16Mmtk
+  TPLINK_HWID := 0x64000007
+  TPLINK_HWREV := 0x7
+  TPLINK_HWREVADD := 0x7
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
+	kmod-usb-serial-option kmod-usb-net-qmi-wwan uqmi
+  IMAGES := sysupgrade.bin tftp-recovery.bin
+  IMAGE/tftp-recovery.bin := pad-extra 128k | $$(IMAGE/factory.bin)
+endef
+TARGET_DEVICES += tplink_tl-mr6400-v7
+
 define Device/tplink_tl-wa801nd-v5
   $(Device/tplink-v2)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -149,7 +149,8 @@ tplink,tl-mr6400-v4)
 	ucidef_set_led_switch "lan" "lan" "white:lan" "switch0" "0x0e"
 	ucidef_set_led_switch "wan" "wan" "white:wan" "switch0" "0x10"
 	;;
-tplink,tl-mr6400-v5)
+tplink,tl-mr6400-v5|\
+tplink,tl-mr6400-v7)
 	ucidef_set_led_switch "lan" "lan" "white:lan" "switch0" "0x07"
 	ucidef_set_led_switch "wan" "wan" "white:wan" "switch0" "0x08"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -213,7 +213,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
-	tplink,tl-mr6400-v5)
+	tplink,tl-mr6400-v5|\
+	tplink,tl-mr6400-v7)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:wan" "6@eth0"
 		;;


### PR DESCRIPTION
Just got my hands on this device, and after reviewing the forums, I found that the device is exactly the same as the v5 but with double the ram and rom. I tested the v5 rom and it worked, but I only got 8mb of rom (ram was automatically detected). Now, whith this changes the system shows the full 16mb.

---
### Memory Expansion
Based on the discussion of this forum (https://forum.openwrt.org/t/new-device-tp-link-mr6400-v7/214794/10), the v5 and v7 have the same similar hardware apart from the memory expansion on the v7 that doubles the space from 8m -> 16m.

```diff
--- mt7628an_tplink_8m.dtsi
+++ mt7628an_tplink_16m.dtsi
@@ -30,17 +32,17 @@
 			partition@20000 {
 				compatible = "tplink,firmware";
 				label = "firmware";
-				reg = <0x20000 0x7a0000>;
+				reg = <0x20000 0xfa0000>;
 			};
 
-			partition@7c0000 {
+			partition@fc0000 {
 				label = "config";
-				reg = <0x7c0000 0x10000>;
+				reg = <0xfc0000 0x10000>;
 				read-only;
 			};
 
-			factory: partition@7d0000 {
+			factory: partition@fd0000 {
 				label = "factory";
-				reg = <0x7d0000 0x30000>;
+				reg = <0xfd0000 0x30000>;
 				read-only;
```
#### 1. **Firmware partition expansion**
```diff
-reg = <0x20000 0x7a0000>;
+reg = <0x20000 0xfa0000>;
```
The firmware partition was expanded from **7.875 MB** (0x7a0000) to **15.625 MB** (0xfa0000), gaining **8 MB of additional space** for the firmware. This change maximizes the usable flash space on the 16MB device, allowing for larger OpenWrt builds with more packages and features.

#### 2. **Config partition relocation**
```diff
-partition@7c0000 {
+partition@fc0000 {
-reg = <0x7c0000 0x10000>;
+reg = <0xfc0000 0x10000>;
```
The `config` partition was relocated from offset `0x7c0000` to `0xfc0000` (shifted 8MB forward) to accommodate the expanded firmware partition. The partition size remains unchanged at **64 KB** (0x10000), preserving the same storage capacity for device configuration data.

#### 3. **Factory partition relocation**
```diff
-factory: partition@7d0000 {
+factory: partition@fd0000 {
-reg = <0x7d0000 0x30000>;
+reg = <0xfd0000 0x30000>;
```
The `factory` partition was also shifted from `0x7d0000` to `0xfd0000`, maintaining its size at **192 KB** (0x30000). This read-only partition contains critical WiFi calibration data and MAC addresses, which must be preserved at a fixed size for proper device operation.

