### PR TITLE
layerscape: armv8_64b: traverse ten64-mtd fix ASU support

### DIFF
--- a/target/linux/layerscape/image/armv8_64b.mk
+++ b/target/linux/layerscape/image/armv8_64b.mk
@@ -375,10 +375,10 @@ define Device/fsl_lx2160a-rdb-sdboot
 endef
 TARGET_DEVICES += fsl_lx2160a-rdb-sdboot
 
-define Device/traverse_ten64_mtd
+define Device/traverse_ten64-mtd
   DEVICE_VENDOR := Traverse
   DEVICE_MODEL := Ten64 (NAND boot)
-  DEVICE_NAME := ten64-mtd
+  BOARD_NAME := ten64-mtd
   DEVICE_PACKAGES += \
     uboot-envtools \
     kmod-rtc-rx8025 \
@@ -404,5 +404,5 @@ define Device/traverse_ten64_mtd
   MKUBIFS_OPTS := -m $$(PAGESIZE) -e 124KiB -c 600
   SUPPORTED_DEVICES = traverse,ten64
 endef
-TARGET_DEVICES += traverse_ten64_mtd
+TARGET_DEVICES += traverse_ten64-mtd
 


### PR DESCRIPTION
The profiles.json[^1] generated and used during ASU sysupgrades takes DEVICE_NAME as profile name, if you overwrite it and it doesn't match with the imagebuilder profile, which do not notice the overwrite, that breaks ASU sysupgrades, use BOARD_NAME which serves the same goal as overwriting DEVICE_NAME, allowing sysupgrade-tar's/platform checks to be succesfully passed using the old name used in older installations but without affecting the generated profiles.json, thus enabling ASU support.

*Keep the non-stardand profile name with suffix "-mtd"(replaced underscore by hyphen) to remark that this device is also supported in the armsr (armvirt) target as originally intented[^2].
*I think I have fully checked the sysupgrade path to confirm this change does not have side effects.

[^1]: https://downloads.openwrt.org/releases/25.12.0/targets/layerscape/armv8_64b/profiles.json
[^2]: https://github.com/openwrt/openwrt/pull/12828

Fixes: af0546da3440dba24217949527e503820350ff05 ("layerscape: armv8_64b: add Traverse Ten64 NAND variant")
Fixes: https://github.com/openwrt/asu/issues/1583