### PR TITLE
realtek: mdio: convert to regmap_assign_bits()

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/mdio/mdio-realtek-otto.c
@@ -739,14 +739,10 @@ static int rtmdio_839x_setup_ctrl(struct rtmdio_ctrl *ctrl)
 
 static int rtmdio_930x_setup_ctrl(struct rtmdio_ctrl *ctrl)
 {
-	unsigned int mask, val;
-
 	/* Define C22/C45 bus feature set */
-	for (int smi_bus = 0; smi_bus < RTMDIO_MAX_SMI_BUSSES; smi_bus++) {
-		mask = BIT(16 + smi_bus);
-		val = ctrl->bus[smi_bus].is_c45 ? mask : 0;
-		regmap_update_bits(ctrl->map, RTMDIO_930X_SMI_GLB_CTRL, mask, val);
-	}
+	for (int smi_bus = 0; smi_bus < RTMDIO_MAX_SMI_BUSSES; smi_bus++)
+		regmap_assign_bits(ctrl->map, RTMDIO_930X_SMI_GLB_CTRL,
+				   BIT(16 + smi_bus), ctrl->bus[smi_bus].is_c45);
 
 	return 0;
 }
@@ -770,14 +766,12 @@ static void rtmdio_930x_setup_polling(struct rtmdio_ctrl *ctrl)
 		regmap_update_bits(ctrl->map, RTMDIO_930X_SMI_MAC_TYPE_CTRL, mask, val);
 
 		/* polling via standard or resolution register */
-		mask = BIT(20 + ctrl->port[pn].smi_bus);
-		val = phyinfo.has_res_reg ? mask : 0;
-		regmap_update_bits(ctrl->map, RTMDIO_930X_SMI_GLB_CTRL, mask, val);
+		regmap_assign_bits(ctrl->map, RTMDIO_930X_SMI_GLB_CTRL,
+				   BIT(20 + ctrl->port[pn].smi_bus), phyinfo.has_res_reg);
 
 		/* proprietary Realtek 1G/2.5 lite polling */
-		mask = BIT(pn);
-		val = phyinfo.has_giga_lite ? mask : 0;
-		regmap_update_bits(ctrl->map, RTMDIO_930X_SMI_PRVTE_POLLING_CTRL, mask, val);
+		regmap_assign_bits(ctrl->map, RTMDIO_930X_SMI_PRVTE_POLLING_CTRL,
+				   BIT(pn), phyinfo.has_giga_lite);
 
 		/* special duplex/advertisement polling registers */
 		if (phyinfo.poll_duplex || phyinfo.poll_adv_1000 || phyinfo.poll_lpa_1000) {
@@ -830,24 +824,17 @@ static void rtmdio_931x_setup_polling(struct rtmdio_ctrl *ctrl)
 		val = RTMDIO_931X_SMI_PHY_ABLTY_MDIO << (ffs(mask) - 1);
 		regmap_update_bits(ctrl->map, RTMDIO_931X_SMI_PHY_ABLTY_GET_SEL + (pn / 16) * 4,
 				   mask, val);
-		mask = val = 0;
 
 		/* PRVTE0 polling */
-		mask |= BIT(20 + smi_bus);
-		if (phyinfo.has_res_reg)
-			val |= BIT(20 + smi_bus);
-
+		regmap_assign_bits(ctrl->map, RTMDIO_931X_SMI_GLB_CTRL0,
+				   BIT(20 + smi_bus), phyinfo.has_res_reg);
 		/* PRVTE1 polling */
-		mask |= BIT(24 + smi_bus);
-		if (phyinfo.force_res)
-			val |= BIT(24 + smi_bus);
-
-		regmap_update_bits(ctrl->map, RTMDIO_931X_SMI_GLB_CTRL0, mask, val);
+		regmap_assign_bits(ctrl->map, RTMDIO_931X_SMI_GLB_CTRL0,
+				   BIT(24 + smi_bus), phyinfo.force_res);
 
 		/* polling std. or proprietary format (bit 0 of SMI_SETX_FMT_SEL) */
-		mask = BIT(smi_bus * 2);
-		val = phyinfo.force_res ? mask : 0;
-		regmap_update_bits(ctrl->map, RTMDIO_931X_SMI_GLB_CTRL1, mask, val);
+		regmap_assign_bits(ctrl->map, RTMDIO_931X_SMI_GLB_CTRL1,
+				   BIT(smi_bus * 2), phyinfo.force_res);
 
 		/* special polling registers */
 		if (phyinfo.poll_duplex || phyinfo.poll_adv_1000 || phyinfo.poll_lpa_1000) {


### PR DESCRIPTION
Use regmap_assign_bits() where it improves readability. With this there is no need to calculate masks and values in sepearate lines.
