### PR TITLE
sunxi: cortexa7: fix compatible for MYIR-MYD-YT113X boards (SPI and EMMC)

### DIFF
--- a/target/linux/sunxi/patches-6.18/543-ARM-dts-add-support-for-MYIR-MYD-YT113X-boards.patch
+++ b/target/linux/sunxi/patches-6.18/543-ARM-dts-add-support-for-MYIR-MYD-YT113X-boards.patch
@@ -11,7 +11,7 @@
  	sun8i-t3-cqa3t-bv3.dtb \
 --- /dev/null
 +++ b/arch/arm/boot/dts/allwinner/sun8i-t113s-myd-yt113x.dtsi
-@@ -0,0 +1,221 @@
+@@ -0,0 +1,219 @@
 +// SPDX-License-Identifier: (GPL-2.0+ or MIT)
 +// Copyright (C) 2022 Arm Ltd.
 +
@@ -23,8 +23,6 @@
 +#include "sun8i-t113s.dtsi"
 +
 +/ {
-+	compatible = "myir,myd-yt113x", "myir,myc-yt113x", "allwinner,sun8i-t113s";
-+
 +	aliases {
 +		serial5 = &uart5;
 +
@@ -235,7 +233,7 @@
 +};
 --- /dev/null
 +++ b/arch/arm/boot/dts/allwinner/sun8i-t113s-myd-yt113x-emmc.dts
-@@ -0,0 +1,27 @@
+@@ -0,0 +1,28 @@
 +// SPDX-License-Identifier: (GPL-2.0+ or MIT)
 +// Copyright (C) 2022 Arm Ltd.
 +
@@ -247,6 +245,7 @@
 +#include "sun8i-t113s-myd-yt113x.dtsi"
 +
 +/ {
++	compatible = "myir,myd-yt113x-emmc", "myir,myd-yt113x", "myir,myc-yt113x", "allwinner,sun8i-t113s";
 +	model = "MYIR MYD-YT113X (eMMC)";
 +};
 +
@@ -265,7 +264,7 @@
 +};
 --- /dev/null
 +++ b/arch/arm/boot/dts/allwinner/sun8i-t113s-myd-yt113x-spi.dts
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,31 @@
 +// SPDX-License-Identifier: (GPL-2.0+ or MIT)
 +// Copyright (C) 2022 Arm Ltd.
 +
@@ -277,6 +276,7 @@
 +#include "sun8i-t113s-myd-yt113x.dtsi"
 +
 +/ {
++	compatible = "myir,myd-yt113x-spi", "myir,myd-yt113x", "myir,myc-yt113x", "allwinner,sun8i-t113s";
 +	model = "MYIR MYD-YT113X (SPI)";
 +};
 +


### PR DESCRIPTION
Sysupgrade calls fwtool SUPPORTED_DEVICES check and the default entry in METADATA, derived from DEVICE_NAME, does not match the shared compatible.

Also, ASU sysupgrades requires different dts compatible string in order to identify the correct image for each variant.

Add a unique dts compatible to each variant, EMMC and SPI, to match the default SUPPORTED_DEVICES entry derived from DEVICE_NAME and enable ASU sysupgrades by allowing the identification of the correct image for each variant.

Fixes: 716661d562443ce71fc8b302b98832d6923b4373 ("sunxi: add T113-S3 support")