### PR TITLE
[25.12] lantiq: xrx200: autoload lantiq_gswip and tag_gswip to fix failsafe mode

### DIFF
--- a/target/linux/lantiq/modules.mk
+++ b/target/linux/lantiq/modules.mk
@@ -27,7 +27,7 @@ define KernelPackage/dsa-gswip
   FILES:= \
 	$(LINUX_DIR)/drivers/net/dsa/lantiq_gswip.ko \
   	$(LINUX_DIR)/net/dsa/tag_gswip.ko
-  AUTOLOAD:=$(call AutoLoad,41,lantiq_gswip)
+  AUTOLOAD:=$(call AutoLoad,41,tag_gswip lantiq_gswip,1)
 endef
 
 define KernelPackage/dsa-gswip/description


### PR DESCRIPTION
tested on FB7362SL .Without it LAN1 stays down.

(cherry picked from commit 20ae49dde7786fcfa795a2315b5abd12cdc236d7)