### PR TITLE
octeon: add Ubiquiti EdgeRouter 12 support (QCA8511 fabric)

### DIFF
--- a/target/linux/octeon/base-files/etc/board.d/01_network
+++ b/target/linux/octeon/base-files/etc/board.d/01_network
@@ -18,6 +18,10 @@ ubnt,edgerouter-4)
 ubnt,edgerouter-6p)
 	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "lan0"
 	;;
+ubnt,edgerouter-12)
+	# ER-12: config_generate will create br-lan with switch0 as its port.
+	ucidef_set_interface_lan "switch0"
+	;;
 cisco,vedge1000)
 	ucidef_set_interfaces_lan_wan "mgmt0" "lan0"
 	;;

--- a/target/linux/octeon/base-files/etc/init.d/er12-fabric
+++ b/target/linux/octeon/base-files/etc/init.d/er12-fabric
@@ -1,0 +1,300 @@
+#!/bin/sh /etc/rc.common
+
+START=18
+STOP=89
+
+TRUNK_SLAVES="lan4 lan5 lan6 lan7"
+VLAN_BASE_DEFAULT=4086
+SWITCH0_VID=4094
+
+board_id() {
+	jsonfilter -i /etc/board.json -e '@.model.id' 2>/dev/null || true
+}
+
+is_er12() {
+	[ "$(board_id)" = "ubnt,edgerouter-12" ]
+}
+
+has_dev() {
+	ip link show dev "$1" >/dev/null 2>&1
+}
+
+get_base_vid() {
+	# OpenWrt-native deterministic default; avoid vendor-specific ubnt-hal-e dependency.
+	echo "$VLAN_BASE_DEFAULT"
+}
+
+set_octeon_param() {
+	local name="$1"
+	local value="$2"
+	local path="/sys/module/octeon_ethernet/parameters/${name}"
+
+	[ -e "$path" ] || return 0
+	echo "$value" > "$path" 2>/dev/null || true
+}
+
+set_vlan_aware_state() {
+	local enabled="$1"
+	local base_vid="$2"
+
+	[ -n "$base_vid" ] || base_vid="$VLAN_BASE_DEFAULT"
+	set_octeon_param er12_vlan_base_vid "$base_vid"
+	set_octeon_param er12_vlan_switch0_vid "$SWITCH0_VID"
+	set_octeon_param er12_vlan_aware "$enabled"
+}
+
+set_ipv6_default_policy() {
+	local disabled="$1"
+
+	[ -d /proc/sys/net/ipv6/conf ] || return 0
+	[ -e /proc/sys/net/ipv6/conf/default/disable_ipv6 ] || return 0
+
+	if [ "$disabled" = "1" ]; then
+		echo 1 > /proc/sys/net/ipv6/conf/default/disable_ipv6 2>/dev/null || true
+		[ -e /proc/sys/net/ipv6/conf/default/accept_ra ] && \
+			echo 0 > /proc/sys/net/ipv6/conf/default/accept_ra 2>/dev/null || true
+		[ -e /proc/sys/net/ipv6/conf/default/accept_dad ] && \
+			echo 0 > /proc/sys/net/ipv6/conf/default/accept_dad 2>/dev/null || true
+		[ -e /proc/sys/net/ipv6/conf/default/autoconf ] && \
+			echo 0 > /proc/sys/net/ipv6/conf/default/autoconf 2>/dev/null || true
+	else
+		echo 0 > /proc/sys/net/ipv6/conf/default/disable_ipv6 2>/dev/null || true
+		[ -e /proc/sys/net/ipv6/conf/default/accept_ra ] && \
+			echo 1 > /proc/sys/net/ipv6/conf/default/accept_ra 2>/dev/null || true
+		[ -e /proc/sys/net/ipv6/conf/default/accept_dad ] && \
+			echo 1 > /proc/sys/net/ipv6/conf/default/accept_dad 2>/dev/null || true
+		[ -e /proc/sys/net/ipv6/conf/default/autoconf ] && \
+			echo 1 > /proc/sys/net/ipv6/conf/default/autoconf 2>/dev/null || true
+	fi
+}
+
+multicast_guarded_dev() {
+	case "$1" in
+		itf|switch0|lan4|lan5|lan6|lan7)
+			return 0
+			;;
+		esac
+
+	return 1
+}
+
+disable_multicast_dev() {
+	local dev="$1"
+
+	[ -n "$dev" ] || return 0
+	has_dev "$dev" || return 0
+	multicast_guarded_dev "$dev" && return 0
+	ip link set dev "$dev" multicast off >/dev/null 2>&1 || true
+}
+
+enable_multicast_dev() {
+	local dev="$1"
+
+	[ -n "$dev" ] || return 0
+	has_dev "$dev" || return 0
+	ip link set dev "$dev" multicast on >/dev/null 2>&1 || true
+}
+
+disable_ipv6_dev() {
+	local dev="$1"
+
+	[ -n "$dev" ] || return 0
+	[ -d /proc/sys/net/ipv6/conf ] || return 0
+	[ -e "/proc/sys/net/ipv6/conf/${dev}/disable_ipv6" ] || return 0
+
+	echo 1 > "/proc/sys/net/ipv6/conf/${dev}/disable_ipv6" 2>/dev/null || true
+	[ -e "/proc/sys/net/ipv6/conf/${dev}/accept_ra" ] && \
+		echo 0 > "/proc/sys/net/ipv6/conf/${dev}/accept_ra" 2>/dev/null || true
+	[ -e "/proc/sys/net/ipv6/conf/${dev}/accept_dad" ] && \
+		echo 0 > "/proc/sys/net/ipv6/conf/${dev}/accept_dad" 2>/dev/null || true
+	[ -e "/proc/sys/net/ipv6/conf/${dev}/autoconf" ] && \
+		echo 0 > "/proc/sys/net/ipv6/conf/${dev}/autoconf" 2>/dev/null || true
+}
+
+enable_ipv6_dev() {
+	local dev="$1"
+
+	[ -n "$dev" ] || return 0
+	[ -d /proc/sys/net/ipv6/conf ] || return 0
+	[ -e "/proc/sys/net/ipv6/conf/${dev}/disable_ipv6" ] || return 0
+
+	echo 0 > "/proc/sys/net/ipv6/conf/${dev}/disable_ipv6" 2>/dev/null || true
+	[ -e "/proc/sys/net/ipv6/conf/${dev}/accept_ra" ] && \
+		echo 1 > "/proc/sys/net/ipv6/conf/${dev}/accept_ra" 2>/dev/null || true
+	[ -e "/proc/sys/net/ipv6/conf/${dev}/accept_dad" ] && \
+		echo 1 > "/proc/sys/net/ipv6/conf/${dev}/accept_dad" 2>/dev/null || true
+	[ -e "/proc/sys/net/ipv6/conf/${dev}/autoconf" ] && \
+		echo 1 > "/proc/sys/net/ipv6/conf/${dev}/autoconf" 2>/dev/null || true
+}
+
+remove_unwanted_slaves() {
+	local slaves dev wanted keep
+
+	[ -e /sys/class/net/itf/bonding/slaves ] || return 0
+	slaves="$(cat /sys/class/net/itf/bonding/slaves 2>/dev/null || true)"
+
+	for dev in $slaves; do
+		wanted=0
+		for keep in $TRUNK_SLAVES; do
+			[ "$dev" = "$keep" ] && wanted=1 && break
+		done
+		[ "$wanted" -eq 1 ] || echo "-$dev" > /sys/class/net/itf/bonding/slaves 2>/dev/null || true
+	done
+}
+
+add_slave() {
+	local dev="$1"
+	local slaves
+
+	[ -e "/sys/class/net/${dev}" ] || return 0
+	[ -e /sys/class/net/itf/bonding/slaves ] || return 1
+
+	disable_ipv6_dev "$dev"
+	disable_multicast_dev "$dev"
+	ip link set dev "$dev" down >/dev/null 2>&1 || true
+
+	slaves="$(cat /sys/class/net/itf/bonding/slaves 2>/dev/null || true)"
+	echo " $slaves " | grep -q " ${dev} " && return 0
+	echo "+${dev}" > /sys/class/net/itf/bonding/slaves
+}
+
+ensure_itf() {
+	local dev
+
+	modprobe bonding >/dev/null 2>&1 || true
+	modprobe 8021q >/dev/null 2>&1 || true
+
+	if has_dev bond0 && ! has_dev itf; then
+		ip link set dev bond0 down >/dev/null 2>&1 || true
+		ip link set dev bond0 name itf >/dev/null 2>&1 || true
+	fi
+
+	if ! has_dev itf; then
+		ip link add itf type bond mode balance-xor miimon 100 xmit_hash_policy layer2+3 >/dev/null 2>&1 \
+			|| ip link add itf type bond mode balance-xor miimon 100 >/dev/null 2>&1 \
+			|| ip link add itf type bond >/dev/null 2>&1 \
+			|| return 1
+	fi
+
+	disable_ipv6_dev itf
+	disable_multicast_dev itf
+	ip link set dev itf down >/dev/null 2>&1 || true
+
+	remove_unwanted_slaves
+	for dev in $TRUNK_SLAVES; do
+		add_slave "$dev" || true
+	done
+
+	for dev in lan0 lan1 lan2 lan3; do
+		has_dev "$dev" || continue
+		disable_ipv6_dev "$dev"
+		disable_multicast_dev "$dev"
+		ip link set dev "$dev" down >/dev/null 2>&1 || true
+	done
+
+	for dev in $TRUNK_SLAVES; do
+		has_dev "$dev" || continue
+		ip link set dev "$dev" up >/dev/null 2>&1 || true
+	done
+
+	ip link set dev itf up >/dev/null 2>&1 || true
+	return 0
+}
+
+vlan_link_ok() {
+	local name="$1"
+	local vid="$2"
+	local first
+
+	first="$(ip -d link show dev "$name" 2>/dev/null | sed -n 1p)"
+	echo "$first" | grep -q "@itf" || return 1
+	ip -d link show dev "$name" 2>/dev/null | grep -Eq "vlan .* id ${vid}( |$)" || return 1
+
+	return 0
+}
+
+ensure_vlan_dev() {
+	local name="$1"
+	local vid="$2"
+	local first
+
+	if has_dev "$name"; then
+		if vlan_link_ok "$name" "$vid"; then
+			disable_ipv6_dev "$name"
+			disable_multicast_dev "$name"
+			ip link set dev "$name" up >/dev/null 2>&1 || true
+			return 0
+		fi
+
+		first="$(ip -d link show dev "$name" 2>/dev/null | sed -n 1p)"
+		echo "$first" | grep -q "@itf" || {
+			logger -t er12-fabric "refusing to replace non-itf device $name"
+			return 1
+		}
+
+		ip link set dev "$name" down >/dev/null 2>&1 || true
+		ip link del dev "$name" >/dev/null 2>&1 || return 1
+	fi
+
+	ip link add link itf name "$name" type vlan id "$vid" >/dev/null 2>&1 || return 1
+	disable_ipv6_dev "$name"
+	disable_multicast_dev "$name"
+	ip link set dev "$name" up >/dev/null 2>&1 || true
+	return 0
+}
+
+lock_fabric_ipv6() {
+	local dev idx
+
+	disable_ipv6_dev itf
+	disable_multicast_dev itf
+
+	for dev in $TRUNK_SLAVES lan0 lan1 lan2 lan3; do
+		disable_ipv6_dev "$dev"
+		disable_multicast_dev "$dev"
+	done
+
+	idx=0
+	while [ "$idx" -lt 8 ]; do
+		disable_ipv6_dev "eth${idx}"
+		disable_multicast_dev "eth${idx}"
+		idx=$((idx + 1))
+	done
+}
+
+start() {
+	local idx base_vid
+
+	is_er12 || return 0
+	set_ipv6_default_policy 1
+
+	base_vid="$(get_base_vid)"
+	set_vlan_aware_state 1 "$base_vid"
+
+	ensure_itf || {
+		set_ipv6_default_policy 0
+		logger -t er12-fabric "failed to prepare itf bond"
+		return 0
+	}
+
+	idx=0
+	while [ "$idx" -lt 8 ]; do
+		ensure_vlan_dev "eth${idx}" "$((base_vid + idx))" || true
+		idx=$((idx + 1))
+	done
+	ensure_vlan_dev switch0 "$SWITCH0_VID" || true
+
+	lock_fabric_ipv6
+	set_ipv6_default_policy 0
+	lock_fabric_ipv6
+	enable_ipv6_dev switch0
+	enable_multicast_dev switch0
+
+	logger -t er12-fabric "prepared stock-style fabric: itf trunks=${TRUNK_SLAVES}, base_vid=${base_vid}, eth0-eth7, switch0"
+}
+
+stop() {
+	is_er12 || return 0
+	set_ipv6_default_policy 0
+	set_vlan_aware_state 0 "$(get_base_vid)"
+}

