### PR TITLE
ramips: wex-1166dhpl: add Buffalo WEX-1166DHPL support

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -289,6 +289,47 @@ define Build/buffalo-tag-dhp
 	mv $@.new $@
 endef
 
+define Build/buffalo-wex-image
+	$(eval version=$(word 1,$(1)))
+	$(eval verify_len=$(if $(word 2,$(1)),$(word 2,$(1)),0x4))
+	( \
+		set -e; \
+		be32() { \
+			printf '%b' \
+				"\\$$(printf '%03o' $$((($$1 >> 24) & 255)))" \
+				"\\$$(printf '%03o' $$((($$1 >> 16) & 255)))" \
+				"\\$$(printf '%03o' $$((($$1 >> 8) & 255)))" \
+				"\\$$(printf '%03o' $$(( $$1 & 255)))"; \
+		}; \
+		img="$@"; \
+		tmp="$$img.tmp"; \
+		hdr="$$img.hdr"; \
+		cp "$$img" "$$tmp"; \
+		kernel_len="$$(dd if="$$tmp" bs=1 skip=12 count=4 2>/dev/null | od -An -N4 -tu4 --endian big | tr -d ' \n')"; \
+		rootfs_off="$$((64 + kernel_len))"; \
+		file_size="$$(stat -c%s "$$tmp")"; \
+		crc_len="$$(( $(verify_len) ))"; \
+		target_end="$$((rootfs_off + crc_len))"; \
+		[ "$$target_end" -gt "$$rootfs_off" ]; \
+		if [ "$$file_size" -lt "$$target_end" ]; then \
+			pad="$$((target_end - file_size))"; \
+			head -c "$$pad" /dev/zero | tr '\000' '\377' >> "$$tmp"; \
+			file_size="$$target_end"; \
+		fi; \
+		rootfs_crc="$$(dd if="$$tmp" bs=1 skip="$$rootfs_off" count="$$crc_len" 2>/dev/null | gzip -1 -c | tail -c8 | od -An -N4 -tu4 --endian little | tr -d ' \n')"; \
+		dd if=/dev/zero bs=1 count=32 2>/dev/null | dd of="$$tmp" bs=1 seek=32 conv=notrunc 2>/dev/null; \
+		printf 'BUFFALO Ver:$(version)' | dd of="$$tmp" bs=1 seek=32 conv=notrunc 2>/dev/null; \
+		be32 "$$crc_len" | dd of="$$tmp" bs=1 seek=56 conv=notrunc 2>/dev/null; \
+		be32 "$$rootfs_crc" | dd of="$$tmp" bs=1 seek=60 conv=notrunc 2>/dev/null; \
+		dd if="$$tmp" bs=1 count=64 2>/dev/null > "$$hdr"; \
+		be32 0 | dd of="$$hdr" bs=1 seek=4 conv=notrunc 2>/dev/null; \
+		hcrc="$$(gzip -1 -c < "$$hdr" | tail -c8 | od -An -N4 -tu4 --endian little | tr -d ' \n')"; \
+		be32 "$$hcrc" | dd of="$$tmp" bs=1 seek=4 conv=notrunc 2>/dev/null; \
+		mv "$$tmp" "$$img"; \
+		rm -f "$$hdr"; \
+	)
+endef
+
 define Build/buffalo-trx
 	$(eval magic=$(word 1,$(1)))
 	$(eval kern_bin=$(if $(1),$(IMAGE_KERNEL),$@))

--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -310,6 +310,41 @@ define Build/buffalo-trx
 	mv $@.new $@
 endef
 
