### PR TITLE
qualcommax: ipq807x: add Zyxel WAX510D/WAX610D

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq807x
@@ -32,7 +32,9 @@ compex,wpq873|\
 edgecore,eap102|\
 zyxel,nbg7815|\
 zyxel,nwa110ax|\
-zyxel,nwa210ax)
+zyxel,nwa210ax|\
+zyxel,wax510d|\
+zyxel,wax610d)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x10000"
 	;;
 asus,rt-ax89x|\

--- a/package/utils/zyxel-bootconfig-ipq807x/files/95_apply_bootconfig
+++ b/package/utils/zyxel-bootconfig-ipq807x/files/95_apply_bootconfig
@@ -3,7 +3,9 @@ apply_bootconfig() {
 
 	case $(board_name) in
 	zyxel,nwa110ax|\
-	zyxel,nwa210ax)
+	zyxel,nwa210ax|\
+	zyxel,wax510d|\
+	zyxel,wax610d)
 		status="$(zyxel-bootconfig-ipq807x show | awk '/image0:/ {print $2}')"
 		[ "$status" != "selected" ] && zyxel-bootconfig-ipq807x --force set image0
 		;;

--- a/target/linux/qualcommax/dts/ipq8070-nwa110ax-wax510d.dtsi
+++ b/target/linux/qualcommax/dts/ipq8070-nwa110ax-wax510d.dtsi
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (c) 2026 Michael Lotz <mmlr@mlotz.ch>
+ */
+
+#include "ipq807x-nwax10ax.dtsi"
+
+/ {
+	aliases {
+		ethernet0 = &dp1;
+		label-mac-device = &dp1;
+	};
+};
+
+&switch {
+	switch_lan_bmp = <ESS_PORT1>;
+	switch_mac_mode = <MAC_MODE_SGMII0_RGMII4>;
+};
+
+&dp1 {
+	label = "uplink";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&label_mac 0>;
+};
+
+&wifi {
+	qcom,ath11k-calibration-variant = "Zyxel-NWA110AX";
+};

--- a/target/linux/qualcommax/dts/ipq8070-wax510d.dts
+++ b/target/linux/qualcommax/dts/ipq8070-wax510d.dts
@@ -8,6 +8,6 @@
 #include "ipq8070-nwa110ax-wax510d.dtsi"
 
 / {
-	model = "Zyxel NWA110AX";
-	compatible = "zyxel,nwa110ax", "qcom,ipq8074";
+	model = "Zyxel WAX510D";
+	compatible = "zyxel,wax510d", "qcom,ipq8074";
 };

