### PR TITLE
[24.10]: u-boot: backport swig bugfix (tegra, sunxi)

### DIFF
--- a/package/boot/uboot-sunxi/patches/003-scripts-dtc-pylibfdt-libfdt-i_shipped-Use-SWIG_AppendOutp.patch
+++ b/package/boot/uboot-sunxi/patches/003-scripts-dtc-pylibfdt-libfdt-i_shipped-Use-SWIG_AppendOutp.patch
@@ -1,0 +1,54 @@
+From a63456b9191fae2fe49f4b121e025792022e3950 Mon Sep 17 00:00:00 2001
+From: Markus Volk <f_l_k@t-online.de>
+Date: Wed, 30 Oct 2024 06:07:16 +0100
+Subject: [PATCH] scripts/dtc/pylibfdt/libfdt.i_shipped: Use SWIG_AppendOutput
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Swig has changed language specific AppendOutput functions. The helper
+macro SWIG_AppendOutput remains unchanged. Use that instead
+of SWIG_Python_AppendOutput, which would require an extra parameter
+since swig 4.3.0.
+
+/home/flk/poky/build-test/tmp/work/qemux86_64-poky-linux/u-boot/2024.10/git/arch/x86/cpu/u-boot-64.lds
+| scripts/dtc/pylibfdt/libfdt_wrap.c: In function '_wrap_fdt_next_node':
+| scripts/dtc/pylibfdt/libfdt_wrap.c:5581:17: error: too few arguments to function 'SWIG_Python_AppendOutput'
+|  5581 |     resultobj = SWIG_Python_AppendOutput(resultobj, val);
+|       |                 ^~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Markus Volk <f_l_k@t-online.de>
+Reported-by: Rudi Heitbaum <rudi@heitbaum.com>
+Link: https://github.com/dgibson/dtc/pull/154
+---
+ scripts/dtc/pylibfdt/libfdt.i_shipped | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/scripts/dtc/pylibfdt/libfdt.i_shipped
++++ b/scripts/dtc/pylibfdt/libfdt.i_shipped
+@@ -1037,7 +1037,7 @@ typedef uint32_t fdt32_t;
+ 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
+ 		buff = PyByteArray_FromStringAndSize(
+ 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
+-		resultobj = SWIG_Python_AppendOutput(resultobj, buff);
++		resultobj = SWIG_AppendOutput(resultobj, buff);
+ 	}
+ }
+
+@@ -1076,7 +1076,7 @@ typedef uint32_t fdt32_t;
+
+ %typemap(argout) int *depth {
+         PyObject *val = Py_BuildValue("i", *arg$argnum);
+-        resultobj = SWIG_Python_AppendOutput(resultobj, val);
++        resultobj = SWIG_AppendOutput(resultobj, val);
+ }
+
+ %apply int *depth { int *depth };
+@@ -1092,7 +1092,7 @@ typedef uint32_t fdt32_t;
+            if (PyTuple_GET_SIZE(resultobj) == 0)
+               resultobj = val;
+            else
+-              resultobj = SWIG_Python_AppendOutput(resultobj, val);
++              resultobj = SWIG_AppendOutput(resultobj, val);
+         }
+ }

--- a/package/boot/uboot-tegra/patches/001-scripts-dtc-pylibfdt-libfdt-i_shipped-Use-SWIG_AppendOutp.patch
+++ b/package/boot/uboot-tegra/patches/001-scripts-dtc-pylibfdt-libfdt-i_shipped-Use-SWIG_AppendOutp.patch
@@ -1,0 +1,54 @@
+From a63456b9191fae2fe49f4b121e025792022e3950 Mon Sep 17 00:00:00 2001
+From: Markus Volk <f_l_k@t-online.de>
+Date: Wed, 30 Oct 2024 06:07:16 +0100
+Subject: [PATCH] scripts/dtc/pylibfdt/libfdt.i_shipped: Use SWIG_AppendOutput
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Swig has changed language specific AppendOutput functions. The helper
+macro SWIG_AppendOutput remains unchanged. Use that instead
+of SWIG_Python_AppendOutput, which would require an extra parameter
+since swig 4.3.0.
+
+/home/flk/poky/build-test/tmp/work/qemux86_64-poky-linux/u-boot/2024.10/git/arch/x86/cpu/u-boot-64.lds
+| scripts/dtc/pylibfdt/libfdt_wrap.c: In function '_wrap_fdt_next_node':
+| scripts/dtc/pylibfdt/libfdt_wrap.c:5581:17: error: too few arguments to function 'SWIG_Python_AppendOutput'
+|  5581 |     resultobj = SWIG_Python_AppendOutput(resultobj, val);
+|       |                 ^~~~~~~~~~~~~~~~~~~~~~~~
+
+Signed-off-by: Markus Volk <f_l_k@t-online.de>
+Reported-by: Rudi Heitbaum <rudi@heitbaum.com>
+Link: https://github.com/dgibson/dtc/pull/154
+---
+ scripts/dtc/pylibfdt/libfdt.i_shipped | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/scripts/dtc/pylibfdt/libfdt.i_shipped
++++ b/scripts/dtc/pylibfdt/libfdt.i_shipped
+@@ -1037,7 +1037,7 @@ typedef uint32_t fdt32_t;
+ 			fdt_string(fdt1, fdt32_to_cpu($1->nameoff)));
+ 		buff = PyByteArray_FromStringAndSize(
+ 			(const char *)($1 + 1), fdt32_to_cpu($1->len));
+-		resultobj = SWIG_Python_AppendOutput(resultobj, buff);
++		resultobj = SWIG_AppendOutput(resultobj, buff);
+ 	}
+ }
+
+@@ -1076,7 +1076,7 @@ typedef uint32_t fdt32_t;
+
+ %typemap(argout) int *depth {
+         PyObject *val = Py_BuildValue("i", *arg$argnum);
+-        resultobj = SWIG_Python_AppendOutput(resultobj, val);
++        resultobj = SWIG_AppendOutput(resultobj, val);
+ }
+
+ %apply int *depth { int *depth };
+@@ -1092,7 +1092,7 @@ typedef uint32_t fdt32_t;
+            if (PyTuple_GET_SIZE(resultobj) == 0)
+               resultobj = val;
+            else
+-              resultobj = SWIG_Python_AppendOutput(resultobj, val);
++              resultobj = SWIG_AppendOutput(resultobj, val);
+         }
+ }


### PR DESCRIPTION
This PR is the same as #21415, but fixes more impacted targets (`tegra` & `sunxi`) which were missed during that PR.

---

When building on current Debian stable (13), which has a newer swig version, the build process fails. This was previously described in #20620, #21415, and in this PR's commit messages.

I was not able to find backportable commits for these targets (`tegra` & `sunxi`), as most simply updated to/past 25.01 on `main`, before this problem showed up.

For additional context, u-boot 25.01 added the SWIG fix: u-boot/u-boot@a63456b9191fae2fe49f4b121e025792022e3950, which was part of v2025.01-rc2.

As such, targets either updated to/past u-boot 25.01 (e.g. tegra 92cd360aacd697f81f649ef78a7a5bb0d007f84a and sunxi 2aba2b32ce69556be76e428499abb39293f0a94b), or removed the patch when bumping the version (e.g. rockchip 92814fec77fe24a68ab4a2acbf3ac245163c6090).