### PR TITLE
[kernel] fix SFP I2C comms on XikeStor switches

### DIFF
--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
@@ -147,27 +147,35 @@
 	/* SDA0-7 correspond to GPIO9-16 */
 	i2c0: i2c@0 {
 		reg = <0>;
+		clock-frequency = <50000>;
 	};
 	i2c1: i2c@1 {
 		reg = <1>;
+		clock-frequency = <50000>;
 	};
 	i2c2: i2c@2 {
 		reg = <2>;
+		clock-frequency = <50000>;
 	};
 	i2c3: i2c@3 {
 		reg = <3>;
+		clock-frequency = <50000>;
 	};
 	i2c4: i2c@4 {
 		reg = <4>;
+		clock-frequency = <50000>;
 	};
 	i2c5: i2c@5 {
 		reg = <5>;
+		clock-frequency = <50000>;
 	};
 	i2c6: i2c@6 {
 		reg = <6>;
+		clock-frequency = <50000>;
 	};
 	i2c7: i2c@7 {
 		reg = <7>;
+		clock-frequency = <50000>;
 	};
 };
 

--- a/target/linux/realtek/patches-6.12/999-i2c-slow-speed-on-rtl9300.patch
+++ b/target/linux/realtek/patches-6.12/999-i2c-slow-speed-on-rtl9300.patch
@@ -1,0 +1,34 @@
+--- a/drivers/i2c/busses/i2c-rtl9300.c
++++ b/drivers/i2c/busses/i2c-rtl9300.c
+@@ -11,10 +11,16 @@
+ #include <linux/unaligned.h>
+ 
+ enum rtl9300_bus_freq {
+-	RTL9300_I2C_STD_FREQ,
+-	RTL9300_I2C_FAST_FREQ,
++	RTL9300_I2C_STD_FREQ,			// 100kHz
++	RTL9300_I2C_FAST_FREQ,			// 400kHz
++	RTL9300_I2C_SUPER_FAST_FREQ,	// 2.5MHz
++	RTL9300_I2C_SLOW_FREQ,			// 50kHz
+ };
+ 
++#define RTL9300_I2C_MAX_SUPER_FAST_FREQ	2500000
++#define RTL9300_I2C_MAX_SLOW_FREQ		50000
++
++
+ struct rtl9300_i2c;
+ 
+ struct rtl9300_i2c_chan {
+@@ -434,6 +440,12 @@ static int rtl9300_i2c_probe(struct plat
+ 		case I2C_MAX_FAST_MODE_FREQ:
+ 			chan->bus_freq = RTL9300_I2C_FAST_FREQ;
+ 			break;
++		case RTL9300_I2C_MAX_SUPER_FAST_FREQ:
++			chan->bus_freq = RTL9300_I2C_SUPER_FAST_FREQ;
++			break;
++		case RTL9300_I2C_MAX_SLOW_FREQ:
++			chan->bus_freq = RTL9300_I2C_SLOW_FREQ;
++			break;
+ 		default:
+ 			dev_warn(i2c->dev, "SDA%d clock-frequency %d not supported using default\n",
+ 				 sda_num, clock_freq);


### PR DESCRIPTION
Some 10G optics showed random "module transmit fault indicated" due to I2C read errors on ONTi ONT-S508CL-8S/XikeStor SKS8300-8X switches. The same modules work with the original firmware and on other Linux based devices.

There seems to be some differences in how we talk to those modules using I2C in OpenWRT. To fix this this patch adds support for 50kHz I2C speed on SFPs and enables that for XikeStor/Onti devices. Since SFPs only transmit very few bytes this should not have any real downsides.

Fixes https://github.com/openwrt/openwrt/issues/21665