### PR TITLE
realtek: dts: fix ethernet-switch node

### DIFF
--- a/target/linux/realtek/dts/rtl930x.dtsi
+++ b/target/linux/realtek/dts/rtl930x.dtsi
@@ -290,7 +290,7 @@
 			#thermal-sensor-cells = <0>;
 		};
 
-		switch0: switch@1b000000 {
+		switch0: ethernet-switch {
 			compatible = "realtek,rtl9301-switch", "realtek,otto-switch";
 			status = "okay";
 

--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -326,7 +326,7 @@
 			};
 		};
 
-		switch0: switch@1b000000 {
+		switch0: ethernet-switch {
 			compatible = "realtek,rtl9311-switch", "realtek,otto-switch";
 			status = "okay";
 


### PR DESCRIPTION
RTL93xx devices can no longer find the switch node in the DTS. Commit 4c92254 ("relocate/retype switch node") refactored the switch node definition to better align with upstream. Sadly the redefinition for RTL93xx devices failed.

- RTL83xx: use "switch0: ethernet-switch"
- RTL93xx: use "switch0: switch@1b000000"

Follow up commit 8b969f7 ("drop realtek,smi-address property) changed the dts lookup sequence for mdio initialization. On RTL93xx devices it cannot find the switchnode via
of_get_child_by_name(dev->of_node->parent, "ethernet-switch")

Fix the switch node type for RTL93xx