### PR TITLE
realtek: support configurable LED interface mode on RTL930x

### DIFF
--- a/target/linux/realtek/dts/macros.dtsi
+++ b/target/linux/realtek/dts/macros.dtsi
@@ -70,7 +70,7 @@
 		managed = "in-band-status"; \
 	};
 
-// LED Set mode definitions
+/* LED Set mode definitions */
 #define RTL93XX_LED_SET_NONE        (0)
 #define RTL93XX_LED_SET_10G         (1 << 0)
 #define RTL93XX_LED_SET_5G          (1 << 1)
@@ -85,3 +85,8 @@
 #define RTL93XX_LED_SET_TX          (1 << 13)
 #define RTL93XX_LED_SET_COLLISION   (1 << 14)
 #define RTL93XX_LED_SET_DUPLEX      (1 << 15)
+
+/* LED Interface modes */
+#define RTL93XX_LED_MODE_SERIAL             1
+#define RTL93XX_LED_MODE_SINGLE_COLOR_SCAN  2
+#define RTL93XX_LED_MODE_BI_COLOR_SCAN      3

--- a/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
+++ b/target/linux/realtek/files-6.18/drivers/net/dsa/rtl83xx/rtl930x.c
@@ -2610,6 +2610,7 @@ static void rtl930x_led_init(struct rtl838x_switch_priv *priv)
 	struct device_node *node;
 	struct device *dev = priv->dev;
 	u8 leds_in_set[4] = {};
+	u32 led_mode = 1;
 	u32 pm = 0;
 
 	node = of_find_compatible_node(NULL, NULL, "realtek,rtl9300-leds");
@@ -2683,8 +2684,9 @@ static void rtl930x_led_init(struct rtl838x_switch_priv *priv)
 		sw_w32_mask(0, set << pos, RTL930X_LED_PORT_FIB_SET_SEL_CTRL(i));
 	}
 
-	/* Set LED mode to serial (0x1) */
-	sw_w32_mask(0x3, 0x1, RTL930X_LED_GLB_CTRL);
+	/* Set LED mode */
+	of_property_read_u32(node, "realtek,led-mode", &led_mode);
+	sw_w32_mask(0x3, led_mode & 0x3, RTL930X_LED_GLB_CTRL);
 
 	/* Set LED active state */
 	if (of_property_read_bool(node, "active-low"))


### PR DESCRIPTION
Add support for changing the LED mode via the device tree.

Currently it always defaults to SERIAL mode. With this change, one can also use the SINGLE_COLOR_SCAN and BI_COLOR_SCAN modes.