### PR TITLE
Fix huge TARGET_ROOTFS_PARTSIZE(>2048) problem.

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -209,8 +209,9 @@ DTCO_FLAGS += $(DTC_WARN_FLAGS)
 # @param 2: Padding.
 ##
 define Image/pad-to
-	dd if=$(1) of=$(1).new bs=$(2) conv=sync
-	mv $(1).new $(1)
+    @dd if=$1 of=$1.new bs=4096 count=$$((($2) / 4096)) conv=sync
+    @dd if=/dev/zero bs=$$((($2) % 4096)) count=1 >>$1.new 2>/dev/null || true
+    @mv $1.new $1
 endef
 
 ifeq ($(DUMP),)


### PR DESCRIPTION
Fixes #10510, #7027,  #16710

!!! My fix addresses the undefined behavior of the dd command when using the combination of bs=8192 (>2048) and conv=sync options
In this scenario, the resulting image will have a size larger than the bs option by the number of read/write times. For a large TARGET_ROOTFS_PARTSIZE of 8194, the resulting image *.new.img (8192/2048*8192) was approximately 32GB instead
 of 8GB. When using larger TARGET_ROOTFS_PARTSIZE values, I encountered a "not enough space on device" error.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
