### PR TITLE
netifd: dhcp: allow raw hex payload for vendorid option

### DIFF
--- a/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
+++ b/package/network/config/netifd/files/lib/netifd/proto/dhcp.sh
@@ -68,6 +68,16 @@ proto_dhcp_setup() {
 	[ -z "$clientid" ] && clientid="$(proto_dhcp_get_default_clientid "$iface")"
 	[ -n "$clientid" ] && clientid="-x 0x3d:${clientid//:/}"
 	[ -n "$vendorid" ] && append dhcpopts "-x 0x3c:$(echo -n "$vendorid" | hexdump -ve '1/1 "%02x"')"
+	if [ -n "$vendorid" ]; then
+	    if echo "$vendorid" | grep -Eq '^[0-9a-fA-F]+$' && \
+	       [ $(( ${#vendorid} % 2 )) -eq 0 ]; then
+	        # vendorid is ASCII-HEX payload, use directly
+	        append dhcpopts "-x 0x3c:$vendorid"
+	    else
+	        # vendorid is plain string, convert to ASCII-HEX
+	        append dhcpopts "-x 0x3c:$(echo -n "$vendorid" | hexdump -ve '1/1 "%02x"')"
+	    fi
+	fi
 	[ -n "$iface6rd" ] && proto_export "IFACE6RD=$iface6rd"
 	[ "$iface6rd" != 0 -a -f /lib/netifd/proto/6rd.sh ] && append dhcpopts "-O 212"
 	[ -n "$zone6rd" ] && proto_export "ZONE6RD=$zone6rd"


### PR DESCRIPTION
If vendorid contains a pure hexadecimal string of even length, treat it as a raw DHCP Option 60 payload and pass it directly to udhcpc. Otherwise, retain existing behavior and encode the string as ASCII hex.

This preserves backward compatibility while enabling binary vendor class identifiers required by some ISPs.