### PR TITLE
realtek: various fixes for XS1930 switches

### DIFF
--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-10.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-10.dts
@@ -13,33 +13,6 @@
 	compatible = "zyxel,xs1930-10", "realtek,rtl9313-soc";
 	model = "Zyxel XS1930-10";
 
-	leds {
-		led_pwr_green: led-2 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_POWER;
-			gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
-			default-state = "on";
-		};
-		led_pwr_red: led-3 {
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_POWER;
-			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
-		};
-		led_cloud_green: led-4 {
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
-		};
-		led_cloud_red: led-5 {
-			color = <LED_COLOR_ID_RED>;
-			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
-		};
-		led_locator: led-6 {
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_INDICATOR;
-			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
-		};
-	};
-
 	led_set: led_set@0 {
 		compatible = "realtek,rtl9300-leds";
 		active-low;

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-10.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-10.dts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /dts-v1/;
 
-#include "rtl9313_zyxel_xs1930.dtsi"
+#include "rtl9313_zyxel_xs1930-aqr813.dtsi"
 
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
@@ -12,104 +12,10 @@
 / {
 	compatible = "zyxel,xs1930-10", "realtek,rtl9313-soc";
 	model = "Zyxel XS1930-10";
-
-	led_set: led_set@0 {
-		compatible = "realtek,rtl9300-leds";
-		active-low;
-
-		/* Blue | Green | Red */
-		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
-			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
-			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M |
-			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
-			    (RTL93XX_LED_SET_5G | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_LINK |
-			     RTL93XX_LED_SET_ACT)>;
-
-		realtek,led-set0-force-port-mask = <0x00300000 0x00000000>;
-	};
-
-	sfp_gpio_mux: gpio-mux {
-		compatible = "gpio-mux";
-		mux-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>,
-			    <&gpio0 14 GPIO_ACTIVE_HIGH>;
-		#mux-control-cells = <0>;
-		idle-state = <MUX_IDLE_AS_IS>;
-	};
-
-	sfp1_gpio: sfp-gpio-1 {
-		compatible = "gpio-line-mux";
-		gpio-controller;
-		#gpio-cells = <2>;
-
-		mux-controls = <&sfp_gpio_mux>;
-		muxed-gpio = <&gpio0 19 GPIO_ACTIVE_HIGH>;
-
-		gpio-line-names = "SFP1_LOS", "SFP1_MOD_ABS", "SFP1_TX_FAULT";
-		gpio-line-mux-states = <0>, <1>, <3>;
-	};
-
-	sfp2_gpio: sfp-gpio-2 {
-		compatible = "gpio-line-mux";
-		gpio-controller;
-		#gpio-cells = <2>;
-
-		mux-controls = <&sfp_gpio_mux>;
-		muxed-gpio = <&gpio0 27 GPIO_ACTIVE_HIGH>;
-
-		gpio-line-names = "SFP2_LOS", "SFP2_MOD_ABS", "SFP2_TX_FAULT";
-		gpio-line-mux-states = <0>, <1>, <3>;
-	};
-
-	sfp1: sfp-p1 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c0>;
-		los-gpio = <&sfp1_gpio 0 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&sfp1_gpio 1 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio0 5 GPIO_ACTIVE_HIGH>;
-		tx-fault-gpio = <&sfp1_gpio 2 GPIO_ACTIVE_HIGH>;
-	};
-
-	sfp2: sfp-p2 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c1>;
-		los-gpio = <&sfp2_gpio 0 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&sfp2_gpio 1 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio0 11 GPIO_ACTIVE_HIGH>;
-		tx-fault-gpio = <&sfp2_gpio 2 GPIO_ACTIVE_HIGH>;
-	};
 };
 
