### PR TITLE
mediatek: mt7622: replace mtd-eeprom with nvmem

### DIFF
--- a/target/linux/mediatek/dts/mt7622-asiarf-ap7622-wh1.dts
+++ b/target/linux/mediatek/dts/mt7622-asiarf-ap7622-wh1.dts
@@ -432,7 +432,7 @@
 					#size-cells = <1>;
 
 					factory_eeprom: eeprom@0 {
-						reg = <0x0 0x5000>;
+						reg = <0x0 0x4da8>;
 					};
 
 					macaddr_factory_7fff4: macaddr@7fff4 {

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp2.dts
@@ -89,7 +89,7 @@
 				reg = <0x140000 0x80000>;
 			};
 
-			factory: partition@1c0000 {
+			partition@1c0000 {
 				label = "factory";
 				reg = <0x1c0000 0x40000>;
 				read-only;
@@ -99,10 +99,18 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+
 					macaddr_factory_4: macaddr@4 {
 						compatible = "mac-base";
 						reg = <0x4 0x6>;
 						#nvmem-cell-cells = <1>;
+					};
+
+					eeprom_factory_5000: eeprom@5000 {
+						reg = <0x5000 0x4da8>;
 					};
 				};
 			};

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp3.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp3.dts
@@ -138,10 +138,24 @@
 				read-only;
 			};
 
-			factory: partition@1c0000 {
+			partition@1c0000 {
 				label = "factory";
 				reg = <0x1c0000 0x40000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+
+					eeprom_factory_5000: eeprom@5000 {
+						reg = <0x5000 0x4da8>;
+					};
+				};
 			};
 
 			partition@200000 {

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-3200ax4s.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-3200ax4s.dts
@@ -138,10 +138,24 @@
 				read-only;
 			};
 
-			factory: partition@1c0000 {
+			partition@1c0000 {
 				label = "factory";
 				reg = <0x1c0000 0x100000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+
+					eeprom_factory_5000: eeprom@5000 {
+						reg = <0x5000 0xe00>;
+					};
+				};
 			};
 
 			partition@2c0000 {

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr.dtsi
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr.dtsi
@@ -120,13 +120,9 @@
 };
 
 &slot0 {
-	status = "okay";
-
-	wifi@0,0 {
+	wmac1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x5000>;
-		ieee80211-freq-limit = <5000000 6000000>;
 	};
 };
 
@@ -222,7 +218,14 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&wmac1 {
+	nvmem-cells = <&eeprom_factory_5000>;
+	nvmem-cell-names = "eeprom";
+	ieee80211-freq-limit = <5000000 6000000>;
 };
 
 &rtc {

--- a/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-ax3200-a1.dtsi
+++ b/target/linux/mediatek/dts/mt7622-dlink-eagle-pro-ai-ax3200-a1.dtsi
@@ -210,12 +210,9 @@
 };
 
 &slot0 {
-	wmac1: mt7915@0,0 {
+	wmac1: wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		ieee80211-freq-limit = <5000000 6000000>;
-		mediatek,mtd-eeprom = <&factory 0x05000>;
-		nvmem-cells = <&macaddr_odm 3>;
-		nvmem-cell-names = "mac-address";
 	};
 };
 
@@ -322,10 +319,24 @@
 				};
 			};
 
-			factory: partition@5CC0000 {
+			partition@5CC0000 {
 				label = "Factory";
 				reg = <0x05CC0000 0x00100000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+
+					eeprom_factory_5000: eeprom@5000 {
+						reg = <0x5000 0xe00>;
+					};
+				};
 			};
 
 			partition@5DC0000 {
@@ -366,9 +377,13 @@
 &wmac {
 	pinctrl-names = "default";
 	pinctrl-0 = <&epa_elna_pins>;
-	mediatek,mtd-eeprom = <&factory 0x0000>;
-	nvmem-cells = <&macaddr_odm 2>;
-	nvmem-cell-names = "mac-address";
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_odm 2>;
+	nvmem-cell-names = "eeprom", "mac-address";
 	status = "okay";
 };
 
+&wmac1 {
+	nvmem-cells = <&eeprom_factory_5000>, <&macaddr_odm 3>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	ieee80211-freq-limit = <5000000 6000000>;
+};

--- a/target/linux/mediatek/dts/mt7622-elecom-wrc-2533gent.dts
+++ b/target/linux/mediatek/dts/mt7622-elecom-wrc-2533gent.dts
@@ -173,9 +173,9 @@
 };
 
 &slot0 {
-	mt7615@0,0 {
+	wmac1: wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x05000>;
 	};
 };
 
@@ -543,10 +543,24 @@
 				read-only;
 			};
 
-			factory: partition@1c0000 {
+			partition@1c0000 {
 				label = "factory";
 				reg = <0x1c0000 0x0040000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+
+					eeprom_factory_5000: eeprom@5000 {
+						reg = <0x5000 0x4da8>;
+					};
+				};
 			};
 
 			partition@200000 {
@@ -603,6 +617,12 @@
 };
 
 &wmac {
-	mediatek,mtd-eeprom = <&factory 0x0000>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	status = "okay";
+};
+
+&wmac1 {
+	nvmem-cells = <&eeprom_factory_5000>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7622-elecom-wrc-x3200gst3.dtsi
+++ b/target/linux/mediatek/dts/mt7622-elecom-wrc-x3200gst3.dtsi
@@ -314,7 +314,7 @@
 				read-only;
 			};
 
