### PR TITLE
[25.12]: build: apk-related improvements, part 2

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -219,15 +219,6 @@ define KernelPackage
     $(call KernelPackage/$(1))
     $(call KernelPackage/$(1)/$(BOARD))
     $(call KernelPackage/$(1)/$(BOARD)/$(SUBTARGET))
-
-    # Add an implicit self-provide. apk can't handle self provides, be it
-    # versioned or virtual, so opt for a prefix and a suffix instead. Package
-    # name without a prefix/suffix is too generic and might conflict with other
-    # packages, e.g. wireguard. This allows several variants to provide the same
-    # virtual package without adding extra provides to the default one, e.g.
-    # r8169 implicitly provides kmod-r8169-any and is marked as default, so
-    # r8125 can explicitly provide @kmod-r8169-any as well.
-    PROVIDES+=@kmod-$(1)-any
   endef
 
   ifdef KernelPackage/$(1)/conffiles

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -522,7 +522,7 @@ else
 	  --info "url:$(URL)" \
 	  --info "maintainer:$(MAINTAINER)" \
 	  $$(if $$(Package/$(1)/PROVIDES),--info "provides:$$(Package/$(1)/PROVIDES)") \
-	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100",$(if $(PROVIDES),--info "provider-priority:1")) \
+	  $(if $(DEFAULT_VARIANT),--info "provider-priority:100") \
 	  $$(APK_SCRIPTS_$(1)) \
 	  --info "depends:$$(foreach depends,$$(subst $$(comma),$$(space),$$(subst $$(space),,$$(subst $$(paren_right),,$$(subst $$(paren_left),,$$(Package/$(1)/DEPENDS))))),$$(depends))" \
 	  --files "$$(IDIR_$(1))" \

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -195,10 +195,9 @@ endef
 #   self. Filter it out, but keep virtual self provides, in the form of
 #   @(kmod-)?${package_name}-any.
 #
-# - Packages implicitly add a virtual @${package_name}-any provide in Package.
-#
-# - kmods implicitly add a virtual @kmod-${package_name}-any provide in
-#   KernelPackage.
+# - Packages implicitly add a virtual @${package_name}-any provide in Package,
+#   which implies that kmods, which are also packages, will have a virtual
+#   @kmod-${package_name}-any provide.
 #
 # - Aside from the two aforementioned implicit provides, packages are expected
 #   to manage their provides themselves.

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -505,21 +505,21 @@ else
 		echo 'export pkgname="$(1)$$(ABIV_$(1))"'; \
 		echo "add_group_and_user"; \
 		echo "default_postinst"; \
-		[ ! -f $$(ADIR_$(1))/postinst-pkg ] || sed -z 's/^\s*#!/#!/' "$$(ADIR_$(1))/postinst-pkg"; \
+		[ ! -f $$(ADIR_$(1))/postinst-pkg ] || sed '/^\s*#!/d' "$$(ADIR_$(1))/postinst-pkg"; \
 	) > $$(ADIR_$(1))/post-install;
 
     ifdef Package/$(1)/preinst
 	( \
 		echo "#!/bin/sh"; \
 		echo 'export PKG_UPGRADE=1'; \
-		[ ! -f $$(ADIR_$(1))/preinst ] || sed -z 's/^\s*#!/#!/' "$$(ADIR_$(1))/preinst"; \
+		[ ! -f $$(ADIR_$(1))/preinst ] || sed '/^\s*#!/d' "$$(ADIR_$(1))/preinst"; \
 	) > $$(ADIR_$(1))/pre-upgrade;
     endif
 
 	( \
 		echo "#!/bin/sh"; \
 		echo 'export PKG_UPGRADE=1'; \
-		[ ! -f $$(ADIR_$(1))/post-install ] || sed -z 's/^\s*#!/#!/' "$$(ADIR_$(1))/post-install"; \
+		[ ! -f $$(ADIR_$(1))/post-install ] || sed '/^\s*#!/d' "$$(ADIR_$(1))/post-install"; \
 	) > $$(ADIR_$(1))/post-upgrade;
 
 	( \
@@ -529,7 +529,7 @@ else
 		echo 'export root="$$$${IPKG_INSTROOT}"'; \
 		echo 'export pkgname="$(1)$$(ABIV_$(1))"'; \
 		echo "default_prerm"; \
-		[ ! -f $$(ADIR_$(1))/prerm-pkg ] || sed -z 's/^\s*#!/#!/' "$$(ADIR_$(1))/prerm-pkg"; \
+		[ ! -f $$(ADIR_$(1))/prerm-pkg ] || sed '/^\s*#!/d' "$$(ADIR_$(1))/prerm-pkg"; \
 	) > $$(ADIR_$(1))/pre-deinstall;
 
 	[ ! -f $$(ADIR_$(1))/postrm ] || sed -zi 's/^\s*#!/#!/' "$$(ADIR_$(1))/postrm";

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -78,6 +78,55 @@ define FixupDependencies
   $(call AddDependency,$(1),$$(DEPS))
 endef
 
