### PR TITLE
mediatek: update Tenda BE12 Pro support

### DIFF
--- a/target/linux/mediatek/dts/mt7987a-tenda-be12-pro.dts
+++ b/target/linux/mediatek/dts/mt7987a-tenda-be12-pro.dts
@@ -12,7 +12,7 @@
 	compatible = "tenda,be12-pro", "mediatek,mt7987a", "mediatek,mt7987";
 
 	aliases {
-		label-mac-device = &gmac2;
+		label-mac-device = &gmac0;
 		led-boot = &led_status_green;
 		led-failsafe = &led_status_red;
 		led-running = &led_status_green;
@@ -80,13 +80,13 @@
 
 			partition@0 {
 				label = "Bootloader";
-				reg = <0x00000 0x0300000>;
+				reg = <0x000000 0x0300000>;
 				read-only;
 			};
 
 			partition@300000 {
 				label = "u-boot-env";
-				reg = <0x0300000 0x0080000>;
+				reg = <0x300000 0x0080000>;
 			};
 
 			partition@380000 {
@@ -113,7 +113,7 @@
 
 			partition@780000 {
 				label = "kernel";
-				reg = <0x780000 0x600000>;
+				reg = <0x780000 0x0600000>;
 			};
 
 			partition@d80000 {
@@ -140,7 +140,7 @@
 	phy-mode = "2500base-x";
 	status = "okay";
 
-	nvmem-cells = <&macaddr_factory_4 (-1)>;
+	nvmem-cells = <&macaddr_factory_4 (-2)>;
 	nvmem-cell-names = "mac-address";
 
 	fixed-link {
@@ -155,7 +155,7 @@
 	phy-handle = <&phy15>;
 	status = "okay";
 
-	nvmem-cells = <&macaddr_factory_4 (-3)>;
+	nvmem-cells = <&macaddr_factory_4 (-2)>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -164,7 +164,7 @@
 	phy-handle = <&phy11>;
 	status = "okay";
 
-	nvmem-cells = <&macaddr_factory_4 (-2)>;
+	nvmem-cells = <&macaddr_factory_4 (-1)>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -273,14 +273,14 @@
 
 				port@0 {
 					reg = <0>;
-					label = "lan1";
+					label = "lan5";
 					phy-mode = "internal";
 					phy-handle = <&internal_phy1>;
 				};
 
 				port@1 {
 					reg = <1>;
-					label = "lan2";
+					label = "lan4";
 					phy-mode = "internal";
 					phy-handle = <&internal_phy2>;
 				};
@@ -351,11 +351,11 @@
 
 	pcie@0,0 {
 		reg = <0x0000 0 0 0 0>;
+		device_type = "pci";
 
 		mt7992@0,0 {
 			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
-			device_type = "pci";
 
 			nvmem-cells = <&eeprom_factory_0>;
 			nvmem-cell-names = "eeprom";
@@ -368,13 +368,13 @@
 
 			band@0 {
 				reg = <0>;
-				nvmem-cells = <&macaddr_factory_4 (0)>;
+				nvmem-cells = <&macaddr_factory_4 1>;
 				nvmem-cell-names = "mac-address";
 			};
 
 			band@1 {
 				reg = <1>;
-				nvmem-cells = <&macaddr_factory_4 (1)>;
+				nvmem-cells = <&macaddr_factory_4 3>;
 				nvmem-cell-names = "mac-address";
 			};
 		};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -178,7 +178,7 @@ mediatek_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2" eth1
 		;;
 	tenda,be12-pro)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 eth1" eth2
+		ucidef_set_interfaces_lan_wan "lan3 lan4 lan5 eth1" eth2
 		;;
 	tplink,fr365-v1)
 		ucidef_set_interfaces_lan_wan "port1 port3 port4 port5 port6" "port2"


### PR DESCRIPTION
- Update network port names based on the shell

- Fix boot log errors:
`OF: /soc/pcie@11280000/pcie@0,0: Missing device_type`

- Match vendor firmware Ethernet and wireless MAC addresses

```
LAN MAC 50:xx:xx:xx:xx:60
WAN MAC 50:xx:xx:xx:xx:61
2G  MAC 50:xx:xx:xx:xx:63
5G  MAC 50:xx:xx:xx:xx:65
```