### PR TITLE
dnsmasq: require busybox pidof applet

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -44,7 +44,7 @@ define Package/dnsmasq/Default
   CATEGORY:=Base system
   TITLE:=DNS and DHCP server
   URL:=http://www.thekelleys.org.uk/dnsmasq/
-  DEPENDS:=+libubus
+  DEPENDS:=+libubus +@BUSYBOX_CONFIG_PIDOF
   USERID:=dnsmasq=453:dnsmasq=453
 endef
 


### PR DESCRIPTION
The dnsmasq init script uses pidof, but BusyBox may be built without it. Add a Kconfig dependency on BUSYBOX_CONFIG_PIDOF to ensure the applet is available at runtime.
