### PR TITLE
wifi-scripts: ucode: fix ieee80211w default

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -433,8 +433,7 @@
 		"ieee80211w": {
 			"description": "Enables MFP (802.11w) support (0 = disabled, 1 = optional, 2 = required). Requires the 'full' version of wpad/hostapd and support from the Wi-Fi driver",
 			"type": "number",
-			"enum": [ 0, 1, 2 ],
-			"default": 0
+			"enum": [ 0, 1, 2 ]
 		},
 		"ieee80211w_max_timeout": {
 			"type": "alias",


### PR DESCRIPTION
This should not be defaulted to anything in the schema.

What seemed like a minor cleanup actually broke this as the schema defines a default value already. I did not notice as I had this explicitly set in my config.

Fixes: 70ba7512 ("wifi-scripts: ucode: allow sae_pwe to be modified for AP mode")