### PR TITLE
[24.10] dnsmasq: fix start if dhcp-range is not correct

### DIFF
--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -133,8 +133,7 @@ _ip2str START "$start"
 _ip2str END "$end"
 
 if [ "$start" -le "$ipaddr" ] && [ "$ipaddr" -le "$end" ]; then
-    echo "error: address $IP inside range $START..$END" >&2
-    exit 1
+    echo "warning: address $IP inside range $START..$END" >&2
 fi
 
 echo "START=$START"

--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.90
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -597,10 +597,20 @@ dhcp_add() {
 	nettag="${networkid:+set:${networkid},}"
 
 	# make sure the DHCP range is not empty
-	if [ "$dhcpv4" != "disabled" ] && ipcalc "$ipaddr/$prefix_or_netmask" "$start" "$limit" ; then
-		[ "$dynamicdhcpv4" = "0" ] && END="static"
+	if [ "$dhcpv4" != "disabled" ]; then
+		unset START
+		unset END
+		unset NETMASK
+		ipcalc "$ipaddr/$prefix_or_netmask" "$start" "$limit"
 
-		xappend "--dhcp-range=$tags$nettag$START,$END,$NETMASK,$leasetime${options:+ $options}"
+		if [ -z "$START" ] || [ -z "$END" ] || [ -z "$NETMASK" ]; then
+			logger -t dnsmasq \
+				"unable to set dhcp-range for dhcp uci config section '$cfg'" \
+				"on interface '$ifname', please check your config"
+		else
+			[ "$dynamicdhcpv4" = "0" ] && END="static"
+			xappend "--dhcp-range=$tags$nettag$START,$END,$NETMASK,$leasetime${options:+ $options}"
+		fi
 	fi
 
 	if [ "$dynamicdhcpv6" = "0" ] ; then


### PR DESCRIPTION
This is a backport of https://github.com/openwrt/openwrt/pull/18641

Tested on 24.10.5.

Fixes https://github.com/openwrt/openwrt/issues/17455 https://github.com/openwrt/openwrt/issues/17273
