### PR TITLE
ramips: add support for D-Link DIR-1360 A1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-1360-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-1360-a1.dts
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "dlink,dir-1360-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-1360 A1";
+
+	/* 1. Updated for 256MB RAM */
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_white;
+		led-running = &led_power_white;
+		led-upgrade = &led_internet_orange;
+	};
+
+	/* 2. Updated Keys for DIR-1360 */
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	/* 3. Updated LEDs for DIR-1360 */
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			function = "power";
+			color = <3>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_white: power_white {
+			function = "power";
+			color = <1>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_internet_orange: internet_orange {
+			label = "orange:internet";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_internet_white: internet_white {
+			label = "white:internet";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		usb_white {
+			function = "usb";
+			color = <1>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan2g {
+			label = "white:wlan2g";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5g {
+			label = "white:wlan5g";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+};
+
+/* 4. Base NAND Config */
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		/* --- FIX APPLIED HERE: Added "factory:" label --- */
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
+			};
+		};
+
+		partition@140000 {
+			label = "config2";
+			reg = <0x140000 0x40000>;
+			read-only;
+		};
+
+		/* 40MB Firmware Partition */
+		partition@180000 {
+			label = "firmware";
+			compatible = "openwrt,uimage", "denx,uimage";
+			openwrt,padding = <96>;
+			reg = <0x180000 0x2800000>;
+		};
+
+		partition@2980000 {
+			label = "private";
+			reg = <0x2980000 0x2000000>;
+			read-only;
+		};
+
+		partition@4980000 {
+			label = "firmware2";
+			reg = <0x4980000 0x2800000>;
+		};
+
+		partition@7180000 {
+			label = "mydlink";
+			reg = <0x7180000 0x600000>;
+			read-only;
+		};
+
+		partition@7780000 {
+			label = "reserved";
+			reg = <0x7780000 0x880000>;
+			read-only;
+		};
+	};
+};
+
+/* 5. Fixed PCIe / WiFi Config */
+&pcie {
+	status = "okay";
+
+	pcie@0,0 {
+		status = "okay";
+		wifi@0,0 {
+			compatible = "mediatek,mt7615";
+			reg = <0x0000 0 0 0 0>;
+			
+			nvmem-cells = <&macaddr_factory_4>;
+			nvmem-cells = <&macaddr_factory_e000>;
+
+			/* Fixed Calibration Paths */
+			mediatek,mtd-eeprom = <&factory 0x0000>;
+			mediatek,2g-eeprom = <&factory 0x0000>;
+			mediatek,5g-eeprom = <&factory 0x8000>;
+		};
+	};
+};
+
+/* 6. Specific LAN MAC Config */
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+/* 7. Base WAN Config */
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@0 { status = "okay"; label = "lan4"; };
+		port@1 { status = "okay"; label = "lan3"; };
+		port@2 { status = "okay"; label = "lan2"; };
+		port@3 { status = "okay"; label = "lan1"; };
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/dts/mt7621_dlink_dir-1360-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-1360-a1.dts
@@ -10,7 +10,6 @@
 	compatible = "dlink,dir-1360-a1", "mediatek,mt7621-soc";
 	model = "D-Link DIR-1360 A1";
 
-	/* 1. Updated for 256MB RAM */
 	memory@0 {
 		device_type = "memory";
 		reg = <0x0 0x10000000>;
@@ -24,7 +23,6 @@
 		led-upgrade = &led_internet_orange;
 	};
 
-	/* 2. Updated Keys for DIR-1360 */
 	keys {
 		compatible = "gpio-keys";
 
@@ -41,7 +39,6 @@
 		};
 	};
 
-	/* 3. Updated LEDs for DIR-1360 */
 	leds {
 		compatible = "gpio-leds";
 
@@ -90,7 +87,6 @@
 	};
 };
 
-/* 4. Base NAND Config */
 &nand {
 	status = "okay";
 
@@ -111,7 +107,6 @@
 			read-only;
 		};
 
-		/* --- FIX APPLIED HERE: Added "factory:" label --- */
 		factory: partition@100000 {
 			label = "factory";
 			reg = <0x100000 0x40000>;
@@ -126,16 +121,16 @@
 					reg = <0x0 0x4da8>;
 				};
 
-				macaddr_factory_4: macaddr@4 {
-					reg = <0x4 0x6>;
-				};
-
 				macaddr_factory_e000: macaddr@e000 {
 					reg = <0xe000 0x6>;
 				};
 
 				macaddr_factory_e006: macaddr@e006 {
 					reg = <0xe006 0x6>;
+				};
+
+				macaddr_factory_e00c: macaddr@e00c {
+					reg = <0xe00c 0x6>;
 				};
 			};
 		};
