### PR TITLE
realtek: pcs: rtl931x: add 2500Base-X support

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -3148,6 +3148,13 @@ static int rtpcs_931x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 		mode_val = 0x9;
 		break;
 
+	case RTPCS_SDS_MODE_2500BASEX:
+		/* available SDK code doesn't have this value. based on brute-forcing
+		 * the SerDes mode register field until the link is working
+		 */
+		mode_val = 0x2d;
+		break;
+
 	case RTPCS_SDS_MODE_10GBASER:
 		mode_val = 0x35;
 		break;

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -3386,12 +3386,22 @@ static int rtpcs_931x_sds_link_sts_get(struct rtpcs_serdes *sds)
 {
 	u32 sts, sts1, latch_sts, latch_sts1;
 
-	if (0) {
+	switch (sds->hw_mode) {
+	case RTPCS_SDS_MODE_XSGMII:
 		sts = rtpcs_sds_read_bits(sds, 0x41, 29, 8, 0);
 		sts1 = rtpcs_sds_read_bits(sds, 0x81, 29, 8, 0);
 		latch_sts = rtpcs_sds_read_bits(sds, 0x41, 30, 8, 0);
 		latch_sts1 = rtpcs_sds_read_bits(sds, 0x81, 30, 8, 0);
-	} else {
+		break;
+
+	case RTPCS_SDS_MODE_SGMII:
+	case RTPCS_SDS_MODE_HISGMII:
+	case RTPCS_SDS_MODE_2500BASEX:
+		sts = rtpcs_sds_read_bits(sds, 0x41, 29, 8, 0);
+		latch_sts = rtpcs_sds_read_bits(sds, 0x41, 30, 8, 0);
+		break;
+
+	default:
 		sts = rtpcs_sds_read_bits(sds, 0x5, 0, 12, 12);
 		latch_sts = rtpcs_sds_read_bits(sds, 0x4, 1, 2, 2);
 		latch_sts1 = rtpcs_sds_read_bits(sds, 0x42, 1, 2, 2);


### PR DESCRIPTION
This adds basic support for 2500Base-X on RTL931x, simply by providing a working mode value which was missing before. Trying to use 2500Base-X resulted in pcs_config returning with `-ENOTSUPP` so far. The value is not from the SDK, instead I brute-forced the SerDes mode register until the link was working.

Also adjusts the "sleeping" link status reading function. Though not used yet, we might do so in the future and making it less confusing at this stage is good.

Tested on Netgear MS510TXM with RTL8221B-VB-CG PHYs (dynamically switches between SGMII and 2500Base-X) and with 2.5G-T SFP module