### PR TITLE
mediatek: add support for Buffalo WSR-2533DHP3

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7622
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_mt7622
@@ -34,7 +34,8 @@ linksys,e8450-ubi)
 		;;
 	esac
 	;;
-buffalo,wsr-2533dhp2)
+buffalo,wsr-2533dhp2|\
+buffalo,wsr-2533dhp3)
 	ubootenv_add_uci_config "/dev/mtd3" "0x0" "0x1000" "0x20000"
 	;;
 dlink,eagle-pro-ai-m32-a1|\

--- a/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp3.dts
+++ b/target/linux/mediatek/dts/mt7622-buffalo-wsr-2533dhp3.dts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7622-buffalo-wsr.dtsi"
+
+/ {
+	model = "Buffalo WSR-2533DHP3";
+	compatible = "buffalo,wsr-2533dhp3", "mediatek,mt7622";
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x0f000000>;
+		device_type = "memory";
+	};
+};
+
+&pio {
+	/* Serial NAND is shared pin with SPI-NOR */
+	serial_nand_pins: serial-nand-pins {
+		mux {
+			function = "flash";
+			groups = "snfi";
+		};
+
+		conf-cmd-dat {
+			pins = "SPI_WP", "SPI_HOLD", "SPI_MOSI",
+			       "SPI_MISO", "SPI_CS";
+			input-enable;
+			drive-strength = <MTK_DRIVE_16mA>;
+			bias-pull-up;
+		};
+
+		conf-clk {
+			pins = "SPI_CLK";
+			drive-strength = <MTK_DRIVE_16mA>;
+			bias-pull-down;
+		};
+	};
+};
+
+&mdio {
+	switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 54 GPIO_ACTIVE_HIGH>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				label = "lan4";
+			};
+
+			port@1 {
+				reg = <1>;
+				label = "lan3";
+			};
+
+			port@2 {
+				reg = <2>;
+				label = "lan2";
+			};
+
+			port@3 {
+				reg = <3>;
+				label = "lan1";
+			};
+
+			port@4 {
+				reg = <4>;
+				label = "wan";
+			};
+
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&gmac0>;
+				phy-connection-type = "2500base-x";
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+};
+
+&snfi {
+	pinctrl-names = "default";
+	pinctrl-0 = <&serial_nand_pins>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <104000000>;
+		nand-ecc-engine = <&snfi>;
+		mediatek,bmt-v2;
+		mediatek,bmt-table-size = <0x1000>;
+		/*
+		 * - Preloader - (kernel (6MiB, in firmware))
+		 * - Kernel2 - board_data
+		 */
+		mediatek,bmt-remap-range = <0x0 0x800000>,
+					   <0x3400000 0x3600000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "Preloader";
+				reg = <0x0 0x80000>;
+				read-only;
+			};
+
+			partition@80000 {
+				label = "ATF";
+				reg = <0x80000 0x40000>;
+				read-only;
+			};
+
+			partition@c0000 {
+				label = "u-boot";
+				reg = <0xc0000 0x80000>;
+				read-only;
+			};
+
+			partition@140000 {
+				label = "u-boot-env";
+				reg = <0x140000 0x80000>;
+				read-only;
+			};
+
+			factory: partition@1c0000 {
+				label = "factory";
+				reg = <0x1c0000 0x40000>;
+				read-only;
+			};
+
+			partition@200000 {
+				compatible = "brcm,trx";
+				brcm,trx-magic = <0x33504844>;
+				label = "firmware";
+				reg = <0x200000 0x3200000>;
+			};
+
+			partition@3400000 {
+				label = "Kernel2";
+				reg = <0x3400000 0x3200000>;
+			};
+
+			partition@6600000 {
+				label = "glbcfg";
+				reg = <0x6600000 0x200000>;
+				read-only;
+			};
+
+			partition@6800000 {
+				label = "board_data";
+				reg = <0x6800000 0x200000>;
+				read-only;
+			};
+		};
+	};
+};

--- a/target/linux/mediatek/image/mt7622.mk
+++ b/target/linux/mediatek/image/mt7622.mk
@@ -163,6 +163,16 @@ define Device/buffalo_wsr-2533dhp2
 endef
 TARGET_DEVICES += buffalo_wsr-2533dhp2
 
