### PR TITLE
airoha: use in-band phylink for RTL8261N USXGMII ports in W1700k

### DIFF
--- a/target/linux/airoha/dts/an7581-w1700k-ubi.dts
+++ b/target/linux/airoha/dts/an7581-w1700k-ubi.dts
@@ -318,9 +318,14 @@
 	nvmem-cell-names = "mac-address";
 };
 
+&pon_pcs {
+	status = "okay";
+};
+
 &gdm2 {
 	status = "okay";
 
+	managed = "in-band-status";
 	phy-handle = <&phy8>;
 	phy-mode = "usxgmii";
 
@@ -329,9 +334,14 @@
 	openwrt,netdev-name = "wan";
 };
 
+&eth_pcs {
+	status = "okay";
+};
+
 &gdm4 {
 	status = "okay";
 
+	managed = "in-band-status";
 	phy-handle = <&phy5>;
 	phy-mode = "usxgmii";
 


### PR DESCRIPTION
After the standalone Airoha PCS driver and pcs-handle binding, wan (gdm2) 
and lan2 (gdm4) netdevs probe but do not pass traffic.
USXGMII link state is provided by the PCS via in-band status.

Same configuration as Nokia Valyrian.