### PR TITLE
mediatek: filogic: kap-630/kn-3811/kn-3911: fix partition node name

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
@@ -57,7 +57,7 @@
 				reg = <0x0 0x600000>;
 			};
 
-			partition@400000 {
+			partition@600000 {
 				label = "ubi";
 				reg = <0x600000 0x0>;
 			};

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
@@ -98,7 +98,7 @@
 				reg = <0x0 0x600000>;
 			};
 
-			partition@400000 {
+			partition@600000 {
 				label = "ubi";
 				reg = <0x600000 0x0>;
 			};

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
@@ -73,7 +73,7 @@
 				reg = <0x0 0x600000>;
 			};
 
-			partition@400000 {
+			partition@600000 {
 				label = "ubi";
 				reg = <0x600000 0x0>;
 			};


### PR DESCRIPTION
partition@400000 label referenced address 0x600000, fix node name to match.
