### PR TITLE
mediatek: backport upstream thermal patch for mt7981

### DIFF
--- a/target/linux/mediatek/patches-6.12/062-v6.18-arm64-dts-mediatek-add-thermal-sensor-support-on-mt7.patch
+++ b/target/linux/mediatek/patches-6.12/062-v6.18-arm64-dts-mediatek-add-thermal-sensor-support-on-mt7.patch
@@ -1,0 +1,69 @@
+From 0da6f7a0ab5322eb6d091a9c89d799adfeae078d Mon Sep 17 00:00:00 2001
+From: Aleksander Jan Bajkowski <olek2@wp.pl>
+Date: Sun, 7 Sep 2025 13:15:09 +0200
+Subject: [PATCH] arm64: dts: mediatek: add thermal sensor support on mt7981
+
+The temperature sensor in the MT7981 is same as in the MT7986.
+
+Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Link: https://lore.kernel.org/r/20250907111742.23195-2-olek2@wp.pl
+Signed-off-by: Matthias Brugger <matthias.bgg@gmail.com>
+---
+ arch/arm64/boot/dts/mediatek/mt7981b.dtsi | 31 ++++++++++++++++++++++-
+ 1 file changed, 30 insertions(+), 1 deletion(-)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7981b.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7981b.dtsi
+@@ -76,7 +76,7 @@
+ 			#reset-cells = <1>;
+ 		};
+ 
+-		clock-controller@1001e000 {
++		apmixedsys: clock-controller@1001e000 {
+ 			compatible = "mediatek,mt7981-apmixedsys";
+ 			reg = <0 0x1001e000 0 0x1000>;
+ 			#clock-cells = <1>;
+@@ -184,6 +184,31 @@
+ 			status = "disabled";
+ 		};
+ 
++		thermal@1100c800 {
++			compatible = "mediatek,mt7981-thermal",
++				     "mediatek,mt7986-thermal";
++			reg = <0 0x1100c800 0 0x800>;
++			interrupts = <GIC_SPI 138 IRQ_TYPE_LEVEL_HIGH>;
++			clocks = <&infracfg CLK_INFRA_THERM_CK>,
++				 <&infracfg CLK_INFRA_ADC_26M_CK>;
++			clock-names = "therm", "auxadc";
++			nvmem-cells = <&thermal_calibration>;
++			nvmem-cell-names = "calibration-data";
++			#thermal-sensor-cells = <1>;
++			mediatek,auxadc = <&auxadc>;
++			mediatek,apmixedsys = <&apmixedsys>;
++		};
++
++		auxadc: adc@1100d000 {
++			compatible = "mediatek,mt7981-auxadc",
++				     "mediatek,mt7986-auxadc";
++			reg = <0 0x1100d000 0 0x1000>;
++			clocks = <&infracfg CLK_INFRA_ADC_26M_CK>;
++			clock-names = "main";
++			#io-channel-cells = <1>;
++			status = "disabled";
++		};
++
+ 		pio: pinctrl@11d00000 {
+ 			compatible = "mediatek,mt7981-pinctrl";
+ 			reg = <0 0x11d00000 0 0x1000>,
+@@ -211,6 +236,10 @@
+ 			reg = <0 0x11f20000 0 0x1000>;
+ 			#address-cells = <1>;
+ 			#size-cells = <1>;
++
++			thermal_calibration: thermal-calib@274 {
++				reg = <0x274 0xc>;
++			};
+ 		};
+ 
+ 		clock-controller@15000000 {

--- a/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
+++ b/target/linux/mediatek/patches-6.12/117-complete-mt7981b-dtsi.patch
@@ -88,13 +88,11 @@ working:
  	soc {
  		compatible = "simple-bus";
  		ranges;
-@@ -76,13 +134,13 @@
- 			#reset-cells = <1>;
+@@ -77,12 +135,12 @@
  		};
  
--		clock-controller@1001e000 {
+ 		apmixedsys: clock-controller@1001e000 {
 -			compatible = "mediatek,mt7981-apmixedsys";
-+		apmixedsys: clock-controller@1001e000 {
 +			compatible = "mediatek,mt7981-apmixedsys", "syscon";
  			reg = <0 0x1001e000 0 0x1000>;
  			#clock-cells = <1>;
@@ -160,41 +158,16 @@ working:
  			clocks = <&infracfg CLK_INFRA_I2C0_CK>,
  				 <&infracfg CLK_INFRA_AP_DMA_CK>,
  				 <&infracfg CLK_INFRA_I2C_MCK_CK>,
-@@ -142,7 +215,32 @@
+@@ -142,7 +215,7 @@
  			status = "disabled";
  		};
  
 -		spi@11009000 {
-+		thermal: thermal@1100c800 {
-+			#thermal-sensor-cells = <1>;
-+			compatible = "mediatek,mt7981-thermal", "mediatek,mt7986-thermal";
-+			reg = <0 0x1100c800 0 0x800>;
-+			interrupts = <GIC_SPI 138 IRQ_TYPE_LEVEL_HIGH>;
-+			clocks = <&infracfg CLK_INFRA_THERM_CK>,
-+				 <&infracfg CLK_INFRA_ADC_26M_CK>;
-+			clock-names = "therm", "auxadc";
-+			mediatek,auxadc = <&auxadc>;
-+			mediatek,apmixedsys = <&apmixedsys>;
-+			nvmem-cells = <&thermal_calibration>;
-+			nvmem-cell-names = "calibration-data";
-+		};
-+
-+		auxadc: adc@1100d000 {
-+			compatible = "mediatek,mt7981-auxadc",
-+				     "mediatek,mt7986-auxadc",
-+				     "mediatek,mt7622-auxadc";
-+			reg = <0 0x1100d000 0 0x1000>;
-+			clocks = <&infracfg CLK_INFRA_ADC_26M_CK>,
-+				 <&infracfg CLK_INFRA_ADC_FRC_CK>;
-+			clock-names = "main", "32k";
-+			#io-channel-cells = <1>;
-+		};
-+
 +		spi2: spi@11009000 {
  			compatible = "mediatek,mt7981-spi-ipm", "mediatek,spi-ipm";
  			reg = <0 0x11009000 0 0x1000>;
  			interrupts = <GIC_SPI 142 IRQ_TYPE_LEVEL_HIGH>;
-@@ -156,7 +254,7 @@
+@@ -156,7 +229,7 @@
  			status = "disabled";
  		};
  
@@ -203,7 +176,7 @@ working:
  			compatible = "mediatek,mt7981-spi-ipm", "mediatek,spi-ipm";
  			reg = <0 0x1100a000 0 0x1000>;
  			interrupts = <GIC_SPI 140 IRQ_TYPE_LEVEL_HIGH>;
-@@ -170,7 +268,7 @@
+@@ -170,7 +243,7 @@
  			status = "disabled";
  		};
  
@@ -212,10 +185,31 @@ working:
  			compatible = "mediatek,mt7981-spi-ipm", "mediatek,spi-ipm";
  			reg = <0 0x1100b000 0 0x1000>;
  			interrupts = <GIC_SPI 141 IRQ_TYPE_LEVEL_HIGH>;
-@@ -184,6 +282,41 @@
+@@ -184,7 +257,7 @@
  			status = "disabled";
  		};
  
+-		thermal@1100c800 {
++		thermal: thermal@1100c800 {
+ 			compatible = "mediatek,mt7981-thermal",
+ 				     "mediatek,mt7986-thermal";
+ 			reg = <0 0x1100c800 0 0x800>;
+@@ -201,12 +274,48 @@
+ 
+ 		auxadc: adc@1100d000 {
+ 			compatible = "mediatek,mt7981-auxadc",
+-				     "mediatek,mt7986-auxadc";
++				     "mediatek,mt7986-auxadc",
++				     "mediatek,mt7622-auxadc";
+ 			reg = <0 0x1100d000 0 0x1000>;
+-			clocks = <&infracfg CLK_INFRA_ADC_26M_CK>;
+-			clock-names = "main";
++			clocks = <&infracfg CLK_INFRA_ADC_26M_CK>,
++				 <&infracfg CLK_INFRA_ADC_FRC_CK>;
++			clock-names = "main", "32k";
+ 			#io-channel-cells = <1>;
++		};
++
 +		pcie: pcie@11280000 {
 +			compatible = "mediatek,mt7981-pcie",
 +				     "mediatek,mt8192-pcie";
@@ -228,7 +222,7 @@ working:
 +			bus-range = <0x00 0xff>;
 +			ranges = <0x82000000 0 0x20000000
 +				  0x0 0x20000000 0 0x10000000>;
-+			status = "disabled";
+ 			status = "disabled";
 +
 +			clocks = <&infracfg CLK_INFRA_IPCIE_CK>,
 +				 <&infracfg CLK_INFRA_IPCIE_PIPE_CK>,
@@ -249,12 +243,10 @@ working:
 +				#address-cells = <0>;
 +				#interrupt-cells = <1>;
 +			};
-+		};
-+
+ 		};
+ 
  		pio: pinctrl@11d00000 {
- 			compatible = "mediatek,mt7981-pinctrl";
- 			reg = <0 0x11d00000 0 0x1000>,
-@@ -204,6 +337,35 @@
+@@ -229,6 +338,35 @@
  			gpio-controller;
  			#gpio-cells = <2>;
  			#interrupt-cells = <2>;
@@ -290,14 +282,10 @@ working:
  		};
  
  		efuse@11f20000 {
-@@ -211,17 +373,297 @@
- 			reg = <0 0x11f20000 0 0x1000>;
- 			#address-cells = <1>;
- 			#size-cells = <1>;
-+
-+			thermal_calibration: thermal-calib@274 {
-+				reg = <0x274 0xc>;
-+			};
+@@ -240,17 +378,293 @@
+ 			thermal_calibration: thermal-calib@274 {
+ 				reg = <0x274 0xc>;
+ 			};
 +
 +			phy_calibration: phy-calib@8dc {
 +				reg = <0x8dc 0x10>;
@@ -590,7 +578,7 @@ working:
  			reg = <0 0x18000000 0 0x1000000>,
  			      <0 0x10003000 0 0x1000>,
  			      <0 0x11d10000 0 0x1000>;
-@@ -234,6 +676,67 @@
+@@ -263,6 +677,67 @@
  			clock-names = "mcu", "ap2conn";
  			resets = <&watchdog MT7986_TOPRGU_CONSYS_SW_RST>;
  			reset-names = "consys";
@@ -658,7 +646,7 @@ working:
  		};
  	};
  
-@@ -245,4 +748,8 @@
+@@ -274,4 +749,8 @@
  			     <GIC_PPI 11 IRQ_TYPE_LEVEL_LOW>,
  			     <GIC_PPI 10 IRQ_TYPE_LEVEL_LOW>;
  	};

--- a/target/linux/mediatek/patches-6.12/187-arm64-dts-mediatek-fix-mt7981-spim-clock.patch
+++ b/target/linux/mediatek/patches-6.12/187-arm64-dts-mediatek-fix-mt7981-spim-clock.patch
@@ -14,7 +14,7 @@ Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
 
 --- a/arch/arm64/boot/dts/mediatek/mt7981b.dtsi
 +++ b/arch/arm64/boot/dts/mediatek/mt7981b.dtsi
-@@ -248,6 +248,10 @@
+@@ -223,6 +223,10 @@
  				 <&topckgen CLK_TOP_SPI_SEL>,
  				 <&infracfg CLK_INFRA_SPI2_CK>,
  				 <&infracfg CLK_INFRA_SPI2_HCK_CK>;
@@ -25,7 +25,7 @@ Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
  			clock-names = "parent-clk", "sel-clk", "spi-clk", "hclk";
  			#address-cells = <1>;
  			#size-cells = <0>;
-@@ -262,6 +266,10 @@
+@@ -237,6 +241,10 @@
  				 <&topckgen CLK_TOP_SPI_SEL>,
  				 <&infracfg CLK_INFRA_SPI0_CK>,
  				 <&infracfg CLK_INFRA_SPI0_HCK_CK>;
@@ -36,7 +36,7 @@ Signed-off-by: Shiji Yang <yangshiji66@outlook.com>
  			clock-names = "parent-clk", "sel-clk", "spi-clk", "hclk";
  			#address-cells = <1>;
  			#size-cells = <0>;
-@@ -273,9 +281,13 @@
+@@ -248,9 +256,13 @@
  			reg = <0 0x1100b000 0 0x1000>;
  			interrupts = <GIC_SPI 141 IRQ_TYPE_LEVEL_HIGH>;
  			clocks = <&topckgen CLK_TOP_CB_M_D2>,


### PR DESCRIPTION
Backport upstream patch that adds node for thermal driver.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>