### PR TITLE
[25.12] ramips: mt76x8: add support for Cudy WR300 v1

### DIFF
--- a/target/linux/ramips/dts/mt7628an_cudy_wr300-v1.dts
+++ b/target/linux/ramips/dts/mt7628an_cudy_wr300-v1.dts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "cudy,wr300-v1", "mediatek,mt7628an-soc";
+	model = "Cudy WR300 v1";
+
+	aliases {
+		led-boot = &white_status;
+		led-running = &white_status;
+		led-failsafe = &red_status;
+		led-upgrade = &red_status;
+		label-mac-device = &ethernet;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&gpio 36 GPIO_ACTIVE_LOW>;
+		};
+
+		button-wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&gpio 38 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		red_status: red_status {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio 44 GPIO_ACTIVE_LOW>;
+		};
+
+		white_status: white_status {
+			function = LED_FUNCTION_STATUS;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&gpio 37 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <40000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0x30000>;
+				read-only;
+			};
+
+			partition@30000 {
+				label = "u-boot-env";
+				reg = <0x30000 0x10000>;
+				read-only;
+			};
+
+			partition@40000 {
+				label = "factory";
+				reg = <0x40000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x400>;
+					};
+				};
+			};
+
+			partition@50000 {
+				compatible = "denx,uimage";
+				label = "firmware";
+				reg = <0x50000 0x7a0000>;
+			};
+
+			partition@7f0000 {
+				label = "bdinfo";
+				reg = <0x7f0000 0x10000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					macaddr_bdinfo_de00: macaddr@de00 {
+						compatible = "mac-base";
+						reg = <0xde00 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+		};
+	};
+};
+
+&state_default {
+	gpio {
+		groups = "i2s", "refclk", "wdt", "wled_an";
+		function = "gpio";
+	};
+};
+
+&wmac {
+	status = "okay";
+
+	nvmem-cells = <&eeprom_factory_0>, <&macaddr_bdinfo_de00 1>;
+	nvmem-cell-names = "eeprom", "mac-address";
+};
+
+&ethernet {
+	nvmem-cells = <&macaddr_bdinfo_de00 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&esw {
+	mediatek,portmap = <0x4f>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -243,6 +243,15 @@ define Device/cudy_tr1200-v1
 endef
 TARGET_DEVICES += cudy_tr1200-v1
 
+define Device/cudy_wr300-v1
+  IMAGE_SIZE := 7808k
+  DEVICE_VENDOR := Cudy
+  DEVICE_MODEL := WR300
+  DEVICE_VARIANT := v1
+  SUPPORTED_DEVICES += cudy,wr300
+endef
+TARGET_DEVICES += cudy_wr300-v1
+
 define Device/cudy_wr1000
   IMAGE_SIZE := 7872k
   IMAGES += factory.bin

--- a/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/mt76x8/base-files/etc/board.d/02_network
@@ -127,6 +127,7 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"0:lan" "1:lan" "4:wan" "6@eth0"
 		;;
+	cudy,wr300-v1|\
 	hongdian,h8850-v20|\
 	keenetic,kn-1112|\
 	keenetic,kn-1212|\


### PR DESCRIPTION
Hardware:
 - SoC: MediaTek MT7628AN (MIPS 580MHz)
 - Flash: 8 MiB NOR
 - RAM: 64 MiB DDR2
 - WLAN: 2.4 GHz (MT7628)
 - Ethernet: 1x 10/100 Mbps WAN, 3x 10/100 LAN (MT7628)
 - Buttons: 1x Reset, 1x wps
 - LEDs: Front: 1x Red, 1x White
 - Serial console: unpopulated header, 115200 8n1
 - Power: 12v barrel

MAC addresses:
+---------+-------------------+-----------+
|         | MAC               | Algorithm |
+---------+-------------------+-----------+
| LAN/WAN | d4:0d:ab:xx:xx:x0 | label     |
| WLAN 2g | d4:0d:ab:xx:xx:x1 | label+1   |
+---------+-------------------+-----------+

Migration to OpenWrt:
- Download the RSA-signed intermediate firmware from the Cudy website: `openwrt-ramips-mt76x8-cudy_wr300-squashfs-flash.bin`
- Connect the computer to the LAN and flash the intermediate firmware via the OEM web interface
- OpenWrt is now accessible via 192.168.1.1

Revert to OEM firmware:
- Set up a TFTP server on IP 192.168.1.88 and connect to the WAN port (upper port)
- Provide the Cudy firmware as `recovery.bin` in the TFTP server
- Power on the device and hold the reset button immediately after the first LED blink
- The recovery process will start
- When the recovery process is done, OEM firmware is accessible via 192.168.10.1 again

General information:
- No possibility to load an initramfs image via U-Boot because there is no option to interrupt U-Boot


Link: https://github.com/openwrt/openwrt/pull/23426

(cherry picked from commit e892edd60f759b150f7ea771b3b0c9e462eb01b8)