### PR TITLE
realtek: dsa: relax rtldsa_ethernet_loaded()

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -1540,19 +1540,13 @@ static int rtl83xx_fib_event(struct notifier_block *this, unsigned long event, v
  */
 static int rtldsa_ethernet_loaded(struct platform_device *pdev)
 {
-	struct device_node *dn = pdev->dev.of_node;
-	struct device_node *ports, *port;
+	struct platform_device *eth_pdev;
+	struct device_node *port_np;
+	struct device_node *eth_np;
 	int ret = -EPROBE_DEFER;
 
-	ports = of_get_child_by_name(dn, "ethernet-ports");
-	if (!ports)
-		return -ENODEV;
-
-	for_each_child_of_node(ports, port) {
-		struct device_node *eth_np;
-		struct platform_device *eth_pdev;
-
-		eth_np = of_parse_phandle(port, "ethernet", 0);
+	for_each_node_with_property(port_np, "ethernet") {
+		eth_np = of_parse_phandle(port_np, "ethernet", 0);
 		if (!eth_np)
 			continue;
 
@@ -1564,9 +1558,9 @@ static int rtldsa_ethernet_loaded(struct platform_device *pdev)
 
 		if (eth_pdev->dev.driver)
 			ret = 0;
-	}
 
-	of_node_put(ports);
+		put_device(&eth_pdev->dev);
+	}
 
 	return ret;
 }


### PR DESCRIPTION
The Realtek DSA driver accesses the DTS at two locations.

- rtldsa_ethernet_loaded(): to check if ethernet driver is active
- rtl83xx_mdio_probe(): to create ports and link to pcs/phy

The first function does not directly search for the ethernet driver but looks it up through the switch port nodes. ~~This is broken since 63729a8 ("realtek: dts: replace ports by ethernet-ports").~~ Avoid future issues and simply search all nodes that have a "ethernet" link to the network driver.

While we are here add a missing put_device() to keep reference counters clean.

~~Fixes: 63729a8 ("realtek: dts: replace ports by ethernet-ports")~~
