### PR TITLE
button-hotplug: add KEY_SETUP and KEY_VENDOR handling

### DIFF
--- a/package/kernel/button-hotplug/src/button-hotplug.c
+++ b/package/kernel/button-hotplug/src/button-hotplug.c
@@ -87,6 +87,8 @@ static const struct bh_map button_map[] = {
 	BH_MAP(KEY_POWER,	"power"),
 	BH_MAP(KEY_POWER2,	"reboot"),
 	BH_MAP(KEY_RFKILL,	"rfkill"),
+	BH_MAP(KEY_SETUP,	"setup"),
+	BH_MAP(KEY_VENDOR,	"vendor"),
 	BH_MAP(KEY_WPS_BUTTON,	"wps"),
 	BH_MAP(KEY_WIMAX,	"wwan"),
 };


### PR DESCRIPTION
Add KEY_SETUP and KEY_VENDOR keys. Many Rockchip devices, including all of those in e13cbab6840b ("rockchip: enable SARADC; add buttons hotplug and ADC kmods to default packages") have one or both of these buttons.