@@ -146,7 +141,6 @@
 			read-only;
 		};
 
-		/* 40MB Firmware Partition */
 		partition@180000 {
 			label = "firmware";
 			compatible = "openwrt,uimage", "denx,uimage";
@@ -179,7 +173,6 @@
 	};
 };
 
-/* 5. Fixed PCIe / WiFi Config */
 &pcie {
 	status = "okay";
 
@@ -188,25 +181,19 @@
 		wifi@0,0 {
 			compatible = "mediatek,mt7615";
 			reg = <0x0000 0 0 0 0>;
-			
-			nvmem-cells = <&macaddr_factory_4>;
-			nvmem-cells = <&macaddr_factory_e000>;
-
-			/* Fixed Calibration Paths */
+			nvmem-cells = <&macaddr_factory_e00c>;
+			nvmem-cell-names = "mac-address";
+			mac-address-increment = <1>;
 			mediatek,mtd-eeprom = <&factory 0x0000>;
-			mediatek,2g-eeprom = <&factory 0x0000>;
-			mediatek,5g-eeprom = <&factory 0x8000>;
 		};
 	};
 };
 
-/* 6. Specific LAN MAC Config */
 &gmac0 {
 	nvmem-cells = <&macaddr_factory_e000>;
 	nvmem-cell-names = "mac-address";
 };
 
-/* 7. Base WAN Config */
 &gmac1 {
 	status = "okay";
 	label = "wan";

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -948,6 +948,20 @@ define Device/dlink_dir_nand_128m
 	check-size
 endef
 
+define Device/dlink_dir-1360-a1
+  $(Device/dlink_dir_nand_128m)
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DIR-1360
+  DEVICE_VARIANT := A1
+  DLK_HWID := DLK6E5101001
+  IMAGE_SIZE := 120832k
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7615-firmware kmod-usb3 kmod-usb-dwc3-mtk luci ubi-utils
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += dlink_dir-1360-a1
+
 define Device/dlink_dir-1935-a1
   $(Device/dlink_dir-8xx-a1)
   DEVICE_MODEL := DIR-1935

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -99,6 +99,13 @@ dlink,dap-x1860-a1)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimedium" "wlan1" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan1" "76" "100"
 	;;
+dlink,dir-1360-a1)
+	ucidef_set_led_default "power" "Power" "white:power" "1"
+	ucidef_set_led_netdev "internet" "Internet" "white:internet" "eth1"
+	ucidef_set_led_wlan "wlan2g" "WLAN2G" "white:wlan2g" "phy0radio"
+	ucidef_set_led_wlan "wlan5g" "WLAN5G" "white:wlan5g" "phy1radio"
+	ucidef_set_led_usbport "usb" "USB" "white:usb" "usb1-port1" "usb2-port1"
+	;;
 dlink,dir-1960-a1|\
 dlink,dir-2055-a1|\
 dlink,dir-2150-a1|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -46,6 +46,9 @@ ramips_setup_interfaces()
 	cudy,ap1300-outdoor-v1|\
 	dlink,dap-1620-b1|\
 	dlink,dap-x1860-a1|\
+	dlink,dir-1360-a1)
+	        ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+		;;
 	dlink,dra-1360-a1|\
 	edimax,re23s|\
 	linksys,re7000|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -84,6 +84,7 @@ platform_do_upgrade() {
 	belkin,rt1800|\
 	dlink,covr-x1860-a1|\
 	dlink,dap-x1860-a1|\
+        dlink,dir-1360-a1|\
 	dlink,dir-1960-a1|\
 	dlink,dir-2055-a1|\
 	dlink,dir-2150-a1|\


### PR DESCRIPTION
This PR adds support for the D-Link DIR-1360 A1.
​Support is inherited from the DIR-853 A3 DTS via #include, but with significant hardware-specific corrections:
​RAM: Unlocked to 256MB (the DIR-853 A3 base is limited to 128MB).
​Buttons: Verified via interrupt counters; Reset is GPIO 7 and WPS is GPIO 18.
​LEDs: Mapped based on sysfs verification; USB is GPIO 3, 2.4G is GPIO 10, and 5G is GPIO 4.
​MAC Addresses: Verified offsets 0x4 (WLAN) and 0xe000 (LAN) from factory partition.
​The HWID DLK6E5101001 has been added to mt7621.mk to ensure compatibility with the stock recovery interface.

​Signed-off-by: Aryaman Srivastava 
aryamansrivastava895@gmail.com

build ramips/mt7621/dlink_dir-1360-a1