### PR TITLE
wifi-scripts: fix hostapd config for 160MHz

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -354,10 +354,10 @@ function device_htmode_append(config) {
 			config.vht_capab += '[BF-ANTENNA-' + min(((vht_capab >> 13) & 3) + 1, config.beamformer_antennas) + ']';
 
 		/* supported Channel widths */
-		if (((vht_capab & 0xc) == 4 || (vht_capab & 0xc) == 8) && config.vht160 >= 1)
-			config.vht_capab += '[VHT160]';
 		if ((vht_capab & 0xc) == 8 && config.vht160 >= 2)
 			config.vht_capab += '[VHT160-80PLUS80]';
+		else if (((vht_capab & 0xc) == 4 || (vht_capab & 0xc) == 8) && config.vht160 >= 1)
+			config.vht_capab += '[VHT160]';
 
 		/* maximum MPDU length */
 		if ((vht_capab & 3) > 1 && config.vht_max_mpdu >= 11454)


### PR DESCRIPTION
Fix a logic error that under certain circumstances (ie. 160MHz AP on VHT80+80 capable hardware) could create an invalid `hostapd-phyX.conf` which contains both, [VHT160-80PLUS80] as well as [VHT160] in its `vht_capab` option. Such AP will fail to start with the message:

`daemon.err: hostapd: Configured VHT capability [VHT_CAP_SUPP_CHAN_WIDTH_MASK] exceeds max value supported by the driver (3 > 2)`

This should be committed into the main as well as 25.12 branches.

Fixes: #22481
Fixes: #22436