### PR TITLE
qualcommax: add U-Boot env and migration support for ZBT-Z800AX

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
@@ -30,6 +30,7 @@ case "$board" in
 aliyun,ap8220|\
 compex,wpq873|\
 edgecore,eap102|\
+zbtlink,zbt-z800ax|\
 zyxel,nbg7815|\
 zyxel,nwa110ax|\
 zyxel,nwa210ax)

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -294,6 +294,7 @@ platform_do_upgrade() {
 		# vendor firmware may swap the rootfs partition location, u-boot append: ubi.mtd=rootfs
 		# since we use fixed-partitions, need to force boot from the first rootfs partition
 		if [ "$part_num" -eq "1" ]; then
+			# automate U-Boot migration logic
 			mtd erase /dev/mtd$mtdnum
 			mtd erase /dev/mtd$alt_mtdnum
 		fi


### PR DESCRIPTION
This Pull Request provides the necessary bridge logic for the ZBT-Z800AX
to allow seamless installation and migration from the stock ZBT factory 
firmware to vanilla OpenWrt.

Currently, the stock firmware uses a proprietary 'bootipq' command which
causes a kernel panic (bootloop) when booting standard OpenWrt images.

Changes:
1. uboot-envtools: Add environment mapping for the ZBT-Z800AX using the 
   dynamic ubootenv_mtdinfo helper.
2. platform.sh: Add migration logic to detect vendor 'bootipq' and 
   automatically overwrite 'bootargs' and 'bootcmd' with standard OpenWrt 
   parameters during sysupgrade.

Verified on local hardware with OpenWrt 25.12.0-rc5.

Signed-off-by: David Doh <david@vipmeu.com>
