### PR TITLE
x86: base-files add support for Sophos 210r3 and 230r2

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -127,8 +127,9 @@ sophos-sg-135r3|sophos-xg-135r3| \
 sophos-sg-135wr3|sophos-xg-135wr3)
 	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth5 eth7 eth8" "eth6"
 	;;
-sophos-xg-210r3)
-	ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5 eth6 eth7" "eth0"
+sophos-sg-210r3|sophos-xg-210r3| \
+sophos-sg-230r2|sophox-xg-230r2)
+	ucidef_set_interfaces_lan_wan "eth0 eth2 eth3 eth4 eth5" "eth1"
 	;;
 supermicro-sys-e302-9d)
 	ucidef_set_interface_lan "eth0 eth1 eth2 eth3 eth4 eth5 eth6 eth7"

--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -38,7 +38,9 @@ do_sysinfo_x86() {
 			local product_version
 			product_version="$(cat /sys/devices/virtual/dmi/id/product_version 2>/dev/null)"
 			case "$product_version" in
-			105*|115*|125*|135*|85*|86*)
+			105*|106*|115*|125*|135*| \
+			210*|230*|310*|330*|430*|450*| \
+			550*|650*|750*|85*|86*)
 				product="${product}-${product_version}"
 				break
 				;;


### PR DESCRIPTION
This fixes a previous commit for Sophos XG 210r3 which was missing board_name mapping and adds support for the SG related version and the XG/SG 230r2 which is the same hardware with a faster processor.

Sophos board_name mapping was modified to support all Sophos SG/XG devices.

Sophos SG/XG 210r3 and SG/XG 230r2 are rackmounted x86 based firewall with 6 RJ-45 gigabit ethernet ports (eth0-5) and 2 SFP gigabit ethernet ports (eth6, eth7) all running Intel NICs supported by igb driver. The 210r3 and 230r2 only differ in the processor used.  This board update maps eth1 (marked as WAN) as wan and eth0 and eth2-5 as lan.  Leaving the two SFP ports unmapped.

Signed-off-by: Raylynn Knight <rayknight@me.com>