### PR TITLE
wifi-scripts: Add support for tagging of PSK with a name

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-station.json
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/schema/wireless.wifi-station.json
@@ -23,6 +23,10 @@
 			"description": "The passphrase that shall be used",
 			"type": "string"
 		},
+		"name": {
+			"description": "Optional key name",
+			"type": "string"
+		},
 		"vid": {
 			"description": "The VLAN Id used by the station",
 			"type": "string"

--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/ap.uc
@@ -347,6 +347,8 @@ function iface_wpa_stations(config, stas) {
 				let station = `${mac} ${sta.config.key}\n`;
 				if (sta.config.vid)
 					station = `vlanid=${sta.config.vid} ` + station;
+				if (sta.config.name)
+					station = `keyid=${sta.config.name} ` + station;
 				file.write(station);
 			}
 		}

--- a/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
+++ b/package/network/config/wifi-scripts/files/lib/netifd/hostapd.sh
@@ -435,13 +435,15 @@ hostapd_set_psk_file() {
 	local ifname="$1"
 	local vlan="$2"
 	local vlan_id=""
+	local key_name=""
 
-	json_get_vars vid key
+	json_get_vars vid key name
 	json_get_values mac_list mac
 	set_default mac_list "00:00:00:00:00:00"
 	[ -n "$vid" ] && vlan_id="vlanid=$vid "
+	[ -n "$name" ] && key_name="keyid=$name "
 	for mac in $mac_list; do
-		echo "${vlan_id} ${mac} ${key}" >> /var/run/hostapd-${ifname}.psk
+		echo "${vlan_id}${key_name}${mac} ${key}" >> /var/run/hostapd-${ifname}.psk
 	done
 }
 


### PR DESCRIPTION
Adds support for adding a key identifier to allow identification of used keys in the handshake logs