### PR TITLE
[25.12] lantiq: add missing WAN MAC override

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse.dtsi
@@ -222,7 +222,7 @@
 			reg = <0xe105300 0x100>;
 		};
 
-		ppe@e234000 {
+		ppe: ppe@e234000 {
 			compatible = "lantiq,ppe-ase";
 			reg = <0xe234000 0x40000>;
 			interrupt-parent = <&icu0>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse_allnet_all0333cj.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/amazonse_allnet_all0333cj.dts
@@ -78,6 +78,11 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_uboot_ethaddr 1>;
+	nvmem-cell-names = "mac-address";
+};
+
 &localbus {
 	flash@0 {
 		compatible = "lantiq,nor";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vg3503j.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vg3503j.dts
@@ -57,6 +57,16 @@
 	};
 };
 
+&eth0 {
+	nvmem-cells = <&macaddr_uboot_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ppe {
+	nvmem-cells = <&macaddr_uboot_ethaddr 1>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gphy0 {
 	lantiq,gphy-mode = <GPHY_MODE_GE>;
 };
@@ -69,8 +79,6 @@
 	pinctrl-0 = <&gphy0_led0_pins>, <&gphy0_led1_pins>, <&gphy0_led2_pins>,
 		    <&gphy1_led0_pins>, <&gphy1_led1_pins>, <&gphy1_led2_pins>;
 	pinctrl-names = "default";
-	nvmem-cells = <&macaddr_uboot_ethaddr 0>;
-	nvmem-cell-names = "mac-address";
 };
 
 &gswip_mdio {

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7510kw22.dtsi
@@ -116,6 +116,11 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_boardconfig_16 2>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gphy0 {
 	lantiq,gphy-mode = <GPHY_MODE_FE>;
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vgv7519.dtsi
@@ -216,6 +216,8 @@
 		label = "wan";
 		phy-mode = "rgmii";
 		phy-handle = <&phy5>;
+		nvmem-cells = <&macaddr_boardconfig_16 0>;
+		nvmem-cell-names = "mac-address";
 	};
 };
 

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vrv9510kwac23.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_arcadyan_vrv9510kwac23.dts
@@ -314,6 +314,8 @@
 		label = "wan";
 		phy-mode = "internal";
 		phy-handle = <&phy13>;
+		nvmem-cells = <&macaddr_boardconfig_16 0>;
+		nvmem-cell-names = "mac-address";
 	};
 	port@5 {
 		reg = <5>;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_bt_homehub-v5a.dts
@@ -226,11 +226,6 @@
 	};
 };
 
-&ppe {
-	nvmem-cells = <&macaddr_caldata_110c 4>;
-	nvmem-cell-names = "mac-address";
-};
-
 &localbus {
 	flash@1 {
 		compatible = "lantiq,nand-xway";

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_lantiq_easy80920.dtsi
@@ -106,6 +106,11 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&ppe {
+	nvmem-cells = <&macaddr_uboot_ethaddr 1>;
+	nvmem-cell-names = "mac-address";
+};
+
 &gphy0 {
 	lantiq,gphy-mode = <GPHY_MODE_GE>;
 };

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_zyxel_p-2812hnu-fx.dtsi
@@ -157,7 +157,15 @@
 		    <&gphy0_led1_pins>, <&gphy0_led2_pins>,
 		    <&gphy1_led1_pins>, <&gphy1_led2_pins>;
 	pinctrl-names = "default";
+};
+
+&eth0 {
 	nvmem-cells = <&macaddr_uboot_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ppe {
+	nvmem-cells = <&macaddr_uboot_ethaddr 1>;
 	nvmem-cell-names = "mac-address";
 };
 


### PR DESCRIPTION
In the original userspace implementation, the WAN and DSL interfaces used the same MAC. Mirror that here.


Link: https://github.com/openwrt/openwrt/pull/21081

(cherry picked from commit 02f40d63e23a67aad34aae01079352ae6f690e2c)

Needed for 25.12 to avoid random MAC address.

More info: https://github.com/openwrt/openwrt/pull/21081#issuecomment-4004242307
