### PR TITLE
airoha: an7581: add support for Nokia bell_xg-040g-md

### DIFF
--- a/target/linux/airoha/an7581/base-files/etc/board.d/02_network
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/02_network
@@ -14,6 +14,9 @@ an7581_setup_interfaces()
 	airoha,an7581-evb)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1"
 		;;
+	bell,xg-040g-md)
+		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "eth1"
+		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"
 		;;

--- a/target/linux/airoha/dts/an7581-bell_xg-040g-md.dts
+++ b/target/linux/airoha/dts/an7581-bell_xg-040g-md.dts
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include "an7581.dtsi"
+
+/ {
+	model = "Nokia Bell XG-040G-MD";
+	compatible = "bell,xg-040g-md", "airoha,an7581";
+
+	aliases {
+		serial0 = &uart1;
+	};
+
+	chosen {
+		bootargs = "ubi.mtd=ubi root=ubi0:rootfs rootfstype=squashfs ro rootwait console=ttyS0,115200 earlycon";
+		stdout-path = "serial0:115200n8";
+		linux,usable-memory-range = <0x0 0x80200000 0x0 0x1fe00000>;
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x0 0x80000000 0x0 0x80000000>;
+	};
+
+	efuse-banks {
+		compatible = "airoha,an7581-efuses";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		bank@0 {
+			reg = <0>;
+		};
+
+		bank@1 {
+			reg = <1>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pwr_led: led-0 {
+			label = "green:power";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&en7581_pinctrl 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "default-on";
+		};
+
+		pon_led: led-1 {
+			label = "green:pon";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 18 GPIO_ACTIVE_LOW>;
+		};
+
+		los_led: led-2 {
+			label = "red:los";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 19 GPIO_ACTIVE_LOW>;
+		};
+
+		internet_led: led-3 {
+			label = "green:internet";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 20 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&en7581_pinctrl 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&en7581_pinctrl {
+	gpio-ranges = <&en7581_pinctrl 0 13 47>;
+
+	mdio_pins: mdio-pins {
+		mux {
+			function = "mdio";
+			groups = "mdio";
+		};
+
+		conf {
+			pins = "gpio2";
+			output-high;
+		};
+	};
+
+	gswp2_led0_pins: gswp2-led0-pins {
+		mux {
+			pins = "gpio34";
+			function = "phy2_led0";
+		};
+	};
+
+	gswp3_led0_pins: gswp3-led0-pins {
+		mux {
+			pins = "gpio35";
+			function = "phy3_led0";
+		};
+	};
+
+	gswp4_led0_pins: gswp4-led0-pins {
+		mux {
+			pins = "gpio42";
+			function = "phy4_led0";
+		};
+	};
+};
+
+&snfi {
+	status = "okay";
+};
+
+&spi_nand {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootloader";
+			reg = <0x00000000 0x00080000>;
+		};
+
+		partition@80000 {
+			label = "env";
+			reg = <0x00080000 0x00080000>;
+		};
+
+		partition@100000 {
+			label = "ubi";
+			reg = <0x00100000 0x0ff00000>;
+		};
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+};
+
+&gdm1 {
+	status = "okay";
+};
+
+&gdm4 {
+	status = "okay";
+	phy-handle = <&phy15>;
+	phy-mode = "2500base-x";
+	label = "eth1";
+};
+
+&switch {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	ports {
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+
+	mdio {
+		ethernet-phy@a {
+			status = "okay";
+			pinctrl-names = "gbe-led";
+			pinctrl-0 = <&gswp2_led0_pins>;
+
+			leds {
+				led@0 {
+					status = "okay";
+					active-low;
+					function = LED_FUNCTION_LAN;
+					color = <LED_COLOR_ID_GREEN>;
+				};
+			};
+		};
+
+		ethernet-phy@b {
+			status = "okay";
+			pinctrl-names = "gbe-led";
+			pinctrl-0 = <&gswp3_led0_pins>;
+
+			leds {
+				led@0 {
+					status = "okay";
+					active-low;
+					function = LED_FUNCTION_LAN;
+					color = <LED_COLOR_ID_GREEN>;
+				};
+			};
+		};
+
+		ethernet-phy@c {
+			status = "okay";
+			pinctrl-names = "gbe-led";
+			pinctrl-0 = <&gswp4_led0_pins>;
+
+			leds {
+				led@0 {
+					status = "okay";
+					active-low;
+					function = LED_FUNCTION_LAN;
+					color = <LED_COLOR_ID_GREEN>;
+				};
+			};
+		};
+
+		phy15: ethernet-phy@f {
+			compatible = "ethernet-phy-id03a2.a411", "ethernet-phy-ieee802.3-c45";
+			reg = <15>;
+
+			reset-gpios = <&en7581_pinctrl 31 GPIO_ACTIVE_LOW>;
+			reset-assert-us = <10000>;
+			reset-deassert-us = <2000000>;
+
+			leds {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				led@0 {
+					reg = <0>;
+					function = LED_FUNCTION_LAN;
+					color = <LED_COLOR_ID_GREEN>;
+				};
+			};
+		};
+	};
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+	phys = <&usb1_phy PHY_TYPE_USB2>;
+	mediatek,u3p-dis-msk = <0x1>;
+};

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -42,3 +42,23 @@ define Device/airoha_an7581-evb-emmc
   ARTIFACTS := preloader.bin bl31-uboot.fip
 endef
 TARGET_DEVICES += airoha_an7581-evb-emmc
+
+define Device/bell_xg-040g-md
+  $(call Device/FitImageLzma)
+  DEVICE_VENDOR := Nokia
+  DEVICE_MODEL := Bell XG-040G-MD
+  DEVICE_DTS := an7581-bell_xg-040g-md
+  SOC := an7581
+  KERNEL_LOADADDR := 0x80088000
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 8192k
+  IMAGE_SIZE := 261120k
+  KERNEL_IN_UBI := 1
+  UBINIZE_OPTS := -s 2048
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-phy-airoha-en8811h kmod-i2c-an7581 kmod-leds-gpio kmod-gpio-button-hotplug uboot-envtools ubi-utils kmod-usb-storage-uas kmod-usb-net-cdc-ether kmod-fs-vfat kmod-fs-exfat kmod-fs-ext4 kmod-fs-ntfs3 blkid lsblk
+endef
+TARGET_DEVICES += bell_xg-040g-md

--- a/target/linux/generic/backport-6.12/902-01-v6.14-mtd-spinand-Introduce-a-way-to-avoid-raw-access.patch
+++ b/target/linux/generic/backport-6.12/902-01-v6.14-mtd-spinand-Introduce-a-way-to-avoid-raw-access.patch
@@ -1,0 +1,81 @@
+From 6d9d6ab3a82af50e36e13e7bc8e2d1b970e39f79 Mon Sep 17 00:00:00 2001
+From: Takahiro Kuwano <Takahiro.Kuwano@infineon.com>
+Date: Tue, 3 Dec 2024 11:46:49 +0900
+Subject: [PATCH 1/1] mtd: spinand: Introduce a way to avoid raw access
+
+SkyHigh spinand device has ECC enable bit in configuration register but
+it must be always enabled. If ECC is disabled, read and write ops
+results in undetermined state. For such devices, a way to avoid raw
+access is needed.
+
+Introduce SPINAND_NO_RAW_ACCESS flag to advertise the device does not
+support raw access. In such devices, the on-die ECC engine ops returns
+error to I/O request in raw mode.
+
+Checking and marking BBM need to be cared as special case, by adding
+fallback mechanism that tries read/write OOB with ECC enabled.
+
+Signed-off-by: Takahiro Kuwano <Takahiro.Kuwano@infineon.com>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+---
+ drivers/mtd/nand/spi/core.c | 22 ++++++++++++++++++++--
+ include/linux/mtd/spinand.h |  1 +
+ 2 files changed, 21 insertions(+), 2 deletions(-)
+
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -294,6 +294,9 @@ static int spinand_ondie_ecc_prepare_io_
+ 	struct spinand_device *spinand = nand_to_spinand(nand);
+ 	bool enable = (req->mode != MTD_OPS_RAW);
+ 
++	if (!enable && spinand->flags & SPINAND_NO_RAW_ACCESS)
++		return -EOPNOTSUPP;
++
+ 	memset(spinand->oobbuf, 0xff, nanddev_per_page_oobsize(nand));
+ 
+ 	/* Only enable or disable the engine */
+@@ -921,9 +924,17 @@ static bool spinand_isbad(struct nand_de
+ 		.oobbuf.in = marker,
+ 		.mode = MTD_OPS_RAW,
+ 	};
++	int ret;
+ 
+ 	spinand_select_target(spinand, pos->target);
+-	spinand_read_page(spinand, &req);
++
++	ret = spinand_read_page(spinand, &req);
++	if (ret == -EOPNOTSUPP) {
++		/* Retry with ECC in case raw access is not supported */
++		req.mode = MTD_OPS_PLACE_OOB;
++		spinand_read_page(spinand, &req);
++	}
++
+ 	if (marker[0] != 0xff || marker[1] != 0xff)
+ 		return true;
+ 
+@@ -966,7 +977,14 @@ static int spinand_markbad(struct nand_d
+ 	if (ret)
+ 		return ret;
+ 
+-	return spinand_write_page(spinand, &req);
++	ret = spinand_write_page(spinand, &req);
++	if (ret == -EOPNOTSUPP) {
++		/* Retry with ECC in case raw access is not supported */
++		req.mode = MTD_OPS_PLACE_OOB;
++		ret = spinand_write_page(spinand, &req);
++	}
++
++	return ret;
+ }
+ 
+ static int spinand_mtd_block_markbad(struct mtd_info *mtd, loff_t offs)
+--- a/include/linux/mtd/spinand.h
++++ b/include/linux/mtd/spinand.h
+@@ -316,6 +316,7 @@ struct spinand_ecc_info {
+ #define SPINAND_HAS_CR_FEAT_BIT		BIT(1)
+ #define SPINAND_HAS_PROG_PLANE_SELECT_BIT		BIT(2)
+ #define SPINAND_HAS_READ_PLANE_SELECT_BIT		BIT(3)
++#define SPINAND_NO_RAW_ACCESS				BIT(4)
+ 
+ /**
+  * struct spinand_ondie_ecc_conf - private SPI-NAND on-die ECC engine structure

--- a/target/linux/generic/backport-6.12/902-02-v6.14-mtd-spinand-Add-support-for-SkyHigh-S35ML-3-family.patch
+++ b/target/linux/generic/backport-6.12/902-02-v6.14-mtd-spinand-Add-support-for-SkyHigh-S35ML-3-family.patch
@@ -1,0 +1,201 @@
+From 1a50e3612de9187857f55ee14a573f7f8e7d4ebc Mon Sep 17 00:00:00 2001
+From: Takahiro Kuwano <Takahiro.Kuwano@infineon.com>
+Date: Tue, 3 Dec 2024 11:46:50 +0900
+Subject: [PATCH] mtd: spinand: Add support for SkyHigh S35ML-3 family
+
+SkyHigh S35ML01G300, S35ML01G301, S35ML02G300, and S35ML04G300 are 1Gb,
+2Gb, and 4Gb SLC SPI NAND flash family. This family of devices has
+on-die ECC which parity bits are stored to hidden area. In this family
+the on-die ECC cannot be disabled so raw access needs to be prevented.
+
+Link: https://www.skyhighmemory.com/download/SPI_S35ML01_04G3_002_19205.pdf?v=P
+Co-developed-by: KR Kim <kr.kim@skyhighmemory.com>
+Signed-off-by: KR Kim <kr.kim@skyhighmemory.com>
+Signed-off-by: Takahiro Kuwano <Takahiro.Kuwano@infineon.com>
+Signed-off-by: Miquel Raynal <miquel.raynal@bootlin.com>
+---
+ drivers/mtd/nand/spi/Makefile  |   2 +-
+ drivers/mtd/nand/spi/core.c    |   1 +
+ drivers/mtd/nand/spi/skyhigh.c | 147 +++++++++++++++++++++++++++++++++
+ include/linux/mtd/spinand.h    |   1 +
+ 4 files changed, 150 insertions(+), 1 deletion(-)
+ create mode 100644 drivers/mtd/nand/spi/skyhigh.c
+
+--- a/drivers/mtd/nand/spi/Makefile
++++ b/drivers/mtd/nand/spi/Makefile
+@@ -1,4 +1,4 @@
+ # SPDX-License-Identifier: GPL-2.0
+ spinand-objs := core.o alliancememory.o ato.o esmt.o fmsh.o foresee.o gigadevice.o macronix.o
+-spinand-objs += micron.o paragon.o toshiba.o winbond.o xtx.o
++spinand-objs += micron.o paragon.o skyhigh.o toshiba.o winbond.o xtx.o
+ obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -1184,6 +1184,7 @@ static const struct spinand_manufacturer
+ 	&macronix_spinand_manufacturer,
+ 	&micron_spinand_manufacturer,
+ 	&paragon_spinand_manufacturer,
++	&skyhigh_spinand_manufacturer,
+ 	&toshiba_spinand_manufacturer,
+ 	&winbond_spinand_manufacturer,
+ 	&xtx_spinand_manufacturer,
+--- /dev/null
++++ b/drivers/mtd/nand/spi/skyhigh.c
+@@ -0,0 +1,147 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) 2024 SkyHigh Memory Limited
++ *
++ * Author: Takahiro Kuwano <takahiro.kuwano@infineon.com>
++ * Co-Author: KR Kim <kr.kim@skyhighmemory.com>
++ */
++
++#include <linux/device.h>
++#include <linux/kernel.h>
++#include <linux/mtd/spinand.h>
++
++#define SPINAND_MFR_SKYHIGH			0x01
++#define SKYHIGH_STATUS_ECC_1TO2_BITFLIPS	(1 << 4)
++#define SKYHIGH_STATUS_ECC_3TO6_BITFLIPS	(2 << 4)
++#define SKYHIGH_STATUS_ECC_UNCOR_ERROR		(3 << 4)
++#define SKYHIGH_CONFIG_PROTECT_EN		BIT(1)
++
++static SPINAND_OP_VARIANTS(read_cache_variants,
++		SPINAND_PAGE_READ_FROM_CACHE_QUADIO_OP(0, 4, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_X4_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_DUALIO_OP(0, 2, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_X2_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(true, 0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(false, 0, 1, NULL, 0));
++
++static SPINAND_OP_VARIANTS(write_cache_variants,
++		SPINAND_PROG_LOAD_X4(true, 0, NULL, 0),
++		SPINAND_PROG_LOAD(true, 0, NULL, 0));
++
++static SPINAND_OP_VARIANTS(update_cache_variants,
++		SPINAND_PROG_LOAD_X4(false, 0, NULL, 0),
++		SPINAND_PROG_LOAD(false, 0, NULL, 0));
++
++static int skyhigh_spinand_ooblayout_ecc(struct mtd_info *mtd, int section,
++					 struct mtd_oob_region *region)
++{
++	/* ECC bytes are stored in hidden area. */
++	return -ERANGE;
++}
++
++static int skyhigh_spinand_ooblayout_free(struct mtd_info *mtd, int section,
++					  struct mtd_oob_region *region)
++{
++	if (section)
++		return -ERANGE;
++
++	/* ECC bytes are stored in hidden area. Reserve 2 bytes for the BBM. */
++	region->offset = 2;
++	region->length = mtd->oobsize - 2;
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops skyhigh_spinand_ooblayout = {
++	.ecc = skyhigh_spinand_ooblayout_ecc,
++	.free = skyhigh_spinand_ooblayout_free,
++};
++
++static int skyhigh_spinand_ecc_get_status(struct spinand_device *spinand,
++					  u8 status)
++{
++	switch (status & STATUS_ECC_MASK) {
++	case STATUS_ECC_NO_BITFLIPS:
++		return 0;
++
++	case SKYHIGH_STATUS_ECC_UNCOR_ERROR:
++		return -EBADMSG;
++
++	case SKYHIGH_STATUS_ECC_1TO2_BITFLIPS:
++		return 2;
++
++	case SKYHIGH_STATUS_ECC_3TO6_BITFLIPS:
++		return 6;
++
++	default:
++		break;
++	}
++
++	return -EINVAL;
++}
++
++static const struct spinand_info skyhigh_spinand_table[] = {
++	SPINAND_INFO("S35ML01G301",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x15),
++		     NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(6, 32),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_NO_RAW_ACCESS,
++		     SPINAND_ECCINFO(&skyhigh_spinand_ooblayout,
++				     skyhigh_spinand_ecc_get_status)),
++	SPINAND_INFO("S35ML01G300",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x14),
++		     NAND_MEMORG(1, 2048, 128, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(6, 32),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_NO_RAW_ACCESS,
++		     SPINAND_ECCINFO(&skyhigh_spinand_ooblayout,
++				     skyhigh_spinand_ecc_get_status)),
++	SPINAND_INFO("S35ML02G300",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x25),
++		     NAND_MEMORG(1, 2048, 128, 64, 2048, 40, 2, 1, 1),
++		     NAND_ECCREQ(6, 32),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_NO_RAW_ACCESS,
++		     SPINAND_ECCINFO(&skyhigh_spinand_ooblayout,
++				     skyhigh_spinand_ecc_get_status)),
++	SPINAND_INFO("S35ML04G300",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x35),
++		     NAND_MEMORG(1, 2048, 128, 64, 4096, 80, 2, 1, 1),
++		     NAND_ECCREQ(6, 32),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_NO_RAW_ACCESS,
++		     SPINAND_ECCINFO(&skyhigh_spinand_ooblayout,
++				     skyhigh_spinand_ecc_get_status)),
++};
++
++static int skyhigh_spinand_init(struct spinand_device *spinand)
++{
++	/*
++	 * Config_Protect_En (bit 1 in Block Lock register) must be set to 1
++	 * before writing other bits. Do it here before core unlocks all blocks
++	 * by writing block protection bits.
++	 */
++	return spinand_write_reg_op(spinand, REG_BLOCK_LOCK,
++				    SKYHIGH_CONFIG_PROTECT_EN);
++}
++
++static const struct spinand_manufacturer_ops skyhigh_spinand_manuf_ops = {
++	.init = skyhigh_spinand_init,
++};
++
++const struct spinand_manufacturer skyhigh_spinand_manufacturer = {
++	.id = SPINAND_MFR_SKYHIGH,
++	.name = "SkyHigh",
++	.chips = skyhigh_spinand_table,
++	.nchips = ARRAY_SIZE(skyhigh_spinand_table),
++	.ops = &skyhigh_spinand_manuf_ops,
++};
+--- a/include/linux/mtd/spinand.h
++++ b/include/linux/mtd/spinand.h
+@@ -270,6 +270,7 @@ extern const struct spinand_manufacturer
+ extern const struct spinand_manufacturer macronix_spinand_manufacturer;
+ extern const struct spinand_manufacturer micron_spinand_manufacturer;
+ extern const struct spinand_manufacturer paragon_spinand_manufacturer;
++extern const struct spinand_manufacturer skyhigh_spinand_manufacturer;
+ extern const struct spinand_manufacturer toshiba_spinand_manufacturer;
+ extern const struct spinand_manufacturer winbond_spinand_manufacturer;
+ extern const struct spinand_manufacturer xtx_spinand_manufacturer;

--- a/target/linux/generic/pending-6.12/487-mtd-spinand-Add-support-for-Etron-EM73D044VCx.patch
+++ b/target/linux/generic/pending-6.12/487-mtd-spinand-Add-support-for-Etron-EM73D044VCx.patch
@@ -43,13 +43,13 @@ Submitted-by: Daniel Danzberger <daniel@dd-wrt.com>
 @@ -1,4 +1,4 @@
  # SPDX-License-Identifier: GPL-2.0
 -spinand-objs := core.o alliancememory.o ato.o esmt.o fmsh.o foresee.o gigadevice.o macronix.o
--spinand-objs += micron.o paragon.o toshiba.o winbond.o xtx.o
+-spinand-objs += micron.o paragon.o skyhigh.o toshiba.o winbond.o xtx.o
 +spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fmsh.o foresee.o gigadevice.o
-+spinand-objs += macronix.o micron.o paragon.o toshiba.o winbond.o xtx.o
++spinand-objs += macronix.o micron.o paragon.o skyhigh.o toshiba.o winbond.o xtx.o
  obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1160,6 +1160,7 @@ static const struct spinand_manufacturer
+@@ -1178,6 +1178,7 @@ static const struct spinand_manufacturer
  	&ato_spinand_manufacturer,
  	&esmt_8c_spinand_manufacturer,
  	&esmt_c8_spinand_manufacturer,

--- a/target/linux/mediatek/patches-6.12/121-hack-spi-nand-1b-bbm.patch
+++ b/target/linux/mediatek/patches-6.12/121-hack-spi-nand-1b-bbm.patch
@@ -1,6 +1,6 @@
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -913,7 +913,7 @@ static int spinand_mtd_write(struct mtd_
+@@ -910,10 +910,10 @@ static int spinand_mtd_write(struct mtd_
  static bool spinand_isbad(struct nand_device *nand, const struct nand_pos *pos)
  {
  	struct spinand_device *spinand = nand_to_spinand(nand);
@@ -9,7 +9,7 @@
  	struct nand_page_io_req req = {
  		.pos = *pos,
  		.ooblen = sizeof(marker),
-@@ -924,7 +924,7 @@ static bool spinand_isbad(struct nand_de
+@@ -921,10 +921,10 @@ static bool spinand_isbad(struct nand_de
  
  	spinand_select_target(spinand, pos->target);
  	spinand_read_page(spinand, &req);


### PR DESCRIPTION
airoha: add support for Nokia Bell XG-040G-MD

This adds support for the Nokia Bell XG-040G-MD ONT device.

Hardware specification:
- SoC: Airoha AN7581
- RAM: 512MB DDR4 (Jinhua CA4S4G16V-F9HPC)
- Flash: 256MB SPI NAND (SkyHigh S35ML02G300)
- Ethernet:
  - 1x 2.5GbE port (EcoNet EN8811H PHY) labeled as LAN1
  - 3x 1GbE ports (internal AN7581 switch) labeled as LAN2, LAN3, LAN4
- PON: EcoNet EN7572AN
- USB: 1x USB 2.0, 1x USB 3.0
- LEDs: 4x GPIO-controlled (power, PON, LOS, internet)
- Buttons: 1x reset button