### PR TITLE
realtek: rtl931x: add support for Hasivo F5800W-12S+

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -103,7 +103,8 @@ realtek_setup_macs()
 	tplink,tl-st1008f-v2|\
 	zyxel,xgs1010-12-a1)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)
-		[ -z "$lan_mac" ] || [ "$lan_mac" = "00:e0:4c:00:00:00" ] && lan_mac=$(macaddr_random)
+		mac_prefix=$(echo "$lan_mac" | cut -d: -f1-5)
+		[ -z "$lan_mac" ] || [ "$mac_prefix" = "00:e0:4c:00:00" ] && lan_mac=$(macaddr_random)
 		lan_mac_start=$lan_mac
 		eth0_mac=$lan_mac
 		;;

--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -100,6 +100,7 @@ realtek_setup_macs()
 		;;
 	hasivo,f1100w-4sx-4xgt|\
 	hasivo,f1100w-4sx-4xgt-512mb|\
+	hasivo,f5800w-12s-plus|\
 	tplink,tl-st1008f-v2|\
 	zyxel,xgs1010-12-a1)
 		lan_mac=$(mtd_get_mac_ascii u-boot-env ethaddr)

--- a/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
+++ b/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
@@ -36,11 +36,14 @@ case "$(board_name)" in
 # environment, and the real ethaddr stored in RUNTIME/RUNTIME2 JFFS2 partitions,
 # which would be annoying to deal with. Also ethaddr isn't printed on the case.
 #
-# TL-ST1008F v2 ships with a dummy ethaddr because it's an unmanaged switch.
+# F5800W-12S+ same as F1100W, except the MAC address ends with :10, not :00.
+#
+# TL-ST1008F v2 ships with the dummy ethaddr because it's sold as unmanaged.
 #
 # We store the random ethaddr if the currently stored ethaddr is empty or dummy.
 hasivo,f1100w-4sx-4xgt|\
 hasivo,f1100w-4sx-4xgt-512mb|\
+hasivo,f5800w-12s-plus|\
 tplink,tl-st1008f-v2)
 	env_ethaddr=$(macaddr_canonicalize "$(fw_printenv -n ethaddr 2>/dev/null)")
 	ethaddr_prefix=$(echo "$env_ethaddr" | cut -d: -f1-5)

--- a/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
+++ b/target/linux/realtek/base-files/etc/uci-defaults/99_fwenv-store-ethaddr
@@ -11,48 +11,53 @@ BOARD_CFG=/etc/board.json
 
 # Some devices make it hard or impossible to acquire a usable ethaddr / MAC address
 # of the device. Some store it in weird places, some ship with only the common
-# Realtek dummy ethaddr, and some are outright broken.
+# Realtek dummy ethaddr, and some are outright broken. Often the MAC address
+# isn't printed on the case label either.
 #
 # For these devices, we generate a random ethaddr in /etc/board.d/02_network,
-# which is stored in /etc/board.json. Here we take this random ethaddr and
-# persist it in the U-Boot environment, so that it survives sysupgrades.
+# which is saved in /etc/board.json.
+#
+# Here we take this random ethaddr and store it in the U-Boot environment,
+# so that it survives sysupgrades and factory resets.
+
+store_board_ethaddr() {
+	local board_ethaddr
+	json_init
+	json_load_file "$BOARD_CFG"
+	json_select network_device
+	json_select eth0
+	json_get_var board_ethaddr macaddr
+	json_cleanup
+	[ -n "$board_ethaddr" ] && fw_setenv ethaddr "$board_ethaddr"
+}
 
 case "$(board_name)" in
+# F1100W-4SX-4XGT and its variants ship with the dummy ethaddr in the u-boot
+# environment, and the real ethaddr stored in RUNTIME/RUNTIME2 JFFS2 partitions,
+# which would be annoying to deal with. Also ethaddr isn't printed on the case.
+#
+# TL-ST1008F v2 ships with a dummy ethaddr because it's an unmanaged switch.
+#
+# We store the random ethaddr if the currently stored ethaddr is empty or dummy.
 hasivo,f1100w-4sx-4xgt|\
 hasivo,f1100w-4sx-4xgt-512mb|\
 tplink,tl-st1008f-v2)
 	env_ethaddr=$(macaddr_canonicalize "$(fw_printenv -n ethaddr 2>/dev/null)")
