### PR TITLE
linux-firmware: ath11k: add IPQ5018, IPQ8074, QCN9074

### DIFF
--- a/package/firmware/ath11k-firmware/Makefile
+++ b/package/firmware/ath11k-firmware/Makefile
@@ -47,11 +47,6 @@ define Package/ath11k-firmware-default
   DEPENDS:=
 endef
 
-define Package/ath11k-firmware-ipq5018
-$(Package/ath11k-firmware-default)
-  TITLE:=IPQ5018 ath11k firmware
-endef
-
 define Package/ath11k-firmware-ipq5018-qcn6122
 $(Package/ath11k-firmware-default)
   TITLE:=IPQ5018/QCN6122 ath11k firmware
@@ -60,16 +55,6 @@ endef
 define Package/ath11k-firmware-ipq6018
 $(Package/ath11k-firmware-default)
   TITLE:=IPQ6018 ath11k firmware
-endef
-
-define Package/ath11k-firmware-ipq8074
-$(Package/ath11k-firmware-default)
-  TITLE:=IPQ8074 ath11k firmware
-endef
-
-define Package/ath11k-firmware-qcn9074
-$(Package/ath11k-firmware-default)
-  TITLE:=QCN9074 ath11k firmware
 endef
 
 define Build/Clean
@@ -91,13 +76,6 @@ define Build/Compile
 
 endef
 
-define Package/ath11k-firmware-ipq5018/install
-	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/IPQ5018/hw1.0
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/IPQ5018/hw1.0/2.6.0.1/WLAN.HK.2.6.0.1-01291-QCAHKSWPL_SILICONZ-1/* \
-		$(1)/lib/firmware/ath11k/IPQ5018/hw1.0/
-endef
-
 define Package/ath11k-firmware-ipq5018-qcn6122/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/IPQ5018/hw1.0
 	$(INSTALL_DATA) \
@@ -116,24 +94,5 @@ define Package/ath11k-firmware-ipq6018/install
 		$(1)/lib/firmware/IPQ6018/
 endef
 
-define Package/ath11k-firmware-ipq8074/install
-	$(INSTALL_DIR) $(1)/lib/firmware/IPQ8074
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/IPQ8074/hw2.0/2.9.0.1/WLAN.HK.2.9.0.1-02146-QCAHKSWPL_SILICONZ-1/* \
-		$(1)/lib/firmware/IPQ8074/
-endef
-
-define Package/ath11k-firmware-qcn9074/install
-	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/QCN9074/hw1.0
-	$(INSTALL_DATA) \
-		$(PKG_BUILD_DIR)/QCN9074/hw1.0/2.9.0.1/WLAN.HK.2.9.0.1-02146-QCAHKSWPL_SILICONZ-1/* \
-		$(1)/lib/firmware/ath11k/QCN9074/hw1.0/
-	$(INSTALL_BIN) \
-		$(PKG_BUILD_DIR)/QCN9074/hw1.0/board-2.bin $(1)/lib/firmware/ath11k/QCN9074/hw1.0/board-2.bin
-endef
-
-$(eval $(call BuildPackage,ath11k-firmware-ipq5018))
 $(eval $(call BuildPackage,ath11k-firmware-ipq5018-qcn6122))
 $(eval $(call BuildPackage,ath11k-firmware-ipq6018))
-$(eval $(call BuildPackage,ath11k-firmware-ipq8074))
-$(eval $(call BuildPackage,ath11k-firmware-qcn9074))

--- a/package/firmware/linux-firmware/qca_ath11k.mk
+++ b/package/firmware/linux-firmware/qca_ath11k.mk
@@ -1,3 +1,19 @@
+Package/ath11k-firmware-ipq5018 = $(call Package/firmware-default,IPQ5018 ath11k firmware,,LICENCE.atheros_firmware)
+define Package/ath11k-firmware-ipq5018/install
+	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/IPQ5018/hw1.0
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/ath11k/IPQ5018/hw1.0/* $(1)/lib/firmware/ath11k/IPQ5018/hw1.0/
+endef
+$(eval $(call BuildPackage,ath11k-firmware-ipq5018))
+
+Package/ath11k-firmware-ipq8074 = $(call Package/firmware-default,IPQ8074 ath11k firmware,,LICENCE.atheros_firmware)
+define Package/ath11k-firmware-ipq8074/install
+	$(INSTALL_DIR) $(1)/lib/firmware/IPQ8074
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/ath11k/IPQ8074/hw2.0/* $(1)/lib/firmware/IPQ8074/
+endef
+$(eval $(call BuildPackage,ath11k-firmware-ipq8074))
+
 Package/ath11k-firmware-qca2066 = $(call Package/firmware-default,QCA2066 ath11k firmware,,LICENCE.atheros_firmware)
 define Package/ath11k-firmware-qca2066/install
 	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/QCA2066/hw2.1
@@ -13,6 +29,14 @@ define Package/ath11k-firmware-qca6390/install
 		$(PKG_BUILD_DIR)/ath11k/QCA6390/hw2.0/* $(1)/lib/firmware/ath11k/QCA6390/hw2.0/
 endef
 $(eval $(call BuildPackage,ath11k-firmware-qca6390))
+
+Package/ath11k-firmware-qcn9074 = $(call Package/firmware-default,QCN9074 ath11k firmware,,LICENCE.atheros_firmware)
+define Package/ath11k-firmware-qcn9074/install
+	$(INSTALL_DIR) $(1)/lib/firmware/ath11k/QCN9074/hw1.0
+	$(INSTALL_DATA) \
+		$(PKG_BUILD_DIR)/ath11k/QCN9074/hw1.0/* $(1)/lib/firmware/ath11k/QCN9074/hw1.0/
+endef
+$(eval $(call BuildPackage,ath11k-firmware-qcn9074))
 
 Package/ath11k-firmware-wcn6750 = $(call Package/firmware-default,WCN6750 ath11k firmware,,LICENCE.atheros_firmware)
 define Package/ath11k-firmware-wcn6750/install


### PR DESCRIPTION
Use linux-firmware repository for IPQ5018, IPQ8074 and QCN9074.
All officially released firmware versions are available there.

IPQ5018: [WLAN.HK.2.6.0.1-01300-QCAHKSWPL_SILICONZ-1](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/ath11k/IPQ5018/hw1.0?id=98e85bcbefbeb10d5594beb14a4e9e73aa6fe874)
IPQ8074: [WLAN.HK.2.9.0.1-02146-QCAHKSWPL_SILICONZ-1](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/ath11k/IPQ8074/hw2.0?id=0dba9647591886ad8e073a6a571498af5eba2391)
QCN9074: [WLAN.HK.2.9.0.1-02175-QCAHKSWPL_SILICONZ-2](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/commit/ath11k/QCN9074/hw1.0?id=811bb52b1d293c3a9641c8747c8963ade18b7e81)