### PR TITLE
[25.12] kernel: add kmods for vsockets over virtio

### DIFF
--- a/package/kernel/linux/modules/virt.mk
+++ b/package/kernel/linux/modules/virt.mk
@@ -139,3 +139,59 @@ define KernelPackage/vhost-net
 endef
 
 $(eval $(call KernelPackage,vhost-net))
+
+
+define KernelPackage/vsock
+  SUBMENU:=Virtualization
+  TITLE:=Virtual Socket Protocol
+  KCONFIG:= \
+	CONFIG_VSOCKETS \
+	CONFIG_VSOCKETS_LOOPBACK=n \
+	CONFIG_HYPERV_VSOCKETS=n
+  FILES:=$(LINUX_DIR)/net/vmw_vsock/vsock.ko
+  AUTOLOAD:=$(call AutoProbe,vsock)
+endef
+
+define KernelPackage/vsock/description
+  Kernel support support for the Virtual Socket Protocol.
+  Often used when running in a VM to communicate with the hypervisor.
+  Additionally needs a hypervisor-specific transport driver.
+endef
+
+$(eval $(call KernelPackage,vsock))
+
+
+define KernelPackage/vsock-virtio-common
+  SUBMENU:=Virtualization
+  TITLE:=Module used by other drivers to access Virtio Virtual Sockets
+  DEPENDS:=+kmod-vsock
+  KCONFIG:=CONFIG_VIRTIO_VSOCKETS_COMMON
+  FILES:=$(LINUX_DIR)/net/vmw_vsock/vmw_vsock_virtio_transport_common.ko
+  AUTOLOAD:=$(call AutoProbe,vmw_vsock_virtio_transport_common)
+  HIDDEN:=1
+endef
+
+$(eval $(call KernelPackage,vsock-virtio-common))
+
+
+define KernelPackage/vsock-virtio
+  SUBMENU:=Virtualization
+  TITLE:=Virtio transport driver for Virtual Sockets
+  DEPENDS:= @VIRTIO_SUPPORT +kmod-vsock +kmod-vsock-virtio-common
+  KCONFIG:=CONFIG_VIRTIO_VSOCKETS
+  FILES:=$(LINUX_DIR)/net/vmw_vsock/vmw_vsock_virtio_transport.ko
+  AUTOLOAD:=$(call AutoProbe,vmw_vsock_virtio_transport)
+endef
+
+define KernelPackage/vsock-virtio/description
+  Kernel support for Virtual Sockets over virtio.
+  Enable this transport if you plan to run OpenWRT in a virtual machine and the
+  hypervisor supports Virtual Sockets over virtio (Incus for example).
+
+  Usually needed by "guest agents" to function, as it provides a communication
+  channel between the guest os and the hypervisor.
+
+  The module will be called vmw_vsock_virtio_transport.
+endef
+
+$(eval $(call KernelPackage,vsock-virtio))


### PR DESCRIPTION
The required changes to run openwrt in a vm are now in distrobuilder and lxc-ci. All we need to get 25.12 running in a vm is to backport this commit.

cherry picked from c88e8a98167c82ce56ce184389b011637c204337

Related work:
- openwrt/openwrt#21392
- lxc/lxc-ci#965
- lxc/lxc-ci#966
- lxc/distrobuilder#981
- lxc/distrobuilder#960

@aparcar 