--- a/target/linux/qualcommax/dts/ipq8071-nwa210ax-wax610d.dtsi
+++ b/target/linux/qualcommax/dts/ipq8071-nwa210ax-wax610d.dtsi
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/*
+ * Copyright (c) 2025 Pascal Beleiu <pascal@beleiu.de>
+ * Copyright (c) 2025 Eric Schäfer <eric@es86.de>
+ */
+
+#include "ipq807x-nwax10ax.dtsi"
+
+/ {
+	aliases {
+		ethernet0 = &dp5;
+		ethernet1 = &dp1;
+		label-mac-device = &dp5;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		gpio_green {
+			gpios = <&tlmm 50 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		gpio_red {
+			gpios = <&tlmm 51 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-pins {
+		pins = "gpio30";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+};
+
+&switch {
+	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT5)>;
+	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
+	switch_mac_mode1 = <MAC_MODE_SGMII_PLUS>;
+};
+
+&phyinfo {
+	port@5 {
+		port_id = <5>;
+		phy_address = <16>;
+		port_mac_sel = "QGMAC_PORT";
+	};
+};
+
+&mdio {
+	qca8081: ethernet-phy@16 {
+		compatible = "ethernet-phy-id004d.d101";
+		reg = <16>;
+		reset-deassert-us = <10000>;
+		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&dp1 {
+	label = "lan1";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&label_mac 1>;
+};
+
+&dp5 {
+	status = "okay";
+	phy-handle = <&qca8081>;
+	phy-mode = "sgmii";
+	label = "uplink";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&label_mac 0>;
+};
+
+&wifi {
+	qcom,ath11k-calibration-variant = "Zyxel-NWA210AX";
+};

--- a/target/linux/qualcommax/dts/ipq8071-nwa210ax.dts
+++ b/target/linux/qualcommax/dts/ipq8071-nwa210ax.dts
@@ -6,84 +6,9 @@
 
 /dts-v1/;
 
-#include "ipq807x-nwax10ax.dtsi"
+#include "ipq8071-nwa210ax-wax610d.dtsi"
 
 / {
 	model = "Zyxel NWA210AX";
 	compatible = "zyxel,nwa210ax", "qcom,ipq8074";
-
-	aliases {
-		ethernet0 = &dp5;
-		ethernet1 = &dp1;
-		label-mac-device = &dp5;
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		gpio_green {
-			gpios = <&tlmm 50 GPIO_ACTIVE_HIGH>;
-			default-state = "off";
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		gpio_red {
-			gpios = <&tlmm 51 GPIO_ACTIVE_HIGH>;
-			default-state = "off";
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-		};
-	};
-};
-
-&tlmm {
-	button_pins: button-pins {
-		pins = "gpio30";
-		function = "gpio";
-		drive-strength = <8>;
-		bias-pull-up;
-	};
-};
-
-&switch {
-	switch_lan_bmp = <(ESS_PORT1 | ESS_PORT5)>;
-	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
-	switch_mac_mode1 = <MAC_MODE_SGMII_PLUS>;
-};
-
-&phyinfo {
-	port@5 {
-		port_id = <5>;
-		phy_address = <16>;
-		port_mac_sel = "QGMAC_PORT";
-	};
-};
-
-&mdio {
-	qca8081: ethernet-phy@16 {
-		compatible = "ethernet-phy-id004d.d101";
-		reg = <16>;
-		reset-deassert-us = <10000>;
-		reset-gpios = <&tlmm 44 GPIO_ACTIVE_LOW>;
-	};
-};
-
-&dp1 {
-	label = "lan1";
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&label_mac 1>;
-};
-
-&dp5 {
-	status = "okay";
-	phy-handle = <&qca8081>;
-	phy-mode = "sgmii";
-	label = "uplink";
-	nvmem-cell-names = "mac-address";
-	nvmem-cells = <&label_mac 0>;
-};
-
-&wifi {
-	qcom,ath11k-calibration-variant = "Zyxel-NWA210AX";
 };

--- a/target/linux/qualcommax/dts/ipq8071-wax610d.dts
+++ b/target/linux/qualcommax/dts/ipq8071-wax610d.dts
@@ -5,9 +5,9 @@
 
 /dts-v1/;
 
-#include "ipq8070-nwa110ax-wax510d.dtsi"
+#include "ipq8071-nwa210ax-wax610d.dtsi"
 
 / {
-	model = "Zyxel NWA110AX";
-	compatible = "zyxel,nwa110ax", "qcom,ipq8074";
+	model = "Zyxel WAX610D";
+	compatible = "zyxel,wax610d", "qcom,ipq8074";
 };

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -605,7 +605,7 @@ define Device/zyxel_nbg7815
 endef
 TARGET_DEVICES += zyxel_nbg7815
 
-define Device/zyxel_nwax10ax_common
+define Device/zyxel_nwa_wax_common
 	$(call Device/FitImage)
 	$(call Device/UbiFit)
 	DEVICE_VENDOR := Zyxel
@@ -614,24 +614,47 @@ define Device/zyxel_nwax10ax_common
 	IMAGE_SIZE := 61440k
 	IMAGES += factory.bin
 	IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE) | zyxel-nwax10ax-fit
+	DEVICE_PACKAGES := zyxel-bootconfig-ipq807x kmod-leds-lp5562
+endef
+
+define Device/zyxel_nwa110ax_wax510d_common
+	$(call Device/zyxel_nwa_wax_common)
+	DEVICE_DTS_CONFIG := config@ac01
+	SOC := ipq8070
+	DEVICE_PACKAGES += ipq-wifi-zyxel_nwa110ax
+endef
+
+define Device/zyxel_nwa210ax_wax610d_common
+	$(call Device/zyxel_nwa_wax_common)
+	DEVICE_DTS_CONFIG := config@ac02
+	SOC := ipq8071
+	DEVICE_PACKAGES += ipq-wifi-zyxel_nwa210ax
 endef
 
 define Device/zyxel_nwa110ax
-	$(call Device/zyxel_nwax10ax_common)
+	$(call Device/zyxel_nwa110ax_wax510d_common)
 	DEVICE_MODEL := NWA110AX
-	DEVICE_DTS_CONFIG := config@ac01
-	SOC := ipq8070
-	DEVICE_PACKAGES := ipq-wifi-zyxel_nwa110ax zyxel-bootconfig-ipq807x kmod-leds-lp5562
 	ZYXEL_MODEL_ID := 59 e1
 endef
 TARGET_DEVICES += zyxel_nwa110ax
 
 define Device/zyxel_nwa210ax
-	$(call Device/zyxel_nwax10ax_common)
+	$(call Device/zyxel_nwa210ax_wax610d_common)
 	DEVICE_MODEL := NWA210AX
-	DEVICE_DTS_CONFIG := config@ac02
-	SOC := ipq8071
-	DEVICE_PACKAGES := ipq-wifi-zyxel_nwa210ax zyxel-bootconfig-ipq807x kmod-leds-lp5562
 	ZYXEL_MODEL_ID := 5c e1
 endef
 TARGET_DEVICES += zyxel_nwa210ax
+
+define Device/zyxel_wax510d
+	$(call Device/zyxel_nwa110ax_wax510d_common)
+	DEVICE_MODEL := WAX510D
+	ZYXEL_MODEL_ID := 56 e1
+endef
+TARGET_DEVICES += zyxel_wax510d
+
+define Device/zyxel_wax610d
+	$(call Device/zyxel_nwa210ax_wax610d_common)
+	DEVICE_MODEL := WAX610D
+	ZYXEL_MODEL_ID := 5b e1
+endef
+TARGET_DEVICES += zyxel_wax610d

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -74,10 +74,12 @@ ipq807x_setup_interfaces()
 	zyxel,nbg7815)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4 10g" "wan"
 		;;
-	zyxel,nwa110ax)
+	zyxel,nwa110ax|\
+	zyxel,wax510d)
 		ucidef_set_interface_lan "uplink" "dhcp"
 		;;
-	zyxel,nwa210ax)
+	zyxel,nwa210ax|\
+	zyxel,wax610d)
 		ucidef_set_interface_lan "uplink lan1" "dhcp"
 		;;
 	*)
