### PR TITLE
[25.12] mediatek: filogic: Add new Router model ZBT-Z8106AX-T

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8106ax-t.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8106ax-t.dts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "mt7981b-zbtlink-zbt-z8106ax.dtsi"
+
+/ {
+	model = "Zbtlink ZBT-Z8106AX-T";
+	compatible = "zbtlink,zbt-z8106ax-t", "mediatek,mt7981b";
+};

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8106ax.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8106ax.dtsi
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status_green;
+		led-failsafe = &led_status_green;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac1;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs = "earlycon=uart8250,mmio32,0x11002000 console=ttyS0,115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x10000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		wan {
+			color = <LED_COLOR_ID_AMBER>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "eth1";
+		};
+
+		led_status_green: pwr {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		4g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_MOBILE;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led-wlan2g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			function-enumerator = <0>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-wlan5g {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+			function-enumerator = <1>;
+			linux,default-trigger = "phy1tpt";
+		};
+	};
+
+	reg_3p3v: regulator-3p3v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-3.3V";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	reg_5v: regulator-5v {
+		compatible = "regulator-fixed";
+		regulator-name = "fixed-5V";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&pio 2 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1000>;
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+
+		4g {
+			gpio-export,name = "4g";
+			gpio-export,output = <1>;
+			gpios = <&pio 4 GPIO_ACTIVE_HIGH>;
+		};
+
+		sim {
+			gpio-export,name = "sim";
+			gpio-export,output = <0>;
+			gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+		};
+
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		/* LAN */
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 0>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		/* WAN */
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_2a 0>;
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+		interrupt-controller;
+		#interrupt-cells = <1>;
+		interrupt-parent = <&pio>;
+		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan1";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan2";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan3";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan4";
+		};
+
+		port@4 {
+			reg = <4>;
+			label = "wwan";
+		};
+
+		port@6 {
+			reg = <6>;
+			label = "cpu";
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bl2";
+				reg = <0x0000000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			nand_rootfs: partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x7280000>;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	nvmem-cells = <&eeprom_factory>;
+	nvmem-cell-names = "eeprom";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_a 1>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
+	vusb33-supply = <&reg_3p3v>;
+	vbus-supply = <&reg_5v>;
+};
+
+&factory {
+	compatible = "nvmem-cells";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	macaddr_factory_4: macaddr@4 {
+		reg = <0x4 0x6>;
+		compatible = "mac-base";
+		#nvmem-cell-cells = <1>;
+	};
+
+	macaddr_factory_a: macaddr@a {
+		reg = <0xa 0x6>;
+		compatible = "mac-base";
+		#nvmem-cell-cells = <1>;
+	};
+
+	macaddr_factory_2a: macaddr@2a {
+		reg = <0x2a 0x6>;
+		compatible = "mac-base";
+		#nvmem-cell-cells = <1>;
+	};
+
+	eeprom_factory: eeprom@0 {
+		reg = <0x0 0x1000>;
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -327,6 +327,10 @@ zbtlink,zbt-z8103ax|\
 zbtlink,zbt-z8103ax-c)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
+zbtlink,zbt-z8106ax-t)
+	ucidef_set_led_netdev "wan" "wan" "amber:wan" "eth1" "link tx rx"
+	ucidef_set_led_netdev "mobile" "mobile" "green:mobile" "wwan" "link tx rx"
+	;;
 zyxel,ex5601-t0-stock|\
 zyxel,ex5601-t0-ubootmod)
 	ucidef_set_led_netdev "lan1" "LAN1" "mdio-bus:05:green:lan" "lan1" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -76,7 +76,10 @@ mediatek_setup_interfaces()
 	wavlink,wl-wn536ax6-a|\
 	zbtlink,zbt-z8102ax|\
 	zbtlink,zbt-z8102ax-v2)
-		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" eth1
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1"
+		;;
+	zbtlink,zbt-z8106ax-t)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" "eth1 wwan"
 		;;
 	asiarf,ap7986-003|\
 	asus,tuf-ax4200q|\

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/03_gpio_switches
@@ -21,6 +21,10 @@ zbtlink,zbt-z8102ax-v2)
 	ucidef_add_gpio_switch "sim1" "SIM 1" "sim1" "1"
 	ucidef_add_gpio_switch "sim2" "SIM 2" "sim2" "1"
 	;;
+zbtlink,zbt-z8106ax-t)
+	ucidef_add_gpio_switch "4g" "Power modem" "4g" "1"
+	ucidef_add_gpio_switch "sim" "SIM" "sim" "1"
+	;;
 esac
 
 board_config_flush

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -3254,6 +3254,26 @@ define Device/zbtlink_zbt-z8103ax-c
 endef
 TARGET_DEVICES += zbtlink_zbt-z8103ax-c
 
