### PR TITLE
dnsmasq: bump to v2.92rel2

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -8,13 +8,13 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dnsmasq
-PKG_UPSTREAM_VERSION:=2.92
-PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
+PKG_UPSTREAM_VERSION:=2.92rel2
+PKG_VERSION:=$(subst rel,.,$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION))))
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/
-PKG_HASH:=4bf50c2c1018f9fbc26037df51b90ecea0cb73d46162846763b92df0d6c3a458
+PKG_HASH:=43d72b8c129bdf33d17bafedc98823f63e46b5005128066bf0d2a472a32ce06a
 
 PKG_LICENSE:=GPL-2.0
 PKG_LICENSE_FILES:=COPYING


### PR DESCRIPTION
version 2.92rel2
	2.92 point release incorporating fixes for
	CVE-2026-2291
	CVE-2026-4890
	CVE-2026-4891
	CVE-2026-4892
	CVE-2026-4893
	CVE-2026-5172

CVE-2026-2291
dnsmasq's extract_name() function can be abused to cause a heap buffer
overflow, enabling an attacker to inject false DNS cache entries. This could
cause DNS queries to be redirected to attacker-controlled IP addresses or
result in a Denial of Service (DoS).

CVE-2026-4890
An infinite-loop flaw in the DNSSEC validation of dnsmasq allows remote
attackers to cause Denial of Service (DoS) conditions via a crafted DNS packet.

CVE-2026-4891
A heap-based out-of-bounds read vulnerability in the DNSSEC validation of
dnsmasq allows remote attackers to leak memory information via a crafted DNS
packet.

CVE-2026-4892
A heap-based out-of-bounds write vulnerability in the DHCPv6 implementation of
dnsmasq allows local attackers to execute arbitrary code with root privileges
via a crafted DHCPv6 packet.

CVE-2026-4893
An information disclosure vulnerability in dnsmasq allows remote attackers to
bypass source checks via a crafted DNS packet containing RFC 7871 client-subnet
information.

CVE-2026-5172
A buffer overflow vulnerability in dnsmasq’s extract_addresses() function
allows attackers to trigger a heap out-of-bounds read and crash dnsmasq by
exploiting a malformed DNS response.

https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2026q2/018471.html
https://seclists.org/oss-sec/2026/q2/480

cc @hauke