### PR TITLE
mediatek: fix gmac definition for cudy m3000

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
@@ -86,7 +86,7 @@
 		phy-handle = <&rtl8221b_phy>;
 
 		nvmem-cell-names = "mac-address";
-		nvmem-cells = <&macaddr_bdinfo_de00 1>;
+		nvmem-cells = <&macaddr_bdinfo_de00 0>;
 	};
 
 	gmac1: mac@1 {
@@ -96,7 +96,7 @@
 		phy-handle = <&int_gbe_phy>;
 
 		nvmem-cell-names = "mac-address";
-		nvmem-cells = <&macaddr_bdinfo_de00 0>;
+		nvmem-cells = <&macaddr_bdinfo_de00 1>;
 	};
 };
 


### PR DESCRIPTION
Similar to https://github.com/openwrt/openwrt/pull/21543 the gmac definition has an offset of 1 at the moment. This leads to an off by one error in downstream projects (https://github.com/freifunk-gluon/gluon/pull/3663) that rely on the package label mac.

If possible a backport to 25.12 and 24.10 would be welcome. I won't get my hopes up, but if a backport to 23.05 would be possible, it would be greatly appreciated.
