### PR TITLE
mediatek: add support for Haolian HL3020P

### DIFF
--- a/target/linux/mediatek/dts/mt7981b-haolian-hl3020p-leds.dts
+++ b/target/linux/mediatek/dts/mt7981b-haolian-hl3020p-leds.dts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+#include "mt7981b-haolian-hl3020p.dts"
+
+/ {
+	model = "Haolian HL3020P-LEDS";
+	compatible = "haolian,hl3020p-leds", "mediatek,mt7981";
+
+	aliases {
+		led-boot = &led_panel_power;
+		led-failsafe = &led_panel_power;
+		led-running = &led_panel_power;
+		led-upgrade = &led_panel_power;
+	};
+
+	leds {
+		/delete-node/ led-0;
+		/delete-node/ led-1;
+		/delete-node/ led-2;
+		/delete-node/ led-3;
+		/delete-node/ led-4;
+		/delete-node/ led-5;
+		/delete-node/ led-6;
+		/delete-node/ led-7;
+		/delete-node/ led-8;
+
+		wlan-5g {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+		};
+
+		wan-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_panel_power: power {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		p0 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <0>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		p2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		p3 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		wan-blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		wlan-2g {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+		};
+
+		mesh {
+			color = <LED_COLOR_ID_BLUE>;
+			function = "mesh";
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-haolian-hl3020p-rgb.dts
+++ b/target/linux/mediatek/dts/mt7981b-haolian-hl3020p-rgb.dts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+#include "mt7981b-haolian-hl3020p.dts"
+
+/ {
+	model = "Haolian HL3020P-RGB";
+	compatible = "haolian,hl3020p-rgb", "mediatek,mt7981";
+
+	aliases {
+		led-boot = &led_rgb_blue;
+		led-failsafe = &led_rgb_blue;
+		led-running = &led_rgb_blue;
+		led-upgrade = &led_rgb_blue;
+	};
+
+	leds {
+		/delete-node/ led-0;
+		/delete-node/ led-1;
+		/delete-node/ led-2;
+		/delete-node/ led-3;
+		/delete-node/ led-4;
+		/delete-node/ led-5;
+		/delete-node/ led-6;
+		/delete-node/ led-7;
+		/delete-node/ led-8;
+
+		led_rgb_blue: rgb-blue {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		rgb-green {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		rgb-red {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/mediatek/dts/mt7981b-haolian-hl3020p.dts
+++ b/target/linux/mediatek/dts/mt7981b-haolian-hl3020p.dts
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+
+/dts-v1/;
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+#include "mt7981b.dtsi"
+
+/ {
+	model = "Haolian HL3020P";
+	compatible = "haolian,hl3020p", "mediatek,mt7981";
+
+	aliases {
+		label-mac-device = &gmac1;
+
+		led-boot = &led_power_blue;
+		led-failsafe = &led_power_blue;
+		led-running = &led_power_blue;
+		led-upgrade = &led_power_blue;
+
+		serial0 = &uart0;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		rootdisk = <&ubi_fit_volume>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		button-0 {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&pio 0 GPIO_ACTIVE_LOW>;
+			debounce-interval = <60>;
+		};
+
+		button-1 {
+			label = "reset";
+			gpios = <&pio 1 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+			debounce-interval = <60>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-0 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WLAN_5GHZ;
+			gpios = <&pio 5 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy1tpt";
+		};
+
+		led-1 {
+			color = <LED_COLOR_ID_RED>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 6 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_power_blue: led-2 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_POWER;
+			gpios = <&pio 7 GPIO_ACTIVE_LOW>;
+		};
+
+		led-3 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <1>;
+			gpios = <&pio 9 GPIO_ACTIVE_LOW>;
+		};
+
+		led-4 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <2>;
+			gpios = <&pio 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led-5 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_LAN;
+			function-enumerator = <3>;
+			gpios = <&pio 11 GPIO_ACTIVE_LOW>;
+		};
+
+		led-6 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WAN;
+			gpios = <&pio 12 GPIO_ACTIVE_LOW>;
+		};
+
+		led-7 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = LED_FUNCTION_WLAN_2GHZ;
+			gpios = <&pio 34 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "phy0tpt";
+		};
+
+		led-8 {
+			color = <LED_COLOR_ID_BLUE>;
+			function = "mesh";
+			gpios = <&pio 35 GPIO_ACTIVE_LOW>;
+		};
+	};
+};
+
+&eth {
+	status = "okay";
+
+	gmac0: mac@0 {
+		compatible = "mediatek,eth-mac";
+		reg = <0>;
+		phy-mode = "2500base-x";
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 (-1)>;
+
+		fixed-link {
+			speed = <2500>;
+			full-duplex;
+			pause;
+		};
+	};
+
+	gmac1: mac@1 {
+		compatible = "mediatek,eth-mac";
+		reg = <1>;
+		phy-mode = "gmii";
+		phy-handle = <&int_gbe_phy>;
+
+		nvmem-cell-names = "mac-address";
+		nvmem-cells = <&macaddr_factory_4 (-2)>;
+	};
+};
+
+&mdio_bus {
+	switch: switch@1f {
+		compatible = "mediatek,mt7531";
+		reg = <0x1f>;
+		reset-gpios = <&pio 39 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0_flash_pins>;
+	status = "okay";
+
+	/* Production hardware uses a 128 MiB SPI-NAND. */
+	spi_nand@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+
+		spi-max-frequency = <52000000>;
+		spi-tx-buswidth = <4>;
+		spi-rx-buswidth = <4>;
+
+		spi-cal-enable;
+		spi-cal-mode = "read-data";
+		spi-cal-datalen = <7>;
+		spi-cal-data = /bits/ 8 <0x53 0x50 0x49 0x4e 0x41 0x4e 0x44>;
+		spi-cal-addrlen = <5>;
+		spi-cal-addr = /bits/ 32 <0x0 0x0 0x0 0x0 0x0>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "BL2";
+				reg = <0x0 0x100000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "u-boot-env";
+				reg = <0x100000 0x80000>;
+				read-only;
+			};
+
+			partition@180000 {
+				label = "Factory";
+				reg = <0x180000 0x200000>;
+				read-only;
+
+				nvmem-layout {
+					compatible = "fixed-layout";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					eeprom_factory_0: eeprom@0 {
+						reg = <0x0 0x1000>;
+					};
+
+					macaddr_factory_4: macaddr@4 {
+						compatible = "mac-base";
+						reg = <0x4 0x6>;
+						#nvmem-cell-cells = <1>;
+					};
+				};
+			};
+
+			partition@380000 {
+				label = "FIP";
+				reg = <0x380000 0x200000>;
+				read-only;
+			};
+
+			partition@580000 {
+				label = "ubi";
+				reg = <0x580000 0x7a80000>;
+				compatible = "linux,ubi";
+
+				volumes {
+					ubi_fit_volume: ubi-volume-fit {
+						volname = "fit";
+					};
+
+					ubi_ubootenv: ubi-volume-ubootenv {
+						volname = "ubootenv";
+					};
+
+					ubi_ubootenv2: ubi-volume-ubootenv2 {
+						volname = "ubootenv2";
+					};
+				};
+			};
+		};
+	};
+};
+
+&switch {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			label = "lan0";
+		};
+
+		port@1 {
+			reg = <1>;
+			label = "lan1";
+		};
+
+		port@2 {
+			reg = <2>;
+			label = "lan2";
+		};
+
+		port@3 {
+			reg = <3>;
+			label = "lan3";
+		};
+
+		port@6 {
+			reg = <6>;
+			ethernet = <&gmac0>;
+			phy-mode = "2500base-x";
+
+			fixed-link {
+				speed = <2500>;
+				full-duplex;
+				pause;
+			};
+		};
+	};
+};
+
+&pio {
+	spi0_flash_pins: spi0-pins {
+		mux {
+			function = "spi";
+			groups = "spi0", "spi0_wp_hold";
+		};
+
+		conf-pu {
+			pins = "SPI0_CS", "SPI0_HOLD", "SPI0_WP";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-up = <MTK_PUPD_SET_R1R0_11>;
+		};
+
+		conf-pd {
+			pins = "SPI0_CLK", "SPI0_MOSI", "SPI0_MISO";
+			drive-strength = <MTK_DRIVE_8mA>;
+			bias-pull-down = <MTK_PUPD_SET_R1R0_11>;
+		};
+	};
+};
+
+&uart0 {
+	status = "okay";
+};
+
+&usb_phy {
+	status = "okay";
+};
+
+&watchdog {
+	status = "okay";
+};
+
+&wifi {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	nvmem-cell-names = "eeprom";
+	nvmem-cells = <&eeprom_factory_0>;
+
+	ieee80211-freq-limit = <2400000 2500000>, <5170000 5835000>;
+
+	band@0 {
+		reg = <0>;
+		nvmem-cells = <&macaddr_factory_4 (0)>;
+		nvmem-cell-names = "mac-address";
+	};
+
+	band@1 {
+		reg = <1>;
+		nvmem-cells = <&macaddr_factory_4 (1)>;
+		nvmem-cell-names = "mac-address";
+	};
+};
+
+&xhci {
+	status = "okay";
+};

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/01_leds
@@ -233,6 +233,27 @@ routerich,ax3000-ubootmod)
 	ucidef_set_led_netdev "wan" "wan" "blue:wan" "wan" "link tx rx"
 	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "wan" "link"
 	;;