--- a/target/linux/octeon/base-files/etc/uci-defaults/99-er12-fabric
+++ b/target/linux/octeon/base-files/etc/uci-defaults/99-er12-fabric
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+board_id() {
+	jsonfilter -i /etc/board.json -e @.model.id 2>/dev/null || true
+}
+
+if [ "$(board_id)" = "ubnt,edgerouter-12" ]; then
+	/etc/init.d/er12-fabric enable
+	/etc/init.d/er12-fabric start || true
+	/usr/sbin/er12-netmode stock --no-reload || true
+	uci commit network
+fi
+
+exit 0

--- a/target/linux/octeon/base-files/lib/preinit/79_move_config
+++ b/target/linux/octeon/base-files/lib/preinit/79_move_config
@@ -34,7 +34,8 @@ octeon_move_config() {
 			;;
 		er|\
 		ubnt,edgerouter-4|\
-		ubnt,edgerouter-6p)
+		ubnt,edgerouter-6p|\
+		ubnt,edgerouter-12)
 			move_config "/dev/mmcblk0p1" "vfat"
 			;;
 		cisco,vedge1000)

--- a/target/linux/octeon/base-files/lib/upgrade/platform.sh
+++ b/target/linux/octeon/base-files/lib/upgrade/platform.sh
@@ -56,7 +56,8 @@ platform_copy_config() {
 		;;
 	er|\
 	ubnt,edgerouter-4|\
-	ubnt,edgerouter-6p)
+	ubnt,edgerouter-6p|\
+	ubnt,edgerouter-12)
 		platform_copy_config_helper /dev/mmcblk0p1 vfat
 		;;
 	cisco,vedge1000)
@@ -129,7 +130,8 @@ platform_do_upgrade() {
 	case "$board" in
 	er | \
 	ubnt,edgerouter-4 | \
-	ubnt,edgerouter-6p)
+	ubnt,edgerouter-6p | \
+	ubnt,edgerouter-12)
 		kernel=/dev/mmcblk0p1
 		;;
 	ubnt,erlite|\
@@ -164,6 +166,7 @@ platform_check_image() {
 	itus,shield-router | \
 	ubnt,edgerouter-4 | \
 	ubnt,edgerouter-6p | \
+	ubnt,edgerouter-12 | \
 	ubnt,erlite | \
 	ubnt,usg | \
 	cisco,vedge1000)

