### PR TITLE
kirkwood: add support for Zyxel NSA320

### DIFF
--- a/package/boot/uboot-kirkwood/Makefile
+++ b/package/boot/uboot-kirkwood/Makefile
@@ -90,6 +90,11 @@ define U-Boot/nsa310s
   BUILD_DEVICES:=zyxel_nsa310s
 endef
 
+define U-Boot/nsa320
+  NAME:=Zyxel NSA320
+  BUILD_DEVICES:=zyxel_nsa320
+endef
+
 define U-Boot/nsa325
   NAME:=Zyxel NSA325v1 and v2
   BUILD_DEVICES:=zyxel_nsa325
@@ -127,6 +132,7 @@ UBOOT_TARGETS := \
 	netgear_ms2110 \
 	nsa310 \
 	nsa310s \
+	nsa320 \
 	nsa325 \
 	pogo_e02 pogo_e02_second_stage \
 	pogoplugv4 \

--- a/package/boot/uboot-kirkwood/patches/009-nsa320-uboot-generic.patch
+++ b/package/boot/uboot-kirkwood/patches/009-nsa320-uboot-generic.patch
@@ -1,0 +1,685 @@
+--- a/arch/arm/mach-kirkwood/Kconfig
++++ b/arch/arm/mach-kirkwood/Kconfig
+@@ -68,6 +68,9 @@
+ config TARGET_NSA310S
+ 	bool "Zyxel NSA310S"
+ 
++config TARGET_NSA320
++	bool "Zyxel NSA320"
++
+ config TARGET_SBx81LIFKW
+ 	bool "Allied Telesis SBx81GS24/SBx81GT40/SBx81XS6/SBx81XS16"
+ 
+@@ -109,6 +112,7 @@
+ source "board/Seagate/nas220/Kconfig"
+ source "board/zyxel/nsa310/Kconfig"
+ source "board/zyxel/nsa310s/Kconfig"
++source "board/zyxel/nsa320/Kconfig"
+ source "board/zyxel/nsa325/Kconfig"
+ source "board/alliedtelesis/SBx81LIFKW/Kconfig"
+ source "board/alliedtelesis/SBx81LIFXCAT/Kconfig"
+--- /dev/null
++++ b/board/zyxel/nsa320/Kconfig
+@@ -0,0 +1,12 @@
++if TARGET_NSA320
++
++config SYS_BOARD
++	default "nsa320"
++
++config SYS_VENDOR
++	default "zyxel"
++
++config SYS_CONFIG_NAME
++	default "nsa320"
++
++endif
+--- /dev/null
++++ b/board/zyxel/nsa320/kwbimage.cfg
+@@ -0,0 +1,164 @@
++#
++# Based on guruplug.c originally written by
++# Siddarth Gore <gores@marvell.com>
++# (C) Copyright 2009
++# Marvell Semiconductor <www.marvell.com>
++#
++# See file CREDITS for list of people who contributed to this
++# project.
++#
++# This program is free software; you can redistribute it and/or
++# modify it under the terms of the GNU General Public License as
++# published by the Free Software Foundation; either version 2 of
++# the License, or (at your option) any later version.
++#
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program; if not, write to the Free Software
++# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
++# MA 02110-1301 USA
++#
++# Refer docs/README.kwimage for more details about how-to configure
++# and create kirkwood boot image
++#
++
++# Boot Media configurations
++BOOT_FROM	nand
++# BOOT_FROM	uart
++NAND_ECC_MODE	default
++NAND_PAGE_SIZE	0x0800
++
++# SOC registers configuration using bootrom header extension
++# Maximum KWBIMAGE_MAX_CONFIG configurations allowed
++
++# Configure RGMII-0 interface pad voltage to 1.8V
++DATA 0xFFD100e0 0x1b1b1b9b
++
++#Dram initalization for SINGLE x16 CL=5 @ 400MHz
++DATA 0xFFD01400 0x43000c30	# DDR Configuration register
++# bit13-0:  0xc30 (3120 DDR2 clks refresh rate)
++# bit23-14: zero
++# bit24: 1= enable exit self refresh mode on DDR access
++# bit25: 1 required
++# bit29-26: zero
++# bit31-30: 01
++
++DATA 0xFFD01404 0x37543000	# DDR Controller Control Low
++# bit 4:    0=addr/cmd in smame cycle
++# bit 5:    0=clk is driven during self refresh, we don't care for APX
++# bit 6:    0=use recommended falling edge of clk for addr/cmd
++# bit14:    0=input buffer always powered up
++# bit18:    1=cpu lock transaction enabled
++# bit23-20: 5=recommended value for CL=5 and STARTBURST_DEL disabled bit31=0
++# bit27-24: 7= CL+2, STARTBURST sample stages, for freqs 400MHz, unbuffered DIMM
++# bit30-28: 3 required
++# bit31:    0=no additional STARTBURST delay
++
++DATA 0xFFD01408 0x22125451	# DDR Timing (Low) (active cycles value +1)
++# bit3-0:   TRAS lsbs
++# bit7-4:   TRCD
++# bit11- 8: TRP
++# bit15-12: TWR
++# bit19-16: TWTR
++# bit20:    TRAS msb
++# bit23-21: 0x0
++# bit27-24: TRRD
++# bit31-28: TRTP
++
++DATA 0xFFD0140C 0x00000a33	#  DDR Timing (High)
++# bit6-0:   TRFC
++# bit8-7:   TR2R
++# bit10-9:  TR2W
++# bit12-11: TW2W
++# bit31-13: zero required
++
++DATA 0xFFD01410 0x000000cc	#  DDR Address Control
++# bit1-0:   01, Cs0width=x8
++# bit3-2:   10, Cs0size=1Gb
++# bit5-4:   01, Cs1width=x8
++# bit7-6:   10, Cs1size=1Gb
++# bit9-8:   00, Cs2width=nonexistent
++# bit11-10: 00, Cs2size =nonexistent
++# bit13-12: 00, Cs3width=nonexistent
++# bit15-14: 00, Cs3size =nonexistent
++# bit16:    0,  Cs0AddrSel
++# bit17:    0,  Cs1AddrSel
++# bit18:    0,  Cs2AddrSel
++# bit19:    0,  Cs3AddrSel
++# bit31-20: 0 required
++
++DATA 0xFFD01414 0x00000000	#  DDR Open Pages Control
++# bit0:    0,  OpenPage enabled
++# bit31-1: 0 required
++
++DATA 0xFFD01418 0x00000000	#  DDR Operation
++# bit3-0:   0x0, DDR cmd
++# bit31-4:  0 required
++
++DATA 0xFFD0141C 0x00000C52	#  DDR Mode
++# bit2-0:   2, BurstLen=2 required
++# bit3:     0, BurstType=0 required
++# bit6-4:   4, CL=5
++# bit7:     0, TestMode=0 normal
++# bit8:     0, DLL reset=0 normal
++# bit11-9:  6, auto-precharge write recovery ????????????
++# bit12:    0, PD must be zero
++# bit31-13: 0 required
++
++DATA 0xFFD01420 0x00000040	#  DDR Extended Mode
++# bit0:    0,  DDR DLL enabled
++# bit1:    0,  DDR drive strenght normal
++# bit2:    0,  DDR ODT control lsd (disabled)
++# bit5-3:  000, required
++# bit6:    1,  DDR ODT control msb, (disabled)
++# bit9-7:  000, required
++# bit10:   0,  differential DQS enabled
++# bit11:   0, required
++# bit12:   0, DDR output buffer enabled
++# bit31-13: 0 required
++
++DATA 0xFFD01424 0x0000F17F	#  DDR Controller Control High
++# bit2-0:  111, required
++# bit3  :  1  , MBUS Burst Chop disabled
++# bit6-4:  111, required
++# bit7  :  0
++# bit8  :  1  , add writepath sample stage, must be 1 for DDR freq >= 300MHz
++# bit9  :  0  , no half clock cycle addition to dataout
++# bit10 :  0  , 1/4 clock cycle skew enabled for addr/ctl signals
++# bit11 :  0  , 1/4 clock cycle skew disabled for write mesh
++# bit15-12: 1111 required
++# bit31-16: 0    required
++
++DATA 0xFFD01428 0x00085520	# DDR2 ODT Read Timing (default values)
++DATA 0xFFD0147C 0x00008552	# DDR2 ODT Write Timing (default values)
++
++DATA 0xFFD01500 0x00000000	# CS[0]n Base address to 0x0
++DATA 0xFFD01504 0x0FFFFFF1	# CS[0]n Size
++# bit0:    1,  Window enabled
++# bit1:    0,  Write Protect disabled
++# bit3-2:  00, CS0 hit selected
++# bit23-4: ones, required
++# bit31-24: 0x0F, Size (i.e. 256MB)
++
++DATA 0xFFD01508 0x10000000	# CS[1]n Base address to 256Mb
++DATA 0xFFD0150C 0x0FFFFFF5	# CS[1]n Size 256Mb Window enabled for CS1
++
++DATA 0xFFD01514 0x00000000	# CS[2]n Size, window disabled
++DATA 0xFFD0151C 0x00000000	# CS[3]n Size, window disabled
++
++DATA 0xFFD01494 0x00030000	#  DDR ODT Control (Low)
++DATA 0xFFD01498 0x00000000	#  DDR ODT Control (High)
++# bit1-0:  00, ODT0 controlled by ODT Control (low) register above
++# bit3-2:  01, ODT1 active NEVER!
++# bit31-4: zero, required
++
++DATA 0xFFD0149C 0x0000E803	# CPU ODT Control
++DATA 0xFFD01480 0x00000001	# DDR Initialization Control
++#bit0=1, enable DDR init upon this register write
++
++# End of Header extension
++DATA 0x0 0x0
+--- /dev/null
++++ b/board/zyxel/nsa320/MAINTAINERS
+@@ -0,0 +1,6 @@
++NSA320 BOARD
++M:	Jason Plum <jplum@archlinuxarm.org>
++S:	Maintained
++F:	board/zyxel/nsa320/
++F:	include/configs/nsa320.h
++F:	configs/nsa320_defconfig
+--- /dev/null
++++ b/board/zyxel/nsa320/Makefile
+@@ -0,0 +1,14 @@
++#
++# (C) Copyright 2015 bodhi <mibodhi@gmail.com>
++#
++# Based on
++# (C) Copyright 2009
++# Marvell Semiconductor <www.marvell.com>
++# Written-by: Prafulla Wadaskar <prafulla@marvell.com>
++#
++# SPDX-License-Identifier:	GPL-2.0+
++#
++
++obj-y	:= nsa320.o
++
++
+--- /dev/null
++++ b/board/zyxel/nsa320/nsa320.c
+@@ -0,0 +1,218 @@
++/*
++ * Copyright (C) 2015-2017  bodhi <mibodhi@gmail.com>
++ *
++ * Based on
++ * Copyright (C) 2012  Peter Schildmann <linux@schildmann.info>
++ *
++ * Based on guruplug.c originally written by
++ * Siddarth Gore <gores@marvell.com>
++ * (C) Copyright 2009
++ * Marvell Semiconductor <www.marvell.com>
++ *
++ * See file CREDITS for list of people who contributed to this
++ * project.
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License as
++ * published by the Free Software Foundation; either version 2 of
++ * the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
++ * MA 02110-1301 USA
++ */
++
++#include <common.h>
++#include <miiphy.h>
++#include <asm/arch/soc.h>
++#include <asm/arch/mpp.h>
++#include <asm/arch/cpu.h>
++#include <asm/gpio.h>
++#include <asm/io.h>
++#include "nsa320.h"
++
++
++DECLARE_GLOBAL_DATA_PTR;
++
++int board_early_init_f(void)
++{
++	/*
++	 * default gpio configuration
++	 * There are maximum 64 gpios controlled through 2 sets of registers
++	 * the below configuration configures mainly initial LED status
++	 */
++	mvebu_config_gpio(NSA320_VAL_LOW, NSA320_VAL_HIGH,
++		       NSA320_OE_LOW, NSA320_OE_HIGH);
++
++	/* Multi-Purpose Pins Functionality configuration */
++	/* (all LEDs & power off active high) */
++	u32 kwmpp_config[] = {
++		MPP0_NF_IO2,
++		MPP1_NF_IO3,
++		MPP2_NF_IO4,
++		MPP3_NF_IO5,
++		MPP4_NF_IO6,
++		MPP5_NF_IO7,
++		MPP6_SYSRST_OUTn,
++		MPP7_GPO,
++		MPP8_TW_SDA,		/* PCF8563 RTC chip   */
++		MPP9_TW_SCK,		/* connected to TWSI  */
++		MPP10_UART0_TXD,
++		MPP11_UART0_RXD,
++		MPP12_GPO,		/* HDD2 LED (green)   */
++		MPP13_GPIO,		/* HDD2 LED (red)     */
++		MPP14_GPIO,		/* MCU DATA pin (in)  */
++		MPP15_GPIO,		/* USB LED (green)    */
++		MPP16_GPIO,		/* MCU CLK pin (out)  */
++		MPP17_GPIO,		/* MCU ACT pin (out)  */
++		MPP18_NF_IO0,
++		MPP19_NF_IO1,
++		MPP20_GPIO,
++		MPP21_GPIO,		/* USB power          */
++		MPP22_GPIO,
++		MPP23_GPIO,
++		MPP24_GPIO,
++		MPP25_GPIO,
++		MPP26_GPIO,
++		MPP27_GPIO,
++		MPP28_GPIO,		/* SYS LED (green)    */
++		MPP29_GPIO,		/* SYS LED (orange)   */
++		MPP30_GPIO,
++		MPP31_GPIO,
++		MPP32_GPIO,
++		MPP33_GPIO,
++		MPP34_GPIO,
++		MPP35_GPIO,
++		MPP36_GPIO,		/* reset button       */
++		MPP37_GPIO,		/* copy button        */
++		MPP38_GPIO,		/* VID B0             */
++		MPP39_GPIO,		/* COPY LED (green)   */
++		MPP40_GPIO,		/* COPY LED (red)     */
++		MPP41_GPIO,		/* HDD1 LED (green)   */
++		MPP42_GPIO,		/* HDD1 LED (red)     */
++		MPP43_GPIO,		/* HTP pin            */
++		MPP44_GPIO,		/* buzzer             */
++		MPP45_GPIO,		/* VID B1             */
++		MPP46_GPIO,		/* power button       */
++		MPP47_GPIO,		/* power resume data  */
++		MPP48_GPIO,		/* power off          */
++		MPP49_GPIO,		/* power resume clock */
++		0
++	};
++	kirkwood_mpp_conf(kwmpp_config, NULL);
++	return 0;
++}
++
++int board_init(void)
++{
++	/* address of boot parameters */
++	gd->bd->bi_boot_params = mvebu_sdram_bar(0) + 0x100;
++
++	return 0;
++}
++
++#ifdef CONFIG_RESET_PHY_R
++/* Configure and enable MV88E1318 PHY */
++void reset_phy(void)
++{
++	u16 reg;
++	u16 devadr;
++	char *name = "egiga0";
++
++	if (miiphy_set_current_dev(name))
++		return;
++
++	/* command to read PHY dev address */
++	if (miiphy_read(name, 0xEE, 0xEE, (u16 *) &devadr)) {
++		printf("Err..%s could not read PHY dev address\n",
++			__FUNCTION__);
++		return;
++	}
++
++	/* Set RGMII delay */
++	miiphy_write(name, devadr, MV88E1318_PGADR_REG, 2);
++	miiphy_read(name, devadr, MV88E1318_MAC_CTRL_REG, &reg);
++	reg |= (MV88E1318_RGMII_RXTM_CTRL | MV88E1318_RGMII_TXTM_CTRL);
++	miiphy_write(name, devadr, MV88E1318_MAC_CTRL_REG, reg);
++	miiphy_write(name, devadr, MV88E1318_PGADR_REG, 0);
++
++	/* reset the phy */
++	miiphy_reset(name, devadr);
++
++	/* The ZyXEL NSA320 uses the 88E1310 Alaska  */
++	/* and has an MCU attached to the LED[2] via tristate interrupt */
++	reg = 0;
++
++	/* switch to LED register page */
++	miiphy_write(name, devadr, MV88E1318_PGADR_REG, MV88E1318_LED_PG);
++	/* read out LED polarity register */
++	miiphy_read(name, devadr, MV88E1318_LED_POL_REG, &reg);
++	/* clear 4, set 5 - LED2 low, tri-state */
++	reg &= ~(MV88E1318_LED2_4);
++	reg |= (MV88E1318_LED2_5);
++	/* write back LED polarity register */
++	miiphy_write(name, devadr, MV88E1318_LED_POL_REG, reg);
++	/* jump back to page 0, per the PHY chip documenation. */
++	miiphy_write(name, devadr, MV88E1318_PGADR_REG, 0);
++
++	/* Set the phy back to auto-negotiation mode */
++	miiphy_write(name, devadr, 0x4, 0x1e1);
++	miiphy_write(name, devadr, 0x9, 0x300);
++	/* Downshift */
++	miiphy_write(name, devadr, 0x10, 0x3860);
++	miiphy_write(name, devadr, 0x0, 0x9140);
++
++	printf("MV88E1318 PHY initialized on %s\n", name);
++}
++#endif /* CONFIG_RESET_PHY_R */
++
++#ifdef CONFIG_SHOW_BOOT_PROGRESS
++void show_boot_progress(int val)
++{
++	struct kwgpio_registers *gpio0 = (struct kwgpio_registers *)MVEBU_GPIO0_BASE;
++	u32 dout0 = readl(&gpio0->dout);
++	u32 blen0 = readl(&gpio0->blink_en);
++
++	struct kwgpio_registers *gpio1 = (struct kwgpio_registers *)MVEBU_GPIO1_BASE;
++	u32 dout1 = readl(&gpio1->dout);
++	u32 blen1 = readl(&gpio1->blink_en);
++
++	switch (val) {
++	case BOOTSTAGE_ID_DECOMP_IMAGE:
++		writel(blen0 & ~(SYS_GREEN_LED | SYS_ORANGE_LED), &gpio0->blink_en);
++		writel((dout0 & ~SYS_GREEN_LED) | SYS_ORANGE_LED, &gpio0->dout);
++		break;
++	case BOOTSTAGE_ID_RUN_OS:
++		writel(dout0 & ~SYS_ORANGE_LED, &gpio0->dout);
++		writel(blen0 | SYS_GREEN_LED, &gpio0->blink_en);
++		break;
++	case BOOTSTAGE_ID_NET_START:
++		writel(dout1 & ~COPY_RED_LED, &gpio1->dout);
++		writel((blen1 & ~COPY_RED_LED) | COPY_GREEN_LED, &gpio1->blink_en);
++		break;
++	case BOOTSTAGE_ID_NET_LOADED:
++		writel(blen1 & ~(COPY_RED_LED | COPY_GREEN_LED), &gpio1->blink_en);
++		writel((dout1 & ~COPY_RED_LED) | COPY_GREEN_LED, &gpio1->dout);
++		break;
++	case -BOOTSTAGE_ID_NET_NETLOOP_OK:
++	case -BOOTSTAGE_ID_NET_LOADED:
++		writel(dout1 & ~COPY_GREEN_LED, &gpio1->dout);
++		writel((blen1 & ~COPY_GREEN_LED) | COPY_RED_LED, &gpio1->blink_en);
++		break;
++	default:
++		if (val < 0) {
++			/* error */
++			printf("Error occured, error code = %d\n", -val);
++			writel(dout0 & ~SYS_GREEN_LED, &gpio0->dout);
++			writel(blen0 | SYS_ORANGE_LED, &gpio0->blink_en);
++		}
++		break;
++	}
++}
++#endif
+--- /dev/null
++++ b/board/zyxel/nsa320/nsa320.h
+@@ -0,0 +1,69 @@
++/*
++ * Copyright (C) 2012  Peter Schildmann <linux@schildmann.info>
++ *
++ * Based on guruplug.h originally written by
++ * Siddarth Gore <gores@marvell.com>
++ * (C) Copyright 2009
++ * Marvell Semiconductor <www.marvell.com>
++ *
++ * See file CREDITS for list of people who contributed to this
++ * project.
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License as
++ * published by the Free Software Foundation; either version 2 of
++ * the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
++ * MA 02110-1301 USA
++ */
++
++#ifndef __NSA320_H
++#define __NSA320_H
++
++/* low GPIO's */
++#define HDD2_GREEN_LED		(1 << 12)
++#define HDD2_RED_LED		(1 << 13)
++#define USB_GREEN_LED		(1 << 15)
++#define USB_POWER		(1 << 21)
++#define SYS_GREEN_LED		(1 << 28)
++#define SYS_ORANGE_LED		(1 << 29)
++
++#define PIN_USB_GREEN_LED	15
++#define PIN_USB_POWER		21
++
++#define NSA320_OE_LOW		(~(HDD2_GREEN_LED | HDD2_RED_LED | \
++				   USB_GREEN_LED | USB_POWER | \
++				   SYS_GREEN_LED | SYS_ORANGE_LED))
++#define NSA320_VAL_LOW		(SYS_GREEN_LED | USB_POWER)
++
++/* high GPIO's */
++#define COPY_GREEN_LED		(1 << 7)
++#define COPY_RED_LED		(1 << 8)
++#define HDD1_GREEN_LED		(1 << 9)
++#define HDD1_RED_LED		(1 << 10)
++
++#define NSA320_OE_HIGH		(~(COPY_GREEN_LED | COPY_RED_LED | \
++				   HDD1_GREEN_LED | HDD1_RED_LED))
++#define NSA320_VAL_HIGH		(0)
++
++/* PHY related */
++#define MV88E1318_PGADR_REG		22
++#define MV88E1318_MAC_CTRL_REG	21
++#define MV88E1318_MAC_CTRL_PG	2
++#define MV88E1318_RGMII_TXTM_CTRL	(1 << 4)
++#define MV88E1318_RGMII_RXTM_CTRL	(1 << 5)
++#define MV88E1318_LED_PG        3
++#define MV88E1318_LED_POL_REG	17
++#define MV88E1318_LED2_4	    (1 << 4)
++#define MV88E1318_LED2_5	    (1 << 5)
++
++
++#endif /* __NSA320_H */
+--- /dev/null
++++ b/configs/nsa320_defconfig
+@@ -0,0 +1,48 @@
++CONFIG_ARM=y
++CONFIG_SYS_DCACHE_OFF=y
++CONFIG_ARCH_CPU_INIT=y
++CONFIG_KIRKWOOD=y
++CONFIG_SYS_TEXT_BASE=0x600000
++CONFIG_TARGET_NSA320=y
++CONFIG_SYS_PROMPT="NSA320> "
++CONFIG_IDENT_STRING="\nZyxel NSA320 2-Bay Power Media Server"
++CONFIG_NR_DRAM_BANKS=2
++CONFIG_BOOTDELAY=3
++# CONFIG_CMD_IMLS is not set
++# CONFIG_CMD_FLASH is not set
++CONFIG_MVGBE=y
++CONFIG_MII=y
++CONFIG_SYS_NS16550=y
++CONFIG_CMD_FDT=y
++CONFIG_OF_LIBFDT=y
++CONFIG_CMD_SETEXPR=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_MII=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_USB=y
++CONFIG_CMD_DATE=y
++CONFIG_CMD_EXT2=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_FAT=y
++CONFIG_CMD_JFFS2=y
++CONFIG_MTD=y
++CONFIG_MTD_RAW_NAND=y
++CONFIG_MTDPARTS_DEFAULT="mtdparts=orion_nand:0x0c0000(uboot),0x80000(uboot_env),0x7ec0000(ubi)"
++CONFIG_CMD_MTDPARTS=y
++CONFIG_CMD_ENV=y
++CONFIG_CMD_NAND=y
++CONFIG_EFI_PARTITION=y
++CONFIG_ENV_IS_IN_NAND=y
++CONFIG_ENV_SIZE=0x20000
++CONFIG_ENV_OFFSET=0xC0000
++CONFIG_ENV_SECT_SIZE=0x20000
++CONFIG_ENV_ADDR=0xC0000
++CONFIG_CMD_UBI=y
++CONFIG_USB_STORAGE=y
++CONFIG_USB=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_LZMA=y
++CONFIG_LZO=y
++CONFIG_SYS_LONGHELP=y
+--- /dev/null
++++ b/include/configs/nsa320.h
+@@ -0,0 +1,110 @@
++/*
++ * Copyright (C) 2015-2017  bodhi <mibodhi@gmail.com>
++ *
++ * Based on 
++ * Copyright (C) 2012  Peter Schildmann <linux@schildmann.info>
++ *
++ * Based on guruplug.h originally written by
++ * Siddarth Gore <gores@marvell.com>
++ * (C) Copyright 2009
++ * Marvell Semiconductor <www.marvell.com>
++ *
++ * See file CREDITS for list of people who contributed to this
++ * project.
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License as
++ * published by the Free Software Foundation; either version 2 of
++ * the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
++ * MA 02110-1301 USA
++ */
++
++#ifndef _CONFIG_NSA320_H
++#define _CONFIG_NSA320_H
++
++/*
++ * High Level Configuration Options (easy to change)
++ */
++#define CONFIG_FEROCEON_88FR131	1	/* CPU Core subversion */
++#define CONFIG_KIRKWOOD		1	/* SOC Family Name */
++#define CONFIG_KW88F6281	1	/* SOC Name */
++#define CONFIG_MACH_NSA320		/* Machine type */
++#define CONFIG_MACH_TYPE	MACH_TYPE_NSA320
++#define CONFIG_SKIP_LOWLEVEL_INIT	/* disable board lowlevel_init */
++
++/*
++ * Misc Configuration Options
++ */
++#define CONFIG_SHOW_BOOT_PROGRESS 1	/* boot progess display (LED's) */
++
++/*
++ * Commands configuration
++ */
++#define CONFIG_SYS_NO_FLASH             /* Declare no flash (NOR/SPI) */
++#define CONFIG_SYS_MVFS                 /* Picks up Filesystem from mv-common.h */
++#define CONFIG_CMD_ENV
++#define CONFIG_PREBOOT
++#define CONFIG_SYS_HUSH_PARSER
++#define CONFIG_SYS_PROMPT_HUSH_PS2 "> "
++/*
++ * mv-common.h should be defined after CMD configs since it used them
++ * to enable certain macros
++ */
++#include "mv-common.h"
++
++/*
++ * Default environment variables
++ */
++#define CONFIG_BOOTCOMMAND \
++    "ubi part ubi; " \
++    "ubi read 0x800000 kernel; " \
++    "bootm 0x800000"
++
++#define CONFIG_EXTRA_ENV_SETTINGS \
++    "console=console=ttyS0,115200\0"        \
++    "mtdids=nand0=orion_nand\0"             \
++    "mtdparts="CONFIG_MTDPARTS_DEFAULT "\0" \
++    "bootargs_root=\0"
++
++/*
++ * Ethernet Driver configuration
++ */
++#ifdef CONFIG_CMD_NET
++#define CONFIG_MVGBE_PORTS		{1, 0}	/* enable port 0 only */
++#define CONFIG_PHY_BASE_ADR		0x1
++#define CONFIG_NETCONSOLE
++#endif /* CONFIG_CMD_NET */
++
++/*
++ * SATA Driver configuration
++ */
++#ifdef CONFIG_MVSATA_IDE
++#define CONFIG_SYS_ATA_IDE0_OFFSET      MV_SATA_PORT0_OFFSET
++#define CONFIG_SYS_ATA_IDE1_OFFSET      MV_SATA_PORT1_OFFSET
++#endif /* CONFIG_MVSATA_IDE */
++
++/*
++ * File system
++ */
++#define CONFIG_JFFS2_NAND
++#define CONFIG_JFFS2_LZO
++
++/*
++ *  Date Time
++ */
++#ifdef CONFIG_CMD_DATE
++#define CONFIG_RTC_MV
++#endif /* CONFIG_CMD_DATE */
++
++#define CONFIG_KIRKWOOD_GPIO /* Enable GPIO Support */
++
++#endif /* _CONFIG_NSA320_H */

