### PR TITLE
mediatek: add support for TP-Link VX830v

### DIFF
--- a/target/linux/mediatek/Makefile
+++ b/target/linux/mediatek/Makefile
@@ -8,7 +8,7 @@ BOARDNAME:=MediaTek ARM
 SUBTARGETS:=filogic mt7622 mt7623 mt7629
 FEATURES:=dt-overlay emmc fpu gpio nand pci pcie rootfs-part separate_ramdisk squashfs usb
 
-KERNEL_PATCHVER:=6.12
+KERNEL_PATCHVER:=6.6
 
 include $(INCLUDE_DIR)/target.mk
 DEFAULT_PACKAGES += \

--- a/target/linux/mediatek/dts/mt7986a-tplink-vx830v.dts
+++ b/target/linux/mediatek/dts/mt7986a-tplink-vx830v.dts
@@ -1,0 +1,490 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR MIT)
+
+/dts-v1/;
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	compatible = "tplink,vx830v", "mediatek,mt7986a";
+	model = "TP-Link VX830v";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;	/* 512 MiB */
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		/* GPIOs decoded from vendor tp_gpio.ko btn table */
+
+		reset {
+			label = "reset";
+			gpios = <&pio 26 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&pio 24 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		wifi {
+			label = "wifi";
+			gpios = <&pio 25 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		/* GPIOs decoded from vendor tp_gpio.ko led table */
+
+		led_power: led-power {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 10 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+
+		led-inet-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-inet-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-sfp {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "sfp";
+			gpios = <&pio 43 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-lan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			gpios = <&pio 32 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-lan1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&pio 46 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-lan2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&pio 49 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-lan3 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&pio 48 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-ewan {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			function-enumerator = <2>;
+			gpios = <&pio 47 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-phone-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "phone";
+			gpios = <&pio 17 GPIO_ACTIVE_LOW>;
+		};
+
+		led-usb {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_USB;
+			gpios = <&pio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led-phone-red {
+			color = <LED_COLOR_ID_RED>;
+			function = "phone";
+			gpios = <&pio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		led-dsl {
+			color = <LED_COLOR_ID_GREEN>;
+			function = "dsl";
+			gpios = <&pio 45 GPIO_ACTIVE_HIGH>;
+		};
+
+		led-los {
+			color = <LED_COLOR_ID_RED>;
+			function = "los";
+			gpios = <&pio 63 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	/* GPON / combo SFP cage on WAN (mac@1) — GPIOs from vendor DTS */
+	sfp_wan: sfp-wan {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		maximum-power-milliwatt = <2000>;
+		tx-disable-gpios = <&pio 13 GPIO_ACTIVE_HIGH>;
+		los-gpios = <&pio 27 GPIO_ACTIVE_HIGH>;
+		rate-select0-gpios = <&pio 28 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "2500base-x";
+		phy-handle = <&phy15>;
+		label = "wan";
+		/*
+		 * Vendor DTS defines a combo port (copper PHY + SFP) here.
+		 * To use the GPON SFP module instead of the copper PHY,
+		 * replace the phy-handle line above with:
+		 *   managed = "in-band-status";
+		 *   sfp = <&sfp_wan>;
+		 */
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+/* EN8811H reset GPIOs held HIGH (deasserted) via gpio-hog in &pio — no Linux GPIO/reset manipulation */
+
+		/*
+		 * Airoha EN8811H 2.5 GbE PHYs.
+		 * MDIO addresses 0x0e / 0x0f taken from the vendor DTS
+		 * (reg = <0x0e> and reg = <0x0f>).
+		 */
+
+		/* Connected to switch port 5 — lan3 */
+		phy14: ethernet-phy@e {
+			compatible = "ethernet-phy-id03a2.a411";
+			reg = <14>;
+			phy-mode = "2500base-x";
+			airoha,pnswap-rx;
+		};
+
+		/* Connected to gmac1 — WAN */
+		phy15: ethernet-phy@f {
+			compatible = "ethernet-phy-id03a2.a411";
+			reg = <15>;
+			phy-mode = "2500base-x";
+			airoha,pnswap-rx;
+		};
+
+		switch: switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "lan0";
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan2";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan1";
+				};
+
+				/*
+				 * port@3 is not wired on the VX830v
+				 * (absent from vendor DTS).
+				 */
+
+				port@5 {
+					reg = <5>;
+					label = "lan3";
+					phy-mode = "2500base-x";
+					phy-handle = <&phy14>;
+				};
+
+				port@6 {
+					reg = <6>;
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&i2c0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c_pins>;
+};
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie_pins>;
+	status = "okay";
+};
+
+&pio {
+	/*
+	 * EN8811H PHY reset lines (active-low RESET_N).
+	 * gpio-hog forces them HIGH (deasserted) during GPIO controller
+	 * init, before any PHY driver probes.  Without this the kernel
+	 * pinctrl resets the pins to input/floating and the PHY MCUs
+	 * never become ready.
+	 */
+	phy14_rst: phy14-rst-hog {
+		gpio-hog;
+		gpios = <6 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "en8811h-a-reset";
+	};
+
+	phy15_rst: phy15-rst-hog {
+		gpio-hog;
+		gpios = <11 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "en8811h-b-reset";
+	};
+
+	i2c_pins: i2c-pins-3-4 {
+		mux {
+			function = "i2c";
+			groups = "i2c";
+		};
+	};
+
+	pcie_pins: pcie-pins-9-10-41 {
+		mux {
+			function = "pcie";
+			groups = "pcie_clk", "pcie_pereset";
+		};
+	};
+
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <8>;
+			mediatek,pull-up-adv = <0>;	/* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <8>;
+			mediatek,pull-down-adv = <0>;	/* bias-disable */
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <4>;
+		};
+	};
+
+
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	num-cs = <2>;
+	cs-gpios = <0>, <0>;
+	status = "okay";
+
+	/* Vendor DTS places the NAND on CS1 (reg = <1>) */
+	spi_nand: spi_nand@1 {
+		compatible = "spi-nand";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <1>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x0 0x200000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "u-boot-env";
+				reg = <0x200000 0x100000>;
+			};
+
+			partition@300000 {
+				label = "misc_ro";
+				reg = <0x300000 0x600000>;
+				read-only;
+
+				compatible = "nvmem-cells";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				eeprom_caldata: eeprom@0 {
+					reg = <0x0 0x1000>;
+				};
+			};
+
+			partition@900000 {
+				label = "misc_rw";
+				reg = <0x900000 0x600000>;
+			};
+
+			partition@f00000 {
+				label = "ubi0";
+				reg = <0xf00000 0x2800000>;
+			};
+
+			partition@3700000 {
+				label = "ubi1";
+				reg = <0x3700000 0x2800000>;
+			};
+
+			partition@5f00000 {
+				label = "misc_rw_bak";
+				reg = <0x5f00000 0x600000>;
+			};
+
+			partition@6500000 {
+				label = "bflag";
+				reg = <0x6500000 0x600000>;
+			};
+
+			partition@6b00000 {
+				label = "misc_isp";
+				reg = <0x6b00000 0x600000>;
+			};
+
+			// Partizione custom: spazio libero da 0x7800000 a 0xf000000 (120MB)
+			partition@7800000 {
+				label = "openwrt_ext";
+				reg = <0x7800000 0x7800000>; // 120MB
+			};
+
+			// Partizione "whole": tutta la NAND (read-only, solo per dump)
+			partition@f000000 {
+				label = "whole";
+				reg = <0x0 0x10000000>; // 256MB
+				read-only;
+			};
+		};
+	};
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&pcie_phy {
+	status = "okay";
+};
+
+&ssusb {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+
+	nvmem-cells = <&eeprom_caldata>;
+	nvmem-cell-names = "eeprom";
+};
+

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -6,34 +6,15 @@ board=$(board_name)
 board_config_update
 
 case $board in
-airpi,ap3000m)
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "orange:wlan-2ghz" "phy0-ap0" "link tx rx"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "white:wlan-5ghz" "phy1-ap0" "link tx rx"
-	;;
 abt,asr3000)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1"
 	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:wlan-2ghz" "phy0-ap0"
 	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan-5ghz" "phy1-ap0"
 	;;
-acer,predator-w6|\
-acer,predator-w6d)
-	ucidef_set_led_netdev "internet" "INTERNET" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100 link_1000 tx rx"
-	ucidef_set_led_netdev "internet" "INTERNET" "mdio-bus:06:green:wan" "eth1" "link_2500 tx rx"
-	;;
-acer,predator-w6x-stock|\
-acer,predator-w6x-ubootmod)
-	ucidef_set_led_netdev "wan" "wan" "rgb:status" "eth1"
-	;;
-asus,rt-ax52|\
-asus,rt-ax57m|\
-snr,snr-cpe-ax2)
+asus,rt-ax52)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
 	;;
-asus,tuf-ax4200)
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:white:wan" "eth1" "link tx rx"
-	;;
-asus,tuf-ax4200q|\
-asus,tuf-ax6000)
+asus,tuf-ax4200q)
 	ucidef_set_led_netdev "lan5" "LAN5" "mdio-bus:05:white:lan" "lan5" "link tx rx"
 	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:white:wan" "eth1" "link tx rx"
 	;;
@@ -52,29 +33,17 @@ bananapi,bpi-r3-mini)
 	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan-2" "phy1-ap0"
 	;;
 bananapi,bpi-r4|\
-bananapi,bpi-r4-2g5|\
 bananapi,bpi-r4-poe)
-	ucidef_set_led_netdev "wan" "wan" "mt7530-0:00:green:wan" "wan" "link tx rx"
+	ucidef_set_led_netdev "wan" "wan" "mt7530-0:00:green:lan" "wan" "link tx rx"
 	ucidef_set_led_netdev "lan1" "lan1" "mt7530-0:01:green:lan" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan2" "mt7530-0:02:green:lan" "lan2" "link tx rx"
 	ucidef_set_led_netdev "lan3" "lan3" "mt7530-0:03:green:lan" "lan3" "link tx rx"
 	;;
-bananapi,bpi-r4-lite)
-	ucidef_set_led_netdev "sfp0" "sfp0" "green:sfp" "sfp0" "link tx rx"
-	;;
-bazis,ax3000wm)
-	ucidef_set_led_netdev "wanact" "WANACT" "mdio-bus:05:amber:wan" "eth0" "rx tx"
-	ucidef_set_led_netdev "wanlink" "WANLINK" "mdio-bus:05:green:wan" "eth0" "link"
-	ucidef_set_led_netdev "lanlink" "LANLINK" "green:lan" "eth1" "link"
-	ucidef_set_led_netdev "internet" "internet" "blue:wan-online" "wan" "link"
-	;;
 cudy,re3000-v1|\
-kebidumei,ax3000-u22|\
 wavlink,wl-wn573hx3)
 	ucidef_set_led_netdev "lan" "lan" "green:lan" "eth0" "link tx rx"
 	;;
-cudy,wr3000-v1|\
-cudy,wr3000e-v1)
+cudy,wr3000-v1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan"
 	;;
 cudy,wr3000h-v1|\
@@ -85,17 +54,6 @@ cudy,wr3000p-v1)
 	ucidef_set_led_netdev "lan4" "lan4" "white:lan-4" "lan4" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "white:wan" "wan" "link tx rx"
 	ucidef_set_led_netdev "internet" "internet" "white:wan-online" "wan" "link"
-	;;
-cudy,wbr3000uax-v1|\
-cudy,wbr3000uax-v1-ubootmod)
-	ucidef_set_led_default "internet_off" "internet_off" "red:fault" "1"
-	ucidef_set_led_netdev "internet" "internet" "blue:wan-online" "wan" "link"
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "tx rx"
-	ucidef_set_led_default "lan_off" "lan_off" "red:wps" "1"
-	ucidef_set_led_netdev "lan" "lan" "blue:lan" "br-lan" "link tx rx"
-	;;
-elecom,wrc-x3000gs3)
-	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
 	;;
 glinet,gl-x3000|\
 glinet,gl-xe3000)
@@ -114,36 +72,17 @@ huasifei,wh3000)
 iptime,ax3000q)
 	ucidef_set_led_netdev "wan" "WAN" "amber:wan" "wan" "link tx rx"
 	;;
-iptime,ax3000se)
-	ucidef_set_led_netdev "wlan" "WLAN" "blue:wlan" "phy1-ap0"
-	;;
 iptime,ax3000sm)
 	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
 	;;
 iptime,ax7800m-6e)
 	ucidef_set_led_netdev "wan" "wan" "mdio-bus:06:blue:wan" "eth1" "link tx rx"
 	;;
-keenetic,kn-1812|\
-netcraze,nc-1812)
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "green:indicator-1" "phy0.0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "green:wlan" "phy0.1-ap0"
-	ucidef_set_led_netdev "internet" "internet" "green:wan-online" "wan" "link"
-	;;
-keenetic,kn-3711|\
-keenetic,kn-3811)
-	ucidef_set_led_netdev "internet" "internet" "green:wan" "wan" "link"
-	;;
 mercusys,mr80x-v3)
 	ucidef_set_led_netdev "lan1" "lan-1" "green:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan-2" "green:lan-2" "lan2" "link tx rx"
 	ucidef_set_led_netdev "lan3" "lan-3" "green:lan-3" "lan3" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
-	;;
-mercusys,mr85x)
-	ucidef_set_led_switch "lan0" "lan-0" "green:lan-0" "switch0" "0x01"
-	ucidef_set_led_switch "lan1" "lan-1" "green:lan-1" "switch0" "0x02"
-	ucidef_set_led_switch "lan2" "lan-2" "green:lan-2" "switch0" "0x04"
-	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
 mercusys,mr90x-v1|\
 mercusys,mr90x-v1-ubi)
@@ -152,47 +91,16 @@ mercusys,mr90x-v1-ubi)
 	ucidef_set_led_netdev "lan-2" "lan-2" "green:lan-2" "lan2" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
-netcore,n60)
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan" "eth1" "link tx rx"
-	;;
-netcore,n60-pro)
-	ucidef_set_led_netdev "lan1" "LAN1" "mdio-bus:05:green:lan" "lan1" "link tx rx"
-	ucidef_set_led_netdev "wanact" "WANACT" "mdio-bus:06:green:wan" "eth1" "tx rx"
-	ucidef_set_led_netdev "wanlink" "WANLINK" "blue:wan" "eth1" "link"
-	;;
-netgear,eax17)
-	ucidef_set_led_default power_green "Power (green)" green:power 1
-	ucidef_set_led_default power_red   "Power (red)"   red:power   0
-	ucidef_set_led_default rlink_red   "Client (red)"  red:lan     0
-	ucidef_set_led_default clink_red   "Router (red)"  red:wan     0
-	ucidef_set_led_wps     wps_green   "WPS (green)"   green:wps
-	ucidef_set_led_netdev  lan_speed_fast  "LAN Link (green)"     green:status  eth0
-	uci -q set system.lan_speed_fast.mode='link'
-	ucidef_set_led_netdev  lan_speed_slow  "LAN Activity (yellow)" yellow:status eth0
-	uci -q set system.lan_speed_slow.mode='tx rx'
-	;;
 netgear,wax220)
 	ucidef_set_led_netdev "eth0" "LAN" "green:lan" "eth0"
-	;;
-netis,nx30v2)
-	ucidef_set_led_netdev "wanlink" "WANLINK" "blue:wan" "eth1" "link"
-	ucidef_set_led_netdev "wanact" "WANACT" "blue:wan-online" "eth1" "tx rx"
 	;;
 netis,nx31)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
 	;;
-netis,nx32u)
-	ucidef_set_led_netdev "internet" "internet" "green:wan-online" "wan" "link"
-	;;
-imou,hx21|\
 nokia,ea0326gmp)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "eth1" "link"
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "br-lan" "link"
 	ucidef_set_led_netdev "wlan" "WLAN" "green:wlan" "phy1-ap0" "link"
-	;;
-nradio,c8-668gl)
-	ucidef_set_led_netdev "wifi" "WIFI" "blue:wlan" "phy1-ap0" "link"
-	ucidef_set_led_netdev "5g" "5G" "blue:indicator-0" "eth1" "link"
 	;;
 openembed,som7981)
 	ucidef_set_led_netdev "lanact" "LANACT" "amber:lan" "eth1" "rx tx"
@@ -222,36 +130,6 @@ routerich,ax3000-v1)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
 	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "eth1" "link"
 	;;
