### PR TITLE
realtek: 50kHz I2C for SFPs on Xikestor SKS8300-8X

### DIFF
--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
@@ -147,27 +147,35 @@
 	/* SDA0-7 correspond to GPIO9-16 */
 	i2c0: i2c@0 {
 		reg = <0>;
+		clock-frequency = <50000>;
 	};
 	i2c1: i2c@1 {
 		reg = <1>;
+		clock-frequency = <50000>;
 	};
 	i2c2: i2c@2 {
 		reg = <2>;
+		clock-frequency = <50000>;
 	};
 	i2c3: i2c@3 {
 		reg = <3>;
+		clock-frequency = <50000>;
 	};
 	i2c4: i2c@4 {
 		reg = <4>;
+		clock-frequency = <50000>;
 	};
 	i2c5: i2c@5 {
 		reg = <5>;
+		clock-frequency = <50000>;
 	};
 	i2c6: i2c@6 {
 		reg = <6>;
+		clock-frequency = <50000>;
 	};
 	i2c7: i2c@7 {
 		reg = <7>;
+		clock-frequency = <50000>;
 	};
 };
 


### PR DESCRIPTION
Some 10G optics showed random "module transmit fault indicated" due to I2C read errors on ONTi ONT-S508CL-8S/XikeStor SKS8300-8X switches. The same modules work with the original firmware and on other Linux based devices.

There seems to be some differences in how we talk to those modules using I2C in OpenWRT. To fix this this patch adds support for 50kHz I2C speed on SFPs and enables that for XikeStor/Onti devices. Since SFPs only transmit very few bytes this should not have any real downsides.

This patch configures I2C to use 50kHz clock in the DTS for the affected devices. For it to work it requires a change in the RTL9300 I2C driver. This can be safely merged without the kernel change (but will not work in that case as it will fall back to 100kHz).

Part 2 of the fix for #21665
Part 1 is #22209
