### PR TITLE
rockchip: enable maskrom button for NanoPi R5C/R5S

### DIFF
--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -151,7 +151,7 @@ define Device/friendlyarm_nanopi-r5c
   $(Device/rk3568)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R5C
-  DEVICE_PACKAGES := kmod-r8169 kmod-rtw88-8822ce rtl8822ce-firmware wpad-basic-mbedtls
+  DEVICE_PACKAGES := kmod-button-hotplug kmod-input-adc-keys kmod-r8169 kmod-rtw88-8822ce rtl8822ce-firmware wpad-basic-mbedtls
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r5c
 
@@ -159,7 +159,7 @@ define Device/friendlyarm_nanopi-r5s
   $(Device/rk3568)
   DEVICE_VENDOR := FriendlyARM
   DEVICE_MODEL := NanoPi R5S
-  DEVICE_PACKAGES := kmod-r8169
+  DEVICE_PACKAGES := kmod-button-hotplug kmod-input-adc-keys kmod-r8169
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r5s
 


### PR DESCRIPTION
The MASKROM button was added to the device tree for FriendlyELEC NanoPi R5C/R5S in Linux 6.17 in https://github.com/torvalds/linux/commit/07e04c071a35abe12957b575cd1453ccafc02eb6 ("arm64: dts: rockchip: Add maskrom button to NanoPi R5S + R5C").

Now that rockchip target has switched to 6.18 in 67740e311b8e ("rockchip: switch to kernel 6.18"), add `kmod-button-hotplug` and `kmod-input-adc-keys` to the default packages for NanoPi R5C/R5S
