### PR TITLE
apk: add help text for 'apk add --force-reinstall'

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git

--- a/package/system/apk/patches/0002-openwrt-wiki-help-link.patch
+++ b/package/system/apk/patches/0002-openwrt-wiki-help-link.patch
@@ -1,8 +1,6 @@
-diff --git a/src/genhelp_apk.lua b/src/genhelp_apk.lua
-index a62e84d22ed5..a97264f6ab3c 100644
 --- a/src/genhelp_apk.lua
 +++ b/src/genhelp_apk.lua
-@@ -65,7 +65,7 @@ local function render_options(doc, out, options)
+@@ -65,7 +65,7 @@ local function render_options(doc, out,
  end
  
  local function render_footer(doc, out)

--- a/package/system/apk/patches/0100-add-add-force-reinstall-option.patch
+++ b/package/system/apk/patches/0100-add-add-force-reinstall-option.patch
@@ -46,3 +46,16 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	}
  
  	r = apk_solver_commit(db, 0, world);
+--- a/doc/apk-add.8.scd
++++ b/doc/apk-add.8.scd
+@@ -30,6 +30,10 @@ To later upgrade or downgrade back to a
+ *apk add* supports the commit options described in *apk*(8), as well as the
+ following options:
+ 
++*--force-reinstall*
++	Allow reinstalling already-installed packages without a version
++	change. Only the named packages are reinstalled, not dependencies.
++
+ *--initdb*
+ 	Initialize a new package database.
+ 


### PR DESCRIPTION
Add a help text for the new `--force-reinstall` option, so that users will actually find the new option.

Modify the patch from 91cff1a to also add help text for the new option to the docs. The first sentence of the help text will be picked up by the compiler to be shown in the help message of `apk add -h` 

```
root@router5:~# apk add -h
apk-tools 3.0.5, compiled for aarch64.
...
Add options:
  --force-reinstall     Allow reinstalling already-installed packages
                        without a version change
  --initdb              Initialize a new package database
  --latest, -l          Always choose the latest package by version
  --no-chown            Deperecated alias for --usermode
...
```

(Also refresh patches)
Improves: 91cff1a "apk: add --force-reinstall option"

cc @nbd168 @aparcar @hauke 
