### PR TITLE
ramips: add support for TP-Link Archer MR402 v1

### DIFF
--- a/target/linux/ramips/dts/mt7628an_tplink_archer-mr402-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-mr402-v1.dts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,archer-mr402-v1", "mediatek,mt7628an-soc";
+	model = "TP-Link Archer MR402 v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		signal1 {
+			function = "signal1";
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			function = "signal2";
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			function = "signal3";
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x00000000 0x00020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x00020000 0x00cc0000>;
+			};
+
+			partition@ce0000 {
+				label = "romfile";
+				reg = <0x00ce0000 0x00010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_romfile_f100: macaddr@f100 {
+						compatible = "mac-base";
+						reg = <0xf100 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@cf0000 {
+				label = "radio";
+				reg = <0x00cf0000 0x00010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_radio_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@d00000 {
+				label = "userdata";
+				reg = <0x00d00000 0x00300000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "p0led_an", "p1led_an", "p2led_an",
+			 "p3led_an", "p4led_an", "uart1", "wdt";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_romfile_f100 0>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_romfile_f100 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	status = "okay";
+};
+
+&esw {
+	mediatek,portmap = <0x37>;
+	mediatek,portdisable = <0x30>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_romfile_f100 (-1)>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};

--- a/target/linux/ramips/dts/mt7628an_tplink_archer-mr402-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_tplink_archer-mr402-v1.dts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "tplink,archer-mr402-v1", "mediatek,mt7628an-soc";
+	model = "TP-Link Archer MR402 v1";
+
+	aliases {
+		led-boot = &led_power;
+		led-failsafe = &led_power;
+		led-running = &led_power;
+		led-upgrade = &led_power;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		lan {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wan {
+			function = LED_FUNCTION_WAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 40 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power: power {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 39 GPIO_ACTIVE_LOW>;
+		};
+
+		signal1 {
+			function = "signal1";
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 41 GPIO_ACTIVE_LOW>;
+		};
+
+		signal2 {
+			function = "signal2";
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 42 GPIO_ACTIVE_LOW>;
+		};
+
+		signal3 {
+			function = "signal3";
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 43 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan {
+			function = LED_FUNCTION_WLAN;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "network";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		rfkill {
+			label = "rfkill";
+			gpios = <&gpio 46 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RFKILL>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "boot";
+				reg = <0x00000000 0x00020000>;
+				read-only;
+			};
+
+			partition@20000 {
+				compatible = "tplink,firmware";
+				label = "firmware";
+				reg = <0x00020000 0x00cc0000>;
+			};
+
+			partition@ce0000 {
+				label = "romfile";
+				reg = <0x00ce0000 0x00010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_romfile_f100: macaddr@f100 {
+						compatible = "mac-base";
+						reg = <0xf100 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@cf0000 {
+				label = "radio";
+				reg = <0x00cf0000 0x00010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					eeprom_radio_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+				};
+			};
+
+			partition@d00000 {
+				label = "userdata";
+				reg = <0x00d00000 0x00300000>;
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2c", "p0led_an", "p1led_an", "p2led_an",
+			 "p3led_an", "p4led_an", "uart1", "wdt";
+		function = "gpio";
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_romfile_f100 0>;
+	nvmem-cell-names = "mac-address";
+	status = "okay";
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_radio_0>, <&macaddr_romfile_f100 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	status = "okay";
+};
+
+&esw {
+	mediatek,portmap = <0x37>;
+	mediatek,portdisable = <0x30>;
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		ieee80211-freq-limit = <5000000 6000000>;
+		nvmem-cells = <&eeprom_radio_8000>, <&macaddr_romfile_f100 (-1)>;
+		nvmem-cell-names = "eeprom", "mac-address";
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -903,6 +903,26 @@ define Device/tplink_archer-mr200-v6
 endef
 TARGET_DEVICES += tplink_archer-mr200-v6
 
+define Device/tplink_archer-mr402-v1
+  $(Device/tplink-v2)
+  IMAGE_SIZE := 12864k
+  DEVICE_MODEL := Archer MR402
+  DEVICE_VARIANT := v1
+  TPLINK_FLASHLAYOUT := 16Mmtk
+  TPLINK_HWID := 0x20000001
+  TPLINK_HWREV := 0x1
+  TPLINK_HWREVADD := 0x1
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap \
+	kmod-usb2 kmod-usb-serial-option \
+	kmod-usb-net-cdc-ether kmod-usb-net-cdc-ncm
+  KERNEL := kernel-bin | append-dtb | lzma -d22
+  KERNEL_INITRAMFS := kernel-bin | append-dtb
+  IMAGES := sysupgrade.bin tftp-recovery.bin
+
+  IMAGE/tftp-recovery.bin := pad-extra 128k | $$(IMAGE/factory.bin)
+endef
+TARGET_DEVICES += tplink_archer-mr402-v1
+
 define Device/tplink_re200-v2
   $(Device/tplink-safeloader)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -955,6 +955,27 @@ define Device/tplink_archer-mr200-v6
 endef
 TARGET_DEVICES += tplink_archer-mr200-v6
 
+define Device/tplink_archer-mr402-v1
+  $(Device/tplink-v2)
+  IMAGE_SIZE := 12864k
+  DEVICE_MODEL := Archer MR402
+  DEVICE_VARIANT := v1
+  TPLINK_FLASHLAYOUT := 16Mmtk
+  TPLINK_HWID := 0x40200001
+  TPLINK_HWREV := 0x1
+  TPLINK_HWREVADD := 0x1
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap \
+	kmod-ledtrig-network \
+	kmod-usb2 kmod-usb-serial-option \
+	kmod-usb-net-cdc-ether kmod-usb-net-cdc-ncm
+  KERNEL := kernel-bin | append-dtb | lzma -d22
+  KERNEL_INITRAMFS := kernel-bin | append-dtb
+  IMAGES := sysupgrade.bin tftp-recovery.bin
+
+  IMAGE/tftp-recovery.bin := pad-extra 128k | $$(IMAGE/factory.bin)
+endef
+TARGET_DEVICES += tplink_archer-mr402-v1
+
 define Device/tplink_re200-v2
   $(Device/tplink-safeloader)
   IMAGE_SIZE := 7808k

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -150,7 +150,8 @@ tplink,tl-mr6400-v4)
 	ucidef_set_led_switch "wan" "wan" "white:wan" "switch0" "0x10"
 	;;
 tplink,tl-mr6400-v5|\
-tplink,tl-mr6400-v7)
+tplink,tl-mr6400-v7|\
+tplink,archer-mr402-v1)
 	ucidef_set_led_switch "lan" "lan" "white:lan" "switch0" "0x07"
 	ucidef_set_led_switch "wan" "wan" "white:wan" "switch0" "0x08"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/01_leds
@@ -165,7 +165,8 @@ tplink,tl-mr6400-v4)
 	ucidef_set_led_switch "wan" "wan" "white:wan" "switch0" "0x10"
 	;;
 tplink,tl-mr6400-v5|\
-tplink,tl-mr6400-v7)
+tplink,tl-mr6400-v7|\
+tplink,archer-mr402-v1)
 	ucidef_set_led_switch "lan" "lan" "white:lan" "switch0" "0x07"
 	ucidef_set_led_switch "wan" "wan" "white:wan" "switch0" "0x08"
 	;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -214,7 +214,8 @@ ramips_setup_interfaces()
 			"1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
 	tplink,tl-mr6400-v5|\
-	tplink,tl-mr6400-v7)
+	tplink,tl-mr6400-v7|\
+	tplink,archer-mr402-v1)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:wan" "6@eth0"
 		;;
@@ -365,6 +366,9 @@ ramips_setup_macs()
 	tplink,archer-c50-v4|\
 	tplink,archer-c50-v6)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary rom 0xf100)" 1)
