### PR TITLE
mediatek: filogic: kn-1812: update support

### DIFF
--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
@@ -506,7 +506,7 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		mt7996@0,0 {
+		mt7992@0,0 {
 			reg = <0x0000 0 0 0 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
@@ -398,6 +398,8 @@
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <0x1b>;
 
+		interrupt-parent = <&pio>;
+		interrupts = <2 IRQ_TYPE_LEVEL_LOW>;
 		reset-gpios = <&pio 4 GPIO_ACTIVE_LOW>;
 		reset-assert-us = <100000>;
 		reset-deassert-us = <221000>;

--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
@@ -400,7 +400,7 @@
 
 		reset-gpios = <&pio 4 GPIO_ACTIVE_LOW>;
 		reset-assert-us = <100000>;
-		reset-deassert-us = <100000>;
+		reset-deassert-us = <221000>;
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
@@ -541,7 +541,7 @@
 
 		conf {
 			groups = "mdc_mdio0";
-			drive-strength = <MTK_DRIVE_4mA>;
+			drive-strength = <MTK_DRIVE_10mA>;
 		};
 	};
 

--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
@@ -140,7 +140,7 @@
 				reg = <0x0 0x600000>;
 			};
 
-			partition@400000 {
+			partition@600000 {
 				label = "ubi";
 				reg = <0x600000 0x0>;
 			};

--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
@@ -608,3 +608,7 @@
 &tphy {
 	status = "okay";
 };
+
+&xsphy {
+	status = "okay";
+};

--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
@@ -369,7 +369,6 @@
 	nvmem-cell-names = "mac-address";
 	label = "wan";
 	phy-mode = "internal";
-	phy-connection-type = "internal";
 	phy = <&int_2p5g_phy>;
 	status = "okay";
 };
@@ -411,7 +410,6 @@
 	nvmem-cell-names = "mac-address";
 	label = "lan5";
 	phy-mode = "usxgmii";
-	phy-connection-type = "usxgmii";
 	phy = <&phy27>;
 	status = "okay";
 };


### PR DESCRIPTION
This pull request:
1. Fixes Realtek RTL8261be deassert interval
2. Adds interrupt support for Realtek RTL8261be
3. Fixes partition node name
4. Drops unneeded phy-connection-type property
5. Fixes mdio drive strength to 10ma
6. Enables xsphy node
7. Adds cosmetic changes