### PR TITLE
cron: clarify procd-managed crond behaviorcron: clarify procd-managed crond behavior

### DIFF
--- a/package/utils/busybox/files/cron
+++ b/package/utils/busybox/files/cron
@@ -1,5 +1,6 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2006-2011 OpenWrt.org
+# BusyBox crond init script (procd managed)
 
 START=50
 
@@ -12,6 +13,9 @@ validate_cron_section() {
 }
 
 start_service() {
+        # crond is only started when at least one crontab exists.
+        # BusyBox expects crontabs in /etc/crontabs/<user> and will ignore
+        # entries whose <user> does not exist.
 	[ -z "$(ls /etc/crontabs/)" ] && return 1
 
 	loglevel="$(uci_get "system.@system[0].cronloglevel")"
@@ -29,6 +33,11 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param command "$PROG" -f -c /etc/crontabs -l "${loglevel:-7}"
+        # Track crontab files so procd can restart/recreate the instance when
+        # watched files or instance parameters (e.g. cronloglevel) change.t add package/utils/busybox/files/cron
+	git commit --amend -s
+	git push -f origin cron-doc-v2
+
 	for crontab in /etc/crontabs/*; do
 		 procd_set_param file "$crontab"
 	done


### PR DESCRIPTION
Add comments to the BusyBox crond init script to clarify how it is managed by procd.

Document that:
- crond is only started when /etc/crontabs is non-empty
- BusyBox expects crontabs in /etc/crontabs/<user> and ignores unknown users
- procd tracks crontab files and may restart/recreate the instance when needed,
  e.g. to apply changes to command line arguments such as cronloglevel