-			factory: partition@1c0000 {
+			partition@1c0000 {
 				label = "factory";
 				reg = <0x1c0000 0x100000>;
 				read-only;
@@ -324,10 +324,18 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+
 					macaddr_factory_4: macaddr@4 {
 						compatible = "mac-base";
 						reg = <0x4 0x6>;
 						#nvmem-cell-cells = <1>;
+					};
+
+					eeprom_factory_5000: eeprom@5000 {
+						reg = <0x5000 0xe00>;
 					};
 
 					macaddr_factory_7fff4: macaddr@7fff4 {
@@ -384,15 +392,9 @@
 };
 
 &slot0 {
-	status = "okay";
-
-	wifi@0,0 {
+	wmac1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x5000>;
-		ieee80211-freq-limit = <5000000 6000000>;
-		nvmem-cells = <&macaddr_factory_4 1>;
-		nvmem-cell-names = "mac-address";
 	};
 };
 
@@ -427,5 +429,12 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&wmac1 {
+	nvmem-cells = <&eeprom_factory_5000>, <&macaddr_factory_4 1>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	ieee80211-freq-limit = <5000000 6000000>;
 };

--- a/target/linux/mediatek/dts/mt7622-linksys-e8450.dts
+++ b/target/linux/mediatek/dts/mt7622-linksys-e8450.dts
@@ -42,7 +42,7 @@
 			reg = <0x140000 0x0080000>;
 		};
 
-		factory: partition@1c0000 {
+		partition@1c0000 {
 			label = "factory";
 			reg = <0x1c0000 0x0100000>;
 
@@ -50,6 +50,14 @@
 				compatible = "fixed-layout";
 				#address-cells = <1>;
 				#size-cells = <1>;
+
+				eeprom_factory_0: eeprom@0 {
+					reg = <0x0 0x4da8>; /* actual length 0x400 */
+				};
+
+				eeprom_factory_5000: eeprom@5000 {
+					reg = <0x5000 0xe00>;
+				};
 
 				macaddr_factory_7fff4: macaddr@7fff4 {
 					reg = <0x7fff4 0x6>;
@@ -103,12 +111,14 @@
 };
 
 &wmac {
-	mediatek,mtd-eeprom = <&factory 0x0000>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	status = "okay";
 };
 
 &wmac1 {
-	mediatek,mtd-eeprom = <&factory 0x05000>;
+	nvmem-cells = <&eeprom_factory_5000>;
+	nvmem-cell-names = "eeprom";
 };
 
 &gmac0 {

--- a/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
+++ b/target/linux/mediatek/dts/mt7622-netgear-wax206.dts
@@ -357,7 +357,7 @@
 };
 
 &slot0 {
-	wmac1: mt7915@0,0 {
+	wmac1: wifi@0,0 {
 		reg = <0x0000 0 0 0 0>;
 		ieee80211-freq-limit = <5000000 6000000>;
 	};
@@ -405,7 +405,7 @@
 				reg = <0x140000 0x0080000>;
 			};
 
-			factory: partition@1c0000 {
+			partition@1c0000 {
 				label = "Factory";
 				reg = <0x1c0000 0x0100000>;
 				read-only;
@@ -414,6 +414,14 @@
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+
+					eeprom_factory_5000: eeprom@5000 {
+						reg = <0x5000 0xe00>;
+					};
 
 					macaddr_factory_7fff4: macaddr@7fff4 {
 						reg = <0x7fff4 0x6>;
@@ -553,10 +561,12 @@
 };
 
 &wmac {
-	mediatek,mtd-eeprom = <&factory 0x0000>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 	status = "okay";
 };
 
 &wmac1 {
-	mediatek,mtd-eeprom = <&factory 0x05000>;
+	nvmem-cells = <&eeprom_factory_5000>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7622-reyee-ax3200-e5.dts
+++ b/target/linux/mediatek/dts/mt7622-reyee-ax3200-e5.dts
@@ -50,10 +50,24 @@
 				reg = <0x80000 0x10000>;
 			};
 
-			factory: partition@90000 {
+			partition@90000 {
 				label = "Factory";
 				reg = <0x90000 0x40000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+
+					eeprom_factory_5000: eeprom@5000 {
+						reg = <0x5000 0xe00>;
+					};
+				};
 			};
 
 			partition@d0000 {
@@ -77,20 +91,26 @@
 	};
 };
 
+&slot0 {
+	wmac1: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+	};
+};
+
 &wmac {
 	status = "okay";
 
 	pinctrl-names = "default";
 	pinctrl-0 = <&epa_elna_pins>;
-	mediatek,mtd-eeprom = <&factory 0x0>;
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
-&slot0 {
-	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x5000>;
-		ieee80211-freq-limit = <5000000 6000000>;
-		mediatek,disable-radar-background;
-	};
+&wmac1 {
+	nvmem-cells = <&eeprom_factory_5000>;
+	nvmem-cell-names = "eeprom";
+	ieee80211-freq-limit = <5000000 6000000>;
+	mediatek,disable-radar-background;
 };

--- a/target/linux/mediatek/dts/mt7622-rfb1-ubi.dts
+++ b/target/linux/mediatek/dts/mt7622-rfb1-ubi.dts
@@ -37,9 +37,19 @@
 				reg = <0x140000 0x0080000>;
 			};
 
-			factory: partition@1c0000 {
+			partition@1c0000 {
 				label = "Factory";
 				reg = <0x1c0000 0x0100000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+				};
 			};
 
 			partition@200000 {

--- a/target/linux/mediatek/dts/mt7622-ruijie-rg-ew3200gx-pro.dts
+++ b/target/linux/mediatek/dts/mt7622-ruijie-rg-ew3200gx-pro.dts
@@ -47,10 +47,24 @@
 				reg = <0xb0000 0x20000>;
 			};
 
-			factory: partition@D0000 {
+			partition@D0000 {
 				label = "Factory";
 				reg = <0xd0000 0x80000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+
+					eeprom_factory_5000: eeprom@5000 {
+						reg = <0x5000 0xe00>;
+					};
+				};
 			};
 
 			partition@150000 {
@@ -74,20 +88,26 @@
 	};
 };
 
+&slot0 {
+	wmac1: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+	};
+};
+
 &wmac {
 	status = "okay";
 
 	pinctrl-names = "default";
 	pinctrl-0 = <&epa_elna_pins>;
-	mediatek,mtd-eeprom = <&factory 0x0>;
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
-&slot0 {
-	wifi@0,0 {
-		compatible = "mediatek,mt76";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x5000>;
-		ieee80211-freq-limit = <5000000 6000000>;
-		mediatek,disable-radar-background;
-	};
+&wmac1 {
+	nvmem-cells = <&eeprom_factory_5000>;
+	nvmem-cell-names = "eeprom";
+	ieee80211-freq-limit = <5000000 6000000>;
+	mediatek,disable-radar-background;
 };

--- a/target/linux/mediatek/dts/mt7622-smartrg-SDG-841-t6.dts
+++ b/target/linux/mediatek/dts/mt7622-smartrg-SDG-841-t6.dts
@@ -297,11 +297,11 @@
 						#size-cells = <1>;
 
 						eeprom0: eeprom@0 {
-							reg = <0x0 0x5000>;
+							reg = <0x0 0xe00>;
 						};
 
 						eeprom1: eeprom@5000 {
-							reg = <0x5000 0x5000>;
+							reg = <0x5000 0xe00>;
 						};
 					};
 				};
@@ -330,13 +330,17 @@
 };
 
 &slot0 {
-	mt7915@0,0 {
-		#address-cells = <1>;
-		#size-cells = <0>;
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
+
 		nvmem-cells = <&eeprom0>;
 		nvmem-cell-names = "eeprom";
+
 		ieee80211-freq-limit = <2400000 5330000>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
 
 		band@0 {
 			/* 2.4 GHz */
@@ -361,9 +365,11 @@
 };
 
 &slot1 {
-	mt7915@0,0 {
-		/* upper 5 GHz */
+	/* upper 5 GHz */
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
+
 		nvmem-cells = <&eeprom1>, <&macaddr 0xf>;
 		nvmem-cell-names = "eeprom", "mac-address";
 		ieee80211-freq-limit = <5490000 5835000>;

--- a/target/linux/mediatek/dts/mt7622-totolink-a8000ru.dts
+++ b/target/linux/mediatek/dts/mt7622-totolink-a8000ru.dts
@@ -107,10 +107,9 @@
 };
 
 &slot0 {
-	mt7615@0,0 {
+	wmac1: wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x5000>;
-		ieee80211-freq-limit = <5490000 6000000>;
 	};
 };
 
@@ -121,10 +120,9 @@
 };
 
 &slot1 {
-	mt7615@0,0 {
+	wmac2: wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x10000>;
-		ieee80211-freq-limit = <5000000 5490000>;
 	};
 };
 
@@ -282,7 +280,7 @@
 				read-only;
 			};
 
-			factory: partition@1c0000 {
+			partition@1c0000 {
 				label = "factory";
 				reg = <0x1c0000 0x40000>;
 				read-only;
@@ -292,12 +290,24 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+
 					macaddr_factory_24: macaddr@24 {
 						reg = <0x24 0x6>;
 					};
 
 					macaddr_factory_2a: macaddr@2a {
 						reg = <0x2a 0x6>;
+					};
+
+					eeprom_factory_5000: eeprom@5000 {
+						reg = <0x5000 0x4da8>;
+					};
+
+					eeprom_factory_10000: eeprom@10000 {
+						reg = <0x10000 0x4da8>;
 					};
 				};
 			};
@@ -344,8 +354,23 @@
 };
 
 &wmac {
+	status = "okay";
+
 	pinctrl-names = "default";
 	pinctrl-0 = <&epa_elna_pins>;
-	mediatek,mtd-eeprom = <&factory 0x0>;
-	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&wmac1 {
+	nvmem-cells = <&eeprom_factory_5000>;
+	nvmem-cell-names = "eeprom";
+	ieee80211-freq-limit = <5490000 6000000>;
+};
+
+&wmac2 {
+	nvmem-cells = <&eeprom_factory_10000>;
+	nvmem-cell-names = "eeprom";
+	ieee80211-freq-limit = <5000000 5490000>;
 };

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1-ubootmod.dts
@@ -28,13 +28,27 @@
 		reg = <0xc0000 0x10000>;
 	};
 
-	factory: partition@d0000 {
+	partition@d0000 {
 		label = "factory";
 		reg = <0xd0000 0x40000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>; /* actual length 0x400 */
+			};
+
+			eeprom_factory_20000: eeprom@20000 {
+				reg = <0x20000 0xe00>;
+			};
+		};
 	};
 
