### PR TITLE
mediatek: add fixes for Keenetic KN-3711/KN-3811/KN-3911

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
@@ -9,7 +9,7 @@
 	compatible = "keenetic,kn-3711", "mediatek,mt7981";
 
 	aliases {
-		label-mac-device = &gmac0;
+		label-mac-device = &gmac1;
 		led-boot = &power_led;
 		led-failsafe = &power_led;
 		led-running = &power_led;
@@ -117,7 +117,7 @@
 		};
 	};
 
-	mac@1 {
+	gmac1: mac@1 {
 		compatible = "mediatek,eth-mac";
 		reg = <1>;
 		phy-mode = "gmii";

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3711.dts
@@ -209,13 +209,6 @@
 		spi-tx-buswidth = <4>;
 		spi-rx-buswidth = <4>;
 
-		spi-cal-enable;
-		spi-cal-mode = "read-data";
-		spi-cal-datalen = <7>;
-		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
-		spi-cal-addrlen = <5>;
-		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
-
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
 		mediatek,bmt-max-reserved-blocks = <64>;

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
@@ -123,7 +123,7 @@
 		phy-mode = "2500base-x";
 
 		nvmem-cell-names = "mac-address";
-		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cells = <&macaddr_factory_4>;
 
 		fixed-link {
 			speed = <2500>;
@@ -140,7 +140,7 @@
 		label = "wan";
 
 		nvmem-cell-names = "mac-address";
-		nvmem-cells = <&macaddr_factory_a 0>;
+		nvmem-cells = <&macaddr_factory_a>;
 	};
 };
 
@@ -270,16 +270,12 @@
 
 					/* lan mac */
 					macaddr_factory_4: macaddr@4 {
-						compatible = "mac-base";
 						reg = <0x4 0x6>;
-						#nvmem-cell-cells = <1>;
 					};
 
 					/* wan mac */
 					macaddr_factory_a: macaddr@a {
-						compatible = "mac-base";
 						reg = <0xa 0x6>;
-						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
@@ -9,7 +9,7 @@
 	compatible = "keenetic,kn-3811", "mediatek,mt7981";
 
 	aliases {
-		label-mac-device = &gmac0;
+		label-mac-device = &gmac1;
 		led-boot = &power_led;
 		led-failsafe = &power_led;
 		led-running = &power_led;

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
@@ -225,13 +225,6 @@
 		spi-tx-buswidth = <4>;
 		spi-rx-buswidth = <4>;
 
-		spi-cal-enable;
-		spi-cal-mode = "read-data";
-		spi-cal-datalen = <7>;
-		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
-		spi-cal-addrlen = <5>;
-		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
-
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
 		mediatek,bmt-max-reserved-blocks = <64>;

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
@@ -9,7 +9,7 @@
 	compatible = "keenetic,kn-3911", "mediatek,mt7981";
 
 	aliases {
-		label-mac-device = &gmac0;
+		label-mac-device = &gmac1;
 		led-boot = &status_led;
 		led-failsafe = &status_led;
 		led-running = &status_led;
@@ -94,7 +94,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&mdio_pins>;
 
-	gmac0: mac@0 {
+	mac@0 {
 		compatible = "mediatek,eth-mac";
 		reg = <0>;
 		phy-mode = "2500base-x";

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
@@ -172,13 +172,6 @@
 		spi-tx-buswidth = <4>;
 		spi-rx-buswidth = <4>;
 
-		spi-cal-enable;
-		spi-cal-mode = "read-data";
-		spi-cal-datalen = <7>;
-		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
-		spi-cal-addrlen = <5>;
-		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
-
 		mediatek,nmbm;
 		mediatek,bmt-max-ratio = <1>;
 		mediatek,bmt-max-reserved-blocks = <64>;

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
@@ -102,7 +102,7 @@
 		label = "lan";
 
 		nvmem-cell-names = "mac-address";
-		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cells = <&macaddr_factory_4>;
 	};
 
 	gmac1: mac@1 {
@@ -113,7 +113,7 @@
 		label = "wan";
 
 		nvmem-cell-names = "mac-address";
-		nvmem-cells = <&macaddr_factory_a 0>;
+		nvmem-cells = <&macaddr_factory_a>;
 	};
 };
 
@@ -217,16 +217,12 @@
 
 					/* lan mac */
 					macaddr_factory_4: macaddr@4 {
-						compatible = "mac-base";
 						reg = <0x4 0x6>;
-						#nvmem-cell-cells = <1>;
 					};
 
 					/* wan mac */
 					macaddr_factory_a: macaddr@a {
-						compatible = "mac-base";
 						reg = <0xa 0x6>;
-						#nvmem-cell-cells = <1>;
 					};
 				};
 			};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -123,6 +123,10 @@ netcraze,nc-1812)
 	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan" "phy0.1-ap0"
 	ucidef_set_led_netdev "internet" "internet" "green:wan-online" "wan" "link"
 	;;
+keenetic,kn-3711|\
+keenetic,kn-3811)
+	ucidef_set_led_netdev "internet" "internet" "green:wan" "wan" "link"
+	;;
 mercusys,mr80x-v3)
 	ucidef_set_led_netdev "lan1" "lan-1" "green:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan-2" "green:lan-2" "lan2" "link tx rx"


### PR DESCRIPTION
This pull request introduces the following fixes:
- fix label mac device for Keenetic KN-3711/KN-3811/KN-3911
- drop spi calibration for Keenetic KN-3711/KN-3811/KN-3911
- simplify nvmem mac definition for Keenetic KN-3811/KN-3911 (cosmetic)
- enable wan led for wan port for Keenetic KN-3711/KN-3811
