### PR TITLE
libmnl: assign PKG_LICENSE_FILES

### DIFF
--- a/package/libs/libmnl/Makefile
+++ b/package/libs/libmnl/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libmnl
 PKG_VERSION:=1.0.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
@@ -22,6 +22,7 @@ PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_LICENSE:=LGPL-2.1+
+PKG_LICENSE_FILES:=COPYING
 PKG_CPE_ID:=cpe:/a:netfilter:libmnl
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Set `PKG_LICENSE_FILES` for libmnl.