### PR TITLE
mpc85xx: unify wrapper address of simple image devices

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mpc85xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/mpc85xx
@@ -9,8 +9,8 @@ board=$(board_name)
 
 case "$board" in
 enterasys,ws-ap3715i)
-	ubootenv_add_uci_config "$(find_mtd_part 'cfg1')" "0x0" "0x10000" "0x10000"
-	ubootenv_add_uci_config "$(find_mtd_part 'cfg2')" "0x0" "0x10000" "0x10000"
+	ubootenv_add_uci_config "/dev/mtd$(find_mtd_index 'cfg1')" "0x0" "0x1000" "0x10000"
+	ubootenv_add_uci_config "/dev/mtd$(find_mtd_index 'cfg2')" "0x0" "0x1000" "0x10000"
 	;;
 extreme-networks,ws-ap3825i)
 	ubootenv_add_uci_config "$(find_mtd_part 'cfg1')" "0x0" "0x10000" "0x20000"

--- a/target/linux/mpc85xx/files/arch/powerpc/boot/dts/ws-ap3715i.dts
+++ b/target/linux/mpc85xx/files/arch/powerpc/boot/dts/ws-ap3715i.dts
@@ -234,13 +234,11 @@
 				partition@120000 {
 					reg = <0x120000 0x10000>;
 					label = "cfg1";
-					read-only;
 				};
 
 				partition@130000 {
 					reg = <0x130000 0x10000>;
 					label = "cfg2";
-					read-only;
 				};
 
 				partition@140000 {

--- a/target/linux/mpc85xx/image/p1010.mk
+++ b/target/linux/mpc85xx/image/p1010.mk
@@ -41,7 +41,7 @@ define Device/enterasys_ws-ap3715i
   KERNEL_NAME := simpleImage.ws-ap3715i
   KERNEL_ENTRY := 0x1500000
   KERNEL_LOADADDR := 0x1500000
-  KERNEL = kernel-bin | lzma | uImage lzma
+  KERNEL = kernel-bin | libdeflate-gzip | uImage gzip
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata
 endef

--- a/target/linux/mpc85xx/patches-6.12/099-mpc85xx-p1010-change-wrapper-address-of-simple-image-devices.patch
+++ b/target/linux/mpc85xx/patches-6.12/099-mpc85xx-p1010-change-wrapper-address-of-simple-image-devices.patch
@@ -1,0 +1,10 @@
+--- a/arch/powerpc/boot/wrapper
++++ b/arch/powerpc/boot/wrapper
+@@ -351,6 +351,7 @@ adder875-redboot)
+ simpleboot-*)
+     platformo="$object/fixed-head.o $object/simpleboot.o"
+     binary=y
++    link_address='0x1500000'
+     ;;
+ asp834x-redboot)
+     platformo="$object/fixed-head.o $object/redboot-83xx.o"

--- a/target/linux/mpc85xx/patches-6.12/100-powerpc-85xx-tl-wdr4900-v1-support.patch
+++ b/target/linux/mpc85xx/patches-6.12/100-powerpc-85xx-tl-wdr4900-v1-support.patch
@@ -12,10 +12,9 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
 Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
 ---
  arch/powerpc/boot/Makefile           |  3 ++-
- arch/powerpc/boot/wrapper            |  5 +++++
  arch/powerpc/platforms/85xx/Kconfig  | 12 ++++++++++++
  arch/powerpc/platforms/85xx/Makefile |  1 +
- 4 files changed, 20 insertions(+), 1 deletion(-)
+ 4 files changed, 15 insertions(+), 1 deletion(-)
 
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
@@ -36,20 +35,6 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  # Board ports in arch/powerpc/platform/86xx/Kconfig
  image-$(CONFIG_MVME7100)                += dtbImage.mvme7100
  
---- a/arch/powerpc/boot/wrapper
-+++ b/arch/powerpc/boot/wrapper
-@@ -348,6 +348,11 @@ adder875-redboot)
-     platformo="$object/fixed-head.o $object/redboot-8xx.o"
-     binary=y
-     ;;
-+simpleboot-tl-wdr4900-v1)
-+    platformo="$object/fixed-head.o $object/simpleboot.o"
-+    link_address='0x1500000'
-+    binary=y
-+    ;;
- simpleboot-*)
-     platformo="$object/fixed-head.o $object/simpleboot.o"
-     binary=y
 --- a/arch/powerpc/platforms/85xx/Kconfig
 +++ b/arch/powerpc/platforms/85xx/Kconfig
 @@ -176,6 +176,18 @@ config STX_GP3

--- a/target/linux/mpc85xx/patches-6.12/101-powerpc-85xx-hiveap-330-support.patch
+++ b/target/linux/mpc85xx/patches-6.12/101-powerpc-85xx-hiveap-330-support.patch
@@ -46,13 +46,3 @@
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
  # Board ports in arch/powerpc/platform/86xx/Kconfig
  image-$(CONFIG_MVME7100)                += dtbImage.mvme7100
