### PR TITLE
airoha: rename kmod-pwm-an7581 to kmod-pwm-airoha

### DIFF
--- a/target/linux/airoha/modules.mk
+++ b/target/linux/airoha/modules.mk
@@ -20,10 +20,10 @@ endef
 $(eval $(call KernelPackage,i2c-an7581))
 
 
-define KernelPackage/pwm-an7581
+define KernelPackage/pwm-airoha
   SUBMENU:=$(OTHER_MENU)
-  TITLE:=Airoha EN7581 PWM
-  DEPENDS:=@(TARGET_airoha_an7581)
+  TITLE:=Airoha AN7581 and AN7583 PWM
+  DEPENDS:=@TARGET_airoha_an7581||TARGET_airoha_an7583
   KCONFIG:= \
         CONFIG_PWM=y \
         CONFIG_PWM_AIROHA=y \
@@ -33,10 +33,10 @@ define KernelPackage/pwm-an7581
   AUTOLOAD:=$(call AutoProbe,pwm-airoha)
 endef
 
-define KernelPackage/pwm-an7581/description
+define KernelPackage/pwm-airoha/description
  Kernel module to use the PWM channel on Airoha SoC
 endef
 
-$(eval $(call KernelPackage,pwm-an7581))
+$(eval $(call KernelPackage,pwm-airoha))
 
 


### PR DESCRIPTION
Certain targets for an7581 and an7583 referred to kmod-pwm-airoha; however in the target modules makefile the module is referred to as kmod-pwm-an7581, causing buildbot to fail.

Change the name of kmod-pwm-an7581 to kmod-pwm-airoha to resolve this.

Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>