### PR TITLE
qualcommax: ipq807x: add label mac alias for Linksys MX5300

### DIFF
--- a/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
+++ b/target/linux/qualcommax/files/arch/arm64/boot/dts/qcom/ipq8072-mx5300.dts
@@ -35,6 +35,10 @@
 		bootargs-append = " root=/dev/ubiblock0_0 rootfstype=squashfs ro";
 	};
 
+	aliases {
+		label-mac-device = &dp2;
+	};
+
 	keys {
 		compatible = "gpio-keys";
 		pinctrl-0 = <&button_pins>;


### PR DESCRIPTION
The correct label mac is needed in a downstream project. https://github.com/freifunk-gluon/gluon/pull/3727

Signed-off-by: Steffen Förster <nemesis@chemnitz.freifunk.net>

