### PR TITLE
[25.12] apk: backport help text changes (wiki link , force-reinstall help text)

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git

--- a/package/system/apk/patches/0002-openwrt-wiki-help-link.patch
+++ b/package/system/apk/patches/0002-openwrt-wiki-help-link.patch
@@ -1,0 +1,13 @@
+diff --git a/src/genhelp_apk.lua b/src/genhelp_apk.lua
+index a62e84d22ed5..a97264f6ab3c 100644
+--- a/src/genhelp_apk.lua
++++ b/src/genhelp_apk.lua
+@@ -65,7 +65,7 @@ local function render_options(doc, out, options)
+ end
+ 
+ local function render_footer(doc, out)
+-	table.insert(out, ("\nFor more information: man %s %s\n"):format(doc.mansection, doc.manpage))
++	table.insert(out, ("\nFor more information:\n  https://openwrt.org/docs/guide-user/additional-software/apk\n"))
+ end
+ 
+ local function render_optgroups(doc, out, groups)

--- a/package/system/apk/patches/0002-openwrt-wiki-help-link.patch
+++ b/package/system/apk/patches/0002-openwrt-wiki-help-link.patch
@@ -1,8 +1,6 @@
-diff --git a/src/genhelp_apk.lua b/src/genhelp_apk.lua
-index a62e84d22ed5..a97264f6ab3c 100644
 --- a/src/genhelp_apk.lua
 +++ b/src/genhelp_apk.lua
-@@ -65,7 +65,7 @@ local function render_options(doc, out, options)
+@@ -65,7 +65,7 @@ local function render_options(doc, out,
  end
  
  local function render_footer(doc, out)

--- a/package/system/apk/patches/0100-add-add-force-reinstall-option.patch
+++ b/package/system/apk/patches/0100-add-add-force-reinstall-option.patch
@@ -46,3 +46,16 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	}
  
  	r = apk_solver_commit(db, 0, world);
+--- a/doc/apk-add.8.scd
++++ b/doc/apk-add.8.scd
+@@ -30,6 +30,10 @@ To later upgrade or downgrade back to a
+ *apk add* supports the commit options described in *apk*(8), as well as the
+ following options:
+ 
++*--force-reinstall*
++	Allow reinstalling already-installed packages without a version
++	change. Only the named packages are reinstalled, not dependencies.
++
+ *--initdb*
+ 	Initialize a new package database.
+ 


### PR DESCRIPTION
cc @robimarko 
Regarding your response to my comment in https://github.com/openwrt/openwrt/pull/22426#issuecomment-4141617265

>There is a conflict so I cannot just cherry pick it.
> Can you please make a PR and I will merge it?

I cherry-picked also the other helpful apk commit from @efahl , changing the help text to point to our wiki instead of a non-existing man page, and then my commit cherry-picked cleanly. (efahl's commit added minor dirty stuff, which my commit cleans away. Net change is a clean addition of two helpful changes to 25.12)