### PR TITLE
realtek: refactor MAC address configuration in 02_network script

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -60,6 +60,7 @@ realtek_setup_macs()
 	xikestor,sks8300-12e2t2x)
 		label_mac=$(get_mac_label)
 		lan_mac="$label_mac"
+		lan_mac_start=$lan_mac
 		;;
 	hpe,1920-8g|\
 	hpe,1920-8g-poe-65w|\
@@ -83,26 +84,29 @@ realtek_setup_macs()
 	plasmacloud,psx8|\
 	plasmacloud,psx10|\
 	plasmacloud,psx28)
-		lan_mac_start=skip
 		lan_mac="$(get_mac_label)"
 		;;
 	tplink,tl-st1008f-v2|\
 	zyxel,xgs1010-12-a1)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		[ -z "$lan_mac" ] || [ "$lan_mac" = "00:e0:4c:00:00:00" ] && lan_mac=$(macaddr_random)
+		lan_mac_start=$lan_mac
 		;;
 	xikestor,sks8300-8x)
 		lan_mac=$(mtd_get_mac_binary board-info 0x1f1)
+		lan_mac_start=$lan_mac
 		;;
 	xikestor,sks8310-8x)
 		lan_mac=$(mtd_get_mac_binary factory 0x80)
 		label_mac="$lan_mac"
+		lan_mac_start=$lan_mac
 		;;
 	*)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env2 mac_start)
 		lan_mac_end=$(mtd_get_mac_ascii u-boot-env2 mac_end)
 		label_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		[ -z "$lan_mac" ] && lan_mac=$label_mac
+		lan_mac_start=$lan_mac
 		;;
 	esac
 
@@ -110,8 +114,7 @@ realtek_setup_macs()
 	[ -n "$lan_mac" ] && ucidef_set_bridge_mac "$lan_mac"
 	[ -n "$lan_mac" ] && ucidef_set_network_device_mac eth0 $lan_mac
 
-	[ -z "$lan_mac_start" -a -n "$lan_mac" ] && lan_mac_start=$lan_mac
-	[ "$lan_mac_start" != "skip" ] && realtek_setup_macs_lan "$lan_list" "$lan_mac_start" "$lan_mac_end"
+	[ -n "$lan_mac_start" ] && realtek_setup_macs_lan "$lan_list" "$lan_mac_start" "$lan_mac_end"
 
 	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
 }

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -83,7 +83,7 @@ realtek_setup_macs()
 	plasmacloud,psx28)
 		lan_mac_start=skip
 		lan_mac="$(get_mac_label)"
-	;;
+		;;
 	tplink,tl-st1008f-v2|\
 	zyxel,xgs1010-12-a1)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -45,6 +45,7 @@ realtek_setup_macs()
 	local board="$1"
 	local lan_list="$2"
 
+	local eth0_mac=""
 	local lan_mac=""
 	local lan_mac_start=""
 	local lan_mac_end=""
@@ -58,8 +59,7 @@ realtek_setup_macs()
 	tplink,t1600g-28ts-v3|\
 	xikestor,sks8300-8t|\
 	xikestor,sks8300-12e2t2x)
-		label_mac=$(get_mac_label)
-		lan_mac="$label_mac"
+		lan_mac=$(get_mac_label)
 		lan_mac_start=$lan_mac
 		;;
 	hpe,1920-8g|\
@@ -73,6 +73,7 @@ realtek_setup_macs()
 	hpe,1920-48g-poe)
 		label_mac=$(mtd_get_mac_binary factory 0x68)
 		lan_mac=$label_mac
+		eth0_mac=$lan_mac
 		mac_count1=$(hexdump -v -n 4 -s 0x110 -e '4 "%d"' $(find_mtd_part factory) 2>/dev/null)
 		mac_count2=$(hexdump -v -n 4 -s 0x114 -e '4 "%d"' $(find_mtd_part factory) 2>/dev/null)
 		lan_mac_start=$(macaddr_add $lan_mac 2)
@@ -91,15 +92,18 @@ realtek_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		[ -z "$lan_mac" ] || [ "$lan_mac" = "00:e0:4c:00:00:00" ] && lan_mac=$(macaddr_random)
 		lan_mac_start=$lan_mac
+		eth0_mac=$lan_mac
 		;;
 	xikestor,sks8300-8x)
 		lan_mac=$(mtd_get_mac_binary board-info 0x1f1)
 		lan_mac_start=$lan_mac
+		eth0_mac=$lan_mac
 		;;
 	xikestor,sks8310-8x)
 		lan_mac=$(mtd_get_mac_binary factory 0x80)
 		label_mac="$lan_mac"
 		lan_mac_start=$lan_mac
+		eth0_mac=$lan_mac
 		;;
 	allnet,all-sg8208m|\
 	apresia,aplgs120gtss|\
@@ -154,12 +158,14 @@ realtek_setup_macs()
 		label_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		[ -z "$lan_mac" ] && lan_mac=$label_mac
 		lan_mac_start=$lan_mac
