### PR TITLE
realtek: dsa: remove storm control

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -188,9 +188,6 @@ int rtl83xx_lag_del(struct dsa_switch *ds, int group, int port);
  * collect them in this section.
  */
 
-void rtl838x_egress_rate_queue_limit(struct rtl838x_switch_priv *priv, int port,
-				     int queue, u32 rate);
-
 void rtl839x_pie_rule_dump(struct  pie_rule *pr);
 void rtl839x_set_egress_queue(int port, int queue);
 


### PR DESCRIPTION
This fixes https://github.com/openwrt/openwrt/issues/21692

Removing all of qos.c is tempting.  I believe this was written as some sort of hardware feature demo, without considering the actual usefulness.  But I don't have any rtl839x for testing, so better leave the remaining queue stuff for now