@@ -114,7 +116,9 @@ ipq807x_setup_macs()
 		lan_mac=$label_mac
 		;;
 	zyxel,nwa110ax|\
-	zyxel,nwa210ax)
+	zyxel,nwa210ax|\
+	zyxel,wax510d|\
+	zyxel,wax610d)
 		label_mac=$(get_mac_label_dt)
 		lan_mac=$label_mac
 		;;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -141,14 +141,16 @@ case "$FIRMWARE" in
 		ath11k_patch_mac $(macaddr_add $label_mac 4) 2
 		ath11k_set_macflag
 		;;
-	zyxel,nwa110ax)
+	zyxel,nwa110ax|\
+	zyxel,wax510d)
 		caldata_extract "0:art" 0x1000 0x20000
 		label_mac=$(get_mac_label)
 		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
 		ath11k_patch_mac $(macaddr_add $label_mac 1) 1
 		ath11k_set_macflag
 		;;
-	zyxel,nwa210ax)
+	zyxel,nwa210ax|\
+	zyxel,wax610d)
 		caldata_extract "0:art" 0x1000 0x20000
 		label_mac=$(get_mac_label)
 		ath11k_patch_mac $(macaddr_add $label_mac 3) 0

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -188,7 +188,9 @@ platform_do_upgrade() {
 	netgear,wax620|\
 	netgear,wax630|\
 	zyxel,nwa110ax|\
-	zyxel,nwa210ax)
+	zyxel,nwa210ax|\
+	zyxel,wax510d|\
+	zyxel,wax610d)
 		nand_do_upgrade "$1"
 		;;
 	asus,rt-ax89x)


