### PR TITLE
tools/cmake: update to 4.3.0

### DIFF
--- a/tools/cmake/Makefile
+++ b/tools/cmake/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cmake
-PKG_VERSION:=4.2.3
+PKG_VERSION:=4.3.1
 PKG_VERSION_MAJOR:=$(word 1,$(subst ., ,$(PKG_VERSION))).$(word 2,$(subst ., ,$(PKG_VERSION)))
 PKG_RELEASE:=1
 PKG_CPE_ID:=cpe:/a:kitware:cmake
@@ -15,7 +15,7 @@ PKG_CPE_ID:=cpe:/a:kitware:cmake
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/Kitware/CMake/releases/download/v$(PKG_VERSION)/ \
 		https://cmake.org/files/v$(PKG_VERSION_MAJOR)/
-PKG_HASH:=7efaccde8c5a6b2968bad6ce0fe60e19b6e10701a12fce948c2bf79bac8a11e9
+PKG_HASH:=0798f4be7a1a406a419ac32db90c2956936fecbf50db3057d7af47d69a2d7edb
 
 HOST_BUILD_PARALLEL:=1
 HOST_CONFIGURE_PARALLEL:=1

--- a/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
+++ b/tools/cmake/patches/130-bootstrap_parallel_make_flag.patch
@@ -1,6 +1,6 @@
 --- a/bootstrap
 +++ b/bootstrap
-@@ -1521,7 +1521,10 @@ int main(){ printf("1%c", (char)0x0a); r
+@@ -1522,7 +1522,10 @@ int main(){ printf("1%c", (char)0x0a); r
  ' > "test.c"
  cmake_original_make_flags="${cmake_make_flags}"
  if test "x${cmake_parallel_make}" != "x"; then

--- a/tools/cmake/patches/150-zstd-libarchive.patch
+++ b/tools/cmake/patches/150-zstd-libarchive.patch
@@ -1,6 +1,6 @@
 --- a/Utilities/cmlibarchive/CMakeLists.txt
 +++ b/Utilities/cmlibarchive/CMakeLists.txt
-@@ -669,7 +669,7 @@ IF(ENABLE_ZSTD)
+@@ -680,7 +680,7 @@ IF(ENABLE_ZSTD)
      SET(ZSTD_FIND_QUIETLY TRUE)
    ENDIF (ZSTD_INCLUDE_DIR)
  

--- a/tools/cmake/patches/160-disable_xcode_generator.patch
+++ b/tools/cmake/patches/160-disable_xcode_generator.patch
@@ -1,6 +1,6 @@
 --- a/Source/CMakeLists.txt
 +++ b/Source/CMakeLists.txt
-@@ -903,7 +903,7 @@ if(CMake_USE_XCOFF_PARSER)
+@@ -923,7 +923,7 @@ if(CMake_USE_XCOFF_PARSER)
  endif()
  
  # Xcode only works on Apple
@@ -11,7 +11,7 @@
      PRIVATE
 --- a/Source/cmake.cxx
 +++ b/Source/cmake.cxx
-@@ -142,7 +142,7 @@
+@@ -144,7 +144,7 @@
  #  endif
  #endif
  


### PR DESCRIPTION
Release notes:https://cmake.org/cmake/help/latest/release/4.3.html

Refresh patches:
- 130-bootstrap_parallel_make_flag.patch
- 150-zstd-libarchive.patch
- 160-disable_xcode_generator.patch