### PR TITLE
Imagebuilder: speedup by reducing apk query calls

### DIFF
--- a/target/imagebuilder/files/Makefile
+++ b/target/imagebuilder/files/Makefile
@@ -153,21 +153,62 @@ BUILD_PACKAGES+= \
   "kernel=$(KERNEL_VERSION)"
 endif
 
-# Get ABI version suffix for a package from an apk index
+# Get ABI version suffix for a package
+# Input example: 
+# $(1)=libustream-mbedtls
+# $(2)=... libustream-mbedtls20201210:20201210 ...
 #
 # 1: package name
+# 2: list of packages names with ABI suffixes 
 define GetABISuffix
-$(shell $(APK) query --fields tags --match provides $(1) | tr ' ' '\n' | grep '^openwrt:abiversion=' | cut -d= -f2)
+$(strip
+  $(foreach name_abi_abi,$(2),
+    $(eval abi:=$(lastword $(subst :, ,$(name_abi_abi))))
+    $(eval name_abi:=$(firstword $(subst :, ,$(name_abi_abi))))
+    $(if $(filter $(1)$(abi),$(name_abi)),
+      $(abi)
+    )
+  )
+)
+endef
+
+# Get list of packages matching the "Tags:" field in APK metadata
+# with the parameter $(1) and print them in the format:
+# "package_name<abi_version>:tag_value"
+# 
+# apk query --fields name,tags --match tags 'openwrt:abi*'
+# Name: libustream-mbedtls20201210
+# Tags: openwrt:abiversion=20201210
+# ...
+# Output: ... libustream-mbedtls20201210:20201210 ...
+#
+# 1: tag to match
+define GetPackagesByTags
+$(strip $(shell $(APK) query --fields name,tags --match tags '$(1)' | awk ' \
+  /^Name:/ { \
+    name = $$2 \
+  } \
+  /^Tags:/ { \
+    for (i=2; i<=NF; i++) { \
+      if ($$i ~ /^$(1)/) { \
+        split($$i, tag, "="); \
+        printf "%s:%s ", name, tag[2]; \
+      } \
+    } \
+  }' \
+))
 endef
 
 # Format packages by adding an ABI version suffix if found
 #
 # 1: list of packages
 define FormatPackages
