### PR TITLE
build: use STAGING_DIR for special APK package versions

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -103,9 +103,9 @@ ifneq ($(CONFIG_USE_APK),)
 		--repositories-file /dev/null --repository file://$(PACKAGE_DIR_ALL)/packages.adb \
 		$(if $(CONFIG_SIGNED_PACKAGES),,--allow-untrusted) \
 		$$(cat $(TMP_DIR)/apk_install_list) \
-			"base-files=$(shell cat $(TMP_DIR)/base-files.version)" \
-			"libc=$(shell cat $(TMP_DIR)/libc.version)" \
-			"kernel=$(subst -rc,_rc,$(shell cat $(TMP_DIR)/kernel.version))"
+			"base-files=$(shell cat $(STAGING_DIR)/base-files.version)" \
+			"libc=$(shell cat $(STAGING_DIR)/libc.version)" \
+			"kernel=$(subst -rc,_rc,$(shell cat $(STAGING_DIR)/kernel.version))"
 
 	rm -rf $(TARGET_DIR)/run
 else

--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -256,7 +256,7 @@ ifneq ($(CONFIG_USE_APK),)
 
 	rm -f $(1)/etc/uci-defaults/13_fix-group-user
 	rm -f $(1)/sbin/pkg_check
-	echo $(PKG_RELEASE)~$(lastword $(subst -, ,$(REVISION))) >$(TMP_DIR)/base-files.version
+	echo $(PKG_RELEASE)~$(lastword $(subst -, ,$(REVISION))) >$(STAGING_DIR)/base-files.version
 else
 	$(if $(CONFIG_CLEAN_IPKG),, \
 		mkdir -p $(1)/etc/opkg; \

--- a/package/kernel/linux/Makefile
+++ b/package/kernel/linux/Makefile
@@ -65,7 +65,7 @@ define Package/kernel/install
 	strings $(LINUX_DIR)/modules.builtin.modinfo | \
 		grep -E -v "\.(file$(if CONFIG_MODULE_STRIPPED,|parmtype))=" | \
 		tr '\n' '\0' > $(1)/$(MODULES_SUBDIR)/modules.builtin.modinfo
-	echo $(LINUX_VERSION)~$(LINUX_VERMAGIC)-r$(LINUX_RELEASE) > $(TMP_DIR)/kernel.version
+	echo $(LINUX_VERSION)~$(LINUX_VERMAGIC)-r$(LINUX_RELEASE) > $(STAGING_DIR)/kernel.version
 endef
 
 define Package/kernel/extra_provides

--- a/package/libs/toolchain/Makefile
+++ b/package/libs/toolchain/Makefile
@@ -578,7 +578,7 @@ ifeq ($(CONFIG_EXTERNAL_TOOLCHAIN),)
   endef
 
   define Package/libc/install
-    echo $(LIBC_VERSION)-r$(PKG_RELEASE) > $(TMP_DIR)/libc.version; \
+    echo $(LIBC_VERSION)-r$(PKG_RELEASE) > $(STAGING_DIR)/libc.version; \
     $(call Package/$(LIBC)/install,$1)
   endef
 
@@ -698,7 +698,7 @@ else
   endef
 
   define Package/libc/install
-	echo $(LIBC_VERSION)-r$(PKG_RELEASE) > $(TMP_DIR)/libc.version; \
+	echo $(LIBC_VERSION)-r$(PKG_RELEASE) > $(STAGING_DIR)/libc.version; \
 	for file in $(call qstrip,$(CONFIG_LIBC_FILE_SPEC)); do \
 		if [ '$(CONFIG_USE_GLIBC)' != '' ] ; then \
 			case "$${file}" in \

--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -126,9 +126,9 @@ endif
 	fi
 	$(SED) 's,^# REVISION:=.*,REVISION:=$(REVISION),g' $(PKG_BUILD_DIR)/include/version.mk
 	$(SED) 's,^# SOURCE_DATE_EPOCH:=.*,SOURCE_DATE_EPOCH:=$(SOURCE_DATE_EPOCH),g' $(PKG_BUILD_DIR)/include/version.mk
-	$(SED) 's,^# BASE_FILES_VERSION:=.*,BASE_FILES_VERSION:=$(shell cat $(TMP_DIR)/base-files.version),g' $(PKG_BUILD_DIR)/include/version.mk
-	$(SED) 's,^# LIBC_VERSION:=.*,LIBC_VERSION:=$(shell cat $(TMP_DIR)/libc.version),g' $(PKG_BUILD_DIR)/include/version.mk
-	$(SED) 's,^# KERNEL_VERSION:=.*,KERNEL_VERSION:=$(shell cat $(TMP_DIR)/kernel.version),g' $(PKG_BUILD_DIR)/include/version.mk
+	$(SED) 's,^# BASE_FILES_VERSION:=.*,BASE_FILES_VERSION:=$(shell cat $(STAGING_DIR)/base-files.version),g' $(PKG_BUILD_DIR)/include/version.mk
+	$(SED) 's,^# LIBC_VERSION:=.*,LIBC_VERSION:=$(shell cat $(STAGING_DIR)/libc.version),g' $(PKG_BUILD_DIR)/include/version.mk
+	$(SED) 's,^# KERNEL_VERSION:=.*,KERNEL_VERSION:=$(shell cat $(STAGING_DIR)/kernel.version),g' $(PKG_BUILD_DIR)/include/version.mk
 	$(SED) '/LINUX_VERMAGIC:=/ { s,unknown,$(LINUX_VERMAGIC),g }' $(PKG_BUILD_DIR)/include/kernel.mk
 	find $(PKG_BUILD_DIR) -name CVS -o -name .git -o -name .svn \
 	  | $(XARGS) rm -rf


### PR DESCRIPTION
Removing `tmp/` after having built base-files or toolchain currently breaks rootfs generation:

```
$ rm -rf tmp
$ make V=w
...
 make[2] package/install
cat: .../openwrt/tmp/base-files.version: No such file or directory
cat: .../openwrt/openwrt/tmp/libc.version: No such file or directory
ERROR: 'base-files=' is not a valid world dependency, format is name(@tag)([<>~=]version)
make[2]: *** [package/Makefile:100: package/install] Error 99
```

The only way to recover from here is to clean toolchain and base-files via

```
$ make package/{base-files,toolchain}/clean
```

`tmp/` is supposed to be ephemeral, so clearing it is an expected action, which normally just triggers a regeneration of all files there.

Fix this by moving the version files to $(STAGING_DIR).

Fixes: 63e178f067 ("build: lock versions for special APK packages")