### PR TITLE
mpc85xx: p1010: Correct WiFi switch behavior for TL-WDR4900v1

### DIFF
--- a/target/linux/mpc85xx/Makefile
+++ b/target/linux/mpc85xx/Makefile
@@ -19,8 +19,7 @@ KERNELNAME:=zImage
 include $(INCLUDE_DIR)/target.mk
 
 DEFAULT_PACKAGES += \
-	kmod-input-core kmod-input-gpio-keys kmod-button-hotplug \
-	kmod-leds-gpio kmod-ath9k wpad-basic-mbedtls kmod-usb2 \
-	uboot-envtools kmod-crypto-hw-talitos
+	kmod-gpio-button-hotplug kmod-leds-gpio kmod-ath9k wpad-basic-mbedtls \
+	kmod-usb2 uboot-envtools kmod-crypto-hw-talitos
 
 $(eval $(call BuildTarget))

--- a/target/linux/mpc85xx/Makefile
+++ b/target/linux/mpc85xx/Makefile
@@ -18,8 +18,7 @@ KERNELNAME:=zImage
 include $(INCLUDE_DIR)/target.mk
 
 DEFAULT_PACKAGES += \
-	kmod-input-core kmod-input-gpio-keys kmod-button-hotplug \
-	kmod-leds-gpio kmod-ath9k wpad-basic-mbedtls kmod-usb2 \
-	uboot-envtools kmod-crypto-hw-talitos
+	kmod-gpio-button-hotplug kmod-leds-gpio kmod-ath9k wpad-basic-mbedtls \
+	kmod-usb2 uboot-envtools kmod-crypto-hw-talitos
 
 $(eval $(call BuildTarget))

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/tl-wdr4900-v1.dts
@@ -460,6 +460,8 @@
 			label = "RFKILL switch";
 			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RFKILL>;
+			linux,input-type = <EV_SW>;
+			debounce-interval = <60>;
 		};
 	};
 };


### PR DESCRIPTION
This PR corrects the WiFi flipswitch behavior for the TP-Link TL-WDR4900v1. Currently, the switch is configured in the DTS like a pushbutton, which means it has to be toggled to "On" position, then back to "Off" in order to have an effect. The corrected behavior after applying this PR is honoring the switch _position_ "On" for WiFi enabled, and "Off" for WiFi disabled.

As a prerequisite, replace the standard Linux input subsystem (`kmod-input-core` et al), that is currently used for `mpc85xx`, with the more resource-friendly `gpio-button-hotplug` driver. This change has already been done over a decade ago for other targets (or they were never using the full input subsystem in the first place) and has probably only been missed for `mpc85xx` due to the low popularity of the target.

The PR is divided into two commits:
- First commit replaces the input subsystem for the whole target
- Second commit updates the DTS for TP-Link TL-WDR4900v1

I've skimmed through all supported `mpc85xx` devices' DTS and don't expect any regression to occur in regards to the input subsystem change. In addition, I'm using this for my personal builds since OpenWrt 23.05 already, therefore it can be counted as thoroughly tested on about a third of all supported devices from this target.

For test/review, also pinging @CHKDSK88, who I know owns a few other supported `mpc85xx` devices that I don't own.

Fixes: #13552
