### PR TITLE
ucode: fix build with GCC 15 and musl fortify headers

### DIFF
--- a/package/utils/ucode/Makefile
+++ b/package/utils/ucode/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ucode
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=https://github.com/jow-/ucode.git

--- a/package/utils/ucode/patches/122-ix-build-with-GCC-15.patch
+++ b/package/utils/ucode/patches/122-ix-build-with-GCC-15.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -33,7 +33,6 @@ if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 6)
+     -Wformat
+     -Werror=implicit-function-declaration
+     -Werror=format-security
+-    -Werror=format-nonliteral
+   )
+ endif()
+


### PR DESCRIPTION
-Werror=format-nonliteral is incompatible with musl's fortify stdio.h wrappers, which forward format strings through a variable argument, triggering false positives inside system headers.