### PR TITLE
ramips: add support for ELECOM WMC-C2533GST

### DIFF
--- a/target/linux/ramips/dts/mt7621_elecom_wmc-c2533gst.dts
+++ b/target/linux/ramips/dts/mt7621_elecom_wmc-c2533gst.dts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7621_elecom_wrc-gs-2pci.dtsi"
+
+/ {
+	compatible = "elecom,wmc-c2533gst", "mediatek,mt7621-soc";
+	model = "ELECOM WMC-C2533GST";
+};
+
+&partitions {
+	partition@50000 {
+		compatible = "denx,uimage";
+		label = "firmware";
+		reg = <0x50000 0x1800000>;
+	};
+
+	partition@1850000 {
+		label = "tm_pattern";
+		reg = <0x1850000 0x400000>;
+		read-only;
+	};
+
+	partition@1c50000 {
+		label = "tm_key";
+		reg = <0x1c50000 0x100000>;
+		read-only;
+	};
+
+	partition@1d50000 {
+		label = "nvram";
+		reg = <0x1d50000 0xb0000>;
+		read-only;
+	};
+
+	partition@1e00000 {
+		label = "user_data";
+		reg = <0x1e00000 0x200000>;
+		read-only;
+	};
+};
+
+&gmac0 {
+	nvmem-cells = <&macaddr_factory_fff4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&gmac1 {
+	nvmem-cells = <&macaddr_factory_fffa>;
+	nvmem-cell-names = "mac-address";
+};
+
+&factory {
+	nvmem-layout {
+		compatible = "fixed-layout";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		macaddr_factory_fff4: macaddr@fff4 {
+			reg = <0xfff4 0x6>;
+		};
+
+		macaddr_factory_fffa: macaddr@fffa {
+			reg = <0xfffa 0x6>;
+		};
+	};
+};

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -1279,6 +1279,14 @@ define Device/elecom_wrc-gs
   DEVICE_PACKAGES := kmod-mt7615-firmware -uboot-envtools
 endef
 
+define Device/elecom_wmc-c2533gst
+  $(Device/elecom_wrc-gs)
+  IMAGE_SIZE := 24576k
+  DEVICE_MODEL := WMC-C2533GST
+  ELECOM_HWNAME := WMC-2HC
+endef
+TARGET_DEVICES += elecom_wmc-c2533gst
+
 define Device/elecom_wmc-m1267gst2
   $(Device/elecom_wrc-gs)
   IMAGE_SIZE := 24576k


### PR DESCRIPTION

This adds support for the ELECOM WMC-C2533GST.

It shares the same basic hardware and 32 MiB SPI-NOR flash layout as the
already supported ELECOM WRC-2533GST2. The notable differences are that
the factory image uses the `WMC-2HC` hardware name, and the Ethernet MAC
addresses are stored at `factory` offsets `0xfff4` / `0xfffa`, matching
the WMC-M1267GST2 layout rather than the WRC-2533GST2 layout.

## Implementation notes

- Reuses `mt7621_elecom_wrc-gs-2pci.dtsi` for the shared MT7621A +
  2x MT7615 hardware.
- Reuses `Device/elecom_wrc-gs` for factory image generation.
- Uses `ELECOM_HWNAME := WMC-2HC`, verified from the stock firmware header
  and trailer.
- Keeps the WRC-2533GST2 32 MiB partition layout.
- Uses WMC-style Ethernet MAC offsets:
  - LAN: `factory` offset `0xfff4`
  - WAN: `factory` offset `0xfffa`

## Tested

Tested on an ELECOM WMC-C2533GST with stock firmware v1.26.

- Stock firmware image layout inspected and `WMC-2HC` hardware name verified.
- Factory image accepted by the stock Web UI.
- OpenWrt boot verified.
- Sysupgrade verified.
- RAM and SPI-NOR flash size verified.
- Partition layout verified against stock mtd dump.
- Ethernet MAC layout verified.
- 2.4 GHz and 5 GHz MT7615 radios detected.
- MT7615 firmware loading verified.
- Wi-Fi MAC layout verified from factory EEPROM data.
- LAN ports exposed as `lan1`-`lan4` and WAN as `wan`.
- LAN port connectivity verified.
- WAN DHCP/connectivity verified.
- 2.4 GHz and 5 GHz AP operation verified.
- GPIO LED manual control verified.
- Reset and WPS buttons verified.
- Router/AP slide switch GPIO behavior verified.
