### PR TITLE
airoha: an7581: w1700k: fix RTL8261N PHY boot failure

### DIFF
--- a/target/linux/airoha/dts/an7581-w1700k-ubi.dts
+++ b/target/linux/airoha/dts/an7581-w1700k-ubi.dts
@@ -351,8 +351,8 @@
 			compatible = "ethernet-phy-ieee802.3-c45";
 			reg = <5>;
 			reset-gpios = <&en7581_pinctrl 46 GPIO_ACTIVE_LOW>;
-			reset-assert-us = <40000>;
-			reset-deassert-us = <150000>;
+			reset-assert-us = <200000>;
+			reset-deassert-us = <200000>;
 			interrupt-parent = <&en7581_pinctrl>;
 			interrupts = <22 IRQ_TYPE_LEVEL_LOW>;
 			realtek,pnswap-tx;
@@ -363,8 +363,8 @@
 			compatible = "ethernet-phy-ieee802.3-c45";
 			reg = <8>;
 			reset-gpios = <&en7581_pinctrl 31 GPIO_ACTIVE_LOW>;
-			reset-assert-us = <40000>;
-			reset-deassert-us = <150000>;
+			reset-assert-us = <200000>;
+			reset-deassert-us = <200000>;
 			interrupt-parent = <&en7581_pinctrl>;
 			interrupts = <23 IRQ_TYPE_LEVEL_LOW>;
 			realtek,pnswap-tx;


### PR DESCRIPTION
## Summary

Fix intermittent 10G PHY boot failure on W1700K and XR1701G boards
with Realtek RTL8261N/RTL8261BE PHYs.

On cold boot, the USXGMII link sometimes fails to come up and stays
dead until power cycle. The RTL8261N needs time to load its internal
firmware after reset deassertion. The current GPIO reset timing
(40ms assert / 150ms deassert) is too short — the PHY firmware load
hasn't completed when the PCS starts link training.

Fix: increase both PHY reset assert and deassert delays to 200ms,
matching the OEM firmware values.

Confirmed fix on:
- Gemtek W1700K (RTL8261N on phy5/lan2 and phy8/wan)
- XR1701G (RTL8261BE)

Multiple users reported this issue:
- https://github.com/OpenWRT-fanboy/OpenW1700k/issues (W1700K)
- Confirmed independently on XR1701G boards

## Test plan
- [ ] Cold boot 20+ times with 10G device plugged in
- [ ] Verify link comes up reliably on both lan2 and wan
- [ ] Verify no regression on boot time (adds ~100ms total)