### PR TITLE
ath79: Ubiquiti UniFi AC LR: Fix model selection in ASU

### DIFF
--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -289,7 +289,7 @@ define Device/ubnt_unifiac-lr
   $(Device/ubnt_unifiac)
   DEVICE_MODEL := UniFi AC LR
   DEVICE_PACKAGES += -swconfig
-  SUPPORTED_DEVICES += unifiac-lite ubnt,unifiac-lite
+  SUPPORTED_DEVICES += unifiac-lite
 endef
 TARGET_DEVICES += ubnt_unifiac-lr
 


### PR DESCRIPTION
Remove supported device ubnt,unifiac-lite from ubnt,unifiac-lr. With this setting ASU would sometimes select the image for UniFi AC LR on the UniFi AC Lite because they share the same supported devices.

Fixes: https://github.com/openwrt/openwrt/issues/22541
