### PR TITLE
arm-trusted-firmware-mediatek: update to v2026-01-23

### DIFF
--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -13,9 +13,9 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/mtk-openwrt/arm-trusted-firmware.git
-PKG_SOURCE_DATE:=2025-07-11
-PKG_SOURCE_VERSION:=78a0dfd927bb00ce973a1f8eb4079df0f755887a
-PKG_MIRROR_HASH:=72a5f3f00f9e368226bb779dc098aac6195a312b48cc22172987d494ccd135d1
+PKG_SOURCE_DATE:=2026-01-23
+PKG_SOURCE_VERSION:=e06f258664198a901ff1c7c0c87802a115179451
+PKG_MIRROR_HASH:=e094f5c2838f366e9b2d87e85e0c324ac3b955dd02a493adced843031cf6b517
 
 PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
 
@@ -36,10 +36,10 @@ define Trusted-Firmware-A/Default
   BOARD_QFN:=
   DRAM_USE_COMB:=
   RAM_BOOT_UART_DL:=
+  USE_SPI2:=
   USE_UBI:=
   FIP_OFFSET:=
   FIP_SIZE:=
-  SPIM_CTRL:=
 endef
 
 define Trusted-Firmware-A/mt7622-nor-1ddr
@@ -464,7 +464,6 @@ define Trusted-Firmware-A/mt7987-spim-nand0
   BOOT_DEVICE:=spim-nand
   BUILD_SUBTARGET:=filogic
   PLAT:=mt7987
-  SPIM_CTRL:=0
 endef
 
 define Trusted-Firmware-A/mt7987-spim-nand0-ubi-comb
@@ -473,7 +472,6 @@ define Trusted-Firmware-A/mt7987-spim-nand0-ubi-comb
   BUILD_SUBTARGET:=filogic
   PLAT:=mt7987
   USE_UBI:=1
-  SPIM_CTRL:=0
 endef
 
 define Trusted-Firmware-A/mt7987-spim-nand2-ubi-comb
@@ -481,8 +479,8 @@ define Trusted-Firmware-A/mt7987-spim-nand2-ubi-comb
   BOOT_DEVICE:=spim-nand
   BUILD_SUBTARGET:=filogic
   PLAT:=mt7987
+  USE_SPI2:=1
   USE_UBI:=1
-  SPIM_CTRL:=2
 endef
 
 define Trusted-Firmware-A/mt7987-ram-comb
@@ -787,7 +785,7 @@ TFA_MAKE_FLAGS += \
 	$(if $(USE_UBI),UBI=1 $(if $(findstring mt7986,$(PLAT)),OVERRIDE_UBI_START_ADDR=0x200000)) \
 	$(if $(FIP_OFFSET),OVERRIDE_FIP_BASE=$(FIP_OFFSET)) \
 	$(if $(FIP_SIZE),OVERRIDE_FIP_SIZE=$(FIP_SIZE)) \
-	$(if $(SPIM_CTRL),SPIM_CTRL=$(SPIM_CTRL)) \
+	$(if $(USE_SPI2),SPIM_NAND_PREFER_SPI2=1) \
 	$(if $(RAM_BOOT_UART_DL),bl2,all)
 
 define Package/trusted-firmware-a-ram/install

--- a/package/boot/arm-trusted-firmware-mediatek/patches/0005-mt7987-make-SPI-controller-configurable.patch
+++ b/package/boot/arm-trusted-firmware-mediatek/patches/0005-mt7987-make-SPI-controller-configurable.patch
@@ -16,67 +16,25 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  5 files changed, 53 insertions(+), 3 deletions(-)
  create mode 100644 plat/mediatek/mt7987/Config.in
 
---- a/plat/mediatek/apsoc_common/Config.in
-+++ b/plat/mediatek/apsoc_common/Config.in
-@@ -783,6 +783,7 @@ config ENABLE_BL31_RUNTIME_LOG
- 	default 1
- 	depends on _ENABLE_BL31_RUNTIME_LOG
- 
-+source "plat/mediatek/mt7987/Config.in"
- source "plat/mediatek/mt7988/Config.in"
- 
- endmenu # Platform configurations
---- /dev/null
-+++ b/plat/mediatek/mt7987/Config.in
-@@ -0,0 +1,29 @@
-+# SPDX-License-Identifier: BSD-3-Clause
-+#
-+# Copyright (c) 2025 Daniel Golle <daniel@makrotopia.org>
-+#
-+# MT7987 platform-specific configurations
-+#
-+
-+if _PLAT_MT7987
-+
-+choice
-+	prompt "SPI controller"
-+	depends on (_BOOT_DEVICE_SPIM_NAND || _BOOT_DEVICE_SPI_NOR)
-+	default _SPIM_CTRL_0 if _BOOT_DEVICE_SPIM_NAND
-+	default _SPIM_CTRL_2 if _BOOT_DEVICE_SPI_NOR
-+
-+	config _SPIM_CTRL_0
-+		bool "0"
-+
-+	config _SPIM_CTRL_2
-+		bool "2"
-+
-+endchoice
-+
-+config SPIM_CTRL
-+	int
-+	default 0 if _SPIM_CTRL_0
-+	default 2 if _SPIM_CTRL_2
-+
-+endif # _PLAT_MT7987
 --- a/plat/mediatek/mt7987/bl2/bl2.mk
 +++ b/plat/mediatek/mt7987/bl2/bl2.mk
 @@ -91,7 +91,11 @@ endif # END OF BOOT_DEVICE = ram
  ifeq ($(BOOT_DEVICE),nor)
  $(eval $(call BL2_BOOT_NOR))
  BL2_SOURCES		+=	$(MTK_PLAT_SOC)/bl2/bl2_dev_spi_nor.c
