### PR TITLE
[RFC] implement generic bootflag machanism and tooling

### DIFF
--- a/package/utils/bootflag/Makefile
+++ b/package/utils/bootflag/Makefile
@@ -1,0 +1,36 @@
+#
+# Copyright (C) 2026 Michael Lotz <mmlr@mlotz.ch>
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bootflag
+PKG_RELEASE:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/bootflag
+	SECTION:=utils
+	CATEGORY:=Base system
+	TITLE:=Utility for reading and setting generic bootflags
+	MAINTAINER:=Michael Lotz <mmlr@mlotz.ch>
+endef
+
+define Package/bootflag/description
+	This package contains the bootflag utility to display and manipulate generic
+	bootflags. It can be used to display and select the active boot image in
+	dual-image setups for example.
+endef
+
+define Build/Compile
+endef
+
+define Package/bootflag/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) ./files/bootflag $(1)/usr/bin/bootflag
+endef
+
+$(eval $(call BuildPackage,bootflag))

--- a/package/utils/bootflag/files/bootflag
+++ b/package/utils/bootflag/files/bootflag
@@ -1,0 +1,182 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Copyright (C) 2026 Michael Lotz <mmlr@mlotz.ch>
+
+print_usage_and_exit() {
+	echo "usage: $0 [<options>] <command> <flag> [<arguments>]
+
+Commands:
+	list
+		List all available flags.
+
+	values <flag>
+		Prints the available named values of the flag, if present.
+
+	show <flag>
+		Prints the current value of the flag in human readable format.
+
+	get <flag>
+		Prints the raw value of the flag.
+
+	set <flag> <value>
+		Sets the value of the flag either by numeric value or label."
+
+	exit 1
+}
+
+find_flag_declaration() {
+	find /sys/firmware/devicetree -path "*/nvmem-layout/$1@*" | head -n1
+}
+
+find_flag_cell() {
+	find /sys/devices/platform -path "*/cells/$1@*" | head -n1
+}
+
+read_hex() {
+	hexdump -ve "$2/1 \"%02x\" \" \"" "$1" | sed 's/ $//'
+}
+
+write_hex() {
+	echo -ne $(echo "$1" | awk '{ gsub(/.{2}/, "\\\\x&") }1')
+}
+
+hex_sequence() {
+	WIDTH=$(($2 * 2))
+
+	for I in $(seq 0 "$1")
+	do
+		printf "%0${WIDTH}x\n" "$I"
+	done
+}
+
+get_flag_width() {
+	hexdump -ve '/4 "%u\n"' "$1/reg" | tail -n1
+}
+
+get_flag_labels() {
+	FLAG=$1
+
+	[ -r "$FLAG/value-labels" ] || return
+
+	WIDTH=$(get_flag_width "$FLAG")
+	LABELS=$(cat "$FLAG/value-labels" | tr "\0" " ")
+
+	if [ -r "$FLAG/values" ]
+	then
+		set -- $(read_hex "$FLAG/values" "$WIDTH")
+	else
+		COUNT=$(echo "$LABELS" | tr " " "\n" | wc -l)
+		set -- $(hex_sequence "$COUNT" "$WIDTH")
+	fi
+
+	for LABEL in $(cat "$FLAG/value-labels" | tr '\0' ' ')
+	do
+		echo "$1=$LABEL"
+		shift
+	done
+}
+
+get_flag_label_for_value() {
+	get_flag_labels "$1" | grep "^$2=" | cut -d'=' -f2
+}
+
+get_flag_value_for_label() {
+	get_flag_labels "$1" | grep "^.*=$2$" | cut -d'=' -f1
+}
+
+[ -z "$1" ] && print_usage_and_exit
+
+NAME="$2"
+
+if [ ! -z "$NAME" ]
+then
+	FLAG=$(find_flag_declaration "$NAME")
+	if [ -z "$FLAG" ]
+	then
+		echo "flag \"$NAME\" not found"
+		exit 2
+	fi
+fi
+
+case "$1" in
+	list)
+		[ $# -eq 1 ] || print_usage_and_exit
+
+		COMPATIBLES=$(find /sys/firmware/devicetree \
+			-path "*/nvmem-layout/*" -name "compatible" | sort)
+		for COMPATIBLE in $COMPATIBLES
+		do
+			[ $(cat "$COMPATIBLE") == "bootflag" ] || continue
+
+			CELL=$(dirname "$COMPATIBLE")
+
+			echo -n $(basename ${CELL%@*})
+			if [ ! -r "$CELL/label" ]
+			then
+				echo
+				continue
+			fi
+
+			echo " - $(cat "$CELL/label")"
+		done
+	;;
+
+	values)
+		[ $# -eq 2 ] || print_usage_and_exit
+
+		LABELS=$(get_flag_labels "$FLAG")
+
+		if [ -z "$LABELS" ]
+		then
+			echo "no value labels, use numeric values"
+		else
+			echo "$LABELS"
+		fi
+	;;
+
+	show|get)
+		[ $# -eq 2 ] || print_usage_and_exit
+
+		WIDTH=$(get_flag_width "$FLAG")
+		CELL=$(find_flag_cell "$NAME")
+		VALUE=$(read_hex "$CELL" "$WIDTH")
+
+		if [ "$1" == "get" ]
+		then
+			echo "$VALUE"
+		else
+			LABEL=$(get_flag_label_for_value "$FLAG" "$VALUE")
+			[ -z "$LABEL" ] || LABEL="=$LABEL"
+			echo "current \"$NAME\" value: $VALUE$LABEL"
+		fi
+	;;
+
+	set)
+		[ $# -eq 3 ] || print_usage_and_exit
+
+		CELL=$(find_flag_cell "$NAME")
+
+		VALUE=$(get_flag_value_for_label "$FLAG" "$3")
+		if [ -z "$VALUE" ]
+		then
+			if [ $(echo "$3" | grep -ci "^[0-9a-fA-F]*$") != 1 ]
+			then
+				echo "value \"$3\" not found for \"$NAME\""
+				exit 3
+			fi
+
+			VALUE="$3"
+		fi
+
+		LABEL=$(get_flag_label_for_value "$FLAG" "$VALUE")
+		[ -z "$LABEL" ] || LABEL="=$LABEL"
+
+		echo "setting \"$NAME\" value to $VALUE$LABEL"
+		write_hex "$VALUE" > "$CELL"
+	;;
+
+	*)
+		print_usage_and_exit
+	;;
+esac

