### PR TITLE
filogic: add support for Arcadyan WG620443

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -129,7 +129,7 @@ mtd_get_mac_encrypted_arcadyan_mt7986() {
 
 	part=$(find_mtd_part "$mtdname")
 	if [ -z "$part" ]; then
-		echo "mtd_get_mac_encrypted_arcadyan: partition $mtdname not found!" >&2
+		echo "mtd_get_mac_encrypted_arcadyan_mt7986: partition $mtdname not found!" >&2
 		return
 	fi
 
@@ -148,7 +148,7 @@ mtd_get_mac_encrypted_arcadyan_mt7986() {
 		dd if="$part" bs=1 count="$size" skip=$((0x6800 + 8)) 2>/dev/null | \
 			openssl aes-128-cbc -d -nopad -K "$key" -iv "$iv" > "$temp_conf"
 	else
-		echo "mtd_get_mac_encrypted_arcadyan: Neither uencrypt nor openssl was found!" >&2
+		echo "mtd_get_mac_encrypted_arcadyan_mt7986: Neither uencrypt nor openssl was found!" >&2
 		rm -rf "$temp_dir"
 		rm -f "$temp_conf"
 		return

--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -117,6 +117,58 @@ mtd_get_mac_encrypted_arcadyan() {
 	[ -n "$mac_dirty" ] && macaddr_canonicalize "$mac_dirty"
 }
 
+mtd_get_mac_encrypted_arcadyan_mt7986() {
+	local mtdname="$1"
+	local key="$2"
+	local iv="$3"
+	local part
+	local size
+	local mac_dirty
+	local temp_conf
+	local temp_dir
+
+	part=$(find_mtd_part "$mtdname")
+	if [ -z "$part" ]; then
+		echo "mtd_get_mac_encrypted_arcadyan: partition $mtdname not found!" >&2
+		return
+	fi
+
+	temp_conf=$(mktemp) || return
+	temp_dir=$(mktemp -d) || {
+		rm -f "$temp_conf"
+		return
+	}
+
+	# Config decryption and getting mac. Trying uencrypt and openssl utils.
+	size=$((0x$(dd if="$part" skip=$((0x6800 + 4)) bs=1 count=4 2>/dev/null | hexdump -v -e '1/4 "%08x"')))
+	if [ -f /usr/bin/uencrypt ]; then
+		dd if="$part" bs=1 count="$size" skip=$((0x6800 + 8)) 2>/dev/null | \
+			uencrypt -d -n -k "$key" -i "$iv" > "$temp_conf"
+	elif [ -f /usr/bin/openssl ]; then
+		dd if="$part" bs=1 count="$size" skip=$((0x6800 + 8)) 2>/dev/null | \
+			openssl aes-128-cbc -d -nopad -K "$key" -iv "$iv" > "$temp_conf"
+	else
+		echo "mtd_get_mac_encrypted_arcadyan: Neither uencrypt nor openssl was found!" >&2
+		rm -rf "$temp_dir"
+		rm -f "$temp_conf"
+		return
+	fi
+
+	tar xzf "$temp_conf" -C "$temp_dir" || {
+		rm -rf "$temp_dir"
+		rm -f "$temp_conf"
+		return
+	}
+
+	mac_dirty=$(grep -m1 '^ARC_SYS_BASEMAC=' "$temp_dir/.glbcfg" | cut -d= -f2-)
+
+	rm -rf "$temp_dir"
+	rm -f "$temp_conf"
+
+	# "canonicalize" mac
+	[ -n "$mac_dirty" ] && macaddr_canonicalize "$mac_dirty"
+}
+
 mtd_get_mac_encrypted_deco() {
 	local mtdname="$1"
 

--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -117,6 +117,61 @@ mtd_get_mac_encrypted_arcadyan() {
 	[ -n "$mac_dirty" ] && macaddr_canonicalize "$mac_dirty"
 }
 
+mtd_get_mac_encrypted_arcadyan_mt7986() {
+	local mtdname="$1"
+	local key="$2"
+	local iv="$3"
+	local part
+	local size
+	local mac_dirty
+	local temp_conf
+	local temp_dir
+
+	part=$(find_mtd_part "$mtdname")
+	if [ -z "$part" ]; then
+		echo "mtd_get_mac_encrypted_arcadyan_mt7986: partition $mtdname not found!" >&2
+		return
+	fi
+
+	temp_conf=$(mktemp) || return
+	temp_dir=$(mktemp -d) || {
+		rm -f "$temp_conf"
+		return
+	}
+
+	# Config decryption and getting mac. Trying uencrypt and openssl utils.
+	size=$(dd if="$part" skip=$((0x6800 + 4)) bs=1 count=4 2>/dev/null | \
+		hexdump -v -e '1/4 "%08x"')
+	size=$((0x$size))
+	if [ -f /usr/bin/uencrypt ]; then
+		dd if="$part" bs=1 count="$size" skip=$((0x6800 + 8)) 2>/dev/null | \
+			uencrypt -d -n -k "$key" -i "$iv" > "$temp_conf"
+	elif [ -f /usr/bin/openssl ]; then
+		dd if="$part" bs=1 count="$size" skip=$((0x6800 + 8)) 2>/dev/null | \
+			openssl aes-128-cbc -d -nopad -K "$key" -iv "$iv" > "$temp_conf"
+	else
+		echo "mtd_get_mac_encrypted_arcadyan_mt7986: Neither uencrypt nor" \
+			"openssl was found!" >&2
+		rm -rf "$temp_dir"
+		rm -f "$temp_conf"
+		return
+	fi
+
+	tar xzf "$temp_conf" -C "$temp_dir" || {
+		rm -rf "$temp_dir"
+		rm -f "$temp_conf"
+		return
+	}
+
+	mac_dirty=$(grep -m1 '^ARC_SYS_BASEMAC=' "$temp_dir/.glbcfg" | cut -d= -f2-)
+
+	rm -rf "$temp_dir"
+	rm -f "$temp_conf"
+
+	# "canonicalize" mac
+	[ -n "$mac_dirty" ] && macaddr_canonicalize "$mac_dirty"
+}
+
 mtd_get_mac_encrypted_deco() {
 	local mtdname="$1"
 

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -70,6 +70,7 @@ huasifei,wh3000|\
 nradio,c8-668gl)
 	ubootenv_add_mmc "u-boot-env" "" "0x0" "0x80000"
 	;;
+arcadyan,wg620443|\
 asiarf,ap7986-003|\
 cetron,ct3003|\
 comfast,cf-wr632ax|\
@@ -77,7 +78,7 @@ edgecore,eap111|\
 netgear,wax220|\
 zbtlink,zbt-z8102ax|\
 zbtlink,zbt-z8103ax)
-	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
+	ubootenv_add_mtd "u-boot-env" "0x0" "0x20000" "0x20000" "1"
 	;;
 asus,rt-ax59u)
 	ubootenv_add_uci_config "/dev/mtd0" "0x100000" "0x20000" "0x20000"

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -78,7 +78,7 @@ edgecore,eap111|\
 netgear,wax220|\
 zbtlink,zbt-z8102ax|\
 zbtlink,zbt-z8103ax)
