### PR TITLE
ramips: add support for TP-Link RE205 v2

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_re205-v2.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_re205-v2.dts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_tplink_re200.dtsi"
+
+/ {
+	compatible = "tplink,re205-v2", "mediatek,mt7628an-soc";
+	model = "TP-Link RE205 v2";
+
+	/delete-node/ leds;
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wifi2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		signal_blue {
+			label = "blue:signal";
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		signal_red {
+			label = "red:signal";
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -933,6 +933,16 @@ define Device/tplink_re200-v4
 endef
 TARGET_DEVICES += tplink_re200-v4
 
+define Device/tplink_re205-v2
+  $(Device/tplink-safeloader)
+  IMAGE_SIZE := 7808k
+  DEVICE_MODEL := RE205
+  DEVICE_VARIANT := v2
+  DEVICE_PACKAGES := kmod-mt76x0e
+  TPLINK_BOARD_ID := RE205-V2
+endef
+TARGET_DEVICES += tplink_re205-v2
+
 define Device/tplink_re205-v3
   $(Device/tplink-safeloader)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -132,6 +132,7 @@ tplink,tl-mr3020-v3|\
 tplink,tl-wa801nd-v5)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0"
 	;;
+tplink,re205-v2|\
 tplink,re205-v3)
 	ucidef_set_led_netdev "lan" "lan" "blue:signal" "eth0"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -28,6 +28,7 @@ ramips_setup_interfaces()
 	tplink,re200-v2|\
 	tplink,re200-v3|\
 	tplink,re200-v4|\
+	tplink,re205-v2|\
 	tplink,re205-v3|\
 	tplink,re220-v2|\
 	tplink,re305-v1|\


### PR DESCRIPTION
## Summary

Add OpenWrt support for the TP-Link RE205 v2 range extender.

The RE205 v2 is a dual-band (2.4GHz + 5GHz) range extender based on the
MT7628AN + MT7610E chipset. It shares the same hardware platform as the
already-supported RE205 v3 and RE200 v4, but with a different board ID
and product version in the TP-Link safeloader format.

### Hardware

- SoC: MediaTek MT7628AN (MIPS 24KEc @ 580MHz)
- RAM: 64MB
- Flash: 8MB
- 2.4GHz: MT7628 802.11b/g/n HT20 (2T2R)
- 5GHz: MT7610E 802.11a/n/ac VHT80 (1T1R, PCIe)
- Ethernet: 1x 10/100 Mbps
- LEDs: 5x (power, signal blue, signal red, 2.4GHz, 5GHz)
- Button: WPS/Reset (GPIO 38)

### Changes

- **DTS**: New device tree based on `mt7628an_tplink_re200.dtsi` with blue LED GPIO mapping (39-43), identical to RE205 v3
- **tplink-safeloader**: Board entry with 13 `special_id` entries extracted from stock firmware, partition table identical to RE200 v4 and RE205 v3
- **Image definition**: 7808k image size, `kmod-mt76x0e` for 5GHz PCIe radio
- **board.d**: LED and network entries grouped with RE205 v3

### Testing

- Built and flashed successfully (both factory from stock firmware and sysupgrade)
- Tested on OpenWrt 24.10.5 and snapshot
- 2.4GHz and 5GHz radios working, 18+ clients stable
- LuCI accessible, all LEDs functional
- Sysupgrade with and without config preservation verified
- Performance validated: MCS 5-7 TX rates, 90% CPU idle, no driver errors

### Installation

Flash via stock TP-Link web UI using the factory image, or via TFTP recovery
(hold reset during power-on, device at 192.168.1.1, TFTP server at 192.168.1.66,
firmware renamed to `test.bin` — see [RE200 wiki](https://openwrt.org/toh/tp-link/re200)).