### PR TITLE
realtek: add support for Zyxel GS1920-24HPv2

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -76,7 +76,8 @@ realtek_setup_macs()
 	plasmacloud,mcx3|\
 	plasmacloud,psx8|\
 	plasmacloud,psx10|\
-	plasmacloud,psx28)
+	plasmacloud,psx28|\
+	zyxel,gs1920-24hp-v2)
 		lan_mac="$(get_mac_label)"
 		;;
 	tplink,tl-st1008f-v2|\

--- a/target/linux/realtek/dts/rtl8391_zyxel_gs1920-24hp-v2.dts
+++ b/target/linux/realtek/dts/rtl8391_zyxel_gs1920-24hp-v2.dts
@@ -1,0 +1,134 @@
+/dts-v1/;
+
+#include "rtl839x_zyxel_gs1920-24hp-common.dtsi"
+
+/ {
+	compatible = "zyxel,gs1920-24hp-v2", "realtek,rtl8391-soc";
+	model = "Zyxel GS1920-24HPv2";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x10000000>;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	leds {
+		cloud-amber {
+			gpios = <&gpio1 27 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_AMBER>;
+		};
+
+		pwr-green {
+			gpios = <&gpio1 18 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			default-state = "on";
+		};
+
+		pwr-amber {
+			gpios = <&gpio1 19 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_AMBER>;
+		};
+
+		poe-max {
+			gpios = <&gpio1 35 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_AMBER>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys-polled";
+		poll-interval = <20>;
+
+		restore {
+			label = "restore";
+			gpios = <&gpio1 32 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_KEY>;
+		};
+	};
+
+	/delete-node/ i2c-gpio-0;
+	/delete-node/ i2c-gpio-1;
+
+	i2c-gpio-shared {
+		compatible = "i2c-gpio-shared";
+		scl-gpios = <&gpio1 3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		i2c0: i2c@0 {
+			sda-gpios = <&gpio1 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+			i2c-gpio,delay-us = <2>;
+		};
+
+		i2c1: i2c@1 {
+			sda-gpios = <&gpio1 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+			i2c-gpio,delay-us = <2>;
+		};
+	};
+};
+
+&i2c2 {
+	scl-gpios = <&gpio1 9 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+};
+
+&i2c3 {
+	scl-gpios = <&gpio1 15 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+};
+
+&i2c4 {
+	lm96000: lm96000@2e {
+		compatible = "national,lm85";
+		reg = <0x2e>;
+	};
+};
+
+&flash_partitions {
+	partition@20000 {
+		label = "reserved";
+		reg = <0x20000 0x1e0000>;
+		read-only;
+	};
+
+	partition@200000 {
+		reg = <0x200000 0x1e00000>;
+		label = "factory";
+
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "loader";
+			reg = <0x0 0x10000>;
+		};
+
+		partition@10000 {
+			label = "firmware";
+			reg = <0x10000 0x1d00000>;
+			compatible = "openwrt,uimage", "denx,uimage";
+		};
+	};
+};
+
+&mdio_bus0 {
+	/* External phy RTL8214FC #1 */
+	EXTERNAL_SFP_PHY_FULL(24, 0)
+	EXTERNAL_SFP_PHY_FULL(25, 1)
+	EXTERNAL_SFP_PHY_FULL(26, 2)
+	EXTERNAL_SFP_PHY_FULL(27, 3)
+};
+
+&switch0 {
+	ports {
+		SWITCH_PORT_SDS(24, 25, 6, qsgmii)
+		SWITCH_PORT_SDS(25, 26, 6, qsgmii)
+		SWITCH_PORT_SDS(26, 27, 6, qsgmii)
+		SWITCH_PORT_SDS(27, 28, 6, qsgmii)
+	};
+};

--- a/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24hp-v1.dts
+++ b/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24hp-v1.dts
@@ -1,21 +1,10 @@
 /dts-v1/;
 
