### PR TITLE
realtek: eth: rtl931x: reduce logging of special packet trap

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -311,7 +311,7 @@ static bool rteth_931x_decode_tag(struct p_hdr *h, struct dsa_tag *t)
 	t->crc_error = h->cpu_tag[1] & BIT(6);
 
 	if (t->reason != 63)
-		pr_info("%s: Reason %d, port %d, queue %d\n", __func__, t->reason, t->port, t->queue);
+		pr_debug("%s: Reason %d, port %d, queue %d\n", __func__, t->reason, t->port, t->queue);
 	if (t->reason >= 19 && t->reason <= 27)	/* NIC_RX_REASON_RMA */
 		t->l2_offloaded = 0;
 	else


### PR DESCRIPTION
For packets trapped to the CPU for a special reason (not normal forward), the RTL931x tag decoding always print a log message with level INFO. This is not needed and just spams the log, e.g. when LLDP packets are running through the network, each of them causes a log message.

Make that a debug message instead of an info message. We can keep it, just change when it's printed.