### PR TITLE
ath79: support Dragino MS14 and LPS8 boards

### DIFF
--- a/target/linux/ath79/dts/ar9330_dragino_dragino2.dtsi
+++ b/target/linux/ath79/dts/ar9330_dragino_dragino2.dtsi
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9330.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	pinctrl-names = "default";
+	pinctrl-0 = <&jtag_disable_pins>;
+
+	aliases {
+		led-boot = &led_system;
+		led-failsafe = &led_system;
+		led-running = &led_system;
+		led-upgrade = &led_system;
+		label-mac-device = &wmac;
+	};
+
+	gpio_leds: leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&switch_led_disable_pins>;
+
+		led_system: system {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 28 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+			panic-indicator;
+		};
+	};
+
+	gpio_keys: keys {
+		compatible = "gpio-keys";
+	};
+};
+
+&usb {
+	status = "okay";
+
+	dr_mode = "host";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&spi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <50000000>;
+		reg = <0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x000000 0x040000>;
+				read-only;
+			};
+
+			partition@40000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x040000 0xfa0000>;
+			};
+
+			partition@fe0000 {
+				label = "config";
+				reg = <0xfe0000 0x10000>;
+				read-only;
+			};
+			partition@ff0000 {
+				label = "art";
+				reg = <0xff0000 0x010000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_art_0: macaddr@0 {
+						reg = <0x0 0x6>;
+					};
+
+					macaddr_art_6: macaddr@6 {
+						reg = <0x6 0x6>;
+					};
+
+					macaddr_art_1002: macaddr@1002 {
+						reg = <0x1002 0x6>;
+					};
+
+					cal_art_1000: calibration@1000 {
+						reg = <0x1000 0x440>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&eth0 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&eth1 {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_6>;
+	nvmem-cell-names = "mac-address";
+
+	gmac-config {
+		device = <&gmac>;
+
+		switch-phy-addr-swap = <0>;
+		switch-phy-swap = <0>;
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&macaddr_art_1002>, <&cal_art_1000>;
+	nvmem-cell-names = "mac-address", "calibration";
+};

--- a/target/linux/ath79/dts/ar9330_dragino_lps8.dts
+++ b/target/linux/ath79/dts/ar9330_dragino_lps8.dts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9330_dragino_dragino2.dtsi"
+
+/ {
+	model = "Dragino LPS8";
+	compatible = "dragino,lps8", "qca,ar9330";
+
+	spi-gpio {
+		compatible = "spi-gpio";
+		mosi-gpios = <&gpio 18 GPIO_ACTIVE_HIGH>;
+		miso-gpios = <&gpio 20 GPIO_ACTIVE_HIGH>;
+		sck-gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
+		cs-gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
+		num-chipselects = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		lora@0 {
+			compatible = "semtech,sx1301";
+			reg = <0>;
+			spi-max-frequency = <8000000>;
+		};
+	};
+};
+
+&eth1 {
+	compatible = "syscon", "simple-mfd";
+};
+
+&gpio_keys {
+	reset {
+		label = "reset";
+		linux,code = <KEY_RESTART>;
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gpio_leds {
+	lan {
+		function = LED_FUNCTION_LAN;
+		color = <LED_COLOR_ID_RED>;
+		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+	};
+
+	wan {
+		function = LED_FUNCTION_WAN;
+		color = <LED_COLOR_ID_RED>;
+		gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
+	};
+
+	wlan {
+		/* Attaching this via led-sources causes oopses for some reason */
+		function = LED_FUNCTION_WLAN;
+		color = <LED_COLOR_ID_GREEN>;
+		gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
+		linux,default-trigger = "phy0tpt";
+	};
+};
+
+&led_system {
+	color = <LED_COLOR_ID_BLUE>;
+};

--- a/target/linux/ath79/dts/ar9330_dragino_ms14.dts
+++ b/target/linux/ath79/dts/ar9330_dragino_ms14.dts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "ar9330_dragino_dragino2.dtsi"
+
+/ {
+	model = "Dragino MS14";
+	compatible = "dragino,ms14", "qca,ar9330";
+};
+
+&gpio_leds {
+	lan {
+		function = LED_FUNCTION_LAN;
+		color = <LED_COLOR_ID_RED>;
+		gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
+	};
+
+	wan {
+		function = LED_FUNCTION_WAN;
+		color = <LED_COLOR_ID_RED>;
+		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gpio_keys {
+	jumpstart {
+		label = "jumpstart";
+		linux,code = <BTN_0>;
+		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
+	};
+
+	reset {
+		label = "reset";
+		linux,code = <KEY_RESTART>;
+		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&wmac {
+	led {
+		led-sources = <0>;
+	};
+};

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -252,6 +252,9 @@ dlink,dap-1365-a1)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimediumhigh" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan0" "76" "100"
 	;;
+dragino,lps8)
+	ucidef_set_led_netdev "lan" "LAN" "red:lan" "eth0"
+	;;
 dragino,ms14)
 	ucidef_set_led_netdev "lan" "LAN" "red:lan" "eth0"
 	ucidef_set_led_netdev "wan" "WAN" "red:wan" "eth1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
@@ -252,6 +252,10 @@ dlink,dap-1365-a1)
 	ucidef_set_led_rssi "rssimediumhigh" "RSSIMEDIUMHIGH" "green:rssimediumhigh" "wlan0" "51" "100"
 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "green:rssihigh" "wlan0" "76" "100"
 	;;
+dragino,ms14)
+	ucidef_set_led_netdev "lan" "LAN" "red:lan" "eth0"
+	ucidef_set_led_netdev "wan" "WAN" "red:wan" "eth1"
+	;;
 engenius,ens202ext-v1|\
 engenius,enstationac-v1)
 	ucidef_set_rssimon "wlan0" "200000" "1"

--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
+++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
@@ -40,6 +40,7 @@ ath79_setup_interfaces()
 	dlink,dap-2680-a1|\
 	dlink,dap-3320-a1|\
 	dlink,dir-505|\
+	dragino,lps8|\
 	engenius,eap1200h|\
 	engenius,eap1750h|\
 	engenius,eap600|\

--- a/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
+++ b/target/linux/ath79/generic/base-files/etc/uci-defaults/04_led_migration
@@ -11,6 +11,9 @@ dlink,dap-1330-a1)
 		"green:signal1=green:rssimediumhigh" \
 		"green:signal2=green:rssihigh"
 	;;
+dragino,ms14)
+	migrate_leds "red:system=red:status"
+	;;
 engenius,epg5000)
 	migrate_leds ":wlan-2g=:wlan2g" ":wlan-5g=:wlan5g"
 	;;

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1315,6 +1315,16 @@ define Device/dlink_dir-842-c3
 endef
 TARGET_DEVICES += dlink_dir-842-c3
 
