### PR TITLE
mediatek: dts: openwrt-one: Increase NAND SPI bus-width

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
+++ b/target/linux/mediatek/dts/mt7981b-openwrt-one.dts
@@ -306,6 +306,8 @@
 		compatible = "spi-nand";
 		reg = <0>;
 		spi-max-frequency = <52000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
 
 		spi-cal-enable;
 		spi-cal-mode = "read-data";


### PR DESCRIPTION
Enable Quad SPI with spi-tx-bus-width and spi-rx-bus-width.

On my board, without this change:

[    1.434495] ubi0: attaching mtd7
[    3.188692] ubi0: scanning is finished

With this change:

[    1.321608] ubi0: attaching mtd5
[    2.113752] ubi0: scanning is finished