### PR TITLE
mediatek: add support for netis NX62

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2179,6 +2179,9 @@ TARGET_DEVICES += netcore_n60
 define Device/netcore_n60-pro
   DEVICE_VENDOR := Netcore
   DEVICE_MODEL := N60 Pro
+  DEVICE_ALT0_VENDOR := netis
+  DEVICE_ALT0_MODEL := NX62
+  DEVICE_ALT0_VARIANT := V1
   DEVICE_DTS := mt7986a-netcore-n60-pro
   DEVICE_DTS_DIR := ../dts
   UBINIZE_OPTS := -E 5


### PR DESCRIPTION
Same hardware as Netcore N60 Pro
Add:
DEVICE_ALT0_VENDOR := netis
DEVICE_ALT0_MODEL := NX62
DEVICE_ALT0_VARIANT := V1
