### PR TITLE
ramips: enable fw_printenv for D-Link COVR-X1860 A1

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/ramips
+++ b/package/boot/uboot-tools/uboot-envtools/files/ramips
@@ -44,6 +44,9 @@ arcadyan,we420223-99|\
 dlink,dir-806a-b1)
 	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x1000" "0x1000"
 	;;
+dlink,covr-x1860-a1)
+	ubootenv_add_uci_config "/dev/mtd1" "0x2000" "0x4000" "0x2000"
+	;;
 asus,rt-ax53u|\
 asus,rt-ax54|\
 asus,4g-ax56|\


### PR DESCRIPTION
Vendor U-Boot stores its environment at offset 0x2000 inside the "config" partition (size 0x4000). The offset is not erase-block aligned, so the fw_env tool's alignment check rejects the natural secsize=0x20000. Declaring secsize=0x2000 passes the check, lets fw_printenv read the real env (factory_mac, hw_version, bundle_number, ...), and causes fw_setenv to fail cleanly on erase rather than corrupting anything (the kernel rejects sub-erase-block MEMERASE).

`fw_setenv` does not work however, as this does not allow having an offset which is not aligned.
Therefore, the /dev/mtd1 partition is kept readonly.

Tested on a D-Link COVR X1860.