### PR TITLE
target: imx: cortexa53: add sysupgrade for additional venice boards

### DIFF
--- a/target/linux/imx/cortexa53/base-files/lib/upgrade/platform.sh
+++ b/target/linux/imx/cortexa53/base-files/lib/upgrade/platform.sh
@@ -1,6 +1,7 @@
 
 enable_image_metadata_check() {
 	case "$(board_name)" in
+	gateworks,imx8m*|\
 	gw,imx8m*)
 		REQUIRE_IMAGE_METADATA=1
 		;;

--- a/target/linux/imx/image/cortexa53.mk
+++ b/target/linux/imx/image/cortexa53.mk
@@ -58,7 +58,11 @@ define Device/gateworks_venice
 	gw,imx8mn-gw7902 \
 	gw,imx8mm-gw7903 \
 	gateworks,imx8mp-gw71xx-2x \
+	gateworks,imx8mp-gw72xx-2x \
+	gateworks,imx8mp-gw73xx-2x \
 	gateworks,imx8mp-gw74xx \
+	gateworks,imx8mm-gw75xx-0x \
+	gateworks,imx8mp-gw75xx-2x \
 	gateworks,imx8mm-gw7904 \
 	gateworks,imx8mm-gw7905-0x \
 	gateworks,imx8mp-gw7905-2x


### PR DESCRIPTION
Add some additional Gateworks Venice boards to sysupgrade support.

This should backport cleanly to 25.12 and 24.10 branches.