### PR TITLE
mac80211: activate BRCMFMAC_SDIO on x86

### DIFF
--- a/package/kernel/mac80211/broadcom.mk
+++ b/package/kernel/mac80211/broadcom.mk
@@ -438,6 +438,7 @@ define KernelPackage/brcmfmac/config
 		default y if TARGET_rockchip
 		default y if TARGET_sunxi
 		default y if TARGET_stm32
+		default y if TARGET_x86
 		default n
 		help
 		  Enable support for cards attached to an SDIO bus.


### PR DESCRIPTION
Activate the option BRCMFMAC_SDIO by default on x86 too. x86 already compiles MMC support into the kernel. This will just compile brcmfmac with MMC support.

Fixes: https://github.com/openwrt/openwrt/issues/22155