### PR TITLE
ipq806x: fallback to devicetree for ath10k calibration on TP-Link OnHub

### DIFF
--- a/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ipq806x/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -30,7 +30,11 @@ case "$FIRMWARE" in
 	case "$board" in
 	asus,onhub|\
 	tplink,onhub)
-		base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration0
+		if [ -f /sys/firmware/vpd/ro/wifi_base64_calibration0 ]; then
+			base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration0
+		else
+			base64_extract /sys/firmware/devicetree/base/soc/pci@1b500000/pcie@0/ath10k@0,0/qcom,ath10k-calibration-data-base64
+		fi
 		;;
 	esac
 	;;
@@ -38,7 +42,11 @@ case "$FIRMWARE" in
 	case "$board" in
 	asus,onhub|\
 	tplink,onhub)
-		base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration1
+		if [ -f /sys/firmware/vpd/ro/wifi_base64_calibration1 ]; then
+			base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration1
+		else
+			base64_extract /sys/firmware/devicetree/base/soc/pci@1b700000/pcie@0/ath10k@0,0/qcom,ath10k-calibration-data-base64
+		fi
 		;;
 	esac
 	;;
@@ -46,7 +54,11 @@ case "$FIRMWARE" in
 	case "$board" in
 	asus,onhub|\
 	tplink,onhub)
-		base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration2
+		if [ -f /sys/firmware/vpd/ro/wifi_base64_calibration2 ]; then
+			base64_extract /sys/firmware/vpd/ro/wifi_base64_calibration2
+		else
+			base64_extract /sys/firmware/devicetree/base/soc/pci@1b900000/pcie@0/ath10k@0,0/qcom,ath10k-calibration-data-base64
+		fi
 		;;
 	esac
 	;;


### PR DESCRIPTION
On OpenWrt 25.12.x for the TP-Link OnHub target, the /sys/firmware/vpd/ro directory is no longer exposed by the kernel, causing the extraction of wifi_base64_calibration* inside the 11-ath10k-caldata script to fail silently. This causes the ath10k driver to crash on boot with 'otp calibration failed: 2'.
This patch updates the hotplug script to fallback and extract the factory base64 calibration data from the device tree 'qcom,ath10k-calibration-data-base64' properties if the VPD sysfs nodes are missing.
Resolves #21243