### PR TITLE
ramips: fix initramfs kernel loadaddr for EAP615-Wall v1

### DIFF
--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2986,7 +2986,6 @@ define Device/tplink_eap615-wall-v1
   KERNEL_LOADADDR := 0x82000000
   KERNEL := kernel-bin | relocate-kernel $(loadaddr-y) | lzma | \
 	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | pad-to 64k
-  KERNEL_INITRAMFS := kernel-bin | lzma -d22 | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
   IMAGE_SIZE := 13248k
 endef
 TARGET_DEVICES += tplink_eap615-wall-v1


### PR DESCRIPTION
The kernel load address was changed in commit e2d823d06830 ("ramips: fix LZMA decompression error for TP-Link EAP615-Wall"). We also need to relocate the load address for initramfs image so that it can be booted correctly.

Fixes: https://github.com/openwrt/openwrt/issues/22505
