### PR TITLE
realtek: pcs: combined CMU setup for RTL93xx

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -3427,21 +3427,24 @@ static int rtpcs_931x_sds_cmu_page_get(enum rtpcs_sds_mode hw_mode)
 {
 	switch (hw_mode) {
 	case RTPCS_SDS_MODE_SGMII:
-	case RTPCS_SDS_MODE_1000BASEX:		/* MII_1000BX_FIBER / 100BX_FIBER / 1000BX100BX_AUTO */
-		return 0x24;
-	case RTPCS_SDS_MODE_2500BASEX:		/* MII_2500Base_X: */
-		return 0x28;
-/*	case MII_HISGMII_5G: */
-/*		return 0x2a; */
+	case RTPCS_SDS_MODE_1000BASEX:
+		return 0x24;			/* ANA_1G */
+	case RTPCS_SDS_MODE_2500BASEX:
+		return 0x28;			/* ANA_3G */
 	case RTPCS_SDS_MODE_QSGMII:
-		return 0x2a;			/* Code also has 0x34 */
-/*	case MII_RXAUI_LITE: */
-/*		return 0x2c; */
-	case RTPCS_SDS_MODE_XSGMII:		/* MII_XSGMII */
-	case RTPCS_SDS_MODE_10GBASER:		/* MII_10GR */
-		return 0x2e;
+		return 0x2a;			/* ANA_5G/6G */
+	//	return 0x34;
+	case RTPCS_SDS_MODE_XSGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GDXGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
+	case RTPCS_SDS_MODE_USXGMII_5GSXGMII:
+	case RTPCS_SDS_MODE_USXGMII_5GDXGMII:
+	case RTPCS_SDS_MODE_USXGMII_2_5GSXGMII:
+	case RTPCS_SDS_MODE_10GBASER:
+		return 0x2e;			/* ANA_10G */
 	default:
-		return -EINVAL;
+		return -ENOTSUPP;
 	}
 }
 

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -98,9 +98,6 @@
 #define RTPCS_930X_SDS_SUBMODE_USXGMII_SX	0x0
 #define RTPCS_930X_SDS_SUBMODE_USXGMII_QX	0x2
 
-#define RTPCS_930X_PLL_LC		0x3
-#define RTPCS_930X_PLL_RING		0x1
-
 /* Registers of the internal SerDes of the 9310 */
 #define RTPCS_931X_MAC_GROUP0_1_CTRL		(0x13a4)
 #define RTPCS_931X_MAC_GROUP2_3_CTRL		(0x13a8)
@@ -150,8 +147,8 @@ enum rtpcs_port_media {
 };
 
 enum rtpcs_sds_pll_type {
-	RTPCS_SDS_PLL_TYPE_RING,
-	RTPCS_SDS_PLL_TYPE_LC,
+	RTPCS_SDS_PLL_TYPE_RING = 0,
+	RTPCS_SDS_PLL_TYPE_LC = 1,
 	RTPCS_SDS_PLL_TYPE_END,
 };
 
@@ -1255,7 +1252,9 @@ static void rtpcs_930x_sds_get_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds
 	 */
 
 	pll_val = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, pbit + 1, pbit);
-	*pll = pll_val == RTPCS_930X_PLL_LC ? RTPCS_SDS_PLL_TYPE_LC : RTPCS_SDS_PLL_TYPE_RING;
+
+	/* bit 0 is force-bit, bit 1 is PLL selector */
+	*pll = (enum rtpcs_sds_pll_type)(pll_val >> 1);
 
 	sbit = *pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
 	speed_val = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, sbit + 3, sbit);
@@ -1270,7 +1269,6 @@ static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	int sbit = pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
 	int pbit = (sds == even_sds) ? 4 : 6;
-	int pll_val;
 
 	if (speed >= RTPCS_SDS_PLL_SPD_END)
 		return -EINVAL;
@@ -1287,9 +1285,10 @@ static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_
 	 * always activate both.
 	 */
 
-	pll_val = pll == RTPCS_SDS_PLL_TYPE_LC ? RTPCS_930X_PLL_LC : RTPCS_930X_PLL_RING;
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 0, 0xf);
-	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, pbit + 1, pbit, pll_val);
+
+	/* bit 0 is force-bit, bit 1 is PLL selector */
+	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, pbit + 1, pbit, (pll << 1) | BIT(0));
 
 	/* bit 0 is force-bit, bits [3:1] are speed selector */
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, sbit + 3, sbit, (speed << 1) | BIT(0));

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -1239,28 +1239,49 @@ static void rtpcs_930x_sds_rx_reset(struct rtpcs_serdes *sds,
 	rtpcs_sds_write_bits(sds, page, 0x15, 4, 4, 0x0);
 }
 
-static void rtpcs_930x_sds_get_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type *pll,
+static int rtpcs_930x_sds_get_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type *pll)
+{
+	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
+	int pbit = (sds == even_sds) ? 4 : 6;
+	int pll_sel;
+
+	pll_sel = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, pbit + 1, pbit);
+	if (pll_sel < 0)
+		return pll_sel;
+
+	/* bit 0 is force-bit, bit 1 is PLL selector */
+	*pll = (enum rtpcs_sds_pll_type)(pll_sel >> 1);
+	return 0;
+}
+
+static void rtpcs_930x_sds_get_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
 					enum rtpcs_sds_pll_speed *speed)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
-	int sbit, pbit = (sds == even_sds) ? 4 : 6;
-	int pll_val, speed_val;
+	int sbit, speed_val;
 
 	/*
 	 * PLL data is shared between adjacent SerDes in the even lane. Each SerDes defines
 	 * what PLL it needs (ring or LC) while the PLL itself stores the current speed.
 	 */
 
-	pll_val = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, pbit + 1, pbit);
-
-	/* bit 0 is force-bit, bit 1 is PLL selector */
-	*pll = (enum rtpcs_sds_pll_type)(pll_val >> 1);
-
-	sbit = *pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
+	sbit = pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
 	speed_val = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, sbit + 3, sbit);
 
 	/* bit 0 is force-bit, bits [3:1] are speed selector */
 	*speed = (enum rtpcs_sds_pll_speed)(speed_val >> 1);
+}
+
+static int rtpcs_930x_sds_set_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode,
+					 enum rtpcs_sds_pll_type pll)
+{
+	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
+	int pbit = (sds == even_sds) ? 4 : 6;
+
+	/* Selecting the PLL a SerDes is done in the even lane register */
+
+	/* bit 0 is force-bit, bit 1 is PLL selector */
+	return rtpcs_sds_write_bits(even_sds, 0x20, 0x12, pbit + 1, pbit, (pll << 1) | BIT(0));
 }
 
 static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
@@ -1268,7 +1289,6 @@ static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	int sbit = pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
-	int pbit = (sds == even_sds) ? 4 : 6;
 
 	if (speed >= RTPCS_SDS_PLL_SPD_END)
 		return -EINVAL;
@@ -1287,9 +1307,6 @@ static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_
 
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 0, 0xf);
 
-	/* bit 0 is force-bit, bit 1 is PLL selector */
-	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, pbit + 1, pbit, (pll << 1) | BIT(0));
-
 	/* bit 0 is force-bit, bits [3:1] are speed selector */
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, sbit + 3, sbit, (speed << 1) | BIT(0));
 
@@ -1300,9 +1317,8 @@ static void rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	int reset_sequence[4] = { 3, 2, 3, 1 };
-	enum rtpcs_sds_pll_speed speed;
 	enum rtpcs_sds_pll_type pll;
-	int i, bit;
+	int ret, i, bit;
 
 	/*
 	 * After the PLL speed has changed, the CMU must take over the new values. The models
@@ -1310,7 +1326,10 @@ static void rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
 	 * to flipping two bits in a special sequence.
 	 */
 
-	rtpcs_930x_sds_get_pll_data(sds, &pll, &speed);
+	ret = rtpcs_930x_sds_get_pll_select(sds, &pll);
+	if (ret < 0)
+		return;
+
 	bit = pll == RTPCS_SDS_PLL_TYPE_LC ? 2 : 0;
 
 	for (i = 0; i < ARRAY_SIZE(reset_sequence); i++)
