### PR TITLE
spi-nor: support for non-uniform erase region description in DTS

### DIFF
--- a/target/linux/generic/files/drivers/mtd/spi-nor/of_regions.c
+++ b/target/linux/generic/files/drivers/mtd/spi-nor/of_regions.c
@@ -1,0 +1,147 @@
+#include <linux/dev_printk.h>
+#include <linux/mtd/mtd.h>
+#include <linux/mtd/spi-nor.h>
+#include <linux/of_platform.h>
+
+#include "core.h"
+
+int spi_nor_parse_of_override(struct spi_nor *nor)
+{
+    struct mtd_info *mtd = &nor->mtd;
+    struct device_node *mtd_node;
+    struct device_node *ofregions_node;
+    struct device_node *pr;
+    struct mtd_erase_region_info *erase_regions;
+    const struct spi_nor_erase_map *erase_map;
+    int nr_regions, i;
+    int ret = 0;
+
+    mtd_node = mtd_get_of_node(mtd);
+    if (!mtd_node) {
+        dev_warn(nor->dev, "MTD OF section is not found.\n");
+		return 0;
+    }
+
+    ofregions_node = of_get_child_by_name(mtd_node, "regions");
+    if (!ofregions_node) {
+        dev_warn(nor->dev, "OF regions section is not found.\n");
+        return 0;
+    }
+
+    /* First count the subnodes */
+	nr_regions = 0;
+	for_each_child_of_node(ofregions_node,  pr) {
+		nr_regions++;
+	}
+
+    if (nr_regions == 0) {
+        dev_warn(nor->dev, "no OF regions in \"regions\" section.\n");
+		goto out_node;
+    }
+
+    erase_map = &nor->params->erase_map;
+
+    if (!erase_map->uniform_erase_type) {
+        dev_warn(nor->dev, "Device has non-uniform layout. This is not yet supported for OF region override.\n");
+
+        ret = -EOPNOTSUPP;
+        goto out_node;
+    }
+
+    erase_regions = devm_kcalloc(nor->dev, nr_regions, sizeof(*erase_regions), GFP_KERNEL);
+    if (!erase_regions) {
+        ret = -ENOMEM;
+        goto out_node;
+    }
+
+    i = 0;
+    for_each_child_of_node(ofregions_node, pr) {
+        const __be32 *reg, *erase_block;
+        int reg_len, erase_block_len;
+        int et;
+        int a_cells, s_cells;
+        uint32_t region_offset, region_size, region_erasesize;
+
+        reg = of_get_property(pr, "reg", &reg_len);
+		if (!reg) {
+			dev_warn(nor->dev, "ofregion region %pOF (%pOF) missing reg property.\n",
+				 pr, mtd_node);
+			goto ofregion_fail;
+		}
+
+        erase_block = of_get_property(pr, "erase-block", &erase_block_len);
+        if (!erase_block) {
+			dev_warn(nor->dev, "ofregion region %pOF (%pOF) missing reg property.\n",
+				 pr, mtd_node);
+			goto ofregion_fail;
+        }
+
+        a_cells = of_n_addr_cells(pr);
+		s_cells = of_n_size_cells(pr);
+
+        if (reg_len / 4 != a_cells + s_cells) {
+			dev_dbg(nor->dev, "ofregion region %pOF (%pOF) error parsing reg property.\n",
+                      pr, mtd_node);
+			goto ofregion_fail;
+		}
+
+        if (erase_block_len / 4 != s_cells) {
+			dev_dbg(nor->dev, "ofregion region %pOF (%pOF) error parsing erase-block property.\n",
+                      pr, mtd_node);
+			goto ofregion_fail;
+		}
+
+        region_offset = of_read_number(reg, a_cells);
+        region_size = of_read_number(reg + a_cells, s_cells);
+        region_erasesize = of_read_number(erase_block, s_cells);
+
+        for(et = 0; et < SNOR_ERASE_TYPE_MAX; et++) {
+            if (erase_map->erase_type[et].size != region_erasesize)
+                continue;
+
+            if (region_offset & erase_map->erase_type[et].size_mask) {
+                dev_warn(nor->dev, "ofregion region %pOF (%pOF) offset is not aligned to the requested erase block 0x%08x.\n", pr, mtd_node, region_offset);
+                goto ofregion_fail;
+            }
+
+            if (region_size & erase_map->erase_type[et].size_mask) {
+                dev_warn(nor->dev, "ofregion region %pOF (%pOF) size is not aligned to the requested erase block 0x%08x.\n", pr, mtd_node, region_size);
+                goto ofregion_fail;
+            }
+
+            break;
+        }
+
+        if (et >= SNOR_ERASE_TYPE_MAX) {
+            dev_warn(nor->dev, "ofregion region %pOF (%pOF) erase block size 0x%06x is not supported by flash device.\n", pr, mtd_node, region_erasesize);
+            goto ofregion_fail;
+        }
+
+        erase_regions[i].offset = region_offset;
+        erase_regions[i].numblocks = region_size >> erase_map->erase_type[et].size_shift;
+        erase_regions[i].erasesize = region_erasesize;
+        erase_regions[i].lockmap = NULL;
+
+        dev_info(nor->dev, "found ofregion 0x%08x@0x%08x with erase block size 0x%06x", region_offset, region_size, region_erasesize);
+
+        i++;
+    }
+
+    mtd->numeraseregions = nr_regions;
+    mtd->eraseregions = erase_regions;
+
+    ret = 0;
+
+    goto out_loop;
+ofregion_fail:
+	dev_err(nor->dev, "error parsing ofregion region %pOF (%pOF)\n",
+	       pr, mtd_node);
+
+    devm_kfree(nor->dev, erase_regions);
+    ret = -EINVAL;
+out_loop:
+    of_node_put(pr);
+out_node:
+    of_node_put(ofregions_node);
+    return ret;
+}

