### PR TITLE
mediatek: filogic: add support for TP-Link Archer BE805

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -1181,6 +1181,14 @@ define U-Boot/mt7988_rfb-sd
   DEPENDS:=+trusted-firmware-a-mt7988-sdmmc-comb
 endef
 
+define U-Boot/mt7988_tplink_be805-v120
+  NAME:=TP-Link BE805 v1.20 Chainloader
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=tplink_be805-v1.20
+  UBOOT_CONFIG:=mt7988a_tplink_be805-v1.20
+  UBOOT_IMAGE:=u-boot.bin
+endef
+
 UBOOT_TARGETS := \
 	mt7620_mt7530_rfb \
 	mt7620_rfb \
@@ -1280,7 +1288,8 @@ UBOOT_TARGETS := \
 	mt7988_rfb-snand \
 	mt7988_rfb-nor \
 	mt7988_rfb-emmc \
-	mt7988_rfb-sd
+	mt7988_rfb-sd \
+	mt7988_tplink_be805-v120
 
 UBOOT_CUSTOMIZE_CONFIG := \
 	--disable TOOLS_KWBIMAGE \

--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -1303,6 +1303,14 @@ define U-Boot/mt7988_tplink_be450
   DEPENDS:=+trusted-firmware-a-mt7988-spim-nand-ubi-ddr4
 endef
 
+define U-Boot/mt7988_tplink_be805
+  NAME:=TP-Link BE805 Chainloader
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=tplink_be805-v1 tplink_be805-v1.20
+  UBOOT_CONFIG:=mt7988a_tplink_be805
+  UBOOT_IMAGE:=u-boot.bin
+endef
+
 UBOOT_TARGETS := \
 	mt7620_mt7530_rfb \
 	mt7620_rfb \
@@ -1412,7 +1420,8 @@ UBOOT_TARGETS := \
 	mt7988_rfb-nor \
 	mt7988_rfb-emmc \
 	mt7988_rfb-sd \
-	mt7988_tplink_be450
+	mt7988_tplink_be450 \
+	mt7988_tplink_be805
 
 UBOOT_CUSTOMIZE_CONFIG := \
 	--disable TOOLS_KWBIMAGE \

