### PR TITLE
realtek: Add hasivo,s600w-5xgt-1s+ switch

### DIFF
--- a/target/linux/realtek/dts/rtl9303_hasivo_s600w-5xgt-1sp.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s600w-5xgt-1sp.dts
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "hasivo,s600w-5xgt-1s+", "realtek,rtl930x-soc";
+	model = "Hasivo S600W-5XGT-1S+";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>; /* 256 MiB */
+	};
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+		label-mac-device = &ethernet0;
+	};
+
+	chosen {
+		stdout-path = "serial0:38400n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>,<&pinmux_enable_led_sync>;
+		led_sys: led-0 {
+			label = "green:system";
+                        color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	led_set: led_set {
+		compatible = "realtek,rtl9300-leds";
+		// Device has unwired ports, skip their LEDs
+		realtek,led-set0-force-port-mask = <0x0a000000>;
+		led_set0 = <
+		(	// ORANGE LEFT RJ45 - 10G link, blink on activity
+			RTL93XX_LED_SET_LINK |
+			RTL93XX_LED_SET_10G
+		)
+		(	// GREEN RIGHT RJ45 - 10M/100M/1G link, blink on activity
+			RTL93XX_LED_SET_ACT |
+			RTL93XX_LED_SET_LINK |
+			RTL93XX_LED_SET_10M |
+			RTL93XX_LED_SET_100M |
+			RTL93XX_LED_SET_1G |
+			RTL93XX_LED_SET_2P5G |
+			RTL93XX_LED_SET_5G |
+			RTL93XX_LED_SET_10G
+		)
+		(	// GREEN LEFT RJ45 - 2.5/5G link
+			RTL93XX_LED_SET_LINK |
+			RTL93XX_LED_SET_5G |
+			RTL93XX_LED_SET_2P5G
+		)
+		>;
+	};
+
+	i2c_scl7_sda6: i2c-gpio-sfp {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		scl-gpios = <&gpio0 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		status = "okay";
+
+		clock-frequency = <100000>;
+	};
+
+	sfp0: sfp-p26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_scl7_sda6>;
+		mod-def0-gpio = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		// TODO: should exist...
+		//los-gpio = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+		// TODO: unknown if we have one of these
+                //tx-disable-gpio = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+		// TODO: This value is not informed by anything yet... 
+		maximum-power-milliwatt = <2900>;
+		#thermal-sensor-cells = <0>;
+	};
+
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* stock is LOADER */
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x00e0000>;
+				read-only;
+			};
+
+			/* stock is BDINFO */
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x00e0000 0x0010000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_ubootenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+					serialnumber_ubootenv: serialnumber {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_bt_port_no_ubootenv: pse_bt_port_no {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_existed_flag_ubootenv: pse_existed_flag {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_power_bank_ubootenv: pse_power_bank {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			/* stock is SYSINFO */
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0x00f0000 0x0010000>;
+				read-only;
+			};
+
+			/* stock is JFFS2 CFG */
+			partition@100000 {
+				label = "jffs";
+				reg = <0x0100000 0x0100000>;
+			};
+
+			/* stock is JFFS2 LOG */
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x0200000 0x0100000>;
+			};
+
+			/* stock is RUNTIME */
+			partition@300000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x0300000 0x0700000>;
+			};
+
+			/* stock is RUNTIME2 */
+			partition@a00000 {
+				label = "runtime2";
+				reg = <0x0a00000 0x1600000>;
+				read-only;
+			};
+		};
+	};
+};
+
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_bus0 {
+	PHY_C45(0, 0)
+	PHY_C45(8, 16)
+};
+
+&mdio_bus1 {
+	PHY_C45(16, 0)
+	PHY_C45(20, 16)
+};
+
+&mdio_bus2 {
+	PHY_C45(24, 0)
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_LED(0, 1, 2, 0, usxgmii)
+		SWITCH_PORT_LED(8, 2, 3, 0, usxgmii)
+		SWITCH_PORT_LED(16, 3, 4, 0, usxgmii)
+		SWITCH_PORT_LED(20, 4, 5, 0, usxgmii)
+		SWITCH_PORT_LED(24, 5, 6, 0, usxgmii)
+
+		SWITCH_PORT_SFP(26, 6, 8, 0, 0)
+
+		/* Internal SoC */
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/dts/rtl9303_hasivo_s600w-5xgt-1sp.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s600w-5xgt-1sp.dts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "hasivo,s600w-5xgt-1s+", "realtek,rtl930x-soc";
+	model = "Hasivo S600W-5XGT-1S+";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>; /* 256 MiB */
+	};
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+		label-mac-device = &ethernet0;
+	};
+
+	chosen {
+		stdout-path = "serial0:38400n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>,<&pinmux_enable_led_sync>;
+		led_sys: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	led_set: led_set {
+		compatible = "realtek,rtl9300-leds";
+		/* Port 25 and 27  are unused but present in the HC595 shift
+                 * register chain. Force it into the serial LED stream
+                 * to align all LED positions correctly.
+                 */
+		realtek,led-set0-force-port-mask = <0x0a000000>;
+		led_set0 = <
+		(	/* ORANGE LEFT RJ45 - 10G link, blink on activity */
+			RTL93XX_LED_SET_LINK |
+			RTL93XX_LED_SET_10G
+		)
+		(	/* GREEN RIGHT RJ45 - 10M/100M/1G link, blink on activity */
+			RTL93XX_LED_SET_ACT |
+			RTL93XX_LED_SET_LINK |
+			RTL93XX_LED_SET_10M |
+			RTL93XX_LED_SET_100M |
+			RTL93XX_LED_SET_1G |
+			RTL93XX_LED_SET_2P5G |
+			RTL93XX_LED_SET_5G |
+			RTL93XX_LED_SET_10G
+		)
+		(	/* GREEN LEFT RJ45 - 2.5/5G link */
+			RTL93XX_LED_SET_LINK |
+			RTL93XX_LED_SET_5G |
+			RTL93XX_LED_SET_2P5G
+		)
+		>;
+	};
+
+	i2c_scl7_sda6: i2c-gpio-sfp {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		scl-gpios = <&gpio0 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		status = "okay";
+
+		clock-frequency = <100000>;
+	};
+
+	sfp0: sfp-p26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_scl7_sda6>;
+		mod-def0-gpio = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		/* value taken from similar router, spec unavailable */
+		maximum-power-milliwatt = <2500>;
+	};
+
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* stock is LOADER */
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x00e0000>;
+				read-only;
+			};
+
+			/* stock is BDINFO */
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x00e0000 0x0010000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_ubootenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+					serialnumber_ubootenv: serialnumber {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_bt_port_no_ubootenv: pse_bt_port_no {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_existed_flag_ubootenv: pse_existed_flag {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_power_bank_ubootenv: pse_power_bank {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			/* stock is SYSINFO */
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0x00f0000 0x0010000>;
+				read-only;
+			};
+
+			/* stock is JFFS2 CFG */
+			partition@100000 {
+				label = "jffs";
+				reg = <0x0100000 0x0100000>;
+			};
+
+			/* stock is JFFS2 LOG */
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x0200000 0x0100000>;
+			};
+
+			/* stock is RUNTIME */
+			partition@300000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x0300000 0x0700000>;
+			};
+
+			/* stock is RUNTIME2 */
+			partition@a00000 {
+				label = "runtime2";
+				reg = <0x0a00000 0x1600000>;
+				read-only;
+			};
+		};
+	};
+};
+
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_bus0 {
+	PHY_C45(0, 0)
+	PHY_C45(8, 16)
+};
+
+&mdio_bus1 {
+	PHY_C45(16, 0)
+	PHY_C45(20, 16)
+};
+
+&mdio_bus2 {
+	PHY_C45(24, 0)
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_LED(0, 1, 2, 0, 0, usxgmii)
+		SWITCH_PORT_LED(8, 2, 3, 0, 0, usxgmii)
+		SWITCH_PORT_LED(16, 3, 4, 0, 0, usxgmii)
+		SWITCH_PORT_LED(20, 4, 5, 0, 0, usxgmii)
+		SWITCH_PORT_LED(24, 5, 6, 0, 0, usxgmii)
+
+		SWITCH_PORT_SFP(26, 6, 8, 0, 0)
+
+		/* Internal SoC */
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -12,6 +12,15 @@ define Device/d-link_dgs-1250-28x
 endef
 TARGET_DEVICES += d-link_dgs-1250-28x
 
+define Device/hasivo_s600w-5xgt-1sp
+  SOC := rtl9303
+  DEVICE_VENDOR := Hasivo
+  DEVICE_MODEL := S600W-5XGT-1S+
+  IMAGE_SIZE := 12288k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += hasivo_s600w-5xgt-1sp
+
 define Device/hasivo_s1100w-8xgt-se
   SOC := rtl9303
   DEVICE_VENDOR := Hasivo

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -80,6 +80,16 @@ define Device/hasivo_s600wp-5gt-2sx-se
 endef
 TARGET_DEVICES += hasivo_s600wp-5gt-2sx-se
 
+define Device/hasivo_s600w-5xgt-1sp
+  SOC := rtl9303
+  DEVICE_VENDOR := Hasivo
+  DEVICE_MODEL := S600W-5XGT-1S+
+  DEVICE_PACKAGES := kmod-phy-realtek rtl8261n-firmware
+  IMAGE_SIZE := 7168k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += hasivo_s600w-5xgt-1sp
+
 define Device/horaco_zx-swtgw2c8f
   SOC := rtl9303
   UIMAGE_MAGIC := 0x83800000


### PR DESCRIPTION
WIP: Adds initial support for another hasivo switch, with input from @bevanweiss 

NOTE: Commit will be amended to include device information per norms. (This is my first)

Device tree for i2c/sfp and button are currently guesses, my first attempt at a hardware add, feedback very welcome.

Note, the build system does not like `+` symbols as found in model name, and this is translated to a `p` in filenames.

# Commit Message:

This commit adds support for the Hasivo S600W-5XGT-1S+

The Hasivo S600W-5XGT-1S+ a layer 3 switch with 5x 10G RJ45 and 1x SFP+
port. It is powered by a C13 AC connector with an internal power supply.


S600W-5XGT-1S+ hardware info:

* CPU: RTL9303
* RAM: 256MB DDR3 600MHz
* Storage: 32 MB (SIOC8 NOR, 3.3V)
* Networking: 
  * 5x 10 Gigabit Ethernet RJ45
  * 1x 10 Gigabit Ethernet SFP+
* WiFi: None
* Serial: RJ45 rollover (cisco pinout)
  * 38400 baud default

The device has the following flash layout:
```
MXIC/C22019/MMIO32-4/ModeC add SPI NOR partition
MTD partitions obtained from built-in array
Creating 7 MTD partitions on "rtk_norsf_g3":
0x000000000000-0x0000000e0000 : "LOADER"
0x0000000e0000-0x0000000f0000 : "BDINFO"
0x0000000f0000-0x000000100000 : "SYSINFO"
0x000000100000-0x000000200000 : "JFFS2 CFG"
0x000000200000-0x000000300000 : "JFFS2 LOG"
0x000000300000-0x000000a00000 : "RUNTIME"
0x000000a00000-0x000002000000 : "RUNTIME2"
```

This device ships with U-Boot configured to require the sequence:
 * CTRL-C, z, h
to be entered within 3 seconds of startup on the serial console.

# Initially booting OpenWRT:

You will need an RJ45 serial cable, and a system to act as a tftp
server to host the initial initramfs image.

1. Connect a terminal at 38400 bps to the RJ45 console port
2. Configure tftp server on an interface at 192.168.1.111
3. Put the initramfs-kernel image into the tftp server root
4. Connect the first port of the switch to the tftp server system
5. Turn on switch and quickly press CTRL-C then z, h
6. At the u-boot prompt run these 3 commands:
```
rtk network on
tftpboot 0x84f00000 192.168.1.111:openwrt-realtek-rtl930x-hasivo_s600w-5xgt-1sp-initramfs-kernel.bin
bootm
```
7. You should now be be booted into the OpenWRT initramfs.

# OpenWrt Installation:

* Dump your original flash
* Re-plug ethernet cable as an ethernet client
* Use ifconfig/route or ip command to setup internet
* Add your favourite DNS servers to resolv.conf
* Test as you see fit before deciding to flash
* `scp` the `sysupgrade` image to the device and run the normal `sysupgrade` procedure:
```
scp -O openwrt-realtek-rtl930x-hasivo_s600w-5xgt-1sp-squashfs-sysupgrade.bin root@192.168.1.1:/tmp/
ssh root@192.168.1.1 "sysupgrade -n /tmp/openwrt-realtek-rtl930x-hasivo_s600w-5xgt-1sp-squashfs-sysupgrade.bin"

```
* OpenWrt should now be installed on the device.

Boot log and interface display:

```
RTL9300# #  tftpboot 0x84f00000 192.168.1.111:openwrt-realtek-rtl930x-hasivo_s600w-5xgt-1sp-initramfs-kernel.bin
Using rtl9300#0 device
TFTP from server 192.168.1.111; our IP address is 192.168.1.1
Filename 'openwrt-realtek-rtl930x-hasivo_s600w-5xgt-1sp-initramfs-kernel.bin'.
Load address: 0x84f00000
Loading: #################################################################
         #################################################################
         #################################################################
         #################################################################
         #################################################################
         ###################
done
Bytes transferred = 5049128 (4d0b28 hex)
RTL9300# # bootm
## Booting kernel from Legacy Image at 84f00000 ...
   Image Name:   MIPS OpenWrt Linux-6.12.71
   Created:      2026-02-20   0:34:44 UTC
   Image Type:   MIPS Linux Kernel Image (lzma compressed)
   Data Size:    5049064 Bytes = 4.8 MB
   Load Address: 80100000
   Entry Point:  80100000
   Verifying Checksum ... OK
   Uncompressing Kernel Image ... OK

Starting kernel ...

[    0.000000] Linux version 6.12.71 (jhohertz@MS-S1-MAX) (mips-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r32541-beb134292d) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Fri Feb 20 00:34:44 2026
[    0.000000] Realtek RTL9303 rev B (6487) SoC with 256 MB
[    0.000000] printk: legacy bootconsole [early0] enabled
[    0.000000] CPU0 revision is: 00019555 (MIPS 34Kc)
[    0.000000] MIPS: machine is Hasivo S600W-5XGT-1S+
[    0.000000] earlycon: ns16550a0 at MMIO 0x18002000 (options '38400n8')
[    0.000000] printk: legacy bootconsole [ns16550a0] enabled
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Using appended Device Tree.
[    0.000000] OF: reserved mem: Reserved memory: No reserved-memory node in the DT
[    0.000000] Detected 1 available secondary CPU(s)
[    0.000000] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.000000] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000]   HighMem  empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000000fffffff]
[    0.000000] percpu: Embedded 12 pages/cpu s18128 r8192 d22832 u49152
[    0.000000] pcpu-alloc: s18128 r8192 d22832 u49152 alloc=12*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1
[    0.000000] Kernel command line: earlycon
[    0.000000] Dentry cache hash table entries: 32768 (order: 5, 131072 bytes, linear)
[    0.000000] Inode-cache hash table entries: 16384 (order: 4, 65536 bytes, linear)
[    0.000000] Writing ErrCtl register=0006cfb6
[    0.000000] Readback ErrCtl register=0006cfb6
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 65536
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] SLUB: HWalign=32, Order=0-3, MinObjects=0, CPUs=2, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000]  Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks Trace: Setting shift to 1 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=2.
[    0.000000] NR_IRQS: 256
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] Failed to get CPU clock: -2
[    0.000000] CPU frequency from device tree: 800MHz
[    0.000000] clocksource: realtek_otto_timer: mask: 0xfffffff max_cycles: 0xfffffff, max_idle_ns: 38225208801 ns
[    0.000003] sched_clock: 28 bits at 3125kHz, resolution 320ns, wraps every 42949672800ns
[    0.026789] Calibrating delay loop... 531.66 BogoMIPS (lpj=2658304)
[    0.097251] pid_max: default: 32768 minimum: 301
[    0.123806] Mount-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.147894] Mountpoint-cache hash table entries: 1024 (order: 0, 4096 bytes, linear)
[    0.186998] rcu: Hierarchical SRCU implementation.
[    0.202814] rcu:     Max phase no-delay instances is 1000.
[    0.222011] smp: Bringing up secondary CPUs ...
[    0.238889] Primary instruction cache 32kB, VIPT, 4-way, linesize 32 bytes.
[    0.238946] Primary data cache 32kB, 4-way, PIPT, no aliases, linesize 32 bytes
[    0.239037] CPU1 revision is: 00019555 (MIPS 34Kc)
[    0.316676] Counter synchronization [CPU#0 -> CPU#1]: passed
[    0.398201] smp: Brought up 1 node, 2 CPUs
[    0.413208] Memory: 238392K/262144K available (7508K kernel code, 718K rwdata, 1696K rodata, 9784K init, 243K bss, 22632K reserved, 0K cma-reserved, 0K highmem)
[    0.467077] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.499527] futex hash table entries: 512 (order: 2, 16384 bytes, linear)
[    0.528613] pinctrl core: initialized pinctrl subsystem
[    0.549343] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.569720] thermal_sys: Registered thermal governor 'step_wise'
[    0.593312] clocksource: Switched to clocksource realtek_otto_timer
[    0.645649] NET: Registered PF_INET protocol family
[    0.662075] IP idents hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.687079] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.714680] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.740246] TCP established hash table entries: 2048 (order: 1, 8192 bytes, linear)
[    0.765551] TCP bind hash table entries: 2048 (order: 3, 32768 bytes, linear)
[    0.789234] TCP: Hash tables configured (established 2048 bind 2048)
[    0.811063] MPTCP token hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.835372] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.856960] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.881057] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.903103] workingset: timestamp_bits=14 max_order=16 bucket_order=2
[    0.930194] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.949560] jffs2: version 2.2 (NAND) (SUMMARY) (ZLIB) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.996334] pinctrl-single 1b000200.pinmux: 32 pins, size 4
[    1.015873] pinctrl-single 1b00c600.pinmux: 32 pins, size 4
[    1.035521] pinctrl-single 1b00cc00.pinmux: 32 pins, size 4
[    1.141152] Serial: 8250/16550 driver, 2 ports, IRQ sharing disabled
[    1.165065] printk: legacy console [ttyS0] disabled
[    1.182075] 18002000.uart: ttyS0 at MMIO 0x18002000 (irq = 30, base_baud = 10937500) is a 16550A
[    1.211134] printk: legacy console [ttyS0] enabled
[    1.211134] printk: legacy console [ttyS0] enabled
[    1.242921] printk: legacy bootconsole [early0] disabled
[    1.242921] printk: legacy bootconsole [early0] disabled
[    1.278620] printk: legacy bootconsole [ns16550a0] disabled
[    1.278620] printk: legacy bootconsole [ns16550a0] disabled
[    1.355631] brd: module loaded
[    1.371262] 7 fixed-partitions partitions found on MTD device spi0.0
[    1.392855] Creating 7 MTD partitions on "spi0.0":
[    1.408952] 0x000000000000-0x0000000e0000 : "u-boot"
[    1.427760] 0x0000000e0000-0x0000000f0000 : "u-boot-env"
[    1.448192] 0x0000000f0000-0x000000100000 : "u-boot-env2"
[    1.468288] 0x000000100000-0x000000200000 : "jffs"
[    1.486368] 0x000000200000-0x000000300000 : "jffs2"
[    1.504038] 0x000000300000-0x000000a00000 : "firmware"
[    1.527329] mtdsplit_uimage: no uImage found in "firmware"
[    1.549513] mtdsplit_uimage: no uImage found in "firmware"
[    1.567824] 0x000000a00000-0x000002000000 : "runtime2"
[    1.948608] skip polling setup for unknown PHY 001ccaf3 on port 0
[    1.968920] skip polling setup for unknown PHY 001ccaf3 on port 8
[    1.989171] skip polling setup for unknown PHY 001ccaf3 on port 16
[    2.009704] skip polling setup for unknown PHY 001ccaf3 on port 20
[    2.030209] skip polling setup for unknown PHY 001ccaf3 on port 24
[    2.052270] realtek-otto-serdes-mdio 1b000000.switchcore:mdio-serdes: Realtek SerDes mdio bus initialized, 12 SerDes, 64 pages, 32 registers
[    2.094663] realtek-otto-pcs 1b000000.switchcore:pcs: Realtek PCS driver initialized
[    2.121034] Probing RTL838X eth device pdev: 818e2200, dev: 818e2210
[    2.144870] i2c_dev: i2c /dev entries driver
[    2.191789] NET: Registered PF_INET6 protocol family
[    2.212871] Segment Routing with IPv6
[    2.225229] In-situ OAM (IOAM) with IPv6
[    2.238420] NET: Registered PF_PACKET protocol family
[    2.255771] 8021q: 802.1Q VLAN Support v1.8
[    2.322239] i2c-gpio i2c: using lines 518 (SDA) and 519 (SCL)
[    2.342148] sfp sfp-p26: Host maximum power 2.9W
[    2.360903] Probing RTL838X eth device pdev: 818e2200, dev: 818e2210
[    2.384486] Using MAC 00:e0:4c:00:00:00
[    2.420175] rtldsa_93xx_setup called
[    2.432270] In rtldsa_vlan_setup
[    2.443056] rtl83xx-switch switch@1b000000: MC_PMASK_ALL_PORTS: 000000001fffffff
[    3.533341] rtldsa_enable_phy_polling:          5110101
[    3.551072] rtl83xx-switch switch@1b000000: led_set0 has 3 LEDs configured
[    3.573878] rtl83xx-switch switch@1b000000: led_set1 has 2 LEDs configured
[    3.596844] rtl83xx-switch switch@1b000000: configuring for fixed/internal link mode
[    3.622760] Realtek RTL8261N realtek-mdio:00: rtkphy_config_init:80 [RTL8261N/RTL8264/RTL826XB] phy_id: 0x1CCAF3 PHYAD:0
[    3.654132] sfp sfp-p26: please wait, module slow to respond
[    3.659116] rtl83xx-switch switch@1b000000 lan1 (uninitialized): PHY [realtek-mdio:00] driver [Realtek RTL8261N] (irq=POLL)
[    3.716843] Realtek RTL8261N realtek-mdio:08: rtkphy_config_init:80 [RTL8261N/RTL8264/RTL826XB] phy_id: 0x1CCAF3 PHYAD:8
[    3.753206] rtl83xx-switch switch@1b000000 lan2 (uninitialized): PHY [realtek-mdio:08] driver [Realtek RTL8261N] (irq=POLL)
[    3.792460] Realtek RTL8261N realtek-mdio:10: rtkphy_config_init:80 [RTL8261N/RTL8264/RTL826XB] phy_id: 0x1CCAF3 PHYAD:16
[    3.829192] rtl83xx-switch switch@1b000000 lan3 (uninitialized): PHY [realtek-mdio:10] driver [Realtek RTL8261N] (irq=POLL)
[    3.868045] Realtek RTL8261N realtek-mdio:14: rtkphy_config_init:80 [RTL8261N/RTL8264/RTL826XB] phy_id: 0x1CCAF3 PHYAD:20
[    3.904759] rtl83xx-switch switch@1b000000 lan4 (uninitialized): PHY [realtek-mdio:14] driver [Realtek RTL8261N] (irq=POLL)
[    3.944183] Realtek RTL8261N realtek-mdio:18: rtkphy_config_init:80 [RTL8261N/RTL8264/RTL826XB] phy_id: 0x1CCAF3 PHYAD:24
[    3.980910] rtl83xx-switch switch@1b000000 lan5 (uninitialized): PHY [realtek-mdio:18] driver [Realtek RTL8261N] (irq=POLL)
[    4.021483] rtl838x-eth 1b000000.switchcore:ethernet eth0: entered promiscuous mode
[    4.047085] DSA: tree 0 setup
[    4.057054] LINK state irq: 23
[    4.067398] rtl930x_dbgfs_init called
[    4.079650] rtl83xx-switch switch@1b000000: Link is Up - 10Gbps/Full - flow control off
[    4.106694] clk: Disabling unused clocks
[    4.163893] Freeing unused kernel image (initmem) memory: 9784K
[    4.183566] This architecture does not have kernel memory protection.
[    4.204986] Run /init as init process
[    4.217147]   with arguments:
[    4.227008]     /init
[    4.234549]   with environment:
[    4.244961]     HOME=/
[    4.252760]     TERM=linux
[    4.757728] init: Console is alive
[    4.769651] init: - watchdog -
[    4.796078] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    4.822111] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    4.849765] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    4.882966] init: - preinit -
[    7.653392] random: crng init done
Cannot parse config file '/etc/fw_env.config': No such file or directory
Failed to find NVMEM device
[    8.199283] RESETTING CPU_PORT 28
[    8.409788] rtl838x-eth 1b000000.switchcore:ethernet eth0: configuring for fixed/internal link mode
[    8.439760] In rteth_mac_config, mode 1
[    8.453578] rtl83xx-switch switch@1b000000 lan1: configuring for inband/usxgmii link mode
[    8.480817] realtek-otto-pcs 1b000000.switchcore:pcs: configure SerDes 2 for mode usxgmii
[    8.518234] rtpcs_930x_phy_enable_10g_1g 1gbit phy: 00001140
[    8.537034] rtpcs_930x_phy_enable_10g_1g 1gbit phy enabled: 00001140
[    8.558126] rtpcs_930x_phy_enable_10g_1g 10gbit phy: 00002040
[    8.577218] rtpcs_930x_phy_enable_10g_1g 10gbit phy after: 00002040
[    8.598012] rtpcs_930x_phy_enable_10g_1g set medium: 00000002
[    8.617110] rtpcs_930x_phy_enable_10g_1g set medium after: 00000002
[    8.637924] rtpcs_930x_setup_serdes: Configuring RTL9300 SERDES 2
[    8.678289] start_1.1.1 initial value for sds 2
[    8.693433] end_1.1.1 --
[    8.701783] start_1.1.2 Load DFE init. value
[    8.715945] end_1.1.2
[    8.723541] start_1.1.3 disable LEQ training,enable DFE clock
[    8.742640] end_1.1.3 --
[    8.751066] start_1.1.4 offset cali setting
[    8.764981] end_1.1.4
[    8.772489] start_1.1.5 LEQ and DFE setting
[    8.786369] rtpcs_930x_sds_do_rx_calibration_1 not PHY-based or SerDes, implement DAC!
[    8.812659] end_1.1.5
[    8.825307] start_1.2.1 ForegroundOffsetCal_Manual
[    8.841238] end_1.2.1
[    8.846329] start_1.2.3 Foreground Calibration
[    8.868643] rtpcs_930x_sds_do_rx_calibration_2_3: fgcal_gray: 22, fgcal_binary 29
[    8.893503] rtpcs_930x_sds_do_rx_calibration_2_3: end_1.2.3
[    8.912000] start_1.4.1
[    9.132726] end_1.4.1
[    9.140901] start_1.4.2
[    9.149485] vth_set_bin = 3
[    9.157612] vth_set_bin = 3
[    9.166901] Vth Maunal = 0
[    9.277562] Tap0 Sign : +
[    9.286578] tap0_coef_bin = 17
[    9.295291] tap0 manual = 0
[    9.305472] end_1.4.2
[    9.386227] 8021q: adding VLAN 0 to HW filter on device lan1
[    9.412809] rtl838x-eth 1b000000.switchcore:ethernet eth0: Link is Up - 1Gbps/Full - flow control off
Press the [f] key and hit [enter] to enter failsafe mode
Press the [1], [2], [3] or [4] key and hit [enter] to select the debug level
[   13.818915] procd: - early -
[   13.829074] procd: - watchdog -
[   14.463504] procd: - watchdog -
[   14.474527] procd: - ubus -
[   14.542569] procd: - init -
Please press Enter to activate this console.
[   15.240096] kmodloader: loading kernel modules from /etc/modules.d/*
[   15.361391] kmodloader: done loading kernel modules from /etc/modules.d/*
[   16.644465] urngd: v1.0.2 started.
[   33.654376] in rteth_stop
[   33.673472] rtl838x-eth 1b000000.switchcore:ethernet eth0: Link is Down
[   34.309386] RESETTING CPU_PORT 28
[   34.519965] rtl838x-eth 1b000000.switchcore:ethernet eth0: configuring for fixed/internal link mode
[   34.549921] In rteth_mac_config, mode 1
[   34.563376] rtl838x-eth 1b000000.switchcore:ethernet eth0: Link is Up - 1Gbps/Full - flow control off
[   34.604775] rtl83xx-switch switch@1b000000 lan1: configuring for inband/usxgmii link mode
[   34.632463] 8021q: adding VLAN 0 to HW filter on device lan1
[   34.664367] switch: port 1(lan1) entered blocking state
[   34.681923] switch: port 1(lan1) entered disabled state
[   34.699591] rtl83xx-switch switch@1b000000 lan1: entered allmulticast mode
[   34.722598] rtl838x-eth 1b000000.switchcore:ethernet eth0: entered allmulticast mode
[   34.749268] rtl83xx-switch switch@1b000000 lan1: entered promiscuous mode
[   34.852317] rtl83xx-switch switch@1b000000 lan2: configuring for inband/usxgmii link mode
[   34.879744] realtek-otto-pcs 1b000000.switchcore:pcs: configure SerDes 3 for mode usxgmii
[   34.918136] rtpcs_930x_phy_enable_10g_1g 1gbit phy: 00001140
[   34.937029] rtpcs_930x_phy_enable_10g_1g 1gbit phy enabled: 00001140
[   34.958187] rtpcs_930x_phy_enable_10g_1g 10gbit phy: 00002040
[   34.977458] rtpcs_930x_phy_enable_10g_1g 10gbit phy after: 00002040
[   34.998436] rtpcs_930x_phy_enable_10g_1g set medium: 00000002
[   35.017722] rtpcs_930x_phy_enable_10g_1g set medium after: 00000002
[   35.038706] rtpcs_930x_setup_serdes: Configuring RTL9300 SERDES 3
[   35.082810] start_1.1.1 initial value for sds 3
[   35.098125] end_1.1.1 --
[   35.106704] start_1.1.2 Load DFE init. value
[   35.121045] end_1.1.2
[   35.128789] start_1.1.3 disable LEQ training,enable DFE clock
[   35.148045] end_1.1.3 --
[   35.156650] start_1.1.4 offset cali setting
[   35.170683] end_1.1.4
[   35.178397] start_1.1.5 LEQ and DFE setting
[   35.192404] rtpcs_930x_sds_do_rx_calibration_1 not PHY-based or SerDes, implement DAC!
[   35.218879] end_1.1.5
[   35.232552] start_1.2.1 ForegroundOffsetCal_Manual
[   35.248652] end_1.2.1
[   35.254848] start_1.2.3 Foreground Calibration
[   35.277387] rtpcs_930x_sds_do_rx_calibration_2_3: fgcal_gray: 18, fgcal_binary 27
[   35.302450] rtpcs_930x_sds_do_rx_calibration_2_3: end_1.2.3
[   35.321080] start_1.4.1
[   35.589406] end_1.4.1
[   35.597615] start_1.4.2
[   35.606540] vth_set_bin = 4
[   35.614780] vth_set_bin = 4
[   35.624221] Vth Maunal = 0
[   35.755742] Tap0 Sign : +
[   35.764837] tap0_coef_bin = 11
[   35.773703] tap0 manual = 0
[   35.784006] end_1.4.2
[   35.880416] 8021q: adding VLAN 0 to HW filter on device lan2
[   35.911754] switch: port 2(lan2) entered blocking state
[   35.929286] switch: port 2(lan2) entered disabled state
[   35.946923] rtl83xx-switch switch@1b000000 lan2: entered allmulticast mode
[   35.970622] rtl83xx-switch switch@1b000000 lan2: entered promiscuous mode
[   36.028934] rtl83xx-switch switch@1b000000 lan3: configuring for inband/usxgmii link mode
[   36.056262] realtek-otto-pcs 1b000000.switchcore:pcs: configure SerDes 4 for mode usxgmii
[   36.095788] rtpcs_930x_phy_enable_10g_1g 1gbit phy: 00001140
[   36.114691] rtpcs_930x_phy_enable_10g_1g 1gbit phy enabled: 00001140
[   36.135945] rtpcs_930x_phy_enable_10g_1g 10gbit phy: 00002040
[   36.155201] rtpcs_930x_phy_enable_10g_1g 10gbit phy after: 00002040
[   36.176189] rtpcs_930x_phy_enable_10g_1g set medium: 00000002
[   36.195426] rtpcs_930x_phy_enable_10g_1g set medium after: 00000002
[   36.216398] rtpcs_930x_setup_serdes: Configuring RTL9300 SERDES 4
[   36.260686] start_1.1.1 initial value for sds 4
[   36.275960] end_1.1.1 --
[   36.284500] start_1.1.2 Load DFE init. value
[   36.298848] end_1.1.2
[   36.306565] start_1.1.3 disable LEQ training,enable DFE clock
[   36.325826] end_1.1.3 --
[   36.334445] start_1.1.4 offset cali setting
[   36.348471] end_1.1.4
[   36.356224] start_1.1.5 LEQ and DFE setting
[   36.370264] rtpcs_930x_sds_do_rx_calibration_1 not PHY-based or SerDes, implement DAC!
[   36.396746] end_1.1.5
[   36.410212] start_1.2.1 ForegroundOffsetCal_Manual
[   36.426304] end_1.2.1
[   36.431915] start_1.2.3 Foreground Calibration
[   36.454371] rtpcs_930x_sds_do_rx_calibration_2_3: fgcal_gray: 63, fgcal_binary 32
[   36.479292] rtpcs_930x_sds_do_rx_calibration_2_3: end_1.2.3
[   36.497850] start_1.4.1
[   36.718721] end_1.4.1
[   36.726865] start_1.4.2
[   36.735564] vth_set_bin = 4
[   36.743768] vth_set_bin = 4
[   36.753053] Vth Maunal = 0
[   36.864016] Tap0 Sign : +
[   36.872977] tap0_coef_bin = 14
[   36.881749] tap0 manual = 0
[   36.892018] end_1.4.2
[   36.972979] 8021q: adding VLAN 0 to HW filter on device lan3
[   37.002703] switch: port 3(lan3) entered blocking state
[   37.020159] switch: port 3(lan3) entered disabled state
[   37.037796] rtl83xx-switch switch@1b000000 lan3: entered allmulticast mode
[   37.061738] rtl83xx-switch switch@1b000000 lan3: entered promiscuous mode
[   37.099389] rtl83xx-switch switch@1b000000 lan4: configuring for inband/usxgmii link mode
[   37.126571] realtek-otto-pcs 1b000000.switchcore:pcs: configure SerDes 5 for mode usxgmii
[   37.164090] rtpcs_930x_phy_enable_10g_1g 1gbit phy: 00001140
[   37.182900] rtpcs_930x_phy_enable_10g_1g 1gbit phy enabled: 00001140
[   37.204084] rtpcs_930x_phy_enable_10g_1g 10gbit phy: 00002040
[   37.223305] rtpcs_930x_phy_enable_10g_1g 10gbit phy after: 00002040
[   37.244150] rtpcs_930x_phy_enable_10g_1g set medium: 00000002
[   37.263375] rtpcs_930x_phy_enable_10g_1g set medium after: 00000002
[   37.284241] rtpcs_930x_setup_serdes: Configuring RTL9300 SERDES 5
[   37.324788] start_1.1.1 initial value for sds 5
[   37.339904] end_1.1.1 --
[   37.348381] start_1.1.2 Load DFE init. value
[   37.362656] end_1.1.2
[   37.370306] start_1.1.3 disable LEQ training,enable DFE clock
[   37.389507] end_1.1.3 --
[   37.397986] start_1.1.4 offset cali setting
[   37.411973] end_1.1.4
[   37.419622] start_1.1.5 LEQ and DFE setting
[   37.433579] rtpcs_930x_sds_do_rx_calibration_1 not PHY-based or SerDes, implement DAC!
[   37.459971] end_1.1.5
[   37.472608] start_1.2.1 ForegroundOffsetCal_Manual
[   37.488583] end_1.2.1
[   37.493793] start_1.2.3 Foreground Calibration
[   37.516080] rtpcs_930x_sds_do_rx_calibration_2_3: fgcal_gray: 17, fgcal_binary 25
[   37.540982] rtpcs_930x_sds_do_rx_calibration_2_3: end_1.2.3
[   37.559532] start_1.4.1
[   37.780422] end_1.4.1
[   37.788570] start_1.4.2
[   37.797273] vth_set_bin = 3
[   37.805474] vth_set_bin = 3
[   37.814871] Vth Maunal = 0
[   37.925724] Tap0 Sign : +
[   37.934785] tap0_coef_bin = 27
[   37.943564] tap0 manual = 0
[   37.953821] end_1.4.2
[   38.034788] 8021q: adding VLAN 0 to HW filter on device lan4
[   38.065627] switch: port 4(lan4) entered blocking state
[   38.083108] switch: port 4(lan4) entered disabled state
[   38.100574] rtl83xx-switch switch@1b000000 lan4: entered allmulticast mode
[   38.124161] rtl83xx-switch switch@1b000000 lan4: entered promiscuous mode
[   38.162014] rtl83xx-switch switch@1b000000 lan5: configuring for inband/usxgmii link mode
[   38.189179] realtek-otto-pcs 1b000000.switchcore:pcs: configure SerDes 6 for mode usxgmii
[   38.226700] rtpcs_930x_phy_enable_10g_1g 1gbit phy: 00001140
[   38.245501] rtpcs_930x_phy_enable_10g_1g 1gbit phy enabled: 00001140
[   38.266648] rtpcs_930x_phy_enable_10g_1g 10gbit phy: 00002040
[   38.285823] rtpcs_930x_phy_enable_10g_1g 10gbit phy after: 00002040
[   38.306709] rtpcs_930x_phy_enable_10g_1g set medium: 00000002
[   38.325856] rtpcs_930x_phy_enable_10g_1g set medium after: 00000002
[   38.346797] rtpcs_930x_setup_serdes: Configuring RTL9300 SERDES 6
[   38.387244] start_1.1.1 initial value for sds 6
[   38.402380] end_1.1.1 --
[   38.410870] start_1.1.2 Load DFE init. value
[   38.425120] end_1.1.2
[   38.432659] start_1.1.3 disable LEQ training,enable DFE clock
[   38.451770] end_1.1.3 --
[   38.460248] start_1.1.4 offset cali setting
[   38.474240] end_1.1.4
[   38.481748] start_1.1.5 LEQ and DFE setting
[   38.495677] rtpcs_930x_sds_do_rx_calibration_1 not PHY-based or SerDes, implement DAC!
[   38.522055] end_1.1.5
[   38.534835] start_1.2.1 ForegroundOffsetCal_Manual
[   38.550765] end_1.2.1
[   38.555920] start_1.2.3 Foreground Calibration
[   38.578244] rtpcs_930x_sds_do_rx_calibration_2_3: fgcal_gray: 61, fgcal_binary 35
[   38.603155] rtpcs_930x_sds_do_rx_calibration_2_3: end_1.2.3
[   38.621717] start_1.4.1
[   38.842629] end_1.4.1
[   38.850771] start_1.4.2
[   38.859481] vth_set_bin = 7
[   38.867657] vth_set_bin = 7
[   38.877022] Vth Maunal = 0
[   38.987937] Tap0 Sign : +
[   38.996953] tap0_coef_bin = 0
[   39.005710] tap0 manual = 0
[   39.015704] end_1.4.2
[   39.096628] 8021q: adding VLAN 0 to HW filter on device lan5
[   39.125250] switch: port 5(lan5) entered blocking state
[   39.142649] switch: port 5(lan5) entered disabled state
[   39.160121] rtl83xx-switch switch@1b000000 lan5: entered allmulticast mode
[   39.185024] rtl83xx-switch switch@1b000000 lan5: entered promiscuous mode
[   39.210365] rtl83xx-switch switch@1b000000 lan1: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   39.225461] rtl83xx-switch switch@1b000000 lan6: configuring for inband/10gbase-r link mode
[   39.267214] realtek-otto-pcs 1b000000.switchcore:pcs: configure SerDes 8 for mode 10gbase-r
[   39.305375] rtpcs_930x_phy_enable_10g_1g 1gbit phy: 00001140
[   39.324214] rtpcs_930x_phy_enable_10g_1g 1gbit phy enabled: 00001140
[   39.345366] rtpcs_930x_phy_enable_10g_1g 10gbit phy: 00002040
[   39.364513] rtpcs_930x_phy_enable_10g_1g 10gbit phy after: 00002040
[   39.385432] rtpcs_930x_phy_enable_10g_1g set medium: 00000002
[   39.404560] rtpcs_930x_phy_enable_10g_1g set medium after: 00000002
[   39.425441] rtpcs_930x_setup_serdes: Configuring RTL9300 SERDES 8
[   39.445833] rtpcs_930x_sds_config_pll: SDS 8 using LC PLL for mode 4
[   39.588718] rtpcs_930x_sds_10g_idle WARNING: Waiting for RX idle timed out, SDS 8
[   39.613565] start_1.1.1 initial value for sds 8
[   39.628732] end_1.1.1 --
[   39.637210] start_1.1.2 Load DFE init. value
[   39.651502] end_1.1.2
[   39.659096] start_1.1.3 disable LEQ training,enable DFE clock
[   39.678273] end_1.1.3 --
[   39.686778] start_1.1.4 offset cali setting
[   39.700755] end_1.1.4
[   39.708390] start_1.1.5 LEQ and DFE setting
[   39.722387] end_1.1.5
[   39.735095] start_1.2.1 ForegroundOffsetCal_Manual
[   39.751002] end_1.2.1
[   39.756152] start_1.2.3 Foreground Calibration
[   39.778497] rtpcs_930x_sds_do_rx_calibration_2_3: fgcal_gray: 63, fgcal_binary 32
[   39.803379] rtpcs_930x_sds_do_rx_calibration_2_3: end_1.2.3
[   39.821963] start_1.4.1
[   40.042807] end_1.4.1
[   40.050935] start_1.4.2
[   40.059639] vth_set_bin = 7
[   40.067855] vth_set_bin = 7
[   40.077215] Vth Maunal = 0
[   40.188022] Tap0 Sign : +
[   40.197042] tap0_coef_bin = 31
[   40.205811] tap0 manual = 0
[   40.216051] end_1.4.2
[   40.225391] start_1.5.2
[   40.303701] end_1.5.2
[   40.331955] rtpcs_930x_sds_do_rx_calibration: SDS enabled
[   40.409977] 8021q: adding VLAN 0 to HW filter on device lan6
[   40.429125] switch: port 1(lan1) entered blocking state
[   40.446577] switch: port 1(lan1) entered forwarding state
[   40.466656] switch: port 6(lan6) entered blocking state
[   40.484104] switch: port 6(lan6) entered disabled state
[   40.501610] rtl83xx-switch switch@1b000000 lan6: entered allmulticast mode
[   40.525258] rtl83xx-switch switch@1b000000 lan6: entered promiscuous mode
[   60.654011] sfp sfp-p26: failed to read EEPROM: -ENXIO

root@OpenWrt:~# ip addr
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1504 qdisc mq state UP qlen 1000
    link/ether 00:e0:4c:00:00:00 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::2e0:4cff:fe00:0/64 scope link
       valid_lft forever preferred_lft forever
3: lan1@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master switch state UP qlen 1000
    link/ether 00:e0:4c:00:00:00 brd ff:ff:ff:ff:ff:ff
4: lan2@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 00:e0:4c:00:00:00 brd ff:ff:ff:ff:ff:ff
5: lan3@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 00:e0:4c:00:00:00 brd ff:ff:ff:ff:ff:ff
6: lan4@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 00:e0:4c:00:00:00 brd ff:ff:ff:ff:ff:ff
7: lan5@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 00:e0:4c:00:00:00 brd ff:ff:ff:ff:ff:ff
8: lan6@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master switch state LOWERLAYERDOWN qlen 1000
    link/ether 00:e0:4c:00:00:00 brd ff:ff:ff:ff:ff:ff
9: switch: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP qlen 1000
    link/ether 00:e0:4c:00:00:00 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::2e0:4cff:fe00:0/64 scope link
       valid_lft forever preferred_lft forever
10: switch.1@switch: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP qlen 1000
    link/ether 00:e0:4c:00:00:00 brd ff:ff:ff:ff:ff:ff
    inet 192.168.1.1/24 brd 192.168.1.255 scope global switch.1
       valid_lft forever preferred_lft forever
    inet6 fd8a:a3b0:4a13::1/60 scope global noprefixroute
       valid_lft forever preferred_lft forever
    inet6 fe80::2e0:4cff:fe00:0/64 scope link
       valid_lft forever preferred_lft forever
```
