### PR TITLE
mediatek: add support for Keenetic KAP-630/Netcraze NAP-630

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+#include "mt7981b-keenetic-kap-630.dtsi"
+
+/ {
+	model = "Keenetic KAP-630";
+	compatible = "keenetic,kap-630", "mediatek,mt7981";
+};

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include "mt7981b.dtsi"
+
+/ {
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &status_led_green;
+		led-failsafe = &status_led_orange;
+		led-running = &status_led_green;
+		led-upgrade = &status_led_green;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 24 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		status_led_green: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
+		};
+
+		status_led_orange: led-1 {
+			color = <LED_COLOR_ID_ORANGE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x600000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x600000 0x0>;
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy10>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_a>;
+	};
+};
+
+&mdio_bus {
+	/* Airoha EN8811H */
+	phy10: ethernet-phy@a {
+		reg = <0xa>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_EDGE_FALLING>;
+		reset-gpios = <&pio 22 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <20000>;
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	/* Winbond W25N01GVZEIG (128M) */
+	spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* bl2 */
+			partition@0 {
+				label = "preloader";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			/* fip */
+			partition@80000 {
+				label = "u-boot";
+				reg = <0x80000 0x200000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "u-config";
+				reg = <0x280000 0x80000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "rf-eeprom";
+				reg = <0x300000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_a: macaddr@a {
+						reg = <0xa 0x6>;
+					};
+				};
+			};
+
+			firmware1: partition@500000 {
+				label = "firmware_1";
+				reg = <0x500000 0x3500000>;
+			};
+
+			partition@3a00000 {
+				label = "config_1";
+				reg = <0x3a00000 0x80000>;
+				read-only;
+			};
+
+			partition@3a80000 {
+				label = "dump";
+				reg = <0x3a80000 0x80000>;
+				read-only;
+			};
+
+			partition@3c00000 {
+				label = "u-state";
+				reg = <0x3c00000 0x20000>;
+				read-only;
+			};
+
+			partition@3e80000 {
+				label = "u-config_res";
+				reg = <0x3e80000 0x80000>;
+				read-only;
+			};
+
+			partition@3f00000 {
+				label = "rf-eeprom_res";
+				reg = <0x3f00000 0x200000>;
+				read-only;
+			};
+
+			firmware2: partition@4100000 {
+				label = "firmware_2";
+				reg = <0x4140000 0x3500000>;
+			};
+
+			partition@7600000 {
+				label = "config_2";
+				reg = <0x7600000 0x80000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wifi {
+	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
+	status = "okay";
+};
+
+&sgmiisys0 {
+	/delete-node/ mediatek,pnswap;
+};

--- a/target/linux/mediatek/dts/mt7981b-netcraze-nap-630.dts
+++ b/target/linux/mediatek/dts/mt7981b-netcraze-nap-630.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+#include "mt7981b-keenetic-kap-630.dtsi"
+
+/ {
+	model = "Netcraze NAP-630";
+	compatible = "netcraze,nap-630", "mediatek,mt7981";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -110,6 +110,8 @@ mediatek_setup_interfaces()
 	cudy,ap3000-v1|\
 	cudy,re3000-v1|\
 	kebidumei,ax3000-u22|\
+	keenetic,kap-630|\
+	netcraze,nap-630|\
 	netgear,eax17|\
 	netgear,wax220|\
 	openfi,6c|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -153,9 +153,11 @@ case "$board" in
 	jdcloud,re-cp-03)
 		[ "$PHYNBR" = "1" ] && mmc_get_mac_binary factory 0xa > /sys${DEVPATH}/macaddress
 		;;
+	keenetic,kap-630|\
 	keenetic,kn-3711|\
 	keenetic,kn-3811|\
-	keenetic,kn-3911)
+	keenetic,kn-3911|\
+	netcraze,nap-630)
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary rf-eeprom 0x4)" > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1785,6 +1785,32 @@ define Device/kebidumei_ax3000-u22
 endef
 TARGET_DEVICES += kebidumei_ax3000-u22
 
+define Device/keenetic_kap-630-common
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
+		kmod-phy-airoha-en8811h
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 6144k
+  IMAGE_SIZE := 108544k
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
+	append-squashfs4-fakeroot
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size | zyimage -d $$(ZYIMAGE_ID) -v "$$(DEVICE_MODEL)"
+endef
+
+define Device/keenetic_kap-630
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KAP-630
+  DEVICE_DTS := mt7981b-keenetic-kap-630
+  ZYIMAGE_ID := 0x810630
+  $(call Device/keenetic_kap-630-common)
+endef
+TARGET_DEVICES += keenetic_kap-630
+
 define Device/keenetic_kn-1812-common
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7992-firmware kmod-usb3 \
@@ -2227,6 +2253,15 @@ define Device/netcore_n60-pro
   ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot netcore_n60-pro
 endef
 TARGET_DEVICES += netcore_n60-pro
+
+define Device/netcraze_nap-630
+  DEVICE_VENDOR := Netcraze
+  DEVICE_MODEL := NAP-630
+  DEVICE_DTS := mt7981b-netcraze-nap-630
+  ZYIMAGE_ID := 0xC10630
+  $(call Device/keenetic_kap-630-common)
+endef
+TARGET_DEVICES += netcraze_nap-630
 
 define Device/netcraze_nc-1812
   DEVICE_VENDOR := Netcraze


### PR DESCRIPTION
This commit adds support for Keenetic KAP-630/Netcraze NAP-630

Specification:
 - MT7981 CPU using 2.4GHz and 5GHz WiFi (both AX)
 - 512MB RAM
 - 128MB SPI NAND
 - 1 led with two colors (green, orange)
 - 1 button (reset)
 - 1 2.5Gbit ethernet port based on Airoha EN8811H phy

Serial Interface:
 - 3 Pins GND, RX, TX
 - Settings: 115200, 8N1

Notes:
 - The device supports dual boot mode

Flash instruction:
The only way to flash OpenWrt image is to use tftp recovery mode in U-Boot:

1. Configure PC with static IP 192.168.1.2/24 and tftp server.
2. a) Keenetic Rename "openwrt-mediatek-filogic-keenetic_kap-630-squashfs-factory.bin" to "KAP-630_recovery.bin" and place it in tftp server directory. 
    b) Netcraze Rename "openwrt-mediatek-filogic-netcraze_nap-630-squashfs-factory.bin" to "NAP-630_recovery.bin" and place it in tftp server directory.
4. Connect PC with ethernet port, press the reset button, power up the device and keep button pressed until status led start blinking.
5. Device will download file from server, write it to flash and reboot.