### PR TITLE
mediatek: filogic: add support for ipTIME AX6000M

### DIFF
--- a/target/linux/mediatek/dts/mt7986a-iptime-ax6000m.dts
+++ b/target/linux/mediatek/dts/mt7986a-iptime-ax6000m.dts
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	model = "ipTIME AX6000M";
+	compatible = "iptime,ax6000m", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+			debounce-interval = <60>;
+		};
+
+		button-1 {
+			label = "reset";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: led-0 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_CPU;
+			gpios = <&pio 22 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+
+	pcie_pins: pcie-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_pereset";
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				   "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				   "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				   "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				   "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				   "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				   "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x6e00000>;
+			};
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 3>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <50000>;
+		reset-post-delay-us = <20000>;
+	};
+};
+
+&mdio {
+
+	switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		reset-assert-us = <10000>;
+		reset-deassert-us = <10000>;
+
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "wan";
+			};
+			port@1 {
+				reg = <1>;
+				label = "lan1";
+			};
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+			port@3 {
+				reg = <3>;
+				label = "lan3";
+			};
+			port@4 {
+				reg = <4>;
+				label = "lan4";
+			};
+
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&wifi {
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+	status = "okay";
+};
+
+&pcie_phy {
+	status = "okay";
+};
+
+&trng {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&ssusb {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -251,6 +251,11 @@ mediatek_setup_macs()
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac=$wan_mac
 		;;
+	iptime,ax6000m)
+		base_mac=$(mtd_get_mac_binary "Factory" 0x4)
+		wan_mac=$(macaddr_add "$base_mac" 1)
+		label_mac=$base_mac
+		;;
 	mercusys,mr80x-v3|\
 	mercusys,mr85x)
 		mac_dirty=$(cat "/tmp/tp_data/default-mac" | sed -n 's/^'"MAC"'://p')

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -132,7 +132,8 @@ case "$board" in
 		;;
 	iptime,ax3000m|\
 	iptime,ax3000se|\
-	iptime,ax3000sm)
+	iptime,ax3000sm|\
+	iptime,ax6000m)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_setbit $addr 26) 25) 27) 28) > \
 			/sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1720,6 +1720,25 @@ define Device/iptime_ax7800m-6e
 endef
 TARGET_DEVICES += iptime_ax7800m-6e
 
+
+define Device/iptime_ax6000m
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := AX6000M
+  DEVICE_DTS := mt7986a-iptime-ax6000m
+  DEVICE_DTS_DIR := ../dts
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 114688k
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax6000m
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+endef
+TARGET_DEVICES += iptime_ax6000m
+
 define Device/jcg_q30-pro
   DEVICE_VENDOR := JCG
   DEVICE_MODEL := Q30 PRO


### PR DESCRIPTION
Add support for the ipTIME AX6000M, a MediaTek Filogic-based dual-band WiFi 6 router.

This adds support for the ipTIME AX6000M including the device DTS, image recipe entry, MAC address handling, and correct LAN port ordering.

## Specification

| Component | Model |
|-----------|------|
| SoC | MediaTek MT7986A (Filogic 830) |
| RAM | 512 MB DDR3 |
| Flash | 128 MB SPI-NAND |
| Switch | MediaTek MT7531 |
| Wireless 2.4 GHz | MediaTek MT7975N |
| Wireless 5 GHz | MediaTek MT7975PN |
| USB | 1 × USB 3.0 |

### Buttons

| Button |
|------|
| Reset |
| WPS |

### LEDs

| Type | LEDs |
|-----|------|
| GPIO-controlled | CPU (used as power), WiFi 2.4G, WiFi 5G |
| Switch-controlled | WAN, LAN1, LAN2, LAN3, LAN4 |

## Flash Layout

The device uses **SPI-NAND with NMBM and UBI**.

| Partition | Address |
|----------|--------|
| BL2 | 0x00000000 |
| u-boot-env | 0x00100000 |
| Factory | 0x00180000 |
| FIP | 0x00380000 |
| ubi | 0x00580000 |

## MAC Address

The base MAC address is stored in the **Factory partition at offset 0x4**.

Observed default addresses:

| Interface | Address |
|----------|--------|
| base | b0:xx:xx:2a:xx:ac |
| LAN | b0:xx:xx:2a:xx:af |
| WAN | b0:xx:xx:2a:xx:ad |
| 2G | b0:xx:xx:2a:xx:ac |
| 5G | b2:xx:xx:4a:xx:ac |

Derived rules:

| Interface | Calculation |
|----------|-------------|
| WLAN 2.4 GHz | base |
| WAN | base + 1 |
| LAN | base + 3 |
| WLAN 5 GHz | base-derived MAC with locally administered bit set |

The Ethernet MAC assignment is implemented in:

```
target/linux/mediatek/filogic/base-files/etc/board.d/02_network
```

<details>
<summary>Installation</summary>

### Method 1: UART available

Initial installation can be performed from the **U-Boot console**.

0. Configure the host PC as:

```
192.168.0.2/24
```

2. Interrupt boot and enter the boot menu
3. Select `0` to enter U-Boot
4. Start the TFTP server:

```
tftpsrv
```

5. The bootloader starts a TFTP server at:

```
192.168.0.1
```

6. Upload the **initramfs image via TFTP**, then boot it:

```
bootm 0x46000000
```

7. Configure the host PC as:

```
192.168.1.2/24
```


8. After OpenWrt initramfs boots, copy the sysupgrade image:

```
scp -O *sysupgrade.bin root@192.168.1.1:/tmp
```

9. Then flash it:

```
sysupgrade /tmp/*sysupgrade.bin
```

### Method 2: Bootloader recovery (no UART)

The bootloader also provides a **TFTP recovery mode**.

1. Hold the **reset button**
2. Power on the device
3. Keep holding for about **10 seconds**
4. Release when the **CPU LED pattern changes**

The device then starts a TFTP server at:

```
192.168.0.1
```

From this state either:

- boot the initramfs image and install via sysupgrade, or
- use the **vendor recovery utility**, which bypasses firmware verification and directly uploads the sysupgrade image.

</details> 

<details><summary>Screenshot</summary>
<p>