--- a/package/boot/uboot-tools/uboot-envtools/files/kirkwood
+++ b/package/boot/uboot-tools/uboot-envtools/files/kirkwood
@@ -27,6 +27,7 @@ raidsonic,ib-nas62x0|\
 seagate,dockstar|\
 zyxel,nsa310b|\
 zyxel,nsa310s|\
+zyxel,nsa320|\
 zyxel,nsa325)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x20000" "0x20000"
 	;;

--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -494,6 +494,22 @@ endef
 $(eval $(call KernelPackage,hwmon-nct7802))
 
 
+define KernelPackage/hwmon-nsa320
+  TITLE:=NSA320 monitoring support
+  KCONFIG:=CONFIG_SENSORS_NSA320
+  FILES:=$(LINUX_DIR)/drivers/hwmon/nsa320-hwmon.ko
+  AUTOLOAD:=$(call AutoProbe,nsa320-hwmon)
+  $(call AddDepends/hwmon)
+endef
+
+define KernelPackage/hwmon-nsa320/description
+ Kernel module for Holtek HT46R065 microcontroller with onboard
+ firmware that configures it to act as a hardware monitor.
+endef
+
+$(eval $(call KernelPackage,hwmon-nsa320))
+
+
 define KernelPackage/hwmon-pc87360
   TITLE:=PC87360 monitoring support
   KCONFIG:=CONFIG_SENSORS_PC87360