### PR DESCRIPTION
The Zyxel WAX510D is the same physical device as the NWA110AX. Likewise the WAX610D is the same physical device as the NWA210AX. The difference between the models is only in the stock firmware features. This commit factors out a common DTS and build definition for each pair of devices.

Hardware:
* SoC: Qualcomm IPQ8070A (WAX510D) or IPQ8071A (WAX610D)
* RAM: 1GiB 1x Samsung K4A8G165WC-BCTD
* Flash: 8MiB Winbond W25Q64DW SPI-NOR, 256MiB Winbond W29N02GZ SPI-NAND
* WLAN 2.4GHz: QCN5024 2x2:2 802.11b/g/n/ax
* WLAN 5GHz: QCN5054 2x2:2 (WAX510D) or 4x4:4 (WAX610D) 802.11n/ac/ax
* Ethernet: 1x 1GbE with AR8033 PHY, 1x 2.5GbE with QCA8081 on WAX610D only
* Serial Config: 3.3V TTL 115200-8-N-1, externally accessible
* Serial Layout: GND TX RX 3.3V (don't connect, marked with triangle)
* LEDs: 1x red, 1x green, 1x blue, 1x white
* Buttons: 1x reset

MAC addresses WAX510D:
* Uplink: base address on label
* 2.4GHz WLAN: base + 1
* 5GHz WLAN: base + 2

MAC addresses WAX610D:
* Uplink: base address on label
* LAN1: base + 1
* 2.4GHz WLAN: base + 2
* 5GHz WLAN: base + 3

MAC address offsets verified against stock firmware.

Flashing Notes:
The devices use a dual-image setup and OpenWrt can only be installed as image 0. When the currently running stock firmware is image 0, OpenWrt will be installed as image 1, may or may not boot into OpenWrt and the return to stock firmware after the next reboot. If this happens, install any version of stock firmware so that it runs as image 1, before installing OpenWrt. Alternatively, if there already is a valid stock firmware in image 1, the "debug dual-image show" and
"debug dual-image set boot-image image1" commands can be used in the stock CLI via serial/SSH/telnet to switch to image 1.

Flashing with Stock Web Interface:
* Get the OpenWrt factory image and rename it to a shorter name, for example "openwrt.bin" (the stock firmware has a character limit)
* In the web interface, go to "Maintenance" -> "File Manager" -> "Firmware Package" (or click the link next to "Firmware Version" under "Device Information" on the dashboard)
* Under "Upload File" browse to the renamed OpenWrt factory image and click on "Upload"

Switch between Firmware:
* OpenWrt to stock: "zyxel-bootconfig-ipq807x set image1"
* Stock to OpenWrt: "debug dual-image set boot-image image0"

Unbrick / Revert to Stock with the Boot Module:
* Disconnect the device from power
* Configure your machine to 192.168.1.103/24 and start a TFTP server
* Put the stock firmware image into the TFTP server root and rename it to "ZLD-current"
* Establish a serial connection to the device through the console port
* Connect the device to power
* When prompted, press a key to abort automatic boot and enter debug mode
* Use the "atnz" command to flash the firmware image
* Use the "atgo" command to boot from the newly flashed image

---

The above factory flash, unbrick/revert and firmware switching steps have been tested on both the WAX510D and WAX610D. The change has also been verified to not break the NWA110AX, but couldn't be verified against NWA210AX for lack of hardware.