### PR TITLE
HPE 1920-24g-POE-370w (JG926A) fan control script

### DIFF
--- a/target/linux/realtek/base-files/etc/init.d/jg926a_fan_ctrl
+++ b/target/linux/realtek/base-files/etc/init.d/jg926a_fan_ctrl
@@ -1,0 +1,15 @@
+#!/bin/sh /etc/rc.common
+
+START=21
+STOP=99
+USE_PROCD=1
+
+start_service() {
+logger -t fan.control "Fan Control Script Started"
+procd_open_instance
+procd_set_param command "/sbin/jg926a_fan_ctrl.sh"
+procd_set_param stdout 0
+procd_set_param stderr 0
+procd_set_param respawn
+procd_close_instance
+}

--- a/target/linux/realtek/base-files/etc/init.d/jg926a_fan_ctrl
+++ b/target/linux/realtek/base-files/etc/init.d/jg926a_fan_ctrl
@@ -4,7 +4,9 @@ START=21
 STOP=99
 USE_PROCD=1
 
-start_service() {
+boot() {
+	case $(board_name) in
+	
 logger -t fan.control "Fan Control Script Started"
 procd_open_instance
 procd_set_param command "/sbin/jg926a_fan_ctrl.sh"
@@ -12,4 +14,5 @@ procd_set_param stdout 0
 procd_set_param stderr 0
 procd_set_param respawn
 procd_close_instance
+esac
 }

--- a/target/linux/realtek/base-files/etc/init.d/jg926a_fan_ctrl
+++ b/target/linux/realtek/base-files/etc/init.d/jg926a_fan_ctrl
@@ -1,7 +1,6 @@
 #!/bin/sh /etc/rc.common
 
 START=21
-STOP=99
 USE_PROCD=1
 
 boot() {

--- a/target/linux/realtek/base-files/etc/init.d/jg926a_fan_ctrl
+++ b/target/linux/realtek/base-files/etc/init.d/jg926a_fan_ctrl
@@ -5,7 +5,7 @@ USE_PROCD=1
 
 boot() {
 	case $(board_name) in
-	
+	hpe,1920-24g-poe-370w)
 logger -t fan.control "Fan Control Script Started"
 procd_open_instance
 procd_set_param command "/sbin/jg926a_fan_ctrl.sh"

--- a/target/linux/realtek/base-files/sbin/jg926a_fan_ctrl.sh
+++ b/target/linux/realtek/base-files/sbin/jg926a_fan_ctrl.sh
@@ -36,5 +36,5 @@ elif [ $TEMP -gt $TEMP_HIGH -o $LOAD -gt $LOAD_HIGH ]; then
 else
     echo 0 > $PWM
 fi
-sleep 15
+sleep 360
 done

--- a/target/linux/realtek/base-files/sbin/jg926a_fan_ctrl.sh
+++ b/target/linux/realtek/base-files/sbin/jg926a_fan_ctrl.sh
@@ -29,7 +29,7 @@ LOAD=$(ubus call poe info | grep consumption | head -n 1 | awk -F'"consumption":
 FAULT=$(find /sys/devices/platform/gpio_fan_array/hwmon/hwmon[0-9] -name "fan1_alarm" 2>/dev/null)
 if [ $FAULT -eq 1 ]; then
     echo 100 > $PWM
-    logger FAN FAULT DETECTED! FANS SET TO HIGH! FAN CONTROL SCRIPT TERMINATING! MQTT REPORT SENT!
+    logger FAN FAULT DETECTED! FANS SET TO HIGH! FAN CONTROL SCRIPT TERMINATING!
     exit 0
 elif [ $TEMP -gt $TEMP_HIGH -o $LOAD -gt $LOAD_HIGH ]; then
     echo 100 > $PWM

--- a/target/linux/realtek/base-files/sbin/jg926a_fan_ctrl.sh
+++ b/target/linux/realtek/base-files/sbin/jg926a_fan_ctrl.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# HPE 1920-24G-PoE+ 370W (JG926A) fan control script 
+
+# Find PWM file - this check must run since the location will vary based on the number of SFP transcievers in use
+PWM=$(find /sys/devices/platform/gpio_fan_array/hwmon/hwmon[0-9] -name "pwm1" 2>/dev/null)
+
+if [ -f "$PWM" ]; then
+    logger -t $(echo Found PWM Input at $PWM)
+else
+    logger -t PWM File not found. Fans will remain running high. Script Exiting.
+    exit 0
+fi
+
+#Find fault indicator - this check must run since the location will vary based on the number of SFP transcievers in use
+FAULT=$(find /sys/devices/platform/gpio_fan_array/hwmon/hwmon[0-9] -name "fan1_alarm" 2>/dev/null)
+if [ -f "$FAULT" ]; then
+    logger -t $(echo Found Fan Failure Indicator at $FAULT)
+else
+    logger -t Fan Failure Indicator not found. 
+fi
+
+TEMP_HIGH=65
+LOAD_HIGH=300
+
+while true; do
+TEMP=$(cut -c1-2 /sys/class/hwmon/hwmon0/temp1_input)
+LOAD=$(ubus call poe info | grep consumption | head -n 1 | awk -F'"consumption": ' '{print $2}' | awk -F',' '{printf "%.1f\n", $1}')
+FAULT=$(find /sys/devices/platform/gpio_fan_array/hwmon/hwmon[0-9] -name "fan1_alarm" 2>/dev/null)
+if [ $FAULT -eq 1 ]; then
+    echo 100 > $PWM
+    logger FAN FAULT DETECTED! FANS SET TO HIGH! FAN CONTROL SCRIPT TERMINATING! MQTT REPORT SENT!
+    exit 0
+elif [ $TEMP -gt $TEMP_HIGH -o $LOAD -gt $LOAD_HIGH ]; then
+    echo 100 > $PWM
+else
+    echo 0 > $PWM
+fi
+sleep 15
+done


### PR DESCRIPTION
Fan control script for HPE 1920-24g-POE-370w (JG926A). This may be applicable to similar HPE RTL838x based switches but  I don't have any to test. Will set fans to high if CPU temp reaches 65 degrees or POE delivered reaches 300W.