### PR TITLE
mediatek/filogic: Add support for COMFAST WR631AX and refactor comfast mt7981 devices

### DIFF
--- a/package/boot/uboot-mediatek/Makefile
+++ b/package/boot/uboot-mediatek/Makefile
@@ -305,6 +305,18 @@ define U-Boot/mt7981_cmcc_rax3000m-nand-ddr4
   DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr4
 endef
 
+define U-Boot/mt7981_comfast_cf-wr631ax
+  NAME:=COMFAST CF-WR631AX
+  BUILD_SUBTARGET:=filogic
+  BUILD_DEVICES:=comfast_cf-wr631ax-ubootmod
+  UBOOT_CONFIG:=mt7981_comfast_cf-wr631ax
+  UBOOT_IMAGE:=u-boot.fip
+  BL2_BOOTDEV:=spim-nand
+  BL2_SOC:=mt7981
+  BL2_DDRTYPE:=ddr3-1866
+  DEPENDS:=+trusted-firmware-a-mt7981-spim-nand-ddr3-1866
+endef
+
 define U-Boot/mt7981_comfast_cf-wr632ax
   NAME:=COMFAST CF-WR632AX
   BUILD_SUBTARGET:=filogic
@@ -1258,6 +1270,7 @@ UBOOT_TARGETS := \
 	mt7981_cmcc_rax3000m-emmc-ddr4 \
 	mt7981_cmcc_rax3000m-nand-ddr3 \
 	mt7981_cmcc_rax3000m-nand-ddr4 \
+	mt7981_comfast_cf-wr631ax \
 	mt7981_comfast_cf-wr632ax \
 	mt7981_creatlentem_clt-r30b1-ubi \
 	mt7981_cudy_tr3000-v1 \

--- a/package/boot/uboot-mediatek/patches/448-add-comfast_cf-wr632ax.patch
+++ b/package/boot/uboot-mediatek/patches/448-add-comfast_cf-wr632ax.patch
@@ -1,64 +1,36 @@
 --- /dev/null
 +++ b/arch/arm/dts/mt7981-comfast-cf-wr632ax.dts
-@@ -0,0 +1,151 @@
+@@ -0,0 +1,41 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +
 +/dts-v1/;
-+#include "mt7981.dtsi"
-+#include <dt-bindings/gpio/gpio.h>
-+#include <dt-bindings/input/linux-event-codes.h>
++#include "mt7981-comfast-common.dtsi"
 +
 +/ {
 +	model = "COMFAST CF-WR632AX";
 +	compatible = "comfast,cf-wr632ax", "mediatek,mt7981";
 +
-+	chosen {
-+		stdout-path = &uart0;
-+		tick-timer = &timer0;
-+	};
-+
 +	memory@40000000 {
 +		device_type = "memory";
 +		reg = <0x40000000 0x20000000>;
 +	};
-+
-+	gpio-keys {
-+		compatible = "gpio-keys";
-+
-+		button-reset {
-+			label = "reset";
-+			linux,code = <KEY_RESTART>;
-+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
-+		};
-+	};
-+
-+	gpio-leds {
-+		compatible = "gpio-leds";
-+
-+		led_status_blue: led-0 {
-+			label = "blue:status";
-+			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
-+			default-state = "off";
-+		};
-+
-+		led_status_green: led-1 {
-+			label = "green:status";
-+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
-+			default-state = "off";
-+		};
-+
-+		led_status_red: led-2 {
-+			label = "red:status";
-+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
-+			default-state = "on";
-+		};
-+	};
 +};
 +
++&led_status_blue {
++	gpios = <&pio 8 GPIO_ACTIVE_LOW>;
++};
++
++&led_status_green {
++	gpios = <&pio 35 GPIO_ACTIVE_LOW>;
++};
++
++&led_status_red {
++	gpios = <&pio 34 GPIO_ACTIVE_LOW>;
++};
++
++
 +&eth {
-+	status = "okay";
 +	mediatek,gmac-id = <1>;
-+	phy-mode = "gmii";
 +	phy-handle = <&phy0>;
 +
 +	mdio {
@@ -70,88 +42,6 @@
 +	};
 +};
 +
-+&pio {
-+	spi_flash_pins: spi0-pins-func-1 {
-+		mux {
-+			function = "flash";
-+			groups = "spi0", "spi0_wp_hold";
-+		};
-+
-+		conf-pu {
-+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
-+			drive-strength = <MTK_DRIVE_4mA>;
-+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
-+		};
-+
-+		conf-pd {
-+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
-+			drive-strength = <MTK_DRIVE_4mA>;
-+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
-+		};
-+	};
-+};
-+
-+&spi0 {
-+	#address-cells = <1>;
-+	#size-cells = <0>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&spi_flash_pins>;
-+	status = "okay";
-+	must_tx;
-+	enhance_timing;
-+	dma_ext;
-+	ipm_design;
-+	support_quad;
-+	tick_dly = <2>;
-+	sample_sel = <0>;
-+
-+	spi_nand@0 {
-+		compatible = "spi-nand";
-+		reg = <0>;
-+		spi-max-frequency = <52000000>;
-+
-+		partitions {
-+			compatible = "fixed-partitions";
-+			#address-cells = <1>;
-+			#size-cells = <1>;
-+
-+			partition@0 {
-+				label = "BL2";
-+				reg = <0x0 0x100000>;
-+			};
-+
-+			partition@100000 {
-+				label = "u-boot-env";
-+				reg = <0x100000 0x80000>;
-+			};
-+
-+			partition@180000 {
-+				label = "Factory";
-+				reg = <0x180000 0x200000>;
-+			};
-+
-+			partition@380000 {
-+				label = "FIP";
-+				reg = <0x380000 0x200000>;
-+			};
-+
-+			partition@580000 {
-+				label = "ubi";
-+				reg = <0x580000 0x7a80000>;
-+				compatible = "linux,ubi";
-+			};
-+		};
-+	};
-+};
-+
-+&uart0 {
-+	mediatek,force-highspeed;
-+	status = "okay";
-+};
-+
-+&watchdog {
-+	status = "disabled";
-+};
 --- /dev/null
 +++ b/configs/mt7981_comfast_cf-wr632ax_defconfig
 @@ -0,0 +1,111 @@

