### PR TITLE
dnsmasq: add fallback for default dhcpv4/dhcpv6 values

### DIFF
--- a/package/network/services/dnsmasq/Makefile
+++ b/package/network/services/dnsmasq/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=dnsmasq
 PKG_UPSTREAM_VERSION:=2.93
 PKG_VERSION:=$(subst test,~~test,$(subst rc,~rc,$(PKG_UPSTREAM_VERSION)))
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_UPSTREAM_VERSION).tar.xz
 PKG_SOURCE_URL:=https://thekelleys.org.uk/dnsmasq/

--- a/package/network/services/dnsmasq/files/dhcp.conf
+++ b/package/network/services/dnsmasq/files/dhcp.conf
@@ -28,9 +28,12 @@ config dnsmasq
 
 config dhcp lan
 	option interface	lan
-	option start 	100
+	option start	100
 	option limit	150
 	option leasetime	12h
+	option ra	server
+	option dhcpv4	server
+	option dhcpv6	server
 
 config dhcp wan
 	option interface	wan

--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -575,8 +575,8 @@ dhcp_add() {
 	config_get_bool dynamicdhcpv4 "$cfg" dynamicdhcpv4 $dynamicdhcp
 	config_get_bool dynamicdhcpv6 "$cfg" dynamicdhcpv6 $dynamicdhcp
 
-	config_get dhcpv4 "$cfg" dhcpv4
-	config_get dhcpv6 "$cfg" dhcpv6
+	config_get dhcpv4 "$cfg" dhcpv4 disabled
+	config_get dhcpv6 "$cfg" dhcpv6 disabled
 
 	config_get ra "$cfg" ra
 	config_get ra_management "$cfg" ra_management


### PR DESCRIPTION
The default dhcpv4/dhcpv6 in odhcpd is disabled.
Add default values to keep consistency.

Link: https://github.com/openwrt/odhcpd/blob/master/README.md

Ref: https://github.com/openwrt/luci/pull/8642