### PR TITLE
apk: hardcode uclient-fetch instead of wget

### DIFF
--- a/package/system/apk/Makefile
+++ b/package/system/apk/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=apk
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE_URL=https://gitlab.alpinelinux.org/alpine/apk-tools.git
 PKG_SOURCE_PROTO:=git
@@ -26,7 +26,7 @@ define Package/apk/default
   SECTION:=base
   CATEGORY:=Base system
   TITLE:=apk package manager
-  DEPENDS:=+zlib +wget-any
+  DEPENDS:=+uclient-fetch +zlib
   URL:=$(PKG_SOURCE_URL)
   PROVIDES:=apk
 endef

--- a/package/system/apk/patches/0020-hardcode-uclient-fetch-instead-of-wget.patch
+++ b/package/system/apk/patches/0020-hardcode-uclient-fetch-instead-of-wget.patch
@@ -1,0 +1,29 @@
+From 55775f54fd801c8ad2a609189304024951fd7ae1 Mon Sep 17 00:00:00 2001
+From: George Sapkin <george@sapk.in>
+Date: Sun, 29 Mar 2026 11:15:53 +0300
+Subject: [PATCH] hardcode uclient-fetch instead of wget
+
+Both wget-ssl and wget-nossl provide @wget-any that apk depends on and
+both are valid choices for users to install. However, wget-nossl lacks
+TLS support which makes installing and updating packages impossible.
+Making wget-nossl have lower alternative priority than uclient-fetch
+defeats the purpose of installing it, since uclient-fetch will be the
+default alternative for wget.
+
+Instead, hardcode uclient-fetch to be always used instead of wget, so
+users can install whichever wget variant they prefer.
+---
+ src/io_url_wget.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/io_url_wget.c
++++ b/src/io_url_wget.c
+@@ -19,7 +19,7 @@ struct apk_istream *apk_io_url_istream(c
+ 	char *argv[16];
+ 	int i = 0;
+
+-	argv[i++] = "wget";
++	argv[i++] = "uclient-fetch";
+ 	argv[i++] = "-q";
+ 	argv[i++] = "-T";
+ 	argv[i++] = wget_timeout;


### PR DESCRIPTION
Both wget-ssl and wget-nossl provide `@wget-any` that apk depends on and both are valid choices for users to install. However, wget-nossl lacks TLS support which makes installing and updating packages impossible. Making wget-nossl have lower alternative priority than uclient-fetch defeats the purpose of installing it, since uclient-fetch will be the default alternative for wget.

Instead, patch apk to hardcode uclient-fetch to be always used instead of wget, so users can install whichever wget variant they prefer.

An alternative is to drop wget-nossl altogether and leave wget-ssl as the only variant. This would leave both uclient-fetch and wget as sole `@wget-any` providers with a natural alternative order.

Before:

```shell
root@OpenWrt:~# apk add wget-nossl
(1/2) Installing libpcre2 (10.47-r1)
  Executing libpcre2-10.47-r1.post-install
(2/2) Installing wget-nossl (1.25.0-r4)
  Executing wget-nossl-1.25.0-r4.post-install
  * add alternative: /usr/bin/wget -> /usr/libexec/wget-nossl OK: 18.7 MiB in 153 packages
root@OpenWrt:~# apk update
ERROR: wget: exited with error 1
WARNING: updating https://downloads.openwrt.org/snapshots/targets/x86/64/packages/packages.adb: unexpected end of file ERROR: wget: exited with error 1
WARNING: updating https://downloads.openwrt.org/snapshots/packages/x86_64/base/packages.adb: unexpected end of file ERROR: wget: exited with error 1
WARNING: updating https://downloads.openwrt.org/snapshots/targets/x86/64/kmods/6.12.77-1-c9fff994e410f83a85b5db92074f9dca/packages.adb: unexpected end of file ERROR: wget: exited with error 1
WARNING: updating https://downloads.openwrt.org/snapshots/packages/x86_64/luci/packages.adb: unexpected end of file ERROR: wget: exited with error 1
WARNING: updating https://downloads.openwrt.org/snapshots/packages/x86_64/packages/packages.adb: unexpected end of file ERROR: wget: exited with error 1
WARNING: updating https://downloads.openwrt.org/snapshots/packages/x86_64/routing/packages.adb: unexpected end of file ERROR: wget: exited with error 1
WARNING: updating https://downloads.openwrt.org/snapshots/packages/x86_64/telephony/packages.adb: unexpected end of file ERROR: wget: exited with error 1
WARNING: updating https://downloads.openwrt.org/snapshots/packages/x86_64/video/packages.adb: unexpected end of file
 [https://downloads.openwrt.org/snapshots/targets/x86/64/packages/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/base/packages.adb]
 [https://downloads.openwrt.org/snapshots/targets/x86/64/kmods/6.12.77-1-c9fff994e410f83a85b5db92074f9dca/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/luci/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/packages/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/routing/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/telephony/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/video/packages.adb]
0 unavailable, 8 stale; 10970 distinct packages available
```

After:

```shell
root@OpenWrt:/tmp# apk add wget-nossl
(1/2) Installing libpcre2 (10.47-r1)
  Executing libpcre2-10.47-r1.post-install
(2/2) Installing wget-nossl (1.25.0-r4)
  Executing wget-nossl-1.25.0-r4.post-install
  * add alternative: /usr/bin/wget -> /usr/libexec/wget-nossl OK: 18.7 MiB in 153 packages
root@OpenWrt:/tmp# apk update
 [https://downloads.openwrt.org/snapshots/targets/x86/64/packages/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/base/packages.adb]
 [https://downloads.openwrt.org/snapshots/targets/x86/64/kmods/6.12.77-1-c9fff994e410f83a85b5db92074f9dca/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/luci/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/packages/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/routing/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/telephony/packages.adb]
 [https://downloads.openwrt.org/snapshots/packages/x86_64/video/packages.adb]
OK: 10970 distinct packages available
```

Fixes: https://github.com/openwrt/openwrt/issues/14894 (although this touches apk only and not the other tools like opkg, so might be a good idea to keep that open, if relevant)
Fixes: https://github.com/openwrt/packages/issues/28920

Run tested:
- SNAPSHOT, r33661-92c7feebd2, x86/64, QEMU

cc: @aparcar, @efahl