### PR TITLE
firewall4: prefer over firewall as dependency

### DIFF
--- a/package/network/config/firewall4/Makefile
+++ b/package/network/config/firewall4/Makefile
@@ -5,7 +5,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=firewall4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/firewall4.git
@@ -28,6 +28,7 @@ define Package/firewall4
 	+ucode +ucode-mod-fs +ucode-mod-ubus +ucode-mod-uci
   EXTRA_DEPENDS:=ucode (>=2022.03.22)
   PROVIDES:=uci-firewall
+  DEFAULT_VARIANT:=1
 endef
 
 define Package/firewall4/description


### PR DESCRIPTION
When the virtual package "uci-firewall" is installed, the choice between "firewall" and "firewall4" is arbitrary, sometimes resulting in one, sometimes the other.

Set the default variant on "firewall4" to make it the preferred package when installed as a dependency.

Link: https://forum.openwrt.org/t/owut-openwrt-upgrade-tool/200035/1126
