### PR TITLE
netifd: skip uci state update for interfaces not in config

### DIFF
--- a/package/network/config/netifd/files/etc/hotplug.d/iface/00-netstate
+++ b/package/network/config/netifd/files/etc/hotplug.d/iface/00-netstate
@@ -1,4 +1,4 @@
-[ ifup = "$ACTION" ] && {
+[ "$ACTION" = "ifup" ] && uci -q get "network.$INTERFACE" >/dev/null && {
 	uci_toggle_state network "$INTERFACE" up 1
 	[ -n "$DEVICE" ] && {
 		uci_toggle_state network "$INTERFACE" ifname "$DEVICE"


### PR DESCRIPTION
The 00-netstate hotplug script runs uci_toggle_state for every interface ifup event, including internal/dummy interfaces like "wan_4" that netifd creates but which don't exist in UCI config. This causes "Invalid argument" errors from uci:

daemon.err netifd: /sbin/uci: Invalid argument

Add a uci -q get guard to verify the interface exists in the network config before attempting to set state on it. Interfaces not present in UCI config are silently skipped.

Also fix the test condition to follow the conventional "$variable" = "literal" ordering.

Tested by @compact21 on OpenWrt 24.10.5 - confirmed errors no longer appear for dynamic interfaces, and valid interfaces are unaffected.

Fixes: https://github.com/openwrt/openwrt/issues/21935

By mistake i did mess with previously pr.

Thanks @compact21
I've updated and verified my email and force-pushed the commit. Please check again.



