### PR TITLE
malta: migrate to new image building system

### DIFF
--- a/scripts/qemustart
+++ b/scripts/qemustart
@@ -224,7 +224,7 @@ start_qemu_malta() {
 	qemu_exe="qemu-system-mips$is64$isel"
 	[ -n "$is64" ] && cpu="MIPS64R2-generic" || cpu="24Kc"
 
-	[ -n "$kernel" ] || kernel="$o_bindir/openwrt-malta-${o_subtarget%-*}-vmlinux-initramfs.elf"
+	[ -n "$kernel" ] || kernel="$o_bindir/openwrt-malta-${o_subtarget%-*}-generic-initramfs-kernel.bin"
 
 	[ -z "$rootfs" ] || {
 		if [ ! -f "$rootfs" -a -s "$rootfs.gz" ]; then

--- a/target/linux/malta/image/Makefile
+++ b/target/linux/malta/image/Makefile
@@ -5,48 +5,28 @@
 include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/image.mk
 
-define CompressLzma
-  $(STAGING_DIR_HOST)/bin/lzma e $(1) -lc1 -lp2 -pb2 $(2)
+KERNEL_LOADADDR := 0x80100000
+
+define Device/Default
+  PROFILES := Default
+  KERNEL_NAME := vmlinux.elf
+  KERNEL_INITRAMFS_NAME := vmlinux-initramfs.elf
+  KERNEL := kernel-bin
+  KERNEL_INSTALL := 1
+  FILESYSTEMS := ext4 squashfs
+  IMAGES := rootfs.img rootfs.img.gz
+  IMAGE/rootfs.img := append-rootfs | pad-to $(ROOTFS_PARTSIZE)
+  IMAGE/rootfs.img.gz := append-rootfs | pad-to $(ROOTFS_PARTSIZE) | gzip
+  ARTIFACTS := uImage-lzma uImage-gzip
+  ARTIFACT/uImage-lzma := kernel-bin | lzma | uImage lzma
+  ARTIFACT/uImage-gzip := kernel-bin | gzip | uImage gzip
+  SUPPORTED_DEVICES :=
 endef
 
-define CompressGzip
-	gzip -9n -c $(1) > $(2)
+define Device/generic
+  DEVICE_VENDOR := MIPS
+  DEVICE_MODEL := Malta CoreLV board (QEMU)
 endef
-
-define MkuImage
-	mkimage -A mips -O linux -T kernel -a 0x80100000 -C $(1) $(2) \
-		-e 0x80100000 -n 'MIPS OpenWrt Linux-$(LINUX_VERSION)' \
-		-d $(3) $(4)
-endef
-
-define Image/Prepare
-	$(call CompressLzma,$(KDIR)/vmlinux,$(KDIR)/vmlinux.bin.lzma)
-	$(call MkuImage,lzma,,$(KDIR)/vmlinux.bin.lzma,$(KDIR)/uImage.lzma)
-	$(call CompressGzip,$(KDIR)/vmlinux,$(KDIR)/vmlinux.bin.gz)
-	$(call MkuImage,gzip,,$(KDIR)/vmlinux.bin.gz,$(KDIR)/uImage.gz)
-endef
-
-define Image/BuildKernel
-	cp $(KDIR)/vmlinux.elf $(BIN_DIR)/$(IMG_PREFIX)-vmlinux.elf
-	cp $(KDIR)/uImage.lzma $(BIN_DIR)/$(IMG_PREFIX)-uImage-lzma
-	cp $(KDIR)/uImage.gz $(BIN_DIR)/$(IMG_PREFIX)-uImage-gzip
-endef
-
-define Image/Build/Initramfs
-	cp $(KDIR)/vmlinux-initramfs.elf $(BIN_DIR)/$(IMG_PREFIX)-vmlinux-initramfs.elf
-	cp $(KDIR)/vmlinux-initramfs $(BIN_DIR)/$(IMG_PREFIX)-vmlinux-initramfs.bin
-endef
-
-define Image/Build/gzip
-	gzip -f9n $(BIN_DIR)/$(IMG_ROOTFS)-$(1).img
-endef
-
-$(eval $(call Image/gzip-ext4-padded-squashfs))
-
-define Image/Build
-	$(call Image/Build/$(1))
-	$(CP) $(KDIR)/root.$(1) $(BIN_DIR)/$(IMG_ROOTFS)-$(1).img
-	$(call Image/Build/gzip/$(1))
-endef
+TARGET_DEVICES += generic
 
 $(eval $(call BuildImage))


### PR DESCRIPTION
commit f0cc164178575943f95f87fb6dd83841a7d95a8a
Author: Paul Spooren <mail@aparcar.org>
Date:   Sun Feb 8 20:14:43 2026 +0100

    scripts/qemustart: update malta kernel path for Device macro naming

    Update the default kernel path in start_qemu_malta() to match the new
    image naming scheme after the malta target was converted to the Device
    macro system with device name 'generic'.

commit fa28b5d01d64f2cd2e540a750461a31556a79d82
Author: Paul Spooren <mail@aparcar.org>
Date:   Sun Feb 8 19:50:34 2026 +0100

    malta: convert to Device macro image building

    Convert the malta target from the legacy Image/BuildKernel and
    Image/Build pattern to the modern Device macro system. This is the
    last target still using the legacy pattern.

    The Device macro system automatically generates per-image JSON
    metadata files which get aggregated into profiles.json, enabling
    firmware selector and other tooling support for all malta subtargets
    (be, le, be64, le64).

    The kernel ELF is produced via KERNEL_NAME := vmlinux.elf (matching
    octeon), uImage artifacts are built using the standard Build/lzma,
    Build/gzip and Build/uImage commands with the existing load address
    0x80100000, and rootfs images use append-rootfs with optional gzip
    compression.

    The device is named 'generic' following the convention used by other
    virtual/emulated targets (x86, armsr, octeon).