+$(eval pkg_names_abi:=$(call GetPackagesByTags,openwrt:abi*)) \
 $(strip $(foreach pkg,$(strip $(subst ",,$(1))),
   $(eval pkg_name:=$(firstword $(subst =, ,$(pkg))))
+  $(eval pkg_ver:=)
   $(if $(findstring =,$(pkg)),$(eval pkg_ver:==$(lastword $(subst =, ,$(pkg)))))
-  $(pkg_name)$(call GetABISuffix,$(pkg_name))$(pkg_ver)
+  $(pkg_name)$(call GetABISuffix,$(pkg_name),$(pkg_names_abi))$(pkg_ver)
 ))
 endef
 


### PR DESCRIPTION
"apk query" calls seem expensive, rework the abi appending helpers to make the minimal calls as possible. With local imagebuilder, little index and little package list the difference is noticeable, but with remote indexes, larger indexes and larger package lists the difference should be even larger.

Since the list of packages with abi is short and it should not grow much, get the list of all packages with abi and proccess it, avoiding more calls to apk.

- Continue handling correctly extra "Tags:" if existing.
- Reset "pkg_ver" to avoid appending the last version found to the successive packages.
  - https://github.com/openwrt/openwrt/pull/21713 (Related)

------------------------------------
Tests with local (standalone) imagebuilder:
*The first run always takes more time because of creation the index
- Before: 
```
/workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64 $ time make manifest PACKAGES="kmod-r8169 jq jq-full dnsmasq-dhcpv6 iw kmod-ath10k-ct ethtool ethtool-full ca-certificat
es wget-ssl -wpad-basic-mbedtls wpad-basic-wolfssl kmod-r8127 busybox-selinux kmod-r8168 sqlite3-cli"
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
Generate local signing keys...
read EC key
writing EC key
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
WARNING: opening /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/packages/packages.adb: No such file or directory
Package list missing or not up-to-date, generating it.

Building package index...
apk-mbedtls - 3.0.2-r2
...
zlib - 1.3.1-r1
real    0m 2.96s
user    0m 1.54s
sys     0m 1.79s

/workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64 $ time make manifest PACKAGES="kmod-r8169 jq jq-full dnsmasq-dhcpv6 iw kmod-ath10k-ct ethtool ethtool-full ca-certificat
es wget-ssl -wpad-basic-mbedtls wpad-basic-wolfssl kmod-r8127 busybox-selinux kmod-r8168 sqlite3-cli"
apk-mbedtls - 3.0.2-r2
base-files - 1682~17d45f677b
...
wpad-basic-wolfssl - 2025.08.26~ca266cc2-r1
zlib - 1.3.1-r1
real    0m 2.44s
user    0m 1.26s
sys     0m 1.59s
/workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64 $ time make manifest PACKAGES="kmod-r8169 jq jq-full dnsmasq-dhcpv6 iw kmod-ath10k-ct ethtool ethtool-full ca-certificat
es wget-ssl -wpad-basic-mbedtls wpad-basic-wolfssl kmod-r8127 busybox-selinux kmod-r8168 sqlite3-cli"
apk-mbedtls - 3.0.2-r2
base-files - 1682~17d45f677b
...
zlib - 1.3.1-r1
real    0m 2.32s
user    0m 1.31s
sys     0m 1.47s
```

After:
```
/workdir $ cd bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/
/workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64 $ time make manifest PACKAGES="kmod-r8169 jq jq-full dnsmasq-dhcpv6 iw kmod-ath10k-ct ethtool ethtool-full ca-certificat
es wget-ssl -wpad-basic-mbedtls wpad-basic-wolfssl kmod-r8127 busybox-selinux kmod-r8168 sqlite3-cli"
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
Generate local signing keys...
read EC key
writing EC key
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
WARNING: opening /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/packages/packages.adb: No such file or directory
Package list missing or not up-to-date, generating it.

Building package index...
apk-mbedtls - 3.0.2-r2
...
wpad-basic-wolfssl - 2025.08.26~ca266cc2-r1
zlib - 1.3.1-r1
real    0m 1.42s
user    0m 0.61s
sys     0m 0.73s

/workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64 $ time make manifest PACKAGES="kmod-r8169 jq jq-full dnsmasq-dhcpv6 iw kmod-ath10k-ct ethtool ethtool-full ca-certificat
es wget-ssl -wpad-basic-mbedtls wpad-basic-wolfssl kmod-r8127 busybox-selinux kmod-r8168 sqlite3-cli"
apk-mbedtls - 3.0.2-r2
...
wpad-basic-wolfssl - 2025.08.26~ca266cc2-r1
zlib - 1.3.1-r1
real    0m 0.88s
user    0m 0.41s
sys     0m 0.50s
```

Test with SNAPSHOT imagebuilder (OpenWrt full index):
- Before:
```
/workdir $ cd bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/
/workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64 $ time make manifest PACKAGES="kmod-r8169 jq jq-full dnsmasq-dhcpv6 iw kmod-ath10k-ct ethtool ethtool-full ca-certificat
es wget-ssl -wpad-basic-mbedtls wpad-basic-wolfssl kmod-r8127 busybox-selinux kmod-r8168 sqlite3-cli"
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
Generate local signing keys...
WARNING: can't open config file: /builder/shared-workdir/build/staging_dir/host/etc/ssl/openssl.cnf
WARNING: can't open config file: /builder/shared-workdir/build/staging_dir/host/etc/ssl/openssl.cnf
read EC key
writing EC key
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
WARNING: opening /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/packages/packages.adb: No such file or directory
Package list missing or not up-to-date, generating it.

Building package index...
apk-mbedtls - 3.0.2-r2
...
wpad-basic-wolfssl - 2025.08.26~ca266cc2-r1
zlib - 1.3.1-r1
real    0m 40.70s
user    0m 6.62s
sys     0m 4.64s
/workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64 $

/workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64 $ time make manifest PACKAGES="kmod-r8169 jq jq-full dnsmasq-dhcpv6 iw kmod-ath10k-ct ethtool ethtool-full ca-certificat
es wget-ssl -wpad-basic-mbedtls wpad-basic-wolfssl kmod-r8127 busybox-selinux kmod-r8168 sqlite3-cli"
apk-mbedtls - 3.0.2-r2
...
wpad-basic-wolfssl - 2025.08.26~ca266cc2-r1
zlib - 1.3.1-r1
real    0m 20.05s
user    0m 4.05s
sys     0m 3.15s
```
- After (patching Makefile directly):
```
/workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64 $ time make manifest PACKAGES="kmod-r8169 jq jq-full dnsmasq-dhcpv6 iw kmod-ath10k-ct ethtool ethtool-full ca-certificat
es wget-ssl -wpad-basic-mbedtls wpad-basic-wolfssl kmod-r8127 busybox-selinux kmod-r8168 sqlite3-cli"
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
Generate local signing keys...
WARNING: can't open config file: /builder/shared-workdir/build/staging_dir/host/etc/ssl/openssl.cnf
WARNING: can't open config file: /builder/shared-workdir/build/staging_dir/host/etc/ssl/openssl.cnf
read EC key
writing EC key
make: TMPDIR value /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/tmp: No such file or directory
make: using default temporary directory '/tmp'
WARNING: opening /workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64/packages/packages.adb: No such file or directory
Package list missing or not up-to-date, generating it.

Building package index...
apk-mbedtls - 3.0.2-r2
...
zlib - 1.3.1-r1
real    0m 23.59s
user    0m 3.21s
sys     0m 2.46s

/workdir/bin/targets/malta/le/openwrt-imagebuilder-malta-le.Linux-x86_64 $ time make manifest PACKAGES="kmod-r8169 jq jq-full dnsmasq-dhcpv6 iw kmod-ath10k-ct ethtool ethtool-full ca-certificat
es wget-ssl -wpad-basic-mbedtls wpad-basic-wolfssl kmod-r8127 busybox-selinux kmod-r8168 sqlite3-cli"
apk-mbedtls - 3.0.2-r2
...
wpad-basic-wolfssl - 2025.08.26~ca266cc2-r1
zlib - 1.3.1-r1
real    0m 2.28s
user    0m 0.62s
sys     0m 0.69s
```
