### PR TITLE
airoha: an7581: Add support Nokia Bell XG-040G-MD

### DIFF
--- a/target/linux/airoha/an7581/base-files/etc/board.d/01_leds
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/01_leds
@@ -13,6 +13,11 @@ airoha,an7581-evb)
 	ucidef_set_led_usbport "usb1" "USB 1" "green:usb-1" "usb1-port1" "usb2-port1"
 	ucidef_set_led_usbport "usb2" "USB 2" "green:usb-2" "usb3-port1" "usb4-port1"
 	;;
+nokia,xg-040g-md)
+	ucidef_set_led_netdev "internet" "INTERNET" "green:internet" "lan1"
+	ucidef_set_led_usbport "usb1" "USB 3.0" "green:usb-1" "1-1" "2-1"
+	ucidef_set_led_usbport "usb2" "USB 2.0" "green:usb-2" "3-1"
+	;;
 gemtek,w1700k-ubi)
 	ucidef_set_led_netdev "lan3-yellow" "lan3" "yellow:lan-3" "lan3" "link_10 link_100"
 	ucidef_set_led_netdev "lan3-green" "lan3" "green:lan-3" "lan3" "link_1000 tx rx"

--- a/target/linux/airoha/an7581/base-files/etc/board.d/02_network
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/02_network
@@ -14,6 +14,9 @@ an7581_setup_interfaces()
 	airoha,an7581-evb)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1"
 		;;
+	nokia,xg-040g-md)
+		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "lan1"
+		;;
 	gemtek,w1700k-ubi)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" "wan"
 		;;