@@ -1366,17 +1385,26 @@ static void rtpcs_930x_sds_set_power(struct rtpcs_serdes *sds, bool on)
 static void rtpcs_930x_sds_reconfigure_pll(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll)
 {
 	enum rtpcs_sds_pll_speed speed;
-	enum rtpcs_sds_pll_type tmp;
-	int mode;
+	enum rtpcs_sds_pll_type old_pll;
+	int mode, ret;
 
 	mode = __rtpcs_930x_sds_get_ip_mode(sds);
-	rtpcs_930x_sds_get_pll_data(sds, &tmp, &speed);
+
+	ret = rtpcs_930x_sds_get_pll_select(sds, &old_pll);
+	if (ret < 0)
+		return;
+
+	rtpcs_930x_sds_get_pll_data(sds, old_pll, &speed);
 
 	rtpcs_930x_sds_set_power(sds, false);
 	__rtpcs_930x_sds_set_ip_mode(sds, RTPCS_930X_SDS_OFF);
 
 	rtpcs_930x_sds_set_pll_data(sds, pll, speed);
 	rtpcs_930x_sds_reset_cmu(sds);
+
+	ret = rtpcs_930x_sds_set_pll_select(sds, sds->hw_mode, pll);
+	if (ret < 0)
+		return;
 
 	__rtpcs_930x_sds_set_ip_mode(sds, mode);
 	if (rtpcs_930x_sds_wait_clock_ready(sds))
@@ -1392,7 +1420,7 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 	enum rtpcs_sds_pll_speed speed, neighbor_speed;
 	enum rtpcs_sds_pll_type pll, neighbor_pll;
 	bool speed_changed = true;
-	int neighbor_mode;
+	int neighbor_mode, ret;
 
 	/*
 	 * A SerDes pair on the RTL930x is driven by two PLLs. A low speed ring PLL can generate
@@ -1414,7 +1442,12 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 	 */
 
 	neighbor_mode = __rtpcs_930x_sds_get_ip_mode(nb_sds);
-	rtpcs_930x_sds_get_pll_data(nb_sds, &neighbor_pll, &neighbor_speed);
+
+	ret = rtpcs_930x_sds_get_pll_select(sds, &neighbor_pll);
+	if (ret < 0)
+		return ret;
+
+	rtpcs_930x_sds_get_pll_data(nb_sds, neighbor_pll, &neighbor_speed);
 
 	if ((hw_mode == RTPCS_SDS_MODE_1000BASEX) ||
 	    (hw_mode == RTPCS_SDS_MODE_SGMII))
@@ -1446,6 +1479,10 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 
 	if (speed_changed)
 		rtpcs_930x_sds_reset_cmu(sds);
+
+	ret = rtpcs_930x_sds_set_pll_select(sds, hw_mode, pll);
+	if (ret < 0)
+		return ret;
 
 	pr_info("%s: SDS %d using %s PLL for mode %d\n", __func__, sds->id,
 		pll == RTPCS_SDS_PLL_TYPE_LC ? "LC" : "ring", hw_mode);

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -153,9 +153,16 @@ enum rtpcs_port_media {
 };
 
 enum rtpcs_sds_pll_type {
-	RTPCS_SDS_PLL_RING,
-	RTPCS_SDS_PLL_LC,
-	RTPCS_SDS_PLL_END,
+	RTPCS_SDS_PLL_TYPE_RING,
+	RTPCS_SDS_PLL_TYPE_LC,
+	RTPCS_SDS_PLL_TYPE_END,
+};
+
+enum rtpcs_sds_pll_speed {
+	RTPCS_SDS_PLL_SPD_1000,
+	RTPCS_SDS_PLL_SPD_2500,
+	RTPCS_SDS_PLL_SPD_10000,
+	RTPCS_SDS_PLL_SPD_END,
 };
 
 enum rtpcs_chip_version {
@@ -1251,9 +1258,9 @@ static void rtpcs_930x_sds_get_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds
 	 */
 
 	pll_val = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, pbit + 1, pbit);
-	*pll = pll_val == RTPCS_930X_PLL_LC ? RTPCS_SDS_PLL_LC : RTPCS_SDS_PLL_RING;
+	*pll = pll_val == RTPCS_930X_PLL_LC ? RTPCS_SDS_PLL_TYPE_LC : RTPCS_SDS_PLL_TYPE_RING;
 
-	sbit = *pll == RTPCS_SDS_PLL_LC ? 8 : 12;
+	sbit = *pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
 	*speed = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, sbit + 3, sbit);
 }
 
@@ -1261,7 +1268,7 @@ static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_
 				       int speed)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
-	int sbit = pll == RTPCS_SDS_PLL_LC ? 8 : 12;
+	int sbit = pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
 	int pbit = (sds == even_sds) ? 4 : 6;
 	int pll_val;
 
@@ -1270,10 +1277,10 @@ static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_
 	    (speed != RTSDS_930X_PLL_10000))
 		return -EINVAL;
 
-	if (pll >= RTPCS_SDS_PLL_END)
+	if (pll >= RTPCS_SDS_PLL_TYPE_END)
 		return -EINVAL;
 
-	if ((pll == RTPCS_SDS_PLL_RING) && (speed == RTSDS_930X_PLL_10000))
+	if ((pll == RTPCS_SDS_PLL_TYPE_RING) && (speed == RTSDS_930X_PLL_10000))
 		return -EINVAL;
 
 	/*
@@ -1282,7 +1289,7 @@ static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_
 	 * always activate both.
 	 */
 
-	pll_val = pll == RTPCS_SDS_PLL_LC ? RTPCS_930X_PLL_LC : RTPCS_930X_PLL_RING;
+	pll_val = pll == RTPCS_SDS_PLL_TYPE_LC ? RTPCS_930X_PLL_LC : RTPCS_930X_PLL_RING;
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 0, 0xf);
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, pbit + 1, pbit, pll_val);
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, sbit + 3, sbit, speed);
@@ -1304,7 +1311,7 @@ static void rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
 	 */
 
 	rtpcs_930x_sds_get_pll_data(sds, &pll, &speed);
-	bit = pll == RTPCS_SDS_PLL_LC ? 2 : 0;
+	bit = pll == RTPCS_SDS_PLL_TYPE_LC ? 2 : 0;
 
 	for (i = 0; i < ARRAY_SIZE(reset_sequence); i++)
 		rtpcs_sds_write_bits(even_sds, 0x21, 0x0b, bit + 1, bit,
@@ -1418,19 +1425,20 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 		return -ENOTSUPP;
 
 	if (!neighbor_mode)
-		pll = speed == RTSDS_930X_PLL_10000 ? RTPCS_SDS_PLL_LC : RTPCS_SDS_PLL_RING;
+		pll = speed == RTSDS_930X_PLL_10000 ? RTPCS_SDS_PLL_TYPE_LC
+						    : RTPCS_SDS_PLL_TYPE_RING;
 	else if (speed == neighbor_speed) {
 		speed_changed = false;
 		pll = neighbor_pll;
-	} else if (neighbor_pll == RTPCS_SDS_PLL_RING)
-		pll = RTPCS_SDS_PLL_LC;
+	} else if (neighbor_pll == RTPCS_SDS_PLL_TYPE_RING)
+		pll = RTPCS_SDS_PLL_TYPE_LC;
 	else if (speed == RTSDS_930X_PLL_10000) {
 		pr_info("%s: SDS %d needs LC PLL, reconfigure SDS %d to use ring PLL\n",
 			__func__, sds->id, nb_sds->id);
-		rtpcs_930x_sds_reconfigure_pll(nb_sds, RTPCS_SDS_PLL_RING);
-		pll = RTPCS_SDS_PLL_LC;
+		rtpcs_930x_sds_reconfigure_pll(nb_sds, RTPCS_SDS_PLL_TYPE_RING);
+		pll = RTPCS_SDS_PLL_TYPE_LC;
 	} else
-		pll = RTPCS_SDS_PLL_RING;
+		pll = RTPCS_SDS_PLL_TYPE_RING;
 
 	rtpcs_930x_sds_set_pll_data(sds, pll, speed);
 
@@ -1438,7 +1446,7 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 		rtpcs_930x_sds_reset_cmu(sds);
 
 	pr_info("%s: SDS %d using %s PLL for mode %d\n", __func__, sds->id,
-		pll == RTPCS_SDS_PLL_LC ? "LC" : "ring", hw_mode);
+		pll == RTPCS_SDS_PLL_TYPE_LC ? "LC" : "ring", hw_mode);
 
 	return 0;
 }
@@ -3363,27 +3371,27 @@ static int rtpcs_931x_sds_config_cmu(struct rtpcs_serdes *sds, enum rtpcs_sds_mo
 		return 0;
 
 	case RTPCS_SDS_MODE_QSGMII:
-		pll_type = RTPCS_SDS_PLL_RING;
+		pll_type = RTPCS_SDS_PLL_TYPE_RING;
 		force_pll_spd = false;
 		break;
 
 	case RTPCS_SDS_MODE_1000BASEX:
-		pll_type = RTPCS_SDS_PLL_RING;
+		pll_type = RTPCS_SDS_PLL_TYPE_RING;
 		force_pll_spd = false;
 		break;
 
 /*	case MII_1000BX100BX_AUTO:
-		pll_type = RTPCS_SDS_PLL_RING;
+		pll_type = RTPCS_SDS_PLL_TYPE_RING;
 		force_pll_spd = false;
 		break; */
 
 	case RTPCS_SDS_MODE_SGMII:
-		pll_type = RTPCS_SDS_PLL_RING;
+		pll_type = RTPCS_SDS_PLL_TYPE_RING;
 		force_pll_spd = false;
 		break;
 
 	case RTPCS_SDS_MODE_2500BASEX:
-		pll_type = RTPCS_SDS_PLL_RING;
+		pll_type = RTPCS_SDS_PLL_TYPE_RING;
 		force_pll_spd = true;
 		break;
 
@@ -3405,10 +3413,10 @@ static int rtpcs_931x_sds_config_cmu(struct rtpcs_serdes *sds, enum rtpcs_sds_mo
 	}
 
 	pr_info("%s: pll_type %s cmu_page %x force_pll_spd %d even_sds %d sds %d\n",
-		__func__, pll_type == RTPCS_SDS_PLL_LC ? "LC" : "ring", cmu_page, force_pll_spd,
-		even_sds->id, sds->id);
+		__func__, pll_type == RTPCS_SDS_PLL_TYPE_LC ? "LC" : "ring", cmu_page,
+		force_pll_spd, even_sds->id, sds->id);
 
