### PR TITLE
generic: phy: adm6996: fix build on 6.18 kernel

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/adm6996.c
+++ b/target/linux/generic/files/drivers/net/phy/adm6996.c
@@ -1180,13 +1180,16 @@ static int adm6996_gpio_probe(struct platform_device *pdev)
 	priv->read = adm6996_read_gpio_reg;
 	priv->write = adm6996_write_gpio_reg;
 
-	ret = devm_gpio_request(&pdev->dev, priv->eecs, "adm_eecs");
+	ret = devm_gpio_request_one(&pdev->dev, priv->eecs,
+				    GPIOF_IN, "adm_eecs");
 	if (ret)
 		return ret;
-	ret = devm_gpio_request(&pdev->dev, priv->eedi, "adm_eedi");
+	ret = devm_gpio_request_one(&pdev->dev, priv->eedi,
+				    GPIOF_IN, "adm_eedi");
 	if (ret)
 		return ret;
-	ret = devm_gpio_request(&pdev->dev, priv->eesk, "adm_eesk");
+	ret = devm_gpio_request_one(&pdev->dev, priv->eesk,
+				    GPIOF_IN, "adm_eesk");
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
devm_gpio_request() was removed since kernel 6.17. Convert it to devm_gpio_request_one() to fix:

target/linux/generic/files/drivers/net/phy/adm6996.c: In function 'adm6996_gpio_probe': target/linux/generic/files/drivers/net/phy/adm6996.c:1183:15: error: implicit declaration of function 'devm_gpio_request'; did you mean 'devm_gpio_request_one'? [-Wimplicit-function-declaration]
 1183 |         ret = devm_gpio_request(&pdev->dev, priv->eecs, "adm_eecs");
      |               ^~~~~~~~~~~~~~~~~
      |               devm_gpio_request_one

Link: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-6.18.y&id=a5589313383074c48a1b3751d592a6e084ae0573