### PR TITLE
wifi-scripts: ucode: add support for setting he_twt_responder and fix setting he_twt_required

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-device.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-device.json
@@ -334,6 +334,11 @@
 			"type": "boolean",
 			"default": false
 		},
+		"he_twt_responder": {
+			"description": "Whether TWT (HE) responder is enabled.",
+			"type": "boolean",
+			"default": true
+		},
 		"hostapd_options": {
 			"type": "array",
 			"items": {

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -428,7 +428,7 @@ function device_htmode_append(config) {
 			config.he_spr_psr_enabled = false;
 		if (!(he_mac_cap[0] & 0x4))
 			config.he_twt_responder = false;
-		if (!(he_mac_cap[0] & 0x1))
+		if (!config.he_twt_responder)
 			config.he_twt_required= false;
 
 		append_vars(config, [

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -426,12 +426,15 @@ function device_htmode_append(config) {
 			config.he_mu_beamformer = false;
 		if (!(he_phy_cap[7] & 0x1))
 			config.he_spr_psr_enabled = false;
+		if (!(he_mac_cap[0] & 0x4))
+			config.he_twt_responder = false;
 		if (!(he_mac_cap[0] & 0x1))
 			config.he_twt_required= false;
 
 		append_vars(config, [
 			'ieee80211ax', 'he_oper_chwidth', 'he_oper_centr_freq_seg0_idx',
-			'he_su_beamformer', 'he_su_beamformee', 'he_mu_beamformer', 'he_twt_required',
+			'he_su_beamformer', 'he_su_beamformee', 'he_mu_beamformer',
+			'he_twt_required', 'he_twt_responder',
 			'he_default_pe_duration', 'he_rts_threshold', 'he_mu_edca_qos_info_param_count',
 			'he_mu_edca_qos_info_q_ack', 'he_mu_edca_qos_info_queue_request', 'he_mu_edca_qos_info_txop_request',
 			'he_mu_edca_ac_be_aifsn', 'he_mu_edca_ac_be_aci', 'he_mu_edca_ac_be_ecwmin',


### PR DESCRIPTION
`he_twt_responder` is an option in hostapd config for setting HE TWT responder.

Add support for it in wifi-scripts.

Also make `he_twt_required` depends on `he_twt_responder`.