### PR TITLE
ath79: ag71xx_legacy: use page_pool for RX buffers

### DIFF
--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/Kconfig
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/Kconfig
@@ -2,6 +2,7 @@ config AG71XX_LEGACY
 	tristate "Atheros AR7XXX/AR9XXX built-in ethernet mac support"
 	depends on ATH79
 	select PHYLIB
+	select PAGE_POOL
 	help
 	  If you wish to compile a kernel for AR7XXX/91XXX and enable
 	  ethernet support, then you should always answer Y to this.

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx.h
@@ -110,6 +110,7 @@ struct ag71xx_ring {
 	struct ag71xx_buf	*buf;
 	u8			*descs_cpu;
 	dma_addr_t		descs_dma;
+	struct page_pool	*page_pool;
 	u16			desc_split;
 	u16			order;
 	unsigned int		curr;

--- a/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
+++ b/target/linux/ath79/files/drivers/net/ethernet/atheros/ag71xx/ag71xx_main.c
@@ -16,6 +16,7 @@
 #include <linux/of_address.h>
 #include <linux/of_platform.h>
 #include <linux/version.h>
+#include <net/page_pool/helpers.h>
 #include "ag71xx.h"
 
 #define AG71XX_DEFAULT_MSG_ENABLE	\
@@ -163,9 +164,9 @@ static void ag71xx_ring_rx_clean(struct ag71xx *ag)
 
 	for (i = 0; i < ring_size; i++)
 		if (ring->buf[i].rx_buf) {
-			dma_unmap_single(&ag->pdev->dev, ring->buf[i].dma_addr,
-					 ag->rx_buf_size, DMA_FROM_DEVICE);
-			skb_free_frag(ring->buf[i].rx_buf);
+			page_pool_free_va(ring->page_pool,
+					  ring->buf[i].rx_buf, false);
+			ring->buf[i].rx_buf = NULL;
 		}
 }
 
@@ -175,23 +176,57 @@ static int ag71xx_buffer_size(struct ag71xx *ag)
 	       SKB_DATA_ALIGN(sizeof(struct skb_shared_info));
 }
 
+static unsigned int ag71xx_rx_buf_page_offset(void *data)
+{
+	struct page *page = virt_to_head_page(data);
+
+	return (char *)data - (char *)page_address(page);
+}
+
 static bool ag71xx_fill_rx_buf(struct ag71xx *ag, struct ag71xx_buf *buf,
-			       int offset,
-			       void *(*alloc)(unsigned int size))
+			       int offset)
 {
 	struct ag71xx_ring *ring = &ag->rx_ring;
 	struct ag71xx_desc *desc = ag71xx_ring_desc(ring, buf - &ring->buf[0]);
+	unsigned int page_offset;
+	struct page *page;
 	void *data;
 
-	data = alloc(ag71xx_buffer_size(ag));
-	if (!data)
+	page = page_pool_dev_alloc_frag(ring->page_pool, &page_offset,
+					ag71xx_buffer_size(ag));
+	if (!page)
 		return false;
 
+	data = page_address(page) + page_offset;
 	buf->rx_buf = data;
-	buf->dma_addr = dma_map_single(&ag->pdev->dev, data, ag->rx_buf_size,
-				       DMA_FROM_DEVICE);
-	desc->data = (u32) buf->dma_addr + offset;
+	desc->data = (u32)(page_pool_get_dma_addr(page) + page_offset + offset);
 	return true;
+}
+
+static int ag71xx_rx_page_pool_create(struct ag71xx *ag)
+{
+	struct ag71xx_ring *ring = &ag->rx_ring;
+	unsigned int buf_size = ag71xx_buffer_size(ag);
+	struct page_pool_params pp_params = {
+		.order = get_order(buf_size),
+		.flags = PP_FLAG_DMA_MAP | PP_FLAG_DMA_SYNC_DEV,
+		.pool_size = BIT(ring->order),
+		.nid = dev_to_node(&ag->pdev->dev),
+		.dev = &ag->pdev->dev,
+		.napi = &ag->napi,
+		.dma_dir = DMA_FROM_DEVICE,
+		.max_len = buf_size,
+		.netdev = ag->dev,
+	};
+	struct page_pool *page_pool;
+
+	page_pool = page_pool_create(&pp_params);
+	if (IS_ERR(page_pool))
+		return PTR_ERR(page_pool);
+
+	ring->page_pool = page_pool;
+
+	return 0;
 }
 
 static int ag71xx_ring_rx_init(struct ag71xx *ag)
