### PR TITLE
sdk: add support to sign each .apk package by sdk

### DIFF
--- a/target/sdk/convert-config.pl
+++ b/target/sdk/convert-config.pl
@@ -8,6 +8,7 @@ while (<>) {
 	my $type;
 	chomp;
 	next if /^CONFIG_SIGNED_PACKAGES/;
+	next if /^CONFIG_SIGN_EACH_PACKAGE/;
 
 	if (/^CONFIG_((BINARY)|(DOWNLOAD))_FOLDER=(.*)$/) {
 		# We don't want to preserve the build setting of

--- a/target/sdk/files/Config.in
+++ b/target/sdk/files/Config.in
@@ -18,6 +18,15 @@ menu "Global build settings"
 		bool "Cryptographically sign package lists"
 		default y
 
+	config SIGN_EACH_PACKAGE
+		bool "Cryptographically sign each package .apk file"
+		depends on USE_APK
+		default y
+		help
+		  Sign also the individual package .apk file. Removes the need for
+		  --allow-untrusted when installing self-compiled packages to a
+		  firmware compiled by the same buildhost as public key matches.
+
 	comment "General build options"
 
 	config BUILD_PATENTED


### PR DESCRIPTION
cc @aparcar @robimarko 

Add support to signing each package's .apk file into SDK. This adds into SDK the feature alrready added to the normal builds by f20794a

Currently SDK does not sign the compiled packages, causing untrusted package errors at package installation. The reason is the logic in f20794a of defaulting to 'n' in BUILDBOT and 'y' elsewhere. As downloadable SDKs are compiled by the buildbot, the option gets 'n' set as the default. And the option is not among the few build options exposed in the SDK menuconfig, so the user can't easily change it.

Enable the feature by default:

* Exclude the SIGN_EACH_PACKAGE option from sdk/convert-config.pl
* Default to 'y' and expose the option in the SDK config menu.

(Avoiding untrusted errors naturally requires the user to copy the public key into the router, quite similar as with full builds.)

Reference to:
* enabling in full builds: commit f20794a / PR https://github.com/openwrt/openwrt/pull/22221
* forum discussion in https://forum.openwrt.org/t/apk-untrusted-signature-errors-with-packages-compiled-with-sdk/249479 initiated by @orangepizza 

Tested with mediatek/mt7622 RT3200.
(EDIT: This is actually something, that can only be finally tested with SDK built by the real buildbot)

SDK menuconfig:

```
  │ ┌────────────────────────────────────────────────────────────────────────────┐ │  
  │ │    [*] Select all target specific packages by default                      │ │  
  │ │    [*] Select all kernel module packages by default                        │ │  
  │ │    [*] Select all userspace packages by default                            │ │  
  │ │    [*] Cryptographically sign package lists                                │ │  
  │ │    [*] Cryptographically sign each package .apk file                       │ │  
  │ │        *** General build options ***                                       │ │  
  │ │    [ ] Compile with support for patented functionality                     │ │  

```

Package installation test:

```
root@router4:~# apk verify /tmp/joe-4.6-r3.apk
/tmp/joe-4.6-r3.apk: OK

root@router4:~# apk add /tmp/joe-4.6-r3.apk
(1/1) Upgrading joe (4.6-r2 -> 4.6-r3)
  Executing joe-4.6-r3.post-upgrade
OK: 51.8 MiB in 315 packages
```