--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -479,6 +479,22 @@ endef
 $(eval $(call KernelPackage,hwmon-nct7802))
 
 
+define KernelPackage/hwmon-nsa320
+  TITLE:=NSA320 monitoring support
+  KCONFIG:=CONFIG_SENSORS_NSA320
+  FILES:=$(LINUX_DIR)/drivers/hwmon/nsa320-hwmon.ko
+  AUTOLOAD:=$(call AutoProbe,nsa320-hwmon)
+  $(call AddDepends/hwmon)
+endef
+
+define KernelPackage/hwmon-nsa320/description
+ Kernel module for Holtek HT46R065 microcontroller with onboard
+firmware that configures it to act as a hardware monitor.
+endef
+
+$(eval $(call KernelPackage,hwmon-nsa320))
+
+
 define KernelPackage/hwmon-pc87360
   TITLE:=PC87360 monitoring support
   KCONFIG:=CONFIG_SENSORS_PC87360

--- a/target/linux/kirkwood/base-files/etc/board.d/02_network
+++ b/target/linux/kirkwood/base-files/etc/board.d/02_network
@@ -34,6 +34,7 @@ kirkwood_setup_interfaces()
 	seagate,goflexnet|\
 	zyxel,nsa310b|\
 	zyxel,nsa310s|\
