### PR TITLE
ipq40xx: add support for Netgear RBR50v2 and RBS50v2

### DIFF
--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -73,12 +73,14 @@ ipq40xx_setup_interfaces()
 	ezviz,cs-w3-wd1200g-eup|\
 	netgear,rbr40|\
 	netgear,rbr50|\
+	netgear,rbr50-v2|\
 	netgear,srr60)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
 	avm,fritzbox-7530|\
 	netgear,rbs40|\
 	netgear,rbs50|\
+	netgear,rbs50-v2|\
 	netgear,srs60)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
@@ -237,6 +239,7 @@ ipq40xx_setup_macs()
 		;;
 	netgear,rbr40|\
 	netgear,rbr50|\
+	netgear,rbr50-v2|\
 	netgear,srr60|\
 	pakedge,wr-1)
 		wan_mac=$(macaddr_add $(get_mac_label) 1)

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -78,12 +78,14 @@ ipq40xx_setup_interfaces()
 	ezviz,cs-w3-wd1200g-eup|\
 	netgear,rbr40|\
 	netgear,rbr50|\
+	netgear,rbr50-v2|\
 	netgear,srr60)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" "wan"
 		;;
 	avm,fritzbox-7530|\
 	netgear,rbs40|\
 	netgear,rbs50|\
