### PR TITLE
mtd: spinand: add support for Dosilicon SPI NANDs

### DIFF
--- a/target/linux/qualcommax/patches-6.12/0402-mtd-spi-nand-Support-dosilicon.patch
+++ b/target/linux/qualcommax/patches-6.12/0402-mtd-spi-nand-Support-dosilicon.patch
@@ -1,0 +1,327 @@
+From cead43cc5781492f2706eeed1157c8986a216bc9 Mon Sep 17 00:00:00 2001
+From: Jon Lin <jon.lin@rock-chips.com>
+Date: Sun, 17 Oct 2021 09:51:39 +0800
+Subject: [PATCH] mtd: spinand: Support dosilicon
+
+DS35X1GA, DS35Q2GA, DS35M1GA, DS35M2GA, DS35Q2GB, DS35M1GB
+
+Modifications for spi-qpic-snand controller compatibility:
+Adjusted the driver code to work correctly with the spi-qpic-snand controller.
+
+Signed-off-by: Jon Lin <jon.lin@rock-chips.com>
+Signed-off-by: mark304188 <mark304188@hotmail.com>
+---
+ drivers/mtd/nand/spi/Makefile    |   2 +-
+ drivers/mtd/nand/spi/core.c      |   1 +
+ drivers/mtd/nand/spi/dosilicon.c | 187 +++++++++++++++++++++++++++++++
+ include/linux/mtd/spinand.h      |   1 +
+ 4 files changed, 190 insertions(+), 1 deletion(-)
+ create mode 100644 drivers/mtd/nand/spi/dosilicon.c
+
+--- a/drivers/mtd/nand/spi/Makefile
++++ b/drivers/mtd/nand/spi/Makefile
+@@ -1,4 +1,5 @@
+ # SPDX-License-Identifier: GPL-2.0
+ spinand-objs := core.o alliancememory.o ato.o esmt.o etron.o fmsh.o foresee.o gigadevice.o
++spinand-objs += dosilicon.o
+ spinand-objs += macronix.o micron.o paragon.o skyhigh.o toshiba.o winbond.o xtx.o
+ obj-$(CONFIG_MTD_SPI_NAND) += spinand.o
+--- a/drivers/mtd/nand/spi/core.c
++++ b/drivers/mtd/nand/spi/core.c
+@@ -1184,6 +1184,7 @@ static const struct nand_ops spinand_ops
+ static const struct spinand_manufacturer *spinand_manufacturers[] = {
+ 	&alliancememory_spinand_manufacturer,
+ 	&ato_spinand_manufacturer,
++	&dosilicon_spinand_manufacturer,
+ 	&esmt_8c_spinand_manufacturer,
+ 	&esmt_c8_spinand_manufacturer,
+ 	&etron_spinand_manufacturer,
+--- /dev/null
++++ b/drivers/mtd/nand/spi/dosilicon.c
+@@ -0,0 +1,276 @@
++// SPDX-License-Identifier: GPL-2.0
++/*
++ * Copyright (c) 2020 Rockchip Electronics Co., Ltd.
++ */
++
++#include <linux/device.h>
++#include <linux/kernel.h>
++#include <linux/mtd/spinand.h>
++
++#define SPINAND_MFR_DOSILICON			0xE5
++
++#define DOSICON_STATUS_ECC_MASK			GENMASK(6, 4)
++#define DOSICON_STATUS_ECC_NO_BITFLIPS		(0 << 4)
++#define DOSICON_STATUS_ECC_1TO3_BITFLIPS	(1 << 4)
++#define DOSICON_STATUS_ECC_4TO6_BITFLIPS	(3 << 4)
++#define DOSICON_STATUS_ECC_7TO8_BITFLIPS	(5 << 4)
++
++static SPINAND_OP_VARIANTS(read_cache_variants,
++		SPINAND_PAGE_READ_FROM_CACHE_X4_OP(0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(true, 0, 1, NULL, 0),
++		SPINAND_PAGE_READ_FROM_CACHE_OP(false, 0, 1, NULL, 0));
++
++static SPINAND_OP_VARIANTS(write_cache_variants,
++		SPINAND_PROG_LOAD(false, 0, NULL, 0));		//spi-qpic-snand does NOT support opcode 0x02,use 0x84 instead
++
++static SPINAND_OP_VARIANTS(update_cache_variants,
++		SPINAND_PROG_LOAD(false, 0, NULL, 0));		//spi-qpic-snand does NOT support opcode 0x02,use 0x84 instead
++
++static int ds35xxga_ooblayout_ecc(struct mtd_info *mtd, int section,
++				  struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	region->offset = (16 * section) + 8;
++	region->length = 8;
++
++	return 0;
++}
++
++static int ds35xxga_ooblayout_free(struct mtd_info *mtd, int section,
++				   struct mtd_oob_region *region)
++{
++	if (section > 3)
++		return -ERANGE;
++
++	region->offset = (16 * section) + 2;
++	region->length = 6;
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops ds35xxga_ooblayout = {
++	.ecc = ds35xxga_ooblayout_ecc,
++	.free = ds35xxga_ooblayout_free,
++};
++
++static int ds35xxgb_ooblayout_ecc(struct mtd_info *mtd, int section,
++				  struct mtd_oob_region *region)
++{
++	if (section)
++		return -ERANGE;
++
++	region->offset = 64;
++	region->length = 64;
++
++	return 0;
++}
++
++static int ds35xxgb_ooblayout_free(struct mtd_info *mtd, int section,
++				   struct mtd_oob_region *region)
++{
++	if (section)
++		return -ERANGE;
++
++	/* Reserve 1 bytes for the BBM. */
++	region->offset = 1;
++	region->length = 63;
++
++	return 0;
++}
++
++static const struct mtd_ooblayout_ops ds35xxgb_ooblayout = {
++	.ecc = ds35xxgb_ooblayout_ecc,
++	.free = ds35xxgb_ooblayout_free,
++};
++
++static int ds35xxgb_ecc_get_status(struct spinand_device *spinand,
++				   u8 status)
++{
++	switch (status & DOSICON_STATUS_ECC_MASK) {
++	case STATUS_ECC_NO_BITFLIPS:
++		return 0;
++
++	case STATUS_ECC_UNCOR_ERROR:
++		return -EBADMSG;
++
++	case DOSICON_STATUS_ECC_1TO3_BITFLIPS:
++		return 3;
++
++	case DOSICON_STATUS_ECC_4TO6_BITFLIPS:
++		return 6;
++
++	case DOSICON_STATUS_ECC_7TO8_BITFLIPS:
++		return 8;
++
++	default:
++		break;
++	}
++
++	return -EINVAL;
++}
++
++static const struct spinand_info dosilicon_spinand_table[] = {
++	SPINAND_INFO("DS35X1GA",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x71),
++		     NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(4, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxga_ooblayout, NULL)),
++	SPINAND_INFO("DS35Q2GA",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x72),
++		     NAND_MEMORG(1, 2048, 64, 64, 2048, 40, 2, 1, 1),
++		     NAND_ECCREQ(4, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxga_ooblayout, NULL)),
++	SPINAND_INFO("DS35M1GA",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x21),
++		     NAND_MEMORG(1, 2048, 64, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(4, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxga_ooblayout, NULL)),
++	SPINAND_INFO("DS35M2GA",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x22),
++		     NAND_MEMORG(1, 2048, 64, 64, 2048, 40, 2, 1, 1),
++		     NAND_ECCREQ(4, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxga_ooblayout, NULL)),
++	SPINAND_INFO("DS35Q2GB",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xF2),
++		     NAND_MEMORG(1, 2048, 128, 64, 2048, 40, 2, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout,
++				     ds35xxgb_ecc_get_status)),
++	SPINAND_INFO("DS35M1GB",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xA1),
++		     NAND_MEMORG(1, 2048, 128, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout,
++				     ds35xxgb_ecc_get_status)),
++	SPINAND_INFO("DS35Q1GB",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xF1),
++		     NAND_MEMORG(1, 2048, 128, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout,
++				     ds35xxgb_ecc_get_status)),
++	SPINAND_INFO("DS35Q4GM",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xF4),
++		     NAND_MEMORG(1, 2048, 128, 64, 4096, 80, 2, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout,
++				     ds35xxgb_ecc_get_status)),
++	SPINAND_INFO("DS35Q12B",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xF5),
++		     NAND_MEMORG(1, 2048, 128, 64, 512, 10, 1, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout,
++				     ds35xxgb_ecc_get_status)),
++	SPINAND_INFO("DS35M12B",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xA5),
++		     NAND_MEMORG(1, 2048, 128, 64, 512, 10, 1, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout,
++				     ds35xxgb_ecc_get_status)),
++	SPINAND_INFO("DS35Q1GD-IB",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x51),
++		     NAND_MEMORG(1, 2048, 128, 64, 1024, 20, 1, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout, ds35xxgb_ecc_get_status)),
++	SPINAND_INFO("DS35M4GB-IB",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x64),
++		     NAND_MEMORG(1, 2048, 128, 64, 4096, 40, 1, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout, ds35xxgb_ecc_get_status)),
++	SPINAND_INFO("DS35Q4GB-IB",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xB4),
++		     NAND_MEMORG(1, 2048, 128, 64, 4096, 40, 1, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout, ds35xxgb_ecc_get_status)),
++	SPINAND_INFO("DS35Q12C-IB",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x75),
++		     NAND_MEMORG(1, 2048, 128, 64, 512, 10, 1, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout, ds35xxgb_ecc_get_status)),
++	SPINAND_INFO("DS35M12C-IB",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0x25),
++		     NAND_MEMORG(1, 2048, 128, 64, 512, 10, 1, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout, ds35xxgb_ecc_get_status)),
++	SPINAND_INFO("DS35Q2GBS",
++		     SPINAND_ID(SPINAND_READID_METHOD_OPCODE_DUMMY, 0xB2),
++		     NAND_MEMORG(1, 2048, 128, 64, 2048, 40, 1, 1, 1),
++		     NAND_ECCREQ(8, 512),
++		     SPINAND_INFO_OP_VARIANTS(&read_cache_variants,
++					      &write_cache_variants,
++					      &update_cache_variants),
++		     SPINAND_HAS_QE_BIT,
++		     SPINAND_ECCINFO(&ds35xxgb_ooblayout, ds35xxgb_ecc_get_status)),
++};
++
++static const struct spinand_manufacturer_ops dosilicon_spinand_manuf_ops = {
++};
++
++const struct spinand_manufacturer dosilicon_spinand_manufacturer = {
++	.id = SPINAND_MFR_DOSILICON,
++	.name = "dosilicon",
++	.chips = dosilicon_spinand_table,
++	.nchips = ARRAY_SIZE(dosilicon_spinand_table),
++	.ops = &dosilicon_spinand_manuf_ops,
++};
+--- a/include/linux/mtd/spinand.h
++++ b/include/linux/mtd/spinand.h
+@@ -262,6 +262,7 @@ struct spinand_manufacturer {
+ /* SPI NAND manufacturers */
+ extern const struct spinand_manufacturer alliancememory_spinand_manufacturer;
+ extern const struct spinand_manufacturer ato_spinand_manufacturer;
++extern const struct spinand_manufacturer dosilicon_spinand_manufacturer;
+ extern const struct spinand_manufacturer esmt_8c_spinand_manufacturer;
+ extern const struct spinand_manufacturer esmt_c8_spinand_manufacturer;
+ extern const struct spinand_manufacturer etron_spinand_manufacturer;

--- a/target/linux/qualcommax/patches-6.12/0412-mtd-spinand-qpic-only-support-max-4-bytes-ID.patch
+++ b/target/linux/qualcommax/patches-6.12/0412-mtd-spinand-qpic-only-support-max-4-bytes-ID.patch
@@ -14,7 +14,7 @@ Signed-off-by: Ziyang Huang <hzyitc@outlook.com>
 
 --- a/drivers/mtd/nand/spi/core.c
 +++ b/drivers/mtd/nand/spi/core.c
-@@ -1337,7 +1337,7 @@ int spinand_match_and_init(struct spinan
+@@ -1338,7 +1338,7 @@ int spinand_match_and_init(struct spinan
  		if (rdid_method != info->devid.method)
  			continue;
  


### PR DESCRIPTION
mtd: spinand: add support for Dosilicon SPI NANDs
Add support for the following Dosilicon SPI NAND chips:
- DS35X1GA, DS35Q2GA, DS35M1GA, DS35M2GA
- DS35Q2GB, DS35M1GB

The original driver comes from ImmortalWrt (adapted from MediaTek). 
[https://github.com/immortalwrt/immortalwrt/blob/7259b8ca8252066655bf17d3c8e731b00ab5eb8f/target/linux/mediatek/patches-6.12/341-mtd-spinand-Support-dosilicon.patch#L4](url)
This version includes modifications to ensure compatibility with the Qualcomm QPIC SNAND controller (used on ipq5018 and other qualcommax targets).

Tested on IPQ5018-based device with spi-qpic-snand controller.