### PR TITLE
bcm53xx: drop vendor wl*_ runtime NVRAM before brcmfmac attach

### DIFF
--- a/package/utils/nvram/files/nvram-bcm53xx.init
+++ b/package/utils/nvram/files/nvram-bcm53xx.init
@@ -71,11 +71,27 @@ set_bcm43602_variables() {
 	esac
 }
 
+drop_vendor_wl_runtime_state() {
+	# Drop vendor-generated wl*_ runtime state that can confuse brcmfmac
+	# during early attach. Keep only minimal wl*_ identity keys.
+
+	case $(board_name) in
+		asus,rt-ac3200|\
+		asus,rt-ac5300)
+			for k in $(nvram show 2>/dev/null | cut -d= -f1 | grep -E '^(wl0_|wl1_|wl2_)'); do
+				echo "$k" | grep -Eq '^(wl0_(fabid|state|state_idx)|wl1_(fabid|state|state_idx)|wl2_(fabid|state|state_idx))$' && continue
+				nvram unset "$k" && COMMIT=1
+			done
+			;;
+	esac
+}
+
 boot() {
 	. /lib/functions.sh
 
 	clear_partialboots
 	set_wireless_led_behaviour
+	drop_vendor_wl_runtime_state
 	set_bcm43602_variables
 
 	[ "$COMMIT" = "1" ] && nvram commit


### PR DESCRIPTION
### Summary

This PR addresses a device-specific brcmfmac initialization issue observed on
ASUS RT-AC5300 when upgrading directly from ASUSWRT while preserving a complete
vendor NVRAM.

The intent is not to replace vendor calibration data or expand the default
NVRAM baseline, but to remove vendor-generated runtime state that is
incompatible with brcmfmac during early attach.

---

### Observed behavior

**RT-AC3200**
- Wi-Fi initializes correctly with a complete, vendor-provided ASUSWRT NVRAM.
- No additional baseline values are strictly required for brcmfmac to function.

**RT-AC5300**
- When flashing directly from ASUSWRT to OpenWrt and keeping the full vendor
  NVRAM, `radio0` fails to appear.
- Investigation shows that brcmfmac fails during early attach while parsing a
  large set (700+) of vendor-generated `wl*_` runtime variables.
- Removing this runtime state allows Wi-Fi to initialize reliably.

---

### Rationale

- The affected `wl*_` variables represent runtime state generated by the vendor
  driver, not calibration or board data.
- This runtime state is not used by OpenWrt and is incompatible with brcmfmac
  during early initialization on RT-AC5300.
- Removing only this runtime state restores reliable operation without touching
  valid vendor calibration data.

For consistency and predictability, the same cleanup can safely be applied on
RT-AC3200 as well, even though it does not strictly require it.

---

### Scope

- Preserve vendor calibration and board data
- Remove only vendor-generated `wl*_` runtime state
- Avoid growing `nvram-bcm53xx.init`
- Keep the approach minimal and homogeneous across bcm53xx devices using
  brcmfmac

---

### Notes

This PR intentionally focuses only on NVRAM runtime cleanup required for
brcmfmac stability. Other observations (sysupgrade behavior, LuCI backup
format, flashing workflows) are out of scope and will be handled separately.

