### PR TITLE
ramips: add support for 360 T6GS

### DIFF
--- a/target/linux/ramips/dts/mt7621_qihoo_360t6gs.dts
+++ b/target/linux/ramips/dts/mt7621_qihoo_360t6gs.dts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "qihoo,360t6gs", "mediatek,mt7621-soc";
+	model = "Qihoo 360 T6GS";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x000000 0x080000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x080000 0x040000>;
+		};
+
+		partition@c0000 {
+			label = "Factory";
+			reg = <0x0c0000 0x040000>;
+			read-only;
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				eeprom_factory: eeprom@0 {
+					reg = <0x0 0x1000>;
+				};
+
+				macaddr_factory_4: macaddr@4 {
+					compatible = "mac-base";
+					reg = <0x4 0x6>;
+					#nvmem-cell-cells = <1>;
+				};
+			};
+		};
+
+		partition@180000 {
+			label = "kernel";
+			reg = <0x180000 0x400000>;
+		};
+
+		partition@580000 {
+			label = "firmware";
+			reg = <0x580000 0x7a80000>;
+			compatible = "linux,ubi";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory>;
+		nvmem-cell-names = "eeprom";
+		mediatek,disable-radar-background;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_factory_4 2>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_factory_4 3>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	nvmem-cells = <&macaddr_factory_4 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	nvmem-cells = <&macaddr_factory_4 1>;
+	nvmem-cell-names = "mac-address";
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+		pause;
+	};
+};
+
+&switch0 {
+	status = "okay";
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart3", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/dts/mt7621_qihoo_360t6gs.dts
+++ b/target/linux/ramips/dts/mt7621_qihoo_360t6gs.dts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "qihoo,360t6gs", "mediatek,mt7621-soc";
+	model = "Qihoo 360 T6GS";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_green;
+		label-mac-device = &gmac0;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_red: led-0 {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_green: led-1 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio 10 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps {
+			label = "wps";
+			gpios = <&gpio 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+};
+
+&nand {
+	status = "okay";
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		partition@0 {
+			label = "u-boot";
+			reg = <0x000000 0x080000>;
+			read-only;
+		};
+
+		partition@80000 {
+			label = "u-boot-env";
+			reg = <0x080000 0x040000>;
+		};
+
+		partition@c0000 {
+			label = "Factory";
+			reg = <0x0c0000 0x040000>;
+			read-only;
+			nvmem-layout {
+				compatible = "fixed-layout";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				eeprom_factory: eeprom@0 {
+					reg = <0x0 0x1000>;
+				};
+
+				macaddr_factory_3fff4: macaddr@3fff4 {
+					reg = <0x3fff4 0x6>;
+				};
+
+				macaddr_factory_3fffa: macaddr@3fffa {
+					reg = <0x3fffa 0x6>;
+				};
+			};
+		};
+
+		partition@180000 {
+			label = "kernel";
+			reg = <0x180000 0x400000>;
+		};
+
+		partition@580000 {
+			label = "firmware";
+			reg = <0x580000 0x7a80000>;
+			compatible = "linux,ubi";
+		};
+	};
+};
+
+&pcie {
+	status = "okay";
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory>;
+		nvmem-cell-names = "eeprom";
+		mediatek,disable-radar-background;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		band@0 {
+			reg = <0>;
+			nvmem-cells = <&macaddr_factory_3fff4 1>;
+			nvmem-cell-names = "mac-address";
+		};
+
+		band@1 {
+			reg = <1>;
+			nvmem-cells = <&macaddr_factory_3fffa 2>;
+			nvmem-cell-names = "mac-address";
+		};
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	nvmem-cells = <&macaddr_factory_3fff4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	status = "okay";
+	label = "wan";
+	nvmem-cells = <&macaddr_factory_3fffa>;
+	nvmem-cell-names = "mac-address";
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+		pause;
+	};
+};
+
+&switch0 {
+	status = "okay";
+	ports {
+		port@0 {
+			status = "okay";
+			label = "lan1";
+		};
+
+		port@1 {
+			status = "okay";
+			label = "lan2";
+		};
+
+		port@2 {
+			status = "okay";
+			label = "lan3";
+		};
+
+		port@3 {
+			status = "okay";
+			label = "wan";
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "jtag", "uart3", "wdt";
+		function = "gpio";
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2677,6 +2677,19 @@ define Device/plasmacloud_pax1800-lite
 endef
 TARGET_DEVICES += plasmacloud_pax1800-lite
 
+define Device/qihoo_360t6gs
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := Qihoo
+  DEVICE_MODEL := 360 T6GS
+  IMAGE_SIZE := 125000k
+  IMAGES += firmware.bin
+  IMAGE/firmware.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
+  DEVICE_PACKAGES += kmod-mt7915-firmware
+endef
+TARGET_DEVICES += qihoo_360t6gs
+
 define Device/raisecom_msg1500-x-00
   $(Device/nand)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -2679,6 +2679,19 @@ define Device/plasmacloud_pax1800-lite
 endef
 TARGET_DEVICES += plasmacloud_pax1800-lite
 
+define Device/qihoo_360t6gs
+  $(Device/nand)
+  $(Device/uimage-lzma-loader)
+  DEVICE_VENDOR := Qihoo
+  DEVICE_MODEL := 360 T6GS
+  IMAGE_SIZE := 125000k
+  IMAGES += firmware.bin
+  IMAGE/firmware.bin := append-kernel | pad-to $$(KERNEL_SIZE) | append-ubi | \
+	check-size
+  DEVICE_PACKAGES += kmod-mt7915-firmware
+endef
+TARGET_DEVICES += qihoo_360t6gs
+
 define Device/raisecom_msg1500-x-00
   $(Device/nand)
   $(Device/uimage-lzma-loader)

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -24,6 +24,7 @@ ramips_setup_interfaces()
 	hiwifi,hc5962|\
 	mercusys,mr70x-v1|\
 	netgear,wax202|\
+	qihoo,360t6gs|\
 	sim,simax1800t|\
 	sim,simax1800u|\
 	tplink,mr600-v2-eu|\
@@ -315,6 +316,10 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii Config ethaddr)
 		label_mac=$lan_mac
 		;;
+	qihoo,360t6gs)
+		lan_mac=$(cat /sys/class/net/eth0/address)
+		label_mac=$lan_mac
+		wan_mac=$(macaddr_add "$lan_mac" 1)
 	yuncore,ax820)
 		label_mac=$(mtd_get_mac_binary Factory 0x4)
 		;;