-routerich,be7200)
-	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-2" "lan2" "link tx rx"
-	ucidef_set_led_netdev "lan-3" "lan-3" "blue:lan-3" "lan3" "link tx rx"
-	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
-	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
-	ucidef_set_led_netdev "wlan5g" "wlan-5ghz" "blue:wlan-5ghz" "phy0.1-ap0" "link tx rx"
-	;;
-smartrg,sdg-8612)
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:amber:lan" "lan4" "link_10 link_100"
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-0" "lan4" "link_1000"
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-1" "lan4" "link_2500"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-0" "eth1" "link_1000"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-1" "eth1" "link_2500"
-	;;
-smartrg,sdg-8614)
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:amber:lan" "lan4" "link_10 link_100"
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-0" "lan4" "link_1000"
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan-1" "lan4" "link_2500"
-	;;
-smartrg,sdg-8622|\
-smartrg,sdg-8632)
-	ucidef_set_led_netdev "lan" "LAN" "mdio-bus:05:amber:lan" "lan" "link_10 link_100"
-	ucidef_set_led_netdev "lan" "LAN" "mdio-bus:05:green:lan-0" "lan" "link_1000"
-	ucidef_set_led_netdev "lan" "LAN" "mdio-bus:05:green:lan-1" "lan" "link_2500"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-0" "eth1" "link_1000"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan-1" "eth1" "link_2500"
-	;;
 smartrg,sdg-8733|\
 smartrg,sdg-8734)
 	ucidef_set_led_netdev "lan-1-green" "LAN1" "mdio-bus:08:green:lan" "lan1" "link_2500 link_5000"
@@ -275,25 +153,8 @@ smartrg,sdg-8733a)
 	ucidef_set_led_netdev "wan-orange" "WAN" "mdio-bus:08:orange:wan" "wan" "link_100 link_1000"
 	ucidef_set_led_netdev "wan-white" "WAN" "mdio-bus:08:white:wan" "wan" "link_10000"
 	;;
-teltonika,rutc50)
-	ucidef_set_led_netdev "wan-green" "WAN" "mdio-bus:00:green:wan" "wan" "link_1000 tx rx"
-	ucidef_set_led_netdev "wan-amber" "WAN" "mdio-bus:00:amber:wan" "wan" "link_100 link_10 tx rx"
-	;;
 totolink,x6000r)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan" "link tx rx"
-	;;
-tplink,archer-ax80-v1-eu)
-	ucidef_set_led_netdev "lan" "LAN" "white:lan" "br-lan" "link tx rx"
-	;;
-tplink,be450)
-	ucidef_set_led_netdev "br-lan" "lan" "blue:lan" "br-lan" "link tx rx"
-	ucidef_set_led_netdev "wlan2g" "WLAN2G" "blue:wlan-2ghz" "phy0.0-ap0"
-	ucidef_set_led_netdev "wlan5g" "WLAN5G" "blue:wlan-5ghz" "phy0.1-ap0"
-	;;
-tplink,fr365-v1)
-	ucidef_set_led_netdev "port2-green-act" "port-2" "green:port2_act" "port2" "link tx rx"
-	ucidef_set_led_netdev "port1-green-act" "port-1" "green:sfp" "port1" "link tx rx"
-	ucidef_set_led_netdev "wlan" "wlan" "green:wlan" "phy1-ap0"
 	;;
 tplink,re6000xd)
 	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-0" "lan1" "link tx rx"
@@ -304,13 +165,7 @@ wavlink,wl-wn536ax6-a)
 	ucidef_set_led_netdev "wifi" "wifi" "blue:wlan" "phy1-ap0" "link"
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
 	;;
-wavlink,wl-wn551x3)
-        ucidef_set_led_netdev "lan-1" "lan-1" "green:lan-1" "lan1" "link tx rx"
-        ucidef_set_led_netdev "lan-2" "lan-2" "green:lan-2" "lan2" "link tx rx"
-        ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
-        ;;
-wavlink,wl-wn586x3|\
-wavlink,wl-wn586x3b)
+wavlink,wl-wn586x3)
 	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-2" "lan2" "link tx rx"
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link tx rx"
@@ -323,33 +178,15 @@ xiaomi,redmi-router-ax6000-stock|\
 xiaomi,redmi-router-ax6000-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "rgb:network" "wan"
 	;;
-zbtlink,zbt-z8103ax|\
-zbtlink,zbt-z8103ax-c)
+zbtlink,zbt-z8103ax)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
 zyxel,ex5601-t0-stock|\
 zyxel,ex5601-t0-ubootmod)
-	ucidef_set_led_netdev "lan1" "LAN1" "mdio-bus:05:green:lan" "lan1" "link tx rx"
-	ucidef_set_led_netdev "wan" "2.5G-WAN" "mdio-bus:06:green:wan" "wan" "link_2500"
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0" "link tx rx"
-	ucidef_set_led_netdev "internet" "INTERNET" "green:inet" "wan" "link tx rx"
+	ucidef_set_led_netdev "wan" "WAN" "green:inet" "eth1" "link tx rx"
 	ucidef_set_led_netdev "wifi-24g" "WIFI-2.4G" "green:wifi24g" "phy0-ap0" "link tx rx"
 	ucidef_set_led_netdev "wifi-5g" "WIFI-5G" "green:wifi5g" "phy1-ap0" "link tx rx"
-	;;
-zyxel,nwa50ax-pro)
-	ucidef_set_led_netdev "uplink" "UPLINK" "mdio-bus:05:amber:wan" "eth0" "link_10 link_100 link_2500 tx rx"
-	ucidef_set_led_netdev "uplink" "UPLINK" "mdio-bus:05:green:wan" "eth0" "link_1000 link_2500 tx rx"
-	;;
-zyxel,ex5700-telenor)
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:amber:lan" "lan4" "link_10 link_100 tx rx"
-	ucidef_set_led_netdev "lan4" "LAN4" "mdio-bus:05:green:lan" "lan4" "link tx rx"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:amber:wan" "eth1" "link_10 link_100 tx rx"
-	ucidef_set_led_netdev "wan" "WAN" "mdio-bus:06:green:wan" "eth1" "link tx rx"
-	;;
-zyxel,wx5600-t0-ubootmod)
-	ucidef_set_led_netdev "lan1" "LAN1" "mdio-bus:06:green:lan" "lan1" "link tx rx"
-	ucidef_set_led_netdev "lan2" "LAN2" "mdio-bus:05:green:lan" "lan2" "link tx rx"
-	ucidef_set_led_netdev "wlan5" "wlan5" "green:wlan-0" "phy1-ap0" "link tx rx"
 	;;
 esac
 

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -9,31 +9,22 @@ mediatek_setup_interfaces()
 
 	case $board in
 	abt,asr3000|\
-	buffalo,wsr-6000ax8|\
 	cmcc,rax3000m|\
 	h3c,magic-nx30-pro|\
-	imou,hx21|\
 	konka,komi-a31|\
-	netis,nx30v2|\
 	netis,nx31|\
 	nokia,ea0326gmp|\
 	mercusys,mr80x-v3|\
 	routerich,ax3000-v1|\
-	zbtlink,zbt-z8103ax|\
-	zbtlink,zbt-z8103ax-c)
+	zbtlink,zbt-z8103ax)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" eth1
 		;;
-	acelink,ew-7886cax|\
-	tplink,eap683-lr)
+	acelink,ew-7886cax)
 		ucidef_set_interface_lan "eth0" "dhcp"
 		;;
 	acer,predator-w6|\
 	acer,predator-w6d)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 game" eth1
-		;;
-	acer,predator-w6x-stock|\
-	acer,predator-w6x-ubootmod)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
 		;;
 	acer,vero-w6m)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" internet
@@ -43,24 +34,16 @@ mediatek_setup_interfaces()
 		;;
 	asus,rt-ax52|\
 	asus,rt-ax59u|\
-	asus,zenwifi-bt8|\
-	asus,zenwifi-bt8-ubootmod|\
 	cetron,ct3003|\
 	cmcc,a10-stock|\
 	cmcc,a10-ubootmod|\
 	confiabits,mt7981|\
-	creatlentem,clt-r30b1|\
-	creatlentem,clt-r30b1-112m|\
 	cudy,wr3000-v1|\
 	jcg,q30-pro|\
-	keenetic,kn-3711|\
 	keenetic,kn-3811|\
-	netis,nx32u|\
 	qihoo,360t7|\
 	routerich,ax3000|\
-	routerich,ax3000-ubootmod|\
-	routerich,be7200|\
-	tenbay,wr3000k)
+	routerich,ax3000-ubootmod)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
 		;;
 	asus,tuf-ax4200|\
@@ -69,16 +52,15 @@ mediatek_setup_interfaces()
 	jdcloud,re-cp-03|\
 	mediatek,mt7981-rfb|\
 	netcore,n60|\
-	netcore,n60-pro|\
-	nradio,c8-668gl|\
 	ruijie,rg-x60-pro|\
 	unielec,u7981-01*|\
 	wavlink,wl-wn536ax6-a|\
 	zbtlink,zbt-z8102ax|\
-	zbtlink,zbt-z8102ax-v2)
+	zbtlink,zbt-z8102ax-v2|\
+	zyxel,ex5601-t0-stock|\
+	zyxel,ex5601-t0-ubootmod)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
 		;;
-	asiarf,ap7986-003|\
 	asus,tuf-ax4200q|\
 	asus,tuf-ax6000|\
 	glinet,gl-mt6000|\
@@ -87,55 +69,40 @@ mediatek_setup_interfaces()
 	tplink,tl-xtr8488)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" eth1
 		;;
+	tplink,vx830v)
+		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" "eth1"
+		;;
 	bananapi,bpi-r3)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "sfp1 wan"
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp2" "eth1 wan"
 		;;
-	bananapi,bpi-r4)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 sfp-lan" "wan sfp-wan"
-		;;
-	bananapi,bpi-r4-lite)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 sfp-lan" wan
-		;;
-	bananapi,bpi-r4-2g5|\
-	bananapi,bpi-r4-poe)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan sfp-wan"
-		;;
-	comfast,cf-e393ax)
-		ucidef_set_interfaces_lan_wan "lan1" eth1
-		;;
-	cudy,ap3000wall-v1)
-		ucidef_set_interface_lan "lan1 lan2 lan3 lan4 lan5"
-		;;
-	cudy,ap3000outdoor-v1|\
-	cudy,ap3000-v1|\
-	cudy,re3000-v1|\
-	kebidumei,ax3000-u22|\
-	keenetic,kap-630|\
-	netcraze,nap-630|\
-	netgear,eax17|\
-	netgear,wax220|\
-	openfi,6c|\
-	ubnt,unifi-6-plus|\
-	wavlink,wl-wn573hx3|\
-	widelantech,wap430x|\
-	zyxel,nwa50ax-pro)
-		ucidef_set_interface_lan "eth0"
-		;;
-	airpi,ap3000m|\
 	bananapi,bpi-r3-mini|\
 	edgecore,eap111|\
 	huasifei,wh3000|\
 	huasifei,wh3000-pro)
 		ucidef_set_interfaces_lan_wan eth0 eth1
 		;;
-	bazis,ax3000wm|\
+	bananapi,bpi-r4|\
+	bananapi,bpi-r4-poe)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 eth1" "wan eth2"
+		;;
+	comfast,cf-e393ax)
+		ucidef_set_interfaces_lan_wan "lan1" eth1
+		;;
+	cudy,ap3000outdoor-v1|\
+	cudy,ap3000-v1|\
+	cudy,re3000-v1|\
+	netgear,wax220|\
+	openfi,6c|\
+	ubnt,unifi-6-plus|\
+	wavlink,wl-wn573hx3|\
+	zyxel,nwa50ax-pro)
+		ucidef_set_interface_lan "eth0"
+		;;
 	cudy,m3000-v1|\
-	cudy,m3000-v2-yt8821|\
 	cudy,tr3000-256mb-v1|\
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
 	glinet,gl-mt2500|\
-	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt3000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
@@ -147,18 +114,12 @@ mediatek_setup_interfaces()
 	dlink,aquila-pro-ai-m60-a1)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" internet
 		;;
-	comfast,cf-wr632ax|\
-	comfast,cf-wr632ax-ubootmod|\
 	keenetic,kn-3911|\
 	smartrg,sdg-8622|\
 	smartrg,sdg-8632|\
 	smartrg,sdg-8733a|\
 	yuncore,ax835)
 		ucidef_set_interfaces_lan_wan lan wan
-		;;
-	keenetic,kn-1812|\
-	netcraze,nc-1812)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan5" "wan"
 		;;
 	mediatek,mt7986a-rfb)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 lan6" "eth1 wan"
@@ -169,32 +130,16 @@ mediatek_setup_interfaces()
 	mediatek,mt7988a-rfb)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3 eth2" eth1
 		;;
-	mercusys,mr85x)
-		ucidef_add_switch "switch0" "0:lan0" "1:lan1" "2:lan2" "6@eth0"
-		ucidef_set_interfaces_lan_wan "eth0.1 eth0.2 eth0.3" eth1
-		;;
 	mercusys,mr90x-v1|\
 	mercusys,mr90x-v1-ubi)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2" eth1
 		;;
-	tenda,be12-pro)
-		ucidef_set_interfaces_lan_wan "lan3 lan4 lan5 eth1" eth2
-		;;
-	tplink,fr365-v1)
-		ucidef_set_interfaces_lan_wan "port1 port3 port4 port5 port6" "port2"
-		;;
 	tplink,tl-xdr6086|\
-	wavlink,wl-wn551x3|\
-	wavlink,wl-wn586x3|\
-	wavlink,wl-wn586x3b)
+	wavlink,wl-wn586x3)
 		ucidef_set_interfaces_lan_wan "lan1 lan2" eth1
 		;;
-	tplink,archer-ax80-v1|\
-	tplink,archer-ax80-v1-eu)
+	tplink,archer-ax80-v1)
 		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" eth1
-		;;
-	tplink,be450)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 eth2" eth1
 		;;
 	tplink,re6000xd)
 		ucidef_set_interface_lan "lan1 lan2 eth1"
@@ -206,9 +151,6 @@ mediatek_setup_interfaces()
 	xiaomi,redmi-router-ax6000-stock|\
 	xiaomi,redmi-router-ax6000-ubootmod)
 		ucidef_set_interfaces_lan_wan "lan2 lan3 lan4" wan
-		;;
-	zyxel,wx5600-t0-ubootmod)
-		ucidef_set_interface_lan "lan1 lan2"
 		;;
 	*)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" wan
@@ -224,27 +166,15 @@ mediatek_setup_macs()
 	local label_mac=""
 
 	case $board in
-	airpi,ap3000m)
-		base_mac=$(macaddr_generate_from_mmc_cid mmcblk0)
-		lan_mac="$base_mac"
-		wan_mac="$(macaddr_add "$base_mac" 1)"
-		;;
 	acer,predator-w6|\
 	acer,predator-w6d|\
 	acer,vero-w6m)
 		wan_mac=$(mmc_get_mac_ascii u-boot-env WANMAC)
 		lan_mac=$(mmc_get_mac_ascii u-boot-env LANMAC)
 		;;
-	acer,predator-w6x-stock|\
-	acer,predator-w6x-ubootmod)
-		wan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-		lan_mac=$(macaddr_add "$wan_mac" 1)
-		label_mac=$wan_mac
-		;;
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\
-	bananapi,bpi-r4|\
-	bananapi,bpi-r4-lite)
+	bananapi,bpi-r4)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)
 		;;
 	h3c,magic-nx30-pro)
@@ -252,8 +182,7 @@ mediatek_setup_macs()
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac=$wan_mac
 		;;
-	mercusys,mr80x-v3|\
-	mercusys,mr85x)
+	mercusys,mr80x-v3)
 		mac_dirty=$(cat "/tmp/tp_data/default-mac" | sed -n 's/^'"MAC"'://p')
 		label_mac=$(macaddr_canonicalize "$mac_dirty")
 		lan_mac=$label_mac
@@ -261,18 +190,12 @@ mediatek_setup_macs()
 		;;
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
-	tplink,archer-ax80-v1-eu|\
 	tplink,re6000xd)
 		label_mac=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		lan_mac=$label_mac
 		;;
 	netgear,wax220)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env mac)
-		label_mac=$lan_mac
-		;;
-	nradio,c8-668gl)
-		lan_mac=$(mmc_get_mac_ascii bdinfo "fac_mac ")
-		wan_mac=$(macaddr_add "$lan_mac" 2)
 		label_mac=$lan_mac
 		;;
 	qihoo,360t7)
