### PR TITLE
ath79: wndap360: fix ethernet

### DIFF
--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -49,6 +49,8 @@
 &eth0 {
 	status = "okay";
 
+	pll-data = <0x11110000 0x00001099 0x00991099>;
+
 	phy-mode = "rgmii";
 	phy-handle = <&phy1>;
 

--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -10,6 +10,10 @@
 	compatible = "netgear,wndap360", "qca,ar7161";
 	model = "Netgear WNDAP360";
 
+	chosen {
+		/delete-property/ bootargs;
+	};
+
 	aliases {
 		led-boot = &led_power_orange;
 		led-failsafe = &led_power_orange;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -2234,6 +2234,7 @@ define Device/netgear_wndap360
   $(Device/netgear_generic)
   SOC := ar7161
   DEVICE_MODEL := WNDAP360
+  DEVICE_PACKAGES := kmod-owl-loader
   IMAGE_SIZE := 7744k
   BLOCKSIZE := 256k
   KERNEL := kernel-bin | append-dtb | gzip | uImage gzip


### PR DESCRIPTION
Users report pll-data is needed for gigabit speeds.

Fixes: https://github.com/openwrt/openwrt/issues/11025

Needs backport to 25.12.

ping @robimarko 