### PR TITLE
dropbear: back up all of the config files

### DIFF
--- a/package/network/services/dropbear/Makefile
+++ b/package/network/services/dropbear/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=dropbear
 PKG_VERSION:=2026.91
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:= \
@@ -77,10 +77,7 @@ endef
 
 define Package/dropbear/conffiles
 /etc/config/dropbear
-/etc/dropbear/authorized_keys
-/etc/dropbear/dropbear_ecdsa_host_key
-/etc/dropbear/dropbear_ed25519_host_key
-/etc/dropbear/dropbear_rsa_host_key
+/etc/dropbear/
 endef
 
 define Package/dropbearconvert


### PR DESCRIPTION
`/etc/dropbear/` had been part of base-files `conffiles`, and that
was removed to rationalize things.  Taking it out of there was
the right thing to do, but all of the directory should be
preserved not just part of it.