@@ -284,14 +207,6 @@ mediatek_setup_macs()
 		label_mac=$(mtd_get_mac_ascii product_info ethaddr)
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add "$label_mac" 1)
-		;;
-	tplink,eap683-lr)
-		label_mac=$(get_mac_binary "/tmp/factory/default-mac" 0)
-		lan_mac=$label_mac
-		;;
-	tplink,fr365-v1)
-		lan_mac=$(strings /dev/mtd11 | grep 'option macaddr' | awk -F"'" '{print $2}')
-		wan_mac="$(macaddr_add $lan_mac 1)"
 		;;
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-ax3000t-ubootmod|\

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
@@ -8,10 +8,6 @@ case "$board" in
 huasifei,wh3000-pro)
 	ucidef_add_gpio_switch "modem_power" "Modem power" "modem_power" "0"
 	;;
-teltonika,rutc50)
-	ucidef_add_gpio_switch "modem_power" "Modem power button" "modem_power" "1"
-	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
-	;;
 zbtlink,zbt-z8102ax|\
 zbtlink,zbt-z8102ax-v2)
 	ucidef_add_gpio_switch "5g1" "Power 1st modem" "5g1" "1"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/05_compat-version
@@ -6,11 +6,8 @@ board_config_update
 
 case "$(board_name)" in
 	bananapi,bpi-r3)
-		ucidef_set_compat_version "1.3"
+		ucidef_set_compat_version "1.2"
 		;;
-	bananapi,bpi-r4|\
-	bananapi,bpi-r4-2g5|\
-	bananapi,bpi-r4-poe|\
 	routerich,ax3000|\
 	zbtlink,zbt-z8102ax-v2)
 		ucidef_set_compat_version "1.1"

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -9,23 +9,25 @@ board=$(board_name)
 case "$FIRMWARE" in
 "mediatek/mt7981_eeprom_mt7976_dbdc.bin")
 	case "$board" in
-	mercusys,mr80x-v3|\
-	mercusys,mr85x)
+	mercusys,mr80x-v3)
 		ln -sf /tmp/tp_data/MT7981_EEPROM.bin \
 			/lib/firmware/$FIRMWARE
 		;;
-	tplink,fr365-v1)
-		ln -sf /tmp/wlan/radio /lib/firmware/$FIRMWARE
+	ubnt,unifi-6-plus)
+		caldata_extract_mmc "factory" 0x0 0x1000
 		;;
 	esac
 	;;
 "mediatek/mt7986_eeprom_mt7975_dual.bin")
 	case "$board" in
 	mercusys,mr90x-v1|\
-	tplink,archer-ax80-v1-eu|\
 	tplink,re6000xd)
 		ln -sf /tmp/tp_data/MT7986_EEPROM.bin \
 			/lib/firmware/$FIRMWARE
+		;;
+	tplink,vx830v)
+		dd if=/tmp/misc_ro/0x003A0000 of=/lib/firmware/$FIRMWARE \
+			bs=4096 count=1 2>/dev/null
 		;;
 	esac
 	;;
@@ -33,17 +35,6 @@ case "$FIRMWARE" in
 	case "$board" in
 	tplink,archer-ax80-v1)
 		ln -sf /tmp/tp_data/MT7986_EEPROM.bin \
-			/lib/firmware/$FIRMWARE
-		;;
-	tplink,eap683-lr)
-		ln -sf /tmp/factory/radio /lib/firmware/$FIRMWARE
-		;;
-	esac
-	;;
-"mediatek/mt7996/mt7992_eeprom.bin")
-	case "$board" in
-	tplink,be450)
-		ln -sf /tmp/tp_data/MT7992_EEPROM.bin \
 			/lib/firmware/$FIRMWARE
 		;;
 	esac

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -27,17 +27,6 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && mmc_get_mac_ascii u-boot-env 2gMAC > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && mmc_get_mac_ascii u-boot-env 5gMAC > /sys${DEVPATH}/macaddress
 		;;
-	acer,predator-w6x-stock|\
-	acer,predator-w6x-ubootmod)
-		hw_mac_addr="$(mtd_get_mac_ascii u-boot-env ethaddr)"
-		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
-		;;
-	airpi,ap3000m)
-		base_mac=$(macaddr_generate_from_mmc_cid mmcblk0)
-		[ "$PHYNBR" = "0" ] && macaddr_add $base_mac 2 > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_add $base_mac 3 > /sys${DEVPATH}/macaddress
-		;;
 	asus,rt-ax59u)
 		CI_UBIPART="UBI_DEV"
 		addr=$(mtd_get_mac_binary_ubi "Factory" 0x4)
@@ -49,7 +38,6 @@ case "$board" in
 			/sys${DEVPATH}/macaddress
 		;;
 	asus,rt-ax52|\
-	asus,rt-ax57m|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax4200q|\
 	asus,tuf-ax6000)
@@ -68,7 +56,6 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
 	bananapi,bpi-r4|\
-	bananapi,bpi-r4-2g5|\
 	bananapi,bpi-r4-poe)
 		addr=$(cat /sys/class/net/eth0/address)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
@@ -89,16 +76,12 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		;;
 	cudy,ap3000outdoor-v1|\
-	cudy,ap3000wall-v1|\
 	cudy,ap3000-v1|\
 	cudy,m3000-v1|\
-	cudy,m3000-v2-yt8821|\
 	cudy,re3000-v1|\
 	cudy,tr3000-256mb-v1|\
 	cudy,tr3000-v1|\
 	cudy,tr3000-v1-ubootmod|\
-	cudy,wbr3000uax-v1|\
-	cudy,wbr3000uax-v1-ubootmod|\
 	cudy,wr3000e-v1|\
 	cudy,wr3000s-v1|\
 	cudy,wr3000h-v1|\
@@ -131,8 +114,6 @@ case "$board" in
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $addr > /sys${DEVPATH}/macaddress
 		;;
-	iptime,ax3000m|\
-	iptime,ax3000se|\
 	iptime,ax3000sm)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_unsetbit $(macaddr_setbit $addr 26) 25) 27) 28) > \
@@ -145,8 +126,7 @@ case "$board" in
 		[ "$PHYNBR" = "2" ] && macaddr_setbit_la $addr2 > /sys${DEVPATH}/macaddress
 		;;
 	jcg,q30-pro|\
-	netcore,n60|\
-	netcore,n60-pro)
+	netcore,n60)
 		# Originally, phy1 is phy0 mac with LA bit set. However, this would conflict
 		# addresses on multiple VIFs with the other radio. Use label mac to set LA bit.
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(get_mac_label) > /sys${DEVPATH}/macaddress
@@ -154,16 +134,12 @@ case "$board" in
 	jdcloud,re-cp-03)
 		[ "$PHYNBR" = "1" ] && mmc_get_mac_binary factory 0xa > /sys${DEVPATH}/macaddress
 		;;
-	keenetic,kap-630|\
-	keenetic,kn-3711|\
 	keenetic,kn-3811|\
-	keenetic,kn-3911|\
-	netcraze,nap-630)
+	keenetic,kn-3911)
 		[ "$PHYNBR" = "1" ] && \
 			macaddr_setbit_la "$(mtd_get_mac_binary rf-eeprom 0x4)" > /sys${DEVPATH}/macaddress
 		;;
-	mercusys,mr80x-v3|\
-	mercusys,mr85x)
+	mercusys,mr80x-v3)
 		mac_dirty=$(cat "/tmp/tp_data/default-mac" | sed -n 's/^'"MAC"'://p')
 		label_mac=$(macaddr_canonicalize "$mac_dirty")
 		[ "$PHYNBR" = "0" ] && macaddr_add $label_mac -1 > /sys${DEVPATH}/macaddress
@@ -171,8 +147,6 @@ case "$board" in
 		;;
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
-	tplink,archer-ax80-v1-eu|\
-	tplink,be450|\
 	tplink,re6000xd)
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
@@ -183,8 +157,7 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 3 > /sys${DEVPATH}/macaddress
 		;;
-	netis,nx31|\
-	netis,nx32u)
+	netis,nx31)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		addr=$(macaddr_unsetbit $(macaddr_setbit_la $addr) 25)
 		addr_2g=$(macaddr_unsetbit $(macaddr_unsetbit $addr 26) 27)
@@ -197,11 +170,6 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		;;
-	nradio,c8-668gl)
-		hw_mac_addr=$(mmc_get_mac_ascii bdinfo "fac_mac ")
-		[ "$PHYNBR" = "0" ] && echo "$hw_mac_addr" > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $hw_mac_addr > /sys${DEVPATH}/macaddress
-		;;
 	qihoo,360t7)
 		addr=$(mtd_get_mac_ascii factory lanMac)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
@@ -212,16 +180,6 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
-	tplink,eap683-lr)
-		addr=$(get_mac_label)
-		[ "$PHYNBR" = "0" ] && echo $addr > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
-		;;
-	tplink,fr365-v1)
-		addr=$(strings /dev/mtd11 | grep 'option macaddr' | awk -F"'" '{print $2}')
-		[ "$PHYNBR" = "0" ] && echo $addr > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
-		;;
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088)
@@ -230,15 +188,28 @@ case "$board" in
 	tplink,tl-xtr8488)
 		[ "$PHYNBR" = "1" ] && get_mac_label > /sys${DEVPATH}/macaddress
 		;;
+	ubnt,unifi-6-plus)
+		addr=$(mtd_get_mac_binary EEPROM 0x6)
+		[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
+		;;
 	routerich,ax3000|\
 	routerich,ax3000-ubootmod|\
 	zbtlink,zbt-z8102ax|\
-	zbtlink,zbt-z8102ax-v2)
+	zbtlink,zbt-z8102ax-v2|\
+	zbtlink,zbt-z8103ax|\
+	zyxel,ex5601-t0-stock|\
+	zyxel,ex5601-t0-ubootmod)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		;;
 	wavlink,wl-wn573hx3)
 		addr=$(mtd_get_mac_binary factory 0x04)
 		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $(macaddr_add $addr -0x300000) > /sys${DEVPATH}/macaddress
+		;;
+	zyxel,nwa50ax-pro)
+		hw_mac_addr="$(mtd_get_mac_binary mrd 0x1fff8)"
+		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
 		;;
 esac

--- a/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount
+++ b/target/linux/mediatek/filogic/base-files/etc/init.d/bootcount
@@ -23,28 +23,6 @@ boot() {
 		EOF
 		logger "bootcount: rd23 model detected, nvram was updated"
 		;;
-	teltonika,rutc50)
-		#Bootloader expect successfull startup value after update, we need to write success value to bootconfig partition
-		#otherwise bootloader will fallback to previous root partition
-		. /lib/functions.sh
-		local PART="$(cmdline_get_var ubi.mtd)"
-		local MTD_INDEX=$(find_mtd_index bootconfig-a)
-
-		case "$PART" in
-		rutos-a)
-			[ "$(md5sum /dev/mtd$MTD_INDEX | awk '{print $1}')" = "adc4a78e76efc6b4afdc41925e4017c6" ] || {
-				logger -t "bootcount" "saving new failsafe boot config in /dev/mtd$MTD_INDEX bootconfig-a partition rutos-a"
-				echo -ne "\xe1\xb0\xba\xba\x01\x00\xf9\x01\xf8\x01\xf0\x00\x3d\xd4\xfb\x95" | mtd -e bootconfig-a write - bootconfig-a
-			}
-			;;
-		rutos-b)
-			[ "$(md5sum /dev/mtd$MTD_INDEX | awk '{print $1}')" = "2904b3476604ef153d1925acdde062e8" ] || {
-				logger -t "bootcount" "saving new failsafe boot config in /dev/mtd$MTD_INDEX bootconfig-a partition rutos-b"
-				echo -ne "\xe1\xb0\xba\xba\x01\x01\xf7\x01\xf8\x00\xf0\x00\xce\xd4\x44\x08" | mtd -e bootconfig-a write - bootconfig-a
-				}
-			;;
-		esac
-		;;
 	zyxel,ex5700-telenor)
 		fw_setenv uboot_bootcount 0
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/uci-defaults/05_fix-compat-version
+++ b/target/linux/mediatek/filogic/base-files/etc/uci-defaults/05_fix-compat-version
@@ -2,11 +2,8 @@
 
 case "$(board_name)" in
 	bananapi,bpi-r3)
-	compat_version="$(uci get system.@system[0].compat_version)"
-	if [ "${compat_version%%.*}" = "1" ] && [ "${compat_version##*.}" -le 1 ]; then
-		uci set system.@system[0].compat_version="1.2"
-		uci commit system
-	fi
+	uci set system.@system[0].compat_version="1.2"
+	uci commit system
 	;;
 esac
 

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/04_set_netdev_label
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/04_set_netdev_label
@@ -10,14 +10,6 @@ set_netdev_labels() {
 		[ "$netdev" = "$label" ] && continue
 		ip link set "$netdev" name "$label"
 	done
-
-	for dir in /sys/class/net/*; do
-		[ -r "$dir/of_node/openwrt,netdev-name" ] || continue
-		read -r label < "$dir/of_node/openwrt,netdev-name"
-		netdev="${dir##*/}"
-		[ "$netdev" = "$label" ] && continue
-		ip link set "$netdev" name "$label"
-	done
 }
 
 boot_hook_add preinit_main set_netdev_labels

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -1,32 +1,25 @@
 . /lib/functions/system.sh
 
 mount_ubi_part() {
-	local mtd_name="$1"
-	local part_name="$2"
-	local mtd_num=$(grep \"$mtd_name\" /proc/mtd | cut -d: -f1 | sed 's/mtd//g')
+	local part_name="$1"
+	local mtd_num=$(grep $part_name /proc/mtd | cut -c4)
 	local ubi_num=$(ubiattach -m $mtd_num | \
 		awk -F',' '/UBI device number [0-9]{1,}/{print $1}' | \
 		awk '{print $4}')
-	mkdir /tmp/$mtd_name
-	mount -r -t ubifs ubi$ubi_num:$part_name /tmp/$mtd_name
+	mkdir /tmp/$part_name
+	mount -r -t ubifs ubi$ubi_num:$part_name /tmp/$part_name
 }
 
 preinit_mount_cfg_part() {
 	case $(board_name) in
 	mercusys,mr80x-v3|\
-	mercusys,mr85x|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
-	tplink,archer-ax80-v1-eu|\
-	tplink,be450|\
 	tplink,re6000xd)
-		mount_ubi_part "tp_data" "tp_data"
+		mount_ubi_part "tp_data"
 		;;
-	tplink,eap683-lr)
-		mount_ubi_part "factory" "ubi_factory_data"
-		;;
-	tplink,fr365-v1)
-		mount_ubi_part "wlan" "ubi_wlan_factory_data"
+	tplink,vx830v)
+		mount_ubi_part "misc_ro"
 		;;
 	*)
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -12,16 +12,6 @@ preinit_set_mac_address() {
 		ip link set dev game address "$lan_mac"
 		ip link set dev eth1 address "$wan_mac"
 		;;
-	acer,predator-w6x-stock|\
-	acer,predator-w6x-ubootmod)
-		wan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-		lan_mac=$(macaddr_add "$wan_mac" 1)
-		ip link set dev lan1 address "$lan_mac"
-		ip link set dev lan2 address "$lan_mac"
-		ip link set dev lan3 address "$lan_mac"
-		ip link set dev lan4 address "$lan_mac"
-		ip link set dev eth1 address "$wan_mac"
-		;;
 	acer,vero-w6m)
 		wan_mac=$(mmc_get_mac_ascii u-boot-env WANMAC)
 		lan_mac=$(mmc_get_mac_ascii u-boot-env LANMAC)
@@ -40,25 +30,9 @@ preinit_set_mac_address() {
 		;;
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
-	tplink,archer-ax80-v1-eu|\
 	tplink,re6000xd)
 		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
 		ip link set dev eth1 address "$(macaddr_add $addr 1)"
-		;;
-	tplink,be450)
-		addr=$(get_mac_binary "/tmp/tp_data/default-mac" 0)
-		ip link set dev eth1 address "$(macaddr_add $addr 1)"
-		ip link set dev eth2 address "$(macaddr_add $addr 2)"
-		;;
-	tplink,fr365-v1)
-		lan_mac=$(strings /dev/mtd11 | grep 'option macaddr' | awk -F"'" '{print $2}')
-		wan_mac="$(macaddr_add $lan_mac 1)"
-		ip link set dev port2 address "$wan_mac"
-		ip link set dev port1 address "$lan_mac"
-		ip link set dev port3 address "$lan_mac"
-		ip link set dev port4 address "$lan_mac"
-		ip link set dev port5 address "$lan_mac"
-		ip link set dev port6 address "$lan_mac"
 		;;
 	*)
 		;;

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -1,5 +1,5 @@
 REQUIRE_IMAGE_METADATA=1
