### PR TITLE
ramips: add support for EDUP EP-RT2983

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -48,6 +48,7 @@ asus,rt-ax53u|\
 asus,rt-ax54|\
 asus,4g-ax56|\
 belkin,rt1800|\
+edup,ep-rt2983|\
 elecom,wrc-x1800gs|\
 h3c,tx1800-plus|\
 h3c,tx1801-plus|\

--- a/target/linux/ramips/dts/mt7621_edup_ep-rt2983.dts
+++ b/target/linux/ramips/dts/mt7621_edup_ep-rt2983.dts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "edup,ep-rt2983", "mediatek,mt7621-soc";
+	model = "EDUP EP-RT2983";
+
+	aliases {
+		label-mac-device = &gmac0;
+
+		led-boot = &led_wps;
+		led-failsafe = &led_system_red;
+		led-upgrade = &led_system_red;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		key-0 {
+			label = "wps";
+			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		key-1 {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_wps: led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WPS;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_system_red: led-2 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_INDICATOR;
+			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_3fff4 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_factory_3fffa 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&nand {
+	status = "okay";
+
+	mediatek,nmbm;
+	mediatek,bmt-remap-range = <0x000000 0x580000>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x80000>;
+		};
+
+		partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0xe00>;
+				};
+
+				macaddr_factory_3fff4: macaddr@3fff4 {
+					compatible = "mac-base";
+					reg = <0x3fff4 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+
+				macaddr_factory_3fffa: macaddr@3fffa {
+					compatible = "mac-base";
+					reg = <0x3fffa 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@180000 {
+			label = "firmware";
+			reg = <0x180000 0x7680000>;
+
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x400000>;
+			};
+
+			partition@400000 {
+				label = "ubi";
+				reg = <0x400000 0x7280000>;
+			};
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+
+		mediatek,disable-radar-background;
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1250,6 +1250,22 @@ define Device/edup_ep-rt2960s
 endef
 TARGET_DEVICES += edup_ep-rt2960s
 
+define Device/edup_ep-rt2983
+  $(Device/dsa-migration)
+  $(Device/nand)
+  IMAGE_SIZE := 121344k
+  DEVICE_VENDOR := EDUP
+  DEVICE_MODEL := EP-RT2983
+  KERNEL_LOADADDR := 0x82000000
+  KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
+	append-ubi | check-size
+  DEVICE_PACKAGES += kmod-mt7915-firmware
+endef
+TARGET_DEVICES += edup_ep-rt2983
+
 define Device/elecom_wrc-gs
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -62,6 +62,7 @@ cudy,ap1300-outdoor-v1)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "lan"
 	;;
 confiabits,mt7621-v1|\
+edup,ep-rt2983|\
 genexis,pulse-ex400|\
 netis,n6)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -15,6 +15,7 @@ ramips_setup_interfaces()
 	confiabits,mt7621-v1|\
 	dlink,dir-x1860-b1|\
 	edup,ep-rt2960s|\
+	edup,ep-rt2983|\
 	gehua,ghl-r-001|\
 	h3c,tx1800-plus|\
 	h3c,tx1801-plus|\

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -74,6 +74,15 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary factory 0x4)" > /sys${DEVPATH}/macaddress
 		;;
+	edup,ep-rt2983|\
+	netis,n6)
+		hw_mac_addr="$(mtd_get_mac_binary Factory 0x4)"
+		hw_mac_addr=$(macaddr_setbit $hw_mac_addr 28)
+		hw_mac_2g=$(macaddr_unsetbit $hw_mac_addr 26)
+		hw_mac_5g=$(macaddr_setbit $hw_mac_addr 27)
+		[ "$PHYNBR" = "0" ] && echo -n "$hw_mac_2g" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && echo -n "$hw_mac_5g" > /sys${DEVPATH}/macaddress
+		;;
 	h3c,tx1800-plus|\
 	h3c,tx1801-plus|\
 	h3c,tx1806)
