### PR TITLE
pse-pd backports: patch netlink & PSE PRIO

### DIFF
--- a/target/linux/generic/backport-6.12/627-01-v6.17-net-pse-pd-Add-ethtool_netlink_generated-header.patch
+++ b/target/linux/generic/backport-6.12/627-01-v6.17-net-pse-pd-Add-ethtool_netlink_generated-header.patch
@@ -2,22 +2,25 @@ From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: OpenWrt PSE-PD Backport <openwrt@openwrt.org>
 Date: Fri, 31 Jan 2025 00:00:00 +0000
 Subject: [PATCH] net: pse-pd: Add ethtool netlink definitions for PSE events
+ and priority
 
 GENERATED PATCH - OpenWrt PSE-PD Backport
 
 This patch:
-1. Creates include/uapi/linux/ethtool_netlink_generated.h with PSE event
+1. Adds ETHTOOL_A_PSE_PW_D_ID, ETHTOOL_A_PSE_PRIO_MAX, ETHTOOL_A_PSE_PRIO to
+   the ETHTOOL_A_PSE_* enum in ethtool_netlink.h (backported from kernel 6.17+)
+2. Creates include/uapi/linux/ethtool_netlink_generated.h with PSE event
    definitions (in mainline 6.17+, this file is auto-generated)
-2. Adds ETHTOOL_MSG_PSE_NTF to the kernel message types enum
+3. Adds ETHTOOL_MSG_PSE_NTF to the kernel message types enum
 
-These definitions are required by PSE event reporting patches.
+These definitions are required by PSE event reporting and priority patches.
 
 Signed-off-by: OpenWrt PSE-PD Backport <openwrt@openwrt.org>
 Signed-off-by: Carlo Szelinsky <github@szelinsky.de>
 ---
- include/uapi/linux/ethtool_netlink.h           |  1 +
- include/uapi/linux/ethtool_netlink_generated.h | 45 ++++++++++++++++++
- 2 files changed, 46 insertions(+)
+ include/uapi/linux/ethtool_netlink.h           |  4 ++
+ include/uapi/linux/ethtool_netlink_generated.h | 31 ++++++++++++++++++++++++++
+ 2 files changed, 35 insertions(+)
  create mode 100644 include/uapi/linux/ethtool_netlink_generated.h
 
 --- a/include/uapi/linux/ethtool_netlink.h
@@ -30,31 +33,25 @@ Signed-off-by: Carlo Szelinsky <github@szelinsky.de>
  	/* add new constants above here */
  	__ETHTOOL_MSG_KERNEL_CNT,
  	ETHTOOL_MSG_KERNEL_MAX = __ETHTOOL_MSG_KERNEL_CNT - 1
