### PR TITLE
[25.12] mac80211: ath9k: patch hw.c for gpio mask from dt

### DIFF
--- a/package/kernel/mac80211/patches/ath9k/550-ath9k-of.patch
+++ b/package/kernel/mac80211/patches/ath9k/550-ath9k-of.patch
@@ -164,3 +164,26 @@
  	return 0;
  }
  
+--- a/drivers/net/wireless/ath/ath9k/hw.c
++++ b/drivers/net/wireless/ath/ath9k/hw.c
+@@ -2429,6 +2429,7 @@ static bool ath9k_hw_dfs_tested(struct ath_hw *ah)
+ static void ath9k_gpio_cap_init(struct ath_hw *ah)
+ {
+ 	struct ath9k_hw_capabilities *pCap = &ah->caps;
++	u32 gpio_mask = pCap->gpio_mask;
+ 
+ 	if (AR_SREV_9271(ah)) {
+ 		pCap->num_gpio_pins = AR9271_NUM_GPIO;
+@@ -2479,6 +2480,12 @@ static void ath9k_gpio_cap_init(struct ath_hw *ah)
+ 		pCap->num_gpio_pins = AR_NUM_GPIO;
+ 		pCap->gpio_mask = AR_GPIO_MASK;
+ 	}
++
++	if (gpio_mask) {
++		pCap->gpio_mask = gpio_mask;
++		ath_info(ath9k_hw_common(ah), "Use overridden gpio mask 0x%x\n",
++			 gpio_mask);
++	}
+ }
+ 
+ int ath9k_hw_fill_cap_info(struct ath_hw *ah)


### PR DESCRIPTION
"qca,gpio-mask" used to be read between ath9k_hw_init() and ath9k_init_queues(). After 12913c3c5658992985e13f4395dee86e5450154d it is read in ath9k_of_init(), but it gets overwritten by ath9k_gpio_cap_init() during the call of ath9k_hw_init(), and causes https://github.com/openwrt/openwrt/issues/22340

If keeping the most of 12913c3c5658992985e13f4395dee86e5450154d, ath9k_gpio_cap_init() could be patched to keep the existing non-zero gpio mask (coming from device tree).

Tested on Netgear WNDR4500 v3:
[   22.558083] ath9k 0000:00:00.0: enabling device (0000 -> 0002)
[   22.569548] ath: phy1: Use overridden gpio mask 0xf6ff


Link: https://github.com/openwrt/openwrt/pull/22376

(cherry picked from commit a1f5273)