--- a/target/linux/airoha/dts/an7581-nokia_xg-040g-md.dts
+++ b/target/linux/airoha/dts/an7581-nokia_xg-040g-md.dts
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include "an7581.dtsi"
+
+/ {
+	model = "Nokia Bell XG-040G-MD";
+	compatible = "nokia,xg-040g-md", "airoha,an7581";
+
+	aliases {
+		serial0 = &uart1;
+	};
+
+	chosen {
+		bootargs = "ubi.mtd=ubi root=ubi0:rootfs rootfstype=squashfs ro rootwait console=ttyS0,115200 earlycon";
+		stdout-path = "serial0:115200n8";
+		linux,usable-memory-range = <0x0 0x80200000 0x0 0x1fe00000>;
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x0 0x80000000 0x0 0x80000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pwr_led: led-0 {
+			label = "green:power";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&en7581_pinctrl 17 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "default-on";
+		};
+
+		pon_led: led-1 {
+			label = "green:pon";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 18 GPIO_ACTIVE_LOW>;
+		};
+
+		los_led: led-2 {
+			label = "red:los";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 19 GPIO_ACTIVE_LOW>;
+		};
+
+		internet_led: led-3 {
+			label = "green:internet";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&en7581_pinctrl 20 GPIO_ACTIVE_LOW>;
+		};
+
+		usb_led1: led-4 {
+			label = "green:usb-1";
+			gpios = <&en7581_pinctrl 21 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "usbport";
+		};
+
+		usb_led2: led-5 {
+			label = "green:usb-2";
+			gpios = <&en7581_pinctrl 22 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&en7581_pinctrl 0 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+};
+
+&en7581_pinctrl {
+	gpio-ranges = <&en7581_pinctrl 0 13 47>;
+
+	mdio_pins: mdio-pins {
+		mux {
+			function = "mdio";
+			groups = "mdio";
+		};
+		conf {
+			pins = "gpio2";
+			output-high;
+		};
+	};
+
+	gswp2_led0_pins: gswp2-led0-pins {
+		mux {
+			pins = "gpio34";
+			function = "phy2_led0";
+		};
+	};
+
+	gswp3_led0_pins: gswp3-led0-pins {
+		mux {
+			pins = "gpio35";
+			function = "phy3_led0";
+		};
+	};
+
+	gswp4_led0_pins: gswp4-led0-pins {
+		mux {
+			pins = "gpio42";
+			function = "phy4_led0";
+		};
+	};
+};
+
+&snfi {
+	status = "okay";
+};
+
+&spi_nand {
+	nand-ecc-strength = <4>;
+	nand-ecc-step-size = <512>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "bootloader";
+			reg = <0x00000000 0x00080000>;
+		};
+
+		partition@80000 {
+			label = "bosa";
+			reg = <0x00080000 0x00040000>;
+		};
+
+		partition@c0000 {
+			label = "ri";
+			reg = <0x000c0000 0x00040000>;
+		};
+
+		partition@100000 {
+			label = "ubi";
+			reg = <0x00100000 0xff00000>;
+		};
+	};
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+};
+
+&gdm1 {
+	status = "okay";
+};
+
+&gdm4 {
+	status = "okay";
+	phy-handle = <&phy15>;
+	phy-mode = "2500base-x";
+	openwrt,netdev-name = "lan1";
+};
+
+&switch {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	ports {
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan4";
+		};
+	};
+
+	mdio {
+		ethernet-phy@a {
+			status = "okay";
+			pinctrl-names = "gbe-led";
+			pinctrl-0 = <&gswp2_led0_pins>;
+
+			leds {
+				led@0 {
+					status = "okay";
+					active-low;
+					function = LED_FUNCTION_LAN;
+					color = <LED_COLOR_ID_GREEN>;
+				};
+			};
+		};
+
+		ethernet-phy@b {
+			status = "okay";
+			pinctrl-names = "gbe-led";
+			pinctrl-0 = <&gswp3_led0_pins>;
+
+			leds {
+				led@0 {
+					status = "okay";
+					active-low;
+					function = LED_FUNCTION_LAN;
+					color = <LED_COLOR_ID_GREEN>;
+				};
+			};
+		};
+
+		ethernet-phy@c {
+			status = "okay";
+			pinctrl-names = "gbe-led";
+			pinctrl-0 = <&gswp4_led0_pins>;
+
+			leds {
+				led@0 {
+					status = "okay";
+					active-low;
+					function = LED_FUNCTION_LAN;
+					color = <LED_COLOR_ID_GREEN>;
+				};
+			};
+		};
+
+		phy15: ethernet-phy@f {
+			compatible = "ethernet-phy-id03a2.a411", "ethernet-phy-ieee802.3-c45";
+			reg = <15>;
+
+			reset-gpios = <&en7581_pinctrl 31 GPIO_ACTIVE_LOW>;
+			reset-assert-us = <10000>;
+			reset-deassert-us = <2000000>;
+
+			leds {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				led@0 {
+					reg = <0>;
+					function = LED_FUNCTION_LAN;
+					color = <LED_COLOR_ID_GREEN>;
+				};
+			};
+		};
+	};
+};
+
+&usb0 {
+	status = "okay";
+};
+
+&usb1 {
+	status = "okay";
+	phys = <&usb1_phy PHY_TYPE_USB2>;
+	mediatek,u3p-dis-msk = <0x1>;
+};
+
+&afe {
+	status = "disabled";
+};

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -70,6 +70,27 @@ define Device/airoha_an7581-evb-emmc
 endef
 TARGET_DEVICES += airoha_an7581-evb-emmc
 
+define Device/nokia_xg-040g-md
+  $(call Device/FitImageLzma)
+  DEVICE_VENDOR := Nokia
+  DEVICE_MODEL := Bell XG-040G-MD
+  DEVICE_VARIANT := Router Mode
+  DEVICE_DTS := an7581-nokia_xg-040g-md
+  SOC := an7581
+  KERNEL_LOADADDR := 0x80088000
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_SIZE := 8192k
+  IMAGE_SIZE := 261120k
+  KERNEL_IN_UBI := 1
+  UBINIZE_OPTS := -s 2048
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-phy-airoha-en8811h kmod-i2c-an7581 ubi-utils usbutils kmod-usb2 kmod-usb3 kmod-usb-storage-uas
+endef
+TARGET_DEVICES += nokia_xg-040g-md
+
 define Device/gemtek_w1700k-ubi
   DEVICE_VENDOR := Gemtek
   DEVICE_MODEL := W1700K

