### PR TITLE
airoha: Add PCIe sub-nodes for NPU wifi offloading

### DIFF
--- a/target/linux/airoha/dts/an7581-evb-emmc.dts
+++ b/target/linux/airoha/dts/an7581-evb-emmc.dts
@@ -184,12 +184,32 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&pcie0_rst_pins>;
 	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+		};
+	};
 };
 
 &pcie1 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pcie1_rst_pins>;
 	status = "okay";
+
+	pcie@1,0 {
+		reg = <0x0000 0 0 0 0>;
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+		};
+	};
 };
 
 &pcie2 {

--- a/target/linux/airoha/dts/an7581-evb.dts
+++ b/target/linux/airoha/dts/an7581-evb.dts
@@ -196,12 +196,32 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&pcie0_rst_pins>;
 	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+		};
+	};
 };
 
 &pcie1 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pcie1_rst_pins>;
 	status = "okay";
+
+	pcie@1,0 {
+		reg = <0x0000 0 0 0 0>;
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			airoha,npu = <&npu>;
+			airoha,eth = <&eth>;
+		};
+	};
 };
 
 &npu {


### PR DESCRIPTION
Introduce missing PCIe sub-nodes required to enable NPU wifi offloading on Airoha AN7581 SoC.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
