### PR TITLE
tools/patch-image: fix incorrect munmap sizes

### DIFF
--- a/tools/patch-image/src/patch-cmdline.c
+++ b/tools/patch-image/src/patch-cmdline.c
@@ -76,7 +76,7 @@ int main(int argc, char **argv)
 	ret = 0;
 
 err3:
-	munmap((void *) ptr, len);
+	munmap((void *) ptr, search_space + CMDLINE_MAX);
 err2:
 	if (fd > 0)
 		close(fd);

--- a/tools/patch-image/src/patch-dtb.c
+++ b/tools/patch-image/src/patch-dtb.c
@@ -90,11 +90,11 @@ int main(int argc, char **argv)
 	ret = 0;
 
 err4:
-	munmap((void *) ptr, len);
+	munmap((void *) ptr, search_space + dtb_max_size);
 err3:
 	if (fd > 0)
 		close(fd);
-	munmap((void *) ptrdtb, len);
+	munmap((void *) ptrdtb, dtb_max_size);
 err2:
 	if (fddtb > 0)
 		close(fddtb);


### PR DESCRIPTION
## Problem

Both `patch-cmdline.c` and `patch-dtb.c` pass incorrect sizes to `munmap()`. The variable `len` is reused for a different purpose than the mmap size:

**patch-cmdline.c:**
- `mmap(0, search_space + CMDLINE_MAX, ...)` — maps `search_space + 512` bytes
- `munmap(ptr, len)` — unmaps `strlen(argv[2])` bytes (the cmdline string length)

**patch-dtb.c:**
- `mmap(0, search_space + dtb_max_size, ...)` for the kernel image
- `mmap(0, dtb_max_size, ...)` for the DTB file
- Both `munmap()` calls use `len` which is `s.st_size` (DTB file size)

Since the munmap size doesn't match the mmap size, only a partial unmap occurs, leaking the remainder of the mapping.

## Fix

Pass the correct sizes to `munmap()` matching the corresponding `mmap()` calls:
- `patch-cmdline.c`: `search_space + CMDLINE_MAX`
- `patch-dtb.c`: `search_space + dtb_max_size` for ptr, `dtb_max_size` for ptrdtb