### PR TITLE
chromium: Add #{address,size}-cells to /firmware

### DIFF
--- a/target/linux/ipq40xx/dts/qcom-ipq4019-wifi.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-wifi.dts
@@ -31,6 +31,11 @@
 		stdout-path = &blsp1_uart1;
 	};
 
+	firmware {
+		#address-cells = <1>;
+		#size-cells = <1>;
+	};
+
 	memory {
 		device_type = "memory";
 		reg = <0x80000000 0x20000000>; /* 512MB */

--- a/target/linux/ipq806x/dts/qcom-ipq8064-onhub.dtsi
+++ b/target/linux/ipq806x/dts/qcom-ipq8064-onhub.dtsi
@@ -20,6 +20,11 @@
 		stdout-path = "serial0:115200n8";
 	};
 
+	firmware {
+		#address-cells = <1>;
+		#size-cells = <1>;
+	};
+
 	reserved-memory {
 		#address-cells = <1>;
 		#size-cells = <1>;


### PR DESCRIPTION
Commit b4d7263bc3b6 ("kernel: of: avoid some unnecessary bad cell count warnings") backported Linux commit 6e5773d52f4a ("of/address: Fix WARN when attempting translating non-translatable addresses"), which started requiring `#address-cells` for a device's parent if we want to use the reg resource in a device node.

Many Chromium devices use a `/firmware/coreboot` device node that is patched in by the boot firmware. These structures look something like:

```
  # find /sys/firmware/devicetree/base/firmware/
  /sys/firmware/devicetree/base/firmware/
  /sys/firmware/devicetree/base/firmware/scm
  /sys/firmware/devicetree/base/firmware/scm/compatible
  /sys/firmware/devicetree/base/firmware/scm/name
  /sys/firmware/devicetree/base/firmware/ranges
  /sys/firmware/devicetree/base/firmware/chromeos
  /sys/firmware/devicetree/base/firmware/chromeos/fmap-offset
  /sys/firmware/devicetree/base/firmware/chromeos/compatible
  /sys/firmware/devicetree/base/firmware/chromeos/readonly-firmware-version
  /sys/firmware/devicetree/base/firmware/chromeos/nonvolatile-context-storage
  /sys/firmware/devicetree/base/firmware/chromeos/hardware-id
  /sys/firmware/devicetree/base/firmware/chromeos/firmware-type
  /sys/firmware/devicetree/base/firmware/chromeos/vboot-shared-data
  /sys/firmware/devicetree/base/firmware/chromeos/nonvolatile-context-offset
  /sys/firmware/devicetree/base/firmware/chromeos/firmware-version
  /sys/firmware/devicetree/base/firmware/chromeos/nonvolatile-context-size
  /sys/firmware/devicetree/base/firmware/chromeos/name
  /sys/firmware/devicetree/base/firmware/coreboot
  /sys/firmware/devicetree/base/firmware/coreboot/compatible
  /sys/firmware/devicetree/base/firmware/coreboot/board-id
  /sys/firmware/devicetree/base/firmware/coreboot/reg
  /sys/firmware/devicetree/base/firmware/coreboot/name
  /sys/firmware/devicetree/base/firmware/name
```

Notably, there is no `#{address,size}-cells` in `/firmware`.

This breaks any driver relying on a device under /firmware, such as the coreboot_table driver.

This is technically an ill-formatted FDT, and so we might as well just add the properties ourselves.

---

Regression: https://github.com/openwrt/openwrt/pull/20942
Resolves: https://github.com/openwrt/openwrt/issues/21243