+define Device/dragino_ms14
+  SOC := ar9330
+  DEVICE_VENDOR := Dragino
+  DEVICE_MODEL := MS14
+  DEVICE_PACKAGES := kmod-usb-chipidea2
+  IMAGE_SIZE := 16000k
+  SUPPORTED_DEVICES += dragino2
+endef
+TARGET_DEVICES += dragino_ms14
+
 define Device/elecom_wab
   DEVICE_VENDOR := ELECOM
   IMAGE_SIZE := 14336k

--- a/target/linux/ath79/image/generic.mk
+++ b/target/linux/ath79/image/generic.mk
@@ -1315,13 +1315,24 @@ define Device/dlink_dir-842-c3
 endef
 TARGET_DEVICES += dlink_dir-842-c3
 
-define Device/dragino_ms14
+define Device/dragino2_common
   SOC := ar9330
   DEVICE_VENDOR := Dragino
-  DEVICE_MODEL := MS14
   DEVICE_PACKAGES := kmod-usb-chipidea2
   IMAGE_SIZE := 16000k
   SUPPORTED_DEVICES += dragino2
+endef
+
+define Device/dragino_lps8
+  $(Device/dragino2_common)
+  DEVICE_MODEL := LPS8
+  DEVICE_PACKAGES += kmod-spi-gpio kmod-spi-dev
+endef
+TARGET_DEVICES += dragino_lps8
+
+define Device/dragino_ms14
+  $(Device/dragino2_common)
+  DEVICE_MODEL := MS14
 endef
 TARGET_DEVICES += dragino_ms14
 


### PR DESCRIPTION
Dragino MS14 is a small router/development kit with two Fast Ethernet
ports, with single 1x1 2,4GHz Wi-Fi radio and expansion headers.

Dragino LPS8 is a LoRa/LoRaWAN gateway with single Wi-Fi 4 radio and a
single Fast Ethernet port, based around Dragino HE module.
   
Specifications:
CPU: Atheros AR9330 SoC @400MHz,
RAM: 64MB DDR,
Flash: 16MB SPI-NOR,
Ethernet: One 100Mbps port.
Wireless: built-in 1x1 802.11 2.4GHz radio,
USB: single USB2.0 High speed host port,
LoRa (on LPS8): Semtech SX1301 or compatible module, dependent on LoRa band.
    
Installation:
Log in via SSH to the unit, default username and password are 'root' and
'dragino', respectively. SSH listens on port 2222.
Just 'sysupgrade -n' from vendor firmware, dropping old configuration.
    
Restore vendor firmware:
the same as installation, just 'sysupgrade -F -n', dropping configuration.