### PR TITLE
mediatek: filogic: fix devicetree compiler warnings

### DIFF
--- a/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
+++ b/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
@@ -371,7 +371,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			partition@00000 {
+			partition@0 {
 				label = "bl2";
 				reg = <0x00000 0x0040000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-bazis-ax3000wm.dts
+++ b/target/linux/mediatek/dts/mt7981b-bazis-ax3000wm.dts
@@ -277,6 +277,8 @@
 	status = "okay";
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
+	#address-cells = <1>;
+	#size-cells = <0>;
 	
 	band@0 {
 		reg = <0>;

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
@@ -253,6 +253,8 @@
 	status = "okay";
 	nvmem-cell-names = "eeprom";
 	nvmem-cells = <&eeprom_factory_0>;
+	#address-cells = <1>;
+	#size-cells = <0>;
 
 	band@0 {
 		reg = <0>;

--- a/target/linux/mediatek/dts/mt7981b-netgear-eax17.dts
+++ b/target/linux/mediatek/dts/mt7981b-netgear-eax17.dts
@@ -251,6 +251,8 @@
 	status = "okay";
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
+	#address-cells = <1>;
+	#size-cells = <0>;
 
 	band@0 {
 		reg = <0>;

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dtsi
@@ -253,6 +253,8 @@
 	status = "okay";
 	nvmem-cells = <&eeprom_factory>;
 	nvmem-cell-names = "eeprom";
+	#address-cells = <1>;
+	#size-cells = <0>;
 
 	band@0 {
 		reg = <0>;

--- a/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
+++ b/target/linux/mediatek/dts/mt7986a-iptime-ax7800m-6e.dts
@@ -368,13 +368,15 @@
 
 	pcie@0,0 {
 		reg = <0x0000 0 0 0 0>;
-		#address-cells = <0x03>;
-		#size-cells = <0x02>;
+		#address-cells = <3>;
+		#size-cells = <2>;
 
 		wifi@0,0 {
 			reg = <0x0000 0 0 0 0>;
 			nvmem-cells = <&eeprom_factory_a0000>;
 			nvmem-cell-names = "eeprom";
+			#address-cells = <1>;
+			#size-cells = <0>;
 
 			band@0 {
 				reg = <0>;

--- a/target/linux/mediatek/dts/mt7986b-buffalo-wsr-6000ax8.dts
+++ b/target/linux/mediatek/dts/mt7986b-buffalo-wsr-6000ax8.dts
@@ -398,6 +398,8 @@
 	nvmem-cells = <&eeprom_factory_0>, <&precal_factory_1010>;
 	nvmem-cell-names = "eeprom", "precal";
 	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
 
 	band@0 {
 		reg = <0>;

--- a/target/linux/mediatek/dts/mt7987a-tenda-be12-pro.dts
+++ b/target/linux/mediatek/dts/mt7987a-tenda-be12-pro.dts
@@ -352,6 +352,8 @@
 	pcie@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		device_type = "pci";
+		#address-cells = <3>;
+		#size-cells = <2>;
 
 		mt7992@0,0 {
 			compatible = "mediatek,mt76";


### PR DESCRIPTION
This PR fixes some dts syntax errors.
