### PR TITLE
bcm53xx: nvmem conversions

### DIFF
--- a/target/linux/bcm53xx/base-files/etc/board.d/02_network
+++ b/target/linux/bcm53xx/base-files/etc/board.d/02_network
@@ -53,21 +53,28 @@ bcm53xx_setup_macs()
 	wan_macaddr="$(nvram get wan_hwaddr)"
 
 	case "$board" in
-	dlink,dir-885l | \
-	linksys,ea9200 | \
-	linksys,panamera | \
 	netgear,r7900 | \
 	netgear,r8000 | \
 	netgear,r8500)
 		etXmacaddr=$(nvram get et2macaddr)
 		offset=1
 		;;
-	luxul,xwr-3100-v1 | \
-	luxul,xwr-3150-v1)
-		etXmacaddr=$(nvram get et0macaddr)
-		offset=5
-		;;
-	*)
+	asus,rt-ac3200|\
+	asus,rt-ac5300|\
+	asus,rt-ac56u|\
+	asus,rt-ac68u|\
+	asus,rt-n18u|\
+	buffalo,wxr-1900dhp|\
+	buffalo,wzr-600dhp2|\
+	buffalo,wzr-900dhp|\
+	buffalo,wzr-1750dhp|\
+	dlink,dir-890l|\
+	linksys,ea6500-v2|\
+	netgear,r6250-v1|\
+	netgear,r6300-v2|\
+	netgear,r7000|\
+	smartrg,sr400ac|\
+	tenda,ac9)
 		etXmacaddr=$(nvram get et0macaddr)
 		offset=1
 		;;

--- a/target/linux/bcm53xx/patches-6.12/304-ARM-dts-BCM5301X-Specify-switch-ports-for-remaining-.patch
+++ b/target/linux/bcm53xx/patches-6.12/304-ARM-dts-BCM5301X-Specify-switch-ports-for-remaining-.patch
@@ -140,50 +140,6 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 +		};
 +	};
 +};
---- a/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6300-v1.dts
-+++ b/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6300-v1.dts
-@@ -46,3 +46,41 @@
- &usb3_phy {
- 	status = "okay";
- };
-+
-+&srab {
-+	status = "okay";
-+
-+	ports {
-+		port@0 {
-+			label = "lan1";
-+		};
-+
-+		port@1 {
-+			label = "lan2";
-+		};
-+
-+		port@2 {
-+			label = "lan3";
-+		};
-+
-+		port@3 {
-+			label = "lan4";
-+		};
-+
-+		port@4 {
-+			label = "wan";
-+		};
-+
-+		port@5 {
-+			label = "cpu";
-+		};
-+
-+		port@7 {
-+			status = "disabled";
-+		};
-+
-+		port@8 {
-+			status = "disabled";
-+		};
-+	};
-+};
 --- a/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6500-v2.dts
 +++ b/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6500-v2.dts
 @@ -43,3 +43,41 @@
@@ -316,52 +272,6 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 +		};
 +	};
 +};
---- a/arch/arm/boot/dts/broadcom/bcm4709-asus-rt-ac87u.dts
-+++ b/arch/arm/boot/dts/broadcom/bcm4709-asus-rt-ac87u.dts
-@@ -77,6 +77,43 @@
- 	status = "okay";
- };
- 
-+&srab {
-+	status = "okay";
-+
-+	ports {
-+		port@0 {
-+			label = "wan";
-+
-+			nvmem-cells = <&et1macaddr 1>;
-+			nvmem-cell-names = "mac-address";
-+		};
-+
-+		port@1 {
-+			label = "lan1";
-+		};
-+
-+		port@2 {
-+			label = "lan2";
-+		};
-+
-+		port@3 {
-+			label = "lan3";
-+		};
-+
-+		port@5 {
-+			status = "disabled";
-+		};
-+
-+		port@7 {
-+			label = "cpu";
-+		};
-+
-+		port@8 {
-+			status = "disabled";
-+		};
-+	};
-+};
-+
- &nandcs {
- 	partitions {
- 		compatible = "fixed-partitions";
 --- a/arch/arm/boot/dts/broadcom/bcm4709-buffalo-wxr-1900dhp.dts
 +++ b/arch/arm/boot/dts/broadcom/bcm4709-buffalo-wxr-1900dhp.dts
 @@ -130,3 +130,41 @@
@@ -494,49 +404,6 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 +		};
 +	};
 +};
