### PR TITLE
odhcp6c: fix default route clash with two active DHCPv6 clients

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.script
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.script
@@ -121,7 +121,10 @@ setup_interface () {
 		entry="${entry#*,}"
 		local valid="${entry%%,*}"
 		entry="${entry#*,}"
-		local metric="${entry%%,*}"
+		local ra_metric="${entry%%,*}"
+
+		config_load network
+		config_get metric "$INTERFACE" metric "$ra_metric"
 
 		for xentry in $RA_ROUTES; do
 			local xprefix="${xentry%%,*}"


### PR DESCRIPTION
Currently, dhcpv6.script ignores the 'metric' option defined in /etc/config/network because the variable is not exported to the script's environment by netifd/odhcp6c. This results in all DHCPv6/RA default routes being assigned a RA-provided metric of 512.

In multi-WAN environments, this causes a routing clash where multiple interfaces have identical route priorities, leading to non-deterministic traffic flow and broken failover.

We can fix this by:
- Fetching the 'metric' value directly from the UCI interface configuration using config_get.
- Overriding the RA-provided metric with the UCI value if set.