### PR TITLE
[25.12] ath79: Mikrotik RB750r2: fix DEVICE_PACKAGES

### DIFF
--- a/target/linux/ath79/image/mikrotik.mk
+++ b/target/linux/ath79/image/mikrotik.mk
@@ -24,7 +24,7 @@ define Device/mikrotik_routerboard-750-r2
   $(Device/mikrotik_nor)
   SOC := qca9533
   DEVICE_MODEL := RouterBOARD 750 r2 (hEX lite)
-  DEVICE_PACKAGES := -kmod-ath9k -wpad-basic-mbedtls
+  DEVICE_PACKAGES += -kmod-ath9k -wpad-basic-mbedtls
   IMAGE_SIZE := 16256k
   SUPPORTED_DEVICES += rb-750-r2
 endef


### PR DESCRIPTION
cherry pick dfbaf846501b1f17d4ac916bb87ad84773414ed8 to fix #22475 (13fd9a9ce037a877f9f6f4117b5a524811b2fbee)

(from [here](https://github.com/openwrt/openwrt/pull/22134#issuecomment-3951953448))
