### PR TITLE
ramips: add support for TP-Link Festa F61

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2968,6 +2968,12 @@ define Device/tplink_eap613-v1
   $(Device/tplink-safeloader)
   DEVICE_MODEL := EAP613
   DEVICE_VARIANT := v1
+  DEVICE_ALT0_VENDOR := TP-Link
+  DEVICE_ALT0_MODEL := Festa F61
+  DEVICE_ALT0_VARIANT := v1
+  DEVICE_ALT1_VENDOR := TP-Link
+  DEVICE_ALT1_MODEL := EAP610
+  DEVICE_ALT1_VARIANT := v3
   DEVICE_PACKAGES := kmod-mt7915-firmware -uboot-envtools
   TPLINK_BOARD_ID := EAP610-V3
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | pad-to 64k


### PR DESCRIPTION
The Festa F61 is an MT7621-based device (16MB Flash/256MB RAM) identical to the EAP613 v1 and EAP610 v3. It is added as an ALT0 variant.

This support depends on the corresponding update to firmware-utils (commit 33dbcba) to include the Festa F61 in the support list, enabling the stock web interface to accept the image.



