### PR TITLE
qualcommax: ipq807x: fix LED controller assignment for linksys_mx4x00 devices

### DIFF
--- a/package/kernel/linux/modules/leds.mk
+++ b/package/kernel/linux/modules/leds.mk
@@ -257,7 +257,7 @@ define KernelPackage/leds-st1202
   DEPENDS:=+kmod-i2c-core +kmod-ledtrig-pattern
   KCONFIG:=CONFIG_LEDS_ST1202
   FILES:= $(LINUX_DIR)/drivers/leds/leds-st1202.ko
-  AUTOLOAD:=$(call AutoProbe,leds-st1202)
+  AUTOLOAD:=$(call AutoLoad,60,leds-st1202,1)
 endef
 
 define KernelPackage/leds-st1202/description

--- a/target/linux/qualcommax/dts/ipq8174-homewrk.dts
+++ b/target/linux/qualcommax/dts/ipq8174-homewrk.dts
@@ -46,6 +46,36 @@
 	};
 };
 
+&blsp1_i2c2 {
+	status = "okay";
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
 &swport2 {
 	label = "wan";
 	nvmem-cells = <&mac_address 0>;

--- a/target/linux/qualcommax/dts/ipq8174-mx4200v1.dts
+++ b/target/linux/qualcommax/dts/ipq8174-mx4200v1.dts
@@ -11,6 +11,36 @@
 	compatible = "linksys,mx4200v1", "qcom,ipq8074";
 };
 
+&blsp1_i2c2 {
+	status = "okay";
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
 &wifi {
 	status = "okay";
 

--- a/target/linux/qualcommax/dts/ipq8174-mx4200v2.dts
+++ b/target/linux/qualcommax/dts/ipq8174-mx4200v2.dts
@@ -10,6 +10,36 @@
 	compatible = "linksys,mx4200v2", "qcom,ipq8074";
 };
 
+&blsp1_i2c2 {
+	status = "okay";
+
+	led-controller@58 {
+		compatible = "st,led1202";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x58>;
+
+		led_system_green: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			linux,default-trigger = "none";
+		};
+		led_system_red: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			linux,default-trigger = "none";
+		};
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			linux,default-trigger = "none";
+		};
+	};
+};
+
 &wifi {
 	status = "okay";
 

--- a/target/linux/qualcommax/dts/ipq8174-mx4300.dts
+++ b/target/linux/qualcommax/dts/ipq8174-mx4300.dts
@@ -256,6 +256,36 @@
 	};
 };
 
