### PR TITLE
treewide: strip trailing whitespace

### DIFF
--- a/package/system/mtd/src/mtd.c
+++ b/package/system/mtd/src/mtd.c
@@ -774,7 +774,7 @@ static void usage(void)
 	fprintf(stderr, "Usage: mtd [<options> ...] <command> [<arguments> ...] <device>[:<device>...]\n\n"
 	"The device is in the format of mtdX (eg: mtd4) or its label.\n"
 	"mtd recognizes these commands:\n"
-	"        dump                    dump mtd device\n"	
+	"        dump                    dump mtd device\n"
 	"        unlock                  unlock the device\n"
 	"        refresh                 refresh mtd partition\n"
 	"        erase                   erase all data on device\n"

--- a/target/linux/mediatek/dts/mt7622-asiarf-ap7622-wh1.dts
+++ b/target/linux/mediatek/dts/mt7622-asiarf-ap7622-wh1.dts
@@ -14,7 +14,7 @@
 / {
 	model = "AsiaRF AP7622 WH1";
 	compatible = "asiarf,ap7622-wh1", "mediatek,mt7622";
-	
+
 	aliases {
 		serial0 = &uart0;
 		led-boot = &led_power;
@@ -22,51 +22,51 @@
 		led-running = &led_power;
 		led-upgrade = &led_power;
 	};
-	
+
 	chosen {
 		stdout-path = "serial0:115200n8";
 		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8 swiotlb=512";
 	};
-	
+
 	cpus {
 		cpu@0 {
 			proc-supply = <&mt6380_vcpu_reg>;
 			sram-supply = <&mt6380_vm_reg>;
 		};
-		
+
 		cpu@1 {
 			proc-supply = <&mt6380_vcpu_reg>;
 			sram-supply = <&mt6380_vm_reg>;
 		};
 	};
-	
+
 	mmc1_pwrseq: mmc1_pwrseq {
 		compatible = "mmc-pwrseq-simple";
 		reset-gpios = <&pio 97 GPIO_ACTIVE_LOW>;
 		post-power-on-delay-ms = <200>;
 	};
-	
+
 	gpio-keys {
 		compatible = "gpio-keys";
-		
+
 		reset {
 			label = "reset";
 			linux,code = <KEY_RESTART>;
 			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
 		};
-		
+
 		wps {
 			label = "wps";
 			linux,code = <KEY_WPS_BUTTON>;
 			gpios = <&pio 102 GPIO_ACTIVE_LOW>;
 		};
 	};
-	
+
 	memory@40000000 {
 		reg = <0 0x40000000 0 0x20000000>;// 512MiB
 		device_type = "memory";
 	};
-	
+
 	reg_3p3v: regulator-3p3v {
 		compatible = "regulator-fixed";
 		regulator-name = "fixed-3.3V";
@@ -75,7 +75,7 @@
 		regulator-boot-on;
 		regulator-always-on;
 	};
-	
+
 	reg_5v: regulator-5v {
 		compatible = "regulator-fixed";
 		regulator-name = "fixed-5V";
@@ -84,17 +84,17 @@
 		regulator-boot-on;
 		regulator-always-on;
 	};
-	
+
 	gpio-leds {
 		compatible = "gpio-leds";
 		status = "okay";
-		
+
 		led_power: power {
 			color = <LED_COLOR_ID_BLUE>;
 			function = LED_FUNCTION_POWER;
 			gpios = <&pio 101 GPIO_ACTIVE_HIGH>;
 		};
-		
+
 		wlan {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WLAN;
@@ -120,25 +120,25 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&eth_pins>;
 	status = "okay";
-	
+
 	gmac0: mac@0 {
 		compatible = "mediatek,eth-mac";
 		nvmem-cells = <&macaddr_factory_7fff4>;
 		nvmem-cell-names = "mac-address";
 		reg = <0>;
 		phy-mode = "2500base-x";
-		
+
 		fixed-link {
 			speed = <2500>;
 			full-duplex;
 			pause;
 		};
 	};
-	
+
 	mdio-bus {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		
+
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
@@ -147,44 +147,44 @@
 			interrupt-parent = <&pio>;
 			interrupts = <53 IRQ_TYPE_LEVEL_HIGH>;
 			reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
-			
+
 			ports {
 				#address-cells = <1>;
 				#size-cells = <0>;
-				
+
 				port@0 {
 					reg = <0>;
 					label = "lan1";
 				};
-				
+
 				port@1 {
 					reg = <1>;
 					label = "lan2";
 				};
-				
+
 				port@2 {
 					reg = <2>;
 					label = "lan3";
 				};
-				
+
 				port@3 {
 					reg = <3>;
 					label = "lan4";
 				};
-				
+
 				port@4 {
 					reg = <4>;
 					label = "wan";
 					nvmem-cells = <&macaddr_factory_7fffa>;
 					nvmem-cell-names = "mac-address";
 				};
-				
+
 				port@6 {
 					reg = <6>;
 					label = "cpu";
 					ethernet = <&gmac0>;
 					phy-mode = "2500base-x";
-					
+
 					fixed-link {
 						speed = <2500>;
 						full-duplex;
@@ -193,7 +193,7 @@
 				};
 			};
 		};
-		
+
 	};
 };
 
@@ -209,14 +209,14 @@
 	vqmmc-supply = <&reg_3p3v>;
 	assigned-clocks = <&topckgen CLK_TOP_MSDC30_1_SEL>;
 	assigned-clock-parents = <&topckgen CLK_TOP_UNIV48M>;
-	
+
 	cap-mmc-highspeed;
 	cap-sdio-irq;
 	non-removable;
 	disable-wp;
 	drv-type = <2>;
 	mmc-pwrseq = <&mmc1_pwrseq>;
-	
+
 	#address-cells = <1>;
 	#size-cells = <0>;
 	mm6108_sdio@0 {
@@ -249,7 +249,7 @@
 			groups = "mdc_mdio", "rgmii_via_gmac2";
 		};
 	};
-	
+
 	pcie0_pins: pcie0-pins {
 		mux {
 			function = "pcie";
@@ -258,7 +258,7 @@
 			"pcie0_1_clkreq";
 		};
 	};
-	
+
 	pcie1_pins: pcie1-pins {
 		mux {
 			function = "pcie";
@@ -267,27 +267,27 @@
 			"pcie1_0_clkreq";
 		};
 	};
-	
+
 	pmic_bus_pins: pmic-bus-pins {
 		mux {
 			function = "pmic";
 			groups = "pmic_bus";
 		};
 	};
-	
+
 	wled_pins: wled-pins {
 		mux {
 			function = "led";
 			groups = "wled";
 		};
 	};
-	
+
 	sd0_pins_default: sd0-pins-default {
 		mux {
 			function = "sd";
 			groups = "sd_0";
 		};
-		
+
 		/* "I2S2_OUT, "I2S4_IN"", "I2S3_IN", "I2S2_IN",
 		*  "I2S4_OUT", "I2S3_OUT" are used as DAT0, DAT1,
 		*  DAT2, DAT3, CMD, CLK for SD respectively.
@@ -309,26 +309,26 @@
 			bias-pull-up;
 		};
 	};
-	
+
 	sd0_pins_uhs: sd0-pins-uhs {
 		mux {
 			function = "sd";
 			groups = "sd_0";
 		};
-		
+
 		conf-cmd-data {
 			pins = "I2S2_OUT", "I2S4_IN", "I2S3_IN",
 			"I2S2_IN","I2S4_OUT";
 			input-enable;
 			bias-pull-up;
 		};
-		
+
 		conf-clk {
 			pins = "I2S3_OUT";
 			bias-pull-down;
 		};
 	};
-	
+
 	/* Serial NAND is shared pin with SPI-NOR */
 	serial_nand_pins: serial-nand-pins {
 		mux {
@@ -336,35 +336,35 @@
 			groups = "snfi";
 		};
 	};
-	
+
 	spic0_pins: spic0-pins {
 		mux {
 			function = "spi";
 			groups = "spic0_0";
 		};
 	};
-	
+
 	spic1_pins: spic1-pins {
 		mux {
 			function = "spi";
 			groups = "spic1_0";
 		};
 	};
-	
+
 	uart0_pins: uart0-pins {
 		mux {
 			function = "uart";
 			groups = "uart0_0_tx_rx";
 		};
 	};
-	
+
 	uart2_pins: uart2-pins {
 		mux {
 			function = "uart";
 			groups = "uart2_1_tx_rx";
 		};
 	};
-	
+
 	watchdog_pins: watchdog-pins {
 		mux {
 			function = "watchdog";
@@ -383,7 +383,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&serial_nand_pins>;
 	status = "okay";
-	
+
 	flash@0 {
 		compatible = "spi-nand";
 		mediatek,bmt-table-size = <0x1000>;
@@ -392,40 +392,40 @@
 		reg = <0>;
 		spi-rx-bus-width = <4>;
 		spi-tx-bus-width = <4>;
-		
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			
+
 			partition@0 {
 				label = "Preloader";
 				reg = <0x00000 0x0080000>;
 				read-only;
 			};
-			
+
 			partition@80000 {
 				label = "ATF";
 				reg = <0x80000 0x0040000>;
 				read-only;
 			};
-			
+
 			partition@c0000 {
 				label = "Bootloader";
 				reg = <0xc0000 0x0080000>;
 				read-only;
 			};
-			
+
 			partition@140000 {
 				label = "Config";
 				reg = <0x140000 0x0080000>;
 			};
-			
+
 			partition@1c0000 {
 				label = "Factory";
 				reg = <0x1c0000 0x0100000>;
 				read-only;
-				
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -434,36 +434,36 @@
 					factory_eeprom: eeprom@0 {
 						reg = <0x0 0x5000>;
 					};
-					
+
 					macaddr_factory_7fff4: macaddr@7fff4 {
 						reg = <0x7fff4 0x6>;
 					};
-					
+
 					macaddr_factory_7fffa: macaddr@7fffa {
 						reg = <0x7fffa 0x6>;
 					};
 				};
 			};
-			
+
 			partition@2c0000 {
 				label = "firmware";
 				reg = <0x2c0000 0x2000000>;// 32 MiB
-				
+
 				compatible = "fixed-partitions";
 				#address-cells = <1>;
 				#size-cells = <1>;
-				
+
 				partition@0 {
 					label = "kernel";
 					reg = <0x0 0x0800000>;
 				};
-				
+
 				partition@600000 {
 					label = "ubi";
 					reg = <0x800000 0x1800000>;
 				};
 			};
-			
+
 			partition@22c0000 {
 				label = "User_data";
 				reg = <0x22c0000 0x5300000>;

--- a/target/linux/mediatek/dts/mt7981b-asus-rt-ax57m.dts
+++ b/target/linux/mediatek/dts/mt7981b-asus-rt-ax57m.dts
@@ -67,7 +67,7 @@
 			function = LED_FUNCTION_LAN;
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
-		};		
+		};
 
 		wlan24 {
 			function = LED_FUNCTION_WLAN_2GHZ;
@@ -241,7 +241,7 @@
 
 		precal_factory_1010: precal@1010 {
 			reg = <0x1010 0x6f010>;
-		};		
+		};
 	};
 };
 

--- a/target/linux/mediatek/dts/mt7981b-bazis-ax3000wm.dts
+++ b/target/linux/mediatek/dts/mt7981b-bazis-ax3000wm.dts
@@ -53,7 +53,7 @@
 			gpios = <&pio 4 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy0tpt";
 		};
-		
+
 		led_warning: led_fault {
 			function = LED_FUNCTION_FAULT;
 			color = <LED_COLOR_ID_RED>;
@@ -78,7 +78,7 @@
 			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy1tpt";
 		};
-		
+
 		led_lan_back {
 			function = LED_FUNCTION_LAN;
 			color = <LED_COLOR_ID_GREEN>;
@@ -130,7 +130,7 @@
 	phy5: phy@5 {
 		compatible = "ethernet-phy-ieee802.3-c45";
 		reg = <5>;
-		
+
 		leds {
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -203,11 +203,11 @@
 					eeprom_factory_0: eeprom@0 {
 						reg = <0x0 0x1000>;
 					};
-					
+
 					mac_lan: macaddr@4 {
 						reg = <0x4 0x6>;
 					};
-					
+
 					mac_wan: macaddr@a {
 						reg = <0xa 0x6>;
 					};
@@ -218,8 +218,8 @@
 
 					mac_wlan_5ghz: macaddr@24 {
 						reg = <0x24 0x6>;
-					};	
-					
+					};
+
 				};
 			};
 
@@ -233,12 +233,12 @@
 				label = "ubi";
 				reg = <0x580000 0x7a40000>;
 				compatible = "linux,ubi";
-			
+
 				volumes {
 					ubi_rootdisk: ubi-volume-fit {
 						volname = "fit";
 					};
-					
+
 					ubi_ubootenv: ubi-volume-ubootenv {
 						volname = "ubootenv";
 					};
@@ -279,7 +279,7 @@
 	nvmem-cell-names = "eeprom";
 	#address-cells = <1>;
 	#size-cells = <0>;
-	
+
 	band@0 {
 		reg = <0>;
 		nvmem-cells = <&mac_wlan_2ghz>;

--- a/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dtsi
@@ -13,7 +13,7 @@
 		led-upgrade = &led_warning;
 		serial0 = &uart0;
 	};
-	
+
 	leds {
 		compatible = "gpio-leds";
 
@@ -28,7 +28,7 @@
 			color = <LED_COLOR_ID_BLUE>;
 			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
 		};
-		
+
 		led_warning: led_fault {
 			function = LED_FUNCTION_FAULT;
 			color = <LED_COLOR_ID_RED>;

--- a/target/linux/mediatek/dts/mt7981b-totolink-x6000r.dts
+++ b/target/linux/mediatek/dts/mt7981b-totolink-x6000r.dts
@@ -22,12 +22,12 @@
 	chosen {
 		stdout-path = "serial0:115200n8";
 	};
-		
+
 	memory@40000000 {
 		reg = <0 0x40000000 0 0x10000000>;
 		device_type = "memory";
 	};
-	
+
 	gpio-keys {
 		compatible = "gpio-keys";
 
@@ -84,7 +84,7 @@
 
 		nvmem-cells = <&macaddr_factory_14>;
 		nvmem-cell-names = "mac-address";
-		
+
 		fixed-link {
 			speed = <2500>;
 			full-duplex;
@@ -137,7 +137,7 @@
 				reg = <3>;
 				label = "lan1";
 			};
-			
+
 			port@6 {
 				reg = <6>;
 				label = "cpu";

--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-3port-128nand-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-3port-128nand-common.dtsi
@@ -90,10 +90,10 @@
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
-					
+
 					eeprom_factory: eeprom@0 {
 						reg = <0x0 0x1000>;
-					};					
+					};
 
 					macaddr_factory_4: macaddr@4 {
 						reg = <0x4 0x6>;

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dts
@@ -10,6 +10,6 @@
 };
 
 &ubi {
-	/* reduce ubi partition size from .dtsi to fit into 64M Nand */ 
+	/* reduce ubi partition size from .dtsi to fit into 64M Nand */
 	reg = <0x580000 0x4000000>;
 };

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dtsi
@@ -84,7 +84,7 @@
 			linux,default-trigger = "phy1tpt";
 		};
 	};
-		
+
 };
 
 &eth {

--- a/target/linux/mediatek/dts/mt7986a-asiarf-ap7986-003.dts
+++ b/target/linux/mediatek/dts/mt7986a-asiarf-ap7986-003.dts
@@ -218,7 +218,7 @@
 			groups = "pcie_clk", "pcie_wake", "pcie_pereset";
 		};
 	};