-	if (pll_type == RTPCS_SDS_PLL_RING) {
+	if (pll_type == RTPCS_SDS_PLL_TYPE_RING) {
 		rtpcs_sds_write_bits(sds, cmu_page, 0x7, 15, 15, 0x0);
 
 		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 2, 0x3);
@@ -3418,7 +3426,7 @@ static int rtpcs_931x_sds_config_cmu(struct rtpcs_serdes *sds, enum rtpcs_sds_mo
 				     force_lc_mode_val_bit, 0x0);
 		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 12, 12, 0x1);
 		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 15, 13, force_pll_spd ? 0x1 : 0x0);
-	} else if (pll_type == RTPCS_SDS_PLL_LC) {
+	} else if (pll_type == RTPCS_SDS_PLL_TYPE_LC) {
 		rtpcs_sds_write_bits(sds, cmu_page, 0x7, 15, 15, 0x1);
 
 		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 1, 0, 0x3);

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -1312,6 +1312,29 @@ static int rtpcs_930x_sds_set_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sd
 	return rtpcs_sds_write_bits(even_sds, 0x20, 0x12, pbit + 1, pbit, (pll << 1) | BIT(0));
 }
 
+static void rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
+{
+	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
+	int reset_sequence[4] = { 3, 2, 3, 1 };
+	enum rtpcs_sds_pll_type pll;
+	int bit, i, ret;
+
+	/*
+	 * After the PLL speed has changed, the CMU must take over the new values. The models
+	 * of the Otto platform have different reset sequences. Luckily it always boils down
+	 * to flipping two bits in a special sequence.
+	 */
+	ret = rtpcs_930x_sds_get_pll_select(sds, &pll);
+	if (ret < 0)
+		return;
+
+	bit = pll == RTPCS_SDS_PLL_TYPE_LC ? 2 : 0;
+
+	for (i = 0; i < ARRAY_SIZE(reset_sequence); i++)
+		rtpcs_sds_write_bits(even_sds, 0x21, 0x0b, bit + 1, bit,
+				     reset_sequence[i]);
+}
+
 static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
 				       enum rtpcs_sds_pll_speed speed)
 {
@@ -1338,31 +1361,8 @@ static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_
 	/* bit 0 is force-bit, bits [3:1] are speed selector */
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, sbit + 3, sbit, (speed << 1) | BIT(0));
 
+	rtpcs_930x_sds_reset_cmu(sds);
 	return 0;
-}
-
-static void rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
-{
-	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
-	int reset_sequence[4] = { 3, 2, 3, 1 };
-	enum rtpcs_sds_pll_type pll;
-	int ret, i, bit;
-
-	/*
-	 * After the PLL speed has changed, the CMU must take over the new values. The models
-	 * of the Otto platform have different reset sequences. Luckily it always boils down
-	 * to flipping two bits in a special sequence.
-	 */
-
-	ret = rtpcs_930x_sds_get_pll_select(sds, &pll);
-	if (ret < 0)
-		return;
-
-	bit = pll == RTPCS_SDS_PLL_TYPE_LC ? 2 : 0;
-
-	for (i = 0; i < ARRAY_SIZE(reset_sequence); i++)
-		rtpcs_sds_write_bits(even_sds, 0x21, 0x0b, bit + 1, bit,
-				     reset_sequence[i]);
 }
 
 static int rtpcs_930x_sds_wait_clock_ready(struct rtpcs_serdes *sds)
@@ -1428,7 +1428,6 @@ static void rtpcs_930x_sds_reconfigure_pll(struct rtpcs_serdes *sds, enum rtpcs_
 	__rtpcs_930x_sds_set_ip_mode(sds, RTPCS_930X_SDS_OFF);
 
 	rtpcs_930x_sds_set_pll_data(sds, pll, speed);
-	rtpcs_930x_sds_reset_cmu(sds);
 
 	ret = rtpcs_930x_sds_set_pll_select(sds, sds->hw_mode, pll);
 	if (ret < 0)
@@ -1497,10 +1496,8 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 	} else
 		pll = RTPCS_SDS_PLL_TYPE_RING;
 
-	rtpcs_930x_sds_set_pll_data(sds, pll, speed);
-
 	if (speed_changed)
-		rtpcs_930x_sds_reset_cmu(sds);
+		rtpcs_930x_sds_set_pll_data(sds, pll, speed);
 
 	ret = rtpcs_930x_sds_set_pll_select(sds, hw_mode, pll);
 	if (ret < 0)

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -179,6 +179,14 @@ struct rtpcs_serdes_ops {
 	int (*set_autoneg)(struct rtpcs_serdes *sds, unsigned int neg_mode,
 			   const unsigned long *advertising);
 	void (*restart_autoneg)(struct rtpcs_serdes *sds);
+
+	/* CMU management */
+	int (*get_pll_select)(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type *pll);
+	int (*set_pll_select)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode,
+			      enum rtpcs_sds_pll_type pll);
+	int (*reset_cmu)(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll);
+	/* online reconfiguration of a running SerDes to another PLL */
+	int (*reconfigure_to_pll)(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll);
 };
 
 struct rtpcs_sds_reg_field {

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -3448,95 +3448,92 @@ static int rtpcs_931x_sds_cmu_page_get(enum rtpcs_sds_mode hw_mode)
 	}
 }
 
-static int rtpcs_931x_sds_config_cmu(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
+static int rtpcs_931x_sds_get_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type *pll)
+{
+	int cmu_page, pll_sel;
+
+	cmu_page = rtpcs_931x_sds_cmu_page_get(sds->hw_mode);
+	if (cmu_page < 0)
+		return cmu_page;
+
+	pll_sel = rtpcs_sds_read_bits(sds, cmu_page, 0x7, 15, 15);
+	if (pll_sel < 0)
+		return pll_sel;
+
+	*pll = (enum rtpcs_sds_pll_type)pll_sel;
+	return 0;
+}
+
+static int rtpcs_931x_sds_set_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode,
+					 enum rtpcs_sds_pll_type pll)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
-	u32 force_lc_mode_bit, force_lc_mode_val_bit;
-	enum rtpcs_sds_pll_type pll_type; /* SDK calls this cmu_type */
-	bool force_pll_spd;
-	int cmu_page = 0;
-
-	switch (hw_mode) {
-	case RTPCS_SDS_MODE_OFF:
-	case RTPCS_SDS_MODE_XSGMII:
-	case RTPCS_SDS_MODE_10GBASER:
-	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
-	case RTPCS_SDS_MODE_USXGMII_10GDXGMII:
-	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
-	case RTPCS_SDS_MODE_USXGMII_5GSXGMII:
-	case RTPCS_SDS_MODE_USXGMII_5GDXGMII:
-	case RTPCS_SDS_MODE_USXGMII_2_5GSXGMII:
-		return 0;
-
-	case RTPCS_SDS_MODE_QSGMII:
-		pll_type = RTPCS_SDS_PLL_TYPE_RING;
-		force_pll_spd = false;
-		break;
-
-	case RTPCS_SDS_MODE_1000BASEX:
-		pll_type = RTPCS_SDS_PLL_TYPE_RING;
-		force_pll_spd = false;
-		break;
-
-/*	case MII_1000BX100BX_AUTO:
-		pll_type = RTPCS_SDS_PLL_TYPE_RING;
-		force_pll_spd = false;
-		break; */
-
-	case RTPCS_SDS_MODE_SGMII:
-		pll_type = RTPCS_SDS_PLL_TYPE_RING;
-		force_pll_spd = false;
-		break;
-
-	case RTPCS_SDS_MODE_2500BASEX:
-		pll_type = RTPCS_SDS_PLL_TYPE_RING;
-		force_pll_spd = true;
-		break;
-
-	default:
-		pr_info("SerDes %d mode is invalid\n", sds->id);
-		return -EINVAL;
-	}
+	int cmu_page, ret, val;
+	int frc_lc_mode_bit;
 
 	cmu_page = rtpcs_931x_sds_cmu_page_get(hw_mode);
 	if (cmu_page < 0)
-		return -EINVAL;
+		return cmu_page;
 
