### PR TITLE
base-files: add warning to distfeeds.list

### DIFF
--- a/include/feeds.mk
+++ b/include/feeds.mk
@@ -48,6 +48,8 @@ endef
 # 1: destination file
 define FeedSourcesAppendAPK
 ( \
+  echo '# This file is auto-generated and build-specific, any changes will be intentionally lost in sysupgrade.'; \
+  echo '# Add your custom feeds to /etc/apk/repositories.d/customfeeds.list'; \
   echo '%U/targets/%S/packages/packages.adb'; \
   $(strip $(if $(CONFIG_PER_FEED_REPO), \
 	echo '%U/packages/%A/base/packages.adb'; \


### PR DESCRIPTION
Add a message to the apk distfeeds.list that changes won't be saved and that users should modify customfeeds.list instead.

---
Motivated by https://github.com/openwrt/openwrt/pull/17847