### PR TITLE
ramips: Add support for Arcadyan WG630223

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -88,7 +88,10 @@ mtd_get_mac_ascii() {
 
 mtd_get_mac_encrypted_arcadyan() {
 	local iv="00000000000000000000000000000000"
-	local key="2A4B303D7644395C3B2B7053553C5200"
+	local key="$2"
+	if [ -z "$key" ]; then
+		key="2A4B303D7644395C3B2B7053553C5200"
+	fi
 	local mac_dirty
 	local mtdname="$1"
 	local part

--- a/target/linux/ramips/dts/mt7621_arcadyan_wg630223.dts
+++ b/target/linux/ramips/dts/mt7621_arcadyan_wg630223.dts
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "arcadyan,wg630223", "mediatek,mt7621-soc";
+	model = "Arcadyan WG630223";
+
+	aliases {
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+		bootargs-override = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led_status_blue: led-1 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 14 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_green: led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 15 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_status_red: led-3 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 16 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		key-restart {
+			label = "reset";
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+};
+
+&nand {
+	status = "okay";
+	mediatek,nmbm;
+	mediatek,bmt-remap-range = <0x0000000 0x05c0000>, <0x1980000 0x3800000>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x0 0x80000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x80000 0x80000>;
+		};
+
+		factory: partition@100000 {
+			label = "factory";
+			reg = <0x100000 0x80000>;
+			read-only;
+
+			compatible = "nvmem-cells";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			macaddr_factory_fff0: macaddr@fff0 {
+				reg = <0xfff0 0x6>;
+			};
+		};
+
+		partition@180000 {
+			label = "firmware";
+			reg = <0x180000 0x1800000>;
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "kernel";
+				reg = <0x0 0x440000>;
+			};
+
+			partition@440000 {
+				label = "ubi";
+				reg = <0x440000 0x13c0000>;
+			};
+		};
+
+		partition@1980000 {
+			label = "firmware_backup";
+			reg = <0x1980000 0x1800000>;
+		};
+
+		partition@3180000 {
+			label = "firmware_mp";
+			reg = <0x3180000 0x1800000>;
+		};
+
+		partition@4980000 {
+			label = "pricfg";
+			reg = <0x4980000 0x200000>;
+		};
+
+		partition@4b80000 {
+			label = "seccfg";
+			reg = <0x4b80000 0x200000>;
+		};
+
+		partition@4d80000 {
+			label = "arc_log";
+			reg = <0x4d80000 0x200000>;
+		};
+
+		partition@4f80000 {
+			label = "board_data";
+			reg = <0x4f80000 0x200000>;
+		};
+
+		partition@5180000 {
+			label = "boot_data";
+			reg = <0x5180000 0x200000>;
+		};
+
+		partition@5380000 {
+			label = "User_data";
+			reg = <0x5380000 0x1800000>;
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		mediatek,mtd-eeprom = <&factory 0x0000>;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_fff0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	phy-handle = <&phy4>;
+
+	nvmem-cells = <&macaddr_factory_fff0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio {
+	phy4: ethernet-phy@4 {
+		reg = <4>;
+	};
+};
+
+&switch0 {
+	ports {
+		port@2 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "lan1";
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -3867,3 +3867,25 @@ define Device/zyxel_wsm20
   KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb | znet-header V1.00(ABZF.0)C0
 endef
 TARGET_DEVICES += zyxel_wsm20
+
+define Device/arcadyan_wg630223
+  $(Device/dsa-migration)
+  DEVICE_VENDOR := Arcadyan
+  DEVICE_MODEL := WG630223
+  IMAGE_SIZE := 24576k
+  KERNEL_SIZE := 4352k
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb \
+           | arcadyan-trx 0x30524448 | pad-to $$(KERNEL_SIZE)
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+                     fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS += initramfs-factory.trx
+  ARTIFACT/initramfs-factory.trx := append-image-stage initramfs-kernel.bin | arcadyan-trx 0x30524448
+endif
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915-firmware uencrypt-mbedtls
+endef
+TARGET_DEVICES += arcadyan_wg630223

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -94,6 +94,7 @@ ramips_setup_interfaces()
 		ucidef_set_interfaces_lan_wan "lan" "wan"
 		;;
 	asiarf,ap7621-nv1|\
+	arcadayan,wg630223|\
 	beeline,smartbox-flash|\
 	beeline,smartbox-giga|\
 	elecom,wmc-x1800gst|\
@@ -233,7 +234,12 @@ ramips_setup_macs()
 		label_mac=$(mtd_get_mac_ascii board_data mac)
 		lan_mac=$label_mac
 		ucidef_set_network_device_mac eth0 $(macaddr_add "$label_mac" 3)
-	;;
+		;;
+	arcadyan,wg630223)
+		label_mac=$(mtd_get_mac_encrypted_arcadyan "board_data" "42583038694070636D5964652324252A")
+		lan_mac=$label_mac
+		wan_mac=$(macaddr_add "$lan_mac" 3)
+		;;
 	asus,rt-ac65p|\
 	asus,rt-ac85p)
 		wan_mac=$(mtd_get_mac_ascii u-boot-env et1macaddr)

--- a/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+++ b/target/linux/ramips/mt7621/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
@@ -26,6 +26,15 @@ case "$board" in
 			echo -n "$mac5" > /sys${DEVPATH}/macaddress
 		fi
 		;;
+	arcadyan,wg630223)
+		hw_mac_addr=$(mtd_get_mac_encrypted_arcadyan "board_data" "42583038694070636D5964652324252A")
+		hw_mac_addr=$(macaddr_setbit $hw_mac_addr 7)
+		hw_mac_addr=$(macaddr_unsetbit $hw_mac_addr 25)
+		hw_mac_addr=$(macaddr_setbit $hw_mac_addr 28)
+		[ "$PHYNBR" = "0" ] && macaddr_setbit_la $hw_mac_addr > /sys${DEVPATH}/macaddress
+		hw_mac_addr=$(macaddr_setbit $hw_mac_addr 27)
+		[ "$PHYNBR" = "1" ] && macaddr_setbit_la $hw_mac_addr > /sys${DEVPATH}/macaddress
+		;;
 	beeline,smartbox-flash)
 		hw_mac_addr=$(macaddr_add $(mtd_get_mac_encrypted_arcadyan "board_data") 1)
 		[ "$PHYNBR" = "0" ] && echo -n "$hw_mac_addr" > /sys${DEVPATH}/macaddress

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -65,12 +65,22 @@ platform_do_upgrade() {
 		dd if=/dev/mtd5 bs=1024 count=52224 >> /tmp/backup_firmware.bin
 		mtd -e firmware2 write /tmp/backup_firmware.bin firmware2
 		;;
+	arcadyan,wg630223)
+		dd if=/dev/mtd12 of=/tmp/mtd12.bin bs=1024
+		local boot_sect=`dd if=/tmp/mtd12.bin bs=1 skip=8 count=2 2>/dev/null | hexdump -v -e '1/1 "%02x"'`
+		if [ "$boot_sect" == "0100" ]; then
+			echo 'Switching boot partition to "firmware" ...'
+			printf '\x00\x00' | dd of=/tmp/mtd12.bin bs=1 seek=8 count=2 conv=notrunc
+			mtd write /tmp/mtd12.bin /dev/mtd12
+		fi
+		;;
 	esac
 
 	case "$board" in
 	ampedwireless,ally-00x19k|\
 	ampedwireless,ally-r1900k|\
 	arcadyan,we420223-99|\
+	arcadyan,wg630223|\
 	asus,rt-ac65p|\
 	asus,rt-ac85p|\
 	asus,rt-ax53u|\


### PR DESCRIPTION
## Specification
Model: Arcadyan WG630223(-TC)
CPU: Mediatek MT7621A
RAM: 256MB DDR3
Flash: 128MB
WiFi: 2.4GHz 5GHz 4x4
GbE: 1 WAN and 2 LANs
Power: 12V 1A DC 5.5/2.1 Jack
LED: 3

## Installation on `-TC` variant
### Flash stage 1 recovery image via WebUI
 * Navigate to `System` -> `Firmware Update` in WebUI
 * Select `openwrt-xx.xx.xx-initramfs-factory.trx` file
 * Launch Web DevTools then select the iframe of `system_f.htm`
 * Execute following JS script to start flash the stage 1 firmware.

```
$("input[type=file]").attr("name","mtkfile")
var f=document.webForm;
f.action="upload.cgi";
f.ENCTYPE='multipart/form-data';
subForm({frm:f,genfrm:0,cmd:'',uploadtype:1,wizard:1,wait:2,done:function(){check_FW_and_jump();}});
```
* When the blue LED light up,the recovery image is installed and booted

### Flash system image
* Navigate browser to `http://192.168.1.1`
* Upgrade OpenWrt with `openwrt-xx.xx.xx-squashfs-sysupgrade.bin`
* Reboot

This PR is based on #10535 by Lenaius Chang <system1357@gmail.com>