### PR TITLE
realtek: dts: new SWITCH_PORT_LED() macro

### DIFF
--- a/target/linux/realtek/dts/macros.dtsi
+++ b/target/linux/realtek/dts/macros.dtsi
@@ -51,6 +51,16 @@
 		phy-mode = #m ; \
 	};
 
+#define SWITCH_PORT_LED(p, l, s, c, m) \
+	port##p: port@##p { \
+		reg = <##p>; \
+		label = SWITCH_PORT_LABEL(l) ; \
+		led-set = <##c>; \
+		pcs-handle = <&serdes##s>; \
+		phy-handle = <&phy##p>; \
+		phy-mode = #m ; \
+	};
+
 #define SWITCH_SFP_PORT(n, s, m) \
 	port##n: port@##n { \
 		reg = <##n>; \

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
@@ -128,71 +128,15 @@
 	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
-
-		port@0 {
-			reg = <0>;
-			label = "lan1";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy0>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@1 {
-			reg = <1>;
-			label = "lan2";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy1>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@2 {
-			reg = <2>;
-			label = "lan3";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy2>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@3 {
-			reg = <3>;
-			label = "lan4";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy3>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@4 {
-			reg = <4>;
-			label = "lan5";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy4>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@5 {
-			reg = <5>;
-			label = "lan6";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy5>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@6 {
-			reg = <6>;
-			label = "lan7";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy6>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@7 {
-			reg = <7>;
-			label = "lan8";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy7>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
+		
+		SWITCH_PORT_LED(0, 1, 2, 0, usxgmii);
+		SWITCH_PORT_LED(1, 2, 2, 0, usxgmii);
+		SWITCH_PORT_LED(2, 3, 2, 0, usxgmii);
+		SWITCH_PORT_LED(3, 4, 2, 0, usxgmii);
+		SWITCH_PORT_LED(4, 5, 2, 0, usxgmii);
+		SWITCH_PORT_LED(5, 6, 2, 0, usxgmii);
+		SWITCH_PORT_LED(6, 7, 2, 0, usxgmii);
+		SWITCH_PORT_LED(7, 8, 2, 0, usxgmii);
 
 		port@24 {
 			reg = <24>;


### PR DESCRIPTION
Several devices (including the upcoming DGS-1250) need a fully featured port definition that includes:

- port number
- label
- led-set
- pcs-handle
- phy-handle
- phy-mode

Provide a new macro for that and make the Zyxel XGS-1210 series the first consumer of it.
