### PR TITLE
x86/base-files: add support for CloudGenix ION 2000

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -31,6 +31,15 @@ cisco-mx100-hw)
 	ucidef_set_network_device_path "eth11" "pci0000:00/0000:00:01.1/0000:02:00.2"
 	ucidef_set_interfaces_lan_wan "mgmt eth2 eth3 eth4 eth5 eth6 eth7 eth8 eth9 eth10 eth11" "wan"
 	;;
+cloudgenix-ion-2000)
+	ucidef_set_network_device_path "eth0" "pci0000:00/0000:00:01.0/0000:01:00.0"
+	ucidef_set_network_device_path "eth1" "pci0000:00/0000:00:02.0/0000:02:00.0"
+	ucidef_set_network_device_path "eth2" "pci0000:00/0000:00:14.0"
+	ucidef_set_network_device_path "eth3" "pci0000:00/0000:00:14.1"
+	ucidef_set_network_device_path "eth4" "pci0000:00/0000:00:14.2"
+	ucidef_set_network_device_path "eth5" "pci0000:00/0000:00:14.3"
+	ucidef_set_interfaces_lan_wan "eth1 eth2 eth3 eth4 eth5" "eth0"
+	;;
 dell-emc-edge620)
 	ucidef_set_interfaces_lan_wan "eth0 eth1 eth2 eth3 eth7" "eth6"
 	;;


### PR DESCRIPTION
The CloudGenix ION 2000 is a discontinued entry-level SD-WAN appliance,
a rebranded Lanner FW-7525 based on the Intel Atom C2XXX family of processors
with 4 integrated GbE ports and 2 additional I210 GbE ports. It can often be
found on eBay starting below USD 30.

Specs:
* CPU: Intel Atom C2558 @2.4GHz (Quad-core)
* RAM: 1x 4GB DDR3 SO-DIMM
* Storage: 1x Compact Flash,
      1x 420GB SATA 3.0 SSD
* Ethernet: 6x GbE RJ-45
* USB: 2x USB 2.0
* PCI: 1x Mini-PCIe slot
* Power: 12V/5A

The device's BIOS is password-protected, and the password somehow hasn't leaked,
but OpenWrt can be successfully booted by overwriting the stock OS on the boot
media.

See https://forum.openwrt.org/t/report-openwrt-on-cloudgenix-ion-2000/249315
for more details.

The two I210 NICs and integrated NICs are pinned to their
PCIe paths to ensure consistent interface ordering matching
the physical port layout with eth0 assigned to controller and
acting as WAN with remaining devices as LAN.

Signed-off-by: Raylynn Knight <rayknight@me.com>