### PR TITLE
build: purge DESCRIPTION

### DIFF
--- a/include/kernel.mk
+++ b/include/kernel.mk
@@ -212,7 +212,6 @@ define KernelPackage
     TITLE:=$(TITLE)
     SECTION:=kernel
     CATEGORY:=Kernel modules
-    DESCRIPTION:=$(DESCRIPTION)
     EXTRA_DEPENDS:=kernel (=$(subst -rc,_rc,$(LINUX_VERSION))~$(LINUX_VERMAGIC)-r$(LINUX_RELEASE))
     VERSION:=$(subst -rc,_rc,$(LINUX_VERSION))$(if $(PKG_VERSION),.$(PKG_VERSION))-r$(if $(PKG_RELEASE),$(PKG_RELEASE),$(LINUX_RELEASE))
     PKGFLAGS:=$(PKGFLAGS)

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -435,7 +435,7 @@ Installed-Size: 0
 $(_endef)
 
     $$(PACK_$(1)) : export CONTROL=$$(Package/$(1)/CONTROL)
-    $$(PACK_$(1)) : export DESCRIPTION=$$(Package/$(1)/description)
+    $$(PACK_$(1)) : $(call shexport,Package/$(1)/description)
     $$(PACK_$(1)) : export PATH=$$(TARGET_PATH_PKG)
     $$(PACK_$(1)) : export PKG_SOURCE_DATE_EPOCH:=$(PKG_SOURCE_DATE_EPOCH)
     $$(PACK_$(1)) : export SOURCE_DATE_EPOCH:=$(PKG_SOURCE_DATE_EPOCH)
@@ -493,7 +493,7 @@ ifeq ($(CONFIG_USE_APK),)
 	(cd $$(IDIR_$(1))/CONTROL; \
 		( \
 			echo "$$$$CONTROL"; \
-			printf "Description: "; echo "$$$$DESCRIPTION" | sed -e 's,^[[:space:]]*, ,g'; \
+			printf "Description: "; echo "$$$$$(call shvar,Package/$(1)/description)" | sed -e 's,^[[:space:]]*, ,g'; \
 		) > control; \
 		chmod 644 control; \
 		( \

--- a/include/package.mk
+++ b/include/package.mk
@@ -339,10 +339,6 @@ define BuildPackage
   # default, so wget-ssl can explicitly provide @wget-any as well.
   $(eval PROVIDES:=$(strip @$(1)-any $(PROVIDES)))
 
-ifdef DESCRIPTION
-$$(error DESCRIPTION:= is obsolete, use Package/PKG_NAME/description)
-endif
-
 ifndef Package/$(1)/description
 define Package/$(1)/description
 	$(TITLE)

--- a/include/target.mk
+++ b/include/target.mk
@@ -359,7 +359,7 @@ endif
 
 define BuildTargets/DumpCurrent
   .PHONY: dumpinfo
-  dumpinfo : export DESCRIPTION=$$(Target/Description)
+  dumpinfo: $(call shexport,Target/Description)
   dumpinfo:
 	@echo 'Target: $(TARGETID)'; \
 	 echo 'Target-Board: $(BOARD)'; \
@@ -376,7 +376,7 @@ define BuildTargets/DumpCurrent
 	 echo 'Linux-Kernel-Arch: $(LINUX_KARCH)'; \
 	$(if $(SUBTARGET),,$(if $(DEFAULT_SUBTARGET), echo 'Default-Subtarget: $(DEFAULT_SUBTARGET)'; )) \
 	 echo 'Target-Description:'; \
-	 echo "$$$$DESCRIPTION"; \
+	 echo "$$$$$(call shvar,Target/Description);"; \
 	 echo '@@'; \
 	 $(if $(DEFAULT_PROFILE),echo 'Target-Default-Profile: $(DEFAULT_PROFILE)';) \
 	 echo 'Default-Packages: $(DEFAULT_PACKAGES)'; \


### PR DESCRIPTION
`DESCRIPTION` field has been deprecated since 2007, yet internal exporting causes intermittent package build failures due to the deprecation check, even with packages that don't have that fields set. Replace all `DESCRIPTION` exports with alternative variables defined through `shexport` and `shvar` helpers and remove the check.

Fixes: 547b127d ("make kernel module packaging code reusable and use it in madwifi")
Fixes: 7558f028 ("DESCRIPTION:= is obselete, so complain if it is used and use TITLE if no description is set")
Fixes: cc435322 ("build: optimize target metadata dump")
Fixes: d081edf7 ("build: clean up and optimize ipkg control generator code")

Tested:
- main `make world` with liburing
  apk packages, including kmods, and targets in `.targetinfo` all have correct descriptions
- 24.10.5 SDK liburing
  Control in opkg package has correct description

Related:
- https://github.com/openwrt/packages/issues/28414

cc: @systemcrash, @efahl, @robimarko 