### PR TITLE
realtek: refresh 'add-pcs-rtl-otto' patch

### DIFF
--- a/target/linux/realtek/patches-6.18/730-add-pcs-rtl-otto.patch
+++ b/target/linux/realtek/patches-6.18/730-add-pcs-rtl-otto.patch
@@ -11,7 +11,7 @@ Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
 ---
 --- a/drivers/net/pcs/Kconfig
 +++ b/drivers/net/pcs/Kconfig
-@@ -45,6 +45,15 @@ config PCS_MTK_USXGMII
+@@ -46,6 +46,15 @@ config PCS_MTK_USXGMII
  	  1000Base-X, 2500Base-X and Cisco SGMII are supported on the same
  	  differential pairs via an embedded LynxI PCS.
  


### PR DESCRIPTION
Refresh the patch to account for recent changes in the generic kernel patches. Makes the CI kernel patch check happy again.

Fixes: c271123724fc ("generic: 6.18: fix MediaTek USXGMII driver")
