### PR TITLE
mediatek: disable SafeXcel crypto accelerator

### DIFF
--- a/target/linux/mediatek/filogic/target.mk
+++ b/target/linux/mediatek/filogic/target.mk
@@ -2,7 +2,7 @@ ARCH:=aarch64
 SUBTARGET:=filogic
 BOARDNAME:=Filogic 8x0 (MT798x)
 CPU_TYPE:=cortex-a53
-DEFAULT_PACKAGES += fitblk kmod-crypto-hw-safexcel wpad-basic-mbedtls uboot-envtools
+DEFAULT_PACKAGES += fitblk wpad-basic-mbedtls uboot-envtools
 KERNELNAME:=Image dtbs
 DEFAULT_PROFILE:=openwrt_one
 

--- a/target/linux/mediatek/mt7623/target.mk
+++ b/target/linux/mediatek/mt7623/target.mk
@@ -9,7 +9,7 @@ CPU_TYPE:=cortex-a7
 CPU_SUBTYPE:=neon-vfpv4
 KERNELNAME:=Image dtbs zImage
 FEATURES+=display usbgadget
-DEFAULT_PACKAGES+=fitblk kmod-crypto-hw-safexcel uboot-envtools
+DEFAULT_PACKAGES+=fitblk uboot-envtools
 
 define Target/Description
 	Build firmware images for MediaTek mt7623 ARM based boards.


### PR DESCRIPTION
The SafeXcel hardware crypto accelerator is broken.

Performance is degraded versus CPU processing, [1] or in other cases (DCO, IPSec) traffic completely stops. [2]

Disable the SafeXcel kernel module as default package for the two targets that currently have it enabled (`mt7623` and `filogic`) and leave it as optional package.

[1] https://github.com/openwrt/openwrt/pull/10561#issuecomment-1300428044
[1] https://forum.openwrt.org/t/mt6000-custom-build-with-luci-and-some-optimization-kernel-6-12-x/185241/2004

[2] https://github.com/openwrt/packages/pull/27421#issuecomment-3488738966
[2] https://github.com/openwrt/openwrt/issues/23102
[2] https://github.com/openwrt/openwrt/issues/21310