@@ -132,14 +141,6 @@ case "$board" in
 		hw_mac_addr=$(mtd_get_mac_ascii Config ethaddr)
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
-		;;
-	netis,n6)
-		hw_mac_addr="$(mtd_get_mac_binary Factory 0x4)"
-		hw_mac_addr=$(macaddr_setbit $hw_mac_addr 28)
-		hw_mac_2g=$(macaddr_unsetbit $hw_mac_addr 26)
-		hw_mac_5g=$(macaddr_setbit $hw_mac_addr 27)
-		[ "$PHYNBR" = "0" ] && echo -n "$hw_mac_2g" > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && echo -n "$hw_mac_5g" > /sys${DEVPATH}/macaddress
 		;;
 	mts,wg430223)
 		hw_mac_addr=$(macaddr_add $(mtd_get_mac_encrypted_arcadyan "board_data") 1)

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -96,6 +96,7 @@ platform_do_upgrade() {
 	dlink,dir-853-a3|\
 	dlink,dir-x1860-b1|\
 	edup,ep-rt2960s|\
+	edup,ep-rt2983|\
 	elecom,wmc-x1800gst|\
 	elecom,wsc-x1800gs|\
 	etisalat,s3|\


### PR DESCRIPTION
```
ramips: add support for EDUP EP-RT2983
EDUP EP-RT2983 comes with a factory installed version of OpenWrt 23.05
with device name "netis,n6".

Specification
--------------
- SoC       : MediaTek MT7621AT, MIPS, 880 MHz
- RAM       : 256 MiB
- Flash     : NAND 128 MiB (Toshiba)
- WLAN      : MT7905DAN + MT7975DN
  - 2.4 GHz : b/g/n/ax, 574 Mbps, MIMO 2x2
  - 5 GHz   : a/n/ac/ax, 1201 Mbps, MIMO 2x2
- Ethernet  : 10/100/1000 Mbps x4 (1x WAN, 3x LAN)
- UART      : 3.3V, 115200n8
- Buttons   : 1x Reset
              1x WPS
- LEDs      : 1x Power (green)
              1x WiFi (green)
              1x Mesh/WPS (green); flashing green during boot
              3x LAN (green)
              1x WAN (green); flashing red during upgrade and failsafe
- Power     : 12 VDC 1A

Installation
-------------
1. Log in to LuCI
2. Go to System, Backup / Flash Firmware
3. If desired, backup the current system by saving (all) the mtdblock
contents.
4. Flash new firmware image, select Flash image.
5. Browse and select the sysupgrade file
"openwrt-*-ramips-mt7621-edup_ep-rt2983-squashfs-sysupgrade.bin"
and then Upload.
6. Unselect "Keep settings and retain the current configuration"
Note: All settings will be reset to default. WiFi is not enabled by
default so a connection via Ethernet is necessary to log in and set up.
7. Allow "Force upgrade" (tick the box if there is one), or press Continue
if there is no box to tick. This is because the name is now
"edup,ep-rt2983" as it should have been from the start.
8. Proceed to flash. Wait for reboot and keep power connected.
9. After reboot, default address to access LuCI is 192.168.1.1 with
no password

Recovery (UART)
----------------
1. Remove the 4 screws on the bottom and pry open the cover.
2. Connect serial adapter to the unpopulated serial header pins
TX, RX, GND near the WPS button. Do not connect VCC.
3. Start serial terminal (e.g. minicom, screen, etc) on the computer and
turn on the router.
4. As prompted, hit any key to stop autoboot.
5. Enter 2 to select "2. Upgrade firmware"
6. Enter 0 to select "0 - TFTP client (Default)"
7. Accept the defaults by pressing Enter for
"Input U-Boot's IP address: 192.168.1.1",
"TFTP server's IP address: 192.168.1.2",
"Input IP netmask: 255.255.255.0"
8. Assign your PC's Ethernet port a static IP 192.168.1.2 with netmask
255.255.255.0 and connect to a LAN port on the router using the
Ethernet cable. Disconnect all other network connections (e.g. WiFi) on
the computer.
9. Serve the factory image
"openwrt-*-ramips-mt7621-edup_ep-rt2983-squashfs-factory.bin" using
a TFTP server, e.g. tftpd64. For convenience, the filename can be renamed
to something shorter.
10. In the serial terminal, when prompted "Input file name:", enter the
filename from the previous step and press Enter.
11. The factory image will be flashed as indicated. Wait for reboot.

MAC addresses prototype
------------------------
+---------+---------------------+
|         | MAC example         |
+---------+---------------------+
| LAN     | CC:D8:1F:47:xx:yy   |
| WAN     | CC:D8:1F:47:xx:yy+1 |
| WLAN 2G | CC:D8:1F:17:xx:yy+2 |
| WLAN 5G | CC:D8:1F:77:xx:yy+2 |
+---------+---------------------+

Signed-off-by: Ryan Leung <untilscour@protonmail.com>
```