### PR TITLE
ramips: remove nvmem-cells compatible

### DIFF
--- a/target/linux/ramips/dts/mt7628an_creality_wb-01.dts
+++ b/target/linux/ramips/dts/mt7628an_creality_wb-01.dts
@@ -84,11 +84,8 @@
 			};
 
 			factory: partition@40000 {
-				compatible = "nvmem-cells";
 				label = "factory";
 				reg = <0x40000 0x10000>;
-				#address-cells = <1>;
-				#size-cells = <1>;
 				read-only;
 
 				nvmem-layout {


### PR DESCRIPTION
nvmem-layout is used instead of the older nvmem-cells. Seems to be a copy/paste mistake.
