### PR TITLE
mpc85xx: relocate AP3825i simpleImage loader

### DIFF
--- a/target/linux/mpc85xx/image/p1020.mk
+++ b/target/linux/mpc85xx/image/p1020.mk
@@ -83,8 +83,8 @@ define Device/extreme-networks_ws-ap3825i
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
   BLOCKSIZE := 128k
   KERNEL_NAME := simpleImage.ws-ap3825i
-  KERNEL_ENTRY := 0x1500000
-  KERNEL_LOADADDR := 0x1500000
+  KERNEL_ENTRY := 0x3000000
+  KERNEL_LOADADDR := 0x3000000
   KERNEL = kernel-bin | fit none $(KDIR)/image-$$(DEVICE_DTS).dtb
   IMAGES := sysupgrade.bin
   IMAGE/sysupgrade.bin := append-kernel | append-rootfs | pad-rootfs | append-metadata

--- a/target/linux/mpc85xx/patches-6.6/107-powerpc-85xx-add-ws-ap3825i-support.patch
+++ b/target/linux/mpc85xx/patches-6.6/107-powerpc-85xx-add-ws-ap3825i-support.patch
@@ -55,13 +55,15 @@ WS-AP3825i AP.
  
 --- a/arch/powerpc/boot/wrapper
 +++ b/arch/powerpc/boot/wrapper
-@@ -350,7 +350,8 @@ adder875-redboot)
-     ;;
- simpleboot-hiveap-330|\
- simpleboot-tl-wdr4900-v1|\
--simpleboot-ws-ap3710i)
-+simpleboot-ws-ap3710i|\
-+simpleboot-ws-ap3825i)
-     platformo="$object/fixed-head.o $object/simpleboot.o"
+@@ -355,6 +355,11 @@ simpleboot-ws-ap3710i)
      link_address='0x1500000'
+     binary=y
+     ;;
++simpleboot-ws-ap3825i)
++    platformo="$object/fixed-head.o $object/simpleboot.o"
++    link_address='0x3000000'
++    binary=y
++    ;;
+ simpleboot-*)
+     platformo="$object/fixed-head.o $object/simpleboot.o"
      binary=y


### PR DESCRIPTION
Backport of 4afaacdd7f5 from main to openwrt-24.10.

Prebuilt openwrt-24.10 (24.10.0-24.10.5) initramfs and sysupgrade images for extreme-networks_ws-ap3825i (mpc85xx/p1020) are unbootable: the simpleImage loader is linked at 0x1500000, which the kernel-6.x decompression scratch overruns -- `ft_fixup_l2cache: FDT_ERR_NOTFOUND` then a silent hang. sysupgrade from a working 23.05.5 succeeds then bricks the unit on reboot.

#15237 was closed in 2024 by 84a48ce, which was insufficient; the regression returned as the kernel grew. 4afaacdd7f5 (in main) relocates the loader to 0x3000000, past the U-Boot load area. It is not in openwrt-24.10 and there is no existing backport.

Bench-verified on hardware (WS-AP3825i, U-Boot 2010.12.6): stock 24.10.5 initramfs hangs as above; main/SNAPSHOT (kernel 6.12.89) boots cleanly; this cherry-pick onto openwrt-24.10 produces an image that boots identically.

Refs #15237.