### PR TITLE
qualcommbe: ipq95xx: rdp433 add dts compatible to SUPPORTED_DEVICES

### DIFF
--- a/target/linux/qualcommbe/image/ipq95xx.mk
+++ b/target/linux/qualcommbe/image/ipq95xx.mk
@@ -25,5 +25,6 @@ define Device/qcom_rdp433
 	KERNEL_SIZE := 6096k
 	IMAGE_SIZE := 25344k
 	IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-rootfs | pad-rootfs | check-size | append-metadata
+	SUPPORTED_DEVICES += qcom,ipq9574-ap-al02-c7
 endef
 TARGET_DEVICES += qcom_rdp433


### PR DESCRIPTION
The default derived SUPPORTED_DEVICES "qcom,rdp433" does not match the actual dts compatible "qcom,ipq9574-ap-al02-c7" used by this board [^1], breaking sysupgrade and ASU support.
Add actual upstream device dts compatible to SUPPORTED_DEVICES.

Fixes: 93173aee96e7496f3ff158046d3d19cd42c2e031 ("qualcommbe: ipq95xx: Add initial support for new target")

*The qualcommbe target/platform is `source-only` yet.

[^1]: https://elixir.bootlin.com/linux/v6.12.76/source/arch/arm64/boot/dts/qcom/ipq9574-rdp433.dts