### PR TITLE
hostapd: initialize first BSS radio_mask during driver init

### DIFF
--- a/package/network/services/hostapd/patches/370-preserve_radio_mask.patch
+++ b/package/network/services/hostapd/patches/370-preserve_radio_mask.patch
@@ -58,7 +58,16 @@
  static int nl80211_register_beacons(struct wpa_driver_nl80211_data *drv,
  				    struct nl80211_wiphy_data *w)
  {
-@@ -6236,7 +6254,7 @@ const char * nl80211_iftype_str(enum nl8
+@@ -2427,6 +2445,8 @@ static void * wpa_driver_nl80211_drv_ini
+ 					       p2p_mode))
+ 		goto failed;
+ 
++	bss->radio_mask = nl80211_get_radio_mask(bss);
++
+ 	if (drv->capa.flags2 & WPA_DRIVER_FLAGS2_CONTROL_PORT_TX_STATUS) {
+ 		drv->control_port_ap = 1;
+ 		goto skip_wifi_status;
+@@ -6236,7 +6256,7 @@ const char * nl80211_iftype_str(enum nl8
  static int nl80211_create_iface_once(struct wpa_driver_nl80211_data *drv,
  				     const char *ifname,
  				     enum nl80211_iftype iftype,
@@ -67,7 +76,7 @@
  				     int (*handler)(struct nl_msg *, void *),
  				     void *arg)
  {
-@@ -6256,6 +6274,10 @@ static int nl80211_create_iface_once(str
+@@ -6256,6 +6276,10 @@ static int nl80211_create_iface_once(str
  	if (wds && nla_put_u8(msg, NL80211_ATTR_4ADDR, wds))
  		goto fail;
  
@@ -78,7 +87,7 @@
  	/*
  	 * Tell cfg80211 that the interface belongs to the socket that created
  	 * it, and the interface should be deleted when the socket is closed.
-@@ -6311,14 +6333,14 @@ static int nl80211_create_iface_once(str
+@@ -6311,14 +6335,14 @@ static int nl80211_create_iface_once(str
  
  int nl80211_create_iface(struct wpa_driver_nl80211_data *drv,
  			 const char *ifname, enum nl80211_iftype iftype,
@@ -96,7 +105,7 @@
  
  	/* if error occurred and interface exists already */
  	if (ret < 0 && if_nametoindex(ifname)) {
-@@ -6344,7 +6366,7 @@ int nl80211_create_iface(struct wpa_driv
+@@ -6344,7 +6368,7 @@ int nl80211_create_iface(struct wpa_driv
  
  		/* Try to create the interface again */
  		ret = nl80211_create_iface_once(drv, ifname, iftype, addr,
@@ -105,7 +114,7 @@
  	}
  
  	if (ret >= 0 && is_p2p_net_interface(iftype)) {
-@@ -8688,8 +8710,8 @@ static int i802_set_wds_sta(void *priv,
+@@ -8688,8 +8712,8 @@ static int i802_set_wds_sta(void *priv,
  		if (!if_nametoindex(name)) {
  			if (nl80211_create_iface(drv, name,
  						 NL80211_IFTYPE_AP_VLAN,
@@ -116,7 +125,7 @@
  				return -1;
  
  			if (bridge_ifname)
-@@ -9060,7 +9082,8 @@ static int wpa_driver_nl80211_if_add(voi
+@@ -9060,7 +9084,8 @@ static int wpa_driver_nl80211_if_add(voi
  
  		os_memset(&p2pdev_info, 0, sizeof(p2pdev_info));
  		ifidx = nl80211_create_iface(drv, ifname, nlmode, addr,
@@ -126,7 +135,7 @@
  					     &p2pdev_info, use_existing);
  		if (!p2pdev_info.wdev_id_set || ifidx != 0) {
  			wpa_printf(MSG_ERROR, "nl80211: Failed to create a P2P Device interface %s",
-@@ -9077,7 +9100,8 @@ static int wpa_driver_nl80211_if_add(voi
+@@ -9077,7 +9102,8 @@ static int wpa_driver_nl80211_if_add(voi
  			   (long long unsigned int) p2pdev_info.wdev_id);
  	} else {
  		ifidx = nl80211_create_iface(drv, ifname, nlmode, addr,
@@ -136,7 +145,7 @@
  		if (use_existing && ifidx == -ENFILE) {
  			added = 0;
  			ifidx = if_nametoindex(ifname);
-@@ -9147,6 +9171,8 @@ static int wpa_driver_nl80211_if_add(voi
+@@ -9147,6 +9173,8 @@ static int wpa_driver_nl80211_if_add(voi
  		new_bss->ctx = bss_ctx;
  		new_bss->added_if = added;
  

--- a/package/network/services/hostapd/patches/463-add-mcast_rate-to-11s.patch
+++ b/package/network/services/hostapd/patches/463-add-mcast_rate-to-11s.patch
@@ -29,7 +29,7 @@ Tested-by: Simon Wunderlich <simon.wunderlich@openmesh.com>
  struct wpa_driver_set_key_params {
 --- a/src/drivers/driver_nl80211.c
 +++ b/src/drivers/driver_nl80211.c
-@@ -12376,6 +12376,18 @@ static int nl80211_put_mesh_id(struct nl
+@@ -12378,6 +12378,18 @@ static int nl80211_put_mesh_id(struct nl
  }
  
  
@@ -48,7 +48,7 @@ Tested-by: Simon Wunderlich <simon.wunderlich@openmesh.com>
  static int nl80211_put_mesh_config(struct nl_msg *msg,
  				   struct wpa_driver_mesh_bss_params *params)
  {
-@@ -12437,6 +12449,7 @@ static int nl80211_join_mesh(struct i802
+@@ -12439,6 +12451,7 @@ static int nl80211_join_mesh(struct i802
  	    nl80211_put_basic_rates(msg, params->basic_rates) ||
  	    nl80211_put_mesh_id(msg, params->meshid, params->meshid_len) ||
  	    nl80211_put_beacon_int(msg, params->beacon_int) ||

--- a/package/network/services/hostapd/patches/601-ucode_support.patch
+++ b/package/network/services/hostapd/patches/601-ucode_support.patch
@@ -689,7 +689,7 @@ as adding/removing interfaces.
  	nl_cb_set(bss->nl_cb, NL_CB_SEQ_CHECK, NL_CB_CUSTOM,
  		  no_seq_check, NULL);
  	nl_cb_set(bss->nl_cb, NL_CB_VALID, NL_CB_CUSTOM,
-@@ -8854,6 +8875,7 @@ static void *i802_init(struct hostapd_da
+@@ -8856,6 +8877,7 @@ static void *i802_init(struct hostapd_da
  	char master_ifname[IFNAMSIZ];
  	int ifindex, br_ifindex = 0;
  	int br_added = 0;
@@ -697,7 +697,7 @@ as adding/removing interfaces.
  
  	bss = wpa_driver_nl80211_drv_init(hapd, params->ifname,
  					  params->global_priv, 1,
-@@ -8914,21 +8936,17 @@ static void *i802_init(struct hostapd_da
+@@ -8916,21 +8938,17 @@ static void *i802_init(struct hostapd_da
  	    (params->num_bridge == 0 || !params->bridge[0]))
  		add_ifidx(drv, br_ifindex, drv->ifindex);
  
@@ -729,7 +729,7 @@ as adding/removing interfaces.
  	}
  
  	if (drv->capa.flags2 & WPA_DRIVER_FLAGS2_CONTROL_PORT_RX) {
-@@ -9310,6 +9328,50 @@ static int wpa_driver_nl80211_if_remove(
+@@ -9312,6 +9330,50 @@ static int wpa_driver_nl80211_if_remove(
  	return 0;
  }
  
@@ -780,7 +780,7 @@ as adding/removing interfaces.
  
  static int cookie_handler(struct nl_msg *msg, void *arg)
  {
-@@ -11195,6 +11257,37 @@ static bool nl80211_is_drv_shared(void *
+@@ -11197,6 +11259,37 @@ static bool nl80211_is_drv_shared(void *
  #endif /* CONFIG_IEEE80211BE */
  
  
@@ -818,7 +818,7 @@ as adding/removing interfaces.
  static int driver_nl80211_send_mlme(void *priv, const u8 *data,
  				    size_t data_len, int noack,
  				    unsigned int freq,
-@@ -15014,6 +15107,8 @@ const struct wpa_driver_ops wpa_driver_n
+@@ -15016,6 +15109,8 @@ const struct wpa_driver_ops wpa_driver_n
  	.set_acl = wpa_driver_nl80211_set_acl,
  	.if_add = wpa_driver_nl80211_if_add,
  	.if_remove = driver_nl80211_if_remove,

--- a/package/network/services/hostapd/patches/740-snoop_iface.patch
+++ b/package/network/services/hostapd/patches/740-snoop_iface.patch
@@ -123,7 +123,7 @@ untagged DHCP packets
  	 * get_wowlan - Get wake-on-wireless status
 --- a/src/drivers/driver_nl80211.c
 +++ b/src/drivers/driver_nl80211.c
-@@ -12896,7 +12896,7 @@ static const char * drv_br_net_param_str
+@@ -12898,7 +12898,7 @@ static const char * drv_br_net_param_str
  
  
  static int wpa_driver_br_set_net_param(void *priv, enum drv_br_net_param param,
@@ -132,7 +132,7 @@ untagged DHCP packets
  {
  	struct i802_bss *bss = priv;
  	char path[128];
-@@ -12922,8 +12922,11 @@ static int wpa_driver_br_set_net_param(v
+@@ -12924,8 +12924,11 @@ static int wpa_driver_br_set_net_param(v
  			return -EINVAL;
  	}
  

--- a/package/network/services/hostapd/patches/780-Implement-APuP-Access-Point-Micro-Peering.patch
+++ b/package/network/services/hostapd/patches/780-Implement-APuP-Access-Point-Micro-Peering.patch
@@ -429,7 +429,7 @@ Hotfix-by: Sebastian Gottschall https://github.com/mirror/dd-wrt/commit/0c3001a6
  	 * send_action - Transmit an Action frame
 --- a/src/drivers/driver_nl80211.c
 +++ b/src/drivers/driver_nl80211.c
-@@ -8706,25 +8706,15 @@ static int have_ifidx(struct wpa_driver_
+@@ -8708,25 +8708,15 @@ static int have_ifidx(struct wpa_driver_
  
  
  static int i802_set_wds_sta(void *priv, const u8 *addr, int aid, int val,


### PR DESCRIPTION
Secondary BSSes inherit the alloc value which bypasses NL80211_ATTR_VIF_RADIO_MASK in nl80211_create_iface() and causes the kernel to default new interfaces to all radios.

The ucode bss_create fallback fails to correct this because the interface is already UP.. the kernel rejects SET_INTERFACE with -EBUSY.

The fix prevents secondary VAPs on single wiphy systems from starting with an incorrect radio mask.