### PR TITLE
imagebuilder: suppress rootfs image when filesystem specified

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -373,6 +373,7 @@ define Image/gzip-ext4-padded-squashfs
 
 endef
 
+ifeq ($(filter-out targz,$(ROOTFS_FILESYSTEM)),)
 ifdef CONFIG_TARGET_ROOTFS_TARGZ
   define Image/Build/targz
 	$(TAR) -cp --numeric-owner --owner=0 --group=0 --mode=a-s --sort=name \
@@ -380,11 +381,14 @@ ifdef CONFIG_TARGET_ROOTFS_TARGZ
 		-C $(TARGET_DIR)/ . | gzip -9n > $(BIN_DIR)/$(IMG_PREFIX)$(if $(PROFILE_SANITIZED),-$(PROFILE_SANITIZED))-rootfs.tar.gz
   endef
 endif
+endif
 
+ifeq ($(filter-out cpiogz,$(ROOTFS_FILESYSTEM)),)
 ifdef CONFIG_TARGET_ROOTFS_CPIOGZ
   define Image/Build/cpiogz
 	( cd $(TARGET_DIR); find . | $(STAGING_DIR_HOST)/bin/cpio -o -H newc -R 0:0 | gzip -9n >$(BIN_DIR)/$(IMG_ROOTFS).cpio.gz )
   endef
+endif
 endif
 
 mkfs_packages = $(filter-out @%,$(PACKAGES_$(call param_get,pkg,pkg=$(target_params))))


### PR DESCRIPTION
When using imagebuilder to create images, ROOTFS_FILESYSTEM may be defined to create just the desired images, but the '*-rootfs.tar.gz' images are being created unconditionally for many targets.

By making generation of these images conditional on the state of ROOTFS_FILESYSTEM, we can save significant space (measured 3-7 MB depending on length of package list) and time.

---
@aparcar 
@dangowrt 

Tested on x86/64 and mvebu/cortexa9 targets.  A couple of representative "before" imagebuilder test runs shown below.  The savings depends a lot on how many packages are included in the build, with default sizes of these rootfs images around ~3MB.  Wall time savings was usually on the order of 3-4 seconds, so not huge, but still something.

```
$ find -name '*rootfs.tar.gz' | xargs ls -la
-rw-r--r-- 1 x x 4463897 May 20 06:47 openwrt-x86-64-generic-rootfs.tar.gz
-rw-r--r-- 1 x x 6292314 May 20 06:59 openwrt-mvebu-cortexa9-linksys_wrt3200acm-rootfs.tar.gz
```