### PR TITLE
package: add support for LEDS_SYSCON per board

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -22,6 +22,19 @@ endef
 
 $(eval $(call KernelPackage,leds-gpio))
 
+define KernelPackage/leds-syscon
+  SUBMENU:=$(LEDS_MENU)
+  TITLE:=SYSCON LED support
+  KCONFIG:=CONFIG_LEDS_SYSCON=y \
+  CONFIG_MFD_SYSCON=y
+endef
+
+define KernelPackage/leds-syscon/description
+ Kernel support for LEDs via SYSCON registers
+endef
+
+$(eval $(call KernelPackage,leds-syscon))
+
 LED_TRIGGER_DIR=$(LINUX_DIR)/drivers/leds/trigger
 
 define KernelPackage/leds-group-multicolor


### PR DESCRIPTION
Currently there is no package enablement for LEDS_SYSCON, which means that for boards that map certain LEDs through syscon registers (like the Realtek Hasivo switch series, mapping LEDs through STC8 MFD driver), the LEDS_SYSCON would otherwise need to be enabled at a full target level.

This package will allow individual boards to bring in syscon LED support.
