### PR TITLE
[24.10] kernel: mtk_eth_soc: fix memory leak in downstream patch

### DIFF
--- a/target/linux/generic/pending-6.6/737-net-ethernet-mtk_eth_soc-add-paths-and-SerDes-modes-.patch
+++ b/target/linux/generic/pending-6.6/737-net-ethernet-mtk_eth_soc-add-paths-and-SerDes-modes-.patch
@@ -518,7 +518,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	phy_interface_t phy_mode;
  	struct phylink *phylink;
  	struct mtk_mac *mac;
-@@ -4644,16 +4792,41 @@ static int mtk_add_mac(struct mtk_eth *e
+@@ -4644,16 +4792,44 @@ static int mtk_add_mac(struct mtk_eth *e
  	mac->id = id;
  	mac->hw = eth;
  	mac->of_node = np;
@@ -526,15 +526,30 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	if (pcs_np) {
 +		mac->sgmii_pcs = mtk_pcs_lynxi_get(eth->dev, pcs_np);
 +		if (IS_ERR(mac->sgmii_pcs)) {
-+			if (PTR_ERR(mac->sgmii_pcs) == -EPROBE_DEFER)
-+				return -EPROBE_DEFER;
++			if (PTR_ERR(mac->sgmii_pcs) != -EPROBE_DEFER)
++				dev_err(eth->dev,
++					"cannot select SGMII PCS, error %ld\n",
++					PTR_ERR(mac->sgmii_pcs));
++
++			err = PTR_ERR(mac->sgmii_pcs);
++			goto free_netdev;
++		}
++	}
  
 -	err = of_get_ethdev_address(mac->of_node, eth->netdev[id]);
 -	if (err == -EPROBE_DEFER)
 -		return err;
-+			dev_err(eth->dev, "cannot select SGMII PCS, error %ld\n",
-+				PTR_ERR(mac->sgmii_pcs));
-+			return PTR_ERR(mac->sgmii_pcs);
++	pcs_np = of_parse_phandle(mac->of_node, "pcs-handle", 1);
++	if (pcs_np) {
++		mac->usxgmii_pcs = mtk_usxgmii_pcs_get(eth->dev, pcs_np);
++		if (IS_ERR(mac->usxgmii_pcs)) {
++			if (PTR_ERR(mac->usxgmii_pcs) != -EPROBE_DEFER)
++				dev_err(eth->dev,
++					"cannot select USXGMII PCS, error %ld\n",
++					PTR_ERR(mac->usxgmii_pcs));
++
++			err = PTR_ERR(mac->usxgmii_pcs);
++			goto free_netdev;
 +		}
 +	}
  
@@ -543,19 +558,6 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 -		eth_hw_addr_random(eth->netdev[id]);
 -		dev_err(eth->dev, "generated random MAC address %pM\n",
 -			eth->netdev[id]->dev_addr);
-+	pcs_np = of_parse_phandle(mac->of_node, "pcs-handle", 1);
-+	if (pcs_np) {
-+		mac->usxgmii_pcs = mtk_usxgmii_pcs_get(eth->dev, pcs_np);
-+		if (IS_ERR(mac->usxgmii_pcs)) {
-+			if (PTR_ERR(mac->usxgmii_pcs) == -EPROBE_DEFER)
-+				return -EPROBE_DEFER;
-+
-+			dev_err(eth->dev, "cannot select USXGMII PCS, error %ld\n",
-+				PTR_ERR(mac->usxgmii_pcs));
-+			return PTR_ERR(mac->usxgmii_pcs);
-+		}
-+	}
-+
 +	if (mtk_is_netsys_v3_or_greater(eth) && (mac->sgmii_pcs || mac->usxgmii_pcs)) {
 +		mac->pextp = devm_of_phy_get(eth->dev, mac->of_node, NULL);
 +		if (IS_ERR(mac->pextp)) {
@@ -563,12 +565,13 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +				dev_err(eth->dev, "cannot get PHY, error %ld\n",
 +					PTR_ERR(mac->pextp));
 +
-+			return PTR_ERR(mac->pextp);
++			err = PTR_ERR(mac->pextp);
++			goto free_netdev;
 +		}
  	}
  
  	memset(mac->hwlro_ip, 0, sizeof(mac->hwlro_ip));
-@@ -4736,8 +4909,21 @@ static int mtk_add_mac(struct mtk_eth *e
+@@ -4736,8 +4912,21 @@ static int mtk_add_mac(struct mtk_eth *e
  		phy_interface_zero(mac->phylink_config.supported_interfaces);
  		__set_bit(PHY_INTERFACE_MODE_INTERNAL,
  			  mac->phylink_config.supported_interfaces);
@@ -590,7 +593,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	phylink = phylink_create(&mac->phylink_config,
  				 of_fwnode_handle(mac->of_node),
  				 phy_mode, &mtk_phylink_ops);
-@@ -4788,6 +4974,26 @@ free_netdev:
+@@ -4788,6 +4977,26 @@ free_netdev:
  	return err;
  }
  
@@ -617,7 +620,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  void mtk_eth_set_dma_device(struct mtk_eth *eth, struct device *dma_dev)
  {
  	struct net_device *dev, *tmp;
-@@ -4934,7 +5140,8 @@ static int mtk_probe(struct platform_dev
+@@ -4934,7 +5143,8 @@ static int mtk_probe(struct platform_dev
  			regmap_write(cci, 0, 3);
  	}
  
@@ -627,7 +630,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		err = mtk_sgmii_init(eth);
  
  		if (err)
-@@ -5045,6 +5252,24 @@ static int mtk_probe(struct platform_dev
+@@ -5045,6 +5255,24 @@ static int mtk_probe(struct platform_dev
  		}
  	}
  
@@ -652,7 +655,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	if (MTK_HAS_CAPS(eth->soc->caps, MTK_SHARED_INT)) {
  		err = devm_request_irq(eth->dev, eth->irq[0],
  				       mtk_handle_irq, 0,
-@@ -5148,6 +5373,11 @@ static int mtk_remove(struct platform_de
+@@ -5148,6 +5376,11 @@ static int mtk_remove(struct platform_de
  		mtk_stop(eth->netdev[i]);
  		mac = netdev_priv(eth->netdev[i]);
  		phylink_disconnect_phy(mac->phylink);

--- a/target/linux/generic/pending-6.6/738-01-net-ethernet-mtk_eth_soc-reduce-rx-ring-size-for-older.patch
+++ b/target/linux/generic/pending-6.6/738-01-net-ethernet-mtk_eth_soc-reduce-rx-ring-size-for-older.patch
@@ -30,7 +30,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/drivers/net/ethernet/mediatek/mtk_eth_soc.c
 +++ b/drivers/net/ethernet/mediatek/mtk_eth_soc.c
-@@ -5409,7 +5409,7 @@ static const struct mtk_soc_data mt2701_
+@@ -5412,7 +5412,7 @@ static const struct mtk_soc_data mt2701_
  		.desc_size = sizeof(struct mtk_rx_dma),
  		.irq_done_mask = MTK_RX_DONE_INT,
  		.dma_l4_valid = RX_DMA_L4_VALID,
@@ -39,7 +39,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
-@@ -5437,7 +5437,7 @@ static const struct mtk_soc_data mt7621_
+@@ -5440,7 +5440,7 @@ static const struct mtk_soc_data mt7621_
  		.desc_size = sizeof(struct mtk_rx_dma),
  		.irq_done_mask = MTK_RX_DONE_INT,
  		.dma_l4_valid = RX_DMA_L4_VALID,
@@ -48,7 +48,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
-@@ -5467,7 +5467,7 @@ static const struct mtk_soc_data mt7622_
+@@ -5470,7 +5470,7 @@ static const struct mtk_soc_data mt7622_
  		.desc_size = sizeof(struct mtk_rx_dma),
  		.irq_done_mask = MTK_RX_DONE_INT,
  		.dma_l4_valid = RX_DMA_L4_VALID,
@@ -57,7 +57,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
-@@ -5496,7 +5496,7 @@ static const struct mtk_soc_data mt7623_
+@@ -5499,7 +5499,7 @@ static const struct mtk_soc_data mt7623_
  		.desc_size = sizeof(struct mtk_rx_dma),
  		.irq_done_mask = MTK_RX_DONE_INT,
  		.dma_l4_valid = RX_DMA_L4_VALID,
@@ -66,7 +66,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
-@@ -5522,7 +5522,7 @@ static const struct mtk_soc_data mt7629_
+@@ -5525,7 +5525,7 @@ static const struct mtk_soc_data mt7629_
  		.desc_size = sizeof(struct mtk_rx_dma),
  		.irq_done_mask = MTK_RX_DONE_INT,
  		.dma_l4_valid = RX_DMA_L4_VALID,
@@ -75,7 +75,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
  	},
-@@ -5554,7 +5554,7 @@ static const struct mtk_soc_data mt7981_
+@@ -5557,7 +5557,7 @@ static const struct mtk_soc_data mt7981_
  		.dma_l4_valid = RX_DMA_L4_VALID_V2,
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
@@ -84,7 +84,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	},
  };
  
-@@ -5584,7 +5584,7 @@ static const struct mtk_soc_data mt7986_
+@@ -5587,7 +5587,7 @@ static const struct mtk_soc_data mt7986_
  		.dma_l4_valid = RX_DMA_L4_VALID_V2,
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,
@@ -93,7 +93,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	},
  };
  
-@@ -5637,7 +5637,7 @@ static const struct mtk_soc_data rt5350_
+@@ -5640,7 +5640,7 @@ static const struct mtk_soc_data rt5350_
  		.dma_l4_valid = RX_DMA_L4_VALID_PDMA,
  		.dma_max_len = MTK_TX_DMA_BUF_LEN,
  		.dma_len_offset = 16,


### PR DESCRIPTION
Bc-bocun Chen of MediaTek has discovered a memory leak in the error path in our downstream patch for mtk_eth_soc which adds support for the 10G PCS and PHY paths of the MT7988 SoC.
Fix this by freeing the at this point already allocated netdev resources before returning the error.

Fixes: 4cb6bd9a6d ("mediatek: switch to pending XFI 10G Ethernet drivers")
Reported-by: Bc-bocun Chen <bc-bocun.chen@mediatek.com>
(cherry picked from commit 4d71c767c4a54d1ec9fbd59b1a552f37b165288c)