### PR TITLE
ramips: add support for Securifi Almond 3/3S family

### DIFF
--- a/target/linux/ramips/dts/mt7621_securifi_almond-3.dts
+++ b/target/linux/ramips/dts/mt7621_securifi_almond-3.dts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (c) 2026
+ * Author: Fil Dunsky <filipp.dunsky@gmail.com>
+ */
+
+#include "mt7621_securifi_almond.dtsi"
+
+/ {
+	compatible = "securifi,almond-3", "mediatek,mt7621-soc";
+	model = "Securifi Almond 3";
+};

--- a/target/linux/ramips/dts/mt7621_securifi_almond-3s.dts
+++ b/target/linux/ramips/dts/mt7621_securifi_almond-3s.dts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (c) 2026
+ * Author: Fil Dunsky <filipp.dunsky@gmail.com>
+ */
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "securifi,almond-3s", "mediatek,mt7621-soc";
+	model = "Securifi Almond 3S";
+
+	aliases {
+		serial2 = &uartlite3;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			debounce-interval = <20>;
+		};
+
+		/* Battery-cover contact ("tamper"): a latch, not a momentary
+		 * button. EV_SW makes gpio-button-hotplug report the cover
+		 * position already at boot, so userspace can evaluate it from
+		 * any state (the stock firmware used it for a tamper alarm).
+		 */
+		tamper {
+			label = "tamper";
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+			debounce-interval = <50>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		/* GPIO 31 gates the LCD backlight, not a discrete status LED.
+		 * Deliberately not wired to the led-boot/-running/-upgrade/
+		 * -failsafe aliases: blinking or blanking it would flash or
+		 * black out the whole display.
+		 */
+		display_power {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		modem-reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 { /* MT25QL512AB */
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		broken-flash-reset;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					mac_lan: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+
+					mac_wan: macaddr@2e {
+						reg = <0x2e 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x3fb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&mac_lan>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&mac_wan>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+/* EM357 Zigbee NCP: EZSP over ASH, 57600 8N1, no flow control
+ * (ASH escapes control bytes at the protocol level).
+ */
+&uartlite3 {
+	status = "okay";
+	current-speed = <57600>;
+};

--- a/target/linux/ramips/dts/mt7621_securifi_almond-3s.dts
+++ b/target/linux/ramips/dts/mt7621_securifi_almond-3s.dts
@@ -4,63 +4,11 @@
  * Author: Fil Dunsky <filipp.dunsky@gmail.com>
  */
 
-#include "mt7621.dtsi"
-
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
-#include <dt-bindings/gpio/gpio.h>
+#include "mt7621_securifi_almond.dtsi"
 
 / {
 	compatible = "securifi,almond-3s", "mediatek,mt7621-soc";
 	model = "Securifi Almond 3S";
-
-	aliases {
-		serial2 = &uartlite3;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,57600n8";
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
-			debounce-interval = <20>;
-		};
-
-		/* Battery-cover contact ("tamper"): a latch, not a momentary
-		 * button. EV_SW makes gpio-button-hotplug report the cover
-		 * position already at boot, so userspace can evaluate it from
-		 * any state (the stock firmware used it for a tamper alarm).
-		 */
-		tamper {
-			label = "tamper";
-			linux,code = <BTN_0>;
-			linux,input-type = <EV_SW>;
-			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
-			debounce-interval = <50>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		/* GPIO 31 gates the LCD backlight, not a discrete status LED.
-		 * Deliberately not wired to the led-boot/-running/-upgrade/
-		 * -failsafe aliases: blinking or blanking it would flash or
-		 * black out the whole display.
-		 */
-		display_power {
-			color = <LED_COLOR_ID_WHITE>;
-			function = LED_FUNCTION_POWER;
-			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
-			default-state = "on";
-		};
-	};
 
 	gpio-export {
 		compatible = "gpio-export";
@@ -73,139 +21,17 @@
 	};
 };
 
-&i2c {
-	status = "okay";
-};
-
-&spi0 {
-	status = "okay";
-
-	flash@0 { /* MT25QL512AB */
-		compatible = "jedec,spi-nor";
-		reg = <0>;
-		spi-max-frequency = <52000000>;
-		broken-flash-reset;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "u-boot";
-				reg = <0x0 0x30000>;
-				read-only;
-			};
-
-			partition@30000 {
-				label = "u-boot-env";
-				reg = <0x30000 0x10000>;
-			};
-
-			partition@40000 {
-				label = "factory";
-				reg = <0x40000 0x10000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					eeprom_factory_0: eeprom@0 {
-						reg = <0x0 0x200>;
-					};
-
-					eeprom_factory_8000: eeprom@8000 {
-						reg = <0x8000 0x200>;
-					};
-
-					mac_lan: macaddr@28 {
-						reg = <0x28 0x6>;
-					};
-
-					mac_wan: macaddr@2e {
-						reg = <0x2e 0x6>;
-					};
-				};
-			};
-
-			partition@50000 {
-				compatible = "openwrt,uimage", "denx,uimage";
-				label = "firmware";
-				reg = <0x50000 0x3fb0000>;
-			};
-		};
+&keys {
+	/* Battery-cover contact ("tamper"): a latch, not a momentary
+	 * button. EV_SW makes gpio-button-hotplug report the cover
+	 * position already at boot, so userspace can evaluate it from
+	 * any state (the stock firmware used it for a tamper alarm).
+	 */
+	tamper {
+		label = "tamper";
+		linux,code = <BTN_0>;
+		linux,input-type = <EV_SW>;
+		gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+		debounce-interval = <50>;
 	};
-};
-
-&pcie {
-	status = "okay";
-};
-
-&pcie0 {
-	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		ieee80211-freq-limit = <5000000 6000000>;
-
-		nvmem-cells = <&eeprom_factory_8000>;
-		nvmem-cell-names = "eeprom";
-	};
-};
-
-&pcie1 {
-	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		ieee80211-freq-limit = <2400000 2500000>;
-
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
-	};
-};
-
-&gmac0 {
-	nvmem-cells = <&mac_lan>;
-	nvmem-cell-names = "mac-address";
-};
-
-&ethernet {
-	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
-};
-
-&state_default {
-	gpio {
-		groups = "jtag", "wdt", "rgmii2";
-		function = "gpio";
-	};
-};
-
-&switch0 {
-	ports {
-		port@0 {
-			status = "okay";
-			label = "wan";
-			nvmem-cells = <&mac_wan>;
-			nvmem-cell-names = "mac-address";
-		};
-
-		port@1 {
-			status = "okay";
-			label = "lan2";
-		};
-
-		port@2 {
-			status = "okay";
-			label = "lan1";
-		};
-	};
-};
-
-/* EM357 Zigbee NCP: EZSP over ASH, 57600 8N1, no flow control
- * (ASH escapes control bytes at the protocol level).
- */
-&uartlite3 {
-	status = "okay";
-	current-speed = <57600>;
 };

--- a/target/linux/ramips/dts/mt7621_securifi_almond-3s.dts
+++ b/target/linux/ramips/dts/mt7621_securifi_almond-3s.dts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (c) 2026
+ * Author: Fil Dunsky <filipp.dunsky@gmail.com>
+ */
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "securifi,almond-3s", "mediatek,mt7621-soc";
+	model = "Securifi Almond 3S";
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			debounce-interval = <20>;
+		};
+
+		/* Battery-cover contact ("tamper"): a latch, not a momentary
+		 * button. EV_SW makes gpio-button-hotplug report the cover
+		 * position already at boot, so userspace can evaluate it from
+		 * any state (the stock firmware used it for a tamper alarm).
+		 */
+		tamper {
+			label = "tamper";
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+			gpios = <&gpio 28 GPIO_ACTIVE_LOW>;
+			debounce-interval = <50>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		/* GPIO 31 gates the LCD backlight, not a discrete status LED.
+		 * Deliberately not wired to the led-boot/-running/-upgrade/
+		 * -failsafe aliases: blinking or blanking it would flash or
+		 * black out the whole display.
+		 */
+		display_power {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		modem-reset {
+			gpio-export,name = "modem_reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio 33 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 { /* MT25QL512AB */
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		broken-flash-reset;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					mac_lan: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+
+					mac_wan: macaddr@2e {
+						reg = <0x2e 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x3fb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&mac_lan>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&mac_wan>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+/* EM357 Zigbee NCP: EZSP over ASH, 57600 8N1, no flow control
+ * (ASH escapes control bytes at the protocol level).
+ */
+&uartlite3 {
+	status = "okay";
+	current-speed = <57600>;
+};

--- a/target/linux/ramips/dts/mt7621_securifi_almond.dtsi
+++ b/target/linux/ramips/dts/mt7621_securifi_almond.dtsi
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (c) 2026
+ * Author: Fil Dunsky <filipp.dunsky@gmail.com>
+ */
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	aliases {
+		serial2 = &uartlite3;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	keys: keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 32 GPIO_ACTIVE_LOW>;
+			debounce-interval = <20>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		/* GPIO 31 gates the LCD backlight, not a discrete status LED.
+		 * Deliberately not wired to the led-boot/-running/-upgrade/
+		 * -failsafe aliases: blinking or blanking it would flash or
+		 * black out the whole display.
+		 */
+		display_power {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio 31 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+	};
+};
+
+&i2c {
+	status = "okay";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 { /* MT25QL512AB */
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		broken-flash-reset;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					mac_lan: macaddr@28 {
+						reg = <0x28 0x6>;
+					};
+
+					mac_wan: macaddr@2e {
+						reg = <0x2e 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x3fb0000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <2400000 2500000>;
+
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&mac_lan>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethernet {
+	pinctrl-0 = <&mdio_pins>, <&rgmii1_pins>;
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt", "rgmii2";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "wan";
+			nvmem-cells = <&mac_wan>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};
+
+/* EM357 Zigbee NCP: EZSP over ASH, 57600 8N1, no flow control
+ * (ASH escapes control bytes at the protocol level).
+ */
+&uartlite3 {
+	status = "okay";
+	current-speed = <57600>;
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2800,6 +2800,19 @@ define Device/samknows_whitebox-v8
 endef
 TARGET_DEVICES += samknows_whitebox-v8
 
+define Device/securifi_almond-3s
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := Securifi
+  DEVICE_MODEL := Almond
+  DEVICE_VARIANT := 3S
+  IMAGE_SIZE := 65216k
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | \
+	pad-rootfs | check-size | append-metadata
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 -uboot-envtools \
+	kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+endef
+TARGET_DEVICES += securifi_almond-3s
+
 define Device/sercomm_na502
   $(Device/nand)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2800,6 +2800,18 @@ define Device/samknows_whitebox-v8
 endef
 TARGET_DEVICES += samknows_whitebox-v8
 
+define Device/securifi_almond-3
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := Securifi
+  DEVICE_MODEL := Almond
+  DEVICE_VARIANT := 3
+  IMAGE_SIZE := 65216k
+  IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | \
+	pad-rootfs | check-size | append-metadata
+  DEVICE_PACKAGES := kmod-mt76x2 kmod-usb3 -uboot-envtools
+endef
+TARGET_DEVICES += securifi_almond-3
+
 define Device/securifi_almond-3s
   $(Device/uimage-lzma-loader)
   DEVICE_VENDOR := Securifi

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -121,6 +121,11 @@ ramips_setup_interfaces()
 	xiaomi,mi-router-4a-gigabit-v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
 		;;
+	securifi,almond-3s)
+		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
+		ucidef_set_interface "modem" device "/dev/cdc-wdm0" protocol "qmi"
+		uci add_list firewall.@zone[1].network='modem'
+		;;
 	bolt,arion)
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		ucidef_set_interface "eth_data" device "modem.103" protocol "static" ipaddr "10.22.127.222" netmask "255.255.255.255"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -114,6 +114,7 @@ ramips_setup_interfaces()
 	mts,wg430223|\
 	oraybox,x3a|\
 	renkforce,ws-wn530hp3-a|\
+	securifi,almond-3|\
 	xiaomi,mi-router-3g|\
 	xiaomi,mi-router-3g-v2|\
 	xiaomi,mi-router-4|\


### PR DESCRIPTION
Two devices sharing one board, split into `mt7621_securifi_almond.dtsi` plus two thin device trees. Compared to the previously pushed 3S commit, the Almond 3S commit only gains the `serial2 = &uartlite3` alias (keeps the Zigbee NCP on /dev/ttyS2 regardless of which UARTs are enabled); the second commit moves the common part into the dtsi (the generated 3S DTB is byte-identical before and after the split) and adds the Almond 3.

## Securifi Almond 3S

MediaTek MT7621A
256 MB RAM, 64 MB MT25QL512AB SPI NOR flash
Wi-Fi: 2x MediaTek MT7662 (2.4 GHz and 5 GHz)
Ethernet: 2x LAN, 1x WAN (1 Gbit)
WWAN: miniPCIe Quectel EC21-E LTE Cat 1 (EC21EFAR06A03M4G)
LCD display: S028HQ29NN with SX8650 touchscreen controller
MCU: PIC16LF1509 (battery gauge, buzzer, front LED, power button)
Charge controller: BQ24133 (battery lasts for 4-5 hours of work)
Zigbee: EM357 on uartlite3 (57600)
Buzzer (siren)
LEDs: 1x white front LED (driven by the MCU)
Buttons: Reset (gpio-keys); Tamper battery-cover contact exposed as
  an EV_SW switch; Power is wired to the PIC
Power input: 12 V / 2.5 A barrel jack
UART header: VCC TX GND RX, console 57600 8N1 (do not connect VCC)

## Securifi Almond 3

The non-S sibling: the same board without the LTE modem, the battery
with its charger and the battery-cover tamper contact.

MediaTek MT7621A
256 MB RAM, 64 MB MT25QL512AB SPI NOR flash
Wi-Fi: 2x MediaTek MT7662 (2.4 GHz and 5 GHz)
Ethernet: 2x LAN, 1x WAN (1 Gbit)
USB: 1x USB 2.0
LCD display: 2.8" 320x240 ST7789V panel on a GPIO bus with SX8650
  touchscreen controller (I2C 0x48)
MCU: PIC16F1503 on I2C 0x2a (RGB front LED, buzzer)
Zigbee: EM357 on uartlite3 (57600)
Buzzer
LEDs: 1x RGB front LED (driven by the MCU)
Buttons: Reset (gpio-keys)
Power input: 12 V barrel jack
UART header: VCC TX GND RX, console 57600 8N1 (do not connect VCC)

## MAC addresses and EEPROM data (both devices)

factory 0x28: LAN MAC (gmac0)
factory 0x2e: WAN MAC (switch0 port@0)
factory 0x0:    2.4GHz wireless EEPROM
factory 0x8000: 5GHz wireless EEPROM

## Status

- Working on both: Wi-Fi, ethernet, USB, reset button, reboot,
  sysupgrade (broken-flash-reset in the .dts); LTE modem on the 3S
- The white "LED" on GPIO 31 is the LCD backlight gate; the board has
  no separate GPIO status LED. It is kept lit via default-state and
  is deliberately not wired to the led-boot / led-running /
  led-upgrade / led-failsafe aliases: on a full-screen backlight the
  boot and failsafe blinking flashes the entire display, and the
  sysupgrade handler in diag.sh switches the running LED off, which
  would leave the screen dark for the several minutes a flash takes
- LCD, touchscreen, buzzer, front LED (white on the 3S, RGB on the 3)
  and the 3S battery gauge are fully functional through an
  out-of-tree driver and UI package (kmod-lcd-almond3s,
  lcd-ui-almond3s): https://github.com/fildunsky/openwrt-almond3s
- The SX8650 touch controller (0x48) and the PIC MCU (0x2a) sit on
  the MT7621 I2C bus, which is why &i2c is enabled: the companion
  driver talks to them through the standard i2c-mt7621 adapter
- Zigbee: the EM357 NCP on uartlite3 (/dev/ttyS2, 57600 8N1, no flow
  control) runs the stock EmberZNet 6.7.8 firmware and speaks the
  standard EZSP v8 / ASH protocol, so any EZSP host stack can drive
  it. The NCP firmware can be updated in place over the same UART
  (EZSP launchStandaloneBootloader, then XMODEM at 115200 baud);
  with the companion tool: `almond3s-zig flash ncp-uart-sw-6.7.8.ebl 1`
- 3S only: the tamper contact sits under the battery cover (the cover
  also guards the battery and the SIM slot) and is a latch rather
  than a momentary button, hence EV_SW: gpio-button-hotplug reports
  the initial cover position at boot

The uimage-lzma-loader is required: the stock U-Boot fails to
decompress modern LZMA kernels (LZMA ERROR 1). With the loader the
initramfs uImage carries an uncompressed self-extracting stub, so
the stock bootloader boots it with plain bootm.

## Installation (both devices)

1. Boot into initramfs. Either stop the stock U-Boot on the serial
   console (press 4, set the computer to 10.10.10.3, serve the image
   via tftp: `tftpboot 0x82000000 <initramfs-kernel.bin>; bootm
   0x82000000`), or, without opening the case, log in to the stock
   firmware over telnet (admin/admin) and write the initramfs image
   into the first kernel slot with the vendor mtd tool:
   `mtd_write write <initramfs-kernel.bin> Kernel`, then reboot.
   The stock U-Boot checks only the uImage header and CRC, and keeps
   the second slot as a fallback.

2. Back up all partitions via the LuCI menu.

3. Flash uboot-mt7621 by DragonBluep. The stock firmware uses dual
   boot wasting 50% of flash space; since this device is useless on
   the stock firmware it makes sense to utilize the whole flash,
   hence we have to flash the uboot-mt7621 bootloader:
   https://github.com/DragonBluep/uboot-mt7621

   Bootloader recipe (Actions -> Build customized U-Boot):
   NOR, 192k(u-boot),64k(u-boot-env),64k(factory),-(firmware),
   0x50000, Reset button GPIO: 32, System LED GPIO: 31,
   CPU: 880 MHz, RAM: 1200 MT/s, DDR3-256MiB,
   oldparam: false (do not check), Baud Rate: 57600

   insmod mtd-rw i_want_a_brick=1
   mtd write u-boot-mt7621.bin u-boot

4. Flash the sysupgrade image (`sysupgrade -n` from the initramfs or
   via LuCI), wait 4-5 minutes.

5. After reboot, wait for another 11 minutes till the filesystem is
   initialized and enjoy OpenWrt!

