### PR TITLE
Realtek rtl9310 gpio fixes

### DIFF
--- a/target/linux/realtek/dts/rtl9312_plasmacloud_common.dtsi
+++ b/target/linux/realtek/dts/rtl9312_plasmacloud_common.dtsi
@@ -27,7 +27,7 @@
 
 	gpio-restart {
 		compatible = "gpio-restart";
-		gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+		gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 	};
 
 	keys {
@@ -48,9 +48,9 @@
 		pinctrl-0 = <&pinmux_disable_spi0>;
 
 		i2c-bus = <&i2c0>;
-		los-gpio = <&gpio0 8 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 9 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+		los-gpio = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 17 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 18 GPIO_ACTIVE_HIGH>;
 	};
 
 	sfp1: sfp-lan26 {
@@ -61,25 +61,25 @@
 			    <&pinmux_disable_spi0_cs1>;
 		i2c-bus = <&i2c1>;
 
-		los-gpio = <&gpio0 11 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 12 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		los-gpio = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 20 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 22 GPIO_ACTIVE_HIGH>;
 	};
 
 	sfp2: sfp-lan27 {
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c2>;
-		los-gpio = <&gpio0 21 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 22 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio0 23 GPIO_ACTIVE_HIGH>;
+		los-gpio = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 15 GPIO_ACTIVE_HIGH>;
 	};
 
 	sfp3: sfp-lan28 {
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c3>;
-		los-gpio = <&gpio0 24 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 25 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio0 26 GPIO_ACTIVE_HIGH>;
+		los-gpio = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+		mod-def0-gpio = <&gpio0 1 GPIO_ACTIVE_LOW>;
+		tx-disable-gpio = <&gpio0 2 GPIO_ACTIVE_HIGH>;
 	};
 
 	leds {
@@ -91,7 +91,7 @@
 		led_status: led-0 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
-			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
 		};
 
 		led-1 {

--- a/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
+++ b/target/linux/realtek/dts/rtl9313_xikestor_sks8300-12x-v1.dts
@@ -34,7 +34,7 @@
 
 		button-reset {
 			label = "reset";
-			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};
@@ -43,7 +43,7 @@
 		compatible = "gpio-leds";
 
 		led_sys: led-0 {
-			gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_STATUS;
 		};
@@ -74,8 +74,8 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		sda-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
-		scl-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+		sda-gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+		scl-gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
 
 		i2c-gpio,delay-us = <5>;	/* ~100 kHz */
 		lm75: sensor@4f {

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12f.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12f.dts
@@ -17,7 +17,7 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c0>;
 		los-gpio = <&gpio1 10 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 3 GPIO_ACTIVE_LOW>;
+		mod-def0-gpio = <&gpio0 27 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 0 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 36 GPIO_ACTIVE_HIGH>;
 	};
@@ -26,7 +26,7 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c1>;
 		los-gpio = <&gpio1 11 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 4 GPIO_ACTIVE_LOW>;
+		mod-def0-gpio = <&gpio0 28 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 1 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 21 GPIO_ACTIVE_HIGH>;
 	};
@@ -35,7 +35,7 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c2>;
 		los-gpio = <&gpio1 12 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 25 GPIO_ACTIVE_LOW>;
+		mod-def0-gpio = <&gpio0 1 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 2 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 22 GPIO_ACTIVE_HIGH>;
 	};
@@ -44,7 +44,7 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c3>;
 		los-gpio = <&gpio1 13 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 6 GPIO_ACTIVE_LOW>;
+		mod-def0-gpio = <&gpio0 30 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 3 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 23 GPIO_ACTIVE_HIGH>;
 	};
@@ -53,7 +53,7 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c4>;
 		los-gpio = <&gpio1 14 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 7 GPIO_ACTIVE_LOW>;
+		mod-def0-gpio = <&gpio0 31 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 4 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 	};
@@ -62,7 +62,7 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c5>;
 		los-gpio = <&gpio1 34 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 29 GPIO_ACTIVE_LOW>;
+		mod-def0-gpio = <&gpio0 5 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 5 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 25 GPIO_ACTIVE_HIGH>;
 	};
@@ -71,7 +71,7 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c6>;
 		los-gpio = <&gpio1 33 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 31 GPIO_ACTIVE_LOW>;
