### PR TITLE
 target: qualcommax: add Datto AP440 support

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
@@ -10,6 +10,7 @@ board=$(board_name)
 case "$board" in
 8devices,mango-dvk|\
 8devices,mango-dvk-sfp|\
+datto,ap440|\
 cambiumnetworks,xe3-4)
 	ubootenv_add_mtd "0:APPSBLENV" "0x0" "0x10000" "0x10000"
 	;;

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -37,6 +37,7 @@ ALLWIFIBOARDS:= \
 	cambiumnetworks_xe34 \
 	cmcc_rm2-6 \
 	compex_wpq873 \
+	datto_ap440 \
 	dynalink_dl-wrx36 \
 	edgecore_eap102 \
 	edimax_cax1800 \
@@ -224,6 +225,7 @@ $(eval $(call generate-ipq-wifi-package,buffalo_wxr-5950ax12,Buffalo WXR-5950AX1
 $(eval $(call generate-ipq-wifi-package,cambiumnetworks_xe34,Cambium Networks XE3-4))
 $(eval $(call generate-ipq-wifi-package,cmcc_rm2-6,CMCC RM2-6))
 $(eval $(call generate-ipq-wifi-package,compex_wpq873,Compex WPQ-873))
+$(eval $(call generate-ipq-wifi-package,datto_ap440,Datto AP440))
 $(eval $(call generate-ipq-wifi-package,dynalink_dl-wrx36,Dynalink DL-WRX36))
 $(eval $(call generate-ipq-wifi-package,edgecore_eap102,Edgecore EAP102))
 $(eval $(call generate-ipq-wifi-package,edimax_cax1800,Edimax CAX1800))

--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-ap440.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq6010-ap440.dts
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq6018.dtsi"
+#include "ipq6018-cp-cpu.dtsi"
+#include "ipq6018-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/net/qcom-ipq-ess.h>
+
+/ {
+	model = "Datto AP440";
+	compatible = "datto,ap440", "qcom,ipq6018";
+
+	aliases {
+		serial0 = &blsp1_uart3;
+		ethernet0 = &dp3;
+		ethernet1 = &dp4;
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		led_status: status {
+			label = "status";
+			gpios = <&tlmm 37 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	gpio-watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&tlmm 68 GPIO_ACTIVE_LOW>;
+		hw_algo = "toggle";
+		/* hw_margin_ms is actually 300s but driver limits it to 60s */
+		hw_margin_ms = <60000>;
+		always-running;
+	};
+
+	usb_vbus: regulator-usb-vbus {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&tlmm 30 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-always-on;
+		pinctrl-0 = <&usb_pins>;
+		pinctrl-names = "default";
+	};
+};
+
+&soc {
+	watchdog@b017000 {
+		status = "okay";
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio64";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio65";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	led_pins: led-pins {
+		pins = "gpio37";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	spi_0_pins: spi-0-pins {
+		pins = "gpio38", "gpio39", "gpio40", "gpio41";
+		function = "blsp0_spi";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	usb_pins: usb-pins {
+		pins = "gpio30";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+		output-high;
+	};
+};
+
+&blsp1_uart3 {
+	pinctrl-0 = <&serial_3_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&blsp1_spi1 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	flash@0 {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x0 0xc0000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				label = "0:MIBIB";
+				reg = <0xc0000 0x10000>;
+				read-only;
+			};
+
+			partition@d0000 {
+				label = "0:QSEE";
+				reg = <0xd0000 0x1a0000>;
+				read-only;
+			};
+
+			partition@270000 {
+				label = "0:DEVCFG";
+				reg = <0x270000 0x10000>;
+				read-only;
+			};
+
+			partition@280000 {
+				label = "0:RPM";
+				reg = <0x280000 0x20000>;
+				read-only;
+			};
+
+			partition@2a0000 {
+				label = "0:CDT";
+				reg = <0x2a0000 0x10000>;
+				read-only;
+			};
+
+			partition@2b0000 {
+				label = "0:APPSBLENV";
+				reg = <0x2b0000 0x10000>;
+			};
+
+			partition@2c0000 {
+				label = "0:APPSBL";
+				reg = <0x2c0000 0xa0000>;
+				read-only;
+			};
+
+			partition@360000 {
+				label = "0:ART";
+				reg = <0x360000 0x40000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					mac_base: mac@0 {
+						reg = <0x0 0x6>;
+					};
+				};
+			};
+
+			partition@3a0000 {
+				label = "datto";
+				reg = <0x3a0000 0x30000>;
+				read-only;
+			};
+
+			partition@3d0000 {
+				label = "serial";
+				reg = <0x3d0000 0x30000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			kernel@0 {
+				label = "kernel";
+				reg = <0x00000000 0x01000000>; /* 16 MiB */
+			};
+
+			ubi@1000000 {
+				label = "ubi";
+				reg = <0x01000000 0x1f000000>; /* 496 MiB */
+			};
+		};
+	};
+};
+
+&mdio {
+    status = "okay";
+
+    pinctrl-0 = <&mdio_pins>;
+    pinctrl-names = "default";
+    reset-gpios = <&tlmm 75 GPIO_ACTIVE_LOW>;
+    reset-delay-us = <10000>;
+    reset-post-delay-us = <50000>;
+
+    ethernet-phy-package@0 {
+        #address-cells = <1>;
+        #size-cells = <0>;
+        compatible = "qcom,qca8075-package";
+        reg = <0>;
+
+        qcom,package-mode = "psgmii";
+
+        phy0: ethernet-phy@3 {
+            reg = <3>;
+            qca,disable-smarteee;
+            qca,disable-hibernation;
+        };
+
+        phy1: ethernet-phy@4 {
+            reg = <4>;
+            qca,disable-smarteee;
+            qca,disable-hibernation;
+        };
+    };
+};
+
+&switch {
+	status = "okay";
+
+	switch_cpu_bmp = <ESS_PORT0>;
+	switch_lan_bmp = <ESS_PORT3>;
+	switch_wan_bmp = <ESS_PORT4>;
+	switch_mac_mode = <MAC_MODE_PSGMII>;
+	switch_mac_mode1 = <MAC_MODE_DISABLED>;
+	switch_mac_mode2 = <MAC_MODE_DISABLED>;
+	bm_tick_mode = <0>;
+	tm_tick_mode = <0>;
+	port3_pcs_channel = <4>;
+	port4_pcs_channel = <3>;
+
+	qcom,port_phyinfo {
+		port@3 {
+			port_id = <3>;
+			phy_address = <4>;
+		};
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp3 {
+    status = "okay";
+	phy-handle = <&phy1>;
+	label = "wan";
+	nvmem-cells = <&mac_base>;
+	nvmem-cell-names = "mac-address";
+	mac-address-increment = <1>;
+};
+
+&dp4 {
+    status = "okay";
+	phy-handle = <&phy0>;
+	label = "lan";
+	nvmem-cells = <&mac_base>;
+	nvmem-cell-names = "mac-address";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Datto-AP440";
+};
+
+&pcie_phy {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpio = <&tlmm 60 GPIO_ACTIVE_LOW>;
+
+	bridge@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+
+		wifi2: wifi@1,0 {
+			status = "okay";
+			compatible = "qcom,ath10k";
+			reg = <0x00010000 0 0 0 0>;
+
+			qcom,ath10k-calibration-variant = "Datto-AP440-FCC-indoor";
+		};
+	};
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&qusb_phy_1 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb2 {
+	status = "okay";
+	vbus-supply = <&usb_vbus>;
+
+	dwc_1: usb@7000000 {
+		snps,nominal-elastic-buffer;
+		snps,quirk-ref-clock-adjustment = <0xa87f0>;
+		snps,quirk-ref-clock-period = <0x29>;
+	};
+};

--- a/target/linux/qualcommax/image/ipq60xx.mk
+++ b/target/linux/qualcommax/image/ipq60xx.mk
@@ -285,3 +285,12 @@ define Device/yuncore_fap650
 	IMAGE/factory.ubin := append-ubi | qsdk-ipq-factory-nand
 endef
 TARGET_DEVICES += yuncore_fap650
+
+define Device/datto_ap440
+	$(call Device/FitImage)
+	DEVICE_VENDOR := Datto
+	DEVICE_MODEL := AP440
+	SOC := ipq6010
+	DEVICE_PACKAGES := ipq-wifi-datto_ap440
+endef
+TARGET_DEVICES += datto_ap440

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/board.d/02_network
@@ -15,7 +15,8 @@ ipq60xx_setup_interfaces()
 	glinet,gl-axt1800)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
-	alfa-network,ap120c-ax)
+	alfa-network,ap120c-ax|\
+	datto,ap440)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	cambiumnetworks,xe3-4)

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/10-ath10k-caldata
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/10-ath10k-caldata
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+[ -e /lib/firmware/$FIRMWARE ] && exit 0
+
+. /lib/functions/caldata.sh
+
+board=$(board_name)
+
+case "$FIRMWARE" in
+"ath10k/cal-pci-0000:01:00.0.bin")
+	case "$board" in
+	datto,ap440)
+		caldata_extract "0:ART" 0x33000 0x2f20
+		;;
+	esac
+	;;
+*)
+	exit 1
+	;;
+esac

--- a/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq60xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -19,6 +19,9 @@ case "$FIRMWARE" in
 		ath11k_patch_mac $(macaddr_add $label_mac 1) 0
 		ath11k_set_macflag
 		;;
+	datto,ap440)
+		caldata_extract "0:ART" 0x1000 0x20000
+		;;
 	cambiumnetworks,xe3-4)
 		caldata_extract "0:ART" 0x1000 0x10000
 		;;


### PR DESCRIPTION
This PR adds support for the Datto AP440 (ipq6010):

- add device DTS and image definition
- add uboot-envtools entry for APPSBLENV
- add board network defaults
- add ath10k/ath11k caldata handlers
- add ipq-wifi package entry

Tested on AP440:
- booted sysupgrade image
- Ethernet lan/wan functional
- Wi‑Fi radios load with caldata from 0:ART

Signed-off-by: John Pho Betar phobetard@proton.me