### PR TITLE
mediatek: filogic: add support for MERCUSYS Halo H90X v1

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -808,6 +808,18 @@ define U-Boot/mt7986_jdcloud_re-cp-03
   DEPENDS:=+trusted-firmware-a-mt7986-emmc-ddr4
 endef
 
+define U-Boot/mt7986_mercusys_h90x-v1
+  NAME:=MERCUSYS H90X v1
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=mercusys_h90x-v1-ubi
+  UBOOT_CONFIG:=mt7986_mercusys_h90x-v1
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand-ubi
+  BL2_SOC:=mt7986
+  BL2_DDRTYPE:=ddr3
+  DEPENDS:=+trusted-firmware-a-mt7986-spim-nand-ubi-ddr3
+endef
+
 define U-Boot/mt7986_mercusys_mr90x-v1
   NAME:=MERCUSYS MR90X v1
   BUILD_SUBTARGET:=filogic
@@ -1249,6 +1261,7 @@ UBOOT_TARGETS := \
 	mt7986_bananapi_bpi-r3-mini-snand \
 	mt7986_glinet_gl-mt6000 \
 	mt7986_jdcloud_re-cp-03 \
+	mt7986_mercusys_h90x-v1 \
 	mt7986_mercusys_mr90x-v1 \
 	mt7986_netcore_n60 \
 	mt7986_netcore_n60-pro \

