### PR TITLE
kernel: fix lz4 initramfs creation

### DIFF
--- a/include/kernel-defaults.mk
+++ b/include/kernel-defaults.mk
@@ -201,7 +201,7 @@ define Kernel/CompileImage/Initramfs
 				$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_GZIP), \
 					$(STAGING_DIR_HOST)/bin/libdeflate-gzip -n -f -S .gzip -12 $(KERNEL_BUILD_DIR)/initrd$(2).cpio;) \
 				$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZ4), \
-					$(STAGING_DIR_HOST)/bin/lz4c -l -c1 -fz --favor-decSpeed $(KERNEL_BUILD_DIR)/initrd$(2).cpio;) \
+					$(STAGING_DIR_HOST)/bin/lz4c -l -c1 -fz --favor-decSpeed $(KERNEL_BUILD_DIR)/initrd$(2).cpio $(KERNEL_BUILD_DIR)/initrd$(2).cpio.lz4;) \
 				$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZMA), \
 					$(STAGING_DIR_HOST)/bin/lzma e -lc1 -lp2 -pb2 $(KERNEL_BUILD_DIR)/initrd$(2).cpio $(KERNEL_BUILD_DIR)/initrd$(2).cpio.lzma;) \
 				$(if $(CONFIG_TARGET_INITRAMFS_COMPRESSION_LZO), \


### PR DESCRIPTION
lz4c expects the target filename, provide it.