### PR TITLE
kernel: add kmod-fb-tft-st7789v

### DIFF
--- a/package/kernel/linux/modules/video.mk
+++ b/package/kernel/linux/modules/video.mk
@@ -280,6 +280,22 @@ endef
 $(eval $(call KernelPackage,fb-tft-ili9486))
 
 
+define KernelPackage/fb-tft-st7789v
+  SUBMENU:=$(VIDEO_MENU)
+  TITLE:=FB driver for the ST7789V LCD Controller
+  DEPENDS:=+kmod-fb-tft
+  KCONFIG:=CONFIG_FB_TFT_ST7789V
+  FILES:=$(LINUX_DIR)/drivers/staging/fbtft/fb_st7789v.ko
+  AUTOLOAD:=$(call AutoLoad,09,fb_st7789v)
+endef
+
+define KernelPackage/fb-tft-st7789v/description
+  FB driver for the ST7789V LCD Controller
+endef
+
+$(eval $(call KernelPackage,fb-tft-st7789v))
+
+
 define KernelPackage/cec-core
   SUBMENU:=$(VIDEO_MENU)
   TITLE:=CEC framework


### PR DESCRIPTION
This module adds support for the Sitronix ST7789V LCD controller used in
devices like the Waveshare 1.14" LCD displays designed for Raspberry Pi
and the Ubiquiti UniFi Travel Router's built-in display.

Related #22740 
