### PR TITLE
wifi-scripts: make "rsn_preauth_interfaces" use the same interface as "ft_iface"

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -1004,10 +1004,10 @@ hostapd_set_bss_options() {
 			fi
 		fi
 
-		if [ -n "$network_bridge" -a "$rsn_preauth" = 1 ]; then
+		if [ -n "$network_ifname" -a "$rsn_preauth" = 1 ]; then
 			set_default auth_cache 1
 			append bss_conf "rsn_preauth=1" "$N"
-			append bss_conf "rsn_preauth_interfaces=$network_bridge" "$N"
+			append bss_conf "rsn_preauth_interfaces=$network_ifname" "$N"
 		else
 			case "$auth_type" in
 			sae|psk-sae|owe)


### PR DESCRIPTION
`rsn_preauth_interfaces` needs to be set to the same interface as `ft_iface` since RSN preauth traffic has the same issue as FT traffic in DSA configurations that enable VLAN filtering: packets sent on the main bridge interface (for example, `br-lan`) won't get properly VID tagged and so end being dropped.

Instead, hostapd should listen for and send RSN preauth traffic on the proper VLAN interface (for example `br-lan.1`).

This fixes RSN pre-authentication in such DSA configurations.
