### PR TITLE
kexec-tools: add zstd to package dependencies

### DIFF
--- a/package/boot/kexec-tools/Config.in
+++ b/package/boot/kexec-tools/Config.in
@@ -11,4 +11,9 @@ config KEXEC_LZMA
 	prompt "lzma support"
 	default n
 
+config KEXEC_ZSTD
+	bool
+	prompt "zstd support"
+	default n
+	
 endmenu

--- a/package/boot/kexec-tools/Makefile
+++ b/package/boot/kexec-tools/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=kexec-tools
 PKG_VERSION:=2.0.32
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@KERNEL/linux/utils/kernel/kexec
@@ -19,7 +19,7 @@ PKG_LICENSE:=GPL-2.0-only
 PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:kernel:kexec-tools
 
-PKG_CONFIG_DEPENDS := CONFIG_KEXEC_ZLIB CONFIG_KEXEC_LZMA
+PKG_CONFIG_DEPENDS := CONFIG_KEXEC_ZLIB CONFIG_KEXEC_LZMA CONFIG_KEXEC_ZSTD
 
 PKG_BUILD_FLAGS:=gc-sections
 
@@ -48,7 +48,7 @@ define Package/kexec
   TITLE:=Kernel boots kernel
   DEPENDS:=\
 	@(armeb||arm||aarch64||i386||x86_64||powerpc64||mipsel||mips) \
-	+KEXEC_ZLIB:zlib +KEXEC_LZMA:liblzma @KERNEL_KEXEC
+	+KEXEC_ZLIB:zlib +KEXEC_LZMA:liblzma +KEXEC_ZSTD:libzstd @KERNEL_KEXEC
 endef
 
 define Package/kexec/description
@@ -86,6 +86,7 @@ CONFIGURE_ARGS = \
 		--sysconfdir=/etc \
 		$(if $(CONFIG_KEXEC_ZLIB),--with,--without)-zlib \
 		$(if $(CONFIG_KEXEC_LZMA),--with,--without)-lzma \
+		$(if $(CONFIG_KEXEC_ZSTD),--with,--without)-zstd \
 		TARGET_LD="$(TARGET_CROSS)ld"
 
 CONFIGURE_VARS += \


### PR DESCRIPTION
Fixed build failure caused by missing libzstd dependency. 

Added CONFIG_KEXEC_ZSTD configuration option and libzstd library dependency declaration, following the same pattern as existing zlib and lzma support.

Fixes: https://github.com/openwrt/openwrt/commit/e75218ef4a271a9325483d4b6460755462e17aa0

Link: https://github.com/openwrt/openwrt/pull/21623#issuecomment-3805115332