### PR TITLE
scripts: add git_commit to profiles.json

### DIFF
--- a/scripts/json_overview_image_info.py
+++ b/scripts/json_overview_image_info.py
@@ -2,7 +2,7 @@
 
 from os import getenv, environ
 from pathlib import Path
-from subprocess import run, PIPE
+from subprocess import run, PIPE, DEVNULL
 from sys import argv
 import json
 import re
@@ -91,6 +91,15 @@ if output:
         "release": linux_release,
         "vermagic": linux_vermagic,
     }
+
+    git_commit = run(
+        ["git", "rev-parse", "HEAD"],
+        stdout=PIPE,
+        stderr=DEVNULL,
+        universal_newlines=True,
+    )
+    if git_commit.returncode == 0:
+        output["git_commit"] = git_commit.stdout.strip()
 
     for artifact in "imagebuilder", "sdk", "toolchain":
         filename = add_artifact(artifact)


### PR DESCRIPTION
Right now we only have the special getver.sh output (i.e. r32802-f505120278) instead of the actual, full git hash. Offer the full hash for downstream tooling, specifically the KernelCI.