### PR TITLE
gemini: support upgrade on reference designs

### DIFF
--- a/target/linux/gemini/base-files/lib/upgrade/platform.sh
+++ b/target/linux/gemini/base-files/lib/upgrade/platform.sh
@@ -1,10 +1,81 @@
 REQUIRE_IMAGE_METADATA=1
+MTDSYSFS=/sys/class/mtd
+
+gemini_do_platform_upgrade() {
+	ESZ=`cat ${MTDSYSFS}/mtd1/erasesize`
+	if test ${ESZ} == 131072 ; then
+		echo "MTD1 has 128kb EB size..."
+	else
+		echo "MTD1 has wrong EB size!"
+	fi
+	NAME=`cat ${MTDSYSFS}/mtd1/name`
+	SZ=`cat ${MTDSYSFS}/mtd1/size`
+	KSZ=$(($ESZ * $2))
+	if test "x${NAME}" == "xKern" ; then
+		if test ${SZ} == ${KSZ} ; then
+			echo "MTD1 OK..."
+		else
+			echo "MTD1 is wrong size, aborting" >&2
+			exit 1
+		fi
+	else
+		echo "MTD1 has wrong name, aborting" >&2
+		exit 1
+	fi
+	NAME=`cat ${MTDSYSFS}/mtd2/name`
+	SZ=`cat ${MTDSYSFS}/mtd2/size`
+	RSZ=$(($ESZ * $3))
+	if test "x${NAME}" == "xRamdisk" ; then
+		if test ${SZ} == ${RSZ} ; then
+			echo "MTD2 OK..."
+		else
+			echo "MTD2 is wrong size, aborting" >&2
+			exit 1
+		fi
+	else
+		echo "MTD2 has wrong name, aborting" >&2
+		exit 1
+	fi
+	NAME=`cat ${MTDSYSFS}/mtd3/name`
+	SZ=`cat ${MTDSYSFS}/mtd3/size`
+	ASZ=$(($ESZ * $4))
+	if test "x${NAME}" == "xApplication" ; then
+		if test ${SZ} == ${ASZ} ; then
+			echo "MTD3 OK..."
+		else
+			echo "MTD3 is wrong size, aborting" >&2
+			exit 1
+		fi
+	else
+		echo "MTD3 has wrong name, aborting" >&2
+		exit 1
+	fi
+	echo "Extract the three firmware parts"
+	tar xvfz "$1"; rm "$1"
+	sync
+	echo 3 > /proc/sys/vm/drop_caches
+	echo "COMMENCING UPGRADE. BE PATIENT, THIS IS NOT FAST!"
+	echo "Upgrade Kern partition (kernel part 1, $2 erase blocks)"
+	mtd write zImage Kern
+	[ $? -ne 0 ] && exit 1
+	echo "Upgrade Ramdisk partition (kernel part 2, $3 erase blocks)"
+	mtd write rd.gz Ramdisk
+	[ $? -ne 0 ] && exit 1
+	echo "Upgrade Application partition (rootfs, $4 erase blocks)"
+	mtd write hddapp.tgz Application
+	[ $? -ne 0 ] && exit 1
+}
 
 platform_check_image() {
 	local board=$(board_name)
 
 	case "$board" in
 	dlink,dir-685)
+		return 0
+		;;
+	raidsonic,ib-4220-b|\
+	itian,sq201|\
+	storlink,gemini324)
 		return 0
 		;;
 	esac
@@ -20,6 +91,13 @@ platform_do_upgrade() {
 	dlink,dir-685)
 		PART_NAME=firmware
 		default_do_upgrade "$1"
+		;;
+	itian,sq201|\
+	storlink,gemini324)
+		gemini_do_platform_upgrade "$1" 16 48 48
+		;;
+	raidsonic,ib-4220-b)
+		gemini_do_platform_upgrade "$1" 24 48 48
 		;;
 	esac
 }

--- a/target/linux/gemini/image/Makefile
+++ b/target/linux/gemini/image/Makefile
@@ -89,18 +89,19 @@ endef
 # 0x000000320000-0x000000920000 : "Ramdisk" - second part of the kernel and
 #                                 some padding goes here
 # 0x000000920000-0x000000f20000 : "Application" - rootfs goes here
-define Build/storlink-default-images
+define CreateStorlinkTarfile
 	mkdir -p $@.tmp
 
-	# "App" partition is the rootfs
+	# "Application" partition is the rootfs
 	mv $@ $@.tmp/hddapp.tgz
 	# 256 bytes copy routine
