### PR TITLE
x86/base-files: add support for AppNeta-M35

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -149,16 +149,25 @@ traverse-technologies-geos)
 	[ -n "$macaddr" ] && ucidef_set_interface_macaddr "wan" "$macaddr"
 	;;
 silicom-80500-0214-*)
-        ucidef_set_network_device_path "wan0" "pci0000:00/0000:00:16.0/0000:03:00.0"
-        ucidef_set_network_device_path "wan1" "pci0000:00/0000:00:16.0/0000:03:00.1"
-        ucidef_set_network_device_path "media0" "pci0000:00/0000:00:17.0/0000:02:00.1"
-        ucidef_set_network_device_path "media1" "pci0000:00/0000:00:17.0/0000:02:00.0"
-        ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:0c.0/0000:04:00.0"
-        ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:0e.0/0000:05:00.0"
-        ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:0f.0/0000:06:00.0"
-        ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:10.0/0000:07:00.0"
-        ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3" "wan0"
-        ;;
+	ucidef_set_network_device_path "wan0" "pci0000:00/0000:00:16.0/0000:03:00.0"
+	ucidef_set_network_device_path "wan1" "pci0000:00/0000:00:16.0/0000:03:00.1"
+	ucidef_set_network_device_path "media0" "pci0000:00/0000:00:17.0/0000:02:00.1"
+	ucidef_set_network_device_path "media1" "pci0000:00/0000:00:17.0/0000:02:00.0"
+	ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:0c.0/0000:04:00.0"
+	ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:0e.0/0000:05:00.0"
+	ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:0f.0/0000:06:00.0"
+	ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:10.0/0000:07:00.0"
+	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3" "wan0"
+	;;
+to-be-filled-by-o-e-m-appneta-m35)
+	ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:01.0/0000:01:00.0"
+	ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:02.0/0000:02:00.0"
+	ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:14.0"
+	ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:14.1"
+	ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:14.2"
+	ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:14.3"
+	ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
+	;;
 esac
 board_config_flush
 


### PR DESCRIPTION
The AppNeta-M35 is a discontinued network monitor a rebranded Lanner FW-7525 based on the Intel Atom
C2XXX family of processors with 4 integrated GbE ports and 2 additional I210 GbE ports.  It can often be found on eBay.

Specs:
* CPU: Intel Atom C2XXX
* RAM: 1x 8GB DDR3 SO-DIMM
* Storage: 1x 16GB Compact Flash, 1x SATA 3.0
* Ethernet: 6x GbE RJ-45
* USB: 2x USB 2.0
* WiFi: 1x Intel AC 7260
* Power: 12V/5A

Installation:
1. Write the combined-efi.img to a CF card: dd if=combined-efi.img of=/dev/sdX conv=fdatasync

The two I210 NICs and integrated NICs are pinned to their PCIe paths to ensure consistent interface ordering matching the physical port layout. eth0 is assigned as WAN and remaining devices as LAN.

Signed-off-by: Raylynn Knight <rayknight@me.com>