-	eeprom: partition@110000 {
+	partition@110000 {
 		label = "eeprom";
 		reg = <0x110000 0x10000>;
 		read-only;
@@ -64,26 +78,4 @@
 		label = "firmware";
 		reg = <0x1000000 0x3000000>;
 	};
-};
-
-&wmac {
-	mediatek,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
-	status = "okay";
-};
-
-&slot0 {
-	wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x20000>;
-		nvmem-cells = <&macaddr_eeprom_6>;
-		nvmem-cell-names = "mac-address";
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dts
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dts
@@ -28,13 +28,27 @@
 		reg = <0xc0000 0x10000>;
 	};
 
-	factory: partition@d0000 {
+	partition@d0000 {
 		label = "factory";
 		reg = <0xd0000 0x40000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>; /* actual length 0x400 */
+			};
+
+			eeprom_factory_20000: eeprom@20000 {
+				reg = <0x20000 0xe00>;
+			};
+		};
 	};
 
-	eeprom: partition@110000 {
+	partition@110000 {
 		label = "eeprom";
 		reg = <0x110000 0x10000>;
 		read-only;
@@ -75,26 +89,4 @@
 		label = "kernel1";
 		reg = <0x2110000 0x1ee0000>;
 	};
-};
-
-&wmac {
-	mediatek,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
-	status = "okay";
-};
-
-&slot0 {
-	wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x20000>;
-		nvmem-cells = <&macaddr_eeprom_6>;
-		nvmem-cell-names = "mac-address";
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v1.dtsi
@@ -51,3 +51,26 @@
 	};
 };
 
+&gmac0 {
+	nvmem-cells = <&macaddr_eeprom_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&slot0 {
+	wmac1: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0 0 0 0 0>;
+	};
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_eeprom_0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	status = "okay";
+};
+
+&wmac1 {
+	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_eeprom_6>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	ieee80211-freq-limit = <5000000 6000000>;
+};

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2-ubootmod.dts
@@ -28,13 +28,27 @@
 		reg = <0xc0000 0x10000>;
 	};
 
-	factory: partition@d0000 {
+	partition@d0000 {
 		label = "factory";
 		reg = <0xd0000 0x40000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>; /* actual length 0x400 */
+			};
+
+			eeprom_factory_20000: eeprom@20000 {
+				reg = <0x20000 0xe00>;
+			};
+		};
 	};
 
-	eeprom: partition@110000 {
+	partition@110000 {
 		label = "eeprom";
 		reg = <0x110000 0x10000>;
 		read-only;
@@ -64,26 +78,4 @@
 		label = "firmware";
 		reg = <0x1000000 0x3000000>;
 	};
-};
-
-&wmac {
-	mediatek,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
-	status = "okay";
-};
-
-&slot0 {
-	wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x20000>;
-		nvmem-cells = <&macaddr_eeprom_6>;
-		nvmem-cell-names = "mac-address";
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2.dts
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2.dts
@@ -28,13 +28,27 @@
 		reg = <0xc0000 0x10000>;
 	};
 
-	factory: partition@d0000 {
+	partition@d0000 {
 		label = "factory";
 		reg = <0xd0000 0x40000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>; /* actual length 0x400 */
+			};
+
+			eeprom_factory_20000: eeprom@20000 {
+				reg = <0x20000 0xe00>;
+			};
+		};
 	};
 