--- a/package/boot/uboot-mediatek/patches/472-add-mercusys-h90x-v1.patch
+++ b/package/boot/uboot-mediatek/patches/472-add-mercusys-h90x-v1.patch
@@ -1,0 +1,61 @@
+--- /dev/null
++++ b/configs/mt7986_mercusys_h90x-v1_defconfig
+@@ -0,0 +1,2 @@
++include "mt7986_mercusys_mr90x-v1_defconfig"
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/mercusys_h90x-v1_env"
+--- /dev/null
++++ b/defenvs/mercusys_h90x-v1_env
+@@ -0,0 +1,53 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootargs=console=ttyS0,115200n8 console_msg_format=syslog
++bootcmd=run check_buttons ; run boot_production ; run boot_recovery
++bootconf=config-1
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-mercusys_h90x-v1-ubi-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-mercusys_h90x-v1-ubi-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-mercusys_h90x-v1-ubi-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-mercusys_h90x-v1-ubi-squashfs-sysupgrade.itb
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )  [0;36m[SPI-NAND][0m
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=noboot=1 ; replacevol=1 ; run boot_tftp_production ; noboot= ; replacevol= ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=noboot=1 ; replacevol=1 ; run boot_tftp_recovery ; noboot= ; replacevol= ; run bootmenu_confirm_return
++bootmenu_6=[31mLoad BL31+U-Boot FIP via TFTP then write to NAND.[0m=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=[31mLoad BL2 preloader via TFTP then write to NAND.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_default=run led_boot ; run bootcmd ; run boot_recovery ; replacevol=1 ; run boot_tftp_forever
++boot_production=run led_boot ; run ubi_read_production && bootm $loadaddr#$bootconf
++boot_recovery=run led_boot ; run ubi_read_recovery && bootm $loadaddr#$bootconf
++boot_tftp=run led_boot ; tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_forever=run led_boot ; while true ; do run boot_tftp ; sleep 1 ; done
++boot_tftp_production=run led_boot ; tftpboot $loadaddr $bootfile_upg && test $replacevol = 1 && iminfo $loadaddr && run ubi_write_production ; if test $noboot = 1 ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_recovery=run led_boot ; tftpboot $loadaddr $bootfile && test $replacevol = 1 && iminfo $loadaddr && run ubi_write_recovery ; if test $noboot = 1 ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_write_fip=run led_boot ; tftpboot $loadaddr $bootfile_fip && run ubi_write_fip && run reset_factory
++boot_tftp_write_bl2=run led_boot ; tftpboot $loadaddr $bootfile_bl2 && run snand_write_bl2
++check_buttons=if button reset ; then run boot_tftp ; fi
++ethaddr_factory=mtd read factory 0x40080000 0x0 0x20000 && env readmem -b ethaddr 0x40088000 0x6 ; setenv ethaddr_factory
++led_boot=led green:status off ; led amber:status on
++reset_factory=mw $loadaddr 0xff 0x1f000 ; ubi write $loadaddr ubootenv 0x1f000 ; ubi write $loadaddr ubootenv2 0x1f000 ; ubi remove rootfs_data
++snand_write_bl2=mtd erase bl2 && mtd write bl2 $loadaddr 0x0 0x40000
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x1f000 dynamic ; ubi check ubootenv2 || ubi create ubootenv2 0x1f000 dynamic
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_fip=run ubi_remove_rootfs ; ubi check fip && ubi remove fip ; ubi create fip $filesize static && ubi write $loadaddr fip $filesize
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run ethaddr_factory ; run _switch_to_menu ; run _init_env ; bootmenu
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -37,6 +37,7 @@ h3c,magic-nx30-pro|\
 imou,hx21|\
 jcg,q30-pro|\
 konka,komi-a31|\
+mercusys,h90x-v1-ubi|\
 mercusys,mr90x-v1-ubi|\
 netcore,n60|\
 netcore,n60-pro|\
@@ -109,6 +110,7 @@ buffalo,wsr-3000ax4p|\
 buffalo,wsr-6000ax8|\
 elecom,wrc-x6000gsd|\
 elecom,wrc-x6000qs|\
+mercusys,h90x-v1|\
 mercusys,mr80x-v3|\
 mercusys,mr85x|\
 mercusys,mr90x-v1|\

--- a/target/linux/mediatek/dts/mt7986b-mercusys-h90x-v1-ubi.dts
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-h90x-v1-ubi.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+#include "mt7986b-mercusys-mr90x-v1-ubi.dts"
+
+/ {
+	compatible = "mercusys,h90x-v1-ubi", "mediatek,mt7986b";
+	model = "MERCUSYS H90X v1 (UBI)";
+};
+
+&switch {
+	ports {
+		/delete-node/ port@0;
+	};
+};

--- a/target/linux/mediatek/dts/mt7986b-mercusys-h90x-v1.dts
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-h90x-v1.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+#include "mt7986b-mercusys-mr90x-v1.dts"
+
+/ {
+	compatible = "mercusys,h90x-v1", "mediatek,mt7986b";
+	model = "MERCUSYS H90X v1";
+};
+
+&switch {
+	ports {
+		/delete-node/ port@0;
+	};
+};

--- a/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1-common.dtsi
@@ -218,7 +218,7 @@
 		compatible = "spi-nand";
 		reg = <0>;
 
-		spi-max-frequency = <20000000>;
+		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -140,6 +140,12 @@ keenetic,kn-3711|\
 keenetic,kn-3811)
 	ucidef_set_led_netdev "internet" "internet" "green:wan" "wan" "link"
 	;;
+mercusys,h90x-v1|\
+mercusys,h90x-v1-ubi)
+	ucidef_set_led_netdev "lan-1" "lan-1" "green:lan-1" "lan1" "link tx rx"
+	ucidef_set_led_netdev "lan-2" "lan-2" "green:lan-2" "lan2" "link tx rx"
+	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
+	;;
 mercusys,mr80x-v3)
 	ucidef_set_led_netdev "lan1" "lan-1" "green:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan2" "lan-2" "green:lan-2" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -194,6 +194,8 @@ mediatek_setup_interfaces()
 	tplink,fr365-v1)
 		ucidef_set_interfaces_lan_wan "port1 port3 port4 port5 port6" "port2"
 		;;
+	mercusys,h90x-v1|\
+	mercusys,h90x-v1-ubi|\
 	tplink,tl-xdr6086|\
 	wavlink,wl-wn551x3|\
 	wavlink,wl-wn586x3|\

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -21,6 +21,7 @@ case "$FIRMWARE" in
 	;;
 "mediatek/mt7986_eeprom_mt7975_dual.bin")
 	case "$board" in
+	mercusys,h90x-v1|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1-eu|\
 	tplink,re6000xd)

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -173,6 +173,7 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $label_mac -1 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $label_mac -2 > /sys${DEVPATH}/macaddress
 		;;
