### PR TITLE
iwinfo: clear nl80211 freqlist entry

### DIFF
--- a/package/network/utils/iwinfo/Makefile
+++ b/package/network/utils/iwinfo/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=libiwinfo
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL=$(PROJECT_GIT)/project/iwinfo.git

--- a/package/network/utils/iwinfo/patches/101-nl80211-init-freq-entry.patch
+++ b/package/network/utils/iwinfo/patches/101-nl80211-init-freq-entry.patch
@@ -1,0 +1,11 @@
+--- a/iwinfo_nl80211.c
++++ b/iwinfo_nl80211.c
+@@ -3246,6 +3246,8 @@ static int nl80211_get_freqlist_cb(struc
+ 					    freqs[NL80211_FREQUENCY_ATTR_DISABLED])
+ 						continue;
+ 
++					memset(e, 0, sizeof(*e));
++
+ 					e->band = nl80211_get_band(band->nla_type);
+ 					e->mhz = nla_get_u32(freqs[NL80211_FREQUENCY_ATTR_FREQ]);
+ 					e->channel = nl80211_freq2channel(e->mhz);


### PR DESCRIPTION
Zero the freqlist entry before filling it in nl80211_get_freqlist_cb().

Without this, long-lived processes such as rpcd can reuse dirty stack contents and keep random bits in the exported data. This shows up in ubus iwinfo freqlist replies as bogus flags such as no_10mhz and no_20mhz, even though they are not actually set.

Clear the whole entry first so only flags reported by nl80211 are returned.


