### PR TITLE
kernel: cake_mq: expose sync_time parameter via debugfs

### DIFF
--- a/target/linux/generic/hack-6.12/710-net-sched-sch_cake-configure-sync_time-via-debugfs.patch
+++ b/target/linux/generic/hack-6.12/710-net-sched-sch_cake-configure-sync_time-via-debugfs.patch
@@ -1,0 +1,68 @@
+From 4eb720d360d3fc227eedbc76993719e1906c418c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jonas=20K=C3=B6ppeler?= <j.koeppeler@tu-berlin.de>
+Date: Wed, 11 Mar 2026 17:42:44 +0100
+Subject: [PATCH] net/sched: sch_cake: configure sync_time via debugfs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add a debugfs entry for sync_time to allow runtime adjustment of its
+value without recompilation. sync_time is specified in nanoseconds;
+setting it to 0 triggers synchronization on every packet.
+
+Signed-off-by: Jonas Köppeler <j.koeppeler@tu-berlin.de>
+---
+ net/sched/sch_cake.c | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletion(-)
+
+--- a/net/sched/sch_cake.c
++++ b/net/sched/sch_cake.c
+@@ -71,6 +71,7 @@
+ #include <net/pkt_cls.h>
+ #include <net/tcp.h>
+ #include <net/flow_dissector.h>
++#include <linux/debugfs.h>
+ 
+ #if IS_ENABLED(CONFIG_NF_CONNTRACK)
+ #include <net/netfilter/nf_conntrack_core.h>
+@@ -81,6 +82,8 @@
+ #define CAKE_QUEUES (1024)
+ #define CAKE_FLOW_MASK 63
+ #define CAKE_FLOW_NAT_FLAG 64
++static u64 g_sync_time_ns = 200*NSEC_PER_USEC;
++static struct dentry *cake_mq_debugfs;
+ 
+ /* struct cobalt_params - contains codel and blue parameters
+  * @interval:	codel initial drop rate
+@@ -2013,7 +2016,7 @@ static struct sk_buff *cake_dequeue(stru
+ 	u32 len;
+ 
+ 	if (q->config->is_shared && q->rate_ns &&
+-	    now - q->last_checked_active >= q->config->sync_time) {
++	    now - q->last_checked_active >= g_sync_time_ns) {
+ 		struct net_device *dev = qdisc_dev(sch);
+ 		struct cake_sched_data *other_priv;
+ 		u64 new_rate = q->config->rate_bps;
+@@ -3352,8 +3355,13 @@ static int __init cake_module_init(void)
+ 		return ret;
+ 
+ 	ret = register_qdisc(&cake_mq_qdisc_ops);
+-	if (ret)
++	if (ret) {
+ 		unregister_qdisc(&cake_qdisc_ops);
++	} else {
++		struct dentry *cake_mq_debugfs = debugfs_create_dir("cake_mq", NULL);
++
++		debugfs_create_u64("sync_time_ns", 0644, cake_mq_debugfs, &g_sync_time_ns);
++	}
+ 
+ 	return ret;
+ }
+@@ -3362,6 +3370,7 @@ static void __exit cake_module_exit(void
+ {
+ 	unregister_qdisc(&cake_qdisc_ops);
+ 	unregister_qdisc(&cake_mq_qdisc_ops);
++	debugfs_remove_recursive(cake_mq_debugfs);
+ }
+ 
+ module_init(cake_module_init)

--- a/target/linux/generic/hack-6.18/710-net-sched-sch_cake-configure-sync_time-via-debugfs.patch
+++ b/target/linux/generic/hack-6.18/710-net-sched-sch_cake-configure-sync_time-via-debugfs.patch
@@ -1,0 +1,68 @@
+From 4eb720d360d3fc227eedbc76993719e1906c418c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jonas=20K=C3=B6ppeler?= <j.koeppeler@tu-berlin.de>
+Date: Wed, 11 Mar 2026 17:42:44 +0100
+Subject: [PATCH] net/sched: sch_cake: configure sync_time via debugfs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add a debugfs entry for sync_time to allow runtime adjustment of its
+value without recompilation. sync_time is specified in nanoseconds;
+setting it to 0 triggers synchronization on every packet.
+
+Signed-off-by: Jonas Köppeler <j.koeppeler@tu-berlin.de>
+---
+ net/sched/sch_cake.c | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletion(-)
+
+--- a/net/sched/sch_cake.c
++++ b/net/sched/sch_cake.c
+@@ -71,6 +71,7 @@
+ #include <net/pkt_cls.h>
+ #include <net/tcp.h>
+ #include <net/flow_dissector.h>
++#include <linux/debugfs.h>
+ 
+ #if IS_ENABLED(CONFIG_NF_CONNTRACK)
+ #include <net/netfilter/nf_conntrack_core.h>
+@@ -81,6 +82,8 @@
+ #define CAKE_QUEUES (1024)
+ #define CAKE_FLOW_MASK 63
+ #define CAKE_FLOW_NAT_FLAG 64
++static u64 g_sync_time_ns = 200*NSEC_PER_USEC;
++static struct dentry *cake_mq_debugfs;
+ 
+ /* struct cobalt_params - contains codel and blue parameters
+  * @interval:	codel initial drop rate
+@@ -2019,7 +2022,7 @@ static struct sk_buff *cake_dequeue(stru
+ 	u32 len;
+ 
+ 	if (q->config->is_shared && q->rate_ns &&
+-	    now - q->last_checked_active >= q->config->sync_time) {
++	    now - q->last_checked_active >= g_sync_time_ns) {
+ 		struct net_device *dev = qdisc_dev(sch);
+ 		struct cake_sched_data *other_priv;
+ 		u64 new_rate = q->config->rate_bps;
+@@ -3358,8 +3361,13 @@ static int __init cake_module_init(void)
+ 		return ret;
+ 
+ 	ret = register_qdisc(&cake_mq_qdisc_ops);
+-	if (ret)
++	if (ret) {
+ 		unregister_qdisc(&cake_qdisc_ops);
++	} else {
++		struct dentry *cake_mq_debugfs = debugfs_create_dir("cake_mq", NULL);
++
++		debugfs_create_u64("sync_time_ns", 0644, cake_mq_debugfs, &g_sync_time_ns);
++	}
+ 
+ 	return ret;
+ }
+@@ -3368,6 +3376,7 @@ static void __exit cake_module_exit(void
+ {
+ 	unregister_qdisc(&cake_qdisc_ops);
+ 	unregister_qdisc(&cake_mq_qdisc_ops);
++	debugfs_remove_recursive(cake_mq_debugfs);
+ }
+ 
+ module_init(cake_module_init)


### PR DESCRIPTION
This patch enables for the configuration of the sync_time parameter. This is especially helpful to get feedback from users about suitable values. Once a solid solution is found this patch can be removed.

Related to #22344 
@tohojo 
