### PR TITLE
[25.12] firmware: Add support for Airoha EN7581/AN7583 NPU variant firmware

### DIFF
--- a/package/firmware/linux-firmware/airoha.mk
+++ b/package/firmware/linux-firmware/airoha.mk
@@ -16,6 +16,7 @@ endef
 
 $(eval $(call BuildPackage,airoha-en8811h-firmware))
 
+
 Package/airoha-en7581-npu-firmware = $(call Package/firmware-default,Airoha EN7581 NPU firmware,,LICENSE.airoha)
 define Package/airoha-en7581-npu-firmware/install
 	$(INSTALL_DIR) $(1)/lib/firmware/airoha
@@ -26,3 +27,27 @@ define Package/airoha-en7581-npu-firmware/install
 endef
 
 $(eval $(call BuildPackage,airoha-en7581-npu-firmware))
+
+
+Package/airoha-en7581-mt7996-npu-firmware = $(call Package/firmware-default,Airoha EN7581+MT7996 NPU firmware,,LICENSE.airoha)
+define Package/airoha-en7581-mt7996-npu-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/airoha
+	$(CP) \
+		$(PKG_BUILD_DIR)/airoha/en7581_MT7996_npu_data.bin \
+		$(PKG_BUILD_DIR)/airoha/en7581_MT7996_npu_rv32.bin \
+		$(1)/lib/firmware/airoha
+endef
+
+$(eval $(call BuildPackage,airoha-en7581-mt7996-npu-firmware))
+
+
+Package/airoha-an7583-npu-firmware = $(call Package/firmware-default,Airoha AN7583 NPU firmware,,LICENSE.airoha)
+define Package/airoha-an7583-npu-firmware/install
+	$(INSTALL_DIR) $(1)/lib/firmware/airoha
+	$(CP) \
+		$(PKG_BUILD_DIR)/airoha/an7583_npu_data.bin \
+		$(PKG_BUILD_DIR)/airoha/an7583_npu_rv32.bin \
+		$(1)/lib/firmware/airoha
+endef
+
+$(eval $(call BuildPackage,airoha-an7583-npu-firmware))


### PR DESCRIPTION
Add support for Airoha EN7581/AN7583 NPU variant firmware present in linux-firmware. The Airoha EN7581 NPU variant is to support devices equipped with the MT7996 WiFi chip.

While at it also add an extra new line to follow pattern of double new line to separate each firmware package.

Cherry picked from 57bf713