### PR TITLE
nilfs-utils: update to 2.3.0

### DIFF
--- a/package/utils/nilfs-utils/Makefile
+++ b/package/utils/nilfs-utils/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nilfs-utils
-PKG_VERSION:=2.2.12
+PKG_VERSION:=2.3.0
 PKG_RELEASE:=1
 PKG_URL:=https://nilfs.sourceforge.io
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://nilfs.sourceforge.io/download/
-PKG_HASH:=fc9a8520b68928d43fffa465c3b3845cc9b7d4973f4fbde4b3c7ecf25ce52d09
+PKG_HASH:=c0876a7ecd13d4b54cb65abb9ad6cd0bf1ed102d03ca12738f12eab9bd84e67b
 
 PKG_MAINTAINER:=Pavlo Samko <bulldozerbsg@gmail.com>
 PKG_LICENSE:=GPL-2.0
@@ -63,19 +63,12 @@ define Package/libnilfsgc
   DEPENDS:=+libnilfs
 endef
 
-define Package/libnilfscleaner
-  SECTION:=libs
-  CATEGORY:=Libraries
-  TITLE:=libnilfscleaner
-  DEPENDS:=+libuuid +nilfs-cleanerd @KERNEL_POSIX_MQUEUE
-endef
-
 define Package/nilfs-clean
   SECTION:=utils
   CATEGORY:=Utilities
   SUBMENU:=Filesystem
   TITLE:=run garbage collector on NILFS file system
-  DEPENDS:=+libnilfs +libnilfscleaner
+  DEPENDS:=+libuuid +libnilfs @KERNEL_POSIX_MQUEUE
 endef
 
 define Package/nilfs-resize
@@ -121,25 +114,26 @@ endef
 # libmount is used and support of the selinux context mount options
 # depends on the libmount that distro provides.
 CONFIGURE_ARGS += \
+	--enable-usrmerge \
 	--without-selinux
 
 define Package/nilfs-mkfs/install
-	$(INSTALL_DIR) $(1)/sbin
-	$(CP) $(PKG_INSTALL_DIR)/sbin/mkfs.nilfs2 $(1)/sbin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/mkfs.nilfs2 $(1)/usr/sbin/
 endef
 
 define Package/nilfs-cleanerd/install
 	$(INSTALL_DIR) $(1)/etc
 	$(CP) $(PKG_INSTALL_DIR)/etc/nilfs_cleanerd.conf $(1)/etc/
 
-	$(INSTALL_DIR) $(1)/sbin
-	$(CP) $(PKG_INSTALL_DIR)/sbin/nilfs_cleanerd $(1)/sbin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/nilfs_cleanerd $(1)/usr/sbin/
 endef
 
 define Package/nilfs-mount/install
-	$(INSTALL_DIR) $(1)/sbin
-	$(CP) $(PKG_INSTALL_DIR)/sbin/mount.nilfs2 $(1)/sbin/
-	$(CP) $(PKG_INSTALL_DIR)/sbin/umount.nilfs2 $(1)/sbin/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/mount.nilfs2 $(1)/usr/sbin/
+	$(CP) $(PKG_INSTALL_DIR)/usr/sbin/umount.nilfs2 $(1)/usr/sbin/
 endef
 
 define Package/libnilfs/install
@@ -150,11 +144,6 @@ endef
 define Package/libnilfsgc/install
 	$(INSTALL_DIR) $(1)/usr/lib
 	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnilfsgc.so* $(1)/usr/lib/
-endef
-
-define Package/libnilfscleaner/install
-	$(INSTALL_DIR) $(1)/usr/lib
-	$(CP) $(PKG_INSTALL_DIR)/usr/lib/libnilfscleaner.so* $(1)/usr/lib/
 endef
 
 define Package/nilfs-clean/install
@@ -195,7 +184,6 @@ $(eval $(call BuildPackage,nilfs-cleanerd))
 $(eval $(call BuildPackage,nilfs-mount))
 $(eval $(call BuildPackage,libnilfs))
 $(eval $(call BuildPackage,libnilfsgc))
-$(eval $(call BuildPackage,libnilfscleaner))
 $(eval $(call BuildPackage,nilfs-clean))
 $(eval $(call BuildPackage,nilfs-resize))
 $(eval $(call BuildPackage,nilfs-tune))


