### PR TITLE
realtek: dsa: allow building as a module

### DIFF
--- a/target/linux/realtek/files-6.12/arch/mips/rtl-otto/prom.c
+++ b/target/linux/realtek/files-6.12/arch/mips/rtl-otto/prom.c
@@ -39,6 +39,8 @@
 #define soc_w32(val, reg)		writel(val, RTL_SOC_BASE + reg)
 
 struct rtl83xx_soc_info soc_info;
+EXPORT_SYMBOL(soc_info);
+
 const void *fdt;
 
 static char rtl_soc_name[16];

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/Makefile
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/Makefile
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: GPL-2.0
-obj-$(CONFIG_NET_DSA_RTL83XX)	+= common.o dsa.o \
-	rtl838x.o rtl839x.o rtl930x.o rtl931x.o debugfs.o qos.o tc.o
+obj-$(CONFIG_NET_DSA_RTL83XX) += rtl_otto_dsa.o
+rtl_otto_dsa-objs := common.o dsa.o rtl838x.o rtl839x.o rtl930x.o rtl931x.o debugfs.o qos.o tc.o

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -24,8 +24,6 @@
 #include <asm/mach-rtl-otto/mach-rtl-otto.h>
 #include "rtl838x_eth.h"
 
-int rtl83xx_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type_data);
-
 #define RTETH_OWN_CPU		1
 #define RTETH_RX_RING_SIZE	128
 #define RTETH_RX_RINGS		2
@@ -1366,6 +1364,23 @@ static struct phylink_pcs *rteth_mac_select_pcs(struct phylink_config *config,
 	return &ctrl->pcs;
 }
 
+static int rteth_setup_tc(struct net_device *dev, enum tc_setup_type type, void *type_data)
+{
+    struct dsa_switch *ds;
+    struct dsa_port *dp;
+
+    if (!netdev_uses_dsa(dev))
+        return -EOPNOTSUPP;
+
+    dp = dev->dsa_ptr;
+    ds = dp->ds;
+
+    if (!ds->ops->port_setup_tc)
+        return -EOPNOTSUPP;
+
+    return ds->ops->port_setup_tc(ds, dp->index, type, type_data);
+}
+
 static const struct net_device_ops rteth_838x_netdev_ops = {
 	.ndo_open = rteth_open,
 	.ndo_stop = rteth_stop,
@@ -1376,7 +1391,7 @@ static const struct net_device_ops rteth_838x_netdev_ops = {
 	.ndo_tx_timeout = rteth_tx_timeout,
 	.ndo_set_features = rteth_83xx_set_features,
 	.ndo_fix_features = rteth_fix_features,
-	.ndo_setup_tc = rtl83xx_setup_tc,
+	.ndo_setup_tc = rteth_setup_tc,
 };
 
 static const struct rteth_config rteth_838x_cfg = {
@@ -1423,7 +1438,7 @@ static const struct net_device_ops rteth_839x_netdev_ops = {
 	.ndo_tx_timeout = rteth_tx_timeout,
 	.ndo_set_features = rteth_83xx_set_features,
 	.ndo_fix_features = rteth_fix_features,
-	.ndo_setup_tc = rtl83xx_setup_tc,
+	.ndo_setup_tc = rteth_setup_tc,
 };
 
 static const struct rteth_config rteth_839x_cfg = {
@@ -1470,7 +1485,7 @@ static const struct net_device_ops rteth_930x_netdev_ops = {
 	.ndo_tx_timeout = rteth_tx_timeout,
 	.ndo_set_features = rteth_93xx_set_features,
 	.ndo_fix_features = rteth_fix_features,
-	.ndo_setup_tc = rtl83xx_setup_tc,
+	.ndo_setup_tc = rteth_setup_tc,
 };
 
 static const struct rteth_config rteth_930x_cfg = {
@@ -1520,6 +1535,7 @@ static const struct net_device_ops rteth_931x_netdev_ops = {
 	.ndo_tx_timeout = rteth_tx_timeout,
 	.ndo_set_features = rteth_93xx_set_features,
 	.ndo_fix_features = rteth_fix_features,
+	.ndo_setup_tc = rteth_setup_tc,
 };
 
 static const struct rteth_config rteth_931x_cfg = {


### PR DESCRIPTION
Cleanup some dependencies to allow for dsa module compilation.