### PR TITLE
mediatek: filogic: ASUS RT-AX52 PRO support

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -389,6 +389,8 @@ TARGET_DEVICES += arcadyan_mozart
 define Device/asus_rt-ax52
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AX52
+  DEVICE_ALT0_VENDOR := ASUS
+  DEVICE_ALT0_MODEL := RT-AX52 PRO
   DEVICE_DTS := mt7981b-asus-rt-ax52
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware


### PR DESCRIPTION
This PR backports support OpenWrt for ASUS RT-AX52 PRO v1(also tested on v1.1)
(cherry picked from commit https://github.com/openwrt/openwrt/commit/776a926c25d3d5903df9b596df812ebc7d4f6753):
Commits:
[mediatek: filogic: ASUS RT-AX52 PRO support#21905](https://github.com/openwrt/openwrt/pull/21905/changes/776a926c25d3d5903df9b596df812ebc7d4f6753)
Compile and run tested.
