### PR TITLE
RFC: ath79: tp-link: tl-wr902ac-v1: move to tiny

### DIFF
--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -458,8 +458,7 @@ tplink,cpe510-v3)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:link3" "wlan0" "51" "100" "-50" "13"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:link4" "wlan0" "76" "100" "-75" "13"
 	;;
-comfast,cf-e380ac-v2|\
-tplink,tl-wr902ac-v1)
+comfast,cf-e380ac-v2)
 	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
 	ucidef_set_led_netdev "internet" "Internet" "green:internet" "eth0"
 	;;

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -101,7 +101,6 @@ ath79_setup_interfaces()
 	tplink,re450-v3|\
 	tplink,re455-v1|\
 	tplink,tl-wa1201-v2|\
-	tplink,tl-wr902ac-v1|\
 	ubnt,bullet-ac|\
 	ubnt,bullet-m-xw|\
 	ubnt,lap-120|\

--- a/target/linux/ath79/image/generic-tp-link.mk
+++ b/target/linux/ath79/image/generic-tp-link.mk
@@ -872,20 +872,6 @@ define Device/tplink_tl-wr842n-v3
 endef
 TARGET_DEVICES += tplink_tl-wr842n-v3
 
-define Device/tplink_tl-wr902ac-v1
-  $(Device/tplink-safeloader)
-  SOC := qca9531
-  DEVICE_MODEL := TL-WR902AC
-  DEVICE_VARIANT := v1
-  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport \
-	kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9887-ct \
-	-swconfig -uboot-envtools
-  TPLINK_BOARD_ID := TL-WR902AC-V1
-  IMAGE_SIZE := 7360k
-  SUPPORTED_DEVICES += tl-wr902ac-v1
-endef
-TARGET_DEVICES += tplink_tl-wr902ac-v1
-
 define Device/tplink_tl-wr941hp-v1
   $(Device/tplink-safeloader)
   SOC := tp9343

--- a/target/linux/ath79/image/tiny-tp-link.mk
+++ b/target/linux/ath79/image/tiny-tp-link.mk
@@ -479,6 +479,20 @@ define Device/tplink_tl-wr841-v12
 endef
 TARGET_DEVICES += tplink_tl-wr841-v12
 
+define Device/tplink_tl-wr902ac-v1
+  $(Device/tplink-safeloader)
+  SOC := qca9531
+  DEVICE_MODEL := TL-WR902AC
+  DEVICE_VARIANT := v1
+  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ledtrig-usbport \
+	kmod-ath10k-ct-smallbuffers ath10k-firmware-qca9887-ct \
+	-swconfig -uboot-envtools
+  TPLINK_BOARD_ID := TL-WR902AC-V1
+  IMAGE_SIZE := 7360k
+  SUPPORTED_DEVICES += tl-wr902ac-v1
+endef
+TARGET_DEVICES += tplink_tl-wr902ac-v1
+
 define Device/tplink_tl-wr940n-v3
   $(Device/tplink-4mlzma)
   SOC := tp9343

--- a/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/01_leds
@@ -118,6 +118,10 @@ tplink,tl-wpa8630p-v2.0-eu|\
 tplink,tl-wpa8630p-v2.1-eu)
 	ucidef_set_led_switch "lan" "LAN" "green:lan" "switch0" "0x3c"
 	;;
+tplink,tl-wr902ac-v1)
+	ucidef_set_led_netdev "lan" "LAN" "green:lan" "eth0"
+	ucidef_set_led_netdev "internet" "Internet" "green:internet" "eth0"
+	;;
 tplink,tl-wr940n-v3|\
 tplink,tl-wr940n-v4|\
 tplink,tl-wr941nd-v6)

--- a/target/linux/ath79/tiny/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/tiny/base-files/etc/board.d/02_network
@@ -39,6 +39,7 @@ ath79_setup_interfaces()
 	tplink,tl-wr703n|\
 	tplink,tl-wr802n-v1|\
 	tplink,tl-wr802n-v2|\
+	tplink,tl-wr902ac-v1|\
 	ubnt,bullet-m-ar7240|\
 	ubnt,bullet-m-ar7241|\
 	ubnt,nanobridge-m|\


### PR DESCRIPTION
As discussed in: https://github.com/openwrt/openwrt/issues/23261

This target is starting to get over its max flash size

Related discussion in: https://github.com/efahl/owut/issues/74
