### PR TITLE
build: export SOURCE_DATE_EPOCH to .provides

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -439,6 +439,8 @@ $(_endef)
     $$(PACK_$(1)) : export PATH=$$(TARGET_PATH_PKG)
     $$(PACK_$(1)) : export PKG_SOURCE_DATE_EPOCH:=$(PKG_SOURCE_DATE_EPOCH)
     $$(PACK_$(1)) : export SOURCE_DATE_EPOCH:=$(PKG_SOURCE_DATE_EPOCH)
+    $(PKG_INFO_DIR)/$(1).provides : export PKG_SOURCE_DATE_EPOCH:=$(PKG_SOURCE_DATE_EPOCH)
+    $(PKG_INFO_DIR)/$(1).provides : export SOURCE_DATE_EPOCH:=$(PKG_SOURCE_DATE_EPOCH)
     $(PKG_INFO_DIR)/$(1).provides $$(PACK_$(1)): $(STAMP_BUILT) $(INCLUDE_DIR)/package-pack.mk
 	rm -rf $$(IDIR_$(1))
 ifeq ($$(CONFIG_USE_APK),)


### PR DESCRIPTION
The .provides and package targets share the same recipe, but SOURCE_DATE_EPOCH was only exported for the package target. When Make builds the .provides target first (as it appears first in the target list), the recipe runs without SOURCE_DATE_EPOCH in the environment, causing apk mkpkg to use actual file mtimes instead of the reproducible timestamp.

Add the SOURCE_DATE_EPOCH export to the .provides target as well, ensuring the environment variable is available regardless of which target Make chooses to build first.