### PR TITLE
scripts/ext-tools.sh: set all prebuilt tool files to same timestamp

### DIFF
--- a/scripts/ext-tools.sh
+++ b/scripts/ext-tools.sh
@@ -4,10 +4,6 @@ TOOLS_TAR=""
 HOST_BUILD_DIR=$(pwd)/"build_dir/host"
 HOST_STAGING_DIR_STAMP=$(pwd)/"staging_dir/host/stamp"
 
-refresh_timestamps() {
-	find -H "$1" -not -type l -print0 | xargs -0 touch
-}
-
 extract_prebuilt_tar() {
 	tar -xf "$1"
 }
@@ -18,15 +14,15 @@ refresh_prebuilt_tools() {
 		exit 1
 	fi
 
-	refresh_timestamps "$HOST_BUILD_DIR"
-	sleep 1
-
 	if [ ! -d "$HOST_STAGING_DIR_STAMP" ]; then
 		echo "Can't find Host Staging Dir Stamp "$HOST_STAGING_DIR_STAMP"" >&2
 		exit 1
 	fi
 
-	refresh_timestamps "$HOST_STAGING_DIR_STAMP"
+	local now
+	now=$(date +%Y%m%d%H%M.%S)
+	find -H "$HOST_BUILD_DIR" "$HOST_STAGING_DIR_STAMP" \
+		-type f -empty -print0 | xargs -0 touch -t "$now"
 
 	return 0
 }


### PR DESCRIPTION
The GitHub CI was sometimes still building some tools again even when the same version was already pre-built. This change fixes the problem and should improve the speed of the GitHub CI actions. The duration of the "Build tools" step will be reduced from 5 to 20 minutes down to 10 to 15 seconds.

make also checks that dependencies are not more recent than the target it wants to build. Previously find returned files in an arbitrary order and touch set the current timestamp. Since touch is called per file the timestamps differ in fractional seconds, so not all files got the same time. make detected a more recent dependency and started to rebuild. Now all files are set to the same timestamp and make will assume everything is up to date.

It is sufficient to only touch the stamp files to prevent rebuilding.