### PR TITLE
ramips: mt7621: add support for SNR-Keep-AC10

### DIFF
--- a/target/linux/ramips/dts/mt7621_snr_snr-keep-ac10.dts
+++ b/target/linux/ramips/dts/mt7621_snr_snr-keep-ac10.dts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "snr,snr-keep-ac10", "mediatek,mt7621-soc";
+	model = "SNR-KEEP-AC10";
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-lan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		mesh {
+			label = "mesh";
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "uart2", "uart3", "jtag";
+		function = "gpio";
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "config";
+				reg = <0x30000 0x10000>;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+
+					macaddr_factory_e000: macaddr@e000 {
+						reg = <0xe000 0x6>;
+					};
+
+					macaddr_factory_e006: macaddr@e006 {
+						reg = <0xe006 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0xfb0000>;
+			};
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_e006>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "lan";
+	phy-handle = <&ethphy4>;
+
+	nvmem-cells = <&macaddr_factory_e000>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy4 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@3 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <2400000 2500000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2797,6 +2797,16 @@ define Device/snr_snr-cpe-me2-sfp
 endef
 TARGET_DEVICES += snr_snr-cpe-me2-sfp
 
+define Device/snr_snr-keep-ac10
+  $(Device/dts-igmp)
+  DEVICE_VENDOR := SNR
+  DEVICE_MODEL := SNR-KEEP-AC10
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+	kmod-leds-aw2026 -uboot-envtools
+  IMAGE_SIZE := 16064k
+endef
+TARGET_DEVICES += snr_snr-keep-ac10
+
 define Device/storylink_sap-g3200u3
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/01_leds
@@ -211,6 +211,11 @@ oraybox,x3a)
 snr,snr-cpe-me1)
 	ucidef_set_led_usbport "usb" "USB" "green:usb" "usb1-port1" "usb2-port1"
 	;;
+snr,snr-keep-ac10|\
+yuncore,ax820)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "lan"
+	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
+	;;
 tplink,archer-a6-v3|\
 tplink,archer-ax21-v4|\
 tplink,archer-ax23-v1|\
@@ -267,10 +272,6 @@ youhua,wr1200js)
 	;;
 yuncore,fap690)
 	ucidef_set_led_netdev "eth_link" "LAN link" "blue:status" "lan" "link"
-	;;
-yuncore,ax820)
-	ucidef_set_led_netdev "lan" "LAN" "green:lan" "lan"
-	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan"
 	;;
 z-router,zr-2660)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "br-lan" "link tx rx"

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -85,6 +85,7 @@ ramips_setup_interfaces()
 	maginon,mc-1200ac|\
 	meig,slt866|\
 	openfi,5pro|\
+	snr,snr-keep-ac10|\
 	wavlink,ws-wn572hp3-4g|\
 	winstars,ws-wn583a6|\
 	yuncore,ax820|\


### PR DESCRIPTION
Hardware:
SOC: MediaTek MT7621AT
RAM: 128 MiB DDR3 ESMT M15T1G1664A
Flash: 16 MiB SPI-NOR XMC 25QH128DHIQ
WI1: MT7603EN
WI2: MT7613BEN

Ethernet:
1x 10/100/1000 Mbps LAN
1x 10/100/1000 Mbps WAN
Buttons: Reset, WPS
LEDs: 1xLAN LED, 1xWAN LED,
System RGB LED with AW2026 (Green: working, Orange: booting)
UART: 57600 8N1

Flash Layout:
0x000000000000 - 0x000000030000 : "Bootloader"
0x000000030000 - 0x000000040000 : "Config"
0x000000040000 - 0x000000050000 : "Factory"
0x000000050000 - 0x000001000000 : "firmware"
0x000000050000 - 0x000000210000 : "kernel"
0x000000210000 - 0x000001000000 : "rootfs"
0x000000940000 - 0x000001000000 : "rootfs_data"

Installation:
Connect to the router via UART (3.3V, baudrate 57600, 8N1). Connect the
power cable. Interrupt autoboot and select "0. U-Boot console".
Set your TFTP server ip to 192.168.1.131. Put initramfs-kernel.bin onto
TFTP server. Go back in U-Boot console and execute:
tftpboot <initramfs-kernel.bin>
bootm
After that you can do sysupgrade in console or in LuCI.

Unsupported features:
- System RGB LED (AW2026 driver needed)
- Sysupgrade via WEB failsafe UI

I need some help with these two.