### PR TITLE
ipq40xx: avoid randomized MAC address on boot

### DIFF
--- a/target/linux/ipq40xx/dts/qcom-ipq4018-a42.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-a42.dts
@@ -52,13 +52,11 @@
 	};
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_status_green;
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;
 		led-upgrade = &led_status_green;
-		label-mac-device = &swport5;
+		label-mac-device = &gmac;
 	};
 
 	leds {
@@ -201,6 +199,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &switch {
@@ -218,9 +219,6 @@
 &swport5 {
 	status = "okay";
 	label = "ethernet1";
-
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-gl-a1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-gl-a1300.dts
@@ -11,13 +11,11 @@
 	compatible = "glinet,gl-a1300", "qcom,ipq4019";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_run;
 		led-failsafe = &led_run;
 		led-running = &led_run;
 		led-upgrade = &led_run;
-		label-mac-device = &swport4;
+		label-mac-device = &gmac;
 	};
 
 	chosen {
@@ -302,6 +300,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0 0>;
 };
 
 &switch {
@@ -320,8 +321,6 @@
 	status = "okay";
 
 	label = "lan1";
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&macaddr_gmac0 0>;
 };
 
 &swport5 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-pa1200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-pa1200.dts
@@ -52,13 +52,11 @@
 	};
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_status_purple;
 		led-failsafe = &led_status_yellow;
 		led-running = &led_status_cyan;
 		led-upgrade = &led_status_yellow;
-		label-mac-device = &swport5;
+		label-mac-device = &gmac;
 	};
 
 	leds {
@@ -193,6 +191,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &switch {
@@ -210,9 +211,6 @@
 &swport5 {
 	status = "okay";
 	label = "ethernet1";
-
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &wifi0 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4018-rt-ac58u.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4018-rt-ac58u.dts
@@ -16,8 +16,6 @@
 	};
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;
@@ -327,6 +325,7 @@
 
 &gmac {
 	status = "okay";
+
 	nvmem-cells = <&macaddr_factory_5006>;
 	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-a62.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-a62.dts
@@ -52,13 +52,11 @@
 	};
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_status_green;
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;
 		led-upgrade = &led_status_green;
-		label-mac-device = &swport4;
+		label-mac-device = &gmac;
 	};
 
 	leds {
@@ -229,6 +227,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &switch {
@@ -238,9 +239,6 @@
 &swport4 {
 	status = "okay";
 	label = "ethernet1";
-
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &swport5 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-deco-m5.dtsi
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-deco-m5.dtsi
@@ -12,7 +12,7 @@
 	};
 
 	aliases {
-		label-mac-device = &swport4;
+		label-mac-device = &gmac;
 	};
 
 	keys {
@@ -341,6 +341,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0 0>;
 };
 
 &switch {
@@ -350,9 +353,6 @@
 &swport4 {
 	status = "okay";
 	label = "lan";
-
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&macaddr_gmac0 0>;
 };
 
 &swport5 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-pa2200.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-pa2200.dts
@@ -44,13 +44,11 @@
 	};
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &led_power_orange;
 		led-failsafe = &led_status_blue;
 		led-running = &led_power_orange;
 		led-upgrade = &led_status_blue;
-		label-mac-device = &swport4;
+		label-mac-device = &gmac;
 	};
 
 	leds {
@@ -209,6 +207,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &switch {
@@ -218,9 +219,6 @@
 &swport4 {
 	status = "okay";
 	label = "ethernet1";
-
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&macaddr_gmac0>;
 };
 
 &swport5 {

--- a/target/linux/ipq40xx/dts/qcom-ipq4029-gl-b1300.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4029-gl-b1300.dts
@@ -25,13 +25,11 @@
 	compatible = "glinet,gl-b1300";
 
 	aliases {
-		// TODO: Verify if the ethernet0 alias is needed
-		ethernet0 = &gmac;
 		led-boot = &power;
 		led-failsafe = &power;
 		led-running = &power;
 		led-upgrade = &power;
-		label-mac-device = &swport4;
+		label-mac-device = &gmac;
 	};
 
 	memory {
@@ -287,6 +285,9 @@
 
 &gmac {
 	status = "okay";
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_gmac0 0>;
 };
 
 &switch {
@@ -305,8 +306,6 @@
 	status = "okay";
 
 	label = "lan1";
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&macaddr_gmac0 0>;
 };
 
 &swport5 {


### PR DESCRIPTION
In cases where an nvmem definition is applied to the switch ports, change to apply to the root gmac so that a randomized MAC address does not get set.

Also remove the aliases. Since nvmem is used, we don't care about the bootloader.

ping @DragonBluep 