### PR TITLE
uboot-mediatek: bpi-r4-lite fix emmc frequency

### DIFF
--- a/package/boot/uboot-mediatek/patches/470-add-bpi-r4-lite.patch
+++ b/package/boot/uboot-mediatek/patches/470-add-bpi-r4-lite.patch
@@ -1133,7 +1133,7 @@
 +};
 --- /dev/null
 +++ b/arch/arm/dts/mt7987a-bpi-r4-lite-spim-nand-u-boot.dtsi
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,82 @@
 +// SPDX-License-Identifier: GPL-2.0
 +/*
 + * Copyright (c) 2025 MediaTek Inc.
@@ -1161,6 +1161,19 @@
 +		full-duplex;
 +		pause;
 +	};
++};
++
++&mmc0 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&mmc_pins_default>;
++	max-frequency = <48000000>;
++	bus-width = <4>;
++	cap-mmc-highspeed;
++	cap-mmc-hw-reset;
++	vmmc-supply = <&reg_3p3v>;
++	vqmmc-supply = <&reg_3p3v>;
++	non-removable;
++	status = "okay";
 +};
 +
 +&spi2 {


### PR DESCRIPTION
Use lower emmc frequency. This fix issue when mmc write from uboot failed.

Hit it when:
- we boot from NAND
- choose "Install bootloader, recovery and production to eMMC"

MMC erase: dev # 0, block # 0, count 1024 ... 1024 blocks erased: OK
MMC write: dev # 0, block # 0, count 1024 ... mmc write failed
0 blocks written: ERROR

