### PR TITLE
build: propagate errors when generating apk indexes

### DIFF
--- a/package/Makefile
+++ b/package/Makefile
@@ -129,6 +129,7 @@ $(curdir)/index: FORCE
 	@echo Generating package index...
 ifneq ($(CONFIG_USE_APK),)
 	@for d in $(PACKAGE_SUBDIRS); do \
+		set -e; \
 		mkdir -p $$d; \
 		cd $$d || continue; \
 		ls *.apk >/dev/null 2>&1 || continue; \


### PR DESCRIPTION
The build would continue even if the some of the intermediate commands
failed, as long as the last command in the final iteration of the loop
was successful.

Add 'set -e' to the subshell so that we immediately exit. Previously,
only the exit status of the final make-index-json.py mattered.

Fixes: https://github.com/openwrt/openwrt/issues/21981