### PR TITLE
qualcommax: ipq50xx: add support for TP-Link EAP650-Outdoor-v1

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
@@ -12,6 +12,7 @@ cmcc,mr3000d-ci|\
 cmcc,pz-l8|\
 elecom,wrc-x3000gs2|\
 iodata,wn-dax3000gr|\
+tplink,eap650-outdoor-v1|\
 zyxel,scr50axe)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
 	;;

--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
@@ -13,6 +13,7 @@ cmcc,pz-l8|\
 elecom,wrc-x3000gs2|\
 elecom,wrc-x3000gst2|\
 iodata,wn-dax3000gr|\
+tplink,eap650-outdoor-v1|\
 zyxel,scr50axe)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
 	;;

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -98,6 +98,7 @@ ALLWIFIBOARDS:= \
 	tplink_eap620hd-v1 \
 	tplink_eap623-outdoor-hd-v1 \
 	tplink_eap625-outdoor-hd-v1 \
+	tplink_eap650-outdoor-v1 \
 	tplink_eap660hd-v1 \
 	tplink_tl-wa1201-v2 \
 	wallys_dr40x9 \
@@ -294,6 +295,7 @@ $(eval $(call generate-ipq-wifi-package,tplink_eap620-hd-v3,TP-Link EAP620 HD v3
 $(eval $(call generate-ipq-wifi-package,tplink_eap620hd-v1,TP-Link EAP620 HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap623-outdoor-hd-v1,TP-Link EAP623-Outdoor HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap625-outdoor-hd-v1,TP-Link EAP625-Outdoor HD v1))
+$(eval $(call generate-ipq-wifi-package,tplink_eap650-outdoor-v1,TP-Link EAP650-Outdoor v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap660hd-v1,TP-Link EAP660 HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_tl-wa1201-v2,TP-Link TL-WA1201 V2))
 $(eval $(call generate-ipq-wifi-package,wallys_dr40x9,Wallys DR40X9))

--- a/package/firmware/ipq-wifi/Makefile
+++ b/package/firmware/ipq-wifi/Makefile
@@ -93,6 +93,7 @@ ALLWIFIBOARDS:= \
 	tplink_eap620-hd-v3 \
 	tplink_eap623-outdoor-hd-v1 \
 	tplink_eap625-outdoor-hd-v1 \
+	tplink_eap650-outdoor-v1 \
 	tplink_eap660hd-v1 \
 	tplink_archer-c59-v1 \
 	tplink_archer-c6-v2 \
@@ -287,6 +288,7 @@ $(eval $(call generate-ipq-wifi-package,tplink_eap620hd-v1,TP-Link EAP620 HD v1)
 $(eval $(call generate-ipq-wifi-package,tplink_eap620-hd-v3,TP-Link EAP620 HD v3))
 $(eval $(call generate-ipq-wifi-package,tplink_eap623-outdoor-hd-v1,TP-Link EAP623-Outdoor HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap625-outdoor-hd-v1,TP-Link EAP625-Outdoor HD v1))
+$(eval $(call generate-ipq-wifi-package,tplink_eap650-outdoor-v1,TP-Link EAP650-Outdoor v1))
 $(eval $(call generate-ipq-wifi-package,tplink_eap660hd-v1,TP-Link EAP660 HD v1))
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c59-v1,TP-Link Archer C59 V1))
 $(eval $(call generate-ipq-wifi-package,tplink_archer-c6-v2,TP-Link Archer C6 V2))

--- a/target/linux/qualcommax/dts/ipq5018-eap650-outdoor-v1.dts
+++ b/target/linux/qualcommax/dts/ipq5018-eap650-outdoor-v1.dts
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq5018.dtsi"
+#include "ipq5018-ess.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "TP-Link EAP650-Outdoor v1";
+	compatible = "tplink,eap650-outdoor-v1", "qcom,ipq5018";
+
+	aliases {
+		label-mac-device = <&dp2>;
+
+		led-boot = &led_system_green;
+		led-failsafe = &led_system_yellow;
+		led-running = &led_system_green;
+		led-upgrade = &led_system_yellow;
+
+		serial0 = &blsp1_uart1;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " ubi.block=0,rootfs root=/dev/ubiblock0_1 swiotlb=1 coherent_pool=2M";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_yellow: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_YELLOW>;
+			gpios = <&tlmm 46 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_system_green: led-1 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		button-pins {
+			pins = "gpio38";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	serial_0_pins: uart0-state {
+		pins = "gpio20", "gpio21";
+		function = "blsp0_uart0";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	mdio1_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio36";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio37";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	qpic_pins: qpic-state {
+		clock-pins {
+			pins = "gpio9";
+			function = "qspi_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		cs-pins {
+			pins = "gpio8";
+			function = "qspi_cs";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		data-pins {
+			pins = "gpio4", "gpio5", "gpio6", "gpio7";
+			function = "qspi_data";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	switch_reset_pins: switch-reset-state {
+		pins = "gpio39";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&xo_board_clk {
+	clock-div = <4>;
+	clock-mult = <1>;
+};
+
+&blsp1_uart1 {
+	status = "okay";
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qfprom {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	pinctrl-0 = <&qpic_pins>;
+	pinctrl-names = "default";
+
+	// GigaDevice F50D1G41LB-83YIG2M
+	nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		nand-ecc-engine = <&qpic_nand>;
+
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
+
+	qcom,port_phyinfo {
+		port@1 {
+			port_id = <1>;
+			mdiobus = <&mdio0>;
+			phy_address = <7>;
+		};
+
+		port@2 {
+			port_id = <2>;
+			phy_address = <4>;
+			mdiobus = <&mdio1>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&dp2 {
+	status = "okay";
+
+	label = "lan";
+	phy-handle = <&rtl8211f_4>;
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+&mdio1 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio1_pins>, <&switch_reset_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 39 GPIO_ACTIVE_LOW>;
+
+	// RTL8211 Phy0 -> LAN
+	rtl8211f_4: ethernet-phy@4 {
+		reg = <4>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+	};
+};
+
+&tsens {
+	status = "okay";
+};
+
+&pcie0_phy {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpios = <&tlmm 15 GPIO_ACTIVE_LOW>;
+
+	pcie@0 {
+		wifi@0,0 {
+			status = "okay";
+
+			// QCN6024: ath11k lacks DT compatible for PCI cards
+			compatible = "pci17cb,1104";
+			reg = <0x00010000 0 0 0 0>;
+
+			qcom,ath11k-calibration-variant = "TP-Link-EAP650-Outdoor-v1";
+			qcom,ath11k-fw-memory-mode = <1>;
+		};
+	};
+};
+
+&q6v5_wcss {
+	firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt",
+			"ath11k/IPQ5018/hw1.0/m3_fw.mdt";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,rproc = <&q6v5_wcss>;
+	qcom,ath11k-calibration-variant = "TP-Link-EAP650-Outdoor-v1";
+	qcom,ath11k-fw-memory-mode = <1>;
+};

--- a/target/linux/qualcommax/dts/ipq5018-eap650-outdoor-v1.dts
+++ b/target/linux/qualcommax/dts/ipq5018-eap650-outdoor-v1.dts
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq5018.dtsi"
+#include "ipq5018-ess.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "TP-Link EAP650-Outdoor v1";
+	compatible = "tplink,eap650-outdoor-v1", "qcom,ipq5018";
+
+	aliases {
+		label-mac-device = <&dp2>;
+
+		led-boot = &led_system_green;
+		led-failsafe = &led_system_yellow;
+		led-running = &led_system_green;
+		led-upgrade = &led_system_yellow;
+
+		serial0 = &blsp1_uart1;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " ubi.block=0,rootfs root=/dev/ubiblock0_1 swiotlb=1 coherent_pool=2M";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		reset {
+			label = "reset";
+			gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_system_yellow: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_YELLOW>;
+			gpios = <&tlmm 46 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_system_green: led-1 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&tlmm 31 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		button-pins {
+			pins = "gpio38";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	serial_0_pins: uart0-state {
+		pins = "gpio20", "gpio21";
+		function = "blsp0_uart0";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	mdio1_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio36";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio37";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	qpic_pins: qpic-state {
+		clock-pins {
+			pins = "gpio9";
+			function = "qspi_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		cs-pins {
+			pins = "gpio8";
+			function = "qspi_cs";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		data-pins {
+			pins = "gpio4", "gpio5", "gpio6", "gpio7";
+			function = "qspi_data";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	switch_reset_pins: switch-reset-state {
+		pins = "gpio39";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&xo_board_clk {
+	clock-div = <4>;
+	clock-mult = <1>;
+};
+
+&blsp1_uart1 {
+	status = "okay";
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qfprom {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	pinctrl-0 = <&qpic_pins>;
+	pinctrl-names = "default";
+	
+	// GigaDevice F50D1G41LB-83YIG2M
+	nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		nand-ecc-engine = <&qpic_nand>;
+
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+
+			partition-0-appsblenv {
+				compatible = "fixed-partitions";
+				label = "0:appsblenv";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				partition@0 {
+					label = "env-data";
+					reg = <0x0 0x40000>;
+
+					nvmem-layout {
+						compatible = "u-boot,env";
+
+						macaddr_appsblenv_ethaddr: ethaddr {
+							compatible = "mac-base";
+							#nvmem-cell-cells = <1>;
+						};
+					};
+				};
+			};
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+	
+	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
+
+	qcom,port_phyinfo {
+		port@0 {
+			port_id = <1>;
+			mdiobus = <&mdio0>;
+			phy_address = <7>;
+		};
+
+		port@1 {
+			port_id = <2>;
+			phy_address = <4>;
+			mdiobus = <&mdio1>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+		
+	};
+};
+
+&dp2 {
+	status = "okay";
+
+	label = "lan";
+	phy-handle = <&rtl8211f_4>;
+
+	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&macaddr_appsblenv_ethaddr (0)>;
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+&mdio1 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio1_pins>, <&switch_reset_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 39 GPIO_ACTIVE_LOW>;
+
+	// RTL8211 Phy0 -> LAN
+	rtl8211f_4: ethernet-phy@4 {
+		reg = <4>;
+		compatible = "ethernet-phy-ieee802.3-c22";
+	};
+};
+
+&tsens {
+	status = "okay";
+};
+
+&pcie0_phy {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+
+	perst-gpios = <&tlmm 15 GPIO_ACTIVE_LOW>;
+
+	pcie@0 {
+		wifi@0,0 {
+			status = "okay";
+
+			// QCN6024: ath11k lacks DT compatible for PCI cards
+			compatible = "pci17cb,1104";
+			reg = <0x00010000 0 0 0 0>;
+
+			qcom,ath11k-calibration-variant = "TP-Link-EAP650-Outdoor-v1";
+			qcom,ath11k-fw-memory-mode = <1>;
+		};
+	};
+};
+
+&q6v5_wcss {
+	firmware-name = "ath11k/IPQ5018/hw1.0/q6_fw.mdt",
+			"ath11k/IPQ5018/hw1.0/m3_fw.mdt";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,rproc = <&q6v5_wcss>;
+	qcom,ath11k-calibration-variant = "TP-Link-EAP650-Outdoor-v1";
+	qcom,ath11k-fw-memory-mode = <1>;
+};

--- a/target/linux/qualcommax/image/ipq50xx.mk
+++ b/target/linux/qualcommax/image/ipq50xx.mk
@@ -201,6 +201,24 @@ define Device/linksys_spnmx56
 endef
 TARGET_DEVICES += linksys_spnmx56
 
+define Device/tplink_eap650-outdoor-v1
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := TP-Link
+	DEVICE_MODEL := EAP650-Outdoor
+	DEVICE_VARIANT := v1
+	DEVICE_DTS_CONFIG := config@mp03.1
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	NAND_SIZE := 128m
+	SOC := ipq5018
+	DEVICE_PACKAGES := ath11k-firmware-ipq5018 \
+		kmod-ath11k-pci \
+		ath11k-firmware-qcn9074 \
+		ipq-wifi-tplink_eap650-outdoor-v1
+endef
+TARGET_DEVICES += tplink_eap650-outdoor-v1
+
 define Device/xiaomi_ipq50xx_ax_base
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/image/ipq50xx.mk
+++ b/target/linux/qualcommax/image/ipq50xx.mk
@@ -182,6 +182,24 @@ define Device/linksys_spnmx56
 endef
 TARGET_DEVICES += linksys_spnmx56
 
+define Device/tplink_eap650-outdoor-v1
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := TP-Link
+	DEVICE_MODEL := EAP650-Outdoor
+	DEVICE_VARIANT := v1
+	DEVICE_DTS_CONFIG := config@mp03.1
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	NAND_SIZE := 128m
+	SOC := ipq5018
+	DEVICE_PACKAGES := ath11k-firmware-ipq5018 \
+		kmod-ath11k-pci \
+		ath11k-firmware-qcn9074 \
+		ipq-wifi-tplink_eap650-outdoor-v1
+endef
+TARGET_DEVICES += tplink_eap650-outdoor-v1
+
 define Device/xiaomi_ax6000
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
@@ -37,12 +37,35 @@ ipq50xx_setup_interfaces()
 		ucidef_set_network_device_conduit "lan3" "eth1"
 		ucidef_set_network_device_conduit "wan" "eth0"
 		;;
+	tplink,eap650-outdoor-v1)
+		ucidef_set_interface_lan "lan"
+		;;
 	esac
+}
+
+ipq50xx_setup_macs()
+{
+	local board="$1"
+	local lan_mac=""
+	local wan_mac=""
+	local label_mac=""
+
+	case $board in
+	tplink,eap650-outdoor-v1)
+		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
+		lan_mac=$label_mac
+		;;
+	esac
+
+	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac
+	[ -n "$wan_mac" ] && ucidef_set_interface_macaddr "wan" $wan_mac
+	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
 }
 
 board_config_update
 board=$(board_name)
 ipq50xx_setup_interfaces $board
+ipq50xx_setup_macs $board
 board_config_flush
 
 exit 0

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
@@ -35,12 +35,35 @@ ipq50xx_setup_interfaces()
 		ucidef_set_network_device_conduit "lan3" "eth1"
 		ucidef_set_network_device_conduit "wan" "eth0"
 		;;
+	tplink,eap650-outdoor-v1)
+		ucidef_set_interface_lan "lan" "dhcp"
+		;;
 	esac
+}
+
+ipq50xx_setup_macs()
+{
+	local board="$1"
+	local lan_mac=""
+	local wan_mac=""
+	local label_mac=""
+
+	case $board in
+	tplink,eap650-outdoor-v1)
+		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
+		lan_mac=$label_mac
+		;;
+	esac
+
+	[ -n "$lan_mac" ] && ucidef_set_interface_macaddr "lan" $lan_mac
+	[ -n "$wan_mac" ] && ucidef_set_interface_macaddr "wan" $wan_mac
+	[ -n "$label_mac" ] && ucidef_set_label_macaddr $label_mac
 }
 
 board_config_update
 board=$(board_name)
 ipq50xx_setup_interfaces $board
+ipq50xx_setup_macs $board
 board_config_flush
 
 exit 0

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -46,6 +46,12 @@ case "$FIRMWARE" in
 		ath11k_remove_regdomain
 		ath11k_set_macflag
 		;;
+	tplink,eap650-outdoor-v1)
+		caldata_from_file "/tmp/factory_data/radio" 0 0x20000
+		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
+		ath11k_patch_mac $label_mac 0
+		ath11k_set_macflag
+		;;
 	xiaomi,ax6000)
 		caldata_extract "0:art" 0x1000 0x20000
 		;;
@@ -129,6 +135,12 @@ case "$FIRMWARE" in
 		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
 		ath11k_remove_regdomain
+		ath11k_set_macflag
+		;;
+	tplink,eap650-outdoor-v1)
+		caldata_from_file "/tmp/factory_data/radio1" 0 0x20000
+		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
+		ath11k_patch_mac $(macaddr_add $label_mac 1) 0
 		ath11k_set_macflag
 		;;
 	xiaomi,ax6000)

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -47,6 +47,12 @@ case "$FIRMWARE" in
 		ath11k_remove_regdomain
 		ath11k_set_macflag
 		;;
+	tplink,eap650-outdoor-v1)
+		caldata_from_file "/tmp/factory_data/radio" 0 0x20000
+		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
+		ath11k_patch_mac $label_mac 0
+		ath11k_set_macflag
+		;;
 	xiaomi,ax6000|\
 	xiaomi,redmi-ax5400)
 		caldata_extract "0:art" 0x1000 0x20000
@@ -132,6 +138,12 @@ case "$FIRMWARE" in
 		label_mac=$(mtd_get_mac_ascii devinfo hw_mac_addr)
 		ath11k_patch_mac $(macaddr_add $label_mac 2) 0
 		ath11k_remove_regdomain
+		ath11k_set_macflag
+		;;
+	tplink,eap650-outdoor-v1)
+		caldata_from_file "/tmp/factory_data/radio1" 0 0x20000
+		label_mac=$(get_mac_binary /tmp/factory_data/default-mac 0)
+		ath11k_patch_mac $(macaddr_add $label_mac 1) 0
 		ath11k_set_macflag
 		;;
 	xiaomi,ax6000|\

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/preinit/09_mount_factory_data
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/preinit/09_mount_factory_data
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+preinit_mount_factory_data() {
+	local mtd_path
+
+	. /lib/functions.sh
+	. /lib/functions/system.sh
+
+	case $(board_name) in
+	tplink,eap650-outdoor-v1)
+		mtd_path=$(find_mtd_chardev "factory_data")
+		ubiattach --dev-path="$mtd_path" --devn=1
+		mkdir /tmp/factory_data
+		mount -o ro,noatime -t ubifs ubi1:ubi_factory_data /tmp/factory_data
+		;;
+	esac
+}
+
+boot_hook_add preinit_main preinit_mount_factory_data

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
@@ -165,6 +165,56 @@ linksys_mx_pre_upgrade() {
 	fi
 }
 
+tplink_get_boot_part() {
+	local cur_boot_part
+	local args
+
+	# Try to find rootfs from kernel arguments
+	read -r args < /proc/cmdline
+	for arg in $args; do
+		local ubi_mtd_arg=${arg#ubi.mtd=}
+		case "$ubi_mtd_arg" in
+		rootfs|rootfs_1)
+			echo "$ubi_mtd_arg"
+			return
+		;;
+		esac
+	done
+
+	# Fallback to u-boot env (e.g. when running initramfs)
+	cur_boot_part="$(/usr/sbin/fw_printenv -n tp_boot_idx)"
+	case $cur_boot_part in
+	1)
+		echo rootfs_1
+		;;
+	0|*)
+		echo rootfs
+		;;
+	esac
+}
+
+tplink_do_upgrade() {
+	local new_boot_part
+
+	case $(tplink_get_boot_part) in
+	rootfs)
+		CI_UBIPART="rootfs_1"
+		new_boot_part=1
+		;;
+	rootfs_1)
+		CI_UBIPART="rootfs"
+		new_boot_part=0
+		;;
+	esac
+
+	fw_setenv -s - <<-EOF
+		tp_boot_idx $new_boot_part
+	EOF
+
+	remove_oem_ubi_volume ubi_rootfs
+	nand_do_upgrade "$1"
+}
+
 platform_check_image() {
 	return 0;
 }
@@ -212,6 +262,9 @@ platform_do_upgrade() {
 		linksys_bootconfig_pre_upgrade "$1"
 		remove_oem_ubi_volume ubi_rootfs
 		nand_do_upgrade "$1"
+		;;
+	tplink,eap650-outdoor-v1)
+		tplink_do_upgrade "$1"
 		;;
 	xiaomi,ax6000|\
 	xiaomi,redmi-ax5400)

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
@@ -165,6 +165,56 @@ linksys_mx_pre_upgrade() {
 	fi
 }
 
+tplink_get_boot_part() {
+	local cur_boot_part
+	local args
+
+	# Try to find rootfs from kernel arguments
+	read -r args < /proc/cmdline
+	for arg in $args; do
+		local ubi_mtd_arg=${arg#ubi.mtd=}
+		case "$ubi_mtd_arg" in
+		rootfs|rootfs_1)
+			echo "$ubi_mtd_arg"
+			return
+		;;
+		esac
+	done
+
+	# Fallback to u-boot env (e.g. when running initramfs)
+	cur_boot_part="$(/usr/sbin/fw_printenv -n tp_boot_idx)"
+	case $cur_boot_part in
+	1)
+		echo rootfs_1
+		;;
+	0|*)
+		echo rootfs
+		;;
+	esac
+}
+
+tplink_do_upgrade() {
+	local new_boot_part
+
+	case $(tplink_get_boot_part) in
+	rootfs)
+		CI_UBIPART="rootfs_1"
+		new_boot_part=1
+	;;
+	rootfs_1)
+		CI_UBIPART="rootfs"
+		new_boot_part=0
+	;;
+	esac
+
+	fw_setenv -s - <<-EOF
+		tp_boot_idx $new_boot_part
+	EOF
+
+	remove_oem_ubi_volume ubi_rootfs
+	nand_do_upgrade "$1"
+}
+
 platform_check_image() {
 	return 0;
 }
