### PR TITLE
hostapd: fix bogus ENFILE when reusing existing AP interface

### DIFF
--- a/package/network/services/hostapd/patches/053-nl80211-Avoid-bogus-ENFILE-with-use_existing.patch
+++ b/package/network/services/hostapd/patches/053-nl80211-Avoid-bogus-ENFILE-with-use_existing.patch
@@ -1,0 +1,85 @@
+From b74e7e6d6cda70e4477e0f8212d619132c13370c Mon Sep 17 00:00:00 2001
+From: Yanghan Ye <yyh94306@gmail.com>
+Date: Sun, 24 May 2026 04:13:13 +0800
+Subject: [PATCH] nl80211: Avoid bogus ENFILE with use_existing
+
+When use_existing is set, nl80211_create_iface() may be called for an
+interface that already exists. The current code still sends
+NL80211_CMD_NEW_INTERFACE first and only falls back to reusing the
+existing netdev after the create attempt fails.
+
+This can produce a misleading ENFILE/"Too many open files in system"
+failure in the log even though the subsequent use_existing path succeeds.
+
+Check for an existing interface before attempting to create it when
+use_existing is allowed. Keep the fallback path for races where the
+interface appears after the initial check or for other create failures
+that leave an existing netdev behind.
+
+Signed-off-by: Yanghan Ye <yyh94306@gmail.com>
+---
+ src/drivers/driver_nl80211.c | 36 +++++++++++++++++++++++-------------
+ 1 file changed, 23 insertions(+), 13 deletions(-)
+
+diff --git a/src/drivers/driver_nl80211.c b/src/drivers/driver_nl80211.c
+index d87b39969..e8eecfd16 100644
+--- a/src/drivers/driver_nl80211.c
++++ b/src/drivers/driver_nl80211.c
+@@ -6643,6 +6643,24 @@ static int nl80211_create_iface_once(struct wpa_driver_nl80211_data *drv,
+ }
+ 
+ 
++static int nl80211_use_existing_iface(struct wpa_driver_nl80211_data *drv,
++				      const char *ifname,
++				      enum nl80211_iftype iftype,
++				      const u8 *addr)
++{
++	wpa_printf(MSG_DEBUG, "nl80211: Continue using existing interface %s",
++		   ifname);
++	if (addr && iftype != NL80211_IFTYPE_MONITOR &&
++	    linux_set_ifhwaddr(drv->global->ioctl_sock, ifname, addr) < 0 &&
++	    (linux_set_iface_flags(drv->global->ioctl_sock, ifname, 0) < 0 ||
++	     linux_set_ifhwaddr(drv->global->ioctl_sock, ifname, addr) < 0 ||
++	     linux_set_iface_flags(drv->global->ioctl_sock, ifname, 1) < 0))
++		return -1;
++
++	return -ENFILE;
++}
++
++
+ int nl80211_create_iface(struct wpa_driver_nl80211_data *drv,
+ 			 const char *ifname, enum nl80211_iftype iftype,
+ 			 const u8 *addr, int wds,
+@@ -6651,25 +6669,17 @@ int nl80211_create_iface(struct wpa_driver_nl80211_data *drv,
+ {
+ 	int ret;
+ 
++	if (use_existing && if_nametoindex(ifname))
++		return nl80211_use_existing_iface(drv, ifname, iftype, addr);
++
+ 	ret = nl80211_create_iface_once(drv, ifname, iftype, addr, wds, handler,
+ 					arg);
+ 
+ 	/* if error occurred and interface exists already */
+ 	if (ret < 0 && if_nametoindex(ifname)) {
+ 		if (use_existing) {
+-			wpa_printf(MSG_DEBUG, "nl80211: Continue using existing interface %s",
+-				   ifname);
+-			if (addr && iftype != NL80211_IFTYPE_MONITOR &&
+-			    linux_set_ifhwaddr(drv->global->ioctl_sock, ifname,
+-					       addr) < 0 &&
+-			    (linux_set_iface_flags(drv->global->ioctl_sock,
+-						   ifname, 0) < 0 ||
+-			     linux_set_ifhwaddr(drv->global->ioctl_sock, ifname,
+-						addr) < 0 ||
+-			     linux_set_iface_flags(drv->global->ioctl_sock,
+-						   ifname, 1) < 0))
+-					return -1;
+-			return -ENFILE;
++			return nl80211_use_existing_iface(drv, ifname, iftype,
++							  addr);
+ 		}
+ 		wpa_printf(MSG_INFO, "Try to remove and re-create %s", ifname);
+ 
+-- 
+2.43.0

--- a/package/network/services/hostapd/patches/370-preserve_radio_mask.patch
+++ b/package/network/services/hostapd/patches/370-preserve_radio_mask.patch
@@ -87,7 +87,7 @@
  	/*
  	 * Tell cfg80211 that the interface belongs to the socket that created
  	 * it, and the interface should be deleted when the socket is closed.
-@@ -6643,14 +6667,14 @@ static int nl80211_create_iface_once(str
+@@ -6661,17 +6685,17 @@ static int nl80211_use_existing_iface(st
  
  int nl80211_create_iface(struct wpa_driver_nl80211_data *drv,
  			 const char *ifname, enum nl80211_iftype iftype,
@@ -97,6 +97,9 @@
  			 void *arg, int use_existing)
  {
  	int ret;
+ 
+ 	if (use_existing && if_nametoindex(ifname))
+ 		return nl80211_use_existing_iface(drv, ifname, iftype, addr);
  
 -	ret = nl80211_create_iface_once(drv, ifname, iftype, addr, wds, handler,
 -					arg);

--- a/package/network/services/hostapd/patches/602-nl80211-short-circuit-use-existing-iface.patch
+++ b/package/network/services/hostapd/patches/602-nl80211-short-circuit-use-existing-iface.patch
@@ -1,0 +1,82 @@
+From cc152837acb9cc58dd5b6c9d8899777c23e33be5 Mon Sep 17 00:00:00 2001
+From: Yanghan Ye <yyh94306@gmail.com>
+Date: Sun, 12 Apr 2026 18:55:57 +0800
+Subject: [PATCH] nl80211: short-circuit the use_existing interface path
+
+OpenWrt may pre-create AP netdevs from ucode before hostapd reaches the
+driver-level interface-add path. When use_existing is already set, the
+current code still sends NL80211_CMD_NEW_INTERFACE first, logs a bogus
+ENFILE/"Too many open files in system" failure, and only then falls back
+to the already-existing netdev.
+
+Short-circuit that case: if use_existing is allowed and the target
+ifname already exists, skip the create attempt and immediately reuse the
+interface.
+
+Signed-off-by: Yanghan Ye <yyh94306@gmail.com>
+---
+ src/drivers/driver_nl80211.c | 36 +++++++++++++++++++++++-------------
+ 1 file changed, 23 insertions(+), 13 deletions(-)
+
+diff --git a/src/drivers/driver_nl80211.c b/src/drivers/driver_nl80211.c
+index 413b6bd..8917204 100644
+--- a/src/drivers/driver_nl80211.c
++++ b/src/drivers/driver_nl80211.c
+@@ -6686,6 +6686,24 @@ static int nl80211_create_iface_once(struct wpa_driver_nl80211_data *drv,
+ }
+ 
+ 
++static int nl80211_use_existing_iface(struct wpa_driver_nl80211_data *drv,
++				      const char *ifname,
++				      enum nl80211_iftype iftype,
++				      const u8 *addr)
++{
++	wpa_printf(MSG_DEBUG, "nl80211: Continue using existing interface %s",
++		   ifname);
++	if (addr && iftype != NL80211_IFTYPE_MONITOR &&
++	    linux_set_ifhwaddr(drv->global->ioctl_sock, ifname, addr) < 0 &&
++	    (linux_set_iface_flags(drv->global->ioctl_sock, ifname, 0) < 0 ||
++	     linux_set_ifhwaddr(drv->global->ioctl_sock, ifname, addr) < 0 ||
++	     linux_set_iface_flags(drv->global->ioctl_sock, ifname, 1) < 0))
++		return -1;
++
++	return -ENFILE;
++}
++
++
+ int nl80211_create_iface(struct wpa_driver_nl80211_data *drv,
+ 			 const char *ifname, enum nl80211_iftype iftype,
+ 			 const u8 *addr, int wds, u32 radio_mask,
+@@ -6694,25 +6712,17 @@ int nl80211_create_iface(struct wpa_driver_nl80211_data *drv,
+ {
+ 	int ret;
+ 
++	if (use_existing && if_nametoindex(ifname))
++		return nl80211_use_existing_iface(drv, ifname, iftype, addr);
++
+ 	ret = nl80211_create_iface_once(drv, ifname, iftype, addr, wds, radio_mask,
+ 					handler, arg);
+ 
+ 	/* if error occurred and interface exists already */
+ 	if (ret < 0 && if_nametoindex(ifname)) {
+ 		if (use_existing) {
+-			wpa_printf(MSG_DEBUG, "nl80211: Continue using existing interface %s",
+-				   ifname);
+-			if (addr && iftype != NL80211_IFTYPE_MONITOR &&
+-			    linux_set_ifhwaddr(drv->global->ioctl_sock, ifname,
+-					       addr) < 0 &&
+-			    (linux_set_iface_flags(drv->global->ioctl_sock,
+-						   ifname, 0) < 0 ||
+-			     linux_set_ifhwaddr(drv->global->ioctl_sock, ifname,
+-						addr) < 0 ||
+-			     linux_set_iface_flags(drv->global->ioctl_sock,
+-						   ifname, 1) < 0))
+-					return -1;
+-			return -ENFILE;
++			return nl80211_use_existing_iface(drv, ifname, iftype,
++							  addr);
+ 		}
+ 		wpa_printf(MSG_INFO, "Try to remove and re-create %s", ifname);
+ 
+-- 
+2.43.0


### PR DESCRIPTION
OpenWrt may pre-create AP netdevs before hostapd reaches the nl80211 interface creation path.

When `use_existing` is enabled and the target interface already exists, the current code still tries `NL80211_CMD_NEW_INTERFACE` first. That results in a misleading ENFILE / "Too many open files in system" message before hostapd falls back to reusing the existing interface.

This patch skips that redundant create attempt and directly reuses the existing interface when `use_existing` is allowed.

This preserves the existing reuse behavior while avoiding the bogus error log.

Related: openwrt/openwrt#20387