### PR TITLE
[25.12] ext-toolchain: fix wrapper for gcc-ar, gcc-nm, gcc-ranlib

### DIFF
--- a/scripts/ext-toolchain.sh
+++ b/scripts/ext-toolchain.sh
@@ -282,6 +282,9 @@ wrap_bins() {
 				fi
 
 				case "${cmd##*/}" in
+					*-gcc-ar|*-gcc-nm|*-gcc-ranlib)
+						wrap_bin_other "$out" "$bin"
+					;;
 					*-*cc|*-*cc-*|*-*++|*-*++-*|*-cpp)
 						wrap_bin_cc "$out" "$bin"
 					;;


### PR DESCRIPTION
This PR proposes to backport #21757 to v25.12, which resolves issue #21859

This patch fixes the external toolchain wrapper generation script, which incorrectly applies compiler flags to **gcc-ar**, **gcc-nm**, and **gcc-ranlib** tools. This causes them to be wrapped as compilers and receive **CFLAGS**, breaking builds with errors like:
```
ar: two different operation options specified
```