### PR TITLE
Revert "bmips: huawei-hg556a-c: use nvmem for wifi eeprom"

### DIFF
--- a/target/linux/bmips/dts/bcm6358-huawei-hg556a-c.dts
+++ b/target/linux/bmips/dts/bcm6358-huawei-hg556a-c.dts
@@ -38,26 +38,16 @@
 	};
 };
 
-&cal_data {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		cal_data_1fe00: calibration@1fe00 {
-			reg = <0x1fe00 0x200>;
-		};
-	};
-};
-
 &pci {
 	status = "okay";
 
 	wifi@1,0 {
-		compatible = "pci1814,3062";
+		compatible = "pci0,0";
 		reg = <0x0800 0 0 0 0>;
 
-		nvmem-cells = <&cal_data_1fe00>, <&macaddr_cfe_6a0 1>;
-		nvmem-cell-names = "calibration", "mac-address";
+		ralink,mtd-eeprom = <&cal_data 0x1fe00>;
+
+		nvmem-cells = <&macaddr_cfe_6a0 1>;
+		nvmem-cell-names = "mac-address";
 	};
 };


### PR DESCRIPTION
This reverts commit 72f43ac220616fbd2f9658b9b60a861e8565a998.

The NVMEM codepath does not perform automatic byte conversion. It can be fixed but the upstream version is quite different from the local mac80211 patch. Revert until mac80211 gets updated and the whole mess can get squared away.

Fixes: https://github.com/openwrt/openwrt/issues/22057