### PR TITLE
linux-firmware: update to 20260410

### DIFF
--- a/package/firmware/linux-firmware/Makefile
+++ b/package/firmware/linux-firmware/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=linux-firmware
-PKG_VERSION:=20260309
+PKG_VERSION:=20260410
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=@KERNEL/linux/kernel/firmware
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
-PKG_HASH:=c74cc6f562b58ad5bc6b2b00a61abc29c9e49e06126e7ba34fbca9928e07a96c
+PKG_HASH:=b7812ed6d59f6b09ecceddaa0be842a7e82a79cc0e46ca60478a4ebf02f1e178
 
 PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
 


### PR DESCRIPTION
```
% git log --no-merges --pretty=oneline --abbrev-commit 20260309...20260410
d3a8c256bf3b amdgpu: Revert Yellow Carp DMUB fw to 0x4000045
3b0b51d12d4e linux-firmware: qcom: sync audioreach firmwares from v1.0.3 build
b8df98acdc99 qcom: consolidate audioreach-tplg firmwares into one location in WHENCE
4cc3cf379e31 WHENCE: Fix ISH firmware symlink prefix for Lenovo PTL systems
6ca086313157 intel_vpu: Update NPU firmware
98c7d41b4cd9 Revert "rtl_bt: Update RTL8822C BT USB and UART firmware to 0x0673"
b7562faee6a4 nvidia: add acr/bl symlink for booting GSP-RM on GA100
461b77109fec qcom: add QUPv3 firmware for shikra
c87f3b91047e xe: Update GUC to v70.60.0 for LNL, BMG, PTL
11c04932225d qcom: update ADSP firmware for sm8750 platform
7590efdfb65f qcom: update CDSP firmware for glymur platform
b9e055ef6eed cirrus: cs35l41: Add support for new HP laptops
c1f5e540c545 cirrus: cs35l41: Add support for new ASUS laptops
dc147588ce1d cirrus: cs35l41: Add support for ASUS GZ302EAC and add 15.5dB bincfg
0bdf116777fb WHENCE: Move Dell remoteproc firmware to correct section
3c4cf8321887 qcom: vpu: add video firmware for SM8450
cc2cb17f5ed9 cirrus: cs35l56: Add firmware for Cirrus Amps for some ASUS laptops
1d57ec2fdc3f cirrus: cs35l56: Add firmware for Cirrus Amps for some Lenovo laptops
f56580c068ec iwlwifi: add Bz/Sc FW for core103-40 release
8b1582ab9739 iwlwifi: Add Hr/Gf firmware for core103-40 release
dafb7e8506a7 iwlwifi: update ty/So/Ma firmwares for core103-40 release
eb2d3ddcbaf4 amdgpu: DMCUB updates for various ASICs
a4c4b1863262 xe: Update PTL GSC to v105.0.2.1397
28455e71d17f linux-firmware: add firmware for Moxa mux50u devices
4ca3317e935e rtl_bt: Update RTL8852B BT USB FW to 0x127C_FD78
b56c03b62139 ath11k: WCN6855 hw2.0@nfa765: update to WLAN.HSP.1.1-04866.5-QCAHSPSWPL_V1_V2_SILICONZ_IOE-1
4c5450b2683a ath11k: QCA6698AQ hw2.1: update to WLAN.HSP.1.1-04866.5-QCAHSPSWPL_V1_V2_SILICONZ_IOE-1
f463012bf671 linux-firmware: update firmware for qat_4xxx devices
3dba1ce1e347 linux-firmware: update firmware for qat_402xx devices
dc04275f5679 linux-firmware: update firmware for qat_420xx devices
7bac18568c39 linux-firmware: update firmware for an8811hb 2.5G ethernet phy
827c67ef8287 linux-firmware: qcom: Add FW blobs for DELL XPS13 9345
ffccda596131 amdgpu: DMCUB updates for various ASICs
7bea13fc9a53 cirrus: cs35l63: Update firmware for Cirrus Amps for some Dell laptops
2d3de9fe2fb8 cirrus: cs35l63: Fix Cirrus Amp firmware links for some Dell laptops
d5a533e96ed1 linux-firmware: Add firmware file for Intel BlazarIW
457378a39e59 linux-firmware: Add firmware file for Intel BlazarIGfp2 core
b21b48725314 iwlwifi: add Bz/Wh FW for core102-56 release
6fb332659360 ath12k: WCN7850 hw2.0: update to WLAN.HMT.1.1.c7-00108-QCAHMTSWPL_V1.0_V2.0_SILICONZ_UPSTREAM-3
78029d11e29a mediatek MT7921: update bluetooth firmware to 20260224111243
546a25acc8e8 mediatek MT7920: update bluetooth firmware to 20260224111231
87a7d3c72b19 Add LENOVO ISH firmware v5.8.1.7720 for X1 Carbon (Gen 14) and X1 2-in-1 (Gen 11)
f71ae94fbda2 linux-firmware: Add ISH firmware file for Intel Wildcat Lake platform
87414f9ba8f8 linux-firmware: update firmware for MT7920 WiFi device
ced02591a802 linux-firmware: update firmware for MT7921 WiFi device
81608d9216ce linux-firmware: Update firmware file for Intel Quasar core
be85c6639a91 Intel Bluetooth: Update firmware file for Intel Bluetooth AX201
c3bc50dc241d linux-firmware: Add firmware file for Intel ScorpiusGfp2 core
4590121e2ecc linux-firmware: Update firmware file for Intel Scorpius core
179d9acb2171 linux-firmware: Update firmware file for Intel BlazarIGfP core
ed10eae8facb linux-firmware: Update firmware file for Intel BlazarI core
cca6520d6620 linux-firmware: Update firmware file for Intel BlazarU-HrPGfP core
3315fba7271d linux-firmware: Update firmware file for Intel BlazarU core
dab39c0fbe7a intel_vpu: Update NPU firmware
237bfc162a3a amdgpu: DMCUB updates for various ASICs
a8316dd1ccbc qcom: add QUPv3 firmware for QCS615 platform
934a7b3e16b8 Add LENOVO ISH firmware v5.8.0.7720 for X9-15 2025
```