### PR TITLE
ramips: add support for OrayBox-P5

### DIFF
--- a/target/linux/ramips/dts/mt7621_oraybox_p5.dts
+++ b/target/linux/ramips/dts/mt7621_oraybox_p5.dts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "oraybox,p5", "mediatek,mt7621-soc";
+	model = "OrayBox P5";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: led-status-blue {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_red: led-status-red {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			panic-indicator;
+		};
+
+		led_status_green: led-status-green {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 8 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	reg_usb_vbus: regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_vbus";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		gpio = <&gpio 12 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
+
+	ubi-concat {
+		compatible = "mtd-concat";
+		devices = <&ubiconcat0 &ubiconcat1>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "ubi";
+				reg = <0x0 0x78c0000>;
+			};
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "kpanic";
+			reg = <0x80000 0x80000>;
+		};
+
+		partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x40000>;
+			read-only;
+		};
+
+		partition@140000 {
+			label = "kernel";
+			reg = <0x140000 0x400000>;
+			read-only;
+		};
+
+		ubiconcat0: partition@540000 {
+			label = "ubi file system 0";
+			reg = <0x540000 0x1c00000>;
+		};
+		
+		partition@2140000 {
+			label = "debug";
+			reg = <0x2140000 0x80000>;
+		};
+
+		partition@21c0000 {
+			label = "bdinfo";
+			reg = <0x21c0000 0x80000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				macaddr_bdinfo_9: macaddr@9 {
+					reg = <0x9 0x6>;
+				};
+			};
+		};
+
+		partition@2240000 {
+			label = "reserve";
+			reg = <0x2240000 0x80000>;
+			read-only;
+		};
+
+		ubiconcat1: partition@22c0000 {
+			label = "ubi file system 1";
+			reg = <0x22c0000 0x5cc0000>;
+		};
+
+		partition@7f80000 {
+			label = "opt";
+			reg = <0x7f80000 0x80000>;
+		};
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_bdinfo_9>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ports {
+		port@3 {
+			status = "okay";
+			label = "lan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt", "uart3";
+		function = "gpio";
+	};
+};
+
+&xhci {
+	vbus-supply = <&reg_usb_vbus>;
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2629,6 +2629,19 @@ define Device/openfi_5pro
 endef
 TARGET_DEVICES += openfi_5pro
 
+define Device/oraybox_p5
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 32768k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
+  DEVICE_VENDOR := OrayBox
+  DEVICE_MODEL := P5
+  DEVICE_PACKAGES := kmod-usb3
+endef
+TARGET_DEVICES += oraybox_p5
+
 define Device/oraybox_x3a
   $(Device/dsa-migration)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -56,6 +56,7 @@ ramips_setup_interfaces()
 	netgear,eax12|\
 	netgear,ex6150|\
 	netgear,wax214v2|\
+	oraybox,p5|\
 	plasmacloud,pax1800-lite|\
 	sercomm,na502|\
 	sercomm,na502s|\

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -139,6 +139,7 @@ platform_do_upgrade() {
 	netgear,wax214v2|\
 	netis,n6|\
 	netis,wf2881|\
+	oraybox,p5|\
 	raisecom,msg1500-x-00|\
 	rostelecom,rt-fe-1a|\
 	rostelecom,rt-sf-1|\


### PR DESCRIPTION
OrayBox P5 is a bridge mode router, based on MediaTek MT7621.

Specification:

* SoC: MT7621AT
* RAM: DDR3 256 MiB
* Flash: 128 MiB Nand Flash (F59L1G81MA-25T)
* Wi-Fi: non-existent
* Ethernet: 1x 1000Mbps (Supports PoE power supply in PD mode. IEEE 802.3af standard.)
* USB: 1x USB Type-A 3.0 Host Port
* Button: 1x Reset button
* LED: 1x Blue LED + 1x Red LED + 1x Green LED
* Power: DC 12V 1A

Manufacturer Page:
https://pgy.oray.com/router/p5.html/parameter

Flash Layout:

0x000000000000-0x000000080000 : "u-boot"
0x000000080000-0x000000100000 : "kpanic"
0x000000100000-0x000000140000 : "factory"
0x000000140000-0x000002140000 : "firmware"
0x000002140000-0x0000021c0000 : "debug"
0x0000021c0000-0x000002240000 : "bdinfo"
0x000002240000-0x0000022c0000 : "reserve"
0x0000022c0000-0x000007f80000 : "overlay"
0x000007f80000-0x000008000000 : "opt"

GPIO:
* Reset button : 18
* Blue LED: 6
* Red LED: 7
* Green LED: 8

Installation: serial connection

* 1.Upgrade the firmware to the development version.
* 2.Connect to the TTL serial port and restart the router. During the startup process, follow the prompts to swiftly input 'f' and press Enter to access OpenWrt failsafe mode.
* 3.Upload the factory firmware (e.g. oraybox_p5-squashfs-factory.bin) to the /tmp directory using scp.
* 4.Enter the command 'mtd write /tmp/XXX-factory.bin firmware'. This will initiate the flashing of the firmware.
* 5.Double-check that there are no issues. If you're confident, type 'reboot' to restart the router.
