### PR TITLE
uboot-at91: fix wrong BUILD_DEVICES for sama5d4_xplained_nandflash

### DIFF
--- a/package/boot/uboot-at91/Makefile
+++ b/package/boot/uboot-at91/Makefile
@@ -104,7 +104,7 @@ endef
 define U-Boot/sama5d4_xplained_nandflash
   NAME:=SAMA5D4 Xplained board (NandFlash)
   BUILD_SUBTARGET:=sama5
-  BUILD_DEVICES:=microchip_sama5d3-xplained
+  BUILD_DEVICES:=microchip_sama5d4-xplained
 endef
 
 define U-Boot/sama5d27_som1_ek_mmc


### PR DESCRIPTION
The sama5d4_xplained_nandflash target incorrectly references microchip_sama5d3-xplained as its BUILD_DEVICES value.

This appears to be a copy-paste error, as all other SAMA5D4 Xplained targets (e.g. mmc and spiflash) correctly use microchip_sama5d4-xplained. The target name itself also clearly refers to the SAMA5D4 platform.

In addition, the SAMA5D3 Xplained and SAMA5D4 Xplained boards use different NAND flash hardware and configurations, so pointing the nandflash target to a SAMA5D3 device is incorrect and may lead to invalid builds or runtime issues.

Fix the inconsistency by updating BUILD_DEVICES to microchip_sama5d4-xplained, aligning the nandflash target with the rest of the SAMA5D4 definitions and ensuring the correct device mapping.

Signed-off-by: Cerrone Diamant cerrone@tutamail.com