### PR TITLE
realtek: mdio: rtl838x: activate combo PHY media detection

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -368,8 +368,8 @@ static int rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 
 	/* Enable PHY control via SoC */
 	if (priv->family_id == RTL8380_FAMILY_ID) {
-		/* Enable SerDes NWAY and PHY control via SoC */
-		sw_w32_mask(BIT(7), BIT(15), RTL838X_SMI_GLB_CTRL);
+		/* Enable PHY control by telling SoC that "PHY patching is done" */
+		sw_w32_mask(0, BIT(15), RTL838X_SMI_GLB_CTRL);
 	} else if (priv->family_id == RTL8390_FAMILY_ID) {
 		/* Disable PHY polling via SoC */
 		sw_w32_mask(BIT(7), 0, RTL839X_SMI_GLB_CTRL);


### PR DESCRIPTION
There is a misunderstanding about BIT(7) aka EX_PHY_MAN_24_27 in SMI_GLB_CTRL register. The SDK sets it at different places and it is not clear what it is for. Observation shows that it is essential for a working MAC_LINK_MEDIA_STS register.

A RTL838x device has usally two configurations

- port 24/26 are 2 serdes driven fiber ports
- port 24-27 are 4 PHY driven combo ports

In the combo case the above bit must be set so that a switch between copper and fiber can be detected. Cleanup the MDIO initialization and remove the unneeded bit handling in the DSA driver.