### PR TITLE
netfilter: fix some dependencies

### DIFF
--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -13,10 +13,11 @@ P_EBT:=bridge/netfilter/
 endif
 
 # 1: variable
-# 2: kconfig symbols
+# 2: kconfig symbol - multiple symbols are not supported
 # 3: file list
 # 4: version dependency
 define nf_add
+ $(if $(word 2,$(2)),$(warning ### FAIL: nf_add called with multiple symbols for $(1): $(2)))
  $(if $(4),ifeq ($$(strip $$(call CompareKernelPatchVer,$$(KERNEL_PATCHVER),$(firstword $(4)),$(lastword $(4)))),1))
   $(1)-$$($(2)) += $(3)
  $(if $(4),endif)

--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -146,6 +146,7 @@ $(eval $(call nf_add,IPT_FLOW,CONFIG_NETFILTER_XT_TARGET_FLOWOFFLOAD, $(P_XT)xt_
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_REJECT6,CONFIG_NF_REJECT_IPV6, $(P_V6)nf_reject_ipv6),))
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_IPT6,CONFIG_IP6_NF_IPTABLES, $(P_V6)ip6_tables),))
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_IPT6,CONFIG_IP6_NF_IPTABLES_LEGACY, $(P_V6)ip6_tables),))
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_CONNTRACK,CONFIG_NF_DEFRAG_IPV6, $(P_V6)nf_defrag_ipv6),))
 

--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -286,6 +286,7 @@ $(eval $(if $(NF_KMOD),$(call nf_add,NF_CONNCOUNT,CONFIG_NETFILTER_CONNCOUNT, $(
 #
 
 $(eval $(if $(NF_KMOD),$(call nf_add,EBTABLES,CONFIG_BRIDGE_NF_EBTABLES, $(P_EBT)ebtables),))
+$(eval $(if $(NF_KMOD),$(call nf_add,EBTABLES,CONFIG_BRIDGE_NF_EBTABLES_LEGACY, $(P_EBT)ebtables),))
 
 # ebtables: tables
 $(eval $(call nf_add,EBTABLES,CONFIG_BRIDGE_EBT_BROUTE, $(P_EBT)ebtable_broute))

--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -31,11 +31,11 @@ endef
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_REJECT,CONFIG_NF_REJECT_IPV4, $(P_V4)nf_reject_ipv4),))
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_IPT,CONFIG_IP_NF_IPTABLES, $(P_V4)ip_tables),))
-$(eval $(if $(NF_KMOD),$(call nf_add,NF_IPT,CONFIG_NETFILTER_XTABLES, $(P_XT)x_tables),))
 
-$(eval $(if $(NF_KMOD),$(call nf_add,IPT_CORE,CONFIG_NETFILTER_XTABLES, $(P_XT)xt_tcpudp),))
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_CORE,CONFIG_IP_NF_FILTER, $(P_V4)iptable_filter),))
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_CORE,CONFIG_IP_NF_MANGLE, $(P_V4)iptable_mangle),))
+
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_XTABLES,CONFIG_NETFILTER_XTABLES, $(P_XT)x_tables $(P_XT)xt_tcpudp),))
 
 # userland only
 $(eval $(if $(NF_KMOD),,$(call nf_add,IPT_CORE,CONFIG_IP_NF_IPTABLES, xt_standard ipt_icmp xt_tcp xt_udp xt_comment xt_set xt_SET)))

--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -31,6 +31,7 @@ endef
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_REJECT,CONFIG_NF_REJECT_IPV4, $(P_V4)nf_reject_ipv4),))
 
 $(eval $(if $(NF_KMOD),$(call nf_add,NF_IPT,CONFIG_IP_NF_IPTABLES, $(P_V4)ip_tables),))
+$(eval $(if $(NF_KMOD),$(call nf_add,NF_IPT,CONFIG_IP_NF_IPTABLES_LEGACY, $(P_V4)ip_tables),))
 
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_CORE,CONFIG_IP_NF_FILTER, $(P_V4)iptable_filter),))
 $(eval $(if $(NF_KMOD),$(call nf_add,IPT_CORE,CONFIG_IP_NF_MANGLE, $(P_V4)iptable_mangle),))

