### PR TITLE
kernel: net: sfp: improve OEM SFP-10G-T fixup

### DIFF
--- a/target/linux/generic/backport-6.12/736-v7.2-net-phy-sfp-probe-for-RollBall-I2C-to-MDIO-bridge-in.patch
+++ b/target/linux/generic/backport-6.12/736-v7.2-net-phy-sfp-probe-for-RollBall-I2C-to-MDIO-bridge-in.patch
@@ -1,0 +1,171 @@
+From 8fe125892f40cbe284fba8eda49a0407984fc74c Mon Sep 17 00:00:00 2001
+From: Petr Wozniak <petr.wozniak@gmail.com>
+Date: Wed, 27 May 2026 07:39:09 +0200
+Subject: [PATCH] net: phy: sfp: probe for RollBall I2C-to-MDIO bridge in
+ mdio-i2c
+
+The "OEM"/"SFP-10G-T" quirk entry in sfp_fixup_rollball_cc()
+unconditionally forces MDIO_I2C_ROLLBALL for all modules matching that
+vendor/part-number combination.  This works for modules that genuinely
+implement a RollBall I2C-to-MDIO bridge, but silently breaks modules
+that share the same EEPROM strings without having such a bridge.
+
+The Realtek RTL8261BE-CG is one such module: a pure copper 10G SFP+
+media converter with no I2C-to-MDIO bridge.  Its EEPROM reports
+vendor="OEM", part="SFP-10G-T-I", and -- critically -- Vendor OUI
+00:00:00, making OUI-based differentiation impossible.  With
+MDIO_I2C_ROLLBALL forced, the module silently ACKs the unlock password
+write, the MDIO bus is created, but no PHY responds; the SFP state
+machine cycles through the RollBall PHY-probe retry window before
+reporting no PHY.
+
+Move the probe into i2c_mii_init_rollball() in mdio-i2c.c, where the
+RollBall protocol constants are already defined.  After sending the
+unlock password, issue a CMD_READ and poll for CMD_DONE up to 200 ms
+(10 x 20 ms, matching the existing rollball poll tolerance).  A genuine
+RollBall bridge asserts CMD_DONE within that window; modules without a
+bridge never do, so i2c_mii_init_rollball() returns -ENODEV.
+mdio_i2c_alloc() propagates -ENODEV to the caller to signal that no
+bridge is present and PHY probing should be skipped.
+sfp_sm_add_mdio_bus() catches -ENODEV and transitions
+sfp->mdio_protocol to MDIO_I2C_NONE so the rest of the state machine
+skips PHY probing for this module.
+
+Any I2C-level error (NACK, timeout) during the probe is also treated as
+-ENODEV: if the module does not respond at I2C address 0x51 at all,
+there is certainly no RollBall bridge there, and SFP initialization
+should not abort.
+
+The probe writes are safe with respect to SFP EEPROM integrity: only
+modules explicitly listed in the quirk table enter this path, and the
+RollBall password unlock write to 0x51 was already issued by
+i2c_mii_init_rollball() before the probe for all such modules.  Any
+module without a device at 0x51 NACKs the transfer and is treated as
+-ENODEV.
+
+Add "OEM"/"SFP-10G-T-I" to the quirk table so RTL8261BE modules enter
+the probe path; genuine RollBall modules continue to work as before.
+
+Signed-off-by: Petr Wozniak <petr.wozniak@gmail.com>
+Reviewed-by: Maxime Chevallier <maxime.chevallier@bootlin.com>
+Link: https://patch.msgid.link/20260527053909.2118-1-petr.wozniak@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/mdio/mdio-i2c.c | 59 ++++++++++++++++++++++++++++++++-----
+ drivers/net/phy/sfp.c       | 14 +++++++--
+ 2 files changed, 63 insertions(+), 10 deletions(-)
+
+--- a/drivers/net/mdio/mdio-i2c.c
++++ b/drivers/net/mdio/mdio-i2c.c
+@@ -352,6 +352,50 @@ static int i2c_mii_write_rollball(struct
+ 	return 0;
+ }
+ 
++static int i2c_mii_probe_rollball(struct i2c_adapter *i2c)
++{
++	u8 data_buf[] = { ROLLBALL_DATA_ADDR, 0x01, 0x00, 0x00 };
++	u8 cmd_buf[]  = { ROLLBALL_CMD_ADDR, ROLLBALL_CMD_READ };
++	u8 cmd_addr   = ROLLBALL_CMD_ADDR;
++	struct i2c_msg msgs[2];
++	u8 result;
++	int ret;
++	int i;
++
++	msgs[0].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[0].flags = 0;
++	msgs[0].len   = sizeof(data_buf);
++	msgs[0].buf   = data_buf;
++	msgs[1].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[1].flags = 0;
++	msgs[1].len   = sizeof(cmd_buf);
++	msgs[1].buf   = cmd_buf;
++
++	ret = i2c_transfer_rollball(i2c, msgs, ARRAY_SIZE(msgs));
++	if (ret < 0)
++		return -ENODEV;
++
++	msgs[0].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[0].flags = 0;
++	msgs[0].len   = 1;
++	msgs[0].buf   = &cmd_addr;
++	msgs[1].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[1].flags = I2C_M_RD;
++	msgs[1].len   = 1;
++	msgs[1].buf   = &result;
++
++	for (i = 0; i < 10; i++) {
++		msleep(20);
++		ret = i2c_transfer_rollball(i2c, msgs, ARRAY_SIZE(msgs));
++		if (ret < 0)
++			return -ENODEV;
++		if (result == ROLLBALL_CMD_DONE)
++			return 0;
++	}
++
++	return -ENODEV;
++}
++
+ static int i2c_mii_init_rollball(struct i2c_adapter *i2c)
+ {
+ 	struct i2c_msg msg;
+@@ -371,11 +415,11 @@ static int i2c_mii_init_rollball(struct
+ 
+ 	ret = i2c_transfer(i2c, &msg, 1);
+ 	if (ret < 0)
+-		return ret;
+-	else if (ret != 1)
++		return -ENODEV;
++	if (ret != 1)
+ 		return -EIO;
+-	else
+-		return 0;
++
++	return i2c_mii_probe_rollball(i2c);
+ }
+ 
+ struct mii_bus *mdio_i2c_alloc(struct device *parent, struct i2c_adapter *i2c,
+@@ -399,9 +443,10 @@ struct mii_bus *mdio_i2c_alloc(struct de
+ 	case MDIO_I2C_ROLLBALL:
+ 		ret = i2c_mii_init_rollball(i2c);
+ 		if (ret < 0) {
+-			dev_err(parent,
+-				"Cannot initialize RollBall MDIO I2C protocol: %d\n",
+-				ret);
++			if (ret != -ENODEV)
++				dev_err(parent,
++					"Cannot initialize RollBall MDIO I2C protocol: %d\n",
++					ret);
+ 			mdiobus_free(mii);
+ 			return ERR_PTR(ret);
+ 		}
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -572,6 +572,7 @@ static const struct sfp_quirk sfp_quirks
+ 	// OEM SFP-GE-T is a 1000Base-T module with broken TX_FAULT indicator
+ 	SFP_QUIRK_F("OEM", "SFP-GE-T", sfp_fixup_ignore_tx_fault),
+ 
++	SFP_QUIRK_F("OEM", "SFP-10G-T-I", sfp_fixup_rollball),
+ 	SFP_QUIRK_F("OEM", "SFP-10G-T", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_S("OEM", "SFP-2.5G-T", sfp_quirk_oem_2_5g),
+ 	SFP_QUIRK_S("OEM", "SFP-2.5G-BX10-D", sfp_quirk_2500basex),
+@@ -1958,10 +1959,17 @@ static void sfp_sm_fault(struct sfp *sfp
+ 
+ static int sfp_sm_add_mdio_bus(struct sfp *sfp)
+ {
+-	if (sfp->mdio_protocol != MDIO_I2C_NONE)
+-		return sfp_i2c_mdiobus_create(sfp);
++	int ret;
+ 
+-	return 0;
++	if (sfp->mdio_protocol == MDIO_I2C_NONE)
++		return 0;
++
++	ret = sfp_i2c_mdiobus_create(sfp);
++	if (ret == -ENODEV) {
++		sfp->mdio_protocol = MDIO_I2C_NONE;
++		return 0;
++	}
++	return ret;
+ }
+ 
+ /* Probe a SFP for a PHY device if the module supports copper - the PHY

--- a/target/linux/generic/backport-6.18/736-v7.2-net-phy-sfp-probe-for-RollBall-I2C-to-MDIO-bridge-in.patch
+++ b/target/linux/generic/backport-6.18/736-v7.2-net-phy-sfp-probe-for-RollBall-I2C-to-MDIO-bridge-in.patch
@@ -1,0 +1,171 @@
+From 8fe125892f40cbe284fba8eda49a0407984fc74c Mon Sep 17 00:00:00 2001
+From: Petr Wozniak <petr.wozniak@gmail.com>
+Date: Wed, 27 May 2026 07:39:09 +0200
+Subject: [PATCH] net: phy: sfp: probe for RollBall I2C-to-MDIO bridge in
+ mdio-i2c
+
+The "OEM"/"SFP-10G-T" quirk entry in sfp_fixup_rollball_cc()
+unconditionally forces MDIO_I2C_ROLLBALL for all modules matching that
+vendor/part-number combination.  This works for modules that genuinely
+implement a RollBall I2C-to-MDIO bridge, but silently breaks modules
+that share the same EEPROM strings without having such a bridge.
+
+The Realtek RTL8261BE-CG is one such module: a pure copper 10G SFP+
+media converter with no I2C-to-MDIO bridge.  Its EEPROM reports
+vendor="OEM", part="SFP-10G-T-I", and -- critically -- Vendor OUI
+00:00:00, making OUI-based differentiation impossible.  With
+MDIO_I2C_ROLLBALL forced, the module silently ACKs the unlock password
+write, the MDIO bus is created, but no PHY responds; the SFP state
+machine cycles through the RollBall PHY-probe retry window before
+reporting no PHY.
+
+Move the probe into i2c_mii_init_rollball() in mdio-i2c.c, where the
+RollBall protocol constants are already defined.  After sending the
+unlock password, issue a CMD_READ and poll for CMD_DONE up to 200 ms
+(10 x 20 ms, matching the existing rollball poll tolerance).  A genuine
+RollBall bridge asserts CMD_DONE within that window; modules without a
+bridge never do, so i2c_mii_init_rollball() returns -ENODEV.
+mdio_i2c_alloc() propagates -ENODEV to the caller to signal that no
+bridge is present and PHY probing should be skipped.
+sfp_sm_add_mdio_bus() catches -ENODEV and transitions
+sfp->mdio_protocol to MDIO_I2C_NONE so the rest of the state machine
+skips PHY probing for this module.
+
+Any I2C-level error (NACK, timeout) during the probe is also treated as
+-ENODEV: if the module does not respond at I2C address 0x51 at all,
+there is certainly no RollBall bridge there, and SFP initialization
+should not abort.
+
+The probe writes are safe with respect to SFP EEPROM integrity: only
+modules explicitly listed in the quirk table enter this path, and the
+RollBall password unlock write to 0x51 was already issued by
+i2c_mii_init_rollball() before the probe for all such modules.  Any
+module without a device at 0x51 NACKs the transfer and is treated as
+-ENODEV.
+
+Add "OEM"/"SFP-10G-T-I" to the quirk table so RTL8261BE modules enter
+the probe path; genuine RollBall modules continue to work as before.
+
+Signed-off-by: Petr Wozniak <petr.wozniak@gmail.com>
+Reviewed-by: Maxime Chevallier <maxime.chevallier@bootlin.com>
+Link: https://patch.msgid.link/20260527053909.2118-1-petr.wozniak@gmail.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+---
+ drivers/net/mdio/mdio-i2c.c | 59 ++++++++++++++++++++++++++++++++-----
+ drivers/net/phy/sfp.c       | 14 +++++++--
+ 2 files changed, 63 insertions(+), 10 deletions(-)
+
+--- a/drivers/net/mdio/mdio-i2c.c
++++ b/drivers/net/mdio/mdio-i2c.c
+@@ -419,6 +419,50 @@ static int i2c_mii_write_rollball(struct
+ 	return 0;
+ }
+ 
++static int i2c_mii_probe_rollball(struct i2c_adapter *i2c)
++{
++	u8 data_buf[] = { ROLLBALL_DATA_ADDR, 0x01, 0x00, 0x00 };
++	u8 cmd_buf[]  = { ROLLBALL_CMD_ADDR, ROLLBALL_CMD_READ };
++	u8 cmd_addr   = ROLLBALL_CMD_ADDR;
++	struct i2c_msg msgs[2];
++	u8 result;
++	int ret;
++	int i;
++
++	msgs[0].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[0].flags = 0;
++	msgs[0].len   = sizeof(data_buf);
++	msgs[0].buf   = data_buf;
++	msgs[1].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[1].flags = 0;
++	msgs[1].len   = sizeof(cmd_buf);
++	msgs[1].buf   = cmd_buf;
++
++	ret = i2c_transfer_rollball(i2c, msgs, ARRAY_SIZE(msgs));
++	if (ret < 0)
++		return -ENODEV;
++
++	msgs[0].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[0].flags = 0;
++	msgs[0].len   = 1;
++	msgs[0].buf   = &cmd_addr;
++	msgs[1].addr  = ROLLBALL_PHY_I2C_ADDR;
++	msgs[1].flags = I2C_M_RD;
++	msgs[1].len   = 1;
++	msgs[1].buf   = &result;
++
++	for (i = 0; i < 10; i++) {
++		msleep(20);
++		ret = i2c_transfer_rollball(i2c, msgs, ARRAY_SIZE(msgs));
++		if (ret < 0)
++			return -ENODEV;
++		if (result == ROLLBALL_CMD_DONE)
++			return 0;
++	}
++
++	return -ENODEV;
++}
++
+ static int i2c_mii_init_rollball(struct i2c_adapter *i2c)
+ {
+ 	struct i2c_msg msg;
+@@ -438,11 +482,11 @@ static int i2c_mii_init_rollball(struct
+ 
+ 	ret = i2c_transfer(i2c, &msg, 1);
+ 	if (ret < 0)
+-		return ret;
+-	else if (ret != 1)
++		return -ENODEV;
++	if (ret != 1)
+ 		return -EIO;
+-	else
+-		return 0;
++
++	return i2c_mii_probe_rollball(i2c);
+ }
+ 
+ static bool mdio_i2c_check_functionality(struct i2c_adapter *i2c,
+@@ -487,9 +531,10 @@ struct mii_bus *mdio_i2c_alloc(struct de
+ 	case MDIO_I2C_ROLLBALL:
+ 		ret = i2c_mii_init_rollball(i2c);
+ 		if (ret < 0) {
+-			dev_err(parent,
+-				"Cannot initialize RollBall MDIO I2C protocol: %d\n",
+-				ret);
++			if (ret != -ENODEV)
++				dev_err(parent,
++					"Cannot initialize RollBall MDIO I2C protocol: %d\n",
++					ret);
+ 			mdiobus_free(mii);
+ 			return ERR_PTR(ret);
+ 		}
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -579,6 +579,7 @@ static const struct sfp_quirk sfp_quirks
+ 	// OEM SFP-GE-T is a 1000Base-T module with broken TX_FAULT indicator
+ 	SFP_QUIRK_F("OEM", "SFP-GE-T", sfp_fixup_ignore_tx_fault),
+ 
++	SFP_QUIRK_F("OEM", "SFP-10G-T-I", sfp_fixup_rollball),
+ 	SFP_QUIRK_F("OEM", "SFP-10G-T", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_S("OEM", "SFP-2.5G-T", sfp_quirk_oem_2_5g),
+ 	SFP_QUIRK_S("OEM", "SFP-2.5G-BX10-D", sfp_quirk_2500basex),
+@@ -2022,10 +2023,17 @@ static void sfp_sm_fault(struct sfp *sfp
+ 
+ static int sfp_sm_add_mdio_bus(struct sfp *sfp)
+ {
+-	if (sfp->mdio_protocol != MDIO_I2C_NONE)
+-		return sfp_i2c_mdiobus_create(sfp);
++	int ret;
+ 
+-	return 0;
++	if (sfp->mdio_protocol == MDIO_I2C_NONE)
++		return 0;
++
++	ret = sfp_i2c_mdiobus_create(sfp);
++	if (ret == -ENODEV) {
++		sfp->mdio_protocol = MDIO_I2C_NONE;
++		return 0;
++	}
++	return ret;
+ }
+ 
+ /* Probe a SFP for a PHY device if the module supports copper - the PHY

--- a/target/linux/generic/pending-6.12/660-net-sfp-improve-OEM-SFP-10G-T-fixup.patch
+++ b/target/linux/generic/pending-6.12/660-net-sfp-improve-OEM-SFP-10G-T-fixup.patch
@@ -1,0 +1,25 @@
+From f651ada23faaac0734d903c7fc283d182c1b1ff2 Mon Sep 17 00:00:00 2001
+From: Chukun Pan <amadeus@jmu.edu.cn>
+Date: Thu, 9 Apr 2026 17:36:16 +0800
+Subject: [PATCH] net: sfp: improve OEM SFP-10G-T fixup
+
+Some OEM SFP-10G-T modules use rate adaptation phys with eeproms
+configured for a fixed 10G rate. The kernel reports 'mdiobus scan
+returned -EIO'. So remove the RollBall protocol to make it work.
+
+Signed-off-by: Chukun Pan <amadeus@jmu.edu.cn>
+---
+ drivers/net/phy/sfp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -551,7 +551,7 @@ static const struct sfp_quirk sfp_quirks
+ 	// OEM SFP-GE-T is a 1000Base-T module with broken TX_FAULT indicator
+ 	SFP_QUIRK_F("OEM", "SFP-GE-T", sfp_fixup_ignore_tx_fault),
+ 
+-	SFP_QUIRK_F("OEM", "SFP-10G-T", sfp_fixup_rollball_cc),
++	SFP_QUIRK_F("OEM", "SFP-10G-T", sfp_fixup_10gbaset_30m),
+ 	SFP_QUIRK_S("OEM", "SFP-2.5G-T", sfp_quirk_oem_2_5g),
+ 	SFP_QUIRK_S("OEM", "SFP-2.5G-BX10-D", sfp_quirk_2500basex),
+ 	SFP_QUIRK_S("OEM", "SFP-2.5G-BX10-U", sfp_quirk_2500basex),

--- a/target/linux/generic/pending-6.12/750-net-sfp-add-quirk-for-QINIYEK-BJ-SFP-10G-T-copper-SF.patch
+++ b/target/linux/generic/pending-6.12/750-net-sfp-add-quirk-for-QINIYEK-BJ-SFP-10G-T-copper-SF.patch
@@ -16,7 +16,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -578,6 +578,7 @@ static const struct sfp_quirk sfp_quirks
+@@ -579,6 +579,7 @@ static const struct sfp_quirk sfp_quirks
  	SFP_QUIRK_S("OEM", "SFP-2.5G-BX10-U", sfp_quirk_2500basex),
  	SFP_QUIRK_F("OEM", "RTSFP-10", sfp_fixup_rollball_cc),
  	SFP_QUIRK_F("OEM", "RTSFP-10G", sfp_fixup_rollball_cc),

--- a/target/linux/generic/pending-6.18/750-net-sfp-add-quirk-for-QINIYEK-BJ-SFP-10G-T-copper-SF.patch
+++ b/target/linux/generic/pending-6.18/750-net-sfp-add-quirk-for-QINIYEK-BJ-SFP-10G-T-copper-SF.patch
@@ -16,7 +16,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -585,6 +585,7 @@ static const struct sfp_quirk sfp_quirks
+@@ -586,6 +586,7 @@ static const struct sfp_quirk sfp_quirks
  	SFP_QUIRK_S("OEM", "SFP-2.5G-BX10-U", sfp_quirk_2500basex),
  	SFP_QUIRK_F("OEM", "RTSFP-10", sfp_fixup_rollball_cc),
  	SFP_QUIRK_F("OEM", "RTSFP-10G", sfp_fixup_rollball_cc),

--- a/target/linux/generic/pending-6.18/751-net-sfp-add-quirk-for-TP-LINK-SM410U.patch
+++ b/target/linux/generic/pending-6.18/751-net-sfp-add-quirk-for-TP-LINK-SM410U.patch
@@ -14,7 +14,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -591,6 +591,7 @@ static const struct sfp_quirk sfp_quirks
+@@ -592,6 +592,7 @@ static const struct sfp_quirk sfp_quirks
  	SFP_QUIRK_F("Turris", "RTSFP-10G", sfp_fixup_rollball),
  
  	SFP_QUIRK_S("ZOERAX", "SFP-2.5G-T", sfp_quirk_oem_2_5g),

--- a/target/linux/realtek/patches-6.18/714-net-phy-sfp-add-support-for-SMBus.patch
+++ b/target/linux/realtek/patches-6.18/714-net-phy-sfp-add-support-for-SMBus.patch
@@ -10,7 +10,7 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -850,6 +850,29 @@ static int sfp_i2c_mdiobus_create(struct
+@@ -851,6 +851,29 @@ static int sfp_i2c_mdiobus_create(struct
  	return 0;
  }
  
@@ -40,20 +40,31 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
  static void sfp_i2c_mdiobus_destroy(struct sfp *sfp)
  {
  	mdiobus_unregister(sfp->i2c_mii);
-@@ -2024,9 +2047,15 @@ static void sfp_sm_fault(struct sfp *sfp
+@@ -2025,16 +2048,22 @@ static void sfp_sm_fault(struct sfp *sfp
  
  static int sfp_sm_add_mdio_bus(struct sfp *sfp)
  {
--	if (sfp->mdio_protocol != MDIO_I2C_NONE)
-+	if (sfp->mdio_protocol == MDIO_I2C_NONE)
-+		return 0;
-+
-+	if (i2c_check_functionality(sfp->i2c, I2C_FUNC_I2C))
- 		return sfp_i2c_mdiobus_create(sfp);
+-	int ret;
++	int ret = 0;
  
-+	if (i2c_check_functionality(sfp->i2c, I2C_FUNC_SMBUS_BYTE_DATA))
-+		return sfp_sm_mdiobus_create(sfp);
+ 	if (sfp->mdio_protocol == MDIO_I2C_NONE)
+ 		return 0;
+ 
+-	ret = sfp_i2c_mdiobus_create(sfp);
+-	if (ret == -ENODEV) {
+-		sfp->mdio_protocol = MDIO_I2C_NONE;
+-		return 0;
++	if (i2c_check_functionality(sfp->i2c, I2C_FUNC_I2C)) {
++		ret = sfp_i2c_mdiobus_create(sfp);
++		if (ret == -ENODEV) {
++			sfp->mdio_protocol = MDIO_I2C_NONE;
++			return 0;
++		}
+ 	}
 +
- 	return 0;
++	if (i2c_check_functionality(sfp->i2c, I2C_FUNC_SMBUS_BYTE_DATA))
++		ret = sfp_sm_mdiobus_create(sfp);
++
+ 	return ret;
  }
  

--- a/target/linux/realtek/patches-6.18/741-net-sfp-apply-I2C-adapter-quirks-to-limit-blocks.patch
+++ b/target/linux/realtek/patches-6.18/741-net-sfp-apply-I2C-adapter-quirks-to-limit-blocks.patch
@@ -25,7 +25,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
 
 --- a/drivers/net/phy/sfp.c
 +++ b/drivers/net/phy/sfp.c
-@@ -809,21 +809,29 @@ static int sfp_smbus_byte_write(struct s
+@@ -810,21 +810,29 @@ static int sfp_smbus_byte_write(struct s
  
  static int sfp_i2c_configure(struct sfp *sfp, struct i2c_adapter *i2c)
  {

--- a/target/linux/realtek/patches-6.18/742-net-sfp-extend-SMBus-support.patch
+++ b/target/linux/realtek/patches-6.18/742-net-sfp-extend-SMBus-support.patch
@@ -42,7 +42,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  #include <linux/workqueue.h>
  
  #include "sfp.h"
-@@ -758,50 +759,101 @@ static int sfp_i2c_write(struct sfp *sfp
+@@ -759,50 +760,101 @@ static int sfp_i2c_write(struct sfp *sfp
  	return ret == ARRAY_SIZE(msgs) ? len : 0;
  }
  
@@ -164,7 +164,7 @@ Signed-off-by: Jonas Jelonek <jelonek.jonas@gmail.com>
  	}
  
  	return data - (u8 *)buf;
-@@ -810,17 +862,32 @@ static int sfp_smbus_byte_write(struct s
+@@ -811,17 +863,32 @@ static int sfp_smbus_byte_write(struct s
  static int sfp_i2c_configure(struct sfp *sfp, struct i2c_adapter *i2c)
  {
  	size_t max_block_size;


### PR DESCRIPTION
Some RTL8261BE OEM SFP-10G-T modules lack a RollBall I2C-to-MDIO
bridge. Import [upstream patches](https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=8fe125892f40cbe284fba8eda49a0407984fc74c) to prevent excessive timeouts.