+	zyxel,nsa320|\
 	zyxel,nsa325)
 		ucidef_set_interface_lan "eth0" "dhcp"
 		;;
@@ -75,6 +76,7 @@ kirkwood_setup_macs()
 		wan_mac=$(mtd_get_mac_ascii u_env eth1addr)
 		;;
 	zyxel,nsa310b|\
+	zyxel,nsa320|\
 	zyxel,nsa325)
 		lan_mac=$(mtd_get_mac_ascii uboot_env ethaddr)
 		;;

--- a/target/linux/kirkwood/image/Makefile
+++ b/target/linux/kirkwood/image/Makefile
@@ -401,6 +401,15 @@ define Device/zyxel_nsa310s
 endef
 TARGET_DEVICES += zyxel_nsa310s
 
+define Device/zyxel_nsa320
+  DEVICE_VENDOR := Zyxel
+  DEVICE_MODEL := NSA320
+  DEVICE_PACKAGES := kmod-ata-marvell-sata kmod-fs-ext4 \
+	kmod-gpio-button-hotplug kmod-rtc-pcf8563 kmod-hwmon-nsa320
+  SUPPORTED_DEVICES += nsa320
+endef
+TARGET_DEVICES += zyxel_nsa320
+
 define Device/zyxel_nsa325
   DEVICE_VENDOR := Zyxel
   DEVICE_MODEL := NSA325

