### PR TITLE
netifd: Makefile changes to support modern PSE-PD control

### DIFF
--- a/package/network/config/netifd/Makefile
+++ b/package/network/config/netifd/Makefile
@@ -1,4 +1,5 @@
 include $(TOPDIR)/rules.mk
+include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=netifd
 PKG_RELEASE:=3
@@ -31,8 +32,20 @@ define Package/netifd/conffiles
 /etc/udhcpc.user.d/
 endef
 
+# Stage kernel ethtool headers separately to avoid ioctl.h conflicts
+# Only ethtool_netlink.h needs the newer kernel version (for PSE attributes)
+ETHTOOL_HEADERS_DIR := $(PKG_BUILD_DIR)/kernel-headers
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(INSTALL_DIR) $(ETHTOOL_HEADERS_DIR)/linux
+	$(CP) $(LINUX_DIR)/user_headers/include/linux/ethtool.h $(ETHTOOL_HEADERS_DIR)/linux/
+	$(CP) $(LINUX_DIR)/user_headers/include/linux/ethtool_netlink.h $(ETHTOOL_HEADERS_DIR)/linux/
+endef
+
 TARGET_CFLAGS += \
 	-I$(STAGING_DIR)/usr/include/libnl-tiny \
+	-I$(ETHTOOL_HEADERS_DIR) \
 	-I$(STAGING_DIR)/usr/include
 
 CMAKE_OPTIONS += \


### PR DESCRIPTION
This Commit is related to the [netifd changes](https://github.com/openwrt/netifd/pull/65) to support modern PSE-PD:


There are different steps to perform:
1) the net pse-pd backport from upstream (6.18 to 6.12) [[done](https://github.com/openwrt/openwrt/pull/21810)]
1) [netifd](https://github.com/openwrt/netifd/pull/65): [ready to merge, but requires the patches & this PR to be merged]
2) [luci](https://github.com/openwrt/luci/commit/8e493db75a80194a1f76ded11df4dbf32f1235d1): [done]
3) Makefile changes of netifd (this PR)
4) Some [smaller changes to the netlink headers](https://github.com/openwrt/openwrt/pull/21926) [done]

The changes do not interfere with the version and are similar to how the iptables package handles this

**Some details: The whole scheme works as a pipeline:**
  1. Some smaller Kernel backport patches  add PSE ethtool netlink definitions to the kernel's UAPI headers
  2. Build/Prepare (this change) copies just the two ethtool headers from the patched kernel into an isolated directory
  3. -I ordering ensures netifd's compiler sees the patched headers before the (stale) staging directory copies
  4. Result: netifd can use ETHTOOL_A_PSE_PRIO, ETHTOOL_MSG_PSE_NTF, etc. without header conflicts