### PR TITLE
realtek: dsa: remove half-cooked SoC version determination

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -1419,7 +1419,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->r = &rtl838x_reg;
 		priv->ds->num_ports = 29;
 		priv->fib_entries = 8192;
-		rtl8380_get_version(priv);
 		priv->ds->num_lag_ids = 8;
 		priv->l2_bucket_size = 4;
 		priv->n_mst = 64;
@@ -1436,7 +1435,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->r = &rtl839x_reg;
 		priv->ds->num_ports = 53;
 		priv->fib_entries = 16384;
-		rtl8390_get_version(priv);
 		priv->ds->num_lag_ids = 16;
 		priv->l2_bucket_size = 4;
 		priv->n_mst = 256;
@@ -1453,10 +1451,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->r = &rtl930x_reg;
 		priv->ds->num_ports = 29;
 		priv->fib_entries = 16384;
-		/* TODO A version based on CHIP_INFO and MODEL_NAME_INFO should
-		 * be constructed. For now, just set it to a static 'A'
-		 */
-		priv->version = RTL8390_VERSION_A;
 		priv->ds->num_lag_ids = 16;
 		sw_w32(0, RTL930X_ST_CTRL);
 		priv->l2_bucket_size = 8;
@@ -1474,10 +1468,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->r = &rtl931x_reg;
 		priv->ds->num_ports = 57;
 		priv->fib_entries = 16384;
-		/* TODO A version based on CHIP_INFO and MODEL_NAME_INFO should
-		 * be constructed. For now, just set it to a static 'A'
-		 */
-		priv->version = RTL8390_VERSION_A;
 		priv->ds->num_lag_ids = 16;
 		sw_w32(0, RTL931x_ST_CTRL);
 		priv->l2_bucket_size = 8;
@@ -1487,7 +1477,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->n_counters = 2048;
 		break;
 	}
-	pr_debug("Chip version %c\n", priv->version);
 
 	err = rtl83xx_mdio_probe(priv);
 	if (err) {

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1775,33 +1775,6 @@ irqreturn_t rtl838x_switch_irq(int irq, void *dev_id)
 	return IRQ_HANDLED;
 }
 
-void rtl8380_get_version(struct rtl838x_switch_priv *priv)
-{
-	u32 rw_save, info_save;
-	u32 info;
-
-	rw_save = sw_r32(RTL838X_INT_RW_CTRL);
-	sw_w32(rw_save | 0x3, RTL838X_INT_RW_CTRL);
-
-	info_save = sw_r32(RTL838X_CHIP_INFO);
-	sw_w32(info_save | 0xA0000000, RTL838X_CHIP_INFO);
-
-	info = sw_r32(RTL838X_CHIP_INFO);
-	sw_w32(info_save, RTL838X_CHIP_INFO);
-	sw_w32(rw_save, RTL838X_INT_RW_CTRL);
-
-	if ((info & 0xFFFF) == 0x6275) {
-		if (((info >> 16) & 0x1F) == 0x1)
-			priv->version = RTL8380_VERSION_A;
-		else if (((info >> 16) & 0x1F) == 0x2)
-			priv->version = RTL8380_VERSION_B;
-		else
-			priv->version = RTL8380_VERSION_B;
-	} else {
-		priv->version = '-';
-	}
-}
-
 void rtl838x_vlan_profile_dump(int profile)
 {
 	u32 p;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1285,7 +1285,6 @@ struct rtl838x_switch_priv {
 	struct device *dev;
 	u16 id;
 	u16 family_id;
-	char version;
 	struct rtl838x_port ports[57];
 	struct phylink_pcs *pcs[57];
 	struct mutex reg_mutex;		/* Mutex for individual register manipulations */

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -624,19 +624,6 @@ irqreturn_t rtl839x_switch_irq(int irq, void *dev_id)
 	return IRQ_HANDLED;
 }
 
-void rtl8390_get_version(struct rtl838x_switch_priv *priv)
-{
-	u32 info, model;
-
-	sw_w32_mask(0xf << 28, 0xa << 28, RTL839X_CHIP_INFO);
-	info = sw_r32(RTL839X_CHIP_INFO);
-
-	model = sw_r32(RTL839X_MODEL_NAME_INFO);
-	priv->version = RTL8390_VERSION_A + ((model & 0x3f) >> 1);
-
-	pr_debug("RTL839X Chip-Info: %x, version %c\n", info, priv->version);
-}
-
 void rtl839x_vlan_profile_dump(int profile)
 {
 	u32 p[2];

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -6,10 +6,6 @@
 #include <net/dsa.h>
 #include "rtl838x.h"
 
-#define RTL8380_VERSION_A 'A'
-#define RTL8390_VERSION_A 'A'
-#define RTL8380_VERSION_B 'B'
-
 struct fdb_update_work {
 	struct work_struct work;
 	struct net_device *ndev;
@@ -161,14 +157,12 @@ int rtl838x_set_egress_rate(struct rtl838x_switch_priv *priv, int port, u32 rate
 /* RTL838x-specific */
 u32 rtl838x_hash(struct rtl838x_switch_priv *priv, u64 seed);
 irqreturn_t rtl838x_switch_irq(int irq, void *dev_id);
-void rtl8380_get_version(struct rtl838x_switch_priv *priv);
 void rtl838x_vlan_profile_dump(int index);
 void rtl838x_print_matrix(void);
 
 /* RTL839x-specific */
 u32 rtl839x_hash(struct rtl838x_switch_priv *priv, u64 seed);
 irqreturn_t rtl839x_switch_irq(int irq, void *dev_id);
-void rtl8390_get_version(struct rtl838x_switch_priv *priv);
 void rtl839x_vlan_profile_dump(int index);
 void rtl839x_exec_tbl2_cmd(u32 cmd);
 void rtl839x_print_matrix(void);


### PR DESCRIPTION
There are some code pieces that determine the SoC version of the running system. For RTL83xx it reads out the registers, for RTL93xx it simply uses a constant value. Without any consumer of this data drop it.
