### PR TITLE
[25.12] ath79: untag to cpu ports on 2-cpu-port devices by default

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -136,7 +136,7 @@ ath79_setup_interfaces()
 		;;
 	airtight,c-75)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "2:wan" "3:lan" "6@eth1"
+			"0u@eth0" "2:wan" "3:lan" "6u@eth1"
 		;;
 	alfa-network,ap121fe)
 		ucidef_set_interface_lan "eth0 usb0"
@@ -200,7 +200,7 @@ ath79_setup_interfaces()
 	tplink,tl-wdr4900-v2|\
 	tplink,tl-wdr7500-v3)
 		ucidef_add_switch "switch0" \
-			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
+			"0u@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6u@eth0" "1:wan"
 		;;
 	buffalo,bhr-4grv|\
 	buffalo,wzr-hp-g450h)
@@ -210,11 +210,11 @@ ath79_setup_interfaces()
 	buffalo,bhr-4grv2|\
 	trendnet,tew-823dru)
 		ucidef_add_switch "switch0" \
-			"0@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth0"
+			"0u@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6u@eth0"
 		;;
 	buffalo,wzr-450hp2)
 		ucidef_add_switch "switch0" \
-			"6@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
+			"6u@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0u@eth0"
 		;;
 	buffalo,wzr-600dhp|\
 	buffalo,wzr-hp-ag300h|\
@@ -287,7 +287,7 @@ ath79_setup_interfaces()
 	comfast,cf-wr650ac-v2|\
 	zyxel,nbg6616)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth1"
+			"0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6u@eth1"
 		;;
 	compex,wpj344-16m|\
 	compex,wpj563)
@@ -301,7 +301,7 @@ ath79_setup_interfaces()
 	dell,apl26-0ae|\
 	dell,apl27-0b1)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "2:lan:1" "3:lan:2" "6@eth1"
+			"0u@eth0" "2:lan:1" "3:lan:2" "6u@eth1"
 		;;
 	devolo,dlan-pro-1200plus-ac|\
 	devolo,magic-2-wifi)
@@ -318,11 +318,11 @@ ath79_setup_interfaces()
 		;;
 	dlink,dap-2695-a1)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "2:lan" "3:wan" "6@eth1"
+			"0u@eth0" "2:lan" "3:wan" "6u@eth1"
 		;;
 	dlink,dap-3662-a1)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan:2" "2:lan:1" "6@eth1"
+			"0u@eth0" "1:lan:2" "2:lan:1" "6u@eth1"
 		;;
 	dlink,dch-g020-a1)
 		ucidef_add_switch "switch0" \
@@ -393,7 +393,7 @@ ath79_setup_interfaces()
 		;;
 	jjplus,jwap230)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "5:wan:1" "1:lan:2" "6@eth1"
+			"0u@eth0" "5:wan:1" "1:lan:2" "6u@eth1"
 		;;
 	joyit,jt-or750i)
 		ucidef_set_interface_wan "eth1"
@@ -416,7 +416,7 @@ ath79_setup_interfaces()
 		;;
 	librerouter,librerouter-v1)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "5:wan" "6@eth1" "4:lan"
+			"0u@eth0" "5:wan" "6u@eth1" "4:lan"
 		;;
 	longdata,aps256)
 		ucidef_set_interface_wan "eth1"
@@ -512,7 +512,7 @@ ath79_setup_interfaces()
 		;;
 	ruckus,r500)
 		ucidef_add_switch "switch0" \
-			"6u@eth0" "5:lan:1" "3:lan:2" "0@eth1"
+			"6u@eth0" "5:lan:1" "3:lan:2" "0u@eth1"
 		;;
 	teltonika,rut955|\
 	teltonika,rut955-h7v3c0)
@@ -527,7 +527,7 @@ ath79_setup_interfaces()
 	tplink,archer-d7-v1|\
 	tplink,archer-d7b-v1)
 		ucidef_add_switch "switch0" \
-			"0@eth1" "3:lan:3" "4:lan:2" "5:lan:1" "6@eth0" "2:wan:4" "1:wan:5"
+			"0u@eth1" "3:lan:3" "4:lan:2" "5:lan:1" "6u@eth0" "2:wan:4" "1:wan:5"
 		;;
 	tplink,deco-m4r-v1|\
 	tplink,deco-s4-v2)
@@ -567,7 +567,7 @@ ath79_setup_interfaces()
 	tplink,tl-wr1043nd-v3|\
 	tplink,tl-wr1045nd-v2)
 		ucidef_add_switch "switch0" \
-			"0@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan" "6@eth0"
+			"0u@eth1" "1:lan:4" "2:lan:3" "3:lan:2" "4:lan:1" "5:wan" "6u@eth0"
 		;;
 	tplink,tl-wr2543-v1)
 		ucidef_add_switch "switch0" \

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -13,7 +13,7 @@ ath79_setup_interfaces()
 		;;
 	domywifi,dw33d)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "1:wan" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth1"
+			"0u@eth0" "1:wan" "2:lan" "3:lan" "4:lan" "5:lan" "6u@eth1"
 		;;
 	dongwon,dw02-412h-64m|\
 	dongwon,dw02-412h-128m)
@@ -42,7 +42,7 @@ ath79_setup_interfaces()
 		;;
 	linksys,ea4500-v3)
 		ucidef_add_switch "switch0" \
-			"6@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0@eth0"
+			"6u@eth1" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "0u@eth0"
 		;;
 	netgear,pgzng1)
 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
@@ -81,7 +81,7 @@ ath79_setup_interfaces()
 	zyxel,emg2926-q10a|\
 	zyxel,nbg6716)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6@eth1"
+			"0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan" "5:wan" "6u@eth1"
 		;;
 	*)
 		ucidef_set_interfaces_lan_wan "eth0" "eth1"


### PR DESCRIPTION
Currently, devices having two cpu ports to the switch managed by swconfig, especally those with qca955x, line tplink archer c7 v2 and linksys ea4500 v3, use vlan on different cpu port to separate networks by default. (e.g. eth1.1 for lan, eth0.2 for wan)

However, untagging to these vlans cpu ports, and limiting vlans in the switch on these devices could effectively offload the expense to process vlan tag from cpu to the switch, and increase the throughput of lan <-> wan ipoe routing.

Tested on my tplink tl-wdr4900 v2, where ucidef_add_switch "switch0" "0u@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6u@eth0" "1:wan" finally generates on /etc/config/network:

config device
	option name 'br-lan'
	option type 'bridge'
	list ports 'eth1'

config interface 'lan'
	option device 'br-lan'
	option proto 'static'
	list ipaddr '192.168.1.1/24'
	option ip6assign '60'

config interface 'wan'
	option device 'eth0'
	option proto 'dhcp'

config interface 'wan6'
	option device 'eth0'
	option proto 'dhcpv6'

config switch
	option name 'switch0'
	option reset '1'
	option enable_vlan '1'

config switch_vlan
	option device 'switch0'
	option vlan '1'
	option ports '2 3 4 5 0'

config switch_vlan
	option device 'switch0'
	option vlan '2'
	option ports '1 6'

and the throughput of lan <-> wan ipoe routing with software flow offload increases from around
[850 Mbps](https://openwrt.org/toh/tp-link/archer-c5-c7-wdr7500#nat_performance) to 900 Mbps.


Link: https://github.com/openwrt/openwrt/pull/19444

(cherry picked from commit d35d92a)

