### PR TITLE
realtek: dsa: refactor fast_age()

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/debugfs.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/debugfs.c
@@ -384,7 +384,7 @@ static ssize_t age_out_write(struct file *filp, const char __user *buffer,
 	if (res < 0)
 		return res;
 
-	rtldsa_83xx_fast_age(p->dp->ds, p->dp->index);
+	rtldsa_port_fast_age(p->dp->ds, p->dp->index);
 
 	return res;
 }

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -1936,7 +1936,7 @@ void rtldsa_83xx_fast_age(struct dsa_switch *ds, int port)
 	mutex_unlock(&priv->reg_mutex);
 }
 
-static void rtldsa_931x_fast_age(struct dsa_switch *ds, int port)
+static void rtldsa_931x_fast_age_old(struct dsa_switch *ds, int port)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 	u32 val;
@@ -1956,12 +1956,12 @@ static void rtldsa_931x_fast_age(struct dsa_switch *ds, int port)
 	mutex_unlock(&priv->reg_mutex);
 }
 
-static void rtldsa_930x_fast_age(struct dsa_switch *ds, int port)
+static void rtldsa_930x_fast_age_old(struct dsa_switch *ds, int port)
 {
 	struct rtl838x_switch_priv *priv = ds->priv;
 
 	if (priv->family_id == RTL9310_FAMILY_ID)
-		return rtldsa_931x_fast_age(ds, port);
+		return rtldsa_931x_fast_age_old(ds, port);
 
 	pr_debug("FAST AGE port %d\n", port);
 	mutex_lock(&priv->reg_mutex);
@@ -3076,7 +3076,7 @@ const struct dsa_switch_ops rtldsa_93xx_switch_ops = {
 	.port_bridge_join	= rtldsa_port_bridge_join,
 	.port_bridge_leave	= rtldsa_port_bridge_leave,
 	.port_stp_state_set	= rtldsa_port_stp_state_set,
-	.port_fast_age		= rtldsa_930x_fast_age,
+	.port_fast_age		= rtldsa_930x_fast_age_old,
 	.port_mst_state_set	= rtldsa_port_mst_state_set,
 
 	.port_vlan_filtering	= rtldsa_vlan_filtering,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/dsa.c
@@ -2190,11 +2190,11 @@ static int rtldsa_port_vlan_fast_age(struct dsa_switch *ds, int port, u16 vid)
 	struct rtl838x_switch_priv *priv = ds->priv;
 	int ret;
 
-	if (!priv->r->vlan_port_fast_age)
+	if (!priv->r->fast_age)
 		return -EOPNOTSUPP;
 
 	mutex_lock(&priv->reg_mutex);
-	ret = priv->r->vlan_port_fast_age(priv, port, vid);
+	ret = priv->r->fast_age(priv, port, vid);
 	mutex_unlock(&priv->reg_mutex);
 
 	return ret;

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.c
@@ -1613,6 +1613,20 @@ static void rtl838x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid
 		sw_w32_mask(0xfff << 16, pvid << 16, RTL838X_VLAN_PORT_PB_VLAN + (port << 2));
 }
 
+static int rtldsa_838x_fast_age(struct rtl838x_switch_priv *priv, int port, int vid)
+{
+	u32 val;
+
+	val = BIT(26) | BIT(23) | (port << 5);
+	if (vid >= 0)
+		val |= BIT(24) | (vid << 10);
+
+	sw_w32(val, priv->r->l2_tbl_flush_ctrl);
+	do { } while (sw_r32(priv->r->l2_tbl_flush_ctrl) & BIT(26));
+
+	return 0;
+}
+
 static int rtl838x_set_ageing_time(unsigned long msec)
 {
 	int t = sw_r32(RTL838X_L2_CTRL_1);
@@ -1731,6 +1745,7 @@ const struct rtldsa_config rtldsa_838x_cfg = {
 	.vlan_port_keep_tag_set = rtl838x_vlan_port_keep_tag_set,
 	.vlan_port_pvidmode_set = rtl838x_vlan_port_pvidmode_set,
 	.vlan_port_pvid_set = rtl838x_vlan_port_pvid_set,
+	.fast_age = rtldsa_838x_fast_age,
 	.trk_mbr_ctr = rtl838x_trk_mbr_ctr,
 	.rma_bpdu_fld_pmask = RTL838X_RMA_BPDU_FLD_PMSK,
 	.spcl_trap_eapol_ctrl = RTL838X_SPCL_TRAP_EAPOL_CTRL,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1284,7 +1284,7 @@ struct rtldsa_config {
 	void (*vlan_port_pvidmode_set)(int port, enum pbvlan_type type, enum pbvlan_mode mode);
 	void (*vlan_port_pvid_set)(int port, enum pbvlan_type type, int pvid);
 	void (*vlan_port_keep_tag_set)(int port, bool keep_outer, bool keep_inner);
-	int (*vlan_port_fast_age)(struct rtl838x_switch_priv *priv, int port, u16 vid);
+	int (*fast_age)(struct rtl838x_switch_priv *priv, int port, int vid);
 	void (*set_vlan_igr_filter)(int port, enum igr_filter state);
 	void (*set_vlan_egr_filter)(int port, enum egr_filter state);
 	void (*enable_learning)(int port, bool enable);

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl839x.c
@@ -1554,6 +1554,20 @@ static void rtl839x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid
 		sw_w32_mask(0xfff << 16, pvid << 16, RTL839X_VLAN_PORT_PB_VLAN + (port << 2));
 }
 
+static int rtldsa_839x_fast_age(struct rtl838x_switch_priv *priv, int port, int vid)
+{
+	u32 val;
+
+	val = BIT(28) | BIT(25) | (port << 6);
+	if (vid >= 0)
+		val |= BIT(26) | (vid << 12);
+
+	sw_w32(val, priv->r->l2_tbl_flush_ctrl);
+	do { } while (sw_r32(priv->r->l2_tbl_flush_ctrl) & BIT(28));
+
+	return 0;
+}
+
 static int rtl839x_set_ageing_time(unsigned long msec)
 {
 	int t = sw_r32(RTL839X_L2_CTRL_1);
@@ -1671,6 +1685,7 @@ const struct rtldsa_config rtldsa_839x_cfg = {
 	.write_l2_entry_using_hash = rtl839x_write_l2_entry_using_hash,
 	.read_cam = rtl839x_read_cam,
 	.write_cam = rtl839x_write_cam,
+	.fast_age = rtldsa_839x_fast_age,
 	.trk_mbr_ctr = rtl839x_trk_mbr_ctr,
 	.rma_bpdu_fld_pmask = RTL839X_RMA_BPDU_FLD_PMSK,
 	.spcl_trap_eapol_ctrl = RTL839X_SPCL_TRAP_EAPOL_CTRL,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl83xx.h
@@ -130,7 +130,7 @@ inline void rtl_table_data_w(struct table_reg *r, u32 v, int i);
 void rtldsa_838x_qos_init(struct rtl838x_switch_priv *priv);
 void rtldsa_839x_qos_init(struct rtl838x_switch_priv *priv);
 
-void rtldsa_83xx_fast_age(struct dsa_switch *ds, int port);
+void rtldsa_port_fast_age(struct dsa_switch *ds, int port);
 int rtl83xx_packet_cntr_alloc(struct rtl838x_switch_priv *priv);
 int rtldsa_port_get_stp_state(struct rtl838x_switch_priv *priv, int port);
 int rtl83xx_port_is_under(const struct net_device *dev, struct rtl838x_switch_priv *priv);

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -2338,17 +2338,20 @@ static void rtl930x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid
 		sw_w32_mask(0xfff << 16, pvid << 16, RTL930X_VLAN_PORT_PB_VLAN + (port << 2));
 }
 
-static int rtldsa_930x_vlan_port_fast_age(struct rtl838x_switch_priv *priv, int port, u16 vid)
+static int rtldsa_930x_fast_age(struct rtl838x_switch_priv *priv, int port, int vid)
 {
 	u32 val;
 
 	sw_w32(port << 11, RTL930X_L2_TBL_FLUSH_CTRL + 4);
 
 	val = 0;
-	val |= vid << 12;
 	val |= BIT(26); /* compare port id */
-	val |= BIT(28); /* compare VID */
 	val |= BIT(30); /* status - trigger flush */
+	if (vid >= 0) {
+		val |= BIT(28); /* compare VID */
+		val |= vid << 12;
+	}
+
 	sw_w32(val, RTL930X_L2_TBL_FLUSH_CTRL);
 
 	do { } while (sw_r32(priv->r->l2_tbl_flush_ctrl) & BIT(30));
@@ -2673,7 +2676,7 @@ const struct rtldsa_config rtldsa_930x_cfg = {
 	.vlan_port_keep_tag_set = rtl930x_vlan_port_keep_tag_set,
 	.vlan_port_pvidmode_set = rtl930x_vlan_port_pvidmode_set,
 	.vlan_port_pvid_set = rtl930x_vlan_port_pvid_set,
-	.vlan_port_fast_age = rtldsa_930x_vlan_port_fast_age,
+	.fast_age = rtldsa_930x_fast_age,
 	.trk_mbr_ctr = rtl930x_trk_mbr_ctr,
 	.rma_bpdu_fld_pmask = RTL930X_RMA_BPDU_FLD_PMSK,
 	.init_eee = rtl930x_init_eee,

--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/rtl931x.c
@@ -1478,17 +1478,20 @@ static void rtl931x_vlan_port_pvid_set(int port, enum pbvlan_type type, int pvid
 		sw_w32_mask(0xfff << 14, pvid << 14, RTL931X_VLAN_PORT_IGR_CTRL + (port << 2));
 }
 
-static int rtldsa_931x_vlan_port_fast_age(struct rtl838x_switch_priv *priv, int port, u16 vid)
+static int rtldsa_931x_fast_age(struct rtl838x_switch_priv *priv, int port, int vid)
 {
 	u32 val;
 
-	sw_w32(vid << 20, RTL931X_L2_TBL_FLUSH_CTRL + 4);
+	sw_w32(0, RTL931X_L2_TBL_FLUSH_CTRL + 4);
 
 	val = 0;
 	val |= port << 11;
 	val |= BIT(24); /* compare port id */
-	val |= BIT(26); /* compare VID */
 	val |= BIT(28); /* status - trigger flush */
+	if (vid >= 0) {
+		sw_w32(vid << 20, RTL931X_L2_TBL_FLUSH_CTRL + 4);
+		val |= BIT(26); /* compare VID */
+	}
 	sw_w32(val, RTL931X_L2_TBL_FLUSH_CTRL);
 
 	do { } while (sw_r32(RTL931X_L2_TBL_FLUSH_CTRL) & BIT(28));
@@ -1827,7 +1830,7 @@ const struct rtldsa_config rtldsa_931x_cfg = {
 	.vlan_port_keep_tag_set = rtl931x_vlan_port_keep_tag_set,
 	.vlan_port_pvidmode_set = rtl931x_vlan_port_pvidmode_set,
 	.vlan_port_pvid_set = rtl931x_vlan_port_pvid_set,
-	.vlan_port_fast_age = rtldsa_931x_vlan_port_fast_age,
+	.fast_age = rtldsa_931x_fast_age,
 	.trk_mbr_ctr = rtldsa_931x_trk_mbr_ctr,
 	.rma_bpdu_fld_pmask = RTL931X_RMA_BPDU_FLD_PMSK,
 	.set_vlan_igr_filter = rtl931x_set_igr_filter,


### PR DESCRIPTION
This series refactors the fast_age() functions of the dsa driver.

A lot of functionality already was available. Sadly the targets implemented it differently and some code was duplicated. Align this.