### PR TITLE
realtek: rtl93xx: remove MDB handlers instead of checking id

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -2493,9 +2493,6 @@ static int rtldsa_port_mdb_add(struct dsa_switch *ds, int port,
 	u64 seed = priv->r->l2_hash_seed(mac, vid);
 	int mc_group;
 
-	if (priv->id >= 0x9300)
-		return -EOPNOTSUPP;
-
 	pr_debug("In %s port %d, mac %llx, vid: %d\n", __func__, port, mac, vid);
 
 	if (priv->lag_non_primary & BIT_ULL(port)) {
@@ -3122,8 +3119,10 @@ const struct dsa_switch_ops rtldsa_93xx_switch_ops = {
 	.port_fdb_del		= rtldsa_port_fdb_del,
 	.port_fdb_dump		= rtldsa_port_fdb_dump,
 
+	/* ToDo: test on rtl93xx
 	.port_mdb_add		= rtldsa_port_mdb_add,
 	.port_mdb_del		= rtldsa_port_mdb_del,
+	*/
 
 	.port_mirror_add	= rtldsa_port_mirror_add,
 	.port_mirror_del	= rtldsa_port_mirror_del,


### PR DESCRIPTION
Right now the MDB code part should be unused on rtl93xx as after a priv->id check we return -EOPNOTSUPP. With unset MDB handlers / handlers set to NULL this should have the same result. And let's us avoid this priv->id check in the code.

ToDo: Once someone can verify the MDB code on an rtl93xx device then we can add these handlers in again.

---

This patch was split from and originally developed in: https://github.com/openwrt/openwrt/pull/18780. The purpose of this patch was also to avoid adding more priv->(family_)id checks / bailouts in the multicast code for rtl93xx for now.