### PR TITLE
lantiq: dts: add missing gpio.h header for falcon.dtsi

### DIFF
--- a/target/linux/lantiq/dts/falcon.dtsi
+++ b/target/linux/lantiq/dts/falcon.dtsi
@@ -1,5 +1,7 @@
 /dts-v1/;
 
+#include <dt-bindings/gpio/gpio.h>
+
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;


### PR DESCRIPTION
Fix build error:

FATAL ERROR: Syntax error parsing input tree
Lexical error: ../dts/falcon.dtsi:175.22-38 Unexpected 'GPIO_ACTIVE_HIGH'
Lexical error: ../dts/falcon.dtsi:176.15-31 Unexpected 'GPIO_ACTIVE_HIGH'

Fixes: c186d17fa518 ("treewide: replace numbers with GPIO_ACTIVE")