### PR TITLE
ath79: tiny: set default BLOCKSIZE to 4 KB

### DIFF
--- a/target/linux/ath79/image/Makefile
+++ b/target/linux/ath79/image/Makefile
@@ -68,7 +68,11 @@ define Device/Default
   DEVICE_DTS = $$(SOC)_$(1)
   PROFILES = Default
   MTDPARTS :=
+ifeq ($(SUBTARGET),tiny)
+  BLOCKSIZE := 4k
+else
   BLOCKSIZE := 64k
+endif
   KERNEL := kernel-bin | append-dtb | lzma | uImage lzma
   KERNEL_INITRAMFS := kernel-bin | append-dtb | lzma | uImage lzma
   LOADER_KERNEL_MAGIC :=

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -3,7 +3,6 @@ include ./common-tp-link.mk
 define Device/tplink_rex5x
   $(Device/tplink-safeloader)
   SOC := qca9558
-  BLOCKSIZE := 4k
   IMAGE_SIZE := 7680k
   KERNEL_SIZE := 6016k
   DEVICE_PACKAGES := kmod-ath10k-ct-smallbuffers ath10k-firmware-qca988x-ct

--- a/target/linux/ath79/image/tiny.mk
+++ b/target/linux/ath79/image/tiny.mk
@@ -81,7 +81,6 @@ TARGET_DEVICES += dlink_dir-869-a1
 
 define Device/engenius_eap350-v1
   $(Device/senao_loader_okli)
-  BLOCKSIZE := 4k
   SOC := ar7242
   DEVICE_VENDOR := EnGenius
   DEVICE_MODEL := EAP350
@@ -95,7 +94,6 @@ TARGET_DEVICES += engenius_eap350-v1
 
 define Device/engenius_ecb350-v1
   $(Device/senao_loader_okli)
-  BLOCKSIZE := 4k
   SOC := ar7242
   DEVICE_VENDOR := EnGenius
   DEVICE_MODEL := ECB350
@@ -124,7 +122,6 @@ TARGET_DEVICES += engenius_enh202-v1
 define Device/nec_wf1200hp
   DEVICE_MODEL := Aterm WF1200HP
   SOC := ar9344
-  BLOCKSIZE := 4k
   IMAGE_SIZE := 7936k
   NEC_FW_TYPE := H047
   $(Device/nec-netbsd-aterm)
@@ -137,7 +134,6 @@ TARGET_DEVICES += nec_wf1200hp
 define Device/nec_wf1200hp2
   DEVICE_MODEL := Aterm WF1200HP2
   SOC := ar9344
-  BLOCKSIZE := 4k
   IMAGE_SIZE := 7936k
   NEC_FW_TYPE := H053
   $(Device/nec-netbsd-aterm)
@@ -150,7 +146,6 @@ TARGET_DEVICES += nec_wf1200hp2
 define Device/nec_wg600hp
   DEVICE_MODEL := Aterm WG600HP
   SOC := ar9344
-  BLOCKSIZE := 4k
   IMAGE_SIZE := 7936k
   NEC_FW_TYPE := H044
   $(Device/nec-netbsd-aterm)
@@ -160,7 +155,6 @@ TARGET_DEVICES += nec_wg600hp
 define Device/nec_wr8750n
   SOC := ar9344
   DEVICE_MODEL := Aterm WR8750N
-  BLOCKSIZE := 4k
   IMAGE_SIZE := 7936k
   NEC_FW_TYPE := H033a
   $(Device/nec-netbsd-aterm)
@@ -170,7 +164,6 @@ TARGET_DEVICES += nec_wr8750n
 define Device/nec_wr9500n
   SOC := ar9344
   DEVICE_MODEL := Aterm WR9500N
-  BLOCKSIZE := 4k
   IMAGE_SIZE := 16128k
   NEC_FW_TYPE := H033
   $(Device/nec-netbsd-aterm)
@@ -193,7 +186,6 @@ define Device/sitecom_wlr-7100
   DEVICE_VENDOR := Sitecom
   DEVICE_MODEL := WLR-7100
   DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct-smallbuffers kmod-usb2
-  BLOCKSIZE := 4k
   IMAGES += factory.dlf
   IMAGE/factory.dlf := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | check-size | \


### PR DESCRIPTION
The NOR Flash mtd erase block size is 4 KB on ath79 tiny sub-target. Squashfs-split driver always check and create the jffs2 rootfs_data partition on the first free block. However, sysupgrade script append the config backup to the end of the sysupgrade image. If we pad the image to the 64 KB boundary, the kernel will unable to find a valid jffs2 partition and then recreate the rootfs_data partition. Users may lose theirs config during upgrades. Fix this issue by setting BLOCKSIZE to 4 KB so that the sysupgrade image can be aligned to the 4 KB boundary.

Fixes: https://github.com/openwrt/openwrt/issues/20495