### PR TITLE
ath79: tiny: fix rootfs_data alignment for RE355/RE450

### DIFF
--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -3,12 +3,12 @@ include ./common-tp-link.mk
 define Device/tplink_rex5x
   $(Device/tplink-safeloader)
   SOC := qca9558
+  BLOCKSIZE := 4k
   IMAGE_SIZE := 7680k
   KERNEL_SIZE := 6016k
   DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
   DEVICE_COMPAT_VERSION := 2.0
-  DEVICE_COMPAT_MESSAGE := Partition layout has changed compared to older versions by utilizing unused flash. \
-    Upgrade via sysupgrade mechanism (-F) will only work if flashed image still fits to the size of old partition (6016 KiB).
+  DEVICE_COMPAT_MESSAGE := Partition layout and blocksize changed. Use sysupgrade -F; image must not exceed 6016 KiB (5.875 MB).
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -1,6 +1,6 @@
 include ./common-tp-link.mk
 
-define Device/tplink_rex5x-v1
+define Device/tplink_rex5x
   $(Device/tplink-safeloader)
   SOC := qca9558
   IMAGE_SIZE := 7680k
@@ -13,7 +13,7 @@ define Device/tplink_rex5x-v1
 endef
 
 define Device/tplink_re355-v1
-  $(Device/tplink_rex5x-v1)
+  $(Device/tplink_rex5x)
   DEVICE_MODEL := RE355
   DEVICE_VARIANT := v1
   TPLINK_BOARD_ID := RE355
@@ -22,7 +22,7 @@ endef
 TARGET_DEVICES += tplink_re355-v1
 
 define Device/tplink_re450-v1
-  $(Device/tplink_rex5x-v1)
+  $(Device/tplink_rex5x)
   DEVICE_MODEL := RE450
   DEVICE_VARIANT := v1
   TPLINK_BOARD_ID := RE450
@@ -31,17 +31,10 @@ endef
 TARGET_DEVICES += tplink_re450-v1
 
 define Device/tplink_re450-v2
-  $(Device/tplink-safeloader)
+  $(Device/tplink_rex5x)
   SOC := qca9563
-  IMAGE_SIZE := 7680k
-  KERNEL_SIZE := 6016k
   DEVICE_MODEL := RE450
   DEVICE_VARIANT := v2
-  DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
-  DEVICE_COMPAT_VERSION := 2.0
-  DEVICE_COMPAT_MESSAGE := Partition layout has changed compared to older versions by utilizing unused flash. \
-    Upgrade via sysupgrade mechanism (-F) will only work if flashed image still fits to the size of old partition (6016 KiB).
-  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size | append-metadata
   TPLINK_BOARD_ID := RE450-V2
   LOADER_TYPE := elf
 endef

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -7,7 +7,7 @@ define Device/tplink_rex5x
   IMAGE_SIZE := 7680k
   KERNEL_SIZE := 6016k
   DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct
-  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_VERSION := 3.0
   DEVICE_COMPAT_MESSAGE := Partition layout and blocksize changed. Use sysupgrade -F; image must not exceed 6016 KiB (5.875 MB).
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | check-size | append-metadata
 endef

--- a/target/linux/ath79/tiny/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/05_compat-version
@@ -16,7 +16,7 @@ case "$(board_name)" in
 	tplink,re355-v1|\
 	tplink,re450-v1|\
 	tplink,re450-v2)
-		ucidef_set_compat_version "2.0"
+		ucidef_set_compat_version "3.0"
 		;;
 esac
 


### PR DESCRIPTION
This PR contains three commits for TP-Link RE355 v1 and RE450 (v1/v2).

**1. Config refactor (no functional change)**
- Rename tplink_rex5x-v1 to tplink_rex5x
- Make RE355 v1, RE450 v1 and RE450 v2 inherit from it
- Remove duplicated fields from RE450 v2

This commit is purely a cleanup to simplify the definitions and avoid duplication. No image parameters or packages are changed.

**2 & 3. Fix rootfs_data alignment issue (BLOCKSIZE := 4k)**
Rootfs data was misaligned, which caused rootfs_data not to be properly preserved across sysupgrade.
This is fixed by setting: `BLOCKSIZE := 4k` to match the actual flash erase block size and ensure proper JFFS2 alignment.

A `DEVICE_COMPAT_MESSAGE` was added to clearly document the partition/blocksize change and the requirement to use `sysupgrade -F` when applicable.

Thank you.