### PR TITLE
mediatek: filogic: gl-mt2500 fix compatibles PHY variants for ASU sysupgrades

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -58,6 +58,7 @@ acer,predator-w6|\
 acer,predator-w6d|\
 acer,vero-w6m|\
 glinet,gl-mt2500|\
+glinet,gl-mt2500-airoha|\
 glinet,gl-mt6000|\
 glinet,gl-x3000|\
 glinet,gl-xe3000|\

--- a/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
+++ b/target/linux/mediatek/base-files/lib/preinit/05_set_preinit_iface
@@ -6,6 +6,7 @@ set_preinit_iface() {
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
 	glinet,gl-mt2500|\
+	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt3000|\
 	openembed,som7981|\
 	wavlink,wl-wn573hx3)

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v1.dts
@@ -3,6 +3,11 @@
 /dts-v1/;
 #include "mt7981b-glinet-gl-mt2500.dtsi"
 
+/ {
+	model = "GL.iNet GL-MT2500 (MaxLinear PHY)";
+	compatible = "glinet,gl-mt2500", "mediatek,mt7981";
+};
+
 &gmac0 {
 	phy-handle = <&phy5>;
 };

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500-v2.dts
@@ -3,6 +3,11 @@
 /dts-v1/;
 #include "mt7981b-glinet-gl-mt2500.dtsi"
 
+/ {
+	model = "GL.iNet GL-MT2500 (Airoha PHY)";
+	compatible = "glinet,gl-mt2500-airoha", "mediatek,mt7981";
+};
+
 &gmac0 {
 	phy-handle = <&phy13>;
 };

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt2500.dtsi
@@ -5,9 +5,6 @@
 #include <dt-bindings/pinctrl/mt65xx.h>
 
 / {
-	model = "GL.iNet GL-MT2500";
-	compatible = "glinet,gl-mt2500", "mediatek,mt7981";
-
 	aliases {
 		label-mac-device = &gmac0;
 		led-boot = &led_sys_white;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -130,6 +130,7 @@ mediatek_setup_interfaces()
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
 	glinet,gl-mt2500|\
+	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt3000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -128,6 +128,7 @@ platform_do_upgrade() {
 	airpi,ap3000m|\
 	arcadyan,mozart|\
 	glinet,gl-mt2500|\
+	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
@@ -352,6 +353,7 @@ platform_copy_config() {
 	airpi,ap3000m|\
 	arcadyan,mozart|\
 	glinet,gl-mt2500|\
+	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\


### PR DESCRIPTION
These devices share the same "compatible" in device tree causing some incompatibilities (sysupgrades, ASU profile identification), assign a unique "compatible" and "model" to each variant.

Context:
Commit https://github.com/openwrt/openwrt/commit/8d30e07180367cdeb4affd79adead6e1025355c9 added each variant's dts compatible to the SUPPORTED_DEVICES field of the other variant to make easy sysupgrades between these physically indistinguishable devices variants possible.

But there were found three issues which does not allow this:
- the sysupgrade's stricter check still used in some sysupgrade paths(this check is being replaced(and redundant) with the newer fwtool's SUPPORTED_DEVICES check using the info in images METADATA), this check will fail when sysupgrading from a different board_name(compatible dts) that the image was created for (image profile name).[^2]
- ASU needs unique "dts compatible" to identify the devices profile.
- and an ASU's profile identification limitation when several devices from a common target share SUPPORTED_DEVICES entries.[^3]

There is a proposal for these issues but not yet implemented [^4][^3].
Until these issues are fixed we won't allow "easy" sysupgrades between these two device variants.

Commit https://github.com/openwrt/openwrt/commit/b71f4665cda10c284c9460409ae30fb9b0beecf8 avoided the ASU profile identification limitation but missed the required two unique dts compatibles in order to make the two variants fully work, although not allowing easy sysupgrade between them.

[^2]: sysupgrade stricter check https://github.com/openwrt/openwrt/issues/20566#issuecomment-3583555482
[^3]: ASU proposal https://github.com/openwrt/asu/pull/1533
[^4]: allow easy sysupgrade proposal https://github.com/openwrt/openwrt/pull/20947

Fixes: b71f466 ("mediatek: filogic: fix supported_devices list for gl-mt2500")
Fixes: 8d30e07 ("mediatek: filogic: fix for new GL.iNet GL-MT2500/GL-MT2500A hardware revision")
Fixes: https://github.com/openwrt/openwrt/issues/20566
Fixes: https://github.com/openwrt/asu/issues/1525