### PR TITLE
build: make abi-versioned packages appear in builbot phase1 persistent downloads repositories (re-try)

### DIFF
--- a/include/package-pack.mk
+++ b/include/package-pack.mk
@@ -609,6 +609,14 @@ else
 	  --output "$$(PACK_$(1))"
 endif
 
+ifdef CONFIG_BUILDBOT
+ifndef SDK
+	# Workaround to ensure a coherent set of abi-versioned dependencies in builbots phase 1 repositories
+	# If ABI version is set and it is not a "nonshared" package, copy it to the root/target packages folder
+	$$(if $$(ABIV_$(1)),$(if $(filter nonshared,$(PKG_FLAGS)),,cp $$(PACK_$(1)) $(PACKAGE_DIR)/))
+endif
+endif
+
 	@[ -f $$(PACK_$(1)) ]
 
     $(1)-clean:

--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -76,8 +76,9 @@ ifeq ($(CONFIG_IB_STANDALONE),)
 		-name 'kernel$(PACKAGE_VERSION_SEPARATOR)*.$(PACKAGE_SUFFIX)' \) \
 	  -exec $(CP) -t $(PKG_BUILD_DIR)/packages {} +
 else
-	$(FIND) $(wildcard $(PACKAGE_SUBDIRS)) -type f -name '*.$(PACKAGE_SUFFIX)' \
-		-exec $(CP) -t $(PKG_BUILD_DIR)/packages/ {} +
+	rsync -a --include='*.$(PACKAGE_SUFFIX)' --exclude='*' \
+	$(foreach dir,$(wildcard $(PACKAGE_SUBDIRS)),$(dir)/) \
+	$(PKG_BUILD_DIR)/packages/
 endif
 
 ifneq ($(CONFIG_SIGNATURE_CHECK),)


### PR DESCRIPTION
In order to keep a coherent set of packages and their dependencies, abi-versioned lib packages must be kept in the frozen phase1 builbot downloads repositories for the imagebuilders be able to find/download the older abi-versioned packages as they still are required as dependencies by the original set of packages built in that phase 1 run.

i.e.25.12.0-rc1..4 builds(packages built in phase 1) depend on older version of libubox, libubus, etc. and those packages are not longer available in the phase 2 repositories ("mtd" in the example):
```
    Building package index...
    ERROR: unable to select packages:
    libubox20251208 (no such package):
        required by: mtd-27[libubox20251208]
    make[2]: *** [Makefile:254: package_install] Error 2
    make[1]: *** [Makefile:193: _call_manifest] Error 2
    make: *** [Makefile:369: manifest] Error 2
```

After following git history/mailing lists/github topics related to missing dependencies issues when abi-versioned packages are updated. And the attempts to fix this like marking these packages as nonshared. A bit less problematic way might be to keep these specific packages in both places. Like if they were being builded in the two phases. (without changing "pkg_flags" for them)

Exploiting the fact that the phase1/phase2's package handling selection depends on which directory are located the packages whether pkg_flags contain the "nonshared" flag or not. We can just copy the .apk/.ipk files to the appropriate directory. Builbots will treat them just correctly and the indexes will be coherent as we simply check for all packages available in the specific directories.
*(phase1 builbot builds only the abi-versioned packages required for the builds, including all non-shared packages's dependencies?, not all the abi-versioned packages but that should be good enough to get a coherent set of packages and dependencies in the phase1 "static" download repositories(target's non-shared packages))

Copying the .apk/.ipk(TODO: check opkg compatibility) files just after the package creation to the desired directory seems compatible with all the other building/packaging/builbots logic.
The same package would appear in two packages.adb indexes in some cases, but that does not seem to be a problem.

**So, if packages have a ABI version and are not markied as non-shared, copy them to the root/target packages directory.**
*Add a guard define to only happens in BUILBOT enviroment and not SDK is running to **limit the scope for phase 1 builbot**.

*This PR/series include a companion commit fix for a emerged issue where imagebuilder building's logic throws an error when trying to merge all packages into one folder because the "find + exec $(CP)" command does not like overwriting the same files in the same call. Use rsync instead.

*Packages are already being built by buildbots in phase 1, now we are simply forcing buildbot to include them to the target/phase1 repository.
*The number and size of the packages affected/copied is relatively small.
*Avoid adding extra logic to builbots or a new "pkg_flags" semantic to build in the two phases.

References: https://github.com/openwrt/openwrt/commit/8307da3dbdaff13d5ce99f8aefa32f5b7a2e18e6 ("treewide: unmark selected packages nonshared")
References: https://github.com/openwrt/openwrt/pull/4233
References: https://lists.openwrt.org/pipermail/openwrt-devel/2021-June/035451.html
References: https://lists.infradead.org/pipermail/openwrt-devel/2021-July/035736.html
References: https://lists.infradead.org/pipermail/openwrt-devel/2021-July/035741.html