### PR TITLE
mediatek: filogic: add support for ASUS RT-BE59

### DIFF
--- a/target/linux/mediatek/dts/mt7987a-asus-rt-be59.dts
+++ b/target/linux/mediatek/dts/mt7987a-asus-rt-be59.dts
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+/*
+ * Copyright (C) 2025 MediaTek Inc.
+ * Author: Sam.Shih <sam.shih@mediatek.com>
+ */
+
+/dts-v1/;
+#include "mt7987a.dtsi"
+#include <dt-bindings/input/input.h>
+
+/* MT7987A RFB DTS for DT overlay-based device tree */
+/ {
+	model = "ASUS RT-BE59";
+	compatible = "asus,rt-be59", "mediatek,mt7987a", "mediatek,mt7987";
+
+	chosen {
+		bootargs-override = "rootfstype=squashfs ubi.mtd=UBI_DEV console=ttyS0,115200n1 earlycon=uart8250,mmio32,0x11000000 pci=pcie_bus_perf";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <10>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		wan-red {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+	aliases {
+		ethernet0 = "/soc/ethernet@15100000/mac@0";
+		ethernet1 = "/soc/ethernet@15100000/mac@1";
+		ethernet2 = "/soc/ethernet@15100000/mac@2";
+	};
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+};
+
+&fan {
+	pwms = <&pwm 0 50000 0>;
+	status = "disabled";
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie0_pins>;
+	status = "okay";
+	slot0: pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+
+		mt7996@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			device_type = "pci";
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+			ieee80211-freq-limit = <2400000 2500000>,
+						<5170000 5835000>; 
+		};
+	};
+};
+
+&pcie1 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_pins>;
+	status = "disabled";
+};
+
+&pwm {
+	status = "disabled";
+};
+
+&ssusb {
+	status = "okay";
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0_pins>;
+	status = "okay";
+};
+
+&spi1 {
+	status = "disabled";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				reg = <0x0 0x400000>;
+				label = "bootloader";
+				read-only;
+			};
+
+			partition@400000 {
+				compatible = "linux,ubi";
+				reg = <0x400000 0x7c00000>;
+				label = "UBI_DEV";
+
+				volumes {
+					ubi_factory: ubi-volume-factory {
+						volname = "Factory";
+					};
+				};
+			};
+		};
+	};
+};
+
+&ubi_factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		eeprom_factory_0: eeprom@0 {
+			reg = <0x0 0x1E00>;
+		};
+	};
+};
+
+&gmac0 {
+	phy-mode = "2500base-x";
+	status = "okay";
+	fixed-link {
+		speed = <2500>;
+		full-duplex;
+		pause;
+	};
+};
+
+&gmac1 {
+	phy-mode = "internal";
+	phy-handle = <&phy15>;
+	status = "okay";
+};
+
+&gmac2 {
+	label = "lan1";
+	phy-handle = <&phy11>;
+	phy-mode = "2500base-x";
+	status = "okay";
+};
+
+&mdio {
+	mfd: mfd@1 {
+		compatible = "airoha,an8855-mfd";
+		reg = <1>;
+		status = "okay";
+
+		efuse {
+			compatible = "airoha,an8855-efuse";
+			#nvmem-cell-cells = <0>;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				shift_sel_port0_tx_a: shift-sel-port0-tx-a@c {
+					reg = <0xc 0x4>;
+				};
+
+				shift_sel_port0_tx_b: shift-sel-port0-tx-b@10 {
+					reg = <0x10 0x4>;
+				};
+
+				shift_sel_port0_tx_c: shift-sel-port0-tx-c@14 {
+					reg = <0x14 0x4>;
+				};
+
+				shift_sel_port0_tx_d: shift-sel-port0-tx-d@18 {
+					reg = <0x18 0x4>;
+				};
+
+				shift_sel_port1_tx_a: shift-sel-port1-tx-a@1c {
+					reg = <0x1c 0x4>;
+				};
+
+				shift_sel_port1_tx_b: shift-sel-port1-tx-b@20 {
+					reg = <0x20 0x4>;
+				};
+
+				shift_sel_port1_tx_c: shift-sel-port1-tx-c@24 {
+					reg = <0x24 0x4>;
+				};
+
+				shift_sel_port1_tx_d: shift-sel-port1-tx-d@28 {
+					reg = <0x28 0x4>;
+				};
+
+				shift_sel_port2_tx_a: shift-sel-port2-tx-a@2c {
+					reg = <0x2c 0x4>;
+				};
+
+				shift_sel_port2_tx_b: shift-sel-port2-tx-b@30 {
+					reg = <0x30 0x4>;
+				};
+
+				shift_sel_port2_tx_c: shift-sel-port2-tx-c@34 {
+					reg = <0x34 0x4>;
+				};
+
+				shift_sel_port2_tx_d: shift-sel-port2-tx-d@38 {
+					reg = <0x38 0x4>;
+				};
+
+				shift_sel_port3_tx_a: shift-sel-port3-tx-a@4c {
+					reg = <0x4c 0x4>;
+				};
+
+				shift_sel_port3_tx_b: shift-sel-port3-tx-b@50 {
+					reg = <0x50 0x4>;
+				};
+
+				shift_sel_port3_tx_c: shift-sel-port3-tx-c@54 {
+					reg = <0x54 0x4>;
+				};
+
+				shift_sel_port3_tx_d: shift-sel-port3-tx-d@58 {
+					reg = <0x58 0x4>;
+				};
+			};
+		};
+
+		ethernet-switch {
+			compatible = "airoha,an8855-switch";
+			reset-gpios = <&pio 42 GPIO_ACTIVE_HIGH>;
+			airoha,ext-surge;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "lan4";
+					phy-mode = "internal";
+					phy-handle = <&internal_phy1>;
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan3";
+					phy-mode = "internal";
+					phy-handle = <&internal_phy2>;
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan2";
+					phy-mode = "internal";
+					phy-handle = <&internal_phy3>;
+				};
+
+				port@5 {
+					reg = <5>;
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+
+		mdio {
+			compatible = "airoha,an8855-mdio";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			internal_phy1: phy@1 {
+				reg = <1>;
+
+				nvmem-cells = <&shift_sel_port0_tx_a>,
+						<&shift_sel_port0_tx_b>,
+						<&shift_sel_port0_tx_c>,
+						<&shift_sel_port0_tx_d>;
+				nvmem-cell-names = "tx_a", "tx_b", "tx_c", "tx_d";
+			};
+
+			internal_phy2: phy@2 {
+				reg = <2>;
+
+				nvmem-cells = <&shift_sel_port1_tx_a>,
+						<&shift_sel_port1_tx_b>,
+						<&shift_sel_port1_tx_c>,
+						<&shift_sel_port1_tx_d>;
+				nvmem-cell-names = "tx_a", "tx_b", "tx_c", "tx_d";
+			};
+
+			internal_phy3: phy@3 {
+				reg = <3>;
+
+				nvmem-cells = <&shift_sel_port2_tx_a>,
+						<&shift_sel_port2_tx_b>,
+						<&shift_sel_port2_tx_c>,
+						<&shift_sel_port2_tx_d>;
+				nvmem-cell-names = "tx_a", "tx_b", "tx_c", "tx_d";
+			};
+		};
+	};
+
+	/* built-in 2.5G Ethernet PHY */
+	phy15: phy@15 {
+		pinctrl-names = "i2p5gbe-led";
+		pinctrl-0 = <&i2p5gbe_led0_pins>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <15>;
+		phy-mode = "internal";
+	};
+
+	phy11: phy@11 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <11>;
+		reset-gpios = <&pio 48 GPIO_ACTIVE_LOW>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <10000>;
+	};
+};
+

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -37,6 +37,10 @@ asus,tuf-ax6000)
 	ucidef_set_led_netdev "lan5" "LAN5" "mdio-bus:05:white:lan" "lan5" "link tx rx"
 	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:white:wan" "eth1" "link tx rx"
 	;;
