### PR TITLE
Add port mirror support to UCI

### DIFF
--- a/package/network/config/port-mirror-scripts/Makefile
+++ b/package/network/config/port-mirror-scripts/Makefile
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2026 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=port-mirror-scripts
+PKG_VERSION:=1.0
+PKG_RELEASE:=1
+PKG_LICENSE:=GPL-2.0
+
+PKG_MAINTAINER:=Albrecht Lohofener <albrechtloh@gmx.de>
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/port-mirror-scripts
+  SECTION:=net
+  CATEGORY:=Base system
+  TITLE:=Port mirroring UCI service
+  DEPENDS:=+tc-tiny
+  PKGARCH:=all
+endef
+
+define Package/port-mirror-scripts/description
+ A shell-based UCI service that manages persistent tc-based port mirroring
+ rules for supported switch ports.
+endef
+
+define Package/port-mirror-scripts/conffiles
+/etc/config/port-mirror
+endef
+
+define Build/Prepare
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/port-mirror-scripts/install
+	$(INSTALL_DIR) $(1)
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,port-mirror-scripts))

--- a/package/network/config/port-mirror-scripts/files/etc/config/port-mirror
+++ b/package/network/config/port-mirror-scripts/files/etc/config/port-mirror
@@ -1,0 +1,6 @@
+config mirror 'example'
+	option enabled '0'
+	option source 'lan2'
+	option target 'lan8'
+	option ingress '1'
+	option egress '1'

--- a/package/network/config/port-mirror-scripts/files/etc/init.d/port-mirror
+++ b/package/network/config/port-mirror-scripts/files/etc/init.d/port-mirror
@@ -1,0 +1,35 @@
+#!/bin/sh /etc/rc.common
+
+START=50
+USE_PROCD=1
+
+validate_port_mirror_section()
+{
+	uci_validate_section port-mirror mirror "${1}" \
+		'enabled:bool' \
+		'source:string' \
+		'target:string' \
+		'ingress:bool' \
+		'egress:bool'
+}
+
+service_triggers()
+{
+	procd_add_reload_trigger "port-mirror"
+	procd_add_validation validate_port_mirror_section
+}
+
+start_service()
+{
+	/usr/sbin/port-mirror-apply
+}
+
+reload_service()
+{
+	/usr/sbin/port-mirror-apply
+}
+
+stop_service()
+{
+	/usr/sbin/port-mirror-apply --flush
+}

--- a/package/network/config/port-mirror-scripts/files/usr/sbin/port-mirror-apply
+++ b/package/network/config/port-mirror-scripts/files/usr/sbin/port-mirror-apply
@@ -1,0 +1,162 @@
+#!/bin/sh
+
+set -e
+
+CONFIG=port-mirror
+INGRESS_PREF=49150
+EGRESS_PREF=49151
+SEEN_SOURCES=" "
+
+. /lib/functions.sh
+
+log() {
+	logger -t port-mirror "$*"
+}
+
+warn() {
+	log "warning: $*"
+}
+
+die() {
+	log "error: $*"
+	echo "port-mirror: $*" >&2
+	exit 1
+}
+
+device_exists() {
+	ip link show dev "$1" >/dev/null 2>&1
+}
+
+list_devices() {
+	ip -o link show | awk -F': ' '{print $2}' | cut -d@ -f1
+}
+
+filter_exists() {
+	local dev="$1"
+	local direction="$2"
+	local pref="$3"
+
+	tc filter show dev "$dev" "$direction" 2>/dev/null | grep -q "pref $pref "
+}
+
+delete_filter() {
+	local dev="$1"
+	local direction="$2"
+	local pref="$3"
+
+	if filter_exists "$dev" "$direction" "$pref"; then
+		tc filter del dev "$dev" "$direction" pref "$pref" 2>/dev/null || true
+	fi
+}
+
+ensure_clsact() {
+	local dev="$1"
+
+	tc qdisc add dev "$dev" clsact 2>/dev/null || true
+}
+
+maybe_delete_clsact() {
+	local dev="$1"
+	local count
+
+	count="$({
+		tc filter show dev "$dev" ingress 2>/dev/null
+		tc filter show dev "$dev" egress 2>/dev/null
+	} | grep -c '^filter ' || true)"
+
+	[ "$count" -eq 0 ] || return 0
+	tc qdisc del dev "$dev" clsact 2>/dev/null || true
+}
+
+apply_filter() {
+	local dev="$1"
+	local direction="$2"
+	local pref="$3"
+	local target="$4"
+
+	tc filter replace dev "$dev" "$direction" pref "$pref" matchall \
+		action mirred egress mirror dev "$target"
+}
+
+validate_rule() {
+	local section="$1"
+	local enabled source target ingress egress
+
+	config_get_bool enabled "$section" enabled 0
+	[ "$enabled" -eq 1 ] || return 0
+
+	config_get source "$section" source
+	config_get target "$section" target
+	config_get_bool ingress "$section" ingress 1
+	config_get_bool egress "$section" egress 1
+
+	[ -n "${source:-}" ] || die "section '$section' is missing option source"
+	[ -n "${target:-}" ] || die "section '$section' is missing option target"
+	[ "$source" != "$target" ] || die "section '$section' uses the same source and target '$source'"
+	[ "$ingress" -eq 1 ] || [ "$egress" -eq 1 ] || die "section '$section' must enable ingress or egress"
+	device_exists "$source" || die "section '$section' references missing source '$source'"
+	device_exists "$target" || die "section '$section' references missing target '$target'"
+	case "$SEEN_SOURCES" in
+	*" $source "*)
+		die "multiple enabled sections use source '$source'; only one mirror section per source is supported"
+		;;
+	esac
+	SEEN_SOURCES="$SEEN_SOURCES$source "
+}
+
+flush_owned_filters() {
+	local dev
+
+	for dev in $(list_devices); do
+		device_exists "$dev" || continue
+		delete_filter "$dev" ingress "$INGRESS_PREF"
+		delete_filter "$dev" egress "$EGRESS_PREF"
+		maybe_delete_clsact "$dev"
+	done
+}
+
+apply_section() {
+	local section="$1"
+	local enabled source target ingress egress
+
+	config_get_bool enabled "$section" enabled 0
+	config_get source "$section" source
+	config_get target "$section" target
+	config_get_bool ingress "$section" ingress 1
+	config_get_bool egress "$section" egress 1
+
+	[ "$enabled" -eq 1 ] || return 0
+
+	ensure_clsact "$source"
+
+	if [ "$ingress" -eq 1 ]; then
+		apply_filter "$source" ingress "$INGRESS_PREF" "$target"
+	fi
+
+	if [ "$egress" -eq 1 ]; then
+		apply_filter "$source" egress "$EGRESS_PREF" "$target"
+	fi
+}
+
+validate_cb() {
+	validate_rule "$1"
+}
+
+apply_cb() {
+	apply_section "$1"
+}
+
+main() {
+	config_load "$CONFIG"
+	config_foreach validate_cb mirror
+	flush_owned_filters
+
+	if [ "${1:-}" = "--flush" ]; then
+		exit 0
+	fi
+
+	config_foreach apply_cb mirror
+	log "applied port mirror configuration"
+}
+
+main "$@"


