### PR TITLE
kernel: rtl8261n: Always configure as USXGMII

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/phy_patch.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/phy_patch.c
@@ -98,11 +98,6 @@ static int32 _phy_patch_process(uint32 unit, rtk_port_t port, uint8 portOffset, 
     return (chk_ret == RT_ERR_CHECK_FAILED) ? chk_ret : RT_ERR_OK;
 }
 
-rtk_hwpatch_t rtl826XB_patch_rtk_conf[] = {
-    {RTK_PATCH_OP_PSDS0   , 0xff , 0x07  , 0x10  , 15, 0, 0x80aa, RTK_PATCH_CMP_WC  , 0, 0, 0, 0},
-    {RTK_PATCH_OP_PSDS0   , 0xff , 0x06  , 0x12  , 15, 0, 0x5078, RTK_PATCH_CMP_WC  , 0, 0, 0, 0},
-};
-
 /* Function Name:
  *      phy_patch
  * Description:
@@ -175,16 +170,6 @@ int32 phy_patch(uint32 unit, rtk_port_t port, uint8 portOffset, uint8 patch_mode
             break;
         }
     }
-#ifdef CONFIG_MACH_REALTEK_RTL
-    ret = _phy_patch_process(unit, port, portOffset, rtl826XB_patch_rtk_conf, sizeof(rtl826XB_patch_rtk_conf), patch_mode);
-    if (ret == RT_ERR_CHECK_FAILED)
-        chk_ret = ret;
-    else if (ret  != RT_ERR_OK)
-    {
-        RT_LOG(LOG_MAJOR_ERR, (MOD_HAL | MOD_PHY), "U%u P%u patch_mode:%u id:%u patch-%u failed. ret:0x%X\n", unit, port, patch_mode, i, patch_type, ret);
-        return ret;
-    }
-#endif
 
     return (chk_ret == RT_ERR_CHECK_FAILED) ? chk_ret : RT_ERR_OK;
 }

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
@@ -78,9 +78,6 @@ static int rtkphy_config_init(struct phy_device *phydev)
         case REALTEK_PHY_ID_RTL8264B:
         case REALTEK_PHY_ID_RTL8264:
             phydev_info(phydev, "%s:%u [RTL8261N/RTL8264/RTL826XB] phy_id: 0x%X PHYAD:%d\n", __FUNCTION__, __LINE__, phydev->drv->phy_id, phydev->mdio.addr);
-#ifdef CONFIG_MACH_REALTEK_RTL
-            return 0;
-#endif
 
           #if 1 /* toggle reset */
             phy_modify_mmd_changed(phydev, 30, 0x145, BIT(0)  , 1);

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
@@ -81,6 +81,7 @@ static int rtkphy_config_init(struct phy_device *phydev)
 
           #if 1 /* toggle reset */
             phy_modify_mmd_changed(phydev, 30, 0x145, BIT(0)  , 1);
+            mdelay(30);
             phy_modify_mmd_changed(phydev, 30, 0x145, BIT(0)  , 0);
             mdelay(30);
           #endif


### PR DESCRIPTION
In the past, all the configuration of SerDes and PHYs on the realtek switches were done  using u-boot (`rtk init`). But since RTL930x switched to SerDes configuration under Linux, the SoC side is no longer using the Realtek-proprietary variant of USXGMII. The communication to the RTL8261N PHYs on those switches broke because of this incompatibility.

Enabling the full initialization on `CONFIG_MACH_REALTEK_RTL` converts also the PHY side to the standard USXGMII and therefore ensures that both sides speak the same dialect.

In this process, also an undocumented `CONFIG_MACH_REALTEK_RTL` only patch needs to be removed. It was never actually reached before. Simply, because `rtkphy_config_init()` returned on `CONFIG_MACH_REALTEK_RTL` switches before the PHY patching was reached. But it also seems to be wrong to apply it now. The SerDes<->PHY communication should use the standard USXGMII and not some proprietary Realtek variant.

---

This was mostly extracted from a discussion with @jonasjelonek (https://github.com/openwrt/openwrt/pull/22563#issuecomment-4191291033)