### PR TITLE
ramips: fix for Keenetic KN-1910

### DIFF
--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -111,6 +111,7 @@ platform_do_upgrade() {
 	iptime,ax2004m|\
 	iptime,t5004|\
 	jcg,q20|\
+	keenetic,kn-1910|\
 	keenetic,kn-3510|\
 	linksys,e5600|\
 	linksys,e7350|\


### PR DESCRIPTION
Set nand flash for KN-1910

Sysupgrade or any other methods i tried (asu, owut) not working without it. Tested with a local build.

Signed-off-by: Esat Yiğithan GÖKTOPRAK <eygoktoprak@gmail.com>