### PR TITLE
hostapd: check wps_cred_add_sae for ucode credentials

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-iface.json
@@ -1205,6 +1205,10 @@
 		"wps_pushbutton": {
 			"description": "Support WPS pushbutton",
 			"type": "boolean"
+		},
+		"wps_cred_add_sae": {
+			"description": "Automatically enable SAE (WPA3-Personal transition mode) when a WPA2-PSK credential is received via WPS",
+			"type": "boolean"
 		}
 	}
 }

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -254,7 +254,7 @@ function iface_wps(config) {
 
 		append_vars(config, [
 			'wps_state', 'device_type', 'device_name', 'config_methods', 'wps_independent', 'eap_server',
-			'ap_pin', 'ap_setup_locked', 'upnp_iface', 'uuid'
+			'ap_pin', 'ap_setup_locked', 'upnp_iface', 'uuid', 'wps_cred_add_sae'
 		]);
 	}
 }

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/supplicant.uc
@@ -261,7 +261,7 @@ export function generate(config_list, data, interface) {
 	if (data.config.scan_list)
 		interface.config.freq_list = join(" ", data.config.scan_list);
 
-	append_vars(interface.config, [ 'country', 'beacon_int', 'freq_list' ]);
+	append_vars(interface.config, [ 'country', 'beacon_int', 'freq_list', 'wps_cred_add_sae' ]);
 
 	setup_sta(data.config, interface.config);
 

--- a/package/network/services/hostapd/src/wpa_supplicant/ucode.c
+++ b/package/network/services/hostapd/src/wpa_supplicant/ucode.c
@@ -199,7 +199,11 @@ void wpas_ucode_wps_complete(struct wpa_supplicant *wpa_s,
 	switch (cred->auth_type) {
 	case WPS_AUTH_WPAPSK | WPS_AUTH_WPA2PSK:
 	case WPS_AUTH_WPA2PSK:
-		encryption = "psk2";
+		if (wpa_s->conf->wps_cred_add_sae &&
+		    cred->key_len != 2 * PMK_LEN)
+			encryption = "sae-mixed";
+		else
+			encryption = "psk2";
 		break;
 	case WPS_AUTH_WPAPSK:
 		encryption = "psk";


### PR DESCRIPTION
When generate ucode credentials ubus event check
also wps_cred_add_sae set, which allow to use WPS
with EAP and PSK.

Using this for multiap WPS and SAE configuration.