### PR TITLE
ramips: dts: add 'broken-cd' for VoCore2 MMC

### DIFF
--- a/target/linux/ramips/dts/mt7628an_vocore_vocore2.dtsi
+++ b/target/linux/ramips/dts/mt7628an_vocore_vocore2.dtsi
@@ -94,6 +94,7 @@
 &sdhci {
 	status = "okay";
 
+	broken-cd;
 	pinctrl-0 = <&sdxc_iot_mode>;
 	pinctrl-1 = <&sdxc_iot_mode>;
 };


### PR DESCRIPTION
This model doesn't have cd pin on its MicroSD card slot.

Fixes: https://github.com/openwrt/openwrt/issues/20288
Fixes: https://github.com/openwrt/openwrt/issues/22603

Ref: https://vocore.io/v2.html
[vocore2.sd.sch.pdf](https://github.com/user-attachments/files/24672168/vocore2.sd.sch.pdf)

@nickbash11 @omgtehlion Please check this fix.