+# WEX header: "BUFFALO Ver:" at offset 32, verified length at 56, and CRC32 at 60.
+# Limit the bootloader's rootfs CRC to four bytes to avoid a long boot delay.
+define Build/buffalo-wex-image
+	$(eval version=$(word 1,$(1)))
+	( \
+		set -e; \
+		be32() { \
+			printf '%b' \
+				"\\$$(printf '%03o' $$((($$1 >> 24) & 255)))" \
+				"\\$$(printf '%03o' $$((($$1 >> 16) & 255)))" \
+				"\\$$(printf '%03o' $$((($$1 >> 8) & 255)))" \
+				"\\$$(printf '%03o' $$(( $$1 & 255)))"; \
+		}; \
+		img="$@"; \
+		tmp="$$img.tmp"; \
+		hdr="$$img.hdr"; \
+		cp "$$img" "$$tmp"; \
+		kernel_len="$$(dd if="$$tmp" bs=1 skip=12 count=4 2>/dev/null | od -An -N4 -tu4 --endian big | tr -d ' \n')"; \
+		rootfs_off="$$((64 + kernel_len))"; \
+		crc_len="$$((0x4))"; \
+		[ "$$(stat -c%s "$$tmp")" -ge "$$((rootfs_off + crc_len))" ]; \
+		rootfs_crc="$$(dd if="$$tmp" bs=1 skip="$$rootfs_off" count="$$crc_len" 2>/dev/null | gzip -1 -c | tail -c8 | od -An -N4 -tu4 --endian little | tr -d ' \n')"; \
+		dd if=/dev/zero bs=1 count=32 2>/dev/null | dd of="$$tmp" bs=1 seek=32 conv=notrunc 2>/dev/null; \
+		printf 'BUFFALO Ver:$(version)' | dd of="$$tmp" bs=1 seek=32 conv=notrunc 2>/dev/null; \
+		be32 "$$crc_len" | dd of="$$tmp" bs=1 seek=56 conv=notrunc 2>/dev/null; \
+		be32 "$$rootfs_crc" | dd of="$$tmp" bs=1 seek=60 conv=notrunc 2>/dev/null; \
+		dd if="$$tmp" bs=1 count=64 2>/dev/null > "$$hdr"; \
+		be32 0 | dd of="$$hdr" bs=1 seek=4 conv=notrunc 2>/dev/null; \
+		hcrc="$$(gzip -1 -c < "$$hdr" | tail -c8 | od -An -N4 -tu4 --endian little | tr -d ' \n')"; \
+		be32 "$$hcrc" | dd of="$$tmp" bs=1 seek=4 conv=notrunc 2>/dev/null; \
+		mv "$$tmp" "$$img"; \
+		rm -f "$$hdr"; \
+	)
+endef
+
 define Build/check-size
 	@imagesize="$$(stat -c%s $@)"; \
 	limitsize="$$(($(call exp_units,$(if $(1),$(1),$(IMAGE_SIZE)))))"; \