-	if (sds == even_sds) { 
-		force_lc_mode_bit = 4;
-		force_lc_mode_val_bit = 5;
-	} else {
-		force_lc_mode_bit = 6;
-		force_lc_mode_val_bit = 7;
-	}
+	/*
+	 * bits [5:4] (even) / [7:6] (odd) are used by RTL930x as selector. The selector
+	 * for RTL931x SerDes is in the CMU page of each SerDes, depending on the hardware
+	 * mode.
+	 *
+	 * Here, the SDK calls them 'frc_lc_mode' and 'frc_lc_mode_val'. However, they don't
+	 * seem to have any effect and thus their purpose is unknown. So just set them as
+	 * the SDK does.
+	 */
+	val = (pll == RTPCS_SDS_PLL_TYPE_LC) ? 0x3 : 0x1;
+	frc_lc_mode_bit = (sds == even_sds) ? 4 : 6;
+	ret = rtpcs_sds_write_bits(even_sds, 0x20, 0x12, frc_lc_mode_bit + 1,
+				   frc_lc_mode_bit, val);
+	if (ret < 0)
+		return ret;
 
-	pr_info("%s: pll_type %s cmu_page %x force_pll_spd %d even_sds %d sds %d\n",
-		__func__, pll_type == RTPCS_SDS_PLL_TYPE_LC ? "LC" : "ring", cmu_page,
-		force_pll_spd, even_sds->id, sds->id);
+	return rtpcs_sds_write_bits(sds, cmu_page, 0x7, 15, 15, pll);
+}
 
-	if (pll_type == RTPCS_SDS_PLL_TYPE_RING) {
-		rtpcs_sds_write_bits(sds, cmu_page, 0x7, 15, 15, 0x0);
+static int rtpcs_931x_sds_reconfigure_to_pll(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll)
+{
+	enum rtpcs_sds_pll_type tmp_pll;
+	enum rtpcs_sds_pll_speed speed;
+	enum rtpcs_sds_mode tmp_mode;
+	int ret;
 
-		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 2, 0x3);
-		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, force_lc_mode_bit,
-				     force_lc_mode_bit, 0x1);
-		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, force_lc_mode_val_bit,
-				     force_lc_mode_val_bit, 0x0);
-		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 12, 12, 0x1);
-		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 15, 13, force_pll_spd ? 0x1 : 0x0);
-	} else if (pll_type == RTPCS_SDS_PLL_TYPE_LC) {
-		rtpcs_sds_write_bits(sds, cmu_page, 0x7, 15, 15, 0x1);
+	/* assume we always reconfigure to the other PLL */
+	tmp_pll = (pll == RTPCS_SDS_PLL_TYPE_LC) ? RTPCS_SDS_PLL_TYPE_RING : RTPCS_SDS_PLL_TYPE_LC;
 
-		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 1, 0, 0x3);
-		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, force_lc_mode_bit,
-				     force_lc_mode_bit, 0x1);
-		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, force_lc_mode_val_bit,
-				     force_lc_mode_val_bit, 0x1);
-		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 8, 8, 0x1);
-		rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 11, 9, force_pll_spd ? 0x1 : 0x0);
-	}
+	ret = rtpcs_93xx_sds_get_pll_config(sds, tmp_pll, &speed);
+	if (ret < 0)
+		return ret;
 
