### PR TITLE
airoha: fix dts compatibles for sysupgrades and ASU profile identification

### DIFF
--- a/target/linux/airoha/dts/an7581-evb-emmc-eagle.dts
+++ b/target/linux/airoha/dts/an7581-evb-emmc-eagle.dts
@@ -6,7 +6,7 @@
 
 / {
 	model = "Airoha AN7581 Evaluation Board (eMMC + Eagle)";
-	compatible = "airoha,an7581-evb", "airoha,an7581", "airoha,en7581";
+	compatible = "airoha,an7581-evb-emmc-eagle", "airoha,an7581-evb", "airoha,an7581", "airoha,en7581";
 
 	aliases {
 		serial0 = &uart1;

--- a/target/linux/airoha/dts/an7581-evb-emmc-kite.dts
+++ b/target/linux/airoha/dts/an7581-evb-emmc-kite.dts
@@ -6,7 +6,7 @@
 
 / {
 	model = "Airoha AN7581 Evaluation Board (eMMC + Kite)";
-	compatible = "airoha,an7581-evb", "airoha,an7581", "airoha,en7581";
+	compatible = "airoha,an7581-evb-emmc-kite", "airoha,an7581-evb", "airoha,an7581", "airoha,en7581";
 
 	aliases {
 		serial0 = &uart1;

--- a/target/linux/airoha/dts/an7583-evb-emmc.dts
+++ b/target/linux/airoha/dts/an7583-evb-emmc.dts
@@ -7,8 +7,8 @@
 #include "an7583.dtsi"
 
 / {
-	model = "Airoha AN7583 Evaluation Board";
-	compatible = "airoha,an7583-evb", "airoha,an7583", "airoha,en7583";
+	model = "Airoha AN7583 Evaluation Board (eMMC)";
+	compatible = "airoha,an7583-evb-emmc", "airoha,an7583-evb", "airoha,an7583", "airoha,en7583";
 
 	aliases {
 		serial0 = &uart1;


### PR DESCRIPTION
Use different dts compatible strings for each emmc + wifi device variants missed during the additions.
This fixes sysupgrade's fwtool SUPPORTED_DEVICES check and ASU profile identification.