--- a/target/linux/generic/pending-6.12/921-nvmem-fix-cell-write-clobber.patch
+++ b/target/linux/generic/pending-6.12/921-nvmem-fix-cell-write-clobber.patch
@@ -1,0 +1,51 @@
+From: Michael Lotz <mmlr@mlotz.ch>
+Subject: nvmem: fix cell write clobber of outside bits
+
+When a nvmem cell does not end on a byte boundary, the missing bits are
+filled by reading the pre-existing value. They are then masked and or-ed
+with the value in the buffer to be written, which gets its value from
+the input buffer. However, when the input buffer has bits set outside
+the width of the cell, those were never cleared. That allowed a nvmem
+cell write to clobber the remaining upper bits. Fix this by first
+clearing the bits of the buffer that are outside of the cell and only
+then or-ing the pre-existing value.
+
+Cell declaration:
+
+    status@0 {
+        reg = <0x0 0x1>;
+        bits = <2 2>;
+    };
+
+Existing value:  0x10
+Write value:     0xff
+Expected result: 0x1c
+Actual result:   0xfc
+
+So contrary to expectation the upper bits of the write buffer were
+written instead of being masked off.
+
+Signed-off-by: Michael Lotz <mmlr@mlotz.ch>
+--- a/drivers/nvmem/core.c
++++ b/drivers/nvmem/core.c
+@@ -1776,7 +1776,7 @@ static void *nvmem_cell_prepare_write_bu
+ {
+ 	struct nvmem_device *nvmem = cell->nvmem;
+ 	int i, rc, nbits, bit_offset = cell->bit_offset;
+-	u8 v, *p, *buf, *b, pbyte, pbits;
++	u8 v, *p, *buf, *b, pbyte, pbits, mask;
+ 
+ 	nbits = cell->nbits;
+ 	buf = kzalloc(cell->bytes, GFP_KERNEL);
+@@ -1814,8 +1814,10 @@ static void *nvmem_cell_prepare_write_bu
+ 				    cell->offset + cell->bytes - 1, &v, 1);
+ 		if (rc)
+ 			goto err;
+-		*p |= GENMASK(7, (nbits + bit_offset) % BITS_PER_BYTE) & v;
+ 
++		mask = GENMASK(7, (nbits + bit_offset) % BITS_PER_BYTE);
++		*p &= ~mask;
++		*p |= v & mask;
+ 	}
+ 
+ 	return buf;

