### PR TITLE
realtek: dsa: move port_ignore constant to config

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -575,7 +575,7 @@ static int rtl83xx_l2_nexthop_add(struct rtl838x_switch_priv *priv, struct rtl83
 		e.block_sa = false;
 		e.suspended = false;
 		e.age = 0;			/* With port-ignore */
-		e.port = priv->port_ignore;
+		e.port = priv->r->port_ignore;
 		u64_to_ether_addr(nh->mac, &e.mac[0]);
 	}
 	e.next_hop = true;
@@ -665,7 +665,7 @@ static int rtl83xx_l3_nexthop_update(struct rtl838x_switch_priv *priv,  __be32 i
 		pr_debug("Route with id %d to %pI4 / %d\n", r->id, &r->dst_ip, r->prefix_len);
 
 		r->nh.mac = r->nh.gw = mac;
-		r->nh.port = priv->port_ignore;
+		r->nh.port = priv->r->port_ignore;
 		r->nh.id = r->id;
 
 		/* Do we need to explicitly add a DMAC entry with the route's nh index? */
@@ -1097,7 +1097,7 @@ static int rtldsa_fib4_add(struct rtl838x_switch_priv *priv,
 			int slot;
 
 			route->nh.mac = mac;
-			route->nh.port = priv->port_ignore;
+			route->nh.port = priv->r->port_ignore;
 			route->attr.valid = true;
 			route->attr.action = ROUTE_ACT_TRAP2CPU;
 			route->attr.type = 0;
@@ -1418,7 +1418,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->l2_bucket_size = 4;
 		priv->n_mst = 64;
 		priv->n_pie_blocks = 12;
-		priv->port_ignore = 0x1f;
 		priv->n_counters = 128;
 		break;
 	case RTL8390_FAMILY_ID:
@@ -1433,7 +1432,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->l2_bucket_size = 4;
 		priv->n_mst = 256;
 		priv->n_pie_blocks = 18;
-		priv->port_ignore = 0x3f;
 		priv->n_counters = 1024;
 		break;
 	case RTL9300_FAMILY_ID:
@@ -1449,7 +1447,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->l2_bucket_size = 8;
 		priv->n_mst = 64;
 		priv->n_pie_blocks = 16;
-		priv->port_ignore = 0x3f;
 		priv->n_counters = 2048;
 		break;
 	case RTL9310_FAMILY_ID:
@@ -1465,7 +1462,6 @@ static int rtl83xx_sw_probe(struct platform_device *pdev)
 		priv->l2_bucket_size = 8;
 		priv->n_mst = 128;
 		priv->n_pie_blocks = 16;
-		priv->port_ignore = 0x3f;
 		priv->n_counters = 2048;
 		break;
 	}

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1700,6 +1700,7 @@ const struct rtldsa_config rtldsa_838x_cfg = {
 	.isr_port_link_sts_chg = RTL838X_ISR_PORT_LINK_STS_CHG,
 	.imr_port_link_sts_chg = RTL838X_IMR_PORT_LINK_STS_CHG,
 	.imr_glb = RTL838X_IMR_GLB,
+	.port_ignore = 0x1f,
 	.vlan_tables_read = rtl838x_vlan_tables_read,
 	.vlan_set_tagged = rtl838x_vlan_set_tagged,
 	.vlan_set_untagged = rtl838x_vlan_set_untagged,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1273,6 +1273,7 @@ struct rtldsa_config {
 	int isr_port_link_sts_chg;
 	int imr_port_link_sts_chg;
 	int imr_glb;
+	u8 port_ignore;
 	void (*vlan_tables_read)(u32 vlan, struct rtl838x_vlan_info *info);
 	void (*vlan_set_tagged)(u32 vlan, struct rtl838x_vlan_info *info);
 	void (*vlan_set_untagged)(u32 vlan, u64 portmask);
@@ -1360,7 +1361,6 @@ struct rtl838x_switch_priv {
 	u8 cpu_port;
 	u8 port_mask;
 	u8 port_width;
-	u8 port_ignore;
 	u64 irq_mask;
 	u32 fib_entries;
 	int l2_bucket_size;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1640,6 +1640,7 @@ const struct rtldsa_config rtldsa_839x_cfg = {
 	.isr_port_link_sts_chg = RTL839X_ISR_PORT_LINK_STS_CHG,
 	.imr_port_link_sts_chg = RTL839X_IMR_PORT_LINK_STS_CHG,
 	.imr_glb = RTL839X_IMR_GLB,
+	.port_ignore = 0x3f,
 	.vlan_tables_read = rtl839x_vlan_tables_read,
 	.vlan_set_tagged = rtl839x_vlan_set_tagged,
 	.vlan_set_untagged = rtl839x_vlan_set_untagged,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -2645,6 +2645,7 @@ const struct rtldsa_config rtldsa_930x_cfg = {
 	.isr_port_link_sts_chg = RTL930X_ISR_PORT_LINK_STS_CHG,
 	.imr_port_link_sts_chg = RTL930X_IMR_PORT_LINK_STS_CHG,
 	.imr_glb = RTL930X_IMR_GLB,
+	.port_ignore = 0x3f,
 	.vlan_tables_read = rtl930x_vlan_tables_read,
 	.vlan_set_tagged = rtl930x_vlan_set_tagged,
 	.vlan_set_untagged = rtl930x_vlan_set_untagged,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -1830,6 +1830,7 @@ const struct rtldsa_config rtldsa_931x_cfg = {
 	.isr_port_link_sts_chg = RTL931X_ISR_PORT_LINK_STS_CHG,
 	.imr_port_link_sts_chg = RTL931X_IMR_PORT_LINK_STS_CHG,
 	/* imr_glb does not exist on RTL931X */
+	.port_ignore = 0x3f,
 	.vlan_tables_read = rtl931x_vlan_tables_read,
 	.vlan_set_tagged = rtl931x_vlan_set_tagged,
 	.vlan_set_untagged = rtl931x_vlan_set_untagged,


### PR DESCRIPTION
Device specific constants belong into the config structure. No need to initialize them manually during probing within a family_id switch statement. Although there are lots of constants that need to be converted start with port_ignore as a simple one.
