### PR TITLE
starfive: improve board support

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/starfive
+++ b/package/boot/uboot-tools/uboot-envtools/files/starfive
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2017 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+[ -e /etc/config/ubootenv ] && exit 0
+
+touch /etc/config/ubootenv
+
+. /lib/uboot-envtools.sh
+. /lib/functions.sh
+
+board=$(board_name)
+
+case "$board" in
+starfive,visionfive-2-v1.3b)
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x10000" "0x10000"
+	;;
+esac
+
+config_load ubootenv
+config_foreach ubootenv_add_app_config ubootenv
+
+exit 0

--- a/target/linux/starfive/image/Makefile
+++ b/target/linux/starfive/image/Makefile
@@ -52,7 +52,7 @@ define Device/visionfive2-v1.2a
   DEVICE_VENDOR := StarFive
   DEVICE_MODEL := VisionFive2 v1.2a
   DEVICE_DTS := starfive/jh7110-starfive-visionfive-2-v1.2a
-  DEVICE_PACKAGES := kmod-eeprom-at24
+  DEVICE_PACKAGES := kmod-eeprom-at24 kmod-leds-gpio
 endef
 TARGET_DEVICES += visionfive2-v1.2a
 
@@ -60,7 +60,7 @@ define Device/visionfive2-v1.3b
   DEVICE_VENDOR := StarFive
   DEVICE_MODEL := VisionFive2 v1.3b
   DEVICE_DTS := starfive/jh7110-starfive-visionfive-2-v1.3b
-  DEVICE_PACKAGES := kmod-eeprom-at24
+  DEVICE_PACKAGES := kmod-eeprom-at24 kmod-leds-gpio
 endef
 TARGET_DEVICES += visionfive2-v1.3b
 
@@ -77,7 +77,8 @@ define Device/visionfive-v1
   DEVICE_VENDOR := StarFive
   DEVICE_MODEL := VisionFive v1
   DEVICE_DTS := starfive/jh7100-starfive-visionfive-v1
-  DEVICE_PACKAGES := kmod-eeprom-at24 kmod-brcmfmac cypress-firmware-43430-sdio wpad-basic-mbedtls
+  DEVICE_PACKAGES := kmod-eeprom-at24 kmod-brcmfmac cypress-firmware-43430-sdio wpad-basic-mbedtls \
+			kmod-leds-gpio
 endef
 TARGET_DEVICES += visionfive-v1
 

--- a/target/linux/starfive/image/Makefile
+++ b/target/linux/starfive/image/Makefile
@@ -24,6 +24,7 @@ define Build/riscv-sdcard
 	mcopy -i $@.boot $(LINUX_DIR)/arch/riscv/boot/dts/$(DEVICE_DTS).dtb ::dtb
 	mcopy -i $@.boot $@-boot.scr ::boot.scr.uimg
 	mcopy -i $@.boot $(IMAGE_KERNEL) ::Image
+	mcopy -i $@.boot jh7110-vf2-uenv.txt ::vf2_uEnv.txt
 	./gen_starfive_sdcard_img.sh \
 		$@ \
 		$@.boot \

--- a/target/linux/starfive/image/Makefile
+++ b/target/linux/starfive/image/Makefile
@@ -60,7 +60,7 @@ define Device/visionfive2-v1.3b
   DEVICE_VENDOR := StarFive
   DEVICE_MODEL := VisionFive2 v1.3b
   DEVICE_DTS := starfive/jh7110-starfive-visionfive-2-v1.3b
-  DEVICE_PACKAGES := kmod-eeprom-at24 kmod-leds-gpio
+  DEVICE_PACKAGES := kmod-eeprom-at24 kmod-leds-gpio uboot-envtools
 endef
 TARGET_DEVICES += visionfive2-v1.3b
 

--- a/target/linux/starfive/image/jh7110-vf2-uenv.txt
+++ b/target/linux/starfive/image/jh7110-vf2-uenv.txt
@@ -1,0 +1,6 @@
+boot2=echo "HELLO WORLD"; run bootcmd
+fatbootpart=1:3
+devnum=1
+boot_targets=mmc1
+bootcmd_mmc1=setenv devnum 1; run mmc_boot
+bootcmd=run chipa_set_linux; run cpu_vol_set; run bootcmd_mmc1

