### PR TITLE
[25.12] mediatek: cudy nand: fix wrong nmbm configuration

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wbr3000uax-v1.dts
@@ -7,3 +7,9 @@
 	model = "Cudy WBR3000UAX v1";
 	compatible = "cudy,wbr3000uax-v1", "mediatek,mt7981";
 };
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000-nand.dtsi
@@ -85,9 +85,6 @@
 
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
-		mediatek,nmbm;
-		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000e-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000e-v1.dts
@@ -8,3 +8,9 @@
 	model = "Cudy WR3000E v1";
 	compatible = "cudy,wr3000e-v1", "mediatek,mt7981";
 };
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000h-v1.dts
@@ -8,3 +8,9 @@
 	model = "Cudy WR3000H v1";
 	compatible = "cudy,wr3000h-v1", "mediatek,mt7981";
 };
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000p-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000p-v1.dts
@@ -8,3 +8,9 @@
 	model = "Cudy WR3000P v1";
 	compatible = "cudy,wr3000p-v1", "mediatek,mt7981";
 };
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};

--- a/target/linux/mediatek/dts/mt7981b-cudy-wr3000s-v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-cudy-wr3000s-v1.dts
@@ -8,3 +8,9 @@
 	model = "Cudy WR3000S v1";
 	compatible = "cudy,wr3000s-v1", "mediatek,mt7981";
 };
+
+&spi_nand {
+	mediatek,nmbm;
+	mediatek,bmt-max-ratio = <1>;
+	mediatek,bmt-max-reserved-blocks = <64>;
+};


### PR DESCRIPTION
Backport to 25.12 for https://github.com/openwrt/openwrt/pull/22832