### PR TITLE
generic: 6.12: dsa: mt7530: untag VLAN-aware bridge PVID

### DIFF
--- a/target/linux/generic/pending-6.12/999-net-dsa-mt7530-untag-vlan-aware-bridge-pvid.patch
+++ b/target/linux/generic/pending-6.12/999-net-dsa-mt7530-untag-vlan-aware-bridge-pvid.patch
@@ -1,0 +1,20 @@
+Index: linux-6.12.79/drivers/net/dsa/mt7530.c
+===================================================================
+--- linux-6.12.79.orig/drivers/net/dsa/mt7530.c
++++ linux-6.12.79/drivers/net/dsa/mt7530.c
+@@ -2352,6 +2352,7 @@ mt7530_setup(struct dsa_switch *ds)
+ 	}
+ 
+ 	ds->assisted_learning_on_cpu_port = true;
++	ds->untag_vlan_aware_bridge_pvid = true;
+ 	ds->mtu_enforcement_ingress = true;
+ 
+ 	if (priv->id == ID_MT7530) {
+@@ -2541,6 +2542,7 @@ mt7531_setup_common(struct dsa_switch *d
+ 	int ret, i;
+ 
+ 	ds->assisted_learning_on_cpu_port = true;
++	ds->untag_vlan_aware_bridge_pvid = true;
+ 	ds->mtu_enforcement_ingress = true;
+ 
+ 	mt753x_trap_frames(priv);


### PR DESCRIPTION
Fixes #18576.

Problem:
On OpenWrt One / mediatek filogic, with bridge VLAN filtering enabled,
untagged ingress traffic on an access/PVID port does not reach the
corresponding bridge VLAN upper interface. ARP is visible on the physical
port but not on br-lan.<vid>.

Change:
Enable DSA software untagging of the bridge PVID for VLAN-aware bridges in
the mt7530/mt7531 setup paths.

Tested:
- target: mediatek/filogic
- device: OpenWrt One
- base: v25.12.2
- build success confirmed
- runtime test confirmed:
  - client on eth1 configured as untagged/PVID VLAN 10
  - router interface on br-lan.10 at 192.168.10.1
  - ping from client to 192.168.10.1 succeeded
  - ip neigh show dev br-lan.10 learned 192.168.10.2 as REACHABLE