@@ -211,6 +261,9 @@ platform_do_upgrade() {
 		linksys_bootconfig_pre_upgrade "$1"
 		remove_oem_ubi_volume ubi_rootfs
 		nand_do_upgrade "$1"
+		;;
+	tplink,eap650-outdoor-v1)
+		tplink_do_upgrade "$1"
 		;;
 	xiaomi,ax6000)
 		# Make sure that UART is enabled


### PR DESCRIPTION
TP-Link EAP650-Outdoor is a 802.11ax AP claiming AX3000 support. It is wall or pole mountable, and rated for outdoor use. It can only be powered via PoE.

Linked pull request: https://github.com/openwrt/firmware_qca-wireless/pull/134

Specifications:
---------------
* CPU: Qualcomm IPQ5018 Dual core Cortex-A53
* RAM: 512 MB
* Storage: 128MB NAND GigaDevice F50D1G41LB-83YIG2M
* Ethernet: 1x Gigabit RJ45 port with PoE input
* 2.4GHz: IPQ5018 802.11b/g/n/ax (2x 4dBi)
* 5GHz: QCN6024 802.11n/ac/ax (2x 5dBi)
* LEDs: 1x Status LED (Green/Yellow)
* Buttons: 1x Reset
* UART: 4-pin unpopulated header TX RX GND VCC - JP2 (3.3V, 115200/8)

