### PR TITLE
qualcommax: ipq807x: add Netgear RBx850 support

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
@@ -42,7 +42,9 @@ qnap,301w)
 dynalink,dl-wrx36|\
 netgear,rax120v2|\
 netgear,rbr750|\
+netgear,rbr850|\
 netgear,rbs750|\
+netgear,rbs850|\
 netgear,sxr80|\
 netgear,sxs80|\
 netgear,wax218|\

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -71,6 +71,7 @@ ALLWIFIBOARDS:= \
 	netgear_rbk40 \
 	netgear_rbk350 \
 	netgear_rbk750 \
+	netgear_rbk850 \
 	netgear_sxk80 \
 	netgear_wax214 \
 	netgear_wax218 \
@@ -263,6 +264,7 @@ $(eval $(call generate-ipq-wifi-package,netgear_rbk20,Netgear RBK20))
 $(eval $(call generate-ipq-wifi-package,netgear_rbk40,Netgear RBK40))
 $(eval $(call generate-ipq-wifi-package,netgear_rbk350,Netgear RBK350))
 $(eval $(call generate-ipq-wifi-package,netgear_rbk750,Netgear RBK750))
+$(eval $(call generate-ipq-wifi-package,netgear_rbk850,Netgear RBK850))
 $(eval $(call generate-ipq-wifi-package,netgear_sxk80,Netgear SXK80))
 $(eval $(call generate-ipq-wifi-package,netgear_wax214,Netgear WAX214))
 $(eval $(call generate-ipq-wifi-package,netgear_wax218,Netgear WAX218))

--- a/target/linux/qualcommax/dts/ipq8074-rbr850.dts
+++ b/target/linux/qualcommax/dts/ipq8074-rbr850.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (c) 2026 Michael Lotz <mmlr@mlotz.ch>
+ */
+
+/dts-v1/;
+
+#include "ipq8074-rbx850.dtsi"
+
+/ {
+	model = "Netgear RBR850";
+	compatible = "netgear,rbr850", "qcom,ipq8074";
+};
+
+&switch {
+	switch_wan_bmp = <ESS_PORT5>;
+	switch_mac_mode1 = <MAC_MODE_SGMII_CHANNEL0>;
+};
+
+&ports {
+	port@5 {
+		port_id = <5>;
+		phy_address = <0x18>;
+		port_mac_sel = "QGMAC_PORT";
+	};
+};
+
+&mdio {
+	phy4: ethernet-phy@18 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0x18>;
+	};
+};
+
+&dp5 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&phy4>;
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_boarddata 1>;
+};

--- a/target/linux/qualcommax/dts/ipq8074-rbs850.dts
+++ b/target/linux/qualcommax/dts/ipq8074-rbs850.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (c) 2026 Michael Lotz <mmlr@mlotz.ch>
+ */
+
+/dts-v1/;
+
+#include "ipq8074-rbx850.dtsi"
+
+/ {
+	model = "Netgear RBS850";
+	compatible = "netgear,rbs850", "qcom,ipq8074";
+};

--- a/target/linux/qualcommax/dts/ipq8074-rbx750.dtsi
+++ b/target/linux/qualcommax/dts/ipq8074-rbx750.dtsi
@@ -5,182 +5,51 @@
 
 /dts-v1/;
 
