### PR TITLE
realtek: dsa: rtl93xx: avoid LAG transmission on down link

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.12/drivers/net/dsa/rtl83xx/common.c
@@ -3,7 +3,6 @@
 #include <linux/of_mdio.h>
 #include <linux/of_platform.h>
 #include <net/arp.h>
-#include <net/lag.h>
 #include <net/nexthop.h>
 #include <net/neighbour.h>
 #include <net/netevent.h>
@@ -566,9 +565,7 @@ static int rtldsa_93xx_lag_set_group2ports(struct rtl838x_switch_priv *priv, int
 
 	table_pos = 0;
 	for_each_set_bit(i, ports, ARRAY_SIZE(priv->ports)) {
-		struct net_device *lag_slave = priv->ports[i].dp->user;
-
-		if (lag_slave && !net_lag_port_dev_txable(lag_slave))
+		if (!priv->ports[i].dp->lag_tx_enabled)
 			continue;
 
 		group_ports[table_pos] = i;


### PR DESCRIPTION
When the link goes down on the other end of a bond, it was noticed that the switch was still trying to send data over this link.

Problem here is that `net_lag_port_dev_txable()` uses `bond_is_active_slave_dev()` to look the state up. But this is actually showing if a link is a NOT a backup - not if the link should be really be TX enabled or not.

As a DSA driver, it is important to consume the DSA information. `dp->lag_tx_enabled` must therefore be used for DSA `.port_lag_change` events. This variable contains two information from the `struct netdev_lag_lower_state_info`:

    tx_enabled = linfo->link_up && linfo->tx_enabled;

Fixes: 89322b4d69a7 ("rtl93xx: dsa: Handle lag_change properly")