### PR TITLE
mac80211: ath9k: fix memory leak

### DIFF
--- a/package/kernel/mac80211/patches/ath9k/548-ath9k_enable_gpio_chip.patch
+++ b/package/kernel/mac80211/patches/ath9k/548-ath9k_enable_gpio_chip.patch
@@ -32,7 +32,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  #ifdef CPTCFG_ATH9K_DEBUGFS
 --- a/drivers/net/wireless/ath/ath9k/gpio.c
 +++ b/drivers/net/wireless/ath/ath9k/gpio.c
-@@ -16,12 +16,120 @@
+@@ -16,12 +16,122 @@
  
  #include "ath9k.h"
  
@@ -96,7 +96,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +/* register GPIO chip */
 +static void ath9k_register_gpio_chip(struct ath_softc *sc)
 +{
-+	struct gpio_chip *gc = sc->gpiochip;
++	struct gpio_chip *gc;
 +	struct ath_hw *ah = sc->sc_ah;
 +
 +	gc = kzalloc(sizeof(struct gpio_chip), GFP_KERNEL);
@@ -119,6 +119,8 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 +		kfree(gc);
 +		return;
 +	}
++
++	sc->gpiochip = gc;
 +}
 +
 +/* remove GPIO chip */
@@ -155,7 +157,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  static void ath_fill_led_pin(struct ath_softc *sc)
  {
  	struct ath_hw *ah = sc->sc_ah;
-@@ -79,6 +187,12 @@ static int ath_add_led(struct ath_softc
+@@ -79,6 +189,12 @@ static int ath_add_led(struct ath_softc
  	else
  		ath9k_hw_set_gpio(sc->sc_ah, gpio->gpio, gpio->active_low);
  
@@ -168,7 +170,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	return 0;
  }
  
-@@ -117,16 +231,23 @@ void ath_deinit_leds(struct ath_softc *s
+@@ -117,16 +233,23 @@ void ath_deinit_leds(struct ath_softc *s
  
  	while (!list_empty(&sc->leds)) {
  		led = list_first_entry(&sc->leds, struct ath_led, list);
@@ -192,7 +194,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	char led_name[32];
  	const char *trigger;
  
-@@ -135,6 +256,15 @@ void ath_init_leds(struct ath_softc *sc)
+@@ -135,6 +258,15 @@ void ath_init_leds(struct ath_softc *sc)
  	if (AR_SREV_9100(sc->sc_ah))
  		return;
  


### PR DESCRIPTION
sc->gpiochip is assigned to gc when it should be the other way around. This allows gpiod_free to work properly.

Fixes: e78dc2eae4 ("mac80211: ath9k: clean up gpiochi")

ping @robimarko 