### PR TITLE
ramips: mt7621: add support for ZTE MF258

### DIFF
--- a/target/linux/ramips/dts/mt7621_zte_mf258.dts
+++ b/target/linux/ramips/dts/mt7621_zte_mf258.dts
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+//
+// Device Tree Source for ZTE MF258 (MK258) LTE Router
+//
+// Hardware:
+//   - SoC: MediaTek MT7621AT (dual-core MIPS 1004Kc, 4 VPEs)
+//   - RAM: 128MB DDR
+//   - Flash: 128MB NAND only (128KB erase, no SPI NOR)
+//   - WiFi: MT7603E (2.4GHz, PCIe0) + MT7663E (5GHz, PCIe1)
+//   - Ethernet: GMAC0 (RGMII to MT7530 switch, 2 LAN ports)
+//               GMAC1 (internal GPHY, WAN)
+//   - LEDs: 8x on I2C GPIO expander AW9523B @ 0x5B
+//   - Console: ttyS0 @ 57600
+//
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+
+/ {
+	compatible = "zte,mf258", "mediatek,mt7621-soc";
+	model = "ZTE MF258";
+
+	aliases {
+		led-boot = &led_internet;
+		led-failsafe = &led_internet;
+		led-running = &led_internet;
+		led-upgrade = &led_sig1;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,57600";
+	};
+
+	/* LEDs on I2C GPIO expander AW9523B @ 0x5B (active low) */
+	leds {
+		compatible = "gpio-leds";
+
+		led_sig1: sig1 {
+			label = "green:sig1";
+			gpios = <&aw9523 0 GPIO_ACTIVE_LOW>;
+		};
+
+		sig2 {
+			label = "green:sig2";
+			gpios = <&aw9523 1 GPIO_ACTIVE_LOW>;
+		};
+
+		sig3 {
+			label = "green:sig3";
+			gpios = <&aw9523 2 GPIO_ACTIVE_LOW>;
+		};
+
+		sig4 {
+			label = "green:sig4";
+			gpios = <&aw9523 3 GPIO_ACTIVE_LOW>;
+		};
+
+		power {
+			label = "green:power";
+			gpios = <&aw9523 4 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi5g {
+			label = "green:wifi5g";
+			gpios = <&aw9523 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led_internet: internet {
+			label = "green:internet";
+			gpios = <&aw9523 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wifi2g {
+			label = "green:wifi2g";
+			gpios = <&aw9523 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+/* No SPI NOR on this device */
+&spi0 {
+	status = "disabled";
+};
+
+/*
+ * I2C bus — AW9523B GPIO expander @ 0x5B
+ * RSTN pin not wired to SoC; driver does soft reset via I2C.
+ * Dummy reset-gpios satisfies driver requirement (never toggled).
+ */
+&i2c {
+	status = "okay";
+
+	aw9523: led-controller@5b {
+		compatible = "awinic,aw9523-pinctrl";
+		reg = <0x5b>;
+		reset-gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		gpio-controller;
+		#gpio-cells = <2>;
+	};
+};
+
+/*
+ * NAND flash — 128MB, 128KB erase blocks
+ *
+ * OpenWrt layout: Bootloader + Config + Factory preserved,
+ * kernel at 0xF00000 (U-Boot loads from this fixed offset),
+ * rest of flash as single UBI partition (104.5MB).
+ *
+ * Original ZTE partitions (0x200000-0xF00000) not defined here
+ * but data is preserved on NAND.
+ */
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "Bootloader";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "Config";
+			reg = <0x80000 0x80000>;
+		};
+
+		factory: partition@100000 {
+			label = "Factory";
+			reg = <0x100000 0x100000>;
+			read-only;
+
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				/* 2.4GHz WiFi calibration (MT7603E) */
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x400>;
+				};
+
+				/* 5GHz WiFi calibration (MT7663E) */
+				eeprom_factory_8000: eeprom@8000 {
+					reg = <0x8000 0x4da8>;
+				};
+
+				/* Ethernet MAC addresses */
+				macaddr_lan: macaddr@e000 {
+					reg = <0xe000 0x6>;
+				};
+
+				macaddr_wan: macaddr@e006 {
+					reg = <0xe006 0x6>;
+				};
+			};
+		};
+
+		/* 0x200000 - 0xF00000: original ZTE partitions, not used by OpenWrt */
+
+		partition@f00000 {
+			label = "kernel";
+			reg = <0xf00000 0x800000>;
+		};
+
+		partition@1700000 {
+			label = "ubi";
+			reg = <0x1700000 0x6880000>;
+		};
+	};
+};
+
+&ethernet {
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmii1_pins &mdio_pins>;
+};
+
+/* GMAC0: LAN — MT7530 switch via RGMII */
+&gmac0 {
+	nvmem-cells = <&macaddr_lan>;
+	nvmem-cell-names = "mac-address";
+};
+
+/* GMAC1: WAN — internal GPHY */
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&ethphy0>;
+
+	nvmem-cells = <&macaddr_wan>;
+	nvmem-cell-names = "mac-address";
+};
+
+&ethphy0 {
+	/delete-property/ interrupts;
+};
+
+&switch0 {
+	ports {
+		/* 2 physical LAN ports: port@2 = lan1, port@4 = lan2 (verified) */
+		port@0 {
+			status = "disabled";
+		};
+
+		port@1 {
+			status = "disabled";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@3 {
+			status = "disabled";
+		};
+
+		port@4 {
+			status = "okay";
+			label = "lan2";
+		};
+	};
+};
+
+/* PCIe WiFi: MT7603E (2.4GHz) + MT7663E (5GHz), mt76 driver */
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+	};
+};
+
+&xhci {
+	status = "disabled";
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3867,3 +3867,15 @@ define Device/zyxel_wsm20
   KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | znet-header V1.00(ABZF.0)C0
 endef
 TARGET_DEVICES += zyxel_wsm20
+
+define Device/zte_mf258
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  IMAGE_SIZE := 36352k
+  KERNEL_SIZE := 8192k
+  DEVICE_VENDOR := ZTE
+  DEVICE_MODEL := MF258
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e kmod-mt7663-firmware-ap \
+	kmod-i2c-mt7621 kmod-8021q
+endef
+TARGET_DEVICES += zte_mf258

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -191,6 +191,9 @@ ramips_setup_interfaces()
 	ruijie,rg-ew1200g-pro-v1.1)
 		ucidef_set_interfaces_lan_wan "lan3 lan2 lan1" "wan"
 		;;
