### PR TITLE
uboot-microchipsw: add FIP update flashing shortcut

### DIFF
--- a/package/boot/uboot-microchipsw/src/board/microchip/lan969x/lan969x.env
+++ b/package/boot/uboot-microchipsw/src/board/microchip/lan969x/lan969x.env
@@ -8,3 +8,5 @@ bootargs=console=ttyAT0,115200 root=PARTLABEL=rootfs rootwait
 mmc_read_kernel=mmc read $loadaddr $part_addr 0x100 && imszb $loadaddr image_size && test 0x$image_size -le 0x$part_size && mmc read $loadaddr $part_addr $image_size
 boot_system=part start mmc 0 kernel part_addr && part size mmc 0 kernel part_size && run mmc_read_kernel && bootm
 bootcmd=run boot_system
+filesize_to_blk=setexpr cnt $filesize + 0x1ff && setexpr cnt $cnt / 0x200
+mmc_write_fip=part start mmc 0 fip part_addr && part size mmc 0 fip part_size && run filesize_to_blk && test 0x$cnt -le 0x$part_size && mmc erase fip && mmc write $loadaddr $part_addr $cnt


### PR DESCRIPTION
Add env variable to make it easy to flash an FIP update.
