### PR TITLE
airoha: w1700k with 528 erase blocks for the BMT partition

### DIFF
--- a/package/boot/uboot-airoha/patches/999-airoha-add-gemtek-w1700k.patch
+++ b/package/boot/uboot-airoha/patches/999-airoha-add-gemtek-w1700k.patch
@@ -276,13 +276,13 @@ Signed-off-by: Kenneth Kasilag <kenneth@kasilag.me>
 +
 +		ubi@700000 {
 +			label = "ubi";
-+			reg = <0x00700000 0x1f700000>;
++			reg = <0x00700000 0x1b700000>;
 +		};
 +
 +		/* reserved for bad block table */
-+		reserved_bmt@1fe00000 {
++		reserved_bmt@1be00000 {
 +			label = "reserved_bmt";
-+			reg = <0x1fe00000 0x00200000>;
++			reg = <0x1be00000 0x04200000>;
 +			read-only;
 +		};
 +	};

--- a/target/linux/airoha/an7581/base-files/etc/board.d/05_compat-version
+++ b/target/linux/airoha/an7581/base-files/etc/board.d/05_compat-version
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2020 OpenWrt.org
+#
+
+. /lib/functions.sh
+. /lib/functions/uci-defaults.sh
+
+board_config_update
+
+case "$(board_name)" in
+	gemtek,w1700k-ubi)
+		ucidef_set_compat_version "2.0"
+		;;
+esac
+
+board_config_flush
+
+exit 0

--- a/target/linux/airoha/dts/an7581-w1700k-ubi.dts
+++ b/target/linux/airoha/dts/an7581-w1700k-ubi.dts
@@ -182,7 +182,7 @@
 
 		partition@700000 {
 			label = "ubi";
-			reg = <0x00700000 0x1f700000>;
+			reg = <0x00700000 0x1b700000>;
 			compatible = "linux,ubi";
 
 			volumes {
@@ -211,9 +211,9 @@
 		};
 
 		/* reserved for bad block table */
-		reserved_bmt@1fe00000 {
+		reserved_bmt@1be00000 {
 			label = "reserved_bmt";
-			reg = <0x1fe00000 0x00200000>;
+			reg = <0x1be00000 0x04200000>;
 			read-only;
 		};
 	};

--- a/target/linux/airoha/image/an7581.mk
+++ b/target/linux/airoha/image/an7581.mk
@@ -97,6 +97,10 @@ define Device/gemtek_w1700k-ubi
   DEVICE_ALT2_MODEL := W1700K
   DEVICE_ALT2_VARIANT := UBI
   DEVICE_DTS := an7581-w1700k-ubi
+  DEVICE_COMPAT_VERSION := 2.0
+  DEVICE_COMPAT_MESSAGE := Partition table has been changed to cooperate \
+       with the vendor bootloader with regard to the BMT/BBT partition at \
+       the end of flash. A reinstall including corrected chainloader is needed.
   DEVICE_PACKAGES := airoha-en7581-mt7996-npu-firmware \
 		    fitblk kmod-i2c-an7581 kmod-hwmon-nct7802 \
 		    kmod-mt7996-firmware kmod-phy-rtl8261n \


### PR DESCRIPTION
In a forum post (https://forum.openwrt.org/t/quantum-fiber-w1700k-support/222776/3039), it was noted that the vendor bootloader is continually fighting with the chainloading u-boot over the final 250 eraseblocks on the flash chip. When the vendor bootloader runs, it looks for a header RAWB and perhaps some additional integrity checks, and if it fails to validate the BMT information, it rewrites the blocks. Then, the chainloading u-boot notices that those blocks, which it considers part of mtd2, do not have UBI headers and rewrites them back to UBI blocks. If any of those blocks actually held data, the vendor u-boot would effectively erase them, damaging the filesystems or other information located there. The vendor firmware ended the "system" partition at flash address 0x1be00000, however, it doesn't appear that the vendor u-boot cares about anything prior to 0x1e0c0000. Meanwhile, OpenWrt has device trees that assume BMT is confined to the last 2MiB of flash, which appears to be erroneous. 

This commit "corrects" the mtd partition table boundaries to expand the BMT partition reserved_bmt to 250 eraseblocks, so that the vendor u-boot no longer fights with the chainloading u-boot. It might be more conservative to expand the BMT partition to 528 erase blocks, following the vendor partitioning. I don't know if those extra 278 erase blocks are used for anything.

I have built a chainloader, vanilla recovery and sysupgrade firmwares, built an installer using this patch and https://github.com/hurrian/w1700k-ubi-installer and my vanilla recovery and sysupgrade firmwares, replaced the chainloading u-boot and then used my installer on my W1700K and it seems to work.

Some coordination with @hurrian on a new installer is warranted. Also, the wiki will need updating with the revised partition table.