### PR TITLE
sunxi/cortexa53: extend BOARDNAME with H618 support

### DIFF
--- a/target/linux/sunxi/cortexa53/target.mk
+++ b/target/linux/sunxi/cortexa53/target.mk
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 ARCH:=aarch64
-BOARDNAME:=Allwinner A64/H5/H6/H616
+BOARDNAME:=Allwinner A64/H5/H6/H616/H618
 CPU_TYPE:=cortex-a53
 KERNELNAME:=Image dtbs
 FEATURES+=fpu


### PR DESCRIPTION
Add H618 to Allwinner cortexa53 subtarget description to include Orange Pi Zero 2W (Allwinner H618) in the visible target list.