### PR TITLE
tools/expat: fix PKG_CPE_ID

### DIFF
--- a/tools/expat/Makefile
+++ b/tools/expat/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=expat
-PKG_CPE_ID:=cpe:/a:libexpat:libexpat
+PKG_CPE_ID:=cpe:/a:libexpat_project:libexpat
 PKG_VERSION:=2.7.4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz


### PR DESCRIPTION
cpe:/a:libexpat_project:libexpat is the correct CPE ID for expat: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:libexpat_project:libexpat

Fixes: ff59f3f4bdb56c779579aaa11b815f4c83abbac5 (tools/expat: fix PKG_CPE_ID)
