### PR TITLE
realtek: mdio: drop realtek,smi-address property

### DIFF
--- a/target/linux/realtek/dts/rtl838x.dtsi
+++ b/target/linux/realtek/dts/rtl838x.dtsi
@@ -274,6 +274,14 @@
 			compatible = "realtek,rtl8380-thermal";
 			#thermal-sensor-cells = <0>;
 		};
+
+		switch0: ethernet-switch {
+			compatible = "realtek,rtl8380-switch", "realtek,otto-switch";
+			status = "okay";
+
+			interrupt-parent = <&intc>;
+			interrupts = <20 2>;
+		};
 	};
 
 	pinmux@1b000144 {
@@ -352,13 +360,6 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges = <0 0x9f000000 0x10000>;
-	};
-
-	switch0: switch@1b000000 {
-		compatible = "realtek,rtl8380-switch", "realtek,otto-switch";
-
-		interrupt-parent = <&intc>;
-		interrupts = <20 2>;
 	};
 
 	thermal_zones: thermal-zones {

--- a/target/linux/realtek/dts/rtl839x.dtsi
+++ b/target/linux/realtek/dts/rtl839x.dtsi
@@ -306,6 +306,14 @@
 			compatible = "realtek,rtl8390-thermal";
 			#thermal-sensor-cells = <0>;
 		};
+
+		switch0: ethernet-switch {
+			compatible = "realtek,rtl8392-switch", "realtek,otto-switch";
+			status = "okay";
+
+			interrupt-parent = <&intc>;
+			interrupts = <20 2>;
+		};
 	};
 
 	pinmux@1b000004 {
@@ -353,14 +361,6 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		ranges = <0 0x9f000000 0x18000>;
-	};
-
-	switch0: switch@1b000000 {
-		status = "okay";
-		compatible = "realtek,rtl8392-switch", "realtek,otto-switch";
-
-		interrupt-parent = <&intc>;
-		interrupts = <20 2>;
 	};
 
 	thermal_zones: thermal-zones {

--- a/target/linux/realtek/dts/rtl9302_plasmacloud_common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_plasmacloud_common.dtsi
@@ -155,28 +155,24 @@
 		compatible = "ethernet-phy-ieee802.3-c45";
 	};
 