-#include "ipq8074.dtsi"
-#include "ipq8074-hk-cpu.dtsi"
-#include "ipq8074-ess.dtsi"
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
+#include "ipq8074-rbx750_850.dtsi"
 
 / {
 	aliases {
-		led-boot = &lp5562_white;
-		led-failsafe = &lp5562_red;
-		led-upgrade = &lp5562_blue;
-		serial0 = &blsp1_uart5;
 		label-mac-device = &dp5;
-	};
-
-	chosen {
-		stdout-path = "serial0:115200n8";
-		bootargs-append = " ubi.mtd=rootfs root=/dev/ubiblock0_1";
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-
-		wps {
-			label = "wps";
-			gpios = <&tlmm 34 GPIO_ACTIVE_HIGH>;
-			linux,code = <KEY_WPS_BUTTON>;
-		};
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		power_green {
-			gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_POWER;
-			linux,default-trigger = "default-on";
-		};
-
-		power_red {
-			gpios = <&tlmm 56 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_POWER;
-		};
-	};
-};
-
-&blsp1_uart5 {
-	status = "okay";
-};
-
-&prng {
-	status = "okay";
-};
-
-&cryptobam {
-	status = "okay";
-};
-
-&crypto {
-	status = "okay";
-};
-
-&edma {
-	status = "okay";
-};
-
-&tlmm {
-	mdio_pins: mdio-pins {
-		mdc {
-			pins = "gpio68";
-			function = "mdc";
-			drive-strength = <8>;
-			bias-pull-up;
-		};
-
-		mdio {
-			pins = "gpio69";
-			function = "mdio";
-			drive-strength = <8>;
-			bias-pull-up;
-		};
 	};
 };
 
 &switch {
-	status = "okay";
-
 	switch_lan_bmp = <(ESS_PORT2 | ESS_PORT4 | ESS_PORT5)>;
 	switch_wan_bmp = <ESS_PORT1>;
 	switch_mac_mode = <MAC_MODE_PSGMII>;
+};
 
