### PR TITLE
procd: add support for no_new_privs parameter

### DIFF
--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -264,7 +264,7 @@ _procd_set_param() {
 			json_add_int "$type" $(kill -l "$1")
 		;;
 		pidfile|user|group|seccomp|capabilities|facility|\
-		extroot|overlaydir|tmpoverlaysize)
+		extroot|overlaydir|tmpoverlaysize|no_new_privs)
 			json_add_string "$type" "$1"
 		;;
 		stdout|stderr|no_new_privs)

--- a/package/system/procd/files/procd.sh
+++ b/package/system/procd/files/procd.sh
@@ -265,6 +265,11 @@ _procd_set_param() {
 		;;
 		pidfile|user|group|seccomp|capabilities|facility|\
 		extroot|overlaydir|tmpoverlaysize|no_new_privs)
+            case "$type" in
+				pidfile|user|group)
+					[ -z "$1" ] && { logger -p daemon.err "procd: $type cannot be empty"; return 1; }
+				;;
+			esac
 			json_add_string "$type" "$1"
 		;;
 		stdout|stderr|no_new_privs)


### PR DESCRIPTION
Allow setting the no_new_privs flag for service instances to improve security by preventing processes from gaining new privileges via execve.

