### PR TITLE
ipq40xx: remove ethernet0 alias

### DIFF
--- a/target/linux/ipq40xx/dts/qcom-ipq4018-cs-w3-wd1200g-eup.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-cs-w3-wd1200g-eup.dts
@@ -11,8 +11,6 @@
 	compatible = "ezviz,cs-w3-wd1200g-eup";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_status_green;
 		led-failsafe = &led_status_red;
 		led-running = &led_status_blue;
@@ -249,6 +247,7 @@
 
 &gmac {
 	status = "okay";
+
 	nvmem-cells = <&macaddr_art_0>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-eap1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-eap1300.dts
@@ -41,12 +41,11 @@
 	};
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &power;
 		led-failsafe = &power;
 		led-running = &power;
 		led-upgrade = &power;
+		label-mac-device = &gmac;
 	};
 
 	leds {
@@ -238,12 +237,13 @@
 &swport5 {
 	status = "okay";
 	label = "lan";
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
 };
 
 &gmac {
 	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
 };
 
 &mdio {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-gl-ap1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-gl-ap1300.dts
@@ -11,12 +11,11 @@
 	compatible = "glinet,gl-ap1300";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;
 		led-upgrade = &led_power;
+		label-mac-device = &gmac;
 	};
 
 	memory {
@@ -273,6 +272,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &switch {
@@ -282,9 +284,6 @@
 &swport4 {
 	status = "okay";
 	label = "lan";
-
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
 };
 
 &swport5 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-mf287_common.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-mf287_common.dtsi
@@ -11,8 +11,6 @@
 
 / {
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_status;
 		led-failsafe = &led_status;
 		led-running = &led_status;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-cm520-79f.dts
@@ -11,8 +11,6 @@
 	compatible = "mobipromo,cm520-79f";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_sys;
 		led-failsafe = &led_sys;
 		led-running = &led_sys;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac-c1.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac-c1.dts
@@ -11,11 +11,6 @@
 / {
 	model = "Qxwlan E2600AC c1";
 	compatible = "qxwlan,e2600ac-c1";
-
-	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
-	};
 };
 
 &blsp1_spi1 {
@@ -121,6 +116,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &switch {
@@ -130,9 +128,6 @@
 &swport4 {
 	status = "okay";
 	label = "sw-eth1";
-
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &swport5 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac-c2.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-e2600ac-c2.dts
@@ -11,11 +11,6 @@
 / {
 	model = "Qxwlan E2600AC c2";
 	compatible = "qxwlan,e2600ac-c2";
-
-	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
-	};
 };
 
 &blsp1_spi1 {
@@ -160,6 +155,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &switch {
@@ -169,9 +167,6 @@
 &swport2 {
 	status = "okay";
 	label = "sw-eth1";
-
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &swport4 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-habanero-dvk.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-habanero-dvk.dts
@@ -12,8 +12,6 @@
 	compatible = "8dev,habanero-dvk";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_status;
 		led-failsafe = &led_status;
 		led-running = &led_status;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf18a.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf18a.dts
@@ -14,8 +14,6 @@
 	compatible = "zte,mf18a";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;
@@ -231,6 +229,7 @@
 
 &gmac {
 	status = "okay";
+
 	nvmem-cell-names = "mac-address";
 	nvmem-cells = <&macaddr_config_0 0>;
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf282plus.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf282plus.dts
@@ -13,8 +13,6 @@
 	compatible = "zte,mf282plus";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_internal;
 		led-failsafe = &led_internal;
 		led-running = &led_internal;
@@ -213,6 +211,7 @@
 
 &gmac {
 	status = "okay";
+
 	nvmem-cell-names = "mac-address";
 	nvmem-cells = <&macaddr_config_0 0>;
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf286d.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf286d.dts
@@ -12,8 +12,6 @@
 	compatible = "zte,mf286d";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_internal;
 		led-failsafe = &led_internal;
 		led-running = &led_internal;
@@ -207,6 +205,7 @@
 
 &gmac {
 	status = "okay";
+
 	nvmem-cell-names = "mac-address";
 	nvmem-cells = <&macaddr_config_0 0>;
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-mf289f.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-mf289f.dts
@@ -13,8 +13,6 @@
 	compatible = "zte,mf289f";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_status;
 		led-failsafe = &led_status;
 		led-running = &led_status;
@@ -316,6 +314,7 @@
 
 &gmac {
 	status = "okay";
+
 	nvmem-cell-names = "mac-address";
 	nvmem-cells = <&macaddr_mac_0 0>;
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-wtr-m2133hp.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-wtr-m2133hp.dts
@@ -29,8 +29,6 @@
 	};
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_power_blue;
 		led-failsafe = &led_power_orange;
 		led-running = &led_power_white;
@@ -445,6 +443,7 @@
 
 &gmac {
 	status = "okay";
+
 	nvmem-cell-names = "mac-address";
 	nvmem-cells = <&macaddr_orgdata_20>;
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4028-wpj428.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4028-wpj428.dts
@@ -73,8 +73,6 @@
 	};
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &status;
 		led-failsafe = &status;
 		led-upgrade = &status;
@@ -263,6 +261,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cells = <&macaddr_art_e018>;
+	nvmem-cell-names = "mac-address";
 };
 
 &switch {
@@ -272,9 +273,6 @@
 &swport4 {
 	status = "okay";
 	label = "lan1";
-
-	nvmem-cells = <&macaddr_art_e018>;
-	nvmem-cell-names = "mac-address";
 };
 
 &swport5 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-ap-303h.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-ap-303h.dts
@@ -10,8 +10,6 @@
 	compatible = "aruba,ap-303h";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_system_green;
 		led-failsafe = &led_system_red;
 		led-running = &led_system_green;

--- a/target/linux/ipq40xx/dts/qcom-ipq40x9-dr40x9.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq40x9-dr40x9.dts
@@ -9,11 +9,6 @@
 	model = "Wallystech DR40X9";
 	compatible = "wallys,dr40x9";
 
-	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
-	};
-
 	chosen {
 		bootargs-append = " ubi.mtd=ubi root=/dev/ubiblock0_1";
 	};
@@ -349,6 +344,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &switch {
@@ -358,8 +356,6 @@
 &swport4 {
 	status = "okay";
 	label = "wan";
-	nvmem-cells = <&macaddr_art_0>;
-	nvmem-cell-names = "mac-address";
 };
 
 &swport5 {


### PR DESCRIPTION
Not needed when using nvmem. All others left alone.

ping @robimarko 