### PR TITLE
kernel: net: ethernet: mtk_eth_soc: fix memory leak in downstream patch

### DIFF
--- a/target/linux/generic/pending-6.12/737-net-ethernet-mtk_eth_soc-add-paths-and-SerDes-modes-.patch
+++ b/target/linux/generic/pending-6.12/737-net-ethernet-mtk_eth_soc-add-paths-and-SerDes-modes-.patch
@@ -505,7 +505,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	phy_interface_t phy_mode;
  	struct phylink *phylink;
  	struct mtk_mac *mac;
-@@ -4866,16 +5018,41 @@ static int mtk_add_mac(struct mtk_eth *e
+@@ -4866,16 +5018,44 @@ static int mtk_add_mac(struct mtk_eth *e
  	mac->id = id;
  	mac->hw = eth;
  	mac->of_node = np;
@@ -513,15 +513,30 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	if (pcs_np) {
 +		mac->sgmii_pcs = mtk_pcs_lynxi_get(eth->dev, pcs_np);
 +		if (IS_ERR(mac->sgmii_pcs)) {
-+			if (PTR_ERR(mac->sgmii_pcs) == -EPROBE_DEFER)
-+				return -EPROBE_DEFER;
++			if (PTR_ERR(mac->sgmii_pcs) != -EPROBE_DEFER)
++				dev_err(eth->dev,
++					"cannot select SGMII PCS, error %ld\n",
++					PTR_ERR(mac->sgmii_pcs));
++
++			err = PTR_ERR(mac->sgmii_pcs);
++			goto free_netdev;
++		}
++	}
  
 -	err = of_get_ethdev_address(mac->of_node, eth->netdev[id]);
 -	if (err == -EPROBE_DEFER)
 -		return err;
-+			dev_err(eth->dev, "cannot select SGMII PCS, error %ld\n",
-+				PTR_ERR(mac->sgmii_pcs));
-+			return PTR_ERR(mac->sgmii_pcs);
++	pcs_np = of_parse_phandle(mac->of_node, "pcs-handle", 1);
++	if (pcs_np) {
++		mac->usxgmii_pcs = mtk_usxgmii_pcs_get(eth->dev, pcs_np);
++		if (IS_ERR(mac->usxgmii_pcs)) {
++			if (PTR_ERR(mac->usxgmii_pcs) != -EPROBE_DEFER)
++				dev_err(eth->dev,
++					"cannot select USXGMII PCS, error %ld\n",
++					PTR_ERR(mac->usxgmii_pcs));
++
++			err = PTR_ERR(mac->usxgmii_pcs);
++			goto free_netdev;
 +		}
 +	}
  
@@ -530,19 +545,6 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 -		eth_hw_addr_random(eth->netdev[id]);
 -		dev_err(eth->dev, "generated random MAC address %pM\n",
 -			eth->netdev[id]->dev_addr);
-+	pcs_np = of_parse_phandle(mac->of_node, "pcs-handle", 1);
-+	if (pcs_np) {
-+		mac->usxgmii_pcs = mtk_usxgmii_pcs_get(eth->dev, pcs_np);
-+		if (IS_ERR(mac->usxgmii_pcs)) {
-+			if (PTR_ERR(mac->usxgmii_pcs) == -EPROBE_DEFER)
-+				return -EPROBE_DEFER;
-+
-+			dev_err(eth->dev, "cannot select USXGMII PCS, error %ld\n",
-+				PTR_ERR(mac->usxgmii_pcs));
-+			return PTR_ERR(mac->usxgmii_pcs);
-+		}
-+	}
-+
 +	if (mtk_is_netsys_v3_or_greater(eth) && (mac->sgmii_pcs || mac->usxgmii_pcs)) {
 +		mac->pextp = devm_of_phy_optional_get(eth->dev, mac->of_node, NULL);
 +		if (IS_ERR(mac->pextp)) {
@@ -550,12 +552,13 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +				dev_err(eth->dev, "cannot get PHY, error %ld\n",
 +					PTR_ERR(mac->pextp));
 +
-+			return PTR_ERR(mac->pextp);
++			err = PTR_ERR(mac->pextp);
++			goto free_netdev;
 +		}
  	}
  
  	memset(mac->hwlro_ip, 0, sizeof(mac->hwlro_ip));
-@@ -4958,8 +5135,21 @@ static int mtk_add_mac(struct mtk_eth *e
+@@ -4958,8 +5138,21 @@ static int mtk_add_mac(struct mtk_eth *e
  		phy_interface_zero(mac->phylink_config.supported_interfaces);
  		__set_bit(PHY_INTERFACE_MODE_INTERNAL,
  			  mac->phylink_config.supported_interfaces);
@@ -577,7 +580,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	phylink = phylink_create(&mac->phylink_config,
  				 of_fwnode_handle(mac->of_node),
  				 phy_mode, &mtk_phylink_ops);
-@@ -5010,6 +5200,26 @@ free_netdev:
+@@ -5010,6 +5203,26 @@ free_netdev:
  	return err;
  }
  
@@ -604,7 +607,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  void mtk_eth_set_dma_device(struct mtk_eth *eth, struct device *dma_dev)
  {
  	struct net_device *dev, *tmp;
-@@ -5156,7 +5366,8 @@ static int mtk_probe(struct platform_dev
+@@ -5156,7 +5369,8 @@ static int mtk_probe(struct platform_dev
  			regmap_write(cci, 0, 3);
  	}
  
@@ -614,7 +617,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		err = mtk_sgmii_init(eth);
  
  		if (err)
-@@ -5267,6 +5478,24 @@ static int mtk_probe(struct platform_dev
+@@ -5267,6 +5481,24 @@ static int mtk_probe(struct platform_dev
  		}
  	}
  
@@ -639,7 +642,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	if (MTK_HAS_CAPS(eth->soc->caps, MTK_SHARED_INT)) {
  		err = devm_request_irq(eth->dev, eth->irq[0],
  				       mtk_handle_irq, 0,
-@@ -5377,6 +5606,11 @@ static void mtk_remove(struct platform_d
+@@ -5377,6 +5609,11 @@ static void mtk_remove(struct platform_d
  		mtk_stop(eth->netdev[i]);
  		mac = netdev_priv(eth->netdev[i]);
  		phylink_disconnect_phy(mac->phylink);

--- a/target/linux/generic/pending-6.12/738-01-net-ethernet-mtk_eth_soc-reduce-rx-ring-size-for-older.patch
+++ b/target/linux/generic/pending-6.12/738-01-net-ethernet-mtk_eth_soc-reduce-rx-ring-size-for-older.patch
@@ -30,7 +30,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -5644,7 +5644,7 @@ static const struct mtk_soc_data mt2701_
+@@ -5647,7 +5647,7 @@ static const struct mtk_soc_data mt2701_
  		DESC_SIZE(struct mtk_rx_dma),
  		.irq_done_mask = MTK_RX_DONE_INT,
  		.dma_l4_valid = RX_DMA_L4_VALID,
@@ -39,7 +39,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
-@@ -5672,7 +5672,7 @@ static const struct mtk_soc_data mt7621_
+@@ -5675,7 +5675,7 @@ static const struct mtk_soc_data mt7621_
  		DESC_SIZE(struct mtk_rx_dma),
  		.irq_done_mask = MTK_RX_DONE_INT,
  		.dma_l4_valid = RX_DMA_L4_VALID,
@@ -48,7 +48,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
-@@ -5702,7 +5702,7 @@ static const struct mtk_soc_data mt7622_
+@@ -5705,7 +5705,7 @@ static const struct mtk_soc_data mt7622_
  		DESC_SIZE(struct mtk_rx_dma),
  		.irq_done_mask = MTK_RX_DONE_INT,
  		.dma_l4_valid = RX_DMA_L4_VALID,
@@ -57,7 +57,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
-@@ -5731,7 +5731,7 @@ static const struct mtk_soc_data mt7623_
+@@ -5734,7 +5734,7 @@ static const struct mtk_soc_data mt7623_
  		DESC_SIZE(struct mtk_rx_dma),
  		.irq_done_mask = MTK_RX_DONE_INT,
  		.dma_l4_valid = RX_DMA_L4_VALID,
@@ -66,7 +66,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
-@@ -5757,7 +5757,7 @@ static const struct mtk_soc_data mt7629_
+@@ -5760,7 +5760,7 @@ static const struct mtk_soc_data mt7629_
  		DESC_SIZE(struct mtk_rx_dma),
  		.irq_done_mask = MTK_RX_DONE_INT,
  		.dma_l4_valid = RX_DMA_L4_VALID,
@@ -75,7 +75,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
-@@ -5789,7 +5789,7 @@ static const struct mtk_soc_data mt7981_
+@@ -5792,7 +5792,7 @@ static const struct mtk_soc_data mt7981_
  		.dma_l4_valid = RX_DMA_L4_VALID_V2,
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
@@ -84,7 +84,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	},
  };
  
-@@ -5819,7 +5819,7 @@ static const struct mtk_soc_data mt7986_
+@@ -5822,7 +5822,7 @@ static const struct mtk_soc_data mt7986_
  		.dma_l4_valid = RX_DMA_L4_VALID_V2,
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
@@ -93,7 +93,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	},
  };
  
-@@ -5872,7 +5872,7 @@ static const struct mtk_soc_data rt5350_
+@@ -5875,7 +5875,7 @@ static const struct mtk_soc_data rt5350_
  		.dma_l4_valid = RX_DMA_L4_VALID_PDMA,
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,

--- a/target/linux/mediatek/patches-6.12/750-net-ethernet-mtk_eth_soc-add-mt7987-support.patch
+++ b/target/linux/mediatek/patches-6.12/750-net-ethernet-mtk_eth_soc-add-mt7987-support.patch
@@ -126,7 +126,7 @@ Signed-off-by: Bo-Cun Chen <bc-bocun.chen@mediatek.com>
  			if (mtk_is_netsys_v1(eth))
  				val |= MTK_QTX_SCH_LEAKY_BUCKET_EN;
  			mtk_w32(eth, val, soc->reg_map->qdma.qtx_sch + ofs);
-@@ -5880,6 +5916,36 @@ static const struct mtk_soc_data mt7986_
+@@ -5883,6 +5919,36 @@ static const struct mtk_soc_data mt7986_
  	},
  };
  
@@ -163,7 +163,7 @@ Signed-off-by: Bo-Cun Chen <bc-bocun.chen@mediatek.com>
  static const struct mtk_soc_data mt7988_data = {
  	.reg_map = &mt7988_reg_map,
  	.ana_rgc3 = 0x128,
-@@ -5941,6 +6007,7 @@ const struct of_device_id of_mtk_match[]
+@@ -5944,6 +6010,7 @@ const struct of_device_id of_mtk_match[]
  	{ .compatible = "mediatek,mt7629-eth", .data = &mt7629_data },
  	{ .compatible = "mediatek,mt7981-eth", .data = &mt7981_data },
  	{ .compatible = "mediatek,mt7986-eth", .data = &mt7986_data },


### PR DESCRIPTION
Bc-bocun Chen of MediaTek has discovered a memory leak in the error path in our downstream patch for mtk_eth_soc which adds support for the 10G PCS and PHY paths of the MT7988 SoC.
Fix this by freeing the at this point already allocated netdev resources before returning the error.

Fixes: https://github.com/openwrt/openwrt/commit/4cb6bd9a6d7ca2b5ff90592b815d344de1ab6770 ("mediatek: switch to pending XFI 10G Ethernet drivers")