### PR TITLE
mediatek: filogic: Add new Router model ZBT-Z8803BE

### DIFF
--- a/target/linux/mediatek/dts/mt7988a-zbtlink-zbt-z8803be.dts
+++ b/target/linux/mediatek/dts/mt7988a-zbtlink-zbt-z8803be.dts
@@ -1,0 +1,561 @@
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
+
+/dts-v1/;
+#include "mt7988a.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+#include <dt-bindings/regulator/richtek,rt5190a-regulator.h>
+
+/ {
+	model = "Zbtlink Z8803BE";
+	compatible = "zbtlink,zbt-z8803be", "mediatek,mt7988a";
+
+	aliases {
+		led-boot = &led_blue;
+		led-failsafe = &led_red;
+		led-running = &led_blue;
+		led-upgrade = &led_blue;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200n1 \
+			    earlycon=uart8250,mmio32,0x11000000 \
+			    pci=pcie_bus_perf";
+	};
+
+	memory@40000000 {
+		reg = <0x0 0x40000000 0x0 0x40000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		led_red: red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 62 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 58 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led_blue: blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 60 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "default-on";
+		};
+
+		led-5g1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_MOBILE;
+			function-enumerator = <1>;
+			gpios = <&pio 61 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		led-5g2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_MOBILE;
+			function-enumerator = <2>;
+			gpios = <&pio 53 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+	};
+
+	gpio-export {
+		compatible = "gpio-export";
+		#size-cells = <0>;
+
+		/*
+		 * Enable power to the primary modem (modem0) by default.
+		 * The secondary slot (modem1) remains powered off until
+		 * userspace explicitly enables it when populated.
+		 */
+		modem0 {
+			gpio-export,name = "5g1";
+			gpio-export,output = <1>;
+			gpios = <&pio 17 GPIO_ACTIVE_HIGH>;
+		};
+		modem1 {
+			gpio-export,name = "5g2";
+			gpio-export,output = <0>;
+			gpios = <&pio 52 GPIO_ACTIVE_HIGH>;
+		};
+		sim {
+			gpio-export,name = "sim";
+			gpio-export,output = <1>;
+			gpios = <&pio 59 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	sfp: sfp@0 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		mod-def0-gpios = <&pio 82 GPIO_ACTIVE_LOW>;
+		los-gpios = <&pio 81 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpios = <&pio 36 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <3000>;
+	};
+
+	fan: pwm-fan {
+		compatible = "pwm-fan";
+		#cooling-cells = <2>;
+		cooling-levels = <0 80 112 144 176 216 255>;
+		pwms = <&pwm 0 10000 0>;
+		status = "okay";
+	};
+
+	watchdog-gpio {
+		compatible = "linux,wdt-gpio";
+		gpios = <&pio 18 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <60000>;
+		always-running;
+		status = "okay";
+	};
+};
+
+&cpu0 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu1 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu2 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu3 {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cci {
+	proc-supply = <&rt5190_buck3>;
+};
+
+&cpu_thermal {
+	/delete-node/cooling-maps;
+	/delete-node/trips;
+
+	trips {
+		cpu_trip_crit: crit {
+			temperature = <100000>;
+			hysteresis = <2000>;
+			type = "critical";
+		};
+
+		cpu_trip_active_high: active-high {
+			temperature = <60000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_low: active-low {
+			temperature = <45000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+
+		cpu_trip_active_silent: active-silent {
+			temperature = <38000>;
+			hysteresis = <2000>;
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		cpu-active-high {
+			/* active: set fan to cooling level 3 */
+			cooling-device = <&fan 3 3>;
+			trip = <&cpu_trip_active_high>;
+		};
+
+		cpu-active-low {
+			/* active: set fan to cooling level 1 */
+			cooling-device = <&fan 1 1>;
+			trip = <&cpu_trip_active_low>;
+		};
+
+		cpu-active-silent {
+			/* active: set fan to cooling level 0 */
+			cooling-device = <&fan 0 0>;
+			trip = <&cpu_trip_active_silent>;
+		};
+	};
+};
+
+&pio {
+	mdio0_pins: mdio0-pins {
+		mux {
+			function = "eth";
+			groups = "mdc_mdio0";
+		};
+
+		conf {
+			groups = "mdc_mdio0";
+			drive-strength = <MTK_DRIVE_8mA>;
+		};
+	};
+
+	gbe0_led0_pins: gbe0-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe0_led0";
+		};
+	};
+
+	gbe2_led0_pins: gbe2-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe2_led0";
+		};
+	};
+
+	gbe3_led0_pins: gbe3-led0-pins {
+		mux {
+			function = "led";
+			groups = "gbe3_led0";
+		};
+	};
+
+	i2c0_pins: i2c0-g0-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c0_1";
+		};
+	};
+
+	i2c2_0_pins: i2c2-g0-pins {
+		mux {
+			function = "i2c";
+			groups = "i2c2_0";
+		};
+	};
+
+	i2p5gbe_led0_pins: 2p5gbe-led0-pins {
+		mux {
+			function = "led";
+			groups = "2p5gbe_led0";
+		};
+	};
+
+	spi0_flash_pins: spi0-flash-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+	};
+};
+
+&i2c0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0_pins>;
+	status = "okay";
+
+	rt5190a@64 {
+		compatible = "richtek,rt5190a";
+		reg = <0x64>;
+		vin2-supply = <&rt5190_buck1>;
+		vin3-supply = <&rt5190_buck1>;
+		vin4-supply = <&rt5190_buck1>;
+
+		regulators {
+			rt5190_buck1: buck1 {
+				regulator-name = "rt5190a-buck1";
+				regulator-min-microvolt = <5090000>;
+				regulator-max-microvolt = <5090000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			buck2 {
+				regulator-name = "vcore";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			rt5190_buck3: buck3 {
+				regulator-name = "vproc";
+				regulator-min-microvolt = <600000>;
+				regulator-max-microvolt = <1400000>;
+				regulator-boot-on;
+			};
+			buck4 {
+				regulator-name = "rt5190a-buck4";
+				regulator-min-microvolt = <850000>;
+				regulator-max-microvolt = <850000>;
+				regulator-allowed-modes =
+				<RT5190A_OPMODE_AUTO RT5190A_OPMODE_FPWM>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+			ldo {
+				regulator-name = "rt5190a-ldo";
+				regulator-min-microvolt = <1200000>;
+				regulator-max-microvolt = <1200000>;
+				regulator-boot-on;
+				regulator-always-on;
+			};
+		};
+	};
+};
+
+&i2c2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2_0_pins>;
+	status = "okay";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+	};
+};
+
+&spi_nand {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "BL2";
+			reg = <0x00000 0x0100000>;
+			read-only;
+		};
+
+		partition@100000 {
+			label = "u-boot-env";
+			reg = <0x100000 0x80000>;
+		};
+
+		factory: partition@180000 {
+			label = "Factory";
+			reg = <0x180000 0x400000>;
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				mt7996_eeprom: eeprom@0 {
+					reg = <0x0 0x1e00>;
+				};
+
+				gmac0_mac: macaddr@ffff4 {
+					reg = <0xffff4 0x6>;
+				};
+
+				gmac1_mac: macaddr@ffffa {
+					reg = <0xffffa 0x6>;
+				};
+
+				gmac2_mac: macaddr@fffee {
+					reg = <0xfffee 0x6>;
+				};
+			};
+		};
+
+		partition@580000 {
+			label = "FIP";
+			reg = <0x580000 0x200000>;
+		};
+
+		partition@780000 {
+			label = "ubi";
+			reg = <0x780000 0x7080000>;
+			compatible = "linux,ubi";
+		};
+	};
+};
+
+&pcie0 {
+	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x0000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		mt7996@0,0 {
+			reg = <0x0000 0 0 0 0>;
+			nvmem-cell-names = "eeprom";
+			nvmem-cells = <&mt7996_eeprom>;
+		};
+	};
+};
+
+&pcie1 {
+	status = "okay";
+};
+
+&pcie3 {
+	/*
+	 * Since the PCIe probe order is PCIe3 -> PCIe0 -> PCIe1 and there is
+	 * only one reset GPIO available, it must be connected to the first
+	 * device in the probe sequence (PCIe3).
+	 */
+	wifi-reset-gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+	wifi-reset-msleep = <100>;
+	status = "okay";
+};
+
+&eth {
+	pinctrl-0 = <&mdio0_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&gmac0 {
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&gmac0_mac>;
+	status = "okay";
+};
+
+&gmac1 {
+	phy-mode = "internal";
+	phy-connection-type = "internal";
+	phy = <&int_2p5g_phy>;
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&gmac1_mac>;
+	status = "okay";
+};
+
+&gmac2 {
+	sfp = <&sfp>;
+	managed = "in-band-status";
+	phy-mode = "10gbase-r";
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&gmac2_mac>;
+	status = "okay";
+};
+
+&int_2p5g_phy {
+	pinctrl-names = "i2p5gbe-led";
+	pinctrl-0 = <&i2p5gbe_led0_pins>;
+};
+
+&switch {
+	status = "okay";
+};
+
+&gsw_phy0 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe0_led0_pins>;
+};
+
+&gsw_phy0_led0 {
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_ORANGE>;
+	status = "okay";
+};
+
+&gsw_port0 {
+	label = "lan0";
+};
+
+&gsw_phy1 {
+	status = "disabled";
+};
+
+&gsw_port1 {
+	status = "disabled";
+};
+
+&gsw_phy2 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe2_led0_pins>;
+};
+
+&gsw_phy2_led0 {
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_ORANGE>;
+	status = "okay";
+};
+
+&gsw_port2 {
+	label = "lan1";
+};
+
+&gsw_phy3 {
+	pinctrl-names = "gbe-led";
+	pinctrl-0 = <&gbe3_led0_pins>;
+};
+
+&gsw_phy3_led0 {
+	function = LED_FUNCTION_LAN;
+	color = <LED_COLOR_ID_ORANGE>;
+	status = "okay";
+};
+
+&gsw_port3 {
+	label = "lan2";
+};
+
+&ssusb0 {
+	status = "okay";
+};
+
+&ssusb1 {
+	status = "okay";
+};
+
+&tphy {
+	status = "okay";
+};
+
+&xsphy {
+	status = "okay";
+};
+
+&serial0 {
+	status = "okay";
+};
+
+&pwm {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -342,7 +342,8 @@ xiaomi,redmi-router-ax6000-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "rgb:network" "wan"
 	;;
 zbtlink,zbt-z8103ax|\
-zbtlink,zbt-z8103ax-c)
+zbtlink,zbt-z8103ax-c|\
+zbtlink,zbt-z8803be)
 	ucidef_set_led_netdev "wan" "wan" "green:wan" "eth1" "link tx rx"
 	;;
 zbtlink,zbt-z8106ax-s|\

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -23,6 +23,10 @@ mediatek_setup_interfaces()
 	zbtlink,zbt-z8103ax-c)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" eth1
 		;;
