### PR TITLE
image: fix per device targz rootfs wrong suffix and redundant images

### DIFF
--- a/include/image.mk
+++ b/include/image.mk
@@ -898,8 +898,12 @@ define Device/Build
     $$(call Device/Build/compile,$$(compile),$(1))))
 
   $$(eval $$(foreach image,$$(IMAGES), \
-    $$(foreach fs,$$(filter $(TARGET_FILESYSTEMS),$$(FILESYSTEMS)), \
+    $$(foreach fs,$$(filter $$(filter-out targz,$(TARGET_FILESYSTEMS)),$$(FILESYSTEMS)), \
       $$(call Device/Build/image,$$(fs),$$(image),$(1)))))
+
+  $(if $(CONFIG_TARGET_ROOTFS_TARGZ), \
+    IMAGE/rootfs.tar.gz := append-rootfs
+    $$(eval $$(call Device/Build/image,targz,rootfs.tar.gz,$(1))))
 
   $$(eval $$(foreach artifact,$$(ARTIFACTS), \
     $$(call Device/Build/artifact,$$(artifact),$(1))))


### PR DESCRIPTION
In commit d89cb72c23fea53883c1e6203020d9b555208452 , a new rootfs type "targz" was introduced, to correctly pack the rootfs AFTER `DEVICE_PACKAGES` installation (unlike the old simple `rootfs.tar.gz`) .

The expected release artifact shall be a single corresponding tar gz release accompanying or relacing the old simple `rootfs.tar.gz`.

However, if one take a look at the v25.12 series release download pages, e.g. [25.12.4/x86/64](https://downloads.openwrt.org/releases/25.12.4/targets/x86/64/), one could see that there're now four release artifacts related to rootfs targz:

- [generic-targz-combined-efi.img.gz](https://downloads.openwrt.org/releases/25.12.4/targets/x86/64/openwrt-25.12.4-x86-64-generic-targz-combined-efi.img.gz)
- [generic-targz-combined.img.gz](https://downloads.openwrt.org/releases/25.12.4/targets/x86/64/openwrt-25.12.4-x86-64-generic-targz-combined.img.gz)
- [generic-targz-rootfs.img.gz](https://downloads.openwrt.org/releases/25.12.4/targets/x86/64/openwrt-25.12.4-x86-64-generic-targz-rootfs.img.gz)
- [rootfs.tar.gz](https://downloads.openwrt.org/releases/25.12.4/targets/x86/64/openwrt-25.12.4-x86-64-rootfs.tar.gz)

It's obvious the new `targz` release actually reuses the same `TARGET_ROOTFS_{TYPE}` handler same as `squashfs`, `ext4` and alike. And the three `generic-targz` img.gz contains the same expected tar gz either as their second partition, or as the whole image. This could be verified by the following script:

```bash
URL_PARENT=https://downloads.openwrt.org/releases/25.12.4/targets/x86/64/openwrt-25.12.4-x86-64-
for TYPE in combined-efi combined rootfs; do
        curl -L "${URL_PARENT}generic-targz-${TYPE}.img.gz" | gzip -cd > "${TYPE}.img"
done
for TYPE in combined-efi combined; do
        INFO=$(sfdisk -d "${TYPE}.img" | sed -n 's/^'"${TYPE}.img"'2 : start= \+\([0-9]\+\), size= \+\([0-9]\+\),.\+.\+$/\1 \2/p')
        dd if="${TYPE}.img" of="${TYPE}.tar.gz" bs=512 skip="${INFO%% *}" count="${INFO##* }"
done
cp rootfs.img rootfs.tar.gz
sha256sum combined-efi.tar.gz combined.tar.gz rootfs.tar.gz
file rootfs.tar.gz
```

Output:
```log
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
100 13.12M 100 13.12M   0      0 194.6M      0                              0
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
100 12.93M 100 12.93M   0      0 190.9M      0                              0
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
100  7.13M 100  7.13M   0      0 257.6M      0                              0
GPT PMBR size mismatch (246304 != 246334) will be corrected by write.
The backup GPT table is corrupt, but the primary appears OK, so that will be used.
The backup GPT table is not on the end of the device.
212992+0 records in
212992+0 records out
109051904 bytes (109 MB, 104 MiB) copied, 0.258064 s, 423 MB/s
212992+0 records in
212992+0 records out
109051904 bytes (109 MB, 104 MiB) copied, 0.261621 s, 417 MB/s
18b98d3562dc3067ae095ee44d4ff3158cf84e89063c3df66c0ef6638922ba71  combined-efi.tar.gz
18b98d3562dc3067ae095ee44d4ff3158cf84e89063c3df66c0ef6638922ba71  combined.tar.gz
18b98d3562dc3067ae095ee44d4ff3158cf84e89063c3df66c0ef6638922ba71  rootfs.tar.gz
rootfs.tar.gz: gzip compressed data, max compression, from Unix, original size modulo 2^32 0
```

The checksum of the extracted, actually expected .tar.gz are all same. And if we peek inside its content, it's indeed what we expected:

```
> tar -tzf rootfs.tar.gz
./
./bin/
./bin/ash
./bin/board_detect
./bin/busybox
./bin/cat
./bin/chgrp
./bin/chmod
./bin/chown
./bin/config_generate
./bin/cp
./bin/date
...
```

A disk image with a `tar.gz` as its second partiton doesn't boot anyway and I doubt if there's any mechanic to make it bootable. So `generic-targz-combined-efi.img.gz` and `generic-targz-combined.img.gz` are not needed at all, and `generic-targz-rootfs.img.gz` shall be renamed to have a `tar.gz` suffix instead.

Therefore work around this by skipping creating images for fs `targz` in the general loop, and only create the rootfs.tar.gz later for `targz` "fs"

This affects both the real builder and imagebuilder. I've tested this with multiple imagebuilders.

Tested with `openwrt-imagebuilder-25.12.4-mvebu-cortexa53.Linux-x86_64`:

```sh
rm -rf bin && make image PROFILE=generic
```

Without the fix:

```
> tree bin/
bin/
└── targets
    └── x86
        └── 64
            ├── openwrt-25.12.4-x86-64-generic.bom.cdx.json
            ├── openwrt-25.12.4-x86-64-generic-ext4-combined-efi.img.gz
            ├── openwrt-25.12.4-x86-64-generic-ext4-combined.img.gz
            ├── openwrt-25.12.4-x86-64-generic-ext4-rootfs.img.gz
            ├── openwrt-25.12.4-x86-64-generic-kernel.bin
            ├── openwrt-25.12.4-x86-64-generic.manifest
            ├── openwrt-25.12.4-x86-64-generic-rootfs.tar.gz
            ├── openwrt-25.12.4-x86-64-generic-squashfs-combined-efi.img.gz
            ├── openwrt-25.12.4-x86-64-generic-squashfs-combined.img.gz
            ├── openwrt-25.12.4-x86-64-generic-squashfs-rootfs.img.gz
            ├── openwrt-25.12.4-x86-64-generic-targz-combined-efi.img.gz
            ├── openwrt-25.12.4-x86-64-generic-targz-combined.img.gz
            ├── openwrt-25.12.4-x86-64-generic-targz-rootfs.img.gz
            ├── profiles.json
            └── sha256sums
```

With the fix:
```
> tree bin/
bin/
└── targets
    └── x86
        └── 64
            ├── openwrt-25.12.4-x86-64-generic.bom.cdx.json
            ├── openwrt-25.12.4-x86-64-generic-ext4-combined-efi.img.gz
            ├── openwrt-25.12.4-x86-64-generic-ext4-combined.img.gz
            ├── openwrt-25.12.4-x86-64-generic-ext4-rootfs.img.gz
            ├── openwrt-25.12.4-x86-64-generic-kernel.bin
            ├── openwrt-25.12.4-x86-64-generic.manifest
            ├── openwrt-25.12.4-x86-64-generic-rootfs.tar.gz
            ├── openwrt-25.12.4-x86-64-generic-squashfs-combined-efi.img.gz
            ├── openwrt-25.12.4-x86-64-generic-squashfs-combined.img.gz
            ├── openwrt-25.12.4-x86-64-generic-squashfs-rootfs.img.gz
            ├── openwrt-25.12.4-x86-64-generic-targz-rootfs.tar.gz
            ├── profiles.json
            └── sha256sums
```

And with `openwrt-imagebuilder-25.12.4-mvebu-cortexa53.Linux-x86_64`:

```sh
rm -rf bin && make image PROFILE=ripe_atlas-v5
```

Without the fix:
```
> tree bin/
bin/
└── targets
    └── mvebu
        └── cortexa53
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5.bom.cdx.json
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5-ext4-sdcard.img.gz
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5.manifest
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5-rootfs.tar.gz
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5-squashfs-sdcard.img.gz
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5-targz-sdcard.img.gz
            ├── profiles.json
            └── sha256sums
```

With the fix:
```
> tree bin/
bin/
└── targets
    └── mvebu
        └── cortexa53
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5.bom.cdx.json
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5-ext4-sdcard.img.gz
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5.manifest
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5-rootfs.tar.gz
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5-squashfs-sdcard.img.gz
            ├── openwrt-25.12.4-mvebu-cortexa53-ripe_atlas-v5-targz-rootfs.tar.gz
            ├── profiles.json
            └── sha256sums
```
