### PR TITLE
mediatek: filogic: persistent macaddr via soc-uuid

### DIFF
--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -230,12 +230,19 @@ macaddr_add() {
 	echo $oui:$nic
 }
 
-macaddr_generate_from_mmc_cid() {
-	local mmc_dev=$1
-
-	local sd_hash=$(sha256sum /sys/class/block/$mmc_dev/device/cid)
-	local mac_base=$(macaddr_canonicalize "$(echo "${sd_hash}" | dd bs=1 count=12 2>/dev/null)")
+# arg is a sysfs path or glob; must not contain whitespace
+macaddr_generate_from_uuid() {
+	local hash=$(sha256sum $1)
+	local mac_base=$(macaddr_canonicalize "$(echo "${hash}" | dd bs=1 count=12 2>/dev/null)")
 	echo "$(macaddr_unsetbit_mc "$(macaddr_setbit_la "${mac_base}")")"
+}
+
+macaddr_generate_from_mmc_cid() {
+	macaddr_generate_from_uuid "/sys/class/block/$1/device/cid"
+}
+
+macaddr_generate_from_soc_uuid() {
+	macaddr_generate_from_uuid "/sys/bus/nvmem/devices/$1/cells/soc-uuid*"
 }
 
 macaddr_geteui() {

--- a/package/base-files/files/lib/functions/system.sh
+++ b/package/base-files/files/lib/functions/system.sh
@@ -249,12 +249,19 @@ macaddr_add() {
 	echo $oui:$nic
 }
 
-macaddr_generate_from_mmc_cid() {
-	local mmc_dev=$1
-
-	local sd_hash=$(sha256sum /sys/class/block/$mmc_dev/device/cid)
-	local mac_base=$(macaddr_canonicalize "$(echo "${sd_hash}" | dd bs=1 count=12 2>/dev/null)")
+# arg is a sysfs path or glob; must not contain whitespace
+macaddr_generate_from_uuid() {
+	local hash=$(sha256sum $1)
+	local mac_base=$(macaddr_canonicalize "$(echo "${hash}" | dd bs=1 count=12 2>/dev/null)")
 	echo "$(macaddr_unsetbit_mc "$(macaddr_setbit_la "${mac_base}")")"
+}
+
+macaddr_generate_from_mmc_cid() {
+	macaddr_generate_from_uuid "/sys/class/block/$1/device/cid"
+}
+
+macaddr_generate_from_soc_uuid() {
+	macaddr_generate_from_uuid "/sys/bus/nvmem/devices/$1/cells/soc-uuid*"
 }
 
 macaddr_geteui() {

--- a/target/linux/mediatek/dts/mt7987.dtsi
+++ b/target/linux/mediatek/dts/mt7987.dtsi
@@ -1032,6 +1032,10 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
+			soc-uuid@140 {
+				reg = <0x140 0x10>;
+			};
+
 			lvts_calibration: calib@918 {
 				reg = <0x918 0x10>;
 			};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -257,7 +257,10 @@ mediatek_setup_macs()
 		label_mac=$wan_mac
 		;;
 	bananapi,bpi-r3|\
-	bananapi,bpi-r3-mini|\
+	bananapi,bpi-r3-mini)
+		lan_mac=$(macaddr_generate_from_soc_uuid nvmem0)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
 	bananapi,bpi-r4|\
 	bananapi,bpi-r4-lite)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -292,7 +292,10 @@ mediatek_setup_macs()
 		label_mac=$wan_mac
 		;;
 	bananapi,bpi-r3|\
-	bananapi,bpi-r3-mini|\
+	bananapi,bpi-r3-mini)
+		lan_mac=$(macaddr_generate_from_soc_uuid nvmem0)
+		wan_mac=$(macaddr_add "$lan_mac" 1)
+		;;
 	bananapi,bpi-r4|\
 	bananapi,bpi-r4-lite)
 		wan_mac=$(macaddr_add $(cat /sys/class/net/eth0/address) 1)

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -306,7 +306,7 @@ mediatek_setup_macs()
 		label_mac=$wan_mac
 		;;
 	hiveton,h5000m)
-		lan_mac=$(macaddr_generate_from_mmc_cid mmcblk0)
+		lan_mac=$(macaddr_generate_from_soc_uuid nvmem0)
 		wan_mac=$(macaddr_add "$lan_mac" 1)
 		label_mac=$wan_mac
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -63,7 +63,7 @@ case "$board" in
 		;;
 	bananapi,bpi-r3|\
 	bananapi,bpi-r3-mini)
