### PR TITLE
base-files: preserve root's $HOME during sysupgrade

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -27,6 +27,7 @@ PKG_CONFIG_DEPENDS += \
 	CONFIG_EMMC_SUPPORT \
 	CONFIG_CLEAN_IPKG \
 	CONFIG_PER_FEED_REPO \
+	CONFIG_BASE_FILES_ROOTDIR_PRESERVE \
 	$(foreach feed,$(FEEDS_AVAILABLE),CONFIG_FEED_$(feed))
 
 include $(INCLUDE_DIR)/package.mk
@@ -47,6 +48,14 @@ define Package/base-files
   TITLE:=Base filesystem for OpenWrt
   URL:=https://openwrt.org/
   VERSION:=$(PKG_RELEASE)~$(lastword $(subst -, ,$(REVISION)))
+endef
+
+define Package/base-files/config
+	config BASE_FILES_ROOTDIR_PRESERVE
+		bool "Preserve across sysupgrades"
+		default n
+		help
+		  Backup and restore during sysupgrade
 endef
 
 define Package/base-files/conffiles
@@ -71,6 +80,7 @@ define Package/base-files/conffiles
 /etc/shinit
 /etc/sysctl.conf
 /etc/sysupgrade.conf
+$(if $(CONFIG_BASE_FILES_ROOTDIR_PRESERVE),/root/)
 $(call $(TARGET)/conffiles)
 endef
 


### PR DESCRIPTION
Root will probably want to preserve his ssh keys, authorized_keys, his shell profile, any scripts he has in ~/bin/, etc.
