### PR TITLE
Revert "lantiq: arv7525pw: use nvmem for eeprom"

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7525pw.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/danube_arcadyan_arv7525pw.dts
@@ -135,10 +135,6 @@
 					macaddr_boardconfig_16: macaddr@16 {
 						reg = <0x16 0x6>;
 					};
-
-					eeprom_boardconfig_410: eeprom@410 {
-						reg = <0x410 0x200>;
-					};
 				};
 			};
 		};
@@ -156,8 +152,7 @@
 	wifi@e,0 {
 		compatible = "pci0,0";
 		reg = <0x7000 0 0 0 0>;
-		nvmem-cells = <&eeprom_boardconfig_410>;
-		nvmem-cell-names = "eeprom";
+		ralink,mtd-eeprom = <&boardconfig 0x410>;
 	};
 };
 


### PR DESCRIPTION
This reverts commit 9dbd45c18702cdd55fcfb0f71dc505afa1ff64d6.

Compared to ralink,mtd-eeprom , the nvmewm binding ends up byteswapping the data on big endian hosts. Meaning on big endian, the nvmwem binding is equivalent to:

ralink,mtd-eeprom +
ralink,eeprom-wrap

Revert as a result since there's no eeprom-swap here.

ping @robimarko @hauke 

Should be backported to 25.12.

Although I wonder how legit this is. All other lantiq devices swap the eeprom.