### PR TITLE
linux-firmware: update to 20260309

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
-PKG_VERSION:=20260221
+PKG_VERSION:=20260309
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=bd19acc4c1a02548e09d3df67f987fe6e378df735bab138c1d9e917962056d94
+PKG_HASH:=c74cc6f562b58ad5bc6b2b00a61abc29c9e49e06126e7ba34fbca9928e07a96c
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
```
% git log --no-merges --pretty=oneline --abbrev-commit 20260110...20260309
6d5c4e499d32 mediatek MT7922: update bluetooth firmware to 20260224103448
e426f99ddbe6 linux-firmware: update firmware for MT7922 WiFi device
21d670224ad1 cirrus: cs42l45: Add CS42L45 SDCA codec firmware for Dell laptops
bfebfc16a8b3 cirrus: cs35l63: Add firmware for Cirrus CS35L63 for various Dell laptops
cf2d1a574838 linux-firmware: Remove duplicate fw and Rename Lenovo ISH LNLM firmware files accordingly
b9e372cffcb0 amdgpu: DMCUB updates for various ASICs
397e9a13dbb4 linux-firmware: Add firmware file for Intel BlazarIGfp2 core
b251087087e8 QCA: Update Bluetooth QCA6698 firmware to 2.1.2-00069
f58642691280 qcom: Update CDSP firmware for QCM6490 platform
f4fccdeaa58a linux-firmware: add firmware for Lontium LT8713SX DP hub
822ba35b15b1 linux-firmware: qcom: sync audioreach firmwares from v1.0.2 build
6b986839e4bc qcom: update ADSP, CDSP firmware for sm8750  platform
eb48837f8acc qcom: update ADSP dtb.mbn for glymur platform
87768b59c878 qca: Update Bluetooth WCN6750 1.1.3-00105 firmware to 1.1.3-00106
64330a97f0f2  QCA: Update Bluetooth WCN6856 firmware 2.1.0-00659 to 2.1.0-00665
bcc17f274d19 amdgpu: update PSP 13.0.14 firmware
bed8b292d199 amdgpu: update GC 9.4.4 firmware
40518428a964 amdgpu: update PSP 13.0.5 firmware
6f3948e1a80f amdgpu: update GC 10.3.6 firmware
c5c71a6b42ef amdgpu: update PSP 13.0.0 kicker firmware
936b64f49831 amdgpu: update VCN 4.0.0 firmware
ca25e8cea638 amdgpu: update PSP 13.0.0 firmware
652378d0d156 amdgpu: update GC 11.0.0 firmware
ca31625e94c9 amdgpu: update SDMA 6.1.3 firmware
d1b9b7263627 amdgpu: update PSP 14.0.5 firmware
ab1f658c787b amdgpu: update GC 11.5.3 firmware
58b10704da49 amdgpu: update beige goby firmware
127e3755fe43 amdgpu: update SDMA 6.1.2 firmware
a7669eb10e78 amdgpu: update PSP 14.0.4 firmware
e2d3b43db975 amdgpu: update GC 11.5.2 firmware
c0bec6f13e3f amdgpu: update dimgrey cavefish firmware
7ab313a9f169 amdgpu: update vangogh firmware
60bd7581c608 amdgpu: update navy flounder firmware
6237f479d99e amdgpu: update PSP 13.0.11 firmware
29ffce4483d3 amdgpu: update GC 11.0.4 firmware
8746dc896220 amdgpu: update VCN 4.0.2 firmware
afe6f8da8aec amdgpu: update SDMA 6.0.1 firmware
f940f4540549 amdgpu: update PSP 13.0.4 firmware
4e47f7fa71fb amdgpu: update GC 11.0.1 firmware
f789bb032a9c amdgpu: update sienna cichlid firmware
48f3c77d8f79 amdgpu: update navi14 firmware
2d7345645d59 amdgpu: update green sardine firmware
31d1b0dd5396 amdgpu: update VCN 4.0.6 firmware
212257aad62c amdgpu: update SDMA 6.1.1 firmware
28dd17d1d31b amdgpu: update PSP 14.0.1 firmware
dea4e8a3376c amdgpu: update GC 11.5.1 firmware
8669af2dd952 amdgpu: update VCN 5.0.0 firmware
7177f2135df7 amdgpu: update SMU 14.0.3 firmware
2a0af58da356 amdgpu: update PSP 14.0.3 firmware
1dd31ea90f7f amdgpu: update GC 12.0.1 firmware
4db65e675ed0 amdgpu: update VPE 6.1.0 firmware
4b81a4817629 amdgpu: update VCN 4.0.5 firmware
d23903078c5f amdgpu: update SDMA 6.1.0 firmware
dea480a1b32b amdgpu: update PSP 14.0.0 firmware
de99d0fd70ca amdgpu: update GC 11.5.0 firmware
683aace3644f amdgpu: update navi12 firmware
eba8a69fb7b6 amdgpu: update SMU 14.0.2 firmware
b39b4a98582b amdgpu: update PSP 14.0.2 firmware
37e9adcb709d amdgpu: update GC 12.0.0 firmware
aaca282a05b6 amdgpu: update renoir firmware
18461c2329d1 amdgpu: update navi10 firmware
4773307708e9 amdgpu: update VCN 4.0.4 firmware
897d73a7b650 amdgpu: update SDMA 6.0.2 firmware
1d4fdf2cbdc4 amdgpu: update PSP 13.0.7 firmware
1d5d7a62ebff amdgpu: update GC 11.0.2 firmware
ffbc28980e23 amdgpu: update VCN 4.0.3 firmware
138597a4e0bd amdgpu: update PSP 13.0.6 firmware
19e0d4624bdb amdgpu: update GC 9.4.3 firmware
a9004d5a0ba4 amdgpu: update yellow carp firmware
b5d25d858b7e amdgpu: update PSP 13.0.10 firmware
c6feb53895f6 amdgpu: update GC 11.0.3 firmware
95c430cdd81a amdgpu: update VCN 5.0.1 firmware
ad7910db6e83 amdgpu: update PSP 13.0.12 firmware
e7f955441b97 amdgpu: update GC 9.5.0 firmware
1d609638b772 linux-firmware:Renaming the file back for HP EliteBook X Flip G1i
26668fabcfea linux-firmware:Renaming the file back for HP EliteBook X Flip G1i
49cf497556b9 linux-firmware:Renaming the file back for HP EliteBook X Flip G1i
58cf579b98c0 amdnpu: Restore old NPU firmware for compatibility
4aaa9c557e90 cirrus: cs42l45: Add CS42L45 SDCA codec firmware for Dell laptops
feba387aac8f lenovo: remove obsolete ish_lnlm_53c4ffad_2a17559f.bin firmware
df954d275a07 linux-firmware: update firmware for MT7902 BT device
edc18bd4dc29 linux-firmware: update firmware for MT7902 WiFi device
30a139cb6561 qcom: vpu: fix SC7280 VPU Gen2 firmware and add compatibility symlink
65c7ff3ec808 amdgpu: DMCUB updates for various ASICs
6a24a5a92c32 qcom: Update DSP firmware for qcs8300 platform
39f04545b26f cirrus: cs35l41: Add Firmware for ASUS Zenbook Laptop using CS35L41 HDA
664f8b6adeba qcom: Update DSP firmware for sa8775p platform
bed52d78bc0c amdgpu: DMCUB updates for various ASICs
342ce02256f3 rtw89: 8851b: add format-1 for fw v0.29.41.5 with fw elements
4a216696655b rtw89: 8852a: add format-1 for fw v0.13.36.2 with fw elements
0579ff05d882 rtw89: 8852bt: add regd and diag_mac and update txpwr to R09
af193c46b6bd rtw89: 8852b: update txpwr element to R43
81eae19b21a0 rtw89: 8852b: add format-2 with v0.29.29.15 and fw elements
1cfed3e213c5 Revert "rtw89: 8852b: update fw to v0.29.128.0 with format suffix -2"
86725d7351e8 xe: Update GUC to v70.58.0 for LNL, BMG, PTL
cbd0f9753754 ath11k: WCN6855 hw2.0: update board-2.bin
65a3c868b360 ath11k: QCA6390 hw2.0: update board-2.bin
0364daaa28a2 qcom: Add gpu firmwares for Glymur chipset
6c1e2562f626 amdgpu: DMCUB updates for various ASICs
2bb21553d510 qcom: vpu: add video firmware for Glymur
8fafd2481eed qcom: add QUPv3 firmware for x1e80100 platform
fd38db51a2a6 Bluetooth: Add symbolic links for Intel Solar JfP2/1 firmware variants
07b822cc556d Bluetooth: Add symbolic links for Intel Solar firmware variants
1b902aa966e4 Bluetooth: Add symbolic links for Intel Pulsar firmware variants
949dba8936ab Bluetooth: Add symbolic links for Intel AX201 firmware variants
81a99dba039a ath10k: WCN3990 hw1.0: update board-2.bin
b69afa29d3f6 qcom: add ADSP, CDSP firmware for glymur platform
4e83a67a5637 ASoC: tas2783: Add Firmware files for tas2783A
87972e133405 linux-firmware: Update firmware file for Intel Solar core
a693bc58e2ac mediatek MT7921: update bluetooth firmware to 20251223091725
fbf93476b789 rtl_bt: Update RTL8822C BT USB and UART firmware to 0x0673
a712a43ff2c0 ath12k: WCN7850 hw2.0: update board-2.bin
ec76089d563e ath12k: QCN9274 hw2.0: update to WLAN.WBE.1.6-01243-QCAHKSWPL_SILICONZ-1
49df41843d27 ath11k: WCN6855 hw2.0: update board-2.bin
fd8bdffeabe4 ath11k: QCA6698AQ hw2.1: update board-2.bin
af03e44a2029 WHENCE: Correct 2 trailing whitespaces
1043c0303910 linux-firmware: Add firmware for airoha-npu-7581 driver used for MT7990 offloading
f18b40ebf5e8 linux-firmware: Add Dell ISH firmware for Intel panther lake systems
9a727f07bc60 amdgpu: DMCUB updates for various ASICs
fb1cfb1989ea linux-firmware: update Aeonsemi AS21x1x firmware to 1.9.1
0fa5e69a0d9e rtl_nic: add firmware rtl8125cp-1 for RTL8125cp
dfff492a66a0 ice: update DDP LAG package to 1.3.2.0
db024df1e153 cirrus: cs35l56: Add WHENCE links for 17aa233c spkid0 firmware
a80ebbccb826 rtw89: 8922a: update REGD R73-R08, txpwr R46 and element of diag MAC
f9c84ebaefbf rtw89: 8852c: update REGD R73-R60, txpwr R82 and element of diag MAC
d8fc35003355 Update firmware for NPU PHX, STX and STX HALO
a7bd257ea496 qcom: Update ADSP and add CDSP firmware for qcs6490-radxa-dragon-q6a
1ccefae136c4 qcom: Remove ADSP SensorPD json for Radxa Dragon Q6A
afae3262fa2f amdgpu: DMCUB updates for various ASICs
ff3470eca79b intel/ish: Add Lenovo ISH firmware support for X1 and X9 systems
53ec87319d28 cirrus: cs42l45: Add CS42L45 SDCA codec firmware for Lenovo laptops
8ca12d6383d0 cirrus: cs42l45: Add CS42L45 SDCA codec firmware for Dell laptops
ecf00f092a8e cirrus: cs35l57 cs35l63: Add firmware for Cirrus Amps for some Lenovo laptops
d01a86bd2b35 cirrus: cs35l56 cs35l57: Add and update firmware for some Dell laptops
e22074558beb Intel IPU7: Update firmware binary for Panther Lake
a80dabbc28fa linux-firmware: update firmware for MT7921 WiFi device
1e2c15348485 amdgpu: DMCUB updates for various ASICs
9e79ce04180f linux-firmware: Add firmware file for Intel ScorpiusGfp2 core
f401a31ab5ba linux-firmware: Update firmware file for Intel Scorpius core
6be3bd6cc295 linux-firmware: Update firmware file for Intel BlazarIGfP core
99a2479f94e1 linux-firmware: Update firmware file for Intel BlazarI core
9bf06b2bdf74 linux-firmware: Update firmware file for Intel BlazarU-HrPGfP core
40a812ce5880 linux-firmware: Update firmware file for Intel BlazarU core
634af751cc56 rtl_bt: Update RTL8852BT/RTL8852BE-VT BT USB FW to 0x06EB_C65F
4cc877a7c241 linux-firmware: Add firmware for airoha-npu-7583 driver
9a9285ce9b44 iwlwifi: add Bz/Sc FW for core102-56 release
579ca4320f6b iwlwifi: Add Hr/Gf firmware for core102-56 release
90af9c636906 iwlwifi: update ty/So/Ma firmwares for core102-56 release
05a6a40bbba8 xe: Add GSC 105.0.2.1301 for PTL
087f9b0a8d23 mediatek: rename MT8188 SCP firmware
a438fce32e0e qcom: Update DSP firmware for QCM6490 platform
bfc1d7433ddd linux-firmware: qcom: sync audioreach firmwares from v1.0.1 build
```
Build system: x86/64
Build-tested: x86/64-glibc
Run-tested: Intel N150 based system