### PR TITLE
bcm53xx: mr26: fix nvmem MAC override

### DIFF
--- a/target/linux/bcm53xx/patches-6.12/051-ARM-dts-meraki-mr26-wifi-MACs-in-dts.patch
+++ b/target/linux/bcm53xx/patches-6.12/051-ARM-dts-meraki-mr26-wifi-MACs-in-dts.patch
@@ -25,7 +25,7 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
  	status = "disabled";
  };
  
-+&pcie0 {
++&pcie_bridge0 {
 +	wifi@0,0 {
 +		reg = <0x0000 0 0 0 0>;
 +		compatible = "brcm,bcm43431";
@@ -34,7 +34,7 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
 +	};
 +};
 +
-+&pcie1 {
++&pcie_bridge1 {
 +	wifi@0,0 {
 +		reg = <0x0000 0 0 0 0>;
 +		compatible = "brcm,bcm43431";
@@ -43,7 +43,7 @@ Signed-off-by: Rosen Penev <rosenp@gmail.com>
 +	};
 +};
 +
-+&pcie2 {
++&pcie_bridge2 {
 +	wifi@0,0 {
 +		reg = <0x0000 0 0 0 0>;
 +		compatible = "brcm,bcm43428";


### PR DESCRIPTION
I wrongly added the wifi devices to the pcie nodes and not the bridge nodes as they were not present at the time.

Fixes: 58056df ("bcm53xx: backport nvmem mac for meraki mr26")

ping @robimarko @t4thfavor @guybw @slicknickthequick

No idea who else could possibly test this. I'm sure it's correct though.