-RAMFS_COPY_BIN='fitblk fit_check_sign'
+RAMFS_COPY_BIN='fitblk'
 
 asus_initial_setup()
 {
@@ -10,18 +10,6 @@ asus_initial_setup()
 	ubirmvol /dev/ubi0 -N rootfs_data
 	ubirmvol /dev/ubi0 -N jffs2
 	ubimkvol /dev/ubi0 -N jffs2 -s 0x3e000
-}
-
-buffalo_initial_setup()
-{
-	local mtdnum="$( find_mtd_index ubi )"
-	if [ ! "$mtdnum" ]; then
-		echo "unable to find mtd partition ubi"
-		return 1
-	fi
-
-	ubidetach -m "$mtdnum"
-	ubiformat /dev/mtd$mtdnum -y
 }
 
 xiaomi_initial_setup()
@@ -79,58 +67,46 @@ platform_do_upgrade() {
 
 	case "$board" in
 	abt,asr3000|\
-	acer,predator-w6x-ubootmod|\
-	asus,zenwifi-bt8-ubootmod|\
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\
 	bananapi,bpi-r4|\
-	bananapi,bpi-r4-2g5|\
 	bananapi,bpi-r4-poe|\
-	bananapi,bpi-r4-lite|\
-	bazis,ax3000wm|\
 	cmcc,a10-ubootmod|\
 	cmcc,rax3000m|\
-	comfast,cf-wr632ax-ubootmod|\
 	cudy,tr3000-v1-ubootmod|\
-	cudy,wbr3000uax-v1-ubootmod|\
 	gatonetworks,gdsp|\
 	h3c,magic-nx30-pro|\
-	imou,hx21|\
 	jcg,q30-pro|\
 	jdcloud,re-cp-03|\
 	konka,komi-a31|\
 	mediatek,mt7981-rfb|\
 	mediatek,mt7988a-rfb|\
 	mercusys,mr90x-v1-ubi|\
-	netis,nx30v2|\
 	netis,nx31|\
-	netis,nx32u|\
 	nokia,ea0326gmp|\
 	openwrt,one|\
 	netcore,n60|\
-	netcore,n60-pro|\
 	qihoo,360t7|\
 	routerich,ax3000-ubootmod|\
-	routerich,be7200|\
-	snr,snr-cpe-ax2|\
 	tplink,tl-xdr4288|\
 	tplink,tl-xdr6086|\
 	tplink,tl-xdr6088|\
 	tplink,tl-xtr8488|\
+	tplink,vx830v)
+		CI_UBIPART="ubi0"
+		nand_do_upgrade "$1"
+		;;
 	xiaomi,mi-router-ax3000t-ubootmod|\
 	xiaomi,redmi-router-ax6000-ubootmod|\
 	xiaomi,mi-router-wr30u-ubootmod|\
-	zyxel,ex5601-t0-ubootmod|\
-	zyxel,wx5600-t0-ubootmod)
+	zyxel,ex5601-t0-ubootmod)
 		fit_do_upgrade "$1"
 		;;
 	acer,predator-w6|\
 	acer,predator-w6d|\
 	acer,vero-w6m|\
-	airpi,ap3000m|\
 	arcadyan,mozart|\
 	glinet,gl-mt2500|\
-	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
@@ -148,17 +124,14 @@ platform_do_upgrade() {
 		emmc_do_upgrade "$1"
 		;;
 	asus,rt-ax52|\
-	asus,rt-ax57m|\
 	asus,rt-ax59u|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax4200q|\
-	asus,tuf-ax6000|\
-	asus,zenwifi-bt8)
+	asus,tuf-ax6000)
 		CI_UBIPART="UBI_DEV"
 		CI_KERNPART="linux"
 		nand_do_upgrade "$1"
 		;;
-	buffalo,wsr-6000ax8|\
 	cudy,wr3000h-v1|\
 	cudy,wr3000p-v1)
 		CI_UBIPART="ubi"
@@ -166,11 +139,9 @@ platform_do_upgrade() {
 		;;
 	cudy,re3000-v1|\
 	cudy,wr3000-v1|\
-	kebidumei,ax3000-u22|\
-	totolink,x6000r|\
+	yuncore,ax835|\
 	wavlink,wl-wn573hx3|\
-	widelantech,wap430x|\
-	yuncore,ax835)
+	totolink,x6000r)
 		default_do_upgrade "$1"
 		;;
 	dlink,aquila-pro-ai-m30-a1|\
@@ -178,57 +149,12 @@ platform_do_upgrade() {
 		fw_setenv sw_tryactive 0
 		nand_do_upgrade "$1"
 		;;
-	elecom,wrc-x3000gs3)
-		local bootnum="$(mstc_rw_bootnum)"
-		case "$bootnum" in
-		1|2)
-			CI_UBIPART="ubi$bootnum"
-			[ -z "$(find_mtd_index $CI_UBIPART)" ] &&
-				CI_UBIPART="ubi"
-			;;
-		*)
-			v "invalid bootnum found ($bootnum), rebooting..."
-			nand_do_upgrade_failed
-			;;
-		esac
-		nand_do_upgrade "$1"
-		;;
 	mercusys,mr80x-v3|\
-	mercusys,mr85x|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
-	tplink,archer-ax80-v1-eu|\
-	tplink,be450|\
 	tplink,re6000xd)
 		CI_UBIPART="ubi0"
 		nand_do_upgrade "$1"
-		;;
-	netgear,eax17)
-		echo "UPGRADING SECOND SLOT"
-		CI_KERNPART="kernel2"
-		CI_ROOTPART="rootfs2"
-		nand_do_flash_file "$1" || nand_do_upgrade_failed
-		echo "UPGRADING PRIMARY SLOT"
-		CI_KERNPART="kernel"
-		CI_ROOTPART="rootfs"
-		nand_do_flash_file "$1" || nand_do_upgrade_failed
-		nand_do_upgrade_success
-		;;
-	tplink,fr365-v1)
-		CI_UBIPART="ubi"
-		CI_KERNPART="kernel"
-		CI_ROOTPART="rootfs"
-		nand_do_upgrade "$1"
-		;;
-	teltonika,rutc50)
-		CI_UBIPART="$(cmdline_get_var ubi.mtd)"
-		nand_do_upgrade "$1"
-		;;
-	nradio,c8-668gl)
-		CI_DATAPART="rootfs_data"
-		CI_KERNPART="kernel_2nd"
-		CI_ROOTPART="rootfs_2nd"
-		emmc_do_upgrade "$1"
 		;;
 	ubnt,unifi-6-plus)
 		CI_KERNPART="kernel0"
@@ -269,61 +195,20 @@ PART_NAME=firmware
 
 platform_check_image() {
 	local board=$(board_name)
+	local magic="$(get_magic_long "$1")"
 
 	[ "$#" -gt 1 ] && return 1
 
 	case "$board" in
-	abt,asr3000|\
-	acer,predator-w6x-ubootmod|\
-	asus,zenwifi-bt8-ubootmod|\
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\
 	bananapi,bpi-r4|\
-	bananapi,bpi-r4-2g5|\
 	bananapi,bpi-r4-poe|\
-	bananapi,bpi-r4-lite|\
-	bazis,ax3000wm|\
-	cmcc,a10-ubootmod|\
-	cmcc,rax3000m|\
-	comfast,cf-wr632ax-ubootmod|\
-	cudy,tr3000-v1-ubootmod|\
-	cudy,wbr3000uax-v1-ubootmod|\
-	gatonetworks,gdsp|\
-	h3c,magic-nx30-pro|\
-	jcg,q30-pro|\
-	jdcloud,re-cp-03|\
-	konka,komi-a31|\
-	mediatek,mt7981-rfb|\
-	mediatek,mt7988a-rfb|\
-	mercusys,mr90x-v1-ubi|\
-	nokia,ea0326gmp|\
-	netis,nx32u|\
-	openwrt,one|\
-	netcore,n60|\
-	qihoo,360t7|\
-	routerich,ax3000-ubootmod|\
-	tplink,tl-xdr4288|\
-	tplink,tl-xdr6086|\
-	tplink,tl-xdr6088|\
-	tplink,tl-xtr8488|\
-	xiaomi,mi-router-ax3000t-ubootmod|\
-	xiaomi,redmi-router-ax6000-ubootmod|\
-	xiaomi,mi-router-wr30u-ubootmod|\
-	zyxel,ex5601-t0-ubootmod)
-		fit_check_image "$1"
-		return $?
-		;;
-	creatlentem,clt-r30b1|\
-	creatlentem,clt-r30b1-112m|\
-	nradio,c8-668gl)
-		# tar magic `ustar`
-		magic="$(dd if="$1" bs=1 skip=257 count=5 2>/dev/null)"
-
-		[ "$magic" != "ustar" ] && {
+	cmcc,rax3000m)
+		[ "$magic" != "d00dfeed" ] && {
 			echo "Invalid image type."
 			return 1
 		}
-
 		return 0
 		;;
 	*)
@@ -340,12 +225,8 @@ platform_copy_config() {
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\
 	bananapi,bpi-r4|\
-	bananapi,bpi-r4-2g5|\
 	bananapi,bpi-r4-poe|\
-	bananapi,bpi-r4-lite|\
-	cmcc,rax3000m|\
-	gatonetworks,gdsp|\
-	mediatek,mt7988a-rfb)
+	cmcc,rax3000m)
 		if [ "$CI_METHOD" = "emmc" ]; then
 			emmc_copy_config
 		fi
@@ -353,17 +234,14 @@ platform_copy_config() {
 	acer,predator-w6|\
 	acer,predator-w6d|\
 	acer,vero-w6m|\
-	airpi,ap3000m|\
 	arcadyan,mozart|\
 	glinet,gl-mt2500|\
-	glinet,gl-mt2500-airoha|\
 	glinet,gl-mt6000|\
 	glinet,gl-x3000|\
 	glinet,gl-xe3000|\
 	huasifei,wh3000|\
 	huasifei,wh3000-pro|\
 	jdcloud,re-cp-03|\
-	nradio,c8-668gl|\
 	smartrg,sdg-8612|\
 	smartrg,sdg-8614|\
 	smartrg,sdg-8622|\
@@ -382,16 +260,11 @@ platform_pre_upgrade() {
 
 	case "$board" in
 	asus,rt-ax52|\
-	asus,rt-ax57m|\
 	asus,rt-ax59u|\
 	asus,tuf-ax4200|\
 	asus,tuf-ax4200q|\
-	asus,tuf-ax6000|\
-	asus,zenwifi-bt8)
+	asus,tuf-ax6000)
 		asus_initial_setup
-		;;
-	buffalo,wsr-6000ax8)
-		buffalo_initial_setup
 		;;
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-wr30u-stock|\

--- a/target/linux/mediatek/image/Makefile
+++ b/target/linux/mediatek/image/Makefile
@@ -22,7 +22,7 @@ define Device/Default
   KERNEL_INITRAMFS = kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
   KERNEL_LOADADDR = $(loadaddr-y)
-  FILESYSTEMS := squashfs erofs
+  FILESYSTEMS := squashfs
   DEVICE_DTS_DIR := $(DTS_DIR)
   NETGEAR_ENC_MODEL :=
   NETGEAR_ENC_REGION :=

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1,20 +1,9 @@
 DTS_DIR := $(DTS_DIR)/mediatek
-DEVICE_VARS += SUPPORTED_TELTONIKA_DEVICES
-DEVICE_VARS += SUPPORTED_TELTONIKA_HW_MODS
 
 define Image/Prepare
 	# For UBI we want only one extra block
 	rm -f $(KDIR)/ubi_mark
 	echo -ne '\xde\xad\xc0\xde' > $(KDIR)/ubi_mark
-endef
-
-define Build/fit-with-netgear-top-level-rootfs-node
-	$(call Build/fit-its,$(1))
-	$(TOPDIR)/scripts/gen_netgear_rootfs_node.sh $(KERNEL_BUILD_DIR)/root.squashfs > $@.rootfs
-	awk '/configurations/ { system("cat $@.rootfs") } 1' $@.its > $@.its.tmp
-	@mv -f $@.its.tmp $@.its
-	@rm -f $@.rootfs
-	$(call Build/fit-image,$(1))
 endef
 
 define Build/mt7981-bl2
@@ -33,28 +22,12 @@ define Build/mt7986-bl31-uboot
 	cat $(STAGING_DIR_IMAGE)/mt7986_$1-u-boot.fip >> $@
 endef
 
-define Build/mt7987-bl2
-	cat $(STAGING_DIR_IMAGE)/mt7987-$1-bl2.img >> $@
-endef
-
-define Build/mt7987-bl31-uboot
-	cat $(STAGING_DIR_IMAGE)/mt7987_$1-u-boot.fip >> $@
-endef
-
 define Build/mt7988-bl2
 	cat $(STAGING_DIR_IMAGE)/mt7988-$1-bl2.img >> $@
 endef
 
 define Build/mt7988-bl31-uboot
 	cat $(STAGING_DIR_IMAGE)/mt7988_$1-u-boot.fip >> $@
-endef
-
-define Build/simplefit
-	cp $@ $@.tmp 2>/dev/null || true
-	ptgen -g -o $@.tmp -a 1 -l 1024 \
-	-t 0x2e -N FIT		-p $(CONFIG_TARGET_ROOTFS_PARTSIZE)M@17k
-	cat $@.tmp >> $@
-	rm $@.tmp
 endef
 
 define Build/mt798x-gpt
@@ -79,47 +52,44 @@ define Build/mt798x-gpt
 	rm $@.tmp
 endef
 
-# Variation of the normal partition table to account
-# for factory and mfgdata partition
-#
-# Keep fip partition at standard offset to keep consistency
-# with uboot commands
-define Build/mt7988-mozart-gpt
-	cp $@ $@.tmp 2>/dev/null || true
-	ptgen -g -o $@.tmp -a 1 -l 1024 \
-			-t 0x83	-N ubootenv	-r	-p 512k@4M \
-			-t 0xef	-N fip		  -r	-p 4M@6656k \
-			-t 0x83	-N factory	-r	-p 8M@25M \
-			-t 0x2e	-N mfgdata	-r	-p 8M@33M \
-			-t 0xef -N recovery	-r	-p 32M@41M \
-			-t 0x2e -N production		-p $(CONFIG_TARGET_ROOTFS_PARTSIZE)M@73M
-	cat $@.tmp >> $@
-	rm $@.tmp
+metadata_gl_json = \
+	'{ $(if $(IMAGE_METADATA),$(IMAGE_METADATA)$(comma)) \
+		"metadata_version": "1.1", \
+		"compat_version": "$(call json_quote,$(compat_version))", \
+		$(if $(DEVICE_COMPAT_MESSAGE),"compat_message": "$(call json_quote,$(DEVICE_COMPAT_MESSAGE))"$(comma)) \
+		$(if $(filter-out 1.0,$(compat_version)),"new_supported_devices": \
+			[$(call metadata_devices,$(SUPPORTED_DEVICES))]$(comma) \
+			"supported_devices": ["$(call json_quote,$(legacy_supported_message))"]$(comma)) \
+		$(if $(filter 1.0,$(compat_version)),"supported_devices":[$(call metadata_devices,$(SUPPORTED_DEVICES))]$(comma)) \
+		"version": { \
+			"release": "$(call json_quote,$(VERSION_NUMBER))", \
+			"date": "$(shell TZ='Asia/Chongqing' date '+%Y%m%d%H%M%S')", \
+			"dist": "$(call json_quote,$(VERSION_DIST))", \
+			"version": "$(call json_quote,$(VERSION_NUMBER))", \
+			"revision": "$(call json_quote,$(REVISION))", \
+			"target": "$(call json_quote,$(TARGETID))", \
+			"board": "$(call json_quote,$(if $(BOARD_NAME),$(BOARD_NAME),$(DEVICE_NAME)))" \
+		} \
+	}'
+
+define Build/append-gl-metadata
+	$(if $(SUPPORTED_DEVICES),-echo $(call metadata_gl_json,$(SUPPORTED_DEVICES)) | fwtool -I - $@)
+	sha256sum "$@" | cut -d" " -f1 > "$@.sha256sum"
+	[ ! -s "$(BUILD_KEY)" -o ! -s "$(BUILD_KEY).ucert" -o ! -s "$@" ] || { \
+		cp "$(BUILD_KEY).ucert" "$@.ucert" ;\
+		usign -S -m "$@" -s "$(BUILD_KEY)" -x "$@.sig" ;\
+		ucert -A -c "$@.ucert" -x "$@.sig" ;\
+		fwtool -S "$@.ucert" "$@" ;\
+	}
 endef
 
 define Build/append-openwrt-one-eeprom
 	dd if=$(STAGING_DIR_IMAGE)/mt7981_eeprom_mt7976_dbdc.bin >> $@
 endef
 