-	eeprom: partition@110000 {
+	partition@110000 {
 		label = "eeprom";
 		reg = <0x110000 0x10000>;
 		read-only;
@@ -75,26 +89,4 @@
 		label = "kernel1";
 		reg = <0x2110000 0x1ee0000>;
 	};
-};
-
-&wmac {
-	mediatek,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
-	status = "okay";
-};
-
-&slot0 {
-	wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x20000>;
-		nvmem-cells = <&macaddr_eeprom_6>;
-		nvmem-cell-names = "mac-address";
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2.dtsi
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v2.dtsi
@@ -48,3 +48,26 @@
 	};
 };
 
+&gmac0 {
+	nvmem-cells = <&macaddr_eeprom_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&slot0 {
+	wmac1: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0 0 0 0 0>;
+	};
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_eeprom_0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	status = "okay";
+};
+
+&wmac1 {
+	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_eeprom_6>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	ieee80211-freq-limit = <5000000 6000000>;
+};

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v3-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v3-ubootmod.dts
@@ -28,13 +28,27 @@
 		reg = <0xc0000 0x10000>;
 	};
 
-	factory: partition@d0000 {
+	partition@d0000 {
 		label = "factory";
 		reg = <0xd0000 0x40000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>; /* actual length 0x400 */
+			};
+
+			eeprom_factory_20000: eeprom@20000 {
+				reg = <0x20000 0xe00>;
+			};
+		};
 	};
 
-	eeprom: partition@110000 {
+	partition@110000 {
 		label = "eeprom";
 		reg = <0x110000 0x10000>;
 		read-only;
@@ -64,26 +78,4 @@
 		label = "firmware";
 		reg = <0x1000000 0x3000000>;
 	};
-};
-
-&wmac {
-	mediatek,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
-	status = "okay";
-};
-
-&slot0 {
-	wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x20000>;
-		nvmem-cells = <&macaddr_eeprom_6>;
-		nvmem-cell-names = "mac-address";
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v3.dts
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v3.dts
@@ -28,13 +28,27 @@
 		reg = <0xc0000 0x10000>;
 	};
 
-	factory: partition@d0000 {
+	partition@d0000 {
 		label = "factory";
 		reg = <0xd0000 0x40000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x4da8>; /* actual length 0x400 */
+			};
+
+			eeprom_factory_20000: eeprom@20000 {
+				reg = <0x20000 0xe00>;
+			};
+		};
 	};
 
-	eeprom: partition@110000 {
+	partition@110000 {
 		label = "eeprom";
 		reg = <0x110000 0x10000>;
 		read-only;
@@ -75,26 +89,4 @@
 		label = "kernel1";
 		reg = <0x2110000 0x1ee0000>;
 	};
-};
-
-&wmac {
-	mediatek,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
-	status = "okay";
-};
-
-&slot0 {
-	wifi@0,0 {
-		reg = <0x0 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x20000>;
-		nvmem-cells = <&macaddr_eeprom_6>;
-		nvmem-cell-names = "mac-address";
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&gmac0 {
-	nvmem-cells = <&macaddr_eeprom_0>;
-	nvmem-cell-names = "mac-address";
 };

--- a/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v3.dtsi
+++ b/target/linux/mediatek/dts/mt7622-ubnt-unifi-6-lr-v3.dtsi
@@ -48,3 +48,27 @@
 		};
 	};
 };
+
+&gmac0 {
+	nvmem-cells = <&macaddr_eeprom_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&slot0 {
+	wmac1: wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0 0 0 0 0>;
+	};
+};
+
+&wmac {
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_eeprom_0>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	status = "okay";
+};
+
+&wmac1 {
+	nvmem-cells = <&eeprom_factory_20000>, <&macaddr_eeprom_6>;
+	nvmem-cell-names = "eeprom", "mac-address";
+	ieee80211-freq-limit = <5000000 6000000>;
+};

--- a/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
+++ b/target/linux/mediatek/dts/mt7622-xiaomi-redmi-router-ax6s.dts
@@ -267,7 +267,7 @@
 				reg = <0x180000 0x40000>;
 			};
 
-			factory: partition@1c0000 {
+			partition@1c0000 {
 				label = "factory";
 				reg = <0x1c0000 0x80000>;
 				read-only;
@@ -277,10 +277,18 @@
 					#address-cells = <1>;
 					#size-cells = <1>;
 
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x4da8>; /* actual length 0x400 */
+					};
+
 					macaddr_factory_4: macaddr@4 {
 						compatible = "mac-base";
 						reg = <0x4 0x6>;
 						#nvmem-cell-cells = <1>;
+					};
+
+					eeprom_factory_5000: eeprom@5000 {
+						reg = <0x5000 0xe00>;
 					};
 				};
 			};
@@ -331,14 +339,9 @@
 };
 
 &slot0 {
-	status = "okay";
-
-	wifi@0,0 {
+	wmac1: wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x5000>;
-		ieee80211-freq-limit = <5000000 6000000>;
-		mediatek,disable-radar-background;
 	};
 };
 
@@ -373,5 +376,13 @@
 &wmac {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+};
+
+&wmac1 {
+	nvmem-cells = <&eeprom_factory_5000>;
+	nvmem-cell-names = "eeprom";
+	ieee80211-freq-limit = <5000000 6000000>;
+	mediatek,disable-radar-background;
 };

--- a/target/linux/mediatek/dts/mt7981a-comfast-cf-e393ax.dts
+++ b/target/linux/mediatek/dts/mt7981a-comfast-cf-e393ax.dts
@@ -167,7 +167,7 @@
 				read-only;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
+++ b/target/linux/mediatek/dts/mt7981a-teltonika-rutc50.dts
@@ -382,7 +382,7 @@
 				reg = <0x40000 0x0010000>;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "factory";
 				reg = <0x50000 0x00A0000>;
 				read-only;
@@ -398,11 +398,7 @@
 				};
 			};
 
