### PR TITLE
mediatek: filogic: fix MT7987 dtsi spi nodes

### DIFF
--- a/target/linux/mediatek/dts/mt7987.dtsi
+++ b/target/linux/mediatek/dts/mt7987.dtsi
@@ -750,6 +750,8 @@
 						 <&topckgen CLK_TOP_SPI_SEL>;
 			clock-names = "parent-clk", "sel-clk", "spi-clk",
 				      "hclk";
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 
@@ -769,6 +771,8 @@
 						  CLK_TOP_SPIM_MST_SEL>;
 			clock-names = "parent-clk", "sel-clk", "spi-clk",
 				      "hclk";
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 
@@ -788,6 +792,8 @@
 						 <&topckgen CLK_TOP_SPI_SEL>;
 			clock-names = "parent-clk", "sel-clk", "spi-clk",
 				      "hclk";
+			#address-cells = <1>;
+			#size-cells = <0>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Upstream devicetree bindings marks address-cells and size-cells "required". (mediatek,spi-mt65xx.yaml)

This change will fix some dtc warnings.