### PR TITLE
base-files: add provisioning support via firmware metadata

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -307,6 +307,14 @@ create_backup_archive() {
 			tar c${TAR_V} -C / -T "$CONFFILES" || ret=1
 		fi
 
+		# Add provisioning uci-defaults scripts extracted from firmware metadata
+		if [ $ret -eq 0 ] && [ -d /tmp/sysupgrade.d ]; then
+			for script in /tmp/sysupgrade.d/*; do
+				[ -f "$script" ] || continue
+				tar_print_member "/etc/uci-defaults/${script##*/}" "$(cat "$script")" || ret=1
+			done
+		fi
+
 		[ $ret -eq 0 ]
 	} | gzip > "${conf_tar:-/proc/self/fd/1}"
 	err=$?
@@ -318,6 +326,7 @@ create_backup_archive() {
 	fi
 
 	rm -f "$CONFFILES"
+	rm -rf /tmp/sysupgrade.d
 
 	return "$err"
 }

--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -403,6 +403,27 @@ json_get_var forceable "forceable"
 	fi
 }
 
+# Notify user about provisioning scripts extracted from firmware metadata
+if [ -d /tmp/sysupgrade.d ] && [ -n "$(ls /tmp/sysupgrade.d 2>/dev/null)" ]; then
+	echo "Provisioning scripts found in firmware image:"
+	for script in /tmp/sysupgrade.d/*; do
+		[ -f "$script" ] && echo "  - ${script##*/}"
+	done
+	echo "These scripts will run on first boot after upgrade."
+	ask_bool 0 "View provisioning scripts" && {
+		for script in /tmp/sysupgrade.d/*; do
+			[ -f "$script" ] || continue
+			echo "=== ${script##*/} ==="
+			cat "$script"
+			echo ""
+		done
+	}
+	ask_bool 1 "Continue with upgrade" || {
+		rm -rf /tmp/sysupgrade.d
+		exit 0
+	}
+fi
+
 if [ -n "$CONF_IMAGE" ]; then
 	case "$(get_magic_word $CONF_IMAGE cat)" in
 		# .gz files


### PR DESCRIPTION
Add support for uci-defaults provisioning scripts embedded in firmware metadata. This enables cloud-init style device configuration where scripts are attached to the sysupgrade image and executed on first boot.

The provisioning data is stored in the existing fwtool JSON metadata:

```json
  {
    "provisioning": {
      "uci-defaults": {
        "90_hostname": "<base64-gzipped-script>",
        "91_wifi": "<base64-gzipped-script>"
      }
    }
  }
```

Each script is individually gzipped and base64 encoded, allowing multiple tools to add their own scripts independently.

During sysupgrade:
1. fwtool_extract_provisioning() extracts scripts to /tmp/sysupgrade.d/
2. Scripts are included in the backup archive as /etc/uci-defaults/*
3. After reboot, uci_apply_defaults() executes them on first boot