### PR TITLE
imx: cortexa9: ventana, fix profiles names in profiles.json

### DIFF
--- a/target/linux/imx/image/common.mk
+++ b/target/linux/imx/image/common.mk
@@ -18,7 +18,7 @@ define Build/imx-combined-image
 
 	mkimage -A arm -O linux -T script -C none -a 0 -e 0 \
 		-n '$(DEVICE_ID) OpenWrt bootscript' \
-		-d bootscript-$(DEVICE_NAME) \
+		-d bootscript-$(if $(BOARD_NAME),$(BOARD_NAME),$(DEVICE_NAME)) \
 		$@.boot/boot.scr
 
 	cp $@ $@.fs

--- a/target/linux/imx/image/cortexa9.mk
+++ b/target/linux/imx/image/cortexa9.mk
@@ -19,8 +19,8 @@ define Build/boot-overlay
 	)
 	mkimage -A arm -O linux -T script -C none -a 0 -e 0 \
 		-n '$(DEVICE_ID) OpenWrt bootscript' \
-		-d ./bootscript-$(DEVICE_NAME) \
-		$@.boot/6x_bootscript-$(DEVICE_NAME)
+		-d ./bootscript-$(if $(BOARD_NAME),$(BOARD_NAME),$(DEVICE_NAME)) \
+		$@.boot/6x_bootscript-$(if $(BOARD_NAME),$(BOARD_NAME),$(DEVICE_NAME))
 
 	$(STAGING_DIR_HOST)/bin/mkfs.ubifs \
 		--space-fixup --compr=zlib --squash-uids \
@@ -43,7 +43,7 @@ endef
 define Build/recovery-scr
 	mkimage -A arm -O linux -T script -C none -a 0 -e 0 \
 	-n '$(DEVICE_ID) OpenWrt recovery bootscript' \
-	-d ./recovery-$(DEVICE_NAME) $@
+	-d ./recovery-$(if $(BOARD_NAME),$(BOARD_NAME),$(DEVICE_NAME)) $@
 endef
 
 define Build/apalis-emmc
@@ -63,7 +63,7 @@ define Build/ventana-img
 	)
 	mkimage -A arm -O linux -T script -C none -a 0 -e 0 \
 		-n '$(DEVICE_ID) OpenWrt bootscript' \
-		-d bootscript-$(DEVICE_NAME) \
+		-d bootscript-$(if $(BOARD_NAME),$(BOARD_NAME),$(DEVICE_NAME)) \
 		$@.boot/boot/6x_bootscript-ventana
 	cp $@ $@.fs
 
@@ -92,7 +92,7 @@ define Device/gateworks_ventana
   DEVICE_VENDOR := Gateworks
   DEVICE_MODEL := Ventana family
   DEVICE_VARIANT := normal NAND flash
-  DEVICE_NAME := ventana
+  BOARD_NAME := ventana
   DEVICE_DTS:= \
 	imx6dl-gw51xx \
 	imx6dl-gw52xx \


### PR DESCRIPTION
These two image profiles overwrite DEVICE_NAME making the two image profiles appear with the same name "ventana" in the "profiles.json" mixing ramdomly the two profiles.

Use BOARD_NAME instead to keep the two profiles names unique (orginal DEVICE_NAME) hence generating a coherent "profiles.json".

Since there are image recipes hardconding DEVICE_NAME, change them to use BOARD_NAME if defined, in order to preserve the previous names used in those recipes.

Fixes: cbc8bcfbaa71fe0928bf07d29ec0fe6217fd51ad ("imx6: image: use vendor_model scheme")

cc. @efahl 