### PR TITLE
tools/m4: fix build with GCC 15 and glibc 2.43

### DIFF
--- a/tools/m4/patches/001-fix-gnulib-bsearch-gcc15.patch
+++ b/tools/m4/patches/001-fix-gnulib-bsearch-gcc15.patch
@@ -1,0 +1,166 @@
+--- a/lib/stdlib.in.h
++++ b/lib/stdlib.in.h
+@@ -227,16 +227,6 @@ _GL_INLINE_HEADER_BEGIN
+ #endif
+ 
+ 
+-/* Declarations for ISO C N3322.  */
+-#if defined __GNUC__ && __GNUC__ >= 15 && !defined __clang__
+-_GL_EXTERN_C void *_GL_FUNCDECL_SYS_NAME (bsearch)
+-  (const void *__key, const void *__base, size_t __nmemb, size_t __size,
+-   int (*__compare) (const void *, const void *))
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3) _GL_ARG_NONNULL ((5));
+-_GL_EXTERN_C void qsort (void *__base, size_t __nmemb, size_t __size,
+-                         int (*__compare) (const void *, const void *))
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 2) _GL_ARG_NONNULL ((4));
+-#endif
+ 
+ 
+ #if @GNULIB__EXIT@
+--- a/lib/string.in.h
++++ b/lib/string.in.h
+@@ -218,88 +218,6 @@ _GL_EXTERN_C void free (void *);
+ #endif
+ 
+ 
+-/* Declarations for ISO C N3322.  */
+-#if defined __GNUC__ && __GNUC__ >= 15 && !defined __clang__
+-# ifndef memcpy
+-_GL_EXTERN_C void *memcpy (void *__dest, const void *__src, size_t __n)
+-#  if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-#  endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-# endif
+-# ifndef memccpy
+-_GL_EXTERN_C void *memccpy (void *__dest, const void *__src, int __c, size_t __n)
+-#  if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-#  endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 4)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 4);
+-# endif
+-# ifndef memmove
+-_GL_EXTERN_C void *memmove (void *__dest, const void *__src, size_t __n)
+-#  if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-#  endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-# endif
+-# ifndef strncpy
+-_GL_EXTERN_C char *strncpy (char *__dest, const char *__src, size_t __n)
+-#  if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-#  endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-# endif
+-# ifndef strndup
+-_GL_EXTERN_C char *strndup (const char *__s, size_t __n)
+-#  if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-#  endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 2);
+-# endif
+-# ifndef strncat
+-_GL_EXTERN_C char *strncat (char *__dest, const char *__src, size_t __n)
+-#  if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-#  endif
+-  _GL_ARG_NONNULL ((1)) _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-# endif
+-# ifndef memcmp
+-_GL_EXTERN_C int memcmp (const void *__s1, const void *__s2, size_t __n)
+-#  if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-#  endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-# endif
+-# ifndef strncmp
+-_GL_EXTERN_C int strncmp (const char *__s1, const char *__s2, size_t __n)
+-#  if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-#  endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-# endif
+-# if !defined memchr && !defined __cplusplus
+-_GL_EXTERN_C void *memchr (const void *__s, int __c, size_t __n)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3);
+-_GL_EXTERN_C void *memrchr (const void *__s, int __c, size_t __n)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3);
+-# endif
+-# ifndef memset
+-_GL_EXTERN_C void *memset (void *__s, int __c, size_t __n)
+-#  if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-#  endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3);
+-# endif
+-# ifndef memset_explicit
+-_GL_EXTERN_C void *memset_explicit (void *__s, int __c, size_t __n)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3);
+-# endif
+-#endif
+ 
+ 
+ /* Clear a block of memory.  The compiler will not delete a call to
+--- a/lib/wchar.in.h
++++ b/lib/wchar.in.h
+@@ -263,53 +263,6 @@ _GL_EXTERN_C void free (void *);
+ #endif
+ 
+ 
+-/* Declarations for ISO C N3322.  */
+-#if defined __GNUC__ && __GNUC__ >= 15 && !defined __clang__
+-_GL_EXTERN_C wchar_t *wmemcpy (wchar_t *__dest, const wchar_t *__src, size_t __n)
+-# if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-# endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-_GL_EXTERN_C wchar_t *wmemmove (wchar_t *__dest, const wchar_t *__src, size_t __n)
+-# if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-# endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-_GL_EXTERN_C wchar_t *wcsncpy (wchar_t *__dest, const wchar_t *__src, size_t __n)
+-# if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-# endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-_GL_EXTERN_C wchar_t *wcsncat (wchar_t *__dest, const wchar_t *__src, size_t __n)
+-# if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-# endif
+-  _GL_ARG_NONNULL ((1)) _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-_GL_EXTERN_C int wmemcmp (const wchar_t *__s1, const wchar_t *__s2, size_t __n)
+-# if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-# endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-_GL_EXTERN_C int wcsncmp (const wchar_t *__s1, const wchar_t *__s2, size_t __n)
+-# if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-# endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (2, 3);
+-# ifndef __cplusplus
+-_GL_EXTERN_C wchar_t *(wmemchr) (const wchar_t *__s, wchar_t __wc, size_t __n)
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3);
+-# endif
+-_GL_EXTERN_C wchar_t *wmemset (wchar_t *__s, wchar_t __wc, size_t __n)
+-# if __GLIBC__ + (__GLIBC_MINOR__ >= 2) > 2
+-  _GL_ATTRIBUTE_NOTHROW
+-# endif
+-  _GL_ATTRIBUTE_NONNULL_IF_NONZERO (1, 3);
+-#endif
+ 
+ 
+ /* Convert a single-byte character to a wide character.  */


### PR DESCRIPTION
Host build fails on GCC 15 + glibc 2.43 (Arch Linux current):

```
./stdlib.h:827: error: expected identifier or '(' before '_Generic'
./string.h:218: error: expected identifier or '(' before '_Generic'
./wchar.h:263: error: expected identifier or '(' before '_Generic'
```

m4 was updated to 1.4.21 in #21987 which fixed one instance, but
string.in.h and wchar.in.h still contain ISO C N3322 declaration
blocks guarded by `__GNUC__ >= 15` that conflict with glibc 2.43's
`_Generic`-based inline definitions of memcpy, wmemcpy, strncpy etc.

These blocks only add nullability annotations; removing them has no
effect on GCC < 15 or Clang builds. The proper fix belongs in gnulib
upstream.