### PR TITLE
realtek: add support for XikeStor SKS8300-12X V1

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -64,6 +64,7 @@ realtek_setup_macs()
 	tplink,t1600g-28ts-v3|\
 	xikestor,sks8300-8t|\
 	xikestor,sks8300-12e2t2x|\
+	xikestor,sks8300-12x-v1|\
 	zyxel,xgs1210-12-a1|\
 	zyxel,xgs1210-12-b1)
 		lan_mac=$(get_mac_label)

--- a/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
+++ b/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
@@ -1,0 +1,537 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl931x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "xikestor,sks8300-12x-v1", "realtek,rtl9313-soc";
+	model = "XikeStor SKS8300-12X V1";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* first 256 MiB */
+		      <0x90000000 0x10000000>; /* remaining 256 MiB */
+	};
+
+	aliases {
+		label-mac-device = &ethernet0;
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: led-0 {
+			gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		/* LED[0]: green | LED[1]: amber */
+		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT) 
+			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)>;
+	};
+
+	/*
+	 * Diodes PT7A7514WE is fed by hardware-assisted SYS_LED. There is no
+	 * real driver for this. However, this node causes a quirk being applied 
+	 * very early to avoid a reset during early boot.
+	 */
+	watchdog1: watchdog {
+		compatible = "diodes,pt7a75xx-wdt";
+	};
+
+	i2c-gpio0 {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		sda-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+		scl-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+
+		i2c-gpio,delay-us = <5>;	/* ~100 kHz */
+		lm75: sensor@4f {
+			compatible = "national,lm75a";
+			reg = <0x4f>;
+		};
+	};
+
+	sfp1: sfp-p1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda0>;
+		los-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp2: sfp-p2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda1>;
+		los-gpio = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp3: sfp-p3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda2>;
+		los-gpio = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp4: sfp-p4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda3>;
+		los-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp5: sfp-p5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda4>;
+		los-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 13 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp6: sfp-p6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda5>;
+		los-gpio = <&gpio1 21 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 22 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp7: sfp-p7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda6>;
+		los-gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 25 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp8: sfp-p8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda7>;
+		los-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 28 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp9: sfp-p9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda9>;
+		los-gpio = <&gpio2 3 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio2 4 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio2 5 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp10: sfp-p10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda8>;
+		los-gpio = <&gpio2 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio2 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio2 2 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp11: sfp-p11 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda11>;
+		los-gpio = <&gpio2 9 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio2 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio2 11 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp12: sfp-p12 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda10>;
+		los-gpio = <&gpio2 6 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio2 7 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio2 8 GPIO_ACTIVE_HIGH>;
+		#thermal-sensor-cells = <0>;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c1_sda0: i2c@0 {
+		reg = <0>;
+	};
+	i2c1_sda1: i2c@1 {
+		reg = <1>;
+	};
+	i2c1_sda2: i2c@2 {
+		reg = <2>;
+	};
+	i2c1_sda3: i2c@3 {
+		reg = <3>;
+	};
+	i2c1_sda4: i2c@4 {
+		reg = <4>;
+	};
+	i2c1_sda5: i2c@5 {
+		reg = <5>;
+	};
+};
+
+&i2c_mst2 {
+	status = "okay";
+
+	i2c2_sda6: i2c@6 {
+		reg = <6>;
+	};
+	i2c2_sda7: i2c@7 {
+		reg = <7>;
+	};
+	i2c2_sda8: i2c@8 {
+		reg = <8>;
+	};
+	i2c2_sda9: i2c@9 {
+		reg = <9>;
+	};
+	i2c2_sda10: i2c@a {
+		reg = <10>;
+	};
+	i2c2_sda11: i2c@b {
+		reg = <11>;
+	};
+};
+
+&mdio_aux {
+	status = "okay";
+
+	gpio1: gpio@0 {
+		compatible = "realtek,rtl8231";
+		reg = <0>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio1 0 0 37>;
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+
+	gpio2: gpio@1 {
+		compatible = "realtek,rtl8231";
+		reg = <1>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio2 0 0 37>;
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			/* although this device uses u-boot, there is no u-boot-env
+			 * partition. Information is taken from either baked-in
+			 * default environment or data in 'board-info' in custom
+			 * format.
+			 * U-boot seems to be modified to also not provide 'saveenv'
+			 * nor use a 'BDINFO' partition if it has been set manually.
+			 */
+
+			/* "flash_raw" on stock */
+			partition@100000 {
+				label = "board-info";
+				reg = <0x100000 0x30000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_vendor: macaddr@1f1 {
+						compatible = "mac-base";
+						reg = <0x1f1 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@130000 {
+				label = "syslog";
+				reg = <0x130000 0xd0000>;
+				read-only;
+			};
+
+			/* "flash_user" on stock */
+			partition@200000 {
+				compatible = "fixed-partitions";
+				label = "firmware";
+				reg = <0x200000 0x1e00000>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "kernel";
+					reg = <0x0 0x800000>;
+				};
+
+				partition@800000 {
+					label = "rootfs";
+					reg = <0x800000 0x1600000>;
+				};
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_vendor 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port0: port@0 {
+			reg = <0>;
+			label = "lan1";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes2>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp1>;
+		};
+
+		port8: port@8 {
+			reg = <8>;
+			label = "lan2";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes3>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp2>;
+		};
+
+		port16: port@16 {
+			reg = <16>;
+			label = "lan3";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes4>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp3>;
+		};
+
+		port24: port@24 {
+			reg = <24>;
+			label = "lan4";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes5>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp4>;
+		};
+
+		port32: port@32 {
+			reg = <32>;
+			label = "lan5";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes6>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp5>;
+		};
+
+		port40: port@40 {
+			reg = <40>;
+			label = "lan6";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes7>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp6>;
+		};
+
+		port48: port@48 {
+			reg = <48>;
+			label = "lan7";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes8>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp7>;
+		};
+
+		port50: port@50 {
+			reg = <50>;
+			label = "lan8";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes9>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp8>;
+		};
+
+		port52: port@52 {
+			reg = <52>;
+			label = "lan10";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes10>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp10>;
+		};
+
+		port53: port@53 {
+			reg = <53>;
+			label = "lan9";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes11>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp9>;
+		};
+
+		port54: port@54 {
+			reg = <54>;
+			label = "lan12";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes12>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp12>;
+		};
+
+		port55: port@55 {
+			reg = <55>;
+			label = "lan11";
+			led-set = <0>;
+			managed = "in-band-status";
+			pcs-handle = <&serdes13>;
+			phy-mode = "1000base-x";
+			sfp = <&sfp11>;
+		};
+
+		/* CPU port */
+		port@56 {
+			ethernet = <&ethernet0>;
+			reg = <56>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <10000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&serdes2 {
+	realtek,pnswap-tx;
+};
+
+&serdes3 {
+	realtek,pnswap-tx;
+};
+
+&serdes4 {
+	realtek,pnswap-tx;
+};
+
+&serdes5 {
+	realtek,pnswap-tx;
+};
+
+&serdes6 {
+	realtek,pnswap-tx;
+};
+
+&serdes7 {
+	realtek,pnswap-tx;
+};
+
+&serdes8 {
+	realtek,pnswap-tx;
+};
+
+&serdes9 {
+	realtek,pnswap-tx;
+};
+
+&serdes10 {
+	realtek,pnswap-tx;
+};
+
+&serdes11 {
+	realtek,pnswap-tx;
+};
+
+&serdes12 {
+	realtek,pnswap-tx;
+};
+
+&serdes13 {
+	realtek,pnswap-tx;
+};
+

--- a/target/linux/realtek/files-6.12/arch/mips/include/asm/mach-rtl-otto/mach-rtl-otto.h
+++ b/target/linux/realtek/files-6.12/arch/mips/include/asm/mach-rtl-otto/mach-rtl-otto.h
@@ -29,6 +29,9 @@
 #define RTL838X_INT_RW_CTRL		(0x0058)
 #define RTL838X_EXT_VERSION		(0x00D0)
 
+#define RTL931X_LED_GLB_CTRL		(0x0600)
+#define RTL931X_MAC_L2_GLOBAL_CTRL2	(0x1358)
+
 /* Definition of family IDs */
 #define RTL8380_FAMILY_ID		(0x8380)
 #define RTL8390_FAMILY_ID		(0x8390)

--- a/target/linux/realtek/image/Makefile
+++ b/target/linux/realtek/image/Makefile
@@ -108,6 +108,11 @@ define Build/linksys-image
 	mv $@.new $@
 endef
 
+define Build/xikestor-nosimg
+	$(STAGING_DIR_HOST)/bin/nosimg-enc -i $@ -o $@.new
+	mv $@.new $@
+endef
+
 define Build/zynsig
 	$(STAGING_DIR_HOST)/bin/zynsig -i $@ \
 		-o $@.new

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -2,11 +2,6 @@
 
 include ./common.mk
 
-define Build/xikestor-nosimg
-  $(STAGING_DIR_HOST)/bin/nosimg-enc -i $@ -o $@.new
-  mv $@.new $@
-endef
-
 define Device/hasivo_s1100w-8xgt-se
   SOC := rtl9303
   DEVICE_VENDOR := Hasivo

--- a/target/linux/realtek/image/rtl931x.mk
+++ b/target/linux/realtek/image/rtl931x.mk
@@ -30,3 +30,17 @@ define Device/plasmacloud_psx28
   DEVICE_PACKAGES += poemgr
 endef
 TARGET_DEVICES += plasmacloud_psx28
+
+define Device/xikestor_sks8300-12x-v1
+  SOC := rtl9313
+  DEVICE_VENDOR := XikeStor
+  DEVICE_MODEL := SKS8300-12X
+  DEVICE_VARIANT := V1
+  BLOCKSIZE := 64k
+  KERNEL_SIZE := 8192k
+  IMAGE_SIZE := 30720k
+  IMAGE/sysupgrade.bin := pad-extra 256 | append-kernel | xikestor-nosimg | \
+        jffs2 nos.img -e 4KiB -x lzma | pad-to $$$$(KERNEL_SIZE) | \
+        append-rootfs | pad-rootfs | append-metadata | check-size
+endef
+TARGET_DEVICES += xikestor_sks8300-12x-v1


### PR DESCRIPTION
This series adds support for RTL9313-based XikeStor SKS8300-12X switch with 12x SFP+, quite similar to SKS8300-8X. This device works fine with the current RTL931x SFP situation.

**This PR is for V1 with the 19" sized case. As of 2026, there's also a V2 with a narrower case**

The device seems to need some special handling. In my testing, initramfs boot worked totally fine while flash boot just had a reset after short time. Some investigation showed that the XikeStor proprietary boot wrapper seems to mangle with the SYS_LED/GPIO0 settings on autoboot. This requires an early quirk though I'm not sure if it's a good way to implement it like that.
@plappermaul any advise on that?