### PR TITLE
realtek: rtl930x: Add Hasivo S600WP-5GT-2SX-SE

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -77,6 +77,7 @@ realtek_setup_macs()
 		;;
 	d-link,dgs-1250-28x|\
 	hasivo,s1100wp-8gt-se|\
+	hasivo,s600wp-5gt-2sx-se|\
 	hpe,1920-8g|\
 	hpe,1920-8g-poe-65w|\
 	hpe,1920-8g-poe-180w|\

--- a/target/linux/realtek/dts/rtl9303_hasivo_s600wp-5gt-2sx-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s600wp-5gt-2sx-se.dts
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "hasivo,s600wp-5gt-2sx-se";
+	model = "Hasivo S600WP-5GT-2SX-SE";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x08000000>; /* 128 MiB */
+	};
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+		label-mac-device = &ethernet0;
+	};
+
+	chosen {
+		stdout-path = "serial0:38400n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_sys_led>, <&pinmux_enable_led_sync>;
+
+		led_sys: led-0 {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+
+		/* Port 25 is unused but present in the HC595 shift
+		 * register chain. Force it into the serial LED stream
+		 * to align all LED positions correctly.
+		 */
+		realtek,led-set0-force-port-mask = <(1 << 25)>;
+
+		/*
+		 * RJ45 LED0 (green): 1G/LINK/ACT
+		 * RJ45 LED1 (green): 10M/100M/LINK/ACT
+		 * RJ45 LED2 (orange): 2.5G/LINK/ACT
+		 */
+		led_set0 = <(RTL93XX_LED_SET_1G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_10M | RTL93XX_LED_SET_100M |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)>;
+
+		/*
+		 * SFP+ LED0: 10G/LINK/ACT
+		 * SFP+ LED1: 1G/LINK/ACT
+		 * SFP+ LED2: spacer to keep 3 slots per port
+		 */
+		led_set1 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_1G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_NONE)>;
+	};
+
+	/*
+	 * TODO: I2C bus to the on-board HS104 PSE controller (PoE).
+	 * Defined here for documentation/future use; currently unused
+	 * because PSE/PoE support for this board is not yet wired up.
+	 */
+	i2c_scl23_sda22: i2c-scl23-sda22 {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		scl-gpios = <&gpio0 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+	};
+
+	i2c_sfp0: i2c-sfp0 {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		scl-gpios = <&gpio0 7 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 6 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <50>;
+	};
+
+	i2c_sfp1: i2c-sfp1 {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		scl-gpios = <&gpio0 11 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 10 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <50>;
+	};
+
+	sfp0: sfp-p26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_sfp0>;
+		mod-def0-gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2500>;
+	};
+
+	sfp1: sfp-p27 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c_sfp1>;
+		mod-def0-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		maximum-power-milliwatt = <2500>;
+		/*
+		 * Stock firmware wires tx-disable to GPIO 12 (FB_TXDIS_1).
+		 * The pin is not claimed by the hardware I2C controller
+		 * (SDA pinmux is in GPIO mode) but still cannot be driven
+		 * HIGH for unknown reasons. Omitted for now.
+		 */
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "fudan,fm25q128", "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* stock is LOADER */
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x00e0000>;
+				read-only;
+			};
+
+			/* stock is BDINFO */
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x00e0000 0x0010000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_ubootenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+					serialnumber_ubootenv: serialnumber {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_bt_port_no_ubootenv: pse_bt_port_no {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_existed_flag_ubootenv: pse_existed_flag {
+						#nvmem-cell-cells = <1>;
+					};
+					pse_power_bank_ubootenv: pse_power_bank {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			/* stock is SYSINFO */
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0x00f0000 0x0010000>;
+				read-only;
+			};
+
+			/* stock is JFFS2_CFG */
+			partition@100000 {
+				label = "jffs";
+				reg = <0x0100000 0x0100000>;
+			};
+
+			/* stock is JFFS2_LOG */
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x0200000 0x0100000>;
+			};
+
+			/* stock is RUNTIME */
+			partition@300000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x0300000 0x0c00000>;
+			};
+
+			/* stock is OEMINFO */
+			partition@f00000 {
+				label = "oeminfo";
+				reg = <0x0f00000 0x0100000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_bus0 {
+	/* External RTL8221B PHYs */
+	PHY_C45(0, 1)
+	PHY_C45(8, 2)
+	PHY_C45(16, 3)
+	PHY_C45(20, 4)
+};
+
+&mdio_bus1 {
+	/* External RTL8221B PHY */
+	PHY_C45(24, 1)
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+			pcs-handle = <&serdes2>;
+			phy-handle = <&phy0>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@8 {
+			reg = <8>;
+			label = "lan2";
+			pcs-handle = <&serdes3>;
+			phy-handle = <&phy8>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@16 {
+			reg = <16>;
+			label = "lan3";
+			pcs-handle = <&serdes4>;
+			phy-handle = <&phy16>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@20 {
+			reg = <20>;
+			label = "lan4";
+			pcs-handle = <&serdes5>;
+			phy-handle = <&phy20>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		port@24 {
+			reg = <24>;
+			label = "lan5";
+			pcs-handle = <&serdes6>;
+			phy-handle = <&phy24>;
+			phy-mode = "sgmii";
+			managed = "in-band-status";
+			led-set = <0>;
+		};
+
+		SWITCH_PORT_SFP(26, 6, 8, 1, 0)
+		SWITCH_PORT_SFP(27, 7, 9, 1, 1)
+
+		/* Internal SoC */
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -30,6 +30,15 @@ define Device/hasivo_s1100wp-8gt-se
 endef
 TARGET_DEVICES += hasivo_s1100wp-8gt-se
 
+define Device/hasivo_s600wp-5gt-2sx-se
+  SOC := rtl9303
+  DEVICE_VENDOR := Hasivo
+  DEVICE_MODEL := S600WP-5GT-2SX-SE
+  IMAGE_SIZE := 12288k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += hasivo_s600wp-5gt-2sx-se
+
 define Device/plasmacloud-common
   SOC := rtl9302
   UIMAGE_MAGIC := 0x93000000


### PR DESCRIPTION
This commit adds support for Hasivo S600WP-5GT-2SX-SE switch.

The pse part does not work yet, but we are working on the driver...
I could not make i2c connect to any sfp module, but the modules itself are working well. I wonder if the i2c is not wired at all. I get a connection to the MFD & pse module via i2c... 

Sadly I have never tested it with the stock firmware before overwriting the flash. @bevanweiss @plappermaul @jonasjelonek any thought on this?

best,