+		;;
+	tplink,archer-mr402-v1)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary romfile 0xf100)" 1)
 		;;
 	wavlink,wl-wn570ha1|\
 	zbtlink,zbt-we1226)

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -230,7 +230,8 @@ ramips_setup_interfaces()
 			"1:lan" "2:lan" "3:lan" "4:wan" "6@eth0"
 		;;
 	tplink,tl-mr6400-v5|\
-	tplink,tl-mr6400-v7)
+	tplink,tl-mr6400-v7|\
+	tplink,archer-mr402-v1)
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "2:lan" "3:wan" "6@eth0"
 		;;
@@ -390,6 +391,9 @@ ramips_setup_macs()
 	tplink,archer-c50-v4|\
 	tplink,archer-c50-v6)
 		wan_mac=$(macaddr_add "$(mtd_get_mac_binary rom 0xf100)" 1)
+		;;
+	tplink,archer-mr402-v1)
+		wan_mac=$(macaddr_add "$(mtd_get_mac_binary romfile 0xf100)" 1)
 		;;
 	wavlink,wl-wn570ha1|\
 	zbtlink,zbt-we1226)


### PR DESCRIPTION
This PR adds support for the TP-Link Archer MR402 v1.

**Hardware:**

```
SoC: MediaTek MT7628AN
RAM: 128 MiB
RAM chip: M14D1G1664A
Flash: 16 MiB SPI NOR (cFeon QX128A-104HIP)
Ethernet: 3x 10/100 Mbps LAN, 1x 10/100 Mbps LAN/WAN
Switch: integrated MT7628AN switch
2.4 GHz Wi-Fi: integrated MT7628AN
5 GHz Wi-Fi: MT7613BE (PCIe)
LTE modem: Quectel EC200A (PPP/ECM/NCM)
LEDs: power, LAN, WAN, WLAN, 3x signal strength
Buttons: reset, Wi-Fi/WPS
Power: 12 VDC, 1 A
UART: J2, VCC pin marked, 115200 8N1
```

**Notes:**

The vendor "romfile" partition contains the Ethernet MAC address, serial number and the IMEI printed on the device label (the LTE modem has its own IMEI stored internally). Wi-Fi calibration data is stored in flash. Vendor boot logs confirm reads from offset 0x00cf0000.

**MAC address layout:**

```
LAN: romfile 0xf100
WAN: romfile 0xf100 + 1
2.4 GHz Wi-Fi: romfile 0xf100
5 GHz Wi-Fi: romfile 0xf100 - 1
```

**Factory reflash procedure:**

```
- Use the OpenWrt tftp-recovery image.
- Rename the image to tp_recovery.bin.
- PC static IP: 192.168.0.225/24
- Hold RESET while powering on until the TFTP transfer starts.
```

The same TFTP recovery procedure can be used to return to the vendor firmware by renaming the stock firmware image to `tp_recovery.bin`.