### PR TITLE
ramips: mt76x8: add support for Xiaomi RC04

### DIFF
--- a/target/linux/ramips/dts/mt7628an_xiaomi_rc04.dts
+++ b/target/linux/ramips/dts/mt7628an_xiaomi_rc04.dts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+
+#include "mt7628an_xiaomi_mi-ra75.dts"
+
+/ {
+	compatible = "xiaomi,mi-wifi-range-extender-ac1200-rc04", "xiaomi,mira75", "mediatek,mt7628an-soc";
+	model = "Xiaomi Mi AC1200 WLAN Range Extender RC04";
+};
+
+/* Override the EEPROM layout size to accommodate the MT7613BE radio chip data */
+&eeprom_factory_8000 {
+	reg = <0x8000 0x4da8>;
+};

--- a/target/linux/ramips/image/mt76x8.mk
+++ b/target/linux/ramips/image/mt76x8.mk
@@ -1474,6 +1474,16 @@ define Device/xiaomi_mi-ra75
 endef
 TARGET_DEVICES += xiaomi_mi-ra75
 
+define Device/xiaomi_rc04
+  $(Device/xiaomi_mi-ra75)
+  DEVICE_VENDOR := Xiaomi
+  DEVICE_MODEL := MiWiFi Range Extender AC1200
+  DEVICE_VARIANT := RC04
+  DEVICE_PACKAGES := $(filter-out kmod-mt76x2,$(DEVICE_PACKAGES)) kmod-mt7615e kmod-mt7663-firmware-ap
+  SUPPORTED_DEVICES := xiaomi,mi-wifi-range-extender-ac1200-rc04
+endef
+TARGET_DEVICES += xiaomi_rc04
+
 define Device/yuncore_cpe200
   IMAGE_SIZE := 7872k
   DEVICE_VENDOR := Yuncore


### PR DESCRIPTION
The Xiaomi Mi WiFi Range Extender AC1200 (RC04) is a newer hardware revision of the RA75. The devices are physically identical on the outside, but the RC04 replaces the 5GHz MT7612EN Wi-Fi chip with an MT7613BE.

This patch adds a new device profile for the RC04 that inherits from the RA75 but replaces kmod-mt76x2 with kmod-mt7615e and the corresponding mt7663 firmware to ensure 5GHz functionality. The required device tree is also included.