### PR TITLE
qualcommbe: ipq95xx: require image metadata for sysupgrade checks

### DIFF
--- a/target/linux/qualcommbe/ipq95xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommbe/ipq95xx/base-files/lib/upgrade/platform.sh
@@ -1,4 +1,5 @@
 PART_NAME=firmware
+REQUIRE_IMAGE_METADATA=1
 
 RAMFS_COPY_BIN='fw_printenv fw_setenv head'
 RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'


### PR DESCRIPTION
Add the flag required to enforce the fwtool's image metadata checks. All sysupgrade image recipes on this platform already append the metadata.

Fixes: 93173aee96e7496f3ff158046d3d19cd42c2e031 ("qualcommbe: ipq95xx: Add initial support for new target")

A reference: https://github.com/openwrt/openwrt/commit/be296745f82665272771e1cfeb2c19438cf3cb5a
CC: @Ansuel @robimarko 