### PR TITLE
ramips: add support for ipTIME A3004NS-M

### DIFF
--- a/files/etc/init.d/mt7615-dbdc
+++ b/files/etc/init.d/mt7615-dbdc
@@ -1,0 +1,20 @@
+#!/bin/sh /etc/rc.common
+
+START=99
+
+start() {
+	local dbdc_path="/sys/kernel/debug/ieee80211/phy0/mt76/dbdc"
+	local timeout=30
+	local i=0
+
+	while [ ! -f "$dbdc_path" ] && [ "$i" -lt "$timeout" ]; do
+		sleep 1
+		i=$((i + 1))
+	done
+
+	if [ -f "$dbdc_path" ]; then
+		echo 1 > "$dbdc_path"
+		sleep 1
+		wifi reload
+	fi
+}

--- a/files/etc/rc.d/S99mt7615-dbdc
+++ b/files/etc/rc.d/S99mt7615-dbdc
@@ -1,0 +1,1 @@
+../init.d/mt7615-dbdc

--- a/files/etc/uci-defaults/99-fix-eeprom-dbdc
+++ b/files/etc/uci-defaults/99-fix-eeprom-dbdc
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Fix MT7615 DBDC flag in factory eeprom (one-time, first boot only)
+# Changes byte 0x3e bit[5:4] from 00 (5GHz only) to 10 (DBDC)
+
+FACTORY_MTD=$(grep '"factory"' /proc/mtd | cut -d: -f1)
+if [ -z "$FACTORY_MTD" ]; then
+	exit 0
+fi
+
+dd if="/dev/$FACTORY_MTD" of=/tmp/factory.bin 2>/dev/null
+CURRENT=$(dd if=/tmp/factory.bin bs=1 skip=62 count=1 2>/dev/null | hexdump -e '1/1 "%02x"')
+
+if [ "$CURRENT" = "0a" ]; then
+	printf '\x2a' | dd of=/tmp/factory.bin bs=1 seek=62 conv=notrunc 2>/dev/null
+	mtd write /tmp/factory.bin factory
+fi
+
+rm -f /tmp/factory.bin
+exit 0

--- a/target/linux/ramips/dts/mt7621_iptime_a3004ns-m.dts
+++ b/target/linux/ramips/dts/mt7621_iptime_a3004ns-m.dts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "iptime,a3004ns-m", "mediatek,mt7621-soc";
+	model = "ipTIME A3004NS-M";
+
+	aliases {
+		led-boot = &led_cpu;
+		led-failsafe = &led_cpu;
+		led-running = &led_cpu;
+		led-upgrade = &led_cpu;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_cpu: cpu {
+			function = LED_FUNCTION_CPU;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		usb {
+			function = LED_FUNCTION_USB;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			trigger-sources = <&xhci_ehci_port1>;
+			linux,default-trigger = "usbport";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_uboot_1fc20: macaddr@1fc20 {
+						reg = <0x1fc20 0x6>;
+					};
+
+					macaddr_uboot_1fc40: macaddr@1fc40 {
+						reg = <0x1fc40 0x6>;
+					};
+				};
+			};
+
+			partition@20000 {
+				label = "config";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "factory";
+				reg = <0x30000 0x10000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>;
+					};
+				};
+			};
+
+			partition@40000 {
+				label = "firmware";
+				reg = <0x40000 0xfc0000>;
+				compatible = "denx,uimage";
+			};
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_uboot_1fc20>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "lan1";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_uboot_1fc40>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan4";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "wdt", "i2c", "uart3";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1833,6 +1833,18 @@ define Device/iptime_a3004ns-dual
 endef
 TARGET_DEVICES += iptime_a3004ns-dual
 
+define Device/iptime_a3004ns-m
+  $(Device/dsa-migration)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 16128k
+  UIMAGE_NAME := a3004nm
+  DEVICE_VENDOR := ipTIME
+  DEVICE_MODEL := A3004NS-M
+  DEVICE_PACKAGES := kmod-usb3 kmod-mt7615e kmod-mt7615-firmware \
+	kmod-usb-ledtrig-usbport -uboot-envtools
+endef
+TARGET_DEVICES += iptime_a3004ns-m
+
 define Device/iptime_a3004t
   $(Device/nand)
   $(Device/uimage-lzma-loader)


### PR DESCRIPTION
Add support for the ipTIME A3004NS-M AC1300 wireless router based on MT7621 SoC with MT7615 DBDC WiFi.

Hardware:
- SoC: MediaTek MT7621
- WiFi: MediaTek MT7615 (DBDC, 2.4GHz + 5GHz)
- Flash: 16MB SPI-NOR
- RAM: 256MB DDR3
- Ports: 1x WAN + 4x LAN (GbE)
- USB: 1x USB 3.0

Includes:
- DTS with correct port mapping (ethphy0=LAN1, port@4=WAN)
- MT7615 DBDC support via init script and eeprom auto-patch
- Factory eeprom DBDC flag fix (first-boot uci-defaults)