### PR TITLE
realtek: dts: add LGS328C port 21 definition

### DIFF
--- a/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
+++ b/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
@@ -197,6 +197,7 @@
 		SWITCH_PORT_SDS(17, 18, 3, usxgmii)
 		SWITCH_PORT_SDS(18, 19, 3, usxgmii)
 		SWITCH_PORT_SDS(19, 20, 3, usxgmii)
+		SWITCH_PORT_SDS(20, 21, 3, usxgmii)
 		SWITCH_PORT_SDS(21, 22, 3, usxgmii)
 		SWITCH_PORT_SDS(22, 23, 3, usxgmii)
 		SWITCH_PORT_SDS(23, 24, 3, usxgmii)


### PR DESCRIPTION
Port 21 definition was missed during addition of LGS328C. Add it to the dts.