### PR TITLE
microchipsw: lan969x: tactical-1000: rename ports

### DIFF
--- a/target/linux/microchipsw/dts/lan9696-tactical-1000.dts
+++ b/target/linux/microchipsw/dts/lan9696-tactical-1000.dts
@@ -585,6 +585,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 0>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan4";
 		};
 
 		port1: port@1 {
@@ -593,6 +594,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 0>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan3";
 		};
 
 		port2: port@2 {
@@ -601,6 +603,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 0>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan2";
 		};
 
 		port3: port@3 {
@@ -609,6 +612,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 0>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan1";
 		};
 
 		port4: port@4 {
@@ -617,6 +621,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 1>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan8";
 		};
 
 		port5: port@5 {
@@ -625,6 +630,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 1>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan7";
 		};
 
 		port6: port@6 {
@@ -633,6 +639,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 1>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan6";
 		};
 
 		port7: port@7 {
@@ -641,6 +648,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 1>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan5";
 		};
 
 		port8: port@8 {
@@ -649,6 +657,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 2>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan12";
 		};
 
 		port9: port@9 {
@@ -657,6 +666,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 2>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan11";
 		};
 
 		port10: port@10 {
@@ -665,6 +675,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 2>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan10";
 		};
 
 		port11: port@11 {
@@ -673,6 +684,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 2>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan9";
 		};
 
 		port12: port@12 {
@@ -681,6 +693,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 3>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan16";
 		};
 
 		port13: port@13 {
@@ -689,6 +702,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 3>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan15";
 		};
 
 		port14: port@14 {
@@ -697,6 +711,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 3>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan14";
 		};
 
 		port15: port@15 {
@@ -705,6 +720,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 3>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan13";
 		};
 
 		port16: port@16 {
@@ -713,6 +729,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 4>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan20";
 		};
 
 		port17: port@17 {
@@ -721,6 +738,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 4>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan19";
 		};
 
 		port18: port@18 {
@@ -729,6 +747,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 4>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan18";
 		};
 
 		port19: port@19 {
@@ -737,6 +756,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 4>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan17";
 		};
 
 		port20: port@20 {
@@ -745,6 +765,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 5>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan24";
 		};
 
 		port21: port@21 {
@@ -753,6 +774,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 5>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan23";
 		};
 
 		port22: port@22 {
@@ -761,6 +783,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 5>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan22";
 		};
 
 		port23: port@23 {
@@ -769,6 +792,7 @@
 			phy-mode = "qsgmii";
 			phys = <&serdes 5>;
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "lan21";
 		};
 
 		port24: port@24 {
@@ -779,6 +803,7 @@
 			managed = "in-band-status";
 			microchip,bandwidth = <10000>;
 			microchip,sd-sgpio = <24>;
+			openwrt,netdev-name = "sfp1";
 		};
 
 		port25: port@25 {
@@ -789,6 +814,7 @@
 			managed = "in-band-status";
 			microchip,bandwidth = <10000>;
 			microchip,sd-sgpio = <28>;
+			openwrt,netdev-name = "sfp2";
 		};
 
 		port26: port@26 {
@@ -799,6 +825,7 @@
 			managed = "in-band-status";
 			microchip,bandwidth = <10000>;
 			microchip,sd-sgpio = <32>;
+			openwrt,netdev-name = "sfp3";
 		};
 
 		port27: port@27 {
@@ -809,6 +836,7 @@
 			managed = "in-band-status";
 			microchip,bandwidth = <10000>;
 			microchip,sd-sgpio = <36>;
+			openwrt,netdev-name = "sfp4";
 		};
 
 		port29: port@29 {
@@ -817,6 +845,7 @@
 			phy-handle = <&phy3>;
 			phy-mode = "rgmii-id";
 			microchip,bandwidth = <1000>;
+			openwrt,netdev-name = "mgmt";
 		};
 	};
 };

--- a/target/linux/microchipsw/lan969x/base-files/etc/board.d/02_network
+++ b/target/linux/microchipsw/lan969x/base-files/etc/board.d/02_network
@@ -9,7 +9,7 @@ lan969x_setup_interfaces()
 	case "$board" in
 	microchip,ev23x71a|\
 	novarq,tactical-1000)
-		lan_list=$(ls -1 -v -d /sys/class/net/eth* | xargs -n1 basename | xargs)
+		lan_list=$(ls -1 -v -d /sys/class/net/eth* /sys/class/net/lan* /sys/class/net/sfp* /sys/class/net/mgmt* | xargs -n1 basename | xargs)
 		ucidef_set_interface_lan "$lan_list"
 		;;
 	*)

