### PR TITLE
kernel: use netif_receive_skb_list for lantiq and bmips

### DIFF
--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_adsl.c
@@ -147,7 +147,7 @@ static INLINE int get_tx_desc(unsigned int, unsigned int *);
 /*
  *  Mailbox handler and signal function
  */
-static INLINE int mailbox_rx_irq_handler(unsigned int);
+static INLINE int mailbox_rx_irq_handler(unsigned int, struct list_head *);
 static irqreturn_t mailbox_irq_handler(int, void *);
 static INLINE void mailbox_signal(unsigned int, int);
 #ifdef CONFIG_IFX_PTM_RX_TASKLET
@@ -352,16 +352,19 @@ static int ptm_stop(struct net_device *dev)
 
 static unsigned int ptm_poll(int ndev, unsigned int work_to_do)
 {
+    LIST_HEAD(rx_list);
     unsigned int work_done = 0;
 
     ASSERT(ndev >= 0 && ndev < ARRAY_SIZE(g_net_dev), "ndev = %d (wrong value)", ndev);
 
     while ( work_done < work_to_do && WRX_DMA_CHANNEL_CONFIG(ndev)->vlddes > 0 ) {
-        if ( mailbox_rx_irq_handler(ndev) < 0 )
+        if ( mailbox_rx_irq_handler(ndev, &rx_list) < 0 )
             break;
 
         work_done++;
     }
+
+    netif_receive_skb_list(&rx_list);
 
     return work_done;
 }
@@ -645,14 +648,13 @@ static INLINE int get_tx_desc(unsigned int itf, unsigned int *f_full)
     return desc_base;
 }
 
