### PR TITLE
ipq806x: ap3935: disable hibernation on LAN1

### DIFF
--- a/target/linux/ipq806x/dts/qcom-ipq8068-ap3935.dts
+++ b/target/linux/ipq806x/dts/qcom-ipq8068-ap3935.dts
@@ -314,6 +314,7 @@
 
 	phy1: ethernet-phy@1 {
 		reg = <1>;
+		qca,disable-hibernation-mode;
 	};
 
 	phy2: ethernet-phy@2 {


### PR DESCRIPTION
The Extreme Networks AP3935's LAN1 port (gmac0/RGMII to AR8035 at MDIO addr 1) fails to acquire a link if no Ethernet cable is connected at power-on; the port stays dead even after a cable is later inserted, and only a network restart recovers it.

The AR803x family enables hibernation mode by default, this setting overrides it.

I compared the power consumption impact on an AP that is running Gluon v2025.1.x (OpenWrt 24.10) with both client and WiFi mesh on and active. Measured was with a simple Shelly plug:

### Hibernation enabled/stock (OpenWrt 24.10)

After Boot:

* 6.8W no cable
* ~10W no cable + WiFi load
* 7.2W with only LAN2

After /etc/init.d/network restart (the current workaround to get LAN1 to work):

* 7.2W only LAN1 
* ~12W only LAN1 under WiFi load
* ~8W both LAN1+LAN2

### Hibernation disabled (OpenWrt 24.10)

After Boot:

* 7W no cable
* ~10W no cable + WiFi load
* 7.2W with LAN1
* 7.5W with LAN2
* 7.7W both LAN1+LAN2


This fixes #17635