### PR TITLE
Improve WPA 3 compatibility and add additional options

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -962,6 +962,11 @@
 		"rsn_preauth": {
 			"type": "boolean"
 		},
+		"sae_ext_key": {
+			"description": "Advertise the SAE-EXT-KEY AKM alongside plain SAE. Mandatory for EHT, enabled by default.",
+			"type": "boolean",
+			"default": true
+		},
 		"sae_password_file": {
 			"description": "External file containing VLAN SAE MAC address triplets",
 			"type": "string"

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -962,11 +962,6 @@
 		"rsn_preauth": {
 			"type": "boolean"
 		},
-		"rsn_override": {
-			"type": "number",
-			"description": "Use RSNE override IE WPA3 compatibility (0: disabled, 1: enabled, 2:force WPA2 for older devices)",
-			"default": 1
-		},
 		"sae_password_file": {
 			"description": "External file containing VLAN SAE MAC address triplets",
 			"type": "string"

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -1040,6 +1040,14 @@
 			"description": "Local time zone as specified in 8.3 of IEEE Std 1003.1-2004",
 			"type": "string"
 		},
+		"transition_disable": {
+			"description": "Transition modes the AP signals as disabled per WPA3 v3.5 §13. Entries 'sae', 'sae-pk', 'wpa3', 'owe' are OR'd into the bitmap; 'on' (or '1') derives it from auth_type; 'off' (or '0') suppresses the element. Unset by default.",
+			"type": "array",
+			"items": {
+				"type": "string",
+				"enum": [ "on", "off", "0", "1", "sae", "sae-pk", "wpa3", "owe" ]
+			}
+		},
 		"uapsd": {
 			"type": "alias",
 			"default": "uapsd_advertisement_enabled"

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -418,6 +418,20 @@ function iface_roaming(config) {
 	]);
 }
 
+function default_group_mgmt_cipher(config) {
+	let p = ' ' + (config.wpa_pairwise ?? '') + ' ';
+
+	if (wildcard(p, '* CCMP *') || wildcard(p, '* TKIP *'))
+		return 'AES-128-CMAC';
+	if (wildcard(p, '* CCMP-256 *'))
+		return 'BIP-CMAC-256';
+	if (wildcard(p, '* GCMP *'))
+		return 'BIP-GMAC-128';
+	if (wildcard(p, '* GCMP-256 *'))
+		return 'BIP-GMAC-256';
+	return 'AES-128-CMAC';
+}
+
 function iface_mfp(config) {
 	let override_mfp = config.rsn_override_mfp || config.rsn_override_mfp_2;
 
@@ -426,10 +440,7 @@ function iface_mfp(config) {
 		return;
 	}
 
-	if (config.auth_type == 'eap192')
-		config.group_mgmt_cipher = 'BIP-GMAC-256';
-	else
-		config.group_mgmt_cipher = config.ieee80211w_mgmt_cipher ?? 'AES-128-CMAC';
+	config.group_mgmt_cipher = config.ieee80211w_mgmt_cipher ?? default_group_mgmt_cipher(config);
 
 	set_default(config, 'beacon_prot', 1);
 

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -439,6 +439,42 @@ function iface_mfp(config) {
 	]);
 }
 
