### PR TITLE
ramips-mt7621: fix xiaomi redmi router ac2100 label mac being off by one

### DIFF
--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-ac2100.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-ac2100.dts
@@ -13,7 +13,7 @@
 		led-failsafe = &led_status_yellow;
 		led-running = &led_status_blue;
 		led-upgrade = &led_status_blue;
-		label-mac-device = &gmac0;
+		label-mac-device = &gmac1;
 	};
 
 	leds {

--- a/target/linux/ramips/dts/mt7621_xiaomi_redmi-router-ac2100.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_redmi-router-ac2100.dts
@@ -13,7 +13,7 @@
 		led-failsafe = &led_status_amber;
 		led-running = &led_status_white;
 		led-upgrade = &led_status_white;
-		label-mac-device = &gmac0;
+		label-mac-device = &gmac1;
 	};
 
 	leds {


### PR DESCRIPTION
The Xiaomi Redmi/Mi Router AC2100 does have the correct label mac on the WAN interface. This MAC is available as gmac1.


The gmac1 is defined in the dtsi as:

```
nvmem-cells = <&macaddr_factory_e006>;
nvmem-cell-names = "mac-address";
```

So I guess this is fine.
As gmac0 is not used anywhere else, one could also remove this..? But I would rather not touch it.

Tested by @jrasko - works well.