### PR TITLE
generic: mxl862xx: 6.18: fix phylink_pcs get_state signature

### DIFF
--- a/target/linux/generic/pending-6.18/760-11-net-dsa-mxl862xx-add-support-for-SerDes-ports.patch
+++ b/target/linux/generic/pending-6.18/760-11-net-dsa-mxl862xx-add-support-for-SerDes-ports.patch
@@ -807,7 +807,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	state->duplex = DUPLEX_FULL;
 +}
 +
-+static void mxl862xx_pcs_get_state(struct phylink_pcs *pcs,
++static void mxl862xx_pcs_get_state(struct phylink_pcs *pcs, unsigned int mode,
 +				   struct phylink_link_state *state)
 +{
 +	struct mxl862xx_priv *priv = pcs_to_mxl862xx_pcs(pcs)->priv;
@@ -845,7 +845,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +		bmsr = BMSR_LSTATUS;
 +		if (st.an_complete)
 +			bmsr |= BMSR_ANEGCOMPLETE;
-+		phylink_mii_c22_pcs_decode_state(state, bmsr, lpa);
++		phylink_mii_c22_pcs_decode_state(state, mode, bmsr, lpa);
 +
 +		/* Override speed/duplex with firmware's resolved values
 +		 * for downshift detection.

--- a/target/linux/generic/pending-6.18/760-26-DO-NOT-SUBMIT-net-dsa-mxl862xx-legacy-SFP-API-fallba.patch
+++ b/target/linux/generic/pending-6.18/760-26-DO-NOT-SUBMIT-net-dsa-mxl862xx-legacy-SFP-API-fallba.patch
@@ -113,7 +113,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 +	return MXL862XX_API_WRITE(priv, SYS_MISC_SFP_SET, ser_intf);
 +}
 +
-+static void mxl862xx_legacy_pcs_get_state(struct phylink_pcs *pcs,
++static void mxl862xx_legacy_pcs_get_state(struct phylink_pcs *pcs, unsigned int mode,
 +					  struct phylink_link_state *state)
 +{
 +	struct mxl862xx_priv *priv = pcs_to_mxl862xx_pcs(pcs)->priv;


### PR DESCRIPTION
Add the missing 'mode' parameter to mxl862xx_pcs_get_state to match the phylink_pcs prototype.


Fixes CI compilation errors for: https://github.com/openwrt/openwrt/pull/20965 and https://github.com/openwrt/openwrt/pull/21418