### PR TITLE
[25.12] mediatek: filogic: add support for TP-Link F65

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-tplink-f65v1.dts
+++ b/target/linux/mediatek/dts/mt7981b-tplink-f65v1.dts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/mt65xx.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	compatible = "tplink,f65-v1", "mediatek,mt7981";
+	model = "TP-Link F65 v1";
+
+	aliases {
+		serial0 = &uart0;
+		led-boot = &led_status;
+		led-failsafe = &led_status;
+		led-running = &led_status;
+		led-upgrade = &led_status;
+	};
+
+	chosen {
+		bootargs-append = " ubi.mtd=ubi root=/dev/ubiblock0_1";
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@40000000 {
+		reg = <0 0x40000000 0 0x20000000>;
+		device_type = "memory";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status: led_status {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_BLUE>;
+			gpios = <&pio 35 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+		mediatek,nmbm;
+		mediatek,bmt-max-ratio = <1>;
+		mediatek,bmt-max-reserved-blocks = <64>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "bl2";
+				reg = <0x00000 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "boot-config";
+				reg = <0x100000 0x100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "boot-config1";
+				reg = <0x200000 0x100000>;
+				read-only;
+			};
+
+			partition@300000 {
+				compatible = "u-boot,env";
+				label = "u-boot-env";
+				reg = <0x300000 0x100000>;
+			};
+
+			partition@400000 {
+				label = "fip0";
+				reg = <0x400000 0x200000>;
+				read-only;
+			};
+
+			partition@600000 {
+				label = "fip1";
+				reg = <0x600000 0x200000>;
+				read-only;
+			};
+
+			partition@800000 {
+				label = "oops";
+				reg = <0x800000 0x100000>;
+				read-only;
+			};
+
+			partition@900000 {
+				label = "ubi";
+				reg = <0x900000 0x2680000>;
+			};
+
+			partition@2F80000 {
+				label = "ubi_1";
+				reg = <0x2F80000 0x2680000>;
+				read-only;
+			};
+
+			partition@5600000 {
+				label = "factory";
+				reg = <0x5600000 0x800000>;
+				read-only;
+			};
+
+			partition@5E00000 {
+				label = "runtime_data";
+				reg = <0x5E00000 0xC00000>;
+				read-only;
+			};
+
+			partition@6A00000 {
+				label = "backup_data";
+				reg = <0x6A00000 0x800000>;
+				read-only;
+			};
+
+			partition@7200000 {
+				label = "runtime_backup";
+				reg = <0x7200000 0x800000>;
+				read-only;
+			};
+
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+	};
+};
+
+&wifi {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -119,6 +119,7 @@ mediatek_setup_interfaces()
 	netgear,eax17|\
 	netgear,wax220|\
 	openfi,6c|\
+	tplink,f65-v1|\
 	ubnt,unifi-6-plus|\
 	wavlink,wl-wn573hx3|\
 	widelantech,wap430x|\
@@ -292,7 +293,8 @@ mediatek_setup_macs()
 		wan_mac=$label_mac
 		lan_mac=$(macaddr_add "$label_mac" 1)
 		;;
-	tplink,eap683-lr)
+	tplink,eap683-lr|\
+	tplink,f65-v1)
 		label_mac=$(get_mac_binary "/tmp/factory/default-mac" 0)
 		lan_mac=$label_mac
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/firmware/11-mt76-caldata
@@ -14,6 +14,9 @@ case "$FIRMWARE" in
 		ln -sf /tmp/tp_data/MT7981_EEPROM.bin \
 			/lib/firmware/$FIRMWARE
 		;;
+	tplink,f65-v1)
+		ln -sf /tmp/factory/radio /lib/firmware/$FIRMWARE
+		;;
 	tplink,fr365-v1)
 		ln -sf /tmp/wlan/radio /lib/firmware/$FIRMWARE
 		;;

--- a/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
+++ b/target/linux/mediatek/filogic/base-files/etc/hotplug.d/ieee80211/11_fix_wifi_mac
@@ -230,7 +230,8 @@ case "$board" in
 		[ "$PHYNBR" = "0" ] && macaddr_add $addr 2 > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 3 > /sys${DEVPATH}/macaddress
 		;;
-	tplink,eap683-lr)
+	tplink,eap683-lr|\
+	tplink,f65-v1)
 		addr=$(get_mac_label)
 		[ "$PHYNBR" = "0" ] && echo $addr > /sys${DEVPATH}/macaddress
 		[ "$PHYNBR" = "1" ] && macaddr_add $addr 1 > /sys${DEVPATH}/macaddress

--- a/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
+++ b/target/linux/mediatek/filogic/base-files/lib/preinit/09_mount_cfg_part
@@ -22,7 +22,8 @@ preinit_mount_cfg_part() {
 	tplink,re6000xd)
 		mount_ubi_part "tp_data" "tp_data"
 		;;
-	tplink,eap683-lr)
+	tplink,eap683-lr|\
+	tplink,f65-v1)
 		mount_ubi_part "factory" "ubi_factory_data"
 		;;
 	tplink,fr365-v1)

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2995,6 +2995,19 @@ define Device/tplink_re6000xd
 endef
 TARGET_DEVICES += tplink_re6000xd
 
+define Device/tplink_f65-v1
+  DEVICE_VENDOR := TP-Link
+  DEVICE_MODEL := F65
+  DEVICE_VARIANT := v1
+  DEVICE_DTS := mt7981b-tplink-f65v1
+  DEVICE_DTS_DIR := ../dts
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware mt7981-wo-firmware
+endef
+TARGET_DEVICES += tplink_f65-v1
+
 define Device/tplink_fr365-v1
   DEVICE_VENDOR := TP-Link
   DEVICE_MODEL := FR365


### PR DESCRIPTION
Add support for TP-Link Festa F65, an AX3000 ceiling mount WiFi 6 AP.

Hardware
--------
SOC	: MediaTek MT7981B 2x A53
RAM	: ESMT M15T4G16256A 512MiB
Flash	: ESMT F50L1G41LB 128 MiB
ETH	: 1x 1GbE
WiFi	: MT7976
Buttons	: Reset
Leds	: Blue status led on top
Power	: DC 12V 1.2A / PoE

Installation
------------
1. Disassemble the device
2. Solder UART to pins VGRT right of the ethernet port
3. Connect UART console (3.3V)
4. Press Ctrl+b to stop in u-boot shell
5. Use `mtkload` to boot `openwrt-initramfs-kernel.bin` via tftp
6. Flash `openwrt-squashfs-sysupgrade.bin` via sysupgrade

Revert to OEM firmware
----------------------
1. Hold reset button while plugging in power
2. Configure host ethernet to 192.168.0.1/24
3. Go to http://192.168.0.254
4. Upload OEM firmware

MAC Addresses
-------------
LAN   : DC:62:79:xx:xx:28 (printed on label)
2.4GHz: DC:62:79:xx:xx:28
5GHz  : DC:62:79:xx:xx:29


Link: https://github.com/openwrt/openwrt/pull/22138

(cherry picked from commit 7449064f641a53ff494498432df7b768796e768e)