### PR TITLE
x86/base-files + kernel/modules: improve Dell Edge620/640/680 support

### DIFF
--- a/package/kernel/linux/modules/netdevices.mk
+++ b/package/kernel/linux/modules/netdevices.mk
@@ -1492,7 +1492,7 @@ define KernelPackage/ixgbe
     CONFIG_IXGBE_DCA=n \
     CONFIG_IXGBE_DCB=y
   FILES:=$(LINUX_DIR)/drivers/net/ethernet/intel/ixgbe/ixgbe.ko
-  AUTOLOAD:=$(call AutoLoad,35,ixgbe)
+  AUTOLOAD:=$(call AutoLoad,35,ixgbe,1)
 endef
 
 define KernelPackage/ixgbe/description

--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -40,8 +40,18 @@ cloudgenix-ion-2000)
 	ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:14.3"
 	ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
 	;;
-dell-emc-edge620)
-	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth7" "eth6"
+dell-emc-edge620*| \
+dell-emc-edge640*| \
+dell-emc-edge680*)
+	ucidef_set_network_device_path "ge1" "pci0000:00/0000:00:0b.0/0000:02:00.2"
+	ucidef_set_network_device_path "ge2" "pci0000:00/0000:00:0b.0/0000:02:00.3"
+	ucidef_set_network_device_path "ge3" "pci0000:00/0000:00:0b.0/0000:02:00.0"
+	ucidef_set_network_device_path "ge4" "pci0000:00/0000:00:0b.0/0000:02:00.1"
+	ucidef_set_network_device_path "ge5" "pci0000:00/0000:00:17.0/0000:07:00.1"
+	ucidef_set_network_device_path "ge6" "pci0000:00/0000:00:17.0/0000:07:00.0"
+	ucidef_set_network_device_path "sfp1" "pci0000:00/0000:00:16.0/0000:05:00.1"
+	ucidef_set_network_device_path "sfp2" "pci0000:00/0000:00:16.0/0000:05:00.0"
+	ucidef_set_interfaces_lan_wan "ge1 ge2 ge3 ge4 ge5" "ge6"
 	;;
 dfi-inc-adn553| \
 dfi-inc-asl553)


### PR DESCRIPTION
This improves on openwrt/openwrt@aeb9028aabf6bf90638a822d563f54a2c4146e6d by adding support for
other Dell EMC Edge620/640/680 devices and mapping
the interfaces to match the markings on the device.

This modifies the netdevices.mk file to set the boot flag for
ixgbe driver to load it in early stage of the boot process to
allow for proper mapping of the network interface PCI paths
inside the 02_network script. This will also allow other devices
using the ixgbe driver to do proper mapping in 02_network script.
The 02_network script is then modified to support all
dell-emc-620/640/680 devices.  It now maps the network
interfaces via PCI paths to match the markings on the device.
The interface marked GE6 is still used for WAN with
interfaces GE1-GE5 used for LAN.

The SFP1 and SFP2 interfaces are left to be assigned by
the user.

Signed-off-by: Raylynn Knight <rayknight@me.com>

