### PR TITLE
lantiq: xrx200: autoload lantiq_gswip and tag_gswip to fix failsafe mode

### DIFF
--- a/target/linux/lantiq/modules.mk
+++ b/target/linux/lantiq/modules.mk
@@ -27,7 +27,7 @@ define KernelPackage/dsa-gswip
   FILES:= \
 	$(LINUX_DIR)/drivers/net/dsa/lantiq_gswip.ko \
   	$(LINUX_DIR)/net/dsa/tag_gswip.ko
-  AUTOLOAD:=$(call AutoLoad,41,lantiq_gswip)
+  AUTOLOAD:=$(call AutoLoad,41,tag_gswip lantiq_gswip,1)
 endef
 
 define KernelPackage/dsa-gswip/description


### PR DESCRIPTION
lantiq_gswip and tag_gswip were not loaded during failsafe, leaving the switch uninitialised. This caused LAN1 port to show no link, making SSH-based recovery impossible.

Add the autoload flag and include tag_gswip (which was also missing from the autoload list) so the switch initialises correctly in failsafe mode.

Tested on BT HomeHub 5A (lantiq/xrx200).

Fixes #22480