### PR TITLE
tools/packages: fix a few build problems on Alpine Linux

### DIFF
--- a/package/boot/arm-trusted-firmware-tools/Makefile
+++ b/package/boot/arm-trusted-firmware-tools/Makefile
@@ -29,10 +29,16 @@ define Package/arm-trusted-firmware-tools
   BUILDONLY:=1
 endef
 
+ifeq ($(shell uname -s),Linux)
+	HOST_MUSL_FLAG:=$(shell [ "$$(2>&1 ldd --version | head -n 1 | cut -d ' ' -f1)" = "musl" ] && echo " -D__MUSL__")
+else
+	HOST_MUSL_FLAG:=
+endif
+
 define Host/Compile
 	$(MAKE) -C \
 		$(HOST_BUILD_DIR)/tools/fiptool \
-		CPPFLAGS="$(HOST_CFLAGS)" \
+		CPPFLAGS="$(HOST_CFLAGS)$(HOST_MUSL_FLAG)" \
 		LDFLAGS="$(HOST_LDFLAGS)" \
 		OPENSSL_DIR="$(STAGING_DIR_HOST)"
 endef

--- a/package/boot/arm-trusted-firmware-tools/patches/003-fiptool_musl_fix.patch
+++ b/package/boot/arm-trusted-firmware-tools/patches/003-fiptool_musl_fix.patch
@@ -1,0 +1,14 @@
+--- a/tools/fiptool/fiptool.c
++++ b/tools/fiptool/fiptool.c
+@@ -318,7 +318,11 @@
+ 
+ #ifdef BLKGETSIZE64
+ 	if ((st.st_mode & S_IFBLK) != 0)
++#ifdef __MUSL__
++		if (ioctl(fileno(fp), (int)BLKGETSIZE64, &st_size) == -1)
++#else
+ 		if (ioctl(fileno(fp), BLKGETSIZE64, &st_size) == -1)
++#endif
+ 			log_err("ioctl %s", filename);
+ #endif
+ 

--- a/package/network/utils/nftables/patches/001-for-bash-syntax.patch
+++ b/package/network/utils/nftables/patches/001-for-bash-syntax.patch
@@ -1,0 +1,11 @@
+--- a/configure
++++ b/configure
+@@ -17940,7 +17940,7 @@
+ 	echo "	${STABLE_RELEASE}"
+ 	echo "};"
+ 	echo "static char nftbuildstamp[] = {"
+-	for ((i = 56; i >= 0; i-= 8)); do
++	for i in `seq 56 -8 0`; do
+ 		echo "	((uint64_t)MAKE_STAMP >> $i) & 0xff,"
+ 	done
+ 	echo "};"

--- a/tools/bc/patches/001-getopt-declaration.patch
+++ b/tools/bc/patches/001-getopt-declaration.patch
@@ -1,0 +1,11 @@
+--- a/lib/getopt.c
++++ b/lib/getopt.c
+@@ -197,7 +197,7 @@ static char *posixly_correct;
+    whose names are inconsistent.  */
+ 
+ #ifndef getenv
+-extern char *getenv ();
++extern char *getenv (const char *);
+ #endif
+ 
+ #endif /* not __GNU_LIBRARY__ */


### PR DESCRIPTION
Alpine Linux is listed as a supported build host [in the Wiki](https://openwrt.org/docs/guide-developer/toolchain/install-buildsystem#alpine), yet building OpenWrt in Alpine Linux isn't working anymore for a few years already.

Given that OpenWrt is now even using Alpine's package manager, it's a bit embarrassing that OpenWrt itself can't be built using Alpine Linux. Especially since the fixes to make it work are rather trivial.

This PR provides a few patches in order to make it possible again to build OpenWrt on an Alpine Linux build host (at least for the targets I'm usually building).

The following patches are included:

- **arm-trusted-firmware-tools: "ioctl" type cast**
Related issue: #13339
MUSL LibC declares `ioctl(int,int,...)`, while (all?) other Linux LibC declare it as `ioctl(int,unsigned long,...)`. This causes a warning when compiling under Alpine, which for OpenWrt in particular, breaks compilation due to `-Werror` and `-pedantic` switches.
The "fix" I suggested in [#13339](https://github.com/openwrt/openwrt/issues/13339#issuecomment-3847294158) (unconditional cast to `int`) is the official Alpine patch. While being ridiculously simple and unlikely to break anything, even in other distros, it's more of a crude workaround, imo. So for this PR, I tried to limit the type cast to only MUSL based hosts. Since MUSL doesn't provide a predefined macro for detection (like e.g. `__GLIBC__`), I'm detecting MUSL by scraping the `ldd --version` output, which seems to be a more or less widely accepted method.
- **nftables: bash-style "for" loop in `configure`**
Numeric `for` loops are a bashism and won't work in Alpine's BusyBox. Replace with a portable equivalent. This was apparently also fixed in nftables already in a commit after 1.1.6 (went by me unnoticed, but my fix is identical anyway).
- **bc: "getenv()" declaration in "getopt.c"**
This is already fixed in bc 1.08.2, but OpenWrt is currently using 1.08.1. Backport the fix for the time being.

PR applies to Main as well as 25.12.
Fixes: #13339 