### PR TITLE
base-files: change LED default behaviour

### DIFF
--- a/package/base-files/files/etc/init.d/led
+++ b/package/base-files/files/etc/init.d/led
@@ -59,7 +59,7 @@ load_led() {
 	config_get dev $1 dev
 	config_get ports $1 port
 	config_get mode $1 mode
-	config_get_bool default $1 default "0"
+	config_get_bool default $1 default "nil"
 	config_get delayon $1 delayon
 	config_get delayoff $1 delayoff
 	config_get interval $1 interval "50"
@@ -103,13 +103,24 @@ load_led() {
 		}
 		printf "\n" >> /var/run/led.state
 
-		[ "$default" = 0 ] &&
+		case $default in
+		"0")
 			echo 0 >/sys/class/leds/${sysfs}/brightness
+		;;
 
-		[ "$default" = 1 ] && {
-			[ -z "$brightness" ] && brightness="$(cat /sys/class/leds/${sysfs}/max_brightness)"
+		"1")
+			[ -z "$brightness" ] && \
+				brightness="$(cat /sys/class/leds/${sysfs}/max_brightness)"
 			echo "$brightness" > /sys/class/leds/${sysfs}/brightness
-		}
+		;;
+
+		*)
+			if [ -n "$brightness" ]; then
+				brightness="$(cat /sys/class/leds/${sysfs}/max_brightness)"
+				echo $(brightness) >/sys/class/leds/${sysfs}/brightness
+			fi
+		;;
+		esac
 
 		led_color_set "$1" "$sysfs"
 


### PR DESCRIPTION
makes /etc/init.d/led not change brightness by default

To this point LEDs were being turned off by default before setting a trigger.

Most kernel triggers set operational brightness to max_brightness if it was set to 0 initially.

This caused RGB LEDs (or LEDs with non-binary brightness in general) to ignore 'option brightness' in uci unless 'option default 1' was set. (max_brightness was used instead)

- - -

From what I've seen in the commit history, setting brightness to `'0'` before changing triggers is mostly historical, though it might cause a change in behaviour in single-color LEDs in some obscure triggers. (`option default '0'` will need to be set to preserve the current behaviour. Although that's unneeded in almost all cases, from what I can see.)