### PR DESCRIPTION
Release notes v2.2.13-2.3.0 (from https://nilfs.sourceforge.io/download/ChangeLog-utils-v2):
nilfs-utils-2.3.0  Sun Jan 25, 2026 JST

	* New Features:
	  - Support file/directory arguments for utilities (lscp, lssu,
	    nilfs-clean, etc.) to automatically resolve backing devices.
	  - nilfs-clean: Automatically adjust GC speed by default, eliminating
	    manual tuning.

	* GC Daemon (cleanerd) Improvements:
	  - Cap segments per cleaning step by available free segments to
	    prevent stalling when free space is running out.  Also, cap
	    the number of segments per cleaning step to prevent theoretical
	    size_t overflow on 32-bit systems.
	  - Improve signal handling (exit cleanly on SIGINT, ignore SIGUSR2).
	  - Add state dump feature (SIGUSR1).

	* Build System Updates:
	  - Support generating pkg-config information for shared libraries.
	  - Support pkg-config for finding dependencies (libuuid, libmount,
	    libblkid, libselinux).
	  - Do not install static libraries by default.
	  - Gather system programs directly below sbin source directory.

	* Library Refactoring and API Changes:
	  - Reorganize APIs in libnilfs and libnilfsgc:
	    - Add/update APIs for segment I/O, resize, and freeze/thaw.
	    - Unify type definitions (use standard uint32_t/uint64_t).
	    - Remove obsolete APIs and internal structures from public headers.

	* Other Utilities Updates:
	  - mkfs.nilfs2: Set "block_count read-only compat" flag by default.
          - Align help message output and exit codes with standard conventions
	    (e.g. nilfs-tune).
	  - nilfs-resize: Use new library API for layout information.

	* Miscellaneous:
	  - Refactor type definitions (use uint64_t/uint32_t/bool/size_t) for
	    safety and consistency.
	  - Adapt to Sparse code checking (fix endian macros, etc.).
	  - Massive code cleanups and coding style fixes.

	* Note: Although the development tree diverged from v2.2.5, updates
	  in the v2.2.y stable branch are backports derived from the master
	  branch.  Consequently, this release incorporates all fixes and
	  improvements listed below from nilfs-utils-2.2.6 through
	  nilfs-utils-2.2.16.

nilfs-utils-2.2.16  Sun Jan 25, 2026 JST

	* Fix a build issue on distributions with fully merged bin/sbin:
	  - build: avoid overwriting binaries with compat symlinks on
	    merged-/usr (e.g., Fedora Rawhide)
	* Backport some kernel-doc warning fixes

nilfs-utils-2.2.15  Wed Jan 21, 2026 JST

	* Fix a regression introduced in nilfs-utils-2.2.12:
	  - chcp: fix inverted logic in argument parsing
	* Backport miscellaneous fixes:
	  - libparser: reject negative values in
	    nilfs_parse_protection_period()
	  - mkfs.nilfs2: remove stray debug print
	* Backport manual page updates:
	  - man: fix typos, grammatical errors and style
	  - man: update examples in nilfs.8

nilfs-utils-2.2.14  Sat Jan 17, 2026 JST

	* Fix various error handling issues in libmount-based mount/umount
	  helpers:
	  - mount.nilfs2: fix broken overlapping rw-mount protection
	  - mount.nilfs2: fix ignored error on remount target mismatch
	  - umount.nilfs2: fix assertion failure when unmounting multiple
	    targets
	  - umount.nilfs2: fix incorrect error code handling in libmount-based
	    umount
	  - mount.nilfs2: fix error code handling in nilfs_do_mount_one()
	  - mount.nilfs2: fix error return in nilfs_mount_attrs_parse() and
	    its caller
	  - umount.nilfs2: fix exit code accumulation and reorganize status
	    codes
	  - umount.nilfs2: fix broken empty string check
	  - {mount,umount}.nilfs2: check return values of mnt_context_set_*()
	  - mount.nilfs2: check return value of mnt_fs_set_root()
	* Fix a build warning for mkfs.nilfs2:
	  - Remove unnecessary local variables in prepare_dat()
	* Build updates:
	  - Ignore actmp files

nilfs-utils-2.2.13  Sun Dec 28, 2025 JST

	* Build updates:
	  - Support UsrMerge and Bin-Sbin merge with automatic detection
	  - Autodetect architecture-specific library directory
	  - Fix installation of missing header file nilfs_gc.h
	  - Remove unused UTIL_CHECK_LIB macro
	  - Add a few autoconf temporary artifacts to .gitignore
	* Fix a build warning for legacy mount helpers
	  - mount.nilfs2: do not use security_context_t in the legacy variant
	* Documentation:
	  - Modernize description regarding libmount and mtab handling
	  - Reorganize build instructions and consolidate legacy info
	  - Add instruction to use 'make distclean' when changing config
	  - Update troubleshooting guide for build issues
	  - Add installation and uninstallation instructions to README
	  - Add a new section to explain cross-compilation and deployment
	  - Remove inappropriate example for --libdir option
	  - Fix some grammatical errors and inappropriate expressions
