### PR TITLE
realtek: dsa: drop dsa builtin mdio bus

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/common.c
@@ -211,72 +211,20 @@ u64 rtl839x_get_port_reg_le(int reg)
 	return v;
 }
 
-static int rtldsa_bus_read(struct mii_bus *bus, int addr, int regnum)
-{
-	struct rtl838x_switch_priv *priv = bus->priv;
-
-	return mdiobus_read_nested(priv->parent_bus, addr, regnum);
-}
-
-static int rtldsa_bus_write(struct mii_bus *bus, int addr, int regnum, u16 val)
-{
-	struct rtl838x_switch_priv *priv = bus->priv;
-
-	return mdiobus_write_nested(priv->parent_bus, addr, regnum, val);
-}
-
-static int rtldsa_bus_c45_read(struct mii_bus *bus, int addr, int devad, int regnum)
-{
-	struct rtl838x_switch_priv *priv = bus->priv;
-
-	return mdiobus_c45_read_nested(priv->parent_bus, addr, devad, regnum);
-}
-
-static int rtldsa_bus_c45_write(struct mii_bus *bus, int addr, int devad, int regnum, u16 val)
-{
-	struct rtl838x_switch_priv *priv = bus->priv;
-
-	return mdiobus_c45_write_nested(priv->parent_bus, addr, devad, regnum, val);
-}
-
 static int rtl83xx_mdio_probe(struct rtl838x_switch_priv *priv)
 {
 	struct device_node *dn, *phy_node, *pcs_node, *led_node;
-	struct device *dev = priv->dev;
 	struct mii_bus *bus;
-	int ret;
 	u32 pn;
 
+	/* Check if mdio bus is defined with status "okay" and already registered */
 	dn = of_find_compatible_node(NULL, NULL, "realtek,otto-mdio");
-	if (!dn)
+	if (!dn || !of_device_is_available(dn))
 		return -ENODEV;
-
-	if (!of_device_is_available(dn))
-		ret = -ENODEV;
-
-	priv->parent_bus = of_mdio_find_bus(dn);
-	if (!priv->parent_bus)
-		return -EPROBE_DEFER;
-
-	bus = devm_mdiobus_alloc(priv->ds->dev);
+	bus = of_mdio_find_bus(dn);
 	if (!bus)
-		return -ENOMEM;
-
-	bus->name = "rtldsa_mdio";
-	bus->read = rtldsa_bus_read;
-	bus->write = rtldsa_bus_write;
-	bus->read_c45 = rtldsa_bus_c45_read;
-	bus->write_c45 = rtldsa_bus_c45_write;
-	bus->phy_mask = priv->parent_bus->phy_mask;
-	snprintf(bus->id, MII_BUS_ID_SIZE, "%s-%d", bus->name, dev->id);
-
-	bus->parent = dev;
-	priv->ds->user_mii_bus = bus;
-	priv->ds->user_mii_bus->priv = priv;
-
-	ret = mdiobus_register(priv->ds->user_mii_bus);
-	if (ret)
-		return ret;
+		return -EPROBE_DEFER;
+	put_device(&bus->dev);
 
 	dn = of_find_compatible_node(NULL, NULL, "realtek,otto-switch");
 	if (!dn) {

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/dsa.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/dsa.c
@@ -2498,20 +2498,6 @@ out:
 	return 0;
 }
 
-static int rtldsa_phy_read(struct dsa_switch *ds, int addr, int regnum)
-{
-	struct rtl838x_switch_priv *priv = ds->priv;
-
-	return mdiobus_read_nested(priv->parent_bus, addr, regnum);
-}
-
-static int rtldsa_phy_write(struct dsa_switch *ds, int addr, int regnum, u16 val)
-{
-	struct rtl838x_switch_priv *priv = ds->priv;
-
-	return mdiobus_write_nested(priv->parent_bus, addr, regnum, val);
-}
-
 static const struct flow_action_entry *rtldsa_rate_policy_extract(struct flow_cls_offload *cls)
 {
 	struct flow_rule *rule;
@@ -2635,9 +2621,6 @@ const struct dsa_switch_ops rtldsa_83xx_switch_ops = {
 	.get_tag_protocol	= rtldsa_get_tag_protocol,
 	.setup			= rtldsa_83xx_setup,
 
-	.phy_read		= rtldsa_phy_read,
-	.phy_write		= rtldsa_phy_write,
-
 	.phylink_get_caps	= rtldsa_83xx_phylink_get_caps,
 
 	.get_strings		= rtldsa_get_strings,
@@ -2697,9 +2680,6 @@ const struct phylink_mac_ops rtldsa_93xx_phylink_mac_ops = {
 const struct dsa_switch_ops rtldsa_93xx_switch_ops = {
 	.get_tag_protocol	= rtldsa_get_tag_protocol,
 	.setup			= rtldsa_93xx_setup,
-
-	.phy_read		= rtldsa_phy_read,
-	.phy_write		= rtldsa_phy_write,
 
 	.phylink_get_caps	= rtldsa_93xx_phylink_get_caps,
 

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.h
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl838x.h
@@ -1523,7 +1523,6 @@ struct rtl838x_switch_priv {
 	struct mutex pie_mutex;		/* Mutex for Packet Inspection Engine */
 	int link_state_irq;
 	int mirror_group_ports[4];
-	struct mii_bus *parent_bus;
 	const struct rtldsa_config *r;
 	u64 irq_mask;
 	struct dentry *dbgfs_dir;


### PR DESCRIPTION
For a long time the dsa driver has been providing a builtin mdio bus via dsa default attribute user_mii_bus. This simply uses read/write commands from the standard realtek otto bus (aka parent). The reason has always been unclear.

Looking around the kernel 6.18 codebase there is only one case where this is really needed. The only consumer is dsa_user_phy_setup().

```
ret = phylink_of_phy_connect(dp->pl, port_dn, phy_flags); 
if (ret == -ENODEV && ds->user_mii_bus) {
	/* We could not connect to a designated PHY or SFP, so try to
	 * use the switch internal MDIO bus instead 
	 */ 
	 ret = dsa_user_phy_connect(user_dev, dp->index, phy_flags); 
}
```

Luckily the phylink_of_phy_connect() works fine and the internal bus access is not needed at all. No need to keep the bus alive. Drop it.
