### PR TITLE
ramips: mt7621: fix MT7530 LED hardware override

### DIFF
--- a/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
+++ b/target/linux/ramips/dts/mt7621_sercomm_s1500.dtsi
@@ -229,6 +229,9 @@
 };
 
 &switch0 {
+	gpio-controller;
+	#gpio-cells = <2>;
+
 	ports {
 		port@0 {
 			status = "okay";

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3-pro.dts
@@ -222,6 +222,9 @@
 };
 
 &switch0 {
+	gpio-controller;
+	#gpio-cells = <2>;
+
 	ports {
 		port@1 {
 			status = "okay";

--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3g.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-3g.dts
@@ -95,6 +95,9 @@
 };
 
 &switch0 {
+	gpio-controller;
+	#gpio-cells = <2>;
+
 	ports {
 		port@1 {
 			status = "okay";


### PR DESCRIPTION
On affected devices the switch port LEDs (amber:wan, amber:lan-*)
cannot be controlled via the Linux LED subsystem: even when the
LEDs are configured off in /etc/config/system, they continue to
blink with network traffic.

MT7530 boots with LED_IO_MODE register (0x7d04) set to 0x00077777,
placing all LED pins in hardware PHY mode. In this mode the switch
autonomously drives LED pins according to link status and traffic,
bypassing the Linux GPIO subsystem entirely.

The kernel already provides mt7530_setup_gpio() in
drivers/net/dsa/mt7530.c which writes LED_IO_MODE=0, switching pins
to software control. This function is only called when the DTS node
carries the gpio-controller property.

Add gpio-controller and #gpio-cells = <2> to the &switch0 node for
all MT7621 devices that use phylink LED triggers (mt7530-0:0N:*) but
lack gpio-controller, so mt7530_setup_gpio() runs at boot and hands
LED pin control to the Linux LED subsystem.

Tested on Xiaomi Mi Router 3G.