### PR TITLE
x86: add support for DFI ASL553

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -34,7 +34,8 @@ cisco-mx100-hw)
 dell-emc-edge620)
 	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth7" "eth6"
 	;;
-dfi-inc-adn553)
+dfi-inc-adn553| \
+dfi-inc-asl553)
 	ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:1c.0/0000:01:00.0"
 	ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:1d.0/0000:03:00.0"
 	ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:1c.6/0000:02:00.0"


### PR DESCRIPTION
The DFI ASL553 is a 3.5" SBC very similar to the ADN553. The network topology is identical, so both boards share the same network configuration.

Differences from the ADN553:
* CPU: Intel Atom x7835RE (8C, 12W) / x7433RE (4C, 9W) / x7213RE (2C, 9W) / x7211RE (2C, 6W) (Amston Lake / x7000RE series instead of Alder Lake-N)
* Ethernet: Intel I226IT instead of I226V
* Audio: Realtek ALC888S instead of ALC888

For installation and board detection details, see commit b6b09a2ad838 ("x86: add support for DFI ADN553").
