### PR TITLE
ramips: enable U-Boot env access for Zyxel NWA50AX/NWA55AXE

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -60,6 +60,8 @@ linksys,e7350|\
 netgear,eax12|\
 netgear,wax202|\
 netis,n6|\
+zyxel,nwa50ax|\
+zyxel,nwa55axe|\
 zyxel,wsm20)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;

--- a/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
+++ b/target/linux/ramips/dts/mt7621_zyxel_nwa-ax.dtsi
@@ -33,7 +33,6 @@
 		partition@80000 {
 			label = "u-boot-env";
 			reg = <0x80000 0x80000>;
-			read-only;
 		};
 
 		partition@100000 {


### PR DESCRIPTION
These three devices share mt7621_zyxel_nwa-ax.dtsi and run a vendor U-Boot 2018.09 build with MediaTek's custom NMBM env driver. The env_nmbm_load function in the vendor U-Boot binary reads the env from NMBM offset 0x80000 with size 0x20000 (i.e. offset 0 of the u-boot-env partition, one 128 KB erase block), so fw_env can use the partition directly:

  ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"

Drop read-only from the u-boot-env partition in the shared DTSI so fw_setenv can write back. The factory partition keeps its read-only flag; the env partition ships blank from the factory (no saveenv has ever been run) so fw_printenv will still warn "Bad CRC, using default environment" until a fw_setenv call populates it, which is expected and matches mainline U-Boot behaviour on an empty env area.

Tested and validated on a NWA55AXE, first fw_printenv shows `Warning: Bad CRC, using default environment`.
First fw_setenv also shows `Warning: Bad CRC, using default environment` but sets and initializes correctly.

Link to forum post about this problem: https://forum.openwrt.org/t/zyxel-nwa55axe-etc-fw-env-config-no-such-file-or-directory/249187/15
Related issue: https://github.com/openwrt/openwrt/issues/23214