### PR DESCRIPTION
I’m working with a Zyxel GS1900-8, which uses the Realtek RTL8380M switch SoC. This hardware supports port mirroring, and while it can be configured via `tc`, that approach is not very user-friendly. Additionally, `uci` currently has no awareness of this feature.

This PR is not intended for immediate merging; rather, it is meant to start a discussion on how port mirroring could be properly integrated into OpenWrt. Since OpenWrt already supports Ethernet switches, port mirroring is an important feature that would benefit from a more standardized configuration approach.

I previously raised the question of how to configure port mirroring on the [forum](https://forum.openwrt.org/t/how-to-configure-port-mirroring/249162
), but did not receive any responses. As a result, I began working on an initial implementation.

The proposed solution follows a similar design to the [qos-scripts](https://github.com/openwrt/openwrt/tree/main/package/network/config/qos-scripts) package. It introduces a new configuration file at `/etc/config/port-mirror` along with a corresponding set of scripts. However, I’m not sure whether a standalone `port-mirror-scripts` approach is the right direction, or if it would be more appropriate to integrate port mirroring directly into [netifd](https://github.com/openwrt/netifd).

I’d appreciate feedback on the overall approach and guidance on how this feature should ideally be integrated into OpenWrt.


Here are some example UCI commands:

```sh
uci set port-mirror.lan2_to_lan8=mirror
uci set port-mirror.lan2_to_lan8.enabled='1'
uci set port-mirror.lan2_to_lan8.source='lan2'
uci set port-mirror.lan2_to_lan8.target='lan8'
uci set port-mirror.lan2_to_lan8.ingress='1'
uci set port-mirror.lan2_to_lan8.egress='1'
uci commit port-mirror
/etc/init.d/port-mirror reload
```

Disable the rule without deleting it:

```sh
uci set port-mirror.lan2_to_lan8.enabled='0'
uci commit port-mirror
/etc/init.d/port-mirror reload
```

Remove the rule completely:

```sh
uci delete port-mirror.lan2_to_lan8
uci commit port-mirror
/etc/init.d/port-mirror reload
```


For transparency: the initial implementation was generated with the help of Copilot AI and validated through manual testing. I have not yet reviewed every line of code in detail.

Before investing time in a thorough review and refinement, I’d like to confirm whether the port-mirror-scripts approach is considered acceptable. If this direction isn’t suitable, I’d prefer to adjust the design first rather than refine an approach that may not be adopted.