### PR TITLE
realtek: eth: merge & simplify irq handlers

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
@@ -64,26 +64,22 @@
 #define RTL839X_DMA_IF_CTRL			(0x786c)
 
 #define RTL930X_DMA_IF_CTRL			(0xe028)
-#define RTL930X_DMA_IF_INTR_RX_DONE_STS		(0xe020)
 #define RTL930X_DMA_IF_INTR_TX_DONE_STS		(0xe024)
 #define RTL930X_DMA_IF_INTR_RX_DONE_MSK		(0xe014)
-#define RTL930X_DMA_IF_INTR_TX_DONE_MSK		(0xe018)
 #define RTL930X_L2_NTFY_IF_INTR_MSK		(0xe04C)
 #define RTL930X_L2_NTFY_IF_INTR_STS		(0xe050)
 
 /* TODO: RTL931X_DMA_IF_CTRL has different bits meanings */
 #define RTL931X_DMA_IF_CTRL			(0x0928)
-#define RTL931X_DMA_IF_INTR_RX_DONE_STS		(0x0920)
 #define RTL931X_DMA_IF_INTR_TX_DONE_STS		(0x0924)
 #define RTL931X_DMA_IF_INTR_RX_DONE_MSK		(0x0914)
-#define RTL931X_DMA_IF_INTR_TX_DONE_MSK		(0x0918)
 #define RTL931X_L2_NTFY_IF_INTR_MSK		(0x09E4)
 #define RTL931X_L2_NTFY_IF_INTR_STS		(0x09E8)
 
 #define RTL839X_DMA_IF_INTR_NOTIFY_MASK		GENMASK(22, 20)
 #define RTL83XX_DMA_IF_INTR_RX_DONE_MASK	GENMASK(15, 8)
 #define RTL83XX_DMA_IF_INTR_RX_RUN_OUT_MASK	GENMASK(7, 0)
-#define RTL83XX_DMA_IF_INTR_RX_MASK(ring)	(BIT(ring) | BIT(ring + 8))
+#define RTL83XX_DMA_IF_INTR_RX_MASK(ring)	(BIT(ring + 8))
 #define RTL93XX_DMA_IF_INTR_RX_MASK(ring)	(BIT(ring))
 
 /* MAC address settings */
@@ -411,17 +407,14 @@ struct rteth_config {
 	int rx_rings;
 	int tx_rx_enable;
 	int tx_trigger_mask;
-	irqreturn_t (*net_irq)(int irq, void *dev_id);
 	int mac_l2_port_ctrl;
 	int qm_pkt2cpu_intpri_map;
 	int qm_rsn2cpuqid_ctrl;
 	int qm_rsn2cpuqid_cnt;
 	int dma_if_intr_sts;
 	int dma_if_intr_msk;
-	int dma_if_intr_rx_done_sts;
 	int dma_if_intr_tx_done_sts;
 	int dma_if_intr_rx_done_msk;
-	int dma_if_intr_tx_done_msk;
 	int l2_ntfy_if_intr_sts;
 	int l2_ntfy_if_intr_msk;
 	int dma_if_ctrl;


### PR DESCRIPTION
Two different irq handlers exist for RTL83xx and RTL93xx. Basically they do always the same.

- Check transmit interrupts (not needed anymore)
- Check rx overflow interrupts (not needed anymore)
- Determine rx interrupts and queues that must be processed.
- In case of RTL839x check for L2 interrupts

With all the recent refactoring their logic is more or less the same. Merge them into one handler. For better readability add a helper that determines the work (aka rings) that needs to be processed.
