### PR TITLE
ramips: dir-3040-a1: fix MAC address assignment

### DIFF
--- a/target/linux/ramips/dts/mt7621_dlink_dir-3040-a1.dts
+++ b/target/linux/ramips/dts/mt7621_dlink_dir-3040-a1.dts
@@ -55,13 +55,33 @@
 };
 
 &wifi0 {
-	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_e000 1>;
-	nvmem-cell-names = "eeprom", "mac-address";
-	ieee80211-freq-limit;
 	/delete-property/ ieee80211-freq-limit;
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_e000 2>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_e000 1>;
+		nvmem-cell-names = "mac-address";
+	};
 };
 
 &wifi1 {
 	nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_e000 3>;
 	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_e000 4>;
+	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -54,11 +54,6 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_add $label_mac 2 > /sys${DEVPATH}/macaddress
 		;;
-	dlink,dir-3040-a1)
-		lan_mac_addr="$(mtd_get_mac_binary factory 0xe000)"
-		[ "$PHYNBR" = "0" ] && \
-			macaddr_add $lan_mac_addr 2 > /sys${DEVPATH}/macaddress
-		;;
 	dlink,dir-853-a3)
 		[ "$PHYNBR" = "0" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary factory 0xe000)" \


### PR DESCRIPTION
The dtsi used handles a bunch of non-DBDC platforms where the assignments are correct. The 3040-a1 is different as there are 3 instead of 2 wifi interfaces and WAN needs to be incremented by 1.

Remove userspace wifi assignmwent which was needed before per band nvmem was supported.

ping @Sinbiosis 

band@0 and band@1 's MACs might need to be swapped. Not sure.