### PR TITLE
Claude PR review improvments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,6 +32,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "/claude"
           track_progress: true
+          include_fix_links: false
           claude_args: >-
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(grep:*)"
             --disallowedTools "Bash(git add:*),Bash(git commit:*),Bash(git rm:*),Bash(git push:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,6 +31,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "/claude"
+          track_progress: true
           claude_args: >-
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(grep:*)"
             --disallowedTools "Bash(git add:*),Bash(git commit:*),Bash(git rm:*),Bash(git push:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,5 +32,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "/claude"
           claude_args: >-
-            --allowedTools "mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(grep:*)"
             --disallowedTools "Bash(git add:*),Bash(git commit:*),Bash(git rm:*),Bash(git push:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,3 +33,4 @@ jobs:
           trigger_phrase: "/claude"
           claude_args: >-
             --allowedTools "mcp__github_inline_comment__create_inline_comment"
+            --disallowedTools "Bash(git add:*),Bash(git commit:*),Bash(git rm:*),Bash(git push:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,3 +34,15 @@ jobs:
           claude_args: >-
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(grep:*)"
             --disallowedTools "Bash(git add:*),Bash(git commit:*),Bash(git rm:*),Bash(git push:*)"
+        env:
+          APPEND_SYSTEM_PROMPT: >-
+            IMPORTANT: For any issue tied to a specific file and line number,
+            you MUST call mcp__github_inline_comment__create_inline_comment to
+            post it as an inline comment on the diff. This is a separate
+            channel from mcp__github_comment__update_claude_comment and does
+            NOT violate the "only update your tracking comment" rule — both
+            tools should be used. Do NOT put line-specific issues in the
+            top-level tracking comment. Only use the top-level tracking
+            comment for a brief overall verdict. Never describe or summarize
+            what the PR does. Only report actual problems, concerns, or
+            suggestions. If nothing is wrong, say so in one short sentence.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 1
 
       - name: PR Review
-        uses: hauke/claude-code-action@95d07da986168a9998e8e4713ec29b7c162b4dd9 # v1.0.77-fixed
+        uses: hauke/claude-code-action@0ca689a0ca61147a6e7ee99f8453f2c73b8a6b40 # v1.0.93.2
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,3 +31,5 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           trigger_phrase: "/claude"
+          claude_args: >-
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"


### PR DESCRIPTION
This contains misc improvements to the Claude code PR reviewer.
 * It does inline comments on PRs now
 * It should be less verbose
 * It should handle PRs which are not on top of the current main branch better. I hope it will not complain about changes from other commits any more.
 * Fine tune the Claude Code allowed tools to allow grep with wildcard, but prevent git modifications. 
 * Update github action, this also contains a more recent claude code version 