### PR TITLE
realtek: switch HPE 1920 series to NVMEM

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -62,6 +62,7 @@ realtek_setup_macs()
 		lan_mac=$(get_mac_label)
 		lan_mac_start=$lan_mac
 		;;
+	hasivo,s1100wp-8gt-se|\
 	hpe,1920-8g|\
 	hpe,1920-8g-poe-65w|\
 	hpe,1920-8g-poe-180w|\
@@ -70,16 +71,7 @@ realtek_setup_macs()
 	hpe,1920-24g-poe-180w|\
 	hpe,1920-24g-poe-370w|\
 	hpe,1920-48g|\
-	hpe,1920-48g-poe)
-		label_mac=$(mtd_get_mac_binary factory 0x68)
-		lan_mac=$label_mac
-		eth0_mac=$lan_mac
-		mac_count1=$(hexdump -v -n 4 -s 0x110 -e '4 "%d"' $(find_mtd_part factory) 2>/dev/null)
-		mac_count2=$(hexdump -v -n 4 -s 0x114 -e '4 "%d"' $(find_mtd_part factory) 2>/dev/null)
-		lan_mac_start=$(macaddr_add $lan_mac 2)
-		lan_mac_end=$(macaddr_add $lan_mac $((mac_count2-mac_count1)))
-		;;
-	hasivo,s1100wp-8gt-se|\
+	hpe,1920-48g-poe|\
 	plasmacloud,esx28|\
 	plasmacloud,mcx3|\
 	plasmacloud,psx8|\

--- a/target/linux/realtek/dts/rtl8380_hpe_1920-8g.dtsi
+++ b/target/linux/realtek/dts/rtl8380_hpe_1920-8g.dtsi
@@ -89,6 +89,9 @@
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp0>;
+
+			nvmem-cells = <&macaddr_factory 10>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		port@26 {
@@ -98,6 +101,9 @@
 			phy-mode = "1000base-x";
 			managed = "in-band-status";
 			sfp = <&sfp1>;
+
+			nvmem-cells = <&macaddr_factory 11>;
+			nvmem-cell-names = "mac-address";
 		};
 
 		port@28 {
@@ -110,4 +116,44 @@
 			};
 		};
 	};
