### PR TITLE
build: reject non-matching artifacts

### DIFF
--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -36,8 +36,9 @@ def add_artifact(artifact, prefix="openwrt-"):
         output[artifact] = {}
         for file in files:
             file = str(file.name)
-            arch = re.match(r".*Linux-([^.]*)\.", file).group(1)
-            output[artifact][arch] = file
+            arch = re.match(r".*Linux-([^.]*)\.", file)
+            if arch:
+                output[artifact][arch.group(1)] = file
 
 
 for json_file in work_dir.glob("*.json"):


### PR DESCRIPTION
Check for malformed artifact names before dereferencing them.

Fixes: https://github.com/openwrt/openwrt/commit/5816d883ff3884ae96c3293b316f6d56c099eee0
