### PR TITLE
realtek: mdio: rename main mdio bus

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -960,7 +960,7 @@ static int rtmdio_probe(struct platform_device *pdev)
 	bus->write_c45 = rtmdio_write_c45;
 	bus->parent = dev;
 	bus->phy_mask = ~0;
-	snprintf(bus->id, MII_BUS_ID_SIZE, "%s-mii", dev_name(dev));
+	snprintf(bus->id, MII_BUS_ID_SIZE, "realtek-mdio");
 
 	device_set_node(&bus->dev, of_fwnode_handle(dev->of_node));
 	ret = devm_mdiobus_register(dev, bus);


### PR DESCRIPTION
Looking at the Realtek mdio busses there are curently the following

```
root@OpenWrt:~# mdio
1b000000.switchcore:mdio-controller-mii
fixed-0
realtek-aux-mdio
realtek-serdes-mdio
rtldsa_mdio-0
```

The main mdio bus for the phys is named after the dts node it belongs to (1b000000.switchcore:mdio-controller-mii). As it is attached to the controller node it is even more confusing.

Align the naming to the other busses and use "realtek-mdio".
