### PR TITLE
ipq50xx: add label-mac-device to Linksys MX5500

### DIFF
--- a/target/linux/qualcommax/dts/ipq5018-mx5500.dts
+++ b/target/linux/qualcommax/dts/ipq5018-mx5500.dts
@@ -11,6 +11,10 @@
 		bootargs-append = " root=/dev/ubiblock0_0 coherent_pool=2M";
 		stdout-path = "serial0:115200n8";
 	};
+
+	aliases {
+		label-mac-device = &dp2;
+	};
 };
 
 /*


### PR DESCRIPTION
Add the label-mac-device alias to the device dts.