+		mod-def0-gpio = <&gpio0 7 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 6 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 26 GPIO_ACTIVE_HIGH>;
 	};
@@ -80,7 +80,7 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c7>;
 		los-gpio = <&gpio1 32 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		mod-def0-gpio = <&gpio0 18 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 7 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 27 GPIO_ACTIVE_HIGH>;
 	};
@@ -89,7 +89,7 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c8>;
 		los-gpio = <&gpio1 31 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 11 GPIO_ACTIVE_LOW>;
+		mod-def0-gpio = <&gpio0 19 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 8 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 28 GPIO_ACTIVE_HIGH>;
 	};
@@ -98,7 +98,7 @@
 		compatible = "sff,sfp";
 		i2c-bus = <&i2c9>;
 		los-gpio = <&gpio1 30 GPIO_ACTIVE_HIGH>;
-		mod-def0-gpio = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		mod-def0-gpio = <&gpio0 20 GPIO_ACTIVE_LOW>;
 		tx-disable-gpio = <&gpio1 9 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&gpio1 29 GPIO_ACTIVE_HIGH>;
 	};

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-12hp.dts
@@ -17,7 +17,7 @@
 		led_poe_max: led-7 {
 			color = <LED_COLOR_ID_RED>;
 			function = "poe-usage";
-			gpios = <&gpio0 3 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 27 GPIO_ACTIVE_LOW>;
 		};
 	};
 };
@@ -39,8 +39,8 @@
 	realtek,led-set1-force-port-mask = <0x00000000 0x00000800>;
 };
 
-&led_sys_green { gpios = <&gpio0 23 GPIO_ACTIVE_LOW>; };
-&led_sys_red { gpios = <&gpio0 0 GPIO_ACTIVE_LOW>; };
+&led_sys_green { gpios = <&gpio0 15 GPIO_ACTIVE_LOW>; };
+&led_sys_red { gpios = <&gpio0 24 GPIO_ACTIVE_LOW>; };
 
 &gpio0 {
 	poe_enable_hog {

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930-aqr813.dtsi
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930-aqr813.dtsi
@@ -12,8 +12,8 @@
 / {
 	sfp_gpio_mux: gpio-mux {
 		compatible = "gpio-mux";
-		mux-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>,
-			    <&gpio0 14 GPIO_ACTIVE_HIGH>;
+		mux-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>,
+			    <&gpio0 22 GPIO_ACTIVE_HIGH>;
 		#mux-control-cells = <0>;
 		idle-state = <MUX_IDLE_AS_IS>;
 	};
@@ -24,7 +24,7 @@
 		#gpio-cells = <2>;
 
 		mux-controls = <&sfp_gpio_mux>;
-		muxed-gpio = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		muxed-gpio = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 
 		gpio-line-names = "SFP1_LOS", "SFP1_MOD_ABS", "SFP1_TX_FAULT";
 		gpio-line-mux-states = <0>, <1>, <3>;
@@ -36,7 +36,7 @@
 		#gpio-cells = <2>;
 
 		mux-controls = <&sfp_gpio_mux>;
-		muxed-gpio = <&gpio0 27 GPIO_ACTIVE_HIGH>;
+		muxed-gpio = <&gpio0 3 GPIO_ACTIVE_HIGH>;
 
 		gpio-line-names = "SFP2_LOS", "SFP2_MOD_ABS", "SFP2_TX_FAULT";
 		gpio-line-mux-states = <0>, <1>, <3>;
@@ -47,7 +47,7 @@
 		i2c-bus = <&i2c0>;
 		los-gpio = <&sfp1_gpio 0 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&sfp1_gpio 1 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpio = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&sfp1_gpio 2 GPIO_ACTIVE_HIGH>;
 	};
 
@@ -56,7 +56,7 @@
 		i2c-bus = <&i2c1>;
 		los-gpio = <&sfp2_gpio 0 GPIO_ACTIVE_HIGH>;
 		mod-def0-gpio = <&sfp2_gpio 1 GPIO_ACTIVE_LOW>;
-		tx-disable-gpio = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+		tx-disable-gpio = <&gpio0 19 GPIO_ACTIVE_HIGH>;
 		tx-fault-gpio = <&sfp2_gpio 2 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
+++ b/target/linux/realtek/dts/rtl9313_zyxel_xs1930.dtsi
@@ -31,7 +31,7 @@
 
 		key-restore {
 			label = "restore";
-			gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 4 GPIO_ACTIVE_LOW>;
 			linux,code = <BTN_0>;
 		};
 	};
@@ -44,40 +44,40 @@
 		led_sys_green: led-0 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_INDICATOR;
-			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_sys_red: led-1 {
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_INDICATOR;
-			gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 6 GPIO_ACTIVE_HIGH>;
 		};
 
 		led_pwr_green: led-2 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = LED_FUNCTION_POWER;
-			gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 			default-state = "on";
 		};
 		led_pwr_red: led-3 {
 			color = <LED_COLOR_ID_RED>;
 			function = LED_FUNCTION_POWER;
-			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 		};
 		led_cloud_green: led-4 {
 			color = <LED_COLOR_ID_GREEN>;
 			function = "cloud";
-			gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
 		};
 		led_cloud_red: led-5 {
 			color = <LED_COLOR_ID_RED>;
 			function = "cloud";
-			gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 1 GPIO_ACTIVE_LOW>;
 		};
 		led_locator: led-6 {
 			color = <LED_COLOR_ID_BLUE>;
 			function = "locator";
-			gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 		};
 	};
 
