### PR TITLE
kernel: add kmod-hwmon-corsair-cpro

### DIFF
--- a/package/kernel/linux/modules/hwmon.mk
+++ b/package/kernel/linux/modules/hwmon.mk
@@ -110,6 +110,21 @@ endef
 $(eval $(call KernelPackage,hwmon-coretemp))
 
 
+define KernelPackage/hwmon-corsair-cpro
+  TITLE:=Corsair Commander Pro controller
+  KCONFIG:=CONFIG_SENSORS_CORSAIR_CPRO
+  FILES:=$(LINUX_DIR)/drivers/hwmon/corsair-cpro.ko
+  AUTOLOAD:=$(call AutoProbe,corsair-cpro)
+  $(call AddDepends/hwmon,+kmod-usb-hid)
+endef
+
+define KernelPackage/hwmon-corsair-cpro/description
+ Kernel module for the Corsair Commander Pro controller and Corsair 1000D
+endef
+
+$(eval $(call KernelPackage,hwmon-corsair-cpro))
+
+
 define KernelPackage/hwmon-dme1737
   TITLE:=SMSC DME1737 and compatible monitoring support
   KCONFIG:=CONFIG_SENSORS_DME1737


### PR DESCRIPTION
This module adds support for the Corsair Commander Pro and Corsair Commander Pro (1000D) fan and temperature monitoring controllers.

The Corsair Commander Pro is a PC fan controller, for which the kernel already provides a driver. I have built 2 simple hardware devices that act as Corsair Commander Pro-compatible devices, but with support for only a single fan.

12V fan:
<img width="4096" height="3072" alt="IMG_20260521_123320" src="https://github.com/user-attachments/assets/83c4a52b-1f02-4d7b-b924-11995aa8b87c" />

5V fan:
<img width="3072" height="4096" alt="IMG_20260521_123434" src="https://github.com/user-attachments/assets/f3586089-bc15-45c0-bd1e-7cd17ad1c612" />

when device plugin:
```
[  348.182088] corsair-cpro 0003:1B1C:0C10.0001: hidraw0: USB HID v1.11 Device [Corsair Commander PRO] on usb-xhci-hcd.0.auto-1/input2
```

sensors output:
```
corsaircpro-hid-3-1
Adapter: HID adapter
in0:              N/A  
in1:              N/A  
in2:              N/A  
fan1 3pin:   1428 RPM
pwm1:             32%
```