-#include "rtl839x.dtsi"
-
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/leds/common.h>
+#include "rtl839x_zyxel_gs1920-24hp-common.dtsi"
 
 / {
 	compatible = "zyxel,gs1920-24hp-v1", "realtek,rtl8392-soc";
 	model = "Zyxel GS1920-24HPv1";
-
-	aliases {
-		led-boot = &led_sys;
-		led-failsafe = &led_sys;
-		led-running = &led_sys;
-		led-upgrade = &led_sys;
-	};
 
 	memory@0 {
 		device_type = "memory";
@@ -26,28 +15,11 @@
 		stdout-path = "serial0:9600n8";
 	};
 
-
 	leds {
-		pinctrl-names = "default";
-		pinctrl-0 = <&pinmux_disable_sys_led>;
-		compatible = "gpio-leds";
-
-		led_sys: sys {
-			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
-			function = LED_FUNCTION_STATUS;
-			color = <LED_COLOR_ID_GREEN>;
-		};
-
 		alarm {
 			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
 			function = LED_FUNCTION_FAULT;
 			color = <LED_COLOR_ID_RED>;
-		};
-
-		locator {
-			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
-			function = LED_FUNCTION_INDICATOR;
-			color = <LED_COLOR_ID_BLUE>;
 		};
 	};
 
@@ -61,260 +33,56 @@
 			linux,code = <KEY_RESTART>;
 		};
 	};
+};
 