+asus,rt-be59)
+	ucidef_set_led_netdev "wan" "WAN" "white:wan" "eth1" "link tx rx"
+	ucidef_set_led_netdev "lan" "LAN" "white:lan" "br-lan" "link tx rx"
+	;;
 confiabits,mt7981)
 	ucidef_set_led_netdev "lan1" "lan1" "blue:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan2" "blue:lan-2" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -40,6 +40,9 @@ mediatek_setup_interfaces()
 	arcadyan,mozart)
 		ucidef_set_interfaces_lan_wan "lan0 eth1" eth2
 		;;
+	asus,rt-be59)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax59u|\
 	asus,zenwifi-bt8|\
@@ -236,6 +239,11 @@ mediatek_setup_macs()
 	bananapi,bpi-r4|\
 	bananapi,bpi-r4-lite)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
+		;;
+	asus,rt-be59)
+		lan_mac=$(cat /sys/class/net/eth0/address)
+		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
+		label_mac=$lan_mac
 		;;
 	h3c,magic-nx30-pro)
 		wan_mac=$(mtd_get_mac_ascii pdt_data_1 ethaddr)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -61,6 +61,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_setbit_la $(macaddr_add $addr 1) > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && echo "$addr" > /sys${DEVPATH}/macaddress
 		;;