--- a/target/linux/microchipsw/lan969x/base-files/lib/preinit/04_set_netdev_label
+++ b/target/linux/microchipsw/lan969x/base-files/lib/preinit/04_set_netdev_label
@@ -1,0 +1,15 @@
+set_netdev_labels() {
+	local dir
+	local label
+	local netdev
+
+	for dir in /sys/class/net/*; do
+		[ -r "$dir/of_node/openwrt,netdev-name" ] || continue
+		read -r label < "$dir/of_node/openwrt,netdev-name"
+		netdev="${dir##*/}"
+		[ "$netdev" = "$label" ] && continue
+		ip link set "$netdev" name "$label"
+	done
+}
+
+boot_hook_add preinit_main set_netdev_labels

--- a/target/linux/microchipsw/patches-6.12/0097-v6.19-net-sparx5-lan969x-populate-netdev-of_node.patch
+++ b/target/linux/microchipsw/patches-6.12/0097-v6.19-net-sparx5-lan969x-populate-netdev-of_node.patch
@@ -1,0 +1,26 @@
+From fc6aa0e470e092873eddb213d996a8beee86bf4d Mon Sep 17 00:00:00 2001
+From: Robert Marko <robert.marko@sartura.hr>
+Date: Mon, 10 Nov 2025 13:42:53 +0100
+Subject: [PATCH] net: sparx5/lan969x: populate netdev of_node
+
+Populate of_node for the port netdevs, to make the individual ports
+of_nodes available in sysfs.
+
+Signed-off-by: Robert Marko <robert.marko@sartura.hr>
+Link: https://patch.msgid.link/20251110124342.199216-1-robert.marko@sartura.hr
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/microchip/sparx5/sparx5_main.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+--- a/drivers/net/ethernet/microchip/sparx5/sparx5_main.c
++++ b/drivers/net/ethernet/microchip/sparx5/sparx5_main.c
+@@ -396,6 +396,8 @@ static int sparx5_create_port(struct spa
+ 
+ 	spx5_port->phylink = phylink;
+ 
++	spx5_port->ndev->dev.of_node = spx5_port->of_node;
++
+ 	return 0;
+ }
+ 

--- a/target/linux/microchipsw/patches-6.12/0098-v7.0-net-sparx5-lan969x-fix-DWRR-cost-max-to-match-hardwa.patch
+++ b/target/linux/microchipsw/patches-6.12/0098-v7.0-net-sparx5-lan969x-fix-DWRR-cost-max-to-match-hardwa.patch
@@ -1,0 +1,38 @@
+From 6c28aa8dfdf24f554d4c5d4ff7d723a95360d94a Mon Sep 17 00:00:00 2001
+From: Daniel Machon <daniel.machon@microchip.com>
+Date: Tue, 10 Feb 2026 14:44:01 +0100
+Subject: [PATCH] net: sparx5/lan969x: fix DWRR cost max to match hardware
+ register width
+
+DWRR (Deficit Weighted Round Robin) scheduling distributes bandwidth
+across traffic classes based on per-queue cost values, where lower cost
+means higher bandwidth share.
+
+The SPX5_DWRR_COST_MAX constant is 63 (6 bits) but the hardware
+register field HSCH_DWRR_ENTRY_DWRR_COST is GENMASK(24, 20), only
+5 bits wide (max 31). This causes sparx5_weight_to_hw_cost() to
+compute cost values that silently overflow via FIELD_PREP, resulting
+in incorrect scheduling weights.
+
+Set SPX5_DWRR_COST_MAX to 31 to match the hardware register width.
+
+Fixes: 211225428d65 ("net: microchip: sparx5: add support for offloading ets qdisc")
+Signed-off-by: Daniel Machon <daniel.machon@microchip.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/20260210-sparx5-fix-dwrr-cost-max-v1-1-58fbdbc25652@microchip.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/ethernet/microchip/sparx5/sparx5_qos.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/microchip/sparx5/sparx5_qos.h
++++ b/drivers/net/ethernet/microchip/sparx5/sparx5_qos.h
+@@ -35,7 +35,7 @@
+ #define SPX5_SE_BURST_UNIT 4096
+ 
+ /* Dwrr */
+-#define SPX5_DWRR_COST_MAX 63
++#define SPX5_DWRR_COST_MAX 31
+ 
+ struct sparx5_shaper {
+ 	u32 mode;


### PR DESCRIPTION
Rename ports to match the case, backport required kernel fix for renaming and one more bugfix.