### PR TITLE
qualcommax: ipq807x: fix bootconfig script sysupgrade problem

### DIFF
--- a/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq60xx/base-files/lib/upgrade/platform.sh
@@ -3,7 +3,7 @@
 PART_NAME=firmware
 REQUIRE_IMAGE_METADATA=1
 
-RAMFS_COPY_BIN='fw_printenv fw_setenv head'
+RAMFS_COPY_BIN='fw_printenv fw_setenv head seq'
 RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
 remove_oem_ubi_volume() {

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -1,7 +1,7 @@
 PART_NAME=firmware
 REQUIRE_IMAGE_METADATA=1
 
-RAMFS_COPY_BIN='fw_printenv fw_setenv head'
+RAMFS_COPY_BIN='fw_printenv fw_setenv head seq'
 RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
 xiaomi_initramfs_prepare() {


### PR DESCRIPTION
This is an interesting one for me and I am open to suggestions. 

Sysupgrade using this code path fails because /usr/bin/seq is not copied over to the ramdisk that is used by stage2 of sysupgrade.

```
Tue Jan 27 09:06:09 UTC 2026 upgrade: Performing system upgrade...
336+0 records in
336+0 records out
/lib/upgrade/do_stage2: line 50: seq: not found
Could not get partition index for rootfs in /tmp/mtd2.bin
Tue Jan 27 09:06:09 UTC 2026 upgrade: failed to read bootconfig index...
sysupgrade failed
```

However the same or similar code (using seq) is used elsewhere apparently without issues?

Qihoo 360v6:
https://github.com/openwrt/openwrt/blob/bc8424ab89cd64d94637a0580c9c7723c7c50550/target/linux/qualcommax/ipq60xx/base-files/lib/functions/bootconfig.sh#L50
Linksys MX6200
https://github.com/openwrt/openwrt/blob/bc8424ab89cd64d94637a0580c9c7723c7c50550/target/linux/qualcommax/ipq50xx/base-files/lib/functions/bootconfig.sh#L50

Any thoughts @robimarko @qzydustin @georgemoussalem?