+	mercusys,h90x-v1|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
 	tplink,archer-ax80-v1-eu|\

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -15,6 +15,7 @@ preinit_mount_cfg_part() {
 	case $(board_name) in
 	mercusys,mr80x-v3|\
 	mercusys,mr85x|\
+	mercusys,h90x-v1|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
 	tplink,archer-ax80-v1-eu|\

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -38,6 +38,7 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address "$addr"
 		ip link set dev eth1 address "$addr"
 		;;
+	mercusys,h90x-v1|\
 	mercusys,mr90x-v1|\
 	tplink,archer-ax80-v1|\
 	tplink,archer-ax80-v1-eu|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -140,6 +140,7 @@ platform_do_upgrade() {
 	konka,komi-a31|\
 	mediatek,mt7981-rfb|\
 	mediatek,mt7988a-rfb|\
+	mercusys,h90x-v1-ubi|\
 	mercusys,mr90x-v1-ubi|\
 	netis,nx30v2|\
 	netis,nx31|\
@@ -245,6 +246,7 @@ platform_do_upgrade() {
 		esac
 		nand_do_upgrade "$1"
 		;;
+	mercusys,h90x-v1|\
 	mercusys,mr80x-v3|\
 	mercusys,mr85x|\
 	mercusys,mr90x-v1|\
@@ -344,6 +346,7 @@ platform_check_image() {
 	konka,komi-a31|\
 	mediatek,mt7981-rfb|\
 	mediatek,mt7988a-rfb|\
+	mercusys,h90x-v1-ubi|\
 	mercusys,mr90x-v1-ubi|\
 	nokia,ea0326gmp|\
 	netis,nx32u|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2357,6 +2357,51 @@ define Device/mediatek_mt7988a-rfb
 endef
 TARGET_DEVICES += mediatek_mt7988a-rfb
 
+define Device/mercusys_h90x-mr90x-common
+  DEVICE_VENDOR := MERCUSYS
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+endef
+
+define Device/mercusys_h90x-mr90x-common-ubi
+  $(call Device/mercusys_h90x-mr90x-common)
+  DEVICE_DTC_FLAGS := --pad 4096
+  DEVICE_DTS_LOADADDR := 0x43f00000
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
+	pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
+	append-metadata
+  ARTIFACTS := bl31-uboot.fip preloader.bin
+  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ubi-ddr3
+endef
+
+define Device/mercusys_h90x-v1
+  DEVICE_MODEL := H90X v1
+  DEVICE_DTS := mt7986b-mercusys-h90x-v1
+  $(call Device/mercusys_h90x-mr90x-common)
+  IMAGE_SIZE := 51200k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += mercusys_h90x-v1
+
+define Device/mercusys_h90x-v1-ubi
+  DEVICE_MODEL := H90X v1 (UBI)
+  DEVICE_DTS := mt7986b-mercusys-h90x-v1-ubi
+  $(call Device/mercusys_h90x-mr90x-common-ubi)
+  ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot mercusys_h90x-v1
+endef
+TARGET_DEVICES += mercusys_h90x-v1-ubi
+
 define Device/mercusys_mr80x-v3
   DEVICE_VENDOR := MERCUSYS
   DEVICE_MODEL := MR80X
@@ -2385,44 +2430,19 @@ endef
 TARGET_DEVICES += mercusys_mr85x
 
 define Device/mercusys_mr90x-v1
-  DEVICE_VENDOR := MERCUSYS
   DEVICE_MODEL := MR90X v1
   DEVICE_DTS := mt7986b-mercusys-mr90x-v1
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
+  $(call Device/mercusys_h90x-mr90x-common)
   IMAGE_SIZE := 51200k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
 endef
 TARGET_DEVICES += mercusys_mr90x-v1
 
 define Device/mercusys_mr90x-v1-ubi
-  DEVICE_VENDOR := MERCUSYS
   DEVICE_MODEL := MR90X v1 (UBI)
   DEVICE_DTS := mt7986b-mercusys-mr90x-v1-ubi
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x43f00000
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | \
-	pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-with-rootfs | \
-	append-metadata
-  ARTIFACTS := bl31-uboot.fip preloader.bin
+  $(call Device/mercusys_h90x-mr90x-common-ubi)
   ARTIFACT/bl31-uboot.fip := mt7986-bl31-uboot mercusys_mr90x-v1
-  ARTIFACT/preloader.bin := mt7986-bl2 spim-nand-ubi-ddr3
 endef
 TARGET_DEVICES += mercusys_mr90x-v1-ubi
 


### PR DESCRIPTION
## MERCUSYS Halo H90X (v1) Support

Adds support for the MERCUSYS Halo H90X (EU) v1 with both the stock flash layout and an optional OpenWrt U-Boot UBI layout.

### Hardware Highlights

- **SoC:** MediaTek MT7986BLA
- **Switch/PHY:** MT7531AE + MaxLinear GPY211 (2.5GbE)
- **Flash:** 128 MiB SPI-NAND (ESMT F50L1G41LB / POWERCHIP PSU1GS20DX / GigaDevice GD5F1GQ5UEYIGY)
- **RAM:** 512 MiB
- **WLAN:** MT7975N/MT7975P (AX6000)

The H90X is closely related to the MR90X, but has one fewer MT7531 LAN port and a different stock NAND layout.

Detailed installation, recovery, and return-to-stock instructions are included in the commit message.

> [!WARNING]
> Not every complete installation path has been tested from an untouched stock device yet, so UART access is still recommended while testing the conversion procedures.