### PR TITLE
realtek: rtl930x: add Horaco ZX-SW82TS-L2P

### DIFF
--- a/target/linux/realtek/base-files/etc/board.d/02_network
+++ b/target/linux/realtek/base-files/etc/board.d/02_network
@@ -79,6 +79,7 @@ realtek_setup_macs()
 	d-link,dgs-1250-28x|\
 	hasivo,s1100wp-8gt-se|\
 	hasivo,s600wp-5gt-2sx-se|\
+	horaco,zx-sw82ts-l2p|\
 	hpe,1920-8g|\
 	hpe,1920-8g-poe-65w|\
 	hpe,1920-8g-poe-180w|\

--- a/target/linux/realtek/dts/rtl9302_horaco_zx-sw82ts-l2p.dts
+++ b/target/linux/realtek/dts/rtl9302_horaco_zx-sw82ts-l2p.dts
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/dts-v1/;
+
+#include "rtl930x.dtsi"
+
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/phy/phy.h>
+
+/ {
+	compatible = "horaco,zx-sw82ts-l2p", "realtek,rtl9302-soc";
+	model = "Horaco ZX-SW82TS-L2P / S1300WP-8GT-2S+";
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x00000000 0x10000000>, /* 256 MiB lowmem */
+		      <0x20000000 0x10000000>; /* 256 MiB highmem */
+	};
+
+	aliases {
+		led-boot = &led_sys;
+		led-failsafe = &led_sys;
+		led-running = &led_sys;
+		led-upgrade = &led_sys;
+	};
+
+	chosen {
+		bootargs = "console=ttyS0,115200 earlycon";
+		stdout-path = "serial0:115200n8";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		button-reset {
+			label = "reset";
+			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_sys: led-0 {
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_STATUS;
+			gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	led_set {
+		compatible = "realtek,rtl9300-leds";
+		active-low;
+
+		/*
+		 * Copper ports: 3 slots/port.
+		 * Slot 2 (DTS[0]) = Amber (Port N Amber)
+		 * Slot 1 (DTS[1]) = Spacer (0)
+		 * Slot 0 (DTS[2]) = Green (Port N Green)
+		 */
+		led_set0 = <
+			(RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			0x0000
+			(RTL93XX_LED_SET_10M | RTL93XX_LED_SET_100M | RTL93XX_LED_SET_1G |
+			 RTL93XX_LED_SET_2P5G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+		>;
+
+		/*
+		 * SFP+ ports: 2 slots/port (Bi-color).
+		 * Slot 1 (DTS[0]) = Red (10G Link/Act)
+		 * Slot 0 (DTS[1]) = Green (1G Link/Act)
+		 */
+		led_set1 = <
+			(RTL93XX_LED_SET_10G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+			(RTL93XX_LED_SET_1G | RTL93XX_LED_SET_LINK | RTL93XX_LED_SET_ACT)
+		>;
+
+		/*
+		 * Total Serial Stream (36 bits):
+		 * - MAC 12-15: 4 ports * 3 bits = 12-bit Preamble (Set 0).
+		 * - MAC 16-23: 8 ports * 3 bits = 24 bits Copper (Set 0).
+		 * - MAC 26-27: 2 ports * 2 bits = 4 bits SFP colors (Set 3).
+		 * (MAC 24, 25 skipped to prevent shifts).
+		 */
+		/*realtek,led-set0-force-port-mask = <0x00fff000>;
+		realtek,led-set3-force-port-mask = <0x0c000000>;*/
+	};
+
+	i2c-poe {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "i2c-gpio";
+		scl-gpios = <&gpio0 3 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		sda-gpios = <&gpio0 4 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		i2c-gpio,delay-us = <2>;
+
+		rtc@51 {
+			compatible = "nxp,pcf8563";
+			reg = <0x51>;
+		};
+
+		mcu_wdt: mcu@6f {
+			compatible = "hasivo,mcu-wdt";
+			reg = <0x6f>;
+		};
+
+		stc8: mfd@4d {
+			compatible = "hasivo,stc8-mfd", "syscon";
+			reg = <0x4d>;
+			hasivo,execute-bit = <0x40>;
+			hasivo,execute-bit-registers = <0x01 0x02>;
+
+			poe_led_lan1: led-1 {
+				compatible = "register-bit-led";
+				offset = <0x01>;
+				mask = <0x08>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <1>;
+				default-state = "off";
+				linux,default-trigger = "2-000d:port0:delivering";
+			};
+
+			poe_led_lan2: led-2 {
+				compatible = "register-bit-led";
+				offset = <0x01>;
+				mask = <0x04>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <2>;
+				default-state = "off";
+				linux,default-trigger = "2-000d:port1:delivering";
+			};
+
+			poe_led_lan3: led-3 {
+				compatible = "register-bit-led";
+				offset = <0x01>;
+				mask = <0x02>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <3>;
+				default-state = "off";
+				linux,default-trigger = "2-000d:port2:delivering";
+			};
+
+			poe_led_lan4: led-4 {
+				compatible = "register-bit-led";
+				offset = <0x01>;
+				mask = <0x01>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <4>;
+				default-state = "off";
+				linux,default-trigger = "2-000d:port3:delivering";
+			};
+
+			poe_led_lan5: led-5 {
+				compatible = "register-bit-led";
+				offset = <0x02>;
+				mask = <0x08>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <5>;
+				default-state = "off";
+				linux,default-trigger = "2-0015:port0:delivering";
+			};
+
+			poe_led_lan6: led-6 {
+				compatible = "register-bit-led";
+				offset = <0x02>;
+				mask = <0x04>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <6>;
+				default-state = "off";
+				linux,default-trigger = "2-0015:port1:delivering";
+			};
+
+			poe_led_lan7: led-7 {
+				compatible = "register-bit-led";
+				offset = <0x02>;
+				mask = <0x02>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <7>;
+				default-state = "off";
+				linux,default-trigger = "2-0015:port2:delivering";
+			};
+
+			poe_led_lan8: led-8 {
+				compatible = "register-bit-led";
+				offset = <0x02>;
+				mask = <0x01>;
+				color = <LED_COLOR_ID_ORANGE>;
+				function = "poe";
+				function-enumerator = <8>;
+				default-state = "off";
+				linux,default-trigger = "2-0015:port3:delivering";
+			};
+		};
+	};
+
+	sfp1: sfp-p26 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c0>;
+	};
+
+	sfp2: sfp-p27 {
+		compatible = "sff,sfp";
+		i2c-bus = <&i2c1>;
+	};
+};
+
+&i2c_mst1 {
+	status = "okay";
+	clock-frequency = <100000>;
+
+	i2c0: i2c@6 { reg = <6>; };
+	i2c1: i2c@7 { reg = <7>; };
+};
+
+&serdes6 {
+	rx-polarity = <PHY_POL_INVERT>;
+	tx-polarity = <PHY_POL_INVERT>;
+};
+
+&serdes7 {
+	tx-polarity = <PHY_POL_INVERT>;
+};
+
+&uart0 {
+	current-speed = <115200>;
+};
+
+&spi0 {
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			partition@0 {
+				label = "u-boot";
+				reg = <0x0000000 0x00e0000>;
+				read-only;
+			};
+
+			partition@e0000 {
+				label = "u-boot-env";
+				reg = <0x00e0000 0x0010000>;
+
+				nvmem-layout {
+					compatible = "u-boot,env";
+					macaddr_ubootenv_ethaddr: ethaddr {
+					};
+				};
+			};
+
+			partition@f0000 {
+				label = "sysinfo";
+				reg = <0x00f0000 0x0010000>;
+				read-only;
+			};
+
+			partition@100000 {
+				label = "jffs2_cfg";
+				reg = <0x0100000 0x0100000>;
+				read-only;
+			};
+
+			partition@200000 {
+				label = "jffs2_log";
+				reg = <0x0200000 0x0100000>;
+				read-only;
+			};
+
+			partition@300000 {
+				label = "runtime";
+				reg = <0x0300000 0x0700000>;
+				read-only;
+			};
+
+			partition@a00000 {
+				label = "firmware";
+				reg = <0x0a00000 0x1600000>;
+			};
+		};
+	};
+};
+
+&ethernet0 {
+	nvmem-cells = <&macaddr_ubootenv_ethaddr 0>;
+	nvmem-cell-names = "mac-address";
+};
+
+&mdio_bus2 {
+	phypkg1: ethernet-phy-package@1 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <1>;
+
+		PHY_C45_PAIR_ORDER(16, 1, 0)
+		PHY_C45_PAIR_ORDER(17, 2, 0)
+		PHY_C45_PAIR_ORDER(18, 3, 1)
+		PHY_C45_PAIR_ORDER(19, 4, 1)
+	};
+
+	phypkg2: ethernet-phy-package@5 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <5>;
+
+		PHY_C45_PAIR_ORDER(20, 5, 0)
+		PHY_C45_PAIR_ORDER(21, 6, 0)
+		PHY_C45_PAIR_ORDER(22, 7, 1)
+		PHY_C45_PAIR_ORDER(23, 8, 1)
+	};
+};
+
+&switch0 {
+	ethernet-ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		SWITCH_PORT_LED(16, 1, 6, 0, 0, 10g-qxgmii)
+		SWITCH_PORT_LED(17, 2, 6, 1, 0, 10g-qxgmii)
+		SWITCH_PORT_LED(18, 3, 6, 2, 0, 10g-qxgmii)
+		SWITCH_PORT_LED(19, 4, 6, 3, 0, 10g-qxgmii)
+
+		SWITCH_PORT_LED(20, 5, 7, 0, 0, 10g-qxgmii)
+		SWITCH_PORT_LED(21, 6, 7, 1, 0, 10g-qxgmii)
+		SWITCH_PORT_LED(22, 7, 7, 2, 0, 10g-qxgmii)
+		SWITCH_PORT_LED(23, 8, 7, 3, 0, 10g-qxgmii)
+
+		SWITCH_PORT_SFP(26, 9, 8, 1, 1)
+		SWITCH_PORT_SFP(27, 10, 9, 1, 2)
+
+		port@28 {
+			reg = <28>;
+			label = "cpu";
+			ethernet = <&ethernet0>;
+			phy-mode = "internal";
+
+			fixed-link {
+				speed = <1000>;
+				full-duplex;
+			};
+		};
+	};
+};