+	zbtlink,zbt-z8803be)
+		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2" eth1
+		ucidef_set_interface "wan_sfp" device "eth2" protocol "none"
+		;;
 	acelink,ew-7886cax|\
 	tplink,eap683-lr)
 		ucidef_set_interface_lan "eth0" "dhcp"

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -292,7 +292,8 @@ platform_do_upgrade() {
 		nand_do_flash_file "$1" || nand_do_upgrade_failed
 		nand_do_upgrade_success
 		;;
-	tplink,fr365-v1)
+	tplink,fr365-v1|\
+	zbtlink,zbt-z8803be)
 		CI_UBIPART="ubi"
 		CI_KERNPART="kernel"
 		CI_ROOTPART="rootfs"

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -3679,6 +3679,23 @@ define Device/zbtlink_zbt-z8106ax-t
 endef
 TARGET_DEVICES += zbtlink_zbt-z8106ax-t
 
+define Device/zbtlink_zbt-z8803be
+  DEVICE_VENDOR := Zbtlink
+  DEVICE_MODEL := ZBT-Z8803BE
+  DEVICE_DTS := mt7988a-zbtlink-zbt-z8803be
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-sfp kmod-hwmon-pwmfan kmod-usb3 kmod-mt7996-firmware mt7988-2p5g-phy-firmware mt7988-wo-firmware
+  DEVICE_DTC_FLAGS := --pad 4096
+  SUPPORTED_DEVICES += zbtlink,zbt-z8803be,mt7988a-nand
+  KERNEL := kernel-bin | gzip | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGES := sysupgrade.bin
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+endef
+TARGET_DEVICES += zbtlink_zbt-z8803be
+
 define Device/zyxel_ex5601-t0-stock
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := EX5601-T0


