### PR TITLE
ramips: fix kernel decompress error for ELECOM WRC-X1800GS

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1413,7 +1413,7 @@ define Device/elecom_wrc-x1800gs
   $(Device/nand)
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-X1800GS
-  KERNEL_LOADADDR := 0x82000000
+  KERNEL_LOADADDR := 0x88000000
   KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | \
 	znet-header 4.04(XVF.1)b90 COMC 0x68 | elecom-product-header WRC-X1800GS


### PR DESCRIPTION
The bootloader reads the compressed kernel to 0x82000000. We need to decompress kernel to a different address far from 0x82000000 to avoid memory overlap.

Fixes: https://github.com/openwrt/openwrt/issues/22270

cc @stktr