### PR TITLE
realtek: change clk and mach to use __raw reads and writes

### DIFF
--- a/target/linux/realtek/files-6.18/arch/mips/include/asm/mach-rtl-otto/mach-rtl-otto.h
+++ b/target/linux/realtek/files-6.18/arch/mips/include/asm/mach-rtl-otto/mach-rtl-otto.h
@@ -15,8 +15,8 @@
 
 #define RTL838X_SW_BASE			((volatile void *) 0xBB000000)
 
-#define sw_r32(reg)			readl(RTL838X_SW_BASE + reg)
-#define sw_w32(val, reg)		writel(val, RTL838X_SW_BASE + reg)
+#define sw_r32(reg)			__raw_readl(RTL838X_SW_BASE + reg)
+#define sw_w32(val, reg)		__raw_writel(val, RTL838X_SW_BASE + reg)
 #define sw_w32_mask(clear, set, reg)	sw_w32((sw_r32(reg) & ~(clear)) | (set), reg)
 
 #define RTL838X_MODEL_NAME_INFO		(0x00D4)

--- a/target/linux/realtek/files-6.18/arch/mips/rtl-otto/prom.c
+++ b/target/linux/realtek/files-6.18/arch/mips/rtl-otto/prom.c
@@ -35,8 +35,8 @@
 
 #define RTL931X_DRAM_CONFIG		0x14304c
 
-#define soc_r32(reg)			readl(RTL_SOC_BASE + reg)
-#define soc_w32(val, reg)		writel(val, RTL_SOC_BASE + reg)
+#define soc_r32(reg)			__raw_readl(RTL_SOC_BASE + reg)
+#define soc_w32(val, reg)		__raw_writel(val, RTL_SOC_BASE + reg)
 
 struct rtl83xx_soc_info soc_info;
 EXPORT_SYMBOL(soc_info);

--- a/target/linux/realtek/files-6.18/drivers/clk/realtek/clk-rtl83xx.c
+++ b/target/linux/realtek/files-6.18/drivers/clk/realtek/clk-rtl83xx.c
@@ -80,11 +80,11 @@
 
 #include "clk-rtl83xx.h"
 
-#define read_sw(reg)		ioread32(((void *)RTL_SW_CORE_BASE) + reg)
-#define read_soc(reg)		ioread32(((void *)RTL_SOC_BASE) + reg)
+#define read_sw(reg)		__raw_readl(((void *)RTL_SW_CORE_BASE) + reg)
+#define read_soc(reg)		__raw_readl(((void *)RTL_SOC_BASE) + reg)
 
-#define write_sw(val, reg)	iowrite32(val, ((void *)RTL_SW_CORE_BASE) + reg)
-#define write_soc(val, reg)	iowrite32(val, ((void *)RTL_SOC_BASE) + reg)
+#define write_sw(val, reg)	__raw_writel(val, ((void *)RTL_SW_CORE_BASE) + reg)
+#define write_soc(val, reg)	__raw_writel(val, ((void *)RTL_SOC_BASE) + reg)
 
 /*
  * some hardware specific definitions


### PR DESCRIPTION
As it stands, `readl/writel` and `ioread32/iowrite32` are really not intended for native endian register access and enabling `CONFIG_SWAP_IO_SPACE` breaks it.

This series addresses this by changing these to a `__raw` variants, which are what upstream uses for accessing registers in native endian.