-static INLINE int mailbox_rx_irq_handler(unsigned int ch)   //  return: < 0 - descriptor not available, 0 - received one packet
+static INLINE int mailbox_rx_irq_handler(unsigned int ch, struct list_head *rx_list)   //  return: < 0 - descriptor not available, 0 - received one packet
 {
     unsigned int ndev = ch;
     struct sk_buff *skb;
     struct sk_buff *new_skb;
     volatile struct rx_descriptor *desc;
     struct rx_descriptor reg_desc;
-    int netif_rx_ret;
 
     desc = &g_ptm_priv_data.itf[ndev].rx_desc[g_ptm_priv_data.itf[ndev].rx_desc_pos];
     if ( desc->own || !desc->c )    //  if PP32 hold descriptor or descriptor not completed
@@ -675,12 +677,10 @@ static INLINE int mailbox_rx_irq_handler(unsigned int ch)   //  return: < 0 - de
             skb->dev = g_net_dev[ndev];
             skb->protocol = eth_type_trans(skb, skb->dev);
 
-            netif_rx_ret = netif_receive_skb(skb);
+            list_add_tail(&skb->list, rx_list);
 
-            if ( netif_rx_ret != NET_RX_DROP ) {
-                g_ptm_priv_data.itf[ndev].stats.rx_packets++;
-                g_ptm_priv_data.itf[ndev].stats.rx_bytes += reg_desc.datalen;
-            }
+            g_ptm_priv_data.itf[ndev].stats.rx_packets++;
+            g_ptm_priv_data.itf[ndev].stats.rx_bytes += reg_desc.datalen;
 
             reg_desc.dataptr = ((unsigned int)new_skb->data >> 2) & 0x0FFFFFFF;
             reg_desc.byteoff = RX_HEAD_MAC_ADDR_ALIGNMENT;
@@ -726,8 +726,12 @@ static irqreturn_t mailbox_irq_handler(int irq, void *dev_id)
         else {
             //  RX
 #ifdef CONFIG_IFX_PTM_RX_INTERRUPT
+            LIST_HEAD(rx_list);
+
             while ( WRX_DMA_CHANNEL_CONFIG(i)->vlddes > 0 )
-                mailbox_rx_irq_handler(i);
+                mailbox_rx_irq_handler(i, &rx_list);
+
+            netif_receive_skb_list(&rx_list);
 #else
             IFX_REG_W32_MASK(1 << i, 0, MBOX_IGU1_IER);
             napi_schedule(&g_ptm_priv_data.itf[i].napi);
@@ -759,17 +763,20 @@ static INLINE void mailbox_signal(unsigned int itf, int is_tx)
 #ifdef CONFIG_IFX_PTM_RX_TASKLET
 static void do_ptm_tasklet(unsigned long arg)
 {
+    LIST_HEAD(rx_list);
     unsigned int work_to_do = 25;
     unsigned int work_done = 0;
 
     ASSERT(arg >= 0 && arg < ARRAY_SIZE(g_net_dev), "arg = %lu (wrong value)", arg);
 
     while ( work_done < work_to_do && WRX_DMA_CHANNEL_CONFIG(arg)->vlddes > 0 ) {
-        if ( mailbox_rx_irq_handler(arg) < 0 )
+        if ( mailbox_rx_irq_handler(arg, &rx_list) < 0 )
             break;
 
         work_done++;
     }
+
+    netif_receive_skb_list(&rx_list);
 
     //  interface down
     if ( !netif_running(g_net_dev[arg]) )

--- a/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
+++ b/package/kernel/lantiq/ltq-ptm/src/ifxmips_ptm_vdsl.c
@@ -204,6 +204,7 @@ static int ptm_stop(struct net_device *dev)
 
 static unsigned int ptm_poll(int ndev, unsigned int work_to_do)
 {
+    LIST_HEAD(rx_list);
     unsigned int work_done = 0;
     volatile struct rx_descriptor *desc;
     struct rx_descriptor reg_desc;
@@ -231,7 +232,7 @@ static unsigned int ptm_poll(int ndev, unsigned int work_to_do)
             skb->dev = g_net_dev[0];
             skb->protocol = eth_type_trans(skb, skb->dev);
 
-            netif_receive_skb(skb);
+            list_add_tail(&skb->list, &rx_list);
 
             g_ptm_priv_data.itf[0].stats.rx_packets++;
             g_ptm_priv_data.itf[0].stats.rx_bytes += reg_desc.datalen;
@@ -251,6 +252,8 @@ static unsigned int ptm_poll(int ndev, unsigned int work_to_do)
 
         work_done++;
     }
+
+    netif_receive_skb_list(&rx_list);
 
     return work_done;
 }

--- a/package/kernel/lantiq/vrx518_tc/patches/202-napi.patch
+++ b/package/kernel/lantiq/vrx518_tc/patches/202-napi.patch
@@ -358,13 +358,17 @@
  #ifdef CONFIG_SOC_TYPE_XWAY
      if (ppa_drv_datapath_mac_entry_setting)
          ppa_drv_datapath_mac_entry_setting(dev->dev_addr, 0, 6, 10, 1, 2);
-@@ -562,7 +570,7 @@ static void ptm_rx(struct net_device *de
- 	ptm_tc->stats64.rx_packets++;
- 	ptm_tc->stats64.rx_bytes += skb->len;
- 
+@@ -562,7 +570,9 @@ static void ptm_rx(struct net_device *de
+-	ptm_tc->stats64.rx_packets++;
+-	ptm_tc->stats64.rx_bytes += skb->len;
+-
 -	if (netif_rx(skb) == NET_RX_DROP)
-+	if (netif_receive_skb(skb) == NET_RX_DROP)
- 		ptm_tc->stats64.rx_dropped++;
++	LIST_HEAD(rx_list);
++
++	ptm_tc->stats64.rx_packets++;
++	ptm_tc->stats64.rx_bytes += skb->len;
++	list_add_tail(&skb->list, &rx_list);
++	netif_receive_skb_list(&rx_list);
  
  	return;
 @@ -662,6 +670,9 @@ static int ptm_dev_init(struct tc_priv *

--- a/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6348-enet.c
+++ b/target/linux/bmips/files/drivers/net/ethernet/broadcom/bcm6348-enet.c
@@ -589,6 +589,7 @@ static int bcm6348_emac_receive_queue(struct net_device *ndev, int budget)
 	struct bcm6348_iudma *iudma = emac->iudma;
 	struct platform_device *pdev = emac->pdev;
 	struct device *dev = &pdev->dev;
+	LIST_HEAD(rx_list);
 	int processed = 0;
 
 	/* don't scan ring further than number of refilled
@@ -662,8 +663,10 @@ static int bcm6348_emac_receive_queue(struct net_device *ndev, int budget)
 		skb->protocol = eth_type_trans(skb, ndev);
 		ndev->stats.rx_packets++;
 		ndev->stats.rx_bytes += len;
-		netif_receive_skb(skb);
+		list_add_tail(&skb->list, &rx_list);
 	} while (--budget > 0);
+
+	netif_receive_skb_list(&rx_list);
 
 	if (processed || !emac->rx_desc_count) {
 		bcm6348_emac_refill_rx(ndev);


### PR DESCRIPTION
Batch RX skbs before handing them to the network stack in the Lantiq PTM drivers and the bmips bcm6348 Ethernet driver.

Update the VRX518 TC NAPI patch to use the list receive helper as well.

Assisted-by: Codex:GPT-5.5