### PR TITLE
ramips: mt7621: fix network configuration

### DIFF
--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -46,9 +46,6 @@ ramips_setup_interfaces()
 	cudy,ap1300-outdoor-v1|\
 	dlink,dap-1620-b1|\
 	dlink,dap-x1860-a1|\
-	dlink,dir-1360-a1)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
-		;;
 	dlink,dra-1360-a1|\
 	edimax,re23s|\
 	linksys,re7000|\


### PR DESCRIPTION
The configuration for the dlink,dir-1360-a1 also changed the settings for the devices defined on top of it. "lan1 lan2 lan3 lan4" "wan" is the default configuration, no need to add it here.

Fixes: 7a8e2efed587 ("ramips: add support for D-Link DIR-1360 A1")