### PR TITLE
[WIP] qualcommbe: add Ubiquiti Cloud Gateway Fiber (ucgfiber)

### DIFF
--- a/target/linux/qualcommbe/files/arch/arm64/boot/dts/qcom/ipq9574-ucgfiber.dts
+++ b/target/linux/qualcommbe/files/arch/arm64/boot/dts/qcom/ipq9574-ucgfiber.dts
@@ -1,0 +1,535 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR BSD-3-Clause)
+/* UniFi Fiber Gateway
+ *
+ * Copyright (c) 2020-2021 The Linux Foundation. All rights reserved.
+ * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include "ipq9574.dtsi"
+
+/ {
+	model = "Ubiquiti Networks Cloud Gateway Fiber";
+	compatible = "ubnt,ucgfiber", "qcom,ipq9574-ap-al02-c18", "qcom,ipq9574-al02", "qcom,ipq9574";
+
+	aliases {
+		serial0 = &blsp1_uart2;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	regulator_fixed_3p3: s3300 {
+		compatible = "regulator-fixed";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-name = "fixed_3p3";
+	};
+
+	regulator_fixed_0p925: s0925 {
+		compatible = "regulator-fixed";
+		regulator-min-microvolt = <925000>;
+		regulator-max-microvolt = <925000>;
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-name = "fixed_0p925";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&gpio_keys_default>;
+		pinctrl-names = "default";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 52 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&gpio_leds_default>;
+		pinctrl-names = "default";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "sfp";
+			function-enumerator = <7>;
+			gpios = <&tlmm 44 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "sfp";
+			function-enumerator = <6>;
+			gpios = <&tlmm 45 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	sfp6: sfp6 {
+		/* WAN port 7, connected to PPE port 6 */
+		compatible = "sff,sfp";
+		i2c-bus = <&blsp1_i2c4>;
+		mod-def0-gpios = <&tlmm 41 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio_ext 2 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpios = <&gpio_ext 1 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <3000>;
+	};
+
+	sfp7: sfp7 {
+		/* WAN port 6, connected to PPE port 5 */
+		compatible = "sff,sfp";
+		i2c-bus = <&blsp1_i2c3>;
+		mod-def0-gpios = <&tlmm 40 GPIO_ACTIVE_LOW>;
+		los-gpios = <&gpio_ext 4 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpios = <&gpio_ext 5 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <3000>;
+	};
+};
+
+&blsp1_spi0 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x00 0xc0000>;
+				label = "SBL1";
+			};
+
+			partition@c0000 {
+				reg = <0xc0000 0x10000>;
+				label = "MIBIB";
+			};
+
+			partition@d0000 {
+				reg = <0xd0000 0x20000>;
+				label = "BOOTCONFIG";
+			};
+
+			partition@f0000 {
+				reg = <0xf0000 0x180000>;
+				label = "QSEE";
+			};
+
+			partition@270000 {
+				reg = <0x270000 0x10000>;
+				label = "DEVCFG";
+			};
+
+			partition@280000 {
+				reg = <0x280000 0x10000>;
+				label = "APDP";
+			};
+
+			partition@290000 {
+				reg = <0x290000 0x40000>;
+				label = "TME";
+			};
+
+			partition@2d0000 {
+				reg = <0x2d0000 0x20000>;
+				label = "RPM";
+			};
+
+			partition@2f0000 {
+				reg = <0x2f0000 0x10000>;
+				label = "CDT";
+			};
+
+			partition@300000 {
+				reg = <0x300000 0x10000>;
+				label = "u-boot-env";
+			};
+
+			partition@310000 {
+				reg = <0x310000 0xc0000>;
+				label = "u-boot";
+			};
+
+			partition@3d0000 {
+				reg = <0x3d0000 0x100000>;
+				label = "ART";
+			};
+
+			partition@4d0000 {
+				reg = <0x4d0000 0x10000>;
+				label = "EEPROM";
+				read-only;
+			};
+
+			partition@4e0000 {
+				reg = <0x4e0000 0x10000>;
+				label = "Factory";
+				read-only;
+			};
+
+			partition@4f0000 {
+				reg = <0x4f0000 0x100000>;
+				label = "config";
+			};
+		};
+	};
+};
+
+&blsp1_uart2 {
+	pinctrl-0 = <&uart2_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&rpm_requests {
+	regulators {
+		compatible = "qcom,rpm-mp5496-regulators";
+
+		ipq9574_s1: s1 {
+		/*
+		 * During kernel bootup, the SoC runs at 800MHz with 875mV set by the bootloaders.
+		 * During regulator registration, kernel not knowing the initial voltage,
+		 * considers it as zero and brings up the regulators with minimum supported voltage.
+		 * Update the regulator-min-microvolt with SVS voltage of 725mV so that
+		 * the regulators are brought up with 725mV which is sufficient for all the
+		 * corner parts to operate at 800MHz
+		 */
+			regulator-min-microvolt = <725000>;
+			regulator-max-microvolt = <1075000>;
+		};
+
+		mp5496_l2: l2 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-always-on;
+			regulator-boot-on;
+		};
+
+		mp5496_l5: l5 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-always-on;
+			regulator-boot-on;
+		};
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&tlmm {
+	spi_0_pins: spi-0-state {
+		pins = "gpio11", "gpio12", "gpio13", "gpio14";
+		function = "blsp0_spi";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	gpio_keys_default: gpio-keys-default-state {
+		pins = "gpio52";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+
+	gpio_leds_default: gpio-leds-default-state {
+		pins = "gpio44", "gpio45";
+		function = "gpio";
+		drive-strength = <8>;
+		output-low;
+		bias-pull-up;
+	};
+
+	pcie2_default: pcie2-default-state {
+		perst-n-pins {
+			pins = "gpio28";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+			output-low;
+		};
+
+		wake-n-pins {
+			pins = "gpio32";
+			function = "pcie2_wake";
+			drive-strength = <6>;
+			bias-pull-up;
+		};
+	};
+
+	i2c3_pins: i2c3-pins {
+		pins = "gpio15", "gpio16";
+		function = "blsp3_i2c";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	i2c4_pins: i2c4-pins {
+		pins = "gpio50", "gpio51";
+		function = "blsp4_i2c";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	spi1_pins: spi1-pins {
+		mux_0 {
+			pins = "gpio61", "gpio62", "gpio64";
+			function = "blsp1_spi";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		mux_1 {
+			pins = "gpio60", "gpio63";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	sdc_default_state: sdc-default-state {
+		clk-pins {
+			pins = "gpio5";
+			function = "sdc_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		cmd-pins {
+			pins = "gpio4";
+			function = "sdc_cmd";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		data-pins {
+			pins = "gpio0", "gpio1", "gpio2",
+			       "gpio3", "gpio6", "gpio7",
+			       "gpio8", "gpio9";
+			function = "sdc_data";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		rclk-pins {
+			pins = "gpio10";
+			function = "sdc_rclk";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&ref_48mhz_clk {
+	clock-div = <1>;
+	clock-mult = <1>;
+};
+
+&xo_board_clk {
+	clock-div = <2>;
+	clock-mult = <1>;
+};
+
+&xo_clk {
+	clock-frequency = <48000000>;
+};
+
+&sdhc_1 {
+	pinctrl-0 = <&sdc_default_state>;
+	pinctrl-names = "default";
+	mmc-ddr-1_8v;
+	mmc-hs200-1_8v;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+	max-frequency = <384000000>;
+	bus-width = <8>;
+	status = "okay";
+};
+
+&pcie2_phy {
+	status = "okay";
+};
+
+&pcie2 {
+	pinctrl-0 = <&pcie2_default>;
+	pinctrl-names = "default";
+
+	perst-gpios = <&tlmm 28 GPIO_ACTIVE_LOW>;
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+};
+
+&qcom_ppe {
+	status = "okay";
+
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ppe_port1: port@1 {
+			reg = <1>;
+			phy-mode = "usxgmii";
+			pcs-handle = <&pcs0_ch0>;
+			clocks = <&nsscc NSS_CC_PORT1_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT1_RX_CLK>,
+				 <&nsscc NSS_CC_PORT1_TX_CLK>;
+			clock-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+			resets = <&nsscc PORT1_MAC_ARES>,
+				 <&nsscc PORT1_RX_ARES>,
+				 <&nsscc PORT1_TX_ARES>;
+			reset-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+
+			/* RTL8273 switch CPU port */
+			/* RTL8261N 10G PHY connected via switch? */
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+				pause;
+			};
+		};
+
+		ppe_port5: port@5 {
+			reg = <5>;
+			phy-mode = "usxgmii";
+			managed = "in-band-status";
+			pcs-handle = <&pcs1_ch0>;
+			sfp = <&sfp7>;
+			clocks = <&nsscc NSS_CC_PORT5_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT5_RX_CLK>,
+				 <&nsscc NSS_CC_PORT5_TX_CLK>;
+			clock-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+			resets = <&nsscc PORT5_MAC_ARES>,
+				 <&nsscc PORT5_RX_ARES>,
+				 <&nsscc PORT5_TX_ARES>;
+			reset-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+		};
+
+		ppe_port6: port@6 {
+			reg = <6>;
+			phy-mode = "usxgmii";
+			managed = "in-band-status";
+			pcs-handle = <&pcs2_ch0>;
+			sfp = <&sfp6>;
+			clocks = <&nsscc NSS_CC_PORT6_MAC_CLK>,
+				 <&nsscc NSS_CC_PORT6_RX_CLK>,
+				 <&nsscc NSS_CC_PORT6_TX_CLK>;
+			clock-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+			resets = <&nsscc PORT6_MAC_ARES>,
+				 <&nsscc PORT6_RX_ARES>,
+				 <&nsscc PORT6_TX_ARES>;
+			reset-names = "port_mac",
+				      "port_rx",
+				      "port_tx";
+		};
+	};
+};
+
+&blsp1_i2c3 {
+	pinctrl-0 = <&i2c3_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	rtl8238b@20 {
+		compatible = "realtek,rtl8238b";
+		reg = <0x20>;
+		power-budget-mw = <51000>;
+		reset = <&tlmm 25 GPIO_ACTIVE_LOW>;
+		interrupts-extended = <&tlmm 42 IRQ_TYPE_EDGE_RISING>;
+
+		port@3 {
+			mode = "at";
+			led = <&gpio_ext 11 GPIO_ACTIVE_HIGH>;
+			indexes = <3 3>;
+		};
+	};
+
+	gpio_ext: pca9575@22 {
+		compatible = "nxp,pca9575";
+		reg = <0x22>;
+		gpio-controller;
+		pupd-val = [ff 00];
+		#gpio-cells = <0x02>;
+		reset_gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
+	};
+
+	s35390a@30 {
+		compatible = "sii,s35390a";
+		reg = <0x30>;
+	};
+};
+
+&blsp1_i2c4 {
+	pinctrl-0 = <&i2c4_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	lis2dw12@19 {
+		compatible = "st,lis2dw12";
+		reg = <0x19>;
+		interrupts-extended = <&tlmm 33 IRQ_TYPE_EDGE_FALLING>;
+	};
+
+	ctf2302@32 {
+		compatible = "sensylink,ctf2302";
+		reg = <0x32>;
+		ch-dis = <0x2000>;
+	};
+
+	lm63@4c {
+		compatible = "national,lm63";
+		reg = <0x4c>;
+		tachometer-en;
+	};
+};
+
+&blsp1_spi1 {
+	status = "ok";
+	pinctrl-0 = <&spi1_pins>;
+	pinctrl-names = "default";
+
+	display@0 {
+//		compatible = "st7735fb";
+		compatible = "jd-t18003-t01";
+		reg = <0>;
+		spi-max-frequency = <15000000>;
+		dc-gpios = <&tlmm 63 GPIO_ACTIVE_HIGH>;
+		reset-gpios = <&tlmm 60 GPIO_ACTIVE_HIGH>;
+		status = "ok";
+	};
+};

--- a/target/linux/qualcommbe/image/ipq95xx.mk
+++ b/target/linux/qualcommbe/image/ipq95xx.mk
@@ -24,3 +24,15 @@ define Device/qcom_rdp433
 	IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 TARGET_DEVICES += qcom_rdp433
+
+define Device/ubnt_ucgfiber
+	$(call Device/FitImageLzma)
+	$(call Device/EmmcImage)
+	DEVICE_VENDOR := Ubiquiti Networks
+	DEVICE_MODEL := Cloud Gateway Fiber
+	SOC := ipq9574
+	DEVICE_PACKAGES := kmod-gpio-pca953x kmod-iio-st_accel-i2c kmod-hwmon-lm63 \
+			   kmod-phy-rtl8261n kmod-rtc-s35390a kmod-sfp \
+			   -wpad-basic-mbedtls -kmod-usb3 -kmod-usb-dwc3 -kmod-usb-dwc3-qcom
+endef
+TARGET_DEVICES += ubnt_ucgfiber


### PR DESCRIPTION
working:
 * Ethernet
   * PPE port 1 (RTL8372 switch CPU port)
   * PPE port 5 (SFP port 7)
   * PPE port 6 (SFP port 6)
 * SFP cages
 * eMMC
 * SPI-NOR
 * I2C busses
 * PCA I2C GPIO expander
 * RTC
 * LEDs
 * reset button
 * lm63 temperatur sensor

not working:
 * MDIO (reads 0x0000ffff for everything, maybe clk problem?)
 * RTL8372 switch (no driver, affected by broken host MDIO)
 * RTL8238 PoE (no driver, connected via I2C)
 * RTL8261N 10G PHY (hooked to RTL8372, not accessible due to broken host MDIO)
 * Sensylink CTF2302 fan controller (no driver, see below for simiar driver)
 https://patchwork.kernel.org/project/linux-hwmon/patch/20230331133437.3329487-1-corone.il.han@gmail.com/

untested:
 * accelerometer
 * display (connected to spi1)