### PR TITLE
[24.10] ramips: fix gmac defintion for cudy ap1300 outdoor

### DIFF
--- a/target/linux/ramips/dts/mt7621_cudy_ap1300-outdoor-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_ap1300-outdoor-v1.dts
@@ -175,7 +175,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 1>;
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 0>;
 		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
@@ -185,14 +185,14 @@
 	wifi@1,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_bdinfo_de00 2>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_bdinfo_de00 1>;
 		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
 
 &gmac0 {
-	nvmem-cells = <&macaddr_bdinfo_de00 1>;
+	nvmem-cells = <&macaddr_bdinfo_de00 0>;
 	nvmem-cell-names = "mac-address";
 };
 


### PR DESCRIPTION
The gmac definition has an offset of 1 at the moment. This leads to an off by one error in downstream projects that rely on the package label mac.

This is the backport to 24.10 to get https://github.com/freifunk-gluon/gluon/pull/3640 done.

Link: https://github.com/openwrt/openwrt/pull/21543