### PR TITLE
network: add uci-vrf support package

### DIFF
--- a/package/network/config/uci-vrf/Makefile
+++ b/package/network/config/uci-vrf/Makefile
@@ -1,0 +1,47 @@
+#
+# Copyright (C) 2026 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=uci-vrf
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/uci-vrf
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=VRF config support in /etc/config/network
+  DEPENDS:=+kmod-vrf +ip
+  PKGARCH:=all
+endef
+
+define Package/uci-vrf/description
+ Virtual Routing and Forwarding (VRF) config support in /etc/config/network
+ using custom UCI sections and a lightweight helper outside of netifd.
+endef
+
+define Build/Compile
+endef
+
+define Build/Configure
+endef
+
+define Package/uci-vrf/install
+	$(INSTALL_DIR) \
+		$(1)/etc/init.d \
+		$(1)/etc/hotplug.d/iface \
+		$(1)/etc/hotplug.d/net \
+		$(1)/usr/sbin
+	$(INSTALL_BIN) ./files/uci-vrf $(1)/usr/sbin/uci-vrf
+	$(INSTALL_BIN) ./files/uci-vrf.init $(1)/etc/init.d/uci-vrf
+	$(INSTALL_DATA) ./files/uci-vrf.hotplug $(1)/etc/hotplug.d/iface/95-uci-vrf
+	$(INSTALL_DATA) ./files/uci-vrf.hotplug $(1)/etc/hotplug.d/net/95-uci-vrf
+endef
+
+$(eval $(call BuildPackage,uci-vrf))

