### PR TITLE
wireguard-tools: add default for endpoint_port

### DIFF
--- a/package/network/utils/wireguard-tools/files/wireguard_watchdog
+++ b/package/network/utils/wireguard-tools/files/wireguard_watchdog
@@ -28,7 +28,7 @@ check_peer_activity() {
   config_get_bool disabled "${cfg}" "disabled" 0
   config_get public_key "${cfg}" "public_key"
   config_get endpoint_host "${cfg}" "endpoint_host"
-  config_get endpoint_port "${cfg}" "endpoint_port"
+  config_get endpoint_port "${cfg}" "endpoint_port" "51820"
 
   if [ "${disabled}" -eq 1 ]; then
     # skip disabled peers


### PR DESCRIPTION
If the Endpoint Port is not configured, which marked as optional, the variable endpoint_port contains an empty string which leads to the issue as follows if the connection needs to be fixed.

  Unable to find port of endpoint: `example.com:'

Closes #12525 