### PR TITLE
mtd: fis: fix buffer overflow from negative memset size

### DIFF
--- a/package/system/mtd/src/fis.c
+++ b/package/system/mtd/src/fis.c
@@ -215,7 +215,7 @@ fis_remap(struct fis_part *old, int n_old, struct fis_part *new, int n_new)
 		memmove(desc, last, end - tmp);
 		if (desc < last) {
 			tmp = end - (last - desc) * sizeof(struct fis_image_desc);
-			memset(tmp, 0xff, tmp - end);
+			memset(tmp, 0xff, end - tmp);
 		}
 	}
 


### PR DESCRIPTION
## Problem

In `fis_remap()`, the memset to clear freed FIS descriptor slots uses `tmp - end` as the size argument. Since `tmp` is computed as `end - (positive_value)`, it is always less than `end`, making the subtraction negative.

When this negative value is implicitly cast to `size_t` (unsigned), it wraps to a very large number (e.g., `0xFFFFFF...`), causing a massive buffer overflow that corrupts memory and likely crashes the system.

## Fix

Swap the subtraction operands from `tmp - end` to `end - tmp`, which correctly yields the positive number of bytes that need to be cleared with `0xff`.

## Impact

This bug affects devices using RedBoot FIS (Flash Image System) partition tables. The overflow occurs during FIS partition remapping, which happens during sysupgrade on affected devices.