### PR TITLE
realtek: irq: switch to of_fwnode_handle()

### DIFF
--- a/target/linux/realtek/patches-6.18/314-irqchip-irq-realtek-rtl-add-VPE-support.patch
+++ b/target/linux/realtek/patches-6.18/314-irqchip-irq-realtek-rtl-add-VPE-support.patch
@@ -310,7 +310,7 @@ Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
 +		if (!domain)
 +			goto domain_err;
 +
-+		output->fwnode = of_node_to_fwnode(node);
++		output->fwnode = of_fwnode_handle(node);
 +		output->output_index = p;
 +		output->domain = domain;
 +


### PR DESCRIPTION
Kernel 6.19 will get rid of of_node_to_fwnode(). Switch to its successor of_fwnode_handle() that is already available in 6.18. This will simplify a future kernel upgrade.