### PR TITLE
tools/e2fsprogs: fix build with system libblkid probe API

### DIFF
--- a/tools/e2fsprogs/Makefile
+++ b/tools/e2fsprogs/Makefile
@@ -31,7 +31,8 @@ HOST_CONFIGURE_ARGS += \
 	--disable-nls \
 	--enable-threads=pth \
 	--disable-fuse2fs \
-	--with-crond-dir=no
+	--with-crond-dir=no \
+	--enable-libblkid
 
 # The following uses pkg-config the wrong way around. Just override it.
 HOST_CONFIGURE_VARS += \


### PR DESCRIPTION
Host build fails on systems with e2fsprogs >= 1.47.0 installed:

```
plausible.c:132:21: error: unknown type name 'blkid_probe'
plausible.c:133:41: error: unknown type name 'blkid_probe'
```

configure detects the system libblkid probe API and defines
HAVE_BLKID_PROBE_GET_PARTITIONS, but the host build links against
the internal blkid stub which lacks that API.

Override the configure cache variables to prevent system libblkid
probe API detection, consistent with the existing uuid override.