-	ubootenv_add_mtd "u-boot-env" "0x0" "0x20000" "0x20000" "1"
+	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;
 asus,rt-ax59u)
 	ubootenv_add_uci_config "/dev/mtd0" "0x100000" "0x20000" "0x20000"

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -80,6 +80,7 @@ huasifei,wh3000|\
 nradio,c8-668gl)
 	ubootenv_add_mmc "u-boot-env" "" "0x0" "0x80000"
 	;;
+arcadyan,wg620443|\
 asiarf,ap7986-003|\
 cetron,ct3003|\
 comfast,cf-wr632ax|\

--- a/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
+++ b/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
@@ -170,29 +170,6 @@
 	status = "okay";
 };
 
-&pcie {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pcie_pins>;
-	status = "okay";
-
-	pcie@0,0 {
-		#address-cells = <3>;
-		#size-cells = <2>;
-		reg = <0x0000 0 0 0 0>;
-
-		wifi@0,0 {
-			compatible = "mediatek,mt76";
-			reg = <0x0000 0 0 0 0>;
-			nvmem-cells = <&eeprom_2g_5g>;
-			nvmem-cell-names = "eeprom";
-		};
-	};
-};
-
-&pcie_phy {
-	status = "okay";
-};
-
 &watchdog {
 	status = "okay";
 };
@@ -202,7 +179,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&wf_2g_5g_pins>;
 
-	nvmem-cells = <&eeprom_2g_5g>;
+	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };
 
@@ -299,7 +276,7 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
-					eeprom_2g_5g: eeprom@0 {
+					eeprom_factory_0: eeprom@0 {
 						reg = <0x0 0x1000>;
 					};
 				};