---- a/arch/powerpc/boot/wrapper
-+++ b/arch/powerpc/boot/wrapper
-@@ -348,6 +348,7 @@ adder875-redboot)
-     platformo="$object/fixed-head.o $object/redboot-8xx.o"
-     binary=y
-     ;;
-+simpleboot-hiveap-330|\
- simpleboot-tl-wdr4900-v1)
-     platformo="$object/fixed-head.o $object/simpleboot.o"
-     link_address='0x1500000'

--- a/target/linux/mpc85xx/patches-6.12/106-powerpc-85xx-ws-ap3710i-support.patch
+++ b/target/linux/mpc85xx/patches-6.12/106-powerpc-85xx-ws-ap3710i-support.patch
@@ -46,15 +46,3 @@
  # Board ports in arch/powerpc/platform/86xx/Kconfig
  image-$(CONFIG_MVME7100)                += dtbImage.mvme7100
  
---- a/arch/powerpc/boot/wrapper
-+++ b/arch/powerpc/boot/wrapper
-@@ -349,7 +349,8 @@ adder875-redboot)
-     binary=y
-     ;;
- simpleboot-hiveap-330|\
--simpleboot-tl-wdr4900-v1)
-+simpleboot-tl-wdr4900-v1|\
-+simpleboot-ws-ap3710i)
-     platformo="$object/fixed-head.o $object/simpleboot.o"
-     link_address='0x1500000'
-     binary=y

--- a/target/linux/mpc85xx/patches-6.12/107-powerpc-85xx-add-ws-ap3825i-support.patch
+++ b/target/linux/mpc85xx/patches-6.12/107-powerpc-85xx-add-ws-ap3825i-support.patch
@@ -55,8 +55,8 @@ WS-AP3825i AP.
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -355,6 +355,11 @@ simpleboot-ws-ap3710i)
-     link_address='0x1500000'
+@@ -348,6 +348,11 @@ adder875-redboot)
+     platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;
 +simpleboot-ws-ap3825i)

--- a/target/linux/mpc85xx/patches-6.12/110-powerpc-85xx-br200-wp-support.patch
+++ b/target/linux/mpc85xx/patches-6.12/110-powerpc-85xx-br200-wp-support.patch
@@ -45,13 +45,3 @@
  image-$(CONFIG_HIVEAP_330)		+= simpleImage.hiveap-330
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
  image-$(CONFIG_WS_AP3710I)		+= simpleImage.ws-ap3710i
---- a/arch/powerpc/boot/wrapper
-+++ b/arch/powerpc/boot/wrapper
-@@ -348,6 +348,7 @@ adder875-redboot)
-     platformo="$object/fixed-head.o $object/redboot-8xx.o"
-     binary=y
-     ;;
-+simpleboot-br200-wp|\
- simpleboot-hiveap-330|\
- simpleboot-tl-wdr4900-v1|\
- simpleboot-ws-ap3710i)

--- a/target/linux/mpc85xx/patches-6.18/099-mpc85xx-p1010-change-wrapper-address-of-simple-image-devices.patch
+++ b/target/linux/mpc85xx/patches-6.18/099-mpc85xx-p1010-change-wrapper-address-of-simple-image-devices.patch
@@ -1,0 +1,10 @@
+--- a/arch/powerpc/boot/wrapper
++++ b/arch/powerpc/boot/wrapper
+@@ -342,6 +342,7 @@ adder875-redboot)
+ simpleboot-*)
+     platformo="$object/fixed-head.o $object/simpleboot.o"
+     binary=y
++    link_address='0x1500000'
+     ;;
+ asp834x-redboot)
+     platformo="$object/fixed-head.o $object/redboot-83xx.o"

--- a/target/linux/mpc85xx/patches-6.18/100-powerpc-85xx-tl-wdr4900-v1-support.patch
+++ b/target/linux/mpc85xx/patches-6.18/100-powerpc-85xx-tl-wdr4900-v1-support.patch
@@ -12,10 +12,9 @@ Signed-off-by: Gabor Juhos <juhosg@openwrt.org>
 Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
 ---
  arch/powerpc/boot/Makefile           |  3 ++-
- arch/powerpc/boot/wrapper            |  5 +++++
  arch/powerpc/platforms/85xx/Kconfig  | 12 ++++++++++++
  arch/powerpc/platforms/85xx/Makefile |  1 +
- 4 files changed, 20 insertions(+), 1 deletion(-)
+ 4 files changed, 15 insertions(+), 1 deletion(-)
 
 --- a/arch/powerpc/boot/Makefile
 +++ b/arch/powerpc/boot/Makefile
@@ -36,20 +35,6 @@ Signed-off-by: Pawel Dembicki <paweldembicki@gmail.com>
  # Board ports in arch/powerpc/platform/86xx/Kconfig
  image-$(CONFIG_MVME7100)                += dtbImage.mvme7100
  
