### PR TITLE
wireguard-tools: increase watchdog idle timeout to 180s

### DIFF
--- a/package/network/utils/wireguard-tools/files/wireguard_watchdog
+++ b/package/network/utils/wireguard-tools/files/wireguard_watchdog
@@ -53,7 +53,7 @@ check_peer_activity() {
   last_handshake=$(wg show ${iface} latest-handshakes | grep ${public_key} | awk '{print $2}')
   [ -z ${last_handshake} ] && return 0;
   idle_seconds=$(($(date +%s)-${last_handshake}))
-  [ ${idle_seconds} -lt 150 ] && return 0;
+  [ ${idle_seconds} -lt 180 ] && return 0;
   logger -t "wireguard_monitor" "${iface} endpoint ${endpoint_host}:${endpoint_port} is not responding for ${idle_seconds} seconds, trying to re-resolve hostname"
   wg set ${iface} peer ${public_key} endpoint "${endpoint_host}:${endpoint_port}"
 }


### PR DESCRIPTION
The current 150s watchdog timeout is too aggressive, leading to  premature hostname re-resolution on alive connections. 

Even with a 25s keepalive, handshakes may not occur within the 150s window. Increasing the timeout to 180s aligns the watchdog with WireGuard's REJECT_AFTER_TIME constant, ensuring we only re-resolve when the connection is truly considered dead.