### PR TITLE
mediatek: filogic: add support for Z8103AX-G

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax-g.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax-g.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "mt7981b-zbtlink-zbt-z8103ax.dtsi"
+
+/ {
+	model = "Zbtlink ZBT-Z8103AX-G";
+	compatible = "zbtlink,zbt-z8103ax-g", "mediatek,mt7981b";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -327,7 +327,8 @@ xiaomi,redmi-router-ax6000-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "rgb:network" "wan"
 	;;
 zbtlink,zbt-z8103ax|\
-zbtlink,zbt-z8103ax-c)
+zbtlink,zbt-z8103ax-c|\
+zbtlink,zbt-z8103ax-g)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
 zyxel,ex5601-t0-stock|\

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -20,7 +20,8 @@ mediatek_setup_interfaces()
 	mercusys,mr80x-v3|\
 	routerich,ax3000-v1|\
 	zbtlink,zbt-z8103ax|\
-	zbtlink,zbt-z8103ax-c)
+	zbtlink,zbt-z8103ax-c|\
+	zbtlink,zbt-z8103ax-g)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" eth1
 		;;
 	acelink,ew-7886cax|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -3376,6 +3376,23 @@ define Device/zbtlink_zbt-z8103ax-c
 endef
 TARGET_DEVICES += zbtlink_zbt-z8103ax-c
 
+define Device/zbtlink_zbt-z8103ax-g
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-Z8103AX-G
+  DEVICE_DTS := mt7981b-zbtlink-zbt-z8103ax-g
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3
+  KERNEL_IN_UBI := 1
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 117248k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zbtlink_zbt-z8103ax-g
+
 define Device/zyxel_ex5601-t0-stock
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := EX5601-T0


### PR DESCRIPTION
Add support zbtlink zbt-z8103ax variant 'G' a.k.a 'Pro',
about the same as the 'C' variant but with a USB port.

To install force sysupgrade from stock firmware in the web interface.