### PR TITLE
kernel: rtl8261n: clear PMA_CTRL LPOWER bit on Realtek SoCs

### DIFF
--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
@@ -63,7 +63,12 @@ static int rtl826xb_probe(struct phy_device *phydev)
     priv->isBasePort = (phydev->drv->phy_id == REALTEK_PHY_ID_RTL8261N) ? (1) : (((phydev->mdio.addr % 4) == 0) ? (1) : (0));
     priv->pnswap_rx = device_property_read_bool(dev, "realtek,pnswap-rx");
     priv->pnswap_tx = device_property_read_bool(dev, "realtek,pnswap-tx");
+    priv->enable_pma_low_power =
+        device_property_read_bool(dev, "realtek,enable-pma-low-power");
     phydev->priv = priv;
+
+    if (!priv->enable_pma_low_power)
+        phydev_warn(phydev, "PMA low-power suspend disabled\n");
 
     return 0;
 }
@@ -145,11 +150,13 @@ static int rtkphy_config_init(struct phy_device *phydev)
 
 static int rtkphy_c45_suspend(struct phy_device *phydev)
 {
-    int ret = 0;
+    struct rtk_phy_priv *priv = phydev->priv;
+    int ret;
 
-#ifndef CONFIG_MACH_REALTEK_RTL
-    ret = rtk_phylib_c45_power_low(phydev);
-#endif
+    if (!priv->enable_pma_low_power)
+        return -EOPNOTSUPP;
+
+    ret = genphy_c45_pma_suspend(phydev);
 
     phydev->speed = SPEED_UNKNOWN;
     phydev->duplex = DUPLEX_UNKNOWN;

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phy.c
@@ -159,15 +159,6 @@ static int rtkphy_c45_suspend(struct phy_device *phydev)
     return ret;
 }
 
-static int rtkphy_c45_resume(struct phy_device *phydev)
-{
-#ifndef CONFIG_MACH_REALTEK_RTL
-    return rtk_phylib_c45_power_normal(phydev);
-#else
-    return 0;
-#endif
-}
-
 static int rtkphy_c45_config_aneg(struct phy_device *phydev)
 {
     bool changed = false;
@@ -274,7 +265,7 @@ static struct phy_driver rtk_phy_drivers[] = {
         .config_init        = rtkphy_config_init,
         .probe              = rtl826xb_probe,
         .suspend            = rtkphy_c45_suspend,
-        .resume             = rtkphy_c45_resume,
+        .resume             = genphy_c45_pma_resume,
         .config_aneg        = rtkphy_c45_config_aneg,
         .aneg_done          = rtkphy_c45_aneg_done,
         .read_status        = rtkphy_c45_read_status,
@@ -286,7 +277,7 @@ static struct phy_driver rtk_phy_drivers[] = {
         .config_init        = rtkphy_config_init,
         .probe              = rtl826xb_probe,
         .suspend            = rtkphy_c45_suspend,
-        .resume             = rtkphy_c45_resume,
+        .resume             = genphy_c45_pma_resume,
         .config_aneg        = rtkphy_c45_config_aneg,
         .aneg_done          = rtkphy_c45_aneg_done,
         .read_status        = rtkphy_c45_read_status,
@@ -298,7 +289,7 @@ static struct phy_driver rtk_phy_drivers[] = {
         .config_init        = rtkphy_config_init,
         .probe              = rtl826xb_probe,
         .suspend            = rtkphy_c45_suspend,
-        .resume             = rtkphy_c45_resume,
+        .resume             = genphy_c45_pma_resume,
         .config_aneg        = rtkphy_c45_config_aneg,
         .aneg_done          = rtkphy_c45_aneg_done,
         .read_status        = rtkphy_c45_read_status,

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.c
@@ -81,14 +81,6 @@ int32 rtk_phylib_mmd_read(rtk_phydev *phydev, uint32 mmd, uint32 reg, uint8 msb,
 
 /* Function Driver */
 
-int32 rtk_phylib_c45_power_low(rtk_phydev *phydev)
-{
-    int32  ret = 0;
-    RTK_PHYLIB_ERR_CHK(rtk_phylib_mmd_write(phydev, 1, 0, 11, 11, 1));
-
-    return 0;
-}
-
 int32 rtk_phylib_c45_pcs_loopback(rtk_phydev *phydev, uint32 enable)
 {
     int32  ret = 0;

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.c
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.c
@@ -81,14 +81,6 @@ int32 rtk_phylib_mmd_read(rtk_phydev *phydev, uint32 mmd, uint32 reg, uint8 msb,
 
 /* Function Driver */
 
-int32 rtk_phylib_c45_power_normal(rtk_phydev *phydev)
-{
-    int32  ret = 0;
-    RTK_PHYLIB_ERR_CHK(rtk_phylib_mmd_write(phydev, 1, 0, 11, 11, 0));
-
-    return 0;
-}
-
 int32 rtk_phylib_c45_power_low(rtk_phydev *phydev)
 {
     int32  ret = 0;

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.h
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.h
@@ -53,6 +53,7 @@ struct rtk_phy_priv {
 
     bool pnswap_rx;
     bool pnswap_tx;
+    bool enable_pma_low_power;
 };
 
 #if defined(RTK_PHYDRV_IN_LINUX)
@@ -98,7 +99,6 @@ int32 rtk_phylib_mmd_write(rtk_phydev *phydev, uint32 mmd, uint32 reg, uint8 msb
 int32 rtk_phylib_mmd_read(rtk_phydev *phydev, uint32 mmd, uint32 reg, uint8 msb, uint8 lsb, uint32 *pData);
 
 /* Function Driver */
-int32 rtk_phylib_c45_power_low(rtk_phydev *phydev);
 int32 rtk_phylib_c45_pcs_loopback(rtk_phydev *phydev, uint32 enable);
 
 

--- a/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.h
+++ b/target/linux/generic/files/drivers/net/phy/rtl8261n/rtk_phylib.h
@@ -98,7 +98,6 @@ int32 rtk_phylib_mmd_write(rtk_phydev *phydev, uint32 mmd, uint32 reg, uint8 msb
 int32 rtk_phylib_mmd_read(rtk_phydev *phydev, uint32 mmd, uint32 reg, uint8 msb, uint8 lsb, uint32 *pData);
 
 /* Function Driver */
-int32 rtk_phylib_c45_power_normal(rtk_phydev *phydev);
 int32 rtk_phylib_c45_power_low(rtk_phydev *phydev);
 int32 rtk_phylib_c45_pcs_loopback(rtk_phydev *phydev, uint32 enable);
 


### PR DESCRIPTION
While working on the Hasivo S1300WP-8XGT-4S, I figured out that the auto-negotiate never starts...
I could get it running by clearing bit 11 (PMA_CTRL)  ... 

Her is  a working branch, for the device - but everything is still pretty hacky and early stage.

https://github.com/openwrt/openwrt/compare/main...carlosz1986:openwrt:hasivo_S1300WP-8XGT-4S-plus_clean
And the discussion is here:
https://forum.openwrt.org/t/hasivo-s1300wp-8xgt-4s/233033/62

I would appreciate feedback from the experts :-)
cheers

