### PR TITLE
ath79: wndap360: switch MACs to newer firmware

### DIFF
--- a/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
+++ b/target/linux/ath79/dts/ar7161_netgear_wndap360.dts
@@ -19,6 +19,7 @@
 		led-failsafe = &led_power_orange;
 		led-running = &led_power_green;
 		led-upgrade = &led_power_orange;
+		label-mac-device = &ath9k;
 	};
 
 	leds {
@@ -64,7 +65,7 @@
 	phy-mode = "rgmii";
 	phy-handle = <&phy1>;
 
-	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cells = <&macaddr_art_120c 10>;
 	nvmem-cell-names = "mac-address";
 };
 
@@ -115,17 +116,9 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
-					macaddr_art_0: macaddr@0 {
-						reg = <0x0 0x6>;
-					};
-
 					macaddr_art_120c: macaddr@120c {
-						reg = <0x120c 0x6>;
-					};
-
-					macaddr_art_520c: macaddr@520c {
 						compatible = "mac-base";
-						reg = <0x520c 0x6>;
+						reg = <0x120c 0x6>;
 						#nvmem-cell-cells = <1>;
 					};
 
@@ -145,10 +138,10 @@
 &pcie0 {
 	status = "okay";
 
-	wifi@11,0 {
+	ath9k: wifi@11,0 {
 		compatible = "pci168c,0029";
 		reg = <0x8800 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_120c>, <&calibration_art_1000>;
+		nvmem-cells = <&macaddr_art_120c 0>, <&calibration_art_1000>;
 		nvmem-cell-names = "mac-address", "calibration";
 
 		led {
@@ -160,7 +153,7 @@
 	wifi@12,0 {
 		compatible = "pci168c,0029";
 		reg = <0x9000 0 0 0 0>;
-		nvmem-cells = <&macaddr_art_520c 1>, <&calibration_art_5000>;
+		nvmem-cells = <&macaddr_art_120c 8>, <&calibration_art_5000>;
 		nvmem-cell-names = "mac-address", "calibration";
 
 		led {


### PR DESCRIPTION
Original ar71xx has this setup:

define WNDAP360_WMAC0_MAC_OFFSET               0x120c
define WNDAP360_WMAC1_MAC_OFFSET               0x520c

/* Reusing wifi MAC with offset of 1 as eth0 MAC */ ath79_init_mac(ath79_eth0_data.mac_addr,
               art + WNDAP360_WMAC0_MAC_OFFSET, 1);

ap94_pci_init(art + WNDAP360_CALDATA0_OFFSET,
              art + WNDAP360_WMAC0_MAC_OFFSET,
              art + WNDAP360_CALDATA1_OFFSET,
              art + WNDAP360_WMAC1_MAC_OFFSET);

The ath79 port made a questionable change for eth0 being just art with no offset. That MAC ends up being the OUI for Atheros.

WNDAP360_WMAC1_MAC_OFFSET is the same as WNDAP360_WMAC0_MAC_OFFSET except with the first hex value being subtracted by 2, which is not a valid OUI.

And newer Netgear firmware seems to assign differently as well, art_120C as a base and the others incremented by 0x8.

Switch the assignment to the latest firmware and add label-mac-device to document that the first Wi-FI MAC address is printed on the device.

ping @DragonBluep @ronnyadsetts
