### PR TITLE
package-pack: fix Ubuntu 18.04 compilation

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -231,17 +231,17 @@ endef
 # 3: ABI version
 # 4: list of provides
 define FormatProvides
-$(strip
-  $(if $(call FormatABISuffix,$(1),$(3)),
-    $(1) $(foreach provide,
-      $(filter-out $(1),$(4)),
-      $(call AddProvide,$(provide),$(2),$(3))
-    ),
-    $(foreach provide,
-      $(filter-out $(1),$(4)),
-      $(call AddProvide,$(provide),$(2))
-    )
-  )
+$(strip \
+  $(if $(call FormatABISuffix,$(1),$(3)), \
+    $(1) $(foreach provide, \
+      $(filter-out $(1),$(4)), \
+      $(call AddProvide,$(provide),$(2),$(3)) \
+    ), \
+    $(foreach provide, \
+      $(filter-out $(1),$(4)), \
+      $(call AddProvide,$(provide),$(2)) \
+    ) \
+  ) \
 )
 endef
 


### PR DESCRIPTION
Make 4.1 has whitespace bugs fixed in newer versions. Instead of adding \ everywhere, slim the function down.

ping @GeorgeSapkin @robimarko 