### PR TITLE
arm-trusted-firmware-mediatek: add mt7981-spim-nand-ubi-ddr3 builds

### DIFF
--- a/package/boot/arm-trusted-firmware-mediatek/Makefile
+++ b/package/boot/arm-trusted-firmware-mediatek/Makefile
@@ -244,6 +244,15 @@ define Trusted-Firmware-A/mt7981-spim-nand-ddr3
   DDR_TYPE:=ddr3
 endef
 
+define Trusted-Firmware-A/mt7981-spim-nand-ubi-ddr3
+  NAME:=MediaTek MT7981 (SPI-NAND via SPIM using UBI, DDR3)
+  BOOT_DEVICE:=spim-nand
+  BUILD_SUBTARGET:=filogic
+  PLAT:=mt7981
+  DDR_TYPE:=ddr3
+  USE_UBI:=1
+endef
+
 define Trusted-Firmware-A/mt7981-spim-nand-ddr3-1866
   NAME:=MediaTek MT7981 (SPI-NAND via SPIM, DDR3 1866 MT/s)
   BOOT_DEVICE:=spim-nand
@@ -713,6 +722,7 @@ TFA_TARGETS:= \
 	mt7981-sdmmc-ddr3 \
 	mt7981-snand-ddr3 \
 	mt7981-spim-nand-ddr3 \
+	mt7981-spim-nand-ubi-ddr3 \
 	mt7981-spim-nand-ddr3-1866 \
 	mt7981-spim-nand-ubi-ddr4 \
 	mt7981-ram-ddr4 \


### PR DESCRIPTION
Add UBI-enabled build for MT7981 with SPIM-NAND and DDR3 for use with the CLT-R30B1 board. https://github.com/openwrt/openwrt/pull/20666#discussion_r2988585767
