### PR TITLE
github: add Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,38 @@
+name: Claude Code Review
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  code-review:
+    name: Claude Code Review
+    # Only run on PR comments containing "/claude" from users with write access
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/claude') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+               github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+
+      - name: PR Review
+        uses: anthropics/claude-code-action@6062f3709600659be5e47fcddf2cf76993c235c2 # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          trigger_phrase: "/claude"
+          prompt: >-
+            Review this PR for an OpenWrt embedded Linux project,
+            focusing on correctness, security, and coding conventions.
+          claude_args: >-
+            --allowedTools
+            "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
Add claude-code-review.yml using anthropics/claude-code-action@v1. The review runs when a PR comment containing "@claude" is posted, avoiding unnecessary API usage on every push.
Uses issue_comment trigger restricted to PR comments only. Passes ANTHROPIC_API_KEY and GITHUB_TOKEN directly to bypass OIDC token exchange. A short domain hint steers the review toward OpenWrt embedded Linux conventions.

We do not have enough reviews, I tried to use AI to do reviews.

Here are 3 example reviews:
https://github.com/hauke/openwrt/pull/2
https://github.com/hauke/openwrt/pull/3
https://github.com/hauke/openwrt/pull/4
These reviews looks pretty good, but they cost me 0.61$.
Additional review: https://github.com/hauke/openwrt/pull/5 (0.32$)
When we run this on all PRs this would be pretty expensive.

I also tried to develop an other application: https://openwrt-pr.hauke-m.de/
The PR integration is not so good, but it costs about between 0.02$ to 0.06$. We can also add it as a comment to the PR.

All of this was using Claude Sonnet 4.6