+	ethaddr_prefix=$(echo "$env_ethaddr" | cut -d: -f1-5)
 
-	# F1100W-4SX-4XGT and its variants ship with the dummy ethaddr in the u-boot
-	# environment, and the real ethaddr stored in RUNTIME/RUNTIME2 JFFS2 partitions,
-	# which would be annoying to deal with. Also ethaddr isn't printed on the case.
-	#
-	# TL-ST1008F v2 ships with a dummy ethaddr because it's an unmanaged switch.
-	#
-	# We persist the random ethaddr if the currently stored ethaddr is empty or dummy.
-	if [ -z "$env_ethaddr" ] || [ "$env_ethaddr" = "00:e0:4c:00:00:00" ]; then
-		json_init
-		json_load_file "$BOARD_CFG"
-		json_select network_device
-		json_select eth0
-		json_get_var board_ethaddr macaddr
-		[ -n "$board_ethaddr" ] && fw_setenv ethaddr "$board_ethaddr"
+	if [ -z "$env_ethaddr" ] || [ "$ethaddr_prefix" = "00:e0:4c:00:00" ]; then
+		store_board_ethaddr
 	fi
 	;;
+# This device ships with an empty environment (invalid CRC). If it is still in
+# that state, we don't want to modify it, because that would write the defaults
+# of the userspace U-Boot tools (which differ from the ones in the bootloader).
+# Thus, we don't do anything here if the ethaddr variable is empty.
 zyxel,xgs1010-12-a1)
 	env_ethaddr=$(macaddr_canonicalize "$(fw_printenv -n ethaddr 2>/dev/null)")
 
-	# This device ships with an empty environment (invalid CRC). If it is still in
-	# that state, we don't want to modify it, because that would write the defaults
-	# of the userspace U-Boot tools (which differ from the ones in the bootloader).
-	# Thus, we don't do anything here if the ethaddr variable is empty.
 	if [ "$env_ethaddr" = "00:e0:4c:00:00:00" ]; then
-		json_init
-		json_load_file "$BOARD_CFG"
-		json_select network_device
-		json_select eth0
-		json_get_var board_ethaddr macaddr
-		[ -n "$board_ethaddr" ] && fw_setenv ethaddr "$board_ethaddr"
+		store_board_ethaddr
 	fi
 	;;
 esac