-define Build/mstc-header
-  $(eval version=$(word 1,$(1)))
-  $(eval magic=$(word 2,$(1)))
-  gzip -c $@ | tail -c8 > $@.crclen
-  ( \
-    printf "$(magic)"; \
-    tail -c+5 $@.crclen; head -c4 $@.crclen; \
-    dd if=/dev/zero bs=4 count=2; \
-    printf "$(version)" | dd bs=56 count=1 conv=sync 2>/dev/null; \
-    dd if=/dev/zero bs=$$((0x20000 - 0x84)) count=1 conv=sync 2>/dev/null | \
-      tr "\0" "\377"; \
-    cat $@; \
-  ) > $@.new
-  mv $@.new $@
-endef
-
 define Build/zyxel-nwa-fit-filogic
 	$(TOPDIR)/scripts/mkits-zyxel-fit-filogic.sh \
-		$@.its $@ "80 e1 81 e1 ff ff ff ff ff ff"
+		$@.its $@ "80 e1 ff ff ff ff ff ff ff ff"
 	PATH=$(LINUX_DIR)/scripts/dtc:$(PATH) mkimage -f $@.its $@.new
 	@mv $@.new $@
 endef
@@ -139,13 +109,6 @@ define Build/cetron-header
 	rm $@.tmp
 endef
 
-define Build/tenda-mkdualimageheader
-	printf '%b' "\x47\x6f\x64\x31\x00\x00\x00\x00" >"$@.new"
-	gzip -c "$@" | tail -c8 >>"$@.new"
-	cat "$@" >>"$@.new"
-	mv "$@.new" "$@"
-endef
-
 define Device/abt_asr3000
   DEVICE_VENDOR := ABT
   DEVICE_MODEL := ASR3000
@@ -161,9 +124,9 @@ define Device/abt_asr3000
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
   ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot abt_asr3000
@@ -217,48 +180,6 @@ define Device/acer_predator-w6d
 endef
 TARGET_DEVICES += acer_predator-w6d
 
-define Device/acer_predator-w6x-stock
-  DEVICE_VENDOR := Acer
-  DEVICE_MODEL := Predator Connect W6x (Stock Layout)
-  DEVICE_DTS := mt7986a-acer-predator-w6x-stock
-  SUPPORTED_DEVICES += acer,predator-w6x
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  DEVICE_PACKAGES := kmod-usb3 kmod-leds-ws2812b kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  IMAGES := sysupgrade.bin
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += acer_predator-w6x-stock
-
-define Device/acer_predator-w6x-ubootmod
-  DEVICE_VENDOR := Acer
-  DEVICE_MODEL := Predator Connect W6x (OpenWrt U-Boot Layout)
-  DEVICE_DTS := mt7986a-acer-predator-w6x-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-leds-ws2812b kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  IMAGES := sysupgrade.itb
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot acer_predator-w6x
-endef
-TARGET_DEVICES += acer_predator-w6x-ubootmod
-
 define Device/acer_vero-w6m
   DEVICE_VENDOR := Acer
   DEVICE_MODEL := Connect Vero W6m
@@ -273,24 +194,6 @@ define Device/acer_vero-w6m
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += acer_vero-w6m
-
-define Device/asiarf_ap7986-003
-  DEVICE_VENDOR := AsiaRF
-  DEVICE_MODEL := AP7986 003
-  DEVICE_DTS := mt7986a-asiarf-ap7986-003
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-endef
-TARGET_DEVICES += asiarf_ap7986-003
 
 define Device/adtran_smartrg
   DEVICE_VENDOR := Adtran
@@ -355,44 +258,6 @@ $(call Device/adtran_smartrg)
 endef
 TARGET_DEVICES += smartrg_sdg-8734
 
-define Device/airpi_ap3000m
-  DEVICE_VENDOR := Airpi
-  DEVICE_MODEL := AP3000M
-  DEVICE_DTS := mt7981b-airpi-ap3000m
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-  	kmod-hwmon-pwmfan kmod-usb3 f2fsck mkf2fs
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += airpi_ap3000m
-
-define Device/arcadyan_mozart
-  DEVICE_VENDOR := Arcadyan
-  DEVICE_MODEL := Mozart
-  DEVICE_DTS := mt7988a-arcadyan-mozart
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x45f00000
-  DEVICE_PACKAGES := kmod-hwmon-pwmfan e2fsprogs f2fsck mkf2fs kmod-mt7996-firmware
-  KERNEL_LOADADDR := 0x46000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  IMAGES := sysupgrade.itb
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-  ARTIFACTS := emmc-preloader.bin emmc-bl31-uboot.fip emmc-gpt.bin
-  ARTIFACT/emmc-gpt.bin := mt7988-mozart-gpt
-  ARTIFACT/emmc-preloader.bin	:= mt7988-bl2 emmc-comb
-  ARTIFACT/emmc-bl31-uboot.fip	:= mt7988-bl31-uboot arcadyan_mozart
-  SUPPORTED_DEVICES += arcadyan,mozart
-endef
-TARGET_DEVICES += arcadyan_mozart
-
 define Device/asus_rt-ax52
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AX52
@@ -412,37 +277,6 @@ ifeq ($(IB),)
 endif
 endef
 TARGET_DEVICES += asus_rt-ax52
-
-define Device/asus_rt-ax57m
-  DEVICE_VENDOR := ASUS
-  DEVICE_MODEL := RT-AX57M
-  DEVICE_ALT0_VENDOR := ASUS
-  DEVICE_ALT0_MODEL := RT-AX54HP
-  DEVICE_ALT0_VARIANT := V2
-  DEVICE_ALT1_VENDOR := ASUS
-  DEVICE_ALT1_MODEL := RT-AX1800HP
-  DEVICE_ALT1_VARIANT := V2
-  DEVICE_ALT2_VENDOR := ASUS
-  DEVICE_ALT2_MODEL := RT-AX1800S
-  DEVICE_ALT2_VARIANT := V2
-  DEVICE_ALT3_VENDOR := ASUS
-  DEVICE_ALT3_MODEL := RT-AX3000S
-  DEVICE_DTS := mt7981b-asus-rt-ax57m
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  IMAGES := sysupgrade.bin
-  KERNEL := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb  with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-ifeq ($(IB),)
-  ARTIFACTS := initramfs.trx
-  ARTIFACT/initramfs.trx := append-image-stage initramfs-kernel.bin | \
-	uImage none | asus-trx -v 3 -n $$(DEVICE_MODEL)
-endif
-endef
-TARGET_DEVICES += asus_rt-ax57m
 
 define Device/asus_rt-ax59u
   DEVICE_VENDOR := ASUS
@@ -467,16 +301,6 @@ define Device/asus_tuf-ax4200
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-ifeq ($(CONFIG_TARGET_ROOTFS_INITRAMFS_SEPARATE),)
-  # The default boot command of the bootloader does not load the ramdisk from the FIT image
-  ARTIFACTS := initramfs.trx
-  ARTIFACT/initramfs.trx := append-image-stage initramfs-kernel.bin | \
-	uImage none | asus-trx -v 3 -n $$(DEVICE_MODEL)
-endif
-endif
-endif
 endef
 TARGET_DEVICES += asus_tuf-ax4200
 
@@ -488,9 +312,9 @@ define Device/asus_tuf-ax4200q
   DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
   IMAGES := sysupgrade.bin
   KERNEL := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 ifeq ($(IB),)
 ifeq ($(CONFIG_TARGET_INITRAMFS_FORCE),y)
@@ -501,6 +325,30 @@ endif
 endif
 endef
 TARGET_DEVICES += asus_tuf-ax4200q
+
+define Device/arcadyan_mozart
+  DEVICE_VENDOR := Arcadyan
+  DEVICE_MODEL := Mozart
+  DEVICE_DTS := mt7988a-arcadyan-mozart
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTC_FLAGS := --pad 4096
+  DEVICE_DTS_LOADADDR := 0x45f00000
+  DEVICE_PACKAGES := kmod-hwmon-pwmfan e2fsprogs f2fsck mkf2fs kmod-mt7996-firmware
+  KERNEL_LOADADDR := 0x46000000
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  KERNEL_INITRAMFS_SUFFIX := .itb
+  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
+  IMAGES := sysupgrade.itb
+  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
+  ARTIFACTS := emmc-preloader.bin emmc-bl31-uboot.fip emmc-gpt.bin
+  ARTIFACT/emmc-gpt.bin := mt798x-gpt emmc
+  ARTIFACT/emmc-preloader.bin	:= mt7988-bl2 emmc-comb
+  ARTIFACT/emmc-bl31-uboot.fip	:= mt7988-bl31-uboot arcadyan_mozart
+  SUPPORTED_DEVICES += arcadyan,mozart
+endef
+TARGET_DEVICES += arcadyan_mozart
 
 define Device/asus_tuf-ax6000
   DEVICE_VENDOR := ASUS
@@ -517,52 +365,6 @@ define Device/asus_tuf-ax6000
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += asus_tuf-ax6000
-
-define Device/asus_zenwifi-bt8
-  DEVICE_VENDOR := ASUS
-  DEVICE_MODEL := ZenWiFi BT8
-  DEVICE_DTS := mt7988d-asus-zenwifi-bt8
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 mt7988-2p5g-phy-firmware kmod-mt7996-firmware mt7988-wo-firmware
-  KERNEL := kernel-bin | gzip | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_LOADADDR := 0x48080000
-  IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-ifeq ($(IB),)
-ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  ARTIFACTS := factory.bin
-  ARTIFACT/factory.bin := append-image initramfs-kernel.bin | uImage lzma
-endif
-endif
-endef
-TARGET_DEVICES += asus_zenwifi-bt8
-
-define Device/asus_zenwifi-bt8-ubootmod
-  DEVICE_VENDOR := ASUS
-  DEVICE_MODEL := ZenWiFi BT8
-  DEVICE_VARIANT := U-Boot mod
-  DEVICE_DTS := mt7988d-asus-zenwifi-bt8-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x45f00000
-  DEVICE_PACKAGES := kmod-usb3 mt7988-2p5g-phy-firmware kmod-mt7996-firmware mt7988-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7988-bl2 spim-nand-ubi-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7988-bl31-uboot asus_zenwifi-bt8
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL_LOADADDR := 0x46000000
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-endef
-TARGET_DEVICES += asus_zenwifi-bt8-ubootmod
-
 
 define Device/bananapi_bpi-r3
   DEVICE_VENDOR := Bananapi
@@ -615,8 +417,8 @@ endif
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | pad-rootfs | append-metadata
   DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_COMPAT_VERSION := 1.3
-  DEVICE_COMPAT_MESSAGE := First sfp port renamed from eth1 to sfp1
+  DEVICE_COMPAT_VERSION := 1.2
+  DEVICE_COMPAT_MESSAGE := SPI-NAND flash layout changes require bootloader update
 endef
 TARGET_DEVICES += bananapi_bpi-r3
 
@@ -627,8 +429,8 @@ define Device/bananapi_bpi-r3-mini
   DEVICE_DTS_CONFIG := config-mt7986a-bananapi-bpi-r3-mini
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-eeprom-at24 kmod-hwmon-pwmfan kmod-mt7915e kmod-mt7986-firmware \
-		     kmod-phy-airoha-en8811h kmod-usb3 e2fsprogs f2fsck mkf2fs mt7986-wo-firmware
+  DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-mt7915e kmod-mt7986-firmware kmod-phy-airoha-en8811h \
+		     kmod-usb3 e2fsprogs f2fsck mkf2fs mt7986-wo-firmware
   KERNEL_LOADADDR := 0x44000000
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
@@ -646,8 +448,8 @@ endif
     fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
     pad-rootfs | append-metadata
   ARTIFACTS := \
-	emmc-gpt.bin emmc-preloader.bin emmc-bl31-uboot.fip \
-	snand-factory.bin snand-preloader.bin snand-bl31-uboot.fip
+       emmc-gpt.bin emmc-preloader.bin emmc-bl31-uboot.fip \
+       snand-factory.bin snand-preloader.bin snand-bl31-uboot.fip
   ARTIFACT/emmc-gpt.bin := mt798x-gpt emmc
   ARTIFACT/emmc-preloader.bin := mt7986-bl2 emmc-ddr4
   ARTIFACT/emmc-bl31-uboot.fip := mt7986-bl31-uboot bananapi_bpi-r3-mini-emmc
@@ -669,26 +471,20 @@ define Device/bananapi_bpi-r4-common
   DEVICE_VENDOR := Bananapi
   DEVICE_DTS_DIR := $(DTS_DIR)/
   DEVICE_DTS_LOADADDR := 0x45f00000
-  DEVICE_DTS_OVERLAY:= mt7988a-bananapi-bpi-r4-emmc mt7988a-bananapi-bpi-r4-rtc mt7988a-bananapi-bpi-r4-sd
+  DEVICE_DTS_OVERLAY:= mt7988a-bananapi-bpi-r4-emmc mt7988a-bananapi-bpi-r4-rtc mt7988a-bananapi-bpi-r4-sd mt7988a-bananapi-bpi-r4-wifi-mt7996a
   DEVICE_DTC_FLAGS := --pad 4096
   DEVICE_PACKAGES := kmod-hwmon-pwmfan kmod-i2c-mux-pca954x kmod-eeprom-at24 kmod-mt7996-firmware kmod-mt7996-233-firmware \
-		     kmod-rtc-pcf8563 kmod-sfp kmod-phy-aquantia kmod-usb3 e2fsprogs f2fsck mkf2fs mt7988-wo-firmware
-  DEVICE_COMPAT_VERSION := 1.1
-  DEVICE_COMPAT_MESSAGE := The non-switch ports were renamed to match the board/case labels
+		     kmod-rtc-pcf8563 kmod-sfp kmod-usb3 e2fsprogs f2fsck mkf2fs mt7988-wo-firmware
   IMAGES := sysupgrade.itb
   KERNEL_LOADADDR := 0x46000000
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   ARTIFACTS := \
-	       emmc-gpt.bin emmc-preloader.bin emmc-bl31-uboot.fip \
-	       emmc-preloader-8g.bin snand-preloader-8g.bin \
-	       sdcard.img.gz sdcard_8g.img.gz\
+	       emmc-preloader.bin emmc-bl31-uboot.fip \
+	       sdcard.img.gz \
 	       snand-preloader.bin snand-bl31-uboot.fip
-  ARTIFACT/emmc-gpt.bin		:= mt798x-gpt emmc
   ARTIFACT/emmc-preloader.bin	:= mt7988-bl2 emmc-comb
-  ARTIFACT/emmc-preloader-8g.bin	:= mt7988-bl2 emmc-comb-4bg
   ARTIFACT/emmc-bl31-uboot.fip	:= mt7988-bl31-uboot $$(DEVICE_NAME)-emmc
   ARTIFACT/snand-preloader.bin	:= mt7988-bl2 spim-nand-ubi-comb
-  ARTIFACT/snand-preloader-8g.bin	:= mt7988-bl2 spim-nand-ubi-comb-4bg
   ARTIFACT/snand-bl31-uboot.fip	:= mt7988-bl31-uboot $$(DEVICE_NAME)-snand
   ARTIFACT/sdcard.img.gz	:= mt798x-gpt sdmmc |\
 				   pad-to 17k | mt7988-bl2 sdmmc-comb |\
@@ -699,21 +495,6 @@ define Device/bananapi_bpi-r4-common
 				   pad-to 44M | mt7988-bl2 spim-nand-ubi-comb |\
 				   pad-to 45M | mt7988-bl31-uboot $$(DEVICE_NAME)-snand |\
 				   pad-to 51M | mt7988-bl2 emmc-comb |\
-				   pad-to 52M | mt7988-bl31-uboot $$(DEVICE_NAME)-emmc |\
-				   pad-to 56M | mt798x-gpt emmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
-				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
-				) \
-				  gzip
-  ARTIFACT/sdcard_8g.img.gz	:= mt798x-gpt sdmmc |\
-				   pad-to 17k | mt7988-bl2 sdmmc-comb-4bg |\
-				   pad-to 6656k | mt7988-bl31-uboot $$(DEVICE_NAME)-sdmmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS),\
-				   pad-to 12M | append-image-stage initramfs-recovery.itb | check-size 44m |\
-				) \
-				   pad-to 44M | mt7988-bl2 spim-nand-ubi-comb-4bg |\
-				   pad-to 45M | mt7988-bl31-uboot $$(DEVICE_NAME)-snand |\
-				   pad-to 51M | mt7988-bl2 emmc-comb-4bg |\
 				   pad-to 52M | mt7988-bl31-uboot $$(DEVICE_NAME)-emmc |\
 				   pad-to 56M | mt798x-gpt emmc |\
 				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
