### PR TITLE
airoha: reduce HWRNG quality

### DIFF
--- a/target/linux/airoha/patches-6.12/114-v7.0-hwrng-airoha-set-rng-quality-to-900.patch
+++ b/target/linux/airoha/patches-6.12/114-v7.0-hwrng-airoha-set-rng-quality-to-900.patch
@@ -1,0 +1,57 @@
+From c0008a29a006091d7f9d288620c2456afa23ff27 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Mon, 5 Jan 2026 21:41:49 +0100
+Subject: [PATCH] hwrng: airoha - set rng quality to 900
+
+Airoha uses RAW mode to collect noise from the TRNG. These appear to
+be unprocessed oscillations from the tero loop. For this reason, they
+do not have a perfect distribution and entropy. Simple noise compression
+reduces its size by 9%, so setting the quality to 900 seems reasonable.
+The same value is used by the downstream driver.
+
+Compare the size before and after compression:
+$ ls -l random_airoha*
+-rw-r--r-- 1 aleksander aleksander 76546048 Jan  3 23:43 random_airoha
+-rw-rw-r-- 1 aleksander aleksander 69783562 Jan  5 20:23 random_airoha.zip
+
+FIPS test results:
+$ cat random_airoha | rngtest -c 10000
+rngtest 2.6
+Copyright (c) 2004 by Henrique de Moraes Holschuh
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+rngtest: starting FIPS tests...
+rngtest: bits received from input: 200000032
+rngtest: FIPS 140-2 successes: 0
+rngtest: FIPS 140-2 failures: 10000
+rngtest: FIPS 140-2(2001-10-10) Monobit: 9957
+rngtest: FIPS 140-2(2001-10-10) Poker: 10000
+rngtest: FIPS 140-2(2001-10-10) Runs: 10000
+rngtest: FIPS 140-2(2001-10-10) Long run: 4249
+rngtest: FIPS 140-2(2001-10-10) Continuous run: 0
+rngtest: input channel speed: (min=953.674; avg=27698.935; max=19073.486)Mibits/s
+rngtest: FIPS tests speed: (min=59.791; avg=298.028; max=328.853)Mibits/s
+rngtest: Program run time: 647638 microseconds
+
+In general, these data look like real noise, but with lower entropy
+than expected.
+
+Fixes: e53ca8efcc5e ("hwrng: airoha - add support for Airoha EN7581 TRNG")
+Suggested-by: Benjamin Larsson <benjamin.larsson@genexis.eu>
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ drivers/char/hw_random/airoha-trng.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/char/hw_random/airoha-trng.c
++++ b/drivers/char/hw_random/airoha-trng.c
+@@ -212,6 +212,7 @@ static int airoha_trng_probe(struct plat
+ 	trng->rng.init = airoha_trng_init;
+ 	trng->rng.cleanup = airoha_trng_cleanup;
+ 	trng->rng.read = airoha_trng_read;
++	trng->rng.quality = 900;
+ 
+ 	ret = devm_hwrng_register(dev, &trng->rng);
+ 	if (ret) {


### PR DESCRIPTION
Backport a patch that reduces the quality of HWRNG. HWRNG has lower entropy than expected. Thanks to this patch, it has a lower priority.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>