### PR TITLE
ramips: remove mediatek,firmware-eeprom

### DIFF
--- a/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
+++ b/target/linux/ramips/dts/mt7621_zyxel_lte3301-plus.dts
@@ -193,7 +193,6 @@
 	wifi@0,0 {
 		compatible = "mediatek,mt76";
 		reg = <0x0000 0 0 0 0>;
-		mediatek,firmware-eeprom = "mt7615e_eeprom.bin";
 		nvmem-cells = <&eeprom_factory_0>, <&macaddr_factory_fe6e 1>;
 		nvmem-cell-names = "eeprom", "mac-address";
 	};


### PR DESCRIPTION
This is a nonsensical binding that's not implemented anywhere.

ping @ddimension @robimarko 