### PR TITLE
realtek: pcs: unify SerDes MAC mode setting

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -650,6 +650,14 @@ static int rtpcs_sds_set_mac_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode 
 
 /* RTL838X */
 
+/* RTL838X SDS_MODE_SEL field values */
+static const s16 rtpcs_838x_sds_hw_mode_vals[RTPCS_SDS_MODE_MAX] = {
+	[0 ... RTPCS_SDS_MODE_MAX - 1]	= -1,
+	[RTPCS_SDS_MODE_1000BASEX]	= 0x4,
+	[RTPCS_SDS_MODE_SGMII]		= 0x2,
+	[RTPCS_SDS_MODE_QSGMII]		= 0x6,
+};
+
 #define SDS(ctrl,n)	(&(ctrl)->serdes[n])
 
 static void rtpcs_838x_sds_patch_01_qsgmii_6275b(struct rtpcs_ctrl *ctrl)
@@ -812,42 +820,39 @@ static int rtpcs_838x_sds_power(struct rtpcs_serdes *sds, bool power_on)
 	return ret;
 }
 
-static int rtpcs_838x_sds_set_mode(struct rtpcs_serdes *sds,
-				   enum rtpcs_sds_mode hw_mode)
+/*
+ * RTL838X wrapper: after setting the MAC mode, SerDes 4-5 also need the
+ * companion INT_MODE_CTRL field written.
+ */
+static int rtpcs_838x_sds_set_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
 {
-	u8 sds_mode_shift, int_mode_shift;
-	u32 sds_mode_val, int_mode_val;
+	u8 int_mode_shift, int_mode_val;
+	int ret;
 
+	ret = rtpcs_sds_set_mac_mode(sds, hw_mode);
+	if (ret)
+		return ret;
+
+	if (sds->id < 4)
+		return 0;
+
+	int_mode_shift = (sds->id == 5) ? 3 : 0;
 	switch (hw_mode) {
 	case RTPCS_SDS_MODE_1000BASEX:
-		sds_mode_val = 0x4;
 		int_mode_val = 0x1;
 		break;
 	case RTPCS_SDS_MODE_SGMII:
-		sds_mode_val = 0x2;
 		int_mode_val = 0x2;
 		break;
 	case RTPCS_SDS_MODE_QSGMII:
-		sds_mode_val = 0x6;
 		int_mode_val = 0x5;
 		break;
 	default:
 		return -EINVAL;
 	}
 
-	/* Configure SerDes module mode (all SDS 0-5) */
-	sds_mode_shift = (5 - sds->id) * 5;
-	regmap_write_bits(sds->ctrl->map, RTPCS_838X_SDS_MODE_SEL,
-			  0x1f << sds_mode_shift, sds_mode_val << sds_mode_shift);
-
-	/* Configure MAC interface mode (only SDS 4-5) */
-	if (sds->id >= 4) {
-		int_mode_shift = (sds->id == 5) ? 3 : 0;
-		regmap_write_bits(sds->ctrl->map, RTPCS_838X_INT_MODE_CTRL,
-				  0x7 << int_mode_shift, int_mode_val << int_mode_shift);
-	}
-
-	return 0;
+	return regmap_write_bits(sds->ctrl->map, RTPCS_838X_INT_MODE_CTRL,
+				 0x7 << int_mode_shift, int_mode_val << int_mode_shift);
 }
 
 static int rtpcs_838x_sds_patch(struct rtpcs_serdes *sds,
@@ -894,8 +899,16 @@ static int rtpcs_838x_sds_patch(struct rtpcs_serdes *sds,
 
 static int rtpcs_838x_sds_probe(struct rtpcs_serdes *sds)
 {
+	u8 lsb = (5 - sds->id) * 5;
+
 	sds->type = RTPCS_SDS_TYPE_5G;
-	return 0;
+
+	/*
+	 * SDS_MODE_SEL packs 5-bit fields in reverse order: SDS 0 at [25:29],
+	 * SDS 5 at [0:4].
+	 */
+	return rtpcs_sds_alloc_field(sds, &sds->swcore_regs.mac_mode,
+				     RTPCS_838X_SDS_MODE_SEL, lsb, lsb + 4);
 }
 
 static int rtpcs_838x_init(struct rtpcs_ctrl *ctrl)
@@ -4367,6 +4380,7 @@ static const struct rtpcs_config rtpcs_838x_cfg = {
 	.pcs_ops		= &rtpcs_838x_pcs_ops,
 	.sds_ops		= &rtpcs_838x_sds_ops,
 	.sds_regs		= &rtpcs_838x_sds_regs,
+	.sds_hw_mode_vals	= rtpcs_838x_sds_hw_mode_vals,
 	.init			= rtpcs_838x_init,
 	.sds_probe		= rtpcs_838x_sds_probe,
 	.setup_serdes		= rtpcs_838x_setup_serdes,

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -967,6 +967,20 @@ static int rtpcs_838x_setup_serdes(struct rtpcs_serdes *sds,
 
 /* RTL839X */
 
+/*
+ * RTL839X MAC_SERDES_IF_CTRL mode values.
+ * From the vendor SDK; 100BASEX (0x8), 1000BASEX/SGMII (0x7) are documented
+ * but not yet exercised here.
+ */
+static const s16 rtpcs_839x_sds_hw_mode_vals[RTPCS_SDS_MODE_MAX] = {
+	[0 ... RTPCS_SDS_MODE_MAX - 1]  = -1,
+	[RTPCS_SDS_MODE_OFF]            = 0x0,
+	/* [RTPCS_SDS_MODE_100BASEX]    = 0x8, */
+	/* [RTPCS_SDS_MODE_1000BASEX]   = 0x7, */
+	/* [RTPCS_SDS_MODE_SGMII]       = 0x7, */
+	[RTPCS_SDS_MODE_QSGMII]         = 0x6,
+};
+
 static void rtpcs_839x_sds_reset(struct rtpcs_serdes *sds)
 {
 	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
@@ -1009,42 +1023,20 @@ static void rtpcs_839x_sds_reset(struct rtpcs_serdes *sds)
 	rtpcs_sds_write(odd_sds, 0x0, 0x3, 0x7106);
 }
 
-static int rtpcs_839x_sds_set_mode(struct rtpcs_serdes *sds,
-				   enum rtpcs_sds_mode hw_mode)
-{
-	u32 mode_val, reg, shift;
-
-	switch (hw_mode) {
-	case RTPCS_SDS_MODE_OFF:
-		mode_val = 0x0;
-		break;
-/*
-	case RTPCS_SDS_MODE_100BASEX:
-		mode_val = 0x8;
-		break;
-	case RTPCS_SDS_MODE_1000BASEX:
-	case RTPCS_SDS_MODE_SGMII:
-		mode_val = 0x7;
-		break;
-*/
-	case RTPCS_SDS_MODE_QSGMII:
-		mode_val = 0x6;
-		break;
-	default:
-		return -ENOTSUPP;
-	}
-
-	reg = RTPCS_839X_MAC_SERDES_IF_CTRL + (sds->id / 8) * 4;
-	shift = (sds->id % 8) * 4;
-	return regmap_write_bits(sds->ctrl->map, reg, 0xf << shift,
-				 mode_val << shift);
-}
-
 static int rtpcs_839x_sds_probe(struct rtpcs_serdes *sds)
 {
-	bool is_even = sds->id % 2 == 0;
+	u8 id = sds->id;
+	bool is_even = id % 2 == 0;
+	u8 lsb = (id % 8) * 4;
+	int ret;
 
-	if (sds->id == 8 || sds->id == 9 || sds->id == 12 || sds->id == 13)
+	ret = rtpcs_sds_alloc_field(sds, &sds->swcore_regs.mac_mode,
+				    RTPCS_839X_MAC_SERDES_IF_CTRL + (id / 8) * 4,
+				    lsb, lsb + 3);
+	if (ret)
+		return ret;
+
+	if (id == 8 || id == 9 || id == 12 || id == 13)
 		sds->type = RTPCS_SDS_TYPE_10G;
 	else
 		sds->type = RTPCS_SDS_TYPE_5G;
@@ -1183,7 +1175,7 @@ static int rtpcs_839x_setup_serdes(struct rtpcs_serdes *sds,
 	if (sds->type == RTPCS_SDS_TYPE_5G)
 		return 0;
 
-	ret = rtpcs_839x_sds_set_mode(sds, hw_mode);
+	ret = rtpcs_sds_set_mac_mode(sds, hw_mode);
 	if (ret < 0)
 		return ret;
 
@@ -4417,6 +4409,7 @@ static const struct rtpcs_config rtpcs_839x_cfg = {
 	.pcs_ops		= &rtpcs_839x_pcs_ops,
 	.sds_ops		= &rtpcs_839x_sds_ops,
 	.sds_regs		= &rtpcs_839x_sds_regs,
+	.sds_hw_mode_vals	= rtpcs_839x_sds_hw_mode_vals,
 	.init			= rtpcs_839x_init,
 	.sds_probe		= rtpcs_839x_sds_probe,
 	.setup_serdes		= rtpcs_839x_setup_serdes,

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -70,29 +70,24 @@
 #define RTPCS_93XX_MODEL_NAME_INFO		(0x0004)
 #define RTPCS_93XX_CHIP_INFO			(0x0008)
 
-/* RTL930X SerDes supports the following modes:
- * 0x02: SGMII		0x04: 1000BX_FIBER	0x05: FIBER100
- * 0x06: QSGMII		0x09: RSGMII		0x0d: USXGMII
- * 0x10: XSGMII		0x12: HISGMII		0x16: 2500Base_X
- * 0x17: RXAUI_LITE	0x19: RXAUI_PLUS	0x1a: 10G Base-R
- * 0x1b: 10GR1000BX_AUTO			0x1f: OFF
- */
-#define RTPCS_930X_SDS_MODE_SGMII	0x02
-#define RTPCS_930X_SDS_MODE_1000BASEX	0x04
-#define RTPCS_930X_SDS_MODE_QSGMII	0x06
-#define RTPCS_930X_SDS_MODE_USXGMII	0x0d
-#define RTPCS_930X_SDS_MODE_XSGMII	0x10
-#define RTPCS_930X_SDS_MODE_2500BASEX	0x16
-#define RTPCS_930X_SDS_MODE_10GBASER	0x1a
-#define RTPCS_930X_SDS_OFF		0x1f
-#define RTPCS_930X_SDS_MASK		0x1f
+#define RTPCS_930X_SDS_MODE_SEL_0		0x0194
+#define RTPCS_930X_SDS_MODE_SEL_1		0x02a0
+#define RTPCS_930X_SDS_MODE_SEL_2		0x02a4
+#define RTPCS_930X_SDS_MODE_SEL_3		0x0198
+#define RTPCS_930X_SDS_SUBMODE_CTRL_0		0x01cc
+#define RTPCS_930X_SDS_SUBMODE_CTRL_1		0x02d8
 
-/* RTL930X SerDes supports two submodes when mode is USXGMII:
- * 0x00: USXGMII (aka USXGMII_SX)
- * 0x02: 10G_QXGMII (aka USXGMII_QX)
- */
-#define RTPCS_930X_SDS_SUBMODE_USXGMII_SX	0x0
-#define RTPCS_930X_SDS_SUBMODE_USXGMII_QX	0x2
+#define RTPCS_93XX_SDS_MODE_SGMII		0x02
+#define RTPCS_93XX_SDS_MODE_1000BASEX		0x04
+#define RTPCS_93XX_SDS_MODE_QSGMII		0x06
+#define RTPCS_93XX_SDS_MODE_USXGMII		0x0d
+#define RTPCS_93XX_SDS_MODE_XSGMII		0x10
+#define RTPCS_93XX_SDS_MODE_2500BASEX		0x16
+#define RTPCS_93XX_SDS_MODE_10GBASER		0x1a
+#define RTPCS_93XX_SDS_MODE_OFF			0x1f
+
+#define RTPCS_93XX_SDS_USXGMII_SUBMODE_10GSX	0x00
+#define RTPCS_93XX_SDS_USXGMII_SUBMODE_10GQX	0x02
 
 /* Registers of the internal SerDes of the 9310 */
 #define RTPCS_931X_MAC_GROUP0_1_CTRL		(0x13a4)
@@ -1187,6 +1182,20 @@ static int rtpcs_839x_setup_serdes(struct rtpcs_serdes *sds,
 
 /* RTL93XX */
 
+/* forward mapping: enum rtpcs_sds_mode, -1 = unsupported */
+static const s16 rtpcs_93xx_sds_hw_mode_vals[RTPCS_SDS_MODE_MAX] = {
+	[0 ... RTPCS_SDS_MODE_MAX - 1]		= -1,
+	[RTPCS_SDS_MODE_OFF]			= RTPCS_93XX_SDS_MODE_OFF,
+	[RTPCS_SDS_MODE_SGMII]			= RTPCS_93XX_SDS_MODE_SGMII,
+	[RTPCS_SDS_MODE_1000BASEX]		= RTPCS_93XX_SDS_MODE_1000BASEX,
+	[RTPCS_SDS_MODE_2500BASEX]		= RTPCS_93XX_SDS_MODE_2500BASEX,
+	[RTPCS_SDS_MODE_10GBASER]		= RTPCS_93XX_SDS_MODE_10GBASER,
+	[RTPCS_SDS_MODE_QSGMII]			= RTPCS_93XX_SDS_MODE_QSGMII,
+	[RTPCS_SDS_MODE_XSGMII]			= RTPCS_93XX_SDS_MODE_XSGMII,
+	[RTPCS_SDS_MODE_USXGMII_10GSXGMII]	= RTPCS_93XX_SDS_MODE_USXGMII,
+	[RTPCS_SDS_MODE_USXGMII_10GQXGMII]	= RTPCS_93XX_SDS_MODE_USXGMII,
+};
+
 static int rtpcs_93xx_sds_set_autoneg(struct rtpcs_serdes *sds, unsigned int neg_mode,
 				      const unsigned long *advertising)
 {
@@ -1415,7 +1424,56 @@ pll_setup:
 	return ret;
 }
 
+static int rtpcs_93xx_sds_apply_usxgmii_submode(struct rtpcs_serdes *sds,
+						enum rtpcs_sds_mode hw_mode)
+{
+	u8 submode;
+
+	if (!sds->swcore_regs.usxgmii_submode)
+		return 0;
+
+	switch (hw_mode) {
+	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
+		submode = RTPCS_93XX_SDS_USXGMII_SUBMODE_10GSX;
+		break;
+	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
+		submode = RTPCS_93XX_SDS_USXGMII_SUBMODE_10GQX;
+		break;
+	default:
+		return 0;
+	}
+
+	return regmap_field_write(sds->swcore_regs.usxgmii_submode, submode);
+}
+
 /* RTL930X */
+
+/* This mapping is not coherent so it cannot be expressed arithmetically */
+static const struct reg_field rtpcs_930x_mac_mode_fields[RTPCS_930X_SERDES_CNT] = {
+	[0]  = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_0,  0,  4),
+	[1]  = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_0,  6, 10),
+	[2]  = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_0, 12, 16),
+	[3]  = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_0, 18, 22),
+	[4]  = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_1,  0,  4),
+	[5]  = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_1,  6, 10),
+	[6]  = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_1, 12, 16),
+	[7]  = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_1, 18, 22),
+	[8]  = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_2,  0,  4),
+	[9]  = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_2,  6, 10),
+	[10] = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_3,  0,  4),
+	[11] = REG_FIELD(RTPCS_930X_SDS_MODE_SEL_3,  6, 10),
+};
+
+static const struct reg_field rtpcs_930x_usxgmii_submode_fields[] = {
+	[0] = REG_FIELD(RTPCS_930X_SDS_SUBMODE_CTRL_0,  0,  4),
+	[1] = REG_FIELD(RTPCS_930X_SDS_SUBMODE_CTRL_0,  5,  9),
+	[2] = REG_FIELD(RTPCS_930X_SDS_SUBMODE_CTRL_1,  0,  4),
+	[3] = REG_FIELD(RTPCS_930X_SDS_SUBMODE_CTRL_1,  5,  9),
+	[4] = REG_FIELD(RTPCS_930X_SDS_SUBMODE_CTRL_1, 10, 14),
+	[5] = REG_FIELD(RTPCS_930X_SDS_SUBMODE_CTRL_1, 15, 19),
+	[6] = REG_FIELD(RTPCS_930X_SDS_SUBMODE_CTRL_1, 20, 24),
+	[7] = REG_FIELD(RTPCS_930X_SDS_SUBMODE_CTRL_1, 25, 29),
+};
 
 /*
  * RTL930X needs a special mapping from logic SerDes ID to physical SerDes ID,
@@ -1476,86 +1534,6 @@ static int rtpcs_930x_sds_op_xsg_write(struct rtpcs_serdes *sds, int page, int r
 
 	return __rtpcs_sds_write_raw(sds->ctrl, phys_sds_id + 1, page, regnum, bithigh, bitlow,
 				     value);
-}
-
-static const u16 rtpcs_930x_sds_mode_regs[] = {
-	0x0194, 0x0194, 0x0194, 0x0194,		/* SDS_MODE_SEL_0 */
-	0x02a0, 0x02a0, 0x02a0, 0x02a0,		/* SDS_MODE_SEL_1 */
-	0x02a4, 0x02a4,				/* SDS_MODE_SEL_2 */
-	0x0198, 0x0198				/* SDS_MODE_SEL_3 */
-};
-static const u8 rtpcs_930x_sds_mode_lsb[]  = { 0, 6, 12, 18, 0, 6, 12, 18, 0, 6, 0, 6 };
-
-static const u16 rtpcs_930x_sds_submode_regs[] = {
-	0x1cc, 0x1cc,				/* SDS_SUBMODE_CTRL0 */
-	0x2d8, 0x2d8, 0x2d8, 0x2d8,0x2d8, 0x2d8 /* SDS_SUBMODE_CTRL1 */
-};
-static const u8 rtpcs_930x_sds_submode_lsb[] = { 0, 5, 0, 5, 10, 15, 20, 25 };
-
-__always_unused
-static int __rtpcs_930x_sds_get_mac_mode(struct rtpcs_serdes *sds)
-{
-	u8 sds_id = sds->id;
-	int mode_val, ret;
-
-	ret = regmap_read(sds->ctrl->map, rtpcs_930x_sds_mode_regs[sds_id], &mode_val);
-	if (ret < 0)
-		return ret;
-
-	mode_val >>= rtpcs_930x_sds_mode_lsb[sds_id];
-	return mode_val & RTPCS_930X_SDS_MASK;
-}
-
-static int __rtpcs_930x_sds_set_mac_mode(struct rtpcs_serdes *sds, u32 mode)
-{
-	u8 sds_id = sds->id;
-	int ret;
-
-	ret = regmap_write_bits(sds->ctrl->map, rtpcs_930x_sds_mode_regs[sds_id],
-				RTPCS_930X_SDS_MASK << rtpcs_930x_sds_mode_lsb[sds_id],
-				mode << rtpcs_930x_sds_mode_lsb[sds_id]);
-	mdelay(10);
-
-	return ret;
-}
-
-__always_unused
-static int __rtpcs_930x_sds_get_usxgmii_submode(struct rtpcs_serdes *sds)
-{
-	u8 sds_id = sds->id;
-	int submode, ret;
-
-	if (sds->type != RTPCS_SDS_TYPE_10G) {
-		pr_err("%s: SerDes %u doesn't support USXGMII submode\n", __func__, sds_id);
-		return -ENOTSUPP;
-	}
-
-	ret = regmap_read(sds->ctrl->map, rtpcs_930x_sds_submode_regs[sds_id], &submode);
-	if (ret < 0)
-		return ret;
-
-	submode >>= rtpcs_930x_sds_submode_lsb[sds_id];
-	return submode & RTPCS_930X_SDS_MASK;
-}
-
-static int __rtpcs_930x_sds_set_usxgmii_submode(struct rtpcs_serdes *sds, u32 submode)
-{
-	u8 sds_id = sds->id;
-
-	if (sds->type != RTPCS_SDS_TYPE_10G) {
-		pr_err("%s: SerDes %u doesn't support USXGMII submode\n", __func__, sds_id);
-		return -ENOTSUPP;
-	}
-
-	if (submode != RTPCS_930X_SDS_SUBMODE_USXGMII_SX &&
-	    submode != RTPCS_930X_SDS_SUBMODE_USXGMII_QX) {
-		pr_err("%s: unsupported submode 0x%x\n", __func__, submode);
-		return -ENOTSUPP;
-	}
-
-	return regmap_write_bits(sds->ctrl->map, rtpcs_930x_sds_submode_regs[sds_id - 2],
-				 RTPCS_930X_SDS_MASK << rtpcs_930x_sds_submode_lsb[sds_id - 2],
-				 submode << rtpcs_930x_sds_submode_lsb[sds_id - 2]);
 }
 
 static void rtpcs_930x_sds_rx_reset(struct rtpcs_serdes *sds,
@@ -1683,7 +1661,7 @@ static int rtpcs_930x_sds_reconfigure_to_pll(struct rtpcs_serdes *sds, enum rtpc
 		return ret;
 
 	rtpcs_930x_sds_set_power(sds, false);
-	__rtpcs_930x_sds_set_ip_mode(sds, RTPCS_930X_SDS_OFF);
+	__rtpcs_930x_sds_set_ip_mode(sds, RTPCS_93XX_SDS_MODE_OFF);
 
 	ret = rtpcs_93xx_sds_set_pll_config(sds, pll, speed);
 	if (ret < 0)
@@ -1738,31 +1716,6 @@ static int rtpcs_930x_sds_init_state_machine(struct rtpcs_serdes *sds,
 	return ret;
 }
 
-static int rtpcs_930x_sds_get_hw_mode_val(enum rtpcs_sds_mode hw_mode)
-{
-	switch (hw_mode) {
-	case RTPCS_SDS_MODE_OFF:
-		return RTPCS_930X_SDS_OFF;
-	case RTPCS_SDS_MODE_SGMII:
-		return RTPCS_930X_SDS_MODE_SGMII;
-	case RTPCS_SDS_MODE_1000BASEX:
-		return RTPCS_930X_SDS_MODE_1000BASEX;
-	case RTPCS_SDS_MODE_2500BASEX:
-		return RTPCS_930X_SDS_MODE_2500BASEX;
-	case RTPCS_SDS_MODE_10GBASER:
-		return RTPCS_930X_SDS_MODE_10GBASER;
-	case RTPCS_SDS_MODE_QSGMII:
-		return RTPCS_930X_SDS_MODE_QSGMII;
-	case RTPCS_SDS_MODE_XSGMII:
-		return RTPCS_930X_SDS_MODE_XSGMII;
-	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
-	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
-		return RTPCS_930X_SDS_MODE_USXGMII;
-	default:
-		return -ENOTSUPP;
-	}
-}
-
 static int rtpcs_930x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 				      enum rtpcs_sds_mode hw_mode)
 {
@@ -1775,7 +1728,10 @@ static int rtpcs_930x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 	 * if this sequence should quit early in case of errors.
 	 */
 
-	mode_val = rtpcs_930x_sds_get_hw_mode_val(hw_mode);
+	if (hw_mode >= RTPCS_SDS_MODE_MAX)
+		return -EINVAL;
+
+	mode_val = sds->ctrl->cfg->sds_hw_mode_vals[hw_mode];
 	if (mode_val < 0) {
 		pr_err("%s: SDS %d does not support mode %d\n", __func__,
 		       sds->id, hw_mode);
@@ -1783,7 +1739,7 @@ static int rtpcs_930x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 	}
 
 	rtpcs_930x_sds_set_power(sds, false);
-	ret = __rtpcs_930x_sds_set_ip_mode(sds, RTPCS_930X_SDS_OFF);
+	ret = __rtpcs_930x_sds_set_ip_mode(sds, RTPCS_93XX_SDS_MODE_OFF);
 	if (ret < 0)
 		return ret;
 
@@ -1811,53 +1767,10 @@ static int rtpcs_930x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 	return 0;
 }
 
-static int rtpcs_930x_sds_set_mac_mode(struct rtpcs_serdes *sds,
-				       enum rtpcs_sds_mode hw_mode)
+static int rtpcs_930x_sds_set_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
 {
-	int submode_val = -1;
-	int mode_val, ret;
+	int ret;
 
-	mode_val = rtpcs_930x_sds_get_hw_mode_val(hw_mode);
-	if (mode_val < 0)
-		return mode_val;
-
-	switch (hw_mode) {
-	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
-		submode_val = RTPCS_930X_SDS_SUBMODE_USXGMII_SX;
-		break;
-	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
-		submode_val = RTPCS_930X_SDS_SUBMODE_USXGMII_QX;
-		break;
-	default:
-		break;
-	}
-
-	/* SerDes off first. */
-	ret = __rtpcs_930x_sds_set_mac_mode(sds, RTPCS_930X_SDS_OFF);
-	if (ret < 0)
-		return ret;
-
-	if (hw_mode == RTPCS_SDS_MODE_OFF)
-		return 0;
-
-	/* Set the mode. */
-	ret = __rtpcs_930x_sds_set_mac_mode(sds, mode_val);
-	if (ret < 0)
-		return ret;
-
-	/* Set the submode if needed. */
-	if (submode_val >= 0) {
-		ret = __rtpcs_930x_sds_set_usxgmii_submode(sds, submode_val);
-		if (ret < 0)
-			return ret;
-	}
-
-	return 0;
-}
-
-static int rtpcs_930x_sds_set_mode(struct rtpcs_serdes *sds,
-				   enum rtpcs_sds_mode hw_mode)
-{
 	/*
 	 * Several modes can be configured via MAC setup, just by setting
 	 * a register to a specific value and the MAC will configure
@@ -1871,9 +1784,18 @@ static int rtpcs_930x_sds_set_mode(struct rtpcs_serdes *sds,
 	case RTPCS_SDS_MODE_2500BASEX:
 	case RTPCS_SDS_MODE_10GBASER:
 		return rtpcs_930x_sds_set_ip_mode(sds, hw_mode);
+
 	default:
-		return rtpcs_930x_sds_set_mac_mode(sds, hw_mode);
+		break;
 	}
+
+	ret = rtpcs_sds_set_mac_mode(sds, hw_mode);
+	if (ret)
+		return ret;
+
+	mdelay(10);
+
+	return rtpcs_93xx_sds_apply_usxgmii_submode(sds, hw_mode);
 }
 
 static void rtpcs_930x_sds_tx_config(struct rtpcs_serdes *sds,
@@ -3100,12 +3022,29 @@ skip_cali:
 
 static int rtpcs_930x_sds_probe(struct rtpcs_serdes *sds)
 {
-	if (sds->id < 2)
+	struct device *dev = sds->ctrl->dev;
+	struct regmap *map = sds->ctrl->map;
+	u8 id = sds->id;
+
+	if (id < 2)
 		sds->type = RTPCS_SDS_TYPE_5G;
-	else if (sds->id <= 9)
+	else if (id <= 9)
 		sds->type = RTPCS_SDS_TYPE_10G;
 	else
 		sds->type = RTPCS_SDS_TYPE_UNKNOWN;
+
+	sds->swcore_regs.mac_mode = devm_regmap_field_alloc(dev, map,
+							    rtpcs_930x_mac_mode_fields[id]);
+	if (IS_ERR(sds->swcore_regs.mac_mode))
+		return PTR_ERR(sds->swcore_regs.mac_mode);
+
+	/* submode only for 10G SerDes (id 2-9) */
+	if (sds->type == RTPCS_SDS_TYPE_10G) {
+		sds->swcore_regs.usxgmii_submode = devm_regmap_field_alloc(dev, map,
+							rtpcs_930x_usxgmii_submode_fields[id - 2]);
+		if (IS_ERR(sds->swcore_regs.usxgmii_submode))
+			return PTR_ERR(sds->swcore_regs.usxgmii_submode);
+	}
 
 	return 0;
 }
@@ -4452,6 +4391,7 @@ static const struct rtpcs_config rtpcs_930x_cfg = {
 	.pcs_ops		= &rtpcs_930x_pcs_ops,
 	.sds_ops		= &rtpcs_930x_sds_ops,
 	.sds_regs		= &rtpcs_930x_sds_regs,
+	.sds_hw_mode_vals	= rtpcs_93xx_sds_hw_mode_vals,
 	.init			= rtpcs_93xx_init,
 	.sds_probe		= rtpcs_930x_sds_probe,
 	.setup_serdes		= rtpcs_930x_setup_serdes,

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -138,6 +138,8 @@ enum rtpcs_sds_mode {
 	RTPCS_SDS_MODE_USXGMII_5GSXGMII,
 	RTPCS_SDS_MODE_USXGMII_5GDXGMII,
 	RTPCS_SDS_MODE_USXGMII_2_5GSXGMII,
+
+	RTPCS_SDS_MODE_MAX,
 };
 
 enum rtpcs_sds_media {
@@ -213,6 +215,12 @@ struct rtpcs_serdes {
 	const struct rtpcs_sds_ops *ops;
 	const struct rtpcs_sds_regs *regs;
 	enum rtpcs_sds_type type;
+	struct {
+		struct regmap_field *mac_mode;
+		struct regmap_field *mac_mode_force;	/* nullable, 931x only */
+		struct regmap_field *usxgmii_submode;	/* nullable, 93xx only */
+	} swcore_regs;
+
 	enum rtpcs_sds_mode hw_mode;
 	u8 id;
 	u8 num_of_links;
@@ -252,6 +260,8 @@ struct rtpcs_config {
 	const struct phylink_pcs_ops *pcs_ops;
 	const struct rtpcs_sds_ops *sds_ops;
 	const struct rtpcs_sds_regs *sds_regs;
+	const s16 *sds_hw_mode_vals;   /* enum rtpcs_sds_mode, -1 = unsupported */
+
 	int (*init)(struct rtpcs_ctrl *ctrl);
 	int (*sds_probe)(struct rtpcs_serdes *sds);
 	int (*setup_serdes)(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode);
@@ -597,6 +607,43 @@ static int rtpcs_sds_apply_config_xsg(struct rtpcs_serdes *sds,
 			return ret;
 	}
 	return 0;
+}
+
+/*
+ * Allocate a regmap_field on the SoC-side register map for this SerDes and
+ * store the resulting pointer in *dst. Convenience helper for per-SerDes
+ * register fields computed from the SerDes ID. Taking reg/lsb/msb as
+ * integer arguments (rather than a struct reg_field) keeps callers free of
+ * either local reg_field declarations or compound-literal casts, since
+ * REG_FIELD() is a brace-initializer and not a usable expression.
+ */
+static int rtpcs_sds_alloc_field(struct rtpcs_serdes *sds, struct regmap_field **dst,
+				 u32 reg, u8 lsb, u8 msb)
+{
+	struct reg_field rf = REG_FIELD(reg, lsb, msb);
+
+	*dst = devm_regmap_field_alloc(sds->ctrl->dev, sds->ctrl->map, rf);
+	return PTR_ERR_OR_ZERO(*dst);
+}
+
+/*
+ * Write the SerDes MAC mode register. This is the common minimum shared by
+ * all variants. Variant-specific extras (force bit, companion registers,
+ * USXGMII submode, post-write delay) live in per-variant wrappers.
+ */
+static int rtpcs_sds_set_mac_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
+{
+	const struct rtpcs_config *cfg = sds->ctrl->cfg;
+	int val;
+
+	if (hw_mode >= RTPCS_SDS_MODE_MAX)
+		return -EINVAL;
+
+	val = cfg->sds_hw_mode_vals[hw_mode];
+	if (val < 0)
+		return -EOPNOTSUPP;
+
+	return regmap_field_write(sds->swcore_regs.mac_mode, val);
 }
 
 /* Variant-specific functions */

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -1793,7 +1793,7 @@ static int rtpcs_930x_sds_set_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode
 	if (ret)
 		return ret;
 
-	mdelay(10);
+	msleep(10);
 
 	return rtpcs_93xx_sds_apply_usxgmii_submode(sds, hw_mode);
 }
@@ -3178,51 +3178,6 @@ static int rtpcs_931x_sds_power(struct rtpcs_serdes *sds, bool power_on)
 }
 
 /*
- * rtpcs_931x_sds_set_mac_mode
- *
- * Set the SerDes mode in the MAC's registers.
- */
-static int rtpcs_931x_sds_set_mac_mode(struct rtpcs_serdes *sds,
-				       enum rtpcs_sds_mode hw_mode)
-{
-	u32 mode_val;
-	int shift = ((sds->id & 0x3) << 3);
-
-	switch (hw_mode) {
-	case RTPCS_SDS_MODE_OFF:
-		mode_val = 0x1f;
-		break;
-	case RTPCS_SDS_MODE_QSGMII:
-		mode_val = 0x6;
-		break;
-	case RTPCS_SDS_MODE_HISGMII:
-		mode_val = 0x12;
-		break;
-	case RTPCS_SDS_MODE_XSGMII:
-		mode_val = 0x10;
-		break;
-	case RTPCS_SDS_MODE_USXGMII_10GSXGMII:
-	case RTPCS_SDS_MODE_USXGMII_10GDXGMII:
-	case RTPCS_SDS_MODE_USXGMII_10GQXGMII:
-	case RTPCS_SDS_MODE_USXGMII_5GSXGMII:
-	case RTPCS_SDS_MODE_USXGMII_5GDXGMII:
-	case RTPCS_SDS_MODE_USXGMII_2_5GSXGMII:
-		mode_val = 0xd;
-		break;
-	case RTPCS_SDS_MODE_SGMII:
-		mode_val = 0x2;
-		break;
-	default:
-		return -EINVAL;
-	}
-
-	mode_val |= BIT(7); /* force mode bit */
-	return regmap_write_bits(sds->ctrl->map,
-				 RTPCS_931X_SERDES_MODE_CTRL + 4 * (sds->id >> 2),
-				 0xff << shift, mode_val << shift);
-}
-
-/*
  * rtpcs_931x_sds_set_ip_mode
  *
  * Set the SerDes mode in the SerDes IP block's registers.
@@ -3231,10 +3186,17 @@ static int rtpcs_931x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 				      enum rtpcs_sds_mode hw_mode)
 {
 	u32 mode_val;
+	int ret;
 
 	/* clear symbol error count before changing mode */
 	rtpcs_931x_sds_clear_symerr(sds, hw_mode);
-	rtpcs_931x_sds_set_mac_mode(sds, RTPCS_SDS_MODE_OFF);
+	ret = rtpcs_sds_set_mac_mode(sds, RTPCS_SDS_MODE_OFF);
+	if (ret)
+		return ret;
+
+	ret = regmap_field_write(sds->swcore_regs.mac_mode_force, 1);
+	if (ret)
+		return ret;
 
 	switch (hw_mode) {
 	case RTPCS_SDS_MODE_OFF:
@@ -3286,28 +3248,35 @@ static int rtpcs_931x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 static int rtpcs_931x_sds_set_mode(struct rtpcs_serdes *sds,
 				   enum rtpcs_sds_mode hw_mode)
 {
-	if (hw_mode == RTPCS_SDS_MODE_XSGMII)
-		return rtpcs_931x_sds_set_mac_mode(sds, hw_mode);
-	else
+	if (hw_mode == RTPCS_SDS_MODE_XSGMII) {
+		int ret = rtpcs_sds_set_mac_mode(sds, hw_mode);
+		if (ret)
+			return ret;
+
+		return regmap_field_write(sds->swcore_regs.mac_mode_force, 1);
+	} else
 		return rtpcs_931x_sds_set_ip_mode(sds, hw_mode);
 }
 
 static void rtpcs_931x_sds_reset(struct rtpcs_serdes *sds)
 {
-	struct rtpcs_ctrl *ctrl = sds->ctrl;
-	u32 sds_id = sds->id;
-	u32 v, o_mode;
-	int shift = ((sds_id & 0x3) << 3);
+	u32 o_mode, f_bit;
 
 	/* TODO: We need to lock this! */
 
 	rtpcs_931x_sds_power(sds, false);
 
-	regmap_read(ctrl->map, RTPCS_931X_SERDES_MODE_CTRL + 4 * (sds_id >> 2), &o_mode);
-	v = BIT(7) | 0x1F;
-	regmap_write_bits(ctrl->map, RTPCS_931X_SERDES_MODE_CTRL + 4 * (sds_id >> 2),
-			  0xff << shift, v << shift);
-	regmap_write(ctrl->map, RTPCS_931X_SERDES_MODE_CTRL + 4 * (sds_id >> 2), o_mode);
+	/* save current */
+	regmap_field_read(sds->swcore_regs.mac_mode, &o_mode);
+	regmap_field_read(sds->swcore_regs.mac_mode_force, &f_bit);
+
+	/* force off */
+	regmap_field_write(sds->swcore_regs.mac_mode, 0x1f);
+	regmap_field_write(sds->swcore_regs.mac_mode_force, 1);
+
+	/* restore previous */
+	regmap_field_write(sds->swcore_regs.mac_mode, o_mode);
+	regmap_field_write(sds->swcore_regs.mac_mode_force, f_bit);
 
 	rtpcs_931x_sds_power(sds, true);
 }
@@ -3938,12 +3907,28 @@ static int rtpcs_931x_init_mac_groups(struct rtpcs_ctrl *ctrl)
 
 static int rtpcs_931x_sds_probe(struct rtpcs_serdes *sds)
 {
+	u32 base = RTPCS_931X_SERDES_MODE_CTRL + 4 * (sds->id >> 2);
+	u8 lsb = (sds->id & 3) * 8;
+	int ret;
+
 	if (sds->id >= 2)
 		sds->type = RTPCS_SDS_TYPE_10G;
 	else
 		sds->type = RTPCS_SDS_TYPE_UNKNOWN;
 
-	return 0;
+	/*
+	 * Width is 7 bits (lsb..lsb+6) so every MAC mode write also clears
+	 * bit 5 (FEC enable) and bit 6 (10G speedup). These are mode-dependent
+	 * and not yet programmed here; keeping them cleared matches the
+	 * original 8-bit-wide write behaviour.
+	 */
+	ret = rtpcs_sds_alloc_field(sds, &sds->swcore_regs.mac_mode,
+				    base, lsb, lsb + 6);
+	if (ret)
+		return ret;
+
+	return rtpcs_sds_alloc_field(sds, &sds->swcore_regs.mac_mode_force,
+				     base, lsb + 7, lsb + 7);
 }
 
 static int rtpcs_931x_init(struct rtpcs_ctrl *ctrl)
@@ -4433,6 +4418,7 @@ static const struct rtpcs_config rtpcs_931x_cfg = {
 	.pcs_ops		= &rtpcs_931x_pcs_ops,
 	.sds_ops		= &rtpcs_931x_sds_ops,
 	.sds_regs		= &rtpcs_931x_sds_regs,
+	.sds_hw_mode_vals	= rtpcs_93xx_sds_hw_mode_vals,
 	.init			= rtpcs_931x_init,
 	.sds_probe		= rtpcs_931x_sds_probe,
 	.setup_serdes		= rtpcs_931x_setup_serdes,

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -1446,6 +1446,32 @@ static int rtpcs_93xx_sds_apply_usxgmii_submode(struct rtpcs_serdes *sds,
 	return regmap_field_write(sds->swcore_regs.usxgmii_submode, submode);
 }
 
+/*
+ * RTL93XX wrapper: set MAC mode, then handle variant-specific extras:
+ * - post-write delay (required on 930x)
+ * - force-mode bit (931x only; nullable field)
+ *
+ * Each extra no-ops on the variant that doesn't need it — either because
+ * the corresponding regmap_field is NULL, or because the mode doesn't match.
+ */
+static int rtpcs_93xx_sds_set_mac_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode hw_mode)
+{
+	int ret;
+
+	ret = rtpcs_sds_set_mac_mode(sds, hw_mode);
+	if (ret)
+		return ret;
+	msleep(10);
+
+	if (sds->swcore_regs.mac_mode_force) {
+		ret = regmap_field_write(sds->swcore_regs.mac_mode_force, 1);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
 /* RTL930X */
 
 /* This mapping is not coherent so it cannot be expressed arithmetically */
@@ -1789,11 +1815,9 @@ static int rtpcs_930x_sds_set_mode(struct rtpcs_serdes *sds, enum rtpcs_sds_mode
 		break;
 	}
 
-	ret = rtpcs_sds_set_mac_mode(sds, hw_mode);
+	ret = rtpcs_93xx_sds_set_mac_mode(sds, hw_mode);
 	if (ret)
 		return ret;
-
-	msleep(10);
 
 	return rtpcs_93xx_sds_apply_usxgmii_submode(sds, hw_mode);
 }
@@ -3190,11 +3214,7 @@ static int rtpcs_931x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 
 	/* clear symbol error count before changing mode */
 	rtpcs_931x_sds_clear_symerr(sds, hw_mode);
-	ret = rtpcs_sds_set_mac_mode(sds, RTPCS_SDS_MODE_OFF);
-	if (ret)
-		return ret;
-
-	ret = regmap_field_write(sds->swcore_regs.mac_mode_force, 1);
+	ret = rtpcs_93xx_sds_set_mac_mode(sds, RTPCS_SDS_MODE_OFF);
 	if (ret)
 		return ret;
 
@@ -3248,14 +3268,10 @@ static int rtpcs_931x_sds_set_ip_mode(struct rtpcs_serdes *sds,
 static int rtpcs_931x_sds_set_mode(struct rtpcs_serdes *sds,
 				   enum rtpcs_sds_mode hw_mode)
 {
-	if (hw_mode == RTPCS_SDS_MODE_XSGMII) {
-		int ret = rtpcs_sds_set_mac_mode(sds, hw_mode);
-		if (ret)
-			return ret;
+	if (hw_mode == RTPCS_SDS_MODE_XSGMII)
+		return rtpcs_93xx_sds_set_mac_mode(sds, hw_mode);
 
-		return regmap_field_write(sds->swcore_regs.mac_mode_force, 1);
-	} else
-		return rtpcs_931x_sds_set_ip_mode(sds, hw_mode);
+	return rtpcs_931x_sds_set_ip_mode(sds, hw_mode);
 }
 
 static void rtpcs_931x_sds_reset(struct rtpcs_serdes *sds)


### PR DESCRIPTION
This patch series unifies the MAC mode setting for the different SerDes variants to the possible extent, combining shared behavior and reducing per-variant behavior to a needed minimum with a cleaner approach. (*MAC mode setting refers to the mode setting on the more-MAC-side, in the switchcore register spaces - for RTL83xx this refers to the whole operation while for RTL93xx we have the IP mode setting as another way.*)

This comes in handy with using upstream `reg_field`/`regmap_field`, making part of the code cleaner and separating register definitions and read/write operations.

Tested on XS1930-12HP, XGS1250-12 A1, XGS1210-12 A1 (RTL93xx). Current behavior for RTL83xx is preserved so no issues expected. Though a test might be good, I just don't have devices for that available right now.
