### PR TITLE
qualcommax: ipq50xx: ax6000: enable pcie1 for QCA9887

### DIFF
--- a/target/linux/qualcommax/dts/ipq5018-ax6000.dts
+++ b/target/linux/qualcommax/dts/ipq5018-ax6000.dts
@@ -549,13 +549,9 @@
 };
 
 &pcie1 {
-	/*
-	 * although the pcie1 phy probes successfully, the controller is unable
-	 * to bring it up. So let's disable it until a solution is found.
-	 */
-	status = "disabled";
+	status = "okay";
 
-	perst-gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+	perst-gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
 
 	pcie@0 {
 		wifi@0,0 {


### PR DESCRIPTION
## What

Enables PCIe1 on the Xiaomi AX6000 (AIOT) DTS by fixing the PERST GPIO polarity so a second PCIe Wi-Fi card (QCA9887) can train and attach.

The file changed is `target/linux/qualcommax/dts/ipq5018-ax6000.dts`:

```diff
-    /*
-     * although the pcie1 phy probes successfully, the controller is unable
-     * to bring it up. So let's disable it until a solution is found.
-     */
-    status = "disabled";
+    status = "okay";
...
-    perst-gpios = <&tlmm 18 GPIO_ACTIVE_LOW>;
+    perst-gpios = <&tlmm 18 GPIO_ACTIVE_HIGH>;
```

## Why

The existing DTS kept `pcie1` disabled with a comment saying the controller couldn't bring the link up. Comparing against the Xiaomi stock device-tree (extracted from the vendor firmware via `dtc`), the stock DTS uses `GPIO_ACTIVE_HIGH` on `tlmm 18` for the QCA9887 card's PERST, while OpenWrt had `GPIO_ACTIVE_LOW` — inverted polarity holds the card in reset, so the PCIe link never trains.

Flipping the polarity to `GPIO_ACTIVE_HIGH` lets the controller release PERST correctly; the link then trains at Gen1 x1 and the QCA9887 enumerates as `0001:01:00.0`. `ath10k_pci` loads `firmware-2.bin` (QCA9887 10.2.4-1.0-00047), applies the EEPROM calibration from the MTD `0:art` partition via nvmem-cells, and registers `phy0` with mac80211.

This turns the AX6000 into a true tri-radio device:

| Radio | Bus | Driver | Band |
|---|---|---|---|
| IPQ5018 integrated | AHB | ath11k | 2.4 GHz |
| QCN9024 | PCIe0 (x2) | ath11k_pci | 5 GHz |
| QCA9887 | PCIe1 (x1) | ath10k_pci | 5 GHz |

## How tested

Built a sysupgrade image on top of current `main` (kernel 6.12.80) and flashed it to a reworked Xiaomi AX6000 AIOT with a QCA9887 soldered onto the PCIe1 lines.

**PCIe link-up (`dmesg`, QCA9887 on pcie1 @ 0x80000000):**

```
[    0.429430] qcom-pcie 80000000.pcie: PCIe Gen.1 x1 link up
[    1.186847] pci 0001:01:00.0: [168c:0050] type 00 class 0x028000 PCIe Endpoint
[    1.189928] pci 0001:01:00.0: BAR 0 [mem 0x00000000-0x001fffff 64bit]
[    1.232863] pci 0001:01:00.0: BAR 0 [mem 0x80400000-0x805fffff 64bit]: assigned
```

**Driver attach:**

```
[   14.197314] ath10k_pci 0001:01:00.0: enabling device (0000 -> 0002)
[   14.203558] ath10k_pci 0001:01:00.0: pci irq msi oper_irq_mode 2 irq_mode 0 reset_mode 0
[   15.125561] ath10k_pci 0001:01:00.0: qca9887 hw1.0 target 0x4100016d chip_id 0x004000ff sub 0000:0000
[   15.134112] ath10k_pci 0001:01:00.0: firmware ver 10.2.4-1.0-00047 api 5 features no-p2p,ignore-otp,skip-clock-init,mfp,allows-mesh-bcast crc32 62f7565f
[   15.261972] ath10k_pci 0001:01:00.0: board_file api 1 bmi_id N/A crc32 546cca0d
[   16.279253] ath10k_pci 0001:01:00.0: htt-ver 2.1 wmi-op 5 htt-op 2 cal nvmem max-sta 128 raw 0 hwcrypto 1
```

Note `cal nvmem` — calibration loaded from the `0:art` MTD partition via the DTS nvmem-cells.

**All 3 phys come up and beacon simultaneously:**

```
phy#0 (ath10k / QCA9887) phy0-ap0  5 GHz ch36   VHT80  OpenWrt-QCA9887
phy#1 (ath11k / IPQ5018) phy1-ap0  2.4 GHz ch6  HE20   OpenWrt-IPQ5018
phy#2 (ath11k / QCN9024) phy2-ap0  5 GHz ch149  HE80   OpenWrt-QCN9024
```

Scan / association / data-plane sanity-checked on each radio from a client.

## Signed-off-by

```
Signed-off-by: chinawrj <chinawrj@gmail.com>
```

DCO signed. Single-file change; no new symbols or Kconfig churn; `scripts/checkpatch.pl --no-tree` reports `0 errors, 0 warnings`.

