### PR TITLE
tools/llvm-bpf: update to 22.1.3

### DIFF
--- a/tools/llvm-bpf/Makefile
+++ b/tools/llvm-bpf/Makefile
@@ -7,11 +7,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=llvm-project
-PKG_VERSION:=21.1.6
+PKG_VERSION:=22.1.3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).src.tar.xz
 PKG_SOURCE_URL:=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(PKG_VERSION)
-PKG_HASH:=ae67086eb04bed7ca11ab880349b5f1ab6f50e1b88cda376eaf8a845b935762b
+PKG_HASH:=2488c33a959eafba1c44f253e5bbe7ac958eb53fa626298a3a5f4b87373767cd
 PKG_CPE_ID:=cpe:/a:llvm:llvm
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)-$(PKG_VERSION).src


### PR DESCRIPTION
Release Notes:
- https://discourse.llvm.org/t/llvm-21-1-7-released
- https://discourse.llvm.org/t/llvm-21-1-8-released
- https://discourse.llvm.org/t/llvm-22-1-0-released
- https://discourse.llvm.org/t/llvm-22-1-1-released
- https://discourse.llvm.org/t/llvm-22-1-2-released
- https://discourse.llvm.org/t/llvm-22-1-3-released