--- a/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt7621/base-files/etc/board.d/02_network
@@ -24,6 +24,7 @@ ramips_setup_interfaces()
 	hiwifi,hc5962|\
 	mercusys,mr70x-v1|\
 	netgear,wax202|\
+	qihoo,360t6gs|\
 	sim,simax1800t|\
 	sim,simax1800u|\
 	teltonika,rutm11|\
@@ -319,6 +320,10 @@ ramips_setup_macs()
 		lan_mac=$(mtd_get_mac_ascii Config ethaddr)
 		label_mac=$lan_mac
 		;;
+	qihoo,360t6gs)
+		lan_mac=$(cat /sys/class/net/eth0/address)
+		label_mac=$lan_mac
+		wan_mac=$(macaddr_add "$lan_mac" 1)
 	yuncore,ax820)
 		label_mac=$(mtd_get_mac_binary Factory 0x4)
 		;;


### PR DESCRIPTION
Hardware:
---------
* SoC: MediaTek MT7621AT
* RAM: 256MiB DDR3
* Flash: 128MiB NAND
* Wireless: 802.11ax (2x2 MT7915E DBDC / MT7905DAN & MT7975DN)
* Ethernet: 4x 10/100/1000 (MT7530)
* LEDS: 1x RGB
* Button: 1x WPS, 1x Reset

Installation via bootloader:
----------------------------
1. Download [T6GS_flash_stuff.7z](https://wwayd.lanzouu.com/iI9Yw3oiuy6b) file share password is  `978g`, and uncompress it
2. Log into the OEM web GUI
3. Access firmware upgrade page, and flash `T6GS-4.1.0.2669-rel-upgrade.bin` firmware to downgrade firmware
4. Solder TTL header. Pinout: `RX -> TX, TX -> RX, GND -> GND, VCC -> VCC `, Baud 115200
5. Power on router before TTL device connected
6. Connect using a terminal emulator with a 3.3v USB-TTL or similar
7. Login into OEM web GUI and click reboot button
8. Interrupt boot process by spamming `f` and `enter` during boot to enter failsafe mode (if missed, repeat from step 6)
9. Input these commands to open telnet: 
```
mount_root
sed -i 's/.*local debug=.*/\tlocal debug=1/' /etc/init.d/telnet
# set a password
passwd root
```
10. Prepare a web server to provide `u-boot-T6GS.bin` file in local web server, eg `python -m http.server`
11. Reboot into system, connect to  telnet service
12. (Optional) backup vendor supplied firmware:

<summary>Steps to backup vendor images</summary>

<details>

a) Install dropbear
```
# input at telnet terminal
cd /tmp
wget http://<your PC IP>:5000/dropbear_2017.75-5_mipsel_24kc-data.tar.gz
tar -xzvf dropbear_2017.75-5_mipsel_24kc-data.tar.gz -C /
/etc/init.d/dropbear enable
/etc/init.d/dropbear restart
```

b) Backup image
```
cd /tmp
cat /dev/mtd0ro > mtd0-u-boot.bin
cat /dev/mtd1ro > mtd1-u-boot-env.bin
cat /dev/mtd2ro > mtd2-Factory.bin
cat /dev/mtd3ro > mtd3-Config.bin
cat /dev/mtd4ro > mtd4-config.bin
cat /dev/mtd5ro > mtd5-factory.bin
cat /dev/mtd6ro > mtd6-plugin.bin
cat /dev/mtd7ro > mtd7-log.bin
```

c) Retrieve image
```
# input at PC
scp -O -o HostKeyAlgorithms=+ssh-rsa "root@<your router IP>:/tmp/mtd*" ./
```

d) Backup image again
```
# input at telnet terminal
# free up space
rm -f /tmp/mtd*
cat /dev/mtd8ro > mtd8-firmware.bin
cat /dev/mtd12ro > mtd12-firmware-1.bin
```

e) Retrieve image again
```
# input at PC
scp -O -o HostKeyAlgorithms=+ssh-rsa "root@<your router IP>:/tmp/mtd*" ./
```
</details>

13. Input these commands to flash uboot:
```
cd /tmp
wget http://<your PC IP>:5000/u-boot-T6GS.bin
mtd write u-boot-T6GS.bin u-boot
```

14. Hold reset btn and power up, flash openwrt firmware with uboot


Thanks: 
1. [善良的坏boy: 360 T6GS/T6M ImmortalWrt 25.12](https://www.right.com.cn/forum/thread-8468908-1-1.html) 
2. [午时三刻: 360 T6GS detail flash tutorials](https://www.right.com.cn/forum/thread-8457978-1-1.html) 
3. [drl: 360 T6GS TTL flash tutorials](https://www.right.com.cn/forum/thread-8469352-1-1.html)
