### PR TITLE
[25.12] filogic: add support for D-Link AQUILA PRO AI E30

### DIFF
--- a/include/image-commands.mk
+++ b/include/image-commands.mk
@@ -324,7 +324,7 @@ define Build/copy-file
 endef
 
 # Create a header for a D-Link AI series recovery image and add it at the beginning of the image
-# Currently supported: AQUILA M30, EAGLE M32 and R32
+# Currently supported: AQUILA E30 and M30, EAGLE M32 and R32
 # Arguments:
 # 1: Start string of the header
 # 2: Firmware version

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -116,6 +116,7 @@ comfast,cf-e393ax|\
 iptime,ax3000m)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x80000"
 	;;
+dlink,aquila-pro-ai-e30-a1|\
 dlink,aquila-pro-ai-m30-a1|\
 dlink,aquila-pro-ai-m60-a1)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x40000"

--- a/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-e30-a1.dts
+++ b/target/linux/mediatek/dts/mt7981b-dlink-aquila-pro-ai-e30-a1.dts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "D-Link AQUILA PRO AI E30 A1";
+	compatible = "dlink,aquila-pro-ai-e30-a1", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac1;
+		led-boot = &led_status_white;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_white;
+		led-upgrade = &led_status_blue;
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	status = "okay";
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+		label = "lan";
+
+		nvmem-cells = <&macaddr_odm 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x3200000>;
+			};
+
+			partition@3780000 {
+				label = "ubi1";
+				reg = <0x3780000 0x3200000>;
+				read-only;
+			};
+
+			partition@6980000 {
+				label = "Odm";
+				reg = <0x6980000 0x40000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_odm: macaddr@8f {
+						compatible = "mac-base";
+						reg = <0x8f 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+
+			};
+
+			partition@69c0000 {
+				label = "Config1";
+				reg = <0x69c0000 0x80000>;
+				read-only;
+			};
+
+			partition@6a40000 {
+				label = "Config2";
+				reg = <0x6a40000 0x80000>;
+				read-only;
+			};
+
+			partition@6ac0000 {
+				label = "Storage";
+				reg = <0x6ac0000 0xA00000>;
+				read-only;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_00>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_00>;
+		};
+	};
+
+	i2c_pins_g0: i2c-pins-g0 {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+};
+
+&wifi {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_odm 1>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&i2c0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c_pins_g0>;
+
+	gca230718@40 {
+		compatible = "unknown,gca230718";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x40>;
+
+		led_status_red: led@0 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			reg = <0>;
+		};
+
+		led@1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			reg = <1>;
+		};
+
+		led_status_blue: led@2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			reg = <2>;
+		};
+
+		led_status_white: led@3 {
+			color = <LED_COLOR_ID_WHITE>;
+			function = LED_FUNCTION_STATUS;
+			reg = <3>;
+		};
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -147,6 +147,9 @@ mediatek_setup_interfaces()
 	openwrt,one)
 		ucidef_set_interfaces_lan_wan eth1 eth0
 		;;
+	dlink,aquila-pro-ai-e30-a1)
+		ucidef_set_interface_lan "lan"
+		;;
 	dlink,aquila-pro-ai-m30-a1|\
 	dlink,aquila-pro-ai-m60-a1)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" internet

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -174,6 +174,7 @@ platform_do_upgrade() {
 	yuncore,ax835)
 		default_do_upgrade "$1"
 		;;
+	dlink,aquila-pro-ai-e30-a1|\
 	dlink,aquila-pro-ai-m30-a1|\
 	dlink,aquila-pro-ai-m60-a1)
 		fw_setenv sw_tryactive 0

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1353,6 +1353,26 @@ define Device/cudy_wbr3000uax-v1-ubootmod
 endef
 TARGET_DEVICES += cudy_wbr3000uax-v1-ubootmod
 
