### PR TITLE
toolchain: sdk: ib: Allow use of external chain as with openwrt toolchain

### DIFF
--- a/target/imagebuilder/Config.in
+++ b/target/imagebuilder/Config.in
@@ -1,6 +1,6 @@
 config IB
 	bool "Build the OpenWrt Image Builder"
-	depends on !EXTERNAL_TOOLCHAIN
+	depends on !EXTERNAL_TOOLCHAIN || EXTERNAL_TOOLCHAIN_IB
 	default BUILDBOT
 	help
 	  This is essentially a stripped-down version of the buildroot

--- a/target/sdk/Config.in
+++ b/target/sdk/Config.in
@@ -1,6 +1,6 @@
 config SDK
 	bool "Build the OpenWrt SDK"
-	depends on !EXTERNAL_TOOLCHAIN
+	depends on !EXTERNAL_TOOLCHAIN || EXTERNAL_TOOLCHAIN_SDK
 	default BUILDBOT
 	help
 	  This is essentially a stripped-down version of the buildroot

--- a/toolchain/Config.in
+++ b/toolchain/Config.in
@@ -194,6 +194,22 @@ menuconfig EXTERNAL_TOOLCHAIN
 		  Specify additional directories searched for libraries (override LDFLAGS).
 		  Use ./DIR for directories relative to the root above.
 
+	config EXTERNAL_TOOLCHAIN_IB
+		bool
+		prompt "Allow Imagebuilder with external toolchain" if DEVEL
+		depends on EXTERNAL_TOOLCHAIN
+		default n
+		help
+		  Allows selecting to build ImageBuilder even with external toolchain.
+
+	config EXTERNAL_TOOLCHAIN_SDK
+		bool
+		prompt "Allow SDK with external toolchain" if DEVEL
+		depends on EXTERNAL_TOOLCHAIN
+		default n
+		help
+		  Allows selecting to build SDK even with external toolchain.
+
 config NEED_TOOLCHAIN
 	bool
 	depends on DEVEL


### PR DESCRIPTION
This is resend of the original patch:
https://lists.openwrt.org/pipermail/openwrt-devel/2016-January/012552.html 

This PR adds a Kconfig override that allows enabling Build the OpenWrt Image Builder (IB) even when EXTERNAL_TOOLCHAIN is set.

Today IB is not selectable with an external toolchain due to a hard Kconfig dependency. This change does not alter the default behaviour: the override is disabled by default and only takes effect when explicitly enabled by the user.

The primary motivation is enabling automated testing/CI scenarios where an external toolchain is used deliberately (for example a precompiled OpenWrt toolchain fetched from downloads.openwrt.org), while still being able to validate that the ImageBuilder itself builds correctly.


