### PR TITLE
base-files: sysupgrade: avoid cat on missing conffiles_static

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -146,7 +146,7 @@ list_conffiles() {
 		' /usr/lib/opkg/status
 	elif [ -d /lib/apk/packages ]; then
 		conffiles=""
-		for file in /lib/apk/packages/*.conffiles_static; do
+		for file in $(find /lib/apk/packages -name "*.conffiles_static" -type f); do
 			conffiles="$(echo -e "$(cat $file)\n$conffiles")"
 		done
 		echo "$conffiles"


### PR DESCRIPTION
If the user removes all /lib/apk/packages/*.conffiles* files to prevent sysupgrade from preserving configuration, the glob no longer matches and sysupgrade ends up calling cat on a non-existent path:

  cat: can't open '/lib/apk/packages/*.conffiles_static': No such file or directory

Fix this by checking that a matching file exists before attempting to read it.