### PR TITLE
bcm53xx: meraki mx6x: use nvmem MAC assignment

### DIFF
--- a/target/linux/bcm53xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm53xx/base-files/etc/board.d/02_network
@@ -71,12 +71,6 @@ bcm53xx_setup_macs()
 		etXmacaddr=$(nvram get et0macaddr)
 		offset=5
 		;;
-	meraki,mx64 | \
-	meraki,mx64-a0 | \
-	meraki,mx65)
-		etXmacaddr=$(get_mac_binary "/sys/bus/i2c/devices/0-0050/eeprom" 0x66)
-		offset=1
-		;;
 	*)
 		etXmacaddr=$(nvram get et0macaddr)
 		offset=1

--- a/target/linux/bcm53xx/patches-6.12/340-meraki-mx6x-mac-base.patch
+++ b/target/linux/bcm53xx/patches-6.12/340-meraki-mx6x-mac-base.patch
@@ -1,0 +1,53 @@
+--- a/arch/arm/boot/dts/broadcom/bcm958625-meraki-alamo.dtsi
++++ b/arch/arm/boot/dts/broadcom/bcm958625-meraki-alamo.dtsi
+@@ -254,11 +254,17 @@
+ 		port@0 {
+ 			label = "wan1";
+ 			reg = <0>;
++
++			nvmem-cells = <&mac_address 1>;
++			nvmem-cell-names = "mac-address";
+ 		};
+ 
+ 		port@1 {
+ 			label = "wan2";
+ 			reg = <1>;
++
++			nvmem-cells = <&mac_address 1>;
++			nvmem-cell-names = "mac-address";
+ 		};
+ 
+ 		sgmii0: port@4 {
+--- a/arch/arm/boot/dts/broadcom/bcm958625-meraki-kingpin.dtsi
++++ b/arch/arm/boot/dts/broadcom/bcm958625-meraki-kingpin.dtsi
+@@ -154,6 +154,9 @@
+ 		port@4 {
+ 			label = "wan";
+ 			reg = <4>;
++
++			nvmem-cells = <&mac_address 1>;
++			nvmem-cell-names = "mac-address";
+ 		};
+ 
+ 		port@8 {
+--- a/arch/arm/boot/dts/broadcom/bcm958625-meraki-mx6x-common.dtsi
++++ b/arch/arm/boot/dts/broadcom/bcm958625-meraki-mx6x-common.dtsi
+@@ -39,7 +39,7 @@
+ 
+ &amac2 {
+ 	status = "okay";
+-	nvmem-cells = <&mac_address>;
++	nvmem-cells = <&mac_address 0>;
+ 	nvmem-cell-names = "mac-address";
+ };
+ 
+@@ -62,7 +62,9 @@
+ 			#size-cells = <1>;
+ 
+ 			mac_address: mac-address@66 {
++				compatible = "mac-base";
+ 				reg = <0x66 0x6>;
++				#nvmem-cell-cells = <1>;
+ 			};
+ 		};
+ 	};


### PR DESCRIPTION
Userspace handling is deprecated. Once mac-base goes upstream, the patch itself can go upstream as well.

ping @Leo-PL 