### PR TITLE
Realtek fixes for 25.12

### DIFF
--- a/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
+++ b/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
@@ -215,6 +215,7 @@
 		SWITCH_PORT_SDS(17, 18, 3, usxgmii)
 		SWITCH_PORT_SDS(18, 19, 3, usxgmii)
 		SWITCH_PORT_SDS(19, 20, 3, usxgmii)
+		SWITCH_PORT_SDS(20, 21, 3, usxgmii)
 		SWITCH_PORT_SDS(21, 22, 3, usxgmii)
 		SWITCH_PORT_SDS(22, 23, 3, usxgmii)
 		SWITCH_PORT_SDS(23, 24, 3, usxgmii)

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -255,7 +255,7 @@ static int rtldsa_bus_c45_write(struct mii_bus *bus, int addr, int devad, int re
 	return mdiobus_c45_write_nested(priv->parent_bus, addr, devad, regnum, val);
 }
 
-static int __init rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
+static int rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 {
 	struct device_node *dn, *phy_node, *pcs_node, *led_node, *np, *mii_np;
 	struct device *dev = priv->dev;
@@ -405,7 +405,7 @@ static int __init rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 	return 0;
 }
 
-static int __init rtl83xx_get_l2aging(struct rtl838x_switch_priv *priv)
+static int rtl83xx_get_l2aging(struct rtl838x_switch_priv *priv)
 {
 	int t = sw_r32(priv->r->l2_ctrl_1);
 
@@ -1391,7 +1391,7 @@ static int rtldsa_ethernet_loaded(struct platform_device *pdev)
 	return ret;
 }
 
-static int __init rtl83xx_sw_probe(struct platform_device *pdev)
+static int rtl83xx_sw_probe(struct platform_device *pdev)
 {
 	struct rtl838x_switch_priv *priv;
 	struct device *dev = &pdev->dev;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -1586,7 +1586,8 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 
 	rtl83xx_get_l2aging(priv);
 
-	rtl83xx_setup_qos(priv);
+	if (priv->r->qos_init)
+		priv->r->qos_init(priv);
 
 	if (priv->r->l3_setup)
 		priv->r->l3_setup(priv);

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
@@ -547,24 +547,14 @@ static void rtl839x_config_qos(void)
 	}
 }
 
-void __init rtl83xx_setup_qos(struct rtl838x_switch_priv *priv)
+void rtldsa_838x_qos_init(struct rtl838x_switch_priv *priv)
 {
-	switch_priv = priv;
+	rtl838x_config_qos();
+	rtl838x_rate_control_init(priv);
+}
 
-	pr_info("In %s\n", __func__);
-
-	switch (priv->family_id) {
-	case RTL8380_FAMILY_ID:
-		rtl838x_config_qos();
-		rtl838x_rate_control_init(priv);
-		break;
-	case RTL8390_FAMILY_ID:
-		rtl839x_config_qos();
-		rtl839x_rate_control_init(priv);
-		break;
-	default:
-		if (priv->r->qos_init)
-			priv->r->qos_init(priv);
-		break;
-	}
+void rtldsa_839x_qos_init(struct rtl838x_switch_priv *priv)
+{
+	rtl839x_config_qos();
+	rtl839x_rate_control_init(priv);
 }

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
@@ -6,8 +6,6 @@
 
 #include "rtl83xx.h"
 
