### PR TITLE
ramips: expand storage space on U6 lite

### DIFF
--- a/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
+++ b/target/linux/ramips/dts/mt7621_ubnt_unifi-6-lite.dts
@@ -96,12 +96,9 @@
 			partition@1d0000 {
 				compatible = "denx,fit";
 				label = "firmware";
-				reg = <0x1d0000 0xf10000>;
-			};
-
-			partition@10e0000 {
-				label = "kernel1";
-				reg = <0x10e0000 0xf10000>;
+				reg = <0x1d0000 0x1e20000>;
+				/* merge of kernel0 and kernel1, both 0xf10000 in size,
+				 * kernel1 starting at 0x10e0000 */
 			};
 		};
 	};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3258,14 +3258,17 @@ endef
 TARGET_DEVICES += ubnt_edgerouter-x-sfp
 
 define Device/ubnt_unifi-6-lite
-  $(Device/dsa-migration)
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := \
+	Dual kernel paritition merged due to size constraints. \
+	Use sysupgrade -F; image must not exceed 15424KiB (~15MiB).
   DEVICE_VENDOR := Ubiquiti
   DEVICE_MODEL := UniFi U6 Lite
   DEVICE_DTS_CONFIG := config@1
   DEVICE_DTS_LOADADDR := 0x87000000
   DEVICE_PACKAGES += kmod-mt7603 kmod-mt7915-firmware -uboot-envtools
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  IMAGE_SIZE := 15424k
+  IMAGE_SIZE := 30848k
 endef
 TARGET_DEVICES += ubnt_unifi-6-lite
 

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/05_compat-version
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 OpenWrt.org
+# Copyright (C) 2020-2026 OpenWrt.org
 #
 
 . /lib/functions.sh
@@ -10,6 +10,7 @@ board_config_update
 case "$(board_name)" in
 	ubnt,edgerouter-x|\
 	ubnt,edgerouter-x-sfp|\
+	ubnt,unifi-6-lite|\
 	iptime,ax2002m|\
 	iptime,ax2004m)
 		ucidef_set_compat_version "2.0"


### PR DESCRIPTION
While still sufficient for the base image, space runs out quickly with the ~15MiB available in kernel0.  The identical space in kernel1 is unused, and standard installation instructions flash to both areas so it isn't an easy fallback to stock either.

Merge the regions for kernel0 and kernel1 so there's more space available to the user to install packages and some data.
