### PR TITLE
ramips: dts: adjust mt7621 peripherals address range

### DIFF
--- a/target/linux/ramips/dts/mt7621.dtsi
+++ b/target/linux/ramips/dts/mt7621.dtsi
@@ -360,7 +360,7 @@
 
 	sdhci: mmc@1e130000 {
 		compatible = "mediatek,mt7620-mmc", "ralink,mt7620-sdhci";
-		reg = <0x1e130000 0x4000>;
+		reg = <0x1e130000 0x8000>;
 
 		bus-width = <4>;
 		max-frequency = <50000000>;
@@ -428,7 +428,7 @@
 
 	gic: interrupt-controller@1fbc0000 {
 		compatible = "mti,gic";
-		reg = <0x1fbc0000 0x2000>;
+		reg = <0x1fbc0000 0x20000>;
 
 		interrupt-controller;
 		#interrupt-cells = <3>;
@@ -474,7 +474,7 @@
 
 	ethernet: ethernet@1e100000 {
 		compatible = "mediatek,mt7621-eth";
-		reg = <0x1e100000 0x10000>;
+		reg = <0x1e100000 0xe000>;
 
 		clocks = <&sysc MT7621_CLK_FE>, <&sysc MT7621_CLK_ETH>;
 		clock-names = "fe", "ethif";

--- a/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_eap615-wall-v1.dts
@@ -59,10 +59,6 @@
 	};
 };
 
-&ethernet {
-	reg = <0x1e100000 0xe000>;
-};
-
 &spi0 {
 	status = "okay";
 


### PR DESCRIPTION
Adjust the memory remap range according to the mt7621 programming guide to ensure that the driver can correctly access the peripheral registers.