### PR TITLE
ipq40xx: fix art partition name WHW03 V1

### DIFF
--- a/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03.dts
+++ b/target/linux/ipq40xx/files-6.12/arch/arm/boot/dts/qcom/qcom-ipq4019-whw03.dts
@@ -63,7 +63,7 @@
 			compatible = "block-device";
 			partitions {
 				block-partition-art {
-					partname = "art";
+					partname = "0:ART";
 
 					nvmem-layout {
 						compatible = "fixed-layout";


### PR DESCRIPTION
Fix for issue [22539](https://github.com/openwrt/openwrt/issues/22537).