### PR TITLE
base-files: sysupgrade: exclude apk files from backup

### DIFF
--- a/package/base-files/files/sbin/sysupgrade
+++ b/package/base-files/files/sbin/sysupgrade
@@ -224,8 +224,10 @@ build_list_of_backup_overlay_files() {
 		-e '\,^/etc/board.json$,d' \
 		-e '\,^/etc/luci-uploads/\.placeholder,d' \
 		-e '\,/[^/]*-opkg$,d' \
+		-e '\,/[^/]*\.apk-new$,d' \
 		-e '\,^/etc/urandom.seed$,d' \
 		-e '\,^/etc/apk/world$,d' \
+		-e '\,^/etc/apk/repositories\.d/distfeeds\.list$,d' \
 		-e "\,^$INSTALLED_PACKAGES$,d" \
 		-e '\,^/usr/lib/opkg/.*,d' \
 		-e '\,^/lib/apk/.*,d' \


### PR DESCRIPTION
Exclude more apk related files from the sysupgrade backup list when using the various options that scan /etc for changes.

Ensure removal of the system generated distfeeds list, as that contains kernel- and version-specific urls and should never be retained.

Also exclude any '*.apk-new' files, equivalent to the old '*-opkg' files, which may have been created during package installation.

Example before
```bash
  $ sysupgrade -l -c | grep apk
  /etc/apk/keys/buildroot.pem
  /etc/apk/repositories.d/customfeeds.list
  /etc/apk/repositories.d/distfeeds.list
  /etc/owut.d/pre-install.sh.apk-new
  /etc/config/adblock.apk-new
```

After
```bash
  $ sysupgrade -l -c | grep apk
  /etc/apk/keys/buildroot.pem
  /etc/apk/repositories.d/customfeeds.list
```