### PR TITLE
uci: fix build with GCC 15 and musl fortify headers

### DIFF
--- a/package/system/uci/Makefile
+++ b/package/system/uci/Makefile
@@ -9,7 +9,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=uci
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/uci.git
 PKG_SOURCE_PROTO:=git

--- a/package/system/uci/patches/100-fix-build-with-GCC-15.patch
+++ b/package/system/uci/patches/100-fix-build-with-GCC-15.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,7 +8,7 @@ SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS ""
+ ADD_DEFINITIONS(-Wall -Werror)
+ IF(CMAKE_C_COMPILER_VERSION VERSION_GREATER 6)
+ 	ADD_DEFINITIONS(-Wextra -Werror=implicit-function-declaration)
+-	ADD_DEFINITIONS(-Wformat -Werror=format-security -Werror=format-nonliteral)
++	ADD_DEFINITIONS(-Wformat -Werror=format-security)
+ ENDIF()
+ ADD_DEFINITIONS(-Os -std=gnu99 -g3 -Wmissing-declarations -Wno-unused-parameter)
+ ADD_DEFINITIONS(-DUCI_PREFIX="${CMAKE_INSTALL_PREFIX}")


### PR DESCRIPTION
-Werror=format-nonliteral is incompatible with musl's fortify stdio.h wrappers, which forward format strings through a variable argument, triggering false positives inside system headers.