### PR TITLE
wifi-scripts: fix ucode mobility_domain default value

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -363,7 +363,7 @@ function iface_roaming(config) {
 	if (!config.ieee80211r || config.wpa < 2)
 		return;
 
-	set_default(config, 'mobility_domain', substr(md5(config.ssid), 0, 4));
+	set_default(config, 'mobility_domain', substr(md5(config.ssid + '\n'), 0, 4));
 	set_default(config, 'ft_psk_generate_local', config.auth_type == 'psk');
 	set_default(config, 'ft_iface', config.network_ifname);
 


### PR DESCRIPTION
The mobility_domain value generated by ucode differed from the previous
shell script implementation. The legacy shell script used `echo` on the
SSID, which appended a trailing newline.

To maintain roaming compatibility with pre-25.12 releases and OpenWrt
forks in default configuration, update the ucode logic to include this
newline character when generating the default value.

Fixes: #21731