--- a/target/linux/octeon/base-files/usr/sbin/er12-netmode
+++ b/target/linux/octeon/base-files/usr/sbin/er12-netmode
@@ -1,0 +1,142 @@
+#!/bin/sh
+
+set -eu
+
+usage() {
+cat <<'USAGE'
+Usage: er12-netmode stock|safe|all [--no-reload]
+
+Modes:
+  stock - stock-like split: LAN on br-lan (switch0), WAN on lan8, WANB on lan9
+  safe  - same as stock, explicit management-safe baseline
+  all   - bridge all front paths: switch0 + lan8 + lan9 + lan10 + lan11
+USAGE
+}
+
+board_id() {
+	jsonfilter -i /etc/board.json -e '@.model.id' 2>/dev/null || true
+}
+
+ensure_er12() {
+	[ "$(board_id)" = "ubnt,edgerouter-12" ] || {
+		echo "er12-netmode: unsupported board ($(board_id))" >&2
+		exit 1
+	}
+}
+
+ensure_iface() {
+	local ifname="$1"
+	local proto="$2"
+	local dev="$3"
+
+	if ! uci -q get "network.${ifname}" >/dev/null 2>&1; then
+		uci set "network.${ifname}=interface"
+	fi
+
+	uci set "network.${ifname}.proto=${proto}"
+	uci set "network.${ifname}.device=${dev}"
+}
+
+set_bridge_dev() {
+	local name="$1"
+	shift
+
+	uci -q delete "network.${name}" || true
+	uci set "network.${name}=device"
+	uci set "network.${name}.name=${name}"
+	uci set "network.${name}.type=bridge"
+
+	while [ "$#" -gt 0 ]; do
+		uci add_list "network.${name}.ports=$1"
+		shift
+	done
+}
+
+mode_stock_like() {
+	# Stock behavior keeps switch0 as the underlying LAN port via br-lan.
+	uci -q delete network.switch0dev || true
+	uci -q delete network.lan_all || true
+
+	set_bridge_dev br-lan switch0
+	ensure_iface lan static br-lan
+	uci -q delete network.lan.type || true
+	ensure_iface wan dhcp lan8
+	ensure_iface wanb dhcp lan9
+	ensure_iface sfp0 none lan10
+	ensure_iface sfp1 none lan11
+
+	uci -q delete network.wan.auto || true
+	uci -q delete network.wanb.auto || true
+	uci set network.wanb.metric='20'
+	uci set network.sfp0.auto='0'
+	uci set network.sfp1.auto='0'
+
+	# Keep LAN IPv6 enabled in stock mode.
+	uci -q delete network.lan.ipv6 || true
+	uci set network.lan.ip6assign='60'
+	uci -q delete network.lan.delegate || true
+
+	if uci -q get network.br-lan >/dev/null 2>&1; then
+		uci -q delete network.br-lan.ipv6
+	fi
+	if uci -q get network.switch0 >/dev/null 2>&1; then
+		uci -q delete network.switch0.ipv6
+	fi
+
+	if uci -q get dhcp.lan >/dev/null 2>&1; then
+		uci set dhcp.lan.dhcpv6='server'
+		uci set dhcp.lan.ra='server'
+		uci set dhcp.lan.ndp='disabled'
+	fi
+	if uci -q get dhcp.odhcpd >/dev/null 2>&1; then
+		uci -q delete dhcp.odhcpd.disabled || true
+	fi
+}
+
+mode_all() {
+	set_bridge_dev lan_all switch0 lan8 lan9 lan10 lan11
+
+	ensure_iface lan static lan_all
+	ensure_iface wan none lan8
+	ensure_iface wanb none lan9
+	ensure_iface sfp0 none lan10
+	ensure_iface sfp1 none lan11
+
+	uci set network.wan.auto='0'
+	uci set network.wanb.auto='0'
+	uci set network.sfp0.auto='0'
+	uci set network.sfp1.auto='0'
+}
+
+[ "$#" -ge 1 ] || {
+	usage
+	exit 1
+}
+
+mode="$1"
+shift
+
+reload_network=1
+if [ "${1:-}" = "--no-reload" ]; then
+	reload_network=0
+fi
+
+ensure_er12
+
+case "$mode" in
+	stock|safe) mode_stock_like ;;
+	all) mode_all ;;
+	*)
+		usage
+		exit 1
+		;;
+esac
+
+uci commit network
+uci commit dhcp
+
+if [ "$reload_network" -eq 1 ]; then
+	/etc/init.d/network reload || /etc/init.d/network restart
+fi
+
+exit 0

