### PR TITLE
[25.12]: Fix ath12k operation under vfio

### DIFF
--- a/package/kernel/mac80211/patches/ath11k/949-wifi-ath11k-skip-PCIe-global-reset-on-initial-power.patch
+++ b/package/kernel/mac80211/patches/ath11k/949-wifi-ath11k-skip-PCIe-global-reset-on-initial-power.patch
@@ -1,0 +1,29 @@
+wifi: ath11k: skip PCIe global reset on initial power-up
+
+Same issue as fixed in ath12k: ath11k_pci_sw_reset() unconditionally
+calls ath11k_pci_soc_global_reset() on both initial power-up and
+shutdown/recovery paths. The global reset drops the PCIe link and depends
+on physical link retraining by the host root complex to restore MMIO
+access.
+
+Under VFIO passthrough, no hardware link retraining occurs and all
+subsequent MMIO reads return 0xffffffff, causing MHI initialization
+to fail.
+
+Skip ath11k_pci_soc_global_reset() when power_on is true, matching
+the fix applied to ath12k.
+
+Signed-off-by: Nazar Mokrynskyi <nazar@mokrynskyi.com>
+
+--- a/drivers/net/wireless/ath/ath11k/pci.c
++++ b/drivers/net/wireless/ath/ath11k/pci.c
+@@ -385,7 +385,8 @@
+
+ 	ath11k_mhi_clear_vector(ab);
+ 	ath11k_pci_clear_dbg_registers(ab);
+-	ath11k_pci_soc_global_reset(ab);
++	if (!power_on)
++		ath11k_pci_soc_global_reset(ab);
+ 	ath11k_mhi_set_mhictrl_reset(ab);
+ }
+

--- a/package/kernel/mac80211/patches/ath12k/900-wifi-ath12k-skip-PCIe-global-reset-on-initial-power.patch
+++ b/package/kernel/mac80211/patches/ath12k/900-wifi-ath12k-skip-PCIe-global-reset-on-initial-power.patch
@@ -1,0 +1,39 @@
+wifi: ath12k: skip PCIe global reset on initial power-up
+
+ath12k_pci_sw_reset() unconditionally calls ath12k_pci_soc_global_reset()
+regardless of whether the device is being powered up for the first time or
+recovering from a previous run. The global reset drops the PCIe link and
+relies on the host root complex to perform physical link retraining before
+the MHI BHI register can be accessed.
+
+When the device is passed through to a VM via VFIO, no physical link
+retraining occurs after the reset since QEMU's virtual PCIe bridge does
+not implement hardware LTSSM negotiation. As a result, all subsequent
+MMIO reads return 0xffffffff and MHI initialization fails with -EREMOTEIO.
+
+On initial power-up, vfio-pci has already performed a Function Level
+Reset before handing the device to the guest driver, placing it in a
+known clean state equivalent to what the global reset achieves. The global
+reset is therefore redundant on power-up and only necessary on the
+shutdown/recovery path where it tears down an already-running firmware.
+
+Skip ath12k_pci_soc_global_reset() when power_on is true to allow MHI
+initialization to succeed under VFIO passthrough without affecting bare
+metal behavior.
+
+Tested-on: QCN9274 hw2.0 PCI WLAN.WBE.1.6-01243-QCAHKSWPL_SILICONZ-1 (KVM/VFIO)
+
+Signed-off-by: Nazar Mokrynskyi <nazar@mokrynskyi.com>
+
+--- a/drivers/net/wireless/ath/ath12k/pci.c
++++ b/drivers/net/wireless/ath/ath12k/pci.c
+@@ -335,7 +335,8 @@
+
+ 	ath12k_mhi_clear_vector(ab);
+ 	ath12k_pci_clear_dbg_registers(ab);
+-	ath12k_pci_soc_global_reset(ab);
++	if (!power_on)
++		ath12k_pci_soc_global_reset(ab);
+ 	ath12k_mhi_set_mhictrl_reset(ab);
+ }
+

