### PR TITLE
ath79: move label-mac-device out of dtsi

### DIFF
--- a/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi-ap-outdoor-plus.dts
@@ -11,6 +11,7 @@
 		led-failsafe = &led_white;
 		led-running = &led_blue;
 		led-upgrade = &led_blue;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi-ap.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi-ap.dtsi
@@ -8,6 +8,7 @@
 		led-failsafe = &led_dome_green;
 		led-running = &led_dome_green;
 		led-upgrade = &led_dome_green;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/ar7241_ubnt_unifi.dtsi
+++ b/target/linux/ath79/dts/ar7241_ubnt_unifi.dtsi
@@ -6,10 +6,6 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	aliases {
-		label-mac-device = &eth0;
-	};
-
 	keys {
 		compatible = "gpio-keys";
 

--- a/target/linux/ath79/dts/ar9344_engenius_eap600.dts
+++ b/target/linux/ath79/dts/ar9344_engenius_eap600.dts
@@ -8,6 +8,10 @@
 	model = "EnGenius EAP600";
 	compatible = "engenius,eap600", "qca,ar9344";
 
+	aliases {
+		label-mac-device = &eth0;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
+++ b/target/linux/ath79/dts/ar9344_engenius_ecb600.dts
@@ -8,6 +8,10 @@
 	model = "EnGenius ECB600";
 	compatible = "engenius,ecb600", "qca,ar9344";
 
+	aliases {
+		label-mac-device = &eth0;
+	};
+
 	leds {
 		compatible = "gpio-leds";
 

--- a/target/linux/ath79/dts/ar9344_senao_ap-dual.dtsi
+++ b/target/linux/ath79/dts/ar9344_senao_ap-dual.dtsi
@@ -8,7 +8,6 @@
 
 / {
 	aliases {
-		label-mac-device = &eth0;
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;

--- a/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap100.dts
@@ -13,6 +13,7 @@
 		led-failsafe = &led_power_amber;
 		led-running = &led_power_green;
 		led-upgrade = &led_power_amber;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
+++ b/target/linux/ath79/dts/ar9344_watchguard_ap200.dts
@@ -13,6 +13,7 @@
 		led-failsafe = &led_power_amber;
 		led-running = &led_power_green;
 		led-upgrade = &led_power_amber;
+		label-mac-device = &eth0;
 	};
 
 	leds {

--- a/target/linux/ath79/dts/qca9533_yuncore_cpe830.dts
+++ b/target/linux/ath79/dts/qca9533_yuncore_cpe830.dts
@@ -117,7 +117,7 @@
 						reg = <0x1000 0x440>;
 					};
 
-					macaddr_art_wmac: macaddr@1002 {
+					macaddr_art_1002: macaddr@1002 {
 						reg = <0x1002 0x6>;
 					};
 				};
@@ -141,8 +141,8 @@
 
 &wmac {
 	status = "okay";
-	nvmem-cells = <&cal_art_1000>;
-	nvmem-cell-names = "calibration";
+	nvmem-cells = <&cal_art_1000>, <&macaddr_art_1002>;
+	nvmem-cell-names = "calibration", "mac-address";
 
 	led {
 		led-sources = <12>;

--- a/target/linux/ath79/dts/qca9557_zyxel_nbg6616.dts
+++ b/target/linux/ath79/dts/qca9557_zyxel_nbg6616.dts
@@ -9,7 +9,6 @@
 	model = "Zyxel NBG6616";
 
 	aliases {
-		label-mac-device = &wmac;
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;

--- a/target/linux/ath79/dts/qca9558_zyxel_nbg6716.dts
+++ b/target/linux/ath79/dts/qca9558_zyxel_nbg6716.dts
@@ -9,7 +9,6 @@
 	model = "Zyxel NBG6716";
 
 	aliases {
-		label-mac-device = &wmac;
 		led-boot = &led_power;
 		led-failsafe = &led_power;
 		led-running = &led_power;

--- a/target/linux/ath79/dts/qca955x_zyxel_nbg6x16.dtsi
+++ b/target/linux/ath79/dts/qca955x_zyxel_nbg6x16.dtsi
@@ -6,6 +6,11 @@
 #include <dt-bindings/input/input.h>
 
 / {
+
+	aliases {
+		label-mac-device = &wmac;
+	};
+
 	keys: keys {
 		compatible = "gpio-keys";
 

--- a/target/linux/ath79/dts/qca9563_zte_mf281.dts
+++ b/target/linux/ath79/dts/qca9563_zte_mf281.dts
@@ -9,6 +9,10 @@
 	model = "ZTE MF281";
 	compatible = "zte,mf281", "qca,qca9563";
 
+	aliases {
+		label-mac-device = &eth0;
+	};
+
 	leds {
 		pinctrl-names = "default";
 		pinctrl-0 = <&enable_wlan_led_gpio>;

--- a/target/linux/ath79/dts/qca9563_zte_mf282.dts
+++ b/target/linux/ath79/dts/qca9563_zte_mf282.dts
@@ -10,6 +10,10 @@
 	model = "ZTE MF282";
 	compatible = "zte,mf282", "qca,qca9563";
 
+	aliases {
+		label-mac-device = &eth0;
+	};
+
 	ubi-concat {
 		compatible = "mtd-concat";
 		devices = <&ubiconcat0 &ubiconcat1>;

--- a/target/linux/ath79/dts/qca9563_zte_mf28x.dtsi
+++ b/target/linux/ath79/dts/qca9563_zte_mf28x.dtsi
@@ -13,7 +13,6 @@
 		led-failsafe = &led_debug;
 		led-running = &led_debug;
 		led-upgrade = &led_debug;
-		label-mac-device = &eth0;
 	};
 
 	leds {


### PR DESCRIPTION
A script was ran that checks the label-mac-device node to see if it has nvmem definitions as label-mac-device requires nvmem.

This is mostly a change to make the script happy. No intended functional difference.