### PR TITLE
mediatek: add support for ELECOM WRC-X6000QS/GSD

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -106,6 +106,7 @@ jdcloud,re-cp-03)
 	;;
 buffalo,wsr-3000ax4p|\
 buffalo,wsr-6000ax8|\
+elecom,wrc-x6000gsd|\
 elecom,wrc-x6000qs|\
 mercusys,mr80x-v3|\
 mercusys,mr85x|\

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -106,6 +106,7 @@ jdcloud,re-cp-03)
 	;;
 buffalo,wsr-3000ax4p|\
 buffalo,wsr-6000ax8|\
+elecom,wrc-x6000qs|\
 mercusys,mr80x-v3|\
 mercusys,mr85x|\
 mercusys,mr90x-v1|\

--- a/target/linux/mediatek/dts/mt7986b-elecom-wrc-x6000.dtsi
+++ b/target/linux/mediatek/dts/mt7986b-elecom-wrc-x6000.dtsi
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7986b.dtsi"
+
+/ {
+	aliases {
+		serial0 = &uart0;
+
+		label-mac-device = &gmac0;
+		led-boot = &led_power_g;
+		led-failsafe = &led_power_r;
+		led-running = &led_power_g;
+		led-upgrade = &led_power_g;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 2 GPIO_ACTIVE_LOW>;
+		};
+
+		led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			function = LED_FUNCTION_WPS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led-4 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-6 {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-7 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_g: led-8 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 18 GPIO_ACTIVE_LOW>;
+		};
+
+		led-9 {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 20 GPIO_ACTIVE_LOW>;
+		};
+
+		led_power_r: led-10 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 22 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-wps {
+			label = "wps";
+			gpios = <&pio 16 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+
+		/*
+		 * mode0 mode1: (Switch Position)
+		 *   1     0  : Router
+		 *   1     1  : AP
+		 *   0     0  : Repeater (Normal)
+		 *   0     1  : Repeater (Hanareya (en: Outbuilding))
+		 */
+		switch-mode0 {
+			label = "mode0";
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		switch-mode1 {
+			label = "mode1";
+			gpios = <&pio 19 GPIO_ACTIVE_LOW>;
+			linux,code = <BTN_1>;
+			linux,input-type = <EV_SW>;
+		};
+	};
+
+	memory@40000000 {
+		device_type = "memory";
+		reg = <0 0x40000000 0 0x20000000>;
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&trng {
+	status = "okay";
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&pio {
+	spi_flash_pins: spi-flash-pins-33-to-38 {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI2_CS", "SPI2_HOLD", "SPI2_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable;
+		};
+
+		conf-pd {
+			pins = "SPI2_CLK", "SPI2_MOSI", "SPI2_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-disable;
+		};
+	};
+
+	wf_2g_5g_pins: wf-2g-5g-pins {
+		mux {
+			function = "wifi";
+			groups = "wf_2g", "wf_5g";
+		};
+
+		conf {
+			pins = "WF0_HB1", "WF0_HB2", "WF0_HB3", "WF0_HB4",
+				"WF0_HB0", "WF0_HB0_B", "WF0_HB5", "WF0_HB6",
+				"WF0_HB7", "WF0_HB8", "WF0_HB9", "WF0_HB10",
+				"WF0_TOP_CLK", "WF0_TOP_DATA", "WF1_HB1",
+				"WF1_HB2", "WF1_HB3", "WF1_HB4", "WF1_HB0",
+				"WF1_HB5", "WF1_HB6", "WF1_HB7", "WF1_HB8",
+				"WF1_TOP_CLK", "WF1_TOP_DATA";
+			drive-strength = <MTK_DRIVE_4mA>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cells = <&macaddr_factory_2a>;
+		nvmem-cell-names = "mac-address";
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		status = "okay";
+		phy-mode = "2500base-x";
+		phy-handle = <&ethphy5>;
+
+		label = "wan";
+		nvmem-cells = <&macaddr_factory_24>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	mdio-bus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		reset-delay-us = <600>;
+		reset-post-delay-us = <20000>;
+
+		ethphy5: ethernet-phy@5 {
+			compatible = "ethernet-phy-ieee802.3-c45";
+			reg = <5>;
+			max-speed = <2500>;
+
+			leds {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				led@0 {
+					reg = <0>;
+					color = <LED_COLOR_ID_WHITE>;
+					function = LED_FUNCTION_WAN;
+				};
+			};
+		};
+
+		switch@1f {
+			compatible = "mediatek,mt7531";
+			reg = <31>;
+			reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
+
+			interrupt-controller;
+			#interrupt-cells = <1>;
+			interrupt-parent = <&pio>;
+			interrupts = <66 IRQ_TYPE_LEVEL_HIGH>;
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					label = "lan1";
+				};
+
+				port@1 {
+					reg = <1>;
+					label = "lan2";
+				};
+
+				port@2 {
+					reg = <2>;
+					label = "lan3";
+				};
+
+				port@3 {
+					reg = <3>;
+					label = "lan4";
+				};
+
+				port@6 {
+					reg = <6>;
+					ethernet = <&gmac0>;
+					phy-mode = "2500base-x";
+					fixed-link {
+						speed = <2500>;
+						full-duplex;
+						pause;
+					};
+				};
+			};
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi_flash_pins>;
+	num-cs = <2>;
+	cs-gpios = <0>, <0>;
+
+	flash@1 {
+		compatible = "spi-nand";
+		reg = <1>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+		mediatek,bmt-remap-range =
+		<0x0000000 0x5a0000>,  /*     BL2 - Fwheader  (5.625 MiB) */
+		<0x37a0000 0x3b40000>, /*  Config - Fwheader2 (3.625 MiB) */
+		<0x6d40000 0x7580000>; /* Config2 - Backup    (8.25 MiB) */
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: mac-address@4 {
+						reg = <0x4 0x6>;
+					};
+
+					macaddr_factory_a: mac-address@a {
+						reg = <0xa 0x6>;
+					};
+
+					macaddr_factory_24: mac-address@24 {
+						reg = <0x24 0x6>;
+					};
+
+					macaddr_factory_2a: mac-address@2a {
+						reg = <0x2a 0x6>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "Fwheader";
+				reg = <0x580000 0x20000>;
+				read-only;
+			};
+
+			partition@5a0000 {
+				compatible = "mstc,boot";
+				label = "firmware1";
+				reg = <0x5a0000 0x3200000>;
+				mstc,bootnum = <1>;
+				mstc,persist = <&mtd_persist>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label-base = "ubi";
+					reg = <0x0 0x3200000>;
+				};
+			};
+
+			partition@37a0000 {
+				label = "Config";
+				reg = <0x37a0000 0x380000>;
+				read-only;
+			};
+
+			partition@3b20000 {
+				label = "Fwheader_2";
+				reg = <0x3b20000 0x20000>;
+				read-only;
+			};
+
+			partition@3b40000 {
+				compatible = "mstc,boot";
+				label = "firmware2";
+				reg = <0x3b40000 0x3200000>;
+				mstc,bootnum = <2>;
+				mstc,persist = <&mtd_persist>;
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label-base = "ubi";
+					reg = <0x0 0x3200000>;
+				};
+			};
+
+			partition@6d40000 {
+				label = "Config_2";
+				reg = <0x6d40000 0x380000>;
+				read-only;
+			};
+
+			mtd_persist: partition@70c0000 {
+				label = "persist";
+				reg = <0x70c0000 0x100000>;
+			};
+
+			partition@71c0000 {
+				label = "Mrd";
+				reg = <0x71c0000 0x40000>;
+				read-only;
+			};
+
+			partition@7200000 {
+				label = "Backup";
+				reg = <0x7200000 0x380000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&wf_2g_5g_pins>;
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_a>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/dts/mt7986b-elecom-wrc-x6000gsd.dts
+++ b/target/linux/mediatek/dts/mt7986b-elecom-wrc-x6000gsd.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7986b-elecom-wrc-x6000.dtsi"
+
+/ {
+	model = "ELECOM WRC-X6000GSD";
+	compatible = "elecom,wrc-x6000gsd", "mediatek,mt7986b";
+};

--- a/target/linux/mediatek/dts/mt7986b-elecom-wrc-x6000qs.dts
+++ b/target/linux/mediatek/dts/mt7986b-elecom-wrc-x6000qs.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7986b-elecom-wrc-x6000.dtsi"
+
+/ {
+	model = "ELECOM WRC-X6000QS";
+	compatible = "elecom,wrc-x6000qs", "mediatek,mt7986b";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -100,6 +100,7 @@ cudy,wbr3000uax-v1-ubootmod)
 elecom,wrc-x3000gs3)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
 	;;
+elecom,wrc-x6000gsd|\
 elecom,wrc-x6000qs)
 	ucidef_set_led_netdev "wan" "wan" "mdio-bus:05:white:wan" "wan" "link tx rx"
 	;;

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -100,6 +100,9 @@ cudy,wbr3000uax-v1-ubootmod)
 elecom,wrc-x3000gs3)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "wan"
 	;;
+elecom,wrc-x6000qs)
+	ucidef_set_led_netdev "wan" "wan" "mdio-bus:05:white:wan" "wan" "link tx rx"
+	;;
 glinet,gl-x3000|\
 glinet,gl-xe3000)
 	ucidef_set_led_default "power" "POWER" "green:power" "1"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -227,7 +227,8 @@ platform_do_upgrade() {
 		fw_setenv sw_tryactive 0
 		nand_do_upgrade "$1"
 		;;
-	elecom,wrc-x3000gs3)
+	elecom,wrc-x3000gs3|\
+	elecom,wrc-x6000qs)
 		local bootnum="$(mstc_rw_bootnum)"
 		case "$bootnum" in
 		1|2)
