### PR TITLE
build: set SOURCE_DATE_EPOCH to 0

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -423,7 +423,7 @@ $$(call addfield,Depends,$$(Package/$(1)/DEPENDS)
 )$$(call addfield,LicenseFiles,$(LICENSE_FILES)
 )$$(call addfield,Section,$(SECTION)
 )$$(call addfield,Require-User,$(USERID)
-)$$(call addfield,SourceDateEpoch,$(PKG_SOURCE_DATE_EPOCH)
+)$$(call addfield,SourceDateEpoch,0
 )$$(call addfield,URL,$(URL)
 )$$(if $$(ABIV_$(1)),ABIVersion: $$(ABIV_$(1))
 )$(if $(PKG_CPE_ID),CPE-ID: $(PKG_CPE_ID)
@@ -437,8 +437,7 @@ $(_endef)
     $$(PACK_$(1)) : export CONTROL=$$(Package/$(1)/CONTROL)
     $$(PACK_$(1)) : export DESCRIPTION=$$(Package/$(1)/description)
     $$(PACK_$(1)) : export PATH=$$(TARGET_PATH_PKG)
-    $$(PACK_$(1)) : export PKG_SOURCE_DATE_EPOCH:=$(PKG_SOURCE_DATE_EPOCH)
-    $$(PACK_$(1)) : export SOURCE_DATE_EPOCH:=$(PKG_SOURCE_DATE_EPOCH)
+    $$(PACK_$(1)) : export SOURCE_DATE_EPOCH:=0
     $(PKG_INFO_DIR)/$(1).provides $$(PACK_$(1)): $(STAMP_BUILT) $(INCLUDE_DIR)/package-pack.mk
 	rm -rf $$(IDIR_$(1))
 ifeq ($$(CONFIG_USE_APK),)

--- a/include/package.mk
+++ b/include/package.mk
@@ -15,8 +15,6 @@ PKG_SKIP_DOWNLOAD=$(USE_SOURCE_DIR)$(USE_GIT_TREE)$(USE_GIT_SRC_CHECKOUT)
 
 MAKE_J:=$(if $(MAKE_JOBSERVER),$(MAKE_JOBSERVER) $(if $(filter 3.% 4.0 4.1,$(MAKE_VERSION)),-j))
 
-PKG_SOURCE_DATE_EPOCH:=$(if $(DUMP),,$(shell $(TOPDIR)/scripts/get_source_date_epoch.sh $(CURDIR)))
-
 ifeq ($(strip $(PKG_BUILD_PARALLEL)),0)
 PKG_JOBS?=-j1
 else

--- a/scripts/ipkg-build
+++ b/scripts/ipkg-build
@@ -15,9 +15,7 @@ FIND="${FIND:-$(command -v gfind)}"
 TAR="${TAR:-$(command -v tar)}"
 
 # try to use fixed source epoch
-if [ -n "$PKG_SOURCE_DATE_EPOCH" ]; then
-	TIMESTAMP=$(date --date="@$PKG_SOURCE_DATE_EPOCH")
-elif [ -n "$SOURCE_DATE_EPOCH" ]; then
+if [ -n "$SOURCE_DATE_EPOCH" ]; then
 	TIMESTAMP=$(date --date="@$SOURCE_DATE_EPOCH")
 else
 	TIMESTAMP=$(date)


### PR DESCRIPTION
To improve reproducibility one can set SOURCE_DATE_EPOCH and support tools will modify mtime to that timestamp, making them easier "bit for bit" equal, even when build at other times.

In the past, a script would check Git history to determine a reasonably close mtime. With lack of Git history, this is no longer deterministic.

Within OpenWrt, we build in two phases, first firmware and SDK, second phase we take this SDK and build packages from all feeds, without cloning the full Git history. As a result, some packages end up unreproducible.

This commit sets it everywhere to zero, like RPM and NixOS do it. This safes us a bunch of Git history calls and makes things reproducible at no cost. Users unlikely care for the specific mtime on their system, neither in packages they download.