### PR TITLE
imagebuilder: fix parsing ABI for apk packages

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -157,7 +157,7 @@ endif
 #
 # 1: package name
 define GetABISuffix
-$(shell $(APK) query --fields tags --match provides $(1) | grep openwrt:abiversion | awk -F= '{print $$2; exit}')
+$(shell $(APK) query --fields tags --match provides $(1) | tr ' ' '\n' | grep '^openwrt:abiversion=' | cut -d= -f2)
 endef
 
 # Format packages by adding an ABI version suffix if found


### PR DESCRIPTION
Fix parsing ABI when package has multiple tags and apk returns them in a single line.

Fixes: 31cdd13d ("imagebuilder: add ABI suffix to packages when using apk")

cc: @efahl, @feckert, @robimarko 
