### PR TITLE
gpio-button-hotplug: remove LINUX_VERSION_CODE

### DIFF
--- a/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
+++ b/package/kernel/gpio-button-hotplug/src/gpio-button-hotplug.c
@@ -513,15 +513,8 @@ static int gpio_keys_button_probe(struct platform_device *pdev,
 							    GPIOD_IN);
 			if (IS_ERR(bdata->gpiod)) {
 				/* or the legacy (button->gpio is good) way? */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6,18,0)
-				error = devm_gpio_request_one(dev,
-					button->gpio, GPIOF_IN | (
-					button->active_low ? GPIOF_ACTIVE_LOW :
-					0), desc);
-#else
 				error = devm_gpio_request_one(dev,
 					button->gpio, GPIOF_IN, desc);
-#endif
 				if (error) {
 					dev_err_probe(dev, error,
 						      "unable to claim gpio %d",
@@ -530,10 +523,8 @@ static int gpio_keys_button_probe(struct platform_device *pdev,
 				}
 
 				bdata->gpiod = gpio_to_desc(button->gpio);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,18,0)
 				if (button->active_low ^ gpiod_is_active_low(bdata->gpiod))
 					gpiod_toggle_active_low(bdata->gpiod);
-#endif
 			}
 		} else {
 			/* Device-tree */


### PR DESCRIPTION
The 6.18 code works with older kernels as well. Remove the older section and use the newer one always.
