### PR TITLE
realtek: fixup Datto L8 device tree

### DIFF
--- a/target/linux/realtek/dts/rtl8380_datto_l8.dts
+++ b/target/linux/realtek/dts/rtl8380_datto_l8.dts
@@ -129,7 +129,7 @@
 };
 
 &switch0 {
-	ports {
+	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
 


### PR DESCRIPTION
`ports` should be `ethernet-ports`, otherwise initialising ethernet ports fails on 6.18 testing kernel.