### PR TITLE
mediatek: dts: add missing model name for Netis NX30V2

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-netis-nx30v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-netis-nx30v2.dts
@@ -5,6 +5,7 @@
 
 / {
 	compatible = "netis,nx30v2", "mediatek,mt7981";
+	model = "Netis NX30V2";
 
 	aliases {
 		label-mac-device = &gmac0;


### PR DESCRIPTION
This is a necessary property for the Linux kernel.

Fixes: https://github.com/openwrt/openwrt/issues/22996
Fixes: 344bb7f9162b76 ("mediatek: filogic: add support Netcore NX30V2/N30PRO/POWER30AX/W7/GW3001")