### PR TITLE
uboot-mediatek: fix bl2 dependency for Qihoo 360T7

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -645,7 +645,7 @@ define U-Boot/mt7981_qihoo_360t7-ubi
   BUILD_DEVICES:=qihoo_360t7-ubi
   UBOOT_CONFIG:=mt7981_qihoo-360t7-ubi
   UBOOT_IMAGE:=u-boot.fip
-  BL2_BOOTDEV:=spim-nand
+  BL2_BOOTDEV:=spim-nand-ubi
   BL2_SOC:=mt7981
   BL2_DDRTYPE:=ddr3-1866
   DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ubi-ddr3-1866


### PR DESCRIPTION
This commit fixes wrong bl2 dependency which leads to build errors if non-ubi ddr3-1866 bl2 is not exists in the build dir.

Fixes: 9a87c4b ("uboot-mediatek: add Qihoo 360T7 (UBI) support")

