### PR TITLE
ipq40xx: add support for various cradlepoints

### DIFF
--- a/package/utils/cradlepoint-fstab/Makefile
+++ b/package/utils/cradlepoint-fstab/Makefile
@@ -1,0 +1,37 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=cradlepoint-fstab
+PKG_VERSION:=1.0
+PKG_RELEASE:=1
+
+PKG_LICENSE:=GPL-2.0-or-later
+
+PKG_BUILD_PARALLEL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/cradlepoint-fstab/Default
+	SECTION:=firmware
+	CATEGORY:=Firmware
+	TITLE:=fstab Options for Cradlepoint
+endef
+
+define Build/Compile/Default
+	echo "No build necessary"
+endef
+
+define Package/cradlepoint-fstab-ibr-c
+	$(call Package/cradlepoint-fstab/Default)
+	TITLE+= (ibr-c)
+endef
+
+define Package/cradlepoint-fstab-ibr-c/description
+	Allows auto-mounting of differently named ubifs partition for IBR900.
+endef
+
+define Package/cradlepoint-fstab-ibr-c/install
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) files/ibr-c-nand-fstab $(1)/etc/config/fstab
+endef
+
+$(eval $(call BuildPackage,cradlepoint-fstab-ibr-c))

--- a/package/utils/cradlepoint-fstab/files/ibr-c-nand-fstab
+++ b/package/utils/cradlepoint-fstab/files/ibr-c-nand-fstab
@@ -1,0 +1,13 @@
+config 'global'
+	option  anon_swap       '0'
+	option  anon_mount      '0'
+	option  auto_swap       '1'
+	option  auto_mount      '1'
+	option  delay_root      '5'
+	option  check_fs        '0'
+
+config 'mount'
+	option  target          '/overlay'
+	option  device          '/dev/ubi1_0'
+	option  fstype          'ubifs'
+	option  enabled         '1'

--- a/target/linux/ipq40xx/base-files/etc/board.d/01_leds
+++ b/target/linux/ipq40xx/base-files/etc/board.d/01_leds
@@ -32,6 +32,9 @@ avm,fritzbox-7530)
 	ucidef_set_led_netdev "dsl" "DSL" "green:info" "dsl0"
 	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt"
 	;;
+cradlepoint,ibr900)
+	ucidef_set_led_wlan "wlan" "WLAN" "green:wlan" "phy0tpt" "phy1tpt"
+	;;
 edgecore,oap100)
 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "blue:wlan2g" "phy0tpt"
 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "blue:wlan5g" "phy1tpt"

--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
+++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
@@ -86,6 +86,10 @@ ipq40xx_setup_interfaces()
 	netgear,srs60)
 		ucidef_set_interface_lan "lan1 lan2 lan3 lan4"
 		;;
+	cradlepoint,ibr900)
+		ucidef_set_interfaces_lan_wan "lan" "wan"
+		ucidef_set_interface "wwan" device "/dev/cdc-wdm0" protocol "qmi"
+		;;
 	avm,fritzrepeater-3000|\
 	cellc,rtl30vw|\
 	compex,wpj428|\
@@ -193,6 +197,9 @@ ipq40xx_setup_macs()
 	avm,fritzbox-7530)
 		local tffsdev=$(find_mtd_chardev "nand-tffs")
 		wan_mac=$(/usr/bin/fritz_tffs_nand -b -d $tffsdev -n macdsl)
+		;;
+	cradlepoint,ibr900)
+		label_mac=$(mtd_get_mac_ascii 0:CUSTDATA MAC0)
 		;;
 	devolo,magic-2-wifi-next)
 		lan_mac=$(mtd_get_mac_ascii APPSBLENV MacAddress0)

--- a/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/ipq40xx/base-files/etc/board.d/03_gpio_switches
@@ -21,6 +21,10 @@ cilab,meshpoint-one)
 compex,wpj428)
 	ucidef_add_gpio_switch "sim_card_select" "SIM card select" "3" "0"
 	;;
+cradlepoint,ibr900)
+	ucidef_add_gpio_switch "pwr_en_int1" "Internal Modem Power" "630" "1"
+	ucidef_add_gpio_switch "pwr_en_usb1" "USB Power" "625" "1"
+	;;
 meraki,gx20|\
 meraki,z3)
 	ucidef_add_gpio_switch "lan5_poe_disable" "LAN5 PoE disable" "540" "0"