+# Format dependencies and extra dependencies
+#
+# ABI-version EXTRA_DEPENDS so dependencies can be correctly looked up using the
+# existing semantics without the ABI specified. This is needed since ABI-
+# versioned libraries don't provide `${package_name}=${package_version}`, so
+# that same library but with different ABI versions can be installed side by
+# side.
+#
+# Remove duplicate dependencies when EXTRA_DEPENDS specifies a versioned one
+# that is already in DEPENDS.
+#
+# 1: list of dependencies
+# 2: list of extra dependencies
+define FormatDepends
+$(strip
+  $(eval _COMMA_SEP := __COMMA_SEP__)
+  $(eval _SPACE_SEP := __SPACE_SEP__)
+  $(eval _DEPENDS := $(1))
+  $(eval _EXTRA_DEPENDS_ABI := )
+  $(eval _DEP_ITEMS := $(subst $(_COMMA_SEP),$(space),$(subst $(space),$(_SPACE_SEP),$(subst $(comma),$(_COMMA_SEP),$(2)))))
+
+  $(foreach dep,$(_DEP_ITEMS),
+    $(eval _EXTRA_DEP := )
+    $(eval _CUR_DEP := $(subst $(_SPACE_SEP),$(space),$(strip $(dep))))
+    $(eval _PKG_NAME := $(word 1,$(_CUR_DEP)))
+    $(if $(findstring $(paren_left), $(_PKG_NAME)),
+      $(error "Unsupported extra dependency format: no space before '(': $(_CUR_DEP)"))
+    )
+    $(eval _ABI_SUFFIX := $(call GetABISuffix,$(_PKG_NAME)))
+    $(eval _PKG_NAME_ABI := $(_PKG_NAME)$(_ABI_SUFFIX))
+    $(eval _VERSION_CONSTRAINT := $(word 2,$(_CUR_DEP)))
+    $(if $(_VERSION_CONSTRAINT),
+      $(eval _EXTRA_DEP := $(_PKG_NAME_ABI) $(_VERSION_CONSTRAINT)),
+      $(error "Extra dependencies must have version constraints. $(_PKG_NAME) seems to be unversioned.")
+    )
+    $(if $(and $(_EXTRA_DEPENDS_ABI),$(_EXTRA_DEP)),
+      $(eval _EXTRA_DEPENDS_ABI := $(_EXTRA_DEPENDS_ABI)$(comma)$(_EXTRA_DEP)),
+      $(eval _EXTRA_DEPENDS_ABI := $(_EXTRA_DEP))
+    )
+    $(if $(_DEPENDS),
+      $(eval _DEPENDS := $(filter-out $(_PKG_NAME_ABI),$(_DEPENDS)))
+    )
+  )
+
+  $(eval _DEPENDS := $(call mergelist,$(_DEPENDS)))
+  $(_EXTRA_DEPENDS_ABI)$(if $(_DEPENDS),$(comma) $(_DEPENDS))
+)
+endef
+
 # Format provide and add ABI and version if it's not a virtual provide marked
 # with an @.
 #
@@ -308,36 +357,7 @@ endif
         Package/$(1)/DEPENDS := $$(call mergelist,$$(Package/$(1)/DEPENDS))
         Package/$(1)/DEPENDS := $$(EXTRA_DEPENDS)$$(if $$(Package/$(1)/DEPENDS),$$(comma) $$(Package/$(1)/DEPENDS))
       else
