### PR TITLE
[24.10] ramips-mt7621: fix xiaomi mi ac2100 mac address

### DIFF
--- a/target/linux/ramips/dts/mt7621_xiaomi_mi-router-ac2100.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_mi-router-ac2100.dts
@@ -13,7 +13,7 @@
 		led-failsafe = &led_status_yellow;
 		led-running = &led_status_blue;
 		led-upgrade = &led_status_blue;
-		label-mac-device = &gmac0;
+		label-mac-device = &gmac1;
 	};
 
 	leds {

--- a/target/linux/ramips/dts/mt7621_xiaomi_redmi-router-ac2100.dts
+++ b/target/linux/ramips/dts/mt7621_xiaomi_redmi-router-ac2100.dts
@@ -13,7 +13,7 @@
 		led-failsafe = &led_status_amber;
 		led-running = &led_status_white;
 		led-upgrade = &led_status_white;
-		label-mac-device = &gmac0;
+		label-mac-device = &gmac1;
 	};
 
 	leds {


### PR DESCRIPTION
The Xiaomi Redmi/Mi Router AC2100 does have the correct label mac on the WAN interface. This MAC is available as gmac1.

Link: https://github.com/openwrt/openwrt/pull/22567

(cherry picked from commit b1713d623be30d26da0bd48ecff9032881ce5684)

Thanks @hauke