### PR TITLE
mac80211: ath: add country_override module parameter

### DIFF
--- a/package/kernel/mac80211/patches/ath/407-ath_country_override.patch
+++ b/package/kernel/mac80211/patches/ath/407-ath_country_override.patch
@@ -1,0 +1,74 @@
+--- a/drivers/net/wireless/ath/ath.h
++++ b/drivers/net/wireless/ath/ath.h
+@@ -201,6 +201,7 @@
+ 				u32 len,
+ 				gfp_t gfp_mask);
+ bool ath_is_mybeacon(struct ath_common *common, struct ieee80211_hdr *hdr);
++int ath_get_country_override(void);
+ 
+ void ath_hw_setbssidmask(struct ath_common *common);
+ void ath_key_delete(struct ath_common *common, u8 hw_key_idx);
+--- a/drivers/net/wireless/ath/main.c
++++ b/drivers/net/wireless/ath/main.c
+@@ -27,6 +27,17 @@
+ MODULE_DESCRIPTION("Shared library for Atheros wireless LAN cards.");
+ MODULE_LICENSE("Dual BSD/GPL");
+ 
++static int ath_country_override = -1;
++module_param_named(country_override, ath_country_override, int, 0444);
++MODULE_PARM_DESC(country_override,
++	"Override EEPROM country code (ISO 3166-1 numeric, e.g. 276 for Germany)");
++
++int ath_get_country_override(void)
++{
++	return ath_country_override;
++}
++EXPORT_SYMBOL(ath_get_country_override);
++
+ struct sk_buff *ath_rxbuf_alloc(struct ath_common *common,
+ 				u32 len,
+ 				gfp_t gfp_mask)
+--- a/drivers/net/wireless/ath/regd.c
++++ b/drivers/net/wireless/ath/regd.c
+@@ -20,6 +20,7 @@
+ #include <linux/export.h>
+ #include <net/cfg80211.h>
+ #include <net/mac80211.h>
++#include "ath.h"
+ #include "regd.h"
+ #include "regd_common.h"
+ 
+@@ -722,19 +723,23 @@
+ 
+ 	printk(KERN_DEBUG "ath: EEPROM regdomain: 0x%0x\n", reg->current_rd);
+ 
+-	if (!ath_regd_is_eeprom_valid(reg)) {
++	if (ath_get_country_override() >= 0) {
++		printk(KERN_DEBUG "ath: overridden by country_override=%d\n",
++		       ath_get_country_override());
++		reg->country_code = ath_get_country_override();
++	} else if (!ath_regd_is_eeprom_valid(reg)) {
+ 		pr_err("Invalid EEPROM contents\n");
+ 		return -EINVAL;
+-	}
+-
+-	regdmn = ath_regd_get_eepromRD(reg);
+-	reg->country_code = ath_regd_get_default_country(regdmn);
++	} else {
++		regdmn = ath_regd_get_eepromRD(reg);
++		reg->country_code = ath_regd_get_default_country(regdmn);
+ 
+-	if (reg->country_code == CTRY_DEFAULT &&
+-	    regdmn == CTRY_DEFAULT) {
+-		printk(KERN_DEBUG "ath: EEPROM indicates default "
+-		       "country code should be used\n");
+-		reg->country_code = CTRY_UNITED_STATES;
++		if (reg->country_code == CTRY_DEFAULT &&
++		    regdmn == CTRY_DEFAULT) {
++			printk(KERN_DEBUG "ath: EEPROM indicates default "
++			       "country code should be used\n");
++			reg->country_code = CTRY_UNITED_STATES;
++		}
+ 	}
+ 
+ 	if (reg->country_code == CTRY_DEFAULT) {


### PR DESCRIPTION
## Summary

Add a `country_override` module parameter to the `ath` module that allows overriding the EEPROM country code at module load time.

This is a workaround for a fundamental limitation in Qualcomm's closed-source ath10k/ath9k firmware: the DFS radar detection engine initializes with parameters derived from the country code set at firmware boot time, and there is no WMI command to reinitialize it when the regdomain is later updated by hostapd. Unlike the mt76 driver (MediaTek), which performs DFS radar detection in software and can reinitialize it on any regdomain change via its `regd_notifier`, the ath10k firmware treats DFS as a black box that is configured once at startup.

## Problem

The `ath` module's `__ath_regd_init()` in `regd.c` determines the country code from the EEPROM at driver probe time. When the EEPROM contains regdomain `0x0` (as shipped by several manufacturers for global SKUs), the driver hardcodes `CTRY_UNITED_STATES`. Even when the EEPROM contains a valid but wrong country (e.g. a USB adapter with `GB` used in Japan), the EEPROM value takes precedence over the user's configuration.

The firmware's DFS engine initializes with the parameters for this early country code. When hostapd later sets the correct country via `reg_notifier`, the per-phy regdomain in `iw reg get` updates, but the firmware's internal DFS radar detection parameters remain locked to the initial value. On devices operating in a different regulatory region, this causes:

- Wrong DFS radar detection (e.g. FCC pulse patterns instead of ETSI)
- TX blanking leading to `disconnected due to excessive missing ACKs`
- `DISASSOC_LOW_ACK` storms even at close range
- Periodic firmware crashes and radio restarts

## Fix

The patch adds a `country_override` module parameter (ISO 3166-1 numeric code). When set, it overrides the EEPROM country code before firmware initialization, ensuring correct DFS parameters from the start. The existing behavior is preserved when the parameter is not set.

```
# /etc/modules.d/ath
ath country_override=276
```

This workaround is necessary because the ath10k firmware provides no mechanism to reinitialize its DFS engine after boot, unlike mt76 which handles this correctly in `mt7915_regd_notifier()` by calling `mt7915_dfs_init_radar_detector()` on every regdomain change.

## Testing

Tested on Netgear R7800 (QCA9984, OpenWrt 25.12.0, ath10k-ct firmware):

**Before:**
```
ath: EEPROM regdomain: 0x0
ath: Country alpha2 being used: US
...
phy#0: country US: DFS-FCC
```

**After:**
```
ath: EEPROM regdomain: 0x0
ath: overridden by country_override=276
ath: Country alpha2 being used: DE
...
phy#0: country DE: DFS-ETSI
```

The `excessive missing ACKs` disconnections affecting multiple clients stopped after applying the fix.

## Affected devices

Any ath-based device where the EEPROM country doesn't match the operating country:
- **Empty EEPROM (regdomain 0x0):** Netgear R7800, R7500v2, TP-Link Archer C2600, Linksys EA8500 and other global-SKU QCA9984/QCA9880 devices
- **Wrong EEPROM country:** any ath9k/ath10k device moved to a different regulatory region than what the manufacturer programmed

Devices using other drivers (e.g. mt76 for MediaTek) are not affected as they handle DFS reinitialization correctly in software.

Ref: #13070
Ref: #12088