### PR TITLE
realtek: mdio: initialize RTL930x mac type control

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -704,6 +704,8 @@ static void rtmdio_930x_setup_polling(struct mii_bus *bus)
 	struct rtmdio_phy_info phyinfo;
 	unsigned int mask, val;
 
+	regmap_write(ctrl->map, RTMDIO_930X_SMI_MAC_TYPE_CTRL, 0);
+
 	/* Define PHY specific polling parameters */
 	for (int addr = 0; addr < ctrl->cfg->cpu_port; addr++) {
 		if (ctrl->smi_bus[addr] < 0)


### PR DESCRIPTION
For each port (or port group) the mdio bus needs to define the PHY type that is attached to it. There are the following bit values that need to be set in SMI_MAC_TYPE_CTRL.

- 0x0: 10G/1G Fiber (SerDes)
- 0x1: 10G/2G5 GPHY
- 0x2: FEPHY
- 0x3: GPHY

SerDes ports are out of scope of the mdio driver and are handled by the PCS driver. So the corresponding bits are untouched. That is not good as the register default is 0x3 for ports 0-23. To make it simple: Without proper setup devices that have SerDes driven fiber ports at address 0-23 do not poll in the right way. Link detection is broken.

Fix this by initializing the register to zero. This way all ports that are not setup by the mdio driver default to "SerDes". That should be a reasonable assumption.