-			config: partition@f0000	{
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
-
+			partition@f0000	{
 				label = "config";
 				reg = <0xF0000 0x0010000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
+++ b/target/linux/mediatek/dts/mt7981a-ubnt-unifi-6-plus.dts
@@ -111,7 +111,7 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			eeprom: partition@0 {
+			partition@0 {
 				label = "EEPROM";
 				reg = <0x00000 0x10000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-bazis-ax3000wm.dts
+++ b/target/linux/mediatek/dts/mt7981b-bazis-ax3000wm.dts
@@ -190,7 +190,7 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-cetron-ct3003.dts
+++ b/target/linux/mediatek/dts/mt7981b-cetron-ct3003.dts
@@ -144,10 +144,20 @@
 				};
 			};
 
-			factory: partition@280000 {
+			partition@280000 {
 				label = "Factory";
 				reg = <0x0280000 0x0100000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
 			};
 
 			partition@380000 {
@@ -247,5 +257,6 @@
 &wifi {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-common.dtsi
@@ -166,7 +166,7 @@
 				read-only;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-confiabits-mt7981.dts
+++ b/target/linux/mediatek/dts/mt7981b-confiabits-mt7981.dts
@@ -231,7 +231,7 @@
 				read-only;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-cudy-ap3000outdoor-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-ap3000outdoor-v1.dts
@@ -141,7 +141,7 @@
 				read-only;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;
@@ -201,6 +201,7 @@
 
 &wifi {
 	status = "okay";
+
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7981b-cudy-ap3000wall-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-ap3000wall-v1.dts
@@ -156,7 +156,7 @@
 				read-only;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;
@@ -271,6 +271,7 @@
 
 &wifi {
 	status = "okay";
+
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7981b-cudy-m3000.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-m3000.dtsi
@@ -130,10 +130,20 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x0180000 0x0200000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
 			};
 
 			bdinfo: partition@380000 {
@@ -191,5 +201,7 @@
 
 &wifi {
 	status = "okay";
-	mediatek,mtd-eeprom = <&factory 0x0>;
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7981b-cudy-re3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-re3000-v1.dts
@@ -142,7 +142,7 @@
 				read-only;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "Factory";
 				reg = <0x50000 0x10000>;
 				read-only;
@@ -214,6 +214,7 @@
 
 &wifi {
 	status = "okay";
+
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-tr3000-v1.dtsi
@@ -137,7 +137,7 @@
 				read-only;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;
@@ -205,6 +205,7 @@
 
 &wifi {
 	status = "okay";
+
 	nvmem-cells = <&eeprom_factory_0>;
 	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-v1.dts
@@ -160,10 +160,20 @@
 				read-only;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "Factory";
 				reg = <0x50000 0x10000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
 			};
 
 			bdinfo: partition@60000 {
@@ -272,5 +282,7 @@
 
 &wifi {
 	status = "okay";
-	mediatek,mtd-eeprom = <&factory 0x0>;
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7981b-gatonetworks-gdsp.dts
+++ b/target/linux/mediatek/dts/mt7981b-gatonetworks-gdsp.dts
@@ -258,10 +258,13 @@
 };
 
 &wifi {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+
 	#address-cells = <1>;
 	#size-cells = <0>;
-	mediatek,mtd-eeprom = <&factory 0x0>;
-	status = "okay";
 
 	wifi_band_0: band@0 {
 		reg = <0>;
@@ -302,7 +305,7 @@
 				reg = <0x40000 0x0010000>;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "Factory";
 				reg = <0x50000 0x00B0000>;
 				read-only;
@@ -311,6 +314,10 @@
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
 
 					macaddr_wifi: macaddr@4 {
 						reg = <0x4 0x6>;

--- a/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
+++ b/target/linux/mediatek/dts/mt7981b-glinet-gl-mt3000.dts
@@ -171,7 +171,7 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;
@@ -180,6 +180,10 @@
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
 
 					macaddr: macaddr@a {
 						compatible = "mac-base";
@@ -236,7 +240,8 @@
 };
 
 &wifi {
-	mediatek,mtd-eeprom = <&factory 0x0>;
-
 	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-h3c-magic-nx30-pro.dts
@@ -128,10 +128,20 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x0180000 0x0200000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
 			};
 
 			partition@380000 {
@@ -247,5 +257,6 @@
 &wifi {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
+++ b/target/linux/mediatek/dts/mt7981b-iptime-ax3000m.dts
@@ -205,7 +205,7 @@
 				reg = <0x100000 0x80000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-jcg-q30-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-jcg-q30-pro.dts
@@ -119,7 +119,7 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x0180000 0x0200000>;
 				read-only;
@@ -128,6 +128,10 @@
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
 
 					macaddr_wan: macaddr@a0024 {
 						reg = <0xa0024 0x6>;
@@ -233,5 +237,6 @@
 &wifi {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7981b-netgear-eax17.dts
+++ b/target/linux/mediatek/dts/mt7981b-netgear-eax17.dts
@@ -173,15 +173,18 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "factory";
 				reg = <0x180000 0x200000>;
-				compatible = "nvmem-cells";
-				#address-cells = <1>;
-				#size-cells = <1>;
 
-				eeprom_factory_0: eeprom@0 {
-					reg = <0x0 0x1000>;
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
 				};
 			};
 

--- a/target/linux/mediatek/dts/mt7981b-openfi-6c.dts
+++ b/target/linux/mediatek/dts/mt7981b-openfi-6c.dts
@@ -162,7 +162,7 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
+++ b/target/linux/mediatek/dts/mt7981b-qihoo-360t7.dts
@@ -48,6 +48,16 @@
 		label = "factory";
 		reg = <0x7280000 0x80000>;
 		read-only;
+
+		nvmem-layout {
+			compatible = "fixed-layout";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			eeprom_factory_0: eeprom@0 {
+				reg = <0x0 0x1000>;
+			};
+		};
 	};
 
 	partition@7300000 {
@@ -60,5 +70,6 @@
 &wifi {
 	status = "okay";
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7981b-tenbay-wr3000k.dts
+++ b/target/linux/mediatek/dts/mt7981b-tenbay-wr3000k.dts
@@ -179,7 +179,7 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-unielec-u7981-01-nand.dts
+++ b/target/linux/mediatek/dts/mt7981b-unielec-u7981-01-nand.dts
@@ -43,7 +43,7 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "factory";
 				reg = <0x180000 0x200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-3port-128nand-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-3port-128nand-common.dtsi
@@ -81,7 +81,7 @@
 				read-only;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "factory";
 				reg = <0x180000 0x200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn573hx3.dts
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn573hx3.dts
@@ -110,7 +110,7 @@
 				read-only;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "factory";
 				reg = <0x50000 0xb0000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn586x3.dts
+++ b/target/linux/mediatek/dts/mt7981b-wavlink-wl-wn586x3.dts
@@ -155,7 +155,7 @@
 				read-only;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "factory";
 				reg = <0x50000 0xb0000>;
 				read-only;
@@ -164,6 +164,10 @@
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
 
 					macaddr_factory_4: macaddr@4 {
 						compatible = "mac-base";
@@ -263,7 +267,7 @@
 
 &wifi {
 	status = "okay";
-	mediatek,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_factory_4 0>;
-	nvmem-cell-names = "mac-address";
+
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_4 0>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };

--- a/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-xiaomi-mi-router-common.dtsi
@@ -346,7 +346,7 @@
 				reg = <0x140000 0x40000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
+++ b/target/linux/mediatek/dts/mt7981b-yuncore-ax835.dts
@@ -169,7 +169,7 @@
 				read-only;
 			};
 
-			factory: partition@50000 {
+			partition@50000 {
 				label = "Factory";
 				reg = <0x50000 0x10000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8102ax-v2.dts
@@ -195,10 +195,28 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x0180000 0x0200000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_24: macaddr@24 {
+						reg = <0x24 0x6>;
+					};
+
+					macaddr_factory_2a: macaddr@2a {
+						reg = <0x2a 0x6>;
+					};
+				};
 			};
 
 			partition@380000 {
@@ -312,20 +330,4 @@
 	status = "okay";
 	nvmem-cells = <&eeprom_factory>;
 	nvmem-cell-names = "eeprom";
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_24: macaddr@24 {
-		reg = <0x24 0x6>;
-	};
-	macaddr_factory_2a: macaddr@2a {
-		reg = <0x2a 0x6>;
-	};
-	eeprom_factory: eeprom@0 {
-		reg = <0x0 0x1000>;
-	};
 };

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dtsi
@@ -208,10 +208,38 @@
 				reg = <0x100000 0x80000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x200000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_a: macaddr@a {
+						reg = <0xa 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_2a: macaddr@2a {
+						reg = <0x2a 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@380000 {
@@ -274,33 +302,5 @@
 		reg = <1>;
 		nvmem-cells = <&macaddr_factory_a 1>;
 		nvmem-cell-names = "mac-address";
-	};
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	eeprom_factory: eeprom@0 {
-		reg = <0x0 0x1000>;
-	};
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-		compatible = "mac-base";
-		#nvmem-cell-cells = <1>;
-	};
-
-	macaddr_factory_a: macaddr@a {
-		reg = <0xa 0x6>;
-		compatible = "mac-base";
-		#nvmem-cell-cells = <1>;
-	};
-
-	macaddr_factory_2a: macaddr@2a {
-		reg = <0x2a 0x6>;
-		compatible = "mac-base";
-		#nvmem-cell-cells = <1>;
 	};
 };

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8106ax.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8106ax.dtsi
@@ -242,10 +242,38 @@
 				reg = <0x100000 0x80000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x200000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						reg = <0x4 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_a: macaddr@a {
+						reg = <0xa 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_2a: macaddr@2a {
+						reg = <0x2a 0x6>;
+						compatible = "mac-base";
+						#nvmem-cell-cells = <1>;
+					};
+				};
 			};
 
 			partition@380000 {
@@ -319,32 +347,4 @@
 	status = "okay";
 	vusb33-supply = <&reg_3p3v>;
 	vbus-supply = <&reg_5v>;
-};
-
-&factory {
-	compatible = "nvmem-cells";
-	#address-cells = <1>;
-	#size-cells = <1>;
-
-	macaddr_factory_4: macaddr@4 {
-		reg = <0x4 0x6>;
-		compatible = "mac-base";
-		#nvmem-cell-cells = <1>;
-	};
-
-	macaddr_factory_a: macaddr@a {
-		reg = <0xa 0x6>;
-		compatible = "mac-base";
-		#nvmem-cell-cells = <1>;
-	};
-
-	macaddr_factory_2a: macaddr@2a {
-		reg = <0x2a 0x6>;
-		compatible = "mac-base";
-		#nvmem-cell-cells = <1>;
-	};
-
-	eeprom_factory: eeprom@0 {
-		reg = <0x0 0x1000>;
-	};
 };

--- a/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
+++ b/target/linux/mediatek/dts/mt7981b-zyxel-nwa50ax-pro.dts
@@ -143,7 +143,7 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7986a-acer-predator-w6.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-predator-w6.dts
@@ -163,7 +163,8 @@
 };
 
 &slot0 {
-	radio0: mt7915@0,0 {
+	radio0: wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_a0000>, <&precal_factory_a1010>;
 		nvmem-cell-names = "eeprom", "precal";

--- a/target/linux/mediatek/dts/mt7986a-acer-vero-w6m.dts
+++ b/target/linux/mediatek/dts/mt7986a-acer-vero-w6m.dts
@@ -58,7 +58,8 @@
 };
 
 &slot0 {
-	radio0: mt7915@0,0 {
+	radio0: wifi@0,0 {
+		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
 		nvmem-cells = <&eeprom_factory_a0000>, <&precal_factory_a1010>;
 		nvmem-cell-names = "eeprom", "precal";

--- a/target/linux/mediatek/dts/mt7986a-netcore-n60.dts
+++ b/target/linux/mediatek/dts/mt7986a-netcore-n60.dts
@@ -203,10 +203,28 @@
 				reg = <0x0100000 0x0080000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x0180000 0x0200000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_lan: macaddr@1fef20 {
+						reg = <0x1fef20 0x6>;
+					};
+
+					macaddr_wan: macaddr@1fef26 {
+						reg = <0x1fef26 0x6>;
+					};
+				};
 			};
 
 			partition@380000 {
@@ -283,21 +301,6 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&wf_2g_5g_pins>;
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
-};
-
-&factory {
-	nvmem-layout {
-		compatible = "fixed-layout";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		macaddr_lan: macaddr@1fef20 {
-			reg = <0x1fef20 0x6>;
-		};
-
-		macaddr_wan: macaddr@1fef26 {
-			reg = <0x1fef26 0x6>;
-		};
-	};
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7986a-smartrg-bonanza-peak.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-smartrg-bonanza-peak.dtsi
@@ -360,7 +360,8 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		radio0: mt7915@0,0 {
+		radio0: wifi@0,0 {
+			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
 
 			nvmem-cells = <&eeprom_factory_a0000>, <&macaddr 4>;

--- a/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-tplink-tl-xdr-common.dtsi
@@ -200,10 +200,20 @@
 				};
 			};
 
-			factory: partition@160000 {
+			partition@160000 {
 				label = "factory";
 				reg = <0x160000 0x0060000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
 			};
 
 			partition@1c0000 {
@@ -275,8 +285,8 @@
 };
 
 &wifi {
-	mediatek,mtd-eeprom = <&factory 0x0>;
-	nvmem-cells = <&macaddr_config_1c 2>;
-	nvmem-cell-names = "mac-address";
 	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_config_1c 2>;
+	nvmem-cell-names = "eeprom", "mac-address";
 };

--- a/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
+++ b/target/linux/mediatek/dts/mt7986a-xiaomi-redmi-router-ax6000.dtsi
@@ -161,7 +161,7 @@
 				reg = <0x140000 0x40000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x200000>;
 				read-only;
@@ -170,6 +170,10 @@
 					compatible = "fixed-layout";
 					#address-cells = <1>;
 					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
 
 					macaddr_factory_4: macaddr@4 {
 						compatible = "mac-base";
@@ -275,7 +279,8 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&wf_2g_5g_pins>;
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &uart0 {

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-stock.dts
@@ -31,7 +31,7 @@
 		reg = <0x100000 0x80000>;
 	};
 
-	factory: partition@180000 {
+	partition@180000 {
 		label = "Factory";
 		reg = <0x180000 0x200000>;
 		read-only;

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5601-t0-ubootmod.dts
@@ -30,7 +30,7 @@
 		read-only;
 	};
 
-	factory: partition@180000 {
+	partition@180000 {
 		label = "factory";
 		reg = <0x180000 0x200000>;
 		read-only;

--- a/target/linux/mediatek/dts/mt7986a-zyxel-ex5700-telenor.dts
+++ b/target/linux/mediatek/dts/mt7986a-zyxel-ex5700-telenor.dts
@@ -270,7 +270,9 @@
 		wifi@0,0 {
 			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
-			mediatek,mtd-eeprom = <&factory 0xa0000>;
+
+			nvmem-cells = <&eeprom_factory_a0000>;
+			nvmem-cell-names = "eeprom";
 		};
 	};
 };
@@ -288,7 +290,8 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&wf_5g_pins>;
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };
 
 &pio {
@@ -369,10 +372,24 @@
 				label = "u-boot-env";
 				reg = <0x100000 0x80000>;
 			};
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x200000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					eeprom_factory_a0000: eeprom@a0000 {
+						reg = <0xa0000 0xe00>;
+					};
+				};
 			};
 			partition@380000 {
 				label = "FIP";

--- a/target/linux/mediatek/dts/mt7986b-buffalo-wsr-6000ax8.dts
+++ b/target/linux/mediatek/dts/mt7986b-buffalo-wsr-6000ax8.dts
@@ -296,7 +296,7 @@
 				reg = <0x100000 0x80000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x200000>;
 				read-only;

--- a/target/linux/mediatek/dts/mt7986b-netgear-wax220.dts
+++ b/target/linux/mediatek/dts/mt7986b-netgear-wax220.dts
@@ -208,9 +208,19 @@
 				reg = <0x100000 0x80000>;
 			};
 
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x200000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
 			};
 
 			partition@380000 {
@@ -290,5 +300,6 @@
 	pinctrl-0 = <&wf_2g_5g_pins>;
 	pinctrl-1 = <&wf_dbdc_pins>;
 
-	mediatek,mtd-eeprom = <&factory 0x0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/dts/mt7987a-glinet-gl-mt3600be.dts
+++ b/target/linux/mediatek/dts/mt7987a-glinet-gl-mt3600be.dts
@@ -137,7 +137,7 @@
 	pcie@0,0 {
 		reg = <0x0000 0 0 0 0>;
 
-		mt7990@0,0 {
+		wifi@0,0 {
 			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
 			#address-cells = <1>;

--- a/target/linux/mediatek/dts/mt7987a-rfb-emmc.dtso
+++ b/target/linux/mediatek/dts/mt7987a-rfb-emmc.dtso
@@ -89,7 +89,8 @@
 		__overlay__ {
 			slot0: pcie@0,0 {
 				reg = <0x0000 0 0 0 0>;
-				mt7996@0,0 {
+				wifi@0,0 {
+					compatible = "mediatek,mt76";
 					reg = <0x0000 0 0 0 0>;
 					nvmem-cells = <&eeprom_factory_0>;
 					nvmem-cell-names = "eeprom";

--- a/target/linux/mediatek/dts/mt7987a-rfb-spim-nand.dtso
+++ b/target/linux/mediatek/dts/mt7987a-rfb-spim-nand.dtso
@@ -37,7 +37,7 @@
 						reg = <0x0100000 0x0080000>;
 					};
 
-					factory: partition@180000 {
+					partition@180000 {
 						label = "Factory";
 						reg = <0x180000 0x0400000>;
 
@@ -45,6 +45,10 @@
 							compatible = "fixed-layout";
 							#address-cells = <1>;
 							#size-cells = <1>;
+
+							eeprom_factory_0: eeprom@0 {
+								reg = <0x0 0x1e00>;
+							};
 
 							gmac2_mac: eeprom@fffee {
 								reg = <0xfffee 0x6>;
@@ -94,11 +98,12 @@
 			slot0: pcie@0,0 {
 				reg = <0x0000 0 0 0 0>;
 
-				mt7996@0,0 {
+				wifi@0,0 {
 					compatible = "mediatek,mt76";
 					reg = <0x0000 0 0 0 0>;
 					device_type = "pci";
-					mediatek,mtd-eeprom = <&factory 0x0>;
+					nvmem-cells = <&eeprom_factory_0>;
+					nvmem-cell-names = "eeprom";
 				};
 			};
 		};

--- a/target/linux/mediatek/dts/mt7987a-routerich-be7200.dts
+++ b/target/linux/mediatek/dts/mt7987a-routerich-be7200.dts
@@ -329,7 +329,7 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		mt7992@0,0 {
+		wifi@0,0 {
 			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
 

--- a/target/linux/mediatek/dts/mt7987a-tenda-be12-pro.dts
+++ b/target/linux/mediatek/dts/mt7987a-tenda-be12-pro.dts
@@ -355,7 +355,7 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		mt7992@0,0 {
+		wifi@0,0 {
 			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
 

--- a/target/linux/mediatek/dts/mt7988a-arcadyan-mozart.dts
+++ b/target/linux/mediatek/dts/mt7988a-arcadyan-mozart.dts
@@ -311,7 +311,8 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		mt7996@0,0 {
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
 			nvmem-cells = <&eeprom_factory_0>;
 			nvmem-cell-names = "eeprom";

--- a/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
+++ b/target/linux/mediatek/dts/mt7988a-smartrg-mt-stuart.dtsi
@@ -560,7 +560,8 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		mt7996@0,0 {
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/target/linux/mediatek/dts/mt7988d-asus-zenwifi-bt8.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-asus-zenwifi-bt8.dtsi
@@ -285,7 +285,8 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		mt7996_wifi: mt7996@0,0 {
+		mt7996_wifi: wifi@0,0 {
+			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
 		};
 	};

--- a/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
+++ b/target/linux/mediatek/dts/mt7988d-keenetic-kn-1812.dtsi
@@ -504,7 +504,8 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		mt7992@0,0 {
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
+++ b/target/linux/mediatek/dts/mt7988d-tplink-be450.dts
@@ -320,7 +320,8 @@
 		#address-cells = <3>;
 		#size-cells = <2>;
 
-		mt7996@0,0 {
+		wifi@0,0 {
+			compatible = "mediatek,mt76";
 			reg = <0x0000 0 0 0 0>;
 		};
 	};

--- a/target/linux/mediatek/files-6.18/arch/arm64/boot/dts/mediatek/mt7981-rfb-spim-nand.dtso
+++ b/target/linux/mediatek/files-6.18/arch/arm64/boot/dts/mediatek/mt7981-rfb-spim-nand.dtso
@@ -40,9 +40,19 @@
 						reg = <0x0100000 0x0080000>;
 					};
 
-					factory: partition@180000 {
+					partition@180000 {
 						label = "Factory";
 						reg = <0x180000 0x0200000>;
+
+						nvmem-layout {
+							compatible = "fixed-layout";
+							#address-cells = <1>;
+							#size-cells = <1>;
+
+							eeprom_factory_0: eeprom@0 {
+								reg = <0x0 0x1000>;
+							};
+						};
 					};
 
 					partition@380000 {
@@ -69,8 +79,10 @@
 	fragment@2 {
 		target = <&wifi>;
 		__overlay__ {
-			mediatek,mtd-eeprom = <&factory 0x0>;
 			status = "okay";
+
+			nvmem-cells = <&eeprom_factory_0>;
+			nvmem-cell-names = "eeprom";
 		};
 	};
 };

--- a/target/linux/mediatek/files-6.18/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
+++ b/target/linux/mediatek/files-6.18/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nand.dts
@@ -29,9 +29,19 @@
 				label = "u-boot-env";
 				reg = <0x0100000 0x0080000>;
 			};
-			factory: partition@180000 {
+			partition@180000 {
 				label = "Factory";
 				reg = <0x180000 0x0200000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
 			};
 			partition@380000 {
 				label = "FIP";
@@ -46,5 +56,6 @@
 };
 
 &wifi {
-	mediatek,mtd-eeprom = <&factory 0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/files-6.18/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nor.dts
+++ b/target/linux/mediatek/files-6.18/arch/arm64/boot/dts/mediatek/mt7986a-rfb-spim-nor.dts
@@ -28,9 +28,19 @@
 				label = "u-boot-env";
 				reg = <0x40000 0x0010000>;
 			};
-			factory: partition@50000 {
+			partition@50000 {
 				label = "Factory";
 				reg = <0x50000 0x00B0000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+				};
 			};
 			partition@100000 {
 				label = "FIP";
@@ -45,5 +55,6 @@
 };
 
 &wifi {
-	mediatek,mtd-eeprom = <&factory 0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
 };

--- a/target/linux/mediatek/patches-6.18/140-dts-fix-wmac-support-for-mt7622-rfb1.patch
+++ b/target/linux/mediatek/patches-6.18/140-dts-fix-wmac-support-for-mt7622-rfb1.patch
@@ -1,29 +1,42 @@
 From c46ccb69d17e584479df849a107423175a143c83 Mon Sep 17 00:00:00 2001
 From: Felix Fietkau <nbd@nbd.name>
 Date: Sat, 24 Oct 2020 21:15:20 +0200
-Subject: [PATCH] arm64: dts: mediatek: mt7622-rfb1: wire EEPROM to wmac from factory partition
+Subject: [PATCH] arm64: dts: mediatek: mt7622-rfb1: wire EEPROM to wmac from
+ factory partition
 
-Label the factory partition node so it can be referenced by phandle, and
-add a mediatek,mtd-eeprom property to the wmac node pointing at the
-factory partition to supply the calibration data at offset 0x0000.
+Add an nvmem section so that the eeprom can be referenced from the wmac
+node.
 
 Signed-off-by: Felix Fietkau <nbd@nbd.name>
+Signed-off-by: Rosen Penev <rosenp@gmail.com>
 ---
+ arch/arm64/boot/dts/mediatek/mt7622-rfb1.dts | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
 --- a/arch/arm64/boot/dts/mediatek/mt7622-rfb1.dts
 +++ b/arch/arm64/boot/dts/mediatek/mt7622-rfb1.dts
-@@ -599,7 +599,7 @@
- 				reg = <0x140000 0x0080000>;
- 			};
- 
--			partition@1c0000 {
-+			factory: partition@1c0000 {
+@@ -602,6 +602,16 @@
+ 			partition@1c0000 {
  				label = "Factory";
  				reg = <0x1c0000 0x0100000>;
++
++				nvmem-layout {
++					compatible = "fixed-layout";
++					#address-cells = <1>;
++					#size-cells = <1>;
++
++					eeprom_factory_0: eeprom@0 {
++						reg = <0x0 0x4da8>; /* actual length 0x400 */
++					};
++				};
  			};
-@@ -660,5 +660,6 @@
+ 
+ 			partition@200000 {
+@@ -660,5 +670,7 @@
  &wmac {
  	pinctrl-names = "default";
  	pinctrl-0 = <&wmac_pins>;
-+	mediatek,mtd-eeprom = <&factory 0x0000>;
++	nvmem-cells = <&eeprom_factory_0>;
++	nvmem-cell-names = "eeprom";
  	status = "okay";
  };

--- a/target/linux/mediatek/patches-6.18/863-arm64-dts-mt7986-add-sound-wm8960.patch
+++ b/target/linux/mediatek/patches-6.18/863-arm64-dts-mt7986-add-sound-wm8960.patch
@@ -46,9 +46,9 @@ Subject: [PATCH] arm64: dts: mt7986: add sound wm8960
  };
  
  &spi0 {
-@@ -48,3 +78,13 @@
- &wifi {
- 	mediatek,mtd-eeprom = <&factory 0>;
+@@ -59,3 +89,13 @@
+ 	nvmem-cells = <&eeprom_factory_0>;
+ 	nvmem-cell-names = "eeprom";
  };
 +
 +&pio {


### PR DESCRIPTION
These use fairly standard sizes.

0x4da8 for mt7615 + mt7622 and 0xe00 for mt7915.

ping @dangowrt @DragonBluep 