### PR TITLE
dropbear: don't spread conffiles across two packages

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -53,7 +53,6 @@ define Package/base-files/conffiles
 /etc/config/
 /etc/config/network
 /etc/config/system
-/etc/dropbear/
 /etc/ethers
 /etc/group
 /etc/hosts


### PR DESCRIPTION
For some reason, `/etc/config/dropbear` is enumerated as a `conffile` for `dropbear` packaging, but `/etc/dropbear/` is part of `base-files` packaging.  If you're an `openssh-server` user, then you don't have this directory on your router in any case.
