### PR TITLE
build/sdk: fix pkg-config detection inside a nix-shell

### DIFF
--- a/target/sdk/files/Makefile
+++ b/target/sdk/files/Makefile
@@ -14,7 +14,7 @@ export TOPDIR LC_ALL LANG SDK
 
 world:
 
-DISTRO_PKG_CONFIG:=$(shell $(TOPDIR)/scripts/command_all.sh pkg-config | grep '/usr' -m 1)
+DISTRO_PKG_CONFIG:=$(shell $(TOPDIR)/scripts/command_all.sh pkg-config | grep -v 'staging_dir/' -m 1)
 
 export ORIG_PATH:=$(if $(ORIG_PATH),$(ORIG_PATH),$(PATH))
 export PATH:=$(TOPDIR)/staging_dir/host/bin:$(PATH)


### PR DESCRIPTION
The output of command_all when inside a nix-shell looks like the below where /usr does not match:

 ➜ scripts/command_all.sh pkg-config
/nix/store/ifr6srqgpvygd5vp14748d109ri31isv-pkg-config-wrapper-0.29.2/bin/pkg-config

Analog to https://github.com/openwrt/openwrt/commit/86ca7199dfb132042ce3110acef23d74f4ef14a7