--- a/package/boot/uboot-mediatek/patches/503-add-TP-Link-BE805-v1.20-chainloader.patch
+++ b/package/boot/uboot-mediatek/patches/503-add-TP-Link-BE805-v1.20-chainloader.patch
@@ -1,0 +1,193 @@
+--- /dev/null
++++ b/arch/arm/dts/mt7988a-tplink-be805-v1.20.dts
+@@ -0,0 +1,102 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++// Author: Yanase Yuki <dev@zpc.st>
++/dts-v1/;
++#include "mt7988.dtsi"
++
++/ {
++	compatible = "tplink,be805-v1.20", "mediatek,mt7988a";
++	model = "TP-Link BE805 v1.20";
++
++	aliases {
++		serial0 = &uart0;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x0 0x40000000 0x0 0x40000000>;
++	};
++};
++
++&pio {
++	spi0_pins: spi0-pins {
++		mux {
++			function = "spi";
++			groups = "spi0", "spi0_wp_hold";
++		};
++	};
++};
++
++&uart0 {
++	status = "okay";
++};
++
++&spi0 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi0_pins>;
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	flash@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++
++		spi-max-frequency = <52000000>;
++		spi-tx-bus-width = <4>;
++		spi-rx-bus-width = <4>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				reg = <0x0 0x200000>;
++				label = "boot";
++				read-only;
++			};
++
++			partition@200000 {
++				reg = <0x200000 0x100000>;
++				label = "u-boot-env";
++				read-only;
++			};
++
++			partition@300000 {
++				reg = <0x300000 0x3200000>;
++				label = "ubi-stock";
++				read-only;
++			};
++
++			partition@3500000 {
++				compatible = "linux,ubi";
++				reg = <0x3500000 0x3200000>;
++				label = "ubi";
++			};
++
++			partition@6700000 {
++				reg = <0x6700000 0x800000>;
++				label = "userconfig";
++				read-only;
++			};
++
++			partition@6f00000 {
++				reg = <0x6f00000 0x800000>;
++				label = "tp_data";
++				read-only;
++			};
++		};
++	};
++};
++
+--- /dev/null
++++ b/configs/mt7988a_tplink_be805-v1.20_defconfig
+@@ -0,0 +1,79 @@
++CONFIG_ARM=y
++CONFIG_ARM_SMCCC=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x44000000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7988a-tplink-be805-v1.20"
++CONFIG_TARGET_MT7988=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_DEBUG_UART_BASE=0x11000000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++# CONFIG_EFI_LOADER is not set
++CONFIG_FIT=y
++# CONFIG_LEGACY_IMAGE_FORMAT is not set
++CONFIG_BOOTDELAY=3
++CONFIG_DEFAULT_FDT_FILE="mt7988a-tplink-be805-v1.20"
++CONFIG_SYS_CBSIZE=512
++CONFIG_SYS_PBSIZE=1049
++CONFIG_LOGLEVEL=7
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_STACKPROTECTOR=y
++CONFIG_SYS_PROMPT="MT7988 Chainloader> "
++CONFIG_CMD_LICENSE=y
++# CONFIG_BOOTM_PLAN9 is not set
++# CONFIG_BOOTM_RTEMS is not set
++# CONFIG_BOOTM_VXWORKS is not set
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_XIMG is not set
++# CONFIG_CMD_EXPORTENV is not set
++# CONFIG_CMD_IMPORTENV is not set
++# CONFIG_CMD_UNZIP is not set
++CONFIG_CMD_MTD=y
++# CONFIG_CMD_PINMUX is not set
++CONFIG_CMD_RNG=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/tplink_be805-v1.20_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_NO_NET=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_CLK=y
++# CONFIG_I2C is not set
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_FLASH_SFDP_SUPPORT=y
++CONFIG_SPI_FLASH_EON=y
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_ISSI=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_SPANSION=y
++CONFIG_SPI_FLASH_STMICRO=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_XMC=y
++CONFIG_SPI_FLASH_XTX=y
++CONFIG_SPI_FLASH_MTD=y
++CONFIG_UBI_BLOCK=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7988=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_RAM=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_MTK_V2=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/defenvs/tplink_be805-v1.20_env
+@@ -0,0 +1,3 @@
++bootcmd=ubi part ubi; ubi read ${loadaddr} fit; bootm ${loadaddr}
++loadaddr=0x46000000
++