+function iface_transition_disable(config) {
+	if (config.wpa < 2)
+		return;
+
+	let list = config.transition_disable;
+	if (!list || !length(list))
+		return;
+
+	for (let s in list)
+		if (s == 'off' || s == '0')
+			return;
+
+	let bits = 0;
+	for (let s in list) {
+		if (s == 'on' || s == '1') {
+			bits = 0;
+			switch (config.auth_type) {
+			case 'sae':    bits = 0x01; break;
+			case 'eap2':
+			case 'eap192': bits = 0x04; break;
+			case 'owe':    if (!config.owe_transition) bits = 0x08; break;
+			}
+			break;
+		}
+		switch (s) {
+		case 'sae':    bits |= 0x01; break;
+		case 'sae-pk': bits |= 0x02; break;
+		case 'wpa3':   bits |= 0x04; break;
+		case 'owe':    bits |= 0x08; break;
+		}
+	}
+
+	if (bits)
+		append('transition_disable', sprintf('0x%02x', bits));
+}
+
 function iface_key_caching(config) {
 	if (config.wpa < 2)
 		return;
@@ -532,6 +568,8 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 	iface_roaming(config);
 
 	iface_mfp(config);
+
+	iface_transition_disable(config);
 
 	iface_key_caching(config);
 

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -102,8 +102,12 @@ function iface_auth_type(config, band) {
 
 	if (config.auth_type in [ 'sae', 'psk-sae', 'psk-sae-compat' ]) {
 		config.sae_require_mfp = 1;
-		if (!config.ppsk)
-			set_default(config, 'sae_pwe', 2);
+		if (!config.ppsk) {
+			if (band == '6g')
+				set_default(config, 'sae_pwe', 1);
+			else
+				set_default(config, 'sae_pwe', 2);
+		}
 	}
 
 	if (config.own_ip_addr)

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -81,14 +81,26 @@ function iface_accounting_server(config) {
 	append_vars(config, [ 'radius_acct_req_attr' ]);
 }
 
-function iface_auth_type(config) {
+function iface_auth_type(config, band) {
 	if (config.auth_type in [ 'sae', 'owe', 'eap2', 'eap192', 'dpp' ])
 		config.ieee80211w = 2;
 
 	if (config.auth_type in [ 'psk-sae', 'eap-eap2' ])
 		set_default(config, 'ieee80211w', 1);
 
-	if (config.auth_type in [ 'sae', 'psk-sae' ]) {
+	if (config.auth_type == 'psk-sae-compat') {
+		if (band == '6g') {
+			set_default(config, 'ieee80211w', 2);
+		} else {
+			set_default(config, 'ieee80211w', 0);
+			config.rsn_override_mfp = 2;
+			config.rsn_override_omit_rsnxe = 1;
+		}
+		if (config.rsn_override_pairwise_2)
+			config.rsn_override_mfp_2 = 2;
+	}
+
+	if (config.auth_type in [ 'sae', 'psk-sae', 'psk-sae-compat' ]) {
 		config.sae_require_mfp = 1;
 		if (!config.ppsk)
 			set_default(config, 'sae_pwe', 2);
@@ -122,6 +134,7 @@ function iface_auth_type(config) {
 	case 'psk2':
 	case 'sae':
 	case 'psk-sae':
+	case 'psk-sae-compat':
 		config.vlan_possible = 1;
 		config.wps_possible = 1;
 
@@ -137,12 +150,12 @@ function iface_auth_type(config) {
 			 netifd.setup_failed('INVALID_WPA_PSK');
 		}
 
-		if (config.auth_type in [ 'psk', 'psk-sae' ]) {
+		if (config.auth_type in [ 'psk', 'psk-sae', 'psk-sae-compat' ] && band != '6g') {
 			set_default(config, 'wpa_psk_file', `/var/run/hostapd-${config.ifname}.psk`);
 			touch_file(config.wpa_psk_file);
 		}
 
-		if (config.auth_type in [ 'sae', 'psk-sae' ]) {
+		if (config.auth_type in [ 'sae', 'psk-sae', 'psk-sae-compat' ]) {
 			set_default(config, 'sae_password_file', `/var/run/hostapd-${config.ifname}.sae`);
 			touch_file(config.sae_password_file);
 		}
@@ -198,7 +211,7 @@ function iface_auth_type(config) {
 }
 
 function iface_ppsk(config) {
-	if (!(config.auth_type in [ 'none', 'owe', 'psk', 'sae', 'psk-sae', 'wep' ]) || !config.auth_server_addr)
+	if (!(config.auth_type in [ 'none', 'owe', 'psk', 'sae', 'psk-sae', 'psk-sae-compat', 'wep' ]) || !config.auth_server_addr)
 		return;
 
 	iface_authentication_server(config);
@@ -402,7 +415,9 @@ function iface_roaming(config) {
 }
 
 function iface_mfp(config) {
-	if (!config.ieee80211w || config.wpa < 2) {
+	let override_mfp = config.rsn_override_mfp || config.rsn_override_mfp_2;
+
+	if ((!config.ieee80211w && !override_mfp) || config.wpa < 2) {
 		append('ieee80211w', 0);
 		return;
 	}
@@ -432,7 +447,7 @@ function iface_key_caching(config) {
 			'rsn_preauth', 'rsn_preauth_interfaces'
 		]);
 	} else {
-		set_default(config, 'okc', (config.auth_type in  [ 'sae', 'psk-sae', 'owe' ]));
+		set_default(config, 'okc', (config.auth_type in  [ 'sae', 'psk-sae', 'psk-sae-compat', 'owe' ]));
 	}
 
 	if (!config.okc && !config.fils)
@@ -487,12 +502,12 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 			config.auth_type = 'eap2';
 	}
 
-	if (config.auth_type in [ 'psk', 'psk-sae' ])
+	if (config.auth_type in [ 'psk', 'psk-sae', 'psk-sae-compat' ] && data.config.band != '6g')
 		iface_wpa_stations(config, stas);
-	if (config.auth_type in [ 'sae', 'psk-sae' ])
+	if (config.auth_type in [ 'sae', 'psk-sae', 'psk-sae-compat' ])
 		iface_sae_stations(config, stas);
 
-	iface_auth_type(config);
+	iface_auth_type(config, data.config.band);
 
 	iface_accounting_server(config);
 
@@ -520,7 +535,7 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 
 	iface_interworking(config);
 
-	iface.wpa_key_mgmt(config);
+	iface.wpa_key_mgmt(config, data.config.band);
 	append_vars(config, [
 		'wpa_key_mgmt',
 	]);
@@ -539,6 +554,10 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 			'rsn_override_pairwise_2',
 			'rsn_override_mfp_2'
 		]);
+	}
+
+	if (config.rsn_override_omit_rsnxe) {
+		append_vars(config, ['rsn_override_omit_rsnxe']);
 	}
 
 	/* raw options */

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -100,8 +100,14 @@ function iface_auth_type(config, band) {
 			config.rsn_override_mfp_2 = 2;
 	}
 
+	if (config.auth_type == 'owe') {
+		set_default(config, 'owe_groups', '19 20 21');
+		set_default(config, 'owe_ptk_workaround', 1);
+	}
+
 	if (config.auth_type in [ 'sae', 'psk-sae', 'psk-sae-compat' ]) {
 		config.sae_require_mfp = 1;
+		set_default(config, 'sae_groups', '19 20 21');
 		if (!config.ppsk) {
 			if (band == '6g')
 				set_default(config, 'sae_pwe', 1);
@@ -199,11 +205,11 @@ function iface_auth_type(config, band) {
 	}
 
 	append_vars(config, [
-		'sae_require_mfp', 'sae_password_file', 'sae_pwe', 'sae_track_password', 'time_advertisement', 'time_zone',
+		'sae_require_mfp', 'sae_password_file', 'sae_pwe', 'sae_groups', 'sae_track_password', 'time_advertisement', 'time_zone',
 		'wpa_group_rekey', 'wpa_ptk_rekey', 'wpa_gmk_rekey', 'wpa_strict_rekey',
 		'macaddr_acl', 'wpa_psk_radius', 'wpa_psk', 'wpa_passphrase', 'wpa_psk_file',
 		'eapol_version', 'dynamic_vlan', 'radius_request_cui', 'eap_reauth_period',
-		'radius_das_client', 'radius_das_port', 'own_ip_addr', 'dynamic_own_ip_addr',
+		'radius_das_client', 'radius_das_port', 'owe_groups', 'owe_ptk_workaround', 'own_ip_addr', 'dynamic_own_ip_addr',
 		'wpa_disable_eapol_key_retries', 'auth_algs', 'wpa', 'wpa_pairwise',
 		'erp_domain', 'fils_realm', 'erp_send_reauth_start', 'fils_cache_id'
 	]);

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -57,7 +57,7 @@ function iface_setup(config) {
 		'disassoc_low_ack', 'skip_inactivity_poll', 'ignore_broadcast_ssid', 'uapsd_advertisement_enabled',
 		'utf8_ssid', 'multi_ap', 'multi_ap_vlanid', 'multi_ap_profile', 'tdls_prohibit', 'bridge',
 		'wds_sta', 'wds_bridge', 'snoop_iface', 'vendor_elements', 'nas_identifier', 'radius_acct_interim_interval',
-		'ocv', 'beacon_prot', 'spp_amsdu', 'multicast_to_unicast', 'preamble', 'proxy_arp', 'per_sta_vif', 'mbo',
+		'ocv', 'spp_amsdu', 'multicast_to_unicast', 'preamble', 'proxy_arp', 'per_sta_vif', 'mbo',
 		'bss_transition', 'wnm_sleep_mode', 'wnm_sleep_mode_no_keys', 'qos_map_set', 'max_listen_int',
 		'dtim_period', 'wmm_enabled', 'start_disabled', 'na_mcast_to_ucast', 'no_probe_resp_if_max_sta',
 	]);
@@ -412,8 +412,11 @@ function iface_mfp(config) {
 	else
 		config.group_mgmt_cipher = config.ieee80211w_mgmt_cipher ?? 'AES-128-CMAC';
 
+	set_default(config, 'beacon_prot', 1);
+
 	append_vars(config, [
-		'ieee80211w', 'group_mgmt_cipher', 'assoc_sa_query_max_timeout', 'assoc_sa_query_retry_timeout'
+		'ieee80211w', 'group_mgmt_cipher', 'beacon_prot',
+		'assoc_sa_query_max_timeout', 'assoc_sa_query_retry_timeout'
 	]);
 }
 

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -82,17 +82,16 @@ function iface_accounting_server(config) {
 }
 
 function iface_auth_type(config) {
-	if (config.auth_type in [ 'sae', 'owe', 'eap2', 'eap192', 'dpp' ]) {
+	if (config.auth_type in [ 'sae', 'owe', 'eap2', 'eap192', 'dpp' ])
 		config.ieee80211w = 2;
-		config.sae_require_mfp = 1;
-		if (!config.ppsk)
-			set_default(config, 'sae_pwe', 2);
-	}
 
 	if (config.auth_type in [ 'psk-sae', 'eap-eap2' ]) {
 		set_default(config, 'ieee80211w', 1);
 		if (config.rsn_override)
 			config.rsn_override_mfp = 2;
+	}
+
+	if (config.auth_type in [ 'sae', 'psk-sae' ]) {
 		config.sae_require_mfp = 1;
 		if (!config.ppsk)
 			set_default(config, 'sae_pwe', 2);

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -85,11 +85,8 @@ function iface_auth_type(config) {
 	if (config.auth_type in [ 'sae', 'owe', 'eap2', 'eap192', 'dpp' ])
 		config.ieee80211w = 2;
 
-	if (config.auth_type in [ 'psk-sae', 'eap-eap2' ]) {
+	if (config.auth_type in [ 'psk-sae', 'eap-eap2' ])
 		set_default(config, 'ieee80211w', 1);
-		if (config.rsn_override)
-			config.rsn_override_mfp = 2;
-	}
 
 	if (config.auth_type in [ 'sae', 'psk-sae' ]) {
 		config.sae_require_mfp = 1;
@@ -525,27 +522,20 @@ export function generate(interface, data, config, vlans, stas, phy_features) {
 		'wpa_key_mgmt',
 	]);
 
-	if (config.rsn_override_key_mgmt || config.rsn_override_pairwise) {
-		config.rsn_override_mfp ??= config.ieee80211w;
-		config.rsn_override_key_mgmt ??= config.wpa_key_mgmt;
-		config.rsn_override_pairwise ??= config.wpa_pairwise;
+	if (config.rsn_override_key_mgmt && config.rsn_override_pairwise && config.rsn_override_mfp) {
 		append_vars(config, [
 			'rsn_override_key_mgmt',
 			'rsn_override_pairwise',
 			'rsn_override_mfp'
 		]);
+	}
 
-		if (config.mlo) {
-			config.rsn_override_mfp_2 ??= config.rsn_override_mfp;
-			config.rsn_override_key_mgmt_2 ??= config.rsn_override_key_mgmt;
-			config.rsn_override_pairwise_2 ??= config.rsn_override_pairwise;
-
-			append_vars(config, [
-				'rsn_override_key_mgmt_2',
-				'rsn_override_pairwise_2',
-				'rsn_override_mfp_2'
-			]);
-		}
+	if (config.rsn_override_key_mgmt_2 && config.rsn_override_pairwise_2 && config.rsn_override_mfp_2) {
+		append_vars(config, [
+			'rsn_override_key_mgmt_2',
+			'rsn_override_pairwise_2',
+			'rsn_override_mfp_2'
+		]);
 	}
 
 	/* raw options */

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -57,6 +57,15 @@ export function parse_encryption(config, dev_config) {
 		config.auth_type = 'psk-sae';
 		break;
 
+	case 'sae-compat':
+		config.auth_type = 'psk-sae-compat';
+		config.wpa_pairwise = 'CCMP';
+		if (dev_config.band != '6g')
+			config.rsn_override_pairwise = 'CCMP';
+		if (wildcard(dev_config.htmode ?? '', 'EHT*'))
+			config.rsn_override_pairwise_2 = 'GCMP-256';
+		break;
+
 	case 'wpa':
 	case 'wpa2':
 	case 'wpa-mixed':
@@ -104,7 +113,7 @@ export function parse_encryption(config, dev_config) {
 		config.wpa_pairwise ??= 'CCMP';
 };
 
-export function wpa_key_mgmt(config) {
+export function wpa_key_mgmt(config, band) {
 	if (!config.wpa)
 		return;
 
@@ -172,6 +181,36 @@ export function wpa_key_mgmt(config) {
 			append_value(config, 'wpa_key_mgmt', 'WPA-PSK-SHA256');
 		if (config.ieee80211r)
 			append_value(config, 'wpa_key_mgmt', 'FT-PSK');
+		break;
+
+	case 'psk-sae-compat':
+		if (band == '6g') {
+			append_value(config, 'wpa_key_mgmt', 'SAE');
+			if (config.ieee80211r)
+				append_value(config, 'wpa_key_mgmt', 'FT-SAE');
+
+			if (config.sae_ext_key && config.rsn_override_pairwise_2) {
+				append_value(config, 'rsn_override_key_mgmt_2', 'SAE-EXT-KEY');
+				if (config.ieee80211r)
+					append_value(config, 'rsn_override_key_mgmt_2', 'FT-SAE-EXT-KEY');
+			}
+		} else {
+			append_value(config, 'wpa_key_mgmt', 'WPA-PSK');
+			if (config.ieee80211w)
+				append_value(config, 'wpa_key_mgmt', 'WPA-PSK-SHA256');
+			if (config.ieee80211r)
+				append_value(config, 'wpa_key_mgmt', 'FT-PSK');
+
+			append_value(config, 'rsn_override_key_mgmt', 'SAE');
+			if (config.ieee80211r)
+				append_value(config, 'rsn_override_key_mgmt', 'FT-SAE');
+
+			if (config.sae_ext_key && config.rsn_override_pairwise_2) {
+				append_value(config, 'rsn_override_key_mgmt_2', 'SAE-EXT-KEY');
+				if (config.ieee80211r)
+					append_value(config, 'rsn_override_key_mgmt_2', 'FT-SAE-EXT-KEY');
+			}
+		}
 		break;
 
 	case 'owe':

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -116,10 +116,7 @@ export function parse_encryption(config, dev_config) {
 		if (!wpa3_pairwise)
 			break;
 
-		if (config.rsn_override && wpa3_pairwise != config.wpa_pairwise)
-			config.rsn_override_pairwise = wpa3_pairwise;
-		else
-			config.wpa_pairwise = wpa3_pairwise;
+		config.wpa_pairwise = wpa3_pairwise;
 		break;
 	}
 
@@ -158,9 +155,6 @@ export function wpa_key_mgmt(config) {
 		if (config.ieee80211r)
 			append_value(config, 'wpa_key_mgmt', 'FT-EAP');
 
-		if (config.rsn_override)
-			config.rsn_override_key_mgmt = config.wpa_key_mgmt;
-
 		append_value(config, 'wpa_key_mgmt', 'WPA-EAP');
 		break;
 
@@ -180,17 +174,6 @@ export function wpa_key_mgmt(config) {
 		append_value(config, 'wpa_key_mgmt', 'SAE');
 		if (config.ieee80211r)
 			append_value(config, 'wpa_key_mgmt', 'FT-SAE');
-
-		if (config.rsn_override) {
-			config.rsn_override_key_mgmt = config.wpa_key_mgmt;
-
-			append_value(config, 'rsn_override_key_mgmt_2', 'SAE-EXT-KEY');
-			if (config.ieee80211r)
-				append_value(config, 'rsn_override_key_mgmt_2', 'FT-SAE-EXT-KEY');
-		}
-
-		if (config.rsn_override > 1)
-			delete config.wpa_key_mgmt;
 
 		append_value(config, 'wpa_key_mgmt', 'WPA-PSK');
 		if (config.ieee80211w)
@@ -225,13 +208,6 @@ export function wpa_key_mgmt(config) {
 			append_value(config, 'wpa_key_mgmt', 'FILS-SHA256');
 			if (config.ieee80211r)
 				append_value(config, 'wpa_key_mgmt', 'FT-FILS-SHA256');
-
-			if (!config.rsn_override_key_mgmt)
-				break;
-
-			append_value(config, 'rsn_override_key_mgmt', 'FILS-SHA256');
-			if (config.ieee80211r)
-				append_value(config, 'rsn_override_key_mgmt', 'FT-FILS-SHA256');
 			break;
 		}
 	}

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -17,15 +17,7 @@ export function parse_encryption(config, dev_config) {
 			break;
 		}
 
-	config.wpa_pairwise = null;
-	if (config.wpa)
-		config.wpa_pairwise = (config.hw_mode == 'ad') ? 'GCMP' : 'CCMP';
-
 	config.auth_type = encryption[0] ?? 'none';
-
-	let wpa3_pairwise = config.wpa_pairwise;
-	if (wildcard(dev_config?.htmode, 'EHT*') || wildcard(dev_config?.htmode, 'HE*'))
-		wpa3_pairwise = 'GCMP-256 ' + wpa3_pairwise;
 
 	switch(config.auth_type) {
 	case 'owe':
@@ -38,6 +30,7 @@ export function parse_encryption(config, dev_config) {
 
 	case 'wpa3-192':
 		config.auth_type = 'eap192';
+		config.wpa_pairwise = 'GCMP-256';
 		break;
 
 	case 'wpa3-mixed':
@@ -52,7 +45,6 @@ export function parse_encryption(config, dev_config) {
 	case 'psk2':
 	case 'psk-mixed':
 		config.auth_type = 'psk';
-		wpa3_pairwise = null;
 		break;
 
 	case 'sae':
@@ -69,12 +61,6 @@ export function parse_encryption(config, dev_config) {
 	case 'wpa2':
 	case 'wpa-mixed':
 		config.auth_type = 'eap';
-		wpa3_pairwise = null;
-		break;
-
-	default:
-		config.wpa_pairwise = null;
-		wpa3_pairwise = null;
 		break;
 	}
 
@@ -106,20 +92,16 @@ export function parse_encryption(config, dev_config) {
 	case 'gcmp':
 		config.wpa_pairwise = 'GCMP';
 		break;
-
-	default:
-		if (config.encryption == 'wpa3-192') {
-			config.wpa_pairwise = 'GCMP-256';
-			break;
-		}
-
-		if (!wpa3_pairwise)
-			break;
-
-		config.wpa_pairwise = wpa3_pairwise;
-		break;
 	}
 
+	if (!config.wpa)
+		config.wpa_pairwise ??= null;
+	else if (config.hw_mode == 'ad')
+		config.wpa_pairwise ??= 'GCMP';
+	else if (wildcard(dev_config?.htmode, 'EHT*') || wildcard(dev_config?.htmode, 'HE*'))
+		config.wpa_pairwise ??= 'GCMP-256 CCMP';
+	else
+		config.wpa_pairwise ??= 'CCMP';
 };
 
 export function wpa_key_mgmt(config) {

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/iface.uc
@@ -148,14 +148,24 @@ export function wpa_key_mgmt(config) {
 
 	case 'sae':
 		append_value(config, 'wpa_key_mgmt', 'SAE');
-		if (config.ieee80211r)
+		if (config.sae_ext_key)
+			append_value(config, 'wpa_key_mgmt', 'SAE-EXT-KEY');
+		if (config.ieee80211r) {
 			append_value(config, 'wpa_key_mgmt', 'FT-SAE');
+			if (config.sae_ext_key)
+				append_value(config, 'wpa_key_mgmt', 'FT-SAE-EXT-KEY');
+		}
 		break;
 
 	case 'psk-sae':
 		append_value(config, 'wpa_key_mgmt', 'SAE');
-		if (config.ieee80211r)
+		if (config.sae_ext_key)
+			append_value(config, 'wpa_key_mgmt', 'SAE-EXT-KEY');
+		if (config.ieee80211r) {
 			append_value(config, 'wpa_key_mgmt', 'FT-SAE');
+			if (config.sae_ext_key)
+				append_value(config, 'wpa_key_mgmt', 'FT-SAE-EXT-KEY');
+		}
 
 		append_value(config, 'wpa_key_mgmt', 'WPA-PSK');
 		if (config.ieee80211w)

--- a/package/network/utils/iw/patches/001-iw-scan-print-RSN-Element-Override-IEs.patch
+++ b/package/network/utils/iw/patches/001-iw-scan-print-RSN-Element-Override-IEs.patch
@@ -1,0 +1,58 @@
+From d90618809e06e123241f57efdb7039a7a8a43d58 Mon Sep 17 00:00:00 2001
+From: Alex Gavin <a_gavin@icloud.com>
+Date: Sun, 15 Mar 2026 22:16:46 -0700
+Subject: iw: scan: print RSN Element Override IEs
+
+Parse body of RSN Element Override IEs as RSN IEs
+using existing code.
+
+RSN IEs are a minimum size of 4 octets, as detailed
+in IEEE802.11-2024, 9.4.2.23.1
+
+Example output:
+RSN Element Override:
+	 * Version: 1
+	 * Group cipher: CCMP
+	 * Pairwise ciphers: CCMP
+	 * Authentication suites: SAE
+	 * Capabilities: 16-PTKSA-RC 1-GTKSA-RC MFP-required MFP-capable (0x00cc)
+RSN Element Override 2:
+	 * Version: 1
+	 * Group cipher: CCMP
+	 * Pairwise ciphers: GCMP-256
+	 * Authentication suites: SAE-EXT-KEY
+	 * Capabilities: 16-PTKSA-RC 1-GTKSA-RC MFP-required MFP-capable (0x00cc)
+
+Signed-off-by: Alex Gavin <a_gavin@icloud.com>
+Link: https://patch.msgid.link/20260316051646.18303-2-a_gavin@icloud.com
+Signed-off-by: Johannes Berg <johannes.berg@intel.com>
+---
+ scan.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+--- a/scan.c
++++ b/scan.c
+@@ -1893,6 +1893,14 @@ static void print_wifi_osen(const uint8_
+ 	print_osen_ie("OSEN", "OSEN", len, data);
+ }
+ 
++static void print_wifi_rsn_override(const uint8_t type, uint8_t len,
++			    const uint8_t *data,
++			    const struct ie_context *ctx)
++{
++	printf("\n\t");
++	print_rsn_ie("CCMP", "IEEE802.1X", len, data);
++}
++
+ static bool print_wifi_wmm_param(const uint8_t *data, uint8_t len)
+ {
+ 	int i;
+@@ -2344,6 +2352,8 @@ static const struct ie_print wfa_printer
+ 	[16] = { "HotSpot 2.0 Indication", print_hs20_ind, 1, 255, BIT(PRINT_SCAN), },
+ 	[18] = { "HotSpot 2.0 OSEN", print_wifi_osen, 1, 255, BIT(PRINT_SCAN), },
+ 	[28] = { "OWE Transition Mode", print_wifi_owe_tarns, 7, 255, BIT(PRINT_SCAN), },
++	[41] = { "RSN Element Override", print_wifi_rsn_override, 4, 255, BIT(PRINT_SCAN), },
++	[42] = { "RSN Element Override 2", print_wifi_rsn_override, 4, 255, BIT(PRINT_SCAN), },
+ };
+ 
+ static void print_vendor(unsigned char len, unsigned char *data,

--- a/package/network/utils/iw/patches/200-reduce_size.patch
+++ b/package/network/utils/iw/patches/200-reduce_size.patch
@@ -24,15 +24,18 @@
  	case NL80211_CMD_JOIN_IBSS:
  		mac_addr_n2a(macbuf, nla_data(tb[NL80211_ATTR_MAC]));
  		printf("IBSS %s joined\n", macbuf);
-@@ -1297,9 +1300,9 @@ static int print_event(struct nl_msg *ms
+@@ -1297,9 +1300,14 @@ static int print_event(struct nl_msg *ms
  	case NL80211_CMD_ASSOC_COMEBACK: /* 147 */
  		parse_assoc_comeback(tb, gnlh->cmd);
  		break;
 +#endif
  	default:
--		printf("unknown event %d (%s)\n",
--		       gnlh->cmd, command_name(gnlh->cmd));
++#ifndef IW_FULL
 +		printf("unknown event %d\n", gnlh->cmd);
++#else
+ 		printf("unknown event %d (%s)\n",
+ 		       gnlh->cmd, command_name(gnlh->cmd));
++#endif
  		break;
  	}
  
@@ -212,7 +215,7 @@
  		return;
  	}
  
-+#ifdef IW_FULL
++#ifndef IW_FULL
 +	return;
 +#endif
 +

--- a/package/network/utils/iw/patches/200-reduce_size.patch
+++ b/package/network/utils/iw/patches/200-reduce_size.patch
@@ -200,7 +200,7 @@
  };
  
  static void print_wifi_wpa(const uint8_t type, uint8_t len, const uint8_t *data,
-@@ -2213,8 +2218,10 @@ static void print_wifi_wps(const uint8_t
+@@ -2221,8 +2226,10 @@ static void print_wifi_wps(const uint8_t
  
  static const struct ie_print wifiprinters[] = {
  	[1] = { "WPA", print_wifi_wpa, 2, 255, BIT(PRINT_SCAN), },
@@ -211,7 +211,7 @@
  };
  
  static inline void print_p2p(const uint8_t type, uint8_t len,
-@@ -2377,6 +2384,10 @@ static void print_vendor(unsigned char l
+@@ -2387,6 +2394,10 @@ static void print_vendor(unsigned char l
  		return;
  	}
  
@@ -222,7 +222,7 @@
  	if (len >= 4 && memcmp(data, wfa_oui, 3) == 0) {
  		if (data[3] < ARRAY_SIZE(wfa_printers) &&
  		    wfa_printers[data[3]].name &&
-@@ -2576,6 +2587,7 @@ static void print_capa_non_dmg(__u16 cap
+@@ -2586,6 +2597,7 @@ static void print_capa_non_dmg(__u16 cap
  		printf(" ESS");
  	if (capa & WLAN_CAPABILITY_IBSS)
  		printf(" IBSS");
@@ -230,7 +230,7 @@
  	if (capa & WLAN_CAPABILITY_CF_POLLABLE)
  		printf(" CfPollable");
  	if (capa & WLAN_CAPABILITY_CF_POLL_REQUEST)
-@@ -2604,6 +2616,7 @@ static void print_capa_non_dmg(__u16 cap
+@@ -2614,6 +2626,7 @@ static void print_capa_non_dmg(__u16 cap
  		printf(" DelayedBACK");
  	if (capa & WLAN_CAPABILITY_IMM_BACK)
  		printf(" ImmediateBACK");
@@ -238,7 +238,7 @@
  }
  
  static int print_bss_handler(struct nl_msg *msg, void *arg)
-@@ -2694,8 +2707,10 @@ static int print_bss_handler(struct nl_m
+@@ -2704,8 +2717,10 @@ static int print_bss_handler(struct nl_m
  		else
  			printf("\tfreq: %d\n", freq);
  
@@ -249,7 +249,7 @@
  	}
  	if (bss[NL80211_BSS_BEACON_INTERVAL])
  		printf("\tbeacon interval: %d TUs\n",
-@@ -2889,6 +2904,7 @@ static int handle_stop_sched_scan(struct
+@@ -2899,6 +2914,7 @@ static int handle_stop_sched_scan(struct
  	return 0;
  }
  
@@ -257,7 +257,7 @@
  COMMAND(scan, sched_start,
  	SCHED_SCAN_OPTIONS,
  	NL80211_CMD_START_SCHED_SCAN, 0, CIB_NETDEV, handle_start_sched_scan,
-@@ -2899,3 +2915,4 @@ COMMAND(scan, sched_start,
+@@ -2909,3 +2925,4 @@ COMMAND(scan, sched_start,
  COMMAND(scan, sched_stop, "",
  	NL80211_CMD_STOP_SCHED_SCAN, 0, CIB_NETDEV, handle_stop_sched_scan,
  	"Stop an ongoing scheduled scan.");


### PR DESCRIPTION
These are multiple independent commits which are activating some features which are mandatory in Wifi 7 and make some optional options configurable by the users. This should fix some compatibility problems we see with Pixel 10 and other wifi devices. 

 * GCMP-256 is only activated in EHT (WIFI 7) and not in older versions by default. It is only mandatory in EHT and recommended in others.
 * advertise SAE-EXT-KEY AKM on EHT APs
 * enable Beacon Protection by default with PMF