### PR TITLE
realtek: document RTL8224 reset GPIOs for PlasmaCloud PSX8/PSX10/PSX28/ESX28

### DIFF
--- a/target/linux/realtek/dts/rtl9302_plasmacloud_common.dtsi
+++ b/target/linux/realtek/dts/rtl9302_plasmacloud_common.dtsi
@@ -210,3 +210,37 @@
 	nvmem-cells = <&macaddr_ubootenv_ethaddr 8>;
 	nvmem-cell-names = "mac-address";
 };
+
+&gpio0 {
+	/*
+	 * GPIO 6 is the global reset shared by (logical) PHYs 0-3 on MDIO bus0.
+	 * It is intentionally not declared as reset-gpios on any bus: the MDIO
+	 * driver / phylink only support a single reset GPIO per bus, not two
+	 * (or more). And a GPIO can only be used as reset-gpio on a single PHY.
+	 * Attaching it to a single PHY would still reset the other PHYs on
+	 * the same chip as a side effect, leaving their software state out of
+	 * sync with the hardware and likely breaking them.
+	 */
+	phy_reset1 {
+		gpio-hog;
+		gpios = <6 GPIO_ACTIVE_LOW>;
+		output-low;
+		line-name = "phy-reset-lan1-4";
+	};
+
+	/*
+	 * GPIO 10 is the global reset shared by (logical) PHYs 8-11 on MDIO
+	 * bus0. It is intentionally not declared as reset-gpios on any bus:
+	 * the MDIO driver / phylink only support a single reset GPIO per bus,
+	 * not two (or more). And a GPIO can only be used as reset-gpio on a
+	 * single PHY. Attaching it to a single PHY would still reset the other
+	 * PHYs on the same chip as a side effect, leaving their software state
+	 * out of sync with the hardware and likely breaking them.
+	 */
+	phy_reset2 {
+		gpio-hog;
+		gpios = <10 GPIO_ACTIVE_LOW>;
+		output-low;
+		line-name = "phy-reset-lan5-8";
+	};
+};

--- a/target/linux/realtek/dts/rtl9312_plasmacloud_common.dtsi
+++ b/target/linux/realtek/dts/rtl9312_plasmacloud_common.dtsi
@@ -456,3 +456,20 @@
 	nvmem-cells = <&macaddr_ubootenv_ethaddr 28>;
 	nvmem-cell-names = "mac-address";
 };
+
+&gpio0 {
+	/*
+	 * GPIO 29 is the global reset shared by all PHYs across all MDIO busses.
+	 * It is intentionally not declared as reset-gpios on any bus: the MDIO
+	 * driver / phylink only support a reset GPIO per bus, not on the parent
+	 * controller. Attaching it to a single bus would still reset the PHYs
+	 * on the other busses as a side effect, leaving their software state
+	 * out of sync with the hardware and likely breaking them.
+	 */
+	phy_reset {
+		gpio-hog;
+		gpios = <29 GPIO_ACTIVE_LOW>;
+		output-low;
+		line-name = "phy-reset";
+	};
+};


### PR DESCRIPTION
The nRESET pins of the RTL8224 PHYs on the PSX8/PSX10 are wired to GPIO6 (lan1-4) + GPIO10 (lan5-8) of the SoC, but this was never described in the devicetree.

GPIO 6 is the global reset shared by (logical) PHYs 0-3 on MDIO bus0. GPIO 10 is the global reset shared by (logical) PHYs 8-11 on mdio bus0. It is intentionally not declared as reset-gpios on any bus: the MDIO driver / phylink only support a single reset GPIO per bus, not two (or more). And a GPIO can only be used as reset-gpio on a single PHY. Attaching it to a single PHY would still reset the other PHYs on the same chip as a side effect, leaving their software state out of sync with the hardware and likely breaking them.

---

The nRESET pins of the RTL8224 PHYs on the PSX28/ESX28 are wired to GPIO29 of the SoC, but this was never described in the devicetree.

GPIO 29 is the global reset shared by all PHYs across all MDIO busses. It is intentionally not declared as reset-gpios on any bus: the MDIO driver / phylink only support a reset GPIO per bus, not on the parent controller. Attaching it to a single bus would still reset the PHYs on the other busses as a side effect, leaving their software state out of sync with the hardware and likely breaking them.

---

Most of the description text was "borrowed" from https://github.com/openwrt/openwrt/pull/23218