### PR TITLE
treewide: use -n for fw_[saveprint]env

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/init.d/bootcount
+++ b/target/linux/ath79/generic/base-files/etc/init.d/bootcount
@@ -12,8 +12,7 @@ boot() {
 		fw_setenv fwr_verify 0
 		;;
 	qihoo,c301)
-		local n=$(fw_printenv activeregion | cut -d = -f 2)
-		fw_setenv "image${n}trynum" 0
+		fw_setenv $(printf "image%strynum" $(fw_printenv -n activeregion)) 0
 		;;
 	esac
 }

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -97,11 +97,9 @@ define Device/kernel-size-migration-linksys
     2. Run folowing commands in console (ssh or serial): \n$\
     \t fw_printenv \n$\
     \t fw_setenv nandboot \
-    "$$$$(fw_printenv nandboot | awk -F= '{sub(/^nandboot=/, "");print}' \
-    | sed 's/0x300000/0x400000/g')"\n$\
+    "$$$$(fw_printenv -n nandboot | sed 's/0x300000/0x400000/g')"\n$\
     \t fw_setenv altnandboot \
-    "$$$$(fw_printenv altnandboot | awk -F= '{sub(/^altnandboot=/, "");print}' \
-    | sed 's/0x300000/0x400000/g')"\n$\
+    "$$$$(fw_printenv -n altnandboot | sed 's/0x300000/0x400000/g')"\n$\
     3. Test if envs are ok by 'fw_printenv'. \
     It should be the same except last argument of\
     'nand read.e' in 'nandboot' and 'altnandboot'.\n$\


### PR DESCRIPTION
Using awk and cut to simulate -n is pointless.

