### PR TITLE
ramips: dts: convert to dt-bindings clock index

### DIFF
--- a/target/linux/ramips/dts/mt7620a.dtsi
+++ b/target/linux/ramips/dts/mt7620a.dtsi
@@ -1,5 +1,7 @@
 /dts-v1/;
 
+#include <dt-bindings/clock/mediatek,mtmips-sysc.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -67,7 +69,7 @@
 			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
-			clocks = <&sysc 7>;
+			clocks = <&sysc MT7620_CLK_TIMER>;
 
 			interrupt-parent = <&intc>;
 			interrupts = <1>;
@@ -77,7 +79,7 @@
 			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
-			clocks = <&sysc 8>;
+			clocks = <&sysc MT7620_CLK_WATCHDOG>;
 
 			resets = <&sysc 8>;
 			reset-names = "wdt";
@@ -109,7 +111,7 @@
 			compatible = "ralink,mt7620a-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0x500 0x100>;
 
-			clocks = <&sysc 9>;
+			clocks = <&sysc MT7620_CLK_UART>;
 
 			resets = <&sysc 12>;
 
@@ -203,7 +205,7 @@
 			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 10>;
+			clocks = <&sysc MT7620_CLK_I2C>;
 
 			resets = <&sysc 16>;
 			reset-names = "i2c";
@@ -221,7 +223,7 @@
 			compatible = "mediatek,mt7620-i2s";
 			reg = <0xa00 0x100>;
 
-			clocks = <&sysc 11>;
+			clocks = <&sysc MT7620_CLK_I2S>;
 
 			resets = <&sysc 17>;
 			reset-names = "i2s";
@@ -243,7 +245,7 @@
 			compatible = "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
 
-			clocks = <&sysc 12>;
+			clocks = <&sysc MT7620_CLK_SPI1>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -261,7 +263,7 @@
 			compatible = "ralink,rt2880-spi";
 			reg = <0xb40 0x60>;
 
-			clocks = <&sysc 13>;
+			clocks = <&sysc MT7620_CLK_SPI2>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -279,7 +281,7 @@
 			compatible = "ralink,mt7620a-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
-			clocks = <&sysc 14>;
+			clocks = <&sysc MT7620_CLK_UARTLITE>;
 
 			resets = <&sysc 19>;
 
@@ -528,7 +530,7 @@
 		disable-wp;
 		no-1-8-v;
 
-		clocks = <&sysc 15>, <&sysc 15>;
+		clocks = <&sysc MT7620_CLK_MMC>, <&sysc MT7620_CLK_MMC>;
 		clock-names = "source", "hclk";
 
 		interrupt-parent = <&intc>;
@@ -630,7 +632,7 @@
 		compatible = "ralink,rt7620-wifi", "ralink,rt2880-wifi";
 		reg = <0x10180000 0x40000>;
 
-		clocks = <&sysc 16>;
+		clocks = <&sysc MT7620_CLK_WMAC>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/dts/mt7620n.dtsi
+++ b/target/linux/ramips/dts/mt7620n.dtsi
@@ -1,5 +1,7 @@
 /dts-v1/;
 
+#include <dt-bindings/clock/mediatek,mtmips-sysc.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -51,7 +53,7 @@
 			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
-			clocks = <&sysc 7>;
+			clocks = <&sysc MT7620_CLK_TIMER>;
 
 			interrupt-parent = <&intc>;
 			interrupts = <1>;
@@ -61,7 +63,7 @@
 			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
-			clocks = <&sysc 8>;
+			clocks = <&sysc MT7620_CLK_WATCHDOG>;
 
 			resets = <&sysc 8>;
 			reset-names = "wdt";
@@ -171,7 +173,7 @@
 			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 10>;
+			clocks = <&sysc MT7620_CLK_I2C>;
 
 			resets = <&sysc 16>;
 			reset-names = "i2c";
@@ -189,7 +191,7 @@
 			compatible = "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
 
-			clocks = <&sysc 12>;
+			clocks = <&sysc MT7620_CLK_SPI1>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -207,7 +209,7 @@
 			compatible = "ralink,rt2880-spi";
 			reg = <0xb40 0x60>;
 