-&gpio0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pinmux_disable_jtag>;
-
-	sfp_enable_hog {
-		gpio-hog;
-		gpios = <6 GPIO_ACTIVE_LOW>,
-			<7 GPIO_ACTIVE_LOW>;
-		output-high;
-		line-name = "sfp-enable";
-	};
-};
-
-&i2c_mst1 {
-	status = "okay";
-
-	i2c0: i2c@0 {
-		reg = <0>;
-	};
-	i2c1: i2c@1 {
-		reg = <1>;
-	};
-
-	i2c2: i2c@2 {
-		reg = <2>;
-
-		lm96000: lm96000@2e {
-			compatible = "national,lm85";
-			reg = <0x2e>;
-		};
-	};
+&led_set {
+	realtek,led-set0-force-port-mask = <0x00300000 0x00000000>;
 };
 
 &mdio_ctrl {
@@ -117,106 +23,9 @@
 	pinctrl-0 = <&pinmux_enable_mdc_mdio_0>;
 };
 
-&mdio_bus0 {
-	/* External Aquantia AQR813 */
-	PHY_C45(0, 8)
-	PHY_C45(8, 9)
-	PHY_C45(16, 10)
-	PHY_C45(24, 11)
-	PHY_C45(32, 12)
-	PHY_C45(40, 13)
-	PHY_C45(48, 14)
-	PHY_C45(50, 15)
-};
-
 &switch0 {
 	ethernet-ports {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		/* Copper ports behind AQR813 */
-		SWITCH_PORT_LED(0, 1, 2, 0, usxgmii)
-		SWITCH_PORT_LED(8, 2, 3, 0, usxgmii)
-		SWITCH_PORT_LED(16, 3, 4, 0, usxgmii)
-		SWITCH_PORT_LED(24, 4, 5, 0, usxgmii)
-		SWITCH_PORT_LED(32, 5, 6, 0, usxgmii)
-		SWITCH_PORT_LED(40, 6, 7, 0, usxgmii)
-		SWITCH_PORT_LED(48, 7, 8, 0, usxgmii)
-		SWITCH_PORT_LED(50, 8, 9, 0, usxgmii)
-
-		/* SFP+ ports */
 		SWITCH_PORT_SFP(54, 9, 12, 0, 1)
 		SWITCH_PORT_SFP(55, 10, 13, 0, 2)
-
-		/* CPU port */
-		port@56 {
-			reg = <56>;
-			ethernet = <&ethernet0>;
-			phy-mode = "internal";
-			fixed-link {
-				speed = <1000>;
-				full-duplex;
-			};
-		};
 	};
-};
-
-&port0 {
-	managed = "in-band-status";
-};
-
-&port8 {
-	managed = "in-band-status";
-};
-
-&port16 {
-	managed = "in-band-status";
-};
-
-&port24 {
-	managed = "in-band-status";
-};
-
-&port32 {
-	managed = "in-band-status";
-};
-
-&port40 {
-	managed = "in-band-status";
-};
-
-&port48 {
-	managed = "in-band-status";
-};
-
-&port50 {
-	managed = "in-band-status";
-};
-
-&serdes6 {
-	rx-polarity = <PHY_POL_INVERT>;
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes7 {
-	rx-polarity = <PHY_POL_INVERT>;
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes8 {
-	rx-polarity = <PHY_POL_INVERT>;
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes9 {
-	rx-polarity = <PHY_POL_INVERT>;
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes12 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes13 {
-	tx-polarity = <PHY_POL_INVERT>;
 };

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12f.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12f.dts
@@ -115,41 +115,21 @@
 &i2c_mst1 {
 	status = "okay";
 
-	i2c0: i2c@0 {
-		reg = <0>;
-	};
-	i2c1: i2c@1 {
-		reg = <1>;
-	};
-	i2c2: i2c@2 {
-		reg = <2>;
-	};
-	i2c3: i2c@3 {
-		reg = <3>;
-	};
-	i2c4: i2c@4 {
-		reg = <4>;
-	};
-	i2c5: i2c@5 {
-		reg = <5>;
-	};
+	i2c0: i2c@0 { reg = <0>; };
+	i2c1: i2c@1 { reg = <1>; };
+	i2c2: i2c@2 { reg = <2>; };
+	i2c3: i2c@3 { reg = <3>; };
+	i2c4: i2c@4 { reg = <4>; };
+	i2c5: i2c@5 { reg = <5>; };
 };
 
 &i2c_mst2 {
 	status = "okay";
 
-	i2c6: i2c@6 {
-		reg = <6>;
-	};
-	i2c7: i2c@7 {
-		reg = <7>;
-	};
-	i2c8: i2c@8 {
-		reg = <8>;
-	};
-	i2c9: i2c@9 {
-		reg = <9>;
-	};
+	i2c6: i2c@6 { reg = <6>; };
+	i2c7: i2c@7 { reg = <7>; };
+	i2c8: i2c@8 { reg = <8>; };
+	i2c9: i2c@9 { reg = <9>; };
 
 	i2c11: i2c@b {
 		reg = <0xb>;
@@ -266,51 +246,17 @@
 	};
 };
 
-&port54 {
-	managed = "in-band-status";
-};
+&port54 { managed = "in-band-status"; };
+&port55 { managed = "in-band-status"; };
 
-&port55 {
-	managed = "in-band-status";
-};
-
-&serdes2 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes3 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes4 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes5 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes6 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes7 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes8 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes9 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes10 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes11 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
+&serdes2 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes3 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes4 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes5 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes6 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes7 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes8 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes9 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes10 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes11 { tx-polarity = <PHY_POL_INVERT>; };
 

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12f.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12f.dts
@@ -13,24 +13,6 @@
 	compatible = "zyxel,xs1930-12f", "realtek,rtl9313-soc";
 	model = "Zyxel XS1930-12F";
 
-	led_set: led_set@0 {
-		compatible = "realtek,rtl9300-leds";
-		active-low;
-
-		/* SFP ports */
-		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_LINK |
-			     RTL93XX_LED_SET_ACT)
-			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G | RTL93XX_LED_SET_LINK |
-			     RTL93XX_LED_SET_ACT)>;
-		/* Base-T ports */
-		led_set1 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
-			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
-			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M |
-			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
-			    (RTL93XX_LED_SET_5G | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_LINK |
-			     RTL93XX_LED_SET_ACT)>;
-	};
-
 	sfp1: sfp-p1 {
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c0>;
@@ -211,6 +193,14 @@
 &led_cloud_red { gpios = <&gpio1 16 GPIO_ACTIVE_LOW>; };
 &led_locator { gpios = <&gpio1 15 GPIO_ACTIVE_LOW>; };
 
+&led_set {
+	/* SFP ports */
+	led_set1 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_LINK |
+		     RTL93XX_LED_SET_ACT)
+		    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G | RTL93XX_LED_SET_LINK |
+		     RTL93XX_LED_SET_ACT)>;
+};
+
 &mdio_aux {
 	status = "okay";
 
@@ -248,20 +238,20 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		SWITCH_PORT_SFP(0, 1, 2, 0, 1)
-		SWITCH_PORT_SFP(8, 2, 3, 0, 2)
-		SWITCH_PORT_SFP(16, 3, 4, 0, 3)
-		SWITCH_PORT_SFP(24, 4, 5, 0, 4)
-		SWITCH_PORT_SFP(32, 5, 6, 0, 5)
-		SWITCH_PORT_SFP(40, 6, 7, 0, 6)
-		SWITCH_PORT_SFP(48, 7, 8, 0, 7)
-		SWITCH_PORT_SFP(50, 8, 9, 0, 8)
-		SWITCH_PORT_SFP(52, 9, 10, 0, 9)
-		SWITCH_PORT_SFP(53, 10, 11, 0, 10)
+		SWITCH_PORT_SFP(0, 1, 2, 1, 1)
+		SWITCH_PORT_SFP(8, 2, 3, 1, 2)
+		SWITCH_PORT_SFP(16, 3, 4, 1, 3)
+		SWITCH_PORT_SFP(24, 4, 5, 1, 4)
+		SWITCH_PORT_SFP(32, 5, 6, 1, 5)
+		SWITCH_PORT_SFP(40, 6, 7, 1, 6)
+		SWITCH_PORT_SFP(48, 7, 8, 1, 7)
+		SWITCH_PORT_SFP(50, 8, 9, 1, 8)
+		SWITCH_PORT_SFP(52, 9, 10, 1, 9)
+		SWITCH_PORT_SFP(53, 10, 11, 1, 10)
 
 		/* Base-T ports */
-		SWITCH_PORT_LED(54, 11, 12, 1, usxgmii)
-		SWITCH_PORT_LED(55, 12, 13, 1, usxgmii)
+		SWITCH_PORT_LED(54, 11, 12, 0, usxgmii)
+		SWITCH_PORT_LED(55, 12, 13, 0, usxgmii)
 
 		/* CPU port */
 		port@56 {

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12f.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12f.dts
@@ -13,33 +13,6 @@
 	compatible = "zyxel,xs1930-12f", "realtek,rtl9313-soc";
 	model = "Zyxel XS1930-12F";
 
-	leds {
-		led_pwr_green: led-2 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_POWER;
-			gpios = <&gpio2 10 GPIO_ACTIVE_HIGH>;
-			default-state = "on";
-		};
-		led_pwr_red: led-3 {
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_POWER;
-			gpios = <&gpio2 11 GPIO_ACTIVE_LOW>;
-		};
-		led_cloud_green: led-4 {
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&gpio1 17 GPIO_ACTIVE_LOW>;
-		};
-		led_cloud_red: led-5 {
-			color = <LED_COLOR_ID_RED>;
-			gpios = <&gpio1 16 GPIO_ACTIVE_LOW>;
-		};
-		led_locator: led-6 {
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_INDICATOR;
-			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
-		};
-	};
-
 	led_set: led_set@0 {
 		compatible = "realtek,rtl9300-leds";
 		active-low;
@@ -229,6 +202,12 @@
 		};
 	};
 };
+
+&led_pwr_green { gpios = <&gpio2 10 GPIO_ACTIVE_HIGH>; };
+&led_pwr_red { gpios = <&gpio2 11 GPIO_ACTIVE_LOW>; };
+&led_cloud_green { gpios = <&gpio1 17 GPIO_ACTIVE_LOW>; };
+&led_cloud_red { gpios = <&gpio1 16 GPIO_ACTIVE_LOW>; };
+&led_locator { gpios = <&gpio1 15 GPIO_ACTIVE_LOW>; };
 
 &mdio_aux {
 	status = "okay";

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12f.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12f.dts
@@ -122,6 +122,8 @@
 	};
 };
 
