### PR TITLE
openssl: update to 3.5.5

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.5.4
-PKG_RELEASE:=2
+PKG_VERSION:=3.5.5
+PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
 PKG_BUILD_PARALLEL:=1
@@ -21,7 +21,7 @@ PKG_SOURCE_URL:= \
 	https://www.openssl.org/source/old/$(PKG_BASE)/ \
 	https://github.com/openssl/openssl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 
-PKG_HASH:=967311f84955316969bdb1d8d4b983718ef42338639c621ec4c34fddef355e99
+PKG_HASH:=b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt

--- a/package/libs/openssl/patches/010-fix-aes-gcm-siv-cipher.patch
+++ b/package/libs/openssl/patches/010-fix-aes-gcm-siv-cipher.patch
@@ -43,7 +43,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 --- a/providers/implementations/ciphers/cipher_aes_siv.c
 +++ b/providers/implementations/ciphers/cipher_aes_siv.c
 @@ -114,6 +114,7 @@ static int siv_cipher(void *vctx, unsign
-                       size_t outsize, const unsigned char *in, size_t inl)
+     size_t outsize, const unsigned char *in, size_t inl)
  {
      PROV_AES_SIV_CTX *ctx = (PROV_AES_SIV_CTX *)vctx;
 +    static const unsigned char empty;

--- a/package/libs/openssl/patches/140-allow-prefer-chacha20.patch
+++ b/package/libs/openssl/patches/140-allow-prefer-chacha20.patch
@@ -16,9 +16,9 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
 --- a/ssl/ssl_ciph.c
 +++ b/ssl/ssl_ciph.c
-@@ -1488,11 +1488,29 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1471,11 +1471,29 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
      ssl_cipher_apply_rule(0, SSL_kECDHE, 0, 0, 0, 0, 0, CIPHER_DEL, -1, &head,
-                           &tail);
+         &tail);
  
 +    /*
 +     * If OPENSSL_PREFER_CHACHA_OVER_GCM is defined, ChaCha20_Poly1305
@@ -33,20 +33,20 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 +
 +#ifdef OPENSSL_PREFER_CHACHA_OVER_GCM
 +    ssl_cipher_apply_rule(0, 0, 0, SSL_CHACHA20, 0, 0, 0, CIPHER_ADD, -1,
-+                          &head, &tail);
++        &head, &tail);
 +    ssl_cipher_apply_rule(0, 0, 0, SSL_AESGCM, 0, 0, 0, CIPHER_ADD, -1,
-+                          &head, &tail);
++        &head, &tail);
 +#else
      /* Within each strength group, we prefer GCM over CHACHA... */
      ssl_cipher_apply_rule(0, 0, 0, SSL_AESGCM, 0, 0, 0, CIPHER_ADD, -1,
-                           &head, &tail);
+         &head, &tail);
      ssl_cipher_apply_rule(0, 0, 0, SSL_CHACHA20, 0, 0, 0, CIPHER_ADD, -1,
-                           &head, &tail);
+         &head, &tail);
 +#endif
  
      /*
       * ...and generally, our preferred cipher is AES.
-@@ -1547,7 +1565,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
+@@ -1530,7 +1548,7 @@ STACK_OF(SSL_CIPHER) *ssl_create_cipher_
       * Within each group, ciphers remain sorted by strength and previous
       * preference, i.e.,
       * 1) ECDHE > DHE
@@ -55,7 +55,7 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
       * 3) AES > rest
       * 4) TLS 1.2 > legacy
       *
-@@ -2246,7 +2264,13 @@ const char *OSSL_default_cipher_list(voi
+@@ -2232,7 +2250,13 @@ const char *OSSL_default_cipher_list(voi
   */
  const char *OSSL_default_ciphersuites(void)
  {
@@ -71,22 +71,22 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
  }
 --- a/include/openssl/ssl.h.in
 +++ b/include/openssl/ssl.h.in
