### PR TITLE
imagebuilder: skip repository file when standalone

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -98,7 +98,7 @@ OPKG:=$(call opkg,$(TARGET_DIR)) \
 
 export APK_KEYS:=$(TOPDIR)/keys
 APK:=$(call apk,$(TARGET_DIR)) \
-	--repositories-file $(TOPDIR)/repositories \
+	$(if $(CONFIG_IB_STANDALONE),,--repositories-file $(TOPDIR)/repositories) \
 	--repository $(PACKAGE_DIR)/packages.adb \
 	$(if $(CONFIG_SIGNATURE_CHECK),,--allow-untrusted) \
 	--cache-dir $(DL_DIR)


### PR DESCRIPTION
Standalone image builder doesn't have a repositories file as all packages are included, which causes:
    
```
ERROR: failed to read repositories: PATH_TO_BUILDER/repositories: No such file or directory
```    

The images are still built, so this is more of an informational error.
    
Pass related argument to apk only when `CONFIG_IB_STANDALONE` is not set.
    
Fixes: a8d17c21 ("imagebuilder: actually support IB from buildbot")

cc: @Ansuel, @efahl, @robimarko