### PR TITLE
netifd: ensure netifd_loglevel default value as fallback

### DIFF
--- a/package/network/config/netifd/files/etc/init.d/network
+++ b/package/network/config/netifd/files/etc/init.d/network
@@ -19,7 +19,7 @@ start_service() {
 
 	procd_open_instance
 	procd_set_param command /sbin/netifd
-	procd_append_param command -l ${netifd_loglevel}
+	procd_append_param command -l ${netifd_loglevel:-2}
 	procd_set_param respawn
 	procd_set_param watch network.interface
 	[ -e /proc/sys/kernel/core_pattern ] && {


### PR DESCRIPTION
Commit 168d5af added the possibility to configure netifd logging level. The option is read from `/etc/config/network` and validated. Supposedly the validation sets 2 as default.

But in case of a syntax error in `/etc/config/network`, the validation result can be empty. Then the always passed option to netifd is just '-l' instead of '-l 2'. That crashes netifd and prevents network from launching.

Add a fallback value 2 to the variable, so that there will always be a proper value after the '-l' option.

Improves: PR #19737 commit 168d5af "netifd: add loglevel config option (fixes #18001)"
Fixes: #21816

--------------

Run-tested with ipq806x/R7800


Example of error causing the issue fixed with this PR:
`option ip6ifaceid='::78'` in lan section, extra "=" char there:

```
config interface 'lan'
        option device 'br-lan'
        option proto 'static'
        option ipaddr '192.168.1.78'
        option netmask '255.255.255.0'
        option gateway '192.168.1.1'
        option dns '192.168.1.1'
        option ip6assign '60'
        option ip6ifaceid='::78'
```

Error can be noticed from uci cmdline, if tested:
```
root@router78:~# uci show network
uci: Parse error (invalid character in name field) at line 28, byte 26
```

Debug showing empty value in init script after validation at startup:
```
root@router78:~# logread | grep network
Sun Feb  1 18:04:47 2026 user.notice network: netifd log_level = ''
```

Checking for an empty value via fallback default enables netifd to launch.
