### PR TITLE
elfutils: fix license

### DIFF
--- a/package/libs/elfutils/Makefile
+++ b/package/libs/elfutils/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=elfutils
 PKG_VERSION:=0.192
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION) \
@@ -16,7 +16,7 @@ PKG_SOURCE_URL:=https://sourceware.org/$(PKG_NAME)/ftp/$(PKG_VERSION) \
 PKG_HASH:=616099beae24aba11f9b63d86ca6cc8d566d968b802391334c91df54eab416b4
 
 PKG_MAINTAINER:=Luiz Angelo Daros de Luca <luizluca@gmail.com>
-PKG_LICENSE:=GPL-2.0-or-later OR LGPL-3.0-or-later
+PKG_LICENSE:=GPL-2.0-or-later LGPL-3.0-or-later
 PKG_LICENSE_FILES:=COPYING COPYING-GPLV2 COPYING-LGPLV3
 PKG_CPE_ID:=cpe:/a:elfutils_project:elfutils
 


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @luizluca

**Description:**
Remove `OR` between `GPL-2.0-or-later` and `LGPL-3.0-or-later` to avoid
incorrect parsing of `OR` as a separate license in the SBOM.

It seems that OpenWrt does not know how to handle SPDX AND, OR, and grouping. Currently it becomes:

```
{"version":"0.192","cpe":"cpe:/a:elfutils_project:elfutils:0.192","name":"libelf","type":"library","licenses":[{"license":{"name":"GPL-2.0-or-later"}},{"license":{"name":"OR"}},{"license":{"name":"LGPL-3.0-or-later"}}]}
```