### PR TITLE
mtd: check return values of lseek() and write() in mtd_write_buffer()

### DIFF
--- a/package/system/mtd/src/mtd.c
+++ b/package/system/mtd/src/mtd.c
@@ -183,8 +183,14 @@ int mtd_erase_block(int fd, int offset)
 
 int mtd_write_buffer(int fd, const char *buf, int offset, int length)
 {
-	lseek(fd, offset, SEEK_SET);
-	write(fd, buf, length);
+	if (lseek(fd, offset, SEEK_SET) != offset) {
+		fprintf(stderr, "Failed to seek MTD device: %s\n", strerror(errno));
+		return -1;
+	}
+	if (write(fd, buf, length) != length) {
+		fprintf(stderr, "Short write to MTD device\n");
+		return -1;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
## Problems

In `mtd_write_buffer()`, two `write(2)`-related return values are silently discarded:

1. **`lseek()` ignored**: A failed seek (e.g. `EBADF`, `ESPIPE`) followed by `write()` would silently write at the wrong offset — corrupting the MTD device at an unintended location.
2. **`write()` ignored**: A short write or I/O error returns 0 (success) to the caller, leading to silent data corruption with no indication.

## Fix

1. Check `lseek()` return value, print `strerror(errno)` to stderr and return -1 on failure.
2. Check `write()` return value, report short writes to stderr and return -1.

`errno.h` and `string.h` are already included in `mtd.c`.
