### PR TITLE
realtek: mdio: port to phy/address conversion

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -9,7 +9,7 @@
 #include <linux/regmap.h>
 #include <linux/types.h>
 
-#define RTMDIO_MAX_PORT				57
+#define RTMDIO_MAX_PHY				57
 #define RTMDIO_MAX_SMI_BUS			4
 #define RTMDIO_PAGE_SELECT			0x1f
 
@@ -181,10 +181,10 @@
 struct rtmdio_ctrl {
 	struct regmap *map;
 	const struct rtmdio_config *cfg;
-	int page[RTMDIO_MAX_PORT];
-	bool raw[RTMDIO_MAX_PORT];
-	int smi_bus[RTMDIO_MAX_PORT];
-	int smi_addr[RTMDIO_MAX_PORT];
+	int page[RTMDIO_MAX_PHY];
+	bool raw[RTMDIO_MAX_PHY];
+	int smi_bus[RTMDIO_MAX_PHY];
+	int smi_addr[RTMDIO_MAX_PHY];
 	bool smi_bus_isc45[RTMDIO_MAX_SMI_BUS];
 };
 
@@ -877,7 +877,7 @@ static int rtmdio_reset(struct mii_bus *bus)
 static int rtmdio_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
-	struct device_node *dn[RTMDIO_MAX_PORT] = {}, *np;
+	struct device_node *dn[RTMDIO_MAX_PHY] = {}, *np;
 	struct rtmdio_ctrl *ctrl;
 	struct mii_bus *bus;
 	int ret, addr;
@@ -892,7 +892,7 @@ static int rtmdio_probe(struct platform_device *pdev)
 	if (IS_ERR(ctrl->map))
 		return PTR_ERR(ctrl->map);
 
