### PR TITLE
ramips: mt7621: add support for TP-Link ER605 v1

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -136,6 +136,19 @@ mtd_get_mac_encrypted_deco() {
 	echo $macaddr
 }
 
+mtd_get_mac_uci_config() {
+	local mtdname="$1"
+	local part
+
+	part=$(find_mtd_part "$mtdname")
+	if [ -z "$part" ]; then
+		echo "mtd_get_mac_uci_config: partition $mtdname not found!" >&2
+		return
+	fi
+
+	cat "$part" | sed -n 's/^\s*option macaddr\s*'"'"'\?\([0-9A-F:]\+\)'"'"'\?/\1/Ip'
+}
+
 mtd_get_mac_uci_config_ubi() {
 	local volumename="$1"
 

--- a/target/linux/ramips/dts/mt7621_tplink_er605-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_er605-v1.dts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "TP-Link ER605 v1";
+	compatible = "tplink,er605-v1", "mediatek,mt7621-soc";
+
+	chosen {
+		bootargs = "console=ttyS0,115200 noinitrd";
+		// Override bootargs because u-boot passes wrong root parameter.
+		// Instead allow kernel determine root automatically by looking for rootfs volume
+		bootargs-override = "console=ttyS0,115200 noinitrd";
+	};
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &gmac0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led_system: system {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			default-state = "keep";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset button";
+			gpios = <&gpio 8 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+};
+
+&gmac0 {
+	label = "dsa";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan1";
+	phy-handle = <&ethphy0>;
+};
+
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "disabled";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan5";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bootloader";
+				reg = <0x0 0x40000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "bootloader-fs";
+				reg = <0x40000 0x30000>;
+				read-only;
+			};
+
+			partition@70000 {
+				label = "extra-para";
+				reg = <0x70000 0x10000>;
+				read-only;
+			};
+
+			partition@80000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x80000 0xd70000>;
+			};
+
+			partition@df0000 {
+				label = "panic-oops";
+				reg = <0xdf0000 0x20000>;
+				read-only;
+			};
+
+			partition@e10000 {
+				label = "partition-table";
+				reg = <0xe10000 0x10000>;
+				read-only;
+			};
+
+			partition@e20000 {
+				label = "device-info";
+				reg = <0xe20000 0x10000>;
+				read-only;
+			};
+
+			partition@e30000 {
+				label = "support-list";
+				reg = <0xe30000 0x10000>;
+				read-only;
+			};
+
+			partition@e40000 {
+				label = "firmware-info";
+				reg = <0xe40000 0x10000>;
+				read-only;
+			};
+
+			partition@e50000 {
+				label = "tddp";
+				reg = <0xe50000 0x10000>;
+				read-only;
+			};
+
+			partition@e60000 {
+				label = "log";
+				reg = <0xe60000 0x20000>;
+				read-only;
+			};
+
+			partition@e80000 {
+				label = "rootfs_data_back";
+				reg = <0xe80000 0x180000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "pcie", "jtag";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3125,6 +3125,16 @@ define Device/tplink_ec330-g5u-v1
 endef
 TARGET_DEVICES += tplink_ec330-g5u-v1
 
+define Device/tplink_er605-v1
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := ER605
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := -wpad-basic-mbedtls -uboot-envtools
+  IMAGE_SIZE := 13760k
+endef
+TARGET_DEVICES += tplink_er605-v1
+
 define Device/tplink_er605-v2
   $(Device/nand)
   DEVICE_COMPAT_VERSION := 1.2

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -170,6 +170,7 @@ ramips_setup_interfaces()
 	tplink,eap615-wall-v1)
 		ucidef_set_interface_lan "lan0 lan1 lan2 lan3"
 		;;
+	tplink,er605-v1|\
 	tplink,er605-v2)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4 lan5" "wan1"
 		;;
@@ -272,6 +273,11 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii Config lan_hwaddr)
 		wan_mac=$(mtd_get_mac_ascii Config wan_hwaddr)
 		label_mac=$lan_mac
+		;;
+	tplink,er605-v1)
+		label_mac=$(mtd_get_mac_uci_config "tddp")
+		lan_mac=$label_mac
+		wan_mac=$(macaddr_add "$label_mac" 1)
 		;;
 	tplink,er605-v2)
 		CI_UBIPART="firmware"