--- a/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
+++ b/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	model = "Arcadyan WG620443";
+	compatible = "arcadyan,wg620443", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+
+		/* Stock U-Boot crashes unless /chosen/bootargs exists */
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-0 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		switch: switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "wan";
+					phy-handle = <&swphy0>;
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan1";
+					phy-handle = <&swphy1>;
+				};
+
+				port@6 {
+					reg = <6>;
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+
+			mdio {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				swphy0: phy@0 {
+					reg = <0>;
+
+					mediatek,led-config = <
+						0x21 0x8009 /* BASIC_CTRL */
+						0x22 0x0c00 /* ON_DURATION */
+						0x23 0x1400 /* BLINK_DURATION */
+						0x24 0x8000 /* LED0_ON_CTRL */
+						0x25 0x0000 /* LED0_BLINK_CTRL */
+						0x26 0xc007 /* LED1_ON_CTRL */
+						0x27 0x003f /* LED1_BLINK_CTRL */
+					>;
+				};
+
+				swphy1: phy@1 {
+					reg = <1>;
+
+					mediatek,led-config = <
+						0x21 0x8009 /* BASIC_CTRL */
+						0x22 0x0c00 /* ON_DURATION */
+						0x23 0x1400 /* BLINK_DURATION */
+						0x24 0x8000 /* LED0_ON_CTRL */
+						0x25 0x0000 /* LED0_BLINK_CTRL */
+						0x26 0xc007 /* LED1_ON_CTRL */
+						0x27 0x003f /* LED1_BLINK_CTRL */
+					>;
+				};
+			};
+		};
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&pcie {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie_pins>;
+	status = "okay";
+
+	pcie@0,0 {
+		#address-cells = <3>;
+		#size-cells = <2>;
+		reg = <0x0000 0 0 0 0>;
+
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
+			reg = <0x0000 0 0 0 0>;
+			nvmem-cells = <&eeprom_6g>;
+			nvmem-cell-names = "eeprom";
+		};
+	};
+};
+
+&pcie_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+
+	nvmem-cells = <&eeprom_2g_5g>;
+	nvmem-cell-names = "eeprom";
+};
+
+&pio {
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "switch_int", "mdc_mdio";
+		};
+	};
+
+	pcie_pins: pcie-pins {
+		mux {
+			function = "pcie";
+			groups = "pcie_pereset";
+		};
+	};
+
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable; /* bias-disable */
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x000000 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_2g_5g: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					eeprom_6g: eeprom@a0000 {
+						reg = <0xa0000 0x1000>;
+					};
+				};
+			};
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x2400000>;
+			};
+
+			partition@2980000 {
+				label = "Kernel2";
+				reg = <0x2980000 0x2400000>;
+			};
+
+			partition@4d80000 {
+				label = "pricfg";
+				reg = <0x4d80000 0x200000>;
+			};
+
+			partition@4f80000 {
+				label = "seccfg";
+				reg = <0x4f80000 0x200000>;
+			};
+
+			partition@5180000 {
+				label = "arc_log";
+				reg = <0x5180000 0x200000>;
+			};
+
+			partition@5380000 {
+				label = "board_data";
+				reg = <0x5380000 0x200000>;
+			};
+
+			partition@5580000 {
+				label = "boot_data";
+				reg = <0x5580000 0x200000>;
+			};
+
+			partition@5780000 {
+				label = "User_data";
+				reg = <0x5780000 0x1000000>;
+			};
+		};
+	};
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
+++ b/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
@@ -183,7 +183,7 @@
 		wifi@0,0 {
 			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
-			nvmem-cells = <&eeprom_6g>;
+			nvmem-cells = <&eeprom_2g_5g>;
 			nvmem-cell-names = "eeprom";
 		};
 	};

--- a/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
+++ b/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
@@ -302,10 +302,6 @@
 					eeprom_2g_5g: eeprom@0 {
 						reg = <0x0 0x1000>;
 					};
