### PR TITLE
kernel: net: sfp: add quirks for GPON ONT SFP sticks

### DIFF
--- a/target/linux/generic/backport-6.12/782-net-sfp-add-quirk-for-gpon-ont-sticks.patch
+++ b/target/linux/generic/backport-6.12/782-net-sfp-add-quirk-for-gpon-ont-sticks.patch
@@ -1,0 +1,60 @@
+From 95aca8602ef70ffd3d971675751c81826e124f90 Mon Sep 17 00:00:00 2001
+From: John Pavlick <jspavlick@posteo.net>
+Date: Mon, 6 Apr 2026 13:23:33 +0000
+Subject: net: sfp: add quirks for Hisense and HSGQ GPON ONT SFP modules
+
+Several GPON ONT SFP sticks based on Realtek RTL960x report
+1000BASE-LX at 1300MBd in their EEPROM but can operate at 2500base-X.
+On hosts capable of 2500base-X (e.g. Banana Pi R3 / MT7986), the
+kernel negotiates only 1G because it trusts the incorrect EEPROM data.
+
+Add quirks for:
+- Hisense-Leox LXT-010S-H
+- Hisense ZNID-GPON-2311NA
+- HSGQ HSGQ-XPON-Stick
+
+Each quirk advertises 2500base-X and ignores TX_FAULT during the
+module's ~40s Linux boot time.
+
+Tested on Banana Pi R3 (MT7986) with OpenWrt 25.12.1, confirmed
+2.5Gbps link and full throughput with flow offloading.
+
+Reviewed-by: Russell King (Oracle) <rmk+kernel@armlinux.org.uk>
+Suggested-by: Marcin Nita <marcin.nita@leolabs.pl>
+Signed-off-by: John Pavlick <jspavlick@posteo.net>
+Link: https://patch.msgid.link/20260406132321.72563-1-jspavlick@posteo.net
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/phy/sfp.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/drivers/net/phy/sfp.c b/drivers/net/phy/sfp.c
+index ce8924613363b..6b7b8ae15d106 100644
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -543,6 +543,22 @@ static const struct sfp_quirk sfp_quirks[] = {
+ 	SFP_QUIRK("HUAWEI", "MA5671A", sfp_quirk_2500basex,
+ 		  sfp_fixup_ignore_tx_fault_and_los),
+ 
++	// Hisense LXT-010S-H is a GPON ONT SFP (sold as LEOX LXT-010S-H) that
++	// can operate at 2500base-X, but reports 1000BASE-LX / 1300MBd in its
++	// EEPROM
++	SFP_QUIRK("Hisense-Leox", "LXT-010S-H", sfp_quirk_2500basex,
++		  sfp_fixup_ignore_tx_fault),
++
++	// Hisense ZNID-GPON-2311NA can operate at 2500base-X, but reports
++	// 1000BASE-LX / 1300MBd in its EEPROM
++	SFP_QUIRK("Hisense", "ZNID-GPON-2311NA", sfp_quirk_2500basex,
++		  sfp_fixup_ignore_tx_fault),
++
++	// HSGQ HSGQ-XPON-Stick can operate at 2500base-X, but reports
++	// 1000BASE-LX / 1300MBd in its EEPROM
++	SFP_QUIRK("HSGQ", "HSGQ-XPON-Stick", sfp_quirk_2500basex,
++		  sfp_fixup_ignore_tx_fault),
++
+ 	// Lantech 8330-262D-E and 8330-265D can operate at 2500base-X, but
+ 	// incorrectly report 2500MBd NRZ in their EEPROM.
+ 	// Some 8330-265D modules have inverted LOS, while all of them report
+-- 
+cgit 1.3-korg
+


### PR DESCRIPTION
Several GPON ONT SFP sticks based on Realtek RTL960x report 1000BASE-LX at 1300MBd in their EEPROM but can operate at 2500base-X. On hosts capable of 2500base-X (e.g. Banana Pi R3 / MT7986), the kernel negotiates only 1G because it trusts the incorrect EEPROM data, regardless of the LAN_SDS_MODE configured on the module.

Add quirks for:
- Hisense-Leox LXT-010S-H
- Hisense ZNID-GPON-2311NA
- HSGQ HSGQ-XPON-Stick

Each quirk advertises 2500base-X and ignores TX_FAULT during the module's ~40s Linux boot time.

Tested on Banana Pi R3 (MT7986) with OpenWrt 25.12.1, confirmed 2.5Gbps link and full throughput with flow offloading.

CREDIT TO: Marcin Nita from LEOX Labs and I exchanged some emails, talking about the possibility of editing the EEPROM data on my LEOX stick itself. (That has the downside of not helping anyone other than me, unless everyone wants to mess around with flashing/editing their EEPROM on their SFP sticks) And Marcin pointed me to sfp.c as a potential fix/workaround. That sent me down this "rabbit hole" and here I am submitting a PR. So big thank you to Marcin Nita from LEOX Labs.

Note: also submitted upstream to the Linux kernel netdev mailing list as `[PATCH v2] net: sfp: add quirks for GPON ONT SFP sticks` (Message-ID: 20260406114352.69168-1-jspavlick@posteo.net).