### PR TITLE
bcm53xx: add ramdisk to FEATURES

### DIFF
--- a/target/linux/bcm53xx/Makefile
+++ b/target/linux/bcm53xx/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 ARCH:=arm
 BOARD:=bcm53xx
 BOARDNAME:=Broadcom BCM47xx/53xx (ARM)
-FEATURES:=squashfs nand usb pci pcie gpio pwm
+FEATURES:=squashfs nand usb pci pcie gpio pwm ramdisk
 CPU_TYPE:=cortex-a9
 SUBTARGETS:=generic
 


### PR DESCRIPTION
Cisco/Meraki mx64/mx65 targets require initramfs
( ramdisk) for install.
Add it to default target build.

Originally posted at: https://lists.openwrt.org/pipermail/openwrt-devel/2024-October/043324.html