### PR TITLE
build: set max-page-size linker flag to match target page size

### DIFF
--- a/include/package.mk
+++ b/include/package.mk
@@ -61,6 +61,15 @@ ifdef CONFIG_USE_MOLD
   endif
 endif
 
+# loongarch64 sets CONFIG_PAGE_SIZE_16KB, all other targets set CONFIG_PAGE_SIZE_4KB only.
+ifeq ($(ARCH),loongarch64)
+  TARGET_CFLAGS += -Wl,-z,max-page-size=16384
+  TARGET_LDFLAGS += -zmax-page-size=16384
+else
+  TARGET_CFLAGS += -Wl,-z,max-page-size=4096
+  TARGET_LDFLAGS += -zmax-page-size=4096
+endif
+
 include $(INCLUDE_DIR)/hardening.mk
 include $(INCLUDE_DIR)/prereq.mk
 include $(INCLUDE_DIR)/unpack.mk


### PR DESCRIPTION
ELF binaries embed the maximum page size used during linking in the PT_LOAD segment alignment. If this value is larger than the actual system page size, the kernel will still load the binary but wastes memory due to over-alignment. If it is smaller, the binary may fail to load or cause incorrect behavior with features like RELRO.

Most architectures use 4KB pages, but loongarch64 uses 16KB pages (CONFIG_PAGE_SIZE_16KB). Explicitly pass -z max-page-size to the linker so that binaries are built with the correct page alignment for the target, avoiding issues with RELRO segment padding and ensuring correct memory mapping on the target system.

Before binutils 2.39 relro sections were padded to common page size which is 4K on MIPS, with binutils 3.29 the padding was changed to max page size which is 64K on MIPS. With this change we will pad them to 4K again.

This recrudesces the size of user space binaries in OpenWrt. The size of the uncompressed root file system of a mips malta be build decreased by about 20%.

old file size:
```
$ du -s build_dir/target-mips_24kc_musl/root-malta/
15844	build_dir/target-mips_24kc_musl/root-malta/
```

New file size:
```
$ du -s build_dir/target-mips_24kc_musl/root-malta/
12564	build_dir/target-mips_24kc_musl/root-malta/
```

The size of the image did not decrease much because of the strong compression used by OpenWrt.

This is an alternative PR to the solution from: https://github.com/openwrt/openwrt/pull/22224 I prefer this version, it only sets a configuration option instead of patching binutils. Android is now setting the same option to build with 16K page support. 