### PR TITLE
realtek: mdio: rtl838x: re-enable phy control via SoC

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -366,14 +366,9 @@ static int rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 	/* Disable MAC polling the PHY so that we can start configuration */
 	priv->r->set_port_reg_le(0ULL, priv->r->smi_poll_ctrl);
 
-	/* Enable PHY control via SoC */
-	if (priv->family_id == RTL8380_FAMILY_ID) {
-		/* Enable PHY control by telling SoC that "PHY patching is done" */
-		sw_w32_mask(0, BIT(15), RTL838X_SMI_GLB_CTRL);
-	} else if (priv->family_id == RTL8390_FAMILY_ID) {
-		/* Disable PHY polling via SoC */
+	/* Disable PHY polling via SoC */
+	if (priv->family_id == RTL8390_FAMILY_ID)
 		sw_w32_mask(BIT(7), 0, RTL839X_SMI_GLB_CTRL);
-	}
 
 	return 0;
 }

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -60,8 +60,6 @@ static void rtldsa_enable_phy_polling(struct rtl838x_switch_priv *priv)
 	/* PHY update complete, there is no global PHY polling enable bit on the 93xx */
 	if (priv->family_id == RTL8390_FAMILY_ID)
 		sw_w32_mask(0, BIT(7), RTL839X_SMI_GLB_CTRL);
-	else if (priv->family_id == RTL8380_FAMILY_ID)
-		sw_w32_mask(0, BIT(15), RTL838X_SMI_GLB_CTRL);
 }
 
 const struct rtldsa_mib_list_item rtldsa_838x_mib_list[] = {

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -666,6 +666,11 @@ static int rtmdio_838x_reset(struct mii_bus *bus)
 	combo_phy = ctrl->smi_bus[24] < 0 ? 0 : BIT(7);
 	regmap_update_bits(ctrl->map, RTMDIO_838X_SMI_GLB_CTRL, BIT(7), combo_phy);
 
+	/*
+	 * Bit 15, PHY_PATCH_DONE, enables phy control via SoC. This is required for phy
+	 * access, including patching. Must always be set before the phys are probed.
+	 */
+	regmap_update_bits(ctrl->map, RTMDIO_838X_SMI_GLB_CTRL, BIT(15), BIT(15));
 	return 0;
 }
 


### PR DESCRIPTION
@plappermaul, @robimarko 

The Netgear GS108Tv3 fails to bring up any link with recent snapshot builds due to a bug introduced by https://github.com/openwrt/openwrt/pull/21653

Surprisingly, my Zyxel GS1900-10HP A1 worked just fine with a similar build when I tried to reproduce the issue.  And so did the Netgear GS108Tv3 in my initial attempt to bisect the problem.  It worked fine when I tftp booted it, because "rtk network on" sets the missing flag and thereby prevents the bug.

The issue is that phy patching fails unless bit 15 of the SMI_GLB_CTRL is set.  We set if all over the place in the DSA driver.  This is redundant and pointless and should probably be dropped.  But we must set it in the mdio driver reset or similar, before attempting to access the phys.  Otherwise, phy patching fails.  The symptoms are a bit confusing, where most of the phys appear ro probe sucessfully, due to our rather odd phy driver:

```
[    0.965887] Firmware loaded. Size 1184, magic: 83808380
[    0.971992] Realtek RTL8218B (internal) 1b000000.switchcore:mdio-controller-mii:08: patch
[    2.090197] Realtek RTL8218B (internal) 1b000000.switchcore:mdio-controller-mii:08: package not ready for patch.
[    2.101747] Realtek RTL8218B (internal) 1b000000.switchcore:mdio-controller-mii:0f: probe with driver Realtek RTL8218B (internal) failed with error -5
[    2.126707] realtek-otto-serdes-mdio 1b000000.switchcore:mdio-serdes: Realtek SerDes mdio bus initialized, 6 SerDes, 4 pages, 32 registers
[    2.141673] realtek-otto-pcs 1b000000.switchcore:pcs: Realtek PCS driver initialized
[    2.151754] Probing RTL838X eth device pdev: 818a6e00, dev: 818a6e10
[    2.203663] rteth_838x_init_mac
[    2.209893] Using MAC 00:e0:4c:00:00:00
[    2.216856] i2c_dev: i2c /dev entries driver
[    2.234048] NET: Registered PF_INET6 protocol family
[    2.285016] Segment Routing with IPv6
[    2.289418] In-situ OAM (IOAM) with IPv6
[    2.294329] NET: Registered PF_PACKET protocol family
[    2.301216] 8021q: 802.1Q VLAN Support v1.8
[    2.382958] rtl83xx_mdio_probe: RTL838X_SMI_GLB_CTRL: 48028
[    2.422024] In rtldsa_vlan_setup
[    2.425723] rtl83xx-switch switch@1b000000: MC_PMASK_ALL_PORTS: 000000001fffffff
[    3.460165] rtldsa_enable_phy_polling:             ff00
[    3.466070] rtldsa_enable_phy_polling: RTL838X_SMI_GLB_CTRL: 48028
[    4.500467] rtl83xx-switch switch@1b000000: configuring for fixed/internal link mode
[    4.512048] rtl83xx-switch switch@1b000000: Link is Up - 1Gbps/Full - flow control off
[    4.521554] rtl83xx-switch switch@1b000000 lan1 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:08] driver [Realtek RTL8218B (internal)] (irq=POLL)
[    4.544511] rtl83xx-switch switch@1b000000 lan2 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:09] driver [Realtek RTL8218B (internal)] (irq=POLL)
[    4.567116] rtl83xx-switch switch@1b000000 lan3 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:0a] driver [Realtek RTL8218B (internal)] (irq=POLL)
[    4.589974] rtl83xx-switch switch@1b000000 lan4 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:0b] driver [Realtek RTL8218B (internal)] (irq=POLL)
[    4.612969] rtl83xx-switch switch@1b000000 lan5 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:0c] driver [Realtek RTL8218B (internal)] (irq=POLL)
[    4.636332] rtl83xx-switch switch@1b000000 lan6 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:0d] driver [Realtek RTL8218B (internal)] (irq=POLL)
[    4.659362] rtl83xx-switch switch@1b000000 lan7 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:0e] driver [Realtek RTL8218B (internal)] (irq=POLL)
[    4.688105] rtl83xx-switch switch@1b000000 lan8 (uninitialized): PHY [1b000000.switchcore:mdio-controller-mii:0f] driver [Generic PHY] (irq=POLL)
[    4.708368] rtl838x-eth 1b000000.switchcore:ethernet eth0: entered promiscuous mode
```

The failure is total.  None of the ports will detect a link when firmware patching fails.

I cannot find an explanation of the bit 15 change so I assume it was unintentional?  Driver history shows that this bit has always been set. It was there in Birgers first version of the driver. And some boot loaders sets it even when networking is disabled.  I believe there are good reasons for this.

Note that we also set the same bit a couple of times in the DSA driver.  This is redundant and pointless.  It is too late to prevent the bug, and it makes no difference if the mdio driver (or the bootloader) already set it.  The DSA accesses to this register should probably be deleted? 