### PR TITLE
realtek: rtl931x: psx28: Specify POE MCU reset GPIO

### DIFF
--- a/target/linux/realtek/dts/rtl9312_plasmacloud_psx28.dts
+++ b/target/linux/realtek/dts/rtl9312_plasmacloud_psx28.dts
@@ -14,6 +14,16 @@
 			gpios = <&gpio1 28 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		poe_mcu_reset {
+			gpio-export,name = "poe_mcu_reset";
+			gpio-export,output = <1>;
+			gpios = <&gpio1 29 GPIO_ACTIVE_LOW>;
+		};
+	};
 };
 
 &i2c_mst1 {


### PR DESCRIPTION
The MCU (GD32E230G8) which controls the RTL8239 POE++ PSE chips can sometimes hang. In this case, it is necessary to to reset the chip using the nRESET pin which is connected to the GPIO29 of the RTL8231 GPIO expander.

For a reset, the `/sys/class/gpio/poe_mcu_reset/value` file must be set to 1 for a short period and then back to 0. After that, the poemgr must be "restarted" to the MCU back in the expected state.