--- a/package/boot/uboot-mediatek/patches/472-add-comfast_common.patch
+++ b/package/boot/uboot-mediatek/patches/472-add-comfast_common.patch
@@ -1,0 +1,142 @@
+--- /dev/null
++++ b/arch/arm/dts/mt7981-comfast-common.dtsi
+@@ -0,0 +1,139 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++
++/dts-v1/;
++#include "mt7981.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/linux-event-codes.h>
++
++/ {
++	#address-cells = <1>;
++	#size-cells = <1>;
++
++	chosen {
++		stdout-path = &uart0;
++		tick-timer = &timer0;
++	};
++
++	memory@40000000 {
++		device_type = "memory";
++		reg = <0x40000000 0x10000000>;
++	};
++
++	gpio-keys {
++		compatible = "gpio-keys";
++
++		button-reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++
++		led_status_blue: led-0 {
++			label = "blue:status";
++			default-state = "off";
++		};
++
++		led_status_green: led-1 {
++			label = "green:status";
++			default-state = "off";
++		};
++
++		led_status_red: led-2 {
++			label = "red:status";
++			default-state = "on";
++		};
++	};
++};
++
++&eth {
++	status = "okay";
++	phy-mode = "gmii";
++};
++
++&pio {
++	spi_flash_pins: spi0-pins-func-1 {
++		mux {
++			function = "flash";
++			groups = "spi0", "spi0_wp_hold";
++		};
++
++		conf-pu {
++			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
++			drive-strength = <MTK_DRIVE_4mA>;
++			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
++		};
++
++		conf-pd {
++			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
++			drive-strength = <MTK_DRIVE_4mA>;
++			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
++		};
++	};
++};
++
++&spi0 {
++	#address-cells = <1>;
++	#size-cells = <0>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&spi_flash_pins>;
++	status = "okay";
++	must_tx;
++	enhance_timing;
++	dma_ext;
++	ipm_design;
++	support_quad;
++	tick_dly = <2>;
++	sample_sel = <0>;
++
++	spi_nand@0 {
++		compatible = "spi-nand";
++		reg = <0>;
++		spi-max-frequency = <52000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "BL2";
++				reg = <0x0 0x100000>;
++			};
++
++			partition@100000 {
++				label = "u-boot-env";
++				reg = <0x100000 0x80000>;
++			};
++
++			partition@180000 {
++				label = "Factory";
++				reg = <0x180000 0x200000>;
++			};
++
++			partition@380000 {
++				label = "FIP";
++				reg = <0x380000 0x200000>;
++			};
++
++			partition@580000 {
++				label = "ubi";
++				reg = <0x580000 0x7a80000>;
++				compatible = "linux,ubi";
++			};
++		};
++	};
++};
++
++&uart0 {
++	mediatek,force-highspeed;
++	status = "okay";
++};
++
++&watchdog {
++	status = "disabled";
++};
++

