### PR TITLE
ath79: fix default network config for eTactica EG200

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -47,6 +47,7 @@ ath79_setup_interfaces()
 	engenius,ecb1750|\
 	engenius,ecb600|\
 	enterasys,ws-ap3705i|\
+	etactica,eg200|\
 	extreme-networks,ws-ap3805i|\
 	fortinet,fap-220-b|\
 	fortinet,fap-221-b|\
@@ -367,9 +368,6 @@ ath79_setup_interfaces()
 		ucidef_set_interface_lan "eth1"
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan"
-		;;
-	etactica,eg200)
-		ucidef_set_interface_lan "eth0" "dhcp"
 		;;
 	glinet,gl-ar750)
 		ucidef_set_interface_wan "eth1"


### PR DESCRIPTION
Remove non-existent port "dhcp".

Fixes: 1588114cf2a3 ("ath79: add etactica-eg200 support")