### PR TITLE
airoha: w1700k: drop RTL8261N phy interrupt

### DIFF
--- a/target/linux/airoha/dts/an7581-w1700k-ubi.dts
+++ b/target/linux/airoha/dts/an7581-w1700k-ubi.dts
@@ -353,8 +353,8 @@
 			reset-gpios = <&en7581_pinctrl 46 GPIO_ACTIVE_LOW>;
 			reset-assert-us = <200000>;
 			reset-deassert-us = <200000>;
-			interrupt-parent = <&en7581_pinctrl>;
-			interrupts = <22 IRQ_TYPE_LEVEL_LOW>;
+			// interrupt-parent = <&en7581_pinctrl>;
+			// interrupts = <22 IRQ_TYPE_LEVEL_LOW>;
 			realtek,pnswap-tx;
 			realtek,pnswap-rx;
 		};
@@ -365,8 +365,8 @@
 			reset-gpios = <&en7581_pinctrl 31 GPIO_ACTIVE_LOW>;
 			reset-assert-us = <200000>;
 			reset-deassert-us = <200000>;
-			interrupt-parent = <&en7581_pinctrl>;
-			interrupts = <23 IRQ_TYPE_LEVEL_LOW>;
+			// interrupt-parent = <&en7581_pinctrl>;
+			// interrupts = <23 IRQ_TYPE_LEVEL_LOW>;
 			realtek,pnswap-tx;
 			realtek,pnswap-rx;
 		};


### PR DESCRIPTION
The AN7531N SoC has currently problems communicating using `phy_mmd_...` when irqbalance is active. But when there is a communication error in the interrupt handler, the interrupt will be disabled. This can usually be seen in the logs as:

    irq 53: nobody cared (try booting with the "irqpoll" option)
    CPU: 0 UID: 0 PID: 0 Comm: swapper/0 Tainted: G       O   6.12.77 #0
    Tainted: [O]=OOT_MODULE
    Hardware name: Gemtek W1700K (OpenWrt U-Boot layout) (DT)
    Call trace:
     dump_backtrace.part.0+0xbc/0xcc
     show_stack+0x14/0x20
     dump_stack_lvl+0x58/0x74
     dump_stack+0x14/0x1c
     __report_bad_irq+0x48/0xf8
     note_interrupt+0x2f4/0x340
     handle_irq_event+0xac/0xe0
     handle_simple_irq+0xa8/0xfc
     handle_irq_desc+0x30/0x54
     generic_handle_irq+0x1c/0x24
     airoha_irq_handler+0x90/0xe0
     __handle_irq_event_percpu+0x44/0x11c
     handle_irq_event+0x40/0xe0
     handle_fasteoi_irq+0xb4/0x240
     handle_irq_desc+0x30/0x54
     generic_handle_domain_irq+0x18/0x20
     gic_handle_irq+0x60/0xec
     do_interrupt_handler+0x4c/0x84
     el1_interrupt+0x30/0x4c
     el1h_64_irq_handler+0x14/0x1c
     el1h_64_irq+0x68/0x6c
     handle_softirqs+0x98/0x210
     __do_softirq+0x10/0x18
     ____do_softirq+0xc/0x20
     call_on_irq_stack+0x30/0x50
     do_softirq_own_stack+0x18/0x20
     irq_exit_rcu+0x80/0xb8
     el1_interrupt+0x34/0x4c
     el1h_64_irq_handler+0x14/0x1c
     el1h_64_irq+0x68/0x6c
     default_idle_call+0x24/0x34
     do_idle+0x98/0xf0
     cpu_startup_entry+0x30/0x38
     kernel_init+0x0/0x130
     console_on_rootfs+0x0/0x64
     __primary_switched+0x80/0x88
    handlers:
    [<000000002b75be58>] irq_default_primary_handler threaded
                            [<000000006d87ada6>] phy_interrupt
    Disabling IRQ #53

This is not a problem with the rtl8261n driver because it is not registering an interrupt handler. But with the kernel realtek PHY driver, a interrupt handler is registered which can trigger this problem on bootup.

To avoid is, disable the interrupt and use the PHY polling mode also wit the upcoming realtek PHY driver support for RTL8261.

Related-to: https://github.com/openwrt/openwrt/pull/22563
