### PR TITLE
sdk: use TOOLCHAIN_DIR_NAME for STAGING_SUBDIR_TOOLCHAIN

### DIFF
--- a/target/sdk/Makefile
+++ b/target/sdk/Makefile
@@ -18,7 +18,7 @@ SDK_BUILD_DIR:=$(BUILD_DIR)/$(SDK_NAME)
 
 STAGING_SUBDIR_HOST := staging_dir/host
 STAGING_SUBDIR_TARGET := staging_dir/$(TARGET_DIR_NAME)
-STAGING_SUBDIR_TOOLCHAIN := staging_dir/toolchain-$(ARCH)$(ARCH_SUFFIX)_gcc-$(GCCV)_$(LIBC)$(if $(CONFIG_arm),_eabi)
+STAGING_SUBDIR_TOOLCHAIN := staging_dir/$(TOOLCHAIN_DIR_NAME)
 
 BUNDLER_PATH := $(subst $(space),:,$(filter-out $(TOPDIR)/%,$(subst :,$(space),$(PATH))))
 BUNDLER_COMMAND := PATH=$(BUNDLER_PATH) $(XARGS) $(SCRIPT_DIR)/bundle-libraries.sh $(SDK_BUILD_DIR)/$(STAGING_SUBDIR_HOST)


### PR DESCRIPTION
Like a STAGING_SUBDIR_TARGET which uses TARGET_DIR_NAME, we can use TOOLCHAIN_DIR_NAME for STAGING_SUBDIR_TOOLCHAIN to avoid code duplication.