### PR TITLE
ramips: reduce ARCH_DMA_MINALIGN

### DIFF
--- a/target/linux/ramips/files/arch/mips/include/asm/mach-ralink/kmalloc.h
+++ b/target/linux/ramips/files/arch/mips/include/asm/mach-ralink/kmalloc.h
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef __ASM_MACH_RALINK_KMALLOC_H
+#define __ASM_MACH_RALINK_KMALLOC_H
+
+#ifdef CONFIG_DMA_NONCOHERENT
+#define ARCH_DMA_MINALIGN	L1_CACHE_BYTES
+#endif
+
+#endif /* __ASM_MACH_RALINK_KMALLOC_H */

--- a/target/linux/ramips/patches-6.18/110-MIPS-ralink-reduce-ARCH_DMA_MINALIGN.patch
+++ b/target/linux/ramips/patches-6.18/110-MIPS-ralink-reduce-ARCH_DMA_MINALIGN.patch
@@ -1,0 +1,31 @@
+From 1dc85756b759c3ecd21a22b0aef84ed41ddc7596 Mon Sep 17 00:00:00 2001
+From: Qingfang Deng <qingfang.deng@linux.dev>
+Date: Tue, 28 Apr 2026 16:25:40 +0800
+Subject: [PATCH] MIPS: ralink: reduce ARCH_DMA_MINALIGN
+
+Currently, Ralink SoCs use the default ARCH_DMA_MINALIGN value of 128
+bytes defined in mach-generic. This is excessive for these platforms
+and leads to significant memory waste in kmalloc.
+
+Override ARCH_DMA_MINALIGN to use L1_CACHE_BYTES, which is 16 bytes for
+RT288X and 32 bytes for other Ralink SoCs.
+
+Signed-off-by: Qingfang Deng <qingfang.deng@linux.dev>
+Signed-off-by: Thomas Bogendoerfer <tsbogend@alpha.franken.de>
+---
+ arch/mips/include/asm/mach-ralink/kmalloc.h | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+ create mode 100644 arch/mips/include/asm/mach-ralink/kmalloc.h
+
+--- /dev/null
++++ b/arch/mips/include/asm/mach-ralink/kmalloc.h
+@@ -0,0 +1,9 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++#ifndef __ASM_MACH_RALINK_KMALLOC_H
++#define __ASM_MACH_RALINK_KMALLOC_H
++
++#ifdef CONFIG_DMA_NONCOHERENT
++#define ARCH_DMA_MINALIGN	L1_CACHE_BYTES
++#endif
++
++#endif /* __ASM_MACH_RALINK_KMALLOC_H */


### PR DESCRIPTION
Currently, Ralink SoCs use the default ARCH_DMA_MINALIGN value of 128 bytes defined in mach-generic. This is excessive for these platforms and leads to significant memory waste in kmalloc.

Override ARCH_DMA_MINALIGN to use L1_CACHE_BYTES, which is 16 bytes for RT288X and 32 bytes for other Ralink SoCs.