### PR TITLE
realtek: pending upstream rtl9300 i2c speed patch

### DIFF
--- a/target/linux/realtek/patches-6.12/100-rtl9300-i2c-add-more-speeds.patch
+++ b/target/linux/realtek/patches-6.12/100-rtl9300-i2c-add-more-speeds.patch
@@ -1,0 +1,52 @@
+From linux-i2c  Fri Feb 27 11:11:34 2026
+From: Jan Kantert <jan-kernel () kantert ! net>
+Date: Fri, 27 Feb 2026 11:11:34 +0000
+To: linux-i2c
+Subject: [PATCH] i2c: rtl9300: add support for 50 kHz and 2.5 MHz bus speeds
+Message-Id: <20260227111134.2163701-1-jan-kernel () kantert ! net>
+X-MARC-Message: https://marc.info/?l=linux-i2c&m=177219358420283
+
+Some SFP modules on certain switches (for example the ONTi ONT-S508CL-8S and
+XikeStor SKS8300-8X) exhibit unreliable I2C communication at the currently
+supported speeds. Add support for 50 kHz and 2.5 MHz I2C bus modes on the
+RTL9300 to improve compatibility with these devices.
+
+Signed-off-by: Jan Kantert <jan-kernel@kantert.net>
+---
+ drivers/i2c/busses/i2c-rtl9300.c | 16 ++++++++++++++--
+ 1 file changed, 14 insertions(+), 2 deletions(-)
+
+--- a/drivers/i2c/busses/i2c-rtl9300.c
++++ b/drivers/i2c/busses/i2c-rtl9300.c
+@@ -11,10 +11,16 @@
+ #include <linux/unaligned.h>
+ 
+ enum rtl9300_bus_freq {
+-	RTL9300_I2C_STD_FREQ,
+-	RTL9300_I2C_FAST_FREQ,
++	RTL9300_I2C_STD_FREQ,			// 100kHz
++	RTL9300_I2C_FAST_FREQ,			// 400kHz
++	RTL9300_I2C_SUPER_FAST_FREQ,		// 2.5MHz
++	RTL9300_I2C_SLOW_FREQ,			// 50kHz
+ };
+ 
++#define RTL9300_I2C_MAX_SUPER_FAST_FREQ		2500000
++#define RTL9300_I2C_MAX_SLOW_FREQ		50000
++
++
+ struct rtl9300_i2c;
+ 
+ struct rtl9300_i2c_chan {
+@@ -434,6 +440,12 @@ static int rtl9300_i2c_probe(struct plat
+ 		case I2C_MAX_FAST_MODE_FREQ:
+ 			chan->bus_freq = RTL9300_I2C_FAST_FREQ;
+ 			break;
++		case RTL9300_I2C_MAX_SUPER_FAST_FREQ:
++			chan->bus_freq = RTL9300_I2C_SUPER_FAST_FREQ;
++			break;
++		case RTL9300_I2C_MAX_SLOW_FREQ:
++			chan->bus_freq = RTL9300_I2C_SLOW_FREQ;
++			break;
+ 		default:
+ 			dev_warn(i2c->dev, "SDA%d clock-frequency %d not supported using default\n",
+ 				 sda_num, clock_freq);


### PR DESCRIPTION
Some 10G optics showed random "module transmit fault indicated" due to I2C read errors on ONTi ONT-S508CL-8S/XikeStor SKS8300-8X switches. The same modules work with the original firmware and on other Linux based devices.

There seems to be some differences in how we talk to those modules using I2C in OpenWRT. To fix this this patch adds support for 50kHz I2C speed on SFPs and enables that for XikeStor/Onti devices. Since SFPs only transmit very few bytes this should not have any real downsides.

This patch adds support in the i2c driver for 50kHz and 2.5MHz. In a second PR I will configure 50kHz in the DTS for the affected devices.

Part 1 of the fix for #21665
Part 2 is #22210