### PR TITLE
build: Sort files in squashfs using priorities

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -85,6 +85,9 @@ endif
 
 JFFS2OPTS += $(MKFS_DEVTABLE_OPT)
 
+SMART_SORT_CMD = python3 $(TOPDIR)/scripts/sort_image.py
+SORT_TPL = $(TOPDIR)/scripts/rootfs.sort.template
+
 SQUASHFS_BLOCKSIZE := $(CONFIG_TARGET_SQUASHFS_BLOCK_SIZE)k
 SQUASHFSOPT := -b $(SQUASHFS_BLOCKSIZE)
 SQUASHFSOPT += -p '/dev d 755 0 0' -p '/dev/console c 600 0 0 5 1'
@@ -280,9 +283,12 @@ $(eval $(foreach S,$(JFFS2_BLOCKSIZE),$(call Image/mkfs/jffs2/template,$(S))))
 $(eval $(foreach S,$(NAND_BLOCKSIZE),$(call Image/mkfs/jffs2-nand/template,$(S))))
 
 define Image/mkfs/squashfs-common
+	$(SMART_SORT_CMD) $(TARGET_DIR) $(SORT_TPL) $(KDIR)/unsorted.txt > $(KDIR)/rootfs.sort
+
 	$(STAGING_DIR_HOST)/bin/mksquashfs4 $(call mkfs_target_dir,$(1)) $@ \
 		-nopad -noappend -root-owned \
-		-comp $(SQUASHFSCOMP) $(SQUASHFSOPT)
+		-comp $(SQUASHFSCOMP) $(SQUASHFSOPT) \
+        -sort $(KDIR)/rootfs.sort
 endef
 
 ifeq ($(CONFIG_TARGET_ROOTFS_SECURITY_LABELS),y)

--- a/scripts/rootfs.sort.template
+++ b/scripts/rootfs.sort.template
@@ -1,0 +1,32 @@
+# 1. Kernel Modules (converted from lib/modules/**/*.ko)
+@ ^lib/modules/.*\.ko 1000
+
+# 2. Shared Objects (merged and converted to regex)
+@ ^usr/lib/.*\.so 500
+@ ^usr/lib/.*\.so\..* 500
+@ ^lib/.*\.so 500
+@ ^lib/.*\.so\..* 500
+
+# 3. Any other ELF files not caught above
+! executable 400
+
+# 4. Firmware files
+@ ^lib/firmware/.* 300
+
+# 5. Images (glob **/*.png became .*\.png)
+@ .*\.png 250
+
+# 6. Web and Config assets
+@ .*\.json 200
+@ .*\.uc 200
+@ .*\.ut 200
+@ www/cgi-bin/luci 200
+@ .*\.js 200
+@ .*\.css 200
+@ .*\.svg 199
+
+# 7. Shell scripts (not caught by previous rules)
+@ .*\.sh 100
+! shell_script 100
+
+@ .*\.conf 99

--- a/scripts/sort_image.py
+++ b/scripts/sort_image.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+import os
+import sys
+import re
+import subprocess
+
+def get_file_info(filepath):
+    """Executes the 'file' utility to get raw metadata for the given file."""
+    try:
+        # -r: raw, -N: no padding, -F '': no separator for cleaner parsing
+        result = subprocess.check_output(
+            ['file', '-r', '-N', '-F', '', filepath], 
+            stderr=subprocess.STDOUT, 
+            universal_newlines=True
+        )
+        return result
+    except subprocess.Called_ProcessError:
+        return ""
+
+def is_executable_elf(filepath):
+    """Checks for +x permission and ELF format."""
+    if os.access(filepath, os.X_OK):
+        info = get_file_info(filepath)
+        return "ELF" in info
+    return False
+
+def is_shell_script(filepath):
+    """Checks if the file is a POSIX shell script via 'file' utility."""
+    info = get_file_info(filepath)
+    return "shell script" in info.lower() or "POSIX shell script" in info
+
+# Function mapping for the '!' instruction
+FUNCTIONS = {
+    "executable": is_executable_elf,
+    "shell_script": is_shell_script
+}
+
+def main():
+    if len(sys.argv) < 4:
+        print("Usage: ./sort_image.py <scan_dir> <template_file> <unsorted_file>")
+        sys.exit(1)
+
+    scan_dir = sys.argv[1]
+    template_path = sys.argv[2]
+    unsorted_output = sys.argv[3]
+
+    # 1. Recursive scan of the directory - FILTERING START
+    all_files = []
+    for root, _, files in os.walk(scan_dir):
+        for f in files:
+            full_path = os.path.join(root, f)
+            
+            # CRITICAL FILTERS: 
+            # 1. Skip symbolic links (islink check must come first)
+            # 2. Ensure it's a regular file (not a pipe, socket, or device)
+            if os.path.islink(full_path):
+                continue
+            if not os.path.isfile(full_path):
+                continue
+
+            rel_path = os.path.relpath(full_path, scan_dir)
+            all_files.append({'abs': full_path, 'rel': rel_path})
+    # FILTERING END
+
+    sorted_list = []
+
+    # 2. Process the template line by line
+    try:
+        with open(template_path, 'r') as t:
+            for line in t:
+                line = line.strip()
+                if not line or line.startswith('#'):
+                    continue
+
+                parts = line.split()
+                if len(parts) < 3:
+                    continue
+
+                cmd = parts[0]      # ! or @
+                pattern = parts[1]  # func name or regex
+                priority = parts[2] # priority number
+
+                matched_files = []
+
+                for f_obj in all_files:
+                    is_match = False
+                    
+                    if cmd == '!':
+                        func = FUNCTIONS.get(pattern)
+                        if func and func(f_obj['abs']):
+                            is_match = True
+                    
+                    elif cmd == '@':
+                        try:
+                            if re.search(pattern, f_obj['rel']):
+                                is_match = True
+                        except re.error:
+                            continue
+
+                    if is_match:
+                        sorted_list.append(f"{f_obj['rel']} {priority}")
+                        matched_files.append(f_obj)
+
+                for match in matched_files:
+                    all_files.remove(match)
+
+    except FileNotFoundError:
+        print(f"Error: Template file '{template_path}' not found.")
+        sys.exit(1)
+
+    for entry in sorted_list:
+        print(entry)
+
+    with open(unsorted_output, 'w') as u:
+        for f_obj in all_files:
+            u.write(f_obj['rel'] + '\n')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The problem: though the mksquashfs makes some sorting before it does compression, it sorts according to the file extension (according to the doc). This approach has some fundamental drawbacks:

1. The versionized shared objects like libubox.so.23123 have a distinct file extension from all other shared objects
2. Scripts and executables without any extension go mixed
3. No controllable grouping  of shared objects and ELF-executables.

My modification utilizes the yet unused feature of mksquashfs which allows to sort files using specified priorities listed in the special sort file. But we don't (mostly) assign each file in the image a priority instead I've made a small DSL to describe a template for the sort file. During rootfs stage this template is applied via the supplied python script and the sort file is generated.

For now the DSL (and the script) supports either direct file path regexp (lines starting with @) or calling some classification functions (lines starting with !) of which there are currently two: executable and shell_script.

Also it produces a list of non-classified full file names so you can tune the template in the future.

This approach alone gave me ~24Kb of squashfs on a ~2Mb rootfs compressed with XZ.