### PR TITLE
rockchip: add reset button support for NanoPi R5S LTS

### DIFF
--- a/target/linux/rockchip/patches-6.12/011-v6.17-arm64-dts-rockchip-Add-reset-button-to-NanoPi-R5S.patch
+++ b/target/linux/rockchip/patches-6.12/011-v6.17-arm64-dts-rockchip-Add-reset-button-to-NanoPi-R5S.patch
@@ -1,0 +1,52 @@
+From 954f07012794a3aa7ae89e56f070eaa1643af50b Mon Sep 17 00:00:00 2001
+From: Diederik de Haas <didi.debian@cknow.org>
+Date: Fri, 11 Jul 2025 16:20:37 +0200
+Subject: [PATCH] arm64: dts: rockchip: Add reset button to NanoPi R5S
+
+The NanoPi R5S LTS version has a reset button, which is connected via
+GPIO. Note that the non-LTS version does not have the reset button and
+therefore on page 19 of the schematic version 2204 it is marked 'NC',
+but it is connected on the LTS version.
+
+Link: https://lore.kernel.org/r/20250711142138.197445-1-didi.debian@cknow.org
+Signed-off-by: Diederik de Haas <didi.debian@cknow.org>
+Signed-off-by: Heiko Stuebner <heiko@sntech.de>
+---
+ arch/arm64/boot/dts/rockchip/rk3568-nanopi-r5s.dts | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3568-nanopi-r5s.dts
++++ b/arch/arm64/boot/dts/rockchip/rk3568-nanopi-r5s.dts
+@@ -17,6 +17,19 @@
+ 		ethernet0 = &gmac0;
+ 	};
+ 
++	gpio-keys {
++		compatible = "gpio-keys";
++		pinctrl-0 = <&gpio4_a0_k1_pin>;
++		pinctrl-names = "default";
++
++		button-reset {
++			debounce-interval = <50>;
++			gpios = <&gpio4 RK_PA0 GPIO_ACTIVE_LOW>;
++			label = "RESET";
++			linux,code = <KEY_RESTART>;
++		};
++	};
++
+ 	gpio-leds {
+ 		compatible = "gpio-leds";
+ 		pinctrl-names = "default";
+@@ -116,6 +129,12 @@
+ 		};
+ 	};
+ 
++	gpio-keys {
++		gpio4_a0_k1_pin: gpio4-a0-k1-pin {
++			rockchip,pins = <4 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
++		};
++	};
++
+ 	gpio-leds {
+ 		lan1_led_pin: lan1-led-pin {
+ 			rockchip,pins = <3 RK_PD6 RK_FUNC_GPIO &pcfg_pull_none>;

--- a/target/linux/rockchip/patches-6.12/110-arm64-dts-rockchip-Update-LED-properties-for-NanoPi-.patch
+++ b/target/linux/rockchip/patches-6.12/110-arm64-dts-rockchip-Update-LED-properties-for-NanoPi-.patch
@@ -21,7 +21,7 @@ Signed-off-by: Tianling Shen <cnsztl@gmail.com>
  
 --- a/arch/arm64/boot/dts/rockchip/rk3568-nanopi-r5s.dts
 +++ b/arch/arm64/boot/dts/rockchip/rk3568-nanopi-r5s.dts
-@@ -39,7 +39,6 @@
+@@ -52,7 +52,6 @@
  		power_led: led-power {
  			color = <LED_COLOR_ID_RED>;
  			function = LED_FUNCTION_POWER;


### PR DESCRIPTION
This backports upstream commit 954f07012794
("arm64: dts: rockchip: Add reset button to NanoPi R5S").
Link: https://lore.kernel.org/r/20250711142138.197445-1-didi.debian@cknow.org

The NanoPi R5S LTS variant has a reset button wired to GPIO4_A0,
but the current OpenWrt rockchip DTS for rk3568-nanopi-r5s lacks
the corresponding gpio-keys node, so pressing the button produces
no reset/failsafe event.

rockchip already ships kmod-gpio-button-hotplug by default, so
this restores the expected reset button behavior.

The non-LTS NanoPi R5S leaves this pin unconnected, which matches
the upstream rationale.