### PR TITLE
omnia-mcutool: build as C99

### DIFF
--- a/package/utils/omnia-mcutool/Makefile
+++ b/package/utils/omnia-mcutool/Makefile
@@ -36,6 +36,7 @@ microcontroller on the Turris Omnia router. It can also show state of MCU
 settings and configure MCU options (GPIOs, LEDs, power).
 endef
 
+TARGET_CFLAGS += -std=gnu99
 TARGET_LDFLAGS += -lcrypto
 
 define Build/Compile


### PR DESCRIPTION
GCC15 defaults to C23, which does not work here.

ping @elkablo 