### PR TITLE
wifi-scripts: fix broken eap-tls wireless client mode

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/migrate.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/migrate.uc
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2026 Mikhail Zhilkin <csharper2005@gmail.com>
+
+'use strict';
+
+import { cursor } from "uci";
+
+const uci = cursor();
+
+const iface_keys = {
+	"priv_key":		"private_key",
+	"priv_key_pwd":		"private_key_passwd"
+};
+
+let wireless_changed = false;
+
+function migrate_section_keys(config, sid, mapping) {
+	for (let old_key in mapping) {
+		let new_key = mapping[old_key];
+		let val = uci.get(config, sid, old_key);
+
+		if (val != null) {
+			uci.set(config, sid, new_key, val);
+			uci.delete(config, sid, old_key);
+			system([ "logger", `[${sid}] Migrated: ${old_key} -> ${new_key}` ]);
+			wireless_changed = true;
+		}
+	}
+}
+
+uci.load("wireless");
+uci.foreach("wireless", "wifi-iface", (s) => {
+	migrate_section_keys("wireless", s['.name'], iface_keys);
+});
+
+if (wireless_changed)
+	uci.commit("wireless");

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -81,6 +81,8 @@ function setup_sta(data, config) {
 	switch(config.mode) {
 	case 'sta':
 		set_default(config, 'multi_ap_backhaul_sta', config.multi_ap);
+		if (config.eap_type == 'tls')
+			network_append('eap', 'TLS');
 		break;
 
 	case 'adhoc':

--- a/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/06-wifi-migrate
+++ b/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/06-wifi-migrate
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+MIGRATE_SCRIPT="/usr/share/ucode/wifi/migrate.uc"
+
+[ "${ACTION}" = "add" ] && [ -f "$MIGRATE_SCRIPT" ] && \
+	/usr/bin/ucode "$MIGRATE_SCRIPT"


### PR DESCRIPTION
**1. wifi-scripts: ucode: fix sta eap-tls mode**

The `supplicant.uc` script doesn't map `eap_type` '`tls`' to the supplicant `eap` variable. This commit fixes non-working sta eap-tls mode.

**2. base-files: add a migration script for the wireless**

Since OpenWrt 25.12.0 release some `/etc/config/wireless` options were renamed. As a result, eap-tls client doesn't work after the upgrade from OpenWrt 24.10.x release.

This commit adds a migration script that renames:
- Option `priv_key` to `private_key`
- Option `priv_key_pwd` to `private_key_passwd`

Fixes: https://github.com/openwrt/openwrt/issues/22599