--- a/package/network/config/uci-vrf/files/uci-vrf
+++ b/package/network/config/uci-vrf/files/uci-vrf
@@ -1,0 +1,255 @@
+#!/bin/sh
+
+: "${UCI_VRF_PATH:=/sbin:/bin:/usr/sbin:/usr/bin}"
+: "${UCI_VRF_STATE_FILE:=/var/run/uci-vrf.state}"
+: "${UCI_VRF_LOG_TAG:=uci-vrf}"
+: "${UCI_VRF_FUNCTIONS:=/lib/functions.sh}"
+: "${UCI_VRF_NETWORK_FUNCTIONS:=/lib/functions/network.sh}"
+
+PATH="$UCI_VRF_PATH"
+STATE_FILE="$UCI_VRF_STATE_FILE"
+LOG_TAG="$UCI_VRF_LOG_TAG"
+
+. "$UCI_VRF_FUNCTIONS"
+. "$UCI_VRF_NETWORK_FUNCTIONS"
+
+log_msg() {
+	logger -t "$LOG_TAG" "$*"
+}
+
+device_exists() {
+	ip link show dev "$1" >/dev/null 2>&1
+}
+
+is_vrf_device() {
+	ip -d link show dev "$1" 2>/dev/null | grep -q " vrf table "
+}
+
+state_add_vrf() {
+	local name="$1"
+
+	list_contains STATE_VRFS "$name" || append STATE_VRFS "$name"
+}
+
+state_add_member() {
+	local name="$1"
+
+	list_contains STATE_MEMBERS "$name" || append STATE_MEMBERS "$name"
+}
+
+save_state() {
+	local item
+
+	: > "$STATE_FILE"
+
+	for item in $STATE_MEMBERS; do
+		echo "member $item" >> "$STATE_FILE"
+	done
+
+	for item in $STATE_VRFS; do
+		echo "vrf $item" >> "$STATE_FILE"
+	done
+}
+
+teardown_state() {
+	local type name
+
+	[ -f "$STATE_FILE" ] || return 0
+
+	while read -r type name; do
+		[ "$type" = "member" ] || continue
+		[ -n "$name" ] || continue
+		ip link set dev "$name" nomaster 2>/dev/null
+	done < "$STATE_FILE"
+
+	while read -r type name; do
+		[ "$type" = "vrf" ] || continue
+		[ -n "$name" ] || continue
+		ip link del dev "$name" 2>/dev/null
+	done < "$STATE_FILE"
+
+	rm -f "$STATE_FILE"
+}
+
+resolve_vrf_name() {
+	local ref="$1"
+	local cfgtype name
+
+	[ -n "$ref" ] || return 1
+
+	config_get cfgtype "$ref" TYPE
+	if [ "$cfgtype" = "vrf" ]; then
+		config_get name "$ref" name "$ref"
+		printf '%s\n' "$name"
+		return 0
+	fi
+
+	printf '%s\n' "$ref"
+}
+
+resolve_member_device() {
+	local ref="$1"
+	local dev
+
+	[ -n "$ref" ] || return 1
+
+	network_get_device dev "$ref" && [ -n "$dev" ] && {
+		printf '%s\n' "$dev"
+		return 0
+	}
+
+	network_get_physdev dev "$ref" && [ -n "$dev" ] && {
+		printf '%s\n' "$dev"
+		return 0
+	}
+
+	printf '%s\n' "$ref"
+}
+
+ensure_vrf() {
+	local cfg="$1"
+	local enabled name table mtu
+
+	config_get_bool enabled "$cfg" enabled 1
+	[ "$enabled" -eq 1 ] || return 0
+
+	config_get name "$cfg" name "$cfg"
+	config_get table "$cfg" table
+	config_get mtu "$cfg" mtu
+
+	if [ -z "$table" ]; then
+		log_msg "Skipping VRF '$cfg': missing table"
+		return 0
+	fi
+
+	if device_exists "$name"; then
+		if ! is_vrf_device "$name"; then
+			log_msg "Skipping VRF '$cfg': device '$name' exists and is not a VRF"
+			return 0
+		fi
+	else
+		if ! ip link add "$name" type vrf table "$table" 2>/dev/null; then
+			log_msg "Failed to create VRF '$name' with table '$table'"
+			return 0
+		fi
+	fi
+
+	[ -n "$mtu" ] && ip link set dev "$name" mtu "$mtu" 2>/dev/null
+	ip link set dev "$name" up 2>/dev/null
+	state_add_vrf "$name"
+}
+
+attach_member_device() {
+	local ref="$1"
+	local vrf_name="$2"
+	local dev
+
+	dev="$(resolve_member_device "$ref")" || return 0
+	[ -n "$dev" ] || return 0
+
+	if [ "$dev" = "$vrf_name" ]; then
+		log_msg "Skipping member '$dev': device equals VRF '$vrf_name'"
+		return 0
+	fi
+
+	if ! device_exists "$vrf_name"; then
+		log_msg "Skipping member '$dev': VRF '$vrf_name' is not present"
+		return 0
+	fi
+
+	if ! device_exists "$dev"; then
+		log_msg "Skipping member '$dev': device not present"
+		return 0
+	fi
+
+	if ! ip link set dev "$dev" master "$vrf_name" 2>/dev/null; then
+		log_msg "Failed to enslave '$dev' to VRF '$vrf_name'"
+		return 0
+	fi
+
+	state_add_member "$dev"
+}
+
+attach_vrf_device() {
+	local ref="$1"
+	local cfg="$2"
+	local vrf_name
+
+	vrf_name="$(resolve_vrf_name "$cfg")" || return 0
+	attach_member_device "$ref" "$vrf_name"
+}
+
+attach_members_from_vrf() {
+	local cfg="$1"
+	local enabled
+
+	config_get_bool enabled "$cfg" enabled 1
+	[ "$enabled" -eq 1 ] || return 0
+
+	config_list_foreach "$cfg" devices attach_vrf_device "$cfg"
+	config_list_foreach "$cfg" interfaces attach_vrf_device "$cfg"
+}
+
+attach_member_section() {
+	local cfg="$1"
+	local enabled vrf_ref vrf_name device_ref iface_ref
+
+	config_get_bool enabled "$cfg" enabled 1
+	[ "$enabled" -eq 1 ] || return 0
+
+	config_get vrf_ref "$cfg" vrf
+	config_get device_ref "$cfg" device
+	config_get iface_ref "$cfg" interface
+
+	if [ -z "$vrf_ref" ]; then
+		log_msg "Skipping vrf_member '$cfg': missing vrf"
+		return 0
+	fi
+
+	vrf_name="$(resolve_vrf_name "$vrf_ref")" || return 0
+	[ -n "$vrf_name" ] || return 0
+
+	[ -n "$device_ref" ] && attach_member_device "$device_ref" "$vrf_name"
+	[ -n "$iface_ref" ] && attach_member_device "$iface_ref" "$vrf_name"
+}
+
+load_and_apply() {
+	STATE_VRFS=
+	STATE_MEMBERS=
+	unset __NETWORK_CACHE
+
+	config_load network
+	config_foreach ensure_vrf vrf
+	config_foreach attach_members_from_vrf vrf
+	config_foreach attach_member_section vrf_member
+	save_state
+}
+
+cmd_apply() {
+	teardown_state
+	load_and_apply
+}
+
+cmd_attach() {
+	load_and_apply
+}
+
+cmd_teardown() {
+	teardown_state
+}
+
+case "$1" in
+	apply|"")
+		cmd_apply
+	;;
+	attach)
+		cmd_attach
+	;;
+	teardown)
+		cmd_teardown
+	;;
+	*)
+		echo "Usage: $0 [apply|attach|teardown]" >&2
+		exit 1
+	;;
+esac

