### PR TITLE
wifi-scripts: fix txpower 0 treated as auto in ucode

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
+++ b/package/network/config/wifi-scripts/files-ucode/lib/netifd/wireless/mac80211.sh
@@ -93,7 +93,7 @@ function setup_phy(phy, config, data) {
 		rxantenna: config.rxantenna
 	});
 
-	if (config.txpower)
+	if (length(config.txpower) > 0)
 		config.txpower = 'fixed ' + config.txpower + '00';
 	else
 		config.txpower = 'auto';


### PR DESCRIPTION
In the ucode version of mac80211.sh, 'if (config.txpower)' evaluates
to false when txpower is set to 0 (falsy in ucode/JS). This causes
txpower to be set to 'auto' instead of 'fixed 000'.

The old shell version correctly handles this with '[ -n "$txpower" ]'
since '0' is a non-empty string.

Fix by using length() which returns 0 for null/undefined and a
positive value for any valid setting including '0'. This matches
the pattern already used elsewhere in the file (line 307).

Fixes #22855