### PR TITLE
uboot-envtools: add u-boot-env for EX5601/WX5600

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -55,9 +55,7 @@ tplink,tl-xdr6088|\
 tplink,tl-xtr8488|\
 xiaomi,mi-router-ax3000t-ubootmod|\
 xiaomi,mi-router-wr30u-ubootmod|\
-xiaomi,redmi-router-ax6000-ubootmod|\
-zyxel,ex5601-t0-ubootmod|\
-zyxel,wx5600-t0-ubootmod)
+xiaomi,redmi-router-ax6000-ubootmod)
 	ubootenv_add_ubi_default
 	;;
 acer,predator-w6|\
@@ -158,6 +156,11 @@ xiaomi,redmi-router-ax6000-stock)
 	;;
 zyxel,ex5601-t0)
 	ubootenv_add_mtd "u-boot-env" "0x0" "0x20000" "0x40000" "2"
+	;;
+zyxel,ex5601-t0-ubootmod|\
+zyxel,wx5600-t0-ubootmod)
+	ubootenv_add_ubi_default
+	ubootenv_add_sys_mtd "u-boot-env" "0x0" "0x20000" "0x40000" "2"
 	;;
 zyxel,ex5700-telenor)
 	ubootenv_add_uci_config "/dev/ubootenv" "0x0" "0x4000" "0x4000" "1"


### PR DESCRIPTION
Add ability to read u-boot-env partition as sys env for Zyxel EX5601 and WX5600 with custom partitions.
