### PR TITLE
build: do not set CCACHE_COMPILERCHECK

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -352,7 +352,6 @@ ifneq ($(CONFIG_CCACHE),)
   export CCACHE_NOCOMPRESS:=true
   export CCACHE_BASEDIR:=$(TOPDIR)
   export CCACHE_DIR:=$(if $(call qstrip,$(CONFIG_CCACHE_DIR)),$(call qstrip,$(CONFIG_CCACHE_DIR)),$(TOPDIR)/.ccache)
-  export CCACHE_COMPILERCHECK:=%compiler% -v -c
 endif
 
 TARGET_CONFIGURE_OPTS = \


### PR DESCRIPTION
Stop overriding CCACHE_COMPILERCHECK from rules.mk and rely on ccache's default, which hashes the compiler binary's mtime and size.

For a local tree that is enough: the toolchain only changes when it is rebuilt, and a rebuild updates mtime and size. Users who want a stricter check can still set CCACHE_COMPILERCHECK in their environment.

CI does not depend on this export either. The workflow writes a secondary ccache.conf with

  compiler_check=string:<toolchain-commit-sha>

so the cache key is tied to the toolchain source revision. That is both stricter than the previous "%compiler% -v -c" setting and portable across runners, where compiler mtimes would not match after restoring a cache archive.

This should be combined with: https://github.com/openwrt/actions-shared-workflows/pull/103