### PR TITLE
microchipsw: enable DCB by default

### DIFF
--- a/config/Config-kernel.in
+++ b/config/Config-kernel.in
@@ -1277,6 +1277,7 @@ config KERNEL_NET_L3_MASTER_DEV
 config KERNEL_DCB
 	bool "Data Center Bridging support"
 	default y if TARGET_armsr_armv8
+	default y if TARGET_microchipsw
 	default y if TARGET_x86_64
 	help
 	  This enables support for configuring Data Center Bridging (DCB)

--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -2351,7 +2351,8 @@ define KernelPackage/sparx5-switch
   DEPENDS:=@TARGET_microchipsw +kmod-phylink +kmod-ptp
   KCONFIG:= \
   CONFIG_SPARX5_SWITCH \
-  CONFIG_LAN969X_SWITCH=y
+  CONFIG_LAN969X_SWITCH=y \
+  CONFIG_SPARX5_DCB=y
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/microchip/sparx5/sparx5-switch.ko
   AUTOLOAD:=$(call AutoProbe,sparx5-switch,1)
 endef

--- a/target/linux/microchipsw/lan969x/target.mk
+++ b/target/linux/microchipsw/lan969x/target.mk
@@ -5,7 +5,8 @@ FEATURES+= boot-part rootfs-part
 DEFAULT_PACKAGES += kmod-sparx5-switch kmod-sfp kmod-phy-micrel \
 	kmod-usb3 kmod-usb-dwc3 \
 	e2fsprogs kmod-fs-ext4 losetup \
-	kmod-fs-f2fs f2fs-tools
+	kmod-fs-f2fs f2fs-tools \
+	ip-bridge dcb
 
 define Target/Description
 	Build firmware images for Microchip LAN969x switch based boards.


### PR DESCRIPTION
Switchdev driver used by microchipsw supports DCB and has not storage constraints, so enable kernel and driver DCB support by default.
