### PR TITLE
[24.10]: dnsmasq: apply six CVE-fix upstream patches to 2.91

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.90
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/patches/001-CVE-2026-2291.patch
+++ b/package/network/services/dnsmasq/patches/001-CVE-2026-2291.patch
@@ -1,0 +1,29 @@
+commit ec2fbfbbdaa7d7db1c707dce26ce1a37cfe09660
+Author: Simon Kelley <simon@thekelleys.org.uk>
+Date:   Fri Apr 10 16:29:31 2026 +0100
+
+    Fix buffer overflow in struct bigname.  CVE-2026-2291
+    
+    All buffers capable of holding a domain name should be
+    at least MAXDNAME*2 + 1 bytes long, where MAXDNAME is the maximum
+    size of a domain name. The accounts for the trailing zero and the
+    fact that some characters are escaped in the internal representation
+    of a domain name in dnsmasq.
+    
+    The declaration of struct bigname get this wrong, with the effect
+    that a remote attacker capable of asking DNS queries or answering DNS
+    queries can cause a large OOB write in the heap.
+    
+    This was first spotted by Andrew S. Fasano.
+
+--- a/src/dnsmasq.h
++++ b/src/dnsmasq.h
+@@ -467,7 +467,7 @@ struct interface_name {
+ };
+ 
+ union bigname {
+-  char name[MAXDNAME];
++  char name[(2*MAXDNAME) + 1];
+   union bigname *next; /* freelist */
+ };
+ 

