### PR TITLE
realtek: dts: cleanup of ethernet link speed

### DIFF
--- a/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
+++ b/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
@@ -240,7 +240,7 @@
 			ethernet = <&ethernet0>;
 			phy-mode = "internal";
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9302_xikestor_sks8300-12e2t2x.dts
+++ b/target/linux/realtek/dts/rtl9302_xikestor_sks8300-12e2t2x.dts
@@ -359,7 +359,7 @@
 			ethernet = <&ethernet0>;
 			phy-mode = "internal";
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
@@ -365,7 +365,7 @@
 			reg = <28>;
 			phy-mode = "internal";
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
@@ -182,7 +182,7 @@
 			reg = <28>;
 			phy-mode = "internal";
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100w-8xgt-se.dts
@@ -254,7 +254,7 @@
 			phy-mode = "internal";
 
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8gt-se.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_s1100wp-8gt-se.dts
@@ -318,7 +318,7 @@
 			phy-mode = "internal";
 
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f-v2.dts
+++ b/target/linux/realtek/dts/rtl9303_tplink_tl-st1008f-v2.dts
@@ -323,7 +323,7 @@
 			phy-mode = "internal";
 
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9303_vimin_vm-s100-0800ms.dts
+++ b/target/linux/realtek/dts/rtl9303_vimin_vm-s100-0800ms.dts
@@ -312,7 +312,7 @@
 			phy-mode = "internal";
 
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8t.dts
@@ -197,7 +197,7 @@
 			reg = <28>;
 			phy-mode = "internal";
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8300-8x.dts
@@ -342,7 +342,7 @@
 			phy-mode = "internal";
 
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
+++ b/target/linux/realtek/dts/rtl9303_xikestor_sks8310-8x.dts
@@ -349,7 +349,7 @@
 			phy-mode = "internal";
 
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9311_linksys_lgs352c.dts
+++ b/target/linux/realtek/dts/rtl9311_linksys_lgs352c.dts
@@ -374,7 +374,7 @@
 			reg = <56>;
 			phy-mode = "internal";
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};

--- a/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
+++ b/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
@@ -480,7 +480,7 @@
 			reg = <56>;
 			phy-mode = "internal";
 			fixed-link {
-				speed = <10000>;
+				speed = <1000>;
 				full-duplex;
 			};
 		};


### PR DESCRIPTION
Realtek switches have a very simple network adapter for the SOC. They can ship packets via DMA without further offloading features. Even on the RTL931x devices they can barely reach 50MB/s. In the dts there is a mix of 1G/10G definitions. To be consistent and better reflect the performance set the link speed to 1000. This is only cosmetic.
