### PR TITLE
wifi-scripts: fix handling of 64 character WPA key

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -134,7 +134,7 @@ function iface_auth_type(config) {
 			config.macaddr_acl = 2;
 			config.wpa_psk_radius = 2;
 		} else if (length(config.key) == 64) {
-			config.wpa_psk = key;
+			config.wpa_psk = config.key;
 		} else if (length(config.key) >= 8 && length(config.key) <= 63) {
 			config.wpa_passphrase = config.key;
 		} else if (config.key) {


### PR DESCRIPTION
The key variable is not defined in the scope when setting wpa_psk. Use config.key instead.
This fixes configuration the 64 characters wpa_psk directly.

Reported-by: donjoe in OpenWrt Forum