### PR TITLE
microchipsw: lan969x: tactical-1000: fix SFP I2C buses

### DIFF
--- a/target/linux/microchipsw/dts/lan9696-tactical-1000.dts
+++ b/target/linux/microchipsw/dts/lan9696-tactical-1000.dts
@@ -58,7 +58,7 @@
 			    <&sgpio_out 0 3 GPIO_ACTIVE_HIGH>;
 		settle-time-us = <100>;
 
-		i2c_sfp0: i2c@0 {
+		i2c_sfp2: i2c@0 {
 			reg = <0x0>;
 		};
 
@@ -66,7 +66,7 @@
 			reg = <0x1>;
 		};
 
-		i2c_sfp2: i2c@2 {
+		i2c_sfp0: i2c@2 {
 			reg = <0x2>;
 		};
 


### PR DESCRIPTION
SFP I2C buses for ports 1 and 3 were swapped as order changed on production boards.

So, swap them around to fix SFP 1 and 3 failed to read EEPROM errors.

Fixes: 29b3d929a610 ("microchipsw: lan969x: add Novarq Tactical 1000")