### PR TITLE
dropbear: require busybox pidof applet

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -62,7 +62,7 @@ define Package/dropbear
   CATEGORY:=Base system
   TITLE:=Small SSH2 client/server
   MENU:=1
-  DEPENDS:= +USE_GLIBC:libcrypt-compat +DROPBEAR_ZLIB:zlib
+  DEPENDS:= +USE_GLIBC:libcrypt-compat +DROPBEAR_ZLIB:zlib +@BUSYBOX_CONFIG_PIDOF
   ALTERNATIVES:=100:/usr/bin/ssh-keygen:/usr/sbin/dropbear
   $(if $(CONFIG_DROPBEAR_SCP),ALTERNATIVES+= \
 	  100:/usr/bin/scp:/usr/sbin/dropbear,)


### PR DESCRIPTION
The dropbear init script uses pidof, but BusyBox may be built
without it. Add a Kconfig dependency on BUSYBOX_CONFIG_PIDOF
to ensure the applet is available at runtime.
    
Signed-off-by: Ivan Romanov <drizt72@zoho.eu>