--- a/package/network/services/dnsmasq/patches/002-CVE-2026-4890.dnsmasq-2.91.patch
+++ b/package/network/services/dnsmasq/patches/002-CVE-2026-4890.dnsmasq-2.91.patch
@@ -1,0 +1,63 @@
+commit de76f21e115c451cf0653790fc4b209cd4778a07
+Author: Simon Kelley <simon@thekelleys.org.uk>
+Date:   Fri Apr 10 22:16:45 2026 +0100
+
+    Fix NSEC bitmap parsing infinite loop. CVE-2026-4890
+    
+    Report from Royce M <royce@xchglabs.com>.
+    
+    Location: dnssec.c:1290-1306, dnssec.c:1450-1463
+    
+    The bitmap window iteration advances by p[1] instead of p[1]+2 (missing the 2-byte window header). With bitmap_length=0, both rdlen and p are
+    unchanged, causing an infinite loop and dnsmasq stops responding to all queries.
+    
+    The same code accesses p[2] after only checking rdlen >= 2 without verifying p[1] >= 1, causing OOB reads at 6 locations.
+    
+    Both bugs are reachable before RRSIG validation (confirmed by the source comment at line 2125), so no valid DNSSEC signatures are needed.
+
+--- a/src/dnssec.c
++++ b/src/dnssec.c
+@@ -1270,10 +1270,10 @@ static int prove_non_existence_nsec(stru
+ 	     packet checked to be as long as rdlen implies in prove_non_existence() */
+ 	  
+ 	  /* If we can prove that there's no NS record, return that information. */
+-	  if (nons && rdlen >= 2 && p[0] == 0 && (p[2] & (0x80 >> T_NS)) != 0)
++	  if (nons && rdlen >= 2 && p[0] == 0 && p[1] >= 1  && (p[2] & (0x80 >> T_NS)) != 0)
+ 	    *nons = 0;
+ 	  
+-	  if (rdlen >= 2 && p[0] == 0)
++	  if (rdlen >= 2 && p[0] == 0 && p[1] >= 1)
+ 	    {
+ 	      /* A CNAME answer would also be valid, so if there's a CNAME is should 
+ 		 have been returned. */
+@@ -1301,8 +1301,8 @@ static int prove_non_existence_nsec(stru
+ 		  break; /* finished checking */
+ 		}
+ 	      
+-	      rdlen -= p[1];
+-	      p +=  p[1];
++	      rdlen -= p[1] + 2;
++	      p +=  p[1] + 2;
+ 	    }
+ 	  
+ 	  return 0;
+@@ -1429,7 +1429,7 @@ static int check_nsec3_coverage(struct d
+ 		p += hash_len; /* skip next-domain hash */
+ 		rdlen -= p - psave;
+ 
+-		if (rdlen >= 2 && p[0] == 0)
++		if (rdlen >= 2 && p[0] == 0 && p[1] >= 1)
+ 		  {
+ 		    /* If we can prove that there's no NS record, return that information. */
+ 		    if (nons && (p[2] & (0x80 >> T_NS)) != 0)
+@@ -1458,8 +1458,8 @@ static int check_nsec3_coverage(struct d
+ 			break; /* finished checking */
+ 		      }
+ 		    
+-		    rdlen -= p[1];
+-		    p +=  p[1];
++		    rdlen -= p[1] + 2;
++		    p +=  p[1] + 2;
+ 		  }
+ 		
+ 		return 1;

--- a/package/network/services/dnsmasq/patches/003-CVE-2026-4891.patch
+++ b/package/network/services/dnsmasq/patches/003-CVE-2026-4891.patch
@@ -1,0 +1,32 @@
+commit 2cacea42e4d45717bd0ce3ccfe8e78960245e5da
+Author: Simon Kelley <simon@thekelleys.org.uk>
+Date:   Wed Mar 25 23:04:08 2026 +0000
+
+    Verify rdlen field in RRSIG packets. CVE-2026-4891
+    
+    Bug report from Royce M <royce@xchglabs.com>
+    
+    This avoids crafted packets which give a value for rdlen _less_
+    then the space taken up by the fixed data and the signer's name
+    and engender a negative calculated length for the signature.
+
+--- a/src/dnssec.c
++++ b/src/dnssec.c
+@@ -546,10 +546,14 @@ static int validate_rrset(time_t now, st
+ 
+ 	   *ttl_out = ttl;
+ 	 }
+-       
++
++      /* Don't trust rdlen not to be too small and give us a negative sig_len
++	 It has already been checked that it doesn't run us off the end
++	 of the packet. */
++      if ((sig_len = rdlen - (p - psav)) <= 0)
++	return STAT_BOGUS;
++
+       sig = p;
+-      sig_len = rdlen - (p - psav);
+-              
+       nsigttl = htonl(orig_ttl);
+       
+       hash->update(ctx, 18, psav);

--- a/package/network/services/dnsmasq/patches/004-CVE-2026-4892.patch
+++ b/package/network/services/dnsmasq/patches/004-CVE-2026-4892.patch
@@ -1,0 +1,28 @@
+commit 011a36c51438c986535a7248ed2e7f424f8e1078
+Author: Simon Kelley <simon@thekelleys.org.uk>
+Date:   Wed Mar 25 23:16:35 2026 +0000
+
+    Fix buffer overflow in helper.c with large CLIDs. CVE-2026-4892
+    
+    Bug reported bt Royce M <royce@xchglabs.com>
+    
+    Location: helper.c:265-270
+    DHCPv6 CLIDs can be up to 65535 bytes. When --dhcp-script is configured,
+    the helper hex-encodes raw CLID bytes via sprintf("%.2x") into daemon->packet (5131 bytes).
+    A 1000-byte CLID writes ~3000 bytes. The helper process retains root privileges.
+    
+    Note: log6_packet() correctly caps CLID to 100 bytes for logging, but the helper code path was missed.
+
+--- a/src/helper.c
++++ b/src/helper.c
+@@ -261,8 +261,8 @@ int create_helper(int event_fd, int err_
+ 		      data.hostname_len + data.ed_len + data.clid_len, 1))
+ 	continue;
+ 
+-      /* CLID into packet */
+-      for (p = daemon->packet, i = 0; i < data.clid_len; i++)
++      /* CLID into packet: limit to 100 bytes to avoid overflowing buffer. */
++      for (p = daemon->packet, i = 0; i < data.clid_len && i < 100; i++)
+ 	{
+ 	  p += sprintf(p, "%.2x", buf[i]);
+ 	  if (i != data.clid_len - 1) 

--- a/package/network/services/dnsmasq/patches/005-CVE-2026-4893.patch
+++ b/package/network/services/dnsmasq/patches/005-CVE-2026-4893.patch
@@ -1,0 +1,26 @@
+commit 434d68f2eb1a58744470698483a3ae09b5a9a870
+Author: Simon Kelley <simon@thekelleys.org.uk>
+Date:   Wed Mar 25 23:22:37 2026 +0000
+
+    Fix broken client subnet validation. CVE-2026-4893
+    
+    Bug report from Royce M <royce@xchglabs.com>
+    
+    Location: forward.c:713, edns0.c:421
+    
+    With --add-subnet enabled, process_reply() passes the OPT record
+    length (~23 bytes) instead of the packet length to check_source().
+    All internal bounds checks fail, and the function always returns 1.
+    ECS source validation per RFC 7871 Section 9.2 is completely bypassed.
+
+--- a/src/forward.c
++++ b/src/forward.c
+@@ -710,7 +710,7 @@ static size_t process_reply(struct dns_h
+       /* Get extended RCODE. */
+       rcode |= sizep[2] << 4;
+ 
+-      if (option_bool(OPT_CLIENT_SUBNET) && !check_source(header, plen, pheader, query_source))
++      if (option_bool(OPT_CLIENT_SUBNET) && !check_source(header, n, pheader, query_source))
+ 	{
+ 	  my_syslog(LOG_WARNING, _("discarding DNS reply: subnet option mismatch"));
+ 	  return 0;

--- a/package/network/services/dnsmasq/patches/006-CVE-2026-5172.patch
+++ b/package/network/services/dnsmasq/patches/006-CVE-2026-5172.patch
@@ -1,0 +1,26 @@
+commit fa3c8ddef6712b52f562813317e6a997e1210123
+Author: Simon Kelley <simon@thekelleys.org.uk>
+Date:   Mon Mar 30 16:24:33 2026 +0100
+
+    Fix buffer overflow vulnerability in extract_addresses() CVE-2026-5172
+    
+    Thanks to Hugo Martinez Ray for spotting this.
+    
+    The value of rdlen for an RR can be a lie, allowing the
+    call to extract_name() at rfc1025.c:952 to advance the value of p1
+    past the calculated end of the record. The makes the calculation
+    of bytes remaining in the RR underflow to a huge number and results
+    in a massive heap OOB read and certain crash.
+
+--- a/src/rfc1035.c
++++ b/src/rfc1035.c
+@@ -932,7 +932,8 @@ int extract_addresses(struct dns_header
+ 			      /* Name, extract it then re-encode. */
+ 			      int len;
+ 			      
+-			      if (!extract_name(header, qlen, &p1, name, 1, 0))
++			      /* rdlen may lie, and extract_name() advances p1 past where it says the record ends. */
++			      if (!extract_name(header, qlen, &p1, name, 1, 0) || (p1 > endrr))
+ 				{
+ 				  blockdata_free(addr.rrblock.rrdata);
+ 				  return 2;


### PR DESCRIPTION
Apply upstream patches for the recently published CVEs in dnsmasq.

Source: https://thekelleys.org.uk/dnsmasq/CVE/
Reference: https://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2026q2/018471.html


Link: https://github.com/openwrt/openwrt/pull/23328 (cherry picked from commit dc04999b1ff41d6bac64c484e62502f933c32852) [added this to main branch first, 002-CVE-2026-4890.dnsmasq-2.91.patch modified]

(cherry picked from commit 99211b26fb3b9ed71d065a1fa35ce54a0d883944)
