### PR TITLE
mpc85xx: add initial DTS support for RB1100AHx2 (P2020) (Draft)

### DIFF
--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/rb1100ahx2.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/rb1100ahx2.dts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * MikroTik RouterBOARD 1100AHx2 Device Tree Source File
+ *
+ * Copyright (C) 2026 Abdulkader Alrezej
+ */
+
+/dts-v1/;
+
+/include/ "fsl/p2020si-pre.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "MikroTik RouterBOARD 1100AHx2";
+	compatible = "mikrotik,routerboard-1100ahx2", "fsl,p2020";
+
+	aliases {
+		ethernet0 = &enet0;
+		ethernet1 = &enet2;
+		serial0 = &serial0;
+		serial1 = &serial1;
+	};
+
+	chosen {
+		bootargs-override = "console=ttyS0,115200 root=/dev/mtdblock2";
+	};
+
+	memory {
+		device_type = "memory";
+	};
+
+	lbc: localbus@ffe05000 {
+		reg = <0 0xffe05000 0 0x1000>;
+
+		/* NAND Flash */
+		ranges = <0x1 0x0 0x0 0xffa00000 0x00040000>;
+
+		nand@1,0 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			compatible = "fsl,p2020-fcm-nand", "fsl,elbc-fcm-nand";
+			reg = <0x1 0x0 0x40000>;
+
+			partitions {
+				compatible = "fixed-partitions";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "boot";
+					reg = <0x00000000 0x00800000>;
+				};
+
+				partition@800000 {
+					label = "main";
+					reg = <0x00800000 0x07800000>;
+				};
+			};
+		};
+	};
+
+	soc: soc@ffe00000 {
+		ranges = <0x0 0x0 0xffe00000 0x100000>;
+
+		gpio0: gpio-controller@fc00 {
+		};
+
+		i2c@3000 {
+		};
+
+		mdio@24520 {
+			status = "okay";
+
+			switch0: switch@0 {
+				compatible = "qca,qca8327";
+				reg = <0>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					port@0 {
+						reg = <0>;
+						label = "cpu0";
+						phy-mode = "rgmii-id";
+						ethernet = <&enet0>;
+
+						fixed-link {
+							speed = <1000>;
+							full-duplex;
+						};
+					};
+
+					port@1 { reg = <1>; label = "eth1"; };
+					port@2 { reg = <2>; label = "eth2"; };
+					port@3 { reg = <3>; label = "eth3"; };
+					port@4 { reg = <4>; label = "eth4"; };
+					port@5 { reg = <5>; label = "eth5"; };
+				};
+			};
+
+			switch1: switch@1 {
+				compatible = "qca,qca8327";
+				reg = <1>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					port@0 {
+						reg = <0>;
+						label = "cpu0";
+						phy-mode = "rgmii-id";
+						ethernet = <&eth_pcie0>;
+
+						fixed-link {
+							speed = <1000>;
+							full-duplex;
+						};
+					};
+
+					port@1 { reg = <1>; label = "eth6"; };
+					port@2 { reg = <2>; label = "eth7"; };
+					port@3 { reg = <3>; label = "eth8"; };
+					port@4 { reg = <4>; label = "eth9"; };
+					port@5 { reg = <5>; label = "eth10"; };
+				};
+			};
+
+			switch2: switch@2 {
+				compatible = "qca,qca8327";
+				reg = <2>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					port@0 {
+						reg = <0>;
+						label = "cpu0";
+						phy-mode = "rgmii-id";
+						ethernet = <&eth_pcie1>;
+
+						fixed-link {
+							speed = <1000>;
+							full-duplex;
+						};
+					};
+
+					port@1 { reg = <1>; label = "eth11"; };
+					port@2 { reg = <2>; label = "eth12"; };
+					port@3 { reg = <3>; label = "eth13"; };
+				};
+			};
+		};
+
+		enet0: ethernet@24000 {
+			phy-connection-type = "rgmii-id";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+
+		enet1: ethernet@25000 {
+			status = "disabled";
+		};
+
+		enet2: ethernet@26000 {
+			status = "disabled";
+		};
+	};
+
+	pci0: pcie@ffe08000 {
+		reg = <0 0xffe08000 0 0x1000>;
+		ranges  = <0x2000000 0x0 0xc0000000 0x0 0xc0000000 0x0 0x20000000
+				   0x1000000 0x0 0x00000000 0x0 0xffc20000 0x0 0x10000>;
+		status = "okay";
+
+		pcie@0 {
+			ranges = <  0x2000000 0x0 0xc0000000
+						0x2000000 0x0 0xc0000000
+						0x0 0x20000000
+
+						0x1000000 0x0 0x0
+						0x1000000 0x0 0x0
+						0x0 0x100000>;
+
+			eth_pcie0: ethernet@0,0 {
+				compatible = "qca,ar8151";
+				reg = <0x0000 0 0 0 0>;
+			};
+		};
+	};
+
+	pci1: pcie@ffe09000 {
+		reg = <0 0xffe09000 0 0x1000>;
+		ranges = <0x2000000 0x0 0xa0000000 0 0xa0000000 0x0 0x20000000
+				  0x1000000 0x0 0x00000000 0 0xffc10000 0x0 0x10000>;
+		status = "okay";
+
+		pcie@0 {
+			ranges = <  0x2000000 0x0 0xa0000000
+						0x2000000 0x0 0xa0000000
+						0x0 0x20000000
+
+						0x1000000 0x0 0x0
+						0x1000000 0x0 0x0
+						0x0 0x100000>;
+			
+			eth_pcie1: ethernet@0,0 {
+				compatible = "qca,ar8151";
+				reg = <0x0000 0 0 0 0>;
+			};
+		};
+	};
+
+	pci2: pcie@ffe0a000 {
+		status = "disabled";
+	};
+};
+
+/include/ "fsl/p2020si-post.dtsi"

