### PR TITLE
rpcd: add policy to config

### DIFF
--- a/package/system/rpcd/Makefile
+++ b/package/system/rpcd/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/rpcd.git

--- a/package/system/rpcd/files/rpcd.config
+++ b/package/system/rpcd/files/rpcd.config
@@ -2,6 +2,8 @@ config rpcd
 	option socket /var/run/ubus/ubus.sock
 	option timeout 30
 
+config policy 'policy'
+
 config login
 	option username 'root'
 	option password '$p$root'


### PR DESCRIPTION
This is needed for luci to display the policy options in `luci-mod-system`.

