### PR TITLE
ath79: add support for Zyxel WAC6103D-I, NWA1123-AC-PRO, NAP203 and allow MTD offset in zyxel-bootconfig

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -875,3 +875,23 @@ define Build/zyxel-ras-image
 			$(if $(findstring separate-kernel,$(word 1,$(1))),-k $(IMAGE_KERNEL)) \
 		&& mv $@.new $@
 endef
+
+define Build/zyxel-zld-image
+	$(STAGING_DIR_HOST)/bin/mkzyxelzldfw \
+		-v 0x0100 \
+		-m $(DEVICE_MODEL) \
+		-d $(ZLD_MODEL_ID) \
+		-b $(ZLD_BM_CHECKSUM) \
+		-i $(IMAGE_KERNEL) \
+		-o $(ZLD_KERNEL_OFFSET) \
+		-t kernel \
+		-x kernel \
+		-r "$(LINUX_VERSION)" \
+		-i $@ \
+		-o $(ZLD_FS_OFFSET) \
+		-t core \
+		-x zldfs \
+		-r "$(VERSION_DIST) $(VERSION_CODE)" \
+		$@.new
+	mv $@.new $@
+endef

--- a/package/utils/zyxel-bootconfig/files/95_apply_bootconfig
+++ b/package/utils/zyxel-bootconfig/files/95_apply_bootconfig
@@ -9,6 +9,13 @@ apply_bootconfig() {
 		zyxel-bootconfig "/dev/mtd$mtd_idx" set-image-status 0 valid
 		zyxel-bootconfig "/dev/mtd$mtd_idx" set-active-image 0
 		;;
+	zyxel,nap203|\
+	zyxel,nwa1123-ac-pro|\
+	zyxel,wac6103d-i)
+		mtd_idx=$(find_mtd_index "mrd")
+		zyxel-bootconfig "/dev/mtd$mtd_idx:0xffe2" set-image-status 0 valid
+		zyxel-bootconfig "/dev/mtd$mtd_idx:0xffe2" set-active-image 0
+		;;
 	esac
 }
 

--- a/target/linux/ath79/dts/qca9558_zyxel_nap203.dts
+++ b/target/linux/ath79/dts/qca9558_zyxel_nap203.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_zyxel_wac6103.dtsi"
+
+/ {
+	compatible = "zyxel,nap203", "qca,qca9558";
+	model = "Zyxel NAP203";
+};

--- a/target/linux/ath79/dts/qca9558_zyxel_nwa1123-ac-pro.dts
+++ b/target/linux/ath79/dts/qca9558_zyxel_nwa1123-ac-pro.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_zyxel_wac6103.dtsi"
+
+/ {
+	compatible = "zyxel,nwa1123-ac-pro", "qca,qca9558";
+	model = "Zyxel NWA1123-AC-PRO";
+};

