### PR TITLE
ipq40xx: re-enable MeshPoint.One target

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -343,8 +343,7 @@ define Device/cilab_meshpoint-one
 	DEVICE_MODEL := MeshPoint.One
 	DEVICE_PACKAGES += kmod-i2c-gpio kmod-iio-bmp280-i2c kmod-hwmon-ina2xx kmod-rtc-pcf2127
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += cilab_meshpoint-one
+TARGET_DEVICES += cilab_meshpoint-one
 
 define Device/compex_wpj419
 	$(call Device/FitImage)


### PR DESCRIPTION
## Summary

Re-enable the Crisis Innovation Lab MeshPoint.One target for ipq40xx, which was disabled during the DSA migration with the comment "Missing DSA Setup".

**The device needs no additional DSA work** because:

1. It inherits 100% of its network configuration from 8dev Jalapeno via `Device/8dev_jalapeno-common`
2. Both devices share the same DSA network setup in `02_network` (lines 33 and 37 - same block)
3. Same SoC (Qualcomm IPQ4018) and same switch (QCA8072)
4. The Jalapeno has been working with DSA since the migration
5. All board support files (DTS, network config, LED config) are already in the tree

## Changes

- Removed outdated `# Missing DSA Setup` comment
- Uncommented `TARGET_DEVICES += cilab_meshpoint-one`

Net change: 1 insertion, 2 deletions in `target/linux/ipq40xx/image/generic.mk`

## Testing

- Built firmware from current `main` branch successfully
- Firmware images generated: factory.ubi (11 MB), sysupgrade.bin (9.5 MB)
- Kernel: 6.12.74

Pending physical device flash test (device in transit).

## Background

The [MeshPoint.One](https://meshpointone.com) is a mesh WiFi gateway designed for humanitarian crisis response and smart cities. It was deployed in refugee camps during the 2015 Syrian refugee crisis, serving 500,000+ refugees across Croatia and Slovenia. The device was designed by Robert Marko (robert@meshpoint.me) based on the 8dev Jalapeno reference design.

Signed-off-by: Valent Turkovic <valent@meshpoint.me>