### PR TITLE
package: network: fix command injection in dsl_cpe_pipe.sh

### DIFF
--- a/package/network/config/ltq-adsl-app/files/dsl_cpe_pipe.sh
+++ b/package/network/config/ltq-adsl-app/files/dsl_cpe_pipe.sh
@@ -11,7 +11,7 @@ esac
 
 #echo "Call dsl_pipe with $*"
 lock /var/lock/dsl_pipe
-echo $* > /tmp/pipe/dsl_cpe${pipe_no}_cmd
+echo "$*" > /tmp/pipe/dsl_cpe${pipe_no}_cmd
 result=$(cat /tmp/pipe/dsl_cpe${pipe_no}_ack)
 lock -u /var/lock/dsl_pipe
 

--- a/package/network/config/ltq-vdsl-vr11-app/files/dsl_cpe_pipe.sh
+++ b/package/network/config/ltq-vdsl-vr11-app/files/dsl_cpe_pipe.sh
@@ -11,7 +11,7 @@ esac
 
 #echo "Call dsl_pipe with $*"
 lock /var/lock/dsl_pipe
-echo $* > /tmp/pipe/dsl_cpe${pipe_no}_cmd
+echo "$*" > /tmp/pipe/dsl_cpe${pipe_no}_cmd
 result=$(cat /tmp/pipe/dsl_cpe${pipe_no}_ack)
 lock -u /var/lock/dsl_pipe
 

--- a/package/network/config/ltq-vdsl-vr9-app/files/dsl_cpe_pipe.sh
+++ b/package/network/config/ltq-vdsl-vr9-app/files/dsl_cpe_pipe.sh
@@ -11,7 +11,7 @@ esac
 
 #echo "Call dsl_pipe with $*"
 lock /var/lock/dsl_pipe
-echo $* > /tmp/pipe/dsl_cpe${pipe_no}_cmd
+echo "$*" > /tmp/pipe/dsl_cpe${pipe_no}_cmd
 result=$(cat /tmp/pipe/dsl_cpe${pipe_no}_ack)
 lock -u /var/lock/dsl_pipe
 


### PR DESCRIPTION
Fix potential command injection vulnerability in DSL CPE pipe scripts by properly quoting the $* variable expansion.

Affected files:
- package/network/config/ltq-vdsl-vr9-app/files/dsl_cpe_pipe.sh
- package/network/config/ltq-adsl-app/files/dsl_cpe_pipe.sh
- package/network/config/ltq-vdsl-vr11-app/files/dsl_cpe_pipe.sh

Security: This prevents potential shell injection attacks when malicious arguments are passed to these scripts.

The unquoted $* allows word splitting and glob expansion which could be exploited by passing specially crafted arguments.