-			clocks = <&sysc 13>;
+			clocks = <&sysc MT7620_CLK_SPI2>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -225,7 +227,7 @@
 			compatible = "ralink,mt7620a-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
-			clocks = <&sysc 14>;
+			clocks = <&sysc MT7620_CLK_UARTLITE>;
 
 			resets = <&sysc 19>;
 
@@ -372,7 +374,7 @@
 		compatible = "ralink,rt7620-wifi", "ralink,rt2880-wifi";
 		reg = <0x10180000 0x40000>;
 
-		clocks = <&sysc 16>;
+		clocks = <&sysc MT7620_CLK_WMAC>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/dts/mt7628an.dtsi
+++ b/target/linux/ramips/dts/mt7628an.dtsi
@@ -1,5 +1,7 @@
 /dts-v1/;
 
+#include <dt-bindings/clock/mediatek,mtmips-sysc.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -108,7 +110,7 @@
 			compatible = "mediatek,mt7621-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 9>;
+			clocks = <&sysc MT76X8_CLK_I2C>;
 			clock-names = "i2c";
 
 			resets = <&sysc 16>;
@@ -127,7 +129,7 @@
 			compatible = "mediatek,mt7628-i2s";
 			reg = <0xa00 0x100>;
 
-			clocks = <&sysc 10>;
+			clocks = <&sysc MT76X8_CLK_I2S>;
 
 			resets = <&sysc 17>;
 			reset-names = "i2s";
@@ -149,7 +151,7 @@
 			compatible = "ralink,mt7621-spi";
 			reg = <0xb00 0x100>;
 
-			clocks = <&sysc 11>;
+			clocks = <&sysc MT76X8_CLK_SPI1>;
 			clock-names = "spi";
 
 			resets = <&sysc 18>;
@@ -172,7 +174,7 @@
 			reg-io-width = <4>;
 			no-loopback-test;
 
-			clocks = <&sysc 13>;
+			clocks = <&sysc MT76X8_CLK_UART0>;
 
 			resets = <&sysc 12>;
 
@@ -191,7 +193,7 @@
 			reg-io-width = <4>;
 			no-loopback-test;
 
-			clocks = <&sysc 14>;
+			clocks = <&sysc MT76X8_CLK_UART1>;
 
 			resets = <&sysc 19>;
 
@@ -212,7 +214,7 @@
 			reg-io-width = <4>;
 			no-loopback-test;
 
-			clocks = <&sysc 15>;
+			clocks = <&sysc MT76X8_CLK_UART2>;
 
 			resets = <&sysc 20>;
 
@@ -389,7 +391,7 @@
 		disable-wp;
 		no-1-8-v;
 
-		clocks = <&sysc 16>, <&sysc 16>;
+		clocks = <&sysc MT76X8_CLK_MMC>, <&sysc MT76X8_CLK_MMC>;
 		clock-names = "source", "hclk";
 
 		interrupt-parent = <&intc>;
@@ -511,7 +513,7 @@
 		compatible = "mediatek,mt7628-wmac";
 		reg = <0x10300000 0x100000>;
 
-		clocks = <&sysc 17>;
+		clocks = <&sysc MT76X8_CLK_WMAC>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/dts/rt2880.dtsi
+++ b/target/linux/ramips/dts/rt2880.dtsi
@@ -1,5 +1,7 @@
 /dts-v1/;
 
+#include <dt-bindings/clock/mediatek,mtmips-sysc.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -49,7 +51,7 @@
 			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
-			clocks = <&sysc 3>;
+			clocks = <&sysc RT2880_CLK_TIMER>;
 
 			interrupt-parent = <&intc>;
 			interrupts = <1>;
@@ -61,7 +63,7 @@
 			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
