### PR TITLE
button-hotplug: use flex array and not pointer hack

### DIFF
--- a/package/kernel/button-hotplug/src/button-hotplug.c
+++ b/package/kernel/button-hotplug/src/button-hotplug.c
@@ -46,8 +46,8 @@
 #endif
 
 struct bh_priv {
-	unsigned long		*seen;
 	struct input_handle	handle;
+	unsigned long		seen[];
 };
 
 struct bh_event {
@@ -254,13 +254,10 @@ static int button_hotplug_connect(struct input_handler *handler,
 	if (i == ARRAY_SIZE(button_map))
 		return -ENODEV;
 
-	priv = kzalloc(sizeof(*priv) +
-		       (sizeof(unsigned long) * ARRAY_SIZE(button_map)),
-		       GFP_KERNEL);
+	priv = kzalloc(struct_size(priv, seen, ARRAY_SIZE(button_map)), GFP_KERNEL);
 	if (!priv)
 		return -ENOMEM;
 
-	priv->seen = (unsigned long *) &priv[1];
 	priv->handle.private = priv;
 	priv->handle.dev = dev;
 	priv->handle.handler = handler;


### PR DESCRIPTION
The &pointer + 1 trick is a C89 trick to point to area allocated after the size of the struct. We have struct_size and flex arrays now.

ping @hauke @robimarko 