-		addr=$(cat /sys/class/net/eth0/address)
+		addr=$(macaddr_generate_from_soc_uuid nvmem0)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -62,7 +62,8 @@ case "$board" in
 		[ "$PHYNBR" = "1" ] && echo "$addr" > /sys${DEVPATH}/macaddress
 		;;
 	bananapi,bpi-r3|\
-	bananapi,bpi-r3-mini)
+	bananapi,bpi-r3-mini|\
+	hiveton,h5000m)
 		addr=$(macaddr_generate_from_soc_uuid nvmem0)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
@@ -134,11 +135,6 @@ case "$board" in
 		addr=$(mtd_get_mac_ascii pdt_data_1 ethaddr)
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
-		;;
-	hiveton,h5000m)
-		base_mac=$(macaddr_generate_from_mmc_cid mmcblk0)
-		[ "$PHYNBR" = "0" ] && macaddr_add $base_mac 2 > /sys${DEVPATH}/macaddress
-		[ "$PHYNBR" = "1" ] && macaddr_add $base_mac 3 > /sys${DEVPATH}/macaddress
 		;;
 	iptime,ax3000q)
 		addr=$(mtd_get_mac_binary "Factory" 0x4)

--- a/target/linux/mediatek/patches-6.18/062-v6.19-arm64-dts-mediatek-mt7622-add-soc-uuid-cell-to-efuse.patch
+++ b/target/linux/mediatek/patches-6.18/062-v6.19-arm64-dts-mediatek-mt7622-add-soc-uuid-cell-to-efuse.patch
@@ -1,0 +1,31 @@
+From 79fb9654a2eeea8e973f6d329ccf68221703ec59 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 20 Sep 2025 12:56:42 +0100
+Subject: [PATCH] arm64: dts: mediatek: mt7622: add 'soc-uuid' cell to efuse
+
+The efuse of the MediaTek MT7622 contains an 8-byte unique identifier.
+Add a 'soc-uuid' cell covering those 8 bytes to the nvmem defininition
+of the efuse to allow easy access from userspace, eg. to generate a
+persistent random MAC address on boards like the BananaPi R64 which
+doesn't have any factory-assigned addresses.
+
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Signed-off-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ arch/arm64/boot/dts/mediatek/mt7622.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7622.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7622.dtsi
+@@ -278,6 +278,10 @@
+ 		#address-cells = <1>;
+ 		#size-cells = <1>;
+ 
++		soc-uuid@140 {
++			reg = <0x140 0x8>;
++		};
++
+ 		thermal_calibration: calib@198 {
+ 			reg = <0x198 0xc>;
+ 		};

--- a/target/linux/mediatek/patches-6.18/063-v6.19-arm64-dts-mediatek-mt7986a-add-soc-uuid-cell-to-efuse.patch
+++ b/target/linux/mediatek/patches-6.18/063-v6.19-arm64-dts-mediatek-mt7986a-add-soc-uuid-cell-to-efuse.patch
@@ -1,0 +1,31 @@
+From 18d0f98a17757c4030c0af046dfd864c8108738a Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 20 Sep 2025 12:56:51 +0100
+Subject: [PATCH] arm64: dts: mediatek: mt7986a: add 'soc-uuid' cell to efuse
+
+The efuse of the MediaTek MT7986 contains an 8-byte unique identifier.
+Add a 'soc-uuid' cell covering those 8 bytes to the nvmem defininition
+of the efuse to allow easy access from userspace, eg. to generate a
+persistent random MAC address on boards like the BananaPi R3 which
+doesn't have any factory-assigned addresses.
+
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Signed-off-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ arch/arm64/boot/dts/mediatek/mt7986a.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
+@@ -450,6 +450,10 @@
+ 			#address-cells = <1>;
+ 			#size-cells = <1>;
+ 
++			soc-uuid@140 {
++				reg = <0x140 0x8>;
++			};
++
+ 			thermal_calibration: calib@274 {
+ 				reg = <0x274 0xc>;
+ 			};

