### PR TITLE
[25.12] apk: handle edge case when parsing .apk files

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git

--- a/package/system/apk/patches/0034-io-handle-edge-case-when-refilling-read-buffer.patch
+++ b/package/system/apk/patches/0034-io-handle-edge-case-when-refilling-read-buffer.patch
@@ -1,0 +1,29 @@
+From 1e985a4444d8c9ab5a0804b555858dcf518b243a Mon Sep 17 00:00:00 2001
+From: Matt Merhar <mattmerhar@protonmail.com>
+Date: Wed, 11 Feb 2026 16:04:52 -0500
+Subject: [PATCH] io: handle edge case when refilling read buffer
+
+This caused failures when processing specific (< 0.1%) .apk files in
+the packages feed.
+
+It affected packages with a header size greater than the read buffer
+size of 128KB but less than 160KB (128KB + (128KB / 4)).
+
+In those cases, we'd attempt a 0 byte read, leading to APKE_EOF.
+---
+ src/io.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/src/io.c
++++ b/src/io.c
+@@ -120,6 +120,10 @@ ssize_t apk_istream_read_max(struct apk_
+ 			continue;
+ 		}
+ 
++		if (is->ptr - is->buf >= APK_ISTREAM_ALIGN_SYNC) {
++			is->ptr = is->end = is->buf + ((is->ptr - is->buf) % APK_ISTREAM_ALIGN_SYNC);
++		}
++
+ 		r = is->ops->read(is, is->ptr, is->buf + is->buf_size - is->ptr);
+ 		if (r <= 0) break;
+ 


### PR DESCRIPTION
This was a regression introduced in the recent alignment changes and led to failures when reading (i.e. 'mkndx') certain packages like follows:

ERROR: python3-botocore-1.31.7-r1.apk: unexpected end of file

It affected packages with a header size greater than the read buffer size of 128KB but less than 160KB (128KB + (128KB / 4)).

In those cases, we'd attempt a 0 byte read, leading to APKE_EOF.

Based on some tests of files across multiple archs and feeds, it seems the only packages meeting those criteria were python3-botocore and golang-github-jedisct1-dnscrypt-proxy2-dev.

Fixes: 64ec08eee1 ("apk: backport upstream fixes for unaligned access")
Link: https://github.com/openwrt/openwrt/pull/21992
(cherry picked from commit 8c6ed4e927373282b654420ad3962a6a0ea110c3)