--- a/target/linux/ath79/dts/qca9558_zyxel_wac6103.dtsi
+++ b/target/linux/ath79/dts/qca9558_zyxel_wac6103.dtsi
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca955x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mtd/partitions/uimage.h>
+
+/ {
+	aliases {
+		label-mac-device = &eth1;
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-upgrade = &led_power_green;
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		gpio_radio0_ceiling {
+			gpio-export,name = "radio0_ceiling";
+			gpio-export,output = <0>;
+			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
+		};
+
+		gpio_radio1_ceiling {
+			gpio-export,name = "radio1_ceiling";
+			gpio-export,output = <0>;
+			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		antenna_switch {
+			label = "antenna_switch";
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 19 GPIO_ACTIVE_HIGH>;
+			debounce-interval = <60>;
+		};
+	};
+
+	led_spi {
+		compatible = "spi-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sck-gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+		mosi-gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
+		num-chipselects = <1>;
+
+		led_gpio: led_gpio@0 {
+			compatible = "fairchild,74hc595";
+			reg = <0>;
+			gpio-controller;
+			#gpio-cells = <2>;
+			registers-number = <1>;
+			spi-max-frequency = <100000>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&jtag_disable_pins>;
+
+		led_power_green: power_green {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_red: power_red {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		locator_white {
+			function = "locator";
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		management_green {
+			function = "management";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&led_gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		management_red {
+			function = "management";
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&led_gpio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		uplink_green {
+			function = "uplink";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&led_gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "netdev";
+		};
+
+		uplink_amber {
+			function = "uplink";
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&led_gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "netdev";
+		};
+
+		lan1_green {
+			function = "lan1";
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&led_gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "netdev";
+		};
+
+		lan1_amber {
+			function = "lan1";
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&led_gpio 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "netdev";
+		};
+
+		wlan2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&led_gpio 6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&led_gpio 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootm";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "recovery";
+				reg = <0x30000 0x160000>;
+				read-only;
+			};
+
+			partition@190000 {
+				label = "ker_reserved";
+				reg = <0x190000 0x120000>;
+				read-only;
+			};
+
+			partition@2b0000 {
+				label = "fs_reserved";
+				reg = <0x2b0000 0x020000>;
+				read-only;
+			};
+
+			partition@2d0000 {
+				label = "conf";
+				reg = <0x2d0000 0xce0000>;
+				read-only;
+			};
+
+			partition@fb0000 {
+				label = "mrd";
+				reg = <0xfb0000 0x010000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_mrd_0: macaddr@fff8 {
+						compatible = "mac-base";
+						reg = <0xfff8 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@fc0000 {
+				label = "disklog_reserved";
+				reg = <0xfc0000 0x030000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+
+					cal_art_5000: calibration@5000 {
+						reg = <0x5000 0x844>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootm_reserved";
+			reg = <0x0 0x100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "recovery_reserved";
+			reg = <0x100000 0x100000>;
+			read-only;
+		};
+
+		partition@200000 {
+			label = "header";
+			reg = <0x200000 0xa0000>;
+		};
+
+		partition@2a0000 {
+			label = "kernel";
+			reg = <0x2a0000 0x1860000>;
+		};
+
+		partition@1b00000 {
+			label = "ubi";
+			reg = <0x1b00000 0x5500000>;
+		};
+
+		partition@7000000 {
+			label = "alt_header";
+			reg = <0x7000000 0xa0000>;
+		};
+
+		partition@7a00000 {
+			label = "alt_kernel";
+			reg = <0x7a00000 0x1860000>;
+			read-only;
+		};
+
+		partition@8900000 {
+			label = "alt_ubi";
+			reg = <0x8900000 0x5500000>;
+			read-only;
+		};
+
+		partition@de00000 {
+			label = "conf_reserved";
+			reg = <0xde00000 0x100000>;
+			read-only;
+		};
+
+		partition@df00000 {
+			label = "mrd_reserved";
+			reg = <0xdf00000 0x100000>;
+			read-only;
+		};
+
+		partition@e000000 {
+			label = "disklog";
+			reg = <0xe000000 0x1f00000>;
+			read-only;
+		};
+
+		partition@ff00000 {
+			label = "ART_reserved";
+			reg = <0xff00000 0x100000>;
+			read-only;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+
+	phy_port2: ethernet-phy@1 {
+		reg = <1>;
+	};
+
+	phy_port3: ethernet-phy@2 {
+		reg = <2>;
+	};
+
+	switch: switch@10 {
+		compatible = "qca,qca8334";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x10>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "cpu";
+				ethernet = <&eth1>;
+				phy-mode = "sgmii";
+				qca,sgmii-enable-pll;
+				qca,sgmii-rxclk-falling-edge;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "uplink";
+				phy-mode = "internal";
+				phy-handle = <&phy_port2>;
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan1";
+				phy-mode = "internal";
+				phy-handle = <&phy_port3>;
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_mrd_0 0>;
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+
+		rgmii-enabled = <1>;
+
+		rxdv-delay = <3>;
+		rxd-delay = <3>;
+		txen-delay = <0>;
+		txd-delay = <0>;
+	};
+};
+
+&eth1 {
+	status = "okay";
+
+	phy-mode = "sgmii";
+	mdiobus = <&mdio0>;
+
+	nvmem-cells = <&macaddr_mrd_0 0>;
+	nvmem-cell-names = "mac-address";
+
+	pll-data = <0x03000000 0x00000101 0x00001313>;
+
+	gmac-config {
+		device = <&gmac>;
+	};
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&pcie1 {
+	status = "okay";
+
+	ath10k: wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x0000 0 0 0 0>;
+
+		nvmem-cells = <&cal_art_5000>, <&macaddr_mrd_0 2>;
+		nvmem-cell-names = "calibration", "mac-address";
+
+		#gpio-cells = <2>;
+		gpio-controller;
+	};
+};
+
+&wdt {
+	status = "okay";
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_mrd_0 1>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};

--- a/target/linux/ath79/dts/qca9558_zyxel_wac6103d-i.dts
+++ b/target/linux/ath79/dts/qca9558_zyxel_wac6103d-i.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qca9558_zyxel_wac6103.dtsi"
+
+/ {
+	compatible = "zyxel,wac6103d-i", "qca,qca9558";
+	model = "Zyxel WAC6103D-I";
+};

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -1,3 +1,5 @@
+DEVICE_VARS += ZLD_BM_CHECKSUM ZLD_FS_OFFSET ZLD_KERNEL_OFFSET ZLD_MODEL_ID
+
 define Build/dongwon-header
 	head -c 4 $@ > $@.tmp
 	head -c 8 /dev/zero >> $@.tmp
@@ -538,3 +540,42 @@ define Device/zyxel_emg2926_q10a
   RAS_BOARD := AAVK-EMG2926Q10A
 endef
 TARGET_DEVICES += zyxel_emg2926_q10a
+
+define Device/zyxel_wac6103_common
+  SOC := qca9558
+  DEVICE_VENDOR := Zyxel
+  DEVICE_PACKAGES := -uboot-envtools ath10k-firmware-qca988x kmod-ath10k \
+	kmod-dsa-qca8k kmod-phy-qca83xx zyxel-bootconfig
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL := kernel-bin | append-dtb | pad-to $$(BLOCKSIZE) | uImage none
+  KERNEL_INITRAMFS := $$(KERNEL)
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | zyxel-zld-image
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  UBINIZE_OPTS := -E 5
+  ZLD_BM_CHECKSUM := 0x080b4aec
+  ZLD_KERNEL_OFFSET := 0x00190000
+  ZLD_FS_OFFSET := 0x002b0000
+endef
+
+define Device/zyxel_nap203
+  $(Device/zyxel_wac6103_common)
+  DEVICE_MODEL := NAP203
+  ZLD_MODEL_ID := 0x2fe1
+endef
+TARGET_DEVICES += zyxel_nap203
+
+define Device/zyxel_nwa1123-ac-pro
+  $(Device/zyxel_wac6103_common)
+  DEVICE_MODEL := NWA1123-AC-PRO
+  ZLD_MODEL_ID := 0x3fe1
+endef
+TARGET_DEVICES += zyxel_nwa1123-ac-pro
+
+define Device/zyxel_wac6103d-i
+  $(Device/zyxel_wac6103_common)
+  DEVICE_MODEL := WAC6103D-I
+  ZLD_MODEL_ID := 0x25e1
+endef
+TARGET_DEVICES += zyxel_wac6103d-i

--- a/target/linux/ath79/nand/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/nand/base-files/etc/board.d/01_leds
@@ -37,6 +37,16 @@ netgear,wndr4300-v2|\
 netgear,wndr4500-v3)
 	ucidef_set_led_switch "wan-amber" "WAN (amber)" "amber:wan" "switch0" "0x20"
 	;;
+zyxel,nap203|\
+zyxel,nwa1123-ac-pro|\
+zyxel,wac6103d-i)
+	ucidef_set_led_default "power-green" "Power (green)" "green:power" 1
+	ucidef_set_led_default "locator" "Locator" "white:locator" 0
+	ucidef_set_led_netdev "uplink-green" "Uplink (green)" "green:uplink" "uplink"
+	ucidef_set_led_netdev "lan1-green" "LAN1 (green)" "green:lan1" "lan1"
+	ucidef_set_led_wlan "wlan-2ghz" "WLAN2G (green/amber)" "green:wlan-2ghz" "phy1tpt"
+	ucidef_set_led_wlan "wlan-5ghz" "WLAN5G (green/amber)" "green:wlan-5ghz" "phy0tpt"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -83,6 +83,11 @@ ath79_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth1"
 		;;
+	zyxel,nap203|\
+	zyxel,nwa1123-ac-pro|\
+	zyxel,wac6103d-i)
+		ucidef_set_interface_lan "uplink lan1" "dhcp"
+		;;
 	*)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
 		;;

--- a/target/linux/ath79/nand/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ath79/nand/base-files/etc/board.d/03_gpio_switches
@@ -14,6 +14,12 @@ zte,mf286c|\
 zte,mf286r)
 	ucidef_add_gpio_switch "power_btn_block" "Power button blocker" "532" "0"
 	;;
+zyxel,nap203|\
+zyxel,nwa1123-ac-pro|\
+zyxel,wac6103d-i)
+	ucidef_add_gpio_switch "radio0_ceiling" "Radio 0 ceiling mount" "radio0_ceiling"
+	ucidef_add_gpio_switch "radio1_ceiling" "Radio 1 ceiling mount" "radio1_ceiling"
+	;;
 esac
 
 board_config_flush


### PR DESCRIPTION
Zyxel WAC6103D-I is a wall or ceiling mounted dual band 3x3 wireless AC access point with PoE and a per band pair of software switchable antennae. The NWA1123-AC-PRO and the NAP203 are physically the same device with different stock firmware features. This PR adds support for all three models.

The first commit adapts the zyxel-bootconfig command with an optional offset within the MTD partition. This allows to reuse the command for the Zyxel WAC6103D-I and siblings which has the same format for the boot configuration, but not at the beginning of the partition. The tool is then used, with the appropriate offset, on boot to mark the newly flashed image as valid.

The second commit then adds the actual support for the Zyxel WAC6103D-I and its siblings. It reuses the existing mkzyxelzldfw to package the factory image.

Commit message for the device add:

ath79: add support for Zyxel WAC6103D-I, siblings

The Zyxel WAC6103D-I is a wall or ceiling mounted dual band 3x3 wireless
AC access point with PoE and a per band pair of software switchable
antennae. The NWA1123-AC-PRO and the NAP203 are physically the same device
with different stock firmware features. This commit adds support for all
three models.

Hardware:
* SoC: Qualcomm Atheros QCA9558
* RAM: 256MiB 2x Nanya NT5TU64M16HG-AC
* Flash: 16MiB SPI-NOR and 256MiB SPI-NAND MT29F2G08ABAEA
* WLAN 2.4GHz: QCA9558 3x3:3
* WLAN 5GHz: QCA9880 3x3:3
* Ethernet: QCA8334 switch with two external LAN ports
* Serial Config: 3.3V TTL 115200-8-N-1, externally accessible
* Serial Layout: GND TX RX 3.3V (don't connect, marked with triangle)
* LEDs: 2x green/red, 4x green/amber, 1x white
* Inputs: 1x Reset, 1x Antenna toggle switch

MAC addresses:
* Uplink and LAN1: shared base address stored in mrd partition at 0xfff8
* 2.4GHz WLAN: base + 1
* 5GHz WLAN: base + 2

Flashing Notes:
The device uses a dual-image setup and OpenWrt can only be installed as
image 0. When the currently running stock firmware is image 0, OpenWrt
will be installed as image 1, fail to boot and the device returns to stock
firmware. If this happens, install any version of stock firmware so that
it runs as image 1, before installing OpenWrt. Alternatively, if there
already is a valid stock firmware in image 1, the "debug dual-image show"
and "debug dual-image set boot-image image1" commands can be used in the
stock CLI via Serial/SSH/Telnet/Web to switch to image 1. The NAP203 is
always cloud managed and does not provide the full local web interface.
It can only be flashed via FTP or the boot module. The login credentials
are admin/1234 after a factory reset.

Flashing with Stock Web Interface:
* Get the OpenWrt factory image for the specific model
* Rename the factory image to a shorter name, for example "openwrt.bin"
  (the stock firmware uses the name of the file and has a 60 char limit)
* In the web interface, go to "Maintenance" -> "File Manager" ->
  "Firmware Package" (or click the link next to "Firmware Version" under
  "Device Information" on the dashboard)
* Under "Upload File" browse to the renamed OpenWrt factory image and
  click on "Upload"

Flashing with FTP:
* Get the OpenWrt factory image for the specific model
* Rename the factory image to a shorter name, for example "openwrt.bin"
* Use an FTP program to connect to the device and log in as admin
* Use the "bin" command to ensure binary mode is used
* Use "put openwrt.bin" to upload the new firmware
* The device should print confirmation messages, flash the power LED in
  red and automatically reboot into OpenWrt

Flashing / Unbrick / Revert to Stock with the Boot Module:
* Disconnect the device from power
* Configure your machine to 192.168.1.103/24 and start a TFTP server
* Put the OpenWrt factory or stock firmware image into the TFTP server
  root and rename it to "ZLD-current"
* Establish a serial connection to the device through the console port
* Connect the device to power
* When prompted, press a key to abort automatic boot and enter debug mode
* Use the "atnz" command to flash the firmware image
* Use the "atgo" command to boot from the newly flashed image

Antenna Switching:
The device internally has 4 antennae for each frequency band of which
always only 3 are in use. GPIOs are used to switch between the active set,
where the ceiling configuration uses 3 antennae of the same type and the
wall configuration uses the first 2 regular and one dipole antenna. The
switching can be done individually for each band. The GPIOs are exposed as
"gpio_switch" and can be set with "uci set system.radioX_ceiling.value=Y".
The gpio_switch service has to be restarted to apply the change.

The physical antenna toggle switch on the device is implemented as an
input switch mapped to button BTN_0 with the "ceiling" setting acting as
the "pressed" and the "wall" setting acting as the "released" action.