### PR TITLE
mvebu: cortex-a53: uDPU/eDPU: cleanup recipe a bit

### DIFF
--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -138,7 +138,7 @@ endef
 
 define Build/uDPU-firmware
 	(rm -fR $@-fw; mkdir -p $@-fw)
-	$(CP) $(BIN_DIR)/$(DEVICE_IMG_PREFIX)-initramfs.itb $@-fw/recovery.itb
+	$(CP) $(BIN_DIR)/$(KERNEL_INITRAMFS_IMAGE) $@-fw/recovery.itb
 	$(CP) $(IMAGE_ROOTFS) $@-fw/rootfs.tgz
 	$(CP) $@-boot.scr $@-fw/boot.scr
 	$(TAR) -czp --numeric-owner --owner=0 --group=0 --sort=name \

--- a/target/linux/mvebu/image/Makefile
+++ b/target/linux/mvebu/image/Makefile
@@ -149,6 +149,12 @@ define Build/uDPU-firmware
 		-f $(KDIR_TMP)/$(DEVICE_IMG_PREFIX)-firmware.tgz -C $@-fw .
 endef
 
+define Device/FitImage
+  KERNEL_SUFFIX := -uImage.itb
+  KERNEL = kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
+  KERNEL_NAME := Image
+endef
+
 define Device/Default
   PROFILES := Default
   DEVICE_DTS = $$(SOC)-$(lastword $(subst _, ,$(1)))

--- a/target/linux/mvebu/image/cortexa53.mk
+++ b/target/linux/mvebu/image/cortexa53.mk
@@ -99,12 +99,11 @@ TARGET_DEVICES += marvell_armada-3720-db
 
 define Device/methode_udpu
   $(call Device/Default-arm64)
+  $(call Device/FitImage)
   DEVICE_VENDOR := Methode
   DEVICE_MODEL := micro-DPU (uDPU)
   DEVICE_DTS := armada-3720-uDPU
   KERNEL_LOADADDR := 0x00800000
-  KERNEL_INITRAMFS := kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
-  KERNEL_INITRAMFS_SUFFIX := .itb
   DEVICE_PACKAGES += f2fs-tools fdisk kmod-i2c-pxa kmod-hwmon-lm75 kmod-dsa-mv88e6xxx
   DEVICE_IMG_NAME = $$(DEVICE_IMG_PREFIX)-$$(2)
   FILESYSTEMS := targz
@@ -118,7 +117,6 @@ define Device/methode_edpu
   $(call Device/methode_udpu)
   DEVICE_MODEL := eDPU
   DEVICE_DTS := armada-3720-eDPU
-  KERNEL_INITRAMFS := kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
 endef
 TARGET_DEVICES += methode_edpu
 

--- a/target/linux/mvebu/image/cortexa72.mk
+++ b/target/linux/mvebu/image/cortexa72.mk
@@ -2,12 +2,6 @@ define Build/append-bootscript
 	cat $@-boot.scr >> $@
 endef
 
-define Device/FitImage
-  KERNEL_SUFFIX := -uImage.itb
-  KERNEL = kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
-  KERNEL_NAME := Image
-endef
-
 define Device/UbiFit
   KERNEL_IN_UBI := 1
   IMAGES := factory.ubi sysupgrade.bin

--- a/target/linux/mvebu/image/udpu.bootscript
+++ b/target/linux/mvebu/image/udpu.bootscript
@@ -19,17 +19,12 @@ if test ${kernel_addr_r}; then
 	setenv kernel_addr_r 0x5000000
 fi
 
-if test ${fdt_add_r}; then
-	setenv fdt_addr_r 0x4f00000
-fi
-
-setenv console 'console=ttyMV0,115200 earlycon=ar3700_uart,0xd0012000 rootfs_mount_options.compress_algorithm=zstd'
+setenv console 'rootfs_mount_options.compress_algorithm=zstd'
 setenv bootargs ${console} $rootdev rw rootwait
 
-load mmc ${mmcdev}:1 ${fdt_addr_r} @DTB@.dtb
 load mmc ${mmcdev}:1 ${kernel_addr_r} Image
 
-booti ${kernel_addr_r} - ${fdt_addr_r}
+bootm ${kernel_addr_r}
 
 # If the boot command fails, fallback to recovery image
 echo '-- Boot failed, falling back to the recovery image --'


### PR DESCRIPTION
Reuse Device/FitImage recipe instead of open coding it and
drop duplicate KERNEL_INITRAMFS recipe for eDPU.
