### PR TITLE
prereq-build/u-boot: add Python 3.14 support

### DIFF
--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -187,6 +187,7 @@ $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 	perl --version | grep "perl.*v5"))
 
 $(eval $(call SetupHostCommand,python,Please install Python >= 3.7, \
+	python3.14 -V 2>&1 | grep 'Python 3', \
 	python3.13 -V 2>&1 | grep 'Python 3', \
 	python3.12 -V 2>&1 | grep 'Python 3', \
 	python3.11 -V 2>&1 | grep 'Python 3', \
@@ -197,6 +198,7 @@ $(eval $(call SetupHostCommand,python,Please install Python >= 3.7, \
 	python3 -V 2>&1 | grep -E 'Python 3\.([7-9]|[0-9][0-9])\.?'))
 
 $(eval $(call SetupHostCommand,python3,Please install Python >= 3.7, \
+	python3.14 -V 2>&1 | grep 'Python 3', \
 	python3.13 -V 2>&1 | grep 'Python 3', \
 	python3.12 -V 2>&1 | grep 'Python 3', \
 	python3.11 -V 2>&1 | grep 'Python 3', \

--- a/include/prereq-build.mk
+++ b/include/prereq-build.mk
@@ -187,6 +187,7 @@ $(eval $(call SetupHostCommand,perl,Please install Perl 5.x, \
 	perl --version | grep "perl.*v5"))
 
 $(eval $(call SetupHostCommand,python,Please install Python >= 3.8, \
+	python3.14 -V 2>&1 | grep 'Python 3', \
 	python3.13 -V 2>&1 | grep 'Python 3', \
 	python3.12 -V 2>&1 | grep 'Python 3', \
 	python3.11 -V 2>&1 | grep 'Python 3', \
@@ -196,6 +197,7 @@ $(eval $(call SetupHostCommand,python,Please install Python >= 3.8, \
 	python3 -V 2>&1 | grep -E 'Python 3\.([8-9]|[0-9][0-9])\.?'))
 
 $(eval $(call SetupHostCommand,python3,Please install Python >= 3.8, \
+	python3.14 -V 2>&1 | grep 'Python 3', \
 	python3.13 -V 2>&1 | grep 'Python 3', \
 	python3.12 -V 2>&1 | grep 'Python 3', \
 	python3.11 -V 2>&1 | grep 'Python 3', \

--- a/include/u-boot.mk
+++ b/include/u-boot.mk
@@ -29,6 +29,7 @@ endif
 ifdef UBOOT_USE_INTREE_DTC
   $(eval $(call TestHostCommand,python3-dev, \
     Please install the python3-dev package, \
+    python3.14-config --includes 2>&1 | grep 'python3', \
     python3.13-config --includes 2>&1 | grep 'python3', \
     python3.12-config --includes 2>&1 | grep 'python3', \
     python3.11-config --includes 2>&1 | grep 'python3', \


### PR DESCRIPTION
Python 3.14 is the default version on Fedora 43/44.