-	qcom,port_phyinfo {
-		port@1 {
-			port_id = <1>;
-			phy_address = <0>;
-		};
-
-		port@2 {
-			port_id = <2>;
-			phy_address = <1>;
-		};
-
-		port@4 {
-			port_id = <4>;
-			phy_address = <3>;
-		};
-
-		port@5 {
-			port_id = <5>;
-			phy_address = <4>;
-		};
+&ports {
+	port@5 {
+		port_id = <5>;
+		phy_address = <4>;
 	};
 };
 
-&mdio {
-	status = "okay";
-	pinctrl-0 = <&mdio_pins>;
-	pinctrl-names = "default";
-	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
-
-	ethernet-phy-package@0 {
-		#address-cells = <1>;
-		#size-cells = <0>;
-		compatible = "qcom,qca8075-package";
-		reg = <0>;
-
-		phy0: ethernet-phy@0 {
-			compatible = "ethernet-phy-ieee802.3-c22";
-			reg = <0>;
-		};
-
-		phy1: ethernet-phy@1 {
-			compatible = "ethernet-phy-ieee802.3-c22";
-			reg = <1>;
-		};
-
-		phy3: ethernet-phy@3 {
-			compatible = "ethernet-phy-ieee802.3-c22";
-			reg = <3>;
-		};
-
-		phy4: ethernet-phy@4 {
-			compatible = "ethernet-phy-ieee802.3-c22";
-			reg = <4>;
-		};
+&phys {
+	phy4: ethernet-phy@4 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <4>;
 	};
 };
 
 &dp1 {
-	status = "okay";
-	phy-handle = <&phy0>;
 	label = "wan";
 	nvmem-cell-names = "mac-address";
 	nvmem-cells = <&macaddr_boarddata 1>;
 };
 
 &dp2 {
-	status = "okay";
-	phy-handle = <&phy1>;
 	label = "lan3";
 	nvmem-cell-names = "mac-address";
 	nvmem-cells = <&macaddr_boarddata 2>;
 };
 
+&dp3 {
+	status = "disabled";
+};
+
 &dp4 {
-	status = "okay";
-	phy-handle = <&phy3>;
 	label = "lan2";
 	nvmem-cell-names = "mac-address";
 	nvmem-cells = <&macaddr_boarddata 1>;
@@ -194,99 +63,6 @@
 	nvmem-cells = <&macaddr_boarddata 0>;
 };
 
-&qpic_bam {
-	status = "okay";
-};
-
-&qpic_nand {
-	status = "okay";
-
-	nand@0 {
-		reg = <0>;
-		nand-ecc-strength = <4>;
-		nand-ecc-step-size = <512>;
-		nand-bus-width = <8>;
-
-		partitions {
-			compatible = "qcom,smem-part";
-
-			partition-board_data {
-				label = "board_data";
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					macaddr_boarddata: macaddr@40 {
-						compatible = "mac-base";
-						reg = <0x40 0x6>;
-						#nvmem-cell-cells = <1>;
-					};
-				};
-			};
-
-			partition-0-appsblenv {
-				label = "0:appsblenv";
-
-				nvmem-layout {
-					compatible = "u-boot,env";
-					env-size = <0x40000>;
-				};
-			};
-		};
-	};
-};
-
 &wifi {
-	status = "okay";
 	qcom,ath11k-calibration-variant = "Netgear-RBK750";
-};
-
-&blsp1_i2c2 {
-	status = "okay";
-
-	lp5562@31 {
-		compatible = "ti,lp5562";
-		reg = <0x31>;
-		clock-mode = [02];
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		lp5562_red: led@0 {
-			chan-name = "lp5562_red";
-			led-cur = [20];
-			max-cur = [60];
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-			reg = <0>;
-		};
-
-		lp5562_green: led@1 {
-			chan-name = "lp5562_green";
-			led-cur = [20];
-			max-cur = [60];
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-			reg = <1>;
-		};
-
-		lp5562_blue: led@2 {
-			chan-name = "lp5562_blue";
-			led-cur = [20];
-			max-cur = [60];
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_STATUS;
-			reg = <2>;
-		};
-
-		lp5562_white: led@3 {
-			chan-name = "lp5562_white";
-			led-cur = [20];
-			max-cur = [60];
-			color = <LED_COLOR_ID_WHITE>;
-			function = LED_FUNCTION_STATUS;
-			reg = <3>;
-		};
-	};
 };

--- a/target/linux/qualcommax/dts/ipq8074-rbx750_850.dtsi
+++ b/target/linux/qualcommax/dts/ipq8074-rbx750_850.dtsi
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (c) 2026 Michael Lotz <mmlr@mlotz.ch>
+ */
+
+/dts-v1/;
+
+#include "ipq8074.dtsi"
+#include "ipq8074-hk-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &lp5562_white;
+		led-failsafe = &lp5562_red;
+		led-upgrade = &lp5562_blue;
+		serial0 = &blsp1_uart5;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " ubi.mtd=rootfs root=/dev/ubiblock0_1";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 33 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&tlmm 34 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		power_green {
+			gpios = <&tlmm 54 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			linux,default-trigger = "default-on";
+		};
+
+		power_red {
+			gpios = <&tlmm 56 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+		};
+	};
+};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&edma {
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+
+	ports: qcom,port_phyinfo {
+		port@1 {
+			port_id = <1>;
+			phy_address = <0>;
+		};
+
+		port@2 {
+			port_id = <2>;
+			phy_address = <1>;
+		};
+
+		port@3 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	phys: ethernet-phy-package@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "qcom,qca8075-package";
+		reg = <0>;
+
+		phy0: ethernet-phy@0 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <0>;
+		};
+
+		phy1: ethernet-phy@1 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <1>;
+		};
+
+		phy2: ethernet-phy@2 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <2>;
+		};
+
+		phy3: ethernet-phy@3 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <3>;
+		};
+	};
+};
+
+&dp1 {
+	status = "okay";
+	phy-handle = <&phy0>;
+};
+
+&dp2 {
+	status = "okay";
+	phy-handle = <&phy1>;
+};
+
+&dp3 {
+	status = "okay";
+	phy-handle = <&phy2>;
+};
+
+&dp4 {
+	status = "okay";
+	phy-handle = <&phy3>;
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+
+			partition-board_data {
+				label = "board_data";
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_boarddata: macaddr@40 {
+						compatible = "mac-base";
+						reg = <0x40 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition-0-appsblenv {
+				label = "0:appsblenv";
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+					env-size = <0x40000>;
+				};
+			};
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+};
+
+&blsp1_i2c2 {
+	status = "okay";
+
+	lp5562@31 {
+		compatible = "ti,lp5562";
+		reg = <0x31>;
+		clock-mode = [02];
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		lp5562_red: led@0 {
+			chan-name = "lp5562_red";
+			led-cur = [20];
+			max-cur = [60];
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			reg = <0>;
+		};
+
+		lp5562_green: led@1 {
+			chan-name = "lp5562_green";
+			led-cur = [20];
+			max-cur = [60];
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			reg = <1>;
+		};
+
+		lp5562_blue: led@2 {
+			chan-name = "lp5562_blue";
+			led-cur = [20];
+			max-cur = [60];
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			reg = <2>;
+		};
+
+		lp5562_white: led@3 {
+			chan-name = "lp5562_white";
+			led-cur = [20];
+			max-cur = [60];
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			reg = <3>;
+		};
+	};
+};

--- a/target/linux/qualcommax/dts/ipq8074-rbx850.dtsi
+++ b/target/linux/qualcommax/dts/ipq8074-rbx850.dtsi
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (c) 2026 Michael Lotz <mmlr@mlotz.ch>
+ */
+
+/dts-v1/;
+
+#include "ipq8074-rbx750_850.dtsi"
+
+/ {
+	aliases {
+		label-mac-device = &dp1;
+	};
+};
+
+&switch {
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT2 | ESS_PORT3 | ESS_PORT4)>;
+	switch_mac_mode = <MAC_MODE_PSGMII>;
+};
+
+&dp1 {
+	label = "lan1";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_boarddata 0>;
+};
+
+&dp2 {
+	label = "lan2";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_boarddata 1>;
+};
+
+&dp3 {
+	label = "lan3";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_boarddata 2>;
+};
+
+&dp4 {
+	label = "lan4";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_boarddata 3>;
+};
+
+&wifi {
+	qcom,ath11k-calibration-variant = "Netgear-RBK850";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -1,5 +1,5 @@
 DTS_DIR := $(DTS_DIR)/qcom
-DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID TPLINK_SUPPORT_STRING ZYXEL_MODEL_ID
+DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_FLASH_SCRIPT NETGEAR_HW_ID TPLINK_SUPPORT_STRING ZYXEL_MODEL_ID
 
 define Build/asus-fake-ramdisk
 	rm -rf $(KDIR)/tmp/fakerd
@@ -24,13 +24,13 @@ define Build/asus-trx
 	mv $@.new $@
 endef
 
-define Build/netgear-rbx750-qsdk-ipq-factory
-	$(CP) $(FLASH_SCRIPT) $(KDIR_TMP)/
+define Build/netgear-rbx750_850-qsdk-ipq-factory
+	$(CP) $(NETGEAR_FLASH_SCRIPT) $(KDIR_TMP)/
 
 	echo "VERSION : V8.0.0.0_$(LINUX_VERSION)" > $@.metadata
 	echo "MODEL_ID : $(DEVICE_MODEL)" >> $@.metadata
 
-	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh $@.its $(FLASH_SCRIPT) txt $@.metadata ubi $@
+	$(TOPDIR)/scripts/mkits-qsdk-ipq-image.sh $@.its $(NETGEAR_FLASH_SCRIPT) txt $@.metadata ubi $@
 	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
 	@mv $@.new $@
 endef
@@ -294,19 +294,24 @@ endif
 endef
 TARGET_DEVICES += netgear_rax120v2
 
-define Device/netgear_rbx750
+define Device/netgear_rbx750_850
 	$(call Device/FitImage)
 	$(call Device/UbiFit)
 	SOC := ipq8074
 	DEVICE_VENDOR := Netgear
+	DEVICE_PACKAGES := kmod-leds-lp5562
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
-	DEVICE_PACKAGES := ipq-wifi-netgear_rbk750 kmod-leds-lp5562
-	DEVICE_DTS_CONFIG := config@oak03
-	FLASH_SCRIPT := netgear_rbx750.bootscript
+	NETGEAR_FLASH_SCRIPT := netgear_rbx750_850.bootscript
 	IMAGES += factory.chk
-	IMAGE/factory.chk := append-ubi | netgear-rbx750-qsdk-ipq-factory | \
+	IMAGE/factory.chk := append-ubi | netgear-rbx750_850-qsdk-ipq-factory | \
 		netgear-chk
+endef
+
+define Device/netgear_rbx750
+	$(call Device/netgear_rbx750_850)
+	DEVICE_PACKAGES += ipq-wifi-netgear_rbk750
+	DEVICE_DTS_CONFIG := config@oak03
 endef
 
 define Device/netgear_rbr750
@@ -322,6 +327,26 @@ define Device/netgear_rbs750
 	NETGEAR_BOARD_ID := U12H416T00_NETGEAR
 endef
 TARGET_DEVICES += netgear_rbs750
+
+define Device/netgear_rbx850
+	$(call Device/netgear_rbx750_850)
+	DEVICE_PACKAGES += ipq-wifi-netgear_rbk850
+	DEVICE_DTS_CONFIG := config@hk01
+endef
+
+define Device/netgear_rbr850
+	$(call Device/netgear_rbx850)
+	DEVICE_MODEL := RBR850
+	NETGEAR_BOARD_ID := U12H404T00_NETGEAR
+endef
+TARGET_DEVICES += netgear_rbr850
+
+define Device/netgear_rbs850
+	$(call Device/netgear_rbx850)
+	DEVICE_MODEL := RBS850
+	NETGEAR_BOARD_ID := U12H403T00_NETGEAR
+endef
+TARGET_DEVICES += netgear_rbs850
 
 define Device/netgear_sxk80
 	$(call Device/FitImage)

--- a/target/linux/qualcommax/image/netgear_rbx750_850.bootscript
+++ b/target/linux/qualcommax/image/netgear_rbx750_850.bootscript
@@ -2,8 +2,8 @@ imxtract $imgaddr ubi
 nand device 0
 setenv firmware_partition 0
 setenv mtdids nand0=nand0
-setenv mtdparts mtdparts=nand0:0x6d00000@0x11c00000(fs) # RBR750
-mtdparts || setenv mtdparts mtdparts=nand0:0x4280000@0x3e80000(fs) # RBS750
+setenv mtdparts mtdparts=nand0:0x6d00000@0x11c00000(fs) # RBR
+mtdparts || setenv mtdparts mtdparts=nand0:0x4280000@0x3e80000(fs) # RBS
 nand erase.part fs
 nand write $fileaddr fs $filesize
 setenv bootcmd "ubi part fs && ubi read 0x44000000 kernel && bootm"

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -27,6 +27,7 @@ ipq807x_setup_interfaces()
 	dynalink,dl-wrx36|\
 	linksys,mx5300|\
 	linksys,mx8500|\
+	netgear,rbr850|\
 	xiaomi,ax9000|\
 	zbtlink,zbt-z800ax)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