@@ -443,6 +444,12 @@ platform_pre_upgrade() {
 		;;
 	buffalo,wsr-6000ax8)
 		buffalo_initial_setup
+		;;
+	elecom,wrc-x6000qs)
+		local delay=$(fw_printenv -n bootmenu_delay)
+
+		[ -z "$delay" ] || [ "$delay" -eq "0" ] && \
+			fw_setenv bootmenu_delay 3
 		;;
 	xiaomi,mi-router-ax3000t|\
 	xiaomi,mi-router-wr30u-stock|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -228,6 +228,7 @@ platform_do_upgrade() {
 		nand_do_upgrade "$1"
 		;;
 	elecom,wrc-x3000gs3|\
+	elecom,wrc-x6000gsd|\
 	elecom,wrc-x6000qs)
 		local bootnum="$(mstc_rw_bootnum)"
 		case "$bootnum" in
@@ -445,6 +446,7 @@ platform_pre_upgrade() {
 	buffalo,wsr-6000ax8)
 		buffalo_initial_setup
 		;;
+	elecom,wrc-x6000gsd|\
 	elecom,wrc-x6000qs)
 		local delay=$(fw_printenv -n bootmenu_delay)
 

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1578,6 +1578,20 @@ define Device/elecom_wrc-x3000gs3
 endef
 TARGET_DEVICES += elecom_wrc-x3000gs3
 