+};
+
+&port8 {
+	nvmem-cells = <&macaddr_factory 2>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port9 {
+	nvmem-cells = <&macaddr_factory 3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port10 {
+	nvmem-cells = <&macaddr_factory 4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port11 {
+	nvmem-cells = <&macaddr_factory 5>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port12 {
+	nvmem-cells = <&macaddr_factory 6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port13 {
+	nvmem-cells = <&macaddr_factory 7>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port14 {
+	nvmem-cells = <&macaddr_factory 8>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port15 {
+	nvmem-cells = <&macaddr_factory 9>;
+	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/realtek/dts/rtl8382_hpe_1920-16g.dts
+++ b/target/linux/realtek/dts/rtl8382_hpe_1920-16g.dts
@@ -46,3 +46,103 @@
 		};
 	};
 };
+
+&port8 {
+	nvmem-cells = <&macaddr_factory 2>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port9 {
+	nvmem-cells = <&macaddr_factory 3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port10 {
+	nvmem-cells = <&macaddr_factory 4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port11 {
+	nvmem-cells = <&macaddr_factory 5>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port12 {
+	nvmem-cells = <&macaddr_factory 6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port13 {
+	nvmem-cells = <&macaddr_factory 7>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port14 {
+	nvmem-cells = <&macaddr_factory 8>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port15 {
+	nvmem-cells = <&macaddr_factory 9>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port16 {
+	nvmem-cells = <&macaddr_factory 10>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port17 {
+	nvmem-cells = <&macaddr_factory 11>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port18 {
+	nvmem-cells = <&macaddr_factory 12>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port19 {
+	nvmem-cells = <&macaddr_factory 13>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port20 {
+	nvmem-cells = <&macaddr_factory 14>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port21 {
+	nvmem-cells = <&macaddr_factory 15>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port22 {
+	nvmem-cells = <&macaddr_factory 16>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port23 {
+	nvmem-cells = <&macaddr_factory 17>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port24 {
+	nvmem-cells = <&macaddr_factory 18>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port25 {
+	nvmem-cells = <&macaddr_factory 19>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port26 {
+	nvmem-cells = <&macaddr_factory 20>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port27 {
+	nvmem-cells = <&macaddr_factory 21>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/realtek/dts/rtl8382_hpe_1920-24g.dtsi
+++ b/target/linux/realtek/dts/rtl8382_hpe_1920-24g.dtsi
@@ -66,3 +66,143 @@
 		};
 	};
 };
+
+&port0 {
+	nvmem-cells = <&macaddr_factory 2>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port1 {
+	nvmem-cells = <&macaddr_factory 3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port2 {
+	nvmem-cells = <&macaddr_factory 4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port3 {
+	nvmem-cells = <&macaddr_factory 5>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port4 {
+	nvmem-cells = <&macaddr_factory 6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port5 {
+	nvmem-cells = <&macaddr_factory 7>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port6 {
+	nvmem-cells = <&macaddr_factory 8>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port7 {
+	nvmem-cells = <&macaddr_factory 9>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port8 {
+	nvmem-cells = <&macaddr_factory 10>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port9 {
+	nvmem-cells = <&macaddr_factory 11>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port10 {
+	nvmem-cells = <&macaddr_factory 12>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port11 {
+	nvmem-cells = <&macaddr_factory 13>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port12 {
+	nvmem-cells = <&macaddr_factory 14>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port13 {
+	nvmem-cells = <&macaddr_factory 15>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port14 {
+	nvmem-cells = <&macaddr_factory 16>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port15 {
+	nvmem-cells = <&macaddr_factory 17>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port16 {
+	nvmem-cells = <&macaddr_factory 18>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port17 {
+	nvmem-cells = <&macaddr_factory 19>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port18 {
+	nvmem-cells = <&macaddr_factory 20>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port19 {
+	nvmem-cells = <&macaddr_factory 21>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port20 {
+	nvmem-cells = <&macaddr_factory 22>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port21 {
+	nvmem-cells = <&macaddr_factory 23>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port22 {
+	nvmem-cells = <&macaddr_factory 24>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port23 {
+	nvmem-cells = <&macaddr_factory 25>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port24 {
+	nvmem-cells = <&macaddr_factory 26>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port25 {
+	nvmem-cells = <&macaddr_factory 27>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port26 {
+	nvmem-cells = <&macaddr_factory 28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port27 {
+	nvmem-cells = <&macaddr_factory 29>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/realtek/dts/rtl8393_hpe_1920-48g-poe.dts
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920-48g-poe.dts
@@ -106,6 +106,26 @@
 	};
 };
 
+&port48 {
+	nvmem-cells = <&macaddr_factory 50>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port49 {
+	nvmem-cells = <&macaddr_factory 51>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port50 {
+	nvmem-cells = <&macaddr_factory 52>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port51 {
+	nvmem-cells = <&macaddr_factory 53>;
+	nvmem-cell-names = "mac-address";
+};
+
 &uart1 {
 	status = "okay";
 };

--- a/target/linux/realtek/dts/rtl8393_hpe_1920-48g.dts
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920-48g.dts
@@ -96,3 +96,23 @@
 		SWITCH_PORT_SDS(51, 51, 12, qsgmii)
 	};
 };
+
+&port48 {
+	nvmem-cells = <&macaddr_factory 51>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port49 {
+	nvmem-cells = <&macaddr_factory 53>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port50 {
+	nvmem-cells = <&macaddr_factory 50>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port51 {
+	nvmem-cells = <&macaddr_factory 52>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/realtek/dts/rtl8393_hpe_1920.dtsi
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920.dtsi
@@ -150,3 +150,243 @@
 		};
 	};
 };
+
+&port0 {
+	nvmem-cells = <&macaddr_factory 2>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port1 {
+	nvmem-cells = <&macaddr_factory 3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port2 {
+	nvmem-cells = <&macaddr_factory 4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port3 {
+	nvmem-cells = <&macaddr_factory 5>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port4 {
+	nvmem-cells = <&macaddr_factory 6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port5 {
+	nvmem-cells = <&macaddr_factory 7>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port6 {
+	nvmem-cells = <&macaddr_factory 8>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port7 {
+	nvmem-cells = <&macaddr_factory 9>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port8 {
+	nvmem-cells = <&macaddr_factory 10>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port9 {
+	nvmem-cells = <&macaddr_factory 11>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port10 {
+	nvmem-cells = <&macaddr_factory 12>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port11 {
+	nvmem-cells = <&macaddr_factory 13>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port12 {
+	nvmem-cells = <&macaddr_factory 14>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port13 {
+	nvmem-cells = <&macaddr_factory 15>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port14 {
+	nvmem-cells = <&macaddr_factory 16>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port15 {
+	nvmem-cells = <&macaddr_factory 17>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port16 {
+	nvmem-cells = <&macaddr_factory 18>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port17 {
+	nvmem-cells = <&macaddr_factory 19>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port18 {
+	nvmem-cells = <&macaddr_factory 20>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port19 {
+	nvmem-cells = <&macaddr_factory 21>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port20 {
+	nvmem-cells = <&macaddr_factory 22>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port21 {
+	nvmem-cells = <&macaddr_factory 23>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port22 {
+	nvmem-cells = <&macaddr_factory 24>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port23 {
+	nvmem-cells = <&macaddr_factory 25>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port24 {
+	nvmem-cells = <&macaddr_factory 26>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port25 {
+	nvmem-cells = <&macaddr_factory 27>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port26 {
+	nvmem-cells = <&macaddr_factory 28>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port27 {
+	nvmem-cells = <&macaddr_factory 29>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port28 {
+	nvmem-cells = <&macaddr_factory 30>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port29 {
+	nvmem-cells = <&macaddr_factory 31>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port30 {
+	nvmem-cells = <&macaddr_factory 32>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port31 {
+	nvmem-cells = <&macaddr_factory 33>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port32 {
+	nvmem-cells = <&macaddr_factory 34>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port33 {
+	nvmem-cells = <&macaddr_factory 35>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port34 {
+	nvmem-cells = <&macaddr_factory 36>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port35 {
+	nvmem-cells = <&macaddr_factory 37>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port36 {
+	nvmem-cells = <&macaddr_factory 38>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port37 {
+	nvmem-cells = <&macaddr_factory 39>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port38 {
+	nvmem-cells = <&macaddr_factory 40>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port39 {
+	nvmem-cells = <&macaddr_factory 41>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port40 {
+	nvmem-cells = <&macaddr_factory 42>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port41 {
+	nvmem-cells = <&macaddr_factory 43>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port42 {
+	nvmem-cells = <&macaddr_factory 44>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port43 {
+	nvmem-cells = <&macaddr_factory 45>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port44 {
+	nvmem-cells = <&macaddr_factory 46>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port45 {
+	nvmem-cells = <&macaddr_factory 47>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port46 {
+	nvmem-cells = <&macaddr_factory 48>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port47 {
+	nvmem-cells = <&macaddr_factory 49>;
+	nvmem-cell-names = "mac-address";
+};

--- a/target/linux/realtek/dts/rtl83xx_hpe_1920.dtsi
+++ b/target/linux/realtek/dts/rtl83xx_hpe_1920.dtsi
@@ -8,6 +8,10 @@
 		stdout-path = "serial0:38400n8";
 	};
 
+	aliases {
+		label-mac-device = &ethernet0;
+	};
+
 	memory@0 {
 		device_type = "memory";
 		reg = <0x0 0x8000000>;
@@ -24,6 +28,11 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&pinmux_disable_sys_led>;
 	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_factory 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &watchdog0 {
@@ -90,6 +99,18 @@
 				label = "factory";
 				reg = <0x1ff0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_factory: macaddr@68 {
+						compatible = "mac-base";
+						reg = <0x68 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 		};
 	};


### PR DESCRIPTION
The MAC addresses for eth0 and the individual LAN ports are now configured via device tree. The assignment itself stays the same as before, matching factory firmware.

The 02_network script still sets the bridge MAC address, as it is different from the lowest port MAC address.

Tested on:
- HPE 1920-8G (JG920A)
- HPE 1920-24G (JG924A)
- HPE 1920-48G (JG927A)