### PR TITLE
base-files wifi-scripts: allow customization of physical button behavior

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -265,6 +265,16 @@ else
 	$(if $(CONFIG_IPK_FILES_CHECKSUMS),, \
 		rm -f $(1)/sbin/pkg_check)
 endif
+$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_FAILSAFE_DISABLED), \
+	rm -f $(1)/etc/rc.button/failsafe)
+$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_POWER_DISABLED), \
+	rm -f $(1)/etc/rc.button/power)
+$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_REBOOT_DISABLED), \
+	rm -f $(1)/etc/rc.button/reboot)
+$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_RESET_DISABLED), \
+	rm -f $(1)/etc/rc.button/reset)
+$(if $(CONFIG_TARGET_BUTTON_CUSTOMIZATION_RF_KILL_DISABLED), \
+	rm -f $(1)/etc/rc.button/rfkill)
 endef
 
 ifneq ($(DUMP),1)

--- a/package/base-files/files/etc/rc.button/rfkill
+++ b/package/base-files/files/etc/rc.button/rfkill
@@ -6,12 +6,21 @@
 
 rfkill_state=0
 
+wifi_radio_rfkill_disabled() {
+	local rfkill_disabled
+	rfkill_disabled=0
+	config_get rfkill_disabled $1 rfkill_disabled
+	echo $rfkill_disabled
+}
+
 wifi_rfkill_set() {
+	[ "$(wifi_radio_rfkill_disabled $1)" = "1" ] && return
 	uci set wireless.$1.disabled=$rfkill_state
 }
 
 wifi_rfkill_check() {
 	local disabled
+	[ "$(wifi_radio_rfkill_disabled $1)" = "1" ] && return
 	config_get disabled $1 disabled
 	[ "$disabled" = "1" ] || rfkill_state=1
 }

--- a/package/base-files/image-config.in
+++ b/package/base-files/image-config.in
@@ -287,6 +287,50 @@ if VERSIONOPT
 			file names
 endif
 
+menuconfig TARGET_BUTTON_CUSTOMIZATION
+	bool "Target button customization" if IMAGEOPT
+	default n
+	help
+		These options allow to customize the behaviour of the buttons defined in
+		the target's /etc/rc.button/* scripts.  This is useful for release builds
+		or custom OpenWrt redistributions where certain default button handling logic
+		may be undesired.
+
+	config TARGET_BUTTON_CUSTOMIZATION_FAILSAFE_DISABLED
+		bool
+		prompt "Disable failsafe button handling" if TARGET_BUTTON_CUSTOMIZATION
+		default n
+		help
+			If set, the failsafe button handling logic in /etc/rc.button/failsafe is disabled.
+
+	config TARGET_BUTTON_CUSTOMIZATION_POWER_DISABLED
+		bool
+		prompt "Disable power button handling" if TARGET_BUTTON_CUSTOMIZATION
+		default n
+		help
+			If set, the power button handling logic in /etc/rc.button/power is disabled.
+
+	config TARGET_BUTTON_CUSTOMIZATION_REBOOT_DISABLED
+		bool
+		prompt "Disable reboot button handling" if TARGET_BUTTON_CUSTOMIZATION
+		default n
+		help
+			If set, the reboot button handling logic in /etc/rc.button/reboot is disabled.
+
+	config TARGET_BUTTON_CUSTOMIZATION_RESET_DISABLED
+		bool
+		prompt "Disable reset button handling" if TARGET_BUTTON_CUSTOMIZATION
+		default n
+		help
+			If set, the reset button handling logic in /etc/rc.button/reset is disabled.
+
+	config TARGET_BUTTON_CUSTOMIZATION_RF_KILL_DISABLED
+		bool
+		prompt "Disable rfkill button handling" if TARGET_BUTTON_CUSTOMIZATION
+		default n
+		help
+			If set, the rfkill button handling logic in /etc/rc.button/rfkill is disabled.
+
 
 menuconfig PER_FEED_REPO
 	bool "Separate feed repositories" if IMAGEOPT

--- a/package/network/config/wifi-scripts/Config.in
+++ b/package/network/config/wifi-scripts/Config.in
@@ -1,3 +1,10 @@
 config WIFI_SCRIPTS_UCODE
 	bool "Use new ucode based scripts"
 	default y
+
+config WIFI_SCRIPTS_WPS_BUTTON_DISABLED
+	bool
+	prompt "Disable WPS button handling"
+	default n
+	help
+		If set, the WPS button handling logic in /etc/rc.button/wps is disabled.

--- a/package/network/config/wifi-scripts/Makefile
+++ b/package/network/config/wifi-scripts/Makefile
@@ -48,6 +48,9 @@ define Package/wifi-scripts/install
 ifeq ($(CONFIG_WIFI_SCRIPTS_UCODE),y)
 	$(CP) ./files-ucode/* $(1)/
 endif
+ifeq ($(CONFIG_WIFI_SCRIPTS_WPS_BUTTON_DISABLED),y)
+	rm -f $(1)/etc/rc.button/wps
+endif
 endef
 
 $(eval $(call BuildPackage,wifi-scripts))


### PR DESCRIPTION
[wifi-scripts: add option to disable WPS button handling](https://github.com/openwrt/openwrt/commit/cdf8afde3ebb7008dd07e2aea16023343122e243)

In case OpenWrt is used to build a custom distribution, the default
button handling logic may be undesired.

Add config options to disable default standard button handling code
at build-time.

---

[base-files: add options to disable default button handling](https://github.com/openwrt/openwrt/commit/5f49624417bc0bae00b81160d0a340434f2d570a)

In case OpenWrt is used to build a custom distribution, the default
button handling logic may be undesired.

Add config options to disable default standard button handling code
at build-time.


---

[base-files: allow per-radio rfkill button exclusion](https://github.com/openwrt/openwrt/commit/1c6db8ea23ac74b2509ae94d6966ed417ffe71a8)

Implement the new config value "rfkill_disabled".

This option can be set to "1" in order to retain enablement state of a
given radio in case the rfkill button is pressed.