### PR TITLE
wifi-scripts: fix encryption setting of default OpenWrt SSID

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
+++ b/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
@@ -83,7 +83,7 @@ for (let phy_name, phy in board.wlan) {
 			country = '00';
 			encryption = 'owe';
 		} else {
-			encryption = 'open';
+			encryption = 'none';
 		}
 		if (board.wlan.defaults) {
 			defaults = board.wlan.defaults.ssids?.[band_name]?.ssid ? board.wlan.defaults.ssids?.[band_name] : board.wlan.defaults.ssids?.all;


### PR DESCRIPTION
Commit 01a87f4bd0cdbfc84bbc172920e865c1600f7a45 changed the encryption setting of the default SSID "OpenWrt" from "none" to "open". The correct setting as per the [documentation](https://openwrt.org/docs/guide-user/network/wifi/basic#encryption_modes) is "none", though. While this invalid setting won't cause a wrong hostapd setup, it will at least cause malfunction in LuCI.

Change the default encryption setting back to "none".

Also see [my comment in the respective PR](https://github.com/openwrt/openwrt/pull/21313#issuecomment-3829304992).

This should also be backported to 25.12 before final release of 25.12.0. The commit applies cleanly to 25.12 as well. I could still raise a second PR against 25.12, if needed.