### PR TITLE
kernel: tune 24kc instead of 34kc for mips32r2

### DIFF
--- a/target/linux/generic/pending-6.12/308-mips32r2_tune.patch
+++ b/target/linux/generic/pending-6.12/308-mips32r2_tune.patch
@@ -1,5 +1,5 @@
 From: Felix Fietkau <nbd@nbd.name>
-Subject: kernel: add -mtune=34kc to MIPS CFLAGS when building for mips32r2
+Subject: kernel: add -mtune=24kc to MIPS CFLAGS when building for mips32r2
 
 This provides a good tradeoff across at least 24Kc-74Kc, while also
 producing smaller code.
@@ -16,7 +16,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  cflags-$(CONFIG_CPU_TX49XX)	+= $(call cc-option,-march=r4600,-march=mips3) -Wa,--trap
  cflags-$(CONFIG_CPU_MIPS32_R1)	+= -march=mips32 -Wa,--trap
 -cflags-$(CONFIG_CPU_MIPS32_R2)	+= -march=mips32r2 -Wa,--trap
-+cflags-$(CONFIG_CPU_MIPS32_R2)	+= -march=mips32r2 -mtune=34kc -Wa,--trap
++cflags-$(CONFIG_CPU_MIPS32_R2)	+= -march=mips32r2 -mtune=24kc -Wa,--trap
  cflags-$(CONFIG_CPU_MIPS32_R5)	+= -march=mips32r5 -Wa,--trap -modd-spreg
  cflags-$(CONFIG_CPU_MIPS32_R6)	+= -march=mips32r6 -Wa,--trap -modd-spreg
  cflags-$(CONFIG_CPU_MIPS64_R1)	+= -march=mips64 -Wa,--trap

--- a/target/linux/generic/pending-6.18/308-mips32r2_tune.patch
+++ b/target/linux/generic/pending-6.18/308-mips32r2_tune.patch
@@ -1,5 +1,5 @@
 From: Felix Fietkau <nbd@nbd.name>
-Subject: kernel: add -mtune=34kc to MIPS CFLAGS when building for mips32r2
+Subject: kernel: add -mtune=24kc to MIPS CFLAGS when building for mips32r2
 
 This provides a good tradeoff across at least 24Kc-74Kc, while also
 producing smaller code.
@@ -16,7 +16,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  cflags-$(CONFIG_CPU_TX49XX)	+= $(call cc-option,-march=r4600,-march=mips3) -Wa,--trap
  cflags-$(CONFIG_CPU_MIPS32_R1)	+= -march=mips32 -Wa,--trap
 -cflags-$(CONFIG_CPU_MIPS32_R2)	+= -march=mips32r2 -Wa,--trap
-+cflags-$(CONFIG_CPU_MIPS32_R2)	+= -march=mips32r2 -mtune=34kc -Wa,--trap
++cflags-$(CONFIG_CPU_MIPS32_R2)	+= -march=mips32r2 -mtune=24kc -Wa,--trap
  cflags-$(CONFIG_CPU_MIPS32_R5)	+= -march=mips32r5 -Wa,--trap -modd-spreg
  cflags-$(CONFIG_CPU_MIPS32_R6)	+= -march=mips32r6 -Wa,--trap -modd-spreg
  cflags-$(CONFIG_CPU_MIPS64_R1)	+= -march=mips64 -Wa,--trap

--- a/target/linux/realtek/patches-6.12/308-tune-switch-4kec.patch
+++ b/target/linux/realtek/patches-6.12/308-tune-switch-4kec.patch
@@ -2,7 +2,7 @@ From: Markus Stockhausen <markus.stockhausen@gmx.de>
 Date: Fri, 13 Jun 2025 20:25:37 +0100
 Subject: [PATCH] realtek: set mtune 4kec for RTL838x targets
 
-Generic patches will always force the gcc kernel tuning to 34kc. With RTL838x 
+Generic patches will always force the gcc kernel tuning to 24kc. With RTL838x 
 being only 4kec this does not harm but is not right. Match the tuning properly.
 
 Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
@@ -13,10 +13,10 @@ Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
 @@ -164,6 +164,11 @@ cflags-$(CONFIG_CPU_R4X00)	+= $(call cc-
  cflags-$(CONFIG_CPU_TX49XX)	+= $(call cc-option,-march=r4600,-march=mips3) -Wa,--trap
  cflags-$(CONFIG_CPU_MIPS32_R1)	+= -march=mips32 -Wa,--trap
- cflags-$(CONFIG_CPU_MIPS32_R2)	+= -march=mips32r2 -mtune=34kc -Wa,--trap
+ cflags-$(CONFIG_CPU_MIPS32_R2)	+= -march=mips32r2 -mtune=24kc -Wa,--trap
 +
 +#ifdef CONFIG_RTL838X
-+cflags-$(CONFIG_CPU_MIPS32_R2) := $(subst 34kc,4kec,$(cflags-$(CONFIG_CPU_MIPS32_R2)))
++cflags-$(CONFIG_CPU_MIPS32_R2) := $(subst 24kc,4kec,$(cflags-$(CONFIG_CPU_MIPS32_R2)))
 +#endif
 +
  cflags-$(CONFIG_CPU_MIPS32_R5)	+= -march=mips32r5 -Wa,--trap -modd-spreg

--- a/target/linux/realtek/patches-6.18/308-tune-switch-4kec.patch
+++ b/target/linux/realtek/patches-6.18/308-tune-switch-4kec.patch
@@ -2,7 +2,7 @@ From: Markus Stockhausen <markus.stockhausen@gmx.de>
 Date: Fri, 13 Jun 2025 20:25:37 +0100
 Subject: [PATCH] realtek: set mtune 4kec for RTL838x targets
 
-Generic patches will always force the gcc kernel tuning to 34kc. With RTL838x 
+Generic patches will always force the gcc kernel tuning to 24kc. With RTL838x 
 being only 4kec this does not harm but is not right. Match the tuning properly.
 
 Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
@@ -13,10 +13,10 @@ Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
 @@ -160,6 +160,11 @@ cflags-$(CONFIG_CPU_R4X00)	+= $(call cc-
  cflags-$(CONFIG_CPU_TX49XX)	+= $(call cc-option,-march=r4600,-march=mips3) -Wa,--trap
  cflags-$(CONFIG_CPU_MIPS32_R1)	+= -march=mips32 -Wa,--trap
- cflags-$(CONFIG_CPU_MIPS32_R2)	+= -march=mips32r2 -mtune=34kc -Wa,--trap
+ cflags-$(CONFIG_CPU_MIPS32_R2)	+= -march=mips32r2 -mtune=24kc -Wa,--trap
 +
 +#ifdef CONFIG_RTL838X
-+cflags-$(CONFIG_CPU_MIPS32_R2) := $(subst 34kc,4kec,$(cflags-$(CONFIG_CPU_MIPS32_R2)))
++cflags-$(CONFIG_CPU_MIPS32_R2) := $(subst 24kc,4kec,$(cflags-$(CONFIG_CPU_MIPS32_R2)))
 +#endif
 +
  cflags-$(CONFIG_CPU_MIPS32_R5)	+= -march=mips32r5 -Wa,--trap -modd-spreg


### PR DESCRIPTION
GCC generates the same code for 24kc and 34kc. Since we have converted all 34kc targets to the 24kc, it's better to switch kernel -mtune to 24kc to avoid confusing developers.

cc @KanjiMonster @neheb