### PR TITLE
realtek: eth: get rid of family_id

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -460,11 +460,16 @@ static void rteth_93xx_hw_reset(struct rteth_ctrl *ctrl)
 	rteth_nic_reset(ctrl, 0x6);
 
 	/* Setup Head of Line */
-	for (int i = 0; i < RTETH_RX_RINGS; i++) {
-		int pos = (i % 3) * 10;
+	for (int r = 0; r < RTETH_RX_RINGS; r++) {
+		int cnt = min(RTETH_RX_RING_SIZE, 0x3ff);
+		int pos = (r % 3) * 10;
+		u32 v;
 
-		sw_w32_mask(0x3ff << pos, 0, ctrl->r->dma_if_rx_ring_size(i));
-		sw_w32_mask(0x3ff << pos, RTETH_RX_RING_SIZE, ctrl->r->dma_if_rx_ring_cntr(i));
+		/* set ring size */
+		sw_w32_mask(0x3ff << pos, cnt << pos, ctrl->r->dma_if_rx_ring_size(r));
+		/* clear counters */
+		v = (sw_r32(ctrl->r->dma_if_rx_ring_cntr(r)) >> pos) & 0x3ff;
+		sw_w32_mask(0x3ff << pos, v, ctrl->r->dma_if_rx_ring_cntr(r));
 	}
 }
 
@@ -575,18 +580,6 @@ static void rteth_93xx_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
 	/* Setup CPU-Port: RX Buffer truncated at DEFAULT_MTU Bytes */
 	sw_w32((DEFAULT_MTU << 16) | RX_TRUNCATE_EN_93XX, ctrl->r->dma_if_ctrl);
-
-	for (int i = 0; i < RTETH_RX_RINGS; i++) {
-		int cnt = min(RTETH_RX_RING_SIZE - 2, 0x3ff);
-		int pos = (i % 3) * 10;
-		u32 v;
-
-		sw_w32_mask(0x3ff << pos, cnt << pos, ctrl->r->dma_if_rx_ring_size(i));
-
-		/* Some SoCs have issues with missing underflow protection */
-		v = (sw_r32(ctrl->r->dma_if_rx_ring_cntr(i)) >> pos) & 0x3ff;
-		sw_w32_mask(0x3ff << pos, v, ctrl->r->dma_if_rx_ring_cntr(i));
-	}
 
 	rteth_enable_all_rx_irqs(ctrl);
 

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -647,7 +647,7 @@ static void rteth_setup_ring_buffer(struct rteth_ctrl *ctrl)
 	}
 }
 
-static void rtl839x_setup_notify_ring_buffer(struct rteth_ctrl *ctrl)
+static void rteth_839x_setup_notify_ring_buffer(struct rteth_ctrl *ctrl)
 {
 	struct notify_b *b = ctrl->membase;
 
@@ -664,6 +664,10 @@ static void rtl839x_setup_notify_ring_buffer(struct rteth_ctrl *ctrl)
 	/* Enable Notification */
 	sw_w32_mask(0, 1 << 0, RTL839X_L2_NOTIFICATION_CTRL);
 	ctrl->lastEvent = 0;
+
+	/* Make sure the ring structure is visible to the ASIC */
+	mb();
+	flush_cache_all();
 }
 
 static void rteth_838x_hw_init(struct rteth_ctrl *ctrl)
@@ -714,12 +718,8 @@ static int rteth_open(struct net_device *ndev)
 	ctrl->r->hw_reset(ctrl);
 	rteth_setup_cpu_rx_rings(ctrl);
 	rteth_setup_ring_buffer(ctrl);
-	if (ctrl->r->family_id == RTL8390_FAMILY_ID) {
-		rtl839x_setup_notify_ring_buffer(ctrl);
-		/* Make sure the ring structure is visible to the ASIC */
-		mb();
-		flush_cache_all();
-	}
+	if (ctrl->r->setup_notify_ring_buffer)
+		ctrl->r->setup_notify_ring_buffer(ctrl);
 
 	rteth_hw_ring_setup(ctrl);
 	phylink_start(ctrl->phylink);
