### PR TITLE
kernel: sound: fix kmod-sound-midi2 packaging

### DIFF
--- a/package/kernel/linux/modules/sound.mk
+++ b/package/kernel/linux/modules/sound.mk
@@ -663,7 +663,7 @@ $(eval $(call KernelPackage,sound-hda-intel))
 define KernelPackage/sound-midi2
   TITLE:=MIDI 2.0 and UMP Support
   KCONFIG:= \
-	CONFIG_SND_UMP=y  \
+	CONFIG_SND_UMP \
 	CONFIG_SND_UMP_LEGACY_RAWMIDI=y
   FILES:=$(LINUX_DIR)/sound/core/snd-ump.ko
   AUTOLOAD:=$(call AutoProbe,snd-ump)


### PR DESCRIPTION
kmod-sound-midi2 expects sound/core/snd-ump.ko, but CONFIG_SND_UMP=y builds it in-kernel rather than as a module. Replace the forced built-in setting with plain CONFIG_SND_UMP so the module can be packaged correctly.

Fixes:
```
====== Make errors from logs/package/kernel/linux/compile.txt ======
rstrip.sh: /__w/openwrt/openwrt/openwrt/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-alpine_mikrotik/packages/ipkg-arm_cortex-a15_neon-vfpv4/kmod-sound-i8x0/lib/modules/6.18.26/snd-intel8x0.ko: relocatable
rstrip.sh: /__w/openwrt/openwrt/openwrt/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-alpine_mikrotik/packages/ipkg-arm_cortex-a15_neon-vfpv4/kmod-sound-via82xx/lib/modules/6.18.26/snd-via82xx.ko: relocatable
rstrip.sh: /__w/openwrt/openwrt/openwrt/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-alpine_mikrotik/packages/ipkg-arm_cortex-a15_neon-vfpv4/kmod-sound-soc-core/lib/modules/6.18.26/snd-soc-core.ko: relocatable
rstrip.sh: /__w/openwrt/openwrt/openwrt/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-alpine_mikrotik/packages/ipkg-arm_cortex-a15_neon-vfpv4/kmod-sound-soc-ac97/lib/modules/6.18.26/snd-soc-ac97.ko: relocatable
rstrip.sh: /__w/openwrt/openwrt/openwrt/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-alpine_mikrotik/packages/ipkg-arm_cortex-a15_neon-vfpv4/kmod-sound-soc-wm8960/lib/modules/6.18.26/snd-soc-wm8960.ko: relocatable
rstrip.sh: /__w/openwrt/openwrt/openwrt/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-alpine_mikrotik/packages/ipkg-arm_cortex-a15_neon-vfpv4/kmod-sound-soc-spdif/lib/modules/6.18.26/snd-soc-spdif-tx.ko: relocatable
rstrip.sh: /__w/openwrt/openwrt/openwrt/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-alpine_mikrotik/packages/ipkg-arm_cortex-a15_neon-vfpv4/kmod-sound-soc-spdif/lib/modules/6.18.26/snd-soc-spdif-rx.ko: relocatable
rstrip.sh: /__w/openwrt/openwrt/openwrt/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-alpine_mikrotik/packages/ipkg-arm_cortex-a15_neon-vfpv4/kmod-sound-soc-dmic/lib/modules/6.18.26/snd-soc-dmic.ko: relocatable
rstrip.sh: /__w/openwrt/openwrt/openwrt/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-alpine_mikrotik/packages/ipkg-arm_cortex-a15_neon-vfpv4/kmod-sound-dummy/lib/modules/6.18.26/snd-dummy.ko: relocatable
ERROR: module '/__w/openwrt/openwrt/openwrt/build_dir/target-arm_cortex-a15+neon-vfpv4_musl_eabi/linux-alpine_mikrotik/linux-6.18.26/sound/core/snd-ump.ko' is missing.
make[2]: *** [modules/sound.mk:677: /__w/openwrt/openwrt/openwrt/bin/targets/alpine/mikrotik/packages/kmod-sound-midi2-6.18.26-r1.apk] Error 1
time: package/kernel/linux/compile#25.80#23.04#54.43
Error: Process completed with exit code 2.
```