### PR TITLE
kernel: add support for authenc(hmac(md5),*) suites in safexcel driver

### DIFF
--- a/target/linux/generic/backport-6.12/930-v7.1-crypto-safexcel-Group-authenc-ciphersuites.patch
+++ b/target/linux/generic/backport-6.12/930-v7.1-crypto-safexcel-Group-authenc-ciphersuites.patch
@@ -1,0 +1,64 @@
+From c75daa3730132c55dea7cc9c0f8818aea491fe0c Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Tue, 3 Feb 2026 19:21:51 +0100
+Subject: [PATCH 1/2] crypto: safexcel - Group authenc ciphersuites
+
+Move authenc(sha1,des) and authenc(sha1,3des) ciphersuites to appropriate
+groups. No functional changes intended.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Acked-by: Antoine Tenart <atenart@kernel.org>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ drivers/crypto/inside-secure/safexcel.c | 4 ++--
+ drivers/crypto/inside-secure/safexcel.h | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+--- a/drivers/crypto/inside-secure/safexcel.c
++++ b/drivers/crypto/inside-secure/safexcel.c
+@@ -1209,7 +1209,6 @@ static struct safexcel_alg_template *saf
+ 	&safexcel_alg_authenc_hmac_sha256_cbc_aes,
+ 	&safexcel_alg_authenc_hmac_sha384_cbc_aes,
+ 	&safexcel_alg_authenc_hmac_sha512_cbc_aes,
+-	&safexcel_alg_authenc_hmac_sha1_cbc_des3_ede,
+ 	&safexcel_alg_authenc_hmac_sha1_ctr_aes,
+ 	&safexcel_alg_authenc_hmac_sha224_ctr_aes,
+ 	&safexcel_alg_authenc_hmac_sha256_ctr_aes,
+@@ -1242,11 +1241,12 @@ static struct safexcel_alg_template *saf
+ 	&safexcel_alg_hmac_sha3_256,
+ 	&safexcel_alg_hmac_sha3_384,
+ 	&safexcel_alg_hmac_sha3_512,
+-	&safexcel_alg_authenc_hmac_sha1_cbc_des,
++	&safexcel_alg_authenc_hmac_sha1_cbc_des3_ede,
+ 	&safexcel_alg_authenc_hmac_sha256_cbc_des3_ede,
+ 	&safexcel_alg_authenc_hmac_sha224_cbc_des3_ede,
+ 	&safexcel_alg_authenc_hmac_sha512_cbc_des3_ede,
+ 	&safexcel_alg_authenc_hmac_sha384_cbc_des3_ede,
++	&safexcel_alg_authenc_hmac_sha1_cbc_des,
+ 	&safexcel_alg_authenc_hmac_sha256_cbc_des,
+ 	&safexcel_alg_authenc_hmac_sha224_cbc_des,
+ 	&safexcel_alg_authenc_hmac_sha512_cbc_des,
+--- a/drivers/crypto/inside-secure/safexcel.h
++++ b/drivers/crypto/inside-secure/safexcel.h
+@@ -950,7 +950,6 @@ extern struct safexcel_alg_template safe
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha256_cbc_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha384_cbc_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha512_cbc_aes;
+-extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha1_cbc_des3_ede;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha1_ctr_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha224_ctr_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha256_ctr_aes;
+@@ -983,11 +982,12 @@ extern struct safexcel_alg_template safe
+ extern struct safexcel_alg_template safexcel_alg_hmac_sha3_256;
+ extern struct safexcel_alg_template safexcel_alg_hmac_sha3_384;
+ extern struct safexcel_alg_template safexcel_alg_hmac_sha3_512;
+-extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha1_cbc_des;
++extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha1_cbc_des3_ede;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha256_cbc_des3_ede;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha224_cbc_des3_ede;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha512_cbc_des3_ede;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha384_cbc_des3_ede;
++extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha1_cbc_des;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha256_cbc_des;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha224_cbc_des;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha512_cbc_des;