-        _SEP := __COMMA_SEP__
-        _SPACE := __SPACE_SEP__
-        _DEPENDS := $$(Package/$(1)/DEPENDS)
-        _EXTRA_DEPENDS_ABI :=
-        _DEP_ITEMS := $$(subst $$(_SEP),$$(space),$$(subst $$(space),$$(_SPACE),$$(subst $$(comma),$$(_SEP),$$(EXTRA_DEPENDS))))
-
-        $$(foreach dep,$$(_DEP_ITEMS), \
-          $$(eval _CUR_DEP := $$(subst $$(_SPACE),$$(space),$$(strip $$(dep)))) \
-          $$(eval _PKG_NAME := $$(word 1,$$(_CUR_DEP))) \
-          $$(if $$(findstring $$(paren_left), $$(_PKG_NAME)), \
-            $$(error "Unsupported extra dependency format: no space before '(': $$(_CUR_DEP)")) \
-          ) \
-          $$(eval _ABI_SUFFIX := $$(call GetABISuffix,$$(_PKG_NAME))) \
-          $$(eval _PKG_NAME_ABI := $$(_PKG_NAME)$$(_ABI_SUFFIX)) \
-          $$(eval _VERSION_CONSTRAINT := $$(word 2,$$(_CUR_DEP))) \
-          $$(if $$(_VERSION_CONSTRAINT), \
-            $$(eval _EXTRA_DEP := $$(_PKG_NAME_ABI) $$(_VERSION_CONSTRAINT)), \
-            $$(error "Extra dependencies must have version constraints. $$(_PKG_NAME) seems to be unversioned.") \
-          ) \
-          $$(if $$(_EXTRA_DEPENDS_ABI), \
-            $$(eval _EXTRA_DEPENDS_ABI := $$(_EXTRA_DEPENDS_ABI)$$(comma)$$(_EXTRA_DEP)), \
-            $$(eval _EXTRA_DEPENDS_ABI := $$(_EXTRA_DEP)) \
-          ) \
-          $$(if $$(_DEPENDS), \
-            $$(eval _DEPENDS := $$(filter-out $$(_PKG_NAME_ABI),$$(_DEPENDS))) \
-          ) \
-        )
-
-        _DEPENDS := $$(call mergelist,$$(_DEPENDS))
-        Package/$(1)/DEPENDS := $$(_EXTRA_DEPENDS_ABI)$$(if $$(_DEPENDS),$$(comma) $$(_DEPENDS))
+        Package/$(1)/DEPENDS := $$(call FormatDepends,$$(Package/$(1)/DEPENDS),$$(EXTRA_DEPENDS))
       endif
     else
       Package/$(1)/DEPENDS := $$(call mergelist,$$(Package/$(1)/DEPENDS))

--- a/include/package.mk
+++ b/include/package.mk
@@ -337,7 +337,7 @@ define BuildPackage
   # variants to provide the same virtual package without adding extra provides
   # to the default one, e.g. wget implicitly provides wget-any and is marked as
   # default, so wget-ssl can explicitly provide @wget-any as well.
-  PROVIDES+=@$(1)-any
+  $(eval PROVIDES:=$(strip @$(1)-any $(PROVIDES)))
 
 ifdef DESCRIPTION
 $$(error DESCRIPTION:= is obsolete, use Package/PKG_NAME/description)

--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -51,7 +51,6 @@ define Package/libelf
   $(call Package/elfutils/Default)
   DEPENDS:=$(INTL_DEPENDS) +zlib
   TITLE+= (libelf)
-  PROVIDES:=libelf1
 endef
 
 ifeq ($(CONFIG_BUILD_NLS),y)

--- a/package/libs/uclient/Makefile
+++ b/package/libs/uclient/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uclient
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uclient.git
@@ -34,7 +34,8 @@ define Package/uclient-fetch
   CATEGORY:=Network
   TITLE:=Tiny wget replacement using libuclient
   ALTERNATIVES:=200:/usr/bin/wget:/bin/uclient-fetch
