### PR TITLE
realtek: rtl930x: mcx3: specify RTL8224 reset GPIO

### DIFF
--- a/target/linux/realtek/dts/rtl9302_plasmacloud_mcx3.dts
+++ b/target/linux/realtek/dts/rtl9302_plasmacloud_mcx3.dts
@@ -151,6 +151,10 @@
 };
 
 &mdio_bus0 {
+	reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+	reset-assert-us = <100000>;
+	reset-deassert-us = <100000>;
+
 	PHY_C45(0, 0)
 	PHY_C45(1, 1)
 };


### PR DESCRIPTION
The nRESET pins of the RTL8224 PHY on the MCX3 are wired to GPIO6 of the SoC, but this was never described in the devicetree.

Commit c99a30668d5f ("realtek: add RTL8224 initialization to Realtek driver") introduced support for reinitializing RTL8224 PHYs, and commit 084da38a2e74 ("realtek: mdio: activate multiple busses") allowed the MDIO bus provider load the devicetree properties to the bus, including reset descriptors. With both in place, a bus level PHY reset via the hardware pin is now correctly triggered before reinitialization.

Add the missing reset-gpios property so the PHY can be reset via the hardware pin.