### PR TITLE
dnsmasq: require logger package

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -44,7 +44,7 @@ define Package/dnsmasq/Default
   CATEGORY:=Base system
   TITLE:=DNS and DHCP server
   URL:=http://www.thekelleys.org.uk/dnsmasq/
-  DEPENDS:=+libubus +@BUSYBOX_CONFIG_PIDOF
+  DEPENDS:=+libubus +@BUSYBOX_CONFIG_PIDOF +@!PACKAGE_logger:BUSYBOX_CONFIG_LOGGER
   USERID:=dnsmasq=453:dnsmasq=453
 endef
 


### PR DESCRIPTION
The dnsmasq init script uses logger. Add a Kconfig dependency on logger to ensure the utility is available at runtime.
