### PR TITLE
ath79: define wifi for pci168c,0027

### DIFF
--- a/target/linux/ath79/dts/ar7161_adtran_bsap1880.dtsi
+++ b/target/linux/ath79/dts/ar7161_adtran_bsap1880.dtsi
@@ -75,6 +75,16 @@
 
 &pcie0 {
 	status = "okay";
+
+	wifi@11,0 { /* 2.4 GHz */
+		compatible = "pci168c,0027";
+		reg = <0x8800 0 0 0 0>;
+	};
+
+	wifi@12,0 { /* 5 GHz */
+		compatible = "pci168c,0027";
+		reg = <0x9000 0 0 0 0>;
+	};
 };
 
 &spi {

--- a/target/linux/ath79/dts/ar7161_siemens_ws-ap3610.dts
+++ b/target/linux/ath79/dts/ar7161_siemens_ws-ap3610.dts
@@ -69,6 +69,16 @@
 
 &pcie0 {
 	status = "okay";
+
+	wifi@11,0 { /* 2.4 GHz */
+		compatible = "pci168c,0027";
+		reg = <0x8800 0 0 0 0>;
+	};
+
+	wifi@12,0 { /* 5 GHz */
+		compatible = "pci168c,0027";
+		reg = <0x9000 0 0 0 0>;
+	};
 };
 
 &mdio0 {


### PR DESCRIPTION
Document pci168c,0027 for ath79. Will allow potential nvmem updates in the future.

ping @DragonBluep 