### PR TITLE
ath79: untag to cpu ports on qxwlan_e558-v2

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -499,7 +499,7 @@ ath79_setup_interfaces()
 	qxwlan,e558-v2-8m|\
 	qxwlan,e558-v2-16m)
 		ucidef_add_switch "switch0" \
-			"0@eth1" "4:lan" "5:lan" "6@eth0" "3:wan"
+			"0u@eth1" "4:lan" "5:lan" "6u@eth0" "3:wan"
 		;;
 	rosinson,wr818)
 		ucidef_add_switch "switch0" \


### PR DESCRIPTION
These targets seems to be left over, so changed as other targets covered by commit d35d92a .