-static struct rtl838x_switch_priv *switch_priv;
-
 enum scheduler_type {
 	WEIGHTED_FAIR_QUEUE = 0,
 	WEIGHTED_ROUND_ROBIN,
@@ -445,7 +443,7 @@ static void rtl839x_set_scheduling_queue_weights(struct rtl838x_switch_priv *pri
 	mutex_unlock(&priv->reg_mutex);
 }
 
-static void rtl838x_config_qos(void)
+static void rtl838x_config_qos(struct rtl838x_switch_priv *priv)
 {
 	u32 v;
 
@@ -490,10 +488,9 @@ static void rtl838x_config_qos(void)
 	sw_w32_mask(0, 7, RTL838X_QM_PKT2CPU_INTPRI_1);
 }
 
-static void rtl839x_config_qos(void)
+static void rtl839x_config_qos(struct rtl838x_switch_priv *priv)
 {
 	u32 v;
-	struct rtl838x_switch_priv *priv = switch_priv;
 
 	pr_info("Setting up RTL839X QoS\n");
 	pr_info("RTL839X_PRI_SEL_TBL_CTRL(i): %08x\n", sw_r32(RTL839X_PRI_SEL_TBL_CTRL(0)));
@@ -549,12 +546,12 @@ static void rtl839x_config_qos(void)
 
 void rtldsa_838x_qos_init(struct rtl838x_switch_priv *priv)
 {
-	rtl838x_config_qos();
+	rtl838x_config_qos(priv);
 	rtl838x_rate_control_init(priv);
 }
 
 void rtldsa_839x_qos_init(struct rtl838x_switch_priv *priv)
 {
-	rtl839x_config_qos();
+	rtl839x_config_qos(priv);
 	rtl839x_rate_control_init(priv);
 }

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/qos.c
@@ -42,15 +42,6 @@ static void rtl839x_read_out_q_table(int port)
 	rtl839x_exec_tbl2_cmd(cmd);
 }
 
-static void rtl838x_storm_enable(struct rtl838x_switch_priv *priv, int port, bool enable)
-{
-	/* Enable Storm control for that port for UC, MC, and BC */
-	if (enable)
-		sw_w32(0x7, RTL838X_STORM_CTRL_LB_CTRL(port));
-	else
-		sw_w32(0x0, RTL838X_STORM_CTRL_LB_CTRL(port));
-}
-
 u32 rtl838x_get_egress_rate(struct rtl838x_switch_priv *priv, int port)
 {
 	if (port > priv->cpu_port)
@@ -71,67 +62,6 @@ int rtl838x_set_egress_rate(struct rtl838x_switch_priv *priv, int port, u32 rate
 	sw_w32(rate, RTL838X_SCHED_P_EGR_RATE_CTRL(port));
 
 	return old_rate;
-}
-
-/* Set the rate limit for a particular queue in Bits/s
- * units of the rate is 16Kbps
- */
-void rtl838x_egress_rate_queue_limit(struct rtl838x_switch_priv *priv, int port,
-				     int queue, u32 rate)
-{
-	if (port > priv->cpu_port)
-		return;
-
-	if (queue > 7)
-		return;
-
-	sw_w32(rate, RTL838X_SCHED_Q_EGR_RATE_CTRL(port, queue));
-}
-
-static void rtl838x_rate_control_init(struct rtl838x_switch_priv *priv)
-{
-	pr_info("Enabling Storm control\n");
-	/* TICK_PERIOD_PPS */
-	if (priv->id == 0x8380)
-		sw_w32_mask(0x3ff << 20, 434 << 20, RTL838X_SCHED_LB_TICK_TKN_CTRL_0);
-
-	/* Set burst rate */
-	sw_w32(0x00008000, RTL838X_STORM_CTRL_BURST_0); /* UC */
-	sw_w32(0x80008000, RTL838X_STORM_CTRL_BURST_1); /* MC and BC */
-
-	/* Set burst Packets per Second to 32 */
-	sw_w32(0x00000020, RTL838X_STORM_CTRL_BURST_PPS_0); /* UC */
-	sw_w32(0x00200020, RTL838X_STORM_CTRL_BURST_PPS_1); /* MC and BC */
-
-	/* Include IFG in storm control, rate based on bytes/s (0 = packets) */
-	sw_w32_mask(0, 1 << 6 | 1 << 5, RTL838X_STORM_CTRL);
-	/* Bandwidth control includes preamble and IFG (10 Bytes) */
-	sw_w32_mask(0, 1, RTL838X_SCHED_CTRL);
-
-	/* On SoCs except RTL8382M, set burst size of port egress */
-	if (priv->id != 0x8382)
-		sw_w32_mask(0xffff, 0x800, RTL838X_SCHED_LB_THR);
-
-	/* Enable storm control on all ports with a PHY and limit rates,
-	 * for UC and MC for both known and unknown addresses
-	 */
-	for (int i = 0; i < priv->cpu_port; i++) {
-		if (priv->ports[i].phy) {
-			sw_w32((1 << 18) | 0x8000, RTL838X_STORM_CTRL_PORT_UC(i));
-			sw_w32((1 << 18) | 0x8000, RTL838X_STORM_CTRL_PORT_MC(i));
-			sw_w32(0x8000, RTL838X_STORM_CTRL_PORT_BC(i));
-			rtl838x_storm_enable(priv, i, true);
-		}
-	}
-
-	/* Attack prevention, enable all attack prevention measures */
-	/* sw_w32(0x1ffff, RTL838X_ATK_PRVNT_CTRL); */
-	/* Attack prevention, drop (bit = 0) problematic packets on all ports.
-	 * Setting bit = 1 means: trap to CPU
-	 */
-	/* sw_w32(0, RTL838X_ATK_PRVNT_ACT); */
-	/* Enable attack prevention on all ports */
-	/* sw_w32(0x0fffffff, RTL838X_ATK_PRVNT_PORT_EN); */
 }
 
 /* Sets the rate limit, 10MBit/s is equal to a rate value of 625 */
@@ -181,110 +111,6 @@ int rtl839x_set_egress_rate(struct rtl838x_switch_priv *priv, int port, u32 rate
 
 	return old_rate;
 }
-
-/* Set the rate limit for a particular queue in Bits/s
- * units of the rate is 16Kbps
- */
-static void rtl839x_egress_rate_queue_limit(struct rtl838x_switch_priv *priv, int port,
-					    int queue, u32 rate)
-{
-	int lsb = 128 + queue * 20;
-	int low_byte = 8 - (lsb >> 5);
-	int start_bit = lsb - (low_byte << 5);
-	u32 high_mask = 0xfffff	>> (32 - start_bit);
-
-	pr_debug("%s: Setting egress rate on port %d, queue %d to %d\n",
-		 __func__, port, queue, rate);
-	if (port >= priv->cpu_port)
-		return;
-	if (queue > 7)
-		return;
-
-	mutex_lock(&priv->reg_mutex);
-
-	rtl839x_read_scheduling_table(port);
-
-	sw_w32_mask(0xfffff << start_bit, (rate & 0xfffff) << start_bit,
-		    RTL839X_TBL_ACCESS_DATA_2(low_byte));
-	if (high_mask)
-		sw_w32_mask(high_mask, (rate & 0xfffff) >> (32 - start_bit),
-			    RTL839X_TBL_ACCESS_DATA_2(low_byte - 1));
-
-	rtl839x_write_scheduling_table(port);
-
-	mutex_unlock(&priv->reg_mutex);
-}
-
-static void rtl839x_rate_control_init(struct rtl838x_switch_priv *priv)
-{
-	pr_info("%s: enabling rate control\n", __func__);
-	/* Tick length and token size settings for SoC with 250MHz,
-	 * RTL8350 family would use 50MHz
-	 */
-	/* Set the special tick period */
-	sw_w32(976563, RTL839X_STORM_CTRL_SPCL_LB_TICK_TKN_CTRL);
-	/* Ingress tick period and token length 10G */
-	sw_w32(18 << 11 | 151, RTL839X_IGR_BWCTRL_LB_TICK_TKN_CTRL_0);
-	/* Ingress tick period and token length 1G */
-	sw_w32(245 << 11 | 129, RTL839X_IGR_BWCTRL_LB_TICK_TKN_CTRL_1);
-	/* Egress tick period 10G, bytes/token 10G and tick period 1G, bytes/token 1G */
-	sw_w32(18 << 24 | 151 << 16 | 185 << 8 | 97, RTL839X_SCHED_LB_TICK_TKN_CTRL);
-	/* Set the tick period of the CPU and the Token Len */
-	sw_w32(3815 << 8 | 1, RTL839X_SCHED_LB_TICK_TKN_PPS_CTRL);
-
-	/* Set the Weighted Fair Queueing burst size */
-	sw_w32_mask(0xffff, 4500, RTL839X_SCHED_LB_THR);
-
-	/* Storm-rate calculation is based on bytes/sec (bit 5), include IFG (bit 6) */
-	sw_w32_mask(0, 1 << 5 | 1 << 6, RTL839X_STORM_CTRL);
-
-	/* Based on the rate control mode being bytes/s
-	 * set tick period and token length for 10G
-	 */
-	sw_w32(18 << 10 | 151, RTL839X_STORM_CTRL_LB_TICK_TKN_CTRL_0);
-	/* and for 1G ports */
-	sw_w32(246 << 10 | 129, RTL839X_STORM_CTRL_LB_TICK_TKN_CTRL_1);
-
-	/* Set default burst rates on all ports (the same for 1G / 10G) with a PHY
-	 * for UC, MC and BC
-	 * For 1G port, the minimum burst rate is 1700, maximum 65535,
-	 * For 10G ports it is 2650 and 1048575 respectively
-	 */
-	for (int p = 0; p < priv->cpu_port; p++) {
-		if (priv->ports[p].phy && !priv->ports[p].is10G) {
-			sw_w32_mask(0xffff, 0x8000, RTL839X_STORM_CTRL_PORT_UC_1(p));
-			sw_w32_mask(0xffff, 0x8000, RTL839X_STORM_CTRL_PORT_MC_1(p));
-			sw_w32_mask(0xffff, 0x8000, RTL839X_STORM_CTRL_PORT_BC_1(p));
-		}
-	}
-
-	/* Setup ingress/egress per-port rate control */
-	for (int p = 0; p < priv->cpu_port; p++) {
-		if (!priv->ports[p].phy)
-			continue;
-
-		if (priv->ports[p].is10G)
-			rtl839x_set_egress_rate(priv, p, 625000); /* 10GB/s */
-		else
-			rtl839x_set_egress_rate(priv, p, 62500);  /* 1GB/s */
-
-		/* Setup queues: all RTL83XX SoCs have 8 queues, maximum rate */
-		for (int q = 0; q < 8; q++)
-			rtl839x_egress_rate_queue_limit(priv, p, q, 0xfffff);
-
-		if (priv->ports[p].is10G) {
-			/* Set high threshold to maximum */
-			sw_w32_mask(0xffff, 0xffff, RTL839X_IGR_BWCTRL_PORT_CTRL_10G_0(p));
-		} else {
-			/* Set high threshold to maximum */
-			sw_w32_mask(0xffff, 0xffff, RTL839X_IGR_BWCTRL_PORT_CTRL_1(p));
-		}
-	}
-
-	/* Set global ingress low watermark rate */
-	sw_w32(65532, RTL839X_IGR_BWCTRL_CTRL_LB_THR);
-}
-
 
 static void rtl838x_setup_prio2queue_matrix(int *min_queues)
 {
@@ -547,11 +373,9 @@ static void rtl839x_config_qos(struct rtl838x_switch_priv *priv)
 void rtldsa_838x_qos_init(struct rtl838x_switch_priv *priv)
 {
 	rtl838x_config_qos(priv);
-	rtl838x_rate_control_init(priv);
 }
 
 void rtldsa_839x_qos_init(struct rtl838x_switch_priv *priv)
 {
 	rtl839x_config_qos(priv);
-	rtl839x_rate_control_init(priv);
 }

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1744,6 +1744,7 @@ const struct rtl838x_reg rtl838x_reg = {
 	.l3_setup = rtl838x_l3_setup,
 	.set_distribution_algorithm = rtl838x_set_distribution_algorithm,
 	.set_receive_management_action = rtl838x_set_receive_management_action,
+	.qos_init = rtldsa_838x_qos_init,
 };
 
 irqreturn_t rtl838x_switch_irq(int irq, void *dev_id)

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1713,4 +1713,5 @@ const struct rtl838x_reg rtl839x_reg = {
 	.l3_setup = rtl839x_l3_setup,
 	.set_distribution_algorithm = rtl839x_set_distribution_algorithm,
 	.set_receive_management_action = rtl839x_set_receive_management_action,
+	.qos_init = rtldsa_839x_qos_init,
 };

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -131,7 +131,8 @@ inline u16 rtl_table_data(struct table_reg *r, int i);
 inline u32 rtl_table_data_r(struct table_reg *r, int i);
 inline void rtl_table_data_w(struct table_reg *r, u32 v, int i);
 
-void __init rtl83xx_setup_qos(struct rtl838x_switch_priv *priv);
+void rtldsa_838x_qos_init(struct rtl838x_switch_priv *priv);
+void rtldsa_839x_qos_init(struct rtl838x_switch_priv *priv);
 
 void rtl83xx_fast_age(struct dsa_switch *ds, int port);
 int rtl83xx_packet_cntr_alloc(struct rtl838x_switch_priv *priv);

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -193,9 +193,6 @@ int rtl83xx_lag_del(struct dsa_switch *ds, int group, int port);
  * collect them in this section.
  */
 
-void rtl838x_egress_rate_queue_limit(struct rtl838x_switch_priv *priv, int port,
-				     int queue, u32 rate);
-
 int rtl8390_sds_power(int mac, int val);
 void rtl839x_pie_rule_dump(struct  pie_rule *pr);
 void rtl839x_set_egress_queue(int port, int queue);

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -1642,7 +1642,7 @@ static const struct ethtool_ops rtl838x_ethtool_ops = {
 	.set_link_ksettings     = rtl838x_set_link_ksettings,
 };
 
-static int __init rtl838x_eth_probe(struct platform_device *pdev)
+static int rtl838x_eth_probe(struct platform_device *pdev)
 {
 	struct net_device *dev;
 	struct device_node *dn = pdev->dev.of_node;


### PR DESCRIPTION
Backport of fixes for uninitialized memory and storm control in the realtek target.