### PR TITLE
uboot-mediatek: fix malformed patch for Globitel BT-R320

### DIFF
--- a/package/boot/uboot-mediatek/patches/472-add-globitel-bt-r320.patch
+++ b/package/boot/uboot-mediatek/patches/472-add-globitel-bt-r320.patch
@@ -1,6 +1,6 @@
 --- /dev/null
 +++ b/arch/arm/dts/mt7981-globitel-bt-r320.dts
-@@ -0,0 +1,160 @@
+@@ -0,0 +1,158 @@
 +// SPDX-License-Identifier: GPL-2.0
 +
 +/dts-v1/;


### PR DESCRIPTION
fix filogic build fail
