### PR TITLE
github: add workflow_dispatch trigger to kernel and packages

### DIFF
--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -19,6 +19,7 @@ on:
       - 'target/linux/**'
     branches-ignore:
       - master
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/kernel.yml
+++ b/.github/workflows/kernel.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -19,6 +19,7 @@ on:
       - 'toolchain/**'
     branches-ignore:
       - master
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
Allow the Build Kernel and Build all core packages workflows to be launched manually from the Actions tab. The shared workflow side detects workflow_dispatch and, for Build Kernel, rebuilds the full target/subtarget matrix including testing kernel versions, so a manual run can re-seed the s3 ccache when a queued push run got displaced from the concurrency queue by the next commit on main.

actions-shared-workflows PR: https://github.com/openwrt/actions-shared-workflows/pull/115