### PR TITLE
realtek: dts: drop trailing semicolons after macro use

### DIFF
--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
@@ -129,14 +129,14 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		
-		SWITCH_PORT_LED(0, 1, 2, 0, usxgmii);
-		SWITCH_PORT_LED(1, 2, 2, 0, usxgmii);
-		SWITCH_PORT_LED(2, 3, 2, 0, usxgmii);
-		SWITCH_PORT_LED(3, 4, 2, 0, usxgmii);
-		SWITCH_PORT_LED(4, 5, 2, 0, usxgmii);
-		SWITCH_PORT_LED(5, 6, 2, 0, usxgmii);
-		SWITCH_PORT_LED(6, 7, 2, 0, usxgmii);
-		SWITCH_PORT_LED(7, 8, 2, 0, usxgmii);
+		SWITCH_PORT_LED(0, 1, 2, 0, usxgmii)
+		SWITCH_PORT_LED(1, 2, 2, 0, usxgmii)
+		SWITCH_PORT_LED(2, 3, 2, 0, usxgmii)
+		SWITCH_PORT_LED(3, 4, 2, 0, usxgmii)
+		SWITCH_PORT_LED(4, 5, 2, 0, usxgmii)
+		SWITCH_PORT_LED(5, 6, 2, 0, usxgmii)
+		SWITCH_PORT_LED(6, 7, 2, 0, usxgmii)
+		SWITCH_PORT_LED(7, 8, 2, 0, usxgmii)
 
 		port@24 {
 			reg = <24>;


### PR DESCRIPTION
Fix a regression introduced in #22591 ... failed to notice that before it got merged.

@plappermaul just noticed that during some other work
@robimarko hotfix for recently added commit
