### PR TITLE
tools/mkimage: update to v2026.04

### DIFF
--- a/tools/mkimage/Makefile
+++ b/tools/mkimage/Makefile
@@ -26,7 +26,7 @@ define Host/Configure
 		HOSTLDFLAGS="$(HOST_LDFLAGS)" \
 		PKG_CONFIG_EXTRAARGS="--static" \
 		V=$(if $(findstring c,$(OPENWRT_VERBOSE)),1) \
-		tools-only_config
+		tools-only_defconfig
 
 	$(HOST_BUILD_DIR)/scripts/config \
 		--file $(HOST_BUILD_DIR)/.config \

--- a/tools/mkimage/Makefile
+++ b/tools/mkimage/Makefile
@@ -7,14 +7,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mkimage
-PKG_VERSION:=2026.01
+PKG_VERSION:=2026.04
 
 PKG_SOURCE:=u-boot-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
 	https://mirror.cyberbits.eu/u-boot \
 	https://ftp.denx.de/pub/u-boot \
 	ftp://ftp.denx.de/pub/u-boot
-PKG_HASH:=b60d5865cefdbc75da8da4156c56c458e00de75a49b80c1a2e58a96e30ad0d54
+PKG_HASH:=ac7c04b8b7004923b00a4e5d6699c5df4d21233bac9fda690d8cfbc209fff2fd
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/u-boot-$(PKG_VERSION)
 

--- a/tools/mkimage/Makefile
+++ b/tools/mkimage/Makefile
@@ -28,7 +28,11 @@ define Host/Configure
 		V=$(if $(findstring c,$(OPENWRT_VERBOSE)),1) \
 		tools-only_config
 
-	sed -i 's/CONFIG_TOOLS_MKEFICAPSULE=y/# CONFIG_TOOLS_MKEFICAPSULE is not set/' $(HOST_BUILD_DIR)/.config
+	$(HOST_BUILD_DIR)/scripts/config \
+		--file $(HOST_BUILD_DIR)/.config \
+		--disable TOOLS_KWBIMAGE \
+		--disable TOOLS_LIBCRYPTO \
+		--disable TOOLS_MKEFICAPSULE
 endef
 
 define Host/Compile

--- a/tools/mkimage/patches/030-allow-to-use-different-magic.patch
+++ b/tools/mkimage/patches/030-allow-to-use-different-magic.patch
@@ -1,3 +1,8 @@
+From f3d2056b81b7a92d28402c22736534d84fe23cfe Mon Sep 17 00:00:00 2001
+From: Gabor Juhos <juhosg@openwrt.org>
+Date: Mon, 5 Dec 2011 14:52:22 +0000
+Subject: [PATCH] tools/mkimage: allow to use different magic in uImages
+
 This patch makes it possible to set a custom image magic.
 
 --- a/tools/mkimage.c
@@ -24,16 +29,16 @@ This patch makes it possible to set a custom image magic.
  		"          -a ==> set load address to 'addr' (hex)\n"
  		"          -e ==> set entry point to 'ep' (hex)\n"
  		"          -n ==> set image name to 'name'\n"
-@@ -162,7 +164,7 @@ static int add_content(int type, const c
+@@ -164,7 +166,7 @@ static int add_content(int type, const c
  }
  
  static const char optstring[] =
--	"a:A:b:B:c:C:d:D:e:Ef:Fg:G:i:k:K:ln:N:o:O:p:qrR:stT:vVxy:Y:";
-+	"a:A:b:B:c:C:d:D:e:Ef:Fg:G:i:k:K:lM:n:N:o:O:p:qrR:stT:vVxy:Y:";
+-	"a:A:b:B:c:C:d:D:e:Ef:Fg:G:i:k:K:ln:N:o:O:p:qrR:stT:vVxy:Y:z:Z:";
++	"a:A:b:B:c:C:d:D:e:Ef:Fg:G:i:k:K:lM:n:N:o:O:p:qrR:stT:vVxy:Y:z:Z:";
  
  static const struct option longopts[] = {
  	{ "load-address", required_argument, NULL, 'a' },
-@@ -308,6 +310,14 @@ static void process_args(int argc, char
+@@ -312,6 +314,14 @@ static void process_args(int argc, char
  		case 'l':
  			params.lflag = 1;
  			break;


### PR DESCRIPTION
Update to the latest version and add missing 030 patch header.

Changelog:
22aa122eee0 mkimage: Add support for bundling TEE in mkimage -f auto