### PR TITLE
mediatek: filogic: tplink-be450: fix PHY timing, WLAN button, RAM size

### DIFF
--- a/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
+++ b/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
@@ -27,7 +27,7 @@
 	};
 
 	memory@40000000 {
-		reg = <0x0 0x40000000 0x0 0x40000000>;
+		reg = <0x0 0x40000000 0x0 0x20000000>;
 		device_type = "memory";
 	};
 
@@ -68,6 +68,12 @@
 			label = "wps";
 			linux,code = <KEY_WPS_BUTTON>;
 			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi {
+			label = "wlan";
+			linux,code = <KEY_WLAN>;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -121,7 +127,7 @@
 			gpios = <&pio 68 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_USB;
-		};		
+		};
 	};
 };
 
@@ -148,7 +154,6 @@
 
 	spi_nand: spi_nand@0 {
 		compatible = "spi-nand";
-		
 		reg = <0>;
 
 		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
@@ -156,7 +161,7 @@
 		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
 		spi-cal-datalen = <7>;
 		spi-cal-enable;
-		spi-cal-mode = "read-data";		
+		spi-cal-mode = "read-data";
 
 		spi-max-frequency = <52000000>;
 		spi-rx-bus-width = <4>;
@@ -240,7 +245,7 @@
 
 		reset-gpios = <&pio 3 GPIO_ACTIVE_LOW>;
 		reset-assert-us = <100000>;
-		reset-deassert-us = <100000>;
+		reset-deassert-us = <221000>;
 	};
 };
 
@@ -323,8 +328,8 @@
 
 &pio {
 	button_pins: button-pins {
-		pins = "GPIO_RESET", "GPIO_WPS";
-		bias-disable; /* bias-disable */
+		pins = "GPIO_RESET", "GPIO_WPS", "SPI2_MISO";
+		bias-disable;
 	};
 
 	mdio0_pins: mdio0-pins {
@@ -361,11 +366,11 @@
 	};
 
 	enable-usb-power {
-        gpio-hog;
-        gpios = <32 GPIO_ACTIVE_HIGH>;
-        output-high;
-        line-name = "USB power";
-    };
+		gpio-hog;
+		gpios = <32 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "USB power";
+	};
 };
 
 &ssusb1 {


### PR DESCRIPTION
- Fix RTL8261N 10GbE PHY `reset-deassert-us` from 100ms to
  221ms to meet datasheet minimum SMI-ready timing after
  nRESET release (t7 >= 150ms), fixing intermittent boot
  stalls caused by MDIO bus instability
- Add missing WLAN toggle button (GPIO 34) present in stock
  firmware but absent from OpenWrt DTS
- Fix memory size from 1 GB to the actual 512 MB

Fix 1: The RTL8261N 10GbE PHY's `reset-deassert-us` was set
to 100ms (100000us), but the RTL8261N datasheet (Table 108,
parameter t7) specifies a minimum SMI-ready time of 150ms
after nRESET release before the MDIO (SMI) bus can be used.

With only 100ms, the kernel attempts MDIO bus access before
the RTL8261N's SMI interface is stable. Since the RTL8261N
(mdio-bus:00) and the internal MT7988 2.5GbE PHY
(mdio-bus:0f) share the same MDIO bus, a not-yet-ready
RTL8261N disrupts all MDIO traffic, causing the 2.5GbE PHY
firmware loading (`mt798x_2p5ge_phy_config_init`) to stall.

Occasionally observed symptoms on warm reboot:
- Sometimes `mt798x_2p5ge_phy_config_init` hangs for 5+
  minutes or indefinitely
- RCU CPU stalls (rcu: INFO: rcu_sched detected stalls on CPUs)
- mt7996e WiFi chip message timeouts cascading to
  `chip full reset failed`
- System appears hung with only power LED blinking slowly

UART serial log (warm reboot, 100ms):

  [   73.041756] rcu: INFO: rcu_sched self-detected stall on CPU
  [   73.048341] rcu:  2-....: (8 ticks this GP)
  [   73.061641] pc : mt798x_2p5ge_phy_config_init+0x258/0xbb0
  [   73.061653] lr : mt798x_2p5ge_phy_config_init+0x238/0xbb0
  ...
  [ 334.771280] MediaTek MT7988 2.5GbE PHY mdio-bus:0f:
                Firmware date code: 2024/10/30

PHY firmware loading normally takes ~3 seconds; with 100ms it
took 325 seconds due to MDIO bus instability. In the worst
case, the system never recovers.

The TP-Link GPL DTS for the BE450 uses 221ms
(`reset-deassert-us = <221000>`), providing 71ms of margin
above the 150ms datasheet minimum. All MT7988 reference board
DTS files in the GPL use this same 221ms value.

Fix 2: The BE450 has a physical WLAN toggle button on GPIO 34,
defined in the stock TP-Link GPL DTS but missing from the
OpenWrt DTS. Without this definition the button is
non-functional under OpenWrt.

The pin name for GPIO 34 in the MT7988 pinctrl is `SPI2_MISO`,
confirmed by the kernel pinctrl driver (pinctrl-mt7988.c:
MT7988_PIN(34, "SPI2_MISO")) and the official devicetree
binding (mediatek,mt7988-pinctrl.yaml).

Note: GPIO 34 is also used by the BE450 first-stage U-Boot as
a web recovery button (192.168.1.1). Registering it in the
DTS ensures the kernel claims the pin.

Fix 3: The OpenWrt DTS declares 1 GB (0x40000000) of RAM. The
BE450 ships with 512 MB (0x20000000), confirmed via
/proc/meminfo on a running device and cross-checked against
the TP-Link GPL DTS.

Tested-on: TP-Link BE450, OpenWrt SNAPSHOT and V25.12.0

- Warm reboot stability: 20x consecutive, no MDIO stalls
- Reset button (GPIO 13): hotplug events correct
- WPS button (GPIO 14): hotplug events correct
- WLAN button (GPIO 34): hotplug events correct
- All GPIO pins visible in /sys/kernel/debug/gpio
- Memory correctly reported in /proc/meminfo
