### PR TITLE
[25.12]: mvebu: add support for RIPE Atlas Probe v5

### DIFF
--- a/package/boot/uboot-mvebu/Makefile
+++ b/package/boot/uboot-mvebu/Makefile
@@ -75,12 +75,20 @@ define U-Boot/rb5009
   UBOOT_IMAGE:=u-boot.elf
 endef
 
+define U-Boot/atlas
+  NAME:=RIPE Atlas Probe v5
+  BUILD_DEVICES:=ripe_atlas-v5
+  BUILD_SUBTARGET:=cortexa53
+  UBOOT_CONFIG:=turris_mox
+endef
+
 UBOOT_TARGETS:= \
 	mox \
 	clearfog \
 	helios4 \
 	omnia \
 	espressobin \
+	atlas \
 	uDPU \
 	eDPU \
 	rb5009

--- a/target/linux/mvebu/cortexa53/base-files/etc/board.d/01_leds
+++ b/target/linux/mvebu/cortexa53/base-files/etc/board.d/01_leds
@@ -13,6 +13,9 @@ cznic,turris-mox)
 glinet,gl-mv1000)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	;;
+ripe,atlas-v5)
+	ucidef_set_led_heartbeat "lan" "LAN" "red:activity"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/mvebu/cortexa53/base-files/etc/board.d/02_network
+++ b/target/linux/mvebu/cortexa53/base-files/etc/board.d/02_network
@@ -44,6 +44,9 @@ methode,edpu)
 	ucidef_set_interfaces_lan_wan "eth1" "eth0"
 	fi
 	;;
+ripe,atlas-v5)
+	ucidef_set_interface_lan "eth0"
+	;;
 *)
 	ucidef_set_interface_lan "eth0"
 	;;

--- a/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/armada-3720-atlas-v5.dts
+++ b/target/linux/mvebu/files/arch/arm64/boot/dts/marvell/armada-3720-atlas-v5.dts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Device Tree file for RIPE Atlas Probe v5
+ * 2025 by Marek Behún <kabel@kernel.org>
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/bus/moxtet.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include "armada-372x.dtsi"
+
+/ {
+	model = "RIPE Atlas Probe v5";
+	compatible = "ripe,atlas-v5", "marvell,armada3720",
+		     "marvell,armada3710";
+
+	aliases {
+		ethernet0 = &eth0;
+		mmc0 = &sdhci0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x00000000 0x00000000 0x20000000>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led {
+			gpios = <&gpiosb 21 GPIO_ACTIVE_LOW>;
+			function = LED_FUNCTION_ACTIVITY;
+			color = <LED_COLOR_ID_RED>;
+			linux,default-trigger = "default-on";
+		};
+	};
+
+	vsdc_reg: vsdc-reg {
+		compatible = "regulator-gpio";
+		regulator-name = "vsdc";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+
+		gpios = <&gpiosb 23 GPIO_ACTIVE_HIGH>;
+		gpios-states = <0>;
+		states = <1800000 0x1
+			  3300000 0x0>;
+		enable-active-high;
+	};
+
+	firmware {
+		armada-3700-rwtm {
+			compatible = "marvell,armada-3700-rwtm-firmware", "cznic,turris-mox-rwtm";
+		};
+	};
+};
+
+&uart0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart1_pins>;
+	status = "okay";
+};
+
+&eth0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii_pins>;
+	phy-mode = "rgmii-id";
+	phy-handle = <&phy1>;
+	status = "okay";
+};
+
+&sdhci0 {
+	non-removable;
+	bus-width = <4>;
+	mmc-ddr-1_8v;
+	mmc-hs400-1_8v;
+	sd-uhs-sdr104;
+	marvell,xenon-emmc;
+	marvell,xenon-tun-count = <9>;
+	marvell,pad-type = "fixed-1-8v";
+	vqmmc-supply = <&vsdc_reg>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&mmc_pins>;
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+	mmccard: mmccard@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+	};
+};
+
+&mdio {
+	pinctrl-names = "default";
+	pinctrl-0 = <&smi_pins>;
+	status = "okay";
+
+	phy1: ethernet-phy@1 {
+		reg = <1>;
+	};
+};

