### PR TITLE
mediatek: dts: drop wrong sgmiisys0 node override

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
@@ -239,7 +239,3 @@
 	nvmem-cells = <&eeprom_factory_0>;
 	status = "okay";
 };
-
-&sgmiisys0 {
-	/delete-node/ mediatek,pnswap;
-};

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
@@ -281,7 +281,3 @@
 	nvmem-cells = <&eeprom_factory_0>;
 	status = "okay";
 };
-
-&sgmiisys0 {
-	/delete-node/ mediatek,pnswap;
-};

--- a/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
+++ b/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
@@ -458,7 +458,3 @@
 	pinctrl-0 = <&pcie_pins>;
 	status = "okay";
 };
-
-&sgmiisys0 {
-	/delete-node/ mediatek,pnswap;
-};


### PR DESCRIPTION
The sgmiisys0 override uses

  /delete-node/ mediatek,pnswap;

but mediatek,pnswap is a property, not a child node. The correct directive would be /delete-property/. As a result, this statement never had any effect and the property was never removed.

Drop the incorrect override.

P.S. While adding support for Keenetic devices, I used the OpenWrt One as a reference platform, which caused this mistake to be carried over. The mismatch was later discovered accidentally during work on uboot with Airoha EN8811 support.