@@ -51,6 +52,9 @@ ipq807x_setup_interfaces()
 		;;
 	netgear,rax120v2)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "wan"
+		;;
+	netgear,rbs850)
+		ucidef_set_interface_lan "lan1 lan2 lan3 lan4" "dhcp"
 		;;
 	netgear,sxr80|\
 	netgear,sxs80)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -68,12 +68,21 @@ case "$FIRMWARE" in
 		ath11k_set_macflag
 		;;
 	netgear,rbr750|\
-	netgear,rbs750)
+	netgear,rbr850)
 		caldata_extract "0:art" 0x1000 0x20000
 		label_mac=$(get_mac_label_dt)
 		ath11k_patch_mac $(macaddr_add $label_mac 3) 0
 		ath11k_patch_mac $(macaddr_add $label_mac 2) 1
 		ath11k_patch_mac $(macaddr_add $label_mac 4) 2
+		ath11k_set_macflag
+		;;
+	netgear,rbs750|\
+	netgear,rbs850)
+		caldata_extract "0:art" 0x1000 0x20000
+		label_mac=$(get_mac_label_dt)
+		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
+		ath11k_patch_mac $(macaddr_add $label_mac 1) 1
+		ath11k_patch_mac $(macaddr_add $label_mac 3) 2
 		ath11k_set_macflag
 		;;
 	netgear,sxr80|\

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -181,7 +181,9 @@ platform_do_upgrade() {
 	edimax,cax1800|\
 	netgear,rax120v2|\
 	netgear,rbr750|\
+	netgear,rbr850|\
 	netgear,rbs750|\
+	netgear,rbs850|\
 	netgear,sxr80|\
 	netgear,sxs80|\
 	netgear,wax218|\


### PR DESCRIPTION
Netgear RBx850 are tri band, 2.4GHz and 2x 5GHz, 12 stream 802.11ax mesh devices from the Orbi series. The RBR850 is a router with a 2.5GbE WAN and 4 1GbE LAN ports. The RBS850 is a satellite without WAN port and half the flash. The hardware is otherwise identical. They were sold in kits as RBK852-RBK855, with one router and 1-4 satellites.

The RBx850 are substantially similar to the RBx750 so this commit factors out a common DTS, flash script and build definition. It also corrects the MAC address offsets of the RBS750 which are the same as the RBS850 but not the RBR750.

Hardware:
* SoC: Qualcomm IPQ8074
* RAM: 1GiB 2x Samsung 4A4G165WE-BCRC
* Flash: 512MiB Winbond W29N04GZ or 256MiB Winbond W29N02GZ
* WLAN 2.4GHz: QCN5024 4x4:4 b/g/n/ax
* WLAN 5GHz Low Band: QCN5054 4x4:4 a/n/ac/ax 5180-5320MHz
* WLAN 5GHz High Band: QCN5054 4x4:4 a/n/ac/ax 5500-5700MHz
* Ethernet: 4x 1GbE LAN, 1x 2.5GbE WAN on RBR850
* Serial Config: 3.3V TTL 115200-8-N-1, internal populated header
* Serial Layout: Bottom <- RX, TX, GND, 3.3V (don't connect) -> Top
* LEDs: green/red power, white/red/green/blue status
* Buttons: 1x Reset, 1x WPS

MAC addresses:
LAN1: Label
LAN2: Label + 1
LAN3: Label + 2
LAN4: Label + 3
WAN: Label + 1
2.4GHz: Label + 2 (RBR) or 1 (RBS)
5GHz-Low: Label + 3 (RBR) or 2 (RBS)
5GHz-High: Label + 4 (RBR) or 3 (RBS)

Flashing Notes:
The stock firmware images are signed. Both the bootloader and the stock web interface check the signature and will fail to boot/flash. The bootloader automatically does NMRP when a gigabit LAN connection is present. The stock and factory images contain a U-Boot script that is executed when flashing using NMRP. This is used to alter and persist the U-Boot env with a boot command that works with unsigned firmware.

Install OpenWrt:
* Get the nmrpflash utility [0] and OpenWrt factory image
* Find network interface to use: nmrpflash -L
* Start nmrpflash: nmrpflash -i interface -f openwrt-...-factory.img
* Connect one of the device LAN ports to the same network using gigabit
* Plug the device in and wait for the bootloader to flash
* Unplug and replug the device once the power LED on the back blinks amber

Revert to Stock:
The boot command needs to be reverted before flashing the stock firmware, otherwise it will fail to boot and get stuck in recovery mode (red power LED flashing).

* Still in OpenWrt run: fw_setenv bootcmd bootipq
* Restart the device
* Flash the stock firmware RBx850-Va.b.c.d.img using nmrpflash

[0]: https://github.com/jclehner/nmrpflash