### PR TITLE
lantiq: fix u-boot env size for Netgear DGN3500

### DIFF
--- a/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_netgear_dgn3500.dtsi
+++ b/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/ar9_netgear_dgn3500.dtsi
@@ -177,6 +177,7 @@
 
 				nvmem-layout {
 					compatible = "u-boot,env";
+					env-size = <0x1000>;
 
 					macaddr_uboot_ethaddr: ethaddr {
 						#nvmem-cell-cells = <1>;


### PR DESCRIPTION
Correct u-boot env size to fix ethernet driver probe defer.

Fixes: https://github.com/openwrt/openwrt/issues/22692
Fixes: 75b9fae0c338 ("lantiq: dgn3500: use nvmem to load calibration")

cc @Lugaresi