-
-					eeprom_6g: eeprom@a0000 {
-						reg = <0xa0000 0x1000>;
-					};
 				};
 			};
 			partition@380000 {
@@ -322,6 +318,7 @@
 			partition@2980000 {
 				label = "Kernel2";
 				reg = <0x2980000 0x2400000>;
+				read-only;
 			};
 
 			partition@4d80000 {

--- a/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
+++ b/target/linux/mediatek/dts/mt7986a-arcadyan-wg620443.dts
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986a.dtsi"
+
+/ {
+	model = "Arcadyan WG620443";
+	compatible = "arcadyan,wg620443", "mediatek,mt7986a";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+
+		/* Stock U-Boot crashes unless /chosen/bootargs exists */
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-0 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_pins>;
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	mdio: mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		switch: switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "wan";
+					phy-handle = <&swphy0>;
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan1";
+					phy-handle = <&swphy1>;
+				};
+
+				port@6 {
+					reg = <6>;
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+
+			mdio {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				swphy0: phy@0 {
+					reg = <0>;
+
+					mediatek,led-config = <
+						0x21 0x8009 /* BASIC_CTRL */
+						0x22 0x0c00 /* ON_DURATION */
+						0x23 0x1400 /* BLINK_DURATION */
+						0x24 0x8000 /* LED0_ON_CTRL */
+						0x25 0x0000 /* LED0_BLINK_CTRL */
+						0x26 0xc007 /* LED1_ON_CTRL */
+						0x27 0x003f /* LED1_BLINK_CTRL */
+					>;
+				};
+
+				swphy1: phy@1 {
+					reg = <1>;
+
+					mediatek,led-config = <
+						0x21 0x8009 /* BASIC_CTRL */
+						0x22 0x0c00 /* ON_DURATION */
+						0x23 0x1400 /* BLINK_DURATION */
+						0x24 0x8000 /* LED0_ON_CTRL */
+						0x25 0x0000 /* LED0_BLINK_CTRL */
+						0x26 0xc007 /* LED1_ON_CTRL */
+						0x27 0x003f /* LED1_BLINK_CTRL */
+					>;
+				};
+			};
+		};
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&pio {
+	eth_pins: eth-pins {
+		mux {
+			function = "eth";
+			groups = "switch_int", "mdc_mdio";
+		};
+	};
+
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable; /* bias-disable */
+		};
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable; /* bias-disable */
+		};
+	};
+
+	wf_2g_5g_pins: wf_2g_5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+			       "WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+			       "WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+			       "WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+			       "WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+			       "WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+			       "WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x000000 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x2400000>;
+			};
+
+			partition@2980000 {
+				label = "Kernel2";
+				reg = <0x2980000 0x2400000>;
+				read-only;
+			};
+
+			partition@4d80000 {
+				label = "pricfg";
+				reg = <0x4d80000 0x200000>;
+			};
+
+			partition@4f80000 {
+				label = "seccfg";
+				reg = <0x4f80000 0x200000>;
+			};
+
+			partition@5180000 {
+				label = "arc_log";
+				reg = <0x5180000 0x200000>;
+			};
+
+			partition@5380000 {
+				label = "board_data";
+				reg = <0x5380000 0x200000>;
+			};
+
+			partition@5580000 {
+				label = "boot_data";
+				reg = <0x5580000 0x200000>;
+			};
+
+			partition@5780000 {
+				label = "User_data";
+				reg = <0x5780000 0x1000000>;
+			};
+		};
+	};
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -48,6 +48,9 @@ mediatek_setup_interfaces()
 	arcadyan,mozart)
 		ucidef_set_interfaces_lan_wan "lan0 eth1" eth2
 		;;
+	arcadyan,wg620443)
+		ucidef_set_interfaces_lan_wan "lan1" wan
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax59u|\
 	asus,zenwifi-bt8|\
@@ -277,6 +280,12 @@ mediatek_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
 		lan_mac=$(macaddr_add "$wan_mac" 1)
 		label_mac=$wan_mac
+		;;
+	arcadyan,wg620443)
+		base_mac=$(mtd_get_mac_encrypted_arcadyan_mt7986 "pricfg" "89c72f31eb3243e8b0a781fe46a51c56" "87d81103921f4c17cbfd078b056f397a")
+		lan_mac=$base_mac
+		wan_mac=$(macaddr_add "$base_mac" 3)
+		label_mac=$base_mac
 		;;
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -38,6 +38,11 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $base_mac 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $base_mac 3 > /sys${DEVPATH}/macaddress
 		;;
