### PR TITLE
realtek: gpio: backport rtl9607c gpio support patches

### DIFF
--- a/target/linux/realtek/patches-6.12/023-01-v7.0-dt-bindings-gpio-realtek-otto-add-rtl9607-compatible.patch
+++ b/target/linux/realtek/patches-6.12/023-01-v7.0-dt-bindings-gpio-realtek-otto-add-rtl9607-compatible.patch
@@ -1,0 +1,27 @@
+From 49944d6ab7eb951f2aefee69341c623e13434863 Mon Sep 17 00:00:00 2001
+From: Rustam Adilov <adilov@disroot.org>
+Date: Thu, 5 Mar 2026 21:11:05 +0500
+Subject: dt-bindings: gpio: realtek-otto: add rtl9607 compatible
+
+Add the "realtek,rtl9607-gpio" compatible for GPIO nodes
+on the RTL9607C SoC series.
+
+Signed-off-by: Rustam Adilov <adilov@disroot.org>
+Reviewed-by: Linus Walleij <linusw@kernel.org>
+Reviewed-by: Sander Vanheule <sander@svanheule.net>
+Link: https://patch.msgid.link/20260305161106.15999-2-adilov@disroot.org
+Signed-off-by: Bartosz Golaszewski <bartosz.golaszewski@oss.qualcomm.com>
+---
+ Documentation/devicetree/bindings/gpio/realtek,otto-gpio.yaml | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/Documentation/devicetree/bindings/gpio/realtek,otto-gpio.yaml
++++ b/Documentation/devicetree/bindings/gpio/realtek,otto-gpio.yaml
+@@ -30,6 +30,7 @@ properties:
+           - realtek,rtl8390-gpio
+           - realtek,rtl9300-gpio
+           - realtek,rtl9310-gpio
++          - realtek,rtl9607-gpio
+       - const: realtek,otto-gpio
+ 
+   reg: true

--- a/target/linux/realtek/patches-6.12/023-02-v7.0-gpio-realtek-otto-add-rtl9607-support.patch
+++ b/target/linux/realtek/patches-6.12/023-02-v7.0-gpio-realtek-otto-add-rtl9607-support.patch
@@ -1,0 +1,29 @@
+From 8f0aecf2957e7dba78603544368846133bf6d22e Mon Sep 17 00:00:00 2001
+From: Rustam Adilov <adilov@disroot.org>
+Date: Thu, 5 Mar 2026 21:11:06 +0500
+Subject: gpio: realtek-otto: add rtl9607 support
+
+The RTL9607C SoC has support for 3 GPIO banks with 32 GPIOs each and
+the port order is reversed just like in RTL930x.
+
+Signed-off-by: Rustam Adilov <adilov@disroot.org>
+Reviewed-by: Sander Vanheule <sander@svanheule.net>
+Link: https://patch.msgid.link/20260305161106.15999-3-adilov@disroot.org
+Signed-off-by: Bartosz Golaszewski <bartosz.golaszewski@oss.qualcomm.com>
+---
+ drivers/gpio/gpio-realtek-otto.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/drivers/gpio/gpio-realtek-otto.c
++++ b/drivers/gpio/gpio-realtek-otto.c
+@@ -350,6 +350,10 @@ static const struct of_device_id realtek
+ 	{
+ 		.compatible = "realtek,rtl9310-gpio",
+ 	},
++	{
++		.compatible = "realtek,rtl9607-gpio",
++		.data = (void *)GPIO_PORTS_REVERSED,
++	},
+ 	{}
+ };
+ MODULE_DEVICE_TABLE(of, realtek_gpio_of_match);


### PR DESCRIPTION
The gpio controller support for RTL9607C SoCs has been accepted upstream.

This commit backports them to OpenWrt to enable gpio functionality on these SoCs.

I have confirmed and tested gpio interrupts on my RTL9607C router and things are working as expected.