### PR TITLE
ipq-wifi/ath10k: fix 5GHz radio detection on TP-Link TL-WA1201 v2

### DIFF
--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -93,6 +93,7 @@ ALLWIFIBOARDS:= \
 	tplink_archer-c6-v2 \
 	tplink_archer-c60-v1 \
 	tplink_archer-c60-v2 \
+	tplink_tl-wa1201-v2 \
 	wallys_dr40x9 \
 	xiaomi_aiot-ac2350 \
 	xiaomi_ax3600 \
@@ -280,6 +281,7 @@ $(eval $(call generate-ipq-wifi-package,tplink_archer-c59-v1,TP-Link Archer C59 
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c6-v2,TP-Link Archer C6 V2))
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c60-v1,TP-Link Archer C60 V1))
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c60-v2,TP-Link Archer C60 V2))
+$(eval $(call generate-ipq-wifi-package,tplink_tl-wa1201-v2,TP-Link TL-WA1201 V2))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))
 $(eval $(call generate-ipq-wifi-package,xiaomi_aiot-ac2350,Xiaomi AIoT AC2350))
 $(eval $(call generate-ipq-wifi-package,xiaomi_ax3600,Xiaomi AX3600))

--- a/target/linux/ath79/dts/qca9563_tplink_tl-wa1201-v2.dts
+++ b/target/linux/ath79/dts/qca9563_tplink_tl-wa1201-v2.dts
@@ -92,6 +92,7 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&precal_art_5000>, <&macaddr_info_8 (-1)>;
 		nvmem-cell-names = "pre-calibration", "mac-address";
+		qcom,ath10k-calibration-variant = "TP-Link-TL-WA1201-v2";
 	};
 };
 

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -580,7 +580,7 @@ define Device/tplink_tl-wa1201-v2
   DEVICE_MODEL := TL-WA1201
   DEVICE_VARIANT := v2
   TPLINK_BOARD_ID := TL-WA1201-V2
-  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
+  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct ipq-wifi-tplink_tl-wa1201-v2
 endef
 TARGET_DEVICES += tplink_tl-wa1201-v2
 


### PR DESCRIPTION
This fixes the 5ghz radio detection on TP-Link TL-WA1201 v2. Boarddata was extracted from the EU/US vendor firmware and successfully tested by @jimmyd998.

Requires https://github.com/openwrt/firmware_qca-wireless/pull/122 to be merged first and ipq-wifi to be updated to head.

Link: https://github.com/openwrt/openwrt/issues/14541