### PR TITLE
[24.10] wifi-scripts: fix macaddr check in mac80211.uc

### DIFF
--- a/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
+++ b/package/network/config/wifi-scripts/files/lib/wifi/mac80211.uc
@@ -20,7 +20,7 @@ function radio_exists(path, macaddr, phy, radio) {
 			continue;
 		if (radio != null && int(s.radio) != radio)
 			continue;
-		if (s.macaddr & lc(s.macaddr) == lc(macaddr))
+		if (s.macaddr && lc(s.macaddr) == lc(macaddr))
 			return true;
 		if (s.phy == phy)
 			return true;


### PR DESCRIPTION
This fixes a simple logic error in the macaddr existence check in mac80211.uc.

Link: 
- https://github.com/openwrt/openwrt/pull/21277
- https://forum.turris.cz/t/wifi-not-starting-in-9-0-3-9-0-4-9-0-5-seems-to-be-a-known-bug-wheres-the-gitlab-issue/22521/5?u=pepe

(cherry picked from commit 2ebcda1ea6b757864c4700e543a9767752ca766e)