The procedures to 'backup your stock firmware' and 'stock firmware recovery' described in the commit "qualcommax: ipq50xx: Add support for Yuncore AX850" are equivalent for this device.
https://git.openwrt.org/openwrt/openwrt/commit/?id=5d2994a73e20ba840d3096e1ad52add6937fe86d

Installation:
=============

TFTP method
-----------

To flash via tftp, first place the initramfs image on the TFTP server.

    setenv serverip <ip of tftp server>
    setenv ipaddr <ip in same subnet as tftp server>
    tftpboot tplink_eap650-outdoor-v1-initramfs-uImage.itb
    bootm

This should boot OpenWRT. Once booted, flash the sysupgrade.bin image using either luci or the commandline.


**Edited 2026-04-24**
not working:
- ~2.4GHz: htmode HE40 not working~ **must be forced setting `uci set wireless.radio0.noscan='1'`**
- 5GHz: htmode HE80 has bad performances, like
  TX +900 Mbits/sec RX +600 Mbits/sec (running iperf3 not bidir to an host)
  TX +300 Mbits/sec RX +400 Mbits/sec (running iperf3 not bidir to a different ax router)
- ~lan port has not the maximum performances, like
  TX +900 Mbits/sec RX +600 Mbits/sec (running iperf3 not bidir)~ **managed to obtain better RX performances +800Mbits/sec (up to 940Mbits/sec) distributing the interrupts to the second cpu via `echo 2 > /proc/irq/32/smp_affinity`**

**Edited 2026-04-29**
- Added the missing `qcom,ath11k-fw-memory-mode = <1>;` for 2.4Ghz like OEM firmware does

**Edited 2026-05-28**
Linking a repo with some notes on the device, oem dts, serial logs.
And an issue about partially working 80211s:
- iwinfo dev assoclist shows `RX: unknown` on associated stations,
-  vlan interfaces created on top of 802.11s don't work. 
For these 2 I was wondering if it is related to an hardware misconfiguration or it is a possible ath11k driver issue.
collected some debug logs in the repo:
In ap or sta mode seems stable and have decent/good performances.
https://github.com/a-gave/tplink_eap650-outdoor-v1

**Edited 2026-08-02**
Found a working method to gain root access with the original firmware https://www.reddit.com/r/TPLink_Omada/comments/1i2kzxo/real_root_access_to_eap670/
In summary, to get an interactive shell as root via telnet
```
cliclientd tdb "-r chmod 777 /tmp" && sleep 1 && \
    echo "iptables -A INPUT_DROPBEAR -p tcp --dport 23 -j ACCEPT && telnetd -l /bin/ash" > /tmp/runx && \
    cliclientd tdb "-r ash /tmp/runx"
```  

