### PR TITLE
realtek: add support for Ubiquiti UniFi USW Aggregation

### DIFF
--- a/target/linux/realtek/dts/rtl9303_ubnt_usw-aggregation.dts
+++ b/target/linux/realtek/dts/rtl9303_ubnt_usw-aggregation.dts
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "ubnt,usw-aggregation", "realtek,rtl9303-soc";
+	model = "UniFi USW Aggregation";
+
+	aliases {
+		label-mac-device = &ethernet0;
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		pinctrl-names = "default";
+		pinctrl-0 = <&pinmux_enable_led_sync>;
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
+			     RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_10M |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			    RTL93XX_LED_SET_NONE>;
+	};
+
+	sfp0: sfp-p1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		los-gpio = <&gpio2 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio2 2 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio2 3 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio2 1 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp1: sfp-p2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		los-gpio = <&gpio2 4 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio2 6 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio2 7 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio2 5 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp2: sfp-p3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		los-gpio = <&gpio2 8 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio2 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio2 11 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio2 9 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp3: sfp-p4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		los-gpio = <&gpio2 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio2 14 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio2 15 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio2 13 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp4: sfp-p5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c4>;
+		los-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 2 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp5: sfp-p6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c5>;
+		los-gpio = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 6 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio1 5 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp6: sfp-p7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c6>;
+		los-gpio = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 10 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
+	};
+
+	sfp7: sfp-p8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c7>;
+		los-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio1 14 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio1 15 GPIO_ACTIVE_HIGH>;
+		tx-fault-gpio = <&gpio1 13 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	i2c0: i2c@0 { reg = <0>; };
+	i2c1: i2c@1 { reg = <1>; };
+	i2c2: i2c@2 { reg = <2>; };
+	i2c3: i2c@3 { reg = <3>; };
+	i2c4: i2c@4 {
+		reg = <4>;
+
+		gpio1: gpio@21 {
+			compatible = "nxp,pca9555";
+			reg = <0x21>;
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+
+		gpio2: gpio@24 {
+			compatible = "nxp,pca9555";
+			reg = <0x24>;
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+	i2c5: i2c@5 { reg = <5>; };
+	i2c6: i2c@6 { reg = <6>; };
+	i2c7: i2c@7 { reg = <7>; };
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xa0000>;
+				read-only;
+			};
+
+			partition@a0000 {
+				label = "u-boot-env";
+				reg = <0xa0000 0x10000>;
+			};
+
+			partition@b0000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				label = "firmware";
+				reg = <0xb0000 0xe20000>;
+			};
+
+			/* this partition contains data used by U-boot and UniFi OS
+			 * e.g. the bootpartition selector.
+			 */
+			partition@ed0000 {
+				label = "reserved";
+				reg = <0xed0000 0x10000>;
+			};
+
+			partition@ee0000 {
+				label = "cdata";
+				reg = <0xee0000 0x10000>;
+			};
+
+			partition@ef0000 {
+				label = "cfg";
+				reg = <0xef0000 0x100000>;
+			};
+
+			partition@ff0000 {
+				label = "eeprom";
+				reg = <0xff0000 0x10000>;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					factory_macaddr: macaddr@0 {
+						compatible = "mac-base";
+						reg = <0x0 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&gpio0 {
+	/*
+	 * Lines 5/6 are wired to the front-panel STM32 MCU that drives
+	 * the touch display:
+	 *   5 = BOOT0 select (low: run firmware from flash,
+	 *                    high: system bootloader / DFU)
+	 *   6 = reset (active low)
+	 * Named only, not claimed, so userspace can drive them.
+	 */
+	gpio-line-names = "", "", "", "", "", "lcm-mode", "lcm-reset";
+};
+
+&ethernet0 {
+	nvmem-cells = <&factory_macaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_SFP(20, 1, 5, 0, 0)
+		SWITCH_PORT_SFP(16, 2, 4, 0, 1)
+		SWITCH_PORT_SFP(25, 3, 7, 0, 2)
+		SWITCH_PORT_SFP(24, 4, 6, 0, 3)
+		SWITCH_PORT_SFP(27, 5, 9, 0, 4)
+		SWITCH_PORT_SFP(26, 6, 8, 0, 5)
+		SWITCH_PORT_SFP(8, 7, 3, 0, 6)
+		SWITCH_PORT_SFP(0, 8, 2, 0, 7)
+
+		port@28 {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&uart1 {
+	status = "okay";
+
+	/* front touch display MCU reachable here */
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -85,6 +85,15 @@ define Device/tplink_tl-st1008f-v2
 endef
 TARGET_DEVICES += tplink_tl-st1008f-v2
 
+define Device/ubnt_usw-aggregation
+  SOC := rtl9303
+  DEVICE_VENDOR := Ubiquiti
+  DEVICE_MODEL := UniFi USW Aggregation
+  IMAGE_SIZE := 14464k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += ubnt_usw-aggregation
+
 define Device/vimin_vm-s100-0800ms
   SOC := rtl9303
   UIMAGE_MAGIC := 0x93000000


### PR DESCRIPTION
Add support for the RTL9303-based Ubiquiti UniFi USW Aggregation, an 8-port 10G SFP+ aggregation switch. Nothing fancy here, just another switch in our device list.

The front touch display is neat but requires more work, either making use of the high-level JSON-based control that is done between MCU + UniFi OS, or replacing the MCU firmware to have pixel-level control.