### PR TITLE
build: fix toolchain wrapper

### DIFF
--- a/toolchain/wrapper/Makefile
+++ b/toolchain/wrapper/Makefile
@@ -16,10 +16,7 @@ include $(INCLUDE_DIR)/toolchain-build.mk
 # 1: args
 define toolchain_util
 $(strip $(SCRIPT_DIR)/ext-toolchain.sh --toolchain $(CONFIG_TOOLCHAIN_ROOT) \
-	--cflags $(CONFIG_TARGET_OPTIMIZATION) \
-	--cflags "$(if $(call qstrip,$(CONFIG_TOOLCHAIN_LIBC)),-m$(call qstrip,$(CONFIG_TOOLCHAIN_LIBC))) $(if $(CONFIG_SOFT_FLOAT),-msoft-float)" \
-	--cflags "$(patsubst ./%,-I$(TOOLCHAIN_ROOT_DIR)/%,$(call qstrip,$(CONFIG_TOOLCHAIN_INC_PATH)))" \
-	--cflags "$(patsubst ./%,-L$(TOOLCHAIN_ROOT_DIR)/%,$(call qstrip,$(CONFIG_TOOLCHAIN_LIB_PATH)))" \
+	--cflags "$(if $(call qstrip,$(CONFIG_TOOLCHAIN_LIBC)),-m$(call qstrip,$(CONFIG_TOOLCHAIN_LIBC)))" \
 	$(1))
 endef
 


### PR DESCRIPTION
    toolchain wrapper are adding additional option breaking the compilation

    The change ensures consistent behavior between internal and
    external toolchains.

    Currently, the wrapper for external toolchains adds more options than
    the internal toolchain does.

    scripts/patch-specs.sh (used for internal toolchains) only
    injects -idirafter and -L flags for STAGING_DIR.

    In contrast, toolchain/wrapper/Makefile also adds flags for
    CONFIG_TARGET_OPTIMIZATION, CONFIG_TOOLCHAIN_LIBC,
    CONFIG_TOOLCHAIN_INC_PATH, and CONFIG_TOOLCHAIN_LIB_PATH.

    This causes kernel compilation to fail, because it ends up using headers
    from CONFIG_TOOLCHAIN_INC_PATH instead of its own.

    The chosen solution is to remove all additional options from the wrapper
    so both internal and external toolchains behave consistently.

    No regressions have been observed across all combinations:

        internal toolchain / internal kernel
        external toolchain / external kernel
        external toolchain / internal kernel

    Overall, keeping a consistent set of options regardless of the toolchain
    type appears to be the a cleaner and more maintainable approach.

    Signed-off-by: Alarcon Laurent <laurent.alarcon@sagemcom.com>