--- a/target/linux/airoha/patches-6.12/901-snand-mtk-bmt-support.patch
+++ b/target/linux/airoha/patches-6.12/901-snand-mtk-bmt-support.patch
@@ -1,14 +1,14 @@
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -19,6 +19,7 @@
- #include <linux/string.h>
+@@ -20,6 +20,7 @@
  #include <linux/spi/spi.h>
  #include <linux/spi/spi-mem.h>
+ #include <linux/delay.h>
 +#include <linux/mtd/mtk_bmt.h>
  
  static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1604,6 +1605,7 @@ static int spinand_probe(struct spi_mem
+@@ -1622,6 +1623,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -16,7 +16,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1611,6 +1613,7 @@ static int spinand_probe(struct spi_mem
+@@ -1629,6 +1631,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -24,7 +24,7 @@
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1629,6 +1632,7 @@ static int spinand_remove(struct spi_mem
+@@ -1647,6 +1650,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/generic/pending-6.12/498-mtd-spinand-Skyhigh-robust.patch
+++ b/target/linux/generic/pending-6.12/498-mtd-spinand-Skyhigh-robust.patch
@@ -1,0 +1,48 @@
+From 60c34c91159619b9b8fae6d5d76578663e3c6b8a Mon Sep 17 00:00:00 2001
+From: Rongzeng Cai <cairongzeng@outlook.com>
+Date: Sat, 28 Feb 2026 10:15:37 +0800
+Subject: [PATCH] mtd: spinand: add robust read workaround for SkyHigh chips
+
+SkyHigh SPI NAND (ID 0x01) sometimes reports READY too early,
+causing bitflips and UBI errors. Add a 15us delay and re-check
+the status to ensure the device is ready before proceeding.
+
+Signed-off-by: Rongzeng Cai <cairongzeng@outlook.com>
+---
+ drivers/mtd/nand/spi/core.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -19,6 +19,7 @@
+ #include <linux/string.h>
+ #include <linux/spi/spi.h>
+ #include <linux/spi/spi-mem.h>
++#include <linux/delay.h>
+ 
+ static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
+ {
+@@ -634,6 +635,23 @@ static int spinand_read_page(struct spin
+ 	if (ret < 0)
+ 		return ret;
+ 
++	/*
++	 * SkyHigh SPI-NAND Robust Read workaround:
++	 * The first READY signal may be false. Re-check the status register
++	 * after a short delay. If still busy, re-enter the wait loop.
++	 */
++	if (spinand->id.data[0] == 0x01) {
++		udelay(15);
++		ret = spinand_read_status(spinand, &status);
++		if (ret)
++			return ret;
++		if (status & STATUS_BUSY) {
++			ret = spinand_wait(spinand, 0, SPINAND_READ_POLL_DELAY_US, &status);
++			if (ret < 0)
++				return ret;
++		}
++	}
++
+ 	spinand_ondie_ecc_save_status(nand, status);
+ 
+ 	ret = spinand_read_from_cache_op(spinand, req);

--- a/target/linux/generic/pending-6.12/499-mtd-spinand-FudanMicro-FM25G02B.patch
+++ b/target/linux/generic/pending-6.12/499-mtd-spinand-FudanMicro-FM25G02B.patch
@@ -1,0 +1,70 @@
+--- a/drivers/mtd/nand/spi/fmsh.c
++++ b/drivers/mtd/nand/spi/fmsh.c
+@@ -102,6 +102,35 @@ static int fm25s01bi3_ooblayout_free(str
+ 	return 0;
+ }
+ 
++/* ---------- Added for FM25G02B ---------- */
++static int fm25g02b_ooblayout_ecc(struct mtd_info *mtd, int section,
++				  struct mtd_oob_region *region)
++{
++	if (section >= 8)
++		return -ERANGE;
++	region->offset = 64 + section * 8;
++	region->length = 8;
++
++	return 0;
++}
++
++static int fm25g02b_ooblayout_free(struct mtd_info *mtd, int section,
++				   struct mtd_oob_region *region)
++{
++	if (section)
++		return -ERANGE;
++	region->offset = 2;
++	region->length = 62;
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops fm25g02b_ooblayout = {
++	.ecc = fm25g02b_ooblayout_ecc,
++	.free = fm25g02b_ooblayout_free,
++};
++/* ---------------------------------------- */
++
+ static const struct mtd_ooblayout_ops fm25s01a_ooblayout = {
+ 	.ecc = fm25s01a_ooblayout_ecc,
+ 	.free = fm25s01a_ooblayout_free,
+@@ -132,6 +161,26 @@ static const struct spinand_info fmsh_sp
+ 		     SPINAND_HAS_QE_BIT,
+ 		     SPINAND_ECCINFO(&fm25s01bi3_ooblayout,
+ 				      fm25s01bi3_ecc_get_status)),
++	/* ---------- Added for FM25G02B and FM25S02A ---------- */
++	SPINAND_INFO("FM25G02B",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xD2),
++		     NAND_MEMORG(1, 2048, 128, 64, 2048, 40, 1, 1, 1),
++		     NAND_ECCREQ(8, 528),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&fm25g02b_ooblayout, NULL)),
++	SPINAND_INFO("FM25S02A",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xE5),
++		     NAND_MEMORG(1, 2048, 64, 64, 2048, 40, 2, 1, 1),
++		     NAND_ECCREQ(2, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     0,
++		     SPINAND_ECCINFO(&fm25s01a_ooblayout, NULL)),
++	/* ----------------------------------------------------- */
+ };
+ 
+ static const struct spinand_manufacturer_ops fmsh_spinand_manuf_ops = {
+@@ -144,3 +193,4 @@ const struct spinand_manufacturer fmsh_s
+ 	.nchips = ARRAY_SIZE(fmsh_spinand_table),
+ 	.ops = &fmsh_spinand_manuf_ops,
+ };
++

--- a/target/linux/mediatek/patches-6.12/121-hack-spi-nand-1b-bbm.patch
+++ b/target/linux/mediatek/patches-6.12/121-hack-spi-nand-1b-bbm.patch
@@ -1,6 +1,6 @@
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -924,7 +924,7 @@ static int spinand_mtd_write(struct mtd_
+@@ -942,7 +942,7 @@ static int spinand_mtd_write(struct mtd_
  static bool spinand_isbad(struct nand_device *nand, const struct nand_pos *pos)
  {
  	struct spinand_device *spinand = nand_to_spinand(nand);
@@ -9,7 +9,7 @@
  	struct nand_page_io_req req = {
  		.pos = *pos,
  		.ooblen = sizeof(marker),
-@@ -943,7 +943,7 @@ static bool spinand_isbad(struct nand_de
+@@ -961,7 +961,7 @@ static bool spinand_isbad(struct nand_de
  		spinand_read_page(spinand, &req);
  	}
  

--- a/target/linux/mediatek/patches-6.12/330-snand-mtk-bmt-support.patch
+++ b/target/linux/mediatek/patches-6.12/330-snand-mtk-bmt-support.patch
@@ -1,14 +1,14 @@
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -19,6 +19,7 @@
- #include <linux/string.h>
+@@ -20,6 +20,7 @@
  #include <linux/spi/spi.h>
  #include <linux/spi/spi-mem.h>
+ #include <linux/delay.h>
 +#include <linux/mtd/mtk_bmt.h>
  
  static int spinand_read_reg_op(struct spinand_device *spinand, u8 reg, u8 *val)
  {
-@@ -1604,6 +1605,7 @@ static int spinand_probe(struct spi_mem
+@@ -1622,6 +1623,7 @@ static int spinand_probe(struct spi_mem
  	if (ret)
  		return ret;
  
@@ -16,7 +16,7 @@
  	ret = mtd_device_register(mtd, NULL, 0);
  	if (ret)
  		goto err_spinand_cleanup;
-@@ -1611,6 +1613,7 @@ static int spinand_probe(struct spi_mem
+@@ -1629,6 +1631,7 @@ static int spinand_probe(struct spi_mem
  	return 0;
  
  err_spinand_cleanup:
@@ -24,7 +24,7 @@
  	spinand_cleanup(spinand);
  
  	return ret;
-@@ -1629,6 +1632,7 @@ static int spinand_remove(struct spi_mem
+@@ -1647,6 +1650,7 @@ static int spinand_remove(struct spi_mem
  	if (ret)
  		return ret;
  

--- a/target/linux/mediatek/patches-6.12/340-mtd-spinand-Add-support-for-the-Fidelix-FM35X1GA.patch
+++ b/target/linux/mediatek/patches-6.12/340-mtd-spinand-Add-support-for-the-Fidelix-FM35X1GA.patch
@@ -24,7 +24,7 @@ Signed-off-by: Davide Fioravanti <pantanastyle@gmail.com>
  obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1189,6 +1189,7 @@ static const struct spinand_manufacturer
+@@ -1207,6 +1207,7 @@ static const struct spinand_manufacturer
  	&esmt_c8_spinand_manufacturer,
  	&etron_spinand_manufacturer,
  	&fmsh_spinand_manufacturer,

--- a/target/linux/mediatek/patches-6.12/435-drivers-mtd-spinand-Add-calibration-support-for-spin.patch
+++ b/target/linux/mediatek/patches-6.12/435-drivers-mtd-spinand-Add-calibration-support-for-spin.patch
@@ -11,7 +11,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1228,6 +1228,56 @@ static int spinand_manufacturer_match(st
+@@ -1246,6 +1246,56 @@ static int spinand_manufacturer_match(st
  	return -EOPNOTSUPP;
  }
  
@@ -68,7 +68,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
  static int spinand_id_detect(struct spinand_device *spinand)
  {
  	u8 *id = spinand->id.data;
-@@ -1481,6 +1531,10 @@ static int spinand_init(struct spinand_d
+@@ -1499,6 +1549,10 @@ static int spinand_init(struct spinand_d
  	if (!spinand->scratchbuf)
  		return -ENOMEM;
  

--- a/target/linux/mediatek/patches-6.12/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
+++ b/target/linux/mediatek/patches-6.12/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
@@ -12,7 +12,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1269,7 +1269,10 @@ static int spinand_cal_read(void *priv,
+@@ -1287,7 +1287,10 @@ static int spinand_cal_read(void *priv,
  	if (ret)
  		return ret;
  

--- a/target/linux/mediatek/patches-6.12/960-asus-hack-u-boot-ignore-mtdparts.patch
+++ b/target/linux/mediatek/patches-6.12/960-asus-hack-u-boot-ignore-mtdparts.patch
@@ -29,7 +29,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1698,6 +1698,7 @@ static int spinand_remove(struct spi_mem
+@@ -1716,6 +1716,7 @@ static int spinand_remove(struct spi_mem
  
  static const struct spi_device_id spinand_ids[] = {
  	{ .name = "spi-nand" },
@@ -37,7 +37,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	{ /* sentinel */ },
  };
  MODULE_DEVICE_TABLE(spi, spinand_ids);
-@@ -1705,6 +1706,7 @@ MODULE_DEVICE_TABLE(spi, spinand_ids);
+@@ -1723,6 +1724,7 @@ MODULE_DEVICE_TABLE(spi, spinand_ids);
  #ifdef CONFIG_OF
  static const struct of_device_id spinand_of_ids[] = {
  	{ .compatible = "spi-nand" },


### PR DESCRIPTION
airoha: an7581: Nokia Bell XG040GMD Router Mode

Hardware:

SoC: Airoha AN7581
RAM: 512MB DDR4 (Jinhua CA4S4G16V-F9HPC)
Flash: 256MB SPI NAND (SkyHigh S35ML02G300)
Ethernet:
1x 2.5GbE port (EcoNet EN8811H PHY) labeled as LAN1
3x 1GbE ports (internal AN7581 switch) labeled as LAN2, LAN3, LAN4
PON: EcoNet EN7572AN
USB: 1x USB 2.0, 1x USB 3.0
LEDs: 4x GPIO-controlled (power, PON, LOS, internet)
Buttons: 1x reset button

mtd: spinand: robust SkyHigh read workaround
add robust read workaround for SkyHigh chips

mtd: spinand: Add FudanMicro FM25G02B support
Add support for FudanMicro FM25G02B SPI NAND

Signed-off-by: Rongzeng Cai <cairongzeng@outlook.com>