--- a/package/boot/uboot-mediatek/patches/504-add-TP-Link-BE805-chainloader.patch
+++ b/package/boot/uboot-mediatek/patches/504-add-TP-Link-BE805-chainloader.patch
@@ -1,0 +1,193 @@
+--- /dev/null
++++ b/arch/arm/dts/mt7988a-tplink-be805.dts
+@@ -0,0 +1,102 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++// Author: Yanase Yuki <dev@zpc.st>
++/dts-v1/;
++#include "mt7988.dtsi"
++
++/ {
++	compatible = "tplink,be805", "mediatek,mt7988a";
++	model = "TP-Link BE805";
++
++	aliases {
++		serial0 = &uart0;
++	};
++
++	chosen {
++		stdout-path = "serial0:115200n8";
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x0 0x40000000 0x0 0x40000000>;
++	};
++};
++
++&pio {
++	spi0_pins: spi0-pins {
++		mux {
++			function = "spi";
++			groups = "spi0", "spi0_wp_hold";
++		};
++	};
++};
++
++&uart0 {
++	status = "okay";
++};
++
++&spi0 {
++	status = "okay";
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi0_pins>;
++	#address-cells = <1>;
++	#size-cells = <0>;
++
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	flash@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++
++		spi-max-frequency = <52000000>;
++		spi-tx-bus-width = <4>;
++		spi-rx-bus-width = <4>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				reg = <0x0 0x200000>;
++				label = "boot";
++				read-only;
++			};
++
++			partition@200000 {
++				reg = <0x200000 0x100000>;
++				label = "u-boot-env";
++				read-only;
++			};
++
++			partition@300000 {
++				reg = <0x300000 0x3200000>;
++				label = "ubi-stock";
++				read-only;
++			};
++
++			partition@3500000 {
++				compatible = "linux,ubi";
++				reg = <0x3500000 0x3200000>;
++				label = "ubi";
++			};
++
++			partition@6700000 {
++				reg = <0x6700000 0x800000>;
++				label = "userconfig";
++				read-only;
++			};
++
++			partition@6f00000 {
++				reg = <0x6f00000 0x800000>;
++				label = "tp_data";
++				read-only;
++			};
++		};
++	};
++};
++
+--- /dev/null
++++ b/configs/mt7988a_tplink_be805_defconfig
+@@ -0,0 +1,79 @@
++CONFIG_ARM=y
++CONFIG_ARM_SMCCC=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x44000000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7988a-tplink-be805"
++CONFIG_TARGET_MT7988=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_DEBUG_UART_BASE=0x11000000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++# CONFIG_EFI_LOADER is not set
++CONFIG_FIT=y
++# CONFIG_LEGACY_IMAGE_FORMAT is not set
++CONFIG_BOOTDELAY=3
++CONFIG_DEFAULT_FDT_FILE="mt7988a-tplink-be805"
++CONFIG_SYS_CBSIZE=512
++CONFIG_SYS_PBSIZE=1049
++CONFIG_LOGLEVEL=7
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_STACKPROTECTOR=y
++CONFIG_SYS_PROMPT="MT7988 Chainloader> "
++CONFIG_CMD_LICENSE=y
++# CONFIG_BOOTM_PLAN9 is not set
++# CONFIG_BOOTM_RTEMS is not set
++# CONFIG_BOOTM_VXWORKS is not set
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_XIMG is not set
++# CONFIG_CMD_EXPORTENV is not set
++# CONFIG_CMD_IMPORTENV is not set
++# CONFIG_CMD_UNZIP is not set
++CONFIG_CMD_MTD=y
++# CONFIG_CMD_PINMUX is not set
++CONFIG_CMD_RNG=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/tplink_be805_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_NO_NET=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_CLK=y
++# CONFIG_I2C is not set
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_DM_SPI_FLASH=y
++CONFIG_SPI_FLASH_SFDP_SUPPORT=y
++CONFIG_SPI_FLASH_EON=y
++CONFIG_SPI_FLASH_GIGADEVICE=y
++CONFIG_SPI_FLASH_ISSI=y
++CONFIG_SPI_FLASH_MACRONIX=y
++CONFIG_SPI_FLASH_SPANSION=y
++CONFIG_SPI_FLASH_STMICRO=y
++CONFIG_SPI_FLASH_WINBOND=y
++CONFIG_SPI_FLASH_XMC=y
++CONFIG_SPI_FLASH_XTX=y
++CONFIG_SPI_FLASH_MTD=y
++CONFIG_UBI_BLOCK=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7988=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_RAM=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_MTK_V2=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/defenvs/tplink_be805_env
+@@ -0,0 +1,3 @@
++bootcmd=ubi part ubi; ubi read ${loadaddr} fit; bootm ${loadaddr}
++loadaddr=0x46000000
++

--- a/target/linux/mediatek/dts/mt7988a-tplink-be805-v1.20.dts
+++ b/target/linux/mediatek/dts/mt7988a-tplink-be805-v1.20.dts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Author: Yanase Yuki <dev@zpc.st>
+/dts-v1/;
+#include "mt7988a-tplink-be805.dtsi"
+
+/ {
+	compatible = "tplink,be805-v1.20", "tplink,be805", "mediatek,mt7988a";
+	model = "TP-Link BE805 v1.20";
+};
+
+&gmac1 {
+	phy-handle = <&eth_phy1>;
+};
+
+&gmac2 {
+	phy-handle = <&eth_phy0>;
+};
+
+&mdio_bus {
+	reset-gpios = <&pio 71 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <100000>;
+	reset-post-delay-us = <221000>;
+
+	eth_phy0: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <0>;
+		max-speed = <10000>;
+	};
+
+	eth_phy1: ethernet-phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <1>;
+		max-speed = <10000>;
+	};
+};
+

