### PR TITLE
Fix setup of non-80MHz 802.11s mesh interfaces on EHT hardware

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -16,20 +16,22 @@ function set_fixed_freq(data, config) {
 	set_default(config, 'fixed_freq', 1);
 	set_default(config, 'frequency', data.frequency);
 
-	if (data.htmode in [ 'VHT80', 'HE80' ])
+	if (data.htmode in [ 'VHT80', 'HE80', 'EHT80' ])
 		set_default(config, 'max_oper_chwidth', 1);
-	else if (data.htmode in [ 'VHT160', 'HE160' ])
+	else if (data.htmode in [ 'VHT160', 'HE160', 'EHT160' ])
 		set_default(config, 'max_oper_chwidth', 2);
-	else if (data.htmode in [ 'VHT20', 'VHT40', 'HE20', 'HE40' ])
+	else if (data.htmode in [ 'EHT320' ])
+		set_default(config, 'max_oper_chwidth', 9);
+	else if (data.htmode in [ 'VHT20', 'VHT40', 'HE20', 'HE40', 'EHT20', 'EHT40' ])
 		set_default(config, 'max_oper_chwidth', 0);
 	else
 		set_default(config, 'disable_vht', true);
 
 	if (data.htmode in [ 'NOHT' ])
 		set_default(config, 'disable_ht', true);
-	else if (data.htmode in [ 'HT20', 'VHT20', 'HE20' ])
+	else if (data.htmode in [ 'HT20', 'VHT20', 'HE20', 'EHT20' ])
 		set_default(config, 'disable_ht40', true);
-	else if (data.htmode in [ 'VHT40', 'VHT80', 'VHT160', 'HE40', 'HE80', 'HE160' ])
+	else if (data.htmode in [ 'VHT40', 'VHT80', 'VHT160', 'HE40', 'HE80', 'HE160', 'EHT40', 'EHT80', 'EHT160', 'EHT320' ])
 		set_default(config, 'ht40', true);
 
 	if (wildcard(data.htmode, 'VHT*'))


### PR DESCRIPTION
This pull request addresses two separate issues currently preventing the configuration of non-80MHz width 802.11s mesh on EHT hardware.

1. hostapd: does not have 320MHz marked for use in the enumerable in config files, just internally.
2. wifi-scripts: set_fixed_freq is unaware of EHT widths, so it does not emit the correct max_oper_chwidth into the hostapd configuration file

As a result, EHT capable 802.11s meshes don't currently configure themselves correctly currently, and fall back to 80MHz width.