### PR TITLE
realtek: eth: normalize ring counter/size register access

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.c
@@ -241,10 +241,11 @@ static void rteth_83xx_update_counter(struct rteth_ctrl *ctrl, int ring, int rel
 
 static void rteth_93xx_update_counter(struct rteth_ctrl *ctrl, int ring, int released)
 {
-	int pos = (ring % 3) * 10;
+	int shift = (ring % 3) * 10;
+	int reg = (ring / 3) * 4;
 
 	/* writing x to the ring counter increases ring free space by x */
-	regmap_write(ctrl->map, ctrl->r->dma_if_rx_ring_cntr(ring), released << pos);
+	regmap_write(ctrl->map, ctrl->r->dma_if_rx_ring_cntr + reg, released << shift);
 }
 
 struct dsa_tag {
@@ -411,7 +412,7 @@ static void rteth_838x_hw_reset(struct rteth_ctrl *ctrl)
 	rteth_nic_reset(ctrl, 0xc);
 
 	/* Free floating rings without space tracking */
-	regmap_write(ctrl->map, RTL838X_DMA_IF_RX_RING_SIZE, 0);
+	regmap_write(ctrl->map, ctrl->r->dma_if_rx_ring_size, 0);
 }
 
 static void rteth_839x_hw_reset(struct rteth_ctrl *ctrl)
@@ -439,7 +440,7 @@ static void rteth_839x_hw_reset(struct rteth_ctrl *ctrl)
 	regmap_write(ctrl->map, RTL839X_DMA_IF_NBUF_BASE_DESC_ADDR_CTRL, nbuf);
 
 	/* Free floating rings without space tracking */
-	regmap_write(ctrl->map, RTL839X_DMA_IF_RX_RING_SIZE, 0);
+	regmap_write(ctrl->map, ctrl->r->dma_if_rx_ring_size, 0);
 }
 
 static void rteth_93xx_hw_reset(struct rteth_ctrl *ctrl)
@@ -447,16 +448,18 @@ static void rteth_93xx_hw_reset(struct rteth_ctrl *ctrl)
 	rteth_nic_reset(ctrl, 0x6);
 
 	/* Setup Head of Line */
-	for (int r = 0; r < RTETH_RX_RINGS; r++) {
+	for (int ring = 0; ring < RTETH_RX_RINGS; ring++) {
 		int cnt = min(RTETH_RX_RING_SIZE, 0x3ff);
-		int pos = (r % 3) * 10;
+		int shift = (ring % 3) * 10;
+		int reg = (ring / 3) * 4;
 		u32 v;
 
 		/* set ring size */
-		sw_w32_mask(0x3ff << pos, cnt << pos, ctrl->r->dma_if_rx_ring_size(r));
-		/* clear counters */
-		v = (sw_r32(ctrl->r->dma_if_rx_ring_cntr(r)) >> pos) & 0x3ff;
-		sw_w32_mask(0x3ff << pos, v, ctrl->r->dma_if_rx_ring_cntr(r));
+		regmap_update_bits(ctrl->map, ctrl->r->dma_if_rx_ring_size + reg,
+				   0x3ff << shift, cnt << shift);
+		/* clear counters by simply writing the current register values back */
+		regmap_read(ctrl->map, ctrl->r->dma_if_rx_ring_cntr + reg, &v);
+		regmap_write(ctrl->map, ctrl->r->dma_if_rx_ring_cntr + reg, v);
 	}
 }
 
