### PR TITLE
mediatek: mt7981: restore improved fan behaviour

### DIFF
--- a/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
+++ b/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
@@ -36,8 +36,8 @@ working:
  
 +	fan: pwm-fan {
 +		compatible = "pwm-fan";
-+		/* cooling level (0, 1, 2, 3) : (0% duty, 50% duty, 75% duty, 100% duty) */
-+		cooling-levels = <0 128 192 255>;
++		/* cooling level (0, 1, 2, 3, 4, 5, 6, 7) : (0%/25%/37.5%/50%/62.5%/75%/87.5%/100% duty) */
++		cooling-levels = <0 63 95 127 159 191 223 255>;
 +		#cooling-cells = <2>;
 +		status = "disabled";
 +	};
@@ -590,7 +590,7 @@ working:
  			reg = <0 0x18000000 0 0x1000000>,
  			      <0 0x10003000 0 0x1000>,
  			      <0 0x11d10000 0 0x1000>;
-@@ -234,6 +676,67 @@
+@@ -234,6 +676,79 @@
  			clock-names = "mcu", "ap2conn";
  			resets = <&watchdog MT7986_TOPRGU_CONSYS_SW_RST>;
  			reset-names = "consys";
@@ -605,60 +605,72 @@ working:
 +			polling-delay = <1000>;
 +			thermal-sensors = <&thermal 0>;
 +			trips {
-+				cpu_trip_crit: crit {
-+					temperature = <125000>;
++				cpu_trip_active_highest: active-highest {
++					temperature = <70000>;
 +					hysteresis = <2000>;
-+					type = "critical";
-+				};
-+
-+				cpu_trip_hot: hot {
-+					temperature = <120000>;
-+					hysteresis = <2000>;
-+					type = "hot";
++					type = "active";
 +				};
 +
 +				cpu_trip_active_high: active-high {
-+					temperature = <115000>;
++					temperature = <60000>;
 +					hysteresis = <2000>;
 +					type = "active";
 +				};
 +
 +				cpu_trip_active_med: active-med {
-+					temperature = <85000>;
++					temperature = <50000>;
 +					hysteresis = <2000>;
 +					type = "active";
 +				};
 +
 +				cpu_trip_active_low: active-low {
-+					temperature = <60000>;
++					temperature = <45000>;
++					hysteresis = <2000>;
++					type = "active";
++				};
++
++				cpu_trip_active_lowest: active-lowest {
++					temperature = <40000>;
 +					hysteresis = <2000>;
 +					type = "active";
 +				};
 +			};
 +
 +			cooling-maps {
++				cpu-active-highest {
++					/* active: set fan to cooling level 7 */
++					cooling-device = <&fan 7 7>;
++					trip = <&cpu_trip_active_highest>;
++				};
++
 +				cpu-active-high {
-+					/* active: set fan to cooling level 3 */
-+					cooling-device = <&fan 3 3>;
++					/* active: set fan to cooling level 5 */
++					cooling-device = <&fan 5 5>;
 +					trip = <&cpu_trip_active_high>;
 +				};
 +
 +				cpu-active-med {
-+					/* active: set fan to cooling level 2 */
-+					cooling-device = <&fan 2 2>;
++					/* active: set fan to cooling level 3 */
++					cooling-device = <&fan 3 3>;
 +					trip = <&cpu_trip_active_med>;
 +				};
 +
 +				cpu-active-low {
-+					/* passive: set fan to cooling level 1 */
-+					cooling-device = <&fan 1 1>;
++					/* active: set fan to cooling level 2 */
++					cooling-device = <&fan 2 2>;
 +					trip = <&cpu_trip_active_low>;
++				};
++
++				cpu-active-lowest {
++					/* active: set fan to cooling level 1 */
++					cooling-device = <&fan 1 1>;
++					trip = <&cpu_trip_active_lowest>;
 +				};
 +			};
  		};
  	};
  
-@@ -245,4 +748,8 @@
+@@ -245,4 +760,8 @@
  			     <GIC_PPI 11 IRQ_TYPE_LEVEL_LOW>,
  			     <GIC_PPI 10 IRQ_TYPE_LEVEL_LOW>;
  	};


### PR DESCRIPTION
```
mediatek: mt7981: restore improved fan behaviour

Fan behaviour for GL.iNet MT3000 ("glinet,gl-mt3000") and other mt7981
devices was improved in 5a603c7 ("mediatek: mt7981: improve fan
behaviour") but lost when downstream files were replaced by patches in
f9206d1 ("kernel/mediatek: 6.12: replace downstream files by patches").

This commit restores the fan behaviour improvements which also affects
COMFAST CF-WR632AX ("comfast,cf-wr632ax") and other mt7981 devices. 

Signed-off-by: Ryan Leung <untilscour@protonmail.com>
```
fixes #21336