### PR TITLE
wireguard-tools: fix script errors

### DIFF
--- a/package/network/utils/wireguard-tools/files/wireguard.sh
+++ b/package/network/utils/wireguard-tools/files/wireguard.sh
@@ -84,7 +84,7 @@ proto_wireguard_setup() {
 		config_get peer_port "$section" "endpoint_port" "51820"
 		config_get peer_a_ips "$section" "allowed_ips"
 		config_get peer_p_ka "$section" "persistent_keepalive"
-		config_get peer_psk "$section" "peer_psk"
+		config_get peer_psk "$section" "preshared_key"
 
 
 		[ "${peer_eph##*:}" != "$peer_eph" ] && peer_eph="[$peer_eph]"
@@ -94,7 +94,7 @@ proto_wireguard_setup() {
 		[ -n "${peer_key}" ]	&& peer_block="${peer_block}PublicKey=${peer_key}\n"
 		[ -n "${peer_psk}" ]	&& peer_block="${peer_block}PresharedKey=${peer_psk}\n"
 		[ -n "${peer_eph}" ]	&& peer_block="${peer_block}Endpoint=${peer_eph}${peer_port:+:$peer_port}\n"
-		[ -n "${peer_a_ips}" ]	&& peer_block="${peer_block}AllowedIPs=${peer_a_ips/ /, }\n"
+		[ -n "${peer_a_ips}" ]	&& peer_block="${peer_block}AllowedIPs=${peer_a_ips// /, }\n"
 		[ -n "${peer_p_ka}" ]	&& peer_block="${peer_block}PersistentKeepalive=${peer_p_ka}\n"
 
 		[ -n "$peer_key" ] && peer_config="$peer_config$peer_block\n"


### PR DESCRIPTION
follow-up to 148207730a3c9f3aea807df336ca33792e9d3c0f

Schoolboy error on the peer_psk value.

Also fix an issue when joining peer IPv4 and IPv6 AllowedIPs (`${peer_a_ips/ /, }` replaces only the first space, while `${peer_a_ips// /, }` replaces all the spaces).

Closes https://github.com/openwrt/openwrt/issues/21847

ping @robimarko for merge

@schuettecarsten this fixes your problem