### PR TITLE
github: add LLM PR review wrapper and rules

### DIFF
--- a/.github/llm-review-rules.md
+++ b/.github/llm-review-rules.md
@@ -1,0 +1,17 @@
+# LLM review rules — openwrt/openwrt
+
+Project-specific patterns to flag, even when other in-tree files still
+use the deprecated form. The LLM review routine reads this at session
+start.
+
+## Deprecated device-tree patterns
+
+- **LED label syntax.** `label = "green:status";` --> use
+  `color = <LED_COLOR_ID_GREEN>;` + `function = LED_FUNCTION_STATUS;`
+  (constants from `include/dt-bindings/leds/common.h`; pick the
+  `LED_COLOR_ID_<COLOR>` and `LED_FUNCTION_<FUNC>` matching the old
+  `<color>:<function>` string, falling back to `function = "<func>";`
+  if no matching `LED_FUNCTION_*` constant exists).
+- **MAC from MTD.** `mediatek,mtd-eeprom = <&factory 0xNNNN>;` --> use
+  `nvmem-cells = <&macaddr_factory_NN>;` +
+  `nvmem-cell-names = "mac-address";`.

--- a/.github/workflows/llm-review.yml
+++ b/.github/workflows/llm-review.yml
@@ -1,0 +1,91 @@
+name: LLM Review
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      max_prs:
+        description: 'Max PRs to review in this nightly run'
+        required: false
+        type: number
+        default: 16
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || 'nightly' }}
+  cancel-in-progress: false
+
+jobs:
+  detect-kernels:
+    name: Detect kernel versions for extra_repos
+    if: github.repository_owner == 'openwrt'
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+    outputs:
+      extra_repos: ${{ steps.detect.outputs.extra_repos }}
+    steps:
+      - name: Checkout kernel version files
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: target/linux/generic
+
+      - name: Build extra_repos list
+        id: detect
+        run: |
+          set -euo pipefail
+          tags=()
+
+          # Linux stable tree, one tag per kernel-* version file.
+          for f in target/linux/generic/kernel-*; do
+            [ -f "$f" ] || continue
+            major=$(basename "$f" | sed 's/^kernel-//')
+            patch=$(awk -v k="LINUX_VERSION-$major" '$1==k{print $3; exit}' "$f")
+            [ -z "$patch" ] && continue
+            tags+=("gregkh/linux:v${major}${patch}")
+          done
+
+          # U-Boot upstream tracked at master.
+          tags+=("u-boot/u-boot:master")
+
+          # Other upstream/userspace projects whose code OpenWrt PRs
+          # often touch — included as available references; the
+          # routine clones each only when relevant to the diff.
+          tags+=("https://thekelleys.org.uk/git/dnsmasq.git:master")
+          tags+=("https://git.w1.fi/hostap.git:main")
+          tags+=("mkj/dropbear:master")
+          tags+=("jow-/ucode:master")
+          tags+=("openwrt/netifd:master")
+          tags+=("openwrt/procd:main")
+
+          extra=$(IFS=,; echo "${tags[*]:-}")
+          echo "Computed extra_repos: $extra"
+          echo "extra_repos=$extra" >> "$GITHUB_OUTPUT"
+
+  pr-review:
+    if: github.event_name == 'pull_request_target' && github.repository_owner == 'openwrt'
+    needs: detect-kernels
+    permissions: {}
+    uses: openwrt/actions-shared-workflows/.github/workflows/reusable_llm-pr-review.yml@main
+    with:
+      routine_id: ${{ vars.LLM_ROUTINE_ID_PR }}
+      extra_repos: ${{ needs.detect-kernels.outputs.extra_repos }}
+    secrets:
+      llm_routine_token: ${{ secrets.LLM_ROUTINE_TOKEN_PR }}
+
+  nightly:
+    if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.repository_owner == 'openwrt'
+    needs: detect-kernels
+    permissions:
+      pull-requests: read
+    uses: openwrt/actions-shared-workflows/.github/workflows/reusable_llm-nightly-digest.yml@main
+    with:
+      routine_id: ${{ vars.LLM_ROUTINE_ID_NIGHTLY }}
+      extra_repos: ${{ needs.detect-kernels.outputs.extra_repos }}
+      max_prs: ${{ fromJSON(inputs.max_prs || '16') }}
+    secrets:
+      llm_routine_token: ${{ secrets.LLM_ROUTINE_TOKEN_NIGHTLY }}


### PR DESCRIPTION
Drop-in wrapper that calls the reusable LLM review workflows in openwrt/actions-shared-workflows. Triggers on pull_request_target (incl. PRs from forks), a nightly cron (03:00 UTC), and manual workflow_dispatch with a max_prs input override.

A detect-kernels pre-step builds the extra_repos list at workflow runtime: it reads target/linux/generic/kernel-* in the base branch to derive gregkh/linux:v<X.Y.Z> tags for each currently-targeted kernel, then appends u-boot/u-boot:master. The list updates automatically when kernel versions are bumped; the routine clones only the entries actually needed for a given diff.

The bundled .github/llm-review-rules.md teaches the bot two project-specific deprecations to flag even when other in-tree files still use the legacy form:

  - LED label syntax `label = "<color>:<function>";` --> `color = <LED_COLOR_ID_*>;` + `function = "<func>";`
  - `mediatek,mtd-eeprom` for MAC sourcing --> `nvmem-cells` + `nvmem-cell-names = "mac-address";`

Repository settings need LLM_ROUTINE_ID_PR / LLM_ROUTINE_TOKEN_PR and the *_NIGHTLY counterparts populated before the workflow can fire. See openwrt/actions-shared-workflows/docs/llm-review-setup.md for the full setup procedure.

----

This uses Claude code Routines. I can run this 15 times a day and it will use the tokens from my subscription. This makes it much cheaper than the older github action. 
The trigger on PR open in the Cladue code routines does not work on PRs from forked repositories. 

Action: https://github.com/openwrt/actions-shared-workflows/pull/105