### PR TITLE
wifi-scripts: add EHT options to hostapd config

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-device.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-device.json
@@ -153,6 +153,21 @@
 			"type": "boolean",
 			"default": true
 		},
+		"eht_mu_beamformer": {
+			"description": "EHT multiple user beamformer support",
+			"type": "boolean",
+			"default": true
+		},
+		"eht_su_beamformee": {
+			"description": "EHT single user beamformee support",
+			"type": "boolean",
+			"default": true
+		},
+		"eht_su_beamformer": {
+			"description": "EHT single user beamformer support",
+			"type": "boolean",
+			"default": true
+		},
 		"enable_background_radar": {
 			"description": "This feature allows CAC to be run on dedicated radio RF chains",
 			"type": "boolean"

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -448,8 +448,21 @@ function device_htmode_append(config) {
 	}
 
 	if (wildcard(config.htmode, 'EHT*')) {
+		let eht_phy_cap = phy_capabilities.eht_phy_cap;
+
 		config.ieee80211be = true;
-		append_vars(config, [ 'ieee80211be' ]);
+
+		if(!(eht_phy_cap[0] & 0x20))
+			config.eht_su_beamformer = false;
+		if(!(eht_phy_cap[0] & 0x40))
+			config.eht_su_beamformee = false;
+		if(!(eht_phy_cap[7] & 0x70))
+			config.eht_mu_beamformer = false;
+
+		append_vars(config, [
+			'ieee80211be', 'eht_su_beamformer', 'eht_su_beamformee',
+			'eht_mu_beamformer',
+		]);
 
 		if (config.hw_mode == 'a')
 			append_vars(config, [ 'eht_oper_chwidth', 'eht_oper_centr_freq_seg0_idx' ]);
@@ -475,6 +488,7 @@ function device_capabilities(config) {
 			continue;
 		phy_capabilities.he_mac_cap = iftype.he_cap_mac;
 		phy_capabilities.he_phy_cap = iftype.he_cap_phy;
+		phy_capabilities.eht_phy_cap = iftype.eht_cap_phy;
 	}
 
 	phy_features.ftm_responder = device_extended_features(phy.extended_features, NL80211_EXT_FEATURE_ENABLE_FTM_RESPONDER);

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -448,8 +448,21 @@ function device_htmode_append(config) {
 	}
 
 	if (wildcard(config.htmode, 'EHT*')) {
+		let eht_phy_cap = phy_capabilities.eht_phy_cap;
+
 		config.ieee80211be = true;
-		append_vars(config, [ 'ieee80211be' ]);
+
+		if (!(eht_phy_cap[0] & 0x20))
+			config.eht_su_beamformer = false;
+		if (!(eht_phy_cap[0] & 0x40))
+			config.eht_su_beamformee = false;
+		if (!(eht_phy_cap[7] & 0x70))
+			config.eht_mu_beamformer = false;
+
+		append_vars(config, [
+			'ieee80211be', 'eht_su_beamformer', 'eht_su_beamformee',
+			'eht_mu_beamformer',
+		]);
 
 		if (config.hw_mode == 'a')
 			append_vars(config, [ 'eht_oper_chwidth', 'eht_oper_centr_freq_seg0_idx' ]);
@@ -472,11 +485,13 @@ function device_capabilities(config) {
 	phy_capabilities.vht_capa = band.vht_capa ?? 0;
 	phy_capabilities.he_mac_cap = [];
 	phy_capabilities.he_phy_cap = [];
+	phy_capabilities.eht_phy_cap = [];
 	for (let iftype in band.iftype_data) {
 		if (!iftype.iftypes.ap)
 			continue;
 		phy_capabilities.he_mac_cap = iftype.he_cap_mac;
 		phy_capabilities.he_phy_cap = iftype.he_cap_phy;
+		phy_capabilities.eht_phy_cap = iftype.eht_cap_phy;
 	}
 
 	phy_features.ftm_responder = device_extended_features(phy.extended_features, NL80211_EXT_FEATURE_ENABLE_FTM_RESPONDER);


### PR DESCRIPTION
Some EHT options like beamformer/beamformee
are disabled by default in hostapd.conf

Read the EHT Phy Cap structure and enable/disable
switches within the hostapd.conf for capable hardware.

Without this EHT SU beamformer/beamformee and MU
beamformer capabilities are omitted from AP beacons,
even if the driver reports the hardware as capable.