+haolian,hl3020p-leds)
+	ucidef_set_led_default "power" "Power" "blue:power" "1"
+	ucidef_set_led_netdev "wlan2g" "2.4G Wi-Fi" "blue:wlan-2ghz" "phy0-ap0" "link"
+	ucidef_set_led_netdev "wlan5g" "5G Wi-Fi" "blue:wlan-5ghz" "phy1-ap0" "link"
+	ucidef_set_led_netdev "p0" "P0 Link" "blue:lan-0" "lan0" "link"
+	ucidef_set_led_netdev "p2" "P2 Link" "blue:lan-2" "lan2" "link"
+	ucidef_set_led_netdev "p3" "P3 Link" "blue:lan-3" "lan3" "link"
+	;;
+haolian,hl3020p-rgb)
+	;;
+haolian,hl3020p)
+	ucidef_set_led_default "power" "Power" "blue:power" "1"
+	ucidef_set_led_netdev "wlan2g" "2.4G Wi-Fi" "blue:wlan-2ghz" "phy0-ap0" "link"
+	ucidef_set_led_netdev "wlan5g" "5G Wi-Fi" "red:wlan-5ghz" "phy1-ap0" "link"
+	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link"
+	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-2" "lan2" "link"
+	ucidef_set_led_netdev "lan-3" "lan-3" "blue:lan-3" "lan3" "link"
+	ucidef_set_led_netdev "wan" "wan" "blue:wan" "eth1" "link"
+	ucidef_set_led_netdev "wan-off" "wan-off" "red:wan" "eth1" "link"
+	ucidef_set_led_default "mesh" "Mesh" "blue:mesh" "0"
+	;;
 routerich,ax3000-v1)
 	ucidef_set_led_netdev "lan-1" "lan-1" "blue:lan-1" "lan1" "link tx rx"
 	ucidef_set_led_netdev "lan-2" "lan-2" "blue:lan-2" "lan2" "link tx rx"