--- a/target/linux/kirkwood/patches-6.12/119-nsa320.patch
+++ b/target/linux/kirkwood/patches-6.12/119-nsa320.patch
@@ -1,0 +1,54 @@
+--- a/arch/arm/boot/dts/marvell/kirkwood-nsa320.dts
++++ b/arch/arm/boot/dts/marvell/kirkwood-nsa320.dts
+@@ -14,6 +14,13 @@
+ 	model = "Zyxel NSA320";
+ 	compatible = "zyxel,nsa320", "marvell,kirkwood-88f6281", "marvell,kirkwood";
+ 
++	aliases {
++		led-boot = &led_green_sys;
++		led-failsafe = &led_orange_sys;
++		led-running = &led_green_sys;
++		led-upgrade = &led_orange_sys;
++	};
++
+ 	memory {
+ 		device_type = "memory";
+ 		reg = <0x00000000 0x20000000>;
+@@ -142,17 +149,19 @@
+ 			     &pmx_led_hdd1_green &pmx_led_hdd1_red>;
+ 		pinctrl-names = "default";
+ 
+-		led-green-sys {
++		led_green_sys: led-green-sys {
+ 			label = "nsa320:green:sys";
+ 			gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
+ 		};
+-		led-orange-sys {
++		led_orange_sys: led-orange-sys {
+ 			label = "nsa320:orange:sys";
+ 			gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+ 		};
+ 		led-green-hdd1 {
+ 			label = "nsa320:green:hdd1";
+ 			gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "ata1";
+ 		};
+ 		led-red-hdd1 {
+ 			label = "nsa320:red:hdd1";
+@@ -161,6 +170,7 @@
+ 		led-green-hdd2 {
+ 			label = "nsa320:green:hdd2";
+ 			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "ata2";
+ 		};
+ 		led-red-hdd2 {
+ 			label = "nsa320:red:hdd2";
+@@ -169,6 +179,7 @@
+ 		led-green-usb {
+ 			label = "nsa320:green:usb";
+ 			gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "usb-host";
+ 		};
+ 		led-green-copy {
+ 			label = "nsa320:green:copy";

--- a/target/linux/kirkwood/patches-6.18/119-nsa320.patch
+++ b/target/linux/kirkwood/patches-6.18/119-nsa320.patch
@@ -1,0 +1,54 @@
+--- a/arch/arm/boot/dts/marvell/kirkwood-nsa320.dts
++++ b/arch/arm/boot/dts/marvell/kirkwood-nsa320.dts
+@@ -14,6 +14,13 @@
+ 	model = "Zyxel NSA320";
+ 	compatible = "zyxel,nsa320", "marvell,kirkwood-88f6281", "marvell,kirkwood";
+ 
++	aliases {
++		led-boot = &led_green_sys;
++		led-failsafe = &led_orange_sys;
++		led-running = &led_green_sys;
++		led-upgrade = &led_orange_sys;
++	};
++
+ 	memory {
+ 		device_type = "memory";
+ 		reg = <0x00000000 0x20000000>;
+@@ -142,17 +149,19 @@
+ 			     &pmx_led_hdd1_green &pmx_led_hdd1_red>;
+ 		pinctrl-names = "default";
+ 
+-		led-green-sys {
++		led_green_sys: led-green-sys {
+ 			label = "nsa320:green:sys";
+ 			gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
++			default-state = "on";
+ 		};
+-		led-orange-sys {
++		led_orange_sys: led-orange-sys {
+ 			label = "nsa320:orange:sys";
+ 			gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
+ 		};
+ 		led-green-hdd1 {
+ 			label = "nsa320:green:hdd1";
+ 			gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "ata1";
+ 		};
+ 		led-red-hdd1 {
+ 			label = "nsa320:red:hdd1";
+@@ -161,6 +170,7 @@
+ 		led-green-hdd2 {
+ 			label = "nsa320:green:hdd2";
+ 			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "ata2";
+ 		};
+ 		led-red-hdd2 {
+ 			label = "nsa320:red:hdd2";
+@@ -169,6 +179,7 @@
+ 		led-green-usb {
+ 			label = "nsa320:green:usb";
+ 			gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "usb-host";
+ 		};
+ 		led-green-copy {
+ 			label = "nsa320:green:copy";


### PR DESCRIPTION
The Zyxel NSA320 is a 2-bay NAS powered by the Marvell Kirkwood SoC.

Specifications:
- SoC: Marvell 88F6281 ARM v5 @1.2GHz
- Memory: 512MB DDR2 DRAM
- Flash: 128MB NAND
- Ethernet: Gigabit (Marvell 88E1318)
- 1x Power button, 1x Reset button, 1x Copy/Sync button
- 1x Power LED, 5x Status LEDs
- 2x SATA II (internal), 2x USB 2.0 (rear), 1x USB 2.0 (front)
- Fan

MAC addresses:
LAN MAC is stored as u-boot environment variable
should be the exact same as the one on the sticker on the case

Installation:
1. Prepare FAT32 USB drive with u-boot.kwb and initramfs image
2. Connect via serial console (pinout: GND|NC|RX|TX|VCC)
3. From u-boot, read MAC address, flash new bootloader:
   printenv ethaddr
   usb start
   fatload usb 0 0x800000 u-boot.kwb
   nand erase 0x0 0x100000
   nand write 0x800000 0x0 0x100000
   reset
4. Boot into new u-boot, restore MAC address:
   setenv ethaddr AA:BB:CC:DD:EE:FF
   saveenv
5. Load and boot initramfs:
   usb start
   fatload usb 0 0x0800000 openwrt-kirkwood-generic-zyxel_nsa320-initramfs-uImage
   bootm 0x800000
6. Download and install sysupgrade image

For alternative methods, see instructions for other Zyxel NSA3xx models.

The device's BootROM is compatible with 'kwboot'