--- a/target/linux/ramips/dts/mt7628an_buffalo_wex-1166dhpl.dts
+++ b/target/linux/ramips/dts/mt7628an_buffalo_wex-1166dhpl.dts
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "buffalo,wex-1166dhpl", "mediatek,mt7628an-soc";
+	model = "Buffalo WEX-1166DHPL";
+
+	aliases {
+		led-boot = &led_pwr;
+		led-failsafe = &led_pwr;
+		led-running = &led_pwr;
+		led-upgrade = &led_pwr;
+		label-mac-device = &ethernet;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_pwr: pwr {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		pwr2 {
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+			color = <LED_COLOR_ID_ORANGE>;
+		};
+
+		wps {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		wlan2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <58000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "nouser";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x200>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+
+			partition@850000 {
+				compatible = "denx,uimage";
+				label = "firmware2";
+				reg = <0x850000 0x7b0000>;
+			};
+
+		};
+	};
+};
+
+&gpio {
+	enable-leds {
+		gpio-hog;
+		line-name = "enable-leds";
+		output-low;
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3e>;
+	mediatek,led_source = <4>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&usbphy {
+	status = "disabled";
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&state_default {
+	spis {
+		groups = "spis";
+		function = "spis";
+	};
+
+	gpio {
+		groups = "refclk", "i2c", "wled_an";
+		function = "gpio";
+	};
+};
+

--- a/target/linux/ramips/dts/mt7628an_buffalo_wex-1166dhpl.dts
+++ b/target/linux/ramips/dts/mt7628an_buffalo_wex-1166dhpl.dts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "buffalo,wex-1166dhpl", "mediatek,mt7628an-soc";
+	model = "Buffalo WEX-1166DHPL";
+
+	aliases {
+		led-boot = &led_pwr;
+		led-failsafe = &led_pwr;
+		led-running = &led_pwr;
+		led-upgrade = &led_pwr;
+		label-mac-device = &ethernet;
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_pwr: pwr {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		pwr2 {
+			function = LED_FUNCTION_FAULT;
+			color = <LED_COLOR_ID_ORANGE>;
+			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan2g {
+			function = LED_FUNCTION_WLAN_2GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 3 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		wlan5g {
+			function = LED_FUNCTION_WLAN_5GHZ;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio 45 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <58000000>;
+		m25p,fast-read;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x20000>;
+				read-only;
+			};
+
+			partition@20000 {
+				label = "nouser";
+				reg = <0x20000 0x10000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+					};
+
+					eeprom_factory_8000: eeprom@8000 {
+						reg = <0x8000 0x4da8>;
+					};
+
+					macaddr_factory_8004: macaddr@8004 {
+						reg = <0x8004 0x6>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7b0000>;
+			};
+
+			partition@800000 {
+				label = "u-boot2";
+				reg = <0x800000 0x20000>;
+				read-only;
+			};
+
+			partition@820000 {
+				label = "nouser2";
+				reg = <0x820000 0x10000>;
+				read-only;
+			};
+
+			partition@830000 {
+				label = "u-boot-env2";
+				reg = <0x830000 0x10000>;
+				read-only;
+			};
+
+			partition@840000 {
+				label = "factory2";
+				reg = <0x840000 0x10000>;
+				read-only;
+			};
+
+			partition@850000 {
+				label = "firmware2";
+				reg = <0x850000 0x7b0000>;
+			};
+		};
+	};
+};
+
+&gpio {
+	enable-leds {
+		gpio-hog;
+		line-name = "enable-leds";
+		output-low;
+		gpios = <4 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_factory_4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x3d>;
+	mediatek,portdisable = <0x3e>;
+	mediatek,led_source = <4>;
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>, <&macaddr_factory_8004>;
+		nvmem-cell-names = "eeprom", "mac-address";
+		ieee80211-freq-limit = <5000000 6000000>;
+
+		led {
+			led-sources = <2>;
+			led-active-low;
+		};
+	};
+};
+
+&usbphy {
+	status = "disabled";
+};
+
+&ehci {
+	status = "disabled";
+};
+
+&ohci {
+	status = "disabled";
+};
+
+&state_default {
+	spis {
+		groups = "spis";
+		function = "spis";
+	};
+
+	gpio {
+		groups = "refclk", "i2c", "wled_an";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -153,6 +153,20 @@ define Device/buffalo_wcr-1166ds
 endef
 TARGET_DEVICES += buffalo_wcr-1166ds
 
+define Device/buffalo_wex-1166dhpl
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Buffalo
+  DEVICE_MODEL := WEX-1166DHPL
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
+        buffalo-wex-image 9.99 | check-size | append-metadata
+  IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | \
+	buffalo-wex-image 9.99 | check-size
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
+  SUPPORTED_DEVICES += wex-1166dhpl buffalo,wex-1166dhpl
+endef
+TARGET_DEVICES += buffalo_wex-1166dhpl
+
 define Device/comfast_cf-wr617ac
   IMAGE_SIZE := 7872k
   DTS := CF-WR617AC

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -153,6 +153,19 @@ define Device/buffalo_wcr-1166ds
 endef
 TARGET_DEVICES += buffalo_wcr-1166ds
 
+define Device/buffalo_wex-1166dhpl
+  IMAGE_SIZE := 7872k
+  DEVICE_VENDOR := Buffalo
+  DEVICE_MODEL := WEX-1166DHPL
+  IMAGES += factory.bin
+  IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | \
+	check-size | append-metadata
+  IMAGE/factory.bin := append-kernel | append-rootfs | pad-rootfs | \
+	buffalo-wex-image 9.99 | check-size
+  DEVICE_PACKAGES := kmod-mt7615e kmod-mt7663-firmware-ap
+endef
+TARGET_DEVICES += buffalo_wex-1166dhpl
+
 define Device/comfast_cf-wr617ac
   IMAGE_SIZE := 7872k
   DTS := CF-WR617AC

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -211,6 +211,7 @@ ramips_setup_interfaces()
 		ucidef_set_interface "wan" device "/dev/cdc-wdm0" protocol "qmi"
 		;;
 	cudy,re1200-outdoor-v1|\
+	buffalo,wex-1166dhpl|\
 	tplink,tl-mr3020-v3)
 		ucidef_add_switch "switch0" \
 			"0:lan" "6@eth0"
@@ -349,6 +350,7 @@ ramips_setup_macs()
 	onion,omega2p|\
 	vocore,vocore2|\
 	vocore,vocore2-lite|\
+	buffalo,wex-1166dhpl|\
 	wavlink,wl-wn576a2)
 		label_mac=$(mtd_get_mac_binary factory 0x4)
 		;;

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -220,6 +220,7 @@ ramips_setup_interfaces()
 		uci add_list firewall.@zone[1].network='wwan'
 		uci add_list firewall.@zone[1].network='wwan6'
 		;;
+	buffalo,wex-1166dhpl|\
 	cudy,re1200-outdoor-v1|\
 	tplink,tl-mr3020-v3)
 		ucidef_add_switch "switch0" \
@@ -363,6 +364,7 @@ ramips_setup_macs()
 	movingcomm,c120ev)
 		wan_mac=$(mtd_get_mac_binary factory 0x28)
 		;;
+	buffalo,wex-1166dhpl|\
 	onion,omega2|\
 	onion,omega2p|\
 	vocore,vocore2|\


### PR DESCRIPTION
## Specification
Model: Buffalo WEX-1166DHPL
CPU: Mediatek MT7628AN
RAM: 64MB DDR3
Flash: 16MB MX25L12833F
WiFi: 2.4GHz 1x1 + 5GHz MT7615 1x1
FE: 1 LAN
Power: 100V AC Adapter built-in.
LED: 6

## Installation
* Login to webui and get `sysauth` cookie value as `$token`.
* Send `squashfs-factory.bin` firmware by curl.
```
curl -b "sysauth=$token" -F "image=@openwrt-ramips-mt76x8-buffalo_wex-1166dhpl-squashfs-factory.bin" "http://192.168.11.210/cgi-bin/luci/;stok=$token/admin/system/flashops"
```
* Send flashing command bu curl.
```
curl -b "sysauth=$token" -d "step=2&keep=0" "http://192.168.11.210/cgi-bin/luci/;stok=$token/admin/system/flashops"
```
* Wait for router rebooting then go LuCI from LAN port.