### PR TITLE
wifi-scripts: ucode: allow sae_pwe to be modified for AP mode

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -86,17 +86,16 @@ function iface_auth_type(config) {
 		config.ieee80211w = 2;
 		config.sae_require_mfp = 1;
 		if (!config.ppsk)
-			config.sae_pwe = 2;
+			set_default(config, 'sae_pwe', 2);
 	}
 
 	if (config.auth_type in [ 'psk-sae', 'eap-eap2' ]) {
-		if (!config.ieee80211w)
-			config.ieee80211w = 1;
+		set_default(config, 'ieee80211w', 1);
 		if (config.rsn_override)
 			config.rsn_override_mfp = 2;
 		config.sae_require_mfp = 1;
 		if (!config.ppsk)
-			config.sae_pwe = 2;
+			set_default(config, 'sae_pwe', 2);
 	}
 
 	if (config.own_ip_addr)


### PR DESCRIPTION
Some Android devices have issues with H2E causing downgrades to PSK when using WPA2/3. With WPA3 it doesn't work reliably whatsoever.

My Samsung A55/6 for example has the following behavior:

daemon.info hostapd: lan5g: STA <redacted> IEEE 802.11: authenticated
daemon.notice hostapd: SAE: <redacted> indicates support for SAE H2E, but did not use it
daemon.info hostapd: lan2g: STA <redacted> IEEE 802.11: authenticated
daemon.info hostapd: lan2g: STA <redacted> IEEE 802.11: associated (aid 1)
daemon.notice hostapd: lan5g: Prune association for <redacted>
daemon.notice hostapd: lan2g: AP-STA-CONNECTED <redacted> auth_alg=open
daemon.info hostapd: lan2g: STA <redacted> RADIUS: starting accounting session 8234C696AAC1AE7D
daemon.info hostapd: lan2g: STA <redacted> WPA: pairwise key handshake completed (RSN)
daemon.notice hostapd: lan2g: EAPOL-4WAY-HS-COMPLETED <redacted>

This is also brought up in the issue: https://github.com/openwrt/openwrt/issues/9963

Ultimately this allows users to have the option to at the very least disable H2E.

Unrelated: a minor cleanup was done so that ieee80211w uses set_default instead. There is no functional change on that front.