### PR TITLE
x86/base-files: Add bridge config for SN3800

### DIFF
--- a/target/linux/x86/base-files/etc/board.d/02_network
+++ b/target/linux/x86/base-files/etc/board.d/02_network
@@ -104,6 +104,11 @@ mellanox-technologies-ltd-msn3700)
 	ucidef_set_interface_lan "mgmt "
 	ucidef_set_interface_netdev_range "lan" "swp" "1" "32"
 	;;
+mellanox-technologies-ltd-msn3800)
+	ucidef_set_network_device_path "mgmt" "pci0000:00/0000:00:1c.7/0000:09:00.0"
+	ucidef_set_interface_lan "mgmt "
+	ucidef_set_interface_netdev_range "lan" "swp" "1" "64"
+	;;
 pc-engines-apu1|pc-engines-apu2|pc-engines-apu3)
 	ucidef_set_interfaces_lan_wan "eth1 eth2" "eth0"
 	;;


### PR DESCRIPTION
This matches the existing setup for the SN3700. However, I'm not sure it's actually a great default - usually you would not want the mgmt port to be bridged into the front panel ports. Not only because this is a security problem, but also because this creates an easy path to flood the CPU with packets from the front panel, which is undesirable. Opening this as is for discussion - if we change this, it should be changed for all the SN* devices.
