### PR TITLE
ramips: mt7621: use dts for label mac

### DIFF
--- a/target/linux/ramips/dts/mt7621_alfa-network_ax1800rm.dts
+++ b/target/linux/ramips/dts/mt7621_alfa-network_ax1800rm.dts
@@ -124,7 +124,7 @@
 						reg = <0x0 0xe00>;
 					};
 
-					macaddr: macaddr@4 {
+					macaddr_factory_4: macaddr@4 {
 						compatible = "mac-base";
 						reg = <0x4 0x6>;
 						#nvmem-cell-cells = <1>;
@@ -152,18 +152,33 @@
 };
 
 &pcie1 {
-	wifi0: wifi@0,0 {
+	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 
 		nvmem-cells = <&eeprom>;
 		nvmem-cell-names = "eeprom";
 		mediatek,disable-radar-background;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		wifi0: band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_factory_4 0>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_factory_4 1>;
+			nvmem-cell-names = "mac-address";
+		};
 	};
 };
 
 &gmac0 {
-	nvmem-cells = <&macaddr 2>;
+	nvmem-cells = <&macaddr_factory_4 2>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -172,7 +187,7 @@
 	label = "wan";
 	phy-handle = <&ethphy4>;
 
-	nvmem-cells = <&macaddr 3>;
+	nvmem-cells = <&macaddr_factory_4 3>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ramips/dts/mt7621_asus_rt-acx5p.dtsi
+++ b/target/linux/ramips/dts/mt7621_asus_rt-acx5p.dtsi
@@ -12,6 +12,7 @@
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &wifi0;
 	};
 
 	keys {
@@ -95,6 +96,10 @@
 					reg = <0x0 0x4da8>;
 				};
 
+				macaddr_factory_4: macaddr@4 {
+					reg = <0x4 0x6>;
+				};
+
 				eeprom_factory_8000: eeprom@8000 {
 					reg = <0x8000 0x4da8>;
 				};
@@ -136,8 +141,8 @@
 	wifi0: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;
 	};
 };

--- a/target/linux/ramips/dts/mt7621_jcg_y2.dts
+++ b/target/linux/ramips/dts/mt7621_jcg_y2.dts
@@ -13,6 +13,7 @@
 		led-boot = &led_internet;
 		led-failsafe = &led_internet;
 		led-upgrade = &led_internet;
+		label-mac-device = &wifi0;
 	};
 
 	leds {
@@ -75,6 +76,10 @@
 						reg = <0x0 0x4da8>;
 					};
 
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
 					macaddr_factory_e000: macaddr@e000 {
 						reg = <0xe000 0x6>;
 					};
@@ -104,6 +109,15 @@
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_0>;
 		nvmem-cell-names = "eeprom";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		wifi0: band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_factory_4>;
+			nvmem-cell-names = "mac-address";
+		};
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_mr600-v2-eu.dts
@@ -211,7 +211,7 @@
 	label = "wan";
 	phy-handle = <&ethphy4>;
 
-	nvmem-cells = <&macaddr_romfile_f100 0>;
+	nvmem-cells = <&macaddr_romfile_f100 1>;
 	nvmem-cell-names = "mac-address";
 };
 

--- a/target/linux/ramips/dts/mt7621_wavlink_wl-wn53xax.dtsi
+++ b/target/linux/ramips/dts/mt7621_wavlink_wl-wn53xax.dtsi
@@ -12,6 +12,7 @@
 		led-failsafe = &led_status_red;
 		led-running = &led_status_blue;
 		led-upgrade = &led_status_red;
+		label-mac-device = &wifi0;
 	};
 
 	keys {
@@ -108,6 +109,10 @@
 						reg = <0x0 0x400>;
 					};
 
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
 					eeprom_factory_8000: eeprom@8000 {
 						reg = <0x8000 0x4da8>;
 					};
@@ -145,8 +150,8 @@
 	wifi0: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
+++ b/target/linux/ramips/dts/mt7621_winstars_ws-wn583a6.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &led_status_red;
 		led-running = &led_status_blue;
 		led-upgrade = &led_status_red;
+		label-mac-device = &wifi0;
 	};
 
 	leds {
@@ -101,6 +102,10 @@
 						reg = <0x0 0x400>;
 					};
 
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
 					eeprom_factory_8000: eeprom@8000 {
 						reg = <0x8000 0x4da8>;
 					};
