### PR TITLE
realtek: fix D-Link fan control script

### DIFF
--- a/target/linux/realtek/base-files/etc/uci-defaults/04_dlinkfan
+++ b/target/linux/realtek/base-files/etc/uci-defaults/04_dlinkfan
@@ -10,7 +10,7 @@ case "$board" in
 d-link,dgs-1210-28p-f|d-link,dgs-1210-28mp-f)
 	# Enable fan control
 	FAN_CTRL='/sys/class/hwmon/hwmon0'
-	echo 1 > "$FAN_PATH/pwm1_enable"
+	echo 1 > "$FAN_CTRL/pwm1_enable"
 
 	# Set fan script execution in crontab
 	grep -s -q fan_ctrl.sh /etc/crontabs/root && exit 0


### PR DESCRIPTION
When the fan control script was first implemented, a variable was wrongly named. The fan probably never turns on - fix that.

