### PR TITLE
ath79: fix initramfs boot for Huawei AP5030DN and AP6010DN

### DIFF
--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1836,6 +1836,7 @@ define Device/huawei_ap5030dn
   DEVICE_PACKAGES := ath10k-firmware-qca988x-ct kmod-ath10k-ct
   LOADER_TYPE := bin
   LOADER_FLASH_OFFS := 0x111DC0
+  LZMA_TEXT_START := 0x82800000
   KERNEL_SIZE := 15360k
   IMAGE_SIZE := 30720k
   COMPILE := loader-$(1).bin
@@ -1851,6 +1852,7 @@ define Device/huawei_ap6010dn
   DEVICE_MODEL := AP6010DN
   LOADER_TYPE := bin
   LOADER_FLASH_OFFS := 0x111DC0
+  LZMA_TEXT_START := 0x82800000
   KERNEL_SIZE := 15360k
   IMAGE_SIZE := 30720k
   COMPILE := loader-$(1).bin


### PR DESCRIPTION
Fix execution of initramfs image on Huawei AP5030DN and AP6010DN by increasing available memory for LZMA extraction by the loader.

The default leaves only ~23.6 MB between the decompression target and the running loader code. Extracting images with built-in packages lead to overwriting the loader code. This causes the decompression to produce garbage output and hang.

Fix this by overwriting LZMA_TEXT_START to increase the available memory for LZMA extraction to ~39.6 MB.