-	return 0;
+	tmp_mode = sds->hw_mode;
+
+	/* turn off SerDes for reconfiguration */
+	ret = rtpcs_931x_sds_power(sds, false);
+	if (ret < 0)
+		return ret;
+
+	ret = rtpcs_931x_sds_set_mode(sds, RTPCS_SDS_MODE_OFF);
+	if (ret < 0)
+		return ret;
+
+	/* reconfigure to other PLL */
+	ret = rtpcs_93xx_sds_set_pll_config(sds, pll, speed);
+	if (ret < 0)
+		return ret;
+
+	ret = rtpcs_931x_sds_set_pll_select(sds, sds->hw_mode, pll);
+	if (ret < 0)
+		return ret;
+
+	/* turn on SerDes again */
+	ret = rtpcs_931x_sds_set_mode(sds, tmp_mode);
+	if (ret < 0)
+		return ret;
+
+	return rtpcs_931x_sds_power(sds, true);
 }
 
 static int rtpcs_931x_sds_cmu_band_set(struct rtpcs_serdes *sds,
@@ -3865,7 +3862,7 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 	if (ret < 0)
 		return ret;
 
-	ret = rtpcs_931x_sds_config_cmu(sds, hw_mode);
+	ret = rtpcs_93xx_sds_config_cmu(sds, hw_mode);
 	if (ret < 0)
 		return ret;
 
@@ -4350,6 +4347,9 @@ static const struct rtpcs_serdes_ops rtpcs_931x_sds_ops = {
 	.xsg_write		= rtpcs_931x_sds_op_xsg_write,
 	.set_autoneg		= rtpcs_93xx_sds_set_autoneg,
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
+	.get_pll_select		= rtpcs_931x_sds_get_pll_select,
+	.set_pll_select		= rtpcs_931x_sds_set_pll_select,
+	.reconfigure_to_pll	= rtpcs_931x_sds_reconfigure_to_pll,
 };
 
 static const struct rtpcs_sds_regs rtpcs_931x_sds_regs = {

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -1161,7 +1161,6 @@ static int rtpcs_93xx_sds_set_pll_config(struct rtpcs_serdes *sds, enum rtpcs_sd
 	 * LC PLL. As it is unclear if disabling PLLs has any positive or negative effect,
 	 * always activate both.
 	 */
-
 	ret = rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 0, 0xf);
 	if (ret < 0)
 		return ret;
@@ -1186,23 +1185,38 @@ static int rtpcs_93xx_sds_config_cmu(struct rtpcs_serdes *sds, enum rtpcs_sds_mo
 	int ret;
 
 	/*
-	 * A SerDes pair on the RTL930x is driven by two PLLs. A low speed ring PLL can generate
-	 * signals of 1.25G and 3.125G for link speeds of 1G/2.5G. A high speed LC PLL can
-	 * additionally generate a 10.3125G signal for 10G speeds. To drive the pair at different
-	 * speeds each SerDes must use its own PLL. But what if the SerDess attached to the ring
-	 * PLL suddenly needs 10G but the LC PLL is running at 1G? To avoid reconfiguring the
-	 * "partner" SerDes we must choose wisely what assignment serves the current needs. The
-	 * logic boils down to the following rules:
+	 * A SerDes pair on RTL93xx is driven by a shared CMU with two PLLs:
 	 *
-	 * - Use ring PLL for slow 1G speeds
-	 * - Use LC PLL for fast 10G speeds
-	 * - For 2.5G prefer ring over LC PLL
+	 * - a low speed ring PLL which can generate signals of 1.25G and 3.125G for link
+	 *   speeds of 1G/2.5G
+	 * - a high speed LC PLL which can additionally generate a 10.3125G signal for
+	 *   10G link speeds
 	 *
-	 * However, when we want to configure 10G speed while the other SerDes is already using
-	 * the LC PLL for a slower speed, there is no way to avoid reconfiguration. Note that
-	 * this can even happen when the other SerDes is not actually in use, because changing
-	 * the state of a SerDes back to RTL930X_SDS_OFF is not (yet) implemented.
+	 * To drive the pair at different speeds, each SerDes must use its own PLL and we
+	 * must wisely assign the PLLs to the SerDes based on their needs. The logic boils
+	 * down to the following rules:
+	 *
+	 * - use ring PLL for slow 1G speeds
+	 * - use LC PLL for fast 10G speeds
+	 * - for 2.5G prefer ring over LC PLL
+	 *
+	 * For the case that we want to configure 10G speed but the LC PLL is already used
+	 * by the neighbor SerDes and running with a slower speed, there's no way to avoid
+	 * reconfiguration. The neighbor SerDes is reconfigured online to the ring PLL.
 	 */
+
+	if (hw_mode == RTPCS_SDS_MODE_OFF)
+		return 0;
+
+	ret = rtpcs_sds_select_pll_speed(hw_mode, &speed);
+	if (ret < 0)
+		return ret;
+
+	if (nb_sds->hw_mode == RTPCS_SDS_MODE_OFF) {
+		pll = (speed == RTPCS_SDS_PLL_SPD_10000) ? RTPCS_SDS_PLL_TYPE_LC
+							 : RTPCS_SDS_PLL_TYPE_RING;
+		goto pll_setup;
+	}
 
 	ret = nb_sds->ops->get_pll_select(nb_sds, &neighbor_pll);
 	if (ret < 0)
@@ -1212,14 +1226,7 @@ static int rtpcs_93xx_sds_config_cmu(struct rtpcs_serdes *sds, enum rtpcs_sds_mo
 	if (ret < 0)
 		return ret;
 
-	ret = rtpcs_sds_select_pll_speed(hw_mode, &speed);
-	if (ret < 0)
-		return ret;
-
-	if (nb_sds->hw_mode == RTPCS_SDS_MODE_OFF)
-		pll = speed == RTPCS_SDS_PLL_SPD_10000 ? RTPCS_SDS_PLL_TYPE_LC
-						       : RTPCS_SDS_PLL_TYPE_RING;
-	else if (speed == neighbor_speed) {
+	if (speed == neighbor_speed) {
 		speed_changed = false;
 		pll = neighbor_pll;
 	} else if (neighbor_pll == RTPCS_SDS_PLL_TYPE_RING)
@@ -1227,6 +1234,7 @@ static int rtpcs_93xx_sds_config_cmu(struct rtpcs_serdes *sds, enum rtpcs_sds_mo
 	else if (speed == RTPCS_SDS_PLL_SPD_10000) {
 		pr_info("%s: SDS %d needs LC PLL, reconfigure SDS %d to use ring PLL\n",
 			__func__, sds->id, nb_sds->id);
+
 		ret = nb_sds->ops->reconfigure_to_pll(nb_sds, RTPCS_SDS_PLL_TYPE_RING);
 		if (ret < 0)
 			return ret;
@@ -1235,8 +1243,12 @@ static int rtpcs_93xx_sds_config_cmu(struct rtpcs_serdes *sds, enum rtpcs_sds_mo
 	} else
 		pll = RTPCS_SDS_PLL_TYPE_RING;
 
-	if (speed_changed)
+pll_setup:
+	if (speed_changed) {
 		ret = rtpcs_93xx_sds_set_pll_config(sds, pll, speed);
+		if (ret < 0)
+			return ret;
+	}
 
 	ret = sds->ops->set_pll_select(sds, hw_mode, pll);
 	if (ret < 0)
@@ -1244,7 +1256,6 @@ static int rtpcs_93xx_sds_config_cmu(struct rtpcs_serdes *sds, enum rtpcs_sds_mo
 
 	pr_info("%s: SDS %d using %s PLL for mode %d\n", __func__, sds->id,
 		pll == RTPCS_SDS_PLL_TYPE_LC ? "LC" : "ring", hw_mode);
-
 	return ret;
 }
 

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -1119,6 +1119,135 @@ static int rtpcs_93xx_init_serdes_common(struct rtpcs_ctrl *ctrl)
 	return 0;
 }
 
+static int rtpcs_93xx_sds_get_pll_config(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
+					 enum rtpcs_sds_pll_speed *speed)
+{
+	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
+	int sbit, speed_val;
+
+	/*
+	 * PLL config is shared between adjacent SerDes in the even lane. Each SerDes defines
+	 * what PLL it needs (ring or LC) while the PLL itself stores the current speed.
+	 */
+
+	sbit = pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
+	speed_val = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, sbit + 3, sbit);
+	if (speed_val < 0)
+		return speed_val;
+
+	/* bit 0 is force-bit, bits [3:1] are speed selector */
+	*speed = (enum rtpcs_sds_pll_speed)(speed_val >> 1);
+	return 0;
+}
+
+static int rtpcs_93xx_sds_set_pll_config(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
+					 enum rtpcs_sds_pll_speed speed)
+{
+	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
+	int sbit = pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
+	int ret;
+
+	if (speed >= RTPCS_SDS_PLL_SPD_END)
+		return -EINVAL;
+
+	if (pll >= RTPCS_SDS_PLL_TYPE_END)
+		return -EINVAL;
+
+	if ((pll == RTPCS_SDS_PLL_TYPE_RING) && (speed == RTPCS_SDS_PLL_SPD_10000))
+		return -EINVAL;
+
+	/*
+	 * A SerDes clock can either be taken from the low speed ring PLL or the high speed
+	 * LC PLL. As it is unclear if disabling PLLs has any positive or negative effect,
+	 * always activate both.
+	 */
+
+	ret = rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 0, 0xf);
+	if (ret < 0)
+		return ret;
+
+	/* bit 0 is force-bit, bits [3:1] are speed selector */
+	ret = rtpcs_sds_write_bits(even_sds, 0x20, 0x12, sbit + 3, sbit, (speed << 1) | BIT(0));
+	if (ret < 0)
+		return ret;
+
+	if (sds->ops->reset_cmu)
+		ret = sds->ops->reset_cmu(sds, pll);
+
+	return ret;
+}
+
+static int rtpcs_93xx_sds_config_cmu(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
+{
+	struct rtpcs_serdes *nb_sds = rtpcs_sds_get_neighbor(sds);
+	enum rtpcs_sds_pll_speed speed, neighbor_speed;
+	enum rtpcs_sds_pll_type pll, neighbor_pll;
+	bool speed_changed = true;
+	int ret;
+
+	/*
+	 * A SerDes pair on the RTL930x is driven by two PLLs. A low speed ring PLL can generate
+	 * signals of 1.25G and 3.125G for link speeds of 1G/2.5G. A high speed LC PLL can
+	 * additionally generate a 10.3125G signal for 10G speeds. To drive the pair at different
+	 * speeds each SerDes must use its own PLL. But what if the SerDess attached to the ring
+	 * PLL suddenly needs 10G but the LC PLL is running at 1G? To avoid reconfiguring the
+	 * "partner" SerDes we must choose wisely what assignment serves the current needs. The
+	 * logic boils down to the following rules:
+	 *
+	 * - Use ring PLL for slow 1G speeds
+	 * - Use LC PLL for fast 10G speeds
+	 * - For 2.5G prefer ring over LC PLL
+	 *
+	 * However, when we want to configure 10G speed while the other SerDes is already using
+	 * the LC PLL for a slower speed, there is no way to avoid reconfiguration. Note that
+	 * this can even happen when the other SerDes is not actually in use, because changing
+	 * the state of a SerDes back to RTL930X_SDS_OFF is not (yet) implemented.
+	 */
+
+	ret = nb_sds->ops->get_pll_select(nb_sds, &neighbor_pll);
+	if (ret < 0)
+		return ret;
+
+	ret = rtpcs_93xx_sds_get_pll_config(nb_sds, neighbor_pll, &neighbor_speed);
+	if (ret < 0)
+		return ret;
+
+	ret = rtpcs_sds_select_pll_speed(hw_mode, &speed);
+	if (ret < 0)
+		return ret;
+
+	if (nb_sds->hw_mode == RTPCS_SDS_MODE_OFF)
+		pll = speed == RTPCS_SDS_PLL_SPD_10000 ? RTPCS_SDS_PLL_TYPE_LC
+						       : RTPCS_SDS_PLL_TYPE_RING;
+	else if (speed == neighbor_speed) {
+		speed_changed = false;
+		pll = neighbor_pll;
+	} else if (neighbor_pll == RTPCS_SDS_PLL_TYPE_RING)
+		pll = RTPCS_SDS_PLL_TYPE_LC;
+	else if (speed == RTPCS_SDS_PLL_SPD_10000) {
+		pr_info("%s: SDS %d needs LC PLL, reconfigure SDS %d to use ring PLL\n",
+			__func__, sds->id, nb_sds->id);
+		ret = nb_sds->ops->reconfigure_to_pll(nb_sds, RTPCS_SDS_PLL_TYPE_RING);
+		if (ret < 0)
+			return ret;
+
+		pll = RTPCS_SDS_PLL_TYPE_LC;
+	} else
+		pll = RTPCS_SDS_PLL_TYPE_RING;
+
+	if (speed_changed)
+		ret = rtpcs_93xx_sds_set_pll_config(sds, pll, speed);
+
+	ret = sds->ops->set_pll_select(sds, hw_mode, pll);
+	if (ret < 0)
+		return ret;
+
+	pr_info("%s: SDS %d using %s PLL for mode %d\n", __func__, sds->id,
+		pll == RTPCS_SDS_PLL_TYPE_LC ? "LC" : "ring", hw_mode);
+
+	return ret;
+}
+
 /* RTL930X */
 
 /* 
@@ -1290,27 +1419,6 @@ static int rtpcs_930x_sds_get_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sd
 	return 0;
 }
 
-static int rtpcs_930x_sds_get_pll_config(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
-					  enum rtpcs_sds_pll_speed *speed)
-{
-	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
-	int sbit, speed_val;
-
-	/*
-	 * PLL data is shared between adjacent SerDes in the even lane. Each SerDes defines
-	 * what PLL it needs (ring or LC) while the PLL itself stores the current speed.
-	 */
-
-	sbit = pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
-	speed_val = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, sbit + 3, sbit);
-	if (speed_val < 0)
-		return speed_val;
-
-	/* bit 0 is force-bit, bits [3:1] are speed selector */
-	*speed = (enum rtpcs_sds_pll_speed)(speed_val >> 1);
-	return 0;
-}
-
 static int rtpcs_930x_sds_set_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode,
 					 enum rtpcs_sds_pll_type pll)
 {
@@ -1323,11 +1431,10 @@ static int rtpcs_930x_sds_set_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sd
 	return rtpcs_sds_write_bits(even_sds, 0x20, 0x12, pbit + 1, pbit, (pll << 1) | BIT(0));
 }
 
-static int rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
+static int rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	int reset_sequence[4] = { 3, 2, 3, 1 };
-	enum rtpcs_sds_pll_type pll;
 	int bit, i, ret;
 
 	/*
@@ -1335,9 +1442,6 @@ static int rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
 	 * of the Otto platform have different reset sequences. Luckily it always boils down
 	 * to flipping two bits in a special sequence.
 	 */
-	ret = rtpcs_930x_sds_get_pll_select(sds, &pll);
-	if (ret < 0)
-		return ret;
 
 	bit = pll == RTPCS_SDS_PLL_TYPE_LC ? 2 : 0;
 
@@ -1348,40 +1452,6 @@ static int rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
 			return ret;
 	}
 	return 0;
-}
-
-static int rtpcs_930x_sds_set_pll_config(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
-				         enum rtpcs_sds_pll_speed speed)
-{
-	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
-	int sbit = pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
-	int ret;
-
-	if (speed >= RTPCS_SDS_PLL_SPD_END)
-		return -EINVAL;
-
-	if (pll >= RTPCS_SDS_PLL_TYPE_END)
-		return -EINVAL;
-
-	if ((pll == RTPCS_SDS_PLL_TYPE_RING) && (speed == RTPCS_SDS_PLL_SPD_10000))
-		return -EINVAL;
-
-	/*
-	 * A SerDes clock can either be taken from the low speed ring PLL or the high speed
-	 * LC PLL. As it is unclear if disabling PLLs has any positive or negative effect,
-	 * always activate both.
-	 */
-
-	ret = rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 0, 0xf);
-	if (ret < 0)
-		return ret;
-
-	/* bit 0 is force-bit, bits [3:1] are speed selector */
-	ret = rtpcs_sds_write_bits(even_sds, 0x20, 0x12, sbit + 3, sbit, (speed << 1) | BIT(0));
-	if (ret < 0)
-		return ret;
-
-	return rtpcs_930x_sds_reset_cmu(sds);
 }
 
 static int rtpcs_930x_sds_wait_clock_ready(struct rtpcs_serdes *sds)
