### PR TITLE
mediatek: Cudy WR3000P/S v1 LAN LED support

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000p-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000p-v1.dtsi
@@ -43,6 +43,34 @@
 			linux,default-trigger = "phy1tpt";
 		};
 
+		led-lan1 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan2 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan3 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan4 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
+
 		led-wan {
 			function = LED_FUNCTION_WAN;
 			color = <LED_COLOR_ID_WHITE>;

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000s-v1.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000s-v1.dtsi
@@ -48,6 +48,34 @@
 			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "phy1tpt";
 		};
+
+		led-lan1 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan2 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan3 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led-lan4 {
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <4>;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pio 13 GPIO_ACTIVE_LOW>;
+		};
 	};
 };
 


### PR DESCRIPTION
This PR adds LAN LED support for the Cudy WR3000P/S v1 devices.

The changes are split into 2 commits:

1) Add LAN LED support for Cudy WR3000P v1.
2) Add LAN LED support for Cudy WR3000S v1.