-			clocks = <&sysc 4>;
+			clocks = <&sysc RT2880_CLK_WATCHDOG>;
 		};
 
 		intc: intc@200 {
@@ -142,7 +144,7 @@
 			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 6>;
+			clocks = <&sysc RT2880_CLK_I2C>;
 
 			resets = <&sysc 9>;
 			reset-names = "i2c";
@@ -160,7 +162,7 @@
 			compatible = "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
-			clocks = <&sysc 7>;
+			clocks = <&sysc RT2880_CLK_UARTLITE>;
 
 			interrupt-parent = <&intc>;
 			interrupts = <8>;
@@ -219,7 +221,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		clocks = <&sysc 8>;
+		clocks = <&sysc RT2880_CLK_ETHERNET>;
 
 		resets = <&sysc 18>;
 		reset-names = "fe";
@@ -246,7 +248,7 @@
 		compatible = "ralink,rt2880-wifi";
 		reg = <0x480000 0x40000>;
 
-		clocks = <&sysc 9>;
+		clocks = <&sysc RT2880_CLK_WMAC>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/dts/rt3050.dtsi
+++ b/target/linux/ramips/dts/rt3050.dtsi
@@ -1,5 +1,7 @@
 /dts-v1/;
 
+#include <dt-bindings/clock/mediatek,mtmips-sysc.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -50,7 +52,7 @@
 			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
-			clocks = <&sysc 3>;
+			clocks = <&sysc RT305X_CLK_TIMER>;
 
 			interrupt-parent = <&intc>;
 			interrupts = <1>;
@@ -60,7 +62,7 @@
 			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
-			clocks = <&sysc 4>;
+			clocks = <&sysc RT305X_CLK_WATCHDOG>;
 
 			resets = <&sysc 8>;
 			reset-names = "wdt";
@@ -92,7 +94,7 @@
 			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0x500 0x100>;
 
-			clocks = <&sysc 5>;
+			clocks = <&sysc RT305X_CLK_UART>;
 
 			resets = <&sysc 12>;
 
@@ -183,7 +185,7 @@
 			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 6>;
+			clocks = <&sysc RT305X_CLK_I2C>;
 
 			resets = <&sysc 16>;
 			reset-names = "i2c";
@@ -201,7 +203,7 @@
 			compatible = "ralink,rt3050-i2s";
 			reg = <0xa00 0x100>;
 
-			clocks = <&sysc 7>;
+			clocks = <&sysc RT305X_CLK_I2S>;
 
 			resets = <&sysc 17>;
 			reset-names = "i2s";
@@ -224,7 +226,7 @@
 			resets = <&sysc 18>;
 			reset-names = "spi";
 
-			clocks = <&sysc 8>;
+			clocks = <&sysc RT305X_CLK_SPI1>;
 
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -239,7 +241,7 @@
 			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
-			clocks = <&sysc 10>;
+			clocks = <&sysc RT305X_CLK_UARTLITE>;
 
 			resets = <&sysc 19>;
 
@@ -308,7 +310,7 @@
 		compatible = "ralink,rt3050-eth";
 		reg = <0x10100000 0x10000>;
 
-		clocks = <&sysc 11>;
+		clocks = <&sysc RT305X_CLK_ETHERNET>;
 
 		resets = <&sysc 21>, <&sysc 23>;
 		reset-names = "fe", "esw";
@@ -334,7 +336,7 @@
 		compatible = "ralink,rt3050-wifi", "ralink,rt2880-wifi";
 		reg = <0x10180000 0x40000>;
 
-		clocks = <&sysc 12>;
+		clocks = <&sysc RT305X_CLK_WMAC>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/dts/rt3352.dtsi
+++ b/target/linux/ramips/dts/rt3352.dtsi
@@ -1,5 +1,7 @@
 /dts-v1/;
 
+#include <dt-bindings/clock/mediatek,mtmips-sysc.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -51,7 +53,7 @@
 			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
-			clocks = <&sysc 4>;
+			clocks = <&sysc RT3352_CLK_TIMER>;
 
 			interrupt-parent = <&intc>;
 			interrupts = <1>;
@@ -61,7 +63,7 @@
 			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
-			clocks = <&sysc 5>;
+			clocks = <&sysc RT3352_CLK_WATCHDOG>;
 
 			resets = <&sysc 8>;
 			reset-names = "wdt";
@@ -93,7 +95,7 @@
 			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0x500 0x100>;
 
-			clocks = <&sysc 6>;
+			clocks = <&sysc RT3352_CLK_UART>;
 
 			resets = <&sysc 12>;
 
@@ -167,7 +169,7 @@
 			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 7>;
+			clocks = <&sysc RT3352_CLK_I2C>;
 
 			resets = <&sysc 16>;
 			reset-names = "i2c";
@@ -185,7 +187,7 @@
 			compatible = "ralink,rt3352-i2s";
 			reg = <0xa00 0x100>;
 
-			clocks = <&sysc 8>;
+			clocks = <&sysc RT3352_CLK_I2S>;
 
 			resets = <&sysc 17>;
 			reset-names = "i2s";
@@ -209,7 +211,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			clocks = <&sysc 9>;
+			clocks = <&sysc RT3352_CLK_SPI1>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -239,7 +241,7 @@
 			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
-			clocks = <&sysc 11>;
+			clocks = <&sysc RT3352_CLK_UARTLITE>;
 
 			resets = <&sysc 19>;
 
@@ -326,7 +328,7 @@
 		compatible = "ralink,rt3050-eth";
 		reg = <0x10100000 0x10000>;
 
-		clocks = <&sysc 12>;
+		clocks = <&sysc RT3352_CLK_ETHERNET>;
 
 		resets = <&sysc 21>, <&sysc 23>;
 		reset-names = "fe", "esw";
@@ -361,7 +363,7 @@
 		compatible = "ralink,rt3352-wifi", "ralink,rt2880-wifi";
 		reg = <0x10180000 0x40000>;
 
-		clocks = <&sysc 13>;
+		clocks = <&sysc RT3352_CLK_WMAC>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/dts/rt3883.dtsi
+++ b/target/linux/ramips/dts/rt3883.dtsi
@@ -1,5 +1,7 @@
 /dts-v1/;
 
+#include <dt-bindings/clock/mediatek,mtmips-sysc.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -51,7 +53,7 @@
 			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
-			clocks = <&sysc 4>;
+			clocks = <&sysc RT3883_CLK_TIMER>;
 
 			interrupt-parent = <&intc>;
 			interrupts = <1>;
@@ -61,7 +63,7 @@
 			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
-			clocks = <&sysc 5>;
+			clocks = <&sysc RT3883_CLK_WATCHDOG>;
 
 			resets = <&sysc 8>;
 			reset-names = "wdt";
@@ -93,7 +95,7 @@
 			compatible = "ralink,rt3883-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0x500 0x100>;
 
-			clocks = <&sysc 6>;
+			clocks = <&sysc RT3883_CLK_UART>;
 
 			resets = <&sysc 12>;
 
@@ -187,7 +189,7 @@
 			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 7>;
+			clocks = <&sysc RT3883_CLK_I2C>;
 
 			resets = <&sysc 16>;
 			reset-names = "i2c";
@@ -205,7 +207,7 @@
 			compatible = "ralink,rt3883-i2s";
 			reg = <0xa00 0x100>;
 
-			clocks = <&sysc 8>;
+			clocks = <&sysc RT3883_CLK_I2S>;
 
 			resets = <&sysc 17>;
 			reset-names = "i2s";
@@ -229,7 +231,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			clocks = <&sysc 9>;
+			clocks = <&sysc RT3883_CLK_SPI1>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -246,7 +248,7 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			clocks = <&sysc 10>;
+			clocks = <&sysc RT3883_CLK_SPI2>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -261,7 +263,7 @@
 			compatible = "ralink,rt3883-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
-			clocks = <&sysc 11>;
+			clocks = <&sysc RT3883_CLK_UARTLITE>;
 
 			resets = <&sysc 19>;
 
@@ -343,7 +345,7 @@
 		#size-cells = <0>;
 		reg = <0x10100000 0x10000>;
 
-		clocks = <&sysc 12>;
+		clocks = <&sysc RT3883_CLK_ETHERNET>;
 
 		resets = <&sysc 21>;
 		reset-names = "fe";
@@ -463,7 +465,7 @@
 		compatible = "ralink,rt3883-wifi", "ralink,rt2880-wifi";
 		reg = <0x10180000 0x40000>;
 
-		clocks = <&sysc 13>;
+		clocks = <&sysc RT3883_CLK_WMAC>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/dts/rt5350.dtsi
+++ b/target/linux/ramips/dts/rt5350.dtsi
@@ -1,5 +1,7 @@
 /dts-v1/;
 
+#include <dt-bindings/clock/mediatek,mtmips-sysc.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
@@ -51,7 +53,7 @@
 			compatible = "ralink,rt2880-timer";
 			reg = <0x100 0x20>;
 
-			clocks = <&sysc 4>;
+			clocks = <&sysc RT5350_CLK_TIMER>;
 
 			interrupt-parent = <&intc>;
 			interrupts = <1>;
@@ -61,7 +63,7 @@
 			compatible = "ralink,rt2880-wdt";
 			reg = <0x120 0x10>;
 
-			clocks = <&sysc 5>;
+			clocks = <&sysc RT5350_CLK_WATCHDOG>;
 
 			resets = <&sysc 8>;
 			reset-names = "wdt";
@@ -93,7 +95,7 @@
 			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0x500 0x100>;
 
-			clocks = <&sysc 6>;
+			clocks = <&sysc RT5350_CLK_UART>;
 
 			resets = <&sysc 12>;
 
@@ -147,7 +149,7 @@
 			compatible = "ralink,rt2880-i2c";
 			reg = <0x900 0x100>;
 
-			clocks = <&sysc 7>;
+			clocks = <&sysc RT5350_CLK_I2C>;
 
 			resets = <&sysc 16>;
 			reset-names = "i2c";
@@ -165,7 +167,7 @@
 			compatible = "ralink,rt3352-i2s";
 			reg = <0xa00 0x100>;
 
-			clocks = <&sysc 8>;
+			clocks = <&sysc RT5350_CLK_I2S>;
 
 			resets = <&sysc 17>;
 			reset-names = "i2s";
@@ -187,7 +189,7 @@
 			compatible = "ralink,rt2880-spi";
 			reg = <0xb00 0x40>;
 
-			clocks = <&sysc 9>;
+			clocks = <&sysc RT5350_CLK_SPI1>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -205,7 +207,7 @@
 			compatible = "ralink,rt2880-spi";
 			reg = <0xb40 0x60>;
 
-			clocks = <&sysc 10>;
+			clocks = <&sysc RT5350_CLK_SPI2>;
 
 			resets = <&sysc 18>;
 			reset-names = "spi";
@@ -223,7 +225,7 @@
 			compatible = "ralink,rt3052-uart", "ralink,rt2880-uart", "ns16550a";
 			reg = <0xc00 0x100>;
 
-			clocks = <&sysc 11>;
+			clocks = <&sysc RT5350_CLK_UARTLITE>;
 
 			resets = <&sysc 19>;
 
@@ -340,7 +342,7 @@
 		compatible = "ralink,rt5350-eth";
 		reg = <0x10100000 0x10000>;
 
-		clocks = <&sysc 12>;
+		clocks = <&sysc RT5350_CLK_ETHERNET>;
 
 		resets = <&sysc 21>, <&sysc 23>;
 		reset-names = "fe", "esw";
@@ -366,7 +368,7 @@
 		compatible = "ralink,rt5350-wifi", "ralink,rt2880-wifi";
 		reg = <0x10180000 0x40000>;
 
-		clocks = <&sysc 13>;
+		clocks = <&sysc RT5350_CLK_WMAC>;
 
 		interrupt-parent = <&cpuintc>;
 		interrupts = <6>;

--- a/target/linux/ramips/patches-6.12/004-v6.15-dt-bindings-clock-add-clock-definitions-for-Ralink-S.patch
+++ b/target/linux/ramips/patches-6.12/004-v6.15-dt-bindings-clock-add-clock-definitions-for-Ralink-S.patch
@@ -1,0 +1,188 @@
+From adb2424d0d05506c2f36fcba66101d34f7409e45 Mon Sep 17 00:00:00 2001
+From: Sergio Paracuellos <sergio.paracuellos@gmail.com>
+Date: Mon, 20 Jan 2025 10:21:41 +0100
+Subject: [PATCH] dt-bindings: clock: add clock definitions for Ralink SoCs
+
+Add clock missing definitions for RT2880, RT305X, RT3352, RT3383, RT5350,
+MT7620 and MT76X8 Ralink SoCs. Update bindings to clarify clock depending
+on these new introduced constants so consumer nodes can easily use the
+correct one in DTS files matching properly what is being used in driver
+code (clock IDs are implicitly used there).
+
+Signed-off-by: Sergio Paracuellos <sergio.paracuellos@gmail.com>
+Reviewed-by: Krzysztof Kozlowski <krzysztof.kozlowski@linaro.org>
+Acked-by: Stephen Boyd <sboyd@kernel.org>
+Signed-off-by: Thomas Bogendoerfer <tsbogend@alpha.franken.de>
+---
+ .../bindings/clock/mediatek,mtmips-sysc.yaml  |  11 +-
+ .../dt-bindings/clock/mediatek,mtmips-sysc.h  | 130 ++++++++++++++++++
+ 2 files changed, 140 insertions(+), 1 deletion(-)
+ create mode 100644 include/dt-bindings/clock/mediatek,mtmips-sysc.h
+
+--- a/Documentation/devicetree/bindings/clock/mediatek,mtmips-sysc.yaml
++++ b/Documentation/devicetree/bindings/clock/mediatek,mtmips-sysc.yaml
+@@ -18,6 +18,12 @@ description: |
+   These SoCs have an XTAL from where the cpu clock is
+   provided as well as derived clocks for the bus and the peripherals.
+ 
++  Each clock is assigned an identifier and client nodes use this identifier
++  to specify the clock which they consume.
++
++  All these identifiers could be found in:
++  [1]: <include/dt-bindings/clock/mediatek,mtmips-sysc.h>.
++
+ properties:
+   compatible:
+     items:
+@@ -38,7 +44,8 @@ properties:
+ 
+   '#clock-cells':
+     description:
+-      The first cell indicates the clock number.
++      The first cell indicates the clock number, see [1] for available
++      clocks.
+     const: 1
+ 
+   '#reset-cells':
+@@ -56,6 +63,8 @@ additionalProperties: false
+ 
+ examples:
+   - |
++    #include <dt-bindings/clock/mediatek,mtmips-sysc.h>
++
+     syscon@0 {
+       compatible = "ralink,rt5350-sysc", "syscon";
+       reg = <0x0 0x100>;
+--- /dev/null
++++ b/include/dt-bindings/clock/mediatek,mtmips-sysc.h
+@@ -0,0 +1,130 @@
++/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
++/*
++ * Author: Sergio Paracuellos <sergio.paracuellos@gmail.com>
++ */
++
++#ifndef _DT_BINDINGS_CLK_MTMIPS_H
++#define _DT_BINDINGS_CLK_MTMIPS_H
++
++/* Ralink RT-2880 clocks */
++
++#define RT2880_CLK_XTAL		0
++#define RT2880_CLK_CPU		1
++#define RT2880_CLK_BUS		2
++#define RT2880_CLK_TIMER	3
++#define RT2880_CLK_WATCHDOG	4
++#define RT2880_CLK_UART		5
++#define RT2880_CLK_I2C		6
++#define RT2880_CLK_UARTLITE	7
++#define RT2880_CLK_ETHERNET	8
++#define RT2880_CLK_WMAC		9
++
++/* Ralink RT-305X clocks */
++
++#define RT305X_CLK_XTAL		0
++#define RT305X_CLK_CPU		1
++#define RT305X_CLK_BUS		2
++#define RT305X_CLK_TIMER	3
++#define RT305X_CLK_WATCHDOG	4
++#define RT305X_CLK_UART		5
++#define RT305X_CLK_I2C		6
++#define RT305X_CLK_I2S		7
++#define RT305X_CLK_SPI1		8
++#define RT305X_CLK_SPI2		9
++#define RT305X_CLK_UARTLITE	10
++#define RT305X_CLK_ETHERNET	11
++#define RT305X_CLK_WMAC		12
++
++/* Ralink RT-3352 clocks */
++
++#define RT3352_CLK_XTAL		0
++#define RT3352_CLK_CPU		1
++#define RT3352_CLK_PERIPH	2
++#define RT3352_CLK_BUS		3
++#define RT3352_CLK_TIMER	4
++#define RT3352_CLK_WATCHDOG	5
++#define RT3352_CLK_UART		6
++#define RT3352_CLK_I2C		7
++#define RT3352_CLK_I2S		8
++#define RT3352_CLK_SPI1		9
++#define RT3352_CLK_SPI2		10
++#define RT3352_CLK_UARTLITE	11
++#define RT3352_CLK_ETHERNET	12
++#define RT3352_CLK_WMAC		13
++
++/* Ralink RT-3883 clocks */
++
++#define RT3883_CLK_XTAL		0
++#define RT3883_CLK_CPU		1
++#define RT3883_CLK_BUS		2
++#define RT3883_CLK_PERIPH	3
++#define RT3883_CLK_TIMER	4
++#define RT3883_CLK_WATCHDOG	5
++#define RT3883_CLK_UART		6
++#define RT3883_CLK_I2C		7
++#define RT3883_CLK_I2S		8
++#define RT3883_CLK_SPI1		9
++#define RT3883_CLK_SPI2		10
++#define RT3883_CLK_UARTLITE	11
++#define RT3883_CLK_ETHERNET	12
++#define RT3883_CLK_WMAC		13
++
++/* Ralink RT-5350 clocks */
++
++#define RT5350_CLK_XTAL		0
++#define RT5350_CLK_CPU		1
++#define RT5350_CLK_BUS		2
++#define RT5350_CLK_PERIPH	3
++#define RT5350_CLK_TIMER	4
++#define RT5350_CLK_WATCHDOG	5
++#define RT5350_CLK_UART		6
++#define RT5350_CLK_I2C		7
++#define RT5350_CLK_I2S		8
++#define RT5350_CLK_SPI1		9
++#define RT5350_CLK_SPI2		10
++#define RT5350_CLK_UARTLITE	11
++#define RT5350_CLK_ETHERNET	12
++#define RT5350_CLK_WMAC		13
++
++/* Ralink MT-7620 clocks */
++
++#define MT7620_CLK_XTAL		0
++#define MT7620_CLK_PLL		1
++#define MT7620_CLK_CPU		2
++#define MT7620_CLK_PERIPH	3
++#define MT7620_CLK_BUS		4
++#define MT7620_CLK_BBPPLL	5
++#define MT7620_CLK_SDHC		6
++#define MT7620_CLK_TIMER	7
++#define MT7620_CLK_WATCHDOG	8
++#define MT7620_CLK_UART		9
++#define MT7620_CLK_I2C		10
++#define MT7620_CLK_I2S		11
++#define MT7620_CLK_SPI1		12
++#define MT7620_CLK_SPI2		13
++#define MT7620_CLK_UARTLITE	14
++#define MT7620_CLK_MMC		15
++#define MT7620_CLK_WMAC		16
++
++/* Ralink MT-76X8 clocks */
++
++#define MT76X8_CLK_XTAL		0
++#define MT76X8_CLK_CPU		1
++#define MT76X8_CLK_BBPPLL	2
++#define MT76X8_CLK_PCMI2S	3
++#define MT76X8_CLK_PERIPH	4
++#define MT76X8_CLK_BUS		5
++#define MT76X8_CLK_SDHC		6
++#define MT76X8_CLK_TIMER	7
++#define MT76X8_CLK_WATCHDOG	8
++#define MT76X8_CLK_I2C		9
++#define MT76X8_CLK_I2S		10
++#define MT76X8_CLK_SPI1		11
++#define MT76X8_CLK_SPI2		12
++#define MT76X8_CLK_UART0	13
++#define MT76X8_CLK_UART1	14
++#define MT76X8_CLK_UART2	15
++#define MT76X8_CLK_MMC		16
++#define MT76X8_CLK_WMAC		17
++
++#endif /* _DT_BINDINGS_CLK_MTMIPS_H */


### PR DESCRIPTION
Use clock index macros defined in dt-bindings header to improve the code readability.