### PR TITLE
qualcommax: ipq807x: use ascii-env driver

### DIFF
--- a/target/linux/ipq40xx/dts/qcom-ipq4019-whw03.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-whw03.dts
@@ -89,8 +89,6 @@
 
 					nvmem-layout {
 						compatible = "ascii-eq-delim-env";
-						#address-cells = <1>;
-						#size-cells = <1>;
 
 						hw_mac_addr: hw_mac_addr {
 							compatible = "mac-base";

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-xx8300.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-xx8300.dtsi
@@ -180,8 +180,6 @@
 
 				nvmem-layout {
 					compatible = "ascii-eq-delim-env";
-					#address-cells = <1>;
-					#size-cells = <1>;
 
 					hw_mac_addr: hw_mac_addr {
 						compatible = "mac-base";

--- a/target/linux/ipq806x/dts/qcom-ipq8064-eax500.dtsi
+++ b/target/linux/ipq806x/dts/qcom-ipq8064-eax500.dtsi
@@ -185,8 +185,6 @@
 
 				nvmem-layout {
 					compatible = "ascii-eq-delim-env";
-					#address-cells = <1>;
-					#size-cells = <1>;
 
 					hw_mac_addr: hw_mac_addr {
 						compatible = "mac-base";

--- a/target/linux/mediatek/dts/mt7629-linksys-ea7500-v3.dts
+++ b/target/linux/mediatek/dts/mt7629-linksys-ea7500-v3.dts
@@ -216,8 +216,6 @@
 
 				nvmem-layout {
 					compatible = "ascii-eq-delim-env";
-					#address-cells = <1>;
-					#size-cells = <1>;
 
 					hw_mac_addr: hw_mac_addr {
 						compatible = "mac-base";

--- a/target/linux/qualcommax/dts/ipq5018-mx-base.dtsi
+++ b/target/linux/qualcommax/dts/ipq5018-mx-base.dtsi
@@ -123,8 +123,6 @@
 
 				nvmem-layout {
 					compatible = "ascii-eq-delim-env";
-					#address-cells = <1>;
-					#size-cells = <1>;
 
 					hw_mac_addr: hw_mac_addr {
 						compatible = "mac-base";

--- a/target/linux/qualcommax/dts/ipq6000-mr7350.dts
+++ b/target/linux/qualcommax/dts/ipq6000-mr7350.dts
@@ -186,8 +186,6 @@
 
 				nvmem-layout {
 					compatible = "ascii-eq-delim-env";
-					#address-cells = <1>;
-					#size-cells = <1>;
 
 					hw_mac_addr: hw_mac_addr {
 						compatible = "mac-base";

--- a/target/linux/qualcommax/dts/ipq6018-mr7500.dts
+++ b/target/linux/qualcommax/dts/ipq6018-mr7500.dts
@@ -473,8 +473,6 @@
 
 				nvmem-layout {
 					compatible = "ascii-eq-delim-env";
-					#address-cells = <1>;
-					#size-cells = <1>;
 
 					hw_mac_addr: hw_mac_addr {
 						compatible = "mac-base";

--- a/target/linux/qualcommax/dts/ipq8072-mx5300.dts
+++ b/target/linux/qualcommax/dts/ipq8072-mx5300.dts
@@ -15,15 +15,6 @@
 
 	aliases {
 		serial0 = &blsp1_uart5;
-		/*
-		 * Aliases as required by u-boot
-		 * to patch MAC addresses
-		 */
-		ethernet0 = &dp1;
-		ethernet1 = &dp2;
-		ethernet2 = &dp3;
-		ethernet3 = &dp4;
-		ethernet4 = &dp5;
 		led-boot = &led_system_blue;
 		led-running = &led_system_blue;
 		led-failsafe = &led_system_red;
@@ -296,6 +287,15 @@
 				label = "devinfo";
 				reg = <0x1060000 0x20000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "ascii-eq-delim-env";
+
+					hw_mac_addr: hw_mac_addr {
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@1080000 {
@@ -475,30 +475,40 @@
 	status = "okay";
 	phy-handle = <&qca8075_0>;
 	label = "lan1";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp2 {
 	status = "okay";
 	phy-handle = <&qca8075_1>;
 	label = "lan2";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp3 {
 	status = "okay";
 	phy-handle = <&qca8075_2>;
 	label = "lan3";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp4 {
 	status = "okay";
 	phy-handle = <&qca8075_3>;
 	label = "lan4";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp5 {
 	status = "okay";
 	phy-handle = <&qca8075_4>;
 	label = "wan";
+	nvmem-cells = <&hw_mac_addr 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &ssphy_0 {

--- a/target/linux/qualcommax/dts/ipq8174-homewrk.dts
+++ b/target/linux/qualcommax/dts/ipq8174-homewrk.dts
@@ -8,13 +8,6 @@
 	model = "Linksys HomeWRK";
 	compatible = "linksys,homewrk", "qcom,ipq8074";
 
-	aliases {
-		ethernet1 = &dp2;
-		ethernet2 = &dp3;
-		ethernet3 = &dp4;
-		ethernet4 = &dp5;
-	};
-
 	chosen {
 		bootargs-append = " root=/dev/ubiblock0_1";
 	};
@@ -35,6 +28,20 @@
 
 		partitions {
 			compatible = "qcom,smem-part";
+
+			partition-devinfo {
+				label = "devinfo";
+				read-only;
+
+				nvmem-layout {
+					compatible = "ascii-eq-delim-env";
+
+					mac_address: mac_address {
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
 		};
 	};
 };
@@ -43,24 +50,32 @@
 	status = "okay";
 	phy-handle = <&qca8075_1>;
 	label = "wan";
+	nvmem-cells = <&mac_address 0>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp3 {
 	status = "okay";
 	phy-handle = <&qca8075_2>;
 	label = "lan3";
+	nvmem-cells = <&mac_address 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp4 {
 	status = "okay";
 	phy-handle = <&qca8075_3>;
 	label = "lan2";
+	nvmem-cells = <&mac_address 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &dp5 {
 	status = "okay";
 	phy-handle = <&qca8075_4>;
 	label = "lan1";
+	nvmem-cells = <&mac_address 1>;
+	nvmem-cell-names = "mac-address";
 };
 
 &wifi {

--- a/target/linux/ramips/dts/mt7621_linksys_e5600.dts
+++ b/target/linux/ramips/dts/mt7621_linksys_e5600.dts
@@ -120,8 +120,6 @@
 
 			nvmem-layout {
 				compatible = "ascii-eq-delim-env";
-				#address-cells = <1>;
-				#size-cells = <1>;
 
 				hw_mac_addr: hw_mac_addr {
 					compatible = "mac-base";

--- a/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
+++ b/target/linux/ramips/dts/mt7621_linksys_ea7xxx.dtsi
@@ -134,8 +134,6 @@
 
 			nvmem-layout {
 				compatible = "ascii-eq-delim-env";
-				#address-cells = <1>;
-				#size-cells = <1>;
 
 				hw_mac_addr: hw_mac_addr {
 					compatible = "mac-base";


### PR DESCRIPTION
Use ascii-env driver for reading mac addresses directly from devinfo partition for:
- Linksys MX5300
- Linksys HomeWRK

Please confirm that this PR works on HomeWRK.