### PR TITLE
uboot-mediatek: mtd: nand: spi: otp: add NULL guards to OTP size functions

### DIFF
--- a/package/boot/uboot-mediatek/patches/111-mtd-nand-spi-otp-add-NULL-guards-to-OTP-size-functions.patch
+++ b/package/boot/uboot-mediatek/patches/111-mtd-nand-spi-otp-add-NULL-guards-to-OTP-size-functions.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ryan Leung <untilscour@protonmail.com>
+Date: Wed, 20 May 2026 15:16:13 +1000
+Subject: [PATCH] mtd: nand: spi: otp: add NULL guards to OTP size functions
+
+U-Boot v2026.01 introduced drivers/mtd/nand/spi/otp.c which adds `spinand_user_otp_size()` and
+`spinand_fact_otp_size()`. These functions are called unconditionally from `spinand_init()` in
+drivers/mtd/nand/spi/core.c to determine whether to set up OTP methods:
+
+  if (spinand_user_otp_size(spinand) || spinand_fact_otp_size(spinand)) {
+      ret = spinand_set_mtd_otp_ops(spinand); /* drivers/mtd/nand/spi/core.c:2369 */
+      ...
+  }
+
+Both OTP size functions pass `&spinand->user_otp->layout` or `&spinand->fact_otp->layout` to
+`spinand_otp_size()` without first checking whether the pointer is NULL. In the standard probing
+path, these pointers are assigned by `spinand_match_and_init()` from the per-chip `spinand_info`
+table. `100-21-mtd-spi-nand-add-CASN-page-support.patch` adds CASN detection to `spinand_detect()`
+so that when a CASN page is found, `spinand_init_via_casn()` is called instead of
+`spinand_id_detect()`. As `spinand_match_and_init()` is only called via `spinand_id_detect()`, it
+is never invoked for CASN-probed devices.
+
+As a result, `spinand->user_otp` and `spinand->fact_otp` remain NULL from the zero-initialised DM
+priv allocation. Both `spinand_user_otp_size()` and `spinand_fact_otp_size()` spuriously return
+non-zero by reading `layout->npages` from a small mapped address computed from their respective
+NULL pointer, causing `spinand_init()` to call `spinand_set_mtd_otp_ops()` which reads
+`spinand->user_otp->ops` and thereby silently assigns a garbage value to `user_ops` that is then
+dereferenced at `if (user_ops->info)`.
+
+  int spinand_set_mtd_otp_ops(struct spinand_device *spinand)
+  {
+    struct mtd_info *mtd = spinand_to_mtd(spinand);
+    const struct spinand_fact_otp_ops *fact_ops = spinand->fact_otp->ops;
+    const struct spinand_user_otp_ops *user_ops = spinand->user_otp->ops;
+    ...
+    if (user_ops) {
+        if (user_ops->info) /* drivers/mtd/nand/spi/otp.c:343 */
+            ...
+        ...
+    }
+    ...
+  }
+
+On COMFAST CF-WR632AX (MT7981, Winbond W25N01GV) this results in a "Synchronous Abort" during boot.
+The crash was confirmed via `addr2line` on the U-Boot ELF:
+
+  "Synchronous Abort" handler, esr 0x96000004, far 0xeafffffeeafffffe
+  elr: 0000000041e2ff44 (drivers/mtd/nand/spi/otp.c:343)
+  lr : 0000000041e2f2f8 (drivers/mtd/nand/spi/core.c:2369)
+
+The same was observed on Acer Predator Connect W6x (MT7986, Winbond W25N02KV):
+
+  "Synchronous Abort" handler, esr 0x96000004, far 0xeafffffeeafffffe
+  elr: 0000000041e2c868 (drivers/mtd/nand/spi/otp.c:343)
+  lr : 0000000041e2bc1c (drivers/mtd/nand/spi/core.c:2369)
+
+Fix this by adding NULL guards to both OTP size functions so that they return 0 when the pointer is
+NULL. With both functions returning 0, the condition in `spinand_init()` evaluates to false and
+`spinand_set_mtd_otp_ops()` is never called, skipping setup of OTP methods entirely for CASN-probed
+SPI NAND chips.
+
+This change has no effect on SPI NAND chips that do have OTP data but not CASN. For those chips,
+`spinand_match_and_init()` sets `spinand->user_otp` and `spinand->fact_otp` to non-NULL values from
+the per-chip table, the NULL guard does not activate, and the existing behaviour is unchanged.
+
+Fixes: b94de14bafd06660536691ed633f364edf5fbe4d ("uboot-mediatek: update to v2026.01")
+Signed-off-by: Ryan Leung <untilscour@protonmail.com>
+---
+ drivers/mtd/nand/spi/otp.c  | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/drivers/mtd/nand/spi/otp.c
++++ b/drivers/mtd/nand/spi/otp.c
+@@ -39,6 +39,8 @@ static size_t spinand_otp_size(struct sp
+  */
+ size_t spinand_fact_otp_size(struct spinand_device *spinand)
+ {
++	if (!spinand->fact_otp)
++		return 0;
+ 	return spinand_otp_size(spinand, &spinand->fact_otp->layout);
+ }
+ 
+@@ -50,6 +52,8 @@ size_t spinand_fact_otp_size(struct spin
+  */
+ size_t spinand_user_otp_size(struct spinand_device *spinand)
+ {
++	if (!spinand->user_otp)
++		return 0;
+ 	return spinand_otp_size(spinand, &spinand->user_otp->layout);
+ }
+ 


### PR DESCRIPTION
U-Boot v2026.01 introduced drivers/mtd/nand/spi/otp.c which adds `spinand_user_otp_size()` and `spinand_fact_otp_size()`. These functions are called unconditionally from `spinand_init()` in drivers/mtd/nand/spi/core.c to determine whether to set up OTP methods:
```
  if (spinand_user_otp_size(spinand) || spinand_fact_otp_size(spinand)) {
      ret = spinand_set_mtd_otp_ops(spinand); /* drivers/mtd/nand/spi/core.c:2369 */
      ...
  }
```
Both OTP size functions pass `&spinand->user_otp->layout` or `&spinand->fact_otp->layout` to `spinand_otp_size()` without first checking whether the pointer is NULL. In the standard probing path, these pointers are assigned by `spinand_match_and_init()` from the per-chip `spinand_info` table. `100-21-mtd-spi-nand-add-CASN-page-support.patch` adds CASN detection to `spinand_detect()` so that when a CASN page is found, `spinand_init_via_casn()` is called instead of `spinand_id_detect()`. As `spinand_match_and_init()` is only called via `spinand_id_detect()`, it is never invoked for CASN-probed devices.

As a result, `spinand->user_otp` and `spinand->fact_otp` remain NULL from the zero-initialised DM priv allocation. Both `spinand_user_otp_size()` and `spinand_fact_otp_size()` spuriously return non-zero by reading `layout->npages` from a small mapped address computed from their respective NULL pointer, causing `spinand_init()` to call `spinand_set_mtd_otp_ops()` which reads `spinand->user_otp->ops` and thereby silently assigns a garbage value to `user_ops` that is then dereferenced at `if (user_ops->info)`.

```
  int spinand_set_mtd_otp_ops(struct spinand_device *spinand)
  {
    struct mtd_info *mtd = spinand_to_mtd(spinand);
    const struct spinand_fact_otp_ops *fact_ops = spinand->fact_otp->ops;
    const struct spinand_user_otp_ops *user_ops = spinand->user_otp->ops;
    ...
    if (user_ops) {
        if (user_ops->info) /* drivers/mtd/nand/spi/otp.c:343 */
            ...
        ...
    }
    ...
  }
```

On COMFAST CF-WR632AX (MT7981, Winbond W25N01GV) this results in a "Synchronous Abort" during boot. The crash was confirmed via `addr2line` on the U-Boot ELF:
```
  "Synchronous Abort" handler, esr 0x96000004, far 0xeafffffeeafffffe
  elr: 0000000041e2ff44 (drivers/mtd/nand/spi/otp.c:343)
  lr : 0000000041e2f2f8 (drivers/mtd/nand/spi/core.c:2369)
```
The same was observed on Acer Predator Connect W6x (MT7986, Winbond W25N02KV):
```
  "Synchronous Abort" handler, esr 0x96000004, far 0xeafffffeeafffffe
  elr: 0000000041e2c868 (drivers/mtd/nand/spi/otp.c:343)
  lr : 0000000041e2bc1c (drivers/mtd/nand/spi/core.c:2369)
```
Fix this by adding NULL guards to both OTP size functions so that they return 0 when the pointer is NULL. With both functions returning 0, the condition in `spinand_init()` evaluates to false and `spinand_set_mtd_otp_ops()` is never called, skipping setup of OTP methods entirely for CASN-probed SPI NAND chips.

This change has no effect on SPI NAND chips that do have OTP data but not CASN. For those chips, `spinand_match_and_init()` sets `spinand->user_otp` and `spinand->fact_otp` to non-NULL values from the per-chip table, the NULL guard does not activate, and the existing behaviour is unchanged.

Fixes: b94de14bafd06660536691ed633f364edf5fbe4d ("uboot-mediatek: update to v2026.01")
Fixes: #23430

<details>
<summary>bootloop</summary>

```
F0: 102B 0000
FA: 1040 0000
FA: 1040 0000 [0200]
F9: 0000 0000
V0: 0000 0000 [0001]
00: 0000 0000
BP: 2400 0041 [0000]
G0: 1190 0000
EC: 0000 0000 [1000]
T0: 0000 01C2 [010F]
Jump to BL

NOTICE:  BL2: v2.14.0(release):OpenWrt v2026.01.23~e06f2586-1 (mt7981-spim-nand-ddr3-1866)
NOTICE:  BL2: Built : 13:27:17, May 17 2026
NOTICE:  WDT: [40000000] Software reset (reboot)
NOTICE:  EMI: Using DDR3 settings
NOTICE:  EMI: complex R/W mem test passed
NOTICE:  DRAM: 512MB
NOTICE:  CPU: MT7981 (1300MHz)
NOTICE:  SPI-NAND probed by CASN page
NOTICE:  SPI-NAND: WINBOND W25N01GV (128MB)
NOTICE:  SPI-NAND: Page size: 2KB+64, Block size: 128KB
NOTICE:  BL2: Booting BL31
NOTICE:  BL31: v2.14.0(release):OpenWrt v2026.01.23~e06f2586-1 (mt7981-spim-nand-ddr3-1866)
NOTICE:  BL31: Built : 13:27:17, May 17 2026


U-Boot 2026.01-OpenWrt-r34488-059f801a2c (May 17 2026 - 13:27:17 +0000)

CPU:   MediaTek MT7981
Model: COMFAST CF-WR632AX
DRAM:  512 MiB
Core:  29 devices, 16 uclasses, devicetree: embed
Loading Environment from UBI... spi-nand: spi_nand spi_nand@0: WINBOND W25N01GV SPI NAND was found.
spi-nand: spi_nand spi_nand@0: 128 MiB, block size: 128 KiB, page size: 2048, OOB size: 64
"Synchronous Abort" handler, esr 0x96000004, far 0xeafffffeeafffffe
elr: 0000000041e2ff44 lr : 0000000041e2f2f8 (reloc)
elr: 000000005ff66f44 lr : 000000005ff662f8
x0 : eafffffeeafffffe x1 : 000000005fb1a0e0
x2 : eafffffeeafffffe x3 : eafffffeeafffffe
x4 : 000000005ffe1620 x5 : 000000005fb1a440
x6 : 000000005ffe1630 x7 : 000000005fb3ba40
x8 : 0000000000000230 x9 : fffffffffffffff0
x10: 000000000000000d x11: 0000000000000006
x12: 0000000000000000 x13: 000000005ffd9650
x14: 00000000fffffffa x15: 0000000000000000
x16: 000000005ff81ce0 x17: 0000000000000000
x18: 000000005f7ffe10 x19: 000000005fb19f60
x20: 0000000000000000 x21: 000000005fb19200
x22: 000000005fb19200 x23: 000000005fb1ad40
x24: 000000005fb1a0e0 x25: 000000005fb19f60
x26: 0000000000000000 x27: 000000005fb1a0e0
x28: 000000005fb1a380 x29: 000000005f7c1a00

Code: f9400442 aa000043 b4000483 b40002a0 (f9400003)
Resetting CPU ...

resetting ...
```

</details>