### PR TITLE
build: increase x86 default optimization level to -O2

### DIFF
--- a/include/target.mk
+++ b/include/target.mk
@@ -233,6 +233,7 @@ ifeq ($(DUMP),1)
   endif
   ifeq ($(ARCH),i386)
     CPU_TYPE ?= pentium-mmx
+    CPU_CFLAGS := -O2 -pipe
     CPU_CFLAGS_pentium-mmx = -march=pentium-mmx
     CPU_CFLAGS_pentium4 = -march=pentium4
   endif


### PR DESCRIPTION
The x86 targets are not sensitive to the code size. The higher GCC optimization level can help generate more efficient code on these CISC CPUs.

I didn't test this at all. Maybe @graysky2 are interested in this.