### PR TITLE
qualcommax: ipq807x: ipq6018: ath11k: fix monitor rx length

### DIFF
--- a/package/kernel/mac80211/patches/ath11k/949-wifi-ath11k-fix-monitor-rx-pktlen.patch
+++ b/package/kernel/mac80211/patches/ath11k/949-wifi-ath11k-fix-monitor-rx-pktlen.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ruslan Isaev <legale.legale@gmail.com>
+Date: Sat, 28 Feb 2026 00:00:00 +0000
+Subject: [PATCH] wifi: ath11k: fix monitor RX packet length (OpenWrt #16183)
+
+In monitor path the MSDU length was taken from the link descriptor
+(REO/firmware). For IPQ6018/IPQ807x the firmware reports 8 extra bytes,
+causing radiotap frames to end with garbage. Wireshark showed "Tag Length
+is longer than remaining payload" and "Malformed Packet".
+
+Fix by using the length from hal_rx_desc in the buffer (same source as
+normal RX path) for non-fragmented MSDUs. For fragmented MSDUs the link
+descriptor is still needed; apply rx_buf_size -= 8 workaround there.
+
+Fixes: OpenWrt issue #16183
+Link: https://github.com/openwrt/openwrt/issues/16183
+
+Index: backports-6.18.7/drivers/net/wireless/ath/ath11k/dp_rx.c
+===================================================================
+--- backports-6.18.7.orig/drivers/net/wireless/ath/ath11k/dp_rx.c
++++ backports-6.18.7/drivers/net/wireless/ath/ath11k/dp_rx.c
+@@ -5444,6 +5444,16 @@ ath11k_dp_rx_full_mon_mpdu_pop(struct at
+ 
+ 			rx_buf_size = rx_pkt_offset + l2_hdr_offset + frag_len;
+ 
++			if (!is_frag) {
++				rx_buf_size = rx_pkt_offset + l2_hdr_offset +
++					ath11k_dp_rx_h_msdu_start_msdu_len(ar->ab, rx_desc);
++		  } else {
++				rx_buf_size = rx_pkt_offset + l2_hdr_offset + frag_len;
++				if (rx_buf_size >= 8) {
++					rx_buf_size -= 8;
++				}
++			}
++
+ 			ath11k_dp_pkt_set_pktlen(msdu, rx_buf_size);
+ 
+ 			if (!(*head_msdu))


### PR DESCRIPTION
In monitor path the MSDU length was taken from the link descriptor (REO/firmware). For IPQ6018/IPQ807x the firmware reports 8 extra bytes, causing radiotap frames to end with garbage. Wireshark showed "Tag Length is longer than remaining payload" and "Malformed Packet".

Fix by using the length from hal_rx_desc in the buffer (same source as normal RX path) for non-fragmented MSDUs. For fragmented MSDUs the link descriptor is still needed; apply rx_buf_size -= 8 workaround there.

TEST:
cat<<'EOF'>test.sh
ssh root@10.11.11.105 'iw dev mon0 del 2>/dev/null; iw dev wlan0 del 2>/dev/null; iw phy phy0 interface add mon0 type monitor; ip link set mon0 up; iw mon0 set channel 36; iw phy phy0 interface add wlan0 type managed' sleep 2
ssh root@10.11.11.105 'tcpdump -i mon0 -w - -c 45 2>/dev/null' > pcap_managed_plus_mon.pcap echo "=== Managed+Monitor: Tag Length errors ==="
tshark -r pcap_managed_plus_mon.pcap 2>&1 | grep -ci "malformed" || echo 0 echo "=== Packets ==="
tshark -r pcap_managed_plus_mon.pcap 2>&1 | wc -l
tshark -r pcap_managed_plus_mon.pcap 2>&1 | head -10

ssh root@10.11.11.105 'iw dev wlan0 del; ip link set mon0 up' sleep 2
ssh root@10.11.11.105 'tcpdump -i mon0 -w - -c 45 2>/dev/null' > pcap_monitor_only.pcap echo "=== Monitor only: Tag Length errors ==="
tshark -r pcap_monitor_only.pcap 2>&1 | grep -ci "malformed" || echo 0 echo "=== Packets ==="
tshark -r pcap_monitor_only.pcap 2>&1 | wc -l
./test.shtest.shonitor_only.pcap 2>&1 | head -10

=== Managed+Monitor: Tag Length errors ===
2
=== Packets ===
45
    1   0.000000              → IntelCor_f7:d2:53 (f0:d5:bf:f7:d2:53) (RA) 802.11 44 Acknowledgement, Flags=........
    2   0.000137 Shenzhen_d0:3c:e2 (44:d1:fa:d0:3c:e2) (TA) → IntelCor_f7:d2:53 (f0:d5:bf:f7:d2:53) (RA) 802.11 53 VHT/HE NDP Announcement, Sounding Dialog Token=40, Flags=........
    3   0.000553 IntelCor_f7:d2:53 → Shenzhen_d0:3c:e2 802.11 142 Action No Ack, SN=2503, FN=0, Flags=........
    4   0.000708 Shenzhen_d0:3c:e2 (44:d1:fa:d0:3c:e2) (TA) → IntelCor_f7:d2:53 (f0:d5:bf:f7:d2:53) (RA) 802.11 53 VHT/HE NDP Announcement, Sounding Dialog Token=44, Flags=........
    5   0.000791 IntelCor_f7:d2:53 → Shenzhen_d0:3c:e2 802.11 142 Action No Ack, SN=2504, FN=0, Flags=........
    6   0.000838 RalinkTe_28:80:a0 → IntelCor_f7:d2:53 802.11 204 QoS Data, SN=72, FN=0, Flags=.p....F.
    7   0.015335 IntelCor_f7:d2:53 (f0:d5:bf:f7:d2:53) (TA) → Shenzhen_d0:3c:e2 (44:d1:fa:d0:3c:e2) (RA) 802.11 62 802.11 Block Ack, Flags=........
    8   0.015421 RalinkTe_28:80:a0 → a4:c3:be:be:09:7c 802.11 148 QoS Data, SN=3482, FN=0, Flags=.p....F.
    9   0.018751 a4:c3:be:be:09:7c (a4:c3:be:be:09:7c) (TA) → Shenzhen_d0:3c:e1 (44:d1:fa:d0:3c:e1) (RA) 802.11 62 802.11 Block Ack, Flags=........
   10   0.018832              → a4:c3:be:be:09:7c 802.11 1295 QoS Data, SN=3483, FN=0, Flags=.p....F.
=== Monitor only: Tag Length errors ===
18
=== Packets ===
45
    1   0.000000 Shenzhen_d0:3c:e1 → Broadcast    802.11 388 Beacon frame, SN=1750, FN=0, Flags=........, BI=100, SSID="tobe"[Malformed Packet]
    2   0.002110 Shenzhen_d0:3c:e2 → Broadcast    802.11 395 Beacon frame, SN=1687, FN=0, Flags=........, BI=100, SSID="wpa2ent"[Malformed Packet: length of contained item exceeds length of containing item]
    3   0.034155 Shenzhen_ef:21:7b → Broadcast    802.11 1582 Data, SN=318, FN=0, Flags=.p....F.
    4   0.054488 Shenzhen_d0:3c:e4 → Broadcast    802.11 436 Beacon frame, SN=1601, FN=0, Flags=........, BI=100, SSID="tobe-sae"[Malformed Packet: length of contained item exceeds length of containing item]
    5   0.102368 80:c3:63:b9:d9:ee (80:c3:63:b9:d9:ee) (TA) → ff:d2:b7:71:ca:ec (ff:d2:b7:71:ca:ec) (BSSID) 802.11 1690 Power-Save poll, Flags=....RM..
    6   0.102373              →              802.11 1690 Unknown protocol version: 2[Malformed Packet]
    7   0.102376 CamtecEl_ff:44:d1 → CamtecEl_ff:44:d1 (00:00:ff:ff:44:d1) (SA) 802.11 51 PV1 Control[Malformed Packet]
    8   0.114590 Shenzhen_d0:3c:e2 → Broadcast    802.11 395 Beacon frame, SN=1688, FN=0, Flags=........, BI=100, SSID="wpa2ent"[Malformed Packet: length of contained item exceeds length of containing item]
    9   0.122380              →              802.11 1057 Unknown protocol version: 3[Malformed Packet]
   10   0.136557              →              802.11 1690 Unknown protocol version: 2[Malformed Packet]