--- a/target/linux/mediatek/patches-6.18/064-v6.19-arm64-dts-mediatek-mt7981b-add-soc-uuid-cell-to-efuse.patch
+++ b/target/linux/mediatek/patches-6.18/064-v6.19-arm64-dts-mediatek-mt7981b-add-soc-uuid-cell-to-efuse.patch
@@ -1,0 +1,31 @@
+From d261557f7ad37fad44e3c07e76e63a60abcf8bc3 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 20 Sep 2025 12:56:59 +0100
+Subject: [PATCH] arm64: dts: mediatek: mt7981b: add 'soc-uuid' cell to efuse
+
+The efuse of the MediaTek MT7981 contains a 16-byte unique identifier.
+Add a 'soc-uuid' cell covering those 16 bytes to the nvmem defininition
+of the efuse to allow easy access from userspace, eg. to generate a
+persistent random MAC address on boards which don't have any
+factory-assigned addresses.
+
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Signed-off-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ arch/arm64/boot/dts/mediatek/mt7981b.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7981b.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7981b.dtsi
+@@ -237,6 +237,10 @@
+ 			#address-cells = <1>;
+ 			#size-cells = <1>;
+ 
++			soc-uuid@140 {
++				reg = <0x140 0x10>;
++			};
++
+ 			thermal_calibration: thermal-calib@274 {
+ 				reg = <0x274 0xc>;
+ 			};

--- a/target/linux/mediatek/patches-6.18/065-v6.19-arm64-dts-mediatek-mt7988a-add-soc-uuid-cell-to-efuse.patch
+++ b/target/linux/mediatek/patches-6.18/065-v6.19-arm64-dts-mediatek-mt7988a-add-soc-uuid-cell-to-efuse.patch
@@ -1,0 +1,31 @@
+From 6bb220964d608b133a81ac2ff15177a32617ac77 Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 20 Sep 2025 12:57:07 +0100
+Subject: [PATCH] arm64: dts: mediatek: mt7988a: add 'soc-uuid' cell to efuse
+
+The efuse of the MediaTek MT7988 contains a 16-byte unique identifier.
+Add a 'soc-uuid' cell covering those 16 bytes to the nvmem defininition
+of the efuse to allow easy access from userspace, eg. to generate a
+persistent random MAC address on boards like the BananaPi R4 which
+doesn't have any factory-assigned addresses.
+
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Signed-off-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ arch/arm64/boot/dts/mediatek/mt7988a.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
+@@ -714,6 +714,10 @@
+ 			#address-cells = <1>;
+ 			#size-cells = <1>;
+ 
++			soc-uuid@140 {
++				reg = <0x140 0x10>;
++			};
++
+ 			lvts_calibration: calib@918 {
+ 				reg = <0x918 0x28>;
+ 			};

--- a/target/linux/mediatek/patches-6.18/066-v6.19-arm64-dts-mediatek-mt7986a-add-soc-uuid-cell-to-efuse.patch
+++ b/target/linux/mediatek/patches-6.18/066-v6.19-arm64-dts-mediatek-mt7986a-add-soc-uuid-cell-to-efuse.patch
@@ -1,0 +1,31 @@
+From 18d0f98a17757c4030c0af046dfd864c8108738a Mon Sep 17 00:00:00 2001
+From: Daniel Golle <daniel@makrotopia.org>
+Date: Sat, 20 Sep 2025 12:56:51 +0100
+Subject: [PATCH] arm64: dts: mediatek: mt7986a: add 'soc-uuid' cell to efuse
+
+The efuse of the MediaTek MT7986 contains an 8-byte unique identifier.
+Add a 'soc-uuid' cell covering those 8 bytes to the nvmem defininition
+of the efuse to allow easy access from userspace, eg. to generate a
+persistent random MAC address on boards like the BananaPi R3 which
+doesn't have any factory-assigned addresses.
+
+Reviewed-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+Signed-off-by: AngeloGioacchino Del Regno <angelogioacchino.delregno@collabora.com>
+---
+ arch/arm64/boot/dts/mediatek/mt7986a.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
++++ b/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
+@@ -450,6 +450,10 @@
+ 			#address-cells = <1>;
+ 			#size-cells = <1>;
+ 
++			soc-uuid@140 {
++				reg = <0x140 0x8>;
++			};
++
+ 			thermal_calibration: calib@274 {
+ 				reg = <0x274 0xc>;
+ 			};

--- a/target/linux/mediatek/patches-6.18/104-mt7622-add-snor-irq.patch
+++ b/target/linux/mediatek/patches-6.18/104-mt7622-add-snor-irq.patch
@@ -10,7 +10,7 @@ Signed-off-by: Chuanhong Guo <gch981213@gmail.com>
 ---
 --- a/arch/arm64/boot/dts/mediatek/mt7622.dtsi
 +++ b/arch/arm64/boot/dts/mediatek/mt7622.dtsi