@@ -1441,14 +1511,14 @@ static int rtpcs_930x_sds_reconfigure_to_pll(struct rtpcs_serdes *sds, enum rtpc
 	if (ret < 0)
 		return ret;
 
-	ret = rtpcs_930x_sds_get_pll_config(sds, old_pll, &speed);
+	ret = rtpcs_93xx_sds_get_pll_config(sds, old_pll, &speed);
 	if (ret < 0)
 		return ret;
 
 	rtpcs_930x_sds_set_power(sds, false);
 	__rtpcs_930x_sds_set_ip_mode(sds, RTPCS_930X_SDS_OFF);
 
-	ret = rtpcs_930x_sds_set_pll_config(sds, pll, speed);
+	ret = rtpcs_93xx_sds_set_pll_config(sds, pll, speed);
 	if (ret < 0)
 		return ret;
 
@@ -1462,80 +1532,6 @@ static int rtpcs_930x_sds_reconfigure_to_pll(struct rtpcs_serdes *sds, enum rtpc
 
 	rtpcs_930x_sds_set_power(sds, true);
 	return 0;
-}
-
-static int rtpcs_930x_sds_config_cmu(struct rtpcs_serdes *sds,
-				     enum rtpcs_sds_mode hw_mode)
-{
-	struct rtpcs_serdes *nb_sds = rtpcs_sds_get_neighbor(sds);
-	enum rtpcs_sds_pll_speed speed, neighbor_speed;
-	enum rtpcs_sds_pll_type pll, neighbor_pll;
-	bool speed_changed = true;
-	int neighbor_mode, ret;
-
-	/*
-	 * A SerDes pair on the RTL930x is driven by two PLLs. A low speed ring PLL can generate
-	 * signals of 1.25G and 3.125G for link speeds of 1G/2.5G. A high speed LC PLL can
-	 * additionally generate a 10.3125G signal for 10G speeds. To drive the pair at different
-	 * speeds each SerDes must use its own PLL. But what if the SerDess attached to the ring
-	 * PLL suddenly needs 10G but the LC PLL is running at 1G? To avoid reconfiguring the
-	 * "partner" SerDes we must choose wisely what assignment serves the current needs. The
-	 * logic boils down to the following rules:
-	 *
-	 * - Use ring PLL for slow 1G speeds
-	 * - Use LC PLL for fast 10G speeds
-	 * - For 2.5G prefer ring over LC PLL
-	 *
-	 * However, when we want to configure 10G speed while the other SerDes is already using
-	 * the LC PLL for a slower speed, there is no way to avoid reconfiguration. Note that
-	 * this can even happen when the other SerDes is not actually in use, because changing
-	 * the state of a SerDes back to RTL930X_SDS_OFF is not (yet) implemented.
-	 */
-
-	neighbor_mode = __rtpcs_930x_sds_get_ip_mode(nb_sds);
-
-	ret = rtpcs_930x_sds_get_pll_select(sds, &neighbor_pll);
-	if (ret < 0)
-		return ret;
-
-	ret = rtpcs_930x_sds_get_pll_config(nb_sds, neighbor_pll, &neighbor_speed);
-	if (ret < 0)
-		return ret;
-
-	ret = rtpcs_sds_select_pll_speed(hw_mode, &speed);
-	if (ret < 0)
-		return ret;
-
-	if (!neighbor_mode)
-		pll = speed == RTPCS_SDS_PLL_SPD_10000 ? RTPCS_SDS_PLL_TYPE_LC
-						       : RTPCS_SDS_PLL_TYPE_RING;
-	else if (speed == neighbor_speed) {
-		speed_changed = false;
-		pll = neighbor_pll;
-	} else if (neighbor_pll == RTPCS_SDS_PLL_TYPE_RING)
-		pll = RTPCS_SDS_PLL_TYPE_LC;
-	else if (speed == RTPCS_SDS_PLL_SPD_10000) {
-		pr_info("%s: SDS %d needs LC PLL, reconfigure SDS %d to use ring PLL\n",
-			__func__, sds->id, nb_sds->id);
-		ret = rtpcs_930x_sds_reconfigure_to_pll(nb_sds, RTPCS_SDS_PLL_TYPE_RING);
-		if (ret < 0)
-			return ret;
-
-		pll = RTPCS_SDS_PLL_TYPE_LC;
-	} else
-		pll = RTPCS_SDS_PLL_TYPE_RING;
-
-	if (speed_changed)
-		ret = rtpcs_930x_sds_set_pll_config(sds, pll, speed);
-
-	ret = rtpcs_930x_sds_set_pll_select(sds, hw_mode, pll);
-	if (ret < 0)
-		return ret;
-
-	pr_info("%s: SDS %d using %s PLL for mode %d\n", __func__, sds->id,
-		pll == RTPCS_SDS_PLL_TYPE_LC ? "LC" : "ring", hw_mode);
-
-	return ret;
 }
 
 static void rtpcs_930x_sds_reset_state_machine(struct rtpcs_serdes *sds)
@@ -1627,7 +1623,7 @@ static int rtpcs_930x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 	if (hw_mode == RTPCS_SDS_MODE_OFF)
 		return 0;
 
-	ret = rtpcs_930x_sds_config_cmu(sds, hw_mode);
+	ret = rtpcs_93xx_sds_config_cmu(sds, hw_mode);
 	if (ret < 0)
 		pr_err("%s: SDS %d could not configure PLL for mode %d: %d\n", __func__,
 		       sds->id, hw_mode, ret);
@@ -4300,6 +4296,10 @@ static const struct rtpcs_serdes_ops rtpcs_930x_sds_ops = {
 	.xsg_write		= rtpcs_930x_sds_op_xsg_write,
 	.set_autoneg		= rtpcs_93xx_sds_set_autoneg,
 	.restart_autoneg	= rtpcs_generic_sds_restart_autoneg,
+	.get_pll_select		= rtpcs_930x_sds_get_pll_select,
+	.set_pll_select		= rtpcs_930x_sds_set_pll_select,
+	.reset_cmu		= rtpcs_930x_sds_reset_cmu,
+	.reconfigure_to_pll	= rtpcs_930x_sds_reconfigure_to_pll,
 };
 
 static const struct rtpcs_sds_regs rtpcs_930x_sds_regs = {

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -1282,8 +1282,8 @@ static int rtpcs_930x_sds_get_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sd
 	return 0;
 }
 
-static void rtpcs_930x_sds_get_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
-					enum rtpcs_sds_pll_speed *speed)
+static int rtpcs_930x_sds_get_pll_config(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
+					  enum rtpcs_sds_pll_speed *speed)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	int sbit, speed_val;
@@ -1295,9 +1295,12 @@ static void rtpcs_930x_sds_get_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds
 
 	sbit = pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
 	speed_val = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, sbit + 3, sbit);
+	if (speed_val < 0)
+		return speed_val;
 
 	/* bit 0 is force-bit, bits [3:1] are speed selector */
 	*speed = (enum rtpcs_sds_pll_speed)(speed_val >> 1);