--- a/target/linux/mediatek/dts/mt7988a-tplink-be805-v1.dts
+++ b/target/linux/mediatek/dts/mt7988a-tplink-be805-v1.dts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Author: Tuan Phan <pttuan@gmail.com>
+// Author: Yanase Yuki <dev@zpc.st>
+/dts-v1/;
+#include "mt7988a-tplink-be805.dtsi"
+
+/ {
+	compatible = "tplink,be805-v1", "tplink,be805", "mediatek,mt7988a";
+	model = "TP-Link BE805 v1";
+};
+
+&gmac1 {
+	phy-handle = <&eth_phy0>;
+	managed = "in-band-status";
+};
+
+&gmac2 {
+	phy-handle = <&eth_phy8>;
+	managed = "in-band-status";
+};
+
+&mdio_bus {
+	reset-gpios = <&pio 71 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <100000>;
+	reset-post-delay-us = <1000000>;
+	clock-frequency = <10500000>;
+
+	eth_phy0: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <0>;
+		max-speed = <10000>;
+		firmware-name = "Rhe-05.06-Candidate9-AQR_Mediatek_23B_P5_ID45824_LCLVER1.cld";
+		marvell,mdi-cfg-order = <0>;
+	};
+
+	eth_phy8: ethernet-phy@8 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <8>;
+		max-speed = <10000>;
+		firmware-name = "Rhe-05.06-Candidate9-AQR_Mediatek_23B_P5_ID45824_LCLVER1.cld";
+		marvell,mdi-cfg-order = <0>;
+	};
+};
+