-@@ -575,6 +575,7 @@
+@@ -579,6 +579,7 @@
  		compatible = "mediatek,mt7622-nor",
  			     "mediatek,mt8173-nor";
  		reg = <0 0x11014000 0 0xe0>;

--- a/target/linux/mediatek/patches-6.18/115-Revert-arm64-dts-mediatek-fix-t-phy-unit-name.patch
+++ b/target/linux/mediatek/patches-6.18/115-Revert-arm64-dts-mediatek-fix-t-phy-unit-name.patch
@@ -11,7 +11,7 @@ This reverts commit 963c3b0c47ec29b4c49c9f45965cd066f419d17f.
 
 --- a/arch/arm64/boot/dts/mediatek/mt7622.dtsi
 +++ b/arch/arm64/boot/dts/mediatek/mt7622.dtsi
-@@ -908,7 +908,7 @@
+@@ -912,7 +912,7 @@
  		status = "disabled";
  	};
  

--- a/target/linux/mediatek/patches-6.18/116-arm64-dts-mediatek-mt7622-readd-syscon-to-pciesys-no.patch
+++ b/target/linux/mediatek/patches-6.18/116-arm64-dts-mediatek-mt7622-readd-syscon-to-pciesys-no.patch
@@ -22,7 +22,7 @@ Cc: stable@vger.kernel.org
 
 --- a/arch/arm64/boot/dts/mediatek/mt7622.dtsi
 +++ b/arch/arm64/boot/dts/mediatek/mt7622.dtsi
-@@ -798,7 +798,7 @@
+@@ -802,7 +802,7 @@
  	};
  
  	pciesys: clock-controller@1a100800 {

--- a/target/linux/mediatek/patches-6.18/117-complete-mt7981b-dtsi.patch
+++ b/target/linux/mediatek/patches-6.18/117-complete-mt7981b-dtsi.patch
@@ -282,7 +282,7 @@ working:
  		};
  
  		efuse@11f20000 {
-@@ -240,17 +378,293 @@
+@@ -244,17 +382,293 @@
  			thermal_calibration: thermal-calib@274 {
  				reg = <0x274 0xc>;
  			};
@@ -578,7 +578,7 @@ working:
  			reg = <0 0x18000000 0 0x1000000>,
  			      <0 0x10003000 0 0x1000>,
  			      <0 0x11d10000 0 0x1000>;
-@@ -263,6 +677,67 @@
+@@ -267,6 +681,67 @@
  			clock-names = "mcu", "ap2conn";
  			resets = <&watchdog MT7986_TOPRGU_CONSYS_SW_RST>;
  			reset-names = "consys";
@@ -646,7 +646,7 @@ working:
  		};
  	};
  
-@@ -274,4 +749,8 @@
+@@ -278,4 +753,8 @@
  			     <GIC_PPI 11 IRQ_TYPE_LEVEL_LOW>,
  			     <GIC_PPI 10 IRQ_TYPE_LEVEL_LOW>;
  	};

--- a/target/linux/mediatek/patches-6.18/186-arm64-dts-mt7988a-complete-dtsi.patch
+++ b/target/linux/mediatek/patches-6.18/186-arm64-dts-mt7988a-complete-dtsi.patch
@@ -171,9 +171,9 @@ Work-in-progress patch to complete mt7988a.dtsi
  		mmc0: mmc@11230000 {
  			compatible = "mediatek,mt7988-mmc";
  			reg = <0 0x11230000 0 0x1000>,
-@@ -720,6 +840,10 @@
- 			#address-cells = <1>;
- 			#size-cells = <1>;
+@@ -724,6 +844,10 @@
+ 				reg = <0x140 0x10>;
+ 			};
  
 +			cpufreq_calibration: calib@278 {
 +				reg = <0x278 0x1>;
@@ -182,7 +182,7 @@ Work-in-progress patch to complete mt7988a.dtsi
  			lvts_calibration: calib@918 {
  				reg = <0x918 0x28>;
  			};
-@@ -984,12 +1108,14 @@
+@@ -988,12 +1112,14 @@
  			gmac1: mac@1 {
  				compatible = "mediatek,eth-mac";
  				reg = <1>;
@@ -197,7 +197,7 @@ Work-in-progress patch to complete mt7988a.dtsi
  				status = "disabled";
  			};
  
-@@ -1001,6 +1127,21 @@
+@@ -1005,6 +1131,21 @@
  				int_2p5g_phy: ethernet-phy@15 {
  					compatible = "ethernet-phy-ieee802.3-c45";
  					reg = <15>;
@@ -219,7 +219,7 @@ Work-in-progress patch to complete mt7988a.dtsi
  				};
  			};
  		};
