### PR TITLE
gpio-latch-mikrotik: fix logic error

### DIFF
--- a/target/linux/ath79/files/drivers/gpio/gpio-latch-mikrotik.c
+++ b/target/linux/ath79/files/drivers/gpio/gpio-latch-mikrotik.c
@@ -44,7 +44,7 @@ static void gpio_latch_unlock(struct gpio_latch_chip *glc, bool disable)
 		mutex_unlock(&glc->latch_mutex);
 
 	if (disable)
-		glc->latch_enabled = true;
+		glc->latch_enabled = false;
 
 	mutex_unlock(&glc->mutex);
 }


### PR DESCRIPTION
latch_enabled should be false when unlocking. it's set to true when locking. Probably copy/paste bug.