--- a/target/linux/mediatek/dts/mt7988a-tplink-be805.dtsi
+++ b/target/linux/mediatek/dts/mt7988a-tplink-be805.dtsi
@@ -1,0 +1,460 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+// Author: Yanase Yuki <dev@zpc.st>
+/dts-v1/;
+#include "mt7988a.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/regulator/richtek,rt5190a-regulator.h>
+
+/ {
+	compatible = "tplink,be805", "mediatek,mt7988a";
+	chassis-type = "embedded";
+
+	aliases {
+		serial0 = &serial0;
+		label-mac-device = &gmac0;
+		led-boot = &led_center_blue;
+		led-failsafe = &led_center_red;
+		led-running = &led_center_green;
+		led-upgrade = &led_center_red;
+	};
+
+	chosen {
+		bootargs = "root=/dev/fit0 rootwait";
+		rootdisk = <&ubi_rootdisk>;
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0x0 0x40000000 0x0 0x40000000>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		led-button {
+			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
+			label = "led";
+			linux,code = <BTN_0>;
+		};
+
+		reset-button {
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+		};
+
+		wifi-button {
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+			label = "wifi";
+			linux,code = <KEY_WLAN>;
+		};
+
+		wps-button {
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	reg_3v3: regulator-3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "USB 3V3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "USB 5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+};
+
+&cci {
+	proc-supply = <&rt5190a_buck3>;
+};
+
+&cpu0 {
+	proc-supply = <&rt5190a_buck3>;
+};
+
+&cpu1 {
+	proc-supply = <&rt5190a_buck3>;
+};
+
+&cpu2 {
+	proc-supply = <&rt5190a_buck3>;
+};
+
+&cpu3 {
+	proc-supply = <&rt5190a_buck3>;
+};
+
+&pio {
+	i2c0_pins: i2c0-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+
+	i2c1_pins: i2c1-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c1_0";
+		};
+	};
+
+	mdio0_pins: mdio0-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio0";
+		};
+
+		conf {
+			pins = "SMI_0_MDC", "SMI_0_MDIO";
+			drive-strength = <8>;
+		};
+	};
+
+	spi0_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0_wp_hold", "spi0";
+		};
+	};
+};
+
+&serial0 {
+	status = "okay";
+};
+
+&i2c0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+
+	pmic@64 {
+		compatible = "richtek,rt5190a";
+		reg = <0x64>;
+
+		vin2-supply = <&rt5190a_buck1>;
+		vin3-supply = <&rt5190a_buck1>;
+		vin4-supply = <&rt5190a_buck1>;
+
+		regulators {
+			rt5190a_buck1: buck1 {
+				regulator-name = "rt5190a-buck1";
+				regulator-min-microvolt = <5090000>;
+				regulator-max-microvolt = <5090000>;
+				regulator-always-on;
+				regulator-allowed-modes = <RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+			};
+
+			buck2 {
+				regulator-name = "rt5190a-buck2-vcore";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-always-on;
+			};
+
+			rt5190a_buck3: buck3 {
+				regulator-name = "rt5190a-buck3-proc";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-always-on;
+			};
+
+			buck4 {
+				regulator-name = "rt5190a-buck4";
+				regulator-min-microvolt = <850000>;
+				regulator-max-microvolt = <850000>;
+				regulator-always-on;
+				regulator-allowed-modes = <RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+			};
+
+			ldo {
+				regulator-name = "rt5190a-ldo";
+				regulator-min-microvolt = <1200000>;
+				regulator-max-microvolt = <1200000>;
+				regulator-always-on;
+			};
+		};
+	};
+};
+
+&i2c1 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c1_pins>;
+
+	led-controller@32 {
+		compatible = "ti,lp55231";
+		reg = <0x32>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		clock-mode = /bits/ 8 <1>;
+
+		led_center_blue: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_BLUE>;
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			chan-name = "led-center-blue";
+		};
+
+		led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_BLUE>;
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			chan-name = "led-left-blue";
+		};
+
+		led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			chan-name = "led-right-blue";
+		};
+
+		led_center_green: led@3 {
+			reg = <3>;
+			color = <LED_COLOR_ID_GREEN>;
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			chan-name = "led-center-green";
+		};
+
+		led@4 {
+			reg = <4>;
+			color = <LED_COLOR_ID_GREEN>;
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			chan-name = "led-left-green";
+		};
+
+		led@5 {
+			reg = <5>;
+			color = <LED_COLOR_ID_GREEN>;
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			chan-name = "led-right-green";
+		};
+
+		led_center_red: led@6 {
+			reg = <6>;
+			color = <LED_COLOR_ID_RED>;
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			chan-name = "led-center-red";
+		};
+
+		led@7 {
+			reg = <7>;
+			color = <LED_COLOR_ID_RED>;
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			chan-name = "led-left-red";
+		};
+
+		led@8 {
+			reg = <8>;
+			color = <LED_COLOR_ID_RED>;
+			led-cur = /bits/ 8 <0x14>;
+			max-cur = /bits/ 8 <0x20>;
+			chan-name = "led-right-red";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_pins>;
+
+	flash: flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		// half of the max rating (104 MHz)
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		nand-ecc-engine = <&flash>;
+
+		// use stock firmware's value
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = <0 0 0 0 0>;
+	};
+};
+
+&ssusb0 {
+	status = "okay";
+	vusb33-supply = <&reg_3v3>;
+	vbus-supply = <&reg_5v>;
+};
+
+&ssusb1 {
+	status = "okay";
+	vusb33-supply = <&reg_3v3>;
+	vbus-supply = <&reg_5v>;
+};
+
+&pcie0 {
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+
+			nvmem-cells = <&mt7996_eeprom>, <&mac_base (-1)>;
+			nvmem-cell-names = "eeprom", "mac-address";
+		};
+	};
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&tphy {
+	status = "okay";
+};
+
+&xsphy {
+	status = "okay";
+};
+
+&gsw_port0 {
+	label = "lan1";
+};
+
+&gsw_port1 {
+	label = "lan2";
+};
+
+&gsw_port2 {
+	label = "lan4";
+};
+
+&gsw_port3 {
+	label = "lan3";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio0_pins>;
+};
+
+&gmac0 {
+	nvmem-cells = <&mac_base 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	nvmem-cells = <&mac_base 1>;
+	nvmem-cell-names = "mac-address";
+	phy-connection-type = "usxgmii";
+	label = "lan";
+};
+
+&gmac2 {
+	status = "okay";
+	nvmem-cells = <&mac_base 2>;
+	nvmem-cell-names = "mac-address";
+	phy-connection-type = "usxgmii";
+	label = "wan";
+};
+
+&flash {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			reg = <0x0 0x200000>;
+			label = "boot";
+			read-only;
+		};
+
+		partition@200000 {
+			reg = <0x200000 0x100000>;
+			label = "u-boot-env";
+			read-only;
+
+			nvmem-layout {
+				compatible = "u-boot,env";
+				env-size = <0x20000>;
+
+				mac_base: ethaddr {
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@300000 {
+			reg = <0x300000 0x3200000>;
+			label = "ubi-stock";
+		};
+
+		partition@3500000 {
+			compatible = "linux,ubi";
+			reg = <0x3500000 0x3200000>;
+			label = "ubi";
+
+			volumes {
+				ubi-volume-eeprom {
+					volname = "eeprom";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						mt7996_eeprom: eeprom@0 {
+							reg = <0x0 0x1e00>;
+						};
+					};
+				};
+
+				ubi_rootdisk: ubi-volume-fit {
+					volname = "fit";
+				};
+			};
+		};
+
+		partition@6700000 {
+			reg = <0x6700000 0x800000>;
+			label = "userconfig";
+			read-only;
+		};
+
+		partition@6f00000 {
+			reg = <0x6f00000 0x800000>;
+			label = "tp_data";
+			read-only;
+		};
+	};
+};
+

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -207,6 +207,9 @@ mediatek_setup_interfaces()
 	tplink,be450)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 eth2" eth1
 		;;
