### PR TITLE
wireguard-tools: fix AllowedIPs substitution to handle multiple IPs

### DIFF
--- a/package/network/utils/wireguard-tools/files/wireguard.sh
+++ b/package/network/utils/wireguard-tools/files/wireguard.sh
@@ -94,7 +94,7 @@ proto_wireguard_setup() {
 		[ -n "${peer_key}" ]	&& peer_block="${peer_block}PublicKey=${peer_key}\n"
 		[ -n "${peer_psk}" ]	&& peer_block="${peer_block}PresharedKey=${peer_psk}\n"
 		[ -n "${peer_eph}" ]	&& peer_block="${peer_block}Endpoint=${peer_eph}${peer_port:+:$peer_port}\n"
-		[ -n "${peer_a_ips}" ]	&& peer_block="${peer_block}AllowedIPs=${peer_a_ips/ /, }\n"
+		[ -n "${peer_a_ips}" ]	&& peer_block="${peer_block}AllowedIPs=${peer_a_ips// /, }\n"
 		[ -n "${peer_p_ka}" ]	&& peer_block="${peer_block}PersistentKeepalive=${peer_p_ka}\n"
 
 		[ -n "$peer_key" ] && peer_config="$peer_config$peer_block\n"


### PR DESCRIPTION
After 14820773, my WireGuard interface failed to come up with the following error:
```
daemon.notice netifd: wg0 (881): AllowedIP is not in the correct format: `192.168.0.0/2410.0.0.1fd68:7ec9:8ed4::/48'
```

This PR fixes support for multiple allowed IPs for the generated WireGuard config.