### PR TITLE
kernel: net: sfp: add quirk for PLUSOPTIC SFP-1GE-FE-PLUI

### DIFF
--- a/target/linux/generic/pending-6.18/751-net-sfp-add-quirk-for-PLUSOPTIC-SFP-1GE-FE-PLUI.patch
+++ b/target/linux/generic/pending-6.18/751-net-sfp-add-quirk-for-PLUSOPTIC-SFP-1GE-FE-PLUI.patch
@@ -1,0 +1,48 @@
+From: Mark Comerford <markcomerford@gmail.com>
+Subject: [PATCH] net: sfp: add quirk for PLUSOPTIC SFP-1GE-FE-PLUI copper SFP
+
+The PLUSOPTIC SFP-1GE-FE-PLUI 1G copper SFP embeds a Marvell 88E1111 PHY
+(real ID 0x01410cc2) but allows PHY register access slightly after its
+module-present signal is asserted. The first PHY-ID read returns garbage
+(e.g. 0xf95dbb91) which fails to match any registered PHY driver, and
+the sfp_add_phy() call fails with -EINVAL:
+
+  PHY smbus:sfp-pN:16 (id 0xf95dbb91) has no driver loaded
+  Drivers which handle known common cases: CONFIG_BCM84881_PHY, CONFIG_MARVELL_PHY
+  sfp sfp-pN: sfp_add_phy failed: -EINVAL
+
+Unlike RollBall modules, this PHY does not return 0xffff, so the
+existing sm_phy_retries path (which only retries on -ENODEV) never
+fires, and the module is left unbound until the user re-seats it.
+
+Give the module's internal PHY enough time to settle before the first
+probe by bumping module_t_wait to 4 s via a new fixup that does not
+touch the MDIO protocol (the PHY is plain clause-22, not RollBall).
+
+Signed-off-by: Mark Comerford <markcomerford@gmail.com>
+---
+ drivers/net/phy/sfp.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+--- a/drivers/net/phy/sfp.c
++++ b/drivers/net/phy/sfp.c
+@@ -420,6 +420,11 @@ static void sfp_fixup_fs_10gt(struct sfp
+ 	sfp_fixup_rollball_wait4s(sfp);
+ }
+
++static void sfp_fixup_plusoptic_copper(struct sfp *sfp)
++{
++	sfp->module_t_wait = msecs_to_jiffies(4000);
++}
++
+ static void sfp_fixup_halny_gsfp(struct sfp *sfp)
+ {
+ 	/* Ignore the TX_FAULT and LOS signals on this module.
+@@ -565,6 +570,7 @@ static const struct sfp_quirk sfp_quirks
+ 	SFP_QUIRK_F("OEM", "RTSFP-10", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_F("OEM", "RTSFP-10G", sfp_fixup_rollball_cc),
+ 	SFP_QUIRK_F("QINIYEK", "BJ-SFP-10G-T", sfp_fixup_fs_10gt),
++	SFP_QUIRK_F("PLUSOPTIC", "SFP-1GE-FE-PLUI", sfp_fixup_plusoptic_copper),
+ 	SFP_QUIRK_F("Turris", "RTSFP-2.5G", sfp_fixup_rollball),
+ 	SFP_QUIRK_F("Turris", "RTSFP-10", sfp_fixup_rollball),
+ 	SFP_QUIRK_F("Turris", "RTSFP-10G", sfp_fixup_rollball),


### PR DESCRIPTION
The PLUSOPTIC SFP-1GE-FE-PLUI 1G copper SFP embeds a Marvell 88E1111 PHY (real ID 0x01410cc2) but allows PHY register access shortly after mod-def0 is asserted. The first PHY ID read returns a random value which fails to match any registered driver, and sfp_add_phy() fails:

  PHY smbus:sfp-pN:16 (id 0xf95dbb91) has no driver loaded
  Drivers which handle known common cases: CONFIG_BCM84881_PHY, CONFIG_MARVELL_PHY
  sfp sfp-pN: sfp_add_phy failed: -EINVAL

Unlike RollBall modules, this PHY does not return all-ones during initialisation, so get_phy_device() does not return -ENODEV and the existing sm_phy_retries path is never entered. The module is left unbound until the user physically re-seats it.

Add a quirk that bumps module_t_wait to 4 s so the internal PHY has time to settle before the first probe. The MDIO protocol is left at the default clause-22 path as this is a plain Marvell PHY, not a RollBall module.

Tested on a Hasivo F1100WP-4SX-4XGT (Realtek RTL9303) where this module previously required manual re-seating on every boot; with the quirk it links cleanly on first insertion.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
