### PR TITLE
target/linux/ipq40xx: permit standard driver/firmware defaults

### DIFF
--- a/target/linux/ipq40xx/Makefile
+++ b/target/linux/ipq40xx/Makefile
@@ -16,8 +16,8 @@ include $(INCLUDE_DIR)/target.mk
 DEFAULT_PACKAGES += \
 	kmod-usb-dwc3-qcom \
 	kmod-leds-gpio kmod-gpio-button-hotplug \
-	kmod-ath10k-ct wpad-basic-mbedtls \
-	kmod-usb3 kmod-usb-dwc3 ath10k-firmware-qca4019-ct \
+	kmod-ath10k wpad-mesh-mbedtls \
+	kmod-usb3 kmod-usb-dwc3 ath10k-firmware-qca4019 \
 	uboot-envtools
 
 $(eval $(call BuildTarget))

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-lbr20.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-lbr20.dts
@@ -486,6 +486,8 @@
 
 &wifi0 {
 	status = "okay";
+		tx-power-limit = <25>;
+		tx-power-limit = <25>;
 	nvmem-cell-names = "pre-calibration", "mac-address";
 	nvmem-cells = <&precal_art_1000>, <&mac_address_lan 0>;
 	qcom,ath10k-calibration-variant = "Netgear-LBR20";
@@ -493,6 +495,8 @@
 
 &wifi1 {
 	status = "okay";
+		tx-power-limit = <25>;
+		tx-power-limit = <25>;
 	ieee80211-freq-limit = <5470000 5815000>;
 	nvmem-cell-names = "pre-calibration", "mac-address";
 	nvmem-cells = <&precal_art_5000>, <&mac_address_wlan_5g 0>;

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-rbr50.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-rbr50.dts
@@ -38,12 +38,16 @@
 
 &wifi0 {
 	status = "okay";
+		tx-power-limit = <25>;
+		tx-power-limit = <25>;
 
 	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
 };
 
 &wifi1 {
 	status = "okay";
+		tx-power-limit = <25>;
+		tx-power-limit = <25>;
 
 	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
 };

--- a/target/linux/ipq40xx/dts/qcom-ipq4019-rbs50.dts
+++ b/target/linux/ipq40xx/dts/qcom-ipq4019-rbs50.dts
@@ -38,12 +38,16 @@
 
 &wifi0 {
 	status = "okay";
+		tx-power-limit = <25>;
+		tx-power-limit = <25>;
 
 	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
 };
 
 &wifi1 {
 	status = "okay";
+		tx-power-limit = <25>;
+		tx-power-limit = <25>;
 
 	qcom,ath10k-calibration-variant = "Netgear-Orbi-Pro-SRK60";
 };

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -203,7 +203,7 @@ define Device/asus_map-ac2200
 	DEVICE_VENDOR := ASUS
 	DEVICE_MODEL := Lyra (MAP-AC2200)
 	SOC := qcom-ipq4019
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-ath3k
+	DEVICE_PACKAGES := ath10k-firmware-qca9888 kmod-ath3k
 endef
 TARGET_DEVICES += asus_map-ac2200
 
@@ -232,7 +232,7 @@ define Device/asus_rt-ac42u
 #	Rather, this device is a/k/a RT-AC42U
 #	But we'll go with what the vendor firmware has...
 	UIMAGE_NAME:=$(shell echo -e '\03\01\01\01RT-AC82U')
-	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct kmod-usb-ledtrig-usbport
+	DEVICE_PACKAGES := ath10k-firmware-qca9984 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += asus_rt-ac42u
 
@@ -299,7 +299,7 @@ define Device/avm_fritzrepeater-3000
 	DEVICE_VENDOR := AVM
 	DEVICE_MODEL := FRITZ!Repeater 3000
 	SOC := qcom-ipq4019
-	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct fritz-caldata fritz-tffs-nand
+	DEVICE_PACKAGES := ath10k-firmware-qca9984 fritz-caldata fritz-tffs-nand
 endef
 TARGET_DEVICES += avm_fritzrepeater-3000
 
@@ -309,7 +309,7 @@ define Device/buffalo_wtr-m2133hp
 	DEVICE_VENDOR := Buffalo
 	DEVICE_MODEL := WTR-M2133HP
 	SOC := qcom-ipq4019
-	DEVICE_PACKAGES := ath10k-firmware-qca9984-ct
+	DEVICE_PACKAGES := ath10k-firmware-qca9984
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
 endef
@@ -473,7 +473,7 @@ define Device/engenius_eap2200
 	SOC := qcom-ipq4019
 	BLOCKSIZE := 128k
 	PAGESIZE := 2048
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct -kmod-ath10k-ct kmod-ath10k-ct-smallbuffers
+	DEVICE_PACKAGES := ath10k-firmware-qca9888 -kmod-ath10k-ct kmod-ath10k-ct-smallbuffers
 endef
 # Missing DSA Setup
 #TARGET_DEVICES += engenius_eap2200
@@ -626,7 +626,7 @@ define Device/glinet_gl-b2200
 		pad-to 33792k | append-rootfs |\
 		append-metadata | gzip
 	IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct \
+	DEVICE_PACKAGES := ath10k-firmware-qca9888 \
 		kmod-fs-ext4 kmod-mmc kmod-spi-dev mkf2fs e2fsprogs kmod-fs-f2fs
 endef
 TARGET_DEVICES += glinet_gl-b2200
@@ -720,7 +720,7 @@ define Device/linksys_ea8300
 	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
 	IMAGES += factory.bin
 	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=EA8300
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-usb-ledtrig-usbport
+	DEVICE_PACKAGES := ath10k-firmware-qca9888 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += linksys_ea8300
 
@@ -755,7 +755,7 @@ define Device/linksys_mr8300
 	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
 	IMAGES += factory.bin
 	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=MR8300
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-usb-ledtrig-usbport
+	DEVICE_PACKAGES := ath10k-firmware-qca9888 kmod-usb-ledtrig-usbport
 endef
 TARGET_DEVICES += linksys_mr8300
 
@@ -787,7 +787,7 @@ define Device/linksys_whw03
 	IMAGE_SIZE := 131072k
 	IMAGES += factory.bin
 	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | linksys-image type=WHW03
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-leds-pca963x kmod-spi-dev kmod-hci-uart \
+	DEVICE_PACKAGES := ath10k-firmware-qca9888 kmod-leds-pca963x kmod-spi-dev kmod-hci-uart \
 		kmod-fs-ext4 e2fsprogs kmod-fs-f2fs mkf2fs losetup ipq-wifi-linksys_whw03
 endef
 TARGET_DEVICES += linksys_whw03
@@ -806,7 +806,7 @@ define Device/linksys_whw03v2
 	UBINIZE_OPTS := -E 5    # EOD marks to "hide" factory sig at EOF
 	IMAGES += factory.bin
 	IMAGE/factory.bin  := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=WHW03v2
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct kmod-leds-pca963x kmod-spi-dev kmod-hci-uart
+	DEVICE_PACKAGES := ath10k-firmware-qca9888 kmod-leds-pca963x kmod-spi-dev kmod-hci-uart
 endef
 TARGET_DEVICES += linksys_whw03v2
 
@@ -950,7 +950,7 @@ define Device/netgear_lbr20
 	IMAGE/sysupgrade.bin := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
 		append-uImage-fakehdr filesystem | sysupgrade-tar kernel=$$$$@ | \
 		append-metadata
-	DEVICE_PACKAGES := ipq-wifi-netgear_lbr20 ath10k-firmware-qca9888-ct kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
+	DEVICE_PACKAGES := ipq-wifi-netgear_lbr20 ath10k-firmware-qca9888 kmod-usb-net-qmi-wwan kmod-usb-serial-option uqmi
 endef
 TARGET_DEVICES += netgear_lbr20
 
@@ -968,7 +968,7 @@ define Device/netgear_rbx20
 	IMAGE/sysupgrade.bin := append-kernel | pad-offset $$$$(BLOCKSIZE) 64 | \
 		append-uImage-fakehdr filesystem | sysupgrade-tar kernel=$$$$@ | \
 		append-metadata
-	DEVICE_PACKAGES := ipq-wifi-netgear_rbk20 ath10k-firmware-qca9888-ct
+	DEVICE_PACKAGES := ipq-wifi-netgear_rbk20 ath10k-firmware-qca9888
 endef
 
 define Device/netgear_rbr20
@@ -993,7 +993,7 @@ define Device/netgear_rbx40
 	KERNEL_SIZE := 3932160
 	ROOTFS_SIZE := 32243712
 	IMAGE_SIZE := 36175872
-	DEVICE_PACKAGES += ipq-wifi-netgear_rbk40 ath10k-firmware-qca9888-ct
+	DEVICE_PACKAGES += ipq-wifi-netgear_rbk40 ath10k-firmware-qca9888
 endef
 
 define Device/netgear_rbr40
@@ -1018,7 +1018,7 @@ define Device/netgear_rbx50
 	KERNEL_SIZE := 3932160
 	ROOTFS_SIZE := 32243712
 	IMAGE_SIZE := 36175872
-	DEVICE_PACKAGES += ath10k-firmware-qca9984-ct
+	DEVICE_PACKAGES += ath10k-firmware-qca9984
 endef
 
 define Device/netgear_rbr50
@@ -1043,7 +1043,7 @@ define Device/netgear_srx60
 	KERNEL_SIZE := 3932160
 	ROOTFS_SIZE := 32243712
 	IMAGE_SIZE := 36175872
-	DEVICE_PACKAGES += ath10k-firmware-qca9984-ct
+	DEVICE_PACKAGES += ath10k-firmware-qca9984
 endef
 
 define Device/netgear_srr60
@@ -1102,7 +1102,7 @@ define Device/openmesh_a62
 	IMAGES += factory.bin
 	IMAGE/factory.bin := append-rootfs | pad-rootfs | openmesh-image ce_type=A62
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct
+	DEVICE_PACKAGES := ath10k-firmware-qca9888
 endef
 TARGET_DEVICES += openmesh_a62
 
@@ -1170,7 +1170,7 @@ define Device/plasmacloud_pa2200
 	IMAGES += factory.bin
 	IMAGE/factory.bin := append-rootfs | pad-rootfs | openmesh-image ce_type=PA2200
 	IMAGE/sysupgrade.bin/squashfs := append-rootfs | pad-rootfs | sysupgrade-tar rootfs=$$$$@ | append-metadata
-	DEVICE_PACKAGES := ath10k-firmware-qca9888-ct
+	DEVICE_PACKAGES := ath10k-firmware-qca9888
 endef
 TARGET_DEVICES += plasmacloud_pa2200
 
@@ -1398,7 +1398,7 @@ TARGET_DEVICES += zte_mf287pro
 define Device/zte_mf289f
 	$(call Device/zte_mf28x_common)
 	DEVICE_MODEL := MF289F
-	DEVICE_PACKAGES += ath10k-firmware-qca9984-ct
+	DEVICE_PACKAGES += ath10k-firmware-qca9984
 endef
 TARGET_DEVICES += zte_mf289f
 


### PR DESCRIPTION
This patch is a first-timer attempt to use Git's features to remove the insistence on the -ct firmware and drivers, on ipq40xx, to allow when building the images for e.g. LBR20, RBR50v1, RBS50v1, to use the standard (non-ct) drivers, to allow for more even distribution of interrupts across all 4 cores. Plays nicer with SMP, whereas the -ct pins all the traffic on core 0.

**Thermal protection:** In addition to allowing builds that better balance the load across the 4 cores, the maximum power level in this patch for these 'chimney' passively cooled models, has been capped at 25db (316mw), instead of 30db (1000mw). 1000mw is too much for the thermal design of these units, and there are many reports of power amplifier radio failure on them. Ideally, they should be driven up to 23db (199mw) for optimal performance-per-watt, but by allowing up to 316mw it still reduces the thermal load by about 3x. 

Signed-off-by: D. Mark <38119797+Dnominated@users.noreply.github.com>