+	netgear,rbs50-v2|\
 	netgear,srs60)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -125,6 +125,8 @@ platform_do_upgrade() {
 	netgear,lbr20|\
 	netgear,rbr20|\
 	netgear,rbs20|\
+	netgear,rbr50-v2|\
+	netgear,rbs50-v2|\
 	netgear,wac510|\
 	p2w,r619ac-64m|\
 	p2w,r619ac-128m|\

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-rbr50-v2.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-rbr50-v2.dts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019-rbx50-v2.dtsi"
+
+/ {
+	model = "NETGEAR RBR50 v2";
+	compatible = "netgear,rbr50-v2";
+};
+
+&nand {
+	status = "okay";
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+
+	nand@0 {
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x00000000 0x00100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "0:MIBIB";
+				reg = <0x00100000 0x00100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "0:BOOTCONFIG";
+				reg = <0x00200000 0x00100000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "0:QSEE";
+				reg = <0x00300000 0x00100000>;
+				read-only;
+			};
+
+			partition@400000 {
+				label = "0:QSEE_1";
+				reg = <0x00400000 0x00100000>;
+				read-only;
+			};
+
+			partition@500000 {
+				label = "0:CDT";
+				reg = <0x00500000 0x00080000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "0:CDT_1";
+				reg = <0x00580000 0x00080000>;
+				read-only;
+			};
+
+			partition@600000 {
+				label = "0:BOOTCONFIG1";
+				reg = <0x00600000 0x00080000>;
+				read-only;
+			};
+
+			partition@680000 {
+				label = "0:APPSBLENV";
+				reg = <0x00680000 0x00080000>;
+			};
+
+			partition@700000 {
+				label = "0:APPSBL";
+				reg = <0x00700000 0x00200000>;
+				read-only;
+			};
+
+			partition@900000 {
+				label = "0:APPSBL_1";
+				reg = <0x00900000 0x00200000>;
+				read-only;
+			};
+
+			partition@b00000 {
+				label = "0:ART";
+				reg = <0x00b00000 0x00080000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					precal_art_1000: precal@1000 {
+						reg = <0x1000 0x2f20>;
+					};
+
+					precal_art_5000: precal@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+
+					precal_art_9000: precal@9000 {
+						reg = <0x9000 0x2f20>;
+					};
+				};
+			};
+
+			partition@b80000 {
+				label = "0:ART.bak";
+				reg = <0x00b80000 0x00080000>;
+				read-only;
+			};
+
+			partition@c00000 {
+				label = "config";
+				reg = <0x00c00000 0x00100000>;
+				read-only;
+			};
+
+			partition@d00000 {
+				label = "boarddata1";
+				reg = <0x00d00000 0x00080000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					mac_address_lan: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wan: macaddr@6 {
+						compatible = "mac-base";
+						reg = <0x6 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wlan_5g: macaddr@c {
+						compatible = "mac-base";
+						reg = <0xc 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wlan_2nd5g: macaddr@12 {
+						compatible = "mac-base";
+						reg = <0x12 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_bt: macaddr@18 {
+						compatible = "mac-base";
+						reg = <0x18 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@d80000 {
+				label = "boarddata2";
+				reg = <0x00d80000 0x00040000>;
+				read-only;
+			};
+
+			partition@dc0000 {
+				label = "pot";
+				reg = <0x00dc0000 0x00100000>;
+				read-only;
+			};
+
+			partition@ec0000 {
+				label = "boarddata1.bak";
+				reg = <0x00ec0000 0x00080000>;
+				read-only;
+			};
+
+			partition@f40000 {
+				label = "boarddata2.bak";
+				reg = <0x00f40000 0x00040000>;
+				read-only;
+			};
+
+			partition@f80000 {
+				label = "language";
+				reg = <0x00f80000 0x00500000>;
+				read-only;
+			};
+
+			partition@1480000 {
+				label = "cert";
+				reg = <0x01480000 0x00080000>;
+			};
+
+			partition@1500000 {
+				label = "ntgrdata";
+				reg = <0x01500000 0x09300000>;
+			};
+
+			partition@a800000 {
+				label = "firmware";
+				reg = <0x0a800000 0x06720000>;
+			};
+
+			partition@10f20000 {
+				label = "firmware2";
+				reg = <0x10f20000 0x06400000>;
+			};
+
+			partition@17320000 {
+				label = "reserved";
+				reg = <0x17320000 0x08ce0000>;
+			};
+		};
+	};
+};
+
+&swport1 {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&mac_address_wan 0>;
+	label = "wan";
+};
+
+&swport2 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport3 {
+	status = "okay";
+
+	label = "lan2";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan3";
+};

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-rbs50-v2.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-rbs50-v2.dts
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019-rbx50-v2.dtsi"
+
+/ {
+	model = "NETGEAR RBS50 v2";
+	compatible = "netgear,rbs50-v2";
+};
+
+&nand {
+	status = "okay";
+	pinctrl-0 = <&nand_pins>;
+	pinctrl-names = "default";
+
+	nand@0 {
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "0:SBL1";
+				reg = <0x00000000 0x00100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "0:MIBIB";
+				reg = <0x00100000 0x00100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "0:BOOTCONFIG";
+				reg = <0x00200000 0x00100000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "0:QSEE";
+				reg = <0x00300000 0x00100000>;
+				read-only;
+			};
+
+			partition@400000 {
+				label = "0:QSEE_1";
+				reg = <0x00400000 0x00100000>;
+				read-only;
+			};
+
+			partition@500000 {
+				label = "0:CDT";
+				reg = <0x00500000 0x00080000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "0:CDT_1";
+				reg = <0x00580000 0x00080000>;
+				read-only;
+			};
+
+			partition@600000 {
+				label = "0:BOOTCONFIG1";
+				reg = <0x00600000 0x00080000>;
+				read-only;
+			};
+
+			partition@680000 {
+				label = "0:APPSBLENV";
+				reg = <0x00680000 0x00080000>;
+			};
+
+			partition@700000 {
+				label = "0:APPSBL";
+				reg = <0x00700000 0x00200000>;
+				read-only;
+			};
+
+			partition@900000 {
+				label = "0:APPSBL_1";
+				reg = <0x00900000 0x00200000>;
+				read-only;
+			};
+
+			partition@b00000 {
+				label = "0:ART";
+				reg = <0x00b00000 0x00080000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					precal_art_1000: precal@1000 {
+						reg = <0x1000 0x2f20>;
+					};
+
+					precal_art_5000: precal@5000 {
+						reg = <0x5000 0x2f20>;
+					};
+
+					precal_art_9000: precal@9000 {
+						reg = <0x9000 0x2f20>;
+					};
+				};
+			};
+
+			partition@b80000 {
+				label = "0:ART.bak";
+				reg = <0x00b80000 0x00080000>;
+				read-only;
+			};
+
+			partition@c00000 {
+				label = "config";
+				reg = <0x00c00000 0x00100000>;
+				read-only;
+			};
+
+			partition@d00000 {
+				label = "boarddata1";
+				reg = <0x00d00000 0x00080000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					mac_address_lan: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wan: macaddr@6 {
+						compatible = "mac-base";
+						reg = <0x6 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wlan_5g: macaddr@c {
+						compatible = "mac-base";
+						reg = <0xc 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_wlan_2nd5g: macaddr@12 {
+						compatible = "mac-base";
+						reg = <0x12 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					mac_address_bt: macaddr@18 {
+						compatible = "mac-base";
+						reg = <0x18 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@d80000 {
+				label = "boarddata2";
+				reg = <0x00d80000 0x00040000>;
+				read-only;
+			};
+
+			partition@dc0000 {
+				label = "pot";
+				reg = <0x00dc0000 0x00100000>;
+				read-only;
+			};
+
+			partition@ec0000 {
+				label = "boarddata1.bak";
+				reg = <0x00ec0000 0x00080000>;
+				read-only;
+			};
+
+			partition@f40000 {
+				label = "boarddata2.bak";
+				reg = <0x00f40000 0x00040000>;
+				read-only;
+			};
+
+			partition@f80000 {
+				label = "language";
+				reg = <0x00f80000 0x00500000>;
+				read-only;
+			};
+
+			partition@1480000 {
+				label = "ntgrdata";
+				reg = <0x01480000 0x01e00000>;
+			};
+
+			partition@3280000 {
+				label = "firmware";
+				reg = <0x03280000 0x04d80000>;
+			};
+		};
+	};
+};
+
+&swport1 {
+	status = "okay";
+
+	label = "lan1";
+};
+
+&swport2 {
+	status = "okay";
+
+	label = "lan2";
+};
+
+&swport3 {
+	status = "okay";
+
+	label = "lan3";
+};
+
+&swport4 {
+	status = "okay";
+
+	label = "lan4";
+};

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-rbx50-v2.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-rbx50-v2.dtsi
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019-orbi.dtsi"
+
+/ {
+	chosen {
+		bootargs = "ubi.mtd=ubi root=/dev/ubiblock0_0";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led-1 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&tlmm 23 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led_status_green: led-2 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-3 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-4 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&tlmm 26 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_white: led-5 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&tlmm 27 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&sdhci {
+	status = "disabled";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&i2c_0_pins {
+	pinmux {
+		function = "blsp_i2c0";
+		pins = "gpio20", "gpio21";
+		bias-disable;
+	};
+};
+
+&tlmm {
+	nand_pins: nand-pins {
+		pullups {
+			pins = "gpio52", "gpio53", "gpio58", "gpio59";
+			function = "qpic";
+			bias-pull-up;
+		};
+
+		pulldowns {
+			pins = "gpio54", "gpio55", "gpio56",
+				"gpio57", "gpio60", "gpio61",
+				"gpio62", "gpio63", "gpio64",
+				"gpio65", "gpio66", "gpio67",
+				"gpio68", "gpio69";
+			function = "qpic";
+			bias-pull-down;
+		};
+	};
+};
+
+&gmac {
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&mac_address_lan 0>;
+};
+
+&pcie_bridge0 {
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x00010000 0 0 0 0>;
+		ieee80211-freq-limit = <5470000 5875000>;
+		nvmem-cell-names = "pre-calibration", "mac-address";
+		nvmem-cells = <&precal_art_9000>, <&mac_address_wlan_2nd5g 0>;
+		qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_1000>, <&mac_address_lan 0>;
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};
+
+&wifi1 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_5000>, <&mac_address_wlan_5g 0>;
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-rbx50-v2.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-rbx50-v2.dtsi
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	chosen {
+		bootargs = "ubi.mtd=ubi root=/dev/ubiblock0_0";
+	};
+
+	aliases {
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_blue;
+		ethernet0 = &gmac;
+		label-mac-device = &gmac;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&tlmm 49 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led-1 {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&tlmm 23 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led_status_green: led-2 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 24 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-3 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-4 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&tlmm 26 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_white: led-5 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&tlmm 27 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	soc {
+		counter@4a1000 {
+			compatible = "qcom,qca-gcnt";
+			reg = <0x4a1000 0x4>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@194b000 {
+			status = "okay";
+
+			compatible = "qcom,tcsr";
+			reg = <0x194b000 0x100>;
+			qcom,usb-hsphy-mode-select = <TCSR_USB_HSPHY_HOST_MODE>;
+		};
+
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&vqmmc {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio6";
+			function = "mdio";
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio7";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	serial_pins: serial_pinmux {
+		mux {
+			pins = "gpio16", "gpio17";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+
+	i2c_0_pins: i2c_0_pinmux {
+		pinmux {
+			function = "blsp_i2c0";
+			pins = "gpio20", "gpio21";
+			bias-disable;
+		};
+	};
+
+	nand_pins: nand-pins {
+		pullups {
+			pins = "gpio52", "gpio53", "gpio58", "gpio59";
+			function = "qpic";
+			bias-pull-up;
+		};
+
+		pulldowns {
+			pins = "gpio54", "gpio55", "gpio56",
+				"gpio57", "gpio60", "gpio61",
+				"gpio62", "gpio63", "gpio64",
+				"gpio65", "gpio66", "gpio67",
+				"gpio68", "gpio69";
+			function = "qpic";
+			bias-pull-down;
+		};
+	};
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_i2c3 {
+	pinctrl-0 = <&i2c_0_pins>;
+	pinctrl-names = "default";
+
+	status = "okay";
+
+	led-controller@27 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "ti,tlc59108"; /* really is tlc59208f */
+		reg = <0x27>;
+
+		led0@0 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <0>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x0>;
+			linux,default-trigger = "default-on";
+		};
+
+		led1@1 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x1>;
+			linux,default-trigger = "default-on";
+		};
+
+		led2@2 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x2>;
+			linux,default-trigger = "default-on";
+		};
+
+		led3@3 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x3>;
+			linux,default-trigger = "default-on";
+		};
+
+		led4@4 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <4>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x4>;
+			linux,default-trigger = "default-on";
+		};
+
+		led5@5 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <5>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x5>;
+			linux,default-trigger = "default-on";
+		};
+
+		led6@6 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <6>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x6>;
+			linux,default-trigger = "default-on";
+		};
+
+		led7@7 {
+			function = LED_FUNCTION_BACKLIGHT;
+			function-enumerator = <7>;
+			color = <LED_COLOR_ID_WHITE>;
+			reg = <0x7>;
+			linux,default-trigger = "default-on";
+		};
+	};
+};
+
+&blsp1_uart1 {
+	status = "okay";
+
+	pinctrl-0 = <&serial_pins>;
+	pinctrl-names = "default";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+};
+
+&gmac {
+	status = "okay";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&mac_address_lan 0>;
+};
+
+&switch {
+	status = "okay";
+};
+
+&ethphy4 {
+	status = "disabled";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+	wake-gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+};
+
+&pcie_bridge0 {
+	wifi@0,0 {
+		compatible = "qcom,ath10k";
+		reg = <0x00010000 0 0 0 0>;
+		ieee80211-freq-limit = <5470000 5875000>;
+		nvmem-cell-names = "pre-calibration", "mac-address";
+		nvmem-cells = <&precal_art_9000>, <&mac_address_wlan_2nd5g 0>;
+		qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+	};
+};
+
+&wifi0 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_1000>, <&mac_address_lan 0>;
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};
+
+&wifi1 {
+	status = "okay";
+	nvmem-cell-names = "pre-calibration", "mac-address";
+	nvmem-cells = <&precal_art_5000>, <&mac_address_wlan_5g 0>;
+	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
+};

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1027,6 +1027,48 @@ define Device/netgear_rbs50
 endef
 TARGET_DEVICES += netgear_rbs50
 
+define Device/netgear_rbx50-v2
+	$(call Device/DniImage)
+	DEVICE_VENDOR := NETGEAR
+	NETGEAR_HW_ID := 29765352+0+4000+512+2x2+2x2+4x4
+	SOC := qcom-ipq4019
+	DEVICE_DTS_CONFIG := config@2
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	UBINIZE_OPTS := -E 5
+	IMAGE/factory.img := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
+		append-uImage-fakehdr filesystem | pad-to $$$$(KERNEL_SIZE) | \
+		append-ubi | netgear-dni
+	IMAGE/sysupgrade.bin := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
+		append-uImage-fakehdr filesystem | sysupgrade-tar kernel=$$$$@ | \
+		append-metadata
+	DEVICE_PACKAGES += ath10k-firmware-qca9984-ct
+endef
+
+define Device/netgear_rbr50-v2
+	$(call Device/netgear_rbx50-v2)
+	DEVICE_MODEL := RBR50
+	DEVICE_VARIANT := v2
+	NAND_SIZE := 512m
+	KERNEL_SIZE := 6815744
+	ROOTFS_SIZE := 98041856
+	IMAGE_SIZE := 104857600
+	NETGEAR_BOARD_ID := RBR50
+endef
+TARGET_DEVICES += netgear_rbr50-v2
+
+define Device/netgear_rbs50-v2
+	$(call Device/netgear_rbx50-v2)
+	DEVICE_MODEL := RBS50
+	DEVICE_VARIANT := v2
+	NAND_SIZE := 128m
+	KERNEL_SIZE := 6815744
+	ROOTFS_SIZE := 74448896
+	IMAGE_SIZE := 81264640
+	NETGEAR_BOARD_ID := RBS50
+endef
+TARGET_DEVICES += netgear_rbs50-v2
+
 define Device/netgear_srx60
 	$(call Device/netgear_orbi)
 	NETGEAR_HW_ID := 29765352+0+4096+512+2x2+2x2+4x4

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -1063,6 +1063,48 @@ define Device/netgear_rbs50
 endef
 TARGET_DEVICES += netgear_rbs50
 
+define Device/netgear_rbx50-v2
+	$(call Device/DniImage)
+	DEVICE_VENDOR := NETGEAR
+	NETGEAR_HW_ID := 29765352+0+4000+512+2x2+2x2+4x4
+	SOC := qcom-ipq4019
+	DEVICE_DTS_CONFIG := config@2
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	UBINIZE_OPTS := -E 5
+	IMAGE/factory.img := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
+		append-uImage-fakehdr filesystem | pad-to $$$$(KERNEL_SIZE) | \
+		append-ubi | netgear-dni
+	IMAGE/sysupgrade.bin := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
+		append-uImage-fakehdr filesystem | sysupgrade-tar kernel=$$$$@ | \
+		append-metadata
+	DEVICE_PACKAGES += ath10k-firmware-qca9984-ct
+endef
+
+define Device/netgear_rbr50-v2
+	$(call Device/netgear_rbx50-v2)
+	DEVICE_MODEL := RBR50
+	DEVICE_VARIANT := v2
+	NAND_SIZE := 512m
+	KERNEL_SIZE := 6815744
+	ROOTFS_SIZE := 98041856
+	IMAGE_SIZE := 104857600
+	NETGEAR_BOARD_ID := RBR50
+endef
+TARGET_DEVICES += netgear_rbr50-v2
+
+define Device/netgear_rbs50-v2
+	$(call Device/netgear_rbx50-v2)
+	DEVICE_MODEL := RBS50
+	DEVICE_VARIANT := v2
+	NAND_SIZE := 128m
+	KERNEL_SIZE := 6815744
+	ROOTFS_SIZE := 74448896
+	IMAGE_SIZE := 81264640
+	NETGEAR_BOARD_ID := RBS50
+endef
+TARGET_DEVICES += netgear_rbs50-v2
+
 define Device/netgear_srx60
 	$(call Device/netgear_orbi)
 	NETGEAR_HW_ID := 29765352+0+4096+512+2x2+2x2+4x4


### PR DESCRIPTION
The Netgear RBR50 and RBS50 (support added in 2cb24b3f3cd89692f3c0bd137f3f560ada359bfa) had a second hardware revision which switches to NAND flash and makes a few other changes (details in the commit message).

This patch adds support for both devices. All features seem to work.

A few notes:
- This is my first time writing a device tree. I relied heavily on the other `qcom-ipq4019-*.dts*` files for examples, and everything seems to work.
- ~~The device tree as written includes `qcom-ipq4019-orbi.dtsi` (which has a lot of Netgear Orbi-common functionality), though some of the GPIO pin assignments changed for this model so I had to override a few of the properties. I think it's still similar enough to continue using `qcom-ipq4019-orbi.dtsi` as a base, but if preferred I could just copy the relevant portions over and base it on `qcom-ipq4019.dtsi` directly (like [`qcom-ipq4019-rbx20.dtsi`](https://github.com/openwrt/openwrt/blob/557b092273e7ecb4f59305e2be63789522182145/target/linux/ipq40xx/dts/qcom-ipq4019-rbx20.dtsi) _does).~~ _Changed due to additional conflicts from other changes_
- ~~As an experiment, I backported to 25.12 and tested (see the [`add-rbk50v2-25.12`](https://github.com/cptpcrd/openwrt/tree/add-rbk50v2-25.12) branch on my fork), and it works. No changes were needed except for renaming the device tree files (they were moved in 6c982c7db449648f4b9c6d5f0acf6c5fcd6f42e3). Based on the criteria for [backporting device support](https://openwrt.org/docs/guide-developer/device-support-policies#device_support_backports), this seems that it could _perhaps_ qualify (it's not a 100% clone but is quite close, and is easily confused with the v1 model).~~ _Additional time has passed since 25.12 and this is probably no longer true_