### PR TITLE
realtek: dsa: make use of device_get_match_data()

### DIFF
--- a/target/linux/realtek/dts/rtl838x.dtsi
+++ b/target/linux/realtek/dts/rtl838x.dtsi
@@ -355,7 +355,7 @@
 	};
 
 	switch0: switch@1b000000 {
-		compatible = "realtek,rtl83xx-switch";
+		compatible = "realtek,rtl8380-switch", "realtek,otto-switch";
 
 		interrupt-parent = <&intc>;
 		interrupts = <20 2>;

--- a/target/linux/realtek/dts/rtl839x.dtsi
+++ b/target/linux/realtek/dts/rtl839x.dtsi
@@ -357,7 +357,7 @@
 
 	switch0: switch@1b000000 {
 		status = "okay";
-		compatible = "realtek,rtl83xx-switch";
+		compatible = "realtek,rtl8392-switch", "realtek,otto-switch";
 
 		interrupt-parent = <&intc>;
 		interrupts = <20 2>;

--- a/target/linux/realtek/dts/rtl930x.dtsi
+++ b/target/linux/realtek/dts/rtl930x.dtsi
@@ -359,7 +359,7 @@
 	};
 
 	switch0: switch@1b000000 {
-		compatible = "realtek,rtl83xx-switch";
+		compatible = "realtek,rtl9301-switch", "realtek,otto-switch";
 		status = "okay";
 
 		interrupt-parent = <&intc>;

--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -421,7 +421,7 @@
 	};
 
 	switch0: switch@1b000000 {
-		compatible = "realtek,rtl83xx-switch";
+		compatible = "realtek,rtl9311-switch", "realtek,otto-switch";
 		status = "okay";
 
 		interrupt-parent = <&gic>;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -278,7 +278,7 @@ static int rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 	if (ret)
 		return ret;
 
-	dn = of_find_compatible_node(NULL, NULL, "realtek,rtl83xx-switch");
+	dn = of_find_compatible_node(NULL, NULL, "realtek,otto-switch");
 	if (!dn) {
 		dev_err(priv->dev, "No RTL switch node in DTS\n");
 		return -ENODEV;
@@ -1402,6 +1402,7 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 	if (err)
 		return err;
 
+	priv->r = device_get_match_data(&pdev->dev);
 	priv->family_id = soc_info.family;
 	priv->id = soc_info.id;
 	switch (soc_info.family) {
@@ -1411,7 +1412,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->port_mask = 0x1f;
 		priv->port_width = 1;
 		priv->irq_mask = 0x0FFFFFFF;
-		priv->r = &rtl838x_reg;
 		priv->ds->num_ports = RTL838X_CPU_PORT + 1;
 		priv->fib_entries = 8192;
 		priv->ds->num_lag_ids = 8;
@@ -1427,7 +1427,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->port_mask = 0x3f;
 		priv->port_width = 2;
 		priv->irq_mask = 0xFFFFFFFFFFFFFULL;
-		priv->r = &rtl839x_reg;
 		priv->ds->num_ports = RTL839X_CPU_PORT + 1;
 		priv->fib_entries = 16384;
 		priv->ds->num_lag_ids = 16;
@@ -1443,7 +1442,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->port_mask = 0x1f;
 		priv->port_width = 1;
 		priv->irq_mask = 0x0FFFFFFF;
-		priv->r = &rtl930x_reg;
 		priv->ds->num_ports = RTL930X_CPU_PORT + 1;
 		priv->fib_entries = 16384;
 		priv->ds->num_lag_ids = 16;
@@ -1460,7 +1458,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->port_mask = 0x3f;
 		priv->port_width = 2;
 		priv->irq_mask = GENMASK_ULL(priv->cpu_port - 1, 0);
-		priv->r = &rtl931x_reg;
 		priv->ds->num_ports = RTL931X_CPU_PORT + 1;
 		priv->fib_entries = 16384;
 		priv->ds->num_lag_ids = 16;
@@ -1634,7 +1631,22 @@ static void rtl83xx_sw_remove(struct platform_device *pdev)
 }
 
 static const struct of_device_id rtl83xx_switch_of_ids[] = {
-	{ .compatible = "realtek,rtl83xx-switch"},
+	{
+		.compatible = "realtek,rtl8380-switch",
+		.data = &rtldsa_838x_cfg,
+	},
+	{
+		.compatible = "realtek,rtl8392-switch",
+		.data = &rtldsa_839x_cfg,
+	},
+	{
+		.compatible = "realtek,rtl9301-switch",
+		.data = &rtldsa_930x_cfg,
+	},
+	{
+		.compatible = "realtek,rtl9311-switch",
+		.data = &rtldsa_931x_cfg,
+	},
 	{ /* sentinel */ }
 };
 

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1671,7 +1671,7 @@ static void rtl838x_set_receive_management_action(int port, rma_ctrl_t type, act
 	}
 }
 
-const struct rtl838x_reg rtl838x_reg = {
+const struct rtldsa_config rtldsa_838x_cfg = {
 	.mask_port_reg_be = rtl838x_mask_port_reg,
 	.set_port_reg_be = rtl838x_set_port_reg,
 	.get_port_reg_be = rtl838x_get_port_reg,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1231,7 +1231,7 @@ struct rtldsa_mirror_config {
 	u32 val;
 };
 
-struct rtl838x_reg {
+struct rtldsa_config {
 	void (*mask_port_reg_be)(u64 clear, u64 set, int reg);
 	void (*set_port_reg_be)(u64 set, int reg);
 	u64 (*get_port_reg_be)(int reg);
@@ -1355,7 +1355,7 @@ struct rtl838x_switch_priv {
 	int link_state_irq;
 	int mirror_group_ports[4];
 	struct mii_bus *parent_bus;
-	const struct rtl838x_reg *r;
+	const struct rtldsa_config *r;
 	u8 cpu_port;
 	u8 port_mask;
 	u8 port_width;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1609,7 +1609,7 @@ static void rtl839x_set_receive_management_action(int port, rma_ctrl_t type, act
 	}
 }
 
-const struct rtl838x_reg rtl839x_reg = {
+const struct rtldsa_config rtldsa_839x_cfg = {
 	.mask_port_reg_be = rtl839x_mask_port_reg_be,
 	.set_port_reg_be = rtl839x_set_port_reg_be,
 	.get_port_reg_be = rtl839x_get_port_reg_be,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -202,10 +202,10 @@ void rtl931x_print_matrix(void);
 extern const struct dsa_switch_ops rtldsa_83xx_switch_ops;
 extern const struct dsa_switch_ops rtldsa_93xx_switch_ops;
 
-extern const struct rtl838x_reg rtl838x_reg;
-extern const struct rtl838x_reg rtl839x_reg;
-extern const struct rtl838x_reg rtl930x_reg;
-extern const struct rtl838x_reg rtl931x_reg;
+extern const struct rtldsa_config rtldsa_838x_cfg;
+extern const struct rtldsa_config rtldsa_839x_cfg;
+extern const struct rtldsa_config rtldsa_930x_cfg;
+extern const struct rtldsa_config rtldsa_931x_cfg;
 
 /* TODO actually from arch/mips/rtl838x/prom.c */
 extern struct rtl83xx_soc_info soc_info;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -2614,7 +2614,7 @@ static void rtldsa_930x_qos_init(struct rtl838x_switch_priv *priv)
 	rtldsa_930x_qos_set_scheduling_queue_weights(priv);
 }
 
-const struct rtl838x_reg rtl930x_reg = {
+const struct rtldsa_config rtldsa_930x_cfg = {
 	.mask_port_reg_be = rtl838x_mask_port_reg,
 	.set_port_reg_be = rtl838x_set_port_reg,
 	.get_port_reg_be = rtl838x_get_port_reg,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -1800,7 +1800,7 @@ void rtldsa_931x_config_phy_ability_source(struct rtl838x_switch_priv *priv)
 	sw_w32(phy_ablty_sel[3], RTLDSA_931X_SMI_PHY_ABLTY_GET_SEL + 0xc);
 }
 
-const struct rtl838x_reg rtl931x_reg = {
+const struct rtldsa_config rtldsa_931x_cfg = {
 	.mask_port_reg_be = rtl839x_mask_port_reg_be,
 	.set_port_reg_be = rtl839x_set_port_reg_be,
 	.get_port_reg_be = rtl839x_get_port_reg_be,


### PR DESCRIPTION
The SoC specific configuration structure is currently manually assigned depending on the family_id. This will be removed in the future. Make use of device_get_match_data() instead.

While we are here rename the structure prefix.