--- a/target/linux/generic/pending-6.12/922-mtd-implement-nvmem-write-support.patch
+++ b/target/linux/generic/pending-6.12/922-mtd-implement-nvmem-write-support.patch
@@ -1,0 +1,82 @@
+From: Michael Lotz <mmlr@mlotz.ch>
+Subject: mtd: implement nvmem write support
+
+This adds mtd_nvmem_reg_write to handle nvmem writes to MTD devices.
+It is implemented as read-modify-write as needed for flash based
+storage. An erase cycle is performed on the erase blocks affected by the
+write. This is the same mechanism as used by mtdblock, but without any
+caching, as nvmem writes are not expected to be frequent or consist of
+multiple writes.
+
+Signed-off-by: Michael Lotz <mmlr@mlotz.ch>
+--- a/drivers/mtd/mtdcore.c
++++ b/drivers/mtd/mtdcore.c
+@@ -555,6 +555,55 @@ static int mtd_nvmem_reg_read(void *priv
+ 	return retlen == bytes ? 0 : -EIO;
+ }
+ 
++static int mtd_nvmem_reg_write(void *priv, unsigned int offset,
++			      void *val, size_t bytes)
++{
++	struct mtd_info *mtd = priv;
++	struct erase_info erase;
++	u8 *buffer;
++	size_t retlen;
++	int err;
++
++	erase.addr = offset;
++	erase.len = bytes;
++	mtd_align_erase_req(mtd, &erase);
++
++	buffer = kmalloc(erase.len, GFP_KERNEL);
++	if (!buffer)
++		return -ENOMEM;
++
++	err = mtd_read(mtd, erase.addr, erase.len, &retlen, buffer);
++	if (err && err != -EUCLEAN)
++		goto err_free_buffer;
++
++	if (retlen != erase.len) {
++		err = -EIO;
++		goto err_free_buffer;
++	}
++
++	err = mtd_erase(mtd, &erase);
++	if (err) {
++		pr_warn("%s: erase of region [0x%lx, 0x%x] on \"%s\" failed\n",
++			__func__, (unsigned long)erase.addr,
++			(unsigned int)erase.len, mtd->name);
++		goto err_free_buffer;
++	}
++
++	memcpy(buffer + (offset - erase.addr), val, bytes);
++
++	err = mtd_write(mtd, erase.addr, erase.len, &retlen, buffer);
++	kfree(buffer);
++
++	if (err)
++		return err;
++
++	return retlen == erase.len ? 0 : -EIO;
++
++err_free_buffer:
++	kfree(buffer);
++	return err;
++}
++
+ static int mtd_nvmem_add(struct mtd_info *mtd)
+ {
+ 	struct device_node *node = mtd_get_of_node(mtd);
+@@ -566,10 +615,11 @@ static int mtd_nvmem_add(struct mtd_info
+ 	config.owner = THIS_MODULE;
+ 	config.add_legacy_fixed_of_cells = of_device_is_compatible(node, "nvmem-cells");
+ 	config.reg_read = mtd_nvmem_reg_read;
++	config.reg_write = mtd_nvmem_reg_write;
+ 	config.size = mtd->size;
+ 	config.word_size = 1;
+ 	config.stride = 1;
+-	config.read_only = true;
++	config.read_only = !(mtd->flags & MTD_WRITEABLE);
+ 	config.root_only = true;
+ 	config.ignore_wp = true;
+ 	config.priv = mtd;

--- a/target/linux/generic/pending-6.12/923-nvmem-block-provider-write-support.patch
+++ b/target/linux/generic/pending-6.12/923-nvmem-block-provider-write-support.patch
@@ -1,0 +1,76 @@
+From: Michael Lotz <mmlr@mlotz.ch>
+Subject: nvmem-block: implement write support
+
+This adds nvmem write support to the block device nvmem provider.
+
+UNTESTED for lack of hardware.
+
+Signed-off-by: Michael Lotz <mmlr@mlotz.ch>
+--- a/drivers/nvmem/block.c
++++ b/drivers/nvmem/block.c
+@@ -65,6 +65,52 @@ err_release_bdev:
+ 	return ret;
+ }
+ 
++static int blk_nvmem_reg_write(void *priv, unsigned int to,
++			      void *val, size_t bytes)
++{
++	blk_mode_t mode = BLK_OPEN_WRITE | BLK_OPEN_EXCL;
++	unsigned long offs = to & ~PAGE_MASK, to_write;
++	struct blk_nvmem *bnv = priv;
++	size_t bytes_left = bytes;
++	struct file *bdev_file;
++	struct address_space *mapping;
++	const struct address_space_operations *a_ops;
++	struct folio *folio;
++	void *fsdata = NULL;
++	int ret = 0;
++
++	bdev_file = bdev_file_open_by_dev(bnv->dev->devt, mode, priv, NULL);
++	if (!bdev_file)
++		return -ENODEV;
++
++	if (IS_ERR(bdev_file))
++		return PTR_ERR(bdev_file);
++
++	mapping = bdev_file->f_mapping;
++	a_ops = mapping->a_ops;
++
++	while (bytes_left) {
++		to_write = min_t(unsigned long, bytes_left, PAGE_SIZE - offs);
++		ret = a_ops->write_begin(NULL, mapping, to, to_write, &folio, &fsdata);
++		if (ret)
++			goto err_release_bdev;
++
++		memcpy_to_folio(folio, offset_in_folio(folio, offs), val, to_write);
++
++		a_ops->write_end(NULL, mapping, to, to_write, to_write, folio, fsdata);
++
++		offs = 0;
++		bytes_left -= to_write;
++		to += to_write;
++		val += to_write;
++	}
++
++err_release_bdev:
++	fput(bdev_file);
++
++	return ret;
++}
++
+ static int blk_nvmem_register(struct device *dev)
+ {
+ 	struct block_device *bdev = dev_to_bdev(dev);
+@@ -108,10 +154,11 @@ static int blk_nvmem_register(struct dev
+ 	config.owner = THIS_MODULE;
+ 	config.priv = bnv;
+ 	config.reg_read = blk_nvmem_reg_read;
++	config.reg_write = blk_nvmem_reg_write;
+ 	config.size = bdev_nr_bytes(bdev);
+ 	config.word_size = 1;
+ 	config.stride = 1;
+-	config.read_only = true;
++	config.read_only = bdev_read_only(bdev);
+ 	config.root_only = true;
+ 	config.ignore_wp = true;
+ 	config.of_node = to_of_node(dev->fwnode);


### PR DESCRIPTION
The goal of this is to have a generic, device tree and nvmem based approach to handling vendor specific boot and image flags.

This proposal came to be after running into multiple devices that use dual-image setups and having to build or adapt vendor specific tools to support their boot image selection bits.

The following commit message holds more details, with more details for the individual parts in the commit messages of the patches. Note that the last patch, write support for block device backed nvmem-cells, is untested as I currently lack a test setup for that. Note also, that the bootflag package needs to be enabled to test this.

This adds a series of kernel patches:

* A fix for clobbering outside bits on nvmem cell writes
* Making MTD backed nvmem-cells writeable
* Making block device backed nvmem-cells writeable

It also adds a generic tool for enumerating, reading and writing
bootflags from userland through sysfs.

This aims to generalize the concept of having some flag bits/bytes or
sequences stored in non-volatile memory. The bootflag tool allows for
using such flags, declared in the device tree, from userland. It reads
specific labels that allow to map arbitrary values to human readable
symbolic names that can then be used for reading and writing the flags
in a non vendor specific way.

The following example implements a bootflag for image selection and two
image validity states in the format also used by zyxel-bootconfig. It
can generically replace such tools as long as the format can be
described using nvmem cells. It also shows handling of multi-byte
sequences.

Example usage:

    root@OpenWrt:~# bootflag list
    bootflag - boot image selection
    image0-status - image0 validity status
    image1-status - image1 validity status
    testflag - longer byte sequence test

    root@OpenWrt:~# bootflag show bootflag
    current "bootflag" value: 00=image0

    root@OpenWrt:~# bootflag values image0-status
    00=none
    01=new
    02=valid
    03=invalid

    root@OpenWrt:~# bootflag show image0-status
    current "image0-status" value: 03=invalid

    root@OpenWrt:~# bootflag set image0-status valid
    setting "image0-status" value to 02=valid

    root@OpenWrt:~# bootflag show image0-status
    current "image0-status" value: 02=valid

    root@OpenWrt:~# bootflag values testflag
    0000000000000000=none
    ffffffffffffffff=clear
    aabbccddeeff0011=default
    0102030405060708=configured

    root@OpenWrt:~# bootflag show testflag
    current "testflag" value: ffffffffffffffff=clear

    root@OpenWrt:~# bootflag set testflag configured
    setting "testflag" value to 0102030405060708=configured

    root@OpenWrt:~# bootflag show testflag
    current "testflag" value: 0102030405060708=configured

Example device tree:

    &flash {
        partitions {
            compatible = "fixed-partitions";
            #address-cells = <1>;
            #size-cells = <1>;

            ...

            partition@60000 {
                label = "bootconfig";
                reg = <0x60000 0x10000>;

                nvmem-layout {
                    compatible = "fixed-layout";
                    #address-cells = <1>;
                    #size-cells = <1>;

                    image0-status@0 {
                        compatible = "bootflag";
                        label = "image0 validity status";
                        value-labels = "none", "new", "valid",
                            "invalid";
                        reg = <0x0 0x1>;
                        bits = <2 2>;
                    };

                    image1-status@0 {
                        compatible = "bootflag";
                        label = "image1 validity status";
                        value-labels = "none", "new", "valid",
                            "invalid";
                        reg = <0x0 0x1>;
                        bits = <6 2>;
                    };

                    bootflag@1 {
                        compatible = "bootflag";
                        label = "boot image selection";
                        value-labels = "image0", "image1";
                        reg = <0x1 0x1>;
                        bits = <7 1>;
                    };

                    testflag@100 {
                        compatible = "bootflag";
                        label = "longer byte sequence test";
                        values = [00 00 00 00 00 00 00 00],
                                 [ff ff ff ff ff ff ff ff],
                                 [aa bb cc dd ee ff 00 11],
                                 [01 02 03 04 05 06 07 08];
                        value-labels = "none", "clear",
                            "default", "configured";
                        reg = <0x100 0x8>;
                    };
                };
            };

            ...
        };
    };