### PR TITLE
Revert "apm821xx: mx60: increment compat_version"

### DIFF
--- a/target/linux/apm821xx/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/apm821xx/base-files/etc/uci-defaults/05_fix-compat-version
@@ -1,10 +1,7 @@
 . /lib/functions.sh
 
 case "$(board_name)" in
-meraki,mx60)
-	uci set system.@system[0].compat_version="3.1"
-	uci commit system
-	;;
+meraki,mx60|\
 netgear,wndr4700)
 	uci set system.@system[0].compat_version="3.0"
 	uci commit system

--- a/target/linux/apm821xx/image/nand.mk
+++ b/target/linux/apm821xx/image/nand.mk
@@ -50,10 +50,10 @@ define Device/meraki_mx60
   KERNEL := kernel-bin | libdeflate-gzip | MuImage-initramfs gzip
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
   UBINIZE_OPTS := -E 5
-  DEVICE_COMPAT_VERSION := 3.1
-  DEVICE_COMPAT_MESSAGE := meraki_loadaddr of u-boot has to be adjusted before upgrade \
-       to boot properly. Query https://openwrt.org/toh/meraki/mx60#upgrading_to_v2512 \
-       for detail.
+  DEVICE_COMPAT_VERSION := 3.0
+  DEVICE_COMPAT_MESSAGE := uboot's bootcmd has to be updated to support standard multi-image uImages. \
+       Network swconfig configuration cannot be upgraded to DSA. \
+       Upgrade via sysupgrade mechanism is not possible.
 endef
 TARGET_DEVICES += meraki_mx60
 


### PR DESCRIPTION
This reverts commit 17cd653d5f28c6579aea1a0afb86ea94f80f725d.

Raising the value of meraki_loadaddr cannot actually make openwrt 25.12+ boot on mx60 (not mx60w), but might be useful to resolve other issue, so I suggest to revert this and make it a draft, until it proves to resolve something.