-@@ -1012,6 +1153,17 @@
+@@ -1016,6 +1157,17 @@
  			#size-cells = <1>;
  			ranges = <0 0x15400000 0 0x200000>;
  		};

--- a/target/linux/mediatek/patches-6.18/186-arm64-dts-mt7988a-complete-dtsi.patch
+++ b/target/linux/mediatek/patches-6.18/186-arm64-dts-mt7988a-complete-dtsi.patch
@@ -162,9 +162,9 @@ Work-in-progress patch to complete mt7988a.dtsi
  		mmc0: mmc@11230000 {
  			compatible = "mediatek,mt7988-mmc";
  			reg = <0 0x11230000 0 0x1000>,
-@@ -720,6 +840,10 @@
- 			#address-cells = <1>;
- 			#size-cells = <1>;
+@@ -724,6 +844,10 @@
+ 				reg = <0x140 0x10>;
+ 			};
  
 +			cpufreq_calibration: calib@278 {
 +				reg = <0x278 0x1>;
@@ -173,7 +173,7 @@ Work-in-progress patch to complete mt7988a.dtsi
  			lvts_calibration: calib@918 {
  				reg = <0x918 0x28>;
  			};
-@@ -984,12 +1108,14 @@
+@@ -988,12 +1112,14 @@
  			gmac1: mac@1 {
  				compatible = "mediatek,eth-mac";
  				reg = <1>;
@@ -188,7 +188,7 @@ Work-in-progress patch to complete mt7988a.dtsi
  				status = "disabled";
  			};
  
-@@ -1001,6 +1127,21 @@
+@@ -1005,6 +1131,21 @@
  				int_2p5g_phy: ethernet-phy@15 {
  					compatible = "ethernet-phy-ieee802.3-c45";
  					reg = <15>;
@@ -210,7 +210,7 @@ Work-in-progress patch to complete mt7988a.dtsi
  				};
  			};
  		};
-@@ -1012,6 +1153,17 @@
+@@ -1016,6 +1157,17 @@
  			#size-cells = <1>;
  			ranges = <0 0x15400000 0 0x200000>;
  		};

--- a/target/linux/mediatek/patches-6.18/190-arm64-dts-mediatek-mt7622-fix-GICv2-range.patch
+++ b/target/linux/mediatek/patches-6.18/190-arm64-dts-mediatek-mt7622-fix-GICv2-range.patch
@@ -95,7 +95,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
 
 --- a/arch/arm64/boot/dts/mediatek/mt7622.dtsi
 +++ b/arch/arm64/boot/dts/mediatek/mt7622.dtsi
-@@ -345,7 +345,7 @@
+@@ -349,7 +349,7 @@
  		#interrupt-cells = <3>;
  		interrupt-parent = <&gic>;
  		reg = <0 0x10310000 0 0x1000>,

--- a/target/linux/mediatek/patches-6.18/197-arm64-dts-mediatek-mt7986-correct-timer-frequency.patch
+++ b/target/linux/mediatek/patches-6.18/197-arm64-dts-mediatek-mt7986-correct-timer-frequency.patch
@@ -25,7 +25,7 @@ Signed-off-by: Andrea Pesaresi <andreapesaresi82@gmail.com>
 
 --- a/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
 +++ b/arch/arm64/boot/dts/mediatek/mt7986a.dtsi