--- a/package/network/config/uci-vrf/files/uci-vrf.hotplug
+++ b/package/network/config/uci-vrf/files/uci-vrf.hotplug
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+[ -x /etc/init.d/uci-vrf ] || exit 0
+/etc/init.d/uci-vrf enabled || exit 0
+
+case "$ACTION" in
+	ifup|ifupdate|add|register)
+		/usr/sbin/uci-vrf attach
+	;;
+esac

--- a/package/network/config/uci-vrf/files/uci-vrf.init
+++ b/package/network/config/uci-vrf/files/uci-vrf.init
@@ -1,0 +1,23 @@
+#!/bin/sh /etc/rc.common
+
+START=21
+STOP=89
+USE_PROCD=1
+
+PROG=/usr/sbin/uci-vrf
+
+start_service() {
+	"$PROG" apply
+}
+
+reload_service() {
+	"$PROG" apply
+}
+
+stop_service() {
+	"$PROG" teardown
+}
+
+service_triggers() {
+	procd_add_reload_trigger network
+}


### PR DESCRIPTION
This adds a small `uci-vrf` helper package to manage Linux VRF devices
through `/etc/config/network`.

OpenWrt already has kernel VRF support and UCI support for routes and
rules, but it does not provide a simple UCI layer for the VRF devices
themselves. This package fills that gap by introducing `vrf` and
`vrf_member` sections, creating VRF devices, attaching member devices or
logical interfaces, and reapplying state on reload and hotplug events.

The main use case is clean separation of traffic domains, especially
management VRFs. From an ISP / network operations (where i work) perspective this is a
very practical feature for keeping management, transport, and
customer-facing connectivity isolated in a way that fits normal OpenWrt
workflows.

Implementation is intentionally self-contained and does not require
changing `netifd` core behavior. The package uses a helper script plus
init/hotplug integration and keeps a small state file to handle reapply
and teardown cleanly.

Testing covered:
- real UCI parsing and commit/export behavior
- helper behavior for create, attach, teardown, and error cases
- real kernel VRF integration in an isolated network namespace
- default isolation between two VRFs
- explicit route leaking between two VRFs when configured on purpose

Some tests i've run.

```
PASS: real uci parses vrf sections
PASS: real uci exports vrf sections
PASS: real uci can create and commit new vrf section
PASS: helper apply tears down stale state and creates vrf
PASS: helper apply attaches configured devices and interfaces
PASS: helper apply logs skipped invalid or missing members
PASS: helper apply persists tracked vrf membership state
PASS: helper attach does not tear down existing state
PASS: real uci applies two vrfs and keeps them isolated
PASS: real uci applies two vrfs and explicit route leaking works
PASS: all tests completed successfully
```