--- a/target/linux/starfive/patches-6.12/1023-riscv-dts-starfive-visionfive2-add-SYSLED-support.patch
+++ b/target/linux/starfive/patches-6.12/1023-riscv-dts-starfive-visionfive2-add-SYSLED-support.patch
@@ -1,0 +1,34 @@
+From 3a92ee5a97f030bdb1e88272a5d277ecb76836d6 Mon Sep 17 00:00:00 2001
+From: Zoltan HERPAI <wigyori@uid0.hu>
+Date: Sun, 1 Jun 2025 14:03:30 +0000
+Subject: [PATCH 7/8] riscv: dts: starfive: visionfive2: add SYSLED support
+
+A SYS LED is available at aongpio-3. Add standard heartbeat
+support for it.
+
+Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>
+---
+ .../dts/starfive/jh7110-starfive-visionfive-2.dtsi   | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+--- a/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
++++ b/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
+@@ -21,6 +21,18 @@
+ 			reg = <0x0 0x6ce00000 0x0 0x1600000>;
+ 		};
+ 	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led-ack {
++			gpios = <&aongpio 3 GPIO_ACTIVE_HIGH>;
++			color = <LED_COLOR_ID_GREEN>;
++			function = LED_FUNCTION_HEARTBEAT;
++			linux,default-trigger = "heartbeat";
++			label = "ack";
++		};
++	};
+ };
+ 
+ &gmac1 {

--- a/target/linux/starfive/patches-6.12/1024-riscv-dts-starfive-visionfive2-add-LED-aliases-and-s.patch
+++ b/target/linux/starfive/patches-6.12/1024-riscv-dts-starfive-visionfive2-add-LED-aliases-and-s.patch
@@ -1,0 +1,43 @@
+From d930d3d22dcca6946dbdc822d7b8681f0d6372e5 Mon Sep 17 00:00:00 2001
+From: Zoltan HERPAI <wigyori@uid0.hu>
+Date: Sun, 1 Jun 2025 14:06:04 +0000
+Subject: [PATCH 8/8] riscv: dts: starfive: visionfive2: add LED aliases and
+ stop heartbeat
+
+Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>
+---
+ .../boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi   | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+--- a/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
++++ b/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
+@@ -6,10 +6,15 @@
+ 
+ /dts-v1/;
+ #include "jh7110-common.dtsi"
++#include <dt-bindings/leds/common.h>
+ 
+ / {
+ 	aliases {
+ 		ethernet1 = &gmac1;
++		led-boot = &led_ack;
++		led-failsafe = &led_ack;
++		led-running = &led_ack;
++		led-upgrade = &led_ack;
+ 	};
+ 
+ 	reserved-memory {
+@@ -25,11 +30,11 @@
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+-		led-ack {
++		led_ack: led-ack {
+ 			gpios = <&aongpio 3 GPIO_ACTIVE_HIGH>;
+ 			color = <LED_COLOR_ID_GREEN>;
+ 			function = LED_FUNCTION_HEARTBEAT;
+-			linux,default-trigger = "heartbeat";
++			default-state = "on";
+ 			label = "ack";
+ 		};
+ 	};

--- a/target/linux/starfive/patches-6.12/1025-riscv-dts-starfive-visionfive2-add-dma-pool-entry.patch
+++ b/target/linux/starfive/patches-6.12/1025-riscv-dts-starfive-visionfive2-add-dma-pool-entry.patch
@@ -1,0 +1,31 @@
+From 928a660ec1124853d2dae074e74ec7b20fe9bac2 Mon Sep 17 00:00:00 2001
+From: Zoltan HERPAI <wigyori@uid0.hu>
+Date: Sun, 1 Jun 2025 16:02:38 +0000
+Subject: [PATCH] riscv: dts: starfive: visionfive2: add dma pool entry
+
+In the VF2 SDK there is a reserved memory for a shared dma pool, which is
+also updated by the SDK bootloader. Add this node here as well.
+
+Signed-off-by: Zoltan HERPAI <wigyori@uid0.hu>
+---
+ .../boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi  | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+--- a/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
++++ b/arch/riscv/boot/dts/starfive/jh7110-starfive-visionfive-2.dtsi
+@@ -25,6 +25,15 @@
+ 		e24_mem: e24@c0000000 {
+ 			reg = <0x0 0x6ce00000 0x0 0x1600000>;
+ 		};
++
++		linux,cma {
++			compatible = "shared-dma-pool";
++			reusable;
++			size = <0x0 0x20000000>;
++			alignment = <0x0 0x1000>;
++			alloc-ranges = <0x0 0x70000000 0x0 0x20000000>;
++			linux,cma-default;
++		};
+ 	};
+ 
+ 	leds {


### PR DESCRIPTION
This PR will:
 - improve support for newer bootloader versions on the VF2
 - u-boot env handling on VF2
 - add support for the standard OpenWrt status LED handling