### PR TITLE
mpc85xx: p2020: switch P2020RDB to DSA

### DIFF
--- a/target/linux/mpc85xx/Makefile
+++ b/target/linux/mpc85xx/Makefile
@@ -19,7 +19,7 @@ include $(INCLUDE_DIR)/target.mk
 
 DEFAULT_PACKAGES += \
 	kmod-input-core kmod-input-gpio-keys kmod-button-hotplug \
-	kmod-leds-gpio swconfig kmod-ath9k wpad-basic-mbedtls kmod-usb2 \
+	kmod-leds-gpio kmod-ath9k wpad-basic-mbedtls kmod-usb2 \
 	uboot-envtools kmod-crypto-hw-talitos
 
 $(eval $(call BuildTarget))

--- a/target/linux/mpc85xx/base-files/etc/board.d/02_network
+++ b/target/linux/mpc85xx/base-files/etc/board.d/02_network
@@ -20,6 +20,9 @@ enterasys,ws-ap3710i)
 	ucidef_set_interface_lan "eth0"
 	ucidef_set_label_macaddr "$(mtd_get_mac_ascii cfg1 ethaddr)"
 	;;
+fsl,P2020RDB)
+	ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1"
+	;;
 hpe,msm460)
 	ucidef_set_interface_lan "eth0"
 	;;	

--- a/target/linux/mpc85xx/base-files/etc/board.d/05_compat-version
+++ b/target/linux/mpc85xx/base-files/etc/board.d/05_compat-version
@@ -5,6 +5,7 @@
 board_config_update
 
 case "$(board_name)" in
+	fsl,P2020RDB |\
 	tplink,tl-wdr4900-v1)
 		ucidef_set_compat_version "1.1"
 		;;

--- a/target/linux/mpc85xx/base-files/lib/preinit/05_set_preinit_iface_mpc85xx
+++ b/target/linux/mpc85xx/base-files/lib/preinit/05_set_preinit_iface_mpc85xx
@@ -5,6 +5,7 @@
 mpc85xx_set_preinit_iface() {
 	case $(board_name) in
 	aerohive,br200-wp|\
+	fsl,P2020RDB|\
 	ocedo,panda|\
 	tplink,tl-wdr4900-v1)
 		ifname=lan1

--- a/target/linux/mpc85xx/image/p2020.mk
+++ b/target/linux/mpc85xx/image/p2020.mk
@@ -1,9 +1,11 @@
 define Device/freescale_p2020rdb
   DEVICE_VENDOR := Freescale
   DEVICE_MODEL := P2020RDB
+  DEVICE_COMPAT_VERSION := 1.1
+  DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
   DEVICE_DTS_DIR := $(DTS_DIR)/fsl
-  DEVICE_PACKAGES := kmod-hwmon-lm90 kmod-rtc-ds1307 \
-	kmod-gpio-pca953x
+  DEVICE_PACKAGES := kmod-dsa-vsc73xx-platform kmod-gpio-pca953x \
+	  kmod-hwmon-lm90 kmod-rtc-ds1307
   BLOCKSIZE := 128k
   KERNEL := kernel-bin | gzip | \
 	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb

--- a/target/linux/mpc85xx/patches-6.12/104-powerpc-mpc85xx-change-P2020RDB-dts-file-for-OpenWRT.patch
+++ b/target/linux/mpc85xx/patches-6.12/104-powerpc-mpc85xx-change-P2020RDB-dts-file-for-OpenWRT.patch
@@ -111,7 +111,58 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  
  			partition@0 {
  				/* This location must not be altered  */
-@@ -140,13 +136,43 @@
+@@ -128,11 +124,48 @@
+ 			};
+ 		};
+ 
+-		L2switch@2,0 {
++		ethernet-switch@2,0 {
+ 			#address-cells = <1>;
+ 			#size-cells = <1>;
+-			compatible = "vitesse-7385";
++			compatible = "vitesse,vsc7385";
+ 			reg = <0x2 0x0 0x20000>;
++			reset-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
++
++			ethernet-ports {
++				#address-cells = <1>;
++				#size-cells = <0>;
++
++				ethernet-port@1 {
++					reg = <1>;
++					label = "lan1";
++				};
++				ethernet-port@2 {
++					reg = <2>;
++					label = "lan2";
++				};
++				ethernet-port@3 {
++					reg = <3>;
++					label = "lan3";
++				};
++				ethernet-port@4 {
++					reg = <4>;
++					label = "lan4";
++				};
++				ethernet-port@6 {
++					reg = <6>;
++					label = "cpu";
++					ethernet = <&enet0>;
++					phy-mode = "rgmii";
++					rx-internal-delay-ps = <1400>;
++					tx-internal-delay-ps = <2000>;
++
++					fixed-link {
++						speed = <1000>;
++						full-duplex;
++						pause;
++					};
++				};
++			};
+ 		};
+ 
+ 	};
+@@ -140,13 +173,43 @@
  	soc: soc@ffe00000 {
  		ranges = <0x0 0x0 0xffe00000 0x100000>;
  
@@ -155,7 +206,7 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  		spi@7000 {
  			flash@0 {
  				#address-cells = <1>;
-@@ -200,10 +226,12 @@
+@@ -200,10 +263,12 @@
  			phy0: ethernet-phy@0 {
  				interrupts = <3 1 0 0>;
  				reg = <0x0>;
@@ -168,3 +219,18 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  			};
  			tbi-phy@2 {
  				device_type = "tbi-phy";
+@@ -232,8 +297,13 @@
+ 		};
+ 
+ 		enet0: ethernet@24000 {
+-			fixed-link = <1 1 1000 0 0>;
+ 			phy-connection-type = "rgmii-id";
++
++			fixed-link {
++				speed = <1000>;
++				full-duplex;
++				pause;
++			};
+ 		};
+ 
+ 		enet1: ethernet@25000 {


### PR DESCRIPTION
Convert the P2020RDB DTS to DSA for the VSC7385 switch, add port labels and fixed-link. Update board network defaults, preinit iface, and compat version, and include the DSA switch kmod in the image.
