### PR TITLE
realtek: some small fixes for XikeStor SKS8310-8X

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -65,6 +65,7 @@ realtek_setup_macs()
 	xikestor,sks8300-8t|\
 	xikestor,sks8300-12e2t2x|\
 	xikestor,sks8300-12x-v1|\
+	xikestor,sks8310-8x|\
 	zyxel,xgs1210-12-a1|\
 	zyxel,xgs1210-12-b1)
 		lan_mac=$(get_mac_label)
@@ -97,12 +98,6 @@ realtek_setup_macs()
 		;;
 	xikestor,sks8300-8x)
 		lan_mac=$(mtd_get_mac_binary board-info 0x1f1)
-		lan_mac_start=$lan_mac
-		eth0_mac=$lan_mac
-		;;
-	xikestor,sks8310-8x)
-		lan_mac=$(mtd_get_mac_binary factory 0x80)
-		label_mac="$lan_mac"
 		lan_mac_start=$lan_mac
 		eth0_mac=$lan_mac
 		;;

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
@@ -142,9 +142,14 @@
 &i2c_mst1 {
 	status = "okay";
 
-	/* SDA0-7 correspond to GPIO9-16 */
 	i2c0: i2c@0 {
 		reg = <0>;
+
+		/* NXP LM75BD */
+		sensor@48 {
+			compatible = "national,lm75b";
+			reg = <0x48>;
+		};
 	};
 	i2c1: i2c@1 {
 		reg = <1>;

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
@@ -10,6 +10,10 @@
 	compatible = "xikestor,sks8310-8x", "realtek,rtl9303-soc";
 	model = "XikeStor SKS8310-8X";
 
+	aliases {
+		label-mac-device = &ethernet0;
+	};
+
 	memory@0 {
 		device_type = "memory";
 		reg = <0x00000000 0x10000000>, /* first 256 MiB */
@@ -217,6 +221,18 @@
 				label = "factory";
 				reg = <0x1e0000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					factory_macaddr: macaddr@80 {
+						compatible = "mac-base";
+						reg = <0x80 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@1f0000 {
@@ -238,6 +254,11 @@
 			};
 		};
 	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&factory_macaddr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &switch0 {

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
@@ -34,16 +34,6 @@
 		};
 	};
 
-	leds {
-		compatible = "gpio-leds";
-
-		led_sys: led-0 {
-			gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-		};
-	};
-
 	led_set {
 		compatible = "realtek,rtl9300-leds";
 		active-low;

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -132,6 +132,7 @@ define Device/xikestor_sks8310-8x
   UIMAGE_MAGIC := 0x93000000
   DEVICE_VENDOR := XikeStor
   DEVICE_MODEL := SKS8310-8X
+  DEVICE_PACKAGES := kmod-hwmon-lm75
   IMAGE_SIZE := 20480k
   $(Device/kernel-lzma)
   IMAGE/sysupgrade.bin := \


### PR DESCRIPTION
Address some small issues for the XikeStor SKS8310-8X. Convert it to NVMEM for MAC address, drop an invalid DT node and add a missing definition for hwmon IC.

Run-tested on SKS8310-8X.