### PR TITLE
libubox: fix build with GCC 15 and musl fortify headers

### DIFF
--- a/package/libs/libubox/Makefile
+++ b/package/libs/libubox/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libubox
-PKG_RELEASE=1
+PKG_RELEASE=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/libubox.git

--- a/package/libs/libubox/patches/100-fix-build-with-GCC-15.patch
+++ b/package/libs/libubox/patches/100-fix-build-with-GCC-15.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -7,7 +7,7 @@ PROJECT(ubox C)
+ ADD_DEFINITIONS(-Wall -Werror)
+ IF(CMAKE_C_COMPILER_VERSION VERSION_GREATER 6)
+ 	ADD_DEFINITIONS(-Wextra -Werror=implicit-function-declaration)
+-	ADD_DEFINITIONS(-Wformat -Werror=format-security -Werror=format-nonliteral)
++	ADD_DEFINITIONS(-Wformat -Werror=format-security)
+ ENDIF()
+ ADD_DEFINITIONS(-Os -std=gnu99 -g3 -Wmissing-declarations -Wno-unused-parameter)
+ 


### PR DESCRIPTION
`-Werror=format-nonliteral` is incompatible with musl's fortify stdio.h wrappers, which forward format strings through a variable argument, triggering false positives inside system headers.