+	# TODO fix for IB-4220-B
 	dd if=$(KDIR)/copy-kernel.bin of=$@.tmp/zImage
 	$(call Image/pad-to,$@.tmp/zImage,512)
 	# Copy first part of the kernel into zImage
-	dd if=$(IMAGE_KERNEL) of=$@.tmp/zImage bs=1 seek=512 count=2096640
+	dd if=$(IMAGE_KERNEL) of=$@.tmp/zImage bs=1 seek=512 count=$(2)
 	# Put the rest of the kernel into the "ramdisk"
-	dd if=$(IMAGE_KERNEL) of=$@.tmp/rd.gz bs=1 skip=2096640 count=6144k conv=sync
+	dd if=$(IMAGE_KERNEL) of=$@.tmp/rd.gz bs=1 skip=$(2) count=6144k conv=sync
 	cp ./ImageInfo-$(1) $@.tmp/ImageInfo
 
 	sed -i -e "s/DATESTR/`date +%Y%m%d $(if $(SOURCE_DATE_EPOCH),--date "@$(SOURCE_DATE_EPOCH)")`/g" $@.tmp/ImageInfo
@@ -109,6 +110,17 @@ define Build/storlink-default-images
 		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)"))
 
 	rm -rf $@.tmp
+	exit 0
+endef
+
+# 2048k "Kern" partition
+define Build/storlink-default-image
+	$(call CreateStorlinkTarfile,$(1),2096640)
+endef
+
+# 3032k "Kern" partition
+define Build/raidsonic-ib-4220-b-image
+	$(call CreateStorlinkTarfile,$(1),3145216)
 endef
 
 # WBD-111 and WBD-222:
@@ -182,10 +194,17 @@ TARGET_DEVICES += dlink_dns-313
 define Device/storlink-reference
 	COMPILE := copy-kernel-$(1).bin
 	COMPILE/copy-kernel-$(1).bin := copy-kernel.bin
-	IMAGES := factory.bin
+	IMAGES := factory.bin sysupgrade.bin
 	FILESYSTEMS := squashfs
+	# Flash layout:
+	# Kern         512 bytes copy-kernel
+        #              2096640 bytes zImage
+	# Ramdisk      6144k remaining zImage
+	# Application  6144k
 	IMAGE/factory.bin := append-rootfs | pad-rootfs | pad-to 6144k | \
-		storlink-default-images $(1)
+		storlink-default-image $(1)
+	IMAGE/sysupgrade.bin := append-rootfs | pad-rootfs | pad-to 6144k | \
+		storlink-default-image $(1) | append-metadata
 	DEVICE_PACKAGES := $(GEMINI_NAS_PACKAGES)
 endef
 
@@ -203,6 +222,14 @@ define Device/raidsonic_ib-4220-b
 	DEVICE_VENDOR := Raidsonic
 	DEVICE_MODEL := NAS IB-4220-B
 	DEVICE_DTS := gemini-nas4220b
+	# The IB-4220-B has a deviating flash layout
+	# Kern         3072k - 512 | = 3145216
+	# Ramdisk      6144k       | = 9216k
+	# Application  6144k       | = 15360k
+	IMAGE/factory.bin := append-rootfs | pad-rootfs | pad-to 6144k | \
+		raidsonic-ib-4220-b-image $(1)
+	IMAGE/factory.bin := append-rootfs | pad-rootfs | pad-to 6144k | \
+		raidsonic-ib-4220-b-image $(1) | append-metadata
 endef
 TARGET_DEVICES += raidsonic_ib-4220-b
 


### PR DESCRIPTION
The Gemini reference design-derived devices uses a partition format which is predictable and we can exploit this to offer some proper upgrade path.

The kernel for these contains a hack to use this partition format unaltered by combining the partitions "Kern" and "Ramdisk" to one image with all of the kernel+ramdisk in memory.

Then the "Application" which is used for the rootfs go into its own partition.

Standard flash layout:
Kern         2048k |
Ramdisk      6144k | = 9216k
Application  6144k | = 15360k

Following the pattern of the factory image we create three images named zImage, rd.gz and hddapp.tgz (these filenames are misleading! They are just required by the old firmware.) and flash each individually with "mtd" during upgrades.

Since the IB-4220-V has a different layout with a bigger kernel space we parameterize this so we can handle this too. (More fixes are needed for that device though.)

A way to upgrade older OpenWrt on these platforms to the latest and greatest will be to copy the file
target/linux/gemini/base-files/lib/upgrade/platform.sh to /lib/upgrade/platform.sh
on your running system and then run sysupgrade from the image produced after this patch.

The script is picky to sanity check the partitions before commencing upgrade.

This was tested with a full sysupgrade on the iTian SQ201.