### PR TITLE
realtek: switch Zyxel XGS1210 to NVMEM

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -58,7 +58,9 @@ realtek_setup_macs()
 	tplink,sg2452p-v4|\
 	tplink,t1600g-28ts-v3|\
 	xikestor,sks8300-8t|\
-	xikestor,sks8300-12e2t2x)
+	xikestor,sks8300-12e2t2x|\
+	zyxel,xgs1210-12-a1|\
+	zyxel,xgs1210-12-b1)
 		lan_mac=$(get_mac_label)
 		lan_mac_start=$lan_mac
 		;;
@@ -142,8 +144,6 @@ realtek_setup_macs()
 	zyxel,gs1900-8hp-a1|\
 	zyxel,gs1900-8hp-b1|\
 	zyxel,gs1920-24hp-v1|\
-	zyxel,xgs1210-12-a1|\
-	zyxel,xgs1210-12-b1|\
 	zyxel,xgs1250-12-a1|\
 	zyxel,xgs1250-12-b1)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env2 mac_start)

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-common.dtsi
@@ -4,6 +4,10 @@
 #include "rtl9302_zyxel_xgs1x10-12-common.dtsi"
 
 / {
+	aliases {
+		label-mac-device = &ethernet0;
+	};
+
 	keys {
 		compatible = "gpio-keys";
 
@@ -35,6 +39,14 @@
 			partition@e0000 {
 				label = "u-boot-env";
 				reg = <0xe0000 0x10000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_ubootenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 			partition@f0000 {
 				label = "u-boot-env2";
@@ -62,4 +74,9 @@
 			};
 		};
 	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
 };


### PR DESCRIPTION
These devices contain a single MAC address in the U-Boot environment. Set it as eth0 and label MAC in device tree.

To maintain the current state, the 02_network script still sets individual port MAC addresses and the bridge MAC address.

Tested on Zyxel XGS1210-12 rev B1.