### PR TITLE
generic: Fixed FTB when CONFIG_MODULES=n

### DIFF
--- a/target/linux/generic/pending-6.12/205-backtrace_module_info.patch
+++ b/target/linux/generic/pending-6.12/205-backtrace_module_info.patch
@@ -3,37 +3,44 @@ Subject: kernel: when KALLSYMS is disabled, print module address + size for matc
 
 [john@phrozen.org: felix will add this to his upstream queue]
 
+dmitrmax@gmail.com: fixed FTB when CONFIG_MODULES=n
+
 lede-commit 53827cdc824556cda910b23ce5030c363b8f1461
 Signed-off-by: Felix Fietkau <nbd@nbd.name>
+Signed-off-by: Maksim Dmitrichenko <dmitrmax@gmail.com>
 ---
  lib/vsprintf.c | 15 +++++++++++----
  1 file changed, 11 insertions(+), 4 deletions(-)
 
 --- a/lib/vsprintf.c
 +++ b/lib/vsprintf.c
-@@ -983,8 +983,10 @@ char *symbol_string(char *buf, char *end
+@@ -983,8 +983,12 @@ char *symbol_string(char *buf, char *end
  		    struct printf_spec spec, const char *fmt)
  {
  	unsigned long value;
 -#ifdef CONFIG_KALLSYMS
  	char sym[KSYM_SYMBOL_LEN];
 +#ifndef CONFIG_KALLSYMS
++#ifdef CONFIG_MODULES
 +	struct module *mod;
++#endif
 +	int len;
  #endif
  
  	if (fmt[1] == 'R')
-@@ -1005,8 +1007,14 @@ char *symbol_string(char *buf, char *end
+@@ -1005,8 +1009,16 @@ char *symbol_string(char *buf, char *end
  
  	return string_nocheck(buf, end, sym, spec);
  #else
 -	return special_hex_number(buf, end, value, sizeof(void *));
 +	len = snprintf(sym, sizeof(sym), "0x%lx", value);
++#ifdef CONFIG_MODULES
 +	mod = __module_address(value);
 +	if (mod)
 +		snprintf(sym + len, sizeof(sym) - len, " [%s@%p+0x%x]",
 +			 mod->name, mod->mem[MOD_TEXT].base,
 +			 mod->mem[MOD_TEXT].size);
++#endif
  #endif
 +	return string(buf, end, sym, spec);
  }


### PR DESCRIPTION
Kernel failed to build with modules turned off because of the OpenWRT specific patch to lib/vsprintf.c. This PR fixes the patch (but not creating another one on top) as it is marked as pending - I guess nobody would ever accept it upstream if it causes FTB on a legal configuration.