### PR TITLE
[24.10] realtek: Fix unintended RTL8218B phy reset

### DIFF
--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900_gpio.dtsi
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900_gpio.dtsi
@@ -5,10 +5,6 @@
 &mdio_aux {
 	status = "okay";
 
-	reset-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
-	reset-delay-us = <1000>;
-	reset-post-delay-us = <10000>;
-
 	gpio1: expander@0 {
 		compatible = "realtek,rtl8231";
 		reg = <0x0>;

--- a/target/linux/realtek/dts/rtl8380_zyxel_gs1900_gpio_emulated.dtsi
+++ b/target/linux/realtek/dts/rtl8380_zyxel_gs1900_gpio_emulated.dtsi
@@ -5,10 +5,6 @@
 &mdio_gpio {
 	status = "okay";
 
-	reset-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
-	reset-delay-us = <1000>;
-	reset-post-delay-us = <10000>;
-
 	gpio1: expander@0 {
 		compatible = "realtek,rtl8231";
 		reg = <0x0>;

--- a/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24e.dts
+++ b/target/linux/realtek/dts/rtl8382_zyxel_gs1900-24e.dts
@@ -8,6 +8,16 @@
 	model = "Zyxel GS1900-24E";
 };
 
+&gpio0 {
+	/* Shared between the main and aux MDIO busses */
+	mdio_reset {
+		gpio-hog;
+		gpios = <1 GPIO_ACTIVE_LOW>;
+		output-low;
+		line-name = "mdio-reset";
+	};
+};
+
 &mdio {
 	EXTERNAL_PHY(0)
 	EXTERNAL_PHY(1)


### PR DESCRIPTION
The GPIO line connecting to the reset signals of the GS1900-24E(A1)'s
external ICs (RTL8218B phys and RTL8231 expander) cannot be asserted by
the MDIO subsystem, as the reset is shared between busses.

To prevent users from accidentally asserting the reset line, a GPIO hog
is created to permanently de-assert the signal, reliably keeping the
phys and GPIO expanders on.

Backport of https://github.com/openwrt/openwrt/pull/22132
Closes https://github.com/openwrt/openwrt/issues/18620
