### PR TITLE
lantiq: AVM Fritz 736x: fix PCIe reset GPIO

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz736x.dtsi
@@ -156,6 +156,7 @@
 
 &pcie0 {
 	status = "okay";
+	gpio-reset = <&gpio 21 GPIO_ACTIVE_LOW>;
 
 	pcie@0 {
 		reg = <0 0 0 0 0>;


### PR DESCRIPTION
 * lantiq: AVM Fritz 736x: fix PCIe reset GPIO
    
    The vr9.dtsi configures the GPIO 38 as reset GPIO. Also the fon LED is
    configured on GPIO 38. This conflicts and makes the probing of the PCIe
    controller fail in OpenWrt 25.12.
    
    The AVM GPL source code configured GPIO 21 as PCIe reset.
    
    Fixes: https://github.com/openwrt/openwrt/issues/21562

I do not have this device.
@henkv1 Please test this PR and report back. 