### PR TITLE
base-files: ipcalc.sh: get rid of `basename` dependency

### DIFF
--- a/package/base-files/files/bin/ipcalc.sh
+++ b/package/base-files/files/bin/ipcalc.sh
@@ -2,8 +2,6 @@
 
 . /lib/functions/ipv4.sh
 
-PROG="$(basename "$0")"
-
 # wrapper to convert an integer to an address, unless we're using
 # decimal output format.
 # hook for library function
@@ -21,7 +19,7 @@ _ip2str() {
 }
 
 usage() {
-    echo "Usage: $PROG [ -d | -x ] address/prefix [ start limit ]" >&2
+    echo "Usage: ${0##*/} [ -d | -x ] address/prefix [ start limit ]" >&2
     exit 1
 }
 


### PR DESCRIPTION
The netifd/dhcp flow uses this, and as uxc mounts netifd in a container, this allows not mounting `basename` for just a usage.

References: https://github.com/openwrt/procd/pull/34
Suggested-by: Daniel Golle <daniel@makrotopia.org>