### PR TITLE
mediatek: filogic: add support for Wavlink WL-WNT100X3

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-wnt100x3.dts
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-wnt100x3.dts
@@ -1,0 +1,222 @@
+/dts-v1/;
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "WAVLINK WL-WNT100X3";
+	compatible = "wavlink,wl-wnt100x3", "mediatek,mt7981b";
+
+	aliases {
+		label-mac-device = &wifi;
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-keys {
+        compatible = "gpio-keys";
+
+        reset {
+            label = "reset";
+            linux,code = <KEY_RESTART>;
+            gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
+        };
+
+        mode {
+            label = "mode";
+            linux,code = <BTN_0>;
+            linux,input-type = <EV_SW>;
+            gpios = <&pio 25 GPIO_ACTIVE_HIGH>;
+            debounce-interval = <60>;
+        };
+	};
+
+    fan_5v: regulator-fan-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fan";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpios = <&pio 22 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+	};
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_pins>;
+	status = "okay";
+};
+
+&fan {
+	pwms = <&pwm 0 40000 0>;
+    fan-supply = <&fan_5v>;
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+    status = "okay";
+    pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+    gmac0: mac@0 {
+        compatible = "mediatek,eth-mac";
+        reg = <0>;
+        phy-mode = "sgmii";
+        phy-handle = <&phy29>;
+        managed = "in-band-status";
+        nvmem-cells = <&macaddr_lan>;
+        nvmem-cell-names = "mac-address";
+
+    };
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+        nvmem-cells = <&macaddr_wan>;
+        nvmem-cell-names = "mac-address";
+	};
+};
+
+&mdio_bus {
+    phy29: ethernet-phy@29 {
+        reg = <29>;
+        phy-mode = "sgmii";
+    };
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+        partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bl2";
+				reg = <0x00000 0x0100000>;
+                read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+                read-only;
+			};
+
+			partition@180000 {
+				label = "factory";
+				reg = <0x180000 0x0200000>;
+                read-only;
+
+                nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+					
+					eeprom_factory: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+                    macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
+					macaddr_lan: macaddr@3fff4 {
+						reg = <0x3fff4 0x06>;
+					};
+
+					macaddr_wan: macaddr@3fffa {
+						reg = <0x3fffa 0x06>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "fip";
+				reg = <0x380000 0x0200000>;
+                read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x5A00000>;
+			};
+			
+			partition@5F80000 {
+				label = "hw";
+				reg = <0x5F80000 0x0080000>;
+                read-only;
+			};
+		};
+	};
+};
+
+&pio {
+    pwm_pins: pwm0-pins {
+		mux {
+			function = "pwm";
+			groups = "pwm0_1";
+		};
+	};
+
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory 0>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -133,6 +133,7 @@ mediatek_setup_interfaces()
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
 	openembed,som7981|\
+	wavlink,wl-wnt100x3\
 	openwrt,one)
 		ucidef_set_interfaces_lan_wan eth1 eth0
 		;;

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2830,6 +2830,24 @@ define Device/wavlink_wl-wn551x3
 endef
 TARGET_DEVICES += wavlink_wl-wn551x3
 
+define Device/wavlink_wl-wnt100x3
+  DEVICE_VENDOR := WAVLINK
+  DEVICE_MODEL := WL-WNT100X3
+  DEVICE_DTS := mt7981b-wavlink-wl-wnt100x3
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  KERNEL_INITRAMFS_SUFFIX := .itb
+  KERNEL_IN_UBI := 1
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-hwmon-pwmfan
+  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += wavlink_wl-wnt100x3
+
 define Device/wavlink_wl-wn586x3
   DEVICE_VENDOR := WAVLINK
   DEVICE_MODEL := WL-WN586X3


### PR DESCRIPTION
Hardware
--------
- SOC: MediaTek MT7981B
- RAM: 512MB DDR3
- FLASH: 128MB SPI-NAND ESMT F50L1G41LB
- NETWORK: 1 x1000M WAN, 1 x 1000M LAN
- WIFI: MediaTek MT7981B 2x2 DBDC 802.11ax 2T2R (2.4/5)
- LEDs: 1x STATUS (blue)
- USB: 1x USB 3.0 (XHCI)
- FAN: 1x 5V FAN

Installation / Upgrade Procedure
-----------------------------

1.Log in to the web management page.
2.Select the country code and time zone, set the Wi-Fi password, and click Save.
3.Click "More", navigate to "Developer Options", and enable the SSH function.
4.Log in to the device via an SSH client (default IP is usually 192.168.20.1).
5.Use scp to upload the OpenWrt
image(openwrt-mediatek-filogic-wavlink_wl-wnt100x3-squashfs-sysupgrade.bin) to the /tmp directory
6.Perform the flash by running the sysupgrade command (use -n to overwrite the existing configuration)
7.Wait for the device to reboot automatically. Once finished, access the OpenWrt web interface (LuCI) at the default IP 192.168.1.1.

MAC Addresses
-----------------------------

2.4GHz: 80:3F:5D:xx:xx:B1 (Factory, 0x4 (hex))
LAN   : 80:3F:5D:xx:xx:B2 (Factory, 0x3fff4 (hex))
WAN   : 80:3F:5D:xx:xx:B3 (Factory, 0x3fffa (hex))
5GHz  : 80:3F:5D:xx:xx:B4 (Factory, 0xa (hex))

Signed-off-by: Yujia Lei <2198821651@qq.com>
