### PR TITLE
wireguard-tools: use kconfig dependency for ip instead of runtime

### DIFF
--- a/package/network/utils/wireguard-tools/Makefile
+++ b/package/network/utils/wireguard-tools/Makefile
@@ -35,8 +35,8 @@ define Package/wireguard-tools
   MAINTAINER:=Jason A. Donenfeld <Jason@zx2c4.com>
   TITLE:=WireGuard userspace control program (wg)
   DEPENDS:= \
-	  +!BUSYBOX_CONFIG_IP:ip \
-	  +!BUSYBOX_CONFIG_FEATURE_IP_LINK:ip \
+	  +@BUSYBOX_CONFIG_IP \
+	  +@BUSYBOX_CONFIG_FEATURE_IP_LINK \
 	  +kmod-wireguard
 endef
 


### PR DESCRIPTION
On APK-based OpenWrt (25.12+), installing wireguard-tools via
"apk add wireguard-tools" incorrectly requires ip-tiny or ip-full
to be installed, even though busybox already provides the ip command
by default.

This happens because the build system cannot always resolve the
busybox config options when generating the package metadata. As a
result, the ip dependency ends up hardcoded in the .apk package.

Fix this by switching from a conditional runtime dependency on the
ip package to a build-config-level dependency that ensures busybox
ip support is enabled. This avoids adding ip as a runtime package
requirement. Busybox ip is enabled by default and fully supports
the ip link commands that wireguard needs.

Fixes: #22637