### PR TITLE
mediatek: nmbm fix for Huasifei WH3000 Pro NAND

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-huasifei-wh3000-pro-nand.dts
+++ b/target/linux/mediatek/dts/mt7981b-huasifei-wh3000-pro-nand.dts
@@ -20,6 +20,10 @@
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
 
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
 		partitions {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;


### PR DESCRIPTION
This commit adds missing nmbm parameters to device dts.

Before:
```
[   13.065277] ubi0 warning: ubi_eba_init: cannot reserve enough PEBs for bad PEB handling, reserved 36, need 40
[   13.184624] ubi0: attached mtd4 (name "ubi", size 226 MiB)
[   13.250170] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[   13.332343] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[   13.413459] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[   13.496659] ubi0: good PEBs: 1812, bad PEBs: 0, corrupted PEBs: 0
[   13.569460] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[   13.655780] ubi0: max/mean erase counter: 2/1, WL threshold: 4096, image sequence number: 1717500926
[   13.764971] ubi0: available PEBs: 0, total reserved PEBs: 1812, PEBs reserved for bad PEB handling: 36
```

After:
```
[    0.939053] spi-nand spi0.0: Winbond SPI NAND was found.
[    0.944422] spi-nand spi0.0: 256 MiB, block size: 128 KiB, page size: 2048, OOB size: 128
[    0.953256] Signature found at block 2047 [0x0ffe0000]
[    0.958389] NMBM management region starts at block 1920 [0x0f000000]
[    0.966032] First info table with writecount 0 found in block 1920
[    0.975792] Second info table with writecount 0 found in block 1923
[    0.982076] NMBM has been successfully attached
[    0.986815] 5 fixed-partitions partitions found on MTD device spi0.0
[    0.993245] Creating 5 MTD partitions on "spi0.0":
[    0.998028] 0x000000000000-0x000000100000 : "BL2"
[    1.003825] 0x000000100000-0x000000180000 : "u-boot-env"
[    1.009867] 0x000000180000-0x000000380000 : "Factory"
[    1.016776] 0x000000380000-0x000000580000 : "FIP"
[    1.023109] 0x000000580000-0x00000e780000 : "ubi"
[    1.724925] ubi0: default fastmap pool size: 90
[    1.729444] ubi0: default fastmap WL pool size: 45
[    1.734256] ubi0: attaching mtd4
[    2.441513] ubi0: scanning is finished
[    2.451382] ubi0: attached mtd4 (name "ubi", size 226 MiB)
[    2.456876] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    2.463753] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    2.470528] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    2.477481] ubi0: good PEBs: 1808, bad PEBs: 0, corrupted PEBs: 0
[    2.483567] ubi0: user volume: 3, internal volumes: 1, max. volumes count: 128
[    2.490775] ubi0: max/mean erase counter: 2/1, WL threshold: 4096, image sequence number: 0
[    2.499114] ubi0: available PEBs: 0, total reserved PEBs: 1808, PEBs reserved for bad PEB handling: 38
```
