### PR TITLE
wifi-scripts: fix [VHT160]/[VHT160-80PLUS80] usage

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -354,10 +354,10 @@ function device_htmode_append(config) {
 			config.vht_capab += '[BF-ANTENNA-' + min(((vht_capab >> 13) & 3) + 1, config.beamformer_antennas) + ']';
 
 		/* supported Channel widths */
-		if ((vht_capab & 0xc) == 8 && config.vht160 <= 2)
-			config.vht_capab += '[VHT160-80PLUS80]';
-		else if ((vht_capab & 0xc) == 4 && config.vht160 <= 2)
+		if (((vht_capab & 0xc) == 4 || (vht_capab & 0xc) == 8) && config.vht160 >= 1)
 			config.vht_capab += '[VHT160]';
+		if ((vht_capab & 0xc) == 8 && config.vht160 >= 2)
+			config.vht_capab += '[VHT160-80PLUS80]';
 
 		/* maximum MPDU length */
 		if ((vht_capab & 3) > 1 && config.vht_max_mpdu >= 11454)


### PR DESCRIPTION
Don't set vht_capab [VHT160] or [VHT160-80PLUS80] when the AP is not configured to operate in 160 MHz. Fixes an issue degrading station upload speed.

Fixes: #22435
