### PR TITLE
airoha: Enable npu for an7581-evb board

### DIFF
--- a/target/linux/airoha/dts/an7581-evb.dts
+++ b/target/linux/airoha/dts/an7581-evb.dts
@@ -204,6 +204,10 @@
 	status = "okay";
 };
 
+&npu {
+	status = "okay";
+};
+
 &eth {
 	status = "okay";
 };


### PR DESCRIPTION
Enable NPU module for AN7581 evaluation board.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
