### PR TITLE
mt76: build mt7622-firmware only for mt7622 sub-target

### DIFF
--- a/package/kernel/mt76/Makefile
+++ b/package/kernel/mt76/Makefile
@@ -187,7 +187,7 @@ endef
 define KernelPackage/mt7622-firmware
   $(KernelPackage/mt76-default)
   TITLE:=MediaTek MT7622 firmware
-  DEPENDS+=+kmod-mt7615e
+  DEPENDS+=@TARGET_mediatek_mt7622 +kmod-mt7615e
 endef
 
 define KernelPackage/mt7663-firmware-ap


### PR DESCRIPTION
kmod-mt7622-firmware package is only used by mt7622 SoC builtin WiFi.