@@ -129,11 +134,11 @@
 };
 
 &pcie0 {
-	wifi@0,0 {
+	wifi0: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
+++ b/target/linux/ramips/dts/mt7621_yuncore_ax820.dts
@@ -15,6 +15,7 @@
 		led-failsafe = &led_system;
 		led-running = &led_system;
 		led-upgrade = &led_system;
+		label-mac-device = &wifi0;
 	};
 
 	chosen {
@@ -125,6 +126,10 @@
 						reg = <0x0 0xe00>;
 					};
 
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
 					precal_factory_e10: precal@e10 {
 						reg = <0xe10 0x19c10>;
 					};
@@ -157,6 +162,15 @@
 		nvmem-cells = <&eeprom_factory_0>, <&precal_factory_e10>;
 		nvmem-cell-names = "eeprom", "precal";
 		mediatek,disable-radar-background;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		wifi0: band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_factory_4>;
+			nvmem-cell-names = "mac-address";
+		};
 	};
 };
 

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wexx26.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wexx26.dtsi
@@ -62,8 +62,8 @@
 	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {
@@ -114,6 +114,10 @@
 
 					eeprom_factory_0: eeprom@0 {
 						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
 					};
 
 					eeprom_factory_8000: eeprom@8000 {

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg108.dts
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg108.dts
@@ -76,6 +76,10 @@
 						reg = <0x0 0x400>;
 					};
 
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
 					eeprom_factory_8000: eeprom@8000 {
 						reg = <0x8000 0x200>;
 					};
@@ -140,8 +144,8 @@
 	wifi1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <2400000 2500000>;
 
 		led {

--- a/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
+++ b/target/linux/ramips/dts/mt7621_zbtlink_zbt-wg3526.dtsi
@@ -87,6 +87,10 @@
 						reg = <0x0 0x400>;
 					};
 
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
 					eeprom_factory_8000: eeprom@8000 {
 						reg = <0x8000 0x200>;
 					};
@@ -115,8 +119,8 @@
 	wifi0: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		nvmem-cells = <&eeprom_factory_0>;
-		nvmem-cell-names = "eeprom";
+		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+		nvmem-cell-names = "eeprom", "mac-address";
 	};
 };
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -210,17 +210,6 @@ ramips_setup_macs()
 	local label_mac=""
 
 	case $board in
-	alfa-network,ax1800rm|\
-	jcg,y2|\
-	wavlink,wl-wn531a6|\
-	wavlink,wl-wn533a8|\
-	winstars,ws-wn583a6|\
-	zbtlink,zbt-we1326|\
-	zbtlink,zbt-wg108|\
-	zbtlink,zbt-wg3526-16m|\
-	zbtlink,zbt-wg3526-32m)
-		label_mac=$(mtd_get_mac_binary factory 0x4)
-		;;
 	ampedwireless,ally-00x19k)
 		lan_mac=$(mtd_get_mac_ascii hwconfig HW.LAN.MAC.Address)
 		label_mac=$lan_mac
@@ -242,7 +231,6 @@ ramips_setup_macs()
 	asus,rt-ac65p|\
 	asus,rt-ac85p)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env et1macaddr)
-		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;
 	beeline,smartbox-flash)
 		wan_mac=$(mtd_get_mac_encrypted_arcadyan "board_data")
@@ -291,8 +279,7 @@ ramips_setup_macs()
 		wan_mac=$(macaddr_add "$label_mac" 1)
 		;;
 	tplink,mr600-v2-eu)
-		label_mac=$(cat "/sys/class/net/eth0/address")
-		wwan_mac=$(macaddr_add $label_mac 1)
+		wwan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
 		ucidef_set_interface "wwan0" device "/dev/cdc-wdm0" protocol "qmi" macaddr "$wwan_mac"
 		;;
 	ruijie,rg-ew1200g-pro-v1.1|\
@@ -318,9 +305,6 @@ ramips_setup_macs()
 	netgear,wax214v2)
 		lan_mac=$(mtd_get_mac_ascii Config ethaddr)
 		label_mac=$lan_mac
-		;;
-	yuncore,ax820)
-		label_mac=$(mtd_get_mac_binary Factory 0x4)
 		;;
 	esac
 


### PR DESCRIPTION
Userspace handling was needed before band mac overrides.

ping @DragonBluep 