### PR TITLE
realtek: pcs: improve USXGMII config

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3783,14 +3783,10 @@ static int rtpcs_931x_sds_config_hw_mode(struct rtpcs_serdes *sds,
 	case RTPCS_SDS_MODE_USXGMII_5GSXGMII:
 	case RTPCS_SDS_MODE_USXGMII_5GDXGMII:
 	case RTPCS_SDS_MODE_USXGMII_2_5GSXGMII:
-		u32 op_code = 0x6003;
-
 		rtpcs_931x_sds_reset_leq_dfe(sds);
 		rtpcs_931x_sds_rx_reset(sds);
 
-		rtpcs_sds_write(sds, 0x7, 0x10, op_code);
-		rtpcs_sds_write(sds, 0x6, 0x1d, 0x0480);
-		rtpcs_sds_write(sds, 0x6, 0xe, 0x0400);
+		rtpcs_93xx_sds_usxgmii_config(sds, 0x03, 0xa4, 0, 1, 0x1);
 		break;
 
 	case RTPCS_SDS_MODE_QSGMII:

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -1127,6 +1127,16 @@ static int rtpcs_93xx_sds_set_autoneg(struct rtpcs_serdes *sds, unsigned int neg
 		en_val = neg_mode == PHYLINK_PCS_NEG_INBAND_ENABLED ? 0x0 : 0x1;
 
 		return rtpcs_sds_xsg_write_bits(sds, 0x0, 0x2, 9, 8, en_val);
+
+	case RTPCS_SDS_MODE_USXGMII_10GSXGMII ... RTPCS_SDS_MODE_USXGMII_2_5GSXGMII:
+		/*
+		 * CFG_QHSG_AN_EN_CHX: bits [3:0] enable AN on channels 3..0
+		 *
+		 * We do not support forced USXGMII link yet, always activate USXGMII-AN
+		 * for now.
+		 */
+		return rtpcs_sds_write_bits(sds, 0x7, 0x11, 3, 0, 0xf);
+
 	default:
 		return rtpcs_generic_sds_set_autoneg(sds, neg_mode, advertising);
 	}
@@ -2782,7 +2792,7 @@ static const struct rtpcs_sds_config rtpcs_930x_sds_cfg_final_odd[] =
 	{0x2D, 0x13, 0x3C87}, {0x2D, 0x14, 0x1808}
 };
 