+&blsp1_i2c2 {
+	status = "okay";
+
+	led-controller@62 {
+		compatible = "nxp,pca9633";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x62>;
+		nxp,hw-blink;
+
+		led_system_red: led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_green: led@1 {
+			reg = <1>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_system_blue: led@2 {
+			reg = <2>;
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
 &swport2 {
 	label = "wan";
 	nvmem-cells = <&hw_mac_addr 0>;

--- a/target/linux/qualcommax/dts/ipq8174-mx4x00.dtsi
+++ b/target/linux/qualcommax/dts/ipq8174-mx4x00.dtsi
@@ -78,36 +78,6 @@
 	status = "okay";
 };
 
-&blsp1_i2c2 {
-	status = "okay";
-
-	led-controller@62 {
-		compatible = "nxp,pca9633";
-		#address-cells = <1>;
-		#size-cells = <0>;
-		reg = <0x62>;
-		nxp,hw-blink;
-
-		led_system_red: led@0 {
-			reg = <0>;
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led_system_green: led@1 {
-			reg = <1>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led_system_blue: led@2 {
-			reg = <2>;
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_STATUS;
-		};
-	};
-};
-
 &mdio {
 	status = "okay";
 

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -216,7 +216,6 @@ define Device/linksys_mx
 	SOC := ipq8072
 	IMAGES += factory.bin
 	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=$$$$(DEVICE_MODEL)
-	DEVICE_PACKAGES := kmod-leds-pca963x
 endef
 
 define Device/linksys_mx4x00
@@ -229,13 +228,15 @@ define Device/linksys_mx4200v1
 	$(call Device/linksys_mx4x00)
 	DEVICE_MODEL := MX4200
 	DEVICE_VARIANT := v1
-	DEVICE_PACKAGES += kmod-hci-uart
+	DEVICE_PACKAGES += kmod-hci-uart kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx4200v1
 
 define Device/linksys_mx4200v2
-	$(call Device/linksys_mx4200v1)
+	$(call Device/linksys_mx4x00)
+	DEVICE_MODEL := MX4200
 	DEVICE_VARIANT := v2
+	DEVICE_PACKAGES += kmod-hci-uart kmod-leds-st1202
 endef
 TARGET_DEVICES += linksys_mx4200v2
 
@@ -247,6 +248,7 @@ define Device/linksys_mx4300
 	KERNEL_SIZE := 8192k
 	IMAGE_SIZE := 171264k
 	NAND_SIZE := 1024m
+	DEVICE_PACKAGES += kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx4300
 
@@ -254,7 +256,7 @@ define Device/linksys_mx5300
 	$(call Device/linksys_mx)
 	DEVICE_MODEL := MX5300
 	DEVICE_PACKAGES += kmod-rtc-ds1307 ipq-wifi-linksys_mx5300 \
-		kmod-ath10k-ct ath10k-firmware-qca9984-ct
+		kmod-ath10k-ct ath10k-firmware-qca9984-ct kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx5300
 
@@ -262,7 +264,7 @@ define Device/linksys_mx8500
 	$(call Device/linksys_mx)
 	DEVICE_MODEL := MX8500
 	DEVICE_PACKAGES += ipq-wifi-linksys_mx8500 kmod-ath11k-pci \
-		ath11k-firmware-qcn9074 kmod-hci-uart
+		ath11k-firmware-qcn9074 kmod-hci-uart kmod-leds-pca963x
 endef
 TARGET_DEVICES += linksys_mx8500
 

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -24,6 +24,11 @@ spectrum,sax1v1k)
 edgecore,eap102)
 	ucidef_set_led_netdev "wan" "WAN" "green:wanpoe" "wan"
 	;;
+linksys,mx4200v2)
+	ucidef_set_led_default "blue" "blue" "blue:status" "1"
+	ucidef_set_led_default "green" "green" "green:status" "0"
+	ucidef_set_led_default "red" "red" "red:status" "0"
+	;;
 netgear,rax120v2)
 	ucidef_set_led_netdev "aqr" "AQR" "white:aqr" "lan5"
 	;;


### PR DESCRIPTION
## Summary

The Linksys MX4200v2 uses an ST LED1202 LED controller, while the other devices in the mx4x00 family (MX4200v1, MX4300, HomeWRK) use an NXP PCA9633. Since the LED controller node was previously shared via `ipq8174-mx4x00.dtsi`, there was no way to give each device its own controller definition and driver.

This PR moves the LED controller node into each device's individual DTS file so that the MX4200v2 gets the correct ST LED1202 node and loads `kmod-leds-st1202`, while the rest of the family continues to use `kmod-leds-pca963x` as before.

With the driver in place, the three ST LED1202 channels (blue, green, red) are registered in the MX4200v2 board default configuration, exposing them to userspace via UCI and LuCI. Blue is enabled at the OEM default brightness and colour scheme; red and green are off.

The third commit also ensures `kmod-leds-st1202` is loaded early at boot (rather than only on hardware probe). This is required so the boot/LED preinit window can use ST LED1202-backed LEDs correctly, matching how `kmod-leds-pca963x` is handled on the other mx4x00 devices.

> **Note:** This PR depends on PR [#23455](https://github.com/openwrt/openwrt/pull/23455) (leds-st1202 backports and pending fixes) and should not be merged without it. Without those driver fixes, loading `kmod-leds-st1202` on the MX4200v2 would leave pattern sequencing, brightness handling, and hardware-accelerated blink in a broken state, which would be a regression compared to the current situation where no LED driver is loaded for that device.