### PR TITLE
mediatek: filogic: comfast cf-wr632ax: adjust fan behavior & monitor Wi-Fi temps

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
@@ -51,6 +51,72 @@
 	};
 };
 
+&cpu_thermal {
+	trips {
+		cpu_trip_active_highest: active-highest {
+			temperature = <80000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_high: active-high {
+			temperature = <75000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_med: active-med {
+			temperature = <70000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_low: active-low {
+			temperature = <65000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_lowest: active-lowest {
+			temperature = <60000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		cpu-active-highest {
+			/* active: set fan to min 84%, max 100% */
+			cooling-device = <&fan 19 23>;
+			trip = <&cpu_trip_active_highest>;
+		};
+
+		cpu-active-high {
+			/* active: set fan to min 69%, max 84% */
+			cooling-device = <&fan 15 19>;
+			trip = <&cpu_trip_active_high>;
+		};
+
+		cpu-active-med {
+			/* active: set fan to min 49%, max 69% */
+			cooling-device = <&fan 10 15>;
+			trip = <&cpu_trip_active_med>;
+		};
+
+		cpu-active-low {
+			/* active: set fan to min 29%, max 49% */
+			cooling-device = <&fan 5 10>;
+			trip = <&cpu_trip_active_low>;
+		};
+
+		cpu-active-lowest {
+			/* active: set fan to min 10%, max 29% */
+			cooling-device = <&fan 0 5>;
+			trip = <&cpu_trip_active_lowest>;
+		};
+	};
+};
+
 &eth {
 	pinctrl-names = "default";
 	pinctrl-0 = <&mdio_pins>;
@@ -82,6 +148,8 @@
 &fan {
 	pwms = <&pwm 0 10000>;
 	status = "okay";
+	cooling-levels = <25 35 45 55 65 75 85 95 105 115 125 135 145>,
+			<155 165 175 185 195 205 215 225 235 245 255>;
 };
 
 &mdio_bus {

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
@@ -3,6 +3,7 @@
 /dts-v1/;
 
 #include "mt7981b.dtsi"
+#include "thermal-trips-cooling-maps.dtsi"
 
 / {
 	aliases {
@@ -49,6 +50,46 @@
 			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	thermal-zones {
+		wifi0-thermal {
+			thermal-sensors = <&wifi 0>;
+			polling-delay-passive = <1000>;
+			polling-delay = <1000>;
+
+			trips {
+				THERMAL_TRIPS_COMMON(wifi0)
+			};
+
+			cooling-maps {
+				THERMAL_COOLING_MAPS_COMMON(wifi0)
+			};
+		};
+
+		wifi1-thermal {
+			thermal-sensors = <&wifi 1>;
+			polling-delay-passive = <1000>;
+			polling-delay = <1000>;
+
+			trips {
+				THERMAL_TRIPS_COMMON(wifi1)
+			};
+
+			cooling-maps {
+				THERMAL_COOLING_MAPS_COMMON(wifi1)
+			};
+		};
+	};
+};
+
+&cpu_thermal {
+	trips {
+		THERMAL_TRIPS_COMMON(cpu)
+	};
+
+	cooling-maps {
+		THERMAL_COOLING_MAPS_COMMON(cpu)
+	};
 };
 
 &eth {
@@ -80,6 +121,9 @@
 };
 
 &fan {
+	cooling-levels = <0 30 35 40 45 50 55 60 65 70 75 80 85 90 95 100 105 110 115 120 125>,
+			 <130 135 140 145 150 155 165 175 185 195 205 215 225 235 245 255>;
+	fan-stop-to-start-percent = <15>;
 	interrupts-extended = <&pio 4 IRQ_TYPE_EDGE_FALLING>;
 	pulses-per-revolution = <2>;
 	pwms = <&pwm 0 40000>;
@@ -235,6 +279,7 @@
 &wifi {
 	#address-cells = <1>;
 	#size-cells = <0>;
+	#thermal-sensor-cells = <1>;
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 	status = "okay";

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
@@ -86,7 +86,7 @@
 	gmac0: mac@0 {
 		compatible = "mediatek,eth-mac";
 		reg = <0>;
-		label = "wan";
+		openwrt,netdev-name = "wan";
 		phy-mode = "2500base-x";
 		phy-handle = <&phy5>;
 
@@ -97,7 +97,7 @@
 	gmac1: mac@1 {
 		compatible = "mediatek,eth-mac";
 		reg = <1>;
-		label = "lan";
+		openwrt,netdev-name = "lan";
 		phy-mode = "gmii";
 		phy-handle = <&int_gbe_phy>;
 

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
@@ -3,6 +3,7 @@
 /dts-v1/;
 
 #include "mt7981b.dtsi"
+#include "thermal-trips-cooling-maps.dtsi"
 
 / {
 	aliases {
@@ -49,6 +50,32 @@
 			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	thermal-zones {
+		wifi-thermal {
+			thermal-sensors = <&wifi>;
+			polling-delay-passive = <1000>;
+			polling-delay = <1000>;
+
+			trips {
+				THERMAL_TRIPS_COMMON(wifi)
+			};
+
+			cooling-maps {
+				THERMAL_COOLING_MAPS_COMMON(wifi)
+			};
+		};
+	};
+};
+
+&cpu_thermal {
+	trips {
+		THERMAL_TRIPS_COMMON(cpu)
+	};
+
+	cooling-maps {
+		THERMAL_COOLING_MAPS_COMMON(cpu)
+	};
 };
 
 &eth {
@@ -80,6 +107,9 @@
 };
 
 &fan {
+	cooling-levels = <0 30 35 40 45 50 55 60 65 70 75 80 85 90 95 100 105 110 115 120 125>,
+			 <130 135 140 145 150 155 165 175 185 195 205 215 225 235 245 255>;
+	fan-stop-to-start-percent = <15>;
 	interrupts-extended = <&pio 4 IRQ_TYPE_EDGE_FALLING>;
 	pulses-per-revolution = <2>;
 	pwms = <&pwm 0 40000>;
@@ -235,6 +265,7 @@
 &wifi {
 	#address-cells = <1>;
 	#size-cells = <0>;
+	#thermal-sensor-cells = <0>;
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 	status = "okay";

--- a/target/linux/mediatek/dts/thermal-trips-cooling-maps.dtsi
+++ b/target/linux/mediatek/dts/thermal-trips-cooling-maps.dtsi
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+* There are 36 trip levels and the cooling maps start from cooling
+* state 1 (0-index) so cooling-levels must have at least 37 elements.
+* If greater increments between trip levels/cooling-levels are
+* desired/needed, pad the cooling-levels with repeated values:
+* 	cooling-levels = <... 128 128 128 192 192 192 ...>;
+*
+* THERMAL_TRIPS_COMMON and THERMAL_COOLING_MAPS_COMMON must have
+* the same argument within a thermal zone because the argument
+* is the prefix to the trip levels node labels.
+*
+* example:
+* / {
+* 	...
+* 	thermal-zones {
+* 		wifi0-thermal {
+* 			thermal-sensors = <&wifi 0>;
+* 			polling-delay-passive = <1000>;
+* 			polling-delay = <1000>;
+*
+* 			trips {
+* 				THERMAL_TRIPS_COMMON(wifi0)
+* 			};
+*
+* 			cooling-maps {
+* 				THERMAL_COOLING_MAPS_COMMON(wifi0)
+* 			};
+* 		};
+*
+* 		wifi1-thermal {
+* 			thermal-sensors = <&wifi 1>;
+* 			polling-delay-passive = <1000>;
+* 			polling-delay = <1000>;
+*
+* 			trips {
+* 				THERMAL_TRIPS_COMMON(wifi1)
+* 			};
+*
+* 			cooling-maps {
+* 				THERMAL_COOLING_MAPS_COMMON(wifi1)
+* 			};
+* 		};
+* 	};
+* 	...
+* };
+*/
+
+#define THERMAL_TRIPS_COMMON(thermaldevice)			\
+	thermaldevice##_trip_active_highest: active-highest {	\
+		temperature = <108750>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_high: active-high {		\
+		temperature = <107500>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_33: active-33 {		\
+		temperature = <106250>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_32: active-32 {		\
+		temperature = <105000>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_31: active-31 {		\
+		temperature = <103750>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_30: active-30 {		\
+		temperature = <102500>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_29: active-29 {		\
+		temperature = <101250>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_28: active-28 {		\
+		temperature = <100000>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_27: active-27 {		\
+		temperature = <98750>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_26: active-26 {		\
+		temperature = <97500>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_25: active-25 {		\
+		temperature = <96250>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_24: active-24 {		\
+		temperature = <95000>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_23: active-23 {		\
+		temperature = <93750>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_22: active-22 {		\
+		temperature = <92500>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_21: active-21 {		\
+		temperature = <91250>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_20: active-20 {		\
+		temperature = <90000>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_med: active-med {		\
+		temperature = <88750>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_18: active-18 {		\
+		temperature = <87500>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_17: active-17 {		\
+		temperature = <86250>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_16: active-16 {		\
+		temperature = <85000>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_15: active-15 {		\
+		temperature = <83750>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_14: active-14 {		\
+		temperature = <82500>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_13: active-13 {		\
+		temperature = <81250>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_12: active-12 {		\
+		temperature = <80000>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_11: active-11 {		\
+		temperature = <78750>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_10: active-10 {		\
+		temperature = <77500>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_9: active-9 {		\
+		temperature = <76250>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_8: active-8 {		\
+		temperature = <75000>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_7: active-7 {		\
+		temperature = <73750>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_6: active-6 {		\
+		temperature = <72500>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_5: active-5 {		\
+		temperature = <71250>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_4: active-4 {		\
+		temperature = <70000>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_3: active-3 {		\
+		temperature = <68750>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_2: active-2 {		\
+		temperature = <67500>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_low: active-low {		\
+		temperature = <66250>;				\
+		hysteresis = <2500>;				\
+		type = "active";				\
+	};							\
+	thermaldevice##_trip_active_lowest: active-lowest {	\
+		temperature = <65000>;				\
+		hysteresis = <5000>;				\
+		type = "active";				\
+	};
+
+#define THERMAL_COOLING_MAPS_COMMON(thermaldevice)		\
+	thermaldevice-active-highest {				\
+		cooling-device = <&fan 36 36>;			\
+		trip = <&thermaldevice##_trip_active_highest>;	\
+	};							\
+	thermaldevice-active-high {				\
+		cooling-device = <&fan 35 35>;			\
+		trip = <&thermaldevice##_trip_active_high>;	\
+	};							\
+	thermaldevice-active-33 {				\
+		cooling-device = <&fan 34 34>;			\
+		trip = <&thermaldevice##_trip_active_33>;	\
+	};							\
+	thermaldevice-active-32 {				\
+		cooling-device = <&fan 33 33>;			\
+		trip = <&thermaldevice##_trip_active_32>;	\
+	};							\
+	thermaldevice-active-31 {				\
+		cooling-device = <&fan 32 32>;			\
+		trip = <&thermaldevice##_trip_active_31>;	\
+	};							\
+	thermaldevice-active-30 {				\
+		cooling-device = <&fan 31 31>;			\
+		trip = <&thermaldevice##_trip_active_30>;	\
+	};							\
+	thermaldevice-active-29 {				\
+		cooling-device = <&fan 30 30>;			\
+		trip = <&thermaldevice##_trip_active_29>;	\
+	};							\
+	thermaldevice-active-28 {				\
+		cooling-device = <&fan 29 29>;			\
+		trip = <&thermaldevice##_trip_active_28>;	\
+	};							\
+	thermaldevice-active-27 {				\
+		cooling-device = <&fan 28 28>;			\
+		trip = <&thermaldevice##_trip_active_27>;	\
+	};							\
+	thermaldevice-active-26 {				\
+		cooling-device = <&fan 27 27>;			\
+		trip = <&thermaldevice##_trip_active_26>;	\
+	};							\
+	thermaldevice-active-25 {				\
+		cooling-device = <&fan 26 26>;			\
+		trip = <&thermaldevice##_trip_active_25>;	\
+	};							\
+	thermaldevice-active-24 {				\
+		cooling-device = <&fan 25 25>;			\
+		trip = <&thermaldevice##_trip_active_24>;	\
+	};							\
+	thermaldevice-active-23 {				\
+		cooling-device = <&fan 24 24>;			\
+		trip = <&thermaldevice##_trip_active_23>;	\
+	};							\
+	thermaldevice-active-22 {				\
+		cooling-device = <&fan 23 23>;			\
+		trip = <&thermaldevice##_trip_active_22>;	\
+	};							\
+	thermaldevice-active-21 {				\
+		cooling-device = <&fan 22 22>;			\
+		trip = <&thermaldevice##_trip_active_21>;	\
+	};							\
+	thermaldevice-active-20 {				\
+		cooling-device = <&fan 21 21>;			\
+		trip = <&thermaldevice##_trip_active_20>;	\
+	};							\
+	thermaldevice-active-med {				\
+		cooling-device = <&fan 20 20>;			\
+		trip = <&thermaldevice##_trip_active_med>;	\
+	};							\
+	thermaldevice-active-18 {				\
+		cooling-device = <&fan 19 19>;			\
+		trip = <&thermaldevice##_trip_active_18>;	\
+	};							\
+	thermaldevice-active-17 {				\
+		cooling-device = <&fan 18 18>;			\
+		trip = <&thermaldevice##_trip_active_17>;	\
+	};							\
+	thermaldevice-active-16 {				\
+		cooling-device = <&fan 17 17>;			\
+		trip = <&thermaldevice##_trip_active_16>;	\
+	};							\
+	thermaldevice-active-15 {				\
+		cooling-device = <&fan 16 16>;			\
+		trip = <&thermaldevice##_trip_active_15>;	\
+	};							\
+	thermaldevice-active-14 {				\
+		cooling-device = <&fan 15 15>;			\
+		trip = <&thermaldevice##_trip_active_14>;	\
+	};							\
+	thermaldevice-active-13 {				\
+		cooling-device = <&fan 14 14>;			\
+		trip = <&thermaldevice##_trip_active_13>;	\
+	};							\
+	thermaldevice-active-12 {				\
+		cooling-device = <&fan 13 13>;			\
+		trip = <&thermaldevice##_trip_active_12>;	\
+	};							\
+	thermaldevice-active-11 {				\
+		cooling-device = <&fan 12 12>;			\
+		trip = <&thermaldevice##_trip_active_11>;	\
+	};							\
+	thermaldevice-active-10 {				\
+		cooling-device = <&fan 11 11>;			\
+		trip = <&thermaldevice##_trip_active_10>;	\
+	};							\
+	thermaldevice-active-9 {				\
+		cooling-device = <&fan 10 10>;			\
+		trip = <&thermaldevice##_trip_active_9>;	\
+	};							\
+	thermaldevice-active-8 {				\
+		cooling-device = <&fan 9 9>;			\
+		trip = <&thermaldevice##_trip_active_8>;	\
+	};							\
+	thermaldevice-active-7 {				\
+		cooling-device = <&fan 8 8>;			\
+		trip = <&thermaldevice##_trip_active_7>;	\
+	};							\
+	thermaldevice-active-6 {				\
+		cooling-device = <&fan 7 7>;			\
+		trip = <&thermaldevice##_trip_active_6>;	\
+	};							\
+	thermaldevice-active-5 {				\
+		cooling-device = <&fan 6 6>;			\
+		trip = <&thermaldevice##_trip_active_5>;	\
+	};							\
+	thermaldevice-active-4 {				\
+		cooling-device = <&fan 5 5>;			\
+		trip = <&thermaldevice##_trip_active_4>;	\
+	};							\
+	thermaldevice-active-3 {				\
+		cooling-device = <&fan 4 4>;			\
+		trip = <&thermaldevice##_trip_active_3>;	\
+	};							\
+	thermaldevice-active-2 {				\
+		cooling-device = <&fan 3 3>;			\
+		trip = <&thermaldevice##_trip_active_2>;	\
+	};							\
+	thermaldevice-active-low {				\
+		cooling-device = <&fan 2 2>;			\
+		trip = <&thermaldevice##_trip_active_low>;	\
+	};							\
+	thermaldevice-active-lowest {				\
+		cooling-device = <&fan 1 1>;			\
+		trip = <&thermaldevice##_trip_active_lowest>;	\
+	};


### PR DESCRIPTION
- Add thermal zone for the Wi-Fi chip using the same trip levels and cooling map as the CPU.
  - The kernel thermal governor will act on whichever temperature is the highest. 
- Add trip levels spaced 1.25&deg;C apart with double that (2.5&deg;C) for the hysteresis and increments of 5 (out of 255) from 12% to 61% and then increments of 10 from 61% to 100% for the cooling levels/map with fan kick start speed at 15%. The lowest trip level (65&deg;C) has hysteresis of 5&deg;C because it is preferable for the fan to run for longer at low speed than to stop and start repeatedly.
  - In the absence of continuous proportional feedback control, oscillation of fan speed and temperature is inevitable. Tightly grouping the trip levels and cooling levels/map minimises the frequency and amplitude of the oscillation. 

<details>
<summary>Before, the fan would turn on at a minimum of 50% for 2 minutes, off for 2 minutes repeatedly.</summary>

<img width="1180" height="230" alt="before" src="https://github.com/user-attachments/assets/747ae209-db33-4422-b88e-ff82773d5791" />

</details>

<details>
<summary>Now the frequency of oscillation is reduced to ~1x every 30 minutes with minimum fan speed of ~12%.</summary>

<img width="1171" height="222" alt="idle" src="https://github.com/user-attachments/assets/5518e6f1-5ecc-4a5f-9ee3-79a2fa817eda" />

</details>

<details>
<summary>In cold weather, the fan only turns on in the afternoon, stays on until night time and then turns off until the next day's afternoon.</summary>

<img width="1171" height="222" src="https://github.com/user-attachments/assets/fb4e4c19-c52d-40f4-847f-fee54b6ebfc6" />
<img width="1171" height="222" src="https://github.com/user-attachments/assets/d3e20281-83e0-434b-b584-e4862dfeb254" />

</details>

<details>
<summary>Under wireless load, as the Wi-Fi chip temperature exceeds the CPU temperature, the kernel thermal governor activates the cooling/trip levels based on the Wi-Fi chip temperature. As the load eases and the CPU temperature is once again higher than the Wi-Fi chip temperature, the kernel thermal governor activates the cooling/trip levels based on the CPU temperature.</summary>

<img width="1171" height="222" alt="thermal_zone0" src="https://github.com/user-attachments/assets/64fa81f1-4e94-4ed5-ad7a-fc4cd42cb876" />
<img width="1171" height="222" alt="thermal_zone1" src="https://github.com/user-attachments/assets/7179df59-ce1f-4882-b32c-14819034a2a0" />
<img width="1171" height="222" alt="thermal_zone2" src="https://github.com/user-attachments/assets/6f7476a4-d53e-4315-90e2-ba9be9179ff7" />
<img width="1171" height="235" alt="Transfer on br-lan" src="https://github.com/user-attachments/assets/7393df7e-3912-4786-ae5c-4363333e8a02" />
<img width="1171" height="261" alt="Packets on br-lan" src="https://github.com/user-attachments/assets/c0b2fd39-0b49-419c-a341-46d0f673c3cb" />

</details>

While at it, replace the `label` property for ethernet interface names with the property `openwrt,netdev-name` added in commit d4d6c48b6e05 ("mediatek: filogic: support openwrt,netdev-name for renaming interfaces").

v2 comments start at https://github.com/openwrt/openwrt/pull/22936#issuecomment-5036722422

***
<details>
<summary>old version (v1)</summary>

https://github.com/untilscour/openwrt/commit/c3f853d60dac04cc52c8554e5e59a1cfad33c843

v1 comments end at https://github.com/openwrt/openwrt/pull/22936#issuecomment-4365270364

- add more cooling levels so that the fan speed can start slower (min 10% vs min 50% previously) and then change in smaller increments in response to temperature changes
- add more trip levels than the default in `mt7981b.dtsi`

This is similar to the manufacturer's stock firmware which uses higher temperatures for the trip levels:
<details>
<summary>stock device tree (<code>V2.6.0.4</code>) with annotated comments</summary>

```
pwm-fan {
	compatible = "pwm-fan";
	cooling-levels = <0x00 0x1a 0x33 0x4d 0x66 0x80 0x99 0xb3 0xcc 0xe6 0xff>;
	/*                 % 0   10  20   30    40   50   60   70   80   90  100   */
	/* cooling-levels = <0   26  51   77   102  128  153  179  204  230  255>; */
	#cooling-cells = <0x02>;
	status = "okay";
	pwms = <0x02 0x00 0x2710>;
	phandle = <0x06>;
};
 
thermal-zones {
 
	cpu-thermal {
		polling-delay-passive = <0x3e8>;
		polling-delay = <0x3e8>;
		thermal-sensors = <0x05 0x00>;
 
		trips {
 
			active-highest {
				temperature = <0x17318>; /* 95000 70%-100% 179-255 */
				hysteresis = <0x7d0>; /* 2000 */
				type = "active";
				phandle = <0x07>;
			};
 
			active-high {
				temperature = <0x14c08>; /* 85000 50%-80% 128-204 */
				hysteresis = <0x7d0>; /* 2000 */
				type = "active";
				phandle = <0x08>;
			};
 
			active-med {
				temperature = <0x124f8>; /* 75000 30%-50% 77-128 */
				hysteresis = <0x7d0>; /* 2000 */
				type = "active";
				phandle = <0x09>;
			};
 
			active-low {
				temperature = <0xfde8>; /* 65000 10%-30% 26-77 */
				hysteresis = <0x7d0>; /* 2000 */
				type = "active";
				phandle = <0x0a>;
			};
		};
 
		cooling-maps {

			cpu-active-highest {
				cooling-device = <0x06 0x07 0x0a>; /* 70%-100% 179-255 */
				trip = <0x07>;
			};
 
			cpu-active-high {
				cooling-device = <0x06 0x05 0x08>; /* 50%-80% 128-204 */
				trip = <0x08>;
			};
 
			cpu-active-med {
				cooling-device = <0x06 0x03 0x05>; /* 30%-50% 77-128 */
				trip = <0x09>;
			};
 
			cpu-active-low {
				cooling-device = <0x06 0x01 0x03>; /* 10%-30% 26-77 */
				trip = <0x0a>;
			};
		};
	};
};
```

</details>

***

The default `step_wise` thermal governor can decrease as well as increase the fan speed even before a `trip_point` is crossed. (https://github.com/torvalds/linux/commit/2e82368359f63567862a0d438710ddffcb1ace83)

Before, the fan would turn on at 50% when CPU temperature reaches 60&deg;C. Because of the high fan speed it cools down to <span style="white-space: nowrap">58&deg;C (60&deg;C - 2&deg;C hysteresis)</span> in 2 minutes and the cycle constantly repeats: 
<img width="1180" height="230" alt="before" src="https://github.com/user-attachments/assets/747ae209-db33-4422-b88e-ff82773d5791" />

After this change which I have been using for the last few weeks, the fan speed varies constantly and the temperature remains within a small delta: 
<img width="1171" height="222" alt="19" src="https://github.com/user-attachments/assets/2a336469-2716-4149-90e8-df096c068dcf" />
<img width="1171" height="222" alt="20-2" src="https://github.com/user-attachments/assets/fd7fd75b-aad6-48f6-808b-e6e6bbce2950" />
<img width="1171" height="222" alt="20-4" src="https://github.com/user-attachments/assets/24bd9b63-071a-4bb4-9e88-acf9adcb6014" />
<details>
<summary>After changed fan behaviour, with some Wi-Fi Load</summary>
<img width="1171" height="222" src="https://github.com/user-attachments/assets/5bb45b5c-575a-44b0-bffa-61633fda72df" />
<img width="1171" height="222" src="https://github.com/user-attachments/assets/329b3eef-3139-480d-b4dd-f3ee83066060" />
<img width="1171" height="222" src="https://github.com/user-attachments/assets/c8ee9094-5965-4808-ad58-6671673a8600" />
<img width="1171" height="235" src="https://github.com/user-attachments/assets/8f5e6bc2-7496-427a-85cc-28bd8f57ae71" />
<img width="1171" height="261" src="https://github.com/user-attachments/assets/14022a9c-0224-4fc6-95aa-03a9429d7b9a" />
<img width="1171" height="300" src="https://github.com/user-attachments/assets/565122e5-9343-4ddd-83c3-1dd16301df80" />
<img width="1171" height="300" src="https://github.com/user-attachments/assets/f83d00ee-9f0a-446f-b1b0-282b5ff26b10" />
</details>

Cooling levels cannot be added or removed but trip point temperatures can be changed by:
```
echo 50000 > /sys/class/thermal/thermal_zone0/trip_point_X_temp
```
where `X` is the trip point number. 

</details>