### PR TITLE
nft_flow_offload: add L2 bridge offload support

### DIFF
--- a/target/linux/airoha/an7581/base-files/etc/hotplug.d/net/50-nf-bridge-call
+++ b/target/linux/airoha/an7581/base-files/etc/hotplug.d/net/50-nf-bridge-call
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Enable netfilter on br-lan only, so bridged IP traffic traverses the
+# netfilter forward chain where nft_flow_offload can pick it up for
+# hardware PPE offload.
+#
+# Scoped to br-lan to avoid imposing netfilter overhead on user-created
+# bridges (e.g. docker, guest networks) which may not need it.
+
+[ "$ACTION" = "add" ] || exit 0
+[ "$DEVICENAME" = "br-lan" ] || exit 0
+
+bridge=/sys/devices/virtual/net/br-lan/bridge
+[ -d "$bridge" ] || exit 0
+
+echo 1 > "$bridge/nf_call_iptables" 2>/dev/null
+echo 1 > "$bridge/nf_call_ip6tables" 2>/dev/null
+
+exit 0

--- a/target/linux/airoha/an7581/base-files/etc/uci-defaults/15-w1700k-flow-offload
+++ b/target/linux/airoha/an7581/base-files/etc/uci-defaults/15-w1700k-flow-offload
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Install a hotplug script that reloads the firewall after WiFi
+# interfaces come up, so fw4 can discover them and add them to the
+# flowtable for hardware bridge offload via PPE.
+#
+# fw4 auto-discovers bridge member devices for the flowtable, but
+# at boot the firewall starts before hostapd creates WiFi interfaces.
+
+mkdir -p /etc/hotplug.d/net
+cat > /etc/hotplug.d/net/50-flow-offload-wifi <<'HOTPLUG'
+#!/bin/sh
+
+[ "$ACTION" = "add" ] || exit 0
+
+DEV="${DEVICENAME:-$INTERFACE}"
+[ -n "$DEV" ] || exit 0
+
+case "$DEV" in
+	phy*-ap*) ;;
+	*) exit 0 ;;
+esac
+
+# Skip if the device is already in the flowtable (fw4 picked it up).
+nft list flowtable inet fw4 ft 2>/dev/null | grep -qw "\"$DEV\"" && exit 0
+
+# fw4 auto-discovers bridge members on reload. Serialize via flock so
+# concurrent hotplug events don't trigger multiple reloads - the last
+# one after all WiFi interfaces are up will be enough.
+(
+	exec 9>/var/lock/flow-offload-wifi.lock
+	flock -n 9 || exit 0
+	# Brief settle time so sibling AP interfaces also get included.
+	sleep 2
+	/etc/init.d/firewall reload >/dev/null 2>&1
+) &
+
+exit 0
+HOTPLUG
+chmod +x /etc/hotplug.d/net/50-flow-offload-wifi
+
+exit 0

--- a/target/linux/airoha/an7581/target.mk
+++ b/target/linux/airoha/an7581/target.mk
@@ -6,7 +6,8 @@ KERNELNAME:=Image dtbs
 FEATURES+=pwm
 
 DEFAULT_PACKAGES += \
-	airoha-en7581-npu-firmware uboot-envtools
+	airoha-en7581-npu-firmware uboot-envtools \
+	kmod-br-netfilter
 
 define Target/Description
 	Build firmware images for Airoha an7581 ARM based boards.

--- a/target/linux/generic/hack-6.12/721-net-add-packet-mangeling.patch
+++ b/target/linux/generic/hack-6.12/721-net-add-packet-mangeling.patch
@@ -97,7 +97,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	help
 --- a/net/core/dev.c
 +++ b/net/core/dev.c
