### PR TITLE
Fix/p2812 uboot env

### DIFF
--- a/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xrx200/base-files/etc/board.d/02_network
@@ -93,7 +93,8 @@ lantiq_setup_macs()
 	lantiq,easy80920-nor|\
 	zyxel,p-2812hnu-f1|\
 	zyxel,p-2812hnu-f3)
-		wan_mac=$(macaddr_add "$(mtd_get_mac_ascii u-boot-env ethaddr)" 1)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
 		;;
 	arcadyan,vgv7519-brn|\
 	arcadyan,vgv7519-nor|\

--- a/target/linux/lantiq/xrx200/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/lantiq/xrx200/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -1,0 +1,23 @@
+. /lib/functions.sh
+. /lib/functions/system.sh
+
+preinit_set_mac_address() {
+	case $(board_name) in
+	lantiq,easy80920-nand|\
+	lantiq,easy80920-nor|\
+	zyxel,p-2812hnu-f1|\
+	zyxel,p-2812hnu-f3)
+		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
+		[ -n "$lan_mac" ] || return
+
+		# Set eth0 (DSA master) MAC
+		ip link set dev eth0 address "$lan_mac"
+
+		# Set wan port MAC (lan_mac + 1)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		[ -n "$wan_mac" ] && ip link set dev wan address "$wan_mac"
+		;;
+	esac
+}
+
+boot_hook_add preinit_main preinit_set_mac_address


### PR DESCRIPTION
 ## Summary                                                                                                                    
  Fix random MAC address assignment on Zyxel P-2812HNU-F1/F3 and Lantiq Easy80920 devices.                                      
                                                                                                                                
  ## Problem                                                                                                                    
  On OpenWrt 25.12-SNAPSHOT, eth0 (DSA master) and wan port get random MAC addresses on every boot because:                     
  1. Kernel driver `lantiq_xrx200.c` calls `of_get_ethdev_address()` which fails, falling back to `eth_hw_addr_random()`        
  2. The board.d script was missing `lan_mac` variable assignment for these devices                                             
                                                                                                                                
  ## Solution                                                                                                                   
  - Add preinit script (`10_fix_eth_mac.sh`) to set eth0 and wan MAC addresses early in boot by reading from u-boot-env         
  - Fix board.d `02_network` script to properly set `lan_mac` variable                                                          
                                                                                                                                
  ## Testing                                                                                                                    
  Tested on Zyxel P-2812HNU-F1 hardware with OpenWrt 25.12-SNAPSHOT (r32295+191-c25265953b)                                     
                                                                                                                                
  **Before fix:**                                                                                                               
  - eth0: random MAC (changes every boot)                                                                                       
  - wan@eth0: random MAC                                                                                                        
                                                                                                                                
  **After fix:**                                                                                                                
  - eth0: correct MAC from u-boot ethaddr                                                                                       
  - wan@eth0: ethaddr + 1                                                                                                       
  - lan1-4: ethaddr