### PR TITLE
hostapd: fix null dereference for 6GHz-only radios (QCN9074)

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -470,6 +470,8 @@ function device_capabilities(config) {
 
 	phy_capabilities.ht_capa = band.ht_capa ?? 0;
 	phy_capabilities.vht_capa = band.vht_capa ?? 0;
+	phy_capabilities.he_mac_cap = [];
+	phy_capabilities.he_phy_cap = [];
 	for (let iftype in band.iftype_data) {
 		if (!iftype.iftypes.ap)
 			continue;


### PR DESCRIPTION
Fix null reference errors in device_htmode_append() that prevent
6GHz-only PCIe radios (QCN9074/ath11k_pci) from initializing on devices
like the Linksys MX8500 (qualcommax/ipq807x).

he_phy_cap and he_mac_cap in phy_capabilities are only populated inside
the iftype_data loop. When capability bytes are unavailable, they remain
null, causing null dereferences:

  Reference error: left-hand side expression is null
  `if (!(he_phy_cap[3] & 0x80))`

Fix: guard with ?? [] so bitwise checks conservatively disable
beamformer/beamformee/twt features rather than crashing.

Verified: hostapd starts successfully with ieee80211ax=1 on QCN9074
6GHz radio at channel 33 (6115 MHz), width 160 MHz.

Tested on: Linksys MX8500 (qualcommax/ipq807x), OpenWrt 25.12.4.

Fixes #23488