-	
+
 	pwm_pins: pwm-pins {
 		mux {
 			function = "pwm";

--- a/target/linux/mediatek/dts/mt7986b-tplink-archer-ax80-v1-eu.dts
+++ b/target/linux/mediatek/dts/mt7986b-tplink-archer-ax80-v1-eu.dts
@@ -11,7 +11,7 @@
 / {
 	compatible = "tplink,archer-ax80-v1-eu", "mediatek,mt7986b";
 	model = "TP-Link Archer AX80 v1 (EU)";
-	
+
 	aliases {
 		serial0 = &uart0;
 		led-boot = &led_power;
@@ -19,58 +19,58 @@
 		led-running = &led_power;
 		led-upgrade = &led_power;
 	};
-	
+
 	chosen {
 		stdout-path = "serial0:115200n8";
 	};
-	
+
 	memory@40000000 {
 		reg = <0 0x40000000 0 0x20000000>;
 		device_type = "memory";
 	};
-	
+
 	leds {
 		compatible = "gpio-leds";
-		
+
 		led_power: power {
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_POWER;
 			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
-		
+
 		wlan2g {
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_WLAN_2GHZ;
 			gpios = <&pio 11 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "phy0tpt";
 		};
-		
+
 		wlan5g {
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_WLAN_5GHZ;
 			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy1tpt";
 		};
-		
+
 		internet_white {
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_WAN_ONLINE;
 			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
 		};
-		
+
 		internet_orange {
 			color = <LED_COLOR_ID_ORANGE>;
 			function = LED_FUNCTION_WAN;
 			gpios = <&pio 19 GPIO_ACTIVE_LOW>;
 		};
-		
+
 		lan {
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_LAN;
 			gpios = <&pio 16 GPIO_ACTIVE_HIGH>;
 		};
-		
+
 		usb {
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_DISK;
@@ -78,36 +78,36 @@
 			trigger-sources = <&ssusb>;
 			linux,default-trigger = "usbport";
 		};
-		
+
 		wps {
 			color = <LED_COLOR_ID_WHITE>;
 			function = LED_FUNCTION_WPS;
 			gpios = <&pio 18 GPIO_ACTIVE_LOW>;
 		};
 	};
-	
+
 	keys {
 		compatible = "gpio-keys";
-		
+
 		reset {
 			label = "reset";
 			linux,code = <KEY_RESTART>;
 			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
 		};
-		
+
 		wps {
 			label = "wps";
 			linux,code = <KEY_WPS_BUTTON>;
 			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
 		};
-		
+
 		wifi {
 			label = "wlan";
 			linux,code = <KEY_WLAN>;
 			gpios = <&pio 20 GPIO_ACTIVE_LOW>;
 		};
 	};
-	
+
 	reg_3p3v: regulator-3p3v {
 		compatible = "regulator-fixed";
 		regulator-name = "fixed-3.3V";
@@ -116,7 +116,7 @@
 		regulator-boot-on;
 		regulator-always-on;
 	};
-	
+
 	reg_5v: regulator-5v {
 		compatible = "regulator-fixed";
 		regulator-name = "fixed-5V";
@@ -137,7 +137,7 @@
 
 &eth {
 	status = "okay";
-	
+
 	gmac0: mac@0 {
 		compatible = "mediatek,eth-mac";
 		reg = <0>;
@@ -147,25 +147,25 @@
 			full-duplex;
 		};
 	};
-	
+
 	mac@1 {
 		compatible = "mediatek,eth-mac";
 		reg = <1>;
 		phy-mode = "2500base-x";
 		phy-handle = <&phy6>;
 	};
-	
+
 	mdio-bus {
 		#address-cells = <1>;
 		#size-cells = <0>;
 		reset-delay-us = <1500000>;
-		reset-post-delay-us = <1000000>;		
+		reset-post-delay-us = <1000000>;
 		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
 		phy6: phy@6 {
 			compatible = "ethernet-phy-ieee802.3-c45";
 			reg = <6>;
 		};
-		
+
 		switch@1f {
 			compatible = "mediatek,mt7531";
 			reg = <31>;
@@ -174,7 +174,7 @@
 			#interrupt-cells = <1>;
 			interrupt-parent = <&pio>;
 			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
-			
+
 			ports {
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -213,7 +213,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi_flash_pins>;
 	status = "okay";
-	
+
 	flash@0 {
 		compatible = "spi-nand";
 		reg = <0>;
@@ -222,44 +222,44 @@
 		spi-rx-bus-width = <4>;
 		spi-cal-enable;
 		spi-cal-mode = "read-data";
-		
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			
+
 			partition@0 {
 				label = "boot";
 				reg = <0x0 0x200000>;
 				read-only;
 			};
-			
+
 			partition@200000 {
 				label = "u-boot-env";
 				reg = <0x200000 0x100000>;
 			};
-			
+
 			partition@300000 {
 				label = "ubi0";
 				reg = <0x300000 0x3200000>;
 			};
-			
+
 			partition@3500000 {
 				label = "ubi1";
 				reg = <0x3500000 0x3200000>;
 			};
-			
+
 			partition@6700000 {
 				label = "userconfig";
 				reg = <0x6700000 0x800000>;
 			};
-			
+
 			partition@6f00000 {
 				label = "tp_data";
 				reg = <0x6f00000 0x400000>;
 				read-only;
 			};
-			
+
 			partition@7300000 {
 				label = "mali_data";
 				reg = <0x7300000 0x800000>;
@@ -285,7 +285,7 @@
 			bias-disable; /* bias-disable */
 		};
 	};
-	
+
 	wf_2g_5g_pins: wf_2g_5g-pins {
 		mux {
 			function = "wifi";

--- a/target/linux/mediatek/dts/mt7986b-zyxel-wx5600-t0-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7986b-zyxel-wx5600-t0-ubootmod.dts
@@ -155,7 +155,7 @@
 
 				nvmem-layout {
 					compatible = "fixed-layout";
-					#address-cells = <1>; 
+					#address-cells = <1>;
 					#size-cells = <1>;
 
 					eeprom_factory: eeprom@0 {
@@ -315,7 +315,7 @@
 
 &eth {
 	status = "okay";
-	
+
 	gmac0: mac@0 {
 		compatible = "mediatek,eth-mac";
 		reg = <0>;
@@ -325,7 +325,7 @@
 		phy-handle = <&phy5>;
 		label = "lan2";
 	};
-	
+
 	gmac1: mac@1 {
 		compatible = "mediatek,eth-mac";
 		reg = <1>;
@@ -335,22 +335,22 @@
 		phy-handle = <&phy6>;
 		label = "lan1";
 	};
-	
+
 	mdio: mdio-bus{
 		#address-cells = <1>;
 		#size-cells = <0>;
-		
+
 		phy5: phy@5 {
 			compatible = "ethernet-phy-ieee802.3-c45";
 			reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
 			reset-assert-us = <600>;
 			reset-deassert-us = <20000>;
 			reg = <5>;
-			
+
 			leds {
 				#address-cells = <1>;
 				#size-cells = <0>;
-				
+
 				led@0 {
 					reg = <0>;
 					color = <LED_COLOR_ID_GREEN>;
@@ -358,7 +358,7 @@
 				};
 			};
 		};
-		
+
 		phy6: phy@6 {
 			compatible = "ethernet-phy-ieee802.3-c45";
 			reg = <6>;
@@ -366,7 +366,7 @@
 			leds {
 				#address-cells = <1>;
 				#size-cells = <0>;
-				
+
 				led@0 {
 					reg = <0>;
 					color = <LED_COLOR_ID_GREEN>;

--- a/target/linux/qualcommax/dts/ipq5018-scr50axe.dts
+++ b/target/linux/qualcommax/dts/ipq5018-scr50axe.dts
@@ -295,7 +295,7 @@
 		nand-bus-width = <8>;
 		nand-ecc-strength = <4>;
 		nand-ecc-step-size = <512>;
-		
+
 		partitions {
 			compatible = "qcom,smem-part";
 

--- a/target/linux/qualcommax/dts/ipq6000-link.dtsi
+++ b/target/linux/qualcommax/dts/ipq6000-link.dtsi
@@ -64,7 +64,7 @@
 
 &tlmm {
 	gpio-reserved-ranges = <20 1>;
-	
+
 	mdio_pins: mdio-pins {
 		mdc {
 			pins = "gpio64";

--- a/target/linux/ramips/dts/mt7621_asiarf_ap7621-004-v3.dts
+++ b/target/linux/ramips/dts/mt7621_asiarf_ap7621-004-v3.dts
@@ -10,7 +10,7 @@
 
 	keys {
 		compatible = "gpio-keys";
-		
+
 		wps {
 			label = "wps";
 			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
@@ -127,7 +127,7 @@
 			label = "lan4";
 		};
 	};
-	
+
 };
 
 &state_default {

--- a/target/linux/ramips/dts/mt7621_cudy_ap1300-outdoor-v1.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_ap1300-outdoor-v1.dts
@@ -9,12 +9,12 @@
 / {
 	compatible = "cudy,ap1300-outdoor-v1", "mediatek,mt7621-soc";
 	model = "Cudy AP1300 Outdoor v1";
-	
+
 	aliases {
 		led-boot = &led_sys;
 		led-failsafe = &led_sys;
 		led-running = &led_sys;
-		led-upgrade = &led_sys;		
+		led-upgrade = &led_sys;
 		label-mac-device = &gmac0;
 	};
 
@@ -70,9 +70,9 @@
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WLAN_5GHZ;
 			linux,default-trigger = "phy1tpt";
-		};	
+		};
 	};
-	
+
 	watchdog {
 		compatible = "linux,wdt-gpio";
 		gpios = <&gpio 7 GPIO_ACTIVE_LOW>;

--- a/target/linux/ramips/dts/mt7621_cudy_c200p.dts
+++ b/target/linux/ramips/dts/mt7621_cudy_c200p.dts
@@ -28,7 +28,7 @@
 		hw_margin_ms = <1000>;
 		always-running;
 	};
-	
+
 	gpio-export {
 		compatible = "gpio-export";
 		#size-cells = <0>;

--- a/target/linux/ramips/dts/mt7621_tplink_ex220-v2.dts
+++ b/target/linux/ramips/dts/mt7621_tplink_ex220-v2.dts
@@ -177,7 +177,7 @@
 		nvmem-cell-names = "eeprom", "precal", "mac-address";
 		mediatek,disable-radar-background;
 
-		band@1 { 
+		band@1 {
 			reg = <1>;
 			nvmem-cells = <&macaddr_rom_file_f100 2>;
 			nvmem-cell-names = "mac-address";

--- a/target/linux/ramips/dts/mt7628an_creality_wb-01.dts
+++ b/target/linux/ramips/dts/mt7628an_creality_wb-01.dts
@@ -88,7 +88,7 @@
 				label = "factory";
 				reg = <0x40000 0x10000>;
 				#address-cells = <1>;
-				#size-cells = <1>;				
+				#size-cells = <1>;
 				read-only;
 
 				nvmem-layout {
@@ -102,8 +102,8 @@
 
 					macaddr_factory_28: macaddr@28 {
 						reg = <0x28 0x6>;
-					};					
-				};				
+					};
+				};
 			};
 
 			partition@50000 {

--- a/target/linux/ramips/dts/mt7628an_cudy_re1200-outdoor-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_re1200-outdoor-v1.dts
@@ -71,7 +71,7 @@
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_WLAN_5GHZ;
 			linux,default-trigger = "phy1tpt";
-		};	
+		};
 	};
 };
 

--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1112.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1112.dts
@@ -120,7 +120,7 @@
 				label = "rf-eeprom";
 				reg = <0x40000 0x10000>;
 				read-only;
-				
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -164,7 +164,7 @@
 				reg = <0x1030000 0x10000>;
 				read-only;
 			};
-			
+
 			partition@1040000 {
 				label = "rf-eeprom_res";
 				reg = <0x1040000 0x10000>;
@@ -175,7 +175,7 @@
 				label = "firmware_2";
 				reg = <0x1050000 0xf60000>;
 			};
-			
+
 			partition@1fb0000 {
 				label = "config_2";
 				reg = <0x1fb0000 0x40000>;

--- a/target/linux/ramips/dts/mt7628an_keenetic_kn-1212.dts
+++ b/target/linux/ramips/dts/mt7628an_keenetic_kn-1212.dts
@@ -130,7 +130,7 @@
 				label = "rf-eeprom";
 				reg = <0x40000 0x10000>;
 				read-only;
-				
+
 				nvmem-layout {
 					compatible = "fixed-layout";
 					#address-cells = <1>;
@@ -162,7 +162,7 @@
 				reg = <0xef0000 0x100000>;
 				read-only;
 			};
-			
+
 			partition@ff0000 {
 				label = "dump";
 				reg = <0xff0000 0x10000>;
@@ -180,7 +180,7 @@
 				reg = <0x1030000 0x10000>;
 				read-only;
 			};
-			
+
 			partition@1040000 {
 				label = "rf-eeprom_res";
 				reg = <0x1040000 0x10000>;
@@ -191,7 +191,7 @@
 				label = "firmware_2";
 				reg = <0x1050000 0xf60000>;
 			};
-			
+
 			partition@1fb0000 {
 				label = "config_2";
 				reg = <0x1fb0000 0x40000>;

--- a/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
+++ b/target/linux/realtek/dts/rtl9301_linksys_lgs328c.dts
@@ -111,7 +111,7 @@
 		SWITCH_PORT_SDS(5, 6, 1, qsgmii)
 		SWITCH_PORT_SDS(6, 7, 1, qsgmii)
 		SWITCH_PORT_SDS(7, 8, 1, qsgmii)
-		
+
 		SWITCH_PORT_SDS(8, 9, 2, usxgmii)
 		SWITCH_PORT_SDS(9, 10, 2, usxgmii)
 		SWITCH_PORT_SDS(10, 11, 2, usxgmii)
@@ -120,7 +120,7 @@
 		SWITCH_PORT_SDS(13, 14, 2, usxgmii)
 		SWITCH_PORT_SDS(14, 15, 2, usxgmii)
 		SWITCH_PORT_SDS(15, 16, 2, usxgmii)
-		
+
 		SWITCH_PORT_SDS(16, 17, 3, usxgmii)
 		SWITCH_PORT_SDS(17, 18, 3, usxgmii)
 		SWITCH_PORT_SDS(18, 19, 3, usxgmii)
@@ -129,7 +129,7 @@
 		SWITCH_PORT_SDS(21, 22, 3, usxgmii)
 		SWITCH_PORT_SDS(22, 23, 3, usxgmii)
 		SWITCH_PORT_SDS(23, 24, 3, usxgmii)
-		
+
 		port@24 {
 			reg = <24>;
 			label = "lan25";
@@ -162,7 +162,7 @@
 			managed = "in-band-status";
 			sfp = <&sfp3>;
 		};
-		
+
 		port@28 {
 			reg = <28>;
 			ethernet = <&ethernet0>;

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1250-12-common.dtsi
@@ -272,7 +272,7 @@
 		SWITCH_PORT_LED(24, 9, 6, 1, usxgmii)
 		SWITCH_PORT_LED(25, 10, 7, 1, usxgmii)
 		SWITCH_PORT_LED(26, 11, 8, 1, usxgmii)
-		
+
 		port27: port@27 {
 			reg = <27>;
 			label = "lan12";

--- a/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_zyxel_xgs1x10-12-common.dtsi
@@ -128,7 +128,7 @@
 	ethernet-ports {
 		#address-cells = <1>;
 		#size-cells = <0>;
-		
+
 		SWITCH_PORT_LED(0, 1, 2, 0, usxgmii)
 		SWITCH_PORT_LED(1, 2, 2, 0, usxgmii)
 		SWITCH_PORT_LED(2, 3, 2, 0, usxgmii)

--- a/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
+++ b/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
@@ -54,14 +54,14 @@
 
 		/* LED[0]: green | LED[1]: amber */
 		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK |
-			     RTL93XX_LED_SET_ACT) 
+			     RTL93XX_LED_SET_ACT)
 			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G |
 			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)>;
 	};
 
 	/*
 	 * Diodes PT7A7514WE is fed by hardware-assisted SYS_LED. There is no
-	 * real driver for this. However, this node causes a quirk being applied 
+	 * real driver for this. However, this node causes a quirk being applied
 	 * very early to avoid a reset during early boot.
 	 */
 	watchdog1: watchdog {

--- a/target/linux/realtek/files-6.12/arch/mips/rtl-otto/prom.c
+++ b/target/linux/realtek/files-6.12/arch/mips/rtl-otto/prom.c
@@ -327,7 +327,7 @@ static void prepare_highmem(void)
 	 *
 	 * Whenever CPU accesses memory the normal MIPS translation is applied and afterwards
 	 * the bus adds the zone mapping. E.g. a read to 0x81230000 is converted to an cached
-	 * memory access to logical address 0x01230000. It is issued to the OCP bus and the 
+	 * memory access to logical address 0x01230000. It is issued to the OCP bus and the
 	 * mapping from zone 1 register is added. That allows for two memory topologies:
 	 *
 	 * Linear memory with a maximum of 320 MB:

--- a/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.12/drivers/net/pcs/pcs-rtl-otto.c
@@ -820,7 +820,7 @@ static int rtpcs_838x_sds_patch(struct rtpcs_serdes *sds,
 	default:
 		break;
 	}
-	
+
 	return 0;
 }
 
@@ -856,7 +856,7 @@ static int rtpcs_838x_setup_serdes(struct rtpcs_serdes *sds,
 
 	rtpcs_838x_sds_patch(sds, hw_mode);
 	rtpcs_838x_sds_reset(sds);
-	
+
 	/* release reset */
 	rtpcs_sds_write(sds, 0, 3, 0x7106);
 
@@ -1287,7 +1287,7 @@ pll_setup:
 
 /* RTL930X */
 
-/* 
+/*
  * RTL930X needs a special mapping from logic SerDes ID to physical SerDes ID,
  * which takes the page into account. This applies to most of read/write calls.
  */

--- a/target/linux/realtek/files-6.18/arch/mips/rtl-otto/prom.c
+++ b/target/linux/realtek/files-6.18/arch/mips/rtl-otto/prom.c
@@ -327,7 +327,7 @@ static void prepare_highmem(void)
 	 *
 	 * Whenever CPU accesses memory the normal MIPS translation is applied and afterwards
 	 * the bus adds the zone mapping. E.g. a read to 0x81230000 is converted to an cached
-	 * memory access to logical address 0x01230000. It is issued to the OCP bus and the 
+	 * memory access to logical address 0x01230000. It is issued to the OCP bus and the
 	 * mapping from zone 1 register is added. That allows for two memory topologies:
 	 *
 	 * Linear memory with a maximum of 320 MB:

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -815,7 +815,7 @@ static int rtpcs_838x_sds_patch(struct rtpcs_serdes *sds,
 	default:
 		break;
 	}
-	
+
 	return 0;
 }
 
@@ -851,7 +851,7 @@ static int rtpcs_838x_setup_serdes(struct rtpcs_serdes *sds,
 
 	rtpcs_838x_sds_patch(sds, hw_mode);
 	rtpcs_838x_sds_reset(sds);
-	
+
 	/* release reset */
 	rtpcs_sds_write(sds, 0, 3, 0x7106);
 
@@ -1282,7 +1282,7 @@ pll_setup:
 
 /* RTL930X */
 
-/* 
+/*
  * RTL930X needs a special mapping from logic SerDes ID to physical SerDes ID,
  * which takes the page into account. This applies to most of read/write calls.
  */

--- a/target/linux/realtek/image/rt-loader/src/board.c
+++ b/target/linux/realtek/image/rt-loader/src/board.c
@@ -98,7 +98,7 @@ found:
 	else
 		chip_version = ((cinfo >> 16) & 0x1f) - 1;
 
-	snprintf(buffer, len, "RTL%04X%c rev %c (%04x)", model_id, 
+	snprintf(buffer, len, "RTL%04X%c rev %c (%04x)", model_id,
 		 model_version ? model_version + 64 : 0, chip_version + 65, chip_id);
 }
 


### PR DESCRIPTION
Strip trailing whitespace in all code:
`find . -type f | grep "\.c$" | xargs sed -i 's/[ \t]\+$//'`
`find . -type f | grep "\.h$" | xargs sed -i 's/[ \t]\+$//'`
`find . -type f | grep "\.dts$" | xargs sed -i 's/[ \t]\+$//'`
`find . -type f | grep "\.dtsi$" | xargs sed -i 's/[ \t]\+$//'`
