### PR TITLE
ath79: improve supported_devices lists referencing

### DIFF
--- a/target/linux/ath79/image/generic-ubnt.mk
+++ b/target/linux/ath79/image/generic-ubnt.mk
@@ -273,7 +273,7 @@ define Device/ubnt_unifi-ap-lr
   $(Device/ubnt-bz)
   DEVICE_MODEL := UniFi AP
   DEVICE_VARIANT := LR
-  SUPPORTED_DEVICES += unifi ubnt,unifi ubnt,unifi-ap
+  SUPPORTED_DEVICES += unifi ubnt,unifi
 endef
 TARGET_DEVICES += ubnt_unifi-ap-lr
 
@@ -289,7 +289,7 @@ define Device/ubnt_unifiac-lr
   $(Device/ubnt_unifiac)
   DEVICE_MODEL := UniFi AC LR
   DEVICE_PACKAGES += -swconfig
-  SUPPORTED_DEVICES += unifiac-lite ubnt,unifiac-lite
+  SUPPORTED_DEVICES += unifiac-lite
 endef
 TARGET_DEVICES += ubnt_unifiac-lr
 

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1534,7 +1534,7 @@ define Device/engenius_esr1200
   IMAGE/factory.dlf := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | check-size | \
 	senao-header -r 0x101 -p 0x61 -t 2
-  SUPPORTED_DEVICES += esr1200 esr1750 engenius,esr1750
+  SUPPORTED_DEVICES += esr1200 esr1750
 endef
 TARGET_DEVICES += engenius_esr1200
 
@@ -1548,7 +1548,7 @@ define Device/engenius_esr1750
   IMAGE/factory.dlf := append-kernel | pad-to $$$$(BLOCKSIZE) | \
 	append-rootfs | pad-rootfs | check-size | \
 	senao-header -r 0x101 -p 0x62 -t 2
-  SUPPORTED_DEVICES += esr1750 esr1200 engenius,esr1200
+  SUPPORTED_DEVICES += esr1750 esr1200
 endef
 TARGET_DEVICES += engenius_esr1750
 

--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -150,14 +150,13 @@ define Device/glinet_gl-ar300m-nand
   IMAGES += factory.img
   IMAGE/factory.img := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  SUPPORTED_DEVICES += glinet,gl-ar300m-nor
 endef
 TARGET_DEVICES += glinet_gl-ar300m-nand
 
 define Device/glinet_gl-ar300m-nor
   $(Device/glinet_gl-ar300m-common-nand)
   DEVICE_VARIANT := NOR
-  SUPPORTED_DEVICES += glinet,gl-ar300m-nand gl-ar300m
+  SUPPORTED_DEVICES += gl-ar300m
 endef
 TARGET_DEVICES += glinet_gl-ar300m-nor
 
@@ -175,14 +174,13 @@ define Device/glinet_gl-ar750s-nor-nand
   DEVICE_VARIANT := NOR/NAND
   KERNEL_SIZE := 4096k
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  SUPPORTED_DEVICES += glinet,gl-ar750s-nor
 endef
 TARGET_DEVICES += glinet_gl-ar750s-nor-nand
 
 define Device/glinet_gl-ar750s-nor
   $(Device/glinet_gl-ar750s-common)
   DEVICE_VARIANT := NOR
-  SUPPORTED_DEVICES += gl-ar750s glinet,gl-ar750s glinet,gl-ar750s-nor-nand
+  SUPPORTED_DEVICES += gl-ar750s glinet,gl-ar750s
 endef
 TARGET_DEVICES += glinet_gl-ar750s-nor
 


### PR DESCRIPTION
Several ath79 device profiles include another profile's primary DTS compatible string in their SUPPORTED_DEVICES list. This causes ASU (Attended Sysupgrade) to build a wrong mapping, since its flat supported_device-to-profile dictionary gets overwritten by whichever profile is processed last.

Remove cross-references where a profile's SUPPORTED_DEVICES += entry matches another profile's auto-derived primary identifier (the device name with underscores converted to commas). Shared legacy compatibility strings that are not another profile's primary are kept.

Affected devices:
- EnGenius ESR1200/ESR1750: mutual cross-references between devices with different SoCs (qca9557 vs qca9558), which could also cause sysupgrade to accept an incompatible image.
- GL.iNet GL-AR300M NOR/NAND: mutual cross-references between flash variants.
- GL.iNet GL-AR750S NOR/NOR-NAND: same pattern as GL-AR300M.
- Ubiquiti UniFi AP LR: referenced ubnt,unifi-ap (the AP's primary).
- Ubiquiti UniFi AC LR: referenced ubnt,unifiac-lite (the AC Lite's primary).

This is the same class of bug fixed for the GL-MT2500 in commit b71f4665cd ("mediatek: filogic: fix supported_devices list for gl-mt2500").

Fixes: https://github.com/openwrt/asu/issues/1525