--- a/include/netfilter.mk
+++ b/include/netfilter.mk
@@ -265,6 +265,7 @@ $(eval $(if $(NF_KMOD),$(call nf_add,NF_CONNCOUNT,CONFIG_NETFILTER_CONNCOUNT, $(
 #
 
 $(eval $(if $(NF_KMOD),$(call nf_add,EBTABLES,CONFIG_BRIDGE_NF_EBTABLES, $(P_EBT)ebtables),))
+$(eval $(if $(NF_KMOD),$(call nf_add,EBTABLES,CONFIG_BRIDGE_NF_EBTABLES_LEGACY, $(P_EBT)ebtables),))
 
 # ebtables: tables
 $(eval $(call nf_add,EBTABLES,CONFIG_BRIDGE_EBT_BROUTE, $(P_EBT)ebtable_broute))

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -76,7 +76,7 @@ define KernelPackage/nf-ipt
   SUBMENU:=$(NF_MENU)
   TITLE:=Iptables core
   KCONFIG:=$(KCONFIG_NF_IPT)
-  DEPENDS:=+!LINUX_6_12:kmod-iptables
+  DEPENDS:=+!LINUX_6_12:kmod-iptables +kmod-nf-xtables
   FILES:=$(foreach mod,$(NF_IPT-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_IPT-m)))
 endef
@@ -103,7 +103,7 @@ define KernelPackage/ipt-core
   KCONFIG:=$(KCONFIG_IPT_CORE)
   FILES:=$(foreach mod,$(IPT_CORE-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(IPT_CORE-m)))
-  DEPENDS:=+kmod-nf-reject +kmod-nf-ipt +kmod-nf-log
+  DEPENDS:=+kmod-nf-reject +kmod-nf-ipt +kmod-nf-log +kmod-nf-xtables
 endef
 
 define KernelPackage/ipt-core/description
@@ -247,6 +247,15 @@ define AddDepends/ipt
   DEPENDS+= +kmod-ipt-core $(1)
 endef
 
+define KernelPackage/nf-xtables
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter Xtables support
+  KCONFIG:=$(KCONFIG_NF_XTABLES)
+  FILES:=$(foreach mod,$(NF_XTABLES-m),$(LINUX_DIR)/net/$(mod).ko)
+  AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_XTABLES-m)))
+endef
+
+$(eval $(call KernelPackage,nf-xtables))
 
 define KernelPackage/ipt-conntrack
   TITLE:=Basic connection tracking modules
@@ -1299,7 +1308,7 @@ $(eval $(call KernelPackage,nft-tproxy))
 define KernelPackage/nft-compat
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter nf_tables compat support
-  DEPENDS:=+kmod-nft-core +kmod-nf-ipt
+  DEPENDS:=+kmod-nf-xtables +kmod-nft-core +kmod-nf-ipt
   FILES:=$(foreach mod,$(NFT_COMPAT-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NFT_COMPAT-m)))
   KCONFIG:=$(KCONFIG_NFT_COMPAT)

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -1308,7 +1308,7 @@ $(eval $(call KernelPackage,nft-tproxy))
 define KernelPackage/nft-compat
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter nf_tables compat support
-  DEPENDS:=+kmod-nf-xtables +kmod-nft-core +kmod-nf-ipt
+  DEPENDS:=+kmod-nf-xtables +kmod-nft-core
   FILES:=$(foreach mod,$(NFT_COMPAT-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NFT_COMPAT-m)))
   KCONFIG:=$(KCONFIG_NFT_COMPAT)

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -459,7 +459,7 @@ IPVS_MODULES:= \
 define KernelPackage/nf-ipvs
   SUBMENU:=Netfilter Extensions
   TITLE:=IP Virtual Server modules
-  DEPENDS:=@IPV6 +LINUX_6_12:kmod-lib-crc32c +kmod-ipt-conntrack +kmod-nf-conntrack
+  DEPENDS:=@IPV6 +LINUX_6_12:kmod-lib-crc32c +kmod-nf-conntrack +kmod-nf-xtables
   KCONFIG:= \
 	CONFIG_IP_VS \
 	CONFIG_IP_VS_IPV6=y \
@@ -487,7 +487,6 @@ define KernelPackage/nf-ipvs
 	CONFIG_IP_VS_NFCT=y \
 	CONFIG_NETFILTER_XT_MATCH_IPVS
   FILES:=$(foreach mod,$(IPVS_MODULES),$(LINUX_DIR)/net/netfilter/$(mod).ko)
-  $(call AddDepends/ipt,+kmod-ipt-conntrack,+kmod-nf-conntrack)
 endef
 
 define KernelPackage/nf-ipvs/description

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -1472,7 +1472,7 @@ $(eval $(call KernelPackage,nft-tproxy))
 define KernelPackage/nft-compat
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter nf_tables compat support
-  DEPENDS:=+kmod-nf-xtables +kmod-nft-core +kmod-nf-ipt
+  DEPENDS:=+kmod-nf-xtables +kmod-nft-core
   FILES:=$(foreach mod,$(NFT_COMPAT-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NFT_COMPAT-m)))
   KCONFIG:=$(KCONFIG_NFT_COMPAT)

