### PR TITLE
realtek: rtl930x: switch to 320MB/192MB memory layout

### DIFF
--- a/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
+++ b/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
@@ -10,8 +10,8 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x00000000 0x10000000>, /* 256 MiB lowmem */
-		      <0x20000000 0x10000000>; /* 256 MiB highmem */
+		reg = <0x00000000 0x14000000>, /* 320 MiB lowmem */
+		      <0x20000000 0x0c000000>; /* 192 MiB highmem */
 	};
 };
 

--- a/target/linux/realtek/dts/rtl9302_xikestor_sks8300-12e2t2x.dts
+++ b/target/linux/realtek/dts/rtl9302_xikestor_sks8300-12e2t2x.dts
@@ -13,8 +13,8 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x00000000 0x10000000>, /* first 256 MiB */
-		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+		reg = <0x00000000 0x14000000>, /* 320 MiB lowmem */
+		      <0x20000000 0x0c000000>; /* 192 MiB highmem */
 	};
 
 	chosen {

--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
@@ -13,8 +13,8 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x00000000 0x10000000>, /* 256 MiB lowmem */
-		      <0x20000000 0x10000000>; /* 256 MiB highmem */
+		reg = <0x00000000 0x14000000>, /* 320 MiB lowmem */
+		      <0x20000000 0x0c000000>; /* 192 MiB highmem */
 	};
 
 	aliases {

--- a/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f-v2.dts
+++ b/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f-v2.dts
@@ -12,8 +12,8 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x00000000 0x10000000>, /* first 256 MiB */
-		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+		reg = <0x00000000 0x14000000>, /* 320 MiB lowmem */
+		      <0x20000000 0x0c000000>; /* 192 MiB highmem */
 	};
 
 	chosen {

--- a/target/linux/realtek/dts/rtl9303_vimin_vm-s100-0800ms.dts
+++ b/target/linux/realtek/dts/rtl9303_vimin_vm-s100-0800ms.dts
@@ -12,8 +12,8 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x00000000 0x10000000>, /* first 256 MiB */
-		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+		reg = <0x00000000 0x14000000>, /* 320 MiB lowmem */
+		      <0x20000000 0x0c000000>; /* 192 MiB highmem */
 	};
 
 	chosen {

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
@@ -15,8 +15,8 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x00000000 0x10000000>, /* first 256 MiB */
-		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+		reg = <0x00000000 0x14000000>, /* 320 MiB lowmem */
+		      <0x20000000 0x0c000000>; /* 192 MiB highmem */
 	};
 
 	chosen {

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
@@ -12,8 +12,8 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x00000000 0x10000000>, /* first 256 MiB */
-		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+		reg = <0x00000000 0x14000000>, /* 320 MiB lowmem */
+		      <0x20000000 0x0c000000>; /* 192 MiB highmem */
 	};
 
 	aliases {

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
@@ -16,8 +16,8 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x00000000 0x10000000>, /* first 256 MiB */
-		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+		reg = <0x00000000 0x14000000>, /* 320 MiB lowmem */
+		      <0x20000000 0x0c000000>; /* 192 MiB highmem */
 	};
 
 	chosen {

--- a/target/linux/realtek/files-6.18/arch/mips/rtl-otto/prom.c
+++ b/target/linux/realtek/files-6.18/arch/mips/rtl-otto/prom.c
@@ -312,7 +312,7 @@ static void get_system_memory(void)
 static void prepare_highmem(void)
 {
 	if ((soc_info.family != RTL9300_FAMILY_ID) ||
-	    (soc_info.memory_size <= 256 * 1024 * 1024) ||
+	    (soc_info.memory_size <= 320 * 1024 * 1024) ||
 	    !IS_ENABLED(CONFIG_HIGHMEM))
 		return;
 
@@ -328,24 +328,18 @@ static void prepare_highmem(void)
 	 * Whenever CPU accesses memory the normal MIPS translation is applied and afterwards
 	 * the bus adds the zone mapping. E.g. a read to 0x81230000 is converted to an cached
 	 * memory access to logical address 0x01230000. It is issued to the OCP bus and the 
-	 * mapping from zone 1 register is added. That allows for two memory topologies:
+	 * mapping from zone 1 register is added. That allows for this memory topologies:
 	 *
-	 * Linear memory with a maximum of 320 MB:
-	 *
-	 * Zone | map content | logical               | physical
-	 * -------------------+-----------------------+-----------------------
-	 *    1 | 0x00000000  | 0x00000000-0x0fffffff | 0x00000000-0x0fffffff
-	 *    2 | 0x00000000  | 0x10000000-0x13ffffff | 0x10000000-0x13ffffff
-	 *
-	 * 256MB low memory plus up to 2GB high memory:
+	 * 320 MB low memory plus up to 2GB high memory:
 	 *
 	 * Zone | map content | logical               | physical
 	 * -------------------+-----------------------+-----------------------
 	 *    1 | 0x00000000  | 0x00000000-0x0fffffff | 0x00000000-0x0fffffff
-	 *    3 | 0x70000000  | 0x20000000-0x9fffffff | 0x10000000-0x7fffffff
+	 *    1 | 0x00000000  | 0x10000000-0x13ffffff | 0x10000000-0x13ffffff
+	 *    3 | 0x74000000  | 0x20000000-0x9fffffff | 0x14000000-0x7fffffff
 	 */
 
-	pr_info("highmem kernel on RTL930x with > 256 MB RAM, adapt SoC memory mapping\n");
+	pr_info("highmem kernel on RTL930x with > 320 MB RAM, adapt SoC memory mapping\n");
 
 	soc_w32(0, RTL9300_UMSAR0);
 	soc_w32(0, RTL9300_UMSAR1);
@@ -357,7 +351,7 @@ static void prepare_highmem(void)
 	soc_w32(0, RTL9300_SRAMSAR3);
 	__sync();
 
-	soc_w32(0x70000000, RTL9300_O0DOR2);
+	soc_w32(0x74000000, RTL9300_O0DOR2);
 	soc_w32(0x7fffffff, RTL9300_O0DMAR2);
 	__sync();
 }


### PR DESCRIPTION
Highmem is a dead end in linux. Sooner than later it will be removed from the kernel. Thus try to make as much memory as possible available in the low memory area. For the RTL930x devices this means:

- Use 256 MB low memory from zone 1 (0x00000000-0x0fffffff)
- Use  64 MB low memory from zone 2 (0x10000000-0x13ffffff)
- Use rest as highmem   from zone 3 (0x20000000-0x2bffffff)

For more details see prepare_highmem() comment in prom.c
