### PR TITLE
apk: backport upstream fix for invalid fetch timestamps

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git

--- a/package/system/apk/patches/0001-openwrt-move-layer-db-to-temp-folder.patch
+++ b/package/system/apk/patches/0001-openwrt-move-layer-db-to-temp-folder.patch
@@ -10,7 +10,7 @@ Signed-off-by: Paul Spooren <mail@aparcar.org>
 
 --- a/src/database.c
 +++ b/src/database.c
-@@ -1918,7 +1918,7 @@ const char *apk_db_layer_name(int layer)
+@@ -1919,7 +1919,7 @@ const char *apk_db_layer_name(int layer)
  {
  	switch (layer) {
  	case APK_DB_LAYER_ROOT: return "lib/apk/db";

--- a/package/system/apk/patches/0020-io-fix-invalid-fetch-timestamps-with-wget-backend.patch
+++ b/package/system/apk/patches/0020-io-fix-invalid-fetch-timestamps-with-wget-backend.patch
@@ -1,0 +1,33 @@
+From 42f159e67bafe1dad16839c0c0a005b5e89487ba Mon Sep 17 00:00:00 2001
+From: Matt Merhar <mattmerhar@protonmail.com>
+Date: Sun, 1 Feb 2026 21:16:01 -0500
+Subject: [PATCH] io: fix invalid fetch timestamps with wget backend
+
+In OpenWrt it was noticed that files downloaded via 'apk fetch' had
+huge, invalid timestamps.
+
+An strace showed utimensat_time64() being called with tv_sec values like
+-5268223168728060756 and 1167423650789556, causing even an 'ls -l' of
+the file afterwards to crash busybox.
+
+The explanation here is that the process_get_meta() stub in process.c
+doesn't set anything, so the struct is filled with garbage.
+
+To address this, zero init the struct in apk_ostream_copy_meta(). This
+leads to the timestamp of the downloaded file being set to the current
+time.
+---
+ src/io.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/io.c
++++ b/src/io.c
+@@ -1258,7 +1258,7 @@ int apk_ostream_fmt(struct apk_ostream *
+ 
+ void apk_ostream_copy_meta(struct apk_ostream *os, struct apk_istream *is)
+ {
+-	struct apk_file_meta meta;
++	struct apk_file_meta meta = { 0 };
+ 	apk_istream_get_meta(is, &meta);
+ 	os->ops->set_meta(os, &meta);
+ }


### PR DESCRIPTION
Uninitialized memory led to bogus, huge timestamps being set on files downloaded with the wget backend. This caused odd issues like 'ls -l' crashing busybox when attempting to list the .apk file afterwards.

Link: https://gitlab.alpinelinux.org/alpine/apk-tools/-/commit/42f159e67bafe1dad16839c0c0a005b5e89487ba