### PR TITLE
lantiq: xrx200: handle EPROBE_DEFER for MAC address

### DIFF
--- a/target/linux/lantiq/patches-6.12/0801-net-ethernet-lantiq-xrx200-handle-EPROBE_DEFER-for-MAC-address.patch
+++ b/target/linux/lantiq/patches-6.12/0801-net-ethernet-lantiq-xrx200-handle-EPROBE_DEFER-for-MAC-address.patch
@@ -1,0 +1,30 @@
+From: Burak Aydos <byhexadecimal@gmail.com>
+Date: Mon, 03 Feb 2026 12:00:00 +0300
+Subject: [PATCH] net: ethernet: lantiq: xrx200: handle EPROBE_DEFER for MAC
+ address
+
+When the MAC address is provided by an nvmem layout driver (such as
+u-boot-env), the nvmem cell may not be available yet when the ethernet
+driver probes. In this case, of_get_ethdev_address() returns
+-EPROBE_DEFER to indicate the driver should be retried later.
+
+Currently the driver treats all errors equally and falls back to a
+random MAC address. Fix this by propagating EPROBE_DEFER so the
+driver probe is deferred until the nvmem cell becomes available.
+
+Signed-off-by: Burak Aydos <byhexadecimal@gmail.com>
+---
+ drivers/net/ethernet/lantiq_xrx200.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/net/ethernet/lantiq_xrx200.c
++++ b/drivers/net/ethernet/lantiq_xrx200.c
+@@ -597,6 +597,8 @@ static int xrx200_probe(struct platform_
+ 	}
+ 
+ 	err = of_get_ethdev_address(np, net_dev);
++	if (err == -EPROBE_DEFER)
++		return err;
+ 	if (err)
+ 		eth_hw_addr_random(net_dev);
+ 


### PR DESCRIPTION
## Summary

Two fixes for platform ethernet drivers failing to obtain MAC addresses from nvmem layout drivers (such as `u-boot-env`):

- **`net/core/of_net.c`**: `of_get_mac_address_nvmem()` only attempts device-based `nvmem_cell_get()` for platform devices. When this fails (as it does for cells provided by nvmem layout drivers), it returns immediately without trying the DT-based `of_nvmem_cell_get()` path. This patch adds a fallback to the DT-based lookup.

- **`drivers/net/ethernet/lantiq_xrx200.c`**: The driver treats all `of_get_ethdev_address()` errors equally, falling back to a random MAC even on `-EPROBE_DEFER`. This patch propagates `EPROBE_DEFER` so driver probe is deferred until the nvmem cell becomes available.

## Affected devices

This affects all **lantiq xrx200 family** devices that use `u-boot-env` nvmem layout for MAC address assignment. The `of_net.c` fix is generic and may benefit other platforms with the same issue.

## Root cause analysis

When `of_get_mac_address_nvmem()` is called for a platform device (like `1e10b308.eth`):
1. `of_find_device_by_node(np)` returns a valid `pdev`
2. `nvmem_cell_get(dev, "mac-address")` is attempted (device-based lookup)
3. This lookup **cannot find** cells created by nvmem layout drivers (u-boot-env)
4. The function returns the error **without** trying `of_nvmem_cell_get()` (DT-based lookup)
5. xrx200-net driver sees the error, assigns random MAC

DSA ports (like WAN) are **not** platform devices, so they take the DT-based path and get the correct MAC. This is why WAN worked but eth0/LAN did not.

## Test results — Zyxel P-2812HNU-F1

**Before fix** (every boot produces different random MAC):
```
eth0:    addr_assign_type=1 (random)  de:07:6b:XX:XX:XX
lan1-4:  addr_assign_type=1 (random)  de:07:6b:XX:XX:XX
wan:     addr_assign_type=0 (permanent) c8:6c:87:XX:XX:XX  ← only WAN was correct
```

**After fix** (stable across reboots):
```
eth0:    addr_assign_type=0 (permanent) c8:6c:87:XX:XX:XX  ← ethaddr from u-boot env
lan1-4:  addr_assign_type=0 (permanent) c8:6c:87:XX:XX:XX  ← same as eth0
wan:     addr_assign_type=0 (permanent) c8:6c:87:XX:XX:XX  ← ethaddr+1
```

All `addr_assign_type` values are `0` (permanent), confirming MAC addresses are read from nvmem, not randomly generated.

`fw_printenv` confirms nvmem is working:
```
ethaddr=c8:6c:87:XX:XX:XX
```

OUI `c8:6c:87` is registered to ZyXEL Communications Corp.

## Related PRs

- #21780 — `env-size` fix for u-boot-env CRC32 validation (merged, prerequisite)
- #21081 — Move nvmem-cells from `&gswip` to `&eth0` in shared DTSI (merged)
- #21073 — Embed WiFi EEPROM in F1 DTS (open)

## Test plan

- [x] Verify `eth0` gets permanent MAC from u-boot env (`addr_assign_type=0`)
- [x] Verify `wan` still gets correct MAC (ethaddr+1)
- [x] Verify `lan1-4` inherit MAC from `eth0`
- [x] Verify MAC is stable across reboots
- [x] Verify `fw_printenv ethaddr` matches interface MAC