### PR TITLE
lldpd: fix custom configs, remove use of `-O`

### DIFF
--- a/package/network/services/lldpd/files/lldpd.init
+++ b/package/network/services/lldpd/files/lldpd.init
@@ -460,9 +460,6 @@ start_service() {
 
 	[ -n "$ifnames" ] && procd_append_param command -C "$ifnames"
 
-    # Overwrite default configuration locations processed by lldpcli at start
-	procd_append_param command -O "$LLDPD_CONF"
-
 	local restart_hash
 	get_config_restart_hash restart_hash
 	echo -n "$restart_hash" > "$LLDPD_RESTART_HASH"


### PR DESCRIPTION
The init script for `lldpd` was passing `-O /tmp/lldpd.conf` when starting lldpd.  Unfortunately, contrary to the comment in the init script, this causes lldpd to no longer load the "lldpd.d" directory. This means no custom lldpd.conf can be provided by the user or image builder.

As the `-O` option is unnecessary - it is built with sysconfdir=/tmp anyway - just remove it and go our merry way.

(this fixes half of https://github.com/openwrt/openwrt/issues/21698)

NB: change tested on 25.12, not on main