### PR TITLE
realtek: mdio: skip over ethernet-phy-package nodes

### DIFF
--- a/target/linux/realtek/files-6.18/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/mdio/mdio-realtek-otto.c
@@ -749,6 +749,18 @@ static int rtmd_get_phy_info(struct rtmd_ctrl *ctrl, int pn, struct rtmd_phy_inf
 	return 0;
 }
 
+static struct fwnode_handle *rtmd_get_bus_node(struct fwnode_handle *phynode)
+{
+	struct fwnode_handle *parent = fwnode_get_parent(phynode);
+
+	if (parent && fwnode_name_eq(parent, "ethernet-phy-package")) {
+		struct fwnode_handle *grandparent = fwnode_get_parent(parent);
+		fwnode_handle_put(parent);
+		return grandparent;
+	}
+	return parent;
+}
+
 static int rtmd_838x_setup_ctrl(struct rtmd_ctrl *ctrl)
 {
 	/*
@@ -1007,7 +1019,7 @@ static int rtmd_map_ports(struct device *dev)
 		if (smi_addr >= PHY_MAX_ADDR)
 			return dev_err_probe(dev, -EINVAL, "%pfwP illegal phy address\n", fw_phy);
 
-		struct fwnode_handle *fw_bus __free(fwnode_handle) = fwnode_get_parent(fw_phy);
+		struct fwnode_handle *fw_bus __free(fwnode_handle) = rtmd_get_bus_node(fw_phy);
 		if (!fw_bus || fwnode_property_read_u32(fw_bus, "reg", &smi_bus))
 			return dev_err_probe(dev, -EINVAL, "%pfwP no bus number\n",
 					     fw_bus ?: fw_phy);


### PR DESCRIPTION
When we look up the PHY for each switch port, we traverse to the parent node to find the corresponding MDIO bus. This approach breaks down when an explicit `ethernet-phy-package` node is used to bundle multiple PHYs in the same chip.

This is for example going to be necessary when setting up RTL8224s with start addresses not aligned to multiples of 4 - 
there, we can explicitly define a `ethernet-phy-package` node with the appropriate base reg and make it work.

@plappermaul since you originally wrote this, what do you think about this approach? Another option would be to just walk up the tree with `fwnode_for_each_parent_node` and go hunt for an mdio bus node. 