### PR TITLE
realtek: fix 6.18 issues with Aquantia PHY

### DIFF
--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-a1.dts
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-a1.dts
@@ -38,3 +38,15 @@
 		#thermal-sensor-cells = <0>;
 	};
 };
+
+&port24 {
+	managed = "in-band-status";
+};
+
+&port25 {
+	managed = "in-band-status";
+};
+
+&port26 {
+	managed = "in-band-status";
+};

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
@@ -260,97 +260,20 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		port@0 {
-			reg = <0>;
-			label = "lan1";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy0>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@1 {
-			reg = <1>;
-			label = "lan2";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy1>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@2 {
-			reg = <2>;
-			label = "lan3";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy2>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@3 {
-			reg = <3>;
-			label = "lan4";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy3>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@4 {
-			reg = <4>;
-			label = "lan5";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy4>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@5 {
-			reg = <5>;
-			label = "lan6";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy5>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@6 {
-			reg = <6>;
-			label = "lan7";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy6>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
-		port@7 {
-			reg = <7>;
-			label = "lan8";
-			pcs-handle = <&serdes2>;
-			phy-handle = <&phy7>;
-			phy-mode = "usxgmii";
-			led-set = <0>;
-		};
+		SWITCH_PORT_LED(0, 1, 2, 0, usxgmii)
+		SWITCH_PORT_LED(1, 2, 2, 0, usxgmii)
+		SWITCH_PORT_LED(2, 3, 2, 0, usxgmii)
+		SWITCH_PORT_LED(3, 4, 2, 0, usxgmii)
+		SWITCH_PORT_LED(4, 5, 2, 0, usxgmii)
+		SWITCH_PORT_LED(5, 6, 2, 0, usxgmii)
+		SWITCH_PORT_LED(6, 7, 2, 0, usxgmii)
+		SWITCH_PORT_LED(7, 8, 2, 0, usxgmii)
 
-		port@24 {
-			reg = <24>;
-			label = "lan9";
-			pcs-handle = <&serdes6>;
-			phy-handle = <&phy24>;
-			phy-mode = "usxgmii";
-			led-set = <1>;
-		};
-		port@25 {
-			reg = <25>;
-			label = "lan10";
-			pcs-handle = <&serdes7>;
-			phy-handle = <&phy25>;
-			phy-mode = "usxgmii";
-			led-set = <1>;
-		};
-		port@26 {
-			reg = <26>;
-			label = "lan11";
-			pcs-handle = <&serdes8>;
-			phy-handle = <&phy26>;
-			phy-mode = "usxgmii";
-			led-set = <1>;
-		};
-
-		port@27 {
+		SWITCH_PORT_LED(24, 9, 6, 1, usxgmii)
+		SWITCH_PORT_LED(25, 10, 7, 1, usxgmii)
+		SWITCH_PORT_LED(26, 11, 8, 1, usxgmii)
+		
+		port27: port@27 {
 			reg = <27>;
 			label = "lan12";
 			pcs-handle = <&serdes9>;


### PR DESCRIPTION
This series addresses an issue coming up with Zyxel XGS1250-12 A1 when using the 6.18 testing kernel. This device uses Aquantia AQR113C PHYs on the 10G copper ports.

In 6.18, upstream changed the Aquantia driver to report inband signalling capabilities and configure them accordingly [1]. This affects USXGMII signalling/autoneg. This driver reports to support both cases with AN on and AN off, and the kernel then prefers AN off and using outband signalling. However, our RTL93xx doesn't support this yet. This causes a non-working link on affected devices. The link comes up but no traffic passes.

We can turn off USXGMII-AN but some pieces are still missing to make the link actually work. While that is missing, force the Aquantia PHYs to use inband signalling instead of outband. This seems like a better temporary fix than reverting the upstream change. It also works on 6.12.

As a supporting patch, switch the XGS1250-12 DTS to use the recently added SWITCH_PORT_LED macro.

[1] https://github.com/torvalds/linux/commit/5d59109d47c00e3e98aba612529b3871e69efb9d