### PR TITLE
mdadm: move init before fstab init runs

### DIFF
--- a/package/utils/mdadm/files/mdadm.init
+++ b/package/utils/mdadm/files/mdadm.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-START=13
+START=10
 STOP=98
 
 USE_PROCD=1


### PR DESCRIPTION
Ensure md volumes are ready before attempting to mount volumes
