### PR TITLE
mtd: jffs2: add missing malloc NULL check

### DIFF
--- a/package/system/mtd/src/jffs2.c
+++ b/package/system/mtd/src/jffs2.c
@@ -242,6 +242,10 @@ int mtd_replace_jffs2(const char *mtd, int fd, int ofs, const char *filename)
 	mtdofs = ofs;
 
 	buf = malloc(erasesize);
+	if (!buf) {
+		fprintf(stderr, "Out of memory!\n");
+		return -1;
+	}
 	target_ino = 1;
 	if (!last_ino)
 		last_ino = 1;


### PR DESCRIPTION
## Problem

In `mtd_replace_jffs2()`, the return value of `malloc(erasesize)` is never checked. If the allocation fails, `buf` remains NULL and the subsequent `memcpy(buf + ofs, ...)` in `add_data()` will dereference NULL, causing a segfault during JFFS2 filesystem operations.

## Fix

Add a NULL check after `malloc()` and return -1 on allocation failure.