### PR TITLE
[25.12] ramips: pax1800-lite: fix label-mac-device

### DIFF
--- a/target/linux/ramips/dts/mt7621_plasmacloud_pax1800-lite.dts
+++ b/target/linux/ramips/dts/mt7621_plasmacloud_pax1800-lite.dts
@@ -19,7 +19,7 @@
 		led-failsafe = &led_status_green;
 		led-running = &led_status_green;
 		led-upgrade = &led_status_green;
-		label-mac-device = &gmac1;
+		label-mac-device = &gmac0;
 	};
 
 	gpio_export {


### PR DESCRIPTION
The gmac1 is not used and doesn't have any mac address configured. The gmac0 has the nvmem-cells set and can actually be used to retrieve the correct mac address.

Fixes: c7c54f313425 ("ramips: add support for Plasma Cloud PAX1800-Lite")
Link: https://github.com/openwrt/openwrt/pull/23441