### PR TITLE
binutils: Reduce relro pad size

### DIFF
--- a/toolchain/binutils/patches/2.42/200-pad-sections-for-relro-to-multiply-of-common-page-si.patch
+++ b/toolchain/binutils/patches/2.42/200-pad-sections-for-relro-to-multiply-of-common-page-si.patch
@@ -1,0 +1,47 @@
+From 17f4f23d5a7b78b0e563ebfdd78852ce3eeffe7e Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sat, 28 Feb 2026 20:19:50 +0100
+Subject: pad sections for relro to multiply of common page size
+
+Since commit 9833b7757d24 ("PR28824, relro security issues") in binutils
+2.39 the linker pads the relro sections to a multiply of max page size
+and not to a multiply of common page size any more. On MIPS the common
+page size is 4K and the max page size is 64K.
+
+A system can only mark full pages as read, write or executable.
+When a system uses a bigger page size than common page size, relro will
+not work fully any more with this change, because not the full section
+can be marked read only. On systems which are using common page size
+this has no affect.
+
+With this change the size of many binaries will decrease because they
+are are now padded to a multiple of the smaller common page size and not
+a multiply of max page size any more.
+
+Link: https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=9833b7757d246f22db4eb24b8e5db7eb5e05b6d9
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ ld/ldexp.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+--- a/ld/ldexp.c
++++ b/ld/ldexp.c
+@@ -474,8 +474,7 @@ fold_segment_align (etree_value_type *lh
+ 	}
+       else
+ 	{
+-	  if (!link_info.relro)
+-	    expld.result.value += expld.dot & (maxpage - 1);
++	  expld.result.value += expld.dot & (maxpage - 1);
+ 	  if (seg->phase == exp_seg_done)
+ 	    {
+ 	      /* OK.  */
+@@ -486,7 +485,7 @@ fold_segment_align (etree_value_type *lh
+ 	      seg->base = expld.result.value;
+ 	      seg->commonpagesize = commonpage;
+ 	      seg->maxpagesize = maxpage;
+-	      seg->relropagesize = maxpage;
++	      seg->relropagesize = commonpage;
+ 	      seg->relro_end = 0;
+ 	    }
+ 	  else

--- a/toolchain/binutils/patches/2.43.1/200-pad-sections-for-relro-to-multiply-of-common-page-si.patch
+++ b/toolchain/binutils/patches/2.43.1/200-pad-sections-for-relro-to-multiply-of-common-page-si.patch
@@ -1,0 +1,47 @@
+From 17f4f23d5a7b78b0e563ebfdd78852ce3eeffe7e Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sat, 28 Feb 2026 20:19:50 +0100
+Subject: pad sections for relro to multiply of common page size
+
+Since commit 9833b7757d24 ("PR28824, relro security issues") in binutils
+2.39 the linker pads the relro sections to a multiply of max page size
+and not to a multiply of common page size any more. On MIPS the common
+page size is 4K and the max page size is 64K.
+
+A system can only mark full pages as read, write or executable.
+When a system uses a bigger page size than common page size, relro will
+not work fully any more with this change, because not the full section
+can be marked read only. On systems which are using common page size
+this has no affect.
+
+With this change the size of many binaries will decrease because they
+are are now padded to a multiple of the smaller common page size and not
+a multiply of max page size any more.
+
+Link: https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=9833b7757d246f22db4eb24b8e5db7eb5e05b6d9
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ ld/ldexp.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+--- a/ld/ldexp.c
++++ b/ld/ldexp.c
+@@ -474,8 +474,7 @@ fold_segment_align (etree_value_type *lh
+ 	}
+       else
+ 	{
+-	  if (!link_info.relro)
+-	    expld.result.value += expld.dot & (maxpage - 1);
++	  expld.result.value += expld.dot & (maxpage - 1);
+ 	  if (seg->phase == exp_seg_done)
+ 	    {
+ 	      /* OK.  */
+@@ -486,7 +485,7 @@ fold_segment_align (etree_value_type *lh
+ 	      seg->base = expld.result.value;
+ 	      seg->commonpagesize = commonpage;
+ 	      seg->maxpagesize = maxpage;
+-	      seg->relropagesize = maxpage;
++	      seg->relropagesize = commonpage;
+ 	      seg->relro_end = 0;
+ 	    }
+ 	  else

--- a/toolchain/binutils/patches/2.44/200-pad-sections-for-relro-to-multiply-of-common-page-si.patch
+++ b/toolchain/binutils/patches/2.44/200-pad-sections-for-relro-to-multiply-of-common-page-si.patch
@@ -1,0 +1,47 @@
+From 17f4f23d5a7b78b0e563ebfdd78852ce3eeffe7e Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sat, 28 Feb 2026 20:19:50 +0100
+Subject: pad sections for relro to multiply of common page size
+
+Since commit 9833b7757d24 ("PR28824, relro security issues") in binutils
+2.39 the linker pads the relro sections to a multiply of max page size
+and not to a multiply of common page size any more. On MIPS the common
+page size is 4K and the max page size is 64K.
+
+A system can only mark full pages as read, write or executable.
+When a system uses a bigger page size than common page size, relro will
+not work fully any more with this change, because not the full section
+can be marked read only. On systems which are using common page size
+this has no affect.
+
+With this change the size of many binaries will decrease because they
+are are now padded to a multiple of the smaller common page size and not
+a multiply of max page size any more.
+
+Link: https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=9833b7757d246f22db4eb24b8e5db7eb5e05b6d9
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ ld/ldexp.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+--- a/ld/ldexp.c
++++ b/ld/ldexp.c
+@@ -474,8 +474,7 @@ fold_segment_align (etree_value_type *lh
+ 	}
+       else
+ 	{
+-	  if (!link_info.relro)
+-	    expld.result.value += expld.dot & (maxpage - 1);
++	  expld.result.value += expld.dot & (maxpage - 1);
+ 	  if (seg->phase == exp_seg_done)
+ 	    {
+ 	      /* OK.  */
+@@ -486,7 +485,7 @@ fold_segment_align (etree_value_type *lh
+ 	      seg->base = expld.result.value;
+ 	      seg->commonpagesize = commonpage;
+ 	      seg->maxpagesize = maxpage;
+-	      seg->relropagesize = maxpage;
++	      seg->relropagesize = commonpage;
+ 	      seg->relro_end = 0;
+ 	    }
+ 	  else

--- a/toolchain/binutils/patches/2.45.1/200-pad-sections-for-relro-to-multiply-of-common-page-si.patch
+++ b/toolchain/binutils/patches/2.45.1/200-pad-sections-for-relro-to-multiply-of-common-page-si.patch
@@ -1,0 +1,47 @@
+From 17f4f23d5a7b78b0e563ebfdd78852ce3eeffe7e Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Sat, 28 Feb 2026 20:19:50 +0100
+Subject: pad sections for relro to multiply of common page size
+
+Since commit 9833b7757d24 ("PR28824, relro security issues") in binutils
+2.39 the linker pads the relro sections to a multiply of max page size
+and not to a multiply of common page size any more. On MIPS the common
+page size is 4K and the max page size is 64K.
+
+A system can only mark full pages as read, write or executable.
+When a system uses a bigger page size than common page size, relro will
+not work fully any more with this change, because not the full section
+can be marked read only. On systems which are using common page size
+this has no affect.
+
+With this change the size of many binaries will decrease because they
+are are now padded to a multiple of the smaller common page size and not
+a multiply of max page size any more.
+
+Link: https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=9833b7757d246f22db4eb24b8e5db7eb5e05b6d9
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ ld/ldexp.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+--- a/ld/ldexp.c
++++ b/ld/ldexp.c
+@@ -474,8 +474,7 @@ fold_segment_align (etree_value_type *lh
+ 	}
+       else
+ 	{
+-	  if (!link_info.relro)
+-	    expld.result.value += expld.dot & (maxpage - 1);
++	  expld.result.value += expld.dot & (maxpage - 1);
+ 	  if (seg->phase == exp_seg_done)
+ 	    {
+ 	      /* OK.  */
+@@ -486,7 +485,7 @@ fold_segment_align (etree_value_type *lh
+ 	      seg->base = expld.result.value;
+ 	      seg->commonpagesize = commonpage;
+ 	      seg->maxpagesize = maxpage;
+-	      seg->relropagesize = maxpage;
++	      seg->relropagesize = commonpage;
+ 	      seg->relro_end = 0;
+ 	    }
+ 	  else


### PR DESCRIPTION
All OpenWrt targets are only using 4K pages, except loongarch64 which support 4K and 16K pages. Binutils still pads relro sections in most binaries to 64K (max page size). Use the common page size for the relro padding. This is 4K on most CPU architectures and 16K on loongarch64.

This will decrease the size of most libraries.

This before binutils 2.39 relro sections were padded to common page size, with binutils 3.29 the padding was changed to max page size.

This reverts the upstream patch.

The additional padding should not increases compressed file systems like
squashfs. When the library is loaded into memory this page should not
stay in memory because it is never accessed and paged out. I think the
improvement will not be much and looks better than it actually is.

OpenWrt Forum: https://forum.openwrt.org/t/strange-library-sizes-multiples-of-64-kb/246480

Sizes without this change:
```
[hauke@hauke-p14s openwrt]$ ls -al /home/hauke/Downloads/openwrt-malta-be-rootfs/lib
total 1716
drwxr-xr-x 12 hauke hauke   4096 Feb 28 10:12 .
drwxr-xr-x 16 hauke hauke   4096 Feb 28 10:12 ..
drwxr-xr-x  4 hauke hauke   4096 Feb 28 10:12 apk
drwxr-xr-x  2 hauke hauke   4096 Feb 28 10:12 config
drwxr-xr-x  2 hauke hauke   4096 Feb 28 10:12 firmware
drwxr-xr-x  3 hauke hauke   4096 Feb 28 10:12 functions
-rw-r--r--  1 hauke hauke  12207 Feb 28 10:12 functions.sh
lrwxrwxrwx  1 hauke hauke      7 Feb 28 22:10 ld-musl-mips-sf.so.1 -> libc.so
-rw-r--r--  1 hauke hauke  65688 Feb 28 10:12 libblobmsg_json.so.20260213
-rwxr-xr-x  1 hauke hauke 790788 Feb 28 10:12 libc.so
-rw-r--r--  1 hauke hauke  66316 Feb 28 10:12 libfstools.so
-rw-r--r--  1 hauke hauke 131360 Feb 28 10:12 libgcc_s.so.1
-rw-r--r--  1 hauke hauke  65728 Feb 28 10:12 libjson_script.so.20260213
-rw-r--r--  1 hauke hauke  65680 Feb 28 10:12 libpreload-seccomp.so
-rw-r--r--  1 hauke hauke  65612 Feb 28 10:12 libpreload-trace.so
-rw-r--r--  1 hauke hauke  65584 Feb 28 10:12 libsetlbf.so
-rw-r--r--  1 hauke hauke  66276 Feb 28 10:12 libubox.so.20260213
-rw-r--r--  1 hauke hauke  65932 Feb 28 10:12 libubus.so.20251202
-rwxr-xr-x  1 hauke hauke  66064 Feb 28 10:12 libuci.so.20250120
-rw-r--r--  1 hauke hauke  65880 Feb 28 10:12 libustream-ssl.so
-rw-r--r--  1 hauke hauke  66296 Feb 28 10:12 libvalidate.so
drwxr-xr-x  3 hauke hauke   4096 Feb 28 10:12 modules
drwxr-xr-x  4 hauke hauke   4096 Feb 28 10:12 netifd
drwxr-xr-x  2 hauke hauke   4096 Feb 28 10:12 network
drwxr-xr-x  2 hauke hauke   4096 Feb 28 10:12 preinit
drwxr-xr-x  3 hauke hauke   4096 Feb 28 10:12 upgrade
drwxr-xr-x  2 hauke hauke   4096 Feb 28 10:12 wifi
```

Sizes with this change:
```
[hauke@hauke-p14s openwrt]$ ls -al build_dir/target-mips_24kc_musl/root-malta/lib/
total 1156
drwxr-xr-x 12 hauke hauke   4096 Feb 28 20:48 .
drwxr-xr-x 16 hauke hauke   4096 Feb 28 20:48 ..
drwxr-xr-x  4 hauke hauke   4096 Feb 28 20:48 apk
drwxr-xr-x  2 hauke hauke   4096 Feb 28 20:48 config
drwxr-xr-x  2 hauke hauke   4096 Feb 28 20:48 firmware
drwxr-xr-x  3 hauke hauke   4096 Feb 28 20:48 functions
-rw-r--r--  1 hauke hauke  12207 Feb 28 20:48 functions.sh
lrwxrwxrwx  1 hauke hauke      7 Feb 28 20:48 ld-musl-mips-sf.so.1 -> libc.so
-rw-r--r--  1 hauke hauke   8344 Feb 28 20:48 libblobmsg_json.so.20260213
-rwxr-xr-x  1 hauke hauke 758020 Feb 28 20:48 libc.so
-rw-r--r--  1 hauke hauke  37644 Feb 28 20:48 libfstools.so
-rw-r--r--  1 hauke hauke  94496 Feb 28 20:48 libgcc_s.so.1
-rw-r--r--  1 hauke hauke   8384 Feb 28 20:48 libjson_script.so.20260213
-rw-r--r--  1 hauke hauke  37008 Feb 28 20:48 libpreload-seccomp.so
-rw-r--r--  1 hauke hauke   4172 Feb 28 20:48 libpreload-trace.so
-rw-r--r--  1 hauke hauke   4144 Feb 28 20:48 libsetlbf.so
-rw-r--r--  1 hauke hauke  45796 Feb 28 20:48 libubox.so.20260213
-rwxr-xr-x  1 hauke hauke  20876 Feb 28 20:48 libubus.so.20251202
-rwxr-xr-x  1 hauke hauke  29200 Feb 28 20:48 libuci.so.20250120
-rw-r--r--  1 hauke hauke  12632 Feb 28 20:48 libustream-ssl.so
-rw-r--r--  1 hauke hauke  13048 Feb 28 20:48 libvalidate.so
drwxr-xr-x  3 hauke hauke   4096 Feb 28 20:48 modules
drwxr-xr-x  4 hauke hauke   4096 Feb 28 20:48 netifd
drwxr-xr-x  2 hauke hauke   4096 Feb 28 20:48 network
drwxr-xr-x  2 hauke hauke   4096 Feb 28 20:48 preinit
drwxr-xr-x  3 hauke hauke   4096 Feb 28 20:48 upgrade
drwxr-xr-x  2 hauke hauke   4096 Feb 28 20:48 wifi
[hauke@hauke-p14s openwrt]$ 
```