### PR TITLE
mediatek: fix MAC address assignment for ZBT Z8102AX V2

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
@@ -128,7 +128,9 @@
 		compatible = "mediatek,eth-mac";
 		reg = <0>;
 		phy-mode = "2500base-x";
+
 		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_2a>;
 
 		fixed-link {
 			speed = <2500>;
@@ -142,8 +144,9 @@
 		reg = <1>;
 		phy-mode = "gmii";
 		phy-handle = <&int_gbe_phy>;
+
 		nvmem-cell-names = "mac-address";
-		nvmem-cells = <&macaddr_factory_02a>;
+		nvmem-cells = <&macaddr_factory_24>;
 	};
 };
 
@@ -220,29 +223,21 @@
 		port@0 {
 			reg = <0>;
 			label = "lan1";
-			nvmem-cell-names = "mac-address";
-			nvmem-cells = <&macaddr_factory_004>;
 		};
 
 		port@1 {
 			reg = <1>;
 			label = "lan2";
-			nvmem-cell-names = "mac-address";
-			nvmem-cells = <&macaddr_factory_004>;
 		};
 
 		port@2 {
 			reg = <2>;
 			label = "lan3";
-			nvmem-cell-names = "mac-address";
-			nvmem-cells = <&macaddr_factory_004>;
 		};
 
 		port@3 {
 			reg = <3>;
 			label = "lan4";
-			nvmem-cell-names = "mac-address";
-			nvmem-cells = <&macaddr_factory_004>;
 		};
 
 		port@6 {
@@ -324,10 +319,10 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
-	macaddr_factory_004: macaddr@4 {
-		reg = <0x4 0x6>;
+	macaddr_factory_24: macaddr@24 {
+		reg = <0x24 0x6>;
 	};
-	macaddr_factory_02a: macaddr@2a {
+	macaddr_factory_2a: macaddr@2a {
 		reg = <0x2a 0x6>;
 	};
 	eeprom_factory: eeprom@0 {


### PR DESCRIPTION
The ZBT Z8102AX V2 stores its Ethernet MAC addresses in the factory
partition at offsets 0x24 and 0x2a.

Use offset 0x2a for gmac0 and offset 0x24 for gmac1, and remove the
duplicate MAC address assignment from the LAN switch ports. This avoids
all LAN ports being assigned the same MAC address from offset 0x04.

```
label: f8:5e:3c:99:95:c0
wifi-2.4G f8 5e 3c 99 95 be
wifi-5.8G f8 5e 3c 99 95 bf
eth0-lan  f8 5e 3c 99 95 c0
eth1-wan  f8 5e 3c 99 95 c1

:~# hexdump -C /dev/mtd2 | more
00000000  81 79 00 00 f8 5e 3c 99  95 be f8 5e 3c 99 95 bf  |.y...^<....^<...|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000020  00 00 00 00 f8 5e 3c 99  95 c1 f8 5e 3c 99 95 c0  |.....^<....^<...|
00000030  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|

```