### PR TITLE
[25.12] mediatek: filogic: kap-630/kn-3811/kn-3911: fix partition node name and wrong sgmiisys0 node override

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
@@ -239,7 +239,3 @@
 	nvmem-cells = <&eeprom_factory_0>;
 	status = "okay";
 };
-
-&sgmiisys0 {
-	/delete-node/ mediatek,pnswap;
-};

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kap-630.dtsi
@@ -57,7 +57,7 @@
 				reg = <0x0 0x600000>;
 			};
 
-			partition@400000 {
+			partition@600000 {
 				label = "ubi";
 				reg = <0x600000 0x0>;
 			};

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3811.dts
@@ -98,7 +98,7 @@
 				reg = <0x0 0x600000>;
 			};
 
-			partition@400000 {
+			partition@600000 {
 				label = "ubi";
 				reg = <0x600000 0x0>;
 			};

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
@@ -281,7 +281,3 @@
 	nvmem-cells = <&eeprom_factory_0>;
 	status = "okay";
 };
-
-&sgmiisys0 {
-	/delete-node/ mediatek,pnswap;
-};

--- a/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
+++ b/target/linux/mediatek/dts/mt7981b-keenetic-kn-3911.dts
@@ -73,7 +73,7 @@
 				reg = <0x0 0x600000>;
 			};
 
-			partition@400000 {
+			partition@600000 {
 				label = "ubi";
 				reg = <0x600000 0x0>;
 			};

--- a/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
+++ b/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
@@ -458,7 +458,3 @@
 	pinctrl-0 = <&pcie_pins>;
 	status = "okay";
 };
-
-&sgmiisys0 {
-	/delete-node/ mediatek,pnswap;
-};


### PR DESCRIPTION
1. mediatek: dts: drop wrong sgmiisys0 node override
2. partition@400000 label referenced address 0x600000, fix node name to match.

cherry-picked from https://github.com/openwrt/openwrt/pull/22046 and https://github.com/openwrt/openwrt/pull/22576

This pull request depends on https://github.com/openwrt/openwrt/pull/22627