### PR TITLE
mediatek: filogic: ASUS RT-AX52 PRO support

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -396,6 +396,8 @@ TARGET_DEVICES += arcadyan_mozart
 define Device/asus_rt-ax52
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AX52
+  DEVICE_ALT0_VENDOR := ASUS
+  DEVICE_ALT0_MODEL := RT-AX52 PRO
   DEVICE_DTS := mt7981b-asus-rt-ax52
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware


### PR DESCRIPTION
The board is exactly identical to the ASUS RT-AX52, I've literally not changed a single thing. PROOF IMAGE BELOW!:
Only AX52 is AX1800, PRO is AX3000. Also PRO" version's calibration permits 
160 and 80+80MHz channels while non-pro does not.
That is handled inside the driver. No worries from this side.

INSTALL THE OLDEST ASUS STOCK FIRMWARE FOR THIS DEVICE, before starting flashing. Otherwise there will be problems.

SOC: MediaTek MT7981b
RAM: 256MB DDR3
FLASH: 128MB SPI-NAND (Winbond W25N01GV)
WIFI: Mediatek MT7981b DBDC 802.11ax 2.4/5 GHz
ETH: MediaTek MT7531 Switch
UART: 3V3 115200 8N1 (Pinout silkscreened / Do not ocnnect VCC)

Use the compiled asus_rt-ax52-initramfs.trx file from the this repo.

Connect the PC via LAN to one of the yellow router ports and wait until your PC to get a DHCP lease.

Browse to http://192.168.50.1 or http://www.asusrouter.com/

If your router is brand new, finish the setup process and log into the Web-UI.

Navigate to Administration → Firmware Upgrade or use this link http://www.asusrouter.com/Advanced_FirmwareUpgrade_Content.asp.

Upload the .trx file to router

Wait for it to reboot

trx image is initramfs version. You must upgrade to squashfs version.

Browse to http://192.168.1.1/cgi-bin/luci/admin/system/flash

Upload asus_rt-ax52-squashfs-sysupgrade.bin and use sysupgrade -n

Wait for it to reboot

SSH to 192.168.1.1 and set a root password, or browse to http://192.168.1.1

-------Revert to stock asus firmware ---------:
1: Download the rt-ax52-pro firmware from ASUS official website. Save the firmware to tftp server directory and rename to RT-AX52-PRO.trx

2: Connect the PC with TFTP server to the RT-AX52. Set a static ip on the ethernet interface of your PC. (ip address: 192.168.1.70, subnet mask:255.255.255.0)

3: Conect to the serial console, power on again, interrupt the autoboot process by pressing '4' when prompted. $ ubi remove linux
$ ubi remove jffs2
$ ubi remove rootfs
$ ubi remove rootfs_data
$ ubi create linux 0x45fe000
$ reset
then the dut will reboot,interrupt the autoboot process by pressing '2' when prompted. 2: Load System code then write to Flash via TFTP.
Warning!! Erase Linux in Flash then burn new one. Are you sure?(Y/N) $: enter y
you will see the follow, type enter directly:
Input device IP (192.168.1.1) ==:
Input server IP (192.168.1.70) ==:
Input Linux Kernel filename (RT-AX52.trx) ==:

4: wait for the device run up

![kanıt](https://github.com/user-attachments/assets/cb67b908-3e00-47fb-8598-c73fb822d7f0)