+	return 0;
 }
 
 static int rtpcs_930x_sds_set_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode,
@@ -1312,7 +1315,7 @@ static int rtpcs_930x_sds_set_pll_select(struct rtpcs_serdes *sds, enum rtpcs_sd
 	return rtpcs_sds_write_bits(even_sds, 0x20, 0x12, pbit + 1, pbit, (pll << 1) | BIT(0));
 }
 
-static void rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
+static int rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	int reset_sequence[4] = { 3, 2, 3, 1 };
@@ -1326,20 +1329,25 @@ static void rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
 	 */
 	ret = rtpcs_930x_sds_get_pll_select(sds, &pll);
 	if (ret < 0)
-		return;
+		return ret;
 
 	bit = pll == RTPCS_SDS_PLL_TYPE_LC ? 2 : 0;
 
-	for (i = 0; i < ARRAY_SIZE(reset_sequence); i++)
-		rtpcs_sds_write_bits(even_sds, 0x21, 0x0b, bit + 1, bit,
-				     reset_sequence[i]);
+	for (i = 0; i < ARRAY_SIZE(reset_sequence); i++) {
+		ret = rtpcs_sds_write_bits(even_sds, 0x21, 0x0b, bit + 1, bit,
+					   reset_sequence[i]);
+		if (ret < 0)
+			return ret;
+	}
+	return 0;
 }
 
-static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
-				       enum rtpcs_sds_pll_speed speed)
+static int rtpcs_930x_sds_set_pll_config(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
+				         enum rtpcs_sds_pll_speed speed)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	int sbit = pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
+	int ret;
 
 	if (speed >= RTPCS_SDS_PLL_SPD_END)
 		return -EINVAL;
@@ -1356,13 +1364,16 @@ static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_
 	 * always activate both.
 	 */
 
-	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 0, 0xf);
+	ret = rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 0, 0xf);
+	if (ret < 0)
+		return ret;
 
 	/* bit 0 is force-bit, bits [3:1] are speed selector */
-	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, sbit + 3, sbit, (speed << 1) | BIT(0));
+	ret = rtpcs_sds_write_bits(even_sds, 0x20, 0x12, sbit + 3, sbit, (speed << 1) | BIT(0));
+	if (ret < 0)
+		return ret;
 
-	rtpcs_930x_sds_reset_cmu(sds);
-	return 0;
+	return rtpcs_930x_sds_reset_cmu(sds);
 }
 
 static int rtpcs_930x_sds_wait_clock_ready(struct rtpcs_serdes *sds)
@@ -1410,7 +1421,7 @@ static void rtpcs_930x_sds_set_power(struct rtpcs_serdes *sds, bool on)
 	rtpcs_sds_write_bits(sds, 0x20, 0x00, 5, 4, rx_enable);
 }
 
-static void rtpcs_930x_sds_reconfigure_pll(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll)
+static int rtpcs_930x_sds_reconfigure_to_pll(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll)
 {
 	enum rtpcs_sds_pll_speed speed;
 	enum rtpcs_sds_pll_type old_pll;
@@ -1420,27 +1431,32 @@ static void rtpcs_930x_sds_reconfigure_pll(struct rtpcs_serdes *sds, enum rtpcs_
 
 	ret = rtpcs_930x_sds_get_pll_select(sds, &old_pll);
 	if (ret < 0)
-		return;
+		return ret;
 
-	rtpcs_930x_sds_get_pll_data(sds, old_pll, &speed);
+	ret = rtpcs_930x_sds_get_pll_config(sds, old_pll, &speed);
+	if (ret < 0)
+		return ret;
 
 	rtpcs_930x_sds_set_power(sds, false);
 	__rtpcs_930x_sds_set_ip_mode(sds, RTPCS_930X_SDS_OFF);
 
-	rtpcs_930x_sds_set_pll_data(sds, pll, speed);
+	ret = rtpcs_930x_sds_set_pll_config(sds, pll, speed);
+	if (ret < 0)
+		return ret;
 
 	ret = rtpcs_930x_sds_set_pll_select(sds, sds->hw_mode, pll);
 	if (ret < 0)
-		return;
+		return ret;
 
 	__rtpcs_930x_sds_set_ip_mode(sds, mode);
 	if (rtpcs_930x_sds_wait_clock_ready(sds))
 		pr_err("%s: SDS %d could not sync clock\n", __func__, sds->id);
 
 	rtpcs_930x_sds_set_power(sds, true);
+	return 0;
 }
 
-static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
+static int rtpcs_930x_sds_config_cmu(struct rtpcs_serdes *sds,
 				     enum rtpcs_sds_mode hw_mode)
 {
 	struct rtpcs_serdes *nb_sds = rtpcs_sds_get_neighbor(sds);
@@ -1474,7 +1490,9 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 	if (ret < 0)
 		return ret;
 
-	rtpcs_930x_sds_get_pll_data(nb_sds, neighbor_pll, &neighbor_speed);
+	ret = rtpcs_930x_sds_get_pll_config(nb_sds, neighbor_pll, &neighbor_speed);
+	if (ret < 0)
+		return ret;
 
 	ret = rtpcs_sds_select_pll_speed(hw_mode, &speed);
 	if (ret < 0)
@@ -1491,13 +1509,16 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 	else if (speed == RTPCS_SDS_PLL_SPD_10000) {
 		pr_info("%s: SDS %d needs LC PLL, reconfigure SDS %d to use ring PLL\n",
 			__func__, sds->id, nb_sds->id);
-		rtpcs_930x_sds_reconfigure_pll(nb_sds, RTPCS_SDS_PLL_TYPE_RING);
+		ret = rtpcs_930x_sds_reconfigure_to_pll(nb_sds, RTPCS_SDS_PLL_TYPE_RING);
+		if (ret < 0)
+			return ret;
+
 		pll = RTPCS_SDS_PLL_TYPE_LC;
 	} else
 		pll = RTPCS_SDS_PLL_TYPE_RING;
 
 	if (speed_changed)
-		rtpcs_930x_sds_set_pll_data(sds, pll, speed);
+		ret = rtpcs_930x_sds_set_pll_config(sds, pll, speed);
 
 	ret = rtpcs_930x_sds_set_pll_select(sds, hw_mode, pll);
 	if (ret < 0)
@@ -1506,7 +1527,7 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 	pr_info("%s: SDS %d using %s PLL for mode %d\n", __func__, sds->id,
 		pll == RTPCS_SDS_PLL_TYPE_LC ? "LC" : "ring", hw_mode);
 
-	return 0;
+	return ret;
 }
 
 static void rtpcs_930x_sds_reset_state_machine(struct rtpcs_serdes *sds)
@@ -1598,9 +1619,10 @@ static int rtpcs_930x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 	if (hw_mode == RTPCS_SDS_MODE_OFF)
 		return 0;
 
-	if (rtpcs_930x_sds_config_pll(sds, hw_mode))
-		pr_err("%s: SDS %d could not configure PLL for mode %d\n", __func__,
-		       sds->id, hw_mode);
+	ret = rtpcs_930x_sds_config_cmu(sds, hw_mode);
+	if (ret < 0)
+		pr_err("%s: SDS %d could not configure PLL for mode %d: %d\n", __func__,
+		       sds->id, hw_mode, ret);
 
 	ret = __rtpcs_930x_sds_set_ip_mode(sds, mode_val);
 	if (ret < 0)

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -516,6 +516,34 @@ static void rtpcs_generic_sds_restart_autoneg(struct rtpcs_serdes *sds)
 	rtpcs_sds_write_field(sds, &sds->regs->an_restart, 0x1);
 }
 
+static int rtpcs_sds_select_pll_speed(enum rtpcs_sds_mode hw_mode, enum rtpcs_sds_pll_speed *speed)
+{
+	switch (hw_mode) {
+	case RTPCS_SDS_MODE_1000BASEX:
+	case RTPCS_SDS_MODE_SGMII:
+	case RTPCS_SDS_MODE_QSGMII:
+		*speed = RTPCS_SDS_PLL_SPD_1000;
+		break;
+	case RTPCS_SDS_MODE_2500BASEX:
+		*speed = RTPCS_SDS_PLL_SPD_2500;
+		break;
+	case RTPCS_SDS_MODE_10GBASER:
+	case RTPCS_SDS_MODE_XSGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GDXGMII:
+	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
+	case RTPCS_SDS_MODE_USXGMII_5GSXGMII:
+	case RTPCS_SDS_MODE_USXGMII_5GDXGMII:
+	case RTPCS_SDS_MODE_USXGMII_2_5GSXGMII:
+		*speed = RTPCS_SDS_PLL_SPD_10000;
+		break;
+	default:
+		return -ENOTSUPP;
+	}
+
+	return 0;
+}
+
 /* Variant-specific functions */
 
 /* RTL838X */
@@ -1449,15 +1477,9 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 
 	rtpcs_930x_sds_get_pll_data(nb_sds, neighbor_pll, &neighbor_speed);
 
