### PR TITLE
config: add build config option to sign each .apk package

### DIFF
--- a/config/Config-build.in
+++ b/config/Config-build.in
@@ -73,6 +73,16 @@ menu "Global build settings"
 		bool "Use APK instead of OPKG to build distribution"
 		default y
 
+	config SIGN_EACH_PACKAGE
+		bool "Cryptographically sign each package .apk file"
+		depends on USE_APK
+		default n if BUILDBOT
+		default y
+		help
+		  Sign also the individual package .apk file. Removes the need for
+		  --allow-untrusted when installing self-compiled packages to a
+		  firmware compiled by the same buildhost as public key matches.
+
 	comment "General build options"
 
 	config TESTING_KERNEL

--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -605,6 +605,7 @@ else
 	  $$(APK_SCRIPTS_$(1)) \
 	  --info "depends:$$(foreach depends,$$(subst $$(comma),$$(space),$$(subst $$(space),,$$(subst $$(paren_right),,$$(subst $$(paren_left),,$$(Package/$(1)/DEPENDS))))),$$(depends))" \
 	  --files "$$(IDIR_$(1))" \
+	  $(if $(CONFIG_SIGN_EACH_PACKAGE),--sign $(BUILD_KEY_APK_SEC),) \
 	  --output "$$(PACK_$(1))"
 endif
 


### PR DESCRIPTION
cc apk related persons @aparcar @Ansuel @hauke

**Add a build config option to sign each individual .apk package**

If individual .apk files are signed with the build key, they can be installed with `apk add` without `--allow-untrusted` to a firmware compiled by the same buildhost (as the buildhost's public build key is placed into `/etc/apk/keys` by default).

At the moment, since commit 084697e, only the package index is signed, which forces users to use '--allow-untrusted' when installing self-built .apk files. The build key is on the router, but as the .apk is not signed, the key is useless.)

Note: as the option is useful to practically to all other builds than the buildbot builds, I also considered setting the default as 
```
default n if BUILDBOT
default y
```
But I have still left it with "default n" for now.
Opinions?

Current behaviour (without this PR) is failure to verify or install, as the .apk file is not signed. The option  --allow-untrusted is needed.

```
root@router5:~# apk verify /tmp/joe-4.6-r2.apk
/tmp/joe-4.6-r2.apk: UNTRUSTED signature

root@router5:~# apk add /tmp/joe-4.6-r2.apk
ERROR: /tmp/joe-4.6-r2.apk: UNTRUSTED signature

root@router5:~# apk add --allow-untrusted /tmp/joe-4.6-r2.apk
(1/1) Installing joe (4.6-r2)
  Executing joe-4.6-r2.post-install
OK: 67.2 MiB in 320 packages
```

After this PR:

```
root@router5:~# apk verify /tmp/joe-4.6-r2.apk
/tmp/joe-4.6-r2.apk: OK

root@router5:~# apk add /tmp/joe-4.6-r2.apk
(1/1) Installing joe (4.6-r2)
  Executing joe-4.6-r2.post-install
OK: 66.7 MiB in 319 packages
```

Tested with MT6000 and DL-WRX36
