### PR TITLE
u-boot: delete Python 3.x version check

### DIFF
--- a/include/u-boot.mk
+++ b/include/u-boot.mk
@@ -29,13 +29,6 @@ endif
 ifdef UBOOT_USE_INTREE_DTC
   $(eval $(call TestHostCommand,python3-dev, \
     Please install the python3-dev package, \
-    python3.13-config --includes 2>&1 | grep 'python3', \
-    python3.12-config --includes 2>&1 | grep 'python3', \
-    python3.11-config --includes 2>&1 | grep 'python3', \
-    python3.10-config --includes 2>&1 | grep 'python3', \
-    python3.9-config --includes 2>&1 | grep 'python3', \
-    python3.8-config --includes 2>&1 | grep 'python3', \
-    python3.7-config --includes 2>&1 | grep 'python3', \
     python3-config --includes 2>&1 | grep -E 'python3\.([7-9]|[0-9][0-9])\.?'))
 
   $(eval $(call TestHostCommand,python3-setuptools, \

--- a/include/u-boot.mk
+++ b/include/u-boot.mk
@@ -29,13 +29,6 @@ endif
 ifdef UBOOT_USE_INTREE_DTC
   $(eval $(call TestHostCommand,python3-dev, \
     Please install the python3-dev package, \
-    python3.14-config --includes 2>&1 | grep 'python3', \
-    python3.13-config --includes 2>&1 | grep 'python3', \
-    python3.12-config --includes 2>&1 | grep 'python3', \
-    python3.11-config --includes 2>&1 | grep 'python3', \
-    python3.10-config --includes 2>&1 | grep 'python3', \
-    python3.9-config --includes 2>&1 | grep 'python3', \
-    python3.8-config --includes 2>&1 | grep 'python3', \
     python3-config --includes 2>&1 | grep -E 'python3\.([8-9]|[0-9][0-9])\.?'))
 
   $(eval $(call TestHostCommand,python3-setuptools, \


### PR DESCRIPTION
All future Python versions until 3.99 are supported.
No need to check every single version.

Related to: https://github.com/openwrt/openwrt/pull/20758