### PR TITLE
kernel: crypto selftests fixes

### DIFF
--- a/target/linux/generic/backport-6.12/916-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
+++ b/target/linux/generic/backport-6.12/916-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  	}, {
  		.alg = "authenc(hmac(sha1),rfc3686(ctr(aes)))",
 -		.test = alg_test_null,
-+		.generic_driver = "authenc(hmac-sha1-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-sha1-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
  		.fips_allowed = 1,
 +		.suite = {

--- a/target/linux/generic/backport-6.12/917-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
+++ b/target/linux/generic/backport-6.12/917-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  	}, {
  		.alg = "authenc(hmac(sha224),rfc3686(ctr(aes)))",
 -		.test = alg_test_null,
-+		.generic_driver = "authenc(hmac-sha224-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-sha224-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
  		.fips_allowed = 1,
 +		.suite = {

--- a/target/linux/generic/backport-6.12/918-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
+++ b/target/linux/generic/backport-6.12/918-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  	}, {
  		.alg = "authenc(hmac(sha256),rfc3686(ctr(aes)))",
 -		.test = alg_test_null,
-+		.generic_driver = "authenc(hmac-sha256-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-sha256-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
  		.fips_allowed = 1,
 +		.suite = {

--- a/target/linux/generic/backport-6.12/919-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
+++ b/target/linux/generic/backport-6.12/919-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  	}, {
  		.alg = "authenc(hmac(sha384),rfc3686(ctr(aes)))",
 -		.test = alg_test_null,
-+		.generic_driver = "authenc(hmac-sha384-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-sha384-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
  		.fips_allowed = 1,
 +		.suite = {

--- a/target/linux/generic/backport-6.12/920-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
+++ b/target/linux/generic/backport-6.12/920-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  	}, {
  		.alg = "authenc(hmac(sha512),rfc3686(ctr(aes)))",
 -		.test = alg_test_null,
-+		.generic_driver = "authenc(hmac-sha512-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-sha512-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
  		.fips_allowed = 1,
 +		.suite = {

--- a/target/linux/generic/backport-6.12/922-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-md5.patch
+++ b/target/linux/generic/backport-6.12/922-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-md5.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  		}
  	}, {
 +		.alg = "authenc(hmac(md5),rfc3686(ctr(aes)))",
-+		.generic_driver = "authenc(hmac-md5-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-md5-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
 +		.suite = {
 +			.aead = __VECS(hmac_md5_aes_ctr_rfc3686_tv_temp)

--- a/target/linux/generic/backport-6.12/923-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-md5.patch
+++ b/target/linux/generic/backport-6.12/923-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-md5.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  		}
  	}, {
 +		.alg = "authenc(hmac(md5),cbc(aes))",
-+		.generic_driver = "authenc(hmac-md5-lib,cbc(aes-lib))",
++		.generic_driver = "authenc(hmac-md5-lib,cbc(aes-generic))",
 +		.test = alg_test_aead,
 +		.suite = {
 +			.aead = __VECS(hmac_md5_aes_cbc_tv_temp)

--- a/target/linux/generic/backport-6.12/932-v7.1-crypto-tcrypt-clamp-num_mb-to-avoid-divide-by-zero.patch
+++ b/target/linux/generic/backport-6.12/932-v7.1-crypto-tcrypt-clamp-num_mb-to-avoid-divide-by-zero.patch
@@ -1,0 +1,36 @@
+From 32e76e3757e89f370bf2ac8dba8aeb133071834e Mon Sep 17 00:00:00 2001
+From: Saeed Mirzamohammadi <saeed.mirzamohammadi@oracle.com>
+Date: Mon, 2 Mar 2026 15:59:14 -0800
+Subject: [PATCH] crypto: tcrypt - clamp num_mb to avoid divide-by-zero
+
+Passing num_mb=0 to the multibuffer speed tests leaves test_mb_aead_cycles()
+and test_mb_acipher_cycles() dividing by (8 * num_mb). With sec=0 (the
+default), the module prints "1 operation in ..." and hits a divide-by-zero
+fault.
+
+Force num_mb to at least 1 during module init and warn the caller so the
+warm-up loop and the final report stay well-defined.
+
+To reproduce:
+sudo modprobe tcrypt mode=600 num_mb=0
+
+Signed-off-by: Saeed Mirzamohammadi <saeed.mirzamohammadi@oracle.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ crypto/tcrypt.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/crypto/tcrypt.c
++++ b/crypto/tcrypt.c
+@@ -2832,6 +2832,11 @@ static int __init tcrypt_mod_init(void)
+ 			goto err_free_tv;
+ 	}
+ 
++	if (!num_mb) {
++		pr_warn("num_mb must be at least 1; forcing to 1\n");
++		num_mb = 1;
++	}
++
+ 	err = do_test(alg, type, mask, mode, num_mb);
+ 
+ 	if (err) {

--- a/target/linux/generic/backport-6.12/933-v7.1-crypto-tcrypt-stop-ahash-speed-tests-when-setkey-fai.patch
+++ b/target/linux/generic/backport-6.12/933-v7.1-crypto-tcrypt-stop-ahash-speed-tests-when-setkey-fai.patch
@@ -1,0 +1,36 @@
+From 03170b8f84354f1649a757e57c2130e1de237f5d Mon Sep 17 00:00:00 2001
+From: Saeed Mirzamohammadi <saeed.mirzamohammadi@oracle.com>
+Date: Mon, 2 Mar 2026 16:06:40 -0800
+Subject: [PATCH] crypto: tcrypt - stop ahash speed tests when setkey fails
+
+The async hash speed path ignores the return code from
+crypto_ahash_setkey().  If the caller picks an unsupported key length,
+the transform keeps whatever key state it already has and the speed test
+still runs, producing misleading numbers, hence bail out of the loop when
+setkey fails.
+
+Signed-off-by: Saeed Mirzamohammadi <saeed.mirzamohammadi@oracle.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ crypto/tcrypt.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+--- a/crypto/tcrypt.c
++++ b/crypto/tcrypt.c
+@@ -911,8 +911,14 @@ static void test_ahash_speed_common(cons
+ 			break;
+ 		}
+ 
+-		if (klen)
+-			crypto_ahash_setkey(tfm, tvmem[0], klen);
++		if (klen) {
++			ret = crypto_ahash_setkey(tfm, tvmem[0], klen);
++			if (ret) {
++				pr_err("setkey() failed flags=%x: %d\n",
++				       crypto_ahash_get_flags(tfm), ret);
++				break;
++			}
++		}
+ 
+ 		pr_info("test%3u "
+ 			"(%5u byte blocks,%5u bytes per update,%4u updates): ",

--- a/target/linux/generic/backport-6.18/916-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
+++ b/target/linux/generic/backport-6.18/916-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  	}, {
  		.alg = "authenc(hmac(sha1),rfc3686(ctr(aes)))",
 -		.test = alg_test_null,
-+		.generic_driver = "authenc(hmac-sha1-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-sha1-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
  		.fips_allowed = 1,
 +		.suite = {

--- a/target/linux/generic/backport-6.18/917-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
+++ b/target/linux/generic/backport-6.18/917-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  	}, {
  		.alg = "authenc(hmac(sha224),rfc3686(ctr(aes)))",
 -		.test = alg_test_null,
-+		.generic_driver = "authenc(hmac-sha224-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-sha224-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
  		.fips_allowed = 1,
 +		.suite = {

--- a/target/linux/generic/backport-6.18/918-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
+++ b/target/linux/generic/backport-6.18/918-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  	}, {
  		.alg = "authenc(hmac(sha256),rfc3686(ctr(aes)))",
 -		.test = alg_test_null,
-+		.generic_driver = "authenc(hmac-sha256-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-sha256-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
  		.fips_allowed = 1,
 +		.suite = {

--- a/target/linux/generic/backport-6.18/919-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
+++ b/target/linux/generic/backport-6.18/919-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  	}, {
  		.alg = "authenc(hmac(sha384),rfc3686(ctr(aes)))",
 -		.test = alg_test_null,
-+		.generic_driver = "authenc(hmac-sha384-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-sha384-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
  		.fips_allowed = 1,
 +		.suite = {

--- a/target/linux/generic/backport-6.18/920-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
+++ b/target/linux/generic/backport-6.18/920-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-sha.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  	}, {
  		.alg = "authenc(hmac(sha512),rfc3686(ctr(aes)))",
 -		.test = alg_test_null,
-+		.generic_driver = "authenc(hmac-sha512-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-sha512-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
  		.fips_allowed = 1,
 +		.suite = {

--- a/target/linux/generic/backport-6.18/922-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-md5.patch
+++ b/target/linux/generic/backport-6.18/922-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-md5.patch
@@ -23,7 +23,7 @@ Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
  		}
  	}, {
 +		.alg = "authenc(hmac(md5),rfc3686(ctr(aes)))",
-+		.generic_driver = "authenc(hmac-md5-lib,rfc3686(ctr(aes-lib)))",
++		.generic_driver = "authenc(hmac-md5-lib,rfc3686(ctr(aes-generic)))",
 +		.test = alg_test_aead,
 +		.suite = {
 +			.aead = __VECS(hmac_md5_aes_ctr_rfc3686_tv_temp)

--- a/target/linux/generic/backport-6.18/923-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-md5.patch
+++ b/target/linux/generic/backport-6.18/923-v7.1-crypto-testmgr-Add-test-vectors-for-authenc-hmac-md5.patch
@@ -1,6 +1,6 @@
-From dd227f442774a570ffccdfbc9536fec3b4666305 Mon Sep 17 00:00:00 2001
+From c8aadd63ab58ee75713ab487730563e7a160cc35 Mon Sep 17 00:00:00 2001
 From: Aleksander Jan Bajkowski <olek2@wp.pl>
-Date: Sat, 31 Jan 2026 12:35:30 +0100
+Date: Tue, 3 Mar 2026 19:48:44 +0100
 Subject: [PATCH] crypto: testmgr - Add test vectors for
  authenc(hmac(md5),cbc(aes))
 
@@ -10,6 +10,7 @@ script. Then, the results were double-checked on Mediatek MT7981 (safexcel)
 and NXP P2020 (talitos). Both platforms pass self-tests.
 
 Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
 ---
  crypto/testmgr.c |   7 ++
  crypto/testmgr.h | 255 +++++++++++++++++++++++++++++++++++++++++++++++

--- a/target/linux/generic/backport-6.18/932-v7.1-crypto-tcrypt-clamp-num_mb-to-avoid-divide-by-zero.patch
+++ b/target/linux/generic/backport-6.18/932-v7.1-crypto-tcrypt-clamp-num_mb-to-avoid-divide-by-zero.patch
@@ -1,0 +1,36 @@
+From 32e76e3757e89f370bf2ac8dba8aeb133071834e Mon Sep 17 00:00:00 2001
+From: Saeed Mirzamohammadi <saeed.mirzamohammadi@oracle.com>
+Date: Mon, 2 Mar 2026 15:59:14 -0800
+Subject: [PATCH] crypto: tcrypt - clamp num_mb to avoid divide-by-zero
+
+Passing num_mb=0 to the multibuffer speed tests leaves test_mb_aead_cycles()
+and test_mb_acipher_cycles() dividing by (8 * num_mb). With sec=0 (the
+default), the module prints "1 operation in ..." and hits a divide-by-zero
+fault.
+
+Force num_mb to at least 1 during module init and warn the caller so the
+warm-up loop and the final report stay well-defined.
+
+To reproduce:
+sudo modprobe tcrypt mode=600 num_mb=0
+
+Signed-off-by: Saeed Mirzamohammadi <saeed.mirzamohammadi@oracle.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ crypto/tcrypt.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/crypto/tcrypt.c
++++ b/crypto/tcrypt.c
+@@ -2820,6 +2820,11 @@ static int __init tcrypt_mod_init(void)
+ 			goto err_free_tv;
+ 	}
+ 
++	if (!num_mb) {
++		pr_warn("num_mb must be at least 1; forcing to 1\n");
++		num_mb = 1;
++	}
++
+ 	err = do_test(alg, type, mask, mode, num_mb);
+ 
+ 	if (err) {

--- a/target/linux/generic/backport-6.18/933-v7.1-crypto-tcrypt-stop-ahash-speed-tests-when-setkey-fai.patch
+++ b/target/linux/generic/backport-6.18/933-v7.1-crypto-tcrypt-stop-ahash-speed-tests-when-setkey-fai.patch
@@ -1,0 +1,36 @@
+From 03170b8f84354f1649a757e57c2130e1de237f5d Mon Sep 17 00:00:00 2001
+From: Saeed Mirzamohammadi <saeed.mirzamohammadi@oracle.com>
+Date: Mon, 2 Mar 2026 16:06:40 -0800
+Subject: [PATCH] crypto: tcrypt - stop ahash speed tests when setkey fails
+
+The async hash speed path ignores the return code from
+crypto_ahash_setkey().  If the caller picks an unsupported key length,
+the transform keeps whatever key state it already has and the speed test
+still runs, producing misleading numbers, hence bail out of the loop when
+setkey fails.
+
+Signed-off-by: Saeed Mirzamohammadi <saeed.mirzamohammadi@oracle.com>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+---
+ crypto/tcrypt.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+--- a/crypto/tcrypt.c
++++ b/crypto/tcrypt.c
+@@ -911,8 +911,14 @@ static void test_ahash_speed_common(cons
+ 			break;
+ 		}
+ 
+-		if (klen)
+-			crypto_ahash_setkey(tfm, tvmem[0], klen);
++		if (klen) {
++			ret = crypto_ahash_setkey(tfm, tvmem[0], klen);
++			if (ret) {
++				pr_err("setkey() failed flags=%x: %d\n",
++				       crypto_ahash_get_flags(tfm), ret);
++				break;
++			}
++		}
+ 
+ 		pr_info("test%3u "
+ 			"(%5u byte blocks,%5u bytes per update,%4u updates): ",


### PR DESCRIPTION
This PR contains three changes:
* backport tcrypt fixes,
* replace aes-lib with aes-generic in testmgt tests,
* replace testmgr patch with upstream version.

These changes should help identify problems in crypto drivers.

Signed-off-by: Aleksander Jan Bajkowski <olek2@wp.pl>