--- a/package/kernel/mac80211/patches/ath12k/901-wifi-ath12k-skip-unknown-direct-buffer-ring-module-i.patch
+++ b/package/kernel/mac80211/patches/ath12k/901-wifi-ath12k-skip-unknown-direct-buffer-ring-module-i.patch
@@ -1,0 +1,48 @@
+wifi: ath12k: skip unknown direct buffer ring module IDs
+
+The firmware may advertise direct buffer ring capabilities for module
+IDs beyond what the driver currently knows about (WMI_DIRECT_BUF_MAX).
+This happens with newer firmware versions that support additional ring
+types not yet implemented in the driver.
+
+The current code treats an unknown module_id as a fatal error, returning
+-EINVAL and tearing down the entire driver initialization. This is
+incorrect: the driver only needs to set up rings for types it uses
+(SPECTRAL=0, CFR=1) and can safely ignore capability advertisements for
+unknown types.
+
+Change the unknown module_id handling to skip the entry with a debug
+message rather than failing, allowing initialization to proceed.
+
+Tested-on: QCN9274 hw2.0 PCI WLAN.WBE.1.6-01243-QCAHKSWPL_SILICONZ-1
+
+Signed-off-by: Nazar Mokrynskyi <nazar@mokrynskyi.com>
+
+--- a/drivers/net/wireless/ath/ath12k/wmi.c
++++ b/drivers/net/wireless/ath/ath12k/wmi.c
+@@ -4263,10 +4263,10 @@
+ 	dir_buff_caps = ab->db_caps;
+ 	for (i = 0; i < dma_caps_parse->n_dma_ring_caps; i++) {
+ 		if (le32_to_cpu(dma_caps[i].module_id) >= WMI_DIRECT_BUF_MAX) {
+-			ath12k_warn(ab, "Invalid module id %d\n",
+-				    le32_to_cpu(dma_caps[i].module_id));
+-			ret = -EINVAL;
+-			goto free_dir_buff;
++			ath12k_dbg(ab, ATH12K_DBG_WMI,
++				   "Skipping unknown direct buf ring module id %d\n",
++				   le32_to_cpu(dma_caps[i].module_id));
++			continue;
+ 		}
+
+ 		dir_buff_caps[i].id = le32_to_cpu(dma_caps[i].module_id);
+@@ -4278,10 +4278,6 @@
+ 	}
+
+ 	return 0;
+-
+-free_dir_buff:
+-	ath12k_wmi_free_dbring_caps(ab);
+-	return ret;
+ }
+
+ static int ath12k_wmi_svc_rdy_ext_parse(struct ath12k_base *ab,


### PR DESCRIPTION
I've been struggling with [ath12k](https://forum.openwrt.org/t/qcn9274-crashes-the-system-during-driver-load/239491?u=nazar-pc) and even [ath11k](https://forum.openwrt.org/t/qcn9074-doesnt-initialize-on-x86-64/163288?u=nazar-pc) for years.

With these patches it is finally possible to use QCN9274 under KVM with virtio.

---

First patch avoids global reset, allowing module to power on properly. I also created an identical patch for ath11k since I remember having similar issues there. Without this patch I was getting the following:
```
[    6.856855] ath12k_pci 0000:01:00.0: BAR 0 [mem 0xfc600000-0xfc7fffff 64bit]: assigned
[    6.879292] ath12k_pci 0000:01:00.0: MSI vectors: 16
[    6.883931] ath12k_pci 0000:01:00.0: Hardware name: qcn9274 hw2.0
[    6.990901] ath12k_pci 0000:01:00.0: link down error during global reset
[    7.998602] ath12k_pci 0000:01:00.0: link failed to recover after global reset
[    8.011545] mhi mhi0: BHI offset: 0xffffffff is out of range: 0x200000
[    8.013095] ath12k_pci 0000:01:00.0: failed to set mhi state: INIT(0)
[    8.014588] ath12k_pci 0000:01:00.0: failed to start mhi: -34
[    8.016025] ath12k_pci 0000:01:00.0: failed to power up :-34
[    8.050113] ath12k_pci 0000:01:00.0: failed to create soc 0 core: -34
[    8.053079] ath12k_pci 0000:01:00.0: unable to create hw group
[    8.090241] ath12k_pci 0000:01:00.0: failed to init core: -34
[    8.554526] ath12k_pci 0000:01:00.0: probe with driver ath12k_pci failed with error -34
```

With the patch the process goes further:
```
[    6.897009] ath12k_pci 0000:01:00.0: BAR 0 [mem 0xfc600000-0xfc7fffff 64bit]: assigned
[    6.906501] ath12k_pci 0000:01:00.0: MSI vectors: 16
[    6.909033] ath12k_pci 0000:01:00.0: Hardware name: qcn9274 hw2.0
[    6.959630] mhi mhi0: Requested to power ON
[    6.960899] mhi mhi0: Power on setup success
[    7.128588] mhi mhi0: Wait for device to enter SBL or Mission mode
[    7.659325] ath12k_pci 0000:01:00.0: qmi dma allocation failed (20971520 B type 1), will try later with small size
[    7.670187] ath12k_pci 0000:01:00.0: memory type 10 not supported
[    7.674957] kmodloader: done loading kernel modules from /etc/modules.d/*
[    7.683773] ath12k_pci 0000:01:00.0: chip_id 0x0 chip_family 0xb board_id 0x1019 soc_id 0x401a2200
[    7.688137] ath12k_pci 0000:01:00.0: fw_version 0x160484db fw_build_timestamp 2025-12-09 20:09 fw_build_id QC_IMAGE_VERSION_STRING=WLAN.WBE.1.6-01243-QCAHKSWPL_SILICONZ-1
[   10.611560] ath12k_pci 0000:01:00.0: Invalid module id 2
[   10.616467] ath12k_pci 0000:01:00.0: failed to parse tlv -22
[   10.747508] debugfs: File 'simulate_fw_crash' in directory 'pci-0000:01:00.0' already present!
[   10.752188] debugfs: File 'device_dp_stats' in directory 'pci-0000:01:00.0' already present!
[   10.770705] ieee80211 phy0: copying sband (band 1) due to VHT EXT NSS BW flag
[   10.774844] debugfs: File 'ath12k' in directory 'phy0' already present!
[   13.968334] ath12k_pci 0000:01:00.0: failed to send WMI_PDEV_SET_PARAM cmd
[   13.971771] ath12k_pci 0000:01:00.0: failed to set ac override for ARP: -108
[   13.975315] ath12k_pci 0000:01:00.0: fail to start mac operations in pdev idx 0 ret -108
[   14.123699] ath12k_pci 0000:01:00.0: link down error during global reset
[   14.167537] mhi mhi0: BHI offset: 0xffffffff is out of range: 0x200000
[   14.169031] ath12k_pci 0000:01:00.0: failed to set mhi state: INIT(0)
[   14.170504] ath12k_pci 0000:01:00.0: failed to start mhi: -34
```

---

Second patch may be caused by the recent firmware update (just speculation) that causes:
```
[   10.611560] ath12k_pci 0000:01:00.0: Invalid module id 2
[   10.616467] ath12k_pci 0000:01:00.0: failed to parse tlv -22
```

One solution is to ignore unknown capability, it should not be required if driver doesn't know about it anyway.

I noticed a very similar code in ath11k, but wasn't sure if the change is needed there too, so skipped it. Though I have a strong suspicion the same firmware mismatch might happen there too.

---

With both of those I can finally use QCN9274 under KVM virtual machine with virtio, at least with `pci=noaer` on the host. Without `pci=noaer` the module still boots and works properly, but any attempt to shut down or reboot inevitably crashes the host, which I reported to vfio maintainers and it will need to be fixed separately regardless.

I tested all this with 25.12.2, this should be forward-ported to development version and if someone can submit these upstream I would REALLY appreciate (dealing with sending emails from CLI and mailing lists is way too much pain last time I did that a few years ago with a single-line patch to Linux kernel).