### PR TITLE
airoha: an7581: add Nokia Valyrian support

### DIFF
--- a/package/boot/uboot-airoha/Makefile
+++ b/package/boot/uboot-airoha/Makefile
@@ -54,11 +54,22 @@ define U-Boot/an7581_gemtek_w1700k
   UBOOT_IMAGE:=u-boot.bin
 endef
 
+define U-Boot/an7581_nokia_valyrian
+  NAME:=Nokia Valyrian
+  UBOOT_CONFIG:=an7581_nokia_valyrian
+  BUILD_DEVICES:=nokia_valyrian
+  BUILD_SUBTARGET:=an7581
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_IMAGE:=an7581-bl2.bin
+  BL31_IMAGE:=an7581-bl31.bin
+endef
+
 UBOOT_TARGETS := \
 	en7523_rfb \
 	an7581_rfb \
 	an7583_rfb \
-	an7581_gemtek_w1700k
+	an7581_gemtek_w1700k \
+	an7581_nokia_valyrian
 
 UBOOT_CUSTOMIZE_CONFIG := \
 	--disable TOOLS_KWBIMAGE \

--- a/package/boot/uboot-airoha/patches/400-add-nokia-valyrian.patch
+++ b/package/boot/uboot-airoha/patches/400-add-nokia-valyrian.patch
@@ -1,0 +1,242 @@
+--- /dev/null
++++ b/arch/arm/dts/an7581-nokia-valyrian-u-boot.dtsi
+@@ -0,0 +1,104 @@
++// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++
++/ {
++	/* When running as a first-stage bootloader this isn't filled in automatically */
++	memory@80000000 {
++		device_type = "memory";
++		reg = <0x0 0x80000000 0x0 0x40000000>;
++	};
++};
++
++#include "an7581-u-boot.dtsi"
++
++&mmc0 {
++	status = "okay";
++
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	card@0 {
++		compatible = "mmc-card";
++		reg = <0>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			bl@800 {
++				label = "bl2";
++				reg = <0x00000800 0x0001f800>;
++			};
++
++			bootloader@20000 {
++				label = "bootloader";
++				reg = <0x00020000 0x000e0000>;
++			};
++
++			bootloader-inactive@100000 {
++				label = "bootloader-inactive";
++				reg = <0x00100000 0x000e0000>;
++			};
++
++			u-boot-env@1e0000 {
++				label = "u-boot-env";
++				reg = <0x001e0000 0x00020000>;
++
++				u-boot,mmc-env-partition;
++			};
++
++			factory@200000 {
++				label = "factory";
++				reg = <0x00200000 0x00800000>;
++			};
++
++			mfgdata@a00000 {
++				label = "mfgdata";
++				reg = <0x00a00000 0x00100000>;
++			};
++
++			kernel-active@b00000 {
++				label = "kernel-active";
++				reg = <0x00b00000 0x00800000>;
++			};
++
++			kernel-inactive@1300000 {
++				label = "kernel-inactive";
++				reg = <0x01300000 0x00800000>;
++			};
++
++			rootfs-active@1b00000 {
++				label = "rootfs-active";
++				reg = <0x01b00000 0x06400000>;
++			};
++
++			rootfs-inactive@7f00000 {
++				label = "rootfs-inactive";
++				reg = <0x07f00000 0x06400000>;
++			};
++
++			rootfs-data@e300000 {
++				label = "rootfs_data";
++				reg = <0x0e300000 0x02000000>;
++			};
++
++			securestore@10300000 {
++				label = "securestore";
++				reg = <0x10300000 0x1000000>;
++			};
++
++			lcm-data@11300000 {
++				label = "lcm_data";
++				reg = <0x11300000 0x40000000>;
++			};
++		};
++	};
++};
++
++&eth {
++	status = "okay";
++};
++
++&gdm1 {
++	status = "okay";
++};
+--- /dev/null
++++ b/configs/an7581_nokia_valyrian_defconfig
+@@ -0,0 +1,85 @@
++CONFIG_ARM=y
++CONFIG_ARCH_AIROHA=y
++CONFIG_AUTOBOOT_USE_MENUKEY=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_TARGET_AN7581=y
++CONFIG_TEXT_BASE=0x81e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_ENV_SIZE=0x20000
++CONFIG_ENV_OFFSET=0x1e0000
++CONFIG_DM_GPIO=y
++CONFIG_DEFAULT_DEVICE_TREE="airoha/an7581-nokia-valyrian"
++CONFIG_SYS_LOAD_ADDR=0x81800000
++CONFIG_BUILD_TARGET="u-boot.bin"
++# CONFIG_EFI_LOADER is not set
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_BOOTDELAY=3
++CONFIG_DEFAULT_FDT_FILE="airoha/an7581-nokia-valyrian.dtb"
++CONFIG_SYS_PBSIZE=1049
++CONFIG_SYS_CONSOLE_IS_IN_ENV=y
++# CONFIG_DISPLAY_BOARDINFO is not set
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="AN7581> "
++CONFIG_SYS_MAXARGS=8
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_BOOTMENU=y
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_XIMG is not set
++CONFIG_CMD_BIND=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_SF_TEST=y
++CONFIG_CMD_SPI=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_PING=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_FAT=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_CMD_MTDPARTS=y
++CONFIG_CMD_LOG=y
++CONFIG_OF_UPSTREAM=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_SYS_RX_ETH_BUFFER=8
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_CLK=y
++CONFIG_DMA=y
++CONFIG_LED=y
++CONFIG_LED_GPIO=y
++CONFIG_MMC_HS200_SUPPORT=y
++CONFIG_MMC_MTK=y
++CONFIG_AIROHA_ETH=y
++CONFIG_DM_MDIO=y
++CONFIG_CMD_MII=y
++CONFIG_CMD_MDIO=y
++CONFIG_PCS_AIROHA_AN7581=y
++CONFIG_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_RAM=y
++CONFIG_DM_SERIAL=y
++CONFIG_SYS_NS16550=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_AIROHA_SNFI_SPI=y
++CONFIG_SHA512=y
++CONFIG_USE_DEFAULT_ENV_FILE=y
++CONFIG_DEFAULT_ENV_FILE="defenvs/an7581_nokia_valyrian_env"
++CONFIG_FIP_LOADER=y
++CONFIG_PCS_AIROHA_AN7581=y
++CONFIG_PHY_AIROHA_EN8811=y
++CONFIG_PHY_ANEG_TIMEOUT=10000
++CONFIG_PHY_ETHERNET_ID=y
++CONFIG_PHY_AS21XXX=y
+--- /dev/null
++++ b/defenvs/an7581_nokia_valyrian_env
+@@ -0,0 +1,25 @@
++loadaddr=0x90000000
++ipaddr=192.168.1.1
++serverip=192.168.1.10
++emmc_bootfile_bl2=openwrt-airoha-an7581-nokia_valyrian-preloader.bin
++emmc_bootfile_fip=openwrt-airoha-an7581-nokia_valyrian-bl31-uboot.fip
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )  [0;36m[EMMC][0m
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=[31mLoad BL31+U-Boot FIP via TFTP then write to eMMC.[0m=run emmc_boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_2=[31mLoad BL2 preloader via TFTP then write to eMMC.[0m=run emmc_boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_3=Reboot.=reset
++bootmenu_4=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_default=bootm
++reset_factory=eraseenv && reset
++emmc_boot_tftp_write_fip=tftpboot $loadaddr $emmc_bootfile_fip && run emmc_write_fip
++emmc_boot_tftp_write_bl2=tftpboot $loadaddr $emmc_bootfile_bl2 && run emmc_write_bl2
++emmc_write_bl2=mmc erase 0x4 0xfc && mmc write $fileaddr 0x4 0xfc
++emmc_write_fip=mmc erase 0x100 0x700 && mmc write $fileaddr 0x100 0x700
++_init_env=setenv _init_env ; saveenv
++_firstboot=setenv _firstboot ; run _switch_to_menu ; run _init_env ; bootmenu
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"
+--- /dev/null
++++ b/dts/upstream/src/arm64/airoha/an7581-nokia-valyrian.dts
+@@ -0,0 +1,16 @@
++// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
++/dts-v1/;
++
++#include <dt-bindings/leds/common.h>
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include "en7581.dtsi"
++
++/ {
++	model = "Nokia Valyrian";
++	compatible = "nokia,valyrian", "airoha,an7581", "airoha,en7581";
++
++	chosen {
++		stdout-path = &uart1;
++	};
++};

--- a/target/linux/airoha/an7581/base-files/etc/board.d/02_network
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/02_network
@@ -17,6 +17,8 @@ an7581_setup_interfaces()
 	gemtek,w1700k-ubi)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;
+	nokia,valyrian)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 10g" "wan"
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"
 		;;

--- a/target/linux/airoha/dts/an7581-nokia-valyrian.dts
+++ b/target/linux/airoha/dts/an7581-nokia-valyrian.dts
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include "an7581.dtsi"
+
+/ {
+	model = "Nokia Valyrian";
+	compatible = "nokia,valyrian", "airoha,an7581", "airoha,en7581";
+
+	aliases {
+		serial0 = &uart1;
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+	};
+
+	chosen {
+		bootargs = "earlycon";
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x0 0x80000000 0x2 0x00000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		btn-0 {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&en7581_pinctrl 0 GPIO_ACTIVE_LOW>;
+		};
+
+		btn-1 {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&en7581_pinctrl 13 GPIO_ACTIVE_LOW>;
+		};
+
+		btn-2 {
+			label = "wifi";
+			linux,code = <KEY_RFKILL>;
+			gpios = <&en7581_pinctrl 16 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&leds_shift_reg 0 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&leds_shift_reg 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-2 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&leds_shift_reg 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_white: led-3 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&leds_shift_reg 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_AMBER>;
+			gpios = <&leds_shift_reg 4 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&leds_shift_reg 5 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led-6 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&leds_shift_reg 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led-7 {
+			function = LED_FUNCTION_MOBILE;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&leds_shift_reg 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led-8 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&leds_shift_reg 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-9 {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&leds_shift_reg 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-10 {
+			function = LED_FUNCTION_USB;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&leds_shift_reg 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	sfp: sfp {
+		compatible = "sff,sfp";
+
+		i2c-bus = <&i2c0>;
+
+		mod-def0-gpios = <&en7581_pinctrl 33 GPIO_ACTIVE_LOW>;
+		los-gpios = <&en7581_pinctrl 36 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpios = <&en7581_pinctrl 41 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpios = <&en7581_pinctrl 40 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <3000>;
+	};
+
+	i2c-1 {
+		compatible = "i2c-gpio";
+
+		sda-gpios = <&en7581_pinctrl 2 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&en7581_pinctrl 1 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;	/* ~100 kHz */
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		adc@40 {
+			compatible = "richtek,rtq6059";
+			reg = <0x40>;
+
+			#io-channel-cells = <1>;
+		};
+	};
+
+	spi-0 {
+                compatible = "spi-gpio";
+
+                sck-gpios = <&en7581_pinctrl 4 GPIO_ACTIVE_HIGH>;
+                mosi-gpios = <&en7581_pinctrl 3 GPIO_ACTIVE_HIGH>;
+                cs-gpios = <&en7581_pinctrl 30 GPIO_ACTIVE_LOW>;
+
+                num-chipselects = <1>;
+
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                leds_shift_reg: gpio-expander@0 {
+                        compatible = "fairchild,74hc595";
+                        reg = <0>;
+
+			enable-gpios = <&en7581_pinctrl 14 GPIO_ACTIVE_LOW>;
+
+                        gpio-controller;
+
+                        registers-number = <2>;
+                        spi-max-frequency = <100000>;
+
+                        #gpio-cells = <2>;
+                };
+        };
+};
+
+&en7581_pinctrl {
+	gpio-ranges = <&en7581_pinctrl 0 13 47>;
+
+	pcie1_rst_pins: pcie1-rst-pins {
+		conf {
+			pins = "pcie_reset1";
+			drive-open-drain = <1>;
+		};
+	};
+
+	pcie2_rst_pins: pcie2-rst-pins {
+		conf {
+			pins = "pcie_reset2";
+			drive-open-drain = <1>;
+		};
+	};
+
+	gswp1_led0_pins: gswp1-led1-pins {
+		mux {
+			function = "phy1_led0";
+			pins = "gpio43";
+		};
+	};
+
+	gswp2_led0_pins: gswp2-led1-pins {
+		mux {
+			function = "phy2_led0";
+			pins = "gpio44";
+		};
+	};
+
+	gswp3_led0_pins: gswp3-led1-pins {
+		mux {
+			function = "phy3_led0";
+			pins = "gpio45";
+		};
+	};
+
+	mmc_pins: mmc-pins {
+		mux {
+			function = "emmc";
+			groups = "emmc";
+		};
+	};
+};
+
+&mmc0 {
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc_pins>;
+	pinctrl-1 = <&mmc_pins>;
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			bl@800 {
+				label = "bl2";
+				reg = <0x00000800 0x0001f800>;
+			};
+
+			bootloader@20000 {
+				label = "bootloader";
+				reg = <0x00020000 0x000e0000>;
+			};
+
+			bootloader-inactive@100000 {
+				label = "bootloader-inactive";
+				reg = <0x00100000 0x000e0000>;
+			};
+
+			u-boot-env@1e0000 {
+				label = "u-boot-env";
+				reg = <0x001e0000 0x00020000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env-layout";
+				};
+			};
+
+			factory@200000 {
+				label = "factory";
+				reg = <0x00200000 0x00800000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x40000 0x1e00>;
+					};
+
+					mac_factory_2c0000: mac@2c0000 {
+						compatible = "mac-base";
+						reg = <0x2c0000 0x6>;
+
+						#nvmem-cell-cells = <1>;
+					};
+
+					onu_type_factory_2e0000: onu_type@2e0000 {
+						reg = <0x2e0000 0x10>;
+					};
+
+					board_config_factory_2e0010: board_config@2e0010 {
+						reg = <0x2e0010 0x8>;
+					};
+				};
+			};
+
+			mfgdata@a00000 {
+				label = "mfgdata";
+				reg = <0x00a00000 0x00100000>;
+			};
+
+			kernel-active@b00000 {
+				label = "kernel-active";
+				reg = <0x00b00000 0x00800000>;
+			};
+
+			kernel-inactive@1300000 {
+				label = "kernel-inactive";
+				reg = <0x01300000 0x00800000>;
+			};
+
+			rootfs-active@1b00000 {
+				label = "rootfs-active";
+				reg = <0x01b00000 0x06400000>;
+			};
+
+			rootfs-inactive@7f00000 {
+				label = "rootfs-inactive";
+				reg = <0x07f00000 0x06400000>;
+			};
+
+			rootfs-data@e300000 {
+				label = "rootfs_data";
+				reg = <0x0e300000 0x02000000>;
+			};
+
+			securestore@10300000 {
+				label = "securestore";
+				reg = <0x10300000 0x1000000>;
+			};
+
+			lcm-data@11300000 {
+				label = "lcm_data";
+				reg = <0x11300000 0x40000000>;
+			};
+		};
+	};
+};
+
+&usb0 {
+	status = "okay";
+
+	mediatek,u3p-dis-msk = <0x1>;
+	phys = <&usb0_phy PHY_TYPE_USB2>;
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&pciephy {
+	status = "okay";
+};
+
+&pcie0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_rst_pins>;
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
+
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+
+			band@0 {
+				/* 2.4 GHz */
+				reg = <0>;
+				nvmem-cells = <&mac_factory_2c0000 6>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@1 {
+				/* 5 GHz */
+				reg = <1>;
+				nvmem-cells = <&mac_factory_2c0000 7>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			band@2 {
+				/* 6 GHz */
+				reg = <2>;
+				nvmem-cells =<&mac_factory_2c0000 8>;
+				nvmem-cell-names = "mac-address";
+			};
+		};
+	};
+};
+
+&pcie2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie2_rst_pins>;
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+};
+
+&gdm1 {
+	status = "okay";
+
+	nvmem-cells = <&mac_factory_2c0000 3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	as21xx: ethernet-phy@1c {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <0x1c>;
+
+		firmware-name = "as21x1x_fw.bin";
+
+		reset-deassert-us = <1000000>;
+		reset-assert-us = <1000000>;
+		reset-gpios = <&en7581_pinctrl 31 GPIO_ACTIVE_LOW>;
+
+		leds {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			led@0 {
+				reg = <0>;
+				color = <LED_COLOR_ID_GREEN>;
+				function = LED_FUNCTION_LAN;
+				default-state = "keep";
+			};
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+};
+
+&pon_pcs {
+	status = "okay";
+};
+
+&gdm2 {
+	status = "okay";
+
+	sfp = <&sfp>;
+
+	managed = "in-band-status";
+	phy-mode = "usxgmii";
+
+	nvmem-cells = <&mac_factory_2c0000 4>;
+	nvmem-cell-names = "mac-address";
+
+	openwrt,netdev-name = "wan";
+};
+
+&eth_pcs {
+	status = "okay";
+};
+
+&gdm4 {
+	status = "okay";
+
+	managed = "in-band-status";
+	phy-handle = <&as21xx>;
+	phy-mode = "usxgmii";
+
+	nvmem-cells = <&mac_factory_2c0000 5>;
+	nvmem-cell-names = "mac-address";
+
+	openwrt,netdev-name = "10g";
+};
+
+&gsw_port1 {
+	label = "lan1";
+
+	status = "okay";
+};
+
+&gsw_phy1 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp1_led0_pins>;
+
+	status = "okay";
+};
+
+&gsw_phy1_led0 {
+	function = LED_FUNCTION_LAN;
+	active-low;
+
+	status = "okay";
+};
+
+&gsw_port2 {
+	label = "lan2";
+
+	status = "okay";
+};
+
+&gsw_phy2 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp2_led0_pins>;
+
+	status = "okay";
+};
+
+&gsw_phy2_led0 {
+	function = LED_FUNCTION_LAN;
+	active-low;
+
+	status = "okay";
+};
+
+&gsw_port3 {
+	label = "lan3";
+
+	status = "okay";
+};
+
+&gsw_phy3 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gswp3_led0_pins>;
+
+	status = "okay";
+};
+
+&gsw_phy3_led0 {
+	function = LED_FUNCTION_LAN;
+	active-low;
+
+	status = "okay";
+};

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -104,3 +104,17 @@ define Device/gemtek_w1700k-ubi
   SOC := an7581
 endef
 TARGET_DEVICES += gemtek_w1700k-ubi
+
+define Device/nokia_valyrian
+  DEVICE_VENDOR := Nokia
+  DEVICE_MODEL := Valyrian
+  DEVICE_DTS := an7581-nokia-valyrian
+  DEVICE_PACKAGES := kmod-spi-gpio kmod-gpio-nxp-74hc164 kmod-leds-gpio \
+    kmod-i2c-an7581 kmod-i2c-gpio kmod-iio-richtek-rtq6056 \
+    kmod-sfp kmod-phy-aeonsemi-as21xxx \
+    kmod-mt7996-firmware
+  ARTIFACT/preloader.bin := an7581-preloader nokia_valyrian
+  ARTIFACT/bl31-uboot.fip := an7581-bl31-uboot nokia_valyrian
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+endef
+TARGET_DEVICES += nokia_valyrian


### PR DESCRIPTION
Add support for Nokia Valyrian, based on Airoha AN7581 SoC.
