### PR TITLE
[25.12] wifi-scripts: ucode: fix null dereference for 6GHz-only radios

### DIFF
--- a/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
+++ b/package/network/config/wifi-scripts/files-ucode/usr/share/ucode/wifi/hostapd.uc
@@ -467,6 +467,8 @@ function device_capabilities(config) {
 
 	phy_capabilities.ht_capa = band.ht_capa ?? 0;
 	phy_capabilities.vht_capa = band.vht_capa ?? 0;
+	phy_capabilities.he_mac_cap = [];
+	phy_capabilities.he_phy_cap = [];
 	for (let iftype in band.iftype_data) {
 		if (!iftype.iftypes.ap)
 			continue;


### PR DESCRIPTION
Backport of feca0b4507 from main.

Cherry-pick of: wifi-scripts: ucode: fix null dereference for 6GHz-only radios

Link: https://github.com/openwrt/openwrt/issues/23488