+	asus,rt-be59)
+		CI_UBIPART="UBI_DEV"
+		addr=$(mtd_get_mac_binary_ubi "Factory" 0x4)
+		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
+		;;
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini)
 		addr=$(cat /sys/class/net/eth0/address)

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -149,7 +149,8 @@ platform_do_upgrade() {
 	asus,tuf-ax4200|\
 	asus,tuf-ax4200q|\
 	asus,tuf-ax6000|\
-	asus,zenwifi-bt8)
+	asus,zenwifi-bt8|\
+	asus,rt-be59)
 		CI_UBIPART="UBI_DEV"
 		CI_KERNPART="linux"
 		nand_do_upgrade "$1"
@@ -380,7 +381,8 @@ platform_pre_upgrade() {
 	asus,tuf-ax4200|\
 	asus,tuf-ax4200q|\
 	asus,tuf-ax6000|\
-	asus,zenwifi-bt8)
+	asus,zenwifi-bt8|\
+	asus,rt-be59)
 		asus_initial_setup
 		;;
 	buffalo,wsr-6000ax8)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -563,6 +563,27 @@ define Device/asus_zenwifi-bt8-ubootmod
 endef
 TARGET_DEVICES += asus_zenwifi-bt8-ubootmod
 
+define Device/asus_rt-be59
+  DEVICE_VENDOR := ASUS
+  DEVICE_MODEL := RT-BE59
+  DEVICE_DTS := mt7987a-asus-rt-be59
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7996e kmod-mt7992-23-firmware kmod-phy-airoha-en8811h mt7987-2p5g-phy-firmware
+  KERNEL := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  KERNEL_LOADADDR := 0x48080000
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+ifeq ($(IB),)
+  ARTIFACTS := initramfs.trx
+  ARTIFACT/initramfs.trx := append-image-stage initramfs-kernel.bin | \
+	uImage none | asus-trx -v 3 -n $$(DEVICE_MODEL)
+endif
+endef
+TARGET_DEVICES += asus_rt-be59
+
 
 define Device/bananapi_bpi-r3
   DEVICE_VENDOR := Bananapi


### PR DESCRIPTION
Hardware

    SOC: MediaTek MT7987
    RAM: 1GB DDR4
    FLASH: 128MB SPI-NAND GD5F1GM7UE
    WIFI: Mediatek MT7991 + MT7976
    ETH: Airoha AN8855 + EN8811
    UART: 3V3 115200 8N1 (Pinout silkscreened / Do not connect VCC)

Installation

Vendor-UI Method

    Download or make the OpenWrt initramfs.trx image
    Connect the PC via LAN to one of the yellow router ports and wait until your PC to get a DHCP lease.
    Browse to http://192.168.50.1/
    If your router is brand new, finish the setup process and log into the Web-UI.
    Navigate to Administration -> Firmware Upgrade and upload the downloaded OpenWrt image.
    Wait for OpenWrt to boot. Transfer the sysupgrade image to the device using SCP and install using sysupgrade.

   $ sysupgrade -n <path-to-sysupgrade.bin>

TFTP Method

    Download the OpenWrt initramfs image.
    Copy the image to a TFTP server reachable at 192.168.1.70/24.
    Rename the image to rtbe59.bin

    Connect the PC with TFTP server to the RT-BE59.
    Set a static ip on the ethernet interface of your PC.
    (IP address: 192.168.1.70, subnet mask: 255.255.255.0)
    Connect to the serial console, interrupt the autoboot process by pressing '4' when prompted.

    Download & Boot the OpenWrt initramfs image.

   $ tftpboot rtbe59.bin
   $ bootm

    Wait for OpenWrt to boot.
    Transfer the sysupgrade image to the device using SCP and install using sysupgrade.

   $ sysupgrade -n <path-to-sysupgrade.bin>