--- a/target/linux/generic/backport-6.12/931-v7.1-crypto-safexcel-Add-support-for-authenc-hmac-md5-sui.patch
+++ b/target/linux/generic/backport-6.12/931-v7.1-crypto-safexcel-Add-support-for-authenc-hmac-md5-sui.patch
@@ -1,0 +1,279 @@
+From f050e4209ab0ba3f13bb6272a07ce87cbea922c9 Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Tue, 3 Feb 2026 19:21:52 +0100
+Subject: [PATCH 2/2] crypto: safexcel - Add support for authenc(hmac(md5),*)
+ suites
+
+This patch adds support for the following AEAD ciphersuites:
+- authenc(hmac(md5),cbc(aes))
+- authenc(hmac(md5),cbc(des)))
+- authenc(hmac(md5),cbc(des3_ede))
+- authenc(hmac(md5),rfc3686(ctr(aes)))
+
+The first three ciphersuites were tested using testmgr and the recently
+sent test vectors. They passed self-tests.
+
+This is enhanced version of the patch found in the mtk-openwrt-feeds repo.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Reviewed-by: Antoine Tenart <atenart@kernel.org>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ drivers/crypto/inside-secure/safexcel.c       |   4 +
+ drivers/crypto/inside-secure/safexcel.h       |   4 +
+ .../crypto/inside-secure/safexcel_cipher.c    | 149 ++++++++++++++++++
+ 3 files changed, 157 insertions(+)
+
+--- a/drivers/crypto/inside-secure/safexcel.c
++++ b/drivers/crypto/inside-secure/safexcel.c
+@@ -1204,11 +1204,13 @@ static struct safexcel_alg_template *saf
+ 	&safexcel_alg_hmac_sha256,
+ 	&safexcel_alg_hmac_sha384,
+ 	&safexcel_alg_hmac_sha512,
++	&safexcel_alg_authenc_hmac_md5_cbc_aes,
+ 	&safexcel_alg_authenc_hmac_sha1_cbc_aes,
+ 	&safexcel_alg_authenc_hmac_sha224_cbc_aes,
+ 	&safexcel_alg_authenc_hmac_sha256_cbc_aes,
+ 	&safexcel_alg_authenc_hmac_sha384_cbc_aes,
+ 	&safexcel_alg_authenc_hmac_sha512_cbc_aes,
++	&safexcel_alg_authenc_hmac_md5_ctr_aes,
+ 	&safexcel_alg_authenc_hmac_sha1_ctr_aes,
+ 	&safexcel_alg_authenc_hmac_sha224_ctr_aes,
+ 	&safexcel_alg_authenc_hmac_sha256_ctr_aes,
+@@ -1241,11 +1243,13 @@ static struct safexcel_alg_template *saf
+ 	&safexcel_alg_hmac_sha3_256,
+ 	&safexcel_alg_hmac_sha3_384,
+ 	&safexcel_alg_hmac_sha3_512,
++	&safexcel_alg_authenc_hmac_md5_cbc_des3_ede,
+ 	&safexcel_alg_authenc_hmac_sha1_cbc_des3_ede,
+ 	&safexcel_alg_authenc_hmac_sha256_cbc_des3_ede,
+ 	&safexcel_alg_authenc_hmac_sha224_cbc_des3_ede,
+ 	&safexcel_alg_authenc_hmac_sha512_cbc_des3_ede,
+ 	&safexcel_alg_authenc_hmac_sha384_cbc_des3_ede,
++	&safexcel_alg_authenc_hmac_md5_cbc_des,
+ 	&safexcel_alg_authenc_hmac_sha1_cbc_des,
+ 	&safexcel_alg_authenc_hmac_sha256_cbc_des,
+ 	&safexcel_alg_authenc_hmac_sha224_cbc_des,
+--- a/drivers/crypto/inside-secure/safexcel.h
++++ b/drivers/crypto/inside-secure/safexcel.h
+@@ -945,11 +945,13 @@ extern struct safexcel_alg_template safe
+ extern struct safexcel_alg_template safexcel_alg_hmac_sha256;
+ extern struct safexcel_alg_template safexcel_alg_hmac_sha384;
+ extern struct safexcel_alg_template safexcel_alg_hmac_sha512;
++extern struct safexcel_alg_template safexcel_alg_authenc_hmac_md5_cbc_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha1_cbc_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha224_cbc_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha256_cbc_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha384_cbc_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha512_cbc_aes;
++extern struct safexcel_alg_template safexcel_alg_authenc_hmac_md5_ctr_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha1_ctr_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha224_ctr_aes;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha256_ctr_aes;
+@@ -982,11 +984,13 @@ extern struct safexcel_alg_template safe
+ extern struct safexcel_alg_template safexcel_alg_hmac_sha3_256;
+ extern struct safexcel_alg_template safexcel_alg_hmac_sha3_384;
+ extern struct safexcel_alg_template safexcel_alg_hmac_sha3_512;
++extern struct safexcel_alg_template safexcel_alg_authenc_hmac_md5_cbc_des3_ede;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha1_cbc_des3_ede;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha256_cbc_des3_ede;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha224_cbc_des3_ede;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha512_cbc_des3_ede;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha384_cbc_des3_ede;
++extern struct safexcel_alg_template safexcel_alg_authenc_hmac_md5_cbc_des;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha1_cbc_des;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha256_cbc_des;
+ extern struct safexcel_alg_template safexcel_alg_authenc_hmac_sha224_cbc_des;
+--- a/drivers/crypto/inside-secure/safexcel_cipher.c
++++ b/drivers/crypto/inside-secure/safexcel_cipher.c
+@@ -17,6 +17,7 @@
+ #include <crypto/internal/des.h>
+ #include <crypto/gcm.h>
+ #include <crypto/ghash.h>
++#include <crypto/md5.h>
+ #include <crypto/poly1305.h>
+ #include <crypto/sha1.h>
+ #include <crypto/sha2.h>
+@@ -462,6 +463,9 @@ static int safexcel_aead_setkey(struct c
+ 
+ 	/* Auth key */
+ 	switch (ctx->hash_alg) {
++	case CONTEXT_CONTROL_CRYPTO_ALG_MD5:
++		alg = "safexcel-md5";
++		break;
+ 	case CONTEXT_CONTROL_CRYPTO_ALG_SHA1:
+ 		alg = "safexcel-sha1";
+ 		break;
+@@ -1662,6 +1666,42 @@ static int safexcel_aead_cra_init(struct
+ 	return 0;
+ }
+ 
++static int safexcel_aead_md5_cra_init(struct crypto_tfm *tfm)
++{
++	struct safexcel_cipher_ctx *ctx = crypto_tfm_ctx(tfm);
++
++	safexcel_aead_cra_init(tfm);
++	ctx->hash_alg = CONTEXT_CONTROL_CRYPTO_ALG_MD5;
++	ctx->state_sz = MD5_DIGEST_SIZE;
++	return 0;
++}
++
++struct safexcel_alg_template safexcel_alg_authenc_hmac_md5_cbc_aes = {
++	.type = SAFEXCEL_ALG_TYPE_AEAD,
++	.algo_mask = SAFEXCEL_ALG_AES | SAFEXCEL_ALG_MD5,
++	.alg.aead = {
++		.setkey = safexcel_aead_setkey,
++		.encrypt = safexcel_aead_encrypt,
++		.decrypt = safexcel_aead_decrypt,
++		.ivsize = AES_BLOCK_SIZE,
++		.maxauthsize = MD5_DIGEST_SIZE,
++		.base = {
++			.cra_name = "authenc(hmac(md5),cbc(aes))",
++			.cra_driver_name = "safexcel-authenc-hmac-md5-cbc-aes",
++			.cra_priority = SAFEXCEL_CRA_PRIORITY,
++			.cra_flags = CRYPTO_ALG_ASYNC |
++				     CRYPTO_ALG_ALLOCATES_MEMORY |
++				     CRYPTO_ALG_KERN_DRIVER_ONLY,
++			.cra_blocksize = AES_BLOCK_SIZE,
++			.cra_ctxsize = sizeof(struct safexcel_cipher_ctx),
++			.cra_alignmask = 0,
++			.cra_init = safexcel_aead_md5_cra_init,
++			.cra_exit = safexcel_aead_cra_exit,
++			.cra_module = THIS_MODULE,
++		},
++	},
++};
++
+ static int safexcel_aead_sha1_cra_init(struct crypto_tfm *tfm)
+ {
+ 	struct safexcel_cipher_ctx *ctx = crypto_tfm_ctx(tfm);
+@@ -1842,6 +1882,43 @@ struct safexcel_alg_template safexcel_al
+ 	},
+ };
+ 
++static int safexcel_aead_md5_des3_cra_init(struct crypto_tfm *tfm)
++{
++	struct safexcel_cipher_ctx *ctx = crypto_tfm_ctx(tfm);
++
++	safexcel_aead_md5_cra_init(tfm);
++	ctx->alg = SAFEXCEL_3DES; /* override default */
++	ctx->blocksz = DES3_EDE_BLOCK_SIZE;
++	ctx->ivmask = EIP197_OPTION_2_TOKEN_IV_CMD;
++	return 0;
++}
++
++struct safexcel_alg_template safexcel_alg_authenc_hmac_md5_cbc_des3_ede = {
++	.type = SAFEXCEL_ALG_TYPE_AEAD,
++	.algo_mask = SAFEXCEL_ALG_DES | SAFEXCEL_ALG_MD5,
++	.alg.aead = {
++		.setkey = safexcel_aead_setkey,
++		.encrypt = safexcel_aead_encrypt,
++		.decrypt = safexcel_aead_decrypt,
++		.ivsize = DES3_EDE_BLOCK_SIZE,
++		.maxauthsize = MD5_DIGEST_SIZE,
++		.base = {
++			.cra_name = "authenc(hmac(md5),cbc(des3_ede))",
++			.cra_driver_name = "safexcel-authenc-hmac-md5-cbc-des3_ede",
++			.cra_priority = SAFEXCEL_CRA_PRIORITY,
++			.cra_flags = CRYPTO_ALG_ASYNC |
++				     CRYPTO_ALG_ALLOCATES_MEMORY |
++				     CRYPTO_ALG_KERN_DRIVER_ONLY,
++			.cra_blocksize = DES3_EDE_BLOCK_SIZE,
++			.cra_ctxsize = sizeof(struct safexcel_cipher_ctx),
++			.cra_alignmask = 0,
++			.cra_init = safexcel_aead_md5_des3_cra_init,
++			.cra_exit = safexcel_aead_cra_exit,
++			.cra_module = THIS_MODULE,
++		},
++	},
++};
++
+ static int safexcel_aead_sha1_des3_cra_init(struct crypto_tfm *tfm)
+ {
+ 	struct safexcel_cipher_ctx *ctx = crypto_tfm_ctx(tfm);
+@@ -2027,6 +2104,43 @@ struct safexcel_alg_template safexcel_al
+ 	},
+ };
+ 
++static int safexcel_aead_md5_des_cra_init(struct crypto_tfm *tfm)
++{
++	struct safexcel_cipher_ctx *ctx = crypto_tfm_ctx(tfm);
++
++	safexcel_aead_md5_cra_init(tfm);
++	ctx->alg = SAFEXCEL_DES; /* override default */
++	ctx->blocksz = DES_BLOCK_SIZE;
++	ctx->ivmask = EIP197_OPTION_2_TOKEN_IV_CMD;
++	return 0;
++}
++
++struct safexcel_alg_template safexcel_alg_authenc_hmac_md5_cbc_des = {
++	.type = SAFEXCEL_ALG_TYPE_AEAD,
++	.algo_mask = SAFEXCEL_ALG_DES | SAFEXCEL_ALG_MD5,
++	.alg.aead = {
++		.setkey = safexcel_aead_setkey,
++		.encrypt = safexcel_aead_encrypt,
++		.decrypt = safexcel_aead_decrypt,
++		.ivsize = DES_BLOCK_SIZE,
++		.maxauthsize = MD5_DIGEST_SIZE,
++		.base = {
++			.cra_name = "authenc(hmac(md5),cbc(des))",
++			.cra_driver_name = "safexcel-authenc-hmac-md5-cbc-des",
++			.cra_priority = SAFEXCEL_CRA_PRIORITY,
++			.cra_flags = CRYPTO_ALG_ASYNC |
++				     CRYPTO_ALG_ALLOCATES_MEMORY |
++				     CRYPTO_ALG_KERN_DRIVER_ONLY,
++			.cra_blocksize = DES_BLOCK_SIZE,
++			.cra_ctxsize = sizeof(struct safexcel_cipher_ctx),
++			.cra_alignmask = 0,
++			.cra_init = safexcel_aead_md5_des_cra_init,
++			.cra_exit = safexcel_aead_cra_exit,
++			.cra_module = THIS_MODULE,
++		},
++	},
++};
++
+ static int safexcel_aead_sha1_des_cra_init(struct crypto_tfm *tfm)
+ {
+ 	struct safexcel_cipher_ctx *ctx = crypto_tfm_ctx(tfm);
+@@ -2209,6 +2323,41 @@ struct safexcel_alg_template safexcel_al
+ 			.cra_exit = safexcel_aead_cra_exit,
+ 			.cra_module = THIS_MODULE,
+ 		},
++	},
++};
++
++static int safexcel_aead_md5_ctr_cra_init(struct crypto_tfm *tfm)
++{
++	struct safexcel_cipher_ctx *ctx = crypto_tfm_ctx(tfm);
++
++	safexcel_aead_md5_cra_init(tfm);
++	ctx->mode = CONTEXT_CONTROL_CRYPTO_MODE_CTR_LOAD; /* override default */
++	return 0;
++}
++
++struct safexcel_alg_template safexcel_alg_authenc_hmac_md5_ctr_aes = {
++	.type = SAFEXCEL_ALG_TYPE_AEAD,
++	.algo_mask = SAFEXCEL_ALG_AES | SAFEXCEL_ALG_MD5,
++	.alg.aead = {
++		.setkey = safexcel_aead_setkey,
++		.encrypt = safexcel_aead_encrypt,
++		.decrypt = safexcel_aead_decrypt,
++		.ivsize = CTR_RFC3686_IV_SIZE,
++		.maxauthsize = MD5_DIGEST_SIZE,
++		.base = {
++			.cra_name = "authenc(hmac(md5),rfc3686(ctr(aes)))",
++			.cra_driver_name = "safexcel-authenc-hmac-md5-ctr-aes",
++			.cra_priority = SAFEXCEL_CRA_PRIORITY,
++			.cra_flags = CRYPTO_ALG_ASYNC |
++				     CRYPTO_ALG_ALLOCATES_MEMORY |
++				     CRYPTO_ALG_KERN_DRIVER_ONLY,
++			.cra_blocksize = 1,
++			.cra_ctxsize = sizeof(struct safexcel_cipher_ctx),
++			.cra_alignmask = 0,
++			.cra_init = safexcel_aead_md5_ctr_cra_init,
++			.cra_exit = safexcel_aead_cra_exit,
++			.cra_module = THIS_MODULE,
++		},
+ 	},
+ };
+ 


### PR DESCRIPTION
This patch adds support for the following AEAD ciphersuites:
- authenc(hmac(md5),cbc(aes))
- authenc(hmac(md5),cbc(des)))
- authenc(hmac(md5),cbc(des3_ede))
- authenc(hmac(md5),rfc3686(ctr(aes)))

These algorithms are used mainly for backward compatibility with some older equipment. This is enhanced version of the patch found in the mtk-openwrt-feeds repo.

All cipher suites were tested using test vectors on the MediaTek MT7981, MT7986, and MT7988.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
