### PR TITLE
base-files: add ucidef_set_led_brightness and wire up linksys_mx4200v2 LEDs

### DIFF
--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -405,6 +405,12 @@ generate_led() {
 	EOF
 
 	case "$type" in
+		brightness)
+			local brightness
+			json_get_vars brightness
+			[ -n "$brightness" ] && uci -q set system.$cfg.brightness="$brightness"
+		;;
+
 		gpio)
 			local gpio inverted
 			json_get_vars gpio inverted

--- a/package/base-files/files/lib/functions/uci-defaults.sh
+++ b/package/base-files/files/lib/functions/uci-defaults.sh
@@ -416,6 +416,17 @@ ucidef_set_led_ataport() {
 	_ucidef_set_led_trigger "$1" "$2" "$3" ata"$4"
 }
 
+ucidef_set_led_brightness() {
+	_ucidef_set_led_common "$1" "$2" "$3"
+
+	json_add_string type brightness
+	json_add_string default "$4"
+	[ -n "$5" ] && json_add_string brightness "$5"
+	json_select ..
+
+	json_select ..
+}
+
 _ucidef_set_led_common() {
 	local cfg="led_$1"
 	local name="$2"

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/01_leds
@@ -24,6 +24,11 @@ spectrum,sax1v1k)
 edgecore,eap102)
 	ucidef_set_led_netdev "wan" "WAN" "green:wanpoe" "wan"
 	;;
+linksys,mx4200v2)
+	ucidef_set_led_brightness "blue" "blue" "blue:status" "1" "51"
+	ucidef_set_led_brightness "green" "green" "green:status" "0"
+	ucidef_set_led_brightness "red" "red" "red:status" "0"
+	;;
 netgear,rax120v2)
 	ucidef_set_led_netdev "aqr" "AQR" "white:aqr" "lan5"
 	;;


### PR DESCRIPTION
## Summary

PR #17190 introduced the ability to control LED brightness from userspace via UCI. However, there is no counterpart in the board default configuration infrastructure: `ucidef_set_led_default()` can only express on or off, so device profiles have no way to seed an initial brightness when support for a device is first added. This means that for hardware where the OEM ships a specific colour scheme or intensity, the default configuration cannot reflect it.

**Commit 1** adds `ucidef_set_led_brightness()` to `uci-defaults.sh` to close that gap. It works like `ucidef_set_led_default()` but accepts an optional fifth argument for brightness. The value is written as a `brightness` type to `board.json`; `config_generate` picks it up and writes the brightness option into the UCI LED config, where the existing led init script already applies it.

**Commit 2** puts the new function to use for the Linksys MX4200v2, whose ST LED1202 controller supports per-channel current control. Blue is enabled at brightness 51 and red and green are off, matching the OEM default colour scheme and intensity.

> **Note:** For the MX4200v2 configuration in commit 2 to have any effect, PR [#23455](https://github.com/openwrt/openwrt/pull/23455) (leds-st1202 backports and pending fixes) and PR [#23456](https://github.com/openwrt/openwrt/pull/23455) (LED controller assignment fix for linksys_mx4x00 devices) must also be merged.