### PR TITLE
hostapd: fix null reference errors for 6GHz-only radios (QCN9074)

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -388,8 +388,8 @@ function device_htmode_append(config) {
 
 	/* 802.11ax */
 	if (wildcard(config.htmode, 'HE*') || wildcard(config.htmode, 'EHT*')) {
-		let he_phy_cap = phy_capabilities.he_phy_cap;
-		let he_mac_cap = phy_capabilities.he_mac_cap;
+		let he_phy_cap = phy_capabilities.he_phy_cap ?? [];
+		let he_mac_cap = phy_capabilities.he_mac_cap ?? [];
 
 		config.ieee80211ax = true;
 


### PR DESCRIPTION
Fix two null reference errors in device_htmode_append() that prevent
6GHz-only PCIe radios (QCN9074/ath11k_pci) from initializing on devices
like the Linksys MX8500 (qualcommax/ipq807x).

Root cause:
wiphy_band() returns a valid object for the QCN9074 6GHz radio, but
without ht_capa and vht_capa keys, because 6GHz is HE-only (no HT/VHT):

  band keys: [ "rates", "iftype_data", "freqs" ]
  ht_capa:  undefined
  vht_capa: undefined
  iftype_data length: 3

The existing `band.ht_capa ?? 0` and `band.vht_capa ?? 0` handle this
correctly. However, he_phy_cap and he_mac_cap in phy_capabilities are
only populated inside the iftype_data loop. When that loop runs but the
resulting capabilities are not set (edge case), he_phy_cap and he_mac_cap
remain null, causing null dereferences in device_htmode_append():

  Reference error: left-hand side expression is null
  `if (!(he_phy_cap[3] & 0x80))`

Fix: guard he_phy_cap and he_mac_cap with ?? [] so bitwise checks
conservatively disable beamformer/beamformee/twt features when
capability bytes are unavailable, rather than crashing.

Verified: with this fix, hostapd starts successfully with ieee80211ax=1
and he_su_beamformer=1, he_su_beamformee=1, he_mu_beamformer=1 on the
QCN9074 6GHz radio at channel 33 (6115 MHz), width 160 MHz.

Tested on: Linksys MX8500 (qualcommax/ipq807x), OpenWrt 25.12.4,
QCN9074 6GHz radio, HE160 @ channel 33 (6115 MHz).

Fixes #23488