### PR TITLE
ramips: mt76x8: cudy TR1200 v1 add previous dts compatible to SUPPORTED_DEVICES

### DIFF
--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -239,7 +239,7 @@ define Device/cudy_tr1200-v1
   DEVICE_VARIANT := v1
   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci kmod-usb-ledtrig-usbport \
 	kmod-mt7615e kmod-mt7663-firmware-ap
-  SUPPORTED_DEVICES += R46
+  SUPPORTED_DEVICES += cudy,tr1200
 endef
 TARGET_DEVICES += cudy_tr1200-v1
 


### PR DESCRIPTION
Add old dts compatible "cudy,tr1200" to SUPPORTED_DEVICES list to alow "force-less" sysupgrades from the cudy installation image and from old installations using the previous dts compatible. (Also fix ASU profile identification)

Remove "R46" since the required intermediate image offered by Cudy to migrate to OpenWrt does not use it, only the original OEM firmware uses that dts compatible from which we do not support direct sysupgrades.

Fixes: d780d530dd89d135fffc6fb6598e6f7b28cd3921 ("ramips: mt76x8: sync Cudy TR1200 v1 naming")
Fixes: https://github.com/openwrt/openwrt/issues/22640