### PR TITLE
ramips: wn575a3: fix eeprom size for 5ghz wifi

### DIFF
--- a/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
+++ b/target/linux/ramips/dts/mt7628an_wavlink_wl-wn575a3.dts
@@ -111,7 +111,7 @@
 					};
 
 					eeprom_factory_8000: eeprom@8000 {
-						reg = <0x8000 0x200>;
+						reg = <0x8000 0x4da8>;
 					};
 
 					macaddr_factory_28: macaddr@28 {


### PR DESCRIPTION
MT7613 uses 4da8 for eeprom size. eeprom + calibration.

ping @davkdavk