--- a/target/linux/generic/pending-6.12/405-mtd-look-for-master-erase-regions-when-adding-partition.patch
+++ b/target/linux/generic/pending-6.12/405-mtd-look-for-master-erase-regions-when-adding-partition.patch
@@ -1,0 +1,20 @@
+When adding new MTD partitions there is no sense to check numeraseregionw of the parent node if this node is not master it will alwasy have numeraseregions 0
+Index: linux-6.6.122/drivers/mtd/mtdpart.c
+===================================================================
+--- linux-6.6.122.orig/drivers/mtd/mtdpart.c	2026-02-17 12:12:18.349712783 +0400
++++ linux-6.6.122/drivers/mtd/mtdpart.c	2026-02-17 13:12:46.471427849 +0400
+@@ -148,11 +148,11 @@
+ 			part->name, parent->name, child->part.size);
+ 	}
+ 
+-	if (parent->numeraseregions > 1) {
++	if (master->numeraseregions >= 1) {
+ 		/* Deal with variable erase size stuff */
+-		int i, max = parent->numeraseregions;
++		int i, max = master->numeraseregions;
+ 		u64 end = child->part.offset + child->part.size;
+-		struct mtd_erase_region_info *regions = parent->eraseregions;
++		struct mtd_erase_region_info *regions = master->eraseregions;
+ 
+ 		/* Find the first erase regions which is part of this
+ 		 * partition. */

--- a/target/linux/generic/pending-6.12/406-mtd-spi-nor-of-erase-regions-specification.patch
+++ b/target/linux/generic/pending-6.12/406-mtd-spi-nor-of-erase-regions-specification.patch
@@ -1,0 +1,162 @@
+Support for the specification of erase region sizes for SPI-NOR via OF.
+
+Many flashes support for erase blocks other than 64K. But to the moment
+OpenWRT supports only switch to 4K blocks which is not good for JFFS2.
+
+Ideally we'd better have a way to specify 4K for bootloader and its env
+and 32K for the firmware partition.
+
+That way JFFS2 needs only 5x32K blocks, i.e. only 160Kb of flash.
+
+Important: for this to work SFDP read shouldn't be inhibited, otherwise
+driver wouldn't know opcodes for the needed commands. For a unknown reason
+some manufacturer quirks inhibit SFDP parsing.
+
+This patch implements this using OF/DTS, like below:
+	regions {
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		region@0 {
+			reg = <0x0 0x20000>;
+			erase-block = <0x1000>;
+		};
+
+		region@20000 {
+			reg = <0x20000 0x3e0000>;
+			erase-block = <0x8000>;
+		};
+	};
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "breed";
+			reg = <0x0 0x1e000>;
+			read-only;
+		};
+
+		partition@1e000 {
+			label = "breed_env";
+			reg = <0x1e000 0x1000>;
+		};
+
+		partition@1f000 {
+			label = "factory";
+			reg = <0x1f000 0x1000>;
+			read-only;
+            
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@c00 {
+					reg = <0xc00 0x400>;
+				};
+
+				macaddr_uboot_wmac: macaddr@1fc04 {
+					reg = <0xc04 0x6>;
+				};
+
+				macaddr_uboot_eth: macaddr@1fc28 {
+					reg = <0xc28 0x6>;
+				};
+			};
+
+		};
+
+		partition@20000 {
+			compatible = "denx,uimage";
+			label = "firmware";
+			reg = <0x20000 0x3e0000>;
+		};
+	};
+Index: linux-6.12.71/drivers/mtd/spi-nor/Kconfig
+===================================================================
+--- linux-6.12.71.orig/drivers/mtd/spi-nor/Kconfig	2026-02-18 03:02:13.362417089 +0400
++++ linux-6.12.71/drivers/mtd/spi-nor/Kconfig	2026-02-18 03:02:13.358417107 +0400
+@@ -20,6 +20,20 @@
+ 	  For example: A 68K erase will use one 64K erase, and one 4K erase
+ 	  on supporting hardware.
+ 
++config MTD_SPI_NOR_OF_ERASE_REGIONS
++	bool "Support OpenFirmware erase regions specification"
++	depends on OF
++	depends on !MTD_SPI_NOR_USE_4K_SECTORS
++	select MTD_SPI_NOR_USE_VARIABLE_ERASE
++	help
++	  Normaly SPI NOR devices are seen by the driver as the single uniform
++	  erase region. MTD device usually uses the largest erase block
++	  size supported by the flash. If you select this option the kernel
++	  will parse the device tree to split the single region into
++	  multiple regions with custom erase block sizes. Still this requires
++	  for the flash to support requested erase block size and for the region
++	  to be properly aligned.
++
+ config MTD_SPI_NOR_USE_4K_SECTORS
+ 	bool "Use small 4096 B erase sectors"
+ 	default y
+Index: linux-6.12.71/drivers/mtd/spi-nor/Makefile
+===================================================================
+--- linux-6.12.71.orig/drivers/mtd/spi-nor/Makefile	2026-02-18 03:02:13.362417089 +0400
++++ linux-6.12.71/drivers/mtd/spi-nor/Makefile	2026-02-18 03:02:13.358417107 +0400
+@@ -15,6 +15,7 @@
+ spi-nor-objs			+= winbond.o
+ spi-nor-objs			+= xmc.o
+ spi-nor-$(CONFIG_DEBUG_FS)	+= debugfs.o
++spi-nor-$(CONFIG_MTD_SPI_NOR_OF_ERASE_REGIONS) += of_regions.o
+ obj-$(CONFIG_MTD_SPI_NOR)	+= spi-nor.o
+ 
+ obj-$(CONFIG_MTD_SPI_NOR)	+= controllers/
+Index: linux-6.12.71/drivers/mtd/spi-nor/core.h
+===================================================================
+--- linux-6.12.71.orig/drivers/mtd/spi-nor/core.h	2026-02-18 03:02:13.362417089 +0400
++++ linux-6.12.71/drivers/mtd/spi-nor/core.h	2026-02-18 11:14:18.538459067 +0400
+@@ -673,6 +673,10 @@
+ int spi_nor_check_sfdp_signature(struct spi_nor *nor);
+ int spi_nor_parse_sfdp(struct spi_nor *nor);
+ 
++#ifdef CONFIG_MTD_SPI_NOR_OF_ERASE_REGIONS
++int spi_nor_parse_of_override(struct spi_nor *nor);
++#endif
++
+ static inline struct spi_nor *mtd_to_spi_nor(struct mtd_info *mtd)
+ {
+ 	return container_of(mtd, struct spi_nor, mtd);
+@@ -690,7 +694,13 @@
+ 	 * indicator whether we need SFDP parsing for a particular flash. I.e.
+ 	 * non-legacy flash entries in flash_info will have a size of zero iff
+ 	 * SFDP should be used.
++	 *
++	 * But when erase regions feature is enabled the SFDP needs to be read
++	 * in order to find all supported sizes and opcode.
+ 	 */
++	if(IS_ENABLED(CONFIG_MTD_SPI_NOR_OF_ERASE_REGIONS))
++		return true;
++
+ 	return !nor->info->size;
+ }
+ 
+Index: linux-6.12.71/drivers/mtd/spi-nor/core.c
+===================================================================
+--- linux-6.12.71.orig/drivers/mtd/spi-nor/core.c	2026-02-18 02:46:08.038277385 +0400
++++ linux-6.12.71/drivers/mtd/spi-nor/core.c	2026-02-18 11:07:50.270008702 +0400
+@@ -3009,6 +3009,14 @@
+ 			dev_err(nor->dev, "BFPT parsing failed. Please consider using SPI_NOR_SKIP_SFDP when declaring the flash\n");
+ 			return ret;
+ 		}
++#ifdef CONFIG_MTD_SPI_NOR_OF_ERASE_REGIONS
++		err = spi_nor_parse_of_override(nor);
++		if (err < 0) {
++			dev_warn(dev, "Failed to parse device tree erase regions.\n");
++
++			err = 0;
++		}
++#endif
+ 	} else if (nor->info->no_sfdp_flags & SPI_NOR_SKIP_SFDP) {
+ 		spi_nor_no_sfdp_init_params(nor);
+ 	} else {

--- a/target/linux/generic/pending-6.12/479-mtd-spi-nor-add-xtx-xt25f128b.patch
+++ b/target/linux/generic/pending-6.12/479-mtd-spi-nor-add-xtx-xt25f128b.patch
@@ -29,18 +29,22 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  drivers/mtd/spi-nor/spi-nor.c | 4 ++++
  1 file changed, 4 insertions(+)
 
---- a/drivers/mtd/spi-nor/Makefile
-+++ b/drivers/mtd/spi-nor/Makefile
-@@ -14,6 +14,7 @@ spi-nor-objs			+= spansion.o
+Index: linux-6.12.71/drivers/mtd/spi-nor/Makefile
+===================================================================
+--- linux-6.12.71.orig/drivers/mtd/spi-nor/Makefile	2026-02-18 03:02:13.358417107 +0400
++++ linux-6.12.71/drivers/mtd/spi-nor/Makefile	2026-02-18 11:16:50.929253141 +0400
+@@ -14,6 +14,7 @@
  spi-nor-objs			+= sst.o
  spi-nor-objs			+= winbond.o
  spi-nor-objs			+= xmc.o
 +spi-nor-objs			+= xtx.o
  spi-nor-$(CONFIG_DEBUG_FS)	+= debugfs.o
+ spi-nor-$(CONFIG_MTD_SPI_NOR_OF_ERASE_REGIONS) += of_regions.o
  obj-$(CONFIG_MTD_SPI_NOR)	+= spi-nor.o
- 
---- /dev/null
-+++ b/drivers/mtd/spi-nor/xtx.c
+Index: linux-6.12.71/drivers/mtd/spi-nor/xtx.c
+===================================================================
+--- /dev/null	1970-01-01 00:00:00.000000000 +0000
++++ linux-6.12.71/drivers/mtd/spi-nor/xtx.c	2026-02-18 11:16:50.929253141 +0400
 @@ -0,0 +1,20 @@
 +// SPDX-License-Identifier: GPL-2.0
 +#include <linux/mtd/spi-nor.h>
@@ -62,9 +66,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +	.parts = xtx_parts,
 +	.nparts = ARRAY_SIZE(xtx_parts),
 +};
