### PR TITLE
uboot-mediatek: fix malformed patch

### DIFF
--- a/package/boot/uboot-mediatek/patches/503-add-wavlink-wl-wnt100x3.patch
+++ b/package/boot/uboot-mediatek/patches/503-add-wavlink-wl-wnt100x3.patch
@@ -262,7 +262,7 @@
 +};
 --- /dev/null
 +++ b/defenvs/wavlink_wl-wnt100x3_env
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,54 @@
 +ipaddr=192.168.1.1
 +serverip=192.168.1.254
 +loadaddr=0x46000000


### PR DESCRIPTION
The chunk length is not correct.

Fixes: d2fabb974c57 ("mediatek: add support for Wavlink WL-WNT100X3 ubootmod")

Cc @fildunsky