### PR TITLE
realtek: pcs: reduce chattiness and superfluous operations

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -3797,11 +3797,8 @@ static int rtpcs_931x_sds_config_hw_mode(struct rtpcs_serdes *sds,
 static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 				   enum rtpcs_sds_mode hw_mode)
 {
-	struct rtpcs_serdes *even_sds = rtpcs_sds_get_even(sds);
 	struct rtpcs_ctrl *ctrl = sds->ctrl;
 	enum rtpcs_sds_media sds_media;
-	u32 sds_id = sds->id;
-	u32 val;
 	int ret;
 
 	/*
@@ -3810,22 +3807,6 @@ static int rtpcs_931x_setup_serdes(struct rtpcs_serdes *sds,
 	 */
 	if (hw_mode == RTPCS_SDS_MODE_XSGMII)
 		return 0;
-
-	val = rtpcs_sds_read_bits(sds, 0x1F, 0x9, 11, 6);
-
-	pr_info("%s: fibermode %08X stored mode 0x%x", __func__,
-		rtpcs_sds_read(sds, 0x1f, 0x9), val);
-	pr_info("%s: SGMII mode %08X in 0x24 0x9", __func__,
-		rtpcs_sds_read(sds, 0x24, 0x9));
-	pr_info("%s: CMU mode %08X stored even SDS %d", __func__,
-		rtpcs_sds_read(even_sds, 0x20, 0x12), even_sds->id);
-	pr_info("%s: serdes_mode_ctrl %08X", __func__,  RTPCS_931X_SERDES_MODE_CTRL + 4 * (sds_id >> 2));
-	pr_info("%s CMU page 0x24 0x7 %08x\n", __func__, rtpcs_sds_read(sds, 0x24, 0x7));
-	pr_info("%s CMU page 0x26 0x7 %08x\n", __func__, rtpcs_sds_read(sds, 0x26, 0x7));
-	pr_info("%s CMU page 0x28 0x7 %08x\n", __func__, rtpcs_sds_read(sds, 0x28, 0x7));
-	pr_info("%s XSG page 0x0 0xe %08x\n", __func__, rtpcs_sds_read(sds, 0x40, 0xe));
-	pr_info("%s XSG2 page 0x0 0xe %08x\n", __func__, rtpcs_sds_read(sds, 0x80, 0xe));
-	pr_info("%s: 2.5gbit %08X", __func__, rtpcs_sds_read(sds, 0x41, 0x14));
 
 	rtpcs_931x_sds_power(sds, false);
 	rtpcs_931x_sds_set_mode(sds, RTPCS_SDS_MODE_OFF);

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2747,29 +2747,14 @@ static int rtpcs_930x_sds_check_calibration(struct rtpcs_serdes *sds,
 
 static void rtpcs_930x_phy_enable_10g_1g(struct rtpcs_serdes *sds)
 {
-
-	u32 v;
-
 	/* Enable 1GBit PHY */
-	v = rtpcs_sds_read(sds, 0x02, MII_BMCR);
-	pr_info("%s 1gbit phy: %08x\n", __func__, v);
-	v &= ~BMCR_PDOWN;
-	rtpcs_sds_write(sds, 0x02, MII_BMCR, v);
-	pr_info("%s 1gbit phy enabled: %08x\n", __func__, v);
+	rtpcs_sds_write_bits(sds, 0x02, MII_BMCR, 11, 11, 0x0); /* BMCR_PDOWN */
 
 	/* Enable 10GBit PHY */
-	v = rtpcs_sds_read(sds, 0x04, MII_BMCR);
-	pr_info("%s 10gbit phy: %08x\n", __func__, v);
-	v &= ~BMCR_PDOWN;
-	rtpcs_sds_write(sds, 0x04, MII_BMCR, v);
-	pr_info("%s 10gbit phy after: %08x\n", __func__, v);
+	rtpcs_sds_write_bits(sds, 0x04, MII_BMCR, 11, 11, 0x0); /* BMCR_PDOWN */
 
 	/* dal_longan_construct_mac_default_10gmedia_fiber */
-	v = rtpcs_sds_read(sds, 0x1f, 11);
-	pr_info("%s set medium: %08x\n", __func__, v);
-	v |= BIT(1);
-	rtpcs_sds_write(sds, 0x1f, 11, v);
-	pr_info("%s set medium after: %08x\n", __func__, v);
+	rtpcs_sds_write_bits(sds, 0x1f, 11, 1, 1, 0x1);
 }
 
 static int rtpcs_930x_sds_10g_idle(struct rtpcs_serdes *sds)

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -2123,9 +2123,7 @@ static u32 rtpcs_930x_sds_rxcal_leq_read(struct rtpcs_serdes *sds)
 	leq_manual = !!rtpcs_sds_read_bits(sds, 0x2e, 0x18, 15, 15);
 	leq_bin = rtpcs_930x_sds_rxcal_gray_to_binary(leq_gray);
 
-	pr_info("LEQ gray: %u, LEQ bin: %u", leq_gray, leq_bin);
-	pr_info("LEQ manual: %u", leq_manual);
-
+	pr_info("LEQ gray: %u, LEQ bin: %u, LEQ manual: %u\n", leq_gray, leq_bin, leq_manual);
 	return leq_bin;
 }
 
@@ -2278,8 +2276,8 @@ static void rtpcs_930x_sds_do_rx_calibration_1(struct rtpcs_serdes *sds,
 	int tap0_init_val = 0x1f; /* Initial Decision Fed Equalizer 0 tap */
 	int vth_min = 0x1;
 
-	pr_info("start_1.1.1 initial value for sds %d\n", sds->id);
-	rtpcs_sds_write(sds, 6,  0, 0);
+	/* 1.1.1 --- */
+	rtpcs_sds_write(sds, 6,  0, 0); /* initial value */
 
 	/* FGCAL */
 	rtpcs_sds_write_bits(sds, 0x2e, 0x01, 14, 14, 0x00);
@@ -2319,16 +2317,14 @@ static void rtpcs_930x_sds_do_rx_calibration_1(struct rtpcs_serdes *sds,
 	rtpcs_sds_write_bits(sds, 0x2e, 0x13,  2,  0, 0x07);
 	rtpcs_sds_write_bits(sds, 0x2f, 0x0b,  5,  3, vth_min);
 
-	pr_info("end_1.1.1 --\n");
+	/* --- 1.1.1 */
 
-	pr_info("start_1.1.2 Load DFE init. value\n");
-
+	/* 1.1.2 Load DFE initial value --- */
 	rtpcs_sds_write_bits(sds, 0x2e, 0x0f, 13,  7, 0x7f);
 
-	pr_info("end_1.1.2\n");
+	/* --- 1.1.2 */
 
-	pr_info("start_1.1.3 disable LEQ training,enable DFE clock\n");
-
+	/* 1.1.3 disable LEQ training, enable DFE clock --- */
 	rtpcs_sds_write_bits(sds, 0x2e, 0x17,  7,  7, 0x00);
 	rtpcs_sds_write_bits(sds, 0x2e, 0x17,  6,  2, 0x00);
 	rtpcs_sds_write_bits(sds, 0x2e, 0x0c,  8,  8, 0x00);
@@ -2336,15 +2332,13 @@ static void rtpcs_930x_sds_do_rx_calibration_1(struct rtpcs_serdes *sds,
 	rtpcs_sds_write_bits(sds, 0x2e, 0x12, 14, 14, 0x00);
 	rtpcs_sds_write_bits(sds, 0x2f, 0x02, 15, 15, 0x00);
 
-	pr_info("end_1.1.3 --\n");
+	/* --- 1.1.3 */
 
-	pr_info("start_1.1.4 offset cali setting\n");
-
+	/* 1.1.4 offset cali setting --- */
 	rtpcs_sds_write_bits(sds, 0x2e, 0x0f, 15, 14, 0x03);
+	/* --- 1.1.4 */
 
-	pr_info("end_1.1.4\n");
-
-	pr_info("start_1.1.5 LEQ and DFE setting\n");
+	/* 1.1.5 LEQ and DFE setting --- */
 
 	/* assume this is equivalent with (PHY_TYPE == SERDES && MEDIA == FIBER_10G) for now */
 	if (hw_mode == RTPCS_SDS_MODE_10GBASER) {
@@ -2361,12 +2355,12 @@ static void rtpcs_930x_sds_do_rx_calibration_1(struct rtpcs_serdes *sds,
 	rtpcs_sds_write_bits(sds, 0x2f, 0x0b, 15,  9, 0x3c);
 	rtpcs_sds_write_bits(sds, 0x2e, 0x0b,  1,  0, 0x03);
 
-	pr_info("end_1.1.5\n");
+	/* --- 1.1.5 */
 }
 
 static void rtpcs_930x_sds_do_rx_calibration_2_1(struct rtpcs_serdes *sds)
 {
-	pr_info("start_1.2.1 ForegroundOffsetCal_Manual\n");
+	/* 1.2.1 ForegroundOffsetCal_Manual --- */
 
 	/* Gray config endis to 1 */
 	rtpcs_sds_write_bits(sds, 0x2f, 0x02,  2,  2, 0x01);
@@ -2374,7 +2368,7 @@ static void rtpcs_930x_sds_do_rx_calibration_2_1(struct rtpcs_serdes *sds)
 	/* ForegroundOffsetCal_Manual(auto mode) */
 	rtpcs_sds_write_bits(sds, 0x2e, 0x01, 14, 14, 0x00);
 
-	pr_info("end_1.2.1");
+	/* --- 1.2.1 */
 }
 
 static void rtpcs_930x_sds_do_rx_calibration_2_2(struct rtpcs_serdes *sds)
@@ -2391,7 +2385,7 @@ static void rtpcs_930x_sds_do_rx_calibration_2_3(struct rtpcs_serdes *sds)
 	u32 fgcal_binary, fgcal_gray;
 	u32 offset_range;
 
-	pr_info("start_1.2.3 Foreground Calibration\n");
+	/* 1.2.3 Foreground Calibration --- */
 
 	for (int run = 0; run < 10; run++) {
 		/* REG_DBGO_SEL */
@@ -2422,7 +2416,7 @@ static void rtpcs_930x_sds_do_rx_calibration_2_3(struct rtpcs_serdes *sds)
 		rtpcs_sds_write_bits(sds, 0x2e, 0x15, 15, 14, offset_range);
 		rtpcs_930x_sds_do_rx_calibration_2_2(sds);
 	}
-	pr_info("%s: end_1.2.3\n", __func__);
+	/* --- 1.2.3 */
 }
 
 static void rtpcs_930x_sds_do_rx_calibration_2(struct rtpcs_serdes *sds)
@@ -2436,9 +2430,7 @@ static void rtpcs_930x_sds_do_rx_calibration_2(struct rtpcs_serdes *sds)
 static void rtpcs_930x_sds_rxcal_3_1(struct rtpcs_serdes *sds,
 				     enum rtpcs_sds_mode hw_mode)
 {
-	pr_info("start_1.3.1");
-
-	/* ##1.3.1 */
+	/* 1.3.1 --- */
 	if (hw_mode != RTPCS_SDS_MODE_10GBASER &&
 	    hw_mode != RTPCS_SDS_MODE_1000BASEX &&
 	    hw_mode != RTPCS_SDS_MODE_SGMII)
@@ -2447,7 +2439,7 @@ static void rtpcs_930x_sds_rxcal_3_1(struct rtpcs_serdes *sds,
 	rtpcs_sds_write_bits(sds, 0x2e, 0x17, 7, 7, 0x0);
 	rtpcs_930x_sds_rxcal_leq_manual(sds, false, 0);
 
-	pr_info("end_1.3.1");
+	/* --- 1.3.1 */
 }
 
 static void rtpcs_930x_sds_rxcal_3_2(struct rtpcs_serdes *sds,
@@ -2473,7 +2465,7 @@ static void rtpcs_930x_sds_rxcal_3_2(struct rtpcs_serdes *sds,
 	if (hw_mode != RTPCS_SDS_MODE_10GBASER)
 		pr_warn("%s: LEQ only valid for 10GR!\n", __func__);
 
-	pr_info("start_1.3.2");
+	/* 1.3.2 --- */
 
 	for (i = 0; i < 10; i++) {
 		sum10 += rtpcs_930x_sds_rxcal_leq_read(sds);
@@ -2511,9 +2503,9 @@ static void rtpcs_930x_sds_rxcal_3_2(struct rtpcs_serdes *sds,
 		}
 	}
 
-	pr_info("Sds:%u LEQ = %u", sds->id, rtpcs_930x_sds_rxcal_leq_read(sds));
+	pr_info("SDS %u LEQ = %u", sds->id, rtpcs_930x_sds_rxcal_leq_read(sds));
 
-	pr_info("end_1.3.2");
+	/* --- 1.3.2 */
 }
 
 __always_unused
@@ -2533,14 +2525,12 @@ static void rtpcs_930x_sds_do_rx_calibration_4_1(struct rtpcs_serdes *sds)
 	u32 vth_list[2] = {0, 0};
 	u32 tap0_list[4] = {0, 0, 0, 0};
 
-	pr_info("start_1.4.1");
-
-	/* ##1.4.1 */
+	/* 1.4.1 --- */
 	rtpcs_930x_sds_rxcal_vth_manual(sds, false, vth_list);
 	rtpcs_930x_sds_rxcal_tap_manual(sds, 0, false, tap0_list);
 	mdelay(200);
 
-	pr_info("end_1.4.1");
+	/* --- 1.4.2 */
 }
 
 static void rtpcs_930x_sds_do_rx_calibration_4_2(struct rtpcs_serdes *sds)
@@ -2548,7 +2538,7 @@ static void rtpcs_930x_sds_do_rx_calibration_4_2(struct rtpcs_serdes *sds)
 	u32 vth_list[2];
 	u32 tap_list[4];
 
-	pr_info("start_1.4.2");
+	/* 1.4.2 --- */
 
 	rtpcs_930x_sds_rxcal_vth_get(sds, vth_list);
 	rtpcs_930x_sds_rxcal_vth_manual(sds, true, vth_list);
@@ -2558,7 +2548,7 @@ static void rtpcs_930x_sds_do_rx_calibration_4_2(struct rtpcs_serdes *sds)
 	rtpcs_930x_sds_rxcal_tap_get(sds, 0, tap_list);
 	rtpcs_930x_sds_rxcal_tap_manual(sds, 0, true, tap_list);
 
-	pr_info("end_1.4.2");
+	/* --- 1.4.2 */
 }
 
 static void rtpcs_930x_sds_do_rx_calibration_4(struct rtpcs_serdes *sds)
@@ -2574,7 +2564,7 @@ static void rtpcs_930x_sds_do_rx_calibration_5_2(struct rtpcs_serdes *sds)
 	u32 tap3_list[4] = {0};
 	u32 tap4_list[4] = {0};
 
-	pr_info("start_1.5.2");
+	/* 1.5.2 --- */
 
 	rtpcs_930x_sds_rxcal_tap_manual(sds, 1, false, tap1_list);
 	rtpcs_930x_sds_rxcal_tap_manual(sds, 2, false, tap2_list);
@@ -2583,7 +2573,7 @@ static void rtpcs_930x_sds_do_rx_calibration_5_2(struct rtpcs_serdes *sds)
 
 	mdelay(30);
 
-	pr_info("end_1.5.2");
+	/* --- 1.5.2 */
 }
 
 static void rtpcs_930x_sds_do_rx_calibration_5(struct rtpcs_serdes *sds,
@@ -2621,7 +2611,6 @@ static void rtpcs_930x_sds_do_rx_calibration(struct rtpcs_serdes *sds,
 
 	/* Do this only for 10GR mode */
 	if (hw_mode == RTPCS_SDS_MODE_10GBASER) {
-		pr_info("%s: SDS enabled\n", __func__);
 		latch_sts = rtpcs_sds_read_bits(sds, 0x4, 1, 2, 2);
 		mdelay(1);
 		latch_sts = rtpcs_sds_read_bits(sds, 0x4, 1, 2, 2);


### PR DESCRIPTION
The series reduces the chattiness of the PCS driver and some minor superfluous operations. A lot of debug prints still from the former times but they add very little. As a first step, drop some prints.

For RTL930x:
```
[    8.389943] realtek-otto-pcs 1b000000.switchcore:pcs: configure SerDes 2 for mode 1000base-x
[    8.399570] rtl838x_eth 1b000000.switchcore:ethernet eth0: Link is Up - 1Gbps/Full - flow control off
[    8.412997] rtpcs_930x_phy_enable_10g_1g 1gbit phy: 00001140
[    8.419333] rtpcs_930x_phy_enable_10g_1g 1gbit phy enabled: 00001140
[    8.426500] rtpcs_930x_phy_enable_10g_1g 10gbit phy: 00002040
[    8.433052] rtpcs_930x_phy_enable_10g_1g 10gbit phy after: 00002040
[    8.440055] rtpcs_930x_phy_enable_10g_1g set medium: 00000000
[    8.446549] rtpcs_930x_phy_enable_10g_1g set medium after: 00000002
[    8.453669] rtpcs_93xx_sds_config_cmu: SDS 2 using ring PLL for mode 2
[    8.517981] rtpcs_930x_sds_10g_idle: WARNING Waiting for RX idle timed out, SDS 2
[    8.526405] start_1.1.1 initial value for sds 2
[    8.531546] end_1.1.1 --
[    8.534433] start_1.1.2 Load DFE init. value
[    8.539208] end_1.1.2
[    8.541732] start_1.1.3 disable LEQ training,enable DFE clock
[    8.548246] end_1.1.3 --
[    8.551080] start_1.1.4 offset cali setting
[    8.555824] end_1.1.4
[    8.558374] start_1.1.5 LEQ and DFE setting
[    8.563126] end_1.1.5
[    8.570663] start_1.2.1 ForegroundOffsetCal_Manual
[    8.576065] end_1.2.1
[    8.581079] start_1.2.3 Foreground Calibration
[    8.588652] rtpcs_930x_sds_do_rx_calibration_2_3: end_1.2.3
[    8.594925] start_1.4.1
[    8.815366] end_1.4.1
[    8.818111] start_1.4.2
[    8.821665] vthp_set_bin = 7, vthn_set_bin = 3, manual = 0
[    8.931890] tap0: coef_bin = 31, sign = +
[    8.936455] tap0: manual = 0
[    8.939692] end_1.4.2
```
vs.
```
[    8.400061] realtek-otto-pcs 1b000000.switchcore:pcs: configure SerDes 2 for mode 1000base-x
[    8.409677] rtl838x_eth 1b000000.switchcore:ethernet eth0: Link is Up - 1Gbps/Full - flow control off
[    8.423210] rtpcs_93xx_sds_config_cmu: SDS 2 using ring PLL for mode 2
[    8.488254] rtpcs_930x_sds_10g_idle: WARNING Waiting for RX idle timed out, SDS 2
[    8.728251] vthp_set_bin = 7, vthn_set_bin = 3, manual = 0
[    8.835612] tap0: coef_bin = 31, sign = +
[    8.840115] tap0: manual = 0
```
