### PR TITLE
base-files: avoid confusing rm error messages in failsafe_wait

### DIFF
--- a/package/base-files/files/lib/preinit/30_failsafe_wait
+++ b/package/base-files/files/lib/preinit/30_failsafe_wait
@@ -21,8 +21,8 @@ fs_wait_for_key () {
 		touch $keypress_sec
 	fi
 
-	trap "echo 'true' >$keypress_true; lock -u $keypress_wait ; rm -f $keypress_wait" INT
-	trap "echo 'true' >$keypress_true; lock -u $keypress_wait ; rm -f $keypress_wait" USR1
+	trap "echo 'true' >$keypress_true; lock -u $keypress_wait ; rm -f $keypress_wait 2>/dev/null" INT
+	trap "echo 'true' >$keypress_true; lock -u $keypress_wait ; rm -f $keypress_wait 2>/dev/null" USR1
 
 	[ -n "$timeout" ] || timeout=1
 	[ $timeout -ge 1 ] || timeout=1
@@ -37,7 +37,7 @@ fs_wait_for_key () {
 			sleep 1
 		done
 		lock -u $keypress_wait
-		rm -f $keypress_wait
+		rm -f $keypress_wait 2>/dev/null
 	} &
 
 	local consoles="$(cat /sys/class/tty/console/active)"
@@ -68,7 +68,7 @@ fs_wait_for_key () {
 						;;
 					esac
 					lock -u $keypress_wait
-					rm -f $keypress_wait
+					rm -f $keypress_wait 2>/dev/null
 				}
 			done
 		} &


### PR DESCRIPTION
The fs_wait_for_key function runs multiple background processes that all try to delete the same temporary file ($keypress_wait) when they exit. This creates a race condition where one process successfully deletes the file while others fail with ENOENT.

Busybox rm only suppresses "file not found" errors during the initial lstat() check, not during the actual unlink() call. This causes error messages in the boot log even with rm -f:

  rm: can't remove '/tmp/tmp.hKjPDH': No such file or directory

Fixed by redirecting stderr to /dev/null for rm calls in concurrent contexts. This change does not affect functionality and only avoids confusing log output during boot.