### PR TITLE
lantiq: adapt gpio-stp-xway node name to get clock

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9.dtsi
@@ -314,7 +314,7 @@
 			};
 		};
 
-		stp: stp@e100bb0 {
+		stp: gpio@e100bb0 {
 			#gpio-cells = <2>;
 			compatible = "lantiq,gpio-stp-xway";
 			gpio-controller;

--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9.dtsi
@@ -354,7 +354,7 @@
 			};
 		};
 
-		stp: stp@e100bb0 {
+		stp: gpio@e100bb0 {
 			status = "disabled";
 			compatible = "lantiq,gpio-stp-xway";
 			reg = <0xe100bb0 0x40>;


### PR DESCRIPTION
The MIPS code assigns the clock node based on the device tree node name. This name was renamed with kernel 6.12.58 and v6.6.117. Adapt our out of tree device tree files to this rename to fix loading the STP GPIO driver.

Without this fix the driver fails like this:
```
[    0.320000] gpio-stp-xway 1e100bb0.stp: Failed to get clock
[    0.330000] gpio-stp-xway 1e100bb0.stp: probe with driver gpio-stp-xway failed with error -2
```

Link: https://git.kernel.org/linus/b0d04fe6a633ada2c7bc1b5ddd011cbd85961868
Fixes: https://github.com/openwrt/openwrt/issues/21697
