### PR TITLE
wifi-scripts: fix WiFi 6E discovery for 6GHz 320MHz operation

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -283,6 +283,17 @@ function device_htmode_append(config) {
 				}
 			config.op_class = 137;
 			config.eht_oper_chwidth = 7;
+
+			/*
+			 * Set HE operation values for 160MHz backward compatibility
+			 * with WiFi 6E clients. Pick the 160MHz half that contains
+			 * the primary channel.
+			 */
+			config.he_oper_chwidth = 3;
+			if (config.channel < config.eht_oper_centr_freq_seg0_idx)
+				config.he_oper_centr_freq_seg0_idx = config.eht_oper_centr_freq_seg0_idx - 16;
+			else
+				config.he_oper_centr_freq_seg0_idx = config.eht_oper_centr_freq_seg0_idx + 16;
 			break;
 
 		case 'HE40':
@@ -383,8 +394,15 @@ function device_htmode_append(config) {
 		config.ieee80211ax = true;
 
 		if (config.hw_mode == 'a') {
-			config.he_oper_chwidth = config.vht_oper_chwidth;
-			config.he_oper_centr_freq_seg0_idx = config.vht_oper_centr_freq_seg0_idx;
+			/*
+			 * Only set HE values from VHT if not already set.
+			 * For 6GHz 320MHz, these are pre-set for 160MHz backward
+			 * compatibility with WiFi 6E clients.
+			 */
+			if (!config.he_oper_chwidth)
+				config.he_oper_chwidth = config.vht_oper_chwidth;
+			if (!config.he_oper_centr_freq_seg0_idx)
+				config.he_oper_centr_freq_seg0_idx = config.vht_oper_centr_freq_seg0_idx;
 		}
 
 		if (config.band == "6g") {


### PR DESCRIPTION
## Summary

WiFi 6E (802.11ax) clients cannot discover 6GHz APs operating at 320MHz because the HE Operation element contains uninitialized center frequency values.

For EHT320 mode, the code sets `eht_oper_centr_freq_seg0_idx` but not the corresponding HE values. Later, the HE values are copied from VHT values, but VHT is not used on 6GHz, leaving `he_oper_chwidth` and `he_oper_centr_freq_seg0_idx` at 0. This causes WiFi 6E clients to see incorrect channel width information, making the AP invisible to them during scanning.

**Fix:**
1. Set `he_oper_chwidth` to 3 (160MHz) for EHT320 mode
2. Compute `he_oper_centr_freq_seg0_idx` based on the 160MHz segment that contains the primary channel
3. Preserve these pre-set values instead of overwriting them with uninitialized VHT values

WiFi 7 clients continue to see 320MHz operation via the EHT Operation element, while WiFi 6E clients can now discover and connect at 160MHz.

## Test plan

- [x] Tested on Airoha W1700K (mt76 driver) with 6GHz radio configured for EHT320
- [x] Verified `he_oper_centr_freq_seg0_idx` is correctly set in hostapd config
- [x] Confirmed WiFi 6E client (Intel AX211) can now discover and connect to the 6GHz SSID
- [x] Confirmed WiFi 7 clients still connect at 320MHz