### PR TITLE
lantiq: ar9: buffalo-wbmr-hp-g300h add support for ASU sysupgrades

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_buffalo_wbmr-hp-g300h-a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_buffalo_wbmr-hp-g300h-a.dts
@@ -1,0 +1,6 @@
+#include "ar9_buffalo_wbmr-hp-g300h.dtsi"
+
+/ {
+	compatible = "buffalo,wbmr-hp-g300h-a", "lantiq,xway", "lantiq,ar9";
+	model = "Buffalo WBMR-HP-G300H-a";
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_buffalo_wbmr-hp-g300h-b.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_buffalo_wbmr-hp-g300h-b.dts
@@ -1,0 +1,6 @@
+#include "ar9_buffalo_wbmr-hp-g300h.dtsi"
+
+/ {
+	compatible = "buffalo,wbmr-hp-g300h-b", "lantiq,xway", "lantiq,ar9";
+	model = "Buffalo WBMR-HP-G300H-b";
+};

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_buffalo_wbmr-hp-g300h.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_buffalo_wbmr-hp-g300h.dtsi
@@ -4,9 +4,6 @@
 #include <dt-bindings/leds/common.h>
 
 / {
-	compatible = "buffalo,wbmr-hp-g300h", "lantiq,xway", "lantiq,ar9";
-	model = "Buffalo WBMR-HP-G300H";
-
 	chosen {
 		bootargs = "console=ttyLTQ0,115200";
 	};

--- a/target/linux/lantiq/image/ar9.mk
+++ b/target/linux/lantiq/image/ar9.mk
@@ -57,13 +57,12 @@ define Device/buffalo_wbmr-hp-g300h-a
   DEVICE_VARIANT := A
   IMAGE_SIZE := 31488k
   SOC := ar9
-  DEVICE_DTS := ar9_buffalo_wbmr-hp-g300h
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-a kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
-  SUPPORTED_DEVICES := WBMR buffalo,wbmr-hp-g300h
+  SUPPORTED_DEVICES += WBMR buffalo,wbmr-hp-g300h buffalo,wbmr-hp-g300h-b
 endef
 TARGET_DEVICES += buffalo_wbmr-hp-g300h-a
 
@@ -73,13 +72,12 @@ define Device/buffalo_wbmr-hp-g300h-b
   DEVICE_VARIANT := B
   IMAGE_SIZE := 31488k
   SOC := ar9
-  DEVICE_DTS := ar9_buffalo_wbmr-hp-g300h
   DEVICE_PACKAGES := kmod-usb-dwc2 kmod-usb-ledtrig-usbport \
 	kmod-ltq-adsl-ar9-mei kmod-ltq-adsl-ar9 \
 	kmod-ltq-adsl-ar9-fw-b kmod-ltq-atm-ar9 \
 	ltq-adsl-app ppp-mod-pppoa \
 	kmod-ath9k kmod-owl-loader wpad-basic-mbedtls
-  SUPPORTED_DEVICES := WBMR buffalo,wbmr-hp-g300h
+  SUPPORTED_DEVICES += WBMR buffalo,wbmr-hp-g300h buffalo,wbmr-hp-g300h-a
 endef
 TARGET_DEVICES += buffalo_wbmr-hp-g300h-b
 

--- a/target/linux/lantiq/xway/base-files/etc/board.d/02_network
+++ b/target/linux/lantiq/xway/base-files/etc/board.d/02_network
@@ -20,7 +20,8 @@ lantiq_setup_interfaces()
 	arcadyan,arv7518pw|\
 	arcadyan,arv752dpw22|\
 	arcadyan,arv8539pw22|\
-	buffalo,wbmr-hp-g300h)
+	buffalo,wbmr-hp-g300h-a|\
+	buffalo,wbmr-hp-g300h-b)
 		ucidef_add_switch "switch0" \
 			"0t@eth0" "2:lan" "3:lan" "4:lan" "5:lan"
 		;;


### PR DESCRIPTION
Add the required two unique dts compatibles to allow correct profile identification when asking for ASU sysupgrades.

Keep/add each device dts compatible in the other device's SUPPORTED_DEVICES field to keep the ability to sysupgrade between the two ADSL annex image variants.

*Depends on an open PR in the ASU repo.