### PR TITLE
ath79: MF286 - Add WAN Interface For LAN/WAN Port

### DIFF
--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -73,10 +73,15 @@ ath79_setup_interfaces()
 		;;
 	zte,mf286|\
 	zte,mf286a|\
-	zte,mf286c|\
-	zte,mf286r)
+	zte,mf286c)
 		ucidef_add_switch "switch0" \
 			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "5:lan:1"
+		;;
+	zte,mf286r)
+		ucidef_add_switch "switch0" \
+			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "5:wan"
+		ucidef_set_interface "wwan" device "/dev/ttyACM0" protocol "ncm"
+		uci add_list firewall.@zone[1].network='wwan'
 		;;
 	zyxel,emg2926-q10a|\
 	zyxel,nbg6716)

--- a/target/linux/ath79/nand/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/nand/base-files/etc/board.d/02_network
@@ -76,7 +76,7 @@ ath79_setup_interfaces()
 	zte,mf286c|\
 	zte,mf286r)
 		ucidef_add_switch "switch0" \
-			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "5:lan:1"
+			"0@eth0" "1:lan:4" "2:lan:3" "3:lan:2" "5:wan"
 		;;
 	zyxel,emg2926-q10a|\
 	zyxel,nbg6716)


### PR DESCRIPTION
The ZTE MF286 has a LAN/WAN-labelled Ethernet port. 
Currently default settings only has a LAN listed

Migration impact - LAN1 becomes WAN for current installs.
variations in model letter at the end are 4G LTE changes only.

<img width="770" height="413" alt="mf286_current" src="https://github.com/user-attachments/assets/0a2dd965-ac37-4dc8-bfe2-8c0dda329f0f" />

---

After patch

<img width="721" height="526" alt="mf286_new" src="https://github.com/user-attachments/assets/b7e28185-a28f-47a6-af2f-9d46cb2293c5" />
