### PR TITLE
[25.12] mediatek: routerich be7200: fix usb issue

### DIFF
--- a/target/linux/mediatek/dts/mt7987a-routerich-be7200.dts
+++ b/target/linux/mediatek/dts/mt7987a-routerich-be7200.dts
@@ -453,7 +453,6 @@
 	status = "okay";
 
 	vusb33-supply = <&reg_3p3v>;
-	vbus-supply = <&reg_usb_5v>;
 };
 
 &tphyu3port0 {


### PR DESCRIPTION
This commit fixes non-working USB port:

```
[    5.294036] xhci-mtk 11200000.usb: error -EPERM: Failed to get supply 'vbus'
[    5.301163] xhci-mtk 11200000.usb: error -EPERM: Failed to get regulators
[    5.307938] xhci-mtk 11200000.usb: probe with driver xhci-mtk failed with error -1

```

While testing the USB power on/off functionality during the previous commit, I didn't sufficiently test the actual operation of the USB devices.

Fixes: ff5e66a9208a ("mediatek: add support for Routerich BE7200")
