### PR TITLE
ath79: ar7161: swap phy0 and phy1

### DIFF
--- a/target/linux/ath79/dts/ar7161_adtran_bsap1880.dtsi
+++ b/target/linux/ath79/dts/ar7161_adtran_bsap1880.dtsi
@@ -24,13 +24,13 @@
 		wlan5g {
 			label = "green:wifi5g";
 			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan2g {
 			label = "green:wifi2g";
 			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
+			linux,default-trigger = "phy1tpt";
 		};
 
 		led_status_green: status_green {

--- a/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
+++ b/target/linux/ath79/dts/ar7161_buffalo_wzr-hp-ag300h.dtsi
@@ -41,13 +41,13 @@
 		band2g_g {
 			label = "green:band2g";
 			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
+			linux,default-trigger = "phy1tpt";
 		};
 
 		band5g_g {
 			label = "green:band5g";
 			gpios = <&ath9k1 1 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "phy0tpt";
 		};
 
 		router {

--- a/target/linux/ath79/dts/ar7161_fortinet_fap-220-b.dts
+++ b/target/linux/ath79/dts/ar7161_fortinet_fap-220-b.dts
@@ -69,25 +69,25 @@
 		wlan2g-green {
 			label = "green:wlan2g";
 			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan2g-yellow {
 			label = "yellow:wlan2g";
 			gpios = <&ath9k0 3 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0assoc";
+			linux,default-trigger = "phy1assoc";
 		};
 
 		wlan5g-green {
 			label = "green:wlan5g";
 			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "phy0tpt";
 		};
 
 		wlan5g-yellow {
 			label = "yellow:wlan5g";
 			gpios = <&ath9k1 3 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1assoc";
+			linux,default-trigger = "phy0assoc";
 		};
 	};
 

--- a/target/linux/ath79/dts/ar7161_netgear_wndr.dtsi
+++ b/target/linux/ath79/dts/ar7161_netgear_wndr.dtsi
@@ -67,12 +67,12 @@
 		wlan2g {
 			label = "green:wlan2g";
 			gpios = <&ath9k0 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy0tpt";
+			linux,default-trigger = "phy1tpt";
 		};
 		wlan5g {
 			label = "blue:wlan5g";
 			gpios = <&ath9k1 5 GPIO_ACTIVE_LOW>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 

--- a/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
+++ b/target/linux/ath79/dts/ar7161_ruckus_gd11.dtsi
@@ -57,25 +57,25 @@
 		wlan2g-green {
 			label = "green:wlan2g";
 			gpios = <&gpio 2 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy0assoc";
+			linux,default-trigger = "phy1assoc";
 		};
 
 		wlan2g-yellow {
 			label = "yellow:wlan2g";
 			gpios = <&gpio 3 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy0tpt";
+			linux,default-trigger = "phy1tpt";
 		};
 
 		wlan5g-green {
 			label = "green:wlan5g";
 			gpios = <&gpio 4 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy1assoc";
+			linux,default-trigger = "phy0assoc";
 		};
 
 		wlan5g-yellow {
 			label = "yellow:wlan5g";
 			gpios = <&gpio 5 GPIO_ACTIVE_HIGH>;
-			linux,default-trigger = "phy1tpt";
+			linux,default-trigger = "phy0tpt";
 		};
 	};
 


### PR DESCRIPTION
For whatever reason, in the transition from ar71xx to ath79, the second interface ends up as phy0.

Fixes: https://github.com/openwrt/openwrt/issues/22666 https://github.com/openwrt/openwrt/issues/9290

ping @robimarko 