### PR TITLE
realtek: dts: convert to upstream switch notation

### DIFF
--- a/target/linux/realtek/dts/rtl838x.dtsi
+++ b/target/linux/realtek/dts/rtl838x.dtsi
@@ -199,9 +199,11 @@
 		};
 	};
 
-	switchcore@1b000000 {
-		compatible = "syscon", "simple-mfd";
+	switch0: ethernet-switch@1b000000 {
+		compatible = "realtek,rtl8380-switch", "realtek,otto-switch", "syscon", "simple-mfd";
 		reg = <0x1b000000 0x10000>;
+		interrupt-parent = <&intc>;
+		interrupts = <20 2>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -279,14 +281,6 @@
 		soc_thermal: thermal {
 			compatible = "realtek,rtl8380-thermal";
 			#thermal-sensor-cells = <0>;
-		};
-
-		switch0: ethernet-switch {
-			compatible = "realtek,rtl8380-switch", "realtek,otto-switch";
-			status = "okay";
-
-			interrupt-parent = <&intc>;
-			interrupts = <20 2>;
 		};
 	};
 

--- a/target/linux/realtek/dts/rtl839x.dtsi
+++ b/target/linux/realtek/dts/rtl839x.dtsi
@@ -207,9 +207,11 @@
 
 	};
 
-	switchcore@1b000000 {
-		compatible = "syscon", "simple-mfd";
+	switch0: ethernet-switch@1b000000 {
+		compatible = "realtek,rtl8392-switch", "realtek,otto-switch", "syscon", "simple-mfd";
 		reg = <0x1b000000 0x10000>;
+		interrupt-parent = <&intc>;
+		interrupts = <20 2>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -324,14 +326,6 @@
 		soc_thermal: thermal {
 			compatible = "realtek,rtl8390-thermal";
 			#thermal-sensor-cells = <0>;
-		};
-
-		switch0: ethernet-switch {
-			compatible = "realtek,rtl8392-switch", "realtek,otto-switch";
-			status = "okay";
-
-			interrupt-parent = <&intc>;
-			interrupts = <20 2>;
 		};
 	};
 

--- a/target/linux/realtek/dts/rtl930x.dtsi
+++ b/target/linux/realtek/dts/rtl930x.dtsi
@@ -167,9 +167,11 @@
 
 	};
 
-	switchcore@1b000000 {
-		compatible = "syscon", "simple-mfd";
+	switch0: ethernet-switch@1b000000 {
+		compatible = "realtek,rtl9301-switch", "realtek,otto-switch", "syscon", "simple-mfd";
 		reg = <0x1b000000 0x10000>;
+		interrupt-parent = <&intc>;
+		interrupts = <23 2>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -303,14 +305,6 @@
 		soc_thermal: thermal {
 			compatible = "realtek,rtl9300-thermal";
 			#thermal-sensor-cells = <0>;
-		};
-
-		switch0: ethernet-switch {
-			compatible = "realtek,rtl9301-switch", "realtek,otto-switch";
-			status = "okay";
-
-			interrupt-parent = <&intc>;
-			interrupts = <23 2>;
 		};
 	};
 

--- a/target/linux/realtek/dts/rtl931x.dtsi
+++ b/target/linux/realtek/dts/rtl931x.dtsi
@@ -194,9 +194,12 @@
 		};
 	};
 
-	switchcore@1b000000 {
-		compatible = "syscon", "simple-mfd";
+	switch0: ethernet-switch@1b000000 {
+		compatible = "realtek,rtl9311-switch", "realtek,otto-switch", "syscon", "simple-mfd";
 		reg = <0x1b000000 0x10000>;
+		interrupt-parent = <&gic>;
+		interrupts = <GIC_SHARED 15 IRQ_TYPE_LEVEL_HIGH>;
+		#interrupt-cells = <3>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 
@@ -338,15 +341,6 @@
 				reg = <13>;
 				#pcs-cells = <1>;
 			};
-		};
-
-		switch0: ethernet-switch {
-			compatible = "realtek,rtl9311-switch", "realtek,otto-switch";
-			status = "okay";
-
-			interrupt-parent = <&gic>;
-			#interrupt-cells = <3>;
-			interrupts = <GIC_SHARED 15 IRQ_TYPE_LEVEL_HIGH>;
 		};
 	};
 

--- a/target/linux/realtek/files-6.18/drivers/net/mdio/mdio-realtek-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/mdio/mdio-realtek-otto.c
@@ -976,14 +976,9 @@ static int rtmd_map_ports(struct device *dev)
 	struct rtmd_ctrl *ctrl = dev_get_drvdata(dev);
 	int smi_bus, smi_addr, pn;
 
-	struct fwnode_handle *fw_parent __free(fwnode_handle) = fwnode_get_parent(fw_dev);
-	if (!fw_parent)
-		return -ENODEV;
-
-	struct fwnode_handle *fw_switch __free(fwnode_handle) =
-		fwnode_get_named_child_node(fw_parent, "ethernet-switch");
+	struct fwnode_handle *fw_switch __free(fwnode_handle) = fwnode_get_parent(fw_dev);
 	if (!fw_switch)
-		return dev_err_probe(dev, -ENODEV, "%pfwP missing ethernet-switch\n", fw_parent);
+		return -ENODEV;
 
 	struct fwnode_handle *fw_ports __free(fwnode_handle) =
 		fwnode_get_named_child_node(fw_switch, "ethernet-ports");

--- a/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
+++ b/target/linux/realtek/files-6.18/drivers/net/pcs/pcs-rtl-otto.c
@@ -4247,14 +4247,9 @@ static struct rtpcs_serdes *rtpcs_find_serdes(struct rtpcs_ctrl *ctrl,
 static int rtpcs_map_links(struct device *dev, struct rtpcs_ctrl *ctrl)
 {
 	struct fwnode_handle *fw_dev = dev_fwnode(dev);
-	struct fwnode_handle *fw_parent __free(fwnode_handle) = fwnode_get_parent(fw_dev);
-	if (!fw_parent)
-		return -ENODEV;
-
-	struct fwnode_handle *fw_switch __free(fwnode_handle) =
-		fwnode_get_named_child_node(fw_parent, "ethernet-switch");
+	struct fwnode_handle *fw_switch __free(fwnode_handle) = fwnode_get_parent(fw_dev);
 	if (!fw_switch)
-		return dev_err_probe(dev, -ENODEV, "%pfwP missing ethernet-switch\n", fw_parent);
+		return -ENODEV;
 
 	struct fwnode_handle *fw_ports __free(fwnode_handle) =
 		fwnode_get_named_child_node(fw_switch, "ethernet-ports");


### PR DESCRIPTION
There is currently a difference how upstream and downstream define the switch in the dts. Downstream holds the switch as a member node below a root switchcore parent. Upstream uses the switch as the parent.

Upstream:

```
  ethernet-switch@1b000000 {
    mdio-controller@ca00 { };
    ethernet { };
    ethernet-ports { };
  }
```

Downstream:

```
  switchcore@1b000000 {
    ethernet-switch {
      ethernet-ports { };
    };
    mdio-controller@ca00 { };
    ethernet { };
  }
```

Align downstream to upstream and merge the ethernet-switch into the parent node. For this to work adapt the port lookup in the MDIO and PCS driver.

Remark! With this commit the boot process will give the spurious error message "rtl838x_eth 1b000000.ethernet-switch:ethernet eth0: Failed to create a device link to DSA switch 1b000000.ethernet-switch" This comes from the fact that the switch is the parent of the ethernet device. Thus a link back from ethernet device to the switch is no longer possible. Testing shows that the error is just cosmetic.