--- a/package/boot/uboot-mediatek/patches/473-add-comfast_cf-wr631ax.patch
+++ b/package/boot/uboot-mediatek/patches/473-add-comfast_cf-wr631ax.patch
@@ -1,0 +1,209 @@
+--- /dev/null
++++ b/arch/arm/dts/mt7981-comfast-cf-wr631ax.dts
+@@ -0,0 +1,35 @@
++// SPDX-License-Identifier: GPL-2.0-or-later
++
++/dts-v1/;
++#include "mt7981-comfast-common.dtsi"
++
++/ {
++	model = "COMFAST CF-WR631AX";
++	compatible = "comfast,cf-wr631ax", "mediatek,mt7981";
++};
++
++&led_status_blue {
++	gpios = <&pio 9 GPIO_ACTIVE_LOW>;
++};
++
++&led_status_green {
++	gpios = <&pio 10 GPIO_ACTIVE_LOW>;
++};
++
++&led_status_red {
++	gpios = <&pio 11 GPIO_ACTIVE_LOW>;
++};
++
++
++&eth {
++	mediatek,gmac-id = <0>;
++	phy-mode = "2500base-x";
++	mediatek,switch = "mt7531";
++	reset-gpios = <&pio 6 GPIO_ACTIVE_HIGH>;
++
++	fixed-link {
++		speed = <2500>;
++		full-duplex;
++	};
++};
++
+--- /dev/null
++++ b/configs/mt7981_comfast_cf-wr631ax_defconfig
+@@ -0,0 +1,111 @@
++CONFIG_ARM=y
++CONFIG_ARM_SMCCC=y
++CONFIG_SYS_HAS_NONCACHED_MEMORY=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_ARCH_MEDIATEK=y
++CONFIG_TEXT_BASE=0x41e00000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_DEFAULT_DEVICE_TREE="mt7981-comfast-cf-wr631ax"
++CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_TARGET_MT7981=y
++CONFIG_SYS_LOAD_ADDR=0x46000000
++CONFIG_PRE_CON_BUF_ADDR=0x4007EF00
++CONFIG_DEBUG_UART_BASE=0x11002000
++CONFIG_DEBUG_UART_CLOCK=40000000
++CONFIG_DEBUG_UART=y
++CONFIG_FIT=y
++CONFIG_BOOTDELAY=30
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_MENU_SHOW=y
++CONFIG_DEFAULT_FDT_FILE="mediatek/mt7981-comfast-cf-wr631ax.dtb"
++CONFIG_LOGLEVEL=7
++CONFIG_PRE_CONSOLE_BUFFER=y
++CONFIG_LOG=y
++# CONFIG_BOARD_INIT is not set
++CONFIG_BOARD_LATE_INIT=y
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="MT7981> "
++CONFIG_CMD_CPU=y
++CONFIG_CMD_LICENSE=y
++CONFIG_CMD_BOOTMENU=y
++CONFIG_CMD_ASKENV=y
++CONFIG_CMD_ERASEENV=y
++CONFIG_CMD_ENV_FLAGS=y
++CONFIG_CMD_RNG=y
++CONFIG_CMD_STRINGS=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPIO=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MTD=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_TFTPSRV=y
++CONFIG_CMD_RARP=y
++CONFIG_CMD_CDP=y
++CONFIG_CMD_SNTP=y
++CONFIG_CMD_LINK_LOCAL=y
++CONFIG_CMD_DHCP=y
++CONFIG_CMD_DNS=y
++CONFIG_CMD_PING=y
++CONFIG_CMD_PXE=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_PSTORE=y
++CONFIG_CMD_PSTORE_MEM_ADDR=0x42ff0000
++CONFIG_CMD_UUID=y
++CONFIG_CMD_HASH=y
++CONFIG_CMD_SMC=y
++CONFIG_CMD_UBI=y
++CONFIG_CMD_UBI_RENAME=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_OVERWRITE=y
++CONFIG_ENV_IS_IN_UBI=y
++CONFIG_ENV_REDUNDANT=y
++CONFIG_ENV_UBI_PART="ubi"
++CONFIG_ENV_UBI_VOLUME="ubootenv"
++CONFIG_ENV_UBI_VOLUME_REDUND="ubootenv2"
++CONFIG_ENV_RELOC_GD_ENV_ADDR=y
++CONFIG_ENV_USE_DEFAULT_ENV_TEXT_FILE=y
++CONFIG_ENV_DEFAULT_ENV_TEXT_FILE="defenvs/comfast_cf-wr631ax_env"
++CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
++CONFIG_VERSION_VARIABLE=y
++CONFIG_NETCONSOLE=y
++CONFIG_USE_IPADDR=y
++CONFIG_IPADDR="192.168.1.1"
++CONFIG_USE_SERVERIP=y
++CONFIG_SERVERIP="192.168.1.254"
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_BUTTON=y
++CONFIG_BUTTON_GPIO=y
++CONFIG_CLK=y
++CONFIG_GPIO_HOG=y
++CONFIG_LED=y
++CONFIG_LED_BLINK=y
++CONFIG_LED_GPIO=y
++# CONFIG_MMC is not set
++CONFIG_MTD=y
++CONFIG_DM_MTD=y
++CONFIG_MTD_SPI_NAND=y
++CONFIG_MTD_UBI_FASTMAP=y
++CONFIG_PHY_FIXED=y
++CONFIG_MEDIATEK_ETH=y
++CONFIG_PHY=y
++CONFIG_PINCTRL=y
++CONFIG_PINCONF=y
++CONFIG_PINCTRL_MT7981=y
++CONFIG_POWER_DOMAIN=y
++CONFIG_MTK_POWER_DOMAIN=y
++CONFIG_DM_REGULATOR=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_DM_REGULATOR_GPIO=y
++CONFIG_RAM=y
++CONFIG_DM_RNG=y
++CONFIG_RNG_MTK_V2=y
++CONFIG_DM_SERIAL=y
++CONFIG_MTK_SERIAL=y
++CONFIG_SPI=y
++CONFIG_DM_SPI=y
++CONFIG_MTK_SPIM=y
++CONFIG_ZSTD=y
++CONFIG_HEXDUMP=y
+--- /dev/null
++++ b/defenvs/comfast_cf-wr631ax_env
+@@ -0,0 +1,54 @@
++ipaddr=192.168.1.1
++serverip=192.168.1.254
++loadaddr=0x46000000
++console=earlycon=uart8250,mmio32,0x11002000 console=ttyS0
++bootcmd=if pstore check ; then run boot_recovery ; else run boot_ubi ; fi
++bootconf=config-1
++bootdelay=0
++bootfile=openwrt-mediatek-filogic-comfast_cf-wr631ax-ubootmod-initramfs-recovery.itb
++bootfile_bl2=openwrt-mediatek-filogic-comfast_cf-wr631ax-ubootmod-preloader.bin
++bootfile_fip=openwrt-mediatek-filogic-comfast_cf-wr631ax-ubootmod-bl31-uboot.fip
++bootfile_upg=openwrt-mediatek-filogic-comfast_cf-wr631ax-ubootmod-squashfs-sysupgrade.itb
++bootled_pwr=red:status
++bootled_rec=blue:status
++bootmenu_confirm_return=askenv - Press ENTER to return to menu ; bootmenu 60
++bootmenu_default=0
++bootmenu_delay=0
++bootmenu_title=      [0;34m( ( ( [1;39mOpenWrt[0;34m ) ) )
++bootmenu_0=Initialize environment.=run _firstboot
++bootmenu_0d=Run default boot command.=run boot_default
++bootmenu_1=Boot system via TFTP.=run boot_tftp ; run bootmenu_confirm_return
++bootmenu_2=Boot production system from NAND.=run boot_production ; run bootmenu_confirm_return
++bootmenu_3=Boot recovery system from NAND.=run boot_recovery ; run bootmenu_confirm_return
++bootmenu_4=Load production system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_production ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_5=Load recovery system via TFTP then write to NAND.=setenv noboot 1 ; setenv replacevol 1 ; run boot_tftp_recovery ; setenv noboot ; setenv replacevol ; run bootmenu_confirm_return
++bootmenu_6=[31mLoad BL31+U-Boot FIP via TFTP then write to NAND.[0m=run boot_tftp_write_fip ; run bootmenu_confirm_return
++bootmenu_7=[31mLoad BL2 preloader via TFTP then write to NAND.[0m=run boot_tftp_write_bl2 ; run bootmenu_confirm_return
++bootmenu_8=Reboot.=reset
++bootmenu_9=Reset all settings to factory defaults.=run reset_factory ; reset
++boot_first=if button reset ; then led $bootled_rec on ; run boot_tftp_recovery ; setenv flag_recover 1 ; run boot_default ; fi ; bootmenu
++boot_default=if env exists flag_recover ; then else run bootcmd ; fi ; run boot_recovery ; setenv replacevol 1 ; run boot_tftp_forever
++boot_production=led $bootled_pwr on ; run ubi_read_production && bootm $loadaddr#$bootconf ; led $bootled_pwr off
++boot_recovery=led $bootled_rec on ; run ubi_read_recovery && bootm $loadaddr#$bootconf ; led $bootled_rec off
++boot_ubi=run boot_production ; run boot_recovery ; run boot_tftp_forever
++boot_tftp_forever=led $bootled_rec on ; while true ; do run boot_tftp_recovery ; sleep 1 ; done
++boot_tftp_production=tftpboot $loadaddr $bootfile_upg && env exists replacevol && iminfo $loadaddr && run ubi_write_production ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp_recovery=tftpboot $loadaddr $bootfile && env exists replacevol && iminfo $loadaddr && run ubi_write_recovery ; if env exists noboot ; then else bootm $loadaddr#$bootconf ; fi
++boot_tftp=tftpboot $loadaddr $bootfile && bootm $loadaddr#$bootconf
++boot_tftp_write_fip=tftpboot $loadaddr $bootfile_fip && run mtd_write_fip && run reset_factory
++boot_tftp_write_bl2=tftpboot $loadaddr $bootfile_bl2 && run mtd_write_bl2
++reset_factory=ubi part ubi ; mw $loadaddr 0x0 0x800 ; ubi write $loadaddr ubootenv 0x800 ; ubi write $loadaddr ubootenv2 0x800
++mtd_write_fip=mtd erase FIP && mtd write FIP $loadaddr
++mtd_write_bl2=mtd erase BL2 && mtd write BL2 $loadaddr
++ubi_create_env=ubi check ubootenv || ubi create ubootenv 0x100000 dynamic || run ubi_format ; ubi check ubootenv2 || ubi create ubootenv2 0x100000 dynamic || run ubi_format
++ubi_format=ubi detach ; mtd erase ubi && ubi part ubi ; reset
++ubi_prepare_rootfs=if ubi check rootfs_data ; then else if env exists rootfs_data_max ; then ubi create rootfs_data $rootfs_data_max dynamic || ubi create rootfs_data - dynamic ; else ubi create rootfs_data - dynamic ; fi ; fi
++ubi_read_production=ubi read $loadaddr fit && iminfo $loadaddr && run ubi_prepare_rootfs
++ubi_read_recovery=ubi check recovery && ubi read $loadaddr recovery
++ubi_remove_rootfs=ubi check rootfs_data && ubi remove rootfs_data
++ubi_write_production=ubi check fit && ubi remove fit ; run ubi_remove_rootfs ; ubi create fit $filesize dynamic && ubi write $loadaddr fit $filesize
++ubi_write_recovery=ubi check recovery && ubi remove recovery ; run ubi_remove_rootfs ; ubi create recovery $filesize dynamic && ubi write $loadaddr recovery $filesize
++_init_env=setenv _init_env ; run ubi_create_env ; saveenv ; saveenv
++_firstboot=setenv _firstboot ; run _switch_to_menu ; run _init_env ; run boot_first
++_switch_to_menu=setenv _switch_to_menu ; setenv bootdelay 3 ; setenv bootmenu_delay 3 ; setenv bootmenu_0 $bootmenu_0d ; setenv bootmenu_0d ; run _bootmenu_update_title
++_bootmenu_update_title=setenv _bootmenu_update_title ; setenv bootmenu_title "$bootmenu_title       [33m$ver[0m"

--- a/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
+++ b/package/boot/uboot-tools/uboot-envtools/files/mediatek_filogic
@@ -26,6 +26,7 @@ abt,asr3000|\
 acer,predator-w6x-ubootmod|\
 asus,zenwifi-bt8-ubootmod|\
 cmcc,a10-ubootmod|\
+comfast,cf-wr631ax-ubootmod|\
 comfast,cf-wr632ax-ubootmod|\
 creatlentem,clt-r30b1-ubi|\
 cudy,tr3000-v1-ubootmod|\
@@ -77,6 +78,7 @@ nradio,c8-668gl)
 	;;
 asiarf,ap7986-003|\
 cetron,ct3003|\
+comfast,cf-wr631ax|\
 comfast,cf-wr632ax|\
 edgecore,eap111|\
 netgear,wax220|\

--- a/target/linux/mediatek/dts/mt7981a-comfast-cf-e393ax.dts
+++ b/target/linux/mediatek/dts/mt7981a-comfast-cf-e393ax.dts
@@ -1,89 +1,55 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 /dts-v1/;
-#include "mt7981b.dtsi"
+#include "mt7981b-comfast-common.dtsi"
 
 / {
-	model = "COMFAST CF-E393AX";
+	model = "COMFAST CF-E393AX / CF-E395AX";
 	compatible = "comfast,cf-e393ax", "mediatek,mt7981";
 
 	aliases {
-		serial0 = &uart0;
-		led-boot = &led_red;
-		led-failsafe = &led_red;
-		led-running = &led_blue;
-		led-upgrade = &led_green;
-	};
-
-	chosen {
-		bootargs-override = "console=ttyS0,115200n8";
-		stdout-path = "serial0:115200n8";
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_green;
 	};
 
 	memory@40000000 {
 		reg = <0 0x40000000 0 0x10000000>; // 256mb
 		device_type = "memory";
 	};
+};
 
-	gpio-keys {
-		compatible = "gpio-keys";
+&led_status_blue {
+	gpios = <&pio 8 GPIO_ACTIVE_LOW>;
+};
 
-		reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
-		};
-	};
+&led_status_green {
+	gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+};
 
-	leds {
-		compatible = "gpio-leds";
-
-		led_blue: blue {
-			gpios = <&pio 8 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_BLUE>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led_red: red {
-			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_RED>;
-			function = LED_FUNCTION_STATUS;
-		};
-
-		led_green: green {
-			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
-			color = <LED_COLOR_ID_GREEN>;
-			function = LED_FUNCTION_STATUS;
-		};
-	};
+&led_status_red {
+	gpios = <&pio 34 GPIO_ACTIVE_LOW>;
 };
 
 &eth {
-	status = "okay";
-
-	gmac0: mac@0 {
-		/* LAN */
-		compatible = "mediatek,eth-mac";
-		reg = <0>;
-		phy-mode = "2500base-x";
-		nvmem-cells = <&macaddr_factory_e000 0>;
-		nvmem-cell-names = "mac-address";
-
-		fixed-link {
-			speed = <2500>;
-			full-duplex;
-			pause;
-		};
-	};
-
 	gmac1: mac@1 {
-		/* WAN */
 		compatible = "mediatek,eth-mac";
 		reg = <1>;
 		phy-mode = "gmii";
 		phy-handle = <&int_gbe_phy>;
 		nvmem-cells = <&macaddr_factory_e000 1>;
 		nvmem-cell-names = "mac-address";
+	};
+};
+
+&gmac0 {
+	label = "lan";
+
+	fixed-link {
+		speed = <2500>;
+		full-duplex;
+		pause;
 	};
 };
 
@@ -96,150 +62,28 @@
 		interrupt-parent = <&pio>;
 		interrupts = <38 IRQ_TYPE_LEVEL_HIGH>;
 		reset-gpios = <&pio 5 GPIO_ACTIVE_HIGH>;
-	};
-};
 
-&crypto {
-	status = "okay";
-};
-
-&pio {
-	spi0_flash_pins: spi0-pins {
-		mux {
-			function = "spi";
-			groups = "spi0", "spi0_wp_hold";
-		};
-		conf-pu {
-			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
-			drive-strength = <MTK_DRIVE_8mA>;
-			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
-		};
-		conf-pd {
-			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
-			drive-strength = <MTK_DRIVE_8mA>;
-			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
-		};
-	};
-
-};
-
-&spi0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&spi0_flash_pins>;
-	#address-cells = <1>;
-	#size-cells = <0>;
-	status = "okay";
-	#address-cells = <1>;
-	#size-cells = <0>;
-
-	spi_nand: spi_nand@0 {
-		compatible = "spi-nand";
-		reg = <0>;
-		spi-max-frequency = <52000000>;
-
-		spi-cal-enable;
-		spi-cal-mode = "read-data";
-		spi-cal-datalen = <7>;
-		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
-		spi-cal-addrlen = <5>;
-		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
-
-		spi-tx-bus-width = <4>;
-		spi-rx-bus-width = <4>;
-		mediatek,nmbm;
-		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
-
-		partitions {
-			compatible = "fixed-partitions";
+		ports {
 			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "BL2";
-				reg = <0x00000 0x0100000>;
-				read-only;
+			#size-cells = <0>;
+	
+			port@0 {
+				reg = <0>;
+				label = "lan1";
 			};
-
-			partition@100000 {
-				label = "u-boot-env";
-				reg = <0x0100000 0x0080000>;
-				read-only;
-			};
-
-			partition@180000 {
-				label = "Factory";
-				reg = <0x180000 0x0200000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					eeprom_factory_0: eeprom@0 {
-						reg = <0x0 0x1000>;
-					};
-
-					macaddr_factory_e000: macaddr@e000 {
-						compatible = "mac-base";
-						reg = <0xe000 0x6>;
-						#nvmem-cell-cells = <1>;
-					};
+	
+			port@6 {
+				reg = <6>;
+				label = "cpu";
+				ethernet = <&gmac0>;
+				phy-mode = "2500base-x";
+	
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
 				};
 			};
-
-			partition@380000 {
-				label = "FIP";
-				reg = <0x380000 0x0200000>;
-				read-only;
-			};
-
-			partition@580000 {
-				label = "ubi";
-				reg = <0x580000 0x4000000>;
-				compatible = "linux,ubi";
-			};
 		};
 	};
 };
-
-&switch {
-	ports {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		port@0 {
-			reg = <0>;
-			label = "lan1";
-		};
-
-		port@6 {
-			reg = <6>;
-			label = "cpu";
-			ethernet = <&gmac0>;
-			phy-mode = "2500base-x";
-
-			fixed-link {
-				speed = <2500>;
-				full-duplex;
-				pause;
-			};
-		};
-	};
-};
-
-&uart0 {
-	status = "okay";
-};
-
-&watchdog {
-	status = "okay";
-};
-
-&wifi {
-	status = "okay";
-	nvmem-cells = <&eeprom_factory_0>;
-	nvmem-cell-names = "eeprom";
-};
-

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr631ax-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr631ax-ubootmod.dts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7981b-comfast-cf-wr631ax.dts"
+#include "mt7981b-comfast-common-ubootmod.dtsi"
+
+/ {
+	model = "COMFAST CF-WR631AX (OpenWrt U-Boot layout)";
+	compatible = "comfast,cf-wr631ax-ubootmod", "mediatek,mt7981";
+};

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr631ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr631ax.dts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+/dts-v1/;
+#include "mt7981b-comfast-common.dtsi"
+
+/ {
+	model = "COMFAST CF-WR631AX";
+	compatible = "comfast,cf-wr631ax", "mediatek,mt7981";
+	
+	aliases {
+		led-boot = &led_status_blue;
+		led-failsafe = &led_status_blue;
+		led-running = &led_status_green;
+		led-upgrade = &led_status_red;
+	};
+};
+
+&led_status_blue {
+	gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+};
+
+&led_status_green {
+	gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+};
+
+&led_status_red {
+	gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+};
+
+&gpio_keys {
+	mesh_button {
+		label = "mode";
+		linux,code = <BTN_0>;
+		gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+	};
+};
+
+&gmac0 {
+	label = "lan";
+
+	fixed-link {
+		speed = <2500>;
+		full-duplex;
+		pause;
+	};
+};
+
+&mdio_bus {
+	reset-gpios = <&pio 6 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <1500000>;
+	reset-post-delay-us = <1000000>;
+
+	switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <31>;
+		reset-gpios = <&pio 39 0>;
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				label = "lan1";
+				reg = <0>;
+			};
+
+			port@2 {
+				label = "lan2";
+				reg = <2>;
+			};
+
+			port@3 {
+				label = "lan3";
+				reg = <3>;
+			};
+
+			wan: port@4 {
+				label = "wan";
+				reg = <4>;
+
+				nvmem-cells = <&macaddr_factory_e000 1>;
+				nvmem-cell-names = "mac-address";
+			};
+
+			port@6 {
+				ethernet = <&gmac0>;
+				label = "cpu";
+				phy-mode = "2500base-x";
+				reg = <6>;
+
+				fixed-link {
+					speed = <2500>;
+					full-duplex;
+					pause;
+				};
+			};
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-ubootmod.dts
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax-ubootmod.dts
@@ -1,23 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "mt7981b-comfast-cf-wr632ax-common.dtsi"
+#include "mt7981b-comfast-cf-wr632ax.dts"
+#include "mt7981b-comfast-common-ubootmod.dtsi"
 
 / {
 	model = "COMFAST CF-WR632AX (OpenWrt U-Boot layout)";
 	compatible = "comfast,cf-wr632ax-ubootmod", "mediatek,mt7981";
-};
-
-&chosen {
-	bootargs = "root=/dev/fit0 rootwait";
-	rootdisk = <&ubi_rootdisk>;
-};
-
-&ubi {
-	reg = <0x580000 0x7a80000>;
-
-	volumes {
-		ubi_rootdisk: ubi-volume-fit {
-			volname = "fit";
-		};
-	};
 };

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax.dts
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-wr632ax.dts
@@ -1,18 +1,88 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
-#include "mt7981b-comfast-cf-wr632ax-common.dtsi"
+/dts-v1/;
+#include "mt7981b-comfast-common.dtsi"
 
 / {
 	model = "COMFAST CF-WR632AX";
 	compatible = "comfast,cf-wr632ax", "mediatek,mt7981";
+
+	aliases {
+		led-boot = &led_status_red;
+		led-failsafe = &led_status_red;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_green;
+	};
 };
 
-&spi_nand {
-	mediatek,nmbm;
-	mediatek,bmt-max-ratio = <1>;
-	mediatek,bmt-max-reserved-blocks = <64>;
+&led_status_blue {
+	gpios = <&pio 8 GPIO_ACTIVE_LOW>;
 };
 
-&ubi {
-	reg = <0x580000 0x4000000>;
+&led_status_green {
+	gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+};
+
+&led_status_red {
+	gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+};
+
+&mdio_bus {
+	reset-gpios = <&pio 14 GPIO_ACTIVE_LOW>;
+	reset-delay-us = <600>;
+	reset-post-delay-us = <20000>;
+
+	phy5: phy@5 {
+		compatible = "ethernet-phy-ieee802.3-c45";
+		reg = <5>;
+	};
+};
+
+&gmac0 {
+	label = "wan";
+	phy-handle = <&phy5>;
+};
+
+&eth {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mdio_pins>;
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		label = "lan";
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_e000 1>;
+	};
+};
+
+&fan {
+	pwms = <&pwm 0 10000>;
+	status = "okay";
+};
+
+&pwm {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm0_pin>;
+	status = "okay";
+};
+
+&pio {
+	pwm0_pin: pwm0-pin-g0 {
+		mux {
+		function = "pwm";
+		groups = "pwm0_0";
+		};
+	};
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&xhci {
+	status = "okay";
 };

--- a/target/linux/mediatek/dts/mt7981b-comfast-cf-xr186.dts
+++ b/target/linux/mediatek/dts/mt7981b-comfast-cf-xr186.dts
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 
 /dts-v1/;
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
-#include <dt-bindings/leds/common.h>
-
-#include "mt7981b.dtsi"
+#include "mt7981b-comfast-common.dtsi"
 
 / {
 	model = "COMFAST CF-XR186";
@@ -13,31 +9,10 @@
 
 	aliases {
 		label-mac-device = &gmac1;
-		serial0 = &uart0;
 		led-boot = &led_wifi_red;
 		led-failsafe = &led_wifi_red;
 		led-upgrade = &led_wifi_red;
 		led-running = &led_wifi_red;
-	};
-
-	chosen {
-		bootargs-override = "console=ttyS0,115200n8";
-		stdout-path = "serial0:115200n8";
-	};
-
-	memory@40000000 {
-		reg = <0 0x40000000 0 0x10000000>;
-		device_type = "memory";
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			linux,code = <KEY_RESTART>;
-			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
-		};
 	};
 
 	leds {
@@ -69,14 +44,11 @@
 	};
 };
 
-&crypto {
-	status = "okay";
-};
-
 &eth {
 	pinctrl-names = "default";
 	pinctrl-0 = <&mdio_pins>;
-	status = "okay";
+
+	/delete-node/ mac@0;
 
 	gmac1: mac@1 {
 		compatible = "mediatek,eth-mac";
@@ -84,142 +56,6 @@
 		phy-mode = "gmii";
 		phy-handle = <&int_gbe_phy>;
 		nvmem-cells = <&macaddr_factory_e000 0>;
-		nvmem-cell-names = "mac-address";
-	};
-};
-
-&pio {
-	spi0_flash_pins: spi0-pins {
-		mux {
-			function = "spi";
-			groups = "spi0", "spi0_wp_hold";
-		};
-		conf-pu {
-			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
-			drive-strength = <MTK_DRIVE_8mA>;
-			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
-		};
-		conf-pd {
-			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
-			drive-strength = <MTK_DRIVE_8mA>;
-			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
-		};
-	};
-};
-
-&spi0 {
-	pinctrl-names = "default";
-	pinctrl-0 = <&spi0_flash_pins>;
-	status = "okay";
-
-	spi_nand: spi-nand@0 {
-		compatible = "spi-nand";
-		reg = <0>;
-		spi-max-frequency = <52000000>;
-
-		spi-cal-enable;
-		spi-cal-mode = "read-data";
-		spi-cal-datalen = <7>;
-		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
-		spi-cal-addrlen = <5>;
-		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
-
-		spi-tx-bus-width = <4>;
-		spi-rx-bus-width = <4>;
-		mediatek,nmbm;
-		mediatek,bmt-max-ratio = <1>;
-		mediatek,bmt-max-reserved-blocks = <64>;
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			partition@0 {
-				label = "BL2";
-				reg = <0x00000 0x0100000>;
-				read-only;
-			};
-
-			partition@100000 {
-				label = "u-boot-env";
-				reg = <0x0100000 0x0080000>;
-				read-only;
-			};
-
-			factory: partition@180000 {
-				label = "Factory";
-				reg = <0x180000 0x0200000>;
-				read-only;
-
-				nvmem-layout {
-					compatible = "fixed-layout";
-					#address-cells = <1>;
-					#size-cells = <1>;
-
-					eeprom_factory_0: eeprom@0 {
-						reg = <0x0 0x1000>;
-					};
-
-					macaddr_factory_4: macaddr@4 {
-						compatible = "mac-base";
-						reg = <0x4 0x6>;
-						#nvmem-cell-cells = <1>;
-					};
-
-					macaddr_factory_8000: macaddr@8000 {
-						compatible = "mac-base";
-						reg = <0x8000 0x6>;
-						#nvmem-cell-cells = <1>;
-					};
-
-					macaddr_factory_e000: macaddr@e000 {
-						compatible = "mac-base";
-						reg = <0xe000 0x6>;
-						#nvmem-cell-cells = <1>;
-					};
-				};
-			};
-
-			partition@380000 {
-				label = "FIP";
-				reg = <0x380000 0x0200000>;
-				read-only;
-			};
-
-			partition@580000 {
-				label = "ubi";
-				reg = <0x580000 0x4000000>;
-				compatible = "linux,ubi";
-			};
-		};
-	};
-};
-
-&uart0 {
-	status = "okay";
-};
-
-&watchdog {
-	status = "okay";
-};
-
-&wifi {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	status = "okay";
-	nvmem-cells = <&eeprom_factory_0>;
-	nvmem-cell-names = "eeprom";
-
-	band@0 {
-		reg = <0>;
-		nvmem-cells = <&macaddr_factory_4 0>;
-		nvmem-cell-names = "mac-address";
-	};
-
-	band@1 {
-		reg = <1>;
-		nvmem-cells = <&macaddr_factory_8000 0>;
 		nvmem-cell-names = "mac-address";
 	};
 };

--- a/target/linux/mediatek/dts/mt7981b-comfast-common-ubootmod.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-comfast-common-ubootmod.dtsi
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+&chosen {
+	/delete-property/ bootargs-override;
+	bootargs = "root=/dev/fit0 rootwait";
+	rootdisk = <&ubi_rootdisk>;
+};
+
+
+&spi_nand {
+	/delete-property/ mediatek,nmbm;
+	/delete-property/ mediatek,bmt-max-ratio;
+	/delete-property/ mediatek,bmt-max-reserved-blocks;
+};
+
+&ubi {
+	reg = <0x580000 0x7a80000>;
+
+	volumes {
+		ubi_rootdisk: ubi-volume-fit {
+			volname = "fit";
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-comfast-common.dtsi
+++ b/target/linux/mediatek/dts/mt7981b-comfast-common.dtsi
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7981b.dtsi"
+
+/ {
+	aliases {
+		label-mac-device = &gmac0;
+		serial0 = &uart0;
+	};
+
+	chosen: chosen {
+		bootargs-override = "console=ttyS0,115200n8";
+		stdout-path = "serial0:115200n8";
+	};
+
+	gpio_keys: gpio-keys {
+		compatible = "gpio-keys";
+
+		key_reset: reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_blue: blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_status_green: green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+		};
+
+		led_status_red: red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+		};
+	};
+};
+
+&crypto {
+	status = "okay";
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+		nvmem-cells = <&macaddr_factory_e000 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_4mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand: spi-nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4E 0x41 0x4E 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x00000 0x0100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x0100000 0x0080000>;
+				read-only;
+			};
+
+			factory: partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x0200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_e000: macaddr@e000 {
+						compatible = "mac-base";
+						reg = <0xe000 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+
+					macaddr_factory_8000: macaddr@8000 {
+						compatible = "mac-base";
+						reg = <0x8000 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x0200000>;
+				read-only;
+			};
+
+			ubi: partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x4000000>;
+				compatible = "linux,ubi";
+			};
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	#address-cells = <1>;
+	#size-cells = <0>;
+	nvmem-cells = <&eeprom_factory_0>;
+	nvmem-cell-names = "eeprom";
+	status = "okay";
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 0>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_8000 0>;
+		nvmem-cell-names = "mac-address";
+	};
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -170,6 +170,10 @@ mediatek_setup_interfaces()
 	dlink,aquila-pro-ai-m60-a1)
 		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3 lan4" internet
 		;;
+	comfast,cf-wr631ax|\
+	comfast,cf-wr631ax-ubootmod)
+		ucidef_set_interfaces_lan_wan "lan1 lan2 lan3" wan
+		;;
 	comfast,cf-wr632ax|\
 	comfast,cf-wr632ax-ubootmod|\
 	keenetic,kn-3911|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -146,6 +146,7 @@ platform_do_upgrade() {
 	bazis,ax3000wm|\
 	cmcc,a10-ubootmod|\
 	cmcc,rax3000m|\
+	comfast,cf-wr631ax-ubootmod|\
 	comfast,cf-wr632ax-ubootmod|\
 	creatlentem,clt-r30b1-ubi|\
 	cudy,tr3000-v1-ubootmod|\
@@ -360,6 +361,7 @@ platform_check_image() {
 	bazis,ax3000wm|\
 	cmcc,a10-ubootmod|\
 	cmcc,rax3000m|\
+	comfast,cf-wr631ax-ubootmod|\
 	comfast,cf-wr632ax-ubootmod|\
 	creatlentem,clt-r30b1-ubi|\
 	cudy,tr3000-v1-ubootmod|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -967,84 +967,63 @@ define Device/cmcc_rax3000m
 endef
 TARGET_DEVICES += cmcc_rax3000m
 
-define Device/comfast_cf-e393ax
+define Device/comfast_mt7981_common
   DEVICE_VENDOR := COMFAST
-  DEVICE_MODEL := CF-E393AX
-  DEVICE_ALT0_VENDOR := COMFAST
-  DEVICE_ALT0_MODEL := CF-E395AX
-  DEVICE_DTS := mt7981a-comfast-cf-e393ax
+  DEVICE_DTS := $(1)-comfast-$(2)
+  SUPPORTED_DEVICES += $(2)
   DEVICE_DTS_DIR := ../dts
-  DEVICE_DTC_FLAGS := --pad 4096
-  DEVICE_DTS_LOADADDR := 0x43f00000
   DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL_LOADADDR := 0x44000000
   UBINIZE_OPTS := -E 5
   BLOCKSIZE := 128k
-  PAGESIZE := 2048
   IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGES := sysupgrade.bin factory.bin
-  IMAGE/factory.bin := append-ubi | check-size $$$$(IMAGE_SIZE)
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+endef
+
+define Device/comfast_mt7981_common-ubootmod
+  $(call Device/comfast_mt7981_common,$(1),$(2))
+  DEVICE_VARIANT := (OpenWrt U-Boot layout)
+  DEVICE_DTS := $(1)-comfast-$(2)-ubootmod
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
+  KERNEL := kernel-bin | lzma
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  ARTIFACTS := preloader.bin bl31-uboot.fip
+  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3-1866 | pad-to 2048
+  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot comfast_$(2) | pad-to 2048
+endef
+
+define Device/comfast_cf-e393ax
+  DEVICE_MODEL := CF-E393AX
+  $(call Device/comfast_mt7981_common,mt7981a,cf-e393ax)
+  DEVICE_ALT0_VENDOR := COMFAST
+  DEVICE_ALT0_MODEL := CF-E395AX
+  SUPPORTED_DEVICES += cf-e395ax
 endef
 TARGET_DEVICES += comfast_cf-e393ax
 
-define Device/comfast_cf-wr632ax-common
-  DEVICE_VENDOR := COMFAST
-  DEVICE_MODEL := CF-WR632AX
-  DEVICE_DTS_DIR := ../dts
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware kmod-hwmon-pwmfan kmod-usb3
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  KERNEL_IN_UBI := 1
-endef
-
 define Device/comfast_cf-wr632ax
-  DEVICE_DTS := mt7981b-comfast-cf-wr632ax
-  IMAGE_SIZE := 65536k
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  SUPPORTED_DEVICES += cf-wr632ax
-  $(call Device/comfast_cf-wr632ax-common)
+  DEVICE_MODEL := CF-WR632AX
+  $(call Device/comfast_mt7981_common,mt7981b,cf-wr632ax)
+  DEVICE_PACKAGES += kmod-hwmon-pwmfan kmod-usb3
 endef
 TARGET_DEVICES += comfast_cf-wr632ax
 
 define Device/comfast_cf-wr632ax-ubootmod
-  DEVICE_VARIANT := (OpenWrt U-Boot layout)
-  DEVICE_DTS := mt7981b-comfast-cf-wr632ax-ubootmod
-  UBOOTENV_IN_UBI := 1
-  IMAGES := sysupgrade.itb
-  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
-  KERNEL := kernel-bin | gzip
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
-  IMAGE/sysupgrade.itb := append-kernel | \
-	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | append-metadata
-  ARTIFACTS := preloader.bin bl31-uboot.fip
-  ARTIFACT/preloader.bin := mt7981-bl2 spim-nand-ddr3-1866
-  ARTIFACT/bl31-uboot.fip := mt7981-bl31-uboot comfast_cf-wr632ax
-  $(call Device/comfast_cf-wr632ax-common)
+  DEVICE_MODEL := CF-WR632AX
+  $(call Device/comfast_mt7981_common-ubootmod,mt7981b,cf-wr632ax)
+  DEVICE_PACKAGES += kmod-hwmon-pwmfan kmod-usb3
 endef
 TARGET_DEVICES += comfast_cf-wr632ax-ubootmod
 
 define Device/comfast_cf-xr186
-  DEVICE_VENDOR := COMFAST
   DEVICE_MODEL := CF-XR186
-  DEVICE_DTS := mt7981b-comfast-cf-xr186
-  DEVICE_DTS_DIR := ../dts
-  SUPPORTED_DEVICES += cf-xr186
-  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
-  KERNEL := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb
-  KERNEL_INITRAMFS := kernel-bin | lzma | \
-	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd
-  UBINIZE_OPTS := -E 5
-  BLOCKSIZE := 128k
-  PAGESIZE := 2048
-  IMAGE_SIZE := 65536k
-  KERNEL_IN_UBI := 1
-  IMAGES := sysupgrade.bin
-  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  $(call Device/comfast_mt7981_common,mt7981b,cf-xr186)
 endef
 TARGET_DEVICES += comfast_cf-xr186
 

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -1007,12 +1007,24 @@ define Device/comfast_cf-e393ax
 endef
 TARGET_DEVICES += comfast_cf-e393ax
 
+define Device/comfast_cf-wr631ax
+  DEVICE_MODEL := CF-WR631AX
+  $(call Device/comfast_mt7981_common,mt7981b,cf-wr631ax)
+endef
+TARGET_DEVICES += comfast_cf-wr631ax
+
 define Device/comfast_cf-wr632ax
   DEVICE_MODEL := CF-WR632AX
   $(call Device/comfast_mt7981_common,mt7981b,cf-wr632ax)
   DEVICE_PACKAGES += kmod-hwmon-pwmfan kmod-usb3
 endef
 TARGET_DEVICES += comfast_cf-wr632ax
+
+define Device/comfast_cf-wr631ax-ubootmod
+  DEVICE_MODEL := CF-WR631AX
+  $(call Device/comfast_mt7981_common-ubootmod,mt7981b,cf-wr631ax)
+endef
+TARGET_DEVICES += comfast_cf-wr631ax-ubootmod
 
 define Device/comfast_cf-wr632ax-ubootmod
   DEVICE_MODEL := CF-WR632AX


### PR DESCRIPTION
Specification
-------------
- SoC          : MediaTek MT7981B dual-core ARM Cortex-A53 1.3 GHz
- RAM          : DDR3 256 MiB (Nanya NT5CC128M16JR-EK DDR3-1866 (PC3-14900))
- Flash        : SPI-NAND 128 MiB (Winbond 25NO1GVZEIG 2204)
- WLAN         : MediaTek MT7976CN dual-band WiFi 6
  - 2.4 GHz    : b/g/n/ax, MU-MIMO (2x 5 dBi antennas)
  - 5 GHz      : a/n/ac/ax, MU-MIMO (3x 5 dBi antennas)
- Ethernet     :
  - LAN x3     : 10/100/1000 Mbps (MT7531AE)
  - WAN x1     : 10/100/1000 Mbps (MT7531AE)
- UART         : through-hole on PCB
  - assignment : (GND), (RX), (TX), [VCC]
  - settings   : 115200n8
- Buttons x2   : Reset, Mesh
- LEDs x3      : Status (Blue, Green, Red)
- Power        : 12VDC, 1A

Rooting the Stock Firmware:
---------------------------

1. Export config from the device, extract the
contents to a folder. (even though the extension is .file it is actually
a tar.gz file)
2. Edit the etc/shadow file in the extracted contents and replace the
root entry with
root:$1$DR6LkFbI$Px8XMlVdssyk2Fwx.2rLg1:19510:0:99999:7:::
3. Compress the new config artifacts to tar.gz and rename the file to
.file extension. Load config backup to device via webui.
4. After restart root password is openwrt.

Backing up the partitions:
--------------------------
1. root the device
2. backup bl2:
ssh root@192.168.0.1 "dd if=/dev/mtd0ro bs=64k" | dd of=mtd0_bl2.bin
status=progress
3. backup factory:
ssh root@192.168.0.1 "dd if=/dev/mtd2ro bs=64k" | dd of=mtd2_factory.bin
status=progress
4. backup fip:
ssh root@192.168.0.1 "dd if=/dev/mtd3ro bs=64k" | dd of=mtd3_fip.bin
status=progress

Flash instructions
------------------
WebUI Method:

1. Install the *squashfs-sysupgrade.bin image using the stock WebUI
   update page.
2. Press and hold the reset button after reboot
   to wipe the stock config.

SSH Method:
2. Connect via SSH using root:openwrt credentials after rooting.
3. Upload the *squashfs-sysupgrade.bin image.
4. Use the command: sysupgrade -n

Return to stock
---------------
Flash a stock firmware using the OpenWrt sysupgrade method.

Recovery
--------
Power on the router while holding the Reset button until
the LED flashes 5 times.
The U-Boot Flash WebUI will be available at http://192.168.1.1
or
Connect UART and use the U-Boot menu to flash the firmware image
or boot an OpenWrt initramfs image.

OpenWrt U-Boot flash instructions
---------------------------------
With Uart:

1. Serve the bin/targets/mediatek/filogic
 over tftp then go to vendor uboot menu over uart.
2. Update bl2 with
openwrt-mediatek-filogic-comfast_cf-wr631ax-ubootmod-preloader.bin BL2
from the menu
3. Update fip with
openwrt-mediatek-filogic-comfast_cf-wr631ax-ubootmod-bl31-uboot.fip
from the menu
4. Restart the device and go to openwrt uboot and update the rootfs from
the menu.

Without Uart:

1. Flash ordinary OpenWrt image.
2. Login into the device and backup everything, especially 'Factory'
part.
3. Unlock mtd partitions:
    apk add kmod-mtd-rw
    insmod mtd-rw i_want_a_brick=1
4. Write new BL2 and FIP:
    mtd write
openwrt-mediatek-filogic-comfast_cf-wr631ax-ubootmod-preloader.bin BL2
    mtd write
openwrt-mediatek-filogic-comfast_cf-wr631ax-ubootmod-bl31-uboot.fip FIP
5. Set static IP on your PC:
    ip 192.168.1.254 mask 255.255.255.0
6. Serve OpenWrt initramfs image using TFTP server.
7. Reboot device, wait for TFTP recovery to complete.
8. After OpenWrt has booted, perform sysupgrade.

Returning to vendor image from openwrt layout
---------------------------------------------
1. Serve the backups and vendor firmware on the host machine with ip
192.168.1.254.
2. Go to openwrt uboot console
    tftpboot $loadaddr mtd3_fip.bin
    run mtd_write_fip
    tftpboot $loadaddr mtd0_bl2.bin
    run mtd_write_bl2
3. Reset the device and go to vendor uboot menu
4. Update the firmware with vendor firmare via tftp

Debricking
----------
1. In case of an emergency you can always reach to vendor uboot or
openwrt uboot using uart.
2. mtk_uartboot -s /dev/tty[my device] -p
bl2-mt7981-bga-ddr3-ram.bin -f fip.bin --aarch64
3. ram file must the specific file, but you can choose in between your
mtd3_fip.bin dump for vendor uboot or
openwrt-mediatek-filogic-comfast_cf-wr631ax-ubootmod-bl31-uboot.fip for
openwrt uboot
4. Keep pressing the reset button on the device and power on, wait until
the fip image is fully sent.
5. When finished, connect to uboot over uart and flash bl2, fip, and
recover rootfs.

MAC Addresses:
----------------------------------------------------------
| Interface    |  MAC              | Source              |
---------------|-------------------|----------------------
| LAN          | 40:A5:EF:xx:xx:xx | Factory, 0xe000.....|
| WLAN 2.4 GHz | 40:A5:EF:xx:xx:xx | Factory, 0x4        |
| WLAN 5 GHz   | 40:A5:EF:xx:xx:xx | Factory, 0x8000     |
----------------------------------------------------------

Tested with WR631AX:
--------------------------------

Factory -> Openwrt -> Openwrt Ubootmod -> Factory image swap scenarios
3 color Led, MESH + RESET Button
HW Offload + WED
All work fine.

Test of impacted devices due to refactoring
-----------------------------------------------------
WR632AX, E393AX, XR186 compiled dtbs have been converted back to dts, and verified that after the PR functionally same device trees are generated.

Thermal Design:
------------------------

The devices chips are at the bottom of the pcb.  Wifi chip has it is own small thermal sink at the bottom. Rest of the chips have no thermal sink at the bottom. At the top of the pcb there is a relatively big thermal chip contacting to the pcb. So the cooling is indirect and passive. Not the best design but it is what it is.

In this scenario i have tested the vendor firmware and openwrt firmware to compare to check the thermals. They are the same, so openwrt does not introduce any extra heat. But the device runs hot. 80 ~ 90C in ambient temp of 30C.

Openwrt 25.12:
<img width="1285" height="414" alt="image" src="https://github.com/user-attachments/assets/5364675f-6e66-441d-bdb3-d593648e4bf2" />

Vendor Firmware 2.7.0.8:
<img width="841" height="240" alt="image" src="https://github.com/user-attachments/assets/af476bdc-521a-4d5d-8a69-27b1a2765d44" />

Pictures of Device:
---------------------------

<img width="3000" height="4000" alt="PXL_20260526_123237157" src="https://github.com/user-attachments/assets/d00d2a4c-9efa-41e4-a8a3-6cbb400df993" />

<img width="3000" height="4000" alt="PXL_20260521_100825832" src="https://github.com/user-attachments/assets/4df1c2a5-181d-48fe-a338-10e55a74b85d" />
<img width="4000" height="3000" alt="PXL_20260520_130628227" src="https://github.com/user-attachments/assets/94777906-603c-440f-98ef-1c54b94b9c43" />
<img width="4000" height="3000" alt="PXL_20260520_130237196 MP" src="https://github.com/user-attachments/assets/0b8de0f8-7be3-41a4-95f9-3858999bfe0d" />

