### PR TITLE
realtek: rtl838x: drop GS1900 MDIO reset GPIO

### DIFF
--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900_gpio.dtsi
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900_gpio.dtsi
@@ -5,10 +5,6 @@
 &mdio_aux {
 	status = "okay";
 
-	reset-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
-	reset-delay-us = <1000>;
-	reset-post-delay-us = <10000>;
-
 	gpio1: expander@0 {
 		compatible = "realtek,rtl8231";
 		reg = <0x0>;

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900_gpio_emulated.dtsi
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900_gpio_emulated.dtsi
@@ -5,10 +5,6 @@
 &mdio_gpio {
 	status = "okay";
 
-	reset-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
-	reset-delay-us = <1000>;
-	reset-post-delay-us = <10000>;
-
 	gpio1: expander@0 {
 		compatible = "realtek,rtl8231";
 		reg = <0x0>;

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24e-a1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24e-a1.dts
@@ -8,6 +8,16 @@
 	model = "Zyxel GS1900-24E A1";
 };
 
+&gpio0 {
+	/* Shared between the main and aux MDIO busses */
+	mdio_reset {
+		gpio-hog;
+		gpios = <1 GPIO_ACTIVE_LOW>;
+		output-low;
+		line-name = "mdio-reset";
+	};
+};
+
 &mdio_bus0 {
 	EXTERNAL_PHY(0)
 	EXTERNAL_PHY(1)


### PR DESCRIPTION
The reset line wired to the RTL8231 on the GS1900 series may also connect to other external ICs on the board. On the GS1900-24HP, the reset line is wired (via buffers) to the board's RTL8231 expanders and the RTL8218 phys. As these external devices (phys) are on different busses, the reset line shouldn't be specified on one bus or the other and we should drop it.

Link: https://github.com/openwrt/openwrt/issues/18620
Fixes: fd978c2e80b4 ("realtek: Enable Zyxel GS1900's RTL8231 reset line")