-@@ -661,6 +661,7 @@
+@@ -665,6 +665,7 @@
  	timer {
  		compatible = "arm,armv8-timer";
  		interrupt-parent = <&gic>;

--- a/target/linux/mediatek/patches-6.18/198-dts-mt7988a-enable-wed.patch
+++ b/target/linux/mediatek/patches-6.18/198-dts-mt7988a-enable-wed.patch
@@ -43,7 +43,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  	};
  
  	soc {
-@@ -870,6 +896,50 @@
+@@ -874,6 +900,50 @@
  			reg = <0 0x15000000 0 0x1000>;
  			#clock-cells = <1>;
  			#reset-cells = <1>;
@@ -94,7 +94,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  		};
  
  		switch: switch@15020000 {
-@@ -1091,6 +1161,7 @@
+@@ -1095,6 +1165,7 @@
  			#size-cells = <0>;
  			mediatek,ethsys = <&ethsys>;
  			mediatek,infracfg = <&topmisc>;
@@ -102,7 +102,7 @@ Signed-off-by: Daniel Golle <daniel@makrotopia.org>
  
  			gmac0: mac@0 {
  				compatible = "mediatek,eth-mac";
-@@ -1154,6 +1225,72 @@
+@@ -1158,6 +1229,72 @@
  			ranges = <0 0x15400000 0 0x200000>;
  		};
  

--- a/target/linux/mediatek/patches-6.18/602-arm64-dts-mediatek-add-mt7622-pcie-slot-node.patch
+++ b/target/linux/mediatek/patches-6.18/602-arm64-dts-mediatek-add-mt7622-pcie-slot-node.patch
@@ -11,7 +11,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 ---
 --- a/arch/arm64/boot/dts/mediatek/mt7622.dtsi
 +++ b/arch/arm64/boot/dts/mediatek/mt7622.dtsi
-@@ -844,6 +844,12 @@
+@@ -848,6 +848,12 @@
  			#address-cells = <0>;
  			#interrupt-cells = <1>;
  		};
@@ -24,7 +24,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  	};
  
  	pcie1: pcie@1a145000 {
-@@ -882,6 +888,12 @@
+@@ -886,6 +892,12 @@
  			#address-cells = <0>;
  			#interrupt-cells = <1>;
  		};

--- a/target/linux/mediatek/patches-6.18/710-pci-pcie-mediatek-add-support-for-coherent-DMA.patch
+++ b/target/linux/mediatek/patches-6.18/710-pci-pcie-mediatek-add-support-for-coherent-DMA.patch
@@ -10,7 +10,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
 
 --- a/arch/arm64/boot/dts/mediatek/mt7622.dtsi
 +++ b/arch/arm64/boot/dts/mediatek/mt7622.dtsi
-@@ -832,6 +832,9 @@
+@@ -836,6 +836,9 @@
  		bus-range = <0x00 0xff>;
  		ranges = <0x82000000 0 0x20000000 0x0 0x20000000 0 0x8000000>;
  		status = "disabled";
@@ -20,7 +20,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  		#interrupt-cells = <1>;
  		interrupt-map-mask = <0 0 0 7>;
-@@ -876,6 +879,9 @@
+@@ -880,6 +883,9 @@
  		bus-range = <0x00 0xff>;
  		ranges = <0x82000000 0 0x28000000 0x0 0x28000000 0 0x8000000>;
  		status = "disabled";
@@ -30,7 +30,7 @@ Signed-off-by: Felix Fietkau <nbd@nbd.name>
  
  		#interrupt-cells = <1>;
  		interrupt-map-mask = <0 0 0 7>;
-@@ -937,7 +943,7 @@
+@@ -941,7 +947,7 @@
  	};
  
  	hifsys: clock-controller@1af00000 {

--- a/target/linux/mediatek/patches-6.18/941-arm64-dts-mt7986-move-cpuboot-in-a-dedicated-node.patch
+++ b/target/linux/mediatek/patches-6.18/941-arm64-dts-mt7986-move-cpuboot-in-a-dedicated-node.patch
@@ -24,7 +24,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	};
  
  	soc {
-@@ -533,10 +527,11 @@
+@@ -537,10 +531,11 @@
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
  			memory-region = <&wo_emi0>, <&wo_ilm0>, <&wo_dlm0>,
@@ -38,7 +38,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		};
  
  		wed1: wed@15011000 {
-@@ -546,10 +541,11 @@
+@@ -550,10 +545,11 @@
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 206 IRQ_TYPE_LEVEL_HIGH>;
  			memory-region = <&wo_emi1>, <&wo_ilm1>, <&wo_dlm1>,
@@ -52,7 +52,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		};
  
  		eth: ethernet@15100000 {
-@@ -623,6 +619,11 @@
+@@ -627,6 +623,11 @@
  			interrupts = <GIC_SPI 212 IRQ_TYPE_LEVEL_HIGH>;
  		};
  

