### PR TITLE
realtek: add support for Hasivo F1100W-4SX-4XGT and variants

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -96,6 +96,8 @@ realtek_setup_macs()
 	zyxel,gs1920-24hp-v2)
 		lan_mac="$(get_mac_label)"
 		;;
+	hasivo,f1100w-4sx-4xgt|\
+	hasivo,f1100w-4sx-4xgt-512mb|\
 	tplink,tl-st1008f-v2|\
 	zyxel,xgs1010-12-a1)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -95,6 +95,8 @@ realtek_setup_macs()
 	zyxel,gs1920-24hp-v2)
 		lan_mac="$(get_mac_label)"
 		;;
+	hasivo,f1100w-4sx-4xgt|\
+	hasivo,f1100w-4sx-4xgt-512mb|\
 	tplink,tl-st1008f-v2|\
 	zyxel,xgs1010-12-a1)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
+++ b/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
@@ -9,12 +9,27 @@ BOARD_CFG=/etc/board.json
 
 [ "$(rootfs_type)" = "tmpfs" ] && exit 0
 
+# Some devices make it hard or impossible to acquire a usable ethaddr / MAC address
+# of the device. Some store it in weird places, some ship with only the common
+# Realtek dummy ethaddr, and some are outright broken.
+#
+# For these devices, we generate a random ethaddr in /etc/board.d/02_network,
+# which is stored in /etc/board.json. Here we take this random ethaddr and
+# persist it in the U-Boot environment, so that it survives sysupgrades.
+
 case "$(board_name)" in
+hasivo,f1100w-4sx-4xgt|\
+hasivo,f1100w-4sx-4xgt-512mb|\
 tplink,tl-st1008f-v2)
 	env_ethaddr=$(macaddr_canonicalize "$(fw_printenv -n ethaddr 2>/dev/null)")
 
-	# This device ships with a dummy ethaddr because it's an unmanaged switch.
-	# If it hasn't been updated to another one yet, do that now.
+	# F1100W-4SX-4XGT and its variants ship with the dummy ethaddr in the u-boot
+	# environment, and the real ethaddr stored in RUNTIME/RUNTIME2 JFFS2 partitions,
+	# which would be annoying to deal with. Also ethaddr isn't printed on the case.
+	#
+	# TL-ST1008F v2 ships with a dummy ethaddr because it's an unmanaged switch.
+	#
+	# We persist the random ethaddr if the currently stored ethaddr is empty or dummy.
 	if [ -z "$env_ethaddr" ] || [ "$env_ethaddr" = "00:e0:4c:00:00:00" ]; then
 		json_init
 		json_load_file "$BOARD_CFG"

--- a/target/linux/realtek/dts/rtl9303_hasivo_f1100w-4sx-4xgt-512mb.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_f1100w-4sx-4xgt-512mb.dts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl9303_hasivo_f1100w-4sx-4xgt-common.dtsi"
+
+/ {
+	compatible = "hasivo,f1100w-4sx-4xgt-512mb", "realtek,rtl930x-soc";
+	model = "Hasivo F1100W-4SX-4XGT (512MB)";
+
+	memory@0 {
+		reg = <0x00000000 0x10000000>, /* 256 MiB lowmem */
+		      <0x20000000 0x10000000>; /* 256 MiB highmem */
+	};
+};

