### PR TITLE
[24.10]: mediatek: add Motorcomm PHY support to Cudy AP3000 v1

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-ap3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-ap3000-v1.dts
@@ -89,13 +89,19 @@
 };
 
 &mdio_bus {
+	/* We need to have the reset GPIO on the MDIO bus node,
+	 * otherwise the PHY would be held in reset during PHY detection */
+	reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <100000>;
+	reset-post-delay-us = <100000>;
+
 	phy1: phy@1 {
+		/* Either Realtek RTL8221B-VB-CG or Motorcomm YT8821,
+		 * depending on HW revision */
+		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <1>;
 		interrupt-parent = <&pio>;
 		interrupts = <38 IRQ_TYPE_LEVEL_LOW>;
-		reset-gpios = <&pio 39 GPIO_ACTIVE_LOW>;
-		reset-assert-us = <100000>;
-		reset-deassert-us = <100000>;
 	};
 };
 

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -704,7 +704,7 @@ define Device/cudy_ap3000-v1
   IMAGE_SIZE := 65536k
   KERNEL_IN_UBI := 1
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-motorcomm
 endef
 TARGET_DEVICES += cudy_ap3000-v1
 


### PR DESCRIPTION
This is a backport of https://github.com/openwrt/openwrt/pull/21776 to OpenWrt 24.10.

This backport depends on this PR: https://github.com/openwrt/openwrt/pull/21531 from @JakubVanek.

> Newer Cudy AP3000 v1 routers feature a Motorcomm YT8821 PHY
instead of the Realtek PHY [1]. Support for the YT8821
was recently introduced for the Cudy WR3000H router [2].
On the AP3000, the changes allow the PHY to be autodetected.

[1]: https://forum.openwrt.org/t/cudy-ap3000-v1-indoor-wan-motorcomm-yt8821-support/245491
[2]: https://github.com/openwrt/openwrt/pull/21399

Locally im build this two PR and everything works flawlessly on AP3000 v1.

After https://github.com/openwrt/openwrt/pull/21531 is merged, i will retest and mark the PR as ready.