### PR TITLE
econet: en7528: split DASAN H660GM-A into Airtel and Generic variants

### DIFF
--- a/target/linux/econet/base-files/sbin/en75_chboot
+++ b/target/linux/econet/base-files/sbin/en75_chboot
@@ -138,7 +138,8 @@ main() {
         code_openwrt=30
         code_factory=31
         ;;
-    dasan,h660gm-a)
+    dasan,h660gm-a-airtel|\
+    dasan,h660gm-a-generic)
         # bootflag stored in dzs partition at offset 0x49
         part=$(part_named '"dzs"')
         offset_blocks=0

--- a/target/linux/econet/dts/en7528_dasan_h660gm-a-airtel.dts
+++ b/target/linux/econet/dts/en7528_dasan_h660gm-a-airtel.dts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include "en7528_dasan_h660gm-a.dtsi"
+
+/ {
+	model = "DASAN H660GM-A (Airtel)";
+	compatible = "dasan,h660gm-a-airtel", "econet,en7528";
+
+	leds {
+		led_wps: wps {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan1: lan1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan2: lan2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan3: lan3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led_lan4: lan4 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&partitions {
+	partition@60c0000 {
+		label = "unknown";
+		reg = <0x60c0000 0x7d00000>;
+	};
+
+	partition@ddc0000 {
+		label = "reservearea";
+		reg = <0xddc0000 0x240000>;
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_reservearea_40000: eeprom@40000 {
+				reg = <0x40000 0x400>;
+			};
+
+			eeprom_reservearea_1c0000: eeprom@1c0000 {
+				reg = <0x1c0000 0x1000>;
+			};
+		};
+	};
+};

--- a/target/linux/econet/dts/en7528_dasan_h660gm-a-generic.dts
+++ b/target/linux/econet/dts/en7528_dasan_h660gm-a-generic.dts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/dts-v1/;
+
+#include "en7528_dasan_h660gm-a.dtsi"
+
+/ {
+	model = "DASAN H660GM-A (Generic)";
+	compatible = "dasan,h660gm-a-generic", "econet,en7528";
+
+	keys {
+		key-wlan {
+			label = "wlan";
+			gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		led_usb: usb {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan1-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan1-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan2-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan2-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan3-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan3-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan4-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan4-amber {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&partitions {
+	partition@6dc0000 {
+		label = "reservearea";
+		reg = <0x6dc0000 0x240000>;
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_reservearea_40000: eeprom@40000 {
+				reg = <0x40000 0x400>;
+			};
+
+			eeprom_reservearea_1c0000: eeprom@1c0000 {
+				reg = <0x1c0000 0x1000>;
+			};
+		};
+	};
+};

--- a/target/linux/econet/dts/en7528_dasan_h660gm-a.dtsi
+++ b/target/linux/econet/dts/en7528_dasan_h660gm-a.dtsi
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
-/dts-v1/;
 
 #include "en7528.dtsi"
 
@@ -8,9 +7,6 @@
 #include <dt-bindings/leds/common.h>
 
 / {
-	model = "DASAN H660GM-A";
-	compatible = "dasan,h660gm-a", "econet,en7528";
-
 	aliases {
 		led-boot = &led_power;
 		led-failsafe = &led_power;
@@ -64,40 +60,6 @@
 		led_tel: tel {
 			label = "green:tel";
 			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
-		};
-
-		led_wps: wps {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_WPS;
-			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
-		};
-
-		led_lan1: lan1 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_LAN;
-			function-enumerator = <1>;
-			gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
-		};
-
-		led_lan2: lan2 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_LAN;
-			function-enumerator = <2>;
-			gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
-		};
-
-		led_lan3: lan3 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_LAN;
-			function-enumerator = <3>;
-			gpios = <&gpio1 1 GPIO_ACTIVE_LOW>;
-		};
-
-		led_lan4: lan4 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_LAN;
-			function-enumerator = <4>;
-			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
 		};
 
 		led_wlan24: wlan2g {
@@ -186,7 +148,7 @@
 	econet,bmt;
 	econet,bbt-table-size = <250>;
 
-	partitions {
+	partitions: partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -238,29 +200,6 @@
 		partition@40c0000 {
 			label = "rwfs";
 			reg = <0x40c0000 0x2000000>;
-		};
-
-		partition@60c0000 {
-			label = "unknown";
-			reg = <0x60c0000 0x7d00000>;
-		};
-
-		partition@ddc0000 {
-			label = "reservearea";
-			reg = <0xddc0000 0x240000>;
-			nvmem-layout {
-				compatible = "fixed-layout";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
-				eeprom_reservearea_40000: eeprom@40000 {
-					reg = <0x40000 0x400>;
-				};
-
-				eeprom_reservearea_1c0000: eeprom@1c0000 {
-					reg = <0x1c0000 0x1000>;
-				};
-			};
 		};
 	};
 };

--- a/target/linux/econet/image/en7528.mk
+++ b/target/linux/econet/image/en7528.mk
@@ -10,10 +10,22 @@ TARGET_DEVICES += en7528_generic
 define Device/dasan_h660gm-a
   DEVICE_VENDOR := DASAN
   DEVICE_MODEL := H660GM-A
-  DEVICE_DTS := en7528_dasan_h660gm-a
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap
   TRX_MODEL := Dewberry
   IMAGES := tclinux.trx
   IMAGE/tclinux.trx := append-kernel | lzma | tclinux-trx
 endef
-TARGET_DEVICES += dasan_h660gm-a
+
+define Device/dasan_h660gm-a-airtel
+  $(Device/dasan_h660gm-a)
+  DEVICE_VARIANT := Airtel
+  DEVICE_DTS := en7528_dasan_h660gm-a-airtel
+endef
+TARGET_DEVICES += dasan_h660gm-a-airtel
+
+define Device/dasan_h660gm-a-generic
+  $(Device/dasan_h660gm-a)
+  DEVICE_VARIANT := Generic
+  DEVICE_DTS := en7528_dasan_h660gm-a-generic
+endef
+TARGET_DEVICES += dasan_h660gm-a-generic


### PR DESCRIPTION
The DASAN H660GM-A GPON ONT exists in two hardware variants, one distributed by ISPs and one sold directly by the manufacturer [1].

Split the single DTS into a shared dtsi and per-variant DTS files with the correct GPIO mappings, flash layout, and LED definitions.

Variant comparison:

 | Feature | Airtel | Generic |
  |---|---|---|
  | Supplied by | Airtel Xstream Fiber | Retail |
  | Flash | MT29F2G01ABAGD (256MB) | MT29F1G01ABAFD (128MB) |
  | Known P/N | DPW-G-P-66GMAZ-A3 | DPW:G-P-660GMAY-G0, G3 |
  | WPS LED | Yes | No |
  | WLAN button | No | Yes |
  | USB LED | No | Yes |
  | LAN LEDs | Green only| Green + Amber |

[1] https://dasanns.com/en/solution/detail.php?mode=view&cat_no=32&offset=&idx=122

