### PR TITLE
ramips: mt76x8: add support for Cudy LT300 v3

### DIFF
--- a/target/linux/ramips/dts/mt7628an_cudy_lt300-v3.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_lt300-v3.dts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "cudy,lt300-v3", "mediatek,mt7628an-soc";
+	model = "Cudy LT300 v3";
+
+	aliases {
+		led-boot = &white_status;
+		led-running = &white_status;
+		led-failsafe = &red_status;
+		led-upgrade = &red_status;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		red_status: red_status {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+
+		white_status: white_status {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		signal1 {
+			label = "white:signal1";
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			label = "white:signal2";
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			label = "white:signal3";
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+
+		usb4g {
+			gpio-export,name = "4g";
+			gpio-export,output = <0>;
+			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf80000>;
+			};
+
+			partition@fd0000 {
+				label = "debug";
+				reg = <0xfd0000 0x10000>;
+				read-only;
+			};
+
+			partition@fe0000 {
+				label = "backup";
+				reg = <0xfe000 0x10000>;
+				read-only;
+			};
+
+			partition@ff0000 {
+				label = "bdinfo";
+				reg = <0xff0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "i2c", "gpio", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 2>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x3c>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -199,6 +199,17 @@ define Device/creality_wb-01
 endef
 TARGET_DEVICES += creality_wb-01
 
+define Device/cudy_lt300-v3
+  IMAGE_SIZE := 15872k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := LT300
+  DEVICE_VARIANT := v3
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-net-rndis \
+	kmod-usb-serial-option
+  SUPPORTED_DEVICES += R100
+endef
+TARGET_DEVICES += cudy_lt300-v3
+
 define Device/cudy_lt400e-v1
   IMAGE_SIZE := 7808k
   DEVICE_VENDOR := Cudy

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -27,6 +27,9 @@ yuncore,m300)
 creality,wb-01)
 	ucidef_set_led_switch "lan" "lan" "blue:lan" "switch0" "0x1"
 	;;
+cudy,lt300-v3)
+	ucidef_set_led_netdev "internet" "internet" "white:status" "usb0"
+	;;
 cudy,lt400e-v1)
 	ucidef_set_led_switch "lan1" "lan1" "blue:lan-1" "switch0" "0x08"
 	ucidef_set_led_switch "lan2" "lan2" "blue:lan-2" "switch0" "0x04"

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -100,6 +100,12 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"4:lan" "6@eth0"
 		;;
+	cudy,lt300-v3)
+		ucidef_add_switch "switch0" "0:wan" "1:lan" "6@eth0"
+		ucidef_set_interface "wwan" device "usb0" protocol "dhcp"
+		uci add_list firewall.@zone[1].network='wwan'
+		uci add_list firewall.@zone[1].network='wwan6'
+		;;
 	cudy,lt400e-v1)
 		ucidef_add_switch "switch0" \
 			"3:lan:1" "2:lan:2" "1:lan:3" "0:lan:4" "6@eth0"
@@ -284,6 +290,13 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_binary factory 0xe000)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
                 ;;
+	cudy,lt300-v3|\
+	hiwifi,hc5611|\
+	hiwifi,hc5661a|\
+	hiwifi,hc5761a|\
+	hiwifi,hc5861b)
+		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
+		;;
 	cudy,wr1000|\
 	hilink,hlk-7628n|\
 	hilink,hlk-7688a|\
@@ -303,12 +316,6 @@ ramips_setup_macs()
 	wrtnode,wrtnode2p|\
 	wrtnode,wrtnode2r)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary factory 0x4)" 1)
-		;;
-	hiwifi,hc5611|\
-	hiwifi,hc5661a|\
-	hiwifi,hc5761a|\
-	hiwifi,hc5861b)
-		wan_mac=$(macaddr_add "$(cat /sys/class/net/eth0/address)" 1)
 		;;
 	iptime,a3|\
 	iptime,a604m|\


### PR DESCRIPTION
Hardware:
 - SoC: MediaTek MT7628AN (MIPS 580MHz)
 - Flash: 16 MiB NOR
 - RAM: 64 MiB DDR2
 - WLAN: 2.4 GHz (MT7628)
 - Ethernet: 1x 10/100 Mbps WAN/LAN, 1x 10/100 LAN (MT7628)
 - Built-in LTE Modem: MeigLink SLM770A 4G Cat. 4 (150/50 Mbps)
 - Buttons: 1x Reset, 1x wps
 - LEDs: Front: 1x Red, 1x White, Back: 3x White 4G signal strengh
 - Serial console: unpopulated header, 115200 8n1
 - Power: USB-C

MAC addresses:
+---------+-------------------+-----------+
|         | MAC               | Algorithm |
+---------+-------------------+-----------+
| WAN     | 80:af:ca:xx:xx:x1 | label +1  |
| LAN     | 80:af:ca:xx:xx:x0 | label     |
| WLAN 2g | 80:af:ca:xx:xx:x2 | label +2  |
+---------+-------------------+-----------+

Migration to OpenWrt:
- Download the RSA-signed intermediate firmware from the Cudy website: `openwrt-ramips-mt76x8-cudy_lt300-v3-squashfs-flash.bin`
- Connect the computer to the LAN and flash the intermediate firmware via the OEM web interface
- OpenWrt is now accessible via 192.168.1.1

Revert to OEM firmware:
- Set up a TFTP server on IP 192.168.1.88 and connect to the WAN port (upper port)
- Provide the Cudy firmware as recovery.bin in the TFTP server
- Press the reset button while powering on the device
- The recovery process has started now
- When the recovery process is done, OEM firmware is accessible via 192.168.10.1 again

General information:
- No possibility to load an initramfs image via U-Boot because there is no option to interrupt U-Boot

Tested by 4pda user: Bill Humble
