### PR TITLE
system: fix stale /etc/TZ symlink and invert timezone logic

### DIFF
--- a/package/base-files/files/etc/init.d/system
+++ b/package/base-files/files/etc/init.d/system
@@ -21,11 +21,13 @@ system_config() {
 
 	echo "$hostname" > /proc/sys/kernel/hostname
 	[ -z "$conloglevel" -a -z "$buffersize" ] || dmesg ${conloglevel:+-n $conloglevel} ${buffersize:+-s $buffersize}
-	echo "$timezone" > /tmp/TZ
-	[ -n "$zonename" ] && [ -f "/usr/share/zoneinfo/${zonename// /_}" ] \
-		&& ln -sf "/usr/share/zoneinfo/${zonename// /_}" /tmp/localtime \
-		&& rm -f /tmp/TZ
-
+	if [ -n "$zonename" ] && [ -f "/usr/share/zoneinfo/${zonename// /_}" ]; then
+		ln -sf "/usr/share/zoneinfo/${zonename// /_}" /tmp/localtime
+		rm -f /tmp/TZ
+	else
+		echo "$timezone" > /tmp/TZ
+		rm -f /tmp/localtime
+	fi
 	# apply timezone to kernel
 	hwclock -u --systz
 }


### PR DESCRIPTION
Rewrite timezone setup in system_config to eliminate the write-then- delete pattern that left `/tmp/TZ` absent when a valid zoneinfo file was found, causing `/etc/TZ` -> `/tmp/TZ` to become a dead symlink.

Related fix in dnsmasq init: https://github.com/openwrt/openwrt/pull/23588