@@ -1302,12 +1305,12 @@ static const struct rteth_config rteth_838x_cfg = {
 	.qm_rsn2cpuqid_cnt = RTETH_838X_QM_PKT2CPU_INTPRI_CNT,
 	.dma_if_intr_sts = RTETH_838X_DMA_IF_INTR_STS,
 	.dma_if_intr_msk = RTETH_838X_DMA_IF_INTR_MSK,
+	.dma_if_rx_ring_cntr = RTETH_838X_DMA_IF_RX_RING_CNTR,
+	.dma_if_rx_ring_size = RTETH_838X_DMA_IF_RX_RING_SIZE,
 	.dma_if_ctrl = RTL838X_DMA_IF_CTRL,
 	.mac_force_mode_ctrl = RTETH_838X_MAC_FORCE_MODE_CTRL,
 	.dma_rx_base = RTL838X_DMA_RX_BASE,
 	.dma_tx_base = RTL838X_DMA_TX_BASE,
-	.dma_if_rx_ring_size = rtl838x_dma_if_rx_ring_size,
-	.dma_if_rx_ring_cntr = rtl838x_dma_if_rx_ring_cntr,
 	.rst_glb_ctrl = RTL838X_RST_GLB_CTRL_0,
 	.mac_reg = { RTETH_838X_MAC_ADDR_CTRL,
 		     RTETH_838X_MAC_ADDR_CTRL_ALE,
@@ -1348,12 +1351,12 @@ static const struct rteth_config rteth_839x_cfg = {
 	.qm_rsn2cpuqid_cnt = RTETH_839X_QM_PKT2CPU_INTPRI_CNT,
 	.dma_if_intr_sts = RTETH_839X_DMA_IF_INTR_STS,
 	.dma_if_intr_msk = RTETH_839X_DMA_IF_INTR_MSK,
+	.dma_if_rx_ring_cntr = RTETH_839X_DMA_IF_RX_RING_CNTR,
+	.dma_if_rx_ring_size = RTETH_839X_DMA_IF_RX_RING_SIZE,
 	.dma_if_ctrl = RTL839X_DMA_IF_CTRL,
 	.mac_force_mode_ctrl = RTETH_839X_MAC_FORCE_MODE_CTRL,
 	.dma_rx_base = RTL839X_DMA_RX_BASE,
 	.dma_tx_base = RTL839X_DMA_TX_BASE,
-	.dma_if_rx_ring_size = rtl839x_dma_if_rx_ring_size,
-	.dma_if_rx_ring_cntr = rtl839x_dma_if_rx_ring_cntr,
 	.rst_glb_ctrl = RTL839X_RST_GLB_CTRL,
 	.mac_reg = { RTETH_839X_MAC_ADDR_CTRL },
 	.l2_tbl_flush_ctrl = RTL839X_L2_TBL_FLUSH_CTRL,
@@ -1392,14 +1395,14 @@ static const struct rteth_config rteth_930x_cfg = {
 	.qm_rsn2cpuqid_cnt = RTETH_930X_QM_RSN2CPUQID_CTRL_CNT,
 	.dma_if_intr_sts = RTETH_930X_DMA_IF_INTR_STS,
 	.dma_if_intr_msk = RTETH_930X_DMA_IF_INTR_MSK,
+	.dma_if_rx_ring_cntr = RTETH_930X_DMA_IF_RX_RING_CNTR,
+	.dma_if_rx_ring_size = RTETH_930X_DMA_IF_RX_RING_SIZE,
 	.l2_ntfy_if_intr_sts = RTL930X_L2_NTFY_IF_INTR_STS,
 	.l2_ntfy_if_intr_msk = RTL930X_L2_NTFY_IF_INTR_MSK,
 	.dma_if_ctrl = RTL930X_DMA_IF_CTRL,
 	.mac_force_mode_ctrl = RTETH_930X_MAC_FORCE_MODE_CTRL,
 	.dma_rx_base = RTL930X_DMA_RX_BASE,
 	.dma_tx_base = RTL930X_DMA_TX_BASE,
-	.dma_if_rx_ring_size = rtl930x_dma_if_rx_ring_size,
-	.dma_if_rx_ring_cntr = rtl930x_dma_if_rx_ring_cntr,
 	.rst_glb_ctrl = RTL930X_RST_GLB_CTRL_0,
 	.mac_reg = { RTETH_930X_MAC_L2_ADDR_CTRL },
 	.l2_tbl_flush_ctrl = RTL930X_L2_TBL_FLUSH_CTRL,
@@ -1437,14 +1440,14 @@ static const struct rteth_config rteth_931x_cfg = {
 	.qm_rsn2cpuqid_cnt = RTETH_931X_QM_RSN2CPUQID_CTRL_CNT,
 	.dma_if_intr_sts = RTETH_931X_DMA_IF_INTR_STS,
 	.dma_if_intr_msk = RTETH_931X_DMA_IF_INTR_MSK,
+	.dma_if_rx_ring_cntr = RTETH_931X_DMA_IF_RX_RING_CNTR,
+	.dma_if_rx_ring_size = RTETH_931X_DMA_IF_RX_RING_SIZE,
 	.l2_ntfy_if_intr_sts = RTL931X_L2_NTFY_IF_INTR_STS,
 	.l2_ntfy_if_intr_msk = RTL931X_L2_NTFY_IF_INTR_MSK,
 	.dma_if_ctrl = RTL931X_DMA_IF_CTRL,
 	.mac_force_mode_ctrl = RTETH_931X_MAC_FORCE_MODE_CTRL,
 	.dma_rx_base = RTL931X_DMA_RX_BASE,
 	.dma_tx_base = RTL931X_DMA_TX_BASE,
-	.dma_if_rx_ring_size = rtl931x_dma_if_rx_ring_size,
-	.dma_if_rx_ring_cntr = rtl931x_dma_if_rx_ring_cntr,
 	.rst_glb_ctrl = RTL931X_RST_GLB_CTRL,
 	.mac_reg = { RTETH_930X_MAC_L2_ADDR_CTRL },
 	.l2_tbl_flush_ctrl = RTL931X_L2_TBL_FLUSH_CTRL,

--- a/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.h
+++ b/target/linux/realtek/files-6.18/drivers/net/ethernet/rtl838x_eth.h
@@ -10,6 +10,8 @@
 #define RTETH_838X_CPU_PORT			28
 #define RTETH_838X_DMA_IF_INTR_MSK		(0x9f50)
 #define RTETH_838X_DMA_IF_INTR_STS		(0x9f54)
+#define RTETH_838X_DMA_IF_RX_RING_CNTR		(0xb7e8)
+#define RTETH_838X_DMA_IF_RX_RING_SIZE		(0xb7e4)
 #define RTETH_838X_MAC_ADDR_CTRL		(0xa9ec)
 #define RTETH_838X_MAC_ADDR_CTRL_ALE		(0x6b04)
 #define RTETH_838X_MAC_ADDR_CTRL_MAC		(0xa320)
@@ -24,6 +26,8 @@
 #define RTETH_839X_CPU_PORT			52
 #define RTETH_839X_DMA_IF_INTR_MSK		(0x7864)
 #define RTETH_839X_DMA_IF_INTR_STS		(0x7868)
+#define RTETH_839X_DMA_IF_RX_RING_CNTR		(0x603c)
+#define RTETH_839X_DMA_IF_RX_RING_SIZE		(0x6038)
 #define RTETH_839X_MAC_ADDR_CTRL		(0x02b4)
 #define RTETH_839X_MAC_FORCE_MODE_CTRL		(0x02bc + RTETH_839X_CPU_PORT * 4)
 #define RTETH_839X_MAC_L2_PORT_CTRL		(0x8004 + RTETH_839X_CPU_PORT * 128)
@@ -38,6 +42,8 @@
 #define RTETH_930X_CPU_PORT			28
 #define RTETH_930X_DMA_IF_INTR_MSK		(0xe010)
 #define RTETH_930X_DMA_IF_INTR_STS		(0xe01c)
+#define RTETH_930X_DMA_IF_RX_RING_CNTR		(0x7c8c)
+#define RTETH_930X_DMA_IF_RX_RING_SIZE		(0x7c60)
 #define RTETH_930X_MAC_FORCE_MODE_CTRL		(0xca1c + RTETH_930X_CPU_PORT * 4)
 #define RTETH_930X_MAC_L2_ADDR_CTRL		(0xc714)
 #define RTETH_930X_MAC_L2_PORT_CTRL		(0x3268 + RTETH_930X_CPU_PORT * 64)
@@ -50,6 +56,8 @@
 #define RTETH_931X_CPU_PORT			56
 #define RTETH_931X_DMA_IF_INTR_MSK		(0x0910)
 #define RTETH_931X_DMA_IF_INTR_STS		(0x091c)
+#define RTETH_931X_DMA_IF_RX_RING_CNTR		(0x20ac)
+#define RTETH_931X_DMA_IF_RX_RING_SIZE		(0x2080)
 #define RTETH_931X_MAC_FORCE_MODE_CTRL		(0x0dcc + RTETH_931X_CPU_PORT * 4)
 #define RTETH_931X_MAC_L2_ADDR_CTRL		(0x135c)
 #define RTETH_931X_MAC_L2_PORT_CTRL		(0x6000 + RTETH_931X_CPU_PORT * 128)
@@ -104,16 +112,6 @@
 #define RTL839X_DMA_TX_BASE			(0x784c)
 #define RTL930X_DMA_TX_BASE			(0xe000)
 #define RTL931X_DMA_TX_BASE			(0x0900)
-
-#define RTL838X_DMA_IF_RX_RING_SIZE		(0xB7E4)
-#define RTL839X_DMA_IF_RX_RING_SIZE		(0x6038)
-#define RTL930X_DMA_IF_RX_RING_SIZE		(0x7C60)
-#define RTL931X_DMA_IF_RX_RING_SIZE		(0x2080)
-
-#define RTL838X_DMA_IF_RX_RING_CNTR		(0xB7E8)
-#define RTL839X_DMA_IF_RX_RING_CNTR		(0x603c)
-#define RTL930X_DMA_IF_RX_RING_CNTR		(0x7C8C)
-#define RTL931X_DMA_IF_RX_RING_CNTR		(0x20AC)
 
 #define RTL838X_DMA_IF_TX_CUR_DESC_ADDR_CTRL	(0x9F48)
 #define RTL930X_DMA_IF_TX_CUR_DESC_ADDR_CTRL	(0xE008)
@@ -191,46 +189,6 @@
 /* Default MTU with jumbo frames support */
 #define DEFAULT_MTU 9000
 
-inline int rtl838x_dma_if_rx_ring_size(int i)
-{
-	return RTL838X_DMA_IF_RX_RING_SIZE + ((i >> 3) << 2);
-}
-
-inline int rtl839x_dma_if_rx_ring_size(int i)
-{
-	return RTL839X_DMA_IF_RX_RING_SIZE + ((i >> 3) << 2);
-}
-
-inline int rtl930x_dma_if_rx_ring_size(int i)
-{
-	return RTL930X_DMA_IF_RX_RING_SIZE + ((i / 3) << 2);
-}
-
-inline int rtl931x_dma_if_rx_ring_size(int i)
-{
-	return RTL931X_DMA_IF_RX_RING_SIZE + ((i / 3) << 2);
-}
-
-inline int rtl838x_dma_if_rx_ring_cntr(int i)
-{
-	return RTL838X_DMA_IF_RX_RING_CNTR + ((i >> 3) << 2);
-}
-
-inline int rtl839x_dma_if_rx_ring_cntr(int i)
-{
-	return RTL839X_DMA_IF_RX_RING_CNTR + ((i >> 3) << 2);
-}
-
-inline int rtl930x_dma_if_rx_ring_cntr(int i)
-{
-	return RTL930X_DMA_IF_RX_RING_CNTR + ((i / 3) << 2);
-}
-
-inline int rtl931x_dma_if_rx_ring_cntr(int i)
-{
-	return RTL931X_DMA_IF_RX_RING_CNTR + ((i / 3) << 2);
-}
-
 struct p_hdr;
 struct dsa_tag;
 struct rteth_ctrl;
@@ -247,14 +205,14 @@ struct rteth_config {
 	int qm_rsn2cpuqid_cnt;
 	int dma_if_intr_sts;
 	int dma_if_intr_msk;
+	int dma_if_rx_ring_cntr;
+	int dma_if_rx_ring_size;
 	int l2_ntfy_if_intr_sts;
 	int l2_ntfy_if_intr_msk;
 	int dma_if_ctrl;
 	int mac_force_mode_ctrl;
 	int dma_rx_base;
 	int dma_tx_base;
-	int (*dma_if_rx_ring_size)(int ring);
-	int (*dma_if_rx_ring_cntr)(int ring);
 	int rst_glb_ctrl;
 	u32 mac_reg[RTETH_MAX_MAC_REGS];
 	int l2_tbl_flush_ctrl;


### PR DESCRIPTION
For access to the ring counter and size registers there exist currently seperate helpers. These are only for the register number but not the bit position inside the register. Resolve this mix by

- replacing the helpers with the register addresses
- just calculating register & offset manually where needed.

While this might be a little step back it at least aligns with the rest of the register access code. A future commit might bring an even better version.

While we are here fix a bug in rteth_93xx_hw_reset(). Until now this function only clearx the first counter in a register because of a missing bit shift during writeback.
