### PR TITLE
ext-toolchain: fix gcc wrapper tools pattern matching

### DIFF
--- a/scripts/ext-toolchain.sh
+++ b/scripts/ext-toolchain.sh
@@ -282,6 +282,9 @@ wrap_bins() {
 				fi
 
 				case "${cmd##*/}" in
+					*-gcc-ar|*-gcc-nm|*-gcc-ranlib)
+						wrap_bin_other "$out" "$bin"
+					;;
 					*-*cc|*-*cc-*|*-*++|*-*++-*|*-cpp)
 						wrap_bin_cc "$out" "$bin"
 					;;


### PR DESCRIPTION
## Summary

This PR intends to provide a fix for the external toolchain wrapper generation script, which incorrectly applies compiler flags to **gcc-ar**, **gcc-nm**, and **gcc-ranlib** tools. This causes them to be wrapped as compilers and receive **CFLAGS**, breaking builds with errors like:
```
ar: two different operation options specified
```

Closes #21859