### PR TITLE
mwlwifi: add patch series for kernel 6.18 compatibility

### DIFF
--- a/package/kernel/mwlwifi/patches/110-fix-timer-handling-kernel-6.13.patch
+++ b/package/kernel/mwlwifi/patches/110-fix-timer-handling-kernel-6.13.patch
@@ -1,0 +1,43 @@
+From 4bdd4f2a21f830e5987b6dbdbadb389b7f0c12bd Mon Sep 17 00:00:00 2001
+From: Stefan Kalscheuer <stefan@stklcode.de>
+Date: Fri, 3 Apr 2026 14:17:02 +0200
+Subject: [PATCH] fix timer handling kernel >= 6.13
+
+Switch periodic timer shutdown to timer_shutdown_sync() on kernel 6.13
+and newer, as del_timer_sync() is no longer available to use. The new
+call prevents re-arming the timer after shutdown which should be desired
+behavior in this case.
+
+Replace from_timer() with timer_container_of() for kernel 6.16.
+
+Signed-off-by: Stefan Kalscheuer <stefan@stklcode.de>
+---
+ core.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+--- a/core.c
++++ b/core.c
+@@ -738,7 +738,11 @@ static irqreturn_t mwl_isr(int irq, void
+ #ifdef timer_setup
+ static void timer_routine(struct timer_list *t)
+ {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,16,0)
+ 	struct mwl_priv *priv = from_timer(priv, t, period_timer);
++#else
++	struct mwl_priv *priv = timer_container_of(priv, t, period_timer);
++#endif
+ 	struct ieee80211_hw *hw = priv->hw;
+ #else
+ static void timer_routine(unsigned long data)
+@@ -975,7 +979,11 @@ static void mwl_wl_deinit(struct mwl_pri
+ {
+ 	struct ieee80211_hw *hw = priv->hw;
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,13,0)
+ 	del_timer_sync(&priv->period_timer);
++#else
++	timer_shutdown_sync(&priv->period_timer);
++#endif
+ 
+ 	if (priv->irq != -1) {
+ 		free_irq(priv->irq, hw);

--- a/package/kernel/mwlwifi/patches/111-replace-init_dummy_netdev-with-alloc_netdev_dummy-fo.patch
+++ b/package/kernel/mwlwifi/patches/111-replace-init_dummy_netdev-with-alloc_netdev_dummy-fo.patch
@@ -1,0 +1,66 @@
+From 835f385dbf3a47727181e73063a433e5c7113eca Mon Sep 17 00:00:00 2001
+From: Stefan Kalscheuer <stefan@stklcode.de>
+Date: Fri, 3 Apr 2026 16:52:44 +0200
+Subject: [PATCH] replace init_dummy_netdev() with alloc_netdev_dummy() for
+ kernel 6.14+
+
+init_dummy_netdev() was removed in kernel 6.14. Un-embed the net_device
+from the private struct by converting it into a pointer and use
+alloc_netdev_dummy() for initialization of the dummy device.
+
+Signed-off-by: Stefan Kalscheuer <stefan@stklcode.de>
+---
+ hif/pcie/dev.h  |  4 ++++
+ hif/pcie/pcie.c | 17 +++++++++++++++--
+ 2 files changed, 19 insertions(+), 2 deletions(-)
+
+--- a/hif/pcie/dev.h
++++ b/hif/pcie/dev.h
+@@ -583,7 +583,11 @@ struct pcie_priv {
+ 	struct tasklet_struct tx_task;
+ 	struct tasklet_struct tx_done_task;
+ 	/* NAPI */
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
+ 	struct net_device napi_dev;
++#else
++	struct net_device *napi_dev;
++#endif
+ 	struct napi_struct napi;
+ 	struct tasklet_struct rx_task;
+ 	unsigned int tx_head_room;
+--- a/hif/pcie/pcie.c
++++ b/hif/pcie/pcie.c
+@@ -215,9 +215,15 @@ static int pcie_init_8997(struct ieee802
+ 		     (void *)pcie_8997_tx_done_task, (unsigned long)hw);
+ 	tasklet_disable(&pcie_priv->tx_done_task);
+ 	spin_lock_init(&pcie_priv->tx_desc_lock);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,15,0)
+ 	init_dummy_netdev(&pcie_priv->napi_dev);
+-	netif_napi_add(&pcie_priv->napi_dev, &pcie_priv->napi,
+-		       pcie_8997_poll_napi);
++	netif_napi_add(&pcie_priv->napi_dev, &pcie_priv->napi, pcie_8997_poll_napi);
++#else
++	pcie_priv->napi_dev = alloc_netdev_dummy(0);
++	if (!pcie_priv->napi_dev)
++		return -ENOMEM;
++	netif_napi_add(pcie_priv->napi_dev, &pcie_priv->napi, pcie_8997_poll_napi);
++#endif
+ 	pcie_priv->txq_limit = PCIE_TX_QUEUE_LIMIT;
+ 	pcie_priv->txq_wake_threshold = PCIE_TX_WAKE_Q_THRESHOLD;
+ 	pcie_priv->recv_limit = PCIE_RECEIVE_LIMIT;
+@@ -310,8 +316,15 @@ static int pcie_init_8864(struct ieee802
+ 	tasklet_init(&pcie_priv->tx_done_task, (void *)pcie_8864_tx_done_task, (unsigned long)hw);
+ 	tasklet_disable(&pcie_priv->tx_done_task);
+ 	spin_lock_init(&pcie_priv->tx_desc_lock);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6,14,0)
+ 	init_dummy_netdev(&pcie_priv->napi_dev);
+ 	netif_napi_add(&pcie_priv->napi_dev, &pcie_priv->napi, pcie_8864_poll_napi);
++#else
++	pcie_priv->napi_dev = alloc_netdev_dummy(0);
++	if (!pcie_priv->napi_dev)
++		return -ENOMEM;
++	netif_napi_add(pcie_priv->napi_dev, &pcie_priv->napi, pcie_8864_poll_napi);
++#endif
+ 	pcie_priv->txq_limit = PCIE_TX_QUEUE_LIMIT;
+ 	pcie_priv->txq_wake_threshold = PCIE_TX_WAKE_Q_THRESHOLD;
+ 	pcie_priv->recv_limit = PCIE_RECEIVE_LIMIT;


### PR DESCRIPTION
Migrate timer handling (removed in 6.13) and netdev dummy initialization (removed in 6.16) to new methods with guards to not break older kernels.

This resolves compilation errors due to missing `del_timer_sync()`, `from_timer()` and `init_dummy_netdev()`.


Build and run tested for mvebu/cortexa9 on my WRT1900ACS (88W8864)

----

I will propose it upstream. However, since the patches required for 6.12 have neither been meged not rejected yet, I assume this PR will receive more feedback here.