+	arcadyan,wg620443)
+		hw_mac_addr=$(mtd_get_mac_encrypted_arcadyan_mt7986 "pricfg" "89c72f31eb3243e8b0a781fe46a51c56" "87d81103921f4c17cbfd078b056f397a")
+		[ "$PHYNBR" = "0" ] && macaddr_add $hw_mac_addr 1 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $hw_mac_addr 2 > /sys${DEVPATH}/macaddress
+		;;
 	asus,rt-ax59u)
 		CI_UBIPART="UBI_DEV"
 		addr=$(mtd_get_mac_binary_ubi "Factory" 0x4)

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -400,7 +400,7 @@ platform_pre_upgrade() {
 
 		fw_setenv boot_select 0
 		if [ "$(rootfs_type)" = "tmpfs" ]; then
-			fw_setenv bootargs "console=ttyS0,115200n1 ubi.mtd=$mtdnum init=/sbin/init loglevel=8 earlycon=uart8250,mmio32,0x11002000"
+			fw_setenv bootargs "console=ttyS0,115200n8 ubi.mtd=$mtdnum init=/sbin/init loglevel=8 earlycon=uart8250,mmio32,0x11002000"
 			ubidetach -m "$mtdnum" 2>/dev/null || true
 			ubiformat "/dev/mtd$mtdnum" -y
 		fi

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -151,6 +151,10 @@ platform_do_upgrade() {
 		CI_ROOTPART="rootfs"
 		emmc_do_upgrade "$1"
 		;;
+	arcadyan,wg620443)
+		CI_UBIPART="ubi"
+		nand_do_upgrade "$1"
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax57m|\
 	asus,rt-ax59u|\
@@ -389,6 +393,18 @@ platform_pre_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	arcadyan,wg620443)
+		local mtdnum="$(find_mtd_index ubi)"
+
+		[ -n "$mtdnum" ] || return 1
+
+		fw_setenv boot_select 0
+		if [ "$(rootfs_type)" = "tmpfs" ]; then
+			fw_setenv bootargs "console=ttyS0,115200n1 ubi.mtd=$mtdnum init=/sbin/init loglevel=8 earlycon=uart8250,mmio32,0x11002000"
+			ubidetach -m "$mtdnum" 2>/dev/null || true
+			ubiformat "/dev/mtd$mtdnum" -y
+		fi
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax57m|\
 	asus,rt-ax59u|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -400,7 +400,7 @@ platform_pre_upgrade() {
 
 		fw_setenv boot_select 0
 		if [ "$(rootfs_type)" = "tmpfs" ]; then
-			fw_setenv bootargs "console=ttyS0,115200n8 ubi.mtd=$mtdnum init=/sbin/init loglevel=8 earlycon=uart8250,mmio32,0x11002000"
+			fw_setenv bootargs "console=ttyS0,115200n8 ubi.mtd=$mtdnum init=/sbin/init earlycon=uart8250,mmio32,0x11002000"
 			ubidetach -m "$mtdnum" 2>/dev/null || true
 			ubiformat "/dev/mtd$mtdnum" -y
 		fi

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -245,6 +245,10 @@ platform_do_upgrade() {
 		rm -f "$tmpfile"
 		nand_do_upgrade "$1"
 		;;
+	arcadyan,wg620443)
+		CI_UBIPART="ubi"
+		nand_do_upgrade "$1"
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax57m|\
 	asus,rt-ax59u|\
@@ -506,6 +510,21 @@ platform_pre_upgrade() {
 	local board=$(board_name)
 
 	case "$board" in
+	arcadyan,wg620443)
+		local mtdnum="$(find_mtd_index ubi)"
+
+		[ -n "$mtdnum" ] || return 1
+
+		fw_setenv boot_select 0
+		if [ "$(rootfs_type)" = "tmpfs" ]; then
+			local bootargs="console=ttyS0,115200n8 ubi.mtd=$mtdnum"
+			bootargs="$bootargs init=/sbin/init"
+			bootargs="$bootargs earlycon=uart8250,mmio32,0x11002000"
+			fw_setenv bootargs "$bootargs"
+			ubidetach -m "$mtdnum" 2>/dev/null || true
+			ubiformat "/dev/mtd$mtdnum" -y
+		fi
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax57m|\
 	asus,rt-ax59u|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -393,6 +393,27 @@ define Device/arcadyan_mozart
 endef
 TARGET_DEVICES += arcadyan_mozart
 
+define Device/arcadyan_wg620443
+  DEVICE_VENDOR := Arcadyan
+  DEVICE_MODEL := WG620443
+  DEVICE_DTS := mt7986a-arcadyan-wg620443
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-ubootenv-nvram kmod-mt7986-firmware mt7986-wo-firmware uencrypt-mbedtls kmod-mt7915e
+  DEVICE_DTS_LOADADDR := 0x44000000
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 36864k
+  KERNEL_IN_UBI := 1
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS += initramfs-factory.bin
+  ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | \
+	sysupgrade-tar kernel=$$$$@ | append-metadata
+endif
+endef
+TARGET_DEVICES += arcadyan_wg620443
+
 define Device/asus_rt-ax52
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AX52

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -423,6 +423,27 @@ define Device/arcadyan_mozart
 endef
 TARGET_DEVICES += arcadyan_mozart
 
+define Device/arcadyan_wg620443
+  DEVICE_VENDOR := Arcadyan
+  DEVICE_MODEL := WG620443
+  DEVICE_DTS := mt7986a-arcadyan-wg620443
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware uencrypt-mbedtls
+  DEVICE_DTS_LOADADDR := 0x44000000
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 36864k
+  KERNEL_IN_UBI := 1
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  ARTIFACTS += initramfs-factory.bin
+  ARTIFACT/initramfs-factory.bin := append-image-stage initramfs-kernel.bin | \
+	sysupgrade-tar kernel=$$$$@ | append-metadata
+endif
+endef
+TARGET_DEVICES += arcadyan_wg620443
+
 define Device/asus_rt-ax52
   DEVICE_VENDOR := ASUS
   DEVICE_MODEL := RT-AX52


### PR DESCRIPTION
### Hardware specification:

Model: Arcadyan WG620443(-TC)
CPU: MediaTek MT7986A
RAM: 512 MB DDR3
Flash: 128 MB W25N01GVZE1G
WiFi: 2.4 GHz and 5 GHz, 4x4
Ethernet: 1 WAN and 1 LAN
Power: 12 V, 1 A, DC 5.5/2.1 mm jack
LEDs: 3

The -TC suffix identifies the Chunghwa Telecom operator variant. The image
uses the generic WG620443 name, but the installation procedure below has
only been tested on the -TC variant.

The tested stock U-Boot flow loads the FDT at 0x44000000. The kernel uses
the filogic default load address of 0x48000000, so the regions do not
overlap.

Based on modification by Leko Tseng <leko@leko.moe>

### Flash instructions:

1. Enable Telnet from the stock WebUI:
   - Launch a browser and open the WebUI.
   - Navigate to `System` -> `Remote Management`.
   - Open Web DevTools and select the iframe of `remote_management.htm`.
   - Execute `closeDiv()` in the web console.
   - Enable Telnet from LAN access, then click the 'Save' button.

2. Bypass the firmware validation:
   - Telnet into the access point via LAN.
   - Log in with the default credentials.
   - At `Please enter No. or input command: `, enter `Switch_To_SH`.
   - At `Please input command!!>`, enter `cht_arc_JE1xxxxxxx`.
   - `JE1xxxxxxx` is the serial number shown under
     `System` -> `Information`.
   - When the shell appears, enter
     `echo 1 > /tmp/FW_check_dev.log`.

3. Install the recovery image:
   - Navigate to `System` -> `Firmware Update` in the WebUI.
   - Select `openwrt-xx.xx.xx-initramfs-factory.bin`.
   - Open Web DevTools and select the iframe of `system_f.htm`.
   - Execute the following JavaScript to flash the stage 1 firmware:

     $("input[type=file]").attr("name","file")
     var f=document.webForm;
     f.action="upload.cgi";
     f.ENCTYPE='multipart/form-data';
     subForm({
       frm:f,genfrm:0,cmd:'',uploadtype:1,wizard:1,wait:2,
       done:function(){check_FW_and_jump();}
     });

   - When the green LED lights up, the recovery image is installed and
     booted.

4. Install the full image:
   - Open `http://192.168.1.1`/ in a browser.
   - Upgrade OpenWrt with
     `openwrt-xx.xx.xx-squashfs-sysupgrade.bin`.
   - Reboot.

Reverting to stock has not been tested.

### MAC address layout:

LAN: xx:xx:xx:xx:xx:xx from ARC_SYS_BASEMAC (+0)
WAN: xx:xx:xx:xx:xx:xx from ARC_SYS_BASEMAC (+3)
2.4G: xx:xx:xx:xx:xx:xx from ARC_SYS_BASEMAC (+1)
5G: xx:xx:xx:xx:xx:xx from ARC_SYS_BASEMAC (+2)

ARC_SYS_BASEMAC is read from the encrypted pricfg partition.