### PR TITLE
apk: point help message to openwrt wiki

### DIFF
--- a/package/system/apk/patches/0002-openwrt-wiki-help-link.patch
+++ b/package/system/apk/patches/0002-openwrt-wiki-help-link.patch
@@ -1,0 +1,13 @@
+diff --git a/src/genhelp_apk.lua b/src/genhelp_apk.lua
+index a62e84d22ed5..a97264f6ab3c 100644
+--- a/src/genhelp_apk.lua
++++ b/src/genhelp_apk.lua
+@@ -65,7 +65,7 @@ local function render_options(doc, out, options)
+ end
+ 
+ local function render_footer(doc, out)
+-	table.insert(out, ("\nFor more information: man %s %s\n"):format(doc.mansection, doc.manpage))
++	table.insert(out, ("\nFor more information:\n  https://openwrt.org/docs/guide-user/additional-software/apk\n"))
+ end
+ 
+ local function render_optgroups(doc, out, groups)


### PR DESCRIPTION
Instead of directing users to the useless 'man 8 apk', we direct them to the wiki help page.

---
Before
```
$ apk
apk-tools 3.0.5, compiled for x86_64.

Usage: apk [<GLOBAL OPTIONS>...] COMMAND [<OPTIONS>...] [<ARGUMENTS>...]
...
For more information: man 8 apk
```
Now last line changes to
```
For more information:
  https://openwrt.org/docs/guide-user/additional-software/apk
```