### PR TITLE
ipq40xx: change ath10k packages to mainline versions for linksys mr8300

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -745,7 +745,7 @@ define Device/linksys_mr8300
 	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
 	IMAGES += factory.bin
 	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=MR8300
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-usb-ledtrig-usbport
+	DEVICE_PACKAGES := -kmod-ath10k-ct -ath10k-firmware-qca4019-ct kmod-ath10k ath10k-firmware-qca4019 ath10k-firmware-qca9888 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += linksys_mr8300
 


### PR DESCRIPTION
Some devices cannot connect to 2.4Ghz network under 25.12 with same configuration as 24.10 on Linksys MR8300. Use of ATH10k non CT drivers allow device to connect successfully.

This should apply to snapshot and v25.10 branch too.

Bug : https://github.com/openwrt/openwrt/issues/22256#issuecomment-3993274319