### PR TITLE
build: export STAGING_DIR for external toolchain

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -253,6 +253,11 @@ endif
 TARGET_LINKER?=bfd
 TARGET_LDFLAGS+= -fuse-ld=$(TARGET_LINKER)
 
+ifneq ($(CONFIG_EXTERNAL_TOOLCHAIN),)
+TARGET_CFLAGS+= -idirafter $(STAGING_DIR)/usr/include
+TARGET_LDFLAGS+=-L$(STAGING_DIR)/usr/lib -Wl,-rpath-link,$(STAGING_DIR)/usr/lib
+endif
+
 TARGET_PATH_PKG:=$(STAGING_DIR)/host/bin:$(STAGING_DIR_HOSTPKG)/bin:$(TARGET_PATH)
 
 ifeq ($(CONFIG_SOFT_FLOAT),y)


### PR DESCRIPTION
The purpose of this change is to fix numerous compilation errors when 
an external toolchain is used.

On a Vanilla Openwrt, gcc seems to be patched (I didn't find where)
 to be aware of STAGING_DIR

This is observable when simply running the internally compiled gcc

> ./staging_dir/toolchain-.../bin/aarch64-openwrt-linux-gcc test.c
aarch64-openwrt-linux-gcc: warning:
environment variable 'STAGING_DIR' not defined

But external toolchain is not. Numerous compilation and linking
error are raised because header files or libraries are not found.

Fix them requires to fix all packages one by one.

Another solution is to export the STAGING_DIR ressources when an
external toolchain is used.

use -idirafter to add STAGING_DIR at the end. Using -I has cause some
compilation error on our project. And it's better to use local ressources
before STAGING_DIR one.

use -Wl,-rpath-link as -L only has proven to be not sufficient