### PR TITLE
util-linux: fix build on Linux v6.18 against musl

### DIFF
--- a/package/utils/util-linux/patches/0001-nsenter-Fix-AT_HANDLE_FID-on-musl.patch
+++ b/package/utils/util-linux/patches/0001-nsenter-Fix-AT_HANDLE_FID-on-musl.patch
@@ -1,0 +1,30 @@
+From 5452239f6e69d2d3aaa427d2d2253247cfb7cb7b Mon Sep 17 00:00:00 2001
+From: Aleksi Hannula <ahannula4+nixgit@gmail.com>
+Date: Tue, 7 Apr 2026 14:52:16 +0300
+Subject: [PATCH] nsenter: Fix AT_HANDLE_FID on musl
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Aleksi Hannula <ahannula4+nixgit@gmail.com>
+---
+ sys-utils/nsenter.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/sys-utils/nsenter.c b/sys-utils/nsenter.c
+index e10ba9cf90ab..98507958c0f1 100644
+--- a/sys-utils/nsenter.c
++++ b/sys-utils/nsenter.c
+@@ -29,6 +29,9 @@
+ #ifdef HAVE_LINUX_NSFS_H
+ # include <linux/nsfs.h>
+ #endif
++#ifndef AT_HANDLE_FID
++# define AT_HANDLE_FID 0x200
++#endif
+ #ifndef NS_GET_USERNS
+ # define NS_GET_USERNS           _IO(0xb7, 0x1)
+ #endif
+-- 
+2.53.0
+


### PR DESCRIPTION
Backport an upstream patch to avoid usages of an undefined AT_HANDLE_FID.

Closes: https://github.com/openwrt/openwrt/issues/23058