### PR TITLE
treewide: fix licenses

### DIFF
--- a/package/libs/libbpf/Makefile
+++ b/package/libs/libbpf/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libbpf
 PKG_VERSION:=1.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/libbpf/libbpf
 PKG_MIRROR_HASH:=9620f45b4fc0ee5e0f43502634fe48fbcb34ab49d2553b7275fa92f7e02d3dc7
@@ -31,7 +31,7 @@ define Package/libbpf
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=libbpf - eBPF helper library
-  LICENSE:=LGPL-2.1 OR BSD-2-Clause
+  LICENSE:=BSD-2-Clause LGPL-2.1
   ABI_VERSION:=$(PKG_ABI_VERSION)
   URL:=https://www.kernel.org
   DEPENDS:=+libelf

--- a/package/network/utils/bpftool/Makefile
+++ b/package/network/utils/bpftool/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bpftool
 PKG_VERSION:=7.6.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://github.com/libbpf/bpftool
 PKG_MIRROR_HASH:=7406a424375642fda35cae6eccaa8e27c21e4f132123c0207a83f763ef6fe899
@@ -32,7 +32,7 @@ define Package/bpftool/Default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=bpftool - eBPF subsystem utility
-  LICENSE:=GPL-2.0-only OR BSD-2-Clause
+  LICENSE:=BSD-2-Clause GPL-2.0-only
   URL:=https://www.kernel.org
   DEPENDS:=+libelf
 endef

--- a/package/network/utils/xdp-tools/Makefile
+++ b/package/network/utils/xdp-tools/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=xdp-tools
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_VERSION:=1.5.8
 PKG_HASH:=e7b9717074c511fef34aab6e22b16af55fb33307505a5785d25a82b542e596ae
 
@@ -24,7 +24,7 @@ define Package/libxdp
   SECTION:=libs
   CATEGORY:=Libraries
   TITLE:=libxdp - Library for use with XDP
-  LICENSE:=LGPL-2.1 OR BSD-2-Clause
+  LICENSE:=BSD-2-Clause LGPL-2.1
   ABI_VERSION:=$(PKG_ABI_VERSION)
   URL:=https://github.com/xdp-project/xdp-tools/
   DEPENDS:=+libbpf $(BPF_DEPENDS)


### PR DESCRIPTION
## 📦 Package Details

**Maintainer:** @dangowrt, Tony Ambardar <itugrok@yahoo.com>

**Description:**
Avoid incorrect parsing of `OR` as a separate license in the SBOM.

Related to: https://github.com/openwrt/openwrt/pull/21733