### PR TITLE
tools: add ccache dependency to liblzo

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -160,6 +160,7 @@ $(foreach tool, $(filter-out zstd zlib xz pkgconf patch ninja meson libressl exp
 tools-y += ccache xxhash
 $(curdir)/xxhash/compile := $(curdir)/cmake/compile
 $(curdir)/ccache/compile := $(curdir)/xxhash/compile
+$(curdir)/liblzo/compile := $(curdir)/ccache/compile
 endif
 
 # in case there is no patch tool on the host we need to make patch tool a


### PR DESCRIPTION
Title: Ensure ccache is built before liblzo when CONFIG_CCACHE=y and CONFIG_SDK=y
Description:

When enabling both CONFIG_CCACHE=y and CONFIG_SDK=y, an issue occurs where liblzo compiles before ccache, causing a compilation error. This is because the ccache build is not properly ordered in the make process.

This patch ensures that ccache is correctly built before liblzo by explicitly setting the compilation order in the Makefile. With this fix, ccache will be compiled before any other tools like liblzo, preventing the compilation error.