-static void rtpcs_930x_sds_usxgmii_config(struct rtpcs_serdes *sds, bool nway_en,
+static void rtpcs_930x_sds_usxgmii_config(struct rtpcs_serdes *sds,
 					  u32 opcode, u32 am_period,
 					  u32 all_am_markers, u32 an_table,
 					  u32 sync_bit)
@@ -2799,8 +2809,6 @@ static void rtpcs_930x_sds_usxgmii_config(struct rtpcs_serdes *sds, bool nway_en
 	 * - 0xaa: Realtek-proprietary mode (e.g. RTL8224)
 	 */
 	rtpcs_sds_write_bits(sds, 0x7, 0x10, 7, 0, opcode);		/* CFG_QHSG_AN_OPC */
-	/* CFG_QHSG_AN_EN_CHX: bits [3:0] enable AN on channels 3..0 */
-	rtpcs_sds_write_bits(sds, 0x7, 0x11, 3, 0, nway_en ? 0xf : 0);
 
 	rtpcs_sds_write_bits(sds, 0x6, 0x12, 15, 0, am_period);
 	rtpcs_sds_write_bits(sds, 0x6, 0x13, 7,  0, all_am_markers);	/* CFG_AM0_M0 */
@@ -2918,7 +2926,7 @@ static int rtpcs_930x_sds_config_hw_mode(struct rtpcs_serdes *sds, enum rtpcs_sd
 
 		if (!is_xsgmii)
 			/* opcode 0x03: standard/generic USXGMII mode */
-			rtpcs_930x_sds_usxgmii_config(sds, true, 0x03, 0xa4, 0, 1, 0x1);
+			rtpcs_930x_sds_usxgmii_config(sds, 0x03, 0xa4, 0, 1, 0x1);
 		break;
 
 	default:

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -1149,7 +1149,11 @@ static void rtpcs_93xx_sds_usxgmii_config(struct rtpcs_serdes *sds, u32 opcode, 
 	rtpcs_sds_write(sds, 0x06, 0x00, 0x0000);
 	rtpcs_sds_write(sds, 0x06, 0x0D, 0x0F00);
 	rtpcs_sds_write(sds, 0x06, 0x1D, 0x0600);
+
 	rtpcs_sds_write(sds, 0x07, 0x06, 0x1401); /* CFG_QHSG_TXCFG_MAC_CH0 */
+	rtpcs_sds_write(sds, 0x07, 0x08, 0x1401); /* CFG_QHSG_TXCFG_MAC_CH1 */
+	rtpcs_sds_write(sds, 0x07, 0x0a, 0x1401); /* CFG_QHSG_TXCFG_MAC_CH2 */
+	rtpcs_sds_write(sds, 0x07, 0x0c, 0x1401); /* CFG_QHSG_TXCFG_MAC_CH3 */
 
 	/*
 	 * Controls the USXGMII AN mode. Two states are currently known:

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -1142,6 +1142,41 @@ static int rtpcs_93xx_sds_set_autoneg(struct rtpcs_serdes *sds, unsigned int neg
 	}
 }
 
+static void rtpcs_93xx_sds_usxgmii_config(struct rtpcs_serdes *sds, u32 opcode, u32 am_period,
+					  u32 all_am_markers, u32 an_table, u32 sync_bit)
+{
+	/* this comes from USXGMII patch sequences of the SDK */
+	rtpcs_sds_write(sds, 0x06, 0x00, 0x0000);
+	rtpcs_sds_write(sds, 0x06, 0x0D, 0x0F00);
+	rtpcs_sds_write(sds, 0x06, 0x1D, 0x0600);
+	rtpcs_sds_write(sds, 0x07, 0x06, 0x1401); /* CFG_QHSG_TXCFG_MAC_CH0 */
+
+	/*
+	 * Controls the USXGMII AN mode. Two states are currently known:
+	 * - 0x03: generic/standard-compliant mode
+	 * - 0xaa: Realtek-proprietary mode (e.g. RTL8224)
+	 */
+	rtpcs_sds_write_bits(sds, 0x7, 0x10, 7, 0, opcode);		/* CFG_QHSG_AN_OPC */
+
+	rtpcs_sds_write_bits(sds, 0x6, 0x12, 15, 0, am_period);
+	rtpcs_sds_write_bits(sds, 0x6, 0x13, 7,  0, all_am_markers);	/* CFG_AM0_M0 */
+	rtpcs_sds_write_bits(sds, 0x6, 0x13, 15, 8, all_am_markers);	/* CFG_AM0_M1 */
+	rtpcs_sds_write_bits(sds, 0x6, 0x14, 7,  0, all_am_markers);	/* CFG_AM0_M2 */
+	rtpcs_sds_write_bits(sds, 0x6, 0x14, 15, 8, all_am_markers);	/* CFG_AM1_M0 */
+	rtpcs_sds_write_bits(sds, 0x6, 0x15, 7,  0, all_am_markers);	/* CFG_AM1_M1 */
+	rtpcs_sds_write_bits(sds, 0x6, 0x15, 15, 8, all_am_markers);	/* CFG_AM1_M2 */
+	rtpcs_sds_write_bits(sds, 0x6, 0x16, 7,  0, all_am_markers);	/* CFG_AM2_M0 */
+	rtpcs_sds_write_bits(sds, 0x6, 0x16, 15, 8, all_am_markers);	/* CFG_AM2_M1 */
+	rtpcs_sds_write_bits(sds, 0x6, 0x17, 7,  0, all_am_markers);	/* CFG_AM2_M2 */
+	rtpcs_sds_write_bits(sds, 0x6, 0x17, 15, 8, all_am_markers);	/* CFG_AM3_M0 */
+	rtpcs_sds_write_bits(sds, 0x6, 0x18, 7,  0, all_am_markers);	/* CFG_AM3_M1 */
+	rtpcs_sds_write_bits(sds, 0x6, 0x18, 15, 8, all_am_markers);	/* CFG_AM3_M2 */
+	rtpcs_sds_write_bits(sds, 0x6, 0xe, 10, 10, an_table);
+	rtpcs_sds_write_bits(sds, 0x6, 0x1d, 11, 10, sync_bit);
+
+	rtpcs_sds_write_bits(sds, 0x06, 0x03, 15, 15, 0x1);		/* FP_TGR3_CFG_EEE_EN */
+}
+
 static int rtpcs_93xx_init(struct rtpcs_ctrl *ctrl)
 {
 	u32 model_info = 0;
@@ -2792,43 +2827,6 @@ static const struct rtpcs_sds_config rtpcs_930x_sds_cfg_final_odd[] =
 	{0x2D, 0x13, 0x3C87}, {0x2D, 0x14, 0x1808}
 };
 
-static void rtpcs_930x_sds_usxgmii_config(struct rtpcs_serdes *sds,
-					  u32 opcode, u32 am_period,
-					  u32 all_am_markers, u32 an_table,
-					  u32 sync_bit)
-{
-	/* this comes from USXGMII patch sequences of the SDK */
-	rtpcs_sds_write(sds, 0x06, 0x00, 0x0000);
-	rtpcs_sds_write(sds, 0x06, 0x0D, 0x0F00);
-	rtpcs_sds_write(sds, 0x06, 0x1D, 0x0600);
-	rtpcs_sds_write(sds, 0x07, 0x06, 0x1401); /* CFG_QHSG_TXCFG_MAC_CH0 */
-
-	/*
-	 * Controls the USXGMII AN mode. Two states are currently known:
-	 * - 0x03: generic/standard-compliant mode
-	 * - 0xaa: Realtek-proprietary mode (e.g. RTL8224)
-	 */
-	rtpcs_sds_write_bits(sds, 0x7, 0x10, 7, 0, opcode);		/* CFG_QHSG_AN_OPC */
-
-	rtpcs_sds_write_bits(sds, 0x6, 0x12, 15, 0, am_period);
-	rtpcs_sds_write_bits(sds, 0x6, 0x13, 7,  0, all_am_markers);	/* CFG_AM0_M0 */
-	rtpcs_sds_write_bits(sds, 0x6, 0x13, 15, 8, all_am_markers);	/* CFG_AM0_M1 */
-	rtpcs_sds_write_bits(sds, 0x6, 0x14, 7,  0, all_am_markers);	/* CFG_AM0_M2 */
-	rtpcs_sds_write_bits(sds, 0x6, 0x14, 15, 8, all_am_markers);	/* CFG_AM1_M0 */
-	rtpcs_sds_write_bits(sds, 0x6, 0x15, 7,  0, all_am_markers);	/* CFG_AM1_M1 */
-	rtpcs_sds_write_bits(sds, 0x6, 0x15, 15, 8, all_am_markers);	/* CFG_AM1_M2 */
-	rtpcs_sds_write_bits(sds, 0x6, 0x16, 7,  0, all_am_markers);	/* CFG_AM2_M0 */
-	rtpcs_sds_write_bits(sds, 0x6, 0x16, 15, 8, all_am_markers);	/* CFG_AM2_M1 */
-	rtpcs_sds_write_bits(sds, 0x6, 0x17, 7,  0, all_am_markers);	/* CFG_AM2_M2 */
-	rtpcs_sds_write_bits(sds, 0x6, 0x17, 15, 8, all_am_markers);	/* CFG_AM3_M0 */
-	rtpcs_sds_write_bits(sds, 0x6, 0x18, 7,  0, all_am_markers);	/* CFG_AM3_M1 */
-	rtpcs_sds_write_bits(sds, 0x6, 0x18, 15, 8, all_am_markers);	/* CFG_AM3_M2 */
-	rtpcs_sds_write_bits(sds, 0x6, 0xe, 10, 10, an_table);
-	rtpcs_sds_write_bits(sds, 0x6, 0x1d, 11, 10, sync_bit);
-
-	rtpcs_sds_write_bits(sds, 0x06, 0x03, 15, 15, 0x1);		/* FP_TGR3_CFG_EEE_EN */
-}
-
 static int rtpcs_930x_sds_config_hw_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
 {
 	int (*apply_fn)(struct rtpcs_serdes *, const struct rtpcs_sds_config *, size_t);
@@ -2926,7 +2924,7 @@ static int rtpcs_930x_sds_config_hw_mode(struct rtpcs_serdes *sds, enum rtpcs_sd
 
 		if (!is_xsgmii)
 			/* opcode 0x03: standard/generic USXGMII mode */
-			rtpcs_930x_sds_usxgmii_config(sds, 0x03, 0xa4, 0, 1, 0x1);
+			rtpcs_93xx_sds_usxgmii_config(sds, 0x03, 0xa4, 0, 1, 0x1);
 		break;
 
 	default:


### PR DESCRIPTION
This series improves the USXGMII config for RTL93xx devices, making the RTL930x code generic and therefore usable for RTL931x, moving autoneg enable where it belongs and adding a few configuration values.

Tested on: XGS1250-12 A1 (RTL930x) and XS1930-10 (RTL931x)