### PR TITLE
airoha: add support for AN7581+MT7996 NPU firmware

### DIFF
--- a/target/linux/airoha/dts/an7581-evb-emmc.dts
+++ b/target/linux/airoha/dts/an7581-evb-emmc.dts
@@ -232,6 +232,12 @@
 	};
 };
 
+&npu {
+	firmware-name = "airoha/en7581_MT7996_npu_rv32.bin",
+			"airoha/en7581_MT7996_npu_data.bin";
+	status = "okay";
+};
+
 &eth {
 	status = "okay";
 };

--- a/target/linux/airoha/dts/an7581.dtsi
+++ b/target/linux/airoha/dts/an7581.dtsi
@@ -54,6 +54,11 @@
 			no-map;
 			reg = <0x0 0x90c00000 0x0 0x6800>;
 		};
+
+		npu_ba: npu-ba@90c06800 {
+			no-map;
+			reg = <0x0 0x90c06800 0x0 0x200000>;
+		};
 	};
 
 	psci {
@@ -855,9 +860,10 @@
 				     <GIC_SPI 122 IRQ_TYPE_LEVEL_HIGH>,
 				     <GIC_SPI 123 IRQ_TYPE_LEVEL_HIGH>;
 			memory-region = <&npu_binary>, <&npu_pkt>, <&npu_txpkt>,
-					<&npu_txbufid>;
+					<&npu_txbufid>, <&npu_ba>;
 			memory-region-names = "binary", "pkt", "tx-pkt",
-					      "tx-bufid";
+					      "tx-bufid", "ba";
+			status = "disabled";
 		};
 
 		eth: ethernet@1fb50000 {

--- a/target/linux/airoha/patches-6.12/910-01-v7.0-net-airoha-npu-Init-BA-memory-region-if.patch
+++ b/target/linux/airoha/patches-6.12/910-01-v7.0-net-airoha-npu-Init-BA-memory-region-if.patch
@@ -1,0 +1,34 @@
+From 875a59c9a9e584d99d8e9e5aa8435ec9300bfe91 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Thu, 8 Jan 2026 16:05:08 +0100
+Subject: [PATCH] net: airoha: npu: Init BA memory region if provided via DTS
+
+Initialize NPU Block Ack memory region if reserved via DTS.
+Block Ack memory region is used by NPU MT7996 (Eagle) offloading.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Link: https://patch.msgid.link/20260108-airoha-ba-memory-region-v3-2-bf1814e5dcc4@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_npu.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
+index 22f72c14606599..a56b3780bb627c 100644
+--- a/drivers/net/ethernet/airoha/airoha_npu.c
++++ b/drivers/net/ethernet/airoha/airoha_npu.c
+@@ -519,6 +519,14 @@ static int airoha_npu_wlan_init_memory(struct airoha_npu *npu)
+ 	if (err)
+ 		return err;
+ 
++	if (of_property_match_string(npu->dev->of_node, "memory-region-names",
++				     "ba") >= 0) {
++		cmd = WLAN_FUNC_SET_WAIT_DRAM_BA_NODE_ADDR;
++		err = airoha_npu_wlan_set_reserved_memory(npu, 0, "ba", cmd);
++		if (err)
++			return err;
++	}
++
+ 	cmd = WLAN_FUNC_SET_WAIT_IS_FORCE_TO_CPU;
+ 	return airoha_npu_wlan_msg_send(npu, 0, cmd, &val, sizeof(val),
+ 					GFP_KERNEL);

--- a/target/linux/airoha/patches-6.12/910-02-v7.0-net-airoha-npu-Add-the-capability-to-read-firmware-n.patch
+++ b/target/linux/airoha/patches-6.12/910-02-v7.0-net-airoha-npu-Add-the-capability-to-read-firmware-n.patch
@@ -1,0 +1,121 @@
+From 3847173525e307ebcd23bd4863da943ea78b0057 Mon Sep 17 00:00:00 2001
+From: Lorenzo Bianconi <lorenzo@kernel.org>
+Date: Tue, 20 Jan 2026 11:17:18 +0100
+Subject: [PATCH] net: airoha: npu: Add the capability to read firmware names
+ from dts
+
+Introduce the capability to read the firmware binary names from device-tree
+using the firmware-name property if available.
+This patch is needed because NPU firmware binaries are board specific since
+they depend on the MediaTek WiFi chip used on the board (e.g. MT7996 or
+MT7992) and the WiFi chip version info is not available in the NPU driver.
+This is a preliminary patch to enable MT76 NPU offloading if the Airoha SoC
+is equipped with MT7996 (Eagle) WiFi chipset.
+
+Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
+Reviewed-by: Andrew Lunn <andrew@lunn.ch>
+Link: https://patch.msgid.link/20260120-airoha-npu-firmware-name-v4-2-88999628b4c1@kernel.org
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/airoha/airoha_npu.c | 46 ++++++++++++++++++++----
+ 1 file changed, 40 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/ethernet/airoha/airoha_npu.c b/drivers/net/ethernet/airoha/airoha_npu.c
+index a56b3780bb627c..89f22f3f47dc56 100644
+--- a/drivers/net/ethernet/airoha/airoha_npu.c
++++ b/drivers/net/ethernet/airoha/airoha_npu.c
+@@ -16,6 +16,8 @@
+ 
+ #define NPU_EN7581_FIRMWARE_DATA		"airoha/en7581_npu_data.bin"
+ #define NPU_EN7581_FIRMWARE_RV32		"airoha/en7581_npu_rv32.bin"
++#define NPU_EN7581_7996_FIRMWARE_DATA		"airoha/en7581_MT7996_npu_data.bin"
++#define NPU_EN7581_7996_FIRMWARE_RV32		"airoha/en7581_MT7996_npu_rv32.bin"
+ #define NPU_AN7583_FIRMWARE_DATA		"airoha/an7583_npu_data.bin"
+ #define NPU_AN7583_FIRMWARE_RV32		"airoha/an7583_npu_rv32.bin"
+ #define NPU_EN7581_FIRMWARE_RV32_MAX_SIZE	0x200000
+@@ -195,18 +197,18 @@ static int airoha_npu_send_msg(struct airoha_npu *npu, int func_id,
+ }
+ 
+ static int airoha_npu_load_firmware(struct device *dev, void __iomem *addr,
+-				    const struct airoha_npu_fw *fw_info)
++				    const char *fw_name, int fw_max_size)
+ {
+ 	const struct firmware *fw;
+ 	int ret;
+ 
+-	ret = request_firmware(&fw, fw_info->name, dev);
++	ret = request_firmware(&fw, fw_name, dev);
+ 	if (ret)
+ 		return ret == -ENOENT ? -EPROBE_DEFER : ret;
+ 
+-	if (fw->size > fw_info->max_size) {
++	if (fw->size > fw_max_size) {
+ 		dev_err(dev, "%s: fw size too overlimit (%zu)\n",
+-			fw_info->name, fw->size);
++			fw_name, fw->size);
+ 		ret = -E2BIG;
+ 		goto out;
+ 	}
+@@ -218,6 +220,28 @@ static int airoha_npu_load_firmware(struct device *dev, void __iomem *addr,
+ 	return ret;
+ }
+ 
++static int
++airoha_npu_load_firmware_from_dts(struct device *dev, void __iomem *addr,
++				  void __iomem *base)
++{
++	const char *fw_names[2];
++	int ret;
++
++	ret = of_property_read_string_array(dev->of_node, "firmware-name",
++					    fw_names, ARRAY_SIZE(fw_names));
++	if (ret != ARRAY_SIZE(fw_names))
++		return -EINVAL;
++
++	ret = airoha_npu_load_firmware(dev, addr, fw_names[0],
++				       NPU_EN7581_FIRMWARE_RV32_MAX_SIZE);
++	if (ret)
++		return ret;
++
++	return airoha_npu_load_firmware(dev, base + REG_NPU_LOCAL_SRAM,
++					fw_names[1],
++					NPU_EN7581_FIRMWARE_DATA_MAX_SIZE);
++}
++
+ static int airoha_npu_run_firmware(struct device *dev, void __iomem *base,
+ 				   struct resource *res)
+ {
+@@ -233,14 +257,22 @@ static int airoha_npu_run_firmware(struct device *dev, void __iomem *base,
+ 	if (IS_ERR(addr))
+ 		return PTR_ERR(addr);
+ 
++	/* Try to load firmware images using the firmware names provided via
++	 * dts if available.
++	 */
++	if (of_find_property(dev->of_node, "firmware-name", NULL))
++		return airoha_npu_load_firmware_from_dts(dev, addr, base);
++
+ 	/* Load rv32 npu firmware */
+-	ret = airoha_npu_load_firmware(dev, addr, &soc->fw_rv32);
++	ret = airoha_npu_load_firmware(dev, addr, soc->fw_rv32.name,
++				       soc->fw_rv32.max_size);
+ 	if (ret)
+ 		return ret;
+ 
+ 	/* Load data npu firmware */
+ 	return airoha_npu_load_firmware(dev, base + REG_NPU_LOCAL_SRAM,
+-					&soc->fw_data);
++					soc->fw_data.name,
++					soc->fw_data.max_size);
+ }
+ 
+ static irqreturn_t airoha_npu_mbox_handler(int irq, void *npu_instance)
+@@ -790,6 +822,8 @@ module_platform_driver(airoha_npu_driver);
+ 
+ MODULE_FIRMWARE(NPU_EN7581_FIRMWARE_DATA);
+ MODULE_FIRMWARE(NPU_EN7581_FIRMWARE_RV32);
++MODULE_FIRMWARE(NPU_EN7581_7996_FIRMWARE_DATA);
++MODULE_FIRMWARE(NPU_EN7581_7996_FIRMWARE_RV32);
+ MODULE_FIRMWARE(NPU_AN7583_FIRMWARE_DATA);
+ MODULE_FIRMWARE(NPU_AN7583_FIRMWARE_RV32);
+ MODULE_LICENSE("GPL");


### PR DESCRIPTION
This PR backports two patches queued for 7.0 that add support for loading AN7581+MT7996 NPU firmware to enable offload on this platform.

As of 57bf713ef7d427e4b83c05ae4f72b0f817598837 this firmware package is now available in OpenWrt as `airoha-en7581-mt7996-npu-firmware`.

Update the `an7581-evb-emmc` device tree to demonstrate integration of this package.

Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>