### PR TITLE
mediatek: filogic: increase flash speed on Netcore N60 Pro

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
+++ b/target/linux/mediatek/dts/mt7986a-netcore-n60-pro.dts
@@ -238,7 +238,7 @@
 		compatible = "spi-nand";
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 


### PR DESCRIPTION
This commit increases the SPI bus frequency from 20 to 52 MHz. Reduces boot time by 2s. Below is a performance comparison.

spi-max-frequency = <20000000>

> time dd if=/dev/mtd4 of=/dev/null bs=10M count=1
> 1+0 records in
> 1+0 records out
> real    0m 1.86s
> user    0m 0.00s
> sys     0m 0.28s


spi-max-frequency = <52000000>

> time dd if=/dev/mtd4 of=/dev/null bs=10M count=1
> 1+0 records in
> 1+0 records out
> real    0m 1.04s
> user    0m 0.00s
> sys     0m 0.27s


