### PR TITLE
ramips: add support for Wavlink wl-wn531ax2

### DIFF
--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn531ax2.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn531ax2.dts
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "wavlink,wl-wn531ax2", "mediatek,mt7621-rfb-nor", "mt7621-rfb-ax-nor", "mediatek,mt7621-soc";
+	model = "Wavlink WL-WN531AX2";
+
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_red;
+		label-mac-device = &gmac0;
+	};
+
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wifi {
+			label = "blue:wifi";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led_status_blue:status_blue {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: status_red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		touch { /* RH6015C touch sensor -> GPIO 14 */
+			label = "Touch Button";
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+		};
+
+		turbo {
+			label = "turbo";
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+};
+
+&i2c {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <0x989680>;
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x00000 0x30000>;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@50000 {
+				label = "factory";
+				reg = <0x50000 0x40000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0xe00>;
+					};
+
+					macaddr_factory_3fff4: macaddr@3fff4 {
+						reg = <0x3fff4 0x6>;
+					};
+
+					macaddr_factory_3fffa: macaddr@3fffa {
+						reg = <0x3fffa 0x6>;
+					};
+
+				};
+			};
+
+			partition@90000 {
+				label = "firmware";
+				reg = <0x90000 0xf70000>;
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				kernel@0 {
+					reg = <0x0 0x400000>;
+				};
+
+				rootfs@400000 {
+					reg = <0x400000 0xb70000>;
+				};
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		mediatek,disable-radar-background;
+	};
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_3fff4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port0: port@0 {
+			status = "okay";
+		};
+
+		port1: port@1 {
+			status = "okay";
+		};
+
+		port2: port@2 {
+			status = "okay";
+		};
+
+		port3: port@3 {
+			status = "okay";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&macaddr_factory_3fffa>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&port0{
+	label = "lan1";
+};
+
+&port1{
+	label = "lan2";
+};
+
+&port2{
+	label = "lan3";
+};
+
+&port3{
+	label = "lan4";
+};
+
+&state_default {
+	gpio {
+		groups = "rgmii2", "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&uartlite2 {
+	status = "okay";
+};

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn531ax2.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn531ax2.dts
@@ -18,7 +18,6 @@
 		label-mac-device = &gmac0;
 	};
 
-
 	chosen {
 		bootargs = "console=ttyS0,115200";
 	};
@@ -27,12 +26,13 @@
 		compatible = "gpio-leds";
 
 		wifi {
-			label = "blue:wifi";
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
 
-		led_status_blue:status_blue {
+		led_status_blue: status_blue {
 			function = LED_FUNCTION_STATUS;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
@@ -85,7 +85,8 @@
 	flash@0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
-		spi-max-frequency = <0x989680>;
+		spi-max-frequency = <10000000>;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
@@ -122,7 +123,6 @@
 					macaddr_factory_3fffa: macaddr@3fffa {
 						reg = <0x3fffa 0x6>;
 					};
-
 				};
 			};
 

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3272,6 +3272,23 @@ define Device/wavlink_wl-wn531a6
 endef
 TARGET_DEVICES += wavlink_wl-wn531a6
 
+define Device/wavlink_wl-wn531ax2
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := WL-WN531AX2
+  DEVICE_DTS_CONFIG := config@1
+  DEVICE_PACKAGES += kmod-usb3 kmod-mt7915-firmware
+  KERNEL_SIZE := 4096k
+  IMAGE_SIZE := 15040k
+  KERNEL_LOADADDR := 0x83000000
+  SUPPORTED_DEVICES += mt7621-rfb-ax-nor
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | \
+	append-rootfs | pad-rootfs | check-size | append-metadata
+endef
+TARGET_DEVICES += wavlink_wl-wn531ax2
+
 define Device/wavlink_wl-wn533a8
   $(Device/dsa-migration)
   DEVICE_VENDOR := Wavlink

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -210,6 +210,7 @@ ramips_setup_macs()
 	alfa-network,ax1800rm|\
 	jcg,y2|\
 	wavlink,wl-wn531a6|\
+	wavlink,wl-wn531ax2|\
 	wavlink,wl-wn533a8|\
 	winstars,ws-wn583a6|\
 	zbtlink,zbt-we1326|\


### PR DESCRIPTION
Wavlink Easy Mesh AX1800 WN531AX2

Specifications:
- CPU: MediaTek MT7621AT
- RAM: 256MB DDR3 (Nanya NT5CC128M16JR-EK)
- Flash: 16 SPI-NOR
- Ethernet: 1000Base-T x5 (MT7530 SoC)
- WLAN: 2x2 2.4GHz 574Mbps + 2x2 5GHz 1201Mbps (MT7905DAN + MT7975DN)
- LEDs: System (Blue, Red)
- Buttons: Reset, WPS, Touch (RH6015C touch sensor)
- UART: through-hole on PCB 3V3 115200 8N1 (RX, TX, GND)
- Power: 12VDC, 1A

[forum topic](https://forum.openwrt.org/t/openwrt-support-for-wavlink-wl-wn531ax2/140340/6)
[toh](https://openwrt.org/inbox/toh/wavlink/wn531ax2)
