### PR TITLE
build: re-account for all relevant "*.install" stamp files

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -348,11 +348,9 @@ endif
       endif
 
       .PHONY: $(PKG_INSTALL_STAMP).$(1)
-      ifeq ($(CONFIG_PACKAGE_$(1)),y)
-        compile: $(PKG_INSTALL_STAMP).$(1)
-      endif
+      compile: $(PKG_INSTALL_STAMP).$(1)
       $(PKG_INSTALL_STAMP).$(1): prepare-package-install
-		echo "$(1)" >> $(PKG_INSTALL_STAMP)
+		$(if $(filter y,$(CONFIG_PACKAGE_$(1))),echo "$(1)" >> $(PKG_INSTALL_STAMP))
     else
       $(if $(CONFIG_PACKAGE_$(1)),$$(warning WARNING: skipping $(1) -- package has no install section))
     endif


### PR DESCRIPTION
It was noticed that some packages selected as modules in menuconfig will appear as built-in. It seems that has to do with variants and only in some cases, looking at how the list of packages passed to the package manager is created and following that path, git history(and precise commit descriptions) pointed rigthly to the subtle problem.

Resulted that commit 1f22957247caa85b9583ebb4edaee618dff4b3ba ("build: clean up redundant touching of the package install info file") ended up reverting the fix 317b3556a494b2c6f02ef3e965ac42e77342ee4e ("include: properly update .install stamp files") so reapply the same logic to avoid un-selected packages(<*>/<y> -> <m>) to be included as selected(<*>/<y>) in the build (subpackages implementing "variants" from a common source makefile).

Reuse quite precise issue description from Jo-Philipp Wich:

"include: properly update .install stamp files
Right now the $(PKG_INSTALL_STAMP) files are only written if a package is selected as <*> but never deleted or emptied if the corresponding package is getting deselected.

For ordinary packages this usually is no problem as the package/install recipe performs its own check for enabled packages when assembling the list of install stamp files to consider, but this logic might fail under certain circumstances for packages providing multiple build variants.

In case of a multi-variant package, the buildroot first checks if any of the variants is enabled, then resolves all variants of the common source package and finally processes the corresponding .install stamp files of all variants, relying on the assumption that only the selected .install stamp file exists.

When an initially selected variant is getting deselected or changed from <*> to <m> and another variant is marked as <*> instead, the .install stamp file of the deselected variant remains unchanged and a second .install stamp file for the newly selected variant is getting created, causing the package/install recipe to pick up two .install stamps with conflicting variants, leading to opkg file clashes.

This issue happens for example if package "ip" is set to <m> and package "ip-full" to <*> -  the install command will eventually fail with:

     * check_conflicts_for: The following packages conflict with ip:
     * check_conflicts_for: 	ip-full *
     * opkg_install_cmd: Cannot install package ip.

In order to fix the problem, always process the removal requests of the .install stamp files, even for deselected packages but only write the package base name into the stamp file if the corresponding package is marked as builtin."

*apk does not complaints about file conflicts between variants (same origin field, fix pending) nor package level conflict is raised. And the reason is because of a curious behavior of apk: when adding a package which name is a name that other package provides and you also adds that other package, apk replaces the package which name matches the shared name with the other package. (i.e. if you add jq and jq-full apk will end up with just jq-full installed) *But if you manually add the packages with "apk add --allow-untrusted --force-non-repository jq-full*.apk" apk will complain.

Fixes: 1f22957247caa85b9583ebb4edaee618dff4b3ba ("build: clean up redundant touching of the package install info file")
