### PR TITLE
ramips: mt76x8: add support for Keenetic KN-1510

### DIFF
--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1510.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1510.dts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "keenetic,kn-1510", "mediatek,mt7628an-soc";
+	model = "Keenetic KN-1510";
+
+	aliases {
+		label-mac-device = &ethernet;
+
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		internet {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2 {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wifi5 {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	virtual_flash {
+		compatible = "mtd-concat";
+		devices = <&firmware1 &firmware2>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x0 0xf20000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "gpio", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&usbphy {
+	status = "disabled";
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <32000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-config";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "rf-eeprom";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+				};
+			};
+
+			firmware1: partition@50000 {
+				label = "firmware_1";
+				reg = <0x50000 0x790000>;
+			};
+
+			partition@7e0000 {
+				label = "config_1";
+				reg = <0x7e0000 0x10000>;
+				read-only;
+			};
+
+			partition@7f0000 {
+				label = "dump";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+			};
+
+			partition@800000 {
+				label = "u-state";
+				reg = <0x800000 0x30000>;
+				read-only;
+			};
+
+			partition@830000 {
+				label = "u-config_res";
+				reg = <0x830000 0x10000>;
+				read-only;
+			};
+
+			partition@840000 {
+				label = "rf-eeprom_res";
+				reg = <0x840000 0x10000>;
+				read-only;
+			};
+
+			firmware2: partition@850000 {
+				label = "firmware_2";
+				reg = <0x850000 0x790000>;
+			};
+
+			partition@fe0000 {
+				label = "config_2";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,portdisable = <0x30>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -484,6 +484,17 @@ define Device/keenetic_kn-1221
 endef
 TARGET_DEVICES += keenetic_kn-1221
 
+define Device/keenetic_kn-1510
+  IMAGE_SIZE := 15488k
+  DEVICE_VENDOR := Keenetic
+  DEVICE_MODEL := KN-1510
+  DEVICE_PACKAGES := kmod-mt76x0e
+  IMAGES += factory.bin
+  IMAGE/factory.bin := $$(sysupgrade_bin) | pad-to $$$$(BLOCKSIZE) | \
+	check-size | zyimage -d 0x801510 -v "KN-1510"
+endef
+TARGET_DEVICES += keenetic_kn-1510
+
 define Device/keenetic_kn-1613
   IMAGE_SIZE := 15073280
   DEVICE_VENDOR := Keenetic

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -75,6 +75,7 @@ hiwifi,hc5761a)
 keenetic,kn-1112|\
 keenetic,kn-1212|\
 keenetic,kn-1221|\
+keenetic,kn-1510|\
 keenetic,kn-1613|\
 keenetic,kn-1711|\
 keenetic,kn-1713)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -137,6 +137,7 @@ ramips_setup_interfaces()
 	hongdian,h8850-v20|\
 	keenetic,kn-1112|\
 	keenetic,kn-1212|\
+	keenetic,kn-1510|\
 	keenetic,kn-1613|\
 	keenetic,kn-1713|\
 	motorola,mwr03)
@@ -330,6 +331,7 @@ ramips_setup_macs()
 		wan_mac=$(mtd_get_mac_binary factory 0x2e)
 		;;
 	keenetic,kn-1221|\
+	keenetic,kn-1510|\
 	keenetic,kn-1613|\
 	keenetic,kn-3211|\
 	zyxel,keenetic-extra-ii)


### PR DESCRIPTION
Specification:
* CPU: MediaTek MT7628AN (580 MHz)
* Flash: GigaDevice GD25Q128CSIG (16 MiB)
* RAM: Winbond W9751G6KB-25 (64 MiB)

WikiDevi page: <https://wikidevi.wi-cat.ru/Keenetic_City_(KN-1510)>

How to flash:
* Configure TFTP server with IP address 192.168.1.2/24
* Serve OpenWrt factory image as "KN-1510_recovery.bin"
* Connect the PC to router's LAN port, hold the reset button and power the router up. When the power LED starts blinking release the button.

The same instructions apply to OEM firmware, except one can take it from osvault.keenetic.net