### PR TITLE
realtek: fix SMBus Rollball access

### DIFF
--- a/target/linux/realtek/patches-6.18/712-net-phy-add-an-MDIO-SMBus-library.patch
+++ b/target/linux/realtek/patches-6.18/712-net-phy-add-an-MDIO-SMBus-library.patch
@@ -260,8 +260,8 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 +	buf[2] = reg >> 8;
 +	buf[3] = reg & 0xff;
 +
-+	/* send address */
-+	for (i = 0; i < 4; i++) {
++	/* send address, making sure to send the command byte last */
++	for (i = 3; i >= 0; i--) {
 +		data.byte = buf[i];
 +		ret = __i2c_smbus_xfer(i2c, bus_addr, 0, I2C_SMBUS_WRITE, ROLLBALL_CMD_ADDR + i, I2C_SMBUS_BYTE_DATA, &data);
 +		if (ret < 0)
@@ -311,8 +311,8 @@ Signed-off-by: Antoine Tenart <antoine.tenart@bootlin.com>
 +	buf[4] = val >> 8;
 +	buf[5] = val & 0xff;
 +
-+	/* send address and value */
-+	for (i = 0; i < 6; i++) {
++	/* send address and value, making sure to send the command byte last */
++	for (i = 5; i >= 0; i--) {
 +		data.byte = buf[i];
 +		ret = __i2c_smbus_xfer(i2c, bus_addr, 0, I2C_SMBUS_WRITE, ROLLBALL_CMD_ADDR + i, I2C_SMBUS_BYTE_DATA, &data);
 +		if (ret < 0)


### PR DESCRIPTION
The Rollball command byte needs to be written last. Otherwise the controller might access the wrong register or write the wrong value.

Fixes: 1fc19bc06edc ("realtek: rtl93xx: mdio-smbus support for clause 45 and Rollball SFPs")