### PR TITLE
ath79: add env-size for Sitecom WLR-7100 / WLR-8100 u-boot-env

### DIFF
--- a/target/linux/ath79/dts/ar1022_sitecom_wlr-7100.dts
+++ b/target/linux/ath79/dts/ar1022_sitecom_wlr-7100.dts
@@ -128,6 +128,7 @@
 
 				nvmem-layout {
 					compatible = "u-boot,env";
+					env-size = <0x1000>;
 
 					macaddr_uboot_ethaddr: ethaddr {
 						#nvmem-cell-cells = <1>;

--- a/target/linux/ath79/dts/qca9558_sitecom_wlr-8100.dts
+++ b/target/linux/ath79/dts/qca9558_sitecom_wlr-8100.dts
@@ -83,6 +83,7 @@
 
 				nvmem-layout {
 					compatible = "u-boot,env";
+					env-size = <0x1000>;
 
 					macaddr_uboot_ethaddr: ethaddr {
 						#nvmem-cell-cells = <1>;


### PR DESCRIPTION
The Linux kernel assumes that the u-boot environment covers the full partition, but it only covers 0x1000 bytes. Linux checks the CRC and does this over the full partition. This fails like this:
```
u-boot-env-layout 1f000000.spi:flash@0:partitions:partition@30000:nvmem-layout: Invalid calculated CRC32: 0xfcac8c41 (expected: 0x14e6335a)
u-boot-env-layout 1f000000.spi:flash@0:partitions:partition@30000:nvmem-layout: probe with driver u-boot-env-layout failed with error -22
```

Define the u-boot environment with a length of 0x1000 bytes to calculate the CRC only over this area.

When replicating the u-boot environment with these parameters it generates the same CRC:
```
mkenvimage -p 0 -b -s 0x1000 -o output.bin input.txt
```

Fixes: https://github.com/openwrt/openwrt/issues/21696
Fixes: 5e3a602def72 ("ath79: sitecom,wlrx100: use nvmem")