--- a/package/kernel/linux/modules/netfilter.mk
+++ b/package/kernel/linux/modules/netfilter.mk
@@ -76,7 +76,7 @@ define KernelPackage/nf-ipt
   SUBMENU:=$(NF_MENU)
   TITLE:=Iptables core
   KCONFIG:=$(KCONFIG_NF_IPT)
-  DEPENDS:=+!LINUX_6_12:kmod-iptables
+  DEPENDS:=+!LINUX_6_12:kmod-iptables +kmod-nf-xtables
   FILES:=$(foreach mod,$(NF_IPT-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_IPT-m)))
 endef
@@ -103,7 +103,7 @@ define KernelPackage/ipt-core
   KCONFIG:=$(KCONFIG_IPT_CORE)
   FILES:=$(foreach mod,$(IPT_CORE-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(IPT_CORE-m)))
-  DEPENDS:=+kmod-nf-reject +kmod-nf-ipt +kmod-nf-log
+  DEPENDS:=+kmod-nf-reject +kmod-nf-ipt +kmod-nf-log +kmod-nf-xtables
 endef
 
 define KernelPackage/ipt-core/description
@@ -247,6 +247,15 @@ define AddDepends/ipt
   DEPENDS+= +kmod-ipt-core $(1)
 endef
 
+define KernelPackage/nf-xtables
+  SUBMENU:=$(NF_MENU)
+  TITLE:=Netfilter Xtables support
+  KCONFIG:=$(KCONFIG_NF_XTABLES)
+  FILES:=$(foreach mod,$(NF_XTABLES-m),$(LINUX_DIR)/net/$(mod).ko)
+  AUTOLOAD:=$(call AutoProbe,$(notdir $(NF_XTABLES-m)))
+endef
+
+$(eval $(call KernelPackage,nf-xtables))
 
 define KernelPackage/ipt-conntrack
   TITLE:=Basic connection tracking modules
@@ -1463,7 +1472,7 @@ $(eval $(call KernelPackage,nft-tproxy))
 define KernelPackage/nft-compat
   SUBMENU:=$(NF_MENU)
   TITLE:=Netfilter nf_tables compat support
-  DEPENDS:=+kmod-nft-core +kmod-nf-ipt
+  DEPENDS:=+kmod-nf-xtables +kmod-nft-core +kmod-nf-ipt
   FILES:=$(foreach mod,$(NFT_COMPAT-m),$(LINUX_DIR)/net/$(mod).ko)
   AUTOLOAD:=$(call AutoProbe,$(notdir $(NFT_COMPAT-m)))
   KCONFIG:=$(KCONFIG_NFT_COMPAT)

--- a/target/linux/generic/backport-6.12/631-v6.13-netfilter-Make-legacy-configs-user-selectable.patch
+++ b/target/linux/generic/backport-6.12/631-v6.13-netfilter-Make-legacy-configs-user-selectable.patch
@@ -1,0 +1,89 @@
+From 6c959fd5e17387201dba3619b2e6af213939a0a7 Mon Sep 17 00:00:00 2001
+From: Breno Leitao <leitao@debian.org>
+Date: Mon, 30 Sep 2024 02:58:54 -0700
+Subject: [PATCH] netfilter: Make legacy configs user selectable
+
+This option makes legacy Netfilter Kconfig user selectable, giving users
+the option to configure iptables without enabling any other config.
+
+Make the following KConfig entries user selectable:
+ * BRIDGE_NF_EBTABLES_LEGACY
+ * IP_NF_ARPTABLES
+ * IP_NF_IPTABLES_LEGACY
+ * IP6_NF_IPTABLES_LEGACY
+
+Signed-off-by: Breno Leitao <leitao@debian.org>
+Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
+---
+ net/bridge/netfilter/Kconfig |  8 +++++++-
+ net/ipv4/netfilter/Kconfig   | 16 ++++++++++++++--
+ net/ipv6/netfilter/Kconfig   |  9 ++++++++-
+ 3 files changed, 29 insertions(+), 4 deletions(-)
+
+--- a/net/bridge/netfilter/Kconfig
++++ b/net/bridge/netfilter/Kconfig
+@@ -41,7 +41,13 @@ config NF_CONNTRACK_BRIDGE
+ 
+ # old sockopt interface and eval loop
+ config BRIDGE_NF_EBTABLES_LEGACY
+-	tristate
++	tristate "Legacy EBTABLES support"
++	depends on BRIDGE && NETFILTER_XTABLES
++	default n
++	help
++	 Legacy ebtables packet/frame classifier.
++	 This is not needed if you are using ebtables over nftables
++	 (iptables-nft).
+ 
+ menuconfig BRIDGE_NF_EBTABLES
+ 	tristate "Ethernet Bridge tables (ebtables) support"
+--- a/net/ipv4/netfilter/Kconfig
++++ b/net/ipv4/netfilter/Kconfig
+@@ -12,7 +12,13 @@ config NF_DEFRAG_IPV4
+ 
+ # old sockopt interface and eval loop
+ config IP_NF_IPTABLES_LEGACY
+-	tristate
++	tristate "Legacy IP tables support"
++	default	n
++	select NETFILTER_XTABLES
++	help
++	  iptables is a legacy packet classifier.
++	  This is not needed if you are using iptables over nftables
++	  (iptables-nft).
+ 
+ config NF_SOCKET_IPV4
+ 	tristate "IPv4 socket lookup support"
+@@ -318,7 +324,13 @@ endif # IP_NF_IPTABLES
+ 
+ # ARP tables
+ config IP_NF_ARPTABLES
+-	tristate
++	tristate "Legacy ARPTABLES support"
++	depends on NETFILTER_XTABLES
++	default n
++	help
++	  arptables is a legacy packet classifier.
++	  This is not needed if you are using arptables over nftables
++	  (iptables-nft).
+ 
+ config NFT_COMPAT_ARP
+ 	tristate
+--- a/net/ipv6/netfilter/Kconfig
++++ b/net/ipv6/netfilter/Kconfig
+@@ -8,7 +8,14 @@ menu "IPv6: Netfilter Configuration"
+ 
+ # old sockopt interface and eval loop
+ config IP6_NF_IPTABLES_LEGACY
+-	tristate
++	tristate "Legacy IP6 tables support"
++	depends on INET && IPV6
++	select NETFILTER_XTABLES
++	default n
++	help
++	  ip6tables is a legacy packet classifier.
++	  This is not needed if you are using iptables over nftables
++	  (iptables-nft).
+ 
+ config NF_SOCKET_IPV6
+ 	tristate "IPv6 socket lookup support"