@@ -216,8 +251,8 @@ static int ag71xx_ring_rx_init(struct ag71xx *ag)
 	for (i = 0; i < ring_size; i++) {
 		struct ag71xx_desc *desc = ag71xx_ring_desc(ring, i);
 
-		if (!ag71xx_fill_rx_buf(ag, &ring->buf[i], ag->rx_buf_offset,
-					netdev_alloc_frag)) {
+		if (!ag71xx_fill_rx_buf(ag, &ring->buf[i],
+					ag->rx_buf_offset)) {
 			ret = -ENOMEM;
 			break;
 		}
@@ -250,8 +285,7 @@ static int ag71xx_ring_rx_refill(struct ag71xx *ag)
 		desc = ag71xx_ring_desc(ring, i);
 
 		if (!ring->buf[i].rx_buf &&
-		    !ag71xx_fill_rx_buf(ag, &ring->buf[i], offset,
-					napi_alloc_frag))
+		    !ag71xx_fill_rx_buf(ag, &ring->buf[i], offset))
 			break;
 
 		desc->ctrl = DESC_EMPTY;
@@ -272,6 +306,7 @@ static int ag71xx_rings_init(struct ag71xx *ag)
 	struct ag71xx_ring *rx = &ag->rx_ring;
 	int ring_size = BIT(tx->order) + BIT(rx->order);
 	int tx_size = BIT(tx->order);
+	int ret;
 
 	tx->buf = kzalloc(ring_size * sizeof(*tx->buf), GFP_KERNEL);
 	if (!tx->buf)
@@ -289,8 +324,23 @@ static int ag71xx_rings_init(struct ag71xx *ag)
 	rx->descs_cpu = ((void *)tx->descs_cpu) + tx_size * AG71XX_DESC_SIZE;
 	rx->descs_dma = tx->descs_dma + tx_size * AG71XX_DESC_SIZE;
 
+	ret = ag71xx_rx_page_pool_create(ag);
+	if (ret)
+		goto err_free_rings;
+
 	ag71xx_ring_tx_init(ag);
 	return ag71xx_ring_rx_init(ag);
+
+err_free_rings:
+	dma_free_coherent(&ag->pdev->dev, ring_size * AG71XX_DESC_SIZE,
+			  tx->descs_cpu, tx->descs_dma);
+	kfree(tx->buf);
+	tx->descs_cpu = NULL;
+	rx->descs_cpu = NULL;
+	tx->buf = NULL;
+	rx->buf = NULL;
+
+	return ret;
 }
 
 static void ag71xx_rings_free(struct ag71xx *ag)
@@ -303,10 +353,14 @@ static void ag71xx_rings_free(struct ag71xx *ag)
 		dma_free_coherent(&ag->pdev->dev, ring_size * AG71XX_DESC_SIZE,
 				  tx->descs_cpu, tx->descs_dma);
 
+	if (rx->page_pool)
+		page_pool_destroy(rx->page_pool);
+
 	kfree(tx->buf);
 
 	tx->descs_cpu = NULL;
 	rx->descs_cpu = NULL;
+	rx->page_pool = NULL;
 	tx->buf = NULL;
 	rx->buf = NULL;
 }
@@ -1331,18 +1385,24 @@ static int ag71xx_rx_packets(struct ag71xx *ag, int limit)
 		pktlen = desc->ctrl & pktlen_mask;
 		pktlen -= ETH_FCS_LEN;
 
-		dma_unmap_single(&ag->pdev->dev, ring->buf[i].dma_addr,
-				 ag->rx_buf_size, DMA_FROM_DEVICE);
+		page_pool_dma_sync_for_cpu(ring->page_pool,
+					   virt_to_head_page(ring->buf[i].rx_buf),
+					   ag71xx_rx_buf_page_offset(ring->buf[i].rx_buf) +
+					   offset,
+					   pktlen);
 
 		dev->stats.rx_packets++;
 		dev->stats.rx_bytes += pktlen;
 
 		skb = napi_build_skb(ring->buf[i].rx_buf, ag71xx_buffer_size(ag));
 		if (!skb) {
-			skb_free_frag(ring->buf[i].rx_buf);
+			dev->stats.rx_errors++;
+			page_pool_free_va(ring->page_pool,
+					  ring->buf[i].rx_buf, true);
 			goto next;
 		}
 
+		skb_mark_for_recycle(skb);
 		skb_reserve(skb, offset);
 		skb_put(skb, pktlen);
 


### PR DESCRIPTION
Allocate RX buffers from a page_pool and recycle received skbs through it. This replaces the per-buffer DMA map and unmap path with page_pool DMA handling.

Small performance improvement tested with iperf3 --bidir:

Before:

[ ID][Role] Interval           Transfer     Bitrate         Retr
[  5][TX-C]   0.00-10.00  sec   254 MBytes   213 Mbits/sec   26            sender
[  5][TX-C]   0.00-10.01  sec   250 MBytes   210 Mbits/sec                  receiver
[  7][RX-C]   0.00-10.00  sec   182 MBytes   153 Mbits/sec    0            sender
[  7][RX-C]   0.00-10.01  sec   182 MBytes   153 Mbits/sec                  receiver

After:

[ ID][Role] Interval           Transfer     Bitrate         Retr
[  5][TX-C]   0.00-10.00  sec   261 MBytes   219 Mbits/sec   17            sender
[  5][TX-C]   0.00-10.01  sec   258 MBytes   216 Mbits/sec                  receiver
[  7][RX-C]   0.00-10.00  sec   194 MBytes   163 Mbits/sec    0            sender
[  7][RX-C]   0.00-10.01  sec   194 MBytes   163 Mbits/sec                  receiver

Assisted-by:Codex GPT-5.5