### PR TITLE
realtek: rtl930x: Add support for Hasivo s1100wp-8gt-se (excl. PoE)

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -75,6 +75,7 @@ realtek_setup_macs()
 		lan_mac_start=$(macaddr_add $lan_mac 2)
 		lan_mac_end=$(macaddr_add $lan_mac $((mac_count2-mac_count1)))
 		;;
+	hasivo,s1100wp-8gt-se|\
 	plasmacloud,esx28|\
 	plasmacloud,mcx3|\
 	plasmacloud,psx8|\

--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8gt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8gt-se.dts
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "hasivo,s1100wp-8gt-se";
+	model = "Hasivo S1100WP-8GT-SE";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>; /* 256 MiB */
+	};
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+		label-mac-device = &ethernet0;
+	};
+
+	chosen {
+		stdout-path = "serial0:38400n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>, <&pinmux_enable_led_sync>;
+
+		led_sys: led-0 {
+			label = "green:system";
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	led_set: led_set {
+		compatible = "realtek,rtl9300-leds";
+
+		led_set0 = <
+		(	// GREEN LEFT RJ45 - 1G link, blink on activity
+			RTL93XX_LED_SET_1G |
+			RTL93XX_LED_SET_LINK |
+			RTL93XX_LED_SET_ACT
+		)
+		(	// GREEN RIGHT RJ45 - 10M/100M link, blink on activity
+			RTL93XX_LED_SET_10M |
+			RTL93XX_LED_SET_100M |
+			RTL93XX_LED_SET_LINK |
+			RTL93XX_LED_SET_ACT
+		)
+		(	// ORANGE LEFT RJ45 - 2.5G link, blink on activity
+			RTL93XX_LED_SET_2P5G |
+			RTL93XX_LED_SET_LINK |
+			RTL93XX_LED_SET_ACT
+		)
+		>;
+	};
+
+	i2c_scl23_sda22 {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		scl-gpios = <&gpio0 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		status = "okay";
+
+		clock-frequency = <100000>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "fudan,fm25q128", "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* stock is LOADER */
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x00e0000>;
+				read-only;
+			};
+
+			/* stock is BDINFO */
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x00e0000 0x0010000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_ubootenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+					serialnumber_ubootenv: serialnumber {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_bt_port_no_ubootenv: pse_bt_port_no {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_existed_flag_ubootenv: pse_existed_flag {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_power_bank_ubootenv: pse_power_bank {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			/* stock is SYSINFO */
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0x00f0000 0x0010000>;
+				read-only;
+			};
+
+			/* stock is JFFS2_CFG */
+			partition@100000 {
+				label = "jffs";
+				reg = <0x0100000 0x0100000>;
+			};
+
+			/* stock is JFFS2_LOG */
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x0200000 0x0100000>;
+			};
+
+			/* stock is RUNTIME */
+			partition@300000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x0300000 0x0c00000>;
+			};
+
+			/* stock is OEMINFO */
+			partition@f00000 {
+				label = "oeminfo";
+				reg = <0x0f00000 0x0100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_bus0 {
+	/* External RTL8221B PHY */
+	phy0: ethernet-phy@1 {
+		reg = <0>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		realtek,smi-address = <1>;
+	};
+
+	/* External RTL8221B PHY */
+	phy8: ethernet-phy@8 {
+		reg = <8>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		realtek,smi-address = <2>;
+	};
+
+	/* External RTL8221B PHY */
+	phy16: ethernet-phy@16 {
+		reg = <16>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		realtek,smi-address = <3>;
+	};
+
+	/* External RTL8221B PHY */
+	phy20: ethernet-phy@20 {
+		reg = <20>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		realtek,smi-address = <4>;
+	};
+};
+
+&mdio_bus1 {
+	/* External RTL8221B PHY */
+	phy24: ethernet-phy@24 {
+		reg = <24>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		realtek,smi-address = <1>;
+	};
+
+	/* External RTL8221B PHY */
+	phy25: ethernet-phy@25 {
+		reg = <25>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		realtek,smi-address = <2>;
+	};
+
+	/* External RTL8221B PHY */
+	phy26: ethernet-phy@26 {
+		reg = <26>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		realtek,smi-address = <3>;
+	};
+
+	/* External RTL8221B PHY */
+	phy27: ethernet-phy@27 {
+		reg = <27>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		realtek,smi-address = <4>;
+	};
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			pcs-handle = <&serdes2>;
+			phy-handle = <&phy0>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@8 {
+			reg = <8>;
+			label = "lan2";
+			pcs-handle = <&serdes3>;
+			phy-handle = <&phy8>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@16 {
+			reg = <16>;
+			label = "lan3";
+			pcs-handle = <&serdes4>;
+			phy-handle = <&phy16>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@20 {
+			reg = <20>;
+			label = "lan4";
+			pcs-handle = <&serdes5>;
+			phy-handle = <&phy20>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@24 {
+			reg = <24>;
+			label = "lan5";
+			pcs-handle = <&serdes6>;
+			phy-handle = <&phy24>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@25 {
+			reg = <25>;
+			label = "lan6";
+			pcs-handle = <&serdes7>;
+			phy-handle = <&phy25>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@26 {
+			reg = <26>;
+			label = "lan7";
+			pcs-handle = <&serdes8>;
+			phy-handle = <&phy26>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@27 {
+			reg = <27>;
+			label = "lan8";
+			pcs-handle = <&serdes9>;
+			phy-handle = <&phy27>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		/* Internal SoC */
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -16,6 +16,15 @@ define Device/hasivo_s1100w-8xgt-se
 endef
 TARGET_DEVICES += hasivo_s1100w-8xgt-se
 
+define Device/hasivo_s1100wp-8gt-se
+  SOC := rtl9303
+  DEVICE_VENDOR := Hasivo
+  DEVICE_MODEL := S1100WP-8GT-SE
+  IMAGE_SIZE := 12288k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += hasivo_s1100wp-8gt-se
+
 define Device/plasmacloud-common
   SOC := rtl9302
   UIMAGE_MAGIC := 0x93000000


### PR DESCRIPTION
This commit adds support for Hasivo S1100WP-8GT-SE switch.

Device specification
--------------------
SoC Type:		Realtek RTL9303
RAM:		Samsung K4B2G1646F-BYMA (256MB DDR3 SDRAM)
Flash:		Fudan FM25Q128A (16 MB)
Ethernet:		8x RTL8221B 10/100/1000/2500Mbps PHY
LEDs:		2 LEDs + 4 LEDs/port
			1x power green (no control)
			1x system green (via RLT9303 GPIO)
			3x RJ45 LEDs/port (via HC595 shift registers on LED spi)
				1x Green
				1x Green/Orange
			1x Orange LED/port for PoE status (below RJ45 on STC8)
Button:		Reset
USB ports:		None
Bootloader:		Realtek U-Boot 2011.12.(3.6.6.55087) (Nov 13 2022 - 14:37:31) Fan:		None installed (but board provision for temp/FET/fan) POE:		2x HS104PTI for 802.3af/at/bt PoE (Not yet working)

Installing OpenWrt
------------------
1. UART RJ45 requires soldering a connector to the unpopulated footprint (RJ1). (Amphenol RJHSEE380 or similar)
    The header is on the top right of this image:
    https://forum.openwrt.org/uploads/default/original/3X/4/d/4d2ab97fad7e2c5b0a0bdca4de887918c6dcff97.jpeg
3. Connect to UART 38400@8n1, using Cisco Console Rollover cable (RS232)
4. Set computer IP to 192.168.0.111, and plug in with 2.5Gbps
5. Enter bootloader by pressing esc key during boot
6. Enter password `Hs2021cfgmg`
7. Type `XXXX` to get into U-Boot
8. Type `rtk network on`
9. Use tftp if you have a 2.5G network connection (other speeds won't work).
    If you use serial you can increase the baudrate of uboot with `setenv baudrate 115200`
9.1. `tftpboot 0x84f00000 <openwrt-initramfs-filename>`
9.2. Otherwise use serial transfer (Y modem): `loady 0x84f00000`
10. `bootm 0x84f00000`

Now you should be in OpenWRT, and can use sysupgrade to install.