-	if ((hw_mode == RTPCS_SDS_MODE_1000BASEX) ||
-	    (hw_mode == RTPCS_SDS_MODE_SGMII))
-		speed = RTPCS_SDS_PLL_SPD_1000;
-	else if (hw_mode == RTPCS_SDS_MODE_2500BASEX)
-		speed = RTPCS_SDS_PLL_SPD_2500;
-	else if (hw_mode == RTPCS_SDS_MODE_10GBASER)
-		speed = RTPCS_SDS_PLL_SPD_10000;
-	else
-		return -ENOTSUPP;
+	ret = rtpcs_sds_select_pll_speed(hw_mode, &speed);
+	if (ret < 0)
+		return ret;
 
 	if (!neighbor_mode)
 		pll = speed == RTPCS_SDS_PLL_SPD_10000 ? RTPCS_SDS_PLL_TYPE_LC

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -98,9 +98,6 @@
 #define RTPCS_930X_SDS_SUBMODE_USXGMII_SX	0x0
 #define RTPCS_930X_SDS_SUBMODE_USXGMII_QX	0x2
 
-#define RTSDS_930X_PLL_1000		0x1
-#define RTSDS_930X_PLL_10000		0x5
-#define RTSDS_930X_PLL_2500		0x3
 #define RTPCS_930X_PLL_LC		0x3
 #define RTPCS_930X_PLL_RING		0x1
 
@@ -159,9 +156,9 @@ enum rtpcs_sds_pll_type {
 };
 
 enum rtpcs_sds_pll_speed {
-	RTPCS_SDS_PLL_SPD_1000,
-	RTPCS_SDS_PLL_SPD_2500,
-	RTPCS_SDS_PLL_SPD_10000,
+	RTPCS_SDS_PLL_SPD_1000 = 0,
+	RTPCS_SDS_PLL_SPD_2500 = 1,
+	RTPCS_SDS_PLL_SPD_10000 = 2,
 	RTPCS_SDS_PLL_SPD_END,
 };
 
@@ -1246,11 +1243,11 @@ static void rtpcs_930x_sds_rx_reset(struct rtpcs_serdes *sds,
 }
 
 static void rtpcs_930x_sds_get_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type *pll,
-					int *speed)
+					enum rtpcs_sds_pll_speed *speed)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	int sbit, pbit = (sds == even_sds) ? 4 : 6;
-	int pll_val;
+	int pll_val, speed_val;
 
 	/*
 	 * PLL data is shared between adjacent SerDes in the even lane. Each SerDes defines
@@ -1261,26 +1258,27 @@ static void rtpcs_930x_sds_get_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds
 	*pll = pll_val == RTPCS_930X_PLL_LC ? RTPCS_SDS_PLL_TYPE_LC : RTPCS_SDS_PLL_TYPE_RING;
 
 	sbit = *pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
-	*speed = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, sbit + 3, sbit);
+	speed_val = rtpcs_sds_read_bits(even_sds, 0x20, 0x12, sbit + 3, sbit);
+
+	/* bit 0 is force-bit, bits [3:1] are speed selector */
+	*speed = (enum rtpcs_sds_pll_speed)(speed_val >> 1);
 }
 
 static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll,
-				       int speed)
+				       enum rtpcs_sds_pll_speed speed)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	int sbit = pll == RTPCS_SDS_PLL_TYPE_LC ? 8 : 12;
 	int pbit = (sds == even_sds) ? 4 : 6;
 	int pll_val;
 
-	if ((speed != RTSDS_930X_PLL_1000) &&
-	    (speed != RTSDS_930X_PLL_2500) &&
-	    (speed != RTSDS_930X_PLL_10000))
+	if (speed >= RTPCS_SDS_PLL_SPD_END)
 		return -EINVAL;
 
 	if (pll >= RTPCS_SDS_PLL_TYPE_END)
 		return -EINVAL;
 
-	if ((pll == RTPCS_SDS_PLL_TYPE_RING) && (speed == RTSDS_930X_PLL_10000))
+	if ((pll == RTPCS_SDS_PLL_TYPE_RING) && (speed == RTPCS_SDS_PLL_SPD_10000))
 		return -EINVAL;
 
 	/*
@@ -1292,7 +1290,9 @@ static int rtpcs_930x_sds_set_pll_data(struct rtpcs_serdes *sds, enum rtpcs_sds_
 	pll_val = pll == RTPCS_SDS_PLL_TYPE_LC ? RTPCS_930X_PLL_LC : RTPCS_930X_PLL_RING;
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, 3, 0, 0xf);
 	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, pbit + 1, pbit, pll_val);
-	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, sbit + 3, sbit, speed);
+
+	/* bit 0 is force-bit, bits [3:1] are speed selector */
+	rtpcs_sds_write_bits(even_sds, 0x20, 0x12, sbit + 3, sbit, (speed << 1) | BIT(0));
 
 	return 0;
 }
@@ -1301,8 +1301,9 @@ static void rtpcs_930x_sds_reset_cmu(struct rtpcs_serdes *sds)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	int reset_sequence[4] = { 3, 2, 3, 1 };
+	enum rtpcs_sds_pll_speed speed;
 	enum rtpcs_sds_pll_type pll;
-	int speed, i, bit;
+	int i, bit;
 
 	/*
 	 * After the PLL speed has changed, the CMU must take over the new values. The models
@@ -1365,8 +1366,9 @@ static void rtpcs_930x_sds_set_power(struct rtpcs_serdes *sds, bool on)
 
 static void rtpcs_930x_sds_reconfigure_pll(struct rtpcs_serdes *sds, enum rtpcs_sds_pll_type pll)
 {
+	enum rtpcs_sds_pll_speed speed;
 	enum rtpcs_sds_pll_type tmp;
-	int mode, speed;
+	int mode;
 
 	mode = __rtpcs_930x_sds_get_ip_mode(sds);
 	rtpcs_930x_sds_get_pll_data(sds, &tmp, &speed);
@@ -1388,9 +1390,10 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 				     enum rtpcs_sds_mode hw_mode)
 {
 	struct rtpcs_serdes *nb_sds = rtpcs_sds_get_neighbor(sds);
+	enum rtpcs_sds_pll_speed speed, neighbor_speed;
 	enum rtpcs_sds_pll_type pll, neighbor_pll;
-	int speed, neighbor_speed, neighbor_mode;
 	bool speed_changed = true;
+	int neighbor_mode;
 
 	/*
 	 * A SerDes pair on the RTL930x is driven by two PLLs. A low speed ring PLL can generate
@@ -1416,23 +1419,23 @@ static int rtpcs_930x_sds_config_pll(struct rtpcs_serdes *sds,
 
 	if ((hw_mode == RTPCS_SDS_MODE_1000BASEX) ||
 	    (hw_mode == RTPCS_SDS_MODE_SGMII))
-		speed = RTSDS_930X_PLL_1000;
+		speed = RTPCS_SDS_PLL_SPD_1000;
 	else if (hw_mode == RTPCS_SDS_MODE_2500BASEX)
-		speed = RTSDS_930X_PLL_2500;
+		speed = RTPCS_SDS_PLL_SPD_2500;
 	else if (hw_mode == RTPCS_SDS_MODE_10GBASER)
-		speed = RTSDS_930X_PLL_10000;
+		speed = RTPCS_SDS_PLL_SPD_10000;
 	else
 		return -ENOTSUPP;
 
 	if (!neighbor_mode)
-		pll = speed == RTSDS_930X_PLL_10000 ? RTPCS_SDS_PLL_TYPE_LC
-						    : RTPCS_SDS_PLL_TYPE_RING;
+		pll = speed == RTPCS_SDS_PLL_SPD_10000 ? RTPCS_SDS_PLL_TYPE_LC
+						       : RTPCS_SDS_PLL_TYPE_RING;
 	else if (speed == neighbor_speed) {
 		speed_changed = false;
 		pll = neighbor_pll;
 	} else if (neighbor_pll == RTPCS_SDS_PLL_TYPE_RING)
 		pll = RTPCS_SDS_PLL_TYPE_LC;
-	else if (speed == RTSDS_930X_PLL_10000) {
+	else if (speed == RTPCS_SDS_PLL_SPD_10000) {
 		pr_info("%s: SDS %d needs LC PLL, reconfigure SDS %d to use ring PLL\n",
 			__func__, sds->id, nb_sds->id);
 		rtpcs_930x_sds_reconfigure_pll(nb_sds, RTPCS_SDS_PLL_TYPE_RING);


### PR DESCRIPTION
This series makes the CMU setup currently implemented for RTL930x generic and usable for RTL931x since the logic is needed there too, most details are shared and the current CMU setup for RTL931x is incomplete and lacks logic for specific cases when running adjacent SerDes on different speeds (which was already an issue on RTL930x).

---

This is most likely not the forever final state. The last PRs were rather targeted on improving the features. You can't make an omelette without breaking eggs so there will be several cleanups after this trying to bring this more into a good shape.