### PR TITLE
realtek: dsa: rtl83xx: fix init section mismatch

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -1559,7 +1559,8 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 
 	rtl83xx_get_l2aging(priv);
 
-	rtl83xx_setup_qos(priv);
+	if (priv->r->qos_init)
+		priv->r->qos_init(priv);
 
 	if (priv->r->l3_setup)
 		priv->r->l3_setup(priv);

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
@@ -547,24 +547,14 @@ static void rtl839x_config_qos(void)
 	}
 }
 
-void __init rtl83xx_setup_qos(struct rtl838x_switch_priv *priv)
+void rtldsa_838x_qos_init(struct rtl838x_switch_priv *priv)
 {
-	switch_priv = priv;
+	rtl838x_config_qos();
+	rtl838x_rate_control_init(priv);
+}
 
-	pr_info("In %s\n", __func__);
-
-	switch (priv->family_id) {
-	case RTL8380_FAMILY_ID:
-		rtl838x_config_qos();
-		rtl838x_rate_control_init(priv);
-		break;
-	case RTL8390_FAMILY_ID:
-		rtl839x_config_qos();
-		rtl839x_rate_control_init(priv);
-		break;
-	default:
-		if (priv->r->qos_init)
-			priv->r->qos_init(priv);
-		break;
-	}
+void rtldsa_839x_qos_init(struct rtl838x_switch_priv *priv)
+{
+	rtl839x_config_qos();
+	rtl839x_rate_control_init(priv);
 }

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1748,6 +1748,7 @@ const struct rtl838x_reg rtl838x_reg = {
 	.l3_setup = rtl838x_l3_setup,
 	.set_distribution_algorithm = rtl838x_set_distribution_algorithm,
 	.set_receive_management_action = rtl838x_set_receive_management_action,
+	.qos_init = rtldsa_838x_qos_init,
 };
 
 irqreturn_t rtl838x_switch_irq(int irq, void *dev_id)

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1698,4 +1698,5 @@ const struct rtl838x_reg rtl839x_reg = {
 	.l3_setup = rtl839x_l3_setup,
 	.set_distribution_algorithm = rtl839x_set_distribution_algorithm,
 	.set_receive_management_action = rtl839x_set_receive_management_action,
+	.qos_init = rtldsa_839x_qos_init,
 };

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -131,7 +131,8 @@ inline u16 rtl_table_data(struct table_reg *r, int i);
 inline u32 rtl_table_data_r(struct table_reg *r, int i);
 inline void rtl_table_data_w(struct table_reg *r, u32 v, int i);
 
-void __init rtl83xx_setup_qos(struct rtl838x_switch_priv *priv);
+void rtldsa_838x_qos_init(struct rtl838x_switch_priv *priv);
+void rtldsa_839x_qos_init(struct rtl838x_switch_priv *priv);
 
 void rtl83xx_fast_age(struct dsa_switch *ds, int port);
 int rtl83xx_packet_cntr_alloc(struct rtl838x_switch_priv *priv);


### PR DESCRIPTION
Compilation currently spits this message:

```
WARNING: modpost: vmlinux: section mismatch in reference:
rtl83xx_sw_probe+0x6a4 (section: .text.rtl83xx_sw_probe)
-> rtl83xx_setup_qos (section: .init.text)
```

That means that we have a "normal" function caller (can be called during the whole uptime) and a "initialization" function callee (only available during init.

Fix this and directly fix the unwanted family checks.