### PR TITLE
ramips: remove obsolete SPI flash nodes after kernel fix

### DIFF
--- a/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_archer-c5-v4.dts
@@ -80,13 +80,6 @@
 	};
 };
 
-&spi0 {
-	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-	};
-};
-
 &state_default {
 	gpio {
 		groups = "i2c", "uartf", "ephy", "rgmii2";

--- a/target/linux/ramips/dts/mt7620a_tplink_ec220-g5-v2.dts
+++ b/target/linux/ramips/dts/mt7620a_tplink_ec220-g5-v2.dts
@@ -88,13 +88,6 @@
 	};
 };
 
-&spi0 {
-	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
-	};
-};
-
 &state_default {
 	gpio {
 		groups = "i2c", "uartf", "ephy", "rgmii2";

--- a/target/linux/ramips/dts/mt7621_plasmacloud_pax1800-lite.dts
+++ b/target/linux/ramips/dts/mt7621_plasmacloud_pax1800-lite.dts
@@ -94,8 +94,6 @@
 	num-cs = <2>;
 
 	flash@0 {
-		#address-cells = <1>;
-		#size-cells = <1>;
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <20000000>;
 		reg = <0>;


### PR DESCRIPTION
Remove incomplete SPI flash definitions from affected device tree files. These fragments only defined address-cells and size-cells without any actual flash configuration (partitions, compatible string, etc.).

After applying openwrt/openwrt#20942 ("kernel: of: fix bad cell count error for SPI flash node"), the kernel properly handles SPI flash nodes without requiring these incomplete definitions in device-specific DTS files.

This cleanup eliminates unnecessary code that was likely a workaround for the previous kernel issue.