### PR TITLE
x86: base-files add support for Sophos 125r3/125r3w

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -121,6 +121,8 @@ sophos-sg-135r2|sophos-xg-135r2| \
 sophos-sg-135wr2|sophos-xg-135wr2)
 	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3 eth4 eth5 eth6 eth7" "eth1"
 	;;
+sophos-sg-125r3|sophos-xg-125r3| \
+sophos-sg-125wr3|sophos-xg-125wr3| \
 sophos-sg-135r3|sophos-xg-135r3| \
 sophos-sg-135wr3|sophos-xg-135wr3)
 	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth5 eth7 eth8" "eth6"


### PR DESCRIPTION
x86: base-files add support for Sophos 135r3/135r3w

The Sophos SG/XG-125 revision 3 like the already supported SG/XG-135 revision 3 has odd numbering of eth ports where the WAN port (as marked on the case) is: `eth6` and `eth0`, `eth1`, `eth2`, `eth3`, `eth5`, `eth7`, `eth8` are LAN ports.

Port `eth4` confirmed to be the SFP port.

Signed-off-by:  Raylynn Knight <rayknight@me.com>