### PR TITLE
ixp4xx-microcode: use snprintf in IxNpeMicrocode.h

### DIFF
--- a/package/firmware/ixp4xx-microcode/src/IxNpeMicrocode.h
+++ b/package/firmware/ixp4xx-microcode/src/IxNpeMicrocode.h
@@ -116,12 +116,14 @@ int main(int argc, char *argv[])
 		*(unsigned*)field = to_be32(image->id);
 		char filename[40], slnk[10];
 
-		sprintf(filename, "NPE-%c.%08x", (field[0] & 0xf) + 'A',
-			image->id);
+		snprintf(filename, sizeof(filename), "NPE-%c.%08x",
+			 (field[0] & 0xf) + 'A', image->id);
 		if (image->id == 0x00090000)
-			sprintf(slnk, "NPE-%c-HSS", (field[0] & 0xf) + 'A');
+			snprintf(slnk, sizeof(slnk), "NPE-%c-HSS",
+				 (field[0] & 0xf) + 'A');
 		else
-			sprintf(slnk, "NPE-%c", (field[0] & 0xf) + 'A');
+			snprintf(slnk, sizeof(slnk), "NPE-%c",
+				 (field[0] & 0xf) + 'A');
 
 		printf("Writing image: %s.NPE_%c Func: %2x Rev: %02x.%02x "
 			"Size: %5d to: '%s'\n",


### PR DESCRIPTION
## Summary

Replace `sprintf()` calls with `snprintf()` in the ixp4xx-microcode
host extraction tool (`IxNpeMicrocode.h`) to bound writes into the
fixed-size `filename[40]` and `slnk[10]` stack buffers.

This is a host-build utility (`hostcc`) that processes hash-pinned
firmware images. The change adds defense in depth — `snprintf` ensures
buffer writes are always bounded regardless of input.

## Changes

- `package/firmware/ixp4xx-microcode/src/IxNpeMicrocode.h`
  - `sprintf` → `snprintf` with `sizeof(buf)` for all three call sites
  - Lines reformatted to stay within 80-character limit

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*