### PR TITLE
realtek: i2c: rtl9300: backport driver cleanup patches

### DIFF
--- a/target/linux/realtek/patches-6.12/025-01-v7.0-i2c-rtl9300-remove-const-cast.patch
+++ b/target/linux/realtek/patches-6.12/025-01-v7.0-i2c-rtl9300-remove-const-cast.patch
@@ -1,0 +1,54 @@
+From fc31008d5f57e71afa124550ca01b4399434435e Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 16 Dec 2025 22:30:26 -0800
+Subject: i2c: rtl9300: remove const cast
+
+These casts are used to remove const for no good reason. Fix the types
+instead.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+Reviewed-by: Chris Packham <chris.packham@alliedtelesis.co.nz>
+Signed-off-by: Andi Shyti <andi.shyti@kernel.org>
+Link: https://lore.kernel.org/r/20251217063027.37987-2-rosenp@gmail.com
+---
+ drivers/i2c/busses/i2c-rtl9300.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+--- a/drivers/i2c/busses/i2c-rtl9300.c
++++ b/drivers/i2c/busses/i2c-rtl9300.c
+@@ -129,7 +129,7 @@ static int rtl9310_i2c_select_scl(struct
+ 
+ static int rtl9300_i2c_config_chan(struct rtl9300_i2c *i2c, struct rtl9300_i2c_chan *chan)
+ {
+-	struct rtl9300_i2c_drv_data *drv_data;
++	const struct rtl9300_i2c_drv_data *drv_data;
+ 	int ret;
+ 
+ 	if (i2c->sda_num == chan->sda_num)
+@@ -139,7 +139,7 @@ static int rtl9300_i2c_config_chan(struc
+ 	if (ret)
+ 		return ret;
+ 
+-	drv_data = (struct rtl9300_i2c_drv_data *)device_get_match_data(i2c->dev);
++	drv_data = device_get_match_data(i2c->dev);
+ 	ret = drv_data->select_scl(i2c, i2c->scl_num);
+ 	if (ret)
+ 		return ret;
+@@ -372,7 +372,7 @@ static int rtl9300_i2c_probe(struct plat
+ 	struct device *dev = &pdev->dev;
+ 	struct rtl9300_i2c *i2c;
+ 	struct fwnode_handle *child;
+-	struct rtl9300_i2c_drv_data *drv_data;
++	const struct rtl9300_i2c_drv_data *drv_data;
+ 	struct reg_field fields[F_NUM_FIELDS];
+ 	u32 clock_freq, scl_num, sda_num;
+ 	int ret, i = 0;
+@@ -399,7 +399,7 @@ static int rtl9300_i2c_probe(struct plat
+ 
+ 	platform_set_drvdata(pdev, i2c);
+ 
+-	drv_data = (struct rtl9300_i2c_drv_data *)device_get_match_data(i2c->dev);
++	drv_data = device_get_match_data(i2c->dev);
+ 	if (device_get_child_node_count(dev) > drv_data->max_nchan)
+ 		return dev_err_probe(dev, -EINVAL, "Too many channels\n");
+ 

--- a/target/linux/realtek/patches-6.12/025-02-v7.0-i2c-rtl9300-use-of-instead-of-fwnode.patch
+++ b/target/linux/realtek/patches-6.12/025-02-v7.0-i2c-rtl9300-use-of-instead-of-fwnode.patch
@@ -1,0 +1,56 @@
+From f6551f7861aca09cb2fdf675d6bb9ca2ffa9038a Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 16 Dec 2025 22:30:27 -0800
+Subject: i2c: rtl9300: use of instead of fwnode
+
+Avoids having to use to_of_node and just assign directly. This is an OF
+only driver anyway.
+
+Use _scoped for the for each loop to avoid refcount leaks.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+Reviewed-by: Chris Packham <chris.packham@alliedtelesis.co.nz>
+Signed-off-by: Andi Shyti <andi.shyti@kernel.org>
+Link: https://lore.kernel.org/r/20251217063027.37987-3-rosenp@gmail.com
+---
+ drivers/i2c/busses/i2c-rtl9300.c | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+--- a/drivers/i2c/busses/i2c-rtl9300.c
++++ b/drivers/i2c/busses/i2c-rtl9300.c
+@@ -371,7 +371,6 @@ static int rtl9300_i2c_probe(struct plat
+ {
+ 	struct device *dev = &pdev->dev;
+ 	struct rtl9300_i2c *i2c;
+-	struct fwnode_handle *child;
+ 	const struct rtl9300_i2c_drv_data *drv_data;
+ 	struct reg_field fields[F_NUM_FIELDS];
+ 	u32 clock_freq, scl_num, sda_num;
+@@ -415,15 +414,15 @@ static int rtl9300_i2c_probe(struct plat
+ 		return ret;
+ 
+ 	i = 0;
+-	device_for_each_child_node(dev, child) {
++	for_each_child_of_node_scoped(dev->of_node, child) {
+ 		struct rtl9300_i2c_chan *chan = &i2c->chans[i];
+ 		struct i2c_adapter *adap = &chan->adap;
+ 
+-		ret = fwnode_property_read_u32(child, "reg", &sda_num);
++		ret = of_property_read_u32(child, "reg", &sda_num);
+ 		if (ret)
+ 			return ret;
+ 
+-		ret = fwnode_property_read_u32(child, "clock-frequency", &clock_freq);
++		ret = of_property_read_u32(child, "clock-frequency", &clock_freq);
+ 		if (ret)
+ 			clock_freq = I2C_MAX_STANDARD_MODE_FREQ;
+ 
+@@ -449,7 +448,7 @@ static int rtl9300_i2c_probe(struct plat
+ 		adap->retries = 3;
+ 		adap->dev.parent = dev;
+ 		i2c_set_adapdata(adap, chan);
+-		adap->dev.of_node = to_of_node(child);
++		adap->dev.of_node = child;
+ 		snprintf(adap->name, sizeof(adap->name), "%s SDA%d\n", dev_name(dev), sda_num);
+ 		i++;
+ 

--- a/target/linux/realtek/patches-6.12/100-rtl9300-i2c-add-more-speeds.patch
+++ b/target/linux/realtek/patches-6.12/100-rtl9300-i2c-add-more-speeds.patch
@@ -37,7 +37,7 @@ Signed-off-by: Jan Kantert <jan-kernel@kantert.net>
  struct rtl9300_i2c;
  
  struct rtl9300_i2c_chan {
-@@ -434,6 +440,12 @@ static int rtl9300_i2c_probe(struct plat
+@@ -433,6 +439,12 @@ static int rtl9300_i2c_probe(struct plat
  		case I2C_MAX_FAST_MODE_FREQ:
  			chan->bus_freq = RTL9300_I2C_FAST_FREQ;
  			break;

--- a/target/linux/realtek/patches-6.18/025-01-v7.0-i2c-rtl9300-remove-const-cast.patch
+++ b/target/linux/realtek/patches-6.18/025-01-v7.0-i2c-rtl9300-remove-const-cast.patch
@@ -1,0 +1,54 @@
+From fc31008d5f57e71afa124550ca01b4399434435e Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 16 Dec 2025 22:30:26 -0800
+Subject: i2c: rtl9300: remove const cast
+
+These casts are used to remove const for no good reason. Fix the types
+instead.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+Reviewed-by: Chris Packham <chris.packham@alliedtelesis.co.nz>
+Signed-off-by: Andi Shyti <andi.shyti@kernel.org>
+Link: https://lore.kernel.org/r/20251217063027.37987-2-rosenp@gmail.com
+---
+ drivers/i2c/busses/i2c-rtl9300.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+--- a/drivers/i2c/busses/i2c-rtl9300.c
++++ b/drivers/i2c/busses/i2c-rtl9300.c
+@@ -129,7 +129,7 @@ static int rtl9310_i2c_select_scl(struct
+ 
+ static int rtl9300_i2c_config_chan(struct rtl9300_i2c *i2c, struct rtl9300_i2c_chan *chan)
+ {
+-	struct rtl9300_i2c_drv_data *drv_data;
++	const struct rtl9300_i2c_drv_data *drv_data;
+ 	int ret;
+ 
+ 	if (i2c->sda_num == chan->sda_num)
+@@ -139,7 +139,7 @@ static int rtl9300_i2c_config_chan(struc
+ 	if (ret)
+ 		return ret;
+ 
+-	drv_data = (struct rtl9300_i2c_drv_data *)device_get_match_data(i2c->dev);
++	drv_data = device_get_match_data(i2c->dev);
+ 	ret = drv_data->select_scl(i2c, i2c->scl_num);
+ 	if (ret)
+ 		return ret;
+@@ -372,7 +372,7 @@ static int rtl9300_i2c_probe(struct plat
+ 	struct device *dev = &pdev->dev;
+ 	struct rtl9300_i2c *i2c;
+ 	struct fwnode_handle *child;
+-	struct rtl9300_i2c_drv_data *drv_data;
++	const struct rtl9300_i2c_drv_data *drv_data;
+ 	struct reg_field fields[F_NUM_FIELDS];
+ 	u32 clock_freq, scl_num, sda_num;
+ 	int ret, i = 0;
+@@ -399,7 +399,7 @@ static int rtl9300_i2c_probe(struct plat
+ 
+ 	platform_set_drvdata(pdev, i2c);
+ 
+-	drv_data = (struct rtl9300_i2c_drv_data *)device_get_match_data(i2c->dev);
++	drv_data = device_get_match_data(i2c->dev);
+ 	if (device_get_child_node_count(dev) > drv_data->max_nchan)
+ 		return dev_err_probe(dev, -EINVAL, "Too many channels\n");
+ 

--- a/target/linux/realtek/patches-6.18/025-02-v7.0-i2c-rtl9300-use-of-instead-of-fwnode.patch
+++ b/target/linux/realtek/patches-6.18/025-02-v7.0-i2c-rtl9300-use-of-instead-of-fwnode.patch
@@ -1,0 +1,56 @@
+From f6551f7861aca09cb2fdf675d6bb9ca2ffa9038a Mon Sep 17 00:00:00 2001
+From: Rosen Penev <rosenp@gmail.com>
+Date: Tue, 16 Dec 2025 22:30:27 -0800
+Subject: i2c: rtl9300: use of instead of fwnode
+
+Avoids having to use to_of_node and just assign directly. This is an OF
+only driver anyway.
+
+Use _scoped for the for each loop to avoid refcount leaks.
+
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
+Reviewed-by: Chris Packham <chris.packham@alliedtelesis.co.nz>
+Signed-off-by: Andi Shyti <andi.shyti@kernel.org>
+Link: https://lore.kernel.org/r/20251217063027.37987-3-rosenp@gmail.com
+---
+ drivers/i2c/busses/i2c-rtl9300.c | 9 ++++-----
+ 1 file changed, 4 insertions(+), 5 deletions(-)
+
+--- a/drivers/i2c/busses/i2c-rtl9300.c
++++ b/drivers/i2c/busses/i2c-rtl9300.c
+@@ -371,7 +371,6 @@ static int rtl9300_i2c_probe(struct plat
+ {
+ 	struct device *dev = &pdev->dev;
+ 	struct rtl9300_i2c *i2c;
+-	struct fwnode_handle *child;
+ 	const struct rtl9300_i2c_drv_data *drv_data;
+ 	struct reg_field fields[F_NUM_FIELDS];
+ 	u32 clock_freq, scl_num, sda_num;
+@@ -415,15 +414,15 @@ static int rtl9300_i2c_probe(struct plat
+ 		return ret;
+ 
+ 	i = 0;
+-	device_for_each_child_node(dev, child) {
++	for_each_child_of_node_scoped(dev->of_node, child) {
+ 		struct rtl9300_i2c_chan *chan = &i2c->chans[i];
+ 		struct i2c_adapter *adap = &chan->adap;
+ 
+-		ret = fwnode_property_read_u32(child, "reg", &sda_num);
++		ret = of_property_read_u32(child, "reg", &sda_num);
+ 		if (ret)
+ 			return ret;
+ 
+-		ret = fwnode_property_read_u32(child, "clock-frequency", &clock_freq);
++		ret = of_property_read_u32(child, "clock-frequency", &clock_freq);
+ 		if (ret)
+ 			clock_freq = I2C_MAX_STANDARD_MODE_FREQ;
+ 
+@@ -449,7 +448,7 @@ static int rtl9300_i2c_probe(struct plat
+ 		adap->retries = 3;
+ 		adap->dev.parent = dev;
+ 		i2c_set_adapdata(adap, chan);
+-		adap->dev.of_node = to_of_node(child);
++		adap->dev.of_node = child;
+ 		snprintf(adap->name, sizeof(adap->name), "%s SDA%d\n", dev_name(dev), sda_num);
+ 		i++;
+ 

--- a/target/linux/realtek/patches-6.18/100-rtl9300-i2c-add-more-speeds.patch
+++ b/target/linux/realtek/patches-6.18/100-rtl9300-i2c-add-more-speeds.patch
@@ -37,7 +37,7 @@ Signed-off-by: Jan Kantert <jan-kernel@kantert.net>
  struct rtl9300_i2c;
  
  struct rtl9300_i2c_chan {
-@@ -434,6 +440,12 @@ static int rtl9300_i2c_probe(struct plat
+@@ -433,6 +439,12 @@ static int rtl9300_i2c_probe(struct plat
  		case I2C_MAX_FAST_MODE_FREQ:
  			chan->bus_freq = RTL9300_I2C_FAST_FREQ;
  			break;


### PR DESCRIPTION
Backport 2 patches from [1] that cleanup the i2c-rtl9300 upstream driver. They have been long accepted and are already in mainline kernel as of 7.0-rc1.
This backport is required for upcoming upstream patches for rtl9607c support.

CC: @neheb 

[1] - https://lore.kernel.org/linux-i2c/20251217063027.37987-1-rosenp@gmail.com/