### PR TITLE
realtek: arch: rtl-otto: add rtl9607 model info support

### DIFF
--- a/target/linux/realtek/files-6.18/arch/mips/include/asm/mach-rtl-otto/mach-rtl-otto.h
+++ b/target/linux/realtek/files-6.18/arch/mips/include/asm/mach-rtl-otto/mach-rtl-otto.h
@@ -25,6 +25,9 @@
 #define RTL839X_CHIP_INFO		(0x0FF4)
 #define RTL93XX_MODEL_NAME_INFO		(0x0004)
 #define RTL93XX_CHIP_INFO		(0x0008)
+#define RTL96XX_MODEL_NAME_INFO		(0x10000)
+#define RTL96XX_CHIP_INFO		(0x10004)
+#define RTL96XX_CHIP_SUB_INFO		(0x10008)
 
 #define RTL838X_INT_RW_CTRL		(0x0058)
 #define RTL838X_EXT_VERSION		(0x00D0)
@@ -38,12 +41,14 @@
 #define RTL8390_FAMILY_ID		(0x8390)
 #define RTL9300_FAMILY_ID		(0x9300)
 #define RTL9310_FAMILY_ID		(0x9310)
+#define RTL9607_FAMILY_ID		(0x9607)
 
 /* Basic SoC Features */
 #define RTL838X_CPU_PORT		28
 #define RTL839X_CPU_PORT		52
 #define RTL930X_CPU_PORT		28
 #define RTL931X_CPU_PORT		56
+#define RTL9607_CPU_PORT		9
 
 struct rtl83xx_soc_info {
 	unsigned char *name;
@@ -52,6 +57,7 @@ struct rtl83xx_soc_info {
 	unsigned int revision;
 	unsigned int cpu;
 	bool testchip;
+	unsigned int subtype;
 	int cpu_port;
 	int memory_size;
 };

--- a/target/linux/realtek/files-6.18/arch/mips/rtl-otto/prom.c
+++ b/target/linux/realtek/files-6.18/arch/mips/rtl-otto/prom.c
@@ -215,6 +215,23 @@ static void __init rtl93xx_read_details(u32 model)
 		soc_info.testchip = true;
 }
 
+static void __init rtl96xx_read_details(u32 model)
+{
+	u32 chip_info, chip_subtype;
+
+	sw_w32(0xa << 28, RTL96XX_CHIP_INFO);
+
+	chip_info = sw_r32(RTL96XX_CHIP_INFO);
+	soc_info.cpu = chip_info & 0xffff;
+
+	sw_w32(0xb << 28, RTL96XX_CHIP_SUB_INFO);
+
+	chip_subtype = sw_r32(RTL96XX_CHIP_SUB_INFO);
+	soc_info.subtype = chip_subtype & 0x1f;
+
+	soc_info.revision = model & 0xf;
+}
+
 static u32 __init read_model(void)
 {
 	u32 model, id;
@@ -259,6 +276,16 @@ static u32 __init read_model(void)
 		return model;
 	}
 
+	model = sw_r32(RTL96XX_MODEL_NAME_INFO);
+	id = model >> 16 & 0xffff;
+	if (id == 0x9607) {
+		soc_info.id = id;
+		soc_info.family = RTL9607_FAMILY_ID;
+		soc_info.cpu_port = RTL9607_CPU_PORT;
+		rtl96xx_read_details(model);
+		return model;
+	}
+
 	return 0;
 }
 
@@ -281,6 +308,7 @@ static void __init set_system_type(void)
 {
 	char revision = '?';
 	char *es = "";
+	char subtype[12] = "";
 
 	if (soc_info.revision >= 0 && soc_info.revision < 26)
 		revision = 'A' + soc_info.revision;
@@ -288,9 +316,12 @@ static void __init set_system_type(void)
 	if (soc_info.testchip)
 		es = " ES";
 
+	if (soc_info.subtype)
+		snprintf(subtype, sizeof(subtype), " subtype %02X", soc_info.subtype);
+
 	snprintf(rtl_system_type, sizeof(rtl_system_type),
-		 "Realtek %s%s rev %c (%04X)",
-		 soc_info.name, es, revision, soc_info.cpu);
+		 "Realtek %s%s%s rev %c (%04X)",
+		 soc_info.name, es, subtype, revision, soc_info.cpu);
 }
 
 static void get_system_memory(void)
@@ -311,8 +342,11 @@ static void get_system_memory(void)
 
 static void prepare_highmem(void)
 {
-	if ((soc_info.family != RTL9300_FAMILY_ID) ||
-	    (soc_info.memory_size <= 256 * 1024 * 1024) ||
+	if (soc_info.family != RTL9300_FAMILY_ID &&
+	    soc_info.family != RTL9607_FAMILY_ID)
+		return;
+
+	if ((soc_info.memory_size <= 256 * 1024 * 1024) ||
 	    !IS_ENABLED(CONFIG_HIGHMEM))
 		return;
 


### PR DESCRIPTION
I believe the same way as with the separated patches for drivers support on RTL9607C, changes to `arch/mips/rtl-otto` can be carved out into its own patch from the https://github.com/openwrt/openwrt/pull/20064

As it was there pretty much from the beginning of that pull request, it has been numerously tested by different people.
cc: @ProMix0 @naseef 

From my own tests the model and subtype readout works as expected.

```
## Booting kernel from Legacy Image at 81000000 ...
   Image Name:   MIPS OpenWrt Linux-6.18.21
   Image Type:   MIPS Linux Kernel Image (lzma compressed)
   Data Size:    5453575 Bytes = 5.2 MiB
   Load Address: 80100000
   Entry Point:  80100000
   Verifying Checksum ... OK
   Uncompressing Kernel Image
[    0.000000] Linux version 6.18.21 (binguy@binpc) (mips-openwrt-linux-musl-gcc (OpenWrt GCC 14.3.0 r34044-511734d67f) 14.3.0, GNU ld (GNU Binutils) 2.44) #0 SMP Sun Apr 19 10:38:16 2026
[    0.000000] Realtek RTL9607C subtype 18 rev B (6831) SoC with 256 MB
```

Let me know if this carve out is fine or should it rather be together with the aforementioned subtarget pull request.