### PR TITLE
ubus: fix build with GCC 15 and musl fortify headers

### DIFF
--- a/package/system/ubus/Makefile
+++ b/package/system/ubus/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ubus
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/ubus.git

--- a/package/system/ubus/patches/100-fix-build-with-GCC-15.patch
+++ b/package/system/ubus/patches/100-fix-build-with-GCC-15.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -4,7 +4,7 @@ PROJECT(ubus C)
+ 
+ ADD_COMPILE_OPTIONS(-Wall -Werror)
+ IF(CMAKE_C_COMPILER_VERSION VERSION_GREATER 6)
+-  ADD_COMPILE_OPTIONS(-Wextra -Wformat -Werror=format-security -Werror=format-nonliteral)
++  ADD_COMPILE_OPTIONS(-Wextra -Wformat -Werror=format-security)
+   ADD_COMPILE_OPTIONS($<$<COMPILE_LANGUAGE:C>:-Werror=implicit-function-declaration>)
+ ENDIF()
+ ADD_COMPILE_OPTIONS(-Os -g3 -Wmissing-declarations -Wno-unused-parameter)


### PR DESCRIPTION
-Werror=format-nonliteral is incompatible with musl's fortify stdio.h wrappers, which forward format strings through a variable argument, triggering false positives inside system headers.