### PR TITLE
airoha: fix USXGMII data path on speed changes

### DIFF
--- a/target/linux/airoha/patches-6.12/620-net-pcs-airoha-fix-USXGMII-rate-adaptation-on-speed.patch
+++ b/target/linux/airoha/patches-6.12/620-net-pcs-airoha-fix-USXGMII-rate-adaptation-on-speed.patch
@@ -1,0 +1,151 @@
+From: Ryan Chen <rchen14b@gmail.com>
+Date: Thu, 06 Mar 2026 12:00:00 -0600
+Subject: [PATCH 1/2] net: pcs: airoha: fix USXGMII rate adaptation on speed
+ changes
+
+The USXGMII rate adaptation code in airoha_pcs_link_up() is inside an
+else branch that only executes when neg_mode is not
+PHYLINK_PCS_NEG_INBAND_ENABLED. However, USXGMII uses in-band
+autonegotiation, so this code path is never reached on speed changes.
+The RATE_UPDATE_MODE and FORCE_RATE_ADAPT_MODE registers remain
+configured for the previous speed.
+
+Fix this by moving the USXGMII rate adaptation block out of the
+forced-mode-only branch so it runs regardless of the negotiation mode.
+The SGMII in-band FIFO threshold adjustment and the SGMII/1000BASEX
+forced-mode speed configuration remain gated on their respective
+negotiation modes as before.
+
+Signed-off-by: Ryan Chen <rchen14b@gmail.com>
+---
+ drivers/net/pcs/airoha/pcs-airoha-common.c | 127 +++++++++++---------
+ 1 file changed, 69 insertions(+), 58 deletions(-)
+
+--- a/drivers/net/pcs/airoha/pcs-airoha-common.c
++++ b/drivers/net/pcs/airoha/pcs-airoha-common.c
+@@ -635,64 +635,69 @@
+
+ 	data = priv->data;
+
+-	if (neg_mode == PHYLINK_PCS_NEG_INBAND_ENABLED) {
+-		if (interface == PHY_INTERFACE_MODE_SGMII) {
+-			regmap_update_bits(priv->hsgmii_rate_adp,
+-					   AIROHA_PCS_HSGMII_RATE_ADAPT_CTRL_1,
+-					   AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_WR_THR |
+-					   AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_RD_THR,
+-					   FIELD_PREP(AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_WR_THR, 0x0) |
+-					   FIELD_PREP(AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_RD_THR, 0x0));
+-			udelay(1);
+-			regmap_update_bits(priv->hsgmii_rate_adp,
+-					   AIROHA_PCS_HSGMII_RATE_ADAPT_CTRL_1,
+-					   AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_WR_THR |
+-					   AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_RD_THR,
+-					   FIELD_PREP(AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_WR_THR, 0xf) |
+-					   FIELD_PREP(AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_RD_THR, 0x5));
+-		}
+-	} else {
+-		if (interface == PHY_INTERFACE_MODE_USXGMII ||
+-		    interface == PHY_INTERFACE_MODE_10GBASER) {
+-			u32 mode;
+-			u32 rate_adapt;
+-
+-			switch (speed) {
+-			case SPEED_10000:
+-				rate_adapt = AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_10000;
+-				mode = AIROHA_PCS_USXGMII_MODE_10000;
+-				break;
+-			case SPEED_5000:
+-				rate_adapt = AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_5000;
+-				mode = AIROHA_PCS_USXGMII_MODE_5000;
+-				break;
+-			case SPEED_2500:
+-				rate_adapt = AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_2500;
+-				mode = AIROHA_PCS_USXGMII_MODE_2500;
+-				break;
+-			case SPEED_1000:
+-				rate_adapt = AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_1000;
+-				mode = AIROHA_PCS_USXGMII_MODE_1000;
+-				break;
+-			case SPEED_100:
+-				rate_adapt = AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_100;
+-				mode = AIROHA_PCS_USXGMII_MODE_100;
+-				break;
+-			}
+-
+-			/* Trigger USXGMII change mode and force selected speed */
+-			regmap_update_bits(priv->usxgmii_pcs, AIROHA_PCS_USXGMII_PCS_AN_CONTROL_7,
+-					   AIROHA_PCS_USXGMII_RATE_UPDATE_MODE |
+-					   AIROHA_PCS_USXGMII_MODE,
+-					   AIROHA_PCS_USXGMII_RATE_UPDATE_MODE | mode);
+-
+-			regmap_update_bits(priv->hsgmii_rate_adp, AIROHA_PCS_HSGMII_RATE_ADAPT_CTRL_11,
+-					   AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_EN |
+-					   AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE,
+-					   AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_EN |
+-					   rate_adapt);
++	if (neg_mode == PHYLINK_PCS_NEG_INBAND_ENABLED &&
++	    interface == PHY_INTERFACE_MODE_SGMII) {
++		regmap_update_bits(priv->hsgmii_rate_adp,
++				   AIROHA_PCS_HSGMII_RATE_ADAPT_CTRL_1,
++				   AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_WR_THR |
++				   AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_RD_THR,
++				   FIELD_PREP(AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_WR_THR, 0x0) |
++				   FIELD_PREP(AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_RD_THR, 0x0));
++		udelay(1);
++		regmap_update_bits(priv->hsgmii_rate_adp,
++				   AIROHA_PCS_HSGMII_RATE_ADAPT_CTRL_1,
++				   AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_WR_THR |
++				   AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_RD_THR,
++				   FIELD_PREP(AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_WR_THR, 0xf) |
++				   FIELD_PREP(AIROHA_PCS_HSGMII_RATE_ADAPT_RX_AFIFO_RD_THR, 0x5));
++	}
++
++	/* Update USXGMII rate adaptation for the current speed.
++	 * This must run regardless of negotiation mode because USXGMII
++	 * uses in-band autoneg but still requires the rate adaptation
++	 * registers to be updated when the link speed changes.
++	 */
++	if (interface == PHY_INTERFACE_MODE_USXGMII ||
++	    interface == PHY_INTERFACE_MODE_10GBASER) {
++		u32 mode;
++		u32 rate_adapt;
++
++		switch (speed) {
++		case SPEED_10000:
++			rate_adapt = AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_10000;
++			mode = AIROHA_PCS_USXGMII_MODE_10000;
++			break;
++		case SPEED_5000:
++			rate_adapt = AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_5000;
++			mode = AIROHA_PCS_USXGMII_MODE_5000;
++			break;
++		case SPEED_2500:
++			rate_adapt = AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_2500;
++			mode = AIROHA_PCS_USXGMII_MODE_2500;
++			break;
++		case SPEED_1000:
++			rate_adapt = AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_1000;
++			mode = AIROHA_PCS_USXGMII_MODE_1000;
++			break;
++		case SPEED_100:
++			rate_adapt = AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_100;
++			mode = AIROHA_PCS_USXGMII_MODE_100;
++			break;
+ 		}
+
++		regmap_update_bits(priv->usxgmii_pcs, AIROHA_PCS_USXGMII_PCS_AN_CONTROL_7,
++				   AIROHA_PCS_USXGMII_RATE_UPDATE_MODE |
++				   AIROHA_PCS_USXGMII_MODE,
++				   AIROHA_PCS_USXGMII_RATE_UPDATE_MODE | mode);
++
++		regmap_update_bits(priv->hsgmii_rate_adp, AIROHA_PCS_HSGMII_RATE_ADAPT_CTRL_11,
++				   AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_EN |
++				   AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE,
++				   AIROHA_PCS_HSGMII_RATE_ADPT_FORCE_RATE_ADAPT_MODE_EN |
++				   rate_adapt);
++	}
++
++	if (neg_mode != PHYLINK_PCS_NEG_INBAND_ENABLED) {
+ 		if (interface == PHY_INTERFACE_MODE_SGMII ||
+ 		    interface == PHY_INTERFACE_MODE_1000BASEX) {
+ 			u32 force_speed;

--- a/target/linux/airoha/patches-6.12/621-net-pcs-airoha-AN7581-add-global-digital-reset-for.patch
+++ b/target/linux/airoha/patches-6.12/621-net-pcs-airoha-AN7581-add-global-digital-reset-for.patch
@@ -1,0 +1,114 @@
+From: Ryan Chen <rchen14b@gmail.com>
+Date: Thu, 06 Mar 2026 12:00:00 -0600
+Subject: [PATCH 2/2] net: pcs: airoha: AN7581: add global digital reset for
+ USXGMII speed changes
+
+On the EN7581, when phylink renegotiates a new speed within the same
+USXGMII interface mode, only link_up() is called (not pcs_config()).
+The existing link_up() only resets the TXPCS, which is insufficient:
+the RX data path (RXPCS, FIFOs, PMA digital logic) remains configured
+for the previous speed and no traffic flows.
+
+Fix this by adding a global digital reset sequence to the AN7581
+link_up callback for USXGMII and 10GBASE-R interfaces.
+
+Guard the global reset with a needs_full_init flag set by pcs_config()
+after bringup(). On the first link_up after bringup, skip the global
+reset since bringup already performed full PCS/PMA initialization.
+During this window the PHY firmware may still be loading and its SerDes
+is unstable — a global PCS reset can corrupt the USXGMII autoneg state
+permanently. On subsequent link_up calls (cable replug, speed changes),
+the global reset fires normally since the PHY is fully initialized.
+
+Signed-off-by: Ryan Chen <rchen14b@gmail.com>
+---
+ drivers/net/pcs/airoha/pcs-airoha-common.c |  1 +
+ drivers/net/pcs/airoha/pcs-airoha.h        |  1 +
+ drivers/net/pcs/airoha/pcs-an7581.c        | 55 +++++++++++++++++++++
+ 3 files changed, 57 insertions(+)
+
+--- a/drivers/net/pcs/airoha/pcs-airoha.h
++++ b/drivers/net/pcs/airoha/pcs-airoha.h
+@@ -1188,6 +1188,7 @@
+ 	struct reset_control_bulk_data rsts[AIROHA_PCS_MAX_NUM_RSTS];
+ 
+ 	bool manual_rx_calib;
++	bool needs_full_init;
+ };
+ 
+ struct airoha_pcs_port {
+--- a/drivers/net/pcs/airoha/pcs-airoha-common.c
++++ b/drivers/net/pcs/airoha/pcs-airoha-common.c
+@@ -422,6 +422,7 @@
+ 		ret = data->bringup(priv, interface);
+ 		if (ret)
+ 			return ret;
++		priv->needs_full_init = true;
+ 	}
+ 
+ 	/* Set final configuration for various modes */
+--- a/drivers/net/pcs/airoha/pcs-an7581.c
++++ b/drivers/net/pcs/airoha/pcs-an7581.c
+@@ -1363,6 +1363,29 @@
+ 
+ void an7581_pcs_phya_link_up(struct airoha_pcs_priv *priv)
+ {
++	u32 rst_mask = AIROHA_PCS_PMA_SW_HSG_RXPCS_RST_N |
++		       AIROHA_PCS_PMA_SW_HSG_TXPCS_RST_N |
++		       AIROHA_PCS_PMA_SW_XFI_RXPCS_BIST_RST_N |
++		       AIROHA_PCS_PMA_SW_XFI_RXPCS_RST_N |
++		       AIROHA_PCS_PMA_SW_XFI_TXPCS_RST_N |
++		       AIROHA_PCS_PMA_SW_TX_FIFO_RST_N |
++		       AIROHA_PCS_PMA_SW_REF_RST_N |
++		       AIROHA_PCS_PMA_SW_ALLPCS_RST_N |
++		       AIROHA_PCS_PMA_SW_PMA_RST_N |
++		       AIROHA_PCS_PMA_SW_TX_RST_N |
++		       AIROHA_PCS_PMA_SW_RX_RST_N |
++		       AIROHA_PCS_PMA_SW_RX_FIFO_RST_N;
++	u32 val;
++	int i;
++
++	/* Wait for any ongoing PCS reset to complete before proceeding. */
++	for (i = 0; i < 50; i++) {
++		regmap_read(priv->xfi_pma, AIROHA_PCS_PMA_SW_RST_SET, &val);
++		if ((val & rst_mask) == rst_mask)
++			break;
++		usleep_range(1000, 2000);
++	}
++
+ 	/* Reset TXPCS on link up */
+ 	regmap_clear_bits(priv->xfi_pma, AIROHA_PCS_PMA_SW_RST_SET,
+ 			  AIROHA_PCS_PMA_SW_HSG_TXPCS_RST_N);
+@@ -1371,6 +1394,32 @@
+ 
+ 	regmap_set_bits(priv->xfi_pma, AIROHA_PCS_PMA_SW_RST_SET,
+ 			AIROHA_PCS_PMA_SW_HSG_TXPCS_RST_N);
++
++	if (priv->interface == PHY_INTERFACE_MODE_USXGMII ||
++	    priv->interface == PHY_INTERFACE_MODE_10GBASER) {
++		if (priv->needs_full_init) {
++			priv->needs_full_init = false;
++			dev_dbg(priv->dev, "link_up: skipping global reset (bringup just ran)\n");
++			return;
++		}
++
++		dev_dbg(priv->dev, "link_up: performing global digital reset\n");
++		an7581_pcs_cdr_reset(priv, priv->interface, false);
++
++		/* Assert global reset (keep REF_RST_N high) */
++		regmap_update_bits(priv->xfi_pma, AIROHA_PCS_PMA_SW_RST_SET,
++				   rst_mask, AIROHA_PCS_PMA_SW_REF_RST_N);
++
++		usleep_range(100, 200);
++
++		/* Deassert global reset */
++		regmap_set_bits(priv->xfi_pma, AIROHA_PCS_PMA_SW_RST_SET,
++				rst_mask);
++
++		usleep_range(5000, 7000);
++
++		an7581_pcs_cdr_reset(priv, priv->interface, false);
++	}
+ }
+ 
+ static bool an7581_pcs_have_rx_signal(struct airoha_pcs_priv *priv)


### PR DESCRIPTION
## Summary

Fix two bugs in the AN7581 PCS driver that break USXGMII data path
when phylink renegotiates speed.

**Patch 620 — Rate adaptation not updated for USXGMII:**
The rate adaptation register writes in `airoha_pcs_link_up()` were
inside the forced-mode-only branch (`neg_mode != PHYLINK_PCS_NEG_INBAND`).
USXGMII always uses in-band autoneg, so these registers were never
updated on speed changes. This causes PSE flooding that also breaks
1G switch ports sharing the same Frame Engine.

Fix: move USXGMII rate adaptation out of the forced-mode guard.

**Patch 621 — RX data path not reinitialized on speed change:**
When phylink renegotiates speed within the same interface mode (e.g.
10G → 2.5G → 10G), only `link_up()` is called — not `pcs_config()`.
The existing TXPCS-only reset in `an7581_pcs_phya_link_up()` is
insufficient. The RX deserialization, FIFOs, and PMA digital logic
remain configured for the old speed, silently dropping all packets.

Fix: add a full PCS/PMA global digital reset (CDR re-lock + all reset
lines except REF_RST_N) for USXGMII and 10GBASE-R speed changes.

Guard the reset with a `needs_full_init` flag set by `pcs_config()`
after `bringup()` runs. This skips the global reset on the first
`link_up()` after boot/re-probe, when `bringup()` already did a full
PCS/PMA init and the PHY firmware may still be loading. Firing a
global reset during PHY init can corrupt USXGMII autoneg state.

Both bugs are in the upstream `pcs-an7581.c` driver and affect any
AN7581 board with USXGMII PHYs (RTL8261N, AS21xxx).

## Test results
- Gemtek W1700K (AN7581 + dual RTL8261N on USXGMII)
- Boot with 1G device on lan2: link comes up at 1G, no dead link
- Boot with 10G device on lan2: link comes up at 10G
- Cable replug: global reset fires, link recovers in ~3s
- Verified with debug logging: "skipping global reset" on boot,
  "performing global digital reset" on replug

## Test plan
- [ ] Build for airoha target
- [ ] Boot with cable plugged in — verify no permanent link failure
- [ ] Unplug/replug cable — verify link recovers
- [ ] Test with both 1G and 10G devices on USXGMII ports