### PR TITLE
realtek: thermal: extend the current driver to support rtl960x

### DIFF
--- a/target/linux/realtek/patches-6.12/330-add-realtek-thernal-driver.patch
+++ b/target/linux/realtek/patches-6.12/330-add-realtek-thernal-driver.patch
@@ -6,10 +6,10 @@
  
 +config REALTEK_THERMAL
 +	tristate "Realtek RTL838x and RTL930x thermal sensor support"
-+	depends on RTL838X || RTL839X || RTL930X || COMPILE_TEST
++	depends on RTL838X || RTL839X || RTL930X || RTL960X || COMPILE_TEST
 +	depends on THERMAL_OF
 +	help
-+	  Support thermal sensor in Realtek RTL838x, RTL839x and RTL930x SoCs
++	  Support thermal sensor in Realtek RTL838x, RTL839x, RTL930x and RTL960x SoCs
 +
  endif
 --- a/drivers/thermal/Makefile


### PR DESCRIPTION
This pull request serves as a part of the series of extending existing or adding new drivers support for the rtl9607c / rtl8198d SoCs and to separate subtarget addition from driver additions.

This commit adds support for RTL9607C / RTL8198D thermal controller in the current `realtek-thermal` driver.

[Realtek SDK](https://github.com/jameywine/GPL-for-GP3000/blob/main/linux-5.10.x/drivers/net/ethernet/realtek/rtl86900/sdk/src/dal/rtl9607c/dal_rtl9607c_switch.c#L3125C1-L3125C32) writes some magic values to different `thermal_ctrl` registers and it is unclear what is behind the REG_X bit fields of these registers. Simple set of `RTL9607_REG_PPOW` bit seems to be enough to initialize thermal controller.
There is also efuse calibration data but for simplicity sake, they are not used for temperature calculation at the moment.

Looking at how temperature is calculated in `dal_dal9607c_switch_thermal_get` from Realtek SDK code, there doesn't seem be any bits for temperature output validation so we have to blindly trust that the readings are correct in the temp calculation function.

As it was the part of the https://github.com/openwrt/openwrt/pull/20064 pull request, testing of the driver on rtl9607 based machine has already been done https://github.com/openwrt/openwrt/pull/20064#issuecomment-3567689064