### PR TITLE
rockchip/rk3576: fix uboot failure by disabling HS200 mode

### DIFF
--- a/package/boot/uboot-rockchip/patches/109-rk3576-uboot-emmc-stability-fix.patch
+++ b/package/boot/uboot-rockchip/patches/109-rk3576-uboot-emmc-stability-fix.patch
@@ -1,0 +1,11 @@
+--- a/arch/arm/dts/rk3576-generic.dts
++++ b/arch/arm/dts/rk3576-generic.dts
+@@ -25,7 +25,7 @@
+ &sdhci {
+ 	bus-width = <8>;
+ 	cap-mmc-highspeed;
+-	mmc-hs200-1_8v;
++	max-frequency = <52000000>;
+ 	no-sd;
+ 	no-sdio;
+ 	non-removable;


### PR DESCRIPTION
The u-boot emmc driver for the rk3576 platform seems to be unstable when it's in HS200 high speed mode, and it would frequently cause the kernel image fail to load with the following error:

  ** fs_devread read error - block
  Failed to load 'kernel.img'

After the failure, the uboot driver enters a broken state, and the device is inaccessible unless `mmc dev 0` is executed to refresh the state.

If the kernel is loaded successfully, it will operate in HS400 enhanced mode with 200MHz clock reliably, this suggests the issue is in uboot's emmc driver.

Disable HS200 mode and limit the frequency to 52MHz will make the kernel load reliably, once kernel is loaded, it will take over with it's own driver, so this will not affect the actual performacne.

For more details, see [#23491](https://github.com/openwrt/openwrt/issues/23491)

