### PR TITLE
bcm53xx: fix target name of meraki_mx64-a0

### DIFF
--- a/target/linux/bcm53xx/image/Makefile
+++ b/target/linux/bcm53xx/image/Makefile
@@ -459,13 +459,13 @@ define Device/meraki_mx64
 endef
 TARGET_DEVICES += meraki_mx64
 
-define Device/meraki_mx64_a0
+define Device/meraki_mx64-a0
   $(call Device/meraki_mx64)
   DEVICE_VARIANT := A0
   DEVICE_DTS_CONFIG := config@2
   DEVICE_DTS := bcm958625-meraki-mx64-a0
 endef
-TARGET_DEVICES += meraki_mx64_a0
+TARGET_DEVICES += meraki_mx64-a0
 
 define Device/meraki_mx65
   $(call Device/meraki_mx6x)


### PR DESCRIPTION
The target name of meraki_mx64-a0 in
target/linux/bcm53xx/image/Makefile used not to be consistent with the one defined in target/linux/bcm53xx/base-files/lib/upgrade/platform.sh and generates warning for "Image check failed" during sysupgrade.

This commit would also make the target name for meraki_mx64-a0 to conform to the openwrt standard.
