### PR TITLE
[pre-6.18] realtek: name cleanups

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -1394,7 +1394,7 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		return -ENOMEM;
 	priv->ds->dev = dev;
 	priv->ds->priv = priv;
-	priv->ds->ops = &rtl83xx_switch_ops;
+	priv->ds->ops = &rtldsa_83xx_switch_ops;
 	priv->ds->needs_standalone_vlan_filtering = true;
 	priv->dev = dev;
 	dev_set_drvdata(dev, priv);
@@ -1411,7 +1411,7 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 	priv->id = soc_info.id;
 	switch (soc_info.family) {
 	case RTL8380_FAMILY_ID:
-		priv->ds->ops = &rtl83xx_switch_ops;
+		priv->ds->ops = &rtldsa_83xx_switch_ops;
 		priv->cpu_port = RTL838X_CPU_PORT;
 		priv->port_mask = 0x1f;
 		priv->port_width = 1;
@@ -1427,7 +1427,7 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->n_counters = 128;
 		break;
 	case RTL8390_FAMILY_ID:
-		priv->ds->ops = &rtl83xx_switch_ops;
+		priv->ds->ops = &rtldsa_83xx_switch_ops;
 		priv->cpu_port = RTL839X_CPU_PORT;
 		priv->port_mask = 0x3f;
 		priv->port_width = 2;
@@ -1443,7 +1443,7 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->n_counters = 1024;
 		break;
 	case RTL9300_FAMILY_ID:
-		priv->ds->ops = &rtl93xx_switch_ops;
+		priv->ds->ops = &rtldsa_93xx_switch_ops;
 		priv->cpu_port = RTL930X_CPU_PORT;
 		priv->port_mask = 0x1f;
 		priv->port_width = 1;
@@ -1460,7 +1460,7 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->n_counters = 2048;
 		break;
 	case RTL9310_FAMILY_ID:
-		priv->ds->ops = &rtl93xx_switch_ops;
+		priv->ds->ops = &rtldsa_93xx_switch_ops;
 		priv->cpu_port = RTL931X_CPU_PORT;
 		priv->port_mask = 0x3f;
 		priv->port_width = 2;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -1417,7 +1417,7 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->port_width = 1;
 		priv->irq_mask = 0x0FFFFFFF;
 		priv->r = &rtl838x_reg;
-		priv->ds->num_ports = 29;
+		priv->ds->num_ports = RTL838X_CPU_PORT + 1;
 		priv->fib_entries = 8192;
 		priv->ds->num_lag_ids = 8;
 		priv->l2_bucket_size = 4;
@@ -1433,7 +1433,7 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->port_width = 2;
 		priv->irq_mask = 0xFFFFFFFFFFFFFULL;
 		priv->r = &rtl839x_reg;
-		priv->ds->num_ports = 53;
+		priv->ds->num_ports = RTL839X_CPU_PORT + 1;
 		priv->fib_entries = 16384;
 		priv->ds->num_lag_ids = 16;
 		priv->l2_bucket_size = 4;
@@ -1449,7 +1449,7 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->port_width = 1;
 		priv->irq_mask = 0x0FFFFFFF;
 		priv->r = &rtl930x_reg;
-		priv->ds->num_ports = 29;
+		priv->ds->num_ports = RTL930X_CPU_PORT + 1;
 		priv->fib_entries = 16384;
 		priv->ds->num_lag_ids = 16;
 		sw_w32(0, RTL930X_ST_CTRL);
@@ -1466,7 +1466,7 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->port_width = 2;
 		priv->irq_mask = GENMASK_ULL(priv->cpu_port - 1, 0);
 		priv->r = &rtl931x_reg;
-		priv->ds->num_ports = 57;
+		priv->ds->num_ports = RTL931X_CPU_PORT + 1;
 		priv->fib_entries = 16384;
 		priv->ds->num_lag_ids = 16;
 		sw_w32(0, RTL931x_ST_CTRL);

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/debugfs.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/debugfs.c
@@ -180,7 +180,7 @@ static ssize_t stp_state_write(struct file *filp, const char __user *buffer,
 	if (res < 0)
 		return res;
 
-	rtl83xx_port_stp_state_set(p->dp->ds, p->dp->index, (u8)value);
+	rtldsa_port_stp_state_set(p->dp->ds, p->dp->index, (u8)value);
 
 	return res;
 }
@@ -384,7 +384,7 @@ static ssize_t age_out_write(struct file *filp, const char __user *buffer,
 	if (res < 0)
 		return res;
 
-	rtl83xx_fast_age(p->dp->ds, p->dp->index);
+	rtldsa_83xx_fast_age(p->dp->ds, p->dp->index);
 
 	return res;
 }

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -456,7 +456,7 @@ static void rtldsa_vlan_setup(struct rtl838x_switch_priv *priv)
 
 	priv->r->vlan_profile_setup(0);
 	priv->r->vlan_profile_setup(1);
-	pr_info("UNKNOWN_MC_PMASK: %016llx\n", priv->r->read_mcast_pmask(UNKNOWN_MC_PMASK));
+	dev_info(priv->dev, "MC_PMASK_ALL_PORTS: %016llx\n", priv->r->read_mcast_pmask(MC_PMASK_ALL_PORTS_IDX));
 	priv->r->vlan_profile_dump(0);
 
 	info.fid = 0;			/* Default Forwarding ID / MSTI */
@@ -2107,7 +2107,7 @@ static int rtldsa_vlan_add(struct dsa_switch *ds, int port,
 	if (!vlan->vid)
 		return 0;
 
-	if (vlan->vid > 4095) {
+	if (vlan->vid >= MAX_VLANS) {
 		dev_err(priv->dev, "VLAN out of range: %d", vlan->vid);
 		return -ENOTSUPP;
 	}
@@ -2179,7 +2179,7 @@ static int rtldsa_vlan_del(struct dsa_switch *ds, int port,
 	if (!vlan->vid)
 		return 0;
 
-	if (vlan->vid > 4095) {
+	if (vlan->vid >= MAX_VLANS) {
 		dev_err(priv->dev, "VLAN out of range: %d", vlan->vid);
 		return -ENOTSUPP;
 	}

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -27,7 +27,7 @@ static void rtldsa_init_counters(struct rtl838x_switch_priv *priv);
 static void rtldsa_port_xstp_state_set(struct rtl838x_switch_priv *priv, int port,
 				       u8 state, u16 mst_slot);
 
-static void rtl83xx_init_stats(struct rtl838x_switch_priv *priv)
+static void rtldsa_83xx_init_stats(struct rtl838x_switch_priv *priv)
 {
 	mutex_lock(&priv->reg_mutex);
 
@@ -43,7 +43,7 @@ static void rtl83xx_init_stats(struct rtl838x_switch_priv *priv)
 	mutex_unlock(&priv->reg_mutex);
 }
 
-static void rtl83xx_enable_phy_polling(struct rtl838x_switch_priv *priv)
+static void rtldsa_enable_phy_polling(struct rtl838x_switch_priv *priv)
 {
 	u64 v = 0;
 
@@ -423,9 +423,9 @@ const struct rtldsa_mib_desc rtldsa_931x_mib = {
 
 /* DSA callbacks */
 
-static enum dsa_tag_protocol rtl83xx_get_tag_protocol(struct dsa_switch *ds,
-						      int port,
-						      enum dsa_tag_protocol mprot)
+static enum dsa_tag_protocol rtldsa_get_tag_protocol(struct dsa_switch *ds,
+						     int port,
+						     enum dsa_tag_protocol mprot)
 {
 	/* The switch does not tag the frames, instead internally the header
 	 * structure for each packet is tagged accordingly.
@@ -433,7 +433,7 @@ static enum dsa_tag_protocol rtl83xx_get_tag_protocol(struct dsa_switch *ds,
 	return DSA_TAG_PROTO_TRAILER;
 }
 
-static void rtl83xx_vlan_set_pvid(struct rtl838x_switch_priv *priv,
+static void rtldsa_vlan_set_pvid(struct rtl838x_switch_priv *priv,
 				  int port, int pvid)
 {
 	/* Set both inner and outer PVID of the port */
@@ -448,7 +448,7 @@ static void rtl83xx_vlan_set_pvid(struct rtl838x_switch_priv *priv,
 }
 
 /* Initialize all VLANS */
-static void rtl83xx_vlan_setup(struct rtl838x_switch_priv *priv)
+static void rtldsa_vlan_setup(struct rtl838x_switch_priv *priv)
 {
 	struct rtl838x_vlan_info info;
 
@@ -482,7 +482,7 @@ static void rtl83xx_vlan_setup(struct rtl838x_switch_priv *priv)
 	 * CPU port as ingress when VLAN filtering is enabled.
 	 */
 	for (int i = 0; i <= priv->cpu_port; i++) {
-		rtl83xx_vlan_set_pvid(priv, i, 0);
+		rtldsa_vlan_set_pvid(priv, i, 0);
 		info.member_ports |= BIT_ULL(i);
 	}
 	priv->r->vlan_set_tagged(0, &info);
@@ -504,8 +504,8 @@ static void rtldsa_setup_lldp_traps(struct rtl838x_switch_priv *priv)
 		priv->r->set_receive_management_action(i, LLDP, TRAP2CPU);
 }
 
-static void rtl83xx_port_set_salrn(struct rtl838x_switch_priv *priv,
-				   int port, bool enable)
+static void rtldsa_port_set_salrn(struct rtl838x_switch_priv *priv,
+				  int port, bool enable)
 {
 	int shift = SALRN_PORT_SHIFT(port);
 	int val = enable ? SALRN_MODE_HARDWARE : SALRN_MODE_DISABLED;
@@ -514,7 +514,7 @@ static void rtl83xx_port_set_salrn(struct rtl838x_switch_priv *priv,
 		    priv->r->l2_port_new_salrn(port));
 }
 
-static int rtl83xx_setup(struct dsa_switch *ds)
+static int rtldsa_83xx_setup(struct dsa_switch *ds)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 
@@ -551,10 +551,10 @@ static int rtl83xx_setup(struct dsa_switch *ds)
 	else
 		rtl839x_print_matrix();
 
-	rtl83xx_init_stats(priv);
+	rtldsa_83xx_init_stats(priv);
 	rtldsa_init_counters(priv);
 
-	rtl83xx_vlan_setup(priv);
+	rtldsa_vlan_setup(priv);
 
 	rtldsa_setup_bpdu_traps(priv);
 	rtldsa_setup_lldp_traps(priv);
@@ -563,7 +563,7 @@ static int rtl83xx_setup(struct dsa_switch *ds)
 
 	priv->r->l2_learning_setup();
 
-	rtl83xx_port_set_salrn(priv, priv->cpu_port, false);
+	rtldsa_port_set_salrn(priv, priv->cpu_port, false);
 	ds->assisted_learning_on_cpu_port = true;
 
 	/* Make sure all frames sent to the switch's MAC are trapped to the CPU-port
@@ -575,7 +575,7 @@ static int rtl83xx_setup(struct dsa_switch *ds)
 		sw_w32(0x2, RTL839X_SPCL_TRAP_SWITCH_MAC_CTRL);
 
 	/* Enable MAC Polling PHY again */
-	rtl83xx_enable_phy_polling(priv);
+	rtldsa_enable_phy_polling(priv);
 	pr_debug("Please wait until PHY is settled\n");
 	msleep(1000);
 	priv->r->pie_init(priv);
@@ -583,7 +583,7 @@ static int rtl83xx_setup(struct dsa_switch *ds)
 	return 0;
 }
 
-static int rtl93xx_setup(struct dsa_switch *ds)
+static int rtldsa_93xx_setup(struct dsa_switch *ds)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 
@@ -626,7 +626,7 @@ static int rtl93xx_setup(struct dsa_switch *ds)
 	/* TODO: Initialize statistics */
 	rtldsa_init_counters(priv);
 
-	rtl83xx_vlan_setup(priv);
+	rtldsa_vlan_setup(priv);
 
 	rtldsa_setup_bpdu_traps(priv);
 	rtldsa_setup_lldp_traps(priv);
@@ -635,10 +635,10 @@ static int rtl93xx_setup(struct dsa_switch *ds)
 
 	priv->r->l2_learning_setup();
 
-	rtl83xx_port_set_salrn(priv, priv->cpu_port, false);
+	rtldsa_port_set_salrn(priv, priv->cpu_port, false);
 	ds->assisted_learning_on_cpu_port = true;
 
-	rtl83xx_enable_phy_polling(priv);
+	rtldsa_enable_phy_polling(priv);
 
 	priv->r->pie_init(priv);
 
@@ -698,9 +698,9 @@ static void rtldsa_93xx_phylink_get_caps(struct dsa_switch *ds, int port,
 	__set_bit(PHY_INTERFACE_MODE_10G_QXGMII, config->supported_interfaces);
 }
 
-static void rtl83xx_phylink_mac_config(struct dsa_switch *ds, int port,
-				       unsigned int mode,
-					const struct phylink_link_state *state)
+static void rtldsa_83xx_phylink_mac_config(struct dsa_switch *ds, int port,
+					   unsigned int mode,
+					   const struct phylink_link_state *state)
 {
 	struct dsa_port *dp = dsa_to_port(ds, port);
 	struct rtl838x_switch_priv *priv = ds->priv;
@@ -729,9 +729,9 @@ static void rtl83xx_phylink_mac_config(struct dsa_switch *ds, int port,
 	sw_w32(mcr, priv->r->mac_force_mode_ctrl(port));
 }
 
-static void rtl931x_phylink_mac_config(struct dsa_switch *ds, int port,
-				       unsigned int mode,
-					const struct phylink_link_state *state)
+static void rtldsa_931x_phylink_mac_config(struct dsa_switch *ds, int port,
+					   unsigned int mode,
+					   const struct phylink_link_state *state)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 	u32 reg;
@@ -745,9 +745,9 @@ static void rtl931x_phylink_mac_config(struct dsa_switch *ds, int port,
 	sw_w32(reg, priv->r->mac_force_mode_ctrl(port));
 }
 
-static void rtl93xx_phylink_mac_config(struct dsa_switch *ds, int port,
-				       unsigned int mode,
-					const struct phylink_link_state *state)
+static void rtldsa_93xx_phylink_mac_config(struct dsa_switch *ds, int port,
+					   unsigned int mode,
+					   const struct phylink_link_state *state)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 
@@ -756,15 +756,15 @@ static void rtl93xx_phylink_mac_config(struct dsa_switch *ds, int port,
 		return;
 
 	if (priv->family_id == RTL9310_FAMILY_ID)
-		return rtl931x_phylink_mac_config(ds, port, mode, state);
+		return rtldsa_931x_phylink_mac_config(ds, port, mode, state);
 
 	/* Disable MAC completely */
 	sw_w32(0, RTL930X_MAC_FORCE_MODE_CTRL + 4 * port);
 }
 
-static void rtl83xx_phylink_mac_link_down(struct dsa_switch *ds, int port,
-					  unsigned int mode,
-				     phy_interface_t interface)
+static void rtldsa_83xx_phylink_mac_link_down(struct dsa_switch *ds, int port,
+					      unsigned int mode,
+					      phy_interface_t interface)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 	int mask = 0;
@@ -777,9 +777,9 @@ static void rtl83xx_phylink_mac_link_down(struct dsa_switch *ds, int port,
 	sw_w32_mask(mask, 0, priv->r->mac_force_mode_ctrl(port));
 }
 
-static void rtl93xx_phylink_mac_link_down(struct dsa_switch *ds, int port,
-					  unsigned int mode,
-				     phy_interface_t interface)
+static void rtldsa_93xx_phylink_mac_link_down(struct dsa_switch *ds, int port,
+					      unsigned int mode,
+					      phy_interface_t interface)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 	u32 v = 0;
@@ -795,12 +795,12 @@ static void rtl93xx_phylink_mac_link_down(struct dsa_switch *ds, int port,
 	sw_w32_mask(v, 0, priv->r->mac_force_mode_ctrl(port));
 }
 
-static void rtl83xx_phylink_mac_link_up(struct dsa_switch *ds, int port,
-					unsigned int mode,
-				   phy_interface_t interface,
-				   struct phy_device *phydev,
-				   int speed, int duplex,
-				   bool tx_pause, bool rx_pause)
+static void rtldsa_83xx_phylink_mac_link_up(struct dsa_switch *ds, int port,
+					    unsigned int mode,
+					    phy_interface_t interface,
+					    struct phy_device *phydev,
+					    int speed, int duplex,
+					    bool tx_pause, bool rx_pause)
 {
 	struct dsa_port *dp = dsa_to_port(ds, port);
 	struct rtl838x_switch_priv *priv = ds->priv;
@@ -858,12 +858,12 @@ static void rtl83xx_phylink_mac_link_up(struct dsa_switch *ds, int port,
 	sw_w32_mask(0, 0x3, priv->r->mac_port_ctrl(port));
 }
 
-static void rtl93xx_phylink_mac_link_up(struct dsa_switch *ds, int port,
-					unsigned int mode,
-					phy_interface_t interface,
-					struct phy_device *phydev,
-					int speed, int duplex,
-					bool tx_pause, bool rx_pause)
+static void rtldsa_93xx_phylink_mac_link_up(struct dsa_switch *ds, int port,
+					    unsigned int mode,
+					    phy_interface_t interface,
+					    struct phy_device *phydev,
+					    int speed, int duplex,
+					    bool tx_pause, bool rx_pause)
 {
 	struct dsa_port *dp = dsa_to_port(ds, port);
 	struct rtl838x_switch_priv *priv = ds->priv;
@@ -1442,7 +1442,7 @@ static void rtldsa_get_pause_stats(struct dsa_switch *ds, int port,
 	rtldsa_counters_unlock(priv, port);
 }
 
-static int rtl83xx_mc_group_alloc(struct rtl838x_switch_priv *priv, int port)
+static int rtldsa_mc_group_alloc(struct rtl838x_switch_priv *priv, int port)
 {
 	int mc_group = find_first_zero_bit(priv->mc_group_bm, MAX_MC_GROUPS - 1);
 	u64 portmask;
@@ -1457,7 +1457,7 @@ static int rtl83xx_mc_group_alloc(struct rtl838x_switch_priv *priv, int port)
 	return mc_group;
 }
 
-static u64 rtl83xx_mc_group_add_port(struct rtl838x_switch_priv *priv, int mc_group, int port)
+static u64 rtldsa_mc_group_add_port(struct rtl838x_switch_priv *priv, int mc_group, int port)
 {
 	u64 portmask = priv->r->read_mcast_pmask(mc_group);
 
@@ -1469,7 +1469,7 @@ static u64 rtl83xx_mc_group_add_port(struct rtl838x_switch_priv *priv, int mc_gr
 	return portmask;
 }
 
-static u64 rtl83xx_mc_group_del_port(struct rtl838x_switch_priv *priv, int mc_group, int port)
+static u64 rtldsa_mc_group_del_port(struct rtl838x_switch_priv *priv, int mc_group, int port)
 {
 	u64 portmask = priv->r->read_mcast_pmask(mc_group);
 
@@ -1563,7 +1563,7 @@ static int rtldsa_get_mac_eee(struct dsa_switch *ds, int port, struct ethtool_ke
 	return 0;
 }
 
-static int rtl83xx_set_ageing_time(struct dsa_switch *ds, unsigned int msec)
+static int rtldsa_set_ageing_time(struct dsa_switch *ds, unsigned int msec)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 
@@ -1924,7 +1924,7 @@ static void rtldsa_port_xstp_state_set(struct rtl838x_switch_priv *priv, int por
 	priv->r->stp_set(priv, mst_slot, port_state);
 }
 
-void rtl83xx_port_stp_state_set(struct dsa_switch *ds, int port, u8 state)
+void rtldsa_port_stp_state_set(struct dsa_switch *ds, int port, u8 state)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 	struct dsa_port *dp = dsa_to_port(ds, port);
@@ -1944,7 +1944,7 @@ unlock:
 	mutex_unlock(&priv->reg_mutex);
 }
 
-void rtl83xx_fast_age(struct dsa_switch *ds, int port)
+void rtldsa_83xx_fast_age(struct dsa_switch *ds, int port)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 	int s = priv->family_id == RTL8390_FAMILY_ID ? 2 : 0;
@@ -1989,7 +1989,7 @@ static void rtldsa_931x_fast_age(struct dsa_switch *ds, int port)
 	mutex_unlock(&priv->reg_mutex);
 }
 
-static void rtl930x_fast_age(struct dsa_switch *ds, int port)
+static void rtldsa_930x_fast_age(struct dsa_switch *ds, int port)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 
@@ -2027,9 +2027,9 @@ static int rtldsa_port_mst_state_set(struct dsa_switch *ds, int port,
 	return 0;
 }
 
-static int rtl83xx_vlan_filtering(struct dsa_switch *ds, int port,
-				  bool vlan_filtering,
-				  struct netlink_ext_ack *extack)
+static int rtldsa_vlan_filtering(struct dsa_switch *ds, int port,
+				 bool vlan_filtering,
+				 struct netlink_ext_ack *extack)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 
@@ -2067,8 +2067,8 @@ static int rtl83xx_vlan_filtering(struct dsa_switch *ds, int port,
 	return 0;
 }
 
-static int rtl83xx_vlan_prepare(struct dsa_switch *ds, int port,
-				const struct switchdev_obj_port_vlan *vlan)
+static int rtldsa_vlan_prepare(struct dsa_switch *ds, int port,
+			       const struct switchdev_obj_port_vlan *vlan)
 {
 	struct rtl838x_vlan_info info;
 	struct rtl838x_switch_priv *priv = ds->priv;
@@ -2092,9 +2092,9 @@ static int rtl83xx_vlan_prepare(struct dsa_switch *ds, int port,
 	return 0;
 }
 
-static int rtl83xx_vlan_add(struct dsa_switch *ds, int port,
-			    const struct switchdev_obj_port_vlan *vlan,
-			    struct netlink_ext_ack *extack)
+static int rtldsa_vlan_add(struct dsa_switch *ds, int port,
+			   const struct switchdev_obj_port_vlan *vlan,
+			   struct netlink_ext_ack *extack)
 {
 	struct rtl838x_vlan_info info;
 	struct rtl838x_switch_priv *priv = ds->priv;
@@ -2112,7 +2112,7 @@ static int rtl83xx_vlan_add(struct dsa_switch *ds, int port,
 		return -ENOTSUPP;
 	}
 
-	err = rtl83xx_vlan_prepare(ds, port, vlan);
+	err = rtldsa_vlan_prepare(ds, port, vlan);
 	if (err)
 		return err;
 
@@ -2128,9 +2128,9 @@ static int rtl83xx_vlan_add(struct dsa_switch *ds, int port,
 	 */
 	if (port != priv->cpu_port) {
 		if (vlan->flags & BRIDGE_VLAN_INFO_PVID)
-			rtl83xx_vlan_set_pvid(priv, port, vlan->vid);
+			rtldsa_vlan_set_pvid(priv, port, vlan->vid);
 		else if (priv->ports[port].pvid == vlan->vid)
-			rtl83xx_vlan_set_pvid(priv, port, 0);
+			rtldsa_vlan_set_pvid(priv, port, 0);
 	}
 
 	/* Get port memberships of this vlan */
@@ -2165,8 +2165,8 @@ static int rtl83xx_vlan_add(struct dsa_switch *ds, int port,
 	return 0;
 }
 
-static int rtl83xx_vlan_del(struct dsa_switch *ds, int port,
-			    const struct switchdev_obj_port_vlan *vlan)
+static int rtldsa_vlan_del(struct dsa_switch *ds, int port,
+			   const struct switchdev_obj_port_vlan *vlan)
 {
 	struct rtl838x_vlan_info info;
 	struct rtl838x_switch_priv *priv = ds->priv;
@@ -2189,7 +2189,7 @@ static int rtl83xx_vlan_del(struct dsa_switch *ds, int port,
 
 	/* Reset to default if removing the current PVID */
 	if (vlan->vid == pvid)
-		rtl83xx_vlan_set_pvid(priv, port, 0);
+		rtldsa_vlan_set_pvid(priv, port, 0);
 
 	/* Get port memberships of this vlan */
 	priv->r->vlan_tables_read(vlan->vid, &info);
@@ -2258,7 +2258,8 @@ static int rtldsa_vlan_msti_set(struct dsa_switch *ds, struct dsa_bridge bridge,
 	return 0;
 }
 
-static void rtl83xx_setup_l2_uc_entry(struct rtl838x_l2_entry *e, int port, int vid, u64 mac)
+static void rtldsa_setup_l2_uc_entry(struct rtl838x_l2_entry *e, int port,
+				     int vid, u64 mac)
 {
 	memset(e, 0, sizeof(*e));
 
@@ -2275,7 +2276,7 @@ static void rtl83xx_setup_l2_uc_entry(struct rtl838x_l2_entry *e, int port, int 
 	u64_to_ether_addr(mac, e->mac);
 }
 
-static void rtl83xx_setup_l2_mc_entry(struct rtl838x_l2_entry *e, int vid, u64 mac, int mc_group)
+static void rtldsa_setup_l2_mc_entry(struct rtl838x_l2_entry *e, int vid, u64 mac, int mc_group)
 {
 	memset(e, 0, sizeof(*e));
 
@@ -2295,8 +2296,8 @@ static void rtl83xx_setup_l2_mc_entry(struct rtl838x_l2_entry *e, int vid, u64 m
  * when an empty slot was found and must exist is false, the index of the slot is returned
  * when no slots are available returns -1
  */
-static int rtl83xx_find_l2_hash_entry(struct rtl838x_switch_priv *priv, u64 seed,
-				      bool must_exist, struct rtl838x_l2_entry *e)
+static int rtldsa_find_l2_hash_entry(struct rtl838x_switch_priv *priv, u64 seed,
+				     bool must_exist, struct rtl838x_l2_entry *e)
 {
 	int idx = -1;
 	u32 key = priv->r->l2_hash_key(priv, seed);
@@ -2323,8 +2324,8 @@ static int rtl83xx_find_l2_hash_entry(struct rtl838x_switch_priv *priv, u64 seed
  * when an empty slot was found the index of the slot is returned
  * when no slots are available returns -1
  */
-static int rtl83xx_find_l2_cam_entry(struct rtl838x_switch_priv *priv, u64 seed,
-				     bool must_exist, struct rtl838x_l2_entry *e)
+static int rtldsa_find_l2_cam_entry(struct rtl838x_switch_priv *priv, u64 seed,
+				    bool must_exist, struct rtl838x_l2_entry *e)
 {
 	int idx = -1;
 	u64 entry;
@@ -2345,9 +2346,9 @@ static int rtl83xx_find_l2_cam_entry(struct rtl838x_switch_priv *priv, u64 seed,
 	return idx;
 }
 
-static int rtl83xx_port_fdb_add(struct dsa_switch *ds, int port,
-				const unsigned char *addr, u16 vid,
-				const struct dsa_db db)
+static int rtldsa_port_fdb_add(struct dsa_switch *ds, int port,
+			       const unsigned char *addr, u16 vid,
+			       const struct dsa_db db)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 	u64 mac = ether_addr_to_u64(addr);
@@ -2362,20 +2363,20 @@ static int rtl83xx_port_fdb_add(struct dsa_switch *ds, int port,
 
 	mutex_lock(&priv->reg_mutex);
 
-	idx = rtl83xx_find_l2_hash_entry(priv, seed, false, &e);
+	idx = rtldsa_find_l2_hash_entry(priv, seed, false, &e);
 
 	/* Found an existing or empty entry */
 	if (idx >= 0) {
-		rtl83xx_setup_l2_uc_entry(&e, port, vid, mac);
+		rtldsa_setup_l2_uc_entry(&e, port, vid, mac);
 		priv->r->write_l2_entry_using_hash(idx >> 2, idx & 0x3, &e);
 		goto out;
 	}
 
 	/* Hash buckets full, try CAM */
-	idx = rtl83xx_find_l2_cam_entry(priv, seed, false, &e);
+	idx = rtldsa_find_l2_cam_entry(priv, seed, false, &e);
 
 	if (idx >= 0) {
-		rtl83xx_setup_l2_uc_entry(&e, port, vid, mac);
+		rtldsa_setup_l2_uc_entry(&e, port, vid, mac);
 		priv->r->write_cam(idx, &e);
 		goto out;
 	}
@@ -2388,9 +2389,9 @@ out:
 	return err;
 }
 
-static int rtl83xx_port_fdb_del(struct dsa_switch *ds, int port,
-				const unsigned char *addr, u16 vid,
-				const struct dsa_db db)
+static int rtldsa_port_fdb_del(struct dsa_switch *ds, int port,
+			       const unsigned char *addr, u16 vid,
+			       const struct dsa_db db)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 	u64 mac = ether_addr_to_u64(addr);
@@ -2401,7 +2402,7 @@ static int rtl83xx_port_fdb_del(struct dsa_switch *ds, int port,
 	pr_debug("In %s, mac %llx, vid: %d\n", __func__, mac, vid);
 	mutex_lock(&priv->reg_mutex);
 
-	idx = rtl83xx_find_l2_hash_entry(priv, seed, true, &e);
+	idx = rtldsa_find_l2_hash_entry(priv, seed, true, &e);
 
 	if (idx >= 0) {
 		pr_debug("Found entry index %d, key %d and bucket %d\n", idx, idx >> 2, idx & 3);
@@ -2411,7 +2412,7 @@ static int rtl83xx_port_fdb_del(struct dsa_switch *ds, int port,
 	}
 
 	/* Check CAM for spillover from hash buckets */
-	idx = rtl83xx_find_l2_cam_entry(priv, seed, true, &e);
+	idx = rtldsa_find_l2_cam_entry(priv, seed, true, &e);
 
 	if (idx >= 0) {
 		e.valid = false;
@@ -2426,8 +2427,8 @@ out:
 	return err;
 }
 
-static int rtl83xx_port_fdb_dump(struct dsa_switch *ds, int port,
-				 dsa_fdb_dump_cb_t *cb, void *data)
+static int rtldsa_port_fdb_dump(struct dsa_switch *ds, int port,
+				dsa_fdb_dump_cb_t *cb, void *data)
 {
 	struct rtl838x_l2_entry e;
 	struct rtl838x_switch_priv *priv = ds->priv;
@@ -2462,7 +2463,7 @@ static int rtl83xx_port_fdb_dump(struct dsa_switch *ds, int port,
 	return 0;
 }
 
-static bool rtl83xx_mac_is_unsnoop(const unsigned char *addr)
+static bool rtldsa_mac_is_unsnoop(const unsigned char *addr)
 {
 	/*
 	 * RFC4541, section 2.1.2.2 + section 3:
@@ -2480,9 +2481,9 @@ static bool rtl83xx_mac_is_unsnoop(const unsigned char *addr)
 	return false;
 }
 
-static int rtl83xx_port_mdb_add(struct dsa_switch *ds, int port,
-				const struct switchdev_obj_port_mdb *mdb,
-				const struct dsa_db db)
+static int rtldsa_port_mdb_add(struct dsa_switch *ds, int port,
+					const struct switchdev_obj_port_mdb *mdb,
+					const struct dsa_db db)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 	u64 mac = ether_addr_to_u64(mdb->addr);
@@ -2502,7 +2503,7 @@ static int rtl83xx_port_mdb_add(struct dsa_switch *ds, int port,
 		return -EINVAL;
 	}
 
-	if (rtl83xx_mac_is_unsnoop(mdb->addr)) {
+	if (rtldsa_mac_is_unsnoop(mdb->addr)) {
 		dev_dbg(priv->dev,
 			"%s: %pM might belong to an unsnoopable IP. ignore\n",
 			__func__, mdb->addr);
@@ -2511,43 +2512,43 @@ static int rtl83xx_port_mdb_add(struct dsa_switch *ds, int port,
 
 	mutex_lock(&priv->reg_mutex);
 
-	idx = rtl83xx_find_l2_hash_entry(priv, seed, false, &e);
+	idx = rtldsa_find_l2_hash_entry(priv, seed, false, &e);
 
 	/* Found an existing or empty entry */
 	if (idx >= 0) {
 		if (e.valid) {
 			pr_debug("Found an existing entry %016llx, mc_group %d\n",
 				 ether_addr_to_u64(e.mac), e.mc_portmask_index);
-			rtl83xx_mc_group_add_port(priv, e.mc_portmask_index, port);
+			rtldsa_mc_group_add_port(priv, e.mc_portmask_index, port);
 		} else {
 			pr_debug("New entry for seed %016llx\n", seed);
-			mc_group = rtl83xx_mc_group_alloc(priv, port);
+			mc_group = rtldsa_mc_group_alloc(priv, port);
 			if (mc_group < 0) {
 				err = -ENOTSUPP;
 				goto out;
 			}
-			rtl83xx_setup_l2_mc_entry(&e, vid, mac, mc_group);
+			rtldsa_setup_l2_mc_entry(&e, vid, mac, mc_group);
 			priv->r->write_l2_entry_using_hash(idx >> 2, idx & 0x3, &e);
 		}
 		goto out;
 	}
 
 	/* Hash buckets full, try CAM */
-	idx = rtl83xx_find_l2_cam_entry(priv, seed, false, &e);
+	idx = rtldsa_find_l2_cam_entry(priv, seed, false, &e);
 
 	if (idx >= 0) {
 		if (e.valid) {
 			pr_debug("Found existing CAM entry %016llx, mc_group %d\n",
 				 ether_addr_to_u64(e.mac), e.mc_portmask_index);
-			rtl83xx_mc_group_add_port(priv, e.mc_portmask_index, port);
+			rtldsa_mc_group_add_port(priv, e.mc_portmask_index, port);
 		} else {
 			pr_debug("New entry\n");
-			mc_group = rtl83xx_mc_group_alloc(priv, port);
+			mc_group = rtldsa_mc_group_alloc(priv, port);
 			if (mc_group < 0) {
 				err = -ENOTSUPP;
 				goto out;
 			}
-			rtl83xx_setup_l2_mc_entry(&e, vid, mac, mc_group);
+			rtldsa_setup_l2_mc_entry(&e, vid, mac, mc_group);
 			priv->r->write_cam(idx, &e);
 		}
 		goto out;
@@ -2563,9 +2564,9 @@ out:
 	return err;
 }
 
-static int rtl83xx_port_mdb_del(struct dsa_switch *ds, int port,
-				const struct switchdev_obj_port_mdb *mdb,
-			 const struct dsa_db db)
+static int rtldsa_port_mdb_del(struct dsa_switch *ds, int port,
+			       const struct switchdev_obj_port_mdb *mdb,
+			       const struct dsa_db db)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 	u64 mac = ether_addr_to_u64(mdb->addr);
@@ -2582,7 +2583,7 @@ static int rtl83xx_port_mdb_del(struct dsa_switch *ds, int port,
 		return 0;
 	}
 
-	if (rtl83xx_mac_is_unsnoop(mdb->addr)) {
+	if (rtldsa_mac_is_unsnoop(mdb->addr)) {
 		dev_dbg(priv->dev,
 			"%s: %pM might belong to an unsnoopable IP. ignore\n",
 			__func__, mdb->addr);
@@ -2591,11 +2592,11 @@ static int rtl83xx_port_mdb_del(struct dsa_switch *ds, int port,
 
 	mutex_lock(&priv->reg_mutex);
 
-	idx = rtl83xx_find_l2_hash_entry(priv, seed, true, &e);
+	idx = rtldsa_find_l2_hash_entry(priv, seed, true, &e);
 
 	if (idx >= 0) {
 		pr_debug("Found entry index %d, key %d and bucket %d\n", idx, idx >> 2, idx & 3);
-		portmask = rtl83xx_mc_group_del_port(priv, e.mc_portmask_index, port);
+		portmask = rtldsa_mc_group_del_port(priv, e.mc_portmask_index, port);
 		if (!portmask) {
 			e.valid = false;
 			priv->r->write_l2_entry_using_hash(idx >> 2, idx & 0x3, &e);
@@ -2604,10 +2605,10 @@ static int rtl83xx_port_mdb_del(struct dsa_switch *ds, int port,
 	}
 
 	/* Check CAM for spillover from hash buckets */
-	idx = rtl83xx_find_l2_cam_entry(priv, seed, true, &e);
+	idx = rtldsa_find_l2_cam_entry(priv, seed, true, &e);
 
 	if (idx >= 0) {
-		portmask = rtl83xx_mc_group_del_port(priv, e.mc_portmask_index, port);
+		portmask = rtldsa_mc_group_del_port(priv, e.mc_portmask_index, port);
 		if (!portmask) {
 			e.valid = false;
 			priv->r->write_cam(idx, &e);
@@ -2751,7 +2752,9 @@ static int rtldsa_port_pre_bridge_flags(struct dsa_switch *ds, int port,
 	return 0;
 }
 
-static int rtl83xx_port_bridge_flags(struct dsa_switch *ds, int port, struct switchdev_brport_flags flags, struct netlink_ext_ack *extack)
+static int rtldsa_port_bridge_flags(struct dsa_switch *ds, int port,
+				    struct switchdev_brport_flags flags,
+				    struct netlink_ext_ack *extack)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 
@@ -2782,9 +2785,9 @@ static int rtl83xx_port_bridge_flags(struct dsa_switch *ds, int port, struct swi
 	return 0;
 }
 
-static bool rtl83xx_lag_can_offload(struct dsa_switch *ds,
-				    struct net_device *lag,
-				    struct netdev_lag_upper_info *info)
+static bool rtldsa_83xx_lag_can_offload(struct dsa_switch *ds,
+					struct net_device *lag,
+					struct netdev_lag_upper_info *info)
 {
 	int id;
 
@@ -2801,7 +2804,7 @@ static bool rtl83xx_lag_can_offload(struct dsa_switch *ds,
 	return true;
 }
 
-static int rtl83xx_port_lag_change(struct dsa_switch *ds, int port)
+static int rtldsa_port_lag_change(struct dsa_switch *ds, int port)
 {
 	pr_debug("%s: %d\n", __func__, port);
 	/* Nothing to be done... */
@@ -2809,17 +2812,17 @@ static int rtl83xx_port_lag_change(struct dsa_switch *ds, int port)
 	return 0;
 }
 
-static int rtl83xx_port_lag_join(struct dsa_switch *ds,
-				 int port,
-				 struct dsa_lag lag,
-				 struct netdev_lag_upper_info *info,
-				 struct netlink_ext_ack *extack)
+static int rtldsa_port_lag_join(struct dsa_switch *ds,
+				int port,
+				struct dsa_lag lag,
+				struct netdev_lag_upper_info *info,
+				struct netlink_ext_ack *extack)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 	int err = 0;
 	int group;
 
-	if (!rtl83xx_lag_can_offload(ds, lag.dev, info))
+	if (!rtldsa_83xx_lag_can_offload(ds, lag.dev, info))
 		return -EOPNOTSUPP;
 
 	mutex_lock(&priv->reg_mutex);
@@ -2853,8 +2856,8 @@ out:
 	return err;
 }
 
-static int rtl83xx_port_lag_leave(struct dsa_switch *ds, int port,
-				  struct dsa_lag lag)
+static int rtldsa_port_lag_leave(struct dsa_switch *ds, int port,
+				 struct dsa_lag lag)
 {
 	int group, err;
 	struct rtl838x_switch_priv *priv = ds->priv;
@@ -3014,17 +3017,17 @@ unlock:
 	return ret;
 }
 
-const struct dsa_switch_ops rtl83xx_switch_ops = {
-	.get_tag_protocol	= rtl83xx_get_tag_protocol,
-	.setup			= rtl83xx_setup,
+const struct dsa_switch_ops rtldsa_83xx_switch_ops = {
+	.get_tag_protocol	= rtldsa_get_tag_protocol,
+	.setup			= rtldsa_83xx_setup,
 
 	.phy_read		= rtldsa_phy_read,
 	.phy_write		= rtldsa_phy_write,
 
 	.phylink_get_caps	= rtldsa_83xx_phylink_get_caps,
-	.phylink_mac_config	= rtl83xx_phylink_mac_config,
-	.phylink_mac_link_down	= rtl83xx_phylink_mac_link_down,
-	.phylink_mac_link_up	= rtl83xx_phylink_mac_link_up,
+	.phylink_mac_config	= rtldsa_83xx_phylink_mac_config,
+	.phylink_mac_link_down	= rtldsa_83xx_phylink_mac_link_down,
+	.phylink_mac_link_up	= rtldsa_83xx_phylink_mac_link_up,
 	.phylink_mac_select_pcs	= rtldsa_phylink_mac_select_pcs,
 
 	.get_strings		= rtldsa_get_strings,
@@ -3043,47 +3046,47 @@ const struct dsa_switch_ops rtl83xx_switch_ops = {
 	.get_mac_eee		= rtldsa_get_mac_eee,
 	.set_mac_eee		= rtldsa_set_mac_eee,
 
-	.set_ageing_time	= rtl83xx_set_ageing_time,
+	.set_ageing_time	= rtldsa_set_ageing_time,
 	.port_bridge_join	= rtldsa_port_bridge_join,
 	.port_bridge_leave	= rtldsa_port_bridge_leave,
-	.port_stp_state_set	= rtl83xx_port_stp_state_set,
-	.port_fast_age		= rtl83xx_fast_age,
+	.port_stp_state_set	= rtldsa_port_stp_state_set,
+	.port_fast_age		= rtldsa_83xx_fast_age,
 	.port_mst_state_set	= rtldsa_port_mst_state_set,
 
-	.port_vlan_filtering	= rtl83xx_vlan_filtering,
-	.port_vlan_add		= rtl83xx_vlan_add,
-	.port_vlan_del		= rtl83xx_vlan_del,
+	.port_vlan_filtering	= rtldsa_vlan_filtering,
+	.port_vlan_add		= rtldsa_vlan_add,
+	.port_vlan_del		= rtldsa_vlan_del,
 	.vlan_msti_set		= rtldsa_vlan_msti_set,
 
-	.port_fdb_add		= rtl83xx_port_fdb_add,
-	.port_fdb_del		= rtl83xx_port_fdb_del,
-	.port_fdb_dump		= rtl83xx_port_fdb_dump,
+	.port_fdb_add		= rtldsa_port_fdb_add,
+	.port_fdb_del		= rtldsa_port_fdb_del,
+	.port_fdb_dump		= rtldsa_port_fdb_dump,
 
-	.port_mdb_add		= rtl83xx_port_mdb_add,
-	.port_mdb_del		= rtl83xx_port_mdb_del,
+	.port_mdb_add		= rtldsa_port_mdb_add,
+	.port_mdb_del		= rtldsa_port_mdb_del,
 
 	.port_mirror_add	= rtldsa_port_mirror_add,
 	.port_mirror_del	= rtldsa_port_mirror_del,
 
-	.port_lag_change	= rtl83xx_port_lag_change,
-	.port_lag_join		= rtl83xx_port_lag_join,
-	.port_lag_leave		= rtl83xx_port_lag_leave,
+	.port_lag_change	= rtldsa_port_lag_change,
+	.port_lag_join		= rtldsa_port_lag_join,
+	.port_lag_leave		= rtldsa_port_lag_leave,
 
 	.port_pre_bridge_flags	= rtldsa_port_pre_bridge_flags,
-	.port_bridge_flags	= rtl83xx_port_bridge_flags,
+	.port_bridge_flags	= rtldsa_port_bridge_flags,
 };
 
-const struct dsa_switch_ops rtl93xx_switch_ops = {
-	.get_tag_protocol	= rtl83xx_get_tag_protocol,
-	.setup			= rtl93xx_setup,
+const struct dsa_switch_ops rtldsa_93xx_switch_ops = {
+	.get_tag_protocol	= rtldsa_get_tag_protocol,
+	.setup			= rtldsa_93xx_setup,
 
 	.phy_read		= rtldsa_phy_read,
 	.phy_write		= rtldsa_phy_write,
 
 	.phylink_get_caps	= rtldsa_93xx_phylink_get_caps,
-	.phylink_mac_config	= rtl93xx_phylink_mac_config,
-	.phylink_mac_link_down	= rtl93xx_phylink_mac_link_down,
-	.phylink_mac_link_up	= rtl93xx_phylink_mac_link_up,
+	.phylink_mac_config	= rtldsa_93xx_phylink_mac_config,
+	.phylink_mac_link_down	= rtldsa_93xx_phylink_mac_link_down,
+	.phylink_mac_link_up	= rtldsa_93xx_phylink_mac_link_up,
 	.phylink_mac_select_pcs	= rtldsa_phylink_mac_select_pcs,
 
 	.get_strings		= rtldsa_get_strings,
@@ -3102,35 +3105,35 @@ const struct dsa_switch_ops rtl93xx_switch_ops = {
 	.get_mac_eee		= rtldsa_get_mac_eee,
 	.set_mac_eee		= rtldsa_set_mac_eee,
 
-	.set_ageing_time	= rtl83xx_set_ageing_time,
+	.set_ageing_time	= rtldsa_set_ageing_time,
 	.port_bridge_join	= rtldsa_port_bridge_join,
 	.port_bridge_leave	= rtldsa_port_bridge_leave,
-	.port_stp_state_set	= rtl83xx_port_stp_state_set,
-	.port_fast_age		= rtl930x_fast_age,
+	.port_stp_state_set	= rtldsa_port_stp_state_set,
+	.port_fast_age		= rtldsa_930x_fast_age,
 	.port_mst_state_set	= rtldsa_port_mst_state_set,
 
-	.port_vlan_filtering	= rtl83xx_vlan_filtering,
-	.port_vlan_add		= rtl83xx_vlan_add,
-	.port_vlan_del		= rtl83xx_vlan_del,
+	.port_vlan_filtering	= rtldsa_vlan_filtering,
+	.port_vlan_add		= rtldsa_vlan_add,
+	.port_vlan_del		= rtldsa_vlan_del,
 	.port_vlan_fast_age	= rtldsa_port_vlan_fast_age,
 	.vlan_msti_set		= rtldsa_vlan_msti_set,
 
-	.port_fdb_add		= rtl83xx_port_fdb_add,
-	.port_fdb_del		= rtl83xx_port_fdb_del,
-	.port_fdb_dump		= rtl83xx_port_fdb_dump,
+	.port_fdb_add		= rtldsa_port_fdb_add,
+	.port_fdb_del		= rtldsa_port_fdb_del,
+	.port_fdb_dump		= rtldsa_port_fdb_dump,
 
-	.port_mdb_add		= rtl83xx_port_mdb_add,
-	.port_mdb_del		= rtl83xx_port_mdb_del,
+	.port_mdb_add		= rtldsa_port_mdb_add,
+	.port_mdb_del		= rtldsa_port_mdb_del,
 
 	.port_mirror_add	= rtldsa_port_mirror_add,
 	.port_mirror_del	= rtldsa_port_mirror_del,
 
-	.port_lag_change	= rtl83xx_port_lag_change,
-	.port_lag_join		= rtl83xx_port_lag_join,
-	.port_lag_leave		= rtl83xx_port_lag_leave,
+	.port_lag_change	= rtldsa_port_lag_change,
+	.port_lag_join		= rtldsa_port_lag_join,
+	.port_lag_leave		= rtldsa_port_lag_leave,
 
 	.port_pre_bridge_flags	= rtldsa_port_pre_bridge_flags,
-	.port_bridge_flags	= rtl83xx_port_bridge_flags,
+	.port_bridge_flags	= rtldsa_port_bridge_flags,
 
 	.cls_flower_add		= rtldsa_cls_flower_add,
 	.cls_flower_del		= rtldsa_cls_flower_del,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -192,7 +192,7 @@ static void rtl838x_vlan_set_untagged(u32 vlan, u64 portmask)
 	/* Access UNTAG table (0) via register 1 */
 	struct table_reg *r = rtl_table_get(RTL8380_TBL_1, 0);
 
-	sw_w32(portmask & 0x1fffffff, rtl_table_data(r, 0));
+	sw_w32(portmask & RTL838X_MC_PMASK_ALL_PORTS, rtl_table_data(r, 0));
 	rtl_table_write(r, vlan);
 	rtl_table_release(r);
 }
@@ -485,16 +485,17 @@ static void rtl838x_write_mcast_pmask(int idx, u64 portmask)
 	/* Access MC_PMSK (2) via register RTL8380_TBL_L2 */
 	struct table_reg *q = rtl_table_get(RTL8380_TBL_L2, 2);
 
-	sw_w32(((u32)portmask) & 0x1fffffff, rtl_table_data(q, 0));
+	sw_w32(((u32)portmask) & RTL838X_MC_PMASK_ALL_PORTS, rtl_table_data(q, 0));
 	rtl_table_write(q, idx);
 	rtl_table_release(q);
 }
 
 static void rtl838x_vlan_profile_setup(int profile)
 {
-	u32 pmask_id = UNKNOWN_MC_PMASK;
-	/* Enable L2 Learning BIT 0, portmask UNKNOWN_MC_PMASK for unknown MC traffic flooding */
-	u32 p = 1 | pmask_id << 1 | pmask_id << 10 | pmask_id << 19;
+	u32 p = RTL838X_VLAN_L2_LEARN_EN(1) |
+		RTL838X_VLAN_L2_UNKN_MC_FLD(MC_PMASK_ALL_PORTS_IDX) |
+		RTL838X_VLAN_IP4_UNKN_MC_FLD(MC_PMASK_ALL_PORTS_IDX) |
+		RTL838X_VLAN_IP6_UNKN_MC_FLD(MC_PMASK_ALL_PORTS_IDX);
 
 	sw_w32(p, RTL838X_VLAN_PROFILE(profile));
 
@@ -503,7 +504,7 @@ static void rtl838x_vlan_profile_setup(int profile)
 	 * On RTL93XX, the portmask is directly set in the profile,
 	 * see e.g. rtl9300_vlan_profile_setup
 	 */
-	rtl838x_write_mcast_pmask(UNKNOWN_MC_PMASK, 0x1fffffff);
+	rtl838x_write_mcast_pmask(MC_PMASK_ALL_PORTS_IDX, RTL838X_MC_PMASK_ALL_PORTS);
 }
 
 static void rtl838x_l2_learning_setup(void)
@@ -512,7 +513,9 @@ static void rtl838x_l2_learning_setup(void)
 	 * to the reserved entry in the portmask table used also for
 	 * multicast flooding
 	 */
-	sw_w32(UNKNOWN_MC_PMASK << 9 | UNKNOWN_MC_PMASK, RTL838X_L2_FLD_PMSK);
+	sw_w32(RTL838X_L2_BC_FLD(MC_PMASK_ALL_PORTS_IDX) |
+	       RTL838X_L2_UNKN_UC_FLD(MC_PMASK_ALL_PORTS_IDX),
+	       RTL838X_L2_FLD_PMSK);
 
 	/* Enable learning constraint system-wide (bit 0), per-port (bit 1)
 	 * and per vlan (bit 2)
@@ -1779,12 +1782,15 @@ void rtl838x_vlan_profile_dump(int profile)
 {
 	u32 p;
 
-	if (profile < 0 || profile > 7)
+	if (profile < 0 || profile > RTL838X_VLAN_PROFILE_MAX)
 		return;
 
 	p = sw_r32(RTL838X_VLAN_PROFILE(profile));
 
 	pr_debug("VLAN profile %d: L2 learning: %d, UNKN L2MC FLD PMSK %d, UNKN IPMC FLD PMSK %d, UNKN IPv6MC FLD PMSK: %d\n",
-		 profile, p & 1, (p >> 1) & 0x1ff, (p >> 10) & 0x1ff, (p >> 19) & 0x1ff);
+		 profile, RTL838X_VLAN_L2_LEARN_EN_R(p),
+		 RTL838X_VLAN_L2_UNKN_MC_FLD_PMSK(p),
+		 RTL838X_VLAN_IP4_UNKN_MC_FLD_PMSK(p),
+		 RTL838X_VLAN_IP6_UNKN_MC_FLD_PMSK(p));
 }
 

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -3,6 +3,7 @@
 #ifndef _RTL838X_H
 #define _RTL838X_H
 
+#include <asm/mach-rtl838x/mach-rtl83xx.h>
 #include <net/dsa.h>
 
 /* Register definition */
@@ -45,27 +46,72 @@
 /* VLAN registers */
 #define RTL838X_VLAN_CTRL			(0x3A74)
 #define RTL838X_VLAN_PROFILE(idx)		(0x3A88 + ((idx) << 2))
+#define RTL838X_VLAN_PROFILE_MAX		7
 #define RTL838X_VLAN_PORT_EGR_FLTR		(0x3A84)
 #define RTL838X_VLAN_PORT_PB_VLAN		(0x3C00)
 #define RTL838X_VLAN_PORT_IGR_FLTR		(0x3A7C)
 
+#define RTL838X_VLAN_L2_LEARN_EN(i)		(i)
+#define RTL838X_VLAN_L2_UNKN_MC_FLD(pmsk)	(pmsk << 1)
+#define RTL838X_VLAN_IP4_UNKN_MC_FLD(pmsk)	(pmsk << 10)
+#define RTL838X_VLAN_IP6_UNKN_MC_FLD(pmsk)	(pmsk << 19)
+
+#define RTL838X_VLAN_L2_LEARN_EN_R(p)		(p & RTL838X_VLAN_L2_LEARN_EN(1))
+#define RTL838X_VLAN_L2_UNKN_MC_FLD_PMSK(p)	((p >> 1) & (MAX_MC_PMASKS - 1))
+#define RTL838X_VLAN_IP4_UNKN_MC_FLD_PMSK(p)	((p >> 10) & (MAX_MC_PMASKS - 1))
+#define RTL838X_VLAN_IP6_UNKN_MC_FLD_PMSK(p)	((p >> 19) & (MAX_MC_PMASKS - 1))
+
 #define RTL839X_VLAN_PROFILE(idx)		(0x25C0 + (((idx) << 3)))
+#define RTL839X_VLAN_PROFILE_MAX		7
 #define RTL839X_VLAN_CTRL			(0x26D4)
 #define RTL839X_VLAN_PORT_PB_VLAN		(0x26D8)
 #define RTL839X_VLAN_PORT_IGR_FLTR		(0x27B4)
 #define RTL839X_VLAN_PORT_EGR_FLTR		(0x27C4)
 
+#define RTL839X_VLAN_L2_LEARN_EN(i)		(i)
+#define RTL839X_VLAN_L2_UNKN_MC_FLD(pmsk)	(pmsk << 1)
+#define RTL839X_VLAN_IP4_UNKN_MC_FLD(pmsk)	(pmsk << 13)
+#define RTL839X_VLAN_IP6_UNKN_MC_FLD(pmsk)	(pmsk)
+
+#define RTL839X_VLAN_L2_LEARN_EN_R(p)		(p[1] & RTL839X_VLAN_L2_LEARN_EN(1))
+#define RTL839X_VLAN_L2_UNKN_MC_FLD_PMSK(p)	((p[1] >> 1) & (MAX_MC_PMASKS - 1))
+#define RTL839X_VLAN_IP4_UNKN_MC_FLD_PMSK(p)	((p[1] >> 13) & (MAX_MC_PMASKS - 1))
+#define RTL839X_VLAN_IP6_UNKN_MC_FLD_PMSK(p)	((p[0]) & (MAX_MC_PMASKS - 1))
+
 #define RTL930X_VLAN_PROFILE_SET(idx)		(0x9c60 + (((idx) * 20)))
+#define RTL930X_VLAN_PROFILE_MAX		7
 #define RTL930X_VLAN_CTRL			(0x82D4)
 #define RTL930X_VLAN_PORT_PB_VLAN		(0x82D8)
 #define RTL930X_VLAN_PORT_IGR_FLTR		(0x83C0)
 #define RTL930X_VLAN_PORT_EGR_FLTR		(0x83C8)
 
+#define RTL930X_VLAN_L2_UNKN_MC_FLD(pmsk)	(pmsk)
+#define RTL930X_VLAN_IP4_UNKN_MC_FLD(pmsk)	(pmsk)
+#define RTL930X_VLAN_IP6_UNKN_MC_FLD(pmsk)	(pmsk)
+
+#define RTL930X_VLAN_L2_LEARN_EN_R(p)		(p[0] & (3 << 21))
+#define RTL930X_VLAN_L2_UNKN_MC_FLD_PMSK(p)	(p[2] & RTL930X_MC_PMASK_ALL_PORTS)
+#define RTL930X_VLAN_IP4_UNKN_MC_FLD_PMSK(p)	(p[3] & RTL930X_MC_PMASK_ALL_PORTS)
+#define RTL930X_VLAN_IP6_UNKN_MC_FLD_PMSK(p)	(p[4] & RTL930X_MC_PMASK_ALL_PORTS)
+
 #define RTL931X_VLAN_PROFILE_SET(idx)		(0x9800 + (((idx) * 28)))
+#define RTL931X_VLAN_PROFILE_MAX		15
 #define RTL931X_VLAN_CTRL			(0x94E4)
 #define RTL931X_VLAN_PORT_IGR_CTRL		(0x94E8)
 #define RTL931X_VLAN_PORT_IGR_FLTR		(0x96B4)
 #define RTL931X_VLAN_PORT_EGR_FLTR		(0x96C4)
+
+#define RTL931X_VLAN_L2_UNKN_MC_FLD_H(pmsk)	(((u64)pmsk) >> 32)
+#define RTL931X_VLAN_L2_UNKN_MC_FLD_L(pmsk)	(pmsk & GENMASK_ULL(31, 0))
+#define RTL931X_VLAN_IP4_UNKN_MC_FLD_H(pmsk)	(((u64)pmsk) >> 32)
+#define RTL931X_VLAN_IP4_UNKN_MC_FLD_L(pmsk)	(pmsk & GENMASK_ULL(31, 0))
+#define RTL931X_VLAN_IP6_UNKN_MC_FLD_H(pmsk)	(((u64)pmsk) >> 32)
+#define RTL931X_VLAN_IP6_UNKN_MC_FLD_L(pmsk)	(pmsk & GENMASK_ULL(31, 0))
+
+#define RTL931X_VLAN_L2_LEARN_EN_R(p)		(p[0] & (3 << 14))
+#define RTL931X_VLAN_L2_UNKN_MC_FLD_PMSK(p)	((((u64)p[1]) << 32 | p[2]) & RTL931X_MC_PMASK_ALL_PORTS)
+#define RTL931X_VLAN_IP4_UNKN_MC_FLD_PMSK(p)	((((u64)p[3]) << 32 | p[4]) & RTL931X_MC_PMASK_ALL_PORTS)
+#define RTL931X_VLAN_IP6_UNKN_MC_FLD_PMSK(p)	((((u64)p[5]) << 32 | p[6]) & RTL931X_MC_PMASK_ALL_PORTS)
 
 /* Table access registers */
 #define RTL838X_TBL_ACCESS_CTRL_0		(0x6914)
@@ -206,6 +252,11 @@
 
 #define RTL930X_L2_UNKN_UC_FLD_PMSK		(0x9064)
 #define RTL931X_L2_UNKN_UC_FLD_PMSK		(0xC8F4)
+
+#define RTL838X_L2_BC_FLD(pmsk)			(pmsk << 9)
+#define RTL838X_L2_UNKN_UC_FLD(pmsk)		(pmsk)
+#define RTL839X_L2_BC_FLD(pmsk)			(pmsk << 12)
+#define RTL839X_L2_UNKN_UC_FLD(pmsk)		(pmsk)
 
 #define RTL838X_L2_LRN_CONSTRT_EN		(0x3368)
 #define RTL838X_L2_PORT_LRN_CONSTRT		(0x32A0)
@@ -701,8 +752,20 @@ typedef enum {
 #define MAX_LAGS 16
 #define MAX_PRIOS 8
 #define RTL930X_PORT_IGNORE 0x3f
+/* ToDo: MAX_MC_GROUPS could be increased
+ * 838x/839x/930x/931x -> 8192/16384/16384/32768 entries (priv->fib_entries)
+ * They are shared with unicast entries
+ */
 #define MAX_MC_GROUPS 512
-#define UNKNOWN_MC_PMASK (MAX_MC_GROUPS - 1)
+/* ToDo: MAX_MC_PMASKS could be increased
+ * 838x/839x/930x/931x -> 512/4096/1024/4096 entries
+ */
+#define MAX_MC_PMASKS 512
+#define RTL838X_MC_PMASK_ALL_PORTS (GENMASK(RTL838X_CPU_PORT, 0))
+#define RTL839X_MC_PMASK_ALL_PORTS (GENMASK_ULL(RTL839X_CPU_PORT, 0))
+#define RTL930X_MC_PMASK_ALL_PORTS (GENMASK(RTL930X_CPU_PORT, 0))
+#define RTL931X_MC_PMASK_ALL_PORTS (GENMASK_ULL(RTL931X_CPU_PORT, 0))
+#define MC_PMASK_ALL_PORTS_IDX	((MAX_MC_PMASKS - 1))
 #define PIE_BLOCK_SIZE 128
 #define MAX_PIE_ENTRIES (18 * PIE_BLOCK_SIZE)
 #define N_FIXED_FIELDS 12

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -130,11 +130,11 @@ inline void rtl_table_data_w(struct table_reg *r, u32 v, int i);
 void rtldsa_838x_qos_init(struct rtl838x_switch_priv *priv);
 void rtldsa_839x_qos_init(struct rtl838x_switch_priv *priv);
 
-void rtl83xx_fast_age(struct dsa_switch *ds, int port);
+void rtldsa_83xx_fast_age(struct dsa_switch *ds, int port);
 int rtl83xx_packet_cntr_alloc(struct rtl838x_switch_priv *priv);
 int rtldsa_port_get_stp_state(struct rtl838x_switch_priv *priv, int port);
 int rtl83xx_port_is_under(const struct net_device *dev, struct rtl838x_switch_priv *priv);
-void rtl83xx_port_stp_state_set(struct dsa_switch *ds, int port, u8 state);
+void rtldsa_port_stp_state_set(struct dsa_switch *ds, int port, u8 state);
 int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type_data);
 
 /* Port register accessor functions for the RTL839x and RTL931X SoCs */
@@ -199,8 +199,8 @@ void rtl930x_pie_rule_dump_raw(u32 r[]);
 
 void rtl931x_print_matrix(void);
 
-extern const struct dsa_switch_ops rtl83xx_switch_ops;
-extern const struct dsa_switch_ops rtl93xx_switch_ops;
+extern const struct dsa_switch_ops rtldsa_83xx_switch_ops;
+extern const struct dsa_switch_ops rtldsa_93xx_switch_ops;
 
 extern const struct rtl838x_reg rtl838x_reg;
 extern const struct rtl838x_reg rtl839x_reg;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -310,17 +310,20 @@ void rtl930x_vlan_profile_dump(int profile)
 {
 	u32 p[5];
 
-	if (profile < 0 || profile > 7)
+	if (profile < 0 || profile > RTL930X_VLAN_PROFILE_MAX)
 		return;
 
 	p[0] = sw_r32(RTL930X_VLAN_PROFILE_SET(profile));
 	p[1] = sw_r32(RTL930X_VLAN_PROFILE_SET(profile) + 4);
-	p[2] = sw_r32(RTL930X_VLAN_PROFILE_SET(profile) + 8) & 0x1FFFFFFF;
-	p[3] = sw_r32(RTL930X_VLAN_PROFILE_SET(profile) + 12) & 0x1FFFFFFF;
-	p[4] = sw_r32(RTL930X_VLAN_PROFILE_SET(profile) + 16) & 0x1FFFFFFF;
+	p[2] = sw_r32(RTL930X_VLAN_PROFILE_SET(profile) + 8);
+	p[3] = sw_r32(RTL930X_VLAN_PROFILE_SET(profile) + 12);
+	p[4] = sw_r32(RTL930X_VLAN_PROFILE_SET(profile) + 16);
 
-	pr_debug("VLAN %d: L2 learn: %d; Unknown MC PMasks: L2 %0x, IPv4 %0x, IPv6: %0x",
-		 profile, p[0] & (3 << 21), p[2], p[3], p[4]);
+	pr_debug("VLAN %d: L2 learn: %d; Unknown MC PMasks: L2 %0lx, IPv4 %0lx, IPv6: %0lx",
+		 profile, RTL930X_VLAN_L2_LEARN_EN_R(p),
+		 RTL930X_VLAN_L2_UNKN_MC_FLD_PMSK(p),
+		 RTL930X_VLAN_IP4_UNKN_MC_FLD_PMSK(p),
+		 RTL930X_VLAN_IP6_UNKN_MC_FLD_PMSK(p));
 	pr_debug("  Routing enabled: IPv4 UC %c, IPv6 UC %c, IPv4 MC %c, IPv6 MC %c\n",
 		 p[0] & BIT(17) ? 'y' : 'n', p[0] & BIT(16) ? 'y' : 'n',
 		 p[0] & BIT(13) ? 'y' : 'n', p[0] & BIT(12) ? 'y' : 'n');
@@ -359,9 +362,10 @@ static void rtl930x_vlan_profile_setup(int profile)
 
 	/* Enable routing of Ipv4/6 Unicast and IPv4/6 Multicast traffic */
 	p[0] |= BIT(17) | BIT(16) | BIT(13) | BIT(12);
-	p[2] = 0x1fffffff; /* L2 unknown MC flooding portmask all ports, including the CPU-port */
-	p[3] = 0x1fffffff; /* IPv4 unknown MC flooding portmask */
-	p[4] = 0x1fffffff; /* IPv6 unknown MC flooding portmask */
+
+	p[2] = RTL930X_VLAN_L2_UNKN_MC_FLD(RTL930X_MC_PMASK_ALL_PORTS);
+	p[3] = RTL930X_VLAN_IP4_UNKN_MC_FLD(RTL930X_MC_PMASK_ALL_PORTS);
+	p[4] = RTL930X_VLAN_IP6_UNKN_MC_FLD(RTL930X_MC_PMASK_ALL_PORTS);
 
 	sw_w32(p[0], RTL930X_VLAN_PROFILE_SET(profile));
 	sw_w32(p[1], RTL930X_VLAN_PROFILE_SET(profile) + 4);
@@ -373,10 +377,10 @@ static void rtl930x_vlan_profile_setup(int profile)
 static void rtl930x_l2_learning_setup(void)
 {
 	/* Portmask for flooding broadcast traffic */
-	sw_w32(0x1fffffff, RTL930X_L2_BC_FLD_PMSK);
+	sw_w32(RTL930X_MC_PMASK_ALL_PORTS, RTL930X_L2_BC_FLD_PMSK);
 
 	/* Portmask for flooding unicast traffic with unknown destination */
-	sw_w32(0x1fffffff, RTL930X_L2_UNKN_UC_FLD_PMSK);
+	sw_w32(RTL930X_MC_PMASK_ALL_PORTS, RTL930X_L2_UNKN_UC_FLD_PMSK);
 
 	/* Limit learning to maximum: 32k entries, after that just flood (bits 0-1) */
 	sw_w32((0x7fff << 2) | 0, RTL930X_L2_LRN_CONSTRT_CTRL);

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -147,8 +147,8 @@ static void rtl931x_vlan_profile_dump(int index)
 	profile[0] = sw_r32(RTL931X_VLAN_PROFILE_SET(index));
 	profile[1] = (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 4) & 0x1FFFFFFFULL) << 32 |
 		     (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 8) & 0xFFFFFFFF);
-	profile[2] = (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 16) & 0x1FFFFFFFULL) << 32 |
-		     (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 12) & 0xFFFFFFFF);
+	profile[2] = (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 12) & 0x1FFFFFFFULL) << 32 |
+		     (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 16) & 0xFFFFFFFF);
 	profile[3] = (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 20) & 0x1FFFFFFFULL) << 32 |
 		     (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 24) & 0xFFFFFFFF);
 

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -139,21 +139,24 @@ inline int rtl931x_tbl_access_data_0(int i)
 
 static void rtl931x_vlan_profile_dump(int index)
 {
-	u64 profile[4];
+	u32 p[7];
 
-	if (index < 0 || index > 15)
+	if (index < 0 || index > RTL931X_VLAN_PROFILE_MAX)
 		return;
 
-	profile[0] = sw_r32(RTL931X_VLAN_PROFILE_SET(index));
-	profile[1] = (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 4) & 0x1FFFFFFFULL) << 32 |
-		     (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 8) & 0xFFFFFFFF);
-	profile[2] = (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 12) & 0x1FFFFFFFULL) << 32 |
-		     (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 16) & 0xFFFFFFFF);
-	profile[3] = (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 20) & 0x1FFFFFFFULL) << 32 |
-		     (sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 24) & 0xFFFFFFFF);
+	p[0] = sw_r32(RTL931X_VLAN_PROFILE_SET(index));
+	p[1] = sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 4);
+	p[2] = sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 8);
+	p[3] = sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 12);
+	p[4] = sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 16);
+	p[5] = sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 20);
+	p[6] = sw_r32(RTL931X_VLAN_PROFILE_SET(index) + 24);
 
 	pr_debug("VLAN %d: L2 learning: %d, L2 Unknown MultiCast Field %llx, IPv4 Unknown MultiCast Field %llx, IPv6 Unknown MultiCast Field: %llx\n",
-		 index, (u32)(profile[0] & (3 << 14)), profile[1], profile[2], profile[3]);
+		 index, RTL931X_VLAN_L2_LEARN_EN_R(p),
+		 RTL931X_VLAN_L2_UNKN_MC_FLD_PMSK(p),
+		 RTL931X_VLAN_IP4_UNKN_MC_FLD_PMSK(p),
+		 RTL931X_VLAN_IP6_UNKN_MC_FLD_PMSK(p));
 }
 
 static int rtldsa_931x_stp_get(struct rtl838x_switch_priv *priv, u16 msti, int port, u32 port_state[])
@@ -809,12 +812,12 @@ static void rtl931x_vlan_profile_setup(int profile)
 	/* p[0] |= BIT(17) | BIT(16) | BIT(13) | BIT(12); */
 	p[0] |= 0x3 << 11; /* COPY2CPU */
 
-	p[1] = 0x1FFFFFF; /* L2 unknwon MC flooding portmask all ports, including the CPU-port */
-	p[2] = 0xFFFFFFFF;
-	p[3] = 0x1FFFFFF; /* IPv4 unknwon MC flooding portmask */
-	p[4] = 0xFFFFFFFF;
-	p[5] = 0x1FFFFFF; /* IPv6 unknwon MC flooding portmask */
-	p[6] = 0xFFFFFFFF;
+	p[1] = RTL931X_VLAN_L2_UNKN_MC_FLD_H(RTL931X_MC_PMASK_ALL_PORTS);
+	p[2] = RTL931X_VLAN_L2_UNKN_MC_FLD_L(RTL931X_MC_PMASK_ALL_PORTS);
+	p[3] = RTL931X_VLAN_IP4_UNKN_MC_FLD_H(RTL931X_MC_PMASK_ALL_PORTS);
+	p[4] = RTL931X_VLAN_IP4_UNKN_MC_FLD_L(RTL931X_MC_PMASK_ALL_PORTS);
+	p[5] = RTL931X_VLAN_IP6_UNKN_MC_FLD_H(RTL931X_MC_PMASK_ALL_PORTS);
+	p[6] = RTL931X_VLAN_IP6_UNKN_MC_FLD_L(RTL931X_MC_PMASK_ALL_PORTS);
 
 	for (int i = 0; i < 7; i++)
 		sw_w32(p[i], RTL931X_VLAN_PROFILE_SET(profile) + i * 4);
@@ -824,10 +827,10 @@ static void rtl931x_vlan_profile_setup(int profile)
 static void rtl931x_l2_learning_setup(void)
 {
 	/* Portmask for flooding broadcast traffic */
-	rtl839x_set_port_reg_be(0x1FFFFFFFFFFFFFF, RTL931X_L2_BC_FLD_PMSK);
+	rtl839x_set_port_reg_be(RTL931X_MC_PMASK_ALL_PORTS, RTL931X_L2_BC_FLD_PMSK);
 
 	/* Portmask for flooding unicast traffic with unknown destination */
-	rtl839x_set_port_reg_be(0x1FFFFFFFFFFFFFF, RTL931X_L2_UNKN_UC_FLD_PMSK);
+	rtl839x_set_port_reg_be(RTL931X_MC_PMASK_ALL_PORTS, RTL931X_L2_UNKN_UC_FLD_PMSK);
 
 	/* Limit learning to maximum: 64k entries, after that just flood (bits 0-2) */
 	sw_w32((0xffff << 3) | FORWARD, RTL931X_L2_LRN_CONSTRT_CTRL);


### PR DESCRIPTION
For one thing this ensures a unified function naming especially in dsa.c, that is that all functions should start with rtldsa_ in dsa.c.

For another this adds names/macros for various "magic numbers", to hopefully increase readability and add more context to these numbers.

Tested-on: Zyxel GS1900-24E A1

---

These patches were split from and originally developed in: https://github.com/openwrt/openwrt/pull/18780.