---- a/arch/powerpc/boot/wrapper
-+++ b/arch/powerpc/boot/wrapper
-@@ -339,6 +339,11 @@ adder875-redboot)
-     platformo="$object/fixed-head.o $object/redboot-8xx.o"
-     binary=y
-     ;;
-+simpleboot-tl-wdr4900-v1)
-+    platformo="$object/fixed-head.o $object/simpleboot.o"
-+    link_address='0x1500000'
-+    binary=y
-+    ;;
- simpleboot-*)
-     platformo="$object/fixed-head.o $object/simpleboot.o"
-     binary=y
 --- a/arch/powerpc/platforms/85xx/Kconfig
 +++ b/arch/powerpc/platforms/85xx/Kconfig
 @@ -155,6 +155,18 @@ config STX_GP3

--- a/target/linux/mpc85xx/patches-6.18/101-powerpc-85xx-hiveap-330-support.patch
+++ b/target/linux/mpc85xx/patches-6.18/101-powerpc-85xx-hiveap-330-support.patch
@@ -46,13 +46,3 @@
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
  # Board ports in arch/powerpc/platform/86xx/Kconfig
  image-$(CONFIG_MVME7100)                += dtbImage.mvme7100
---- a/arch/powerpc/boot/wrapper
-+++ b/arch/powerpc/boot/wrapper
-@@ -339,6 +339,7 @@ adder875-redboot)
-     platformo="$object/fixed-head.o $object/redboot-8xx.o"
-     binary=y
-     ;;
-+simpleboot-hiveap-330|\
- simpleboot-tl-wdr4900-v1)
-     platformo="$object/fixed-head.o $object/simpleboot.o"
-     link_address='0x1500000'

--- a/target/linux/mpc85xx/patches-6.18/106-powerpc-85xx-ws-ap3710i-support.patch
+++ b/target/linux/mpc85xx/patches-6.18/106-powerpc-85xx-ws-ap3710i-support.patch
@@ -46,15 +46,3 @@
  # Board ports in arch/powerpc/platform/86xx/Kconfig
  image-$(CONFIG_MVME7100)                += dtbImage.mvme7100
  
---- a/arch/powerpc/boot/wrapper
-+++ b/arch/powerpc/boot/wrapper
-@@ -340,7 +340,8 @@ adder875-redboot)
-     binary=y
-     ;;
- simpleboot-hiveap-330|\
--simpleboot-tl-wdr4900-v1)
-+simpleboot-tl-wdr4900-v1|\
-+simpleboot-ws-ap3710i)
-     platformo="$object/fixed-head.o $object/simpleboot.o"
-     link_address='0x1500000'
-     binary=y

--- a/target/linux/mpc85xx/patches-6.18/107-powerpc-85xx-add-ws-ap3825i-support.patch
+++ b/target/linux/mpc85xx/patches-6.18/107-powerpc-85xx-add-ws-ap3825i-support.patch
@@ -55,8 +55,8 @@ WS-AP3825i AP.
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -346,6 +346,11 @@ simpleboot-ws-ap3710i)
-     link_address='0x1500000'
+@@ -339,6 +339,11 @@ adder875-redboot)
+     platformo="$object/fixed-head.o $object/redboot-8xx.o"
      binary=y
      ;;
 +simpleboot-ws-ap3825i)

--- a/target/linux/mpc85xx/patches-6.18/110-powerpc-85xx-br200-wp-support.patch
+++ b/target/linux/mpc85xx/patches-6.18/110-powerpc-85xx-br200-wp-support.patch
@@ -45,13 +45,3 @@
  image-$(CONFIG_HIVEAP_330)		+= simpleImage.hiveap-330
  image-$(CONFIG_TL_WDR4900_V1)		+= simpleImage.tl-wdr4900-v1
  image-$(CONFIG_WS_AP3710I)		+= simpleImage.ws-ap3710i
---- a/arch/powerpc/boot/wrapper
-+++ b/arch/powerpc/boot/wrapper
-@@ -339,6 +339,7 @@ adder875-redboot)
-     platformo="$object/fixed-head.o $object/redboot-8xx.o"
-     binary=y
-     ;;
-+simpleboot-br200-wp|\
- simpleboot-hiveap-330|\
- simpleboot-tl-wdr4900-v1|\
- simpleboot-ws-ap3710i)


### PR DESCRIPTION
The wrapper address of simple image devices should have been changed at commit 6a8b831 , but only TL-WDR4900 and BR200-WP are changed at that time, and now the wrapper address changes are split among patches for specific devices. More importantly, commit 6a8b831 forgot to change Enterasys WS-AP3715i, causing
https://github.com/openwrt/openwrt/issues/23112 .

This commit will gather the change of wrapper address of simple image devices into a dedicated patch file.

Tested: Both WS-AP3715i and TL-WDR4900 v1 boot well.

Fixes: https://github.com/openwrt/openwrt/issues/23112
