### PR TITLE
modules: video: Fix DRM client lib dependency

### DIFF
--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -336,7 +336,7 @@ $(eval $(call KernelPackage,drm-buddy))
 define KernelPackage/drm-client-lib
   SUBMENU:=$(VIDEO_MENU)
   TITLE:=DRM client library setup helper
-  DEPENDS:=@DISPLAY_SUPPORT +@LINUX_6_18 +kmod-drm +kmod-drm-kms-helper
+  DEPENDS:=@DISPLAY_SUPPORT @LINUX_6_18 +kmod-drm +kmod-drm-kms-helper
   KCONFIG:=CONFIG_DRM_CLIENT_LIB
   FILES:= $(LINUX_DIR)/drivers/gpu/drm/clients/drm_client_lib.ko
   AUTOLOAD:=$(call AutoProbe,drm_client_lib)


### PR DESCRIPTION
Fix dependency for kmod-drm-client-lib module:
error: recursive dependency detected!
	symbol LINUX_6_18 is selected by PACKAGE_kmod-drm-client-lib
	symbol PACKAGE_kmod-drm-client-lib is selected by LINUX_6_18