@@ -737,111 +518,12 @@ TARGET_DEVICES += bananapi_bpi-r4
 
 define Device/bananapi_bpi-r4-poe
   DEVICE_MODEL := BPi-R4 2.5GE
-  DEVICE_DTS := mt7988a-bananapi-bpi-r4-2g5
+  DEVICE_DTS := mt7988a-bananapi-bpi-r4-poe
   DEVICE_DTS_CONFIG := config-mt7988a-bananapi-bpi-r4-poe
   $(call Device/bananapi_bpi-r4-common)
   DEVICE_PACKAGES += mt7988-2p5g-phy-firmware
-  SUPPORTED_DEVICES += bananapi,bpi-r4-2g5
 endef
 TARGET_DEVICES += bananapi_bpi-r4-poe
-
-define Device/bananapi_bpi-r4-lite
-  DEVICE_VENDOR := Bananapi
-  DEVICE_MODEL := BPi-R4 Lite
-  DEVICE_DTS := mt7987a-bananapi-bpi-r4-lite
-  DEVICE_DTS_OVERLAY:= mt7987a-bananapi-bpi-r4-lite-1pcie-2L mt7987a-bananapi-bpi-r4-lite-2pcie-1L \
-		       mt7987a-bananapi-bpi-r4-lite-emmc mt7987a-bananapi-bpi-r4-lite-sd \
-		       mt7987a-bananapi-bpi-r4-lite-nand mt7987a-bananapi-bpi-r4-lite-nor
-  DEVICE_DTS_CONFIG := config-mt7987a-bananapi-bpi-r4-lite
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x4ff00000
-  DEVICE_PACKAGES := kmod-eeprom-at24 kmod-gpio-pca953x kmod-i2c-mux-pca954x \
-		     kmod-rtc-pcf8563 kmod-sfp kmod-usb3 e2fsprogs mkf2fs mt7987-2p5g-phy-firmware
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  KERNEL_LOADADDR := 0x40000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-  ARTIFACTS := \
-	       emmc-preloader.bin emmc-bl31-uboot.fip \
-	       nor-preloader.bin nor-bl31-uboot.fip \
-	       sdcard.img.gz \
-	       snand-preloader.bin snand-bl31-uboot.fip
-  ARTIFACT/emmc-preloader.bin	:= mt7987-bl2 emmc-comb
-  ARTIFACT/emmc-bl31-uboot.fip	:= mt7987-bl31-uboot bananapi_bpi-r4-lite-emmc
-  ARTIFACT/nor-preloader.bin	:= mt7987-bl2 nor-comb
-  ARTIFACT/nor-bl31-uboot.fip	:= mt7987-bl31-uboot bananapi_bpi-r4-lite-nor
-  ARTIFACT/snand-preloader.bin	:= mt7987-bl2 spim-nand2-ubi-comb
-  ARTIFACT/snand-bl31-uboot.fip	:= mt7987-bl31-uboot bananapi_bpi-r4-lite-snand
-  ARTIFACT/sdcard.img.gz	:= mt798x-gpt sdmmc |\
-				   pad-to 17k | mt7987-bl2 sdmmc-comb |\
-				   pad-to 6656k | mt7987-bl31-uboot bananapi_bpi-r4-lite-sdmmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS),\
-				   pad-to 12M | append-image-stage initramfs-recovery.itb | check-size 44m |\
-				) \
-				   pad-to 44M | mt7987-bl2 spim-nand2-ubi-comb |\
-				   pad-to 45M | mt7987-bl31-uboot bananapi_bpi-r4-lite-snand |\
-				   pad-to 49M | mt7987-bl2 nor-comb |\
-				   pad-to 50M | mt7987-bl31-uboot bananapi_bpi-r4-lite-nor |\
-				   pad-to 51M | mt7987-bl2 emmc-comb |\
-				   pad-to 52M | mt7987-bl31-uboot bananapi_bpi-r4-lite-emmc |\
-				   pad-to 56M | mt798x-gpt emmc |\
-				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
-				   pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
-				) \
-				  gzip
-ifeq ($(DUMP),)
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-endif
-endef
-TARGET_DEVICES += bananapi_bpi-r4-lite
-
-define Device/bazis_ax3000wm
-  DEVICE_VENDOR := Bazis
-  DEVICE_MODEL := AX3000WM
-  DEVICE_DTS := mt7981b-bazis-ax3000wm
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	append-metadata
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot bazis-ax3000wm
-endef
-TARGET_DEVICES += bazis_ax3000wm
-
-define Device/buffalo_wsr-6000ax8
-  DEVICE_MODEL := WSR-6000AX8
-  DEVICE_VENDOR := Buffalo
-  DEVICE_ALT0_MODEL := WSR-6000AX8P
-  DEVICE_ALT0_VENDOR := Buffalo
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS := mt7986b-buffalo-wsr-6000ax8
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  IMAGE_SIZE := 26624k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += buffalo_wsr-6000ax8
 
 define Device/cetron_ct3003
   DEVICE_VENDOR := Cetron
@@ -939,20 +621,14 @@ define Device/cmcc_rax3000m
   IMAGE/sysupgrade.itb := append-kernel | \
 	 fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
 	 pad-rootfs | append-metadata
-  ARTIFACTS := emmc-gpt.bin \
-	emmc-ddr3-bl31-uboot.fip emmc-ddr3-preloader.bin \
-	emmc-ddr4-bl31-uboot.fip emmc-ddr4-preloader.bin \
-	nand-ddr3-bl31-uboot.fip nand-ddr3-preloader.bin \
-	nand-ddr4-bl31-uboot.fip nand-ddr4-preloader.bin
+  ARTIFACTS := \
+	emmc-gpt.bin emmc-preloader.bin emmc-bl31-uboot.fip \
+	nand-preloader.bin nand-bl31-uboot.fip
   ARTIFACT/emmc-gpt.bin := mt798x-gpt emmc
-  ARTIFACT/emmc-ddr3-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-emmc-ddr3
-  ARTIFACT/emmc-ddr3-preloader.bin  := mt7981-bl2 emmc-ddr3-1866
-  ARTIFACT/emmc-ddr4-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-emmc-ddr4
-  ARTIFACT/emmc-ddr4-preloader.bin  := mt7981-bl2 emmc-ddr4
-  ARTIFACT/nand-ddr3-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-nand-ddr3
-  ARTIFACT/nand-ddr3-preloader.bin  := mt7981-bl2 spim-nand-ddr3-1866
-  ARTIFACT/nand-ddr4-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-nand-ddr4
-  ARTIFACT/nand-ddr4-preloader.bin  := mt7981-bl2 spim-nand-ddr4
+  ARTIFACT/emmc-preloader.bin := mt7981-bl2 emmc-ddr4
+  ARTIFACT/emmc-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-emmc
+  ARTIFACT/nand-preloader.bin := mt7981-bl2 spim-nand-ddr4
+  ARTIFACT/nand-bl31-uboot.fip := mt7981-bl31-uboot cmcc_rax3000m-nand
 endef
 TARGET_DEVICES += cmcc_rax3000m
 
@@ -968,9 +644,9 @@ define Device/comfast_cf-e393ax
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
   KERNEL_LOADADDR := 0x44000000
   KERNEL = kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+       fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL_INITRAMFS = kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+       fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
   PAGESIZE := 2048
