### PR TITLE
ipq40xx: backport MeshPoint.One re-enable to 25.12

### DIFF
--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -343,8 +343,7 @@ define Device/cilab_meshpoint-one
 	DEVICE_MODEL := MeshPoint.One
 	DEVICE_PACKAGES += kmod-i2c-gpio kmod-iio-bmp280-i2c kmod-hwmon-ina2xx kmod-rtc-pcf2127
 endef
-# Missing DSA Setup
-#TARGET_DEVICES += cilab_meshpoint-one
+TARGET_DEVICES += cilab_meshpoint-one
 
 define Device/compex_wpj419
 	$(call Device/FitImage)


### PR DESCRIPTION
Backport of commit a75cc4f18ca ("ipq40xx: re-enable MeshPoint.One target")
from main to the 25.12 release branch.

The MeshPoint.One was disabled during the DSA migration. It shares the
same IPQ4018/QCA8072 platform and DSA network config as 8dev Jalapeno,
which has been working since the migration.

This is a 1-line change (uncomment TARGET_DEVICES) with zero risk to
other devices.

Original PR: #22258 (merged by @robimarko on 2026-03-04)

Signed-off-by: Valent Turkovic <valent@meshpointone.com>