### PR TITLE
lantiq: handle EPROBE_DEFER for MAC

### DIFF
--- a/target/linux/lantiq/patches-6.12/028-NET-lantiq-various-etop-fixes.patch
+++ b/target/linux/lantiq/patches-6.12/028-NET-lantiq-various-etop-fixes.patch
@@ -766,7 +766,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
  	if (!res) {
-@@ -671,18 +872,54 @@ ltq_etop_probe(struct platform_device *p
+@@ -671,18 +872,60 @@ ltq_etop_probe(struct platform_device *p
  		goto err_out;
  	}
  
@@ -805,7 +805,13 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
 +	if (err)
 +		pr_err("Can't find phy-mode for port\n");
 +
-+	of_get_mac_address(pdev->dev.of_node, priv->mac);
++	err = of_get_mac_address(pdev->dev.of_node, priv->mac);
++	if (err == -EPROBE_DEFER)
++		goto err_out;
++	if (err) {
++		eth_hw_addr_random(dev);
++		dev_err(&pdev->dev, "generated random MAC address %pM\n", priv->mac);
++	}
 +
 +	priv->clk_ppe = clk_get(&pdev->dev, NULL);
 +	if (IS_ERR(priv->clk_ppe))
@@ -827,7 +833,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  	spin_lock_init(&priv->lock);
  	SET_NETDEV_DEV(dev, &pdev->dev);
  
-@@ -698,15 +935,10 @@ ltq_etop_probe(struct platform_device *p
+@@ -698,15 +941,10 @@ ltq_etop_probe(struct platform_device *p
  		goto err_free;
  	}
  
@@ -847,7 +853,7 @@ Signed-off-by: John Crispin <blogic@openwrt.org>
  
  	err = register_netdev(dev);
  	if (err)
-@@ -733,31 +965,22 @@ static void ltq_etop_remove(struct platf
+@@ -733,31 +971,22 @@ static void ltq_etop_remove(struct platf
  	}
  }
  


### PR DESCRIPTION
If nvmem is used for ethernet mac address, we need to defer loading to get the proper mac.

ping @hkallweit

I know you wanted to move the etop driver to be local to openwrt.