### PR TITLE
lantiq: dm200: Fix loading PHY firmware

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7412.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7412.dts
@@ -186,6 +186,13 @@
 	lantiq,gphy-mode = <GPHY_MODE_FE>;
 };
 
+/* This PHY is not used, but try to load the 100M FW too */
+&gphy1 {
+	status = "disabled";
+
+	lantiq,gphy-mode = <GPHY_MODE_FE>;
+};
+
 &gswip_mdio {
 	phy11: ethernet-phy@11 {
 		reg = <0x11>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_netgear_dm200.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_netgear_dm200.dts
@@ -97,6 +97,13 @@
 	nvmem-cell-names = "mac-address";
 };
 
+/* This PHY is not used, but try to load the 100M FW too */
+&gphy0 {
+	status = "disabled";
+
+	lantiq,gphy-mode = <GPHY_MODE_FE>;
+};
+
 &gphy1 {
 	lantiq,gphy-mode = <GPHY_MODE_FE>;
 };


### PR DESCRIPTION
The device has 1 100MBit/s port. By default the PHY firmware is running in 1GBit/s mode. The driver will try to load the 1GBit/s firmware and fail if it is not there. Set the GPHY0 also to 100MBit/s mode.

The driver uses all nodes independent of the status attribute.

Do the same fix for AVM FRITZ!Box 7412 too.