### PR TITLE
mediatek: filogic: add support for netis MEX6000

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2520,6 +2520,8 @@ define Device/netcore_n60-pro
   DEVICE_ALT0_VENDOR := netis
   DEVICE_ALT0_MODEL := NX62
   DEVICE_ALT0_VARIANT := V1
+  DEVICE_ALT1_VENDOR := netis
+  DEVICE_ALT1_MODEL := MEX6000
   DEVICE_DTS := mt7986a-netcore-n60-pro
   DEVICE_DTS_DIR := ../dts
   UBINIZE_OPTS := -E 5

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2456,6 +2456,8 @@ define Device/netcore_n60-pro
   DEVICE_ALT0_VENDOR := netis
   DEVICE_ALT0_MODEL := NX62
   DEVICE_ALT0_VARIANT := V1
+  DEVICE_ALT1_VENDOR := netis
+  DEVICE_ALT1_MODEL := MEX6000
   DEVICE_DTS := mt7986a-netcore-n60-pro
   DEVICE_DTS_DIR := ../dts
   UBINIZE_OPTS := -E 5


### PR DESCRIPTION
Same hardware as Netcore N60 Pro
[https://netu.co.kr/atboard_view.php?grp1=support&grp2=faq&uid=28373](https://netu.co.kr/atboard_view.php?grp1=support&grp2=faq&uid=28373)

Add:
DEVICE_ALT1_VENDOR := netis
DEVICE_ALT1_MODEL := MEX6000