--- a/target/linux/mvebu/image/cortexa53.mk
+++ b/target/linux/mvebu/image/cortexa53.mk
@@ -121,3 +121,12 @@ define Device/methode_edpu
   KERNEL_INITRAMFS := kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
 endef
 TARGET_DEVICES += methode_edpu
+
+define Device/ripe_atlas-v5
+  $(call Device/Default-arm64)
+  DEVICE_VENDOR := RIPE
+  DEVICE_MODEL := Atlas v5
+  SOC := armada-3720
+  BOOT_SCRIPT := ripe-atlas
+endef
+TARGET_DEVICES += ripe_atlas-v5

--- a/target/linux/mvebu/image/ripe-atlas.bootscript
+++ b/target/linux/mvebu/image/ripe-atlas.bootscript
@@ -1,0 +1,51 @@
+if part uuid ${devtype} ${devnum}:${distro_bootpart} bootuuid; then
+	if test "${bootfstype}" = "btrfs"; then
+		# Original BTRFS partition layout
+		rootdev="PARTUUID=${bootuuid}"
+		rootflags="commit=5,subvol=@"
+		bootpath="/@/boot"
+	else
+		# OpenWrt default ext4 bootpart + rootpart layout
+		setexpr rootpart ${distro_bootpart} + 1
+		rootdev="/dev/mmcblk0p${rootpart}"
+		rootflags="commit=5"
+		bootpath="/"
+	fi
+
+	load ${devtype} ${devnum}:${distro_bootpart} ${fdt_addr_r} ${bootpath}/armada-3720-atlas-v5.dtb
+	if test "$filesize" != "0"; then
+		has_dtb=1
+	else
+		setenv has_dtb 0
+		echo "Cannot find device tree binary!"
+	fi
+
+	if test $has_dtb -eq 1; then
+		load ${devtype} ${devnum}:${distro_bootpart} ${kernel_addr_r} ${bootpath}/Image
+		if test "$filesize" = "0"; then
+			echo "Failed to load ${bootpath}/Image"
+			echo "Now trying ${bootpath}/Image.lzma"
+			tmp_addr_r=0x10000000
+			load ${devtype} ${devnum}:${distro_bootpart} ${tmp_addr_r} ${bootpath}/Image.lzma
+			if test "$filesize" != "0"; then
+				if lzmadec ${tmp_addr_r} ${kernel_addr_r}; then
+					echo "Successfully decompressed Image.lzma"
+				else
+					echo "Failed decompressing Image.lzma"
+					filesize=0
+				fi
+			else
+				echo "Failed to load ${subvol}/boot/Image.lzma"
+			fi
+		fi
+		if test "$filesize" != "0"; then
+			setenv bootargs "earlyprintk console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000 rootfstype=${bootfstype} root=${rootdev} rootflags=${rootflags} rootwait ${contract} rw cfg80211.freg=${regdomain} ${quirks}"
+			booti ${kernel_addr_r} - ${fdt_addr_r}
+			echo "Booting Image failed"
+		else
+			echo "Cannot load kernel binary"
+		fi
+	fi
+
+	env delete bootuuid rootpart
+fi


### PR DESCRIPTION
This PR backports support for the RIPE Atlas Probe v5 to 25.12. (#20031)

As the v5 Probe is based on the Turris MOX (which is already supported in 25.12), I believe backporting the v5 Probe is sensible.

Description of the original PR (for `main`):
> RIPE Atlas Probe v5 is a network measurement device based on Turris MOX.
> 
> u-boot bootscript supports booting both from the original Turris BTRFS layout and default OpenWRT ext4 boot + root partition layout.
> 
> `armada-3720-atlas-v5.dts` has been submitted to the Kernel for review.
> 
> Specifications:
> 
> - SoC: Marvell ARMADA 3720
> - RAM: 512 MiB, DDR3
> - eMMC: 4G
> - Ethernet: 1x 1GbE
> 
> Flash instructions are described in the commit message.

Link: https://github.com/openwrt/openwrt/pull/20031
(cherry picked from commit 0271f2ee3649fcabcf5cb989743bbbdc38b34b3e)

Thanks again @tmacholda for that PR! :)