### PR TITLE
realtek: eth: harden receive path

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
@@ -1022,11 +1022,11 @@ static int rteth_hw_receive(struct net_device *dev, int ring, int budget)
 		packet = &ctrl->rx_data[ring].packet[slot];
 		len = packet->len;
 
-		if (!len) {
-			netdev_err(dev, "empty packet received\n");
+		if (len < ETH_FCS_LEN || len > RING_BUFFER) {
+			netdev_err(dev, "invalid packet with %d bytes received\n", len);
 			break;
 		} else if (!dsa) {
-			len -= 4;
+			len -= ETH_FCS_LEN;
 		}
 
 		skb = netdev_alloc_skb_ip_align(dev, len);


### PR DESCRIPTION
The hardware usually takes care that

- a packet is no larger than the available buffer
- has at least a FCS checksum of 4 bytes

Nevertheless be cautious and improve the existing packet check. Just in case ...
