### PR TITLE
mediatek: filogic: add support for ZBT-Z8102AX V2 (eMMC)

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -130,6 +130,9 @@ gatonetworks,gdsp)
 glinet,gl-mt3000)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x20000"
 	;;
+zbtlink,zbt-z8102ax-v2-emmc)
+	ubootenv_add_uci_config "/dev/mmcblk0p2" "0x0" "0x80000" "0x200"
+	;;
 openembed,som7981)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x80000"
 	ubootenv_add_uci_sys_config "/dev/mtd3" "0x0" "0x100000" "0x100000"

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -146,6 +146,9 @@ jiorouter,ax6000-jidu6101)
 	envdev=/dev/$(nand_find_volume "$envubi" u-boot-env)
 	ubootenv_add_uci_config "$envdev" "0x0" "0x80000" "0x80000" "1"
 	;;
+zbtlink,zbt-z8102ax-v2-emmc)
+	ubootenv_add_uci_config "/dev/mmcblk0p2" "0x0" "0x80000" "0x200"
+	;;
 openembed,som7981)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x80000" "0x80000"
 	ubootenv_add_uci_sys_config "/dev/mtd3" "0x0" "0x100000" "0x100000"

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2-emmc.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2-emmc.dts
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "ZBT Z8102AX V2 (eMMC)";
+	compatible = "zbtlink,zbt-z8102ax-v2-emmc", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "console=ttyS0,115200n8 root=PARTLABEL=rootfs rootwait";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x40000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		button-mesh {
+			label = "mesh";
+			linux,code = <BTN_0>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		button-hub {
+			label = "hub";
+			linux,code = <BTN_1>;
+			gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: red {
+			gpios = <&pio 9 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_status_green: green {
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_status_blue: blue {
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		4g {
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <0>;
+		};
+
+		4g2 {
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <1>;
+		};
+	};
+
+	gpio-watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1000>;
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		pcie {
+			gpio-export,name = "pcie_power";
+			gpio-export,output = <1>;
+			gpios = <&pio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		5g1 {
+			gpio-export,name = "5g1";
+			gpio-export,output = <1>;
+			gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		5g2 {
+			gpio-export,name = "5g2";
+			gpio-export,output = <1>;
+			gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		sim1 {
+			gpio-export,name = "sim1";
+			gpio-export,output = <0>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		sim2 {
+			gpio-export,name = "sim2";
+			gpio-export,output = <0>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		/* LAN */
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 0>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		/* WAN */
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 2>;
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&mmc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_default>;
+	pinctrl-1 = <&mmc0_pins_uhs>;
+	bus-width = <8>;
+	max-frequency = <52000000>;
+	cap-mmc-highspeed;
+	no-sd;
+	no-sdio;
+	non-removable;
+	vmmc-supply = <&reg_3p3v>;
+	status = "okay";
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+
+			partitions {
+				block-partition-env {
+					partname = "u-boot-env";
+
+					nvmem-layout {
+						compatible = "u-boot,env";
+					};
+				};
+
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory: eeprom@0 {
+							reg = <0x0 0x1000>;
+						};
+
+						macaddr_factory_4: macaddr@4 {
+							compatible = "mac-base";
+							reg = <0x4 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+
+				block-partition-kernel {
+					partname = "kernel";
+				};
+
+				block-partition-rootfs {
+					partname = "rootfs";
+				};
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+		};
+
+		port@6 {
+			reg = <6>;
+			label = "cpu";
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	mmc0_pins_default: mmc0-pins-default {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+
+	mmc0_pins_uhs: mmc0-pins-uhs {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2-emmc.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2-emmc.dts
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "ZBT Z8102AX V2 (eMMC)";
+	compatible = "zbtlink,zbt-z8102ax-v2-emmc", "mediatek,mt7981";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "console=ttyS0,115200n8 root=PARTLABEL=rootfs rootwait";
+		rootdisk = <&rootfs_partition>;
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x40000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		button-mesh {
+			label = "mesh";
+			linux,code = <BTN_0>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		button-hub {
+			label = "hub";
+			linux,code = <BTN_1>;
+			gpios = <&pio 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: red {
+			gpios = <&pio 9 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_status_green: green {
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_status_blue: blue {
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		4g {
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <0>;
+		};
+
+		4g2 {
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_USB;
+			function-enumerator = <1>;
+		};
+	};
+
+	gpio-watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1000>;
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		pcie {
+			gpio-export,name = "pcie_power";
+			gpio-export,output = <1>;
+			gpios = <&pio 3 GPIO_ACTIVE_HIGH>;
+		};
+
+		5g1 {
+			gpio-export,name = "5g1";
+			gpio-export,output = <1>;
+			gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		5g2 {
+			gpio-export,name = "5g2";
+			gpio-export,output = <1>;
+			gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+		};
+
+		sim1 {
+			gpio-export,name = "sim1";
+			gpio-export,output = <0>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+		sim2 {
+			gpio-export,name = "sim2";
+			gpio-export,output = <0>;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		/* LAN */
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 0>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		/* WAN */
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 2>;
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&mmc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-names = "default", "state_uhs";
+	pinctrl-0 = <&mmc0_pins_default>;
+	pinctrl-1 = <&mmc0_pins_uhs>;
+	bus-width = <8>;
+	max-frequency = <52000000>;
+	cap-mmc-highspeed;
+	no-sd;
+	no-sdio;
+	non-removable;
+	vmmc-supply = <&reg_3p3v>;
+	status = "okay";
+
+	card@0 {
+		compatible = "mmc-card";
+		reg = <0>;
+
+		block {
+			compatible = "block-device";
+
+			partitions {
+				block-partition-env {
+					partname = "u-boot-env";
+
+					nvmem-layout {
+						compatible = "u-boot,env";
+					};
+				};
+
+				block-partition-factory {
+					partname = "factory";
+
+					nvmem-layout {
+						compatible = "fixed-layout";
+						#address-cells = <1>;
+						#size-cells = <1>;
+
+						eeprom_factory: eeprom@0 {
+							reg = <0x0 0x1000>;
+						};
+
+						macaddr_factory_4: macaddr@4 {
+							compatible = "mac-base";
+							reg = <0x4 0x6>;
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+
+				block-partition-kernel {
+					partname = "kernel";
+				};
+
+				rootfs_partition: block-partition-rootfs {
+					partname = "rootfs";
+				};
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+		};
+
+		port@6 {
+			reg = <6>;
+			label = "cpu";
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	mmc0_pins_default: mmc0-pins-default {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+
+	mmc0_pins_uhs: mmc0-pins-uhs {
+		mux {
+			function = "flash";
+			groups = "emmc_45";
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	nvmem-cells = <&eeprom_factory>;
+	nvmem-cell-names = "eeprom";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -77,6 +77,7 @@ mediatek_setup_interfaces()
 	wavlink,wl-wn536ax6-a|\
 	zbtlink,zbt-z8102ax|\
 	zbtlink,zbt-z8102ax-v2|\
+	zbtlink,zbt-z8102ax-v2-emmc|\
 	zbtlink,zbt-z8106ax-s)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1"
 		;;
@@ -294,6 +295,11 @@ mediatek_setup_macs()
 		label_mac=$(mtd_get_mac_ascii product_info ethaddr)
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add "$label_mac" 1)
+		;;
+	zbtlink,zbt-z8102ax-v2-emmc)
+		lan_mac=$(mmc_get_mac_binary factory 0x4)
+		[ -n "$lan_mac" ] && wan_mac=$(macaddr_add "$lan_mac" 2)
+		label_mac=$lan_mac
 		;;
 	tplink,eap683-lr)
 		label_mac=$(get_mac_binary "/tmp/factory/default-mac" 0)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -89,6 +89,7 @@ mediatek_setup_interfaces()
 	wavlink,wl-wn536ax6-a|\
 	zbtlink,zbt-z8102ax|\
 	zbtlink,zbt-z8102ax-v2|\
+	zbtlink,zbt-z8102ax-v2-emmc|\
 	zbtlink,zbt-z8106ax-s)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1"
 		;;
@@ -325,6 +326,11 @@ mediatek_setup_macs()
 		label_mac=$(mtd_get_mac_ascii product_info ethaddr)
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add "$label_mac" 1)
+		;;
+	zbtlink,zbt-z8102ax-v2-emmc)
+		lan_mac=$(mmc_get_mac_binary factory 0x4)
+		[ -n "$lan_mac" ] && wan_mac=$(macaddr_add "$lan_mac" 2)
+		label_mac=$lan_mac
 		;;
 	tplink,eap683-lr|\
 	tplink,f65-v1)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
@@ -14,7 +14,8 @@ teltonika,rutc50)
 	ucidef_add_gpio_switch "modem_reset" "Modem reset" "modem_reset" "0"
 	;;
 zbtlink,zbt-z8102ax|\
-zbtlink,zbt-z8102ax-v2)
+zbtlink,zbt-z8102ax-v2|\
+zbtlink,zbt-z8102ax-v2-emmc)
 	ucidef_add_gpio_switch "5g1" "Power 1st modem" "5g1" "1"
 	ucidef_add_gpio_switch "5g2" "Power 2nd modem" "5g2" "1"
 	ucidef_add_gpio_switch "pcie" "Power PCIe port" "pcie" "1"

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -237,8 +237,14 @@ case "$board" in
 	routerich,ax3000|\
 	routerich,ax3000-ubootmod|\
 	zbtlink,zbt-z8102ax|\
-	zbtlink,zbt-z8102ax-v2)
-		addr=$(mtd_get_mac_binary "Factory" 0x4)
+	zbtlink,zbt-z8102ax-v2|\
+	zbtlink,zbt-z8102ax-v2-emmc)
+		if [ "$board" = "zbtlink,zbt-z8102ax-v2-emmc" ]; then
+			addr=$(mmc_get_mac_binary factory 0x4)
+			[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
+		else
+			addr=$(mtd_get_mac_binary "Factory" 0x4)
+		fi
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		;;
 	wavlink,wl-wn573hx3)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -238,8 +238,14 @@ case "$board" in
 	routerich,ax3000|\
 	routerich,ax3000-ubootmod|\
 	zbtlink,zbt-z8102ax|\
-	zbtlink,zbt-z8102ax-v2)
-		addr=$(mtd_get_mac_binary "Factory" 0x4)
+	zbtlink,zbt-z8102ax-v2|\
+	zbtlink,zbt-z8102ax-v2-emmc)
+		if [ "$board" = "zbtlink,zbt-z8102ax-v2-emmc" ]; then
+			addr=$(mmc_get_mac_binary factory 0x4)
+			[ "$PHYNBR" = "0" ] && echo "$addr" > /sys${DEVPATH}/macaddress
+		else
+			addr=$(mtd_get_mac_binary "Factory" 0x4)
+		fi
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress
 		;;
 	ruijie,rg-x60-pro)

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -186,6 +186,12 @@ platform_do_upgrade() {
 		CI_ROOTPART="rootfs"
 		emmc_do_upgrade "$1"
 		;;
+	zbtlink,zbt-z8102ax-v2-emmc)
+		CI_ROOTDEV="mmcblk0"
+		CI_KERNPART="kernel"
+		CI_ROOTPART="rootfs"
+		emmc_do_upgrade "$1"
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax57m|\
 	asus,rt-ax59u|\
@@ -417,7 +423,8 @@ platform_copy_config() {
 	smartrg,sdg-8733|\
 	smartrg,sdg-8733a|\
 	smartrg,sdg-8734|\
-	ubnt,unifi-6-plus)
+	ubnt,unifi-6-plus|\
+	zbtlink,zbt-z8102ax-v2-emmc)
 		emmc_copy_config
 		;;
 	esac

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -242,6 +242,12 @@ platform_do_upgrade() {
 		rm -f "$tmpfile"
 		nand_do_upgrade "$1"
 		;;
+	zbtlink,zbt-z8102ax-v2-emmc)
+		CI_ROOTDEV="mmcblk0"
+		CI_KERNPART="kernel"
+		CI_ROOTPART="rootfs"
+		emmc_do_upgrade "$1"
+		;;
 	asus,rt-ax52|\
 	asus,rt-ax57m|\
 	asus,rt-ax59u|\
@@ -490,7 +496,8 @@ platform_copy_config() {
 	smartrg,sdg-8733|\
 	smartrg,sdg-8733a|\
 	smartrg,sdg-8734|\
-	ubnt,unifi-6-plus)
+	ubnt,unifi-6-plus|\
+	zbtlink,zbt-z8102ax-v2-emmc)
 		emmc_copy_config
 		;;
 	esac

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -3415,6 +3415,19 @@ define Device/zbtlink_zbt-z8102ax-v2
 endef
 TARGET_DEVICES += zbtlink_zbt-z8102ax-v2
 
+define Device/zbtlink_zbt-z8102ax-v2-emmc
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-Z8102AX-V2
+  DEVICE_VARIANT := (EMMC)
+  DEVICE_DTS := mt7981b-zbtlink-zbt-z8102ax-v2-emmc
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-net-qmi-wwan kmod-usb-serial-option kmod-usb-net-cdc-ether kmod-fs-f2fs f2fsck mkf2fs
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zbtlink_zbt-z8102ax-v2-emmc
+
 define Device/zbtlink_zbt-z8103ax
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-Z8103AX

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -3667,6 +3667,7 @@ TARGET_DEVICES += zbtlink_zbt-z8102ax
 define Device/zbtlink_zbt-z8102ax-v2
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-Z8102AX-V2
+  DEVICE_VARIANT := (SPI-NAND)
   DEVICE_DTS := mt7981b-zbtlink-zbt-z8102ax-v2
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-net-qmi-wwan kmod-usb-serial-option
@@ -3682,6 +3683,19 @@ define Device/zbtlink_zbt-z8102ax-v2
   DEVICE_COMPAT_MESSAGE := Partition layout has been changed to fit the bootloader
 endef
 TARGET_DEVICES += zbtlink_zbt-z8102ax-v2
+
+define Device/zbtlink_zbt-z8102ax-v2-emmc
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-Z8102AX-V2
+  DEVICE_VARIANT := (EMMC)
+  DEVICE_DTS := mt7981b-zbtlink-zbt-z8102ax-v2-emmc
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-net-qmi-wwan kmod-usb-serial-option kmod-usb-net-cdc-ether kmod-fs-f2fs f2fsck mkf2fs
+  KERNEL := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zbtlink_zbt-z8102ax-v2-emmc
 
 define Device/zbtlink_zbt-z8103ax
   DEVICE_VENDOR := Zbtlink


### PR DESCRIPTION
This PR adds support for the **eMMC variant** of the **ZBT Z8102AX V2** router, which was previously only available with SPI-NAND storage.

**This PR supersedes #21995**

### Specifications
- SoC: MediaTek MT7981B
- RAM: 1024MiB DDR4
- Storage: eMMC (8GB, GPT layout defined by vendor bootloader)
- Network: 4x Gigabit LAN + 1x Gigabit WAN, MT7531 switch
- WiFi: MT7976CN (AX3000 2.4GHz + 5GHz dual-band)
- USB: 1x USB 3.0 port + 2x M.2 slots (5G modem support)
- Buttons: Reset, Mesh (WPS)
- Power: DC 12V 2 A
- UART: 115200n8 (VCC-RX-TX-GND layout)

The device uses standard OpenWrt squashfs with overlay filesystem for persistent storage.

### Installation
- Power down the router and hold the Reset button.
- While holding the button, power up the router.
- Keep holding the button for about 10 seconds until the LEDs change, then release.
- Connect your computer to a LAN port and navigate to 192.168.1.1 in a web browser.
- You should see the U-Boot Web Recovery GUI.
- Upload the OpenWrt sysupgrade file (squashfs-sysupgrade.bin) to flash the firmware.

Note: The Web Recovery GUI can also be used to unbrick the device if an incorrect firmware is flashed.

### Partition Layout

Partition  | Size      | Description
-----------|-----------|------------
factory    | 512 KiB   | WiFi calibration & MAC addresses
fip        | 512 KiB   | Firmware image payload (ATF)
kernel     | 8 MiB     | Linux kernel image
rootfs     | remaining space | Root filesystem with overlay

### Block Device Mapping

/dev/        | Name    | Sectors | Description
-------------|---------|---------|------------
mmcblk0      |         | 7634944 | 8GB eMMC
mmcblk0p1    | gpt     | 17      | GPT table
mmcblk0p2    | u-boot-env     | 512     | U-Boot environment
mmcblk0p3    | factory | 2048    | Factory data
mmcblk0p4    | fip     | 2048    | Firmware payload
mmcblk0p5    | kernel  | 32768   | Linux kernel
mmcblk0p6    | rootfs  | 7298560 | Squashfs + Overlay
mmcblk0boot0 |         | 4096    | eMMC boot partition 0
mmcblk0boot1 |         | 4096    | eMMC boot partition 1

### Rootfs Filesystem

The rootfs uses **squashfs as a read-only base filesystem** with **automatic overlay mounting** for persistent configuration storage.

**Squashfs (Read-only):**
- Type: squashfs
- Mount point: /rom
- Contains: OpenWrt base system

**Overlay (Read-write):**
- Type: automatically created (ext4 or f2fs depending on configuration)
- Mount point: /overlay
- Stored in: Free space within rootfs partition
- Survives: Reboots, sysupgrade operations

**Persistent Data Locations:**
- /etc/config/* - Network and system configuration
- /etc/passwd* - User account information
- /root - Root home directory
- /var/* - Application state and logs
- Custom packages and modifications

### MAC Address Assignment

The device derives all MAC addresses from a single base address stored in the factory partition:

Interface    | MAC Address       | Offset
-------------|-------------------|-------
Base MAC     | f8:5e:3c:66:af:c6 | +0
LAN Ports    | f8:5e:3c:66:af:c6 | +0
WiFi 2.4GHz  | f8:5e:3c:66:af:c6 | +0
WiFi 5GHz    | f8:5e:3c:66:af:c7 | +1
WAN Port     | f8:5e:3c:66:af:c8 | +2

### Implementation Details

**Device Tree**: mt7981b-zbtlink-zbt-z8102ax-v2-emmc.dts
- eMMC support with NVMEM layout for factory partition
- Rootdisk reference for libfstools overlay detection
- GPIO and LED configuration for all indicators

**Build Configuration**: target/linux/mediatek/image/filogic.mk
- Uses vendor GPT partition layout
- Kernel and rootfs sysupgrade support
- Factory image generation for initial flashing

### Testing Performed

- Device tree compilation and validation
- eMMC partition detection and mounting
- Overlay filesystem automatic creation and persistence
- WiFi calibration data loading from factory partition
- MAC address derivation and assignment
- Sysupgrade with configuration preservation

### Related Issues

This PR supersedes #21995.
Compared to #21995, this version aligns the ZBT-Z8102AX V2 eMMC flow with existing filogic eMMC devices by wiring board-specific eMMC paths in base-files (MAC derivation from the MMC factory partition, sysupgrade via emmc_do_upgrade, and U-Boot env on mmcblk0p2), and by adding the V2 eMMC profile so image metadata and runtime board handling are consistent.

### Notes for Reviewers

- The device follows the vendor GPT partition layout
- Overlay support is enabled through libfstools automatic detection via root=PARTLABEL=rootfs rootwait kernel parameter
- The device is backward compatible with existing OpenWrt infrastructure
- No additional kernel patches or out-of-tree drivers required

### Credits
Signed-off-by: giorez <nospam@rezzoli.com>
Co-authored-by: tokisaki <moebest@outlook.jp>
