### PR TITLE
realtek: make all link speeds work for RTL8221B in Zyxel XGS1210-12 rev B1

### DIFF
--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
@@ -221,16 +221,18 @@
 			label = "lan9";
 			pcs-handle = <&serdes6>;
 			phy-handle = <&phy24>;
-			phy-mode = "2500base-x";
+			phy-mode = "sgmii";
 			led-set = <1>;
+			managed = "in-band-status";
 		};
 		port@25 {
 			reg = <25>;
 			label = "lan10";
 			pcs-handle = <&serdes7>;
 			phy-handle = <&phy25>;
-			phy-mode = "2500base-x";
+			phy-mode = "sgmii";
 			led-set = <1>;
+			managed = "in-band-status";
 		};
 
 		port@26 {


### PR DESCRIPTION
SGMII only works correctly on this device if inband auto-negotiation is enabled. Configure the PHY for SGMII and in-band mode in the device tree to make this happen.

For 2.5G link speeds the PHY will still switch to 2500Base-X without AN.

The same configuration also works on RTL8226, so it is fine to apply this change to the A1 revision of XGS1010-12/XGS1210-12 as well.

Tested on XGS1010-12 rev A1 and XGS1210-12 rev B1.