---- a/drivers/mtd/spi-nor/core.c
-+++ b/drivers/mtd/spi-nor/core.c
-@@ -1979,6 +1979,7 @@ static const struct spi_nor_manufacturer
+Index: linux-6.12.71/drivers/mtd/spi-nor/core.c
+===================================================================
+--- linux-6.12.71.orig/drivers/mtd/spi-nor/core.c	2026-02-18 11:07:50.270008702 +0400
++++ linux-6.12.71/drivers/mtd/spi-nor/core.c	2026-02-18 11:19:34.000000000 +0400
+@@ -1979,6 +1979,7 @@
  	&spi_nor_sst,
  	&spi_nor_winbond,
  	&spi_nor_xmc,
@@ -72,9 +78,11 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  };
  
  static const struct flash_info spi_nor_generic_flash = {
---- a/drivers/mtd/spi-nor/core.h
-+++ b/drivers/mtd/spi-nor/core.h
-@@ -593,6 +593,7 @@ extern const struct spi_nor_manufacturer
+Index: linux-6.12.71/drivers/mtd/spi-nor/core.h
+===================================================================
+--- linux-6.12.71.orig/drivers/mtd/spi-nor/core.h	2026-02-18 11:14:18.538459067 +0400
++++ linux-6.12.71/drivers/mtd/spi-nor/core.h	2026-02-18 11:16:50.929253141 +0400
+@@ -593,6 +593,7 @@
  extern const struct spi_nor_manufacturer spi_nor_sst;
  extern const struct spi_nor_manufacturer spi_nor_winbond;
  extern const struct spi_nor_manufacturer spi_nor_xmc;

--- a/target/linux/mediatek/patches-6.12/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
+++ b/target/linux/mediatek/patches-6.12/436-drivers-mtd-spi-nor-Add-calibration-support-for-spi-.patch
@@ -10,9 +10,11 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
  drivers/mtd/spi-nor/core.c  | 15 +++++++++++++++
  2 files changed, 19 insertions(+), 1 deletion(-)
 
---- a/drivers/mtd/nand/spi/core.c
-+++ b/drivers/mtd/nand/spi/core.c
-@@ -1261,7 +1261,10 @@ static int spinand_cal_read(void *priv,
+Index: linux-6.12.71/drivers/mtd/nand/spi/core.c
+===================================================================
+--- linux-6.12.71.orig/drivers/mtd/nand/spi/core.c	2026-02-18 11:20:35.803588843 +0400
++++ linux-6.12.71/drivers/mtd/nand/spi/core.c	2026-02-18 11:20:35.799588872 +0400
+@@ -1261,7 +1261,10 @@
  	if (ret)
  		return ret;
  
@@ -24,9 +26,11 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
  	if (ret < 0)
  		return ret;
  
---- a/drivers/mtd/spi-nor/core.c
-+++ b/drivers/mtd/spi-nor/core.c
-@@ -3300,6 +3300,18 @@ static const struct flash_info *spi_nor_
+Index: linux-6.12.71/drivers/mtd/spi-nor/core.c
+===================================================================
+--- linux-6.12.71.orig/drivers/mtd/spi-nor/core.c	2026-02-18 11:20:35.803588843 +0400
++++ linux-6.12.71/drivers/mtd/spi-nor/core.c	2026-02-18 11:20:35.799588872 +0400
+@@ -3308,6 +3308,18 @@
  	return NULL;
  }
  
@@ -45,7 +49,7 @@ Signed-off-by: SkyLake.Huang <skylake.huang@mediatek.com>
  static const struct flash_info *spi_nor_get_flash_info(struct spi_nor *nor,
  						       const char *name)
  {
-@@ -3474,6 +3486,9 @@ int spi_nor_scan(struct spi_nor *nor, co
+@@ -3482,6 +3494,9 @@
  	if (ret)
  		return ret;
  


### PR DESCRIPTION
With a proper support from the flash chip we can now define regions with non-default (neither 64K no 4K) erase block size using DTS.

With this we  can now place the bootloader's env into a 4K region while giving 32K blocks to JFFS2.

Many flashes support for erase blocks other than 64K. But to the moment
OpenWRT supports only switch to 4K blocks entirely which is not good for JFFS2.

Ideally we'd better have a way to specify 4K for bootloader and its env
and 32K for the firmware partition.

That way the minimal JFFS2 needs only 5x32K blocks, i.e. only 160Kb of flash.

Important: for this to work SFDP read shouldn't be inhibited, otherwise
driver wouldn't know opcodes for the needed commands. That is why
enabling this feature overrides result of `spi_nor_needs_sfdp()` to `true`

This patch implements this concept using OF/DTS, like below:
```
	regions {
		#address-cells = <1>;
		#size-cells = <1>;

		region@0 {
			reg = <0x0 0x20000>;
			erase-block = <0x1000>;
		};

		region@20000 {
			reg = <0x20000 0x3e0000>;
			erase-block = <0x8000>;
		};
	};

	partitions {
		compatible = "fixed-partitions";
		#address-cells = <1>;
		#size-cells = <1>;

		partition@0 {
			label = "breed";
			reg = <0x0 0x1e000>;
			read-only;
		};

		partition@1e000 {
			label = "breed_env";
			reg = <0x1e000 0x1000>;
		};

		partition@1f000 {
			label = "factory";
			reg = <0x1f000 0x1000>;
			read-only;
            
			nvmem-layout {
				compatible = "fixed-layout";
				#address-cells = <1>;
				#size-cells = <1>;

				eeprom_factory_0: eeprom@c00 {
					reg = <0xc00 0x400>;
				};

				macaddr_uboot_wmac: macaddr@1fc04 {
					reg = <0xc04 0x6>;
				};

				macaddr_uboot_eth: macaddr@1fc28 {
					reg = <0xc28 0x6>;
				};
			};

		};

		partition@20000 {
			compatible = "denx,uimage";
			label = "firmware";
			reg = <0x20000 0x3e0000>;
		};
	};
```