### PR TITLE
mvebu: cortex-a53: respect DEVICE_packages for Methode devices

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -117,6 +117,7 @@ fs-types-$(CONFIG_TARGET_ROOTFS_JFFS2_NAND) += $(addprefix jffs2-nand-,$(NAND_BL
 fs-types-$(CONFIG_TARGET_ROOTFS_EXT4FS) += ext4
 fs-types-$(CONFIG_TARGET_ROOTFS_UBIFS) += ubifs
 fs-types-$(CONFIG_TARGET_ROOTFS_EROFS) += erofs
+fs-types-$(CONFIG_TARGET_ROOTFS_TARGZ) += targz
 fs-subtypes-$(CONFIG_TARGET_ROOTFS_JFFS2) += $(addsuffix -raw,$(addprefix jffs2-,$(JFFS2_BLOCKSIZE)))
 
 TARGET_FILESYSTEMS := $(fs-types-y)
@@ -327,6 +328,12 @@ define Image/mkfs/erofs
 	env -u SOURCE_DATE_EPOCH $(STAGING_DIR_HOST)/bin/mkfs.erofs -z$(EROFSCOMP) \
 		-C$(EROFS_PCLUSTERSIZE) $(EROFSOPT) \
 		$@ $(call mkfs_target_dir,$(1))
+endef
+
+define Image/mkfs/targz
+	$(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
+		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
+		-C $(call mkfs_target_dir,$(1)) . | gzip -9n > $@
 endef
 
 define Image/Manifest

--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -139,14 +139,12 @@ endef
 define Build/uDPU-firmware
 	(rm -fR $@-fw; mkdir -p $@-fw)
 	$(CP) $(BIN_DIR)/$(DEVICE_IMG_PREFIX)-initramfs.itb $@-fw/recovery.itb
+	$(CP) $(IMAGE_ROOTFS) $@-fw/rootfs.tgz
 	$(CP) $@-boot.scr $@-fw/boot.scr
-	$(TAR) -cvzp --numeric-owner --owner=0 --group=0 --sort=name \
-		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
-		-f $@-fw/rootfs.tgz -C $(TARGET_DIR) .
-	$(TAR) -cvzp --numeric-owner --owner=0 --group=0 --sort=name \
+	$(TAR) -czp --numeric-owner --owner=0 --group=0 --sort=name \
 		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
 		-f $@-fw/boot.tgz -C $@.boot .
-	$(TAR) -cvzp --numeric-owner --owner=0 --group=0 --sort=name \
+	$(TAR) -czp --numeric-owner --owner=0 --group=0 --sort=name \
 		$(if $(SOURCE_DATE_EPOCH),--mtime="@$(SOURCE_DATE_EPOCH)") \
 		-f $(KDIR_TMP)/$(DEVICE_IMG_PREFIX)-firmware.tgz -C $@-fw .
 endef

--- a/target/linux/mvebu/image/cortexa53.mk
+++ b/target/linux/mvebu/image/cortexa53.mk
@@ -103,6 +103,7 @@ define Device/methode_udpu
   KERNEL_INITRAMFS_SUFFIX := .itb
   DEVICE_PACKAGES += f2fs-tools fdisk kmod-i2c-pxa kmod-hwmon-lm75 kmod-dsa-mv88e6xxx
   DEVICE_IMG_NAME = $$(DEVICE_IMG_PREFIX)-$$(2)
+  FILESYSTEMS := targz
   IMAGES := firmware.tgz
   IMAGE/firmware.tgz := boot-scr | boot-img-ext4 | uDPU-firmware | append-metadata
   BOOT_SCRIPT := udpu


### PR DESCRIPTION
Currently, buildbot-generated images for Methode devices are effectively broken as they have no networking, LM75, nor I2C kmods included.

This is happening because the recipe for generating the custom sysupgrade tarball, as this device uses F2FS directly, uses `$(TARGET_DIR)` as the rootfs directory.

However, this works only when building for a single device, as then the required kmods are part of the target rootfs in `$(TARGET_DIR)`, but as soon as multiple devices are chosen and per-device rootfs is enabled, then the kmods listed in DEVICE_PACKAGES are not present anymore, as the rootfs in `$(TARGET_DIR)` is universal for the subtarget.

So, we expand existing `CONFIG_TARGET_ROOTFS_TARGZ` support by adding it as a proper fs-type, so that buildsystem generates a per device rootfs under a lock that respects `DEVICE_PACKAGES` like for other filesystems, and then we can use that rootfs tarball directly in the device recipe for assembling the custom tarball.