### PR DESCRIPTION
This PR aims to cleanup some unneeded and fix some missing dependencies to allow building nftables-only images.

While trying to build an nftables-only image, I hit the following missing symbols in the xtables-addon package from the packages feed. With this PR, it should be possible to fix that without adding unneeded dependencies on iptables packages or kmods, by adding a dependency on kmod-nft-compat.

```
# MODPOST /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/Module.symvers
   scripts/mod/modpost -M        -o /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/Module.symvers -n -T /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/modules.order -i Module.symvers -e -i /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/symvers/button-hotplug.symvers -i /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/symvers/cryptodev-linux.symvers -i /home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/symvers/nat46.symvers
ERROR: modpost: "xt_register_target" [/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/ACCOUNT/xt_ACCOUNT.ko] undefined!
ERROR: modpost: "xt_unregister_target" [/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/ACCOUNT/xt_ACCOUNT.ko] undefined!
ERROR: modpost: "xt_request_find_match" [/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/xt_CHAOS.ko] undefined!
ERROR: modpost: "xt_request_find_target" [/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/xt_CHAOS.ko] undefined!
ERROR: modpost: "xt_register_target" [/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/xt_CHAOS.ko] undefined!
ERROR: modpost: "xt_unregister_target" [/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/xt_CHAOS.ko] undefined!
ERROR: modpost: "xt_register_target" [/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/xt_DELUDE.ko] undefined!
ERROR: modpost: "xt_unregister_target" [/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/xt_DELUDE.ko] undefined!
ERROR: modpost: "xt_register_target" [/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/xt_DHCPMAC.ko] undefined!
ERROR: modpost: "xt_register_match" [/home/stijn/Development/OpenWrt/openwrt/build_dir/target-x86_64_musl/linux-x86_64/xtables-addons-3.27/extensions/xt_DHCPMAC.ko] undefined!
WARNING: modpost: suppressed 43 unresolved symbol warnings because there were too many)
```
Other issues I've been hitting:

```
ERROR: module '/home/stijn/Development/OpenWrt/openwrt/build_dir/target-arm_arm1176jzf-s+vfp_musl_eabi/linux-bcm27xx_bcm2708/linux-6.12.54/net/ipv4/netfilter/ip_tables.ko' is missing.
```
```
ERROR: module '/home/stijn/Development/OpenWrt/openwrt/build_dir/target-powerpc64_e5500_musl/linux-qoriq_generic/linux-6.12.67/net/ipv6/netfilter/ip6_tables.ko' is missing.
```

These problems do not occur on the buildbots as they enable CONFIG_ALL_KMODS.

As the backported patch exposes a few new symbols that are not handled in OpenWrt yet, the backport of the patch is done after adding the symbols, to avoid breakage during git bisect.