### PR TITLE
hostapd: fix EAP-PWD in experimental hostapd-radius server

### DIFF
--- a/package/network/services/hostapd/src/hostapd/radius.c
+++ b/package/network/services/hostapd/src/hostapd/radius.c
@@ -568,6 +568,7 @@ static int radius_setup(struct radius_state *s, struct radius_config *c)
 	eap->max_auth_rounds = 100;
 	eap->max_auth_rounds_short = 50;
 	eap->ssl_ctx = tls_init(&conf);
+	eap->pwd_group = 19;
 	if (!eap->ssl_ctx) {
 		wpa_printf(MSG_INFO, "TLS init failed\n");
 		return 1;


### PR DESCRIPTION
Without initializing pwd_group, it's set to 0, which is reserved value.

When EAP-PWD is used in wpa_supplicant/eapol_test, next error is seen:
EAP-PWD: Server EAP-pwd-ID proposal: group=0 random=1 prf=1 prep=0
EAP-pwd: Unsupported or disabled proposal

Tested with eapol_test and Android phone. Selected group is default in hostapd and the only one mandatory in RFC.