--- a/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-12.dts
+++ b/target/linux/octeon/files/arch/mips/boot/dts/cavium-octeon/cn7130_ubnt_edgerouter-12.dts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "cn7130_ubnt_edgerouter-e300.dtsi"
+
+/ {
+	compatible = "ubnt,edgerouter-12", "cavium,cn7130";
+	model = "Ubiquiti EdgeRouter 12";
+};
+
+&smi0 {
+	phy0: ethernet-phy@0 {
+		device_type = "ethernet-phy";
+		compatible = "atheros,ar8033", "ethernet-phy-ieee802.3-c22";
+		cavium,qlm-trim = "6,sgmii";
+		reg = <0>;
+	};
+
+	phy1: ethernet-phy@1 {
+		device_type = "ethernet-phy";
+		compatible = "atheros,ar8033", "ethernet-phy-ieee802.3-c22";
+		cavium,qlm-trim = "6,sgmii";
+		reg = <1>;
+	};
+
+	phy2: ethernet-phy@2 {
+		device_type = "ethernet-phy";
+		compatible = "atheros,ar8033", "ethernet-phy-ieee802.3-c22";
+		cavium,qlm-trim = "6,sgmii";
+		reg = <2>;
+	};
+
+	phy3: ethernet-phy@3 {
+		device_type = "ethernet-phy";
+		compatible = "atheros,ar8033", "ethernet-phy-ieee802.3-c22";
+		cavium,qlm-trim = "6,sgmii";
+		reg = <3>;
+	};
+
+	phy5: ethernet-phy@5 {
+		sfp = <&sfp>;
+	};
+
+	phy8: ethernet-phy@8 {
+		device_type = "ethernet-phy";
+		interrupts = <17 8>;
+		interrupt-parent = <&gpio>;
+		compatible = "vitesse,vsc8514", "ethernet-phy-ieee802.3-c22";
+		reg = <8>;
+	};
+
+	phy9: ethernet-phy@9 {
+		device_type = "ethernet-phy";
+		interrupts = <17 8>;
+		interrupt-parent = <&gpio>;
+		compatible = "vitesse,vsc8514", "ethernet-phy-ieee802.3-c22";
+		reg = <9>;
+	};
+
+	phy10: ethernet-phy@10 {
+		device_type = "ethernet-phy";
+		interrupts = <17 8>;
+		interrupt-parent = <&gpio>;
+		compatible = "vitesse,vsc8514", "ethernet-phy-ieee802.3-c22";
+		reg = <10>;
+	};
+
+	phy11: ethernet-phy@11 {
+		device_type = "ethernet-phy";
+		interrupts = <17 8>;
+		interrupt-parent = <&gpio>;
+		compatible = "vitesse,vsc8514", "ethernet-phy-ieee802.3-c22";
+		reg = <11>;
+	};
+};
+
+&pip {
+	interface@0 {
+		ethernet@0 {
+			label = "lan10";
+			status = "okay";
+			phy-mode = "sgmii";
+			phy-handle = <&phy4>;
+			nvmem-cells = <&macaddr_eeprom_0 0>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		ethernet@1 {
+			label = "lan11";
+			status = "okay";
+			phy-mode = "sgmii";
+			phy-handle = <&phy5>;
+			nvmem-cells = <&macaddr_eeprom_0 12>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		ethernet@2 {
+			label = "lan8";
+		};
+
+		ethernet@3 {
+			label = "lan9";
+		};
+	};
+
+	interface@1 {
+		status = "okay";
+
+		ethernet@0 {
+			label = "lan4";
+			status = "okay";
+			phy-mode = "sgmii";
+			cavium,force-link-up;
+			nvmem-cells = <&macaddr_eeprom_0 3>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		ethernet@1 {
+			label = "lan5";
+			status = "okay";
+			phy-mode = "sgmii";
+			cavium,force-link-up;
+			nvmem-cells = <&macaddr_eeprom_0 4>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		ethernet@2 {
+			label = "lan6";
+			status = "okay";
+			phy-mode = "sgmii";
+			cavium,force-link-up;
+			nvmem-cells = <&macaddr_eeprom_0 5>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		ethernet@3 {
+			label = "lan7";
+			status = "okay";
+			phy-mode = "sgmii";
+			cavium,force-link-up;
+			nvmem-cells = <&macaddr_eeprom_0 6>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+
+	interface@2 {
+		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "cavium,octeon-3860-pip-interface";
+		reg = <2>;
+
+		ethernet@0 {
+			label = "lan0";
+			status = "okay";
+			compatible = "cavium,octeon-3860-pip-port";
+			reg = <0>;
+			phy-mode = "sgmii";
+			cavium,force-link-up;
+			nvmem-cells = <&macaddr_eeprom_0 7>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		ethernet@1 {
+			label = "lan1";
+			status = "okay";
+			compatible = "cavium,octeon-3860-pip-port";
+			reg = <1>;
+			phy-mode = "sgmii";
+			cavium,force-link-up;
+			nvmem-cells = <&macaddr_eeprom_0 8>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		ethernet@2 {
+			label = "lan2";
+			status = "okay";
+			compatible = "cavium,octeon-3860-pip-port";
+			reg = <2>;
+			phy-mode = "sgmii";
+			cavium,force-link-up;
+			nvmem-cells = <&macaddr_eeprom_0 9>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		ethernet@3 {
+			label = "lan3";
+			status = "okay";
+			compatible = "cavium,octeon-3860-pip-port";
+			reg = <3>;
+			phy-mode = "sgmii";
+			cavium,force-link-up;
+			nvmem-cells = <&macaddr_eeprom_0 10>;
+			nvmem-cell-names = "mac-address";
+			};
+		};
+};

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -75,6 +75,14 @@ define Device/ubnt_edgerouter-6p
 endef
 TARGET_DEVICES += ubnt_edgerouter-6p
 
+define Device/ubnt_edgerouter-12
+  $(Device/ubnt_edgerouter-e300)
+  DEVICE_MODEL := EdgeRouter 12
+  DEVICE_DTS := cn7130_ubnt_edgerouter-12
+  DEVICE_PACKAGES += kmod-bonding kmod-8021q ip-full ip-bridge
+endef
+TARGET_DEVICES += ubnt_edgerouter-12
+
 ERLITE_CMDLINE:=-mtdparts=phys_mapped_flash:512k(boot0)ro,512k(boot1)ro,64k(eeprom)ro root=/dev/sda2 rootfstype=squashfs,ext4 rootwait
 define Device/ubnt_edgerouter-lite
   DEVICE_VENDOR := Ubiquiti

--- a/target/linux/octeon/patches-6.12/703-ubnt-e300-if2-sgmii.patch
+++ b/target/linux/octeon/patches-6.12/703-ubnt-e300-if2-sgmii.patch
@@ -1,0 +1,25 @@
+From: tusker <tusker@wildduck.tusker.net.au>
+Date: Mon, 23 Feb 2026 09:00:00 +0000
+Subject: [PATCH] mips: octeon: map UBNT E300 interface 2 to SGMII
+
+EdgeRouter E300/ER-12 boards wire interface 2 through the QCA8511 switch path. Use SGMII mode for this board instead of NPI so the datapath is initialized correctly.
+
+Signed-off-by: tusker <tusker@wildduck.tusker.net.au>
+--- a/arch/mips/cavium-octeon/executive/cvmx-helper.c
++++ b/arch/mips/cavium-octeon/executive/cvmx-helper.c
+@@ -268,6 +268,15 @@ static cvmx_helper_interface_mode_t __cv
+ 			return CVMX_HELPER_INTERFACE_MODE_SGMII;
+ 		}
+ 	case 2:
++		/*
++		 * EdgeRouter E300/ER-12 uses interface 2 for the front-panel
++		 *
++		 * copper path behind QCA8511. Keep it on the SGMII datapath
++		 * instead of exposing these ports as raw NPI netdevs.
++		 */
++		if (cvmx_sysinfo_get()->board_type == CVMX_BOARD_TYPE_UBNT_E300)
++			return CVMX_HELPER_INTERFACE_MODE_SGMII;
++
+ 		return CVMX_HELPER_INTERFACE_MODE_NPI;
+ 	case 3:
+ 		return CVMX_HELPER_INTERFACE_MODE_LOOP;

--- a/target/linux/octeon/patches-6.12/704-ubnt-e300-qca8511-forcelink.patch
+++ b/target/linux/octeon/patches-6.12/704-ubnt-e300-qca8511-forcelink.patch
@@ -1,0 +1,83 @@
+From: tusker <tusker@wildduck.tusker.net.au>
+Date: Mon, 23 Feb 2026 09:00:00 +0000
+Subject: [PATCH] mips: octeon: add DT force-link override for switch-backed ports
+
+Allow PIP ports without direct PHY binding to be marked with cavium,force-link-up in DT. This is needed for ER-12 switch-backed lanes to come up with the expected fixed 1G full-duplex link state.
+
+Signed-off-by: tusker <tusker@wildduck.tusker.net.au>
+--- a/arch/mips/cavium-octeon/executive/cvmx-helper-board.c
++++ b/arch/mips/cavium-octeon/executive/cvmx-helper-board.c
+@@ -32,6 +32,7 @@
+  */
+ 
+ #include <linux/bug.h>
++#include <linux/of.h>
+ #include <asm/octeon/octeon.h>
+ #include <asm/octeon/cvmx-bootinfo.h>
+ 
+@@ -210,6 +211,54 @@ int cvmx_helper_board_get_mii_address(in
+  * Returns The ports link status. If the link isn't fully resolved, this must
+  *	   return zero.
+  */
++
++/*
++ * Allow DT to force fixed link state on ports without direct PHY binding.
++ *
++ * This keeps board behavior in DT instead of hardcoded board checks.
++ */
++static bool __cvmx_helper_force_link_from_dt(int ipd_port,
++					     union cvmx_helper_link_info *result)
++{
++	struct device_node *pip, *iface, *eth;
++	char ifname[32], ethname[32];
++	int interface, index;
++
++	interface = cvmx_helper_get_interface_num(ipd_port);
++	index = cvmx_helper_get_interface_index_num(ipd_port);
++
++	pip = of_find_node_by_name(NULL, "pip");
++	if (!pip)
++		return false;
++
++	snprintf(ifname, sizeof(ifname), "interface@%d", interface);
++	iface = of_get_child_by_name(pip, ifname);
++	of_node_put(pip);
++	if (!iface)
++		return false;
++
++	snprintf(ethname, sizeof(ethname), "ethernet@%x", index);
++	eth = of_get_child_by_name(iface, ethname);
++	if (!eth) {
++		snprintf(ethname, sizeof(ethname), "ethernet@%d", index);
++		eth = of_get_child_by_name(iface, ethname);
++	}
++	of_node_put(iface);
++	if (!eth)
++		return false;
++
++	if (!of_property_read_bool(eth, "cavium,force-link-up")) {
++		of_node_put(eth);
++		return false;
++	}
++
++	of_node_put(eth);
++	result->s.link_up = 1;
++	result->s.full_duplex = 1;
++	result->s.speed = 1000;
++	return true;
++}
++
+ union cvmx_helper_link_info __cvmx_helper_board_link_get(int ipd_port)
+ {
+ 	union cvmx_helper_link_info result;
+@@ -228,6 +277,10 @@ union cvmx_helper_link_info __cvmx_helpe
+ 		return result;
+ 	}
+ 
++	/* Generic DT-driven fixed-link for board paths behind switch fabric. */
++	if (__cvmx_helper_force_link_from_dt(ipd_port, &result))
++		return result;
++
+ 	if (OCTEON_IS_MODEL(OCTEON_CN3XXX)
+ 		   || OCTEON_IS_MODEL(OCTEON_CN58XX)
+ 		   || OCTEON_IS_MODEL(OCTEON_CN50XX)) {

--- a/target/linux/octeon/patches-6.12/705-ubnt-e300-dt-pcs-reset-on-open.patch
+++ b/target/linux/octeon/patches-6.12/705-ubnt-e300-dt-pcs-reset-on-open.patch
@@ -1,0 +1,87 @@
+--- a/drivers/staging/octeon/ethernet-mdio.c
++++ b/drivers/staging/octeon/ethernet-mdio.c
+@@ -10,9 +10,11 @@
+ #include <linux/phy.h>
+ #include <linux/ratelimit.h>
+ #include <linux/of_mdio.h>
++#include <linux/delay.h>
+ #include <net/dst.h>
+ 
+ #include "octeon-ethernet.h"
++#include <asm/octeon/cvmx-pcsx-defs.h>
+ #include "ethernet-defines.h"
+ #include "ethernet-mdio.h"
+ #include "ethernet-util.h"
+@@ -35,6 +37,62 @@ static int cvm_oct_nway_reset(struct net
+ 	return -EINVAL;
+ }
+ 
++static bool cvm_oct_need_pcs_reset_on_open(struct octeon_ethernet *priv)
++{
++	return priv->of_node &&
++		of_property_read_bool(priv->of_node, "cavium,pcs-reset-on-open");
++}
++
++/*
++ * Some Qualcomm/Atheros SGMII paths only recover after a PCS power cycle.
++ * Keep this DT-driven so board DTS decides which ports require it.
++ */
++static void cvm_oct_set_port_pcs(struct net_device *dev, bool up)
++{
++	struct octeon_ethernet *priv = netdev_priv(dev);
++	int interface = cvmx_helper_get_interface_num(priv->port);
++	int index = cvmx_helper_get_interface_index_num(priv->port);
++	union cvmx_pcsx_mrx_control_reg control_reg;
++	union cvmx_gmxx_prtx_cfg gmx_cfg;
++	union cvmx_pcsx_miscx_ctl_reg pcsx_miscx_ctl_reg;
++
++	control_reg.u64 = cvmx_read_csr(CVMX_PCSX_MRX_CONTROL_REG(index, interface));
++	control_reg.s.an_en = 1;
++	control_reg.s.spdmsb = 1;
++	control_reg.s.spdlsb = 0;
++	control_reg.s.dup = 1;
++	control_reg.s.pwr_dn = up ? 0 : 1;
++	cvmx_write_csr(CVMX_PCSX_MRX_CONTROL_REG(index, interface), control_reg.u64);
++	cvmx_read_csr(CVMX_PCSX_MRX_CONTROL_REG(index, interface));
++
++	if (!up)
++		return;
++
++	gmx_cfg.u64 = cvmx_read_csr(CVMX_GMXX_PRTX_CFG(index, interface));
++	gmx_cfg.s.speed = 1;
++	gmx_cfg.s.speed_msb = 0;
++	gmx_cfg.s.slottime = 1;
++	cvmx_write_csr(CVMX_GMXX_PRTX_CFG(index, interface), gmx_cfg.u64);
++
++	pcsx_miscx_ctl_reg.u64 = cvmx_read_csr(CVMX_PCSX_MISCX_CTL_REG(index, interface));
++	pcsx_miscx_ctl_reg.s.samp_pt = 1;
++	cvmx_write_csr(CVMX_PCSX_MISCX_CTL_REG(index, interface), pcsx_miscx_ctl_reg.u64);
++	cvmx_read_csr(CVMX_PCSX_MISCX_CTL_REG(index, interface));
++}
++
++static void cvm_oct_pcs_recover_path(struct net_device *dev)
++{
++	struct octeon_ethernet *priv = netdev_priv(dev);
++
++	if (!cvm_oct_need_pcs_reset_on_open(priv))
++		return;
++
++	cvm_oct_set_port_pcs(dev, false);
++	msleep(30);
++	cvm_oct_set_port_pcs(dev, true);
++	msleep(20);
++}
++
+ const struct ethtool_ops cvm_oct_ethtool_ops = {
+ 	.get_drvinfo = cvm_oct_get_drvinfo,
+ 	.nway_reset = cvm_oct_nway_reset,
+@@ -140,6 +198,9 @@ int cvm_oct_phy_setup_device(struct net_
+ 	struct device_node *phy_node;
+ 	struct phy_device *phydev = NULL;
+ 
++	/* Run board-selected PCS recovery before probing/starting PHY. */
++	cvm_oct_pcs_recover_path(dev);
++
+ 	if (!priv->of_node)
+ 		goto no_phy;
+ 

--- a/target/linux/octeon/patches-6.12/706-ubnt-e300-pcs-recovery-linkup.patch
+++ b/target/linux/octeon/patches-6.12/706-ubnt-e300-pcs-recovery-linkup.patch
@@ -1,0 +1,100 @@
+--- a/drivers/staging/octeon/ethernet-mdio.c
++++ b/drivers/staging/octeon/ethernet-mdio.c
+@@ -10,6 +10,7 @@
+ #include <linux/phy.h>
+ #include <linux/ratelimit.h>
+ #include <linux/of_mdio.h>
++#include <linux/of.h>
+ #include <linux/delay.h>
+ #include <net/dst.h>
+ 
+@@ -37,10 +38,37 @@ static int cvm_oct_nway_reset(struct net
+ 	return -EINVAL;
+ }
+ 
+-static bool cvm_oct_need_pcs_reset_on_open(struct octeon_ethernet *priv)
++static bool cvm_oct_is_er12_qca_path_port(struct octeon_ethernet *priv)
+ {
+-	return priv->of_node &&
+-		of_property_read_bool(priv->of_node, "cavium,pcs-reset-on-open");
++	int interface = cvmx_helper_get_interface_num(priv->port);
++	int index = cvmx_helper_get_interface_index_num(priv->port);
++
++	return of_machine_is_compatible("ubnt,edgerouter-12") &&
++		(interface == 1) && index < 4;
++}
++
++static bool cvm_oct_need_pcs_recovery(struct octeon_ethernet *priv)
++{
++	if (priv->of_node &&
++	    of_property_read_bool(priv->of_node, "cavium,pcs-reset-on-open"))
++		return true;
++
++	return cvm_oct_is_er12_qca_path_port(priv);
++}
++
++static void cvm_oct_force_link_state(struct octeon_ethernet *priv, bool up)
++{
++	union cvmx_helper_link_info link_info;
++
++	link_info.u64 = priv->link_info;
++	link_info.s.link_up = up ? 1 : 0;
++	if (up) {
++		link_info.s.full_duplex = 1;
++		if (!link_info.s.speed)
++			link_info.s.speed = 1000;
++	}
++
++	cvmx_helper_link_set(priv->port, link_info);
+ }
+ 
+ /*
+@@ -80,16 +108,27 @@ static void cvm_oct_set_port_pcs(struct
+ 	cvmx_read_csr(CVMX_PCSX_MISCX_CTL_REG(index, interface));
+ }
+ 
+-static void cvm_oct_pcs_recover_path(struct net_device *dev)
++static void cvm_oct_pcs_recover_path(struct net_device *dev, const char *reason)
+ {
+ 	struct octeon_ethernet *priv = netdev_priv(dev);
++	int interface = cvmx_helper_get_interface_num(priv->port);
++	int index = cvmx_helper_get_interface_index_num(priv->port);
++	bool from_dt = priv->of_node &&
++		of_property_read_bool(priv->of_node, "cavium,pcs-reset-on-open");
+ 
+-	if (!cvm_oct_need_pcs_reset_on_open(priv))
++	if (!cvm_oct_need_pcs_recovery(priv))
+ 		return;
+ 
++	netdev_info(dev,
++			"PCS recovery (%s, source=%s) on port=%d (iface=%d index=%d)\n",
++			reason, from_dt ? "dt" : "er12-fallback",
++			priv->port, interface, index);
++
++	cvm_oct_force_link_state(priv, false);
+ 	cvm_oct_set_port_pcs(dev, false);
+ 	msleep(30);
+ 	cvm_oct_set_port_pcs(dev, true);
++	cvm_oct_force_link_state(priv, true);
+ 	msleep(20);
+ }
+ 
+@@ -151,6 +190,9 @@ void cvm_oct_adjust_link(struct net_devi
+ 	if (priv->poll)
+ 		priv->poll(dev);
+ 
++	if (!priv->last_link && dev->phydev->link)
++		cvm_oct_pcs_recover_path(dev, "link-up");
++
+ 	if (priv->last_link != dev->phydev->link) {
+ 		priv->last_link = dev->phydev->link;
+ 		cvmx_helper_link_set(priv->port, link_info);
+@@ -199,7 +241,7 @@ int cvm_oct_phy_setup_device(struct net_
+ 	struct phy_device *phydev = NULL;
+ 
+ 	/* Run board-selected PCS recovery before probing/starting PHY. */
+-	cvm_oct_pcs_recover_path(dev);
++	cvm_oct_pcs_recover_path(dev, "phy-setup");
+ 
+ 	if (!priv->of_node)
+ 		goto no_phy;

--- a/target/linux/octeon/patches-6.12/707-ubnt-e300-if2-reset-timeout-recovery.patch
+++ b/target/linux/octeon/patches-6.12/707-ubnt-e300-if2-reset-timeout-recovery.patch
@@ -1,0 +1,43 @@
+--- a/arch/mips/cavium-octeon/executive/cvmx-helper-sgmii.c
++++ b/arch/mips/cavium-octeon/executive/cvmx-helper-sgmii.c
+@@ -136,6 +136,12 @@ static int __cvmx_helper_need_g15618(voi
+ 		return 0;
+ }
+ 
++static int __cvmx_helper_sgmii_er12_qca8511_path(int interface, int index)
++{
++	return cvmx_sysinfo_get()->board_type == CVMX_BOARD_TYPE_UBNT_E300 &&
++		(interface == 1 || interface == 2) && index >= 0 && index < 4;
++}
++
+ /**
+  * Initialize the SERTES link for the first time or after a loss
+  * of link.
+@@ -166,10 +172,24 @@ static int __cvmx_helper_sgmii_hardware_
+ 		if (CVMX_WAIT_FOR_FIELD64
+ 		    (CVMX_PCSX_MRX_CONTROL_REG(index, interface),
+ 		     union cvmx_pcsx_mrx_control_reg, reset, ==, 0, 10000)) {
+-			cvmx_dprintf("SGMII%d: Timeout waiting for port %d "
++			if (__cvmx_helper_sgmii_er12_qca8511_path(interface, index)) {
++				/*
++				 * ER-12 ports 0-3 sit behind QCA8511 and can keep RESET
++				 * asserted after warm boot. Deassert manually and continue
++				 * through PCS power-cycle/link init.
++				 */
++				control_reg.u64 =
++					cvmx_read_csr(CVMX_PCSX_MRX_CONTROL_REG(index, interface));
++				control_reg.s.reset = 0;
++				cvmx_write_csr(CVMX_PCSX_MRX_CONTROL_REG(index, interface),
++					       control_reg.u64);
++				cvmx_read_csr(CVMX_PCSX_MRX_CONTROL_REG(index, interface));
++			} else {
++				cvmx_dprintf("SGMII%d: Timeout waiting for port %d "
+ 				     "to finish reset\n",
+-			     interface, index);
+-			return -1;
++				     interface, index);
++				return -1;
++			}
+ 		}
+ 	}
+ 

--- a/target/linux/octeon/patches-6.12/708-ubnt-e300-honor-force-link-up-in-adjust-link.patch
+++ b/target/linux/octeon/patches-6.12/708-ubnt-e300-honor-force-link-up-in-adjust-link.patch
@@ -1,0 +1,39 @@
+--- a/drivers/staging/octeon/ethernet-mdio.c
++++ b/drivers/staging/octeon/ethernet-mdio.c
+@@ -176,25 +176,30 @@ void cvm_oct_note_carrier(struct octeon_
+ void cvm_oct_adjust_link(struct net_device *dev)
+ {
+ 	struct octeon_ethernet *priv = netdev_priv(dev);
++	bool force_link_up = priv->of_node &&
++		of_property_read_bool(priv->of_node, "cavium,force-link-up");
+ 	union cvmx_helper_link_info link_info;
+ 
+ 	link_info.u64		= 0;
+-	link_info.s.link_up	= dev->phydev->link ? 1 : 0;
+-	link_info.s.full_duplex = dev->phydev->duplex ? 1 : 0;
+-	link_info.s.speed	= dev->phydev->speed;
++	link_info.s.link_up	= (dev->phydev->link || force_link_up) ? 1 : 0;
++	link_info.s.full_duplex = force_link_up ? 1 : (dev->phydev->duplex ? 1 : 0);
++	link_info.s.speed	= force_link_up && dev->phydev->speed <= 0 ? 1000 : dev->phydev->speed;
+ 	priv->link_info		= link_info.u64;
+ 
++	if (force_link_up)
++		netif_carrier_on(dev);
++
+ 	/*
+ 	 * The polling task need to know about link status changes.
+ 	 */
+ 	if (priv->poll)
+ 		priv->poll(dev);
+ 
+-	if (!priv->last_link && dev->phydev->link)
++	if (!priv->last_link && (dev->phydev->link || force_link_up))
+ 		cvm_oct_pcs_recover_path(dev, "link-up");
+ 
+-	if (priv->last_link != dev->phydev->link) {
+-		priv->last_link = dev->phydev->link;
++	if (priv->last_link != link_info.s.link_up) {
++		priv->last_link = link_info.s.link_up;
+ 		cvmx_helper_link_set(priv->port, link_info);
+ 		cvm_oct_note_carrier(priv, link_info);
+ 	}

--- a/target/linux/octeon/patches-6.12/709-ubnt-e300-er12-vlan-switch0-rx-tagging.patch
+++ b/target/linux/octeon/patches-6.12/709-ubnt-e300-er12-vlan-switch0-rx-tagging.patch
@@ -1,0 +1,112 @@
+--- a/drivers/staging/octeon/ethernet-rx.c
++++ b/drivers/staging/octeon/ethernet-rx.c
+@@ -17,6 +17,7 @@
+ #include <linux/ratelimit.h>
+ #include <linux/smp.h>
+ #include <linux/interrupt.h>
++#include <linux/if_vlan.h>
+ #include <net/dst.h>
+ #ifdef CONFIG_XFRM
+ #include <linux/xfrm.h>
+@@ -37,6 +38,21 @@ static struct oct_rx_group {
+ 	struct napi_struct napi;
+ } oct_rx_group[16];
+ 
++/*
++ * Match stock ER-12 behavior: tag rewrite on interface 1 only when
++ * VLAN-aware fabric mode is enabled.
++ */
++static inline bool cvm_oct_er12_vlan_aware_port(int port)
++{
++	if (!of_machine_is_compatible("ubnt,edgerouter-12"))
++		return false;
++
++	if (!cvm_oct_get_vlan_aware_state())
++		return false;
++
++	return cvmx_helper_get_interface_num(port) == 1;
++}
++
+ /**
+  * cvm_oct_do_interrupt - interrupt handler.
+  * @irq: Interrupt number.
+@@ -333,23 +349,56 @@ static int cvm_oct_poll(struct oct_rx_gr
+ 			 * currently up.
+ 			 */
+ 			if (likely(dev->flags & IFF_UP)) {
+-				skb->protocol = eth_type_trans(skb, dev);
+-				skb->dev = dev;
++				bool drop_packet = false;
+ 
+-				if (unlikely(work->word2.s.not_IP ||
+-					     work->word2.s.IP_exc ||
+-					     work->word2.s.L4_error ||
+-					     !work->word2.s.tcp_or_udp))
+-					skb->ip_summed = CHECKSUM_NONE;
+-				else
+-					skb->ip_summed = CHECKSUM_UNNECESSARY;
+-
+-				/* Increment RX stats for virtual ports */
+-				if (port >= CVMX_PIP_NUM_INPUT_PORTS) {
+-					dev->stats.rx_packets++;
+-					dev->stats.rx_bytes += skb->len;
++				if (cvm_oct_er12_vlan_aware_port(port)) {
++					u16 vlan_tci = 0;
++					int vlan_rc;
++
++					vlan_rc = __vlan_get_tag(skb, &vlan_tci);
++					if (vlan_rc) {
++						/*
++						 * Untagged ingress from QCA8511 must be presented
++						 * through switch0 (VID 4094 in stock-style fabric).
++						 */
++						skb = vlan_insert_tag(skb, htons(ETH_P_8021Q),
++								      cvm_oct_get_vlan_switch0_vid());
++					} else {
++						u16 vlan_id = vlan_tci & VLAN_VID_MASK;
++
++						if (vlan_id > 0 &&
++						    vlan_id < cvm_oct_get_vlan_base_vid())
++							skb = vlan_insert_tag(skb, htons(ETH_P_8021Q),
++								      cvm_oct_get_vlan_switch0_vid());
++					}
++
++					if (unlikely(!skb))
++						drop_packet = true;
++				}
++
++				if (!drop_packet) {
++					skb->protocol = eth_type_trans(skb, dev);
++					skb->dev = dev;
++
++					if (unlikely(work->word2.s.not_IP ||
++						     work->word2.s.IP_exc ||
++						     work->word2.s.L4_error ||
++						     !work->word2.s.tcp_or_udp))
++						skb->ip_summed = CHECKSUM_NONE;
++					else
++						skb->ip_summed = CHECKSUM_UNNECESSARY;
++
++					/* Increment RX stats for virtual ports */
++					if (port >= CVMX_PIP_NUM_INPUT_PORTS) {
++						dev->stats.rx_packets++;
++						dev->stats.rx_bytes += skb->len;
++					}
++					netif_receive_skb(skb);
++				} else {
++					dev->stats.rx_dropped++;
++					if (skb)
++						dev_kfree_skb_irq(skb);
+ 				}
+-				netif_receive_skb(skb);
+ 			} else {
+ 				/*
+ 				 * Drop any packet received for a device that
+@@ -358,6 +407,7 @@ static int cvm_oct_poll(struct oct_rx_gr
+ 				dev->stats.rx_dropped++;
+ 				dev_kfree_skb_irq(skb);
+ 			}
++
+ 		} else {
+ 			/*
+ 			 * Drop any packet received for a device that

--- a/target/linux/octeon/patches-6.12/710-ubnt-e300-er12-vlan-switch0-tx-untagging.patch
+++ b/target/linux/octeon/patches-6.12/710-ubnt-e300-er12-vlan-switch0-tx-untagging.patch
@@ -1,0 +1,45 @@
+--- a/drivers/staging/octeon/ethernet-tx.c
++++ b/drivers/staging/octeon/ethernet-tx.c
+@@ -12,6 +12,7 @@
+ #include <linux/ip.h>
+ #include <linux/ratelimit.h>
+ #include <linux/string.h>
++#include <linux/if_vlan.h>
+ #include <linux/interrupt.h>
+ #include <net/dst.h>
+ #ifdef CONFIG_XFRM
+@@ -30,6 +31,18 @@
+ #define CVM_OCT_SKB_CB(skb)	((u64 *)((skb)->cb))
+ 
+ /*
++ * Match stock ER-12 behavior: tag pop on interface 1 only when
++ * VLAN-aware fabric mode is enabled.
++ */
++static inline bool cvm_oct_er12_vlan_aware_egress(struct octeon_ethernet *priv)
++{
++	if (!of_machine_is_compatible("ubnt,edgerouter-12"))
++		return false;
++
++	return cvm_oct_get_vlan_aware_state() && INTERFACE(priv->port) == 1;
++}
++
++/*
+  * You can define GET_SKBUFF_QOS() to override how the skbuff output
+  * function determines which output queue is used. The default
+  * implementation always uses the base queue for the port. If, for
+@@ -148,6 +161,15 @@ netdev_tx_t cvm_oct_xmit(struct sk_buff
+ 	 */
+ 	prefetch(priv);
+ 
++	if (unlikely(cvm_oct_er12_vlan_aware_egress(priv))) {
++		u16 vlan_tci = 0;
++
++		__vlan_get_tag(skb, &vlan_tci);
++		if (vlan_tci == cvm_oct_get_vlan_switch0_vid() &&
++		    skb_vlan_tagged_multi(skb))
++			__skb_vlan_pop(skb, &vlan_tci);
++	}
++
+ 	/*
+ 	 * The check on CVMX_PKO_QUEUES_PER_PORT_* is designed to
+ 	 * completely remove "qos" in the event neither interface

--- a/target/linux/octeon/patches-6.12/711-ubnt-e300-er12-vlan-aware-controls.patch
+++ b/target/linux/octeon/patches-6.12/711-ubnt-e300-er12-vlan-aware-controls.patch
@@ -1,0 +1,63 @@
+--- a/drivers/staging/octeon/ethernet.c
++++ b/drivers/staging/octeon/ethernet.c
+@@ -82,6 +82,46 @@ MODULE_PARM_DESC(pow_send_list, "\n"
+ 	"\t\"eth2,spi3,spi7\" would cause these three devices to transmit\n"
+ 	"\tusing the pow_send_group.");
+ 
++/*
++ * Stock ER-12 datapath enables special VLAN handling only in VLAN-aware
++ * switch-fabric mode.
++ */
++static u32 er12_vlan_aware_enabled;
++static u16 er12_vlan_base_vid = 4086;
++static u16 er12_vlan_switch0_vid = 4094;
++
++int cvm_oct_get_vlan_aware_state(void)
++{
++	return er12_vlan_aware_enabled ? 1 : 0;
++}
++EXPORT_SYMBOL(cvm_oct_get_vlan_aware_state);
++
++int cvm_oct_get_vlan_base_vid(void)
++{
++	return er12_vlan_base_vid;
++}
++EXPORT_SYMBOL(cvm_oct_get_vlan_base_vid);
++
++int cvm_oct_get_vlan_switch0_vid(void)
++{
++	return er12_vlan_switch0_vid;
++}
++EXPORT_SYMBOL(cvm_oct_get_vlan_switch0_vid);
++
++void cvm_oct_set_vlan_aware_cb(u32 status, u16 base_vid, u16 sw0_vid)
++{
++	er12_vlan_aware_enabled = status ? 1 : 0;
++	if (base_vid)
++		er12_vlan_base_vid = base_vid;
++	if (sw0_vid)
++		er12_vlan_switch0_vid = sw0_vid;
++}
++EXPORT_SYMBOL(cvm_oct_set_vlan_aware_cb);
++
++module_param_named(er12_vlan_aware, er12_vlan_aware_enabled, uint, 0644);
++module_param_named(er12_vlan_base_vid, er12_vlan_base_vid, ushort, 0644);
++module_param_named(er12_vlan_switch0_vid, er12_vlan_switch0_vid, ushort, 0644);
++
+ int rx_napi_weight = 32;
+ module_param(rx_napi_weight, int, 0444);
+ MODULE_PARM_DESC(rx_napi_weight, "The NAPI WEIGHT parameter.");
+--- a/drivers/staging/octeon/octeon-ethernet.h
++++ b/drivers/staging/octeon/octeon-ethernet.h
+@@ -94,6 +94,11 @@ void cvm_oct_note_carrier(struct octeon_
+ 			  union cvmx_helper_link_info li);
+ void cvm_oct_link_poll(struct net_device *dev);
+ 
++int cvm_oct_get_vlan_aware_state(void);
++int cvm_oct_get_vlan_base_vid(void);
++int cvm_oct_get_vlan_switch0_vid(void);
++void cvm_oct_set_vlan_aware_cb(u32 status, u16 base_vid, u16 sw0_vid);
++
+ extern int always_use_pow;
+ extern int pow_send_group;
+ extern int pow_receive_groups;

--- a/target/linux/octeon/patches-6.12/712-ubnt-e300-er12-if1-mac-link-get.patch
+++ b/target/linux/octeon/patches-6.12/712-ubnt-e300-er12-if1-mac-link-get.patch
@@ -1,0 +1,25 @@
+--- a/arch/mips/cavium-octeon/executive/cvmx-helper-sgmii.c
++++ b/arch/mips/cavium-octeon/executive/cvmx-helper-sgmii.c
+@@ -139,7 +139,7 @@ static int __cvmx_helper_need_g15618(voi
+ static int __cvmx_helper_sgmii_er12_qca8511_path(int interface, int index)
+ {
+ 	return cvmx_sysinfo_get()->board_type == CVMX_BOARD_TYPE_UBNT_E300 &&
+-		(interface == 1 || interface == 2) && index >= 0 && index < 4;
++		interface == 1 && index >= 0 && index < 4;
+ }
+ 
+ /**
+@@ -468,6 +468,13 @@ union cvmx_helper_link_info __cvmx_helpe
+ 
+ 	result.u64 = 0;
+ 
++	/*
++	 * ER-12 switched fabric is a fixed MAC-side link to QCA8511.
++	 * Use board/DT fixed-link status instead of PHY-mode autoneg.
++	 */
++	if (__cvmx_helper_sgmii_er12_qca8511_path(interface, index))
++		return __cvmx_helper_board_link_get(ipd_port);
++
+ 	if (cvmx_sysinfo_get()->board_type == CVMX_BOARD_TYPE_SIM) {
+ 		/* The simulator gives you a simulated 1Gbps full duplex link */
+ 		result.s.link_up = 1;

--- a/target/linux/octeon/patches-6.12/713-ubnt-e300-er12-if1-hard-forcelink.patch
+++ b/target/linux/octeon/patches-6.12/713-ubnt-e300-er12-if1-hard-forcelink.patch
@@ -1,0 +1,21 @@
+--- a/arch/mips/cavium-octeon/executive/cvmx-helper-board.c
++++ b/arch/mips/cavium-octeon/executive/cvmx-helper-board.c
+@@ -277,6 +277,18 @@ union cvmx_helper_link_info __cvmx_helpe
+ 		return result;
+ 	}
+ 
++	if (cvmx_sysinfo_get()->board_type == CVMX_BOARD_TYPE_UBNT_E300) {
++		int interface = cvmx_helper_get_interface_num(ipd_port);
++		int index = cvmx_helper_get_interface_index_num(ipd_port);
++
++		if (interface == 1 && index >= 0 && index < 4) {
++			result.s.link_up = 1;
++			result.s.full_duplex = 1;
++			result.s.speed = 1000;
++			return result;
++		}
++	}
++
+ 	/* Generic DT-driven fixed-link for board paths behind switch fabric. */
+ 	if (__cvmx_helper_force_link_from_dt(ipd_port, &result))
+ 		return result;

--- a/target/linux/octeon/patches-6.12/714-ubnt-e300-er12-switch0-pop-single-tag.patch
+++ b/target/linux/octeon/patches-6.12/714-ubnt-e300-er12-switch0-pop-single-tag.patch
@@ -1,0 +1,12 @@
+--- a/drivers/staging/octeon/ethernet-tx.c
++++ b/drivers/staging/octeon/ethernet-tx.c
+@@ -165,8 +165,7 @@ netdev_tx_t cvm_oct_xmit(struct sk_buff
+ 		u16 vlan_tci = 0;
+ 
+ 		__vlan_get_tag(skb, &vlan_tci);
+-		if (vlan_tci == cvm_oct_get_vlan_switch0_vid() &&
+-		    skb_vlan_tagged_multi(skb))
++		if (vlan_tci == cvm_oct_get_vlan_switch0_vid())
+ 			__skb_vlan_pop(skb, &vlan_tci);
+ 	}
+ 

--- a/target/linux/octeon/patches-6.12/999_add_npi_for_cn7xxxx.patch
+++ b/target/linux/octeon/patches-6.12/999_add_npi_for_cn7xxxx.patch
@@ -1,0 +1,18 @@
+From: tusker <tusker@wildduck.tusker.net.au>
+Date: Mon, 23 Feb 2026 09:00:00 +0000
+Subject: [PATCH] mips: octeon: allow NPI probe on CN7XXX
+
+Enable NPI port probing on CN7XXX so interface allocation matches ER-12 platform requirements.
+
+Signed-off-by: tusker <tusker@wildduck.tusker.net.au>
+--- a/arch/mips/cavium-octeon/executive/cvmx-helper-npi.c
++++ b/arch/mips/cavium-octeon/executive/cvmx-helper-npi.c
+@@ -49,7 +49,7 @@
+ int __cvmx_helper_npi_probe(int interface)
+ {
+ #if CVMX_PKO_QUEUES_PER_PORT_PCI > 0
+-	if (OCTEON_IS_MODEL(OCTEON_CN38XX) || OCTEON_IS_MODEL(OCTEON_CN58XX))
++	if (OCTEON_IS_MODEL(OCTEON_CN38XX) || OCTEON_IS_MODEL(OCTEON_CN58XX) || OCTEON_IS_MODEL(OCTEON_CN7XXX))
+ 		return 4;
+ 	else if (OCTEON_IS_MODEL(OCTEON_CN56XX)
+ 		 && !OCTEON_IS_MODEL(OCTEON_CN56XX_PASS1_X))


### PR DESCRIPTION
This series adds initial OpenWrt support for **Ubiquiti EdgeRouter 12 (ubnt,edgerouter-12)** on `octeon/generic` and aligns runtime LAN behavior with standard OpenWrt conventions.

## What this changes
- Adds ER-12 device support and board integration.
- Adds octeon kernel patch stack for ER-12/QCA8511 data path behavior.
- Adds ER-12 fabric bring-up script (`er12-fabric`) and netmode helper (`er12-netmode`).
- Uses `br-lan` as LAN interface with `switch0` as underlying bridge port.
- Hardens `er12-netmode` UCI delete operations under `set -e`.
- Removes vendor `ubnt-hal-e` runtime dependency and uses deterministic OpenWrt VLAN base default.
- Refreshes octeon kernel patches for current master (`make target/linux/refresh`).

## Validation
Hardware tested on Ubiquiti EdgeRouter 12.

Validated on flashed image:
- LAN config: `network.lan.device='br-lan'`
- Underlay: `switch0` is up and enslaved to `br-lan`
- WAN/WANB mapping from stock netmode: `lan8` / `lan9`
- IPv6 present on LAN bridge
- Stable management reachability after repeated sysupgrade/reboot cycles

## Build and flash testing
- Built in clean builder context on remote build host/container.
- Flashed with `sysupgrade -n` and validated post-boot state.
- Flash instructions are included directly in the top commit message as requested for this series.
