### PR TITLE
kernel: hide kmod-pppox

### DIFF
--- a/package/kernel/linux/modules/netsupport.mk
+++ b/package/kernel/linux/modules/netsupport.mk
@@ -605,7 +605,7 @@ define KernelPackage/pppox
   SUBMENU:=$(NETWORK_SUPPORT_MENU)
   TITLE:=PPPoX helper
   DEPENDS:=kmod-ppp
-  KCONFIG:=CONFIG_PPPOE
+  HIDDEN:=1
   FILES:=$(LINUX_DIR)/drivers/net/ppp/pppox.ko
 endef
 


### PR DESCRIPTION
The pppox module is a dependency of pppoe/pptp/pppol2tp and does not have a separate Kconfig symbol.