### PR TITLE
lantiq-u-boot fix for gawk-5.4 with new regex engine.

### DIFF
--- a/package/boot/uboot-lantiq/patches/0118-gawk-5.4-regex-compat.patch
+++ b/package/boot/uboot-lantiq/patches/0118-gawk-5.4-regex-compat.patch
@@ -1,0 +1,77 @@
+--- a/tools/lantiq_ram_init_uart.awk
++++ b/tools/lantiq_ram_init_uart.awk
+@@ -23,45 +23,45 @@ function print_header()
+ 
+ function mc_danube_prologue()
+ {
+-	/* Clear access error log registers */
++#	/* Clear access error log registers */
+ 	print "0xbf800010", "0x0"
+ 	print "0xbf800020", "0x0"
+ 
+-	/* Enable DDR and SRAM module in memory controller */
++#	/* Enable DDR and SRAM module in memory controller */
+ 	print "0xbf800060", "0x5"
+ 
+-	/* Clear start bit of DDR memory controller */
++#	/* Clear start bit of DDR memory controller */
+ 	print "0xbf801030", "0x0"
+ }
+ 
+ function mc_ar9_prologue()
+ {
+-	/* Clear access error log registers */
++#	/* Clear access error log registers */
+ 	print "0xbf800010", "0x0"
+ 	print "0xbf800020", "0x0"
+ 
+-	/* Enable FPI, DDR and SRAM module in memory controller */
++#	/* Enable FPI, DDR and SRAM module in memory controller */
+ 	print "0xbf800060", "0xD"
+ 
+-	/* Clear start bit of DDR memory controller */
++#	/* Clear start bit of DDR memory controller */
+ 	print "0xbf801030", "0x0"
+ }
+ 
+ function mc_ddr1_epilogue()
+ {
+-	/* Set start bit of DDR memory controller */
++#	/* Set start bit of DDR memory controller */
+ 	print "0xbf801030", "0x100"
+ }
+ 
+ function mc_ddr2_prologue()
+ {
+-	/* Put memory controller in inactive mode */
++#	/* Put memory controller in inactive mode */
+ 	print "0xbf401070", "0x0"
+ }
+ 
+ function mc_ddr2_epilogue(mc_ccr07_value)
+ {
+-	/* Put memory controller in active mode */
++#	/* Put memory controller in active mode */
+ 	mc_ccr07_value = or(mc_ccr07_value, 0x100)
+ 	printf("0xbf401070 0x%x\n", mc_ccr07_value)
+ }
+@@ -92,13 +92,14 @@ BEGIN {
+ }
+ 
+ /^#define/ {
+-	/* CCR07 contains MC enable bit and must not be set here */
+-	if (tolower($2) == "mc_ccr07_value")
++#	/* CCR07 contains MC enable bit and must not be set here */
++	if (tolower($2) == "mc_ccr07_value") {
+ 		mc_ccr07_value = strtonum($3)
+-	if (tolower($2) == "mc_dc03_value")
+-		/* CCR07 contains MC enable bit and must not be set here */
+-	else
++	} else if (tolower($2) == "mc_dc03_value") {
++#		/* CCR07 contains MC enable bit and must not be set here */
++	} else {
+ 		printf("0x%x %s\n", reg_base, tolower($3))
++	}
+ 
+ 	reg_base += 0x10
+ }


### PR DESCRIPTION
Currently also “GAWK_GNU_MATCHERS=1 make” would work to compile it
Only _ram targets are not build. SPL are marked broken
New engine is more strict about the syntax.

1st /* has # now in front
awk: /tmp/openwrt-git/build_dir/target-mips_24kc_musl/u-boot-bthomehubv5a_ram/u-boot-2013.10/tools/lantiq_ram_init_uart.awk:26: error: ? * + or {interval} not preceded by valid subpattern: /* Clear access error log registers */

2nd if else has now corrected braces.
awk: /tmp/openwrt-git/build_dir/target-mips_24kc_musl/u-boot-bthomehubv5a_ram/u-boot-2013.10/tools/lantiq_ram_init_uart.awk:100: 	^ syntax error

Signed-off-by: Stefan Grau <stefan_grau@t-online.de>