### PR TITLE
rockchip: fix set default serial_{addr,port} in boot script

### DIFF
--- a/target/linux/rockchip/image/default.bootscript
+++ b/target/linux/rockchip/image/default.bootscript
@@ -1,18 +1,20 @@
 part uuid ${devtype} ${devnum}:2 uuid
 
-if test $stdout = 'serial@2ad40000' ;
-then serial_addr=',0x2ad40000'; serial_port='ttyS0';
-elif test $stdout = 'serial@fe660000' ;
-then serial_addr=',0xfe660000'; serial_port='ttyS2';
-elif test $stdout = 'serial@feb50000' ;
-then serial_addr=',0xfeb50000'; serial_port='ttyS2';
-elif test $stdout = 'serial@ff130000' ;
-then serial_addr=',0xff130000'; serial_port='ttyS2';
-elif test $stdout = 'serial@ff1a0000' ;
-then serial_addr=',0xff1a0000'; serial_port='ttyS2';
-elif test $stdout = 'serial@ff9f0000' ;
-then serial_addr=',0xff9f0000'; serial_port='ttyS0';
-fi;
+if test $soc = 'rk3308'; then
+	serial_addr=',0xff0c0000'; serial_port='ttyS2';
+elif test $soc = 'rk3328'; then
+	serial_addr=',0xff130000'; serial_port='ttyS2';
+elif test $soc = 'rk3399'; then
+	serial_addr=',0xff1a0000'; serial_port='ttyS2';
+elif test $soc = 'rk3528'; then
+	serial_addr=',0xff9f0000'; serial_port='ttyS0';
+elif test $soc = 'rk3568'; then
+	serial_addr=',0xfe660000'; serial_port='ttyS2';
+elif test $soc = 'rk3576'; then
+	serial_addr=',0x2ad40000'; serial_port='ttyS0';
+elif test $soc = 'rk3588'; then
+	serial_addr=',0xfeb50000'; serial_port='ttyS2';
+fi
 
 setenv bootargs "console=${serial_port},1500000 earlycon=uart8250,mmio32${serial_addr} root=PARTUUID=${uuid} rw rootwait";
 


### PR DESCRIPTION
```
On some SoCs like RK3399, U-Boot no longer export the serial
address in $stdout variable, it has been changed to something like
`stdout=serial,vidconsole` since video supported was added. So
detect $soc variable instead, this also makes the script more clear.

Addtional note: rk3566 is reported as rk3568, rk3582 is reported as
rk3588 in $soc.
```