### PR TITLE
realtek: dts: add Netgear GS110TPP serdes for port 9/10

### DIFF
--- a/target/linux/realtek/dts/rtl8380_netgear_gs110tpp-v1.dts
+++ b/target/linux/realtek/dts/rtl8380_netgear_gs110tpp-v1.dts
@@ -61,7 +61,7 @@
 
 &switch0 {
 	ethernet-ports {
-		SWITCH_PORT(16, 9, qsgmii)
-		SWITCH_PORT(17, 10, qsgmii)
+		SWITCH_PORT_SDS(16, 9, 2, qsgmii)
+		SWITCH_PORT_SDS(17, 10, 2, qsgmii)
 	};
 };


### PR DESCRIPTION
The Netgear GS110TPP uses an RTL8214C to drive ports 9 and 10. The DTS is missing the corresponding serdes assignment. From looking at [1] it seems to be connected to pins 82-85 (serdes 2). Add that definition. With that the last improper use of SWITCH_PORT() macro is sorted out.

Remark: I do not own this device. The patch just resembles what the picture [1] shows.

[1] https://svanheule.net/switches/_media/wiki/gs110tpp-top.jpg