+	tplink,be805-v1.20)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan" wan
+		;;
 	tplink,re6000xd)
 		ucidef_set_interface_lan "lan1 lan2 eth1"
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -234,6 +234,10 @@ mediatek_setup_interfaces()
 	tplink,be450-ubi)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 eth2" eth1
 		;;
+	tplink,be805-v1|\
+	tplink,be805-v1.20)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan" wan
+		;;
 	tplink,re6000xd)
 		ucidef_set_interface_lan "lan1 lan2 eth1"
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -19,6 +19,7 @@ preinit_mount_cfg_part() {
 	tplink,archer-ax80-v1|\
 	tplink,archer-ax80-v1-eu|\
 	tplink,be450|\
+	tplink,be805-v1.20|\
 	tplink,re6000xd)
 		mount_ubi_part "tp_data" "tp_data"
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -19,6 +19,8 @@ preinit_mount_cfg_part() {
 	tplink,archer-ax80-v1|\
 	tplink,archer-ax80-v1-eu|\
 	tplink,be450|\
+	tplink,be805-v1|\
+	tplink,be805-v1.20|\
 	tplink,re6000xd)
 		mount_ubi_part "tp_data" "tp_data"
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -153,6 +153,7 @@ platform_do_upgrade() {
 	routerich,ax3000-ubootmod|\
 	routerich,be7200|\
 	snr,snr-cpe-ax2|\
+	tplink,be805-v1.20|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088|\
@@ -352,6 +353,7 @@ platform_check_image() {
 	qihoo,360t7|\
 	qihoo,360t7-ubi|\
 	routerich,ax3000-ubootmod|\
+	tplink,be805-v1.20|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -183,6 +183,8 @@ platform_do_upgrade() {
 	snr,snr-cpe-ax2|\
 	teralink,tl3020-256mb|\
 	tplink,be450-ubi|\
+	tplink,be805-v1|\
+	tplink,be805-v1.20|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088|\
@@ -424,6 +426,8 @@ platform_check_image() {
 	routerich,ax3000-ubootmod|\
 	teralink,tl3020-256mb|\
 	tplink,be450-ubi|\
+	tplink,be805-v1|\
+	tplink,be805-v1.20|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -49,6 +49,10 @@ define Build/mt7988-bl31-uboot
 	cat $(STAGING_DIR_IMAGE)/mt7988_$1-u-boot.fip >> $@
 endef
 
+define Build/mt7988-uboot-raw
+	cat $(STAGING_DIR_IMAGE)/mt7988_$1-u-boot.bin >> $@
+endef
+
 define Build/simplefit
 	cp $@ $@.tmp 2>/dev/null || true
 	ptgen -g -o $@.tmp -a 1 -l 1024 \
@@ -3021,6 +3025,28 @@ define Device/tplink_be450
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += tplink_be450
+
+define Device/tplink_be805-v1.20
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := BE805 v1.20
+  DEVICE_DTS := mt7988a-tplink-be805-v1.20
+  DEVICE_DTS_DIR := ../dts
+  IMAGE_SIZE := 40960k
+  KERNEL_IN_UBI := 1
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  KERNEL := kernel-bin | gzip
+  IMAGE/sysupgrade.bin := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
+	check-size | append-metadata
+  ARTIFACTS := second-u-boot.bin
+  ARTIFACT/second-u-boot.bin := mt7988-uboot-raw tplink_be805-v120 | gzip | \
+	uImage gzip -T standalone -a 0x44000000 -e 0x44000000 -n "OpenWrt U-Boot Chainloader"
+  DEVICE_PACKAGES := kmod-leds-lp5523 kmod-mt7996-firmware \
+	kmod-usb3 mt7988-wo-firmware
+endef
+TARGET_DEVICES += tplink_be805-v1.20
 
 define Device/tplink_eap683-lr
   DEVICE_VENDOR := TP-Link

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -49,6 +49,10 @@ define Build/mt7988-bl31-uboot
 	cat $(STAGING_DIR_IMAGE)/mt7988_$1-u-boot.fip >> $@
 endef
 
+define Build/mt7988-uboot-raw
+	cat $(STAGING_DIR_IMAGE)/mt7988_$1-u-boot.bin >> $@
+endef
+
 define Build/simplefit
 	cp $@ $@.tmp 2>/dev/null || true
 	ptgen -g -o $@.tmp -a 1 -l 1024 \
@@ -3340,6 +3344,44 @@ define Device/tplink_be450-ubi
   ARTIFACT/preloader.bin := mt7988-bl2 spim-nand-ubi-ddr4
 endef
 TARGET_DEVICES += tplink_be450-ubi
+
+define Device/tplink_be805
+  DEVICE_VENDOR := TP-Link
+  DEVICE_DTS_DIR := ../dts
+  IMAGE_SIZE := 40960k
+  KERNEL_IN_UBI := 1
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  UBINIZE_OPTS := -E 5
+  KERNEL := kernel-bin | libdeflate-gzip
+  ARTIFACTS := second-u-boot.bin
+  ARTIFACT/second-u-boot.bin := mt7988-uboot-raw tplink_be805 | libdeflate-gzip | \
+	uImage gzip -T standalone -a 0x44000000 -e 0x44000000 -n "OpenWrt U-Boot Chainloader"
+endef
+
+define Device/tplink_be805-v1
+$(call Device/tplink_be805)
+  DEVICE_MODEL := BE805 v1
+  DEVICE_DTS := mt7988a-tplink-be805-v1
+  DEVICE_PACKAGES := kmod-leds-lp5523 kmod-mt7996-firmware \
+	kmod-phy-aquantia kmod-usb3 mt7988-wo-firmware
+  IMAGE/sysupgrade.bin := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
+	check-size | append-metadata
+endef
+TARGET_DEVICES += tplink_be805-v1
+
+define Device/tplink_be805-v1.20
+$(call Device/tplink_be805)
+  DEVICE_MODEL := BE805 v1.20
+  DEVICE_DTS := mt7988a-tplink-be805-v1.20
+  DEVICE_PACKAGES := kmod-leds-lp5523 kmod-mt7996-firmware \
+	kmod-usb3 mt7988-wo-firmware rtl826x-firmware
+  IMAGE/sysupgrade.bin := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
+	check-size | append-metadata
+endef
+TARGET_DEVICES += tplink_be805-v1.20
 
 define Device/tplink_eap683-lr
   DEVICE_VENDOR := TP-Link


### PR DESCRIPTION
This Pull Request adds support for TP-Link BE805 v1.20.
Other revision may not work due to hardware differences.
For install instructions, please see commit messages.

Device info:
- SoC: MT7988A
- DRAM: 1024MiB
- SPI-NAND: 128MiB
- LED: TI LP55231 (3x RGB LED, 9 channels)
- PMIC: MT6682AN
- 1G LAN: Internal MT753x
- 10G PHY: RTL8261BE x2
- Wi-FI: MT7996AV MT7977AN MT7977BN MT7976GN

~~Current problem: 10G WAN sometimes unstable after (re)boot, and need to wait few minutes for link up. 10G LAN doesn't have such problem.~~
Update: Patching of rtl8261n phy driver to support rtl8261be  seems fixed this problem.
So I think this problem will be fixed after merge of #20450 .

Since I don't have 10G env, I tested 10G LAN/WAN with 1G connection only.