### PR TITLE
apm821xx: mx60: increment compat_version

### DIFF
--- a/target/linux/apm821xx/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/apm821xx/base-files/etc/uci-defaults/05_fix-compat-version
@@ -1,7 +1,10 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
-meraki,mx60|\
+meraki,mx60)
+	uci set system.@system[0].compat_version="3.1"
+	uci commit system
+	;;
 netgear,wndr4700)
 	uci set system.@system[0].compat_version="3.0"
 	uci commit system

--- a/target/linux/apm821xx/image/nand.mk
+++ b/target/linux/apm821xx/image/nand.mk
@@ -50,10 +50,10 @@ define Device/meraki_mx60
   KERNEL := kernel-bin | libdeflate-gzip | MuImage-initramfs gzip
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   UBINIZE_OPTS := -E 5
-  DEVICE_COMPAT_VERSION := 3.0
-  DEVICE_COMPAT_MESSAGE := uboot's bootcmd has to be updated to support standard multi-image uImages. \
-       Network swconfig configuration cannot be upgraded to DSA. \
-       Upgrade via sysupgrade mechanism is not possible.
+  DEVICE_COMPAT_VERSION := 3.1
+  DEVICE_COMPAT_MESSAGE := meraki_loadaddr of u-boot has to be adjusted before upgrade \
+       to boot properly. Query https://openwrt.org/toh/meraki/mx60#upgrading_to_v2512 \
+       for detail.
 endef
 TARGET_DEVICES += meraki_mx60
 


### PR DESCRIPTION
meraki_loadaddr=1000000 may not enough to boot openwrt 25.12+ on mx60,
so directly sysupgrade without changing meraki_loadaddr would result
broken, but the u-boot-env partition used to be marked read-only, so
compat_version had better be incremented to show a notification to
direct users to the wiki to prepare the sysupgrade manually.

This should be merged atop https://github.com/openwrt/openwrt/pull/16618 .