### PR TITLE
dropbear: use only one key for initramfs boots

### DIFF
--- a/package/network/services/dropbear/files/dropbear.init
+++ b/package/network/services/dropbear/files/dropbear.init
@@ -113,9 +113,12 @@ hk_generate_as_needed()
 			# unsupported key type
 			rm -f "${kfile}"
 			continue
-		fi
+		else
+			chmod 0600 "${kfile}"
 
-		chmod 0600 "${kfile}"
+			# initramfs uses only one key
+			grep -q " /rom " /proc/mounts || break
+		fi
 	done
 
 	kgen=


### PR DESCRIPTION
Development on low end devices (like the Realtek RTL838x switch) can be a pain. Especially booting from initramfs takes ~80 seconds until network is available. Most of the time the device is occupied generating the dropbear SSH RSA key.

By checking for /rom mount point detect if the device is running an initramfs boot. In this case stop key generation loop after first key was generated successfully. This even works with tiny builds without Ed25519 support.

- Tiny build has no Ed25519 support. It still generates RSA keys.
- Other builds will only generate an Ed25519 key (within a second)

This takes down the initramfs boot times of RTL838x to ~42s. Other devices should improve too.