+		eth0_mac=$lan_mac
 		;;
 	esac
 
+	[ -n "$eth0_mac" ] && ucidef_set_network_device_mac eth0 $eth0_mac
+
 	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac
 	[ -n "$lan_mac" ] && ucidef_set_bridge_mac "$lan_mac"
-	[ -n "$lan_mac" ] && ucidef_set_network_device_mac eth0 $lan_mac
 
 	[ -n "$lan_mac_start" ] && realtek_setup_macs_lan "$lan_list" "$lan_mac_start" "$lan_mac_end"
 

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -101,7 +101,54 @@ realtek_setup_macs()
 		label_mac="$lan_mac"
 		lan_mac_start=$lan_mac
 		;;
-	*)
+	allnet,all-sg8208m|\
+	apresia,aplgs120gtss|\
+	d-link,dgs-1210-10mp-f|\
+	d-link,dgs-1210-10p|\
+	d-link,dgs-1210-16|\
+	d-link,dgs-1210-20|\
+	d-link,dgs-1210-26|\
+	d-link,dgs-1210-28|\
+	d-link,dgs-1210-28mp-f|\
+	d-link,dgs-1210-28p-f|\
+	d-link,dgs-1210-52|\
+	engenius,ews2910p-v1|\
+	engenius,ews2910p-v3|\
+	hasivo,s1100w-8xgt-se|\
+	inaba,aml2-17gp|\
+	iodata,bsh-g24mb|\
+	linksys,lgs310c|\
+	linksys,lgs328c|\
+	linksys,lgs352c|\
+	netgear,gs108t-v3|\
+	netgear,gs110tpp-v1|\
+	netgear,gs110tup-v1|\
+	netgear,gs308t-v1|\
+	netgear,gs310tp-v1|\
+	netgear,gs750e|\
+	panasonic,m16eg-pn28160k|\
+	panasonic,m24eg-pn28240k|\
+	panasonic,m48eg-pn28480k|\
+	panasonic,m8eg-pn28080k|\
+	vimin,vm-s100-0800ms|\
+	zyxel,gs1900-10hp-a1|\
+	zyxel,gs1900-16-a1|\
+	zyxel,gs1900-24-a1|\
+	zyxel,gs1900-24-b1|\
+	zyxel,gs1900-24e-a1|\
+	zyxel,gs1900-24ep-a1|\
+	zyxel,gs1900-24hp-a1|\
+	zyxel,gs1900-24hp-b1|\
+	zyxel,gs1900-48-a1|\
+	zyxel,gs1900-8-a1|\
+	zyxel,gs1900-8-b1|\
+	zyxel,gs1900-8hp-a1|\
+	zyxel,gs1900-8hp-b1|\
+	zyxel,gs1920-24hp-v1|\
+	zyxel,xgs1210-12-a1|\
+	zyxel,xgs1210-12-b1|\
+	zyxel,xgs1250-12-a1|\
+	zyxel,xgs1250-12-b1)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env2 mac_start)
 		lan_mac_end=$(mtd_get_mac_ascii u-boot-env2 mac_end)
 		label_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -55,7 +55,9 @@ realtek_setup_macs()
 	tplink,sg2008p-v1|\
 	tplink,sg2210p-v3|\
 	tplink,sg2452p-v4|\
-	tplink,t1600g-28ts-v3)
+	tplink,t1600g-28ts-v3|\
+	xikestor,sks8300-8t|\
+	xikestor,sks8300-12e2t2x)
 		label_mac=$(get_mac_label)
 		lan_mac="$label_mac"
 		;;
@@ -88,11 +90,6 @@ realtek_setup_macs()
 	zyxel,xgs1010-12-a1)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		[ -z "$lan_mac" ] || [ "$lan_mac" = "00:e0:4c:00:00:00" ] && lan_mac=$(macaddr_random)
-		;;
-	xikestor,sks8300-8t|\
-	xikestor,sks8300-12e2t2x)
-		lan_mac="$(get_mac_label)"
-		label_mac="$lan_mac"
 		;;
 	xikestor,sks8300-8x)
 		lan_mac=$(mtd_get_mac_binary board-info 0x1f1)


### PR DESCRIPTION
This makes the configuration of MAC addresses more explicit and removes some redundant configuration:

- Individual port addresses are only configured if `lan_mac_start` is explicitly set
- Devices using U-Boot environment are now all listed instead of this being the default case
- eth0 MAC address and label MAC are no longer set if already done by device tree
- Renamed `lan_mac` to avoid any confusion with similarly-named `lan_mac_start`/`lan_mac_end`

In my opinion, this makes it clearer what is actually going on (with the most important change being how `lan_mac_start` is handled).

Tested on:
- Zyxel XGS1010-12 rev A1
- Zyxel XGS1210-12 rev B1
- HPE 1920G-8G (JG920A)