### PR TITLE
realtek: dts: replace ports by ethernet-ports

### DIFF
--- a/target/linux/realtek/dts/rtl8380_d-link_dgs-1210-10mp-f.dts
+++ b/target/linux/realtek/dts/rtl8380_d-link_dgs-1210-10mp-f.dts
@@ -87,7 +87,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
+++ b/target/linux/realtek/dts/rtl8380_engenius_ews2910p.dtsi
@@ -183,7 +183,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8380_hpe_1920-8g.dtsi
+++ b/target/linux/realtek/dts/rtl8380_hpe_1920-8g.dtsi
@@ -69,7 +69,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8380_linksys_lgs310c.dts
+++ b/target/linux/realtek/dts/rtl8380_linksys_lgs310c.dts
@@ -160,7 +160,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8380_netgear_gigabit.dtsi
+++ b/target/linux/realtek/dts/rtl8380_netgear_gigabit.dtsi
@@ -136,7 +136,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8380_netgear_gs110tpp-v1.dts
+++ b/target/linux/realtek/dts/rtl8380_netgear_gs110tpp-v1.dts
@@ -60,7 +60,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT(16, 9, qsgmii)
 		SWITCH_PORT(17, 10, qsgmii)
 	};

--- a/target/linux/realtek/dts/rtl8380_netgear_gs110tup-v1.dts
+++ b/target/linux/realtek/dts/rtl8380_netgear_gs110tup-v1.dts
@@ -50,7 +50,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT_SDS(16, 9, 2, qsgmii)
 
 		port@24 {

--- a/target/linux/realtek/dts/rtl8380_netgear_gs310tp-v1.dts
+++ b/target/linux/realtek/dts/rtl8380_netgear_gs310tp-v1.dts
@@ -50,7 +50,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		/* TODO: fixed link SFP is not right */
 
 		port24: port@24 {

--- a/target/linux/realtek/dts/rtl8380_panasonic_m8eg-pn28080k.dts
+++ b/target/linux/realtek/dts/rtl8380_panasonic_m8eg-pn28080k.dts
@@ -86,7 +86,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8380_tplink_sg2210p-v3.dts
+++ b/target/linux/realtek/dts/rtl8380_tplink_sg2210p-v3.dts
@@ -8,7 +8,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		port24: port@24 {
 			reg = <24>;
 			label = "lan-sfp2";

--- a/target/linux/realtek/dts/rtl8380_tplink_sg2xxx.dtsi
+++ b/target/linux/realtek/dts/rtl8380_tplink_sg2xxx.dtsi
@@ -151,7 +151,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp-a1.dts
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900-10hp-a1.dts
@@ -53,7 +53,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		port@24 {
 			reg = <24>;
 			label = "lan9";

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900.dtsi
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900.dtsi
@@ -98,7 +98,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_allnet_all-sg8208m.dts
+++ b/target/linux/realtek/dts/rtl8382_allnet_all-sg8208m.dts
@@ -108,7 +108,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_apresia_aplgs120gtss.dts
+++ b/target/linux/realtek/dts/rtl8382_apresia_aplgs120gtss.dts
@@ -225,7 +225,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-10p.dts
+++ b/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-10p.dts
@@ -86,7 +86,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-16.dts
+++ b/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-16.dts
@@ -35,7 +35,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-20.dts
+++ b/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-20.dts
@@ -35,7 +35,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-26.dts
+++ b/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-26.dts
@@ -75,7 +75,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-28_common.dtsi
+++ b/target/linux/realtek/dts/rtl8382_d-link_dgs-1210-28_common.dtsi
@@ -36,7 +36,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_hpe_1920-16g.dts
+++ b/target/linux/realtek/dts/rtl8382_hpe_1920-16g.dts
@@ -8,7 +8,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_hpe_1920-24g.dtsi
+++ b/target/linux/realtek/dts/rtl8382_hpe_1920-24g.dtsi
@@ -19,7 +19,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_inaba_aml2-17gp.dts
+++ b/target/linux/realtek/dts/rtl8382_inaba_aml2-17gp.dts
@@ -108,7 +108,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_iodata_bsh-g24mb.dts
+++ b/target/linux/realtek/dts/rtl8382_iodata_bsh-g24mb.dts
@@ -151,7 +151,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_panasonic_m16eg-pn28160k.dts
+++ b/target/linux/realtek/dts/rtl8382_panasonic_m16eg-pn28160k.dts
@@ -127,7 +127,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_panasonic_m24eg-pn28240k.dts
+++ b/target/linux/realtek/dts/rtl8382_panasonic_m24eg-pn28240k.dts
@@ -137,7 +137,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_tplink_t1600g-28ts-v3.dts
+++ b/target/linux/realtek/dts/rtl8382_tplink_t1600g-28ts-v3.dts
@@ -124,7 +124,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-16-a1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-16-a1.dts
@@ -20,7 +20,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT_SDS(16, 9, 2, qsgmii)
 		SWITCH_PORT_SDS(17, 10, 2, qsgmii)
 		SWITCH_PORT_SDS(18, 11, 2, qsgmii)

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24.dtsi
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24.dtsi
@@ -69,7 +69,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT_SDS(0, 1, 0, qsgmii)
 		SWITCH_PORT_SDS(1, 2, 0, qsgmii)
 		SWITCH_PORT_SDS(2, 3, 0, qsgmii)

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24e-a1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24e-a1.dts
@@ -39,7 +39,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT_SDS(1, 1, 0, qsgmii)
 		SWITCH_PORT_SDS(0, 2, 0, qsgmii)
 		SWITCH_PORT_SDS(3, 3, 0, qsgmii)

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24ep-a1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24ep-a1.dts
@@ -33,7 +33,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT_SDS(0, 1, 0, qsgmii)
 		SWITCH_PORT_SDS(1, 2, 0, qsgmii)
 		SWITCH_PORT_SDS(2, 3, 0, qsgmii)

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-a1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-a1.dts
@@ -75,7 +75,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT_SDS(0, 1, 0, qsgmii)
 		SWITCH_PORT_SDS(1, 2, 0, qsgmii)
 		SWITCH_PORT_SDS(2, 3, 0, qsgmii)

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-b1.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24hp-b1.dts
@@ -71,7 +71,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT_SDS(0, 1, 0, qsgmii)
 		SWITCH_PORT_SDS(1, 2, 0, qsgmii)
 		SWITCH_PORT_SDS(2, 3, 0, qsgmii)

--- a/target/linux/realtek/dts/rtl8391_zyxel_gs1920-24hp-v2.dts
+++ b/target/linux/realtek/dts/rtl8391_zyxel_gs1920-24hp-v2.dts
@@ -125,7 +125,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT_SDS(24, 25, 6, qsgmii)
 		SWITCH_PORT_SDS(25, 26, 6, qsgmii)
 		SWITCH_PORT_SDS(26, 27, 6, qsgmii)

--- a/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24hp-v1.dts
+++ b/target/linux/realtek/dts/rtl8392_zyxel_gs1920-24hp-v1.dts
@@ -79,7 +79,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT_SDS(48, 25, 12, qsgmii)
 		SWITCH_PORT_SDS(49, 26, 12, qsgmii)
 		SWITCH_PORT_SDS(50, 27, 12, qsgmii)

--- a/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52.dts
+++ b/target/linux/realtek/dts/rtl8393_d-link_dgs-1210-52.dts
@@ -79,7 +79,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8393_edgecore_ecs4100-12ph.dts
+++ b/target/linux/realtek/dts/rtl8393_edgecore_ecs4100-12ph.dts
@@ -245,7 +245,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8393_hpe_1920-48g-poe.dts
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920-48g-poe.dts
@@ -98,7 +98,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT_SDS(48, 49, 12, qsgmii)
 		SWITCH_PORT_SDS(49, 50, 12, qsgmii)
 		SWITCH_PORT_SDS(50, 51, 12, qsgmii)

--- a/target/linux/realtek/dts/rtl8393_hpe_1920-48g.dts
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920-48g.dts
@@ -89,7 +89,7 @@
 
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		SWITCH_PORT_SDS(48, 50, 12, qsgmii)
 		SWITCH_PORT_SDS(49, 52, 12, qsgmii)
 		SWITCH_PORT_SDS(50, 49, 12, qsgmii)

--- a/target/linux/realtek/dts/rtl8393_hpe_1920.dtsi
+++ b/target/linux/realtek/dts/rtl8393_hpe_1920.dtsi
@@ -81,7 +81,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8393_netgear_gs750e.dts
+++ b/target/linux/realtek/dts/rtl8393_netgear_gs750e.dts
@@ -168,7 +168,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8393_panasonic_m48eg-pn28480k.dts
+++ b/target/linux/realtek/dts/rtl8393_panasonic_m48eg-pn28480k.dts
@@ -300,7 +300,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8393_tplink_sg2452p-v4.dts
+++ b/target/linux/realtek/dts/rtl8393_tplink_sg2452p-v4.dts
@@ -346,7 +346,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48-a1.dts
+++ b/target/linux/realtek/dts/rtl8393_zyxel_gs1900-48-a1.dts
@@ -207,7 +207,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl839x_zyxel_gs1920-24hp-common.dtsi
+++ b/target/linux/realtek/dts/rtl839x_zyxel_gs1920-24hp-common.dtsi
@@ -184,7 +184,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
+++ b/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
@@ -171,7 +171,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9302_plasmacloud_common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_plasmacloud_common.dtsi
@@ -181,7 +181,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9302_plasmacloud_mcx3.dts
+++ b/target/linux/realtek/dts/rtl9302_plasmacloud_mcx3.dts
@@ -164,7 +164,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9302_plasmacloud_psx10.dts
+++ b/target/linux/realtek/dts/rtl9302_plasmacloud_psx10.dts
@@ -36,7 +36,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		port@26 {
 			reg = <26>;
 			label = "lan9";

--- a/target/linux/realtek/dts/rtl9302_xikestor_sks8300-12e2t2x.dts
+++ b/target/linux/realtek/dts/rtl9302_xikestor_sks8300-12e2t2x.dts
@@ -225,7 +225,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
@@ -256,7 +256,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
@@ -143,7 +143,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
@@ -178,7 +178,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8gt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8gt-se.dts
@@ -235,7 +235,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f-v2.dts
+++ b/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f-v2.dts
@@ -233,7 +233,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9303_vimin_vm-s100-0800ms.dts
+++ b/target/linux/realtek/dts/rtl9303_vimin_vm-s100-0800ms.dts
@@ -222,7 +222,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
@@ -184,7 +184,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
@@ -244,7 +244,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
@@ -241,7 +241,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9311_linksys_lgs352c.dts
+++ b/target/linux/realtek/dts/rtl9311_linksys_lgs352c.dts
@@ -302,7 +302,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9312_plasmacloud_common.dtsi
+++ b/target/linux/realtek/dts/rtl9312_plasmacloud_common.dtsi
@@ -386,7 +386,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
+++ b/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
@@ -350,7 +350,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 


### PR DESCRIPTION
In most drivers upstream use "ethernet-ports" instead of "ports" in dts. Especially the upstream rtl9300 mdio driver uses this to lookup the port/phy mapping. Do the same downstream. There is no need to adapt the dsa driver because it scans the dts via for_each_node_by_name(dn, "port").