@@ -1300,7 +1300,6 @@ static const struct net_device_ops rteth_838x_netdev_ops = {
 };
 
 static const struct rteth_config rteth_838x_cfg = {
-	.family_id = RTL8380_FAMILY_ID,
 	.cpu_port = RTETH_838X_CPU_PORT,
 	.rx_rings = 8,
 	.tx_rx_enable = 0xc,
@@ -1346,7 +1345,6 @@ static const struct net_device_ops rteth_839x_netdev_ops = {
 };
 
 static const struct rteth_config rteth_839x_cfg = {
-	.family_id = RTL8390_FAMILY_ID,
 	.cpu_port = RTETH_839X_CPU_PORT,
 	.rx_rings = 8,
 	.tx_rx_enable = 0xc,
@@ -1373,6 +1371,7 @@ static const struct rteth_config rteth_839x_cfg = {
 	.hw_stop = &rteth_839x_hw_stop,
 	.hw_reset = &rteth_839x_hw_reset,
 	.init_mac = &rteth_839x_init_mac,
+	.setup_notify_ring_buffer = &rteth_839x_setup_notify_ring_buffer,
 	.netdev_ops = &rteth_839x_netdev_ops,
 };
 
@@ -1390,7 +1389,6 @@ static const struct net_device_ops rteth_930x_netdev_ops = {
 };
 
 static const struct rteth_config rteth_930x_cfg = {
-	.family_id = RTL9300_FAMILY_ID,
 	.cpu_port = RTETH_930X_CPU_PORT,
 	.rx_rings = 32,
 	.tx_rx_enable = 0x30,
@@ -1435,7 +1433,6 @@ static const struct net_device_ops rteth_931x_netdev_ops = {
 };
 
 static const struct rteth_config rteth_931x_cfg = {
-	.family_id = RTL9310_FAMILY_ID,
 	.cpu_port = RTETH_931X_CPU_PORT,
 	.rx_rings = 32,
 	.tx_rx_enable = 0x30,

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -672,7 +672,6 @@ static void rteth_839x_setup_notify_ring_buffer(struct rteth_ctrl *ctrl)
 
 static void rteth_838x_hw_init(struct rteth_ctrl *ctrl)
 {
-	rteth_838x_hw_en_rxtx(ctrl);
 	/* Trap IGMP/MLD traffic to CPU-Port */
 	sw_w32(0x3, RTL838X_SPCL_TRAP_IGMP_CTRL);
 	/* Flush learned FDB entries on link down of a port */
@@ -681,7 +680,6 @@ static void rteth_838x_hw_init(struct rteth_ctrl *ctrl)
 
 static void rteth_839x_hw_init(struct rteth_ctrl *ctrl)
 {
-	rteth_839x_hw_en_rxtx(ctrl);
 	/* Trap MLD and IGMP messages to CPU_PORT */
 	sw_w32(0x3, RTL839X_SPCL_TRAP_IGMP_CTRL);
 	/* Flush learned FDB entries on link down of a port */
@@ -690,7 +688,6 @@ static void rteth_839x_hw_init(struct rteth_ctrl *ctrl)
 
 static void rteth_930x_hw_init(struct rteth_ctrl *ctrl)
 {
-	rteth_930x_hw_en_rxtx(ctrl);
 	/* Flush learned FDB entries on link down of a port */
 	sw_w32_mask(0, BIT(7), RTL930X_L2_CTRL);
 	/* Trap MLD and IGMP messages to CPU_PORT */
@@ -699,7 +696,6 @@ static void rteth_930x_hw_init(struct rteth_ctrl *ctrl)
 
 static void rteth_931x_hw_init(struct rteth_ctrl *ctrl)
 {
-	rteth_931x_hw_en_rxtx(ctrl);
 	/* Trap MLD and IGMP messages to CPU_PORT */
 	sw_w32((0x2 << 3) | 0x2, RTL931X_VLAN_APP_PKT_CTRL);
 	/* Set PCIE_PWR_DOWN */
@@ -728,6 +724,7 @@ static int rteth_open(struct net_device *ndev)
 		napi_enable(&ctrl->rx_qs[i].napi);
 
 	ctrl->r->hw_init(ctrl);
+	ctrl->r->hw_en_rxtx(ctrl);
 	netif_tx_start_all_queues(ndev);
 	spin_unlock_irqrestore(&ctrl->lock, flags);
 
@@ -906,7 +903,7 @@ static void rteth_tx_timeout(struct net_device *ndev, unsigned int txqueue)
 	spin_lock_irqsave(&ctrl->lock, flags);
 	rteth_hw_stop(ctrl);
 	rteth_hw_ring_setup(ctrl);
-	rteth_838x_hw_en_rxtx(ctrl);
+	ctrl->r->hw_en_rxtx(ctrl);
 	netif_trans_update(ndev);
 	netif_start_queue(ndev);
 	spin_unlock_irqrestore(&ctrl->lock, flags);
@@ -1324,6 +1321,7 @@ static const struct rteth_config rteth_838x_cfg = {
 	.update_counter = rteth_83xx_update_counter,
 	.create_tx_header = rteth_838x_create_tx_header,
 	.decode_tag = rteth_838x_decode_tag,
+	.hw_en_rxtx = rteth_838x_hw_en_rxtx,
 	.hw_init = &rteth_838x_hw_init,
 	.hw_stop = &rteth_838x_hw_stop,
 	.hw_reset = &rteth_838x_hw_reset,
@@ -1367,6 +1365,7 @@ static const struct rteth_config rteth_839x_cfg = {
 	.update_counter = rteth_83xx_update_counter,
 	.create_tx_header = rteth_839x_create_tx_header,
 	.decode_tag = rteth_839x_decode_tag,
+	.hw_en_rxtx = rteth_839x_hw_en_rxtx,
 	.hw_init = &rteth_839x_hw_init,
 	.hw_stop = &rteth_839x_hw_stop,
 	.hw_reset = &rteth_839x_hw_reset,
@@ -1412,6 +1411,7 @@ static const struct rteth_config rteth_930x_cfg = {
 	.update_counter = rteth_93xx_update_counter,
 	.create_tx_header = rteth_93xx_create_tx_header,
 	.decode_tag = rteth_930x_decode_tag,
+	.hw_en_rxtx = rteth_930x_hw_en_rxtx,
 	.hw_init = &rteth_930x_hw_init,
 	.hw_stop = &rteth_930x_hw_stop,
 	.hw_reset = &rteth_93xx_hw_reset,
@@ -1456,6 +1456,7 @@ static const struct rteth_config rteth_931x_cfg = {
 	.update_counter = rteth_93xx_update_counter,
 	.create_tx_header = rteth_93xx_create_tx_header,
 	.decode_tag = rteth_931x_decode_tag,
+	.hw_en_rxtx = rteth_931x_hw_en_rxtx,
 	.hw_init = &rteth_931x_hw_init,
 	.hw_stop = &rteth_931x_hw_stop,
 	.hw_reset = &rteth_93xx_hw_reset,

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -576,7 +576,7 @@ static void rteth_839x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 	sw_w32_mask(0, 3, ctrl->r->mac_force_mode_ctrl);
 }
 
-static void rteth_93xx_hw_en_rxtx(struct rteth_ctrl *ctrl)
+static void rteth_930x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
 	/* Setup CPU-Port: RX Buffer truncated at DEFAULT_MTU Bytes */
 	sw_w32((DEFAULT_MTU << 16) | RX_TRUNCATE_EN_93XX, ctrl->r->dma_if_ctrl);
@@ -589,15 +589,25 @@ static void rteth_93xx_hw_en_rxtx(struct rteth_ctrl *ctrl)
 	/* Restart TX/RX to CPU port, enable CRC checking */
 	sw_w32_mask(0x0, 0x3 | BIT(4), ctrl->r->mac_l2_port_ctrl);
 
-	if (ctrl->r->family_id == RTL9300_FAMILY_ID)
-		sw_w32_mask(0, BIT(ctrl->r->cpu_port), RTL930X_L2_UNKN_UC_FLD_PMSK);
-	else
-		sw_w32_mask(0, BIT(ctrl->r->cpu_port), RTL931X_L2_UNKN_UC_FLD_PMSK);
+	sw_w32_mask(0, BIT(ctrl->r->cpu_port), RTL930X_L2_UNKN_UC_FLD_PMSK);
+	sw_w32(0x217, ctrl->r->mac_force_mode_ctrl);
+}
 
-	if (ctrl->r->family_id == RTL9300_FAMILY_ID)
-		sw_w32(0x217, ctrl->r->mac_force_mode_ctrl);
-	else
-		sw_w32(0x2a1d, ctrl->r->mac_force_mode_ctrl);
+static void rteth_931x_hw_en_rxtx(struct rteth_ctrl *ctrl)
+{
+	/* Setup CPU-Port: RX Buffer truncated at DEFAULT_MTU Bytes */
+	sw_w32((DEFAULT_MTU << 16) | RX_TRUNCATE_EN_93XX, ctrl->r->dma_if_ctrl);
+
+	rteth_enable_all_rx_irqs(ctrl);
+
+	/* Enable DMA */
+	sw_w32_mask(0, ctrl->r->tx_rx_enable, ctrl->r->dma_if_ctrl);
+
+	/* Restart TX/RX to CPU port, enable CRC checking */
+	sw_w32_mask(0x0, 0x3 | BIT(4), ctrl->r->mac_l2_port_ctrl);
+
+	sw_w32_mask(0, BIT(ctrl->r->cpu_port), RTL931X_L2_UNKN_UC_FLD_PMSK);
+	sw_w32(0x2a1d, ctrl->r->mac_force_mode_ctrl);
 }
 
 static void rteth_setup_ring_buffer(struct rteth_ctrl *ctrl)
@@ -676,7 +686,7 @@ static void rteth_839x_hw_init(struct rteth_ctrl *ctrl)
 
 static void rteth_930x_hw_init(struct rteth_ctrl *ctrl)
 {
-	rteth_93xx_hw_en_rxtx(ctrl);
+	rteth_930x_hw_en_rxtx(ctrl);
 	/* Flush learned FDB entries on link down of a port */
 	sw_w32_mask(0, BIT(7), RTL930X_L2_CTRL);
 	/* Trap MLD and IGMP messages to CPU_PORT */
@@ -685,7 +695,7 @@ static void rteth_930x_hw_init(struct rteth_ctrl *ctrl)
 
 static void rteth_931x_hw_init(struct rteth_ctrl *ctrl)
 {
-	rteth_93xx_hw_en_rxtx(ctrl);
+	rteth_931x_hw_en_rxtx(ctrl);
 	/* Trap MLD and IGMP messages to CPU_PORT */
 	sw_w32((0x2 << 3) | 0x2, RTL931X_VLAN_APP_PKT_CTRL);
 	/* Set PCIE_PWR_DOWN */

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -525,7 +525,7 @@ static void rteth_hw_ring_setup(struct rteth_ctrl *ctrl)
 		       ctrl->r->dma_tx_base + r * 4);
 }
 
-static void rtl838x_hw_en_rxtx(struct rteth_ctrl *ctrl)
+static void rteth_838x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
 	/* Truncate RX buffer to DEFAULT_MTU bytes, pad TX */
 	sw_w32((DEFAULT_MTU << 16) | RX_TRUNCATE_EN_83XX | TX_PAD_EN_838X, ctrl->r->dma_if_ctrl);
@@ -548,7 +548,7 @@ static void rtl838x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 	sw_w32_mask(0, BIT(3), ctrl->r->mac_l2_port_ctrl);
 }
 
-static void rtl839x_hw_en_rxtx(struct rteth_ctrl *ctrl)
+static void rteth_839x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
 	/* Setup CPU-Port: RX Buffer */
 	sw_w32((DEFAULT_MTU << 5) | RX_TRUNCATE_EN_83XX, ctrl->r->dma_if_ctrl);
@@ -571,7 +571,7 @@ static void rtl839x_hw_en_rxtx(struct rteth_ctrl *ctrl)
 	sw_w32_mask(0, 3, ctrl->r->mac_force_mode_ctrl);
 }
 
-static void rtl93xx_hw_en_rxtx(struct rteth_ctrl *ctrl)
+static void rteth_93xx_hw_en_rxtx(struct rteth_ctrl *ctrl)
 {
 	/* Setup CPU-Port: RX Buffer truncated at DEFAULT_MTU Bytes */
 	sw_w32((DEFAULT_MTU << 16) | RX_TRUNCATE_EN_93XX, ctrl->r->dma_if_ctrl);
@@ -690,7 +690,7 @@ static int rteth_open(struct net_device *ndev)
 
 	switch (ctrl->r->family_id) {
 	case RTL8380_FAMILY_ID:
-		rtl838x_hw_en_rxtx(ctrl);
+		rteth_838x_hw_en_rxtx(ctrl);
 		/* Trap IGMP/MLD traffic to CPU-Port */
 		sw_w32(0x3, RTL838X_SPCL_TRAP_IGMP_CTRL);
 		/* Flush learned FDB entries on link down of a port */
@@ -698,7 +698,7 @@ static int rteth_open(struct net_device *ndev)
 		break;
 
 	case RTL8390_FAMILY_ID:
-		rtl839x_hw_en_rxtx(ctrl);
+		rteth_839x_hw_en_rxtx(ctrl);
 		/* Trap MLD and IGMP messages to CPU_PORT */
 		sw_w32(0x3, RTL839X_SPCL_TRAP_IGMP_CTRL);
 		/* Flush learned FDB entries on link down of a port */
@@ -706,7 +706,7 @@ static int rteth_open(struct net_device *ndev)
 		break;
 
 	case RTL9300_FAMILY_ID:
-		rtl93xx_hw_en_rxtx(ctrl);
+		rteth_93xx_hw_en_rxtx(ctrl);
 		/* Flush learned FDB entries on link down of a port */
 		sw_w32_mask(0, BIT(7), RTL930X_L2_CTRL);
 		/* Trap MLD and IGMP messages to CPU_PORT */
@@ -714,7 +714,7 @@ static int rteth_open(struct net_device *ndev)
 		break;
 
 	case RTL9310_FAMILY_ID:
-		rtl93xx_hw_en_rxtx(ctrl);
+		rteth_93xx_hw_en_rxtx(ctrl);
 
 		/* Trap MLD and IGMP messages to CPU_PORT */
 		sw_w32((0x2 << 3) | 0x2,  RTL931X_VLAN_APP_PKT_CTRL);
@@ -903,7 +903,7 @@ static void rteth_tx_timeout(struct net_device *ndev, unsigned int txqueue)
 	spin_lock_irqsave(&ctrl->lock, flags);
 	rteth_hw_stop(ctrl);
 	rteth_hw_ring_setup(ctrl);
-	rtl838x_hw_en_rxtx(ctrl);
+	rteth_838x_hw_en_rxtx(ctrl);
 	netif_trans_update(ndev);
 	netif_start_queue(ndev);
 	spin_unlock_irqrestore(&ctrl->lock, flags);

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -663,6 +663,42 @@ static void rtl839x_setup_notify_ring_buffer(struct rteth_ctrl *ctrl)
 	ctrl->lastEvent = 0;
 }
 
+static void rteth_838x_hw_init(struct rteth_ctrl *ctrl)
+{
+	rteth_838x_hw_en_rxtx(ctrl);
+	/* Trap IGMP/MLD traffic to CPU-Port */
+	sw_w32(0x3, RTL838X_SPCL_TRAP_IGMP_CTRL);
+	/* Flush learned FDB entries on link down of a port */
+	sw_w32_mask(0, BIT(7), RTL838X_L2_CTRL_0);
+}
+
+static void rteth_839x_hw_init(struct rteth_ctrl *ctrl)
+{
+	rteth_839x_hw_en_rxtx(ctrl);
+	/* Trap MLD and IGMP messages to CPU_PORT */
+	sw_w32(0x3, RTL839X_SPCL_TRAP_IGMP_CTRL);
+	/* Flush learned FDB entries on link down of a port */
+	sw_w32_mask(0, BIT(7), RTL839X_L2_CTRL_0);
+}
+
+static void rteth_930x_hw_init(struct rteth_ctrl *ctrl)
+{
+	rteth_93xx_hw_en_rxtx(ctrl);
+	/* Flush learned FDB entries on link down of a port */
+	sw_w32_mask(0, BIT(7), RTL930X_L2_CTRL);
+	/* Trap MLD and IGMP messages to CPU_PORT */
+	sw_w32((0x2 << 3) | 0x2, RTL930X_VLAN_APP_PKT_CTRL);
+}
+
+static void rteth_931x_hw_init(struct rteth_ctrl *ctrl)
+{
+	rteth_93xx_hw_en_rxtx(ctrl);
+	/* Trap MLD and IGMP messages to CPU_PORT */
+	sw_w32((0x2 << 3) | 0x2, RTL931X_VLAN_APP_PKT_CTRL);
+	/* Set PCIE_PWR_DOWN */
+	sw_w32_mask(0, BIT(1), RTL931X_PS_SOC_CTRL);
+}
+
 static int rteth_open(struct net_device *ndev)
 {
 	unsigned long flags;
@@ -688,44 +724,8 @@ static int rteth_open(struct net_device *ndev)
 	for (int i = 0; i < RTETH_RX_RINGS; i++)
 		napi_enable(&ctrl->rx_qs[i].napi);
 
-	switch (ctrl->r->family_id) {
-	case RTL8380_FAMILY_ID:
-		rteth_838x_hw_en_rxtx(ctrl);
-		/* Trap IGMP/MLD traffic to CPU-Port */
-		sw_w32(0x3, RTL838X_SPCL_TRAP_IGMP_CTRL);
-		/* Flush learned FDB entries on link down of a port */
-		sw_w32_mask(0, BIT(7), RTL838X_L2_CTRL_0);
-		break;
-
-	case RTL8390_FAMILY_ID:
-		rteth_839x_hw_en_rxtx(ctrl);
-		/* Trap MLD and IGMP messages to CPU_PORT */
-		sw_w32(0x3, RTL839X_SPCL_TRAP_IGMP_CTRL);
-		/* Flush learned FDB entries on link down of a port */
-		sw_w32_mask(0, BIT(7), RTL839X_L2_CTRL_0);
-		break;
-
-	case RTL9300_FAMILY_ID:
-		rteth_93xx_hw_en_rxtx(ctrl);
-		/* Flush learned FDB entries on link down of a port */
-		sw_w32_mask(0, BIT(7), RTL930X_L2_CTRL);
-		/* Trap MLD and IGMP messages to CPU_PORT */
-		sw_w32((0x2 << 3) | 0x2,  RTL930X_VLAN_APP_PKT_CTRL);
-		break;
-
-	case RTL9310_FAMILY_ID:
-		rteth_93xx_hw_en_rxtx(ctrl);
-
-		/* Trap MLD and IGMP messages to CPU_PORT */
-		sw_w32((0x2 << 3) | 0x2,  RTL931X_VLAN_APP_PKT_CTRL);
-
-		/* Set PCIE_PWR_DOWN */
-		sw_w32_mask(0, BIT(1), RTL931X_PS_SOC_CTRL);
-		break;
-	}
-
+	ctrl->r->hw_init(ctrl);
 	netif_tx_start_all_queues(ndev);
-
 	spin_unlock_irqrestore(&ctrl->lock, flags);
 
 	return 0;
@@ -1322,6 +1322,7 @@ static const struct rteth_config rteth_838x_cfg = {
 	.update_counter = rteth_83xx_update_counter,
 	.create_tx_header = rteth_838x_create_tx_header,
 	.decode_tag = rteth_838x_decode_tag,
+	.hw_init = &rteth_838x_hw_init,
 	.hw_stop = &rteth_838x_hw_stop,
 	.hw_reset = &rteth_838x_hw_reset,
 	.init_mac = &rteth_838x_init_mac,
@@ -1365,6 +1366,7 @@ static const struct rteth_config rteth_839x_cfg = {
 	.update_counter = rteth_83xx_update_counter,
 	.create_tx_header = rteth_839x_create_tx_header,
 	.decode_tag = rteth_839x_decode_tag,
+	.hw_init = &rteth_839x_hw_init,
 	.hw_stop = &rteth_839x_hw_stop,
 	.hw_reset = &rteth_839x_hw_reset,
 	.init_mac = &rteth_839x_init_mac,
@@ -1409,6 +1411,7 @@ static const struct rteth_config rteth_930x_cfg = {
 	.update_counter = rteth_93xx_update_counter,
 	.create_tx_header = rteth_93xx_create_tx_header,
 	.decode_tag = rteth_930x_decode_tag,
+	.hw_init = &rteth_930x_hw_init,
 	.hw_stop = &rteth_930x_hw_stop,
 	.hw_reset = &rteth_93xx_hw_reset,
 	.init_mac = &rteth_930x_init_mac,
@@ -1453,6 +1456,7 @@ static const struct rteth_config rteth_931x_cfg = {
 	.update_counter = rteth_93xx_update_counter,
 	.create_tx_header = rteth_93xx_create_tx_header,
 	.decode_tag = rteth_931x_decode_tag,
+	.hw_init = &rteth_931x_hw_init,
 	.hw_stop = &rteth_931x_hw_stop,
 	.hw_reset = &rteth_93xx_hw_reset,
 	.init_mac = &rteth_931x_init_mac,

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -731,10 +731,55 @@ static int rteth_open(struct net_device *ndev)
 	return 0;
 }
 
+static void rteth_838x_hw_stop(struct rteth_ctrl *ctrl)
+{
+	/* Block all ports */
+	sw_w32(0x03000000, RTL838X_TBL_ACCESS_DATA_0(0));
+	sw_w32(0x00000000, RTL838X_TBL_ACCESS_DATA_0(1));
+	sw_w32(1 << 15 | 2 << 12, RTL838X_TBL_ACCESS_CTRL_0);
+
+	/* Disable FAST_AGE_OUT otherwise flush will hang */
+	sw_w32_mask(BIT(23), 0, RTL838X_L2_CTRL_1);
+
+	/* Flush L2 address cache */
+	for (int i = 0; i <= ctrl->r->cpu_port; i++) {
+		sw_w32(BIT(26) | BIT(23) | i << 5, ctrl->r->l2_tbl_flush_ctrl);
+		do { } while (sw_r32(ctrl->r->l2_tbl_flush_ctrl) & BIT(26));
+	}
+
+	/* CPU-Port: Link down */
+	sw_w32(0x6192C, ctrl->r->mac_force_mode_ctrl);
+}
+
+static void rteth_839x_hw_stop(struct rteth_ctrl *ctrl)
+{
+	/* Flush L2 address cache */
+	for (int i = 0; i <= ctrl->r->cpu_port; i++) {
+		sw_w32(BIT(28) | BIT(25) | i << 5, ctrl->r->l2_tbl_flush_ctrl);
+		do { } while (sw_r32(ctrl->r->l2_tbl_flush_ctrl) & BIT(28));
+	}
+
+	sw_w32(0x75, ctrl->r->mac_force_mode_ctrl);
+}
+
+static void rteth_930x_hw_stop(struct rteth_ctrl *ctrl)
+{
+	/* TODO: L2 flush needed */
+
+	/* CPU-Port: Link down */
+	sw_w32_mask(0x3, 0, ctrl->r->mac_force_mode_ctrl);
+}
+
+static void rteth_931x_hw_stop(struct rteth_ctrl *ctrl)
+{
+	/* TODO: L2 flush needed */
+
+	/* CPU-Port: Link down */
+	sw_w32_mask(BIT(0) | BIT(9), 0, ctrl->r->mac_force_mode_ctrl);
+}
+
 static void rteth_hw_stop(struct rteth_ctrl *ctrl)
 {
-	u32 force_mac = ctrl->r->family_id == RTL8380_FAMILY_ID ? 0x6192C : 0x75;
-
 	/* Disable RX/TX from/to CPU-port */
 	sw_w32_mask(0x3, 0, ctrl->r->mac_l2_port_ctrl);
 
@@ -742,36 +787,8 @@ static void rteth_hw_stop(struct rteth_ctrl *ctrl)
 	sw_w32_mask(ctrl->r->tx_rx_enable, 0, ctrl->r->dma_if_ctrl);
 	mdelay(200); /* Test, whether this is needed */
 
-	/* Block all ports */
-	if (ctrl->r->family_id == RTL8380_FAMILY_ID) {
-		sw_w32(0x03000000, RTL838X_TBL_ACCESS_DATA_0(0));
-		sw_w32(0x00000000, RTL838X_TBL_ACCESS_DATA_0(1));
-		sw_w32(1 << 15 | 2 << 12, RTL838X_TBL_ACCESS_CTRL_0);
-	}
-
-	/* Flush L2 address cache */
-	if (ctrl->r->family_id == RTL8380_FAMILY_ID) {
-		/* Disable FAST_AGE_OUT otherwise flush will hang */
-		sw_w32_mask(BIT(23), 0, RTL838X_L2_CTRL_1);
-		for (int i = 0; i <= ctrl->r->cpu_port; i++) {
-			sw_w32(BIT(26) | BIT(23) | i << 5, ctrl->r->l2_tbl_flush_ctrl);
-			do { } while (sw_r32(ctrl->r->l2_tbl_flush_ctrl) & BIT(26));
-		}
-	} else if (ctrl->r->family_id == RTL8390_FAMILY_ID) {
-		for (int i = 0; i <= ctrl->r->cpu_port; i++) {
-			sw_w32(BIT(28) | BIT(25) | i << 5, ctrl->r->l2_tbl_flush_ctrl);
-			do { } while (sw_r32(ctrl->r->l2_tbl_flush_ctrl) & BIT(28));
-		}
-	}
-	/* TODO: L2 flush register is 64 bit on RTL931X and 930X */
-
-	/* CPU-Port: Link down */
-	if (ctrl->r->family_id == RTL8380_FAMILY_ID || ctrl->r->family_id == RTL8390_FAMILY_ID)
-		sw_w32(force_mac, ctrl->r->mac_force_mode_ctrl);
-	else if (ctrl->r->family_id == RTL9300_FAMILY_ID)
-		sw_w32_mask(0x3, 0, ctrl->r->mac_force_mode_ctrl);
-	else if (ctrl->r->family_id == RTL9310_FAMILY_ID)
-		sw_w32_mask(BIT(0) | BIT(9), 0, ctrl->r->mac_force_mode_ctrl);
+	/* family specific stop */
+	ctrl->r->hw_stop(ctrl);
 	mdelay(100);
 
 	rteth_disable_all_irqs(ctrl);
@@ -1305,6 +1322,7 @@ static const struct rteth_config rteth_838x_cfg = {
 	.update_counter = rteth_83xx_update_counter,
 	.create_tx_header = rteth_838x_create_tx_header,
 	.decode_tag = rteth_838x_decode_tag,
+	.hw_stop = &rteth_838x_hw_stop,
 	.hw_reset = &rteth_838x_hw_reset,
 	.init_mac = &rteth_838x_init_mac,
 	.netdev_ops = &rteth_838x_netdev_ops,
@@ -1347,6 +1365,7 @@ static const struct rteth_config rteth_839x_cfg = {
 	.update_counter = rteth_83xx_update_counter,
 	.create_tx_header = rteth_839x_create_tx_header,
 	.decode_tag = rteth_839x_decode_tag,
+	.hw_stop = &rteth_839x_hw_stop,
 	.hw_reset = &rteth_839x_hw_reset,
 	.init_mac = &rteth_839x_init_mac,
 	.netdev_ops = &rteth_839x_netdev_ops,
@@ -1390,6 +1409,7 @@ static const struct rteth_config rteth_930x_cfg = {
 	.update_counter = rteth_93xx_update_counter,
 	.create_tx_header = rteth_93xx_create_tx_header,
 	.decode_tag = rteth_930x_decode_tag,
+	.hw_stop = &rteth_930x_hw_stop,
 	.hw_reset = &rteth_93xx_hw_reset,
 	.init_mac = &rteth_930x_init_mac,
 	.netdev_ops = &rteth_930x_netdev_ops,
@@ -1433,6 +1453,7 @@ static const struct rteth_config rteth_931x_cfg = {
 	.update_counter = rteth_93xx_update_counter,
 	.create_tx_header = rteth_93xx_create_tx_header,
 	.decode_tag = rteth_931x_decode_tag,
+	.hw_stop = &rteth_931x_hw_stop,
 	.hw_reset = &rteth_93xx_hw_reset,
 	.init_mac = &rteth_931x_init_mac,
 	.netdev_ops = &rteth_931x_netdev_ops,

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.c
@@ -731,7 +731,7 @@ static int rteth_open(struct net_device *ndev)
 	return 0;
 }
 
-static void rtl838x_hw_stop(struct rteth_ctrl *ctrl)
+static void rteth_hw_stop(struct rteth_ctrl *ctrl)
 {
 	u32 force_mac = ctrl->r->family_id == RTL8380_FAMILY_ID ? 0x6192C : 0x75;
 
@@ -788,7 +788,7 @@ static int rteth_stop(struct net_device *ndev)
 	pr_info("in %s\n", __func__);
 
 	phylink_stop(ctrl->phylink);
-	rtl838x_hw_stop(ctrl);
+	rteth_hw_stop(ctrl);
 
 	for (int i = 0; i < RTETH_RX_RINGS; i++)
 		napi_disable(&ctrl->rx_qs[i].napi);
@@ -884,7 +884,7 @@ static void rteth_tx_timeout(struct net_device *ndev, unsigned int txqueue)
 
 	pr_warn("%s\n", __func__);
 	spin_lock_irqsave(&ctrl->lock, flags);
-	rtl838x_hw_stop(ctrl);
+	rteth_hw_stop(ctrl);
 	rteth_hw_ring_setup(ctrl);
 	rtl838x_hw_en_rxtx(ctrl);
 	netif_trans_update(ndev);
@@ -1597,7 +1597,7 @@ static void rtl838x_eth_remove(struct platform_device *pdev)
 
 	if (dev) {
 		pr_info("Removing platform driver for rtl838x-eth\n");
-		rtl838x_hw_stop(ctrl);
+		rteth_hw_stop(ctrl);
 
 		netif_tx_stop_all_queues(dev);
 

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
@@ -262,6 +262,7 @@ struct rteth_config {
 	int l2_tbl_flush_ctrl;
 	void (*create_tx_header)(struct rteth_packet *h, unsigned int dest_port, int prio);
 	bool (*decode_tag)(struct rteth_packet *h, struct dsa_tag *tag);
+	void (*hw_en_rxtx)(struct rteth_ctrl *ctrl);
 	void (*hw_init)(struct rteth_ctrl *ctrl);
 	void (*hw_stop)(struct rteth_ctrl *ctrl);
 	void (*hw_reset)(struct rteth_ctrl *ctrl);

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
@@ -263,6 +263,7 @@ struct rteth_config {
 	int l2_tbl_flush_ctrl;
 	void (*create_tx_header)(struct rteth_packet *h, unsigned int dest_port, int prio);
 	bool (*decode_tag)(struct rteth_packet *h, struct dsa_tag *tag);
+	void (*hw_stop)(struct rteth_ctrl *ctrl);
 	void (*hw_reset)(struct rteth_ctrl *ctrl);
 	int (*init_mac)(struct rteth_ctrl *ctrl);
 	void (*update_counter)(struct rteth_ctrl *ctrl, int ring, int released);

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
@@ -263,6 +263,7 @@ struct rteth_config {
 	int l2_tbl_flush_ctrl;
 	void (*create_tx_header)(struct rteth_packet *h, unsigned int dest_port, int prio);
 	bool (*decode_tag)(struct rteth_packet *h, struct dsa_tag *tag);
+	void (*hw_init)(struct rteth_ctrl *ctrl);
 	void (*hw_stop)(struct rteth_ctrl *ctrl);
 	void (*hw_reset)(struct rteth_ctrl *ctrl);
 	int (*init_mac)(struct rteth_ctrl *ctrl);

--- a/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.12/drivers/net/ethernet/rtl838x_eth.h
@@ -239,7 +239,6 @@ struct rteth_ctrl;
 struct rteth_packet;
 
 struct rteth_config {
-	int family_id;
 	int cpu_port;
 	int rx_rings;
 	int tx_rx_enable;
@@ -267,6 +266,7 @@ struct rteth_config {
 	void (*hw_stop)(struct rteth_ctrl *ctrl);
 	void (*hw_reset)(struct rteth_ctrl *ctrl);
 	int (*init_mac)(struct rteth_ctrl *ctrl);
+	void (*setup_notify_ring_buffer)(struct rteth_ctrl *ctrl);
 	void (*update_counter)(struct rteth_ctrl *ctrl, int ring, int released);
 	const struct net_device_ops *netdev_ops;
 };


### PR DESCRIPTION
This series removes the last consumers of family_id in the ethernet driver.