### PR TITLE
openssl: update to 3.5.6

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.5.5
+PKG_VERSION:=3.5.6
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -21,7 +21,7 @@ PKG_SOURCE_URL:= \
 	https://www.openssl.org/source/old/$(PKG_BASE)/ \
 	https://github.com/openssl/openssl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 
-PKG_HASH:=b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89
+PKG_HASH:=deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt


### PR DESCRIPTION
This release incorporates the following bug fixes and mitigations:

Fixed incorrect failure handling in RSA KEM RSASVE encapsulation.
(CVE-2026-31790)

Fixed loss of key agreement group tuple structure when the DEFAULT keyword is used in the server-side configuration of the key-agreement group list.
(CVE-2026-2673)

Fixed potential use-after-free in DANE client code.
(CVE-2026-28387)

Fixed NULL pointer dereference when processing a delta CRL.
(CVE-2026-28388)

Fixed possible NULL dereference when processing CMS KeyAgreeRecipientInfo.
(CVE-2026-28389)

Fixed possible NULL dereference when processing CMS KeyTransportRecipientInfo.
(CVE-2026-28390)

Fixed heap buffer overflow in hexadecimal conversion.
(CVE-2026-31789)

No need refresh patches.
