### PR TITLE
mediatek: filogic: fix EAX17 rootfs hash in FIT node for per-device r…

### DIFF
--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -10,7 +10,7 @@ endef
 
 define Build/fit-with-netgear-top-level-rootfs-node
 	$(call Build/fit-its,$(1))
-	$(TOPDIR)/scripts/gen_netgear_rootfs_node.sh $(KERNEL_BUILD_DIR)/root.squashfs > $@.rootfs
+	$(TOPDIR)/scripts/gen_netgear_rootfs_node.sh $(KERNEL_BUILD_DIR)/root.squashfs$(if $(TARGET_PER_DEVICE_ROOTFS),+pkg=$(ROOTFS_ID/$(DEVICE_NAME))) > $@.rootfs
 	awk '/configurations/ { system("cat $@.rootfs") } 1' $@.its > $@.its.tmp
 	@mv -f $@.its.tmp $@.its
 	@rm -f $@.rootfs


### PR DESCRIPTION
…ootfs builds

When CONFIG_TARGET_PER_DEVICE_ROOTFS is enabled (as in buildbot builds), the final per-device rootfs is assembled at root.squashfs+pkg=<hash> rather than root.squashfs. The gen_netgear_rootfs_node.sh script was always hashing root.squashfs (the base rootfs without device-specific packages), causing the size and hash in the FIT node to not match the actual rootfs written to the UBI volume, resulting in boot failure on buildbot-produced images.

Fix by using the per-device rootfs path when TARGET_PER_DEVICE_ROOTFS is set, consistent with how include/image.mk handles the same distinction elsewhere.

Fixes: 46ab9f3f1c ("filogic: add support for Netgear EAX17")