+&fan0 { gpios = <&gpio1 35 GPIO_ACTIVE_HIGH>; };
+
 &gpio0 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinmux_disable_jtag>,

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
@@ -31,6 +31,9 @@
 	realtek,led-set1-force-port-mask = <0x00000000 0x00000800>;
 };
 
+&led_sys_green { gpios = <&gpio0 23 GPIO_ACTIVE_LOW>; };
+&led_sys_red { gpios = <&gpio0 0 GPIO_ACTIVE_LOW>; };
+
 &gpio0 {
 	poe_enable_hog {
 		gpio-hog;

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
@@ -13,33 +13,6 @@
 	compatible = "zyxel,xs1930-12hp", "realtek,rtl9313-soc";
 	model = "Zyxel XS1930-12HP";
 
-	leds {
-		led_pwr_green: led-2 {
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_POWER;
-			gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
-			default-state = "on";
-		};
-		led_pwr_red: led-3 {
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_POWER;
-			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
-		};
-		led_cloud_green: led-4 {
-			color = <LED_COLOR_ID_GREEN>;
-			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
-		};
-		led_cloud_red: led-5 {
-			color = <LED_COLOR_ID_RED>;
-			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
-		};
-		led_locator: led-6 {
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_INDICATOR;
-			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
-		};
-	};
-
 	led_set: led_set@0 {
 		compatible = "realtek,rtl9300-leds";
 		active-low;

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
@@ -53,9 +53,7 @@
 
 &i2c_mst1 {
 	/* PoE management MCU sits here */
-	i2c3: i2c@3 {
-		reg = <3>;
-	};
+	i2c3: i2c@3 { reg = <3>; };
 };
 
 &mdio_ctrl {
@@ -84,19 +82,9 @@
 	};
 };
 
-&port52 {
-	managed = "in-band-status";
-};
+&port52 { managed = "in-band-status"; };
+&port53 { managed = "in-band-status"; };
 
-&port53 {
-	managed = "in-band-status";
-};
-
-&serdes10 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes11 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
+&serdes10 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes11 { tx-polarity = <PHY_POL_INVERT>; };
 

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
@@ -12,6 +12,14 @@
 / {
 	compatible = "zyxel,xs1930-12hp", "realtek,rtl9313-soc";
 	model = "Zyxel XS1930-12HP";
+
+	leds {
+		led_poe_max: led-7 {
+			color = <LED_COLOR_ID_RED>;
+			function = "poe-usage";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		};
+	};
 };
 
 &led_set {

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /dts-v1/;
 
-#include "rtl9313_zyxel_xs1930.dtsi"
+#include "rtl9313_zyxel_xs1930-aqr813.dtsi"
 
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/gpio/gpio.h>
@@ -12,96 +12,26 @@
 / {
 	compatible = "zyxel,xs1930-12hp", "realtek,rtl9313-soc";
 	model = "Zyxel XS1930-12HP";
+};
 
-	led_set: led_set@0 {
-		compatible = "realtek,rtl9300-leds";
-		active-low;
+&led_set {
+	/* Phantom port chain padding (2 LEDs) */
+	led_set1 = <RTL93XX_LED_SET_NONE
+		    RTL93XX_LED_SET_NONE>;
 
-		/* Blue | Green | Red */
-		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
-			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
-			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M |
-			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
-			    (RTL93XX_LED_SET_5G | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_LINK |
-			     RTL93XX_LED_SET_ACT)>;
-		/* Phantom port chain padding (2 LEDs) */
-		led_set1 = <RTL93XX_LED_SET_NONE
-			    RTL93XX_LED_SET_NONE>;
-
-		/* The LED PCB has two daisy-chained RTL8231 in scan mode.
-		 * Net LEDs for P3-P12 are on the first RTL8231, P1/P2
-		 * net LEDs are on the second. The 12 real ports provide
-		 * 36 LED bits but the chain requires 65 bits to correctly
-		 * span both chips. Phantom ports 1-7, 9-10 (set0, 3 LEDs
-		 * each) and port 11 (set1, 2 LEDs) pad the chain with
-		 * the remaining 29 bits.
-		 */
-		realtek,led-set0-force-port-mask = <0x00000000 0x000006FE>;
-		realtek,led-set1-force-port-mask = <0x00000000 0x00000800>;
-	};
-
-	sfp_gpio_mux: gpio-mux {
-		compatible = "gpio-mux";
-		mux-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>,
-			    <&gpio0 14 GPIO_ACTIVE_HIGH>;
-		#mux-control-cells = <0>;
-		idle-state = <MUX_IDLE_AS_IS>;
-	};
-
-	sfp1_gpio: sfp-gpio-1 {
-		compatible = "gpio-line-mux";
-		gpio-controller;
-		#gpio-cells = <2>;
-
-		mux-controls = <&sfp_gpio_mux>;
-		muxed-gpio = <&gpio0 19 GPIO_ACTIVE_HIGH>;
-
-		gpio-line-names = "SFP1_LOS", "SFP1_MOD_ABS", "SFP1_TX_FAULT";
-		gpio-line-mux-states = <0>, <1>, <3>;
-	};
-
-	sfp2_gpio: sfp-gpio-2 {
-		compatible = "gpio-line-mux";
-		gpio-controller;
-		#gpio-cells = <2>;
-
-		mux-controls = <&sfp_gpio_mux>;
-		muxed-gpio = <&gpio0 27 GPIO_ACTIVE_HIGH>;
-
-		gpio-line-names = "SFP2_LOS", "SFP2_MOD_ABS", "SFP2_TX_FAULT";
-		gpio-line-mux-states = <0>, <1>, <3>;
-	};
-
-	sfp1: sfp-p1 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c0>;
-		los-gpio = <&sfp1_gpio 0 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&sfp1_gpio 1 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio0 5 GPIO_ACTIVE_HIGH>;
-		tx-fault-gpio = <&sfp1_gpio 2 GPIO_ACTIVE_HIGH>;
-	};
-
-	sfp2: sfp-p2 {
-		compatible = "sff,sfp";
-		i2c-bus = <&i2c1>;
-		los-gpio = <&sfp2_gpio 0 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&sfp2_gpio 1 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio0 11 GPIO_ACTIVE_HIGH>;
-		tx-fault-gpio = <&sfp2_gpio 2 GPIO_ACTIVE_HIGH>;
-	};
+	/* The LED PCB has two daisy-chained RTL8231 in scan mode.
+	 * Net LEDs for P3-P12 are on the first RTL8231, P1/P2
+	 * net LEDs are on the second. The 12 real ports provide
+	 * 36 LED bits but the chain requires 65 bits to correctly
+	 * span both chips. Phantom ports 1-7, 9-10 (set0, 3 LEDs
+	 * each) and port 11 (set1, 2 LEDs) pad the chain with
+	 * the remaining 29 bits.
+	 */
+	realtek,led-set0-force-port-mask = <0x00000000 0x000006FE>;
+	realtek,led-set1-force-port-mask = <0x00000000 0x00000800>;
 };
 
 &gpio0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&pinmux_disable_jtag>;
-
-	sfp_enable_hog {
-		gpio-hog;
-		gpios = <6 GPIO_ACTIVE_LOW>,
-			<7 GPIO_ACTIVE_LOW>;
-		output-high;
-		line-name = "sfp-enable";
-	};
 	poe_enable_hog {
 		gpio-hog;
 		gpios = <10 GPIO_ACTIVE_HIGH>;
@@ -111,25 +41,6 @@
 };
 
 &i2c_mst1 {
-	status = "okay";
-
-	i2c0: i2c@0 {
-		reg = <0>;
-	};
-
-	i2c1: i2c@1 {
-		reg = <1>;
-	};
-
-	i2c2: i2c@2 {
-		reg = <2>;
-
-		lm96000: lm96000@2e {
-			compatible = "national,lm85";
-			reg = <0x2e>;
-		};
-	};
-
 	/* PoE management MCU sits here */
 	i2c3: i2c@3 {
 		reg = <3>;
@@ -143,18 +54,6 @@
 		    <&pinmux_enable_mdc_mdio_2>;
 };
 
-&mdio_bus0 {
-	/* AQR813 */
-	PHY_C45(0, 8)
-	PHY_C45(8, 9)
-	PHY_C45(16, 10)
-	PHY_C45(24, 11)
-	PHY_C45(32, 12)
-	PHY_C45(40, 13)
-	PHY_C45(48, 14)
-	PHY_C45(50, 15)
-};
-
 &mdio_bus1 {
 	PHY_C45(52, 0)	/* AQR113C */
 };
@@ -165,70 +64,13 @@
 
 &switch0 {
 	ethernet-ports {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		/* Copper ports behind AQR813 */
-		SWITCH_PORT_LED(0, 1, 2, 0, usxgmii)
-		SWITCH_PORT_LED(8, 2, 3, 0, usxgmii)
-		SWITCH_PORT_LED(16, 3, 4, 0, usxgmii)
-		SWITCH_PORT_LED(24, 4, 5, 0, usxgmii)
-		SWITCH_PORT_LED(32, 5, 6, 0, usxgmii)
-		SWITCH_PORT_LED(40, 6, 7, 0, usxgmii)
-		SWITCH_PORT_LED(48, 7, 8, 0, usxgmii)
-		SWITCH_PORT_LED(50, 8, 9, 0, usxgmii)
-
 		/* Copper ports behind AQR113C */
 		SWITCH_PORT_LED(52, 9, 10, 0, usxgmii)
 		SWITCH_PORT_LED(53, 10, 11, 0, usxgmii)
 
-		/* SFP+ ports */
 		SWITCH_PORT_SFP(54, 11, 12, 0, 1)
 		SWITCH_PORT_SFP(55, 12, 13, 0, 2)
-
-		/* CPU port */
-		port@56 {
-			ethernet = <&ethernet0>;
-			reg = <56>;
-			phy-mode = "internal";
-			fixed-link {
-				speed = <1000>;
-				full-duplex;
-			};
-		};
 	};
-};
-
-&port0 {
-	managed = "in-band-status";
-};
-
-&port8 {
-	managed = "in-band-status";
-};
-
-&port16 {
-	managed = "in-band-status";
-};
-
-&port24 {
-	managed = "in-band-status";
-};
-
-&port32 {
-	managed = "in-band-status";
-};
-
-&port40 {
-	managed = "in-band-status";
-};
-
-&port48 {
-	managed = "in-band-status";
-};
-
-&port50 {
-	managed = "in-band-status";
 };
 
 &port52 {
@@ -239,26 +81,6 @@
 	managed = "in-band-status";
 };
 
-&serdes6 {
-	rx-polarity = <PHY_POL_INVERT>;
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes7 {
-	rx-polarity = <PHY_POL_INVERT>;
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes8 {
-	rx-polarity = <PHY_POL_INVERT>;
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes9 {
-	rx-polarity = <PHY_POL_INVERT>;
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
 &serdes10 {
 	tx-polarity = <PHY_POL_INVERT>;
 };
@@ -267,10 +89,3 @@
 	tx-polarity = <PHY_POL_INVERT>;
 };
 
-&serdes12 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
-
-&serdes13 {
-	tx-polarity = <PHY_POL_INVERT>;
-};

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-aqr813.dtsi
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-aqr813.dtsi
@@ -65,6 +65,21 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinmux_disable_jtag>;
 
+	/*
+	 * GPIO 31 is the global reset pin shared by all PHYs across all MDIO
+	 * buses. It is intentionally not declared as reset-gpios on any bus:
+	 * the MDIO driver / phylink only support a reset GPIO per bus, not on
+	 * the parent controller. Attaching it to a single bus would still reset
+	 * the PHYs on the other buses as a side effect, leaving their software
+	 * state out of sync with the hardware and likely breaking them.
+	 */
+	phy_reset_hog {
+		gpio-hog;
+		gpios = <31 GPIO_ACTIVE_LOW>;
+		output-low;
+		line-name = "phy-reset";
+	};
+
 	sfp_enable_hog {
 		gpio-hog;
 		gpios = <6 GPIO_ACTIVE_LOW>,

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-aqr813.dtsi
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-aqr813.dtsi
@@ -134,37 +134,14 @@
 	};
 };
 
-&port0 {
-	managed = "in-band-status";
-};
-
-&port8 {
-	managed = "in-band-status";
-};
-
-&port16 {
-	managed = "in-band-status";
-};
-
-&port24 {
-	managed = "in-band-status";
-};
-
-&port32 {
-	managed = "in-band-status";
-};
-
-&port40 {
-	managed = "in-band-status";
-};
-
-&port48 {
-	managed = "in-band-status";
-};
-
-&port50 {
-	managed = "in-band-status";
-};
+&port0 { managed = "in-band-status"; };
+&port8 { managed = "in-band-status"; };
+&port16 { managed = "in-band-status"; };
+&port24 { managed = "in-band-status"; };
+&port32 { managed = "in-band-status"; };
+&port40 { managed = "in-band-status"; };
+&port48 { managed = "in-band-status"; };
+&port50 { managed = "in-band-status"; };
 
 &serdes6 {
 	rx-polarity = <PHY_POL_INVERT>;
@@ -186,10 +163,6 @@
 	tx-polarity = <PHY_POL_INVERT>;
 };
 
-&serdes12 {
-	tx-polarity = <PHY_POL_INVERT>;
-};
+&serdes12 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes13 { tx-polarity = <PHY_POL_INVERT>; };
 
-&serdes13 {
-	tx-polarity = <PHY_POL_INVERT>;
-};

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-aqr813.dtsi
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-aqr813.dtsi
@@ -10,19 +10,6 @@
 #include <dt-bindings/phy/phy.h>
 
 / {
-	led_set: led_set@0 {
-		compatible = "realtek,rtl9300-leds";
-		active-low;
-
-		/* Blue | Green | Red */
-		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
-			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
-			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M |
-			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
-			    (RTL93XX_LED_SET_5G | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_LINK |
-			     RTL93XX_LED_SET_ACT)>;
-	};
-
 	sfp_gpio_mux: gpio-mux {
 		compatible = "gpio-mux";
 		mux-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>,

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-aqr813.dtsi
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-aqr813.dtsi
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl9313_zyxel_xs1930.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/mux/mux.h>
+#include <dt-bindings/phy/phy.h>
+
+/ {
+	led_set: led_set@0 {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		/* Blue | Green | Red */
+		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_5G | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT)>;
+	};
+
+	sfp_gpio_mux: gpio-mux {
+		compatible = "gpio-mux";
+		mux-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>,
+			    <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		#mux-control-cells = <0>;
+		idle-state = <MUX_IDLE_AS_IS>;
+	};
+
+	sfp1_gpio: sfp-gpio-1 {
+		compatible = "gpio-line-mux";
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		mux-controls = <&sfp_gpio_mux>;
+		muxed-gpio = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+
+		gpio-line-names = "SFP1_LOS", "SFP1_MOD_ABS", "SFP1_TX_FAULT";
+		gpio-line-mux-states = <0>, <1>, <3>;
+	};
+
+	sfp2_gpio: sfp-gpio-2 {
+		compatible = "gpio-line-mux";
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		mux-controls = <&sfp_gpio_mux>;
+		muxed-gpio = <&gpio0 27 GPIO_ACTIVE_HIGH>;
+
+		gpio-line-names = "SFP2_LOS", "SFP2_MOD_ABS", "SFP2_TX_FAULT";
+		gpio-line-mux-states = <0>, <1>, <3>;
+	};
+
+	sfp1: sfp-p1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&sfp1_gpio 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&sfp1_gpio 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&sfp1_gpio 2 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp2: sfp-p2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&sfp2_gpio 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&sfp2_gpio 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&sfp2_gpio 2 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&gpio0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinmux_disable_jtag>;
+
+	sfp_enable_hog {
+		gpio-hog;
+		gpios = <6 GPIO_ACTIVE_LOW>,
+			<7 GPIO_ACTIVE_LOW>;
+		output-high;
+		line-name = "sfp-enable";
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c0: i2c@0 {
+		reg = <0>;
+	};
+	i2c1: i2c@1 {
+		reg = <1>;
+	};
+
+	i2c2: i2c@2 {
+		reg = <2>;
+
+		lm96000: lm96000@2e {
+			compatible = "national,lm85";
+			reg = <0x2e>;
+		};
+	};
+};
+
+&mdio_bus0 {
+	/* AQR813 */
+	PHY_C45(0, 8)
+	PHY_C45(8, 9)
+	PHY_C45(16, 10)
+	PHY_C45(24, 11)
+	PHY_C45(32, 12)
+	PHY_C45(40, 13)
+	PHY_C45(48, 14)
+	PHY_C45(50, 15)
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		/* Copper ports behind AQR813 */
+		SWITCH_PORT_LED(0, 1, 2, 0, usxgmii)
+		SWITCH_PORT_LED(8, 2, 3, 0, usxgmii)
+		SWITCH_PORT_LED(16, 3, 4, 0, usxgmii)
+		SWITCH_PORT_LED(24, 4, 5, 0, usxgmii)
+		SWITCH_PORT_LED(32, 5, 6, 0, usxgmii)
+		SWITCH_PORT_LED(40, 6, 7, 0, usxgmii)
+		SWITCH_PORT_LED(48, 7, 8, 0, usxgmii)
+		SWITCH_PORT_LED(50, 8, 9, 0, usxgmii)
+
+		/* CPU port */
+		port@56 {
+			ethernet = <&ethernet0>;
+			reg = <56>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&port0 {
+	managed = "in-band-status";
+};
+
+&port8 {
+	managed = "in-band-status";
+};
+
+&port16 {
+	managed = "in-band-status";
+};
+
+&port24 {
+	managed = "in-band-status";
+};
+
+&port32 {
+	managed = "in-band-status";
+};
+
+&port40 {
+	managed = "in-band-status";
+};
+
+&port48 {
+	managed = "in-band-status";
+};
+
+&port50 {
+	managed = "in-band-status";
+};
+
+&serdes6 {
+	rx-polarity = <PHY_POL_INVERT>;
+	tx-polarity = <PHY_POL_INVERT>;
+};
+
+&serdes7 {
+	rx-polarity = <PHY_POL_INVERT>;
+	tx-polarity = <PHY_POL_INVERT>;
+};
+
+&serdes8 {
+	rx-polarity = <PHY_POL_INVERT>;
+	tx-polarity = <PHY_POL_INVERT>;
+};
+
+&serdes9 {
+	rx-polarity = <PHY_POL_INVERT>;
+	tx-polarity = <PHY_POL_INVERT>;
+};
+
+&serdes12 {
+	tx-polarity = <PHY_POL_INVERT>;
+};
+
+&serdes13 {
+	tx-polarity = <PHY_POL_INVERT>;
+};

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
@@ -81,6 +81,19 @@
 		};
 	};
 
+	led_set: led_set@0 {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		/* Blue | Green | Red */
+		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    (RTL93XX_LED_SET_5G | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_LINK |
+			     RTL93XX_LED_SET_ACT)>;
+	};
+
 	fan0: gpio-fan {
 		compatible = "gpio-fan";
 		gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
@@ -52,6 +52,31 @@
 			function = LED_FUNCTION_INDICATOR;
 			gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
 		};
+
+		led_pwr_green: led-2 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+		};
+		led_pwr_red: led-3 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+		};
+		led_cloud_green: led-4 {
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+		};
+		led_cloud_red: led-5 {
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+		};
+		led_locator: led-6 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_INDICATOR;
+			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
+		};
 	};
 };
 

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
@@ -32,7 +32,7 @@
 		key-restore {
 			label = "restore";
 			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
+			linux,code = <BTN_0>;
 		};
 	};
 

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
@@ -66,15 +66,17 @@
 		};
 		led_cloud_green: led-4 {
 			color = <LED_COLOR_ID_GREEN>;
+			function = "cloud";
 			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
 		};
 		led_cloud_red: led-5 {
 			color = <LED_COLOR_ID_RED>;
+			function = "cloud";
 			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
 		};
 		led_locator: led-6 {
 			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_INDICATOR;
+			function = "locator";
 			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
 		};
 	};

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
@@ -78,6 +78,16 @@
 			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
 		};
 	};
+
+	fan0: gpio-fan {
+		compatible = "gpio-fan";
+		gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+
+		gpio-fan,speed-map =
+			<3600 0>,
+			<9000 1>;
+		#cooling-cells = <2>;
+	};
 };
 
 &spi0 {

--- a/target/linux/realtek/image/rtl931x.mk
+++ b/target/linux/realtek/image/rtl931x.mk
@@ -49,7 +49,7 @@ TARGET_DEVICES += xikestor_sks8300-12x-v1
 
 define Device/zyxel_xs1930
   SOC := rtl9313
-  DEVICE_PACKAGES := kmod-hwmon-lm85
+  DEVICE_PACKAGES := kmod-hwmon-lm85 kmod-hwmon-gpiofan
   FLASH_ADDR := 0xb4280000
   IMAGE_SIZE := 31808k
   ZYNFW_ALIGN := 0x10000


### PR DESCRIPTION
This series covers several fixes to make the device tree sources for XS1930 switches better by reducing duplication, improving readability and adding fixes/extensions which were missed while adding support for those.