--- a/target/linux/realtek/image/rtl930x.mk
+++ b/target/linux/realtek/image/rtl930x.mk
@@ -69,6 +69,16 @@ define Device/hasivo_s600wp-5gt-2sx-se
 endef
 TARGET_DEVICES += hasivo_s600wp-5gt-2sx-se
 
+define Device/horaco_zx-sw82ts-l2p
+  SOC := rtl9302
+  DEVICE_VENDOR := Horaco
+  DEVICE_MODEL := ZX-SW82TS-L2P
+  DEVICE_PACKAGES := kmod-i2c-gpio kmod-rtc-pcf8563 kmod-hasivo-mcu-wdt kmod-mfd-hasivo-stc8
+  IMAGE_SIZE := 31744k
+  $(Device/kernel-lzma)
+endef
+TARGET_DEVICES += horaco_zx-sw82ts-l2p
+
 define Device/horaco_zx-swtgw2c8f
   SOC := rtl9303
   UIMAGE_MAGIC := 0x83800000

--- a/target/linux/realtek/patches-6.18/744-net-phy-use-shared-addr-for-RTL8224.patch
+++ b/target/linux/realtek/patches-6.18/744-net-phy-use-shared-addr-for-RTL8224.patch
@@ -1,0 +1,83 @@
+--- a/drivers/net/phy/realtek/realtek_main.c
++++ b/drivers/net/phy/realtek/realtek_main.c
+@@ -293,6 +293,10 @@ struct rtl821x_priv {
+ 	u16 iner;
+ };
+ 
++struct rtl8224_priv {
++	u8 port_offset;
++};
++
+ struct rtl822x_priv {
+ 	bool enable_aldps;
+ };
+@@ -2166,7 +2170,8 @@ static int rtl8224_sds_modify(struct phy
+ 
+ static int rtl8224_serdes_config(struct phy_device *phydev)
+ {
+-	if ((phydev->mdio.addr & 3) != 0)
++	struct rtl8224_priv *priv = phydev->priv;
++	if (priv->port_offset != 0)
+ 		return 0;
+ 
+ 	/* Turn SerDes OFF */
+@@ -2248,7 +2253,8 @@ static int rtl8224_serdes_config(struct
+ static int rtl8224_mdi_config_order(struct phy_device *phydev)
+ {
+ 	struct device_node *np = phydev->mdio.dev.of_node;
+-	u8 port_offset = phydev->mdio.addr & 3;
++	struct rtl8224_priv *priv = phydev->priv;
++	u8 port_offset = priv->port_offset;
+ 	u32 order = 0;
+ 	int ret;
+ 
+@@ -2273,7 +2279,8 @@ static int rtl8224_mdi_config_order(stru
+ static int rtl8224_mdi_config_polarity(struct phy_device *phydev)
+ {
+ 	struct device_node *np = phydev->mdio.dev.of_node;
+-	u8 offset = (phydev->mdio.addr & 3) * 4;
++	struct rtl8224_priv *priv = phydev->priv;
++	u8 offset = priv->port_offset * 4;
+ 	u32 polarity = 0;
+ 	int ret;
+ 
+@@ -2312,9 +2319,36 @@ static int rtl8224_config_init(struct ph
+ 
+ static int rtl8224_probe(struct phy_device *phydev)
+ {
+-	/* Chip exposes 4 ports, join all of them in the same package */
+-	return devm_phy_package_join(&phydev->mdio.dev, phydev,
+-				     phydev->mdio.addr & ~3, 0);
++	struct rtl8224_priv *priv;
++	struct device_node *np;
++	u32 base_addr;
++	int ret;
++
++	priv = devm_kzalloc(&phydev->mdio.dev, sizeof(*priv), GFP_KERNEL);
++	if (!priv)
++		return -ENOMEM;
++
++	/* Chip exposes 4 ports, join them into a package via device tree */
++	if (!devm_of_phy_package_join(&phydev->mdio.dev, phydev, 0)) {
++		np = phy_package_get_node(phydev);
++		if (of_property_read_u32(np, "reg", &base_addr)) {
++			return -EINVAL;
++		}
++
++		priv->port_offset = phydev->mdio.addr - base_addr;
++		phydev->priv = priv;
++		return 0;
++	}
++
++	/* Fall back to assuming addresses are assigned % 4 */
++	ret = devm_phy_package_join(&phydev->mdio.dev, phydev,
++				    phydev->mdio.addr & ~3, 0);
++	if (ret)
++		return ret;
++
++	priv->port_offset = phydev->mdio.addr & 3;
++	phydev->priv = priv;
++	return 0;
+ }
+ 
+ static bool rtlgen_supports_2_5gbps(struct phy_device *phydev)


### PR DESCRIPTION
Add support for the Horaco ZX-SW82TS-L2P, also labelled S1300WP-8GT-2S+ on the PCB.

PoE support is pending on:
- #22245 

Support for this device is based on lots of work thanks to @bevanweiss @plappermaul @carlosz1986 and others

# Hardware

| | |
| ---: | :--- |
| **SoC** | Realtek RTL9302D |
| **RAM** | 512MB |
| **Flash** | Macronix MX25L25645G 32MiB |
| **Ethernet** | 2x4 port RTL8224 2.5G PHY<br>2x SFP+ 10G |
| **LEDs** | 1x power green<br>1x SYS green<br>8x3 LEDs per RJ45 port:<br>&nbsp;&nbsp;&nbsp;&nbsp;- 1x green (1G link/activity)<br>&nbsp;&nbsp;&nbsp;&nbsp;- 1x orange (2.5G link/activity)<br>&nbsp;&nbsp;&nbsp;&nbsp;- 1x orange PoE<br>2x2 LEDs per SFP+ port:<br>&nbsp;&nbsp;&nbsp;&nbsp;- 1x green<br>&nbsp;&nbsp;&nbsp;&nbsp;- 1x red |
| **Button** | Reset |
| **Console** | 1x CISCO-style RJ45 RS232 port |
| **USB ports** | 1x USB2 |
| **Bootloader** | Realtek U-Boot 2011.12 |
| **PoE** | 2x HS104PTI |
    
# Installing OpenWrt

1. Connect to UART 38400@8n1, using a CISCO-style console cable
2. Enter the bootloader by pressing Ctrl-C, z, h in sequence at the
   countdown
3. Increase the baud rate via `setenv baudrate 115200`
4. Configure a compatible board model:
   `setenv boardmodel RTL9301_8218B_4XGE`
5. Turn on networking `rtk network on`
6. Connect a DAC cable to port 10 (right SFP+ port)
7. Turn on the port: `rtk 10g 27 dac50cm`
8. Read the image via TFTP: `tftpboot 0x84f00000 192.168.1.111:sw8.bin`
9. Boot into OpenWrt: `bootm 0x84f00000`

Note that the switch has an external hardware watchdog that will
reboot the device after a few minutes. You therefore need to boot
into OpenWrt before that happens. OpenWrt will then take care of
the watchdog.