-@@ -3671,6 +3671,11 @@ static int xmit_one(struct sk_buff *skb,
+@@ -3679,6 +3679,11 @@ static int xmit_one(struct sk_buff *skb,
  	if (dev_nit_active(dev))
  		dev_queue_xmit_nit(skb, dev);
  

--- a/target/linux/generic/pending-6.12/675-01-net-export-__dev_fill_forward_path-and-br_fdb_find_rcu.patch
+++ b/target/linux/generic/pending-6.12/675-01-net-export-__dev_fill_forward_path-and-br_fdb_find_rcu.patch
@@ -1,0 +1,107 @@
+From: Ryan Chen <rchen14b@gmail.com>
+Date: Sun, 16 Mar 2026 12:00:00 -0500
+Subject: [PATCH 1/2] net: export __dev_fill_forward_path and br_fdb_find_rcu
+
+Export __dev_fill_forward_path() which accepts an external
+net_device_path_ctx, allowing callers to pre-populate VLAN info
+for bridge offload. Also export br_fdb_find_rcu() so netfilter
+flow offload can check if a destination MAC is known in the
+bridge FDB.
+
+These are prerequisites for nft_flow_offload bridging support.
+
+Signed-off-by: Ryan Chen <rchen14b@gmail.com>
+---
+ include/linux/netdevice.h |  2 ++
+ net/bridge/br_fdb.c       |  1 +
+ net/core/dev.c            | 32 ++++++++++++++++++--------------
+ 3 files changed, 21 insertions(+), 14 deletions(-)
+
+--- a/include/linux/netdevice.h
++++ b/include/linux/netdevice.h
+@@ -3079,6 +3079,8 @@ int dev_get_iflink(const struct net_devi
+ int dev_fill_metadata_dst(struct net_device *dev, struct sk_buff *skb);
+ int dev_fill_forward_path(const struct net_device *dev, const u8 *daddr,
+ 			  struct net_device_path_stack *stack);
++int __dev_fill_forward_path(struct net_device_path_ctx *ctx, const u8 *daddr,
++			    struct net_device_path_stack *stack);
+ struct net_device *__dev_get_by_flags(struct net *net, unsigned short flags,
+ 				      unsigned short mask);
+ struct net_device *dev_get_by_name(struct net *net, const char *name);
+--- a/net/bridge/br_fdb.c
++++ b/net/bridge/br_fdb.c
+@@ -269,6 +269,7 @@ struct net_bridge_fdb_entry *br_fdb_find
+ {
+ 	return fdb_find_rcu(&br->fdb_hash_tbl, addr, vid);
+ }
++EXPORT_SYMBOL_GPL(br_fdb_find_rcu);
+ 
+ /* When a static FDB entry is added, the mac address from the entry is
+  * added to the bridge private HW address list and all required ports
+--- a/net/core/dev.c
++++ b/net/core/dev.c
+@@ -726,44 +726,52 @@ static struct net_device_path *dev_fwd_p
+ 	return &stack->path[k];
+ }
+ 
+-int dev_fill_forward_path(const struct net_device *dev, const u8 *daddr,
+-			  struct net_device_path_stack *stack)
++int __dev_fill_forward_path(struct net_device_path_ctx *ctx, const u8 *daddr,
++			    struct net_device_path_stack *stack)
+ {
+ 	const struct net_device *last_dev;
+-	struct net_device_path_ctx ctx = {
+-		.dev	= dev,
+-	};
+ 	struct net_device_path *path;
+ 	int ret = 0;
+ 
+-	memcpy(ctx.daddr, daddr, sizeof(ctx.daddr));
++	memcpy(ctx->daddr, daddr, sizeof(ctx->daddr));
+ 	stack->num_paths = 0;
+-	while (ctx.dev && ctx.dev->netdev_ops->ndo_fill_forward_path) {
+-		last_dev = ctx.dev;
++	while (ctx->dev && ctx->dev->netdev_ops->ndo_fill_forward_path) {
++		last_dev = ctx->dev;
+ 		path = dev_fwd_path(stack);
+ 		if (!path)
+ 			return -1;
+ 
+ 		memset(path, 0, sizeof(struct net_device_path));
+-		ret = ctx.dev->netdev_ops->ndo_fill_forward_path(&ctx, path);
++		ret = ctx->dev->netdev_ops->ndo_fill_forward_path(ctx, path);
+ 		if (ret < 0)
+ 			return -1;
+ 
+-		if (WARN_ON_ONCE(last_dev == ctx.dev))
++		if (WARN_ON_ONCE(last_dev == ctx->dev))
+ 			return -1;
+ 	}
+ 
+-	if (!ctx.dev)
++	if (!ctx->dev)
+ 		return ret;
+ 
+ 	path = dev_fwd_path(stack);
+ 	if (!path)
+ 		return -1;
+ 	path->type = DEV_PATH_ETHERNET;
+-	path->dev = ctx.dev;
++	path->dev = ctx->dev;
+ 
+ 	return ret;
+ }
++EXPORT_SYMBOL_GPL(__dev_fill_forward_path);
++
++int dev_fill_forward_path(const struct net_device *dev, const u8 *daddr,
++			  struct net_device_path_stack *stack)
++{
++	struct net_device_path_ctx ctx = {
++		.dev	= dev,
++	};
++
++	return __dev_fill_forward_path(&ctx, daddr, stack);
++}
+ EXPORT_SYMBOL_GPL(dev_fill_forward_path);
+ 
+ /* must be called under rcu_read_lock(), as we dont take a reference */

--- a/target/linux/generic/pending-6.12/675-02-nft_flow_offload-add-bridging-support.patch
+++ b/target/linux/generic/pending-6.12/675-02-nft_flow_offload-add-bridging-support.patch
@@ -1,0 +1,339 @@
+From: Ryan Chen <rchen14b@gmail.com>
+Date: Sun, 16 Mar 2026 12:00:00 -0500
+Subject: [PATCH 2/2] netfilter: nft_flow_offload: add bridging support
+
+Without this patch, bridging traffic is unable to BIND using
+nft_flow_offload. When two devices are bridged (e.g. WiFi STA to
+LAN port via br-lan), the flow offload engine only knows how to
+handle L3 routed traffic.
+
+This patch adds:
+- Bridge detection via FDB lookup (nft_flow_offload_is_bridging)
+- Separate route path for bridged traffic that uses in/out ifindex
+  directly instead of L3 route lookup
+- MAC address extraction from ethernet header for bridged flows
+- VLAN-aware bridge support via bridge port VLAN context
+- Fix for VLAN untag underflow in nft_dev_path_info
+
+Based on MediaTek SDK patch by Bo-Cun Chen <bc-bocun.chen@mediatek.com>.
+Adapted for Airoha AN7581 PPE offload.
+
+Signed-off-by: Ryan Chen <rchen14b@gmail.com>
+---
+ net/netfilter/nft_flow_offload.c | 220 +++++++++++++++++++++++++++----
+ 1 file changed, 196 insertions(+), 24 deletions(-)
+
+--- a/net/netfilter/nft_flow_offload.c
++++ b/net/netfilter/nft_flow_offload.c
+@@ -15,6 +15,7 @@
+ #include <net/netfilter/nf_conntrack_core.h>
+ #include <net/netfilter/nf_conntrack_extend.h>
+ #include <net/netfilter/nf_flow_table.h>
++#include "../bridge/br_private.h"
+ 
+ struct nft_flow_offload {
+ 	struct nft_flowtable	*flowtable;
+@@ -46,7 +47,48 @@ static bool nft_is_valid_ether_device(co
+ 	return true;
+ }
+ 
+-static int nft_dev_fill_forward_path(const struct nf_flow_route *route,
++static u16 nft_flow_offload_get_vlan_id(struct net_bridge_port *port,
++					struct sk_buff *skb)
++{
++	u16 vlan_id = 0;
++
++	if (!port || !br_opt_get(port->br, BROPT_VLAN_ENABLED))
++		return 0;
++
++	if (skb_vlan_tag_present(skb))
++		vlan_id = skb_vlan_tag_get_id(skb);
++	else
++		br_vlan_get_pvid_rcu(skb->dev, &vlan_id);
++
++	return vlan_id;
++}
++
++static bool nft_flow_offload_is_bridging(struct sk_buff *skb)
++{
++	struct net_bridge_port *port;
++	unsigned char *dmac = eth_hdr(skb)->h_dest;
++	bool bridging = false;
++	u16 vlan_id;
++
++	if (!netif_is_bridge_port(skb->dev))
++		return false;
++
++	rcu_read_lock();
++	port = br_port_get_rcu(skb->dev);
++	if (port) {
++		vlan_id = nft_flow_offload_get_vlan_id(port, skb);
++
++		/* lookup fdb entry */
++		if (br_fdb_find_rcu(port->br, dmac, vlan_id))
++			bridging = true;
++	}
++	rcu_read_unlock();
++
++	return bridging;
++}
++
++static int nft_dev_fill_forward_path(struct net_device_path_ctx *ctx,
++				     const struct nf_flow_route *route,
+ 				     const struct dst_entry *dst_cache,
+ 				     const struct nf_conn *ct,
+ 				     enum ip_conntrack_dir dir, u8 *ha,
+@@ -60,6 +102,9 @@ static int nft_dev_fill_forward_path(con
+ 	if (!nft_is_valid_ether_device(dev))
+ 		goto out;
+ 
++	if (!is_zero_ether_addr(ha))
++		goto out;
++
+ 	n = dst_neigh_lookup(dst_cache, daddr);
+ 	if (!n)
+ 		return -1;
+@@ -74,7 +119,26 @@ static int nft_dev_fill_forward_path(con
+ 		return -1;
+ 
+ out:
+-	return dev_fill_forward_path(dev, ha, stack);
++	return __dev_fill_forward_path(ctx, ha, stack);
++}
++
++static void nft_br_vlan_dev_fill_forward_path(const struct nft_pktinfo *pkt,
++					      struct net_device_path_ctx *ctx)
++{
++	struct net_bridge_port *port;
++	u16 vlan_id;
++
++	rcu_read_lock();
++	port = br_port_get_rcu(pkt->skb->dev);
++	if (port) {
++		vlan_id = nft_flow_offload_get_vlan_id(port, pkt->skb);
++		if (vlan_id) {
++			ctx->num_vlans = 1;
++			ctx->vlan[0].id = vlan_id;
++			ctx->vlan[0].proto = port->br->vlan_proto;
++		}
++	}
++	rcu_read_unlock();
+ }
+ 
+ struct nft_forward_info {
+@@ -103,12 +167,12 @@ static void nft_dev_path_info(const stru
+ 
+ 	for (i = 0; i < stack->num_paths; i++) {
+ 		path = &stack->path[i];
++		info->indev = path->dev;
+ 		switch (path->type) {
+ 		case DEV_PATH_ETHERNET:
+ 		case DEV_PATH_DSA:
+ 		case DEV_PATH_VLAN:
+ 		case DEV_PATH_PPPOE:
+-			info->indev = path->dev;
+ 			if (is_zero_ether_addr(info->h_source))
+ 				memcpy(info->h_source, path->dev->dev_addr, ETH_ALEN);
+ 
+@@ -150,10 +214,8 @@ static void nft_dev_path_info(const stru
+ 				info->num_encaps++;
+ 				break;
+ 			case DEV_PATH_BR_VLAN_UNTAG:
+-				if (WARN_ON_ONCE(info->num_encaps-- == 0)) {
+-					info->indev = NULL;
+-					break;
+-				}
++				if (info->num_encaps > 0)
++					info->num_encaps--;
+ 				break;
+ 			case DEV_PATH_BR_VLAN_KEEP:
+ 				break;
+@@ -161,7 +223,6 @@ static void nft_dev_path_info(const stru
+ 			info->xmit_type = FLOW_OFFLOAD_XMIT_DIRECT;
+ 			break;
+ 		default:
+-			info->indev = NULL;
+ 			break;
+ 		}
+ 	}
+@@ -192,22 +253,44 @@ static bool nft_flowtable_find_dev(const
+ 	return found;
+ }
+ 
+-static void nft_dev_forward_path(struct nf_flow_route *route,
+-				 const struct nf_conn *ct,
+-				 enum ip_conntrack_dir dir,
+-				 struct nft_flowtable *ft)
++static int nft_dev_forward_path(const struct nft_pktinfo *pkt,
++				struct nf_flow_route *route,
++				const struct nf_conn *ct,
++				enum ip_conntrack_dir dir,
++				struct nft_flowtable *ft)
+ {
+ 	const struct dst_entry *dst = route->tuple[dir].dst;
+ 	struct net_device_path_stack stack;
++	struct net_device_path_ctx ctx = {
++		.dev	= dst->dev,
++	};
+ 	struct nft_forward_info info = {};
++	struct ethhdr *eth;
++	enum ip_conntrack_dir skb_dir;
+ 	unsigned char ha[ETH_ALEN];
+ 	int i;
+ 
+-	if (nft_dev_fill_forward_path(route, dst, ct, dir, ha, &stack) >= 0)
++	memset(ha, 0, sizeof(ha));
++
++	if (nft_flow_offload_is_bridging(pkt->skb) && skb_mac_header_was_set(pkt->skb)) {
++		eth = eth_hdr(pkt->skb);
++		skb_dir = CTINFO2DIR(skb_get_nfct(pkt->skb) & NFCT_INFOMASK);
++		if (skb_dir != dir) {
++			memcpy(ha, eth->h_source, ETH_ALEN);
++			memcpy(info.h_source, eth->h_dest, ETH_ALEN);
++		} else {
++			memcpy(ha, eth->h_dest, ETH_ALEN);
++			memcpy(info.h_source, eth->h_source, ETH_ALEN);
++		}
++
++		nft_br_vlan_dev_fill_forward_path(pkt, &ctx);
++	}
++
++	if (nft_dev_fill_forward_path(&ctx, route, dst, ct, dir, ha, &stack) >= 0)
+ 		nft_dev_path_info(&stack, &info, ha, &ft->data);
+ 
+ 	if (!info.indev || !nft_flowtable_find_dev(info.indev, ft))
+-		return;
++		return -ENOENT;
+ 
+ 	route->tuple[!dir].in.ifindex = info.indev->ifindex;
+ 	for (i = 0; i < info.num_encaps; i++) {
+@@ -224,13 +307,15 @@ static void nft_dev_forward_path(struct
+ 		route->tuple[dir].out.hw_ifindex = info.hw_outdev->ifindex;
+ 		route->tuple[dir].xmit_type = info.xmit_type;
+ 	}
++
++	return 0;
+ }
+ 
+-static int nft_flow_route(const struct nft_pktinfo *pkt,
+-			  const struct nf_conn *ct,
+-			  struct nf_flow_route *route,
+-			  enum ip_conntrack_dir dir,
+-			  struct nft_flowtable *ft)
++static int nft_flow_route_routing(const struct nft_pktinfo *pkt,
++				  const struct nf_conn *ct,
++				  struct nf_flow_route *route,
++				  enum ip_conntrack_dir dir,
++				  struct nft_flowtable *ft)
+ {
+ 	struct dst_entry *this_dst = skb_dst(pkt->skb);
+ 	struct dst_entry *other_dst = NULL;
+@@ -270,13 +355,89 @@ static int nft_flow_route(const struct n
+ 	nft_default_forward_path(route, this_dst, dir);
+ 	nft_default_forward_path(route, other_dst, !dir);
+ 
+-	if (route->tuple[dir].xmit_type	== FLOW_OFFLOAD_XMIT_NEIGH &&
++	if (route->tuple[dir].xmit_type == FLOW_OFFLOAD_XMIT_NEIGH &&
++	    route->tuple[!dir].xmit_type == FLOW_OFFLOAD_XMIT_NEIGH) {
++		if (nft_dev_forward_path(pkt, route, ct, dir, ft) ||
++		    nft_dev_forward_path(pkt, route, ct, !dir, ft))
++			return -ENOENT;
++	}
++
++	return 0;
++}
++
++static int
++nft_flow_route_dir(const struct nft_pktinfo *pkt,
++		   const struct nf_conn *ct,
++		   struct nf_flow_route *route,
++		   enum ip_conntrack_dir dir,
++		   int ifindex)
++{
++	struct dst_entry *other_dst = NULL;
++	struct flowi fl;
++
++	memset(&fl, 0, sizeof(fl));
++	switch (nft_pf(pkt)) {
++	case NFPROTO_IPV4:
++		fl.u.ip4.daddr = ct->tuplehash[!dir].tuple.src.u3.ip;
++		fl.u.ip4.flowi4_oif = ifindex;
++		fl.u.ip4.flowi4_tos = RT_TOS(ip_hdr(pkt->skb)->tos);
++		fl.u.ip4.flowi4_mark = pkt->skb->mark;
++		fl.u.ip4.flowi4_flags = FLOWI_FLAG_ANYSRC;
++		break;
++	case NFPROTO_IPV6:
++		fl.u.ip6.saddr = ct->tuplehash[!dir].tuple.dst.u3.in6;
++		fl.u.ip6.daddr = ct->tuplehash[!dir].tuple.src.u3.in6;
++		fl.u.ip6.flowi6_oif = ifindex;
++		fl.u.ip6.flowlabel = ip6_flowinfo(ipv6_hdr(pkt->skb));
++		fl.u.ip6.flowi6_mark = pkt->skb->mark;
++		fl.u.ip6.flowi6_flags = FLOWI_FLAG_ANYSRC;
++		break;
++	}
++
++	nf_route(nft_net(pkt), &other_dst, &fl, false, nft_pf(pkt));
++	if (!other_dst)
++		return -ENOENT;
++
++	nft_default_forward_path(route, other_dst, dir);
++
++	return 0;
++}
++
++static int
++nft_flow_route_bridging(const struct nft_pktinfo *pkt,
++			const struct nf_conn *ct,
++			struct nf_flow_route *route,
++			enum ip_conntrack_dir dir,
++			struct nft_flowtable *ft)
++{
++	int ret;
++
++	ret = nft_flow_route_dir(pkt, ct, route, dir,
++				 nft_out(pkt)->ifindex);
++	if (ret)
++		return ret;
++
++	ret = nft_flow_route_dir(pkt, ct, route, !dir,
++				 nft_in(pkt)->ifindex);
++	if (ret)
++		goto err_route_dir1;
++
++	if (route->tuple[dir].xmit_type == FLOW_OFFLOAD_XMIT_NEIGH &&
+ 	    route->tuple[!dir].xmit_type == FLOW_OFFLOAD_XMIT_NEIGH) {
+-		nft_dev_forward_path(route, ct, dir, ft);
+-		nft_dev_forward_path(route, ct, !dir, ft);
++		if (nft_dev_forward_path(pkt, route, ct, dir, ft) ||
++		    nft_dev_forward_path(pkt, route, ct, !dir, ft)) {
++			ret = -ENOENT;
++			goto err_route_dir2;
++		}
+ 	}
+ 
+ 	return 0;
++
++err_route_dir2:
++	dst_release(route->tuple[!dir].dst);
++err_route_dir1:
++	dst_release(route->tuple[dir].dst);
++	return ret;
+ }
+ 
+ static bool nft_flow_offload_skip(struct sk_buff *skb, int family)
+@@ -364,8 +525,13 @@ static void nft_flow_offload_eval(const
+ 		goto out;
+ 
+ 	dir = CTINFO2DIR(ctinfo);
+-	if (nft_flow_route(pkt, ct, &route, dir, priv->flowtable) < 0)
+-		goto err_flow_route;
++	if (nft_flow_offload_is_bridging(pkt->skb)) {
++		if (nft_flow_route_bridging(pkt, ct, &route, dir, priv->flowtable) < 0)
++			goto err_flow_route;
++	} else {
++		if (nft_flow_route_routing(pkt, ct, &route, dir, priv->flowtable) < 0)
++			goto err_flow_route;
++	}
+ 
+ 	flow = flow_offload_alloc(ct);
+ 	if (!flow)

--- a/target/linux/generic/pending-6.12/675-03-nft_flow_offload-add-DEV_PATH_MTK_WDMA-path.patch
+++ b/target/linux/generic/pending-6.12/675-03-nft_flow_offload-add-DEV_PATH_MTK_WDMA-path.patch
@@ -1,0 +1,30 @@
+From: Ryan Chen <rchen14b@gmail.com>
+Date: Sun, 16 Mar 2026 13:00:00 -0500
+Subject: [PATCH] netfilter: add DEV_PATH_MTK_WDMA path to nft_flow_offload
+
+Without this patch, nft_dev_path_info will populate an incorrect source
+MAC address for WiFi bridge offload via WDMA. When a bridged flow goes
+through the MT7996 WiFi device, the DEV_PATH_MTK_WDMA step in the
+device path doesn't set h_source, causing the PPE entry to get a zero
+source MAC and packets stall in both software fastpath and hardware path.
+
+Based on MediaTek SDK patch by Bo-Cun Chen <bc-bocun.chen@mediatek.com>.
+
+Signed-off-by: Ryan Chen <rchen14b@gmail.com>
+---
+ net/netfilter/nft_flow_offload.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/net/netfilter/nft_flow_offload.c
++++ b/net/netfilter/nft_flow_offload.c
+@@ -222,6 +222,10 @@ static void nft_dev_path_info(const stru
+ 			}
+ 			info->xmit_type = FLOW_OFFLOAD_XMIT_DIRECT;
+ 			break;
++		case DEV_PATH_MTK_WDMA:
++			if (is_zero_ether_addr(info->h_source))
++				memcpy(info->h_source, path->dev->dev_addr, ETH_ALEN);
++			break;
+ 		default:
+ 			break;
+ 		}

--- a/target/linux/generic/pending-6.12/675-04-nft_flow_offload-add-vlan-passthrough-support.patch
+++ b/target/linux/generic/pending-6.12/675-04-nft_flow_offload-add-vlan-passthrough-support.patch
@@ -1,0 +1,68 @@
+From: Ryan Chen <rchen14b@gmail.com>
+Date: Thu, 20 Mar 2026 10:00:00 -0500
+Subject: [PATCH 4/4] netfilter: nft_flow_offload: add VLAN passthrough support
+
+VLAN passthrough packets can be offloaded when bridge-nf-filter-vlan-tagged
+is enabled. When a packet has a VLAN tag and the bridge does not have VLAN
+filtering enabled (passthrough mode), record the VLAN encap info so the
+hardware flow offload entry includes the correct VLAN tag.
+
+Without this patch, VLAN-tagged bridged traffic cannot be offloaded by PPE
+because the VLAN encap information is missing from the flow entry.
+
+Enable with: echo 1 > /proc/sys/net/bridge/bridge-nf-filter-vlan-tagged
+
+Based on MediaTek SDK patch by chak-kei.lam <chak-kei.lam@mediatek.com>.
+
+Signed-off-by: Ryan Chen <rchen14b@gmail.com>
+---
+ net/netfilter/nft_flow_offload.c | 31 +++++++++++++++++++++++++++++--
+ 1 file changed, 29 insertions(+), 2 deletions(-)
+
+--- a/net/netfilter/nft_flow_offload.c
++++ b/net/netfilter/nft_flow_offload.c
+@@ -156,6 +156,30 @@ struct nft_forward_info {
+ 	enum flow_offload_xmit_type xmit_type;
+ };
+ 
++static void nft_fill_vlan_passthrough_info(const struct nft_pktinfo *pkt,
++					   struct nft_forward_info *info)
++{
++	struct net_bridge_port *port;
++
++	if (!skb_vlan_tag_present(pkt->skb))
++		return;
++
++	rcu_read_lock();
++	port = br_port_get_rcu(pkt->skb->dev);
++	/* when bridge vlan enabled, the vlan tag would be handled by the bridge */
++	if (port && !br_opt_get(port->br, BROPT_VLAN_ENABLED)) {
++		if (info->num_encaps >= NF_FLOW_TABLE_ENCAP_MAX) {
++			info->indev = NULL;
++			goto out;
++		}
++		info->encap[info->num_encaps].id = skb_vlan_tag_get_id(pkt->skb);
++		info->encap[info->num_encaps].proto = pkt->skb->vlan_proto;
++		info->num_encaps++;
++	}
++out:
++	rcu_read_unlock();
++}
++
+ static void nft_dev_path_info(const struct net_device_path_stack *stack,
+ 			      struct nft_forward_info *info,
+ 			      unsigned char *ha, struct nf_flowtable *flowtable)
+@@ -290,8 +314,12 @@ static int nft_dev_forward_path(const st
+ 		nft_br_vlan_dev_fill_forward_path(pkt, &ctx);
+ 	}
+ 
+-	if (nft_dev_fill_forward_path(&ctx, route, dst, ct, dir, ha, &stack) >= 0)
++	if (nft_dev_fill_forward_path(&ctx, route, dst, ct, dir, ha, &stack) >= 0) {
++		/* Add VLAN pass through info if needed */
++		nft_fill_vlan_passthrough_info(pkt, &info);
++
+ 		nft_dev_path_info(&stack, &info, ha, &ft->data);
++	}
+ 
+ 	if (!info.indev || !nft_flowtable_find_dev(info.indev, ft))
+ 		return -ENOENT;

--- a/target/linux/generic/pending-6.12/700-netfilter-nft_flow_offload-handle-netdevice-events-f.patch
+++ b/target/linux/generic/pending-6.12/700-netfilter-nft_flow_offload-handle-netdevice-events-f.patch
@@ -55,7 +55,7 @@ Signed-off-by: Pablo Neira Ayuso <pablo@netfilter.org>
  }
 --- a/net/netfilter/nft_flow_offload.c
 +++ b/net/netfilter/nft_flow_offload.c
-@@ -494,47 +494,14 @@ static struct nft_expr_type nft_flow_off
+@@ -692,47 +692,14 @@ static struct nft_expr_type nft_flow_off
  	.owner		= THIS_MODULE,
  };
  


### PR DESCRIPTION
## Summary

Bridged traffic (e.g. WiFi client to wired LAN through br-lan) currently
cannot be offloaded via nft_flow_offload. Only routed/NAT flows get
picked up by the flowtable. This means AP/bridge mode setups always go
through the full kernel bridge + conntrack + netfilter path for every
packet, regardless of hardware capabilities.

These patches add bridge awareness to nft_flow_offload:
- Detect bridged packets by looking up the destination MAC in the bridge FDB
- Build flow entries using bridge port in/out interfaces instead of L3 routes
- Handle WDMA path for WiFi bridge offload (MT7996)
- Support VLAN passthrough when bridge VLAN filtering is disabled

This benefits both software and hardware flowtable users:
- **Software flowtable** (`flow_offloading=1`): bridged traffic takes the
  kernel fast path, skipping per-packet conntrack/firewall/FDB lookups.
  Works on any device, no PPE or hardware offload needed.
- **Hardware offload** (`flow_offloading_hw=1`): bridged flows are pushed
  to PPE hardware on MediaTek and Airoha platforms for wire-speed forwarding.

The second commit enables the required infrastructure on the Airoha AN7581
target (kmod-br-netfilter, sysctl, WiFi flowtable hotplug).

Based on MediaTek SDK patches (999-ppe-15, 999-ppe-16, 999-ppe-24) by
Bo-Cun Chen and chak-kei.lam. Adapted and tested on Airoha AN7581.

The PPE drivers on both MediaTek (mtk_ppe) and Airoha (airoha_ppe) already
support PPE_PKT_TYPE_BRIDGE entries — these patches complete the netfilter
side of the pipeline.

## Test results
- Airoha AN7581 (Gemtek W1700K) in AP/bridge mode: verified [HW_OFFLOAD]
  for both wired and WiFi bridged flows
- MediaTek MT7981 (Cudy TR3000 v1) tested by @ttc0419: CPU usage reduced
  from 24% to 8% on 250Mbps WAN, flows bound correctly
- Router mode (NAT) offload: no regression
- Devices without PPE: no behavior change, code paths only activate when
  a flowtable is configured

## Test plan
- [x] Build for airoha target, verify patches apply cleanly
- [x] Boot in AP/bridge mode, verify bridged flows get [HW_OFFLOAD]
- [x] Confirm router mode NAT offload still works
- [x] Build and test on mediatek/filogic (MT7981) — confirmed by @ttc0419
- [ ] Test software-only flowtable (no hardware offload) on a device without PPE