### PR TITLE
ipq40xx: Enable Devolo Magic 2 WiFi next

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -392,7 +392,6 @@ define Device/devolo_magic-2-wifi-next
 	IMAGE_SIZE := 26624k
 	IMAGES := sysupgrade.bin
 	IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
-	DEFAULT := n
 endef
 TARGET_DEVICES += devolo_magic-2-wifi-next
 


### PR DESCRIPTION
Note that for G.hn support some packages need to be extracted from the Devolo firmware. This is not included in this commit.

I tested that everything works with my own Devolo Magic 2 WiFi next device.