### PR TITLE
build: fix help text for BUILD_LOG option

### DIFF
--- a/config/Config-devel.in
+++ b/config/Config-devel.in
@@ -188,7 +188,7 @@ menuconfig DEVEL
 	config BUILD_LOG
 		bool "Enable log files during build process" if DEVEL
 		help
-		  If enabled, log files will be written to the ./log directory.
+		  If enabled, log files will be written to the ./logs directory.
 
 	config BUILD_LOG_DIR
 		string "Log folder" if DEVEL

--- a/target/sdk/files/Config.in
+++ b/target/sdk/files/Config.in
@@ -129,7 +129,7 @@ menu "Advanced configuration options (for developers)"
 	config BUILD_LOG
 		bool "Enable log files during build process"
 		help
-		  If enabled, log files will be written to the ./log directory.
+		  If enabled, log files will be written to the ./logs directory.
 
 	config SRC_TREE_OVERRIDE
 		bool "Enable package source tree override"


### PR DESCRIPTION
The help text for the BUILD_LOG option incorrectly states that log files are written to the "./log" directory. In practice, build logs are written to the "./logs" directory by default.

Update the help text in both Config-devel.in and the SDK Config.in to correctly reflect this.