### PR TITLE
realtek: add support for NicGiga S100-0800S-M

### DIFF
--- a/target/linux/realtek/dts/rtl9303_nicgiga_s100-0800s-m.dts
+++ b/target/linux/realtek/dts/rtl9303_nicgiga_s100-0800s-m.dts
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "nicgiga,s100-0800s-m", "realtek,rtl930x-soc";
+	model = "NicGiga S100-0800S-M";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* first 256 MiB */
+		      <0x20000000 0x10000000>; /* remaining 256 MiB */
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		/* One green LED per SFP cage, lit on link + activity at any speed. */
+		led_set0 = <(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_5G | RTL93XX_LED_SET_2P5G |
+			     RTL93XX_LED_SET_1G | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_10M |
+			     RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)>;
+	};
+
+	i2c_gpio {
+		compatible = "i2c-gpio";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-gpio,delay-us = <2>;
+		scl-gpios = <&gpio0 22 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 23 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+
+		gpioexp0: i2c@38 {
+			reg = <0x38>;
+			compatible = "nxp,pca9534";
+			gpio-controller;
+			#gpio-cells = <2>;
+		};
+	};
+
+	/*
+	 * The related TP-Link TL-ST1008F v2 (same RTL9303 reference design)
+	 * routes the SFP cage MOD_ABS lines to gpio0 pins 0-7, but on this
+	 * board those pins read stuck-low under OpenWrt (an empty cage still
+	 * reads "present"), and the PCA9534 expander is fully consumed by
+	 * TX_DISABLE. No mod-def0-gpio is therefore wired up; module presence
+	 * is instead detected by polling the SFP EEPROM over I2C, which also
+	 * handles runtime hot-insertion and removal.
+	 */
+	sfp0: sfp-p1 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+		tx-disable-gpio = <&gpioexp0 0 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2900>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp1: sfp-p2 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+		tx-disable-gpio = <&gpioexp0 1 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp2: sfp-p3 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c2>;
+		tx-disable-gpio = <&gpioexp0 2 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp3: sfp-p4 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c3>;
+		tx-disable-gpio = <&gpioexp0 3 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp4: sfp-p5 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c4>;
+		tx-disable-gpio = <&gpioexp0 4 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2000>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp5: sfp-p6 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c5>;
+		tx-disable-gpio = <&gpioexp0 5 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp6: sfp-p7 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c6>;
+		tx-disable-gpio = <&gpioexp0 6 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <1500>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	sfp7: sfp-p8 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c7>;
+		tx-disable-gpio = <&gpioexp0 7 GPIO_ACTIVE_HIGH>;
+		maximum-power-milliwatt = <2900>;
+		#thermal-sensor-cells = <0>;
+	};
+
+	watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
+		hw_algo = "toggle";
+		hw_margin_ms = <1200>;
+		always-running;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+
+	/* SDA0-7 correspond to GPIO9-16 */
+	i2c0: i2c@0 { reg = <0>; };
+	i2c1: i2c@1 { reg = <1>; };
+	i2c2: i2c@2 { reg = <2>; };
+	i2c3: i2c@3 { reg = <3>; };
+	i2c4: i2c@4 { reg = <4>; };
+	i2c5: i2c@5 { reg = <5>; };
+	i2c6: i2c@6 { reg = <6>; };
+	i2c7: i2c@7 { reg = <7>; };
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <100000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0 0xe0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0xe0000 0x10000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+
+					macaddr_ubootenv_ethaddr: ethaddr {
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@f0000 {
+				label = "u-boot-env2";
+				reg = <0xf0000 0x10000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "jffs2-cfg";
+				reg = <0x100000 0x100000>;
+			};
+
+			partition@200000 {
+				label = "jffs2-log";
+				reg = <0x200000 0x100000>;
+			};
+
+			partition@300000 {
+				compatible = "openwrt,uimage", "denx,uimage";
+				reg = <0x300000 0x1d00000>;
+				label = "firmware";
+				openwrt,ih-magic = <0x93030000>;
+			};
+		};
+	};
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		SWITCH_PORT_SFP(0, 1, 2, 0, 0)
+		SWITCH_PORT_SFP(8, 2, 3, 0, 1)
+		SWITCH_PORT_SFP(16, 3, 4, 0, 2)
+		SWITCH_PORT_SFP(20, 4, 5, 0, 3)
+		SWITCH_PORT_SFP(24, 5, 6, 0, 4)
+		SWITCH_PORT_SFP(25, 6, 7, 0, 5)
+		SWITCH_PORT_SFP(26, 7, 8, 0, 6)
+		SWITCH_PORT_SFP(27, 8, 9, 0, 7)
+
+		port@1c {
+			ethernet = <&ethernet0>;
+			reg = <28>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 1>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port8 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 2>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port16 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 3>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port20 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 4>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port24 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 5>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port25 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 6>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port26 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 7>;
+	nvmem-cell-names = "mac-address";
+};
+
+&port27 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 8>;
+	nvmem-cell-names = "mac-address";
+};
+
+&thermal_zones {
+	sfp-thermal {
+		polling-delay-passive = <10000>;
+		polling-delay = <10000>;
+		thermal-sensors = <&sfp0>, <&sfp1>, <&sfp2>, <&sfp3>, <&sfp4>, <&sfp5>, <&sfp6>, <&sfp7>;
+		trips {
+			sfp-crit {
+				temperature = <110000>;
+				hysteresis = <1000>;
+				type = "critical";
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -97,6 +97,17 @@ define Device/horaco_zx-swtgw2c8f
 endef
 TARGET_DEVICES += horaco_zx-swtgw2c8f
 
+define Device/nicgiga_s100-0800s-m
+  SOC := rtl9303
+  UIMAGE_MAGIC := 0x93030000
+  DEVICE_VENDOR := NicGiga
+  DEVICE_MODEL := S100-0800S-M
+  DEVICE_PACKAGES := kmod-gpio-pca953x
+  IMAGE_SIZE := 29696k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += nicgiga_s100-0800s-m
+
 define Device/plasmacloud-common
   SOC := rtl9302
   UIMAGE_MAGIC := 0x93000000


### PR DESCRIPTION
## Summary

Adds support for the NicGiga S100-0800S-M, an 8-port 10G SFP+ managed switch
built on the Realtek RTL9303 reference design.

This joins the other RTL93xx-based 8xSFP+ devices already in tree
(`tplink_tl-st1008f-v2`, `ubnt_usw-aggregation`, `vimin_vm-s100-0800ms`,
`xikestor_sks8300-8x`, `xikestor_sks8310-8x`), each of which routes the SFP
cage sideband signals differently. This board is notable in routing none of
them to a software-visible GPIO source (see below); no target-wide changes
are needed.

## Hardware

| | |
|---|---|
| SoC | Realtek RTL9303 |
| RAM | 512 MiB DDR3 |
| Flash | 32 MiB SPI-NOR |
| Network | 8x 1G/10G SFP+ (SerDes 2-9) |
| GPIO expander | 1x PCA9534 on bit-banged i2c-gpio, used for TX_DISABLE |
| Buttons | 1x reset (gpio-keys, BTN_0/1/2 strap inputs) |
| Console | Front-panel RJ45 console port (Cisco-style pinout), 115200 8N1 |
| Bootloader | Realtek-flavoured U-Boot (vendor) |

## SFP presence detection

The TL-ST1008F v2 reference DTS in tree drives each cage's `mod-def0-gpio`
from `gpio0` pins 0-7. On this board those pins are stuck low, so a
verbatim copy of the TP-Link DTS makes the sfp driver believe every cage
is populated and spam `-EIO` on the empty ones at boot.

This board only fits a single PCA9534 (8-bit) expander on a bit-banged
i2c-gpio bus, and it is fully consumed by `tx-disable` -- one pin per cage.
There is no available GPIO source for `mod-def0`, `los`, or `tx-fault`.
By contrast the recently-added Ubiquiti UniFi USW Aggregation (same
RTL9303, same 8x SFP+ cage count) routes all four sideband signals per
cage through two PCA9555s on the hardware i2c master -- a more capable
but more expensive board layout.

Consequence on this device:

- The DTS omits `mod-def0-gpio`, `los-gpio` and `tx-fault-gpio` on all
  eight cages and keeps only `i2c-bus` and `tx-disable-gpio`. With no
  mod-def0 hint, the sfp driver falls back to I2C-poll presence
  detection, which is silent on empty cages.
- Modules must be present at boot for the cage's sfp state machine to
  initialise. Pulling and reseating a module in a cage that was populated
  at boot is detected and relinks normally.
- Runtime hot-insertion into a previously-empty cage is not detected
  until the next reboot.

**Known limitation, not a hardware limit:** the vendor firmware hot-swaps
cages (including fresh insertion into a previously-empty cage) without
issue, so presence detection is clearly achievable on this hardware. The
hot-plug gap above is a limitation of the current OpenWrt support, and is
being investigated separately (whether `gpio0` 0-7 can be driven as
working MOD_ABS inputs via a different pinmux, or whether the mainline sfp
I2C-poll path can detect insertions on empty-at-boot cages). The DTS as
submitted is correct and `-EIO`-free for the present-at-boot case.

## Tested

- Boots from flash after `sysupgrade -n`; U-Boot is untouched and TFTP
  recovery from the U-Boot prompt remains available.
- All eight SFP+ ports link at 10GBASE-R (SR optics) and 10GBASE-CR
  (passive DAC).
- DSA VLAN configuration through UCI/`bridge-vlan` works end-to-end
  (default untagged VLAN + additional tagged VLANs on all eight ports).
- Empty cages produce no `-EIO` spam during operation (single one-shot
  burst at boot only, identical to the TL-ST1008F v2 baseline).

## Backing up vendor firmware (recommended)

NicGiga does not publish stock firmware downloads, and `sysupgrade -n`
overwrites the `firmware` mtd partition. If you ever want to revert to
vendor firmware, dump the flash from the RAM-booted initramfs **before**
running `sysupgrade`:

```
cat /proc/mtd                                    # note the partition layout
mkdir -p /tmp/oem
for d in /dev/mtd[0-9]; do cat "$d" > /tmp/oem/$(basename "$d").bin; done
tar czf /tmp/oem-backup.tar.gz -C /tmp oem
sha256sum /tmp/oem-backup.tar.gz                 # note this hash
```

Copy `oem-backup.tar.gz` off the device (`scp` from a second machine,
since the initramfs has no outbound `scp` client) and re-verify the
sha256 on the destination. Keep the `u-boot` partition dump with the
rest -- you will not rewrite it during a stock restore, but having it
preserves a complete recovery image.

To restore vendor firmware later, RAM-boot the initramfs again, copy
the saved `mtd5.bin` (or whichever partition `/proc/mtd` labels
`firmware`) back onto the device, then:

```
mtd write /tmp/mtd5.bin firmware
reboot
```

Do **not** write `u-boot` or `u-boot-env`.

## Installation

1. Connect to the front-panel RJ45 console port (115200 8N1, Cisco-style
   pinout) and interrupt the vendor U-Boot.
2. Bring up the network and TFTP-boot the OpenWrt initramfs image:

   ```
   rtk network on
   setenv ipaddr 192.168.1.1
   setenv serverip <tftp-server-ip>
   tftpboot 0x82000000 openwrt-realtek-rtl930x-nicgiga_s100-0800s-m-initramfs-kernel.bin
   bootm 0x82000000
   ```

3. From the running initramfs, copy the sysupgrade image onto the device
   (`scp` from another host, or `tftp -g -r` if the initramfs has a tftp
   client) and flash it:

   ```
   sysupgrade -n openwrt-realtek-rtl930x-nicgiga_s100-0800s-m-squashfs-sysupgrade.bin
   ```

   `-n` skips config carry-over (there is no prior OpenWrt config on a
   first install).

## Recovery

`sysupgrade` only rewrites the `firmware` partition. U-Boot and its
environment are untouched, so the TFTP-boot step above always works as a
recovery path regardless of the state of the firmware partition.


