### PR TITLE
libunistring: undef bsearch/wmemchr before GCC 15 redecl

### DIFF
--- a/package/libs/libunistring/Makefile
+++ b/package/libs/libunistring/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libunistring
 PKG_VERSION:=1.4.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=@GNU/$(PKG_NAME)

--- a/package/libs/libunistring/patches/101-fix-build-with-GCC-15.patch
+++ b/package/libs/libunistring/patches/101-fix-build-with-GCC-15.patch
@@ -1,0 +1,20 @@
+--- a/lib/stdlib.in.h	2025-09-24 06:01:31.000000000 +0700
++++ b/lib/stdlib.in.h	2026-02-16 21:27:16.663759400 +0700
+@@ -224,6 +224,7 @@
+ 
+ /* Declarations for ISO C N3322.  */
+ #if defined __GNUC__ && __GNUC__ >= 15 && !defined __clang__
++#undef bsearch
+ _GL_EXTERN_C void *bsearch (const void *__key,
+                             const void *__base, size_t __nmemb, size_t __size,
+                             int (*__compare) (const void *, const void *))
+--- a/lib/wchar.in.h	2025-09-24 06:01:32.000000000 +0700
++++ b/lib/wchar.in.h	2026-02-16 21:30:29.648527000 +0700
+@@ -301,6 +301,7 @@
+   _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3)
+   _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+ # ifndef __cplusplus
++#undef wmemchr
+ _GL_EXTERN_C wchar_t *wmemchr (const wchar_t *__s, wchar_t __wc, size_t __n)
+   _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3);
+ # endif


### PR DESCRIPTION
GCC 15 defines bsearch and wmemchr as qualifier-generic macros (ISO C N3322), causing errors when gnulib redeclares them with _GL_EXTERN_C. Add #undef before each declaration to suppress macro expansion.

Fixes #22137