### PR TITLE
tools/cmake: update to 4.2.3

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=4.2.0
+PKG_VERSION:=4.2.3
 PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
@@ -15,7 +15,7 @@ PKG_CPE_ID:=cpe:/a:kitware:cmake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
 		https://cmake.org/files/v$(PKG_VERSION_MAJOR)/
-PKG_HASH:=4104e94657d247c811cb29985405a360b78130b5d51e7f6daceb2447830bd579
+PKG_HASH:=7efaccde8c5a6b2968bad6ce0fe60e19b6e10701a12fce948c2bf79bac8a11e9
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1

--- a/tools/cmake/patches/160-disable_xcode_generator.patch
+++ b/tools/cmake/patches/160-disable_xcode_generator.patch
@@ -11,7 +11,7 @@
      PRIVATE
 --- a/Source/cmake.cxx
 +++ b/Source/cmake.cxx
-@@ -143,7 +143,7 @@
+@@ -142,7 +142,7 @@
  #  endif
  #endif
  


### PR DESCRIPTION
Update cmake to version 4.2.3.
* refresh patches

Minor update, no major feature changes compared to 4.2.0: 
https://cmake.org/cmake/help/v4.2/release/4.2.html#id18

Tested by compiling mediatek/RT3200 firmware with the updated cmake in toolchain.
