### PR TITLE
uboot-tools + tools/mkimage: update to version 2026.01

### DIFF
--- a/package/boot/uboot-tools/Makefile
+++ b/package/boot/uboot-tools/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_DISTNAME:=u-boot
-PKG_VERSION:=2025.10
+PKG_VERSION:=2026.01
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_DISTNAME)-$(PKG_VERSION).tar.bz2
@@ -10,7 +10,7 @@ PKG_SOURCE_URL:= \
 	https://mirror.cyberbits.eu/u-boot \
 	ftp://ftp.denx.de/pub/u-boot
 PKG_URL:=https://docs.u-boot.org/en/latest/
-PKG_HASH:=b4f032848e56cc8f213ad59f9132c084dbbb632bc29176d024e58220e0efdf4a
+PKG_HASH:=b60d5865cefdbc75da8da4156c56c458e00de75a49b80c1a2e58a96e30ad0d54
 PKG_SOURCE_SUBDIR:=$(PKG_DISTNAME)-$(PKG_VERSION)
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_DISTNAME)-$(PKG_VERSION)
 

--- a/package/boot/uboot-tools/patches/003-tools-dumpimage-fix-tools-compile.patch
+++ b/package/boot/uboot-tools/patches/003-tools-dumpimage-fix-tools-compile.patch
@@ -10,8 +10,6 @@ This patch is to fix compilation for uboot-tool V2025.01 in openwrt.
 
 * remove mkeficapsule from build to avoid gnulib dependencies
 
-* disable bmp_logo from build to allow compilation
-
 Signed-off-by: Scott Mercer <TheRootEd24@gmail.com>
 ---
  tools/Makefile | 38 ++++++++++++++++++++++++++------------
@@ -66,7 +64,7 @@ Signed-off-by: Scott Mercer <TheRootEd24@gmail.com>
  
  mkfwumdata-objs := mkfwumdata.o generated/lib/crc32.o
  HOSTLDLIBS_mkfwumdata += -luuid
-@@ -330,10 +345,9 @@ HOST_EXTRACFLAGS += -include $(srctree)/
+@@ -330,8 +345,7 @@ HOST_EXTRACFLAGS += -include $(srctree)/
  		-I$(srctree)/scripts/dtc/libfdt \
  		-I$(srctree)/tools \
  		-DUSE_HOSTCC \
@@ -74,8 +72,5 @@ Signed-off-by: Scott Mercer <TheRootEd24@gmail.com>
 -		-D_GNU_SOURCE
 +		-D__KERNEL_STRICT_NAMES
  
--__build:	$(LOGO-y)
-+__build:	$(LOGO-n)
- 
- $(LOGO_H):	$(obj)/bmp_logo $(LOGO_BMP)
- 	$(obj)/bmp_logo --gen-info $(LOGO_BMP) > $@
+ ifeq ($(CROSS_BUILD_TOOLS),)
+ __build:	$(LOGO-y)

--- a/tools/mkimage/Makefile
+++ b/tools/mkimage/Makefile
@@ -7,14 +7,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mkimage
-PKG_VERSION:=2025.10
+PKG_VERSION:=2026.01
 
 PKG_SOURCE:=u-boot-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
 	https://mirror.cyberbits.eu/u-boot \
 	https://ftp.denx.de/pub/u-boot \
 	ftp://ftp.denx.de/pub/u-boot
-PKG_HASH:=b4f032848e56cc8f213ad59f9132c084dbbb632bc29176d024e58220e0efdf4a
+PKG_HASH:=b60d5865cefdbc75da8da4156c56c458e00de75a49b80c1a2e58a96e30ad0d54
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/u-boot-$(PKG_VERSION)
 

--- a/tools/mkimage/patches/030-allow-to-use-different-magic.patch
+++ b/tools/mkimage/patches/030-allow-to-use-different-magic.patch
@@ -24,16 +24,16 @@ This patch makes it possible to set a custom image magic.
  		"          -a ==> set load address to 'addr' (hex)\n"
  		"          -e ==> set entry point to 'ep' (hex)\n"
  		"          -n ==> set image name to 'name'\n"
-@@ -160,7 +162,7 @@ static int add_content(int type, const c
+@@ -162,7 +164,7 @@ static int add_content(int type, const c
  }
  
  static const char optstring[] =
--	"a:A:b:B:c:C:d:D:e:Ef:Fg:G:i:k:K:ln:N:o:O:p:qrR:stT:vVx";
-+	"a:A:b:B:c:C:d:D:e:Ef:Fg:G:i:k:K:lM:n:N:o:O:p:qrR:stT:vVx";
+-	"a:A:b:B:c:C:d:D:e:Ef:Fg:G:i:k:K:ln:N:o:O:p:qrR:stT:vVxy:Y:";
++	"a:A:b:B:c:C:d:D:e:Ef:Fg:G:i:k:K:lM:n:N:o:O:p:qrR:stT:vVxy:Y:";
  
  static const struct option longopts[] = {
  	{ "load-address", required_argument, NULL, 'a' },
-@@ -304,6 +306,14 @@ static void process_args(int argc, char
+@@ -308,6 +310,14 @@ static void process_args(int argc, char
  		case 'l':
  			params.lflag = 1;
  			break;


### PR DESCRIPTION
Update both host and target package to the latest stable version.

**uboot-tools**

Patches manually refreshed:
* 003-tools-dumpimage-fix-tools-compile.patch

Logo generation is now guarded for cross-compile targets[^1], so we can drop this change.

**mkimage**

Patches manually refreshed:
* 030-allow-to-use-different-magic.patch

Flags `y` and `Y` were introduced upstream[^2]. Trivially merge our `m`  and update some line numbers.

Build and run tested on x86/64 host for _mvebu/cortexa9_ (Turris Omnia)

[^1]: https://github.com/u-boot/u-boot/commit/371a76e845504c9ba7ca216b6edfb4ae4ec14e56
[^2]: https://github.com/u-boot/u-boot/commit/e560735558e313be8e883f9efcf729997df8b30e