### PR TITLE
airoha: an7581: fix w1700k fan script

### DIFF
--- a/target/linux/airoha/an7581/base-files/etc/init.d/airoha_fan
+++ b/target/linux/airoha/an7581/base-files/etc/init.d/airoha_fan
@@ -1,3 +1,4 @@
+#!/bin/sh /etc/rc.common
 #
 # Copyright (C) 2025 openwrt.org
 #
@@ -14,7 +15,7 @@ find_nct7802()
 			return
 		fi
 	done
-	echo "/sys/class/hwmon/hwmon5" # fallback
+	echo "/sys/class/hwmon/hwmon3" # fallback
 }
 
 boot()


### PR DESCRIPTION
W1700K fan script is missing the #!/bin/sh /etc/rc.common shebang and requires execution bits set.
