### PR TITLE
lantiq: vr200: switch to nvmem eeprom

### DIFF
--- a/target/linux/lantiq/dts/vr9_tplink_vr200.dtsi
+++ b/target/linux/lantiq/dts/vr9_tplink_vr200.dtsi
@@ -198,12 +198,11 @@
 		device_type = "pci";
 
 		wifi@0,0 {
+			compatible = "mediatek,mt76";
 			reg = <0 0 0 0 0>;
-			mediatek,mtd-eeprom = <&radio 0x0000>;
-			big-endian;
 			ieee80211-freq-limit = <5000000 6000000>;
-			nvmem-cells = <&macaddr_romfile_f100 2>;
-			nvmem-cell-names = "mac-address";
+			nvmem-cells = <&eeprom_radio_0>, <&macaddr_romfile_f100 2>;
+			nvmem-cell-names = "eeprom", "mac-address";
 		};
 	};
 };
@@ -274,10 +273,20 @@
 				read-only;
 			};
 
-			radio: partition@ff0000 {
+			partition@ff0000 {
 				reg = <0xff0000 0x10000>;
 				label = "radio";
 				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_radio_0: eeprom@0 {
+						reg = <0x0 0x200>;
+					};
+				};
 			};
 		};
 	};


### PR DESCRIPTION
mediatek,mtd-eeprom predates nvmem and is being phased out.

At first glance, it looks like it's doing something useful with its big-endian binding. However on further inspection, big-endian is handled in the same function that mediatek,mtd-eeprom is handled. In addition, the older mtd_read way of extracting the firmware byteswaps the data on big endian hosts which big-endian byteswaps back. nvmem does not do such byteswapping.

ping @xdarklight @h-s-c @dangowrt 