### PR TITLE
mt76: pass LED define via ccflags-y

### DIFF
--- a/package/kernel/mt76/patches/003-pass-LED-define-via-ccflags-y.patch
+++ b/package/kernel/mt76/patches/003-pass-LED-define-via-ccflags-y.patch
@@ -1,0 +1,26 @@
+From: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+Date: Thu, 2 Apr 2026 19:01:10 +0200
+Subject: Subject: [PATCH] mt76: pass LED define via ccflags-y
+
+Replace the deprecated EXTRA_CFLAGS with ccflags-y so that
+the -DCONFIG_MT76_LEDS define is applied correctly by the kernel
+build system. EXTRA_CFLAGS is no longer honored by recent
+kbuilds[1]; ccflags-y is the supported variable and works
+on kernels 6.12 and 6.18.
+
+1. https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v6.18.20&id=f77bf01425b11947eeb3b5b54685212c302741b8
+
+Signed-off-by: Mieczyslaw Nalewaj <namiltd@yahoo.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,5 @@
+ # SPDX-License-Identifier: BSD-3-Clause-Clear
+-EXTRA_CFLAGS += -Werror -DCONFIG_MT76_LEDS
++ccflags-y += -Werror -DCONFIG_MT76_LEDS
+ obj-m := mt76.o
+ obj-$(CONFIG_MT76_USB) += mt76-usb.o
+ obj-$(CONFIG_MT76_SDIO) += mt76-sdio.o


### PR DESCRIPTION
Replace the deprecated EXTRA_CFLAGS with ccflags-y so that the -DCONFIG_MT76_LEDS define is applied correctly by the kernel build system. EXTRA_CFLAGS is no longer honored by recent kbuilds[1]; ccflags-y is the supported variable and works on kernels 6.12 and 6.18.

1. https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v6.18.20&id=f77bf01425b11947eeb3b5b54685212c302741b8
