### PR TITLE
dnsmasq: fix dnsmasq failure on non-existent leasefile directory

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1101,6 +1101,8 @@ dnsmasq_start()
 	fi
 
 	config_get leasefile $cfg leasefile "/tmp/dhcp.leases"
+	local leasefiledir="$(dirname $leasefile)"
+	[ ! -e "$leasefiledir" ] && mkdir -p "$leasefiledir" && chown dnsmasq:dnsmasq "$leasefiledir"
 	[ -n "$leasefile" ] && [ ! -e "$leasefile" ] && touch "$leasefile"
 	config_get_bool cachelocal "$cfg" cachelocal 1
 


### PR DESCRIPTION
Instead of failing to start if the leasefile directory does not exist, create the leasefile directory in the init script and assign the appropriate ownership to it. The leasefile location is specified in the 'leasefile' parameter is /etc/config/dhcp.

This patch fixes #21659.
