### PR TITLE
realtek: mdio: cleanup for multiple busses

### DIFF
--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -172,11 +172,14 @@
  * reimplemented. For now it should be sufficient.
  */
 
+struct rtmdio_port {
+	int page;
+};
 
 struct rtmdio_ctrl {
 	struct regmap *map;
 	const struct rtmdio_config *cfg;
-	int page[RTMDIO_MAX_PHY];
+	struct rtmdio_port port[RTMDIO_MAX_PHY];
 	bool raw[RTMDIO_MAX_PHY];
 	int smi_bus[RTMDIO_MAX_PHY];
 	int smi_addr[RTMDIO_MAX_PHY];
@@ -508,14 +511,14 @@ static int rtmdio_read(struct mii_bus *bus, int addr, int regnum)
 	if (addr >= ctrl->cfg->num_phys)
 		return -ENODEV;
 
-	if (regnum == RTMDIO_PAGE_SELECT && ctrl->page[addr] != ctrl->cfg->raw_page)
-		return ctrl->page[addr];
+	if (regnum == RTMDIO_PAGE_SELECT && ctrl->port[addr].page != ctrl->cfg->raw_page)
+		return ctrl->port[addr].page;
 
-	ctrl->raw[addr] = (ctrl->page[addr] == ctrl->cfg->raw_page);
+	ctrl->raw[addr] = (ctrl->port[addr].page == ctrl->cfg->raw_page);
 
-	err = (*ctrl->cfg->read_phy)(bus, addr, ctrl->page[addr], regnum, &val);
+	err = (*ctrl->cfg->read_phy)(bus, addr, ctrl->port[addr].page, regnum, &val);
 	pr_debug("rd_PHY(adr=%d, pag=%d, reg=%d) = %d, err = %d\n",
-		 addr, ctrl->page[addr], regnum, val, err);
+		 addr, ctrl->port[addr].page, regnum, val, err);
 	return err ? err : val;
 }
 
@@ -541,10 +544,10 @@ static int rtmdio_write(struct mii_bus *bus, int addr, int regnum, u16 val)
 	if (addr >= ctrl->cfg->num_phys)
 		return -ENODEV;
 
-	page = ctrl->page[addr];
+	page = ctrl->port[addr].page;
 
 	if (regnum == RTMDIO_PAGE_SELECT)
