### PR TITLE
[25.12] ath79: remove kmod-ath9k and wpad from Mikrotik RB750r2

### DIFF
--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -24,6 +24,7 @@ define Device/mikrotik_routerboard-750-r2
   $(Device/mikrotik_nor)
   SOC := qca9533
   DEVICE_MODEL := RouterBOARD 750 r2 (hEX lite)
+  DEVICE_PACKAGES := -kmod-ath9k -wpad-basic-mbedtls
   IMAGE_SIZE := 16256k
   SUPPORTED_DEVICES += rb-750-r2
 endef


### PR DESCRIPTION
The RB750r2 (HEXLite) does not have wifi and those packages bloat the image by a significant amount. When building a custom image with WireGuard and booting that from initramfs, there wasn't enough space left in tmpfs to upload and flash the squashfs image. Investigating what packages I could remove, I discovered these unneeded ones.


Link: https://github.com/openwrt/openwrt/pull/22134

(cherry picked from commit 42cd48678745d5a99720e03595c53230a3c078f9)