+define Device/elecom_wrc-x6000gsd
+  DEVICE_VENDOR := ELECOM
+  DEVICE_MODEL := WRC-X6000GSD
+  DEVICE_DTS := mt7986b-elecom-wrc-x6000gsd
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  IMAGES += factory.bin
+  IMAGE/factory.bin := sysupgrade-tar | mstc-header 5.04(XZR.0)b90 YTC@ | \
+	elecom-product-header WRC-X6000GS
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+endef
+TARGET_DEVICES += elecom_wrc-x6000gsd
+
 define Device/elecom_wrc-x6000qs
   DEVICE_VENDOR := ELECOM
   DEVICE_MODEL := WRC-X6000QS

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1578,6 +1578,20 @@ define Device/elecom_wrc-x3000gs3
 endef
 TARGET_DEVICES += elecom_wrc-x3000gs3
 
+define Device/elecom_wrc-x6000qs
+  DEVICE_VENDOR := ELECOM
+  DEVICE_MODEL := WRC-X6000QS
+  DEVICE_DTS := mt7986b-elecom-wrc-x6000qs
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_DTS_LOADADDR := 0x47000000
+  IMAGES += factory.bin
+  IMAGE/factory.bin := sysupgrade-tar | mstc-header 5.04(XZL.0)b90 COMD | \
+	elecom-product-header WRC-X6000QS
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7986-firmware mt7986-wo-firmware
+endef
+TARGET_DEVICES += elecom_wrc-x6000qs
+
 define Device/gatonetworks_gdsp
   DEVICE_VENDOR := GatoNetworks
   DEVICE_MODEL := gdsp


### PR DESCRIPTION
This patch series is a successor of #21387 with an additional support for WRC-X6000GSD.

fixes:

- correct `GPIO_ACTIVE_*` flags of wps/reset buttons
- fix wrong indentation (spaces vs. tabs) in the dts
- convert remap-range of MediaTek BMT (addr-size ---> start-end)

improvements:

- use a generic name (`ethernet-phy`) for the node name of the ethernet phy
- remove unused dt labels of LEDs and mdio
- sort LEDs in order of GPIO pin number
- set "wan" to eth1
- cleanup unused image variables (image/filogic.mk)
- update `bootmenu_delay` to `3` on sysupgrade when needed to enable bootmenu of U-Boot
  - (default: `bootmenu_delay=0`)

---

@minihui-me Could you please test this on your WRC-X6000QS?

- factory image (accepted by stock WebUI?)
- booting (failsafe mode triggered by reset/wps buttons without a press, or not?)
- mode0/1 buttons

  examples (WRC-X6000GSD):

  ```
  (Router):
  root@OpenWrt:~# grep "|mode[01]\s\+)" /sys/kernel/debug/gpio
   gpio-519 (                    |mode0               ) in  hi IRQ ACTIVE LOW
   gpio-531 (                    |mode1               ) in  lo IRQ ACTIVE LOW

  (AP):
  root@OpenWrt:~# grep "|mode[01]\s\+)" /sys/kernel/debug/gpio
   gpio-519 (                    |mode0               ) in  hi IRQ ACTIVE LOW
   gpio-531 (                    |mode1               ) in  hi IRQ ACTIVE LOW

  (Repeater (normal)):
  root@OpenWrt:~# grep "|mode[01]\s\+)" /sys/kernel/debug/gpio
   gpio-519 (                    |mode0               ) in  lo IRQ ACTIVE LOW
   gpio-531 (                    |mode1               ) in  lo IRQ ACTIVE LOW

  (Repeater (hanareya):
  root@OpenWrt:~# grep "|mode[01]\s\+)" /sys/kernel/debug/gpio
   gpio-519 (                    |mode0               ) in  lo IRQ ACTIVE LOW
   gpio-531 (                    |mode1               ) in  hi IRQ ACTIVE LOW
  ```

- `fw_printenv`