### PR TITLE
realtek: imagebuilder: add explicit guard around loader generation

### DIFF
--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -100,10 +100,12 @@ TARGET_DEVICES += zyxel_gs1900-48-a1
 
 define Device/zyxel_gs1920-24hp-v1
   FLASH_ADDR := 0xb40c0000
+ifeq ($(IB),)
   ARTIFACTS := loader.bin
   ARTIFACT/loader.bin := \
     rt-loader-standalone | \
     zynsig
+endif
   SOC := rtl8392
   IMAGE_SIZE := 12144k
   DEVICE_VENDOR := Zyxel


### PR DESCRIPTION
The imagebuilder cannot compile source, so we must guard against generation of artifact targets that require this.  Without this guard we see an error when building the zyxel,gs1920-24hp-v1 profile.

  Create standalone rt-loader, loading uimage from address 0xb40c0000
  mips-openwrt-linux-musl-gcc -fpic -msoft-float -Iinclude -c -o ... src/startup.S
  make[4]: mips-openwrt-linux-musl-gcc: No such file or directory

----
First encountered at
https://github.com/openwrt/docker/actions/runs/21018968909/job/60435561030#step:7:424

So, subsequently tested all realtek and microchipsw subtargets and profiles.