### PR TITLE
wolfssl: allow enabling RISC-V assembler optimization

### DIFF
--- a/package/libs/wolfssl/Makefile
+++ b/package/libs/wolfssl/Makefile
@@ -88,7 +88,7 @@ define Package/libwolfsslcpu-crypto
 $(call Package/libwolfssl/Default)
   TITLE:=wolfSSL library with AES CPU instructions
   PROVIDES:=libwolfssl libcyassl
-  DEPENDS:=@((aarch64||x86_64)&&(m||!TARGET_bcm27xx))
+  DEPENDS:=@((aarch64||x86_64||riscv64)&&(m||!TARGET_bcm27xx))
   ABI_VERSION:=$(PKG_ABI_VERSION)
   VARIANT:=cpu-crypto
 endef
@@ -101,7 +101,7 @@ endef
 
 define Package/libwolfsslcpu-crypto/description
 $(call Package/libwolfssl/description)
-This variant uses AES CPU instructions (Intel AESNI or ARMv8 Crypto Extension)
+This variant uses AES CPU instructions (Intel AESNI, ARMv8 Crypto Extension or RISC-V ASM)
 endef
 
 define Package/libwolfsslcpu-crypto/config
@@ -192,6 +192,8 @@ else ifdef CONFIG_aarch64
     Package/libwolfsslcpu-crypto/preinst=$(Package/libwolfsslcpu-crypto/preinst-aarch64)
 else ifdef CONFIG_TARGET_x86_64
 	CONFIGURE_ARGS += --enable-intelasm
+else ifdef CONFIG_riscv64
+	CONFIGURE_ARGS += --enable-riscv-asm
 endif
 
 ifeq ($(CONFIG_WOLFSSL_HAS_OCSP),y)


### PR DESCRIPTION
wolfssl implemented AES ECB/CBC/CTR/GCM/CCM in RISC-V assembler, achieving massive speed improvements on boards with such CPUs.

Benchmarking on a Sifive Unleashed (oldest Linux-capable RISC-V board), results are:

No optimization:
wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
RNG                         10 MiB took 1.772 seconds,    5.644 MiB/s
AES-128-CBC-enc              5 MiB took 16.264 seconds,    0.307 MiB/s
AES-128-CBC-dec              5 MiB took 16.314 seconds,    0.306 MiB/s
AES-192-CBC-enc              5 MiB took 19.460 seconds,    0.257 MiB/s
AES-192-CBC-dec              5 MiB took 19.480 seconds,    0.257 MiB/s
AES-256-CBC-enc              5 MiB took 22.633 seconds,    0.221 MiB/s
AES-256-CBC-dec              5 MiB took 22.715 seconds,    0.220 MiB/s
AES-128-GCM-enc              5 MiB took 16.324 seconds,    0.306 MiB/s
AES-128-GCM-dec              5 MiB took 16.450 seconds,    0.304 MiB/s
AES-192-GCM-enc              5 MiB took 19.487 seconds,    0.257 MiB/s
AES-192-GCM-dec              5 MiB took 19.621 seconds,    0.255 MiB/s
AES-256-GCM-enc              5 MiB took 22.644 seconds,    0.221 MiB/s
AES-256-GCM-dec              5 MiB took 22.805 seconds,    0.219 MiB/s
[...]

Enabled optimization:
wolfCrypt Benchmark (block bytes 1048576, min 1.0 sec each)
RNG                         10 MiB took 1.459 seconds,    6.855 MiB/s
AES-128-CBC-enc             15 MiB took 1.028 seconds,   14.592 MiB/s
AES-128-CBC-dec             15 MiB took 1.006 seconds,   14.916 MiB/s
AES-192-CBC-enc             15 MiB took 1.187 seconds,   12.634 MiB/s
AES-192-CBC-dec             15 MiB took 1.180 seconds,   12.713 MiB/s
AES-256-CBC-enc             15 MiB took 1.359 seconds,   11.037 MiB/s
AES-256-CBC-dec             15 MiB took 1.352 seconds,   11.096 MiB/s
AES-128-GCM-enc             10 MiB took 1.140 seconds,    8.769 MiB/s
AES-128-GCM-dec             10 MiB took 1.140 seconds,    8.770 MiB/s
AES-192-GCM-enc             10 MiB took 1.256 seconds,    7.963 MiB/s
AES-192-GCM-dec             10 MiB took 1.261 seconds,    7.931 MiB/s
AES-256-GCM-enc             10 MiB took 1.373 seconds,    7.285 MiB/s
AES-256-GCM-dec             10 MiB took 1.371 seconds,    7.291 MiB/s
[...]

HMAC- and SHA- functions also have significant improvements.