### PR TITLE
mediatek: fix typo in SPDX header (GL-2.0 -> GPL-2.0)

### DIFF
--- a/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1-common.dtsi
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1-common.dtsi
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (GL-2.0 OR MIT)
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
 
 /dts-v1/;
 #include <dt-bindings/input/input.h>

--- a/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1-ubi.dts
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1-ubi.dts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (GL-2.0 OR MIT)
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
 
 #include "mt7986b-mercusys-mr90x-v1-common.dtsi"
 

--- a/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1.dts
+++ b/target/linux/mediatek/dts/mt7986b-mercusys-mr90x-v1.dts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (GL-2.0 OR MIT)
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
 
 #include "mt7986b-mercusys-mr90x-v1-common.dtsi"
 

--- a/target/linux/mediatek/dts/mt7986b-tplink-re6000xd.dts
+++ b/target/linux/mediatek/dts/mt7986b-tplink-re6000xd.dts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: (GL-2.0 OR MIT)
+// SPDX-License-Identifier: (GPL-2.0 OR MIT)
 
 /dts-v1/;
 #include <dt-bindings/input/input.h>


### PR DESCRIPTION
Add a missing P in the license header.