### PR TITLE
scripts: feeds: don't refresh .config upon update

### DIFF
--- a/scripts/feeds
+++ b/scripts/feeds
@@ -892,8 +892,6 @@ sub update {
 		};
 	}
 
-	refresh_config();
-
 	return $failed;
 }
 


### PR DESCRIPTION
Feeds update does not make updated packages available to compile; they must be installed. Despite this, update refreshes the .config, deleting selections in the .config which have not been installed yet. The deleted selections are not restored with `./scripts/feeds install` nor with `make defconfig` because these steps cannot conjure up already deleted selections.

Change update to not modify the .config and leave it to `./scripts/feeds install -d <y|m|n>` or `make defconfig` or other *config options.