---- a/arch/arm/boot/dts/broadcom/bcm47094-phicomm-k3.dts
-+++ b/arch/arm/boot/dts/broadcom/bcm47094-phicomm-k3.dts
-@@ -38,6 +38,40 @@
- 	status = "okay";
- };
- 
-+&srab {
-+	status = "okay";
-+
-+	ports {
-+		port@0 {
-+			label = "lan1";
-+		};
-+
-+		port@1 {
-+			label = "lan2";
-+		};
-+
-+		port@2 {
-+			label = "lan3";
-+		};
-+
-+		port@3 {
-+			label = "wan";
-+		};
-+
-+		port@5 {
-+			label = "cpu";
-+		};
-+
-+		port@7 {
-+			status = "disabled";
-+		};
-+
-+		port@8 {
-+			status = "disabled";
-+		};
-+	};
-+};
-+
- &nandcs {
- 	partitions {
- 		compatible = "fixed-partitions";
 --- a/arch/arm/boot/dts/broadcom/bcm47081-tplink-archer-c5-v2.dts
 +++ b/arch/arm/boot/dts/broadcom/bcm47081-tplink-archer-c5-v2.dts
 @@ -91,6 +91,44 @@

--- a/target/linux/bcm53xx/patches-6.12/311-ARM-dts-BCM5301X-EA9200-set-WAN-MAC-from-nvram.patch
+++ b/target/linux/bcm53xx/patches-6.12/311-ARM-dts-BCM5301X-EA9200-set-WAN-MAC-from-nvram.patch
@@ -1,0 +1,36 @@
+From 3482a3f37240826c825d05fceebbfe5877f587d4 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 17 Feb 2026 20:20:16 -0800
+Subject: [PATCH] ARM: dts: BCM5301X: EA9200: set WAN MAC from nvram
+
+The MAC address from the stock firmare is offset by 1. Define it
+properly to avoid having to override it in userspace.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ arch/arm/boot/dts/broadcom/bcm4709-linksys-ea9200.dts | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/arch/arm/boot/dts/broadcom/bcm4709-linksys-ea9200.dts
++++ b/arch/arm/boot/dts/broadcom/bcm4709-linksys-ea9200.dts
+@@ -25,6 +25,10 @@
+ 	nvram@1c080000 {
+ 		compatible = "brcm,nvram";
+ 		reg = <0x1c080000 0x180000>;
++
++		et2macaddr: et2macaddr {
++			#nvmem-cell-cells = <1>;
++		};
+ 	};
+ 
+ 	gpio-keys {
+@@ -70,6 +74,9 @@
+ 
+ 		port@4 {
+ 			label = "wan";
++
++			nvmem-cells = <&et2macaddr 1>;
++			nvmem-cell-names = "mac-address";
+ 		};
+ 
+ 		port@5 {

--- a/target/linux/bcm53xx/patches-6.12/312-ARM-dts-BCM5301X-panamera-set-WAN-MAC-from-nvram.patch
+++ b/target/linux/bcm53xx/patches-6.12/312-ARM-dts-BCM5301X-panamera-set-WAN-MAC-from-nvram.patch
@@ -1,0 +1,36 @@
+From cbbaa1f69301755409bc3ddbf2401c8b87a73658 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 17 Feb 2026 20:30:02 -0800
+Subject: [PATCH] ARM: dts: BCM5301X: panamera: set WAN MAC from nvram
+
+The MAC address from the stock firmare is offset by 1. Define it
+properly to avoid having to override it in userspace.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ arch/arm/boot/dts/broadcom/bcm47094-linksys-panamera.dts | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/arch/arm/boot/dts/broadcom/bcm47094-linksys-panamera.dts
++++ b/arch/arm/boot/dts/broadcom/bcm47094-linksys-panamera.dts
+@@ -25,6 +25,10 @@
+ 	nvram@1c080000 {
+ 		compatible = "brcm,nvram";
+ 		reg = <0x1c080000 0x100000>;
++
++		et2macaddr: et2macaddr {
++			#nvmem-cell-cells = <1>;
++		};
+ 	};
+ 
+ 	gpio-keys {
+@@ -230,6 +234,9 @@
+ 
+ 		port@4 {
+ 			label = "wan";
++
++			nvmem-cells = <&et2macaddr 1>;
++			nvmem-cell-names = "mac-address";
+ 		};
+ 
+ 		port@5 {

--- a/target/linux/bcm53xx/patches-6.12/313-ARM-dts-BCM5301X-AC87U-specify-switch.patch
+++ b/target/linux/bcm53xx/patches-6.12/313-ARM-dts-BCM5301X-AC87U-specify-switch.patch
@@ -1,0 +1,69 @@
+From cdcbe55d86588aa8c296847a445c1b1a59f4a617 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 17 Feb 2026 20:58:58 -0800
+Subject: [PATCH] ARM: dts: BCM5301X: AC87U: specify switch
+
+bcm-ns.dtsi specifies a default layout that is not correct for the
+RT-AC87U. Also allows setting the WAN MAC address properly.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ .../dts/broadcom/bcm4709-asus-rt-ac87u.dts    | 40 +++++++++++++++++++
+ 1 file changed, 40 insertions(+)
+
+--- a/arch/arm/boot/dts/broadcom/bcm4709-asus-rt-ac87u.dts
++++ b/arch/arm/boot/dts/broadcom/bcm4709-asus-rt-ac87u.dts
+@@ -26,6 +26,9 @@
+ 	};
+ 
+ 	nvram@1c080000 {
++		compatible = "brcm,nvram";
++		reg = <0x1c080000 0x180000>;
++
+ 		et1macaddr: et1macaddr {
+ 			#nvmem-cell-cells = <1>;
+ 		};
+@@ -77,6 +80,43 @@
+ 	status = "okay";
+ };
+ 
++&srab {
++	status = "okay";
++
++	ports {
++		port@0 {
++			label = "wan";
++
++			nvmem-cells = <&et1macaddr 1>;
++			nvmem-cell-names = "mac-address";
++		};
++
++		port@1 {
++			label = "lan1";
++		};
++
++		port@2 {
++			label = "lan2";
++		};
++
++		port@3 {
++			label = "lan3";
++		};
++
++		port@5 {
++			status = "disabled";
++		};
++
++		port@7 {
++			label = "cpu";
++		};
++
++		port@8 {
++			status = "disabled";
++		};
++	};
++};
++
+ &nandcs {
+ 	partitions {
+ 		compatible = "fixed-partitions";

--- a/target/linux/bcm53xx/patches-6.12/314-ARM-dts-BCM5301X-EA6300-specify-switch.patch
+++ b/target/linux/bcm53xx/patches-6.12/314-ARM-dts-BCM5301X-EA6300-specify-switch.patch
@@ -1,0 +1,71 @@
+From c4c21947b9a641131afe07d6c5f1abd3ff6b8bb0 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 17 Feb 2026 21:05:09 -0800
+Subject: [PATCH] ARM: dts: BCM5301X: EA6300: specify switch
+
+bcm-ns.dtsi specifies a default layout that is not correct for the
+EA6300. Also allows setting the WAN MAC address properly.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ .../broadcom/bcm4708-linksys-ea6300-v1.dts    | 45 +++++++++++++++++++
+ 1 file changed, 45 insertions(+)
+
+--- a/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6300-v1.dts
++++ b/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6300-v1.dts
+@@ -24,6 +24,10 @@
+ 	nvram@1c080000 {
+ 		compatible = "brcm,nvram";
+ 		reg = <0x1c080000 0x180000>;
++
++		et0macaddr: et0macaddr {
++			#nvmem-cell-cells = <1>;
++		};
+ 	};
+ 
+ 	gpio-keys {
+@@ -46,3 +50,44 @@
+ &usb3_phy {
+ 	status = "okay";
+ };
++
++&srab {
++	status = "okay";
++
++	ports {
++		port@0 {
++			label = "lan1";
++		};
++
++		port@1 {
++			label = "lan2";
++		};
++
++		port@2 {
++			label = "lan3";
++		};
++
++		port@3 {
++			label = "lan4";
++		};
++
++		port@4 {
++			label = "wan";
++
++			nvmem-cells = <&et0macaddr 1>;
++			nvmem-cell-names = "mac-address";
++		};
++
++		port@5 {
++			label = "cpu";
++		};
++
++		port@7 {
++			status = "disabled";
++		};
++
++		port@8 {
++			status = "disabled";
++		};
++	};
++};

--- a/target/linux/bcm53xx/patches-6.12/315-ARM-dts-BCM5301X-phicomm-k3-specify-switch.patch
+++ b/target/linux/bcm53xx/patches-6.12/315-ARM-dts-BCM5301X-phicomm-k3-specify-switch.patch
@@ -1,0 +1,75 @@
+From 22785d47e3a5a8e5321586a9776a70a5e88148a2 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 17 Feb 2026 21:13:49 -0800
+Subject: [PATCH] ARM: dts: BCM5301X: phicomm-k3: specify switch
+
+bcm-ns.dtsi specifies a default layout that is not correct for the
+K3. Also allows setting the WAN MAC address properly.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ .../boot/dts/broadcom/bcm47094-phicomm-k3.dts | 46 +++++++++++++++++++
+ 1 file changed, 46 insertions(+)
+
+--- a/arch/arm/boot/dts/broadcom/bcm47094-phicomm-k3.dts
++++ b/arch/arm/boot/dts/broadcom/bcm47094-phicomm-k3.dts
+@@ -19,6 +19,15 @@
+ 		      <0x88000000 0x18000000>;
+ 	};
+ 
++	nvram@1c080000 {
++		compatible = "brcm,nvram";
++		reg = <0x1c080000 0x100000>;
++
++		et0macaddr: et0macaddr {
++			#nvmem-cell-cells = <1>;
++		};
++	};
++
+ 	gpio-keys {
+ 		compatible = "gpio-keys";
+ 
+@@ -38,6 +47,43 @@
+ 	status = "okay";
+ };
+ 
++&srab {
++	status = "okay";
++
++	ports {
++		port@0 {
++			label = "lan1";
++		};
++
++		port@1 {
++			label = "lan2";
++		};
++
++		port@2 {
++			label = "lan3";
++		};
++
++		port@3 {
++			label = "wan";
++
++			nvmem-cells = <&et0macaddr 1>;
++			nvmem-cell-names = "mac-address";
++		};
++
++		port@5 {
++			label = "cpu";
++		};
++
++		port@7 {
++			status = "disabled";
++		};
++
++		port@8 {
++			status = "disabled";
++		};
++	};
++};
++
+ &nandcs {
+ 	partitions {
+ 		compatible = "fixed-partitions";

--- a/target/linux/bcm53xx/patches-6.18/304-ARM-dts-BCM5301X-Specify-switch-ports-for-remaining-.patch
+++ b/target/linux/bcm53xx/patches-6.18/304-ARM-dts-BCM5301X-Specify-switch-ports-for-remaining-.patch
@@ -140,50 +140,6 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 +		};
 +	};
 +};
---- a/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6300-v1.dts
-+++ b/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6300-v1.dts
-@@ -46,3 +46,41 @@
- &usb3_phy {
- 	status = "okay";
- };
-+
-+&srab {
-+	status = "okay";
-+
-+	ports {
-+		port@0 {
-+			label = "lan1";
-+		};
-+
-+		port@1 {
-+			label = "lan2";
-+		};
-+
-+		port@2 {
-+			label = "lan3";
-+		};
-+
-+		port@3 {
-+			label = "lan4";
-+		};
-+
-+		port@4 {
-+			label = "wan";
-+		};
-+
-+		port@5 {
-+			label = "cpu";
-+		};
-+
-+		port@7 {
-+			status = "disabled";
-+		};
-+
-+		port@8 {
-+			status = "disabled";
-+		};
-+	};
-+};
 --- a/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6500-v2.dts
 +++ b/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6500-v2.dts
 @@ -43,3 +43,41 @@
@@ -316,52 +272,6 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 +		};
 +	};
 +};
---- a/arch/arm/boot/dts/broadcom/bcm4709-asus-rt-ac87u.dts
-+++ b/arch/arm/boot/dts/broadcom/bcm4709-asus-rt-ac87u.dts
-@@ -77,6 +77,43 @@
- 	status = "okay";
- };
- 
-+&srab {
-+	status = "okay";
-+
-+	ports {
-+		port@0 {
-+			label = "wan";
-+
-+			nvmem-cells = <&et1macaddr 1>;
-+			nvmem-cell-names = "mac-address";
-+		};
-+
-+		port@1 {
-+			label = "lan1";
-+		};
-+
-+		port@2 {
-+			label = "lan2";
-+		};
-+
-+		port@3 {
-+			label = "lan3";
-+		};
-+
-+		port@5 {
-+			status = "disabled";
-+		};
-+
-+		port@7 {
-+			label = "cpu";
-+		};
-+
-+		port@8 {
-+			status = "disabled";
-+		};
-+	};
-+};
-+
- &nandcs {
- 	partitions {
- 		compatible = "fixed-partitions";
 --- a/arch/arm/boot/dts/broadcom/bcm4709-buffalo-wxr-1900dhp.dts
 +++ b/arch/arm/boot/dts/broadcom/bcm4709-buffalo-wxr-1900dhp.dts
 @@ -130,3 +130,41 @@
@@ -494,49 +404,6 @@ Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
 +		};
 +	};
 +};
---- a/arch/arm/boot/dts/broadcom/bcm47094-phicomm-k3.dts
-+++ b/arch/arm/boot/dts/broadcom/bcm47094-phicomm-k3.dts
-@@ -38,6 +38,40 @@
- 	status = "okay";
- };
- 
-+&srab {
-+	status = "okay";
-+
-+	ports {
-+		port@0 {
-+			label = "lan1";
-+		};
-+
-+		port@1 {
-+			label = "lan2";
-+		};
-+
-+		port@2 {
-+			label = "lan3";
-+		};
-+
-+		port@3 {
-+			label = "wan";
-+		};
-+
-+		port@5 {
-+			label = "cpu";
-+		};
-+
-+		port@7 {
-+			status = "disabled";
-+		};
-+
-+		port@8 {
-+			status = "disabled";
-+		};
-+	};
-+};
-+
- &nandcs {
- 	partitions {
- 		compatible = "fixed-partitions";
 --- a/arch/arm/boot/dts/broadcom/bcm47081-tplink-archer-c5-v2.dts
 +++ b/arch/arm/boot/dts/broadcom/bcm47081-tplink-archer-c5-v2.dts
 @@ -91,6 +91,44 @@

--- a/target/linux/bcm53xx/patches-6.18/311-ARM-dts-BCM5301X-EA9200-set-WAN-MAC-from-nvram.patch
+++ b/target/linux/bcm53xx/patches-6.18/311-ARM-dts-BCM5301X-EA9200-set-WAN-MAC-from-nvram.patch
@@ -1,0 +1,36 @@
+From 3482a3f37240826c825d05fceebbfe5877f587d4 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 17 Feb 2026 20:20:16 -0800
+Subject: [PATCH] ARM: dts: BCM5301X: EA9200: set WAN MAC from nvram
+
+The MAC address from the stock firmare is offset by 1. Define it
+properly to avoid having to override it in userspace.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ arch/arm/boot/dts/broadcom/bcm4709-linksys-ea9200.dts | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/arch/arm/boot/dts/broadcom/bcm4709-linksys-ea9200.dts
++++ b/arch/arm/boot/dts/broadcom/bcm4709-linksys-ea9200.dts
+@@ -25,6 +25,10 @@
+ 	nvram@1c080000 {
+ 		compatible = "brcm,nvram";
+ 		reg = <0x1c080000 0x180000>;
++
++		et2macaddr: et2macaddr {
++			#nvmem-cell-cells = <1>;
++		};
+ 	};
+ 
+ 	gpio-keys {
+@@ -70,6 +74,9 @@
+ 
+ 		port@4 {
+ 			label = "wan";
++
++			nvmem-cells = <&et2macaddr 1>;
++			nvmem-cell-names = "mac-address";
+ 		};
+ 
+ 		port@5 {

--- a/target/linux/bcm53xx/patches-6.18/312-ARM-dts-BCM5301X-panamera-set-WAN-MAC-from-nvram.patch
+++ b/target/linux/bcm53xx/patches-6.18/312-ARM-dts-BCM5301X-panamera-set-WAN-MAC-from-nvram.patch
@@ -1,0 +1,36 @@
+From cbbaa1f69301755409bc3ddbf2401c8b87a73658 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 17 Feb 2026 20:30:02 -0800
+Subject: [PATCH] ARM: dts: BCM5301X: panamera: set WAN MAC from nvram
+
+The MAC address from the stock firmare is offset by 1. Define it
+properly to avoid having to override it in userspace.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ arch/arm/boot/dts/broadcom/bcm47094-linksys-panamera.dts | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/arch/arm/boot/dts/broadcom/bcm47094-linksys-panamera.dts
++++ b/arch/arm/boot/dts/broadcom/bcm47094-linksys-panamera.dts
+@@ -25,6 +25,10 @@
+ 	nvram@1c080000 {
+ 		compatible = "brcm,nvram";
+ 		reg = <0x1c080000 0x100000>;
++
++		et2macaddr: et2macaddr {
++			#nvmem-cell-cells = <1>;
++		};
+ 	};
+ 
+ 	gpio-keys {
+@@ -230,6 +234,9 @@
+ 
+ 		port@4 {
+ 			label = "wan";
++
++			nvmem-cells = <&et2macaddr 1>;
++			nvmem-cell-names = "mac-address";
+ 		};
+ 
+ 		port@5 {

--- a/target/linux/bcm53xx/patches-6.18/313-ARM-dts-BCM5301X-AC87U-specify-switch.patch
+++ b/target/linux/bcm53xx/patches-6.18/313-ARM-dts-BCM5301X-AC87U-specify-switch.patch
@@ -1,0 +1,69 @@
+From cdcbe55d86588aa8c296847a445c1b1a59f4a617 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 17 Feb 2026 20:58:58 -0800
+Subject: [PATCH] ARM: dts: BCM5301X: AC87U: specify switch
+
+bcm-ns.dtsi specifies a default layout that is not correct for the
+RT-AC87U. Also allows setting the WAN MAC address properly.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ .../dts/broadcom/bcm4709-asus-rt-ac87u.dts    | 40 +++++++++++++++++++
+ 1 file changed, 40 insertions(+)
+
+--- a/arch/arm/boot/dts/broadcom/bcm4709-asus-rt-ac87u.dts
++++ b/arch/arm/boot/dts/broadcom/bcm4709-asus-rt-ac87u.dts
+@@ -26,6 +26,9 @@
+ 	};
+ 
+ 	nvram@1c080000 {
++		compatible = "brcm,nvram";
++		reg = <0x1c080000 0x180000>;
++
+ 		et1macaddr: et1macaddr {
+ 			#nvmem-cell-cells = <1>;
+ 		};
+@@ -77,6 +80,43 @@
+ 	status = "okay";
+ };
+ 
++&srab {
++	status = "okay";
++
++	ports {
++		port@0 {
++			label = "wan";
++
++			nvmem-cells = <&et1macaddr 1>;
++			nvmem-cell-names = "mac-address";
++		};
++
++		port@1 {
++			label = "lan1";
++		};
++
++		port@2 {
++			label = "lan2";
++		};
++
++		port@3 {
++			label = "lan3";
++		};
++
++		port@5 {
++			status = "disabled";
++		};
++
++		port@7 {
++			label = "cpu";
++		};
++
++		port@8 {
++			status = "disabled";
++		};
++	};
++};
++
+ &nandcs {
+ 	partitions {
+ 		compatible = "fixed-partitions";

--- a/target/linux/bcm53xx/patches-6.18/314-ARM-dts-BCM5301X-EA6300-specify-switch.patch
+++ b/target/linux/bcm53xx/patches-6.18/314-ARM-dts-BCM5301X-EA6300-specify-switch.patch
@@ -1,0 +1,71 @@
+From c4c21947b9a641131afe07d6c5f1abd3ff6b8bb0 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 17 Feb 2026 21:05:09 -0800
+Subject: [PATCH] ARM: dts: BCM5301X: EA6300: specify switch
+
+bcm-ns.dtsi specifies a default layout that is not correct for the
+EA6300. Also allows setting the WAN MAC address properly.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ .../broadcom/bcm4708-linksys-ea6300-v1.dts    | 45 +++++++++++++++++++
+ 1 file changed, 45 insertions(+)
+
+--- a/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6300-v1.dts
++++ b/arch/arm/boot/dts/broadcom/bcm4708-linksys-ea6300-v1.dts
+@@ -24,6 +24,10 @@
+ 	nvram@1c080000 {
+ 		compatible = "brcm,nvram";
+ 		reg = <0x1c080000 0x180000>;
++
++		et0macaddr: et0macaddr {
++			#nvmem-cell-cells = <1>;
++		};
+ 	};
+ 
+ 	gpio-keys {
+@@ -46,3 +50,44 @@
+ &usb3_phy {
+ 	status = "okay";
+ };
++
++&srab {
++	status = "okay";
++
++	ports {
++		port@0 {
++			label = "lan1";
++		};
++
++		port@1 {
++			label = "lan2";
++		};
++
++		port@2 {
++			label = "lan3";
++		};
++
++		port@3 {
++			label = "lan4";
++		};
++
++		port@4 {
++			label = "wan";
++
++			nvmem-cells = <&et0macaddr 1>;
++			nvmem-cell-names = "mac-address";
++		};
++
++		port@5 {
++			label = "cpu";
++		};
++
++		port@7 {
++			status = "disabled";
++		};
++
++		port@8 {
++			status = "disabled";
++		};
++	};
++};

--- a/target/linux/bcm53xx/patches-6.18/315-ARM-dts-BCM5301X-phicomm-k3-specify-switch.patch
+++ b/target/linux/bcm53xx/patches-6.18/315-ARM-dts-BCM5301X-phicomm-k3-specify-switch.patch
@@ -1,0 +1,75 @@
+From 22785d47e3a5a8e5321586a9776a70a5e88148a2 Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 17 Feb 2026 21:13:49 -0800
+Subject: [PATCH] ARM: dts: BCM5301X: phicomm-k3: specify switch
+
+bcm-ns.dtsi specifies a default layout that is not correct for the
+K3. Also allows setting the WAN MAC address properly.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+---
+ .../boot/dts/broadcom/bcm47094-phicomm-k3.dts | 46 +++++++++++++++++++
+ 1 file changed, 46 insertions(+)
+
+--- a/arch/arm/boot/dts/broadcom/bcm47094-phicomm-k3.dts
++++ b/arch/arm/boot/dts/broadcom/bcm47094-phicomm-k3.dts
+@@ -19,6 +19,15 @@
+ 		      <0x88000000 0x18000000>;
+ 	};
+ 
++	nvram@1c080000 {
++		compatible = "brcm,nvram";
++		reg = <0x1c080000 0x100000>;
++
++		et0macaddr: et0macaddr {
++			#nvmem-cell-cells = <1>;
++		};
++	};
++
+ 	gpio-keys {
+ 		compatible = "gpio-keys";
+ 
+@@ -38,6 +47,43 @@
+ 	status = "okay";
+ };
+ 
++&srab {
++	status = "okay";
++
++	ports {
++		port@0 {
++			label = "lan1";
++		};
++
++		port@1 {
++			label = "lan2";
++		};
++
++		port@2 {
++			label = "lan3";
++		};
++
++		port@3 {
++			label = "wan";
++
++			nvmem-cells = <&et0macaddr 1>;
++			nvmem-cell-names = "mac-address";
++		};
++
++		port@5 {
++			label = "cpu";
++		};
++
++		port@7 {
++			status = "disabled";
++		};
++
++		port@8 {
++			status = "disabled";
++		};
++	};
++};
++
+ &nandcs {
+ 	partitions {
+ 		compatible = "fixed-partitions";


### PR DESCRIPTION
Add upstream patches for devices with nvram definitions in dts.

For others, replace * with all devices that have no nvram definitions.

ping @rmilecki 

Parts of this PR sent upstream.

Some of these look very suspicious. Specifically the netgears.