### PR TITLE
mediatek: add Motorcomm PHY support to Cudy M3000

### DIFF
--- a/target/linux/generic/hack-6.12/791-net-phy-motorcomm-disable-addr-0.patch
+++ b/target/linux/generic/hack-6.12/791-net-phy-motorcomm-disable-addr-0.patch
@@ -1,0 +1,131 @@
+From 3d3dbdfe3611d66761cadf2729a096151607f5ab Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jakub=20Van=C4=9Bk?= <linuxtardis@gmail.com>
+Date: Sat, 21 Feb 2026 22:31:46 +0100
+Subject: [PATCH net v1] net: phy: motorcomm: yt8821: disable MDIO broadcast address 0
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The YT8821 PHY responds on two MDIO addresses by default: the address
+selected by its strapping pins and the broadcast address 0.
+
+On platforms where another PHY is hardwired to respond only on address 0
+(e.g. the internal Gigabit PHY in the MediaTek MT7981B SoC), this can lead
+to MDIO bus conflicts. The YT8821 may incorrectly respond to transactions
+intended for the other PHY, leaving it in an inconsistent state. The
+following issues were observed:
+
+- Achieving just 100 Mbps speeds on gigabit links. Dmesg would show
+  messages like
+
+    [ 133.997177] YT8821 2.5Gbps PHY mdio-bus:01: Downshift occurred from negotiated speed 1Gbps to actual speed 100Mbps, check cabling!
+    [ 134.009400] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 100Mbps/Full - flow control off
+
+- Having the PHY report that the link is up, yet no data would flow.
+- The YT8821 would be affected by an "ip link set dev eth1 down"
+  command aimed at the other PHY.
+
+Reduce the impact of this conflict by disabling the broadcast
+address 0 during the PHY configuration process. The feedback from LKML
+is that this patch is not a reliable workaround (the kernel will not be
+disabling the broadcast address early enough). However, the alternative
+seems to be to require a custom U-Boot for these routers, where the
+U-Boot would be doing the MDIO address 0 disabling.
+
+OTOH, empirical testing shows that this change does makes the YT8821 work
+reliably on the Cudy M3000 router when running the current OpenWrt main
+branch with a small device tree patch.
+
+Link: https://github.com/openwrt/openwrt/pull/21584
+Link: https://lore.kernel.org/netdev/d3bb9c36-5a0e-4339-901d-2dd21bdba395@gmail.com/T/#u
+Fixes: b671105b88c3 ("net: phy: Add driver for Motorcomm yt8821 2.5G ethernet phy")
+Signed-off-by: Jakub Vaněk <linuxtardis@gmail.com>
+---
+ drivers/net/phy/motorcomm.c | 48 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+--- a/drivers/net/phy/motorcomm.c
++++ b/drivers/net/phy/motorcomm.c
+@@ -214,6 +214,9 @@
+ #define YT8521_RC1R_RGMII_2_100_NS		14
+ #define YT8521_RC1R_RGMII_2_250_NS		15
+ 
++#define YTPHY_MDIO_ADDRESS_CONTROL_REG		0xA005
++#define YTPHY_MACR_EN_PHY_ADDR_0		BIT(6)
++
+ #define YTPHY_MISC_CONFIG_REG			0xA006
+ #define YTPHY_MCR_FIBER_SPEED_MASK		BIT(0)
+ #define YTPHY_MCR_FIBER_1000BX			(0x1 << 0)
+@@ -2648,6 +2651,30 @@ static int yt8821_soft_reset(struct phy_
+ }
+ 
+ /**
++ * yt8821_disable_mdio_address_zero() - disable MDIO broadcast address 0
++ * @phydev: a pointer to a &struct phy_device
++ *
++ * The YT8821 responds on two MDIO addresses by default:
++ *  - the address selected by its strapping pins
++ *  - the broadcast address 0
++ *
++ * Some other PHYs (e.g. the MT7981B internal Gigabit PHY) are hardwired to
++ * respond only on MDIO address 0. If the YT8821 also listens on address 0,
++ * it may incorrectly react to transactions intended for those PHYs.
++ *
++ * Disabling address 0 on the YT8821 early avoids such MDIO bus conflicts.
++ *
++ * Returns: 0 or negative errno code
++ */
++static int yt8821_disable_mdio_address_zero(struct phy_device *phydev)
++{
++	return ytphy_modify_ext_with_lock(phydev,
++					  YTPHY_MDIO_ADDRESS_CONTROL_REG,
++					  YTPHY_MACR_EN_PHY_ADDR_0,
++					  0);
++}
++
++/**
+  * yt8821_config_init() - phy initializatioin
+  * @phydev: a pointer to a &struct phy_device
+  *
+@@ -2682,6 +2709,10 @@ static int yt8821_config_init(struct phy
+ 		phydev->rate_matching = RATE_MATCH_PAUSE;
+ 	}
+ 
++	ret = yt8821_disable_mdio_address_zero(phydev);
++	if (ret < 0)
++		return ret;
++
+ 	ret = yt8821_serdes_init(phydev);
+ 	if (ret < 0)
+ 		return ret;
+@@ -2700,6 +2731,22 @@ static int yt8821_config_init(struct phy
+ }
+ 
+ /**
++ * yt8821_probe() - early PHY initialization
++ * @phydev: a pointer to a &struct phy_device
++ *
++ * Returns: 0 or negative errno code
++ */
++static int yt8821_probe(struct phy_device *phydev)
++{
++	/*
++	 * Disable the MDIO broadcast address (0) as early as possible.
++	 * This prevents the YT8821 from responding to transactions
++	 * intended for a different PHY that is fixed at address 0.
++	 */
++	return yt8821_disable_mdio_address_zero(phydev);
++}
++
++/**
+  * yt8821_adjust_status() - update speed and duplex to phydev
+  * @phydev: a pointer to a &struct phy_device
+  * @val: read from YTPHY_SPECIFIC_STATUS_REG
+@@ -2954,6 +3001,7 @@ static struct phy_driver motorcomm_phy_d
+ 		PHY_ID_MATCH_EXACT(PHY_ID_YT8821),
+ 		.name			= "YT8821 2.5Gbps PHY",
+ 		.get_features		= yt8821_get_features,
++		.probe			= yt8821_probe,
+ 		.read_page		= yt8521_read_page,
+ 		.write_page		= yt8521_write_page,
+ 		.get_wol		= ytphy_get_wol,

--- a/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-m3000-v1.dts
@@ -83,7 +83,7 @@
 		compatible = "mediatek,eth-mac";
 		reg = <0>;
 		phy-mode = "2500base-x";
-		phy-handle = <&rtl8221b_phy>;
+		phy-handle = <&wan_phy>;
 
 		nvmem-cell-names = "mac-address";
 		nvmem-cells = <&macaddr_bdinfo_de00 0>;
@@ -101,12 +101,16 @@
 };
 
 &mdio_bus {
-	rtl8221b_phy: ethernet-phy@1 {
+	/* We need to have the reset GPIO on the MDIO bus node,
+	 * otherwise the PHY would be held in reset during PHY detection */
+	reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <100000>;
+	reset-post-delay-us = <100000>;
+
+	wan_phy: ethernet-phy@1 {
+		/* Either Realtek RTL8221B-VB-CG or Motorcomm YT8821 */
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <1>;
-		reset-assert-us = <100000>;
-		reset-deassert-us = <100000>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
 		interrupts = <38 IRQ_TYPE_LEVEL_LOW>;
 		interrupt-parent = <&pio>;
 	};

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1143,7 +1143,7 @@ define Device/cudy_m3000-v1
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-motorcomm
 endef
 TARGET_DEVICES += cudy_m3000-v1
 


### PR DESCRIPTION
Some Cudy M3000 (v2?) routers have a Motorcomm YT8821 PHY instead of the Realtek PHY on their 2.5G port, see the PHY ID in https://github.com/openwrt/openwrt/issues/21051#issuecomment-3659510887 . YT8821 support was recently added for the Cudy WR3000H router, see https://github.com/openwrt/openwrt/pull/21399 . Copy the necessary changes to the M3000 device tree.