### PR TITLE
iproute2: include upstream patch for musl libc

### DIFF
--- a/package/network/utils/iproute2/patches/301-fix-UINT_MAX-undeclared-with-build-with-musl-libc.patch
+++ b/package/network/utils/iproute2/patches/301-fix-UINT_MAX-undeclared-with-build-with-musl-libc.patch
@@ -1,0 +1,34 @@
+From 6c1113633fde51b0e60f02243cfad1b3d09762cc Mon Sep 17 00:00:00 2001
+From: Akhilesh Nema <nemaakhilesh@gmail.com>
+Date: Tue, 2 Dec 2025 18:11:24 -0800
+Subject: [PATCH] fix 'UINT_MAX' undeclared with build with musl libc
+
+- utils_math.c:136:20: error: 'UINT_MAX' undeclared (first use in this function)
+- tc_core.c:51:22: error: 'UINT_MAX' undeclared (first use in this function)
+
+Signed-off-by: Akhilesh Nema <nemaakhilesh@gmail.com>
+---
+ lib/utils_math.c | 1 +
+ tc/tc_core.c     | 1 +
+ 2 files changed, 2 insertions(+)
+
+--- a/lib/utils_math.c
++++ b/lib/utils_math.c
+@@ -4,6 +4,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <math.h>
++#include <limits.h>
+ #include <asm/types.h>
+ 
+ #include "utils.h"
+--- a/tc/tc_core.c
++++ b/tc/tc_core.c
+@@ -11,6 +11,7 @@
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <math.h>
++#include <limits.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+ #include <arpa/inet.h>


### PR DESCRIPTION
Due to a missing include, the constant UINT_MAX is undefined. This fixes issues when building v25.12.0-rc5. Including a newer version of iproute2 would include the patch, but causes other building issues.