### PR TITLE
ath79: ws-ap3610: assign MAC address with nvmem

### DIFF
--- a/target/linux/ath79/dts/ar7161_siemens_ws-ap3610.dts
+++ b/target/linux/ath79/dts/ar7161_siemens_ws-ap3610.dts
@@ -108,6 +108,9 @@
 
 	phy-mode = "rgmii-id";
 	phy-handle = <&phy0>;
+
+	nvmem-cells = <&macaddr_cfg1_ethaddr>;
+	nvmem-cell-names = "mac-address";
 };
 
 &spi {
@@ -145,6 +148,14 @@
 				label = "cfg1";
 				reg = <0xe80000 0x40000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env-redundant-bool";
+					env-size = <0x10000>;
+
+					macaddr_cfg1_ethaddr: ethaddr {
+					};
+				};
 			};
 
 			partition@ec0000 {

--- a/target/linux/ath79/dts/ar7161_siemens_ws-ap3610.dts
+++ b/target/linux/ath79/dts/ar7161_siemens_ws-ap3610.dts
@@ -108,6 +108,9 @@
 
 	phy-mode = "rgmii-id";
 	phy-handle = <&phy0>;
+
+	nvmem-cells = <&macaddr_cfg2_ethaddr>;
+	nvmem-cell-names = "mac-address";
 };
 
 &spi {
@@ -151,6 +154,14 @@
 				label = "cfg2";
 				reg = <0xec0000 0x40000>;
 				read-only;
+
+				nvmem-layout {
+					compatible = "u-boot,env-redundant-bool";
+					env-size = <0x10000>;
+
+					macaddr_cfg2_ethaddr: ethaddr {
+					};
+				};
 			};
 
 			partition@f00000 {

--- a/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
+++ b/target/linux/ath79/generic/base-files/lib/preinit/10_fix_eth_mac.sh
@@ -12,9 +12,6 @@ preinit_set_mac_address() {
 		ip link set dev eth0 address $(mtd_get_mac_ascii bdcfg "lanmac")
 		ip link set dev eth1 address $(mtd_get_mac_ascii bdcfg "wanmac")
 		;;
-	siemens,ws-ap3610)
-		ip link set dev eth0 address $(mtd_get_mac_ascii cfg1 ethaddr)
-		;;
 	moxa,awk-1137c)
 		ip link set dev eth0 address $(mtd_get_mac_ascii u-boot-env mac_addr)
 		;;


### PR DESCRIPTION
Userspace handling is deprecated.

As with all ws-ap devices, a redundant u-boot environment is used.