### PR TITLE
[25.12] mediatek: filogic: add support for zbt-z8103ax-d

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax-c.dts
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax-c.dts
@@ -5,6 +5,6 @@
 #include "mt7981b-zbtlink-zbt-z8103ax.dtsi"
 
 / {
-	model = "Zbtlink 3000M(WiFi6) ZBT-Z8103AX-C";
+	model = "Zbtlink 3000M(WiFi6) ZBT-Z8103AX-C/D";
 	compatible = "zbtlink,zbt-z8103ax-c", "mediatek,mt7981b";
 };

--- a/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-zbtlink-zbt-z8103ax.dtsi
@@ -2,6 +2,11 @@
 
 /dts-v1/;
 
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
 #include "mt7981b.dtsi"
 
 / {
@@ -84,7 +89,6 @@
 			linux,default-trigger = "phy1tpt";
 		};
 	};
-		
 };
 
 &eth {
@@ -183,6 +187,10 @@
 		spi-max-frequency = <52000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -3240,6 +3240,8 @@ TARGET_DEVICES += zbtlink_zbt-z8103ax
 define Device/zbtlink_zbt-z8103ax-c
   DEVICE_VENDOR := Zbtlink
   DEVICE_MODEL := ZBT-Z8103AX-C
+  DEVICE_ALT0_VENDOR := Zbtlink
+  DEVICE_ALT0_MODEL := ZBT-Z8103AX-D
   DEVICE_DTS := mt7981b-zbtlink-zbt-z8103ax-c
   DEVICE_DTS_DIR := ../dts
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware


### PR DESCRIPTION
Backport device support for zbt-z8103ax-d to 25.12

Model D DTS is identical to Model C zbt-z8103ax-c. Both models share same motherboard.

Difference between models is

 - Model C is a cylinder shape enclosure containing internal antennas.
 - Model D is a sandwich shape enclosure with 6 external antennas.

Specifications:

SoC: MediaTek MT7981B
RAM: 256MiB
Flash: Winbond SPI-NAND 128 MiB
Switch: 1 WAN, 3 LAN (Gigabit) MediaTek MT7531
Buttons: Reset, Mesh
Power: DC 12V 1A
WiFi: MT7981B 2.4Ghz & 5.8Ghz

Led Layout from left to right:
| LED | control |
| --- | --- |
|   Power |
|   Mesh  | (RGB Led, user controllable, default set to OpenWrt Status)
|    WLAN 2.4G  |(user controllable)
|    WAN  | (user controllable)
|   LAN3 |
|    LAN2 |
|   LAN1 |
|    WLAN 5G | (user controllable)

Installation:

A. Through U-Boot menu:

    - Prepare your connecting computer to use a static IP in network 192.168.1.0/24
    - Power down the router and hold in the Reset button.
    - While holding in the button power up the router again.
    - Hold the button in for 10 seconds and then release.
    - Use your browser to go to 192.168.1.1
    - If you see a GUI allowing for flashing firmware then you got the right model.
    - Upload the **Factory** image file.

Note: U-Boot GUI it can be used to recover from an incorrect firmware flash.

B. Through OpenWrt Dashboard:

    If your router comes with OpenWrt preinstalled (modified by the seller),
    you can easily upgrade by going to the dashboard (192.168.1.1) and then navigate to
    System -> Backup/Flash firmware, then flash the firmware

MAC Addresses:

MAC Addresses were found in Factory partition:
| Offset | MAC| Label |
| --- | --- | --- |
|offset 0x4 |  F8:5E:3C:xx:xx:aa | --> Router Label -2
|offset 0xa | F8:5E:3C:xx:xx:bb | --> Router Label -1
|offset 0x24 | F8:5E:3C:xx:xx:cc | --> Router Label +1
|offset 0x2a  |F8:5E:3C:xx:xx:yy | --> printed on Router Label

<details>

<summary>OpenWRT Boot log</summary>

[bootlog.txt](https://github.com/user-attachments/files/27171541/bootlog.txt)

</details>
