### PR TITLE
xptables: prefer nft variants over legacy

### DIFF
--- a/package/network/utils/arptables/Makefile
+++ b/package/network/utils/arptables/Makefile
@@ -25,7 +25,7 @@ define Package/arptables-legacy
   TITLE:=ARP firewalling software
   DEPENDS:=+kmod-arptables
   URL:=https://git.netfilter.org/arptables/
-  PROVIDES:=arptables
+  PROVIDES:=@arptables
   ALTERNATIVES:=\
     200:/usr/sbin/arptables:/usr/sbin/arptables-legacy
 endef

--- a/package/network/utils/ebtables/Makefile
+++ b/package/network/utils/ebtables/Makefile
@@ -28,7 +28,7 @@ define Package/ebtables-legacy
   DEPENDS:=+kmod-ebtables
   TITLE:=Ethernet bridge firewall administration utility
   URL:=https://ebtables.netfilter.org/
-  PROVIDES:=ebtables
+  PROVIDES:=@ebtables
   ALTERNATIVES:=\
     200:/usr/sbin/ebtables:/usr/sbin/ebtables-legacy
 endef

--- a/package/network/utils/iptables/Makefile
+++ b/package/network/utils/iptables/Makefile
@@ -115,7 +115,8 @@ define Package/arptables-nft
 $(call Package/iptables/Default)
   DEPENDS:=+kmod-nft-arp +xtables-nft +kmod-arptables
   TITLE:=ARP firewall administration tool nft
-  PROVIDES:=arptables
+  PROVIDES:=@arptables
+  DEFAULT_VARIANT:=1
   ALTERNATIVES:=\
     300:/usr/sbin/arptables:xtables-nft-multi \
     300:/usr/sbin/arptables-restore:xtables-nft-multi \
@@ -129,7 +130,8 @@ define Package/ebtables-nft
 $(call Package/iptables/Default)
   DEPENDS:=+kmod-nft-bridge +xtables-nft +kmod-ebtables
   TITLE:=Bridge firewall administration tool nft
-  PROVIDES:=ebtables
+  PROVIDES:=@ebtables
+  DEFAULT_VARIANT:=1
   ALTERNATIVES:=\
     300:/usr/sbin/ebtables:xtables-nft-multi \
     300:/usr/sbin/ebtables-restore:xtables-nft-multi \


### PR DESCRIPTION
Set the default variant on "arptables-nft" and "ebtables-nft" to make them the preferred package when  installed as a dependency.

Link: https://github.com/openwrt/openwrt/pull/22448#issuecomment-4078583377