+	zte,mf258)
+		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
+		;;
 	*)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "wan"
 		;;

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -157,6 +157,7 @@ platform_do_upgrade() {
 	xiaomi,redmi-router-ac2100|\
 	z-router,zr-2660|\
 	z-router,zr-2662|\
+	zte,mf258|\
 	zyxel,nwa50ax|\
 	zyxel,nwa55axe)
 		nand_do_upgrade "$1"


### PR DESCRIPTION
Add support for ZTE MF258 (MK258) LTE CPE router with MT7621 SoC.

## Hardware
- SoC: MT7621AT (dual-core MIPS 1004Kc)
- RAM: 128MB DDR
- Flash: 128MB NAND
- WiFi: MT7603E (2.4GHz) + MT7663E (5GHz)
- LEDs: 8x on I2C AW9523B GPIO expander
- Ports: 2x LAN + 1x WAN

## LTE Modem
This router is sold as a kit: router + external LTE modem (GCT GDM7243)
connected via RJ45 to the WAN port. The modem uses a custom Ethernet-based
protocol (AT commands over TCP, UDP keepalive, LTE data over VLAN 100).

Since the modem requires a custom protocol, a separate daemon is available:
https://github.com/patryk4815/openwrt-gdm7243-lte

It provides a netifd protocol handler (proto 'gctd') and LuCI integration
for modem configuration and signal monitoring.

This is why `kmod-8021q` is included in DEVICE_PACKAGES — LTE data flows
through VLAN 100 on the WAN port.

## Installation

1. Connect UART 3.3V (ttyS0 @ 57600, pinout marked on PCB silkscreen as RTGV: Rx, Tx, GND, Vcc) and set up a TFTP server on your machine
2. Reboot the router and select option 4 in U-Boot menu
3. Load initramfs via TFTP:
   ```
   setenv ipaddr 192.168.100.251
   setenv serverip 192.168.100.22
   tftpboot 0x84000000 openwrt-ramips-mt7621-zte_mf258-initramfs-kernel.bin
   bootm 0x84000000
   ```
4. Once booted, copy sysupgrade image to the router:
   ```
   scp -O openwrt-*-sysupgrade.bin root@<router-ip>:/tmp/
   ```
5. Flash to NAND:
  ```
  sysupgrade -n /tmp/openwrt-*-sysupgrade.bin
  ```

## Test plan
- [x] Kernel boots from NAND
- [x] Ethernet LAN + WAN works
- [x] WiFi drivers load (MT7603E + MT7663E)
- [x] LEDs work via sysfs (AW9523B I2C GPIO expander)
- [x] Sysupgrade works (nand_do_upgrade)