--- a/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
+++ b/target/linux/mediatek/filogic/base-files/etc/board.d/02_network
@@ -8,6 +8,11 @@ mediatek_setup_interfaces()
 	local board="$1"
 
 	case $board in
+	haolian,hl3020p|\
+	haolian,hl3020p-rgb|\
+	haolian,hl3020p-leds)
+		ucidef_set_interfaces_lan_wan "lan0 lan1 lan2 lan3" eth1
+		;;
 	abt,asr3000|\
 	buffalo,wsr-6000ax8|\
 	cmcc,rax3000m|\

--- a/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
+++ b/target/linux/mediatek/filogic/base-files/lib/upgrade/platform.sh
@@ -155,6 +155,9 @@ platform_do_upgrade() {
 	cudy,wr3000p-v1-ubootmod|\
 	gatonetworks,gdsp|\
 	h3c,magic-nx30-pro|\
+	haolian,hl3020p|\
+	haolian,hl3020p-rgb|\
+	haolian,hl3020p-leds|\
 	imou,hx21|\
 	jcg,q30-pro|\
 	jdcloud,re-cp-03|\

--- a/target/linux/mediatek/image/filogic.mk
+++ b/target/linux/mediatek/image/filogic.mk
@@ -2914,6 +2914,77 @@ define Device/routerich_ax3000-v1
 endef
 TARGET_DEVICES += routerich_ax3000-v1
 
+define Device/haolian_hl3020p
+  DEVICE_VENDOR := Haolian
+  DEVICE_MODEL := HL3020P
+  DEVICE_DTS := mt7981b-haolian-hl3020p
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware kmod-usb3 \
+	mt7981-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
+	append-metadata
+endef
+TARGET_DEVICES += haolian_hl3020p
+
+define Device/haolian_hl3020p-rgb
+  DEVICE_VENDOR := Haolian
+  DEVICE_MODEL := HL3020P
+  DEVICE_VARIANT := RGB
+  DEVICE_DTS := mt7981b-haolian-hl3020p-rgb
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware kmod-usb3 \
+	mt7981-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
+	append-metadata
+endef
+TARGET_DEVICES += haolian_hl3020p-rgb
+
+define Device/haolian_hl3020p-leds
+  DEVICE_VENDOR := Haolian
+  DEVICE_MODEL := HL3020P
+  DEVICE_VARIANT := LEDS
+  DEVICE_DTS := mt7981b-haolian-hl3020p-leds
+  DEVICE_DTS_DIR := ../dts
+  DEVICE_PACKAGES := kmod-mt7915e kmod-mt7981-firmware kmod-usb3 \
+	mt7981-wo-firmware
+  UBINIZE_OPTS := -E 5
+  BLOCKSIZE := 128k
+  PAGESIZE := 2048
+  KERNEL_IN_UBI := 1
+  UBOOTENV_IN_UBI := 1
+  IMAGES := sysupgrade.itb
+  KERNEL_INITRAMFS_SUFFIX := -recovery.itb
+  KERNEL := kernel-bin | gzip
+  KERNEL_INITRAMFS := kernel-bin | lzma | \
+	fit lzma $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb with-initrd | pad-to 64k
+  IMAGE/sysupgrade.itb := append-kernel | \
+	fit gzip $$(KDIR)/image-$$(firstword $$(DEVICE_DTS)).dtb external-static-with-rootfs | \
+	append-metadata
+endef
+TARGET_DEVICES += haolian_hl3020p-leds
+
 define Device/routerich_be7200
   DEVICE_VENDOR := Routerich
   DEVICE_MODEL := BE7200


### PR DESCRIPTION
This adds support for Haolian HL3020P, an MT7981B based AX3000 router.

Three profiles are provided:

- Haolian HL3020P
- Haolian HL3020P-RGB
- Haolian HL3020P-LEDS

The commit message contains the required new-device sections:

- Hardware specification
- Flash instructions
- MAC address layout

Tested:

- Rebased onto current openwrt/openwrt main
- Verified the PR branch is one commit ahead of upstream main
- git diff --check HEAD~1..HEAD passes
- Verified all three profiles are visible through make defconfig

Note: make target/linux/compile was started after rebasing to current main, but it did not finish within 15 minutes in my local WSL environment after triggering a larger rebuild.

Signed-off-by: JimmyWang <120630151wang@gmail.com>
