### PR TITLE
[master and 25.12] ath79: enterasys,ws-ap3805i: fix u-boot env

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ath79
+++ b/package/boot/uboot-tools/uboot-envtools/files/ath79
@@ -119,6 +119,10 @@ dell,apl27-0b1)
 domywifi,dw33d)
 	ubootenv_add_uci_config "/dev/mtd4" "0x0" "0x10000" "0x10000"
 	;;
+extreme-networks,ws-ap3805i)
+	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x1000" "0x4000" "1"
+	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x1000" "0x4000" "1"
+	;;
 glinet,gl-ar150)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x8000" "0x10000"
 	;;

--- a/target/linux/ath79/dts/qca9557_extreme-networks_ws-ap3805i.dts
+++ b/target/linux/ath79/dts/qca9557_extreme-networks_ws-ap3805i.dts
@@ -143,7 +143,8 @@
 				read-only;
 
 				nvmem-layout {
-					compatible = "u-boot,env";
+					compatible = "u-boot,env-redundant-count";
+					env-size = <0x10000>;
 
 					macaddr_uboot_ethaddr: ethaddr {
 					};


### PR DESCRIPTION
This is apparently a redundant u-boot config split between cfg1 and
cfg2. The size is also 0x10000 instead of the full amount.

This is needed in order to fix ethernet probing.

Fixes: https://github.com/openwrt/openwrt/commit/3faa3a04bb44c3a265e95cb5f8ec31b37ba37520 ("ath79: enterasys,ws-ap3805i: use nvmem")
