### PR TITLE
bcm27xx: update irq-msi-lib.h header path

### DIFF
--- a/target/linux/bcm27xx/patches-6.12/950-0901-irqchip-Add-Broadcom-bcm2712-MSI-X-interrupt-control.patch
+++ b/target/linux/bcm27xx/patches-6.12/950-0901-irqchip-Add-Broadcom-bcm2712-MSI-X-interrupt-control.patch
@@ -78,7 +78,7 @@ Signed-off-by: Stanimir Varbanov <svarbanov@suse.de>
 +#include <linux/of_platform.h>
  
 -#include <linux/irqchip.h>
-+#include "irq-msi-lib.h"
++#include <linux/irqchip/irq-msi-lib.h>
  
 -#define MIP_INT_RAISED		0x00
 -#define MIP_INT_CLEARED		0x10


### PR DESCRIPTION
Fix build error:

drivers/irqchip/irq-bcm2712-mip.c:14:10: fatal error: irq-msi-lib.h: No such file or directory
   14 | #include "irq-msi-lib.h"
      |          ^~~~~~~~~~~~~~~

Fixes: ba7aa2a97153 ("generic: backport MSI affinity support for DW PCIe")

Cc @hauke @robimarko