### PR TITLE
[24.10] dwc3 gadget

### DIFF
--- a/package/kernel/linux/modules/usb.mk
+++ b/package/kernel/linux/modules/usb.mk
@@ -498,17 +498,28 @@ $(eval $(call KernelPackage,usb-cdns3))
 
 
 define KernelPackage/usb-dwc3
+  SUBMENU:=$(USB_MENU)
   TITLE:=DWC3 USB controller driver
+  DEPENDS:=+USB_GADGET_SUPPORT:kmod-usb-gadget \
+	   +USB_SUPPORT:kmod-usb-core \
+	   +kmod-usb-roles
   KCONFIG:= \
 	CONFIG_USB_DWC3 \
-	CONFIG_USB_DWC3_HOST=y \
-	CONFIG_USB_DWC3_GADGET=n \
-	CONFIG_USB_DWC3_DUAL_ROLE=n \
 	CONFIG_USB_DWC3_DEBUG=n \
 	CONFIG_USB_DWC3_VERBOSE=n
+ifeq ($(CONFIG_USB_SUPPORT)$(CONFIG_USB_GADGET_SUPPORT),yy)
+  KCONFIG+= \
+	CONFIG_USB_DWC3_HOST=n \
+	CONFIG_USB_DWC3_GADGET=n \
+	CONFIG_USB_DWC3_DUAL_ROLE=y
+else
+  KCONFIG+= \
+	CONFIG_USB_DWC3_HOST=$(if $(CONFIG_USB_SUPPORT),y,n) \
+	CONFIG_USB_DWC3_GADGET=$(if $(CONFIG_USB_GADGET_SUPPORT),y,n) \
+	CONFIG_USB_DWC3_DUAL_ROLE=n
+endif
   FILES:= $(LINUX_DIR)/drivers/usb/dwc3/dwc3.ko
   AUTOLOAD:=$(call AutoLoad,54,dwc3,1)
-  $(call AddDepends/usb)
 endef
 
 define KernelPackage/usb-dwc3/description


### PR DESCRIPTION
backport "kernel: usb: kmod-usb-dwc3: add gadget and dual-role modes support" to build DWC3 driver in the right mode:
  - host mode if kernel have usb host support only.
  - gadget mode if kernel have usbgadget support only.
  - dual-role mode if kernel have both usb host and usbgadget support.

