### PR TITLE
build: segregate build artifacts by host architecture

### DIFF
--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from subprocess import run, PIPE
 from sys import argv
 import json
+import re
 
 if len(argv) != 2:
     print("JSON info files script requires output file as argument")
@@ -31,8 +32,12 @@ def get_initial_output(image_info):
 
 def add_artifact(artifact, prefix="openwrt-"):
     files = list(output_dir.glob(f"{prefix}{artifact}-*"))
-    if len(files) == 1:
-        output[artifact] = str(files[0].name)
+    if len(files):
+        output[artifact] = {}
+        for file in files:
+            file = str(file.name)
+            arch = re.match(r".*Linux-([^.]*)\.", file).group(1)
+            output[artifact][arch] = file
 
 
 for json_file in work_dir.glob("*.json"):


### PR DESCRIPTION
Add structured data to each of the build artifacts listed in profiles.json, in order to accomodate future inclusion of different build host architectures.

Link: https://github.com/openwrt/openwrt/pull/22264#issuecomment-4014914414

---

@aparcar 

Profile data now looks like this:
```
$ cat bin/targets/layerscape/armv8_64b/profiles.json | jq '. | {sdk,imagebuilder,"llvm-bpf",toolchain}'
{
  "sdk": {
    "x86_64": "openwrt-sdk-layerscape-armv8_64b_gcc-14.3.0_musl.Linux-x86_64.tar.zst"
  },
  "imagebuilder": {
    "x86_64": "openwrt-imagebuilder-layerscape-armv8_64b.Linux-x86_64.tar.zst"
  },
  "llvm-bpf": {
    "x86_64": "llvm-bpf-21.1.6.Linux-x86_64.tar.zst"
  },
  "toolchain": {
    "x86_64": "openwrt-toolchain-layerscape-armv8_64b_gcc-14.3.0_musl.Linux-x86_64.tar.zst"
  }
}
```