### PR TITLE
lantiq: xrx200: add NVMEM support for Zyxel P-2812HNU u-boot-env

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f1.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f1.dts
@@ -47,6 +47,7 @@
 
 				nvmem-layout {
 					compatible = "u-boot,env";
+					env-size = <0x2000>;
 
 					macaddr_uboot_ethaddr: ethaddr {
 						#nvmem-cell-cells = <1>;


### PR DESCRIPTION
  ## Summary                                                                                                                    
  - Add `env-size = <0x2000>` property to nvmem-layout in vr9_zyxel_p-2812hnu-f1.dts for proper CRC32 validation                
  - Enable NVMEM kernel config options (CONFIG_NVMEM, CONFIG_NVMEM_LAYOUTS, CONFIG_NVMEM_LAYOUT_U_BOOT_ENV, CONFIG_NVMEM_SYSFS) 
  in xrx200/config-6.12                                                                                                         
                                                                                                                                
  This allows the kernel's U-Boot environment NVMEM layout driver to correctly parse the u-boot-env partition and expose        
  environment variables via sysfs at `/sys/bus/nvmem/devices/*/nvmem`.                                                          
                                                                                                                                
  ## Test plan                                                                                                                  
  - [x] Verified NVMEM device appears under /sys/bus/nvmem/devices/                                                             
  - [x] Verified environment variables are accessible via sysfs                                                                 
  - [x] Tested on Zyxel P-2812HNU-F1 hardware