### PR TITLE
mediatek: filogic: fix precal for acer w6/w6d/w6m

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6.dts
@@ -156,13 +156,17 @@
 	eeprom_factory_a0000: eeprom@a0000 {
 		reg = <0xa0000 0x1000>;
 	};
+
+	precal_factory_a1010: precal@a1010 {
+		reg = <0xa1010 0x62810>;
+	};
 };
 
 &slot0 {
 	radio0: mt7915@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_a0000>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_a0000>, <&precal_factory_a1010>;
+		nvmem-cell-names = "eeprom", "precal";
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7986a-acer-vero-w6m.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-vero-w6m.dts
@@ -51,13 +51,17 @@
 	eeprom_factory_a0000: eeprom@a0000 {
 		reg = <0xa0000 0x1000>;
 	};
+
+	precal_factory_a1010: precal@a1010 {
+		reg = <0xa1010 0x62810>;
+	};
 };
 
 &slot0 {
 	radio0: mt7915@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_a0000>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_a0000>, <&precal_factory_a1010>;
+		nvmem-cell-names = "eeprom", "precal";
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7986a-acer-w6-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-acer-w6-common.dtsi
@@ -238,6 +238,10 @@
 						eeprom_factory_0: eeprom@0 {
 							reg = <0x0 0x1000>;
 						};
+
+						precal_factory_1010: precal@1010 {
+							reg = <0x1010 0x62810>;
+						};
 					};
 				};
 			};
@@ -391,8 +395,8 @@
 };
 
 &wifi {
-	nvmem-cells = <&eeprom_factory_0>;
-	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>, <&precal_factory_1010>;
+	nvmem-cell-names = "eeprom", "precal";
 	pinctrl-names = "default", "dbdc";
 	pinctrl-0 = <&wf_2g_5g_pins>;
 	pinctrl-1 = <&wf_dbdc_pins>;


### PR DESCRIPTION
Bootlog complains about missing precal data.

```
mt7915e 0000:01:00.0: missing precal data, size=403472
mt798x-wmac 18000000.wifi: missing precal data, size=403472
```

Fix this by adding them to the dts.

@goldwrt can you give this a test?