@@ -981,44 +657,6 @@ define Device/comfast_cf-e393ax
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += comfast_cf-e393ax
-
-define Device/comfast_cf-wr632ax-common
-  DEVICE_VENDOR := COMFAST
-  DEVICE_MODEL := CF-WR632AX
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-hwmon-pwmfan kmod-usb3
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-endef
-
-define Device/comfast_cf-wr632ax
-  DEVICE_DTS := mt7981b-comfast-cf-wr632ax
-  IMAGE_SIZE := 65536k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  SUPPORTED_DEVICES += cf-wr632ax
-  $(call Device/comfast_cf-wr632ax-common)
-endef
-TARGET_DEVICES += comfast_cf-wr632ax
-
-define Device/comfast_cf-wr632ax-ubootmod
-  DEVICE_VARIANT := (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-comfast-cf-wr632ax-ubootmod
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot comfast_cf-wr632ax
-  $(call Device/comfast_cf-wr632ax-common)
-endef
-TARGET_DEVICES += comfast_cf-wr632ax-ubootmod
 
 define Device/confiabits_mt7981
   DEVICE_VENDOR := Confiabits
@@ -1035,44 +673,6 @@ define Device/confiabits_mt7981
   DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
 endef
 TARGET_DEVICES += confiabits_mt7981
-
-define Device/creatlentem_clt-r30b1-common
-  DEVICE_VENDOR := CreatLentem
-  DEVICE_MODEL := CLT-R30B1
-  DEVICE_ALT0_VENDOR := EDUP
-  DEVICE_ALT0_MODEL := RT2980
-  DEVICE_ALT1_VENDOR := Dragonglass
-  DEVICE_ALT1_MODEL := DGX21
-  DEVICE_ALT2_VENDOR := Livinet
-  DEVICE_ALT2_MODEL := Li228
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-
-define Device/creatlentem_clt-r30b1-112m
-  DEVICE_VARIANT := 112M
-  DEVICE_ALT0_VARIANT := 112M
-  DEVICE_ALT1_VARIANT := 112M
-  DEVICE_ALT2_VARIANT := 112M
-  DEVICE_DTS := mt7981b-creatlentem-clt-r30b1-112m
-  SUPPORTED_DEVICES += clt,r30b1 clt,r30b1-112m
-  IMAGE_SIZE := 114688k
-  $(call Device/creatlentem_clt-r30b1-common)
-endef
-TARGET_DEVICES += creatlentem_clt-r30b1-112m
-
-define Device/creatlentem_clt-r30b1
-  DEVICE_DTS := mt7981b-creatlentem-clt-r30b1
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-  IMAGE_SIZE := 65536k
-  $(call Device/creatlentem_clt-r30b1-common)
-endef
-TARGET_DEVICES += creatlentem_clt-r30b1
 
 define Device/cudy_ap3000outdoor-v1
   DEVICE_VENDOR := Cudy
@@ -1091,23 +691,6 @@ define Device/cudy_ap3000outdoor-v1
 endef
 TARGET_DEVICES += cudy_ap3000outdoor-v1
 
-define Device/cudy_ap3000wall-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := AP3000 Wall
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-ap3000wall-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R68
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_ap3000wall-v1
-
 define Device/cudy_ap3000-v1
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := AP3000
@@ -1121,14 +704,14 @@ define Device/cudy_ap3000-v1
   IMAGE_SIZE := 65536k
   KERNEL_IN_UBI := 1
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-motorcomm
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
 endef
 TARGET_DEVICES += cudy_ap3000-v1
 
 define Device/cudy_m3000-v1
   DEVICE_VENDOR := Cudy
   DEVICE_MODEL := M3000
-  DEVICE_VARIANT := v1/v2
+  DEVICE_VARIANT := v1
   DEVICE_DTS := mt7981b-cudy-m3000-v1
   DEVICE_DTS_DIR := ../dts
   SUPPORTED_DEVICES += R37
@@ -1146,28 +729,6 @@ define Device/cudy_m3000-v1
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
 endef
 TARGET_DEVICES += cudy_m3000-v1
-
-define Device/cudy_m3000-v2-yt8821
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := M3000
-  DEVICE_VARIANT := v2 with Motorcomm YT8821
-  DEVICE_DTS := mt7981b-cudy-m3000-v2-yt8821
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R37
-  DEVICE_DTS_LOADADDR := 0x44000000
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  KERNEL := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-motorcomm
-endef
-TARGET_DEVICES += cudy_m3000-v2-yt8821
 
 define Device/cudy_re3000-v1
   DEVICE_VENDOR := Cudy
@@ -1242,7 +803,7 @@ define Device/cudy_tr3000-v1-ubootmod
   IMAGE/sysupgrade.itb := append-kernel | \
 	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 cudy-ddr3
+  ARTIFACT/preloader.bin := mt7981-bl2 cudy-tr3000-v1
   ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot cudy_tr3000-v1
 endef
 TARGET_DEVICES += cudy_tr3000-v1-ubootmod
@@ -1313,7 +874,7 @@ define Device/cudy_wr3000h-v1
   IMAGE_SIZE := 65536k
   KERNEL_IN_UBI := 1
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-motorcomm
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
 endef
 TARGET_DEVICES += cudy_wr3000h-v1
 
@@ -1330,51 +891,9 @@ define Device/cudy_wr3000p-v1
   IMAGE_SIZE := 65536k
   KERNEL_IN_UBI := 1
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
 endef
 TARGET_DEVICES += cudy_wr3000p-v1
-
-define Device/cudy_wbr3000uax-v1
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WBR3000UAX
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-cudy-wbr3000uax-v1
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += R120
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += cudy_wbr3000uax-v1
-
-define Device/cudy_wbr3000uax-v1-ubootmod
-  DEVICE_VENDOR := Cudy
-  DEVICE_MODEL := WBR3000UAX
-  DEVICE_VARIANT := v1 (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-cudy-wbr3000uax-v1-ubootmod
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 cudy-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot cudy_wbr3000uax-v1
-endef
-TARGET_DEVICES += cudy_wbr3000uax-v1-ubootmod
 
 define Device/dlink_aquila-pro-ai-m30-a1
   DEVICE_VENDOR := D-Link
@@ -1433,40 +952,19 @@ define Device/edgecore_eap111
 endef
 TARGET_DEVICES += edgecore_eap111
 
-define Device/elecom_wrc-x3000gs3
-  DEVICE_VENDOR := ELECOM
-  DEVICE_MODEL := WRC-X3000GS3
-  DEVICE_DTS := mt7981b-elecom-wrc-x3000gs3
-  DEVICE_DTS_DIR := ../dts
-  IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGE/factory.bin := sysupgrade-tar | mstc-header 5.04(XZQ.0)b90 COMD | \
-	elecom-product-header WRC-X3000GS3
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += elecom_wrc-x3000gs3
-
 define Device/gatonetworks_gdsp
   DEVICE_VENDOR := GatoNetworks
   DEVICE_MODEL := gdsp
   DEVICE_DTS := mt7981b-gatonetworks-gdsp
-  DEVICE_DTS_OVERLAY := \
-  mt7981b-gatonetworks-gdsp-gps \
-  mt7981b-gatonetworks-gdsp-sd \
-  mt7981b-gatonetworks-gdsp-sd-boot
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
   IMAGES := sysupgrade.itb
   IMAGE_SIZE := 32768k
-  DEVICE_PACKAGES := e2fsprogs f2fsck mkf2fs fitblk \
-    kmod-mt7915e kmod-mt7981-firmware \
+  DEVICE_PACKAGES := fitblk kmod-mt7915e kmod-mt7981-firmware \
     kmod-usb-net-qmi-wwan kmod-usb-serial-option kmod-usb3 \
-    mt7981-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip sdcard.img.gz
+    mt7981-wo-firmware -kmod-phy-aquantia
+  ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7981-bl2 nor-ddr3
   ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot gatonetworks_gdsp
-  ARTIFACT/sdcard.img.gz := simplefit |\
-  append-image squashfs-sysupgrade.itb | check-size | gzip
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
@@ -1482,13 +980,9 @@ define Device/glinet_gl-mt2500
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTS_LOADADDR := 0x47000000
   DEVICE_PACKAGES := -wpad-basic-mbedtls e2fsprogs f2fsck mkf2fs kmod-usb3
-  SUPPORTED_DEVICES += glinet,mt2500-emmc
-  IMAGES := sysupgrade.bin factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to 32M | append-rootfs
+  SUPPORTED_DEVICES += glinet,mt2500-emmc glinet,gl-mt2500-airoha
+  IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
-  ARTIFACTS := emmc-preloader.bin emmc-bl31-uboot.fip
-  ARTIFACT/emmc-preloader.bin := mt7981-bl2 emmc-ddr4
-  ARTIFACT/emmc-bl31-uboot.fip := mt7981-bl31-uboot glinet_gl-mt2500
 endef
 TARGET_DEVICES += glinet_gl-mt2500
 
@@ -1500,7 +994,7 @@ define Device/glinet_gl-mt2500-airoha
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTS_LOADADDR := 0x47000000
   DEVICE_PACKAGES := -wpad-basic-mbedtls e2fsprogs f2fsck mkf2fs kmod-usb3 kmod-phy-airoha-en8811h airoha-en8811h-firmware
-  SUPPORTED_DEVICES += glinet,mt2500-emmc
+  SUPPORTED_DEVICES += glinet,mt2500-emmc glinet,gl-mt2500
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-gl-metadata
 endef
@@ -1583,9 +1077,9 @@ define Device/h3c_magic-nx30-pro
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
@@ -1621,30 +1115,6 @@ define Device/huasifei_wh3000-pro
 endef
 TARGET_DEVICES += huasifei_wh3000-pro
 
-define Device/imou_hx21
-  DEVICE_VENDOR := Imou
-  DEVICE_MODEL := HX21
-  DEVICE_DTS := mt7981b-imou-hx21
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot imou_hx21
-endef
-TARGET_DEVICES += imou_hx21
-
 define Device/iptime_ax3000q
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := AX3000Q
@@ -1664,26 +1134,6 @@ define Device/iptime_ax3000q
 endef
 TARGET_DEVICES += iptime_ax3000q
 
-define Device/iptime_ax3000se
-  DEVICE_VENDOR := ipTIME
-  DEVICE_MODEL := AX3000SE
-  DEVICE_DTS := mt7981b-iptime-ax3000se
-  DEVICE_DTS_DIR := ../dts
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 32768k
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := sysupgrade.bin
-  IMAGES := factory.bin sysupgrade.bin
-  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3kse
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-endef
-TARGET_DEVICES += iptime_ax3000se
-
 define Device/iptime_ax3000sm
   DEVICE_VENDOR := ipTIME
   DEVICE_MODEL := AX3000SM
@@ -1702,26 +1152,6 @@ define Device/iptime_ax3000sm
   SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
 endef
 TARGET_DEVICES += iptime_ax3000sm
-
-define Device/iptime_ax3000m
-  DEVICE_VENDOR := ipTIME
-  DEVICE_MODEL := AX3000M
-  DEVICE_DTS := mt7981b-iptime-ax3000m
-  DEVICE_DTS_DIR := ../dts
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 32768k
-  KERNEL := kernel-bin | lzma | \
-	    fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := factory.bin sysupgrade.bin
-  IMAGE/factory.bin := sysupgrade-tar | append-metadata | check-size | iptime-crc32 ax3000m
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-endef
-TARGET_DEVICES += iptime_ax3000m
 
 define Device/iptime_ax7800m-6e
   DEVICE_VENDOR := ipTIME
@@ -1756,9 +1186,9 @@ define Device/jcg_q30-pro
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
@@ -1791,93 +1221,6 @@ define Device/jdcloud_re-cp-03
   ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot jdcloud_re-cp-03
 endef
 TARGET_DEVICES += jdcloud_re-cp-03
-
-define Device/kebidumei_ax3000-u22
-  DEVICE_VENDOR := Kebidumei
-  DEVICE_MODEL := AX3000-U22
-  DEVICE_DTS := mt7981b-kebidumei-ax3000-u22
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  IMAGE_SIZE := 14848k
-  KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-nor-rfb
-endef
-TARGET_DEVICES += kebidumei_ax3000-u22
-
-define Device/keenetic_kap-630-common
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-		kmod-phy-airoha-en8811h
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_SIZE := 6144k
-  IMAGE_SIZE := 108544k
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
-	append-squashfs4-fakeroot
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | zyimage -d $$(ZYIMAGE_ID) -v "$$(DEVICE_MODEL)"
-endef
-
-define Device/keenetic_kap-630
-  DEVICE_VENDOR := Keenetic
-  DEVICE_MODEL := KAP-630
-  DEVICE_DTS := mt7981b-keenetic-kap-630
-  ZYIMAGE_ID := 0x810630
-  $(call Device/keenetic_kap-630-common)
-endef
-TARGET_DEVICES += keenetic_kap-630
-
-define Device/keenetic_kn-1812-common
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7992-firmware kmod-usb3 \
-		mt7988-2p5g-phy-firmware mt7988-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_SIZE := 6144k
-  IMAGE_SIZE := 229888k
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
-	append-squashfs4-fakeroot
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | zyimage -d $$(ZYIMAGE_ID) -v "$$(DEVICE_MODEL)"
-endef
-
-define Device/keenetic_kn-1812
-  DEVICE_VENDOR := Keenetic
-  DEVICE_MODEL := KN-1812
-  DEVICE_DTS := mt7988d-keenetic-kn-1812
-  ZYIMAGE_ID := 0x801812
-  $(call Device/keenetic_kn-1812-common)
-endef
-TARGET_DEVICES += keenetic_kn-1812
-
-define Device/keenetic_kn-3711
-  DEVICE_VENDOR := Keenetic
-  DEVICE_MODEL := KN-3711
-  DEVICE_DTS := mt7981b-keenetic-kn-3711
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_SIZE := 6144k
-  IMAGE_SIZE := 108544k
-  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
-	append-squashfs4-fakeroot
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | zyimage -d 0x803711 -v "KN-3711"
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += keenetic_kn-3711
 
 define Device/keenetic_kn-3811
   DEVICE_VENDOR := Keenetic
@@ -2042,57 +1385,6 @@ define Device/mediatek_mt7986b-rfb
 endef
 TARGET_DEVICES += mediatek_mt7986b-rfb
 
-define Device/mediatek_mt7987a-rfb
-  DEVICE_VENDOR := MediaTek
-  DEVICE_MODEL := MT7987A rfb
-  DEVICE_DTS := mt7987a-rfb
-  DEVICE_DTS_OVERLAY:= \
-	mt7987a-rfb-spim-nand \
-	mt7987a-rfb-spim-nor \
-	mt7987a-rfb-emmc \
-	mt7987a-rfb-sd \
-	mt7987a-rfb-eth0-an8801sb \
-	mt7987a-rfb-eth0-an8855 \
-	mt7987a-rfb-eth0-e2p5g \
-	mt7987a-rfb-eth0-mt7531 \
-	mt7987a-rfb-eth1-i2p5g \
-	mt7987a-rfb-eth2-an8801sb \
-	mt7987a-rfb-eth2-e2p5g \
-	mt7987a-rfb-eth2-sfp \
-	mt7987a-rfb-eth2-usb
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x4ff00000
-  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-sfp
-  KERNEL_LOADADDR := 0x40000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  IMAGE_SIZE := $$(shell expr 64 + $$(CONFIG_TARGET_ROOTFS_PARTSIZE))m
-  IMAGES := sysupgrade.itb
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-  ARTIFACTS := \
-	snand-preloader.bin \
-	snand-bl31-uboot.fip \
-	sdcard.img.gz
-  ARTIFACT/snand-preloader.bin	:= mt7987-bl2 spim-nand0-ubi-comb
-  ARTIFACT/snand-bl31-uboot.fip	:= mt7987-bl31-uboot rfb-spim-nand
-  ARTIFACT/sdcard.img.gz	:= mt798x-gpt sdmmc |\
-				   pad-to 17k | mt7987-bl2 sdmmc-comb |\
-				   pad-to 6656k | mt7987-bl31-uboot rfb-sd |\
-				$(if $(CONFIG_TARGET_ROOTFS_INITRAMFS),\
-				  pad-to 12M | append-image-stage initramfs.itb | check-size 44m |\
-				) \
-				$(if $(CONFIG_TARGET_ROOTFS_SQUASHFS),\
-				  pad-to 64M | append-image squashfs-sysupgrade.itb | check-size |\
-				) \
-				  gzip
-endef
-TARGET_DEVICES += mediatek_mt7987a-rfb
-
 define Device/mediatek_mt7988a-rfb
   DEVICE_VENDOR := MediaTek
   DEVICE_MODEL := MT7988A rfb
@@ -2114,7 +1406,7 @@ define Device/mediatek_mt7988a-rfb
   DEVICE_DTS_DIR := $(DTS_DIR)/
   DEVICE_DTC_FLAGS := --pad 4096
   DEVICE_DTS_LOADADDR := 0x45f00000
-  DEVICE_PACKAGES := mt7988-2p5g-phy-firmware kmod-sfp kmod-phy-aquantia
+  DEVICE_PACKAGES := mt7988-2p5g-phy-firmware kmod-sfp
   KERNEL_LOADADDR := 0x46000000
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
@@ -2169,19 +1461,6 @@ define Device/mercusys_mr80x-v3
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += mercusys_mr80x-v3
-
-define Device/mercusys_mr85x
-  DEVICE_VENDOR := MERCUSYS
-  DEVICE_MODEL := MR85X
-  DEVICE_DTS := mt7981b-mercusys-mr85x
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-phy-airoha-en8811h swconfig kmod-switch-rtl8367s
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += mercusys_mr85x
 
 define Device/mercusys_mr90x-v1
   DEVICE_VENDOR := MERCUSYS
@@ -2239,102 +1518,15 @@ define Device/netcore_n60
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr3
   ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot netcore_n60
 endef
 TARGET_DEVICES += netcore_n60
-
-define Device/netcore_n60-pro
-  DEVICE_VENDOR := Netcore
-  DEVICE_MODEL := N60 Pro
-  DEVICE_ALT0_VENDOR := netis
-  DEVICE_ALT0_MODEL := NX62
-  DEVICE_ALT0_VARIANT := V1
-  DEVICE_DTS := mt7986a-netcore-n60-pro
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-usb3
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr4
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot netcore_n60-pro
-endef
-TARGET_DEVICES += netcore_n60-pro
-
-define Device/netcraze_nap-630
-  DEVICE_VENDOR := Netcraze
-  DEVICE_MODEL := NAP-630
-  DEVICE_DTS := mt7981b-netcraze-nap-630
-  ZYIMAGE_ID := 0xC10630
-  $(call Device/keenetic_kap-630-common)
-endef
-TARGET_DEVICES += netcraze_nap-630
-
-define Device/netcraze_nc-1812
-  DEVICE_VENDOR := Netcraze
-  DEVICE_MODEL := NC-1812
-  DEVICE_DTS := mt7988d-netcraze-nc-1812
-  ZYIMAGE_ID := 0xC01812
-  $(call Device/keenetic_kn-1812-common)
-endef
-TARGET_DEVICES += netcraze_nc-1812
-
-define Device/netgear_eax17
-  DEVICE_VENDOR := NETGEAR
-  DEVICE_MODEL := EAX17
-  DEVICE_ALT0_VENDOR := NETGEAR
-  DEVICE_ALT0_MODEL := EAX11
-  DEVICE_ALT0_VARIANT := v3
-  DEVICE_ALT1_VENDOR := NETGEAR
-  DEVICE_ALT1_MODEL := EAX15
-  DEVICE_ALT1_VARIANT := v3
-  DEVICE_ALT2_VENDOR := NETGEAR
-  DEVICE_ALT2_MODEL := EAX14
-  DEVICE_ALT2_VARIANT := v3
-  DEVICE_ALT3_VENDOR := NETGEAR
-  DEVICE_ALT3_MODEL := EAX12
-  DEVICE_ALT3_VARIANT := v2
-  DEVICE_ALT4_VENDOR := NETGEAR
-  DEVICE_ALT4_MODEL := EAX16
-  DEVICE_ALT5_VENDOR := NETGEAR
-  DEVICE_ALT5_MODEL := EAX19
-  DEVICE_DTS := mt7981b-netgear-eax17
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  NETGEAR_ENC_MODEL := EAX17
-  NETGEAR_ENC_REGION := US
-  NETGEAR_ENC_HW_ID_LIST := 1010000013120000_NETGEAR
-  NETGEAR_ENC_MODEL_LIST := EAX17;EAX11v3;EAX15v3;EAX14v3;EAX12v2;EAX16;EAX19
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL = kernel-bin | lzma | \
-	fit-with-netgear-top-level-rootfs-node lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_IN_UBI := 1
-  IMAGE_SIZE := 81920k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  IMAGES += factory.img
-  # Padding to 10M seems to be required by OEM web interface
-  IMAGE/factory.img := sysupgrade-tar | \
-	  pad-to 10M | check-size | netgear-encrypted-factory
-endef
-TARGET_DEVICES += netgear_eax17
 
 define Device/netgear_wax220
   DEVICE_VENDOR := NETGEAR
@@ -2353,37 +1545,6 @@ define Device/netgear_wax220
 	  pad-to 10M | check-size | netgear-encrypted-factory
 endef
 TARGET_DEVICES += netgear_wax220
-
-define Device/netis_nx30v2
-  DEVICE_VENDOR := Netis
-  DEVICE_MODEL := NX30V2
-  DEVICE_ALT0_VENDOR := Netcore
-  DEVICE_ALT0_MODEL := POWER30AX
-  DEVICE_ALT1_VENDOR := Netcore
-  DEVICE_ALT1_MODEL := N30PRO
-  DEVICE_ALT2_VENDOR := GWBN
-  DEVICE_ALT2_MODEL := GW3001
-  DEVICE_ALT3_VENDOR := GLC
-  DEVICE_ALT3_MODEL := W7
-  DEVICE_DTS := mt7981b-netis-nx30v2
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_LOADADDR := 0x44000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  IMAGE_SIZE := 117248k
-  IMAGE/sysupgrade.itb := append-kernel | fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | pad-rootfs | append-metadata
-  ARTIFACTS := spim-nand-preloader.bin spim-nand-bl31-uboot.fip
-  ARTIFACT/spim-nand-preloader.bin	:= mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/spim-nand-bl31-uboot.fip	:= mt7981-bl31-uboot netis_nx30v2
-endef
-TARGET_DEVICES += netis_nx30v2
 
 define Device/netis_nx31
   DEVICE_VENDOR := netis
@@ -2410,32 +1571,6 @@ define Device/netis_nx31
 endef
 TARGET_DEVICES += netis_nx31
 
-define Device/netis_nx32u
-  DEVICE_VENDOR := netis
-  DEVICE_MODEL := NX32U
-  DEVICE_DTS := mt7981b-netis-nx32u
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-	kmod-usb3 kmod-usb-ledtrig-usbport
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot netis_nx32u
-endef
-TARGET_DEVICES += netis_nx32u
-
 define Device/nokia_ea0326gmp
   DEVICE_VENDOR := Nokia
   DEVICE_MODEL := EA0326GMP
@@ -2451,27 +1586,14 @@ define Device/nokia_ea0326gmp
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
   ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot nokia_ea0326gmp
 endef
 TARGET_DEVICES += nokia_ea0326gmp
-
-define Device/nradio_c8-668gl
-  DEVICE_VENDOR := NRadio
-  DEVICE_MODEL := C8-668GL
-  DEVICE_DTS := mt7981b-nradio-c8-668gl
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware \
-	kmod-usb-serial-option kmod-usb-net-cdc-ether kmod-usb-net-qmi-wwan \
-	kmod-usb3
-  IMAGE_SIZE := 131072k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata | check-size
-endef
-TARGET_DEVICES += nradio_c8-668gl
 
 define Device/openembed_som7981
   DEVICE_VENDOR := OpenEmbed
@@ -2501,7 +1623,7 @@ define Device/openfi_6c
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3
   KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += openfi_6c
@@ -2513,7 +1635,7 @@ define Device/openwrt_one
   DEVICE_DTS_DIR := ../dts
   DEVICE_DTC_FLAGS := --pad 4096
   DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-rtc-pcf8563 kmod-usb3 kmod-phy-airoha-en8811h
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-rtc-pcf8563 kmod-usb3 kmod-nvme kmod-phy-airoha-en8811h
   KERNEL_LOADADDR := 0x44000000
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
@@ -2566,9 +1688,9 @@ define Device/qihoo_360t7
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
@@ -2629,34 +1751,6 @@ define Device/routerich_ax3000-v1
 endef
 TARGET_DEVICES += routerich_ax3000-v1
 
-define Device/routerich_be7200
-  DEVICE_VENDOR := Routerich
-  DEVICE_MODEL := BE7200
-  DEVICE_DTS := mt7987a-routerich-be7200
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL_LOADADDR := 0x40000000
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
-	pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
-	pad-rootfs | append-metadata
-  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware kmod-mt7992-firmware \
-	 kmod-regulator-userspace-consumer kmod-usb3
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7987-bl2 spim-nand0
-  ARTIFACT/bl31-uboot.fip := mt7987-bl31-uboot routerich_be7200
-endef
-TARGET_DEVICES += routerich_be7200
-
 define Device/ruijie_rg-x60-pro
   DEVICE_VENDOR := Ruijie
   DEVICE_MODEL := RG-X60 Pro
@@ -2666,86 +1760,6 @@ define Device/ruijie_rg-x60-pro
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += ruijie_rg-x60-pro
-
-define Device/snr_snr-cpe-ax2
-  DEVICE_VENDOR := SNR
-  DEVICE_MODEL := SNR-CPE-AX2
-  DEVICE_DTS := mt7981b-snr-snr-cpe-ax2
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
-	append-metadata
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot snr_snr-cpe-ax2
-endef
-TARGET_DEVICES += snr_snr-cpe-ax2
-
-define Device/teltonika_rutc50
-  DEVICE_VENDOR := Teltonika
-  DEVICE_MODEL := RUTC50
-  SUPPORTED_TELTONIKA_DEVICES := teltonika,rutc
-  DEVICE_DTS := mt7981a-teltonika-rutc50
-  DEVICE_DTS_DIR := ../dts
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBINIZE_OPTS := -E 5
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-net-qmi-wwan \
-  kmod-usb-serial-option kmod-gpio-nxp-74hc164 uqmi
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | append-teltonika-metadata
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += teltonika_rutc50
-
-define Device/tenbay_wr3000k
-  DEVICE_VENDOR := Tenbay
-  DEVICE_MODEL := WR3000K
-  DEVICE_DTS := mt7981b-tenbay-wr3000k
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 49152k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  KERNEL = kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS = kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
-endef
-TARGET_DEVICES += tenbay_wr3000k
-
-define Device/tenda_be12-pro
-  DEVICE_VENDOR := Tenda
-  DEVICE_MODEL := BE12 Pro
-  DEVICE_DTS := mt7987a-tenda-be12-pro
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := mt7987-2p5g-phy-firmware airoha-en8811h-firmware kmod-phy-airoha-en8811h kmod-mt7992-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_LOADADDR := 0x40000000
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.bin := append-kernel | tenda-mkdualimageheader | sysupgrade-tar kernel=$$$$@ | append-metadata
-endef
-TARGET_DEVICES += tenda_be12-pro
 
 define Device/totolink_x6000r
   DEVICE_VENDOR := TOTOLINK
@@ -2760,8 +1774,7 @@ TARGET_DEVICES += totolink_x6000r
 
 define Device/tplink_archer-ax80-v1
   DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := Archer AX80
-  DEVICE_VARIANT := v1
+  DEVICE_MODEL := Archer AX80V1
   DEVICE_DTS := mt7986a-tplink-archer-ax80-v1
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-leds-lp5523 kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
@@ -2772,55 +1785,6 @@ define Device/tplink_archer-ax80-v1
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += tplink_archer-ax80-v1
-
-define Device/tplink_archer-ax80-v1-eu
-  DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := Archer AX80
-  DEVICE_VARIANT := v1 (EU)
-  DEVICE_DTS := mt7986b-tplink-archer-ax80-v1-eu
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 51200k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += tplink_archer-ax80-v1-eu
-
-define Device/tplink_be450
-  DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := BE450
-  DEVICE_DTS := mt7988d-tplink-be450
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7992-firmware kmod-usb3 \
-	    mt7988-2p5g-phy-firmware mt7988-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 51200k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += tplink_be450
-
-define Device/tplink_eap683-lr
-  DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := EAP683-LR
-  DEVICE_ALT0_VENDOR := TP-Link
-  DEVICE_ALT0_MODEL := EAP683-UR
-  DEVICE_DTS := mt7986a-tplink-eap683-lr
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 39424k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += tplink_eap683-lr
 
 define Device/tplink_re6000xd
   DEVICE_VENDOR := TP-Link
@@ -2836,26 +1800,6 @@ define Device/tplink_re6000xd
 endef
 TARGET_DEVICES += tplink_re6000xd
 
-define Device/tplink_fr365-v1
-  DEVICE_VENDOR := TP-Link
-  DEVICE_MODEL := FR365
-  DEVICE_VARIANT := v1
-  DEVICE_DTS := mt7981b-tplink-fr365v1
-  DEVICE_DTS_DIR := ../dts
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 32768k
-  KERNEL_IN_UBI := 1
-  IMAGES += factory.bin
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/factory.ubi := append-ubi | check-size $$$$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := fitblk kmod-sfp kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-endef
-TARGET_DEVICES += tplink_fr365-v1
-
 define Device/tplink_tl-xdr-common
   DEVICE_VENDOR := TP-Link
   DEVICE_DTS_DIR := ../dts
@@ -2868,9 +1812,9 @@ define Device/tplink_tl-xdr-common
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | append-metadata
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | append-metadata
   DEVICE_PACKAGES := fitblk kmod-usb3 kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr3
@@ -2960,24 +1904,6 @@ define Device/wavlink_wl-wn536ax6-a
 endef
 TARGET_DEVICES += wavlink_wl-wn536ax6-a
 
-define Device/wavlink_wl-wn551x3
-  DEVICE_VENDOR := WAVLINK
-  DEVICE_MODEL := WL-WN551X3
-  DEVICE_DTS := mt7981b-wavlink-wl-wn551x3
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  DEVICE_PACKAGES := kmod-usb3 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  SUPPORTED_DEVICES += mediatek,mt7981-spim-snand-rfb
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += wavlink_wl-wn551x3
-
 define Device/wavlink_wl-wn586x3
   DEVICE_VENDOR := WAVLINK
   DEVICE_MODEL := WL-WN586X3
@@ -2988,25 +1914,6 @@ define Device/wavlink_wl-wn586x3
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
 endef
 TARGET_DEVICES += wavlink_wl-wn586x3
-
-define Device/wavlink_wl-wn586x3b
-  DEVICE_VENDOR := WAVLINK
-  DEVICE_MODEL := WL-WN586X3B
-  DEVICE_DTS := mt7981b-wavlink-wl-wn586x3b
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTS_LOADADDR := 0x47000000
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_INITRAMFS_SUFFIX := .itb
-  KERNEL_IN_UBI := 1
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  IMAGES := factory.bin initramfs-kernel.bin sysupgrade.bin
-  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += wavlink_wl-wn586x3b
 
 define Device/wavlink_wl-wn573hx3
   DEVICE_VENDOR := WAVLINK
@@ -3025,21 +1932,6 @@ define Device/wavlink_wl-wn573hx3
   IMAGE/WN573HX3-sysupgrade.bin := append-kernel | pad-to 128k | append-rootfs | pad-rootfs | check-size | append-metadata
 endef
 TARGET_DEVICES += wavlink_wl-wn573hx3
-
-define Device/widelantech_wap430x
-  DEVICE_VENDOR := Widelantech
-  DEVICE_MODEL := WAP430X
-  DEVICE_ALT1_VENDOR := Widelantech
-  DEVICE_ALT1_MODEL := AX3000AM
-  DEVICE_ALT1_VENDOR := UeeVii
-  DEVICE_ALT1_MODEL := UAP200
-  DEVICE_DTS := mt7981b-widelantech-wap430x
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  IMAGE_SIZE := 14784k
-  SUPPORTED_DEVICES += UAP200 AX3000AM # allow upgrade via GECOOS UART menu
-endef
-TARGET_DEVICES += widelantech_wap430x
 
 define Device/xiaomi_mi-router-ax3000t
   DEVICE_VENDOR := Xiaomi
@@ -3075,9 +1967,9 @@ define Device/xiaomi_mi-router-ax3000t-ubootmod
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
   ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot xiaomi_mi-router-ax3000t
@@ -3124,9 +2016,9 @@ define Device/xiaomi_mi-router-wr30u-ubootmod
   KERNEL_INITRAMFS_SUFFIX := -recovery.itb
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3
   ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot xiaomi_mi-router-wr30u
@@ -3173,9 +2065,9 @@ define Device/xiaomi_redmi-router-ax6000-ubootmod
   UBOOTENV_IN_UBI := 1
   KERNEL := kernel-bin | gzip
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
   IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+        fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ddr4
   ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot xiaomi_redmi-router-ax6000
@@ -3259,23 +2151,6 @@ define Device/zbtlink_zbt-z8103ax
 endef
 TARGET_DEVICES += zbtlink_zbt-z8103ax
 
-define Device/zbtlink_zbt-z8103ax-c
-  DEVICE_VENDOR := Zbtlink
-  DEVICE_MODEL := ZBT-Z8103AX-C
-  DEVICE_DTS := mt7981b-zbtlink-zbt-z8103ax-c
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_IN_UBI := 1
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += zbtlink_zbt-z8103ax-c
-
 define Device/zyxel_ex5601-t0-stock
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := EX5601-T0
@@ -3287,6 +2162,7 @@ define Device/zyxel_ex5601-t0-stock
   DEVICE_DTS := mt7986a-zyxel-ex5601-t0-stock
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-usb3
+  SUPPORTED_DEVICES := mediatek,mt7986a-rfb-snand
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 256k
   PAGESIZE := 4096
@@ -3322,9 +2198,9 @@ define Device/zyxel_ex5601-t0-ubootmod
   UBOOTENV_IN_UBI := 1
   KERNEL := kernel-bin | lzma
   KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
   IMAGE/sysupgrade.itb := append-kernel | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
   ARTIFACTS := preloader.bin bl31-uboot.fip
   ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-4k-ddr4
   ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot zyxel_ex5601-t0
@@ -3354,8 +2230,6 @@ TARGET_DEVICES += zyxel_ex5700-telenor
 define Device/zyxel_nwa50ax-pro
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := NWA50AX Pro
-  DEVICE_ALT0_VENDOR := Zyxel
-  DEVICE_ALT0_MODEL := NWA90AX Pro
   DEVICE_DTS := mt7981b-zyxel-nwa50ax-pro
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware zyxel-bootconfig
@@ -3371,30 +2245,23 @@ define Device/zyxel_nwa50ax-pro
 endef
 TARGET_DEVICES += zyxel_nwa50ax-pro
 
-define Device/zyxel_wx5600-t0-ubootmod
-  DEVICE_VENDOR := Zyxel
-  DEVICE_MODEL := WX5600-T0
-  DEVICE_VARIANT := (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7986b-zyxel-wx5600-t0-ubootmod
+define Device/tplink_vx830v
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := VX830v
+  DEVICE_DTS := mt7986a-tplink-vx830v
   DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  IMAGES := sysupgrade.itb
-  BLOCKSIZE := 256k
-  PAGESIZE := 4096
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware kmod-usb3 kmod-phy-airoha-en8811h
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
   KERNEL_IN_UBI := 1
   UBOOTENV_IN_UBI := 1
-  KERNEL := kernel-bin | lzma
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
-  IMAGE/sysupgrade.itb := append-kernel | \
-        fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-4k-ddr3
-  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot zyxel_wx5600-t0
+ifeq ($(IB),)
 ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
-  ARTIFACTS += initramfs-factory.ubi
-  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-recovery.itb | ubinize-kernel
+  ARTIFACTS := initramfs-factory.ubi
+  ARTIFACT/initramfs-factory.ubi := append-image-stage initramfs-kernel.bin | ubinize-kernel
 endif
+endif
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
-TARGET_DEVICES += zyxel_wx5600-t0-ubootmod
+TARGET_DEVICES += tplink_vx830v

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -52,25 +52,6 @@ define Build/mt7622-gpt
 	rm $@.tmp
 endef
 
-define Device/asiarf_ap7622-wh1
-  DEVICE_VENDOR := AsiaRF
-  DEVICE_MODEL := AP7622-WH1
-  DEVICE_DTS := mt7622-asiarf-ap7622-wh1
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-ata-ahci-mtk kmod-btmtkuart kmod-usb3
-  BOARD_NAME := asiarf,ap7622-wh1
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_SIZE := 8192k
-  IMAGE_SIZE := 32768k
-  IMAGES += factory.bin
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-          append-ubi | check-size
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-endef
-TARGET_DEVICES += asiarf_ap7622-wh1
-
 define Device/smartrg_sdg-841-t6
   DEVICE_VENDOR := Adtran
   DEVICE_DTS_DIR := ../dts
@@ -213,19 +194,10 @@ define Device/elecom_wrc-2533gent
 endef
 TARGET_DEVICES += elecom_wrc-2533gent
 
-define Device/elecom_wrc-g01
-  $(Device/elecom_wrc-gst)
-  DEVICE_MODEL := WRC-G01
-  DEVICE_DTS := mt7622-elecom-wrc-g01
-  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
-	append-ubi | check-size | \
-	elecom-wrc-gs-factory WRC-G01 0.00 -N | \
-	append-string MT7622_ELECOM_WRC-G01
-endef
-TARGET_DEVICES += elecom_wrc-g01
-
-define Device/elecom_wrc-gst
+define Device/elecom_wrc-x3200gst3
   DEVICE_VENDOR := ELECOM
+  DEVICE_MODEL := WRC-X3200GST3
+  DEVICE_DTS := mt7622-elecom-wrc-x3200gst3
   DEVICE_DTS_DIR := ../dts
   IMAGE_SIZE := 25600k
   KERNEL_SIZE := 6144k
@@ -233,18 +205,12 @@ define Device/elecom_wrc-gst
   PAGESIZE := 2048
   UBINIZE_OPTS := -E 5
   IMAGES += factory.bin
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_PACKAGES := kmod-mt7915-firmware
-endef
-
-define Device/elecom_wrc-x3200gst3
-  $(Device/elecom_wrc-gst)
-  DEVICE_MODEL := WRC-X3200GST3
-  DEVICE_DTS := mt7622-elecom-wrc-x3200gst3
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | \
 	append-ubi | check-size | \
 	elecom-wrc-gs-factory WRC-X3200GST3 0.00 -N | \
 	append-string MT7622_ELECOM_WRC-X3200GST3
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915-firmware
 endef
 TARGET_DEVICES += elecom_wrc-x3200gst3
 
@@ -294,9 +260,6 @@ define Device/mediatek_mt7622-rfb1
   DEVICE_MODEL := MTK7622 rfb1 AP
   DEVICE_DTS := mt7622-rfb1
   DEVICE_PACKAGES := kmod-ata-ahci-mtk kmod-btmtkuart kmod-usb3
-  UBOOT_PATH := $(STAGING_DIR_IMAGE)/mt7622_rfb1-u-boot-mtk.bin
-  ARTIFACTS := u-boot.bin
-  ARTIFACT/u-boot.bin := append-uboot
 endef
 TARGET_DEVICES += mediatek_mt7622-rfb1
 
@@ -316,9 +279,6 @@ define Device/mediatek_mt7622-rfb1-ubi
   IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
                 check-size $$$$(IMAGE_SIZE)
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  UBOOT_PATH := $(STAGING_DIR_IMAGE)/mt7622_rfb1-u-boot-mtk.bin
-  ARTIFACTS := u-boot.bin
-  ARTIFACT/u-boot.bin := append-uboot
 endef
 TARGET_DEVICES += mediatek_mt7622-rfb1-ubi
 

--- a/target/linux/mediatek/image/mt7629.mk
+++ b/target/linux/mediatek/image/mt7629.mk
@@ -7,9 +7,6 @@ define Device/mediatek_mt7629-rfb
   DEVICE_MODEL := MT7629 rfb AP
   DEVICE_DTS := mt7629-rfb
   DEVICE_PACKAGES := swconfig
-  UBOOT_PATH := $(STAGING_DIR_IMAGE)/mt7629_rfb-u-boot-mtk.bin
-  ARTIFACTS := u-boot.bin
-  ARTIFACT/u-boot.bin := append-uboot
 endef
 TARGET_DEVICES += mediatek_mt7629-rfb
 


### PR DESCRIPTION
Hardware:
| Feature      | Details                                                        |
|--------------|---------------------------------------------------------------|
| **SoC**      | MediaTek MT7986A (Filogic 830)                                |
| **RAM**      | 512 MiB DDR4                                                  |
| **Flash**    | 256 MiB SPI-NAND (NMBM)                                       |
| **WiFi**     | MT7975 dual-band 802.11ax (WiFi 6)                            |
| **LAN**      | 2× GbE + 1× 2.5GbE (Airoha EN8811H)                           |
| **WAN**      | 1× 2.5GbE + SFP GPON combo                                    |
| **VoIP**     | 1× FXS (Si3218x)                                              |
| **USB**      | 1× USB 3.0                                                    |
| **LEDs**     | 15 LEDs (power, internet, SFP, LAN, DSL, phone, USB, LOS)     |
| **Buttons**  | Reset, WPS, WiFi toggle                                       |
| **SFP**      | GPON combo (no vendor specified)                              |

Features:
 - Dual-boot NAND (ubi0/ubi1)
 - WiFi caldata extraction from UBIFS
 - All major hardware tested (LAN, WAN, WiFi, SFP, USB, LED, buttons)

Not tested: VoIP (Si3218x), DSL