### PR TITLE
utils/checkpolicy: drop PKG_CPE_ID

### DIFF
--- a/package/utils/checkpolicy/Makefile
+++ b/package/utils/checkpolicy/Makefile
@@ -17,7 +17,6 @@ PKG_BUILD_DEPENDS:=libselinux
 HOST_BUILD_DEPENDS:=libselinux/host
 
 PKG_MAINTAINER:=Thomas Petazzoni <thomas.petazzoni@bootlin.com>
-PKG_CPE_ID:=cpe:/a:selinuxproject:checkpolicy
 PKG_LICENSE:=GPL-2.0-or-later
 PKG_LICENSE_FILES:=COPYING
 


### PR DESCRIPTION
cpe:/a:selinuxproject:checkpolicy is not a correct CPE ID for checkpolicy: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:selinuxproject:checkpolicy

Fixes: 21992303fa29115f8e3b91eb440e5eb0a51fd57b (checkpolicy: new package)