### PR DESCRIPTION
This commit adds support for TP-Link ER605 v1.

Hardware specifications:
- CPU: MediaTek MT7621DAT (880 MHz, 2 cores)
- CPU type: MIPS 1004Kc
- Flash: 16 MiB (GigaDevice GD25Q127CSIG)
- RAM: 128 MiB
- LAN speed: 1GbE
- LAN ports: 4
- WAN speed: 1GbE
- WAN ports: 1
- Serial: 4-pin header, unpopulated, 3.3V TTL, (115200 8N1)
- Power: 9 VDC, 0.85 A
- LEDs: Power (Green), System (Green)
- Button: RESET

Factory firmware (v1.2.0 Build 20220114 Rel.76871):
```
root@ER605:~# ubus call system board
{
	"kernel": "3.10.108",
	"hostname": "ER605",
	"system": "MT7621",
	"model": "mtk-apsoc-demo",
	"release": {
		"distribution": "OpenWrt",
		"version": "Barrier Breaker",
		"revision": "unknown",
		"codename": "barrier_breaker",
		"target": "ramips\/generic",
		"description": "OpenWrt Barrier Breaker 14.07"
	}
}
```

Factory partitions:
```
0x000000000000-0x000000040000 : "bootloader"
0x000000040000-0x000000070000 : "bootloader-fs"
0x000000070000-0x000000080000 : "extra-para"
0x000000080000-0x000000200000 : "kernel"
0x000000200000-0x000000df0000 : "rootfs"
0x000000df0000-0x000000e10000 : "panic-oops"
0x000000e10000-0x000000e20000 : "partition-table"
0x000000e20000-0x000000e30000 : "device-info"
0x000000e30000-0x000000e40000 : "support-list"
0x000000e40000-0x000000e50000 : "firmware-info"
0x000000e50000-0x000000e60000 : "tddp"
0x000000e60000-0x000000e80000 : "log"
0x000000e80000-0x000001000000 : "rootfs_data"
0x000000000000-0x000001000000 : "firmware"
```

New OpenWrt partitions:
```
...
0x000000080000-0x000000df0000 : "firmware"
...
0x000000e80000-0x000001000000 : "rootfs_data_back"
```

MAC addresses:
 - label/LAN = `option macaddr` from factory `tddp` partition
 - WAN = label MAC + 1

Installation:
Split initramfs into 2 parts for writing to the kernel and rootfs
partitions on live device, leave http server up for sysupgrade.

```
dd if=initramfs-kernel.bin of=kernel-part.bin bs=64k count=24
dd if=initramfs-kernel.bin of=rootfs-part.bin bs=64k skip=24
md5sum kernel-part.bin rootfs-part.bin
python3 -m http.server -d . 8080
```

Downgrade to TP-Link firmware v1.3.1 or less if running v1.3.2.

From the web UI, open "System Tools" and select "Diagnostics".
Enable "Remote Assistance" and login as root.

```
tplink_label_mac=01:23:45:67:89:AB
tplink_username=admin
echo -n "$tplink_label_mac$tplink_username" | md5sum | cut -c1-16
ssh \
  -o "KexAlgorithms=+diffie-hellman-group1-sha1" \
  -o "HostKeyAlgorithms=+ssh-rsa" \
  root@192.168.0.1
```

Download partial initramfs binaries to /tmp and verify checksums match.

```
cd /tmp
wget http://192.168.0.20:8080/kernel-part.bin
wget http://192.168.0.20:8080/rootfs-part.bin
md5sum kernel-part.bin rootfs-part.bin
```

Write partial initramfs binaries to kernel and rootfs.

```
mtd -e kernel write kernel-part.bin kernel
mtd -r -e rootfs write rootfs-part.bin rootfs
```

Login to OpenWrt initramfs as root.

```
ssh root@192.168.1.1
```

Erase firmware partition and perform sysupgrade.

```
mtd erase firmware
sysupgrade -n -p http://192.168.1.111:8080/squashfs-sysupgrade.bin
```

Signed-off-by: Charles Joynson <ctjoynson@gmail.com>