### PR TITLE
scripts/sign_images: fix infinite loop and variable name typo

### DIFF
--- a/scripts/sign_images.sh
+++ b/scripts/sign_images.sh
@@ -5,7 +5,7 @@ TOP_DIR="${TOP_DIR:-./bin/targets}"
 # key to sign images
 BUILD_KEY="${BUILD_KEY:-key-build}" # TODO unify naming?
 # remove other signatures (added e.g.  by buildbot)
-REMOVE_OTER_SIGNATURES="${REMOVE_OTER_SIGNATURES:-1}"
+REMOVE_OTHER_SIGNATURES="${REMOVE_OTHER_SIGNATURES:-1}"
 
 # find all sysupgrade images in TOP_DIR
 # factory images don't need signatures as non OpenWrt system doesn't check them anyway
@@ -13,9 +13,9 @@ for image in $(find $TOP_DIR -type f -name "*-sysupgrade.bin"); do
 	# check if image actually support metadata
 	if fwtool -i /dev/null "$image"; then
 		# remove all previous signatures
-		if [ -n "$REMOVE_OTER_SIGNATURES" ]; then
-			while [ "$?" = 0 ]; do
-				fwtool -t -s /dev/null "$image"
+		if [ -n "$REMOVE_OTHER_SIGNATURES" ]; then
+			while fwtool -t -s /dev/null "$image"; do
+				:
 			done
 		fi
 		# run same operation as build root does for signing


### PR DESCRIPTION
## Problem

The signature removal loop in `sign_images.sh` has a logic error that can cause an infinite loop:

```sh
if [ -n "$REMOVE_OTER_SIGNATURES" ]; then
    while [ "$?" = 0 ]; do
        fwtool -t -s /dev/null "$image"
    done
fi
```

Issues:
1. `$?` on the first iteration reflects the exit status of the `if fwtool -i` test on line 14, NOT the `fwtool -t -s` command inside the loop. So the first iteration always executes.
2. If `fwtool -t -s` always succeeds (which happens when there are signatures to strip), the loop works by accident. But if the tool has any edge case where it always returns 0, the loop never terminates.
3. The variable name `REMOVE_OTER_SIGNATURES` is a typo (missing 'H' in OTHER).

## Fix

1. Move the `fwtool` call into the `while` condition:
   ```sh
   while fwtool -t -s /dev/null "$image"; do :; done
   ```
   This is the idiomatic shell pattern for "run until failure" — the exit status is checked directly as the loop condition.

2. Fix the typo: `REMOVE_OTER_SIGNATURES` -> `REMOVE_OTHER_SIGNATURES`