### PR TITLE
airoha: Fix max RX size configuration

### DIFF
--- a/target/linux/airoha/patches-6.12/920-13-net-airoha-Rework-MTU-configuration.patch
+++ b/target/linux/airoha/patches-6.12/920-13-net-airoha-Rework-MTU-configuration.patch
@@ -155,7 +155,7 @@ Signed-off-by: Lorenzo Bianconi <lorenzo@kernel.org>
  #define AIROHA_MAX_DSA_PORTS		7
  #define AIROHA_MAX_NUM_RSTS		3
  #define AIROHA_MAX_MTU			9220
-+#define AIROHA_MAX_RX_SIZE		16383
++#define AIROHA_MAX_RX_SIZE		16128
  #define AIROHA_MAX_PACKET_SIZE		2048
  #define AIROHA_NUM_QOS_CHANNELS		4
  #define AIROHA_NUM_QOS_QUEUES		8


### PR DESCRIPTION
Set max RX size configuration (AIROHA_MAX_RX_SIZE) to 0x3f00.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
