### PR TITLE
ramips: add support for wavlink halo base pro

### DIFF
--- a/target/linux/ramips/dts/mt7621_wavlink_halo-base-pro.dts
+++ b/target/linux/ramips/dts/mt7621_wavlink_halo-base-pro.dts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/input/input.h>
+
+/ {
+	compatible = "wavlink,halo-base-pro", "mediatek,mt7621-soc";
+	model = "Wavlink Halo Base Pro";
+
+	chosen {
+		bootargs = "console=ttyS0,57600n8";
+	};
+
+	aliases {
+		led-boot = &status_blue;
+		led-failsafe = &status_red;
+		led-running = &status_blue;
+		led-upgrade = &status_red;
+		label-mac-device = &wifi;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		pair {
+				label = "pair";
+				gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+				linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		touch {
+				label = "touch";
+				gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
+				linux,code = <BTN_0>;
+		};
+
+		reset {
+				label = "reset";
+				gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+				linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		status_blue: status_blue {
+				color = <LED_COLOR_ID_BLUE>;
+				function = LED_FUNCTION_STATUS;
+				gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+
+		status_red: status_red {
+				color = <LED_COLOR_ID_RED>;
+				function = LED_FUNCTION_STATUS;
+				gpios = <&gpio 17 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				compatible = "u-boot,env";
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+
+					macaddr_factory_8004: macaddr@8004 {
+						reg = <0x8004 0x6>;
+					};
+
+					macaddr_factory_e000: macaddr@e000 {
+						reg = <0xe000 0x6>;
+					};
+
+					macaddr_factory_e006: macaddr@e006 {
+						reg = <0xe006 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xf30000>;
+			};
+
+			partition@f80000 {
+				label = "vendor";
+				reg = <0xf80000 0x80000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_8004>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+			nvmem-cells = <&macaddr_factory_e000>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan2";
+			nvmem-cells = <&macaddr_factory_e006>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3262,6 +3262,16 @@ define Device/unielec_u7621-06-64m
 endef
 TARGET_DEVICES += unielec_u7621-06-64m
 
+define Device/wavlink_halo-base-pro
+  $(Device/dsa-migration)
+  IMAGE_SIZE := 15552k
+  DEVICE_VENDOR := Wavlink
+  DEVICE_MODEL := Halo Base Pro
+  KERNEL := kernel-bin | append-dtb | lzma | uImage lzma | pad-to 64k
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware kmod-mt7663-firmware-ap
+endef
+TARGET_DEVICES += wavlink_halo-base-pro
+
 define Device/wavlink_wl-wn531a6
   $(Device/dsa-migration)
   DEVICE_VENDOR := Wavlink

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -138,7 +138,8 @@ ramips_setup_interfaces()
 	zyxel,lte3301-plus)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
-	elecom,wsc-x1800gs)
+	elecom,wsc-x1800gs|\
+	wavlink,halo-base-pro)
 		ucidef_set_interface_lan "lan1 lan2"
 		;;
 	gnubee,gb-pc1)


### PR DESCRIPTION
This pull request adds support for the Wavlink Halo Base Pro.

Specs:
|Component|Information|
|---|---|
|SOC:|MT7621DAT|
|RAM:|128MiB|
|Flash:|16MiB NOR|
|Ethernet:|2x 1Gbps LAN|
|WLAN 2.4 GHz:|MT7603EN|
|WLAN 5 GHz:|MT7613BEN|
|LEDs:|1x red & 1x blue GPIO controlled + 2x LAN LEDs|
|Buttons:|Reset, Pair, plus a touch sensor|
|Serial:|3.3v, 57600 baud|
|USB:|None|

MAC address assignment:
- LAN1:			xx:xx:xx:xx:xx:80
- LAN2/WAN:	xx:xx:xx:xx:xx:81 (LAN1 MAC + 1)
- WiFi 2.4G:		xx:xx:xx:xx:xx:82 (LAN1 MAC + 2)
- WiFi 5G:		xx:xx:xx:xx:xx:83 (LAN1 MAC + 3) (label)

Persistent installation via HTTP:
1. Set your computer to a static IP of 192.168.10.100
2. While holding reset, power on the device, and keep holding for ~5 sec
3. Access 192.168.10.1 with your browser, and upload the squashfs image

Persistent installation via TFTP (requires serial console):
1. Configure a TFTP server with a static IP of 192.168.10.100
2. Rename the squashfs image to firmware.bin and place on the TFTP server
3. Power on the device, and choose option 2 to flash via TFTP.
	- With a stock uboot-env, the defaults should be as follows:
		- Device IP: 192.168.10.1
		- Server IP: 192.168.10.100
		- Linux Kernel filename: firmware.bin
	- Accept the defaults and it should flash & boot within a few mins

Initramfs boot (non-persistent) (requires serial console):
1. Configure TFTP as above, but using the initramfs image instead
2. Power on the device, and choose option 4 to enter the uboot console
3. Enter "tftpboot 84000000 firmware.bin" to load the image into RAM
4. Enter "bootm 84000000" to boot the image from ram