### PR TITLE
openssl: update to version 3.0.20

### DIFF
--- a/package/libs/openssl/Makefile
+++ b/package/libs/openssl/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=openssl
-PKG_VERSION:=3.0.19
+PKG_VERSION:=3.0.20
 PKG_RELEASE:=1
 PKG_BUILD_FLAGS:=no-mips16 gc-sections no-lto
 
@@ -21,7 +21,7 @@ PKG_SOURCE_URL:= \
 	https://www.openssl.org/source/old/$(PKG_BASE)/ \
 	https://github.com/openssl/openssl/releases/download/$(PKG_NAME)-$(PKG_VERSION)/
 
-PKG_HASH:=fa5a4143b8aae18be53ef2f3caf29a2e0747430b8bc74d32d88335b94ab63072
+PKG_HASH:=c80a01dfc70ece4dc21168932c37739042d404d46ccc81a5986dd75314ecda6f
 
 PKG_LICENSE:=Apache-2.0
 PKG_LICENSE_FILES:=LICENSE.txt


### PR DESCRIPTION
OpenSSL 3.0.20 is a security patch release. The most severe CVE fixed in this release is Moderate.

This release incorporates the following bug fixes and mitigations:

* Fixed incorrect failure handling in RSA KEM RSASVE encapsulation. (CVE-2026-31790)

* Fixed potential use-after-free in DANE client code. (CVE-2026-28387)

* Fixed NULL pointer dereference when processing a delta CRL. (CVE-2026-28388)

* Fixed possible NULL dereference when processing CMS KeyAgreeRecipientInfo. (CVE-2026-28389)

* Fixed possible NULL dereference when processing CMS KeyTransportRecipientInfo. (CVE-2026-28390)

* Fixed heap buffer overflow in hexadecimal conversion. (CVE-2026-31789)