-	/* i2c of the lower left SFP cage: port 25 */
-	i2c0: i2c-gpio-0 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio1 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio1 3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp0: sfp-p25 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c0>;
-		los-gpio = <&gpio1 1 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 23 GPIO_ACTIVE_LOW>;
-		tx-fault-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
-	};
-
-	/* i2c of the upper left SFP cage: port 26 */
-	i2c1: i2c-gpio-1 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio1 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio1 9 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp1: sfp-p26 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c1>;
-		los-gpio = <&gpio1 7 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 17 GPIO_ACTIVE_LOW>;
-		tx-fault-gpio = <&gpio1 6 GPIO_ACTIVE_HIGH>;
-	};
-
-	/* i2c of the lower right SFP cage: port 27 */
-	i2c2: i2c-gpio-2 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio1 15 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp2: sfp-p27 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c2>;
-		los-gpio = <&gpio1 13 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 13 GPIO_ACTIVE_LOW>;
-		tx-fault-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
-	};
-
-	/* i2c of the upper right SFP cage: port 28 */
-	i2c3: i2c-gpio-3 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio1 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio1 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-	};
-
-	sfp3: sfp-p28 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c3>;
-		los-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 20 GPIO_ACTIVE_LOW>;
-		tx-fault-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
-	};
-
-	/* i2c for hwmon/PoE */
-	i2c4: i2c-gpio-4 {
-		compatible = "i2c-gpio";
-		sda-gpios = <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		scl-gpios = <&gpio0 16 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
-		i2c-gpio,delay-us = <2>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		adt7468: adt7468@2e {
-			compatible = "adi,adt7468";
-			reg = <0x2e>;
-		};
+&i2c4 {
+	adt7468: adt7468@2e {
+		compatible = "adi,adt7468";
+		reg = <0x2e>;
 	};
 };
 
-&spi0 {
-	status = "okay";
-	flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <10000000>;
+&flash_partitions {
+	partition@20000 {
+		label = "reserved";
+		reg = <0x20000 0x90000>;
+		read-only;
+	};
 
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
+	partition@b0000 {
+		reg = <0xb0000 0xf50000>;
+		label = "factory";
 
-			partition@0 {
-				label = "bootbase";
-				reg = <0x0 0x20000>;
-				read-only;
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
 
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
+		partition@0 {
+			label = "loader";
+			reg = <0x0 0x10000>;
+		};
 
-					factory_macaddr: macaddr@1fff8 {
-						reg = <0x1fff8 0x6>;
-					};
-				};
-			};
-
-			partition@20000 {
-				label = "reserved";
-				reg = <0x20000 0x90000>;
-				read-only;
-			};
-
-			partition@b0000 {
-				reg = <0xb0000 0xf50000>;
-				label = "factory";
-
-				compatible = "fixed-partitions";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				partition@0 {
-					label = "loader";
-					reg = <0x0 0x10000>;
-				};
-
-				partition@10000 {
-					label = "firmware";
-					reg = <0x10000 0xf40000>;
-					compatible = "openwrt,uimage", "denx,uimage";
-				};
-			};
+		partition@10000 {
+			label = "firmware";
+			reg = <0x10000 0xf40000>;
+			compatible = "openwrt,uimage", "denx,uimage";
 		};
 	};
-};
-
-&ethernet0 {
-	nvmem-cells = <&factory_macaddr>;
-	nvmem-cell-names = "mac-address";
 };
 
 &mdio_bus0 {
-	/* External phy RTL8218B #1 */
-	EXTERNAL_PHY(0)
-	EXTERNAL_PHY(1)
-	EXTERNAL_PHY(2)
-	EXTERNAL_PHY(3)
-	EXTERNAL_PHY(4)
-	EXTERNAL_PHY(5)
-	EXTERNAL_PHY(6)
-	EXTERNAL_PHY(7)
-
-	/* External phy RTL8218B #2 */
-	EXTERNAL_PHY(8)
-	EXTERNAL_PHY(9)
-	EXTERNAL_PHY(10)
-	EXTERNAL_PHY(11)
-	EXTERNAL_PHY(12)
-	EXTERNAL_PHY(13)
-	EXTERNAL_PHY(14)
-	EXTERNAL_PHY(15)
-
-	/* External phy RTL8218B #3 */
-	EXTERNAL_PHY(16)
-	EXTERNAL_PHY(17)
-	EXTERNAL_PHY(18)
-	EXTERNAL_PHY(19)
-	EXTERNAL_PHY(20)
-	EXTERNAL_PHY(21)
-	EXTERNAL_PHY(22)
-	EXTERNAL_PHY(23)
-
 	/* External phy RTL8214FC #1 */
 	EXTERNAL_SFP_PHY_FULL(48, 0)
 	EXTERNAL_SFP_PHY_FULL(49, 1)
 	EXTERNAL_SFP_PHY_FULL(50, 2)
 	EXTERNAL_SFP_PHY_FULL(51, 3)
-
 };
 
 &switch0 {
 	ports {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		SWITCH_PORT_SDS(0, 1, 0, qsgmii)
-		SWITCH_PORT_SDS(1, 2, 0, qsgmii)
-		SWITCH_PORT_SDS(2, 3, 0, qsgmii)
-		SWITCH_PORT_SDS(3, 4, 0, qsgmii)
-		SWITCH_PORT_SDS(4, 5, 1, qsgmii)
-		SWITCH_PORT_SDS(5, 6, 1, qsgmii)
-		SWITCH_PORT_SDS(6, 7, 1, qsgmii)
-		SWITCH_PORT_SDS(7, 8, 1, qsgmii)
-
-		SWITCH_PORT_SDS(8, 9, 2, qsgmii)
-		SWITCH_PORT_SDS(9, 10, 2, qsgmii)
-		SWITCH_PORT_SDS(10, 11, 2, qsgmii)
-		SWITCH_PORT_SDS(11, 12, 2, qsgmii)
-		SWITCH_PORT_SDS(12, 13, 3, qsgmii)
-		SWITCH_PORT_SDS(13, 14, 3, qsgmii)
-		SWITCH_PORT_SDS(14, 15, 3, qsgmii)
-		SWITCH_PORT_SDS(15, 16, 3, qsgmii)
-
-		SWITCH_PORT_SDS(16, 17, 4, qsgmii)
-		SWITCH_PORT_SDS(17, 18, 4, qsgmii)
-		SWITCH_PORT_SDS(18, 19, 4, qsgmii)
-		SWITCH_PORT_SDS(19, 20, 4, qsgmii)
-		SWITCH_PORT_SDS(20, 21, 5, qsgmii)
-		SWITCH_PORT_SDS(21, 22, 5, qsgmii)
-		SWITCH_PORT_SDS(22, 23, 5, qsgmii)
-		SWITCH_PORT_SDS(23, 24, 5, qsgmii)
-
 		SWITCH_PORT_SDS(48, 25, 12, qsgmii)
 		SWITCH_PORT_SDS(49, 26, 12, qsgmii)
 		SWITCH_PORT_SDS(50, 27, 12, qsgmii)
 		SWITCH_PORT_SDS(51, 28, 12, qsgmii)
-
-		/* CPU-Port */
-		port@52 {
-			ethernet = <&ethernet0>;
-			reg = <52>;
-			phy-mode = "internal";
-			fixed-link {
-				speed = <1000>;
-				full-duplex;
-			};
-		};
-	};
-};
-
-&mdio_aux {
-	status = "okay";
-
-	gpio1: expander@3 {
-		compatible = "realtek,rtl8231";
-		reg = <3>;
-
-		gpio-controller;
-		#gpio-cells = <2>;
-		gpio-ranges = <&gpio1 0 0 37>;
-
-		led-controller {
-			compatible = "realtek,rtl8231-leds";
-			status = "disabled";
-		};
 	};
 };

--- a/target/linux/realtek/dts/rtl839x_zyxel_gs1920-24hp-common.dtsi
+++ b/target/linux/realtek/dts/rtl839x_zyxel_gs1920-24hp-common.dtsi
@@ -1,0 +1,247 @@
+/dts-v1/;
+
+#include "rtl839x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	leds {
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>;
+		compatible = "gpio-leds";
+
+		led_sys: sys {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+		};
+
+		locator {
+			gpios = <&gpio1 14 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_INDICATOR;
+			color = <LED_COLOR_ID_BLUE>;
+		};
+	};
+
+	/* i2c of port 25 SFP cage */
+	i2c0: i2c-gpio-0 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp0: sfp-p25 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		tx-fault-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c of port 26 SFP cage */
+	i2c1: i2c-gpio-1 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 9 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp1: sfp-p26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 17 GPIO_ACTIVE_LOW>;
+		tx-fault-gpio = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c of port 27 SFP cage */
+	i2c2: i2c-gpio-2 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 15 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp2: sfp-p27 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		tx-fault-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c of port 28 SFP cage */
+	i2c3: i2c-gpio-3 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio1 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio1 21 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	sfp3: sfp-p28 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 20 GPIO_ACTIVE_LOW>;
+		tx-fault-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
+	};
+
+	/* i2c for hwmon/PoE */
+	i2c4: i2c-gpio-4 {
+		compatible = "i2c-gpio";
+		sda-gpios = <&gpio0 18 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&gpio0 16 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		flash_partitions: partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootbase";
+				reg = <0x0 0x20000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					factory_macaddr: macaddr@1fff8 {
+						reg = <0x1fff8 0x6>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&factory_macaddr>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_bus0 {
+	/* External phy RTL8218B #1 */
+	EXTERNAL_PHY(0)
+	EXTERNAL_PHY(1)
+	EXTERNAL_PHY(2)
+	EXTERNAL_PHY(3)
+	EXTERNAL_PHY(4)
+	EXTERNAL_PHY(5)
+	EXTERNAL_PHY(6)
+	EXTERNAL_PHY(7)
+
+	/* External phy RTL8218B #2 */
+	EXTERNAL_PHY(8)
+	EXTERNAL_PHY(9)
+	EXTERNAL_PHY(10)
+	EXTERNAL_PHY(11)
+	EXTERNAL_PHY(12)
+	EXTERNAL_PHY(13)
+	EXTERNAL_PHY(14)
+	EXTERNAL_PHY(15)
+
+	/* External phy RTL8218B #3 */
+	EXTERNAL_PHY(16)
+	EXTERNAL_PHY(17)
+	EXTERNAL_PHY(18)
+	EXTERNAL_PHY(19)
+	EXTERNAL_PHY(20)
+	EXTERNAL_PHY(21)
+	EXTERNAL_PHY(22)
+	EXTERNAL_PHY(23)
+};
+
+&switch0 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_SDS(0, 1, 0, qsgmii)
+		SWITCH_PORT_SDS(1, 2, 0, qsgmii)
+		SWITCH_PORT_SDS(2, 3, 0, qsgmii)
+		SWITCH_PORT_SDS(3, 4, 0, qsgmii)
+		SWITCH_PORT_SDS(4, 5, 1, qsgmii)
+		SWITCH_PORT_SDS(5, 6, 1, qsgmii)
+		SWITCH_PORT_SDS(6, 7, 1, qsgmii)
+		SWITCH_PORT_SDS(7, 8, 1, qsgmii)
+
+		SWITCH_PORT_SDS(8, 9, 2, qsgmii)
+		SWITCH_PORT_SDS(9, 10, 2, qsgmii)
+		SWITCH_PORT_SDS(10, 11, 2, qsgmii)
+		SWITCH_PORT_SDS(11, 12, 2, qsgmii)
+		SWITCH_PORT_SDS(12, 13, 3, qsgmii)
+		SWITCH_PORT_SDS(13, 14, 3, qsgmii)
+		SWITCH_PORT_SDS(14, 15, 3, qsgmii)
+		SWITCH_PORT_SDS(15, 16, 3, qsgmii)
+
+		SWITCH_PORT_SDS(16, 17, 4, qsgmii)
+		SWITCH_PORT_SDS(17, 18, 4, qsgmii)
+		SWITCH_PORT_SDS(18, 19, 4, qsgmii)
+		SWITCH_PORT_SDS(19, 20, 4, qsgmii)
+		SWITCH_PORT_SDS(20, 21, 5, qsgmii)
+		SWITCH_PORT_SDS(21, 22, 5, qsgmii)
+		SWITCH_PORT_SDS(22, 23, 5, qsgmii)
+		SWITCH_PORT_SDS(23, 24, 5, qsgmii)
+
+		/* CPU-Port */
+		port@52 {
+			ethernet = <&ethernet0>;
+			reg = <52>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&mdio_aux {
+	status = "okay";
+
+	gpio1: expander@3 {
+		compatible = "realtek,rtl8231";
+		reg = <3>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio1 0 0 37>;
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -129,3 +129,12 @@ define Device/zyxel_gs1920-24hp-v1
   DEVICE_VARIANT := v1
 endef
 TARGET_DEVICES += zyxel_gs1920-24hp-v1
+
+define Device/zyxel_gs1920-24hp-v2
+  $(Device/zyxel_gs1920-24hp)
+  SOC := rtl8391
+  FLASH_ADDR := 0xb4210000
+  IMAGE_SIZE := 30720k
+  DEVICE_VARIANT := v2
+endef
+TARGET_DEVICES += zyxel_gs1920-24hp-v2

--- a/target/linux/realtek/image/rtl839x.mk
+++ b/target/linux/realtek/image/rtl839x.mk
@@ -98,19 +98,15 @@ define Device/zyxel_gs1900-48-a1
 endef
 TARGET_DEVICES += zyxel_gs1900-48-a1
 
-define Device/zyxel_gs1920-24hp-v1
-  FLASH_ADDR := 0xb40c0000
+define Device/zyxel_gs1920-24hp
 ifeq ($(IB),)
   ARTIFACTS := loader.bin
   ARTIFACT/loader.bin := \
     rt-loader-standalone | \
     zynsig
 endif
-  SOC := rtl8392
-  IMAGE_SIZE := 12144k
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := GS1920-24HP
-  DEVICE_VARIANT := v1
   DEVICE_PACKAGES := \
 	  kmod-hwmon-lm85
   KERNEL := \
@@ -123,5 +119,13 @@ endif
     append-dtb | \
     rt-compress | \
     rt-loader
+endef
+
+define Device/zyxel_gs1920-24hp-v1
+  $(Device/zyxel_gs1920-24hp)
+  SOC := rtl8392
+  FLASH_ADDR := 0xb40c0000
+  IMAGE_SIZE := 12144k
+  DEVICE_VARIANT := v1
 endef
 TARGET_DEVICES += zyxel_gs1920-24hp-v1


### PR DESCRIPTION
This series adds support for Zyxel GS1920-24HPv2 which has some differences compared to v1:
 * RTL8391M SoC
 * 256MiB RAM
 * 32MiB Flash (and different partition layout)
 * RTL8214FC uses different port numbers
 * SFP 25 and 26 use a shared SCL
 * SFP 27 and 28 use different SDA
 * LM96000 hardware monitor instead of ADT7468
 * console uses 115200 8N1 by default

Common stuff is moved to a common DTSI and device definition too.