-+ifeq ($(SPIM_CTRL),0)
-+DTS_NAME		:=	mt7987-spi0
-+else
++ifeq ($(SPIM_NAND_PREFER_SPI2),1)
  DTS_NAME		:=	mt7987-spi2
++else
++DTS_NAME		:=	mt7987-spi0
 +endif
  endif # END OF BOOTDEVICE = nor
  
  ifeq ($(BOOT_DEVICE),emmc)
-@@ -112,10 +116,18 @@ ifeq ($(BOOT_DEVICE),spim-nand)
- $(eval $(call BL2_BOOT_SPI_NAND,0,0))
- BL2_SOURCES		+=	$(MTK_PLAT_SOC)/bl2/bl2_dev_spi_nand.c
+@@ -118,7 +122,11 @@ ifeq ($(SPIM_NAND_NO_RETRY),1)
+ BL2_CPPFLAGS		+=	-DSPIM_NAND_NO_RETRY
+ endif # END OF SPIM_NAND_NO_RETRY
  NAND_TYPE		?=	spim:2k+64
-+ifeq ($(SPIM_CTRL),2)
++ifeq ($(SPIM_NAND_PREFER_SPI2),1)
 +DTS_NAME		:=	mt7987-spi2
 +else
  DTS_NAME		:=	mt7987-spi0
@@ -84,45 +42,3 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  $(eval $(call BL2_BOOT_NAND_TYPE_CHECK,$(NAND_TYPE),spim:2k+64 spim:2k+128 spim:4k+256))
  endif # END OF BOOTDEVICE = spim-nand
  
-+ifneq ($(SPIM_CTRL),)
-+BL2_CPPFLAGS		+=	-DSPIM_CTRL=$(SPIM_CTRL)
-+endif
-+
- ifeq ($(BROM_HEADER_TYPE),)
- $(error BOOT_DEVICE has invalid value. Please re-check.)
- endif
---- a/plat/mediatek/mt7987/bl2/bl2_dev_spi_nand.c
-+++ b/plat/mediatek/mt7987/bl2/bl2_dev_spi_nand.c
-@@ -12,10 +12,18 @@
- 
- #define MTK_QSPI_SRC_CLK		CB_MPLL_D2
- 
-+#if SPIM_CTRL == 0
-+#define SELECTED_SPIM SPIM0
-+#elif SPIM_CTRL == 2
-+#define SELECTED_SPIM SPIM2
-+#else
-+#error "Invalid SPI controller selection"
-+#endif
-+
- uint32_t mtk_plat_get_qspi_src_clk(void)
- {
- 	/* config GPIO pinmux to spi mode */
--	mtk_spi_gpio_init(SPIM0);
-+	mtk_spi_gpio_init(SELECTED_SPIM);
- 
- 	/* select 208M clk */
- 	mtk_spi_source_clock_select(MTK_QSPI_SRC_CLK);
---- a/plat/mediatek/mt7987/platform.mk
-+++ b/plat/mediatek/mt7987/platform.mk
-@@ -56,8 +56,8 @@ include make_helpers/dep.mk
- 
- $(call GEN_DEP_RULES,bl2,emicfg bl2_boot_ram bl2_boot_nand_nmbm bl2_dev_mmc bl2_plat_init bl2_plat_setup mt7987_gpio dtb)
- $(call MAKE_DEP,bl2,emicfg,DDR4_4BG_MODE DRAM_DEBUG_LOG DDR3_FREQ_2133 DDR3_FREQ_1866 DDR4_FREQ_3200 DDR4_FREQ_2666)
--$(call MAKE_DEP,bl2,bl2_plat_init,BL2_COMPRESS)
--$(call MAKE_DEP,bl2,bl2_plat_setup,BOOT_DEVICE TRUSTED_BOARD_BOOT BL32_TZRAM_BASE BL32_TZRAM_SIZE BL32_LOAD_OFFSET)
-+$(call MAKE_DEP,bl2,bl2_plat_init,BL2_COMPRESS SPIM_CTRL)
-+$(call MAKE_DEP,bl2,bl2_plat_setup,BOOT_DEVICE TRUSTED_BOARD_BOOT BL32_TZRAM_BASE BL32_TZRAM_SIZE BL32_LOAD_OFFSET SPIM_CTRL)
- $(call MAKE_DEP,bl2,bl2_dev_mmc,BOOT_DEVICE)
- $(call MAKE_DEP,bl2,bl2_boot_ram,RAM_BOOT_DEBUGGER_HOOK RAM_BOOT_UART_DL)
- $(call MAKE_DEP,bl2,bl2_boot_nand_nmbm,NMBM_MAX_RATIO NMBM_MAX_RESERVED_BLOCKS NMBM_DEFAULT_LOG_LEVEL)

--- a/package/boot/arm-trusted-firmware-mediatek/patches/0007-hack-mt7987-bl2-move-FIP-offset-to-0x100000.patch
+++ b/package/boot/arm-trusted-firmware-mediatek/patches/0007-hack-mt7987-bl2-move-FIP-offset-to-0x100000.patch
@@ -16,9 +16,9 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/plat/mediatek/mt7987/bl2/bl2_dev_spi_nor.c
 +++ b/plat/mediatek/mt7987/bl2/bl2_dev_spi_nor.c
-@@ -7,7 +7,7 @@
- #include <stdint.h>
+@@ -8,7 +8,7 @@
  #include <boot_spi.h>
+ #include <mtk_spi.h>
  
 -#define FIP_BASE			0x250000
 +#define FIP_BASE			0x100000


### PR DESCRIPTION
The highlight of this version is that the bl2 size will be reduced by 60+ KB. The MT7987 SPI interface selection hack was replaced by upstream implementation with the new symbol SPIM_NAND_PREFER_SPI2.

cc @dangowrt