### PR TITLE
lantiq: xrx200: fix Zyxel P-2812HNU MAC addresses

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f1.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-f1.dts
@@ -47,6 +47,7 @@
 
 				nvmem-layout {
 					compatible = "u-boot,env";
+					env-size = <0x2000>;
 
 					macaddr_uboot_ethaddr: ethaddr {
 						#nvmem-cell-cells = <1>;


### PR DESCRIPTION
## Summary

Fix random MAC address assignment on Zyxel P-2812HNU-F1 by correcting
the NVMEM u-boot-env parsing and adding the missing nvmem-cells reference
to the eth0 (DSA master) node.

**Changes:**
- Add `env-size = <0x2000>` to DTS nvmem-layout for correct CRC32 validation
- Add `nvmem-cells` reference to `&eth0` (xrx200-net DSA master) node
- Fix `lan_mac` assignment in board.d `02_network` script

> **Note:** Other devices sharing the same platform (Lantiq Easy80920,
> Zyxel P-2812HNU-F3) may have the same issue and could benefit from a
> similar fix, but this patch only covers the P-2812HNU-F1 which was the
> device available for testing.

## Problem

On OpenWrt SNAPSHOT, eth0 (DSA master) and WAN port get random MAC
addresses on every boot. The root cause is the NVMEM u-boot-env layout
driver failing to parse the U-Boot environment:

The u-boot-env partition is 128KB (`0x20000`) but the actual U-Boot
environment is only 8KB (`0x2000`). Without the `env-size` property, the
driver calculates CRC32 over the wrong data size, causing a validation
failure. This makes all NVMEM cells unavailable, so `gswip`, `wan`, and
`eth0` cannot read the MAC address from u-boot `ethaddr`.

## UART Console Logs

### Before fix — kernel boot (CRC32 failure)

```
ROM VER: 1.0.5
CFG 06
NAND
NAND Read OK

U-Boot SPL 2013.10-openwrt5 (Nov 18 2014 - 19:54:01)
SPL: initializing NAND flash
SPL: checking U-Boot image
SPL: loading U-Boot to RAM
SPL: decompressing U-Boot with LZO
SPL: jumping to U-Boot

U-Boot 2013.10-openwrt5 (Jul 06 2021 - 10:04:01) P-2812HNU-Fx

Board: ZyXEL P-2812HNU-Fx
SoC:   Lantiq VRX288 v1.1
CPU:   500 MHz
IO:    250 MHz
BUS:   250 MHz
BOOT:  NAND
DRAM:  128 MiB
NAND:  128 MiB
In:    serial
Out:   serial
Err:   serial
Net:   ltq-eth
```

NVMEM driver fails with CRC32 mismatch:
```
[    0.750000] 0x000000000000-0x000000040000 : "uboot"
[    0.760000] 0x000000040000-0x000000060000 : "u-boot-env"
[    0.760000] 0x000000060000-0x000000560000 : "kernel"
[    0.770000] 0x000000560000-0x000008000000 : "ubi"
[    0.820000] u-boot-env-layout ...: Invalid calculated CRC32: 0x0ce400a9 (expected: 0xb3f6f7c3)
[    0.830000] u-boot-env-layout ...: probe with driver u-boot-env-layout failed with error -22
```

### Before fix — userspace (random MACs, default environment)

```
root@OpenWrt:~# fw_printenv ethaddr
Warning: Bad CRC, using default environment
ethaddr=02:00:11:22:33:44

root@OpenWrt:~# dmesg | grep -i u-boot-env
[    0.760000] 0x000000040000-0x000000060000 : "u-boot-env"
[    0.820000] u-boot-env-layout ...: Invalid calculated CRC32: 0x0ce400a9 (expected: 0xb3f6f7c3)
[    0.830000] u-boot-env-layout ...: probe with driver u-boot-env-layout failed with error -22

root@OpenWrt:~# ip link show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1508 qdisc fq_codel state UNKNOWN qlen 1000
    link/ether ea:ab:8f:78:2f:fd brd ff:ff:ff:ff:ff:ff
```

`ea:ab:8f:78:2f:fd` is a random MAC that changes on every reboot.
The real ethaddr stored in u-boot-env is not `02:00:11:22:33:44`
(that is the hardcoded default used when CRC validation fails).

### After fix — userspace (correct MACs from u-boot ethaddr)

With `env-size = <0x2000>` added to the DTS and `nvmem-cells` on eth0:

```
root@OpenWrt:~# dmesg | grep -i u-boot-env
[    0.760000] 0x000000040000-0x000000060000 : "u-boot-env"

root@OpenWrt:~# fw_printenv ethaddr
ethaddr=<correct MAC from u-boot>

root@OpenWrt:~# ip link show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1508 qdisc fq_codel state UNKNOWN qlen 1000
    link/ether <correct MAC from u-boot>
```

- No CRC32 error in dmesg
- `fw_printenv` reads the real MAC without CRC warning
- `eth0`: base MAC from u-boot ethaddr (via nvmem-cells)
- `wan`: base MAC + 1 (via existing nvmem-cells on DSA port@5)
- `lan1-4`: base MAC (via existing nvmem-cells on gswip)

## Test plan

- [x] Verified CRC32 error disappears from dmesg after adding `env-size`
- [x] Verified `fw_printenv ethaddr` returns correct MAC without CRC warning
- [x] Verified eth0, wan, and LAN interfaces get correct MAC addresses
- [x] Tested on Zyxel P-2812HNU-F1 hardware with OpenWrt SNAPSHOT