### PR TITLE
system/selinux-policy: drop PKG_CPE_ID

### DIFF
--- a/package/system/selinux-policy/Makefile
+++ b/package/system/selinux-policy/Makefile
@@ -14,7 +14,6 @@ PKG_SOURCE_VERSION:=v$(PKG_VERSION)
 PKG_BUILD_DEPENDS:=secilc/host policycoreutils/host
 
 PKG_MAINTAINER:=Dominick Grift <dominick.grift@defensec.nl>
-PKG_CPE_ID:=cpe:/a:defensec:selinux-policy
 PKG_LICENSE:=Unlicense
 PKG_LICENSE_FILES:=LICENSE
 


### PR DESCRIPTION
cpe:/a:defensec:selinux-policy is not a correct CPE ID for selinux-policy: https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:defensec:selinux-policy

Fixes: bf12f05bbfd50ba6f8f9c49a8980239efcc29930 (selinux-policy: adds new package)
