### PR TITLE
 econet: en7528: fix DASAN H660GM-A WiFi eeprom and flash layout

### DIFF
--- a/target/linux/econet/dts/en7528_dasan_h660gm-a-airtel.dts
+++ b/target/linux/econet/dts/en7528_dasan_h660gm-a-airtel.dts
@@ -59,11 +59,11 @@
 			#size-cells = <1>;
 
 			eeprom_reservearea_40000: eeprom@40000 {
-				reg = <0x40000 0x400>;
+				reg = <0x40000 0x4da8>;
 			};
 
 			eeprom_reservearea_1c0000: eeprom@1c0000 {
-				reg = <0x1c0000 0x1000>;
+				reg = <0x1c0000 0x400>;
 			};
 		};
 	};

--- a/target/linux/econet/dts/en7528_dasan_h660gm-a-generic.dts
+++ b/target/linux/econet/dts/en7528_dasan_h660gm-a-generic.dts
@@ -81,6 +81,11 @@
 };
 
 &partitions {
+	partition@60c0000 {
+		label = "unknown";
+		reg = <0x60c0000 0xd00000>;
+	};
+
 	partition@6dc0000 {
 		label = "reservearea";
 		reg = <0x6dc0000 0x240000>;

--- a/target/linux/econet/dts/en7528_dasan_h660gm-a-generic.dts
+++ b/target/linux/econet/dts/en7528_dasan_h660gm-a-generic.dts
@@ -90,11 +90,11 @@
 			#size-cells = <1>;
 
 			eeprom_reservearea_40000: eeprom@40000 {
-				reg = <0x40000 0x400>;
+				reg = <0x40000 0x4da8>;
 			};
 
 			eeprom_reservearea_1c0000: eeprom@1c0000 {
-				reg = <0x1c0000 0x1000>;
+				reg = <0x1c0000 0x400>;
 			};
 		};
 	};

--- a/target/linux/econet/dts/en7528_dasan_h660gm-a.dtsi
+++ b/target/linux/econet/dts/en7528_dasan_h660gm-a.dtsi
@@ -119,7 +119,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_dzs 8>, <&eeprom_reservearea_40000>;
+		nvmem-cells = <&macaddr_dzs 8>, <&eeprom_reservearea_1c0000>;
 		nvmem-cell-names = "mac-address", "eeprom";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
@@ -131,7 +131,7 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&macaddr_dzs 9>, <&eeprom_reservearea_1c0000>;
+		nvmem-cells = <&macaddr_dzs 9>, <&eeprom_reservearea_40000>;
 		nvmem-cell-names = "mac-address", "eeprom";
 		ieee80211-freq-limit = <5000000 6000000>;
 	};


### PR DESCRIPTION
Fix WiFi eeprom references and flash partition layout for DASAN H660GM-A.

The 2.4 GHz (MT7603) and 5 GHz (MT7663) WiFi eeprom nvmem cells were assigned to the wrong PCIe slots. Additionally, the cell sizes were incorrect resulting in a zeroed eeprom with no TX power calibration and only 0–3 dBm available in the wireless interface.

Also adds the missing flash partition between `rwfs `and `reservearea `on  the Generic variant.