### PR TITLE
firewall: change synflood_protect option name

### DIFF
--- a/package/network/config/firewall/files/firewall.config
+++ b/package/network/config/firewall/files/firewall.config
@@ -1,5 +1,5 @@
 config defaults
-	option syn_flood	1
+	option synflood_protect	1
 	option input		REJECT
 	option output		ACCEPT
 	option forward		REJECT


### PR DESCRIPTION
The `syn_flood` option name is deprecated, `synflood_protect` should be used instead. firewall3 and firewall4 both support this option since a long time. LuCI already replaces the option name.
https://github.com/openwrt/luci/commit/0abcb39b623f0eff0fbcdfb99fca8f3224701e86

Suggested-by: rparge in OpenWrt forum