### PR DESCRIPTION
This commit supports a ZBT-Z8803BE from ZBT.

Specifications:

SoC: MediaTek MT7988A (4 cores)
RAM: 1024MiB
Flash: Winbond SPI-NAND 128 MiB
Network: 1 WAN (2.5G), 3 LAN (1G), 1 SFP+ (10G)
2 SIM slots
Buttons: Reset, WPS
Power: DC 12V 3A (Recommend 19V to avoid voltage drop)
WiFi: MT7996 2.4Ghz, 5.8Ghz and 6Ghz (BE19000)
    - 2.4Ghz and 5.8Ghz share same dual band antenna (4)
    - 6Ghz uses dedicated 6G antenna (4)
Misc: 1 USB2.0 port, UART header

Installation:

A. Through U-Boot menu:

  - Prepare your connecting computer to use a static IP in
    network 192.168.1.0/24
  - Power down the router and hold in the Reset button.
  - While holding in the button power up the router again.
  - Hold the button in for 10 seconds and then release.
  - Use your browser to go to 192.168.1.1
  - If you see a GUI allowing for flashing firmware then
    you got the right model.
  - Upload the sysupgrade file.

Note 1: Recovery GUI can be used to recover from an incorrect
      firmware flash.
Note 2: There is a GPIO watchdog that expires after 2 minutes
      so flashing sysupgrade via U-boot needs to be done
      quickly within that timer.

B. Through OpenWrt Dashboard:
   If your router comes with OpenWrt preinstalled
   (modified by the seller), you can easily upgrad
   by going to the dashboard (192.168.1.1) and then
   navigate to System -> Backup/Flash firmware,
   then flash the firmware