### PR TITLE
x86: add support for DFI ADN553

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -34,6 +34,12 @@ cisco-mx100-hw)
 dell-emc-edge620)
 	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth7" "eth6"
 	;;
+dfi-inc-adn553)
+	ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:1c.0/0000:01:00.0"
+	ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:1d.0/0000:03:00.0"
+	ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:1c.6/0000:02:00.0"
+	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
+	;;
 gowin-solution-co-ltd-gw-mb-u01)
 	ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:1c.0/0000:01:00.0/0000:02:02.0/0000:04:00.0"
 	ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:1c.0/0000:01:00.0/0000:02:00.0/0000:03:00.0"

--- a/target/linux/x86/base-files/lib/preinit/01_sysinfo
+++ b/target/linux/x86/base-files/lib/preinit/01_sysinfo
@@ -14,6 +14,7 @@ do_sysinfo_x86() {
 		vendor="$(cat /sys/devices/virtual/dmi/id/$file 2>/dev/null)"
 		case "$vendor" in
 		empty | \
+		Default\ string | \
 		System\ manufacturer | \
 		To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\.)
 			continue
@@ -26,6 +27,7 @@ do_sysinfo_x86() {
 		product="$(cat /sys/devices/virtual/dmi/id/$file 2>/dev/null)"
 		case "$vendor:$product" in
 		?*:empty | \
+		?*:Default\ string | \
 		?*:System\ Product\ Name | \
 		?*:To\ [bB]e\ [fF]illed\ [bB]y\ O\.E\.M\.)
 			continue


### PR DESCRIPTION
The DFI ADN553 is a 3.5" SBC based on Intel Atom Alder Lake-N processors with three Intel I226V 2.5GbE ports.

Specs:
* CPU: Intel Atom x7425E (4C, 12W) / x7213E (2C, 10W) / x7211E (2C, 6W)
* RAM: 1x DDR5 SO-DIMM, up to 16GB
* Storage: 1x M.2 M key 2242/2280 (PCIe Gen3 x1/SATA3), 1x SATA 3.0
* Ethernet: 3x 2.5GbE RJ-45 (Intel I226V)
* USB: 4x USB 3.2 (rear), 2x USB 2.0 (internal)
* Expansion: 1x M.2 B key 3052 (USB3/USB2, opt. PCIe x1, SIM), 1x M.2 E key 2230 (USB/PCIe x1, CNVi)
* Display: 1x HDMI, 1x Type-C DP Alt. Mode, 1x LVDS/eDP
* Power: 9-36V DC wide range input
* TPM: dTPM 2.0 (NPCT750AADYX)
* Form factor: 3.5" SBC (146mm x 102mm)

Installation:
1. Write the combined-efi.img to a USB drive: dd if=combined-efi.img of=/dev/sdX conv=fdatasync
2. Boot the ADN553 from the USB drive via the UEFI boot menu.
3. For permanent installation, write the image to the M.2 or SATA storage device.

The board uses "Default string" as DMI sys_vendor and product_name placeholders, so board detection is fixed by filtering these out and falling through to board_vendor (DFI Inc.) and board_name (ADN553).

The three I226V NICs are pinned to their PCIe paths to ensure consistent interface ordering matching the physical left-to-right port layout. eth0 is assigned as WAN and eth1/eth2 as LAN.