+define Device/dlink_aquila-pro-ai-e30-a1
+  DEVICE_VENDOR := D-Link
+  DEVICE_MODEL := AQUILA PRO AI E30
+  DEVICE_VARIANT := A1
+  DEVICE_DTS := mt7981b-dlink-aquila-pro-ai-e30-a1
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-leds-gca230718 kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+  KERNEL_IN_UBI := 1
+  IMAGE_SIZE := 51200k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+ifeq ($(IB),)
+ifneq ($(CONFIG_TARGET_ROOTFS_INITRAMFS),)
+  IMAGES += recovery.bin
+  IMAGE/recovery.bin := append-image-stage initramfs-kernel.bin | sysupgrade-tar kernel=$$$$@ |\
+    pad-to $$(IMAGE_SIZE) | dlink-ai-recovery-header DLK6E6110002 \x6A\x28\xEE\x0B \x00\x00\x2C\x00 \x00\x00\x20\x03 \x61\x6E
+endif
+endif
+endef
+TARGET_DEVICES += dlink_aquila-pro-ai-e30-a1
+
 define Device/dlink_aquila-pro-ai-m30-a1
   DEVICE_VENDOR := D-Link
   DEVICE_MODEL := AQUILA PRO AI M30


### PR DESCRIPTION
Specification:
The device is similar to the M30 but has only one LAN port and no WAN port.

- MT7981 CPU using 2.4GHz and 5GHz WiFi (both AX)
- 512MB RAM
- 128MB NAND flash with two UBI partitions with identical size
- 1 multi color LED (red, green, blue, white) connected via GCA230718
- 2 buttons (WPS, reset, LED)
- 1 1Gbit LAN port

Disassembly:
- There are two screws at the power connector which must be removed. Afterwards the top case can be removed (it is clipped on, so some tools are required).

Serial Interface:
- The serial interface can be connected to the 4 pin holes on the board. Do NOT connect VCC.
- The pins are labelled on the PCB (RX, TX, GND)
- Settings: 115200, 8N1

MAC addresses:
- LAN MAC is stored in partition "Odm" at offset 0x8f
- WLAN MAC (2.4 GHz and 5GHz) is LAN MAC + 1

Reverting back to OEM firmware:
- There is currently no easy way to revert back to the OEM image
- The methods from M30 and M60 doesn't seem to work anymore
- If you plan to revert back to OEM firmware later, do the following steps before flashing OpenWrt:
  - Boot from initramfs as described in "Flashing via U-Boot" but don't flash anything
  - Instead, make a backup of UBI and UBI1 partition
  - The created dumps must be written to the initial partitions to revert back to OEM

Flashing via Recovery Web Interface:
- Set your IP address to 192.168.200.10, subnetmask 255.255.255.0
- Press the reset button while powering on the device
- Keep the reset button pressed until the LED blinks red
- Open a Chromium based and goto http://192.168.200.50/ (recovery web interface)
- Download openwrt-mediatek-filogic-dlink_aquila-pro-ai-e30-a1-squashfs-recovery.bin
- Note: The recovery web interface always reports successful flashing, even if it fails
- After flashing, the recovery web interface will try to forward the browser to 192.168.0.1 (can be ignored)
- If flashing was successful, OpenWrt is accessible via 192.168.1.1
- The recovery image boots an initramfs image, flash the sys upgrade image to get to „normal“ OpenWrt mode

Flashing via U-Boot:
- Open the case, connect to the UART console
- Set your IP address to 192.168.200.2, subnet mask 255.255.255.0. Connect to one of the LAN interfaces of the router
- Run a tftp server which provides openwrt-mediatek-filogic-dlink_aquila-pro-ai-e30-a1-initramfs-kernel.bin
- Supply the board with 12V
- Select "7. Load image" in the U-Boot menu
- Enter image file, tftp server IP and device IP (if they differ from the default).
- TFTP download to RAM will start. After a few seconds OpenWrt initramfs should start
- The initramfs is accessible via 192.168.1.1, change your IP address accordingly (or use multiple IP addresses on your interface)
- Perform a sysupgrade using openwrt-mediatek-filogic-dlink_aquila-pro-ai-e30-a1-squashfs-sysupgrade.bin
- Reboot the device. OpenWrt should start from flash now

Flashing via OEM web interface is not possible, as it will change the active partition and OpenWrt is only running on the first UBI partition.