<img width="881" height="1552" alt="screenshot" src="https://github.com/user-attachments/assets/c4e1dc45-65ca-4365-b57b-74d8f5c2b05c" />

</p>
</details> 

<details><summary>Kernel Log</summary>
<p>

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.12.74 (sryu@Desktop) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r33364-9a742ecbef) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Fri Mar 13 10:35:10 2026
[    0.000000] KASLR disabled due to lack of seed
[    0.000000] Machine model: ipTIME AX6000M
[    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004303ffff (256 KiB) nomap non-reusable secmon@43000000
[    0.000000] OF: reserved mem: 0x000000004fc00000..0x000000004fcfffff (1024 KiB) nomap non-reusable wmcpu-reserved@4fc00000
[    0.000000] OF: reserved mem: 0x000000004fd00000..0x000000004fd3ffff (256 KiB) nomap non-reusable wo-emi@4fd00000
[    0.000000] OF: reserved mem: 0x000000004fd40000..0x000000004fd7ffff (256 KiB) nomap non-reusable wo-emi@4fd40000
[    0.000000] OF: reserved mem: 0x000000004fd80000..0x000000004ffbffff (2304 KiB) nomap non-reusable wo-data@4fd80000
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000040000000-0x000000005fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[    0.000000]   node   0: [mem 0x0000000043000000-0x000000004303ffff]
[    0.000000]   node   0: [mem 0x0000000043040000-0x000000004fbfffff]
[    0.000000]   node   0: [mem 0x000000004fc00000-0x000000004ffbffff]
[    0.000000]   node   0: [mem 0x000000004ffc0000-0x000000005fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000005fffffff]
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.2
[    0.000000] percpu: Embedded 20 pages/cpu s42520 r8192 d31208 u81920
[    0.000000] pcpu-alloc: s42520 r8192 d31208 u81920 alloc=20*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3 
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: GIC system register CPU interface
[    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: console=ttyS0,115200 boot_from=A
[    0.000000] Unknown kernel command line parameters "boot_from=A", will be passed to user space.
[    0.000000] Dentry cache hash table entries: 65536 (order: 7, 524288 bytes, linear)
[    0.000000] Inode-cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 131072
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[    0.000000] software IO TLB: area num 4.
[    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 1MB
[    0.000000] software IO TLB: mapped [mem 0x000000005fcc5000-0x000000005fdc5000] (1MB)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Hierarchical RCU implementation.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks Trace: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=4.
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[    0.000000] GICv3: 640 SPIs implemented
[    0.000000] GICv3: 0 Extended SPIs implemented
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GICv3: GICv3 features: 16 PPIs
[    0.000000] GICv3: GICD_CTRL.DS=0, SCR_EL3.FIQ=0
[    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[    0.000060] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[    0.000067] pid_max: default: 32768 minimum: 301
[    0.002121] Mount-cache hash table entries: 1024 (order: 1, 8192 bytes, linear)
[    0.002129] Mountpoint-cache hash table entries: 1024 (order: 1, 8192 bytes, linear)
[    0.003726] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.004345] rcu: Hierarchical SRCU implementation.
[    0.004348] rcu: 	Max phase no-delay instances is 1000.
[    0.004468] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.004687] smp: Bringing up secondary CPUs ...
[    0.004948] Detected VIPT I-cache on CPU1
[    0.004985] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[    0.005010] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.005329] Detected VIPT I-cache on CPU2
[    0.005351] GICv3: CPU2: found redistributor 2 region 0:0x000000000c0c0000
[    0.005363] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
[    0.005679] Detected VIPT I-cache on CPU3
[    0.005697] GICv3: CPU3: found redistributor 3 region 0:0x000000000c0e0000
[    0.005707] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
[    0.005743] smp: Brought up 1 node, 4 CPUs
[    0.005747] SMP: Total of 4 processors activated.
[    0.005749] CPU: All CPU(s) started at EL2
[    0.005751] CPU features: detected: 32-bit EL0 Support
[    0.005753] CPU features: detected: CRC32 instructions
[    0.005775] alternatives: applying system-wide alternatives
[    0.005874] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[    0.005998] Memory: 491340K/524288K available (9280K kernel code, 984K rwdata, 2764K rodata, 832K init, 300K bss, 30024K reserved, 0K cma-reserved)
[    0.008159] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.008173] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.008253] 29184 pages in range for non-PLT usage
[    0.008255] 520704 pages in range for PLT usage
[    0.009254] pinctrl core: initialized pinctrl subsystem
[    0.010178] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.010425] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[    0.010444] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.010459] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.010748] thermal_sys: Registered thermal governor 'fair_share'
[    0.010750] thermal_sys: Registered thermal governor 'bang_bang'
[    0.010752] thermal_sys: Registered thermal governor 'step_wise'
[    0.010754] thermal_sys: Registered thermal governor 'user_space'
[    0.010790] ASID allocator initialised with 65536 entries
[    0.011284] pstore: Using crash dump compression: deflate
[    0.011287] pstore: Registered ramoops as persistent store backend
[    0.011289] ramoops: using 0x10000@0x42ff0000, ecc: 0
[    0.012255] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[    0.023853] cryptd: max_cpu_qlen set to 1000
[    0.025360] SCSI subsystem initialized
[    0.025442] libata version 3.00 loaded.
[    0.026643] clocksource: Switched to clocksource arch_sys_counter
[    0.028272] NET: Registered PF_INET protocol family
[    0.028356] IP idents hash table entries: 8192 (order: 4, 65536 bytes, linear)
[    0.029153] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[    0.029163] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.029170] TCP established hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.029193] TCP bind hash table entries: 4096 (order: 5, 131072 bytes, linear)
[    0.029284] TCP: Hash tables configured (established 4096 bind 4096)
[    0.029522] MPTCP token hash table entries: 512 (order: 2, 12288 bytes, linear)
[    0.029595] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.029606] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[    0.029745] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.029765] PCI: CLS 0 bytes, default 64
[    0.030771] workingset: timestamp_bits=46 max_order=17 bucket_order=0
[    0.034199] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.034203] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[    0.074260] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[    0.075169] printk: legacy console [ttyS0] disabled
[    0.095463] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 116, base_baud = 2500000) is a ST16650V2
[    0.095500] printk: legacy console [ttyS0] enabled
[    0.905927] mtk_rng 1020f000.rng: registered RNG driver
[    0.906155] random: crng init done
[    0.916751] loop: module loaded
[    0.921269] spi-nand spi0.0: ESMT SPI NAND was found.
[    0.926318] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[    0.934647] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.940994] Creating 5 MTD partitions on "spi0.0":
[    0.945769] 0x000000000000-0x000000100000 : "BL2"
[    0.951452] 0x000000100000-0x000000180000 : "u-boot-env"
[    0.957318] 0x000000180000-0x000000380000 : "Factory"
[    0.964124] 0x000000380000-0x000000580000 : "FIP"
[    0.970480] 0x000000580000-0x000007380000 : "ubi"
[    1.274323] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081600000, irq 120
[    1.284083] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc081600000, irq 120
[    1.293719] i2c_dev: i2c /dev entries driver
[    1.299204] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[    1.307586] NET: Registered PF_INET6 protocol family
[    1.313273] Segment Routing with IPv6
[    1.316980] In-situ OAM (IOAM) with IPv6
[    1.320923] NET: Registered PF_PACKET protocol family
[    1.326066] 8021q: 802.1Q VLAN Support v1.8
[    1.399391] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[    1.408357] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    1.418320] mt7530-mdio mdio-bus:1f wan (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=124)
[    1.439346] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=125)
[    1.460112] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=126)
[    1.480859] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=127)
[    1.501610] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:04] driver [MediaTek MT7531 PHY] (irq=128)
[    1.512654] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[    1.519370] DSA: tree 0 setup
[    1.522963] UBI: auto-attach mtd4
[    1.526279] ubi0: default fastmap pool size: 40
[    1.530808] ubi0: default fastmap WL pool size: 20
[    1.535582] ubi0: attaching mtd4
[    2.355373] ubi0: scanning is finished
[    2.369473] ubi0: attached mtd4 (name "ubi", size 110 MiB)
[    2.374954] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    2.381816] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.388587] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.395527] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[    2.401517] ubi0: user volume: 5, internal volumes: 1, max. volumes count: 128
[    2.408719] ubi0: max/mean erase counter: 5/3, WL threshold: 4096, image sequence number: 0
[    2.417048] ubi0: available PEBs: 0, total reserved PEBs: 880, PEBs reserved for bad PEB handling: 20
[    2.426249] ubi0: background thread "ubi_bgt0d" started, PID 594
[    2.433048] block ubiblock0_1: created from ubi0:1(rootfs)
[    2.438527] ubiblock: device ubiblock0_1 (rootfs) set to be root filesystem
[    2.445547] clk: Disabling unused clocks
[    2.449707] PM: genpd: Disabling unused power domains
[    2.462317] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[    2.469787] Freeing unused kernel memory: 832K
[    2.474260] Run /sbin/init as init process
[    2.478352]   with arguments:
[    2.481304]     /sbin/init
[    2.483996]   with environment:
[    2.487124]     HOME=/
[    2.489469]     TERM=linux
[    2.492160]     boot_from=A
[    2.696728] init: Console is alive
[    2.700210] init: - watchdog -
[    3.102028] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[    3.121430] usbcore: registered new interface driver usbfs
[    3.126973] usbcore: registered new interface driver hub
[    3.132297] usbcore: registered new device driver usb
[    3.137926] gpio_button_hotplug: loading out-of-tree module taints kernel.
[    3.148873] xhci-mtk 11200000.usb: supply vbus not found, using dummy regulator
[    3.156276] xhci-mtk 11200000.usb: supply vusb33 not found, using dummy regulator
[    3.164581] xhci-mtk 11200000.usb: xHCI Host Controller
[    3.169813] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 1
[    3.180200] xhci-mtk 11200000.usb: hcc params 0x01403f99 hci version 0x110 quirks 0x0000000000200010
[    3.189355] xhci-mtk 11200000.usb: irq 129, io mem 0x11200000
[    3.195171] xhci-mtk 11200000.usb: xHCI Host Controller
[    3.200392] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 2
[    3.207774] xhci-mtk 11200000.usb: Host supports USB 3.2 Enhanced SuperSpeed
[    3.215101] hub 1-0:1.0: USB hub found
[    3.218862] hub 1-0:1.0: 2 ports detected
[    3.223095] usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
[    3.231483] hub 2-0:1.0: USB hub found
[    3.235234] hub 2-0:1.0: 1 port detected
[    3.243136] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[    3.257555] init: - preinit -
[    3.565739] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[    3.574241] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[    3.597807] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[    7.784473] UBIFS (ubi0:4): Mounting in unauthenticated mode
[    7.790234] UBIFS (ubi0:4): background thread "ubifs_bgt0_4" started, PID 749
[    7.843827] UBIFS (ubi0:4): recovery needed
[    7.973803] UBIFS (ubi0:4): recovery completed
[    7.978300] UBIFS (ubi0:4): UBIFS: mounted UBI device 0, volume 4, name "rootfs_data"
[    7.986111] UBIFS (ubi0:4): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[    7.996006] UBIFS (ubi0:4): FS size: 66281472 bytes (63 MiB, 522 LEBs), max 532 LEBs, journal size 3301376 bytes (3 MiB, 26 LEBs)
[    8.007634] UBIFS (ubi0:4): reserved for root: 3130637 bytes (3057 KiB)
[    8.014229] UBIFS (ubi0:4): media format: w5/r0 (latest is w5/r0), UUID <UUID censored>, small LPT model
[    8.028928] mount_root: switching to ubifs overlay
[    8.042881] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[    8.059145] urandom-seed: Seeding with /etc/urandom.seed
[    8.119918] procd: - early -
[    8.122846] procd: - watchdog -
[    8.676689] procd: - watchdog -
[    8.681882] procd: - ubus -
[    8.837514] procd: - init -
[    9.108960] kmodloader: loading kernel modules from /etc/modules.d/*
[    9.133747] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[    9.148028] Loading modules backported from Linux version v6.18.7-0-g5dfbc5357
[    9.155245] Backport generated by backports.git c8a37ce
[    9.280219] urngd: v1.0.2 started.
[    9.670527] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823160739a
[    9.859964] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823160804
[    9.962847] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823160840
[   10.069327] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[   10.177948] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[   10.237743] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   10.358690] PPP generic driver version 2.4.2
[   10.363813] NET: Registered PF_PPPOX protocol family
[   10.371294] kmodloader: done loading kernel modules from /etc/modules.d/*
[   10.395680] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[   12.543590] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[   12.558872] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[   12.567342] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[   12.573905] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[   12.587101] br-lan: port 1(lan1) entered blocking state
[   12.592335] br-lan: port 1(lan1) entered disabled state
[   12.597643] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[   12.603906] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[   12.613895] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[   12.631165] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[   12.641900] br-lan: port 2(lan2) entered blocking state
[   12.647158] br-lan: port 2(lan2) entered disabled state
[   12.652410] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[   12.660438] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[   12.674600] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[   12.685336] br-lan: port 3(lan3) entered blocking state
[   12.690610] br-lan: port 3(lan3) entered disabled state
[   12.695862] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[   12.704028] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[   12.718402] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[   12.729334] br-lan: port 4(lan4) entered blocking state
[   12.734566] br-lan: port 4(lan4) entered disabled state
[   12.739875] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[   12.748189] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[   12.759316] mtk_soc_eth 15100000.ethernet eth1: validation of  with support 00,00000000,00000000,00006000 and advertisement 00,00000000,00000000,00000000 failed: -EINVAL
[   12.774563] mtk_soc_eth 15100000.ethernet eth1: mtk_open: could not attach PHY: -22
[   23.658187] mt7530-mdio mdio-bus:1f lan4: Link is Up - 1Gbps/Full - flow control rx/tx
[   23.658210] br-lan: port 4(lan4) entered blocking state
[   23.671312] br-lan: port 4(lan4) entered forwarding state

</p>
</details> 

<details><summary>SystemLog</summary>
<p>

[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.000000] Linux version 6.12.74 (sryu@Desktop) (aarch64-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r33364-9a742ecbef) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Fri Mar 13 10:35:10 2026
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.warn: [    0.000000] KASLR disabled due to lack of seed
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] Machine model: ipTIME AX6000M
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] OF: reserved mem: 0x0000000042ff0000..0x0000000042ffffff (64 KiB) map non-reusable ramoops@42ff0000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] OF: reserved mem: 0x0000000043000000..0x000000004303ffff (256 KiB) nomap non-reusable secmon@43000000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] OF: reserved mem: 0x000000004fc00000..0x000000004fcfffff (1024 KiB) nomap non-reusable wmcpu-reserved@4fc00000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] OF: reserved mem: 0x000000004fd00000..0x000000004fd3ffff (256 KiB) nomap non-reusable wo-emi@4fd00000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] OF: reserved mem: 0x000000004fd40000..0x000000004fd7ffff (256 KiB) nomap non-reusable wo-emi@4fd40000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] OF: reserved mem: 0x000000004fd80000..0x000000004ffbffff (2304 KiB) nomap non-reusable wo-data@4fd80000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] Zone ranges:
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000]   DMA      [mem 0x0000000040000000-0x000000005fffffff]
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000]   DMA32    empty
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000]   Normal   empty
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] Movable zone start for each node
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] Early memory node ranges
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000]   node   0: [mem 0x0000000040000000-0x0000000042ffffff]
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000]   node   0: [mem 0x0000000043000000-0x000000004303ffff]
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000]   node   0: [mem 0x0000000043040000-0x000000004fbfffff]
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000]   node   0: [mem 0x000000004fc00000-0x000000004ffbffff]
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000]   node   0: [mem 0x000000004ffc0000-0x000000005fffffff]
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] Initmem setup node 0 [mem 0x0000000040000000-0x000000005fffffff]
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] psci: probing for conduit method from DT.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] psci: PSCIv1.1 detected in firmware.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] psci: Using standard PSCI v0.2 function IDs
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] psci: SMC Calling Convention v1.2
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] percpu: Embedded 20 pages/cpu s42520 r8192 d31208 u81920
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.debug: [    0.000000] pcpu-alloc: s42520 r8192 d31208 u81920 alloc=20*4096
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.debug: [    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] Detected VIPT I-cache on CPU0
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] CPU features: detected: GIC system register CPU interface
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] CPU features: kernel page table isolation disabled by kernel configuration
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] alternatives: applying boot alternatives
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.000000] Kernel command line: console=ttyS0,115200 boot_from=A
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.000000] Unknown kernel command line parameters "boot_from=A", will be passed to user space.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] Dentry cache hash table entries: 65536 (order: 7, 524288 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] Inode-cache hash table entries: 32768 (order: 6, 262144 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 131072
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] software IO TLB: SWIOTLB bounce buffer size adjusted to 0MB
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] software IO TLB: area num 4.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] software IO TLB: SWIOTLB bounce buffer size roundup to 1MB
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] software IO TLB: mapped [mem 0x000000005fcc5000-0x000000005fdc5000] (1MB)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] rcu: Hierarchical RCU implementation.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] 	Tracing variant of Tasks RCU enabled.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] RCU Tasks Trace: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1 rcu_task_cpu_ids=4.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] GICv3: GIC: Using split EOI/Deactivate mode
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] GICv3: 640 SPIs implemented
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] GICv3: 0 Extended SPIs implemented
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] Root IRQ handler: gic_handle_irq
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] GICv3: GICv3 features: 16 PPIs
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] GICv3: GICD_CTRL.DS=0, SCR_EL3.FIQ=0
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] GICv3: CPU0: found redistributor 0 region 0:0x000000000c080000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] arch_timer: cp15 timer(s) running at 13.00MHz (phys).
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x2ff89eacb, max_idle_ns: 440795202429 ns
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000000] sched_clock: 56 bits at 13MHz, resolution 76ns, wraps every 4398046511101ns
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000060] Calibrating delay loop (skipped), value calculated using timer frequency.. 26.00 BogoMIPS (lpj=130000)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.000067] pid_max: default: 32768 minimum: 301
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.002121] Mount-cache hash table entries: 1024 (order: 1, 8192 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.002129] Mountpoint-cache hash table entries: 1024 (order: 1, 8192 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.warn: [    0.003726] cacheinfo: Unable to detect cache hierarchy for CPU 0
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.004345] rcu: Hierarchical SRCU implementation.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.004348] rcu: 	Max phase no-delay instances is 1000.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.004468] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.004687] smp: Bringing up secondary CPUs ...
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.004948] Detected VIPT I-cache on CPU1
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.004985] GICv3: CPU1: found redistributor 1 region 0:0x000000000c0a0000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005010] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005329] Detected VIPT I-cache on CPU2
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005351] GICv3: CPU2: found redistributor 2 region 0:0x000000000c0c0000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005363] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005679] Detected VIPT I-cache on CPU3
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005697] GICv3: CPU3: found redistributor 3 region 0:0x000000000c0e0000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005707] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005743] smp: Brought up 1 node, 4 CPUs
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005747] SMP: Total of 4 processors activated.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005749] CPU: All CPU(s) started at EL2
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005751] CPU features: detected: 32-bit EL0 Support
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005753] CPU features: detected: CRC32 instructions
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005775] alternatives: applying system-wide alternatives
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005874] CPU features: emulated: Privileged Access Never (PAN) using TTBR0_EL1 switching
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.005998] Memory: 491340K/524288K available (9280K kernel code, 984K rwdata, 2764K rodata, 832K init, 300K bss, 30024K reserved, 0K cma-reserved)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.008159] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.008173] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.008253] 29184 pages in range for non-PLT usage
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.008255] 520704 pages in range for PLT usage
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.009254] pinctrl core: initialized pinctrl subsystem
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.010178] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.010425] DMA: preallocated 128 KiB GFP_KERNEL pool for atomic allocations
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.010444] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.010459] DMA: preallocated 128 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.010748] thermal_sys: Registered thermal governor 'fair_share'
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.010750] thermal_sys: Registered thermal governor 'bang_bang'
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.010752] thermal_sys: Registered thermal governor 'step_wise'
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.010754] thermal_sys: Registered thermal governor 'user_space'
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.010790] ASID allocator initialised with 65536 entries
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.011284] pstore: Using crash dump compression: deflate
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.011287] pstore: Registered ramoops as persistent store backend
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.011289] ramoops: using 0x10000@0x42ff0000, ecc: 0
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.012255] /soc/interrupt-controller@c000000: Fixed dependency cycle(s) with /soc/interrupt-controller@c000000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.023853] cryptd: max_cpu_qlen set to 1000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.025360] SCSI subsystem initialized
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.debug: [    0.025442] libata version 3.00 loaded.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.026643] clocksource: Switched to clocksource arch_sys_counter
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.028272] NET: Registered PF_INET protocol family
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.028356] IP idents hash table entries: 8192 (order: 4, 65536 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.029153] tcp_listen_portaddr_hash hash table entries: 256 (order: 0, 4096 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.029163] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.029170] TCP established hash table entries: 4096 (order: 3, 32768 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.029193] TCP bind hash table entries: 4096 (order: 5, 131072 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.029284] TCP: Hash tables configured (established 4096 bind 4096)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.029522] MPTCP token hash table entries: 512 (order: 2, 12288 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.029595] UDP hash table entries: 256 (order: 1, 8192 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.029606] UDP-Lite hash table entries: 256 (order: 1, 8192 bytes, linear)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.029745] NET: Registered PF_UNIX/PF_LOCAL protocol family
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.029765] PCI: CLS 0 bytes, default 64
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.030771] workingset: timestamp_bits=46 max_order=17 bucket_order=0
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.034199] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.034203] jffs2: version 2.2 (NAND) (SUMMARY) (LZMA) (RTIME) (CMODE_PRIORITY) (c) 2001-2006 Red Hat, Inc.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.074260] Serial: 8250/16550 driver, 3 ports, IRQ sharing disabled
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.075169] printk: legacy console [ttyS0] disabled
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.095463] 11002000.serial: ttyS0 at MMIO 0x11002000 (irq = 116, base_baud = 2500000) is a ST16650V2
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.095500] printk: legacy console [ttyS0] enabled
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.905927] mtk_rng 1020f000.rng: registered RNG driver
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.906155] random: crng init done
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.916751] loop: module loaded
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.921269] spi-nand spi0.0: ESMT SPI NAND was found.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    0.926318] spi-nand spi0.0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.934647] 5 fixed-partitions partitions found on MTD device spi0.0
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.940994] Creating 5 MTD partitions on "spi0.0":
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.945769] 0x000000000000-0x000000100000 : "BL2"
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.951452] 0x000000100000-0x000000180000 : "u-boot-env"
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.957318] 0x000000180000-0x000000380000 : "Factory"
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.964124] 0x000000380000-0x000000580000 : "FIP"
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    0.970480] 0x000000580000-0x000007380000 : "ubi"
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.274323] mtk_soc_eth 15100000.ethernet eth0: mediatek frame engine at 0xffffffc081600000, irq 120
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.284083] mtk_soc_eth 15100000.ethernet eth1: mediatek frame engine at 0xffffffc081600000, irq 120
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.293719] i2c_dev: i2c /dev entries driver
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.299204] mtk-wdt 1001c000.watchdog: Watchdog enabled (timeout=31 sec, nowayout=0)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.307586] NET: Registered PF_INET6 protocol family
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.313273] Segment Routing with IPv6
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.316980] In-situ OAM (IOAM) with IPv6
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.320923] NET: Registered PF_PACKET protocol family
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.326066] 8021q: 802.1Q VLAN Support v1.8
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.399391] mt7530-mdio mdio-bus:1f: configuring for fixed/2500base-x link mode
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.408357] mt7530-mdio mdio-bus:1f: Link is Up - 2.5Gbps/Full - flow control rx/tx
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.418320] mt7530-mdio mdio-bus:1f wan (uninitialized): PHY [mt7530-0:00] driver [MediaTek MT7531 PHY] (irq=124)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.439346] mt7530-mdio mdio-bus:1f lan1 (uninitialized): PHY [mt7530-0:01] driver [MediaTek MT7531 PHY] (irq=125)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.460112] mt7530-mdio mdio-bus:1f lan2 (uninitialized): PHY [mt7530-0:02] driver [MediaTek MT7531 PHY] (irq=126)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.480859] mt7530-mdio mdio-bus:1f lan3 (uninitialized): PHY [mt7530-0:03] driver [MediaTek MT7531 PHY] (irq=127)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.501610] mt7530-mdio mdio-bus:1f lan4 (uninitialized): PHY [mt7530-0:04] driver [MediaTek MT7531 PHY] (irq=128)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.512654] mtk_soc_eth 15100000.ethernet eth0: entered promiscuous mode
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    1.519370] DSA: tree 0 setup
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    1.522963] UBI: auto-attach mtd4
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    1.526279] ubi0: default fastmap pool size: 40
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    1.530808] ubi0: default fastmap WL pool size: 20
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    1.535582] ubi0: attaching mtd4
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    2.355373] ubi0: scanning is finished
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    2.369473] ubi0: attached mtd4 (name "ubi", size 110 MiB)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    2.374954] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    2.381816] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    2.388587] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    2.395527] ubi0: good PEBs: 880, bad PEBs: 0, corrupted PEBs: 0
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    2.401517] ubi0: user volume: 5, internal volumes: 1, max. volumes count: 128
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    2.408719] ubi0: max/mean erase counter: 5/3, WL threshold: 4096, image sequence number: 0
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    2.417048] ubi0: available PEBs: 0, total reserved PEBs: 880, PEBs reserved for bad PEB handling: 20
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    2.426249] ubi0: background thread "ubi_bgt0d" started, PID 594
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    2.433048] block ubiblock0_1: created from ubi0:1(rootfs)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    2.438527] ubiblock: device ubiblock0_1 (rootfs) set to be root filesystem
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    2.445547] clk: Disabling unused clocks
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    2.449707] PM: genpd: Disabling unused power domains
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    2.462317] VFS: Mounted root (squashfs filesystem) readonly on device 254:0.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    2.469787] Freeing unused kernel memory: 832K
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    2.474260] Run /sbin/init as init process
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.debug: [    2.478352]   with arguments:
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.debug: [    2.481304]     /sbin/init
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.debug: [    2.483996]   with environment:
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.debug: [    2.487124]     HOME=/
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.debug: [    2.489469]     TERM=linux
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.debug: [    2.492160]     boot_from=A
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    2.696728] init: Console is alive
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    2.700210] init: - watchdog -
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    3.102028] kmodloader: loading kernel modules from /etc/modules-boot.d/*
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.121430] usbcore: registered new interface driver usbfs
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.126973] usbcore: registered new interface driver hub
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.132297] usbcore: registered new device driver usb
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.warn: [    3.137926] gpio_button_hotplug: loading out-of-tree module taints kernel.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.warn: [    3.148873] xhci-mtk 11200000.usb: supply vbus not found, using dummy regulator
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.warn: [    3.156276] xhci-mtk 11200000.usb: supply vusb33 not found, using dummy regulator
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.164581] xhci-mtk 11200000.usb: xHCI Host Controller
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.169813] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 1
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.180200] xhci-mtk 11200000.usb: hcc params 0x01403f99 hci version 0x110 quirks 0x0000000000200010
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.189355] xhci-mtk 11200000.usb: irq 129, io mem 0x11200000
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.195171] xhci-mtk 11200000.usb: xHCI Host Controller
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.200392] xhci-mtk 11200000.usb: new USB bus registered, assigned bus number 2
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.207774] xhci-mtk 11200000.usb: Host supports USB 3.2 Enhanced SuperSpeed
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.215101] hub 1-0:1.0: USB hub found
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.218862] hub 1-0:1.0: 2 ports detected
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.223095] usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.231483] hub 2-0:1.0: USB hub found
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.235234] hub 2-0:1.0: 1 port detected
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    3.243136] kmodloader: done loading kernel modules from /etc/modules-boot.d/*
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    3.257555] init: - preinit -
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.565739] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.574241] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    3.597807] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    7.784473] UBIFS (ubi0:4): Mounting in unauthenticated mode
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    7.790234] UBIFS (ubi0:4): background thread "ubifs_bgt0_4" started, PID 749
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    7.843827] UBIFS (ubi0:4): recovery needed
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    7.973803] UBIFS (ubi0:4): recovery completed
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    7.978300] UBIFS (ubi0:4): UBIFS: mounted UBI device 0, volume 4, name "rootfs_data"
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    7.986111] UBIFS (ubi0:4): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    7.996006] UBIFS (ubi0:4): FS size: 66281472 bytes (63 MiB, 522 LEBs), max 532 LEBs, journal size 3301376 bytes (3 MiB, 26 LEBs)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    8.007634] UBIFS (ubi0:4): reserved for root: 3130637 bytes (3057 KiB)
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.notice: [    8.014229] UBIFS (ubi0:4): media format: w5/r0 (latest is w5/r0), UUID <UUID censored>, small LPT model
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    8.028928] mount_root: switching to ubifs overlay
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.warn: [    8.042881] overlayfs: null uuid detected in lower fs '/', falling back to xino=off,index=off,nfs_export=off.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.debug: [    8.059145] urandom-seed: Seeding with /etc/urandom.seed
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    8.119918] procd: - early -
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    8.122846] procd: - watchdog -
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    8.676689] procd: - watchdog -
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    8.681882] procd: - ubus -
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    8.837514] procd: - init -
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    9.108960] kmodloader: loading kernel modules from /etc/modules.d/*
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    9.133747] crypto-safexcel 10320000.crypto: EIP97:230(0,1,4,4)-HIA:270(0,5,5),PE:150/433(alg:7fcdfc00)/0/0/0
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    9.148028] Loading modules backported from Linux version v6.18.7-0-g5dfbc5357
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    9.155245] Backport generated by backports.git c8a37ce
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [    9.280219] urngd: v1.0.2 started.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    9.670527] mt798x-wmac 18000000.wifi: HW/SW Version: 0x8a108a10, Build Time: 20240823160739a
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    9.859964] mt798x-wmac 18000000.wifi: WM Firmware Version: ____000000, Build Time: 20240823160804
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [    9.962847] mt798x-wmac 18000000.wifi: WA Firmware Version: DEV_000000, Build Time: 20240823160840
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [   10.069327] mt798x-wmac 18000000.wifi: registering led 'mt76-phy0'
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [   10.177948] mt798x-wmac 18000000.wifi: registering led 'mt76-phy1'
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.warn: [   10.237743] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [   10.358690] PPP generic driver version 2.4.2
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.info: [   10.363813] NET: Registered PF_PPPOX protocol family
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] user.info: [   10.371294] kmodloader: done loading kernel modules from /etc/modules.d/*
[2026. 3. 14. 오전 12시 7분 52초 GMT+9] kern.warn: [   10.395680] mtdblock: MTD device 'Factory' is NAND, please consider using UBI block devices instead.
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] user.notice: dnsmasq: DNS rebinding protection is active, will discard upstream RFC1918 responses!
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] user.notice: dnsmasq: Allowing 127.0.0.0/8 responses
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: started, version 2.92 cachesize 1000
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: DNS service limited to local subnets
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: compile time options: IPv6 GNU-getopt no-DBus UBus no-i18n no-IDN DHCP no-DHCPv6 no-Lua TFTP no-conntrack no-ipset no-nftset no-auth no-DNSSEC no-ID loop-detect inotify dumpfile
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: UBus support enabled: connected to system bus
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for test
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for onion
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for localhost
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for local
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for invalid
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for bind
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for lan
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.warn: dnsmasq[1]: no servers found in /tmp/resolv.conf.d/resolv.conf.auto, will retry
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: read /etc/hosts - 12 names
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] daemon.info: dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c - 0 names
[2026. 3. 14. 오전 12시 7분 53초 GMT+9] authpriv.info: dropbear[1557]: Not backgrounding
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: : Added device handler type: vrf
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: : Added device handler type: bonding
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: : Added device handler type: 8021ad
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: : Added device handler type: 8021q
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: : Added device handler type: macvlan
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: : Added device handler type: veth
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: : Added device handler type: bridge
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: : Added device handler type: Network device
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: : Added device handler type: tunnel
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: procd: /etc/rc.d/S25packet_steering: pid 334's current affinity list: 0-3
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: procd: /etc/rc.d/S25packet_steering: pid 334's new affinity list: 0
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: procd: /etc/rc.d/S25packet_steering: pid 335's current affinity list: 0-3
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: procd: /etc/rc.d/S25packet_steering: pid 335's new affinity list: 0
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: procd: /etc/rc.d/S50uhttpd: 4+0 records in
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: procd: /etc/rc.d/S50uhttpd: 4+0 records out
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: wpa_supplicant[1711]: Successfully initialized wpa_supplicant
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: ucitrack: Setting up /etc/config/luci-splash reload dependency on /etc/config/firewall
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: ucitrack: Setting up /etc/config/qos reload dependency on /etc/config/firewall
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: ucitrack: Setting up /etc/config/miniupnpd reload dependency on /etc/config/firewall
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: ucitrack: Setting up /etc/config/odhcpd reload dependency on /etc/config/dhcp
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: hostapd: Set MLD config: [ ]
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: hostapd: Reload all interfaces
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: wpa_supplicant[1711]: Set MLD config: [ ]
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.543590] mtk_soc_eth 15100000.ethernet eth0: Link is Down
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.558872] mtk_soc_eth 15100000.ethernet eth0: configuring for fixed/2500base-x link mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.567342] mtk_soc_eth 15100000.ethernet eth0: Link is Up - 2.5Gbps/Full - flow control rx/tx
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.573905] mt7530-mdio mdio-bus:1f lan1: configuring for phy/gmii link mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: ucitrack: Setting up /etc/config/dhcp reload dependency on /etc/config/network
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.587101] br-lan: port 1(lan1) entered blocking state
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.592335] br-lan: port 1(lan1) entered disabled state
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.597643] mt7530-mdio mdio-bus:1f lan1: entered allmulticast mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.603906] mtk_soc_eth 15100000.ethernet eth0: entered allmulticast mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.613895] mt7530-mdio mdio-bus:1f lan1: entered promiscuous mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: Interface 'lan' is enabled
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: Interface 'lan' is setting up now
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: Interface 'lan' is now up
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: ucitrack: Setting up /etc/config/network reload dependency on /etc/config/wireless
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.631165] mt7530-mdio mdio-bus:1f lan2: configuring for phy/gmii link mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.641900] br-lan: port 2(lan2) entered blocking state
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.647158] br-lan: port 2(lan2) entered disabled state
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.652410] mt7530-mdio mdio-bus:1f lan2: entered allmulticast mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.660438] mt7530-mdio mdio-bus:1f lan2: entered promiscuous mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: ucitrack: Setting up non-init /etc/config/fstab reload handler: /sbin/block mount
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.674600] mt7530-mdio mdio-bus:1f lan3: configuring for phy/gmii link mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.685336] br-lan: port 3(lan3) entered blocking state
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.690610] br-lan: port 3(lan3) entered disabled state
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.695862] mt7530-mdio mdio-bus:1f lan3: entered allmulticast mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: ucitrack: Setting up /etc/config/system reload trigger for non-procd /etc/init.d/led
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.704028] mt7530-mdio mdio-bus:1f lan3: entered promiscuous mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: firewall: Reloading firewall due to ifup of lan (br-lan)
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.718402] mt7530-mdio mdio-bus:1f lan4: configuring for phy/gmii link mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.729334] br-lan: port 4(lan4) entered blocking state
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.734566] br-lan: port 4(lan4) entered disabled state
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.739875] mt7530-mdio mdio-bus:1f lan4: entered allmulticast mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: ucitrack: Setting up /etc/config/luci_statistics reload dependency on /etc/config/system
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] user.notice: ucitrack: Setting up /etc/config/dhcp reload dependency on /etc/config/system
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.info: [   12.748189] mt7530-mdio mdio-bus:1f lan4: entered promiscuous mode
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: Interface 'loopback' is enabled
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: Interface 'loopback' is setting up now
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: Interface 'loopback' is now up
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.warn: [   12.759316] mtk_soc_eth 15100000.ethernet eth1: validation of  with support 00,00000000,00000000,00006000 and advertisement 00,00000000,00000000,00000000 failed: -EINVAL
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] kern.err: [   12.774563] mtk_soc_eth 15100000.ethernet eth1: mtk_open: could not attach PHY: -22
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: Interface 'wan' is enabled
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: Interface 'wan6' is enabled
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: Network device 'eth0' link is up
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: Network device 'lo' link is up
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: Interface 'loopback' has link connectivity
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: radio0 (2232): wifi-scripts: Starting
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: hostapd: Set new config for phy phy0:
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: wpa_supplicant[1711]: Set new config for phy phy0
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: wpa_supplicant[1711]: Set new config for phy phy0
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: hostapd: Set new config for phy phy0:
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: radio0 (2232): wifi-scripts: Configuring 'phy0' txantenna: 4294967295, rxantenna: 4294967295 distance: 0
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: netifd: radio1 (2337): wifi-scripts: Starting
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: hostapd: Set new config for phy phy1:
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: wpa_supplicant[1711]: Set new config for phy phy1
[2026. 3. 14. 오전 12시 7분 54초 GMT+9] daemon.notice: wpa_supplicant[1711]: Set new config for phy phy1
[2026. 3. 14. 오전 12시 7분 55초 GMT+9] daemon.notice: hostapd: Set new config for phy phy1:
[2026. 3. 14. 오전 12시 7분 55초 GMT+9] daemon.notice: netifd: radio1 (2337): wifi-scripts: Configuring 'phy1' txantenna: 4294967295, rxantenna: 4294967295 distance: 0
[2026. 3. 14. 오전 12시 7분 55초 GMT+9] daemon.notice: wpa_supplicant[1711]: Start pending MLD interfaces
[2026. 3. 14. 오전 12시 7분 55초 GMT+9] daemon.info: procd: - init complete -
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: exiting on receipt of SIGTERM
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.err: procd: Got unexpected signal 1
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: started, version 2.92 cachesize 1000
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: DNS service limited to local subnets
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: compile time options: IPv6 GNU-getopt no-DBus UBus no-i18n no-IDN DHCP no-DHCPv6 no-Lua TFTP no-conntrack no-ipset no-nftset no-auth no-DNSSEC no-ID loop-detect inotify dumpfile
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: UBus support enabled: connected to system bus
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq-dhcp[1]: DHCP, IP range 192.168.1.100 -- 192.168.1.249, lease time 12h
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for test
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for onion
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for localhost
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for local
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for invalid
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for bind
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: using only locally-known addresses for lan
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.warn: dnsmasq[1]: no servers found in /tmp/resolv.conf.d/resolv.conf.auto, will retry
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: read /etc/hosts - 12 names
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c - 4 names
[2026. 3. 14. 오전 12시 7분 59초 GMT+9] daemon.info: dnsmasq-dhcp[1]: read /etc/ethers - 0 addresses
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] kern.info: [   23.658187] mt7530-mdio mdio-bus:1f lan4: Link is Up - 1Gbps/Full - flow control rx/tx
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] kern.info: [   23.658210] br-lan: port 4(lan4) entered blocking state
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] kern.info: [   23.671312] br-lan: port 4(lan4) entered forwarding state
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] daemon.notice: netifd: Network device 'lan4' link is up
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] daemon.notice: netifd: bridge 'br-lan' link is up
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] daemon.notice: netifd: Interface 'lan' has link connectivity
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] daemon.err: odhcpd[1848]: Failed to send to fe80::7368:b03c:c470:8844%lan@br-lan (Address not available)
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] daemon.err: odhcpd[1848]: Failed to send to fe80::7368:b03c:c470:8844%lan@br-lan (Address not available)
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] daemon.info: dnsmasq[1]: read /etc/hosts - 12 names
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] daemon.info: dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c - 4 names
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] daemon.info: dnsmasq[1]: read /tmp/hosts/odhcpd.hosts.lan - 0 names
[2026. 3. 14. 오전 12시 8분 5초 GMT+9] daemon.info: dnsmasq-dhcp[1]: read /etc/ethers - 0 addresses
[2026. 3. 14. 오전 12시 8분 6초 GMT+9] daemon.info: dnsmasq[1]: read /etc/hosts - 12 names
[2026. 3. 14. 오전 12시 8분 6초 GMT+9] daemon.info: dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c - 4 names
[2026. 3. 14. 오전 12시 8분 6초 GMT+9] daemon.info: dnsmasq[1]: read /tmp/hosts/odhcpd.hosts.lan - 0 names
[2026. 3. 14. 오전 12시 8분 6초 GMT+9] daemon.info: dnsmasq-dhcp[1]: read /etc/ethers - 0 addresses
[2026. 3. 14. 오전 12시 8분 6초 GMT+9] daemon.err: odhcpd[1848]: Failed to send to fe80::7368:b03c:c470:8844%lan@br-lan (Address not available)
[2026. 3. 14. 오전 12시 8분 8초 GMT+9] daemon.warn: odhcpd[1848]: No default route present, setting ra_lifetime to 0!
[2026. 3. 14. 오전 12시 8분 8초 GMT+9] daemon.warn: odhcpd[1848]: rfc9096: br-lan: piofile updated
[2026. 3. 14. 오전 12시 8분 9초 GMT+9] daemon.info: dnsmasq[1]: read /etc/hosts - 12 names
[2026. 3. 14. 오전 12시 8분 9초 GMT+9] daemon.info: dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c - 4 names
[2026. 3. 14. 오전 12시 8분 9초 GMT+9] daemon.info: dnsmasq[1]: read /tmp/hosts/odhcpd.hosts.lan - 2 names
[2026. 3. 14. 오전 12시 8분 9초 GMT+9] daemon.info: dnsmasq-dhcp[1]: read /etc/ethers - 0 addresses
[2026. 3. 14. 오전 12시 8분 22초 GMT+9] daemon.warn: odhcpd[1848]: No default route present, setting ra_lifetime to 0!
[2026. 3. 14. 오전 12시 8분 23초 GMT+9] authpriv.info: dispatcher.uc: luci: accepted login on / for root from 192.168.1.2
[2026. 3. 14. 오전 12시 8분 38초 GMT+9] daemon.warn: odhcpd[1848]: No default route present, setting ra_lifetime to 0!

</p>
</details>

## Tested

- initramfs boot via UART TFTP
- sysupgrade installation
- bootloader TFTP recovery
- wireless MAC assignment

## LAN Port Ordering

The physical LAN ports on the device are labeled **LAN1–LAN4**, but the switch port numbering is reversed.