--- a/target/linux/realtek/dts/rtl9303_hasivo_f1100w-4sx-4xgt-common.dtsi
+++ b/target/linux/realtek/dts/rtl9303_hasivo_f1100w-4sx-4xgt-common.dtsi
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	chosen {
+		stdout-path = "serial0:38400n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: led-0 {
+			gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+
+		led_set0 = <
+			(RTL93XX_LED_SET_NONE)
+			(RTL93XX_LED_SET_10M | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_1G |
+			 RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_5G |
+			 RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+		>;
+	};
+
+	sfp0: sfp-p1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		mod-def0-gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp1: sfp-p2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		mod-def0-gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp2: sfp-p3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		mod-def0-gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp3: sfp-p4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		mod-def0-gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c0: i2c@0 { reg = <0>; };
+	i2c1: i2c@1 { reg = <1>; };
+	i2c2: i2c@2 { reg = <2>; };
+	i2c3: i2c@3 { reg = <3>; };
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* stock is LOADER */
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x00e0000>;
+				read-only;
+			};
+
+			/* stock is BDINFO */
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x00e0000 0x0010000>;
+			};
+
+			/* stock is SYSINFO */
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0x00f0000 0x0010000>;
+			};
+
+			/* stock is CFG JFFS2 */
+			partition@100000 {
+				label = "jffs";
+				reg = <0x0100000 0x0100000>;
+			};
+
+			/* stock is LOG JFFS2 */
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x0200000 0x0100000>;
+			};
+
+			/* stock is RUNTIME and RUNTIME2
+			 * RUNTIME is <0x0300000 0x0e80000>
+			 * RUNTIME2 is <0x1180000 0x0e80000>
+			 */
+			partition@300000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x0300000 0x1d00000>;
+			};
+		};
+	};
+};
+
+&mdio_bus0 {
+	PHY_C45(26, 16)
+};
+
+&mdio_bus1 {
+	PHY_C45(27, 0)
+};
+
+&mdio_bus2 {
+	PHY_C45(24, 0)
+};
+
+&mdio_bus3 {
+	PHY_C45(25, 16)
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* SFP+ ports, lan1-4 */
+		SWITCH_PORT_SFP(0, 1, 2, 0, 0)
+		SWITCH_PORT_SFP(8, 2, 3, 0, 1)
+		SWITCH_PORT_SFP(16, 3, 4, 0, 2)
+		SWITCH_PORT_SFP(20, 4, 5, 0, 3)
+
+		/* RJ45 ports, lan5-8 */
+		SWITCH_PORT_LED(24, 5, 6, 0, usxgmii)
+		SWITCH_PORT_LED(25, 6, 7, 0, usxgmii)
+		SWITCH_PORT_LED(26, 7, 8, 0, usxgmii)
+		SWITCH_PORT_LED(27, 8, 9, 0, usxgmii)
+
+		/* CPU port */
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&thermal_zones {
+	sfp-thermal {
+		polling-delay-passive = <10000>;
+		polling-delay = <10000>;
+		thermal-sensors = <&sfp0>, <&sfp1>, <&sfp2>, <&sfp3>;
+		trips {
+			sfp-crit {
+				temperature = <110000>;
+				hysteresis = <1000>;
+				type = "critical";
+			};
+		};
+	};
+};
+

--- a/target/linux/realtek/dts/rtl9303_hasivo_f1100w-4sx-4xgt.dts
+++ b/target/linux/realtek/dts/rtl9303_hasivo_f1100w-4sx-4xgt.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl9303_hasivo_f1100w-4sx-4xgt-common.dtsi"
+
+/ {
+	compatible = "hasivo,f1100w-4sx-4xgt", "realtek,rtl930x-soc";
+	model = "Hasivo F1100W-4SX-4XGT";
+
+	memory@0 {
+		reg = <0x00000000 0x10000000>; /* 256 MiB */
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -12,6 +12,35 @@ define Device/d-link_dgs-1250-28x
 endef
 TARGET_DEVICES += d-link_dgs-1250-28x
 
+define Device/hasivo_f1100w-4sx-4xgt-common
+  SOC := rtl9303
+  DEVICE_VENDOR := Hasivo
+  DEVICE_MODEL := F1100W-4SX-4XGT
+  DEVICE_ALT0_VENDOR := Hasivo
+  DEVICE_ALT0_MODEL := F1100W-4SX-4XGT-SE
+  DEVICE_ALT1_VENDOR := Hasivo
+  DEVICE_ALT1_MODEL := F1100WP-4SX-4XGT
+  DEVICE_ALT2_VENDOR := Hasivo
+  DEVICE_ALT2_MODEL := F1100WP-4SX-4XGT-SE
+  DEVICE_PACKAGES := kmod-phy-realtek rtl8261n-firmware
+  IMAGE_SIZE := 29696k
+  $(Device/kernel-lzma)
+endef
+
+define Device/hasivo_f1100w-4sx-4xgt
+  $(Device/hasivo_f1100w-4sx-4xgt-common)
+endef
+TARGET_DEVICES += hasivo_f1100w-4sx-4xgt
+
+define Device/hasivo_f1100w-4sx-4xgt-512mb
+  $(Device/hasivo_f1100w-4sx-4xgt-common)
+  DEVICE_VARIANT := 512MB
+  DEVICE_ALT0_VARIANT := 512MB
+  DEVICE_ALT1_VARIANT := 512MB
+  DEVICE_ALT2_VARIANT := 512MB
+endef
+TARGET_DEVICES += hasivo_f1100w-4sx-4xgt-512mb
+
 define Device/hasivo_s1100w-8xgt-se
   SOC := rtl9303
   DEVICE_VENDOR := Hasivo


### PR DESCRIPTION
Depends: 
- [x] #23427 for 10 GbE RJ45

Related:
- #22245 for PoE

This commit adds support for the Hasivo F1100W-4SX-4XGT ethernet 10Gbase and PoE switch.
It also adds support for a whole matrix of variants of this device:

| Device | Revision | RAM | PoE | Console |
|---|---|---|---|---|
| F1100W-4SX-4XGT | v1.03 | 256 MB | n/a | RJ45 |
| F1100W-4SX-4XGT | v1.02 | 512 MB | n/a | RJ45 |
| F1100W-4SX-4XGT-SE | v1.03 | 256 MB | n/a | internal |
| F1100W-4SX-4XGT-SE | v1.02 | 512 MB | n/a | internal |
| F1100WP-4SX-4XGT | v1.03 | 256 MB | yes | RJ45 |
| F1100WP-4SX-4XGT | v1.02 | 512 MB | yes | RJ45 |
| F1100WP-4SX-4XGT-SE | v1.03 | 256 MB | yes | internal |
| F1100WP-4SX-4XGT-SE | v1.02 | 512 MB | yes | internal |

The devices are identical except for presence of the PoE daughter board,
RJ45 console port, and 256 or 512 MB RAM.

The non-512 MB image also works on the older 512 MB board revisions, but not vice versa.

Credit to @mensi @bevanweiss @markc1984

## Hardware

| | |
|---:|:---|
| SoC | RTL9303 rev B |
| RAM | 256 MB Samsung K4B2G1646F DDR3L (board revision v1.03), <br> or 512 MB unknown module (board revision v1.02 and older) |
| Flash | 32 MB Macronix MX25L25645G SPI NOR, <br> 29 MiB usable by OpenWrt |
| Ethernet | 4x SFP+ via SoC (10G/2.5G/1G), <br> 4x RJ45 via 4x RTL8261BE PHY (10G/5G/2.5G/1G/100M/10M) |
| PoE | only on WP variants, <br> 1x 802.3bt 90 W (port 5), <br> 3x 802.3at 30 W (ports 6, 7, 8), <br> via daughter board with Hasivo HS104PTI controller, <br> PoE works but is unmanaged --> future work |
| LEDs | 14 LEDs, 1x power orange, 1x system green, 4x PoE orange, 8x link green/red |
| Button | Reset |
| Console | RJ45 38400 bps 8n1, or pin holes on SE variants |

## Installing OpenWrt

Note: With vendor firmware 7.1.9, the bootloader's network profile is broken.
We need to select a different profile with port/phy overlap to make the TFTP
transfer work. Then only port 5 works in the OpenWrt initramfs, but all ports
work fine after flashing, when we don't need the profile trick anymore.

1. Attach to RJ45 serial console port using a cisco cable.
2. Attach your computer to Port 5 (the first RJ45 port).
3. Serve initramfs-kernel.bin on TFTP 192.168.1.111.
4. Power on the device.
5. Interrupt U-Boot by pressing `Ctrl+C`, then `Z`, then `H`, during 3 second countdown.
6. Run: `setenv boardmodel 'RTL9303_5x8261BE_2XGE_ZHIHUI' ; rtk network on`
7. Run: `tftpboot 0x84f00000 initramfs-kernel.bin ; bootm 0x84f00000`
8. Use `mtd dump` to make backups of all flash partitions.
9. Use SCP to copy `squashfs-sysupgrade.bin` to the device, then run `sysupgrade`.

## Restoring factory firmware

OpenWrt uses the `RUNTIME` and `RUNTIME2` partitions as one combined partition.
To restore them from backups, boot from `initramfs-kernel.bin` just like during
the installation, then use `mtd write` to write your backups of the factory
`mtd5` and `mtd6` partitions.

## Notes/Quirks

- U-Boot interruption is obfuscated. Press `Ctrl+C`, then `Z`, then `H`, during the 3 second countdown.
- U-Boot rtk network profile is broken. Use the `RTL9303_5x8261BE_2XGE_ZHIHUI` profile instead, it makes at least port 5 work.
- MAC address is stored on the `RUNTIME` or `RUNTIME2` partitions, which are used by OpenWrt. Instead, we generate one random MAC address and store it in the U-Boot environment.
- PoE works but is unmanaged. The HS104 driver is worked on in https://github.com/openwrt/openwrt/pull/22245 and will work with ethtool and the kernel's new `pse-pd` subsystem.