--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -49,6 +49,12 @@ case "$FIRMWARE" in
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1") || \
 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader1")
 		;;
+	cradlepoint,ibr900)
+		caldata_extract "0:ART" 0x1000 0x2f20
+		# HACK: hardcode this to USA (?)
+		# cradlepoint has a lookup table in firmware to patch on the fly
+		caldata_patch_data "0000" 0xc 0x2
+		;;
 	cellc,rtl30vw)
 		caldata_extract "0:ART" 0x1000 0x2f20
 		;;
@@ -137,6 +143,12 @@ case "$FIRMWARE" in
 		;;
 	cellc,rtl30vw)
 		caldata_extract "0:ART" 0x5000 0x2f20
+		;;
+	cradlepoint,ibr900)
+		caldata_extract "0:ART" 0x5000 0x2f20
+		# HACK: hardcode this to USA (?)
+		# cradlepoint has a lookup table in firmware to patch on the fly
+		caldata_patch_data "0000" 0xc 0x2
 		;;
 	devolo,magic-2-wifi-next)
 		caldata_extract "ART" 0x5000 0x2f20

--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
@@ -132,6 +132,11 @@ platform_do_upgrade() {
 	wallys,dr40x9)
 		nand_do_upgrade "$1"
 		;;
+	cradlepoint,ibr900)
+		CI_KERNPART="kernel"
+		CI_ROOTPART="ubi_rootfs"
+		nand_do_upgrade "$1"
+		;;
 	alfa-network,ap120c-ac)
 		part="$(awk -F 'ubi.mtd=' '{printf $2}' /proc/cmdline | sed -e 's/ .*$//')"
 		if [ "$part" = "rootfs1" ]; then

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-ibr-c.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-ibr-c.dtsi
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* Copyright (c) 2025-2026 Natalie Moore <natalie@natalielucy.dev> */
+/* Copyright (c) 2025 P. McDonnell <support@ipfm.systems> */
+
+#include "qcom-ipq4019.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/soc/qcom,tcsr.h>
+
+/ {
+	aliases {
+		led-failsafe = &led_attn_red;
+		led-upgrade = &led_attn_red;
+		label-mac-device = &gmac;
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x80000000 0x10000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		ranges;
+
+		rsvd1@87000000 {
+			reg = <0x87000000 0x500000>;
+			no-map;
+		};
+
+		wifi_dump@87500000 {
+			reg = <0x87500000 0x600000>;
+			no-map;
+		};
+
+		rsvd2@87B00000 {
+			reg = <0x87b00000 0x500000>;
+			no-map;
+		};
+	};
+
+	chosen {
+		bootargs-append = " ubi.mtd=ubi ubi.mtd=Filesystem ubi.block=0,1 root=/dev/ubiblock0_1";
+	};
+
+	soc {
+		ess_tcsr@1953000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1953000 0x1000>;
+			qcom,ess-interface-select = <TCSR_ESS_PSGMII>;
+		};
+
+		tcsr@1949000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1949000 0x100>;
+			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
+		};
+
+		tcsr@1957000 {
+			compatible = "qcom,tcsr";
+			reg = <0x1957000 0x100>;
+			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
+		};
+	};
+
+	/* SW I2C Expander */
+	i2c-gpio {
+		compatible = "i2c-gpio";
+
+		sda-gpios = <&tlmm 1 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&tlmm 0 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+
+		i2c-gpio,delay-us = <0x02>;
+
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+
+		status = "okay";
+
+		expander1: gpio@22 {
+			compatible = "ti,tca6424";
+			reg = <0x22>;
+			gpio-controller;
+			#gpio-cells = <0x02>;
+
+			interrupts = <0x3f 0x00>;
+			interrupt-parent = <&tlmm>;
+
+			status = "okay";
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 58 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	gpio_export {
+		compatible = "gpio-export";
+
+		conn_ign_sense {
+			gpio-export,name = "conn_ign_sense";
+			gpio-export,input = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 5 GPIO_ACTIVE_LOW>;
+		};
+
+		sata_ign_sense {
+			gpio-export,name = "sata_ign_sense";
+			gpio-export,input = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 4 GPIO_ACTIVE_LOW>;
+		};
+
+		pwr_off_toggle {
+			gpio-export,name = "pwr_off_toggle";
+			gpio-export,output = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&tlmm 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		pwr_en_int1 {
+			gpio-export,name = "pwr_en_int1";
+			gpio-export,output = <1>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&expander1 18 GPIO_ACTIVE_HIGH>;
+		};
+
+		pwr_off_latch {
+			gpio-export,name = "pwr_off_latch";
+			gpio-export,output = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&expander1 10 GPIO_ACTIVE_HIGH>;
+		};
+
+		pwr_en_usb1 {
+			gpio-export,name = "pwr_en_usb1";
+			gpio-export,output = <1>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&expander1 13 GPIO_ACTIVE_HIGH>;
+		};
+
+		conn_output {
+			gpio-export,name = "conn_output";
+			gpio-export,output = <0>;
+			gpio-export,direction_may_change = <0>;
+			gpios = <&expander1 7 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_ss_0_blue: led-7 {
+			gpios = <&expander1 0 GPIO_ACTIVE_LOW>;
+			label = "blue:ss_0";
+		};
+
+		led_ss_1_blue: led-8 {
+			gpios = <&expander1 1 GPIO_ACTIVE_LOW>;
+			label = "blue:ss_1";
+		};
+
+		led_ss_2_blue: led-9 {
+			gpios = <&expander1 2 GPIO_ACTIVE_LOW>;
+			label = "blue:ss_2";
+		};
+
+		led_ss_3_blue: led-10 {
+			gpios = <&expander1 3 GPIO_ACTIVE_LOW>;
+			label = "blue:ss_3";
+		};
+
+		led_attn_red: led-11 {
+			gpios = <&expander1 4 GPIO_ACTIVE_LOW>;
+			label = "red:attn";
+		};
+
+		led_gps_blue: led-12 {
+			gpios = <&expander1 5 GPIO_ACTIVE_LOW>;
+			label = "blue:gps";
+		};
+
+		led_wlan_green: led-13 {
+			gpios = <&expander1 6 GPIO_ACTIVE_LOW>;
+			label = "green:wlan";
+		};
+
+		led_int_modem_green: led-15 {
+			gpios = <&expander1 15 GPIO_ACTIVE_LOW>;
+			label = "green:int_modem";
+		};
+
+		led_int_modem_red: led-16 {
+			gpios = <&expander1 14 GPIO_ACTIVE_LOW>;
+			label = "red:int_modem";
+		};
+	};
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&blsp_dma {
+	status = "okay";
+};
+
+&blsp1_uart1 {
+	status = "okay";
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+};
+
+&blsp1_spi1 {
+	status = "okay";
+
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	cs-gpios = <&tlmm 54 GPIO_ACTIVE_HIGH>,
+			   <&tlmm 59 GPIO_ACTIVE_HIGH>;
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <24000000>;
+		reg = <0>;
+
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition0@0 {
+				label = "0:SBL1";
+				reg = <0x00000000 0x00040000>;
+				read-only;
+			};
+
+			partition1@60000 {
+				label = "0:QSEE";
+				reg = <0x00060000 0x00060000>;
+				read-only;
+			};
+
+			partition2@e0000 {
+				label = "0:APPSBLENV"; /* uboot env */
+				reg = <0x000e0000 0x00010000>;
+				read-only;
+			};
+
+			partition3@f0000 {
+				label = "0:APPSBL"; /* uboot */
+				reg = <0x000f0000 0x00080000>;
+				read-only;
+			};
+
+			partition4@170000 {
+				label = "0:ART";
+				reg = <0x00170000 0x00010000>;
+				read-only;
+			};
+
+			partition5@180000 {
+				label = "0:CUSTDATA";
+				reg = <0x00180000 0x00010000>;
+				read-only;
+			};
+
+			partition6@190000 {
+				label = "Filemanager";
+				reg = <0x00190000 0x00040000>;
+				read-only;
+			};
+
+			partition7@1d0000 {
+				label = "2nd Filemanager";
+				reg = <0x001d0000 0x00040000>;
+				read-only;
+			};
+		};
+	};
+
+	nand@1 {
+		compatible = "spi-nand", "spinand,mt29f";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <1>;
+		spi-max-frequency = <24000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition0@0 {
+				label = "ubi";
+				reg = <0x00000000 0x01f00000>;
+			};
+
+			partition1@3800000 {
+				label = "Upgrade";
+				reg = <0x01f00000 0x01f00000>;
+			};
+
+			partition2@7000000 {
+				label = "Filesystem";
+				reg = <0x03e00000 0x0C200000>;
+			};
+		};
+	};
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&tlmm {
+	mdio_pins: mdio_pinmux {
+		mux_1 {
+			pins = "gpio53";
+			function = "mdio";
+			bias-pull-up;
+		};
+		mux_2 {
+			pins = "gpio52";
+			function = "mdc";
+			bias-pull-up;
+		};
+	};
+
+	spi_0_pins: spi_0_pinmux {
+		pin {
+			function = "blsp_spi0";
+			pins = "gpio55", "gpio56", "gpio57";
+			drive-strength = <12>;
+			bias-disable;
+		};
+		pin_cs {
+			function = "gpio";
+			pins = "gpio54";
+			drive-strength = <2>;
+			bias-disable;
+			output-high;
+		};
+	};
+
+	serial_0_pins: serial_0_pinmux {
+		mux {
+			pins = "gpio60", "gpio61";
+			function = "blsp_uart0";
+			bias-disable;
+		};
+	};
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+};
+
+&gmac {
+	status = "okay";
+};
+
+&ethphy1 {
+	status = "okay";
+};
+
+&ethphy2 {
+	status = "okay";
+};
+
+&switch {
+	status = "okay";
+};
+
+&swport2 {
+	status = "okay";
+	label = "lan";
+};
+
+&swport3 {
+	status = "okay";
+	label = "wan";
+};
+
+&usb2 {
+	status = "okay";
+};
+
+&usb2_hs_phy {
+	status = "okay";
+};
+
+&usb3 {
+	status = "okay";
+};
+
+&usb3_ss_phy {
+	status = "okay";
+};
+
+&usb3_hs_phy {
+	status = "okay";
+};
+
+&wifi0 {
+	status = "okay";
+};
+
+&wifi1 {
+	status = "okay";
+};

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-ibr900.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-ibr900.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/* Copyright (c) 2025, Natalie Moore <natalie@natalielucy.dev> */
+
+#include "qcom-ipq4019-ibr-c.dtsi"
+
+/ {
+	model = "Cradlepoint IBR900";
+	compatible = "cradlepoint,ibr900";
+};

--- a/target/linux/ipq40xx/image/cradlepoint-kernel-packing.py
+++ b/target/linux/ipq40xx/image/cradlepoint-kernel-packing.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# -*- coding: utf-8 -*-
+
+# Cradlepoint kernel packing tool
+# CRC of the squashfs image lives at the end of the kernel gzip, so let's add it!
+# (c) 2025 Natalie Moore <natalie@natalielucy.dev>
+
+import zlib
+import sys
+import os
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        print('Usage: {} <input-gzip> <output-gzip> <input-squashfs>'.format(sys.argv[0]))
+        sys.exit(1)
+    
+    input_gzip_path = sys.argv[1]
+    output_gzip_path = sys.argv[2]
+    rootfs_file_path = sys.argv[3]
+    
+    with open(rootfs_file_path, 'r+b') as r:
+        rootfs = r.read()
+        curr_len = len(rootfs)
+
+        # pad out squashfs image
+        fs_needed_len = (4096 - (curr_len) % 0x1000)
+        fs_pad = b'\x00' * fs_needed_len
+
+        r.seek(0, os.SEEK_END)
+        r.write(fs_pad)
+        
+        fs_len = curr_len + fs_needed_len
+
+        # seek back to the beginning, and re-read into RAM
+        r.seek(0)
+        new_rootfs = r.read()
+    
+    fs_chksum = zlib.crc32(new_rootfs).to_bytes(4, "little")
+
+    # footer should start on a 4-byte-aligned boundary
+    kern_len = os.path.getsize(input_gzip_path)
+    needed_padding = 4 - ((kern_len) % 4)
+    front_padding = b'\xaa' * needed_padding
+    
+    footer = front_padding + b'\x00\x00\x00\x00\x27\x05\x19\x58' + fs_chksum + fs_len.to_bytes(4, "little") + b'\x00\x00\x00\x00'
+
+    with open(input_gzip_path, 'rb') as i:
+        in_file = i.read()
+    
+    with open(output_gzip_path, 'wb') as o:
+        o.write(in_file)
+        o.write(footer)

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -10,6 +10,16 @@ define Build/netgear-fit-padding
 	mv $@.new $@
 endef
 
+define Build/copy-vmlinux
+	cp $(KDIR)/vmlinux $@
+endef
+
+define Build/cradlepoint-kernel-packing
+	./cradlepoint-kernel-packing.py $@ $@.new $(IMAGE_ROOTFS)
+	rm $@
+	mv $@.new $@
+endef
+
 define Device/FitImage
 	KERNEL_SUFFIX := -uImage.itb
 	KERNEL = kernel-bin | gzip | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb
@@ -376,6 +386,36 @@ define Device/compex_wpj428
 	DEFAULT := n
 endef
 TARGET_DEVICES += compex_wpj428
+
+define Cradlepoint/base_pkgs
+DEVICE_PACKAGES += kmod-gpio-pca953x \
+kmod-usb-acm kmod-usb-net kmod-usb-net-qmi-wwan kmod-usb-serial kmod-usb-serial-option \
+luci-proto-qmi luci-proto-mbim block-mount
+endef
+
+# Base defs for the IBR900
+define Device/cradlepoint_ibr_c
+	$(call Device/FitzImage)
+	$(call Cradlepoint/base_pkgs)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Cradlepoint
+	DEVICE_DTS_CONFIG := config@5
+	SOC := qcom-ipq4019
+	FILESYSTEMS := squashfs
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	IMAGE_SIZE := 65536k
+	KERNEL_SIZE := 8192k
+	IMAGE/sysupgrade.bin = copy-vmlinux | gzip | cradlepoint-kernel-packing | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb | pad-extra 896 | sysupgrade-tar kernel=$$$$@ | append-metadata
+	IMAGE/factory.bin = copy-vmlinux | gzip | cradlepoint-kernel-packing | fit gzip $$(KDIR)/image-$$(DEVICE_DTS).dtb | pad-extra 896 | append-ubi
+	DEVICE_PACKAGES += kmod-spi-dev kmod-i2c-gpio cradlepoint-fstab-ibr-c
+endef
+
+define Device/cradlepoint_ibr900
+	$(call Device/cradlepoint_ibr_c)
+	DEVICE_MODEL := IBR900
+endef
+TARGET_DEVICES += cradlepoint_ibr900
 
 define Device/devolo_magic-2-wifi-next
 	$(call Device/FitzImage)


### PR DESCRIPTION
This commit adds initial support for the Cradlepoint IBR900.

IBR600C and IBR900 are built on the same platform and should be 100% interchangeable with few modifications.

Hardware (IBR600C/900)
--------
SOC:    Qualcomm IPQ4019
FLASH:	64Mbit SPI-NOR
NAND:   256MB
RAM:  	256MB
WIFI:   Onboard 2.4+5GHz on IPQ40xx
ETH:	1x WAN, 1x LAN
LED:	10 (bicolor power (green always on, red switchable), bicolor
internal modem, 4 signal LEDs, green wifi, blue GPS)
BTN:	Reset
UART:	115200 8N1 on a 1x4 header - 1: VCC, 2: GND, 3: RX, 4: TX
OTHER:  mpcie USB3.0 cellular modem

MAC addresses
-------------
LAN	Label MAC (stored in 0:CUSTDATA partition as ASCII (entry
	MAC0=xx:xx:xx:xx:xx:xx))

Installation
------------
Vendor UI
---------
Not possible via vendor UI at this time.

Recovery Console
-----------
1. Use a SPI programmer to modify the configuration data partition to disable silent mode and increase the bootwait time.
2. Break into the bootloader and TFTP the uImage.itb into SRAM and boot.
4. Apply the sysupgrade.bin file and wait for reboot.

It is recommended to perform a full backup of the existing NAND/eMMC, as images from Cradlepoint are encrypted and cannot be re-applied after conversion to OpenWRT.

Back to stock
-------------
1. Write backup image over NAND/eMMC
