### PR TITLE
imagebuilder: actually include kmod packages when not IB_STANDALONE

### DIFF
--- a/target/imagebuilder/Config.in
+++ b/target/imagebuilder/Config.in
@@ -12,6 +12,6 @@ config IB_STANDALONE
 	default y if !BUILDBOT
 	depends on IB
 	help
-	  Disabling this option will cause the ImageBuilder to embed only
-	  toolchain and kmod packages while all other ipk archives will be
+	  Disabling this option will cause the Image Builder to embed only
+	  toolchain and kmod packages while all other package archives will be
 	  fetched from online repositories.

--- a/target/imagebuilder/Makefile
+++ b/target/imagebuilder/Makefile
@@ -72,8 +72,9 @@ ifeq ($(CONFIG_IB_STANDALONE),)
 	$(FIND) $(call FeedPackageDir,libc) -type f \
 	  \( \
 		-name 'base-files$(PACKAGE_VERSION_SEPARATOR)*.$(PACKAGE_SUFFIX)' -or \
-		-name 'libc$(PACKAGE_VERSION_SEPARATOR)*.$(PACKAGE_SUFFIX)' -or \
-		-name 'kernel$(PACKAGE_VERSION_SEPARATOR)*.$(PACKAGE_SUFFIX)' \) \
+		-name 'kernel$(PACKAGE_VERSION_SEPARATOR)*.$(PACKAGE_SUFFIX)' -or \
+		-name 'kmod-*$(PACKAGE_VERSION_SEPARATOR)*.$(PACKAGE_SUFFIX)' -or \
+		-name 'libc$(PACKAGE_VERSION_SEPARATOR)*.$(PACKAGE_SUFFIX)' \) \
 	  -exec $(CP) -t $(PKG_BUILD_DIR)/packages {} +
 else
 	$(FIND) $(wildcard $(PACKAGE_SUBDIRS)) -type f -name '*.$(PACKAGE_SUFFIX)' \


### PR DESCRIPTION
The IB_STANDALONE help text states that when disabled, only toolchain and kmod packages will be embedded in the Image Builder. However, only base-files, libc and kernel packages are actually included. Change the Image Builder Makefile to also include kmod packages when not IB_STANDALONE. While at it, update the IB_STANDALONE help text because package archives are not *.ipk any more.

https://github.com/openwrt/openwrt/blob/35747c66e18bc828cf57b20a8affa3c26b621adc/target/imagebuilder/Config.in#L10-L17
