### PR TITLE
scripts/make-ipkg-dir: fix incorrect grep regex for control file filtering

### DIFF
--- a/scripts/make-ipkg-dir.sh
+++ b/scripts/make-ipkg-dir.sh
@@ -8,10 +8,10 @@ ARCH=$4
 WD=$(pwd)
 
 mkdir -p "$TARGET/CONTROL"
-grep '^[^(Version|Architecture)]' "$CONTROL" > "$TARGET/CONTROL/control"
-grep '^Maintainer' "$CONTROL" 2>&1 >/dev/null || \
+grep -v -e '^Version:' -e '^Architecture:' "$CONTROL" > "$TARGET/CONTROL/control"
+grep '^Maintainer' "$CONTROL" >/dev/null 2>&1 || \
         echo "Maintainer: LEDE Community <lede-dev@lists.infradead.org>" >> "$TARGET/CONTROL/control"
-grep '^Source' "$CONTROL" 2>&1 >/dev/null || {
+grep '^Source' "$CONTROL" >/dev/null 2>&1 || {
         pkgbase=$(echo "$WD" | sed -e "s|^$TOPDIR/||g")
         [ "$pkgbase" = "$WD" ] && src="N/A" || src="$BASE/$pkgbase"
         echo "Source: $src" >> "$TARGET/CONTROL/control"


### PR DESCRIPTION
## Problem

The regex `'^[^(Version|Architecture)]'` uses a character class `[^...]`, not alternation. Instead of excluding lines starting with "Version" or "Architecture", it excludes any line starting with one of these individual characters: `V`, `e`, `r`, `s`, `i`, `o`, `n`, `|`, `A`, `c`, `h`, `t`, `u`, `(`, `)`.

This incorrectly filters out many valid control file fields:
- `Source:` (starts with 's')
- `Section:` (starts with 'S' — actually OK since lowercase 's')
- `Installed-Size:` (starts with 'I' — OK, but 'i' is filtered)
- Any field starting with these common letters

This can lead to incomplete or malformed package control files during build.

## Fix

Use `grep -v -e '^Version:' -e '^Architecture:'` which correctly excludes only lines starting with the literal strings "Version:" or "Architecture:".

Also fix incorrect redirect order on subsequent grep checks: `2>&1 >/dev/null` (stderr goes to original stdout) is changed to `>/dev/null 2>&1` (both suppressed).