### PR TITLE
x86: geode: "geos": fix ASU profile identification

### DIFF
--- a/target/linux/x86/image/geode.mk
+++ b/target/linux/x86/image/geode.mk
@@ -13,5 +13,6 @@ define Device/geos
   DEVICE_MODEL := Geos
   DEVICE_PACKAGES += br2684ctl flashrom kmod-hwmon-lm90 kmod-mppe kmod-pppoa \
 	kmod-usb-ohci-pci linux-atm ppp-mod-pppoa pppdump pppstats soloscli tc
+  SUPPORTED_DEVICES += traverse-technologies-geos
 endef
 TARGET_DEVICES += geos


### PR DESCRIPTION
Add SUPPORTED_DEVICES entry to allow ASU server to identify this specific profile in the, normally "generic", x86/geode target.

*NOTE: Just a remembering of the problem with "generic" (x86, armsr, malta) targets and METADATA, default SUPPORTED_DEVICES is NOT set to avoid failing sysupgrade's fwtool checks since the generic images are shared by several devices, plus the sysinfo's board_name is not reliable in ACPI systems (Do not conflict/block with this use case) https://github.com/openwrt/openwrt/commit/29167cbca3653de05a8b915bc21327dac7d05174

Reference: board_name used by "geos" devices https://github.com/openwrt/openwrt/commit/657418db68fe2be89bdba2a147a08168d7a760ba
Related: issue with generic profile in "geode" https://github.com/openwrt/openwrt/issues/22323