-	for (addr = 0; addr < RTMDIO_MAX_PORT; addr++)
+	for (addr = 0; addr < RTMDIO_MAX_PHY; addr++)
 		ctrl->smi_bus[addr] = -1;
 
 	for_each_node_by_name(np, "ethernet-phy") {

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -108,7 +108,7 @@
 #define RTMDIO_931X_SMI_10GPHY_POLLING_SEL4	(0x0D00)
 
 #define for_each_port(ctrl, addr) \
-	for (int addr = 0; addr < (ctrl)->cfg->cpu_port; addr++) \
+	for (int addr = 0; addr < (ctrl)->cfg->num_phys; addr++) \
 		if ((ctrl)->smi_bus[addr] >= 0)
 
 /*
@@ -189,7 +189,7 @@ struct rtmdio_ctrl {
 };
 
 struct rtmdio_config {
-	int cpu_port;
+	int num_phys;
 	int raw_page;
 	int bus_map_base;
 	int port_map_base;
@@ -494,7 +494,7 @@ static int rtmdio_read_c45(struct mii_bus *bus, int addr, int devnum, int regnum
 	struct rtmdio_ctrl *ctrl = bus->priv;
 	int err, val;
 
-	if (addr >= ctrl->cfg->cpu_port)
+	if (addr >= ctrl->cfg->num_phys)
 		return -ENODEV;
 
 	err = (*ctrl->cfg->read_mmd_phy)(bus, addr, devnum, regnum, &val);
@@ -508,7 +508,7 @@ static int rtmdio_read(struct mii_bus *bus, int addr, int regnum)
 	struct rtmdio_ctrl *ctrl = bus->priv;
 	int err, val;
 
-	if (addr >= ctrl->cfg->cpu_port)
+	if (addr >= ctrl->cfg->num_phys)
 		return -ENODEV;
 
 	if (regnum == RTMDIO_PAGE_SELECT && ctrl->page[addr] != ctrl->cfg->raw_page)
@@ -527,7 +527,7 @@ static int rtmdio_write_c45(struct mii_bus *bus, int addr, int devnum, int regnu
 	struct rtmdio_ctrl *ctrl = bus->priv;
 	int err;
 
-	if (addr >= ctrl->cfg->cpu_port)
+	if (addr >= ctrl->cfg->num_phys)
 		return -ENODEV;
 
 	err = (*ctrl->cfg->write_mmd_phy)(bus, addr, devnum, regnum, val);
@@ -541,7 +541,7 @@ static int rtmdio_write(struct mii_bus *bus, int addr, int regnum, u16 val)
 	struct rtmdio_ctrl *ctrl = bus->priv;
 	int err, page;
 
-	if (addr >= ctrl->cfg->cpu_port)
+	if (addr >= ctrl->cfg->num_phys)
 		return -ENODEV;
 
 	page = ctrl->page[addr];
@@ -899,7 +899,7 @@ static int rtmdio_probe(struct platform_device *pdev)
 		if (of_property_read_u32(np, "reg", &addr))
 			continue;
 
-		if (addr < 0 || addr >= ctrl->cfg->cpu_port) {
+		if (addr < 0 || addr >= ctrl->cfg->num_phys) {
 			dev_err(dev, "illegal port number %d\n", addr);
 			of_node_put(np);
 			return -EINVAL;
@@ -938,7 +938,7 @@ static int rtmdio_probe(struct platform_device *pdev)
 	if (ret)
 		return ret;
 
-	for (addr = 0; addr < ctrl->cfg->cpu_port; addr++) {
+	for (addr = 0; addr < ctrl->cfg->num_phys; addr++) {
 		if (ctrl->smi_bus[addr] < 0)
 			continue;
 
@@ -955,7 +955,7 @@ static int rtmdio_probe(struct platform_device *pdev)
 }
 
 static const struct rtmdio_config rtmdio_838x_cfg = {
-	.cpu_port	= 28,
+	.num_phys	= 28,
 	.raw_page	= 4095,
 	.port_map_base	= RTMDIO_838X_SMI_PORT0_5_ADDR_CTRL,
 	.read_mmd_phy	= rtmdio_838x_read_mmd_phy,
@@ -967,7 +967,7 @@ static const struct rtmdio_config rtmdio_838x_cfg = {
 };
 
 static const struct rtmdio_config rtmdio_839x_cfg = {
-	.cpu_port	= 52,
+	.num_phys	= 52,
 	.raw_page	= 8191,
 	.read_mmd_phy	= rtmdio_839x_read_mmd_phy,
 	.read_phy	= rtmdio_839x_read_phy,
@@ -977,7 +977,7 @@ static const struct rtmdio_config rtmdio_839x_cfg = {
 };
 
 static const struct rtmdio_config rtmdio_930x_cfg = {
-	.cpu_port	= 28,
+	.num_phys	= 28,
 	.raw_page	= 4095,
 	.bus_map_base	= RTMDIO_930X_SMI_PORT0_15_POLLING_SEL,
 	.port_map_base	= RTMDIO_930X_SMI_PORT0_5_ADDR_CTRL,
@@ -990,7 +990,7 @@ static const struct rtmdio_config rtmdio_930x_cfg = {
 };
 
 static const struct rtmdio_config rtmdio_931x_cfg = {
-	.cpu_port	= 56,
+	.num_phys	= 56,
 	.raw_page	= 8191,
 	.bus_map_base	= RTMDIO_931X_SMI_PORT_POLLING_SEL,
 	.port_map_base	= RTMDIO_931X_SMI_PORT_ADDR_CTRL,

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -193,11 +193,11 @@ struct rtmdio_config {
 	int raw_page;
 	int bus_map_base;
 	int port_map_base;
-	int (*read_mmd_phy)(struct mii_bus *bus, u32 port, u32 addr, u32 reg, u32 *val);
+	int (*read_mmd_phy)(struct mii_bus *bus, u32 port, u32 devnum, u32 regnum, u32 *val);
 	int (*read_phy)(struct mii_bus *bus, u32 port, u32 page, u32 reg, u32 *val);
 	int (*reset)(struct mii_bus *bus);
 	void (*setup_polling)(struct mii_bus *bus);
-	int (*write_mmd_phy)(struct mii_bus *bus, u32 port, u32 addr, u32 reg, u32 val);
+	int (*write_mmd_phy)(struct mii_bus *bus, u32 port, u32 devnum, u32 regnum, u32 val);
 	int (*write_phy)(struct mii_bus *bus, u32 port, u32 page, u32 reg, u32 val);
 };
 
@@ -266,14 +266,14 @@ static int rtmdio_838x_write_phy(struct mii_bus *bus, u32 port, u32 page, u32 re
 	return rtmdio_838x_run_cmd(bus, RTMDIO_838X_CMD_WRITE_C22);
 }
 
-static int rtmdio_838x_read_mmd_phy(struct mii_bus *bus, u32 port, u32 addr, u32 reg, u32 *val)
+static int rtmdio_838x_read_mmd_phy(struct mii_bus *bus, u32 port, u32 devnum, u32 regnum, u32 *val)
 {
 	struct rtmdio_ctrl *ctrl = bus->priv;
 	int err;
 
 	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_0, BIT(port));
 	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_2, port << 16);
-	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_3, addr << 16 | reg);
+	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_3, devnum << 16 | regnum);
 	err = rtmdio_838x_run_cmd(bus, RTMDIO_838X_CMD_READ_C45);
 	if (!err)
 		err = regmap_read(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_2, val);
@@ -283,13 +283,13 @@ static int rtmdio_838x_read_mmd_phy(struct mii_bus *bus, u32 port, u32 addr, u32
 	return err;
 }
 
-static int rtmdio_838x_write_mmd_phy(struct mii_bus *bus, u32 port, u32 addr, u32 reg, u32 val)
+static int rtmdio_838x_write_mmd_phy(struct mii_bus *bus, u32 port, u32 devnum, u32 regnum, u32 val)
 {
 	struct rtmdio_ctrl *ctrl = bus->priv;
 
 	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_0, BIT(port));
 	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_2, val << 16);
-	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_3, addr << 16 | reg);
+	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_3, devnum << 16 | regnum);
 
 	return rtmdio_838x_run_cmd(bus, RTMDIO_838X_CMD_WRITE_C45);
 }

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -873,7 +873,7 @@ static int rtmdio_reset(struct mii_bus *bus)
 static int rtmdio_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
-	struct device_node *dn[RTMDIO_MAX_PHY] = {}, *np;
+	struct device_node *np, *dn[RTMDIO_MAX_PHY];
 	struct rtmdio_ctrl *ctrl;
 	struct mii_bus *bus;
 	int ret, addr;

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -107,7 +107,7 @@
 #define RTMDIO_931X_SMI_10GPHY_POLLING_SEL3	(0x0CFC)
 #define RTMDIO_931X_SMI_10GPHY_POLLING_SEL4	(0x0D00)
 
-#define for_each_port(ctrl, addr) \
+#define for_each_phy(ctrl, addr) \
 	for (int addr = 0; addr < (ctrl)->cfg->num_phys; addr++) \
 		if ((ctrl)->smi_bus[addr] >= 0)
 
@@ -567,7 +567,7 @@ static void rtmdio_setup_smi_topology(struct mii_bus *bus)
 	struct rtmdio_ctrl *ctrl = bus->priv;
 	u32 reg, mask, val;
 
-	for_each_port(ctrl, addr) {
+	for_each_phy(ctrl, addr) {
 		if (ctrl->cfg->bus_map_base) {
 			reg = (addr / 16) * 4;
 			mask = 0x3 << ((addr % 16) * 2);
@@ -727,7 +727,7 @@ static void rtmdio_930x_setup_polling(struct mii_bus *bus)
 	regmap_write(ctrl->map, RTMDIO_930X_SMI_MAC_TYPE_CTRL, 0);
 
 	/* Define PHY specific polling parameters */
-	for_each_port(ctrl, addr) {
+	for_each_phy(ctrl, addr) {
 		if (rtmdio_get_phy_info(bus, addr, &phyinfo))
 			continue;
 
@@ -804,7 +804,7 @@ static void rtmdio_931x_setup_polling(struct mii_bus *bus)
 			     RTMDIO_931X_SMI_PHY_ABLTY_SDS * 0x55555555U);
 
 	/* Define PHY specific polling parameters */
-	for_each_port(ctrl, addr) {
+	for_each_phy(ctrl, addr) {
 		int smi = ctrl->smi_bus[addr];
 		unsigned int mask, val;
 		
@@ -938,10 +938,7 @@ static int rtmdio_probe(struct platform_device *pdev)
 	if (ret)
 		return ret;
 
-	for (addr = 0; addr < ctrl->cfg->num_phys; addr++) {
-		if (ctrl->smi_bus[addr] < 0)
-			continue;
-
+	for_each_phy(ctrl, addr) {
 		ret = fwnode_mdiobus_register_phy(bus, of_fwnode_handle(dn[addr]), addr);
 		of_node_put(dn[addr]);
 		if (ret)


### PR DESCRIPTION
The mdio driver has a lot of leftovers from the time when it resided in the ethernet driver. Rename what is needed to conform with upstream mdio/phy.