### PR TITLE
realtek: rt-loader: fix RTL839x/RTL93xx version detection

### DIFF
--- a/target/linux/realtek/image/rt-loader/src/main.c
+++ b/target/linux/realtek/image/rt-loader/src/main.c
@@ -90,7 +90,7 @@ void welcome(void)
 	board_get_system(system, sizeof(system));
 
 	printf("\nrt-loader\n");
-	printf("Running on %s with %dMB\n", system, board_get_memory() >> 20);
+	printf("Running on %s SoC with %d MB\n", system, board_get_memory() >> 20);
 }
 
 void decompress_error(char *x)


### PR DESCRIPTION
There is a misunderstanding of the chip version detection in the rt-loader. For all SoCs the data is gathered from the registers MODEL_NAME_INFO and CHIP_INFO. Sadly the bits are shuffled around with each hardware. Currently the loader gathers the wrong bits for RTL839x and RTL93xx. Fix that.

While we are here write the if statements vice versa for better readability and give some variables better names. Align the ouput with that from the kernel.