+define Device/zbtlink_zbt-z8106ax-t
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-Z8106AX-T
+  DEVICE_ALT0_VENDOR := Zbtlink
+  DEVICE_ALT0_MODEL := ZBT-Z8106AX-M2-T
+  SUPPORTED_DEVICES += zbtlink,z8106ax-2sim
+  DEVICE_DTS := mt7981b-zbtlink-zbt-z8106ax-t
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-usb3 kmod-usb-net-qmi-wwan kmod-usb-serial-option
+  KERNEL_IN_UBI := 1
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  IMAGE_SIZE := 65536k
+  IMAGES += factory.bin
+  IMAGE/factory.bin := append-ubi | check-size $$(IMAGE_SIZE)
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zbtlink_zbt-z8106ax-t
+
 define Device/zyxel_ex5601-t0-stock
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := EX5601-T0


### PR DESCRIPTION
Backport device support for zbt-z8106ax-t

Vendor Zbtlink advertizes this device as model Z8106AX-M2-T on their website www.zbtlink.com. Device label sticked on enclosure however states this is model Z8106AX version -T. I made firmware selector to show this device as
- ZBT-Z8106AX-T to match information printed on the label and
- ZBT-Z8106AX-M2-T to match information found on vendors web pages.

Specifications:

SoC: MediaTek MT7981B
RAM: 256MiB
Flash: Winbond SPI-NAND 128 MiB
Switch: 1 WAN, 4 LAN (Gigabit) MediaTek MT7531
Buttons: Reset
Power: DC 12V-32V 1A
WiFi: MT7981B 2.4Ghz & 5Ghz
USB 3
M2 slot to hold LTE modem
2x nano SIM slots (user controllable)

Router comes in a flat metal box with all antennas detachable.
 - 4 antennas for LTE 4G/5G communication
 - 2 antennas for Wifi 2.4 GHz
 - 2 antennas for Wifi 5 GHz

Power supply could be between 12V and 32V.
This serves both cars equipped with 12V batteries
and trucks equipped with 24V batteries.

Led Layout:

Power (green, user controllable, default set to OpenWrt Status) Mobile (green, user controllable)
WLAN 2.4G (green, user controllable)
WLAN 5G (green, user controllable)

WAN (amber, user controllable, set to show eth1)
LAN1 (amber, hardware controlled)
LAN2 (amber, hardware controlled)
LAN3 (amber, hardware controlled)
LAN4 (amber, hardware controlled)

SIM Slots:

Controlled via exported GPIO named SIM.

echo "0" > /sys/class/gpio/sim/value
 - selects upper sim slot labelled SIM1

echo "1" > /sys/class/gpio/sim/value
 - selects lower sim slot labelled SIM2

Slot SIM2 is set as default and matches label on Router enclosure

---

Installation:

A. Through U-Boot menu:

- Prepare your connecting computer to use a static IP in network 192.168.1.0/24 like a) 192.168.1.10 netmask 255.255.255.0 (legacy notation) b) 192.168.1.10/24 (CIDR notation)
- Power down the router and hold in the Reset button.
- While holding in the button power up the router again.
- Hold the button in for 10 seconds and then release.
- Use your browser to go to 192.168.1.1
- If you see a GUI allowing for flashing firmware then you got the right spot.
- Upload the **Factory** image file.

Note: U-Boot GUI it can be used to recover from an incorrect firmware flash.

B. Through OpenWrt Dashboard:

If your router comes with OpenWrt preinstalled (modified by vendor), you can easily upgrade by going to the dashboard (192.168.1.1) and then navigate to "System" -> "Backup/Flash firmware" Flash OpenWRT firmware and take care to deselect (untick) option "keep settings". Settings done by vendor are incompatible with versions 24.10 or 25.12.

MAC Addresses:

MAC Addresses were found in Factory partition:

offset 0x4 F8:5E:3C:xx:xx:aa --> Router Label -2
offset 0xa F8:5E:3C:xx:xx:bb --> Router Label -1
offset 0x24 F8:5E:3C:xx:xx:cc --> Router Label +1
offset 0x2a F8:5E:3C:xx:xx:yy --> printed on Router Label

Hardware Watchdog:

Device features a GPIO controlled hardware watchdog. Verfied by removing procd controlled watchdog and
seeing device rebooting.

---

Notes:
The zbt-z8106ax-t could be ordered from vendor with a variety of modems. Mine came with a Quectel RM520N-GL. Quectel firmware was at RM520NGLAAR01A07M4G. This level of firmware made some trouble connecting with some of my SIM cardproviders.
Newer firmware level RM520NGLAAR01A08M4G_01.205.01.205 was available searching github repositories. Upgrading my RM520-GL allowed to get successful connects that did fail with older Quectel firmware.

Modem communication is set to ethernet control mode (ECM) by vendor. Vendor takes advantage of ECM by wiring modem to internal switch port WWAN. OpenWRT network configuration wants to define two network interfaces
 - Network interface covering USB0 set with high metric
 - Network interface covering WWAN set with low metric Network interface covering WWAN would be preferred default route.

Please take note that internal switch port wired to LTE modem is named LAN5 in vendor provided firmwares. OpenWRT however names port as WWAN to better describe purpose of port. WWAN is suggested to be assigned to firewall zone WAN.

Did use package qmodem from github repository FUjR/QModem to manage RM520N-GL LTE modem.


Link: https://github.com/openwrt/openwrt/pull/21834