-@@ -199,9 +199,15 @@ extern "C" {
+@@ -201,9 +201,15 @@ extern "C" {
   * DEPRECATED IN 3.0.0, in favor of OSSL_default_ciphersuites()
   * Update both macro and function simultaneously
   */
--#  define TLS_DEFAULT_CIPHERSUITES "TLS_AES_256_GCM_SHA384:" \
--                                   "TLS_CHACHA20_POLY1305_SHA256:" \
--                                   "TLS_AES_128_GCM_SHA256"
-+#  ifdef OPENSSL_PREFER_CHACHA_OVER_GCM
-+#   define TLS_DEFAULT_CIPHERSUITES "TLS_CHACHA20_POLY1305_SHA256:" \
-+                                    "TLS_AES_256_GCM_SHA384:" \
-+                                    "TLS_AES_128_GCM_SHA256"
-+#  else
-+#   define TLS_DEFAULT_CIPHERSUITES "TLS_AES_256_GCM_SHA384:" \
-+                                    "TLS_CHACHA20_POLY1305_SHA256:" \
-+                                    "TLS_AES_128_GCM_SHA256"
-+#  endif
- # endif
+-#define TLS_DEFAULT_CIPHERSUITES "TLS_AES_256_GCM_SHA384:"       \
+-                                 "TLS_CHACHA20_POLY1305_SHA256:" \
+-                                 "TLS_AES_128_GCM_SHA256"
++#ifdef OPENSSL_PREFER_CHACHA_OVER_GCM
++    #define TLS_DEFAULT_CIPHERSUITES "TLS_CHACHA20_POLY1305_SHA256:" \
++                                     "TLS_AES_256_GCM_SHA384:"       \
++                                     "TLS_AES_128_GCM_SHA256"
++#else
++    #define TLS_DEFAULT_CIPHERSUITES "TLS_AES_256_GCM_SHA384:"       \
++                                     "TLS_CHACHA20_POLY1305_SHA256:" \
++                                     "TLS_AES_128_GCM_SHA256"
++#endif
+ #endif
  /*
   * As of OpenSSL 1.0.0, ssl_create_cipher_list() in ssl/ssl_ciph.c always

--- a/package/libs/openssl/patches/500-e_devcrypto-default-to-not-use-digests-in-engine.patch
+++ b/package/libs/openssl/patches/500-e_devcrypto-default-to-not-use-digests-in-engine.patch
@@ -21,21 +21,21 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
 --- a/engines/e_devcrypto.c
 +++ b/engines/e_devcrypto.c
-@@ -906,7 +906,7 @@ static void prepare_digest_methods(void)
+@@ -887,7 +887,7 @@ static void prepare_digest_methods(void)
      for (i = 0, known_digest_nids_amount = 0; i < OSSL_NELEM(digest_data);
-          i++) {
+         i++) {
  
 -        selected_digests[i] = 1;
 +        selected_digests[i] = 0;
  
          /*
           * Check that the digest is usable
-@@ -1120,7 +1120,7 @@ static const ENGINE_CMD_DEFN devcrypto_c
+@@ -1096,7 +1096,7 @@ static const ENGINE_CMD_DEFN devcrypto_c
  #ifdef IMPLEMENT_DIGEST
-    {DEVCRYPTO_CMD_DIGESTS,
-     "DIGESTS",
--    "either ALL, NONE, or a comma-separated list of digests to enable [default=ALL]",
-+    "either ALL, NONE, or a comma-separated list of digests to enable [default=NONE]",
-     ENGINE_CMD_FLAG_STRING},
+     { DEVCRYPTO_CMD_DIGESTS,
+         "DIGESTS",
+-        "either ALL, NONE, or a comma-separated list of digests to enable [default=ALL]",
++        "either ALL, NONE, or a comma-separated list of digests to enable [default=NONE]",
+         ENGINE_CMD_FLAG_STRING },
  #endif
  

--- a/package/libs/openssl/patches/510-e_devcrypto-ignore-error-when-closing-session.patch
+++ b/package/libs/openssl/patches/510-e_devcrypto-ignore-error-when-closing-session.patch
@@ -10,12 +10,11 @@ Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
 
 --- a/engines/e_devcrypto.c
 +++ b/engines/e_devcrypto.c
-@@ -212,9 +212,8 @@ static int cipher_init(EVP_CIPHER_CTX *c
+@@ -211,8 +211,8 @@ static int cipher_init(EVP_CIPHER_CTX *c
      int ret;
  
      /* cleanup a previous session */
--    if (cipher_ctx->sess.ses != 0 &&
--        clean_devcrypto_session(&cipher_ctx->sess) == 0)
+-    if (cipher_ctx->sess.ses != 0 && clean_devcrypto_session(&cipher_ctx->sess) == 0)
 -        return 0;
 +    if (cipher_ctx->sess.ses != 0)
 +        clean_devcrypto_session(&cipher_ctx->sess);


### PR DESCRIPTION
This release incorporates the following bug fixes and mitigations:

  fixed Improper validation of PBMAC1 parameters in PKCS#12 MAC verification.
  (CVE-2025-11187)

  fixed Stack buffer overflow in CMS AuthEnvelopedData parsing.
  (CVE-2025-15467)

  fixed NULL dereference in SSL_CIPHER_find  () function on unknown cipher ID.
  (CVE-2025-15468)

  fixed openssl dgst one-shot codepath silently truncates inputs >16 MiB.
  (CVE-2025-15469)

  fixed TLS 1.3 CompressedCertificate excessive memory allocation.
  (CVE-2025-66199)

  fixed Heap out-of-bounds write in BIO_f_linebuffer on short writes.
  (CVE-2025-68160)

  fixed Unauthenticated/unencrypted trailing bytes with low-level OCB function calls.
  (CVE-2025-69418)

  fixed Out of bounds write in PKCS12_get_friendlyname  () UTF-8 conversion.
  (CVE-2025-69419)

  fixed Missing ASN1_TYPE validation in TS_RESP_verify_response  () function.
  (CVE-2025-69420)

  fixed NULL Pointer Dereference in PKCS12_item_decrypt_d2i_ex  () function.
  (CVE-2025-69421)

  fixed Missing ASN1_TYPE validation in PKCS#12 parsing.
  (CVE-2026-22795)

  fixed ASN1_TYPE Type Confusion in the PKCS7_digest_from_attributes  () function.
  (CVE-2026-22796)

Adjust patches due to formatting changes.

Runtime tested: Xiaomi redmi AX6S, Asus RT-57Uv3