### PR TITLE
qualcommax: ipq50xx: add support for ELECOM WRC-X3000GST2

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq50xx
@@ -11,6 +11,7 @@ case "$board" in
 cmcc,mr3000d-ci|\
 cmcc,pz-l8|\
 elecom,wrc-x3000gs2|\
+elecom,wrc-x3000gst2|\
 iodata,wn-dax3000gr|\
 zyxel,scr50axe)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"

--- a/target/linux/qualcommax/dts/ipq5018-wrc-x3000gst2.dts
+++ b/target/linux/qualcommax/dts/ipq5018-wrc-x3000gst2.dts
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+
+#include "ipq5018.dtsi"
+#include "ipq5018-ess.dtsi"
+#include "ipq5018-qcn6122.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "ELECOM WRC-X3000GST2";
+	compatible = "elecom,wrc-x3000gst2", "qcom,ipq5018";
+
+	aliases {
+		serial0 = &blsp1_uart1;
+		led-boot = &led_power_green;
+		led-failsafe = &led_power_red;
+		led-running = &led_power_green;
+		led-upgrade = &led_power_green;
+		label-mac-device = <&dp1>;
+	};
+
+	chosen {
+		bootargs-append = " root=/dev/ubiblock0_1 coherent_pool=2M";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&button_pins>;
+		pinctrl-names = "default";
+
+		switch-router {
+			label = "router";
+			gpios = <&tlmm 14 GPIO_ACTIVE_HIGH>;
+			linux,code = <BTN_0>;
+			linux,input-type = <EV_SW>;
+		};
+
+		reset-button {
+			label = "reset";
+			gpios = <&tlmm 22 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		wps-button {
+			label = "wps";
+			gpios = <&tlmm 38 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-0 = <&led_pins>;
+		pinctrl-names = "default";
+
+		led-0 {
+			gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WPS;
+		};
+
+		led_power_green: led-1 {
+			gpios = <&tlmm 13 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led_power_red: led-2 {
+			gpios = <&tlmm 16 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_POWER;
+		};
+
+		led-3 {
+			gpios = <&tlmm 24 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			linux,default-trigger = "phy1radio";
+		};
+
+		led-4 {
+			gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+		};
+
+		led-5 {
+			gpios = <&tlmm 26 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			linux,default-trigger = "phy0radio";
+		};
+
+		led-6 {
+			gpios = <&tlmm 28 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+		};
+
+		led-7 {
+			gpios = <&tlmm 46 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+		};
+	};
+};
+
+&sleep_clk {
+	clock-frequency = <32000>;
+};
+
+&xo_board_clk {
+	clock-div = <4>;
+	clock-mult = <1>;
+};
+
+&blsp1_uart1 {
+	status = "okay";
+
+	pinctrl-0 = <&serial_0_pins>;
+	pinctrl-names = "default";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qfprom {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	pinctrl-0 = <&qpic_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		nand-ecc-engine = <&qpic_nand>;
+
+		/* strength=8 breaks NAND I/O, use 4 instead */
+		nand-ecc-strength = <4>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+
+			partition-0-appsblenv {
+				label = "0:appsblenv";
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+					env-size = <0x40000>;
+
+					macaddr_appsblenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_mac_mode = <MAC_MODE_SGMII_CHANNEL0>;
+
+	qcom,port_phyinfo {
+		port@1 {
+			port_id = <1>;
+			mdiobus = <&mdio0>;
+			phy_address = <7>;
+		};
+
+		port@2 {
+			port_id = <2>;
+			forced-speed = <1000>;
+			forced-duplex = <1>;
+		};
+	};
+};
+
+&dp1 {
+	status = "okay";
+
+	label = "wan";
+	nvmem-cells = <&macaddr_appsblenv_ethaddr 3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&dp2 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_appsblenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+
+	fixed-link {
+		speed = <1000>;
+		full-duplex;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+};
+
+&mdio1 {
+	status = "okay";
+
+	pinctrl-0 = <&mdio1_pins>, <&switch_reset_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 39 GPIO_ACTIVE_LOW>;
+
+	qca8337_0: ethernet-phy@0 {
+		reg = <0>;
+	};
+
+	qca8337_1: ethernet-phy@1 {
+		reg = <1>;
+	};
+
+	qca8337_2: ethernet-phy@2 {
+		reg = <2>;
+	};
+
+	qca8337_3: ethernet-phy@3 {
+		reg = <3>;
+	};
+
+	ethernet-switch@18 {
+		compatible = "qca,qca8337";
+		reg = <0x18>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@1 {
+				reg = <1>;
+				label = "lan1";
+				phy-handle = <&qca8337_0>;
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+				phy-handle = <&qca8337_1>;
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan3";
+				phy-handle = <&qca8337_2>;
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "lan4";
+				phy-handle = <&qca8337_3>;
+			};
+
+			port@6 {
+				reg = <6>;
+				phy-mode = "sgmii";
+				ethernet = <&dp2>;
+				qca,sgmii-enable-pll;
+
+				fixed-link {
+					speed = <1000>;
+					full-duplex;
+				};
+			};
+		};
+	};
+};
+
+&tlmm {
+	button_pins: button-state {
+		button-pins {
+			pins = "gpio22", "gpio38";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		switch-pins {
+			pins = "gpio14";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+	};
+
+	led_pins: led-state {
+		pins = "gpio12", "gpio13", "gpio16", "gpio24",
+		       "gpio25", "gpio26", "gpio28", "gpio46";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+
+	mdio1_pins: mdio-state {
+		mdc-pins {
+			pins = "gpio36";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio-pins {
+			pins = "gpio37";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+	};
+
+	qpic_pins: qpic-state {
+		clock-pins {
+			pins = "gpio9";
+			function = "qspi_clk";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		cs-pins {
+			pins = "gpio8";
+			function = "qspi_cs";
+			drive-strength = <8>;
+			bias-disable;
+		};
+
+		data-pins {
+			pins = "gpio4", "gpio5", "gpio6", "gpio7";
+			function = "qspi_data";
+			drive-strength = <8>;
+			bias-disable;
+		};
+	};
+
+	serial_0_pins: uart0-state {
+		pins = "gpio20", "gpio21";
+		function = "blsp0_uart0";
+		bias-disable;
+	};
+
+	switch_reset_pins: switch-reset-state {
+		pins = "gpio39";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-down;
+	};
+};
+
+&q6v5_wcss {
+	status = "okay";
+
+	boot-args = <0x2 4 2 18 0 0>; /* pcie:1, len:4, updid:2, reset:gpio18 */
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,rproc = <&q6_wcss_pd1>;
+	qcom,ath11k-calibration-variant = "ELECOM-WRC-X3000GS2";
+	qcom,ath11k-fw-memory-mode = <1>;
+	qcom,bdf-addr = <0x4c400000>;
+
+	ieee80211-freq-limit = <2400000 2483000>;
+};
+
+&wifi1 {
+	status = "okay";
+
+	qcom,rproc = <&q6_wcss_pd2>;
+	qcom,userpd-subsys-name = "q6v5_wcss_userpd2";
+	qcom,ath11k-calibration-variant = "ELECOM-WRC-X3000GS2";
+	qcom,ath11k-fw-memory-mode = <1>;
+	qcom,bdf-addr = <0x4d100000>;
+	qcom,m3-dump-addr = <0x4df00000>;
+
+	ieee80211-freq-limit = <5150000 5730000>;
+};

--- a/target/linux/qualcommax/image/ipq50xx.mk
+++ b/target/linux/qualcommax/image/ipq50xx.mk
@@ -68,6 +68,25 @@ define Device/elecom_wrc-x3000gs2
 endef
 TARGET_DEVICES += elecom_wrc-x3000gs2
 
+define Device/elecom_wrc-x3000gst2
+	$(call Device/FitImageLzma)
+	DEVICE_VENDOR := ELECOM
+	DEVICE_MODEL := WRC-X3000GST2
+	DEVICE_DTS_CONFIG := config@mp03.3
+	SOC := ipq5018
+	KERNEL_IN_UBI := 1
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	IMAGE_SIZE := 52480k
+	NAND_SIZE := 128m
+	IMAGES += factory.bin
+	IMAGE/factory.bin := append-ubi | qsdk-ipq-factory-nand | \
+		mstc-header 4.04(XZP.0)b90 | elecom-product-header WRC-X3000GST2
+	DEVICE_PACKAGES := ath11k-firmware-ipq5018-qcn6122 \
+		ipq-wifi-elecom_wrc-x3000gs2
+endef
+TARGET_DEVICES += elecom_wrc-x3000gst2
+
 define Device/glinet_gl-b3000
 	$(call Device/FitImage)
 	DEVICE_VENDOR := GL.iNet

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/01_leds
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/01_leds
@@ -11,6 +11,7 @@ board=$(board_name)
 case "$board" in
 cmcc,pz-l8|\
 elecom,wrc-x3000gs2|\
+elecom,wrc-x3000gst2|\
 iodata,wn-dax3000gr)
 	ucidef_set_led_netdev "wan" "WAN" "green:wan" "wan" "tx rx link_10 link_100 link_1000"
 	;;

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/board.d/02_network
@@ -8,6 +8,7 @@ ipq50xx_setup_interfaces()
 	local board="$1"
 	case $board in
 	elecom,wrc-x3000gs2|\
+	elecom,wrc-x3000gst2|\
 	iodata,wn-dax3000gr|\
 	linksys,mr5500|\
 	zyxel,scr50axe)

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -17,6 +17,7 @@ case "$FIRMWARE" in
 		ath11k_remove_regdomain
 		;;
 	elecom,wrc-x3000gs2|\
+	elecom,wrc-x3000gst2|\
 	iodata,wn-dax3000gr|\
 	zyxel,scr50axe)
 		caldata_extract "0:art" 0x1000 0x20000
@@ -70,6 +71,7 @@ case "$FIRMWARE" in
 		ath11k_set_macflag
 		;;
 	elecom,wrc-x3000gs2|\
+	elecom,wrc-x3000gst2|\
 	iodata,wn-dax3000gr|\
 	zyxel,scr50axe)
 		caldata_extract "0:art" 0x26800 0x20000

--- a/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
+++ b/target/linux/qualcommax/ipq50xx/base-files/etc/hotplug.d/ieee80211/05-wifi-migrate
@@ -49,6 +49,7 @@ WIRELESS_CHANGED=false
 
 case "$(board_name)" in
 elecom,wrc-x3000gs2|\
+elecom,wrc-x3000gst2|\
 glinet,gl-b3000|\
 iodata,wn-dax3000gr|\
 linksys,mx2000|\

--- a/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq50xx/base-files/lib/upgrade/platform.sh
@@ -182,6 +182,7 @@ platform_do_upgrade() {
 	cmcc,mr3000d-ci|\
 	cmcc,pz-l8|\
 	elecom,wrc-x3000gs2|\
+	elecom,wrc-x3000gst2|\
 	iodata,wn-dax3000gr)
 		local delay
 


### PR DESCRIPTION
This adds support for the ELECOM WRC-X3000GST2, an IPQ5018-based Wi-Fi 6 router.

The device is almost identical to the already supported WRC-X3000GS2. The main hardware difference is RAM capacity: WRC-X3000GST2 has 512 MiB DDR3, while WRC-X3000GS2 has 256 MiB. Because of this, ath11k Wi-Fi is enabled for WRC-X3000GST2.

The GS2 board data package is reused intentionally. The GST2 stock firmware contains the same bdwlan data as GS2, and the hardware around IPQ5018/QCN6122/antennas is identical.

## Device information

- SoC: Qualcomm IPQ5018
- RAM: 512 MiB DDR3
- Flash: 128 MiB SPI-NAND
- Wi-Fi: 2.4 GHz IPQ5018 + 5 GHz QCN6122, 2T2R
- Ethernet: 5x 10/100/1000 Mbps
  - WAN: IPQ5018 internal PHY
  - LAN: QCA8337 switch
- LEDs: 8x GPIO LEDs
- Buttons/switches: reset, WPS, router/AP slide switch
- UART: 3.3 V, 115200n8

## Notes

WRC-X3000GST2 stock firmware keeps its configuration even when its sysupgrade is called with `-n`. When installing from the OEM WebUI, stock settings may be restored into the OpenWrt overlay on first boot. The commit message therefore includes an extra reset-button initialization step after the first OpenWrt boot.

## Tested

Tested on an ELECOM WRC-X3000GST2 with stock firmware v1.09.

- Factory image accepted by the OEM WebUI
- RAM detected as 512 MiB
- SPI-NAND detected as Macronix MX35UF1G24AD-Z4I
- MAC address layout verified from `0:appsblenv`
  - LAN: `ethaddr` / `eth1addr`
  - WAN: `eth0addr`
  - 2.4 GHz: `wifi0`
  - 5 GHz: `wifi1`
- ath11k firmware/caldata loading verified for IPQ5018 and QCN6122 without board data errors
- 2.4GHz, 5 GHz AP forwarding state verified
- GPIO LEDs enumerated and manual brightness control verified
- WAN LED manual brightness control verified
- Buttons verified via `gpio-button-hotplug`
  - WPS: `BUTTON=wps`
  - reset: `BUTTON=reset`
  - router/AP slide switch: `BUTTON=BTN_0`, `TYPE=switch`
- LAN ports tested individually
- WAN link-up verified
- Stock firmware return procedure documented using the bootconfig index switching method
