### PR TITLE
ramips: cpe200: fix eeprom size

### DIFF
--- a/target/linux/ramips/dts/mt7628an_yuncore_cpe200.dts
+++ b/target/linux/ramips/dts/mt7628an_yuncore_cpe200.dts
@@ -105,7 +105,7 @@
 					};
 
 					eeprom_factory_8000: eeprom@8000 {
-						reg = <0x8000 0x600>;
+						reg = <0x8000 0x4da8>;
 					};
 
 					macaddr_factory_8004: macaddr@8004 {


### PR DESCRIPTION
A size of 600 is incomplete in that calibration data is not included, resulting in low TX power.

Fixes: 64dae105 ("ramips: mt76x8: add support for Yuncore CPE200")

ping @dangowrt 

related: https://github.com/openwrt/mt76/pull/1063#issuecomment-4071950254