-		ctrl->page[addr] = val;
+		ctrl->port[addr].page = val;
 
 	if (!ctrl->raw[addr] && (regnum != RTMDIO_PAGE_SELECT || page == ctrl->cfg->raw_page)) {
 		ctrl->raw[addr] = (page == ctrl->cfg->raw_page);

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -111,8 +111,7 @@
 	for_each_set_bit(addr, ctrl->valid_ports, RTMDIO_MAX_PHY)
 
 #define rtmdio_ctrl_from_bus(bus) \
-	((struct rtmdio_ctrl *)(bus)->priv)
-
+	(((struct rtmdio_chan *)(bus)->priv)->ctrl)
 
 /*
  * On all Realtek switch platforms the hardware periodically reads the link status of all
@@ -194,6 +193,10 @@ struct rtmdio_ctrl {
 	struct rtmdio_port port[RTMDIO_MAX_PHY];
 	struct rtmdio_bus bus[RTMDIO_MAX_SMI_BUS];
 	DECLARE_BITMAP(valid_ports, RTMDIO_MAX_PHY);
+};
+
+struct rtmdio_chan {
+	struct rtmdio_ctrl *ctrl;
 };
 
 struct rtmdio_config {
@@ -909,20 +912,20 @@ static int rtmdio_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
 	struct rtmdio_ctrl *ctrl;
+	struct rtmdio_chan *chan;
 	struct mii_bus *bus;
 	int ret, addr;
 
-	bus = devm_mdiobus_alloc_size(dev, sizeof(*ctrl));
-	if (!bus)
+	ctrl = devm_kzalloc(dev, sizeof(*ctrl), GFP_KERNEL);
+	if (!ctrl)
 		return -ENOMEM;
 
-	ctrl = bus->priv;
+	platform_set_drvdata(pdev, ctrl);
 	ctrl->cfg = (const struct rtmdio_config *)device_get_match_data(dev);
 	ctrl->map = syscon_node_to_regmap(pdev->dev.of_node->parent);
 	if (IS_ERR(ctrl->map))
 		return PTR_ERR(ctrl->map);
 
-	platform_set_drvdata(pdev, ctrl);
 	ret = rtmdio_map_ports(dev);
 	if (ret) {
 		for_each_phy(ctrl, addr)
@@ -930,6 +933,13 @@ static int rtmdio_probe(struct platform_device *pdev)
 		return ret;
 	}
 	rtmdio_setup_smi_topology(ctrl);
+
+	bus = devm_mdiobus_alloc_size(dev, sizeof(*chan));
+	if (!bus)
+		return -ENOMEM;
+
+	chan = bus->priv;
+	chan->ctrl = ctrl;
 
 	bus->name = "Realtek MDIO bus";
 	bus->reset = rtmdio_reset;
@@ -940,7 +950,6 @@ static int rtmdio_probe(struct platform_device *pdev)
 	bus->parent = dev;
 	bus->phy_mask = ~0;
 	snprintf(bus->id, MII_BUS_ID_SIZE, "realtek-mdio");
-
 	device_set_node(&bus->dev, of_fwnode_handle(dev->of_node));
 
 	ret = devm_mdiobus_register(dev, bus);

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -180,11 +180,15 @@ struct rtmdio_port {
 	u8 smi_bus;
 };
 
+struct rtmdio_bus {
+	bool is_c45;
+};
+
 struct rtmdio_ctrl {
 	struct regmap *map;
 	const struct rtmdio_config *cfg;
 	struct rtmdio_port port[RTMDIO_MAX_PHY];
-	bool smi_bus_is_c45[RTMDIO_MAX_SMI_BUS];
+	struct rtmdio_bus bus[RTMDIO_MAX_SMI_BUS];
 	DECLARE_BITMAP(valid_ports, RTMDIO_MAX_PHY);
 };
 
@@ -711,7 +715,7 @@ static int rtmdio_930x_reset(struct mii_bus *bus)
 	/* Define C22/C45 bus feature set */
 	for (int addr = 0; addr < RTMDIO_MAX_SMI_BUS; addr++) {
 		mask = BIT(16 + addr);
-		val = ctrl->smi_bus_is_c45[addr] ? mask : 0;
+		val = ctrl->bus[addr].is_c45 ? mask : 0;
 		regmap_update_bits(ctrl->map, RTMDIO_930X_SMI_GLB_CTRL, mask, val);
 	}
 
@@ -768,7 +772,7 @@ static int rtmdio_931x_reset(struct mii_bus *bus)
 
 	/* Define C22/C45 bus feature set */
 	for (int i = 0; i < RTMDIO_MAX_SMI_BUS; i++) {
-		if (ctrl->smi_bus_is_c45[i])
+		if (ctrl->bus[i].is_c45)
 			c45_mask |= 0x2 << (i * 2);  /* Std. C45, non-standard is 0x3 */
 	}
 	regmap_update_bits(ctrl->map, RTMDIO_931X_SMI_GLB_CTRL1, GENMASK(7, 0), c45_mask);
@@ -887,7 +891,7 @@ static int rtmdio_map_ports(struct device *dev)
 					     of_fwnode_handle(phy->parent));
 
 		if (of_device_is_compatible(phy, "ethernet-phy-ieee802.3-c45"))