-	phy8: ethernet-phy@8 {
-		reg = <8>;
+	phy8: ethernet-phy@4 {
+		reg = <4>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <4>;
 	};
 
-	phy9: ethernet-phy@9 {
-		reg = <9>;
+	phy9: ethernet-phy@5 {
+		reg = <5>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <5>;
 	};
 
-	phy10: ethernet-phy@10 {
-		reg = <10>;
+	phy10: ethernet-phy@6 {
+		reg = <6>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <6>;
 	};
 
-	phy11: ethernet-phy@11 {
-		reg = <11>;
+	phy11: ethernet-phy@7 {
+		reg = <7>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <7>;
 	};
 };
 

--- a/target/linux/realtek/dts/rtl9302_xikestor_sks8300-12e2t2x.dts
+++ b/target/linux/realtek/dts/rtl9302_xikestor_sks8300-12e2t2x.dts
@@ -166,61 +166,51 @@
 };
 
 &mdio_bus1 {
-	phy8: ethernet-phy@8 {
+	phy8: ethernet-phy@0 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <8>;
-		realtek,smi-address = <0>;
+		reg = <0>;
 	};
-	phy9: ethernet-phy@9 {
+	phy9: ethernet-phy@1 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <9>;
-		realtek,smi-address = <1>;
+		reg = <1>;
 	};
-	phy10: ethernet-phy@10 {
+	phy10: ethernet-phy@2 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <10>;
-		realtek,smi-address = <2>;
+		reg = <2>;
 	};
-	phy11: ethernet-phy@11 {
+	phy11: ethernet-phy@3 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <11>;
-		realtek,smi-address = <3>;
+		reg = <3>;
 	};
 };
 
 &mdio_bus2 {
-	phy16: ethernet-phy@16 {
+	phy16: ethernet-phy@0 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <16>;
-		realtek,smi-address = <0>;
+		reg = <0>;
 	};
-	phy17: ethernet-phy@17 {
+	phy17: ethernet-phy@1 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <17>;
-		realtek,smi-address = <1>;
+		reg = <1>;
 	};
-	phy18: ethernet-phy@18 {
+	phy18: ethernet-phy@2 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <18>;
-		realtek,smi-address = <2>;
+		reg = <2>;
 	};
-	phy19: ethernet-phy@19 {
+	phy19: ethernet-phy@3 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <19>;
-		realtek,smi-address = <3>;
+		reg = <3>;
 	};
 };
 
 &mdio_bus3 {
-	phy24: ethernet-phy@24 {
+	phy24: ethernet-phy@0 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <24>;
-		realtek,smi-address = <0>;
+		reg = <0>;
 	};
-	phy25: ethernet-phy@25 {
+	phy25: ethernet-phy@1 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <25>;
-		realtek,smi-address = <1>;
+		reg = <1>;
 	};
 };
 

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-a1.dts
@@ -104,18 +104,16 @@
 };
 
 &mdio_bus1 {
-	phy24: ethernet-phy@24 {
-		reg = <24>;
-		realtek,smi-address = <8>;
+	phy24: ethernet-phy@8 {
+		reg = <8>;
 		compatible = "ethernet-phy-ieee802.3-c45";
 		enet-phy-pair-order = <1>;
 	};
 };
 
 &mdio_bus2 {
-	phy25: ethernet-phy@25 {
-		reg = <25>;
-		realtek,smi-address = <9>;
+	phy25: ethernet-phy@9 {
+		reg = <9>;
 		compatible = "ethernet-phy-ieee802.3-c45";
 		enet-phy-pair-order = <1>;
 	};

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1010-12-a1.dts
@@ -103,12 +103,20 @@
 	};
 };
 
-&phy24 {
-	realtek,smi-address = <8>;
-	enet-phy-pair-order = <1>;
+&mdio_bus1 {
+	phy24: ethernet-phy@24 {
+		reg = <24>;
+		realtek,smi-address = <8>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		enet-phy-pair-order = <1>;
+	};
 };
 
-&phy25 {
-	realtek,smi-address = <9>;
-	enet-phy-pair-order = <1>;
+&mdio_bus2 {
+	phy25: ethernet-phy@25 {
+		reg = <25>;
+		realtek,smi-address = <9>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		enet-phy-pair-order = <1>;
+	};
 };

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-a1.dts
@@ -8,12 +8,20 @@
 	model = "Zyxel XGS1210-12 A1 Switch";
 };
 
-&phy24 {
-	realtek,smi-address = <8>;
-	enet-phy-pair-order = <1>;
+&mdio_bus1 {
+	phy24: ethernet-phy@24 {
+		reg = <24>;
+		realtek,smi-address = <8>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		enet-phy-pair-order = <1>;
+	};
 };
 
-&phy25 {
-	realtek,smi-address = <9>;
-	enet-phy-pair-order = <1>;
+&mdio_bus2 {
+	phy25: ethernet-phy@25 {
+		reg = <25>;
+		realtek,smi-address = <9>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+		enet-phy-pair-order = <1>;
+	};
 };

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-a1.dts
@@ -9,18 +9,16 @@
 };
 
 &mdio_bus1 {
-	phy24: ethernet-phy@24 {
-		reg = <24>;
-		realtek,smi-address = <8>;
+	phy24: ethernet-phy@8 {
+		reg = <8>;
 		compatible = "ethernet-phy-ieee802.3-c45";
 		enet-phy-pair-order = <1>;
 	};
 };
 
 &mdio_bus2 {
-	phy25: ethernet-phy@25 {
-		reg = <25>;
-		realtek,smi-address = <9>;
+	phy25: ethernet-phy@9 {
+		reg = <9>;
 		compatible = "ethernet-phy-ieee802.3-c45";
 		enet-phy-pair-order = <1>;
 	};

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-b1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-b1.dts
@@ -8,10 +8,18 @@
 	model = "Zyxel XGS1210-12 B1 Switch";
 };
 
-&phy24 {
-	realtek,smi-address = <1>;
+&mdio_bus1 {
+	phy24: ethernet-phy@24 {
+		reg = <24>;
+		realtek,smi-address = <1>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
 };
 
-&phy25 {
-	realtek,smi-address = <2>;
+&mdio_bus2 {
+	phy25: ethernet-phy@25 {
+		reg = <25>;
+		realtek,smi-address = <2>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
 };

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-b1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1210-12-b1.dts
@@ -9,17 +9,15 @@
 };
 
 &mdio_bus1 {
-	phy24: ethernet-phy@24 {
-		reg = <24>;
-		realtek,smi-address = <1>;
+	phy24: ethernet-phy@1 {
+		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c45";
 	};
 };
 
 &mdio_bus2 {
-	phy25: ethernet-phy@25 {
-		reg = <25>;
-		realtek,smi-address = <2>;
+	phy25: ethernet-phy@2 {
+		reg = <2>;
 		compatible = "ethernet-phy-ieee802.3-c45";
 	};
 };

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-a1.dts
@@ -10,10 +10,9 @@
 
 &mdio_bus1 {
 	/* External Aquantia 113C PHYs */
-	phy24: ethernet-phy@24 {
-		reg = <24>;
+	phy24: ethernet-phy@8 {
+		reg = <8>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <8>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;
@@ -21,10 +20,9 @@
 };
 
 &mdio_bus2 {
-	phy25: ethernet-phy@25 {
-		reg = <25>;
+	phy25: ethernet-phy@8 {
+		reg = <8>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <8>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;
@@ -32,10 +30,9 @@
 };
 
 &mdio_bus3 {
-	phy26: ethernet-phy@26 {
-		reg = <26>;
+	phy26: ethernet-phy@8 {
+		reg = <8>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <8>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-b1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-b1.dts
@@ -9,10 +9,9 @@
 };
 
 &mdio_bus1 {
-	phy24: ethernet-phy@24 {
-		reg = <24>;
+	phy24: ethernet-phy@0 {
+		reg = <0>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <0>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;
@@ -20,10 +19,9 @@
 };
 
 &mdio_bus2 {
-	phy25: ethernet-phy@25 {
-		reg = <25>;
+	phy25: ethernet-phy@1 {
+		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <1>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;
@@ -31,10 +29,9 @@
 };
 
 &mdio_bus3 {
-	phy26: ethernet-phy@26 {
-		reg = <26>;
+	phy26: ethernet-phy@2 {
+		reg = <2>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <2>;
 		// Disabled because we do not know how to bring up again
 		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 		#thermal-sensor-cells = <0>;

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
@@ -124,24 +124,6 @@
 	};
 };
 
-&mdio_bus1 {
-	phy24: ethernet-phy@24 {
-		reg = <24>;
-		compatible = "ethernet-phy-ieee802.3-c45";
-		// Disabled because we do not know how to bring up again
-		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
-	};
-};
-
-&mdio_bus2 {
-	phy25: ethernet-phy@25 {
-		reg = <25>;
-		compatible = "ethernet-phy-ieee802.3-c45";
-		// Disabled because we do not know how to bring up again
-		// reset-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
-	};
-};
-
 &switch0 {
 	ethernet-ports {
 		#address-cells = <1>;

--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
@@ -132,48 +132,41 @@
 		reg = <0>;
 	};
 
-	phy8: ethernet-phy@8 {
+	phy8: ethernet-phy@1 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <1>;
-		reg = <8>;
+		reg = <1>;
 	};
 
-	phy16: ethernet-phy@16 {
+	phy16: ethernet-phy@2 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <2>;
-		reg = <16>;
+		reg = <2>;
 	};
 
-	phy20: ethernet-phy@20 {
+	phy20: ethernet-phy@3 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <3>;
-		reg = <20>;
+		reg = <3>;
 	};
 };
 
 &mdio_bus3 {
-	phy24: ethernet-phy@24 {
+	phy24: ethernet-phy@16 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <16>;
-		reg = <24>;
+		reg = <16>;
 	};
 
-	phy25: ethernet-phy@25 {
+	phy25: ethernet-phy@17 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <17>;
-		reg = <25>;
+		reg = <17>;
 	};
 
-	phy26: ethernet-phy@26 {
+	phy26: ethernet-phy@18 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <18>;
-		reg = <26>;
+		reg = <18>;
 	};
 
-	phy27: ethernet-phy@27 {
+	phy27: ethernet-phy@19 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <19>;
-		reg = <27>;
+		reg = <19>;
 	};
 };
 

--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8gt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8gt-se.dts
@@ -177,60 +177,52 @@
 &mdio_bus0 {
 	/* External RTL8221B PHY */
 	phy0: ethernet-phy@1 {
-		reg = <0>;
+		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <1>;
 	};
 
 	/* External RTL8221B PHY */
-	phy8: ethernet-phy@8 {
-		reg = <8>;
+	phy8: ethernet-phy@2 {
+		reg = <2>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <2>;
 	};
 
 	/* External RTL8221B PHY */
-	phy16: ethernet-phy@16 {
-		reg = <16>;
+	phy16: ethernet-phy@3 {
+		reg = <3>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <3>;
 	};
 
 	/* External RTL8221B PHY */
-	phy20: ethernet-phy@20 {
-		reg = <20>;
+	phy20: ethernet-phy@4 {
+		reg = <4>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <4>;
 	};
 };
 
 &mdio_bus1 {
 	/* External RTL8221B PHY */
-	phy24: ethernet-phy@24 {
-		reg = <24>;
+	phy24: ethernet-phy@1 {
+		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <1>;
 	};
 
 	/* External RTL8221B PHY */
-	phy25: ethernet-phy@25 {
-		reg = <25>;
+	phy25: ethernet-phy@2 {
+		reg = <2>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <2>;
 	};
 
 	/* External RTL8221B PHY */
-	phy26: ethernet-phy@26 {
-		reg = <26>;
+	phy26: ethernet-phy@3 {
+		reg = <3>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <3>;
 	};
 
 	/* External RTL8221B PHY */
-	phy27: ethernet-phy@27 {
-		reg = <27>;
+	phy27: ethernet-phy@4 {
+		reg = <4>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <4>;
 	};
 };
 

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
@@ -133,48 +133,41 @@
 		reg = <0>;
 	};
 
-	phy8: ethernet-phy@8 {
+	phy8: ethernet-phy@1 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <8>;
-		realtek,smi-address = <1>;
+		reg = <1>;
 	};
 
-	phy16: ethernet-phy@16 {
+	phy16: ethernet-phy@2 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <16>;
-		realtek,smi-address = <2>;
+		reg = <2>;
 	};
 
-	phy20: ethernet-phy@20 {
+	phy20: ethernet-phy@3 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <20>;
-		realtek,smi-address = <3>;
+		reg = <3>;
 	};
 };
 
 &mdio_bus1 {
-	phy24: ethernet-phy@24 {
+	phy24: ethernet-phy@0 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <24>;
-		realtek,smi-address = <0>;
+		reg = <0>;
 	};
 
-	phy25: ethernet-phy@25 {
+	phy25: ethernet-phy@1 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <25>;
-		realtek,smi-address = <1>;
+		reg = <1>;
 	};
 
-	phy26: ethernet-phy@26 {
+	phy26: ethernet-phy@2 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <26>;
-		realtek,smi-address = <2>;
+		reg = <2>;
 	};
 
-	phy27: ethernet-phy@27 {
+	phy27: ethernet-phy@3 {
 		compatible = "ethernet-phy-ieee802.3-c45";
-		reg = <27>;
-		realtek,smi-address = <3>;
+		reg = <3>;
 	};
 };
 

--- a/target/linux/realtek/dts/rtl930x.dtsi
+++ b/target/linux/realtek/dts/rtl930x.dtsi
@@ -289,6 +289,14 @@
 			compatible = "realtek,rtl9300-thermal";
 			#thermal-sensor-cells = <0>;
 		};
+
+		switch0: switch@1b000000 {
+			compatible = "realtek,rtl9301-switch", "realtek,otto-switch";
+			status = "okay";
+
+			interrupt-parent = <&intc>;
+			interrupts = <23 2>;
+		};
 	};
 
 	pinmux@1b000200 {
@@ -356,14 +364,6 @@
 		pinmux_disable_sys_led: disable_sys_led {
 			pinctrl-single,bits = <0x0 0x0 0x1000>;
 		};
-	};
-
-	switch0: switch@1b000000 {
-		compatible = "realtek,rtl9301-switch", "realtek,otto-switch";
-		status = "okay";
-
-		interrupt-parent = <&intc>;
-		interrupts = <23 2>;
 	};
 
 	thermal_zones: thermal-zones {

--- a/target/linux/realtek/dts/rtl9311_linksys_lgs352c.dts
+++ b/target/linux/realtek/dts/rtl9311_linksys_lgs352c.dts
@@ -179,125 +179,101 @@
 };
 
 &mdio_bus1 {
-	phy24: ethernet-phy@24 {
-		reg = <24>;
+	phy24: ethernet-phy@0 {
+		reg = <0>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <0>;
 	};
-	phy25: ethernet-phy@25 {
-		reg = <25>;
+	phy25: ethernet-phy@1 {
+		reg = <1>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <1>;
 	};
-	phy26: ethernet-phy@26 {
-		reg = <26>;
+	phy26: ethernet-phy@2 {
+		reg = <2>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <2>;
 	};
-	phy27: ethernet-phy@27 {
-		reg = <27>;
+	phy27: ethernet-phy@3 {
+		reg = <3>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <3>;
 	};
-	phy28: ethernet-phy@28 {
-		reg = <28>;
+	phy28: ethernet-phy@4 {
+		reg = <4>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <4>;
 	};
-	phy29: ethernet-phy@29 {
-		reg = <29>;
+	phy29: ethernet-phy@5 {
+		reg = <5>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <5>;
 	};
-	phy30: ethernet-phy@30 {
-		reg = <30>;
+	phy30: ethernet-phy@6 {
+		reg = <6>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <6>;
 	};
-	phy31: ethernet-phy@31 {
-		reg = <31>;
+	phy31: ethernet-phy@7 {
+		reg = <7>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <7>;
 	};
-	phy32: ethernet-phy@32 {
-		reg = <32>;
+	phy32: ethernet-phy@8 {
+		reg = <8>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <8>;
 	};
-	phy33: ethernet-phy@33 {
-		reg = <33>;
+	phy33: ethernet-phy@9 {
+		reg = <9>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <9>;
 	};
-	phy34: ethernet-phy@34 {
-		reg = <34>;
+	phy34: ethernet-phy@10 {
+		reg = <10>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <10>;
 	};
-	phy35: ethernet-phy@35 {
-		reg = <35>;
+	phy35: ethernet-phy@11 {
+		reg = <11>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <11>;
 	};
-	phy36: ethernet-phy@36 {
-		reg = <36>;
+	phy36: ethernet-phy@12 {
+		reg = <12>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <12>;
 	};
-	phy37: ethernet-phy@37 {
-		reg = <37>;
+	phy37: ethernet-phy@13 {
+		reg = <13>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <13>;
 	};
-	phy38: ethernet-phy@38 {
-		reg = <38>;
+	phy38: ethernet-phy@14 {
+		reg = <14>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <14>;
 	};
-	phy39: ethernet-phy@39 {
-		reg = <39>;
+	phy39: ethernet-phy@15 {
+		reg = <15>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <15>;
 	};
-	phy40: ethernet-phy@40 {
-		reg = <40>;
+	phy40: ethernet-phy@16 {
+		reg = <16>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <16>;
 	};
-	phy41: ethernet-phy@41 {
-		reg = <41>;
+	phy41: ethernet-phy@17 {
+		reg = <17>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <17>;
 	};
-	phy42: ethernet-phy@42 {
-		reg = <42>;
+	phy42: ethernet-phy@18 {
+		reg = <18>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <18>;
 	};
-	phy43: ethernet-phy@43 {
-		reg = <43>;
+	phy43: ethernet-phy@19 {
+		reg = <19>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <19>;
 	};
-	phy44: ethernet-phy@44 {
-		reg = <44>;
+	phy44: ethernet-phy@20 {
+		reg = <20>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <20>;
 	};
-	phy45: ethernet-phy@45 {
-		reg = <45>;
+	phy45: ethernet-phy@21 {
+		reg = <21>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <21>;
 	};
-	phy46: ethernet-phy@46 {
-		reg = <46>;
+	phy46: ethernet-phy@22 {
+		reg = <22>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <22>;
 	};
-	phy47: ethernet-phy@47 {
-		reg = <47>;
+	phy47: ethernet-phy@23 {
+		reg = <23>;
 		compatible = "ethernet-phy-ieee802.3-c22";
-		realtek,smi-address = <23>;
 	};
 };
 

--- a/target/linux/realtek/dts/rtl9312_plasmacloud_common.dtsi
+++ b/target/linux/realtek/dts/rtl9312_plasmacloud_common.dtsi
@@ -250,138 +250,116 @@
 		compatible = "ethernet-phy-ieee802.3-c45";
 	};
 
-	phy4: ethernet-phy@4 {
+	phy4: ethernet-phy@2 {
+		reg = <2>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
+
+	phy5: ethernet-phy@3 {
+		reg = <3>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
+
+	phy8: ethernet-phy@4 {
 		reg = <4>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <2>;
 	};
 
-	phy5: ethernet-phy@5 {
+	phy9: ethernet-phy@5 {
 		reg = <5>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <3>;
 	};
 
-	phy8: ethernet-phy@8 {
+	phy12: ethernet-phy@6 {
+		reg = <6>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
+
+	phy13: ethernet-phy@7 {
+		reg = <7>;
+		compatible = "ethernet-phy-ieee802.3-c45";
+	};
+
+	phy16: ethernet-phy@8 {
 		reg = <8>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <4>;
 	};
 
-	phy9: ethernet-phy@9 {
+	phy17: ethernet-phy@9 {
 		reg = <9>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <5>;
 	};
 
-	phy12: ethernet-phy@12 {
-		reg = <12>;
+	phy20: ethernet-phy@10 {
+		reg = <10>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <6>;
 	};
 
-	phy13: ethernet-phy@13 {
-		reg = <13>;
+	phy21: ethernet-phy@11 {
+		reg = <11>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <7>;
-	};
-
-	phy16: ethernet-phy@16 {
-		reg = <16>;
-		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <8>;
-	};
-
-	phy17: ethernet-phy@17 {
-		reg = <17>;
-		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <9>;
-	};
-
-	phy20: ethernet-phy@20 {
-		reg = <20>;
-		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <10>;
-	};
-
-	phy21: ethernet-phy@21 {
-		reg = <21>;
-		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <11>;
 	};
 };
 
 &mdio_bus1 {
-	phy24: ethernet-phy@24 {
-		reg = <24>;
+	phy24: ethernet-phy@12 {
+		reg = <12>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <12>;
 	};
 
-	phy25: ethernet-phy@25 {
-		reg = <25>;
+	phy25: ethernet-phy@13 {
+		reg = <13>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <13>;
 	};
 
-	phy28: ethernet-phy@28 {
-		reg = <28>;
+	phy28: ethernet-phy@14 {
+		reg = <14>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <14>;
 	};
 
-	phy29: ethernet-phy@29 {
-		reg = <29>;
+	phy29: ethernet-phy@15 {
+		reg = <15>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <15>;
 	};
 
-	phy32: ethernet-phy@32 {
-		reg = <32>;
+	phy32: ethernet-phy@16 {
+		reg = <16>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <16>;
 	};
 
-	phy33: ethernet-phy@33 {
-		reg = <33>;
+	phy33: ethernet-phy@17 {
+		reg = <17>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <17>;
 	};
 
-	phy36: ethernet-phy@36 {
-		reg = <36>;
+	phy36: ethernet-phy@18 {
+		reg = <18>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <18>;
 	};
 
-	phy37: ethernet-phy@37 {
-		reg = <37>;
+	phy37: ethernet-phy@19 {
+		reg = <19>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <19>;
 	};
 
-	phy40: ethernet-phy@40 {
-		reg = <40>;
+	phy40: ethernet-phy@20 {
+		reg = <20>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <20>;
 	};
 
-	phy41: ethernet-phy@41 {
-		reg = <41>;
+	phy41: ethernet-phy@21 {
+		reg = <21>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <21>;
 	};
 
-	phy44: ethernet-phy@44 {
-		reg = <44>;
+	phy44: ethernet-phy@22 {
+		reg = <22>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <22>;
 	};
 
-	phy45: ethernet-phy@45 {
-		reg = <45>;
+	phy45: ethernet-phy@23 {
+		reg = <23>;
 		compatible = "ethernet-phy-ieee802.3-c45";
-		realtek,smi-address = <23>;
 	};
 };
 

--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -325,6 +325,15 @@
 				reg = <13>;
 			};
 		};
+
+		switch0: switch@1b000000 {
+			compatible = "realtek,rtl9311-switch", "realtek,otto-switch";
+			status = "okay";
+
+			interrupt-parent = <&gic>;
+			#interrupt-cells = <3>;
+			interrupts = <GIC_SHARED 15 IRQ_TYPE_LEVEL_HIGH>;
+		};
 	};
 
 	pinmux@1b00103c {
@@ -418,14 +427,5 @@
 		pinmux_gpio_mdio_en: gpio-mdio-en {
 			pinctrl-single,bits = <0x0 0x100 0x100>;
 		};
-	};
-
-	switch0: switch@1b000000 {
-		compatible = "realtek,rtl9311-switch", "realtek,otto-switch";
-		status = "okay";
-
-		interrupt-parent = <&gic>;
-		#interrupt-cells = <3>;
-		interrupts = <GIC_SHARED 15 IRQ_TYPE_LEVEL_HIGH>;
 	};
 };

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -181,6 +181,7 @@ struct rtmdio_ctrl {
 	bool raw[RTMDIO_MAX_PHY];
 	int smi_bus[RTMDIO_MAX_PHY];
 	int smi_addr[RTMDIO_MAX_PHY];
+	struct device_node *phy_node[RTMDIO_MAX_PHY];
 	bool smi_bus_isc45[RTMDIO_MAX_SMI_BUS];
 };
 
@@ -870,13 +871,67 @@ static int rtmdio_reset(struct mii_bus *bus)
 	return ctrl->cfg->reset(bus);
 }
 
+static int rtmdio_map_ports(struct device *dev)
+{
+	struct rtmdio_ctrl *ctrl = dev_get_drvdata(dev);
+	int bus_addr, addr;
+
+	struct device_node *switch_node __free(device_node) =
+		of_get_child_by_name(dev->of_node->parent, "ethernet-switch");
+	if (!switch_node)
+		return dev_err_probe(dev, -ENODEV, "%pfwP missing ethernet-switch\n",
+				     of_fwnode_handle(dev->of_node->parent));
+
+	struct device_node *ports __free(device_node) =
+		of_get_child_by_name(switch_node, "ethernet-ports");
+	if (!ports)
+		return dev_err_probe(dev, -ENODEV, "%pfwP missing ethernet-ports\n",
+				     of_fwnode_handle(switch_node));
+
+	for (addr = 0; addr < RTMDIO_MAX_PHY; addr++)
+		ctrl->smi_bus[addr] = -1;
+
+	for_each_child_of_node_scoped(ports, port) {
+		if (of_property_read_u32(port, "reg", &addr))
+			continue;
+
+		struct device_node *phy __free(device_node) =
+			of_parse_phandle(port, "phy-handle", 0);
+		if (!phy)
+			continue;
+
+		if (addr >= ctrl->cfg->num_phys)
+			return dev_err_probe(dev, -EINVAL, "%pfwP illegal port number\n",
+					     of_fwnode_handle(port));
+
+		if (of_property_read_u32(phy, "reg", &ctrl->smi_addr[addr]))
+			return dev_err_probe(dev, -EINVAL, "%pfwP no phy address\n",
+					     of_fwnode_handle(phy));
+
+		if (of_property_read_u32(phy->parent, "reg", &bus_addr))
+			return dev_err_probe(dev, -EINVAL, "%pfwP no bus address\n",
+					     of_fwnode_handle(phy->parent));
+
+		if (bus_addr >= RTMDIO_MAX_SMI_BUS)
+			return dev_err_probe(dev, -EINVAL, "%pfwP illegal bus number\n",
+					     of_fwnode_handle(phy->parent));
+
+		if (of_device_is_compatible(phy, "ethernet-phy-ieee802.3-c45"))
+			ctrl->smi_bus_isc45[bus_addr] = true;
+
+		ctrl->smi_bus[addr] = bus_addr;
+		ctrl->phy_node[addr] = of_node_get(phy);
+	}
+
+	return 0;
+}
+
 static int rtmdio_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
-	struct device_node *np, *dn[RTMDIO_MAX_PHY];
 	struct rtmdio_ctrl *ctrl;
 	struct mii_bus *bus;
-	int ret, addr;
+	int ret;
 
 	bus = devm_mdiobus_alloc_size(dev, sizeof(*ctrl));
 	if (!bus)
@@ -888,33 +943,12 @@ static int rtmdio_probe(struct platform_device *pdev)
 	if (IS_ERR(ctrl->map))
 		return PTR_ERR(ctrl->map);
 
-	for (addr = 0; addr < RTMDIO_MAX_PHY; addr++)
-		ctrl->smi_bus[addr] = -1;
-
-	for_each_node_by_name(np, "ethernet-phy") {
-		if (of_property_read_u32(np, "reg", &addr))
-			continue;
-
-		if (addr < 0 || addr >= ctrl->cfg->num_phys) {
-			dev_err(dev, "illegal address number %d\n", addr);
-			of_node_put(np);
-			return -EINVAL;
-		}
-
-		of_property_read_u32(np->parent, "reg", &ctrl->smi_bus[addr]);
-		if (of_property_read_u32(np, "realtek,smi-address", &ctrl->smi_addr[addr]))
-			ctrl->smi_addr[addr] = addr;
-
-		if (ctrl->smi_bus[addr] < 0 || ctrl->smi_bus[addr] >= RTMDIO_MAX_SMI_BUS) {
-			dev_err(dev, "illegal SMI bus number %d\n", ctrl->smi_bus[addr]);
-			of_node_put(np);
-			return -EINVAL;
-		}
-
-		if (of_device_is_compatible(np, "ethernet-phy-ieee802.3-c45"))
-			ctrl->smi_bus_isc45[ctrl->smi_bus[addr]] = true;
-
-		dn[addr] = of_node_get(np);
+	platform_set_drvdata(pdev, ctrl);
+	ret = rtmdio_map_ports(dev);
+	if (ret) {
+		for_each_phy(ctrl, addr)
+			of_node_put(ctrl->phy_node[addr]);
+		return ret;
 	}
 
 	bus->name = "Realtek MDIO bus";
@@ -935,11 +969,13 @@ static int rtmdio_probe(struct platform_device *pdev)
 		return ret;
 
 	for_each_phy(ctrl, addr) {
-		ret = fwnode_mdiobus_register_phy(bus, of_fwnode_handle(dn[addr]), addr);
-		of_node_put(dn[addr]);
-		if (ret)
-			return ret;
+		if (!ret)
+			ret = fwnode_mdiobus_register_phy(bus,
+				of_fwnode_handle(ctrl->phy_node[addr]), addr);
+		of_node_put(ctrl->phy_node[addr]);
 	}
+	if (ret)
+		return ret;
 
 	if (ctrl->cfg->setup_polling)
 		ctrl->cfg->setup_polling(bus);


### PR DESCRIPTION
A phy node in the dts has two properties:

- reg: the (overall) address of the phy
- realtek,smi-address: the address of the phy on its bus

This notation does not align with upstream. reg should be the address of the phy on its bus. But where to get the overall address that is needed for register writes to the hardware?

Luckily the mdio driver and the hardware design sync the ports and phys (overall) addresses. Thus derive missing data from the dts port nodes (below ethernet-ports).

With this commit all dts files must be rewritten as follows:

- if phy has no realtek,smi-address leave it as is
- if phy has realtek,smi-address, write that value into the reg property and drop realtek,smi-address.
