### PR TITLE
dnsmasq: mount /etc/localtime in jail when zoneinfo is available

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -1278,7 +1278,12 @@ dnsmasq_start()
 	procd_add_jail_mount $CONFIGFILE $DHCPBOGUSHOSTNAMEFILE $DHCPSCRIPT $DHCPSCRIPT_DEPENDS
 	procd_add_jail_mount $EXTRA_MOUNT $RFC6761FILE $TRUSTANCHORSFILE
 	procd_add_jail_mount $dnsmasqconffile $dnsmasqconfdir $resolvdir $user_dhcpscript
-	procd_add_jail_mount /etc/passwd /etc/group /etc/TZ /etc/hosts /etc/ethers
+	procd_add_jail_mount /etc/passwd /etc/group /etc/hosts /etc/ethers
+	if [ -e /etc/localtime ]; then
+		procd_add_jail_mount /etc/localtime
+	elif [ -e /etc/TZ ]; then
+		procd_add_jail_mount /etc/TZ
+	fi
 	procd_add_jail_mount_rw /var/run/dnsmasq/ $leasefile
 	case "$logfacility" in */*)
 		[ ! -e "$logfacility" ] && touch "$logfacility"


### PR DESCRIPTION
`/etc/TZ` is a symlink to `/tmp/TZ`, which is only written by the system init script when no valid zoneinfo file is found. When a zonename is configured, `/tmp/TZ` is removed in favor of /tmp/localtime pointing to the correct zoneinfo file, leaving `/etc/TZ` a dead symlink.

Fix the jail mount to prefer `/etc/localtime` when it exists, falling back to `/etc/TZ` otherwise. This matches the precedence logic in the system init script and ensures dnsmasq always has timezone context inside the jail.

Related fix in system init: https://github.com/openwrt/openwrt/pull/23586