+define Device/buffalo_wsr-2533dhp3
+  $(Device/buffalo_wsr)
+  DEVICE_MODEL := WSR-2533DHP3
+  DEVICE_DTS := mt7622-buffalo-wsr-2533dhp3
+  IMAGE_SIZE := 51200k
+  BUFFALO_TRX_MAGIC := 0x33504844
+  DEVICE_PACKAGES := kmod-mt7615-firmware
+endef
+TARGET_DEVICES += buffalo_wsr-2533dhp3
+
 define Device/buffalo_wsr-3200ax4s
   $(Device/buffalo_wsr)
   DEVICE_MODEL := WSR-3200AX4S

--- a/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/mt7622/base-files/etc/board.d/02_network
@@ -54,6 +54,7 @@ mediatek_setup_macs()
 	local label_mac=""
 
 	case $board in
+	buffalo,wsr-2533dhp3|\
 	buffalo,wsr-3200ax4s)
 		lan_mac=$(mtd_get_mac_ascii board_data "mac")
 		wan_mac=$lan_mac

--- a/target/linux/mediatek/mt7622/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/mt7622/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -13,6 +13,11 @@ case "$board" in
 	bananapi,bpi-r64)
 		[ "$PHYNBR" = "0" ] && macaddr_add $(cat /sys/class/net/eth0/address) 2 > /sys${DEVPATH}/macaddress
 		;;
+	buffalo,wsr-2533dhp3)
+		basemac=$(mtd_get_mac_ascii board_data "mac")
+		[ "$PHYNBR" = "0" ] && macaddr_add $basemac 4 > /sys${DEVPATH}/macaddress
+		[ "$PHYNBR" = "1" ] && macaddr_add $basemac 1 > /sys${DEVPATH}/macaddress
+		;;
 	buffalo,wsr-3200ax4s)
 		basemac=$(mtd_get_mac_ascii board_data "mac")
 		[ "$PHYNBR" = "0" ] && macaddr_add $basemac 1 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/09_fix_crc
+++ b/target/linux/mediatek/mt7622/base-files/etc/uci-defaults/09_fix_crc
@@ -16,6 +16,7 @@ case "$(board_name)" in
 buffalo,wsr-2533dhp2)
 	fixup_trx_crc 0x44485032
 	;;
+buffalo,wsr-2533dhp3|\
 buffalo,wsr-3200ax4s)
 	fixup_trx_crc 0x44485033
 	;;

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/buffalo.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/buffalo.sh
@@ -53,6 +53,7 @@ case "$(board_name)" in
 buffalo,wsr-2533dhp2)
 	BUFFALO_TRX_MAGIC="44485032" # "DHP2"
 	;;
+buffalo,wsr-2533dhp3|\
 buffalo,wsr-3200ax4s)
 	BUFFALO_TRX_MAGIC="44485033" # "DHP3"
 	;;

--- a/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/mt7622/base-files/lib/upgrade/platform.sh
@@ -15,6 +15,7 @@ platform_do_upgrade() {
 		fit_do_upgrade "$1"
 		;;
 	buffalo,wsr-2533dhp2|\
+	buffalo,wsr-2533dhp3|\
 	buffalo,wsr-3200ax4s)
 		buffalo_do_upgrade "$1"
 		;;
@@ -56,6 +57,7 @@ platform_check_image() {
 
 	case "$board" in
 	buffalo,wsr-2533dhp2|\
+	buffalo,wsr-2533dhp3|\
 	buffalo,wsr-3200ax4s)
 		buffalo_check_image "$board" "$magic" "$1" || return 1
 		;;


### PR DESCRIPTION
This adds support for the Buffalo WSR-2533DHP3, a 2.4/5 GHz 11ac router based on the MediaTek MT7622B SoC. Full device details and the flashing procedure are in the commit message.

The WSR-2533DHP3 sits between the two already-supported Buffalo MT7622B devices, and the support reuses the common `mt7622-buffalo-wsr.dtsi` and the existing Buffalo TRX image / upgrade flow.

It follows the WSR-3200AX4S for:

- the flash interface: SPI-NAND via `&snfi` (`spi-nand`), and
- the network switch: MT7531 (DSA), and
- the TRX magic `0x33504844`.

It follows the WSR-2533DHP2 for:

- the 5 GHz radio: MT7615 (11ac), so `DEVICE_PACKAGES` uses
  `kmod-mt7615-firmware`, and
- the flash partition layout: two OS images followed by `glbcfg` /
  `board_data` and no "WTB" partition, with the MAC read from
  `board_data`.

The firmware/OS area is 50 MiB (`0x3200000`, vs 58 MiB on the DHP2), so `IMAGE_SIZE` is 51200k, and `bmt-remap-range` is set accordingly. RAM is 256 MiB (`0x0f000000`).