### PR TITLE
ramips: mt7621: add MikroTik sysupgrade-v7 NOR platform check

### DIFF
--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -8,6 +8,33 @@ REQUIRE_IMAGE_METADATA=1
 RAMFS_COPY_BIN='fw_printenv fw_setenv'
 RAMFS_COPY_DATA='/etc/fw_env.config /var/lock/fw_printenv.lock'
 
+platform_check_image_mikrotik_nor() {
+	local bootfwver bootfwmajor
+	local bootentry="$(dd bs=10 skip=1 count=1 if="$1" 2>/dev/null | xargs)"
+
+	if grep -q "\[regular\]" /sys/firmware/mikrotik/soft_config/booter; then
+		read -r bootfwver < /sys/firmware/mikrotik/soft_config/bios_version
+	elif grep -q "\[backup\]" /sys/firmware/mikrotik/soft_config/booter; then
+		read -r bootfwver < /sys/firmware/mikrotik/hard_config/booter_version
+	else
+		return 1
+	fi
+	bootfwmajor="${bootfwver%%.*}"
+
+	if [ "$((bootfwmajor))" = 0 ]; then
+		v "invalid RouterBOOT version"
+		return 1
+	elif [ "$bootfwmajor" -le 6 ] && [ "$bootentry" != "kernel" ]; then
+		v "RouterBOOT 6 and earlier requires ELF-in-YAFFS image"
+		return 1
+	elif [ "$bootfwmajor" -ge 7 ] && [ "$bootentry" != "bootimage" ]; then
+		v "RouterBOOT 7 and later requires NPK-in-YAFFS image"
+		return 1
+	fi
+
+	return 0
+}
+
 platform_check_image() {
 	local board=$(board_name)
 	local magic="$(get_magic_long "$1")"
@@ -18,6 +45,14 @@ platform_check_image() {
 	buffalo,wsr-2533dhpl2|\
 	buffalo,wsr-2533dhpls)
 		buffalo_check_image "$board" "$magic" "$1" || return 1
+		;;
+	mikrotik,ltap-2hnd|\
+	mikrotik,routerboard-750gr3|\
+	mikrotik,routerboard-760igs|\
+	mikrotik,routerboard-m11g|\
+	mikrotik,routerboard-m33g)
+		platform_check_image_mikrotik_nor "$1"
+		return $?
 		;;
 	esac
 


### PR DESCRIPTION
Since commit ("ramips: mikrotik: generate a RouterBOOT v7 NOR compatible sysupgrade") https://github.com/openwrt/openwrt/commit/7276e28e4779d9582a9a42d3ce217407471a2a79 we are generating sysupgrade-v7 images for MikroTik devices with NOR flash and that bootloader version. This commit adds a check to ensure the current RouterBOOT version matches the sysupgrade image version.
```
root@OpenWrt:~# cat /sys/firmware/mikrotik/soft_config/booter
[regular] backup
root@OpenWrt:~# cat /sys/firmware/mikrotik/hard_config/booter_version
3.41
root@OpenWrt:~# cat /sys/firmware/mikrotik/soft_config/bios_version
7.20.5
```

There are two bootable bootloader partitions "regular" and "backup", with "regular" being the original read-only shipped version. We need to check the current active bootloader partition. This can be changed with: (risk of "un-bootable" system if you end up with a sysupgrade-v7 image installed and a <=v6 active bootloader partition or vice versa)

```
    echo "regular">/sys/firmware/mikrotik/soft_config/booter
    echo "y">/sys/firmware/mikrotik/soft_config/commit
```
Based on the previous work done by Daniel Golle https://github.com/openwrt/openwrt/commit/318f07c231552f32542cb2dcb22aac282f0cdb52.

Fixes: https://github.com/openwrt/openwrt/issues/23057
Reported-by: corncobble (GitHub)
