### PR TITLE
realtek: mdio: complete regmap conversion

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -756,22 +756,22 @@ static int rtmdio_930x_reset(struct mii_bus *bus)
 		}
 	}
 
-	pr_debug("%s: RTMDIO_930X_SMI_GLB_CTRL %08x\n", __func__,
-		 sw_r32(RTMDIO_930X_SMI_GLB_CTRL));
-	pr_debug("%s: RTMDIO_930X_SMI_PORT0_15_POLLING_SEL %08x\n", __func__,
-		 sw_r32(RTMDIO_930X_SMI_PORT0_15_POLLING_SEL));
-	pr_debug("%s: RTMDIO_930X_SMI_PORT16_27_POLLING_SEL %08x\n", __func__,
-		 sw_r32(RTMDIO_930X_SMI_PORT16_27_POLLING_SEL));
-	pr_debug("%s: RTMDIO_930X_SMI_MAC_TYPE_CTRL %08x\n", __func__,
-		 sw_r32(RTMDIO_930X_SMI_MAC_TYPE_CTRL));
-	pr_debug("%s: RTMDIO_930X_SMI_10G_POLLING_REG0_CFG %08x\n", __func__,
-		 sw_r32(RTMDIO_930X_SMI_10G_POLLING_REG0_CFG));
-	pr_debug("%s: RTMDIO_930X_SMI_10G_POLLING_REG9_CFG %08x\n", __func__,
-		 sw_r32(RTMDIO_930X_SMI_10G_POLLING_REG9_CFG));
-	pr_debug("%s: RTMDIO_930X_SMI_10G_POLLING_REG10_CFG %08x\n", __func__,
-		 sw_r32(RTMDIO_930X_SMI_10G_POLLING_REG10_CFG));
-	pr_debug("%s: RTMDIO_930X_SMI_PRVTE_POLLING_CTRL %08x\n", __func__,
-		 sw_r32(RTMDIO_930X_SMI_PRVTE_POLLING_CTRL));
+	regmap_read(ctrl->map, RTMDIO_930X_SMI_GLB_CTRL, &val);
+	pr_debug("%s: RTMDIO_930X_SMI_GLB_CTRL %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_930X_SMI_PORT0_15_POLLING_SEL, &val);
+	pr_debug("%s: RTMDIO_930X_SMI_PORT0_15_POLLING_SEL %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_930X_SMI_PORT16_27_POLLING_SEL, &val);
+	pr_debug("%s: RTMDIO_930X_SMI_PORT16_27_POLLING_SEL %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_930X_SMI_MAC_TYPE_CTRL, &val);
+	pr_debug("%s: RTMDIO_930X_SMI_MAC_TYPE_CTRL %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_930X_SMI_10G_POLLING_REG0_CFG, &val);
+	pr_debug("%s: RTMDIO_930X_SMI_10G_POLLING_REG0_CFG %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_930X_SMI_10G_POLLING_REG9_CFG, &val);
+	pr_debug("%s: RTMDIO_930X_SMI_10G_POLLING_REG9_CFG %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_930X_SMI_10G_POLLING_REG10_CFG, &val);
+	pr_debug("%s: RTMDIO_930X_SMI_10G_POLLING_REG10_CFG %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_930X_SMI_PRVTE_POLLING_CTRL, &val);
+	pr_debug("%s: RTMDIO_930X_SMI_PRVTE_POLLING_CTRL %08x\n", __func__, val);
 
 	return 0;
 }
@@ -783,6 +783,7 @@ static int rtmdio_931x_reset(struct mii_bus *bus)
 	u32 poll_sel[4] = { 0 };
 	u32 poll_ctrl = 0;
 	u32 c45_mask = 0;
+	u32 val;
 
 	pr_info("%s called\n", __func__);
 	/* Disable port polling for configuration purposes */
@@ -872,28 +873,28 @@ static int rtmdio_931x_reset(struct mii_bus *bus)
 		}
 	}
 
-	pr_debug("%s: RTMDIO_931X_SMI_GLB_CTRL0 %08x\n", __func__,
-		 sw_r32(RTMDIO_931X_SMI_GLB_CTRL0));
-	pr_debug("%s: RTMDIO_931X_SMI_GLB_CTRL1 %08x\n", __func__,
-		 sw_r32(RTMDIO_931X_SMI_GLB_CTRL1));
-	pr_debug("%s: RTMDIO_931X_SMI_PORT_POLLING_SEL_0_15 %08x\n", __func__,
-		 sw_r32(RTMDIO_931X_SMI_PORT_POLLING_SEL));
-	pr_debug("%s: RTMDIO_931X_SMI_PORT_POLLING_SEL_16_27 %08x\n", __func__,
-		 sw_r32(RTMDIO_931X_SMI_PORT_POLLING_SEL + 4));
-	pr_debug("%s: RTMDIO_931X_SMI_PORT_POLLING_SEL_28_43 %08x\n", __func__,
-		 sw_r32(RTMDIO_931X_SMI_PORT_POLLING_SEL + 8));
-	pr_debug("%s: RTMDIO_931X_SMI_PORT_POLLING_SEL_44_55 %08x\n", __func__,
-		 sw_r32(RTMDIO_931X_SMI_PORT_POLLING_SEL + 12));
-	pr_debug("%s: RTMDIO_931X_SMI_10GPHY_POLLING_SEL0 %08x\n", __func__,
-		 sw_r32(RTMDIO_931X_SMI_10GPHY_POLLING_SEL0));
-	pr_debug("%s: RTMDIO_931X_SMI_10GPHY_POLLING_SEL1 %08x\n", __func__,
-		 sw_r32(RTMDIO_931X_SMI_10GPHY_POLLING_SEL1));
-	pr_debug("%s: RTMDIO_931X_SMI_10GPHY_POLLING_SEL2 %08x\n", __func__,
-		 sw_r32(RTMDIO_931X_SMI_10GPHY_POLLING_SEL2));
-	pr_debug("%s: RTMDIO_931X_SMI_10GPHY_POLLING_SEL3 %08x\n", __func__,
-		 sw_r32(RTMDIO_931X_SMI_10GPHY_POLLING_SEL3));
-	pr_debug("%s: RTMDIO_931X_SMI_10GPHY_POLLING_SEL4 %08x\n", __func__,
-		 sw_r32(RTMDIO_931X_SMI_10GPHY_POLLING_SEL4));
+	regmap_read(ctrl->map, RTMDIO_931X_SMI_GLB_CTRL0, &val);
+	pr_debug("%s: RTMDIO_931X_SMI_GLB_CTRL0 %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_931X_SMI_GLB_CTRL1, &val);
+	pr_debug("%s: RTMDIO_931X_SMI_GLB_CTRL1 %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_931X_SMI_PORT_POLLING_SEL, &val);
+	pr_debug("%s: RTMDIO_931X_SMI_PORT_POLLING_SEL_0_15 %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_931X_SMI_PORT_POLLING_SEL + 4, &val);
+	pr_debug("%s: RTMDIO_931X_SMI_PORT_POLLING_SEL_16_27 %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_931X_SMI_PORT_POLLING_SEL + 8, &val);
+	pr_debug("%s: RTMDIO_931X_SMI_PORT_POLLING_SEL_28_43 %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_931X_SMI_PORT_POLLING_SEL + 12, &val);
+	pr_debug("%s: RTMDIO_931X_SMI_PORT_POLLING_SEL_44_55 %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_931X_SMI_10GPHY_POLLING_SEL0, &val);
+	pr_debug("%s: RTMDIO_931X_SMI_10GPHY_POLLING_SEL0 %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_931X_SMI_10GPHY_POLLING_SEL1, &val);
+	pr_debug("%s: RTMDIO_931X_SMI_10GPHY_POLLING_SEL1 %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_931X_SMI_10GPHY_POLLING_SEL2, &val);
+	pr_debug("%s: RTMDIO_931X_SMI_10GPHY_POLLING_SEL2 %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_931X_SMI_10GPHY_POLLING_SEL3, &val);
+	pr_debug("%s: RTMDIO_931X_SMI_10GPHY_POLLING_SEL3 %08x\n", __func__, val);
+	regmap_read(ctrl->map, RTMDIO_931X_SMI_10GPHY_POLLING_SEL4, &val);
+	pr_debug("%s: RTMDIO_931X_SMI_10GPHY_POLLING_SEL4 %08x\n", __func__, val);
 
 	return 0;
 }

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -358,8 +358,6 @@ static int rtmdio_839x_write_mmd_phy(struct mii_bus *bus, u32 port, u32 devnum, 
 	return rtmdio_839x_run_cmd(bus, RTMDIO_839X_CMD_WRITE_C45);
 }
 
-/* RTL930x specific MDIO functions */
-
 static int rtmdio_930x_run_cmd(struct mii_bus *bus, int cmd)
 {
 	return rtmdio_run_cmd(bus, cmd, RTMDIO_930X_CMD_MASK,
@@ -368,51 +366,58 @@ static int rtmdio_930x_run_cmd(struct mii_bus *bus, int cmd)
 
 static int rtmdio_930x_write_phy(struct mii_bus *bus, u32 port, u32 page, u32 reg, u32 val)
 {
-	u32 v;
+	struct rtmdio_ctrl *ctrl = bus->priv;
+	u32 park_page = 31;
 
-	sw_w32(BIT(port), RTMDIO_930X_SMI_ACCESS_PHY_CTRL_0);
-	sw_w32_mask(0xffff << 16, val << 16, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2);
-	v = reg << 20 | page << 3 | 0x1f << 15 | BIT(2);
-	sw_w32(v, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_1);
+	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_0, BIT(port));
+	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2, val << 16);
+	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_1,
+		     reg << 20 | page << 3 | park_page << 15);
 
 	return rtmdio_930x_run_cmd(bus, RTMDIO_930X_CMD_WRITE_C22);
 }
 
 static int rtmdio_930x_read_phy(struct mii_bus *bus, u32 port, u32 page, u32 reg, u32 *val)
 {
+	struct rtmdio_ctrl *ctrl = bus->priv;
+	u32 park_page = 31;
 	int err;
-	u32 v;
 
-	sw_w32_mask(0xffff << 16, port << 16, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2);
-	v = reg << 20 | page << 3 | 0x1f << 15;
-	sw_w32(v, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_1);
+	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2, port << 16);
+	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_1,
+		     reg << 20 | page << 3 | park_page << 15);
 	err = rtmdio_930x_run_cmd(bus, RTMDIO_930X_CMD_READ_C22);
 	if (!err)
-		*val = (sw_r32(RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2) & 0xffff);
+		err = regmap_read(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2, val);
+	if (!err)
+		*val &= GENMASK(15, 0);
 
 	return err;
 }
 
-/* Write to an mmd register of the PHY */
 static int rtmdio_930x_write_mmd_phy(struct mii_bus *bus, u32 port, u32 devnum, u32 regnum, u32 val)
 {
-	sw_w32(BIT(port), RTMDIO_930X_SMI_ACCESS_PHY_CTRL_0);
-	sw_w32_mask(0xffff << 16, val << 16, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2);
-	sw_w32(devnum << 16 | (regnum & 0xffff), RTMDIO_930X_SMI_ACCESS_PHY_CTRL_3);
+	struct rtmdio_ctrl *ctrl = bus->priv;
+
+	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_0, BIT(port));
+	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2, val << 16);
+	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_3, (devnum << 16) | (regnum & 0xffff));
 
 	return rtmdio_930x_run_cmd(bus, RTMDIO_930X_CMD_WRITE_C45);
 }
 
-/* Read an mmd register of the PHY */
 static int rtmdio_930x_read_mmd_phy(struct mii_bus *bus, u32 port, u32 devnum, u32 regnum, u32 *val)
 {
+	struct rtmdio_ctrl *ctrl = bus->priv;
 	int err ;
 
-	sw_w32_mask(0xffff << 16, port << 16, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2);
-	sw_w32(devnum << 16 | (regnum & 0xffff), RTMDIO_930X_SMI_ACCESS_PHY_CTRL_3);
+	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2, port << 16);
+	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_3, (devnum << 16) | (regnum & 0xffff));
 	err = rtmdio_930x_run_cmd(bus, RTMDIO_930X_CMD_READ_C45);
 	if (!err)
-		*val = (sw_r32(RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2) & 0xffff);
+		err = regmap_read(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2, val);
+	if (!err)
+		*val &= GENMASK(15, 0);
 
 	return err;
 }

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -28,9 +28,6 @@
 
 #define RTMDIO_PHY_POLL_MMD(dev, reg, bit)	((bit << 21) | (dev << 16) | reg)
 
-/* Register base */
-#define RTMDIO_SW_BASE				((volatile void *) 0xBB000000)
-
 /* MDIO bus registers */
 #define RTMDIO_RUN				BIT(0)
 
@@ -104,10 +101,6 @@
 #define RTMDIO_931X_SMI_10GPHY_POLLING_SEL2	(0x0CF8)
 #define RTMDIO_931X_SMI_10GPHY_POLLING_SEL3	(0x0CFC)
 #define RTMDIO_931X_SMI_10GPHY_POLLING_SEL4	(0x0D00)
-
-#define sw_r32(reg)				readl(RTMDIO_SW_BASE + reg)
-#define sw_w32(val, reg)			writel(val, RTMDIO_SW_BASE + reg)
-#define sw_w32_mask(clear, set, reg)		sw_w32((sw_r32(reg) & ~(clear)) | (set), reg)
 
 /*
  * On all Realtek switch platforms the hardware periodically reads the link status of all

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -662,7 +662,7 @@ static int rtmdio_838x_reset(struct mii_bus *bus)
 	int combo_phy;
 
 	/* Disable MAC polling for PHY config. It will be activated later in the DSA driver */
-	sw_w32(0, RTMDIO_838X_SMI_POLL_CTRL);
+	regmap_write(ctrl->map, RTMDIO_838X_SMI_POLL_CTRL, 0);
 
 	/*
 	 * Control bits EX_PHY_MAN_xxx have an important effect on the detection of the media
@@ -671,22 +671,24 @@ static int rtmdio_838x_reset(struct mii_bus *bus)
 	 * PHY driven, it must be a combo PHY and media detection is needed.
 	 */
 	combo_phy = ctrl->smi_bus[24] < 0 ? 0 : BIT(7);
-	sw_w32_mask(BIT(7), combo_phy, RTMDIO_838X_SMI_GLB_CTRL);
+	regmap_update_bits(ctrl->map, RTMDIO_838X_SMI_GLB_CTRL, BIT(7), combo_phy);
 
 	return 0;
 }
 
 static int rtmdio_839x_reset(struct mii_bus *bus)
 {
+	struct rtmdio_ctrl *ctrl = bus->priv;
+
 	return 0;
 
 	pr_debug("%s called\n", __func__);
 	/* BUG: The following does not work, but should! */
 	/* Disable MAC polling the PHY so that we can start configuration */
-	sw_w32(0x00000000, RTMDIO_839X_SMI_PORT_POLLING_CTRL);
-	sw_w32(0x00000000, RTMDIO_839X_SMI_PORT_POLLING_CTRL + 4);
+	regmap_write(ctrl->map, RTMDIO_839X_SMI_PORT_POLLING_CTRL, 0);
+	regmap_write(ctrl->map, RTMDIO_839X_SMI_PORT_POLLING_CTRL + 4, 0);
 	/* Disable PHY polling via SoC */
-	sw_w32_mask(1 << 7, 0, RTMDIO_839X_SMI_GLB_CTRL);
+	regmap_update_bits(ctrl->map, RTMDIO_839X_SMI_GLB_CTRL, BIT(7), 0);
 
 	/* Probably should reset all PHYs here... */
 	return 0;


### PR DESCRIPTION
This series removes all legacy sw_xxx() commands.