### PR TITLE
[25.12] ramips: backport I-O DATA WN-AX2033GR2 support

### DIFF
--- a/target/linux/ramips/dts/mt7621_iodata_wn-ax2033gr2.dts
+++ b/target/linux/ramips/dts/mt7621_iodata_wn-ax2033gr2.dts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_iodata_wn-xx-xr.dtsi"
+
+/ {
+	compatible = "iodata,wn-ax2033gr2", "mediatek,mt7621-soc";
+	model = "I-O DATA WN-AX2033GR2";
+};
+
+&partitions {
+	partition@6b00000 {
+		label = "Backup";
+		reg = <0x6b00000 0x1480000>;
+		read-only;
+	};
+};
+
+&pcie0 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_0>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <2400000 2483000>;
+	};
+};
+
+&pcie1 {
+	wifi@0,0 {
+		compatible = "mediatek,mt76";
+		reg = <0x0000 0 0 0 0>;
+		nvmem-cells = <&eeprom_factory_8000>;
+		nvmem-cell-names = "eeprom";
+		ieee80211-freq-limit = <5000000 5710000>;
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1753,6 +1753,15 @@ define Device/iodata_wn-ax2033gr
 endef
 TARGET_DEVICES += iodata_wn-ax2033gr
 
+define Device/iodata_wn-ax2033gr2
+  $(Device/iodata_nand)
+  DEVICE_MODEL := WN-AX2033GR2
+  KERNEL_INITRAMFS := $(KERNEL_DTB) | loader-kernel | lzma | \
+	uImage lzma -M 0x434f4d42 -n '3.10(XBH.0)b50' | iodata-mstc-header
+  DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615-firmware -uboot-envtools
+endef
+TARGET_DEVICES += iodata_wn-ax2033gr2
+
 define Device/iodata_wn-deax1800gr
   $(Device/dsa-migration)
   DEVICE_VENDOR := I-O DATA

--- a/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/mt7621/base-files/lib/upgrade/platform.sh
@@ -177,6 +177,7 @@ platform_do_upgrade() {
 		;;
 	iodata,wn-ax1167gr2|\
 	iodata,wn-ax2033gr|\
+	iodata,wn-ax2033gr2|\
 	iodata,wn-dx1167r|\
 	iodata,wn-dx2033gr)
 		iodata_mstc_set_flag "debugflag" "factory" "0xfe75" "0,1" "1"


### PR DESCRIPTION
### Description

This is a backport of the I-O DATA WN-AX2033GR2 support to the `openwrt-25.12` branch.
The original changes have already been merged into the master branch.

### Link to original PR

- Cherry-picked from master.
- Original PR: #22762

### Target Device

- **Brand:** I-O DATA
- **Model:** WN-AX2033GR2