-  PROVIDES:=wget
+  DEFAULT_VARIANT:=1
+  PROVIDES:=@wget-any
   DEPENDS:=+libuclient
 endef
 

--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git
@@ -26,7 +26,7 @@ define Package/apk/default
   SECTION:=base
   CATEGORY:=Base system
   TITLE:=apk package manager
-  DEPENDS:=+zlib +wget
+  DEPENDS:=+zlib +wget-any
   URL:=$(PKG_SOURCE_URL)
   PROVIDES:=apk
 endef

--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -145,6 +145,32 @@ BUILD_PACKAGES:=$(sort $(DEFAULT_PACKAGES) $($(USER_PROFILE)_PACKAGES) kernel)
 BUILD_PACKAGES:=$(filter-out $(filter -%,$(BUILD_PACKAGES)) $(patsubst -%,%,$(filter -%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
 BUILD_PACKAGES:=$(USER_PACKAGES) $(BUILD_PACKAGES)
 BUILD_PACKAGES:=$(filter-out $(filter -%,$(BUILD_PACKAGES)) $(patsubst -%,%,$(filter -%,$(BUILD_PACKAGES))),$(BUILD_PACKAGES))
+
+ifneq ($(CONFIG_USE_APK),)
+BUILD_PACKAGES+= \
+  "base-files=$(BASE_FILES_VERSION)" \
+  "libc=$(LIBC_VERSION)" \
+  "kernel=$(KERNEL_VERSION)"
+endif
+
+# Get ABI version suffix for a package from an apk index
+#
+# 1: package name
+define GetABISuffix
+$(shell $(APK) query --fields tags --match provides $(1) | grep openwrt:abiversion | awk -F= '{print $$2; exit}')
+endef
+
+# Format packages by adding an ABI version suffix if found
+#
+# 1: list of packages
+define FormatPackages
+$(strip $(foreach pkg,$(strip $(subst ",,$(1))),
+  $(eval pkg_name:=$(firstword $(subst =, ,$(pkg))))
+  $(if $(findstring =,$(pkg)),$(eval pkg_ver:==$(lastword $(subst =, ,$(pkg)))))
+  $(pkg_name)$(call GetABISuffix,$(pkg_name))$(pkg_ver)
+))
+endef
+
 PACKAGES:=
 
 _call_image: staging_dir/host/.prereq-build
@@ -229,10 +255,8 @@ ifeq ($(CONFIG_USE_APK),)
 	$(OPKG) install $(wildcard $(PACKAGE_DIR)/kernel_*.ipk)
 	$(OPKG) install $(BUILD_PACKAGES)
 else
-	$(APK) add --arch $(ARCH_PACKAGES) --no-scripts $(BUILD_PACKAGES) \
-        "base-files=$(BASE_FILES_VERSION)" \
-        "libc=$(LIBC_VERSION)" \
-        "kernel=$(KERNEL_VERSION)"
+	$(eval BUILD_PACKAGES:=$(call FormatPackages,$(BUILD_PACKAGES)))
+	$(APK) add --arch $(ARCH_PACKAGES) --no-scripts $(BUILD_PACKAGES)
 endif
 
 prepare_rootfs: FORCE


### PR DESCRIPTION
Cherry pick these PR: https://github.com/openwrt/openwrt/pull/21369 and https://github.com/openwrt/openwrt/pull/21449

 * build: remove default provider priority
    
    Remove default provider priority since packages are expected to
    explicitly declare virtual provides and set default variants. With
    default priority some package variants without PROVIDES and not marked
    as default end up with priority 0 and are not picked for installation.
    
    Before the change dnsmasq-dhcpv6 is selected for dnsmasq, because the
    former has higher priority:
    
    name <dnsmasq> selected from selectable list
    select_package: dnsmasq (requirers=1, autosel=1, iif=0, order_id=0x4000005f)
      consider dnsmasq-2.91-r2 iif_triggered=0, tag_ok=1, selectable=1, available=1, flags=0x0, provider_priority=0, installed=0
       prefer existing package
        choose as new provider
      consider dnsmasq-dhcpv6-2.91-r2 iif_triggered=0, tag_ok=1, selectable=1, available=1, flags=0x0, provider_priority=1, installed=0
        prefer highest declared provider priority
        choose as new provider
      consider dnsmasq-full-2.91-r2 iif_triggered=0, tag_ok=1, selectable=1, available=1, flags=0x0, provider_priority=1, installed=0
        prefer lowest available repository
    selecting: dnsmasq-dhcpv6-2.91-r2, available: 1
    assign dnsmasq-dhcpv6 to dnsmasq-dhcpv6-2.91-r2
    assign dnsmasq to dnsmasq-dhcpv6-2.91-r2
    disqualify_package: dnsmasq-2.91-r2 (conflicting provides)
    disqualify_package: dnsmasq-full-2.91-r2 (conflicting provides)
        apply_constraint: libc
        apply_constraint: provider: libc-1.2.5-r5: 1
    
    After the change dnsmasq is selected for dnsmasq based on
    lexicographical order:
    
    name <dnsmasq> selected from selectable list
    select_package: dnsmasq (requirers=1, autosel=1, iif=0, order_id=0x4000005f)
      consider dnsmasq-2.91-r2 iif_triggered=0, tag_ok=1, selectable=1, available=1, flags=0x0, provider_priority=0, installed=0
       prefer existing package
        choose as new provider
      consider dnsmasq-dhcpv6-2.91-r2 iif_triggered=0, tag_ok=1, selectable=1, available=1, flags=0x0, provider_priority=0, installed=0
        prefer lowest available repository
      consider dnsmasq-full-2.91-r2 iif_triggered=0, tag_ok=1, selectable=1, available=1, flags=0x0, provider_priority=0, installed=0
        prefer lowest available repository
    selecting: dnsmasq-2.91-r2, available: 1
    assign dnsmasq to dnsmasq-2.91-r2
    disqualify_package: dnsmasq-dhcpv6-2.91-r2 (conflicting provides)
    disqualify_package: dnsmasq-full-2.91-r2 (conflicting provides)
        apply_constraint: libc
        apply_constraint: provider: libc-1.2.5-r5: 1
    
    Fixes: dea8397 ("include/package-pack: add default 'provider_priority' for APK packages")
    (cherry picked from commit 49fc31903306c346fcda862800f40d5e94cff5b0)

 * build: don't auto mark all provides as virtual
    
    Don't mark all provides as virtual when ALTERNATIVES is set.
    Automatically marking all provides as virtual prevents variants from
    conflicting between each other. Alternatives have nothing to do with
    packaging and packages are expected to manage their own provides.
    
    Updated internal provides explanation.
    
    Remove unnecessary back slashes from FormatProvides.
    
    Fixes: 18029977 ("build: fix apk packaging and ABI-versioning")
    (cherry picked from commit 2a1977a4b83c8b5c61a2e74deeac00e2b58e026f)

 * build: refactor dependency formatting
    
    Refactor dependencies and extra dependencies logic into a helper define
    and document it.
    
    (cherry picked from commit 779fa7ff6caa509d5df3827342162fdb07093cee)

 * build: fix provides logic when ABI version is set
    
    Same as for the base package name, when a package has an ABI version,
    provide both unversioned provider in addition to one with ABI version
    and version.
    
    So for each provide instead of providing only:
    
    $provide$ABI_version=$package_version
    
    now provide:
    
    $provide $provide$ABI_version=$package_version
    
    When a provide ends in a number, the ABI version will be prefixed with
    a - sign, e.g.: provide1-0
    
    Fixes: 18029977 ("build: fix apk packaging and ABI-versioning")
    Signed-off-by: George Sapkin <george@sapk.in>
    Link: https://github.com/openwrt/openwrt/pull/21369
    Signed-off-by: Robert Marko <robimarko@gmail.com>
    (cherry picked from commit 952c918028b4811e5cf0f3fa8607ce50630a5060)

 * uclient: provide virtual wget-any
    
    Packages shouldn't provide a package that another package, in this case
    wget from packages provides. Explicitly provide a virtual @wget-any
    instead to match the implicit wget provide and switch the only consumer
    to use the new provider.
    
    Set uclient-fetch as the default variant for wget-any.
    
    (cherry picked from commit af1fa176c31368e5e56c5a1f31d8a12273536378)

 * elfutils: drop libelf1 provide
    
    ABI version is added to a package name during packaging, so there's no
    need to specify it manually. And nothing explicitly depends on libelf1.
    
    Fixes: d7bf089 ("elfutils: rename libelf1 to libelf")
    Signed-off-by: George Sapkin <george@sapk.in>
    Link: https://github.com/openwrt/openwrt/pull/21369
    Signed-off-by: Robert Marko <robimarko@gmail.com>
    (cherry picked from commit 8cc2743c4865607b67f9b4b2ecacb62e242abb20)

 * build: fix implicit self-provides
    
    Fix setting implicit self-provides for packages when they don't have any
    PROVIDES specified.
    
    Remove redundant self-provide for kmods, since kmods are packages and
    will have a self-provide added already.
    
    Fixes: 5ed650a ("build: add support for virtual provides")
    Fixes: 9b37b71 ("build: provide virtual self in kmods")
    (cherry picked from commit 2d844a077089575ab67fcbd15e021a981387e668)

 * build: remove redundant shebang from apk lifecycle scripts
    
    Due to the way apk lifecycle scripts are defined, they might end up with
    multiple shebangs. Remove them.
    
    Before:
    
      post-upgrade: |
        #!/bin/sh
        export PKG_UPGRADE=1
        #!/bin/sh
        [ "${IPKG_NO_SCRIPT}" = "1" ] && exit 0
        [ -s ${IPKG_INSTROOT}/lib/functions.sh ] || exit 0
        . ${IPKG_INSTROOT}/lib/functions.sh
        export root="${IPKG_INSTROOT}"
        export pkgname="adblock-fast"
        add_group_and_user
        default_postinst
        #!/bin/sh
        # check if we are on real system
        if [ -z "${IPKG_INSTROOT}" ]; then
            /etc/init.d/adblock-fast enable
        fi
        exit 0
    
    After:
    
      post-upgrade: |
        #!/bin/sh
        export PKG_UPGRADE=1
        [ "${IPKG_NO_SCRIPT}" = "1" ] && exit 0
        [ -s ${IPKG_INSTROOT}/lib/functions.sh ] || exit 0
        . ${IPKG_INSTROOT}/lib/functions.sh
        export root="${IPKG_INSTROOT}"
        export pkgname="adblock-fast"
        add_group_and_user
        default_postinst
        # check if we are on real system
        if [ -z "${IPKG_INSTROOT}" ]; then
            /etc/init.d/adblock-fast enable
        fi
        exit 0
    
    Fixes: b52e897 ("include/package-pack: remove leading whitespace from install scripts")
    Fixes: 03880e2 ("include/package-pack: add missing apk package lifecycle events")
    (cherry picked from commit 1dec4683f6a91cb0734e97186738b0ea413bb356)

 * build: add default priority to ABI-versioned packages
    
    If a package has an ABI version defined, set priority to 10. The enables
    packages with an ABI version to be installed by their base name instead
    of a name and an ABI version, e.g.:
    
    libfoo3, where 3 is the ABI version can be installed by just libfoo.
    
    This affects manual installation only, as the dependency resolution
    takes care of ABI versions.
    
    Refactor apk priority logic into a helper define.
    
    (cherry picked from commit 470e030a5eae77e94192e0dd933d7b1b657f7b2c)

 * imagebuilder: add ABI suffix to packages when using apk
    
    If an apk package with an ABI version doesn't have priority set, it
    can't be selected by its base name:
    
    $ make manifest PACKAGES='libustream-openssl libsqlite3'
    ERROR: unable to select packages:
      libsqlite3 (virtual):
        note: please select one of the 'provided by'
              packages explicitly
        provided by: libsqlite3-0
        required by: world[libsqlite3]
      libustream-openssl (virtual):
        note: please select one of the 'provided by'
              packages explicitly
        provided by: libustream-openssl20201210
        required by: world[libustream-openssl]
    
    Look up the ABI version in apk index and if present, add an ABI suffix
    to all requested packages.
    
    (cherry picked from commit 31cdd13d22dd374d4a8b8d86377627ad01928495)
