### PR TITLE
6in4: improve HE tunnel update procedure

### DIFF
--- a/package/network/ipv6/6in4/files/6in4.sh
+++ b/package/network/ipv6/6in4/files/6in4.sh
@@ -25,7 +25,7 @@ test_6in4_rfc1918()
 
 proto_6in4_update() {
 	sh -c '
-		timeout=5
+		timeout=15
 
 		(while [ $((timeout--)) -gt 0 ]; do
 			sleep 1
@@ -123,7 +123,7 @@ proto_6in4_setup() {
 		local ca_path="${SSL_CERT_DIR:-/etc/ssl/certs}"
 
 		[ -f /lib/libustream-ssl.so ] && http=https
-		[ "$http" = "https" -a -z "$(find $ca_path -name "*.0" 2>/dev/null)" ] && {
+		[ "$http" = "https" -a -z "$(find "$ca_path" \( -name "*.0" -o -name "*.crt" \) 2>/dev/null)" ] && {
 			urlget_opts="$urlget_opts --no-check-certificate"
 		}
 
@@ -135,10 +135,12 @@ proto_6in4_setup() {
 
 		local try=0
 		local max=3
+		local retry_delay=5
 
 		(
 			set -o pipefail
-			while [ $((++try)) -le $max ]; do
+			while true; do
+				try=$((try + 1))
 				if proto_6in4_update $urlget $urlget_opts --user="$username" --password="$password" "$url" 2>&1 | \
 					sed -e 's,^Killed$,timeout,' -e "s,^,update $try/$max: ," | \
 					logger -t "$link";
@@ -146,7 +148,11 @@ proto_6in4_setup() {
 					logger -t "$link" "updated"
 					return 0
 				fi
-				sleep 5
+
+				[ "$try" -ge "$max" ] && break
+
+				sleep "$retry_delay"
+				retry_delay=$((retry_delay * 2))
 			done
 			logger -t "$link" "update failed"
 		)


### PR DESCRIPTION
- uclient-fetch timeout bumped from 5s to 15s. If we do not do this we get flagged by HE as the update request is expensive and takes more than 5s to execute. Currently 5s timeout causes uclient-fetch to be killed prematurely as can be seen by the following log:

  10:34:57 user.notice 6in4-henet: update 1/3: timeout
  10:35:07 user.notice 6in4-henet: update 2/3: timeout
  10:35:17 user.notice 6in4-henet: update 3/3: timeout
  10:35:22 user.notice 6in4-henet: update failed

  The above is the worst case, what usually happens is:

  10:53:59 user.notice 6in4-henet: update 1/3: timeout
  10:54:06 user.notice 6in4-henet: update 2/3: abuse
  10:54:06 user.notice 6in4-henet: updated

- We now use an exponential backoff starting from 5 seconds.

- Detect ca-bundle so we don't use --no-check-certificates unnecessarily.

- The while loop was changed so we don't retry unnecessarily after the final failure.

- Worst-case total time the update operation might take before bailing out is:

     (sum(15 + (5 × (2^(x − 1))), 1, 2) + 15) seconds = 1 min