+@@ -970,6 +971,9 @@ enum {
+ 	ETHTOOL_A_C33_PSE_EXT_SUBSTATE,		/* u32 */
+ 	ETHTOOL_A_C33_PSE_AVAIL_PW_LIMIT,	/* u32 */
+ 	ETHTOOL_A_C33_PSE_PW_LIMIT_RANGES,	/* nest - _C33_PSE_PW_LIMIT_* */
++	ETHTOOL_A_PSE_PW_D_ID,			/* u32 */
++	ETHTOOL_A_PSE_PRIO_MAX,			/* u32 */
++	ETHTOOL_A_PSE_PRIO,			/* u32 */
+ 
+ 	/* add new constants above here */
+ 	__ETHTOOL_A_PSE_CNT,
 --- /dev/null
 +++ b/include/uapi/linux/ethtool_netlink_generated.h
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,31 @@
 +/* SPDX-License-Identifier: ((GPL-2.0 WITH Linux-syscall-note) OR BSD-3-Clause) */
-+/*
-+ * Minimal PSE ethtool netlink definitions - OpenWrt backport for 6.12.67
-+ * In mainline 6.17+, this file is auto-generated from:
-+ *   Documentation/netlink/specs/ethtool.yaml
-+ *
-+ * GENERATED PATCH - OpenWrt PSE-PD Backport
-+ */
++/* PSE ethtool netlink definitions - OpenWrt backport for 6.12 */
 +
 +#ifndef _UAPI_LINUX_ETHTOOL_NETLINK_GENERATED_H
 +#define _UAPI_LINUX_ETHTOOL_NETLINK_GENERATED_H
 +
-+/**
-+ * enum ethtool_pse_event - PSE event list for the PSE controller
-+ * @ETHTOOL_PSE_EVENT_OVER_CURRENT: PSE output current is too high
-+ * @ETHTOOL_PSE_EVENT_OVER_TEMP: PSE in over temperature state
-+ * @ETHTOOL_C33_PSE_EVENT_DETECTION: detection process occur on the PSE
-+ * @ETHTOOL_C33_PSE_EVENT_CLASSIFICATION: classification process occur
-+ * @ETHTOOL_C33_PSE_EVENT_DISCONNECTION: PD has been disconnected
-+ * @ETHTOOL_PSE_EVENT_OVER_BUDGET: PSE turned off due to over budget
-+ * @ETHTOOL_PSE_EVENT_SW_PW_CONTROL_ERROR: PSE power control error
-+ */
 +enum ethtool_pse_event {
 +	ETHTOOL_PSE_EVENT_OVER_CURRENT = 1,
 +	ETHTOOL_PSE_EVENT_OVER_TEMP = 2,
@@ -65,16 +62,18 @@ Signed-off-by: Carlo Szelinsky <github@szelinsky.de>
 +	ETHTOOL_PSE_EVENT_SW_PW_CONTROL_ERROR = 64,
 +};
 +
-+/* PSE notification attributes */
 +enum {
 +	ETHTOOL_A_PSE_NTF_HEADER = 1,
 +	ETHTOOL_A_PSE_NTF_EVENTS,
-+
 +	__ETHTOOL_A_PSE_NTF_CNT,
 +	ETHTOOL_A_PSE_NTF_MAX = (__ETHTOOL_A_PSE_NTF_CNT - 1)
 +};
 +
-+/* PSE power domain ID attribute - value 14 in the ETHTOOL_A_PSE_* enum */
-+#define ETHTOOL_A_PSE_PW_D_ID 14
++enum {
++	ETHTOOL_A_PSE_NTF_EVT_UNSPEC,
++	ETHTOOL_A_PSE_NTF_EVT_INDEX,
++	__ETHTOOL_A_PSE_NTF_EVT_CNT,
++	ETHTOOL_A_PSE_NTF_EVT_MAX = (__ETHTOOL_A_PSE_NTF_EVT_CNT - 1)
++};
 +
 +#endif /* _UAPI_LINUX_ETHTOOL_NETLINK_GENERATED_H */

--- a/target/linux/generic/backport-6.12/627-02-v6.17-net-ethtool-Add-PSE-port-priority-support.patch
+++ b/target/linux/generic/backport-6.12/627-02-v6.17-net-ethtool-Add-PSE-port-priority-support.patch
@@ -1,0 +1,68 @@
+# ADAPTED FOR OPENWRT 6.12 - Documentation changes removed
+# Original commit: eeb0c8f72f49
+From eeb0c8f72f49a21984981188404cfd3700edbaff Mon Sep 17 00:00:00 2001
+From: "Kory Maincent (Dent Project)" <kory.maincent@bootlin.com>
+Date: Tue, 17 Jun 2025 14:12:07 +0200
+Subject: [PATCH] net: ethtool: Add PSE port priority support feature
+
+This patch expands the status information provided by ethtool for PSE c33
+with current port priority and max port priority. It also adds a call to
+pse_ethtool_set_prio() to configure the PSE port priority.
+
+Signed-off-by: Kory Maincent (Dent Project) <kory.maincent@bootlin.com>
+Reviewed-by: Oleksij Rempel <o.rempel@pengutronix.de>
+Link: https://patch.msgid.link/20250617-feature_poe_port_prio-v14-8-78a1a645e2ee@bootlin.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Carlo Szelinsky <github@szelinsky.de>
+---
+ net/ethtool/pse-pd.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+--- a/net/ethtool/pse-pd.c
++++ b/net/ethtool/pse-pd.c
+@@ -111,6 +111,9 @@ static int pse_reply_size(const struct e
+ 		len += st->c33_pw_limit_nb_ranges *
+ 		       (nla_total_size(0) +
+ 			nla_total_size(sizeof(u32)) * 2);
++	if (st->prio_max)
++		/* _PSE_PRIO_MAX + _PSE_PRIO */
++		len += nla_total_size(sizeof(u32)) * 2;
+ 
+ 	return len;
+ }
+@@ -205,6 +208,11 @@ static int pse_fill_reply(struct sk_buff
+ 	    pse_put_pw_limit_ranges(skb, st))
+ 		return -EMSGSIZE;
+ 
++	if (st->prio_max &&
++	    (nla_put_u32(skb, ETHTOOL_A_PSE_PRIO_MAX, st->prio_max) ||
++	     nla_put_u32(skb, ETHTOOL_A_PSE_PRIO, st->prio)))
++		return -EMSGSIZE;
++
+ 	return 0;
+ }
+ 
+@@ -226,6 +234,7 @@ const struct nla_policy ethnl_pse_set_po
+ 		NLA_POLICY_RANGE(NLA_U32, ETHTOOL_C33_PSE_ADMIN_STATE_DISABLED,
+ 				 ETHTOOL_C33_PSE_ADMIN_STATE_ENABLED),
+ 	[ETHTOOL_A_C33_PSE_AVAIL_PW_LIMIT] = { .type = NLA_U32 },
++	[ETHTOOL_A_PSE_PRIO] = { .type = NLA_U32 },
+ };
+ 
+ static int
+@@ -283,6 +292,15 @@ ethnl_set_pse(struct ethnl_req_info *req
+ 		if (ret)
+ 			return ret;
+ 	}
++
++	if (tb[ETHTOOL_A_PSE_PRIO]) {
++		unsigned int prio;
++
++		prio = nla_get_u32(tb[ETHTOOL_A_PSE_PRIO]);
++		ret = pse_ethtool_set_prio(phydev->psec, info->extack, prio);
++		if (ret)
++			return ret;
++	}
+ 
+ 	/* These values are already validated by the ethnl_pse_set_policy */
+ 	if (tb[ETHTOOL_A_PODL_PSE_ADMIN_CONTROL] ||


### PR DESCRIPTION
This PR is the last item that is required to support modern PSE-PD (backported from 6.18) in combination with netifd and ethtool...
I didn't add this change to the PSE-PD backports PR, to keep it clean to the upstream without any "hacks" ...

The different steps are:
1) PSE-PD backports from 6.18 to 6.12 [[done](https://github.com/openwrt/openwrt/pull/21810)]
2) Luci support [done]
3) adapt netlink headers and one PSE patch [this PR]
4) adapt netifid Makefile to compile against right headers [[read to review](https://github.com/openwrt/openwrt/pull/21918)]
5) netifd changes can be finally merged after (1-4) [[ready, but based on 1-4](https://github.com/openwrt/netifd/pull/65)]
6) ... Merging first drivers, one is written for hasivo hs104 :-) 

This PR patches the netlink headers for netifd PSE support and it fixes the PSE backports for PSE priority...
The 6.12-01 patches the auto generated ethtool_netlink_generated header. The 6.12 build tools do not have the build system feature for generating the correct netlink headers related to the backports.
The 627-02... patch  is a nearly verbatim copy of the upstream commit. 

@hauke Can you assist one last time, so we get this done  :-) That would unblock all the other PRs... 
happy weekend :-)
best,
Carlo