@@ -96,7 +96,7 @@
 
 	fan0: gpio-fan {
 		compatible = "gpio-fan";
-		gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
 
 		gpio-fan,speed-map =
 			<3600 0>,

--- a/target/linux/realtek/patches-6.18/030-01-gpio-realtek-otto-rtl9310-set-ports-reversed.patch
+++ b/target/linux/realtek/patches-6.18/030-01-gpio-realtek-otto-rtl9310-set-ports-reversed.patch
@@ -1,0 +1,49 @@
+From: Carlo Szelinsky <github@szelinsky.de>
+Date: Fri, 15 May 2026 19:00:00 +0200
+Subject: [PATCH] gpio: realtek-otto: set GPIO_PORTS_REVERSED on RTL9310
+
+The realtek,rtl9310-gpio of_match entry was added without any flags, so
+the driver drives the RTL9310 GPIO block through the byte-swapped access
+path (GPIO_GENERIC_BIG_ENDIAN_BYTE_ORDER / ioread32be). That is wrong:
+the RTL9310 register map has the same byte order as the RTL9300, which
+already carries GPIO_PORTS_REVERSED.
+
+Per the Realtek RTL9310 SoC register map, the data, direction and pin-
+function registers pack one byte per port with port A in the high byte:
+
+  PABCD_CNR (0x00) / PABCD_DIR (0x08) / PABCD_DAT (0x0c):
+    port A = bits 31:24, B = 23:16, C = 15:8, D = 7:0
+
+With native register access GPIO line N is bit N, so lines 24..31 are
+port A, 16..23 port B, 8..15 port C, 0..7 port D. The byte-swapped path
+the missing flag selects reverses the byte order and statically maps
+every line to the wrong port.
+
+Add GPIO_PORTS_REVERSED to the RTL9310 of_match entry, mirroring RTL9300.
+
+The existing in-tree RTL9310 boards (XikeStor SKS8300-12X, Zyxel
+XS1930-*, Plasmacloud ESX28/PSX28, Linksys LGS352C) were brought up
+against the byte-swapped mapping and encode compensated gpio0 line
+numbers in their device trees. They must be re-checked on hardware:
+under the corrected mapping each gpio0 line N moves to
+8 * (3 - N / 8) + N % 8 (a port-nibble swap, its own inverse).
+
+Verified on RTL9313 (Hasivo S1300WP-8XGT-4S+), where the i2c-gpio bus
+reuses the JTAG pins (physically port A pins 3/4) and only resolves to
+the correct pins with the flag set.
+
+Signed-off-by: Carlo Szelinsky <github@szelinsky.de>
+---
+ drivers/gpio/gpio-realtek-otto.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/drivers/gpio/gpio-realtek-otto.c
++++ b/drivers/gpio/gpio-realtek-otto.c
+@@ -350,6 +350,7 @@ static const struct of_device_id realtek
+ 	},
+ 	{
+ 		.compatible = "realtek,rtl9310-gpio",
++		.data = (void *)GPIO_PORTS_REVERSED,
+ 	},
+ 	{
+ 		.compatible = "realtek,rtl9607-gpio",

--- a/target/linux/realtek/patches-6.18/030-02-gpio-realtek-otto-rtl9310-clear-cnr-on-request.patch
+++ b/target/linux/realtek/patches-6.18/030-02-gpio-realtek-otto-rtl9310-clear-cnr-on-request.patch
@@ -1,0 +1,122 @@
+From: Carlo Szelinsky <github@szelinsky.de>
+Date: Fri, 15 May 2026 19:00:00 +0200
+Subject: [PATCH] gpio: realtek-otto: clear CNR on gpio_request for RTL9310
+
+The RTL9310 GPIO block has a Pin Function Control register (CNR) at
+offset 0x00 that selects, per pin, between GPIO mode (bit clear) and a
+dedicated peripheral function (bit set):
+
+  PABCD_CNR (0x00): port A = bits 31:24, B = 23:16, C = 15:8, D = 7:0
+
+Pins can power on in peripheral mode (for example the JTAG pin range on
+port A), leaving the line inaccessible to the GPIO framework even after
+the SoC-level pinmux (pinctrl-single) releases the higher-level function.
+The driver already defines REALTEK_GPIO_REG_CNR but never touches it.
+
+Add request/free callbacks, gated by a new GPIO_HAS_CNR flag, that clear
+the pin's CNR bit on gpio_request and restore it on free. Set GPIO_HAS_CNR
+only for realtek,rtl9310-gpio; RTL9300 carries the same register but has
+worked for years without touching it, so leave its behaviour unchanged.
+
+Verified on RTL9313 (Hasivo S1300WP-8XGT-4S+): the bit-banged i2c bus on
+the JTAG pins (port A pins 3/4) only becomes usable once CNR is cleared,
+in addition to the pinmux_disable_jtag DT reference.
+
+Signed-off-by: Carlo Szelinsky <github@szelinsky.de>
+---
+ drivers/gpio/gpio-realtek-otto.c | 47 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 47 insertions(+)
+
+--- a/drivers/gpio/gpio-realtek-otto.c
++++ b/drivers/gpio/gpio-realtek-otto.c
+@@ -68,6 +68,7 @@ struct realtek_gpio_ctrl {
+ 	struct gpio_generic_chip chip;
+ 	void __iomem *base;
+ 	void __iomem *cpumask_base;
++	unsigned int dev_flags;
+ 	struct cpumask cpu_irq_maskable;
+ 	raw_spinlock_t lock;
+ 	u8 intr_mask[REALTEK_GPIO_MAX];
+@@ -96,6 +97,11 @@ enum realtek_gpio_flags {
+ 	 * range, where the per-cpu enable masks are located.
+ 	 */
+ 	GPIO_INTERRUPTS_PER_CPU = BIT(2),
++	/*
++	 * Has a CNR (pin function control) register at offset 0x00.
++	 * Pins default to peripheral mode and must be switched to GPIO mode.
++	 */
++	GPIO_HAS_CNR = BIT(3),
+ };
+ 
+ static struct realtek_gpio_ctrl *irq_data_to_ctrl(struct irq_data *data)
+@@ -333,6 +339,40 @@ static const struct irq_chip realtek_gpi
+ 	GPIOCHIP_IRQ_RESOURCE_HELPERS,
+ };
+ 
++static int realtek_gpio_request(struct gpio_chip *gc, unsigned int offset)
++{
++	struct realtek_gpio_ctrl *ctrl = gpiochip_get_data(gc);
++	unsigned long flags;
++	u32 cnr;
++
++	if (!(ctrl->dev_flags & GPIO_HAS_CNR))
++		return 0;
++
++	raw_spin_lock_irqsave(&ctrl->lock, flags);
++	cnr = ctrl->bank_read(ctrl->base + REALTEK_GPIO_REG_CNR);
++	cnr &= ~BIT(offset);
++	ctrl->bank_write(ctrl->base + REALTEK_GPIO_REG_CNR, cnr);
++	raw_spin_unlock_irqrestore(&ctrl->lock, flags);
++
++	return 0;
++}
++
++static void realtek_gpio_free(struct gpio_chip *gc, unsigned int offset)
++{
++	struct realtek_gpio_ctrl *ctrl = gpiochip_get_data(gc);
++	unsigned long flags;
++	u32 cnr;
++
++	if (!(ctrl->dev_flags & GPIO_HAS_CNR))
++		return;
++
++	raw_spin_lock_irqsave(&ctrl->lock, flags);
++	cnr = ctrl->bank_read(ctrl->base + REALTEK_GPIO_REG_CNR);
++	cnr |= BIT(offset);
++	ctrl->bank_write(ctrl->base + REALTEK_GPIO_REG_CNR, cnr);
++	raw_spin_unlock_irqrestore(&ctrl->lock, flags);
++}
++
+ static const struct of_device_id realtek_gpio_of_match[] = {
+ 	{
+ 		.compatible = "realtek,otto-gpio",
+@@ -350,7 +390,7 @@ static const struct of_device_id realtek
+ 	},
+ 	{
+ 		.compatible = "realtek,rtl9310-gpio",
+-		.data = (void *)GPIO_PORTS_REVERSED,
++		.data = (void *)(GPIO_PORTS_REVERSED | GPIO_HAS_CNR),
+ 	},
+ 	{
+ 		.compatible = "realtek,rtl9607-gpio",
+@@ -379,6 +419,8 @@ static int realtek_gpio_probe(struct pla
+ 
+ 	dev_flags = (unsigned int) device_get_match_data(dev);
+ 
++	ctrl->dev_flags = dev_flags;
++
+ 	ngpios = REALTEK_GPIO_MAX;
+ 	device_property_read_u32(dev, "ngpios", &ngpios);
+ 
+@@ -423,6 +465,11 @@ static int realtek_gpio_probe(struct pla
+ 	ctrl->chip.gc.ngpio = ngpios;
+ 	ctrl->chip.gc.owner = THIS_MODULE;
+ 
++	if (dev_flags & GPIO_HAS_CNR) {
++		ctrl->chip.gc.request = realtek_gpio_request;
++		ctrl->chip.gc.free = realtek_gpio_free;
++	}
++
+ 	irq = platform_get_irq_optional(pdev, 0);
+ 	if (!(dev_flags & GPIO_INTERRUPTS_DISABLED) && irq > 0) {
+ 		girq = &ctrl->chip.gc.irq;

--- a/target/linux/realtek/patches-6.18/030-03-gpio-realtek-otto-rtl9310-use-port-keyed-imr.patch
+++ b/target/linux/realtek/patches-6.18/030-03-gpio-realtek-otto-rtl9310-use-port-keyed-imr.patch
@@ -1,0 +1,81 @@
+From: Carlo Szelinsky <github@szelinsky.de>
+Date: Fri, 15 May 2026 19:00:00 +0200
+Subject: [PATCH] gpio: realtek-otto: use port-keyed IMR position on RTL9310
+
+The interrupt mask registers are packed differently from the data
+registers on RTL9310. Per the SoC register map the two 2-bit-per-pin
+mask registers split A/B and C/D by half-word:
+
+  PAB_IMR (0x14): port A = bits 31:16, port B = bits 15:0
+  PCD_IMR (0x18): port C = bits 31:16, port D = bits 15:0
+
+The data registers number line 0..15 as ports D/C and line 16..31 as
+ports B/A (see GPIO_PORTS_REVERSED), so the matching mask slots are:
+lines 0..15 in PCD_IMR and lines 16..31 in PAB_IMR. The driver's default
+reversed formula (2 * line) selects the opposite register, the mask never
+reaches the hardware and the IRQ count stays at 0.
+
+Add a port-keyed position helper, (2 * line) ^ 32, gated behind a new
+GPIO_IMR_PORT_KEYED flag set only for realtek,rtl9310-gpio. The XOR flips
+the PAB_IMR <-> PCD_IMR selection (bit 5 of the 64-bit mask position)
+without changing the within-register shift, matching the layout above.
+
+Verified on RTL9313 (Hasivo S1300WP-8XGT-4S+): an SFP+ mod-def0 line on
+port B pin 3 (line 19) delivered no interrupt before this change and
+fires correctly after.
+
+Signed-off-by: Carlo Szelinsky <github@szelinsky.de>
+---
+ drivers/gpio/gpio-realtek-otto.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+--- a/drivers/gpio/gpio-realtek-otto.c
++++ b/drivers/gpio/gpio-realtek-otto.c
+@@ -102,6 +102,16 @@ enum realtek_gpio_flags {
+ 	 * Pins default to peripheral mode and must be switched to GPIO mode.
+ 	 */
+ 	GPIO_HAS_CNR = BIT(3),
++	/*
++	 * IMR registers are port-keyed [BA, DC] even when the line numbering
++	 * is byte-reversed. IMR_AB (offset 0x14) stores [port B | port A]
++	 * masks (port B in the low half), IMR_CD (0x18) stores
++	 * [port D | port C]. Lines 16..31 (ports B/A) live in IMR_AB and
++	 * lines 0..15 (ports D/C) live in IMR_CD; the simple "2 * line"
++	 * formula picks the wrong register. Empirically verified on
++	 * RTL9313 only - set this flag per chip after testing.
++	 */
++	GPIO_IMR_PORT_KEYED = BIT(4),
+ };
+ 
+ static struct realtek_gpio_ctrl *irq_data_to_ctrl(struct irq_data *data)
+@@ -160,6 +170,11 @@ static unsigned int realtek_gpio_line_im
+ 	return 2 * line;
+ }
+ 
++static unsigned int realtek_gpio_line_imr_pos_port_keyed(unsigned int line)
++{
++	return (2 * line) ^ 32;
++}
++
+ static void realtek_gpio_clear_isr(struct realtek_gpio_ctrl *ctrl, u32 mask)
+ {
+ 	ctrl->bank_write(ctrl->base + REALTEK_GPIO_REG_ISR, mask);
+@@ -390,7 +405,7 @@ static const struct of_device_id realtek
+ 	},
+ 	{
+ 		.compatible = "realtek,rtl9310-gpio",
+-		.data = (void *)(GPIO_PORTS_REVERSED | GPIO_HAS_CNR),
++		.data = (void *)(GPIO_PORTS_REVERSED | GPIO_HAS_CNR | GPIO_IMR_PORT_KEYED),
+ 	},
+ 	{
+ 		.compatible = "realtek,rtl9607-gpio",
+@@ -448,6 +463,9 @@ static int realtek_gpio_probe(struct pla
+ 		ctrl->line_imr_pos = realtek_gpio_line_imr_pos_swapped;
+ 	}
+ 
++	if (dev_flags & GPIO_IMR_PORT_KEYED)
++		ctrl->line_imr_pos = realtek_gpio_line_imr_pos_port_keyed;
++
+ 	config = (struct gpio_generic_chip_config) {
+ 		.dev = dev,
+ 		.sz = 4,


### PR DESCRIPTION
RTL9310/9313 GPIO fixes

While bringing up a Hasivo S1300WP-8XGT-4S+ (RTL9313) I ran into what looks like a long-standing issue: the `realtek,rtl9310-gpio` match entry seems to be missing the `GPIO_PORTS_REVERSED` flag that the RTL9300 entry has. As far as I can tell from the Realtek RTL9310 register map, the two chips share the same reversed byte layout, so this looks like an oversight,  but I'd really appreciate a second opinion from people who know this driver better.

The series has three small driver changes:

1. add the missing `GPIO_PORTS_REVERSED` flag;
2. clear the per-pin function-control register (CNR) on request, so pins that boot in peripheral mode (e.g. the JTAG range) can be used as GPIO; This is especially for my S1300WP the case... 
3. use a port-keyed interrupt-mask position, which is what made GPIO interrupts fire on my board.

My main worry: changing the byte order shifts the line-to-pin mapping for **every** RTL9310 board, so the last commit re-maps the `gpio0` line numbers in the other in-tree boards' device trees (Zyxel XS1930, XikeStor, Plasmacloud). Those numbers are derived from the register map, not tested on hardware: I don't have those devices, so I'd really need their owners to confirm before this can be trusted. I left the Linksys LGS352C alone because its gpio0 lines live in a dtsi shared with the RTL9300 LGS328C, which I'm not sure how to handle cleanly.  Suggestions welcome :-)

Everything here is verified only on the one board I have. Happy to split, rework, or drop pieces based on what you think.

CC @plappermaul @jonasjelonek @svanheule @ecsv @namiltd 