### PR TITLE
x86: kmod-sound-cs5535audio: add support for subtarget "legacy"

### DIFF
--- a/target/linux/x86/modules.mk
+++ b/target/linux/x86/modules.mk
@@ -52,7 +52,7 @@ $(eval $(call KernelPackage,f71808e-wdt))
 
 define KernelPackage/sound-cs5535audio
   TITLE:=CS5535/CS5536 Audio Controller
-  DEPENDS:=@TARGET_x86_geode +kmod-ac97
+  DEPENDS:=@(TARGET_x86_geode||TARGET_x86_legacy) +kmod-ac97
   KCONFIG:=CONFIG_SND_CS5535AUDIO
   FILES:=$(LINUX_DIR)/sound/pci/cs5535audio/snd-cs5535audio.ko
   AUTOLOAD:=$(call AutoLoad,36,snd-cs5535audio)


### PR DESCRIPTION
Hi, I'm using OpenWrt on a ThinPC DT166 (AMD Geode LX with CS5536 chipset).
It works like a charm with the x86 "legacy" image v25.12.0-rc2, but the kernel module for internal audio is missing.

I succeeded in building "kmod-sound-cs5535audio" for x86 "legacy" (same as for x86 "geode") and it runs alright on my machine.
It would be great to build it in the official releases. Thanks in advance!

PR relates to #21589 for release 25.12