--- a/target/linux/mpc85xx/image/p2020.mk
+++ b/target/linux/mpc85xx/image/p2020.mk
@@ -29,3 +29,22 @@ define Device/watchguard_xtm330
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += watchguard_xtm330
+
+define Device/mikrotik_rb1100ahx2
+  DEVICE_VENDOR := MikroTik
+  DEVICE_MODEL := RouterBOARD 1100AHx2
+  DEVICE_DTS := rb1100ahx2
+  DEVICE_PACKAGES := kmod-dsa-qca8k kmod-alx \
+    kmod-phy-qca83xx kmod-libphy kmod-mii \
+    kmod-fixed-phy kmod-phylink kmod-phy-at803x
+  BLOCKSIZE := 128k
+  KERNEL_IN_UBI := 1
+  KERNEL = kernel-bin | fit none $$(KDIR)/image-$$(DEVICE_DTS).dtb
+  KERNEL_NAME := zImage.la3000000
+  KERNEL_ENTRY := 0x3000000
+  KERNEL_LOADADDR := 0x3000000
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | \
+	pad-rootfs $$(BLOCKSIZE) | append-metadata
+endef
+TARGET_DEVICES += mikrotik_rb1100ahx2


### PR DESCRIPTION
Add initial Device Tree Source (DTS) support for the MikroTik RouterBOARD 1100AHx2 platform.

Hardware overview:

* NXP QorIQ P2020 PowerPC SoC
* 2GB DDR2 SODIMM memory
* 128MB NAND flash storage
* microSD storage slot
* DB9 serial console interface
* Three AR8327-based Gigabit Ethernet switches
* PCIe-attached AR8151 network controllers
* Integrated PSU supporting 12–24V input

Status:
This is an early-stage hardware description draft.

The following subsystems require validation on real hardware:

* UART boot and console stability
* NAND flash ECC and partition layout
* Ethernet switch topology and DSA configuration
* MAC address storage handling
* GPIO mapping (LED indicators, reset button, buzzer)
* Sysupgrade workflow compatibility

Testing status:

* Kernel boot: Not fully verified
* Networking: Pending hardware verification
* NAND flash requires validation of factory layout and ECC scheme

This submission is intended to start community discussion and hardware review.

Thanks for reviewing this draft.

<img width="600" height="706" alt="Block-RB1100AHx2_130548" src="https://github.com/user-attachments/assets/82760a35-8fe5-4de0-91ec-fe39521fc254" />