-			ctrl->smi_bus_is_c45[smi_bus] = true;
+			ctrl->bus[smi_bus].is_c45 = true;
 
 		ctrl->port[addr].smi_bus = smi_bus;
 		ctrl->port[addr].smi_addr = smi_addr;

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -174,13 +174,13 @@
 
 struct rtmdio_port {
 	int page;
+	bool raw;
 };
 
 struct rtmdio_ctrl {
 	struct regmap *map;
 	const struct rtmdio_config *cfg;
 	struct rtmdio_port port[RTMDIO_MAX_PHY];
-	bool raw[RTMDIO_MAX_PHY];
 	int smi_bus[RTMDIO_MAX_PHY];
 	int smi_addr[RTMDIO_MAX_PHY];
 	struct device_node *phy_node[RTMDIO_MAX_PHY];
@@ -514,7 +514,7 @@ static int rtmdio_read(struct mii_bus *bus, int addr, int regnum)
 	if (regnum == RTMDIO_PAGE_SELECT && ctrl->port[addr].page != ctrl->cfg->raw_page)
 		return ctrl->port[addr].page;
 
-	ctrl->raw[addr] = (ctrl->port[addr].page == ctrl->cfg->raw_page);
+	ctrl->port[addr].raw = (ctrl->port[addr].page == ctrl->cfg->raw_page);
 
 	err = (*ctrl->cfg->read_phy)(bus, addr, ctrl->port[addr].page, regnum, &val);
 	pr_debug("rd_PHY(adr=%d, pag=%d, reg=%d) = %d, err = %d\n",
@@ -549,8 +549,9 @@ static int rtmdio_write(struct mii_bus *bus, int addr, int regnum, u16 val)
 	if (regnum == RTMDIO_PAGE_SELECT)
 		ctrl->port[addr].page = val;
 
-	if (!ctrl->raw[addr] && (regnum != RTMDIO_PAGE_SELECT || page == ctrl->cfg->raw_page)) {
-		ctrl->raw[addr] = (page == ctrl->cfg->raw_page);
+	if (!ctrl->port[addr].raw &&
+	    (regnum != RTMDIO_PAGE_SELECT || page == ctrl->cfg->raw_page)) {
+		ctrl->port[addr].raw = (page == ctrl->cfg->raw_page);
 
 		err = (*ctrl->cfg->write_phy)(bus, addr, page, regnum, val);
 		pr_debug("wr_PHY(adr=%d, pag=%d, reg=%d, val=%d) err = %d\n",
@@ -558,7 +559,7 @@ static int rtmdio_write(struct mii_bus *bus, int addr, int regnum, u16 val)
 		return err;
 	}
 
-	ctrl->raw[addr] = false;
+	ctrl->port[addr].raw = false;
 	return 0;
 }
 

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -175,13 +175,13 @@
 struct rtmdio_port {
 	int page;
 	bool raw;
+	u8 smi_bus;
 };
 
 struct rtmdio_ctrl {
 	struct regmap *map;
 	const struct rtmdio_config *cfg;
 	struct rtmdio_port port[RTMDIO_MAX_PHY];
-	int smi_bus[RTMDIO_MAX_PHY];
 	int smi_addr[RTMDIO_MAX_PHY];
 	struct device_node *phy_node[RTMDIO_MAX_PHY];
 	bool smi_bus_is_c45[RTMDIO_MAX_SMI_BUS];
@@ -572,7 +572,7 @@ static void rtmdio_setup_smi_topology(struct mii_bus *bus)
 		if (ctrl->cfg->bus_map_base) {
 			reg = (addr / 16) * 4;
 			mask = 0x3 << ((addr % 16) * 2);
-			val = ctrl->smi_bus[addr] << ((addr % 16) * 2);
+			val = ctrl->port[addr].smi_bus << ((addr % 16) * 2);
 			regmap_update_bits(ctrl->map, ctrl->cfg->bus_map_base + reg, mask, val);
 		}
 
@@ -738,7 +738,7 @@ static void rtmdio_930x_setup_polling(struct mii_bus *bus)
 		regmap_update_bits(ctrl->map, RTMDIO_930X_SMI_MAC_TYPE_CTRL, mask, val);
 
 		/* polling via standard or resolution register */
-		mask = BIT(20 + ctrl->smi_bus[addr]);
+		mask = BIT(20 + ctrl->port[addr].smi_bus);
 		val = phyinfo.has_res_reg ? mask : 0;
 		regmap_update_bits(ctrl->map, RTMDIO_930X_SMI_GLB_CTRL, mask, val);
 
@@ -789,9 +789,9 @@ static void rtmdio_931x_setup_polling(struct mii_bus *bus)
 
 	/* Define PHY specific polling parameters */
 	for_each_phy(ctrl, addr) {
-		int smi = ctrl->smi_bus[addr];
+		u8 smi = ctrl->port[addr].smi_bus;
 		unsigned int mask, val;
-		
+
 		if (rtmdio_get_phy_info(bus, addr, &phyinfo))
 			continue;
 
@@ -838,7 +838,7 @@ static int rtmdio_reset(struct mii_bus *bus)
 static int rtmdio_map_ports(struct device *dev)
 {
 	struct rtmdio_ctrl *ctrl = dev_get_drvdata(dev);
-	int bus_addr, addr;
+	int smi_bus, addr;
 
 	struct device_node *switch_node __free(device_node) =
 		of_get_child_by_name(dev->of_node->parent, "ethernet-switch");
@@ -873,18 +873,18 @@ static int rtmdio_map_ports(struct device *dev)
 			return dev_err_probe(dev, -EINVAL, "%pfwP no phy address\n",
 					     of_fwnode_handle(phy));
 
-		if (of_property_read_u32(phy->parent, "reg", &bus_addr))
+		if (of_property_read_u32(phy->parent, "reg", &smi_bus))
 			return dev_err_probe(dev, -EINVAL, "%pfwP no bus address\n",
 					     of_fwnode_handle(phy->parent));
 
-		if (bus_addr >= RTMDIO_MAX_SMI_BUS)
+		if (smi_bus >= RTMDIO_MAX_SMI_BUS)
 			return dev_err_probe(dev, -EINVAL, "%pfwP illegal bus number\n",
 					     of_fwnode_handle(phy->parent));
 
 		if (of_device_is_compatible(phy, "ethernet-phy-ieee802.3-c45"))
-			ctrl->smi_bus_is_c45[bus_addr] = true;
+			ctrl->smi_bus_is_c45[smi_bus] = true;
 
-		ctrl->smi_bus[addr] = bus_addr;
+		ctrl->port[addr].smi_bus = smi_bus;
 		ctrl->phy_node[addr] = of_node_get(phy);
 		__set_bit(addr, ctrl->valid_ports);
 	}

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -110,6 +110,10 @@
 #define for_each_phy(ctrl, addr) \
 	for_each_set_bit(addr, ctrl->valid_ports, RTMDIO_MAX_PHY)
 
+#define rtmdio_ctrl_from_bus(bus) \
+	((struct rtmdio_ctrl *)(bus)->priv)
+
+
 /*
  * On all Realtek switch platforms the hardware periodically reads the link status of all
  * PHYs. This is to some degree programmable, so that one can tell the hardware to read
@@ -217,7 +221,7 @@ struct rtmdio_phy_info {
 
 static int rtmdio_run_cmd(struct mii_bus *bus, int cmd, int mask, int regnum, int fail)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	int ret, val;
 
 	ret = regmap_update_bits(ctrl->map, regnum, mask, cmd | RTMDIO_RUN);
@@ -240,7 +244,7 @@ static int rtmdio_838x_run_cmd(struct mii_bus *bus, int cmd)
 
 static int rtmdio_838x_read_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg, u32 *val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	u32 park_page = 31;
 	int err;
 
@@ -259,7 +263,7 @@ static int rtmdio_838x_read_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg
 
 static int rtmdio_838x_write_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg, u32 val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	u32 park_page = 31;
 
 	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_0, BIT(addr));
@@ -272,7 +276,7 @@ static int rtmdio_838x_write_phy(struct mii_bus *bus, u32 addr, u32 page, u32 re
 
 static int rtmdio_838x_read_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, u32 regnum, u32 *val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	int err;
 
 	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_0, BIT(addr));
@@ -289,7 +293,7 @@ static int rtmdio_838x_read_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, u
 
 static int rtmdio_838x_write_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, u32 regnum, u32 val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 
 	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_0, BIT(addr));
 	regmap_write(ctrl->map, RTMDIO_838X_SMI_ACCESS_PHY_CTRL_2, val << 16);
@@ -306,7 +310,7 @@ static int rtmdio_839x_run_cmd(struct mii_bus *bus, int cmd)
 
 static int rtmdio_839x_read_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg, u32 *val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	int err;
 
 	regmap_write(ctrl->map, RTMDIO_839X_PHYREG_CTRL, 0x1ff);
@@ -324,7 +328,7 @@ static int rtmdio_839x_read_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg
 
 static int rtmdio_839x_write_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg, u32 val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 
 	regmap_write(ctrl->map, RTMDIO_839X_PHYREG_CTRL, 0x1ff);
 	regmap_write(ctrl->map, RTMDIO_839X_PHYREG_DATA_CTRL, val << 16);
@@ -338,7 +342,7 @@ static int rtmdio_839x_write_phy(struct mii_bus *bus, u32 addr, u32 page, u32 re
 
 static int rtmdio_839x_read_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, u32 regnum, u32 *val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	int err;
 
 	regmap_write(ctrl->map, RTMDIO_839X_PHYREG_DATA_CTRL,  addr << 16);
@@ -354,7 +358,7 @@ static int rtmdio_839x_read_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, u
 
 static int rtmdio_839x_write_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, u32 regnum, u32 val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 
 	regmap_write(ctrl->map, RTMDIO_839X_PHYREG_PORT_CTRL, BIT_ULL(addr));
 	regmap_write(ctrl->map, RTMDIO_839X_PHYREG_PORT_CTRL + 4, BIT_ULL(addr) >> 32);
@@ -372,7 +376,7 @@ static int rtmdio_930x_run_cmd(struct mii_bus *bus, int cmd)
 
 static int rtmdio_930x_write_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg, u32 val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	u32 park_page = 31;
 
 	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_0, BIT(addr));
@@ -385,7 +389,7 @@ static int rtmdio_930x_write_phy(struct mii_bus *bus, u32 addr, u32 page, u32 re
 
 static int rtmdio_930x_read_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg, u32 *val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	u32 park_page = 31;
 	int err;
 
@@ -403,7 +407,7 @@ static int rtmdio_930x_read_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg
 
 static int rtmdio_930x_write_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, u32 regnum, u32 val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 
 	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_0, BIT(addr));
 	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2, val << 16);
@@ -414,8 +418,8 @@ static int rtmdio_930x_write_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, 
 
 static int rtmdio_930x_read_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, u32 regnum, u32 *val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
-	int err ;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
+	int err;
 
 	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_2, addr << 16);
 	regmap_write(ctrl->map, RTMDIO_930X_SMI_ACCESS_PHY_CTRL_3, (devnum << 16) | (regnum & 0xffff));
@@ -436,7 +440,7 @@ static int rtmdio_931x_run_cmd(struct mii_bus *bus, int cmd)
 
 static int rtmdio_931x_write_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg, u32 val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	u64 mask = BIT_ULL(addr);
 
 	regmap_write(ctrl->map, RTMDIO_931X_SMI_INDRT_ACCESS_CTRL_2, (u32)mask);
@@ -450,7 +454,7 @@ static int rtmdio_931x_write_phy(struct mii_bus *bus, u32 addr, u32 page, u32 re
 
 static int rtmdio_931x_read_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg, u32 *val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	int err;
 
 	regmap_write(ctrl->map, RTMDIO_931X_SMI_INDRT_ACCESS_BC_CTRL, addr << 5);
@@ -466,7 +470,7 @@ static int rtmdio_931x_read_phy(struct mii_bus *bus, u32 addr, u32 page, u32 reg
 
 static int rtmdio_931x_read_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, u32 regnum, u32 *val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	int err;
 
 	regmap_write(ctrl->map, RTMDIO_931X_SMI_INDRT_ACCESS_BC_CTRL, addr << 5);
@@ -482,7 +486,7 @@ static int rtmdio_931x_read_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, u
 
 static int rtmdio_931x_write_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, u32 regnum, u32 val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	u64 mask = BIT_ULL(addr);
 
 	regmap_write(ctrl->map, RTMDIO_931X_SMI_INDRT_ACCESS_CTRL_2, (u32)mask);
@@ -495,7 +499,7 @@ static int rtmdio_931x_write_mmd_phy(struct mii_bus *bus, u32 addr, u32 devnum, 
 
 static int rtmdio_read_c45(struct mii_bus *bus, int addr, int devnum, int regnum)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	int err, val;
 
 	if (addr >= ctrl->cfg->num_phys)
@@ -509,7 +513,7 @@ static int rtmdio_read_c45(struct mii_bus *bus, int addr, int devnum, int regnum
 
 static int rtmdio_read(struct mii_bus *bus, int addr, int regnum)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	int err, val;
 
 	if (addr >= ctrl->cfg->num_phys)
@@ -528,7 +532,7 @@ static int rtmdio_read(struct mii_bus *bus, int addr, int regnum)
 
 static int rtmdio_write_c45(struct mii_bus *bus, int addr, int devnum, int regnum, u16 val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	int err;
 
 	if (addr >= ctrl->cfg->num_phys)
@@ -542,7 +546,7 @@ static int rtmdio_write_c45(struct mii_bus *bus, int addr, int devnum, int regnu
 
 static int rtmdio_write(struct mii_bus *bus, int addr, int regnum, u16 val)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	int err, page;
 
 	if (addr >= ctrl->cfg->num_phys)
@@ -658,7 +662,7 @@ static int rtmdio_get_phy_info(struct mii_bus *bus, int addr, struct rtmdio_phy_
 
 static int rtmdio_838x_reset(struct mii_bus *bus)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 
 	/*
 	 * PHY_PATCH_DONE enables phy control via SoC. This is required for phy access,
@@ -672,7 +676,7 @@ static int rtmdio_838x_reset(struct mii_bus *bus)
 
 static void rtmdio_838x_setup_polling(struct mii_bus *bus)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	int combo_phy;
 
 	/* Disable MAC polling for PHY config. It will be activated later in the DSA driver */
@@ -690,7 +694,7 @@ static void rtmdio_838x_setup_polling(struct mii_bus *bus)
 
 static int rtmdio_839x_reset(struct mii_bus *bus)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 
 	return 0;
 
@@ -708,7 +712,7 @@ static int rtmdio_839x_reset(struct mii_bus *bus)
 
 static int rtmdio_930x_reset(struct mii_bus *bus)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	unsigned int mask, val;
 
 	/* Define C22/C45 bus feature set */
@@ -723,7 +727,7 @@ static int rtmdio_930x_reset(struct mii_bus *bus)
 
 static void rtmdio_930x_setup_polling(struct mii_bus *bus)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	struct rtmdio_phy_info phyinfo;
 	unsigned int mask, val, addr;
 
@@ -761,7 +765,7 @@ static void rtmdio_930x_setup_polling(struct mii_bus *bus)
 
 static int rtmdio_931x_reset(struct mii_bus *bus)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	u32 c45_mask = 0;
 
 	/* Disable polling for configuration purposes */
@@ -781,7 +785,7 @@ static int rtmdio_931x_reset(struct mii_bus *bus)
 
 static void rtmdio_931x_setup_polling(struct mii_bus *bus)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 	struct rtmdio_phy_info phyinfo;
 	u32 addr;
 
@@ -833,7 +837,7 @@ static void rtmdio_931x_setup_polling(struct mii_bus *bus)
 
 static int rtmdio_reset(struct mii_bus *bus)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
+	struct rtmdio_ctrl *ctrl = rtmdio_ctrl_from_bus(bus);
 
 	return ctrl->cfg->reset(bus);
 }

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -173,6 +173,7 @@
  */
 
 struct rtmdio_port {
+	struct device_node *dn;
 	int page;
 	bool raw;
 	u8 smi_addr;
@@ -183,7 +184,6 @@ struct rtmdio_ctrl {
 	struct regmap *map;
 	const struct rtmdio_config *cfg;
 	struct rtmdio_port port[RTMDIO_MAX_PHY];
-	struct device_node *phy_node[RTMDIO_MAX_PHY];
 	bool smi_bus_is_c45[RTMDIO_MAX_SMI_BUS];
 	DECLARE_BITMAP(valid_ports, RTMDIO_MAX_PHY);
 };
@@ -891,7 +891,7 @@ static int rtmdio_map_ports(struct device *dev)
 
 		ctrl->port[addr].smi_bus = smi_bus;
 		ctrl->port[addr].smi_addr = smi_addr;
-		ctrl->phy_node[addr] = of_node_get(phy);
+		ctrl->port[addr].dn = of_node_get(phy);
 		__set_bit(addr, ctrl->valid_ports);
 	}
 
@@ -919,7 +919,7 @@ static int rtmdio_probe(struct platform_device *pdev)
 	ret = rtmdio_map_ports(dev);
 	if (ret) {
 		for_each_phy(ctrl, addr)
-			of_node_put(ctrl->phy_node[addr]);
+			of_node_put(ctrl->port[addr].dn);
 		return ret;
 	}
 
@@ -943,8 +943,8 @@ static int rtmdio_probe(struct platform_device *pdev)
 	for_each_phy(ctrl, addr) {
 		if (!ret)
 			ret = fwnode_mdiobus_register_phy(bus,
-				of_fwnode_handle(ctrl->phy_node[addr]), addr);
-		of_node_put(ctrl->phy_node[addr]);
+				of_fwnode_handle(ctrl->port[addr].dn), addr);
+		of_node_put(ctrl->port[addr].dn);
 	}
 	if (ret)
 		return ret;

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -567,9 +567,8 @@ static int rtmdio_write(struct mii_bus *bus, int addr, int regnum, u16 val)
 	return 0;
 }
 
-static void rtmdio_setup_smi_topology(struct mii_bus *bus)
+static void rtmdio_setup_smi_topology(struct rtmdio_ctrl *ctrl)
 {
-	struct rtmdio_ctrl *ctrl = bus->priv;
 	u32 reg, mask, val, addr;
 
 	for_each_phy(ctrl, addr) {
@@ -926,6 +925,7 @@ static int rtmdio_probe(struct platform_device *pdev)
 			of_node_put(ctrl->port[addr].dn);
 		return ret;
 	}
+	rtmdio_setup_smi_topology(ctrl);
 
 	bus->name = "Realtek MDIO bus";
 	bus->reset = rtmdio_reset;
@@ -939,7 +939,6 @@ static int rtmdio_probe(struct platform_device *pdev)
 
 	device_set_node(&bus->dev, of_fwnode_handle(dev->of_node));
 
-	rtmdio_setup_smi_topology(bus);
 	ret = devm_mdiobus_register(dev, bus);
 	if (ret)
 		return ret;

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -175,6 +175,7 @@
 struct rtmdio_port {
 	int page;
 	bool raw;
+	u8 smi_addr;
 	u8 smi_bus;
 };
 
@@ -182,7 +183,6 @@ struct rtmdio_ctrl {
 	struct regmap *map;
 	const struct rtmdio_config *cfg;
 	struct rtmdio_port port[RTMDIO_MAX_PHY];
-	int smi_addr[RTMDIO_MAX_PHY];
 	struct device_node *phy_node[RTMDIO_MAX_PHY];
 	bool smi_bus_is_c45[RTMDIO_MAX_SMI_BUS];
 	DECLARE_BITMAP(valid_ports, RTMDIO_MAX_PHY);
@@ -579,7 +579,7 @@ static void rtmdio_setup_smi_topology(struct mii_bus *bus)
 		if (ctrl->cfg->port_map_base) {
 			reg = (addr / 6) * 4;
 			mask = 0x1f << ((addr % 6) * 5);
-			val = ctrl->smi_addr[addr] << ((addr % 6) * 5);
+			val = ctrl->port[addr].smi_addr << ((addr % 6) * 5);
 			regmap_update_bits(ctrl->map, ctrl->cfg->port_map_base + reg, mask, val);
 		}
 	}
@@ -838,7 +838,7 @@ static int rtmdio_reset(struct mii_bus *bus)
 static int rtmdio_map_ports(struct device *dev)
 {
 	struct rtmdio_ctrl *ctrl = dev_get_drvdata(dev);
-	int smi_bus, addr;
+	int smi_bus, smi_addr, addr;
 
 	struct device_node *switch_node __free(device_node) =
 		of_get_child_by_name(dev->of_node->parent, "ethernet-switch");
@@ -869,8 +869,13 @@ static int rtmdio_map_ports(struct device *dev)
 			return dev_err_probe(dev, -EINVAL, "%pfwP duplicated port number\n",
 					     of_fwnode_handle(port));
 
-		if (of_property_read_u32(phy, "reg", &ctrl->smi_addr[addr]))
+		if (of_property_read_u32(phy, "reg", &smi_addr))
 			return dev_err_probe(dev, -EINVAL, "%pfwP no phy address\n",
+					     of_fwnode_handle(phy));
+
+		/* relaxed check as RTL839x uses MDIO addresses 0..51 */
+		if (smi_addr >= ctrl->cfg->num_phys)
+			return dev_err_probe(dev, -EINVAL, "%pfwP illegal phy address\n",
 					     of_fwnode_handle(phy));
 
 		if (of_property_read_u32(phy->parent, "reg", &smi_bus))
@@ -885,6 +890,7 @@ static int rtmdio_map_ports(struct device *dev)
 			ctrl->smi_bus_is_c45[smi_bus] = true;
 
 		ctrl->port[addr].smi_bus = smi_bus;
+		ctrl->port[addr].smi_addr = smi_addr;
 		ctrl->phy_node[addr] = of_node_get(phy);
 		__set_bit(addr, ctrl->valid_ports);
 	}

--- a/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/mdio/mdio-realtek-otto.c
@@ -908,31 +908,11 @@ static int rtmdio_map_ports(struct device *dev)
 	return 0;
 }
 
-static int rtmdio_probe(struct platform_device *pdev)
+static int rtmdio_probe_one(struct device *dev, struct rtmdio_ctrl *ctrl)
 {
-	struct device *dev = &pdev->dev;
-	struct rtmdio_ctrl *ctrl;
 	struct rtmdio_chan *chan;
 	struct mii_bus *bus;
 	int ret, addr;
-
-	ctrl = devm_kzalloc(dev, sizeof(*ctrl), GFP_KERNEL);
-	if (!ctrl)
-		return -ENOMEM;
-
-	platform_set_drvdata(pdev, ctrl);
-	ctrl->cfg = (const struct rtmdio_config *)device_get_match_data(dev);
-	ctrl->map = syscon_node_to_regmap(pdev->dev.of_node->parent);
-	if (IS_ERR(ctrl->map))
-		return PTR_ERR(ctrl->map);
-
-	ret = rtmdio_map_ports(dev);
-	if (ret) {
-		for_each_phy(ctrl, addr)
-			of_node_put(ctrl->port[addr].dn);
-		return ret;
-	}
-	rtmdio_setup_smi_topology(ctrl);
 
 	bus = devm_mdiobus_alloc_size(dev, sizeof(*chan));
 	if (!bus)
@@ -954,7 +934,7 @@ static int rtmdio_probe(struct platform_device *pdev)
 
 	ret = devm_mdiobus_register(dev, bus);
 	if (ret)
-		return ret;
+		return dev_err_probe(dev, ret, "cannot register MDIO bus\n");
 
 	for_each_phy(ctrl, addr) {
 		if (!ret)
@@ -965,10 +945,42 @@ static int rtmdio_probe(struct platform_device *pdev)
 	if (ret)
 		return ret;
 
+	/*
+	 * TODO: This polling setup needs to be relocated into rtmdio_probe(). It is a generic
+	 * function and not bus specific. But this will require more rework of the data
+	 * structures. For now it is easier to hand over the single bus that was just created.
+	 */
 	if (ctrl->cfg->setup_polling)
 		ctrl->cfg->setup_polling(bus);
 
 	return 0;
+}
+
+static int rtmdio_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct rtmdio_ctrl *ctrl;
+	int ret, addr;
+
+	ctrl = devm_kzalloc(dev, sizeof(*ctrl), GFP_KERNEL);
+	if (!ctrl)
+		return -ENOMEM;
+
+	platform_set_drvdata(pdev, ctrl);
+	ctrl->cfg = (const struct rtmdio_config *)device_get_match_data(dev);
+	ctrl->map = syscon_node_to_regmap(pdev->dev.of_node->parent);
+	if (IS_ERR(ctrl->map))
+		return PTR_ERR(ctrl->map);
+
+	ret = rtmdio_map_ports(dev);
+	if (ret) {
+		for_each_phy(ctrl, addr)
+			of_node_put(ctrl->port[addr].dn);
+		return ret;
+	}
+	rtmdio_setup_smi_topology(ctrl);
+
+	return rtmdio_probe_one(dev, ctrl);
 }
 
 static const struct rtmdio_config rtmdio_838x_cfg = {


### PR DESCRIPTION
This is a cleanup step before the driver can be converted to multiple busses.