--- a/target/linux/realtek/dts/rtl9313_hasivo_f5800w-12s-plus.dts
+++ b/target/linux/realtek/dts/rtl9313_hasivo_f5800w-12s-plus.dts
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl931x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/phy/phy.h>
+
+/ {
+	compatible = "hasivo,f5800w-12s-plus", "realtek,rtl9313-soc";
+	model = "Hasivo F5800W-12S+";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* 256 MiB lowmem */
+		      <0x90000000 0x10000000>; /* 256 MiB highmem */
+	};
+
+	chosen {
+		stdout-path = "serial0:38400n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		led_set1 = <
+		( // Green lower row - 2.5G/1G link
+			RTL93XX_LED_SET_2P5G |
+			RTL93XX_LED_SET_1G |
+			RTL93XX_LED_SET_LINK |
+			RTL93XX_LED_SET_ACT
+		)
+		( // Green upper row - 10G link
+			RTL93XX_LED_SET_10G |
+			RTL93XX_LED_SET_LINK |
+			RTL93XX_LED_SET_ACT
+		)>;
+	};
+
+	i2c_sys: i2c-system {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_disable_jtag>;
+
+		scl-gpios = <&gpio0 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <28>;
+
+		rtc@51 {
+			compatible = "nxp,pcf8563";
+			reg = <0x51>;
+		};
+
+		mcu_mgmt: mcu@6f {
+			compatible = "hasivo,stc8-mfd", "syscon";
+			reg = <0x6f>;
+
+			mcu_wdt: watchdog {
+				compatible = "hasivo,mcu-wdt";
+			};
+
+			sensor {
+				compatible = "hasivo,mcu-sensor";
+			};
+		};
+	};
+
+	sfp1: sfp-p1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda0>;
+		los-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp2: sfp-p2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda1>;
+		los-gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio0 27 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp3: sfp-p3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda2>;
+		los-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp4: sfp-p4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda3>;
+		los-gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 0 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp5: sfp-p5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda4>;
+		los-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 3 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp6: sfp-p6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1_sda5>;
+		los-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp7: sfp-p7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda6>;
+		los-gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp8: sfp-p8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda7>;
+		los-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 32 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio1 33 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp9: sfp-p9 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda8>;
+		los-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio1 36 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio2 0 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp10: sfp-p10 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda9>;
+		los-gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio2 3 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp11: sfp-p11 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda10>;
+		los-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio2 6 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp12: sfp-p12 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2_sda11>;
+		los-gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpios = <&gpio2 8 GPIO_ACTIVE_LOW>;
+		tx-disable-gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c1_sda0: i2c@0 { reg = <0>; };
+	i2c1_sda1: i2c@1 { reg = <1>; };
+	i2c1_sda2: i2c@2 { reg = <2>; };
+	i2c1_sda3: i2c@3 { reg = <3>; };
+	i2c1_sda4: i2c@4 { reg = <4>; };
+	i2c1_sda5: i2c@5 { reg = <5>; };
+};
+
+&i2c_mst2 {
+	status = "okay";
+
+	i2c2_sda6: i2c@6 { reg = <6>; };
+	i2c2_sda7: i2c@7 { reg = <7>; };
+	i2c2_sda8: i2c@8 { reg = <8>; };
+	i2c2_sda9: i2c@9 { reg = <9>; };
+	i2c2_sda10: i2c@a { reg = <10>; };
+	i2c2_sda11: i2c@b { reg = <11>; };
+};
+
+&mdio_aux {
+	status = "okay";
+
+	gpio1: gpio@0 {
+		compatible = "realtek,rtl8231";
+		reg = <0>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio1 0 0 37>;
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+
+	gpio2: gpio@1 {
+		compatible = "realtek,rtl8231";
+		reg = <1>;
+
+		gpio-controller;
+		#gpio-cells = <2>;
+		gpio-ranges = <&gpio2 0 0 37>;
+
+		led-controller {
+			compatible = "realtek,rtl8231-leds";
+			status = "disabled";
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			/* stock is LOADER */
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x00e0000>;
+				read-only;
+			};
+
+			/* stock is BDINFO */
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x00e0000 0x0010000>;
+			};
+
+			/* stock is SYSINFO */
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0x00f0000 0x0010000>;
+			};
+
+			/* stock is CFG JFFS2 */
+			partition@100000 {
+				label = "jffs";
+				reg = <0x0100000 0x0100000>;
+			};
+
+			/* stock is LOG JFFS2 */
+			partition@200000 {
+				label = "jffs2";
+				reg = <0x0200000 0x0100000>;
+			};
+
+			/* stock is RUNTIME and RUNTIME2
+			 * RUNTIME is <0x0300000 0x0700000>
+			 * RUNTIME2 is <0x0a00000 0x1600000>
+			 */
+			partition@300000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0x0300000 0x1d00000>;
+			};
+		};
+	};
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_SFP(0, 1, 2, 1, 1)
+		SWITCH_PORT_SFP(8, 2, 3, 1, 2)
+		SWITCH_PORT_SFP(16, 3, 4, 1, 3)
+		SWITCH_PORT_SFP(24, 4, 5, 1, 4)
+		SWITCH_PORT_SFP(32, 5, 6, 1, 5)
+		SWITCH_PORT_SFP(40, 6, 7, 1, 6)
+		SWITCH_PORT_SFP(48, 7, 8, 1, 7)
+		SWITCH_PORT_SFP(50, 8, 9, 1, 8)
+		SWITCH_PORT_SFP(52, 9, 10, 1, 9)
+		SWITCH_PORT_SFP(53, 10, 11, 1, 10)
+		SWITCH_PORT_SFP(54, 11, 12, 1, 11)
+		SWITCH_PORT_SFP(55, 12, 13, 1, 12)
+
+		/* CPU port */
+		port@56 {
+			ethernet = <&ethernet0>;
+			reg = <56>;
+			phy-mode = "internal";
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&serdes2 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes3 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes4 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes5 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes6 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes7 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes8 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes9 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes10 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes11 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes12 { tx-polarity = <PHY_POL_INVERT>; };
+&serdes13 { tx-polarity = <PHY_POL_INVERT>; };

--- a/target/linux/realtek/image/rtl931x.mk
+++ b/target/linux/realtek/image/rtl931x.mk
@@ -2,6 +2,16 @@
 
 include ./common.mk
 
+define Device/hasivo_f5800w-12s-plus
+  SOC := rtl9313
+  DEVICE_VENDOR := Hasivo
+  DEVICE_MODEL := F5800W-12S+
+  IMAGE_SIZE := 29696k
+  DEVICE_PACKAGES := kmod-hasivo-mcu-wdt kmod-hasivo-mcu-sensor kmod-rtc-pcf8563
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += hasivo_f5800w-12s-plus
+
 define Device/plasmacloud-common
   SOC := rtl9312
   UIMAGE_MAGIC := 0x93100000


### PR DESCRIPTION
This commit adds support for the Hasivo F5800W-12S+ 12-port SFP+ switch. Based on board revision `RTL_12S+ v1.01`.

Hardware
--------

|          |                                                                |
|----------|----------------------------------------------------------------|
| SoC      | RTL9313 rev B                                                  |
| RAM      | 512 MB Samsung K4B4G1646E                                      |
| Flash    | 32 MB Macronix MX25L25645G SPI NOR, 29 MB usable by OpenWrt    |
| Ethernet | 12x SFP+ via SoC (10G/2.5G/1G)                                 |
| LEDs     | 12x green 10G link, 12x green 1G link,                         |
|          | 3x green power and PSUs -- no system status LED                |
| Button   | Reset                                                          |
| Console  | RJ45 38400 bps 8n1                                             |
| Watchdog | via Hasivo MCU                                                 |
| Power    | 2x internal 100-240V AC PSUs with 2x C14 inputs                |
| Clock    | NXP PCF8563 with coin cell battery                             |
| Fans     | 2x 40mm case fan via Hasivo MCU                                |

Installing OpenWrt
------------------

1. Attach to RJ45 serial console port using a cisco cable.
2. Attach SFP to port 12.
3. Serve initramfs-kernel.bin on TFTP 192.168.1.111.
4. Power on the device.
5. Interrupt U-Boot by pressing `Ctrl+c`, then `z`, then `h`, during 3 second countdown.
6. Bring up networking: `rtk network on ; rtk 10g 55 fiber10g`.
7. Boot from TFTP: `tftpboot 0x84f00000 initramfs-kernel.bin ; bootm 0x84f00000`.
8. Use `mtd dump` to make backups of all flash partitions.
9. Use SCP to copy `squashfs-sysupgrade.bin` to the device, then run `sysupgrade`.

Restoring factory firmware
--------------------------

OpenWrt uses the `RUNTIME` and `RUNTIME2` partitions as one combined partition. To restore them from backups, boot from `initramfs-kernel.bin` just like during the installation, then use `mtd write` to write your backups of the factory `mtd5` and `mtd6` partitions to the live `mtd5` partition.

Notes/Quirks
------------

- U-Boot interruption is obfuscated. Press `Ctrl+c`, then `z`, then `h`, during the 3 second countdown.
- MAC address is stored on the `RUNTIME` or `RUNTIME2` partitions, which are used by OpenWrt. Instead, we generate one random MAC address and store it in the U-Boot environment.
- There is no system status LED. The three non-network LEDs are for primary PSU (MS label), secondary PSU (SL), and powered on/off (PW).

---

- [x] Depends: #23418