--- a/target/linux/mediatek/patches-6.18/945-arm64-dts-mt7986-move-ilm-in-a-dedicated-node.patch
+++ b/target/linux/mediatek/patches-6.18/945-arm64-dts-mt7986-move-ilm-in-a-dedicated-node.patch
@@ -34,7 +34,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  		wo_data: wo-data@4fd80000 {
  			reg = <0 0x4fd80000 0 0x240000>;
  			no-map;
-@@ -526,11 +516,10 @@
+@@ -530,11 +520,10 @@
  			reg = <0 0x15010000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
@@ -49,7 +49,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -540,11 +529,10 @@
+@@ -544,11 +533,10 @@
  			reg = <0 0x15011000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 206 IRQ_TYPE_LEVEL_HIGH>;
@@ -64,7 +64,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -619,6 +607,16 @@
+@@ -623,6 +611,16 @@
  			interrupts = <GIC_SPI 212 IRQ_TYPE_LEVEL_HIGH>;
  		};
  

--- a/target/linux/mediatek/patches-6.18/946-arm64-dts-mt7986-move-dlm-in-a-dedicated-node.patch
+++ b/target/linux/mediatek/patches-6.18/946-arm64-dts-mt7986-move-dlm-in-a-dedicated-node.patch
@@ -34,7 +34,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  	};
  
  	soc {
-@@ -516,10 +506,11 @@
+@@ -520,10 +510,11 @@
  			reg = <0 0x15010000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 205 IRQ_TYPE_LEVEL_HIGH>;
@@ -48,7 +48,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -529,10 +520,11 @@
+@@ -533,10 +524,11 @@
  			reg = <0 0x15011000 0 0x1000>;
  			interrupt-parent = <&gic>;
  			interrupts = <GIC_SPI 206 IRQ_TYPE_LEVEL_HIGH>;
@@ -62,7 +62,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  			mediatek,wo-cpuboot = <&wo_cpuboot>;
  		};
  
-@@ -617,6 +609,16 @@
+@@ -621,6 +613,16 @@
  			reg = <0 0x151f0000 0 0x8000>;
  		};
  

--- a/target/linux/mediatek/patches-6.18/965-dts-mt7988a-add-trng-support.patch
+++ b/target/linux/mediatek/patches-6.18/965-dts-mt7988a-add-trng-support.patch
@@ -11,7 +11,7 @@ Signed-off-by: Marcos Alano <marcoshalano@gmail.com>
 ---
 --- a/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
 +++ b/arch/arm64/boot/dts/mediatek/mt7988a.dtsi
-@@ -1334,4 +1334,8 @@
+@@ -1338,4 +1338,8 @@
  			     <GIC_PPI 11 IRQ_TYPE_LEVEL_LOW>,
  			     <GIC_PPI 10 IRQ_TYPE_LEVEL_LOW>;
  	};

--- a/target/linux/mediatek/patches-6.18/966-pcie-mediatek-gen3-Add-WIFI-HW-reset-flow.patch
+++ b/target/linux/mediatek/patches-6.18/966-pcie-mediatek-gen3-Add-WIFI-HW-reset-flow.patch
@@ -56,7 +56,7 @@ Signed-off-by: Jianguo Zhang <jianguo.zhang@mediatek.com>
  	/*
  	 * Airoha EN7581 has a hw bug asserting/releasing PCIE_PE_RSTB signal
  	 * causing occasional PCIe link down. In order to overcome the issue,
-@@ -926,6 +938,20 @@ static int mtk_pcie_parse_port(struct mt
+@@ -931,6 +943,20 @@ static int mtk_pcie_parse_port(struct mt
  			pcie->num_lanes = num_lanes;
  	}
  


### PR DESCRIPTION
Devices with no factory-assigned MAC address, such as bpi-r3 and bpi-r3-mini, choose a random MAC address every time the device is flashed without saving configuration.

A recent upstream commit [1] added a `soc-uuid` cell to DT efuse, exposing a 8-byte unique identifier, which we now use to generate a persistent MAC address.

This is done by a new `macaddr_generate_from_soc_uuid` function in `lib/functions/system.sh` (which already has a similar function `macaddr_generate_from_mmc_cid`).

See also discussion on the forum [2].

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=18d0f98a17757c4030c0af046dfd864c8108738a
[2] https://forum.openwrt.org/t/openwrt-support-for-banana-pi-bpi-r3/154294/238
