### PR TITLE
ramips: add support for D-Link DIR-1360 A1

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-1360-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-1360-a1.dts
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "dlink,dir-1360-a1", "mediatek,mt7621-soc";
+	model = "D-Link DIR-1360 A1";
+
+	aliases {
+		label-mac-device = &gmac0;
+		led-boot = &led_power_orange;
+		led-failsafe = &led_power_white;
+		led-running = &led_power_white;
+		led-upgrade = &led_power_orange;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power_orange: power_orange {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_white: power_white {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_internet_orange: internet_orange {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_internet_white: internet_white {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "netdev";
+			device-name = "wan";
+			modes = "link tx rx";
+		};
+
+		usb_white {
+			function = LED_FUNCTION_USB;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+
+		wlan2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0radio";
+		};
+
+		wlan5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1radio";
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "config";
+			reg = <0x80000 0x80000>;
+			read-only;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>;
+				};
+
+				macaddr_factory_e000: macaddr@e000 {
+					compatible = "mac-base";
+					reg = <0xe000 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+
+				macaddr_factory_e006: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
+			};
+		};
+
+		partition@140000 {
+			label = "config2";
+			reg = <0x140000 0x40000>;
+			read-only;
+		};
+
+		partition@180000 {
+			label = "firmware";
+			compatible = "openwrt,uimage", "denx,uimage";
+			openwrt,padding = <96>;
+			reg = <0x180000 0x2800000>;
+		};
+
+		partition@2980000 {
+			label = "private";
+			reg = <0x2980000 0x2000000>;
+			read-only;
+		};
+
+		partition@4980000 {
+			label = "firmware2";
+			reg = <0x4980000 0x2800000>;
+		};
+
+		partition@7180000 {
+			label = "mydlink";
+			reg = <0x7180000 0x600000>;
+			read-only;
+		};
+
+		partition@7780000 {
+			label = "reserved";
+			reg = <0x7780000 0x880000>;
+			read-only;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+
+		band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_factory_e000 2>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_factory_e000 1>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	nvmem-cells = <&macaddr_factory_e000 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "uart2", "uart3", "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -948,6 +948,19 @@ define Device/dlink_dir_nand_128m
 	check-size
 endef
 
+define Device/dlink_dir-1360-a1
+  $(Device/dlink_dir_nand_128m)
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := DIR-1360
+  DEVICE_VARIANT := A1
+  DEVICE_PACKAGES := kmod-mt7615-firmware kmod-usb3 kmod-usb-ledtrig-usbport
+  IMAGE_SIZE := 40960k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := $$(IMAGE/recovery.bin)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += dlink_dir-1360-a1
+
 define Device/dlink_dir-1935-a1
   $(Device/dlink_dir-8xx-a1)
   DEVICE_MODEL := DIR-1935

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -99,6 +99,10 @@ dlink,dap-x1860-a1)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimedium" "wlan1" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan1" "76" "100"
 	;;
+dlink,dir-1360-a1)
+	ucidef_set_led_default "power" "Power" "white:power" "1"
+	ucidef_set_led_netdev "internet" "Internet" "white:wan" "wan"
+	;;
 dlink,dir-1960-a1|\
 dlink,dir-2055-a1|\
 dlink,dir-2150-a1|\

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -46,6 +46,9 @@ ramips_setup_interfaces()
 	cudy,ap1300-outdoor-v1|\
 	dlink,dap-1620-b1|\
 	dlink,dap-x1860-a1|\
+	dlink,dir-1360-a1)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
+		;;
 	dlink,dra-1360-a1|\
 	edimax,re23s|\
 	linksys,re7000|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -84,6 +84,7 @@ platform_do_upgrade() {
 	belkin,rt1800|\
 	dlink,covr-x1860-a1|\
 	dlink,dap-x1860-a1|\
+	dlink,dir-1360-a1|\
 	dlink,dir-1960-a1|\
 	dlink,dir-2055-a1|\
 	dlink,dir-2150-a1|\


### PR DESCRIPTION
This PR is a backport of the support for the D-Link DIR-1360 A1 from the main branch.

The original PR was merged into main [here](https://github.com/openwrt/openwrt/pull/21616)

The D-Link DIR-1360 A1 is an AC1300 router based on the MT7621AT SoC.

Specifications :-

* SoC: MediaTek MT7621AT
* RAM: 256 MB DDR3
* Flash: 128 MB SPI NAND (Winbond W29N01HV)
* WiFi: MT7615D (2.4 GHz + 5 GHz DBDC)
* Ethernet: 5x 10/100/1000 Mbps (1x WAN, 4x LAN)
* USB: 1x USB 3.0
* Buttons: Reset, WPS
* LEDs: Power (White/Orange), Internet (White/Orange), USB, 2.4G/5G WLAN

MAC addresses are retrieved from the 'factory' partition via NVMEM. 

LAN: 0xe000 (gmac0)
WAN: 0xe006 (gmac1)
WLAN: 0xe00c (pcie0)

Flash Instruction :-

1-Set a static IP on your PC (e.g., 192.168.0.10, Gateway 192.168.0.1). 
2- Power off the router and connect your PC to a LAN port. 
3- Hold the Reset button and power on the router; continue holding for 5 seconds. 
4- Access the Recovery UI at http://192.168.0.1 in your browser. 
5- Upload the OpenWrt factory.bin image and wait for the reboot.

With these definitions in place, the DIR-1360 A1 boots reliably, exposes all hardware features correctly, and can be flashed via both the OEM recovery interface and standard OpenWrt upgrade paths.