### PR TITLE
libs/gnulib-l10n: drop PKG_CPE_ID

### DIFF
--- a/package/libs/gnulib-l10n/Makefile
+++ b/package/libs/gnulib-l10n/Makefile
@@ -1,7 +1,6 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gnulib-l10n
-PKG_CPE_ID:=cpe:/a:gnu:$(PKG_NAME)
 PKG_VERSION:=20241231
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz


### PR DESCRIPTION
cpe:/a:gnu:gnulib-l10n is not a correct CPE ID for gnulib-l10n: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:gnu:gnulib-l10n

Fixes: 246eba7528434d39013f39fa74e981d999039ff5 (gnulib-l10n: add package)
