### PR TITLE
octeon: add and require image METADATA for sysupgrade safety

### DIFF
--- a/target/linux/octeon/base-files/lib/upgrade/platform.sh
+++ b/target/linux/octeon/base-files/lib/upgrade/platform.sh
@@ -1,6 +1,7 @@
 #
-# Copyright (C) 2021 OpenWrt.org
+# Copyright (C) 2026 OpenWrt.org
 #
+REQUIRE_IMAGE_METADATA=1
 
 if [ -x /usr/sbin/blkid ]; then
   RAMFS_COPY_BIN="/usr/sbin/blkid"

--- a/target/linux/octeon/image/Makefile
+++ b/target/linux/octeon/image/Makefile
@@ -23,7 +23,7 @@ define Device/Default
   KERNEL := kernel-bin | strip-kernel | patch-cmdline
   IMAGES := sysupgrade.tar
   IMAGE/sysupgrade.tar/squashfs := append-rootfs | pad-extra 128k | sysupgrade-tar rootfs=$$$$@
-  IMAGE/sysupgrade.tar := sysupgrade-tar
+  IMAGE/sysupgrade.tar := sysupgrade-tar | append-metadata
 endef
 
 define Device/generic
@@ -38,7 +38,6 @@ define Device/itus_shield-router
   DEVICE_VENDOR := Itus Networks
   DEVICE_MODEL := Shield Router
   CMDLINE := $(ITUSROUTER_CMDLINE)
-  IMAGE/sysupgrade.tar/squashfs += | append-metadata
 endef
 TARGET_DEVICES += itus_shield-router
 


### PR DESCRIPTION
Actually this platform is not implementing the fwtool's images METADATA mechanism, indeed allowing* sysupgrades with images which are not meant for the specific device, together with the fact that the platform checks in this platform were relaxed because of changes of devices names convention (migrated from legacy naming) so are not checking for the hardcoded board_name in the sysupgrade-tar images neither.
*Actually, there are some board_name checks in this platform's sysupgrade paths which minimize the risk of a wrongly cross-sysupgrade but still a risk.

So, append the metadata to the common sysupgrade.tar image recipe and add the REQUIRE_IMAGE_METADATA=1 flag in order to guarantee only the correct images pass sysupgrade checks.

SUPPORTED_DEVICES was already set correctly for these devices which use a custom sysinfo board_name since some devices do not have a proper device tree source.

Remove confusing and wrongly "append-metadata" call in the inner squashfs image recipe for the itus_shield-router case[^1].

[^1]: https://github.com/openwrt/openwrt/pull/3241#discussion_r563208623

Reference: https://github.com/openwrt/openwrt/commit/be296745f82665272771e1cfeb2c19438cf3cb5a
